### PR TITLE
Add API for displaying render results via an OpenGLX window

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -443,6 +443,17 @@ drake_py_unittest(
 )
 
 drake_py_unittest(
+    name = "geometry_render_engine_gl_test",
+    tags = [
+        "manual",  # Avoid running in CI due to dependency on X.
+    ],
+    deps = [
+        ":geometry_py",
+        "//bindings/pydrake/common/test_utilities",
+    ],
+)
+
+drake_py_unittest(
     name = "lcm_test",
     deps = [
         ":lcm_py",

--- a/bindings/pydrake/test/geometry_render_engine_gl_test.py
+++ b/bindings/pydrake/test/geometry_render_engine_gl_test.py
@@ -1,0 +1,22 @@
+import pydrake.geometry as mut
+
+import sys
+import unittest
+import warnings
+
+from pydrake.common.test_utilities import numpy_compare
+
+
+@numpy_compare.check_nonsymbolic_types
+class TestGeometry(unittest.TestCase):
+
+    def test_render_engine_gl_api(self, T):
+        SceneGraph = mut.SceneGraph_[T]
+        scene_graph = SceneGraph()
+        if 'darwin' in sys.platform:  # OpenGL is not supported on macOS.
+            self.assertRaises(RuntimeError, mut.render.MakeRenderEngineGl)
+        else:
+            scene_graph.AddRenderer("gl_renderer",
+                                    mut.render.MakeRenderEngineGl())
+            self.assertTrue(scene_graph.HasRenderer("gl_renderer"))
+            self.assertEqual(scene_graph.RendererCount(), 1)

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -73,13 +73,6 @@ class TestGeometry(unittest.TestCase):
                                     mut.render.RenderEngineVtkParams()))
         self.assertTrue(scene_graph.HasRenderer("test_renderer"))
         self.assertEqual(scene_graph.RendererCount(), 1)
-        if 'darwin' in sys.platform:  # OpenGL is not supported on macOS.
-            self.assertRaises(RuntimeError, mut.render.MakeRenderEngineGl)
-        else:
-            scene_graph.AddRenderer("gl_renderer",
-                                    mut.render.MakeRenderEngineGl())
-            self.assertTrue(scene_graph.HasRenderer("gl_renderer"))
-            self.assertEqual(scene_graph.RendererCount(), 2)
 
         # Test SceneGraphInspector API
         inspector = scene_graph.model_inspector()

--- a/geometry/render/gl_renderer/BUILD.bazel
+++ b/geometry/render/gl_renderer/BUILD.bazel
@@ -34,7 +34,33 @@ drake_cc_library_gl_ubuntu_only(
         "opengl_includes.h",
     ],
     visibility = ["//visibility:private"],
-    deps = ["@opengl"],
+    deps = [
+        "@drake//common",
+        "@opengl",
+        "@x11",
+    ],
+)
+
+anzu_cc_library(
+    name = "load_mesh",
+    srcs = ["load_mesh.cc"],
+    hdrs = ["load_mesh.h"],
+    # NOTE: Required for compatibility with tinyobjloader.
+    linkstatic = 1,
+    deps = [
+        ":opengl_context",
+        "@drake//common:essential",
+        "@tinyobjloader",
+    ],
+)
+
+anzu_cc_library(
+    name = "opengl_geometry",
+    hdrs = ["opengl_geometry.h"],
+    deps = [
+        ":opengl_context",
+        "@drake//math:geometric_transform",
+    ],
 )
 
 # The pure OpenGL-based render engine implementation.
@@ -50,6 +76,7 @@ drake_cc_library(
     hdrs = select({
         "//tools/cc_toolchain:apple": ["render_engine_gl_factory.h"],
         "//conditions:default": [
+            "buffer_dim.h",
             "render_engine_gl.h",
             "render_engine_gl_factory.h",
         ],
@@ -57,10 +84,25 @@ drake_cc_library(
     deps = select({
         "//tools/cc_toolchain:apple": ["//geometry/render:render_engine"],
         "//conditions:default": [
-            ":opengl_context",
-            "//geometry/render:render_engine",
+            ":load_mesh",
+            ":opengl_geometry",
+            ":shader_program",
+            "@drake//common:essential",
+            "@drake//geometry/render:render_engine",
+            "@drake//systems/sensors:image",
+            "@fmt",
         ],
     }),
+)
+
+anzu_cc_library(
+    name = "shader_program",
+    srcs = ["shader_program.cc"],
+    hdrs = ["shader_program.h"],
+    deps = [
+        ":opengl_context",
+        "@drake//common:essential",
+    ],
 )
 
 drake_cc_googletest(
@@ -69,8 +111,14 @@ drake_cc_googletest(
         "//tools/cc_toolchain:apple": ["--gtest_filter=-*"],
         "//conditions:default": [],
     }),
+    data = [
+        "@drake//systems/sensors:test_models",
+    ],
     deps = [
         ":render_engine_gl",
+        "@drake//common:find_resource",
+        "@drake//geometry/render:render_label",
+        "@drake//systems/sensors:color_palette",
     ],
 )
 

--- a/geometry/render/gl_renderer/BUILD.bazel
+++ b/geometry/render/gl_renderer/BUILD.bazel
@@ -7,6 +7,7 @@ load(
     "drake_cc_package_library",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
+load("//tools/skylark:test_tags.bzl", "vtk_test_tags")
 load(
     "defs.bzl",
     "drake_cc_library_gl_ubuntu_only",
@@ -21,8 +22,24 @@ drake_cc_package_library_gl_per_os(
         ":render_engine_gl",
     ],
     ubuntu_deps = [
+        ":load_mesh",
         ":opengl_context",
+        ":opengl_geometry",
         ":render_engine_gl",
+        ":shader_program",
+    ],
+)
+
+drake_cc_library_gl_ubuntu_only(
+    name = "load_mesh",
+    srcs = ["load_mesh.cc"],
+    hdrs = ["load_mesh.h"],
+    # NOTE: Required for compatibility with tinyobjloader.
+    linkstatic = 1,
+    deps = [
+        ":opengl_context",
+        "//common:essential",
+        "@tinyobjloader",
     ],
 )
 
@@ -35,31 +52,19 @@ drake_cc_library_gl_ubuntu_only(
     ],
     visibility = ["//visibility:private"],
     deps = [
-        "@drake//common",
+        "//common:essential",
         "@opengl",
         "@x11",
     ],
 )
 
-anzu_cc_library(
-    name = "load_mesh",
-    srcs = ["load_mesh.cc"],
-    hdrs = ["load_mesh.h"],
-    # NOTE: Required for compatibility with tinyobjloader.
-    linkstatic = 1,
-    deps = [
-        ":opengl_context",
-        "@drake//common:essential",
-        "@tinyobjloader",
-    ],
-)
-
-anzu_cc_library(
+drake_cc_library_gl_ubuntu_only(
     name = "opengl_geometry",
     hdrs = ["opengl_geometry.h"],
+    visibility = ["//visibility:private"],
     deps = [
         ":opengl_context",
-        "@drake//math:geometric_transform",
+        "//math:geometric_transform",
     ],
 )
 
@@ -87,21 +92,20 @@ drake_cc_library(
             ":load_mesh",
             ":opengl_geometry",
             ":shader_program",
-            "@drake//common:essential",
-            "@drake//geometry/render:render_engine",
-            "@drake//systems/sensors:image",
-            "@fmt",
+            "//common:essential",
+            "//geometry/render:render_engine",
+            "//systems/sensors:image",
         ],
     }),
 )
 
-anzu_cc_library(
+drake_cc_library_gl_ubuntu_only(
     name = "shader_program",
     srcs = ["shader_program.cc"],
     hdrs = ["shader_program.h"],
     deps = [
         ":opengl_context",
-        "@drake//common:essential",
+        "//common:essential",
     ],
 )
 
@@ -112,13 +116,16 @@ drake_cc_googletest(
         "//conditions:default": [],
     }),
     data = [
-        "@drake//systems/sensors:test_models",
+        "//systems/sensors:test_models",
+    ],
+    tags = vtk_test_tags() + [
+        "manual",
     ],
     deps = [
         ":render_engine_gl",
-        "@drake//common:find_resource",
-        "@drake//geometry/render:render_label",
-        "@drake//systems/sensors:color_palette",
+        "//common:find_resource",
+        "//geometry/render:render_label",
+        "//systems/sensors:color_palette",
     ],
 )
 

--- a/geometry/render/gl_renderer/buffer_dim.h
+++ b/geometry/render/gl_renderer/buffer_dim.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/hash.h"
+#include "perception/gl_renderer/opengl_includes.h"
+
+namespace anzu {
+namespace gl_renderer {
+
+/** Simple struct for recording the dimensions of a render target. */
+class BufferDim {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(BufferDim)
+
+  BufferDim(int width, int height) : width_(width), height_(height) {}
+
+  int width() const { return width_; }
+  int height() const { return height_; }
+
+  /** Implements the @ref hash_append concept.  */
+  template <class HashAlgorithm>
+  friend void hash_append(HashAlgorithm& hasher,
+                          const BufferDim& dim) noexcept {
+    using drake::hash_append;
+    hash_append(hasher, dim.width_);
+    hash_append(hasher, dim.height_);
+  }
+
+  bool operator==(const BufferDim& dim) const {
+    return width_ == dim.width_ && height_ == dim.height_;
+  }
+
+ private:
+  int width_{-1};
+  int height_{-1};
+};
+
+/** The collection of OpenGL objects which define a render target --
+ essentially, a 2D image that the depth data gets rendered to.  */
+struct RenderTarget {
+  GLuint frame_buffer;
+  GLuint texture;
+  GLuint render_buffer;
+};
+
+}  // namespace gl_renderer
+}  // namespace anzu
+
+namespace std {
+
+/// Provides std::hash<BufferDim>.
+template <>
+struct hash<anzu::gl_renderer::BufferDim>
+    : public drake::DefaultHash {};
+}  // namespace std

--- a/geometry/render/gl_renderer/buffer_dim.h
+++ b/geometry/render/gl_renderer/buffer_dim.h
@@ -2,12 +2,14 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/hash.h"
-#include "perception/gl_renderer/opengl_includes.h"
+#include "drake/geometry/render/gl_renderer/opengl_includes.h"
 
