### PR TITLE
Fix Mac setup script: Rename DejaVu fonts

### DIFF
--- a/setup/mac/source_distribution/Brewfile
+++ b/setup/mac/source_distribution/Brewfile
@@ -6,7 +6,7 @@ tap 'homebrew/cask-versions' unless system '/usr/libexec/java_home --version 1.8
 tap 'robotlocomotion/director'
 
 cask 'adoptopenjdk8' unless system '/usr/libexec/java_home --version 1.8 --failfast &> /dev/null'
-cask 'font-dejavu-sans' unless File.exist? '/Library/Fonts/DejaVuSans.ttf'
+cask 'font-dejavu' unless File.exist? '/Library/Fonts/DejaVuSans.ttf'
 
 brew 'bazel'
 brew 'diffstat'


### PR DESCRIPTION
Mac unprovisioned jobs began failing on April 14th. For example:

[mac-catalina-unprovisioned-clang-bazel-nightly-release](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-catalina-unprovisioned-clang-bazel-nightly-release/128/console)
[mac-mojave-unprovisioned-clang-bazel-continuous-snopt-packaging](https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/mac-mojave-unprovisioned-clang-bazel-continuous-snopt-packaging/929/console)

with the following error message:

```
[4:02:28 AM]  Tapping homebrew/cask-fonts
[4:02:28 AM]  Using robotlocomotion/director
[4:02:36 AM]  Error: Cask 'font-dejavu-sans' is unavailable: No Cask with this name exists. Did you mean one of these?
[4:02:36 AM]  font-dejavu-sans-mono-for-powerline
[4:02:36 AM]  font-dejavusansmono-nerd-font
[4:02:36 AM]  Installing font-dejavu-sans has failed!
```

The DejaVu fonts have been renamed from 'font-dejavu-sans' to 'font-dejvu' (https://github.com/Homebrew/homebrew-cask-fonts/pull/2010)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13070)
<!-- Reviewable:end -->
