### PR TITLE
ignore /.vscode instead of /.vscode/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@
 /.project/
 /.settings/
 /.clwb/
-/.vscode/
+/.vscode
 
 # (Possible) CMake build artifacts
 /build/


### PR DESCRIPTION
because it turns out that having .vscode symlinked to a remote directory simplifies my multi-machine workflow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12956)
<!-- Reviewable:end -->
