### PR TITLE
Add missing implicit integration tests for error control and autodiff

### DIFF
--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -597,6 +597,7 @@ drake_cc_googletest(
     deps = [
         ":velocity_implicit_euler_integrator",
         "//systems/analysis/test_utilities:implicit_integrator_test",
+        "//systems/analysis/test_utilities:quadratic_scalar_system",
     ],
 )
 

--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -471,7 +471,8 @@ drake_cc_googletest(
     deps = [
         ":implicit_euler_integrator",
         "//common/test_utilities:expect_throws_message",
-        "//systems/analysis/test_utilities",
+        "//systems/analysis/test_utilities:implicit_integrator_test",
+        "//systems/analysis/test_utilities:quadratic_scalar_system",
         "//systems/plants/spring_mass_system",
     ],
 )

--- a/systems/analysis/implicit_integrator.cc
+++ b/systems/analysis/implicit_integrator.cc
@@ -59,8 +59,18 @@ void ImplicitIntegrator<T>::ComputeAutoDiffJacobian(
   adiff_context->SetContinuousState(a_xt);
 
   // Evaluate the derivatives at that state.
-  const VectorX<AutoDiffXd> result =
+  VectorX<AutoDiffXd> result =
       this->EvalTimeDerivatives(*adiff_system, *adiff_context).CopyToVector();
+
+  // Sometimes the system's derivatives f(x) do not depend on its states. In
+  // this case, make sure that the Jacobian isn't a n ✕ 0 matrix (this will
+  // cause a segfault when forming Newton iteration matrices). To fix this,
+  // we can just initialize the derivative of the first element if it is empty,
+  // because math::autoDiffToGradientMatrix() will automatically set the second
+  // dimension to the maximum derivative size.
+  if (result.size() > 0 && result[0].derivatives().size() == 0) {
+    result[0].derivatives() = VectorX<T>::Zero(n_state_dim);
+  }
 
   *J = math::autoDiffToGradientMatrix(result);
 }

