### PR TITLE
Add a dependency ticket for all sources excluding input ports

### DIFF
--- a/systems/framework/framework_common.h
+++ b/systems/framework/framework_common.h
@@ -270,19 +270,20 @@ enum BuiltInTicketNumbers {
   kPnTicket             = 10,  // All numeric parameters.
   kPaTicket             = 11,  // All abstract parameters.
   kAllParametersTicket  = 12,  // All parameters p = {pn, pa}.
-  kAllInputPortsTicket  = 13,  // All input ports u.
-  kAllSourcesTicket     = 14,  // All of the above.
-  kConfigurationTicket  = 15,  // All values that may affect configuration.
-  kKinematicsTicket     = 16,  // Configuration plus velocity-affecting values.
+  kAllSourcesExceptInputPortsTicket = 13,  // Everything except input ports.
+  kAllInputPortsTicket  = 14,  // All input ports u.
+  kAllSourcesTicket     = 15,  // All of the above.
+  kConfigurationTicket  = 16,  // All values that may affect configuration.
+  kKinematicsTicket     = 17,  // Configuration plus velocity-affecting values.
   kLastSourceTicket     = kKinematicsTicket,  // (Used in testing.)
 
   // The rest of these are pre-defined computations with associated cache
   // entries.
-  kXcdotTicket          = 17,  // d/dt xc = {qdot, vdot, zdot}.
-  kPeTicket             = 18,  // Potential energy.
-  kKeTicket             = 19,  // Kinetic energy.
-  kPcTicket             = 20,  // Conservative power.
-  kPncTicket            = 21,  // Non-conservative power.
+  kXcdotTicket          = 18,  // d/dt xc = {qdot, vdot, zdot}.
+  kPeTicket             = 19,  // Potential energy.
+  kKeTicket             = 20,  // Kinetic energy.
+  kPcTicket             = 21,  // Conservative power.
+  kPncTicket            = 22,  // Non-conservative power.
 
   kNextAvailableTicket  = kPncTicket+1
 };

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -660,9 +660,31 @@ class SystemBase : public internal::SystemMessageInterface {
   }
 
   /** Returns a ticket indicating dependence on every possible independent
+  source value _except_ input ports. This can be helpful in avoiding the
+  incorrect appearance of algebraic loops in a Diagram (those always involve
+  apparent input port dependencies). For an output port, use this ticket plus
+  tickets for just the input ports on which the output computation _actually_
+  depends. The sources included in this ticket are: time, accuracy, state,
+  and parameters. Note that dependencies on cache entries are _not_ included
+  here. Usually that won't matter since cache entries typically depend on at
+  least one of time, accuracy, state, or parameters so will be invalidated for
+  the same reason the current computation is. However, for a computation that
+  depends on a cache entry that depends only on input ports, be sure that
+  you have included those input ports in the dependency list, or include a
+  direct dependency on the cache entry.
+
+  @see input_port_ticket() to obtain a ticket for an input port.
+  @see cache_entry_ticket() to obtain a ticket for a cache entry.
+  @see all_sources_ticket() to also include all input ports as dependencies. */
+  static DependencyTicket all_sources_except_input_ports_ticket() {
+    return DependencyTicket(internal::kAllSourcesExceptInputPortsTicket);
+  }
+
+  /** Returns a ticket indicating dependence on every possible independent
   source value, including time, accuracy, state, input ports, and parameters
   (but not cache entries). This is the default dependency for computations that
-  have not specified anything more refined.
+  have not specified anything more refined. It is equivalent to the set
+  `{all_sources_except_input_ports_ticket(), all_input_ports_ticket()}`.
   @see cache_entry_ticket() to obtain a ticket for a cache entry. */
   static DependencyTicket all_sources_ticket() {
     return DependencyTicket(internal::kAllSourcesTicket);

--- a/systems/framework/test/leaf_context_test.cc
+++ b/systems/framework/test/leaf_context_test.cc
@@ -722,6 +722,7 @@ TEST_F(LeafContextTest, Invalidation) {
   context_.SetTime(context_.get_time() + 1);  // Ensure this is a change.
   CheckAllCacheValuesUpToDateExcept(cache,
       {depends[internal::kTimeTicket],
+       depends[internal::kAllSourcesExceptInputPortsTicket],
        depends[internal::kAllSourcesTicket]});
 
   // Accuracy.
@@ -731,6 +732,7 @@ TEST_F(LeafContextTest, Invalidation) {
       {depends[internal::kAccuracyTicket],
        depends[internal::kConfigurationTicket],
        depends[internal::kKinematicsTicket],
+       depends[internal::kAllSourcesExceptInputPortsTicket],
        depends[internal::kAllSourcesTicket]});
 
   // This is everything that depends on generalized positions q.
@@ -738,6 +740,7 @@ TEST_F(LeafContextTest, Invalidation) {
       depends[internal::kQTicket], depends[internal::kXcTicket],
       depends[internal::kXTicket], depends[internal::kConfigurationTicket],
       depends[internal::kKinematicsTicket],
+      depends[internal::kAllSourcesExceptInputPortsTicket],
       depends[internal::kAllSourcesTicket]};
 
   // This is everything that depends on generalized velocities v and misc. z.
@@ -746,6 +749,7 @@ TEST_F(LeafContextTest, Invalidation) {
       depends[internal::kXcTicket], depends[internal::kXTicket],
       depends[internal::kConfigurationTicket],
       depends[internal::kKinematicsTicket],
+      depends[internal::kAllSourcesExceptInputPortsTicket],
       depends[internal::kAllSourcesTicket]};
 
   // This is everything that depends on continuous state.
@@ -824,6 +828,7 @@ TEST_F(LeafContextTest, Invalidation) {
        depends[internal::kXTicket],
        depends[internal::kConfigurationTicket],
        depends[internal::kKinematicsTicket],
+       depends[internal::kAllSourcesExceptInputPortsTicket],
        depends[internal::kAllSourcesTicket]};
   MarkAllCacheValuesUpToDate(&cache);
   context_.get_mutable_discrete_state();
@@ -852,6 +857,7 @@ TEST_F(LeafContextTest, Invalidation) {
        depends[internal::kXTicket],
        depends[internal::kConfigurationTicket],
        depends[internal::kKinematicsTicket],
+       depends[internal::kAllSourcesExceptInputPortsTicket],
        depends[internal::kAllSourcesTicket]};
   MarkAllCacheValuesUpToDate(&cache);
   context_.get_mutable_abstract_state();
@@ -871,6 +877,7 @@ TEST_F(LeafContextTest, Invalidation) {
        depends[internal::kConfigurationTicket],
        depends[internal::kKinematicsTicket],
        depends[internal::kAllParametersTicket],
+       depends[internal::kAllSourcesExceptInputPortsTicket],
        depends[internal::kAllSourcesTicket]};
 
   const std::set<CacheIndex> pa_dependent
@@ -878,6 +885,7 @@ TEST_F(LeafContextTest, Invalidation) {
        depends[internal::kConfigurationTicket],
        depends[internal::kKinematicsTicket],
        depends[internal::kAllParametersTicket],
+       depends[internal::kAllSourcesExceptInputPortsTicket],
        depends[internal::kAllSourcesTicket]};
 
   std::set<CacheIndex> p_dependent(pn_dependent);


### PR DESCRIPTION
The default prerequisite set for an output port is `{all_sources_ticket()}`, which is the most conservative choice. In a System with multiple input ports, this can lead to an apparent algebraic loop in the containing Diagram since it will appear that every output port depends on every input port. This occurred recently in practice and fixing it was awkward since it required the author to unpack the contents of "all sources" to leave off just the input ports. That creates a maintenance problem since the meaning of "all sources" will likely change over time. 

This PR provides a new ticket `all_sources_except_input_ports()` and redefines `all_sources_ticket()` to be `{all_sources_except_input_ports(), all_input_ports()}`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13088)
<!-- Reviewable:end -->
