### PR TITLE
Enable use of rigid half space in hydroelastic contact

### DIFF
--- a/examples/multibody/rolling_sphere/README.md
+++ b/examples/multibody/rolling_sphere/README.md
@@ -37,10 +37,9 @@ objects:
 The "hydroelastic" model doesn't have full support yet. There are some types
 of geometries that cannot yet be given a hydroelastic representation and some
 types of contact which aren't modeled yet. For example:
-  - Drake `HalfSpace` shapes can't be represented at all
-  - Drake `Mesh` shapes can only be modeled with _rigid_ hydroelastic
-    representation
-  - Contact between two rigid or two soft objects aren't supported.
+  - Drake `HalfSpace` and `Mesh` shapes can only be modeled with _rigid_
+    hydroleastic representation
+  - Contact between two rigid or two soft objects isn't supported.
 
 __Changing the configuration__
 

--- a/examples/multibody/rolling_sphere/make_rolling_sphere_plant.cc
+++ b/examples/multibody/rolling_sphere/make_rolling_sphere_plant.cc
@@ -38,21 +38,16 @@ std::unique_ptr<drake::multibody::MultibodyPlant<double>> MakeBouncingBallPlant(
   if (scene_graph != nullptr) {
     plant->RegisterAsSourceForSceneGraph(scene_graph);
 
-    // TODO(SeanCurtis-TRI): Once SceneGraph supports hydroelastic contact
-    //  between rigid half space and soft sphere, replace this box with the
-    //  equivalent half space.
-    const double size = 5;
-    RigidTransformd X_WG{Vector3<double>(0, 0, -size / 2)};
-    ProximityProperties box_props;
-    AddRigidHydroelasticProperties(size, &box_props);
-    AddContactMaterial({}, {}, surface_friction, &box_props);
+    const RigidTransformd X_WG;  // identity.
+    ProximityProperties ground_props;
+    AddRigidHydroelasticProperties(&ground_props);
+    AddContactMaterial({}, {}, surface_friction, &ground_props);
     plant->RegisterCollisionGeometry(plant->world_body(), X_WG,
-                                     geometry::Box(size, size, size),
-                                     "collision", std::move(box_props));
-
+                                     geometry::HalfSpace{}, "collision",
+                                     std::move(ground_props));
     // Add visual for the ground.
     plant->RegisterVisualGeometry(plant->world_body(), X_WG,
-                                  geometry::Box(size, size, size), "visual");
+                                  geometry::HalfSpace{}, "visual");
 
     // Add sphere geometry for the ball.
     // Pose of sphere geometry S in body frame B.

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -152,6 +152,7 @@ drake_cc_library(
         ":collision_filter_legacy",
         ":hydroelastic_internal",
         ":mesh_intersection",
+        ":mesh_plane_intersection",
         ":penetration_as_point_pair_callback",
         ":proximity_utilities",
         ":surface_mesh",
@@ -335,6 +336,7 @@ drake_cc_library(
     srcs = ["mesh_plane_intersection.cc"],
     hdrs = ["mesh_plane_intersection.h"],
     deps = [
+        ":bounding_volume_hierarchy",
         ":contact_surface_utility",
         ":mesh_field",
         ":plane",
@@ -714,7 +716,11 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "posed_half_space_test",
-    deps = [":posed_half_space"],
+    deps = [
+        ":posed_half_space",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+    ],
 )
 
 drake_cc_googletest(

--- a/geometry/proximity/hydroelastic_internal.cc
+++ b/geometry/proximity/hydroelastic_internal.cc
@@ -1,7 +1,6 @@
 #include "drake/geometry/proximity/hydroelastic_internal.h"
 
-#include <limits>
-#include <vector>
+#include <string>
 
 #include <fmt/format.h>
 
@@ -21,10 +20,8 @@ namespace geometry {
 namespace internal {
 namespace hydroelastic {
 
-using Eigen::Vector3d;
 using std::make_unique;
 using std::move;
-using std::vector;
 
 SoftGeometry& SoftGeometry::operator=(const SoftGeometry& g) {
   if (this == &g) return *this;
@@ -41,8 +38,10 @@ SoftGeometry& SoftGeometry::operator=(const SoftGeometry& g) {
 RigidGeometry& RigidGeometry::operator=(const RigidGeometry& g) {
   if (this == &g) return *this;
 
-  auto mesh = make_unique<SurfaceMesh<double>>(g.mesh());
-  geometry_ = RigidMesh(move(mesh));
+  geometry_ = std::nullopt;
+  if (!g.is_half_space()) {
+    geometry_ = RigidMesh(make_unique<SurfaceMesh<double>>(g.mesh()));
+  }
 
   return *this;
 }
@@ -194,6 +193,12 @@ class PositiveDouble : public Validator<double> {
     }
   }
 };
+
+std::optional<RigidGeometry> MakeRigidRepresentation(
+    const HalfSpace&, const ProximityProperties&) {
+  // Default constructor creates a rigid half space.
+  return RigidGeometry();
+}
 
 std::optional<RigidGeometry> MakeRigidRepresentation(
     const Sphere& sphere, const ProximityProperties& props) {

--- a/geometry/proximity/mesh_plane_intersection.h
+++ b/geometry/proximity/mesh_plane_intersection.h
@@ -1,11 +1,15 @@
 #pragma once
 
+#include <memory>
 #include <unordered_map>
 #include <vector>
 
 #include "drake/common/sorted_pair.h"
+#include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/proximity/bounding_volume_hierarchy.h"
 #include "drake/geometry/proximity/plane.h"
 #include "drake/geometry/proximity/volume_mesh_field.h"
+#include "drake/geometry/query_results/contact_surface.h"
 #include "drake/math/rigid_transform.h"
 
 namespace drake {
@@ -46,9 +50,11 @@ namespace internal {
 
  @param[in] tet_index       The index of the tetrahedron to attempt to
                             intersect.
- @param[in] field_M         The volume mesh field (and mesh) containing the
-                            tetrahedra to intersect. The vertex positions are
-                            all measured and expressed in Frame M.
+ @param[in] field_M         The _linear_ volume mesh field (and mesh) containing
+                            the tetrahedra to intersect. The vertex positions
+                            are all measured and expressed in Frame M. The
+                            linearity of the field is a strict requirement of
+                            the algorithm.
  @param[in] plane_M         The definition of a plane measured and expressed
                             in Frame M.
  @param[in] X_WM            The relative pose between the mesh frame M and the
@@ -65,13 +71,84 @@ namespace internal {
  @pre `tet_index` lies in the range `[0, field_M.mesh().num_elements())`.
  */
 template <typename T>
-void SliceTetWithPlane(
-    VolumeElementIndex tet_index,
-    const VolumeMeshField<double, double>& field_M, const Plane<T>& plane_M,
-    const math::RigidTransform<T>& X_WM, std::vector<SurfaceFace>* faces,
-    std::vector<SurfaceVertex<T>>* vertices_W, std::vector<T>* surface_e,
-    std::unordered_map<SortedPair<VolumeVertexIndex>, SurfaceVertexIndex>*
-        cut_edges);
+void SliceTetWithPlane(VolumeElementIndex tet_index,
+                       const VolumeMeshFieldLinear<double, double>& field_M,
+                       const Plane<T>& plane_M,
+                       const math::RigidTransform<T>& X_WM,
+                       std::vector<SurfaceFace>* faces,
+                       std::vector<SurfaceVertex<T>>* vertices_W,
+                       std::vector<T>* surface_e,
+                       std::unordered_map<SortedPair<VolumeVertexIndex>,
+                                          SurfaceVertexIndex>* cut_edges);
+
+/* Computes a ContactSurface by intersecting a plane with a set of tetrahedra
+ drawn from the given volume mesh (and its pressure field). The indicated
+ tetrahedra would typically be the result of broadphase culling.
+
+ @param[in] mesh_id         The id associated with the volume mesh.
+ @param[in] mesh_field_M    The _linear_ mesh field (and corresponding mesh,
+                            mesh_M) from which we compute the ContactSurface.
+                            The field (and the mesh vertices) are measured and
+                            expressed in Frame M. The linearity of the field is
+                            a strict requirement of the underlying algorithm.
+ @param[in] plane_id        The id associated with the plane.
+ @param[in] plane_M         The plane to intersect against the tetrahedra;
+                            measured and expressed in the same frame M.
+ @param[in] tet_indces      Indices for the tetrahedra in mesh_M to test against
+                            the plane.
+ @param[in] X_WM            The relative pose between the mesh frame M and the
+                            world frame W. Used to guarantee that the contact
+                            surface is measured and expressed in the world
+                            frame.
+ @returns `nullptr` if there is no intersection, otherwise the appropriate
+           ContactSurface. The normals of the contact surface mesh will all
+           be parallel with the plane normal.
+ @pre  `i ∈ [0, N) ∀ i ∈ tet_indices`, where N is the number of tetrahedra in
+       mesh_M.
+*/
+template <typename T>
+std::unique_ptr<ContactSurface<T>> ComputeContactSurface(
+    GeometryId mesh_id,
+    const VolumeMeshFieldLinear<double, double>& mesh_field_M,
+    GeometryId plane_id, const Plane<T>& plane_M,
+    const std::vector<VolumeElementIndex> tet_indices,
+    const math::RigidTransform<T>& X_WM);
+
+// TODO(SeanCurtis-TRI): This is, in some sense, the "public" api. It refers to
+//  half spaces. Does it belong in this file? Does it belong elsewhere? At the
+//  end of the day, where does surface mesh-soft half space go?
+/* Computes the ContactSurface formed by a rigid half space and a given
+ soft mesh.
+
+ The definition of the half space is implicit in the call -- it is the type
+ defined by the HalfSpace class, thus, only its id and its pose in a common
+ frame (the world frame) is necessary.
+
+ @param[in] id_S        The id of the soft mesh.
+ @param[in] field_S     The _linear_ mesh field (and its corresponding mesh
+                        `mesh_S`) for the soft mesh. The field and mesh vertices
+                        are measured and expressed in Frame S. The linearity of
+                        the field is a strict requirement of the underlying
+                        algorithm.
+ @param[in] bvh_S       The bounding-volume hierarchy of the soft volume mesh
+                        measured and expressed in Frame S.
+ @param[in] X_WS        The relative pose of Frame S and the world frame W.
+ @param[in] id_R        The id of the rigid half space.
+ @param[in] X_WR        The relative pose between Frame R -- the frame the half
+                        space is defined in -- and the world frame W.
+ @returns `nullptr` if there is no collision, otherwise the ContactSurface
+          between geometries S and R. The normals of the contact surface mesh
+          will all be parallel with the plane normal.
+ @tparam T The underlying scalar type. Must be a valid Eigen scalar.
+ */
+template <typename T>
+std::unique_ptr<ContactSurface<T>>
+ComputeContactSurfaceFromSoftVolumeRigidHalfSpace(
+    const GeometryId id_S, const VolumeMeshFieldLinear<double, double>& field_S,
+    const BoundingVolumeHierarchy<VolumeMesh<double>>& bvh_S,
+    const math::RigidTransform<T>& X_WS, const GeometryId id_R,
+    const math::RigidTransform<T>& X_WR);
+
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/plane.h
+++ b/geometry/proximity/plane.h
@@ -68,11 +68,7 @@ class Plane {
       }
       nhat_F_ = n_F / magnitude;
     } else {
-      using std::abs;
-      // We pick a threshold that should easily contain typical precision loss
-      // in the columns/rows of a rotation matrix -- a likely source for plane
-      // normals.
-      DRAKE_ASSERT(abs(n_F.norm() - 1.0) > 1e-13);
+      DRAKE_ASSERT_VOID(ThrowIfInsufficientlyNormal(n_F));
       nhat_F_ = n_F;
     }
     displacement_ = nhat_F_.dot(p_FP);
@@ -90,6 +86,21 @@ class Plane {
   const Vector3<T>& normal() const { return nhat_F_; }
 
  private:
+  // Used to validate the "already normalized" plane normal in debug mode.
+  static void ThrowIfInsufficientlyNormal(const Vector3<T>& n) {
+    using std::abs;
+    const T delta = abs(n.norm() - 1);
+    // We pick a threshold that should easily contain typical precision loss
+    // in the columns/rows of a rotation matrix -- a likely source for plane
+    // normals.
+    if (delta > 1e-13) {
+      throw std::runtime_error(
+          fmt::format("Plane constructed with a normal vector that was "
+                      "declared normalized; the vector is not unit length. "
+                      "Vector [{}] with length {}", n.transpose(), n.norm()));
+    }
+  }
+
   Vector3<T> nhat_F_;
   T displacement_{};
 };

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -156,13 +156,13 @@ GTEST_TEST(ProximityEngineTests, ProcessHydroelasticProperties) {
               HydroelasticType::kUndefined);
   }
 
-  // Case: rigid half_space (unsupported).
+  // Case: rigid half_space.
   {
     HalfSpace half_space;
     const GeometryId half_space_id = GeometryId::get_new_id();
     engine.AddDynamicGeometry(half_space, half_space_id, rigid_properties);
     EXPECT_EQ(ProximityEngineTester::hydroelastic_type(half_space_id, engine),
-              HydroelasticType::kUndefined);
+              HydroelasticType::kRigid);
   }
 
   // Case: rigid box.


### PR DESCRIPTION
Previous commits introduced the mathematical basis for intersecting a half space boundary plane with a tetrahedron. This builds on that atomic operation:

  - Allow instantiation of hydroelastic representation of rigid half space.
  - Define internal representation of rigid half space.
  - Evaluation of ContactSurface from intersection of VolumeMesh with rigid half space.
  - Restore the rolling sphere demo to use a rigid half space as ground instead of the box previously used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12901)
<!-- Reviewable:end -->
