### PR TITLE
Adds utility to "balance" two quadratic forms

### DIFF
--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -18,6 +18,7 @@
 #include "drake/math/continuous_lyapunov_equation.h"
 #include "drake/math/discrete_algebraic_riccati_equation.h"
 #include "drake/math/discrete_lyapunov_equation.h"
+#include "drake/math/matrix_util.h"
 #include "drake/math/orthonormal_basis.h"
 #include "drake/math/quadratic_form.h"
 #include "drake/math/rigid_transform.h"
@@ -314,6 +315,26 @@ void DoScalarIndependentDefinitions(py::module m) {
       .def("MeshValuesFrom", &BarycentricMesh<T>::MeshValuesFrom,
           doc.BarycentricMesh.MeshValuesFrom.doc);
 
+  // Matrix Util.
+  m  // BR
+      .def("IsSymmetric",
+          [](const Eigen::Ref<const MatrixX<T>>& matrix) {
+            return IsSymmetric(matrix);
+          },
+          py::arg("matrix"), doc.IsSymmetric.doc_1args)
+      .def("IsSymmetric",
+          [](const Eigen::Ref<const MatrixX<T>>& matrix, const T& precision) {
+            return IsSymmetric(matrix, precision);
+          },
+          py::arg("matrix"), py::arg("precision"), doc.IsSymmetric.doc_2args)
+      .def("IsPositiveDefinite",
+          [](const Eigen::Ref<const Eigen::MatrixXd>& matrix,
+              double tolerance) {
+            return IsPositiveDefinite(matrix, tolerance);
+          },
+          py::arg("matrix"), py::arg("tolerance") = 0.0,
+          doc.IsPositiveDefinite.doc);
+
   // Quadratic Form.
   m  // BR
       .def("DecomposePSDmatrixIntoXtransposeTimesX",
@@ -321,7 +342,9 @@ void DoScalarIndependentDefinitions(py::module m) {
           py::arg("zero_tol"), doc.DecomposePSDmatrixIntoXtransposeTimesX.doc)
       .def("DecomposePositiveQuadraticForm", &DecomposePositiveQuadraticForm,
           py::arg("Q"), py::arg("b"), py::arg("c"), py::arg("tol") = 0,
-          doc.DecomposePositiveQuadraticForm.doc);
+          doc.DecomposePositiveQuadraticForm.doc)
+      .def("BalanceQuadraticForms", &BalanceQuadraticForms, py::arg("S"),
+          py::arg("P"), doc.BalanceQuadraticForms.doc);
 
   // Riccati and Lyapunov Equations.
   m  // BR

--- a/bindings/pydrake/test/math_test.py
+++ b/bindings/pydrake/test/math_test.py
@@ -318,6 +318,16 @@ class TestMath(unittest.TestCase):
         self.assertAlmostEqual(np.linalg.det(R), 1.0)
         self.assertTrue(np.allclose(R.dot(R.T), np.eye(3)))
 
+    def test_matrix_util(self):
+        A = np.array([[1, 2], [3, 4]])
+
+        self.assertFalse(mut.IsSymmetric(matrix=A))
+        self.assertFalse(mut.IsSymmetric(matrix=A, precision=0))
+        self.assertTrue(mut.IsSymmetric(np.eye(3), 0.))
+
+        self.assertFalse(mut.IsPositiveDefinite(matrix=A, tolerance=0))
+        self.assertTrue(mut.IsPositiveDefinite(A.dot(A.T)))
+
     def test_quadratic_form(self):
         Q = np.diag([1., 2., 3.])
         X = mut.DecomposePSDmatrixIntoXtransposeTimesX(Q, 1e-8)
@@ -328,6 +338,8 @@ class TestMath(unittest.TestCase):
         self.assertEqual(np.size(R, 0), 4)
         self.assertEqual(np.size(R, 1), 3)
         self.assertEqual(len(d), 4)
+        T = mut.BalanceQuadraticForms(S=np.eye(3), P=np.eye(3))
+        np.testing.assert_array_almost_equal(T, np.eye(3))
 
     def test_riccati_lyapunov(self):
         A = 0.1*np.eye(2)

--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -234,6 +234,7 @@ drake_cc_library(
     srcs = ["quadratic_form.cc"],
     hdrs = ["quadratic_form.h"],
     deps = [
+        ":matrix_util",
         "//common:essential",
         "@eigen",
     ],

--- a/math/matrix_util.h
+++ b/math/matrix_util.h
@@ -121,17 +121,17 @@ ToSymmetricMatrixFromLowerTriangularColumns(
 }
 
 /// Checks if a matrix is symmetric and has all eigenvalues greater than @p
-/// threshold.  threshold must be >= 0 -- where 0 implies positive
+/// tolerance.  tolerance must be >= 0 -- where 0 implies positive
 /// semi-definite (but is of course subject to all of the pitfalls of floating
 /// point).
 ///
 /// To consider the numerical robustness of the eigenvalue estimation, we
 /// specifically check that
-/// min_eigenvalue >= threshold * max(1, max_abs_eigenvalue).
+/// min_eigenvalue >= tolerance * max(1, max_abs_eigenvalue).
 template <typename Derived>
 bool IsPositiveDefinite(const Eigen::MatrixBase<Derived>& matrix,
-                        const double threshold) {
-  DRAKE_DEMAND(threshold >= 0);
+                        double tolerance = 0.0) {
+  DRAKE_DEMAND(tolerance >= 0);
   if (!IsSymmetric(matrix)) return false;
 
   // Note: Eigen's documentation clearly warns against using the faster LDLT
@@ -140,12 +140,12 @@ bool IsPositiveDefinite(const Eigen::MatrixBase<Derived>& matrix,
       matrix);
   DRAKE_THROW_UNLESS(eigensolver.info() == Eigen::Success);
   // According to the Lapack manual, the absolute accuracy of eigenvalues is
-  // eps*max(|eigenvalues|), so I will write my thresholds relative to that.
+  // eps*max(|eigenvalues|), so I will write my tolerances relative to that.
   // Anderson et al., Lapack User's Guide, 3rd ed. section 4.7, 1999.
   const double max_abs_eigenvalue =
       eigensolver.eigenvalues().cwiseAbs().maxCoeff();
   return eigensolver.eigenvalues().minCoeff() >=
-         threshold * std::max(1., max_abs_eigenvalue);
+         tolerance * std::max(1., max_abs_eigenvalue);
 }
 
 }  // namespace math

--- a/math/quadratic_form.cc
+++ b/math/quadratic_form.cc
@@ -1,5 +1,7 @@
 #include "drake/math/quadratic_form.h"
 
+#include <algorithm>
+
 #include <Eigen/Cholesky>
 #include <Eigen/Eigenvalues>
 
@@ -68,16 +70,20 @@ std::pair<Eigen::MatrixXd, Eigen::MatrixXd> DecomposePositiveQuadraticForm(
 Eigen::MatrixXd BalanceQuadraticForms(
     const Eigen::Ref<const Eigen::MatrixXd>& S,
     const Eigen::Ref<const Eigen::MatrixXd>& P) {
-  DRAKE_THROW_UNLESS(IsPositiveDefinite(S, 1e-8));
-  DRAKE_THROW_UNLESS(IsPositiveDefinite(P, 1e-8));
-  DRAKE_THROW_UNLESS(S.rows() == P.rows());
-
+  const double tolerance = 1e-8;
   const int n = S.rows();
+  DRAKE_THROW_UNLESS(P.rows() == n);
+  DRAKE_THROW_UNLESS(IsPositiveDefinite(S, tolerance));
+  DRAKE_THROW_UNLESS(IsSymmetric(P, tolerance));
+
   const Eigen::MatrixXd R =
       S.llt().matrixL().solve(Eigen::MatrixXd::Identity(n, n));
 
   const Eigen::JacobiSVD<Eigen::MatrixXd> svd(R * P * R.transpose(),
                                               Eigen::ComputeThinU);
+  // Check that P was full rank (hence RPR' full-rank).
+  DRAKE_THROW_UNLESS(svd.singularValues()(svd.singularValues().size()-1) >=
+                         tolerance*std::max(1., svd.singularValues()(0)));
 
   const Eigen::VectorXd sigmaRootN4 =
       svd.singularValues().array().pow(-0.25).matrix();

--- a/math/quadratic_form.h
+++ b/math/quadratic_form.h
@@ -63,5 +63,38 @@ std::pair<Eigen::MatrixXd, Eigen::MatrixXd>
 DecomposePositiveQuadraticForm(const Eigen::Ref<const Eigen::MatrixXd>& Q,
                                const Eigen::Ref<const Eigen::VectorXd>& b,
                                double c, double tol = 0);
+
+/** Given two positive quadratic forms, x'Sx > 0 and x'Px > 0, Finds a change
+ * of variables x = Ty, which tries to improve the conditioning of the
+ * problem by "balancing" S and P (as inspired by "balanced truncation" in
+ * model-order reduction [1]).
+ *
+ * Adapting from [1], we observe that there is a family coordinate systems
+ * that can simultaneously diagonalize T'ST and T'PT.  We call the result
+ * S-normal if T'ST = I and T'PT = D⁻², call it P-normal if T'ST = D² and
+ * T'PT = I, and call it "balanced" if T'ST = D and T'PT = D⁻¹.
+ *
+ * To understand it, consider first the scalar case: we have two quadratic
+ * functions, sx² and px², with s>0, p>0.  We'd like to choose x=Ty so that
+ * sT²y² and pT²y² are "balanced" (we'd like them both to be close to y²).
+ * We'll choose T=p^{-1/4}s^{-1/4}, which gives sx² = sqrt(s/p)y², and
+ * px² = sqrt(p/s)y².  If s=p, then we have perfect balance!
+ *
+ * In the vector case, we have x'Sx > 0 and x'Px > 0, and we find x=Ty such
+ * that T'ST = D and T'PT = D⁻¹, where D is diagonal.  The recipe is:
+ * - Factorize S = LL', and choose R=L⁻¹.
+ * - Take svd(RPR') = UΣV', and note that U=V for positive definite matrices,
+ * - Choose T = R'U Σ^{-1/4}, where the matrix exponent can be taken
+ *   elementwise because Σ is diagonal.
+ * This gives T'ST = Σ^{-1/2} (by using U'U=I), and T'PT = Σ^{1/2}.
+ *
+ * [1] B. Moore, “Principal component analysis in linear systems:
+ * Controllability, observability, and model reduction,” IEEE Trans. Automat.
+ * Contr., vol. 26, no. 1, pp. 17–32, Feb. 1981.
+ */
+Eigen::MatrixXd BalanceQuadraticForms(
+    const Eigen::Ref<const Eigen::MatrixXd>& S,
+    const Eigen::Ref<const Eigen::MatrixXd>& P);
+
 }  // namespace math
 }  // namespace drake

--- a/math/quadratic_form.h
+++ b/math/quadratic_form.h
@@ -64,29 +64,38 @@ DecomposePositiveQuadraticForm(const Eigen::Ref<const Eigen::MatrixXd>& Q,
                                const Eigen::Ref<const Eigen::VectorXd>& b,
                                double c, double tol = 0);
 
-/** Given two positive quadratic forms, x'Sx > 0 and x'Px > 0, Finds a change
- * of variables x = Ty, which tries to improve the conditioning of the
- * problem by "balancing" S and P (as inspired by "balanced truncation" in
- * model-order reduction [1]).
+/** Given two quadratic forms, x'Sx > 0 and x'Px, (with P symmetric and full
+ * rank), finds a change of variables x = Ty, which simultaneously
+ * diagonalizes both forms (as inspired by "balanced truncation" in
+ * model-order reduction [1]).  In this note, we use abs(M) to indicate the
+ * elementwise absolute value.
  *
- * Adapting from [1], we observe that there is a family coordinate systems
- * that can simultaneously diagonalize T'ST and T'PT.  We call the result
- * S-normal if T'ST = I and T'PT = D⁻², call it P-normal if T'ST = D² and
- * T'PT = I, and call it "balanced" if T'ST = D and T'PT = D⁻¹.
+ * Adapting from [1], we observe that there is a family of coordinate systems
+ * that can simultaneously diagonalize T'ST and T'PT.  Using D to denote a
+ * diagonal matrix, we call the result S-normal if T'ST = I and
+ * abs(T'PT) = D⁻², call it P-normal if T'ST = D² and abs(T'PT) = I, and
+ * call it "balanced" if T'ST = D and abs(T'PT) = D⁻¹. Note that if P > 0,
+ * then T'PT = D⁻¹.
  *
- * To understand it, consider first the scalar case: we have two quadratic
- * functions, sx² and px², with s>0, p>0.  We'd like to choose x=Ty so that
- * sT²y² and pT²y² are "balanced" (we'd like them both to be close to y²).
- * We'll choose T=p^{-1/4}s^{-1/4}, which gives sx² = sqrt(s/p)y², and
- * px² = sqrt(p/s)y².  If s=p, then we have perfect balance!
+ * Note that the numerical "balancing" cannot fundamentally change the scaling
+ * of the problem.  To understand it, consider first the scalar case: we
+ * have two quadratic functions, sx² and px², with s>0, p>0.  We'd like to
+ * choose x=Ty so that sT²y² and pT²y² are "balanced" (we'd like them both
+ * to be close to y²).  We'll choose T=p^{-1/4}s^{-1/4}, which gives
+ * sx² = sqrt(s/p)y², and px² = sqrt(p/s)y².  For instance if s=10, p=1e7, then
+ * t=0.01, and st^2 = 1e-3, pt^2 = 1e3.  The primary merit of this method is
+ * the diagonalization, which happens in the vector case.
  *
- * In the vector case, we have x'Sx > 0 and x'Px > 0, and we find x=Ty such
- * that T'ST = D and T'PT = D⁻¹, where D is diagonal.  The recipe is:
+ * In the vector case, we find x=Ty such that T'ST = D and abs(T'PT) = D⁻¹,
+ * where D is diagonal.  The recipe is:
  * - Factorize S = LL', and choose R=L⁻¹.
- * - Take svd(RPR') = UΣV', and note that U=V for positive definite matrices,
+ * - Take svd(RPR') = UΣV', and note that U=V for positive definite
+ *     matrices, and V is U up to a sign flip of the singular vectors for all
+ *     symmetric matrices.
  * - Choose T = R'U Σ^{-1/4}, where the matrix exponent can be taken
  *   elementwise because Σ is diagonal.
- * This gives T'ST = Σ^{-1/2} (by using U'U=I), and T'PT = Σ^{1/2}.
+ * This gives T'ST = Σ^{-1/2} (by using U'U=I), and abs(T'PT) = Σ^{1/2}.  If
+ * P > 0, then T'PT = Σ^{1/2}.
  *
  * [1] B. Moore, “Principal component analysis in linear systems:
  * Controllability, observability, and model reduction,” IEEE Trans. Automat.

--- a/math/test/quadratic_form_test.cc
+++ b/math/test/quadratic_form_test.cc
@@ -210,6 +210,36 @@ GTEST_TEST(TestDecomposePositiveQuadraticForm, Test6) {
   EXPECT_THROW(DecomposePositiveQuadraticForm(Q, b, c, -1E-15),
                std::runtime_error);
 }
+
+GTEST_TEST(MatrixUtilTest, BalanceQuadraticFormsTest) {
+  Eigen::Matrix3d A, B;
+  // clang-format off
+  A << 1, 2, 4,
+      2, 3, 5,
+      4, 5, 6;
+  B << 7,  8,  9,
+      8, 10, 11,
+      9, 11, 12;
+  // clang-format on
+
+  const Eigen::Matrix3d S = A * A.transpose();
+  const Eigen::Matrix3d P = B * B.transpose();
+  const Eigen::MatrixXd T = BalanceQuadraticForms(S, P);
+
+  const Eigen::MatrixXd D = T.transpose() * S * T;
+  const Eigen::MatrixXd Dinv = T.transpose() * P * T;
+
+  // Check that D and Dinv are diagonal.
+  EXPECT_TRUE(CompareMatrices(D, Eigen::MatrixXd(D.diagonal().asDiagonal()),
+                              1e-11));
+  EXPECT_TRUE(
+      CompareMatrices(Dinv, Eigen::MatrixXd(Dinv.diagonal().asDiagonal()),
+                      1e-11));
+
+  // Check that Dinv is, in fact, the inverse of D.
+  EXPECT_TRUE(CompareMatrices(D.inverse(), Dinv, 1e-11));
+}
+
 }  // namespace
 }  // namespace math
 }  // namespace drake

--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -502,6 +502,7 @@ drake_cc_googletest(
     name = "region_of_attraction_test",
     deps = [
         ":region_of_attraction",
+        "//solvers:mosek_solver",
         "//systems/primitives:symbolic_vector_system",
     ],
 )

--- a/systems/analysis/region_of_attraction.cc
+++ b/systems/analysis/region_of_attraction.cc
@@ -3,7 +3,7 @@
 #include <algorithm>
 
 #include "drake/math/continuous_lyapunov_equation.h"
-#include "drake/math/matrix_util.h"
+#include "drake/math/quadratic_form.h"
 #include "drake/solvers/mathematical_program.h"
 #include "drake/solvers/solve.h"
 
@@ -31,12 +31,53 @@ namespace {
 // If we cannot confirm negative definiteness, then we must ask instead for
 // Vdot >=0 => V >= rho (or x=0).
 Expression FixedLyapunovConvex(const solvers::VectorXIndeterminate& x,
-                               const Polynomial& V, const Polynomial& Vdot) {
+                               const Expression& V, const Expression& Vdot) {
+  // Check if the Hessian of Vdot is negative definite.
+  Environment env;
+  for (int i = 0; i < x.size(); i++) {
+    env.insert(x(i), 0.0);
+  }
+  const Eigen::MatrixXd S =
+      symbolic::Evaluate(symbolic::Jacobian(V.Jacobian(x), x), env);
+  const Eigen::MatrixXd P =
+      symbolic::Evaluate(symbolic::Jacobian(Vdot.Jacobian(x), x), env);
+  // Eigen's recommended way of getting the Eigenvalues.
+  Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> eigensolver(P);
+  DRAKE_THROW_UNLESS(eigensolver.info() == Eigen::Success);
+
+  // A positive max eigenvalue indicates the system is locally unstable.
+  const double max_eigenvalue = eigensolver.eigenvalues().maxCoeff();
+  // According to the Lapack manual, the absolute accuracy of eigenvalues is
+  // eps*max(|eigenvalues|), so I will write my thresholds relative to that.
+  // Anderson et al., Lapack User's Guide, 3rd ed. section 4.7, 1999.
+  const double max_abs_eigenvalue =
+      eigensolver.eigenvalues().cwiseAbs().maxCoeff();
+  DRAKE_THROW_UNLESS(max_eigenvalue <= 1e-8 * std::max(1., max_abs_eigenvalue));
+
+  bool Vdot_is_locally_negative_definite =
+      (max_eigenvalue <= -1e-8 * std::max(1., max_abs_eigenvalue));
+
+  Polynomial V_balanced, Vdot_balanced;
+  if (Vdot_is_locally_negative_definite) {
+    // Then "balance" V and Vdot.
+    const Eigen::MatrixXd T = math::BalanceQuadraticForms(S, -P);
+    const VectorX<Expression> Tx = T*x;
+    Substitution subs;
+    for (int i=0; i<static_cast<int>(x.size()); i++) {
+      subs.emplace(x(i), Tx(i));
+    }
+    V_balanced = Polynomial(V.Substitute(subs));
+    Vdot_balanced = Polynomial(Vdot.Substitute(subs));
+  } else {
+    V_balanced = Polynomial(V);
+    Vdot_balanced = Polynomial(Vdot);
+  }
+
   MathematicalProgram prog;
   prog.AddIndeterminates(x);
 
-  const int V_degree = V.TotalDegree();
-  const int Vdot_degree = Vdot.TotalDegree();
+  const int V_degree = V_balanced.TotalDegree();
+  const int Vdot_degree = Vdot_balanced.TotalDegree();
 
   // TODO(russt): Add this as an argument once I have an example that needs it.
   // This is a reasonable guess.
@@ -49,32 +90,14 @@ Expression FixedLyapunovConvex(const solvers::VectorXIndeterminate& x,
   const int d = std::floor((lambda_degree + Vdot_degree - V_degree) / 2);
   // TODO(russt): Remove ToExpression below pending resolution of #12833.
   prog.AddSosConstraint(
-      ((V - rho) * Polynomial(pow((x.transpose() * x)[0], d)) - lambda * Vdot)
+      ((V_balanced - rho) * Polynomial(pow((x.transpose() * x)[0], d)) -
+       lambda * Vdot_balanced)
           .ToExpression());
 
-  // Check if the Hessian of Vdot is negative definite.
-  Environment env;
-  for (int i = 0; i < x.size(); i++) {
-    env.insert(x(i), 0.0);
-  }
-  const Eigen::MatrixXd H = symbolic::Evaluate(
-      symbolic::Jacobian(Vdot.Jacobian(x), x), env);
-  // Eigen's recommended way of getting the Eigenvalues.
-  Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> eigensolver(H);
-  DRAKE_THROW_UNLESS(eigensolver.info() == Eigen::Success);
-
-  // A positive max eigenvalue indicates the system is locally unstable.
-  const double max_eigenvalue = eigensolver.eigenvalues().maxCoeff();
-  // According to the Lapack manual, the absolute accuracy of eigenvalues is
-  // eps*max(|eigenvalues|), so I will write my thresholds relative to that.
-  // Anderson et al., Lapack User's Guide, 3rd ed. section 4.7, 1999.
-  const double max_abs_eigenvalue =
-      eigensolver.eigenvalues().cwiseAbs().maxCoeff();
-  DRAKE_THROW_UNLESS(max_eigenvalue <= 1e-8 * std::max(1., max_abs_eigenvalue));
-  // If the max eigenvalue is zero, then the linearization does not inform us
-  // on the local stability.  Add lambda is SOS to force prog to confirm
-  // this local stability.
-  if (max_eigenvalue >= -1e-8 * std::max(1., max_abs_eigenvalue)) {
+  // If Vdot is indefinite, then the linearization does not inform us about the
+  // local stability.  Add lambda is SOS to force prog to confirm this local
+  // stability.
+  if (!Vdot_is_locally_negative_definite) {
     prog.AddSosConstraint(lambda);
   }
 
@@ -84,7 +107,7 @@ Expression FixedLyapunovConvex(const solvers::VectorXIndeterminate& x,
   DRAKE_THROW_UNLESS(result.is_success());
 
   DRAKE_THROW_UNLESS(result.GetSolution(rho) > 0.0);
-  return V.ToExpression() / result.GetSolution(rho);
+  return V / result.GetSolution(rho);
 }
 
 }  // namespace
@@ -167,12 +190,7 @@ Expression RegionOfAttraction(const System<double>& system,
 
   const Expression Vdot = V.Jacobian(x_bar).dot(f);
 
-  // TODO(russt): implement numerical "balancing" from matlab version.
-  // https://github.com/RobotLocomotion/drake/blob
-  //        /last_sha_with_original_matlab/drake/matlab/systems
-  //        /%40PolynomialSystem/regionOfAttraction.m
-
-  V = FixedLyapunovConvex(x_bar, Polynomial(V), Polynomial(Vdot));
+  V = FixedLyapunovConvex(x_bar, V, Vdot);
 
   // Put V back into global coordinates.
   Substitution subs;

--- a/systems/analysis/test/region_of_attraction_test.cc
+++ b/systems/analysis/test/region_of_attraction_test.cc
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/solvers/mosek_solver.h"
 #include "drake/systems/primitives/symbolic_vector_system.h"
 
 namespace drake {
@@ -82,6 +83,15 @@ GTEST_TEST(RegionOfAttractionTest, ParriloExample) {
   const Polynomial V_expected{(x * x + y * y) / gamma};
 
   EXPECT_TRUE(Polynomial(V).CoefficientsAlmostEqual(V_expected, 1e-6));
+
+  // Run it again with the lyapunov candidate scaled by a large number to
+  // test the "BalanceQuadraticForms" call (this failed on Mosek without
+  // balancing).
+  if (solvers::MosekSolver::is_available()) {
+    options.lyapunov_candidate = 1e8 * options.lyapunov_candidate;
+    const Expression scaled_V = RegionOfAttraction(*system, *context, options);
+    EXPECT_TRUE(Polynomial(scaled_V).CoefficientsAlmostEqual(V_expected, 1e-6));
+  }
 }
 
 // The cubic polynomial again, but this time with V=x^4.  Tests the case

--- a/systems/analysis/test/region_of_attraction_test.cc
+++ b/systems/analysis/test/region_of_attraction_test.cc
@@ -85,10 +85,10 @@ GTEST_TEST(RegionOfAttractionTest, ParriloExample) {
   EXPECT_TRUE(Polynomial(V).CoefficientsAlmostEqual(V_expected, 1e-6));
 
   // Run it again with the lyapunov candidate scaled by a large number to
-  // test the "BalanceQuadraticForms" call (this failed on Mosek without
-  // balancing).
+  // test the "BalanceQuadraticForms" call (this scaling is the smallest
+  // multiple of 10 that caused Mosek to fail without balancing).
   if (solvers::MosekSolver::is_available()) {
-    options.lyapunov_candidate = 1e8 * options.lyapunov_candidate;
+    options.lyapunov_candidate *= 1e8;
     const Expression scaled_V = RegionOfAttraction(*system, *context, options);
     EXPECT_TRUE(Polynomial(scaled_V).CoefficientsAlmostEqual(V_expected, 1e-6));
   }


### PR DESCRIPTION
and uses it in RegionOfAttraction.
Rederived (much more carefully/thoroughly) from
https://github.com/RobotLocomotion/drake/blob/last_sha_with_original_matlab/drake/matlab/util/balanceQuadForm.m
with more documentation and testing.

adds python bindings for this and the main matrix_util methods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12875)
<!-- Reviewable:end -->
