### PR TITLE
integrators: replace DenseOutput with PiecewiseTrajectory

### DIFF
--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -145,10 +145,8 @@ drake_cc_library(
     srcs = ["integrator_base.cc"],
     hdrs = ["integrator_base.h"],
     deps = [
-        ":dense_output",
-        ":hermitian_dense_output",
-        ":stepwise_dense_output",
         "//common:default_scalars",
+        "//common/trajectories:piecewise_polynomial",
         "//systems/framework:context",
         "//systems/framework:system",
     ],
@@ -299,6 +297,7 @@ drake_cc_library(
     ],
     deps = [
         ":dense_output",
+        ":hermitian_dense_output",
         ":integrator_base",
         ":runge_kutta3_integrator",
         "//common:default_scalars",

--- a/systems/analysis/initial_value_problem.cc
+++ b/systems/analysis/initial_value_problem.cc
@@ -2,6 +2,7 @@
 
 #include <stdexcept>
 
+#include "drake/systems/analysis/hermitian_dense_output.h"
 #include "drake/systems/analysis/runge_kutta3_integrator.h"
 #include "drake/systems/framework/continuous_state.h"
 #include "drake/systems/framework/leaf_system.h"
@@ -255,7 +256,10 @@ std::unique_ptr<DenseOutput<T>> InitialValueProblem<T>::DenseSolve(
 
   // Stops dense integration to prevent future updates to
   // the dense output just built and yields it to the caller.
-  return integrator_->StopDenseIntegration();
+  const std::unique_ptr<trajectories::PiecewisePolynomial<T>> traj =
+      integrator_->StopDenseIntegration();
+
+  return std::make_unique<HermitianDenseOutput<T>>(*traj);
 }
 
 }  // namespace systems

--- a/systems/analysis/integrator_base.cc
+++ b/systems/analysis/integrator_base.cc
@@ -126,7 +126,7 @@ bool IntegratorBase<T>::StepOnceErrorControlledAtMost(const T& h_max) {
       if (get_dense_output()) {
         // Take dense output one step back to undo
         // the last integration step.
-        get_mutable_dense_output()->Rollback();
+        dense_output_->RemoveFinalSegment();
       }
     }
   } while (!step_succeeded);
@@ -436,11 +436,6 @@ typename IntegratorBase<T>::StepResult
     }
   } else {
     full_step = StepOnceErrorControlledAtMost(h);
-  }
-  if (get_dense_output()) {
-    // Consolidates current dense output, merging the step
-    // taken into its internal representation.
-    get_mutable_dense_output()->Consolidate();
   }
 
   // Update generic statistics.

--- a/systems/analysis/test/runge_kutta2_integrator_test.cc
+++ b/systems/analysis/test/runge_kutta2_integrator_test.cc
@@ -135,7 +135,7 @@ GTEST_TEST(IntegratorTest, SpringMassStep) {
   EXPECT_NEAR(x_final_true, x_final, xtol);
 
   // Reclaim dense output and prevent further updates to it.
-  std::unique_ptr<DenseOutput<double>> dense_output =
+  std::unique_ptr<trajectories::PiecewisePolynomial<double>> dense_output =
       integrator.StopDenseIntegration();
 
   // Verify that the built dense output is valid.
@@ -143,7 +143,7 @@ GTEST_TEST(IntegratorTest, SpringMassStep) {
     double x_true, unused_v_true;
     spring_mass.GetClosedFormSolution(initial_position, initial_velocity,
                                       t, &x_true, &unused_v_true);
-    const VectorX<double> x = dense_output->Evaluate(t);
+    const VectorX<double> x = dense_output->value(t);
     EXPECT_NEAR(x_true, x(0), xtol);
   }
 

--- a/systems/analysis/test_utilities/generic_integrator_test.h
+++ b/systems/analysis/test_utilities/generic_integrator_test.h
@@ -82,14 +82,14 @@ TYPED_TEST_P(GenericIntegratorTest, DenseOutput) {
 
     // Check solution.
     EXPECT_TRUE(CompareMatrices(
-        this->integrator_->get_dense_output()->Evaluate(
+        this->integrator_->get_dense_output()->value(
             this->context_->get_time()),
         this->plant_->GetPositionsAndVelocities(*this->context_),
         this->integrator_->get_accuracy_in_use(), MatrixCompareType::relative));
   }
 
   // Stop undergoing dense integration.
-  std::unique_ptr<systems::DenseOutput<double>> dense_output =
+  std::unique_ptr<trajectories::PiecewisePolynomial<double>> dense_output =
       this->integrator_->StopDenseIntegration();
   EXPECT_FALSE(this->integrator_->get_dense_output());
 


### PR DESCRIPTION
This breaks an API (without deprecation) by changing the return type of `IntegratorBase::StopDenseIntegration` and `IntegratorBase::get_mutable_dense_output` to be a `PiecewiseTrajectory`.  After dicussion with @sammy-tri, we decided that this API was officially deep and obscure to warrant this change.  `InitialValueProblem` was the only known consumer of this method (in general, we do not have workflows that would work with the `Integrator` directly, and these APIs were not exposed through `Simulator`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13008)
<!-- Reviewable:end -->
