### PR TITLE
Add slider-based controller for input ports

### DIFF
--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -295,6 +295,13 @@ drake_py_library(
     ],
 )
 
+drake_py_library(
+    name = "system_sliders_py",
+    srcs = ["system_sliders.py"],
+    imports = PACKAGE_INFO.py_imports,
+    deps = [":module_py"],
+)
+
 PY_LIBRARIES_WITH_INSTALL = [
     ":analysis_py",
     ":controllers_py",
@@ -314,6 +321,7 @@ PY_LIBRARIES = [
     ":perception_py",
     ":planar_scenegraph_visualizer_py",
     ":pyplot_visualizer_py",
+    ":system_sliders_py",
 ]
 
 # Symbol roll-up (for user ease).
@@ -542,6 +550,14 @@ drake_py_unittest(
         ":sensors_py",
         "//bindings/pydrake:geometry_py",
         "//bindings/pydrake/common/test_utilities",
+    ],
+)
+
+drake_py_unittest(
+    name = "system_sliders_test",
+    deps = [
+        ":primitives_py",
+        ":system_sliders_py",
     ],
 )
 

--- a/bindings/pydrake/systems/all.py
+++ b/bindings/pydrake/systems/all.py
@@ -10,6 +10,7 @@ from .pyplot_visualizer import *
 from .rendering import *
 from .scalar_conversion import *
 from .sensors import *
+from .system_sliders import *
 from .trajectory_optimization import *
 
 try:

--- a/bindings/pydrake/systems/system_sliders.py
+++ b/bindings/pydrake/systems/system_sliders.py
@@ -1,0 +1,150 @@
+try:
+    import tkinter as tk
+except ImportError:
+    import Tkinter as tk
+
+import numpy as np
+
+from pydrake.systems.framework import VectorSystem
+
+
+class SystemSliders(VectorSystem):
+    """
+    Provides a set of tcl/tk-based sliders intended to control the values
+    of a system's input port. Each value of the input port gets a float slider.
+    Each slider has can be customized with lower_limit, upper_limit, and
+    resolution. These values can be set generally across all sliders or
+    per slider with a vector of length port_size.
+
+    Note: The sliders can only be manipulated while the simulation is
+    advancing time.
+
+    @warning: Do not close the slider GUI while running a simulation. It will
+    cause the simulation to crash.
+
+    @system{ SystemSliders,
+            , # no input ports
+            @output_port{slider_positions} }
+    """
+    def __init__(self, port_size, slider_names=None,
+                 lower_limit=-10., upper_limit=10.,
+                 resolution=-1, length=200, update_period_sec=0.0166,
+                 window=None, title="System inputs"):
+        """
+        Args:
+            port_size:   Size of the input port that's being controlled. This
+                         is the number of sliders that will show up.
+            slider_names: A list of strings describing the names of the sliders
+                         that should be displayed.
+            lower_limit: The value(s) for the lower limits of each slider. See
+                         class documentation for more details.
+            upper_limit: The value(s) for the upper limits of each slider. See
+                         class documentation for more details.
+            resolution:  A scalar or vector of length port_size
+                         that specifies the discretization that the slider will
+                         be rounded to. Use -1 (the default) to disable any
+                         rounding. For example, a resolution of 0.1 will round
+                         to the neareset 0.1. See class documentation for more
+                         details.
+            length:      The length of the sliders in pixels.
+            update_period_sec: Specifies how often the window update() method
+                         gets called. Smaller values will theoretically make
+                         GUI values available to the simulation more quickly,
+                         but may require the simulation to take more steps than
+                         necessary. The default value is suitable for most
+                         applications.
+            window:      Optionally pass in a tkinter.Tk() object to add these
+                         widgets to.  Default behavior is to create a new
+                         window.
+            title:       The string that appears as the title of the gui
+                         window.  Default title is "System sliders"  This
+                         parameter is only used if window is None.
+        """
+        VectorSystem.__init__(self, 0, port_size)
+
+        if window is None:
+            self.window = tk.Tk()
+            self.window.title(title)
+        else:
+            self.window = window
+
+        self.port_size = port_size
+
+        if slider_names is None:
+            slider_names = ["Index " + str(i) for i in range(self.port_size)]
+        if len(slider_names) != self.port_size:
+            raise ValueError(
+                f"Slider names size ({len(slider_names)}) doesn't "
+                f"match port size ({self.port_size})")
+
+        def input_to_vector(x, desc):
+            """
+            Turn scalar inputs into vector of size self.port_size.
+            Throws error if vector input is the wrong size,
+            otherwise returning the vector.
+
+            Args:
+                x: scalar or vector input.
+                desc: string describing the vector, used in error message.
+            """
+            if np.isscalar(x):
+                return np.repeat(x, self.port_size)
+
+            if len(x) == self.port_size:
+                return x
+
+            raise ValueError(
+                f"Size of {desc} ({len(x)}) doesn't "
+                f"match port size ({self.port_size})"
+            )
+
+        lower_limit = input_to_vector(lower_limit, "lower_limit")
+        upper_limit = input_to_vector(upper_limit, "upper_limit")
+        resolution = input_to_vector(resolution, "resolution")
+
+        # Schedule window updates in either case (new or existing window):
+        self.DeclarePeriodicPublish(update_period_sec, 0.0)
+
+        self._sliders = []
+
+        # TODO: support a scroll bar for larger input sizes
+        for i in range(self.port_size):
+            slider = tk.Scale(self.window,
+                              from_=lower_limit[i],
+                              to=upper_limit[i],
+                              resolution=resolution[i],
+                              label=slider_names[i],
+                              length=length,
+                              orient=tk.HORIZONTAL)
+            slider.pack()
+            self._sliders.append(slider)
+
+    def set_position(self, q):
+        """
+        Sets all slider positions to the values in q.
+
+        Args:
+            q: a vector whose length is self.port_size.
+        """
+        if len(q) != self.port_size:
+            raise ValueError(
+                f"Size of q ({len(q)}) doesn't match input "
+                f"port size ({self.port_size})")
+        for i in range(self.port_size):
+            self._sliders[i].set(q[i])
+
+    # TODO(SeanCurtis-TRI): This is technically making a change to system
+    # "state" (the state of the tk window). It's not contained in the
+    # context, which is why we can get away with it. However, it would
+    # be better to add a discrete state vector that gets updated values
+    # from the sliders (and handles the slider update at that time) and
+    # update that in in a DiscreteUpdate.
+    def DoPublish(self, context, event):
+        # GUI functionality is not automatically tested
+        # Must manually test this function to ensure updates run properly
+        self.window.update_idletasks()
+        self.window.update()
+
+    def DoCalcVectorOutput(self, context, unused, unused2, output):
+        for i in range(self.port_size):
+            output[i] = self._sliders[i].get()

