### PR TITLE
trajectories: rename knots to samples

### DIFF
--- a/attic/multibody/rigid_body_plant/drake_visualizer.cc
+++ b/attic/multibody/rigid_body_plant/drake_visualizer.cc
@@ -66,13 +66,13 @@ void DrakeVisualizer::ReplayCachedSimulation() const {
     }
 
     auto sample_data = log_->data();
-    std::vector<MatrixX<double>> knots;
-    knots.reserve(sample_data.cols());
+    std::vector<MatrixX<double>> samples;
+    samples.reserve(sample_data.cols());
     for (int c : included_times) {
-      knots.push_back(sample_data.col(c));
+      samples.push_back(sample_data.col(c));
     }
-    auto func =
-        trajectories::PiecewisePolynomial<double>::ZeroOrderHold(breaks, knots);
+    auto func = trajectories::PiecewisePolynomial<double>::ZeroOrderHold(
+        breaks, samples);
 
     PlaybackTrajectory(func);
   } else {

--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -247,6 +247,7 @@ drake_pybind_library(
     cc_deps = [
         ":polynomial_types_pybind",
         "//bindings/pydrake:documentation_pybind",
+        "//bindings/pydrake/common:deprecation_pybind",
     ],
     cc_srcs = ["trajectories_py.cc"],
     package_info = PACKAGE_INFO,

--- a/bindings/pydrake/test/trajectories_test.py
+++ b/bindings/pydrake/test/trajectories_test.py
@@ -60,21 +60,21 @@ class TestTrajectories(unittest.TestCase):
     def test_pchip(self):
         t = [0., 1., 2.]
         x = np.array([[0, 1, 1]])
-        pp = PiecewisePolynomial.Pchip(breaks=t, samples=x,
-                                       zero_end_point_derivatives=False)
+        pp = PiecewisePolynomial.CubicShapePreserving(
+            breaks=t, samples=x, zero_end_point_derivatives=False)
 
     def test_cubic(self):
         t = [0., 1., 2.]
         x = np.diag((4., 5., 6.))
         periodic_end = False
         # Just test the spelling for these.
-        pp1 = PiecewisePolynomial.Cubic(breaks=t, samples=x,
-                                        periodic_end=periodic_end)
-        pp2 = PiecewisePolynomial.Cubic(breaks=t, samples=x,
-                                        samples_dot=np.identity(3))
-        pp3 = PiecewisePolynomial.Cubic(breaks=t, samples=x,
-                                        sample_dot_start=[0., 0., 0.],
-                                        sample_dot_end=[0., 0., 0.])
+        pp1 = PiecewisePolynomial.CubicWithContinuousSecondDerivatives(
+            breaks=t, samples=x, periodic_end=periodic_end)
+        pp2 = PiecewisePolynomial.CubicHermite(
+            breaks=t, samples=x, samples_dot=np.identity(3))
+        pp3 = PiecewisePolynomial.CubicWithContinuousSecondDerivatives(
+            breaks=t, samples=x, sample_dot_at_start=[0., 0., 0.],
+            sample_dot_at_end=[0., 0., 0.])
 
     def test_slice_and_shift(self):
         x = np.array([[10.], [20.], [30.]]).transpose()

--- a/bindings/pydrake/test/trajectories_test.py
+++ b/bindings/pydrake/test/trajectories_test.py
@@ -60,16 +60,21 @@ class TestTrajectories(unittest.TestCase):
     def test_pchip(self):
         t = [0., 1., 2.]
         x = np.array([[0, 1, 1]])
-        pp = PiecewisePolynomial.Pchip(t, x, zero_end_point_derivatives=False)
+        pp = PiecewisePolynomial.Pchip(breaks=t, samples=x,
+                                       zero_end_point_derivatives=False)
 
     def test_cubic(self):
         t = [0., 1., 2.]
         x = np.diag((4., 5., 6.))
         periodic_end = False
         # Just test the spelling for these.
-        pp1 = PiecewisePolynomial.Cubic(t, x, periodic_end)
-        pp2 = PiecewisePolynomial.Cubic(t, x, np.identity(3))
-        pp3 = PiecewisePolynomial.Cubic(t, x, [0., 0., 0.], [0., 0., 0.])
+        pp1 = PiecewisePolynomial.Cubic(breaks=t, samples=x,
+                                        periodic_end=periodic_end)
+        pp2 = PiecewisePolynomial.Cubic(breaks=t, samples=x,
+                                        samples_dot=np.identity(3))
+        pp3 = PiecewisePolynomial.Cubic(breaks=t, samples=x,
+                                        sample_dot_start=[0., 0., 0.],
+                                        sample_dot_end=[0., 0., 0.])
 
     def test_slice_and_shift(self):
         x = np.array([[10.], [20.], [30.]]).transpose()

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -75,79 +75,83 @@ PYBIND11_MODULE(trajectories, m) {
               const Eigen::Ref<const MatrixX<T>>&>(
               &PiecewisePolynomial<T>::FirstOrderHold),
           doc.PiecewisePolynomial.FirstOrderHold.doc)
-      .def_static("Pchip",
+      .def_static("CubicShapePreserving",
           py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
               const Eigen::Ref<const MatrixX<T>>&, bool>(
-              &PiecewisePolynomial<T>::Pchip),
+              &PiecewisePolynomial<T>::CubicShapePreserving),
           py::arg("breaks"), py::arg("samples"),
           py::arg("zero_end_point_derivatives") = false,
-          doc.PiecewisePolynomial.Pchip.doc)
+          doc.PiecewisePolynomial.CubicShapePreserving.doc)
       .def_static("Pchip",
           [](const Eigen::Ref<const Eigen::VectorXd>& breaks,
               const Eigen::Ref<const MatrixX<T>>& samples,
               bool zero_end_point_derivatives) {
             WarnDeprecated(
-                "Pchip argument knots is renamed to samples.  "
+                "Pchip has been renamed to CubicShapePreserving.  "
                 "Support will be removed after 2020-07-01.");
-            return PiecewisePolynomial<T>::Pchip(
+            return PiecewisePolynomial<T>::CubicShapePreserving(
                 breaks, samples, zero_end_point_derivatives);
           },
           py::arg("breaks"), py::arg("knots"),
           py::arg("zero_end_point_derivatives") = false)
-      .def_static("Cubic",
+      .def_static("CubicWithContinuousSecondDerivatives",
           py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
               const Eigen::Ref<const MatrixX<T>>&,
               const Eigen::Ref<const VectorX<T>>&,
               const Eigen::Ref<const VectorX<T>>&>(
-              &PiecewisePolynomial<T>::Cubic),
-          py::arg("breaks"), py::arg("samples"), py::arg("sample_dot_start"),
-          py::arg("sample_dot_end"),
-          doc.PiecewisePolynomial.Cubic
-              .doc_4args_breaks_samples_sample_dot_start_sample_dot_end)
+              &PiecewisePolynomial<T>::CubicWithContinuousSecondDerivatives),
+          py::arg("breaks"), py::arg("samples"), py::arg("sample_dot_at_start"),
+          py::arg("sample_dot_at_end"),
+          doc.PiecewisePolynomial.CubicWithContinuousSecondDerivatives
+              .doc_4args)
       .def_static("Cubic",
           [](const Eigen::Ref<const Eigen::VectorXd>& breaks,
               const Eigen::Ref<const MatrixX<T>>& samples,
-              const Eigen::Ref<const VectorX<T>>& sample_dot_start,
-              const Eigen::Ref<const VectorX<T>>& sample_dot_end) {
+              const Eigen::Ref<const VectorX<T>>& sample_dot_at_start,
+              const Eigen::Ref<const VectorX<T>>& sample_dot_at_end) {
             WarnDeprecated(
-                "Cubic arguments knots are renamed to samples.  "
+                "This version of Cubic has been renamed to "
+                "CubicWithContinuousSecondDerivatives.  "
                 "Support will be removed after 2020-07-01.");
-            return PiecewisePolynomial<T>::Cubic(
-                breaks, samples, sample_dot_start, sample_dot_end);
+            return PiecewisePolynomial<T>::CubicWithContinuousSecondDerivatives(
+                breaks, samples, sample_dot_at_start, sample_dot_at_end);
           },
           py::arg("breaks"), py::arg("knots"), py::arg("knots_dot_start"),
           py::arg("knots_dot_end"))
-      .def_static("Cubic",
+      .def_static("CubicHermite",
           py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
               const Eigen::Ref<const MatrixX<T>>&,
               const Eigen::Ref<const MatrixX<T>>&>(
-              &PiecewisePolynomial<T>::Cubic),
+              &PiecewisePolynomial<T>::CubicHermite),
           py::arg("breaks"), py::arg("samples"), py::arg("samples_dot"),
-          doc.PiecewisePolynomial.Cubic.doc_3args_breaks_samples_samples_dot)
+          doc.PiecewisePolynomial.CubicHermite.doc)
       .def_static("Cubic",
           [](const Eigen::Ref<const Eigen::VectorXd>& breaks,
               const Eigen::Ref<const MatrixX<T>>& samples,
               const Eigen::Ref<const MatrixX<T>>& samples_dot) {
             WarnDeprecated(
-                "Cubic arguments knots are renamed to samples.  "
+                "This version of Cubic has been renamed to CubicHermite.  "
                 "Support will be removed after 2020-07-01.");
-            return PiecewisePolynomial<T>::Cubic(breaks, samples, samples_dot);
+            return PiecewisePolynomial<T>::CubicHermite(
+                breaks, samples, samples_dot);
           },
           py::arg("breaks"), py::arg("knots"), py::arg("knots_dot"))
