### PR TITLE
trajectories: Preserve time derivatives when evaluating PiecewisePolynomial at end time

### DIFF
--- a/common/trajectories/BUILD.bazel
+++ b/common/trajectories/BUILD.bazel
@@ -122,6 +122,7 @@ drake_cc_googletest(
         ":random_piecewise_polynomial",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
+        "//math:gradient",
     ],
 )
 

--- a/common/trajectories/piecewise_polynomial.h
+++ b/common/trajectories/piecewise_polynomial.h
@@ -561,16 +561,12 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    *
    * @param t The time at which to evaluate the %PiecewisePolynomial.
    * @return The matrix of evaluated values.
+   * @pre If T == symbolic::Expression, `t.is_constant()` must be true.
    *
    * @warning If t does not lie in the range that the polynomial is defined
    *          over, the polynomial will silently be evaluated at the closest
    *          point to t. For example, `value(-1)` will return `value(0)` for a
    *          polynomial defined over [0, 1].
-   * @warning This method only evaluates the polynomial in the segment defined
-   *          by @p t.  If T=symbolic::Expression, then this method will return
-   *          only the symbolic::Expression for the current segment if @p t can
-   *          be cast to double or throw std::runtime_error if @p t cannot be
-   *          cast to double.
    * @warning See warning in @ref polynomial_construction_warning.
    */
   MatrixX<T> value(const T& t) const override {

--- a/common/trajectories/test/piecewise_polynomial_test.cc
+++ b/common/trajectories/test/piecewise_polynomial_test.cc
@@ -468,9 +468,8 @@ GTEST_TEST(PiecewiseTrajectoryTest, SymbolicValues) {
       PiecewisePolynomial<Expression>::FirstOrderHold(symbolic_breaks, samples),
       std::runtime_error);
 
-  // Symbolic samples (and therefore coefficient) returns the symbolic form only
-  // inside the current segment.  This admittedly bad behavior is documented as
-  // a warning in the PiecewisePolynomial::value() documentation.
+  // For symbolic samples (and therefore coefficients), value() returns the
+  // symbolic form at the specified time.
   const Variable x0("x0");
   const Variable x1("x1");
   const Variable x2("x2");


### PR DESCRIPTION
Prior to this PR, evaluating a `PiecewisePolynomial<AutoDiffXd>` at `t == end_time()` would return a `MatrixX<AutoDiffXd>` with empty derivatives, due to the way that Eigen's implementation of `min` for `AutoDiffXd` handles the case where the arguments are equivalent. After this PR, the `MatrixX<AutoDiffXd>` will contain the derivatives for the final segment evaluated at `end_time()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13080)
<!-- Reviewable:end -->
