### PR TITLE
Revert "visualizer: add ConnectPlanarSceneGraphVisualizer"

### DIFF
--- a/bindings/pydrake/systems/planar_scenegraph_visualizer.py
+++ b/bindings/pydrake/systems/planar_scenegraph_visualizer.py
@@ -110,7 +110,7 @@ class PlanarSceneGraphVisualizer(PyPlotVisualizer):
 
         PyPlotVisualizer.__init__(self, facecolor=facecolor, figsize=figsize,
                                   ax=ax, draw_period=draw_period, show=show)
-        self.set_name('planar_scenegraph_visualizer')
+        self.set_name('planar_multibody_visualizer')
 
         self._scene_graph = scene_graph
         self._T_VW = T_VW
@@ -363,37 +363,3 @@ class PlanarSceneGraphVisualizer(PyPlotVisualizer):
                 self._update_body_fill_verts(body_fill, patch_V)
                 body_fill.zorder = X_WB.translation() @ view_dir
         self.ax.set_title('t = {:.1f}'.format(context.get_time()))
-
-
-def ConnectPlanarSceneGraphVisualizer(builder,
-                                      scene_graph,
-                                      output_port=None,
-                                      **kwargs):
-    """Creates an instance of PlanarSceneGraphVisualizer, adds it to the
-    diagram, and wires the scene_graph pose bundle output port to the input
-    port of the visualizer.  Provides a comparable interface to
-    ConnectDrakeVisualizer.
-
-    Args:
-        builder: The diagram builder used to construct the Diagram.
-        scene_graph: The SceneGraph in builder containing the geometry to be
-            visualized.
-        output_port: (optional) If not None, then output_port will be connected
-            to the visualizer input port instead of the scene_graph.
-            get_pose_bundle_output_port().  This is required, for instance,
-            when the SceneGraph is inside a Diagram, and we must connect the
-            exposed port to the visualizer instead of the original SceneGraph
-            port.
-
-        Additional kwargs are passed through to the PlanarSceneGraphVisualizer
-        constructor.
-
-    Returns:
-        The newly created PlanarSceneGraphVisualizer object.
-    """
-    if output_port is None:
-        output_port = scene_graph.get_pose_bundle_output_port()
-    visualizer = builder.AddSystem(
-        PlanarSceneGraphVisualizer(scene_graph, **kwargs))
-    builder.Connect(output_port, visualizer.get_input_port(0))
-    return visualizer

--- a/bindings/pydrake/systems/test/planar_scenegraph_visualizer_test.py
+++ b/bindings/pydrake/systems/test/planar_scenegraph_visualizer_test.py
@@ -13,7 +13,7 @@ from pydrake.multibody.tree import SpatialInertia, UnitInertia
 from pydrake.systems.analysis import Simulator
 from pydrake.systems.framework import DiagramBuilder
 from pydrake.systems.planar_scenegraph_visualizer import (
-   ConnectPlanarSceneGraphVisualizer, PlanarSceneGraphVisualizer)
+    PlanarSceneGraphVisualizer)
 
 
 class TestPlanarSceneGraphVisualizer(unittest.TestCase):
@@ -184,29 +184,3 @@ class TestPlanarSceneGraphVisualizer(unittest.TestCase):
         scene_graph = scene_graph_with_mesh("garbage.STL")
         with self.assertRaises(RuntimeError):
             PlanarSceneGraphVisualizer(scene_graph)
-
-    def testConnectPlanarSceneGraphVisualizer(self):
-        """Cart-Pole with simple geometry."""
-        file_name = FindResourceOrThrow(
-            "drake/examples/multibody/cart_pole/cart_pole.sdf")
-        builder = DiagramBuilder()
-        cart_pole, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.0)
-        Parser(plant=cart_pole).AddModelFromFile(file_name)
-        cart_pole.Finalize()
-
-        visualizer = ConnectPlanarSceneGraphVisualizer(
-            builder=builder, scene_graph=scene_graph, xlim=[23, 1.2])
-        self.assertIsInstance(visualizer, PlanarSceneGraphVisualizer)
-        # Confirm that arguments are passed through.
-        self.assertEqual(visualizer.ax.get_xlim(), (23, 1.2))
-
-        vis2 = ConnectPlanarSceneGraphVisualizer(
-            builder=builder,
-            scene_graph=scene_graph,
-            output_port=scene_graph.get_pose_bundle_output_port())
-        vis2.set_name("vis2")
-        self.assertIsInstance(vis2, PlanarSceneGraphVisualizer)
-
-        diagram = builder.Build()
-        context = diagram.CreateDefaultContext()
-        diagram.Publish(context)


### PR DESCRIPTION
The on-call build cop, @BetsyMcPhail , believes that your PR #12961  may have
broken one or more of Drake's continuous integration builds [1]. It is
possible to break a build even if your PR passed continuous integration
pre-merge because additional platforms are tested post-merge.

The specific build failures under investigation are:
https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-catalina-unprovisioned-clang-bazel-nightly-release/112/
https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-mojave-unprovisioned-clang-bazel-nightly-release/261/

Therefore, the build cop has created this revert PR and started a complete
post-merge build to determine whether your PR was in fact the cause of the
problem. If that build passes, this revert PR will be merged 60 minutes from
now. You can then fix the problem at your leisure, and send a new PR to
reinstate your change.

If you believe your original PR did not actually break the build, please
explain on this thread.

If you believe you can fix the break promptly in lieu of a revert, please
explain on this thread, and send a PR to the build cop for review ASAP.

If you believe your original PR definitely did break the build and should be
reverted, please review and LGTM this PR. This allows the build cop to merge
without waiting for CI results.

For advice on how to handle a build cop revert, see [2].

Thanks!
Your Friendly On-call Build Cop

[1] CI Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Production/
[2] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12969)
<!-- Reviewable:end -->
