### PR TITLE
[geometry] update mesh-half space intersection for full hydroleastic compatibility

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -310,9 +310,11 @@ drake_cc_library(
         "mesh_half_space_intersection.h",
     ],
     deps = [
+        ":contact_surface_utility",
         ":posed_half_space",
         ":surface_mesh",
         "//common",
+        "//geometry:utilities",
     ],
 )
 
@@ -652,7 +654,9 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "mesh_half_space_intersection_test",
     deps = [
+        ":contact_surface_utility",
         ":mesh_half_space_intersection",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -305,11 +305,12 @@ drake_cc_library(
 
 drake_cc_library(
     name = "mesh_half_space_intersection",
+    srcs = ["mesh_half_space_intersection.cc"],
     hdrs = [
         "mesh_half_space_intersection.h",
     ],
     deps = [
-        ":mesh_intersection",
+        ":posed_half_space",
         ":surface_mesh",
         "//common",
     ],

--- a/geometry/proximity/mesh_half_space_intersection.cc
+++ b/geometry/proximity/mesh_half_space_intersection.cc
@@ -1,0 +1,285 @@
+#include "drake/geometry/proximity/mesh_half_space_intersection.h"
+
+#include <array>
+#include <cmath>
+#include <limits>
+#include <utility>
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+template <typename T>
+int sgn(const T& x) {
+  if (x > 0) {
+    return 1;
+  } else {
+    if (x < 0) return -1;
+    return 0;
+  }
+}
+
+/* Utility routine for getting the vertex index from the
+ `edges_to_newly_created_vertices` hashtable. Given an edge (defined by its two
+ end-point vertices a and b) and the signed distances from a plane (`s_a` and
+ `s_b`, respectively), returns the index of the vertex that splits the edge at a
+ crossing plane. The method creates the vertex if the edge hasn't previously
+ been split.
+
+ @pre s_a and s_b must not have the same sign (positive, negative, or zero) of
+      the plane.
+ */
+template <typename T>
+SurfaceVertexIndex GetVertexAddIfNeeded(
+    SurfaceVertexIndex a, SurfaceVertexIndex b, const T& s_a, const T& s_b,
+    const std::vector<SurfaceVertex<T>>& vertices_F,
+    std::unordered_map<SortedPair<SurfaceVertexIndex>, SurfaceVertexIndex>*
+        edges_to_newly_created_vertices,
+    std::vector<SurfaceVertex<T>>* new_vertices_F) {
+  DRAKE_DEMAND(sgn(s_a) != sgn(s_b));
+
+  using std::abs;
+  SortedPair<SurfaceVertexIndex> edge_a_b(a, b);
+  auto edge_a_b_intersection_iter =
+      edges_to_newly_created_vertices->find(edge_a_b);
+  if (edge_a_b_intersection_iter == edges_to_newly_created_vertices->end()) {
+    const T t = abs(s_a) / (abs(s_a) + abs(s_b));
+    // We know that the magnitude of the denominator should always be at
+    // least as large as the magnitude of the numerator (implying that t should
+    // never be greater than unity). Barring an (unlikely) machine epsilon
+    // remainder on division, the assertion below should hold.
+    DRAKE_DEMAND(t >= 0 && t <= 1);
+    bool inserted;
+    std::tie(edge_a_b_intersection_iter, inserted) =
+        edges_to_newly_created_vertices->insert(
+            {edge_a_b, SurfaceVertexIndex(new_vertices_F->size())});
+    DRAKE_DEMAND(inserted);
+    new_vertices_F->emplace_back(
+        vertices_F[a].r_MV() +
+        t * (vertices_F[b].r_MV() - vertices_F[a].r_MV()));
+  }
+
+  return edge_a_b_intersection_iter->second;
+}
+
+/* Utility routine for getting the vertex index from the
+ `vertices_to_newly_created_vertices` hashtable. Given a vertex `index` from the
+ input mesh, returns the corresponding vertex index in `new_vertices_F`. The
+ method creates the vertex in `new_vertices_F` if it hasn't already been added.
+ */
+template <typename T>
+SurfaceVertexIndex GetVertexAddIfNeeded(
+    const std::vector<SurfaceVertex<T>>& vertices_F, SurfaceVertexIndex index,
+    std::unordered_map<SurfaceVertexIndex, SurfaceVertexIndex>*
+        vertices_to_newly_created_vertices,
+    std::vector<SurfaceVertex<T>>* new_vertices_F) {
+  auto v_to_new_v_iter = vertices_to_newly_created_vertices->find(index);
+  if (v_to_new_v_iter == vertices_to_newly_created_vertices->end()) {
+    bool inserted;
+    std::tie(v_to_new_v_iter, inserted) =
+        vertices_to_newly_created_vertices->insert(
+            {index, SurfaceVertexIndex(new_vertices_F->size())});
+    DRAKE_DEMAND(inserted);
+    new_vertices_F->emplace_back(vertices_F[index]);
+  }
+
+  return v_to_new_v_iter->second;
+}
+
+template <typename T>
+void ConstructTriangleHalfspaceIntersectionPolygon(
+    const std::vector<SurfaceVertex<T>>& vertices_F,
+    const SurfaceFace& triangle, const PosedHalfSpace<T>& half_space_F,
+    std::vector<SurfaceVertex<T>>* new_vertices_F,
+    std::vector<SurfaceFace>* new_faces,
+    std::unordered_map<SurfaceVertexIndex, SurfaceVertexIndex>*
+        vertices_to_newly_created_vertices,
+    std::unordered_map<SortedPair<SurfaceVertexIndex>, SurfaceVertexIndex>*
+        edges_to_newly_created_vertices) {
+  DRAKE_DEMAND(new_vertices_F);
+  DRAKE_DEMAND(new_faces);
+  DRAKE_DEMAND(vertices_to_newly_created_vertices);
+  DRAKE_DEMAND(edges_to_newly_created_vertices);
+
+  // NOLINTNEXTLINE(whitespace/line_length)
+  // This code was inspired from
+  // https://www.geometrictools.com/GTEngine/Include/Mathematics/GteIntrHalfspace3Triangle3.h
+  //
+  // Compute the signed distance of each triangle vertex from the half space.
+  // The table of possibilities is listed next with p = num_positive.
+  //
+  //     p  intersection
+  //     ---------------------------------
+  // 1.  0  triangle (original)
+  // 2.  1  quad (2 edges clipped)
+  // 3.  2  triangle (2 edges clipped)
+  // 4.  3  none
+
+  // Compute the signed distance of each triangle vertex from the half space.
+  T s[3];
+  int num_positive = 0;
+  for (int i = 0; i < 3; ++i) {
+    s[i] =
+        half_space_F.CalcSignedDistance(vertices_F[triangle.vertex(i)].r_MV());
+    if (s[i] > 0) ++num_positive;
+  }
+
+  // Case 1: triangle lies completely within the half space. Preserve
+  // the ordering of the triangle vertices.
+  if (num_positive == 0) {
+    const SurfaceVertexIndex v0_new_index = GetVertexAddIfNeeded(
+        vertices_F, triangle.vertex(0), vertices_to_newly_created_vertices,
+        new_vertices_F);
+    const SurfaceVertexIndex v1_new_index = GetVertexAddIfNeeded(
+        vertices_F, triangle.vertex(1), vertices_to_newly_created_vertices,
+        new_vertices_F);
+    const SurfaceVertexIndex v2_new_index = GetVertexAddIfNeeded(
+        vertices_F, triangle.vertex(2), vertices_to_newly_created_vertices,
+        new_vertices_F);
+
+    new_faces->emplace_back(v0_new_index, v1_new_index, v2_new_index);
+    return;
+  }
+
+  // Case 2: The portion of the triangle in the half space is a quadrilateral.
+  if (num_positive == 1) {
+    for (SurfaceVertexIndex i0(0); i0 < 3; ++i0) {
+      if (s[i0] >= 0) {
+        const SurfaceVertexIndex i1((i0 + 1) % 3);
+        const SurfaceVertexIndex i2((i0 + 2) % 3);
+
+        // Get the vertices that result from intersecting edge i0/i1 and
+        // i0/i2.
+        SurfaceVertexIndex edge_i0_i1_intersection_index = GetVertexAddIfNeeded(
+            i0, i1, s[i0], s[i1], vertices_F, edges_to_newly_created_vertices,
+            new_vertices_F);
+        const SurfaceVertexIndex edge_i0_i2_intersection_index =
+            GetVertexAddIfNeeded(i0, i2, s[i0], s[i2], vertices_F,
+                                 edges_to_newly_created_vertices,
+                                 new_vertices_F);
+
+        // Get the indices of the new vertices, adding them if needed.
+        const SurfaceVertexIndex i1_new_index = GetVertexAddIfNeeded(
+            vertices_F, i1, vertices_to_newly_created_vertices, new_vertices_F);
+        const SurfaceVertexIndex i2_new_index = GetVertexAddIfNeeded(
+            vertices_F, i2, vertices_to_newly_created_vertices, new_vertices_F);
+
+        // Add faces, according to the nice ascii art below (thanks Sean
+        // Curtis!):
+        //
+        //             i0
+        //            ╱╲
+        //       e01 ╱  ╲ e02
+        //    ______╱____╲___
+        //         ╱      ╲
+        //        ╱________╲
+        //      i1          i2
+        //
+        // New triangles to cover the quad and maintain the winding.
+        //   (i1, i2, e01)
+        //   (i2, e02, e01)
+        //
+        new_faces->emplace_back(i1_new_index, i2_new_index,
+                                edge_i0_i1_intersection_index);
+        new_faces->emplace_back(i2_new_index, edge_i0_i2_intersection_index,
+                                edge_i0_i1_intersection_index);
+        return;
+      }
+    }
+
+    DRAKE_UNREACHABLE();
+  }
+
+  // Case 3: The portion of the triangle in the half space is a triangle.
+  if (num_positive == 2) {
+    for (SurfaceVertexIndex i0(0); i0 < 3; ++i0) {
+      if (s[i0] <= 0) {
+        const SurfaceVertexIndex i1((i0 + 1) % 3);
+        const SurfaceVertexIndex i2((i0 + 2) % 3);
+
+        // Get the vertex that corresponds to i0.
+        const SurfaceVertexIndex i0_new_index = GetVertexAddIfNeeded(
+            vertices_F, i0, vertices_to_newly_created_vertices, new_vertices_F);
+
+        // Get the vertex that results from intersecting edge i0/i1.
+        const SurfaceVertexIndex edge_i0_i1_intersection_index =
+            GetVertexAddIfNeeded(i0, i1, s[i0], s[i1], vertices_F,
+                                 edges_to_newly_created_vertices,
+                                 new_vertices_F);
+
+        // Get the vertex that results from intersecting edge i0/i2.
+        const SurfaceVertexIndex edge_i0_i2_intersection_index =
+            GetVertexAddIfNeeded(i0, i2, s[i0], s[i2], vertices_F,
+                                 edges_to_newly_created_vertices,
+                                 new_vertices_F);
+
+        new_faces->emplace_back(i0_new_index, edge_i0_i1_intersection_index,
+                                edge_i0_i2_intersection_index);
+        return;
+      }
+    }
+
+    DRAKE_UNREACHABLE();
+  }
+
+  // Case 4: The triangle is outside the half space.
+  DRAKE_DEMAND(num_positive == 3);
+  return;
+}
+
+template void ConstructTriangleHalfspaceIntersectionPolygon(
+    const std::vector<SurfaceVertex<double>>& vertices_F,
+const SurfaceFace& triangle,
+const internal::PosedHalfSpace<double>& half_space_F,
+    std::vector<SurfaceVertex<double>>* new_vertices_F,
+std::vector<SurfaceFace>* new_faces,
+    std::unordered_map<SurfaceVertexIndex, SurfaceVertexIndex>*
+vertices_to_newly_created_vertices,
+std::unordered_map<SortedPair<SurfaceVertexIndex>, SurfaceVertexIndex>*
+edges_to_newly_created_vertices);
+
+template void ConstructTriangleHalfspaceIntersectionPolygon(
+    const std::vector<SurfaceVertex<AutoDiffXd>>& vertices_F,
+const SurfaceFace& triangle,
+const internal::PosedHalfSpace<AutoDiffXd>& half_space_F,
+    std::vector<SurfaceVertex<AutoDiffXd>>* new_vertices_F,
+std::vector<SurfaceFace>* new_faces,
+    std::unordered_map<SurfaceVertexIndex, SurfaceVertexIndex>*
+vertices_to_newly_created_vertices,
+std::unordered_map<SortedPair<SurfaceVertexIndex>, SurfaceVertexIndex>*
+edges_to_newly_created_vertices);
+
+}  // namespace internal
+
+template <typename T>
+SurfaceMesh<T> ConstructSurfaceMeshFromMeshHalfspaceIntersection(
+    const SurfaceMesh<T>& input_mesh_F,
+    const internal::PosedHalfSpace<T>& half_space_F) {
+  std::vector<SurfaceVertex<T>> new_vertices_F;
+  std::vector<SurfaceFace> new_faces;
+  std::unordered_map<SurfaceVertexIndex, SurfaceVertexIndex>
+      vertices_to_newly_created_vertices;
+  std::unordered_map<SortedPair<SurfaceVertexIndex>, SurfaceVertexIndex>
+      edges_to_newly_created_vertices;
+
+  for (const SurfaceFace& face : input_mesh_F.faces()) {
+    ConstructTriangleHalfspaceIntersectionPolygon(
+        input_mesh_F.vertices(), face, half_space_F, &new_vertices_F,
+        &new_faces, &vertices_to_newly_created_vertices,
+        &edges_to_newly_created_vertices);
+  }
+
+  return SurfaceMesh<T>(std::move(new_faces), std::move(new_vertices_F));
+}
+
+template SurfaceMesh<double> ConstructSurfaceMeshFromMeshHalfspaceIntersection(
+    const SurfaceMesh<double>& input_mesh_F,
+    const internal::PosedHalfSpace<double>& half_space_F);
+
+template SurfaceMesh<AutoDiffXd>
+ConstructSurfaceMeshFromMeshHalfspaceIntersection(
+    const SurfaceMesh<AutoDiffXd>& input_mesh_F,
+    const internal::PosedHalfSpace<AutoDiffXd>& half_space_F);
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/mesh_half_space_intersection.cc
+++ b/geometry/proximity/mesh_half_space_intersection.cc
@@ -227,34 +227,9 @@ void ConstructTriangleHalfspaceIntersectionPolygon(
   return;
 }
 
-template void ConstructTriangleHalfspaceIntersectionPolygon(
-    const std::vector<SurfaceVertex<double>>& vertices_F,
-const SurfaceFace& triangle,
-const internal::PosedHalfSpace<double>& half_space_F,
-    std::vector<SurfaceVertex<double>>* new_vertices_F,
-std::vector<SurfaceFace>* new_faces,
-    std::unordered_map<SurfaceVertexIndex, SurfaceVertexIndex>*
-vertices_to_newly_created_vertices,
-std::unordered_map<SortedPair<SurfaceVertexIndex>, SurfaceVertexIndex>*
-edges_to_newly_created_vertices);
-
-template void ConstructTriangleHalfspaceIntersectionPolygon(
-    const std::vector<SurfaceVertex<AutoDiffXd>>& vertices_F,
-const SurfaceFace& triangle,
-const internal::PosedHalfSpace<AutoDiffXd>& half_space_F,
-    std::vector<SurfaceVertex<AutoDiffXd>>* new_vertices_F,
-std::vector<SurfaceFace>* new_faces,
-    std::unordered_map<SurfaceVertexIndex, SurfaceVertexIndex>*
-vertices_to_newly_created_vertices,
-std::unordered_map<SortedPair<SurfaceVertexIndex>, SurfaceVertexIndex>*
-edges_to_newly_created_vertices);
-
-}  // namespace internal
-
 template <typename T>
 SurfaceMesh<T> ConstructSurfaceMeshFromMeshHalfspaceIntersection(
-    const SurfaceMesh<T>& input_mesh_F,
-    const internal::PosedHalfSpace<T>& half_space_F) {
+    const SurfaceMesh<T>& input_mesh_F, const PosedHalfSpace<T>& half_space_F) {
   std::vector<SurfaceVertex<T>> new_vertices_F;
   std::vector<SurfaceFace> new_faces;
   std::unordered_map<SurfaceVertexIndex, SurfaceVertexIndex>
@@ -272,14 +247,35 @@ SurfaceMesh<T> ConstructSurfaceMeshFromMeshHalfspaceIntersection(
   return SurfaceMesh<T>(std::move(new_faces), std::move(new_vertices_F));
 }
 
+template void ConstructTriangleHalfspaceIntersectionPolygon(
+    const std::vector<SurfaceVertex<double>>& vertices_F,
+    const SurfaceFace& triangle, const PosedHalfSpace<double>& half_space_F,
+    std::vector<SurfaceVertex<double>>* new_vertices_F,
+    std::vector<SurfaceFace>* new_faces,
+    std::unordered_map<SurfaceVertexIndex, SurfaceVertexIndex>*
+        vertices_to_newly_created_vertices,
+    std::unordered_map<SortedPair<SurfaceVertexIndex>, SurfaceVertexIndex>*
+        edges_to_newly_created_vertices);
+
+template void ConstructTriangleHalfspaceIntersectionPolygon(
+    const std::vector<SurfaceVertex<AutoDiffXd>>& vertices_F,
+    const SurfaceFace& triangle, const PosedHalfSpace<AutoDiffXd>& half_space_F,
+    std::vector<SurfaceVertex<AutoDiffXd>>* new_vertices_F,
+    std::vector<SurfaceFace>* new_faces,
+    std::unordered_map<SurfaceVertexIndex, SurfaceVertexIndex>*
+        vertices_to_newly_created_vertices,
+    std::unordered_map<SortedPair<SurfaceVertexIndex>, SurfaceVertexIndex>*
+        edges_to_newly_created_vertices);
+
 template SurfaceMesh<double> ConstructSurfaceMeshFromMeshHalfspaceIntersection(
     const SurfaceMesh<double>& input_mesh_F,
-    const internal::PosedHalfSpace<double>& half_space_F);
+    const PosedHalfSpace<double>& half_space_F);
 
 template SurfaceMesh<AutoDiffXd>
 ConstructSurfaceMeshFromMeshHalfspaceIntersection(
     const SurfaceMesh<AutoDiffXd>& input_mesh_F,
-    const internal::PosedHalfSpace<AutoDiffXd>& half_space_F);
+    const PosedHalfSpace<AutoDiffXd>& half_space_F);
 
