### PR TITLE
trajectories:  PiecewisePolynomial constant trajectory is ∀t ∈ [-∞, ∞]

### DIFF
--- a/common/trajectories/exponential_plus_piecewise_polynomial.cc
+++ b/common/trajectories/exponential_plus_piecewise_polynomial.cc
@@ -18,6 +18,8 @@ ExponentialPlusPiecewisePolynomial<T>::
       alpha_(MatrixX<T>::Zero(
           1, piecewise_polynomial_part.get_number_of_segments())),
       piecewise_polynomial_part_(piecewise_polynomial_part) {
+  using std::isfinite;
+  DRAKE_DEMAND(isfinite(piecewise_polynomial_part.start_time()));
   DRAKE_ASSERT(piecewise_polynomial_part.cols() == 1);
 }
 

--- a/common/trajectories/piecewise_polynomial.h
+++ b/common/trajectories/piecewise_polynomial.h
@@ -88,14 +88,15 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
   typedef MatrixX<Polynomial<T>> PolynomialMatrix;
 
   /**
-   * Single segment, constant value constructor over the interval [0, ∞].
+   * Single segment, constant value constructor over the interval [-∞, ∞].
    * The constructed %PiecewisePolynomial will return `constant_value` at
-   * every evaluated point (i.e., `value(t) = constant_value` ∀t ∈ [0, ∞]).
+   * every evaluated point (i.e., `value(t) = constant_value` ∀t ∈ [-∞, ∞]).
    */
   template <typename Derived>
   explicit PiecewisePolynomial(const Eigen::MatrixBase<Derived>& constant_value)
-      : PiecewiseTrajectory<T>(std::vector<T>(
-            {0.0, std::numeric_limits<double>::infinity()})) {
+      : PiecewiseTrajectory<T>(
+            std::vector<T>({-std::numeric_limits<double>::infinity(),
+                            std::numeric_limits<double>::infinity()})) {
     polynomials_.push_back(constant_value.template cast<Polynomial<T>>());
   }
 

--- a/common/trajectories/test/piecewise_polynomial_test.cc
+++ b/common/trajectories/test/piecewise_polynomial_test.cc
@@ -281,20 +281,22 @@ GTEST_TEST(testPiecewisePolynomial, AllTests) {
 }
 
 GTEST_TEST(testPiecewisePolynomial, VectorValueTest) {
-  const std::vector<double> times = {0, .5, 1, 1.5};
+  // Note: Keep one negative time to confirm that negative values can work for
+  // constant trajectories.
+  const std::vector<double> times = {-1.5, 0, .5, 1, 1.5};
   const Eigen::Vector3d value(1, 2, 3);
 
   const PiecewisePolynomial<double> col(value);
   Eigen::MatrixXd out = col.vector_values(times);
   EXPECT_EQ(out.rows(), 3);
-  EXPECT_EQ(out.cols(), 4);
+  EXPECT_EQ(out.cols(), 5);
   for (int i = 0; i < 4; i++) {
     EXPECT_TRUE(CompareMatrices(out.col(i), value, 0));
   }
 
   PiecewisePolynomial<double> row(value.transpose());
   out = row.vector_values(times);
-  EXPECT_EQ(out.rows(), 4);
+  EXPECT_EQ(out.rows(), 5);
   EXPECT_EQ(out.cols(), 3);
   for (int i = 0; i < 4; i++) {
     EXPECT_TRUE(CompareMatrices(out.row(i), value.transpose(), 0));

--- a/systems/framework/test/diagram_builder_test.cc
+++ b/systems/framework/test/diagram_builder_test.cc
@@ -340,7 +340,8 @@ GTEST_TEST(DiagramBuilderTest, ConnectAbstractSubtypes) {
   {
     auto context = diagram->CreateDefaultContext();
     const ExponentialPlusPiecewisePolynomiald input(
-        PiecewisePolynomiald(Vector1d(22.0)));
+        PiecewisePolynomiald::ZeroOrderHold(Eigen::Vector2d(0., 1.),
+                                            Eigen::RowVector2d(22.0, 22.0)));
     diagram->get_input_port(0).FixValue(
         context.get(), Value<Trajectoryd>(input));
     const auto& output =


### PR DESCRIPTION
There should not be anything special about zero here.
The Riccati solver in the finite-horizon LQR sometimes starts at negative time, and should be able to use these constant trajectories.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13096)
<!-- Reviewable:end -->
