### PR TITLE
framework: OutputPort should not depend on SystemBase

### DIFF
--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -397,7 +397,6 @@ drake_cc_library(
     deps = [
         ":context",
         ":output_port_base",
-        ":system_base",
         "//common:default_scalars",
         "//common:essential",
         "//common:value",
@@ -440,6 +439,7 @@ drake_cc_library(
     srcs = ["leaf_output_port.cc"],
     hdrs = ["leaf_output_port.h"],
     deps = [
+        ":cache_entry",
         ":framework_common",
         ":output_port",
         ":vector",

--- a/systems/framework/diagram.cc
+++ b/systems/framework/diagram.cc
@@ -865,7 +865,7 @@ const AbstractValue* Diagram<T>::EvalConnectedSubsystemInputPort(
   auto& diagram_context =
       dynamic_cast<const DiagramContext<T>&>(context_base);
   auto& system =
-      dynamic_cast<const System<T>&>(input_port_base.get_system_base());
+      dynamic_cast<const System<T>&>(input_port_base.get_system_interface());
   const InputPortLocator id{&system, input_port_base.get_index()};
 
   // Find if this input port is exported (connected to an input port of this

--- a/systems/framework/diagram_output_port.h
+++ b/systems/framework/diagram_output_port.h
@@ -45,7 +45,7 @@ class DiagramOutputPort final : public OutputPort<T> {
   // diagram's child subsystems.
   //
   // @param diagram The Diagram that will own this port.
-  // @param system_base The same Diagram cast to its base class.
+  // @param system_interface The same Diagram cast to its base class.
   // @param name A name for the port.  Output ports names must be unique
   //     within the `diagram` System.
   // @param index The output port index to be assigned to the new port.
@@ -57,7 +57,7 @@ class DiagramOutputPort final : public OutputPort<T> {
   //
   // @pre The `diagram` System must actually be a Diagram.
   // @pre `diagram` lifetime must exceed the port's; we retain the pointer here.
-  // @pre `diagram` and `system_base` must be the same object.
+  // @pre `diagram` and `system_interface` must be the same object.
   // @pre `source_output_port` must be owned by a child of `diagram`.
   // @pre `source_subsystem_index` must be the index of that child in `diagram`.
   //
@@ -70,13 +70,13 @@ class DiagramOutputPort final : public OutputPort<T> {
   // to static_cast up to System<T> as is required by OutputPort. We expect
   // the caller to do that cast for us so take a System<T> here.
   DiagramOutputPort(const System<T>* diagram,
-                    SystemBase* system_base,
+                    internal::SystemMessageInterface* system_interface,
                     std::string name,
                     OutputPortIndex index,
                     DependencyTicket ticket,
                     const OutputPort<T>* source_output_port,
                     SubsystemIndex source_subsystem_index)
-      : OutputPort<T>(diagram, system_base, std::move(name), index, ticket,
+      : OutputPort<T>(diagram, system_interface, std::move(name), index, ticket,
                       source_output_port->get_data_type(),
                       source_output_port->size()),
         source_output_port_(source_output_port),

--- a/systems/framework/input_port.h
+++ b/systems/framework/input_port.h
@@ -76,7 +76,7 @@ class InputPort final : public InputPortBase {
   template <typename ValueType, typename = std::enable_if_t<
       std::is_same<AbstractValue, ValueType>::value>>
   const AbstractValue& Eval(const Context<T>& context) const {
-    DRAKE_ASSERT_VOID(get_system_base().ValidateContext(context));
+    DRAKE_ASSERT_VOID(get_system_interface().ValidateContext(context));
     return DoEvalRequired(context);
   }
   // With anything but a BasicVector subclass, we can just DoEval then cast.
@@ -85,7 +85,7 @@ class InputPort final : public InputPortBase {
         !std::is_base_of<BasicVector<T>, ValueType>::value ||
         std::is_same<BasicVector<T>, ValueType>::value)>>
   const ValueType& Eval(const Context<T>& context) const {
-    DRAKE_ASSERT_VOID(get_system_base().ValidateContext(context));
+    DRAKE_ASSERT_VOID(get_system_interface().ValidateContext(context));
     return PortEvalCast<ValueType>(DoEvalRequired(context));
   }
   // With a BasicVector subclass, we need to downcast twice.
@@ -139,7 +139,7 @@ class InputPort final : public InputPortBase {
   FixedInputPortValue& FixValue(Context<T>* context,
                                 const ValueType& value) const {
     DRAKE_DEMAND(context != nullptr);
-    DRAKE_ASSERT_VOID(get_system_base().ValidateContext(*context));
+    DRAKE_ASSERT_VOID(get_system_interface().ValidateContext(*context));
     const bool is_vector_port = (get_data_type() == kVectorValued);
     std::unique_ptr<AbstractValue> abstract_value =
         is_vector_port
@@ -153,7 +153,7 @@ class InputPort final : public InputPortBase {
   operation, because the value is brought up-to-date as part of this
   operation. */
   bool HasValue(const Context<T>& context) const {
-    DRAKE_ASSERT_VOID(get_system_base().ValidateContext(context));
+    DRAKE_ASSERT_VOID(get_system_interface().ValidateContext(context));
     return DoEvalOptional(context);
   }
 
@@ -177,19 +177,20 @@ class InputPort final : public InputPortBase {
   friend class internal::FrameworkFactory;
 
   // See InputPortBase for the meaning of these parameters. The additional
-  // `system` parameter must point to the same object as `system_base`.
+  // `system` parameter must point to the same object as `system_interface`.
   // (They're separate because System is forward-declared so we can't cast.)
   InputPort(
-      const System<T>* system, internal::SystemMessageInterface* system_base,
+      const System<T>* system,
+      internal::SystemMessageInterface* system_interface,
       std::string name, InputPortIndex index, DependencyTicket ticket,
       PortDataType data_type, int size,
       const std::optional<RandomDistribution>& random_type,
       EvalAbstractCallback eval)
-      : InputPortBase(system_base, std::move(name), index, ticket, data_type,
-                      size, random_type, std::move(eval)),
+      : InputPortBase(system_interface, std::move(name), index, ticket,
+                       data_type, size, random_type, std::move(eval)),
         system_(*system) {
     DRAKE_DEMAND(system != nullptr);
-    DRAKE_DEMAND(static_cast<const void*>(system) == system_base);
+    DRAKE_DEMAND(static_cast<const void*>(system) == system_interface);
   }
 
   const System<T>& system_;

--- a/systems/framework/leaf_output_port.h
+++ b/systems/framework/leaf_output_port.h
@@ -10,9 +10,9 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/value.h"
 #include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/cache_entry.h"
 #include "drake/systems/framework/framework_common.h"
 #include "drake/systems/framework/output_port.h"
-#include "drake/systems/framework/system_base.h"
 
 namespace drake {
 namespace systems {
@@ -70,12 +70,13 @@ class LeafOutputPort final : public OutputPort<T> {
   friend class internal::FrameworkFactory;
 
   // Constructs a cached output port. The `system` parameter must be the same
-  // object as the `system_base` parameter.
-  LeafOutputPort(const System<T>* system, SystemBase* system_base,
+  // object as the `system_interface` parameter.
+  LeafOutputPort(const System<T>* system,
+                 internal::SystemMessageInterface* system_interface,
                  std::string name, OutputPortIndex index,
                  DependencyTicket ticket, PortDataType data_type, int size,
                  CacheEntry* cache_entry)
-      : OutputPort<T>(system, system_base, std::move(name), index, ticket,
+      : OutputPort<T>(system, system_interface, std::move(name), index, ticket,
                       data_type, size),
         cache_entry_(cache_entry) {
     DRAKE_DEMAND(cache_entry != nullptr);

--- a/systems/framework/output_port.h
+++ b/systems/framework/output_port.h
@@ -19,7 +19,6 @@
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/framework_common.h"
 #include "drake/systems/framework/output_port_base.h"
-#include "drake/systems/framework/system_base.h"
 
 namespace drake {
 namespace systems {
@@ -107,7 +106,7 @@ class OutputPort : public OutputPortBase {
   template <typename ValueType, typename = std::enable_if_t<
       std::is_same<AbstractValue, ValueType>::value>>
   const AbstractValue& Eval(const Context<T>& context) const {
-    DRAKE_ASSERT_VOID(get_system_base().ValidateContext(context));
+    DRAKE_ASSERT_VOID(get_system_interface().ValidateContext(context));
     return DoEval(context);
   }
   // With anything but a BasicVector subclass, we can just DoEval then cast.
@@ -116,7 +115,7 @@ class OutputPort : public OutputPortBase {
         !std::is_base_of<BasicVector<T>, ValueType>::value ||
         std::is_same<BasicVector<T>, ValueType>::value)>>
   const ValueType& Eval(const Context<T>& context) const {
-    DRAKE_ASSERT_VOID(get_system_base().ValidateContext(context));
+    DRAKE_ASSERT_VOID(get_system_interface().ValidateContext(context));
     return PortEvalCast<ValueType>(DoEval(context));
   }
   // With a BasicVector subclass, we need to downcast twice.
@@ -155,7 +154,7 @@ class OutputPort : public OutputPortBase {
   the Allocate() method. */
   void Calc(const Context<T>& context, AbstractValue* value) const {
     DRAKE_DEMAND(value != nullptr);
-    DRAKE_ASSERT_VOID(get_system_base().ValidateContext(context));
+    DRAKE_ASSERT_VOID(get_system_interface().ValidateContext(context));
     DRAKE_ASSERT_VOID(CheckValidOutputType(*value));
 
     DoCalc(context, value);
@@ -182,17 +181,18 @@ class OutputPort : public OutputPortBase {
   construction. See OutputPortBase::OutputPortBase() for the meaning of these
   parameters.
   @pre The `name` must not be empty.
-  @pre The `system` parameter must be the same object as the `system_base`
+  @pre The `system` parameter must be the same object as the `system_interface`
   parameter. */
-  // The System and SystemBase are provided separately since we don't have
+  // The system and system_interface are provided separately since we don't have
   // access to System's declaration here so can't cast but the caller can.
-  OutputPort(const System<T>* system, SystemBase* system_base, std::string name,
-             OutputPortIndex index, DependencyTicket ticket,
+  OutputPort(const System<T>* system,
+             internal::SystemMessageInterface* system_interface,
+             std::string name, OutputPortIndex index, DependencyTicket ticket,
              PortDataType data_type, int size)
-      : OutputPortBase(system_base, std::move(name), index, ticket, data_type,
-                       size),
+      : OutputPortBase(system_interface, std::move(name), index, ticket,
+                       data_type, size),
         system_{*system} {
-    DRAKE_DEMAND(static_cast<const void*>(system) == system_base);
+    DRAKE_DEMAND(static_cast<const void*>(system) == system_interface);
   }
 
   /** A concrete %OutputPort must provide a way to allocate a suitable object

--- a/systems/framework/port_base.cc
+++ b/systems/framework/port_base.cc
@@ -34,8 +34,8 @@ PortBase::~PortBase() = default;
 std::string PortBase::GetFullDescription() const {
   return fmt::format(
       "{}Port[{}] ({}) of System {} ({})",
-      kind_string_, index_, name_, get_system_base().GetSystemPathname(),
-      NiceTypeName::RemoveNamespaces(get_system_base().GetSystemType()));
+      kind_string_, index_, name_, get_system_interface().GetSystemPathname(),
+      NiceTypeName::RemoveNamespaces(get_system_interface().GetSystemType()));
 }
 
 void PortBase::ThrowBadCast(

--- a/systems/framework/port_base.h
+++ b/systems/framework/port_base.h
@@ -34,7 +34,7 @@ class PortBase {
   // Returns a reference to the system that owns this port. Note that for a
   // diagram port this will be the diagram, not the leaf system whose port was
   // exported.
-  const internal::SystemMessageInterface& get_system_base() const {
+  const internal::SystemMessageInterface& get_system_interface() const {
     return owning_system_;
   }
 #endif
@@ -79,8 +79,8 @@ class PortBase {
   LeafSystem whose output port was forwarded. */
   int get_int_index() const { return index_; }
 
-  /** Returns get_system_base(), but without the const. */
-  internal::SystemMessageInterface& get_mutable_system_base() {
+  /** Returns get_system_interface(), but without the const. */
+  internal::SystemMessageInterface& get_mutable_system_interface() {
     return owning_system_;
   }
 

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -819,7 +819,7 @@ class SystemBase : public internal::SystemMessageInterface {
   // data type.
   void AddInputPort(std::unique_ptr<InputPortBase> port) {
     DRAKE_DEMAND(port != nullptr);
-    DRAKE_DEMAND(&port->get_system_base() == this);
+    DRAKE_DEMAND(&port->get_system_interface() == this);
     DRAKE_DEMAND(port->get_index() == num_input_ports());
     DRAKE_DEMAND(!port->get_name().empty());
 
@@ -844,7 +844,7 @@ class SystemBase : public internal::SystemMessageInterface {
   // data type.
   void AddOutputPort(std::unique_ptr<OutputPortBase> port) {
     DRAKE_DEMAND(port != nullptr);
-    DRAKE_DEMAND(&port->get_system_base() == this);
+    DRAKE_DEMAND(&port->get_system_interface() == this);
     DRAKE_DEMAND(port->get_index() == num_output_ports());
     DRAKE_DEMAND(!port->get_name().empty());
 

--- a/systems/framework/test/input_port_test.cc
+++ b/systems/framework/test/input_port_test.cc
@@ -29,7 +29,7 @@ GTEST_TEST(InputPortTest, VectorTest) {
   const auto context_ptr = dummy_system.CreateDefaultContext();
   const auto& context = *context_ptr;
   const System<T>* const system = &dummy_system;
-  internal::SystemMessageInterface* const system_base = &dummy_system;
+  internal::SystemMessageInterface* const system_interface = &dummy_system;
   const std::string name{"port_name"};
   const InputPortIndex index{2};
   const DependencyTicket ticket;
@@ -38,8 +38,8 @@ GTEST_TEST(InputPortTest, VectorTest) {
   const std::optional<RandomDistribution> random_type = std::nullopt;
 
   auto dut = internal::FrameworkFactory::Make<InputPort<T>>(
-      system, system_base, name, index, ticket, data_type, size, random_type,
-      &DoEval);
+      system, system_interface, name, index, ticket, data_type, size,
+      random_type, &DoEval);
 
   // Check basic getters.
   EXPECT_EQ(dut->get_name(), name);
@@ -47,7 +47,7 @@ GTEST_TEST(InputPortTest, VectorTest) {
   EXPECT_EQ(dut->size(), size);
   EXPECT_EQ(dut->GetFullDescription(),
             "InputPort[2] (port_name) of System ::dummy (DummySystem)");
-  EXPECT_EQ(&dut->get_system_base(), system_base);
+  EXPECT_EQ(&dut->get_system_interface(), system_interface);
   EXPECT_EQ(&dut->get_system(), system);
 
   // Check HasValue.
@@ -89,7 +89,7 @@ GTEST_TEST(InputPortTest, AbstractTest) {
   const auto context_ptr = dummy_system.CreateDefaultContext();
   const auto& context = *context_ptr;
   const System<T>* const system = &dummy_system;
-  internal::SystemMessageInterface* const system_base = &dummy_system;
+  internal::SystemMessageInterface* const system_interface = &dummy_system;
   const std::string name{"port_name"};
   const InputPortIndex index{2};
   const DependencyTicket ticket;
@@ -98,8 +98,8 @@ GTEST_TEST(InputPortTest, AbstractTest) {
   const std::optional<RandomDistribution> random_type = std::nullopt;
 
   auto dut = internal::FrameworkFactory::Make<InputPort<T>>(
-      system, system_base, name, index, ticket, data_type, size, random_type,
-      &DoEval);
+      system, system_interface, name, index, ticket, data_type, size,
+      random_type, &DoEval);
 
   // Check basic getters.
   EXPECT_EQ(dut->get_name(), name);
@@ -107,7 +107,7 @@ GTEST_TEST(InputPortTest, AbstractTest) {
   EXPECT_EQ(dut->size(), size);
   EXPECT_EQ(dut->GetFullDescription(),
             "InputPort[2] (port_name) of System ::dummy (DummySystem)");
-  EXPECT_EQ(&dut->get_system_base(), system_base);
+  EXPECT_EQ(&dut->get_system_interface(), system_interface);
   EXPECT_EQ(&dut->get_system(), system);
 
   // Check HasValue.

--- a/systems/framework/test/output_port_test.cc
+++ b/systems/framework/test/output_port_test.cc
@@ -45,10 +45,11 @@ class DummySystem : public LeafSystem<double> {
 // introduce errors.
 class MyOutputPort : public OutputPort<double> {
  public:
-  MyOutputPort(const System<double>* diagram, SystemBase* system_base,
+  MyOutputPort(const System<double>* diagram,
+               internal::SystemMessageInterface* system_interface,
                OutputPortIndex index, DependencyTicket ticket)
-      : OutputPort<double>(diagram, system_base, "my_output", index, ticket,
-                           kVectorValued, 2) {}
+      : OutputPort<double>(diagram, system_interface, "my_output", index,
+                            ticket, kVectorValued, 2) {}
 
   std::unique_ptr<AbstractValue> DoAllocate() const override {
     return AbstractValue::Make<BasicVector<double>>(


### PR DESCRIPTION
This brings it in line with how InputPort is phrased.

Also fix a related misleading pervasive use of system_base to refer to a SystemMessageInterface instead of a SystemBase.

As noted in #12891.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12906)
<!-- Reviewable:end -->
