### PR TITLE
parsing: Avoid to use implicit conversion from std::filesystem::path to std::string

### DIFF
--- a/multibody/parsing/package_map.cc
+++ b/multibody/parsing/package_map.cc
@@ -167,7 +167,7 @@ void PackageMap::PopulateUpstreamToDrake(const string& model_file) {
         "The file type '{}' is not supported for '{}'",
         extension, model_file));
   }
-  const string model_dir = filesystem::path(model_file).parent_path();
+  const string model_dir = filesystem::path(model_file).parent_path().string();
 
   // Bail out if we can't determine the drake root.
   const std::optional<string> maybe_drake_path = MaybeGetDrakePath();

--- a/multibody/parsing/test/package_map_test.cc
+++ b/multibody/parsing/test/package_map_test.cc
@@ -59,7 +59,8 @@ GTEST_TEST(PackageMapTest, TestPopulateFromXml) {
   const string xml_filename = FindResourceOrThrow(
       "drake/multibody/parsing/test/"
       "package_map_test_packages/package_map_test_package_a/package.xml");
-  const string xml_dirname = filesystem::path(xml_filename).parent_path();
+  const string xml_dirname =
+      filesystem::path(xml_filename).parent_path().string();
   PackageMap package_map;
   package_map.AddPackageXml(xml_filename);
 


### PR DESCRIPTION
This change is done for uniformity with the rest of drake codebase, that already uses the explicit conversion: 
* https://github.com/RobotLocomotion/drake/blob/v0.16.1/multibody/parsing/package_map.cc#L86
* https://github.com/RobotLocomotion/drake/blob/v0.16.1/common/drake_path.cc#L22
* https://github.com/RobotLocomotion/drake/blob/325b90cb5788164d1fd71a0f9f515d95221827f2/multibody/parsing/test/detail_path_utils_test.cc#L66

Furthermore according to the C++ standard, the implicit conversion from std::filesystem::path to std::string is only supported on POSIX-based systems, see https://stackoverflow.com/questions/57377349/implicit-conversion-between-stdfilesystempath-and-stdstring-should-it-hap ,  so this fixes the  compilation of these files on  non-POSIX configuration, see discussion in https://github.com/RobotLocomotion/drake/pull/13046#issuecomment-612930981 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13089)
<!-- Reviewable:end -->
