### PR TITLE
test_utilities: Promote deprecations to errors in pydrake unit tests

### DIFF
--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from pydrake.autodiffutils import AutoDiffXd
 from pydrake.common import RandomGenerator
+from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 from pydrake.examples.pendulum import PendulumPlant
 from pydrake.examples.rimless_wheel import RimlessWheel
 from pydrake.symbolic import Expression
@@ -418,7 +419,7 @@ class TestGeneral(unittest.TestCase):
         diagram.get_input_port(2).FixValue(context, input2)
 
         # Test __str__ methods.
-        self.assertRegexpMatches(str(context), "integrator")
+        self.assertRegex(str(context), "integrator")
         self.assertEqual(str(input2), "[0.003, 0.004, 0.005]")
 
         # Initialize integrator states.
@@ -506,19 +507,22 @@ class TestGeneral(unittest.TestCase):
             system=system, max_step_size=0.01)
         test_integrator = RungeKutta3Integrator(system=system)
 
-        # Test simulator's reset_integrator,
-        # and also the full constructors for
+        # Test simulator's reset_integrator, and also the full constructors for
         # all integrator types.
-        simulator.reset_integrator(
-            RungeKutta2Integrator(
-                system=system,
-                max_step_size=0.01,
-                context=simulator.get_mutable_context()))
+        rk2 = RungeKutta2Integrator(
+            system=system,
+            max_step_size=0.01,
+            context=simulator.get_mutable_context())
+        with catch_drake_warnings(expected_count=1):
+            # TODO(12873) We need an API for this that isn't deprecated.
+            simulator.reset_integrator(rk2)
 
-        simulator.reset_integrator(
-            RungeKutta3Integrator(
-                system=system,
-                context=simulator.get_mutable_context()))
+        rk3 = RungeKutta3Integrator(
+            system=system,
+            context=simulator.get_mutable_context())
+        with catch_drake_warnings(expected_count=1):
+            # TODO(12873) We need an API for this that isn't deprecated.
+            simulator.reset_integrator(rk3)
 
     def test_abstract_output_port_eval(self):
         model_value = AbstractValue.Make("Hello World")

--- a/common/test_utilities/drake_py_unittest_main.py
+++ b/common/test_utilities/drake_py_unittest_main.py
@@ -116,7 +116,12 @@ if __name__ == '__main__':
             print("\n`unittest` specific arguments")
 
         # Delegate the rest to unittest.
-        unittest.main(module=test_name, argv=unittest_argv)
+        #
+        # Use `warnings=False` to tell unittest to keep its hands off of our
+        # warnings settings, exploting a loophole where it checks "if warnings
+        # is None" to check if the user passed a kwarg, but "if warning" to
+        # actually apply the user's kwarg.
+        unittest.main(module=test_name, argv=unittest_argv, warnings=False)
 
     if not args.nostdout_to_stderr:
         sys.stdout.flush()


### PR DESCRIPTION
This used to be the case for python2, but was lost in the transition to python3 due to changes to `unittest.main` semantics.

The python3 `unittest.main` added the following new semantics:
```python
        if warnings is None and not sys.warnoptions:
            # even if DeprecationWarnings are ignored by default
            # print them anyway unless other warnings settings are
            # specified by the warnings arg or the -W python flag
            self.warnings = 'default'
```

Because we apply our warning filters prior to calling `unittest.main()`, the unittest filter for any and all `Warning` instances trumps our more custom filters.

Towards #12873.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12874)
<!-- Reviewable:end -->
