### PR TITLE
workspace: Annotate repository rules with configure=True

### DIFF
--- a/tools/workspace/cc/repository.bzl
+++ b/tools/workspace/cc/repository.bzl
@@ -161,5 +161,6 @@ cc_repository = repository_rule(
         "BAZEL_USE_CPP_ONLY_TOOLCHAIN",
         "CC",
     ],
+    configure = True,
     implementation = _impl,
 )

--- a/tools/workspace/expat/repository.bzl
+++ b/tools/workspace/expat/repository.bzl
@@ -84,5 +84,6 @@ expat_repository = repository_rule(
         "modname": attr.string(default = "expat"),
     },
     local = True,
+    configure = True,
     implementation = _impl,
 )

--- a/tools/workspace/gfortran/repository.bzl
+++ b/tools/workspace/gfortran/repository.bzl
@@ -85,5 +85,6 @@ def _gfortran_impl(repo_ctx):
 
 gfortran_repository = repository_rule(
     local = True,
+    configure = True,
     implementation = _gfortran_impl,
 )

--- a/tools/workspace/ibex/repository.bzl
+++ b/tools/workspace/ibex/repository.bzl
@@ -98,6 +98,7 @@ ibex_repository = repository_rule(
             default = "@drake//tools/workspace/ibex:package-ubuntu.BUILD.bazel",  # noqa
         ),
     },
+    configure = True,
     implementation = _impl,
 )
 

--- a/tools/workspace/libblas/repository.bzl
+++ b/tools/workspace/libblas/repository.bzl
@@ -27,7 +27,7 @@ def _impl(repo_ctx):
             fail(error)
     else:
         repo_ctx.symlink(
-            Label("@drake//tools/workspace/blas:package-macos.BUILD.bazel"),
+            Label("@drake//tools/workspace/libblas:package-macos.BUILD.bazel"),
             "BUILD.bazel",
         )
 
@@ -37,5 +37,6 @@ libblas_repository = repository_rule(
         "licenses": attr.string_list(default = ["notice"]),  # BSD-3-Clause
     },
     local = True,
+    configure = True,
     implementation = _impl,
 )

--- a/tools/workspace/liblapack/repository.bzl
+++ b/tools/workspace/liblapack/repository.bzl
@@ -28,7 +28,7 @@ def _impl(repo_ctx):
             fail(error)
     else:
         repo_ctx.symlink(
-            Label("@drake//tools/workspace/lapack:package-macos.BUILD.bazel"),
+            Label("@drake//tools/workspace/liblapack:package-macos.BUILD.bazel"),  # noqa
             "BUILD.bazel",
         )
 
@@ -38,5 +38,6 @@ liblapack_repository = repository_rule(
         "licenses": attr.string_list(default = ["notice"]),  # BSD-3-Clause
     },
     local = True,
+    configure = True,
     implementation = _impl,
 )

--- a/tools/workspace/numpy/repository.bzl
+++ b/tools/workspace/numpy/repository.bzl
@@ -31,7 +31,6 @@ Arguments:
         //tools/py_toolchain:interpreter_paths.bzl.
 """
 
-load("@drake//tools/workspace:execute.bzl", "which")
 load(
     "@drake//tools/workspace/python:repository.bzl",
     "interpreter_path_attrs",
@@ -84,4 +83,5 @@ numpy_repository = repository_rule(
     _impl,
     attrs = interpreter_path_attrs,
     local = True,
+    configure = True,
 )

--- a/tools/workspace/openblas/repository.bzl
+++ b/tools/workspace/openblas/repository.bzl
@@ -27,7 +27,7 @@ def _impl(repo_ctx):
             fail(error)
     else:
         repo_ctx.symlink(
-            Label("@drake//tools/workspace/blas:package-ubuntu.BUILD.bazel"),
+            Label("@drake//tools/workspace/openblas:package-ubuntu.BUILD.bazel"),  # noqa
             "BUILD.bazel",
         )
 
@@ -40,5 +40,6 @@ openblas_repository = repository_rule(
         ),
     },
     local = True,
+    configure = True,
     implementation = _impl,
 )

--- a/tools/workspace/opengl/repository.bzl
+++ b/tools/workspace/opengl/repository.bzl
@@ -30,5 +30,6 @@ opengl_repository = repository_rule(
         "licenses": attr.string_list(default = ["notice"]),  # SGI-B-2.0.
     },
     local = True,
+    configure = True,
     implementation = _impl,
 )

--- a/tools/workspace/pkg_config.bzl
+++ b/tools/workspace/pkg_config.bzl
@@ -283,6 +283,7 @@ pkg_config_repository = repository_rule(
         "pkg_config_paths": attr.string_list(),
     },
     local = True,
+    configure = True,
     implementation = _impl,
 )
 

--- a/tools/workspace/python/repository.bzl
+++ b/tools/workspace/python/repository.bzl
@@ -253,4 +253,5 @@ python_repository = repository_rule(
     _impl,
     attrs = interpreter_path_attrs,
     local = True,
+    configure = True,
 )

--- a/tools/workspace/snopt/repository.bzl
+++ b/tools/workspace/snopt/repository.bzl
@@ -41,7 +41,6 @@ load(
 load(
     "@drake//tools/workspace:execute.bzl",
     "execute_and_return",
-    "execute_or_fail",
 )
 
 def snopt_repository(

--- a/tools/workspace/which.bzl
+++ b/tools/workspace/which.bzl
@@ -34,6 +34,7 @@ which_repository = repository_rule(
         "additional_search_paths": attr.string_list(),
     },
     local = True,
+    configure = True,
     implementation = _impl,
 )
 

--- a/tools/workspace/x11/repository.bzl
+++ b/tools/workspace/x11/repository.bzl
@@ -31,5 +31,6 @@ x11_repository = repository_rule(
         "licenses": attr.string_list(default = ["notice"]),  # X11/MIT.
     },
     local = True,
+    configure = True,
     implementation = _impl,
 )

--- a/tools/workspace/zlib/repository.bzl
+++ b/tools/workspace/zlib/repository.bzl
@@ -84,5 +84,6 @@ zlib_repository = repository_rule(
         "modname": attr.string(default = "zlib"),
     },
     local = True,
+    configure = True,
     implementation = _impl,
 )


### PR DESCRIPTION
Rules that interrogate the host system (e.g., compiler paths, pkg-config paths, python library paths) should be marked with "configure = True" so that "bazel sync --configure" knows where to look for possible changes.

This is helpful to recover from homebrew include paths changing out from under us (#12989).

Running "bazel sync" finds several typos in our repository.bzl files, now fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12988)
<!-- Reviewable:end -->
