### PR TITLE
 pybind11 docs: Fix sphinx patch for versions > 1.6.7

### DIFF
--- a/bindings/pydrake/doc/LICENSE.TXT
+++ b/bindings/pydrake/doc/LICENSE.TXT
@@ -1,0 +1,9 @@
+This folder contains a file (`pydrake_sphinx_extension.py`) that uses some code
+from Sphinx 1.6.7.
+
+https://github.com/sphinx-doc/sphinx/blob/v1.6.7/sphinx/ext/autodoc.py#L996-L1057
+
+The original license for these files is given in the link below and copied into
+file sphinx.LICENSE.txt.
+
+https://github.com/sphinx-doc/sphinx/blob/v1.6.7/LICENSE

--- a/bindings/pydrake/doc/conf.py
+++ b/bindings/pydrake/doc/conf.py
@@ -55,3 +55,4 @@ html_copy_source = False
 html_show_copyright = False
 
 html_show_sphinx = False
+autodoc_member_order = 'bycustomfunction'

--- a/bindings/pydrake/doc/pydrake_sphinx_extension.py
+++ b/bindings/pydrake/doc/pydrake_sphinx_extension.py
@@ -14,6 +14,7 @@ For guidance, see:
 from collections import namedtuple
 import re
 import warnings
+from typing import Any, Tuple
 
 from sphinx.locale import _
 import sphinx.domains.python as pydoc
@@ -250,6 +251,99 @@ def autodoc_skip_member(app, what, name, obj, skip, options):
     return None
 
 
+def patch_document_members(original, self, all_members=False):
+    # type: (bool) -> None
+    """Generate reST for member documentation.
+
+    If *all_members* is True, do all members, else those given by
+    *self.options.members*.
+
+    Note: This function is a patched version for Drake to add the functionality
+    of sorting the documented members using a custom key function.
+    The original code is from Sphinx 1.6.7 installed via the `python3-sphinx`
+    package.  Debian patches the upstream version:
+    https://sources.debian.org/patches/sphinx/1.6.7-2/
+    However, this piece of code is not patched.
+    https://github.com/sphinx-doc/sphinx/blob/v1.6.7/sphinx/ext/autodoc.py#L996-L1057
+    Our upstream PR: https://github.com/sphinx-doc/sphinx/pull/7177
+    """
+    # set current namespace for finding members
+    self.env.temp_data['autodoc:module'] = self.modname
+    if self.objpath:
+        self.env.temp_data['autodoc:class'] = self.objpath[0]
+
+    want_all = all_members or self.options.inherited_members or \
+        self.options.members is autodoc.ALL
+    # find out which members are documentable
+    members_check_module, members = self.get_object_members(want_all)
+
+    # remove members given by exclude-members
+    if self.options.exclude_members:
+        members = [(membername, member) for (membername, member) in members
+                   if membername not in self.options.exclude_members]
+
+    # document non-skipped members
+    memberdocumenters = []  # type: List[Tuple[Documenter, bool]]
+    for (mname, member, isattr) in self.filter_members(members, want_all):
+        classes = [cls for cls in __import__("six").itervalues(
+            autodoc.AutoDirective._registry)
+            if cls.can_document_member(member, mname, isattr, self)]
+        if not classes:
+            # don't know how to document this member
+            continue
+        # prefer the documenter with the highest priority
+        classes.sort(key=lambda cls: cls.priority)
+        # give explicitly separated module name, so that members
+        # of inner classes can be documented
+        full_mname = self.modname + '::' + \
+            '.'.join(self.objpath + [mname])
+        documenter = classes[-1](self.directive, full_mname, self.indent)
+        memberdocumenters.append((documenter, isattr))
+    member_order = self.options.member_order or \
+        self.env.config.autodoc_member_order
+    if member_order == 'groupwise':
+        # sort by group; relies on stable sort to keep items in the
+        # same group sorted alphabetically
+        memberdocumenters.sort(key=lambda e: e[0].member_order)
+    elif member_order == 'bysource' and self.analyzer:
+        # sort by source order, by virtue of the module analyzer
+        tagorder = self.analyzer.tagorder
+
+        def keyfunc(entry):
+            # type: (Tuple[Documenter, bool]) -> int
+            fullname = entry[0].name.split('::')[1]
+            return tagorder.get(fullname, len(tagorder))
+        memberdocumenters.sort(key=keyfunc)
+    # N.B. Patch for Drake starts here.
+    elif member_order == 'bycustomfunction':
+
+        def custom_key(entry: Tuple[autodoc.Documenter, bool]) -> Any:
+            result = self.env.app.emit_firstresult(
+                'autodoc-member-order-custom-function', entry[0])
+            if result is None:
+                raise RuntimeError("autodoc-member-order-custom-function "
+                                   "has not been specified by user")
+            return result
+        memberdocumenters.sort(key=custom_key)
+    # Patch ends here.
+
+    for documenter, isattr in memberdocumenters:
+        documenter.generate(
+            all_members=True, real_modname=self.real_modname,
+            check_module=members_check_module and not isattr)
+
+    # reset current objects
+    self.env.temp_data['autodoc:module'] = None
+    self.env.temp_data['autodoc:class'] = None
+
+
+def autodoc_member_order_function(app, documenter):
+    """Let's sort the member full-names (`Class.member_name`) by lower-case."""
+    # N.B. This follows suite with the following 3.x code: https://git.io/Jv1CH
+    fullname = documenter.name.split('::')[1]
+    return fullname.lower()
+
+
 def setup(app):
     """Installs Drake-specific extensions and patches.
     """
