### PR TITLE
Use IntegratorBase in DirectTranscription

### DIFF
--- a/systems/trajectory_optimization/BUILD.bazel
+++ b/systems/trajectory_optimization/BUILD.bazel
@@ -75,6 +75,8 @@ drake_cc_library(
         "//common/trajectories:piecewise_polynomial",
         "//math:autodiff",
         "//math:gradient",
+        "//systems/analysis:explicit_euler_integrator",
+        "//systems/analysis:integrator_base",
         "//systems/framework",
         "//systems/primitives:linear_system",
     ],

--- a/systems/trajectory_optimization/direct_transcription.h
+++ b/systems/trajectory_optimization/direct_transcription.h
@@ -5,6 +5,7 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/trajectories/piecewise_polynomial.h"
+#include "drake/systems/analysis/integrator_base.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/system.h"
 #include "drake/systems/primitives/linear_system.h"
@@ -171,9 +172,10 @@ class DirectTranscription : public MultipleShooting {
 
   // AutoDiff versions of the System components (for the constraints).
   // These values are allocated iff the dynamic constraints are allocated
-  // as DiscreteTimeSystemConstraints, otherwise they are nullptr.
+  // as DirectTranscriptionConstraint, otherwise they are nullptr.
   std::unique_ptr<const System<AutoDiffXd>> system_;
   std::unique_ptr<Context<AutoDiffXd>> context_;
+  std::unique_ptr<IntegratorBase<AutoDiffXd>> integrator_;
   const InputPort<AutoDiffXd>* input_port_{nullptr};
   FixedInputPortValue* input_port_value_{nullptr};  // Owned by the context.
 

--- a/systems/trajectory_optimization/test/direct_transcription_test.cc
+++ b/systems/trajectory_optimization/test/direct_transcription_test.cc
@@ -312,7 +312,7 @@ GTEST_TEST(DirectTranscriptionTest, DiscreteTimeSystemTest) {
   BasicVector<double> final_state(Eigen::VectorXd::Zero(2));
 
   DRAKE_DEMAND(initial_state.size() == 2);
-  DRAKE_DEMAND(final_state.size() ==2);
+  DRAKE_DEMAND(final_state.size() == 2);
 
   // Set the initial and final state constraints.
   const int kTheta_index = 0, kThetadot_index = 1;


### PR DESCRIPTION
First step towards generalizing DirectTranscription to use a user-specified integrator.  This one just replaces the hard-coded Euler integrator with the IntegratorBase version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12889)
<!-- Reviewable:end -->
