### PR TITLE
add /.vscode/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /.project/
 /.settings/
 /.clwb/
+/.vscode/
 
 # (Possible) CMake build artifacts
 /build/


### PR DESCRIPTION
CLion's lack of full symbol support and constant freezing is driving me to try another.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12943)
<!-- Reviewable:end -->
