### PR TITLE
Fix the broken link to py_reference in pydrake_doxygen.h

### DIFF
--- a/bindings/pydrake/pydrake_doxygen.h
+++ b/bindings/pydrake/pydrake_doxygen.h
@@ -328,7 +328,7 @@ Some aliases are provided; prefer these to the full spellings.
 
 `namespace py` is a shorthand alias to `pybind11` for consistency.
 
-@see py_reference, py_reference_internal for dealing with %common ownership
+@see @ref drake::pydrake::py_reference "py_reference", @ref drake::pydrake::py_reference_internal "py_reference_internal" for dealing with %common ownership
      issues.
 
 @note Downstream users should avoid `using namespace drake::pydrake`, as


### PR DESCRIPTION
As mentioned in the slack thread https://drakedevelopers.slack.com/archives/C3YB3EV5W/p1587349559014100?thread_ts=1587344554.013800&cid=C3YB3EV5W

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13101)
<!-- Reviewable:end -->
