### PR TITLE
framework: Break WitnessFunction dependency cycle

### DIFF
--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -54,6 +54,7 @@ drake_cc_package_library(
         ":value_to_abstract_value",
         ":vector",
         ":vector_system",
+        ":witness_function",
     ],
 )
 
@@ -404,15 +405,22 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "witness_function",
+    srcs = ["witness_function.cc"],
+    hdrs = ["witness_function.h"],
+    deps = [
+        ":context",
+        ":event_collection",
+        ":system_base",
+        "//common:default_scalars",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
     name = "system",
-    srcs = [
-        "system.cc",
-        "witness_function.cc",
-    ],
-    hdrs = [
-        "system.h",
-        "witness_function.h",
-    ],
+    srcs = ["system.cc"],
+    hdrs = ["system.h"],
     deps = [
         ":context",
         ":event_collection",
@@ -422,6 +430,7 @@ drake_cc_library(
         ":system_constraint",
         ":system_output",
         ":system_scalar_converter",
+        ":witness_function",
         "//common:autodiff",
         "//common:default_scalars",
         "//common:essential",

--- a/systems/framework/input_port.h
+++ b/systems/framework/input_port.h
@@ -190,6 +190,8 @@ class InputPort final : public InputPortBase {
                        data_type, size, random_type, std::move(eval)),
         system_(*system) {
     DRAKE_DEMAND(system != nullptr);
+    // Check the precondition on identical parameters; note that comparing as
+    // void* is only valid because we have single inheritance.
     DRAKE_DEMAND(static_cast<const void*>(system) == system_interface);
   }
 

--- a/systems/framework/leaf_system.cc
+++ b/systems/framework/leaf_system.cc
@@ -675,7 +675,7 @@ std::unique_ptr<WitnessFunction<T>> LeafSystem<T>::MakeWitnessFunction(
     const WitnessFunctionDirection& direction_type,
     std::function<T(const Context<T>&)> calc) const {
   return std::make_unique<WitnessFunction<T>>(
-      this, description, direction_type, calc);
+      this, this, description, direction_type, calc);
 }
 
 template <typename T>
@@ -685,7 +685,7 @@ std::unique_ptr<WitnessFunction<T>> LeafSystem<T>::MakeWitnessFunction(
     std::function<T(const Context<T>&)> calc,
     const Event<T>& e) const {
   return std::make_unique<WitnessFunction<T>>(
-      this, description, direction_type, calc, e.Clone());
+      this, this, description, direction_type, calc, e.Clone());
 }
 
 template <typename T>

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -1611,7 +1611,7 @@ class LeafSystem : public System<T> {
       const WitnessFunctionDirection& direction_type,
       T (MySystem::*calc)(const Context<T>&) const) const {
     return std::make_unique<WitnessFunction<T>>(
-        this, description, direction_type, calc);
+        this, this, description, direction_type, calc);
   }
 
   /// Constructs the witness function with the given description (used primarily
@@ -1650,7 +1650,7 @@ class LeafSystem : public System<T> {
     PublishEvent<T> publish_event(fn);
     publish_event.set_trigger_type(TriggerType::kWitness);
     return std::make_unique<WitnessFunction<T>>(
-        this, description, direction_type, calc, publish_event.Clone());
+        this, this, description, direction_type, calc, publish_event.Clone());
   }
 
   /// Constructs the witness function with the given description (used primarily
@@ -1678,7 +1678,7 @@ class LeafSystem : public System<T> {
     DiscreteUpdateEvent<T> du_event(fn);
     du_event.set_trigger_type(TriggerType::kWitness);
     return std::make_unique<WitnessFunction<T>>(
-        this, description, direction_type, calc, du_event.Clone());
+        this, this, description, direction_type, calc, du_event.Clone());
   }
 
   /// Constructs the witness function with the given description (used primarily
@@ -1706,7 +1706,7 @@ class LeafSystem : public System<T> {
     UnrestrictedUpdateEvent<T> uu_event(fn);
     uu_event.set_trigger_type(TriggerType::kWitness);
     return std::make_unique<WitnessFunction<T>>(
-        this, description, direction_type, calc, uu_event.Clone());
+        this, this, description, direction_type, calc, uu_event.Clone());
   }
 
   /// Constructs the witness function with the given description (used primarily
@@ -1729,7 +1729,7 @@ class LeafSystem : public System<T> {
     static_assert(std::is_base_of<LeafSystem<T>, MySystem>::value,
                   "Expected to be invoked from a LeafSystem-derived system.");
     return std::make_unique<WitnessFunction<T>>(
-        this, description, direction_type, calc, e.Clone());
+        this, this, description, direction_type, calc, e.Clone());
   }
 
   /// Constructs the witness function with the given description (used primarily

--- a/systems/framework/output_port.h
+++ b/systems/framework/output_port.h
@@ -192,6 +192,8 @@ class OutputPort : public OutputPortBase {
       : OutputPortBase(system_interface, std::move(name), index, ticket,
                        data_type, size),
         system_{*system} {
+    // Check the precondition on identical parameters; note that comparing as
+    // void* is only valid because we have single inheritance.
     DRAKE_DEMAND(static_cast<const void*>(system) == system_interface);
   }
 

--- a/systems/framework/witness_function.cc
+++ b/systems/framework/witness_function.cc
@@ -1,6 +1,4 @@
 #include "drake/systems/framework/witness_function.h"
 
-#include "drake/systems/framework/system.h"
-
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::WitnessFunction)


### PR DESCRIPTION
Also clean up a few oddities (dead code, etc.) in `WitnessFunction` along the way.

Towards #12814.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12894)
<!-- Reviewable:end -->