--- a/systems/analysis/implicit_integrator.cc
+++ b/systems/analysis/implicit_integrator.cc
@@ -33,6 +33,9 @@ void ImplicitIntegrator<T>::ComputeAutoDiffJacobian(
     const System<T>& system, const T& t, const VectorX<T>& xt,
     const Context<T>& context, MatrixX<T>* J) {
   DRAKE_LOGGER_DEBUG("  ImplicitIntegrator Compute Autodiff Jacobian t={}", t);
+  // TODO(antequ): Investigate how to refactor this method to use
+  // math::jacobian(), if possible.
+
   // Create AutoDiff versions of the state vector.
   VectorX<AutoDiffXd> a_xt = xt;
 
@@ -64,10 +67,11 @@ void ImplicitIntegrator<T>::ComputeAutoDiffJacobian(
 
   *J = math::autoDiffToGradientMatrix(result);
 
-  // Sometimes the system's derivatives f(x) do not depend on its states. In
-  // this case, make sure that the Jacobian isn't a n ✕ 0 matrix (this will
-  // cause a segfault when forming Newton iteration matrices); if it is,
-  // we set it equal to an n x n zero matrix.
+  // Sometimes the system's derivatives f(t, x) do not depend on its states, for
+  // example, when f(t, x) = constant or when f(t, x) depends only on t. In this
+  // case, make sure that the Jacobian isn't a n ✕ 0 matrix (this will cause a
+  // segfault when forming Newton iteration matrices); if it is, we set it equal
+  // to an n x n zero matrix.
   if (J->cols() == 0) {
     *J = MatrixX<T>::Zero(n_state_dim, n_state_dim);
   }

--- a/systems/analysis/test/implicit_euler_integrator_test.cc
+++ b/systems/analysis/test/implicit_euler_integrator_test.cc
@@ -12,13 +12,19 @@ namespace systems {
 namespace analysis_test {
 
 // Tests accuracy for integrating the quadratic system (with the state at time t
-// corresponding to f(t) ≡ 7t² + 7t + C, where C is the initial state) over
+// corresponding to f(t) ≡ 7t² + 7t + f₀, where f₀ is the initial state) over
 // t ∈ [0, 1]. Since the error estimate has a Taylor series that is
 // accurate to O(h²) and since we have no terms beyond this order,
 // halving the step size should improve the error estimate by a factor of 4.
 // Furthermore, we test that the error estimate gives the exact error, with
 // both the correct sign and magnitude.
-GTEST_TEST(ImplicitIntegratorErrorEstimatorTest, QuadraticSystemAccuracy) {
+// Note: this test differs from RadauIntegratorTest::QuadraticTest in that
+// the error estimation for the two-stage Radau integrator is third-order
+// accurate, so that test checks to make sure the error estimate (and error)
+// are zero, while this integrator has a second-order-accurate error estimate,
+// so this test checks to make sure the error estimate is exact (not necessarily
+// zero).
+GTEST_TEST(ImplicitEulerIntegratorTest, QuadraticSystemErrorEstimatorAccuracy) {
   QuadraticScalarSystem quadratic(7);
   auto quadratic_context = quadratic.CreateDefaultContext();
   const double C = quadratic.Evaluate(0);

--- a/systems/analysis/test/implicit_euler_integrator_test.cc
+++ b/systems/analysis/test/implicit_euler_integrator_test.cc
@@ -12,11 +12,11 @@ namespace systems {
 namespace analysis_test {
 
 // Tests accuracy for integrating the quadratic system (with the state at time t
-// corresponding to f(t) ≡ 4t² + 4t + C, where C is the initial state) over
+// corresponding to f(t) ≡ 7t² + 7t + C, where C is the initial state) over
 // t ∈ [0, 1]. Since the error estimate has a Taylor series that is
 // accurate to O(h²) and since we have no terms beyond this order,
 // halving the step size should improve the error estimate by a factor of 4.
-// Furthemore, we test that the error estimate gives the exact error, with
+// Furthermore, we test that the error estimate gives the exact error, with
 // both the correct sign and magnitude.
 GTEST_TEST(ImplicitIntegratorErrorEstimatorTest, QuadraticSystemAccuracy) {
   QuadraticScalarSystem quadratic(7);
@@ -28,11 +28,11 @@ GTEST_TEST(ImplicitIntegratorErrorEstimatorTest, QuadraticSystemAccuracy) {
   ImplicitEulerIntegrator<double> ie(quadratic, quadratic_context.get());
 
   // Ensure that the implicit Euler integrator supports error estimation.
-  ASSERT_EQ(ie.supports_error_estimation(), true);
+  ASSERT_TRUE(ie.supports_error_estimation());
 
   // Per the description in IntegratorBase::get_error_estimate_order(), this
   // should return "2", in accordance with the order of the polynomial in the
-  // Big-Oh term.
+  // Big-O term.
   ASSERT_EQ(ie.get_error_estimate_order(), 2);
 
   const double t_final = 1.5;

--- a/systems/analysis/test/implicit_euler_integrator_test.cc
+++ b/systems/analysis/test/implicit_euler_integrator_test.cc
@@ -5,18 +5,76 @@
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/common/unused.h"
 #include "drake/systems/analysis/test_utilities/implicit_integrator_test.h"
-#include "drake/systems/analysis/test_utilities/linear_scalar_system.h"
-#include "drake/systems/analysis/test_utilities/robertson_system.h"
+#include "drake/systems/analysis/test_utilities/quadratic_scalar_system.h"
 
 namespace drake {
 namespace systems {
 namespace analysis_test {
 
-// Test Euler integrator.
+// Tests accuracy for integrating the quadratic system (with the state at time t
+// corresponding to f(t) ≡ 4t² + 4t + C, where C is the initial state) over
+// t ∈ [0, 1]. Since the error estimate has a Taylor series that is
+// accurate to O(h²) and since we have no terms beyond this order,
+// halving the step size should improve the error estimate by a factor of 4.
+// Furthemore, we test that the error estimate gives the exact error, with
+// both the correct sign and magnitude.
+GTEST_TEST(ImplicitIntegratorErrorEstimatorTest, QuadraticSystemAccuracy) {
+  QuadraticScalarSystem quadratic(7);
+  auto quadratic_context = quadratic.CreateDefaultContext();
+  const double C = quadratic.Evaluate(0);
+  quadratic_context->SetTime(0.0);
+  quadratic_context->get_mutable_continuous_state_vector()[0] = C;
+
+  ImplicitEulerIntegrator<double> ie(quadratic, quadratic_context.get());
+
+  // Ensure that the implicit Euler integrator supports error estimation.
+  ASSERT_EQ(ie.supports_error_estimation(), true);
+
+  // Per the description in IntegratorBase::get_error_estimate_order(), this
+  // should return "2", in accordance with the order of the polynomial in the
+  // Big-Oh term.
+  ASSERT_EQ(ie.get_error_estimate_order(), 2);
+
+  const double t_final = 1.5;
+  ie.set_maximum_step_size(t_final);
+  ie.set_fixed_step_mode(true);
+  ie.Initialize();
+  ASSERT_TRUE(ie.IntegrateWithSingleFixedStepToTime(t_final));
+
+  const double err_est_h = ie.get_error_estimate()->get_vector().GetAtIndex(0);
+  const double expected_answer = quadratic.Evaluate(t_final);
+  const double actual_answer =
+      quadratic_context->get_continuous_state_vector()[0];
+
+  // Verify that the error estimate gets the exact error value. Note the tight
+  // tolerance used.
+  EXPECT_NEAR(err_est_h, actual_answer - expected_answer,
+              10 * std::numeric_limits<double>::epsilon());
+  // Now obtain the error estimate using two half-sized steps of h/2, to verify
+  // the error estimate order.
+  quadratic_context->SetTime(0.0);
+  quadratic_context->get_mutable_continuous_state_vector()[0] = C;
+  ie.Initialize();
+  ASSERT_TRUE(ie.IntegrateWithSingleFixedStepToTime(t_final / 2));
+  ASSERT_TRUE(ie.IntegrateWithSingleFixedStepToTime(t_final));
+
+  const double err_est_2h_2 =
+      ie.get_error_estimate()->get_vector().GetAtIndex(0);
+
+  // Since the error estimate is second order, the estimate from a half-step
+  // should be a quarter the size for a quadratic system.
+  EXPECT_NEAR(err_est_2h_2, 1.0 / 4 * err_est_h,
+              10 * std::numeric_limits<double>::epsilon());
+
+  // Verify the validity of general statistics.
+  ImplicitIntegratorTest<
+      ImplicitEulerIntegrator<double>>::CheckGeneralStatsValidity(&ie);
+}
+
+// Test the implicit Euler integrator.
 typedef ::testing::Types<ImplicitEulerIntegrator<double>> MyTypes;
 INSTANTIATE_TYPED_TEST_SUITE_P(My, ImplicitIntegratorTest, MyTypes);
 
 }  // namespace analysis_test
 }  // namespace systems
 }  // namespace drake
-

--- a/systems/analysis/test/radau_integrator_test.cc
+++ b/systems/analysis/test/radau_integrator_test.cc
@@ -66,9 +66,9 @@ GTEST_TEST(RadauIntegratorTest, CubicSystem) {
 
 // Tests accuracy for integrating the quadratic system (with the state at time t
 // corresponding to f(t) ≡ C₂t² + C₁t + C₀, where C₀ is the initial state) over
-// t ∈ [0, 1]. The error estimate from 2-stage Radau is second order accurate,
+// t ∈ [0, 1]. The error estimate from 2-stage Radau is second-order accurate,
 // meaning that the approximation error will be zero if f'''(t) = 0, which is
-// true for the quadratic equation. We check that the error estimate is perfect
+// true for the quadratic equation. We check that the error estimate is zero
 // for this function.
 GTEST_TEST(RadauIntegratorTest, QuadraticTest) {
   QuadraticScalarSystem quadratic;
@@ -80,6 +80,10 @@ GTEST_TEST(RadauIntegratorTest, QuadraticTest) {
   // Create the integrator.
   const int num_stages = 2;
   RadauIntegrator<double, num_stages> radau(quadratic, quadratic_context.get());
+
+  // Ensure that the Radau3 integrator supports error estimation.
+  EXPECT_EQ(radau.supports_error_estimation(), true);
+
   const double t_final = 1.0;
   radau.set_maximum_step_size(t_final);
   radau.set_fixed_step_mode(true);
@@ -211,6 +215,10 @@ GTEST_TEST(RadauIntegratorTest, Radau1MatchesImplicitEuler) {
   RadauIntegrator<double, num_stages> radau1(spring_damper,
                                              context_radau1.get());
   ImplicitEulerIntegrator<double> ie(spring_damper, context_ie.get());
+
+  // Ensure that both integrators support error estimation.
+  EXPECT_EQ(radau1.supports_error_estimation(), true);
+  EXPECT_EQ(radau1.supports_error_estimation(), ie.supports_error_estimation());
 
   // Set maximum step sizes that are reasonable for this system.
   radau1.set_maximum_step_size(1e-2);

--- a/systems/analysis/test/radau_integrator_test.cc
+++ b/systems/analysis/test/radau_integrator_test.cc
@@ -66,10 +66,17 @@ GTEST_TEST(RadauIntegratorTest, CubicSystem) {
 
 // Tests accuracy for integrating the quadratic system (with the state at time t
 // corresponding to f(t) ≡ C₂t² + C₁t + C₀, where C₀ is the initial state) over
-// t ∈ [0, 1]. The error estimate from 2-stage Radau is second-order accurate,
+// t ∈ [0, 1]. The error estimate from 2-stage Radau is third-order accurate,
 // meaning that the approximation error will be zero if f'''(t) = 0, which is
 // true for the quadratic equation. We check that the error estimate is zero
 // for this function.
+// Note: this test differs from [Velocity]ImplicitEulerIntegratorTest::
+// QuadraticSystemErrorEstimatorAccuracy in that the error estimation for the
+// two-stage Radau integrator is third-order accurate, so this test checks to
+// make sure the error estimate (and error) are zero, while both the implicit
+// Euler and the velocity-implicit Euler integrators have a second-order-
+// accurate error estimate, so their tests check to make sure the error
+// estimate is exact (not necessarily zero).
 GTEST_TEST(RadauIntegratorTest, QuadraticTest) {
   QuadraticScalarSystem quadratic;
   auto quadratic_context = quadratic.CreateDefaultContext();

--- a/systems/analysis/test/radau_integrator_test.cc
+++ b/systems/analysis/test/radau_integrator_test.cc
@@ -82,7 +82,7 @@ GTEST_TEST(RadauIntegratorTest, QuadraticTest) {
   RadauIntegrator<double, num_stages> radau(quadratic, quadratic_context.get());
 
   // Ensure that the Radau3 integrator supports error estimation.
-  EXPECT_EQ(radau.supports_error_estimation(), true);
+  EXPECT_TRUE(radau.supports_error_estimation());
 
   const double t_final = 1.0;
   radau.set_maximum_step_size(t_final);
@@ -217,8 +217,8 @@ GTEST_TEST(RadauIntegratorTest, Radau1MatchesImplicitEuler) {
   ImplicitEulerIntegrator<double> ie(spring_damper, context_ie.get());
 
   // Ensure that both integrators support error estimation.
-  EXPECT_EQ(radau1.supports_error_estimation(), true);
-  EXPECT_EQ(radau1.supports_error_estimation(), ie.supports_error_estimation());
+  EXPECT_TRUE(radau1.supports_error_estimation());
+  EXPECT_TRUE(ie.supports_error_estimation());
 
   // Set maximum step sizes that are reasonable for this system.
   radau1.set_maximum_step_size(1e-2);

--- a/systems/analysis/test/velocity_implicit_euler_integrator_test.cc
+++ b/systems/analysis/test/velocity_implicit_euler_integrator_test.cc
@@ -10,11 +10,11 @@ namespace systems {
 namespace analysis_test {
 
 // Tests accuracy for integrating the quadratic system (with the state at time t
-// corresponding to f(t) ≡ 4t² + 4t + C, where C is the initial state) over
+// corresponding to f(t) ≡ 7t² + 7t + C, where C is the initial state) over
 // t ∈ [0, 1]. Since the error estimate has a Taylor series that is
 // accurate to O(h²) and since we have no terms beyond this order,
 // halving the step size should improve the error estimate by a factor of 4.
-// Furthemore, we test that the error estimate gives the exact error, with
+// Furthermore, we test that the error estimate gives the exact error, with
 // both the correct sign and magnitude.
 GTEST_TEST(VelocityImplicitIntegratorErrorEstimatorTest,
            QuadraticSystemAccuracy) {
@@ -29,11 +29,11 @@ GTEST_TEST(VelocityImplicitIntegratorErrorEstimatorTest,
 
   // Ensure that the velocity-implicit Euler integrator supports error
   // estimation.
-  ASSERT_EQ(vie.supports_error_estimation(), true);
+  ASSERT_TRUE(vie.supports_error_estimation());
 
   // Per the description in IntegratorBase::get_error_estimate_order(), this
   // should return "2", in accordance with the order of the polynomial in the
-  // Big-Oh term.
+  // Big-O term.
   ASSERT_EQ(vie.get_error_estimate_order(), 2);
 
   const double t_final = 1.5;

--- a/systems/analysis/test/velocity_implicit_euler_integrator_test.cc
+++ b/systems/analysis/test/velocity_implicit_euler_integrator_test.cc
@@ -10,14 +10,20 @@ namespace systems {
 namespace analysis_test {
 
 // Tests accuracy for integrating the quadratic system (with the state at time t
-// corresponding to f(t) ≡ 7t² + 7t + C, where C is the initial state) over
+// corresponding to f(t) ≡ 7t² + 7t + f₀, where f₀ is the initial state) over
 // t ∈ [0, 1]. Since the error estimate has a Taylor series that is
 // accurate to O(h²) and since we have no terms beyond this order,
 // halving the step size should improve the error estimate by a factor of 4.
 // Furthermore, we test that the error estimate gives the exact error, with
 // both the correct sign and magnitude.
-GTEST_TEST(VelocityImplicitIntegratorErrorEstimatorTest,
-           QuadraticSystemAccuracy) {
+// Note: this test differs from RadauIntegratorTest::QuadraticTest in that
+// the error estimation for the two-stage Radau integrator is third-order
+// accurate, so that test checks to make sure the error estimate (and error)
+// are zero, while this integrator has a second-order-accurate error estimate,
+// so this test checks to make sure the error estimate is exact (not necessarily
+// zero).
+GTEST_TEST(VelocityImplicitEulerIntegratorTest,
+           QuadraticSystemErrorEstimatorAccuracy) {
   QuadraticScalarSystem quadratic(7);
   auto quadratic_context = quadratic.CreateDefaultContext();
   const double C = quadratic.Evaluate(0);

--- a/systems/analysis/test/velocity_implicit_euler_integrator_test.cc
+++ b/systems/analysis/test/velocity_implicit_euler_integrator_test.cc
@@ -3,10 +3,77 @@
 #include <gtest/gtest.h>
 
 #include "drake/systems/analysis/test_utilities/implicit_integrator_test.h"
+#include "drake/systems/analysis/test_utilities/quadratic_scalar_system.h"
 
 namespace drake {
 namespace systems {
 namespace analysis_test {
+
+// Tests accuracy for integrating the quadratic system (with the state at time t
+// corresponding to f(t) ≡ 4t² + 4t + C, where C is the initial state) over
+// t ∈ [0, 1]. Since the error estimate has a Taylor series that is
+// accurate to O(h²) and since we have no terms beyond this order,
+// halving the step size should improve the error estimate by a factor of 4.
+// Furthemore, we test that the error estimate gives the exact error, with
+// both the correct sign and magnitude.
+GTEST_TEST(VelocityImplicitIntegratorErrorEstimatorTest,
+           QuadraticSystemAccuracy) {
+  QuadraticScalarSystem quadratic(7);
+  auto quadratic_context = quadratic.CreateDefaultContext();
+  const double C = quadratic.Evaluate(0);
+  quadratic_context->SetTime(0.0);
+  quadratic_context->get_mutable_continuous_state_vector()[0] = C;
+
+  VelocityImplicitEulerIntegrator<double> vie(quadratic,
+                                              quadratic_context.get());
+
+  // Ensure that the velocity-implicit Euler integrator supports error
+  // estimation.
+  ASSERT_EQ(vie.supports_error_estimation(), true);
+
+  // Per the description in IntegratorBase::get_error_estimate_order(), this
+  // should return "2", in accordance with the order of the polynomial in the
+  // Big-Oh term.
+  ASSERT_EQ(vie.get_error_estimate_order(), 2);
+
+  const double t_final = 1.5;
+  vie.set_maximum_step_size(t_final);
+  vie.set_fixed_step_mode(true);
+  vie.Initialize();
+  ASSERT_TRUE(vie.IntegrateWithSingleFixedStepToTime(t_final));
+
+  const double err_est_h = vie.get_error_estimate()->get_vector().GetAtIndex(0);
+  const double expected_answer = quadratic.Evaluate(t_final);
+  const double actual_answer =
+      quadratic_context->get_continuous_state_vector()[0];
+
+  // Verify that the error estimate gets the exact error value. Note the tight
+  // tolerance used.
+  EXPECT_NEAR(err_est_h, actual_answer - expected_answer,
+              10 * std::numeric_limits<double>::epsilon());
+
+  // Now obtain the error estimate corresponding to two half-sized "steps" of
+  // size h/2, to verify the error estimate order. To clarify, this means that
+  // the velocity-implicit Euler integrator would take four small steps and two
+  // large steps here.
+  quadratic_context->SetTime(0.0);
+  quadratic_context->get_mutable_continuous_state_vector()[0] = C;
+  vie.Initialize();
+  ASSERT_TRUE(vie.IntegrateWithSingleFixedStepToTime(t_final / 2));
+  ASSERT_TRUE(vie.IntegrateWithSingleFixedStepToTime(t_final));
+
+  const double err_est_2h_2 =
+      vie.get_error_estimate()->get_vector().GetAtIndex(0);
+
+  // Since the error estimate is second order, the estimate from half-steps
+  // should be a quarter the size for a quadratic system.
+  EXPECT_NEAR(err_est_2h_2, 1.0 / 4 * err_est_h,
+              10 * std::numeric_limits<double>::epsilon());
+
+  // Verify the validity of general statistics.
+  ImplicitIntegratorTest<
+      VelocityImplicitEulerIntegrator<double>>::CheckGeneralStatsValidity(&vie);
+}
 
 // Test Velocity-Implicit Euler integrator on common implicit tests.
 typedef ::testing::Types<VelocityImplicitEulerIntegrator<double>> MyTypes;

--- a/systems/analysis/test_utilities/BUILD.bazel
+++ b/systems/analysis/test_utilities/BUILD.bazel
@@ -195,8 +195,10 @@ drake_cc_library(
 drake_cc_library(
     name = "stationary_system",
     testonly = 1,
+    srcs = ["stationary_system.cc"],
     hdrs = ["stationary_system.h"],
     deps = [
+        "//common:default_scalars",
         "//systems/framework",
     ],
 )

--- a/systems/analysis/test_utilities/implicit_integrator_test.h
+++ b/systems/analysis/test_utilities/implicit_integrator_test.h
@@ -917,12 +917,11 @@ TYPED_TEST_P(ImplicitIntegratorTest, Stationary) {
   using Integrator = TypeParam;
   Integrator integrator(*stationary, context.get());
 
+  integrator.set_maximum_step_size(1.0);
+
   if (integrator.supports_error_estimation()) {
-    integrator.set_maximum_step_size(1.0);
     integrator.set_target_accuracy(1e-3);
-    integrator.request_initial_step_size_target(1e-4);
-  } else {
-    integrator.set_maximum_step_size(1e-1);
+    integrator.request_initial_step_size_target(1e-3);
   }
 
   // Integrate the system
@@ -949,13 +948,13 @@ TYPED_TEST_P(ImplicitIntegratorTest, Stationary) {
     new_state.SetAtIndex(0, 0.0);
     new_state.SetAtIndex(1, 0.0);
 
+    integrator.set_maximum_step_size(1.0);
+
     if (integrator.supports_error_estimation()) {
-      integrator.set_maximum_step_size(1.0);
       integrator.set_target_accuracy(1e-3);
-      integrator.request_initial_step_size_target(1e-4);
-    } else {
-      integrator.set_maximum_step_size(1e-1);
+      integrator.request_initial_step_size_target(1e-3);
     }
+
     // Initialize the integrator to discard the cached Jacobian.
     integrator.Initialize();
 

--- a/systems/analysis/test_utilities/implicit_integrator_test.h
+++ b/systems/analysis/test_utilities/implicit_integrator_test.h
@@ -955,7 +955,14 @@ TYPED_TEST_P(ImplicitIntegratorTest, Stationary) {
       integrator.request_initial_step_size_target(1e-3);
     }
 
-    // Initialize the integrator to discard the cached Jacobian.
+    // Initialize to reset cached Jacobians. This is necessary; otherwise, for
+    // some problems, the Jacobian may not be computed again because the
+    // previous one was good enough for Newton-Raphson to converge.
+    // TODO(antequ): This issue only exists for velocity-implicit Euler
+    // integrator; other implicit integrators reset their Jacobians in
+    // set_jacobian_computation_scheme(). Clear the velocity-implicit Euler
+    // integrator's Jacobian cache too in set_jacobian_computation_scheme(),
+    // and remove this call. See issue #13069.
     integrator.Initialize();
 
     // Integrate the system

--- a/systems/analysis/test_utilities/stationary_system.cc
+++ b/systems/analysis/test_utilities/stationary_system.cc
@@ -1,5 +1,31 @@
 #include "drake/systems/analysis/test_utilities/stationary_system.h"
 
+#include "drake/systems/framework/context.h"
+#include "drake/systems/framework/continuous_state.h"
+#include "drake/systems/framework/leaf_system.h"
+#include "drake/systems/framework/system_type_tag.h"
+
+namespace drake {
+namespace systems {
+namespace analysis_test {
+
+template <class T>
+StationarySystem<T>::StationarySystem()
+    : LeafSystem<T>(SystemTypeTag<StationarySystem>{}) {
+  this->DeclareContinuousState(1 /* num q */, 1 /* num v */, 0 /* num z */);
+}
+
+template <class T>
+void StationarySystem<T>::DoCalcTimeDerivatives(
+    const Context<T>&, ContinuousState<T>* derivatives) const {
+  // State does not evolve.
+  derivatives->get_mutable_vector().SetAtIndex(0, T(0.0));
+  derivatives->get_mutable_vector().SetAtIndex(1, T(0.0));
+}
+
+}  // namespace analysis_test
+}  // namespace systems
+}  // namespace drake
+
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class drake::systems::analysis_test::StationarySystem)
-

--- a/systems/analysis/test_utilities/stationary_system.cc
+++ b/systems/analysis/test_utilities/stationary_system.cc
@@ -1,0 +1,5 @@
+#include "drake/systems/analysis/test_utilities/stationary_system.h"
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class drake::systems::analysis_test::StationarySystem)
+

--- a/systems/analysis/test_utilities/stationary_system.h
+++ b/systems/analysis/test_utilities/stationary_system.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "drake/common/default_scalars.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/leaf_system.h"
 
@@ -9,24 +10,32 @@ namespace analysis_test {
 
 /// System with no state evolution for testing numerical differencing in
 /// integrators that use it.
-class StationarySystem final : public LeafSystem<double> {
+/// @tparam_default_scalar
+template <typename T>
+class StationarySystem final : public LeafSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(StationarySystem)
 
-  StationarySystem() : LeafSystem<double>() {
+  StationarySystem() : LeafSystem<T>(SystemTypeTag<StationarySystem>{}) {
     this->DeclareContinuousState(1 /* num q */, 1 /* num v */, 0 /* num z */);
   }
 
+  /// Scalar-converting copy constructor.  See @ref system_scalar_conversion.
+  template <typename U>
+  explicit StationarySystem(const StationarySystem<U>&) : StationarySystem() {}
+
  protected:
-  void DoCalcTimeDerivatives(
-      const Context<double>& context,
-      ContinuousState<double>* derivatives) const override {
+  void DoCalcTimeDerivatives(const Context<T>&,
+                             ContinuousState<T>* derivatives) const override {
     // State does not evolve.
-    derivatives->get_mutable_vector().SetAtIndex(0, 0.0);
-    derivatives->get_mutable_vector().SetAtIndex(1, 0.0);
+    derivatives->get_mutable_vector().SetAtIndex(0, T(0.0));
+    derivatives->get_mutable_vector().SetAtIndex(1, T(0.0));
   }
 };
 
 }  // namespace analysis_test
 }  // namespace systems
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class drake::systems::analysis_test::StationarySystem)

--- a/systems/analysis/test_utilities/stationary_system.h
+++ b/systems/analysis/test_utilities/stationary_system.h
@@ -2,6 +2,7 @@
 
 #include "drake/common/default_scalars.h"
 #include "drake/systems/framework/context.h"
+#include "drake/systems/framework/continuous_state.h"
 #include "drake/systems/framework/leaf_system.h"
 
 namespace drake {
@@ -16,9 +17,7 @@ class StationarySystem final : public LeafSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(StationarySystem)
 
-  StationarySystem() : LeafSystem<T>(SystemTypeTag<StationarySystem>{}) {
-    this->DeclareContinuousState(1 /* num q */, 1 /* num v */, 0 /* num z */);
-  }
+  StationarySystem();
 
   /// Scalar-converting copy constructor.  See @ref system_scalar_conversion.
   template <typename U>
@@ -26,11 +25,7 @@ class StationarySystem final : public LeafSystem<T> {
 
  protected:
   void DoCalcTimeDerivatives(const Context<T>&,
-                             ContinuousState<T>* derivatives) const override {
-    // State does not evolve.
-    derivatives->get_mutable_vector().SetAtIndex(0, T(0.0));
-    derivatives->get_mutable_vector().SetAtIndex(1, T(0.0));
-  }
+                             ContinuousState<T>* derivatives) const override;
 };
 
 }  // namespace analysis_test


### PR DESCRIPTION
This commit:
1. Adds a QuadraticSystemAccuracy test to verify that the implicit Euler and velocity-implicit Euler integrators have second-order error estimation (by halving the step size and comparing the error estimate) and that they achieve the exact right error on a quadratic system.
2. Adds a few lines to verify that the implicit integrators support error estimation.
3. Tests the StationarySystem with an Autodiff'd Jacobian Computation scheme, to make sure AutoDiff Jacobians function properly when the derivative does not depend on the state.
4. Fixes a bug in the AutoDiff Jacobian Computation where if the derivative does not depend on the state, implicit integrators segfault because the iteration matrix adds a Jacobian matrix with 0 width to an identity square matrix.

Also tagging #12528 as well as @sherm1 and @amcastro-tri

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12996)
<!-- Reviewable:end -->
