### PR TITLE
Partially revert "Make lcm_test pass under ... bazel run ..."

### DIFF
--- a/bindings/pydrake/systems/test/lcm_test.py
+++ b/bindings/pydrake/systems/test/lcm_test.py
@@ -91,7 +91,7 @@ class TestSystemsLcm(unittest.TestCase):
         return simulator.get_context().Clone()
 
     def test_subscriber(self):
-        lcm = DrakeLcm(lcm_url="memq://")
+        lcm = DrakeLcm()
         dut = mut.LcmSubscriberSystem.Make(
             channel="TEST_CHANNEL", lcm_type=quaternion_t, lcm=lcm)
         model_message = self._model_message()
@@ -102,7 +102,7 @@ class TestSystemsLcm(unittest.TestCase):
         self.assert_lcm_equal(actual_message, model_message)
 
     def test_subscriber_cpp(self):
-        lcm = DrakeLcm(lcm_url="memq://")
+        lcm = DrakeLcm()
         dut = mut.LcmSubscriberSystem.Make(
             channel="TEST_CHANNEL", lcm_type=quaternion_t, lcm=lcm,
             use_cpp_serializer=True)
@@ -116,7 +116,7 @@ class TestSystemsLcm(unittest.TestCase):
 
     def test_subscriber_wait_for_message(self):
         """Checks how `WaitForMessage` works without Python threads."""
-        lcm = DrakeLcm("memq://")
+        lcm = DrakeLcm()
         sub = mut.LcmSubscriberSystem.Make("TEST_LOOP", header_t, lcm)
         value = AbstractValue.Make(header_t())
         for old_message_count in range(3):
@@ -137,7 +137,7 @@ class TestSystemsLcm(unittest.TestCase):
         dut.Publish(context)
 
     def test_publisher(self):
-        lcm = DrakeLcm(lcm_url="memq://")
+        lcm = DrakeLcm()
         dut = mut.LcmPublisherSystem.Make(
             channel="TEST_CHANNEL", lcm_type=quaternion_t, lcm=lcm,
             publish_period=0.1)
@@ -148,7 +148,7 @@ class TestSystemsLcm(unittest.TestCase):
         self.assert_lcm_equal(subscriber.message, model_message)
 
     def test_publisher_cpp(self):
-        lcm = DrakeLcm(lcm_url="memq://")
+        lcm = DrakeLcm()
         dut = mut.LcmPublisherSystem.Make(
             channel="TEST_CHANNEL", lcm_type=quaternion_t, lcm=lcm,
             use_cpp_serializer=True)
@@ -174,7 +174,7 @@ class TestSystemsLcm(unittest.TestCase):
         # Next, construct a diagram and add both the interface system and
         # a subscriber.
         builder = DiagramBuilder()
-        lcm = DrakeLcm("memq://")
+        lcm = DrakeLcm()
         lcm_system = builder.AddSystem(mut.LcmInterfaceSystem(lcm=lcm))
         # Create subscriber in the diagram.
         subscriber = builder.AddSystem(mut.LcmSubscriberSystem.Make(


### PR DESCRIPTION
This reverts commit 102a7f577cc22b41cf8a69aee61ccc17f5bde004 from #13067 but leaves its new file overview comment intact.

Also remove another `memq` that snuck in in the subsequent commit.

Running tests via `bazel run` is it is brittle and unsupported; we should not pretend otherwise, especially when doing so would add copypasta into dozens of unit test source files.

If we want to move towards supporting it, we should enhance `drake_cc_googletest_main` and `drake_py_unittest_main` to partially re-implement the test environment that bazel sets up for us, not change individual unit tests to cope.

Use `--test_output` to control output, not `bazel run`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13079)
<!-- Reviewable:end -->
