### PR TITLE
cleanup: use typename T in polynomial classes

### DIFF
--- a/bindings/pydrake/polynomial_py.cc
+++ b/bindings/pydrake/polynomial_py.cc
@@ -13,12 +13,12 @@ namespace pydrake {
 
 PYBIND11_MODULE(polynomial, m) {
   {
-    using CoefficientType = double;
-    using Class = Polynomial<CoefficientType>;
+    using T = double;
+    using Class = Polynomial<T>;
     constexpr auto& cls_doc = pydrake_doc.Polynomial;
     py::class_<Class>(m, "Polynomial", cls_doc.doc)
         .def(py::init<>(), cls_doc.ctor.doc_0args)
-        .def(py::init<const CoefficientType&>(), cls_doc.ctor.doc_1args_scalar)
+        .def(py::init<const T&>(), cls_doc.ctor.doc_1args_scalar)
         .def(py::init<const Eigen::Ref<const Eigen::VectorXd>&>(),
             cls_doc.ctor.doc_1args_constEigenMatrixBase)
         .def("GetNumberOfCoefficients", &Class::GetNumberOfCoefficients,

--- a/common/polynomial.cc
+++ b/common/polynomial.cc
@@ -15,8 +15,8 @@ using std::runtime_error;
 using std::string;
 using std::vector;
 
-template <typename CoefficientType>
-bool Polynomial<CoefficientType>::Monomial::HasSameExponents(
+template <typename T>
+bool Polynomial<T>::Monomial::HasSameExponents(
     const Monomial& other) const {
   if (terms.size() != other.terms.size()) return false;
 
@@ -29,16 +29,16 @@ bool Polynomial<CoefficientType>::Monomial::HasSameExponents(
   return true;
 }
 
-template <typename CoefficientType>
-Polynomial<CoefficientType>::Polynomial(const CoefficientType& scalar) {
+template <typename T>
+Polynomial<T>::Polynomial(const T& scalar) {
   Monomial m;
   m.coefficient = scalar;
   monomials_.push_back(m);
   is_univariate_ = true;
 }
 
-template <typename CoefficientType>
-Polynomial<CoefficientType>::Polynomial(const CoefficientType coefficient,
+template <typename T>
+Polynomial<T>::Polynomial(const T coefficient,
                                         const vector<Term>& terms) {
   Monomial m;
   m.coefficient = coefficient;
@@ -61,27 +61,27 @@ Polynomial<CoefficientType>::Polynomial(const CoefficientType coefficient,
   monomials_.push_back(m);
 }
 
-template <typename CoefficientType>
-Polynomial<CoefficientType>::Polynomial(
+template <typename T>
+Polynomial<T>::Polynomial(
     typename vector<
-        typename Polynomial<CoefficientType>::Monomial>::const_iterator start,
-    typename vector<typename Polynomial<CoefficientType>::Monomial>::
+        typename Polynomial<T>::Monomial>::const_iterator start,
+    typename vector<typename Polynomial<T>::Monomial>::
         const_iterator finish) {
   is_univariate_ = true;
   for (
       typename vector<
-          typename Polynomial<CoefficientType>::Monomial>::const_iterator iter =
+          typename Polynomial<T>::Monomial>::const_iterator iter =
           start;
       iter != finish; iter++)
     monomials_.push_back(*iter);
   MakeMonomialsUnique();
 }
 
-template <typename CoefficientType>
-Polynomial<CoefficientType>::Polynomial(const string varname,
+template <typename T>
+Polynomial<T>::Polynomial(const string varname,
                                         const unsigned int num) {
   Monomial m;
-  m.coefficient = CoefficientType{1};
+  m.coefficient = T{1};
   Term t;
   t.var = VariableNameToId(varname, num);
   t.power = 1;
@@ -90,8 +90,8 @@ Polynomial<CoefficientType>::Polynomial(const string varname,
   is_univariate_ = true;
 }
 
-template <typename CoefficientType>
-Polynomial<CoefficientType>::Polynomial(const CoefficientType& coeff,
+template <typename T>
+Polynomial<T>::Polynomial(const T& coeff,
                                         const VarType& v) {
   Monomial m;
   m.coefficient = coeff;
@@ -103,21 +103,21 @@ Polynomial<CoefficientType>::Polynomial(const CoefficientType& coeff,
   is_univariate_ = true;
 }
 
-template <typename CoefficientType>
-int Polynomial<CoefficientType>::GetNumberOfCoefficients() const {
+template <typename T>
+int Polynomial<T>::GetNumberOfCoefficients() const {
   return static_cast<int>(monomials_.size());
 }
 
-template <typename CoefficientType>
-int Polynomial<CoefficientType>::Monomial::GetDegree() const {
+template <typename T>
+int Polynomial<T>::Monomial::GetDegree() const {
   if (terms.empty()) return 0;
   int degree = terms[0].power;
   for (size_t i = 1; i < terms.size(); i++) degree *= terms[i].power;
   return degree;
 }
 
-template <typename CoefficientType>
-int Polynomial<CoefficientType>::Monomial::GetDegreeOf(VarType v) const {
+template <typename T>
+int Polynomial<T>::Monomial::GetDegreeOf(VarType v) const {
   for (const Term& term : terms) {
     if (term.var == v) {
       return term.power;
@@ -126,9 +126,9 @@ int Polynomial<CoefficientType>::Monomial::GetDegreeOf(VarType v) const {
   return 0;
 }
 
-template <typename CoefficientType>
-typename Polynomial<CoefficientType>::Monomial
-Polynomial<CoefficientType>::Monomial::Factor(const Monomial& divisor) const {
+template <typename T>
+typename Polynomial<T>::Monomial
+Polynomial<T>::Monomial::Factor(const Monomial& divisor) const {
   Monomial error, result;
   error.coefficient = 0;
   result.coefficient = coefficient / divisor.coefficient;
@@ -148,8 +148,8 @@ Polynomial<CoefficientType>::Monomial::Factor(const Monomial& divisor) const {
   return result;
 }
 
-template <typename CoefficientType>
-int Polynomial<CoefficientType>::GetDegree() const {
+template <typename T>
+int Polynomial<T>::GetDegree() const {
   int max_degree = 0;
   for (typename vector<Monomial>::const_iterator iter = monomials_.begin();
        iter != monomials_.end(); iter++) {
@@ -160,8 +160,8 @@ int Polynomial<CoefficientType>::GetDegree() const {
   return max_degree;
 }
 
-template <typename CoefficientType>
-bool Polynomial<CoefficientType>::IsAffine() const {
+template <typename T>
+bool Polynomial<T>::IsAffine() const {
   for (const auto& monomial : monomials_) {
     if ((monomial.terms.size() > 1) || (monomial.GetDegree() > 1)) {
       return false;
@@ -170,32 +170,32 @@ bool Polynomial<CoefficientType>::IsAffine() const {
   return true;
 }
 
-template <typename CoefficientType>
-typename Polynomial<CoefficientType>::VarType
-Polynomial<CoefficientType>::GetSimpleVariable() const {
+template <typename T>
+typename Polynomial<T>::VarType
+Polynomial<T>::GetSimpleVariable() const {
   if (monomials_.size() != 1) return 0;
   if (monomials_[0].terms.size() != 1) return 0;
   if (monomials_[0].terms[0].power != 1) return 0;
   return monomials_[0].terms[0].var;
 }
 
-template <typename CoefficientType>
-const std::vector<typename Polynomial<CoefficientType>::Monomial>&
-Polynomial<CoefficientType>::GetMonomials() const {
+template <typename T>
+const std::vector<typename Polynomial<T>::Monomial>&
+Polynomial<T>::GetMonomials() const {
   return monomials_;
 }
 
-template <typename CoefficientType>
-Matrix<CoefficientType, Dynamic, 1>
-Polynomial<CoefficientType>::GetCoefficients() const {
+template <typename T>
+Matrix<T, Dynamic, 1>
+Polynomial<T>::GetCoefficients() const {
   if (!is_univariate_)
     throw runtime_error(
         "getCoefficients is only defined for univariate polynomials");
 
   int deg = GetDegree();
 
-  Matrix<CoefficientType, Dynamic, 1> coefficients =
-      Matrix<CoefficientType, Dynamic, 1>::Zero(deg + 1);
+  Matrix<T, Dynamic, 1> coefficients =
+      Matrix<T, Dynamic, 1>::Zero(deg + 1);
   for (typename vector<Monomial>::const_iterator iter = monomials_.begin();
        iter != monomials_.end(); iter++) {
     if (iter->terms.empty())
@@ -206,10 +206,10 @@ Polynomial<CoefficientType>::GetCoefficients() const {
   return coefficients;
 }
 
-template <typename CoefficientType>
-std::set<typename Polynomial<CoefficientType>::VarType>
-Polynomial<CoefficientType>::GetVariables() const {
-  std::set<Polynomial<CoefficientType>::VarType> vars;
+template <typename T>
+std::set<typename Polynomial<T>::VarType>
+Polynomial<T>::GetVariables() const {
+  std::set<Polynomial<T>::VarType> vars;
   for (const Monomial& monomial : monomials_) {
     for (const Term& term : monomial.terms) {
       vars.insert(term.var);
@@ -218,12 +218,12 @@ Polynomial<CoefficientType>::GetVariables() const {
   return vars;
 }
 
-template <typename CoefficientType>
-Polynomial<CoefficientType> Polynomial<CoefficientType>::EvaluatePartial(
-    const std::map<VarType, CoefficientType>& var_values) const {
+template <typename T>
+Polynomial<T> Polynomial<T>::EvaluatePartial(
+    const std::map<VarType, T>& var_values) const {
   std::vector<Monomial> new_monomials;
   for (const Monomial& monomial : monomials_) {
-    CoefficientType new_coefficient = monomial.coefficient;
+    T new_coefficient = monomial.coefficient;
     std::vector<Term> new_terms;
     for (const Term& term : monomial.terms) {
       if (var_values.count(term.var)) {
@@ -238,8 +238,8 @@ Polynomial<CoefficientType> Polynomial<CoefficientType>::EvaluatePartial(
   return Polynomial(new_monomials.begin(), new_monomials.end());
 }
 
-template <typename CoefficientType>
-void Polynomial<CoefficientType>::Subs(const VarType& orig,
+template <typename T>
+void Polynomial<T>::Subs(const VarType& orig,
                                        const VarType& replacement) {
   for (typename vector<Monomial>::iterator iter = monomials_.begin();
        iter != monomials_.end(); iter++) {
@@ -250,8 +250,8 @@ void Polynomial<CoefficientType>::Subs(const VarType& orig,
   }
 }
 
-template <typename CoefficientType>
-Polynomial<CoefficientType> Polynomial<CoefficientType>::Derivative(
+template <typename T>
+Polynomial<T> Polynomial<T>::Derivative(
     int derivative_order) const {
   DRAKE_DEMAND(derivative_order >= 0);
   if (!is_univariate_)
@@ -260,7 +260,7 @@ Polynomial<CoefficientType> Polynomial<CoefficientType>::Derivative(
   if (derivative_order == 0) {
     return *this;
   }
-  Polynomial<CoefficientType> ret;
+  Polynomial<T> ret;
 
   for (typename vector<Monomial>::const_iterator iter = monomials_.begin();
        iter != monomials_.end(); iter++) {
@@ -280,13 +280,13 @@ Polynomial<CoefficientType> Polynomial<CoefficientType>::Derivative(
   return ret;
 }
 
-template <typename CoefficientType>
-Polynomial<CoefficientType> Polynomial<CoefficientType>::Integral(
-    const CoefficientType& integration_constant) const {
+template <typename T>
+Polynomial<T> Polynomial<T>::Integral(
+    const T& integration_constant) const {
   if (!is_univariate_)
     throw runtime_error(
         "Integral is only defined for univariate polynomials");
-  Polynomial<CoefficientType> ret = *this;
+  Polynomial<T> ret = *this;
 
   for (typename vector<Monomial>::iterator iter = ret.monomials_.begin();
        iter != ret.monomials_.end(); iter++) {
@@ -315,9 +315,9 @@ Polynomial<CoefficientType> Polynomial<CoefficientType>::Integral(
   return ret;
 }
 
-template <typename CoefficientType>
-bool Polynomial<CoefficientType>::operator==(
-    const Polynomial<CoefficientType>& other) const {
+template <typename T>
+bool Polynomial<T>::operator==(
+    const Polynomial<T>& other) const {
   // Comparison of unsorted vectors is faster copying them into std::set
   // btrees rather than using std::is_permutation().
   // TODO(#2216) switch from multiset to set for further performance gains.
@@ -328,9 +328,9 @@ bool Polynomial<CoefficientType>::operator==(
   return this_monomials == other_monomials;
 }
 
-template <typename CoefficientType>
-Polynomial<CoefficientType>& Polynomial<CoefficientType>::operator+=(
-    const Polynomial<CoefficientType>& other) {
+template <typename T>
+Polynomial<T>& Polynomial<T>::operator+=(
+    const Polynomial<T>& other) {
   for (const auto& iter : other.monomials_) {
     monomials_.push_back(iter);
   }
@@ -338,20 +338,20 @@ Polynomial<CoefficientType>& Polynomial<CoefficientType>::operator+=(
   return *this;
 }
 
-template <typename CoefficientType>
-Polynomial<CoefficientType>& Polynomial<CoefficientType>::operator-=(
-    const Polynomial<CoefficientType>& other) {
+template <typename T>
+Polynomial<T>& Polynomial<T>::operator-=(
+    const Polynomial<T>& other) {
   for (const auto& iter : other.monomials_) {
     monomials_.push_back(iter);
-    monomials_.back().coefficient *= CoefficientType{-1};
+    monomials_.back().coefficient *= T{-1};
   }
   MakeMonomialsUnique();  // also sets is_univariate false if necessary
   return *this;
 }
 
-template <typename CoefficientType>
-Polynomial<CoefficientType>& Polynomial<CoefficientType>::operator*=(
-    const Polynomial<CoefficientType>& other) {
+template <typename T>
+Polynomial<T>& Polynomial<T>::operator*=(
+    const Polynomial<T>& other) {
   vector<Monomial> new_monomials;
 
   for (const auto& iter : monomials_) {
@@ -381,9 +381,9 @@ Polynomial<CoefficientType>& Polynomial<CoefficientType>::operator*=(
   return *this;
 }
 
-template <typename CoefficientType>
-Polynomial<CoefficientType>& Polynomial<CoefficientType>::operator+=(
-    const CoefficientType& scalar) {
+template <typename T>
+Polynomial<T>& Polynomial<T>::operator+=(
+    const T& scalar) {
   // add to the constant monomial if I have one
   for (typename vector<Monomial>::iterator iter = monomials_.begin();
        iter != monomials_.end(); iter++) {
@@ -400,9 +400,9 @@ Polynomial<CoefficientType>& Polynomial<CoefficientType>::operator+=(
   return *this;
 }
 
-template <typename CoefficientType>
-Polynomial<CoefficientType>& Polynomial<CoefficientType>::operator-=(
-    const CoefficientType& scalar) {
+template <typename T>
+Polynomial<T>& Polynomial<T>::operator-=(
+    const T& scalar) {
   // add to the constant monomial if I have one
   for (typename vector<Monomial>::iterator iter = monomials_.begin();
        iter != monomials_.end(); iter++) {
@@ -419,9 +419,9 @@ Polynomial<CoefficientType>& Polynomial<CoefficientType>::operator-=(
   return *this;
 }
 
-template <typename CoefficientType>
-Polynomial<CoefficientType>& Polynomial<CoefficientType>::operator*=(
-    const CoefficientType& scalar) {
+template <typename T>
+Polynomial<T>& Polynomial<T>::operator*=(
+    const T& scalar) {
   for (typename vector<Monomial>::iterator iter = monomials_.begin();
        iter != monomials_.end(); iter++) {
     iter->coefficient *= scalar;
@@ -429,9 +429,9 @@ Polynomial<CoefficientType>& Polynomial<CoefficientType>::operator*=(
   return *this;
 }
 
-template <typename CoefficientType>
-Polynomial<CoefficientType>& Polynomial<CoefficientType>::operator/=(
-    const CoefficientType& scalar) {
+template <typename T>
+Polynomial<T>& Polynomial<T>::operator/=(
+    const T& scalar) {
   for (typename vector<Monomial>::iterator iter = monomials_.begin();
        iter != monomials_.end(); iter++) {
     iter->coefficient /= scalar;
@@ -439,26 +439,26 @@ Polynomial<CoefficientType>& Polynomial<CoefficientType>::operator/=(
   return *this;
 }
 
-template <typename CoefficientType>
-const Polynomial<CoefficientType> Polynomial<CoefficientType>::operator+(
+template <typename T>
+const Polynomial<T> Polynomial<T>::operator+(
     const Polynomial& other) const {
-  Polynomial<CoefficientType> ret = *this;
+  Polynomial<T> ret = *this;
   ret += other;
   return ret;
 }
 
-template <typename CoefficientType>
-const Polynomial<CoefficientType> Polynomial<CoefficientType>::operator-(
+template <typename T>
+const Polynomial<T> Polynomial<T>::operator-(
     const Polynomial& other) const {
-  Polynomial<CoefficientType> ret = *this;
+  Polynomial<T> ret = *this;
   ret -= other;
   return ret;
 }
 
-template <typename CoefficientType>
-const Polynomial<CoefficientType> Polynomial<CoefficientType>::operator-()
+template <typename T>
+const Polynomial<T> Polynomial<T>::operator-()
     const {
-  Polynomial<CoefficientType> ret = *this;
+  Polynomial<T> ret = *this;
   for (typename vector<Monomial>::iterator iter = ret.monomials_.begin();
        iter != ret.monomials_.end(); iter++) {
     iter->coefficient = -iter->coefficient;
@@ -466,25 +466,25 @@ const Polynomial<CoefficientType> Polynomial<CoefficientType>::operator-()
   return ret;
 }
 
-template <typename CoefficientType>
-const Polynomial<CoefficientType> Polynomial<CoefficientType>::operator*(
-    const Polynomial<CoefficientType>& other) const {
-  Polynomial<CoefficientType> ret = *this;
+template <typename T>
+const Polynomial<T> Polynomial<T>::operator*(
+    const Polynomial<T>& other) const {
+  Polynomial<T> ret = *this;
   ret *= other;
   return ret;
 }
 
-template <typename CoefficientType>
-const Polynomial<CoefficientType> Polynomial<CoefficientType>::operator/(
-    const CoefficientType& scalar) const {
-  Polynomial<CoefficientType> ret = *this;
+template <typename T>
+const Polynomial<T> Polynomial<T>::operator/(
+    const T& scalar) const {
+  Polynomial<T> ret = *this;
   ret /= scalar;
   return ret;
 }
 
-template <typename CoefficientType>
-typename Polynomial<CoefficientType>::RootsType
-Polynomial<CoefficientType>::Roots() const {
+template <typename T>
+typename Polynomial<T>::RootsType
+Polynomial<T>::Roots() const {
   if (!is_univariate_)
     throw runtime_error(
         "Roots is only defined for univariate polynomials");
@@ -496,9 +496,9 @@ Polynomial<CoefficientType>::Roots() const {
   int degree = static_cast<int>(coefficients.size()) - 1;
   switch (degree) {
     case 0:
-      return Polynomial<CoefficientType>::RootsType(degree);
+      return Polynomial<T>::RootsType(degree);
     case 1: {
-      Polynomial<CoefficientType>::RootsType ret(degree);
+      Polynomial<T>::RootsType ret(degree);
       ret[0] = -coefficients[0] / coefficients[1];
       return ret;
     }
@@ -511,8 +511,8 @@ Polynomial<CoefficientType>::Roots() const {
   }
 }
 
-template <typename CoefficientType>
-bool Polynomial<CoefficientType>::IsApprox(const Polynomial& other,
+template <typename T>
+bool Polynomial<T>::IsApprox(const Polynomial& other,
                                            const RealScalar& tol) const {
   return GetCoefficients().isApprox(other.GetCoefficients(), tol);
 }
@@ -522,8 +522,8 @@ const unsigned int kNumNameChars = sizeof(kNameChars) - 1;
 const unsigned int kNameLength = 4;
 const unsigned int kMaxNamePart = 923521;  // (kNumNameChars+1)^kNameLength;
 
-template <typename CoefficientType>
-bool Polynomial<CoefficientType>::IsValidVariableName(const string name) {
+template <typename T>
+bool Polynomial<T>::IsValidVariableName(const string name) {
   size_t len = name.length();
   if (len < 1) return false;
   for (size_t i = 0; i < len; i++)
@@ -531,9 +531,9 @@ bool Polynomial<CoefficientType>::IsValidVariableName(const string name) {
   return true;
 }
 
-template <typename CoefficientType>
-typename Polynomial<CoefficientType>::VarType
-Polynomial<CoefficientType>::VariableNameToId(const string name,
+template <typename T>
+typename Polynomial<T>::VarType
+Polynomial<T>::VariableNameToId(const string name,
                                               const unsigned int m) {
   DRAKE_THROW_UNLESS(IsValidVariableName(name));
   unsigned int multiplier = 1;
@@ -556,8 +556,8 @@ Polynomial<CoefficientType>::VariableNameToId(const string name,
   return static_cast<VarType>(2) * (name_part + kMaxNamePart * (m - 1));
 }
 
-template <typename CoefficientType>
-string Polynomial<CoefficientType>::IdToVariableName(const VarType id) {
+template <typename T>
+string Polynomial<T>::IdToVariableName(const VarType id) {
   VarType name_part = (id / 2) % kMaxNamePart;  // id/2 to be compatible w/
                                                 // msspoly, even though I'm not
                                                 // doing the trig support here
@@ -578,8 +578,8 @@ string Polynomial<CoefficientType>::IdToVariableName(const VarType id) {
   return string(name) + std::to_string((m + 1));
 }
 
-template <typename CoefficientType>
-void Polynomial<CoefficientType>::MakeMonomialsUnique(void) {
+template <typename T>
+void Polynomial<T>::MakeMonomialsUnique(void) {
   VarType unique_var = 0;  // also update the univariate flag
   for (int i = static_cast<int>(monomials_.size()) - 1; i >= 0; --i) {
     if (monomials_[i].coefficient == 0) {

--- a/common/test/polynomial_test.cc
+++ b/common/test/polynomial_test.cc
@@ -19,39 +19,39 @@ using std::uniform_real_distribution;
 namespace drake {
 namespace {
 
-template <typename CoefficientType>
+template <typename T>
 void testIntegralAndDerivative() {
   VectorXd coefficients = VectorXd::Random(5);
-  Polynomial<CoefficientType> poly(coefficients);
+  Polynomial<T> poly(coefficients);
 
   EXPECT_TRUE(CompareMatrices(poly.GetCoefficients(),
                               poly.Derivative(0).GetCoefficients(), 1e-14,
                               MatrixCompareType::absolute));
 
-  Polynomial<CoefficientType> third_derivative = poly.Derivative(3);
+  Polynomial<T> third_derivative = poly.Derivative(3);
 
-  Polynomial<CoefficientType> third_derivative_check =
+  Polynomial<T> third_derivative_check =
       poly.Derivative().Derivative().Derivative();
 
   EXPECT_TRUE(CompareMatrices(third_derivative.GetCoefficients(),
                               third_derivative_check.GetCoefficients(), 1e-14,
                               MatrixCompareType::absolute));
 
-  Polynomial<CoefficientType> tenth_derivative = poly.Derivative(10);
+  Polynomial<T> tenth_derivative = poly.Derivative(10);
 
   EXPECT_TRUE(CompareMatrices(tenth_derivative.GetCoefficients(),
                               VectorXd::Zero(1), 1e-14,
                               MatrixCompareType::absolute));
 
-  Polynomial<CoefficientType> integral = poly.Integral(0.0);
-  Polynomial<CoefficientType> poly_back = integral.Derivative();
+  Polynomial<T> integral = poly.Integral(0.0);
+  Polynomial<T> poly_back = integral.Derivative();
 
   EXPECT_TRUE(CompareMatrices(poly_back.GetCoefficients(),
                               poly.GetCoefficients(), 1e-14,
                               MatrixCompareType::absolute));
 }
 
-template <typename CoefficientType>
+template <typename T>
 void testOperators() {
   int max_num_coefficients = 6;
   int num_tests = 10;
@@ -61,24 +61,24 @@ void testOperators() {
 
   for (int i = 0; i < num_tests; ++i) {
     VectorXd coeff1 = VectorXd::Random(int_distribution(generator));
-    Polynomial<CoefficientType> poly1(coeff1);
+    Polynomial<T> poly1(coeff1);
 
     VectorXd coeff2 = VectorXd::Random(int_distribution(generator));
-    Polynomial<CoefficientType> poly2(coeff2);
+    Polynomial<T> poly2(coeff2);
 
     double scalar = uniform(generator);
 
-    Polynomial<CoefficientType> sum = poly1 + poly2;
-    Polynomial<CoefficientType> difference = poly2 - poly1;
-    Polynomial<CoefficientType> product = poly1 * poly2;
-    Polynomial<CoefficientType> poly1_plus_scalar = poly1 + scalar;
-    Polynomial<CoefficientType> poly1_minus_scalar = poly1 - scalar;
-    Polynomial<CoefficientType> poly1_scaled = poly1 * scalar;
-    Polynomial<CoefficientType> poly1_div = poly1 / scalar;
-    Polynomial<CoefficientType> poly1_times_poly1 = poly1;
-    const Polynomial<CoefficientType> pow_poly1_3{pow(poly1, 3)};
-    const Polynomial<CoefficientType> pow_poly1_4{pow(poly1, 4)};
-    const Polynomial<CoefficientType> pow_poly1_10{pow(poly1, 10)};
+    Polynomial<T> sum = poly1 + poly2;
+    Polynomial<T> difference = poly2 - poly1;
+    Polynomial<T> product = poly1 * poly2;
+    Polynomial<T> poly1_plus_scalar = poly1 + scalar;
+    Polynomial<T> poly1_minus_scalar = poly1 - scalar;
+    Polynomial<T> poly1_scaled = poly1 * scalar;
+    Polynomial<T> poly1_div = poly1 / scalar;
+    Polynomial<T> poly1_times_poly1 = poly1;
+    const Polynomial<T> pow_poly1_3{pow(poly1, 3)};
+    const Polynomial<T> pow_poly1_4{pow(poly1, 4)};
+    const Polynomial<T> pow_poly1_10{pow(poly1, 10)};
     poly1_times_poly1 *= poly1_times_poly1;
 
     double t = uniform(generator);
@@ -119,7 +119,7 @@ void testOperators() {
   }
 }
 
-template <typename CoefficientType>
+template <typename T>
 void testRoots() {
   int max_num_coefficients = 6;
   default_random_engine generator;
@@ -128,7 +128,7 @@ void testRoots() {
   int num_tests = 50;
   for (int i = 0; i < num_tests; ++i) {
     VectorXd coeffs = VectorXd::Random(int_distribution(generator));
-    Polynomial<CoefficientType> poly(coeffs);
+    Polynomial<T> poly(coeffs);
     auto roots = poly.Roots();
     EXPECT_EQ(roots.rows(), poly.GetDegree());
     for (int k = 0; k < roots.size(); k++) {
@@ -153,7 +153,7 @@ void testEvalType() {
   EXPECT_EQ(typeid(decltype(valueComplexInput)), typeid(std::complex<double>));
 }
 
-template <typename CoefficientType>
+template <typename T>
 void testPolynomialMatrix() {
   int max_matrix_rows_cols = 7;
   int num_coefficients = 6;
@@ -165,11 +165,11 @@ void testPolynomialMatrix() {
   int rows_B = cols_A;
   int cols_B = matrix_size_distribution(generator);
 
-  auto A = test::RandomPolynomialMatrix<CoefficientType>(num_coefficients,
+  auto A = test::RandomPolynomialMatrix<T>(num_coefficients,
                                                          rows_A, cols_A);
-  auto B = test::RandomPolynomialMatrix<CoefficientType>(num_coefficients,
+  auto B = test::RandomPolynomialMatrix<T>(num_coefficients,
                                                          rows_B, cols_B);
-  auto C = test::RandomPolynomialMatrix<CoefficientType>(num_coefficients,
+  auto C = test::RandomPolynomialMatrix<T>(num_coefficients,
                                                          rows_A, cols_A);
   auto product = A * B;
   auto sum = A + C;

--- a/common/test_utilities/random_polynomial_matrix.h
+++ b/common/test_utilities/random_polynomial_matrix.h
@@ -6,19 +6,18 @@ namespace drake {
 namespace test {
 
 /// Obtains a matrix of random unvariate Polynomials of the specified size.
-template <typename CoefficientType = double>
-static Eigen::Matrix<Polynomial<CoefficientType>,
-                     Eigen::Dynamic, Eigen::Dynamic>
+template <typename T = double>
+static Eigen::Matrix<Polynomial<T>, Eigen::Dynamic, Eigen::Dynamic>
 RandomPolynomialMatrix(Eigen::Index num_coefficients_per_polynomial,
                        Eigen::Index rows, Eigen::Index cols) {
-  Eigen::Matrix<Polynomial<CoefficientType>, Eigen::Dynamic, Eigen::Dynamic>
+  Eigen::Matrix<Polynomial<T>, Eigen::Dynamic, Eigen::Dynamic>
       mat(rows, cols);
   for (Eigen::Index row = 0; row < mat.rows(); ++row) {
     for (Eigen::Index col = 0; col < mat.cols(); ++col) {
       auto coeffs =
-          (Eigen::Matrix<CoefficientType, Eigen::Dynamic, 1>::Random(
+          (Eigen::Matrix<T, Eigen::Dynamic, 1>::Random(
               num_coefficients_per_polynomial)).eval();
-      mat(row, col) = Polynomial<CoefficientType>(coeffs);
+      mat(row, col) = Polynomial<T>(coeffs);
     }
   }
   return mat;

--- a/common/trajectories/piecewise_polynomial.cc
+++ b/common/trajectories/piecewise_polynomial.cc
@@ -73,16 +73,14 @@ PiecewisePolynomial<T>::derivative(int derivative_order) const {
 template <typename T>
 PiecewisePolynomial<T>
 PiecewisePolynomial<T>::integral(double value_at_start_time) const {
-  CoefficientMatrix matrix_value_at_start_time =
-      CoefficientMatrix::Constant(rows(), cols(), value_at_start_time);
+  MatrixX<T> matrix_value_at_start_time =
+      MatrixX<T>::Constant(rows(), cols(), value_at_start_time);
   return integral(matrix_value_at_start_time);
 }
 
 template <typename T>
-PiecewisePolynomial<T>
-PiecewisePolynomial<T>::integral(
-    const typename PiecewisePolynomial<T>::CoefficientMatrixRef&
-        value_at_start_time) const {
+PiecewisePolynomial<T> PiecewisePolynomial<T>::integral(
+    const Eigen::Ref<MatrixX<T>>& value_at_start_time) const {
   PiecewisePolynomial ret = *this;
   for (int segment_index = 0; segment_index < this->get_number_of_segments();
        segment_index++) {
@@ -172,8 +170,8 @@ operator-=(const PiecewisePolynomial<T>& other) {
 }
 
 template <typename T>
-PiecewisePolynomial<T>& PiecewisePolynomial<T>::
-operator*=(const PiecewisePolynomial<T>& other) {
+PiecewisePolynomial<T>& PiecewisePolynomial<T>::operator*=(
+    const PiecewisePolynomial<T>& other) {
   if (!this->SegmentTimesEqual(other))
     throw runtime_error(
         "Multiplication not yet implemented when segment times are not equal");
@@ -184,26 +182,23 @@ operator*=(const PiecewisePolynomial<T>& other) {
 }
 
 template <typename T>
-PiecewisePolynomial<T>& PiecewisePolynomial<T>::
-operator+=(const typename PiecewisePolynomial<
-           T>::CoefficientMatrix& offset) {
+PiecewisePolynomial<T>& PiecewisePolynomial<T>::operator+=(
+    const MatrixX<T>& offset) {
   for (size_t i = 0; i < polynomials_.size(); i++)
     polynomials_[i] += offset.template cast<PolynomialType>();
   return *this;
 }
 
 template <typename T>
-PiecewisePolynomial<T>& PiecewisePolynomial<T>::
-operator-=(const typename PiecewisePolynomial<
-           T>::CoefficientMatrix& offset) {
+PiecewisePolynomial<T>& PiecewisePolynomial<T>::operator-=(
+    const MatrixX<T>& offset) {
   for (size_t i = 0; i < polynomials_.size(); i++)
     polynomials_[i] -= offset.template cast<PolynomialType>();
   return *this;
 }
 
 template <typename T>
-const PiecewisePolynomial<T>
-PiecewisePolynomial<T>::operator+(
+const PiecewisePolynomial<T> PiecewisePolynomial<T>::operator+(
     const PiecewisePolynomial<T>& other) const {
   PiecewisePolynomial<T> ret = *this;
   ret += other;
@@ -211,8 +206,7 @@ PiecewisePolynomial<T>::operator+(
 }
 
 template <typename T>
-const PiecewisePolynomial<T>
-PiecewisePolynomial<T>::operator-(
+const PiecewisePolynomial<T> PiecewisePolynomial<T>::operator-(
     const PiecewisePolynomial<T>& other) const {
   PiecewisePolynomial<T> ret = *this;
   ret -= other;
@@ -220,37 +214,32 @@ PiecewisePolynomial<T>::operator-(
 }
 
 template <typename T>
-const PiecewisePolynomial<T>
-    PiecewisePolynomial<T>::operator*(
-        const PiecewisePolynomial<T>& other) const {
+const PiecewisePolynomial<T> PiecewisePolynomial<T>::operator*(
+    const PiecewisePolynomial<T>& other) const {
   PiecewisePolynomial<T> ret = *this;
   ret *= other;
   return ret;
 }
 
 template <typename T>
-const PiecewisePolynomial<T>
-PiecewisePolynomial<T>::operator+(
-    const typename PiecewisePolynomial<T>::CoefficientMatrix&
-        offset) const {
+const PiecewisePolynomial<T> PiecewisePolynomial<T>::operator+(
+    const MatrixX<T>& offset) const {
   PiecewisePolynomial<T> ret = *this;
   ret += offset;
   return ret;
 }
 
 template <typename T>
-const PiecewisePolynomial<T>
-PiecewisePolynomial<T>::operator-(
-    const typename PiecewisePolynomial<T>::CoefficientMatrix&
-        offset) const {
+const PiecewisePolynomial<T> PiecewisePolynomial<T>::operator-(
+    const MatrixX<T>& offset) const {
   PiecewisePolynomial<T> ret = *this;
   ret -= offset;
   return ret;
 }
 
 template <typename T>
-bool PiecewisePolynomial<T>::isApprox(
-    const PiecewisePolynomial<T>& other, double tol) const {
+bool PiecewisePolynomial<T>::isApprox(const PiecewisePolynomial<T>& other,
+                                      double tol) const {
   if (rows() != other.rows() || cols() != other.cols()) return false;
 
   if (!this->SegmentTimesEqual(other, tol)) return false;
@@ -378,10 +367,10 @@ template <typename T>
 void PiecewisePolynomial<T>::
     CheckSplineGenerationInputValidityOrThrow(
         const std::vector<double>& breaks,
-        const std::vector<CoefficientMatrix>& samples,
+        const std::vector<MatrixX<T>>& samples,
         int min_length) {
   const std::vector<double>& times = breaks;
-  const std::vector<CoefficientMatrix>& Y = samples;
+  const std::vector<MatrixX<T>>& Y = samples;
   if (times.size() != Y.size()) {
     throw std::runtime_error(
         "Number of break points does not match number of samples.");
@@ -418,7 +407,7 @@ template <typename T>
 PiecewisePolynomial<T>
 PiecewisePolynomial<T>::ZeroOrderHold(
     const std::vector<double>& breaks,
-    const std::vector<CoefficientMatrix>& samples) {
+    const std::vector<MatrixX<T>>& samples) {
   CheckSplineGenerationInputValidityOrThrow(breaks, samples, 2);
 
   std::vector<PolynomialMatrix> polys;
@@ -444,7 +433,7 @@ template <typename T>
 PiecewisePolynomial<T>
 PiecewisePolynomial<T>::FirstOrderHold(
     const std::vector<double>& breaks,
-    const std::vector<CoefficientMatrix>& samples) {
+    const std::vector<MatrixX<T>>& samples) {
   CheckSplineGenerationInputValidityOrThrow(breaks, samples, 2);
 
   std::vector<PolynomialMatrix> polys;
@@ -484,13 +473,11 @@ namespace {
 // See equation (2.10) in the following reference for more details.
 // http://www.mi.sanu.ac.rs/~gvm/radovi/mon.pdf
 template <typename T>
-MatrixX<T> ComputePchipEndSlope(
-    double dt0, double dt1,
-    const typename PiecewisePolynomial<T>::CoefficientMatrix& slope0,
-    const typename PiecewisePolynomial<T>::CoefficientMatrix& slope1) {
+MatrixX<T> ComputePchipEndSlope(double dt0, double dt1,
+                                const MatrixX<T>& slope0,
+                                const MatrixX<T>& slope1) {
   constexpr T kSlopeEpsilon = 1e-10;
-  typename PiecewisePolynomial<T>::CoefficientMatrix deriv =
-      ((2.0 * dt0 + dt1) * slope0 - dt0 * slope1) / (dt0 + dt1);
+  MatrixX<T> deriv = ((2.0 * dt0 + dt1) * slope0 - dt0 * slope1) / (dt0 + dt1);
   for (int i = 0; i < deriv.rows(); ++i) {
     for (int j = 0; j < deriv.cols(); ++j) {
       if (sign(deriv(i, j), kSlopeEpsilon) !=
@@ -520,10 +507,10 @@ template <typename T>
 PiecewisePolynomial<T>
 PiecewisePolynomial<T>::CubicShapePreserving(
     const std::vector<double>& breaks,
-    const std::vector<CoefficientMatrix>& samples,
+    const std::vector<MatrixX<T>>& samples,
     bool zero_end_point_derivatives) {
   const std::vector<double>& times = breaks;
-  const std::vector<CoefficientMatrix>& Y = samples;
+  const std::vector<MatrixX<T>>& Y = samples;
 
   if (zero_end_point_derivatives) {
     CheckSplineGenerationInputValidityOrThrow(times, Y, 2);
@@ -536,15 +523,15 @@ PiecewisePolynomial<T>::CubicShapePreserving(
   int cols = Y.front().cols();
 
   std::vector<PolynomialMatrix> polynomials(N - 1);
-  std::vector<CoefficientMatrix> slope(N - 1);
+  std::vector<MatrixX<T>> slope(N - 1);
   std::vector<double> dt(N - 1);
 
-  std::vector<CoefficientMatrix> Ydot(N, CoefficientMatrix::Zero(rows, cols));
+  std::vector<MatrixX<T>> Ydot(N, MatrixX<T>::Zero(rows, cols));
   Eigen::Matrix<T, 4, 1> coeffs;
 
   // Computes the end slopes.
-  CoefficientMatrix Ydot_start = CoefficientMatrix::Zero(rows, cols);
-  CoefficientMatrix Ydot_end = CoefficientMatrix::Zero(rows, cols);
+  MatrixX<T> Ydot_start = MatrixX<T>::Zero(rows, cols);
+  MatrixX<T> Ydot_end = MatrixX<T>::Zero(rows, cols);
 
   if (!zero_end_point_derivatives) {
     Ydot_start =
@@ -601,11 +588,11 @@ template <typename T>
 PiecewisePolynomial<T>
 PiecewisePolynomial<T>::CubicHermite(
     const std::vector<double>& breaks,
-    const std::vector<CoefficientMatrix>& samples,
-    const std::vector<CoefficientMatrix>& samples_dot) {
+    const std::vector<MatrixX<T>>& samples,
+    const std::vector<MatrixX<T>>& samples_dot) {
   const std::vector<double>& times = breaks;
-  const std::vector<CoefficientMatrix>& Y = samples;
-  const std::vector<CoefficientMatrix>& Ydot = samples_dot;
+  const std::vector<MatrixX<T>>& Y = samples;
+  const std::vector<MatrixX<T>>& Ydot = samples_dot;
   CheckSplineGenerationInputValidityOrThrow(times, Y, 2);
 
   int N = static_cast<int>(times.size());
@@ -645,12 +632,12 @@ template <typename T>
 int PiecewisePolynomial<T>::
     SetupCubicSplineInteriorCoeffsLinearSystem(
         const std::vector<double>& breaks,
-        const std::vector<CoefficientMatrix>& samples,
+        const std::vector<MatrixX<T>>& samples,
         int row, int col,
         MatrixX<T>* A,
         VectorX<T>* b) {
   const std::vector<double>& times = breaks;
-  const std::vector<CoefficientMatrix>& Y = samples;
+  const std::vector<MatrixX<T>>& Y = samples;
   int N = static_cast<int>(times.size());
 
   DRAKE_DEMAND(A != nullptr);
@@ -712,13 +699,13 @@ template <typename T>
 PiecewisePolynomial<T>
 PiecewisePolynomial<T>::CubicWithContinuousSecondDerivatives(
     const std::vector<double>& breaks,
-    const std::vector<CoefficientMatrix>& samples,
-    const CoefficientMatrix& sample_dot_at_start,
-    const CoefficientMatrix& sample_dot_at_end) {
+    const std::vector<MatrixX<T>>& samples,
+    const MatrixX<T>& sample_dot_at_start,
+    const MatrixX<T>& sample_dot_at_end) {
   const std::vector<double>& times = breaks;
-  const std::vector<CoefficientMatrix>& Y = samples;
-  const CoefficientMatrix& Ydot_start = sample_dot_at_start;
-  const CoefficientMatrix& Ydot_end = sample_dot_at_end;
+  const std::vector<MatrixX<T>>& Y = samples;
+  const MatrixX<T>& Ydot_start = sample_dot_at_start;
+  const MatrixX<T>& Ydot_end = sample_dot_at_end;
 
   CheckSplineGenerationInputValidityOrThrow(times, Y, 2);
 
@@ -786,10 +773,10 @@ template <typename T>
 PiecewisePolynomial<T>
 PiecewisePolynomial<T>::CubicWithContinuousSecondDerivatives(
     const std::vector<double>& breaks,
-    const std::vector<CoefficientMatrix>& samples,
+    const std::vector<MatrixX<T>>& samples,
     bool periodic_end_condition) {
   const std::vector<double>& times = breaks;
-  const std::vector<CoefficientMatrix>& Y = samples;
+  const std::vector<MatrixX<T>>& Y = samples;
   CheckSplineGenerationInputValidityOrThrow(times, Y, 3);
 
   int N = static_cast<int>(times.size());

--- a/common/trajectories/piecewise_polynomial.h
+++ b/common/trajectories/piecewise_polynomial.h
@@ -83,8 +83,6 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
 
   typedef Polynomial<T> PolynomialType;
   typedef MatrixX<PolynomialType> PolynomialMatrix;
-  typedef MatrixX<T> CoefficientMatrix;
-  typedef Eigen::Ref<CoefficientMatrix> CoefficientMatrixRef;
 
   /**
    * Single segment, constant value constructor over the interval [0, ∞].
@@ -193,7 +191,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * interpolating Polynomial objects that pass through the sample points. These
    * methods differ by the continuity constraints that they enforce at break
    * points and whether each sample represents a full matrix (versions taking
-   * `const std::vector<CoefficientMatrix>&`) or a column vector (versions
+   * `const std::vector<MatrixX<T>>&`) or a column vector (versions
    * taking `const Eigen::Ref<const MatrixX<T>>&`).
    *
    * These methods will throw `std::runtime_error` if:
@@ -217,7 +215,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    */
   static PiecewisePolynomial<T> ZeroOrderHold(
       const std::vector<double>& breaks,
-      const std::vector<CoefficientMatrix>& samples);
+      const std::vector<MatrixX<T>>& samples);
 
   /**
    * Version of ZeroOrderHold(breaks, samples) that uses vector samples and
@@ -241,7 +239,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    */
   static PiecewisePolynomial<T> FirstOrderHold(
       const std::vector<double>& breaks,
-      const std::vector<CoefficientMatrix>& samples);
+      const std::vector<MatrixX<T>>& samples);
 
   /**
    * Version of FirstOrderHold(breaks, samples) that uses vector samples and
@@ -300,14 +298,14 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    */
   static PiecewisePolynomial<T> CubicShapePreserving(
       const std::vector<double>& breaks,
-      const std::vector<CoefficientMatrix>& samples,
+      const std::vector<MatrixX<T>>& samples,
       bool zero_end_point_derivatives = false);
 
   DRAKE_DEPRECATED("2020-07-01",
                    "Pchip has been renamed to CubicShapePreserving.")
   static PiecewisePolynomial<T> Pchip(
       const std::vector<double>& breaks,
-      const std::vector<CoefficientMatrix>& samples,
+      const std::vector<MatrixX<T>>& samples,
       bool zero_end_point_derivatives = false) {
     return CubicShapePreserving(breaks, samples, zero_end_point_derivatives);
   }
@@ -350,17 +348,17 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    */
   static PiecewisePolynomial<T> CubicWithContinuousSecondDerivatives(
       const std::vector<double>& breaks,
-      const std::vector<CoefficientMatrix>& samples,
-      const CoefficientMatrix& sample_dot_at_start,
-      const CoefficientMatrix& sample_dot_at_end);
+      const std::vector<MatrixX<T>>& samples,
+      const MatrixX<T>& sample_dot_at_start,
+      const MatrixX<T>& sample_dot_at_end);
 
   DRAKE_DEPRECATED("2020-07-01", "This version of Cubic has been renamed to "
                                  "CubicWithContinuousSecondDerivatives.")
   static PiecewisePolynomial<T> Cubic(
       const std::vector<double>& breaks,
-      const std::vector<CoefficientMatrix>& samples,
-      const CoefficientMatrix& sample_dot_at_start,
-      const CoefficientMatrix& sample_dot_at_end) {
+      const std::vector<MatrixX<T>>& samples,
+      const MatrixX<T>& sample_dot_at_start,
+      const MatrixX<T>& sample_dot_at_end) {
     return CubicWithContinuousSecondDerivatives(
         breaks, samples, sample_dot_at_start, sample_dot_at_end);
   }
@@ -403,15 +401,15 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    */
   static PiecewisePolynomial<T> CubicHermite(
       const std::vector<double>& breaks,
-      const std::vector<CoefficientMatrix>& samples,
-      const std::vector<CoefficientMatrix>& samples_dot);
+      const std::vector<MatrixX<T>>& samples,
+      const std::vector<MatrixX<T>>& samples_dot);
 
   DRAKE_DEPRECATED("2020-07-01", "This version of Cubic has been renamed to "
   "CubicHermite.")
   static PiecewisePolynomial<T> Cubic(
       const std::vector<double>& breaks,
-      const std::vector<CoefficientMatrix>& samples,
-      const std::vector<CoefficientMatrix>& samples_dot) {
+      const std::vector<MatrixX<T>>& samples,
+      const std::vector<MatrixX<T>>& samples_dot) {
     return CubicHermite(breaks, samples, samples_dot);
   }
 
@@ -464,14 +462,14 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    */
   static PiecewisePolynomial<T> CubicWithContinuousSecondDerivatives(
       const std::vector<double>& breaks,
-      const std::vector<CoefficientMatrix>& samples,
+      const std::vector<MatrixX<T>>& samples,
       bool periodic_end_condition = false);
 
   DRAKE_DEPRECATED("2020-07-01", "This version of Cubic has been renamed to "
   "CubicWithContinuousSecondDerivatives.")
   static PiecewisePolynomial<T> Cubic(
       const std::vector<double>& breaks,
-      const std::vector<CoefficientMatrix>& samples,
+      const std::vector<MatrixX<T>>& samples,
       bool periodic_end_condition = false) {
     return CubicWithContinuousSecondDerivatives(breaks, samples,
                                                 periodic_end_condition);
@@ -540,7 +538,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * (zeroth-order coefficient) of the resulting Polynomial.
    */
   PiecewisePolynomial<T> integral(
-      const CoefficientMatrixRef& value_at_start_time) const;
+      const Eigen::Ref<MatrixX<T>>& value_at_start_time) const;
 
   /**
    * Returns `true` if this trajectory has no breaks/samples/polynomials.
@@ -639,9 +637,9 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    */
   PiecewisePolynomial& operator*=(const PiecewisePolynomial& other);
 
-  PiecewisePolynomial& operator+=(const CoefficientMatrix& coeff);
+  PiecewisePolynomial& operator+=(const MatrixX<T>& coeff);
 
-  PiecewisePolynomial& operator-=(const CoefficientMatrix& coeff);
+  PiecewisePolynomial& operator-=(const MatrixX<T>& coeff);
 
   /**
    * Adds each Polynomial in the PolynomialMatrix of `other` to the
@@ -676,9 +674,9 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    */
   const PiecewisePolynomial operator*(const PiecewisePolynomial& other) const;
 
-  const PiecewisePolynomial operator+(const CoefficientMatrix& coeff) const;
+  const PiecewisePolynomial operator+(const MatrixX<T>& coeff) const;
 
-  const PiecewisePolynomial operator-(const CoefficientMatrix& coeff) const;
+  const PiecewisePolynomial operator-(const MatrixX<T>& coeff) const;
 
   /**
    * Checks whether a %PiecewisePolynomial is approximately equal to this one.
@@ -776,7 +774,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
   // "not-a-sample" / etc). These will be specified by the callers.
   static int SetupCubicSplineInteriorCoeffsLinearSystem(
       const std::vector<double>& breaks,
-      const std::vector<CoefficientMatrix>& samples, int row, int col,
+      const std::vector<MatrixX<T>>& samples, int row, int col,
       MatrixX<T>* A, VectorX<T>* b);
 
   // Throws std::runtime_error if
@@ -786,7 +784,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
   // `breaks` has length smaller than min_length.
   static void CheckSplineGenerationInputValidityOrThrow(
       const std::vector<double>& breaks,
-      const std::vector<CoefficientMatrix>& samples, int min_length);
+      const std::vector<MatrixX<T>>& samples, int min_length);
 };
 
 }  // namespace trajectories

--- a/common/trajectories/test/piecewise_polynomial_test.cc
+++ b/common/trajectories/test/piecewise_polynomial_test.cc
@@ -23,21 +23,20 @@ namespace drake {
 namespace trajectories {
 namespace {
 
-template<typename CoefficientType>
+template<typename T>
 void testIntegralAndDerivative() {
   int num_coefficients = 5;
   int num_segments = 3;
   int rows = 3;
   int cols = 5;
 
-  typedef PiecewisePolynomial<CoefficientType> PiecewisePolynomialType;
-  typedef typename PiecewisePolynomialType::CoefficientMatrix CoefficientMatrix;
+  typedef PiecewisePolynomial<T> PiecewisePolynomialType;
 
   default_random_engine generator;
   vector<double> segment_times =
       PiecewiseTrajectory<double>::RandomSegmentTimes(num_segments, generator);
   PiecewisePolynomialType piecewise =
-      test::MakeRandomPiecewisePolynomial<CoefficientType>(
+      test::MakeRandomPiecewisePolynomial<T>(
           rows, cols, num_coefficients, segment_times);
 
   // derivative(0) should be same as original piecewise.
@@ -51,9 +50,8 @@ void testIntegralAndDerivative() {
   if (!piecewise.isApprox(piecewise_back, 1e-10)) throw runtime_error("wrong");
 
   // check value at start time
-  CoefficientMatrix desired_value_at_t0 =
-      PiecewisePolynomialType::CoefficientMatrix::Random(piecewise.rows(),
-                                                         piecewise.cols());
+  MatrixX<T> desired_value_at_t0 =
+      MatrixX<T>::Random(piecewise.rows(), piecewise.cols());
   PiecewisePolynomialType integral = piecewise.integral(desired_value_at_t0);
   auto value_at_t0 = integral.value(piecewise.start_time());
   EXPECT_TRUE(CompareMatrices(desired_value_at_t0, value_at_t0, 1e-10,
@@ -67,15 +65,14 @@ void testIntegralAndDerivative() {
   }
 }
 
-template<typename CoefficientType>
+template<typename T>
 void testBasicFunctionality() {
   int max_num_coefficients = 6;
   int num_tests = 100;
   default_random_engine generator;
   uniform_int_distribution<> int_distribution(1, max_num_coefficients);
 
-  typedef PiecewisePolynomial<CoefficientType> PiecewisePolynomialType;
-  typedef typename PiecewisePolynomialType::CoefficientMatrix CoefficientMatrix;
+  typedef PiecewisePolynomial<T> PiecewisePolynomialType;
 
   for (int i = 0; i < num_tests; ++i) {
     int num_coefficients = int_distribution(generator);
@@ -87,22 +84,22 @@ void testBasicFunctionality() {
         PiecewiseTrajectory<double>::RandomSegmentTimes(num_segments,
                                                         generator);
     PiecewisePolynomialType piecewise1 =
-        test::MakeRandomPiecewisePolynomial<CoefficientType>(
+        test::MakeRandomPiecewisePolynomial<T>(
             rows, cols, num_coefficients, segment_times);
     PiecewisePolynomialType piecewise2 =
-        test::MakeRandomPiecewisePolynomial<CoefficientType>(
+        test::MakeRandomPiecewisePolynomial<T>(
             rows, cols, num_coefficients, segment_times);
     PiecewisePolynomialType piecewise3_not_matching_rows =
-        test::MakeRandomPiecewisePolynomial<CoefficientType>(
+        test::MakeRandomPiecewisePolynomial<T>(
             rows + 1, cols, num_coefficients, segment_times);
     PiecewisePolynomialType piecewise4_not_matching_cols =
-        test::MakeRandomPiecewisePolynomial<CoefficientType>(
+        test::MakeRandomPiecewisePolynomial<T>(
             rows, cols + 1, num_coefficients, segment_times);
 
     normal_distribution<double> normal;
     double shift = normal(generator);
-    CoefficientMatrix offset =
-        CoefficientMatrix::Random(piecewise1.rows(), piecewise1.cols());
+    MatrixX<T> offset =
+        MatrixX<T>::Random(piecewise1.rows(), piecewise1.cols());
 
     PiecewisePolynomialType sum = piecewise1 + piecewise2;
     PiecewisePolynomialType difference = piecewise2 - piecewise1;
@@ -184,15 +181,15 @@ void testBasicFunctionality() {
   }
 }
 
-template<typename CoefficientType>
+template<typename T>
 void testValueOutsideOfRange() {
-  typedef PiecewisePolynomial<CoefficientType> PiecewisePolynomialType;
+  typedef PiecewisePolynomial<T> PiecewisePolynomialType;
 
   default_random_engine generator;
   vector<double> segment_times =
       PiecewiseTrajectory<double>::RandomSegmentTimes(6, generator);
   PiecewisePolynomialType piecewise =
-      test::MakeRandomPiecewisePolynomial<CoefficientType>(
+      test::MakeRandomPiecewisePolynomial<T>(
           3, 4, 5, segment_times);
 
   EXPECT_TRUE(CompareMatrices(piecewise.value(piecewise.start_time()),

--- a/common/trajectories/test/random_piecewise_polynomial.h
+++ b/common/trajectories/test/random_piecewise_polynomial.h
@@ -15,24 +15,24 @@ namespace test {
  * Obtains a random PiecewisePolynomial with the given @p segment_times.  Each
  * segment will have a matrix of random Polynomials of the specified size.
  */
-template<typename CoefficientType = double>
-PiecewisePolynomial<CoefficientType>
+template<typename T = double>
+PiecewisePolynomial<T>
 MakeRandomPiecewisePolynomial(Eigen::Index rows, Eigen::Index cols,
                               Eigen::Index num_coefficients_per_polynomial,
                               const std::vector<double> &segment_times) {
   Eigen::Index num_segments =
       static_cast<Eigen::Index>(segment_times.size() - 1);
-  typedef Polynomial<CoefficientType> PolynomialType;
+  typedef Polynomial<T> PolynomialType;
   typedef Eigen::Matrix<PolynomialType, Eigen::Dynamic, Eigen::Dynamic>
       PolynomialMatrix;
   std::vector<PolynomialMatrix> polynomials;
   for (Eigen::Index segment_index = 0; segment_index < num_segments;
        ++segment_index) {
     polynomials.push_back(
-        drake::test::RandomPolynomialMatrix<CoefficientType>(
+        drake::test::RandomPolynomialMatrix<T>(
             num_coefficients_per_polynomial, rows, cols));
   }
-  return PiecewisePolynomial<CoefficientType>(polynomials,
+  return PiecewisePolynomial<T>(polynomials,
                                                             segment_times);
 }
 

--- a/common/trig_poly.h
+++ b/common/trig_poly.h
@@ -43,13 +43,12 @@
  * enforced programmatically.
  * <!-- TODO(ggould-tri): Fix this in the future. -->
  */
-template <typename _CoefficientType = double>
+template <typename T = double>
 class TrigPoly final {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(TrigPoly)
 
-  typedef _CoefficientType CoefficientType;
-  typedef Polynomial<CoefficientType> PolyType;
+  typedef Polynomial<T> PolyType;
   typedef typename PolyType::VarType VarType;
   struct SinCosVars {
     VarType s;
@@ -71,7 +70,7 @@ class TrigPoly final {
 
   /// Constructs a constant TrigPoly.
   // NOLINTNEXTLINE(runtime/explicit) This conversion is desirable.
-  TrigPoly(const CoefficientType& scalar) : poly_(scalar) {}
+  TrigPoly(const T& scalar) : poly_(scalar) {}
 
   /**
    * Constructs a TrigPoly on the associated Polynomial p with no associated
@@ -141,17 +140,17 @@ class TrigPoly final {
 
     const std::vector<typename PolyType::Monomial>& m = p.poly_.GetMonomials();
     if (m.empty()) {
-      return TrigPoly(Polynomial<CoefficientType>(sin(CoefficientType(0))));
+      return TrigPoly(Polynomial<T>(sin(T(0))));
     } else if (p.poly_.GetDegree() > 1) {
       throw std::runtime_error(
           "sin of polynomials with degree > 1 is not supported");
     }
 
     // Base case of recursion is one mononomial with coefficient of 1.
-    if (m.size() == 1 && abs(m[0].coefficient) == CoefficientType(1)) {
+    if (m.size() == 1 && abs(m[0].coefficient) == T(1)) {
       TrigPoly ret = p;
       if (m[0].terms.empty()) {  // then it's a constant
-        ret.poly_ = Polynomial<CoefficientType>(sin(m[0].coefficient));
+        ret.poly_ = Polynomial<T>(sin(m[0].coefficient));
       } else {
         typename SinCosMap::iterator iter =
             ret.sin_cos_map_.find(m[0].terms[0].var);
@@ -164,17 +163,17 @@ class TrigPoly final {
       return ret;
     }
 
-    Polynomial<CoefficientType> pa;
-    Polynomial<CoefficientType> pb(m.begin() + 1, m.end());
-    if (abs(m[0].coefficient) == CoefficientType(1)) {
-      pa = Polynomial<CoefficientType>(m[0].coefficient, m[0].terms);
+    Polynomial<T> pa;
+    Polynomial<T> pb(m.begin() + 1, m.end());
+    if (abs(m[0].coefficient) == T(1)) {
+      pa = Polynomial<T>(m[0].coefficient, m[0].terms);
     } else if (m[0].coefficient - floor(m[0].coefficient) ==
-               CoefficientType(0)) {
+               T(0)) {
       // If the coefficient has integer magnitude greater than 1, recurse by
       // expanding out a term with coefficient of magnitude 1.
-      auto unit = copysign(CoefficientType(1), m[0].coefficient);
-      pa = Polynomial<CoefficientType>(unit, m[0].terms);
-      pb += Polynomial<CoefficientType>(m[0].coefficient - unit, m[0].terms);
+      auto unit = copysign(T(1), m[0].coefficient);
+      pa = Polynomial<T>(unit, m[0].terms);
+      pb += Polynomial<T>(m[0].coefficient - unit, m[0].terms);
     } else {
       throw std::runtime_error("Fractional coefficients not supported");
     }
@@ -200,17 +199,17 @@ class TrigPoly final {
 
     const std::vector<typename PolyType::Monomial>& m = p.poly_.GetMonomials();
     if (m.empty()) {
-      return TrigPoly(Polynomial<CoefficientType>(cos(CoefficientType(0))));
+      return TrigPoly(Polynomial<T>(cos(T(0))));
     } else if (p.poly_.GetDegree() > 1) {
       throw std::runtime_error(
           "cos of polynomials with degree > 1 is not supported");
     }
 
     // Base case of recursion is one mononomial with coefficient of 1.
-    if (m.size() == 1 && abs(m[0].coefficient) == CoefficientType(1)) {
+    if (m.size() == 1 && abs(m[0].coefficient) == T(1)) {
       TrigPoly ret = p;
       if (m[0].terms.empty()) {  // then it's a constant
-        ret.poly_ = Polynomial<CoefficientType>(cos(m[0].coefficient));
+        ret.poly_ = Polynomial<T>(cos(m[0].coefficient));
       } else {
         typename SinCosMap::iterator iter =
             ret.sin_cos_map_.find(m[0].terms[0].var);
@@ -219,24 +218,24 @@ class TrigPoly final {
               "tried taking the sin of a variable that does not exist in my "
               "sin_cos_map");
         ret.poly_.Subs(m[0].terms[0].var, iter->second.c);
-        if (m[0].coefficient == CoefficientType(-1)) {
+        if (m[0].coefficient == T(-1)) {
           ret *= -1;
         }  // cos(-q) => cos(q) => c (instead of -c)
       }
       return ret;
     }
 
-    Polynomial<CoefficientType> pa;
-    Polynomial<CoefficientType> pb(m.begin() + 1, m.end());
-    if (abs(m[0].coefficient) == CoefficientType(1)) {
-      pa = Polynomial<CoefficientType>(m[0].coefficient, m[0].terms);
+    Polynomial<T> pa;
+    Polynomial<T> pb(m.begin() + 1, m.end());
+    if (abs(m[0].coefficient) == T(1)) {
+      pa = Polynomial<T>(m[0].coefficient, m[0].terms);
     } else if (m[0].coefficient - floor(m[0].coefficient) ==
-               CoefficientType(0)) {
+               T(0)) {
       // If the coefficient has integer magnitude greater than 1, recurse by
       // expanding out a term with coefficient of magnitude 1.
-      auto unit = copysign(CoefficientType(1), m[0].coefficient);
-      pa = Polynomial<CoefficientType>(unit, m[0].terms);
-      pb += Polynomial<CoefficientType>(m[0].coefficient - unit, m[0].terms);
+      auto unit = copysign(T(1), m[0].coefficient);
+      pa = Polynomial<T>(unit, m[0].terms);
+      pb += Polynomial<T>(m[0].coefficient - unit, m[0].terms);
     } else {
       throw std::runtime_error("Fractional coefficients not supported");
     }
@@ -265,10 +264,10 @@ class TrigPoly final {
    * supplied for all base variables; supplying values for sin/cos variables
    * is an error.
    */
-  template <typename T>
-  typename Product<CoefficientType, T>::type EvaluateMultivariate(
-      const std::map<VarType, T>& var_values) const {
-    std::map<VarType, T> all_var_values = var_values;
+  template <typename U>
+  typename Product<T, U>::type EvaluateMultivariate(
+      const std::map<VarType, U>& var_values) const {
+    std::map<VarType, U> all_var_values = var_values;
     for (const auto& sin_cos_item : sin_cos_map_) {
       DRAKE_ASSERT(!var_values.count(sin_cos_item.second.s));
       DRAKE_ASSERT(!var_values.count(sin_cos_item.second.c));
@@ -286,9 +285,9 @@ class TrigPoly final {
    * all base variables only; supplying values for sin/cos variables is an
    * error.
    */
-  virtual TrigPoly<CoefficientType> EvaluatePartial(
-      const std::map<VarType, CoefficientType>& var_values) const {
-    std::map<VarType, CoefficientType> var_values_with_sincos = var_values;
+  virtual TrigPoly<T> EvaluatePartial(
+      const std::map<VarType, T>& var_values) const {
+    std::map<VarType, T> var_values_with_sincos = var_values;
     for (const auto& sin_cos_item : sin_cos_map_) {
       DRAKE_ASSERT(!var_values.count(sin_cos_item.second.s));
       DRAKE_ASSERT(!var_values.count(sin_cos_item.second.c));
@@ -337,22 +336,22 @@ class TrigPoly final {
     return *this;
   }
 
-  TrigPoly& operator+=(const CoefficientType& scalar) {
+  TrigPoly& operator+=(const T& scalar) {
     poly_ += scalar;
     return *this;
   }
 
-  TrigPoly& operator-=(const CoefficientType& scalar) {
+  TrigPoly& operator-=(const T& scalar) {
     poly_ -= scalar;
     return *this;
   }
 
-  TrigPoly& operator*=(const CoefficientType& scalar) {
+  TrigPoly& operator*=(const T& scalar) {
     poly_ *= scalar;
     return *this;
   }
 
-  TrigPoly& operator/=(const CoefficientType& scalar) {
+  TrigPoly& operator/=(const T& scalar) {
     poly_ /= scalar;
     return *this;
   }
@@ -370,7 +369,7 @@ class TrigPoly final {
   }
 
   const TrigPoly operator-() const {
-    TrigPoly ret = (*this) * CoefficientType(-1);
+    TrigPoly ret = (*this) * T(-1);
     return ret;
   }
 
@@ -381,13 +380,13 @@ class TrigPoly final {
   }
 
   friend const TrigPoly operator+(const TrigPoly& p,
-                                  const CoefficientType& scalar) {
+                                  const T& scalar) {
     TrigPoly ret = p;
     ret += scalar;
     return ret;
   }
 
-  friend const TrigPoly operator+(const CoefficientType& scalar,
+  friend const TrigPoly operator+(const T& scalar,
                                   const TrigPoly& p) {
     TrigPoly ret = p;
     ret += scalar;
@@ -395,13 +394,13 @@ class TrigPoly final {
   }
 
   friend const TrigPoly operator-(const TrigPoly& p,
-                                  const CoefficientType& scalar) {
+                                  const T& scalar) {
     TrigPoly ret = p;
     ret -= scalar;
     return ret;
   }
 
-  friend const TrigPoly operator-(const CoefficientType& scalar,
+  friend const TrigPoly operator-(const T& scalar,
                                   const TrigPoly& p) {
     TrigPoly ret = -p;
     ret += scalar;
@@ -409,26 +408,26 @@ class TrigPoly final {
   }
 
   friend const TrigPoly operator*(const TrigPoly& p,
-                                  const CoefficientType& scalar) {
+                                  const T& scalar) {
     TrigPoly ret = p;
     ret *= scalar;
     return ret;
   }
-  friend const TrigPoly operator*(const CoefficientType& scalar,
+  friend const TrigPoly operator*(const T& scalar,
                                   const TrigPoly& p) {
     TrigPoly ret = p;
     ret *= scalar;
     return ret;
   }
 
-  const TrigPoly operator/(const CoefficientType& scalar) const {
+  const TrigPoly operator/(const T& scalar) const {
     TrigPoly ret = *this;
     ret /= scalar;
     return ret;
   }
 
   friend std::ostream& operator<<(std::ostream& os,
-                                  const TrigPoly<CoefficientType>& tp) {
+                                  const TrigPoly<T>& tp) {
     os << tp.poly_;
     if (tp.sin_cos_map_.size()) {
       os << " where ";
@@ -448,11 +447,11 @@ class TrigPoly final {
   SinCosMap sin_cos_map_;
 };
 
-template <typename CoefficientType, int Rows, int Cols>
+template <typename T, int Rows, int Cols>
 std::ostream& operator<<(
     std::ostream& os,
-    const Eigen::Matrix<TrigPoly<CoefficientType>, Rows, Cols>& tp_mat) {
-  Eigen::Matrix<Polynomial<CoefficientType>, Rows, Cols> poly_mat(
+    const Eigen::Matrix<TrigPoly<T>, Rows, Cols>& tp_mat) {
+  Eigen::Matrix<Polynomial<T>, Rows, Cols> poly_mat(
       tp_mat.rows(), tp_mat.cols());
   for (int i = 0; i < poly_mat.size(); i++) {
     poly_mat(i) = tp_mat(i).poly();

--- a/solvers/system_identification.h
+++ b/solvers/system_identification.h
@@ -37,15 +37,15 @@ namespace solvers {
  * minimum number of "lumped" parameters and then estimating the values of
  * those parameters based on empirical data.
  */
-template <typename CoefficientType>
+template <typename T>
 class SystemIdentification {
  public:
-  typedef ::Polynomial<CoefficientType> PolyType;
+  typedef ::Polynomial<T> PolyType;
   typedef typename PolyType::Monomial MonomialType;
   typedef typename PolyType::Term TermType;
   typedef typename PolyType::VarType VarType;
   typedef std::map<PolyType, VarType> LumpingMapType;
-  typedef std::map<VarType, CoefficientType> PartialEvalType;
+  typedef std::map<VarType, T> PartialEvalType;
 
   /// Extract lumped parameters from a given polynomial.
   /**
@@ -106,7 +106,7 @@ class SystemIdentification {
    *     estimated values, suitable as input for Polynomial::evaluatePartial.
    *   * error is the root-mean-square error of the estimates.
    */
-  static std::pair<PartialEvalType, CoefficientType> EstimateParameters(
+  static std::pair<PartialEvalType, T> EstimateParameters(
       const VectorXPoly& polys,
       const std::vector<PartialEvalType>& active_var_values);
 
@@ -127,7 +127,7 @@ class SystemIdentification {
     VectorXTrigPoly partially_evaluated_polys;
 
     /// The root-mean-square error of the estimation step.
-    CoefficientType rms_error;
+    T rms_error;
   };
 
   /** Performs full lumped-parameter identification of a system of TrigPolys.
@@ -196,7 +196,7 @@ class SystemIdentification {
    * this will return
    *   {2, x + 1.5 * y}
    */
-  static std::pair<CoefficientType, PolyType>
+  static std::pair<T, PolyType>
   CanonicalizePolynomial(const PolyType& poly);
 
   /// Obtain a new variable ID not already in vars_in_use.  The string part of


### PR DESCRIPTION
instead of CoefficientType and a multitude of typedefs; now closer to comforming to drake standard notation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12948)
<!-- Reviewable:end -->
