### PR TITLE
Rename `InitialValueProblem::SpecifiedValues` to `ODEContext`

### DIFF
--- a/multibody/tree/test/door_hinge_test.cc
+++ b/multibody/tree/test/door_hinge_test.cc
@@ -154,7 +154,7 @@ class DoorHingeTest : public ::testing::Test {
     const VectorX<double> init_state =
         (VectorX<double>(3) << 0.0, 0.0, angular_rate).finished();
 
-    const systems::InitialValueProblem<double>::SpecifiedValues default_values(
+    const systems::InitialValueProblem<double>::OdeContext default_values(
         kInitialTime, init_state, kDefaultParameters);
     systems::InitialValueProblem<double> ivp(energy_ode, default_values);
     ivp.get_mutable_integrator().set_target_accuracy(kIntegrationAccuracy);

--- a/systems/analysis/antiderivative_function.h
+++ b/systems/analysis/antiderivative_function.h
@@ -74,7 +74,7 @@ class AntiderivativeFunction {
                               const std::optional<VectorX<T>>& k_in)
         : v(v_in), k(k_in) {}
 
-    std::optional<T> v;  ///< The lower integration bound v.
+    std::optional<T> v;           ///< The lower integration bound v.
     std::optional<VectorX<T>> k;  ///< The parameter vector 𝐤.
   };
 
@@ -96,8 +96,8 @@ class AntiderivativeFunction {
                          const IntegrableFunctionContext& default_values = {}) {
     // Expresses the scalar integral to be solved as an ODE.
     typename ScalarInitialValueProblem<T>::ScalarOdeFunction
-        scalar_ode_function = [integrable_function](
-            const T& t, const T& x, const VectorX<T>& k) -> T {
+        scalar_ode_function = [integrable_function](const T& t, const T& x,
+                                                    const VectorX<T>& k) -> T {
       unused(x);
       return integrable_function(t, k);
     };
@@ -106,8 +106,8 @@ class AntiderivativeFunction {
         scalar_ivp_default_values;
     // Default initial time for the scalar ODE form falls back
     // to 0 if no lower integration bound is specified.
-    scalar_ivp_default_values.t0 = default_values.v.value_or(
-        static_cast<T>(0.0));
+    scalar_ivp_default_values.t0 =
+        default_values.v.value_or(static_cast<T>(0.0));
     // Default initial state for the scalar ODE form is set to 0.
     scalar_ivp_default_values.x0 = static_cast<T>(0.0);
     // Default parameter vector for the scalar ODE falls back to
@@ -134,8 +134,8 @@ class AntiderivativeFunction {
   ///      values given on construction.
   /// @throws std::logic_error if any of the preconditions is not met.
   T Evaluate(const T& u, const IntegrableFunctionContext& values = {}) const {
-    typename ScalarInitialValueProblem<T>::ScalarOdeContext
-        scalar_ivp_values(values.v, {}, values.k);
+    typename ScalarInitialValueProblem<T>::ScalarOdeContext scalar_ivp_values(
+        values.v, {}, values.k);
     return scalar_ivp_->Solve(u, scalar_ivp_values);
   }
 
@@ -171,8 +171,8 @@ class AntiderivativeFunction {
       const T& w, const IntegrableFunctionContext& values = {}) const {
     // Delegates request to the scalar IVP used for computations, by putting
     // specified values in scalar IVP terms.
-    typename ScalarInitialValueProblem<T>::ScalarOdeContext
-        scalar_ivp_values(values.v, {}, values.k);
+    typename ScalarInitialValueProblem<T>::ScalarOdeContext scalar_ivp_values(
+        values.v, {}, values.k);
     return this->scalar_ivp_->DenseSolve(w, scalar_ivp_values);
   }
 

--- a/systems/analysis/initial_value_problem.cc
+++ b/systems/analysis/initial_value_problem.cc
@@ -37,19 +37,16 @@ class OdeSystem : public LeafSystem<T> {
   // @param state_model The state model vector 𝐱₀, with initial values.
   // @param param_model The parameter model vector 𝐤₀, with default values.
   OdeSystem(const SystemFunction& system_function,
-            const VectorX<T>& state_model,
-            const VectorX<T>& param_model);
+            const VectorX<T>& state_model, const VectorX<T>& param_model);
 
  protected:
-  void DoCalcTimeDerivatives(
-      const Context<T>& context,
-      ContinuousState<T>* derivatives) const override;
+  void DoCalcTimeDerivatives(const Context<T>& context,
+                             ContinuousState<T>* derivatives) const override;
 
  private:
   // General ODE system d𝐱/dt = f(t, 𝐱; 𝐤) function.
   const SystemFunction system_function_;
 };
-
 
 template <typename T>
 OdeSystem<T>::OdeSystem(
@@ -70,10 +67,9 @@ void OdeSystem<T>::DoCalcTimeDerivatives(
   // a BasicVector<T>, and the implementation deals with LeafSystem<T>
   // instances only by design.
   const BasicVector<T>& state_vector = dynamic_cast<const BasicVector<T>&>(
-          context.get_continuous_state_vector());
+      context.get_continuous_state_vector());
   // Retrieves the parameter vector.
-  const BasicVector<T>& parameter_vector =
-      context.get_numeric_parameter(0);
+  const BasicVector<T>& parameter_vector = context.get_numeric_parameter(0);
 
   // Retrieves the derivatives vector. This cast is safe because the
   // ContinuousState<T> of a LeafSystem<T> is flat i.e. it is just
@@ -83,28 +79,26 @@ void OdeSystem<T>::DoCalcTimeDerivatives(
       dynamic_cast<BasicVector<T>&>(derivatives->get_mutable_vector());
   // Computes the derivatives vector using the given system function
   // for the given time and state and with the given parameterization.
-  derivatives_vector.set_value(system_function_(
-      context.get_time(), state_vector.get_value(),
-      parameter_vector.get_value()));
+  derivatives_vector.set_value(system_function_(context.get_time(),
+                                                state_vector.get_value(),
+                                                parameter_vector.get_value()));
 }
 
 }  // namespace
 
-template<typename T>
+template <typename T>
 const double InitialValueProblem<T>::kDefaultAccuracy = 1e-4;
 
-template<typename T>
+template <typename T>
 const T InitialValueProblem<T>::kInitialStepSize = static_cast<T>(1e-4);
 
-template<typename T>
+template <typename T>
 const T InitialValueProblem<T>::kMaxStepSize = static_cast<T>(1e-1);
 
 template <typename T>
-InitialValueProblem<T>::InitialValueProblem(
-    const OdeFunction& ode_function,
-    const OdeContext& default_values)
-    : default_values_(default_values),
-      current_values_(default_values) {
+InitialValueProblem<T>::InitialValueProblem(const OdeFunction& ode_function,
+                                            const OdeContext& default_values)
+    : default_values_(default_values), current_values_(default_values) {
   // Checks that preconditions are met.
   if (!default_values_.t0) {
     throw std::logic_error("No default initial time t0 was given.");
@@ -125,21 +119,19 @@ InitialValueProblem<T>::InitialValueProblem(
   context_->SetTime(default_values_.t0.value());
 
   // Instantiates an explicit RK3 integrator by default.
-  integrator_ = std::make_unique<RungeKutta3Integrator<T>>(
-      *system_, context_.get());
+  integrator_ =
+      std::make_unique<RungeKutta3Integrator<T>>(*system_, context_.get());
 
   // Sets step size and accuracy defaults.
   integrator_->request_initial_step_size_target(
       InitialValueProblem<T>::kInitialStepSize);
-  integrator_->set_maximum_step_size(
-      InitialValueProblem<T>::kMaxStepSize);
-  integrator_->set_target_accuracy(
-      InitialValueProblem<T>::kDefaultAccuracy);
+  integrator_->set_maximum_step_size(InitialValueProblem<T>::kMaxStepSize);
+  integrator_->set_target_accuracy(InitialValueProblem<T>::kDefaultAccuracy);
 }
 
 template <typename T>
-VectorX<T> InitialValueProblem<T>::Solve(
-    const T& tf, const OdeContext& values) const {
+VectorX<T> InitialValueProblem<T>::Solve(const T& tf,
+                                         const OdeContext& values) const {
   // Gets all values to solve with, either given or default, while
   // checking that all preconditions hold.
   const OdeContext safe_values = SanitizeValuesOrThrow(tf, values);
@@ -165,8 +157,7 @@ VectorX<T> InitialValueProblem<T>::Solve(
 }
 
 template <typename T>
-void InitialValueProblem<T>::ResetCachedState(
-    const OdeContext& values) const {
+void InitialValueProblem<T>::ResetCachedState(const OdeContext& values) const {
   // Sets context (initial) time.
   context_->SetTime(values.t0.value());
 
@@ -179,8 +170,7 @@ void InitialValueProblem<T>::ResetCachedState(
   state_vector.set_value(values.x0.value());
 
   // Sets context parameters.
-  BasicVector<T>& parameter_vector =
-      context_->get_mutable_numeric_parameter(0);
+  BasicVector<T>& parameter_vector = context_->get_mutable_numeric_parameter(0);
   parameter_vector.set_value(values.k.value());
 
   // Keeps track of current step size and accuracy settings (regardless
@@ -218,23 +208,26 @@ void InitialValueProblem<T>::ResetCachedStateIfNecessary(
 
 template <typename T>
 typename InitialValueProblem<T>::OdeContext
-InitialValueProblem<T>::SanitizeValuesOrThrow(
-    const T& tf, const OdeContext& values) const {
+InitialValueProblem<T>::SanitizeValuesOrThrow(const T& tf,
+                                              const OdeContext& values) const {
   OdeContext safe_values;
   safe_values.t0 = values.t0.has_value() ? values.t0 : default_values_.t0;
   if (tf < safe_values.t0.value()) {
-    throw std::logic_error("Cannot solve IVP for a time"
-                           " before the initial condition.");
+    throw std::logic_error(
+        "Cannot solve IVP for a time"
+        " before the initial condition.");
   }
   safe_values.x0 = values.x0.has_value() ? values.x0 : default_values_.x0;
   if (safe_values.x0.value().size() != default_values_.x0.value().size()) {
-    throw std::logic_error("IVP initial state vector x0 is"
-                           " of the wrong dimension.");
+    throw std::logic_error(
+        "IVP initial state vector x0 is"
+        " of the wrong dimension.");
   }
   safe_values.k = values.k.has_value() ? values.k : default_values_.k;
   if (safe_values.k.value().size() != default_values_.k.value().size()) {
-    throw std::logic_error("IVP parameters vector k is "
-                           " of the wrong dimension");
+    throw std::logic_error(
+        "IVP parameters vector k is "
+        " of the wrong dimension");
   }
   return safe_values;
 }

--- a/systems/analysis/initial_value_problem.h
+++ b/systems/analysis/initial_value_problem.h
@@ -73,31 +73,35 @@ class InitialValueProblem {
   /// @param x The dependent vector variable 𝐱 ∈ ℝⁿ.
   /// @param k The vector of parameters 𝐤 ∈ ℝᵐ.
   /// @return The derivative vector d𝐱/dt ∈ ℝⁿ.
-  using ODEFunction = std::function<VectorX<T> (
+  using OdeFunction = std::function<VectorX<T> (
       const T& t, const VectorX<T>& x, const VectorX<T>& k)>;
+
+  DRAKE_DEPRECATED("2020-07-01", "ODEFunction has been renamed OdeFunction.")
+  typedef OdeFunction ODEFunction;
 
   /// A collection of values i.e. initial time t₀, initial state vector 𝐱₀
   /// and parameters vector 𝐤.to further specify the ODE system (in order
-  /// to become an initial value problem).
-  struct SpecifiedValues {
+  /// to become an initial value problem).  This places the same role as
+  /// systems::Context, but is intentionally much simpler.
+  struct OdeContext {
     /// Default constructor, leaving all values unspecified.
-    SpecifiedValues() = default;
+    OdeContext() = default;
 
     /// Constructor specifying all values.
     ///
     /// @param t0_in Specified initial time t₀.
     /// @param x0_in Specified initial state vector 𝐱₀.
     /// @param k_in Specified parameter vector 𝐤.
-    SpecifiedValues(const std::optional<T>& t0_in,
+    OdeContext(const std::optional<T>& t0_in,
                     const std::optional<VectorX<T>>& x0_in,
                     const std::optional<VectorX<T>>& k_in)
         : t0(t0_in), x0(x0_in), k(k_in) {}
 
-    bool operator==(const SpecifiedValues& rhs) const {
+    bool operator==(const OdeContext& rhs) const {
       return (t0 == rhs.t0 && x0 == rhs.x0 && k == rhs.k);
     }
 
-    bool operator!=(const SpecifiedValues& rhs) const {
+    bool operator!=(const OdeContext& rhs) const {
       return !operator==(rhs);
     }
 
@@ -105,6 +109,10 @@ class InitialValueProblem {
     std::optional<VectorX<T>> x0;  ///< The initial state vector 𝐱₀ for the IVP.
     std::optional<VectorX<T>> k;  ///< The parameter vector 𝐤 for the IVP.
   };
+
+  DRAKE_DEPRECATED("2020-07-01",
+                   "SpecifiedValues has been renamed OdeContext.")
+  typedef OdeContext SpecifiedValues;
 
   /// Constructs an IVP described by the given @p ode_function, using
   /// given @p default_values.t0 and @p default_values.x0 as initial
@@ -119,8 +127,8 @@ class InitialValueProblem {
   /// @pre An initial state vector @p default_values.x0 is given.
   /// @pre A parameter vector @p default_values.k is given.
   /// @throws std::logic_error if preconditions are not met.
-  InitialValueProblem(const ODEFunction& ode_function,
-                      const SpecifiedValues& default_values);
+  InitialValueProblem(const OdeFunction& ode_function,
+                      const OdeContext& default_values);
 
   /// Solves the IVP for time @p tf, using the initial time t₀, initial state
   /// vector 𝐱₀ and parameter vector 𝐤 present in @p values, falling back to
@@ -138,7 +146,7 @@ class InitialValueProblem {
   ///      must match that of the parameter vector in the default specified
   ///      values given on construction.
   /// @throws std::logic_error if preconditions are not met.
-  VectorX<T> Solve(const T& tf, const SpecifiedValues& values = {}) const;
+  VectorX<T> Solve(const T& tf, const OdeContext& values = {}) const;
 
   /// Solves and yields an approximation of the IVP solution x(t; 𝐤) for
   /// the closed time interval between the initial time t₀ and the given final
@@ -168,7 +176,7 @@ class InitialValueProblem {
   ///      values given on construction.
   /// @throws std::logic_error if any of the preconditions is not met.
   std::unique_ptr<DenseOutput<T>> DenseSolve(
-      const T& tf, const SpecifiedValues& values = {}) const;
+      const T& tf, const OdeContext& values = {}) const;
 
   /// Resets the internal integrator instance by in-place
   /// construction of the given integrator type.
@@ -219,11 +227,11 @@ class InitialValueProblem {
   //                          InitialValueProblem::Solve() and
   //                          InitialValueProblem::DenseSolve()
   //                          do not hold.
-  SpecifiedValues SanitizeValuesOrThrow(
-      const T& tf, const SpecifiedValues& values) const;
+  OdeContext SanitizeValuesOrThrow(
+      const T& tf, const OdeContext& values) const;
 
   // IVP values specified by default.
-  const SpecifiedValues default_values_;
+  const OdeContext default_values_;
 
   // @name Caching support
   //
@@ -236,17 +244,17 @@ class InitialValueProblem {
 
   // Invalidates and initializes cached IVP specified values and
   // integration context based on the newly provided @p values.
-  void ResetCachedState(const SpecifiedValues& values) const;
+  void ResetCachedState(const OdeContext& values) const;
 
   // Conditionally invalidates and initializes cached IVP specified
   // values and integration context based on time @p tf to solve for
   // and the provided @p values. If cached state can be reused, it's a
   // no-op.
   void ResetCachedStateIfNecessary(
-      const T& tf, const SpecifiedValues& values) const;
+      const T& tf, const OdeContext& values) const;
 
   // IVP current specified values (for caching).
-  mutable SpecifiedValues current_values_;
+  mutable OdeContext current_values_;
 
   // IVP ODE solver integration context.
   std::unique_ptr<Context<T>> context_;

--- a/systems/analysis/initial_value_problem.h
+++ b/systems/analysis/initial_value_problem.h
@@ -73,8 +73,8 @@ class InitialValueProblem {
   /// @param x The dependent vector variable 𝐱 ∈ ℝⁿ.
   /// @param k The vector of parameters 𝐤 ∈ ℝᵐ.
   /// @return The derivative vector d𝐱/dt ∈ ℝⁿ.
-  using OdeFunction = std::function<VectorX<T> (
-      const T& t, const VectorX<T>& x, const VectorX<T>& k)>;
+  using OdeFunction = std::function<VectorX<T>(const T& t, const VectorX<T>& x,
+                                               const VectorX<T>& k)>;
 
   DRAKE_DEPRECATED("2020-07-01", "ODEFunction has been renamed OdeFunction.")
   typedef OdeFunction ODEFunction;
@@ -93,25 +93,22 @@ class InitialValueProblem {
     /// @param x0_in Specified initial state vector 𝐱₀.
     /// @param k_in Specified parameter vector 𝐤.
     OdeContext(const std::optional<T>& t0_in,
-                    const std::optional<VectorX<T>>& x0_in,
-                    const std::optional<VectorX<T>>& k_in)
+               const std::optional<VectorX<T>>& x0_in,
+               const std::optional<VectorX<T>>& k_in)
         : t0(t0_in), x0(x0_in), k(k_in) {}
 
     bool operator==(const OdeContext& rhs) const {
       return (t0 == rhs.t0 && x0 == rhs.x0 && k == rhs.k);
     }
 
-    bool operator!=(const OdeContext& rhs) const {
-      return !operator==(rhs);
-    }
+    bool operator!=(const OdeContext& rhs) const { return !operator==(rhs); }
 
-    std::optional<T> t0;  ///< The initial time t₀ for the IVP.
+    std::optional<T> t0;           ///< The initial time t₀ for the IVP.
     std::optional<VectorX<T>> x0;  ///< The initial state vector 𝐱₀ for the IVP.
     std::optional<VectorX<T>> k;  ///< The parameter vector 𝐤 for the IVP.
   };
 
-  DRAKE_DEPRECATED("2020-07-01",
-                   "SpecifiedValues has been renamed OdeContext.")
+  DRAKE_DEPRECATED("2020-07-01", "SpecifiedValues has been renamed OdeContext.")
   typedef OdeContext SpecifiedValues;
 
   /// Constructs an IVP described by the given @p ode_function, using
@@ -196,8 +193,8 @@ class InitialValueProblem {
   ///          InitialValueProblem::get_mutable_integrator().
   template <typename Integrator, typename... Args>
   Integrator* reset_integrator(Args&&... args) {
-    integrator_ = std::make_unique<Integrator>(
-        *system_, std::forward<Args>(args)...);
+    integrator_ =
+        std::make_unique<Integrator>(*system_, std::forward<Args>(args)...);
     integrator_->reset_context(context_.get());
     return static_cast<Integrator*>(integrator_.get());
   }
@@ -227,8 +224,7 @@ class InitialValueProblem {
   //                          InitialValueProblem::Solve() and
   //                          InitialValueProblem::DenseSolve()
   //                          do not hold.
-  OdeContext SanitizeValuesOrThrow(
-      const T& tf, const OdeContext& values) const;
+  OdeContext SanitizeValuesOrThrow(const T& tf, const OdeContext& values) const;
 
   // IVP values specified by default.
   const OdeContext default_values_;
@@ -250,8 +246,7 @@ class InitialValueProblem {
   // values and integration context based on time @p tf to solve for
   // and the provided @p values. If cached state can be reused, it's a
   // no-op.
-  void ResetCachedStateIfNecessary(
-      const T& tf, const OdeContext& values) const;
+  void ResetCachedStateIfNecessary(const T& tf, const OdeContext& values) const;
 
   // IVP current specified values (for caching).
   mutable OdeContext current_values_;

--- a/systems/analysis/scalar_initial_value_problem.h
+++ b/systems/analysis/scalar_initial_value_problem.h
@@ -58,8 +58,8 @@ class ScalarInitialValueProblem {
   /// @param x The dependent variable x ∈ ℝ .
   /// @param k The parameter vector 𝐤 ∈ ℝᵐ.
   /// @return The derivative dx/dt ∈ ℝ.
-  using ScalarOdeFunction = std::function<T(const T& t, const T& x,
-                                            const VectorX<T>& k)>;
+  using ScalarOdeFunction =
+      std::function<T(const T& t, const T& x, const VectorX<T>& k)>;
 
   DRAKE_DEPRECATED("2020-07-01",
                    "ScalarODEFunction has been renamed "
@@ -83,8 +83,8 @@ class ScalarInitialValueProblem {
                      const std::optional<VectorX<T>>& k_in)
         : t0(t0_in), x0(x0_in), k(k_in) {}
 
-    std::optional<T> t0;  ///< The initial time t₀ for the IVP.
-    std::optional<T> x0;  ///< The initial state x₀ for the IVP.
+    std::optional<T> t0;          ///< The initial time t₀ for the IVP.
+    std::optional<T> x0;          ///< The initial state x₀ for the IVP.
     std::optional<VectorX<T>> k;  ///< The parameter vector 𝐤 for the IVP.
   };
 
@@ -210,16 +210,15 @@ class ScalarInitialValueProblem {
  private:
   // Transforms given scalar IVP specified @p values into vector
   // IVP specified values.
-  static typename InitialValueProblem<T>::OdeContext
-  ToVectorIVPOdeContext(const ScalarOdeContext& values) {
+  static typename InitialValueProblem<T>::OdeContext ToVectorIVPOdeContext(
+      const ScalarOdeContext& values) {
     typename InitialValueProblem<T>::OdeContext vector_ivp_values;
     vector_ivp_values.k = values.k;
     vector_ivp_values.t0 = values.t0;
     if (values.x0.has_value()) {
       // Scalar initial state x₀ as a vector initial state 𝐱₀
       // of a single dimension.
-      vector_ivp_values.x0 = VectorX<T>::Constant(
-          1, values.x0.value()).eval();
+      vector_ivp_values.x0 = VectorX<T>::Constant(1, values.x0.value()).eval();
     }
     return vector_ivp_values;
   }

--- a/systems/analysis/scalar_initial_value_problem.h
+++ b/systems/analysis/scalar_initial_value_problem.h
@@ -58,30 +58,39 @@ class ScalarInitialValueProblem {
   /// @param x The dependent variable x ∈ ℝ .
   /// @param k The parameter vector 𝐤 ∈ ℝᵐ.
   /// @return The derivative dx/dt ∈ ℝ.
-  using ScalarODEFunction = std::function<T(const T& t, const T& x,
+  using ScalarOdeFunction = std::function<T(const T& t, const T& x,
                                             const VectorX<T>& k)>;
+
+  DRAKE_DEPRECATED("2020-07-01",
+                   "ScalarODEFunction has been renamed "
+                   "ScalarOdeFunction.")
+  typedef ScalarOdeFunction ScalarODEFunction;
 
   /// A collection of values i.e. initial time t₀, initial state x₀
   /// and parameter vector 𝐤 to further specify the ODE system (in
   /// order to become a scalar initial value problem).
-  struct SpecifiedValues {
+  struct ScalarOdeContext {
     /// Default constructor, leaving all values unspecified.
-    SpecifiedValues() = default;
+    ScalarOdeContext() = default;
 
     /// Constructor specifying all values.
     ///
     /// @param t0_in Specified initial time t₀.
     /// @param x0_in Specified initial state x₀.
     /// @param k_in Specified parameter vector 𝐤.
-    SpecifiedValues(const std::optional<T>& t0_in,
-                    const std::optional<T>& x0_in,
-                    const std::optional<VectorX<T>>& k_in)
+    ScalarOdeContext(const std::optional<T>& t0_in,
+                     const std::optional<T>& x0_in,
+                     const std::optional<VectorX<T>>& k_in)
         : t0(t0_in), x0(x0_in), k(k_in) {}
 
     std::optional<T> t0;  ///< The initial time t₀ for the IVP.
     std::optional<T> x0;  ///< The initial state x₀ for the IVP.
     std::optional<VectorX<T>> k;  ///< The parameter vector 𝐤 for the IVP.
   };
+
+  DRAKE_DEPRECATED("2020-07-01",
+                   "SpecifiedValues has been renamed ScalarOdeContext.")
+  typedef ScalarOdeContext SpecifiedValues;
 
   /// Constructs an scalar IVP described by the given @p scalar_ode_function,
   /// using given @p default_values.t0 and @p default_values.x0 as initial
@@ -96,17 +105,17 @@ class ScalarInitialValueProblem {
   /// @pre An initial state @p default_values.x0 is provided.
   /// @pre An parameter vector @p default_values.k is provided.
   /// @throws std::logic_error if preconditions are not met.
-  ScalarInitialValueProblem(const ScalarODEFunction& scalar_ode_function,
-                            const SpecifiedValues& default_values) {
+  ScalarInitialValueProblem(const ScalarOdeFunction& scalar_ode_function,
+                            const ScalarOdeContext& default_values) {
     // Wraps the given scalar ODE function as a vector ODE function.
-    typename InitialValueProblem<T>::ODEFunction ode_function =
+    typename InitialValueProblem<T>::OdeFunction ode_function =
         [scalar_ode_function](const T& t, const VectorX<T>& x,
                               const VectorX<T>& k) -> VectorX<T> {
       return VectorX<T>::Constant(1, scalar_ode_function(t, x[0], k));
     };
     // Instantiates the vector initial value problem.
     vector_ivp_ = std::make_unique<InitialValueProblem<T>>(
-        ode_function, ToVectorIVPSpecifiedValues(default_values));
+        ode_function, ToVectorIVPOdeContext(default_values));
   }
 
   /// Solves the IVP for time @p tf, using the initial time t₀, initial state
@@ -122,8 +131,8 @@ class ScalarInitialValueProblem {
   ///      must match that of the parameter vector in the default specified
   ///      values given on construction.
   /// @throws std::logic_error if any of the preconditions is not met.
-  T Solve(const T& tf, const SpecifiedValues& values = {}) const {
-    return this->vector_ivp_->Solve(tf, ToVectorIVPSpecifiedValues(values))[0];
+  T Solve(const T& tf, const ScalarOdeContext& values = {}) const {
+    return this->vector_ivp_->Solve(tf, ToVectorIVPOdeContext(values))[0];
   }
 
   /// Solves and yields an approximation of the IVP solution x(t; 𝐤) for the
@@ -155,13 +164,13 @@ class ScalarInitialValueProblem {
   ///      values given on construction.
   /// @throws std::logic_error if any of the preconditions is not met.
   std::unique_ptr<ScalarDenseOutput<T>> DenseSolve(
-      const T& tf, const SpecifiedValues& values = {}) const {
+      const T& tf, const ScalarOdeContext& values = {}) const {
     // Delegates request to the vector form of this IVP by putting
     // specified values in vector form and the resulting dense output
     // back into scalar form.
     const int kDimension = 0;
     std::unique_ptr<DenseOutput<T>> vector_dense_output =
-        this->vector_ivp_->DenseSolve(tf, ToVectorIVPSpecifiedValues(values));
+        this->vector_ivp_->DenseSolve(tf, ToVectorIVPOdeContext(values));
     return std::make_unique<ScalarViewDenseOutput<T>>(
         std::move(vector_dense_output), kDimension);
   }
@@ -201,9 +210,9 @@ class ScalarInitialValueProblem {
  private:
   // Transforms given scalar IVP specified @p values into vector
   // IVP specified values.
-  static typename InitialValueProblem<T>::SpecifiedValues
-  ToVectorIVPSpecifiedValues(const SpecifiedValues& values) {
-    typename InitialValueProblem<T>::SpecifiedValues vector_ivp_values;
+  static typename InitialValueProblem<T>::OdeContext
+  ToVectorIVPOdeContext(const ScalarOdeContext& values) {
+    typename InitialValueProblem<T>::OdeContext vector_ivp_values;
     vector_ivp_values.k = values.k;
     vector_ivp_values.t0 = values.t0;
     if (values.x0.has_value()) {

--- a/systems/analysis/test/antiderivative_function_test.cc
+++ b/systems/analysis/test/antiderivative_function_test.cc
@@ -24,8 +24,8 @@ GTEST_TEST(AntiderivativeFunctionTest, UsingMultipleIntegrators) {
   const VectorX<double> kDefaultParameters =
       VectorX<double>::Constant(2, 1.0);
   // All specified values by default, for function definition.
-  const AntiderivativeFunction<double>::SpecifiedValues kDefaultValues(
-      kDefaultLowerIntegrationBound, kDefaultParameters);
+  const AntiderivativeFunction<double>::IntegrableFunctionContext
+      kDefaultValues(kDefaultLowerIntegrationBound, kDefaultParameters);
 
   // Defines an antiderivative function for f(x; 𝐤) = k₁ * x + k₂.
   AntiderivativeFunction<double> antiderivative_function(
@@ -56,7 +56,7 @@ GTEST_TEST(AntiderivativeFunctionTest, UsingMultipleIntegrators) {
   // integration lower bound.
   const VectorX<double> k2 = VectorX<double>::Constant(2, 5.0);
   const double u2 = kDefaultLowerIntegrationBound + 15.0;
-  AntiderivativeFunction<double>::SpecifiedValues values;
+  AntiderivativeFunction<double>::IntegrableFunctionContext values;
   values.k = k2;
   // Testing against closed form solution of above's integral, which
   // can be written as F(u; 𝐤) = k₀/2 * u^2 + k₁ * u for the specified
@@ -75,8 +75,8 @@ GTEST_TEST(AntiderivativeFunctionTest, EvaluatePreconditionValidation) {
   const VectorX<double> kDefaultParameters =
       VectorX<double>::Constant(2, 1.0);
   // All specified values by default, for function definition.
-  const AntiderivativeFunction<double>::SpecifiedValues kDefaultValues(
-      kDefaultLowerIntegrationBound, kDefaultParameters);
+  const AntiderivativeFunction<double>::IntegrableFunctionContext
+      kDefaultValues(kDefaultLowerIntegrationBound, kDefaultParameters);
 
   // Defines a antiderivative function for f(x; 𝐤) = k₀ * x + k₁.
   const AntiderivativeFunction<double> antiderivative_function(
@@ -115,28 +115,28 @@ GTEST_TEST(AntiderivativeFunctionTest, EvaluatePreconditionValidation) {
       std::logic_error, kInvalidIntegrationBoundErrorMessage);
 
   DRAKE_EXPECT_THROWS_MESSAGE({
-      AntiderivativeFunction<double>::SpecifiedValues values;
+      AntiderivativeFunction<double>::IntegrableFunctionContext values;
       values.k = kInvalidParameters;
       antiderivative_function.Evaluate(
           kValidUpperIntegrationBound, values);
     }, std::logic_error, kInvalidParametersErrorMessage);
 
   DRAKE_EXPECT_THROWS_MESSAGE({
-      AntiderivativeFunction<double>::SpecifiedValues values;
+      AntiderivativeFunction<double>::IntegrableFunctionContext values;
       values.k = kInvalidParameters;
       antiderivative_function.MakeDenseEvalFunction(
           kValidUpperIntegrationBound, values);
     }, std::logic_error, kInvalidParametersErrorMessage);
 
   DRAKE_EXPECT_THROWS_MESSAGE({
-    AntiderivativeFunction<double>::SpecifiedValues values;
+    AntiderivativeFunction<double>::IntegrableFunctionContext values;
     values.k = kValidParameters;
     antiderivative_function.Evaluate(
         kInvalidUpperIntegrationBound, values);
     }, std::logic_error, kInvalidIntegrationBoundErrorMessage);
 
   DRAKE_EXPECT_THROWS_MESSAGE({
-    AntiderivativeFunction<double>::SpecifiedValues values;
+    AntiderivativeFunction<double>::IntegrableFunctionContext values;
     values.k = kValidParameters;
     antiderivative_function.MakeDenseEvalFunction(
         kInvalidUpperIntegrationBound, values);
@@ -162,7 +162,7 @@ TEST_P(AntiderivativeFunctionAccuracyTest, NthPowerMonomialTestCase) {
   const VectorX<double> kDefaultParameters =
       VectorX<double>::Constant(1, 0.0);
   // All specified values by default, for function definition.
-  const AntiderivativeFunction<double>::SpecifiedValues
+  const AntiderivativeFunction<double>::IntegrableFunctionContext
       kDefaultValues({}, kDefaultParameters);
 
   AntiderivativeFunction<double> antiderivative_function(
@@ -183,7 +183,7 @@ TEST_P(AntiderivativeFunctionAccuracyTest, NthPowerMonomialTestCase) {
   const double kArgStep = 1.0;
 
   for (int n = kLowestOrder; n <= kHighestOrder; ++n) {
-    AntiderivativeFunction<double>::SpecifiedValues values;
+    AntiderivativeFunction<double>::IntegrableFunctionContext values;
     values.k = VectorX<double>::Constant(1, static_cast<double>(n)).eval();
 
     const std::unique_ptr<ScalarDenseOutput<double>>
@@ -219,7 +219,7 @@ TEST_P(AntiderivativeFunctionAccuracyTest, HyperbolicTangentTestCase) {
   const VectorX<double> kDefaultParameters =
       VectorX<double>::Constant(1, 0.0);
   // All specified values by default, for function definition.
-  const AntiderivativeFunction<double>::SpecifiedValues
+  const AntiderivativeFunction<double>::IntegrableFunctionContext
       kDefaultValues({}, kDefaultParameters);
 
   AntiderivativeFunction<double> antiderivative_function(
@@ -242,7 +242,7 @@ TEST_P(AntiderivativeFunctionAccuracyTest, HyperbolicTangentTestCase) {
 
   for (double a = kParamIntervalLBound; a <= kParamIntervalUBound;
        a += kParamStep) {
-    AntiderivativeFunction<double>::SpecifiedValues values;
+    AntiderivativeFunction<double>::IntegrableFunctionContext values;
     values.k = VectorX<double>::Constant(1, a).eval();
 
     const std::unique_ptr<ScalarDenseOutput<double>>
@@ -278,7 +278,7 @@ TEST_P(AntiderivativeFunctionAccuracyTest,
   // The denominator roots a and b.
   const VectorX<double> kDefaultParameters = VectorX<double>::Zero(2);
     // All specified values by default, for function definition.
-  const AntiderivativeFunction<double>::SpecifiedValues
+  const AntiderivativeFunction<double>::IntegrableFunctionContext
       kDefaultValues({}, kDefaultParameters);
 
   AntiderivativeFunction<double> antiderivative_function(
@@ -308,7 +308,7 @@ TEST_P(AntiderivativeFunctionAccuracyTest,
        a += k1stPoleStep) {
     for (double b = k2ndPoleIntervalLBound; b <= k2ndPoleIntervalUBound;
          b += k2ndPoleStep) {
-      AntiderivativeFunction<double>::SpecifiedValues values;
+      AntiderivativeFunction<double>::IntegrableFunctionContext values;
       values.k = (VectorX<double>(2) << a, b).finished();
 
     const std::unique_ptr<ScalarDenseOutput<double>>
@@ -346,7 +346,7 @@ TEST_P(AntiderivativeFunctionAccuracyTest, ExponentialFunctionTestCase) {
   // The exponent factor n.
   const VectorX<double> kDefaultParameters = VectorX<double>::Zero(1);
   // All specified values by default, for function definition.
-  const AntiderivativeFunction<double>::SpecifiedValues
+  const AntiderivativeFunction<double>::IntegrableFunctionContext
       kDefaultValues({}, kDefaultParameters);
 
   AntiderivativeFunction<double> antiderivative_function(
@@ -369,7 +369,7 @@ TEST_P(AntiderivativeFunctionAccuracyTest, ExponentialFunctionTestCase) {
 
   for (double n = kParamIntervalLBound; n <= kParamIntervalUBound;
        n += kParamStep) {
-    AntiderivativeFunction<double>::SpecifiedValues values;
+    AntiderivativeFunction<double>::IntegrableFunctionContext values;
     values.k = VectorX<double>::Constant(1, n).eval();
 
     const std::unique_ptr<ScalarDenseOutput<double>>
@@ -406,7 +406,7 @@ TEST_P(AntiderivativeFunctionAccuracyTest, TrigonometricFunctionTestCase) {
   // The factor a in the sine.
   const VectorX<double> kDefaultParameters = VectorX<double>::Zero(1);
   // All specified values by default, for function definition.
-  const AntiderivativeFunction<double>::SpecifiedValues
+  const AntiderivativeFunction<double>::IntegrableFunctionContext
       kDefaultValues({}, kDefaultParameters);
 
   AntiderivativeFunction<double> antiderivative_function(
@@ -429,7 +429,7 @@ TEST_P(AntiderivativeFunctionAccuracyTest, TrigonometricFunctionTestCase) {
 
   for (double a = kParamIntervalLBound; a <= kParamIntervalUBound;
        a += kParamStep) {
-    AntiderivativeFunction<double>::SpecifiedValues values;
+    AntiderivativeFunction<double>::IntegrableFunctionContext values;
     values.k = VectorX<double>::Constant(1, a).eval();
 
     const std::unique_ptr<ScalarDenseOutput<double>>

--- a/systems/analysis/test/initial_value_problem_test.cc
+++ b/systems/analysis/test/initial_value_problem_test.cc
@@ -29,7 +29,7 @@ GTEST_TEST(InitialValueProblemTest, SolutionUsingMultipleIntegrators) {
   // The default parameters 𝐤₀, for IVP definition.
   const VectorX<double> kDefaultParameters = VectorX<double>::Constant(2, 1.0);
   // All specified values by default, for IVP definition.
-  const InitialValueProblem<double>::SpecifiedValues kDefaultValues(
+  const InitialValueProblem<double>::OdeContext kDefaultValues(
       kDefaultInitialTime, kDefaultInitialState, kDefaultParameters);
 
   // Instantiates a generic IVP for test purposes only,
@@ -62,7 +62,7 @@ GTEST_TEST(InitialValueProblemTest, SolutionUsingMultipleIntegrators) {
 
   // Specifies a different parameter vector, but leaves both
   // initial time and state as defaults.
-  InitialValueProblem<double>::SpecifiedValues values;
+  InitialValueProblem<double>::OdeContext values;
   values.k = VectorX<double>::Constant(2, 5.0).eval();
   const VectorX<double>& k2 = values.k.value();
   const double t2 = kDefaultInitialTime + 0.3;
@@ -77,7 +77,7 @@ GTEST_TEST(InitialValueProblemTest, SolutionUsingMultipleIntegrators) {
 GTEST_TEST(InitialValueProblemTest, ConstructionPreconditionsValidation) {
   // Defines a generic ODE d𝐱/dt = -𝐱 + 𝐤, that does not
   // model (nor attempts to model) any physical process.
-  const InitialValueProblem<double>::ODEFunction dummy_ode_function =
+  const InitialValueProblem<double>::OdeFunction dummy_ode_function =
       [](const double& t, const VectorX<double>& x,
          const VectorX<double>& k) -> VectorX<double> {
     unused(k);
@@ -86,14 +86,14 @@ GTEST_TEST(InitialValueProblemTest, ConstructionPreconditionsValidation) {
 
   DRAKE_EXPECT_THROWS_MESSAGE({
       const InitialValueProblem<double>::
-          SpecifiedValues no_values;
+          OdeContext no_values;
       const InitialValueProblem<double> ivp(
           dummy_ode_function, no_values);
     }, std::logic_error, "No default.*");
 
   DRAKE_EXPECT_THROWS_MESSAGE({
       InitialValueProblem<double>::
-          SpecifiedValues values_without_t0;
+          OdeContext values_without_t0;
       values_without_t0.k = VectorX<double>();
       values_without_t0.x0 = VectorX<double>::Zero(2).eval();
       const InitialValueProblem<double> ivp(
@@ -102,7 +102,7 @@ GTEST_TEST(InitialValueProblemTest, ConstructionPreconditionsValidation) {
 
   DRAKE_EXPECT_THROWS_MESSAGE({
       InitialValueProblem<double>::
-          SpecifiedValues values_without_x0;
+          OdeContext values_without_x0;
       values_without_x0.t0 = 0.0;
       values_without_x0.k = VectorX<double>();
       const InitialValueProblem<double> ivp(
@@ -111,7 +111,7 @@ GTEST_TEST(InitialValueProblemTest, ConstructionPreconditionsValidation) {
 
   DRAKE_EXPECT_THROWS_MESSAGE({
       InitialValueProblem<double>::
-          SpecifiedValues values_without_k;
+          OdeContext values_without_k;
       values_without_k.t0 = 0.0;
       values_without_k.x0 = VectorX<double>();
       const InitialValueProblem<double> ivp(
@@ -128,7 +128,7 @@ GTEST_TEST(InitialValueProblemTest, ComputationPreconditionsValidation) {
   // The default parameters 𝐤₀, for IVP definition.
   const VectorX<double> kDefaultParameters = VectorX<double>::Constant(2, 1.0);
   // All specified values by default, for IVP definition.
-  const InitialValueProblem<double>::SpecifiedValues kDefaultValues(
+  const InitialValueProblem<double>::OdeContext kDefaultValues(
       kDefaultInitialTime, kDefaultInitialState, kDefaultParameters);
 
   // Instantiates a generic IVP for test purposes only,
@@ -174,7 +174,7 @@ GTEST_TEST(InitialValueProblemTest, ComputationPreconditionsValidation) {
   DRAKE_EXPECT_THROWS_MESSAGE(ivp.DenseSolve(kInvalidTime), std::logic_error,
                               kInvalidTimeErrorMessage);
   {
-    InitialValueProblem<double>::SpecifiedValues values;
+    InitialValueProblem<double>::OdeContext values;
     values.k = kInvalidParameters;
     DRAKE_EXPECT_THROWS_MESSAGE(
         ivp.Solve(kValidTime, values), std::logic_error,
@@ -185,7 +185,7 @@ GTEST_TEST(InitialValueProblemTest, ComputationPreconditionsValidation) {
   }
 
   {
-    InitialValueProblem<double>::SpecifiedValues values;
+    InitialValueProblem<double>::OdeContext values;
     values.k = kValidParameters;
     DRAKE_EXPECT_THROWS_MESSAGE(ivp.Solve(kInvalidTime, values),
                                 std::logic_error,
@@ -196,7 +196,7 @@ GTEST_TEST(InitialValueProblemTest, ComputationPreconditionsValidation) {
   }
 
   {
-    InitialValueProblem<double>::SpecifiedValues values;
+    InitialValueProblem<double>::OdeContext values;
     values.x0 = kInvalidState;
     values.k = kValidParameters;
     DRAKE_EXPECT_THROWS_MESSAGE(ivp.Solve(kValidTime, values), std::logic_error,
@@ -207,7 +207,7 @@ GTEST_TEST(InitialValueProblemTest, ComputationPreconditionsValidation) {
   }
 
   {
-    InitialValueProblem<double>::SpecifiedValues values;
+    InitialValueProblem<double>::OdeContext values;
     values.x0 = kValidState;
     values.k = kInvalidParameters;
     DRAKE_EXPECT_THROWS_MESSAGE(ivp.Solve(kValidTime, values), std::logic_error,
@@ -218,7 +218,7 @@ GTEST_TEST(InitialValueProblemTest, ComputationPreconditionsValidation) {
   }
 
   {
-    InitialValueProblem<double>::SpecifiedValues values;
+    InitialValueProblem<double>::OdeContext values;
     values.x0 = kValidState;
     values.k = kValidParameters;
     DRAKE_EXPECT_THROWS_MESSAGE(ivp.Solve(kInvalidTime, values),
@@ -258,7 +258,7 @@ TEST_P(InitialValueProblemAccuracyTest, ParticleInAGasMomentum) {
       (VectorX<double>(2) << kDefaultParticleMass,
                              kDefaultGasViscosity).finished();
   // All specified values by default, for IVP definition.
-  const InitialValueProblem<double>::SpecifiedValues kDefaultValues(
+  const InitialValueProblem<double>::OdeContext kDefaultValues(
       kInitialTime, kInitialParticleMomentum, kDefaultParameters);
 
   // Instantiates the particle momentum IVP.
@@ -292,7 +292,7 @@ TEST_P(InitialValueProblemAccuracyTest, ParticleInAGasMomentum) {
        mu += kGasViscosityStep) {
     for (double m = kLowestParticleMass; m <= kHighestParticleMass;
          m += kParticleMassStep) {
-      InitialValueProblem<double>::SpecifiedValues values;
+      InitialValueProblem<double>::OdeContext values;
       values.k = (VectorX<double>(2) << mu, m).finished();
 
       const std::unique_ptr<DenseOutput<double>> particle_momentum_approx =
@@ -342,7 +342,7 @@ TEST_P(InitialValueProblemAccuracyTest, ParticleInAGasForcedVelocity) {
       (VectorX<double>(2) << kDefaultParticleMass,
                              kDefaultGasViscosity).finished();
   // All specified values by default, for IVP definition.
-  const InitialValueProblem<double>::SpecifiedValues kDefaultValues(
+  const InitialValueProblem<double>::OdeContext kDefaultValues(
       kInitialTime, kInitialParticleVelocity, kDefaultParameters);
 
   // Instantiates the particle velocity IVP.
@@ -380,7 +380,7 @@ TEST_P(InitialValueProblemAccuracyTest, ParticleInAGasForcedVelocity) {
        mu += kGasViscosityStep) {
     for (double m = kLowestParticleMass; m <= kHighestParticleMass;
          m += kParticleMassStep) {
-      InitialValueProblem<double>::SpecifiedValues values;
+      InitialValueProblem<double>::OdeContext values;
       values.k = (VectorX<double>(2) << mu, m).finished();
 
       const std::unique_ptr<DenseOutput<double>> particle_velocity_approx =

--- a/systems/analysis/test/scalar_initial_value_problem_test.cc
+++ b/systems/analysis/test/scalar_initial_value_problem_test.cc
@@ -25,7 +25,7 @@ GTEST_TEST(ScalarInitialValueProblemTest, UsingMultipleIntegrators) {
   // The default parameters 𝐤₀, for IVP definition.
   const VectorX<double> kDefaultParameters = VectorX<double>::Constant(1, 1.0);
   // All specified values by default, for IVP definition.
-  const ScalarInitialValueProblem<double>::SpecifiedValues kDefaultValues(
+  const ScalarInitialValueProblem<double>::ScalarOdeContext kDefaultValues(
       kDefaultInitialTime, kDefaultInitialState, kDefaultParameters);
 
   // Instantiates a generic IVP for test purposes only,
@@ -58,7 +58,7 @@ GTEST_TEST(ScalarInitialValueProblemTest, UsingMultipleIntegrators) {
 
   // Specifies a different parameter vector, but leaves both
   // initial time and state as defaults.
-  ScalarInitialValueProblem<double>::SpecifiedValues values;
+  ScalarInitialValueProblem<double>::ScalarOdeContext values;
   values.k = VectorX<double>::Constant(1, 5.0).eval();
   const VectorX<double>& k2 = values.k.value();
   const double t2 = kDefaultInitialTime + 0.3;
@@ -74,7 +74,7 @@ GTEST_TEST(ScalarInitialValueProblemTest, ConstructionPreconditionsValidation) {
   // Defines a generic ODE dx/dt = -x * t, that does not
   // model (nor attempts to model) any physical process.
   const ScalarInitialValueProblem<double>::
-      ScalarODEFunction dummy_scalar_ode_function =
+      ScalarOdeFunction dummy_scalar_ode_function =
       [](const double& t, const double& x,
          const VectorX<double>& k) -> double {
     unused(k);
@@ -83,14 +83,14 @@ GTEST_TEST(ScalarInitialValueProblemTest, ConstructionPreconditionsValidation) {
 
   DRAKE_EXPECT_THROWS_MESSAGE({
       const ScalarInitialValueProblem<double>::
-          SpecifiedValues no_values;
+          ScalarOdeContext no_values;
       const ScalarInitialValueProblem<double> ivp(
           dummy_scalar_ode_function, no_values);
     }, std::logic_error, "No default.*");
 
   DRAKE_EXPECT_THROWS_MESSAGE({
       ScalarInitialValueProblem<double>::
-          SpecifiedValues values_without_t0;
+          ScalarOdeContext values_without_t0;
       values_without_t0.k = VectorX<double>();
       values_without_t0.x0 = 0.0;
       const ScalarInitialValueProblem<double> ivp(
@@ -99,7 +99,7 @@ GTEST_TEST(ScalarInitialValueProblemTest, ConstructionPreconditionsValidation) {
 
   DRAKE_EXPECT_THROWS_MESSAGE({
       ScalarInitialValueProblem<double>::
-          SpecifiedValues values_without_x0;
+          ScalarOdeContext values_without_x0;
       values_without_x0.t0 = 0.0;
       values_without_x0.k = VectorX<double>();
       const ScalarInitialValueProblem<double> ivp(
@@ -108,7 +108,7 @@ GTEST_TEST(ScalarInitialValueProblemTest, ConstructionPreconditionsValidation) {
 
   DRAKE_EXPECT_THROWS_MESSAGE({
       ScalarInitialValueProblem<double>::
-          SpecifiedValues values_without_k;
+          ScalarOdeContext values_without_k;
       values_without_k.t0 = 0.0;
       values_without_k.x0 = 0.0;
       const ScalarInitialValueProblem<double> ivp(
@@ -125,7 +125,7 @@ GTEST_TEST(ScalarInitialValueProblemTest, ComputationPreconditionsValidation) {
   // The default parameters 𝐤₀, for IVP definition.
   const VectorX<double> kDefaultParameters = VectorX<double>::Constant(2, 1.0);
   // All specified values by default, for IVP definition.
-  const ScalarInitialValueProblem<double>::SpecifiedValues kDefaultValues(
+  const ScalarInitialValueProblem<double>::ScalarOdeContext kDefaultValues(
       kDefaultInitialTime, kDefaultInitialState, kDefaultParameters);
 
   // Instantiates a generic IVP for test purposes only,
@@ -165,7 +165,7 @@ GTEST_TEST(ScalarInitialValueProblemTest, ComputationPreconditionsValidation) {
   DRAKE_EXPECT_THROWS_MESSAGE(ivp.DenseSolve(kInvalidTime), std::logic_error,
                               kInvalidTimeErrorMessage);
   {
-    ScalarInitialValueProblem<double>::SpecifiedValues values;
+    ScalarInitialValueProblem<double>::ScalarOdeContext values;
     values.k = kInvalidParameters;
     DRAKE_EXPECT_THROWS_MESSAGE(ivp.Solve(kValidTime, values), std::logic_error,
                                 kInvalidParametersErrorMessage);
@@ -175,7 +175,7 @@ GTEST_TEST(ScalarInitialValueProblemTest, ComputationPreconditionsValidation) {
   }
 
   {
-    ScalarInitialValueProblem<double>::SpecifiedValues values;
+    ScalarInitialValueProblem<double>::ScalarOdeContext values;
     values.k = kValidParameters;
     DRAKE_EXPECT_THROWS_MESSAGE(ivp.Solve(kInvalidTime, values),
                                 std::logic_error, kInvalidTimeErrorMessage);
@@ -213,7 +213,7 @@ TEST_P(ScalarInitialValueProblemAccuracyTest, StoredCharge) {
       VectorX<double>(2) << kInitialResistance,
                             kInitialCapacitance).finished();
   // Wraps all specified values by default, for IVP definition.
-  const ScalarInitialValueProblem<double>::SpecifiedValues kDefaultValues(
+  const ScalarInitialValueProblem<double>::ScalarOdeContext kDefaultValues(
       kInitialTime, kInitialStoredCharge, kDefaultParameters);
 
   // Instantiates the stored charge scalar IVP.
@@ -247,7 +247,7 @@ TEST_P(ScalarInitialValueProblemAccuracyTest, StoredCharge) {
        Rs += kResistanceStep) {
     for (double Cs = kLowestCapacitance; Cs <= kHighestCapacitance ;
          Cs += kCapacitanceStep) {
-      ScalarInitialValueProblem<double>::SpecifiedValues values;
+      ScalarInitialValueProblem<double>::ScalarOdeContext values;
       values.k = (VectorX<double>(2) << Rs, Cs).finished();
 
       const std::unique_ptr<ScalarDenseOutput<double>> stored_charge_approx =
@@ -298,7 +298,7 @@ TEST_P(ScalarInitialValueProblemAccuracyTest, PopulationGrowth) {
   const VectorX<double> kDefaultParameters =
       VectorX<double>::Constant(1, kDefaultMalthusParam);
   // Wraps all specified values by default, for IVP definition.
-  const ScalarInitialValueProblem<double>::SpecifiedValues kDefaultValues(
+  const ScalarInitialValueProblem<double>::ScalarOdeContext kDefaultValues(
       kInitialTime, kInitialPopulation, kDefaultParameters);
 
   ScalarInitialValueProblem<double> population_growth_ivp(
@@ -325,7 +325,7 @@ TEST_P(ScalarInitialValueProblemAccuracyTest, PopulationGrowth) {
   const double tf = kTotalTime;
   for (double r = kLowestMalthusParam; r <= kHighestMalthusParam;
        r += kMalthusParamStep) {
-    ScalarInitialValueProblem<double>::SpecifiedValues values;
+    ScalarInitialValueProblem<double>::ScalarOdeContext values;
     values.k = VectorX<double>::Constant(1, r).eval();
 
     const std::unique_ptr<ScalarDenseOutput<double>> population_growth_approx =


### PR DESCRIPTION
and similar for ScalarInitialValueProblem and AntiderivativeFunction
+ adds deprecations

because SpecifiedValues is very generic, and drake already has a better name for this concept.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12931)
<!-- Reviewable:end -->
