### PR TITLE
trajectories: support default scalars in PiecewiseTrajectory

### DIFF
--- a/common/trajectories/BUILD.bazel
+++ b/common/trajectories/BUILD.bazel
@@ -34,6 +34,7 @@ drake_cc_library(
     hdrs = ["piecewise_trajectory.h"],
     deps = [
         ":trajectory",
+        "//common:default_scalars",
         "//common:essential",
     ],
 )

--- a/common/trajectories/exponential_plus_piecewise_polynomial.cc
+++ b/common/trajectories/exponential_plus_piecewise_polynomial.cc
@@ -28,7 +28,7 @@ std::unique_ptr<Trajectory<T>> ExponentialPlusPiecewisePolynomial<T>::Clone()
 }
 
 template <typename T>
-MatrixX<T> ExponentialPlusPiecewisePolynomial<T>::value(double t) const {
+MatrixX<T> ExponentialPlusPiecewisePolynomial<T>::value(const T& t) const {
   int segment_index = this->get_segment_index(t);
   MatrixX<T> ret = piecewise_polynomial_part_.value(t);
   double tj = this->start_time(segment_index);

--- a/common/trajectories/exponential_plus_piecewise_polynomial.h
+++ b/common/trajectories/exponential_plus_piecewise_polynomial.h
@@ -56,7 +56,7 @@ class ExponentialPlusPiecewisePolynomial final
 
   std::unique_ptr<Trajectory<T>> Clone() const override;
 
-  MatrixX<T> value(double t) const override;
+  MatrixX<T> value(const T& t) const override;
 
   ExponentialPlusPiecewisePolynomial derivative(int derivative_order = 1) const;
 

--- a/common/trajectories/piecewise_polynomial.h
+++ b/common/trajectories/piecewise_polynomial.h
@@ -565,7 +565,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    *          a polynomial defined over [0, 1].
    * @warning See warning in @ref polynomial_construction_warning.
    */
-  MatrixX<T> value(double t) const override {
+  MatrixX<T> value(const T& t) const override {
       const int derivative_order = 0;
       return EvalDerivative(t, derivative_order);
   }

--- a/common/trajectories/piecewise_quaternion.h
+++ b/common/trajectories/piecewise_quaternion.h
@@ -81,7 +81,9 @@ class PiecewiseQuaternionSlerp final : public PiecewiseTrajectory<T> {
    */
   Quaternion<T> orientation(double t) const;
 
-  MatrixX<T> value(double t) const override { return orientation(t).matrix(); }
+  MatrixX<T> value(const T& t) const override {
+    return orientation(t).matrix();
+  }
 
   /**
    * Interpolates angular velocity.

--- a/common/trajectories/piecewise_trajectory.cc
+++ b/common/trajectories/piecewise_trajectory.cc
@@ -13,7 +13,7 @@ namespace drake {
 namespace trajectories {
 
 template <typename T>
-PiecewiseTrajectory<T>::PiecewiseTrajectory(std::vector<double> const& breaks)
+PiecewiseTrajectory<T>::PiecewiseTrajectory(const std::vector<T>& breaks)
     : Trajectory<T>(), breaks_(breaks) {
   for (int i = 1; i < get_number_of_segments() + 1; i++) {
     DRAKE_DEMAND(breaks_[i] - breaks_[i - 1] >= kEpsilonTime);
@@ -21,7 +21,7 @@ PiecewiseTrajectory<T>::PiecewiseTrajectory(std::vector<double> const& breaks)
 }
 
 template <typename T>
-bool PiecewiseTrajectory<T>::is_time_in_range(double time) const {
+boolean<T> PiecewiseTrajectory<T>::is_time_in_range(const T& time) const {
   return (time >= start_time() && time <= end_time());
 }
 
@@ -31,34 +31,34 @@ int PiecewiseTrajectory<T>::get_number_of_segments() const {
 }
 
 template <typename T>
-double PiecewiseTrajectory<T>::start_time(int segment_number) const {
+T PiecewiseTrajectory<T>::start_time(int segment_number) const {
   segment_number_range_check(segment_number);
   return breaks_[segment_number];
 }
 
 template <typename T>
-double PiecewiseTrajectory<T>::end_time(int segment_number) const {
+T PiecewiseTrajectory<T>::end_time(int segment_number) const {
   segment_number_range_check(segment_number);
   return breaks_[segment_number + 1];
 }
 
 template <typename T>
-double PiecewiseTrajectory<T>::duration(int segment_number) const {
+T PiecewiseTrajectory<T>::duration(int segment_number) const {
   return end_time(segment_number) - start_time(segment_number);
 }
 
 template <typename T>
-double PiecewiseTrajectory<T>::start_time() const {
+T PiecewiseTrajectory<T>::start_time() const {
   return start_time(0);
 }
 
 template <typename T>
-double PiecewiseTrajectory<T>::end_time() const {
+T PiecewiseTrajectory<T>::end_time() const {
   return end_time(get_number_of_segments() - 1);
 }
 
 template <typename T>
-int PiecewiseTrajectory<T>::GetSegmentIndexRecursive(double time, int start,
+int PiecewiseTrajectory<T>::GetSegmentIndexRecursive(const T& time, int start,
                                                      int end) const {
   DRAKE_DEMAND(end >= start);
   DRAKE_DEMAND(end < static_cast<int>(breaks_.size()));
@@ -79,15 +79,18 @@ int PiecewiseTrajectory<T>::GetSegmentIndexRecursive(double time, int start,
 }
 
 template <typename T>
-int PiecewiseTrajectory<T>::get_segment_index(double t) const {
+int PiecewiseTrajectory<T>::get_segment_index(const T& t) const {
   if (breaks_.empty()) return 0;
   // clip to min/max times
-  t = std::min(std::max(t, start_time()), end_time());
-  return GetSegmentIndexRecursive(t, 0, static_cast<int>(breaks_.size() - 1));
+  using std::min;
+  using std::max;
+  T time = min(max(t, start_time()), end_time());
+  return GetSegmentIndexRecursive(time, 0,
+                                  static_cast<int>(breaks_.size() - 1));
 }
 
 template <typename T>
-const std::vector<double>& PiecewiseTrajectory<T>::get_segment_times() const {
+const std::vector<T>& PiecewiseTrajectory<T>::get_segment_times() const {
   return breaks_;
 }
 
@@ -103,15 +106,15 @@ void PiecewiseTrajectory<T>::segment_number_range_check(
 }
 
 template <typename T>
-std::vector<double> PiecewiseTrajectory<T>::RandomSegmentTimes(
+std::vector<T> PiecewiseTrajectory<T>::RandomSegmentTimes(
     // TODO(#2274) Fix this NOLINTNEXTLINE(runtime/references)
     int num_segments, std::default_random_engine& generator) {
-  vector<double> breaks;
+  vector<T> breaks;
   uniform_real_distribution<double> uniform(kEpsilonTime, 1);
-  double t0 = uniform(generator);
+  T t0 = uniform(generator);
   breaks.push_back(t0);
   for (int i = 0; i < num_segments; ++i) {
-    double duration = uniform(generator);
+    T duration = uniform(generator);
     breaks.push_back(breaks[i] + duration);
   }
   return breaks;
@@ -121,14 +124,15 @@ template <typename T>
 bool PiecewiseTrajectory<T>::SegmentTimesEqual(
     const PiecewiseTrajectory<T>& other, double tol) const {
   if (breaks_.size() != other.breaks_.size()) return false;
+  using std::abs;
   for (size_t i = 0; i < breaks_.size(); i++) {
-    if (std::abs(breaks_[i] - other.breaks_[i]) > tol) return false;
+    if (abs(breaks_[i] - other.breaks_[i]) > tol) return false;
   }
   return true;
 }
 
-// Explicit instantionations.
-template class PiecewiseTrajectory<double>;
-
 }  // namespace trajectories
 }  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class drake::trajectories::PiecewiseTrajectory)

--- a/common/trajectories/piecewise_trajectory.h
+++ b/common/trajectories/piecewise_trajectory.h
@@ -6,6 +6,7 @@
 
 #include <Eigen/Core>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/trajectories/trajectory.h"
 
 namespace drake {
@@ -15,7 +16,7 @@ namespace trajectories {
 /// segments of time (delimited by `breaks`) to implement a trajectory that
 /// is represented by simpler logic in each segment or "piece".
 ///
-/// @tparam_double_only
+/// @tparam_default_scalars
 template <typename T>
 class PiecewiseTrajectory : public Trajectory<T> {
  public:
@@ -27,28 +28,28 @@ class PiecewiseTrajectory : public Trajectory<T> {
 
   int get_number_of_segments() const;
 
-  double start_time(int segment_number) const;
+  T start_time(int segment_number) const;
 
-  double end_time(int segment_number) const;
+  T end_time(int segment_number) const;
 
-  double duration(int segment_number) const;
+  T duration(int segment_number) const;
 
-  double start_time() const override;
+  T start_time() const override;
 
-  double end_time() const override;
+  T end_time() const override;
 
   /**
    * Returns true iff `t >= getStartTime() && t <= getEndTime()`.
    */
-  bool is_time_in_range(double t) const;
+  boolean<T> is_time_in_range(const T& t) const;
 
-  int get_segment_index(double t) const;
+  int get_segment_index(const T& t) const;
 
-  const std::vector<double>& get_segment_times() const;
+  const std::vector<T>& get_segment_times() const;
 
   void segment_number_range_check(int segment_number) const;
 
-  static std::vector<double> RandomSegmentTimes(
+  static std::vector<T> RandomSegmentTimes(
       // TODO(#2274) Fix this NOLINTNEXTLINE(runtime/references)
       int num_segments, std::default_random_engine &generator);
 
@@ -58,19 +59,22 @@ class PiecewiseTrajectory : public Trajectory<T> {
   PiecewiseTrajectory() = default;
 
   /// @p breaks increments must be greater or equal to kEpsilonTime.
-  explicit PiecewiseTrajectory(const std::vector<double>& breaks);
+  explicit PiecewiseTrajectory(const std::vector<T>& breaks);
 
   bool SegmentTimesEqual(const PiecewiseTrajectory& b,
                          double tol = kEpsilonTime) const;
 
-  const std::vector<double>& breaks() const { return breaks_; }
-  std::vector<double>& get_mutable_breaks() { return breaks_; }
+  const std::vector<T>& breaks() const { return breaks_; }
+  std::vector<T>& get_mutable_breaks() { return breaks_; }
 
  private:
-  int GetSegmentIndexRecursive(double time, int start, int end) const;
+  int GetSegmentIndexRecursive(const T& time, int start, int end) const;
 
-  std::vector<double> breaks_;
+  std::vector<T> breaks_;
 };
 
 }  // namespace trajectories
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class drake::trajectories::PiecewiseTrajectory)

--- a/common/trajectories/test/piecewise_trajectory_test.cc
+++ b/common/trajectories/test/piecewise_trajectory_test.cc
@@ -13,25 +13,26 @@ namespace {
 
 // Dummy implementation of PiecewiseTrajectory to test the basic indexing
 // functions.
-class PiecewiseTrajectoryTester : public PiecewiseTrajectory<double> {
+template <typename T = double>
+class PiecewiseTrajectoryTester : public PiecewiseTrajectory<T> {
  public:
-  explicit PiecewiseTrajectoryTester(const std::vector<double>& times)
-      : PiecewiseTrajectory<double>(times) { }
+  explicit PiecewiseTrajectoryTester(const std::vector<T>& times)
+      : PiecewiseTrajectory<T>(times) { }
   Eigen::Index rows() const override { return 0; }
   Eigen::Index cols() const override { return 0; }
-  Eigen::MatrixXd value(double t) const override {
-    return Eigen::MatrixXd(0, 0);
+  MatrixX<T> value(const T& t) const override {
+    return MatrixX<T>(0, 0);
   }
-  std::unique_ptr<Trajectory<double>> Clone() const override {
+  std::unique_ptr<Trajectory<T>> Clone() const override {
     return nullptr;
   }
-  std::unique_ptr<Trajectory<double>> MakeDerivative(int) const override {
+  std::unique_ptr<Trajectory<T>> MakeDerivative(int) const override {
     return nullptr;
   }
 };
 
 void TestPiecewiseTrajectoryTimeRelatedGetters(
-    const PiecewiseTrajectoryTester& traj,
+    const PiecewiseTrajectoryTester<double>& traj,
     const std::vector<double>& time) {
   EXPECT_EQ(traj.get_number_of_segments(), static_cast<int>(time.size()) - 1);
 
@@ -101,6 +102,28 @@ GTEST_TEST(PiecewiseTrajectoryTest, GetIndexTest) {
 
   TestPiecewiseTrajectoryTimeRelatedGetters(traj, time);
 }
+
+template <typename T>
+void TestScalarType() {
+  std::default_random_engine generator(123);
+  std::vector<T> time =
+      PiecewiseTrajectory<T>::RandomSegmentTimes(5, generator);
+
+  PiecewiseTrajectoryTester<T> traj(time);
+
+  const MatrixX<T> value = traj.value(traj.start_time());
+  EXPECT_EQ(value.rows(), 0);
+  EXPECT_EQ(value.cols(), 0);
+
+  EXPECT_TRUE(static_cast<bool>(
+      traj.is_time_in_range((traj.start_time() + traj.end_time()) / 2.0)));
+}
+
+GTEST_TEST(PiecewiseTrajectoryTest, ScalarTypes) {
+  TestScalarType<AutoDiffXd>();
+  TestScalarType<symbolic::Expression>();
+}
+
 
 }  // namespace
 }  // namespace trajectories

--- a/common/trajectories/trajectory.h
+++ b/common/trajectories/trajectory.h
@@ -12,10 +12,11 @@ namespace drake {
 namespace trajectories {
 
 /**
- * A Trajectory represents a time-varying matrix, indexed by a single
- * scalar double time.
+ * A Trajectory represents a time-varying matrix, indexed by a single scalar
+ * time.
  *
- * @tparam T is a Scalar type for the data that is returned.
+ * @tparam T is any scalar type. This is a header-only abstract class (so no
+ * concrete scalar type instantiations need to be provided).
  */
 template <typename T>
 class Trajectory {
@@ -32,7 +33,7 @@ class Trajectory {
    * @param t The time at which to evaluate the trajectory.
    * @return The matrix of evaluated values.
    */
-  virtual MatrixX<T> value(double t) const = 0;
+  virtual MatrixX<T> value(const T& t) const = 0;
 
   /**
   * If cols()==1, then evaluates the trajectory at each time @p t, and returns
@@ -42,7 +43,7 @@ class Trajectory {
   * the ith time.
   * @throws std::runtime_error if both cols and rows are not equal to 1.
   */
-  MatrixX<T> vector_values(const std::vector<double>& t) const {
+  MatrixX<T> vector_values(const std::vector<T>& t) const {
     if (cols() != 1 && rows() != 1) {
       throw std::runtime_error(
           "This method only supports vector-valued trajectories.");
@@ -80,9 +81,9 @@ class Trajectory {
    */
   virtual Eigen::Index cols() const = 0;
 
-  virtual double start_time() const = 0;
+  virtual T start_time() const = 0;
 
-  virtual double end_time() const = 0;
+  virtual T end_time() const = 0;
 
  protected:
   // Final subclasses are allowed to make copy/move/assign public.


### PR DESCRIPTION
note: the signature of one virtual method changed in a way that I did not know how to deprecate properly:
```
MatrixX<T> value(double) const
```
is now
```
MatrixX<T> value(const T& t) const
```
and derived classes will need to update this to compile.  (unfortunately, the compiler gives a relatively verbose and unhelpful stream of errors because the derived classes become abstract classes)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12986)
<!-- Reviewable:end -->
