### PR TITLE
Add compute contact surface computation to mesh half space code

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -310,11 +310,14 @@ drake_cc_library(
         "mesh_half_space_intersection.h",
     ],
     deps = [
+        ":bounding_volume_hierarchy",
         ":contact_surface_utility",
         ":posed_half_space",
         ":surface_mesh",
         "//common",
+        "//geometry:geometry_ids",
         "//geometry:utilities",
+        "//geometry/query_results:contact_surface",
     ],
 )
 
@@ -657,6 +660,7 @@ drake_cc_googletest(
         ":contact_surface_utility",
         ":mesh_half_space_intersection",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 


### PR DESCRIPTION
This adds one more API where an actual `ContactSurface` is computed (not just the mesh of the contact surface).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12954)
<!-- Reviewable:end -->
