### PR TITLE
WIP: Symbolic integrators

### DIFF
--- a/systems/analysis/integrator_base.cc
+++ b/systems/analysis/integrator_base.cc
@@ -463,6 +463,6 @@ typename IntegratorBase<T>::StepResult
 }  // namespace systems
 }  // namespace drake
 
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class drake::systems::IntegratorBase)
 

--- a/systems/analysis/test/explicit_euler_integrator_test.cc
+++ b/systems/analysis/test/explicit_euler_integrator_test.cc
@@ -314,6 +314,23 @@ GTEST_TEST(IntegratorTest, StepSize) {
   }
 }
 
+GTEST_TEST(IntegratorTest, Symbolic) {
+  using symbolic::Expression;
+
+  // Create the mass spring system.
+  SpringMassSystem<Expression> spring_mass(1., 1., 0.);
+  // Set the maximum step size.
+  const double max_h = .01;
+  // Create a context.
+  auto context = spring_mass.CreateDefaultContext();
+  // Create the integrator.
+  ExplicitEulerIntegrator<Expression> integrator(
+      spring_mass, max_h, context.get());
+  integrator.Initialize();
+
+  EXPECT_TRUE(integrator.IntegrateWithSingleFixedStepToTime(0.1));
+}
+
 }  // namespace
 }  // namespace systems
 }  // namespace drake


### PR DESCRIPTION
Towards #12892.
I tried a few different patterns:
1) black-list methods that will likely never support symbolic w/ enable_if
2) make a bunch of the member variables/arguments currently typed T into
  typedef
      typename std::conditional<std::is_same<T, symbolic::Expression>::value,
                                double, T>::type U;
3) extract all of the error-controlled methods into their own class, which is included conditionally
template <class T>
class IntegratorBase
    : public std::conditional<std::is_same<T, symbolic::Expression>::value,
        void, ErrorControlledIntegratorBase<T>> {

But my current proposal, and the cleanest by far (I think), is to instead whitelist a very simple set of methods with an explicit instantiation of IntegratorBase<Expression>.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12897)
<!-- Reviewable:end -->
