### PR TITLE
multibody: Implement BallRpyJoint

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -8,6 +8,7 @@ import warnings
 from pydrake.autodiffutils import AutoDiffXd
 from pydrake.symbolic import Expression
 from pydrake.multibody.tree import (
+    BallRpyJoint_,
     Body_,
     BodyIndex,
     DoorHinge_,
@@ -1073,10 +1074,19 @@ class TestPlant(unittest.TestCase):
                 damping=2.,
             )
 
+        def make_ball_rpy_joint(plant, P, C):
+            return BallRpyJoint_[T](
+                name="ball_rpy",
+                frame_on_parent=P,
+                frame_on_child=C,
+                damping=2.,
+            )
+
         make_joint_list = [
             make_weld,
             make_prismatic,
             make_revolute,
+            make_ball_rpy_joint,
         ]
 
         for make_joint in make_joint_list:

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -11,6 +11,7 @@
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/tree/ball_rpy_joint.h"
 #include "drake/multibody/tree/body.h"
 #include "drake/multibody/tree/door_hinge.h"
 #include "drake/multibody/tree/force_element.h"
@@ -240,6 +241,31 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.acceleration_lower_limits.doc)
         .def("acceleration_upper_limits", &Class::acceleration_upper_limits,
             cls_doc.acceleration_upper_limits.doc);
+  }
+
+  // BallRpyJoint
+  {
+    using Class = BallRpyJoint<T>;
+    constexpr auto& cls_doc = doc.BallRpyJoint;
+    auto cls = DefineTemplateClassWithDefault<Class, Joint<T>>(
+        m, "BallRpyJoint", param, cls_doc.doc);
+    cls  // BR
+        .def(
+            py::init<const string&, const Frame<T>&, const Frame<T>&, double>(),
+            py::arg("name"), py::arg("frame_on_parent"),
+            py::arg("frame_on_child"), py::arg("damping") = 0, cls_doc.ctor.doc)
+        .def("get_angles", &Class::get_angles, py::arg("context"),
+            cls_doc.get_angles.doc)
+        .def("set_angles", &Class::set_angles, py::arg("context"),
+            py::arg("angles"), cls_doc.set_angles.doc)
+        .def("set_random_angles_distribution",
+            &Class::set_random_angles_distribution, py::arg("angles"),
+            cls_doc.set_random_angles_distribution.doc)
+        .def("get_angular_velocity", &Class::get_angular_velocity,
+            py::arg("context"), cls_doc.get_angular_velocity.doc)
+        .def("set_angular_velocity", &Class::set_angular_velocity,
+            py::arg("context"), py::arg("w_FM"),
+            cls_doc.set_angular_velocity.doc);
   }
 
   // PrismaticJoint

