### PR TITLE
bind CopyToVector for ContinuousState

### DIFF
--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -618,7 +618,9 @@ void DefineFrameworkPySemantics(py::module m) {
         .def("get_vector", &ContinuousState<T>::get_vector,
             py_reference_internal, doc.ContinuousState.get_vector.doc)
         .def("get_mutable_vector", &ContinuousState<T>::get_mutable_vector,
-            py_reference_internal, doc.ContinuousState.get_mutable_vector.doc);
+            py_reference_internal, doc.ContinuousState.get_mutable_vector.doc)
+        .def("CopyToVector", &ContinuousState<T>::CopyToVector,
+            doc.ContinuousState.CopyToVector.doc);
 
     auto discrete_values = DefineTemplateClassWithDefault<DiscreteValues<T>>(
         m, "DiscreteValues", GetPyParam<T>(), doc.DiscreteValues.doc);

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -167,6 +167,8 @@ class TestGeneral(unittest.TestCase):
         x = np.array([0.1, 0.2])
         context.SetContinuousState(x)
         np.testing.assert_equal(
+            context.get_continuous_state().CopyToVector(), x)
+        np.testing.assert_equal(
             context.get_continuous_state_vector().CopyToVector(), x)
         context.SetTimeAndContinuousState(0.3, 2*x)
         np.testing.assert_equal(context.get_time(), 0.3)


### PR DESCRIPTION
to enable:
```
deriv = f.EvalTimeDerivatives(context).CopyToVector()
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12865)
<!-- Reviewable:end -->
