### PR TITLE
doc: Use python@3.8/bin not python@3/bin

### DIFF
--- a/doc/python_bindings.rst
+++ b/doc/python_bindings.rst
@@ -18,7 +18,7 @@ installed as a single package called ``pydrake``.
 
 .. warning::
    On macOS, Drake only supports Python 3.8, which is located at
-   ``/usr/local/opt/python@3/bin/python3`` and is not usually on the
+   ``/usr/local/opt/python@3.8/bin/python3`` and is not usually on the
    ``PATH``.
 
 .. _python-bindings-binary:


### PR DESCRIPTION
Everywhere else in Drake says 3.8/bin which apparently always exists, whereas 3/bin reportedly only sometimes exists.

Amends #13031 per https://github.com/RobotLocomotion/drake/pull/13031#pullrequestreview-396064297.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13093)
<!-- Reviewable:end -->
