### PR TITLE
trajectories: Add ScaleTime to PiecewisePolynomial

### DIFF
--- a/common/trajectories/piecewise_polynomial.h
+++ b/common/trajectories/piecewise_polynomial.h
@@ -741,9 +741,32 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
   void RemoveFinalSegment();
 
   /**
+   * Modifies the trajectory so that pp_after(t) = pp_before(-t).
+   *
+   * @note The new trajectory will evaluate differently at precisely the break
+   * points if the original trajectory was discontinuous at the break points.
+   * This is because the segments are defined on the half-open intervals
+   * [breaks(i), breaks(i+1)), and the order of the breaks have been reversed.
+   */
+  void ReverseTime();
+
+  /**
+   * Scales the time of the trajectory by non-negative `scale` (use
+   * ReverseTime() if you want to also negate time). The resulting polynomial
+   * evaluates to pp_after(t) = pp_before(t/scale).
+   *
+   * As an example, `scale`=2 will result in a trajectory that is twice as long
+   * (start_time() and end_time() have both doubled).
+   */
+  void ScaleTime(double scale);
+
+  /**
    * Adds `offset` to all of the breaks. `offset` need not be a non-negative
-   * number.
-   * @note has no effect if empty().
+   * number.  The resulting polynomial will evaluate to pp_after(t) =
+   * pp_before(t-offset).
+   *
+   * As an example, `offset`=2 will result in the start_time() and end_time()
+   * being 2 seconds later.
    */
   void shiftRight(double offset);
 


### PR DESCRIPTION
Got a little hairy, but I needed to handle the case with scale = -1.0 because I need this for the tvlqr implementation.  (I need to integrate the riccati equation backwards in time, but our simulators don't support it, so I have to reverse the solution).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12966)
<!-- Reviewable:end -->
