### PR TITLE
[geometry] Adding soft half space into contact query

### DIFF
--- a/examples/multibody/rolling_sphere/README.md
+++ b/examples/multibody/rolling_sphere/README.md
@@ -1,10 +1,10 @@
-#Rolling Sphere Example
+# Rolling Sphere Example
 
 This directory contains an example for illustrating the difference between
 contact models. It consists of a rolling sphere on a horizontal ground surface.
 
 ```
-                                <─── wy
+                                <─── ωy
                                 ooooooo
                               o         o
                              o     vx    o
@@ -18,9 +18,14 @@ contact models. It consists of a rolling sphere on a horizontal ground surface.
 __Figure 1, Default configuration:__ The example creates a sphere with initial
 translational velocity in the +Wx direction and an angular velocity around the
 -Wy axis (illustrated by the two vectors labeled with the application's
-corresponding parameters vx and wy, respectively). The ball will begin sliding
+corresponding parameters vx and ωy, respectively). The ball will begin sliding
 in the +Wx direction but eventually friction will cause the ball to slow and
 then accelerate in the -Wx direction.
+
+Both the ground and the sphere can be modeled with soft or rigid compliance
+in the hydroelastic model. However, choice of compliance type (more particularly
+contact between objects of particular compliance) will constrain your choice
+of contact model. See details below.
 
 __Contact models__
 
@@ -28,40 +33,49 @@ There are three contact models that can be exercised (via the `--contact_model`
 parameter). They differ in how they model the contact between two penetrating
 objects:
 
-  - "point": modeled as a point pair.
-  - "hydroelastic": _possibly_ modeled as a contact surface.
+  - "point": modeled as a point pair. The compliance type of the objects do
+    not matter; contact will always be reported and resolved.
+  - "hydroelastic": modeled as a contact surface (where supported). If contact
+    between a pair of objects is detected, but hydroelastic cannot evaluate a
+    contact surface between them, the simulation will throw. See below for
+    circumstances under which a contact surface cannot be computed.
   - "hybrid": modeled as a contact surface where possible, and as a point.
     pair otherwise. More formally known as "hydroelastic callback with
     fallback".
 
-The "hydroelastic" model doesn't have full support yet. There are some types
-of geometries that cannot yet be given a hydroelastic representation and some
-types of contact which aren't modeled yet. For example:
-  - Drake `HalfSpace` and `Mesh` shapes can only be modeled with _rigid_
-    hydroleastic representation
+The "hydroelastic" model doesn't support all combinations of geometries and
+compliance types. There are some types of geometries that cannot yet be given a
+hydroelastic representation and some types of contact which aren't modeled yet.
+
+  - Contact between a rigid shape and soft shape is supported.
   - Contact between two rigid or two soft objects isn't supported.
+  - Drake `Mesh` shapes can only be modeled with _rigid_ hydroleastic
+    representation
 
 __Changing the configuration__
 
 This example allows you to experiment with the contact models by changing the
 configuration in various ways:
-  - Add in an optional wall (as shown below). When using "hybrid" or
+
+  - Add in an optional soft wall (as shown below). When using "hybrid" or
     "hydroelastic" contact models, the wall will have a _soft_ hydroelastic
     representation.
   - Change the compliance type of the sphere from soft (default) to rigid for
+    the "hybrid" and "hydroelastic" models.
+  - Change the compliance type of the ground from rigid (default) to soft for
     the "hybrid" and "hydroelastic" models.
 
 ```
      ▒▒▒▒▒
      ▒▒▒▒▒
      ▒▒▒▒▒
