### PR TITLE
install: Fix drake_bazel_installed use in docker

### DIFF
--- a/tools/install/bazel/repo_template.bzl
+++ b/tools/install/bazel/repo_template.bzl
@@ -54,7 +54,6 @@ def _drake_impl(repo_ctx):
     required_files = [
         "include/drake/common/drake_assert.h",
         "lib/libdrake.so",
-        "share/drake/setup/install_prereqs",
     ]
     for required_file in required_files:
         if not repo_ctx.path(str(prefix) + "/" + required_file).exists:


### PR DESCRIPTION
There's no particular need to insist that install_prereqs exists, and as it happens our Docker images do not contain it.

Closes #13010.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13016)
<!-- Reviewable:end -->
