### PR TITLE
snopt: Tidy up storage declaration

### DIFF
--- a/solvers/snopt_solver.cc
+++ b/solvers/snopt_solver.cc
@@ -115,7 +115,7 @@ template<>
 struct SnoptImpl<false> {
   // The unit number for our "Print file" log for the current thread.  When the
   // "Print file" option is not enabled, this is zero.
-  thread_local static int g_iprint;
+  thread_local inline static int g_iprint;
 
   template <typename Int>
   static void snend(
@@ -194,9 +194,6 @@ struct SnoptImpl<false> {
     ::f_snsetr(buffer, &len, &rvalue, errors, iw, &leniw, rw, &lenrw);
   }
 };
-
-// The next line is C++ boilerplate to declare linker storage for this global.
-thread_local int SnoptImpl<false>::g_iprint;
 
 // Choose the correct SnoptImpl specialization.
 #pragma GCC diagnostic push  // Silence spurious warnings from macOS llvm.


### PR DESCRIPTION
As of C++17, we can use "inline" to avoid repeating ourselves.

In a stackoverflow [error message](https://stackoverflow.com/questions/60289642/error-while-compiling-project-with-drake-using-bazel-on-mac) we see:
```console
drake/solvers/snopt_solver.cc:197:36: error: variable 'g_iprint' is not needed and will not be emitted [-Werror,-Wunneeded-internal-declaration]
```

This tidy might fix that error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12914)
<!-- Reviewable:end -->
