### PR TITLE
attic: Add once-per-process deprecation warning

### DIFF
--- a/attic/BUILD.bazel
+++ b/attic/BUILD.bazel
@@ -1,7 +1,20 @@
 # -*- python -*-
 
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_library",
+)
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 exports_files(["CPPLINT.cfg"])
+
+drake_cc_library(
+    name = "warning",
+    srcs = ["warning.cc"],
+    hdrs = ["warning.h"],
+    install_hdrs_exclude = ["warning.h"],
+    visibility = ["//attic:__subpackages__"],
+    deps = ["//common:essential"],
+)
 
 add_lint_tests()

--- a/attic/multibody/BUILD.bazel
+++ b/attic/multibody/BUILD.bazel
@@ -252,6 +252,7 @@ _RBT_SHARD_COUNT = 2
             ":rigid_body_frame",
             ":rigid_body_loop",
             ":rigid_body_tree_datatypes",
+            "//attic:warning",
             "//attic/multibody/collision",
             "//attic/multibody/joints",
             "//attic/multibody/shapes",

--- a/attic/multibody/rigid_body_tree.cc
+++ b/attic/multibody/rigid_body_tree.cc
@@ -10,6 +10,7 @@
 #include <string>
 #include <unordered_map>
 
+#include "drake/attic/warning.h"
 #include "drake/common/autodiff.h"
 #include "drake/common/constants.h"
 #include "drake/common/eigen_types.h"
@@ -138,6 +139,9 @@ template <typename T>
 RigidBodyTree<T>::RigidBodyTree()
     : collision_model_(drake::multibody::collision::newModel()) {
 #pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
+
+  drake::internal::WarnOnceAboutAtticCode();
+
   // Sets the gravity vector.
   a_grav << 0, 0, 0, 0, 0, -9.81;
 

--- a/attic/warning.cc
+++ b/attic/warning.cc
@@ -1,0 +1,22 @@
+#include "drake/attic/warning.h"
+
+#include "drake/common/text_logging.h"
+
+namespace drake {
+namespace internal {
+
+void WarnOnceAboutAtticCode() {
+  static const logging::Warn log_once(
+      "All Drake code in the 'attic' is being deprecated and will be "
+      "removed from Drake on or after 2020-09-01. This includes "
+      "RigidBodyTree and RigidBodyPlant and their visualization, "
+      "sensors for RigidBodyPlant such as accelerometer, gyro, camera, etc., "
+      "inverse kinematics and inverse dynamics based on RigidBodyTree, and "
+      "SimDiagramBuilder and WorldSimTreeBuilder based on RigidBodyTree. "
+      "Developers should use the replacement MultibodyPlant family instead. "
+      "See https://github.com/RobotLocomotion/drake/issues/12158 for details."
+);
+}
+
+}  // namespace internal
+}  // namespace drake

--- a/attic/warning.h
+++ b/attic/warning.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace drake {
+namespace internal {
+
+/** Prints a deprecation warning the first time it is called.  Subsequent calls
+print no warning. */
+void WarnOnceAboutAtticCode();
+
+}  // namespace internal
+}  // namespace drake

--- a/tools/install/libdrake/build_components.bzl
+++ b/tools/install/libdrake/build_components.bzl
@@ -102,6 +102,7 @@ LIBDRAKE_COMPONENTS = [
     "//systems/rendering",
     "//systems/sensors",
     "//systems/trajectory_optimization",
+    # //attic:warning (indirectly)
     # //common:filesystem (indirectly)
     # //third_party/com_github_finetjul_bender:vtkCapsuleSource (indirectly)
 ]


### PR DESCRIPTION
Relates #12158.

It seems like almost all attic code must create a RBT before being used, so this warning should catch most uses.  If we later find uses not covered here, then we can invoke this new function from those locations as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13030)
<!-- Reviewable:end -->
