### PR TITLE
primitives: Fix missing include in multiplexer.cc and demultiplexer.cc

### DIFF
--- a/systems/primitives/demultiplexer.cc
+++ b/systems/primitives/demultiplexer.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/primitives/demultiplexer.h"
 
+#include <numeric>
+
 #include "drake/common/autodiff.h"
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"

--- a/systems/primitives/multiplexer.cc
+++ b/systems/primitives/multiplexer.cc
@@ -2,6 +2,7 @@
 
 #include <functional>
 #include <memory>
+#include <numeric>
 #include <utility>
 
 #include "drake/common/default_scalars.h"


### PR DESCRIPTION
As these files use `std::accumulate` it is necessary to include `<numeric>` . 

Problem detected compiling the files on [`clang-cl`](https://clang.llvm.org/docs/UsersManual.html#clang-cl) with [MSVC's `STL`](https://github.com/microsoft/STL).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13104)
<!-- Reviewable:end -->