-  w  ▒▒▒▒▒
-  a  ▒▒▒▒▒                       <─── wy
-  l  ▒▒▒▒▒                       ooooooo
-  l  ▒▒▒▒▒                     o         o
-     ▒▒▒▒▒                    o     vx    o
-     ▒▒▒▒▒                    o     ──>   o
-     ▒▒▒▒▒                    o           o
+  w  ▒▒▒▒▒                                                Wz
+  a  ▒▒▒▒▒                       <─── ωy
+  l  ▒▒▒▒▒                       ooooooo                  │   Wy
+  l  ▒▒▒▒▒                     o         o                │  ╱
+     ▒▒▒▒▒                    o     vx    o               │ ╱
+     ▒▒▒▒▒                    o     ──>   o               │╱
+     ▒▒▒▒▒                    o           o               └───────  Wx
      ▒▒▒▒▒                     o         o
      ▒▒▒▒▒                       ooooooo
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -70,24 +84,23 @@ configuration in various ways:
 __Figure 2, Adding the wall__: by adding the wall, the ball will initially
 behave as described in __Figure 1__ but eventually hit the wall.
 
-
 The following table enumerates some configuration options and the simulation
-outcome. Default values are indicated as "(d)". (Note: the ground is _always_
-rigid for the "hydroelastic" and "hybrid" contact models.)
+outcome. Default values are indicated as "(d)".
 
-|  Wall  |  Sphere  | Contact Model | Note |
-| ------ | -------- | ------------- | ------- |
-| no (d) | soft (d) |   point (d)   | Behavior as described in Figure 1 - point pairs visualized |
-| no (d) | soft (d) | hydroelastic  | Behavior as described in Figure 1 - contact surfaces visualized |
-| no (d) | soft (d) |    hybrid     | Same as "hydroelastic" |
-| no (d) |  rigid   |   point (d)   | Behavior as described in Figure 1 - the sphere's rigid declaration is meaningless for point contact and ignored |
-| no (d) |  rigid   | hydroelastic  | Throws _immediate_ exception -- cannot support rigid-rigid contact surface between ground and sphere |
-| no (d) |  rigid   |    hybrid     | Behavior as described in Figure 1 - rigid-rigid contact (between sphere and ground) uses point-pair contact |
-|  yes   | soft (d) |   point (d)   | Behavior as described in Figure 2 - point pairs visualized |
-|  yes   | soft (d) | hydroelastic  | Behavior as described in Figure 2 - Throws exception when sphere hits wall; cannot support soft-soft contact |
-|  yes   | soft (d) |    hybrid     | Behavior as described in Figure 2 - sphere-ground contact is contact surface, sphere-wall contact is point pair |
-|  yes   |  rigid   |    hybrid     | Behavior as described in Figure 2 - sphere-ground contact is point pair, sphere-wall contact is contact surface |
-
+|  Ground   |  Soft Wall  |  Sphere  | Contact Model | Note |
+| --------- | ----------- | -------- | ------------- | ---------------------------------- |
+| rigid (d) |    no (d)   | soft (d) |   point (d)   | Behavior as described in Figure 1 - point pairs visualized |
+| rigid (d) |    no (d)   | soft (d) | hydroelastic  | Behavior as described in Figure 1 - contact surfaces visualized |
+| rigid (d) |    no (d)   | soft (d) |    hybrid     | Same as "hydroelastic" |
+| rigid (d) |    no (d)   |  rigid   |   point (d)   | Behavior as described in Figure 1 - the sphere's rigid declaration is meaningless for point contact and ignored |
+| rigid (d) |    no (d)   |  rigid   | hydroelastic  | Throws _immediate_ exception -- cannot support rigid-rigid contact surface between ground and sphere |
+| rigid (d) |    no (d)   |  rigid   |    hybrid     | Behavior as described in Figure 1 - rigid-rigid contact (between sphere and ground) uses point-pair contact |
+| rigid (d) |     yes     | soft (d) |   point (d)   | Behavior as described in Figure 2 - point pairs visualized |
+| rigid (d) |     yes     | soft (d) | hydroelastic  | Behavior as described in Figure 2 - Throws exception when sphere hits wall; cannot support soft-soft contact |
+| rigid (d) |     yes     | soft (d) |    hybrid     | Behavior as described in Figure 2 - sphere-ground contact is contact surface, sphere-wall contact is point pair |
+| rigid (d) |     yes     |  rigid   |    hybrid     | Behavior as described in Figure 2 - sphere-ground contact is point pair, sphere-wall contact is contact surface |
+|   soft    |   either    | soft (d) | point/hybrid  | Soft-soft contact requires "hybrid" or "point" -- crashes with "hydroelastic" |  
+|   soft    |   either    |  rigid   |     any       | Behavior as described in Figure 2 - contact visualized depends on model |  
 
 ## Prerequisites
 
