### PR TITLE
analysis: Add simulator_flags helper

### DIFF
--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -15,7 +15,9 @@ from pydrake.examples.pendulum import PendulumPlant
 from pydrake.examples.rimless_wheel import RimlessWheel
 from pydrake.symbolic import Expression
 from pydrake.systems.analysis import (
+    GetIntegrationSchemes,
     IntegratorBase, IntegratorBase_,
+    ResetIntegratorFromFlags,
     RungeKutta2Integrator, RungeKutta3Integrator,
     SimulatorStatus, Simulator, Simulator_,
     )
@@ -525,6 +527,17 @@ class TestGeneral(unittest.TestCase):
         with catch_drake_warnings(expected_count=1):
             # TODO(12873) We need an API for this that isn't deprecated.
             simulator.reset_integrator(rk3)
+
+    def test_simulator_flags(self):
+        system = ConstantVectorSource([1])
+        simulator = Simulator(system)
+
+        ResetIntegratorFromFlags(simulator, "runge_kutta2", 0.00123)
+        integrator = simulator.get_integrator()
+        self.assertEqual(type(integrator), RungeKutta2Integrator)
+        self.assertEqual(integrator.get_maximum_step_size(), 0.00123)
+
+        self.assertGreater(len(GetIntegrationSchemes()), 5)
 
     def test_abstract_output_port_eval(self):
         model_value = AbstractValue.Make("Hello World")

--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -34,10 +34,31 @@ drake_cc_package_library(
         ":scalar_view_dense_output",
         ":semi_explicit_euler_integrator",
         ":simulator",
+        ":simulator_flags",
         ":simulator_print_stats",
         ":simulator_status",
         ":stepwise_dense_output",
         ":velocity_implicit_euler_integrator",
+    ],
+)
+
+drake_cc_library(
+    name = "simulator_flags",
+    srcs = ["simulator_flags.cc"],
+    hdrs = ["simulator_flags.h"],
+    deps = [
+        ":bogacki_shampine3_integrator",
+        ":explicit_euler_integrator",
+        ":implicit_euler_integrator",
+        ":radau_integrator",
+        ":runge_kutta2_integrator",
+        ":runge_kutta3_integrator",
+        ":runge_kutta5_integrator",
+        ":semi_explicit_euler_integrator",
+        ":simulator",
+        ":velocity_implicit_euler_integrator",
+        "//common:essential",
+        "//common:nice_type_name",
     ],
 )
 
@@ -55,17 +76,7 @@ drake_cc_library(
     ],
     visibility = ["//:__subpackages__"],
     deps = [
-        ":bogacki_shampine3_integrator",
-        ":explicit_euler_integrator",
-        ":implicit_euler_integrator",
-        ":radau_integrator",
-        ":runge_kutta2_integrator",
-        ":runge_kutta3_integrator",
-        ":runge_kutta5_integrator",
-        ":semi_explicit_euler_integrator",
-        ":simulator",
-        ":velocity_implicit_euler_integrator",
-        "//common:essential",
+        ":simulator_flags",
         "@gflags",
     ],
 )
@@ -381,6 +392,16 @@ drake_cc_library(
 )
 
 # === test/ ===
