### PR TITLE
Added support for revolute joint spring in multibody plant parser

### DIFF
--- a/multibody/parsing/test/sdf_parser_test/revolute_spring_parsing_test.sdf
+++ b/multibody/parsing/test/sdf_parser_test/revolute_spring_parsing_test.sdf
@@ -1,0 +1,128 @@
+<?xml version="1.0" ?>
+
+<!--
+Defines an SDF model with revolute joints for testing the revolute spring
+parser. The only focus is that the parser reads in the values from the
+<spring_stiffness> and <spring_reference> tags properly and assigns a
+default value of zero when the tag is not present. This is an accompanying
+file to detail_sdf_parser_test.cc and therefore they must be kept in sync
+with each other.
+-->
+
+<sdf version='1.6'>
+  <model name='revolute_spring_parsing_test'>
+    <link name='link1'>
+      <inertial>
+        <mass>1</mass>
+        <inertia>
+          <ixx>1.0</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>1.0</iyy>
+          <iyz>0</iyz>
+          <izz>1.0</izz>
+        </inertia>
+      </inertial>
+    </link>
+    <link name='link2'>
+      <inertial>
+        <mass>1</mass>
+        <inertia>
+          <ixx>1.0</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>1.0</iyy>
+          <iyz>0</iyz>
+          <izz>1.0</izz>
+        </inertia>
+      </inertial>
+    </link>
+    <joint name='revolute_spring_reference_and_stiffness' type='revolute'>
+      <child>link2</child>
+      <parent>link1</parent>
+      <axis>
+        <xyz>0 0 1</xyz>
+        <dynamics>
+          <spring_reference>1</spring_reference>
+          <spring_stiffness>5</spring_stiffness>
+        </dynamics>
+        <use_parent_model_frame>1</use_parent_model_frame>
+      </axis>
+    </joint>
+    <link name='link3'>
+      <inertial>
+        <mass>1</mass>
+        <inertia>
+          <ixx>1.0</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>1.0</iyy>
+          <iyz>0</iyz>
+          <izz>1.0</izz>
+        </inertia>
+      </inertial>
+    </link>
+    <joint name='revolute_spring_only_reference' type='revolute'>
+      <child>link3</child>
+      <parent>link2</parent>
+      <axis>
+        <xyz>0 0 1</xyz>
+        <dynamics>
+          <spring_reference>1</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+        <use_parent_model_frame>1</use_parent_model_frame>
+      </axis>
+    </joint>
+    <link name='link4'>
+      <inertial>
+        <mass>1</mass>
+        <inertia>
+          <ixx>1.0</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>1.0</iyy>
+          <iyz>0</iyz>
+          <izz>1.0</izz>
+        </inertia>
+      </inertial>
+    </link>
+    <joint name='revolute_spring_only_stiffness' type='revolute'>
+      <child>link4</child>
+      <parent>link3</parent>
+      <axis>
+        <xyz>0 0 1</xyz>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>5</spring_stiffness>
+        </dynamics>
+        <use_parent_model_frame>1</use_parent_model_frame>
+      </axis>
+    </joint>
+    <link name='link5'>
+      <inertial>
+        <mass>1</mass>
+        <inertia>
+          <ixx>1.0</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>1.0</iyy>
+          <iyz>0</iyz>
+          <izz>1.0</izz>
+        </inertia>
+      </inertial>
+    </link>
+    <joint name='revolute_spring_no_spring' type='revolute'>
+      <child>link5</child>
+      <parent>link4</parent>
+      <axis>
+        <xyz>0 0 1</xyz>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+        <use_parent_model_frame>1</use_parent_model_frame>
+      </axis>
+    </joint>
+  </model>
+</sdf>


### PR DESCRIPTION
If `<spring_stiffness>` is defined in the sdf, then we add a RevoluteSpring on the joint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12992)
<!-- Reviewable:end -->
