### PR TITLE
Add BsplineBasis<T>(const BsplineBasis<double>&)

### DIFF
--- a/math/bspline_basis.cc
+++ b/math/bspline_basis.cc
@@ -53,7 +53,12 @@ BsplineBasis<T>::BsplineBasis(int order, std::vector<T> knots)
                     "equal to twice the order ({}).",
                     knots_.size(), 2 * order));
   }
-  DRAKE_ASSERT(std::is_sorted(knots_.begin(), knots_.end()));
+  // This custom comparator is needed to explicitly convert Formula to bool when
+  // T == Expression.
+  const auto compare = [](const T& val, const T& other) {
+    return static_cast<bool>(val < other);
+  };
+  DRAKE_ASSERT(std::is_sorted(knots_.begin(), knots_.end(), compare));
 }
 
 template <typename T>
@@ -103,10 +108,16 @@ int BsplineBasis<T>::FindContainingInterval(const T& parameter_value) const {
   DRAKE_ASSERT(parameter_value <= final_parameter_value());
   const std::vector<T>& t = knots();
   const T& t_bar = parameter_value;
+  // This custom comparator is needed to explicitly convert Formula to bool when
+  // T == Expression.
+  const auto compare = [](const T& val, const T& other) {
+    return static_cast<bool>(val < other);
+  };
   return std::distance(
-      t.begin(), std::prev(t_bar < final_parameter_value()
-                               ? std::upper_bound(t.begin(), t.end(), t_bar)
-                               : std::lower_bound(t.begin(), t.end(), t_bar)));
+      t.begin(),
+      std::prev(t_bar < final_parameter_value()
+                    ? std::upper_bound(t.begin(), t.end(), t_bar, compare)
+                    : std::lower_bound(t.begin(), t.end(), t_bar, compare)));
 }
 
 template <typename T>
@@ -118,9 +129,8 @@ template <typename T>
 bool BsplineBasis<T>::operator!=(const BsplineBasis<T>& other) const {
   return !this->operator==(other);
 }
-
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
-    class BsplineBasis)
-
 }  // namespace math
 }  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::math::BsplineBasis)

--- a/math/bspline_basis.h
+++ b/math/bspline_basis.h
@@ -48,6 +48,18 @@ class BsplineBasis final {
                const T& initial_parameter_value = 0,
                const T& final_parameter_value = 1);
 
+  /** Constructs a B-spline basis with a non-double scalar type from a
+  BsplineBasis<double>. This conversion is desireable. */
+  template <typename U = T>
+  BsplineBasis(const BsplineBasis<double>& other,
+               typename std::enable_if_t<!std::is_same_v<U, double>>* = {})
+      : order_(other.order()),
+        num_basis_functions_(other.num_basis_functions()) {
+    knots_.reserve(other.knots().size());
+    for (const auto& knot : other.knots()) {
+      knots_.push_back(T(knot));
+    }
+  }
   /** The order of this B-spline basis (k in the class description). */
   int order() const { return order_; }
 
