### PR TITLE
py systems: Fix keep_alive bug for lcm

### DIFF
--- a/bindings/pydrake/systems/lcm_py.cc
+++ b/bindings/pydrake/systems/lcm_py.cc
@@ -99,8 +99,8 @@ PYBIND11_MODULE(lcm, m) {
     py::class_<Class, LeafSystem<double>>(m, "LcmInterfaceSystem",
         (std::string(cls_doc.doc) + kLcmInterfaceSystemClassWarning).c_str())
         .def(py::init<DrakeLcmInterface*>(),
-            // Keep alive, reference: `lcm` keeps `self` alive.
-            py::keep_alive<2, 1>(), py::arg("lcm"), cls_doc.ctor.doc_1args_lcm);
+            // Keep alive, reference: `self` keeps `lcm` alive.
+            py::keep_alive<1, 2>(), py::arg("lcm"), cls_doc.ctor.doc_1args_lcm);
   }
 
   {


### PR DESCRIPTION
Follow-up to #13607

Messed up the `keep_alive` ordering - oops!
(Ran into this while tinkering with it Anzu)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13075)
<!-- Reviewable:end -->