@@ -263,6 +357,9 @@ def setup(app):
         patch_class_add_directive_header)
     # Skip specific members.
     app.connect('autodoc-skip-member', autodoc_skip_member)
+    app.add_event('autodoc-member-order-custom-function')
+    app.connect('autodoc-member-order-custom-function',
+                autodoc_member_order_function)
     # Register directive so we can pretty-print template declarations.
     pydoc.PythonDomain.directives['template'] = pydoc.PyClasslike
     # Register autodocumentation for templates.
@@ -273,4 +370,5 @@ def setup(app):
     pydoc.py_sig_re = IrregularExpression(extended=False)
     patch(autodoc.ClassLevelDocumenter, 'resolve_name', patch_resolve_name)
     patch(autodoc.ModuleLevelDocumenter, 'resolve_name', patch_resolve_name)
+    patch(autodoc.Documenter, 'document_members', patch_document_members)
     return dict(parallel_read_safe=True)

--- a/bindings/pydrake/doc/sphinx.LICENSE.txt
+++ b/bindings/pydrake/doc/sphinx.LICENSE.txt
@@ -1,0 +1,280 @@
+License for Sphinx
+==================
+
+Copyright (c) 2007-2018 by the Sphinx team (see AUTHORS file).
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+Licenses for incorporated software
+==================================
+
+The pgen2 package, included in this distribution under the name
+sphinx.pycode.pgen2, is available in the Python 2.6 distribution under
+the PSF license agreement for Python:
+
+----------------------------------------------------------------------
+Copyright © 2001-2008 Python Software Foundation; All Rights Reserved.
+
+PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+--------------------------------------------
+
+1. This LICENSE AGREEMENT is between the Python Software Foundation
+   ("PSF"), and the Individual or Organization ("Licensee") accessing
+   and otherwise using Python 2.6 software in source or binary form
+   and its associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, PSF
+   hereby grants Licensee a nonexclusive, royalty-free, world-wide
+   license to reproduce, analyze, test, perform and/or display
+   publicly, prepare derivative works, distribute, and otherwise use
+   Python 2.6 alone or in any derivative version, provided, however,
+   that PSF's License Agreement and PSF's notice of copyright, i.e.,
+   "Copyright © 2001-2008 Python Software Foundation; All Rights
+   Reserved" are retained in Python 2.6 alone or in any derivative
+   version prepared by Licensee.
+
+3. In the event Licensee prepares a derivative work that is based on
+   or incorporates Python 2.6 or any part thereof, and wants to make
+   the derivative work available to others as provided herein, then
+   Licensee hereby agrees to include in any such work a brief summary
+   of the changes made to Python 2.6.
+
+4. PSF is making Python 2.6 available to Licensee on an "AS IS" basis.
+   PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED.  BY
+   WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND DISCLAIMS ANY
+   REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS FOR ANY
+   PARTICULAR PURPOSE OR THAT THE USE OF PYTHON 2.6 WILL NOT INFRINGE
+   ANY THIRD PARTY RIGHTS.
+
+5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+   2.6 FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS
+   AS A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON
+   2.6, OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY
+   THEREOF.
+
+6. This License Agreement will automatically terminate upon a material
+   breach of its terms and conditions.
+
+7. Nothing in this License Agreement shall be deemed to create any
+   relationship of agency, partnership, or joint venture between PSF
+   and Licensee.  This License Agreement does not grant permission to
+   use PSF trademarks or trade name in a trademark sense to endorse or
+   promote products or services of Licensee, or any third party.
+
+8. By copying, installing or otherwise using Python 2.6, Licensee
+   agrees to be bound by the terms and conditions of this License
+   Agreement.
+----------------------------------------------------------------------
+
+The included smartypants module, included as sphinx.util.smartypants,
+is available under the following license:
+
+----------------------------------------------------------------------
+SmartyPants_ license::
+
+    Copyright (c) 2003 John Gruber
+    (https://daringfireball.net/projects/smartypants/)
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    *   Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+
+    *   Redistributions in binary form must reproduce the above
+        copyright notice, this list of conditions and the following
+        disclaimer in the documentation and/or other materials
+        provided with the distribution.
+
+    *   Neither the name "SmartyPants" nor the names of its
+        contributors may be used to endorse or promote products
+        derived from this software without specific prior written
+        permission.
+
+    This software is provided by the copyright holders and
+    contributors "as is" and any express or implied warranties,
+    including, but not limited to, the implied warranties of
+    merchantability and fitness for a particular purpose are
+    disclaimed. In no event shall the copyright owner or contributors
+    be liable for any direct, indirect, incidental, special,
+    exemplary, or consequential damages (including, but not limited
+    to, procurement of substitute goods or services; loss of use,
+    data, or profits; or business interruption) however caused and on
+    any theory of liability, whether in contract, strict liability, or
+    tort (including negligence or otherwise) arising in any way out of
+    the use of this software, even if advised of the possibility of
+    such damage.
+
+
+smartypants.py license::
+
+    smartypants.py is a derivative work of SmartyPants.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    *   Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+
+    *   Redistributions in binary form must reproduce the above
+        copyright notice, this list of conditions and the following
+        disclaimer in the documentation and/or other materials
+        provided with the distribution.
+
+    This software is provided by the copyright holders and
+    contributors "as is" and any express or implied warranties,
+    including, but not limited to, the implied warranties of
+    merchantability and fitness for a particular purpose are
+    disclaimed. In no event shall the copyright owner or contributors
+    be liable for any direct, indirect, incidental, special,
+    exemplary, or consequential damages (including, but not limited
+    to, procurement of substitute goods or services; loss of use,
+    data, or profits; or business interruption) however caused and on
+    any theory of liability, whether in contract, strict liability, or
+    tort (including negligence or otherwise) arising in any way out of
+    the use of this software, even if advised of the possibility of
+    such damage.
+----------------------------------------------------------------------
+
+The ElementTree package, included in this distribution in
+test/etree13, is available under the following license:
+
+----------------------------------------------------------------------
+The ElementTree toolkit is
+
+Copyright (c) 1999-2007 by Fredrik Lundh
+
+By obtaining, using, and/or copying this software and/or its
+associated documentation, you agree that you have read, understood,
+and will comply with the following terms and conditions:
+
+Permission to use, copy, modify, and distribute this software and its
+associated documentation for any purpose and without fee is hereby
+granted, provided that the above copyright notice appears in all
+copies, and that both that copyright notice and this permission notice
+appear in supporting documentation, and that the name of Secret Labs
+AB or the author not be used in advertising or publicity pertaining to
+distribution of the software without specific, written prior
+permission.
+
+SECRET LABS AB AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO
+THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANT- ABILITY
+AND FITNESS.  IN NO EVENT SHALL SECRET LABS AB OR THE AUTHOR BE LIABLE
+FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+----------------------------------------------------------------------
+
+The included JQuery JavaScript library is available under the MIT
+license:
+
+----------------------------------------------------------------------
+Copyright (c) 2008 John Resig, https://jquery.com/
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+----------------------------------------------------------------------
+
+The included Underscore JavaScript library is available under the MIT
+license:
+
+----------------------------------------------------------------------
+Copyright (c) 2009 Jeremy Ashkenas, DocumentCloud
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+-------------------------------------------------------------------------------
+
+The included implementation of NumpyDocstring._parse_numpydoc_see_also_section
+was derived from code under the following license:
+
+-------------------------------------------------------------------------------
+
+Copyright (C) 2008 Stefan van der Walt <stefan@mentat.za.net>, Pauli Virtanen <pav@iki.fi>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+-------------------------------------------------------------------------------


### PR DESCRIPTION
Towards: https://github.com/RobotLocomotion/drake/issues/12604

PR #12787 was reverted (#12910), due to failures on Mac.
This PR fixes them.

The Mac failures can be reproduced on Linux by:
- `apt-get remove python3-sphinx`.
- `python3.6 -m pip  install sphinx sphinx_rtd_theme`
- `bazel test --test_output=all --nocache_test_results //bindings/pydrake/doc:gen_sphinx_test`

The first commit `652aa39`, has already been reviewed in #12787 .
Please review the  the second one.

Closes #12604 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12921)
<!-- Reviewable:end -->