@@ -127,7 +139,7 @@ class BsplineBasis final {
 
     // Define short names to match notation in [1].
     const std::vector<T>& t = knots();
-    const T t_bar = parameter_value;
+    const T& t_bar = parameter_value;
     const int k = order();
 
     /* Find the index, 𝑙, of the greatest knot that is less than or equal to

--- a/math/bspline_basis.h
+++ b/math/bspline_basis.h
@@ -48,13 +48,16 @@ class BsplineBasis final {
                const T& initial_parameter_value = 0,
                const T& final_parameter_value = 1);
 
-  /** Constructs a B-spline basis with a non-double scalar type from a
-  BsplineBasis<double>. This conversion is desireable. */
+#ifdef DRAKE_DOXYGEN_CXX
+  /** Conversion constructor. Constructs an instance of BsplineBasis<T> from a
+  double-valued basis. */
+  explicit BsplineBasis(const BsplineBasis<double>& other);
+#else
   template <typename U = T>
-  BsplineBasis(const BsplineBasis<double>& other,
+  explicit BsplineBasis(const BsplineBasis<double>& other,
                /* Prevents ambiguous declarations between default copy
                constructor on double and conversion constructor on T = double.
-               The conversion constructor for T = double will fail to be 
+               The conversion constructor for T = double will fail to be
                instantiated because the second, "hidden" parameter will fail to
                be defined for U = double. */
                typename std::enable_if_t<!std::is_same_v<U, double>>* = {})
@@ -65,6 +68,7 @@ class BsplineBasis final {
       knots_.push_back(T(knot));
     }
   }
+#endif
 
   /** The order of this B-spline basis (k in the class description). */
   int order() const { return order_; }

--- a/math/bspline_basis.h
+++ b/math/bspline_basis.h
@@ -52,6 +52,11 @@ class BsplineBasis final {
   BsplineBasis<double>. This conversion is desireable. */
   template <typename U = T>
   BsplineBasis(const BsplineBasis<double>& other,
+               /* Prevents ambiguous declarations between default copy
+               constructor on double and conversion constructor on T = double.
+               The conversion constructor for T = double will fail to be 
+               instantiated because the second, "hidden" parameter will fail to
+               be defined for U = double. */
                typename std::enable_if_t<!std::is_same_v<U, double>>* = {})
       : order_(other.order()),
         num_basis_functions_(other.num_basis_functions()) {
@@ -60,6 +65,7 @@ class BsplineBasis final {
       knots_.push_back(T(knot));
     }
   }
+
   /** The order of this B-spline basis (k in the class description). */
   int order() const { return order_; }
 

--- a/math/test/bspline_basis_test.cc
+++ b/math/test/bspline_basis_test.cc
@@ -2,63 +2,84 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/autodiff.h"
+#include "drake/common/default_scalars.h"
+#include "drake/common/extract_double.h"
+#include "drake/common/symbolic.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 
 namespace drake {
 namespace math {
 
+using symbolic::Expression;
+
+template <typename T>
+class BsplineBasisTests : public ::testing::Test {};
+
+using DefaultScalars = ::testing::Types<double, AutoDiffXd, Expression>;
+TYPED_TEST_SUITE(BsplineBasisTests, DefaultScalars);
+
 // Verifies that the constructors work as expected.
-GTEST_TEST(BsplineBasisTests, ConstructorTest) {
+TYPED_TEST(BsplineBasisTests, ConstructorTest) {
   const int order = 4;
   const int num_basis_functions = 11;
-  const std::vector<double> clamped_uniform_0_to_1{
+  const std::vector<TypeParam> clamped_uniform_0_to_1{
       0, 0, 0, 0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875, 1, 1, 1, 1};
-  const std::vector<double> uniform_0_to_1{-0.375, -0.25, -0.125, 0,     0.125,
-                                           0.25,   0.375, 0.5,    0.625, 0.75,
-                                           0.875,  1,     1.125,  1.25,  1.375};
-  const std::vector<double> clamped_uniform_1_to_9{1, 1, 1, 1, 2, 3, 4, 5,
-                                                   6, 7, 8, 9, 9, 9, 9};
-  auto check_basis = [](const BsplineBasis<double>& basis, int expected_order,
-                        int expected_num_basis_functions,
-                        const std::vector<double>& expected_knots) {
+  const std::vector<TypeParam> uniform_0_to_1{
+      -0.375, -0.25, -0.125, 0, 0.125, 0.25, 0.375, 0.5,
+      0.625,  0.75,  0.875,  1, 1.125, 1.25, 1.375};
+  const std::vector<TypeParam> clamped_uniform_1_to_9{1, 1, 1, 1, 2, 3, 4, 5,
+                                                      6, 7, 8, 9, 9, 9, 9};
+  auto check_basis = [](const BsplineBasis<TypeParam>& basis,
+                        int expected_order, int expected_num_basis_functions,
+                        const std::vector<TypeParam>& expected_knots) {
     EXPECT_EQ(basis.order(), expected_order);
     EXPECT_EQ(basis.num_basis_functions(), expected_num_basis_functions);
     EXPECT_EQ(basis.knots(), expected_knots);
   };
   // Check the order and num_basis_functions constructor with kClampedUniform.
-  check_basis(BsplineBasis<double>(order, num_basis_functions,
-                                   KnotVectorType::kClampedUniform,
-                                   0 /* initial_parameter_value */,
-                                   1 /* final_parameter_value */),
+  check_basis(BsplineBasis<TypeParam>(order, num_basis_functions,
+                                      KnotVectorType::kClampedUniform,
+                                      0 /* initial_parameter_value */,
+                                      1 /* final_parameter_value */),
               order, num_basis_functions, clamped_uniform_0_to_1);
 
-  check_basis(BsplineBasis<double>(order, num_basis_functions,
-                                   KnotVectorType::kClampedUniform,
-                                   1 /* initial_parameter_value */,
-                                   9 /* final_parameter_value */),
+  check_basis(BsplineBasis<TypeParam>(order, num_basis_functions,
+                                      KnotVectorType::kClampedUniform,
+                                      1 /* initial_parameter_value */,
+                                      9 /* final_parameter_value */),
               order, num_basis_functions, clamped_uniform_1_to_9);
 
   // Check that the order and num_basis_functions constructor defaults to
   // kClampedUniform from 0 to 1.
-  EXPECT_EQ(BsplineBasis<double>(order, num_basis_functions),
-            BsplineBasis<double>(order, num_basis_functions,
-                                 KnotVectorType::kClampedUniform,
-                                 0 /* initial_parameter_value */,
-                                 1 /* final_parameter_value */));
+  EXPECT_EQ(BsplineBasis<TypeParam>(order, num_basis_functions),
+            BsplineBasis<TypeParam>(order, num_basis_functions,
+                                    KnotVectorType::kClampedUniform,
+                                    0 /* initial_parameter_value */,
+                                    1 /* final_parameter_value */));
 
   // Check the order and num_basis_functions constructor with kUniform.
-  check_basis(BsplineBasis<double>(order, num_basis_functions,
-                                   KnotVectorType::kUniform),
+  check_basis(BsplineBasis<TypeParam>(order, num_basis_functions,
+                                      KnotVectorType::kUniform),
               order, num_basis_functions, uniform_0_to_1);
 
   // Check the order and knots constructor.
-  const std::vector<double> arbitrary_knots = {
+  const std::vector<TypeParam> arbitrary_knots = {
       -5, 0, 0.1, 0.2, 0.3, 0.4, 3, 10, 17, 25, 50, 100, 200, 400, 401};
-  check_basis(BsplineBasis<double>(order, arbitrary_knots), order,
+  check_basis(BsplineBasis<TypeParam>(order, arbitrary_knots), order,
               num_basis_functions, arbitrary_knots);
 }
 
-GTEST_TEST(BsplineBasisTests, ConstructorErrors) {
+// Verifies that we can construct a BsplineBasis<T> from a BsplineBasis<double>.
+TYPED_TEST(BsplineBasisTests, ConstructFromDoubleTest) {
+  const int order = 4;
+  const int num_basis_functions = 11;
+  BsplineBasis<double> basis_double{order, num_basis_functions};
+  EXPECT_EQ(BsplineBasis<TypeParam>(basis_double),
+            BsplineBasis<TypeParam>(order, num_basis_functions));
+}
+
+TYPED_TEST(BsplineBasisTests, ConstructorErrors) {
   const int order = 4;
   const char* expected_message_0 =
       "The number of basis functions (.*) should be greater than or equal to "
@@ -69,13 +90,13 @@ GTEST_TEST(BsplineBasisTests, ConstructorErrors) {
       "The number of knots (.*) should be greater than or equal to twice the "
       "order (.*).";
   DRAKE_EXPECT_THROWS_MESSAGE(
-      BsplineBasis<double>(order, {0, 1, 2, 3, 4, 5, 6}), std::invalid_argument,
-      expected_message_1);
+      BsplineBasis<TypeParam>(order, {0, 1, 2, 3, 4, 5, 6}),
+      std::invalid_argument, expected_message_1);
 }
 
 // Verifies that ComputeActiveBasisFunctionIndices() returns the correct values
 // for selected inputs.
-GTEST_TEST(BsplineBasisTests, ComputeActiveBasisFunctionIndicesTest) {
+TYPED_TEST(BsplineBasisTests, ComputeActiveBasisFunctionIndicesTest) {
   /* For a 5-th order B-spline basis with 14 basis functions (k = 5, n = 13),
   the clamped, uniform knot vector from 0 to 1 is
     [0, 0, 0, 0, 0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1, 1, 1, 1].
@@ -84,8 +105,8 @@ GTEST_TEST(BsplineBasisTests, ComputeActiveBasisFunctionIndicesTest) {
   while all other basis functions are in-active (definitely zero). */
   const int expected_order = 5;
   const int expected_num_basis_functions = 14;
-  BsplineBasis<double> bspline_basis_0{expected_order,
-                                       expected_num_basis_functions};
+  BsplineBasis<TypeParam> bspline_basis_0{expected_order,
+                                          expected_num_basis_functions};
 
   auto expected_indices = [](std::initializer_list<int> values) {
     return std::vector<int>(values);
@@ -146,17 +167,17 @@ generated by scipy.interpolate.Bspline.basis_element():
                                    bspline.t[-order],
                                    num_basis_functions),
                        knots)
-        print("parameter_values.push_back(std::vector<double>{{{}}});"
+        print("parameter_values.push_back(std::vector<TypeParam>{{{}}});"
               .format(", ".join("{:.17f}".format(n) for n in u)))
         print("expected_basis_function_values.push_back" +
-              "(std::vector<double>{{{}}});"
+              "(std::vector<TypeParam>{{{}}});"
               .format(", ".join("{:.17f}".format(0.0 if np.isnan(n) else n)
                                 for n in bspline(u))))
 NOTE(avalenzu): Scipy gives B[6](1.0) = 0.0, which is wrong. That value has
 been replaced with the correct one (1.0).
 
 This tests (indirectly) the BsplineBasis::EvaluateCurve() method. */
-GTEST_TEST(BsplineBasisTests, EvaluateBasisFunctionIScipyComparison) {
+TYPED_TEST(BsplineBasisTests, EvaluateBasisFunctionIScipyComparison) {
   const int order = 4;
   const int num_basis_functions = 7;
   BsplineBasis<double> basis{order, num_basis_functions};
@@ -231,43 +252,44 @@ GTEST_TEST(BsplineBasisTests, EvaluateBasisFunctionIScipyComparison) {
     ASSERT_EQ(static_cast<int>(expected_basis_function_values[i].size()),
               num_parameter_values);
     for (int j = 0; j < num_parameter_values; ++j) {
-      EXPECT_NEAR(basis.EvaluateBasisFunctionI(i, parameter_values[i][j]),
-                  expected_basis_function_values[i][j],
+      EXPECT_NEAR(ExtractDoubleOrThrow(
+                      basis.EvaluateBasisFunctionI(i, parameter_values[i][j])),
+                  ExtractDoubleOrThrow(expected_basis_function_values[i][j]),
                   std::numeric_limits<double>::epsilon());
     }
   }
 }
 
 // Tests that {initial,final}_parameter_value() behave as expected.
-GTEST_TEST(BsplineBasisTests, InitialAndFinalParameterValueTest) {
+TYPED_TEST(BsplineBasisTests, InitialAndFinalParameterValueTest) {
   const int order{3};
-  const std::vector<double> knots{-5, 0, 0.1, 0.2, 0.3, 0.4, 3, 10, 17, 25};
-  BsplineBasis<double> bspline_basis{order, knots};
+  const std::vector<TypeParam> knots{-5, 0, 0.1, 0.2, 0.3, 0.4, 3, 10, 17, 25};
+  BsplineBasis<TypeParam> bspline_basis{order, knots};
   EXPECT_EQ(bspline_basis.initial_parameter_value(), knots[order - 1]);
   EXPECT_EQ(bspline_basis.final_parameter_value(), knots[knots.size() - order]);
 }
 
 // Tests that operator==() behaves as expected.
-GTEST_TEST(BsplineBasisTests, OperatorEqualsTest) {
+TYPED_TEST(BsplineBasisTests, OperatorEqualsTest) {
   const int order{3};
-  const std::vector<double> knots{-5, 0, 0.1, 0.2, 0.3, 0.4, 3, 10, 17, 25};
+  const std::vector<TypeParam> knots{-5, 0, 0.1, 0.2, 0.3, 0.4, 3, 10, 17, 25};
 
   // Test that identically constructed objects are equal.
-  EXPECT_TRUE(BsplineBasis<double>(order, knots).operator==(
-    BsplineBasis<double>(order, knots)));
+  EXPECT_TRUE(BsplineBasis<TypeParam>(order, knots).operator==(
+    BsplineBasis<TypeParam>(order, knots)));
 
   // Test that objects with different orders and the same knots are not equal.
-  EXPECT_FALSE(BsplineBasis<double>(order, knots).operator==(
-    BsplineBasis<double>(order + 1, knots)));
+  EXPECT_FALSE(BsplineBasis<TypeParam>(order, knots).operator==(
+    BsplineBasis<TypeParam>(order + 1, knots)));
 
   // Test that objects with the same orders and different knots are not equal.
-  const std::vector<double> other_knots{1, 2, 3, 4, 5, 6, 7, 8};
-  EXPECT_FALSE(BsplineBasis<double>(order, knots).operator==(
-    BsplineBasis<double>(order, other_knots)));
+  const std::vector<TypeParam> other_knots{1, 2, 3, 4, 5, 6, 7, 8};
+  EXPECT_FALSE(BsplineBasis<TypeParam>(order, knots).operator==(
+    BsplineBasis<TypeParam>(order, other_knots)));
 
   // Test that objects with different orders and different knots are not equal.
-  EXPECT_FALSE(BsplineBasis<double>(order, knots).operator==(
-    BsplineBasis<double>(order + 1, other_knots)));
+  EXPECT_FALSE(BsplineBasis<TypeParam>(order, knots).operator==(
+    BsplineBasis<TypeParam>(order + 1, other_knots)));
 }
 
 }  // namespace math

--- a/math/test/bspline_basis_test.cc
+++ b/math/test/bspline_basis_test.cc
@@ -2,10 +2,8 @@
 
 #include <gtest/gtest.h>
 
-#include "drake/common/autodiff.h"
 #include "drake/common/default_scalars.h"
 #include "drake/common/extract_double.h"
-#include "drake/common/symbolic.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 
 namespace drake {
@@ -21,65 +19,68 @@ TYPED_TEST_SUITE(BsplineBasisTests, DefaultScalars);
 
 // Verifies that the constructors work as expected.
 TYPED_TEST(BsplineBasisTests, ConstructorTest) {
+  using T = TypeParam;
   const int order = 4;
   const int num_basis_functions = 11;
-  const std::vector<TypeParam> clamped_uniform_0_to_1{
+  const std::vector<T> clamped_uniform_0_to_1{
       0, 0, 0, 0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875, 1, 1, 1, 1};
-  const std::vector<TypeParam> uniform_0_to_1{
-      -0.375, -0.25, -0.125, 0, 0.125, 0.25, 0.375, 0.5,
-      0.625,  0.75,  0.875,  1, 1.125, 1.25, 1.375};
-  const std::vector<TypeParam> clamped_uniform_1_to_9{1, 1, 1, 1, 2, 3, 4, 5,
-                                                      6, 7, 8, 9, 9, 9, 9};
-  auto check_basis = [](const BsplineBasis<TypeParam>& basis,
-                        int expected_order, int expected_num_basis_functions,
-                        const std::vector<TypeParam>& expected_knots) {
+  const std::vector<T> uniform_0_to_1{-0.375, -0.25, -0.125, 0,     0.125,
+                                      0.25,   0.375, 0.5,    0.625, 0.75,
+                                      0.875,  1,     1.125,  1.25,  1.375};
+  const std::vector<T> clamped_uniform_1_to_9{1, 1, 1, 1, 2, 3, 4, 5,
+                                              6, 7, 8, 9, 9, 9, 9};
+  auto check_basis = [](const BsplineBasis<T>& basis, int expected_order,
+                        int expected_num_basis_functions,
+                        const std::vector<T>& expected_knots) {
     EXPECT_EQ(basis.order(), expected_order);
     EXPECT_EQ(basis.num_basis_functions(), expected_num_basis_functions);
     EXPECT_EQ(basis.knots(), expected_knots);
   };
   // Check the order and num_basis_functions constructor with kClampedUniform.
-  check_basis(BsplineBasis<TypeParam>(order, num_basis_functions,
-                                      KnotVectorType::kClampedUniform,
-                                      0 /* initial_parameter_value */,
-                                      1 /* final_parameter_value */),
+  check_basis(BsplineBasis<T>(order, num_basis_functions,
+                              KnotVectorType::kClampedUniform,
+                              0 /* initial_parameter_value */,
+                              1 /* final_parameter_value */),
               order, num_basis_functions, clamped_uniform_0_to_1);
 
-  check_basis(BsplineBasis<TypeParam>(order, num_basis_functions,
-                                      KnotVectorType::kClampedUniform,
-                                      1 /* initial_parameter_value */,
-                                      9 /* final_parameter_value */),
+  check_basis(BsplineBasis<T>(order, num_basis_functions,
+                              KnotVectorType::kClampedUniform,
+                              1 /* initial_parameter_value */,
+                              9 /* final_parameter_value */),
               order, num_basis_functions, clamped_uniform_1_to_9);
 
   // Check that the order and num_basis_functions constructor defaults to
   // kClampedUniform from 0 to 1.
-  EXPECT_EQ(BsplineBasis<TypeParam>(order, num_basis_functions),
-            BsplineBasis<TypeParam>(order, num_basis_functions,
-                                    KnotVectorType::kClampedUniform,
-                                    0 /* initial_parameter_value */,
-                                    1 /* final_parameter_value */));
+  EXPECT_EQ(BsplineBasis<T>(order, num_basis_functions),
+            BsplineBasis<T>(order, num_basis_functions,
+                            KnotVectorType::kClampedUniform,
+                            0 /* initial_parameter_value */,
+                            1 /* final_parameter_value */));
 
   // Check the order and num_basis_functions constructor with kUniform.
-  check_basis(BsplineBasis<TypeParam>(order, num_basis_functions,
-                                      KnotVectorType::kUniform),
-              order, num_basis_functions, uniform_0_to_1);
+  check_basis(
+      BsplineBasis<T>(order, num_basis_functions, KnotVectorType::kUniform),
+      order, num_basis_functions, uniform_0_to_1);
 
   // Check the order and knots constructor.
-  const std::vector<TypeParam> arbitrary_knots = {
-      -5, 0, 0.1, 0.2, 0.3, 0.4, 3, 10, 17, 25, 50, 100, 200, 400, 401};
-  check_basis(BsplineBasis<TypeParam>(order, arbitrary_knots), order,
+  const std::vector<T> arbitrary_knots = {-5, 0,  0.1, 0.2, 0.3, 0.4, 3,  10,
+                                          17, 25, 50,  100, 200, 400, 401};
+  check_basis(BsplineBasis<T>(order, arbitrary_knots), order,
               num_basis_functions, arbitrary_knots);
 }
 
-// Verifies that we can construct a BsplineBasis<T> from a BsplineBasis<double>.
+// Verifies that we can convert a BsplineBasis<double> to a BsplineBasis<T>.
 TYPED_TEST(BsplineBasisTests, ConstructFromDoubleTest) {
+  using T = TypeParam;
   const int order = 4;
   const int num_basis_functions = 11;
   BsplineBasis<double> basis_double{order, num_basis_functions};
-  EXPECT_EQ(BsplineBasis<TypeParam>(basis_double),
-            BsplineBasis<TypeParam>(order, num_basis_functions));
+  EXPECT_EQ(BsplineBasis<T>(basis_double),
+            BsplineBasis<T>(order, num_basis_functions));
 }
 
 TYPED_TEST(BsplineBasisTests, ConstructorErrors) {
+  using T = TypeParam;
   const int order = 4;
   const char* expected_message_0 =
       "The number of basis functions (.*) should be greater than or equal to "
@@ -89,14 +90,14 @@ TYPED_TEST(BsplineBasisTests, ConstructorErrors) {
   const char* expected_message_1 =
       "The number of knots (.*) should be greater than or equal to twice the "
       "order (.*).";
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      BsplineBasis<TypeParam>(order, {0, 1, 2, 3, 4, 5, 6}),
-      std::invalid_argument, expected_message_1);
+  DRAKE_EXPECT_THROWS_MESSAGE(BsplineBasis<T>(order, {0, 1, 2, 3, 4, 5, 6}),
+                              std::invalid_argument, expected_message_1);
 }
 
 // Verifies that ComputeActiveBasisFunctionIndices() returns the correct values
 // for selected inputs.
 TYPED_TEST(BsplineBasisTests, ComputeActiveBasisFunctionIndicesTest) {
+  using T = TypeParam;
   /* For a 5-th order B-spline basis with 14 basis functions (k = 5, n = 13),
   the clamped, uniform knot vector from 0 to 1 is
     [0, 0, 0, 0, 0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1, 1, 1, 1].
@@ -105,8 +106,7 @@ TYPED_TEST(BsplineBasisTests, ComputeActiveBasisFunctionIndicesTest) {
   while all other basis functions are in-active (definitely zero). */
   const int expected_order = 5;
   const int expected_num_basis_functions = 14;
-  BsplineBasis<TypeParam> bspline_basis_0{expected_order,
-                                          expected_num_basis_functions};
+  BsplineBasis<T> bspline_basis_0{expected_order, expected_num_basis_functions};
 
   auto expected_indices = [](std::initializer_list<int> values) {
     return std::vector<int>(values);
@@ -167,10 +167,10 @@ generated by scipy.interpolate.Bspline.basis_element():
                                    bspline.t[-order],
                                    num_basis_functions),
                        knots)
-        print("parameter_values.push_back(std::vector<TypeParam>{{{}}});"
+        print("parameter_values.push_back(std::vector<T>{{{}}});"
               .format(", ".join("{:.17f}".format(n) for n in u)))
         print("expected_basis_function_values.push_back" +
-              "(std::vector<TypeParam>{{{}}});"
+              "(std::vector<T>{{{}}});"
               .format(", ".join("{:.17f}".format(0.0 if np.isnan(n) else n)
                                 for n in bspline(u))))
 NOTE(avalenzu): Scipy gives B[6](1.0) = 0.0, which is wrong. That value has
@@ -178,67 +178,68 @@ been replaced with the correct one (1.0).
 
 This tests (indirectly) the BsplineBasis::EvaluateCurve() method. */
 TYPED_TEST(BsplineBasisTests, EvaluateBasisFunctionIScipyComparison) {
+  using T = TypeParam;
   const int order = 4;
   const int num_basis_functions = 7;
-  BsplineBasis<double> basis{order, num_basis_functions};
-  std::vector<std::vector<double>> parameter_values{};
-  std::vector<std::vector<double>> expected_basis_function_values{};
-  parameter_values.push_back(std::vector<double>{
+  BsplineBasis<T> basis{order, num_basis_functions};
+  std::vector<std::vector<T>> parameter_values{};
+  std::vector<std::vector<T>> expected_basis_function_values{};
+  parameter_values.push_back(std::vector<T>{
       0.00000000000000000, 0.04166666666666666, 0.08333333333333333,
       0.12500000000000000, 0.16666666666666666, 0.20833333333333331,
       0.25000000000000000, 0.50000000000000000, 0.75000000000000000,
       1.00000000000000000});
-  expected_basis_function_values.push_back(std::vector<double>{
+  expected_basis_function_values.push_back(std::vector<T>{
       1.00000000000000000, 0.57870370370370383, 0.29629629629629639,
       0.12500000000000000, 0.03703703703703705, 0.00462962962962964,
       0.00000000000000000, 0.00000000000000000, 0.00000000000000000,
       0.00000000000000000});
-  parameter_values.push_back(std::vector<double>{
+  parameter_values.push_back(std::vector<T>{
       0.00000000000000000, 0.08333333333333333, 0.16666666666666666,
       0.25000000000000000, 0.33333333333333331, 0.41666666666666663,
       0.50000000000000000, 0.75000000000000000, 1.00000000000000000});
-  expected_basis_function_values.push_back(std::vector<double>{
+  expected_basis_function_values.push_back(std::vector<T>{
       0.00000000000000000, 0.56481481481481488, 0.51851851851851860,
       0.25000000000000000, 0.07407407407407410, 0.00925925925925927,
       0.00000000000000000, 0.00000000000000000, 0.00000000000000000});
-  parameter_values.push_back(std::vector<double>{
+  parameter_values.push_back(std::vector<T>{
       0.00000000000000000, 0.12500000000000000, 0.25000000000000000,
       0.37500000000000000, 0.50000000000000000, 0.62500000000000000,
       0.75000000000000000, 1.00000000000000000});
-  expected_basis_function_values.push_back(std::vector<double>{
+  expected_basis_function_values.push_back(std::vector<T>{
       0.00000000000000000, 0.26041666666666663, 0.58333333333333326,
       0.46875000000000000, 0.16666666666666666, 0.02083333333333333,
       0.00000000000000000, 0.00000000000000000});
-  parameter_values.push_back(std::vector<double>{
+  parameter_values.push_back(std::vector<T>{
       0.00000000000000000, 0.16666666666666666, 0.25000000000000000,
       0.33333333333333331, 0.50000000000000000, 0.66666666666666663,
       0.75000000000000000, 0.83333333333333326, 1.00000000000000000});
-  expected_basis_function_values.push_back(std::vector<double>{
+  expected_basis_function_values.push_back(std::vector<T>{
       0.00000000000000000, 0.04938271604938271, 0.16666666666666666,
       0.37037037037037035, 0.66666666666666663, 0.37037037037037052,
       0.16666666666666666, 0.04938271604938278, 0.00000000000000000});
-  parameter_values.push_back(std::vector<double>{
+  parameter_values.push_back(std::vector<T>{
       0.00000000000000000, 0.25000000000000000, 0.37500000000000000,
       0.50000000000000000, 0.62500000000000000, 0.75000000000000000,
       0.87500000000000000, 1.00000000000000000});
-  expected_basis_function_values.push_back(std::vector<double>{
+  expected_basis_function_values.push_back(std::vector<T>{
       0.00000000000000000, 0.00000000000000000, 0.02083333333333333,
       0.16666666666666666, 0.46875000000000000, 0.58333333333333326,
       0.26041666666666663, 0.00000000000000000});
-  parameter_values.push_back(std::vector<double>{
+  parameter_values.push_back(std::vector<T>{
       0.00000000000000000, 0.25000000000000000, 0.50000000000000000,
       0.58333333333333337, 0.66666666666666663, 0.75000000000000000,
       0.83333333333333326, 0.91666666666666663, 1.00000000000000000});
-  expected_basis_function_values.push_back(std::vector<double>{
+  expected_basis_function_values.push_back(std::vector<T>{
       0.00000000000000000, 0.00000000000000000, 0.00000000000000000,
       0.00925925925925927, 0.07407407407407403, 0.25000000000000000,
       0.51851851851851827, 0.56481481481481488, 0.00000000000000000});
-  parameter_values.push_back(std::vector<double>{
+  parameter_values.push_back(std::vector<T>{
       0.00000000000000000, 0.25000000000000000, 0.50000000000000000,
       0.75000000000000000, 0.79166666666666663, 0.83333333333333337,
       0.87500000000000000, 0.91666666666666663, 0.95833333333333326,
       1.00000000000000000});
-  expected_basis_function_values.push_back(std::vector<double>{
+  expected_basis_function_values.push_back(std::vector<T>{
       0.00000000000000000, 0.00000000000000000, 0.00000000000000000,
       0.00000000000000000, 0.00462962962962962, 0.03703703703703709,
       0.12500000000000000, 0.29629629629629611, 0.57870370370370305,
@@ -262,34 +263,33 @@ TYPED_TEST(BsplineBasisTests, EvaluateBasisFunctionIScipyComparison) {
 
 // Tests that {initial,final}_parameter_value() behave as expected.
 TYPED_TEST(BsplineBasisTests, InitialAndFinalParameterValueTest) {
+  using T = TypeParam;
   const int order{3};
-  const std::vector<TypeParam> knots{-5, 0, 0.1, 0.2, 0.3, 0.4, 3, 10, 17, 25};
-  BsplineBasis<TypeParam> bspline_basis{order, knots};
+  const std::vector<T> knots{-5, 0, 0.1, 0.2, 0.3, 0.4, 3, 10, 17, 25};
+  BsplineBasis<T> bspline_basis{order, knots};
   EXPECT_EQ(bspline_basis.initial_parameter_value(), knots[order - 1]);
   EXPECT_EQ(bspline_basis.final_parameter_value(), knots[knots.size() - order]);
 }
 
 // Tests that operator==() behaves as expected.
 TYPED_TEST(BsplineBasisTests, OperatorEqualsTest) {
+  using T = TypeParam;
   const int order{3};
-  const std::vector<TypeParam> knots{-5, 0, 0.1, 0.2, 0.3, 0.4, 3, 10, 17, 25};
+  const std::vector<T> knots{-5, 0, 0.1, 0.2, 0.3, 0.4, 3, 10, 17, 25};
 
   // Test that identically constructed objects are equal.
-  EXPECT_TRUE(BsplineBasis<TypeParam>(order, knots).operator==(
-    BsplineBasis<TypeParam>(order, knots)));
+  EXPECT_EQ(BsplineBasis<T>(order, knots), BsplineBasis<T>(order, knots));
 
   // Test that objects with different orders and the same knots are not equal.
-  EXPECT_FALSE(BsplineBasis<TypeParam>(order, knots).operator==(
-    BsplineBasis<TypeParam>(order + 1, knots)));
+  EXPECT_NE(BsplineBasis<T>(order, knots), BsplineBasis<T>(order + 1, knots));
 
   // Test that objects with the same orders and different knots are not equal.
-  const std::vector<TypeParam> other_knots{1, 2, 3, 4, 5, 6, 7, 8};
-  EXPECT_FALSE(BsplineBasis<TypeParam>(order, knots).operator==(
-    BsplineBasis<TypeParam>(order, other_knots)));
+  const std::vector<T> other_knots{1, 2, 3, 4, 5, 6, 7, 8};
+  EXPECT_NE(BsplineBasis<T>(order, knots), BsplineBasis<T>(order, other_knots));
 
   // Test that objects with different orders and different knots are not equal.
-  EXPECT_FALSE(BsplineBasis<TypeParam>(order, knots).operator==(
-    BsplineBasis<TypeParam>(order + 1, other_knots)));
+  EXPECT_NE(BsplineBasis<T>(order, knots),
+            BsplineBasis<T>(order + 1, other_knots));
 }
 
 }  // namespace math


### PR DESCRIPTION
This enables implicit conversion from `BsplineBasis<double>` to `BsplineBasis<T>`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13057)
<!-- Reviewable:end -->