-      .def_static("Cubic",
+      .def_static("CubicWithContinuousSecondDerivatives",
           py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
               const Eigen::Ref<const MatrixX<T>>&, bool>(
-              &PiecewisePolynomial<T>::Cubic),
+              &PiecewisePolynomial<T>::CubicWithContinuousSecondDerivatives),
           py::arg("breaks"), py::arg("samples"), py::arg("periodic_end"),
-          doc.PiecewisePolynomial.Cubic
-              .doc_3args_breaks_samples_periodic_end_condition)
+          doc.PiecewisePolynomial.CubicWithContinuousSecondDerivatives
+              .doc_3args)
       .def_static("Cubic",
           [](const Eigen::Ref<const Eigen::VectorXd>& breaks,
               const Eigen::Ref<const MatrixX<T>>& samples, bool periodic_end) {
             WarnDeprecated(
-                "Cubic arguments knots are renamed to samples.  "
+                "This version of Cubic has been renamed to "
+                "CubicWithContinuousSecondDerivatives.  "
                 "Support will be removed after 2020-07-01.");
-            return PiecewisePolynomial<T>::Cubic(breaks, samples, periodic_end);
+            return PiecewisePolynomial<T>::CubicWithContinuousSecondDerivatives(
+                breaks, samples, periodic_end);
           },
           py::arg("breaks"), py::arg("knots"), py::arg("periodic_end"))
       .def("value", &PiecewisePolynomial<T>::value, py::arg("t"),

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -3,6 +3,7 @@
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 
+#include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/polynomial_types_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
@@ -78,33 +79,77 @@ PYBIND11_MODULE(trajectories, m) {
           py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
               const Eigen::Ref<const MatrixX<T>>&, bool>(
               &PiecewisePolynomial<T>::Pchip),
-          py::arg("breaks"), py::arg("knots"),
+          py::arg("breaks"), py::arg("samples"),
           py::arg("zero_end_point_derivatives") = false,
           doc.PiecewisePolynomial.Pchip.doc)
+      .def_static("Pchip",
+          [](const Eigen::Ref<const Eigen::VectorXd>& breaks,
+              const Eigen::Ref<const MatrixX<T>>& samples,
+              bool zero_end_point_derivatives) {
+            WarnDeprecated(
+                "Pchip argument knots is renamed to samples.  "
+                "Support will be removed after 2020-07-01.");
+            return PiecewisePolynomial<T>::Pchip(
+                breaks, samples, zero_end_point_derivatives);
+          },
+          py::arg("breaks"), py::arg("knots"),
+          py::arg("zero_end_point_derivatives") = false)
       .def_static("Cubic",
           py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
               const Eigen::Ref<const MatrixX<T>>&,
               const Eigen::Ref<const VectorX<T>>&,
               const Eigen::Ref<const VectorX<T>>&>(
               &PiecewisePolynomial<T>::Cubic),
-          py::arg("breaks"), py::arg("knots"), py::arg("knots_dot_start"),
-          py::arg("knots_dot_end"),
+          py::arg("breaks"), py::arg("samples"), py::arg("sample_dot_start"),
+          py::arg("sample_dot_end"),
           doc.PiecewisePolynomial.Cubic
-              .doc_4args_breaks_knots_knots_dot_start_knots_dot_end)
+              .doc_4args_breaks_samples_sample_dot_start_sample_dot_end)
+      .def_static("Cubic",
+          [](const Eigen::Ref<const Eigen::VectorXd>& breaks,
+              const Eigen::Ref<const MatrixX<T>>& samples,
+              const Eigen::Ref<const VectorX<T>>& sample_dot_start,
+              const Eigen::Ref<const VectorX<T>>& sample_dot_end) {
+            WarnDeprecated(
+                "Cubic arguments knots are renamed to samples.  "
+                "Support will be removed after 2020-07-01.");
+            return PiecewisePolynomial<T>::Cubic(
+                breaks, samples, sample_dot_start, sample_dot_end);
+          },
+          py::arg("breaks"), py::arg("knots"), py::arg("knots_dot_start"),
+          py::arg("knots_dot_end"))
       .def_static("Cubic",
           py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
               const Eigen::Ref<const MatrixX<T>>&,
               const Eigen::Ref<const MatrixX<T>>&>(
               &PiecewisePolynomial<T>::Cubic),
-          py::arg("breaks"), py::arg("knots"), py::arg("knots_dot"),
-          doc.PiecewisePolynomial.Cubic.doc_3args_breaks_knots_knots_dot)
+          py::arg("breaks"), py::arg("samples"), py::arg("samples_dot"),
+          doc.PiecewisePolynomial.Cubic.doc_3args_breaks_samples_samples_dot)
+      .def_static("Cubic",
+          [](const Eigen::Ref<const Eigen::VectorXd>& breaks,
+              const Eigen::Ref<const MatrixX<T>>& samples,
+              const Eigen::Ref<const MatrixX<T>>& samples_dot) {
+            WarnDeprecated(
+                "Cubic arguments knots are renamed to samples.  "
+                "Support will be removed after 2020-07-01.");
+            return PiecewisePolynomial<T>::Cubic(breaks, samples, samples_dot);
+          },
+          py::arg("breaks"), py::arg("knots"), py::arg("knots_dot"))
       .def_static("Cubic",
           py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
               const Eigen::Ref<const MatrixX<T>>&, bool>(
               &PiecewisePolynomial<T>::Cubic),
-          py::arg("breaks"), py::arg("knots"), py::arg("periodic_end"),
+          py::arg("breaks"), py::arg("samples"), py::arg("periodic_end"),
           doc.PiecewisePolynomial.Cubic
-              .doc_3args_breaks_knots_periodic_end_condition)
+              .doc_3args_breaks_samples_periodic_end_condition)
+      .def_static("Cubic",
+          [](const Eigen::Ref<const Eigen::VectorXd>& breaks,
+              const Eigen::Ref<const MatrixX<T>>& samples, bool periodic_end) {
+            WarnDeprecated(
+                "Cubic arguments knots are renamed to samples.  "
+                "Support will be removed after 2020-07-01.");
+            return PiecewisePolynomial<T>::Cubic(breaks, samples, periodic_end);
+          },
+          py::arg("breaks"), py::arg("knots"), py::arg("periodic_end"))
       .def("value", &PiecewisePolynomial<T>::value, py::arg("t"),
           doc.PiecewisePolynomial.value.doc)
       .def("derivative", &PiecewisePolynomial<T>::derivative,

--- a/common/trajectories/piecewise_polynomial.h
+++ b/common/trajectories/piecewise_polynomial.h
@@ -7,6 +7,7 @@
 #include <Eigen/Core>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/polynomial.h"
 #include "drake/common/trajectories/piecewise_trajectory.h"
@@ -54,10 +55,10 @@ namespace trajectories {
  * `breaks` to indicate the scalar (e.g. times) which form the boundary of
  * each segment.  We use `samples` to indicate the function value at the
  * `breaks`, e.g. `p(breaks[i]) = samples[i]`.  The term `knot` should be
- * reserved for the "(x,y)" coordinate, here `knot[i] = (breaks[i], samples[i])
- * `, though it is use inconsistently in the interpolation literature
- * (sometimes for `breaks`, sometimes for `samples`), so we try to mostly
- * avoid it here.
+ * reserved for the "(x,y)" coordinate, here
+ * `knot[i] = (breaks[i], samples[i])`, though it is used inconsistently in
+ * the interpolation literature (sometimes for `breaks`, sometimes for
+ * `samples`), so we try to mostly avoid it here.
  *
  * PiecewisePolynomial objects can be added, subtracted, and multiplied.
  * They cannot be divided because Polynomials are not closed
@@ -255,6 +256,10 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
       const Eigen::Ref<const Eigen::VectorXd>& breaks,
       const Eigen::Ref<const MatrixX<T>>& samples);
 
+  // TODO(russt): This version of the method is not exposed in pydrake, but
+  //  the version that is has limited documentation that refers back to this
+  //  verbose version.  Either add support for this in pydrake, or flip the
+  //  documentation so that pydrake gets the verbose/stand-along version.
   /**
    * Constructs a third order %PiecewisePolynomial using vector samples,
    * where each column of `samples` represents a sample point. First derivatives
@@ -293,24 +298,42 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    *         @ref coefficient_construction_methods.
    * @exclude_from_pydrake_mkdoc{This overload is not bound in pydrake.}
    */
-  static PiecewisePolynomial<T> Pchip(
+  static PiecewisePolynomial<T> CubicShapePreserving(
       const std::vector<double>& breaks,
       const std::vector<CoefficientMatrix>& samples,
       bool zero_end_point_derivatives = false);
 
+  DRAKE_DEPRECATED("2020-07-01",
+                   "Pchip has been renamed to CubicShapePreserving.")
+  static PiecewisePolynomial<T> Pchip(
+      const std::vector<double>& breaks,
+      const std::vector<CoefficientMatrix>& samples,
+      bool zero_end_point_derivatives = false) {
+    return CubicShapePreserving(breaks, samples, zero_end_point_derivatives);
+  }
+
   /**
-   * Version of Pchip(breaks, samples, zero_end_point_derivatives) that uses
-   * vector samples and Eigen VectorXd / MatrixX<T> inputs. Each column of
-   * `samples` represents a sample point.
+   * Version of CubicShapePreserving(breaks, samples,
+   * zero_end_point_derivatives) that uses vector samples and Eigen VectorXd
+   * and MatrixX<T> inputs. Each column of `samples` represents a sample point.
    *
    * @pre `samples.cols() == breaks.size()`.
    * @throws std::runtime_error under the conditions specified under
    *         @ref coefficient_construction_methods.
    */
-  static PiecewisePolynomial<T> Pchip(
+  static PiecewisePolynomial<T> CubicShapePreserving(
       const Eigen::Ref<const Eigen::VectorXd>& breaks,
       const Eigen::Ref<const MatrixX<T>>& samples,
       bool zero_end_point_derivatives = false);
+
+  DRAKE_DEPRECATED("2020-07-01",
+                   "Pchip has been renamed to CubicShapePreserving.")
+  static PiecewisePolynomial<T> Pchip(
+      const Eigen::Ref<const Eigen::VectorXd>& breaks,
+      const Eigen::Ref<const MatrixX<T>>& samples,
+      bool zero_end_point_derivatives = false) {
+    return CubicShapePreserving(breaks, samples, zero_end_point_derivatives);
+  }
 
   /**
    * Constructs a third order %PiecewisePolynomial using matrix samples.
@@ -325,26 +348,48 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    *         @ref coefficient_construction_methods.
    * @exclude_from_pydrake_mkdoc{This overload is not bound in pydrake.}
    */
+  static PiecewisePolynomial<T> CubicWithContinuousSecondDerivatives(
+      const std::vector<double>& breaks,
+      const std::vector<CoefficientMatrix>& samples,
+      const CoefficientMatrix& sample_dot_at_start,
+      const CoefficientMatrix& sample_dot_at_end);
+
+  DRAKE_DEPRECATED("2020-07-01", "This version of Cubic has been renamed to "
+                                 "CubicWithContinuousSecondDerivatives.")
   static PiecewisePolynomial<T> Cubic(
       const std::vector<double>& breaks,
       const std::vector<CoefficientMatrix>& samples,
-      const CoefficientMatrix& sample_dot_start,
-      const CoefficientMatrix& sample_dot_end);
+      const CoefficientMatrix& sample_dot_at_start,
+      const CoefficientMatrix& sample_dot_at_end) {
+    return CubicWithContinuousSecondDerivatives(
+        breaks, samples, sample_dot_at_start, sample_dot_at_end);
+  }
 
   /**
-   * Version of Cubic(breaks, samples, sample_dot_start, sample_dot_end) that uses
-   * vector samples and Eigen VectorXd / MatrixX<T> inputs. Each column of `samples`
-   * represents a sample point.
+   * Version of CubicWithContinuousSecondDerivatives() that uses vector
+   * samples and Eigen VectorXd / MatrixX<T> inputs. Each column of
+   * `samples` represents a sample point.
    *
    * @pre `samples.cols() == breaks.size()`.
    * @throws std::runtime_error under the conditions specified under
    *         @ref coefficient_construction_methods.
    */
+  static PiecewisePolynomial<T> CubicWithContinuousSecondDerivatives(
+      const Eigen::Ref<const Eigen::VectorXd>& breaks,
+      const Eigen::Ref<const MatrixX<T>>& samples,
+      const Eigen::Ref<const VectorX<T>>& sample_dot_at_start,
+      const Eigen::Ref<const VectorX<T>>& sample_dot_at_end);
+
+  DRAKE_DEPRECATED("2020-07-01", "This version of Cubic has been renamed to "
+  "CubicWithContinuousSecondDerivatives.")
   static PiecewisePolynomial<T> Cubic(
       const Eigen::Ref<const Eigen::VectorXd>& breaks,
       const Eigen::Ref<const MatrixX<T>>& samples,
-      const Eigen::Ref<const VectorX<T>>& sample_dot_start,
-      const Eigen::Ref<const VectorX<T>>& sample_dot_end);
+      const Eigen::Ref<const VectorX<T>>& sample_dot_at_start,
+      const Eigen::Ref<const VectorX<T>>& sample_dot_at_end) {
+    return CubicWithContinuousSecondDerivatives(
+        breaks, samples, sample_dot_at_start, sample_dot_at_end);
+  }
 
   /**
    * Constructs a third order %PiecewisePolynomial using matrix samples and
@@ -356,23 +401,41 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    *
    * @exclude_from_pydrake_mkdoc{This overload is not bound in pydrake.}
    */
-  static PiecewisePolynomial<T> Cubic(
+  static PiecewisePolynomial<T> CubicHermite(
       const std::vector<double>& breaks,
       const std::vector<CoefficientMatrix>& samples,
       const std::vector<CoefficientMatrix>& samples_dot);
 
+  DRAKE_DEPRECATED("2020-07-01", "This version of Cubic has been renamed to "
+  "CubicHermite.")
+  static PiecewisePolynomial<T> Cubic(
+      const std::vector<double>& breaks,
+      const std::vector<CoefficientMatrix>& samples,
+      const std::vector<CoefficientMatrix>& samples_dot) {
+    return CubicHermite(breaks, samples, samples_dot);
+  }
+
   /**
-   * Version of Cubic(breaks, samples, samples_dot) that uses vector samples and
+   * Version of CubicHermite(breaks, samples, samples_dot) that uses vector samples and
    * Eigen VectorXd / MatrixX<T> inputs. Corresponding columns of `samples` and
    * `samples_dot` are used as the sample point and independent variable derivative,
    * respectively.
    *
    * @pre `samples.cols() == samples_dot.cols() == breaks.size()`.
    */
-  static PiecewisePolynomial<T> Cubic(
+  static PiecewisePolynomial<T> CubicHermite(
       const Eigen::Ref<const Eigen::VectorXd>& breaks,
       const Eigen::Ref<const MatrixX<T>>& samples,
       const Eigen::Ref<const MatrixX<T>>& samples_dot);
+
+  DRAKE_DEPRECATED("2020-07-01", "This version of Cubic has been renamed to "
+  "CubicHermite.")
+  static PiecewisePolynomial<T> Cubic(
+      const Eigen::Ref<const Eigen::VectorXd>& breaks,
+      const Eigen::Ref<const MatrixX<T>>& samples,
+      const Eigen::Ref<const MatrixX<T>>& samples_dot) {
+    return CubicHermite(breaks, samples, samples_dot);
+  }
 
   /**
    * Constructs a third order %PiecewisePolynomial using matrix samples.
@@ -399,21 +462,40 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * `periodic_end_condition` is `false` the problem is ill-defined.
    * @exclude_from_pydrake_mkdoc{This overload is not bound in pydrake.}
    */
-  static PiecewisePolynomial<T> Cubic(
+  static PiecewisePolynomial<T> CubicWithContinuousSecondDerivatives(
       const std::vector<double>& breaks,
       const std::vector<CoefficientMatrix>& samples,
       bool periodic_end_condition = false);
 
+  DRAKE_DEPRECATED("2020-07-01", "This version of Cubic has been renamed to "
+  "CubicWithContinuousSecondDerivatives.")
+  static PiecewisePolynomial<T> Cubic(
+      const std::vector<double>& breaks,
+      const std::vector<CoefficientMatrix>& samples,
+      bool periodic_end_condition = false) {
+    return CubicWithContinuousSecondDerivatives(breaks, samples,
+                                                periodic_end_condition);
+  }
+
   /**
-   * Version of Cubic(breaks, samples) that uses vector samples and Eigen VectorXd /
-   * MatrixX<T> inputs. Each column of `samples` represents a sample point.
+   * Version of CubicWithContinuousSecondDerivatives(breaks, samples) that
+   * uses vector samples and Eigen VectorXd / MatrixX<T> inputs. Each column
+   * of `samples` represents a sample point.
    *
    * @pre `samples.cols() == breaks.size()`.
    */
-  static PiecewisePolynomial<T> Cubic(
+  static PiecewisePolynomial<T> CubicWithContinuousSecondDerivatives(
       const Eigen::Ref<const Eigen::VectorXd>& breaks,
       const Eigen::Ref<const MatrixX<T>>& samples,
       bool periodic_end_condition = false);
+
+  static PiecewisePolynomial<T> Cubic(
+      const Eigen::Ref<const Eigen::VectorXd>& breaks,
+      const Eigen::Ref<const MatrixX<T>>& samples,
+      bool periodic_end_condition = false) {
+    return CubicWithContinuousSecondDerivatives(breaks, samples,
+        periodic_end_condition);
+  }
   // @}
 
   /**
@@ -657,8 +739,6 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
   double segmentValueAtGlobalAbscissa(int segment_index, double t,
                                       Eigen::Index row, Eigen::Index col) const;
 
-  static constexpr T kSlopeEpsilon = 1e-10;
-
   // a PolynomialMatrix for each piece (segment).
   std::vector<PolynomialMatrix> polynomials_;
 
@@ -686,7 +766,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
   // Pi(0) = samples[i], for i in [0, N - 2]
   // Pi(duration_i) = samples[i+1], for i in [0, N - 2]
   // N - 2 velocity constraints for the interior points:
-// Pi'(duration_i) = Pi+1'(0), for i in [0, N - 3]
+  // Pi'(duration_i) = Pi+1'(0), for i in [0, N - 3]
   // N - 2 acceleration constraints for the interior points:
   // Pi''(duration_i) = Pi+1''(0), for i in [0, N - 3]
   //
@@ -698,12 +778,6 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
       const std::vector<double>& breaks,
       const std::vector<CoefficientMatrix>& samples, int row, int col,
       MatrixX<T>* A, VectorX<T>* b);
-
-  // Computes the first derivative at the end point using a non-centered,
-  // shape-preserving three-point formulae.
-  static CoefficientMatrix ComputePchipEndSlope(
-      double dt0, double dt1, const CoefficientMatrix& slope0,
-      const CoefficientMatrix& slope1);
 
   // Throws std::runtime_error if
   // `breaks` and `samples` have different length,

--- a/common/trajectories/piecewise_polynomial.h
+++ b/common/trajectories/piecewise_polynomial.h
@@ -28,17 +28,18 @@ namespace trajectories {
  * where a different polynomial is defined for each segment. For a specific
  * example, consider the absolute value function over the interval [-1, 1].
  * We can define a %PiecewisePolynomial over this interval using breaks at
- * t = { -1.0, 0.0, 1.0 }, and "knots" of abs(t).
+ * t = { -1.0, 0.0, 1.0 }, and "samples" of abs(t).
  *
  * @code
  * // Construct the PiecewisePolynomial.
  * const std::vector<double> breaks = { -1.0, 0.0, 1.0 };
- * std::vector<Eigen::MatrixXd> knots(3);
+ * std::vector<Eigen::MatrixXd> samples(3);
  * for (int i = 0; i < static_cast<int>(breaks.size()); ++i) {
- *   knots[i].resize(1, 1);
- *   knots[i](0, 0) = std::abs(breaks[i]);
+ *   samples[i].resize(1, 1);
+ *   samples[i](0, 0) = std::abs(breaks[i]);
  * }
- * const auto pp = PiecewisePolynomial<double>::FirstOrderHold(breaks, knots);
+ * const auto pp =
+ *      PiecewisePolynomial<double>::FirstOrderHold(breaks, samples);
  * const int row = 0, col = 0;
  *
  * // Evaluate the PiecewisePolynomial at some values.
@@ -48,6 +49,15 @@ namespace trajectories {
  * // Show how we can evaluate the first derivative (outputs -1.0).
  * std::cout << pp.derivative(1).value(-.5)(row, col) << std::endl;
  * @endcode
+ *
+ * A note on terminology.  For piecewise-polynomial interpolation, we use
+ * `breaks` to indicate the scalar (e.g. times) which form the boundary of
+ * each segment.  We use `samples` to indicate the function value at the
+ * `breaks`, e.g. `p(breaks[i]) = samples[i]`.  The term `knot` should be
+ * reserved for the "(x,y)" coordinate, here `knot[i] = (breaks[i], samples[i])
+ * `, though it is use inconsistently in the interpolation literature
+ * (sometimes for `breaks`, sometimes for `samples`), so we try to mostly
+ * avoid it here.
  *
  * PiecewisePolynomial objects can be added, subtracted, and multiplied.
  * They cannot be divided because Polynomials are not closed
@@ -177,27 +187,27 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
   /**
    * @anchor coefficient_construction_methods
    * @name Coefficient-based construction methods.
-   * Various methods for constructing a %PiecewisePolynomial using knots of
+   * Various methods for constructing a %PiecewisePolynomial using samples of
    * coefficient matrices. Under the hood, %PiecewisePolynomial constructs
-   * interpolating Polynomial objects that pass through the knot points. These
-   * methods differ by the continuity constraints that they enforce at knot
-   * points and whether each knot represents a full matrix (versions taking
+   * interpolating Polynomial objects that pass through the sample points. These
+   * methods differ by the continuity constraints that they enforce at break
+   * points and whether each sample represents a full matrix (versions taking
    * `const std::vector<CoefficientMatrix>&`) or a column vector (versions
    * taking `const Eigen::Ref<const MatrixX<T>>&`).
    *
    * These methods will throw `std::runtime_error` if:
-   *  - the breaks and knots have different length,
+   *  - the breaks and samples have different length,
    *  - the breaks are not strictly increasing,
-   *  - the knots have inconsistent dimensions (i.e., the matrices do not all
+   *  - the samples have inconsistent dimensions (i.e., the matrices do not all
    *            have identical dimensions),
    *  - the breaks vector has length smaller than 2.
    */
   // @{
 
   /**
-   * Constructs a piecewise constant %PiecewisePolynomial using matrix knots.
-   * Note that constructing a %PiecewisePolynomial requires at least two knot
-   * points, although in this case, the second knot point's value is ignored,
+   * Constructs a piecewise constant %PiecewisePolynomial using matrix samples.
+   * Note that constructing a %PiecewisePolynomial requires at least two sample
+   * points, although in this case, the second sample point's value is ignored,
    * and only its break time is used.
    *
    * @throws std::runtime_error under the conditions specified under
@@ -206,23 +216,23 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    */
   static PiecewisePolynomial<T> ZeroOrderHold(
       const std::vector<double>& breaks,
-      const std::vector<CoefficientMatrix>& knots);
+      const std::vector<CoefficientMatrix>& samples);
 
   /**
-   * Version of ZeroOrderHold(breaks, knots) that uses vector knots and
-   * Eigen VectorXd/MatrixX<T> inputs. Each column of `knots` represents a knot
+   * Version of ZeroOrderHold(breaks, samples) that uses vector samples and
+   * Eigen VectorXd/MatrixX<T> inputs. Each column of `samples` represents a sample
    * point.
    *
-   * @pre `knots.cols() == breaks.size()`
+   * @pre `samples.cols() == breaks.size()`
    * @throws std::runtime_error under the conditions specified under
    *         @ref coefficient_construction_methods.
    */
   static PiecewisePolynomial<T> ZeroOrderHold(
       const Eigen::Ref<const Eigen::VectorXd>& breaks,
-      const Eigen::Ref<const MatrixX<T>>& knots);
+      const Eigen::Ref<const MatrixX<T>>& samples);
 
   /**
-   * Constructs a piecewise linear %PiecewisePolynomial using matrix knots.
+   * Constructs a piecewise linear %PiecewisePolynomial using matrix samples.
    *
    * @throws std::runtime_error under the conditions specified under
    *         @ref coefficient_construction_methods.
@@ -230,30 +240,31 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    */
   static PiecewisePolynomial<T> FirstOrderHold(
       const std::vector<double>& breaks,
-      const std::vector<CoefficientMatrix>& knots);
+      const std::vector<CoefficientMatrix>& samples);
 
   /**
-   * Version of FirstOrderHold(breaks, knots) that uses vector knots and
-   * Eigen VectorXd / MatrixX<T> inputs. Each column of `knots`
-   * represents a knot point.
+   * Version of FirstOrderHold(breaks, samples) that uses vector samples and
+   * Eigen VectorXd / MatrixX<T> inputs. Each column of `samples`
+   * represents a sample point.
    *
-   * @pre `knots.cols() == breaks.size()`
+   * @pre `samples.cols() == breaks.size()`
    * @throws std::runtime_error under the conditions specified under
    *         @ref coefficient_construction_methods.
    */
   static PiecewisePolynomial<T> FirstOrderHold(
       const Eigen::Ref<const Eigen::VectorXd>& breaks,
-      const Eigen::Ref<const MatrixX<T>>& knots);
+      const Eigen::Ref<const MatrixX<T>>& samples);
 
   /**
-   * Constructs a third order %PiecewisePolynomial using matrix knots.
-   * First derivatives are chosen to be "shape preserving", i.e. if
-   * `knots` is monotonic within some interval, the interpolated data will
-   * also be monotonic. The second derivative is not guaranteed to be smooth
-   * across the entire spline.
+   * Constructs a third order %PiecewisePolynomial using vector samples,
+   * where each column of `samples` represents a sample point. First derivatives
+   * are chosen to be "shape preserving", i.e. if `samples` is monotonic
+   * within some interval, the interpolated data will also be monotonic. The
+   * second derivative is not guaranteed to be smooth across the entire spline.
    *
-   * Pchip stands for "Piecewise Cubic Hermite Interpolating Polynomial".
-   * For more details, refer to the matlab file "pchip.m".
+   * MATLAB calls this method "pchip" (short for "Piecewise Cubic Hermite
+   * Interpolating Polynomial"), and provides a nice description in their
+   * documentation.
    * http://home.uchicago.edu/~sctchoi/courses/cs138/interp.pdf is also a good
    * reference.
    *
@@ -263,13 +274,13 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * http://www.mi.sanu.ac.rs/~gvm/radovi/mon.pdf
    * If `zero_end_point_derivatives` is `true`, they are set to zeros.
    *
-   * If `zero_end_point_derivatives` is `false`, `breaks` and `knots` must
+   * If `zero_end_point_derivatives` is `false`, `breaks` and `samples` must
    * have at least 3 elements for the algorithm to determine the first
    * derivatives.
    *
-   * If `zero_end_point_derivatives` is `true`, `breaks` and `knots` may have
+   * If `zero_end_point_derivatives` is `true`, `breaks` and `samples` may have
    * 2 or more elements. For the 2 elements case, the result is equivalent to
-   * computing a cubic polynomial whose values are given by `knots`, and
+   * computing a cubic polynomial whose values are given by `samples`, and
    * derivatives set to zero.
    *
    * @throws std::runtime_error if:
@@ -284,126 +295,124 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    */
   static PiecewisePolynomial<T> Pchip(
       const std::vector<double>& breaks,
-      const std::vector<CoefficientMatrix>& knots,
+      const std::vector<CoefficientMatrix>& samples,
       bool zero_end_point_derivatives = false);
 
   /**
-   * Version of Pchip(breaks, knots, zero_end_point_derivatives) that uses
-   * vector knots and Eigen VectorXd / MatrixX<T> inputs. Each column of
-   * `knots` represents a knot point.
+   * Version of Pchip(breaks, samples, zero_end_point_derivatives) that uses
+   * vector samples and Eigen VectorXd / MatrixX<T> inputs. Each column of
+   * `samples` represents a sample point.
    *
-   * @pre `knots.cols() == breaks.size()`.
+   * @pre `samples.cols() == breaks.size()`.
    * @throws std::runtime_error under the conditions specified under
    *         @ref coefficient_construction_methods.
    */
   static PiecewisePolynomial<T> Pchip(
       const Eigen::Ref<const Eigen::VectorXd>& breaks,
-      const Eigen::Ref<const MatrixX<T>>& knots,
+      const Eigen::Ref<const MatrixX<T>>& samples,
       bool zero_end_point_derivatives = false);
 
   /**
-   * Constructs a third order %PiecewisePolynomial using matrix knots.
+   * Constructs a third order %PiecewisePolynomial using matrix samples.
    * The %PiecewisePolynomial is constructed such that the interior segments
    * have the same value, first and second derivatives at `breaks`.
-   * `knot_dot_at_start` and `knot_dot_at_end` are used for the first and
+   * `sample_dot_at_start` and `sample_dot_at_end` are used for the first and
    * last first derivatives.
    *
-   * @throws std::runtime_error if `knots_dot_at_start` or `knot_dot_at_end`
-   * and `knots` have inconsistent dimensions.
+   * @throws std::runtime_error if `sample_dot_at_start` or `sample_dot_at_end`
+   * and `samples` have inconsistent dimensions.
    * @throws std::runtime_error under the conditions specified under
    *         @ref coefficient_construction_methods.
    * @exclude_from_pydrake_mkdoc{This overload is not bound in pydrake.}
    */
   static PiecewisePolynomial<T> Cubic(
       const std::vector<double>& breaks,
-      const std::vector<CoefficientMatrix>& knots,
-      const CoefficientMatrix& knot_dot_start,
-      const CoefficientMatrix& knot_dot_end);
+      const std::vector<CoefficientMatrix>& samples,
+      const CoefficientMatrix& sample_dot_start,
+      const CoefficientMatrix& sample_dot_end);
 
   /**
-   * Version of Cubic(breaks, knots, knots_dot_start, knots_dot_end) that uses
-   * vector knots and Eigen VectorXd / MatrixX<T> inputs. Each column of `knots`
-   * represents a knot point.
+   * Version of Cubic(breaks, samples, sample_dot_start, sample_dot_end) that uses
+   * vector samples and Eigen VectorXd / MatrixX<T> inputs. Each column of `samples`
+   * represents a sample point.
    *
-   * @pre `knots.cols() == breaks.size()`.
+   * @pre `samples.cols() == breaks.size()`.
    * @throws std::runtime_error under the conditions specified under
    *         @ref coefficient_construction_methods.
    */
   static PiecewisePolynomial<T> Cubic(
       const Eigen::Ref<const Eigen::VectorXd>& breaks,
-      const Eigen::Ref<const MatrixX<T>>& knots,
-      const Eigen::Ref<const VectorX<T>>& knots_dot_start,
-      const Eigen::Ref<const VectorX<T>>& knots_dot_end);
+      const Eigen::Ref<const MatrixX<T>>& samples,
+      const Eigen::Ref<const VectorX<T>>& sample_dot_start,
+      const Eigen::Ref<const VectorX<T>>& sample_dot_end);
 
   /**
-   * Constructs a third order %PiecewisePolynomial using matrix knots and
-   * derivatives of knots (`knots_dot`); each matrix element of `knots_dot`
+   * Constructs a third order %PiecewisePolynomial using matrix samples and
+   * derivatives of samples (`samples_dot`); each matrix element of `samples_dot`
    * represents the derivative with respect to the independent variable (e.g.,
-   * the time derivative) of the corresponding entry in `knots`.
-   * Each segment is fully specified by `knots` and `knot_dot` at both ends.
+   * the time derivative) of the corresponding entry in `samples`.
+   * Each segment is fully specified by `samples` and `sample_dot` at both ends.
    * Second derivatives are not continuous.
    *
    * @exclude_from_pydrake_mkdoc{This overload is not bound in pydrake.}
    */
   static PiecewisePolynomial<T> Cubic(
       const std::vector<double>& breaks,
-      const std::vector<CoefficientMatrix>& knots,
-      const std::vector<CoefficientMatrix>& knots_dot);
+      const std::vector<CoefficientMatrix>& samples,
+      const std::vector<CoefficientMatrix>& samples_dot);
 
   /**
-   * Version of Cubic(breaks, knots, knots_dot) that uses vector knots and
-   * Eigen VectorXd / MatrixX<T> inputs. Corresponding columns of `knots` and
-   * `knots_dot` are used as the knot point and independent variable derivative,
+   * Version of Cubic(breaks, samples, samples_dot) that uses vector samples and
+   * Eigen VectorXd / MatrixX<T> inputs. Corresponding columns of `samples` and
+   * `samples_dot` are used as the sample point and independent variable derivative,
    * respectively.
    *
-   * @pre `knots.cols() == knots_dot.cols() == breaks.size()`.
+   * @pre `samples.cols() == samples_dot.cols() == breaks.size()`.
    */
   static PiecewisePolynomial<T> Cubic(
       const Eigen::Ref<const Eigen::VectorXd>& breaks,
-      const Eigen::Ref<const MatrixX<T>>& knots,
-      const Eigen::Ref<const MatrixX<T>>& knots_dot);
+      const Eigen::Ref<const MatrixX<T>>& samples,
+      const Eigen::Ref<const MatrixX<T>>& samples_dot);
 
   /**
-   * Constructs a third order %PiecewisePolynomial using matrix knots.
+   * Constructs a third order %PiecewisePolynomial using matrix samples.
    * The %PiecewisePolynomial is constructed such that the interior segments
    * have the same value, first and second derivatives at `breaks`. If
-   * `periodic_end_condition` is `false` (default), then the "Not-a-knot" end
+   * `periodic_end_condition` is `false` (default), then the "Not-a-sample" end
    * condition is used here, which means the third derivatives are
    * continuous for the first two and last two segments. If
    * `periodic_end_condition` is `true`, then the first and second derivatives
    * between the end of the last segment and the beginning of the first
    * segment will be continuous. Note that the periodic end condition does
-   * not require the first and last knot to be collocated, nor does it add
-   * an additional knot to connect the first and last segments. Only first
+   * not require the first and last sample to be collocated, nor does it add
+   * an additional sample to connect the first and last segments. Only first
    * and second derivative continuity is enforced.
-   * See https://en.wikipedia.org/wiki/Spline_interpolation,
-   * https://www.math.uh.edu/~jingqiu/math4364/spline.pdf, and
-   * http://www.maths.lth.se/na/courses/FMN081/FMN081-06/lecture11.pdf
+   * See https://en.wikipedia.org/wiki/Spline_interpolation and
+   * https://www.math.uh.edu/~jingqiu/math4364/spline.pdf
    * for more about cubic splines and their end conditions.
-   * The MATLAB files "spline.m" and "csape.m" are also good references.
+   * The MATLAB docs for methods "spline" and "csape" are also good
+   * references.
    *
-   * @param periodic_end_condition Determines whether the "not-a-knot"
-   * (`false`) or the periodic spline (`true`) end condition is used.
-   *
-   * @pre `breaks` and `knots` must have at least 3 elements. The "not-a-knot"
-   * condition is ill-defined for two knots, and the "periodic" condition
-   * would produce a straight line (use `FirstOrderHold` for this instead).
+   * @pre `breaks` and `samples` must have at least 3 elements. If
+   * `periodic_end_condition` is `true`, then for two samples, it would
+   * produce a straight line (use `FirstOrderHold` for this instead), and if
+   * `periodic_end_condition` is `false` the problem is ill-defined.
    * @exclude_from_pydrake_mkdoc{This overload is not bound in pydrake.}
    */
   static PiecewisePolynomial<T> Cubic(
       const std::vector<double>& breaks,
-      const std::vector<CoefficientMatrix>& knots,
+      const std::vector<CoefficientMatrix>& samples,
       bool periodic_end_condition = false);
 
   /**
-   * Version of Cubic(breaks, knots) that uses vector knots and Eigen VectorXd /
-   * MatrixX<T> inputs. Each column of `knots` represents a knot point.
+   * Version of Cubic(breaks, samples) that uses vector samples and Eigen VectorXd /
+   * MatrixX<T> inputs. Each column of `samples` represents a sample point.
    *
-   * @pre `knots.cols() == breaks.size()`.
+   * @pre `samples.cols() == breaks.size()`.
    */
   static PiecewisePolynomial<T> Cubic(
       const Eigen::Ref<const Eigen::VectorXd>& breaks,
-      const Eigen::Ref<const MatrixX<T>>& knots,
+      const Eigen::Ref<const MatrixX<T>>& samples,
       bool periodic_end_condition = false);
   // @}
 
