### PR TITLE
Add default std::nullopt arguments to SolverBase::Solve()

### DIFF
--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -254,8 +254,8 @@ top-level documentation for :py:mod:`pydrake.math`.
             self.Solve(prog, initial_guess, solver_options, &result);
             return result;
           },
-          py::arg("prog"), py::arg("initial_guess"), py::arg("solver_options"),
-          doc.SolverBase.Solve.doc)
+          py::arg("prog"), py::arg("initial_guess") = std::nullopt,
+          py::arg("solver_options") = std::nullopt, doc.SolverBase.Solve.doc)
       // TODO(m-chaturvedi) Add Pybind11 documentation.
       .def("solver_type",
           [](const SolverInterface& self) {

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -668,7 +668,7 @@ class TestMathematicalProgram(unittest.TestCase):
         result = mp.Solve(prog)
         infeasible = mp.GetInfeasibleConstraints(prog=prog, result=result,
                                                  tol=1e-4)
-        self.assertEquals(len(infeasible), 0)
+        self.assertEqual(len(infeasible), 0)
 
     def test_add_indeterminates_and_decision_variables(self):
         prog = mp.MathematicalProgram()
@@ -714,3 +714,6 @@ class TestSolverInterface(unittest.TestCase):
         self.assertTrue("Dummy solver cannot solve" in str(context.exception))
         self.assertIsInstance(result, mp.MathematicalProgramResult)
         self.assertTrue(solver.AreProgramAttributesSatisfied(prog))
+        with self.assertRaises(Exception) as context:
+            result2 = solver.Solve(prog)
+            self.assertIsInstance(result2, mp.MathematicalProgramResult)

--- a/solvers/solver_base.h
+++ b/solvers/solver_base.h
@@ -26,8 +26,8 @@ class SolverBase : public SolverInterface {
   /// return value instead of an output argument.
   MathematicalProgramResult Solve(
       const MathematicalProgram& prog,
-      const std::optional<Eigen::VectorXd>& initial_guess,
-      const std::optional<SolverOptions>& solver_options) const;
+      const std::optional<Eigen::VectorXd>& initial_guess = std::nullopt,
+      const std::optional<SolverOptions>& solver_options = std::nullopt) const;
 
   // Implement the SolverInterface methods.
   void Solve(const MathematicalProgram&, const std::optional<Eigen::VectorXd>&,

--- a/solvers/test/solver_base_test.cc
+++ b/solvers/test/solver_base_test.cc
@@ -129,6 +129,10 @@ GTEST_TEST(SolverBaseTest, SolveAndReturn) {
   const MathematicalProgramResult result = dut.Solve(prog, {}, {});
   EXPECT_EQ(result.get_solver_id(), StubSolverBase::id());
   EXPECT_TRUE(result.is_success());
+  // Confirm that default arguments work, too.
+  const MathematicalProgramResult result2 = dut.Solve(prog);
+  EXPECT_TRUE(result2.is_success());
+
   // We don't bother checking additional result details here, because we know
   // that the solve-and-return method is implemented as a thin shim atop the
   // solve-as-output-argument method.


### PR DESCRIPTION
Users shouldn't have to pass in {} and/or None everywhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12866)
<!-- Reviewable:end -->
