### PR TITLE
[render] Allow a geometry to target a renderer

### DIFF
--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -601,6 +601,14 @@ class SceneGraph final : public systems::LeafSystem<T> {
                   RoleAssign assign = RoleAssign::kNew) const;
 
   /** Assigns the perception role to the geometry indicated by `geometry_id`.
+
+   By default, a geometry with a perception role will be reified by all
+   render::RenderEngine instances. This behavior can be changed. Renderers can
+   be explicitly whitelisted via the ('renderer', 'accepting') perception
+   property. Its type is std::set<std::string> and it contains the names of
+   all the renderers that _may_ reify it. If no property is defined (or an
+   empty set is given), then the default behavior of all renderers attempting
+   to reify it will be restored.
    @pydrake_mkdoc_identifier{perception_direct}
    */
   void AssignRole(SourceId source_id, GeometryId geometry_id,

--- a/geometry/test_utilities/dummy_render_engine.h
+++ b/geometry/test_utilities/dummy_render_engine.h
@@ -98,6 +98,11 @@ class DummyRenderEngine final : public render::RenderEngine {
     return static_cast<int>(registered_geometries_.size());
   }
 
+  /** Reports `true` if the given id is registered with `this` engine.  */
+  bool is_registered(GeometryId id) const {
+    return registered_geometries_.count(id) > 0;
+  }
+
   /** Returns the ids that have been updated via a call to UpdatePoses() and
    the poses that were set.  */
   const std::map<GeometryId, math::RigidTransformd>& updated_ids() const {

--- a/multibody/parsing/detail_scene_graph.h
+++ b/multibody/parsing/detail_scene_graph.h
@@ -30,15 +30,45 @@ std::unique_ptr<geometry::Shape> MakeShapeFromSdfGeometry(
  file, this method makes a new drake::geometry::GeometryInstance object from
  this specification at a pose `X_LG` relatve to its parent link.
  This method returns nullptr when the given SDF specification corresponds
- to a geometry of type `sdf::GeometryType::EMPTY` (`<empty/>` SDF tag.)  */
+ to a geometry of type `sdf::GeometryType::EMPTY` (`<empty/>` SDF tag.)
+
+ <!-- TODO(SeanCurtis-TRI): Ultimately, a module for what we parse should be
+  written outside of this _internal_ namespace. This should go there and
+  merely reference it.  -->
+
+ <h2>Targeting Renderers</h2>
+
+ In addition to the standard SDF <visual> hierarchy, Drake offers an additional
+ tag `<drake:accepting_renderer>`:
+
+ ```
+    <visual>
+      <geometry ... />
+      <drake:accepting_renderer>renderer_name</drake:accepting_renderer>
+      ...
+    </visual>
+ ```
+
+ The new tag serves as a whitelist of renderers for which this visual is
+ targeted.
+
+  - The _value_ of the tag is the name of the renderer.
+  - If the _value_ is empty, that is a parsing error.
+  - If no instance of `<drake:accepting_renderer>` every renderer will be given
+    the chance to reify this visual geometry.
+  - Multiple instances of this tag are allowed. Each instance adds a renderer to
+    the white list.
+
+ This feature is one way to provide multiple visual representations of a body.
+ */
 std::unique_ptr<geometry::GeometryInstance> MakeGeometryInstanceFromSdfVisual(
     const sdf::Visual& sdf_visual, ResolveFilename resolve_filename,
     const math::RigidTransformd& X_LG);
 
 /** Extracts the material properties from the given sdf::Visual object.
  The sdf::Visual object represents a corresponding <visual> tag from an SDF
- file. The material properties are placed into a
- geometry::IllustrationProperties as follows:
+ file. The material properties are placed into both a
+ geometry::IllustrationProperties and geometry::PerceptionProperties  as follows:
 
  <!-- NOTE: Lines longer than 80 columns required for the doxygen tables. -->
  | Group |    Name     |      Type       | Description |

--- a/multibody/parsing/detail_urdf_geometry.h
+++ b/multibody/parsing/detail_urdf_geometry.h
@@ -93,6 +93,35 @@ UrdfMaterial ParseMaterial(const tinyxml2::XMLElement* node, bool name_required,
 
 /** Parses a "visual" element in @p node.
 
+ <!-- TODO(SeanCurtis-TRI): Ultimately, a module for what we parse should be
+  written outside of this _internal_ namespace. This should go there and
+  merely reference it.  -->
+
+ <h2>Targeting Renderers</h2>
+
+ In addition to the standard SDF <visual> hierarchy, Drake offers an additional
+ tag `<drake:accepting_renderer>`:
+
+ ```
+    <visual>
+      <geometry ... />
+      <drake:accepting_renderer name="renderer_name" />
+      ...
+    </visual>
+ ```
+
+ The new tag serves as a whitelist of renderers for which this visual is
+ targeted.
+
+  - The _value_ of the tag is the name of the renderer.
+  - If the _value_ is empty, that is a parsing error.
+  - If no instance of `<drake:accepting_renderer>` every renderer will be given
+    the chance to reify this visual geometry.
+  - Multiple instances of this tag are allowed. Each instance adds a renderer to
+    the white list.
+
+ This feature is one way to provide multiple visual representations of a body.
+
  @param[in] parent_element_name The name of the parent link element, used
  to construct default geometry names and for error reporting.
  @param[in,out] materials The MaterialMap is used to look up materials

--- a/multibody/parsing/test/detail_urdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_urdf_geometry_test.cc
@@ -51,6 +51,7 @@ using tinyxml2::XMLElement;
 
 using math::RigidTransformd;
 using geometry::GeometryInstance;
+using geometry::IllustrationProperties;
 using geometry::ProximityProperties;
 
 // Confirms the logic for reconciling named references to materials.
@@ -667,6 +668,50 @@ TEST_F(UrdfGeometryTests, CollisionProperties) {
   ASSERT_NE(instance.proximity_properties(), nullptr);
   const ProximityProperties& properties = *instance.proximity_properties();
   verify_friction(properties, {4.5, 4.5});
+}
+
+// Confirms that the <drake:accepting_renderer> tag gets properly parsed.
+TEST_F(UrdfGeometryTests, AcceptingRenderers) {
+  const std::string resource_dir{
+    "drake/multibody/parsing/test/urdf_parser_test/"};
+  const std::string file_no_conflict_1 = FindResourceOrThrow(
+      resource_dir + "accepting_renderer.urdf");
+
+  // TODO(SeanCurtis-TRI): Test for the <drake:accepting_renderer> tag without
+  //  name attribute when we can test using an in-memory XML.
+
+  DRAKE_EXPECT_NO_THROW(ParseUrdfGeometry(file_no_conflict_1));
+
+  ASSERT_EQ(visual_instances_.size(), 3);
+
+  const std::string group = "renderer";
+  const std::string property = "accepting";
+
+  for (const auto& instance : visual_instances_) {
+    // TODO(SeanCurtis-TRI): When perception properties are uniquely parsed
+    //  from the file, change this to PerceptionProperties.
+    EXPECT_NE(instance.illustration_properties(), nullptr);
+    const IllustrationProperties& props = *instance.illustration_properties();
+    if (instance.name() == "all_renderers") {
+      EXPECT_FALSE(props.HasProperty(group, property));
+    } else if (instance.name() == "single_renderer") {
+      EXPECT_TRUE(props.HasProperty(group, property));
+      const auto& names =
+          props.GetProperty<std::set<std::string>>(group, property);
+      EXPECT_EQ(names.size(), 1);
+      EXPECT_EQ(names.count("renderer1"), 1);
+    } else if (instance.name() == "multi_renderer") {
+      EXPECT_TRUE(props.HasProperty(group, property));
+      const auto& names =
+          props.GetProperty<std::set<std::string>>(group, property);
+      EXPECT_EQ(names.size(), 2);
+      EXPECT_EQ(names.count("renderer1"), 1);
+      EXPECT_EQ(names.count("renderer2"), 1);
+    } else {
+      GTEST_FAIL() << "Encountered visual geometry not expected: "
+                     << instance.name();
+    }
+  }
 }
 
 }  // namespace

--- a/multibody/parsing/test/urdf_parser_test/accepting_renderer.urdf
+++ b/multibody/parsing/test/urdf_parser_test/accepting_renderer.urdf
@@ -1,0 +1,37 @@
+<?xml version="1.0" ?>
+
+<robot name="non_conflicting_materials_1">
+  <material name="brown">
+    <color rgba="0.93333333333 0.79607843137 0.67843137254 1"/>
+  </material>
+  <material name="red">
+    <color rgba="0.93333333333 0.2 0.2 1"/>
+  </material>
+  <link name="base_link">
+    <visual name="all_renderers">
+      <geometry>
+        <capsule length="0.5" radius="0.2"/>
+      </geometry>
+      <!-- No <drake:accepting_renderer/> tag -->
+    </visual>
+    <visual name="single_renderer">
+      <geometry>
+        <sphere radius="0.25"/>
+      </geometry>
+      <material name="textured">
+        <texture filename="empty.png" />
+      </material>
+      <drake:accepting_renderer name="renderer1"/>
+    </visual>
+    <visual name="multi_renderer">
+      <geometry>
+        <sphere radius="0.25"/>
+      </geometry>
+      <material name="textured">
+        <texture filename="empty.png" />
+      </material>
+      <drake:accepting_renderer name="renderer1"/>
+      <drake:accepting_renderer name="renderer2"/>
+    </visual>
+  </link>
+</robot>

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -407,6 +407,11 @@ geometry::GeometryId MultibodyPlant<T>::RegisterVisualGeometry(
         "phong", "diffuse_map",
         properties.GetProperty<std::string>("phong", "diffuse_map"));
   }
+  if (properties.HasProperty("renderer", "accepting")) {
+    perception_props.AddProperty(
+      "renderer", "accepting",
+      properties.GetProperty<std::set<std::string>>("renderer", "accepting"));
+  }
   member_scene_graph().AssignRole(*source_id_, id, perception_props);
 
   const int visual_index = geometry_id_to_visual_index_.size();

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -1441,10 +1441,14 @@ GTEST_TEST(MultibodyPlantTest, VisualGeometryRegistration) {
   const Vector4<double> sphere2_diffuse{0.1, 0.9, 0.1, 0.5};
   sphere2_props.AddProperty("phong", "diffuse", sphere2_diffuse);
   sphere2_props.AddProperty("phong", "diffuse_map", "empty.png");
+  sphere2_props.AddProperty("renderer", "accepting",
+                            std::set<std::string>{"not_dummy"});
   GeometryId sphere2_id = plant.RegisterVisualGeometry(
-      sphere2, RigidTransformd::Identity(), geometry::Sphere(radius),
-      "visual", sphere2_props);
-  EXPECT_EQ(render_engine.num_registered(), 3);
+      sphere2, RigidTransformd::Identity(), geometry::Sphere(radius), "visual",
+      sphere2_props);
+  // Because sphere 2 white listed a *different* renderer, it didn't get added
+  // to render_engine.
+  EXPECT_EQ(render_engine.num_registered(), 2);
 
   // We are done defining the model.
   plant.Finalize();


### PR DESCRIPTION
This allows for a geometry to define a property in its perception properties which determines whether a RenderEngine will implement it or not. It works by matching the renderer's name with an optionally whitelisted set of "accepting" renderers.

Add new tag to the SDF and URDF files.

 - URDF:
```
  <visual>
    ...
    <drake:accepting_renderer name="renderer_name"/>
  </visual>`
```

 - SDF: 
```
  <visual>
    ...
    <drake:accepting_renderer>renderer_name
    </drake:accepting_renderer>
  </visual>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13053)
<!-- Reviewable:end -->
