### PR TITLE
Disable coverage tests on deprecated iiwa modules

### DIFF
--- a/examples/kuka_iiwa_arm/iiwa_world/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/iiwa_world/BUILD.bazel
@@ -47,6 +47,7 @@ drake_cc_binary(
         "//manipulation/models/iiwa_description:models",
         "//manipulation/models/wsg_50_description:models",
     ],
+    tags = ["no_kcov"],
     test_rule_args = ["--simulation_sec=0.01"],
     deps = [
         "//attic/manipulation/util:sim_diagram_builder",
@@ -75,6 +76,7 @@ drake_cc_googletest(
         "//manipulation/models/iiwa_description:models",
         "//manipulation/models/wsg_50_description:models",
     ],
+    tags = ["no_kcov"],
     deps = [
         ":iiwa_wsg_diagram_factory",
         "//common/test_utilities:eigen_matrix_compare",


### PR DESCRIPTION
These started hitting timeouts in coverage tests after #13015 merged,
which confuses me since none of the code which moved in that PR
appears to be invoked by these tests.  Since the entire directory is
scheduled for deprecation in a couple of weeks, I don't think it's
worth further investigation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13059)
<!-- Reviewable:end -->
