### PR TITLE
workspace: Upgrade imported bazel rules to latest

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,7 +20,7 @@ load("//tools/clion:repository.bzl", "drake_clion_environment")
 
 drake_clion_environment()
 
-load("@bazel_skylib//:lib.bzl", "versions")
+load("@bazel_skylib//lib:versions.bzl", "versions")
 
 # This needs to be in WORKSPACE or a repository rule for native.bazel_version
 # to actually be defined. The minimum_bazel_version value should match the

--- a/tools/workspace/bazel_skylib/repository.bzl
+++ b/tools/workspace/bazel_skylib/repository.bzl
@@ -6,7 +6,7 @@ def bazel_skylib_repository(name, mirrors = None):
     github_archive(
         name = name,
         repository = "bazelbuild/bazel-skylib",
-        commit = "0.5.0",
-        sha256 = "b5f6abe419da897b7901f90cbab08af958b97a8f3575b0d3dd062ac7ce78541f",  # noqa
+        commit = "0.9.0",
+        sha256 = "9245b0549e88e356cd6a25bf79f97aa19332083890b7ac6481a2affb6ada9752",  # noqa
         mirrors = mirrors,
     )

--- a/tools/workspace/rules_pkg/repository.bzl
+++ b/tools/workspace/rules_pkg/repository.bzl
@@ -12,7 +12,7 @@ def rules_pkg_repository(
         name = name,
         repository = "bazelbuild/rules_pkg",  # License: Apache-2.0
         extra_strip_prefix = "pkg",
-        commit = "0.2.4",
-        sha256 = "08ce92b9aea59ce6d592404de6cdfd7100c1140cdf4d4b9266942c20ec998b27",  # noqa
+        commit = "0.2.5",
+        sha256 = "f8bf72e76a15d045f786ef0eba92e073a50bbdbd807d237a43a759d36b1b1e2c",  # noqa
         mirrors = mirrors,
     )

--- a/tools/workspace/rules_python/repository.bzl
+++ b/tools/workspace/rules_python/repository.bzl
@@ -12,7 +12,7 @@ def rules_python_repository(
     github_archive(
         name = name,
         repository = "bazelbuild/rules_python",  # License: Apache-2.0
-        commit = "38f86fb55b698c51e8510c807489c9f4e047480e",
-        sha256 = "c911dc70f62f507f3a361cbc21d6e0d502b91254382255309bc60b7a0f48de28",  # noqa
+        commit = "748aa53d7701e71101dfd15d800e100f6ff8e5d1",
+        sha256 = "64a3c26f95db470c32ad86c924b23a821cd16c3879eed732a7841779a32a60f8",  # noqa
         mirrors = mirrors,
     )


### PR DESCRIPTION
Upgrade bazel_skylib to latest release 0.9.0.
Upgrade rules_pkg to latest release 0.2.5.
Upgrade rules_python to latest commit.

Respell a `load()` because `lib.bzl` is deprecated now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12978)
<!-- Reviewable:end -->
