### PR TITLE
[geometry] Soft half space - rigid mesh contact must cull backfaces

### DIFF
--- a/geometry/proximity/contact_surface_utility.h
+++ b/geometry/proximity/contact_surface_utility.h
@@ -84,6 +84,31 @@ void AddPolygonToMeshData(
     std::vector<SurfaceFace>* faces,
     std::vector<SurfaceVertex<T>>* vertices_F);
 
+
+/* Determines if the indicated triangle has a face normal that is "in the
+ direction" of the given normal.
+
+ The definition of "in the direction" is within a hard-coded tolerance 5π/8,
+ which was empirically determined. Note that there is no one value that always
+ works (see documentation of IsFaceNormalAlongPressureGradient() in
+ mesh_intersection.h for examples).
+
+ @param normal_F    The normal to test against, expressed in Frame F.
+ @param surface_M   The mesh from which the triangle is drawn, measured and
+                    expressed in Frame M.
+ @param tri_index   The index of the triangle in `surface_M` to test.
+ @param R_FM        The relative orientation between the bases of M and F.
+ @pre `normal_F` is unit length.
+ @return `true` if the angle between `normal_F` and the triangle normal lies
+          within the hard-coded tolerance.
+ @tparam T  The computational scalar type. Only supports double and AutoDiffXd.
+ */
+template <typename T>
+bool IsFaceNormalInNormalDirection(const Vector3<T>& normal_F,
+                                   const SurfaceMesh<T>& surface_M,
+                                   SurfaceFaceIndex tri_index,
+                                   const math::RotationMatrix<T>& R_FM);
+
 }  // namespace internal
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/proximity/mesh_intersection.h
+++ b/geometry/proximity/mesh_intersection.h
@@ -433,26 +433,15 @@ bool IsFaceNormalAlongPressureGradient(
     const VolumeMeshField<T, T>& volume_field_M,
     const SurfaceMesh<T>& surface_N, const math::RigidTransform<T>& X_MN,
     const VolumeElementIndex& tet_index, const SurfaceFaceIndex& tri_index) {
-  const Vector3<T>& normal_N = surface_N.face_normal(tri_index);
-  const Vector3<T>  normal_M = X_MN.rotation() * normal_N;
-  // Evaluate the gradient vector on the tetrahedron.
   // TODO(DamrongGuoy): Change the type of volume_field_M from
   //  VolumeMeshField to VolumeMeshFieldLinear and remove this cast.
+  // Evaluate the gradient vector on the tetrahedron.
   const auto field_M =
       dynamic_cast<const VolumeMeshFieldLinear<T, T>*>(&volume_field_M);
   DRAKE_DEMAND(field_M);
   const Vector3<T> grad_p_M = field_M->EvaluateGradient(tet_index);
-  const T dot_product = normal_M.dot(grad_p_M.normalized());
-
-  // We pick 5π/8 empirically.
-  constexpr double kAngleThreshold = 5. * M_PI / 8.;
-  static const double kDotProductThreshold = std::cos(kAngleThreshold);
-  // dot_product greater than kDotProductThreshold means the angle between
-  // the two unit vectors is less than kAngleThreshold.
-  if (dot_product > kDotProductThreshold)
-    return true;
-  else
-    return false;
+  return IsFaceNormalInNormalDirection(grad_p_M.normalized(), surface_N,
+                                       tri_index, X_MN.rotation());
 }
 
 // TODO(DamrongGuoy): Maintain book keeping to avoid duplicate vertices and


### PR DESCRIPTION
For the same reason we cull faces in the contact surface mesh between soft and rigid meshes, the potential contact surface between rigid mesh and soft half space requires the same functionality. This commit:

  - Refactors the core culling logic for reuse.
  - Adds the culling to mesh - half space intersection
  - Adds a test showing culling is happening.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12976)
<!-- Reviewable:end -->
