### PR TITLE
Add Automatic Differentiated Jacobians to Velocity-Implicit Euler Integrator, fourth PR of #12528

### DIFF
--- a/systems/analysis/test_utilities/discontinuous_spring_mass_damper_system.h
+++ b/systems/analysis/test_utilities/discontinuous_spring_mass_damper_system.h
@@ -74,6 +74,9 @@ class DiscontinuousSpringMassDamperSystem final
 
     // Second element of the derivative is spring acceleration.
     (*derivatives)[1] = force / this->get_mass();
+
+    // Third element of the derivative is the energy added into the spring.
+    (*derivatives)[2] = this->CalcConservativePower(context);
   }
 
  private:

--- a/systems/analysis/test_utilities/implicit_integrator_test.h
+++ b/systems/analysis/test_utilities/implicit_integrator_test.h
@@ -18,11 +18,6 @@
 namespace drake {
 namespace systems {
 
-// TODO(antequ): remove this forward declaration once the Velocity-Implicit
-// Euler supports automatic differentiation and central differencing.
-template <typename T>
-class VelocityImplicitEulerIntegrator;
-
 namespace analysis_test {
 
 enum ReuseType { kNoReuse, kReuse };
@@ -56,13 +51,6 @@ class ImplicitIntegratorTest : public ::testing::Test {
 
     // Separate context necessary for the double spring mass system.
     dspring_context_ = stiff_double_system_->CreateDefaultContext();
-
-    // TODO(antequ): remove this check once the Velocity-Implicit Euler supports
-    // automatic differentiation and central differencing.
-    if constexpr (std::is_same_v<IntegratorType,
-                                 VelocityImplicitEulerIntegrator<double>>) {
-      integrator_supports_central_and_auto_diff_ = false;
-    }
   }
 
   void MiscAPITest(ReuseType type) {
@@ -173,7 +161,7 @@ class ImplicitIntegratorTest : public ::testing::Test {
     IntegratorType integrator(*spring_mass_damper_,
                               spring_mass_damper_context_.get());
     integrator.set_maximum_step_size(large_h_);
-    integrator.set_requested_minimum_step_size(small_h_);
+    integrator.set_requested_minimum_step_size(10 * small_h_);
     integrator.set_throw_on_minimum_step_size_violation(false);
     integrator.set_reuse(reuse_type_to_bool(type));
 
@@ -224,56 +212,72 @@ class ImplicitIntegratorTest : public ::testing::Test {
     // Verify that integrator statistics are valid, and reset the statistics.
     CheckGeneralStatsValidity(&integrator);
 
-    // TODO(antequ): remove this check once the Velocity-Implicit Euler
-    // supports autodiff and central differencing
-    if (integrator_supports_central_and_auto_diff_) {
-      // Switch to central differencing.
-      integrator.set_jacobian_computation_scheme(
-          IntegratorType::JacobianComputationScheme::kCentralDifference);
+    // Switch to central differencing.
+    integrator.set_jacobian_computation_scheme(
+        IntegratorType::JacobianComputationScheme::kCentralDifference);
 
-      // Reset the time, position, and velocity.
-      spring_mass_damper_context_->SetTime(0.0);
-      spring_mass_damper_->set_position(spring_mass_damper_context_.get(),
-                                        initial_position);
-      spring_mass_damper_->set_velocity(spring_mass_damper_context_.get(),
-                                        initial_velocity);
+    // Reset the time, position, and velocity.
+    spring_mass_damper_context_->SetTime(0.0);
+    spring_mass_damper_->set_position(spring_mass_damper_context_.get(),
+                                      initial_position);
+    spring_mass_damper_->set_velocity(spring_mass_damper_context_.get(),
+                                      initial_velocity);
 
-      // Integrate for t_final seconds again.
-      integrator.IntegrateWithMultipleStepsToTime(t_final);
-      x_final = xc_final.GetAtIndex(0);
-      v_final = xc_final.GetAtIndex(1);
+    // Initialize to reset cached Jacobians. This is necessary; otherwise, for
+    // some problems, the Jacobian may not be computed again because the
+    // previous one was good enough for Newton-Raphson to converge.
+    // TODO(antequ): This issue only exists for velocity-implicit Euler
+    // integrator; other implicit integrators reset their Jacobians in
+    // set_jacobian_computation_scheme(). Clear the velocity-implicit Euler
+    // integrator's Jacobian cache too in set_jacobian_computation_scheme(),
+    // and remove this call. See issue #13069.
+    integrator.Initialize();
 
-      // Verify that integrator statistics and outputs are valid, and reset the
-      // statistics.
-      EXPECT_NEAR(x_final_true, x_final, xtol);
-      EXPECT_NEAR(v_final_true, v_final, vtol);
-      CheckGeneralStatsValidity(&integrator);
+    // Integrate for t_final seconds again.
+    integrator.IntegrateWithMultipleStepsToTime(t_final);
+    x_final = xc_final.GetAtIndex(0);
+    v_final = xc_final.GetAtIndex(1);
 
-      // Switch to automatic differencing.
-      integrator.set_jacobian_computation_scheme(
-          IntegratorType::JacobianComputationScheme::kAutomatic);
+    // Verify that integrator statistics and outputs are valid, and reset the
+    // statistics.
+    EXPECT_NEAR(x_final_true, x_final, xtol);
+    EXPECT_NEAR(v_final_true, v_final, vtol);
+    CheckGeneralStatsValidity(&integrator);
 
-      // Reset the time, position, and velocity.
-      spring_mass_damper_context_->SetTime(0.0);
-      spring_mass_damper_->set_position(spring_mass_damper_context_.get(),
-                                        initial_position);
-      spring_mass_damper_->set_velocity(spring_mass_damper_context_.get(),
-                                        initial_velocity);
+    // Switch to automatic differencing.
+    integrator.set_jacobian_computation_scheme(
+        IntegratorType::JacobianComputationScheme::kAutomatic);
 
-      // Integrate for t_final seconds again.
-      integrator.IntegrateWithMultipleStepsToTime(t_final);
-      x_final = xc_final.GetAtIndex(0);
-      v_final = xc_final.GetAtIndex(1);
+    // Reset the time, position, and velocity.
+    spring_mass_damper_context_->SetTime(0.0);
+    spring_mass_damper_->set_position(spring_mass_damper_context_.get(),
+                                      initial_position);
+    spring_mass_damper_->set_velocity(spring_mass_damper_context_.get(),
+                                      initial_velocity);
 
-      // Verify that error control was used by making sure that the minimum step
-      // size was smaller than large_h_.
-      EXPECT_LT(integrator.get_smallest_adapted_step_size_taken(), large_h_);
+    // Initialize to reset cached Jacobians. This is necessary; otherwise, for
+    // some problems, the Jacobian may not be computed again because the
+    // previous one was good enough for Newton-Raphson to converge.
+    // TODO(antequ): This issue only exists for velocity-implicit Euler
+    // integrator; other implicit integrators reset their Jacobians in
+    // set_jacobian_computation_scheme(). Clear the velocity-implicit Euler
+    // integrator's Jacobian cache too in set_jacobian_computation_scheme(),
+    // and remove this call. See issue #13069.
+    integrator.Initialize();
 
-      // Verify that integrator statistics and outputs are valid.
-      EXPECT_NEAR(x_final_true, x_final, xtol);
-      EXPECT_NEAR(v_final_true, v_final, vtol);
-      CheckGeneralStatsValidity(&integrator);
-    }
+    // Integrate for t_final seconds again.
+    integrator.IntegrateWithMultipleStepsToTime(t_final);
+    x_final = xc_final.GetAtIndex(0);
+    v_final = xc_final.GetAtIndex(1);
+
+    // Verify that error control was used by making sure that the minimum step
+    // size was smaller than large_h_.
+    EXPECT_LT(integrator.get_smallest_adapted_step_size_taken(), large_h_);
+
+    // Verify that integrator statistics and outputs are valid.
+    EXPECT_NEAR(x_final_true, x_final, xtol);
+    EXPECT_NEAR(v_final_true, v_final, vtol);
+    CheckGeneralStatsValidity(&integrator);
   }
 
   // Integrate the modified mass-spring-damping system, which exhibits a
@@ -339,61 +343,77 @@ class ImplicitIntegratorTest : public ::testing::Test {
     EXPECT_NEAR(equilibrium_velocity, xdot_final, sol_tol);
     CheckGeneralStatsValidity(&integrator);
 
-    // TODO(antequ): remove this check once the Velocity-Implicit Euler
-    // supports autodiff and central differencing
-    if (integrator_supports_central_and_auto_diff_) {
-      // Switch the Jacobian scheme to central differencing.
-      integrator.set_jacobian_computation_scheme(
-          IntegratorType::JacobianComputationScheme::kCentralDifference);
+    // Switch the Jacobian scheme to central differencing.
+    integrator.set_jacobian_computation_scheme(
+        IntegratorType::JacobianComputationScheme::kCentralDifference);
 
-      // Reset the time, position, and velocity.
-      mod_spring_mass_damper_context_->SetTime(0.0);
-      mod_spring_mass_damper_->set_position(
-          mod_spring_mass_damper_context_.get(), initial_position);
-      mod_spring_mass_damper_->set_velocity(
-          mod_spring_mass_damper_context_.get(), initial_velocity);
+    // Reset the time, position, and velocity.
+    mod_spring_mass_damper_context_->SetTime(0.0);
+    mod_spring_mass_damper_->set_position(
+        mod_spring_mass_damper_context_.get(), initial_position);
+    mod_spring_mass_damper_->set_velocity(
+        mod_spring_mass_damper_context_.get(), initial_velocity);
 
-      // Integrate again.
-      integrator.IntegrateWithMultipleStepsToTime(t_final);
+    // Initialize to reset cached Jacobians. This is necessary; otherwise, for
+    // some problems, the Jacobian may not be computed again because the
+    // previous one was good enough for Newton-Raphson to converge.
+    // TODO(antequ): This issue only exists for velocity-implicit Euler
+    // integrator; other implicit integrators reset their Jacobians in
+    // set_jacobian_computation_scheme(). Clear the velocity-implicit Euler
+    // integrator's Jacobian cache too in set_jacobian_computation_scheme(),
+    // and remove this call. See issue #13069.
+    integrator.Initialize();
 
-      // Check the solution and the time again, and reset the statistics again.
-      x_final = mod_spring_mass_damper_context_->get_continuous_state()
-                    .get_vector()
-                    .GetAtIndex(0);
-      xdot_final = mod_spring_mass_damper_context_->get_continuous_state()
-                       .get_vector()
-                       .GetAtIndex(1);
-      EXPECT_NEAR(mod_spring_mass_damper_context_->get_time(), t_final, ttol);
-      EXPECT_NEAR(equilibrium_position, x_final, sol_tol);
-      EXPECT_NEAR(equilibrium_velocity, xdot_final, sol_tol);
-      CheckGeneralStatsValidity(&integrator);
+    // Integrate again.
+    integrator.IntegrateWithMultipleStepsToTime(t_final);
 
-      // Switch the Jacobian scheme to automatic differentiation.
-      integrator.set_jacobian_computation_scheme(
-          IntegratorType::JacobianComputationScheme::kAutomatic);
+    // Check the solution and the time again, and reset the statistics again.
+    x_final = mod_spring_mass_damper_context_->get_continuous_state()
+                  .get_vector()
+                  .GetAtIndex(0);
+    xdot_final = mod_spring_mass_damper_context_->get_continuous_state()
+                      .get_vector()
+                      .GetAtIndex(1);
+    EXPECT_NEAR(mod_spring_mass_damper_context_->get_time(), t_final, ttol);
+    EXPECT_NEAR(equilibrium_position, x_final, sol_tol);
+    EXPECT_NEAR(equilibrium_velocity, xdot_final, sol_tol);
+    CheckGeneralStatsValidity(&integrator);
 
-      // Reset the time, position, and velocity.
-      mod_spring_mass_damper_context_->SetTime(0.0);
-      mod_spring_mass_damper_->set_position(
-          mod_spring_mass_damper_context_.get(), initial_position);
-      mod_spring_mass_damper_->set_velocity(
-          mod_spring_mass_damper_context_.get(), initial_velocity);
+    // Switch the Jacobian scheme to automatic differentiation.
+    integrator.set_jacobian_computation_scheme(
+        IntegratorType::JacobianComputationScheme::kAutomatic);
 
-      // Integrate again.
-      integrator.IntegrateWithMultipleStepsToTime(t_final);
+    // Reset the time, position, and velocity.
+    mod_spring_mass_damper_context_->SetTime(0.0);
+    mod_spring_mass_damper_->set_position(
+        mod_spring_mass_damper_context_.get(), initial_position);
+    mod_spring_mass_damper_->set_velocity(
+        mod_spring_mass_damper_context_.get(), initial_velocity);
 
-      // Check the solution and the time again.
-      x_final = mod_spring_mass_damper_context_->get_continuous_state()
-                    .get_vector()
-                    .GetAtIndex(0);
-      xdot_final = mod_spring_mass_damper_context_->get_continuous_state()
-                       .get_vector()
-                       .GetAtIndex(1);
-      EXPECT_NEAR(mod_spring_mass_damper_context_->get_time(), t_final, ttol);
-      EXPECT_NEAR(equilibrium_position, x_final, sol_tol);
-      EXPECT_NEAR(equilibrium_velocity, xdot_final, sol_tol);
-      CheckGeneralStatsValidity(&integrator);
-    }
+    // Initialize to reset cached Jacobians. This is necessary; otherwise, for
+    // some problems, the Jacobian may not be computed again because the
+    // previous one was good enough for Newton-Raphson to converge.
+    // TODO(antequ): This issue only exists for velocity-implicit Euler
+    // integrator; other implicit integrators reset their Jacobians in
+    // set_jacobian_computation_scheme(). Clear the velocity-implicit Euler
+    // integrator's Jacobian cache too in set_jacobian_computation_scheme(),
+    // and remove this call. See issue #13069.
+    integrator.Initialize();
+
+    // Integrate again.
+    integrator.IntegrateWithMultipleStepsToTime(t_final);
+
+    // Check the solution and the time again.
+    x_final = mod_spring_mass_damper_context_->get_continuous_state()
+                  .get_vector()
+                  .GetAtIndex(0);
+    xdot_final = mod_spring_mass_damper_context_->get_continuous_state()
+                      .get_vector()
+                      .GetAtIndex(1);
+    EXPECT_NEAR(mod_spring_mass_damper_context_->get_time(), t_final, ttol);
+    EXPECT_NEAR(equilibrium_position, x_final, sol_tol);
+    EXPECT_NEAR(equilibrium_velocity, xdot_final, sol_tol);
+    CheckGeneralStatsValidity(&integrator);
   }
 
   // Integrate an undamped system and check its solution accuracy.
@@ -452,49 +472,66 @@ class ImplicitIntegratorTest : public ::testing::Test {
 
     // Verify that integrator statistics are valid and reset the statistics.
     CheckGeneralStatsValidity(&integrator);
-    // TODO(antequ): remove this check once the Velocity-Implicit Euler
-    // supports autodiff and central differencing
-    if (integrator_supports_central_and_auto_diff_) {
-      // Switch to central differencing.
-      integrator.set_jacobian_computation_scheme(
-          IntegratorType::JacobianComputationScheme::kCentralDifference);
 
-      // Reset the time, position, and velocity.
-      context->SetTime(0.0);
-      spring_mass.set_position(context.get(), initial_position);
-      spring_mass.set_velocity(context.get(), initial_velocity);
+    // Switch to central differencing.
+    integrator.set_jacobian_computation_scheme(
+        IntegratorType::JacobianComputationScheme::kCentralDifference);
 
-      // Integrate for t_final seconds again.
-      integrator.IntegrateWithMultipleStepsToTime(t_final);
+    // Reset the time, position, and velocity.
+    context->SetTime(0.0);
+    spring_mass.set_position(context.get(), initial_position);
+    spring_mass.set_velocity(context.get(), initial_velocity);
 
-      // Check results again.
-      x_final = context->get_continuous_state().get_vector().GetAtIndex(0);
-      EXPECT_NEAR(x_final_true, x_final, 5e-3);
-      EXPECT_NEAR(context->get_time(), t_final, ttol);
+    // Initialize to reset cached Jacobians. This is necessary; otherwise, for
+    // some problems, the Jacobian may not be computed again because the
+    // previous one was good enough for Newton-Raphson to converge.
+    // TODO(antequ): This issue only exists for velocity-implicit Euler
+    // integrator; other implicit integrators reset their Jacobians in
+    // set_jacobian_computation_scheme(). Clear the velocity-implicit Euler
+    // integrator's Jacobian cache too in set_jacobian_computation_scheme(),
+    // and remove this call. See issue #13069.
+    integrator.Initialize();
 
-      // Verify that integrator statistics are valid and reset the statistics.
-      CheckGeneralStatsValidity(&integrator);
+    // Integrate for t_final seconds again.
+    integrator.IntegrateWithMultipleStepsToTime(t_final);
 
-      // Switch to automatic differentiation.
-      integrator.set_jacobian_computation_scheme(
-          IntegratorType::JacobianComputationScheme::kAutomatic);
+    // Check results again.
+    x_final = context->get_continuous_state().get_vector().GetAtIndex(0);
+    EXPECT_NEAR(x_final_true, x_final, 5e-3);
+    EXPECT_NEAR(context->get_time(), t_final, ttol);
 
-      // Reset the time, position, and velocity.
-      context->SetTime(0.0);
-      spring_mass.set_position(context.get(), initial_position);
-      spring_mass.set_velocity(context.get(), initial_velocity);
+    // Verify that integrator statistics are valid and reset the statistics.
+    CheckGeneralStatsValidity(&integrator);
 
-      // Integrate for t_final seconds again.
-      integrator.IntegrateWithMultipleStepsToTime(t_final);
+    // Switch to automatic differentiation.
+    integrator.set_jacobian_computation_scheme(
+        IntegratorType::JacobianComputationScheme::kAutomatic);
 
-      // Check results again.
-      x_final = context->get_continuous_state().get_vector().GetAtIndex(0);
-      EXPECT_NEAR(x_final_true, x_final, 5e-3);
-      EXPECT_NEAR(context->get_time(), t_final, ttol);
+    // Reset the time, position, and velocity.
+    context->SetTime(0.0);
+    spring_mass.set_position(context.get(), initial_position);
+    spring_mass.set_velocity(context.get(), initial_velocity);
 
-      // Verify that integrator statistics are valid
-      CheckGeneralStatsValidity(&integrator);
-    }
+    // Initialize to reset cached Jacobians. This is necessary; otherwise, for
+    // some problems, the Jacobian may not be computed again because the
+    // previous one was good enough for Newton-Raphson to converge.
+    // TODO(antequ): This issue only exists for velocity-implicit Euler
+    // integrator; other implicit integrators reset their Jacobians in
+    // set_jacobian_computation_scheme(). Clear the velocity-implicit Euler
+    // integrator's Jacobian cache too in set_jacobian_computation_scheme(),
+    // and remove this call. See issue #13069.
+    integrator.Initialize();
+
+    // Integrate for t_final seconds again.
+    integrator.IntegrateWithMultipleStepsToTime(t_final);
+
+    // Check results again.
+    x_final = context->get_continuous_state().get_vector().GetAtIndex(0);
+    EXPECT_NEAR(x_final_true, x_final, 5e-3);
+    EXPECT_NEAR(context->get_time(), t_final, ttol);
+
+    // Verify that integrator statistics are valid
+    CheckGeneralStatsValidity(&integrator);
   }
 
   // Checks the error estimator for the implicit Euler integrator using the
@@ -522,13 +559,9 @@ class ImplicitIntegratorTest : public ::testing::Test {
     integrator.set_fixed_step_mode(true);
     integrator.set_reuse(reuse_type_to_bool(type));
 
-    // TODO(antequ): remove this check once the Velocity-Implicit Euler
-    // supports autodiff and central differencing
-    if (integrator_supports_central_and_auto_diff_) {
-      // Use automatic differentiation because we can.
-      integrator.set_jacobian_computation_scheme(
-          IntegratorType::JacobianComputationScheme::kAutomatic);
-    }
+    // Use automatic differentiation because we can.
+    integrator.set_jacobian_computation_scheme(
+        IntegratorType::JacobianComputationScheme::kAutomatic);
 
     // Create the initial positions and velocities.
     const int n_initial_conditions = 3;
@@ -756,8 +789,6 @@ class ImplicitIntegratorTest : public ::testing::Test {
   // stiff_damping_b / (2*sqrt(mass*stiff_spring_k)) = 353, meaning
   // that the system is overdamped.
   const double stiff_damping_b_ = 1e8;
-
-  bool integrator_supports_central_and_auto_diff_ = true;
 };
 TYPED_TEST_SUITE_P(ImplicitIntegratorTest);
 

--- a/systems/analysis/test_utilities/spring_mass_damper_system.h
+++ b/systems/analysis/test_utilities/spring_mass_damper_system.h
@@ -131,6 +131,9 @@ class SpringMassDamperSystem : public SpringMassSystem<T> {
 
     // Second element of the derivative is spring acceleration.
     (*derivatives)[1] = force / this->get_mass();
+
+    // Third element of the derivative is the energy added into the spring.
+    (*derivatives)[2] = this->CalcConservativePower(context);
   }
 
  private:

--- a/systems/analysis/velocity_implicit_euler_integrator.cc
+++ b/systems/analysis/velocity_implicit_euler_integrator.cc
@@ -144,6 +144,8 @@ void VelocityImplicitEulerIntegrator<T>::ComputeAutoDiffVelocityJacobian(
       "{}-Jacobian t={}", y.size(), t);
   DRAKE_LOGGER_DEBUG("  computing from qk {}, y {}", qk.transpose(),
                      y.transpose());
+  // TODO(antequ): Investigate how to refactor this method to use
+  // math::jacobian(), if possible.
 
   // Get the system and the context in AutoDiffable format. Inputs must also
   // be copied to the context used by the AutoDiff'd system (which is
@@ -175,10 +177,10 @@ void VelocityImplicitEulerIntegrator<T>::ComputeAutoDiffVelocityJacobian(
 
   *Jy = math::autoDiffToGradientMatrix(result);
 
-  // Sometimes ℓ(y) does not depend on y. In this case, make sure that the
-  // Jacobian isn't a n ✕ 0 matrix (this will cause a segfault when forming
-  // Newton iteration matrices); if it is, we set it equal to an n x n zero
-  // matrix.
+  // Sometimes ℓ(y) does not depend on, for example, when ℓ(y) is a constant or
+  // when ℓ(y) depends only on t. In this case, make sure that the Jacobian
+  // isn't a n ✕ 0 matrix (this will cause a segfault when forming Newton
+  // iteration matrices); if it is, we set it equal to an n x n zero matrix.
   if (Jy->cols() == 0) {
     *Jy = MatrixX<T>::Zero(ny, ny);
   }

--- a/systems/analysis/velocity_implicit_euler_integrator.h
+++ b/systems/analysis/velocity_implicit_euler_integrator.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <stdexcept>
 
+#include "drake/common/autodiff.h"
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/systems/analysis/implicit_integrator.h"
@@ -57,19 +58,19 @@ namespace systems {
  * To find a `(qₖ₊₁,yₖ₊₁)` that approximately satisfies (5-6), we linearize
  * the system (5-6) to compute a Newton step. Define
  *
- *     l(y) = f_y(tⁿ⁺¹,qⁿ + h N(qₖ) v,y),            (7)
- *     Jₗ(y) = ∂l(y) / ∂y.                           (8)
+ *     ℓ(y) = f_y(tⁿ⁺¹,qⁿ + h N(qₖ) v,y),            (7)
+ *     Jₗ(y) = ∂ℓ(y) / ∂y.                           (8)
  *
  * To advance the Newton step, the velocity-implicit Euler integrator solves
  * the following linear equation for `Δy`:
  *
  *     (I - h Jₗ) Δy = - R(yₖ),                      (9)
- * where `R(y) = y - yⁿ - h l(y)` and `Δy = yₖ₊₁ - yₖ`. The `Δy` solution
+ * where `R(y) = y - yⁿ - h ℓ(y)` and `Δy = yₖ₊₁ - yₖ`. The `Δy` solution
  * directly gives us `yₖ₊₁`. It then substitutes the `vₖ₊₁` component of `yₖ₊₁`
  * in (5) to get `qₖ₊₁`.
  *
  * This implementation uses a Newton method and relies upon the convergence
- * to a solution for `y` in `R(y) = 0` where `R(y) = y - yⁿ - h l(y)`
+ * to a solution for `y` in `R(y) = 0` where `R(y) = y - yⁿ - h ℓ(y)`
  * as `h` becomes sufficiently small. General implementational details for
  * the Newton method were gleaned from Section IV.8 in [Hairer, 1996].
  *
@@ -399,30 +400,54 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
 
   // Compute the partial derivatives of the ordinary differential equations with
   // respect to the y variables of a given x(t). In particular, we compute the
-  // Jacobian, Jₗ(y), of the function l(y), used in this integrator's
+  // Jacobian, Jₗ(y), of the function ℓ(y), used in this integrator's
   // residual computation, with respect to y, where y = (v,z) and x = (q,v,z).
   // This Jacobian is then defined as:
-  //     l(y)  = f_y(tⁿ⁺¹, qⁿ + h N(qₖ) v, y)          (7)
-  //     Jₗ(y) = ∂l(y)/∂y                              (8)
+  //     ℓ(y)  = f_y(tⁿ⁺¹, qⁿ + h N(qₖ) v, y)          (7)
+  //     Jₗ(y) = ∂ℓ(y)/∂y                              (8)
   // We use the Jacobian computation scheme from
   // get_jacobian_computation_scheme(), which is either a first-order forward
   // difference, a second-order centered difference, or automatic
   // differentiation. See math::ComputeNumericalGradient() for more details on
   // the first two methods.
-  // @param t refers to tⁿ⁺¹, the time used in the definition of l(y)
+  // @param t refers to tⁿ⁺¹, the time used in the definition of ℓ(y)
   // @param h is the timestep size parameter, h, used in the definition of
-  //        l(y)
+  //        ℓ(y)
   // @param y is the generalized velocity and miscellaneous states around which
   //        to evaluate Jₗ(y).
   // @param qk is qₖ, the current-iteration position used in the definition of
-  //        l(y).
-  // @param qn refers to qⁿ, the initial position used in l(y)
+  //        ℓ(y).
+  // @param qn refers to qⁿ, the initial position used in ℓ(y)
   // @param [out] Jy is the Jacobian matrix, Jₗ(y).
   // @post The context's time will be set to t, and its continuous state will
   //       be indeterminate on return.
   void CalcVelocityJacobian(const T& t, const T& h, const VectorX<T>& y,
                             const VectorX<T>& qk, const VectorX<T>& qn,
                             MatrixX<T>* Jy);
+
+  // Uses automatic differentiation to compute the Jacobian, Jₗ(y), of the
+  // function ℓ(y), used in this integrator's residual computation, with
+  // respect to y, where y = (v,z). This Jacobian is then defined as:
+  //     ℓ(y)  = f_y(tⁿ⁺¹, qⁿ + h N(qₖ) v, y)   (7)
+  //     Jₗ(y) = ∂ℓ(y)/∂y                       (8)
+  // In this method, we compute the Jacobian Jₗ(y) using automatic
+  // differentiation.
+  // @param t refers to tⁿ⁺¹, the time used in the definition of ℓ(y).
+  // @param h is the timestep size parameter, h, used in the definition of
+  //        ℓ(y).
+  // @param y is the generalized velocity and miscellaneous states around which
+  //        to evaluate Jₗ(y).
+  // @param qk is qₖ, the current-iteration position used in the definition of
+  //        ℓ(y).
+  // @param qn refers to qⁿ, the initial position used in ℓ(y).
+  // @param [out] Jy is the Jacobian matrix, Jₗ(y).
+  // @note The context's time will be set to t, and its continuous state will
+  //       be indeterminate on return.
+  void ComputeAutoDiffVelocityJacobian(const T& t, const T& h,
+                                       const VectorX<T>& y,
+                                       const VectorX<T>& qk,
+                                       const VectorX<T>& qn,
+                                       MatrixX<T>* Jy);
 
   // Computes necessary matrices (Jacobian and iteration matrix) for
   // Newton-Raphson (NR) iterations, as necessary. This method is based off of
@@ -454,7 +479,7 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   // @param y is the generalized velocity and miscellaneous states around which
   //        to evaluate Jₗ(y).
   // @param qk is qₖ, the current-iteration position used in the definition of
-  //        l(y), which is used in the definition of Jₗ(y).
+  //        ℓ(y), which is used in the definition of Jₗ(y).
   // @param qn is the generalized position at the beginning of the step.
   // @param h is the integration step size.
   // @param trial specifies which trial (1-4) the Newton-Raphson process is in
@@ -488,7 +513,7 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   // @param y is the generalized velocity and miscellaneous states around which
   //        to evaluate Jₗ(y).
   // @param qk is qₖ, the current-iteration position used in the definition of
-  //        l(y), which is used in the definition of Jₗ(y).
+  //        ℓ(y), which is used in the definition of Jₗ(y).
   // @param qn is qⁿ, the generalized position at the beginning of the step.
   // @param h the integration step size (for computing iteration matrices).
   // @param compute_and_factor_iteration_matrix a function pointer for
@@ -511,14 +536,14 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
 
   // This helper method evaluates the Newton-Raphson residual R(y), defined as
   // the following:
-  //     R(y)  = y - yⁿ - h l(y),
-  //     l(y) = f_y(tⁿ⁺¹, qⁿ + h N(qₖ) v, y),          (7)
+  //     R(y)  = y - yⁿ - h ℓ(y),
+  //     ℓ(y) = f_y(tⁿ⁺¹, qⁿ + h N(qₖ) v, y),          (7)
   // with tⁿ⁺¹, y = (v, z), qₖ, qⁿ, yⁿ, and h passed in.
   // @param t refers to tⁿ⁺¹, the time at which to compute the residual R(y).
   // @param y is the generalized velocity and miscellaneous states around which
   //        to evaluate R(y).
   // @param qk is qₖ, the current-iteration position used in the definition of
-  //        l(y).
+  //        ℓ(y).
   // @param qn is qⁿ, the generalized position at the beginning of the step.
   // @param yn is yⁿ, the generalized velocity and miscellaneous states at the
   //        beginning of the step
@@ -533,24 +558,59 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
                               const VectorX<T>& yn, const T& h,
                               BasicVector<T>* qdot);
 
-  // This helper method evaluates l(y), defined as the following:
-  //     l(y) = f_y(tⁿ⁺¹, qⁿ + h N(qₖ) v, y),          (7)
+  // This helper method evaluates ℓ(y), defined as the following:
+  //     ℓ(y) = f_y(tⁿ⁺¹, qⁿ + h N(qₖ) v, y),          (7)
   // with tⁿ⁺¹, y = (v, z), qₖ, qⁿ, yⁿ, and h passed in.
   // @param t refers to tⁿ⁺¹, the time at which to compute the residual R(y).
   // @param y is the generalized velocity and miscellaneous states around which
-  //        to evaluate l(y).
+  //        to evaluate ℓ(y).
   // @param qk is qₖ, the current-iteration position used in the definition of
-  //        l(y).
+  //        ℓ(y).
   // @param qn is qⁿ, the generalized position at the beginning of the step.
   // @param h is the step size.
   // @param [in, out] qdot is a temporary BasicVector<T> of the same size as qⁿ
   //        allocated by the caller so that this method avoids unnecessary heap
   //        allocations. Its value is indeterminate upon return.
-  // @param [out] result is set to l(y).
+  // @param [out] result is set to ℓ(y).
   // @post The context is set to (tⁿ⁺¹, qⁿ + h N(qₖ) v, y).
   VectorX<T> ComputeLOfY(const T& t, const VectorX<T>& y, const VectorX<T>& qk,
                          const VectorX<T>& qn, const T& h,
-                         BasicVector<T>* qdot);
+                         BasicVector<T>* qdot) {
+    return this->ComputeLOfY(t, y, qk, qn, h, qdot, this->get_system(),
+        this->get_mutable_context());
+  }
+
+  // This helper method evaluates ℓ(y), defined as the following:
+  //     ℓ(y) = f_y(tⁿ⁺¹, qⁿ + h N(qₖ) v, y),    (7)
+  // with tⁿ⁺¹, y = (v, z), qₖ, qⁿ, yⁿ, and h passed in, for a system that can
+  // use scalar type U, which is either a double or an AutoDiffXd scalar type.
+  // If type U is different from T, then y, qdot, and context must also use
+  // the U scalar type. This version of the method exists to allow the
+  // VelocityImplicitEulerIntegrator to include AutoDiff'd systems in ℓ(y)
+  // evaluations, which is necessary when computing an AutoDiff'd velocity
+  // Jacobian; in particular, this version is explicitly called with type
+  // U=AutoDiffXd in ComputeAutoDiffVelocityJacobian().
+  // @param t refers to tⁿ⁺¹, the time at which to compute the residual R(y).
+  // @param y is the generalized velocity and miscellaneous states around which
+  //        to evaluate ℓ(y); it uses the scalar type U.
+  // @param qk is qₖ, the current-iteration position used in the definition of
+  //        ℓ(y).
+  // @param qn is qⁿ, the generalized position at the beginning of the step.
+  // @param h is the step size.
+  // @param [in, out] qdot is a temporary BasicVector<U> of the same size as qⁿ
+  //        allocated by the caller so that this method avoids unnecessary heap
+  //        allocations. Its value is indeterminate upon return.
+  // @param [in] system defines f_y() so that we can evaluate f_y() with the
+  //        U scalar type.
+  // @param [in, out] context to pass in the time and continuous states when
+  //        evaluating f_y(); its scalar type must also be U.
+  // @param [out] result is set to ℓ(y).
+  // @post context is set to (tⁿ⁺¹, qⁿ + h N(qₖ) v, y).
+  template <typename U>
+  VectorX<U> ComputeLOfY(const T& t, const VectorX<U>& y, const VectorX<T>& qk,
+                         const VectorX<T>& qn, const T& h,
+                         BasicVector<U>* qdot, const System<U>& system,
+                         Context<U>* context);
 
   // The last computed iteration matrix and factorization.
   typename ImplicitIntegrator<T>::IterationMatrix iteration_matrix_vie_;
@@ -565,7 +625,12 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
 
   // Variables to avoid heap allocations.
   VectorX<T> xn_, xdot_, xtplus_vie_, xtplus_hvie_;
-  std::unique_ptr<BasicVector<T>> qdot_{nullptr};
+  std::unique_ptr<BasicVector<T>> qdot_;
+  // The following will help avoid repeated heap allocations when computing a
+  // velocity Jacobian using automatic differentiation.
+  std::unique_ptr<System<AutoDiffXd>>      system_ad_;
+  std::unique_ptr<Context<AutoDiffXd>>     context_ad_;
+  std::unique_ptr<BasicVector<AutoDiffXd>> qdot_ad_;
 
   // The last computed velocity+misc Jacobian matrix.
   MatrixX<T> Jy_vie_;
@@ -581,6 +646,21 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   int64_t num_half_vie_jacobian_function_evaluations_{0};
   int64_t num_half_vie_nr_iterations_{0};
 };
+
+// We do not support computing the Velocity Jacobian matrix using automatic
+// differentiation when the scalar is already an AutoDiff type.
+// Note: must be declared inline because it's specialized and located in the
+// header file (to avoid multiple definition errors).
+template <>
+inline void VelocityImplicitEulerIntegrator<AutoDiffXd>::
+    ComputeAutoDiffVelocityJacobian(const AutoDiffXd&, const AutoDiffXd&,
+                                    const VectorX<AutoDiffXd>&,
+                                    const VectorX<AutoDiffXd>&,
+                                    const VectorX<AutoDiffXd>&,
+                                    MatrixX<AutoDiffXd>*) {
+  throw std::runtime_error("AutoDiff'd Jacobian not supported for "
+                           "AutoDiff'd VelocityImplicitEulerIntegrator");
+}
 
 }  // namespace systems
 }  // namespace drake


### PR DESCRIPTION
Add Automatic Differentiated Jacobians to Velocity-Implicit Euler Integrator, fourth PR of #12528

This commit:
1. Adds automatic differentiation as a velocity-Jacobian computation scheme for the velocity-implicit Euler integrator, by following the model of ImplicitIntegrator<T>::ComputeAutoDiffJacobian().
2. Refactors ComputeLOfY() based on the templated <U> IntegratorBase<T>::EvalTimeDerivatives() to enable this computation.
3. Fixes the tests so that they reset integrators between testing the different Jacobian computation schemes, to force Jacobian recomputations.
4. Removes the boolean flags that skip tests that require AutoDiff'd Jacobians.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12967)
<!-- Reviewable:end -->
