### PR TITLE
multibody: Implement UniversalJoint

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -33,6 +33,7 @@ from pydrake.multibody.tree import (
     SpatialInertia_,
     UniformGravityFieldElement_,
     UnitInertia_,
+    UniversalJoint_,
     WeldJoint_,
     world_index,
     world_model_instance,
@@ -1065,6 +1066,14 @@ class TestPlant(unittest.TestCase):
                 damping=2.,
             )
 
+        def make_universal_joint(plant, P, C):
+            return UniversalJoint_[T](
+                name="universal",
+                frame_on_parent=P,
+                frame_on_child=C,
+                damping=2.,
+            )
+
         def make_weld_joint(plant, P, C):
             # TODO(eric.cousineau): Update WeldJoint arg names to be consistent
             # with other joints.
@@ -1079,6 +1088,7 @@ class TestPlant(unittest.TestCase):
             make_ball_rpy_joint,
             make_prismatic_joint,
             make_revolute_joint,
+            make_universal_joint,
             make_weld_joint,
         ]
 
@@ -1123,6 +1133,13 @@ class TestPlant(unittest.TestCase):
                 set_point = 1.
                 joint.set_angle(context=context, angle=set_point)
                 self.assertIsInstance(joint.get_angle(context=context), T)
+            elif joint.name() == "universal":
+                set_point = np.array([1., 2.])
+                joint.set_angles(context=context, angles=set_point)
+                self.assertEqual(len(joint.get_angles(context=context)), 2)
+                joint.set_angular_rates(context=context, theta_dot=set_point)
+                self.assertEqual(
+                    len(joint.get_angular_rates(context=context)), 2)
             elif joint.name() == "weld":
                 # No joint specifc methods to test
                 pass

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -1039,7 +1039,33 @@ class TestPlant(unittest.TestCase):
         `HasJointActuatorNamed`.
         """
 
-        def make_weld(plant, P, C):
+        def make_ball_rpy_joint(plant, P, C):
+            return BallRpyJoint_[T](
+                name="ball_rpy",
+                frame_on_parent=P,
+                frame_on_child=C,
+                damping=2.,
+            )
+
+        def make_prismatic_joint(plant, P, C):
+            return PrismaticJoint_[T](
+                name="prismatic",
+                frame_on_parent=P,
+                frame_on_child=C,
+                axis=[1., 0., 0.],
+                damping=2.,
+            )
+
+        def make_revolute_joint(plant, P, C):
+            return RevoluteJoint_[T](
+                name="revolute",
+                frame_on_parent=P,
+                frame_on_child=C,
+                axis=[1., 0., 0.],
+                damping=2.,
+            )
+
+        def make_weld_joint(plant, P, C):
             # TODO(eric.cousineau): Update WeldJoint arg names to be consistent
             # with other joints.
             return WeldJoint_[T](
@@ -1049,37 +1075,11 @@ class TestPlant(unittest.TestCase):
                 X_PC=RigidTransform_[float](),
             )
 
-        def make_prismatic(plant, P, C):
-            return PrismaticJoint_[T](
-                name="prismatic",
-                frame_on_parent=P,
-                frame_on_child=C,
-                axis=[1., 0., 0.],
-                damping=2.,
-            )
-
-        def make_revolute(plant, P, C):
-            return RevoluteJoint_[T](
-                name="revolute",
-                frame_on_parent=P,
-                frame_on_child=C,
-                axis=[1., 0., 0.],
-                damping=2.,
-            )
-
-        def make_ball_rpy_joint(plant, P, C):
-            return BallRpyJoint_[T](
-                name="ball_rpy",
-                frame_on_parent=P,
-                frame_on_child=C,
-                damping=2.,
-            )
-
         make_joint_list = [
-            make_weld,
-            make_prismatic,
-            make_revolute,
             make_ball_rpy_joint,
+            make_prismatic_joint,
+            make_revolute_joint,
+            make_weld_joint,
         ]
 
         for make_joint in make_joint_list:
@@ -1101,6 +1101,34 @@ class TestPlant(unittest.TestCase):
                 self.assertIsInstance(actuator, JointActuator_[T])
             plant.Finalize()
             self._test_joint_api(T, joint)
+
+            context = plant.CreateDefaultContext()
+            if joint.name() == "ball_rpy":
+                set_point = np.array([1., 2., 3.])
+                joint.set_angles(context=context, angles=set_point)
+                self.assertEqual(len(joint.get_angles(context=context)), 3)
+                joint.set_angular_velocity(context=context, w_FM=set_point)
+                self.assertEqual(
+                    len(joint.get_angular_velocity(context=context)), 3)
+            elif joint.name() == "prismatic":
+                set_point = 1.
+                joint.set_translation(context=context, translation=set_point)
+                self.assertIsInstance(
+                    joint.get_translation(context=context), T)
+                joint.set_translation_rate(context=context,
+                                           translation_dot=set_point)
+                self.assertIsInstance(
+                    joint.get_translation_rate(context=context), T)
+            elif joint.name() == "revolute":
+                set_point = 1.
+                joint.set_angle(context=context, angle=set_point)
+                self.assertIsInstance(joint.get_angle(context=context), T)
+            elif joint.name() == "weld":
+                # No joint specifc methods to test
+                pass
+            else:
+                raise TypeError(
+                    "Joint type " + joint.name() + " not recognized.")
 
     @numpy_compare.check_all_types
     def test_multibody_add_frame(self, T):

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -26,6 +26,7 @@
 #include "drake/multibody/tree/revolute_joint.h"
 #include "drake/multibody/tree/revolute_spring.h"
 #include "drake/multibody/tree/rigid_body.h"
+#include "drake/multibody/tree/universal_joint.h"
 #include "drake/multibody/tree/weld_joint.h"
 
 namespace drake {
@@ -318,6 +319,30 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("set_random_angle_distribution",
             &Class::set_random_angle_distribution, py::arg("angle"),
             cls_doc.set_random_angle_distribution.doc);
+  }
+
+  // UniversalJoint
+  {
+    using Class = UniversalJoint<T>;
+    constexpr auto& cls_doc = doc.UniversalJoint;
+    auto cls = DefineTemplateClassWithDefault<Class, Joint<T>>(
+        m, "UniversalJoint", param, cls_doc.doc);
+    cls  // BR
+        .def(
+            py::init<const string&, const Frame<T>&, const Frame<T>&, double>(),
+            py::arg("name"), py::arg("frame_on_parent"),
+            py::arg("frame_on_child"), py::arg("damping") = 0, cls_doc.ctor.doc)
+        .def("get_angles", &Class::get_angles, py::arg("context"),
+            cls_doc.get_angles.doc)
+        .def("set_angles", &Class::set_angles, py::arg("context"),
+            py::arg("angles"), cls_doc.set_angles.doc)
+        .def("get_angular_rates", &Class::get_angular_rates, py::arg("context"),
+            cls_doc.get_angular_rates.doc)
+        .def("set_angular_rates", &Class::set_angular_rates, py::arg("context"),
+            py::arg("theta_dot"), cls_doc.set_angular_rates.doc)
+        .def("set_random_angles_distribution",
+            &Class::set_random_angles_distribution, py::arg("angles"),
+            cls_doc.set_random_angles_distribution.doc);
   }
 
   // WeldJoint

--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -111,6 +111,7 @@ drake_cc_library(
         "rigid_body.cc",
         "space_xyz_mobilizer.cc",
         "uniform_gravity_field_element.cc",
+        "universal_joint.cc",
         "universal_mobilizer.cc",
         "weld_joint.cc",
         "weld_mobilizer.cc",
@@ -146,6 +147,7 @@ drake_cc_library(
         "rigid_body.h",
         "space_xyz_mobilizer.h",
         "uniform_gravity_field_element.h",
+        "universal_joint.h",
         "universal_mobilizer.h",
         "weld_joint.h",
         "weld_mobilizer.h",
@@ -499,6 +501,14 @@ drake_cc_googletest(
     name = "prismatic_joint_test",
     deps = [
         ":tree",
+    ],
+)
+
+drake_cc_googletest(
+    name = "universal_joint_test",
+    deps = [
+        ":tree",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/multibody/tree/ball_rpy_joint.h
+++ b/multibody/tree/ball_rpy_joint.h
@@ -245,9 +245,6 @@ class BallRpyJoint final : public Joint<T> {
   template <typename>
   friend class BallRpyJoint;
 
-  // Friend class to facilitate testing.
-  friend class JointTester;
-
   // Returns the mobilizer implementing this joint.
   // The internal implementation of this joint could change in a future version.
   // However its public API should remain intact.

--- a/multibody/tree/prismatic_joint.h
+++ b/multibody/tree/prismatic_joint.h
@@ -311,9 +311,6 @@ class PrismaticJoint final : public Joint<T> {
   // private members of PrismaticJoint<T>.
   template <typename> friend class PrismaticJoint;
 
-  // Friend class to facilitate testing.
-  friend class JointTester;
-
   // Returns the mobilizer implementing this joint.
   // The internal implementation of this joint could change in a future version.
   // However its public API should remain intact.

--- a/multibody/tree/space_xyz_mobilizer.h
+++ b/multibody/tree/space_xyz_mobilizer.h
@@ -73,8 +73,6 @@ class SpaceXYZMobilizer final : public MobilizerImpl<T, 3, 3> {
                    const Frame<T>& outboard_frame_M) :
       MobilizerBase(inboard_frame_F, outboard_frame_M) {}
 
-  bool is_floating() const override { return true; }
-
   bool has_quaternion_dofs() const override { return false; }
 
   /// Retrieves from `context` the three space x-y-z angles θ₁, θ₂, θ₃ which

--- a/multibody/tree/test/free_rotating_body_test.cc
+++ b/multibody/tree/test/free_rotating_body_test.cc
@@ -48,19 +48,11 @@ GTEST_TEST(RollPitchYawTest, TimeDerivatives) {
   FreeRotatingBodyPlant<double> free_body_plant(benchmark_.get_I(),
                                                 benchmark_.get_J());
 
-  // We expect the body in this model to be a floating body, however not modeled
-  // using a quaternion mobilizer (it uses a SpaceXYZMobilizer).
-  EXPECT_TRUE(free_body_plant.body().is_floating());
+  // The body in this model is not a floating body but is free to rotate. The
+  // rotation is not modeled using a quaternion mobilizer (it uses a
+  // SpaceXYZMobilizer).
+  EXPECT_FALSE(free_body_plant.body().is_floating());
   EXPECT_FALSE(free_body_plant.body().has_quaternion_dofs());
-
-  // For this simple example with a single floating body we can verify indexes
-  // into the state. In addition, the test above verifies we are not using a
-  // quaternions, but a SpaceXYZMobilizer (3-dofs).
-  // In the state vector x for the model, positions q go first followed by
-  // velocities v. Similarly, angular components go first, followed by
-  // translational components.
-  EXPECT_EQ(free_body_plant.body().floating_positions_start(), 0);
-  EXPECT_EQ(free_body_plant.body().floating_velocities_start(), 3);
 
   // Simulator will create a Context by calling this system's
   // CreateDefaultContext(). This in turn will initialize its state by making a

--- a/multibody/tree/test/universal_joint_test.cc
+++ b/multibody/tree/test/universal_joint_test.cc
@@ -1,0 +1,260 @@
+// clang-format: off
+#include "drake/multibody/tree/multibody_tree-inl.h"
+// clang-format: on
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/multibody/tree/rigid_body.h"
+#include "drake/multibody/tree/universal_joint.h"
+#include "drake/systems/framework/context.h"
+
+namespace drake {
+namespace multibody {
+namespace {
+
+using Eigen::Vector2d;
+using systems::Context;
+
+constexpr double kPositionLowerLimit = -1.0;
+constexpr double kPositionUpperLimit = 1.5;
+constexpr double kVelocityLowerLimit = -1.1;
+constexpr double kVelocityUpperLimit = 1.6;
+constexpr double kAccelerationLowerLimit = -1.2;
+constexpr double kAccelerationUpperLimit = 1.7;
+constexpr double kDamping = 3;
+constexpr double kPositionNonZeroDefault = 0.25;
+
+class UniversalJointTest : public ::testing::Test {
+ public:
+  // Creates a MultibodyTree model with a body hanging from a universal joint.
+  void SetUp() override {
+    // Spatial inertia for adding bodies. The actual value is not important for
+    // these tests and therefore we do not initialize it.
+    const SpatialInertia<double> M_B;  // Default construction is ok for this.
+
+    // Create an empty model.
+    auto model = std::make_unique<internal::MultibodyTree<double>>();
+
+    // Add some bodies so we can add joints between them:
+    body_ = &model->AddBody<RigidBody>(M_B);
+
+    // Add a universal joint between the world and body1:
+    joint_ = &model->AddJoint<UniversalJoint>("Joint", model->world_body(),
+                                              std::nullopt, *body_,
+                                              std::nullopt, kDamping);
+    mutable_joint_ = dynamic_cast<UniversalJoint<double>*>(
+        &model->get_mutable_joint(joint_->index()));
+    DRAKE_DEMAND(mutable_joint_);
+    mutable_joint_->set_position_limits(
+        Vector2d::Constant(kPositionLowerLimit),
+        Vector2d::Constant(kPositionUpperLimit));
+    mutable_joint_->set_velocity_limits(
+        Vector2d::Constant(kVelocityLowerLimit),
+        Vector2d::Constant(kVelocityUpperLimit));
+    mutable_joint_->set_acceleration_limits(
+        Vector2d::Constant(kAccelerationLowerLimit),
+        Vector2d::Constant(kAccelerationUpperLimit));
+
+    // We are done adding modeling elements. Transfer tree to system and get
+    // a Context.
+    system_ = std::make_unique<internal::MultibodyTreeSystem<double>>(
+        std::move(model));
+    context_ = system_->CreateDefaultContext();
+  }
+
+  const internal::MultibodyTree<double>& tree() const {
+    return internal::GetInternalTree(*system_);
+  }
+
+ protected:
+  std::unique_ptr<internal::MultibodyTreeSystem<double>> system_;
+  std::unique_ptr<Context<double>> context_;
+
+  const RigidBody<double>* body_{nullptr};
+  const UniversalJoint<double>* joint_{nullptr};
+  UniversalJoint<double>* mutable_joint_{nullptr};
+};
+
+TEST_F(UniversalJointTest, Type) {
+  const Joint<double>& base = *joint_;
+  EXPECT_EQ(base.type_name(), UniversalJoint<double>::kTypeName);
+}
+
+// Verify the expected number of dofs.
+TEST_F(UniversalJointTest, NumDOFs) {
+  EXPECT_EQ(tree().num_positions(), 2);
+  EXPECT_EQ(tree().num_velocities(), 2);
+  EXPECT_EQ(joint_->num_positions(), 2);
+  EXPECT_EQ(joint_->num_velocities(), 2);
+  EXPECT_EQ(joint_->position_start(), 0);
+  EXPECT_EQ(joint_->velocity_start(), 0);
+}
+
+TEST_F(UniversalJointTest, GetJointLimits) {
+  EXPECT_EQ(joint_->position_lower_limits().size(), 2);
+  EXPECT_EQ(joint_->position_upper_limits().size(), 2);
+  EXPECT_EQ(joint_->velocity_lower_limits().size(), 2);
+  EXPECT_EQ(joint_->velocity_upper_limits().size(), 2);
+  EXPECT_EQ(joint_->acceleration_lower_limits().size(), 2);
+  EXPECT_EQ(joint_->acceleration_upper_limits().size(), 2);
+
+  EXPECT_EQ(joint_->position_lower_limits(),
+            Vector2d::Constant(kPositionLowerLimit));
+  EXPECT_EQ(joint_->position_upper_limits(),
+            Vector2d::Constant(kPositionUpperLimit));
+  EXPECT_EQ(joint_->velocity_lower_limits(),
+            Vector2d::Constant(kVelocityLowerLimit));
+  EXPECT_EQ(joint_->velocity_upper_limits(),
+            Vector2d::Constant(kVelocityUpperLimit));
+  EXPECT_EQ(joint_->acceleration_lower_limits(),
+            Vector2d::Constant(kAccelerationLowerLimit));
+  EXPECT_EQ(joint_->acceleration_upper_limits(),
+            Vector2d::Constant(kAccelerationUpperLimit));
+  EXPECT_EQ(joint_->damping(), kDamping);
+}
+
+// Context-dependent value access.
+TEST_F(UniversalJointTest, ContextDependentAccess) {
+  const Vector2d some_value(M_PI_2, 0.3);
+  // Angle access:
+  joint_->set_angles(context_.get(), some_value);
+  EXPECT_EQ(joint_->get_angles(*context_), some_value);
+
+  // Angular rate access:
+  joint_->set_angular_rates(context_.get(), some_value);
+  EXPECT_EQ(joint_->get_angular_rates(*context_), some_value);
+}
+
+// Tests API to apply torques to individual dof of joint.
+TEST_F(UniversalJointTest, AddInOneForce) {
+  const double some_value = M_PI_2;
+  const double kEpsilon = std::numeric_limits<double>::epsilon();
+  MultibodyForces<double> forces1(tree());
+  MultibodyForces<double> forces2(tree());
+
+  for (int ii = 0; ii < joint_->num_positions(); ii++) {
+    // Add value twice:
+    joint_->AddInOneForce(*context_, ii, some_value, &forces1);
+    joint_->AddInOneForce(*context_, ii, some_value, &forces1);
+    // Add value only once:
+    joint_->AddInOneForce(*context_, ii, some_value, &forces2);
+  }
+  // Add forces2 into itself (same as adding torque twice):
+  forces2.AddInForces(forces2);
+
+  // forces1 and forces2 should be equal:
+  EXPECT_EQ(forces1.generalized_forces(), forces2.generalized_forces());
+  auto F2 = forces2.body_forces().cbegin();
+  for (auto& F1 : forces1.body_forces())
+    EXPECT_TRUE(F1.IsApprox(*F2++, kEpsilon));
+}
+
+TEST_F(UniversalJointTest, Clone) {
+  auto model_clone = tree().CloneToScalar<AutoDiffXd>();
+  const auto& joint_clone = model_clone->get_variant(*joint_);
+
+  EXPECT_EQ(joint_clone.name(), joint_->name());
+  EXPECT_EQ(joint_clone.frame_on_parent().index(),
+            joint_->frame_on_parent().index());
+  EXPECT_EQ(joint_clone.frame_on_child().index(),
+            joint_->frame_on_child().index());
+  EXPECT_EQ(joint_clone.position_lower_limits(),
+            joint_->position_lower_limits());
+  EXPECT_EQ(joint_clone.position_upper_limits(),
+            joint_->position_upper_limits());
+  EXPECT_EQ(joint_clone.velocity_lower_limits(),
+            joint_->velocity_lower_limits());
+  EXPECT_EQ(joint_clone.velocity_upper_limits(),
+            joint_->velocity_upper_limits());
+  EXPECT_EQ(joint_clone.acceleration_lower_limits(),
+            joint_->acceleration_lower_limits());
+  EXPECT_EQ(joint_clone.acceleration_upper_limits(),
+            joint_->acceleration_upper_limits());
+  EXPECT_EQ(joint_clone.damping(), joint_->damping());
+}
+
+TEST_F(UniversalJointTest, SetVelocityAndAccelerationLimits) {
+  const double new_lower = -0.2;
+  const double new_upper = 0.2;
+  // Check for velocity limits.
+  mutable_joint_->set_velocity_limits(Vector2d::Constant(new_lower),
+                                      Vector2d::Constant(new_upper));
+  EXPECT_EQ(joint_->velocity_lower_limits(), Vector2d::Constant(new_lower));
+  EXPECT_EQ(joint_->velocity_upper_limits(), Vector2d::Constant(new_upper));
+  // Does not match num_velocities().
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      mutable_joint_->set_velocity_limits(VectorX<double>(2),
+                                          VectorX<double>()),
+      std::runtime_error,
+      ".* 'lower_limits.size\\(\\) == upper_limits.size\\(\\)' failed.");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      mutable_joint_->set_velocity_limits(VectorX<double>(),
+                                          VectorX<double>(2)),
+      std::runtime_error,
+      ".* 'lower_limits.size\\(\\) == upper_limits.size\\(\\)' failed.");
+  // Lower limit is larger than upper limit.
+  DRAKE_EXPECT_THROWS_MESSAGE(mutable_joint_->set_velocity_limits(
+                                  Vector2d::Constant(2), Vector2d::Constant(0)),
+                              std::runtime_error,
+                              ".* '\\(lower_limits.array\\(\\) <= "
+                              "upper_limits.array\\(\\)\\).all\\(\\)' failed.");
+
+  // Check for acceleration limits.
+  mutable_joint_->set_acceleration_limits(Vector2d::Constant(new_lower),
+                                          Vector2d::Constant(new_upper));
+  EXPECT_EQ(joint_->acceleration_lower_limits(), Vector2d::Constant(new_lower));
+  EXPECT_EQ(joint_->acceleration_upper_limits(), Vector2d::Constant(new_upper));
+  // Does not match num_velocities().
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      mutable_joint_->set_acceleration_limits(VectorX<double>(2),
+                                              VectorX<double>()),
+      std::runtime_error,
+      ".* 'lower_limits.size\\(\\) == upper_limits.size\\(\\)' failed.");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      mutable_joint_->set_acceleration_limits(VectorX<double>(),
+                                              VectorX<double>(2)),
+      std::runtime_error,
+      ".* 'lower_limits.size\\(\\) == upper_limits.size\\(\\)' failed.");
+  // Lower limit is larger than upper limit.
+  DRAKE_EXPECT_THROWS_MESSAGE(mutable_joint_->set_acceleration_limits(
+                                  Vector2d::Constant(2), Vector2d::Constant(0)),
+                              std::runtime_error,
+                              ".* '\\(lower_limits.array\\(\\) <= "
+                              "upper_limits.array\\(\\)\\).all\\(\\)' failed.");
+}
+
+TEST_F(UniversalJointTest, DefaultAngles) {
+  const Vector2d lower_limit_angles = Vector2d::Constant(kPositionLowerLimit);
+  const Vector2d upper_limit_angles = Vector2d::Constant(kPositionUpperLimit);
+
+  const Vector2d default_angles = Vector2d::Zero();
+
+  const Vector2d new_default_angles =
+      Vector2d::Constant(kPositionNonZeroDefault);
+
+  const Vector2d out_of_bounds_low_angles =
+      lower_limit_angles - Vector2d::Constant(1);
+  const Vector2d out_of_bounds_high_angles =
+      upper_limit_angles + Vector2d::Constant(1);
+
+  // Constructor should set the default angle to Vector2d::Zero()
+  EXPECT_EQ(joint_->get_default_angles(), default_angles);
+
+  // Setting a new default angle should propagate so that `get_default_angle()`
+  // remains correct.
+  mutable_joint_->set_default_angles(new_default_angles);
+  EXPECT_EQ(joint_->get_default_angles(), new_default_angles);
+
+  // Setting the default angle out of the bounds of the position limits
+  // should NOT throw an exception.
+  EXPECT_NO_THROW(
+      mutable_joint_->set_default_angles(out_of_bounds_low_angles));
+  EXPECT_NO_THROW(
+      mutable_joint_->set_default_angles(out_of_bounds_high_angles));
+}
+
+}  // namespace
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/tree/universal_joint.cc
+++ b/multibody/tree/universal_joint.cc
@@ -1,0 +1,69 @@
+#include "drake/multibody/tree/universal_joint.h"
+
+#include <memory>
+
+#include "drake/multibody/tree/multibody_tree.h"
+
+namespace drake {
+namespace multibody {
+
+template <typename T>
+template <typename ToScalar>
+std::unique_ptr<Joint<ToScalar>> UniversalJoint<T>::TemplatedDoCloneToScalar(
+    const internal::MultibodyTree<ToScalar>& tree_clone) const {
+  const Frame<ToScalar>& frame_on_parent_body_clone =
+      tree_clone.get_variant(this->frame_on_parent());
+  const Frame<ToScalar>& frame_on_child_body_clone =
+      tree_clone.get_variant(this->frame_on_child());
+
+  // Make the Joint<T> clone.
+  auto joint_clone = std::make_unique<UniversalJoint<ToScalar>>(
+      this->name(), frame_on_parent_body_clone, frame_on_child_body_clone,
+      this->damping());
+  joint_clone->set_position_limits(this->position_lower_limits(),
+                                   this->position_upper_limits());
+  joint_clone->set_velocity_limits(this->velocity_lower_limits(),
+                                   this->velocity_upper_limits());
+  joint_clone->set_acceleration_limits(this->acceleration_lower_limits(),
+                                       this->acceleration_upper_limits());
+
+  return std::move(joint_clone);
+}
+
+template <typename T>
+std::unique_ptr<Joint<double>> UniversalJoint<T>::DoCloneToScalar(
+    const internal::MultibodyTree<double>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
+template <typename T>
+std::unique_ptr<Joint<AutoDiffXd>> UniversalJoint<T>::DoCloneToScalar(
+    const internal::MultibodyTree<AutoDiffXd>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
+template <typename T>
+std::unique_ptr<Joint<symbolic::Expression>> UniversalJoint<T>::DoCloneToScalar(
+    const internal::MultibodyTree<symbolic::Expression>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
+// N.B. Due to esoteric linking errors on Mac (see #9345) involving
+// `MobilizerImpl`, we must place this implementation in the source file, not
+// in the header file.
+template <typename T>
+std::unique_ptr<typename Joint<T>::BluePrint>
+UniversalJoint<T>::MakeImplementationBlueprint() const {
+  auto blue_print = std::make_unique<typename Joint<T>::BluePrint>();
+  auto univeral_mobilizer = std::make_unique<internal::UniversalMobilizer<T>>(
+      this->frame_on_parent(), this->frame_on_child());
+  univeral_mobilizer->set_default_position(this->default_positions());
+  blue_print->mobilizers_.push_back(std::move(univeral_mobilizer));
+  return std::move(blue_print);
+}
+
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::UniversalJoint)

--- a/multibody/tree/universal_joint.h
+++ b/multibody/tree/universal_joint.h
@@ -1,0 +1,284 @@
+#pragma once
+
+#include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/multibody/tree/joint.h"
+#include "drake/multibody/tree/multibody_forces.h"
+#include "drake/multibody/tree/universal_mobilizer.h"
+
+namespace drake {
+namespace multibody {
+
+/// This joint models a universal joint allowing two bodies to rotate relative
+/// to one another with two degrees of freedom.
+/// A universal joint can be thought of as a mechanism consisting of three
+/// bodies; the parent body P, an intermediate cross-shaped body I, and the
+/// child body B. In a physical universal joint, body I has a significantly
+/// smaller mass than P or B. This universal joint model corresponds to the
+/// mathematical limit of having a body I of negligible mass. Given a frame F
+/// attached to the parent body P and a frame M attached to the child body B
+/// (see the Joint class's documentation), the orientation of M in F can then
+/// naturally be defined as follows using a body fixed rotation sequence. A
+/// first rotation of θ₁ about Fx defines the orientation R_FI of the
+/// intermediate frame I attached to body I (notice that by definition Ix = Fx
+/// at all times). A second rotation of θ₂ about Iy defines the orientation R_IM
+/// of frame M (notice that by definition My = Iy at all times). Mathematically,
+/// the orientation of frame M in F is given by <pre>
+///   R_FM(q) = R_FI(θ₁) * R_IM(θ₂)
+/// </pre>
+/// No translational motion of M in F is allowed and the origins, `Mo` and `Fo`,
+/// of frames M and F respectively remain coincident. The angles of rotation
+/// about F's x-axis and M's y-axis, along with their rates, specify the state
+/// of the joint.
+/// Zero θ₁, θ₂ angles corresponds to frames F, I, and M being coincident.
+/// Angles (θ₁, θ₂) are defined to be positive according to the
+/// right-hand-rule with the thumb aligned in the direction of their
+/// respective axes.
+///
+/// @tparam_default_scalar
+template <typename T>
+class UniversalJoint final : public Joint<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(UniversalJoint)
+
+  template <typename Scalar>
+  using Context = systems::Context<Scalar>;
+
+  /// The name for this Joint type.  It resolves to "universal".
+  static const char kTypeName[];
+
+  /// Constructor to create a universal joint between two bodies so that frame F
+  /// attached to the parent body P and frame M attached to the child body B
+  /// rotate as described in the class's documentation. See class documentation
+  /// for details on the angles defining orientation.
+  /// This constructor signature creates a joint with no joint limits, i.e. the
+  /// joint position, velocity and acceleration limits are the pair `(-∞, ∞)`.
+  /// These can be set using the Joint methods set_position_limits(),
+  /// set_velocity_limits() and set_acceleration_limits().
+  /// The first three arguments to this constructor are those of the Joint class
+  /// constructor. See the Joint class's documentation for details.
+  /// The additional parameters are:
+  /// @param[in] damping
+  ///   Viscous damping coefficient, in N⋅m⋅s, used to model losses within the
+  ///   joint. See documentation of damping() for details on modelling of the
+  ///   damping torque.
+  /// @throws std::exception if damping is negative.
+  UniversalJoint(const std::string& name, const Frame<T>& frame_on_parent,
+                 const Frame<T>& frame_on_child, double damping = 0)
+      : Joint<T>(name, frame_on_parent, frame_on_child,
+                 VectorX<double>::Constant(
+                     2, -std::numeric_limits<double>::infinity()),
+                 VectorX<double>::Constant(
+                     2, std::numeric_limits<double>::infinity()),
+                 VectorX<double>::Constant(
+                     2, -std::numeric_limits<double>::infinity()),
+                 VectorX<double>::Constant(
+                     2, std::numeric_limits<double>::infinity()),
+                 VectorX<double>::Constant(
+                     2, -std::numeric_limits<double>::infinity()),
+                 VectorX<double>::Constant(
+                     2, std::numeric_limits<double>::infinity())) {
+    DRAKE_THROW_UNLESS(damping >= 0);
+    damping_ = damping;
+  }
+
+  const std::string& type_name() const override {
+    static const never_destroyed<std::string> name{kTypeName};
+    return name.access();
+  }
+
+  /// Returns `this` joint's damping constant in N⋅m⋅s. The damping torque
+  /// (in N⋅m) is modeled as `τᵢ = -damping⋅ωᵢ, i = 1, 2` i.e. opposing motion,
+  /// with ωᵢ the angular rates about the i-th axis for `this` joint (see
+  /// get_angular_rates())and τᵢ the torque on child body B about the same i-th
+  /// axis.
+  double damping() const { return damping_; }
+
+  /// @name Context-dependent value access
+  /// @{
+
+  /// Gets the rotation angles of `this` joint from `context`. See class
+  /// documentation for the definition of these angles.
+  ///
+  /// @param[in] context The context of the model this joint belongs to.
+  /// @returns The angle coordinates of `this` joint stored in the `context`
+  ///          ordered as (θ₁, θ₂).
+  Vector2<T> get_angles(const Context<T>& context) const {
+    return get_mobilizer()->get_angles(context);
+  }
+
+  /// Sets the `context` so that the generalized coordinates corresponding to
+  /// the rotation angles of `this` joint equals `angles`.
+  /// @param[in] context The context of the model this joint belongs to.
+  /// @param[in] angles The desired angles in radians to be stored in `context`
+  ///                   ordered as (θ₁, θ₂). See class documentation for
+  ///                   details.
+  /// @returns a constant reference to `this` joint.
+  const UniversalJoint<T>& set_angles(Context<T>* context,
+                                      const Vector2<T>& angles) const {
+    get_mobilizer()->set_angles(context, angles);
+    return *this;
+  }
+
+  /// Gets the rates of change, in radians per second, of `this` joint's
+  /// angles (see class documentation) from `context`.
+  /// @param[in] context The context of the model this joint belongs to.
+  /// @returns The rates of change of `this` joint's angles as stored in the
+  ///          `context`.
+  Vector2<T> get_angular_rates(const systems::Context<T>& context) const {
+    return get_mobilizer()->get_angular_rates(context);
+  }
+
+  /// Sets the rates of change, in radians per second, of this `this` joint's
+  /// angles (see class documentation) to `theta_dot`. The new rates of change
+  /// get stored in `context`.
+  /// @param[in] context The context of the model this joint belongs to.
+  /// @param[in] theta_dot The desired rates of change of `this` joints's angles
+  ///                      in radians per second.
+  /// @returns a constant reference to `this` joint.
+  const UniversalJoint<T>& set_angular_rates(
+      systems::Context<T>* context, const Vector2<T>& theta_dot) const {
+    get_mobilizer()->set_angular_rates(context, theta_dot);
+    return *this;
+  }
+
+  /// @}
+
+  /// Gets the default angles for `this` joint. Wrapper for the more general
+  /// `Joint::default_positions()`.
+  /// @returns The default angles of `this` stored in `default_positions_`
+  Vector2<double> get_default_angles() const {
+    return this->default_positions();
+  }
+
+  /// Sets the default angles of this joint.
+  /// @param[in] angles The desired default angles of the joint
+  void set_default_angles(const Vector2<double>& angles) {
+    this->set_default_positions(angles);
+    if (this->has_implementation()) {
+      get_mutable_mobilizer()->set_default_position(this->default_positions());
+    }
+  }
+
+  /// Sets the random distribution that angles of this joint will be randomly
+  /// sampled from. See class documentation for details on the definition of the
+  /// angles.
+  void set_random_angles_distribution(
+      const Vector2<symbolic::Expression>& angles) {
+    get_mutable_mobilizer()->set_random_position_distribution(
+        Vector2<symbolic::Expression>{angles});
+  }
+
+ protected:
+  /// Joint<T> override called through public NVI, Joint::AddInForce().
+  /// Therefore arguments were already checked to be valid.
+  /// For a UniversalJoint, we must always have `joint_dof < 2` since there are
+  /// two degrees of freedom (num_velocities() == 2). `joint_tau` is the torque
+  /// applied about the axis specified by `joint_dof`, the x-axis of the parent
+  /// frame F if `joint_dof = 0` or the y-axis of the child frame M if
+  /// `joint_dof = 1`.  The torque is applied to the body declared as child
+  /// (according to the universal joint's constructor) at the origin of the
+  /// child frame M (which is coincident with the origin of the parent frame F
+  /// at all times). The torque is defined to be positive according to
+  /// the right-hand-rule with the thumb aligned in the direction of the
+  /// selected axis. That is, a positive torque causes a positive rotational
+  /// acceleration (of the child body frame).
+  void DoAddInOneForce(const systems::Context<T>&, int joint_dof,
+                       const T& joint_tau,
+                       MultibodyForces<T>* forces) const override {
+    DRAKE_DEMAND(joint_dof < 2);
+    Eigen::VectorBlock<Eigen::Ref<VectorX<T>>> tau_mob =
+        get_mobilizer()->get_mutable_generalized_forces_from_array(
+            &forces->mutable_generalized_forces());
+    tau_mob(joint_dof) += joint_tau;
+  }
+
+  /// Joint<T> override called through public NVI, Joint::AddInDamping().
+  /// Therefore arguments were already checked to be valid.
+  /// This method adds into `forces` a dissipative torque according to the
+  /// viscous law `τ = -d⋅ω`, with d the damping coefficient (see damping()).
+  void DoAddInDamping(const systems::Context<T>& context,
+                      MultibodyForces<T>* forces) const override {
+    Eigen::VectorBlock<Eigen::Ref<VectorX<T>>> tau =
+        get_mobilizer()->get_mutable_generalized_forces_from_array(
+            &forces->mutable_generalized_forces());
+    const Vector2<T>& theta_dot = get_angular_rates(context);
+    tau = -damping() * theta_dot;
+  }
+
+ private:
+  int do_get_velocity_start() const override {
+    return get_mobilizer()->velocity_start_in_v();
+  }
+
+  int do_get_num_velocities() const override { return 2; }
+
+  int do_get_position_start() const override {
+    return get_mobilizer()->position_start_in_q();
+  }
+
+  int do_get_num_positions() const override { return 2; }
+
+  // Joint<T> overrides:
+  std::unique_ptr<typename Joint<T>::BluePrint> MakeImplementationBlueprint()
+      const override;
+
+  std::unique_ptr<Joint<double>> DoCloneToScalar(
+      const internal::MultibodyTree<double>& tree_clone) const override;
+
+  std::unique_ptr<Joint<AutoDiffXd>> DoCloneToScalar(
+      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const override;
+
+  std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
+      const internal::MultibodyTree<symbolic::Expression>&) const override;
+
+  // Make UniversalJoint templated on every other scalar type a friend of
+  // UniversalJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access
+  // private members of UniversalJoint<T>.
+  template <typename>
+  friend class UniversalJoint;
+
+  // Returns the mobilizer implementing this joint.
+  // The internal implementation of this joint could change in a future version.
+  // However its public API should remain intact.
+  const internal::UniversalMobilizer<T>* get_mobilizer() const {
+    // This implementation should only have one mobilizer.
+    DRAKE_DEMAND(this->get_implementation().num_mobilizers() == 1);
+    const internal::UniversalMobilizer<T>* mobilizer =
+        dynamic_cast<const internal::UniversalMobilizer<T>*>(
+            this->get_implementation().mobilizers_[0]);
+    DRAKE_DEMAND(mobilizer != nullptr);
+    return mobilizer;
+  }
+
+  internal::UniversalMobilizer<T>* get_mutable_mobilizer() {
+    // This implementation should only have one mobilizer.
+    DRAKE_DEMAND(this->get_implementation().num_mobilizers() == 1);
+    auto* mobilizer = dynamic_cast<internal::UniversalMobilizer<T>*>(
+        this->get_implementation().mobilizers_[0]);
+    DRAKE_DEMAND(mobilizer != nullptr);
+    return mobilizer;
+  }
+
+  // Helper method to make a clone templated on ToScalar.
+  template <typename ToScalar>
+  std::unique_ptr<Joint<ToScalar>> TemplatedDoCloneToScalar(
+      const internal::MultibodyTree<ToScalar>& tree_clone) const;
+
+  // This joint's damping constant in N⋅m⋅s.
+  double damping_{0};
+};
+
+template <typename T>
+const char UniversalJoint<T>::kTypeName[] = "universal";
+
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::UniversalJoint)

--- a/multibody/tree/weld_joint.h
+++ b/multibody/tree/weld_joint.h
@@ -105,9 +105,6 @@ class WeldJoint final : public Joint<T> {
   // private members of WeldJoint<T>.
   template <typename> friend class WeldJoint;
 
-  // Friend class to facilitate testing.
-  friend class JointTester;
-
   // Returns the mobilizer implementing this joint.
   // The internal implementation of this joint could change in a future version.
   // However its public API should remain intact.


### PR DESCRIPTION
Creates `UniversalJoint`, a two degree of freedom rotational joint. The joint includes damping but not any spring force (much like RevoluteJoint). In addition, joint limits in MBP are not enforced for this joint and there is no parsing added in this pr. I would love to discuss fixing either/both of these deficiencies.

- [x] Requires ability to mutate joint position limits (#13039 )
- [x] Requires UniversalMobilizer (#13054 )

Towards #12404 

Also removes unused friend class `JointTester` from several joints and fixes a bug that made `SpaceXYZMobilizer` a floating mobilizer.

cc @sherm1 @amcastro-tri

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13055)
<!-- Reviewable:end -->