@@ -452,7 +461,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
       const CoefficientMatrixRef& value_at_start_time) const;
 
   /**
-   * Returns `true` if this trajectory has no breaks/knots/polynomials.
+   * Returns `true` if this trajectory has no breaks/samples/polynomials.
    */
   bool empty() const { return polynomials_.empty(); }
 
@@ -661,33 +670,33 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
 
   // For a cubic spline, there are 4 unknowns for each segment Pi, namely
   // the coefficients for Pi = a0 + a1 * t + a2 * t^2 + a3 * t^3.
-  // Let N be the size of breaks and knots, there are N-1 segments,
+  // Let N be the size of breaks and samples, there are N-1 segments,
   // and thus 4*(N-1) unknowns to fully specified a cubic spline for the given
   // data.
   //
-  // If we are also given N knot_dot (velocity), each Pi will be fully specified
-  // by (knots[i], knot_dot[i]) and (knots[i+1], knot_dot[i+1]).
-  // When knot_dot are not specified, we make the design choice to enforce
-  // continuity up to the second order (Yddot) for the interior points, i.e.
-  // Pi'(duration_i) = Pi+1'(0), and Pi''(duration_i) = Pi+1''(0), where
-  // ' means time derivative, and duration_i = breaks[i+1] - breaks[i] is the
-  // duration for the ith segment.
+  // If we are also given N sample_dot (velocity), each Pi will be fully
+  // specified by (samples[i], sample_dot[i]) and (samples[i+1],
+  // sample_dot[i+1]).  When sample_dot are not specified, we make the design
+  // choice to enforce continuity up to the second order (Yddot) for
+  // the interior points, i.e. Pi'(duration_i) = Pi+1'(0), and
+  // Pi''(duration_i) = Pi+1''(0), where ' means time derivative, and
+  // duration_i = breaks[i+1] - breaks[i] is the duration for the ith segment.
   //
   // At this point, we have 2 * (N - 1) position constraints:
