### PR TITLE
tools: Disable container_overflow checks under asan

### DIFF
--- a/tools/dynamic_analysis/asan.sh
+++ b/tools/dynamic_analysis/asan.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 me=$(python3 -c 'import os; print(os.path.realpath("'"$0"'"))')
 mydir=$(dirname "$me")
-export ASAN_OPTIONS="$ASAN_OPTIONS:check_initialization_order=1:detect_invalid_pointer_pairs=1:detect_stack_use_after_return=1:strict_init_order=1:strict_string_checks=1:strip_path_prefix=/proc/self/cwd/:suppressions=$mydir/asan.supp"
+export ASAN_OPTIONS="$ASAN_OPTIONS:check_initialization_order=1:detect_container_overflow=0:detect_invalid_pointer_pairs=1:detect_stack_use_after_return=1:strict_init_order=1:strict_string_checks=1:strip_path_prefix=/proc/self/cwd/:suppressions=$mydir/asan.supp"
 # LSan is run with ASan by default, ASAN_OPTIONS can't be used to suppress LSan
 # errors
 export LSAN_OPTIONS="$LSAN_OPTIONS:strip_path_prefix=/proc/self/cwd/:suppressions=$mydir/lsan.supp"


### PR DESCRIPTION
Because we use C++ binary libraries from the host OS (instead of compiling all C++ code from source) there can be false positives.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12945)
<!-- Reviewable:end -->