--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -89,6 +89,7 @@ drake_cc_library(
 drake_cc_library(
     name = "multibody_tree_core",
     srcs = [
+        "ball_rpy_joint.cc",
         "body.cc",
         "body_node_impl.cc",
         "door_hinge.cc",
@@ -114,6 +115,7 @@ drake_cc_library(
         "weld_mobilizer.cc",
     ],
     hdrs = [
+        "ball_rpy_joint.h",
         "body.h",
         "body_node.h",
         "body_node_impl.h",
@@ -470,6 +472,13 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "revolute_joint_test",
+    deps = [
+        ":tree",
+    ],
+)
+
+drake_cc_googletest(
+    name = "ball_rpy_joint_test",
     deps = [
         ":tree",
     ],

--- a/multibody/tree/ball_rpy_joint.cc
+++ b/multibody/tree/ball_rpy_joint.cc
@@ -1,0 +1,69 @@
+#include "drake/multibody/tree/ball_rpy_joint.h"
+
+#include <memory>
+#include <stdexcept>
+
+#include "drake/multibody/tree/multibody_tree.h"
+
+namespace drake {
+namespace multibody {
+
+template <typename T>
+template <typename ToScalar>
+std::unique_ptr<Joint<ToScalar>> BallRpyJoint<T>::TemplatedDoCloneToScalar(
+    const internal::MultibodyTree<ToScalar>& tree_clone) const {
+  const Frame<ToScalar>& frame_on_parent_body_clone =
+      tree_clone.get_variant(this->frame_on_parent());
+  const Frame<ToScalar>& frame_on_child_body_clone =
+      tree_clone.get_variant(this->frame_on_child());
+
+  // Make the Joint<T> clone.
+  auto joint_clone = std::make_unique<BallRpyJoint<ToScalar>>(
+      this->name(), frame_on_parent_body_clone, frame_on_child_body_clone,
+      this->damping());
+  joint_clone->set_position_limits(this->position_lower_limits(),
+                                   this->position_upper_limits());
+  joint_clone->set_velocity_limits(this->velocity_lower_limits(),
+                                   this->velocity_upper_limits());
+  joint_clone->set_acceleration_limits(this->acceleration_lower_limits(),
+                                       this->acceleration_upper_limits());
+
+  return std::move(joint_clone);
+}
+
+template <typename T>
+std::unique_ptr<Joint<double>> BallRpyJoint<T>::DoCloneToScalar(
+    const internal::MultibodyTree<double>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
+template <typename T>
+std::unique_ptr<Joint<AutoDiffXd>> BallRpyJoint<T>::DoCloneToScalar(
+    const internal::MultibodyTree<AutoDiffXd>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
+template <typename T>
+std::unique_ptr<Joint<symbolic::Expression>> BallRpyJoint<T>::DoCloneToScalar(
+    const internal::MultibodyTree<symbolic::Expression>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
+// N.B. Due to esoteric linking errors on Mac (see #9345) involving
+// `MobilizerImpl`, we must place this implementation in the source file, not
+// in the header file.
+template <typename T>
+std::unique_ptr<typename Joint<T>::BluePrint>
+BallRpyJoint<T>::MakeImplementationBlueprint() const {
+  auto blue_print = std::make_unique<typename Joint<T>::BluePrint>();
+  blue_print->mobilizers_.push_back(
+      std::make_unique<internal::SpaceXYZMobilizer<T>>(this->frame_on_parent(),
+                                                       this->frame_on_child()));
+  return std::move(blue_print);
+}
+
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::BallRpyJoint)

--- a/multibody/tree/ball_rpy_joint.h
+++ b/multibody/tree/ball_rpy_joint.h
@@ -1,0 +1,276 @@
+#pragma once
+
+#include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/multibody/tree/joint.h"
+#include "drake/multibody/tree/multibody_forces.h"
+#include "drake/multibody/tree/space_xyz_mobilizer.h"
+
+namespace drake {
+namespace multibody {
+
+/// This Joint allows two bodies to rotate freely relative to one another.
+/// That is, given a frame F attached to the parent body P and a frame M
+/// attached to the child body B (see the Joint class's documentation),
+/// this Joint allows frame M to rotate freely with respect to F, while the
+/// origins, Mo and Fo, of frames M and F respectively remain coincident. The
+/// orientation of M relative to F is parameterized with space `x-y-z` Euler
+/// angles.
+///
+/// @tparam_default_scalar
+template <typename T>
+class BallRpyJoint final : public Joint<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BallRpyJoint)
+
+  template <typename Scalar>
+  using Context = systems::Context<Scalar>;
+
+  /// The name for this Joint type.  It resolves to "ball_rpy".
+  static const char kTypeName[];
+
+  /// Constructor to create a ball rpy joint between two bodies so that frame F
+  /// attached to the parent body P and frame M attached to the child body B
+  /// rotate freely relative to one another. See this class's documentation
+  /// for further details on the definition of these frames, get_angles() for an
+  /// explanation of the angles defining orientation, and get_angular_velocity()
+  /// for an explanation of the generalized velocities.
+  /// This constructor signature creates a joint with no joint limits, i.e. the
+  /// joint position, velocity and acceleration limits are the pair `(-∞, ∞)`.
+  /// These can be set using the Joint methods set_position_limits(),
+  /// set_velocity_limits() and set_acceleration_limits().
+  /// The first three arguments to this constructor are those of the Joint class
+  /// constructor. See the Joint class's documentation for details.
+  /// The additional parameters are:
+  /// @param[in] damping
+  ///   Viscous damping coefficient, in N⋅m⋅s, used to model losses within the
+  ///   joint. See documentation of damping() for details on modelling of the
+  ///   damping torque.
+  /// @throws std::exception if damping is negative.
+  BallRpyJoint(const std::string& name, const Frame<T>& frame_on_parent,
+               const Frame<T>& frame_on_child, double damping = 0)
+      : Joint<T>(name, frame_on_parent, frame_on_child,
+                 VectorX<double>::Constant(
+                     3, -std::numeric_limits<double>::infinity()),
+                 VectorX<double>::Constant(
+                     3, std::numeric_limits<double>::infinity()),
+                 VectorX<double>::Constant(
+                     3, -std::numeric_limits<double>::infinity()),
+                 VectorX<double>::Constant(
+                     3, std::numeric_limits<double>::infinity()),
+                 VectorX<double>::Constant(
+                     3, -std::numeric_limits<double>::infinity()),
+                 VectorX<double>::Constant(
+                     3, std::numeric_limits<double>::infinity())) {
+    DRAKE_THROW_UNLESS(damping >= 0);
+    damping_ = damping;
+  }
+
+  const std::string& type_name() const override {
+    static const never_destroyed<std::string> name{kTypeName};
+    return name.access();
+  }
+
+  /// Returns `this` joint's damping constant in N⋅m⋅s. The damping torque
+  /// (in N⋅m) is modeled as `τ = -damping⋅ω`, i.e. opposing motion, with ω the
+  /// angular velocity of frame M in F (see get_angular_velocity()) and τ the
+  /// torque on child body B (to which M is rigidly attached).
+  double damping() const { return damping_; }
+
+  /// @name Context-dependent value access
+  /// @{
+
+  /// Gets the rotation angles of `this` joint from `context`.
+  ///
+  /// The orientation `R_FM` of the child frame M in parent frame F is
+  /// parameterized with space `x-y-z` Euler angles (also known as extrinsic
+  /// angles). That is, the angles θr, θp, θy, correspond to a sequence of
+  /// rotations about the x̂, ŷ, ẑ axes of parent frame F, respectively.
+  /// Mathematically, rotation `R_FM` is given in terms of angles θr, θp, θy
+  /// by: <pre>
+  ///   R_FM(q) = Rz(θy) * Ry(θp) * Rx(θr)
+  /// </pre>
+  /// where `Rx(θ)`, `Ry(θ)` and `Rz(θ)` correspond to the elemental rotations
+  /// in amount of θ about the x, y and z axes respectively.
+  /// Zero θr, θp, θy angles corresponds to frames F and M being coincident.
+  /// Angles θr, θp, θy are defined to be positive according to the
+  /// right-hand-rule with the thumb aligned in the direction of their
+  /// respective axes.
+  ///
+  /// @note Space `x-y-z` angles (extrinsic) are equivalent to Body `z-y-x`
+  /// angles (intrinsic).
+  ///
+  /// @note This particular choice of angles θr, θp, θy for this joint are
+  /// many times referred to as the roll, pitch and yaw angles by many
+  /// dynamicists. They are also known as the Tait-Bryan angles or Cardan
+  /// angles.
+  ///
+  /// @param[in] context
+  ///   The context of the model this joint belongs to.
+  /// @returns The angle coordinates of `this` joint stored in the `context`
+  ///          ordered as θr, θp, θy.
+  Vector3<T> get_angles(const Context<T>& context) const {
+    return get_mobilizer()->get_angles(context);
+  }
+
+  /// Sets the `context` so that the generalized coordinates corresponding to
+  /// the rotation angles of `this` joint equals `angles`.
+  /// @param[in] context
+  ///   The context of the model this joint belongs to.
+  /// @param[in] angles
+  ///   The desired angles in radians to be stored in `context` ordered as θr,
+  ///   θp, θy. See get_angles() for details.
+  /// @returns a constant reference to `this` joint.
+  const BallRpyJoint<T>& set_angles(Context<T>* context,
+                                    const Vector3<T>& angles) const {
+    get_mobilizer()->set_angles(context, angles);
+    return *this;
+  }
+
+  /// Sets the default angles of this joint.  See get_angles() for details on
+  /// the angle representation.
+  void set_default_angles(const Vector3<double>& angles) {
+    get_mutable_mobilizer()->set_default_position(angles);
+  }
+
+  /// Sets the random distribution that angles of this joint will be randomly
+  /// sampled from. See get_angles() for details on the angle representation.
+  void set_random_angles_distribution(
+      const Vector3<symbolic::Expression>& angles) {
+    get_mutable_mobilizer()->set_random_position_distribution(
+        Vector3<symbolic::Expression>{angles});
+  }
+
+  /// Retrieves from `context` the angular velocity `w_FM` of the child frame
+  /// M in the parent frame F, expressed in F.
+  ///
+  /// @param[in] context
+  ///   The context of the model this joint belongs to.
+  /// @retval w_FM
+  ///   A vector in ℝ³ with the angular velocity of the child frame M in the
+  ///   parent frame F, expressed in F. Refer to this class's documentation for
+  ///   further details and definitions of these frames.
+  Vector3<T> get_angular_velocity(const systems::Context<T>& context) const {
+    return get_mobilizer()->get_angular_velocity(context);
+  }
+
+  /// Sets in `context` the state for `this` joint so that the angular velocity
+  /// of the child frame M in the parent frame F is `w_FM`.
+  /// @param[out] context
+  ///   The context of the model this joint belongs to.
+  /// @param[in] w_FM
+  ///   A vector in ℝ³ with the angular velocity of the child frame M in the
+  ///   parent frame F, expressed in F. Refer to this class's documentation for
+  ///   further details and definitions of these frames.
+  /// @returns a constant reference to `this` joint.
+  const BallRpyJoint<T>& set_angular_velocity(systems::Context<T>* context,
+                                              const Vector3<T>& w_FM) const {
+    get_mobilizer()->set_angular_velocity(context, w_FM);
+    return *this;
+  }
+
+  /// @}
+
+ protected:
+  /// Joint<T> override called through public NVI, Joint::AddInForce().
+  /// Adding forces per-dof makes no physical sense. Therefore, this method
+  /// throws an exception if invoked.
+  void DoAddInOneForce(const systems::Context<T>&, int, const T&,
+                       MultibodyForces<T>*) const override {
+    throw std::logic_error(
+        "Ball RPY joints do not allow applying forces to individual degrees of "
+        "freedom.");
+  }
+
+  /// Joint<T> override called through public NVI, Joint::AddInDamping().
+  /// Therefore arguments were already checked to be valid.
+  /// This method adds into `forces` a dissipative torque according to the
+  /// viscous law `τ = -d⋅ω`, with d the damping coefficient (see damping()).
+  void DoAddInDamping(const systems::Context<T>& context,
+                      MultibodyForces<T>* forces) const override {
+    Eigen::VectorBlock<Eigen::Ref<VectorX<T>>> t_BMo_F =
+        get_mobilizer()->get_mutable_generalized_forces_from_array(
+            &forces->mutable_generalized_forces());
+    const Vector3<T>& w_FM = get_angular_velocity(context);
+    t_BMo_F = -damping() * w_FM;
+  }
+
+ private:
+  int do_get_velocity_start() const override {
+    return get_mobilizer()->velocity_start_in_v();
+  }
+
+  int do_get_num_velocities() const override { return 3; }
+
+  int do_get_position_start() const override {
+    return get_mobilizer()->position_start_in_q();
+  }
+
+  int do_get_num_positions() const override { return 3; }
+
+  // Joint<T> overrides:
+  std::unique_ptr<typename Joint<T>::BluePrint> MakeImplementationBlueprint()
+      const override;
+
+  std::unique_ptr<Joint<double>> DoCloneToScalar(
+      const internal::MultibodyTree<double>& tree_clone) const override;
+
+  std::unique_ptr<Joint<AutoDiffXd>> DoCloneToScalar(
+      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const override;
+
+  std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
+      const internal::MultibodyTree<symbolic::Expression>&) const override;
+
+  // Make BallRpyJoint templated on every other scalar type a friend of
+  // BallRpyJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access
+  // private members of BallRpyJoint<T>.
+  template <typename>
+  friend class BallRpyJoint;
+
+  // Friend class to facilitate testing.
+  friend class JointTester;
+
+  // Returns the mobilizer implementing this joint.
+  // The internal implementation of this joint could change in a future version.
+  // However its public API should remain intact.
+  const internal::SpaceXYZMobilizer<T>* get_mobilizer() const {
+    // This implementation should only have one mobilizer.
+    DRAKE_DEMAND(this->get_implementation().num_mobilizers() == 1);
+    const internal::SpaceXYZMobilizer<T>* mobilizer =
+        dynamic_cast<const internal::SpaceXYZMobilizer<T>*>(
+            this->get_implementation().mobilizers_[0]);
+    DRAKE_DEMAND(mobilizer != nullptr);
+    return mobilizer;
+  }
+
+  internal::SpaceXYZMobilizer<T>* get_mutable_mobilizer() {
+    // This implementation should only have one mobilizer.
+    DRAKE_DEMAND(this->get_implementation().num_mobilizers() == 1);
+    auto* mobilizer = dynamic_cast<internal::SpaceXYZMobilizer<T>*>(
+        this->get_implementation().mobilizers_[0]);
+    DRAKE_DEMAND(mobilizer != nullptr);
+    return mobilizer;
+  }
+
+  // Helper method to make a clone templated on ToScalar.
+  template <typename ToScalar>
+  std::unique_ptr<Joint<ToScalar>> TemplatedDoCloneToScalar(
+      const internal::MultibodyTree<ToScalar>& tree_clone) const;
+
+  // This joint's damping constant in N⋅m⋅s.
+  double damping_{0};
+};
+
+template <typename T>
+const char BallRpyJoint<T>::kTypeName[] = "ball_rpy";
+
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::BallRpyJoint)

--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -305,6 +305,20 @@ class Joint : public MultibodyElement<Joint, T, JointIndex>  {
     return acc_upper_limits_;
   }
 
+  /// Sets the position limits to @p lower_limits and @p upper_limits.
+  /// @throws std::exception if the dimension of @p lower_limits or
+  /// @p upper_limits does not match num_positions().
+  /// @throws std::exception if any of @p lower_limits is larger than the
+  /// corresponding term in @p upper_limits.
+  void set_position_limits(const VectorX<double>& lower_limits,
+                           const VectorX<double>& upper_limits) {
+    DRAKE_THROW_UNLESS(lower_limits.size() == upper_limits.size());
+    DRAKE_THROW_UNLESS(lower_limits.size() == num_positions());
+    DRAKE_THROW_UNLESS((lower_limits.array() <= upper_limits.array()).all());
+    pos_lower_limits_ = lower_limits;
+    pos_upper_limits_ = upper_limits;
+  }
+
   /// Sets the velocity limits to @p lower_limits and @p upper_limits.
   /// @throws std::exception if the dimension of @p lower_limits or
   /// @p upper_limits does not match num_velocities().

--- a/multibody/tree/test/ball_rpy_joint_test.cc
+++ b/multibody/tree/test/ball_rpy_joint_test.cc
@@ -1,0 +1,203 @@
+// clang-format: off
+#include "drake/multibody/tree/multibody_tree-inl.h"
+// clang-format: on
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/tree/ball_rpy_joint.h"
+#include "drake/multibody/tree/rigid_body.h"
+#include "drake/systems/framework/context.h"
+
+namespace drake {
+namespace multibody {
+namespace {
+
+using Eigen::Vector3d;
+using systems::Context;
+
+constexpr double kPositionLowerLimit = -1.0;
+constexpr double kPositionUpperLimit = 1.5;
+constexpr double kVelocityLowerLimit = -1.1;
+constexpr double kVelocityUpperLimit = 1.6;
+constexpr double kAccelerationLowerLimit = -1.2;
+constexpr double kAccelerationUpperLimit = 1.7;
+constexpr double kDamping = 3;
+
+class BallRpyJointTest : public ::testing::Test {
+ public:
+  // Creates a MultibodyTree model of a spherical pendulum.
+  void SetUp() override {
+    // Spatial inertia for adding bodies. The actual value is not important for
+    // these tests and therefore we do not initialize it.
+    const SpatialInertia<double> M_B;  // Default construction is ok for this.
+
+    // Create an empty model.
+    auto model = std::make_unique<internal::MultibodyTree<double>>();
+
+    // Add some bodies so we can add joints between them:
+    body_ = &model->AddBody<RigidBody>(M_B);
+
+    // Add a ball rpy joint between the world and body:
+    joint_ = &model->AddJoint<BallRpyJoint>("Joint", model->world_body(),
+                                            std::nullopt, *body_, std::nullopt,
+                                            kDamping);
+    mutable_joint_ = dynamic_cast<BallRpyJoint<double>*>(
+        &model->get_mutable_joint(joint_->index()));
+    DRAKE_DEMAND(mutable_joint_);
+    mutable_joint_->set_position_limits(
+        Vector3d::Constant(kPositionLowerLimit),
+        Vector3d::Constant(kPositionUpperLimit));
+    mutable_joint_->set_velocity_limits(
+        Vector3d::Constant(kVelocityLowerLimit),
+        Vector3d::Constant(kVelocityUpperLimit));
+    mutable_joint_->set_acceleration_limits(
+        Vector3d::Constant(kAccelerationLowerLimit),
+        Vector3d::Constant(kAccelerationUpperLimit));
+
+    // We are done adding modeling elements. Transfer tree to system and get
+    // a Context.
+    system_ = std::make_unique<internal::MultibodyTreeSystem<double>>(
+        std::move(model));
+    context_ = system_->CreateDefaultContext();
+  }
+
+  const internal::MultibodyTree<double>& tree() const {
+    return internal::GetInternalTree(*system_);
+  }
+
+ protected:
+  std::unique_ptr<internal::MultibodyTreeSystem<double>> system_;
+  std::unique_ptr<Context<double>> context_;
+
+  const RigidBody<double>* body_{nullptr};
+  const BallRpyJoint<double>* joint_{nullptr};
+  BallRpyJoint<double>* mutable_joint_{nullptr};
+};
+
+TEST_F(BallRpyJointTest, Type) {
+  const Joint<double>& base = *joint_;
+  EXPECT_EQ(base.type_name(), BallRpyJoint<double>::kTypeName);
+}
+
+// Verify the expected number of dofs.
+TEST_F(BallRpyJointTest, NumDOFs) {
+  EXPECT_EQ(tree().num_positions(), 3);
+  EXPECT_EQ(tree().num_velocities(), 3);
+  EXPECT_EQ(joint_->num_positions(), 3);
+  EXPECT_EQ(joint_->num_velocities(), 3);
+  EXPECT_EQ(joint_->position_start(), 0);
+  EXPECT_EQ(joint_->velocity_start(), 0);
+}
+
+TEST_F(BallRpyJointTest, GetJointLimits) {
+  EXPECT_EQ(joint_->position_lower_limits().size(), 3);
+  EXPECT_EQ(joint_->position_upper_limits().size(), 3);
+  EXPECT_EQ(joint_->velocity_lower_limits().size(), 3);
+  EXPECT_EQ(joint_->velocity_upper_limits().size(), 3);
+  EXPECT_EQ(joint_->acceleration_lower_limits().size(), 3);
+  EXPECT_EQ(joint_->acceleration_upper_limits().size(), 3);
+
+  EXPECT_EQ(joint_->position_lower_limits(),
+            Vector3d::Constant(kPositionLowerLimit));
+  EXPECT_EQ(joint_->position_upper_limits(),
+            Vector3d::Constant(kPositionUpperLimit));
+  EXPECT_EQ(joint_->velocity_lower_limits(),
+            Vector3d::Constant(kVelocityLowerLimit));
+  EXPECT_EQ(joint_->velocity_upper_limits(),
+            Vector3d::Constant(kVelocityUpperLimit));
+  EXPECT_EQ(joint_->acceleration_lower_limits(),
+            Vector3d::Constant(kAccelerationLowerLimit));
+  EXPECT_EQ(joint_->acceleration_upper_limits(),
+            Vector3d::Constant(kAccelerationUpperLimit));
+  EXPECT_EQ(joint_->damping(), kDamping);
+}
+
+// Context-dependent value access.
+TEST_F(BallRpyJointTest, ContextDependentAccess) {
+  const Vector3d some_value(M_PI_2, 0., 1.);
+  // Angle access:
+  joint_->set_angles(context_.get(), some_value);
+  EXPECT_EQ(joint_->get_angles(*context_), some_value);
+
+  // Angular velocity access:
+  joint_->set_angular_velocity(context_.get(), some_value);
+  EXPECT_EQ(joint_->get_angular_velocity(*context_), some_value);
+}
+
+// Tests API to apply torques to joint.
+TEST_F(BallRpyJointTest, AddInOneForce) {
+  const double some_value = M_PI_2;
+  MultibodyForces<double> forces(tree());
+
+  // Since adding forces to individual degrees of freedom of this joint does
+  // not make physical sense, this method should throw.
+  EXPECT_THROW(joint_->AddInOneForce(*context_, 0, some_value, &forces),
+               std::logic_error);
+}
+
+TEST_F(BallRpyJointTest, Clone) {
+  auto model_clone = tree().CloneToScalar<AutoDiffXd>();
+  const auto& joint_clone = model_clone->get_variant(*joint_);
+
+  EXPECT_EQ(joint_clone.name(), joint_->name());
+  EXPECT_EQ(joint_clone.frame_on_parent().index(),
+            joint_->frame_on_parent().index());
+  EXPECT_EQ(joint_clone.frame_on_child().index(),
+            joint_->frame_on_child().index());
+  EXPECT_EQ(joint_clone.position_lower_limits(),
+            joint_->position_lower_limits());
+  EXPECT_EQ(joint_clone.position_upper_limits(),
+            joint_->position_upper_limits());
+  EXPECT_EQ(joint_clone.velocity_lower_limits(),
+            joint_->velocity_lower_limits());
+  EXPECT_EQ(joint_clone.velocity_upper_limits(),
+            joint_->velocity_upper_limits());
+  EXPECT_EQ(joint_clone.acceleration_lower_limits(),
+            joint_->acceleration_lower_limits());
+  EXPECT_EQ(joint_clone.acceleration_upper_limits(),
+            joint_->acceleration_upper_limits());
+  EXPECT_EQ(joint_clone.damping(), joint_->damping());
+}
+
+TEST_F(BallRpyJointTest, SetVelocityAndAccelerationLimits) {
+  const double new_lower = -0.2;
+  const double new_upper = 0.2;
+  // Check for velocity limits.
+  mutable_joint_->set_velocity_limits(Vector3d::Constant(new_lower),
+                                      Vector3d::Constant(new_upper));
+  EXPECT_EQ(joint_->velocity_lower_limits(), Vector3d::Constant(new_lower));
+  EXPECT_EQ(joint_->velocity_upper_limits(), Vector3d::Constant(new_upper));
+  // Does not match num_velocities().
+  EXPECT_THROW(mutable_joint_->set_velocity_limits(VectorX<double>(3),
+                                                   VectorX<double>()),
+               std::runtime_error);
+  EXPECT_THROW(mutable_joint_->set_velocity_limits(VectorX<double>(),
+                                                   VectorX<double>(3)),
+               std::runtime_error);
+  // Lower limit is larger than upper limit.
+  EXPECT_THROW(mutable_joint_->set_velocity_limits(Vector3d::Constant(2),
+                                                   Vector3d::Constant(0)),
+               std::runtime_error);
+
+  // Check for acceleration limits.
+  mutable_joint_->set_acceleration_limits(Vector3d::Constant(new_lower),
+                                          Vector3d::Constant(new_upper));
+  EXPECT_EQ(joint_->acceleration_lower_limits(), Vector3d::Constant(new_lower));
+  EXPECT_EQ(joint_->acceleration_upper_limits(), Vector3d::Constant(new_upper));
+  // Does not match num_velocities().
+  EXPECT_THROW(mutable_joint_->set_acceleration_limits(VectorX<double>(3),
+                                                       VectorX<double>()),
+               std::runtime_error);
+  EXPECT_THROW(mutable_joint_->set_acceleration_limits(VectorX<double>(),
+                                                       VectorX<double>(3)),
+               std::runtime_error);
+  // Lower limit is larger than upper limit.
+  EXPECT_THROW(mutable_joint_->set_acceleration_limits(Vector3d::Constant(2),
+                                                       Vector3d::Constant(0)),
+               std::runtime_error);
+}
+
+}  // namespace
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Creates `BallRpyJoint`, a three degree of freedom rotational joint that uses `SpaceXYZMobilizer` under the hood (and therefore defines orientation with Euler Angles).  The joint includes damping but not any spring force (much like `RevoluteJoint`).  In addition, joint limits in MBP are not enforced for this joint and there is no parsing added in this pr.  I would love to discuss fixing either/both of these deficiencies.

Relates #12404 

cc @sherm1 @amcastro-tri

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13039)
<!-- Reviewable:end -->