+}  // namespace internal
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/proximity/mesh_half_space_intersection.h
+++ b/geometry/proximity/mesh_half_space_intersection.h
@@ -24,31 +24,36 @@ namespace internal {
  duplicate vertices (beyond those already in the input mesh). This function
  uses bookkeeping to prevent the addition of such duplicate vertices, which can
  be created when either a vertex lies inside/on the half space or when an edge
- intersects the half space. The method tracks these created vertices using
+ intersects the half space. The method tracks these resultant vertices using
  `vertices_to_newly_created_vertices` and `edges_to_newly_created_vertices`,
  respectively.
 
- @param vertices_F the vertices from the input mesh as position vectors measured
-        and expressed in Frame F.
- @param triangle a single face from the input mesh.
- @param half_space_F the half space represented by its boundary plane such that
-        the plane's normal points out of the half space, expressed in Frame F.
- @param[in,out] new_vertices_F the accumulator for all of the vertices in the
-                intersecting mesh. It should be empty to start and will
-                gradually accumulate all of the vertices with each subsequent
-                call to this method.
- @param[in,out] new_faces the accumulator for all of the faces in the
-                intersecting mesh. It should be empty to start and will
-                gradually accumulate all of the faces with each subsequent
-                call to this method.
- @param[in,out] vertices_to_newly_created_vertices the accumulated mapping from
-                indices in `vertices_F` to indices in `new_vertices_F`. This
-                mapping should be empty to start and will gradually accumulate
-                elements with each subsequent call to this method.
- @param[in,out] edges_to_newly_created_vertices the accumulated mapping from
-                pairs of indices in `vertices_F` to indices in `new_vertices_F`.
-                This mapping should be empty to start and will gradually
-                accumulate elements with each subsequent call to this method.
+ @param mesh_F
+     The surface mesh to intersect, measured and expressed in Frame F.
+ @param tri_index
+     The index of the triangle, drawn from `mesh_F` to intersect with the half
+     space.
+ @param half_space_F
+     The half space measured and expressed in Frame F.
+ @param X_WF
+     The relative pose between Frame F and Frame W.
+ @param[in,out] new_vertices_W
+     The accumulator for all of the vertices in the intersecting mesh. It should
+     be empty for the first call and will gradually accumulate all of the
+     vertices with each subsequent call to this method. The vertex positions are
+     measured and expressed in frame W.
+ @param[in,out] new_faces
+     The accumulator for all of the faces in the intersecting mesh. It should be
+     empty for the first call and will gradually accumulate all of the faces
+     with each subsequent call to this method.
+ @param[in,out] vertices_to_newly_created_vertices
+     The accumulated mapping from indices in `vertices_F` to indices in
+     `new_vertices_W`. It should be empty for the first call and will gradually
+     accumulate elements with each subsequent call to this method.
+ @param[in,out] edges_to_newly_created_vertices
+     The accumulated mapping from pairs of indices in `vertices_F` to indices in
+     `new_vertices_W`. It should be empty for the first call and will gradually
+     accumulate elements with each subsequent call to this method.
 
  @note Unlike most geometric intersection routines, this method does not
        require the user to provide (or the algorithm to compute) a reasonable
@@ -62,10 +67,9 @@ namespace internal {
 */
 template <typename T>
 void ConstructTriangleHalfspaceIntersectionPolygon(
-    const std::vector<SurfaceVertex<T>>& vertices_F,
-    const SurfaceFace& triangle,
-    const PosedHalfSpace<T>& half_space_F,
-    std::vector<SurfaceVertex<T>>* new_vertices_F,
+    const SurfaceMesh<double>& mesh_F, SurfaceFaceIndex tri_index,
+    const PosedHalfSpace<T>& half_space_F, const math::RigidTransform<T>& X_WF,
+    std::vector<SurfaceVertex<T>>* new_vertices_W,
     std::vector<SurfaceFace>* new_faces,
     std::unordered_map<SurfaceVertexIndex, SurfaceVertexIndex>*
         vertices_to_newly_created_vertices,
@@ -73,19 +77,33 @@ void ConstructTriangleHalfspaceIntersectionPolygon(
         edges_to_newly_created_vertices);
 
 /*
- Constructs the SurfaceMesh that results from intersecting a triangle mesh with
- a half space.
- @param input_mesh_F the mesh with vertices measured and expressed in some
-        frame, F.
- @param half_space_F the half space represented by its boundary plane such that
-        the plane's normal points out of the half space, expressed in Frame F.
- @returns the SurfaceMesh corresponding to the intersection, the vertices of
-          which will be measured and expressed in Frame F.
+ Computes a triangular surface mesh by intersecting a half space with a set of
+ triangles drawn from the given surface mesh. The indicated triangles would
+ typically be the result of broadphase culling.
+
+ Each triangle in `mesh_W` is a proper subset of one triangle in `input_mesh_F`
+ (i.e., fully contained within the triangle in `input_mesh_F`). As such,
+ the face normal for each triangle in `mesh_W` will point in the same direction
+ as its containing triangle in `input_mesh_F`.
+
+ @param input_mesh_F
+     The mesh with vertices measured and expressed in some frame, F.
+ @param half_space_F
+     The half space measured and expressed in Frame F.
+ @param tri_indices
+     A collection of triangle indices in `input_mesh_F`.
+ @param X_WF
+     The relative pose of Frame F with the world frame W.
+ @retval `mesh_W`, the SurfaceMesh corresponding to the intersection between
+         the mesh and the half space; the vertices are measured and expressed in
+         Frame W.
  */
 template <typename T>
 SurfaceMesh<T> ConstructSurfaceMeshFromMeshHalfspaceIntersection(
-    const SurfaceMesh<T>& input_mesh_F,
-    const PosedHalfSpace<T>& half_space_F);
+    const SurfaceMesh<double>& input_mesh_F,
+    const PosedHalfSpace<T>& half_space_F,
+    const std::vector<SurfaceFaceIndex>& tri_indices,
+    const math::RigidTransform<T>& X_WF);
 
 
 }  // namespace internal

--- a/geometry/proximity/mesh_half_space_intersection.h
+++ b/geometry/proximity/mesh_half_space_intersection.h
@@ -64,7 +64,7 @@ template <typename T>
 void ConstructTriangleHalfspaceIntersectionPolygon(
     const std::vector<SurfaceVertex<T>>& vertices_F,
     const SurfaceFace& triangle,
-    const internal::PosedHalfSpace<T>& half_space_F,
+    const PosedHalfSpace<T>& half_space_F,
     std::vector<SurfaceVertex<T>>* new_vertices_F,
     std::vector<SurfaceFace>* new_faces,
     std::unordered_map<SurfaceVertexIndex, SurfaceVertexIndex>*
@@ -72,9 +72,7 @@ void ConstructTriangleHalfspaceIntersectionPolygon(
     std::unordered_map<SortedPair<SurfaceVertexIndex>, SurfaceVertexIndex>*
         edges_to_newly_created_vertices);
 
-}  // namespace internal
-
-/**
+/*
  Constructs the SurfaceMesh that results from intersecting a triangle mesh with
  a half space.
  @param input_mesh_F the mesh with vertices measured and expressed in some
@@ -87,8 +85,9 @@ void ConstructTriangleHalfspaceIntersectionPolygon(
 template <typename T>
 SurfaceMesh<T> ConstructSurfaceMeshFromMeshHalfspaceIntersection(
     const SurfaceMesh<T>& input_mesh_F,
-    const internal::PosedHalfSpace<T>& half_space_F);
+    const PosedHalfSpace<T>& half_space_F);
 
 
+}  // namespace internal
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/proximity/mesh_half_space_intersection.h
+++ b/geometry/proximity/mesh_half_space_intersection.h
@@ -1,98 +1,16 @@
 #pragma once
 
-#include <array>
-#include <cmath>
-#include <limits>
 #include <unordered_map>
-#include <utility>
 #include <vector>
 
 #include "drake/common/eigen_types.h"
 #include "drake/common/sorted_pair.h"
-#include "drake/geometry/proximity/mesh_intersection.h"
+#include "drake/geometry/proximity/posed_half_space.h"
 #include "drake/geometry/proximity/surface_mesh.h"
 
 namespace drake {
 namespace geometry {
-
 namespace internal {
-
-template <typename T>
-int sgn(const T& x) {
-  if (x > 0) {
-    return 1;
-  } else {
-    if (x < 0) return -1;
-    return 0;
-  }
-}
-
-/* Utility routine for getting the vertex index from the
- `edges_to_newly_created_vertices` hashtable. Given an edge (defined by its two
- end-point vertices a and b) and the signed distances from a plane (`s_a` and
- `s_b`, respectively), returns the index of the vertex that splits the edge at a
- crossing plane. The method creates the vertex if the edge hasn't previously
- been split.
-
- @pre s_a and s_b must not have the same sign (positive, negative, or zero) of
-      the plane.
- */
-template <typename T>
-SurfaceVertexIndex GetVertexAddIfNeeded(
-    SurfaceVertexIndex a, SurfaceVertexIndex b, const T& s_a, const T& s_b,
-    const std::vector<SurfaceVertex<T>>& vertices_F,
-    std::unordered_map<SortedPair<SurfaceVertexIndex>, SurfaceVertexIndex>*
-        edges_to_newly_created_vertices,
-    std::vector<SurfaceVertex<T>>* new_vertices_F) {
-  DRAKE_DEMAND(sgn(s_a) != sgn(s_b));
-
-  using std::abs;
-  SortedPair<SurfaceVertexIndex> edge_a_b(a, b);
-  auto edge_a_b_intersection_iter =
-      edges_to_newly_created_vertices->find(edge_a_b);
-  if (edge_a_b_intersection_iter == edges_to_newly_created_vertices->end()) {
-    const T t = abs(s_a) / (abs(s_a) + abs(s_b));
-    // We know that the magnitude of the denominator should always be at
-    // least as large as the magnitude of the numerator (implying that t should
-    // never be greater than unity). Barring an (unlikely) machine epsilon
-    // remainder on division, the assertion below should hold.
-    DRAKE_DEMAND(t >= 0 && t <= 1);
-    bool inserted;
-    std::tie(edge_a_b_intersection_iter, inserted) =
-        edges_to_newly_created_vertices->insert(
-            {edge_a_b, SurfaceVertexIndex(new_vertices_F->size())});
-    DRAKE_DEMAND(inserted);
-    new_vertices_F->emplace_back(
-        vertices_F[a].r_MV() +
-        t * (vertices_F[b].r_MV() - vertices_F[a].r_MV()));
-  }
-
-  return edge_a_b_intersection_iter->second;
-}
-
-/* Utility routine for getting the vertex index from the
- `vertices_to_newly_created_vertices` hashtable. Given a vertex `index` from the
- input mesh, returns the corresponding vertex index in `new_vertices_F`. The
- method creates the vertex in `new_vertices_F` if it hasn't already been added.
- */
-template <typename T>
-SurfaceVertexIndex GetVertexAddIfNeeded(
-    const std::vector<SurfaceVertex<T>>& vertices_F, SurfaceVertexIndex index,
-    std::unordered_map<SurfaceVertexIndex, SurfaceVertexIndex>*
-        vertices_to_newly_created_vertices,
-    std::vector<SurfaceVertex<T>>* new_vertices_F) {
-  auto v_to_new_v_iter = vertices_to_newly_created_vertices->find(index);
-  if (v_to_new_v_iter == vertices_to_newly_created_vertices->end()) {
-    bool inserted;
-    std::tie(v_to_new_v_iter, inserted) =
-        vertices_to_newly_created_vertices->insert(
-            {index, SurfaceVertexIndex(new_vertices_F->size())});
-    DRAKE_DEMAND(inserted);
-    new_vertices_F->emplace_back(vertices_F[index]);
-  }
-
-  return v_to_new_v_iter->second;
-}
 
 /*
  Computes the intersection between a triangle and a half space.
@@ -145,143 +63,14 @@ SurfaceVertexIndex GetVertexAddIfNeeded(
 template <typename T>
 void ConstructTriangleHalfspaceIntersectionPolygon(
     const std::vector<SurfaceVertex<T>>& vertices_F,
-    const SurfaceFace& triangle, const PosedHalfSpace<T>& half_space_F,
+    const SurfaceFace& triangle,
+    const internal::PosedHalfSpace<T>& half_space_F,
     std::vector<SurfaceVertex<T>>* new_vertices_F,
     std::vector<SurfaceFace>* new_faces,
     std::unordered_map<SurfaceVertexIndex, SurfaceVertexIndex>*
         vertices_to_newly_created_vertices,
     std::unordered_map<SortedPair<SurfaceVertexIndex>, SurfaceVertexIndex>*
-        edges_to_newly_created_vertices) {
-  DRAKE_DEMAND(new_vertices_F);
-  DRAKE_DEMAND(new_faces);
-  DRAKE_DEMAND(vertices_to_newly_created_vertices);
-  DRAKE_DEMAND(edges_to_newly_created_vertices);
-
-  // NOLINTNEXTLINE(whitespace/line_length)
-  // This code was inspired from
-  // https://www.geometrictools.com/GTEngine/Include/Mathematics/GteIntrHalfspace3Triangle3.h
-  //
-  // Compute the signed distance of each triangle vertex from the half space.
-  // The table of possibilities is listed next with p = num_positive.
-  //
-  //     p  intersection
-  //     ---------------------------------
-  // 1.  0  triangle (original)
-  // 2.  1  quad (2 edges clipped)
-  // 3.  2  triangle (2 edges clipped)
-  // 4.  3  none
-
-  // Compute the signed distance of each triangle vertex from the half space.
-  T s[3];
-  int num_positive = 0;
-  for (int i = 0; i < 3; ++i) {
-    s[i] =
-        half_space_F.CalcSignedDistance(vertices_F[triangle.vertex(i)].r_MV());
-    if (s[i] > 0) ++num_positive;
-  }
-
-  // Case 1: triangle lies completely within the half space. Preserve
-  // the ordering of the triangle vertices.
-  if (num_positive == 0) {
-    const SurfaceVertexIndex v0_new_index = GetVertexAddIfNeeded(
-        vertices_F, triangle.vertex(0), vertices_to_newly_created_vertices,
-        new_vertices_F);
-    const SurfaceVertexIndex v1_new_index = GetVertexAddIfNeeded(
-        vertices_F, triangle.vertex(1), vertices_to_newly_created_vertices,
-        new_vertices_F);
-    const SurfaceVertexIndex v2_new_index = GetVertexAddIfNeeded(
-        vertices_F, triangle.vertex(2), vertices_to_newly_created_vertices,
-        new_vertices_F);
-
-    new_faces->emplace_back(v0_new_index, v1_new_index, v2_new_index);
-    return;
-  }
-
-  // Case 2: The portion of the triangle in the half space is a quadrilateral.
-  if (num_positive == 1) {
-    for (SurfaceVertexIndex i0(0); i0 < 3; ++i0) {
-      if (s[i0] >= 0) {
-        const SurfaceVertexIndex i1((i0 + 1) % 3);
-        const SurfaceVertexIndex i2((i0 + 2) % 3);
-
-        // Get the vertices that result from intersecting edge i0/i1 and
-        // i0/i2.
-        SurfaceVertexIndex edge_i0_i1_intersection_index = GetVertexAddIfNeeded(
-            i0, i1, s[i0], s[i1], vertices_F, edges_to_newly_created_vertices,
-            new_vertices_F);
-        const SurfaceVertexIndex edge_i0_i2_intersection_index =
-            GetVertexAddIfNeeded(i0, i2, s[i0], s[i2], vertices_F,
-                                 edges_to_newly_created_vertices,
-                                 new_vertices_F);
-
-        // Get the indices of the new vertices, adding them if needed.
-        const SurfaceVertexIndex i1_new_index = GetVertexAddIfNeeded(
-            vertices_F, i1, vertices_to_newly_created_vertices, new_vertices_F);
-        const SurfaceVertexIndex i2_new_index = GetVertexAddIfNeeded(
-            vertices_F, i2, vertices_to_newly_created_vertices, new_vertices_F);
-
-        // Add faces, according to the nice ascii art below (thanks Sean
-        // Curtis!):
-        //
-        //             i0
-        //            ╱╲
-        //       e01 ╱  ╲ e02
-        //    ______╱____╲___
-        //         ╱      ╲
-        //        ╱________╲
-        //      i1          i2
-        //
-        // New triangles to cover the quad and maintain the winding.
-        //   (i1, i2, e01)
-        //   (i2, e02, e01)
-        //
-        new_faces->emplace_back(i1_new_index, i2_new_index,
-                                edge_i0_i1_intersection_index);
-        new_faces->emplace_back(i2_new_index, edge_i0_i2_intersection_index,
-                                edge_i0_i1_intersection_index);
-        return;
-      }
-    }
-
-    DRAKE_UNREACHABLE();
-  }
-
-  // Case 3: The portion of the triangle in the half space is a triangle.
-  if (num_positive == 2) {
-    for (SurfaceVertexIndex i0(0); i0 < 3; ++i0) {
-      if (s[i0] <= 0) {
-        const SurfaceVertexIndex i1((i0 + 1) % 3);
-        const SurfaceVertexIndex i2((i0 + 2) % 3);
-
-        // Get the vertex that corresponds to i0.
-        const SurfaceVertexIndex i0_new_index = GetVertexAddIfNeeded(
-            vertices_F, i0, vertices_to_newly_created_vertices, new_vertices_F);
-
-        // Get the vertex that results from intersecting edge i0/i1.
-        const SurfaceVertexIndex edge_i0_i1_intersection_index =
-            GetVertexAddIfNeeded(i0, i1, s[i0], s[i1], vertices_F,
-                                 edges_to_newly_created_vertices,
-                                 new_vertices_F);
-
-        // Get the vertex that results from intersecting edge i0/i2.
-        const SurfaceVertexIndex edge_i0_i2_intersection_index =
-            GetVertexAddIfNeeded(i0, i2, s[i0], s[i2], vertices_F,
-                                 edges_to_newly_created_vertices,
-                                 new_vertices_F);
-
-        new_faces->emplace_back(i0_new_index, edge_i0_i1_intersection_index,
-                                edge_i0_i2_intersection_index);
-        return;
-      }
-    }
-
-    DRAKE_UNREACHABLE();
-  }
-
-  // Case 4: The triangle is outside the half space.
-  DRAKE_DEMAND(num_positive == 3);
-  return;
-}
+        edges_to_newly_created_vertices);
 
 }  // namespace internal
 
@@ -298,23 +87,8 @@ void ConstructTriangleHalfspaceIntersectionPolygon(
 template <typename T>
 SurfaceMesh<T> ConstructSurfaceMeshFromMeshHalfspaceIntersection(
     const SurfaceMesh<T>& input_mesh_F,
-    const internal::PosedHalfSpace<T>& half_space_F) {
-  std::vector<SurfaceVertex<T>> new_vertices_F;
-  std::vector<SurfaceFace> new_faces;
-  std::unordered_map<SurfaceVertexIndex, SurfaceVertexIndex>
-      vertices_to_newly_created_vertices;
-  std::unordered_map<SortedPair<SurfaceVertexIndex>, SurfaceVertexIndex>
-      edges_to_newly_created_vertices;
+    const internal::PosedHalfSpace<T>& half_space_F);
 
-  for (const SurfaceFace& face : input_mesh_F.faces()) {
-    internal::ConstructTriangleHalfspaceIntersectionPolygon(
-        input_mesh_F.vertices(), face, half_space_F, &new_vertices_F,
-        &new_faces, &vertices_to_newly_created_vertices,
-        &edges_to_newly_created_vertices);
-  }
-
-  return SurfaceMesh<T>(std::move(new_faces), std::move(new_vertices_F));
-}
 
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/proximity/test/mesh_half_space_intersection_test.cc
+++ b/geometry/proximity/test/mesh_half_space_intersection_test.cc
@@ -1,23 +1,31 @@
 #include "drake/geometry/proximity/mesh_half_space_intersection.h"
 
+#include <limits>
+#include <utility>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/autodiff.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/geometry/proximity/contact_surface_utility.h"
+#include "drake/geometry/utilities.h"
 
 namespace drake {
 namespace geometry {
 namespace internal {
 namespace {
 
+using Eigen::Vector3d;
+using math::RigidTransform;
+using math::RotationMatrix;
+using std::move;
+
 template <typename T>
 class MeshHalfspaceIntersectionTest : public ::testing::Test {
  public:
-  /// Returns the posed half space measured and expressed in Frame H.
-  const PosedHalfSpace<T> half_space_H() const { return *half_space_H_; }
-
   // Accessors for data structures used repeatedly.
-  std::vector<SurfaceVertex<T>>& new_vertices() { return new_vertices_; }
+  std::vector<SurfaceVertex<T>>& new_vertices_W() { return new_vertices_W_; }
   std::vector<SurfaceFace>& new_faces() { return new_faces_; }
   std::unordered_map<SurfaceVertexIndex, SurfaceVertexIndex>&
   vertices_to_newly_created_vertices() {
@@ -28,10 +36,11 @@ class MeshHalfspaceIntersectionTest : public ::testing::Test {
     return edges_to_newly_created_vertices_;
   }
 
-  /// Creates a SurfaceMesh with a triangle using the given vertices.
-  SurfaceMesh<T> CreateSurfaceMesh(const Vector3<T>& v0, const Vector3<T>& v1,
-                                   const Vector3<T>& v2) const {
-    std::vector<SurfaceVertex<T>> vertices;
+  /// Creates a SurfaceMesh with a single triangle using the given vertices.
+  SurfaceMesh<double> CreateOneTriangleMesh(const Vector3d& v0,
+                                            const Vector3d& v1,
+                                            const Vector3d& v2) const {
+    std::vector<SurfaceVertex<double>> vertices;
     vertices.emplace_back(v0);
     vertices.emplace_back(v1);
     vertices.emplace_back(v2);
@@ -39,34 +48,91 @@ class MeshHalfspaceIntersectionTest : public ::testing::Test {
     std::vector<SurfaceFace> faces = {SurfaceFace(
         SurfaceVertexIndex(0), SurfaceVertexIndex(1), SurfaceVertexIndex(2))};
 
-    return SurfaceMesh<T>(std::move(faces), std::move(vertices));
+    return SurfaceMesh<double>(move(faces), move(vertices));
+  }
+
+  /// Creates a new SurfaceMesh mesh from the given input mesh, such that the
+  /// resulting mesh has the same domain, but with two differences:
+  ///
+  ///   1. The vertices in the resultant mesh are measured and expressed in
+  ///      Frame W (as opposed to the input mesh's Frame F)
+  ///   2. Each triangle in the input mesh has been turned into three triangles;
+  ///      the original turned into a triangle fan around its centroid.
+  /// This method confirms that the face normal directions are preserved.
+  static SurfaceMesh<double> CreateMeshWithCentroids(
+      const SurfaceMesh<double>& mesh_F, const RigidTransform<T>& X_WF) {
+    using VIndex = SurfaceVertexIndex;
+    using FIndex = SurfaceFaceIndex;
+    constexpr double kEps = 8 * std::numeric_limits<double>::epsilon();
+    const RigidTransform<double>& X_WF_d = convert_to_double(X_WF);
+
+    // All of the original vertices are part of the final mesh. And each face
+    // is a polygon we want to add to the new mesh. So, we copy the vertices
+    // and then simply add polygon after polygon.
+    std::vector<SurfaceFace> new_faces;
+    std::vector<SurfaceVertex<double>> new_vertices_W;
+    std::transform(mesh_F.vertices().begin(), mesh_F.vertices().end(),
+                   std::back_inserter(new_vertices_W),
+                   [&X_WF_d](const SurfaceVertex<double>& v_F) {
+                     return SurfaceVertex<double>{X_WF_d * v_F.r_MV()};
+                   });
+
+    const RotationMatrix<double>& R_WF = X_WF_d.rotation();
+    for (FIndex f_index(0); f_index < mesh_F.num_faces(); ++f_index) {
+      const SurfaceFace& f = mesh_F.element(f_index);
+      // We want to add the triangle fan for the existing face, but also want to
+      // confirm that the new faces have normals that match the input face.
+      std::vector<VIndex> polygon{f.vertex(0), f.vertex(1), f.vertex(2)};
+      const Vector3d& nhat_W = R_WF * mesh_F.face_normal(f_index);
+      AddPolygonToMeshData(polygon, nhat_W, &new_faces, &new_vertices_W);
+
+      // Confirm polygon winding matches between source triangle and triangles
+      // in the new fan.
+      // The triangle fan consists of the last three faces in `new_faces`.
+      const int first_new_face_index = static_cast<int>(new_faces.size()) - 3;
+      for (FIndex j(first_new_face_index); j < new_faces.size(); ++j) {
+        const SurfaceFace& new_face = new_faces[j];
+        const Vector3d& a = new_vertices_W[new_face.vertex(0)].r_MV();
+        const Vector3d& b = new_vertices_W[new_face.vertex(1)].r_MV();
+        const Vector3d& c = new_vertices_W[new_face.vertex(2)].r_MV();
+        const Vector3d new_nhat_W = (b - a).cross((c - a)).normalized();
+        if (!CompareMatrices(nhat_W, new_nhat_W, kEps)) {
+          throw std::runtime_error("Derived mesh's normals are incorrect");
+        }
+      }
+    }
+
+    return SurfaceMesh<double>(move(new_faces), move(new_vertices_W));
   }
 
   // Checks whether two faces from two meshes are equivalent, which we define
   // to mean as some permutation of acceptable windings for the vertices of
   // `fb` yields vertices coincident with those of `fa`.
-  bool AreFacesEquivalent(const SurfaceFace& fa, const SurfaceMesh<T>& mesh_a,
+  bool AreFacesEquivalent(const SurfaceFace& fa,
+                          const SurfaceMesh<double>& mesh_a,
                           const SurfaceFace& fb, const SurfaceMesh<T>& mesh_b) {
+    constexpr double kEps = 10 * std::numeric_limits<double>::epsilon();
     // Get the three vertices from each.
-    std::array<Vector3<T>, 3> vertices_a = {mesh_a.vertex(fa.vertex(0)).r_MV(),
-                                            mesh_a.vertex(fa.vertex(1)).r_MV(),
-                                            mesh_a.vertex(fa.vertex(2)).r_MV()};
+    std::array<Vector3d, 3> vertices_a = {mesh_a.vertex(fa.vertex(0)).r_MV(),
+                                          mesh_a.vertex(fa.vertex(1)).r_MV(),
+                                          mesh_a.vertex(fa.vertex(2)).r_MV()};
     std::array<Vector3<T>, 3> vertices_b = {mesh_b.vertex(fb.vertex(0)).r_MV(),
                                             mesh_b.vertex(fb.vertex(1)).r_MV(),
                                             mesh_b.vertex(fb.vertex(2)).r_MV()};
 
     // Set an array of faces that will be used to determine how the two
-    // triangles align. Each of these faces encodes an acceptable triangle
-    // winding.
+    // triangles align. Each of these faces encodes an "acceptable" triangle
+    // winding. They are "acceptable" because they represent triangles with the
+    // same winding and, therefore, the same normal.
     typedef SurfaceVertexIndex Index;
     std::array<SurfaceFace, 3> permutations = {
         SurfaceFace(Index(0), Index(1), Index(2)),
         SurfaceFace(Index(1), Index(2), Index(0)),
         SurfaceFace(Index(2), Index(0), Index(1))};
 
-    // Verify that at least one of the permutations gives exactly the vertices
-    // from fb. The unit tests permit this since all of the numbers used and
-    // computed have exact floating point representations.
+    // Verify that at least one of the permutations gives essentially the
+    // vertices from fb. We use epsilon because the centroid vertex may have
+    // rounding error in it.
     using std::min;
     T closest_dist = std::numeric_limits<T>::max();
     for (const auto& face : permutations) {
@@ -74,34 +140,34 @@ class MeshHalfspaceIntersectionTest : public ::testing::Test {
       for (int i = 0; i < 3; ++i)
         dist += (vertices_a[face.vertex(i)] - vertices_b[i]).norm();
       closest_dist = min(closest_dist, dist);
-      if (closest_dist == 0.0) break;
+      if (closest_dist <= kEps) break;
     }
 
-    return (closest_dist == 0.0);
+    return closest_dist <= kEps;
   }
 
   // Checks whether two meshes are equivalent, meaning that there is a bijective
   // mapping from every face in mesh a to every face in mesh b. A mapping
   // between faces can only exist if the face in a is considered equivalent to
   // the corresponding face in b -- see AreFacesEquivalent().
-  void VerifyMeshesEquivalent(const SurfaceMesh<T>& mesh1,
-                              const SurfaceMesh<T>& mesh2) {
+  void VerifyMeshesEquivalent(const SurfaceMesh<double>& mesh_a,
+                              const SurfaceMesh<T>& mesh_b) {
     // Simple checks first.
-    ASSERT_EQ(mesh1.num_faces(), mesh2.num_faces());
-    ASSERT_EQ(mesh1.num_vertices(), mesh2.num_vertices());
+    ASSERT_EQ(mesh_a.num_faces(), mesh_b.num_faces());
+    ASSERT_EQ(mesh_a.num_vertices(), mesh_b.num_vertices());
 
     // Iterate through each face of the first mesh, looking for a face from the
     // second mesh that is within the given tolerance. This is a quadratic
     // time algorithm (in the number of faces of the meshes) but we expect the
     // number of faces that this algorithm is run on to be small.
-    std::vector<SurfaceFace> faces_from_mesh2 = mesh2.faces();
-    for (const SurfaceFace& f1 : mesh1.faces()) {
+    std::vector<SurfaceFace> faces_from_mesh_b = mesh_b.faces();
+    for (const SurfaceFace& f1 : mesh_a.faces()) {
       bool found_match = false;
-      for (int i = 0; i < static_cast<int>(faces_from_mesh2.size()); ++i) {
-        if (AreFacesEquivalent(f1, mesh1, faces_from_mesh2[i], mesh2)) {
+      for (int i = 0; i < static_cast<int>(faces_from_mesh_b.size()); ++i) {
+        if (AreFacesEquivalent(f1, mesh_a, faces_from_mesh_b[i], mesh_b)) {
           found_match = true;
-          faces_from_mesh2[i] = faces_from_mesh2.back();
-          faces_from_mesh2.pop_back();
+          faces_from_mesh_b[i] = faces_from_mesh_b.back();
+          faces_from_mesh_b.pop_back();
           break;
         }
       }
@@ -116,45 +182,27 @@ class MeshHalfspaceIntersectionTest : public ::testing::Test {
 
   // Clears all data structures used for constructing the intersection.
   void ClearConstructionDataStructures() {
-    new_vertices().clear();
+    new_vertices_W().clear();
     new_faces().clear();
     vertices_to_newly_created_vertices().clear();
     edges_to_newly_created_vertices().clear();
   }
 
   // Calls the triangle-half space intersection routine using this object's
-  // half space as well as the given mesh and construction data structures.
-  void ConstructTriangleHalfspaceIntersectionPolygon(
-      const SurfaceMesh<T>& mesh,
-      std::vector<SurfaceVertex<T>>* new_vertices_F_in,
-      std::vector<SurfaceFace>* new_faces_in,
-      std::unordered_map<SurfaceVertexIndex, SurfaceVertexIndex>*
-          vertices_to_newly_created_vertices_in,
-      std::unordered_map<SortedPair<SurfaceVertexIndex>, SurfaceVertexIndex>*
-          edges_to_newly_created_vertices_in) {
-    for (const SurfaceFace& face : mesh.faces()) {
-      internal::ConstructTriangleHalfspaceIntersectionPolygon(
-          mesh.vertices(), face, this->half_space_H(),
-          new_vertices_F_in, new_faces_in,
-          vertices_to_newly_created_vertices_in,
-          edges_to_newly_created_vertices_in);
-    }
-  }
-
-  // Convenience function for verifying that the original mesh was output.
-  void VerifyOriginalMeshOutput(
-      const SurfaceMesh<T>& mesh,
-      const std::vector<SurfaceVertex<T>>& new_vertices_in,
-      const std::vector<SurfaceFace>& new_faces_in) {
-    ASSERT_EQ(mesh.num_faces(), new_faces_in.size());
-    ASSERT_EQ(new_vertices_in.size(), mesh.num_vertices());
-    for (SurfaceVertexIndex i(0); i < new_vertices_in.size(); ++i)
-      EXPECT_EQ(new_vertices_in[i].r_MV(), mesh.vertex(i).r_MV());
-    for (SurfaceFaceIndex j(0); j < mesh.num_faces(); ++j) {
-      const SurfaceFace& original_face = mesh.element(j);
-      const SurfaceFace& new_face = new_faces_in[j];
-      for (int i = 0; i < 3; ++i)
-        EXPECT_EQ(new_face.vertex(i), original_face.vertex(i));
+  // half space as well as the test harness's built-in mesh and construction
+  // data structures. The vertices of the final answer will be expressed in the
+  // world frame based on the given relative pose between mesh frame F and
+  // world frame W.
+  void CallConstructTriangleHalfspaceIntersectionPolygon(
+      const SurfaceMesh<double>& mesh_F,
+      const RigidTransform<T> X_WF) {
+    ClearConstructionDataStructures();
+    for (SurfaceFaceIndex f_index(0); f_index < mesh_F.num_elements();
+         ++f_index) {
+      ConstructTriangleHalfspaceIntersectionPolygon(
+          mesh_F, f_index, *this->half_space_F_, X_WF, &this->new_vertices_W_,
+          &this->new_faces_, &this->vertices_to_newly_created_vertices_,
+          &this->edges_to_newly_created_vertices_);
     }
   }
 
@@ -164,35 +212,34 @@ class MeshHalfspaceIntersectionTest : public ::testing::Test {
     // lying on the half space.
     Vector3<T> normal_H(0, 0, 1);
     const Vector3<T> point_H(0, 0, 2);
-    half_space_H_ = std::make_unique<PosedHalfSpace<T>>(normal_H, point_H);
+    half_space_F_ = std::make_unique<PosedHalfSpace<T>>(normal_H, point_H);
   }
 
-  std::vector<SurfaceVertex<T>> new_vertices_;
+  std::vector<SurfaceVertex<T>> new_vertices_W_;
   std::vector<SurfaceFace> new_faces_;
   std::unordered_map<SurfaceVertexIndex, SurfaceVertexIndex>
       vertices_to_newly_created_vertices_;
   std::unordered_map<SortedPair<SurfaceVertexIndex>, SurfaceVertexIndex>
       edges_to_newly_created_vertices_;
-  std::unique_ptr<PosedHalfSpace<T>> half_space_H_;
+  // In this test harness, the half space is always simply defined in the
+  // mesh's frame F.
+  std::unique_ptr<PosedHalfSpace<T>> half_space_F_;
 };  // namespace
 TYPED_TEST_SUITE_P(MeshHalfspaceIntersectionTest);
 
 // Verifies that a triangle that lies fully outside of the half space yields an
 // empty intersection. This covers Case 4 in the code.
 TYPED_TEST_P(MeshHalfspaceIntersectionTest, NoIntersection) {
-  using T = TypeParam;
-
   // Create the mesh, constructing the vertices of the triangle to lie outside
   // the half space.
-  const SurfaceMesh<T> mesh = this->CreateSurfaceMesh(
-      Vector3<T>(0, 0, 3), Vector3<T>(1, 0, 3), Vector3<T>(0, 1, 3));
+  const SurfaceMesh<double> mesh_F = this->CreateOneTriangleMesh(
+      Vector3d(0, 0, 3), Vector3d(1, 0, 3), Vector3d(0, 1, 3));
 
   // Verify no intersection.
-  this->ConstructTriangleHalfspaceIntersectionPolygon(
-      mesh, &this->new_vertices(), &this->new_faces(),
-      &this->vertices_to_newly_created_vertices(),
-      &this->edges_to_newly_created_vertices());
-  EXPECT_TRUE(this->new_vertices().empty());
+  // X_WF = I -- because there is no intersection, the frame of the non-existant
+  // intersection mesh is irrelevant.
+  this->CallConstructTriangleHalfspaceIntersectionPolygon(mesh_F, {});
+  EXPECT_TRUE(this->new_vertices_W().empty());
   EXPECT_TRUE(this->new_faces().empty());
   EXPECT_TRUE(this->vertices_to_newly_created_vertices().empty());
   EXPECT_TRUE(this->edges_to_newly_created_vertices().empty());
@@ -203,56 +250,63 @@ TYPED_TEST_P(MeshHalfspaceIntersectionTest, NoIntersection) {
 TYPED_TEST_P(MeshHalfspaceIntersectionTest, InsideOrOnIntersection) {
   using T = TypeParam;
 
-  // Create the mesh, constructing the vertices of the triangle to lie well
-  // inside the half space.
-  const SurfaceMesh<T> mesh = this->CreateSurfaceMesh(
-      Vector3<T>(3, 5, 1), Vector3<T>(4, 5, 1), Vector3<T>(3, 6, 1));
+  // An arbitrary relationship between Frames W and F -- avoiding additive and
+  // multiplicative identities.
+  const RigidTransform<T> X_WF(
+      RotationMatrix<T>(
+          AngleAxis<T>{M_PI / 7, Vector3<T>{1, 2, 3}.normalized()}),
+      Vector3<T>{-0.25, 0.5, 0.75});
 
-  // Verify the intersection.
-  this->ConstructTriangleHalfspaceIntersectionPolygon(
-      mesh, &this->new_vertices(), &this->new_faces(),
-      &this->vertices_to_newly_created_vertices(),
-      &this->edges_to_newly_created_vertices());
-  this->VerifyOriginalMeshOutput(mesh,
-                                 this->new_vertices(), this->new_faces());
+  {
+    // Case: The triangular mesh lies well inside the half space.
+    const SurfaceMesh<double> mesh_F = this->CreateOneTriangleMesh(
+        Vector3d(3, 5, 1), Vector3d(4, 5, 1), Vector3d(3, 6, 1));
 
-  // Construct the vertices of the triangle to lie exactly on the half space.
-  // Note that this test works because the half space is defined using a
-  // "standard basis" normal vector and simple constant as well a mesh defined
-  // using integral vertex values. If any of these conditions were unmet, this
-  // test might fail.
-  const SurfaceMesh<T> second_mesh = this->CreateSurfaceMesh(
-      Vector3<T>(3, 5, 2), Vector3<T>(4, 5, 2), Vector3<T>(3, 6, 2));
+    this->CallConstructTriangleHalfspaceIntersectionPolygon(mesh_F, X_WF);
 
-  // Verify the intersection.
-  this->ClearConstructionDataStructures();
-  this->ConstructTriangleHalfspaceIntersectionPolygon(
-      second_mesh, &this->new_vertices(), &this->new_faces(),
-      &this->vertices_to_newly_created_vertices(),
-      &this->edges_to_newly_created_vertices());
-  this->VerifyOriginalMeshOutput(second_mesh,
-                                 this->new_vertices(), this->new_faces());
+    // Verify the intersection.
+    SCOPED_TRACE("Single triangle inside half space");
+    this->VerifyMeshesEquivalent(
+        this->CreateMeshWithCentroids(mesh_F, X_WF),
+        SurfaceMesh<T>{move(this->new_faces()), move(this->new_vertices_W())});
+  }
 
-  // Construct two triangles using a shared edge to verify no extraneous
-  // vertices are constructed.
-  std::vector<SurfaceVertex<T>> vertices = {
-      SurfaceVertex<T>(Vector3<T>(4, 5, 2)),
-      SurfaceVertex<T>(Vector3<T>(3, 5, 2)),
-      SurfaceVertex<T>(Vector3<T>(3, 5, 1)),
-      SurfaceVertex<T>(Vector3<T>(2, 5, 2))};
-  typedef SurfaceVertexIndex Index;
-  std::vector<SurfaceFace> faces = {SurfaceFace(Index(0), Index(1), Index(2)),
-                                    SurfaceFace(Index(2), Index(1), Index(3))};
-  const SurfaceMesh<T> third_mesh(std::move(faces), std::move(vertices));
+  {
+    // Case: triangle lies on the boundary plane.
+    const SurfaceMesh<double> mesh_F = this->CreateOneTriangleMesh(
+        Vector3d(3, 5, 2), Vector3d(4, 5, 2), Vector3d(3, 6, 2));
 
-  // Verify the intersection.
-  this->ClearConstructionDataStructures();
-  this->ConstructTriangleHalfspaceIntersectionPolygon(
-      third_mesh, &this->new_vertices(), &this->new_faces(),
-      &this->vertices_to_newly_created_vertices(),
-      &this->edges_to_newly_created_vertices());
-  this->VerifyOriginalMeshOutput(third_mesh,
-                                 this->new_vertices(), this->new_faces());
+    // Verify the intersection.
+    this->CallConstructTriangleHalfspaceIntersectionPolygon(mesh_F, X_WF);
+
+    SCOPED_TRACE("Single triangle on half space boundary");
+    this->VerifyMeshesEquivalent(
+        this->CreateMeshWithCentroids(mesh_F, X_WF),
+        SurfaceMesh<T>{move(this->new_faces()), move(this->new_vertices_W())});
+  }
+
+  {
+    // Case: two triangles with a shared edge, completely enclosed in the half
+    // space. Confirms that no extraneous vertices are introduced.
+    std::vector<SurfaceVertex<double>> vertices = {
+        SurfaceVertex<double>(Vector3d(4, 5, 2)),
+        SurfaceVertex<double>(Vector3d(3, 5, 2)),
+        SurfaceVertex<double>(Vector3d(3, 5, 1)),
+        SurfaceVertex<double>(Vector3d(2, 5, 2))};
+    typedef SurfaceVertexIndex Index;
+    std::vector<SurfaceFace> faces = {
+        SurfaceFace(Index(0), Index(1), Index(2)),
+        SurfaceFace(Index(2), Index(1), Index(3))};
+    const SurfaceMesh<double> mesh_F(move(faces), move(vertices));
+
+    // Verify the intersection.
+    this->CallConstructTriangleHalfspaceIntersectionPolygon(mesh_F, X_WF);
+
+    SCOPED_TRACE("Two triangles with shared edge clipped");
+    this->VerifyMeshesEquivalent(
+        this->CreateMeshWithCentroids(mesh_F, X_WF),
+        SurfaceMesh<T>{move(this->new_faces()), move(this->new_vertices_W())});
+  }
 }
 
 // Verifies that a triangle that has exactly one vertex lying on the half space
@@ -262,49 +316,64 @@ TYPED_TEST_P(MeshHalfspaceIntersectionTest, InsideOrOnIntersection) {
 TYPED_TEST_P(MeshHalfspaceIntersectionTest, VertexOnHalfspaceIntersection) {
   using T = TypeParam;
 
-  // Construct two vertices of the triangle to lie outside the half space and
-  // the other to lie on the half space.
-  const SurfaceMesh<T> mesh = this->CreateSurfaceMesh(
-      Vector3<T>(3, 5, 2), Vector3<T>(4, 5, 3), Vector3<T>(3, 6, 3));
+  // An arbitrary relationship between Frames W and F -- avoiding additive and
+  // multiplicative identities.
+  const RigidTransform<T> X_WF(
+      RotationMatrix<T>(
+          AngleAxis<T>{M_PI / 7, Vector3<T>{1, 2, 3}.normalized()}),
+      Vector3<T>{-0.25, 0.5, 0.75});
 
-  // Verify the degenerate intersection.
-  this->ConstructTriangleHalfspaceIntersectionPolygon(
-      mesh, &this->new_vertices(), &this->new_faces(),
-      &this->vertices_to_newly_created_vertices(),
-      &this->edges_to_newly_created_vertices());
-  EXPECT_EQ(this->new_vertices().size(), 3);
-  EXPECT_EQ(this->new_faces().size(), 1);
-  EXPECT_EQ(this->vertices_to_newly_created_vertices().size(), 1);
-  EXPECT_EQ(this->edges_to_newly_created_vertices().size(), 2);
+  {
+    // Case: one vertex on the boundary, two vertices outside.
+    const SurfaceMesh<double> mesh_F = this->CreateOneTriangleMesh(
+        Vector3d(3, 5, 2), Vector3d(4, 5, 3), Vector3d(3, 6, 3));
 
-  // Check that the mesh that results is equivalent to the expected degenerate
-  // mesh.
-  std::vector<SurfaceVertex<T>> expected_vertices = {
-      SurfaceVertex<T>(Vector3<T>(3, 5, 2)),
-      SurfaceVertex<T>(Vector3<T>(3, 5, 2)),
-      SurfaceVertex<T>(Vector3<T>(3, 5, 2))};
-  typedef SurfaceVertexIndex Index;
-  std::vector<SurfaceFace> expected_faces = {
-      SurfaceFace(Index(0), Index(1), Index(2))};
-  const SurfaceMesh<T> expected_mesh(std::move(expected_faces),
-                                     std::move(expected_vertices));
-  const SurfaceMesh<T> actual_mesh(std::move(this->new_faces()),
-                                   std::move(this->new_vertices()));
-  this->VerifyMeshesEquivalent(expected_mesh, actual_mesh);
+    // Verify the degenerate intersection.
+    this->CallConstructTriangleHalfspaceIntersectionPolygon(mesh_F, X_WF);
 
-  // Construct two vertices of the triangle to lie inside the half space and the
-  // other to lie on the half space.
-  const SurfaceMesh<T> second_mesh = this->CreateSurfaceMesh(
-      Vector3<T>(3, 5, 2), Vector3<T>(4, 5, 1), Vector3<T>(3, 6, 1));
+    EXPECT_EQ(this->new_vertices_W().size(), 4);
+    EXPECT_EQ(this->new_faces().size(), 3);
+    // Evidence that we copied one vertex and split two edges.
+    EXPECT_EQ(this->vertices_to_newly_created_vertices().size(), 1);
+    EXPECT_EQ(this->edges_to_newly_created_vertices().size(), 2);
 
-  // Verify the intersection.
-  this->ClearConstructionDataStructures();
-  this->ConstructTriangleHalfspaceIntersectionPolygon(
-      second_mesh, &this->new_vertices(), &this->new_faces(),
-      &this->vertices_to_newly_created_vertices(),
-      &this->edges_to_newly_created_vertices());
-  this->VerifyOriginalMeshOutput(second_mesh,
-                                 this->new_vertices(), this->new_faces());
+    // Check that the mesh that results is equivalent to the expected degenerate
+    // mesh. The degenerate mesh is a triangle fan around a centroid. We model
+    // the degeneracy as four identical vertices with the appropriate face
+    // topologies.
+    const RigidTransform<double>& X_WF_d = convert_to_double(X_WF);
+    std::vector<SurfaceVertex<double>> expected_vertices_W = {
+        SurfaceVertex<double>(X_WF_d * Vector3d(3, 5, 2)),
+        SurfaceVertex<double>(X_WF_d * Vector3d(3, 5, 2)),
+        SurfaceVertex<double>(X_WF_d * Vector3d(3, 5, 2)),
+        SurfaceVertex<double>(X_WF_d * Vector3d(3, 5, 2))};
+    typedef SurfaceVertexIndex Index;
+    std::vector<SurfaceFace> expected_faces = {
+        SurfaceFace(Index(0), Index(1), Index(3)),
+        SurfaceFace(Index(1), Index(2), Index(3)),
+        SurfaceFace(Index(2), Index(0), Index(3))};
+    const SurfaceMesh<double> expected_mesh_W(move(expected_faces),
+                                              move(expected_vertices_W));
+    const SurfaceMesh<T> actual_mesh_W(move(this->new_faces()),
+                                       move(this->new_vertices_W()));
+
+    SCOPED_TRACE("Triangle outside half space has single vertex on the plane");
+    this->VerifyMeshesEquivalent(expected_mesh_W, actual_mesh_W);
+  }
+
+  {
+    // Case: one vertex on the boundary, two vertices inside.
+    const SurfaceMesh<double> mesh_F = this->CreateOneTriangleMesh(
+        Vector3d(3, 5, 2), Vector3d(4, 5, 1), Vector3d(3, 6, 1));
+
+    // Verify the intersection.
+    this->CallConstructTriangleHalfspaceIntersectionPolygon(mesh_F, X_WF);
+
+    SCOPED_TRACE("Triangle inside half space has single vertex on the plane");
+    this->VerifyMeshesEquivalent(
+        this->CreateMeshWithCentroids(mesh_F, X_WF),
+        SurfaceMesh<T>{move(this->new_faces()), move(this->new_vertices_W())});
+  }
 }
 
 // Verifies that a triangle that has exactly two vertices lying on the half
@@ -314,60 +383,71 @@ TYPED_TEST_P(MeshHalfspaceIntersectionTest, VertexOnHalfspaceIntersection) {
 TYPED_TEST_P(MeshHalfspaceIntersectionTest, EdgeOnHalfspaceIntersection) {
   using T = TypeParam;
 
-  // Construct one vertex of the triangle to lie outside the half space and the
-  // other two to lie on the half space.
-  const SurfaceMesh<T> mesh = this->CreateSurfaceMesh(
-      Vector3<T>(3, 5, 3), Vector3<T>(2, 5, 2), Vector3<T>(4, 5, 2));
+  // An arbitrary relationship between Frames W and F -- avoiding additive and
+  // multiplicative identities.
+  const RigidTransform<T> X_WF(
+      RotationMatrix<T>(
+          AngleAxis<T>{M_PI / 7, Vector3<T>{1, 2, 3}.normalized()}),
+      Vector3<T>{-0.25, 0.5, 0.75});
 
-  // Verify that there is no intersection.
-  this->ConstructTriangleHalfspaceIntersectionPolygon(
-      mesh, &this->new_vertices(), &this->new_faces(),
-      &this->vertices_to_newly_created_vertices(),
-      &this->edges_to_newly_created_vertices());
-  EXPECT_EQ(this->new_vertices().size(), 4);
-  EXPECT_EQ(this->new_faces().size(), 2);
-  EXPECT_EQ(this->vertices_to_newly_created_vertices().size(), 2);
-  EXPECT_EQ(this->edges_to_newly_created_vertices().size(), 2);
+  {
+    // Case: two vertices on the boundary, one outside.
+    const SurfaceMesh<double> mesh_F = this->CreateOneTriangleMesh(
+        Vector3d(3, 5, 3), Vector3d(2, 5, 2), Vector3d(4, 5, 2));
 
-  //                   a
-  //                   ╱╲
-  // ^ z              ╱  ╲
-  // |         ______╱____╲_____
-  // |            b/e      c/d
-  // |
-  // |
-  // --------> x
+    this->CallConstructTriangleHalfspaceIntersectionPolygon(mesh_F, X_WF);
 
-  // Check that the mesh that results is equivalent to the expected degenerate
-  // mesh.
-  std::vector<SurfaceVertex<T>> expected_vertices = {
-      SurfaceVertex<T>(Vector3<T>(2, 5, 2)),
-      SurfaceVertex<T>(Vector3<T>(4, 5, 2)),
-      SurfaceVertex<T>(Vector3<T>(4, 5, 2)),
-      SurfaceVertex<T>(Vector3<T>(2, 5, 2))};
-  typedef SurfaceVertexIndex Index;
-  const Index b(0), c(1), d(2), e(3);
-  std::vector<SurfaceFace> expected_faces = {SurfaceFace(b, c, e),
-                                             SurfaceFace(c, d, e)};
-  const SurfaceMesh<T> expected_mesh(std::move(expected_faces),
-                                     std::move(expected_vertices));
-  const SurfaceMesh<T> actual_mesh(std::move(this->new_faces()),
-                                   std::move(this->new_vertices()));
-  this->VerifyMeshesEquivalent(expected_mesh, actual_mesh);
+    EXPECT_EQ(this->new_vertices_W().size(), 5);
+    EXPECT_EQ(this->new_faces().size(), 4);
+    EXPECT_EQ(this->vertices_to_newly_created_vertices().size(), 2);
+    EXPECT_EQ(this->edges_to_newly_created_vertices().size(), 2);
 
-  // Construct one vertex of the triangle to lie inside the half space and the
-  // other two to lie on the half space.
-  const SurfaceMesh<T> second_mesh = this->CreateSurfaceMesh(
-      Vector3<T>(3, 5, 1), Vector3<T>(4, 5, 2), Vector3<T>(3, 6, 2));
+    //                    a
+    //                   ╱ ╲
+    // ^ z              ╱   ╲
+    // |         ______╱__.__╲_____
+    // |         ▒▒▒b/e▒▒▒f▒▒▒c/d▒▒
+    // |         ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
+    // |         ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
+    // --------> x
+    //
+    // The degenerate quad is formed by (b, c, d, e) which results in a triangle
+    // fan around centroid f.
 
-  // Verify the intersection.
-  this->ClearConstructionDataStructures();
-  this->ConstructTriangleHalfspaceIntersectionPolygon(
-      second_mesh, &this->new_vertices(), &this->new_faces(),
-      &this->vertices_to_newly_created_vertices(),
-      &this->edges_to_newly_created_vertices());
-  this->VerifyOriginalMeshOutput(second_mesh,
-                                 this->new_vertices(), this->new_faces());
+    // Check that the mesh that results is equivalent to the expected degenerate
+    // mesh.
+    const RigidTransform<double>& X_WF_d = convert_to_double(X_WF);
+    std::vector<SurfaceVertex<double>> expected_vertices = {
+        SurfaceVertex<double>(X_WF_d * Vector3d(2, 5, 2)),
+        SurfaceVertex<double>(X_WF_d * Vector3d(4, 5, 2)),
+        SurfaceVertex<double>(X_WF_d * Vector3d(4, 5, 2)),
+        SurfaceVertex<double>(X_WF_d * Vector3d(2, 5, 2)),
+        SurfaceVertex<double>(X_WF_d * Vector3d(3, 5, 2))};
+    typedef SurfaceVertexIndex Index;
+    const Index b(0), c(1), d(2), e(3), f(4);
+    std::vector<SurfaceFace> expected_faces = {
+        SurfaceFace(b, c, f), SurfaceFace(c, d, f), SurfaceFace(d, e, f),
+        SurfaceFace(e, b, f)};
+
+    SCOPED_TRACE("Triangle outside half space has single edge on the plane");
+    this->VerifyMeshesEquivalent(
+        SurfaceMesh<double>{move(expected_faces), move(expected_vertices)},
+        SurfaceMesh<T>{move(this->new_faces()), move(this->new_vertices_W())});
+  }
+
+  {
+    // Case: two vertices on the boundary, one vertex inside.
+    const SurfaceMesh<double> mesh_F = this->CreateOneTriangleMesh(
+        Vector3d(3, 5, 1), Vector3d(4, 5, 2), Vector3d(3, 6, 2));
+
+    // Verify the intersection.
+    this->CallConstructTriangleHalfspaceIntersectionPolygon(mesh_F, X_WF);
+
+    SCOPED_TRACE("Triangle inside half space has single edge on the plane");
+    this->VerifyMeshesEquivalent(
+        this->CreateMeshWithCentroids(mesh_F, X_WF),
+        SurfaceMesh<T>{move(this->new_faces()), move(this->new_vertices_W())});
+  }
 }
 
 // Verifies that a triangle that has two vertices within the half space and
@@ -375,44 +455,58 @@ TYPED_TEST_P(MeshHalfspaceIntersectionTest, EdgeOnHalfspaceIntersection) {
 TYPED_TEST_P(MeshHalfspaceIntersectionTest, QuadrilateralResults) {
   using T = TypeParam;
 
+  // An arbitrary relationship between Frames W and F -- avoiding additive and
+  // multiplicative identities.
+  const RigidTransform<T> X_WF(
+      RotationMatrix<T>(
+          AngleAxis<T>{M_PI / 7, Vector3<T>{1, 2, 3}.normalized()}),
+      Vector3<T>{-0.25, 0.5, 0.75});
+
   // Construct one vertex of the triangle to lie outside the half space and the
   // other two to lie inside the half space.
-  const SurfaceMesh<T> mesh = this->CreateSurfaceMesh(
-      Vector3<T>(3, 5, 3), Vector3<T>(2, 5, 1), Vector3<T>(4, 5, 1));
+  const SurfaceMesh<double> mesh_F = this->CreateOneTriangleMesh(
+      Vector3d(3, 5, 3), Vector3d(2, 5, 1), Vector3d(4, 5, 1));
+
+  const Vector3d nhat_F =
+      (mesh_F.vertices()[1].r_MV() - mesh_F.vertices()[0].r_MV())
+          .cross(mesh_F.vertices()[2].r_MV() - mesh_F.vertices()[0].r_MV())
+          .normalized();
 
   //                   a
   //                   ╱╲
   // ^ z              ╱  ╲
-  // |         _____e╱____╲d___
-  // |              ╱      ╲
-  // |             ╱________╲
-  // |            b          c
+  // |         _____e╱____╲d____
+  // |         ▒▒▒▒▒╱▒▒▒▒▒▒╲▒▒▒▒
+  // |         ▒▒▒▒╱________╲▒▒▒
+  // |         ▒▒▒b▒▒▒▒▒▒▒▒▒▒c▒▒
+  // |         ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
   // --------> x
 
   // Verify the intersection.
-  this->ConstructTriangleHalfspaceIntersectionPolygon(
-      mesh, &this->new_vertices(), &this->new_faces(),
-      &this->vertices_to_newly_created_vertices(),
-      &this->edges_to_newly_created_vertices());
-  ASSERT_EQ(this->new_faces().size(), 2);
-  ASSERT_EQ(this->new_vertices().size(), 4);
+  this->CallConstructTriangleHalfspaceIntersectionPolygon(mesh_F, X_WF);
+
+  ASSERT_EQ(this->new_faces().size(), 4);
+  ASSERT_EQ(this->new_vertices_W().size(), 5);
+  EXPECT_EQ(this->vertices_to_newly_created_vertices().size(), 2);
   ASSERT_EQ(this->edges_to_newly_created_vertices().size(), 2);
 
   // Check that the mesh that results is equivalent to the expected mesh.
-  std::vector<SurfaceVertex<T>> expected_vertices = {
-      SurfaceVertex<T>(Vector3<T>(2, 5, 1)),    // b
-      SurfaceVertex<T>(Vector3<T>(4, 5, 1)),     // c
-      SurfaceVertex<T>(Vector3<T>(3.5, 5, 2)),    // d
-      SurfaceVertex<T>(Vector3<T>(2.5, 5, 2))};  // e
+  const RigidTransform<double>& X_WF_d = convert_to_double(X_WF);
+  std::vector<SurfaceVertex<double>> expected_vertices_W = {
+      SurfaceVertex<double>(X_WF_d * Vector3d(2, 5, 1)),     // b
+      SurfaceVertex<double>(X_WF_d * Vector3d(4, 5, 1)),     // c
+      SurfaceVertex<double>(X_WF_d * Vector3d(3.5, 5, 2)),   // d
+      SurfaceVertex<double>(X_WF_d * Vector3d(2.5, 5, 2))};  // e
+  std::vector<SurfaceFace> expected_faces;
   typedef SurfaceVertexIndex Index;
   const Index b(0), c(1), d(2), e(3);
-  std::vector<SurfaceFace> expected_faces = {SurfaceFace(b, c, e),
-                                             SurfaceFace(c, d, e)};
-  const SurfaceMesh<T> expected_mesh(std::move(expected_faces),
-                                     std::move(expected_vertices));
-  const SurfaceMesh<T> actual_mesh(std::move(this->new_faces()),
-                                   std::move(this->new_vertices()));
-  this->VerifyMeshesEquivalent(expected_mesh, actual_mesh);
+  std::vector<Index> polygon{b, c, d, e};
+  AddPolygonToMeshData(polygon, nhat_F, &expected_faces, &expected_vertices_W);
+
+  SCOPED_TRACE("Triangle intersects; forms quad");
+  this->VerifyMeshesEquivalent(
+      SurfaceMesh<double>{move(expected_faces), move(expected_vertices_W)},
+      SurfaceMesh<T>{move(this->new_faces()), move(this->new_vertices_W())});
 }
 
 // Verifies that a triangle that has one vertex outside the half space, one
@@ -421,40 +515,56 @@ TYPED_TEST_P(MeshHalfspaceIntersectionTest, QuadrilateralResults) {
 TYPED_TEST_P(MeshHalfspaceIntersectionTest, OutsideInsideOn) {
   using T = TypeParam;
 
-  const SurfaceMesh<T> mesh = this->CreateSurfaceMesh(
-      Vector3<T>(3, 5, 3), Vector3<T>(2, 5, 1), Vector3<T>(3.5, 5, 2));
+  // An arbitrary relationship between Frames W and F -- avoiding additive and
+  // multiplicative identities.
+  const RigidTransform<T> X_WF(
+      RotationMatrix<T>(
+          AngleAxis<T>{M_PI / 7, Vector3<T>{1, 2, 3}.normalized()}),
+      Vector3<T>{-0.25, 0.5, 0.75});
+
+  const SurfaceMesh<double> mesh_F = this->CreateOneTriangleMesh(
+      Vector3d(3, 5, 3), Vector3d(2, 5, 1), Vector3d(3.5, 5, 2));
+
+  const Vector3d nhat_F =
+      (mesh_F.vertices()[1].r_MV() - mesh_F.vertices()[0].r_MV())
+          .cross(mesh_F.vertices()[2].r_MV() - mesh_F.vertices()[0].r_MV())
+          .normalized();
 
   // Verify the intersection.
-  this->ConstructTriangleHalfspaceIntersectionPolygon(
-      mesh, &this->new_vertices(), &this->new_faces(),
-      &this->vertices_to_newly_created_vertices(),
-      &this->edges_to_newly_created_vertices());
+  this->CallConstructTriangleHalfspaceIntersectionPolygon(mesh_F, X_WF);
+
   ASSERT_EQ(this->edges_to_newly_created_vertices().size(), 2);
 
   //                   a
   //                   ╱╲
   // ^ z              ╱  ╲
   // |         _____e╱____╲c/d___
-  // |              ╱
-  // |             ╱
-  // |            b
+  // |         ▒▒▒▒▒╱▒▒▒▒▒▒▒▒▒▒▒▒
+  // |         ▒▒▒▒╱▒▒▒▒▒▒▒▒▒▒▒▒▒
+  // |         ▒▒▒b▒▒▒▒▒▒▒▒▒▒▒▒▒▒
+  // |         ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
   // --------> x
+  //
+  // Note: there is an unvisualized edge between vertices b and c -- ascii art
+  // can't draw a line at that angle.
 
   // Check that the mesh that results is equivalent to the expected mesh.
-  std::vector<SurfaceVertex<T>> expected_vertices = {
-      SurfaceVertex<T>(Vector3<T>(2, 5, 1)),    // b
-      SurfaceVertex<T>(Vector3<T>(3.5, 5, 2)),    // c
-      SurfaceVertex<T>(Vector3<T>(3.5, 5, 2)),    // d
-      SurfaceVertex<T>(Vector3<T>(2.5, 5, 2))};  // e
+  const RigidTransform<double>& X_WF_d = convert_to_double(X_WF);
+  std::vector<SurfaceVertex<double>> expected_vertices_W = {
+      SurfaceVertex<double>(X_WF_d * Vector3d(2, 5, 1)),      // b
+      SurfaceVertex<double>(X_WF_d * Vector3d(3.5, 5, 2)),    // c
+      SurfaceVertex<double>(X_WF_d * Vector3d(3.5, 5, 2)),    // d
+      SurfaceVertex<double>(X_WF_d * Vector3d(2.5, 5, 2))};   // e
+  std::vector<SurfaceFace> expected_faces;
   typedef SurfaceVertexIndex Index;
   const Index b(0), c(1), d(2), e(3);
-  std::vector<SurfaceFace> expected_faces = {SurfaceFace(b, c, e),
-                                             SurfaceFace(c, d, e)};
-  const SurfaceMesh<T> expected_mesh(std::move(expected_faces),
-                                     std::move(expected_vertices));
-  const SurfaceMesh<T> actual_mesh(std::move(this->new_faces()),
-                                   std::move(this->new_vertices()));
-  this->VerifyMeshesEquivalent(expected_mesh, actual_mesh);
+  std::vector<Index> polygon{b, c, d, e};
+  AddPolygonToMeshData(polygon, nhat_F, &expected_faces, &expected_vertices_W);
+
+  SCOPED_TRACE("Triangle intersects; single vertex on boundary");
+  this->VerifyMeshesEquivalent(
+      SurfaceMesh<double>{move(expected_faces), move(expected_vertices_W)},
+      SurfaceMesh<T>{move(this->new_faces()), move(this->new_vertices_W())});
 }
 
 // Verifies that a triangle with one vertex inside the half space and two
@@ -463,28 +573,48 @@ TYPED_TEST_P(MeshHalfspaceIntersectionTest, OutsideInsideOn) {
 TYPED_TEST_P(MeshHalfspaceIntersectionTest, OneInsideTwoOutside) {
   using T = TypeParam;
 
-  const SurfaceMesh<T> mesh = this->CreateSurfaceMesh(
-      Vector3<T>(3, 5, 3), Vector3<T>(4, 5, 3), Vector3<T>(3, 6, 1));
+  // An arbitrary relationship between Frames W and F -- avoiding additive and
+  // multiplicative identities.
+  const RigidTransform<T> X_WF(
+      RotationMatrix<T>(
+          AngleAxis<T>{M_PI / 7, Vector3<T>{1, 2, 3}.normalized()}),
+      Vector3<T>{-0.25, 0.5, 0.75});
+
+  const SurfaceMesh<double> mesh_F = this->CreateOneTriangleMesh(
+      Vector3d(3, 5, 3), Vector3d(4, 5, 3), Vector3d(3, 6, 1));
+
+  const Vector3d nhat_F =
+      (mesh_F.vertices()[1].r_MV() - mesh_F.vertices()[0].r_MV())
+          .cross(mesh_F.vertices()[2].r_MV() - mesh_F.vertices()[0].r_MV())
+          .normalized();
+
+  // ^ z
+  // |            b ________ c
+  // |              ╲      ╱
+  // |         _____e╲____╱d____
+  // |         ▒▒▒▒▒▒▒╲▒▒╱▒▒▒▒▒▒
+  // |         ▒▒▒▒▒▒▒▒╲╱▒▒▒▒▒▒▒
+  // |         ▒▒▒▒▒▒▒▒a▒▒▒▒▒▒▒▒
+  // --------> x
 
   // Verify the intersection.
-  this->ConstructTriangleHalfspaceIntersectionPolygon(
-      mesh, &this->new_vertices(), &this->new_faces(),
-      &this->vertices_to_newly_created_vertices(),
-      &this->edges_to_newly_created_vertices());
+  this->CallConstructTriangleHalfspaceIntersectionPolygon(mesh_F, X_WF);
 
   // Check that the mesh that results is equivalent to the expected mesh.
-  std::vector<SurfaceVertex<T>> expected_vertices = {
-      SurfaceVertex<T>(Vector3<T>(3, 6, 1)),
-      SurfaceVertex<T>(Vector3<T>(3, 5.5, 2)),
-      SurfaceVertex<T>(Vector3<T>(3.5, 5.5, 2))};
+  const RigidTransform<double>& X_WF_d = convert_to_double(X_WF);
+  std::vector<SurfaceVertex<double>> expected_vertices_W = {
+      SurfaceVertex<double>(X_WF_d * Vector3d(3, 6, 1)),
+      SurfaceVertex<double>(X_WF_d * Vector3d(3, 5.5, 2)),
+      SurfaceVertex<double>(X_WF_d * Vector3d(3.5, 5.5, 2))};
+  std::vector<SurfaceFace> expected_faces;
   typedef SurfaceVertexIndex Index;
-  std::vector<SurfaceFace> expected_faces = {
-      SurfaceFace(Index(0), Index(1), Index(2))};
-  const SurfaceMesh<T> expected_mesh(std::move(expected_faces),
-                                     std::move(expected_vertices));
-  const SurfaceMesh<T> actual_mesh(std::move(this->new_faces()),
-                                   std::move(this->new_vertices()));
-  this->VerifyMeshesEquivalent(expected_mesh, actual_mesh);
+  std::vector<Index> polygon{Index(0), Index(1), Index(2)};
+  AddPolygonToMeshData(polygon, nhat_F, &expected_faces, &expected_vertices_W);
+
+  SCOPED_TRACE("Triangle intersects; forms a smaller triangle");
+  this->VerifyMeshesEquivalent(
+      SurfaceMesh<double>{move(expected_faces), move(expected_vertices_W)},
+      SurfaceMesh<T>{move(this->new_faces()), move(this->new_vertices_W())});
 }
 
 // Tests that a mesh of a box bisected by the half space produces the expected
@@ -493,12 +623,20 @@ TYPED_TEST_P(MeshHalfspaceIntersectionTest, OneInsideTwoOutside) {
 TYPED_TEST_P(MeshHalfspaceIntersectionTest, BoxMesh) {
   using T = TypeParam;
 
+  // An arbitrary relationship between Frames W and F -- avoiding additive and
+  // multiplicative identities.
+  const RigidTransform<T> X_WF(
+      RotationMatrix<T>(
+          AngleAxis<T>{M_PI / 7, Vector3<T>{1, 2, 3}.normalized()}),
+      Vector3<T>{-0.25, 0.5, 0.75});
+
+
   // Set the box vertices according to the following diagram. The box is
-  // centered at the origin of Frame F. Introducing this frame makes it less
-  // likely that all of the underlying tests might succeed because of some
-  // fortuitous initial values. The halfspace normal points along F's +z axis.
-  // Set the box vertices according to the following diagram. The box is
-  // centered at the origin.
+  // centered at the origin of Frame B. We transform it to some query frame F,
+  // making it less  likely that all of the underlying functionality succeeds
+  // because of some fortuitous initial values. The half space's boundary plane
+  // is z = 0 in Frame B. Set the box vertices according to the following
+  // diagram.
   //               v₁      +Z         v₃
   //               ●───────┆─────────●
   //              /│       ┆        /│
@@ -514,54 +652,68 @@ TYPED_TEST_P(MeshHalfspaceIntersectionTest, BoxMesh) {
   //                 /
   //                +X
 
-  // Set F to an arbitrarily chosen pose relative to the world frame.
-  math::RigidTransform<T> X_WF(math::RollPitchYaw<T>(M_PI_4, M_PI_4, M_PI_4),
+  // Set B to an arbitrarily chosen pose relative to F.
+  RigidTransform<T> X_FB(math::RollPitchYaw<T>(M_PI_4, M_PI_4, M_PI_4),
                                Vector3<T>(1.0, 2.0, 3.0));
+  RigidTransform<double> X_FB_d = convert_to_double(X_FB);
 
-  std::vector<SurfaceVertex<T>> vertices_W;
-  vertices_W.emplace_back(X_WF * Vector3<T>(-1, -1, -1));
-  vertices_W.emplace_back(X_WF * Vector3<T>(-1, -1, 1));
-  vertices_W.emplace_back(X_WF * Vector3<T>(-1, 1, -1));
-  vertices_W.emplace_back(X_WF * Vector3<T>(-1, 1, 1));
-  vertices_W.emplace_back(X_WF * Vector3<T>(1, -1, -1));
-  vertices_W.emplace_back(X_WF * Vector3<T>(1, -1, 1));
-  vertices_W.emplace_back(X_WF * Vector3<T>(1, 1, -1));
-  vertices_W.emplace_back(X_WF * Vector3<T>(1, 1, 1));
+  std::vector<SurfaceVertex<double>> vertices_F;
+  vertices_F.emplace_back(X_FB_d * Vector3d(-1, -1, -1));
+  vertices_F.emplace_back(X_FB_d * Vector3d(-1, -1, 1));
+  vertices_F.emplace_back(X_FB_d * Vector3d(-1, 1, -1));
+  vertices_F.emplace_back(X_FB_d * Vector3d(-1, 1, 1));
+  vertices_F.emplace_back(X_FB_d * Vector3d(1, -1, -1));
+  vertices_F.emplace_back(X_FB_d * Vector3d(1, -1, 1));
+  vertices_F.emplace_back(X_FB_d * Vector3d(1, 1, -1));
+  vertices_F.emplace_back(X_FB_d * Vector3d(1, 1, 1));
 
   // Set the twelve box faces using a counter-clockwise winding.
-  typedef SurfaceVertexIndex Index;
+  typedef SurfaceVertexIndex VIndex;
   std::vector<SurfaceFace> faces;
-  faces.emplace_back(Index(4), Index(6), Index(7));  // +X face
-  faces.emplace_back(Index(7), Index(5), Index(4));  // +X face
-  faces.emplace_back(Index(1), Index(3), Index(2));  // -X face
-  faces.emplace_back(Index(2), Index(0), Index(1));  // -X face
-  faces.emplace_back(Index(2), Index(3), Index(7));  // +Y face
-  faces.emplace_back(Index(7), Index(6), Index(2));  // +Y face
-  faces.emplace_back(Index(4), Index(5), Index(1));  // -Y face
-  faces.emplace_back(Index(1), Index(0), Index(4));  // -Y face
-  faces.emplace_back(Index(7), Index(3), Index(1));  // +Z face
-  faces.emplace_back(Index(1), Index(5), Index(7));  // +Z face
-  faces.emplace_back(Index(4), Index(0), Index(2));  // -Z face
-  faces.emplace_back(Index(2), Index(6), Index(4));  // -Z face
+  faces.emplace_back(VIndex(4), VIndex(6), VIndex(7));  // +X face
+  faces.emplace_back(VIndex(7), VIndex(5), VIndex(4));  // +X face
+  faces.emplace_back(VIndex(1), VIndex(3), VIndex(2));  // -X face
+  faces.emplace_back(VIndex(2), VIndex(0), VIndex(1));  // -X face
+  faces.emplace_back(VIndex(2), VIndex(3), VIndex(7));  // +Y face
+  faces.emplace_back(VIndex(7), VIndex(6), VIndex(2));  // +Y face
+  faces.emplace_back(VIndex(4), VIndex(5), VIndex(1));  // -Y face
+  faces.emplace_back(VIndex(1), VIndex(0), VIndex(4));  // -Y face
+  faces.emplace_back(VIndex(7), VIndex(3), VIndex(1));  // +Z face
+  faces.emplace_back(VIndex(1), VIndex(5), VIndex(7));  // +Z face
+  faces.emplace_back(VIndex(4), VIndex(0), VIndex(2));  // -Z face
+  faces.emplace_back(VIndex(2), VIndex(6), VIndex(4));  // -Z face
 
   // Construct the mesh.
-  const SurfaceMesh<T> mesh(std::move(faces), std::move(vertices_W));
+  const SurfaceMesh<double> mesh_F(move(faces), move(vertices_F));
 
   // Construct the half-space.
-  const Vector3<T> half_space_normal_W = X_WF.rotation() * Vector3<T>(0, 0, 1);
-  const PosedHalfSpace<T> half_space_W(half_space_normal_W, X_WF.translation());
+  const Vector3<T> Bz_F = X_FB.rotation().col(2);
+  const PosedHalfSpace<T> half_space_F(Bz_F, X_FB.translation());
 
   // Compute the intersection.
-  const SurfaceMesh<T> intersection_mesh =
-      ConstructSurfaceMeshFromMeshHalfspaceIntersection(
-          mesh, half_space_W);
-  ASSERT_EQ(intersection_mesh.num_vertices(), 8);
+  typedef SurfaceFaceIndex FIndex;
+  std::vector<FIndex> tri_indices(mesh_F.num_elements());
+  std::iota(tri_indices.begin(), tri_indices.end(), FIndex{0});
 
-  // Note: The sides of the box facing the +/- X and +/- Y directions are each
-  // split into three triangles. The side of the box facing -Z is fully enclosed
-  // (two more triangles) yielding 4 x 3 + 2 = 14 triangles. (The side facing +Z
-  // is outside the half space.)
-  ASSERT_EQ(intersection_mesh.num_faces(), 14);
+  const SurfaceMesh<T> intersection_mesh_W =
+      ConstructSurfaceMeshFromMeshHalfspaceIntersection(
+          mesh_F, half_space_F, tri_indices, X_WF);
+  // Total number of vertices:            22
+  //   -------------------------------------
+  //   vertices lying in half space:       4
+  //   vertices from split edges:          8
+  //   centroid per intersection polygon: 10
+  ASSERT_EQ(intersection_mesh_W.num_vertices(), 22);
+
+  // Each of the +/- X, Y faces of the box have two triangles. They get clipped
+  // into a triangle and quad. Each of those is transformed into a triangle
+  // fan around its centroid, producing 3 and 4 triangles for a total of seven
+  // per direction.
+  // Total number of faces:                         34
+  //   -----------------------------------------------
+  //   -Z triangles, each fanned around centroid:    6
+  //   4 X new triangles per box face:      7 * 4 = 28
+  ASSERT_EQ(intersection_mesh_W.num_faces(), 34);
 }
 
 REGISTER_TYPED_TEST_SUITE_P(MeshHalfspaceIntersectionTest, NoIntersection,
@@ -570,6 +722,17 @@ REGISTER_TYPED_TEST_SUITE_P(MeshHalfspaceIntersectionTest, NoIntersection,
                            EdgeOnHalfspaceIntersection, QuadrilateralResults,
                            OutsideInsideOn, OneInsideTwoOutside, BoxMesh);
 
+// TODO(SeanCurtis-TRI): All of the tests where we actually examine the mesh
+//  use a mesh with a _single_ triangle. In this case, the face-local index
+//  values are perfectly aligned with the mesh-local index values. This hides
+//  potential errors where the two sets of indices do _not_ align so nicely.
+//  Add a test where we intersect a face that doesn't use vertices 0, 1, and 2.
+
+// TODO(SeanCurtis-TRI): The AutoDiffXd type here is *largely* a smoke test.
+//  We're confirming that it builds and that it runs. We're also confirming that
+//  the _value_ is correct -- we have _not_ validated that the derivative values
+//  are correct. That still needs to be done when AutoDiffXd support for
+//  hydroelastics is fully supported.
 typedef ::testing::Types<double, AutoDiffXd> MyTypes;
 INSTANTIATE_TYPED_TEST_SUITE_P(My, MeshHalfspaceIntersectionTest, MyTypes);
 

--- a/geometry/proximity/test/mesh_half_space_intersection_test.cc
+++ b/geometry/proximity/test/mesh_half_space_intersection_test.cc
@@ -7,9 +7,8 @@
 
 namespace drake {
 namespace geometry {
+namespace internal {
 namespace {
-
-using internal::PosedHalfSpace;
 
 template <typename T>
 class MeshHalfspaceIntersectionTest : public ::testing::Test {
@@ -575,5 +574,6 @@ typedef ::testing::Types<double, AutoDiffXd> MyTypes;
 INSTANTIATE_TYPED_TEST_SUITE_P(My, MeshHalfspaceIntersectionTest, MyTypes);
 
 }  // namespace
+}  // namespace internal
 }  // namespace geometry
 }  // namespace drake


### PR DESCRIPTION
The previous mesh-half space mesh intersection had been written in an isolated context. This updates the interface/APIs to provide slightly different functionality:

   - The resultant contact surface *mesh* is defined in the world frame.
  - Every intersected polygon uses the common centroid-generating algorithm for adding itself into the data.
  - Modify the interface to be compatible with broadphase culling.
  - Modification that input meshes are *strictly* double-valued.
  - Found and corrected indexing error; face-local indices [0, 3) were being passed to access mesh-local vertex positions (indexed in the range [0, N)). This was discovered only indirectly in debug build because the polygon constructed had the wrong normal compared to the face it came from.

Furthermore, the implementation has been moved to a .cc file and into the `internal` namespace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12935)
<!-- Reviewable:end -->
