### PR TITLE
fix math::jacobian() segfault when evaluated on constant AutoDiffXd function

### DIFF
--- a/attic/multibody/test/rigid_body_tree/rigid_body_tree_dynamics_test.cc
+++ b/attic/multibody/test/rigid_body_tree/rigid_body_tree_dynamics_test.cc
@@ -108,7 +108,7 @@ TEST_F(RigidBodyTreeInverseDynamicsTest, TestSkewSymmetryProperty) {
   auto qd_to_coriolis_term = [&](const auto& qd_arg) {
     const auto& q_autodiff = q.cast<AutoDiffXd>().eval();
     const auto& qdd_autodiff = qdd.cast<AutoDiffXd>().eval();
-    const auto& qd_arg_dynamic = qd_arg;
+    const auto& qd_arg_dynamic = qd_arg.template cast<AutoDiffXd>().eval();
 
     auto kinematics_cache_coriolis =
         tree_rpy_->CreateKinematicsCacheWithType<AutoDiffXd>();
@@ -159,7 +159,7 @@ TEST_F(RigidBodyTreeInverseDynamicsTest, TestAccelerationJacobianIsMassMatrix) {
     auto vd_to_mass_matrix = [&](const auto& vd_arg) {
       const auto& q_autodiff = q.cast<AutoDiffXd>().eval();
       const auto& v_autodiff = v.cast<AutoDiffXd>().eval();
-      const auto& vd_arg_dynamic = vd_arg;
+      const auto& vd_arg_dynamic = vd_arg.template cast<AutoDiffXd>().eval();
 
       auto cache_xd = tree->CreateKinematicsCacheWithType<AutoDiffXd>();
       cache_xd.initialize(q_autodiff, v_autodiff);
@@ -213,7 +213,7 @@ TEST_F(RigidBodyTreeInverseDynamicsTest, TestGeneralizedGravitationalForces) {
   auto q_to_gravitational_potential_energy = [&](const auto& q_arg) {
     const auto& gravitational_force_autodiff =
         gravitational_force.cast<AutoDiffXd>().eval();
-    const auto& q_arg_dynamic = q_arg;
+    const auto& q_arg_dynamic = q_arg.template cast<AutoDiffXd>().eval();
 
     auto cache_autodiff = tree->CreateKinematicsCacheWithType<AutoDiffXd>();
     cache_autodiff.initialize(q_arg_dynamic);

--- a/attic/multibody/test/rigid_body_tree/rigid_body_tree_dynamics_test.cc
+++ b/attic/multibody/test/rigid_body_tree/rigid_body_tree_dynamics_test.cc
@@ -108,7 +108,7 @@ TEST_F(RigidBodyTreeInverseDynamicsTest, TestSkewSymmetryProperty) {
   auto qd_to_coriolis_term = [&](const auto& qd_arg) {
     const auto& q_autodiff = q.cast<AutoDiffXd>().eval();
     const auto& qdd_autodiff = qdd.cast<AutoDiffXd>().eval();
-    const auto& qd_arg_dynamic = qd_arg.template cast<AutoDiffXd>().eval();
+    const auto& qd_arg_dynamic = qd_arg;
 
     auto kinematics_cache_coriolis =
         tree_rpy_->CreateKinematicsCacheWithType<AutoDiffXd>();
@@ -159,7 +159,7 @@ TEST_F(RigidBodyTreeInverseDynamicsTest, TestAccelerationJacobianIsMassMatrix) {
     auto vd_to_mass_matrix = [&](const auto& vd_arg) {
       const auto& q_autodiff = q.cast<AutoDiffXd>().eval();
       const auto& v_autodiff = v.cast<AutoDiffXd>().eval();
-      const auto& vd_arg_dynamic = vd_arg.template cast<AutoDiffXd>().eval();
+      const auto& vd_arg_dynamic = vd_arg;
 
       auto cache_xd = tree->CreateKinematicsCacheWithType<AutoDiffXd>();
       cache_xd.initialize(q_autodiff, v_autodiff);
@@ -213,7 +213,7 @@ TEST_F(RigidBodyTreeInverseDynamicsTest, TestGeneralizedGravitationalForces) {
   auto q_to_gravitational_potential_energy = [&](const auto& q_arg) {
     const auto& gravitational_force_autodiff =
         gravitational_force.cast<AutoDiffXd>().eval();
-    const auto& q_arg_dynamic = q_arg.template cast<AutoDiffXd>().eval();
+    const auto& q_arg_dynamic = q_arg;
 
     auto cache_autodiff = tree->CreateKinematicsCacheWithType<AutoDiffXd>();
     cache_autodiff.initialize(q_arg_dynamic);

--- a/math/jacobian.h
+++ b/math/jacobian.h
@@ -141,7 +141,7 @@ decltype(auto) jacobian(F &&f, Arg &&x) {
       if (j_limit < chunk_size) {
         ret(i)
             .derivatives()
-            .segment(deriv_num_start + j_limit, deriv_num_start + chunk_size)
+            .segment(deriv_num_start + j_limit, chunk_size - j_limit)
             .setZero();
       }
     }

--- a/math/jacobian.h
+++ b/math/jacobian.h
@@ -65,7 +65,8 @@ decltype(auto) jacobian(F &&f, Arg &&x) {
   using ArgScalar = typename ArgNoRef::Scalar;
 
   // Argument scalar type corresponding to return value of this function.
-  using ReturnArgDerType = VectorX<ArgScalar>;
+  using ReturnArgDerType = Matrix<ArgScalar, ArgNoRef::SizeAtCompileTime, 1, 0,
+                                  ArgNoRef::MaxSizeAtCompileTime, 1>;
   using ReturnArgAutoDiffScalar = AutoDiffScalar<ReturnArgDerType>;
 
   // Return type of this function.
@@ -74,7 +75,8 @@ decltype(auto) jacobian(F &&f, Arg &&x) {
   using ReturnType = decltype(f(std::declval<ReturnArgAutoDiffType>()));
 
   // Scalar type of chunk arguments.
-  using ChunkArgDerType = VectorX<ArgScalar>;
+  using ChunkArgDerType =
+      Matrix<ArgScalar, Eigen::Dynamic, 1, 0, MaxChunkSize, 1>;
   using ChunkArgAutoDiffScalar = AutoDiffScalar<ChunkArgDerType>;
 
   // Allocate output.

--- a/math/test/jacobian_test.cc
+++ b/math/test/jacobian_test.cc
@@ -33,7 +33,7 @@ TEST_F(AutodiffJacobianTest, ConstantFunction) {
   using Eigen::Vector3d;
   Vector3d constant = {-2.5, 1.25, 5.0};
 
-  auto constant_func = [&](const auto& in) {
+  auto constant_func = [&](const auto&) {
     return constant.cast<AutoDiffXd>().eval();
   };
 

--- a/math/test/jacobian_test.cc
+++ b/math/test/jacobian_test.cc
@@ -25,15 +25,13 @@ void FillWithNumbersIncreasingFromZero(Eigen::MatrixBase<Derived>& matrix) {
 
 class AutodiffJacobianTest : public ::testing::Test {};
 
-// This test ensures that math::jacobian() does not segfault on a constant
-// function. In the older math::jacobian() implementation, math::jacobian()
-// segfaults on a constant function when the return type uses scalar type
-// AutoDiffXd, because the derivative size of each chunk result is 0, and
-// indexing into the derivative will segfault.
+// This test ensures that math::jacobian() works properly on a constant
+// function when the return type uses scalar type AutoDiffXd. This function
+// is notable because the derivative size of each chunk result is 0.
 TEST_F(AutodiffJacobianTest, ConstantFunction) {
   using Eigen::Matrix3d;
   using Eigen::Vector3d;
-  Vector3d constant = Vector3d::Zero();
+  Vector3d constant = {-2.5, 1.25, 5.0};
 
   auto constant_func = [&](const auto& in) {
     return constant.cast<AutoDiffXd>().eval();
@@ -46,14 +44,12 @@ TEST_F(AutodiffJacobianTest, ConstantFunction) {
   // Ensure that value is correct.
   auto value_expected = constant_func(x);
   auto value = autoDiffToValueMatrix(jac);
-  EXPECT_TRUE(CompareMatrices(value_expected, value, 1e-12,
-                              MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(value_expected, value));
 
   // Ensure that Jacobian is correct.
   auto jac_matrix = autoDiffToGradientMatrix(jac);
   auto jac_expected = Matrix3d::Zero();
-  EXPECT_TRUE(CompareMatrices(jac_expected, jac_matrix, 1e-12,
-                              MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(jac_expected, jac_matrix));
 }
 
 TEST_F(AutodiffJacobianTest, QuadraticForm) {


### PR DESCRIPTION
Fix math::jacobian() segfault when evaluated on constant AutoDiffXd function

When math::jacobian() is ran on an f(x) with a return scalar type of AutoDiffXd, it will segfault if f(x) does not depend on x. This is because the derivative of the result has size 0, while math::jacobian() tries to index into the f(x) result derivative vector to set its final vector.

This commit:
1. Adds a test into jacobian_test.cc to reproduce this bug, which creates a constant f(x) = 0 of scalar type AutoDiffXd for it to differentiate.
2. Fixes this issue by having the inner for loop stop early, and setting the rest of the derivative vector to 0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/12999)
<!-- Reviewable:end -->
