### PR TITLE
py systems: Bind LcmInterfaceSystem

### DIFF
--- a/bindings/pydrake/systems/lcm_py.cc
+++ b/bindings/pydrake/systems/lcm_py.cc
@@ -10,6 +10,7 @@
 #include "drake/lcm/drake_lcm.h"
 #include "drake/lcm/drake_lcm_interface.h"
 #include "drake/systems/lcm/connect_lcm_scope.h"
+#include "drake/systems/lcm/lcm_interface_system.h"
 #include "drake/systems/lcm/lcm_publisher_system.h"
 #include "drake/systems/lcm/lcm_subscriber_system.h"
 #include "drake/systems/lcm/serializer.h"
@@ -65,6 +66,20 @@ class PySerializerInterface : public py::wrapper<SerializerInterface> {
   }
 };
 
+// Define warning related to lack of multiple inheritance with our fork of
+// pybind11. This will be sufficient for workflows in pure Python, but will
+// not readily support intermingling of C++-constructed LcmInterfaceSystem
+// classes which are then passed to Python.
+constexpr char kLcmInterfaceSystemClassWarning[] = R"""(
+
+Warning:
+    In C++, this class inherits both LeafSystem and DrakeLcmInterface. However,
+    in Python, this only inherits from LeafSystem since our fork of pybind11
+    does not support multiple inheritance. Additionally, it only exposes the
+    constructor accepting a DrakeLcmInterface, so that it can still be used in
+    interface code.
+)""";
+
 }  // namespace
 
 PYBIND11_MODULE(lcm, m) {
@@ -77,6 +92,16 @@ PYBIND11_MODULE(lcm, m) {
 
   py::module::import("pydrake.lcm");
   py::module::import("pydrake.systems.framework");
+
+  {
+    using Class = LcmInterfaceSystem;
+    constexpr auto& cls_doc = doc.LcmInterfaceSystem;
+    py::class_<Class, LeafSystem<double>>(m, "LcmInterfaceSystem",
+        (std::string(cls_doc.doc) + kLcmInterfaceSystemClassWarning).c_str())
+        .def(py::init<DrakeLcmInterface*>(),
+            // Keep alive, reference: `lcm` keeps `self` alive.
+            py::keep_alive<2, 1>(), py::arg("lcm"), cls_doc.ctor.doc_1args_lcm);
+  }
 
   {
     using Class = SerializerInterface;

--- a/bindings/pydrake/systems/test/lcm_test.py
+++ b/bindings/pydrake/systems/test/lcm_test.py
@@ -1,3 +1,6 @@
+"""
+Test bindings of LCM integration with the Systems framework.
+"""
 import pydrake.systems.lcm as mut
 
 import collections
@@ -88,7 +91,7 @@ class TestSystemsLcm(unittest.TestCase):
         return simulator.get_context().Clone()
 
     def test_subscriber(self):
-        lcm = DrakeLcm()
+        lcm = DrakeLcm(lcm_url="memq://")
         dut = mut.LcmSubscriberSystem.Make(
             channel="TEST_CHANNEL", lcm_type=quaternion_t, lcm=lcm)
         model_message = self._model_message()
@@ -99,7 +102,7 @@ class TestSystemsLcm(unittest.TestCase):
         self.assert_lcm_equal(actual_message, model_message)
 
     def test_subscriber_cpp(self):
-        lcm = DrakeLcm()
+        lcm = DrakeLcm(lcm_url="memq://")
         dut = mut.LcmSubscriberSystem.Make(
             channel="TEST_CHANNEL", lcm_type=quaternion_t, lcm=lcm,
             use_cpp_serializer=True)
@@ -134,7 +137,7 @@ class TestSystemsLcm(unittest.TestCase):
         dut.Publish(context)
 
     def test_publisher(self):
-        lcm = DrakeLcm()
+        lcm = DrakeLcm(lcm_url="memq://")
         dut = mut.LcmPublisherSystem.Make(
             channel="TEST_CHANNEL", lcm_type=quaternion_t, lcm=lcm,
             publish_period=0.1)
@@ -145,7 +148,7 @@ class TestSystemsLcm(unittest.TestCase):
         self.assert_lcm_equal(subscriber.message, model_message)
 
     def test_publisher_cpp(self):
-        lcm = DrakeLcm()
+        lcm = DrakeLcm(lcm_url="memq://")
         dut = mut.LcmPublisherSystem.Make(
             channel="TEST_CHANNEL", lcm_type=quaternion_t, lcm=lcm,
             use_cpp_serializer=True)

--- a/systems/lcm/lcm_interface_system.h
+++ b/systems/lcm/lcm_interface_system.h
@@ -52,7 +52,7 @@ class LcmInterfaceSystem final
    * class and must remain valid for the lifetime of this object.  Users MUST
    * NOT start the receive thread on this object.
    */
-  explicit LcmInterfaceSystem(drake::lcm::DrakeLcmInterface*);
+  explicit LcmInterfaceSystem(drake::lcm::DrakeLcmInterface* lcm);
 
   ~LcmInterfaceSystem() final;
 


### PR DESCRIPTION
I want this for usage in Anzu, but it seems that this wasn't bound in Python.

I guess I saw this review go by, and I should have raised an issue with multiple inheritance (I think the same thing could have been accomplished with composition?). Meh, too late, and deprecation for an inheritance structure sounds nigh impossible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13067)
<!-- Reviewable:end -->