--- a/bindings/pydrake/systems/test/system_sliders_test.py
+++ b/bindings/pydrake/systems/test/system_sliders_test.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+
+import numpy as np
+try:
+    import tkinter as tk
+except ImportError:
+    import Tkinter as tk
+
+from pydrake.systems.system_sliders import SystemSliders
+
+
+class TestSystemSliders(unittest.TestCase):
+    def test_multibody_plant_slider(self):
+        # Tests that the UI loads and produces the output, the
+        # size of the output port is correct, and appropriate
+        # errors are thrown for incorrect usage.
+        port_size = 3
+        slider = SystemSliders(port_size,
+                               slider_names=["x", "y", "z"], lower_limit=-5.,
+                               upper_limit=[5., 1., 10.], resolution=0.001,
+                               update_period_sec=0.01, title='test',
+                               length=300)
+        slider.window.withdraw()  # Don't open a window during testing.
+        context = slider.CreateDefaultContext()
+        output = slider.AllocateOutput()
+
+        # Input size matches output size.
+        self.assertEqual(
+            slider.get_output_port(0).size(),
+            port_size
+        )
+
+        # Valid position.
+        q = [.1, 0, 5]
+        slider.set_position(q)
+        slider.CalcOutput(context, output)
+        np.testing.assert_array_equal(output.get_vector_data(0).get_value(), q)
+
+        # Outside of upper limits.
+        q = [10, 10, 10]
+        slider.set_position(q)
+        slider.CalcOutput(context, output)
+        np.testing.assert_array_equal(
+            output.get_vector_data(0).get_value(), [5., 1., 10.])
+
+        # Outside of lower limits.
+        # We set lower limit to -5 by scalar value and we indirectly confirm
+        # that all slider lower limits got set to that scalar by setting all
+        # sliders to a value lower than that lower limit and observing that
+        # they get clamped to the same value.
+        q = [-10, -10, -10]
+        slider.set_position(q)
+        slider.CalcOutput(context, output)
+        np.testing.assert_array_equal(
+            output.get_vector_data(0).get_value(), [-5, -5, -5])
+
+        # Incorrect size of q when setting slider positions.
+        with self.assertRaisesRegex(ValueError, "Size of q \(2\) doesn't " +
+                                                "match input port size \(3\)"
+                                    ):
+            slider.set_position([2, 4])
+
+        # Incorrect size of passed in slider names.
+        with self.assertRaisesRegex(ValueError, "Slider names size \(2\) " +
+                                                "doesn't match port size \(3\)"
+                                    ):
+            SystemSliders(port_size, slider_names=["a", "b"])
+
+        # Incorrect size of passed in lower limits.
+        with self.assertRaisesRegex(ValueError, "Size of lower_limit \(4\) " +
+                                                "doesn't match port size \(3\)"
+                                    ):
+            SystemSliders(port_size, lower_limit=[2, 3, 4, 5])
+
+        # Incorrect size of passed in upper limits.
+        with self.assertRaisesRegex(ValueError, "Size of upper_limit \(0\) " +
+                                                "doesn't match port size \(3\)"
+                                    ):
+            SystemSliders(port_size, upper_limit=[])
+
+        # Incorrect size of passed in resolutions.
+        with self.assertRaisesRegex(ValueError, "Size of resolution \(5\) " +
+                                                "doesn't match port size \(3\)"
+                                    ):
+            SystemSliders(port_size, resolution=[1, 2, 3, 4, 5])


### PR DESCRIPTION
# Description
Pass in an arbitrary port for a Drake system and it produces tk sliders to control them. Useful for testing simulation models quickly
![2020-03-23-1584990683_screenshot_229x165](https://user-images.githubusercontent.com/13571695/77354104-96828400-6d18-11ea-8d08-86bb288cdcd5.jpg)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12925)
<!-- Reviewable:end -->
