### PR TITLE
ignore .history -- for vscode + gitkraken workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 /.settings/
 /.clwb/
 /.vscode
+/.history
 
 # (Possible) CMake build artifacts
 /build/


### PR DESCRIPTION
 gitkraken doesn't support global .gitignore

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12985)
<!-- Reviewable:end -->
