### PR TITLE
Add external torque fields for the jaco status message

### DIFF
--- a/examples/kinova_jaco_arm/jaco_lcm.cc
+++ b/examples/kinova_jaco_arm/jaco_lcm.cc
@@ -207,10 +207,12 @@ lcmt_jaco_status JacoStatusSender::MakeOutputStatus() const {
   msg.joint_position.resize(msg.num_joints, 0);
   msg.joint_velocity.resize(msg.num_joints, 0);
   msg.joint_torque.resize(msg.num_joints, 0);
+  msg.joint_torque_external.resize(msg.num_joints, 0);
   msg.joint_current.resize(msg.num_joints, 0);
   msg.finger_position.resize(msg.num_fingers, 0);
   msg.finger_velocity.resize(msg.num_fingers, 0);
   msg.finger_torque.resize(msg.num_fingers, 0);
+  msg.finger_torque_external.resize(msg.num_fingers, 0);
   msg.finger_current.resize(msg.num_fingers, 0);
   return msg;
 }

--- a/examples/kinova_jaco_arm/jaco_simulation.cc
+++ b/examples/kinova_jaco_arm/jaco_simulation.cc
@@ -101,6 +101,9 @@ int DoMain() {
       builder.AddSystem(
           systems::lcm::LcmPublisherSystem::Make<drake::lcmt_jaco_status>(
           "KINOVA_JACO_STATUS", lcm, kJacoLcmStatusPeriod));
+  // TODO(sammy-tri) populate joint torque (and external torques).  External
+  // torques might want to wait until after #12631 is fixed or it could slow
+  // down the simulation significantly.
   auto status_sender = builder.AddSystem<JacoStatusSender>();
   builder.Connect(jaco_plant->get_state_output_port(jaco_id),
                   status_sender->get_input_port(0));

--- a/examples/kinova_jaco_arm/test/jaco_lcm_test.cc
+++ b/examples/kinova_jaco_arm/test/jaco_lcm_test.cc
@@ -88,24 +88,28 @@ GTEST_TEST(JacoLcmTest, JacoStatusPassthroughTest) {
   status.joint_position.resize(status.num_joints);
   status.joint_velocity.resize(status.num_joints);
   status.joint_torque.resize(status.num_joints);
+  status.joint_torque_external.resize(status.num_joints);
   status.joint_current.resize(status.num_joints);
   for (int i = 0; i < status.num_joints; i++) {
     status.joint_position[i] = i;
     status.joint_velocity[i] = i * 10;
     status.joint_torque[i] = i * 100;
-    status.joint_current[i] = i * 1000;
+    status.joint_torque_external[i] = i * 1000;
+    status.joint_current[i] = i * 10000;
   }
 
   status.num_fingers = kJacoDefaultArmNumFingers;
   status.finger_position.resize(status.num_fingers);
   status.finger_velocity.resize(status.num_fingers);
   status.finger_torque.resize(status.num_fingers);
+  status.finger_torque_external.resize(status.num_fingers);
   status.finger_current.resize(status.num_fingers);
   for (int i = 0; i < status.num_fingers; i++) {
     status.finger_position[i] = -i;
     status.finger_velocity[i] = -i * 10;
     status.finger_torque[i] = -i * 100;
-    status.finger_current[i] = -i * 1000;
+    status.finger_torque_external[i] = -i * 1000;
+    status.finger_current[i] = -i * 10000;
   }
 
   diagram->get_input_port(0).FixValue(context.get(), status);
@@ -120,8 +124,8 @@ GTEST_TEST(JacoLcmTest, JacoStatusPassthroughTest) {
   lcmt_jaco_status status_out =
       output->get_data(0)->get_value<lcmt_jaco_status>();
 
-  // Force and current won't actually pass through since they're not
-  // part of the state in drake.
+  // TODO(sammy-tri) Force and current won't actually pass through.  Add
+  // appropriate input/output ports for those values.
   ASSERT_EQ(status.num_joints, status_out.num_joints);
   for (int i = 0; i < status.num_joints; i++) {
     EXPECT_DOUBLE_EQ(status.joint_position[i], status_out.joint_position[i]);

--- a/lcmtypes/lcmt_jaco_status.lcm
+++ b/lcmtypes/lcmt_jaco_status.lcm
@@ -12,17 +12,19 @@ struct lcmt_jaco_status
 
   double joint_position[num_joints];
   double joint_velocity[num_joints];
-  double joint_torque[num_joints];  // (sometimes called "Angular
-                                    // Force" in Kinova's
-                                    // documentation.
+
+  // "Angular Force" in Kinova's documentation.
+  double joint_torque[num_joints];
+  // "AngularForceGravityFree" in Kinova's documentation.
+  double joint_torque_external[num_joints];
   double joint_current[num_joints];
 
   int32_t num_fingers;
   double finger_position[num_fingers];
   double finger_velocity[num_fingers];
-  double finger_torque[num_fingers]; // (sometimes called "Angular
-                                     // Force" in Kinova's
-                                     // documentation.
+  // "Angular Force" in Kinova's documentation.
+  double finger_torque[num_fingers];
+  // "AngularForceGravityFree" in Kinova's documentation.
+  double finger_torque_external[num_fingers];
   double finger_current[num_fingers];
-
 }


### PR DESCRIPTION
This is a breaking change as the LCM message does not have a
deprecation period.  Due to the lack of external users I think this is
OK.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13017)
<!-- Reviewable:end -->
