### PR TITLE
Move some helper functions from iiwa to manipulation/util

### DIFF
--- a/examples/kuka_iiwa_arm/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/BUILD.bazel
@@ -26,6 +26,7 @@ drake_cc_library(
     hdrs = [
         "iiwa_common.h",
     ],
+    copts = ["-Wno-deprecated-declarations"],
     visibility = ["//visibility:public"],
     deps = [
         "//attic/multibody:rigid_body_tree",
@@ -33,6 +34,7 @@ drake_cc_library(
         "//common:find_resource",
         "//common/trajectories:piecewise_polynomial",
         "//manipulation/kuka_iiwa:iiwa_constants",
+        "//manipulation/util:robot_plan_utils",
         "@lcmtypes_bot2_core",
         "@lcmtypes_robotlocomotion",
     ],
@@ -209,6 +211,7 @@ drake_cc_binary(
         "//common:add_text_logging_gflags",
         "//lcmtypes:iiwa",
         "//manipulation/planner:constraint_relaxing_ik",
+        "//manipulation/util:robot_plan_utils",
         "//math:geometric_transform",
         "//multibody/parsing",
         "//multibody/plant",

--- a/examples/kuka_iiwa_arm/iiwa_common.h
+++ b/examples/kuka_iiwa_arm/iiwa_common.h
@@ -64,6 +64,8 @@ void SetTorqueControlledIiwaGains(Eigen::VectorXd* stiffness,
 /// The number of columns in @p keyframes must match the size of @p time.  Times
 /// must be in strictly increasing order.
 /// @see get_iiwa_max_joint_velocities
+DRAKE_DEPRECATED("2020-07-01",
+                 "This function is being moved to manipulation::util.")
 void ApplyJointVelocityLimits(const MatrixX<double>& keyframes,
                               std::vector<double>* time);
 
@@ -79,6 +81,8 @@ robotlocomotion::robot_plan_t EncodeKeyFrames(
 /// keyframes must match the size of @p joint_names.  The number of columns in
 /// @p keyframes must match the size of @p time.  Times must be in strictly
 /// increasing order.
+DRAKE_DEPRECATED("2020-07-01",
+                 "This function is being moved to manipulation::util.")
 robotlocomotion::robot_plan_t EncodeKeyFrames(
     const std::vector<std::string>& joint_names,
     const std::vector<double>& time, const std::vector<int>& info,

--- a/manipulation/util/BUILD.bazel
+++ b/manipulation/util/BUILD.bazel
@@ -20,6 +20,7 @@ drake_cc_package_library(
     deps = [
         ":bot_core_lcm_encode_decode",
         ":moving_average_filter",
+        ":robot_plan_utils",
         ":trajectory_utils",
     ],
 )
@@ -48,6 +49,20 @@ drake_py_unittest(
     data = [
         ":geometry_inspector",
         "//multibody/benchmarks/acrobot:models",
+    ],
+)
+
+drake_cc_library(
+    name = "robot_plan_utils",
+    srcs = [
+        "robot_plan_utils.cc",
+    ],
+    hdrs = [
+        "robot_plan_utils.h",
+    ],
+    deps = [
+        "//multibody/plant",
+        "@lcmtypes_robotlocomotion",
     ],
 )
 
@@ -92,6 +107,17 @@ drake_cc_googletest(
     deps = [
         ":bot_core_lcm_encode_decode",
         "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "robot_plan_utils_test",
+    data = [
+        "//manipulation/models/iiwa_description:models",
+    ],
+    deps = [
+        ":robot_plan_utils",
+        "//multibody/parsing",
     ],
 )
 

--- a/manipulation/util/robot_plan_utils.cc
+++ b/manipulation/util/robot_plan_utils.cc
@@ -1,0 +1,132 @@
+#include "drake/manipulation/util/robot_plan_utils.h"
+
+#include <map>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_assert.h"
+
+namespace drake {
+namespace manipulation {
+namespace util {
+
+/// @return A vector of joint names corresponding to the positions in @plant
+/// in the order of the joint indices.
+template <typename T>
+std::vector<std::string> GetJointNames(
+    const multibody::MultibodyPlant<T>& plant) {
+
+  std::map<int, std::string> position_names;
+  const int num_positions = plant.num_positions();
+  for (int i = 0; i < plant.num_joints(); ++i) {
+    const multibody::Joint<T>& joint =
+        plant.get_joint(multibody::JointIndex(i));
+    if (joint.num_positions() == 0) {
+      continue;
+    }
+    DRAKE_DEMAND(joint.num_positions() == 1);
+    DRAKE_DEMAND(joint.position_start() < num_positions);
+
+    position_names[joint.position_start()] = joint.name();
+  }
+
+  DRAKE_DEMAND(static_cast<int>(position_names.size()) == num_positions);
+  std::vector<std::string> joint_names;
+  for (int i = 0; i < num_positions; ++i) {
+    joint_names.push_back(position_names[i]);
+  }
+  return joint_names;
+}
+
+void ApplyJointVelocityLimits(
+    const std::vector<Eigen::VectorXd>& keyframes,
+    const Eigen::VectorXd& limits,
+    std::vector<double>* times) {
+  DRAKE_DEMAND(keyframes.size() == times->size());
+  DRAKE_DEMAND(times->front() ==0);
+  const int num_time_steps = keyframes.size();
+
+  // Calculate a matrix of velocities between each timestep.  We'll
+  // use this later to determine by how much the plan exceeds the
+  // joint velocity limits.
+  Eigen::MatrixXd velocities(limits.size(), num_time_steps - 1);
+  for (int i = 0; i < velocities.rows(); i++) {
+    for (int j = 0; j < velocities.cols(); j++) {
+      DRAKE_ASSERT((*times)[j + 1] > (*times)[j]);
+      velocities(i, j) =
+          std::abs((keyframes[j + 1](i) - keyframes[j](i)) /
+                   ((*times)[j + 1] - (*times)[j]));
+    }
+  }
+
+  Eigen::VectorXd velocity_ratios(velocities.rows());
+
+  for (int i = 0; i < velocities.rows(); i++) {
+    const double max_plan_velocity = velocities.row(i).maxCoeff();
+    velocity_ratios(i) = max_plan_velocity / limits(i);
+  }
+
+  const double max_velocity_ratio = velocity_ratios.maxCoeff();
+  if (max_velocity_ratio > 1) {
+    // The code below slows the entire plan such that the fastest step
+    // meets the limits.  If that step is much faster than the others,
+    // the whole plan becomes very slow.
+    drake::log()->debug("Slowing plan by {}", max_velocity_ratio);
+    for (int j = 0; j < num_time_steps; j++) {
+      (*times)[j] *= max_velocity_ratio;
+    }
+  }
+}
+
+robotlocomotion::robot_plan_t EncodeKeyFrames(
+    const std::vector<std::string>& joint_names,
+    const std::vector<double>& times,
+    const std::vector<int>& info,
+    const std::vector<Eigen::VectorXd>& keyframes) {
+  DRAKE_DEMAND(info.size() == times.size());
+  DRAKE_DEMAND(keyframes.size() == times.size());
+
+  const int num_time_steps = keyframes.size();
+
+  robotlocomotion::robot_plan_t plan{};
+  plan.utime = 0;  // I (sam.creasey) don't think this is used?
+  plan.robot_name = "";  // Arbitrary, probably ignored
+  plan.num_states = num_time_steps;
+  const bot_core::robot_state_t default_robot_state{};
+  plan.plan.resize(num_time_steps, default_robot_state);
+  plan.plan_info.resize(num_time_steps, 0);
+  /// Encode the q_sol returned for each timestep into the vector of
+  /// robot states.
+  for (int i = 0; i < num_time_steps; i++) {
+    DRAKE_DEMAND(keyframes[i].size() == static_cast<int>(joint_names.size()));
+    bot_core::robot_state_t& step = plan.plan[i];
+    step.utime = times[i] * 1e6;
+    step.num_joints = keyframes[i].size();
+    for (int j = 0; j < step.num_joints; j++) {
+      step.joint_name.push_back(joint_names[j]);
+      step.joint_position.push_back(keyframes[i](j));
+      step.joint_velocity.push_back(0);
+      step.joint_effort.push_back(0);
+    }
+    plan.plan_info[i] = info[i];
+  }
+  plan.num_grasp_transitions = 0;
+  plan.left_arm_control_type = plan.POSITION;
+  plan.right_arm_control_type = plan.NONE;
+  plan.left_leg_control_type = plan.NONE;
+  plan.right_leg_control_type = plan.NONE;
+  plan.num_bytes = 0;
+
+  return plan;
+}
+
+
+}  // namespace util
+}  // namespace manipulation
+}  // namespace drake
+
+template std::vector<std::string> drake::manipulation::util::GetJointNames(
+    const drake::multibody::MultibodyPlant<double>&);
+template std::vector<std::string> drake::manipulation::util::GetJointNames(
+    const drake::multibody::MultibodyPlant<::drake::AutoDiffXd>&);
+template std::vector<std::string> drake::manipulation::util::GetJointNames(
+    const drake::multibody::MultibodyPlant<::drake::symbolic::Expression>&);

--- a/manipulation/util/robot_plan_utils.h
+++ b/manipulation/util/robot_plan_utils.h
@@ -1,0 +1,50 @@
+#pragma once
+
+/// @file Functions to help with the creation of robot_plan_t messages.
+
+#include <string>
+#include <vector>
+
+#include "robotlocomotion/robot_plan_t.hpp"
+
+#include "drake/multibody/plant/multibody_plant.h"
+
+namespace drake {
+namespace manipulation {
+namespace util {
+
+/// @return A vector of joint names corresponding to the positions in @p plant
+/// in the order of the joint indices.  If joints with duplicate names exist
+/// in different model instance in the plant, the names will be duplicated in
+/// the output.
+template <typename T>
+std::vector<std::string> GetJointNames(
+    const multibody::MultibodyPlant<T>& plant);
+
+/// Scales a plan so that no step exceeds the robot's maximum joint
+/// velocities.  The size of @p keyframes must match the size of @p times.
+/// Times must be in strictly increasing order and start with zero.  Per-joint
+/// velocity limits are specified by @p limits, which much be the same size ad
+/// the number of joints in each element of @p keyframes. Assumes that
+/// velocity limits are equal regardless of direction.  If any step does
+/// exceed the maximum velocities in @p limits, @p times will be modified to
+/// reduce the velocity.
+void ApplyJointVelocityLimits(
+    const std::vector<Eigen::VectorXd>& keyframes,
+    const Eigen::VectorXd& limits,
+    std::vector<double>* times);
+
+/// Makes a robotlocomotion::robot_plan_t message.  The entries in @p
+/// joint_names should be unique, though the behavior if names are duplicated
+/// depends on how the returned plan is evaluated.  The size of each vector in
+/// @p keyframes must match the size of @p joint_names.  The size of @p
+/// keyframes must match the size of @p times.  Times must be in strictly
+/// increasing order.
+robotlocomotion::robot_plan_t EncodeKeyFrames(
+    const std::vector<std::string>& joint_names,
+    const std::vector<double>& times, const std::vector<int>& info,
+    const std::vector<Eigen::VectorXd>& keyframes);
+
+}  // namespace util
+}  // namespace manipulation
+}  // namespace drake

--- a/manipulation/util/test/robot_plan_utils_test.cc
+++ b/manipulation/util/test/robot_plan_utils_test.cc
@@ -1,0 +1,84 @@
+#include "drake/manipulation/util/robot_plan_utils.h"
+
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/multibody/parsing/parser.h"
+
+namespace drake {
+namespace manipulation {
+namespace util {
+
+const char kIiwaUrdf[] =
+    "drake/manipulation/models/iiwa_description/urdf/"
+    "iiwa14_no_collision.urdf";
+
+GTEST_TEST(RobotPlanUtilsTest, GetJointNamesTest) {
+  multibody::MultibodyPlant<double> plant(0.001);
+  multibody::Parser(&plant).AddModelFromFile(FindResourceOrThrow(kIiwaUrdf));
+  plant.WeldFrames(plant.world_frame(),
+                   plant.GetBodyByName("base").body_frame());
+  plant.Finalize();
+
+  std::vector<std::string> joint_names = GetJointNames(plant);
+  ASSERT_EQ(joint_names.size(), 7);
+  EXPECT_EQ(joint_names[0], "iiwa_joint_1");
+  EXPECT_EQ(joint_names[1], "iiwa_joint_2");
+  EXPECT_EQ(joint_names[2], "iiwa_joint_3");
+  EXPECT_EQ(joint_names[3], "iiwa_joint_4");
+  EXPECT_EQ(joint_names[4], "iiwa_joint_5");
+  EXPECT_EQ(joint_names[5], "iiwa_joint_6");
+  EXPECT_EQ(joint_names[6], "iiwa_joint_7");
+}
+
+GTEST_TEST(RobotPlanUtilsTest, ApplyJointVelocityLimitsTest) {
+  std::vector<double> times{0, 1};
+  std::vector<Eigen::VectorXd> keyframes;
+  keyframes.push_back(Eigen::VectorXd::Zero(2));
+  keyframes.push_back(Eigen::VectorXd::Ones(2));
+  Eigen::Vector2d limit(0.9, 1);
+
+  ApplyJointVelocityLimits(keyframes, limit, &times);
+  EXPECT_EQ(times[1], 1. / 0.9);
+}
+
+GTEST_TEST(RobotPlanUtilsTest, EncodeKeyFramesTest) {
+  multibody::MultibodyPlant<double> plant(0.001);
+  multibody::Parser(&plant).AddModelFromFile(FindResourceOrThrow(kIiwaUrdf));
+  plant.WeldFrames(plant.world_frame(),
+                   plant.GetBodyByName("base").body_frame());
+  plant.Finalize();
+
+  std::vector<std::string> joint_names = GetJointNames(plant);
+  std::vector<double> times{0, 2};
+  std::vector<int> info{1, 2};
+  std::vector<Eigen::VectorXd> keyframes;
+  Eigen::VectorXd q(7);
+  q << 1, 2, 3, 4, 5, 6, 7;
+  keyframes.push_back(q);
+  q << 8, 9, 10, 11, 12, 13, 14;
+  keyframes.push_back(q);
+
+  robotlocomotion::robot_plan_t plan =
+      EncodeKeyFrames(joint_names, times, info, keyframes);
+  ASSERT_EQ(plan.plan_info.size(), 2);
+  EXPECT_EQ(plan.plan_info[0], 1);
+  EXPECT_EQ(plan.plan_info[1], 2);
+
+  ASSERT_EQ(plan.plan.size(), 2);
+  EXPECT_EQ(plan.plan.size(), plan.num_states);
+  for (int i = 0; i < static_cast<int>(plan.plan.size()); ++i) {
+    const bot_core::robot_state_t& step = plan.plan[i];
+    EXPECT_EQ(step.utime, i * 2 * 1e6);
+    ASSERT_EQ(step.num_joints, 7);
+    for (int j = 0; j < step.num_joints; j++) {
+      EXPECT_EQ(step.joint_position[j], i * 7 + j + 1);
+    }
+  }
+}
+
+}  // namespace util
+}  // namespace manipulation
+}  // namespace drake


### PR DESCRIPTION
These are items I've used in personal branches exploring planning/sim
with different robots that don't currently have drake examples (or at
least hadn't used this functionality yet).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13015)
<!-- Reviewable:end -->
