### PR TITLE
Update recommended Bazel version to 3.0

### DIFF
--- a/doc/developers.rst
+++ b/doc/developers.rst
@@ -79,7 +79,7 @@ Drake requires a compiler running in C++17 mode.
 | Operating System                 | Bazel | CMake | C/C++ Compiler      | Java              | Python |
 +==================================+=======+=======+=====================+===================+========+
 +----------------------------------+-------+-------+---------------------+-------------------+--------+
-| Ubuntu 18.04 LTS (Bionic Beaver) | 2.1   | 3.10  | | Clang 6.0         | OpenJDK 11        | 3.6    |
+| Ubuntu 18.04 LTS (Bionic Beaver) | 3.0   | 3.10  | | Clang 6.0         | OpenJDK 11        | 3.6    |
 |                                  |       |       | | GCC 7.5 (default) |                   |        |
 +----------------------------------+       +-------+---------------------+-------------------+--------+
 | macOS Mojave (10.14)             |       | 3.16  | | Apple LLVM 11.0.0 | | AdoptOpenJDK 13 | 3.7    |

--- a/setup/ubuntu/source_distribution/install_prereqs.sh
+++ b/setup/ubuntu/source_distribution/install_prereqs.sh
@@ -71,6 +71,6 @@ dpkg_install_from_wget() {
 }
 
 dpkg_install_from_wget \
-  bazel 2.1.0 \
-  https://releases.bazel.build/2.1.0/release/bazel_2.1.0-linux-x86_64.deb \
-  bf12c4c0bb853266676295351da20d13075b26bf23f28c4ffdfefc1b35062ccb
+  bazel 3.0.0 \
+  https://releases.bazel.build/3.0.0/release/bazel_3.0.0-linux-x86_64.deb \
+  dfa79c10bbfa39cd778e1813a273fd3236beb495497baa046f26d393c58bdc35


### PR DESCRIPTION
- [x] Requires macOS unprovisioned to be green (so that we can freeze provisioning at 3.0.0).
- [x] Confirm that TRI builds pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13032)
<!-- Reviewable:end -->