+
+drake_cc_googletest(
+    name = "simulator_flags_test",
+    deps = [
+        ":simulator",
+        ":simulator_flags",
+        "//common:nice_type_name",
+        "//systems/primitives:constant_vector_source",
+    ],
+)
 
 drake_cc_googletest(
     name = "simulator_status_test",

--- a/systems/analysis/integrator_base.h
+++ b/systems/analysis/integrator_base.h
@@ -114,6 +114,9 @@ namespace systems {
  (t₀, x₀). Thus, integrators advance the continuous state of a dynamical
  system forward in time.
 
+ Drake's subclasses of IntegratorBase<T> should follow the naming pattern
+ `FooIntegrator<T>` by convention.
+
  @tparam_default_scalar
  @ingroup integrators
  */

--- a/systems/analysis/radau_integrator.h
+++ b/systems/analysis/radau_integrator.h
@@ -53,6 +53,8 @@ namespace systems {
  *
  * @see ImplicitIntegrator class documentation for information about implicit
  *      integration methods in general.
+ * @see Radau3Integrator and Radau1Integrator alises for third- and first-order
+ *      templates with num_stages already specified.
  * @note This integrator uses the integrator accuracy setting, even when run
  *       in fixed-step mode, to limit the error in the underlying Newton-Raphson
  *       process. See IntegratorBase::set_target_accuracy() for more info.
@@ -215,6 +217,18 @@ class RadauIntegrator final : public ImplicitIntegrator<T> {
   int64_t num_err_est_function_evaluations_{0};
   int64_t num_err_est_nr_iterations_{0};
 };
+
+/** A third-order fully implicit integrator with error estimation.
+See RadauIntegrator with `num_stages == 2` for details.
+@tparam_nonsymbolic_scalar */
+template <typename T>
+using Radau3Integrator = RadauIntegrator<T, 2>;
+
+/** A first-order fully implicit integrator with error estimation.
+See RadauIntegrator with `num_stages == 1` for details.
+@tparam_nonsymbolic_scalar */
+template <typename T>
+using Radau1Integrator = RadauIntegrator<T, 1>;
 
 }  // namespace systems
 }  // namespace drake

--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -586,7 +586,7 @@ class Simulator {
 
   template <class U>
   DRAKE_DEPRECATED(
-      "2020-05-01",
+      "2020-08-01",
       "Use void or max-step-size version of reset_integrator() instead.")
   U* reset_integrator(std::unique_ptr<U> integrator) {
     if (!integrator)

--- a/systems/analysis/simulator_flags.cc
+++ b/systems/analysis/simulator_flags.cc
@@ -1,0 +1,164 @@
+#include "drake/systems/analysis/simulator_flags.h"
+
+#include <cctype>
+#include <initializer_list>
+#include <stdexcept>
+#include <utility>
+
+#include "drake/common/drake_throw.h"
+#include "drake/common/never_destroyed.h"
+#include "drake/common/nice_type_name.h"
+#include "drake/common/unused.h"
+#include "drake/systems/analysis/bogacki_shampine3_integrator.h"
+#include "drake/systems/analysis/explicit_euler_integrator.h"
+#include "drake/systems/analysis/implicit_euler_integrator.h"
+#include "drake/systems/analysis/radau_integrator.h"
+#include "drake/systems/analysis/runge_kutta2_integrator.h"
+#include "drake/systems/analysis/runge_kutta3_integrator.h"
+#include "drake/systems/analysis/runge_kutta5_integrator.h"
+#include "drake/systems/analysis/semi_explicit_euler_integrator.h"
+#include "drake/systems/analysis/velocity_implicit_euler_integrator.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+using std::function;
+using std::pair;
+using std::string;
+using std::vector;
+using symbolic::Expression;
+
+// A functor that implements ResetIntegrator.
+template <typename T>
+using ResetIntegratorFunc =
+    function<IntegratorBase<T>*(Simulator<T>*, const T& /* max_step_size */)>;
+
+// Returns (scheme, functor) pair that implements ResetIntegrator.
+template <typename T>
+using NamedResetIntegratorFunc =
+    pair<string, ResetIntegratorFunc<T>>;
+
+// Converts the class name of the `Integrator` template argument into a string
+// name for the scheme, e.g., FooBarIntegrator<double> becomes "foo_bar".
+template <template <typename> class Integrator>
+string GetIntegratorName() {
+  // Get the class name, e.g., FooBarIntegrator<double>.
+  string full_name = NiceTypeName::Get<Integrator<double>>();
+  string class_name = NiceTypeName::RemoveNamespaces(full_name);
+  if (class_name == "RadauIntegrator<double,1>") {
+    class_name = "Radau1Integrator<double>";
+  } else if (class_name == "RadauIntegrator<double,2>") {
+    class_name = "Radau3Integrator<double>";
+  }
+
+  // Strip off "Integrator<double>" suffix to leave just "FooBar".
+  const string suffix = "Integrator<double>";
+  DRAKE_DEMAND(class_name.size() > suffix.size());
+  const size_t suffix_begin = class_name.size() - suffix.size();
+  DRAKE_DEMAND(class_name.substr(suffix_begin) == suffix);
+  const string camel_name = class_name.substr(0, suffix_begin);
+
+  // Convert "FooBar to "foo_bar".
+  string result;
+  for (char ch : camel_name) {
+    if (std::isupper(ch)) {
+      if (!result.empty()) { result.push_back('_'); }
+      result.push_back(std::tolower(ch));
+    } else {
+      result.push_back(ch);
+    }
+  }
+  return result;
+}
+
+// Returns (scheme, functor) pair to implement reset for this `Integrator`.
+// This would be much simpler if all integrators accepted a max_step_size.
+template <typename T, template <typename> class Integrator>
+NamedResetIntegratorFunc<T> MakeResetter() {
+  constexpr bool is_fixed_step = std::is_constructible_v<
+      Integrator<T>,
+      const System<T>&, T, Context<T>*>;
+  constexpr bool is_error_controlled = std::is_constructible_v<
+      Integrator<T>,
+      const System<T>&, Context<T>*>;
+  static_assert(is_fixed_step ^ is_error_controlled);
+  return NamedResetIntegratorFunc<T>(
+      GetIntegratorName<Integrator>(),
+      [](Simulator<T>* simulator, const T& max_step_size) {
+        if constexpr (is_fixed_step) {
+          IntegratorBase<T>& result =
+              simulator->template reset_integrator<Integrator<T>>(
+                  max_step_size);
+          return &result;
+        } else {
+          IntegratorBase<T>& result =
+              simulator->template reset_integrator<Integrator<T>>();
+          result.set_maximum_step_size(max_step_size);
+          return &result;
+        }
+      });
+}
+
+// Returns the full list of supported (scheme, functor) pairs.  N.B. The list
+// here must be kept in sync with the help string in simulator_gflags.cc.
+template <typename T>
+const vector<NamedResetIntegratorFunc<T>>& GetAllNamedResetIntegratorFuncs() {
+  static const never_destroyed<vector<NamedResetIntegratorFunc<T>>> result{
+    std::initializer_list<NamedResetIntegratorFunc<T>>{
+      // Keep this list sorted alphabetically.
+      MakeResetter<T, BogackiShampine3Integrator>(),
+      MakeResetter<T, ExplicitEulerIntegrator>(),
+      MakeResetter<T, ImplicitEulerIntegrator>(),
+      MakeResetter<T, Radau1Integrator>(),
+      MakeResetter<T, Radau3Integrator>(),
+      MakeResetter<T, RungeKutta2Integrator>(),
+      MakeResetter<T, RungeKutta3Integrator>(),
+      MakeResetter<T, RungeKutta5Integrator>(),
+      MakeResetter<T, SemiExplicitEulerIntegrator>(),
+      MakeResetter<T, VelocityImplicitEulerIntegrator>(),
+  }};
+  return result.access();
+}
+
+}  // namespace
+
+template <typename T>
+IntegratorBase<T>& ResetIntegratorFromFlags(
+    Simulator<T>* simulator,
+    const string& scheme,
+    const T& max_step_size) {
+  DRAKE_THROW_UNLESS(simulator != nullptr);
+
+  const auto& name_func_pairs = GetAllNamedResetIntegratorFuncs<T>();
+  for (const auto& [one_name, one_func] : name_func_pairs) {
+    if (scheme == one_name) {
+      return *one_func(simulator, max_step_size);
+    }
+  }
+  throw std::runtime_error(fmt::format(
+      "Unknown integration scheme: {}", scheme));
+}
+
+const vector<string>& GetIntegrationSchemes() {
+  static const never_destroyed<vector<string>> result{[]() {
+    vector<string> names;
+    const auto& name_func_pairs = GetAllNamedResetIntegratorFuncs<double>();
+    for (const auto& [one_name, one_func] : name_func_pairs) {
+      names.push_back(one_name);
+      unused(one_func);
+    }
+    return names;
+  }()};
+  return result.access();
+}
+
+// Explicit instantiations.
+// We can't support T=Expression because Simulator doesn't support it.
+template IntegratorBase<double>& ResetIntegratorFromFlags(
+    Simulator<double>*, const string&, const double&);
+template IntegratorBase<AutoDiffXd>& ResetIntegratorFromFlags(
+    Simulator<AutoDiffXd>*, const string&, const AutoDiffXd&);
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/analysis/simulator_flags.h
+++ b/systems/analysis/simulator_flags.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "drake/common/default_scalars.h"
+#include "drake/systems/analysis/integrator_base.h"
+#include "drake/systems/analysis/simulator.h"
+
+namespace drake {
+namespace systems {
+
+/** @addtogroup simulation
+ @{
+ @defgroup simulator_configuration Simulator configuration
+
+ Configuration helpers to control Simulator and IntegratorBase settings.
+ @}
+ */
+
+/** Resets the integrator used to advanced the continuous time dynamics of the
+system associated with `simulator` according to the given arguments.
+
+@param[in,out] simulator On input, a valid pointer to a Simulator. On output
+  the integrator for `simulator` is reset according to the given arguments.
+@param[in] scheme Integration scheme to be used, e.g., "runge_kutta2".  See
+  GetIntegrationSchemes() for a the list of valid options.
+@param[in] max_step_size The IntegratorBase::set_maximum_step_size() value.
+@returns A reference to the the newly created integrator owned by `simulator`.
+
+@tparam_default_nonsymbolic_scalar
+@ingroup simulator_configuration */
+template <typename T>
+IntegratorBase<T>& ResetIntegratorFromFlags(
+    Simulator<T>* simulator,
+    const std::string& scheme,
+    const T& max_step_size);
+
+/** Returns the allowed string values for the `scheme` parameter in
+ResetIntegratorFromFlags().
+
+@ingroup simulator_configuration */
+const std::vector<std::string>& GetIntegrationSchemes();
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/analysis/test/simulator_flags_test.cc
+++ b/systems/analysis/test/simulator_flags_test.cc
@@ -1,0 +1,39 @@
+#include "drake/systems/analysis/simulator_flags.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/nice_type_name.h"
+#include "drake/systems/analysis/simulator.h"
+#include "drake/systems/primitives/constant_vector_source.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+GTEST_TEST(SimulatorFlagsTest, ResetIntegrator) {
+  ConstantVectorSource<double> source(2);
+  Simulator<double> simulator(source);
+  const void* prior_integrator = &simulator.get_integrator();
+  IntegratorBase<double>& result = ResetIntegratorFromFlags(
+      &simulator, "runge_kutta2", 0.001);
+  EXPECT_NE(&simulator.get_integrator(), prior_integrator);
+  EXPECT_EQ(&simulator.get_integrator(), &result);
+  EXPECT_EQ(NiceTypeName::Get(result),
+            "drake::systems::RungeKutta2Integrator<double>");
+}
+
+GTEST_TEST(SimulatorFlagsTest, GetSchemes) {
+  const std::vector<std::string>& schemes = GetIntegrationSchemes();
+  EXPECT_GE(schemes.size(), 5);
+
+  // Check that all of the schemes are actually valid.
+  ConstantVectorSource<double> source(2);
+  Simulator<double> simulator(source);
+  for (const auto& one_scheme : schemes) {
+    ResetIntegratorFromFlags(&simulator, one_scheme, 0.001);
+  }
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
Closes #12873.  Relates #12903.

This extends `pydrake.systems.Simulator.reset_integrator`'s deprecation window because up to this point there was no viable replacement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13013)
<!-- Reviewable:end -->
