### PR TITLE
framework: Update internal for ValidateContext rename

### DIFF
--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -525,7 +525,7 @@ class GeometryState {
   // (either in the initialization list or in the body). Failure to do so will
   // lead to errors in the converted GeometryState instance.
   template <typename U>
-  GeometryState(const GeometryState<U>& source)
+  explicit GeometryState(const GeometryState<U>& source)
       : self_source_(source.self_source_),
         source_frame_id_map_(source.source_frame_id_map_),
         source_root_frame_map_(source.source_root_frame_map_),

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -554,7 +554,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   /// Scalar-converting copy constructor.  See @ref system_scalar_conversion.
   template <typename U>
-  MultibodyPlant(const MultibodyPlant<U>& other)
+  explicit MultibodyPlant(const MultibodyPlant<U>& other)
       : internal::MultibodyTreeSystem<T>(
             systems::SystemTypeTag<MultibodyPlant>{},
             other.internal_tree().template CloneToScalar<T>(),

--- a/multibody/plant/test/kuka_iiwa_model_tests.h
+++ b/multibody/plant/test/kuka_iiwa_model_tests.h
@@ -59,7 +59,7 @@ class KukaIiwaModelTests : public ::testing::Test {
     plant_->get_actuation_input_port().FixValue(context_.get(), tau);
 
     // Scalar-convert the model and create a default context for it.
-    plant_autodiff_ = std::make_unique<MultibodyPlant<AutoDiffXd>>(*plant_);
+    plant_autodiff_ = systems::System<double>::ToAutoDiffXd(*plant_);
     context_autodiff_ = plant_autodiff_->CreateDefaultContext();
   }
 

--- a/multibody/plant/test/multibody_plant_jacobians_test.cc
+++ b/multibody/plant/test/multibody_plant_jacobians_test.cc
@@ -115,8 +115,8 @@ TEST_F(KukaIiwaModelTests, CalcJacobianTranslationalVelocityNonUnitQuaternion) {
   const VectorX<double> q_double = plant_->GetPositions(*context_);
   MatrixX<double> p_WoEi_W_deriv_wrt_q(3 * kNumPoints, num_positions);
   CalcJacobianViaPartialDerivativesOfPositionWithRespectToQ(
-      *plant_, context_autodiff_.get(), q_double, frame_E_autodiff, p_EoEi_E,
-      &p_WoEi_W_deriv_wrt_q);
+      *plant_autodiff_, context_autodiff_.get(), q_double, frame_E_autodiff,
+      p_EoEi_E, &p_WoEi_W_deriv_wrt_q);
 
   // Verify the Jacobian Jq_v_WEi_W matches the one from auto-differentiation.
   const double kTolerance = 8 * std::numeric_limits<double>::epsilon();
@@ -264,8 +264,8 @@ TEST_F(KukaIiwaModelTests, CalcJacobianTranslationalVelocityB) {
   const VectorX<double> q_double = plant_->GetPositions(*context_);
   MatrixX<double> p_WoEi_W_deriv_wrt_q(3 * kNumPoints, num_positions);
   CalcJacobianViaPartialDerivativesOfPositionWithRespectToQ(
-      *plant_, context_autodiff_.get(), q_double, frame_E_autodiff, p_EoEi_E,
-      &p_WoEi_W_deriv_wrt_q);
+      *plant_autodiff_, context_autodiff_.get(), q_double, frame_E_autodiff,
+      p_EoEi_E, &p_WoEi_W_deriv_wrt_q);
 
   // Ensure proper sizes for the matrix storing the partial derivatives.
   EXPECT_EQ(p_WoEi_W_deriv_wrt_q.rows(), 3 * kNumPoints);

--- a/systems/framework/cache_entry.cc
+++ b/systems/framework/cache_entry.cc
@@ -46,7 +46,7 @@ std::unique_ptr<AbstractValue> CacheEntry::Allocate() const {
 void CacheEntry::Calc(const ContextBase& context,
                       AbstractValue* value) const {
   DRAKE_DEMAND(value != nullptr);
-  DRAKE_ASSERT_VOID(owning_system_->ThrowIfContextNotCompatible(context));
+  DRAKE_ASSERT_VOID(owning_system_->ValidateContext(context));
   DRAKE_ASSERT_VOID(CheckValidAbstractValue(*value));
 
   calc_function_(context, value);

--- a/systems/framework/framework_common.h
+++ b/systems/framework/framework_common.h
@@ -158,13 +158,9 @@ class SystemMessageInterface {
   // namespace-decorated human-readable name as returned by NiceTypeName.
   virtual std::string GetSystemType() const = 0;
 
-  // Throws an std::logic_error if the given Context is incompatible with
-  // this System. This is likely to be _very_ expensive and should generally be
-  // done only in Debug builds, like this:
-  // @code
-  //    DRAKE_ASSERT_VOID(ThrowIfContextNotCompatible(context));
-  // @endcode
-  virtual void ThrowIfContextNotCompatible(const ContextBase&) const = 0;
+  // Checks whether the given context was created for this system.
+  // See SystemBase::ValidateContext for full documentation.
+  virtual void ValidateContext(const ContextBase& context) const = 0;
 
   // Use this string as a stand-in name for an unnamed System. This is not
   // a default name, just an indicator that there is no name. This is a policy

--- a/systems/framework/input_port.h
+++ b/systems/framework/input_port.h
@@ -76,7 +76,7 @@ class InputPort final : public InputPortBase {
   template <typename ValueType, typename = std::enable_if_t<
       std::is_same<AbstractValue, ValueType>::value>>
   const AbstractValue& Eval(const Context<T>& context) const {
-    DRAKE_ASSERT_VOID(get_system_base().ThrowIfContextNotCompatible(context));
+    DRAKE_ASSERT_VOID(get_system_base().ValidateContext(context));
     return DoEvalRequired(context);
   }
   // With anything but a BasicVector subclass, we can just DoEval then cast.
@@ -85,7 +85,7 @@ class InputPort final : public InputPortBase {
         !std::is_base_of<BasicVector<T>, ValueType>::value ||
         std::is_same<BasicVector<T>, ValueType>::value)>>
   const ValueType& Eval(const Context<T>& context) const {
-    DRAKE_ASSERT_VOID(get_system_base().ThrowIfContextNotCompatible(context));
+    DRAKE_ASSERT_VOID(get_system_base().ValidateContext(context));
     return PortEvalCast<ValueType>(DoEvalRequired(context));
   }
   // With a BasicVector subclass, we need to downcast twice.
@@ -139,7 +139,7 @@ class InputPort final : public InputPortBase {
   FixedInputPortValue& FixValue(Context<T>* context,
                                 const ValueType& value) const {
     DRAKE_DEMAND(context != nullptr);
-    DRAKE_ASSERT_VOID(get_system_base().ThrowIfContextNotCompatible(*context));
+    DRAKE_ASSERT_VOID(get_system_base().ValidateContext(*context));
     const bool is_vector_port = (get_data_type() == kVectorValued);
     std::unique_ptr<AbstractValue> abstract_value =
         is_vector_port
@@ -153,7 +153,7 @@ class InputPort final : public InputPortBase {
   operation, because the value is brought up-to-date as part of this
   operation. */
   bool HasValue(const Context<T>& context) const {
-    DRAKE_ASSERT_VOID(get_system_base().ThrowIfContextNotCompatible(context));
+    DRAKE_ASSERT_VOID(get_system_base().ValidateContext(context));
     return DoEvalOptional(context);
   }
 

--- a/systems/framework/output_port.h
+++ b/systems/framework/output_port.h
@@ -107,7 +107,7 @@ class OutputPort : public OutputPortBase {
   template <typename ValueType, typename = std::enable_if_t<
       std::is_same<AbstractValue, ValueType>::value>>
   const AbstractValue& Eval(const Context<T>& context) const {
-    DRAKE_ASSERT_VOID(get_system_base().ThrowIfContextNotCompatible(context));
+    DRAKE_ASSERT_VOID(get_system_base().ValidateContext(context));
     return DoEval(context);
   }
   // With anything but a BasicVector subclass, we can just DoEval then cast.
@@ -116,7 +116,7 @@ class OutputPort : public OutputPortBase {
         !std::is_base_of<BasicVector<T>, ValueType>::value ||
         std::is_same<BasicVector<T>, ValueType>::value)>>
   const ValueType& Eval(const Context<T>& context) const {
-    DRAKE_ASSERT_VOID(get_system_base().ThrowIfContextNotCompatible(context));
+    DRAKE_ASSERT_VOID(get_system_base().ValidateContext(context));
     return PortEvalCast<ValueType>(DoEval(context));
   }
   // With a BasicVector subclass, we need to downcast twice.
@@ -155,7 +155,7 @@ class OutputPort : public OutputPortBase {
   the Allocate() method. */
   void Calc(const Context<T>& context, AbstractValue* value) const {
     DRAKE_DEMAND(value != nullptr);
-    DRAKE_ASSERT_VOID(get_system_base().ThrowIfContextNotCompatible(context));
+    DRAKE_ASSERT_VOID(get_system_base().ValidateContext(context));
     DRAKE_ASSERT_VOID(CheckValidOutputType(*value));
 
     DoCalc(context, value);

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -80,7 +80,7 @@ class SystemBase : public internal::SystemMessageInterface {
   DRAKE_DEPRECATED("2020-05-01",
                    "This method is no longer necessary. See ValidateContext() "
                    "for a possible replacement.")
-  void ThrowIfContextNotCompatible(const ContextBase& context) const final {
+  void ThrowIfContextNotCompatible(const ContextBase& context) const {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     CheckValidContext(context);
@@ -789,7 +789,7 @@ class SystemBase : public internal::SystemMessageInterface {
 
   /** Checks whether the given context was created for this system.
   @note This method is sufficiently fast for performance sensitive code. */
-  void ValidateContext(const ContextBase& context) const {
+  void ValidateContext(const ContextBase& context) const final {
     if (context.get_system_id() != system_id_) {
       throw std::logic_error(
           fmt::format("Context was not created for {} system {}; it was "

--- a/systems/framework/test/system_base_test.cc
+++ b/systems/framework/test/system_base_test.cc
@@ -83,17 +83,28 @@ GTEST_TEST(SystemBaseTest, NameAndMessageSupport) {
   EXPECT_EQ(system.GetSystemType(),
             "drake::systems::system_base_test_internal::MySystemBase");
 
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  auto context = system.AllocateContext();
+  DRAKE_EXPECT_NO_THROW(system.ValidateContext(*context));
+
+  MySystemBase other_system;
+  auto other_context = other_system.AllocateContext();
+  DRAKE_EXPECT_THROWS_MESSAGE(system.ValidateContext(*other_context),
+                              std::exception,
+                              ".*Context.*was not created for.*");
+}
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+GTEST_TEST(SystemBaseTest, DeprecatedValidationTest) {
+  MySystemBase system;
   auto context = system.AllocateContext();
   DRAKE_EXPECT_NO_THROW(system.ThrowIfContextNotCompatible(*context));
-
   MyContextBase bad_context(false);
   DRAKE_EXPECT_THROWS_MESSAGE(system.ThrowIfContextNotCompatible(bad_context),
                               std::logic_error,
                               ".*Context.*unacceptable.*");
-  #pragma GCC diagnostic pop
 }
+#pragma GCC diagnostic pop
 
 }  // namespace system_base_test_internal
 }  // namespace systems


### PR DESCRIPTION
In #12551 we added a fast new method to `SystemBase` for validating contexts, and deprecated the old ones.  However, one old method was also exposed via `internal::SystemMessageInterface` but the commit did not update that API.  We do that here now, along with some TODOs to enable the checks in Release mode later.

This turns up a bug in unit test code where a `MultibodyPlant<AutoDiffXd>` had conflicting `system_id` values during calculation, because we were accidentally transmogrifying it implicitly(!) while passing it into a function but supplying a `Context` created by a correctly-transmogrified plant.  The implicit conversion was allowed because `MultibodyPlant`'s scalar-converting copy constructor was not marked `explicit`.

This is very bad, so we also add `explicit` to `MultibodyPlant` now. This is a breaking change but well worth it.

We also grep the code for any other missing explicit on such constructors, finding and fixing just one more missing, on `GeometryState`.

Relates #11801, #12560.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12891)
<!-- Reviewable:end -->
