### PR TITLE
Add System support for implicit equations

### DIFF
--- a/examples/acrobot/BUILD.bazel
+++ b/examples/acrobot/BUILD.bazel
@@ -256,6 +256,14 @@ drake_cc_binary(
 )
 
 drake_cc_googletest(
+    name = "acrobot_plant_test",
+    deps = [
+        ":acrobot_plant",
+        "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
     name = "acrobot_geometry_test",
     deps = [
         ":acrobot_geometry",

--- a/examples/acrobot/acrobot_plant.h
+++ b/examples/acrobot/acrobot_plant.h
@@ -87,17 +87,22 @@ class AcrobotPlant : public systems::LeafSystem<T> {
     return this->template GetNumericParameter<AcrobotParams>(context, 0);
   }
 
- protected:
-  T DoCalcKineticEnergy(const systems::Context<T>& context) const override;
-  T DoCalcPotentialEnergy(const systems::Context<T>& context) const override;
-
  private:
   void CopyStateOut(const systems::Context<T>& context,
                     AcrobotState<T>* output) const;
 
+  T DoCalcKineticEnergy(const systems::Context<T>& context) const override;
+
+  T DoCalcPotentialEnergy(const systems::Context<T>& context) const override;
+
   void DoCalcTimeDerivatives(
       const systems::Context<T>& context,
       systems::ContinuousState<T>* derivatives) const override;
+
+  void DoCalcImplicitTimeDerivativesResidual(
+    const systems::Context<T>& context,
+    const systems::ContinuousState<T>& proposed_derivatives,
+    EigenPtr<VectorX<T>> residual) const override;
 };
 
 /// Constructs the Acrobot with (only) encoder outputs.

--- a/examples/acrobot/test/acrobot_plant_test.cc
+++ b/examples/acrobot/test/acrobot_plant_test.cc
@@ -1,0 +1,39 @@
+#include "drake/examples/acrobot/acrobot_plant.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+
+namespace drake {
+namespace examples {
+namespace acrobot {
+namespace {
+
+GTEST_TEST(AcrobotPlantTest, ImplicitTimeDerivatives) {
+  const double kEpsilon = std::numeric_limits<double>::epsilon();
+
+  AcrobotPlant<double> plant;
+  auto context = plant.CreateDefaultContext();
+  context->FixInputPort(0, Vector1d(-.32));
+  context->SetContinuousState(Eigen::Vector4d(.1, .2, .3, .4));
+
+  Eigen::VectorXd residual = plant.AllocateImplicitTimeDerivativesResidual();
+
+  // Try perfect proposed derivatives -- should get near-zero residual.
+  const systems::ContinuousState<double>& proposed_derivatives =
+      plant.EvalTimeDerivatives(*context);
+  plant.CalcImplicitTimeDerivativesResidual(*context, proposed_derivatives,
+                                            &residual);
+
+  // Expected accuracy depends on the mass matrix condition number (about 41
+  // here) and the solve accuracy. We're limited to using Eigen's M.inverse()
+  // here to permit this to be done symbolically, which is not the most
+  // accurate method. 100ε (~2e-14) should be achievable.
+  EXPECT_LT(residual.lpNorm<Eigen::Infinity>(), 100*kEpsilon);
+}
+
+}  // namespace
+}  // namespace acrobot
+}  // namespace examples
+}  // namespace drake
+

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -121,7 +121,11 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
   std::unique_ptr<DiscreteValues<T>> AllocateDiscreteVariables() const final;
 
   void DoCalcTimeDerivatives(const Context<T>& context,
-                             ContinuousState<T>* derivatives) const override;
+                             ContinuousState<T>* derivatives) const final;
+
+  void DoCalcImplicitTimeDerivativesResidual(
+      const Context<T>& context, const ContinuousState<T>& proposed_derivatives,
+      EigenPtr<VectorX<T>> residual) const final;
 
   /// Retrieves a reference to the subsystem with name @p name returned by
   /// get_name().

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -1129,6 +1129,28 @@ class LeafSystem : public System<T> {
       std::unique_ptr<AbstractValue> abstract_state);
   //@}
 
+
+  /** @name    (Advanced) Declare size of implicit time derivatives residual
+  for use with System::CalcImplicitTimeDerivativeResidual(). Most commonly
+  the default value, same as num_continuous_states(), will be the correct
+  size for the residual. */
+  //@{
+
+  /** (Advanced) Overrides the default size for the implicit time
+  derivatives residual. If no value is set, the default size is
+  n=num_continuous_states().
+
+  @param[in] n The size of the residual vector output argument of
+               System::CalcImplicitTimeDerivativesResidual(). If n <= 0
+               restore to the default, num_continuous_states().
+
+  @see implicit_time_derivatives_residual_size()
+  @see System::CalcImplicitTimeDerivativesResidual() */
+  void DeclareImplicitTimeDerivativesResidualSize(int n) {
+    this->set_implicit_time_derivatives_residual_size(n);
+  }
+  //@}
+
   // =========================================================================
   /** @name                    Declare input ports
   Methods in this section are used by derived classes to declare their

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -111,7 +111,16 @@ class System : public SystemBase {
   virtual std::unique_ptr<ContinuousState<T>> AllocateTimeDerivatives() const
       = 0;
 
-  /** Returns a DiscreteState of the same dimensions as the discrete_state
+  /** Returns an Eigen VectorX suitable for use as the output argument to
+  the CalcImplicitTimeDerivativesResidual() method. The returned VectorX
+  will have size implicit_time_derivatives_residual_size() with the
+  elements uninitialized. This is just a convenience method -- you are free
+  to use any properly-sized mutable Eigen object as the residual vector. */
+  VectorX<T> AllocateImplicitTimeDerivativesResidual() const {
+    return VectorX<T>(implicit_time_derivatives_residual_size());
+  }
+
+  /** Returns a DiscreteValues of the same dimensions as the discrete_state
   allocated in CreateDefaultContext. The simulator will provide this state
   as the output argument to Update. */
   virtual std::unique_ptr<DiscreteValues<T>> AllocateDiscreteVariables() const
@@ -243,22 +252,21 @@ class System : public SystemBase {
   //@{
 
   /** Returns a reference to the cached value of the continuous state variable
-  time derivatives, evaluating first if necessary using
-  CalcTimeDerivatives().
+  time derivatives, evaluating first if necessary using CalcTimeDerivatives().
 
-  This method returns the time derivatives `xcdot` of the continuous state
-  `xc`. The referenced return object will correspond elementwise with the
+  This method returns the time derivatives ẋ꜀ of the continuous state
+  x꜀. The referenced return object will correspond elementwise with the
   continuous state in the given Context. Thus, if the state in the Context
-  has second-order structure `xc=[q v z]`, that same structure applies to
-  the derivatives so we will have `xcdot=[qdot vdot zdot]`.
+  has second-order structure `x꜀ = [q v z]`, that same structure applies to
+  the derivatives so we will have `ẋ꜀ = [q̇ ̇v̇ ż]`.
 
   @param context The Context whose time, input port, parameter, state, and
   accuracy values may be used to evaluate the derivatives.
 
-  @retval xcdot The time derivatives of `xc` returned as a reference to an
-                object of the same type and size as this %Context's
-                continuous state.
-  @see CalcTimeDerivatives(), get_time_derivatives_cache_entry() */
+  @retval xcdot Time derivatives ẋ꜀ of x꜀ returned as a reference to an object
+                of the same type and size as `context`'s continuous state.
+  @see CalcTimeDerivatives(), CalcImplicitTimeDerivativesResidual(),
+       get_time_derivatives_cache_entry() */
   const ContinuousState<T>& EvalTimeDerivatives(
       const Context<T>& context) const {
     const CacheEntry& entry = get_time_derivatives_cache_entry();
@@ -453,17 +461,87 @@ class System : public SystemBase {
   depend on both Context and additional input arguments. */
   //@{
 
-  /** Calculates the time derivatives `xcdot` of the continuous state `xc` into
+  /** Calculates the time derivatives ẋ꜀ of the continuous state x꜀ into
   a given output argument. Prefer EvalTimeDerivatives() instead to avoid
   unnecessary recomputation.
-  @see EvalTimeDerivatives() for more information.
 
-  @param context The Context whose contents will be used to evaluate the
-                 derivatives.
-  @param derivatives The time derivatives `xcdot`. Must be the same size as
-                     the continuous state vector in `context`. */
+  This method solves the %System equations in explicit form:
+
+      ẋ꜀ = fₑ(𝓒)
+
+  where `𝓒 = {a, p, t, x, u}` is the current value of the given Context from
+  which accuracy a, parameters p, time t, state x (`={x꜀ xd xₐ}`) and
+  input values u are obtained.
+
+  @param[in] context The source for time, state, inputs, etc. defining the
+      point at which the derivatives should be calculated.
+  @param[out] derivatives The time derivatives ẋ꜀. Must be the same size as
+      the continuous state vector in `context`.
+
+  @see EvalTimeDerivatives() for more information.
+  @see CalcImplicitTimeDerivativesResidual() for the implicit form of these
+       equations.*/
   void CalcTimeDerivatives(const Context<T>& context,
                            ContinuousState<T>* derivatives) const;
+
+  /** Evaluates the implicit form of the %System equations and returns the
+  residual.
+
+  The explicit and implicit forms of the %System equations are
+
+      (1) ẋ꜀ = fₑ(𝓒)            explicit
+      (2) 0 = fᵢ(𝓒; ẋ꜀)         implicit
+
+  where `𝓒 = {a, p, t, x, u}` is the current value of the given Context from
+  which accuracy a, parameters p, time t, state x (`={x꜀ xd xₐ}`) and input
+  values u are obtained. Substituting (1) into (2) shows that the following
+  condition must always hold:
+
+      (3) fᵢ(𝓒; fₑ(𝓒)) = 0      always true
+
+  When `fᵢ(𝓒; ẋ꜀ₚ)` is evaluated with a proposed time derivative ẋ꜀ₚ that
+  differs from ẋ꜀ the result will be non-zero; we call that the _residual_ of
+  the implicit equation. Given a Context and proposed time derivative ẋ꜀ₚ, this
+  method returns the residual r such that
+
+      (4) r = fᵢ(𝓒; ẋ꜀ₚ).
+
+  The returned r will typically be the same length as x꜀ although that is not
+  required. And even if r and x꜀ are the same size, there will not necessarily
+  be any elementwise correspondence between them. (That is, you should not
+  assume that r[i] is the "residual" of ẋ꜀ₚ[i].) For a Diagram, r is the
+  concatenation of residuals from each of the subsystems, in order of subsystem
+  index within the Diagram.
+
+  A default implementation fᵢ⁽ᵈᵉᶠ⁾ for the implicit form is always provided and
+  makes use of the explicit form as follows:
+
+      (5) fᵢ⁽ᵈᵉᶠ⁾(𝓒; ẋ꜀ₚ) ≜ ẋ꜀ₚ − fₑ(𝓒)
+
+  which satisfies condition (3) by construction. (Note that the default
+  implementation requires the residual to have the same size as x꜀.) Substantial
+  efficiency gains can often be obtained by replacing the default function with
+  a customized implementation. Override DoCalcImplicitTimeDerivativesResidual()
+  to replace the default implementation with a better one.
+
+  @param[in] context The source for time, state, inputs, etc. to be used
+      in calculating the residual.
+  @param[in] proposed_derivatives The proposed value ẋ꜀ₚ for the time
+      derivatives of x꜀.
+  @param[out] residual The result r of evaluating the implicit function.
+      Can be any mutable Eigen vector object of size
+      implicit_time_derivatives_residual_size().
+
+  @pre `proposed_derivatives` is compatible with this System.
+  @pre `residual` is of size implicit_time_derivatives_residual_size().
+
+  @see SystemBase::implicit_time_derivatives_residual_size()
+  @see LeafSystem::DeclareImplicitTimeDerivativesResidualSize()
+  @see DoCalcImplicitTimeDerivativesResidual()
+  @see CalcTimeDerivatives() */
+  void CalcImplicitTimeDerivativesResidual(
+      const Context<T>& context, const ContinuousState<T>& proposed_derivatives,
+      EigenPtr<VectorX<T>> residual) const;
 
   /** This method is the public entry point for dispatching all discrete
   variable update event handlers. Using all the discrete update handlers in
@@ -782,7 +860,7 @@ class System : public SystemBase {
   virtual const State<T>* DoGetTargetSystemState(const System<T>& target_system,
                                                  const State<T>* state) const;
 
-  // Returns @p xc if @p target_system equals `this`, nullptr otherwise.
+  // Returns x꜀ if @p target_system equals `this`, nullptr otherwise.
   // Should not be directly called.
   virtual const ContinuousState<T>* DoGetTargetSystemContinuousState(
       const System<T>& target_system,
@@ -932,7 +1010,7 @@ class System : public SystemBase {
     }
   }
 
-  /** Returns a copy of the continuous state vector `xc` into an Eigen
+  /** Returns a copy of the continuous state vector x꜀ into an Eigen
   vector. */
   VectorX<T> CopyContinuousStateVector(const Context<T>& context) const;
   //@}
@@ -1311,11 +1389,11 @@ class System : public SystemBase {
   sections of your concrete class. */
   //@{
 
-  /** Override this if you have any continuous state variables `xc` in your
+  /** Override this if you have any continuous state variables x꜀ in your
   concrete %System to calculate their time derivatives. The `derivatives`
   vector will correspond elementwise with the state vector
   `Context.state.continuous_state.get_state()`. Thus, if the state in the
-  Context has second-order structure `xc=[q,v,z]`, that same structure
+  Context has second-order structure `x꜀=[q v z]`, that same structure
   applies to the derivatives.
 
   This method is called only from the public non-virtual
@@ -1329,6 +1407,23 @@ class System : public SystemBase {
   size zero and aborts otherwise. */
   virtual void DoCalcTimeDerivatives(const Context<T>& context,
                                      ContinuousState<T>* derivatives) const;
+
+  /** Override this if you have an efficient way to evaluate the implicit
+  time derivatives residual for this System. Otherwise the default
+  implementation is
+  `residual = proposed_derivatives − EvalTimeDerivatives(context)`. Note that
+  you cannot use the default implementation if you have changed the declared
+  residual size.
+
+  @note The public method has already verified that `proposed_derivatives`
+  is compatible with this System and that `residual` is non-null and of the
+  the declared size (as reported by
+  SystemBase::implicit_time_derivatives_residual_size()). You do not have to
+  check those two conditions in your implementation, but if you have additional
+  restrictions you should validate that they are also met. */
+  virtual void DoCalcImplicitTimeDerivativesResidual(
+      const Context<T>& context, const ContinuousState<T>& proposed_derivatives,
+      EigenPtr<VectorX<T>> residual) const;
 
   /** Computes the next time at which this System must perform a discrete
   action.

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -8,7 +8,6 @@
 #include "drake/common/random.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
-#include "drake/common/test_utilities/is_dynamic_castable.h"
 #include "drake/examples/pendulum/pendulum_plant.h"
 #include "drake/systems/analysis/test_utilities/stateless_system.h"
 #include "drake/systems/framework/basic_vector.h"
@@ -24,6 +23,11 @@
 #include "drake/systems/primitives/gain.h"
 #include "drake/systems/primitives/integrator.h"
 #include "drake/systems/primitives/zero_order_hold.h"
+
+using Eigen::Vector2d;
+using Eigen::Vector3d;
+using Eigen::Vector4d;
+using Eigen::VectorXd;
 
 namespace drake {
 namespace systems {
@@ -550,18 +554,18 @@ class DiagramTest : public ::testing::Test {
   // Asserts that output_ is what it should be for the default values
   // of input0_, input1_, and input2_.
   void ExpectDefaultOutputs() {
-    Eigen::Vector3d expected_output0(
+    Vector3d expected_output0(
         1 + 8 + 64,
         2 + 16 + 128,
         4 + 32 + 256);  // B
 
-    Eigen::Vector3d expected_output1(
+    Vector3d expected_output1(
         1 + 8,
         2 + 16,
         4 + 32);  // A
     expected_output1 += expected_output0;       // A + B
 
-    Eigen::Vector3d expected_output2(81, 243, 729);  // state of integrator1_
+    Vector3d expected_output2(81, 243, 729);  // state of integrator1_
 
     const BasicVector<double>* output0 = output_->get_vector_data(0);
     ASSERT_TRUE(output0 != nullptr);
@@ -975,11 +979,11 @@ TEST_F(DiagramTest, ToAutoDiffXd) {
   BasicVector<AutoDiffXd> input2(3);
   for (int i = 0; i < 3; ++i) {
     input0[i].value() = 1 + 0.1 * i;
-    input0[i].derivatives() = Eigen::VectorXd::Unit(9, i);
+    input0[i].derivatives() = VectorXd::Unit(9, i);
     input1[i].value() = 2 + 0.2 * i;
-    input1[i].derivatives() = Eigen::VectorXd::Unit(9, 3 + i);
+    input1[i].derivatives() = VectorXd::Unit(9, 3 + i);
     input2[i].value() = 3 + 0.3 * i;
-    input2[i].derivatives() = Eigen::VectorXd::Unit(9, 6 + i);
+    input2[i].derivatives() = VectorXd::Unit(9, 6 + i);
   }
   context->FixInputPort(0, input0);
   context->FixInputPort(1, input1);
@@ -1069,7 +1073,7 @@ TEST_F(DiagramTest, Clone) {
 
   // Recompute the output and check the values.
   diagram_->CalcOutput(*clone, output_.get());
-  Eigen::Vector3d expected_output0(
+  Vector3d expected_output0(
       3 + 8 + 64,
       6 + 16 + 128,
       9 + 32 + 256);  // B
@@ -1079,7 +1083,7 @@ TEST_F(DiagramTest, Clone) {
   EXPECT_EQ(expected_output0[1], output0->get_value()[1]);
   EXPECT_EQ(expected_output0[2], output0->get_value()[2]);
 
-  Eigen::Vector3d expected_output1(
+  Vector3d expected_output1(
       3 + 8,
       6 + 16,
       9 + 32);  // A
@@ -2791,7 +2795,7 @@ GTEST_TEST(MutateSubcontextTest, DiagramRecalculatesOnSubcontextChange) {
   // extra computations.
   int64_t expected_derivative_serial = derivative_cache.serial_number();
 
-  Eigen::VectorXd init_state(3);
+  VectorXd init_state(3);
   init_state << 5., 6., 7.;  // x0(=y0=u1), x1(=y1), x2(=y2)
 
   // Set the state from the diagram level, then evaluate the diagram
@@ -2830,7 +2834,7 @@ GTEST_TEST(MutateSubcontextTest, DiagramRecalculatesOnSubcontextChange) {
   Context<double>& context1 =
       diagram->GetMutableSubsystemContext(*integ1, &*diagram_context);
 
-  Eigen::VectorXd new_x0(1), new_x1(1);
+  VectorXd new_x0(1), new_x1(1);
   new_x0 << 13.; new_x1 << 17.;
   context0.SetContinuousState(new_x0);
   context1.SetContinuousState(new_x1);
@@ -3185,7 +3189,7 @@ class ConstraintTestSystem : public LeafSystem<T> {
                                     1, "x0");
     this->DeclareInequalityConstraint(
         &ConstraintTestSystem::CalcStateConstraint,
-        { Eigen::Vector2d::Zero(), std::nullopt }, "x");
+        { Vector2d::Zero(), std::nullopt }, "x");
   }
 
   // Scalar-converting copy constructor.
@@ -3228,14 +3232,14 @@ GTEST_TEST(DiagramConstraintTest, SystemConstraintsTest) {
   // Set sys1 context.
   diagram->GetMutableSubsystemContext(*sys1, context.get())
       .get_mutable_continuous_state_vector()
-      .SetFromVector(Eigen::Vector2d(5.0, 7.0));
+      .SetFromVector(Vector2d(5.0, 7.0));
 
   // Set sys2 context.
   diagram->GetMutableSubsystemContext(*sys2, context.get())
       .get_mutable_continuous_state_vector()
-      .SetFromVector(Eigen::Vector2d(11.0, 12.0));
+      .SetFromVector(Vector2d(11.0, 12.0));
 
-  Eigen::VectorXd value;
+  VectorXd value;
   // Check system 1's x0 constraint.
   const SystemConstraint<double>& constraint0 =
       diagram->get_constraint(SystemConstraintIndex(0));
@@ -3353,9 +3357,9 @@ class RandomContextTestSystem : public LeafSystem<double> {
  public:
   RandomContextTestSystem() {
     this->DeclareContinuousState(
-        BasicVector<double>(Eigen::Vector2d(-1.0, -2.0)));
+        BasicVector<double>(Vector2d(-1.0, -2.0)));
     this->DeclareNumericParameter(
-        BasicVector<double>(Eigen::Vector3d(1.0, 2.0, 3.0)));
+        BasicVector<double>(Vector3d(1.0, 2.0, 3.0)));
   }
 
   void SetRandomState(const Context<double>& context, State<double>* state,
@@ -3388,9 +3392,9 @@ GTEST_TEST(RandomContextTest, SetRandomTest) {
   auto context = diagram->CreateDefaultContext();
 
   // Back-up the numeric context values.
-  Eigen::Vector4d state = context->get_continuous_state_vector().CopyToVector();
-  Eigen::Vector3d params0 = context->get_numeric_parameter(0).CopyToVector();
-  Eigen::Vector3d params1 = context->get_numeric_parameter(1).CopyToVector();
+  Vector4d state = context->get_continuous_state_vector().CopyToVector();
+  Vector3d params0 = context->get_numeric_parameter(0).CopyToVector();
+  Vector3d params1 = context->get_numeric_parameter(1).CopyToVector();
 
   // Should return the (same) original values.
   diagram->SetDefaultContext(context.get());
@@ -3520,6 +3524,68 @@ GTEST_TEST(InitializationTest, InitializationTest) {
 }
 
 // TODO(siyuan) add direct tests for EventCollection
+
+// A System that does not override the default implicit time derivatives
+// implementation.
+class DefaultExplicitSystem : public LeafSystem<double> {
+ public:
+  DefaultExplicitSystem() { DeclareContinuousState(3); }
+
+  static Vector3d fixed_derivative() { return {1., 2., 3.}; }
+
+ private:
+  void DoCalcTimeDerivatives(const Context<double>& context,
+                             ContinuousState<double>* derivatives) const final {
+    derivatives->SetFromVector(fixed_derivative());
+  }
+};
+
+// A System that _does_ override the default implicit time derivatives
+// implementation, and also changes the residual size from its default.
+class OverrideImplicitSystem : public DefaultExplicitSystem {
+ public:
+  OverrideImplicitSystem() {
+    DeclareImplicitTimeDerivativesResidualSize(1);
+  }
+
+ private:
+  void DoCalcImplicitTimeDerivativesResidual(
+    const systems::Context<double>& context,
+    const systems::ContinuousState<double>& proposed_derivatives,
+    EigenPtr<VectorX<double>> residual) const final {
+    EXPECT_EQ(residual->size(), 1);
+    (*residual)[0] = proposed_derivatives.CopyToVector().sum();
+  }
+};
+
+// A Diagram should concatenate the implicit time derivatives from its
+// component subsystems, and tally up the size correctly.
+GTEST_TEST(ImplicitTimeDerivatives, DiagramProcessing) {
+  const Vector3d derivs = DefaultExplicitSystem::fixed_derivative();
+
+  DiagramBuilder<double> builder;
+  builder.AddSystem<DefaultExplicitSystem>();   // 3 residuals
+  builder.AddSystem<OverrideImplicitSystem>();  // 1 residual
+  builder.AddSystem<DefaultExplicitSystem>();   // 3 more residuals
+  auto diagram = builder.Build();
+  auto context = diagram->CreateDefaultContext();
+
+  EXPECT_EQ(diagram->implicit_time_derivatives_residual_size(), 7);
+  VectorXd residual = diagram->AllocateImplicitTimeDerivativesResidual();
+  EXPECT_EQ(residual.size(), 7);
+
+  auto xdot = diagram->AllocateTimeDerivatives();
+  EXPECT_EQ(xdot->size(), 9);  // 3 derivatives each subsystem
+  const auto xdot_vector = VectorXd::LinSpaced(9, 11., 19.);
+  xdot->SetFromVector(xdot_vector);
+  VectorXd expected_result(7);
+  expected_result.segment<3>(0) = xdot_vector.segment<3>(0) - derivs;
+  expected_result[3] = xdot_vector.segment<3>(3).sum();
+  expected_result.segment<3>(4) = xdot_vector.segment<3>(6) - derivs;
+
+  diagram->CalcImplicitTimeDerivativesResidual(*context, *xdot, &residual);
+  EXPECT_EQ(residual, expected_result);
+}
 
 }  // namespace
 }  // namespace systems

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -24,6 +24,11 @@
 #include "drake/systems/framework/test_utilities/my_vector.h"
 #include "drake/systems/framework/test_utilities/pack_value.h"
 
+using Eigen::Vector2d;
+using Eigen::Vector3d;
+using Eigen::Vector4d;
+using Eigen::VectorXd;
+
 namespace drake {
 namespace systems {
 namespace {
@@ -1094,9 +1099,9 @@ GTEST_TEST(ModelLeafSystemTest, ModelInputGovernsFixedInput) {
   dut.reset();
 
   // The first port should only accept a 1d vector.
-  context->FixInputPort(0, Eigen::VectorXd::Constant(1, 0.0));
+  context->FixInputPort(0, VectorXd::Constant(1, 0.0));
   DRAKE_EXPECT_THROWS_MESSAGE(
-      context->FixInputPort(0, Eigen::VectorXd::Constant(2, 0.0)),
+      context->FixInputPort(0, VectorXd::Constant(2, 0.0)),
       std::exception,
       "System::FixInputPortTypeCheck\\(\\): expected value of type "
       "drake::systems::BasicVector<double> with size=1 "
@@ -1263,7 +1268,7 @@ GTEST_TEST(ModelLeafSystemTest, ModelPortsCalcOutput) {
   EXPECT_EQ(vec0->get_value(), dut.expected_basic().get_value());
   EXPECT_EQ(vec1->get_value(), dut.expected_myvector().get_value());
   EXPECT_EQ(*str2, "concrete string");
-  EXPECT_EQ(vec3->get_value(), Eigen::Vector2d(10., 20.));
+  EXPECT_EQ(vec3->get_value(), Vector2d(10., 20.));
 }
 
 // Tests that the leaf system reserved the declared parameters of interesting
@@ -1289,9 +1294,9 @@ GTEST_TEST(ModelLeafSystemTest, ModelDiscreteState) {
     DeclaredModelDiscreteStateSystem() {
       // Takes a BasicVector.
       indexes_.push_back(
-          DeclareDiscreteState(MyVector2d(Eigen::Vector2d(1., 2.))));
+          DeclareDiscreteState(MyVector2d(Vector2d(1., 2.))));
       // Takes an Eigen vector.
-      indexes_.push_back(DeclareDiscreteState(Eigen::Vector3d(3., 4., 5.)));
+      indexes_.push_back(DeclareDiscreteState(Vector3d(3., 4., 5.)));
       // Four state variables, initialized to zero.
       indexes_.push_back(DeclareDiscreteState(4));
     }
@@ -1310,33 +1315,33 @@ GTEST_TEST(ModelLeafSystemTest, ModelDiscreteState) {
   // Concrete type and value should have been preserved.
   BasicVector<double>& xd0 = xd.get_mutable_vector(0);
   EXPECT_TRUE(is_dynamic_castable<const MyVector2d>(&xd0));
-  EXPECT_EQ(xd0.get_value(), Eigen::Vector2d(1., 2.));
+  EXPECT_EQ(xd0.get_value(), Vector2d(1., 2.));
 
   // Eigen vector should have been stored in a BasicVector-type object.
   BasicVector<double>& xd1 = xd.get_mutable_vector(1);
   EXPECT_EQ(typeid(xd1), typeid(BasicVector<double>));
-  EXPECT_EQ(xd1.get_value(), Eigen::Vector3d(3., 4., 5.));
+  EXPECT_EQ(xd1.get_value(), Vector3d(3., 4., 5.));
 
   // Discrete state with no model should act as though it were given an
   // all-zero Eigen vector model.
   BasicVector<double>& xd2 = xd.get_mutable_vector(2);
   EXPECT_EQ(typeid(xd2), typeid(BasicVector<double>));
-  EXPECT_EQ(xd2.get_value(), Eigen::Vector4d(0., 0., 0., 0.));
+  EXPECT_EQ(xd2.get_value(), Vector4d(0., 0., 0., 0.));
 
   // Now make changes, then see if SetDefaultContext() puts them back.
-  xd0.SetFromVector(Eigen::Vector2d(9., 10.));
-  xd1.SetFromVector(Eigen::Vector3d(11., 12., 13.));
-  xd2.SetFromVector(Eigen::Vector4d(1., 2., 3., 4.));
+  xd0.SetFromVector(Vector2d(9., 10.));
+  xd1.SetFromVector(Vector3d(11., 12., 13.));
+  xd2.SetFromVector(Vector4d(1., 2., 3., 4.));
 
   // Of course that had to work, but let's just prove it ...
-  EXPECT_EQ(xd0.get_value(), Eigen::Vector2d(9., 10.));
-  EXPECT_EQ(xd1.get_value(), Eigen::Vector3d(11., 12., 13.));
-  EXPECT_EQ(xd2.get_value(), Eigen::Vector4d(1., 2., 3., 4.));
+  EXPECT_EQ(xd0.get_value(), Vector2d(9., 10.));
+  EXPECT_EQ(xd1.get_value(), Vector3d(11., 12., 13.));
+  EXPECT_EQ(xd2.get_value(), Vector4d(1., 2., 3., 4.));
 
   dut.SetDefaultContext(&*context);
-  EXPECT_EQ(xd0.get_value(), Eigen::Vector2d(1., 2.));
-  EXPECT_EQ(xd1.get_value(), Eigen::Vector3d(3., 4., 5.));
-  EXPECT_EQ(xd2.get_value(), Eigen::Vector4d(0., 0., 0., 0.));
+  EXPECT_EQ(xd0.get_value(), Vector2d(1., 2.));
+  EXPECT_EQ(xd1.get_value(), Vector3d(3., 4., 5.));
+  EXPECT_EQ(xd2.get_value(), Vector4d(0., 0., 0., 0.));
 }
 
 // Tests that DeclareAbstractState works expectedly.
@@ -1456,7 +1461,7 @@ class DeclaredNonModelOutputSystem : public LeafSystem<double> {
     ++count_calc_dummy_vec2_;
     ASSERT_NE(out, nullptr);
     EXPECT_EQ(out->size(), 2);
-    out->get_mutable_value() = Eigen::Vector2d(-100., -200);
+    out->get_mutable_value() = Vector2d(-100., -200);
   }
 
   // Explicit allocator method.
@@ -1523,9 +1528,9 @@ GTEST_TEST(NonModelLeafSystemTest, NonModelPortsOutput) {
   EXPECT_EQ(output0->size(), 2);
   auto out0_dummy = dynamic_cast<DummyVec2*>(output0);
   EXPECT_NE(out0_dummy, nullptr);
-  EXPECT_EQ(out0_dummy->get_value(), Eigen::Vector2d(100., 200.));
+  EXPECT_EQ(out0_dummy->get_value(), Vector2d(100., 200.));
   out0.Calc(*context, system_output->GetMutableData(0));
-  EXPECT_EQ(out0_dummy->get_value(), Eigen::Vector2d(-100., -200.));
+  EXPECT_EQ(out0_dummy->get_value(), Vector2d(-100., -200.));
 
   EXPECT_EQ(dut.calc_dummy_vec2_calls(), 1);
   EXPECT_EQ(out0.Eval<BasicVector<double>>(*context).get_value(),
@@ -2231,11 +2236,11 @@ class ConstraintBasicVector final : public BasicVector<T> {
   ConstraintBasicVector() : BasicVector<T>(VectorX<T>::Zero(kSize)) {}
   BasicVector<T>* DoClone() const override { return new ConstraintBasicVector; }
 
-  void GetElementBounds(Eigen::VectorXd* lower,
-                        Eigen::VectorXd* upper) const override {
+  void GetElementBounds(VectorXd* lower,
+                        VectorXd* upper) const override {
     const double kInf = std::numeric_limits<double>::infinity();
-    *lower = Eigen::Vector3d(bias, -kInf, -kInf);
-    *upper = Eigen::Vector3d::Constant(kInf);
+    *lower = Vector3d(bias, -kInf, -kInf);
+    *upper = Vector3d::Constant(kInf);
   }
 };
 
@@ -2253,18 +2258,18 @@ class ConstraintTestSystem : public LeafSystem<double> {
   using LeafSystem<double>::DeclareVectorOutputPort;
 
   void CalcState0Constraint(const Context<double>& context,
-                            Eigen::VectorXd* value) const {
+                            VectorXd* value) const {
     *value = Vector1d(context.get_continuous_state_vector()[0]);
   }
   void CalcStateConstraint(const Context<double>& context,
-                           Eigen::VectorXd* value) const {
+                           VectorXd* value) const {
     *value = context.get_continuous_state_vector().CopyToVector();
   }
 
   void CalcOutput(
       const Context<double>& context,
       ConstraintBasicVector<double, 44>* output) const {
-    output->SetFromVector(Eigen::VectorXd::Constant(output->size(), 4.0));
+    output->SetFromVector(VectorXd::Constant(output->size(), 4.0));
   }
 
  private:
@@ -2291,19 +2296,19 @@ GTEST_TEST(SystemConstraintTest, ClassMethodTest) {
   EXPECT_EQ(
       dut.DeclareInequalityConstraint(
           &ConstraintTestSystem::CalcStateConstraint,
-          { Eigen::Vector2d::Zero(), std::nullopt },
+          { Vector2d::Zero(), std::nullopt },
           "x"),
       1);
   EXPECT_EQ(dut.num_constraints(), 2);
 
   auto context = dut.CreateDefaultContext();
   context->get_mutable_continuous_state_vector().SetFromVector(
-      Eigen::Vector2d(5.0, 7.0));
+      Vector2d(5.0, 7.0));
 
   EXPECT_EQ(dut.get_constraint(SystemConstraintIndex(0)).size(), 1);
   EXPECT_EQ(dut.get_constraint(SystemConstraintIndex(1)).size(), 2);
 
-  Eigen::VectorXd value;
+  VectorXd value;
   dut.get_constraint(SystemConstraintIndex(0)).Calc(*context, &value);
   EXPECT_EQ(value.rows(), 1);
   EXPECT_EQ(value[0], 5.0);
@@ -2328,7 +2333,7 @@ GTEST_TEST(SystemConstraintTest, FunctionHandleTest) {
   EXPECT_EQ(dut.num_constraints(), 0);
 
   ContextConstraintCalc<double> calc0 = [](
-      const Context<double>& context, Eigen::VectorXd* value) {
+      const Context<double>& context, VectorXd* value) {
     *value = Vector1d(context.get_continuous_state_vector()[1]);
   };
   EXPECT_EQ(dut.DeclareInequalityConstraint(calc0,
@@ -2338,19 +2343,19 @@ GTEST_TEST(SystemConstraintTest, FunctionHandleTest) {
   EXPECT_EQ(dut.num_constraints(), 1);
 
   ContextConstraintCalc<double> calc1 = [](
-      const Context<double>& context, Eigen::VectorXd* value) {
+      const Context<double>& context, VectorXd* value) {
     *value =
-        Eigen::Vector2d(context.get_continuous_state_vector()[1],
+        Vector2d(context.get_continuous_state_vector()[1],
                         context.get_continuous_state_vector()[0]);
   };
   EXPECT_EQ(dut.DeclareInequalityConstraint(calc1,
-      { std::nullopt, Eigen::Vector2d(2, 3) }, "x_upper"), 1);
+      { std::nullopt, Vector2d(2, 3) }, "x_upper"), 1);
 
   auto context = dut.CreateDefaultContext();
   context->get_mutable_continuous_state_vector().SetFromVector(
-      Eigen::Vector2d(5.0, 7.0));
+      Vector2d(5.0, 7.0));
 
-  Eigen::VectorXd value;
+  VectorXd value;
   const SystemConstraint<double>& inequality_constraint0 =
       dut.get_constraint(SystemConstraintIndex(0));
   inequality_constraint0.Calc(*context, &value);
@@ -2452,13 +2457,13 @@ GTEST_TEST(SystemConstraintTest, ModelVectorTest) {
 
   // `param0[0] >= 11.0` with `param0[0] == 1.0` produces `1.0 >= 11.0`.
   context->get_mutable_numeric_parameter(0)[0] = 1.0;
-  Eigen::VectorXd value0;
+  VectorXd value0;
   constraint0.Calc(*context, &value0);
   EXPECT_TRUE(CompareMatrices(value0, Vector1<double>::Constant(1.0)));
 
   // `xc[0] >= 22.0` with `xc[0] == 2.0` produces `2.0 >= 22.0`.
   context->get_mutable_continuous_state_vector()[0] = 2.0;
-  Eigen::VectorXd value1;
+  VectorXd value1;
   constraint1.Calc(*context, &value1);
   EXPECT_TRUE(CompareMatrices(value1, Vector1<double>::Constant(2.0)));
 
@@ -2466,12 +2471,12 @@ GTEST_TEST(SystemConstraintTest, ModelVectorTest) {
   InputVector input;
   input[0] = 3.0;
   dut.get_input_port(0).FixValue(&*context, input);
-  Eigen::VectorXd value2;
+  VectorXd value2;
   constraint2.Calc(*context, &value2);
   EXPECT_TRUE(CompareMatrices(value2, Vector1<double>::Constant(3.0)));
 
   // `y0[0] >= 44.0` with `y0[0] == 4.0` produces `4.0 >= 44.0`.
-  Eigen::VectorXd value3;
+  VectorXd value3;
   constraint3.Calc(*context, &value3);
   EXPECT_TRUE(CompareMatrices(value3, Vector1<double>::Constant(4.0)));
 }
@@ -2481,9 +2486,9 @@ class RandomContextTestSystem : public LeafSystem<double> {
  public:
   RandomContextTestSystem() {
     this->DeclareContinuousState(
-        BasicVector<double>(Eigen::Vector2d(-1.0, -2.0)));
+        BasicVector<double>(Vector2d(-1.0, -2.0)));
     this->DeclareNumericParameter(
-        BasicVector<double>(Eigen::Vector3d(1.0, 2.0, 3.0)));
+        BasicVector<double>(Vector3d(1.0, 2.0, 3.0)));
   }
 
   void SetRandomState(const Context<double>& context, State<double>* state,
@@ -2511,8 +2516,8 @@ GTEST_TEST(RandomContextTest, SetRandomTest) {
   auto context = system.CreateDefaultContext();
 
   // Back-up the numeric context values.
-  Eigen::Vector2d state = context->get_continuous_state_vector().CopyToVector();
-  Eigen::Vector3d params = context->get_numeric_parameter(0).CopyToVector();
+  Vector2d state = context->get_continuous_state_vector().CopyToVector();
+  Vector3d params = context->get_numeric_parameter(0).CopyToVector();
 
   // Should return the (same) original values.
   system.SetDefaultContext(context.get());
@@ -2801,6 +2806,159 @@ GTEST_TEST(EventSugarTest, HandlersGetCalled) {
   EXPECT_EQ(dut.num_second_discrete_update(), 1);
   EXPECT_EQ(dut.num_unrestricted_update(), 5);
   EXPECT_EQ(dut.num_second_unrestricted_update(), 1);
+}
+
+// A System that does not override the default implicit time derivatives
+// implementation.
+class DefaultExplicitSystem : public LeafSystem<double> {
+ public:
+  DefaultExplicitSystem() { DeclareContinuousState(3); }
+
+  void RedeclareResidualSize(int n) {
+    DeclareImplicitTimeDerivativesResidualSize(n);
+  }
+
+  static Vector3d fixed_derivative() { return {1., 2., 3.}; }
+
+ private:
+  void DoCalcTimeDerivatives(const Context<double>& context,
+                             ContinuousState<double>* derivatives) const final {
+    derivatives->SetFromVector(fixed_derivative());
+  }
+
+  // No override for the implicit derivatives method.
+};
+
+// A System that _does_ override the default implicit time derivatives
+// implementation, and also changes the residual size from its default.
+class OverrideImplicitSystem : public DefaultExplicitSystem {
+ public:
+  OverrideImplicitSystem() {
+    DeclareImplicitTimeDerivativesResidualSize(1);
+  }
+
+  void RedeclareResidualSize(int n) {
+    DeclareImplicitTimeDerivativesResidualSize(n);
+  }
+
+ private:
+  void DoCalcImplicitTimeDerivativesResidual(
+    const systems::Context<double>& context,
+    const systems::ContinuousState<double>& proposed_derivatives,
+    EigenPtr<VectorX<double>> residual) const final {
+    EXPECT_EQ(residual->size(), 1);
+    (*residual)[0] = proposed_derivatives.CopyToVector().sum();
+  }
+};
+
+GTEST_TEST(ImplicitTimeDerivatives, DefaultImplementation) {
+  const Vector3d derivs = DefaultExplicitSystem::fixed_derivative();
+
+  DefaultExplicitSystem dut;
+  auto context = dut.CreateDefaultContext();
+  auto xdot = dut.AllocateTimeDerivatives();
+
+  // Check that SystemBase method returns the default size.
+  EXPECT_EQ(dut.implicit_time_derivatives_residual_size(), 3);
+
+  // Proposing the actual derivative should yield a zero residual.
+  xdot->SetFromVector(derivs);
+
+  // Make sure the vector type returned by the allocator works.
+  VectorXd residual = dut.AllocateImplicitTimeDerivativesResidual();
+  EXPECT_EQ(residual.size(), 3);
+  dut.CalcImplicitTimeDerivativesResidual(*context, *xdot, &residual);
+  EXPECT_EQ(residual, Vector3d::Zero());  // Yes, exactly.
+
+  // To make sure the method isn't just returning zero, try the reverse
+  // case which should have the actual derivative as a residual.
+  xdot->SetFromVector(Vector3d::Zero());
+  dut.CalcImplicitTimeDerivativesResidual(*context, *xdot, &residual);
+  EXPECT_EQ(residual, -derivs);  // Exact.
+
+  // The residual should be acceptable as long as it is some mutable
+  // Eigen object of the right shape.
+
+  // A fixed-size residual should work.
+  Vector3d residual3;
+  dut.CalcImplicitTimeDerivativesResidual(*context, *xdot, &residual3);
+  EXPECT_EQ(residual3, -derivs);
+
+  // Some complicated Eigen mutable object should also work.
+  VectorXd buffer(VectorXd::Zero(5));
+  auto segment = buffer.segment(1, 3);  // Some kind of block object.
+  VectorXd expected_residual(VectorXd::Zero(5));
+  expected_residual.segment(1, 3) = -derivs;
+  dut.CalcImplicitTimeDerivativesResidual(*context, *xdot, &segment);
+  EXPECT_EQ(buffer, expected_residual);
+
+  // Let's change the declared residual size, pass in a matching vector,
+  // and verify that the default implementation complains properly.
+  dut.RedeclareResidualSize(4);
+  Vector4d residual4;
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dut.CalcImplicitTimeDerivativesResidual(*context, *xdot, &residual4),
+      std::logic_error,
+      "System::DoCalcImplicitTimeDerivativesResidual.*"
+      "default implementation requires.*residual size.*4.*"
+      "matches.*state variables.*3.*must override.*");
+
+  // And if the residual matches the state size but not the declared size,
+  // we should get stopped by the NVI public method.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dut.CalcImplicitTimeDerivativesResidual(*context, *xdot, &residual3),
+      std::logic_error,
+      ".*CalcImplicitTimeDerivativesResidual.*"
+      "expected residual.*size 4 but got.*size 3.*\n"
+      "Use AllocateImplicitTimeDerivativesResidual.*");
+}
+
+GTEST_TEST(ImplicitTimeDerivatives, OverrideImplementation) {
+  OverrideImplicitSystem dut;
+  auto context = dut.CreateDefaultContext();
+  auto xdot = dut.AllocateTimeDerivatives();
+  EXPECT_EQ(xdot->size(), 3);
+
+  // Check that SystemBase method returns the adjusted size.
+  EXPECT_EQ(dut.implicit_time_derivatives_residual_size(), 1);
+
+  // Make sure the vector size returned by the allocator reflects the change.
+  VectorXd residual = dut.AllocateImplicitTimeDerivativesResidual();
+  EXPECT_EQ(residual.size(), 1);
+  residual[0] = 99.;  // So we can make sure it gets changed.
+
+  // "Residual" just sums the proposed derivative xdot.
+  xdot->SetFromVector(Vector3d(10., 20., 30.));
+  dut.CalcImplicitTimeDerivativesResidual(*context, *xdot, &residual);
+  EXPECT_EQ(residual[0], 60.);
+
+  // (No need to re-test the acceptable Eigen output types as we did in
+  // the previous test since both go through the same public NVI method.)
+
+  // Check that a wrong-sized residual gets a nice message.
+  Vector3d bad_residual;
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dut.CalcImplicitTimeDerivativesResidual(*context, *xdot, &bad_residual),
+      std::logic_error,
+      ".*CalcImplicitTimeDerivativesResidual.*"
+      "expected residual.*size 1 but got.*size 3.*\n"
+      "Use AllocateImplicitTimeDerivativesResidual.*");
+}
+
+// Check that declaring an illegal residual size just resets size back to the
+// default (that is, the same size as the time derivatives).
+GTEST_TEST(ImplicitTimeDerivatives, ResetToDefaultResidualSize) {
+  OverrideImplicitSystem dut;
+  EXPECT_EQ(dut.implicit_time_derivatives_residual_size(), 1);
+
+  dut.RedeclareResidualSize(0);
+  EXPECT_EQ(dut.implicit_time_derivatives_residual_size(), 3);
+
+  dut.RedeclareResidualSize(1);  // Non-default.
+  EXPECT_EQ(dut.implicit_time_derivatives_residual_size(), 1);
+
+  dut.RedeclareResidualSize(-29);
+  EXPECT_EQ(dut.implicit_time_derivatives_residual_size(), 3);
 }
 
 }  // namespace


### PR DESCRIPTION
Introduces System API for the implicit form of the system equations:
```c++
System::CalcImplicitTimeDerivativesResidual(context, proposed_derivatives, &residual);
VectorX = System::AllocateImplicitTimeDerivativesResidual();
```
The default is that the residual is the same length as the continuous state. A LeafSystem can change that during construction via
```
LeafSystem::DeclareImplicitTimeDerivativesResidualSize(n);
```

Provides a residual form of the Acrobot example reimplemented from #12828.

Resolves #12869.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13068)
<!-- Reviewable:end -->