@@ -125,9 +138,14 @@ can make.
 bazel-bin/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics
 ```
 
-##### Default behavior with hydroelastic contact
+##### Default behavior with hydroelastic contact with default compliance; rigid ground, soft ball
 ```
 bazel-bin/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics --contact_model=hydroelastic
+```
+
+##### Default behavior with hydroelastic contact with reversed compliance; soft ground, rigid ball
+```
+bazel-bin/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics --contact_model=hydroelastic --rigid_ball=1 --soft_ground=1
 ```
 
 ##### Default behavior with hybrid contact

--- a/examples/multibody/rolling_sphere/make_rolling_sphere_plant.h
+++ b/examples/multibody/rolling_sphere/make_rolling_sphere_plant.h
@@ -15,6 +15,13 @@ namespace bouncing_ball {
 /// inelastic collision (zero coefficient of restitution), i.e. energy is lost
 /// due to the collision.
 ///
+/// The hydroelastic compliance type of the ground and ball can be independently
+/// configured. Not every compliance configuration is compatible with every
+/// contact model; contact between strict hydroelastic contact will fail for
+/// two contacting objects with the same compliance type. So, it is important to
+/// use the resulting plant with a contact model consistent with the
+/// configuration of the ball and ground.
+///
 /// @param[in] radius
 ///   The radius of the ball.
 /// @param[in] mass
@@ -32,9 +39,11 @@ namespace bouncing_ball {
 /// @param[in] gravity_W
 ///   The acceleration of gravity vector, expressed in the world frame W.
 /// @param[in] rigid_sphere
-///   If `true`, the sphere will have a _rigid_ hydroelastic representation;
-///   strict hydroelastic contact against the rigid ground will _not_ work. Use
-///   either point or hybrid contact models.
+///   If `true`, the sphere will have a _rigid_ hydroelastic representation
+///   (soft otherwise).
+/// @param[in] soft_ground
+///   If 'true', the ground will have a _soft_ hydroelastic representation
+///   (rigid otherwise).
 /// @param scene_graph
 ///   If a SceneGraph is provided with this argument, this factory method
 ///   will register the new multibody plant to be a source for that geometry
@@ -47,7 +56,7 @@ MakeBouncingBallPlant(
     double radius, double mass,
     double elastic_modulus, double dissipation,
     const drake::multibody::CoulombFriction<double>& surface_friction,
-    const Vector3<double>& gravity_W, bool rigid_sphere,
+    const Vector3<double>& gravity_W, bool rigid_sphere, bool soft_ground,
     geometry::SceneGraph<double>* scene_graph = nullptr);
 
 }  // namespace bouncing_ball

--- a/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
+++ b/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
@@ -45,14 +45,17 @@ DEFINE_double(dissipation, 5.0,
 DEFINE_double(friction_coefficient, 0.3, "friction coefficient.");
 DEFINE_bool(rigid_ball, false,
             "If true, the ball is given a rigid hydroelastic representation "
-            "(instead of the default soft value). Making the ball rigid will"
-            "cause the 'hydroelastic' model to fail, you'll need either 'point'"
-            " or 'hybrid'.");
+            "(instead of the default soft value). Make sure you have the right "
+            "contact model to support this representation.");
+DEFINE_bool(soft_ground, false,
+            "If true, the ground is given a soft hydroelastic representation "
+            "(instead of the default rigid value). Make sure you have the "
+            "right contact model to support this representation.");
 DEFINE_bool(add_wall, false,
             "If true, adds a wall with soft hydroelastic representation in the "
             "path of the default ball trajectory. This will cause the "
-            "simulation to throw when the ball hits the wall with the "
-            "'hydroleastic' model; use the 'hybrid' or 'point' contact model "
+            "simulation to throw when the soft ball hits the wall with the "
+            "'hydroelastic' model; use the 'hybrid' or 'point' contact model "
             "to simulate beyond this contact.");
 
 // Sphere's spatial velocity.
@@ -119,7 +122,8 @@ int do_main() {
 
   MultibodyPlant<double>& plant = *builder.AddSystem(MakeBouncingBallPlant(
       radius, mass, FLAGS_elastic_modulus, FLAGS_dissipation, coulomb_friction,
-      -g * Vector3d::UnitZ(), FLAGS_rigid_ball, &scene_graph));
+      -g * Vector3d::UnitZ(), FLAGS_rigid_ball, FLAGS_soft_ground,
+      &scene_graph));
 
   if (FLAGS_add_wall) {
     geometry::Box wall{0.2, 4, 0.4};

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -152,6 +152,7 @@ drake_cc_library(
     deps = [
         ":collision_filter_legacy",
         ":hydroelastic_internal",
+        ":mesh_half_space_intersection",
         ":mesh_intersection",
         ":mesh_plane_intersection",
         ":penetration_as_point_pair_callback",

--- a/geometry/proximity/hydroelastic_internal.h
+++ b/geometry/proximity/hydroelastic_internal.h
@@ -4,6 +4,7 @@
 #include <optional>
 #include <unordered_map>
 #include <utility>
+#include <variant>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/text_logging.h"
@@ -43,36 +44,118 @@ struct SoftMesh {
   }
 };
 
-/** Definition of a soft geometry for hydroelastic implementations. Today, the
- soft geometry is a soft _mesh_. In the future it will include other soft
- representations (e.g., untessellated half space).  */
+/** Defines a soft half space. The half space is defined such that the half
+ space's boundary plane is z = 0 in Frame H. Vector Hz points _out_ of the half
+ space. The half space is considered to be a soft layer of thickness h
+ overlaying a rigid substrate of infinite extent. Its compliance is
+ characterized by two parameters:
+
+   - elastic modulus: a measure of the stiffness of the material under small
+     deformation (<< h), and
+   - slab thickness: the thickness of the compliant layer.
+
+ The pressure in the soft layer may be modeled in many ways. Currently, we use
+ the simplest model in which the pressure field is `ρ = E⋅d/h`, where `E` is the
+ elastic modulus, `d` is the positive penetration measure, and `h` is the slab
+ thickness -- a simple linear function where pressure is a scale of the depth.
+ This model is valid for small penetrations but fails to capture the increased
+ stiffness for deformations that approch or penetrate the rigid substrate.
+
+ The hydroelastic representation combines elastic modulus and slab thickness
+ into a "pressure scale" value: `s = E / h`, which maps penetration depth to
+ pressure. The pressure gradient is always in the -Hz direction.
+
+ We don't tessellate half spaces because:
+
+   - a finite discretization is a poor representation of an infinite volume, and
+   - it is computationally advantageous to *not* discretize the half space.
+ */
+struct SoftHalfSpace {
+  double pressure_scale;
+  // TODO(SeanCurtis-TRI): Possibly add a customizable pressure function in the
+  //  future; one that isn't simply the scaled, normalized penetration distance.
+};
+
+/** Definition of a soft geometry for hydroelastic implementations. To be a
+ soft geometry, a shape must be associated with either:
+
+   - a volume mesh (including a linearized scalar pressure field), or
+   - a soft half space (with a "slab thickness").  */
 class SoftGeometry {
  public:
-  /** Constructs a soft geometry from a soft mesh.  */
-  SoftGeometry(std::unique_ptr<VolumeMesh<double>> mesh,
-               std::unique_ptr<VolumeMeshField<double, double>> pressure)
-      : geometry_(SoftMesh(std::move(mesh), std::move(pressure))) {}
+  /** Constructs a soft half space representation.  */
+  explicit SoftGeometry(const SoftHalfSpace& soft_half_space)
+      : geometry_(soft_half_space) {}
+
+  /** Constructs a soft mesh representation.  */
+  explicit SoftGeometry(SoftMesh&& soft_mesh)
+      : geometry_(std::move(soft_mesh)) {}
 
   SoftGeometry(const SoftGeometry& g) { *this = g; }
   SoftGeometry& operator=(const SoftGeometry& g);
   SoftGeometry(SoftGeometry&&) = default;
   SoftGeometry& operator=(SoftGeometry&&) = default;
 
-  /** Returns a reference to the volume mesh.  */
-  const VolumeMesh<double>& mesh() const { return *geometry_.mesh; }
+  /** @name  Distinguishing compliant representations
 
-  /** Returns a reference to the mesh's linearized pressure field.  */
+   The %SoftGeometry can contain either a volume mesh (used as the
+   representation for most shapes) or a half space. Accessing the members of
+   either representation (`mesh()`, `pressure_field()`, and `bvh()` for the
+   volume mesh or `pressure_scale()` for the half space) is conditioned on
+   knowing what type a particular instance holds.
+
+   This can be accomplished by querying `is_half_space()`. Attempting to access
+   data members of the *wrong* type will throw an exception.  */
+  //@{
+
+  bool is_half_space() const {
+    return std::holds_alternative<SoftHalfSpace>(geometry_);
+  }
+
+  /** Returns a reference to the volume mesh -- calling this will throw if
+   is_half_space() returns `true`.  */
+  const VolumeMesh<double>& mesh() const {
+    if (is_half_space()) {
+      throw std::runtime_error(
+          "SoftGeometry::mesh() cannot be invoked for soft half space");
+    }
+    return *std::get<SoftMesh>(geometry_).mesh;
+  }
+
+  /** Returns a reference to the mesh's linearized pressure field -- calling
+   this will throw if is_half_space() returns `true`.  */
   const VolumeMeshField<double, double>& pressure_field() const {
-    return *geometry_.pressure;
+    if (is_half_space()) {
+      throw std::runtime_error("SoftGeometry::pressure_field() cannot be "
+                               "invoked for soft half space");
+    }
+    return *std::get<SoftMesh>(geometry_).pressure;
   }
 
-  /** Returns a reference to the bounding volume hierarchy.  */
+  /** Returns a reference to the bounding volume hierarchy -- calling this will
+   throw if is_half_space() returns `true`.  */
   const BoundingVolumeHierarchy<VolumeMesh<double>>& bvh() const {
-    return *geometry_.bvh;
+    if (is_half_space()) {
+      throw std::runtime_error(
+          "SoftGeometry::bvh() cannot be invoked for soft half space");
+    }
+    return *std::get<SoftMesh>(geometry_).bvh;
   }
+
+  /** Returns the half space's pressure scale -- calling this will throw if
+   is_half_space() returns `false`.  */
+  double pressure_scale() const {
+    if (!is_half_space()) {
+      throw std::runtime_error(
+          "SoftGeometry::pressure_scale() cannot be invoked for soft mesh");
+    }
+    return std::get<SoftHalfSpace>(geometry_).pressure_scale;
+  }
+
+  //@}
 
  private:
-  SoftMesh geometry_;
+  std::variant<SoftHalfSpace, SoftMesh> geometry_;
 };
 
 /** Defines a rigid mesh -- a surface mesh and its bounding volume hierarchy.
@@ -99,11 +182,11 @@ class RigidGeometry {
    specification HalfSpace, is defined in its canonical frame H with the
    boundary plane at z = 0 and its outward normal pointing in the Hz direction.
    */
-  RigidGeometry() = default;
+  explicit RigidGeometry(const HalfSpace&) {}
 
-  /** Constructs a rigid representation from the given surface mesh.  */
-  explicit RigidGeometry(std::unique_ptr<SurfaceMesh<double>> mesh)
-      : geometry_(RigidMesh(std::move(mesh))) {}
+  /** Constructs a rigid mesh representation.  */
+  explicit RigidGeometry(RigidMesh&& rigid_mesh)
+      : geometry_(RigidMesh(std::move(rigid_mesh))) {}
 
   RigidGeometry(const RigidGeometry& g) { *this = g; }
   RigidGeometry& operator=(const RigidGeometry& g);
@@ -308,29 +391,35 @@ std::optional<SoftGeometry> MakeSoftRepresentation(const Shape& shape,
   return {};
 }
 
-/** Creates a soft sphere (assuming the proximity properties has sufficient
+/** Creates a soft sphere (assuming the proximity properties have sufficient
  information). Requires the ('hydroelastic', 'resolution_hint') and
  ('material', 'elastic_modulus') properties.  */
 std::optional<SoftGeometry> MakeSoftRepresentation(
     const Sphere& sphere, const ProximityProperties& props);
 
-/** Creates a soft box (assuming the proximity properties has sufficient
+/** Creates a soft box (assuming the proximity properties have sufficient
  information). Requires the ('hydroelastic', 'resolution_hint') and
  ('material', 'elastic_modulus') properties.  */
 std::optional<SoftGeometry> MakeSoftRepresentation(
     const Box& box, const ProximityProperties& props);
 
-/** Creates a soft cylinder (assuming the proximity properties has sufficient
+/** Creates a soft cylinder (assuming the proximity properties have sufficient
  information). Requires the ('hydroelastic', 'resolution_hint') and
  ('material', 'elastic_modulus') properties.  */
 std::optional<SoftGeometry> MakeSoftRepresentation(
     const Cylinder& cylinder, const ProximityProperties& props);
 
-/** Creates a soft ellipsoid (assuming the proximity properties has sufficient
+/** Creates a soft ellipsoid (assuming the proximity properties have sufficient
  information). Requires the ('hydroelastic', 'resolution_hint') and
  ('material', 'elastic_modulus') properties.  */
 std::optional<SoftGeometry> MakeSoftRepresentation(
     const Ellipsoid& ellipsoid, const ProximityProperties& props);
+
+/** Creates a compliant half space (assuming the proximity properties have
+ sufficient information). Requires the ('hydroelastic', 'slab_thickness') and
+ ('material', 'elastic_modulus') properties.  */
+std::optional<SoftGeometry> MakeSoftRepresentation(
+    const HalfSpace& half_space, const ProximityProperties& props);
 
 //@}
 

--- a/geometry/proximity_properties.cc
+++ b/geometry/proximity_properties.cc
@@ -12,6 +12,7 @@ const char* const kHcDissipation = "hunt_crossley_dissipation";
 const char* const kHydroGroup = "hydroelastic";
 const char* const kRezHint = "resolution_hint";
 const char* const kComplianceType = "compliance_type";
+const char* const  kSlabThickness = "slab_thickness";
 
 std::ostream& operator<<(std::ostream& out, const HydroelasticType& type) {
   switch (type) {
@@ -95,6 +96,14 @@ void AddSoftHydroelasticProperties(ProximityProperties* properties) {
   // sufficient.
   properties->AddProperty(internal::kHydroGroup, internal::kComplianceType,
                           internal::HydroelasticType::kSoft);
+}
+
+void AddSoftHydroelasticPropertiesForHalfSpace(
+    double slab_thickness, ProximityProperties* properties) {
+  DRAKE_DEMAND(properties);
+  properties->AddProperty(internal::kHydroGroup, internal::kSlabThickness,
+                          slab_thickness);
+  AddSoftHydroelasticProperties(properties);
 }
 
 }  // namespace geometry

--- a/geometry/proximity_properties.h
+++ b/geometry/proximity_properties.h
@@ -51,6 +51,7 @@ extern const char* const kHcDissipation;  ///< Hunt-Crossley dissipation
    - utility functions for declaring consistent hydroelastic properties
      including
        - differentiating between a rigid and soft geometry
+       - accounting for differences between tessellated meshes and half spaces.
 
  @todo Add reference to discussion of hydroelastic proximity properties along
  the lines of "For the full discussion of preparing geometry for use in the
@@ -61,6 +62,8 @@ extern const char* const kHcDissipation;  ///< Hunt-Crossley dissipation
 extern const char* const kHydroGroup;       ///< Hydroelastic group name.
 extern const char* const kRezHint;          ///< Resolution hint property name.
 extern const char* const kComplianceType;   ///< Compliance type property name.
+extern const char* const kSlabThickness;    ///< Slab thickness property name
+                                            ///< (for half spaces).
 
 //@}
 
@@ -141,6 +144,20 @@ void AddSoftHydroelasticProperties(double resolution_hint,
  hydroelastic representation (e.g., HalfSpace).
  See @ref MODULE_NOT_WRITTEN_YET.  */
 void AddSoftHydroelasticProperties(ProximityProperties* properties);
+
+/** Soft half spaces are handled as a special case; they do not get tessellated.
+ Instead, they are treated as infinite slabs with a finite thickness. This
+ variant is required for hydroelastic half spaces.
+
+ @param slab_thickness      The distance from the half space boundary to its
+                            rigid core (this helps define the extent field of
+                            the half space).
+ @param[out] properties     The properties will be added to this property set.
+ @throws std::logic_error If `properties` already has properties with the names
+                          that this function would need to add.
+ @pre 0 < `slab_thickness` < ∞ . */
+void AddSoftHydroelasticPropertiesForHalfSpace(double slab_thickness,
+                                               ProximityProperties* properties);
 
 //@}
 

--- a/geometry/test/proximity_properties_test.cc
+++ b/geometry/test/proximity_properties_test.cc
@@ -129,6 +129,24 @@ GTEST_TEST(ProximityPropertiesTest, AddSoftProperties) {
             HydroelasticType::kSoft);
 }
 
+// Tests the variant where the static pressure field is defined by the
+// enumeration.
+GTEST_TEST(ProximityPropertiesTest, AddHalfSpaceSoftProperties) {
+  const double E = 1.5e8;
+  for (double thickness : {1e-5, 1.25, 1e7}) {
+    ProximityProperties props;
+    props.AddProperty(internal::kMaterialGroup, internal::kElastic, E);
+    AddSoftHydroelasticPropertiesForHalfSpace(thickness, &props);
+    EXPECT_TRUE(
+        props.HasProperty(internal::kHydroGroup, internal::kSlabThickness));
+    EXPECT_EQ(props.GetProperty<double>(internal::kHydroGroup,
+                                        internal::kSlabThickness),
+              thickness);
+    EXPECT_EQ(props.GetProperty<HydroelasticType>(kHydroGroup, kComplianceType),
+              HydroelasticType::kSoft);
+  }
+}
+
 }  // namespace
 }  // namespace geometry
 }  // namespace drake

--- a/multibody/plant/test/multibody_plant_hydroelastic_contact_results_output_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_contact_results_output_test.cc
@@ -50,7 +50,7 @@ class HydroelasticContactResultsOutputTester : public ::testing::Test {
     plant_ = builder.AddSystem(
         examples::multibody::bouncing_ball::MakeBouncingBallPlant(
             radius, mass, elastic_modulus, dissipation, friction, gravity_W,
-            false /* rigid_sphere */, &scene_graph));
+            false /* rigid_sphere */, false /* soft_ground */, &scene_graph));
     plant_->set_contact_model(ContactModel::kHydroelasticsOnly);
     plant_->Finalize();
 


### PR DESCRIPTION
This exercises the underlying geometric logic to implement a soft half space.
 - Introduce the soft half space hydroelastic reprepsentation.
 - Add dispatch logic for soft half space-rigid mesh.
 - updates the rolling sphere demo so it can exercise the soft half space.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12975)
<!-- Reviewable:end -->
