### PR TITLE
integrators: dense integration works with witness isolation

### DIFF
--- a/common/trajectories/piecewise_trajectory.cc
+++ b/common/trajectories/piecewise_trajectory.cc
@@ -27,7 +27,7 @@ boolean<T> PiecewiseTrajectory<T>::is_time_in_range(const T& time) const {
 
 template <typename T>
 int PiecewiseTrajectory<T>::get_number_of_segments() const {
-  return static_cast<int>(breaks_.size() - 1);
+  return static_cast<int>(breaks_.size() > 0 ? breaks_.size() - 1 : 0);
 }
 
 template <typename T>

--- a/common/trajectories/piecewise_trajectory.h
+++ b/common/trajectories/piecewise_trajectory.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <limits>
 #include <memory>
 #include <random>
 #include <vector>
@@ -20,9 +21,8 @@ namespace trajectories {
 template <typename T>
 class PiecewiseTrajectory : public Trajectory<T> {
  public:
-  // TODO(ggould-tri) This quantity is surprisingly large and never justified.
   /// Minimum delta quantity used for comparing time.
-  static constexpr double kEpsilonTime = 1e-10;
+  static constexpr double kEpsilonTime = std::numeric_limits<double>::epsilon();
 
   ~PiecewiseTrajectory() override = default;
 

--- a/common/trajectories/test/piecewise_polynomial_test.cc
+++ b/common/trajectories/test/piecewise_polynomial_test.cc
@@ -247,7 +247,6 @@ GTEST_TEST(testPiecewisePolynomial, CubicSplinePeriodicBoundaryConditionTest) {
 // Test various exception cases.  We want to check that these throw rather
 // than crash (or return potentially bad data).
 GTEST_TEST(testPiecewisePolynomial, ExceptionsTest) {
-  const double less_than_epsilon = 1e-11;
   Eigen::VectorXd breaks(5);
   breaks << 0, 1, 2, 3, 4;
 
@@ -262,13 +261,6 @@ GTEST_TEST(testPiecewisePolynomial, ExceptionsTest) {
   // No throw with monotonic breaks.
   PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(
       breaks, samples, true);
-
-  // Throw when breaks are too close.
-  breaks[1] = less_than_epsilon;
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(
-          breaks, samples, true),
-      std::runtime_error, "Times must be at least .* apart.");
 
   // Throw when breaks are not strictly monotonic.
   breaks[1] = 0;

--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -468,6 +468,7 @@ drake_cc_googletest(
     name = "integrator_base_test",
     deps = [
         ":integrator_base",
+        "//common/test_utilities:expect_throws_message",
         "//systems/plants/spring_mass_system",
     ],
 )

--- a/systems/analysis/integrator_base.cc
+++ b/systems/analysis/integrator_base.cc
@@ -89,6 +89,11 @@ bool IntegratorBase<T>::StepOnceErrorControlledAtMost(const T& h_max) {
       ValidateSmallerStepSize(step_size_to_attempt, adjusted_step_size);
       ++num_shrinkages_from_substep_failures_;
       ++num_substep_failures_;
+      if (get_dense_output()) {
+        // Take dense output one step back to undo
+        // the last integration step.
+        dense_output_->RemoveFinalSegment();
+      }
     }
     step_size_to_attempt = adjusted_step_size;
 


### PR DESCRIPTION
- Adds a series of tests checking the dense output for error-controlled integration and witness isolation.
- Fixes a few curiousities in the PiecewiseTrajectory / PiecewisePolynomial stack, including the unexplained large tolerance required between successive segments in a piecewisetrajectory.
- IntegratorBase::DoDenseStep is no longer virtual, because the logic within has gotten more complicated and we need a more narrow entry point for any subclasses which eventually want to override the default dense output interpolation strategy.  [THIS IS TECHNICALLY A CHANGE TO THE PUBLIC API, BUT I BELIEVE IT IS ONE THAT HAS NO CONSUMERS].

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13045)
<!-- Reviewable:end -->