-namespace anzu {
-namespace gl_renderer {
+namespace drake {
+namespace geometry {
+namespace render {
+namespace gl {
 
-/** Simple struct for recording the dimensions of a render target. */
+/** Simple class for recording the dimensions of a render target. */
 class BufferDim {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(BufferDim)
@@ -43,13 +45,15 @@ struct RenderTarget {
   GLuint render_buffer;
 };
 
-}  // namespace gl_renderer
-}  // namespace anzu
+}  // namespace gl
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake
 
 namespace std {
 
-/// Provides std::hash<BufferDim>.
+/** Provides std::hash<BufferDim>.  */
 template <>
-struct hash<anzu::gl_renderer::BufferDim>
+struct hash<drake::geometry::render::gl::BufferDim>
     : public drake::DefaultHash {};
 }  // namespace std

--- a/geometry/render/gl_renderer/load_mesh.cc
+++ b/geometry/render/gl_renderer/load_mesh.cc
@@ -1,0 +1,83 @@
+#include "perception/gl_renderer/load_mesh.h"
+
+#include <algorithm>
+#include <fstream>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include <fmt/format.h>
+#include <tiny_obj_loader.h>
+
+#include "drake/common/drake_assert.h"
+
+namespace anzu {
+namespace gl_renderer {
+
+using std::string;
+using std::vector;
+
+std::pair<VertexBuffer, IndexBuffer> LoadMeshFromObj(
+    const std::string& filename) {
+  tinyobj::attrib_t attrib;
+  std::vector<tinyobj::shape_t> shapes;
+  std::vector<tinyobj::material_t> materials;
+  string err;
+  // This renderer assumes everything is triangles -- we rely on tinyobj to
+  // triangulate for us.
+  bool do_tinyobj_triangulation = true;
+
+  // Tinyobj doesn't infer the search directory from the directory containing
+  // the obj file. We have to provide that directory; of course, this assumes
+  // that the material library reference is relative to the obj directory.
+  size_t pos = filename.find_last_of('/');
+  const std::string obj_folder = filename.substr(0, pos + 1);
+  const char* mtl_basedir = obj_folder.c_str();
+  bool ret =
+      tinyobj::LoadObj(&attrib, &shapes, &materials, &err, filename.c_str(),
+                       mtl_basedir, do_tinyobj_triangulation);
+  if (!ret || !err.empty()) {
+    throw std::runtime_error(
+        fmt::format("Error parsing file '{}': {}", filename, err));
+  }
+
+  DRAKE_DEMAND(shapes.size() > 0);
+  // Accumulate vertices.
+  const vector<tinyobj::real_t>& verts = attrib.vertices;
+  const int v_count = static_cast<int>(verts.size()) / 3;
+  DRAKE_DEMAND(static_cast<int>(verts.size()) == v_count * 3);
+  VertexBuffer vertices{v_count, 3};
+  for (int v = 0; v < v_count; ++v) {
+    const int i = v * 3;
+    vertices.block<1, 3>(v, 0) << verts[i], verts[i + 1], verts[i + 2];
+  }
+
+  // Accumulate faces.
+  int tri_count = 0;
+  for (const auto& shape : shapes) {
+    const tinyobj::mesh_t& raw_mesh = shape.mesh;
+    DRAKE_DEMAND(
+        raw_mesh.indices.size() == raw_mesh.num_face_vertices.size() * 3);
+    tri_count += raw_mesh.num_face_vertices.size();
+  }
+
+  IndexBuffer indices{tri_count, 3};
+  int tri_index = 0;
+  for (const auto& shape : shapes) {
+    const tinyobj::mesh_t& raw_mesh = shape.mesh;
+    for (int sub_index = 0;
+         sub_index < static_cast<int>(raw_mesh.num_face_vertices.size());
+         ++sub_index) {
+      const int i = sub_index * 3;
+      indices.block<1, 3>(tri_index, 0)
+          << static_cast<GLuint>(raw_mesh.indices[i].vertex_index),
+          static_cast<GLuint>(raw_mesh.indices[i + 1].vertex_index),
+          static_cast<GLuint>(raw_mesh.indices[i + 2].vertex_index);
+      ++tri_index;
+    }
+  }
+  return std::make_pair(vertices, indices);
+}
+
+}  // namespace gl_renderer
+}  // namespace anzu

--- a/geometry/render/gl_renderer/load_mesh.cc
+++ b/geometry/render/gl_renderer/load_mesh.cc
@@ -1,4 +1,4 @@
-#include "perception/gl_renderer/load_mesh.h"
+#include "drake/geometry/render/gl_renderer/load_mesh.h"
 
 #include <algorithm>
 #include <fstream>
@@ -11,17 +11,18 @@
 
 #include "drake/common/drake_assert.h"
 
-namespace anzu {
-namespace gl_renderer {
+namespace drake {
+namespace geometry {
+namespace render {
+namespace gl {
 
 using std::string;
 using std::vector;
 
-std::pair<VertexBuffer, IndexBuffer> LoadMeshFromObj(
-    const std::string& filename) {
+std::pair<VertexBuffer, IndexBuffer> LoadMeshFromObj(const string& filename) {
   tinyobj::attrib_t attrib;
-  std::vector<tinyobj::shape_t> shapes;
-  std::vector<tinyobj::material_t> materials;
+  vector<tinyobj::shape_t> shapes;
+  vector<tinyobj::material_t> materials;
   string err;
   // This renderer assumes everything is triangles -- we rely on tinyobj to
   // triangulate for us.
@@ -31,7 +32,7 @@ std::pair<VertexBuffer, IndexBuffer> LoadMeshFromObj(
   // the obj file. We have to provide that directory; of course, this assumes
   // that the material library reference is relative to the obj directory.
   size_t pos = filename.find_last_of('/');
-  const std::string obj_folder = filename.substr(0, pos + 1);
+  const string obj_folder = filename.substr(0, pos + 1);
   const char* mtl_basedir = obj_folder.c_str();
   bool ret =
       tinyobj::LoadObj(&attrib, &shapes, &materials, &err, filename.c_str(),
@@ -56,8 +57,8 @@ std::pair<VertexBuffer, IndexBuffer> LoadMeshFromObj(
   int tri_count = 0;
   for (const auto& shape : shapes) {
     const tinyobj::mesh_t& raw_mesh = shape.mesh;
-    DRAKE_DEMAND(
-        raw_mesh.indices.size() == raw_mesh.num_face_vertices.size() * 3);
+    DRAKE_DEMAND(raw_mesh.indices.size() ==
+                 raw_mesh.num_face_vertices.size() * 3);
     tri_count += raw_mesh.num_face_vertices.size();
   }
 
@@ -79,5 +80,7 @@ std::pair<VertexBuffer, IndexBuffer> LoadMeshFromObj(
   return std::make_pair(vertices, indices);
 }
 
-}  // namespace gl_renderer
-}  // namespace anzu
+}  // namespace gl
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/gl_renderer/load_mesh.h
+++ b/geometry/render/gl_renderer/load_mesh.h
@@ -5,18 +5,25 @@
 
 #include <Eigen/Dense>
 
-#include "perception/gl_renderer/opengl_includes.h"
+#include "drake/geometry/render/gl_renderer/opengl_includes.h"
 
-namespace anzu {
-namespace gl_renderer {
+namespace drake {
+namespace geometry {
+namespace render {
+namespace gl {
 
-using VertexBuffer =
-    Eigen::Matrix<GLfloat, Eigen::Dynamic, 3, Eigen::RowMajor>;
+using VertexBuffer = Eigen::Matrix<GLfloat, Eigen::Dynamic, 3, Eigen::RowMajor>;
 using IndexBuffer = Eigen::Matrix<GLuint, Eigen::Dynamic, 3, Eigen::RowMajor>;
 
-/// Loads a mesh's vertices and indices (faces). Does not load textures.
+/** Loads a mesh's vertices and indices (faces). Does not load textures.
+ Note that while this functionality seems similar to ReadObjToSurfaceMesh,
+ RenderEngineGl cannot use SurfaceMesh. Rendering requires normals and texture
+ coordinates; SurfaceMesh was not designed with those quantities in mind.
+ */
 std::pair<VertexBuffer, IndexBuffer> LoadMeshFromObj(
     const std::string& filename);
 
-}  // namespace gl_renderer
-}  // namespace anzu
+}  // namespace gl
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/gl_renderer/load_mesh.h
+++ b/geometry/render/gl_renderer/load_mesh.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <string>
+#include <utility>
+
+#include <Eigen/Dense>
+
+#include "perception/gl_renderer/opengl_includes.h"
+
+namespace anzu {
+namespace gl_renderer {
+
+using VertexBuffer =
+    Eigen::Matrix<GLfloat, Eigen::Dynamic, 3, Eigen::RowMajor>;
+using IndexBuffer = Eigen::Matrix<GLuint, Eigen::Dynamic, 3, Eigen::RowMajor>;
+
+/// Loads a mesh's vertices and indices (faces). Does not load textures.
+std::pair<VertexBuffer, IndexBuffer> LoadMeshFromObj(
+    const std::string& filename);
+
+}  // namespace gl_renderer
+}  // namespace anzu

--- a/geometry/render/gl_renderer/opengl_context.cc
+++ b/geometry/render/gl_renderer/opengl_context.cc
@@ -1,16 +1,170 @@
-#include "drake/geometry/render/gl_renderer/opengl_context.h"
+#include "perception/gl_renderer/opengl_context.h"
 
-// TODO(tehbelinda): Move this to opengl_includes.h in follow-up PR.
+#include <algorithm>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
 #include <GL/glx.h>
 
-namespace drake {
-namespace geometry {
-namespace render {
-namespace gl {
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_throw.h"
+#include "drake/common/text_logging.h"
+
+namespace anzu {
+namespace gl_renderer {
 namespace {
 
+// Helper function for loading OpenGL extension functions.
+template <class F>
+F* GetGLXFunctionARB(const char* func_name) {
+  // We must copy the string to a GLubyte buffer to avoid strict aliasing rules.
+  // https://gist.github.com/shafik/848ae25ee209f698763cffee272a58f8
+  constexpr int kBufferSize = 128;
+  DRAKE_ASSERT(strlen(func_name) < kBufferSize);
+  GLubyte gl_func_name[kBufferSize] = {};
+  std::memcpy(gl_func_name, func_name, strlen(func_name) + 1);
+  return reinterpret_cast<F*>(glXGetProcAddressARB(gl_func_name));
 }
-}  // namespace gl
-}  // namespace render
-}  // namespace geometry
-}  // namespace drake
+
+void gl_debug_callback(GLenum, GLenum type, GLuint, GLenum severity, GLsizei,
+                       const GLchar* message, const void*) {
+  drake::log()->error(
+      "GL CALLBACK: {:s} type = 0x{:x}, severity = 0x{:x}, message = {:s}",
+      (type == GL_DEBUG_TYPE_ERROR ? "** GL_ERROR **" : ""), type, severity,
+      message);
+}
+
+}  // namespace
+
+class OpenGlContext::Impl {
+ public:
+  explicit Impl(bool debug = false) {
+    // See Offscreen Rendering section here:
+    // https://sidvind.com/index.php?title=Opengl/windowless
+
+    // Get framebuffer configs.
+    const int kVisualAttribs[] = {None};
+    int fb_count = 0;
+    GLXFBConfig* fb_configs = glXChooseFBConfig(
+        display(), DefaultScreen(display()), kVisualAttribs, &fb_count);
+    if (fb_configs == nullptr) {
+      throw std::runtime_error("Fail to get FBConfig");
+    }
+
+    // Create an OpenGL context.
+    const int kContextAttribs[] = {GLX_CONTEXT_MAJOR_VERSION_ARB, 4,
+                                   GLX_CONTEXT_MINOR_VERSION_ARB, 5, None};
+    auto glXCreateContextAttribsARB =
+        GetGLXFunctionARB<GLXContext(Display*, GLXFBConfig, GLXContext, Bool,
+                                     const int*)>("glXCreateContextAttribsARB");
+
+    // NOTE: The consts True and False come from gl/glx.h (indirectly), but
+    // ultimately from X11/Xlib.h.
+    context_ = glXCreateContextAttribsARB(display(), fb_configs[0], 0, True,
+                                          kContextAttribs);
+    if (context_ == nullptr) {
+      throw std::runtime_error("Fail to create OpenGL context.");
+    }
+
+    XFree(fb_configs);
+    XSync(display(), False);
+
+    // Make it the current context.
+    make_current();
+
+    // Debug.
+    if (debug) {
+      drake::log()->info("Vendor: {}\n",
+                         reinterpret_cast<const char*>(glGetString(GL_VENDOR)));
+      glEnable(GL_DEBUG_OUTPUT);
+      glDebugMessageCallback(gl_debug_callback, 0);
+    }
+  }
+
+  ~Impl() {
+    if (context_ != nullptr && is_owned_) {
+      glXDestroyContext(display(), context_);
+    }
+  }
+
+  static std::unique_ptr<Impl> get_current() {
+    return std::unique_ptr<Impl>(new Impl(glXGetCurrentContext()));
+  }
+
+  void make_current() const {
+    if (glXGetCurrentContext() != context_ &&
+        !glXMakeCurrent(display(), None, context_)) {
+      throw std::runtime_error("Cannot make context current");
+    }
+  }
+
+  bool is_initialized() const { return context_ != nullptr; }
+
+  static GLint max_texture_size() {
+    GLint res;
+    glGetIntegerv(GL_MAX_TEXTURE_SIZE, &res);
+    return res;
+  }
+
+  static GLint max_renderbuffer_size() {
+    GLint res;
+    glGetIntegerv(GL_MAX_RENDERBUFFER_SIZE, &res);
+    return res;
+  }
+
+ private:
+  // Non-owned.
+  explicit Impl(GLXContext context) : is_owned_(false), context_(context) {}
+
+  static Display* display() {
+    // Turn Display into a singleton to make CI happy, since when we close and
+    // reopen the display on CI, we can't request a new OpenGL context.
+    // This pattern won't call the corresponding `XCloseDisplay()` when the
+    // program exiting, but it seems not so evil to skip that.
+    // (https://linux.die.net/man/3/xclosedisplay)
+    // TODO(duy): If problems crop up in the future, this can/should be
+    // investigated.
+    static Display* g_display = XOpenDisplay(0);
+    DRAKE_THROW_UNLESS(g_display != nullptr);
+    return g_display;
+  }
+
+  bool is_owned_{true};
+  GLXContext context_{nullptr};
+};
+
+OpenGlContext::OpenGlContext(bool debug)
+    : impl_(new OpenGlContext::Impl(debug)) {}
+
+OpenGlContext::OpenGlContext(std::unique_ptr<Impl> impl)
+    : impl_(std::move(impl)) {}
+
+std::unique_ptr<OpenGlContext> OpenGlContext::get_current() {
+  return std::unique_ptr<OpenGlContext>(
+      new OpenGlContext(OpenGlContext::Impl::get_current()));
+}
+
+OpenGlContext::~OpenGlContext() = default;
+
+void OpenGlContext::make_current() const { impl_->make_current(); }
+
+bool OpenGlContext::is_initialized() const { return impl_->is_initialized(); }
+
+GLint OpenGlContext::max_texture_size() {
+  return OpenGlContext::Impl::max_texture_size();
+}
+
+GLint OpenGlContext::max_renderbuffer_size() {
+  return OpenGlContext::Impl::max_renderbuffer_size();
+}
+
+GLint OpenGlContext::max_allowable_texture_size() {
+  // TODO(duy): Take into account CUDA limits.
+  return std::min(gl_renderer::OpenGlContext::max_texture_size(),
+                  gl_renderer::OpenGlContext::max_renderbuffer_size());
+}
+
+}  // namespace gl_renderer
+}  // namespace anzu

--- a/geometry/render/gl_renderer/opengl_context.cc
+++ b/geometry/render/gl_renderer/opengl_context.cc
@@ -51,15 +51,53 @@ class OpenGlContext::Impl {
     // https://sidvind.com/index.php?title=Opengl/windowless
 
     // Get framebuffer configs.
-    const int kVisualAttribs[] = {None};
+    const int kVisualAttribs[] = {GLX_X_RENDERABLE,
+                                  True,
+                                  GLX_X_VISUAL_TYPE,
+                                  GLX_TRUE_COLOR,
+                                  GLX_RED_SIZE,
+                                  8,
+                                  GLX_GREEN_SIZE,
+                                  8,
+                                  GLX_BLUE_SIZE,
+                                  8,
+                                  GLX_ALPHA_SIZE,
+                                  8,
+                                  GLX_DEPTH_SIZE,
+                                  24,
+                                  GLX_DOUBLEBUFFER,
+                                  True,
+                                  None};
     int fb_count = 0;
+    int screen_id = DefaultScreen(display());
     GLXFBConfig* fb_configs = glXChooseFBConfig(
-        display(), DefaultScreen(display()), kVisualAttribs, &fb_count);
+        display(), screen_id, kVisualAttribs, &fb_count);
     if (fb_configs == nullptr) {
       throw std::runtime_error(
           "Error initializing OpenGL Context for RenderEngineGL; no suitable "
           "frame buffer configuration found.");
     }
+
+    XVisualInfo* visual = glXGetVisualFromFBConfig(display(), fb_configs[0]);
+    if (visual == nullptr) {
+      throw std::runtime_error(
+          "Unable to generate an OpenGl display window; visual info "
+          "unavailable.");
+    }
+
+    // Set up window for displaying render results.
+    XSetWindowAttributes window_attribs;
+    window_attribs.border_pixel = BlackPixel(display(), screen_id);
+    window_attribs.background_pixel = WhitePixel(display(), screen_id);
+    window_attribs.override_redirect = True;
+    window_attribs.colormap = XCreateColormap(
+        display(), RootWindow(display(), screen_id), visual->visual, AllocNone);
+    window_attribs.event_mask = ExposureMask;
+    window_ =
+        XCreateWindow(display(), RootWindow(display(), screen_id), 0, 0, 320,
+                      240, 0, visual->depth, InputOutput, visual->visual,
+                      CWBackPixel | CWColormap | CWBorderPixel | CWEventMask,
+                      &window_attribs);
 
     // Create an OpenGL context.
     const int kContextAttribs[] = {GLX_CONTEXT_MAJOR_VERSION_ARB, 4,
@@ -79,6 +117,7 @@ class OpenGlContext::Impl {
     }
 
     XFree(fb_configs);
+    XFree(visual);
     XSync(display(), False);
 
     // Make it the current context.
@@ -97,13 +136,31 @@ class OpenGlContext::Impl {
     if (context_ != nullptr && is_owned_) {
       glXDestroyContext(display(), context_);
     }
+    if (window_) {
+      XWindowAttributes window_attribs;
+      XGetWindowAttributes(display(), window_, &window_attribs);
+      XFreeColormap(display(), window_attribs.colormap);
+      XDestroyWindow(display(), window_);
+    }
   }
 
   void make_current() const {
     if (glXGetCurrentContext() != context_ &&
-        !glXMakeCurrent(display(), None, context_)) {
+        !glXMakeCurrent(display(), window_, context_)) {
       throw std::runtime_error("Cannot make context current");
     }
+  }
+
+  void display_window(const int width, const int height) {
+    XMapRaised(display(), window_);
+    if (width != window_width_ || height != window_height_) {
+      XResizeWindow(display(), window_, width, height);
+      XSync(display(), false);
+      window_width_ = width;
+      window_height_ = height;
+    }
+    XClearWindow(display(), window_);
+    glXSwapBuffers(display(), window_);
   }
 
   bool is_initialized() const { return context_ != nullptr; }
@@ -139,6 +196,9 @@ class OpenGlContext::Impl {
 
   bool is_owned_{true};
   GLXContext context_{nullptr};
+  Window window_;
+  int window_width_{0};
+  int window_height_{0};
 };
 
 OpenGlContext::OpenGlContext(bool debug)
@@ -147,6 +207,10 @@ OpenGlContext::OpenGlContext(bool debug)
 OpenGlContext::~OpenGlContext() = default;
 
 void OpenGlContext::make_current() const { impl_->make_current(); }
+
+void OpenGlContext::display_window(const int width, const int height) {
+  impl_->display_window(width, height);
+}
 
 bool OpenGlContext::is_initialized() const { return impl_->is_initialized(); }
 

--- a/geometry/render/gl_renderer/opengl_context.h
+++ b/geometry/render/gl_renderer/opengl_context.h
@@ -2,36 +2,39 @@
 
 #include <memory>
 
-#include "perception/gl_renderer/opengl_includes.h"
+#include "drake/geometry/render/gl_renderer/opengl_includes.h"
 
-namespace anzu {
-namespace gl_renderer {
+namespace drake {
+namespace geometry {
+namespace render {
+namespace gl {
 
-/// Handle OpenGL context initialization, clean-up and generic OpenGL queries.
-/// This class can either create and own a new context upon construction, or
-/// get a non-owned reference to a context using `get_current()`.
-/// Rendering classes need to keep their own OpenGlContext and ensure that they
-/// switch to it using `make_current()` before any OpenGL calls.
+/** Handle OpenGL context initialization, clean-up and generic OpenGL queries.
+ This class creates and owns a new context upon construction. Rendering classes
+ need to keep their own OpenGlContext and ensure that they switch to it using
+ `make_current()` before any OpenGL calls.
+ */
 class OpenGlContext {
  public:
-  /// Constructor. Open an X display and initialize an OpenGL's context. The
-  /// display will be open and ready for offscreen rendering, but no window is
-  /// visible.
-  /// @param debug  If true, diagnostics about the initialization of the context
-  /// will be written to cerr.
+  /** Constructor. Open an X display and initialize an OpenGL context. The
+   display will be open and ready for offscreen rendering, but no window is
+   visible.
+   @param debug  If true, diagnostics about the initialization of the context
+   will be written to the Drake log.
+   */
   explicit OpenGlContext(bool debug = false);
 
-  /// Releases context if it is not owned.
+  /** Releases context if it is not owned.  */
   ~OpenGlContext();
 
-  // Gets a "non-owned" context pointer
-  static std::unique_ptr<OpenGlContext> get_current();
-
-  /// Makes this context current or throws.
+  /** Makes this context current or throws.  */
   void make_current() const;
 
   bool is_initialized() const;
 
+  /** Returns the specified values for the current OpenGL context.
+   @note Even if invoked via an instance, they may not reflect that instance's
+   configuration if the instance differs from whichever context is current.  */
   static GLint max_texture_size();
   static GLint max_renderbuffer_size();
   static GLint max_allowable_texture_size();
@@ -42,11 +45,10 @@ class OpenGlContext {
   // implementation.
   class Impl;
 
-  // For non-owned context.
-  explicit OpenGlContext(std::unique_ptr<Impl> impl);
-
   std::unique_ptr<Impl> impl_;
 };
 
-}  // namespace gl_renderer
-}  // namespace anzu
+}  // namespace gl
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/gl_renderer/opengl_context.h
+++ b/geometry/render/gl_renderer/opengl_context.h
@@ -30,6 +30,9 @@ class OpenGlContext {
   /** Makes this context current or throws.  */
   void make_current() const;
 
+  /** Display the render result in a window with the given dimensions.  */
+  void display_window(const int width, const int height);
+
   bool is_initialized() const;
 
   /** Returns the specified values for the current OpenGL context.

--- a/geometry/render/gl_renderer/opengl_context.h
+++ b/geometry/render/gl_renderer/opengl_context.h
@@ -2,20 +2,51 @@
 
 #include <memory>
 
-#include "drake/geometry/render/gl_renderer/opengl_includes.h"
+#include "perception/gl_renderer/opengl_includes.h"
 
-namespace drake {
-namespace geometry {
-namespace render {
-namespace gl {
+namespace anzu {
+namespace gl_renderer {
 
-/** Temporary dummy class for building dummy RenderEngineGl dependencies.  */
+/// Handle OpenGL context initialization, clean-up and generic OpenGL queries.
+/// This class can either create and own a new context upon construction, or
+/// get a non-owned reference to a context using `get_current()`.
+/// Rendering classes need to keep their own OpenGlContext and ensure that they
+/// switch to it using `make_current()` before any OpenGL calls.
 class OpenGlContext {
  public:
-  static void Dummy() {}
+  /// Constructor. Open an X display and initialize an OpenGL's context. The
+  /// display will be open and ready for offscreen rendering, but no window is
+  /// visible.
+  /// @param debug  If true, diagnostics about the initialization of the context
+  /// will be written to cerr.
+  explicit OpenGlContext(bool debug = false);
+
+  /// Releases context if it is not owned.
+  ~OpenGlContext();
+
+  // Gets a "non-owned" context pointer
+  static std::unique_ptr<OpenGlContext> get_current();
+
+  /// Makes this context current or throws.
+  void make_current() const;
+
+  bool is_initialized() const;
+
+  static GLint max_texture_size();
+  static GLint max_renderbuffer_size();
+  static GLint max_allowable_texture_size();
+
+ private:
+  // Note: we are dependent on `GL/glx.h` but don't want to let that bleed into
+  // other code. So, we pimpl this up so that glx.h lives only in the
+  // implementation.
+  class Impl;
+
+  // For non-owned context.
+  explicit OpenGlContext(std::unique_ptr<Impl> impl);
+
+  std::unique_ptr<Impl> impl_;
 };
 
-}  // namespace gl
-}  // namespace render
-}  // namespace geometry
-}  // namespace drake
+}  // namespace gl_renderer
+}  // namespace anzu

--- a/geometry/render/gl_renderer/opengl_geometry.h
+++ b/geometry/render/gl_renderer/opengl_geometry.h
@@ -2,11 +2,13 @@
 
 #include <limits>
 
+#include "drake/geometry/render/gl_renderer/opengl_includes.h"
 #include "drake/math/rigid_transform.h"
-#include "perception/gl_renderer/opengl_includes.h"
 
-namespace anzu {
-namespace gl_renderer {
+namespace drake {
+namespace geometry {
+namespace render {
+namespace gl {
 
 /** For a fixed OpenGL context, defines the definition of a mesh geometry. The
  geometry is defined by the handles to various objects in the OpenGL context.
@@ -17,12 +19,6 @@ struct OpenGlGeometry {
   GLuint vertex_buffer{kInvalid};
   GLuint index_buffer{kInvalid};
   int index_buffer_size{0};
-
-  void DeleteResources() {
-    if (vertex_array != kInvalid) glDeleteVertexArrays(1, &vertex_array);
-    if (vertex_buffer != kInvalid) glDeleteBuffers(1, &vertex_buffer);
-    if (index_buffer != kInvalid) glDeleteBuffers(1, &index_buffer);
-  }
 
   /** Reports true if `this` has been defined with meaningful values.  */
   bool is_defined() const {
@@ -44,15 +40,16 @@ struct OpenGlGeometry {
  pose of that geometry in the world frame.  */
 struct OpenGlInstance {
   OpenGlInstance(const OpenGlGeometry& g_in,
-                 const drake::math::RigidTransformd& pose_in,
-                 const drake::Vector3<double>& scale_in)
-      : geometry(g_in), X_WG(pose_in), s_GC(scale_in) {}
+                 const math::RigidTransformd& pose_in,
+                 const Vector3<double>& scale_in)
+      : geometry(g_in), X_WG(pose_in), scale(scale_in) {}
   OpenGlGeometry geometry;
-  drake::math::RigidTransformd X_WG;
-  // The scale factors from the geometry's canonical frame C to the full
-  // geometry frame (providing the basis for non-unit geometry).
-  drake::Vector3<double> s_GC;
+  math::RigidTransformd X_WG;
+  // The scale factors providing the basis for non-unit geometry.
+  Vector3<double> scale;
 };
 
-}  // namespace gl_renderer
-}  // namespace anzu
+}  // namespace gl
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/gl_renderer/opengl_geometry.h
+++ b/geometry/render/gl_renderer/opengl_geometry.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <limits>
+
+#include "drake/math/rigid_transform.h"
+#include "perception/gl_renderer/opengl_includes.h"
+
+namespace anzu {
+namespace gl_renderer {
+
+/** For a fixed OpenGL context, defines the definition of a mesh geometry. The
+ geometry is defined by the handles to various objects in the OpenGL context.
+ If the context is changed or otherwise invalidated, these handles will no
+ longer be valid.  */
+struct OpenGlGeometry {
+  GLuint vertex_array{kInvalid};
+  GLuint vertex_buffer{kInvalid};
+  GLuint index_buffer{kInvalid};
+  int index_buffer_size{0};
+
+  void DeleteResources() {
+    if (vertex_array != kInvalid) glDeleteVertexArrays(1, &vertex_array);
+    if (vertex_buffer != kInvalid) glDeleteBuffers(1, &vertex_buffer);
+    if (index_buffer != kInvalid) glDeleteBuffers(1, &index_buffer);
+  }
+
+  /** Reports true if `this` has been defined with meaningful values.  */
+  bool is_defined() const {
+    return vertex_array != kInvalid && vertex_buffer != kInvalid &&
+           index_buffer != kInvalid;
+  }
+
+  /** Throws an exception with the given `message` if `this` hasn't been
+   populated with meaningful values.  */
+  void throw_if_undefined(const char* message) {
+    if (!is_defined()) throw std::logic_error(message);
+  }
+
+  /** The value of an object that should be considered invalid.  */
+  static constexpr GLuint kInvalid = std::numeric_limits<GLuint>::max();
+};
+
+/** An instance of a geometry in the renderer - the geometry definition and the
+ pose of that geometry in the world frame.  */
+struct OpenGlInstance {
+  OpenGlInstance(const OpenGlGeometry& g_in,
+                 const drake::math::RigidTransformd& pose_in,
+                 const drake::Vector3<double>& scale_in)
+      : geometry(g_in), X_WG(pose_in), s_GC(scale_in) {}
+  OpenGlGeometry geometry;
+  drake::math::RigidTransformd X_WG;
+  // The scale factors from the geometry's canonical frame C to the full
+  // geometry frame (providing the basis for non-unit geometry).
+  drake::Vector3<double> s_GC;
+};
+
+}  // namespace gl_renderer
+}  // namespace anzu

--- a/geometry/render/gl_renderer/opengl_includes.h
+++ b/geometry/render/gl_renderer/opengl_includes.h
@@ -1,8 +1,9 @@
-/// @file
-///
-/// Provides a one-stop shop for pulling in the OpenGl symbols in with the
-/// required extensions. Handles the ordering and the required macros in one
-/// place so dependent headers don't have to worry about it.
+/** @file
+ Provides a one-stop shop for pulling in the OpenGl symbols in with the
+ required extensions. Note that this distinguishes 'generic' OpenGl headers
+ from those that are OS-based. This handles the ordering and the required
+ macros in one place so dependent headers don't have to worry about it.
+ */
 
 #pragma once
 

--- a/geometry/render/gl_renderer/render_engine_gl.cc
+++ b/geometry/render/gl_renderer/render_engine_gl.cc
@@ -296,6 +296,28 @@ void RenderEngineGl::GetDepthImage(ImageDepth32F* depth_image_out,
   }
 }
 
+void RenderEngineGl::UpdateVisibleWindow(
+    const CameraProperties& camera, bool show_window,
+    const RenderTarget& target) const {
+  // We don't need to check that the camera width and camera height match the
+  // target dimensions as this is already handled in the target's creation. The
+  // same camera and target are then used together in the invocation of this
+  // function. The target itself does not retain any size information as it is
+  // retrieved via the BufferDim.
+
+  if (show_window) {
+    // Use the render target buffer as the read buffer and the default buffer
+    // (0) as the draw buffer for displaying in the window. We transfer the full
+    // image bounded by (0, 0) and (camera.width, camera.height) from source to
+    // destination.
+    glBlitNamedFramebuffer(target.frame_buffer, 0,
+                           0, 0, camera.width, camera.height,  // Src bounds.
+                           0, 0, camera.width, camera.height,  // Dest bounds.
+                           GL_COLOR_BUFFER_BIT, GL_NEAREST);
+    opengl_context_->display_window(camera.width, camera.height);
+  }
+}
+
 void RenderEngineGl::ImplementGeometry(const Sphere& sphere, void* user_data) {
   OpenGlGeometry geometry = GetSphere();
   const RegistrationData& data = *static_cast<RegistrationData*>(user_data);

--- a/geometry/render/gl_renderer/render_engine_gl.cc
+++ b/geometry/render/gl_renderer/render_engine_gl.cc
@@ -1,50 +1,610 @@
-#include "drake/geometry/render/gl_renderer/render_engine_gl.h"
+#include "perception/gl_renderer/render_engine_gl.h"
 
-namespace drake {
-namespace geometry {
-namespace render {
+#include <algorithm>
+#include <fstream>
+#include <limits>
+#include <string>
 
-using math::RigidTransformd;
-using systems::sensors::ImageDepth32F;
-using systems::sensors::ImageLabel16I;
-using systems::sensors::ImageRgba8U;
+#include <fmt/format.h>
 
-RenderEngineGl::RenderEngineGl() {
-  gl::OpenGlContext::Dummy();
+namespace anzu {
+namespace gl_renderer {
+
+using drake::geometry::Box;
+using drake::geometry::Convex;
+using drake::geometry::Cylinder;
+using drake::geometry::GeometryId;
+using drake::geometry::HalfSpace;
+using drake::geometry::Mesh;
+using drake::geometry::Shape;
+using drake::geometry::Sphere;
+using drake::geometry::PerceptionProperties;
+using drake::geometry::render::CameraProperties;
+using drake::geometry::render::DepthCameraProperties;
+using drake::geometry::render::RenderEngine;
+using drake::math::RigidTransformd;
+using drake::systems::sensors::ImageDepth32F;
+using drake::systems::sensors::ImageLabel16I;
+using drake::systems::sensors::ImageRgba8U;
+using Eigen::Isometry3d;
+using std::make_shared;
+using std::optional;
+using std::string;
+using std::unique_ptr;
+using std::unordered_map;
+
+namespace {
+
+// Data to pass through the reification process.
+struct RegistrationData {
+  const GeometryId id;
+  const RigidTransformd& X_WG;
+};
+
+}  // namespace
+
+RenderEngineGl::RenderEngineGl()
+    : opengl_context_(make_shared<OpenGlContext>()),
+      shader_program_(make_shared<ShaderProgram>()),
+      meshes_(make_shared<unordered_map<string, OpenGlGeometry>>()),
+      frame_buffers_(make_shared<unordered_map<BufferDim, RenderTarget>>()),
+      visuals_() {
+  if (!opengl_context_->is_initialized())
+    throw std::runtime_error("OpenGL Context has not been initialized.");
+
+  // Setup shader program.
+  const std::string kVertexShader = R"__(
+#version 450
+
+layout(location = 0) in vec3 p_Model;
+out float depth;
+uniform mat4 model_view_matrix;
+uniform mat4 projection_matrix;
+
+void main() {
+  vec4 p_Camera = model_view_matrix * vec4(p_Model, 1);
+  depth = -p_Camera.z;
+  gl_Position = projection_matrix * p_Camera;
+})__";
+  const std::string kFragmentShader = R"__(
+#version 450
+
+in float depth;
+layout(location = 0) out float inverse_depth;
+uniform float depth_z_near;
+uniform float depth_z_far;
+
+void main() {
+  if (depth < depth_z_near)
+    // This is ok for OpenGL >= 4.1:
+    // https://stackoverflow.com/questions/10435253/glsl-infinity-constant
+    inverse_depth = 1.0 / 0.0;
+  else if (depth > depth_z_far)
+    inverse_depth = 0.0;
+  else
+    inverse_depth = 1.0 / depth;
+})__";
+  shader_program_->LoadFromSources(kVertexShader, kFragmentShader);
 }
 
-void RenderEngineGl::UpdateViewpoint(const RigidTransformd&) {}
+void RenderEngineGl::UpdateViewpoint(const RigidTransformd& X_WR) {
+  X_CW_ = X_WR.inverse();
+}
 
 void RenderEngineGl::RenderColorImage(const CameraProperties&, bool,
                                       ImageRgba8U*) const {
+  throw std::runtime_error("RenderEngineDepthGl cannot render color images");
 }
 
-void RenderEngineGl::RenderDepthImage(const DepthCameraProperties&,
-                                      ImageDepth32F*) const {
+void RenderEngineGl::RenderDepthImage(const DepthCameraProperties& camera,
+                                      ImageDepth32F* depth_image_out) const {
+  opengl_context_->make_current();
+
+  const_cast<RenderEngineGl*>(this)->SetCameraProperties(camera);
+
+  RenderTarget target =
+      RenderAt(X_CW_.GetAsMatrix4().matrix().cast<float>(), camera);
+  GetDepthImage(depth_image_out, target);
 }
 
 void RenderEngineGl::RenderLabelImage(const CameraProperties&, bool,
                                       ImageLabel16I*) const {
+  throw std::runtime_error("RenderEngineDepthGl cannot render label images");
 }
 
-bool RenderEngineGl::DoRegisterVisual(GeometryId, const Shape&,
-                                      const PerceptionProperties&,
-                                      const RigidTransformd&) {
+void RenderEngineGl::SetGLProjectionMatrix(
+    const DepthCameraProperties& camera) {
+  shader_program_->Use();
+  shader_program_->SetUniformValue1f("depth_z_near", camera.z_near);
+  shader_program_->SetUniformValue1f("depth_z_far", camera.z_far);
+
+  static constexpr float kGLZNear = 0.01;
+  static constexpr float kGLZFar = 10.0;
+  static constexpr float kInvZNearMinusZFar = 1. / (kGLZNear - kGLZFar);
+  if (camera.z_near < kGLZNear)
+    throw std::runtime_error(fmt::format(
+        "Camera's z_near ({}) is closer than what this render can handle ({})",
+        camera.z_near, kGLZNear));
+  if (camera.z_far > kGLZFar)
+    throw std::runtime_error(fmt::format(
+        "Camera's z_far ({}) is farther than what this render can handle ({})",
+        camera.z_far, kGLZFar));
+
+  // https://unspecified.wordpress.com/2012/06/21/calculating-the-gluperspective-matrix-and-other-opengl-matrix-maths/
+  // An OpenGL projection matrix maps points in a camera coordinate to a "clip
+  // coordinate", in which the projection step maps a 3D point into 2D
+  // normalized device coordinate (NDC). Effectively, image corners are mapped
+  // into a square from -1 to 1 in NDC. Hence, the clip coordinate is
+  // essentially a scaled version of the camera coordinate, where the camera
+  // image frustrum is scaled into a "square" frustrum.
+  //
+  // Because the xy elements of the image corner [f*w/2, f*h/2] is mapped to
+  // [fx*f*w/2, fy*f*h/2] in the "square" clip coordinate by the OpenGL
+  // projection matrix P, we have: fx*f*w/2 == fy*f*h/2, i.e. fx*w == fy*h.
+
+  const float fy = 1.0f / static_cast<float>(tan(camera.fov_y * 0.5));
+  const float fx = fy * camera.height / camera.width;
+  const float A = (kGLZNear + kGLZFar) * kInvZNearMinusZFar;
+  const float B = 2.0f * kGLZNear * kGLZFar * kInvZNearMinusZFar;
+  Eigen::Matrix4f P;
+  // Eigen matrices are col-major, similar to OpenGL.
+  // clang-format off
+  P << fx, 0.0,  0.0, 0.0,
+      0.0, fy,   0.0, 0.0,
+      0.0, 0.0,    A,   B,
+      0.0, 0.0, -1.0, 0.0;
+  // clang-format on
+  auto projection_matrix_id =
+      shader_program_->GetUniformLocation("projection_matrix");
+  glUniformMatrix4fv(projection_matrix_id, 1, GL_FALSE, P.data());
+}
+
+OpenGlGeometry RenderEngineGl::SetupVAO(const VertexBuffer& vertices,
+                                        const IndexBuffer& indices) {
+  OpenGlGeometry geometry;
+  // Create the VAO.
+  glCreateVertexArrays(1, &geometry.vertex_array);
+
+  // Vertex Buffer Object.
+  glCreateBuffers(1, &geometry.vertex_buffer);
+  glNamedBufferStorage(geometry.vertex_buffer,
+                       vertices.size() * sizeof(GLfloat), vertices.data(), 0);
+  // Bind with the VAO.
+  const int kBindingIndex = 0;  // The binding point.
+  glVertexArrayVertexBuffer(geometry.vertex_array, kBindingIndex,
+                            geometry.vertex_buffer, 0, 3 * sizeof(GLfloat));
+
+  // Bind the attribute in vertex shader to the VAO at the same binding point.
+  const int kLocP_ModelAttrib = 0;  // p_Model's location in vertex shader.
+  glVertexArrayAttribFormat(geometry.vertex_array, kLocP_ModelAttrib, 3,
+                            GL_FLOAT, GL_FALSE, 0);
+  glVertexArrayAttribBinding(geometry.vertex_array, kLocP_ModelAttrib,
+                             kBindingIndex);
+  glEnableVertexArrayAttrib(geometry.vertex_array, kLocP_ModelAttrib);
+
+  // Index Buffer Object.
+  glCreateBuffers(1, &geometry.index_buffer);
+  glNamedBufferStorage(geometry.index_buffer, indices.size() * sizeof(GLuint),
+                       indices.data(), 0);
+  // Bind with the VAO.
+  glVertexArrayElementBuffer(geometry.vertex_array, geometry.index_buffer);
+
+  geometry.index_buffer_size = indices.size();
+  return geometry;
+}
+
+RenderTarget RenderEngineGl::SetupFBO(const DepthCameraProperties& camera) {
+  // Create a framebuffer object.
+  RenderTarget target;
+  glCreateFramebuffers(1, &target.frame_buffer);
+
+  // Create the texture object to render to.
+  const int kWidth = camera.width;
+  const int kHeight = camera.height;
+  glGenTextures(1, &target.texture);
+  glBindTexture(GL_TEXTURE_2D, target.texture);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_R32F, kWidth, kHeight, 0, GL_RED, GL_FLOAT,
+               0);
+  glBindTexture(GL_TEXTURE_2D, 0);
+
+  // Attach the texture to FBO color attachment point.
+  glNamedFramebufferTexture(target.frame_buffer, GL_COLOR_ATTACHMENT0,
+                            target.texture, 0);
+
+  // Create the renderbuffer object, acting as the z buffer.
+  glCreateRenderbuffers(1, &target.render_buffer);
+  glNamedRenderbufferStorage(target.render_buffer, GL_DEPTH_COMPONENT, kWidth,
+                             kHeight);
+  // Attach the renderbuffer to FBO's depth attachment point.
+  glNamedFramebufferRenderbuffer(target.frame_buffer, GL_DEPTH_ATTACHMENT,
+                                 GL_RENDERBUFFER, target.render_buffer);
+
+  // check FBO status.
+  GLenum status =
+      glCheckNamedFramebufferStatus(target.frame_buffer, GL_FRAMEBUFFER);
+  if (status != GL_FRAMEBUFFER_COMPLETE) {
+    throw std::runtime_error("FBO creation failed.");
+  }
+
+  // Specify which buffer to be associated with the fragment shader output.
+  GLenum buffers[] = {GL_COLOR_ATTACHMENT0};
+  glNamedFramebufferDrawBuffers(target.frame_buffer, 1, buffers);
+
+  return target;
+}
+
+void RenderEngineGl::SetGLModelViewMatrix(const Eigen::Matrix4f& X_CM) const {
+  auto model_view_matrix_id =
+      shader_program_->GetUniformLocation("model_view_matrix");
+
+  // Our camera frame C wrt the OpenGL's camera frame Cgl.
+  static const Eigen::Matrix4f kX_CglC =
+      (Eigen::Matrix4f() << 1, 0, 0, 0, 0, -1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1)
+          .finished();
+
+  Eigen::Matrix4f X_CglM = kX_CglC * X_CM;
+  glUniformMatrix4fv(model_view_matrix_id, 1, GL_FALSE, X_CglM.data());
+}
+
+void RenderEngineGl::SetCameraProperties(const DepthCameraProperties& camera) {
+  SetGLProjectionMatrix(camera);
+
+  const BufferDim dim{camera.width, camera.height};
+  RenderTarget target;
+  auto iter = frame_buffers_->find(dim);
+  if (iter == frame_buffers_->end()) {
+    target = SetupFBO(camera);
+    frame_buffers_->insert({dim, target});
+  } else {
+    target = iter->second;
+  }
+
+  // Attach the texture to FBO color attachment point before rendering.
+  glBindFramebuffer(GL_FRAMEBUFFER, target.frame_buffer);
+  glNamedFramebufferTexture(target.frame_buffer, GL_COLOR_ATTACHMENT0,
+                            target.texture, 0);
+  glClipControl(GL_UPPER_LEFT, GL_NEGATIVE_ONE_TO_ONE);
+}
+
+RenderTarget RenderEngineGl::RenderAt(
+    const Eigen::Matrix4f& X_CW, const DepthCameraProperties& camera) const {
+  shader_program_->Use();
+
+  // Attach the texture to FBO color attachment point before rendering.
+  BufferDim buffer_dim(camera.width, camera.height);
+  const RenderTarget& target = (*frame_buffers_)[buffer_dim];
+
+  glBindFramebuffer(GL_FRAMEBUFFER, target.frame_buffer);
+  glNamedFramebufferTexture(target.frame_buffer, GL_COLOR_ATTACHMENT0,
+                            target.texture, 0);
+  glClipControl(GL_UPPER_LEFT, GL_NEGATIVE_ONE_TO_ONE);
+
+  //  glClearDepth(0.5);
+  glEnable(GL_DEPTH_TEST);
+  glClear(GL_DEPTH_BUFFER_BIT | GL_COLOR_BUFFER_BIT);
+
+  for (const auto& pair : visuals_) {
+    const auto& vis = pair.second;
+    glBindVertexArray(vis.geometry.vertex_array);
+
+    glViewport(0, 0, camera.width, camera.height);
+    Eigen::DiagonalMatrix<float, 4, 4> X_GC(
+        drake::Vector4<float>(vis.s_GC(0), vis.s_GC(1), vis.s_GC(2), 1.0));
+    SetGLModelViewMatrix(X_CW * vis.X_WG.GetAsMatrix4().cast<float>() * X_GC);
+    glDrawElements(GL_TRIANGLES, vis.geometry.index_buffer_size,
+                   GL_UNSIGNED_INT, 0);
+  }
+
+  glBindVertexArray(0);
+  glNamedFramebufferTexture(target.frame_buffer, GL_COLOR_ATTACHMENT0, 0, 0);
+  glBindFramebuffer(GL_FRAMEBUFFER, 0);
+  shader_program_->Unuse();
+  return target;
+}
+
+void RenderEngineGl::GetDepthImage(ImageDepth32F* depth_image_out,
+                                   const RenderTarget& target) const {
+  glGetTextureImage(target.texture, 0, GL_RED, GL_FLOAT,
+                    depth_image_out->size() * sizeof(GLfloat),
+                    depth_image_out->at(0, 0));
+
+  for (int y = 0; y < depth_image_out->height(); ++y) {
+    for (int x = 0; x < depth_image_out->width(); ++x) {
+      *depth_image_out->at(x, y) = 1.f / *depth_image_out->at(x, y);
+    }
+  }
+}
+
+void RenderEngineGl::ImplementGeometry(const Sphere& sphere, void* user_data) {
+  OpenGlGeometry geometry = GetSphere();
+  const RegistrationData& data = *static_cast<RegistrationData*>(user_data);
+  const double r = sphere.radius();
+  visuals_.emplace(data.id, OpenGlInstance(
+      geometry, data.X_WG, drake::Vector3<double>{r, r, r}));
+}
+
+void RenderEngineGl::ImplementGeometry(const Cylinder& cylinder,
+                                       void* user_data) {
+  OpenGlGeometry geometry = GetCylinder();
+  const RegistrationData& data = *static_cast<RegistrationData*>(user_data);
+  const double r = cylinder.radius();
+  const double l = cylinder.length();
+  visuals_.emplace(data.id, OpenGlInstance(
+      geometry, data.X_WG, drake::Vector3<double>{r, r, l}));
+}
+
+void RenderEngineGl::ImplementGeometry(const HalfSpace&, void* user_data) {
+  OpenGlGeometry geometry = GetHalfSpace();
+  const RegistrationData& data = *static_cast<RegistrationData*>(user_data);
+  visuals_.emplace(data.id, OpenGlInstance(
+      geometry, data.X_WG, drake::Vector3<double>{1, 1, 1}));
+}
+
+void RenderEngineGl::ImplementGeometry(const Box& box, void* user_data) {
+  OpenGlGeometry geometry = GetBox();
+  const RegistrationData& data = *static_cast<RegistrationData*>(user_data);
+  visuals_.emplace(data.id, OpenGlInstance(
+      geometry, data.X_WG,
+      drake::Vector3<double>{box.width(), box.depth(), box.height()}));
+}
+
+void RenderEngineGl::ImplementGeometry(const Mesh& mesh, void* user_data) {
+  OpenGlGeometry geometry = GetMesh(mesh.filename());
+  const RegistrationData& data = *static_cast<RegistrationData*>(user_data);
+  visuals_.emplace(data.id, OpenGlInstance(
+      geometry, data.X_WG,
+      drake::Vector3<double>{1, 1, 1} * mesh.scale()));
+}
+
+void RenderEngineGl::ImplementGeometry(const Convex& convex, void* user_data) {
+  OpenGlGeometry geometry = GetMesh(convex.filename());
+  const RegistrationData& data = *static_cast<RegistrationData*>(user_data);
+  visuals_.emplace(data.id, OpenGlInstance(
+      geometry, data.X_WG,
+      drake::Vector3<double>{1, 1, 1} * convex.scale()));
+}
+
+bool RenderEngineGl::DoRegisterVisual(
+    GeometryId id, const Shape& shape, const PerceptionProperties&,
+    const RigidTransformd& X_FG) {
+  opengl_context_->make_current();
+  RegistrationData data{id, RigidTransformd{X_FG}};
+  shape.Reify(this, &data);
   return true;
 }
 
-void RenderEngineGl::DoUpdateVisualPose(GeometryId,
-                                        const RigidTransformd&) {
+void RenderEngineGl::DoUpdateVisualPose(GeometryId id,
+                                        const RigidTransformd& X_WG) {
+  visuals_.at(id).X_WG.SetFromIsometry3(X_WG);
 }
 
-bool RenderEngineGl::DoRemoveGeometry(GeometryId) {
-  return false;
+bool RenderEngineGl::DoRemoveGeometry(GeometryId id) {
+  auto iter = visuals_.find(id);
+  if (iter != visuals_.end()) {
+    visuals_.erase(iter);
+    return true;
+  } else {
+    return false;
+  }
 }
 
 std::unique_ptr<RenderEngine> RenderEngineGl::DoClone() const {
   return std::unique_ptr<RenderEngineGl>(new RenderEngineGl(*this));
 }
 
-}  // namespace render
-}  // namespace geometry
-}  // namespace drake
+OpenGlGeometry RenderEngineGl::GetSphere() {
+  if (!sphere_.is_defined()) {
+    const int kLatitudeBands = 50;
+    const int kLongitudeBands = 50;
+
+    const int tri_count = 2 * (kLatitudeBands - 1) * kLongitudeBands;
+    const int vert_count = (kLatitudeBands - 1) * kLongitudeBands + 2;
+
+    VertexBuffer vertices{vert_count, 3};
+    IndexBuffer indices{tri_count, 3};
+
+    vertices.block<1, 3>(0, 0) << 0.f, 0.f, 1.f;
+
+    // We don't take slices of the sphere that are equidistant along the z-axis.
+    // Instead, we create slices so that the chord length along the perimeter
+    // of the longitudinal circle are equal.
+    int v = 1;
+    int t = 0;
+
+    GLfloat z = cos(M_PI / kLatitudeBands);
+    GLfloat radius = sqrt(1.0 - z * z);
+    int line_start = 1;
+    for (int i = 0; i < kLongitudeBands; ++i) {
+      const GLfloat theta = i * M_PI * 2 / kLongitudeBands;
+      const GLfloat cos_theta = cos(theta);
+      const GLfloat sin_theta = sin(theta);
+      vertices.block<1, 3>(v++, 0) << radius * cos_theta, radius * sin_theta, z;
+      indices.block<1, 3>(t++, 0) << 0, line_start + i,
+          line_start + (i + 1) % kLongitudeBands;
+    }
+
+    // Latitudinal bands
+    for (int latitude = 1; latitude < kLatitudeBands - 1; ++latitude) {
+      int previous_line_start = line_start;
+      line_start += kLongitudeBands;
+      z = cos((latitude + 1) * M_PI / kLatitudeBands);
+      radius = sqrt(1.0f - z * z);
+      for (int i = 0; i < kLongitudeBands; ++i) {
+        const GLfloat theta = i * M_PI * 2 / kLongitudeBands;
+        const GLfloat cos_theta = cos(theta);
+        const GLfloat sin_theta = sin(theta);
+        vertices.block<1, 3>(v++, 0) << radius * cos_theta, radius * sin_theta,
+            z;
+        const int next = (i + 1) % kLongitudeBands;
+        indices.block<1, 3>(t++, 0) << previous_line_start + i, line_start + i,
+            line_start + next;
+        indices.block<1, 3>(t++, 0) << previous_line_start + i,
+            line_start + next, previous_line_start + next;
+      }
+    }
+
+    // South pole fan
+    vertices.block<1, 3>(v++, 0) << 0.f, 0.f, -1.f;
+    DRAKE_DEMAND(v == vert_count);
+    const int south_pole = line_start + kLongitudeBands;
+    for (int i = 0; i < kLongitudeBands; ++i) {
+      indices.block<1, 3>(t++, 0) << line_start + i, south_pole,
+          line_start + (i + 1) % kLongitudeBands;
+    }
+    DRAKE_DEMAND(t == tri_count);
+
+    sphere_ = SetupVAO(vertices, indices);
+  }
+
+  sphere_.throw_if_undefined("Built-in sphere has some invalid objects");
+
+  return sphere_;
+}
+
+OpenGlGeometry RenderEngineGl::GetCylinder() {
+  if (!cylinder_.is_defined()) {
+    const int kLongitudeBands = 50;
+
+    // A fan of triangles on each cap with kLongitudeBands triangles, and then
+    // that many rectangles along the barrels (with twice as many triangles).
+    const int tri_count = 4 * kLongitudeBands;
+    // A pair of vertices for each longitudinal band + 1 for each cap.
+    const int vert_count = 2 * kLongitudeBands + 2;
+
+    VertexBuffer vertices{vert_count, 3};
+    IndexBuffer indices{tri_count, 3};
+
+    vertices.block<1, 3>(0, 0) << 0.f, 0.f, 0.5f;
+
+    // Both caps are triangle fans around central points (leading to nicer
+    // triangles).
+    const GLfloat radius = 1.f;
+    int line_start = 1;
+    // Index of the previous vertices and triangles, respectively.
+    int v = 0;
+    int t = -1;
+
+    // Top cap.
+    GLfloat z = 0.5f;
+    for (int i = 0; i < kLongitudeBands; ++i) {
+      const auto theta = static_cast<GLfloat>(i * M_PI * 2 / kLongitudeBands);
+      const auto cos_theta = static_cast<GLfloat>(cos(theta));
+      const auto sin_theta = static_cast<GLfloat>(sin(theta));
+      vertices.block<1, 3>(++v, 0) << radius * cos_theta, radius * sin_theta, z;
+      indices.block<1, 3>(++t, 0) << 0, line_start + i,
+          line_start + (i + 1) % kLongitudeBands;
+    }
+
+    // Barrel.
+    line_start += kLongitudeBands;
+    z = -0.5;
+    const int previous_line_start = 1;
+    for (int i = 0; i < kLongitudeBands; ++i) {
+      const auto theta = static_cast<GLfloat>(i * M_PI * 2 / kLongitudeBands);
+      const auto cos_theta = static_cast<GLfloat>(cos(theta));
+      const auto sin_theta = static_cast<GLfloat>(sin(theta));
+      vertices.block<1, 3>(++v, 0) << radius * cos_theta, radius * sin_theta, z;
+      const int next = (i + 1) % kLongitudeBands;
+      indices.block<1, 3>(++t, 0) << previous_line_start + i, line_start + i,
+          line_start + next;
+      indices.block<1, 3>(++t, 0) << previous_line_start + i, line_start + next,
+          previous_line_start + next;
+    }
+
+    // Bottom cap.
+    line_start += kLongitudeBands;
+    vertices.block<1, 3>(++v, 0) << 0, 0, z;
+    for (int i = 0; i < kLongitudeBands; ++i) {
+      indices.block<1, 3>(++t, 0) << v, line_start + (i + 1) % kLongitudeBands,
+          line_start + i;
+    }
+
+    DRAKE_DEMAND(v == vert_count - 1);
+    DRAKE_DEMAND(t == tri_count - 1);
+
+    cylinder_ = SetupVAO(vertices, indices);
+  }
+
+  cylinder_.throw_if_undefined("Built-in cylinder has some invalid objects");
+
+  return cylinder_;
+}
+
+OpenGlGeometry RenderEngineGl::GetHalfSpace() {
+  if (!half_space_.is_defined()) {
+    //                 _  y
+    //                  /|
+    //                 /
+    //     3_________________________ 2
+    //     /         ^ z            /
+    //    /          |_            /  --> x
+    //   /           Go           /
+    //  /                        /
+    // /________________________/
+    // 0                         1
+    const GLfloat kHalfSize = 100.f;
+    VertexBuffer vertices{4, 3};
+    vertices << -kHalfSize, -kHalfSize, 0.f, kHalfSize, -kHalfSize, 0.f,
+        kHalfSize, kHalfSize, 0.f, -kHalfSize, kHalfSize, 0.f;
+
+    IndexBuffer indices{2, 3};
+    indices << 0, 1, 2, 0, 2, 3;
+    half_space_ = SetupVAO(vertices, indices);
+  }
+
+  half_space_.throw_if_undefined(
+      "Built-in half space has some invalid objects");
+
+  return half_space_;
+}
+
+OpenGlGeometry RenderEngineGl::GetBox() {
+  if (!box_.is_defined()) {
+    //     7      6
+    //     _____
+    //    /|    /|
+    //  2/_|__3/ |
+    //  |  |   | |
+    //  | 4|___|_| 5
+    //  | /    | /
+    //  |/_____|/
+    //  0      1
+    VertexBuffer vertices{8, 3};
+    vertices << -0.5f, -0.5f, -0.5f, 0.5f, -0.5f, -0.5f, 0.5f, 0.5f, -0.5f,
+        -0.5f, 0.5f, -0.5f, -0.5f, -0.5f, 0.5f, 0.5f, -0.5f, 0.5f, 0.5f, 0.5f,
+        0.5f, -0.5f, 0.5f, 0.5f;
+    IndexBuffer indices{12, 3};
+    indices << 0, 1, 2, 0, 2, 3, 1, 5, 6, 1, 6, 2, 2, 6, 7, 2, 7, 3, 3, 7, 4, 3,
+        4, 0, 7, 6, 5, 7, 5, 4, 1, 0, 4, 1, 4, 5;
+    box_ = SetupVAO(vertices, indices);
+  }
+
+  box_.throw_if_undefined("Built-in box has some invalid objects");
+
+  return box_;
+}
+
+OpenGlGeometry RenderEngineGl::GetMesh(const string& filename) {
+  OpenGlGeometry mesh;
+  if (meshes_->count(filename) == 0) {
+    auto [vertices, indices] = LoadMeshFromObj(filename);  // NOLINT
+    mesh = SetupVAO(vertices, indices);
+    meshes_->insert({filename, mesh});
+  } else {
+    mesh = meshes_->at(filename);
+  }
+
+  mesh.throw_if_undefined(
+      fmt::format("Error creating object for mesh {}", filename).c_str());
+
+  return mesh;
+}
+
+RenderEngineGl::~RenderEngineGl() = default;
+
+}  // namespace gl_renderer
+}  // namespace anzu

--- a/geometry/render/gl_renderer/render_engine_gl.cc
+++ b/geometry/render/gl_renderer/render_engine_gl.cc
@@ -87,6 +87,7 @@ void RenderEngineGl::RenderDepthImage(const DepthCameraProperties& camera,
       const_cast<RenderEngineGl*>(this)->SetCameraProperties(camera);
 
   RenderAt(X_CW_.GetAsMatrix4().matrix().cast<float>());
+  UpdateVisibleWindow(camera, true, target);
   GetDepthImage(depth_image_out, target);
 }
 

--- a/geometry/render/gl_renderer/render_engine_gl.h
+++ b/geometry/render/gl_renderer/render_engine_gl.h
@@ -38,7 +38,9 @@ class RenderEngineGl final : public RenderEngine {
   /** Inherits RenderEngine::UpdateViewpoint().  */
   void UpdateViewpoint(const math::RigidTransformd& X_WR) override;
 
-  /** Inherits RenderEngine::RenderColorImage().  */
+  /** Inherits RenderEngine::RenderColorImage(). Note that the display window
+   triggered by `show_window` is shared with RenderLabelImage, and only the
+   last color or label image rendered will be visible in the window.  */
   void RenderColorImage(
       const CameraProperties& camera, bool show_window,
       systems::sensors::ImageRgba8U* color_image_out) const override;
@@ -48,7 +50,9 @@ class RenderEngineGl final : public RenderEngine {
       const DepthCameraProperties& camera,
       systems::sensors::ImageDepth32F* depth_image_out) const override;
 
-  /** Inherits RenderEngine::RenderLabelImage().  */
+  /** Inherits RenderEngine::RenderLabelImage(). Note that the display window
+   triggered by `show_window` is shared with RenderColorImage, and only the
+   last color or label image rendered will be visible in the window. */
   void RenderLabelImage(
       const CameraProperties& camera, bool show_window,
       systems::sensors::ImageLabel16I* label_image_out) const override;
@@ -113,6 +117,17 @@ class RenderEngineGl final : public RenderEngine {
   // Configure the vertex array object for a triangle mesh.
   OpenGlGeometry SetupVAO(const VertexBuffer& vertices,
                           const IndexBuffer& indices);
+
+  // Updates the display window with the last image rendered.
+  // If `show_window` is true:
+  //  - if the window is not currently visible, it is made visible
+  //  - the windows contents display the most recent image rendered.
+  // If `show_window` is false:
+  //  - the display window's state is unchanged; hidden remains hidden, and
+  //    visible remains visible with unchanged contents.
+  // @pre RenderTarget's BufferDim is the same as the size reported by `camera`.
+  void UpdateVisibleWindow(const CameraProperties& camera, bool show_window,
+                           const RenderTarget& target) const;
 
   // The cached value transformation between camera and world frame.
   mutable math::RigidTransformd X_CW_;

--- a/geometry/render/gl_renderer/render_engine_gl.h
+++ b/geometry/render/gl_renderer/render_engine_gl.h
@@ -1,54 +1,163 @@
 #pragma once
 
 #include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
-#include "drake/geometry/render/gl_renderer/opengl_context.h"
+#include "drake/common/eigen_types.h"
+#include "drake/geometry/geometry_roles.h"
+#include "drake/geometry/render/camera_properties.h"
 #include "drake/geometry/render/render_engine.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/systems/sensors/image.h"
+#include "perception/gl_renderer/buffer_dim.h"
+#include "perception/gl_renderer/load_mesh.h"
+#include "perception/gl_renderer/opengl_context.h"
+#include "perception/gl_renderer/opengl_geometry.h"
+#include "perception/gl_renderer/shader_program.h"
 
-namespace drake {
-namespace geometry {
-namespace render {
+namespace anzu {
+namespace gl_renderer {
 
-/** See documentation of MakeRenderEngineGl().  */
-class RenderEngineGl final : public RenderEngine {
+/** Optimized simple renderer based on direct calls to the OpenGL API. All
+ geometries with perception role are added to this renderer.  */
+class RenderEngineGl final : public drake::geometry::render::RenderEngine {
  public:
+  /** \name Does not allow public copy, move, or assignment  */
+  //@{
+  RenderEngineGl& operator=(const RenderEngineGl&) = delete;
+  RenderEngineGl(RenderEngineGl&&) = delete;
+  RenderEngineGl& operator=(RenderEngineGl&&) = delete;
+  //@}}
+
   RenderEngineGl();
 
-  /** @see RenderEngine::UpdateViewpoint().  */
-  void UpdateViewpoint(const math::RigidTransformd& X_WR) final;
+  ~RenderEngineGl() override;
 
-  /** @see RenderEngine::RenderColorImage().  */
+  /** Inherits RenderEngine::UpdateViewpoint().  */
+  void UpdateViewpoint(const drake::math::RigidTransformd& X_WR) override;
+
+  /** Inherits RenderEngine::RenderColorImage().  */
   void RenderColorImage(
-      const CameraProperties& camera, bool show_window,
-      systems::sensors::ImageRgba8U* color_image_out) const final;
+      const drake::geometry::render::CameraProperties& camera, bool show_window,
+      drake::systems::sensors::ImageRgba8U* color_image_out) const override;
 
-  /** @see RenderEngine::RenderDepthImage().  */
+  /** Inherits RenderEngine::RenderDepthImage().  */
   void RenderDepthImage(
-      const DepthCameraProperties& camera,
-      systems::sensors::ImageDepth32F* depth_image_out) const final;
+      const drake::geometry::render::DepthCameraProperties& camera,
+      drake::systems::sensors::ImageDepth32F* depth_image_out) const override;
 
-  /** @see RenderEngine::RenderLabelImage().  */
+  /** Inherits RenderEngine::RenderLabelImage().  */
   void RenderLabelImage(
-      const CameraProperties& camera, bool show_window,
-      systems::sensors::ImageLabel16I* label_image_out) const final;
+      const drake::geometry::render::CameraProperties& camera, bool show_window,
+      drake::systems::sensors::ImageLabel16I* label_image_out) const override;
+
+  /** @name    Shape reification  */
+  //@{
+  using drake::geometry::render::RenderEngine::ImplementGeometry;
+  void ImplementGeometry(const drake::geometry::Sphere& sphere,
+                         void* user_data) override;
+  void ImplementGeometry(const drake::geometry::Cylinder& cylinder,
+                         void* user_data) override;
+  void ImplementGeometry(const drake::geometry::HalfSpace& half_space,
+                         void* user_data) override;
+  void ImplementGeometry(const drake::geometry::Box& box,
+                         void* user_data) override;
+  void ImplementGeometry(const drake::geometry::Mesh& mesh,
+                         void* user_data) override;
+  void ImplementGeometry(const drake::geometry::Convex& convex,
+                         void* user_data) override;
+  //@}
 
  private:
   // @see RenderEngine::DoRegisterVisual().
-  bool DoRegisterVisual(GeometryId id, const Shape& shape,
-                        const PerceptionProperties& properties,
-                        const math::RigidTransformd& X_WG) final;
+  bool DoRegisterVisual(
+      drake::geometry::GeometryId id,
+      const drake::geometry::Shape& shape,
+      const drake::geometry::PerceptionProperties& properties,
+      const drake::math::RigidTransformd& X_WG) override;
 
   // @see RenderEngine::DoUpdateVisualPose().
-  void DoUpdateVisualPose(GeometryId id,
-                          const math::RigidTransformd& X_WG) final;
+  void DoUpdateVisualPose(drake::geometry::GeometryId id,
+                          const drake::math::RigidTransformd& X_WG) override;
 
   // @see RenderEngine::DoRemoveGeometry().
-  bool DoRemoveGeometry(GeometryId id) final;
+  bool DoRemoveGeometry(drake::geometry::GeometryId id) override;
 
-  // @see RenderEngine::DoClone().
-  std::unique_ptr<RenderEngine> DoClone() const final;
+  // see RenderEngine::DoClone().
+  std::unique_ptr<drake::geometry::render::RenderEngine> DoClone()
+      const override;
+
+  // Copy constructor used for cloning.
+  RenderEngineGl(const RenderEngineGl& other) = default;
+
+  // Render inverse depth of the object at a specific pose in the camera frame.
+  RenderTarget RenderAt(
+      const Eigen::Matrix4f& X_CM,
+      const drake::geometry::render::DepthCameraProperties& camera) const;
+
+  // Obtain the depth image of rendered from a specific object pose. This is
+  // slow because it reads the buffer back from the GPU.
+  void GetDepthImage(drake::systems::sensors::ImageDepth32F* depth_image_out,
+                     const RenderTarget& target) const;
+
+  // Provide triangle mesh definitions of the various geometries supported by
+  // this renderer: sphere, cylinder, half space, box, and mesh.
+  OpenGlGeometry GetSphere();
+  OpenGlGeometry GetCylinder();
+  OpenGlGeometry GetHalfSpace();
+  OpenGlGeometry GetBox();
+  OpenGlGeometry GetMesh(const std::string& filename);
+
+  // Infrastructure for setting up the frame buffer object.
+  RenderTarget SetupFBO(
+      const drake::geometry::render::DepthCameraProperties& camera);
+
+  // Configure the model view and projection matrices.
+  void SetGLProjectionMatrix(
+      const drake::geometry::render::DepthCameraProperties& camera);
+  void SetGLModelViewMatrix(const Eigen::Matrix4f& X_CM) const;
+
+  // Configure the OpenGL properties dependent on the camera properties.
+  void SetCameraProperties(
+      const drake::geometry::render::DepthCameraProperties& camera);
+
+  // Configure the vertex array object for a triangle mesh.
+  OpenGlGeometry SetupVAO(const VertexBuffer& vertices,
+                          const IndexBuffer& indices);
+
+  // The cached value transformation between camera and world frame.
+  mutable drake::math::RigidTransformd X_CW_;
+
+  // All clones of this context share the same underlying opengl_context_. They
+  // share geometry and frame buffer objects. The following structs are either
+  // shared, or copy safe w.r.t. the shared context.
+  std::shared_ptr<OpenGlContext> opengl_context_;
+
+  // All of the objects below here *depend* on the OpenGL context. Right now,
+  // I'm having each instance of the renderer share these OpenGl objects and
+  // the context. If I'm going to do that, I may be better off making them
+  // part of the Context rather than part of the renderer.
+  std::shared_ptr<ShaderProgram> shader_program_;
+
+  // One OpenGLGeometry per primitive type -- allow for instancing.
+  OpenGlGeometry sphere_;
+  OpenGlGeometry cylinder_;
+  OpenGlGeometry half_space_;
+  OpenGlGeometry box_;
+
+  std::shared_ptr<std::unordered_map<std::string, OpenGlGeometry>> meshes_;
+
+  std::shared_ptr<std::unordered_map<BufferDim, RenderTarget>> frame_buffers_;
+
+  // Mapping from RenderIndex to the visual data associated with that geometry.
+  // This is copied so independent renderers can have different *instances* but
+  // the instances still refer to the same, shared, underlying geometry.
+  std::unordered_map<drake::geometry::GeometryId, OpenGlInstance> visuals_;
 };
 
-}  // namespace render
-}  // namespace geometry
-}  // namespace drake
+}  // namespace gl_renderer
+}  // namespace anzu

--- a/geometry/render/gl_renderer/render_engine_gl_factory.cc
+++ b/geometry/render/gl_renderer/render_engine_gl_factory.cc
@@ -7,7 +7,7 @@ namespace geometry {
 namespace render {
 
 std::unique_ptr<RenderEngine> MakeRenderEngineGl() {
-  return std::make_unique<RenderEngineGl>();
+  return std::make_unique<gl::RenderEngineGl>();
 }
 
 }  // namespace render

--- a/geometry/render/gl_renderer/render_engine_gl_factory.h
+++ b/geometry/render/gl_renderer/render_engine_gl_factory.h
@@ -9,14 +9,10 @@ namespace drake {
 namespace geometry {
 namespace render {
 
-/** Constructs a RenderEngine implementation which uses a purely OpenGL
- renderer. Currently this uses a temporary dummy implementation. Due to the lack
- of support on Mac, this has been initially introduced to verify platform
- specific (i.e. Ubuntu only) conditionals for building and installing. The rest
- of the implementation will be ported over once the conditionalizing is no
- longer considered a risk.
- <!-- TODO(tehbelinda): Complete port of RenderEngineGl. -->
- */
+/** Constructs an optimized simple renderer based on direct calls to the OpenGL
+ API. For now, it only renders depth images, i.e. no color or label images are
+ supported. The presence of PerceptionProperties is enough to register the
+ geometry as no specific properties are required.   */
 std::unique_ptr<RenderEngine> MakeRenderEngineGl();
 
 }  // namespace render

--- a/geometry/render/gl_renderer/shader_program.cc
+++ b/geometry/render/gl_renderer/shader_program.cc
@@ -1,0 +1,108 @@
+#include "perception/gl_renderer/shader_program.h"
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace anzu {
+namespace gl_renderer {
+
+namespace {
+
+GLuint CompileShader(GLuint shader_type, const std::string& shader_code) {
+  GLuint shader_id = glCreateShader(shader_type);
+  char const* source_ptr = shader_code.c_str();
+  glShaderSource(shader_id, 1, &source_ptr, NULL);
+  glCompileShader(shader_id);
+
+  // Check compilation result.
+  GLint result;
+  int info_log_length;
+  glGetShaderiv(shader_id, GL_COMPILE_STATUS, &result);
+  glGetShaderiv(shader_id, GL_INFO_LOG_LENGTH, &info_log_length);
+  if (info_log_length > 0) {
+    std::vector<char> error_message(info_log_length + 1);
+    glGetShaderInfoLog(shader_id, info_log_length, NULL, &error_message[0]);
+    throw std::runtime_error(&error_message[0]);
+  }
+
+  return shader_id;
+}
+
+}  // namespace
+
+void ShaderProgram::LoadFromSources(const std::string& vertex_shader_source,
+                                    const std::string& fragment_shader_source) {
+  // Compile.
+  GLuint vertex_shader_id =
+      CompileShader(GL_VERTEX_SHADER, vertex_shader_source);
+  GLuint fragment_shader_id =
+      CompileShader(GL_FRAGMENT_SHADER, fragment_shader_source);
+
+  // Link.
+  program_id_ = glCreateProgram();
+  glAttachShader(program_id_, vertex_shader_id);
+  glAttachShader(program_id_, fragment_shader_id);
+  glLinkProgram(program_id_);
+
+  // Clean up.
+  glDetachShader(program_id_, vertex_shader_id);
+  glDetachShader(program_id_, fragment_shader_id);
+  glDeleteShader(vertex_shader_id);
+  glDeleteShader(fragment_shader_id);
+
+  // Check.
+  GLint result;
+  int info_log_length;
+  glGetProgramiv(program_id_, GL_LINK_STATUS, &result);
+  glGetProgramiv(program_id_, GL_INFO_LOG_LENGTH, &info_log_length);
+  if (info_log_length > 0) {
+    std::vector<char> error_message(info_log_length + 1);
+    glGetProgramInfoLog(program_id_, info_log_length, NULL, &error_message[0]);
+    throw std::runtime_error(&error_message[0]);
+  }
+}
+
+namespace {
+std::string LoadFile(const std::string& filename) {
+  std::ifstream file(filename.c_str(), std::ios::in);
+  if (!file.is_open())
+    throw std::runtime_error("Error opening shader file: " + filename);
+  std::stringstream content;
+  content << file.rdbuf();
+  file.close();
+  return content.str();
+}
+}  // namespace
+
+void ShaderProgram::LoadFromFiles(const std::string& vertex_shader_file,
+                                  const std::string& fragment_shader_file) {
+  LoadFromSources(LoadFile(vertex_shader_file), LoadFile(fragment_shader_file));
+}
+
+GLint ShaderProgram::GetUniformLocation(const std::string& uniform_name) const {
+  GLint id = glGetUniformLocation(program_id_, uniform_name.c_str());
+  if (id < 0)
+    throw std::runtime_error("Cannot get shader uniform " + uniform_name);
+  return id;
+}
+
+void ShaderProgram::SetUniformValue1f(const std::string& uniform_name,
+                                      float value) const {
+  glUniform1f(GetUniformLocation(uniform_name), value);
+}
+
+void ShaderProgram::Use() const { glUseProgram(program_id_); }
+
+void ShaderProgram::Unuse() const { glUseProgram(0); }
+
+ShaderProgram::~ShaderProgram() {
+  glUseProgram(0);
+  glDeleteProgram(program_id_);
+}
+
+}  // namespace gl_renderer
+}  // namespace anzu

--- a/geometry/render/gl_renderer/shader_program.cc
+++ b/geometry/render/gl_renderer/shader_program.cc
@@ -1,14 +1,15 @@
-#include "perception/gl_renderer/shader_program.h"
+#include "drake/geometry/render/gl_renderer/shader_program.h"
 
 #include <fstream>
-#include <iostream>
 #include <sstream>
 #include <stdexcept>
 #include <string>
 #include <vector>
 
-namespace anzu {
-namespace gl_renderer {
+namespace drake {
+namespace geometry {
+namespace render {
+namespace gl {
 
 namespace {
 
@@ -104,5 +105,7 @@ ShaderProgram::~ShaderProgram() {
   glDeleteProgram(program_id_);
 }
 
-}  // namespace gl_renderer
-}  // namespace anzu
+}  // namespace gl
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/gl_renderer/shader_program.h
+++ b/geometry/render/gl_renderer/shader_program.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <string>
+
+#include "drake/common/drake_copyable.h"
+#include "perception/gl_renderer/opengl_includes.h"
+
+namespace anzu {
+namespace gl_renderer {
+
+/** Definition of a GLSL shader program including a vertex and fragment shader.
+ All operations on this shader program require an active OpenGL context. In
+ fact, they require the same context which was active when the program was
+ "loaded".  */
+class ShaderProgram {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ShaderProgram)
+
+  ShaderProgram() = default;
+
+  ~ShaderProgram();
+
+  /** Loads a %ShaderProgram from GLSL code contained in the provided strings.
+   */
+  void LoadFromSources(const std::string& vertex_shader_source,
+                       const std::string& fragment_shader_source);
+
+  /** Loads a %ShaderProgram from GLSL code contained in the named files.  */
+  void LoadFromFiles(const std::string& vertex_shader_file,
+                     const std::string& fragment_shader_file);
+
+  /** Provides the location of the named shader uniform parameter.  */
+  GLint GetUniformLocation(const std::string& uniform_name) const;
+
+  /** Sets the scalar uniform value to the given value.  */
+  void SetUniformValue1f(const std::string& uniform_name, float value) const;
+
+  /** Binds the program for usage.  */
+  void Use() const;
+
+  /** Unbinds the program.  */
+  void Unuse() const;
+
+ private:
+  GLuint program_id_ = 0;
+};
+
+}  // namespace gl_renderer
+}  // namespace anzu

--- a/geometry/render/gl_renderer/shader_program.h
+++ b/geometry/render/gl_renderer/shader_program.h
@@ -3,10 +3,12 @@
 #include <string>
 
 #include "drake/common/drake_copyable.h"
-#include "perception/gl_renderer/opengl_includes.h"
+#include "drake/geometry/render/gl_renderer/opengl_includes.h"
 
-namespace anzu {
-namespace gl_renderer {
+namespace drake {
+namespace geometry {
+namespace render {
+namespace gl {
 
 /** Definition of a GLSL shader program including a vertex and fragment shader.
  All operations on this shader program require an active OpenGL context. In
@@ -42,8 +44,10 @@ class ShaderProgram {
   void Unuse() const;
 
  private:
-  GLuint program_id_ = 0;
+  GLuint program_id_{0};
 };
 
-}  // namespace gl_renderer
-}  // namespace anzu
+}  // namespace gl
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/gl_renderer/test/render_engine_gl_test.cc
+++ b/geometry/render/gl_renderer/test/render_engine_gl_test.cc
@@ -88,6 +88,7 @@ class RenderEngineGlTest : public ::testing::Test {
     const DepthCameraProperties& camera = camera_in ? *camera_in : camera_;
     ImageDepth32F* depth = depth_in ? depth_in : &depth_;
     EXPECT_NO_THROW(renderer->RenderDepthImage(camera, depth));
+    sleep(1);
   }
 
   // Confirms that all pixels in the member depth image have the same value.

--- a/geometry/render/gl_renderer/test/render_engine_gl_test.cc
+++ b/geometry/render/gl_renderer/test/render_engine_gl_test.cc
@@ -1,18 +1,662 @@
+#include "perception/gl_renderer/render_engine_gl.h"
+
+#include <unordered_map>
+
 #include <gtest/gtest.h>
 
-#include "drake/geometry/render/gl_renderer/render_engine_gl_factory.h"
+#include "drake/common/find_resource.h"
+#include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/geometry_roles.h"
+#include "drake/geometry/render/render_label.h"
+#include "drake/systems/sensors/color_palette.h"
+#include "drake/systems/sensors/image.h"
 
-namespace drake {
-namespace geometry {
-namespace render {
+namespace anzu {
+namespace gl_renderer {
 namespace {
 
-// Tests the temporary dummy implementation of RenderEngineGl doesn't crash.
-GTEST_TEST(RenderEngineGl, DummyRenderDepthImage) {
-  std::unique_ptr<RenderEngine> engine = MakeRenderEngineGl();
+using drake::geometry::Cylinder;
+using drake::geometry::Convex;
+using drake::geometry::Box;
+using drake::geometry::GeometryId;
+using drake::geometry::HalfSpace;
+using drake::geometry::Mesh;
+using drake::geometry::PerceptionProperties;
+using drake::geometry::render::CameraProperties;
+using drake::geometry::render::DepthCameraProperties;
+using drake::geometry::render::RenderEngine;
+using drake::geometry::render::RenderLabel;
+using drake::geometry::Sphere;
+using drake::math::RigidTransformd;
+using drake::systems::sensors::ColorI;
+using drake::systems::sensors::ImageDepth32F;
+using drake::systems::sensors::InvalidDepth;
+using Eigen::Translation3d;
+using Eigen::Vector3d;
+using Eigen::Vector4d;
+using std::make_unique;
+using std::optional;
+using std::unique_ptr;
+using std::unordered_map;
+using std::vector;
+
+// Default camera properties.
+const int kWidth = 640;
+const int kHeight = 480;
+const double kZNear = 0.5;
+const double kZFar = 5.;
+const double kFovY = M_PI_4;
+
+// NOTE: The depth tolerance is this large mostly due to the combination of
+// several factors:
+//   - the sphere test (sphere against terrain)
+//   - The even-valued window dimensions
+//   - the tests against various camera properties
+// The explanation is as follows. The distance to the sphere is only exactly
+// 2 at the point of the sphere directly underneath the camera (the sphere's
+// "peak"). However, with an even-valued window dimension, we never really
+// sample that point. We sample the center of pixels all evenly arrayed around
+// that point. So, that introduces some error. As the image gets *smaller* the
+// pixels get bigger and so the distance away from the peak center increases,
+// which, in turn, increase the measured distance for the fragment. This
+// tolerance accounts for the test case where one image has pixels that are *4X*
+// larger (in area) than the default image size.
+const double kDepthTolerance = 2.5e-4;  // meters.
+
+// Holds `(x, y)` indices of the screen coordinate system where the ranges of
+// `x` and `y` are [0, image_width) and [0, image_height) respectively.
+struct ScreenCoord {
+  ScreenCoord(int x_in, int y_in) : x(x_in), y(y_in) {}
+  int x{};
+  int y{};
+};
+
+std::ostream& operator<<(std::ostream& out, const ScreenCoord& c) {
+  out << "(" << c.x << ", " << c.y << ")";
+  return out;
+}
+
+class RenderEngineGlTest : public ::testing::Test {
+ public:
+  RenderEngineGlTest()
+      : depth_(kWidth, kHeight),
+        // Looking straight down from 3m above the ground.
+        X_WR_(Eigen::Translation3d(0, 0, kDefaultDistance) *
+              Eigen::AngleAxisd(M_PI, Eigen::Vector3d::UnitY()) *
+              Eigen::AngleAxisd(-M_PI_2, Eigen::Vector3d::UnitZ())),
+        geometry_id_(GeometryId::get_new_id()) {}
+
+ protected:
+  // Method to allow the normal case (render with the built-in renderer against
+  // the default camera) to the member images with default window visibility.
+  // This interface allows that to be completely reconfigured by the calling
+  // test.
+  void Render(RenderEngineGl* renderer = nullptr,
+              const DepthCameraProperties* camera_in = nullptr,
+              ImageDepth32F* depth_in = nullptr) {
+    if (!renderer) renderer = renderer_.get();
+    const DepthCameraProperties& camera = camera_in ? *camera_in : camera_;
+    ImageDepth32F* depth = depth_in ? depth_in : &depth_;
+    EXPECT_NO_THROW(renderer->RenderDepthImage(camera, depth));
+  }
+
+  // Confirms that all pixels in the member depth image have the same value.
+  void VerifyUniformDepth(float depth) {
+    if (depth == std::numeric_limits<float>::infinity()) {
+      for (int y = 0; y < kHeight; ++y) {
+        for (int x = 0; x < kWidth; ++x) {
+          ASSERT_EQ(depth_.at(x, y)[0], depth);
+        }
+      }
+    } else {
+      for (int y = 0; y < kHeight; ++y) {
+        for (int x = 0; x < kWidth; ++x) {
+          ASSERT_NEAR(depth_.at(x, y)[0], depth, kDepthTolerance);
+        }
+      }
+    }
+  }
+
+  // Report the coordinates of the set of "outlier" pixels for a given set of
+  // camera properties. These are the pixels that are drawn on by the
+  // background (possibly flat plane, possibly sky) and not the primary
+  // geometry.
+  static std::vector<ScreenCoord> GetOutliers(const CameraProperties& camera) {
+    return std::vector<ScreenCoord>{
+        {kInset, kInset},
+        {kInset, camera.height - kInset - 1},
+        {camera.width - kInset - 1, camera.height - kInset - 1},
+        {camera.width - kInset - 1, kInset}};
+  }
+
+  // Compute the coordinate of the pixel that is drawn on by the primary
+  // geometry given a set of camera properties.
+  static ScreenCoord GetInlier(const CameraProperties& camera) {
+    return ScreenCoord(camera.width / 2, camera.height / 2);
+  }
+
+  // Tests that the depth value in the given `image` at the given `coord` is
+  // the expected depth to within a tolerance. Handles the special case where
+  // the expected distance is infinity.
+  static ::testing::AssertionResult IsExpectedDepth(const ImageDepth32F& image,
+                                                    const ScreenCoord& coord,
+                                                    float expected_depth,
+                                                    float tolerance) {
+    const float actual_depth = image.at(coord.x, coord.y)[0];
+    if (expected_depth == std::numeric_limits<float>::infinity()) {
+      if (actual_depth == expected_depth) {
+        return ::testing::AssertionSuccess();
+      } else {
+        return ::testing::AssertionFailure()
+               << "Expected depth at " << coord << " to be "
+               << "infinity. Found: " << actual_depth;
+      }
+    } else {
+      float delta = std::abs(expected_depth - actual_depth);
+      if (delta <= tolerance) {
+        return ::testing::AssertionSuccess();
+      } else {
+        return ::testing::AssertionFailure()
+               << "Expected depth at " << coord << " to be " << expected_depth
+               << ". Found " << actual_depth << ". Difference " << delta
+               << "is greater than tolerance " << tolerance;
+      }
+    }
+  }
+
+  // Verifies the "outlier" pixels for the given camera belong to the terrain.
+  // If images are provided, the given images will be tested, otherwise the
+  // member images will be tested.
+  void VerifyOutliers(const RenderEngineGl& renderer,
+                      const DepthCameraProperties& camera, const char* name,
+                      ImageDepth32F* depth_in = nullptr) {
+    ImageDepth32F& depth = depth_in ? *depth_in : depth_;
+
+    for (const auto& screen_coord : GetOutliers(camera)) {
+      // Depth
+      EXPECT_TRUE(IsExpectedDepth(depth, screen_coord, expected_outlier_depth_,
+                                  kDepthTolerance))
+          << name;
+    }
+  }
+
+  void SetUp() override {}
+
+  // All tests on this class must invoke this first.
+  void SetUp(const RigidTransformd& X_WR, bool add_terrain = false) {
+    renderer_ = make_unique<RenderEngineGl>();
+    renderer_->UpdateViewpoint(X_WR);
+
+    if (add_terrain) {
+      const GeometryId ground_id = GeometryId::get_new_id();
+      renderer_->RegisterVisual(
+          ground_id, HalfSpace(), PerceptionProperties(),
+          RigidTransformd::Identity(), false /** needs update */);
+    }
+  }
+
+  // Creates a simple perception properties set for fixed, known results.
+  PerceptionProperties simple_material() const {
+    PerceptionProperties material;
+    Vector4d color(kDefaultVisualColor.r / 255., kDefaultVisualColor.g / 255.,
+                   kDefaultVisualColor.b / 255., 1.);
+    material.AddProperty("phong", "diffuse", color);
+    // NOTE: Any render label is sufficient; we aren't  testing them for this
+    // depth-only renderer.
+    material.AddProperty("label", "id", RenderLabel::kEmpty);
+    return material;
+  }
+
+  // Populates the given renderer with the sphere required for
+  // PerformCenterShapeTest().
+  void PopulateSphereTest(RenderEngineGl* renderer) {
+    Sphere sphere{0.5};
+    renderer->RegisterVisual(geometry_id_, sphere, PerceptionProperties(),
+                             RigidTransformd::Identity(),
+                             true /* needs update */);
+    RigidTransformd X_WV{Vector3d{0, 0, 0.5}};
+    X_WV_.clear();
+    X_WV_.insert({geometry_id_, X_WV});
+    renderer->UpdatePoses(X_WV_);
+  }
+
+  // Performs the work to test the rendering with a sphere centered in the
+  // image. To pass, the renderer will have to have been populated with a
+  // compliant sphere and camera configuration (e.g., PopulateSphereTest()).
+  // If force_hidden is true, then the render windows will be suppressed
+  // regardless of any other settings.
+  void PerformCenterShapeTest(RenderEngineGl* renderer, const char* name,
+                              const DepthCameraProperties* camera = nullptr) {
+    const DepthCameraProperties& cam = camera ? *camera : camera_;
+    // Can't use the member images in case the camera has been configured to a
+    // different size than the default camera_ configuration.
+    ImageDepth32F depth(cam.width, cam.height);
+    Render(renderer, &cam, &depth);
+
+    VerifyOutliers(*renderer, cam, name, &depth);
+
+    // Verifies inside the sphere.
+    const ScreenCoord inlier = GetInlier(cam);
+    EXPECT_TRUE(
+        IsExpectedDepth(depth, inlier, expected_object_depth_, kDepthTolerance))
+        << name;
+  }
+
+  // Provide a default visual color for this tests -- it is intended to be
+  // different from the default color of the VTK render engine.
+  const ColorI kDefaultVisualColor = {229u, 229u, 229u};
+  const float kDefaultDistance{3.f};
+
+  // Values to be used with the "centered shape" tests.
+  // The amount inset from the edge of the images to *still* expect terrain
+  // values.
+  static constexpr int kInset{10};
+  float expected_outlier_depth_{3.f};
+  float expected_object_depth_{2.f};
+
+  const DepthCameraProperties camera_ = {kWidth, kHeight, kFovY,
+                                         "n/a",  kZNear,  kZFar};
+  ImageDepth32F depth_;
+  RigidTransformd X_WR_;
+  GeometryId geometry_id_;
+
+  // The pose of the sphere created in PopulateSphereTest().
+  unordered_map<GeometryId, RigidTransformd> X_WV_;
+
+  unique_ptr<RenderEngineGl> renderer_;
+};
+
+// Tests an empty image -- confirms that it clears to the "empty" color -- no
+// use of "inlier" or "outlier" pixel locations.
+TEST_F(RenderEngineGlTest, NoBodyTest) {
+  SetUp(RigidTransformd::Identity());
+  Render();
+
+  VerifyUniformDepth(std::numeric_limits<float>::infinity());
+}
+
+// Tests an image with *only* terrain (perpendicular to the camera's forward
+// direction) -- no use of "inlier" or "outlier" pixel locations.
+TEST_F(RenderEngineGlTest, TerrainTest) {
+  SetUp(X_WR_, true);
+
+  // At two different distances.
+  Vector3d p_WR = X_WR_.translation();
+  for (auto depth : std::array<float, 2>({{2.f, 4.9999f}})) {
+    p_WR.z() = depth;
+    X_WR_.set_translation(p_WR);
+    renderer_->UpdateViewpoint(X_WR_);
+    Render();
+    VerifyUniformDepth(depth);
+  }
+
+  // Closer than kZNear.
+  p_WR.z() = kZNear - 1e-5;
+  X_WR_.set_translation(p_WR);
+  renderer_->UpdateViewpoint(X_WR_);
+  Render();
+  VerifyUniformDepth(InvalidDepth::kTooClose);
+
+  // Farther than kZFar.
+  p_WR.z() = kZFar + 1e-3;
+  X_WR_.set_translation(p_WR);
+  renderer_->UpdateViewpoint(X_WR_);
+  Render();
+  // Verifies depth.
+  for (int y = 0; y < kHeight; ++y) {
+    for (int x = 0; x < kWidth; ++x) {
+      ASSERT_EQ(InvalidDepth::kTooFar, depth_.at(x, y)[0]);
+    }
+  }
+}
+
+// Performs the shape centered in the image with a box.
+TEST_F(RenderEngineGlTest, BoxTest) {
+  SetUp(X_WR_, true);
+
+  // Sets up a box.
+  Box box(1, 1, 1);
+  const GeometryId id = GeometryId::get_new_id();
+  renderer_->RegisterVisual(id, box, simple_material(),
+                            RigidTransformd::Identity(),
+                            true /* needs update */);
+  RigidTransformd X_WV{Eigen::Translation3d(0, 0, 0.5)};
+  renderer_->UpdatePoses(
+      unordered_map<GeometryId, RigidTransformd>{{id, X_WV}});
+
+  PerformCenterShapeTest(renderer_.get(), "Box test");
+}
+
+// Performs the shape centered in the image with a sphere.
+TEST_F(RenderEngineGlTest, SphereTest) {
+  SetUp(X_WR_, true);
+
+  PopulateSphereTest(renderer_.get());
+
+  PerformCenterShapeTest(renderer_.get(), "Sphere test");
+}
+
+// Performs the shape centered in the image with a cylinder.
+TEST_F(RenderEngineGlTest, CylinderTest) {
+  SetUp(X_WR_, true);
+
+  // Sets up a cylinder.
+  Cylinder cylinder(0.2, 1.2);
+  const GeometryId id = GeometryId::get_new_id();
+  renderer_->RegisterVisual(id, cylinder, simple_material(),
+                            RigidTransformd::Identity(),
+                            true /* needs update */);
+  // Position the top of the cylinder to be 1 m above the terrain.
+  RigidTransformd X_WV{Eigen::Translation3d(0, 0, 0.4)};
+  renderer_->UpdatePoses(
+      unordered_map<GeometryId, RigidTransformd>{{id, X_WV}});
+
+  PerformCenterShapeTest(renderer_.get(), "Cylinder test");
+}
+
+// Performs the shape centered in the image with a mesh (which happens to be a
+// box). This simultaneously confirms that if a diffuse_map is specified but it
+// doesn't refer to a file that can be read, that the appearance defaults to
+// the diffuse rgba value.
+TEST_F(RenderEngineGlTest, MeshTest) {
+  SetUp(X_WR_, true);
+
+  auto filename = drake::FindResourceOrThrow(
+      "drake/systems/sensors/test/models/meshes/box.obj");
+  Mesh mesh(filename);
+  PerceptionProperties material = simple_material();
+  // NOTE: Specifying a diffuse map with a known bad path, will force the box
+  // to get the diffuse RGBA value (otherwise it would pick up the `box.png`
+  // texture.
+  material.AddProperty("phong", "diffuse_map", "bad_path");
+  const GeometryId id = GeometryId::get_new_id();
+  renderer_->RegisterVisual(id, mesh, material,
+                            RigidTransformd::Identity(),
+                            true /* needs update */);
+  renderer_->UpdatePoses(unordered_map<GeometryId, RigidTransformd>{
+      {id, RigidTransformd::Identity()}});
+
+  PerformCenterShapeTest(renderer_.get(), "Mesh test");
+}
+
+// Performs the shape centered in the image with a convex mesh (which happens to
+// be a  box). This simultaneously confirms that if a diffuse_map is specified
+// but it doesn't refer to a file that can be read, that the appearance defaults
+// to the diffuse rgba value.
+TEST_F(RenderEngineGlTest, ConvexTest) {
+  SetUp(X_WR_, true);
+
+  auto filename = drake::FindResourceOrThrow(
+      "drake/systems/sensors/test/models/meshes/box.obj");
+  Convex convex(filename);
+  PerceptionProperties material = simple_material();
+  // NOTE: Specifying a diffuse map with a known bad path, will force the box
+  // to get the diffuse RGBA value (otherwise it would pick up the `box.png`
+  // texture.
+  material.AddProperty("phong", "diffuse_map", "bad_path");
+  const GeometryId id = GeometryId::get_new_id();
+  renderer_->RegisterVisual(id, convex, material,
+                            RigidTransformd::Identity(),
+                            true /* needs update */);
+  renderer_->UpdatePoses(unordered_map<GeometryId, RigidTransformd>{
+      {id, RigidTransformd::Identity()}});
+
+  PerformCenterShapeTest(renderer_.get(), "Mesh test");
+}
+
+// This confirms that geometries are correctly removed from the render engine.
+// We add two new geometries (testing the rendering after each addition).
+// By removing the first of the added geometries, we can confirm that the
+// remaining geometries are re-ordered appropriately. Then by removing the,
+// second we should restore the original default image.
+//
+// The default image is based on a sphere sitting on a plane at z = 0 with the
+// camera located above the sphere's center and aimed at that center.
+// THe default sphere is drawn with `●`, the first added sphere with `x`, and
+// the second with `o`. The height of the top of each sphere and its depth in
+// the camera's depth sensors are indicated as zᵢ and dᵢ, i ∈ {0, 1, 2},
+// respectively.
+//
+//             /|\       <---- camera_z = 3
+//              v
+//
+//
+//
+//
+//            ooooo       <---- z₂ = 4r = 2, d₂ = 1
+//          oo     oo
+//         o         o
+//        o           o
+//        o           o
+//        o   xxxxx   o   <---- z₁ = 3r = 1.5, d₁ = 1.5
+//         oxx     xxo
+//         xoo     oox
+//        x   ooooo   x
+//        x   ●●●●●   x   <---- z₀ = 2r = 1, d₀ = 2
+//        x ●●     ●● x
+//         ●         ●
+//        ● xx     xx ●
+// z      ●   xxxxx   ●
+// ^      ●           ●
+// |       ●         ●
+// |        ●●     ●●
+// |__________●●●●●____________
+//
+TEST_F(RenderEngineGlTest, RemoveVisual) {
+  SetUp(X_WR_, true);
+  const float default_depth = expected_object_depth_;
+
+  // Positions a sphere centered at <0, 0, z> with the given color.
+  auto add_sphere = [this](double z, GeometryId geometry_id) {
+    const double kRadius = 0.5;
+    Sphere sphere{kRadius};
+    const float depth = kDefaultDistance - kRadius - z;
+    PerceptionProperties material;
+    renderer_->RegisterVisual(
+        geometry_id, sphere, material, RigidTransformd::Identity(), true);
+    RigidTransformd X_WV{Eigen::Translation3d(0, 0, z)};
+    X_WV_.insert({geometry_id, X_WV});
+    renderer_->UpdatePoses(X_WV_);
+    return depth;
+  };
+
+  // Sets the expected values prior to calling PerformCenterShapeTest().
+  auto set_expectations = [this](float depth) {
+    expected_object_depth_ = depth;
+  };
+
+  const GeometryId id0 = GeometryId::get_new_id();
+  const float depth0 = add_sphere(0.5, id0);
+  set_expectations(depth0);
+  PerformCenterShapeTest(renderer_.get(), "First sphere test");
+
+  // Add another sphere of a different color in front of the default sphere
+  const GeometryId id1 = GeometryId::get_new_id();
+  const float depth1 = add_sphere(0.75, id1);
+  set_expectations(depth1);
+  PerformCenterShapeTest(renderer_.get(), "Second sphere added in remove test");
+
+  // Add a _third_ sphere in front of the second.
+  const GeometryId id2 = GeometryId::get_new_id();
+  float depth2 = add_sphere(1.0, id2);
+  set_expectations(depth2);
+  PerformCenterShapeTest(renderer_.get(), "Third sphere added in remove test");
+
+  // Remove the first sphere added; should report "true" and the render test
+  // should pass without changing expectations.
+  bool removed = renderer_->RemoveGeometry(id1);
+  EXPECT_TRUE(removed);
+  PerformCenterShapeTest(renderer_.get(), "First added sphere removed");
+
+  // Remove the second added sphere; should report true and rendering should
+  // return to its default configuration.
+  removed = renderer_->RemoveGeometry(id2);
+  EXPECT_TRUE(removed);
+  set_expectations(default_depth);
+  PerformCenterShapeTest(renderer_.get(),
+                         "Default image restored by removing extra geometries");
+}
+
+// All of the clone tests use the PerformCenterShapeTest() with the sphere setup
+// to confirm that the clone is behaving as anticipated.
+
+// Tests that the cloned renderer produces the same images (i.e., passes the
+// same test).
+TEST_F(RenderEngineGlTest, SimpleClone) {
+  SetUp(X_WR_, true);
+  PopulateSphereTest(renderer_.get());
+
+  unique_ptr<RenderEngine> clone = renderer_->Clone();
+  EXPECT_NE(dynamic_cast<RenderEngineGl*>(clone.get()), nullptr);
+  PerformCenterShapeTest(dynamic_cast<RenderEngineGl*>(clone.get()),
+                         "Simple clone");
+}
+
+// Tests that the cloned renderer still works, even when the original is
+// deleted.
+TEST_F(RenderEngineGlTest, ClonePersistence) {
+  SetUp(X_WR_, true);
+  PopulateSphereTest(renderer_.get());
+
+  unique_ptr<RenderEngine> clone = renderer_->Clone();
+  // This causes the original renderer copied from to be destroyed.
+  renderer_.reset();
+  ASSERT_EQ(nullptr, renderer_);
+  PerformCenterShapeTest(static_cast<RenderEngineGl*>(clone.get()),
+                         "Clone persistence");
+}
+
+// Tests that the cloned renderer still works, even when the original has values
+// RenderEngineGlTest
+TEST_F(RenderEngineGlTest, CloneIndependence) {
+  SetUp(X_WR_, true);
+  PopulateSphereTest(renderer_.get());
+
+  unique_ptr<RenderEngine> clone = renderer_->Clone();
+  // Move the terrain *up* 10 units in the z.
+  RigidTransformd X_WT_new{Translation3d{0, 0, 10}};
+  // This assumes that the terrain is zero-indexed.
+  renderer_->UpdatePoses(
+      unordered_map<GeometryId, RigidTransformd>{{geometry_id_, X_WT_new}});
+  PerformCenterShapeTest(dynamic_cast<RenderEngineGl*>(clone.get()),
+                         "Clone independence");
+}
+
+// Confirm that the renderer can be used for cameras with different properties.
+// I.e., the camera intrinsics are defined *outside* the renderer.
+TEST_F(RenderEngineGlTest, DifferentCameras) {
+  SetUp(X_WR_, true);
+  PopulateSphereTest(renderer_.get());
+
+  // Baseline -- confirm that all of the defaults in this test still produce
+  // the expected outcome.
+  PerformCenterShapeTest(renderer_.get(), "Camera change - baseline", &camera_);
+
+  // Test changes in sensor sizes.
+  {
+    // Now run it again with a camera with a smaller sensor (quarter area).
+    DepthCameraProperties small_camera{camera_};
+    small_camera.width /= 2;
+    small_camera.height /= 2;
+    PerformCenterShapeTest(renderer_.get(), "Camera change - small camera",
+                           &small_camera);
+
+    // Now run it again with a camera with a bigger sensor (4X area).
+    DepthCameraProperties big_camera{camera_};
+    big_camera.width *= 2;
+    big_camera.height *= 2;
+    PerformCenterShapeTest(renderer_.get(), "Camera change - big camera",
+                           &big_camera);
+  }
+
+  // Test changes in fov (larger and smaller).
+  {
+    DepthCameraProperties narrow_fov(camera_);
+    narrow_fov.fov_y /= 2;
+    PerformCenterShapeTest(renderer_.get(), "Camera change - narrow fov",
+                           &narrow_fov);
+
+    DepthCameraProperties wide_fov(camera_);
+    wide_fov.fov_y *= 2;
+    PerformCenterShapeTest(renderer_.get(), "Camera change - wide fov",
+                           &wide_fov);
+  }
+
+  // Test changes to depth range.
+  {
+    DepthCameraProperties clipping_far_plane(camera_);
+    clipping_far_plane.z_far = expected_outlier_depth_ - 0.1;
+    const float old_outlier_depth = expected_outlier_depth_;
+    expected_outlier_depth_ = std::numeric_limits<float>::infinity();
+    PerformCenterShapeTest(renderer_.get(),
+                           "Camera change - z far clips terrain",
+                           &clipping_far_plane);
+    // NOTE: Need to restored expected outlier depth for next test.
+    expected_outlier_depth_ = old_outlier_depth;
+
+    DepthCameraProperties clipping_near_plane(camera_);
+    clipping_near_plane.z_near = expected_object_depth_ + 0.1;
+    expected_object_depth_ = 0;
+    PerformCenterShapeTest(renderer_.get(), "Camera change - z near clips mesh",
+                           &clipping_near_plane);
+  }
+}
+
+// Tests that registered geometry without specific values renders without error.
+// TODO(SeanCurtis-TRI): When the ability to set defaults is exposed through a
+// public API, actually test for the *default values*. Until then, error-free
+// rendering is sufficient.
+TEST_F(RenderEngineGlTest, DefaultProperties) {
+  SetUp(X_WR_, false /* no terrain */);
+
+  // Sets up a box.
+  Box box(1, 1, 1);
+  const GeometryId id = GeometryId::get_new_id();
+  renderer_->RegisterVisual(id, box, PerceptionProperties(),
+                            RigidTransformd::Identity(), true);
+  RigidTransformd X_WV{Eigen::Translation3d(0, 0, 0.5)};
+  renderer_->UpdatePoses(
+      unordered_map<GeometryId, RigidTransformd>{{id, X_WV}});
+
+  EXPECT_NO_THROW(Render());
+}
+
+// This is a test to make sure that independent renders are truly independent.
+// So, we're going to do a bunch of interleaved operations on the two renderers
+// to make sure that each is still correct.
+TEST_F(RenderEngineGlTest, MultipleRenderers) {
+  RenderEngineGl engine1;
+  RenderEngineGl engine2;
+  const GeometryId ground = GeometryId::get_new_id();
+
+  auto add_terrain = [ground](auto* renderer) {
+    renderer->RegisterVisual(
+        ground, HalfSpace(), PerceptionProperties(),
+        RigidTransformd::Identity(), false /** needs update */);
+  };
+
+  engine1.UpdateViewpoint(X_WR_);
+  add_terrain(&engine1);
+  PopulateSphereTest(&engine1);
+  PerformCenterShapeTest(&engine1, "engine1 - initial render");
+
+  Render(&engine2);
+  VerifyUniformDepth(std::numeric_limits<float>::infinity());
+
+  engine2.UpdateViewpoint(X_WR_);
+  add_terrain(&engine2);
+  Box box(1, 1, 1);
+  const GeometryId box_id = GeometryId::get_new_id();
+  engine2.RegisterVisual(box_id, box, simple_material(),
+                         RigidTransformd::Identity(), true);
+  RigidTransformd X_WV{Eigen::Translation3d(0.2, 0.2, 0.5)};
+  engine2.UpdatePoses(
+      unordered_map<GeometryId, RigidTransformd>{{box_id, X_WV}});
+  PerformCenterShapeTest(&engine2, "engine2 - offset box test");
+
+  PerformCenterShapeTest(&engine1, "engine1 - second render");
 }
 
 }  // namespace
-}  // namespace render
-}  // namespace geometry
-}  // namespace drake
+}  // namespace gl_renderer
+}  // namespace anzu

--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -82,6 +82,7 @@ load("@drake//tools/workspace/tinyxml2:repository.bzl", "tinyxml2_repository")
 load("@drake//tools/workspace/tinyxml:repository.bzl", "tinyxml_repository")
 load("@drake//tools/workspace/uritemplate_py:repository.bzl", "uritemplate_py_repository")  # noqa
 load("@drake//tools/workspace/vtk:repository.bzl", "vtk_repository")
+load("//tools/workspace/x11:repository.bzl", "x11_repository")
 load("@drake//tools/workspace/yaml_cpp:repository.bzl", "yaml_cpp_repository")
 load("@drake//tools/workspace/zlib:repository.bzl", "zlib_repository")
 
@@ -257,6 +258,8 @@ def add_default_repositories(excludes = [], mirrors = DEFAULT_MIRRORS):
         uritemplate_py_repository(name = "uritemplate_py", mirrors = mirrors)
     if "vtk" not in excludes:
         vtk_repository(name = "vtk", mirrors = mirrors)
+    if "x11" not in excludes:
+        x11_repository(name = "x11")
     if "yaml_cpp" not in excludes:
         yaml_cpp_repository(name = "yaml_cpp")
     if "zlib" not in excludes:

--- a/tools/workspace/x11/BUILD.bazel
+++ b/tools/workspace/x11/BUILD.bazel
@@ -1,0 +1,8 @@
+# -*- python -*-
+
+# This file exists to make our directory into a Bazel package, so that our
+# neighboring *.bzl file can be loaded elsewhere.
+
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+add_lint_tests()

--- a/tools/workspace/x11/repository.bzl
+++ b/tools/workspace/x11/repository.bzl
@@ -1,0 +1,19 @@
+# -*- mode: python -*-
+# vi: set ft=python :
+
+load(
+    "@drake//tools/workspace:pkg_config.bzl",
+    "pkg_config_repository",
+)
+
+def x11_repository(
+        name,
+        licenses = ["notice"],  # X11/MIT.
+        modname = "x11",
+        **kwargs):
+    pkg_config_repository(
+        name = name,
+        licenses = licenses,
+        modname = modname,
+        **kwargs
+    )


### PR DESCRIPTION
Will be used in a subsequent PR but split up to keep things manageable
Called from the RenderXXXImage functions like `UpdateWindow(camera, show_window, target);`
It can actually be seen even now from the RenderDepthImage function by calling `UpdateWindow(camera, true, target);` since there is data in the color buffer

Ignore 1st/2nd commit for now (already in PR). Please see 3rd commit only

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12844)
<!-- Reviewable:end -->
