### PR TITLE
Install font-dejavu cask instead of font-dejavu-sans on macOS

### DIFF
--- a/setup/mac/source_distribution/Brewfile
+++ b/setup/mac/source_distribution/Brewfile
@@ -6,7 +6,7 @@ tap 'homebrew/cask-versions' unless system '/usr/libexec/java_home --version 1.8
 tap 'robotlocomotion/director'
 
 cask 'adoptopenjdk8' unless system '/usr/libexec/java_home --version 1.8 --failfast &> /dev/null'
-cask 'font-dejavu-sans' unless File.exist? '/Library/Fonts/DejaVuSans.ttf'
+cask 'font-dejavu' unless File.exist? '/Library/Fonts/DejaVuSans.ttf'
 
 brew 'bazel'
 brew 'diffstat'


### PR DESCRIPTION
See Homebrew/homebrew-cask-fonts#2010.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13071)
<!-- Reviewable:end -->
