### PR TITLE
pydrake meshcat: Fix name parsing bug

### DIFF
--- a/bindings/pydrake/systems/meshcat_visualizer.py
+++ b/bindings/pydrake/systems/meshcat_visualizer.py
@@ -282,11 +282,15 @@ class MeshcatVisualizer(LeafSystem):
         self.axis_radius = axis_radius
 
     def _parse_name(self, name):
-        # Parse name, split on the first (required) occurrence of `::` to get
-        # the source name, and let the rest be the frame name.
-        # TODO(eric.cousineau): Remove name parsing once #9128 is resolved.
+        # Parse name, split on the first occurrence of `::` to get the source
+        # name, and let the rest be the frame name. If `::` is not in name,
+        # source name is "unnamed" and the frame name is `name`.
+        # TODO(eric.cousineau): Remove name parsing once this is reimplemented
+        # to use Shape introspection.
         delim = "::"
-        assert delim in name
+        if delim not in name:
+            default_source = "unnamed"
+            return default_source, name
         pos = name.index(delim)
         source_name = name[:pos]
         frame_name = name[pos + len(delim):]

--- a/bindings/pydrake/systems/test/meshcat_visualizer_test.py
+++ b/bindings/pydrake/systems/test/meshcat_visualizer_test.py
@@ -20,7 +20,12 @@ import meshcat
 import numpy as np
 
 from pydrake.common import FindResourceOrThrow
-from pydrake.geometry import Box, SceneGraph
+from pydrake.geometry import (
+    Box,
+    GeometryInstance,
+    IllustrationProperties,
+    SceneGraph
+)
 from pydrake.multibody.plant import (
     AddMultibodyPlantSceneGraph)
 from pydrake.multibody.parsing import Parser
@@ -156,6 +161,33 @@ class TestMeshcat(unittest.TestCase):
         simulator = Simulator(diagram)
         simulator.set_publish_every_time_step(False)
         simulator.AdvanceTo(.1)
+
+    def test_custom_geometry_name_parsing(self):
+        """
+        Ensure that name parsing does not fail on programmatically added
+        anchored geometries.
+        """
+        # Make a minimal example to ensure MeshcatVisualizer loads anchored
+        # geometry.
+        builder = DiagramBuilder()
+        scene_graph = builder.AddSystem(SceneGraph())
+        meshcat = builder.AddSystem(
+            MeshcatVisualizer(scene_graph,
+                              zmq_url=ZMQ_URL,
+                              open_browser=False))
+        builder.Connect(
+            scene_graph.get_pose_bundle_output_port(),
+            meshcat.get_input_port(0))
+
+        source_id = scene_graph.RegisterSource()
+        geom_inst = GeometryInstance(RigidTransform(), Box(1., 1., 1.), "box")
+        geom_id = scene_graph.RegisterAnchoredGeometry(source_id, geom_inst)
+        # Illustration properties required to ensure geometry is parsed
+        scene_graph.AssignRole(source_id, geom_id, IllustrationProperties())
+
+        diagram = builder.Build()
+        simulator = Simulator(diagram)
+        simulator.Initialize()
 
     def test_contact_force(self):
         """A block sitting on a table."""


### PR DESCRIPTION
Since this assert has bitten me multiple times when I add geometry programmatically and try to visualize it in Meshcat, I wanted to propose a fix.  This was the solution proposed in a [slack discussion](https://drakedevelopers.slack.com/archives/C3YB3EV5W/p1572984455042100) but given that the above TODO references a closed issue, there might be a better solution.

@EricCousineau-TRI for discussion/feature review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13018)
<!-- Reviewable:end -->
