### PR TITLE
[parsing] Add unit test to cover Parser's automatic search for packages

### DIFF
--- a/multibody/parsing/package_map.cc
+++ b/multibody/parsing/package_map.cc
@@ -169,11 +169,12 @@ void PackageMap::PopulateUpstreamToDrake(const string& model_file) {
   }
   const string model_dir = filesystem::path(model_file).parent_path();
 
-  // Bail out if the model file is not part of Drake.
+  // Bail out if we can't determine the drake root.
   const std::optional<string> maybe_drake_path = MaybeGetDrakePath();
   if (!maybe_drake_path) {
     return;
   }
+  // Bail out if the model file is not part of Drake.
   const string& drake_path = *maybe_drake_path;
   auto iter = std::mismatch(drake_path.begin(), drake_path.end(),
                             model_dir.begin());


### PR DESCRIPTION
This relates to issue #12870. It illustrates what the issue documents and is using CI to test the effect of the two deleted lines more globally across the Drake ecosystem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12871)
<!-- Reviewable:end -->
