### PR TITLE
common: Fix includes and using in polynomial.cc

### DIFF
--- a/common/polynomial.cc
+++ b/common/polynomial.cc
@@ -2,6 +2,7 @@
 
 #include <cstring>
 #include <limits>
+#include <numeric>
 #include <set>
 #include <stdexcept>
 #include <utility>
@@ -11,6 +12,7 @@
 
 using Eigen::Dynamic;
 using Eigen::Matrix;
+using std::accumulate;
 using std::pair;
 using std::runtime_error;
 using std::string;


### PR DESCRIPTION
Add to the polynomial.cc file the inclusion of the `numeric` header  and  of the `using std::accumulate` directive as it uses the `accumulate` function.

The code that invokes `accumulate` was moved in PR https://github.com/RobotLocomotion/drake/pull/12950 from the `common/symbolic_expression_cell.cc` that already had the correct include and using directives. 

I guess that this not created in the platforms covered in CI due to some transitive include.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13046)
<!-- Reviewable:end -->
