### PR TITLE
Add Polynomial::CoefficientsAlmostEqual function.

### DIFF
--- a/bindings/pydrake/symbolic_py.cc
+++ b/bindings/pydrake/symbolic_py.cc
@@ -540,6 +540,9 @@ PYBIND11_MODULE(symbolic, m) {
           &Polynomial::RemoveTermsWithSmallCoefficients,
           py::arg("coefficient_tol"),
           doc.Polynomial.RemoveTermsWithSmallCoefficients.doc)
+      .def("CoefficientsAlmostEqual", &Polynomial::CoefficientsAlmostEqual,
+          py::arg("p"), py::arg("tolerance"),
+          doc.Polynomial.CoefficientsAlmostEqual.doc)
       .def(py::self + py::self)
       .def(py::self + Monomial())
       .def(Monomial() + py::self)

--- a/bindings/pydrake/test/symbolic_test.py
+++ b/bindings/pydrake/test/symbolic_test.py
@@ -895,6 +895,12 @@ class TestSymbolicPolynomial(unittest.TestCase):
         self.assertIsInstance(p != q, sym.Formula)
         self.assertEqual(p != q, sym.Formula.True_())
         self.assertFalse(p.EqualTo(q))
+        self.assertTrue(
+            p.CoefficientsAlmostEqual(p + sym.Polynomial(1e-7), 1e-6))
+        self.assertTrue(
+            p.CoefficientsAlmostEqual(p + sym.Polynomial(1e-7 * x), 1e-6))
+        self.assertFalse(
+            p.CoefficientsAlmostEqual(p + sym.Polynomial(2e-6 * x), 1e-6))
 
     def test_repr(self):
         p = sym.Polynomial()

--- a/common/symbolic_polynomial.cc
+++ b/common/symbolic_polynomial.cc
@@ -673,6 +673,12 @@ bool Polynomial::EqualToAfterExpansion(const Polynomial& p) const {
   return PolynomialEqual(*this, p, true);
 }
 
+bool Polynomial::CoefficientsAlmostEqual(const Polynomial& p,
+                                         double tol) const {
+  return PolynomialEqual((*this - p).RemoveTermsWithSmallCoefficients(tol),
+                         Polynomial(0), true);
+}
+
 Formula Polynomial::operator==(const Polynomial& p) const {
   // 1) Let diff = p - (this polynomial).
   // 2) Extract the condition where diff is zero.

--- a/common/symbolic_polynomial.h
+++ b/common/symbolic_polynomial.h
@@ -196,6 +196,11 @@ class Polynomial {
   /// coefficients.
   bool EqualToAfterExpansion(const Polynomial& p) const;
 
+  /// Returns true if this polynomial and @p are almost equal (the difference
+  /// in the corresponding coefficients are all less than @p tol), after
+  /// expanding the coefficients.
+  bool CoefficientsAlmostEqual(const Polynomial& p, double tol) const;
+
   /// Returns a symbolic formula representing the condition where this
   /// polynomial and @p p are the same.
   Formula operator==(const Polynomial& p) const;

--- a/common/test/symbolic_polynomial_test.cc
+++ b/common/test/symbolic_polynomial_test.cc
@@ -882,6 +882,30 @@ TEST_F(SymbolicPolynomialTest, Hash) {
   EXPECT_NE(h(p1), h(p2));
 }
 
+TEST_F(SymbolicPolynomialTest, CoefficientsAlmostEqual) {
+  Polynomial p1{x_ * x_};
+  // Two polynomials with the same number of terms.
+  EXPECT_TRUE(p1.CoefficientsAlmostEqual(Polynomial{x_ * x_}, 1e-6));
+  EXPECT_TRUE(
+      p1.CoefficientsAlmostEqual(Polynomial{(1 + 1e-7) * x_ * x_}, 1e-6));
+  EXPECT_FALSE(p1.CoefficientsAlmostEqual(Polynomial{2 * x_ * x_}, 1e-6));
+  // Another polynomial with an additional small constant term.
+  EXPECT_TRUE(p1.CoefficientsAlmostEqual(Polynomial{x_ * x_ + 1e-7}, 1e-6));
+  EXPECT_FALSE(p1.CoefficientsAlmostEqual(Polynomial{x_ * x_ + 2e-6}, 1e-6));
+  // Another polynomial with small difference on coefficients.
+  EXPECT_TRUE(p1.CoefficientsAlmostEqual(
+      Polynomial{(1. - 1e-7) * x_ * x_ + 1e-7}, 1e-6));
+  EXPECT_FALSE(p1.CoefficientsAlmostEqual(
+      Polynomial{(1. + 2e-6) * x_ * x_ + 1e-7}, 1e-6));
+
+  // Another polynomial with decision variables in the coefficient.
+  const symbolic::Polynomial p2(a_ * x_ * x_, {indeterminates_});
+  EXPECT_TRUE(p2.CoefficientsAlmostEqual(
+      Polynomial{(a_ + 1e-7) * x_ * x_, {indeterminates_}}, 1e-6));
+  EXPECT_FALSE(p2.CoefficientsAlmostEqual(
+      Polynomial{(a_ + 1e-7) * x_ * x_, {indeterminates_}}, 1e-8));
+}
+
 TEST_F(SymbolicPolynomialTest, RemoveTermsWithSmallCoefficients) {
   // Single term.
   Polynomial p1{1e-5 * x_ * x_};


### PR DESCRIPTION
A syntax sugar to compare if two polynomials are almost equal.

Resolves #12817

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12853)
<!-- Reviewable:end -->