-  // Pi(0) = knots[i], for i in [0, N - 2]
-  // Pi(duration_i) = knots[i+1], for i in [0, N - 2]
+  // Pi(0) = samples[i], for i in [0, N - 2]
+  // Pi(duration_i) = samples[i+1], for i in [0, N - 2]
   // N - 2 velocity constraints for the interior points:
-  // Pi'(duration_i) = Pi+1'(0), for i in [0, N - 3]
+// Pi'(duration_i) = Pi+1'(0), for i in [0, N - 3]
   // N - 2 acceleration constraints for the interior points:
   // Pi''(duration_i) = Pi+1''(0), for i in [0, N - 3]
   //
   // These sum up to 4 * (N - 1) - 2. This function sets up the above
   // constraints. There are still 2 constraints missing, which can be resolved
   // by various end point conditions (velocity at the end points /
-  // "not-a-knot" / etc). These will be specified by the callers.
+  // "not-a-sample" / etc). These will be specified by the callers.
   static int SetupCubicSplineInteriorCoeffsLinearSystem(
       const std::vector<double>& breaks,
-      const std::vector<CoefficientMatrix>& knots, int row, int col,
+      const std::vector<CoefficientMatrix>& samples, int row, int col,
       MatrixX<T>* A, VectorX<T>* b);
 
   // Computes the first derivative at the end point using a non-centered,
@@ -697,13 +706,13 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
       const CoefficientMatrix& slope1);
 
   // Throws std::runtime_error if
-  // `breaks` and `knots` have different length,
+  // `breaks` and `samples` have different length,
   // `breaks` is not strictly increasing,
-  // `knots` has inconsistent dimensions,
+  // `samples` has inconsistent dimensions,
   // `breaks` has length smaller than min_length.
   static void CheckSplineGenerationInputValidityOrThrow(
       const std::vector<double>& breaks,
-      const std::vector<CoefficientMatrix>& knots, int min_length);
+      const std::vector<CoefficientMatrix>& samples, int min_length);
 };
 
 }  // namespace trajectories

--- a/common/trajectories/piecewise_quaternion.h
+++ b/common/trajectories/piecewise_quaternion.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/trajectories/piecewise_trajectory.h"
 
