### PR TITLE
Fix drake::Polynomial<T>(0) problem

### DIFF
--- a/common/polynomial.cc
+++ b/common/polynomial.cc
@@ -82,8 +82,7 @@ Polynomial<T>::Polynomial(
 }
 
 template <typename T>
-Polynomial<T>::Polynomial(const string varname,
-                                        const unsigned int num) {
+Polynomial<T>::Polynomial(const string& varname, const unsigned int num) {
   Monomial m;
   m.coefficient = T{1};
   Term t;

--- a/common/test/polynomial_test.cc
+++ b/common/test/polynomial_test.cc
@@ -539,8 +539,8 @@ void TestScalarType() {
   EXPECT_THROW(p.Roots(), std::runtime_error);
   EXPECT_TRUE(static_cast<bool>(p.IsApprox(p, 1e-14)));
 
-  Polynomial<T> x("x");
-  Polynomial<T> y("y");
+  Polynomial<T> x("x", 1);
+  Polynomial<T> y("y", 1);
   const std::map<Polynomiald::VarType, double> eval_point = {
     {x.GetSimpleVariable(), 1},
     {y.GetSimpleVariable(), 2}};
@@ -552,6 +552,13 @@ void TestScalarType() {
 GTEST_TEST(PolynomialTest, ScalarTypes) {
   TestScalarType<AutoDiffXd>();
   TestScalarType<symbolic::Expression>();
+
+  // Checks that we can create an instance, Polynomial<T>(0). `Scalar(0)` (where
+  // Scalar = Polynomial<T>) is a common pattern in Eigen internals and we want
+  // to make sure that we can build these instances.
+  const Polynomial<double> p_double(0);
+  const Polynomial<AutoDiffXd> p_autodiffxd(0);
+  const Polynomial<symbolic::Expression> p_symbolic(0);
 }
 
 }  // anonymous namespace

--- a/common/trajectories/piecewise_polynomial.cc
+++ b/common/trajectories/piecewise_polynomial.cc
@@ -178,14 +178,10 @@ PiecewisePolynomial<T>& PiecewisePolynomial<T>::operator*=(
   if (!this->SegmentTimesEqual(other))
     throw runtime_error(
         "Multiplication not yet implemented when segment times are not equal");
-  if constexpr (std::is_same<T, double>::value) {
-    for (size_t i = 0; i < polynomials_.size(); i++) {
-      polynomials_[i] *= other.polynomials_[i];
-    }
-    return *this;
-  } else {
-    throw runtime_error("Multiplication only supported so far for T=double");
+  for (size_t i = 0; i < polynomials_.size(); i++) {
+    polynomials_[i] *= other.polynomials_[i];
   }
+  return *this;
 }
 
 template <typename T>


### PR DESCRIPTION
When `T = symbolic::Expression` and `T = AutoDiffXd`, `Polynomial<T>(0)` does not
compile as there are two possible candidates.

```
 1. Polynomial(const T& scalar);
 2. explicit Polynomial(const std::string& varname, const unsigned int num = 1);
```

This commit addresses the problem by:

 A. Make 2 have no default arguments.
 B. Provide Polynomial<double>(const std::string&) not to break code using the current API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13076)
<!-- Reviewable:end -->
