### PR TITLE
InverseKinematics allows ignoring joint limits in the constructor.

### DIFF
--- a/bindings/pydrake/multibody/inverse_kinematics_py.cc
+++ b/bindings/pydrake/multibody/inverse_kinematics_py.cc
@@ -37,18 +37,20 @@ PYBIND11_MODULE(inverse_kinematics, m) {
     using Class = InverseKinematics;
     constexpr auto& cls_doc = doc.InverseKinematics;
     py::class_<Class>(m, "InverseKinematics", cls_doc.doc)
-        .def(py::init<const MultibodyPlant<double>&>(), py::arg("plant"),
+        .def(py::init<const MultibodyPlant<double>&, bool>(), py::arg("plant"),
+            py::arg("with_joint_limits") = true,
             // Keep alive, reference: `self` keeps `plant` alive.
             py::keep_alive<1, 2>(),  // BR
-            cls_doc.ctor.doc_1args)
-        .def(py::init<const MultibodyPlant<double>&,
-                 systems::Context<double>*>(),
+            cls_doc.ctor.doc_2args)
+        .def(py::init<const MultibodyPlant<double>&, systems::Context<double>*,
+                 bool>(),
             py::arg("plant"), py::arg("plant_context"),
+            py::arg("with_joint_limits") = true,
             // Keep alive, reference: `self` keeps `plant` alive.
             py::keep_alive<1, 2>(),  // BR
             // Keep alive, reference: `self` keeps `plant_context` alive.
             py::keep_alive<1, 3>(),  // BR
-            cls_doc.ctor.doc_2args)
+            cls_doc.ctor.doc_3args)
         .def("AddPositionConstraint", &Class::AddPositionConstraint,
             py::arg("frameB"), py::arg("p_BQ"), py::arg("frameA"),
             py::arg("p_AQ_lower"), py::arg("p_AQ_upper"),

--- a/bindings/pydrake/multibody/test/inverse_kinematics_test.py
+++ b/bindings/pydrake/multibody/test/inverse_kinematics_test.py
@@ -45,6 +45,12 @@ class TestInverseKinematics(unittest.TestCase):
         self.prog = self.ik_two_bodies.get_mutable_prog()
         self.q = self.ik_two_bodies.q()
 
+        # Test constructor without joint limits
+        ik.InverseKinematics(plant=self.plant, with_joint_limits=False)
+        ik.InverseKinematics(
+            plant=self.plant, plant_context=plant_context,
+            with_joint_limits=False)
+
         def squaredNorm(x):
             return np.array([x[0] ** 2 + x[1] ** 2 + x[2] ** 2 + x[3] ** 2])
 

--- a/multibody/inverse_kinematics/inverse_kinematics.cc
+++ b/multibody/inverse_kinematics/inverse_kinematics.cc
@@ -11,28 +11,34 @@
 
 namespace drake {
 namespace multibody {
-InverseKinematics::InverseKinematics(const MultibodyPlant<double>& plant)
+InverseKinematics::InverseKinematics(const MultibodyPlant<double>& plant,
+                                     bool with_joint_limits)
     : prog_{new solvers::MathematicalProgram()},
       plant_(plant),
       owned_context_(plant_.CreateDefaultContext()),
       context_(owned_context_.get()),
       q_(prog_->NewContinuousVariables(plant_.num_positions(), "q")) {
-  prog_->AddBoundingBoxConstraint(plant.GetPositionLowerLimits(),
-                                  plant.GetPositionUpperLimits(), q_);
+  if (with_joint_limits) {
+    prog_->AddBoundingBoxConstraint(plant.GetPositionLowerLimits(),
+                                    plant.GetPositionUpperLimits(), q_);
+  }
   // TODO(hongkai.dai) Add other position constraints, such as unit length
   // quaternion constraint here.
 }
 
 InverseKinematics::InverseKinematics(const MultibodyPlant<double>& plant,
-                                     systems::Context<double>* plant_context)
+                                     systems::Context<double>* plant_context,
+                                     bool with_joint_limits)
     : prog_{new solvers::MathematicalProgram()},
       plant_(plant),
       owned_context_(nullptr),
       context_(plant_context),
       q_(prog_->NewContinuousVariables(plant.num_positions(), "q")) {
   DRAKE_DEMAND(plant_context);
-  prog_->AddBoundingBoxConstraint(plant.GetPositionLowerLimits(),
-                                  plant.GetPositionUpperLimits(), q_);
+  if (with_joint_limits) {
+    prog_->AddBoundingBoxConstraint(plant.GetPositionLowerLimits(),
+                                    plant.GetPositionUpperLimits(), q_);
+  }
   // TODO(hongkai.dai) Add other position constraints, such as unit length
   // quaternion constraint here.
 }

--- a/multibody/inverse_kinematics/inverse_kinematics.h
+++ b/multibody/inverse_kinematics/inverse_kinematics.h
@@ -29,7 +29,7 @@ class InverseKinematics {
    * solved.
    * @param with_joint_limits If set to true, then the constructor
    * imposes the joint limit (obtained from plant.GetPositionLowerLimits()
-   * and plant.GetPositionUpperLimits(). If set to true, then the constructor
+   * and plant.GetPositionUpperLimits(). If set to false, then the constructor
    * does not impose the joint limit constraints in the constructor.
    * @note The inverse kinematics problem constructed in this way doesn't permit
    * collision related constraint (such as calling
@@ -37,8 +37,8 @@ class InverseKinematics {
    * InverseKinematics(const MultibodyPlant<double>& plant,
    * systems::Context<double>* plant_context);
    */
-  InverseKinematics(const MultibodyPlant<double>& plant,
-                    bool with_joint_limits = true);
+  explicit InverseKinematics(const MultibodyPlant<double>& plant,
+                             bool with_joint_limits = true);
 
   /**
    * Constructs an inverse kinematics problem for a MultibodyPlant. If the user
@@ -66,12 +66,12 @@ class InverseKinematics {
    * This context will be modified during calling ik.prog.Solve(...). When
    * Solve() returns `result`, context will store the optimized posture, namely
    * plant.GetPositions(*context) will be the same as in
-   * result.GetResult(ik.q()). The user could then use this context to perform
+   * result.GetSolution(ik.q()). The user could then use this context to perform
    * kinematic computation (like computing the position of the end-effector
    * etc.).
    * @param with_joint_limits If set to true, then the constructor
    * imposes the joint limit (obtained from plant.GetPositionLowerLimits()
-   * and plant.GetPositionUpperLimits(). If set to true, then the constructor
+   * and plant.GetPositionUpperLimits(). If set to false, then the constructor
    * does not impose the joint limit constraints in the constructor.  */
   InverseKinematics(const MultibodyPlant<double>& plant,
                     systems::Context<double>* plant_context,

--- a/multibody/inverse_kinematics/inverse_kinematics.h
+++ b/multibody/inverse_kinematics/inverse_kinematics.h
@@ -27,13 +27,18 @@ class InverseKinematics {
    * This constructor will create and own a context for @param plant.
    * @param plant The robot on which the inverse kinematics problem will be
    * solved.
+   * @param with_joint_limits If set to true, then the constructor
+   * imposes the joint limit (obtained from plant.GetPositionLowerLimits()
+   * and plant.GetPositionUpperLimits(). If set to true, then the constructor
+   * does not impose the joint limit constraints in the constructor.
    * @note The inverse kinematics problem constructed in this way doesn't permit
    * collision related constraint (such as calling
    * AddMinimumDistanceConstraint). To enable collision related constraint, call
    * InverseKinematics(const MultibodyPlant<double>& plant,
    * systems::Context<double>* plant_context);
    */
-  explicit InverseKinematics(const MultibodyPlant<double>& plant);
+  InverseKinematics(const MultibodyPlant<double>& plant,
+                    bool with_joint_limits = true);
 
   /**
    * Constructs an inverse kinematics problem for a MultibodyPlant. If the user
@@ -58,9 +63,19 @@ class InverseKinematics {
    * // 5. Get the context for the plant.
    * auto plant_context = &(diagram->GetMutableSubsystemContext(items.plant,
    * diagram_context.get()));
-   */
+   * This context will be modified during calling ik.prog.Solve(...). When
+   * Solve() returns `result`, context will store the optimized posture, namely
+   * plant.GetPositions(*context) will be the same as in
+   * result.GetResult(ik.q()). The user could then use this context to perform
+   * kinematic computation (like computing the position of the end-effector
+   * etc.).
+   * @param with_joint_limits If set to true, then the constructor
+   * imposes the joint limit (obtained from plant.GetPositionLowerLimits()
+   * and plant.GetPositionUpperLimits(). If set to true, then the constructor
+   * does not impose the joint limit constraints in the constructor.  */
   InverseKinematics(const MultibodyPlant<double>& plant,
-                    systems::Context<double>* plant_context);
+                    systems::Context<double>* plant_context,
+                    bool with_joint_limits = true);
 
   /** Adds the kinematic constraint that a point Q, fixed in frame B, should lie
    * within a bounding box expressed in another frame A as p_AQ_lower <= p_AQ <=


### PR DESCRIPTION
As mentioned in https://github.com/RobotLocomotion/drake/issues/12849

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12872)
<!-- Reviewable:end -->
