### PR TITLE
Made typo fixes in documentation

### DIFF
--- a/bindings/pydrake/systems/meshcat_visualizer.py
+++ b/bindings/pydrake/systems/meshcat_visualizer.py
@@ -581,7 +581,7 @@ class MeshcatPointCloudVisualizer(LeafSystem):
     MeshcatPointCloudVisualizer is a System block that visualizes a
     PointCloud in meshcat. The PointCloud:
 
-    * Must have XYZ values. Assumed to be in point cloud frmae, ``P``.
+    * Must have XYZ values. Assumed to be in point cloud frame, ``P``.
     * RGB values are optional; if provided, they must be on the range [0..255].
 
     An example using a pydrake MeshcatVisualizer::

--- a/geometry/proximity/test/volume_mesh_test.cc
+++ b/geometry/proximity/test/volume_mesh_test.cc
@@ -239,7 +239,7 @@ GTEST_TEST(VolumeMeshTest, TestCalcBarycentricAutoDiffXd) {
 template<typename T>
 void TestCalcGradBarycentric() {
   // The mesh M consists of one tetrahedral element whose vertices are at the
-  // origin and on the coordinate axes of M's frmae. The chosen vertex
+  // origin and on the coordinate axes of M's frame. The chosen vertex
   // coordinates avoid symmetry but are easy to calculate ∇bᵢ manually.
   //
   //                                 Z

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1322,7 +1322,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// When set_penetration_allowance() is called, %MultibodyPlant will estimate
   /// reasonable penalty method coefficients as a function of the input
   /// penetration allowance. Users will want to run their simulation a number of
-  /// times and asses they are satisfied with the level of inter-penetration
+  /// times and assess they are satisfied with the level of inter-penetration
   /// actually observed in the simulation; if the observed penetration is too
   /// large, the user will want to set a smaller penetration allowance. If the
   /// system is too stiff and the time integration requires very small time


### PR DESCRIPTION
Some things I came across while reading documentation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13095)
<!-- Reviewable:end -->