@@ -14,9 +15,9 @@ namespace trajectories {
 /**
  * A class representing a trajectory for quaternions that are interpolated
  * using piecewise slerp (spherical linear interpolation).
- * All the orientation knots are expected to be with respect to the same
+ * All the orientation samples are expected to be with respect to the same
  * parent reference frame, i.e. q_i represents the rotation R_PBi for the
- * orientation of frame B at the ith knot in a fixed parent frame P.
+ * orientation of frame B at the ith sample in a fixed parent frame P.
  * The world frame is a common choice for the parent frame.
  * The angular velocity and acceleration are also relative to the parent frame
  * and expressed in the parent frame.
@@ -106,14 +107,21 @@ class PiecewiseQuaternionSlerp final : public PiecewiseTrajectory<T> {
   Vector3<T> angular_acceleration(double t) const;
 
   /**
-   * Getter for the internal quaternion knots.
+   * Getter for the internal quaternion samples.
    *
    * @note The returned quaternions might be different from the ones used for
    * construction because the internal representations are set to always be
    * the "closest" w.r.t to the previous one.
    *
-   * @return the internal knot points.
+   * @return the internal sample points.
    */
+  const std::vector<Quaternion<T>>& get_quaternion_samples() const {
+    return quaternions_;
+  }
+
+  DRAKE_DEPRECATED(
+      "2020-07-01",
+      "get_quaternion_knots() is renamed get_quaternion_samples().")
   const std::vector<Quaternion<T>>& get_quaternion_knots() const {
     return quaternions_;
   }
@@ -121,7 +129,7 @@ class PiecewiseQuaternionSlerp final : public PiecewiseTrajectory<T> {
   /**
    * Returns true if all the corresponding segment times are within
    * @p tol seconds, and the angle difference between the corresponding
-   * quaternion knot points are within @p tol.
+   * quaternion sample points are within @p tol.
    */
   bool is_approx(const PiecewiseQuaternionSlerp<T>& other,
                  const T& tol) const;

--- a/common/trajectories/test/piecewise_polynomial_generation_test.cc
+++ b/common/trajectories/test/piecewise_polynomial_generation_test.cc
@@ -12,10 +12,10 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 
-using std::default_random_engine;
-using Eigen::MatrixXd;
 using Eigen::Matrix3d;
+using Eigen::MatrixXd;
 using Eigen::Vector3d;
+using std::default_random_engine;
 
 namespace drake {
 namespace trajectories {
@@ -102,8 +102,7 @@ template <typename CoefficientType>
 bool CheckValues(
     const PiecewisePolynomial<CoefficientType>& traj,
     const std::vector<std::vector<MatrixX<CoefficientType>>>& values,
-    CoefficientType tol,
-    bool check_last_time_step = true) {
+    CoefficientType tol, bool check_last_time_step = true) {
   if (values.empty()) return false;
 
   typedef Polynomial<CoefficientType> PolynomialType;
@@ -149,13 +148,11 @@ template <typename CoefficientType>
 bool CheckInterpolatedValuesAtBreakTime(
     const PiecewisePolynomial<CoefficientType>& traj,
     const std::vector<double>& breaks,
-    const std::vector<MatrixX<CoefficientType>>& values,
-    CoefficientType tol,
+    const std::vector<MatrixX<CoefficientType>>& values, CoefficientType tol,
     bool check_last_time_step = true) {
   int N = static_cast<int>(breaks.size());
   for (int i = 0; i < N; ++i) {
-    if (i == N - 1 && !check_last_time_step)
-      continue;
+    if (i == N - 1 && !check_last_time_step) continue;
     if (!CompareMatrices(traj.value(breaks[i]), values[i], tol,
                          MatrixCompareType::absolute)) {
       return false;
@@ -258,7 +255,8 @@ GTEST_TEST(SplineTests, PchipAndCubicSplineCompareWithMatlabTest) {
   coeffs[4] << 1, 0, 0, 0;
   coeffs[5] << 1, 0, 0, 0;
 
-  PiecewisePolynomial<double> spline = PiecewisePolynomial<double>::Pchip(T, Y);
+  PiecewisePolynomial<double> spline =
+      PiecewisePolynomial<double>::CubicShapePreserving(T, Y);
   EXPECT_EQ(spline.get_number_of_segments(), static_cast<int>(T.size()) - 1);
   for (int t = 0; t < spline.get_number_of_segments(); ++t) {
     const PiecewisePolynomial<double>::PolynomialMatrix& poly_matrix =
@@ -285,7 +283,8 @@ GTEST_TEST(SplineTests, PchipAndCubicSplineCompareWithMatlabTest) {
   coeffs[3] << 0, 1.25, 0, -0.25;
   coeffs[4] << 1, 0.5, -0.75, 0.25;
   coeffs[5] << 1, -0.25, 0, 0.25;
-  spline = PiecewisePolynomial<double>::Cubic(T, Y);
+  spline =
+      PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(T, Y);
   EXPECT_EQ(spline.get_number_of_segments(), static_cast<int>(T.size()) - 1);
   for (int t = 0; t < spline.get_number_of_segments(); ++t) {
     const PiecewisePolynomial<double>::PolynomialMatrix& poly_matrix =
@@ -306,7 +305,7 @@ GTEST_TEST(SplineTests, PchipAndCubicSplineCompareWithMatlabTest) {
   Y[0](0, 0) = 1;
   Y[1](0, 0) = 3;
   Y[2](0, 0) = 3;
-  spline = PiecewisePolynomial<double>::Pchip(T, Y);
+  spline = PiecewisePolynomial<double>::CubicShapePreserving(T, Y);
   EXPECT_TRUE(CompareMatrices(
       spline.getPolynomialMatrix(0)(0, 0).GetCoefficients(),
       Vector4<double>(1, 3, 0, -1), 1e-12, MatrixCompareType::absolute));
@@ -372,10 +371,10 @@ GTEST_TEST(SplineTests, RandomizedPchipSplineTest) {
     for (int i = 0; i < N; ++i) Y[i] = MatrixX<double>::Random(rows, cols);
 
     PiecewisePolynomial<double> spline =
-        PiecewisePolynomial<double>::Pchip(T, Y);
+        PiecewisePolynomial<double>::CubicShapePreserving(T, Y);
     PchipTest(T, Y, spline, 1e-8);
 
-    spline = PiecewisePolynomial<double>::Pchip(
+    spline = PiecewisePolynomial<double>::CubicShapePreserving(
         T, Y, true /* Uses zero end point derivative. */);
     PchipTest(T, Y, spline, 1e-8);
     // Derivatives at end points should be zero.
@@ -392,7 +391,7 @@ GTEST_TEST(SplineTests, PchipLength2Test) {
   Y[1] << 3;
 
   PiecewisePolynomial<double> spline =
-      PiecewisePolynomial<double>::Pchip(T, Y, true);
+      PiecewisePolynomial<double>::CubicShapePreserving(T, Y, true);
   PiecewisePolynomial<double> spline_dot = spline.derivative();
 
   EXPECT_NEAR(spline_dot.value(spline_dot.start_time()).norm(), 0, 1e-10);
@@ -400,21 +399,20 @@ GTEST_TEST(SplineTests, PchipLength2Test) {
 
   // Computes the minimal velocity from T = 0 to T = 1. Since this segment is
   // increasing, the minimal velocity needs to be greater than 0.
-  double v_min = ComputeExtremeVel(
-      spline_dot.getPolynomial(0), T.back(), false);
+  double v_min =
+      ComputeExtremeVel(spline_dot.getPolynomial(0), T.back(), false);
   EXPECT_GE(v_min, 0);
 
   Y[0] << 5;
   Y[1] << -2;
-  spline = PiecewisePolynomial<double>::Pchip(T, Y, true);
+  spline = PiecewisePolynomial<double>::CubicShapePreserving(T, Y, true);
   spline_dot = spline.derivative();
 
   EXPECT_NEAR(spline_dot.value(spline_dot.start_time()).norm(), 0, 1e-10);
   EXPECT_NEAR(spline_dot.value(spline_dot.end_time()).norm(), 0, 1e-10);
 
   // Max velocity should be non positive.
-  double v_max = ComputeExtremeVel(
-      spline_dot.getPolynomial(0), T.back(), true);
+  double v_max = ComputeExtremeVel(spline_dot.getPolynomial(0), T.back(), true);
   EXPECT_LE(v_max, 0);
 }
 
@@ -425,7 +423,7 @@ GTEST_TEST(SplineTests, RandomizedCubicSplineTest) {
   int rows = 3;
   int cols = 4;
 
-  // Test Cubic(T, Y)
+  // Test CubicWithContinuousSecondDerivatives(T, Y)
   for (int ctr = 0; ctr < num_tests; ++ctr) {
     std::vector<double> T =
         PiecewiseTrajectory<double>::RandomSegmentTimes(N - 1, generator);
@@ -433,13 +431,13 @@ GTEST_TEST(SplineTests, RandomizedCubicSplineTest) {
     for (int i = 0; i < N; ++i) Y[i] = MatrixX<double>::Random(rows, cols);
 
     PiecewisePolynomial<double> spline =
-        PiecewisePolynomial<double>::Cubic(T, Y);
+        PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(T, Y);
     EXPECT_TRUE(CheckContinuity(spline, 1e-8, 2));
     EXPECT_TRUE(CheckValues(spline, {Y}, 1e-8));
     EXPECT_TRUE(CheckInterpolatedValuesAtBreakTime(spline, T, Y, 1e-8));
   }
 
-  // Test Cubic(T, Y, Ydot0, Ydot1)
+  // Test CubicWithContinuousSecondDerivatives(T, Y, Ydot0, Ydot1)
   for (int ctr = 0; ctr < num_tests; ++ctr) {
     std::vector<double> T =
         PiecewiseTrajectory<double>::RandomSegmentTimes(N - 1, generator);
@@ -449,7 +447,8 @@ GTEST_TEST(SplineTests, RandomizedCubicSplineTest) {
     MatrixX<double> Ydot0 = MatrixX<double>::Random(rows, cols);
     MatrixX<double> Ydot1 = MatrixX<double>::Random(rows, cols);
     PiecewisePolynomial<double> spline =
-        PiecewisePolynomial<double>::Cubic(T, Y, Ydot0, Ydot1);
+        PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(
+            T, Y, Ydot0, Ydot1);
     EXPECT_TRUE(CheckContinuity(spline, 1e-8, 2));
     EXPECT_TRUE(CheckValues(spline, {Y}, 1e-8));
     EXPECT_TRUE(CheckInterpolatedValuesAtBreakTime(spline, T, Y, 1e-8));
@@ -463,7 +462,7 @@ GTEST_TEST(SplineTests, RandomizedCubicSplineTest) {
         CompareMatrices(Ydot1, Ydot1_test, 1e-8, MatrixCompareType::absolute));
   }
 
-  // Test Cubic(T, Y, Ydots)
+  // Test CubicHermite(T, Y, Ydots)
   for (int ctr = 0; ctr < num_tests; ++ctr) {
     std::vector<double> T =
         PiecewiseTrajectory<double>::RandomSegmentTimes(N - 1, generator);
@@ -476,7 +475,7 @@ GTEST_TEST(SplineTests, RandomizedCubicSplineTest) {
     }
 
     PiecewisePolynomial<double> spline =
-        PiecewisePolynomial<double>::Cubic(T, Y, Ydot);
+        PiecewisePolynomial<double>::CubicHermite(T, Y, Ydot);
     EXPECT_TRUE(CheckContinuity(spline, 1e-8, 1));
     EXPECT_TRUE(CheckValues(spline, {Y, Ydot}, 1e-8));
     EXPECT_TRUE(CheckInterpolatedValuesAtBreakTime(spline, T, Y, 1e-8));
@@ -494,14 +493,18 @@ GTEST_TEST(SplineTests, CubicSplineSize2) {
   Ydot1 << -1;
 
   PiecewisePolynomial<double> spline =
-      PiecewisePolynomial<double>::Cubic(T, Y, Ydot0, Ydot1);
+      PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(
+          T, Y, Ydot0, Ydot1);
   EXPECT_TRUE(CheckValues(spline, {Y, {Ydot0, Ydot1}}, 1e-8));
 
-  spline = PiecewisePolynomial<double>::Cubic(T, Y, {Ydot0, Ydot1});
+  spline = PiecewisePolynomial<double>::CubicHermite(T, Y, {Ydot0, Ydot1});
   EXPECT_TRUE(CheckValues(spline, {Y, {Ydot0, Ydot1}}, 1e-8));
 
-  // Calling Cubic(times, Y) with only 2 samples should not be allowed.
-  EXPECT_THROW(PiecewisePolynomial<double>::Cubic(T, Y), std::runtime_error);
+  // Calling CubicWithContinuousSecondDerivatives(times, Y) with only 2 samples
+  // should not be allowed.
+  EXPECT_THROW(
+      PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(T, Y),
+      std::runtime_error);
 }
 
 // Test that the Eigen API methods return the same results as the std::vector
@@ -525,28 +528,37 @@ GTEST_TEST(SplineTests, EigenTest) {
   EXPECT_TRUE(PP::FirstOrderHold(breaks_mat, samples_mat)
                   .isApprox(PP::FirstOrderHold(breaks_vec, samples_vec), tol));
 
-  EXPECT_TRUE(PP::Pchip(breaks_mat, samples_mat, false)
-                  .isApprox(PP::Pchip(breaks_vec, samples_vec, false), tol));
+  EXPECT_TRUE(
+      PP::CubicShapePreserving(breaks_mat, samples_mat, false)
+          .isApprox(PP::CubicShapePreserving(breaks_vec, samples_vec, false),
+                    tol));
 
-  EXPECT_TRUE(PP::Pchip(breaks_mat, samples_mat, true)
-                  .isApprox(PP::Pchip(breaks_vec, samples_vec, true), tol));
+  EXPECT_TRUE(
+      PP::CubicShapePreserving(breaks_mat, samples_mat, true)
+          .isApprox(PP::CubicShapePreserving(breaks_vec, samples_vec, true),
+                    tol));
 
-  EXPECT_TRUE(PP::Cubic(breaks_mat, samples_mat)
-                  .isApprox(PP::Cubic(breaks_vec, samples_vec), tol));
+  EXPECT_TRUE(PP::CubicWithContinuousSecondDerivatives(breaks_mat, samples_mat)
+                  .isApprox(PP::CubicWithContinuousSecondDerivatives(
+                                breaks_vec, samples_vec),
+                            tol));
 
   Matrix3d samples_dot_mat = 2. * Matrix3d::Identity();
   std::vector<MatrixXd> samples_dot_vec = {
       Vector3d{2., 0., 0.}, Vector3d{0., 2., 0.}, Vector3d{0., 0., 2.}};
 
   EXPECT_TRUE(
-      PP::Cubic(breaks_mat, samples_mat, samples_dot_mat)
-          .isApprox(PP::Cubic(breaks_vec, samples_vec, samples_dot_vec), tol));
-
-  EXPECT_TRUE(
-      PP::Cubic(breaks_mat, samples_mat, samples_dot_vec[0], samples_dot_vec[2])
-          .isApprox(PP::Cubic(breaks_vec, samples_vec, samples_dot_vec[0],
-                              samples_dot_vec[2]),
+      PP::CubicHermite(breaks_mat, samples_mat, samples_dot_mat)
+          .isApprox(PP::CubicHermite(breaks_vec, samples_vec, samples_dot_vec),
                     tol));
+
+  EXPECT_TRUE(PP::CubicWithContinuousSecondDerivatives(breaks_mat, samples_mat,
+                                                       samples_dot_vec[0],
+                                                       samples_dot_vec[2])
+                  .isApprox(PP::CubicWithContinuousSecondDerivatives(
+                                breaks_vec, samples_vec, samples_dot_vec[0],
+                                samples_dot_vec[2]),
+                            tol));
 }
 
 template <typename CoefficientType>
@@ -556,22 +568,27 @@ void TestThrows(const std::vector<double>& breaks,
                std::runtime_error);
   EXPECT_THROW(PiecewisePolynomial<double>::FirstOrderHold(breaks, samples),
                std::runtime_error);
-  EXPECT_THROW(PiecewisePolynomial<double>::Pchip(breaks, samples),
-               std::runtime_error);
-  EXPECT_THROW(PiecewisePolynomial<double>::Cubic(breaks, samples),
-               std::runtime_error);
+  EXPECT_THROW(
+      PiecewisePolynomial<double>::CubicShapePreserving(breaks, samples),
+      std::runtime_error);
+  EXPECT_THROW(
+      PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(
+          breaks, samples),
+      std::runtime_error);
 }
 
 template <typename CoefficientType>
-void TestNoThrows(
-    const std::vector<double>& breaks,
-    const std::vector<MatrixX<CoefficientType>>& samples) {
+void TestNoThrows(const std::vector<double>& breaks,
+                  const std::vector<MatrixX<CoefficientType>>& samples) {
   DRAKE_EXPECT_NO_THROW(
       PiecewisePolynomial<double>::ZeroOrderHold(breaks, samples));
   DRAKE_EXPECT_NO_THROW(
       PiecewisePolynomial<double>::FirstOrderHold(breaks, samples));
-  DRAKE_EXPECT_NO_THROW(PiecewisePolynomial<double>::Pchip(breaks, samples));
-  DRAKE_EXPECT_NO_THROW(PiecewisePolynomial<double>::Cubic(breaks, samples));
+  DRAKE_EXPECT_NO_THROW(
+      PiecewisePolynomial<double>::CubicShapePreserving(breaks, samples));
+  DRAKE_EXPECT_NO_THROW(
+      PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(
+          breaks, samples));
 }
 
 GTEST_TEST(SplineTests, TestException) {
@@ -604,8 +621,11 @@ GTEST_TEST(SplineTests, TestException) {
   DRAKE_EXPECT_NO_THROW(PiecewisePolynomial<double>::FirstOrderHold(T, Y));
   DRAKE_EXPECT_NO_THROW(PiecewisePolynomial<double>::ZeroOrderHold(T, Y));
 
-  EXPECT_THROW(PiecewisePolynomial<double>::Pchip(T, Y), std::runtime_error);
-  EXPECT_THROW(PiecewisePolynomial<double>::Cubic(T, Y), std::runtime_error);
+  EXPECT_THROW(PiecewisePolynomial<double>::CubicShapePreserving(T, Y),
+               std::runtime_error);
+  EXPECT_THROW(
+      PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(T, Y),
+      std::runtime_error);
 
   T = {2};
   Y = std::vector<MatrixX<double>>(T.size(), MatrixX<double>::Zero(rows, cols));
@@ -620,34 +640,40 @@ GTEST_TEST(SplineTests, TestException) {
   Y = std::vector<MatrixX<double>>(T.size(), MatrixX<double>::Zero(rows, cols));
   MatrixX<double> Ydot0(rows, cols);
   MatrixX<double> Ydot1(rows, cols);
-  DRAKE_EXPECT_NO_THROW(PiecewisePolynomial<double>::Cubic(T, Y, Ydot0, Ydot1));
+  DRAKE_EXPECT_NO_THROW(
+      PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(
+          T, Y, Ydot0, Ydot1));
 
   Ydot0.resize(rows, cols);
   Ydot1.resize(rows, cols + 1);
-  EXPECT_THROW(PiecewisePolynomial<double>::Cubic(T, Y, Ydot0, Ydot1),
-               std::runtime_error);
+  EXPECT_THROW(
+      PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(
+          T, Y, Ydot0, Ydot1),
+      std::runtime_error);
 
   Ydot0.resize(rows + 1, cols);
   Ydot1.resize(rows, cols);
-  EXPECT_THROW(PiecewisePolynomial<double>::Cubic(T, Y, Ydot0, Ydot1),
-               std::runtime_error);
+  EXPECT_THROW(
+      PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(
+          T, Y, Ydot0, Ydot1),
+      std::runtime_error);
 
   // Test Ydot mismatch.
   T = {1, 2, 3};
   Y = std::vector<MatrixX<double>>(T.size(), MatrixX<double>::Zero(rows, cols));
   std::vector<MatrixX<double>> Ydot =
       std::vector<MatrixX<double>>(T.size(), MatrixX<double>::Zero(rows, cols));
-  DRAKE_EXPECT_NO_THROW(PiecewisePolynomial<double>::Cubic(T, Y, Ydot));
+  DRAKE_EXPECT_NO_THROW(PiecewisePolynomial<double>::CubicHermite(T, Y, Ydot));
 
   Ydot = std::vector<MatrixX<double>>(T.size() + 1,
                                       MatrixX<double>::Zero(rows, cols));
-  EXPECT_THROW(PiecewisePolynomial<double>::Cubic(T, Y, Ydot),
+  EXPECT_THROW(PiecewisePolynomial<double>::CubicHermite(T, Y, Ydot),
                std::runtime_error);
 
   Ydot =
       std::vector<MatrixX<double>>(T.size(), MatrixX<double>::Zero(rows, cols));
   Ydot.front().resize(rows + 2, cols + 1);
-  EXPECT_THROW(PiecewisePolynomial<double>::Cubic(T, Y, Ydot),
+  EXPECT_THROW(PiecewisePolynomial<double>::CubicHermite(T, Y, Ydot),
                std::runtime_error);
 }
 

--- a/common/trajectories/test/piecewise_polynomial_test.cc
+++ b/common/trajectories/test/piecewise_polynomial_test.cc
@@ -59,7 +59,7 @@ void testIntegralAndDerivative() {
   EXPECT_TRUE(CompareMatrices(desired_value_at_t0, value_at_t0, 1e-10,
                               MatrixCompareType::absolute));
 
-  // check continuity at knot points
+  // check continuity at sample points
   for (int i = 0; i < piecewise.get_number_of_segments() - 1; ++i) {
     EXPECT_EQ(integral.getPolynomial(i)
                   .EvaluateUnivariate(integral.duration(i)),
@@ -212,8 +212,8 @@ GTEST_TEST(testPiecewisePolynomial, CubicSplinePeriodicBoundaryConditionTest) {
   breaks << 0, 1, 2, 3, 4;
 
   // Spline in 3d.
-  Eigen::MatrixXd knots(3, 5);
-  knots << 1, 1, 1,
+  Eigen::MatrixXd samples(3, 5);
+  samples << 1, 1, 1,
         2, 2, 2,
         0, 3, 3,
         -2, 2, 2,
@@ -221,7 +221,7 @@ GTEST_TEST(testPiecewisePolynomial, CubicSplinePeriodicBoundaryConditionTest) {
   const bool periodic_endpoint = true;
 
   PiecewisePolynomial<double> periodic_spline =
-      PiecewisePolynomial<double>::Cubic(breaks, knots, periodic_endpoint);
+      PiecewisePolynomial<double>::Cubic(breaks, samples, periodic_endpoint);
 
   std::unique_ptr<Trajectory<double>> spline_dt =
       periodic_spline.MakeDerivative(1);
@@ -249,27 +249,27 @@ GTEST_TEST(testPiecewisePolynomial, ExceptionsTest) {
   breaks << 0, 1, 2, 3, 4;
 
   // Spline in 3d.
-  Eigen::MatrixXd knots(3, 5);
-  knots << 1, 1, 1,
+  Eigen::MatrixXd samples(3, 5);
+  samples << 1, 1, 1,
         2, 2, 2,
         0, 3, 3,
         -2, 2, 2,
         1, 1, 1;
 
   // No throw with monotonic breaks.
-  PiecewisePolynomial<double>::Cubic(breaks, knots, true);
+  PiecewisePolynomial<double>::Cubic(breaks, samples, true);
 
   // Throw when breaks are too close.
   breaks[1] = less_than_epsilon;
   DRAKE_EXPECT_THROWS_MESSAGE(
-      PiecewisePolynomial<double>::Cubic(breaks, knots, true),
+      PiecewisePolynomial<double>::Cubic(breaks, samples, true),
       std::runtime_error,
       "Times must be at least .* apart.");
 
   // Throw when breaks are not strictly monotonic.
   breaks[1] = 0;
   DRAKE_EXPECT_THROWS_MESSAGE(
-      PiecewisePolynomial<double>::Cubic(breaks, knots, true),
+      PiecewisePolynomial<double>::Cubic(breaks, samples, true),
       std::runtime_error,
       "Times must be in increasing order.");
 }

--- a/common/trajectories/test/piecewise_polynomial_test.cc
+++ b/common/trajectories/test/piecewise_polynomial_test.cc
@@ -221,7 +221,8 @@ GTEST_TEST(testPiecewisePolynomial, CubicSplinePeriodicBoundaryConditionTest) {
   const bool periodic_endpoint = true;
 
   PiecewisePolynomial<double> periodic_spline =
-      PiecewisePolynomial<double>::Cubic(breaks, samples, periodic_endpoint);
+      PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(
+          breaks, samples, periodic_endpoint);
 
   std::unique_ptr<Trajectory<double>> spline_dt =
       periodic_spline.MakeDerivative(1);
@@ -257,21 +258,22 @@ GTEST_TEST(testPiecewisePolynomial, ExceptionsTest) {
         1, 1, 1;
 
   // No throw with monotonic breaks.
-  PiecewisePolynomial<double>::Cubic(breaks, samples, true);
+  PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(
+      breaks, samples, true);
 
   // Throw when breaks are too close.
   breaks[1] = less_than_epsilon;
   DRAKE_EXPECT_THROWS_MESSAGE(
-      PiecewisePolynomial<double>::Cubic(breaks, samples, true),
-      std::runtime_error,
-      "Times must be at least .* apart.");
+      PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(
+          breaks, samples, true),
+      std::runtime_error, "Times must be at least .* apart.");
 
   // Throw when breaks are not strictly monotonic.
   breaks[1] = 0;
   DRAKE_EXPECT_THROWS_MESSAGE(
-      PiecewisePolynomial<double>::Cubic(breaks, samples, true),
-      std::runtime_error,
-      "Times must be in increasing order.");
+      PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(
+          breaks, samples, true),
+      std::runtime_error, "Times must be in increasing order.");
 }
 
 GTEST_TEST(testPiecewisePolynomial, AllTests) {

--- a/common/trajectories/test/piecewise_quaternion_test.cc
+++ b/common/trajectories/test/piecewise_quaternion_test.cc
@@ -87,7 +87,7 @@ std::vector<Quaternion<Scalar>> GenerateRandomQuaternions(
 }
 
 // Tests CheckSlerpInterpolation and "closestness" for PiecewiseQuaternionSlerp
-// generated from random breaks and knots.
+// generated from random breaks and samples.
 GTEST_TEST(TestPiecewiseQuaternionSlerp,
            TestRandomizedPiecewiseQuaternionSlerp) {
   std::default_random_engine generator(123);
@@ -104,7 +104,7 @@ GTEST_TEST(TestPiecewiseQuaternionSlerp,
     EXPECT_TRUE(CheckSlerpInterpolation(rot_spline, t));
   }
 
-  EXPECT_TRUE(CheckClosest(rot_spline.get_quaternion_knots()));
+  EXPECT_TRUE(CheckClosest(rot_spline.get_quaternion_samples()));
 }
 
 // Tests when the given quaternions are not "closest" to the previous one.
@@ -121,7 +121,7 @@ GTEST_TEST(TestPiecewiseQuaternionSlerp,
 
   PiecewiseQuaternionSlerp<double> rot_spline(time, quat);
   const std::vector<Quaternion<double>>& internal_quat =
-      rot_spline.get_quaternion_knots();
+      rot_spline.get_quaternion_samples();
 
   EXPECT_TRUE(CheckClosest(internal_quat));
   EXPECT_FALSE(CheckClosest(quat));
@@ -158,7 +158,7 @@ GTEST_TEST(TestPiecewiseQuaternionSlerp,
   double t = 0.3 * time[0] + 0.7 * time[1];
 
   const std::vector<Quaternion<double>>& internal_quats =
-      rot_spline.get_quaternion_knots();
+      rot_spline.get_quaternion_samples();
   EXPECT_TRUE(CompareMatrices(
       rot_spline.orientation(t).coeffs(),
       internal_quats[0].coeffs(), 1e-10,

--- a/examples/kuka_iiwa_arm/iiwa_world/multi_arm_with_gripper_demo.cc
+++ b/examples/kuka_iiwa_arm/iiwa_world/multi_arm_with_gripper_demo.cc
@@ -78,8 +78,10 @@ void main() {
     std::vector<MatrixX<double>> knots(times.size(),
                                        MatrixX<double>::Zero(7, 1));
     knots[1] << M_PI, 0, 0, M_PI / 2., 0, 0, 0;
-    PiecewisePolynomial<double> poly = PiecewisePolynomial<double>::Cubic(
-        times, knots, MatrixX<double>::Zero(7, 1), MatrixX<double>::Zero(7, 1));
+    PiecewisePolynomial<double> poly =
+        PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(
+            times, knots, MatrixX<double>::Zero(7, 1),
+            MatrixX<double>::Zero(7, 1));
 
     // Adds a trajectory source for desired state and accelerations.
     iiwa_traj_src =

--- a/examples/kuka_iiwa_arm/kuka_plan_runner.cc
+++ b/examples/kuka_iiwa_arm/kuka_plan_runner.cc
@@ -160,8 +160,8 @@ class RobotPlanRunner {
     }
     const Eigen::MatrixXd knot_dot = Eigen::MatrixXd::Zero(kNumJoints, 1);
     plan_.reset(new PiecewisePolynomial<double>(
-        PiecewisePolynomial<double>::Cubic(input_time, knots,
-                                           knot_dot, knot_dot)));
+        PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(
+            input_time, knots, knot_dot, knot_dot)));
     ++plan_number_;
   }
 

--- a/examples/planar_gripper/run_planar_gripper_trajectory_publisher.cc
+++ b/examples/planar_gripper/run_planar_gripper_trajectory_publisher.cc
@@ -93,7 +93,8 @@ int DoMain() {
     times(i) = i * FLAGS_keyframe_dt;
   }
   const auto pp =
-      trajectories::PiecewisePolynomial<double>::Pchip(times, keyframes);
+      trajectories::PiecewisePolynomial<double>::CubicShapePreserving(
+          times, keyframes);
   auto state_src = builder.AddSystem<systems::TrajectorySource<double>>(
       pp, 1 /* with one derivative */);
 

--- a/manipulation/planner/robot_plan_interpolator.cc
+++ b/manipulation/planner/robot_plan_interpolator.cc
@@ -231,12 +231,13 @@ void RobotPlanInterpolator::DoCalcUnrestrictedUpdate(
               input_time, knots);
           break;
         case InterpolatorType::Pchip :
-          plan.pp = PiecewisePolynomial<double>::Pchip(
+          plan.pp = PiecewisePolynomial<double>::CubicShapePreserving(
               input_time, knots, true);
           break;
         case InterpolatorType::Cubic :
-          plan.pp = PiecewisePolynomial<double>::Cubic(
-              input_time, knots, knot_dot, knot_dot);
+          plan.pp =
+              PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(
+                  input_time, knots, knot_dot, knot_dot);
           break;
       }
       plan.pp_deriv = plan.pp.derivative();

--- a/manipulation/util/test/trajectory_utils_test.cc
+++ b/manipulation/util/test/trajectory_utils_test.cc
@@ -15,24 +15,24 @@ class PiecewiseCubicTrajectoryTest : public ::testing::Test {
  protected:
   void SetUp() override {
     times_ = {0, 2, 3, 4};
-    knots_.resize(times_.size(), MatrixX<double>::Zero(2, 1));
-    knots_[0] << 0, 1;
-    knots_[1] << 2, -3;
-    knots_[2] << 1.2, 5;
-    knots_[3] << -1, 6;
+    samples_.resize(times_.size(), MatrixX<double>::Zero(2, 1));
+    samples_[0] << 0, 1;
+    samples_[1] << 2, -3;
+    samples_[2] << 1.2, 5;
+    samples_[3] << -1, 6;
 
     test_times_ = {times_.front() - 0.2, times_.front(),
                    (times_.front() + times_.back()) / 2., times_.back(),
                    times_.back() + 0.3};
 
-    pos_ = PiecewisePolynomial<double>::Cubic(times_, knots_);
+    pos_ = PiecewisePolynomial<double>::Cubic(times_, samples_);
     dut_ = PiecewiseCubicTrajectory<double>(pos_);
     vel_ = pos_.derivative();
     acc_ = vel_.derivative();
   }
 
   std::vector<double> times_;
-  std::vector<MatrixX<double>> knots_;
+  std::vector<MatrixX<double>> samples_;
 
   PiecewiseCubicTrajectory<double> dut_;
   std::vector<double> test_times_;
@@ -95,7 +95,7 @@ TEST_F(PiecewiseCubicTrajectoryTest, IsApprox) {
   EXPECT_TRUE(dut_.is_approx(equal, 1e-12));
 
   PiecewiseCubicTrajectory<double> not_equal(PiecewisePolynomial<double>::Cubic(
-      times_, knots_, Vector2<double>::Zero(), Vector2<double>::Zero()));
+      times_, samples_, Vector2<double>::Zero(), Vector2<double>::Zero()));
 
   EXPECT_TRUE(!dut_.is_approx(not_equal, 1e-12));
 }
@@ -104,18 +104,19 @@ class PiecewiseCartesianTrajectoryTest : public ::testing::Test {
  protected:
   void SetUp() override {
     std::vector<double> times = {1, 2};
-    std::vector<AngleAxis<double>> rot_knots(times.size());
-    std::vector<MatrixX<double>> pos_knots(times.size(), MatrixX<double>(3, 1));
+    std::vector<AngleAxis<double>> rot_samples(times.size());
+    std::vector<MatrixX<double>> pos_samples(times.size(),
+                                             MatrixX<double>(3, 1));
 
-    rot_knots[0] = AngleAxis<double>(0.3, Vector3<double>::UnitX());
-    rot_knots[1] = AngleAxis<double>(-1, Vector3<double>::UnitY());
+    rot_samples[0] = AngleAxis<double>(0.3, Vector3<double>::UnitX());
+    rot_samples[1] = AngleAxis<double>(-1, Vector3<double>::UnitY());
 
-    pos_knots[0] << 0.3, 0, -0.5;
-    pos_knots[1] << 1, -1, 3;
+    pos_samples[0] << 0.3, 0, -0.5;
+    pos_samples[1] << 1, -1, 3;
 
-    std::vector<Isometry3<double>> knots(times.size());
+    std::vector<Isometry3<double>> samples(times.size());
     for (size_t i = 0; i < times.size(); ++i) {
-      knots[i].fromPositionOrientationScale(pos_knots[i], rot_knots[i],
+      samples[i].fromPositionOrientationScale(pos_samples[i], rot_samples[i],
                                             Vector3<double>::Ones());
     }
 
@@ -123,15 +124,16 @@ class PiecewiseCartesianTrajectoryTest : public ::testing::Test {
     Vector3<double> vel1(Vector3<double>::Zero());
 
     dut_ = PiecewiseCartesianTrajectory<
-        double>::MakeCubicLinearWithEndLinearVelocity(times, knots, vel0, vel1);
+        double>::MakeCubicLinearWithEndLinearVelocity(times, samples, vel0,
+                                                      vel1);
 
     test_times_ = {times.front() - 0.2, times.front(),
                    (times.front() + times.back()) / 2., times.back(),
                    times.back() + 0.3};
 
     position_ = PiecewiseCubicTrajectory<double>(
-        PiecewisePolynomial<double>::Cubic(times, pos_knots, vel0, vel1));
-    orientation_ = PiecewiseQuaternionSlerp<double>(times, rot_knots);
+        PiecewisePolynomial<double>::Cubic(times, pos_samples, vel0, vel1));
+    orientation_ = PiecewiseQuaternionSlerp<double>(times, rot_samples);
   }
 
   PiecewiseCartesianTrajectory<double> dut_;
@@ -221,19 +223,19 @@ TEST_F(PiecewiseCartesianTrajectoryTest, TestConstructor) {
 // Tests is_approx().
 TEST_F(PiecewiseCartesianTrajectoryTest, TestIsApprox) {
   std::vector<double> times = {1, 2, 3};
-  std::vector<AngleAxis<double>> rot_knots(times.size());
-  std::vector<MatrixX<double>> pos_knots(times.size(), MatrixX<double>(3, 1));
-  pos_knots[0] << -3, 1, 0;
-  pos_knots[1] << -2, -1, 5;
-  pos_knots[2] << -2, -1, 5;
+  std::vector<AngleAxis<double>> rot_samples(times.size());
+  std::vector<MatrixX<double>> pos_samples(times.size(), MatrixX<double>(3, 1));
+  pos_samples[0] << -3, 1, 0;
+  pos_samples[1] << -2, -1, 5;
+  pos_samples[2] << -2, -1, 5;
 
-  rot_knots[0] = AngleAxis<double>(0.3, Vector3<double>::UnitX());
-  rot_knots[1] = AngleAxis<double>(-1, Vector3<double>::UnitY());
-  rot_knots[2] = AngleAxis<double>(-0.44, Vector3<double>::UnitZ());
+  rot_samples[0] = AngleAxis<double>(0.3, Vector3<double>::UnitX());
+  rot_samples[1] = AngleAxis<double>(-1, Vector3<double>::UnitY());
+  rot_samples[2] = AngleAxis<double>(-0.44, Vector3<double>::UnitZ());
 
   PiecewiseCubicTrajectory<double> new_pos_traj(
-      PiecewisePolynomial<double>::Cubic(times, pos_knots));
-  PiecewiseQuaternionSlerp<double> new_rot_traj(times, rot_knots);
+      PiecewisePolynomial<double>::Cubic(times, pos_samples));
+  PiecewiseQuaternionSlerp<double> new_rot_traj(times, rot_samples);
 
   {
     PiecewiseCartesianTrajectory<double> diff_position(new_pos_traj,

--- a/manipulation/util/test/trajectory_utils_test.cc
+++ b/manipulation/util/test/trajectory_utils_test.cc
@@ -25,7 +25,8 @@ class PiecewiseCubicTrajectoryTest : public ::testing::Test {
                    (times_.front() + times_.back()) / 2., times_.back(),
                    times_.back() + 0.3};
 
-    pos_ = PiecewisePolynomial<double>::Cubic(times_, samples_);
+    pos_ = PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(
+        times_, samples_);
     dut_ = PiecewiseCubicTrajectory<double>(pos_);
     vel_ = pos_.derivative();
     acc_ = vel_.derivative();
@@ -94,8 +95,9 @@ TEST_F(PiecewiseCubicTrajectoryTest, IsApprox) {
   PiecewiseCubicTrajectory<double> equal = dut_;
   EXPECT_TRUE(dut_.is_approx(equal, 1e-12));
 
-  PiecewiseCubicTrajectory<double> not_equal(PiecewisePolynomial<double>::Cubic(
-      times_, samples_, Vector2<double>::Zero(), Vector2<double>::Zero()));
+  PiecewiseCubicTrajectory<double> not_equal(
+      PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(
+          times_, samples_, Vector2<double>::Zero(), Vector2<double>::Zero()));
 
   EXPECT_TRUE(!dut_.is_approx(not_equal, 1e-12));
 }
@@ -132,7 +134,8 @@ class PiecewiseCartesianTrajectoryTest : public ::testing::Test {
                    times.back() + 0.3};
 
     position_ = PiecewiseCubicTrajectory<double>(
-        PiecewisePolynomial<double>::Cubic(times, pos_samples, vel0, vel1));
+        PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(
+            times, pos_samples, vel0, vel1));
     orientation_ = PiecewiseQuaternionSlerp<double>(times, rot_samples);
   }
 
@@ -234,7 +237,8 @@ TEST_F(PiecewiseCartesianTrajectoryTest, TestIsApprox) {
   rot_samples[2] = AngleAxis<double>(-0.44, Vector3<double>::UnitZ());
 
   PiecewiseCubicTrajectory<double> new_pos_traj(
-      PiecewisePolynomial<double>::Cubic(times, pos_samples));
+      PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(
+          times, pos_samples));
   PiecewiseQuaternionSlerp<double> new_rot_traj(times, rot_samples);
 
   {

--- a/manipulation/util/trajectory_utils.h
+++ b/manipulation/util/trajectory_utils.h
@@ -144,8 +144,9 @@ class PiecewiseCartesianTrajectory {
     }
 
     return PiecewiseCartesianTrajectory(
-        trajectories::PiecewisePolynomial<T>::Cubic(times, pos_knots, vel0,
-                                                    vel1),
+        trajectories::PiecewisePolynomial<
+            T>::CubicWithContinuousSecondDerivatives(times, pos_knots, vel0,
+                                                     vel1),
         trajectories::PiecewiseQuaternionSlerp<T>(times, rot_knots));
   }
 

--- a/systems/analysis/hermitian_dense_output.h
+++ b/systems/analysis/hermitian_dense_output.h
@@ -270,7 +270,7 @@ class HermitianDenseOutput final : public StepwiseDenseOutput<T> {
     }
     for (const IntegrationStep& step : raw_steps_) {
       continuous_trajectory_.ConcatenateInTime(
-          trajectories::PiecewisePolynomial<double>::Cubic(
+          trajectories::PiecewisePolynomial<double>::CubicHermite(
               internal::ExtractDoublesOrThrow(step.get_times()),
               internal::ExtractDoublesOrThrow(step.get_states()),
               internal::ExtractDoublesOrThrow(step.get_state_derivatives())));

--- a/systems/analysis/test/hermitian_dense_output_test.cc
+++ b/systems/analysis/test/hermitian_dense_output_test.cc
@@ -304,7 +304,7 @@ TYPED_TEST(HermitianDenseOutputTest, CorrectEvaluation) {
           this->kInitialStateDerivative, this->kMidStateDerivative,
           this->kFinalStateDerivative};
   const trajectories::PiecewisePolynomial<double> hermite_spline =
-      trajectories::PiecewisePolynomial<double>::Cubic(
+      trajectories::PiecewisePolynomial<double>::CubicHermite(
           spline_times, spline_states, spline_state_derivatives);
   // Instantiates dense output.
   HermitianDenseOutput<TypeParam> dense_output;

--- a/systems/controllers/test/zmp_test_util.cc
+++ b/systems/controllers/test/zmp_test_util.cc
@@ -78,7 +78,7 @@ std::vector<PiecewisePolynomial<double>> GenerateDesiredZMPTrajs(
   zmp_trajs.push_back(
       PiecewisePolynomial<double>::FirstOrderHold(time_steps, zmp_d));
   zmp_trajs.push_back(
-      PiecewisePolynomial<double>::Pchip(time_steps, zmp_d));
+      PiecewisePolynomial<double>::CubicShapePreserving(time_steps, zmp_d));
 
   return zmp_trajs;
 }

--- a/systems/trajectory_optimization/direct_collocation.cc
+++ b/systems/trajectory_optimization/direct_collocation.cc
@@ -96,7 +96,7 @@ void DirectCollocationConstraint::DoEval(
   DRAKE_ASSERT(x.size() == 1 + (2 * num_states_) + (2 * num_inputs_));
 
   // Extract our input variables:
-  // h - current time (knot) value
+  // h - current time (breakpoint)
   // x0, x1 state vector at time steps k, k+1
   // u0, u1 input vector at time steps k, k+1
   const AutoDiffXd h = x(0);
@@ -182,8 +182,8 @@ DirectCollocation::DirectCollocation(
 
   DRAKE_ASSERT(static_cast<int>(constraint->num_constraints()) == num_states());
 
-  // For N-1 timesteps, add a constraint which depends on the knot
-  // value along with the state and input vectors at that knot and the
+  // For N-1 timesteps, add a constraint which depends on the breakpoint
+  // along with the state and input vectors at that breakpoint and the
   // next.
   for (int i = 0; i < N() - 1; i++) {
     AddConstraint(constraint,

--- a/systems/trajectory_optimization/direct_collocation.cc
+++ b/systems/trajectory_optimization/direct_collocation.cc
@@ -239,7 +239,8 @@ PiecewisePolynomial<double> DirectCollocation::ReconstructStateTrajectory(
     system_->CalcTimeDerivatives(*context_, continuous_state_.get());
     derivatives[i] = continuous_state_->CopyToVector();
   }
-  return PiecewisePolynomial<double>::Cubic(times_vec, states, derivatives);
+  return PiecewisePolynomial<double>::CubicHermite(times_vec, states,
+                                                   derivatives);
 }
 
 }  // namespace trajectory_optimization

--- a/systems/trajectory_optimization/direct_collocation.h
+++ b/systems/trajectory_optimization/direct_collocation.h
@@ -20,7 +20,7 @@ namespace trajectory_optimization {
 ///    July-August 1987.
 /// It assumes a first-order hold on the input trajectory and a cubic spline
 /// representation of the state trajectory, and adds dynamic constraints (and
-/// running costs) to the midpoints as well as the knot points in order to
+/// running costs) to the midpoints as well as the breakpoints in order to
 /// achieve a 3rd order integration accuracy.
 ///
 /// Note: This algorithm only works with the continuous states of a system.
@@ -37,7 +37,7 @@ class DirectCollocation : public MultipleShooting {
   /// values of the state in this context do not have any effect.  This context
   /// will also be "cloned" by the optimization; changes to the context after
   /// calling this method will NOT impact the trajectory optimization.
-  /// @param num_time_samples The number of knot points in the trajectory.
+  /// @param num_time_samples The number of breakpoints in the trajectory.
   /// @param minimum_timestep Minimum spacing between sample times.
   /// @param maximum_timestep Maximum spacing between sample times.
   /// @param input_port_index A valid input port index for @p system or

--- a/systems/trajectory_optimization/direct_transcription.cc
+++ b/systems/trajectory_optimization/direct_transcription.cc
@@ -345,8 +345,8 @@ void DirectTranscription::AddAutodiffDynamicConstraints(
       *system_, fixed_timestep(), context_.get());
   integrator_->Initialize();
 
-  // For N-1 timesteps, add a constraint which depends on the knot
-  // value along with the state and input vectors at that knot and the
+  // For N-1 timesteps, add a constraint which depends on the breakpoint
+  // along with the state and input vectors at that breakpoint and the
   // next.
   for (int i = 0; i < N() - 1; i++) {
     // Add the dynamic constraints.

--- a/systems/trajectory_optimization/direct_transcription.h
+++ b/systems/trajectory_optimization/direct_transcription.h
@@ -45,7 +45,7 @@ class DirectTranscription : public MultipleShooting {
   ///    context will also be "cloned" by the optimization; changes to the
   ///    context after calling this method will NOT impact the trajectory
   ///    optimization.
-  /// @param num_time_samples The number of knot points in the trajectory.
+  /// @param num_time_samples The number of breakpoints in the trajectory.
   /// @param input_port_index A valid input port index or valid
   /// InputPortSelection for @p system.  All other inputs on the system will be
   /// left disconnected (if they are disconnected in @p context) or will be set
@@ -73,7 +73,7 @@ class DirectTranscription : public MultipleShooting {
   ///    context will also be "cloned" by the optimization; changes to the
   ///    context after calling this method will NOT impact the trajectory
   ///    optimization.
-  /// @param num_time_samples The number of knot points in the trajectory.
+  /// @param num_time_samples The number of breakpoints in the trajectory.
   /// @param input_port_index A valid input port index or valid
   /// InputPortSelection for @p system.  All other inputs on the system will be
   /// left disconnected (if they are disconnected in @p context) or will be set
@@ -104,7 +104,7 @@ class DirectTranscription : public MultipleShooting {
   ///    context will also be "cloned" by the optimization; changes to the
   ///    context after calling this method will NOT impact the trajectory
   ///    optimization.
-  /// @param num_time_samples The number of knot points in the trajectory.
+  /// @param num_time_samples The number of breakpoints in the trajectory.
   /// @param fixed_timestep The spacing between sample times.
   /// @param input_port_index A valid input port index or valid
   /// InputPortSelection for @p system.  All other inputs on the system will be

--- a/systems/trajectory_optimization/multiple_shooting.h
+++ b/systems/trajectory_optimization/multiple_shooting.h
@@ -146,7 +146,7 @@ class MultipleShooting : public solvers::MathematicalProgram {
     DoAddRunningCost(g(0, 0));
   }
 
-  /// Adds a constraint to all knot points, where any instances of time(),
+  /// Adds a constraint to all breakpoints, where any instances of time(),
   /// state(), and/or input() placeholder variables, as well as placeholder
   /// variables returned by calls to NewSequentialVariable(), are substituted
   /// with the relevant variables for each time index.
@@ -294,11 +294,11 @@ class MultipleShooting : public solvers::MathematicalProgram {
       const trajectories::PiecewisePolynomial<double>& traj_init_u,
       const trajectories::PiecewisePolynomial<double>& traj_init_x);
 
-  /// Returns a vector containing the elapsed time at each knot point.
+  /// Returns a vector containing the elapsed time at each breakpoint.
   Eigen::VectorXd GetSampleTimes(
       const Eigen::Ref<const Eigen::VectorXd>& h_var_values) const;
 
-  /// Returns a vector containing the elapsed time at each knot point at the
+  /// Returns a vector containing the elapsed time at each breakpoint at the
   /// solution.
   Eigen::VectorXd GetSampleTimes(
       const solvers::MathematicalProgramResult& result) const {
@@ -306,17 +306,17 @@ class MultipleShooting : public solvers::MathematicalProgram {
   }
 
   /// Returns a matrix containing the input values (arranged in columns) at
-  /// each knot point at the solution.
+  /// each breakpoint at the solution.
   Eigen::MatrixXd GetInputSamples(
       const solvers::MathematicalProgramResult& result) const;
 
   /// Returns a matrix containing the state values (arranged in columns) at
-  /// each knot point at the solution.
+  /// each breakpoint at the solution.
   Eigen::MatrixXd GetStateSamples(
       const solvers::MathematicalProgramResult& result) const;
 
   /// Returns a matrix containing the sequential variable values (arranged in
-  /// columns) at each knot point at the solution.
+  /// columns) at each breakpoint at the solution.
   ///
   /// @param name The name of sequential variable to get the results for.  Must
   /// correspond to an already added sequential variable.

--- a/systems/trajectory_optimization/test/direct_collocation_test.cc
+++ b/systems/trajectory_optimization/test/direct_collocation_test.cc
@@ -96,8 +96,9 @@ GTEST_TEST(DirectCollocationTest, TestCollocationConstraint) {
   const Eigen::Vector2d x0(6, 7), x1(8, 9), u0(10, 11), u1(12, 13);
   const Eigen::Vector2d xdot0 = system->A() * x0 + system->B() * u0;
   const Eigen::Vector2d xdot1 = system->A() * x1 + system->B() * u1;
-  const auto segment = PiecewisePolynomial<double>::Cubic(
-      {0.0, kTimeStep}, {x0, x1}, xdot0, xdot1);
+  const auto segment =
+      PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(
+          {0.0, kTimeStep}, {x0, x1}, xdot0, xdot1);
   const auto derivative = segment.derivative();
   const Eigen::Vector2d defect = derivative.value(kTimeStep / 2.0) -
                                  system->A() * segment.value(kTimeStep / 2.0) -


### PR DESCRIPTION
We've had a long-running incorrect use of notation in our trajectory code.
Correct:
 - breaks and knots both mean the time indices.
 - sample points (or sometimes "control points") indicate the values at those times.
We've been writing e.g. Cubic(breaks, knots).

I've changed all instances (apart from the IK code) to replace knots with either breaks (when time was intended) or samples (when the values were intended).

Deprecating pybind argument names... woohoo!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12939)
<!-- Reviewable:end -->
