### PR TITLE
Use dReal 4.20.03.4

### DIFF
--- a/tools/workspace/dreal/repository.bzl
+++ b/tools/workspace/dreal/repository.bzl
@@ -8,7 +8,7 @@ def dreal_repository(
     github_archive(
         name = name,
         repository = "dreal/dreal4",
-        commit = "4.19.10.3",
-        sha256 = "ebababd6db551014c97933d909a6822ee8f65959be8eb32c8c285c7692d3617e",  # noqa
+        commit = "4.20.03.4",
+        sha256 = "7d24855e0ea18592e3a1681dc226a43ac82e119b583884c24f722536654b84d7",  # noqa
         mirrors = mirrors,
     )


### PR DESCRIPTION
It uses `-Wfoo` instead of `-Werror=foo` in dreal.bzl file. Then, it includes `-Werror` in its `.bazelrc` file which is not loaded when dReal is built as an external.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12905)
<!-- Reviewable:end -->
