### PR TITLE
Make joint store default value

### DIFF
--- a/multibody/tree/ball_rpy_joint.cc
+++ b/multibody/tree/ball_rpy_joint.cc
@@ -56,9 +56,10 @@ template <typename T>
 std::unique_ptr<typename Joint<T>::BluePrint>
 BallRpyJoint<T>::MakeImplementationBlueprint() const {
   auto blue_print = std::make_unique<typename Joint<T>::BluePrint>();
-  blue_print->mobilizers_.push_back(
-      std::make_unique<internal::SpaceXYZMobilizer<T>>(this->frame_on_parent(),
-                                                       this->frame_on_child()));
+  auto ballrpy_mobilizer = std::make_unique<internal::SpaceXYZMobilizer<T>>(
+      this->frame_on_parent(), this->frame_on_child());
+  ballrpy_mobilizer->set_default_position(this->default_positions());
+  blue_print->mobilizers_.push_back(std::move(ballrpy_mobilizer));
   return std::move(blue_print);
 }
 

--- a/multibody/tree/ball_rpy_joint.h
+++ b/multibody/tree/ball_rpy_joint.h
@@ -132,12 +132,6 @@ class BallRpyJoint final : public Joint<T> {
     return *this;
   }
 
-  /// Sets the default angles of this joint.  See get_angles() for details on
-  /// the angle representation.
-  void set_default_angles(const Vector3<double>& angles) {
-    get_mutable_mobilizer()->set_default_position(angles);
-  }
-
   /// Sets the random distribution that angles of this joint will be randomly
   /// sampled from. See get_angles() for details on the angle representation.
   void set_random_angles_distribution(
@@ -175,6 +169,25 @@ class BallRpyJoint final : public Joint<T> {
   }
 
   /// @}
+
+  /// Gets the default angles for `this` joint. Wrapper for the more general
+  /// `Joint::default_positions()`.
+  /// @returns The default angles of `this` stored in `default_positions_`
+  Vector3<double> get_default_angles() const {
+    return this->default_positions();
+  }
+
+  /// Sets the default angles of this joint.
+  /// If the parent tree has been finalized and the underlying mobilizer is
+  /// valid, this method sets the default positions of that mobilizer.
+  /// @param[in] angles
+  ///   The desired default angles of the joint
+  void set_default_angles(const Vector3<double>& angles) {
+    this->set_default_positions(angles);
+    if (this->has_implementation()) {
+      get_mutable_mobilizer()->set_default_position(this->default_positions());
+    }
+  }
 
  protected:
   /// Joint<T> override called through public NVI, Joint::AddInForce().

--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -361,16 +361,8 @@ class Joint : public MultibodyElement<Joint, T, JointIndex> {
   /// Sets the default positions to @p default_positions.
   /// @throws std::exception if the dimension of @p default_positions does not
   /// match num_positions().
-  /// @throws std::exception if any of @p default_positions is smaller than
-  /// the corresponding term in `position_lower_limits()`.
-  /// @throws std::exception if any of @p default_positions is larger than
-  /// the corresponding term in `position_upper_limits()`.
   void set_default_positions(const VectorX<double>& default_positions) {
     DRAKE_THROW_UNLESS(default_positions.size() == num_positions());
-    DRAKE_THROW_UNLESS(
-        (position_lower_limits().array() <= default_positions.array()).all());
-    DRAKE_THROW_UNLESS(
-        (default_positions.array() <= position_upper_limits().array()).all());
     default_positions_ = default_positions;
   }
   /// @}

--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -321,6 +321,9 @@ class Joint : public MultibodyElement<Joint, T, JointIndex> {
   /// @p upper_limits does not match num_positions().
   /// @throws std::exception if any of @p lower_limits is larger than the
   /// corresponding term in @p upper_limits.
+  /// @note Setting the position limits does not affect the
+  /// `default_positions()`, regardless of whether the current
+  /// `default_positions()` satisfy the new position limits.
   void set_position_limits(const VectorX<double>& lower_limits,
                            const VectorX<double>& upper_limits) {
     DRAKE_THROW_UNLESS(lower_limits.size() == upper_limits.size());
@@ -361,6 +364,8 @@ class Joint : public MultibodyElement<Joint, T, JointIndex> {
   /// Sets the default positions to @p default_positions.
   /// @throws std::exception if the dimension of @p default_positions does not
   /// match num_positions().
+  /// @note The values in @p default_positions are NOT constrained to be within
+  /// `position_lower_limits()` and `position_upper_limits()`.
   void set_default_positions(const VectorX<double>& default_positions) {
     DRAKE_THROW_UNLESS(default_positions.size() == num_positions());
     default_positions_ = default_positions;

--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -117,7 +117,8 @@ class Joint : public MultibodyElement<Joint, T, JointIndex> {
         const VectorX<double>& vel_upper_limits,
         const VectorX<double>& acc_lower_limits,
         const VectorX<double>& acc_upper_limits)
-      : MultibodyElement<Joint, T, JointIndex>(frame_on_child.model_instance()),
+      : MultibodyElement<Joint, T, JointIndex>(
+        frame_on_child.model_instance()),
         name_(name),
         frame_on_parent_(frame_on_parent),
         frame_on_child_(frame_on_child),
@@ -139,8 +140,11 @@ class Joint : public MultibodyElement<Joint, T, JointIndex> {
     DRAKE_DEMAND(acc_lower_limits.size() == acc_upper_limits.size());
     DRAKE_DEMAND((acc_lower_limits.array() <= acc_upper_limits.array()).all());
 
-    // initialize the default positions to 0.
-    default_positions_ = VectorX<double>::Zero(pos_lower_limits.size());
+    // N.B. We cannot use `num_positions()` here because it is virtual.
+    const int num_positions = pos_lower_limits.size();
+
+    // intialize the default positions.
+    default_positions_ = VectorX<double>::Zero(num_positions);
   }
 
   virtual ~Joint() {}
@@ -149,16 +153,24 @@ class Joint : public MultibodyElement<Joint, T, JointIndex> {
   const std::string& name() const { return name_; }
 
   /// Returns a const reference to the parent body P.
-  const Body<T>& parent_body() const { return frame_on_parent_.body(); }
+  const Body<T>& parent_body() const {
+    return frame_on_parent_.body();
+  }
 
   /// Returns a const reference to the child body B.
-  const Body<T>& child_body() const { return frame_on_child_.body(); }
+  const Body<T>& child_body() const {
+    return frame_on_child_.body();
+  }
 
   /// Returns a const reference to the frame F attached on the parent body P.
-  const Frame<T>& frame_on_parent() const { return frame_on_parent_; }
+  const Frame<T>& frame_on_parent() const {
+    return frame_on_parent_;
+  }
 
   /// Returns a const reference to the frame M attached on the child body B.
-  const Frame<T>& frame_on_child() const { return frame_on_child_; }
+  const Frame<T>& frame_on_child() const {
+    return frame_on_child_;
+  }
 
   /// Returns a string identifying the type of `this` joint, such as "revolute"
   /// or "prismatic".
@@ -167,7 +179,9 @@ class Joint : public MultibodyElement<Joint, T, JointIndex> {
   /// Returns the index to the first generalized velocity for this joint
   /// within the vector v of generalized velocities for the full multibody
   /// system.
-  int velocity_start() const { return do_get_velocity_start(); }
+  int velocity_start() const {
+    return do_get_velocity_start();
+  }
 
   /// Returns the number of generalized velocities describing this joint.
   int num_velocities() const {
@@ -178,7 +192,9 @@ class Joint : public MultibodyElement<Joint, T, JointIndex> {
   /// Returns the index to the first generalized position for this joint
   /// within the vector q of generalized positions for the full multibody
   /// system.
-  int position_start() const { return do_get_position_start(); }
+  int position_start() const {
+    return do_get_position_start();
+  }
 
   /// Returns the number of generalized positions describing this joint.
   int num_positions() const {
@@ -230,8 +246,11 @@ class Joint : public MultibodyElement<Joint, T, JointIndex> {
   ///   `forces` is `nullptr` or if `forces` doest not have the right sizes to
   ///   accommodate a set of forces for the model to which this joint belongs.
   // NVI to DoAddInOneForce().
-  void AddInOneForce(const systems::Context<T>& context, int joint_dof,
-                     const T& joint_tau, MultibodyForces<T>* forces) const {
+  void AddInOneForce(
+      const systems::Context<T>& context,
+      int joint_dof,
+      const T& joint_tau,
+      MultibodyForces<T>* forces) const {
     DRAKE_DEMAND(forces != nullptr);
     DRAKE_DEMAND(0 <= joint_dof && joint_dof < num_velocities());
     DRAKE_DEMAND(forces->CheckHasRightSizeForModel(this->get_parent_tree()));
@@ -249,8 +268,8 @@ class Joint : public MultibodyElement<Joint, T, JointIndex> {
   ///   not have the right sizes to accommodate a set of forces for the model
   ///   to which this joint belongs.
   // NVI to DoAddInOneForce().
-  void AddInDamping(const systems::Context<T>& context,
-                    MultibodyForces<T>* forces) const {
+  void AddInDamping(
+      const systems::Context<T>& context, MultibodyForces<T>* forces) const {
     DRAKE_DEMAND(forces != nullptr);
     DRAKE_DEMAND(forces->CheckHasRightSizeForModel(this->get_parent_tree()));
     DoAddInDamping(context, forces);
@@ -368,8 +387,7 @@ class Joint : public MultibodyElement<Joint, T, JointIndex> {
 
     std::unique_ptr<typename Joint<ToScalar>::JointImplementation>
         implementation_clone =
-            this->get_implementation().template CloneToScalar<ToScalar>(
-                tree_clone);
+        this->get_implementation().template CloneToScalar<ToScalar>(tree_clone);
     joint_clone->OwnImplementation(std::move(implementation_clone));
 
     return std::move(joint_clone);
@@ -409,7 +427,9 @@ class Joint : public MultibodyElement<Joint, T, JointIndex> {
     }
 
     /// Returns the number of mobilizers in this implementation.
-    int num_mobilizers() const { return static_cast<int>(mobilizers_.size()); }
+    int num_mobilizers() const {
+      return static_cast<int>(mobilizers_.size());
+    }
 
     // Hide the following section from Doxygen.
 #ifndef DRAKE_DOXYGEN_CXX
@@ -486,9 +506,11 @@ class Joint : public MultibodyElement<Joint, T, JointIndex> {
   /// This method is only called by the public NVI AddInOneForce() and therefore
   /// input arguments were checked to be valid.
   /// @see The public NVI AddInOneForce() for details.
-  virtual void DoAddInOneForce(const systems::Context<T>& context,
-                               int joint_dof, const T& joint_tau,
-                               MultibodyForces<T>* forces) const = 0;
+  virtual void DoAddInOneForce(
+      const systems::Context<T>& context,
+      int joint_dof,
+      const T& joint_tau,
+      MultibodyForces<T>* forces) const = 0;
 
   /// Adds into MultibodyForces the forces due to damping within `this` joint.
   /// How forces are added to a MultibodyTree model depends on the underlying
@@ -496,8 +518,8 @@ class Joint : public MultibodyElement<Joint, T, JointIndex> {
   /// constraint) and therefore specific %Joint subclasses must provide a
   /// definition for this method.
   /// The default implementation is a no-op for joints with no damping.
-  virtual void DoAddInDamping(const systems::Context<T>&,
-                              MultibodyForces<T>*) const {}
+  virtual void DoAddInDamping(
+      const systems::Context<T>&, MultibodyForces<T>*) const {}
 
   // Implements MultibodyElement::DoSetTopology(). Joints have no topology
   // though we could require them to have one in the future.

--- a/multibody/tree/prismatic_joint.cc
+++ b/multibody/tree/prismatic_joint.cc
@@ -9,8 +9,7 @@ namespace multibody {
 
 template <typename T>
 template <typename ToScalar>
-std::unique_ptr<Joint<ToScalar>>
-PrismaticJoint<T>::TemplatedDoCloneToScalar(
+std::unique_ptr<Joint<ToScalar>> PrismaticJoint<T>::TemplatedDoCloneToScalar(
     const internal::MultibodyTree<ToScalar>& tree_clone) const {
   const Frame<ToScalar>& frame_on_parent_body_clone =
       tree_clone.get_variant(this->frame_on_parent());

--- a/multibody/tree/prismatic_joint.cc
+++ b/multibody/tree/prismatic_joint.cc
@@ -9,7 +9,8 @@ namespace multibody {
 
 template <typename T>
 template <typename ToScalar>
-std::unique_ptr<Joint<ToScalar>> PrismaticJoint<T>::TemplatedDoCloneToScalar(
+std::unique_ptr<Joint<ToScalar>>
+PrismaticJoint<T>::TemplatedDoCloneToScalar(
     const internal::MultibodyTree<ToScalar>& tree_clone) const {
   const Frame<ToScalar>& frame_on_parent_body_clone =
       tree_clone.get_variant(this->frame_on_parent());

--- a/multibody/tree/prismatic_joint.h
+++ b/multibody/tree/prismatic_joint.h
@@ -97,7 +97,9 @@ class PrismaticJoint final : public Joint<T> {
   /// Since the measures of this axis in either frame F or M are the same (see
   /// this class's documentation for frames's definitions) then,
   /// `axis = axis_F = axis_M`.
-  const Vector3<double>& translation_axis() const { return axis_; }
+  const Vector3<double>& translation_axis() const {
+    return axis_;
+  }
 
   /// Returns `this` joint's damping constant in N⋅s/m.
   double damping() const { return damping_; }
@@ -152,8 +154,8 @@ class PrismaticJoint final : public Joint<T> {
   /// @param[in] translation
   ///   The desired translation in meters to be stored in `context`.
   /// @returns a constant reference to `this` joint.
-  const PrismaticJoint<T>& set_translation(Context<T>* context,
-                                           const T& translation) const {
+  const PrismaticJoint<T>& set_translation(
+      Context<T>* context, const T& translation) const {
     get_mobilizer()->set_translation(context, translation);
     return *this;
   }
@@ -216,8 +218,10 @@ class PrismaticJoint final : public Joint<T> {
   /// positive in the direction along this joint's axis.
   /// That is, a positive force causes a positive translational acceleration
   /// along the joint's axis.
-  void AddInForce(const systems::Context<T>& context, const T& force,
-                  MultibodyForces<T>* multibody_forces) const {
+  void AddInForce(
+      const systems::Context<T>& context,
+      const T& force,
+      MultibodyForces<T>* multibody_forces) const {
     DRAKE_DEMAND(multibody_forces != nullptr);
     DRAKE_DEMAND(
         multibody_forces->CheckHasRightSizeForModel(this->get_parent_tree()));
@@ -233,9 +237,11 @@ class PrismaticJoint final : public Joint<T> {
   /// child (according to the prismatic joint's constructor) at the origin of
   /// the child frame (which is coincident with the origin of the parent frame
   /// at all times).
-  void DoAddInOneForce(const systems::Context<T>&, int joint_dof,
-                       const T& joint_tau,
-                       MultibodyForces<T>* forces) const final {
+  void DoAddInOneForce(
+      const systems::Context<T>&,
+      int joint_dof,
+      const T& joint_tau,
+      MultibodyForces<T>* forces) const final {
     // Right now we assume all the forces in joint_tau go into a single
     // mobilizer.
     Eigen::VectorBlock<Eigen::Ref<VectorX<T>>> tau_mob =
@@ -259,13 +265,17 @@ class PrismaticJoint final : public Joint<T> {
     return get_mobilizer()->velocity_start_in_v();
   }
 
-  int do_get_num_velocities() const override { return 1; }
+  int do_get_num_velocities() const override {
+    return 1;
+  }
 
   int do_get_position_start() const override {
     return get_mobilizer()->position_start_in_q();
   }
 
-  int do_get_num_positions() const override { return 1; }
+  int do_get_num_positions() const override {
+    return 1;
+  }
 
   const T& DoGetOnePosition(const systems::Context<T>& context) const override {
     return get_translation(context);
@@ -276,8 +286,8 @@ class PrismaticJoint final : public Joint<T> {
   }
 
   // Joint<T> finals:
-  std::unique_ptr<typename Joint<T>::BluePrint> MakeImplementationBlueprint()
-      const final {
+  std::unique_ptr<typename Joint<T>::BluePrint>
+  MakeImplementationBlueprint() const final {
     auto blue_print = std::make_unique<typename Joint<T>::BluePrint>();
     auto prismatic_mobilizer =
         std::make_unique<internal::PrismaticMobilizer<T>>(
@@ -299,8 +309,7 @@ class PrismaticJoint final : public Joint<T> {
   // Make PrismaticJoint templated on every other scalar type a friend of
   // PrismaticJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access
   // private members of PrismaticJoint<T>.
-  template <typename>
-  friend class PrismaticJoint;
+  template <typename> friend class PrismaticJoint;
 
   // Friend class to facilitate testing.
   friend class JointTester;
@@ -340,8 +349,7 @@ class PrismaticJoint final : public Joint<T> {
   double damping_{0};
 };
 
-template <typename T>
-const char PrismaticJoint<T>::kTypeName[] = "prismatic";
+template <typename T> const char PrismaticJoint<T>::kTypeName[] = "prismatic";
 
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/revolute_joint.cc
+++ b/multibody/tree/revolute_joint.cc
@@ -10,8 +10,7 @@ namespace multibody {
 
 template <typename T>
 template <typename ToScalar>
-std::unique_ptr<Joint<ToScalar>>
-RevoluteJoint<T>::TemplatedDoCloneToScalar(
+std::unique_ptr<Joint<ToScalar>> RevoluteJoint<T>::TemplatedDoCloneToScalar(
     const internal::MultibodyTree<ToScalar>& tree_clone) const {
   const Frame<ToScalar>& frame_on_parent_body_clone =
       tree_clone.get_variant(this->frame_on_parent());
@@ -56,9 +55,10 @@ template <typename T>
 std::unique_ptr<typename Joint<T>::BluePrint>
 RevoluteJoint<T>::MakeImplementationBlueprint() const {
   auto blue_print = std::make_unique<typename Joint<T>::BluePrint>();
-  blue_print->mobilizers_.push_back(
-      std::make_unique<internal::RevoluteMobilizer<T>>(
-          this->frame_on_parent(), this->frame_on_child(), axis_));
+  auto revolute_mobilizer = std::make_unique<internal::RevoluteMobilizer<T>>(
+      this->frame_on_parent(), this->frame_on_child(), axis_);
+  revolute_mobilizer->set_default_position(this->default_positions());
+  blue_print->mobilizers_.push_back(std::move(revolute_mobilizer));
   return std::move(blue_print);
 }
 

--- a/multibody/tree/revolute_joint.h
+++ b/multibody/tree/revolute_joint.h
@@ -61,12 +61,13 @@ class RevoluteJoint final : public Joint<T> {
   ///   opposing motion, with ω the angular rate for `this` joint (see
   ///   get_angular_rate()).
   /// @throws std::exception if damping is negative.
-  RevoluteJoint(const std::string& name, const Frame<T>& frame_on_parent,
-                const Frame<T>& frame_on_child, const Vector3<double>& axis,
-                double damping = 0)
-      : RevoluteJoint<T>(name, frame_on_parent, frame_on_child, axis,
-                         -std::numeric_limits<double>::infinity(),
-                         std::numeric_limits<double>::infinity(), damping) {}
+  RevoluteJoint(const std::string& name,
+                const Frame<T>& frame_on_parent, const Frame<T>& frame_on_child,
+                const Vector3<double>& axis,
+                double damping = 0) :
+      RevoluteJoint<T>(name, frame_on_parent, frame_on_child, axis,
+                       -std::numeric_limits<double>::infinity(),
+                       std::numeric_limits<double>::infinity(), damping) {}
 
   /// Constructor to create a revolute joint between two bodies so that
   /// frame F attached to the parent body P and frame M attached to the child
@@ -129,7 +130,9 @@ class RevoluteJoint final : public Joint<T> {
   /// Since the measures of this axis in either frame F or M are the same (see
   /// this class's documentation for frames's definitions) then,
   /// `axis = axis_F = axis_M`.
-  const Vector3<double>& revolute_axis() const { return axis_; }
+  const Vector3<double>& revolute_axis() const {
+    return axis_;
+  }
 
   /// Returns `this` joint's damping constant in N⋅m⋅s.
   double damping() const { return damping_; }
@@ -182,7 +185,8 @@ class RevoluteJoint final : public Joint<T> {
   /// @param[in] angle
   ///   The desired angle in radians to be stored in `context`.
   /// @returns a constant reference to `this` joint.
-  const RevoluteJoint<T>& set_angle(Context<T>* context, const T& angle) const {
+  const RevoluteJoint<T>& set_angle(
+      Context<T>* context, const T& angle) const {
     get_mobilizer()->set_angle(context, angle);
     return *this;
   }
@@ -211,8 +215,8 @@ class RevoluteJoint final : public Joint<T> {
   ///   The desired rate of change of `this` joints's angle in radians per
   ///   second.
   /// @returns a constant reference to `this` joint.
-  const RevoluteJoint<T>& set_angular_rate(Context<T>* context,
-                                           const T& angle) const {
+  const RevoluteJoint<T>& set_angular_rate(
+      Context<T>* context, const T& angle) const {
     get_mobilizer()->set_angular_rate(context, angle);
     return *this;
   }
@@ -243,8 +247,10 @@ class RevoluteJoint final : public Joint<T> {
   /// acceleration according to the right-hand-rule around the joint's axis.
   ///
   /// @note A torque is the moment of a set of forces whose resultant is zero.
-  void AddInTorque(const systems::Context<T>& context, const T& torque,
-                   MultibodyForces<T>* forces) const {
+  void AddInTorque(
+      const systems::Context<T>& context,
+      const T& torque,
+      MultibodyForces<T>* forces) const {
     DRAKE_DEMAND(forces != nullptr);
     DRAKE_DEMAND(forces->CheckHasRightSizeForModel(this->get_parent_tree()));
     this->AddInOneForce(context, 0, torque, forces);
@@ -263,9 +269,11 @@ class RevoluteJoint final : public Joint<T> {
   /// joint's axis. That is, a positive torque causes a positive rotational
   /// acceleration (of the child body frame) according to the right-hand-rule
   /// around the joint's axis.
-  void DoAddInOneForce(const systems::Context<T>&, int joint_dof,
-                       const T& joint_tau,
-                       MultibodyForces<T>* forces) const override {
+  void DoAddInOneForce(
+      const systems::Context<T>&,
+      int joint_dof,
+      const T& joint_tau,
+      MultibodyForces<T>* forces) const override {
     // Right now we assume all the forces in joint_tau go into a single
     // mobilizer.
     DRAKE_DEMAND(joint_dof == 0);
@@ -290,13 +298,17 @@ class RevoluteJoint final : public Joint<T> {
     return get_mobilizer()->velocity_start_in_v();
   }
 
-  int do_get_num_velocities() const override { return 1; }
+  int do_get_num_velocities() const override {
+    return 1;
+  }
 
   int do_get_position_start() const override {
     return get_mobilizer()->position_start_in_q();
   }
 
-  int do_get_num_positions() const override { return 1; }
+  int do_get_num_positions() const override {
+    return 1;
+  }
 
   const T& DoGetOnePosition(const systems::Context<T>& context) const override {
     return get_angle(context);
@@ -307,8 +319,8 @@ class RevoluteJoint final : public Joint<T> {
   }
 
   // Joint<T> overrides:
-  std::unique_ptr<typename Joint<T>::BluePrint> MakeImplementationBlueprint()
-      const override;
+  std::unique_ptr<typename Joint<T>::BluePrint>
+  MakeImplementationBlueprint() const override;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(
       const internal::MultibodyTree<double>& tree_clone) const override;
@@ -322,8 +334,7 @@ class RevoluteJoint final : public Joint<T> {
   // Make RevoluteJoint templated on every other scalar type a friend of
   // RevoluteJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access
   // private members of RevoluteJoint<T>.
-  template <typename>
-  friend class RevoluteJoint;
+  template <typename> friend class RevoluteJoint;
 
   // Friend class to facilitate testing.
   friend class JointTester;
@@ -362,8 +373,7 @@ class RevoluteJoint final : public Joint<T> {
   double damping_{0};
 };
 
-template <typename T>
-const char RevoluteJoint<T>::kTypeName[] = "revolute";
+template <typename T> const char RevoluteJoint<T>::kTypeName[] = "revolute";
 
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/revolute_joint.h
+++ b/multibody/tree/revolute_joint.h
@@ -31,7 +31,7 @@ class RevoluteJoint final : public Joint<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RevoluteJoint)
 
-  template<typename Scalar>
+  template <typename Scalar>
   using Context = systems::Context<Scalar>;
 
   static const char kTypeName[];
@@ -61,13 +61,12 @@ class RevoluteJoint final : public Joint<T> {
   ///   opposing motion, with ω the angular rate for `this` joint (see
   ///   get_angular_rate()).
   /// @throws std::exception if damping is negative.
-  RevoluteJoint(const std::string& name,
-                const Frame<T>& frame_on_parent, const Frame<T>& frame_on_child,
-                const Vector3<double>& axis,
-                double damping = 0) :
-      RevoluteJoint<T>(name, frame_on_parent, frame_on_child, axis,
-                       -std::numeric_limits<double>::infinity(),
-                       std::numeric_limits<double>::infinity(), damping) {}
+  RevoluteJoint(const std::string& name, const Frame<T>& frame_on_parent,
+                const Frame<T>& frame_on_child, const Vector3<double>& axis,
+                double damping = 0)
+      : RevoluteJoint<T>(name, frame_on_parent, frame_on_child, axis,
+                         -std::numeric_limits<double>::infinity(),
+                         std::numeric_limits<double>::infinity(), damping) {}
 
   /// Constructor to create a revolute joint between two bodies so that
   /// frame F attached to the parent body P and frame M attached to the child
@@ -130,9 +129,7 @@ class RevoluteJoint final : public Joint<T> {
   /// Since the measures of this axis in either frame F or M are the same (see
   /// this class's documentation for frames's definitions) then,
   /// `axis = axis_F = axis_M`.
-  const Vector3<double>& revolute_axis() const {
-    return axis_;
-  }
+  const Vector3<double>& revolute_axis() const { return axis_; }
 
   /// Returns `this` joint's damping constant in N⋅m⋅s.
   double damping() const { return damping_; }
@@ -185,14 +182,9 @@ class RevoluteJoint final : public Joint<T> {
   /// @param[in] angle
   ///   The desired angle in radians to be stored in `context`.
   /// @returns a constant reference to `this` joint.
-  const RevoluteJoint<T>& set_angle(
-      Context<T>* context, const T& angle) const {
+  const RevoluteJoint<T>& set_angle(Context<T>* context, const T& angle) const {
     get_mobilizer()->set_angle(context, angle);
     return *this;
-  }
-
-  void set_default_angle(double angle) {
-    get_mutable_mobilizer()->set_default_position(Vector1d{angle});
   }
 
   void set_random_angle_distribution(const symbolic::Expression& angle) {
@@ -219,13 +211,30 @@ class RevoluteJoint final : public Joint<T> {
   ///   The desired rate of change of `this` joints's angle in radians per
   ///   second.
   /// @returns a constant reference to `this` joint.
-  const RevoluteJoint<T>& set_angular_rate(
-      Context<T>* context, const T& angle) const {
+  const RevoluteJoint<T>& set_angular_rate(Context<T>* context,
+                                           const T& angle) const {
     get_mobilizer()->set_angular_rate(context, angle);
     return *this;
   }
 
   /// @}
+
+  /// Gets the default rotation angle. Wrapper for the more general
+  /// `Joint::default_positions()`.
+  /// @returns The default angle of `this` stored in `default_positions_`
+  double get_default_angle() const { return this->default_positions()[0]; }
+
+  /// Sets the `default_positions` of this joint (in this case a single angle).
+  /// If the parent tree has been finalized and the underlying mobilizer is
+  /// valid, this method sets the default position of that mobilizer.
+  /// @param[in] angle
+  ///   The desired default angle of the joint
+  void set_default_angle(double angle) {
+    this->set_default_positions(Vector1d{angle});
+    if (this->has_implementation()) {
+      get_mutable_mobilizer()->set_default_position(this->default_positions());
+    }
+  }
 
   /// Adds into `forces` a given `torque` for `this` joint that is to be applied
   /// about the joint's axis. The torque is defined to be positive according to
@@ -234,10 +243,8 @@ class RevoluteJoint final : public Joint<T> {
   /// acceleration according to the right-hand-rule around the joint's axis.
   ///
   /// @note A torque is the moment of a set of forces whose resultant is zero.
-  void AddInTorque(
-      const systems::Context<T>& context,
-      const T& torque,
-      MultibodyForces<T>* forces) const {
+  void AddInTorque(const systems::Context<T>& context, const T& torque,
+                   MultibodyForces<T>* forces) const {
     DRAKE_DEMAND(forces != nullptr);
     DRAKE_DEMAND(forces->CheckHasRightSizeForModel(this->get_parent_tree()));
     this->AddInOneForce(context, 0, torque, forces);
@@ -256,11 +263,9 @@ class RevoluteJoint final : public Joint<T> {
   /// joint's axis. That is, a positive torque causes a positive rotational
   /// acceleration (of the child body frame) according to the right-hand-rule
   /// around the joint's axis.
-  void DoAddInOneForce(
-      const systems::Context<T>&,
-      int joint_dof,
-      const T& joint_tau,
-      MultibodyForces<T>* forces) const override {
+  void DoAddInOneForce(const systems::Context<T>&, int joint_dof,
+                       const T& joint_tau,
+                       MultibodyForces<T>* forces) const override {
     // Right now we assume all the forces in joint_tau go into a single
     // mobilizer.
     DRAKE_DEMAND(joint_dof == 0);
@@ -285,17 +290,13 @@ class RevoluteJoint final : public Joint<T> {
     return get_mobilizer()->velocity_start_in_v();
   }
 
-  int do_get_num_velocities() const override {
-    return 1;
-  }
+  int do_get_num_velocities() const override { return 1; }
 
   int do_get_position_start() const override {
     return get_mobilizer()->position_start_in_q();
   }
 
-  int do_get_num_positions() const override {
-    return 1;
-  }
+  int do_get_num_positions() const override { return 1; }
 
   const T& DoGetOnePosition(const systems::Context<T>& context) const override {
     return get_angle(context);
@@ -306,8 +307,8 @@ class RevoluteJoint final : public Joint<T> {
   }
 
   // Joint<T> overrides:
-  std::unique_ptr<typename Joint<T>::BluePrint>
-  MakeImplementationBlueprint() const override;
+  std::unique_ptr<typename Joint<T>::BluePrint> MakeImplementationBlueprint()
+      const override;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(
       const internal::MultibodyTree<double>& tree_clone) const override;
@@ -321,7 +322,8 @@ class RevoluteJoint final : public Joint<T> {
   // Make RevoluteJoint templated on every other scalar type a friend of
   // RevoluteJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access
   // private members of RevoluteJoint<T>.
-  template <typename> friend class RevoluteJoint;
+  template <typename>
+  friend class RevoluteJoint;
 
   // Friend class to facilitate testing.
   friend class JointTester;
@@ -360,7 +362,8 @@ class RevoluteJoint final : public Joint<T> {
   double damping_{0};
 };
 
-template <typename T> const char RevoluteJoint<T>::kTypeName[] = "revolute";
+template <typename T>
+const char RevoluteJoint<T>::kTypeName[] = "revolute";
 
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/test/ball_rpy_joint_test.cc
+++ b/multibody/tree/test/ball_rpy_joint_test.cc
@@ -23,6 +23,8 @@ constexpr double kVelocityUpperLimit = 1.6;
 constexpr double kAccelerationLowerLimit = -1.2;
 constexpr double kAccelerationUpperLimit = 1.7;
 constexpr double kDamping = 3;
+constexpr double kPositionNonZeroDefault =
+    (kPositionLowerLimit + kPositionUpperLimit) / 2;
 
 class BallRpyJointTest : public ::testing::Test {
  public:
@@ -205,7 +207,7 @@ TEST_F(BallRpyJointTest, DefaultAngles) {
   const Vector3d default_angles = Vector3d::Zero();
 
   const Vector3d new_default_angles =
-      0.5 * lower_limit_angles + 0.5 * upper_limit_angles;
+      Vector3d::Constant(kPositionNonZeroDefault);
 
   const Vector3d out_of_bounds_low_angles =
       lower_limit_angles - Vector3d::Constant(1);

--- a/multibody/tree/test/ball_rpy_joint_test.cc
+++ b/multibody/tree/test/ball_rpy_joint_test.cc
@@ -223,11 +223,11 @@ TEST_F(BallRpyJointTest, DefaultAngles) {
   EXPECT_EQ(joint_->get_default_angles(), new_default_angles);
 
   // Setting the default angle out of the bounds of the position limits
-  // should throw an exception
-  EXPECT_THROW(mutable_joint_->set_default_angles(out_of_bounds_low_angles),
-               std::runtime_error);
-  EXPECT_THROW(mutable_joint_->set_default_angles(out_of_bounds_high_angles),
-               std::runtime_error);
+  // should NOT throw an exception
+  EXPECT_NO_THROW(
+      mutable_joint_->set_default_angles(out_of_bounds_low_angles));
+  EXPECT_NO_THROW(
+      mutable_joint_->set_default_angles(out_of_bounds_high_angles));
 }
 
 }  // namespace

--- a/multibody/tree/test/ball_rpy_joint_test.cc
+++ b/multibody/tree/test/ball_rpy_joint_test.cc
@@ -198,6 +198,36 @@ TEST_F(BallRpyJointTest, SetVelocityAndAccelerationLimits) {
                std::runtime_error);
 }
 
+TEST_F(BallRpyJointTest, DefaultAngles) {
+  const Vector3d lower_limit_angles = Vector3d::Constant(kPositionLowerLimit);
+  const Vector3d upper_limit_angles = Vector3d::Constant(kPositionUpperLimit);
+
+  const Vector3d default_angles = Vector3d::Zero();
+
+  const Vector3d new_default_angles =
+      0.5 * lower_limit_angles + 0.5 * upper_limit_angles;
+
+  const Vector3d out_of_bounds_low_angles =
+      lower_limit_angles - Vector3d::Constant(1);
+  const Vector3d out_of_bounds_high_angles =
+      upper_limit_angles + Vector3d::Constant(1);
+
+  // Constructor should set the default angle to Vector3d::Zero()
+  EXPECT_EQ(joint_->get_default_angles(), default_angles);
+
+  // Setting a new default angle should propogate so that `get_default_angle()`
+  // remains correct.
+  mutable_joint_->set_default_angles(new_default_angles);
+  EXPECT_EQ(joint_->get_default_angles(), new_default_angles);
+
+  // Setting the default angle out of the bounds of the position limits
+  // should throw an exception
+  EXPECT_THROW(mutable_joint_->set_default_angles(out_of_bounds_low_angles),
+               std::runtime_error);
+  EXPECT_THROW(mutable_joint_->set_default_angles(out_of_bounds_high_angles),
+               std::runtime_error);
+}
+
 }  // namespace
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/test/prismatic_joint_test.cc
+++ b/multibody/tree/test/prismatic_joint_test.cc
@@ -175,7 +175,8 @@ TEST_F(PrismaticJointTest, RandomTranslationTest) {
   // zero state.
   RandomGenerator generator;
   tree().SetRandomState(*context_, &context_->get_mutable_state(), &generator);
-  EXPECT_EQ(joint1_->get_translation(*context_), 0.);
+  EXPECT_EQ(joint1_->get_translation(*context_),
+            joint1_->get_default_translation());
 
   // Setup distribution for random initial conditions.
   std::uniform_real_distribution<symbolic::Expression> uniform(
@@ -184,6 +185,33 @@ TEST_F(PrismaticJointTest, RandomTranslationTest) {
   tree().SetRandomState(*context_, &context_->get_mutable_state(), &generator);
   EXPECT_LE(1.0, joint1_->get_translation(*context_));
   EXPECT_GE(kPositionUpperLimit, joint1_->get_translation(*context_));
+}
+
+TEST_F(PrismaticJointTest, DefaultTranslation) {
+  const double default_translation = 0.0;
+
+  const double new_default_translation =
+      0.5 * kPositionLowerLimit + 0.5 * kPositionUpperLimit;
+
+  const double out_of_bounds_low_translation = kPositionLowerLimit - 1;
+  const double out_of_bounds_high_translation = kPositionUpperLimit + 1;
+
+  // Constructor should set the default tranlation to 0.0
+  EXPECT_EQ(joint1_->get_default_translation(), default_translation);
+
+  // Setting a new default translation should propogate so that
+  // `get_default_translation()` remains correct.
+  mutable_joint1_->set_default_translation(new_default_translation);
+  EXPECT_EQ(joint1_->get_default_translation(), new_default_translation);
+
+  // Setting the default angle out of the bounds of the position limits
+  // should throw an exception
+  EXPECT_THROW(
+      mutable_joint1_->set_default_translation(out_of_bounds_low_translation),
+      std::runtime_error);
+  EXPECT_THROW(
+      mutable_joint1_->set_default_translation(out_of_bounds_high_translation),
+      std::runtime_error);
 }
 
 }  // namespace

--- a/multibody/tree/test/prismatic_joint_test.cc
+++ b/multibody/tree/test/prismatic_joint_test.cc
@@ -175,8 +175,7 @@ TEST_F(PrismaticJointTest, RandomTranslationTest) {
   // zero state.
   RandomGenerator generator;
   tree().SetRandomState(*context_, &context_->get_mutable_state(), &generator);
-  EXPECT_EQ(joint1_->get_translation(*context_),
-            joint1_->get_default_translation());
+  EXPECT_EQ(joint1_->get_translation(*context_), 0.);
 
   // Setup distribution for random initial conditions.
   std::uniform_real_distribution<symbolic::Expression> uniform(

--- a/multibody/tree/test/prismatic_joint_test.cc
+++ b/multibody/tree/test/prismatic_joint_test.cc
@@ -204,13 +204,11 @@ TEST_F(PrismaticJointTest, DefaultTranslation) {
   EXPECT_EQ(joint1_->get_default_translation(), new_default_translation);
 
   // Setting the default angle out of the bounds of the position limits
-  // should throw an exception
-  EXPECT_THROW(
-      mutable_joint1_->set_default_translation(out_of_bounds_low_translation),
-      std::runtime_error);
-  EXPECT_THROW(
-      mutable_joint1_->set_default_translation(out_of_bounds_high_translation),
-      std::runtime_error);
+  // should NOT throw an exception
+  EXPECT_NO_THROW(
+      mutable_joint1_->set_default_translation(out_of_bounds_low_translation));
+  EXPECT_NO_THROW(
+      mutable_joint1_->set_default_translation(out_of_bounds_high_translation));
 }
 
 }  // namespace

--- a/multibody/tree/test/revolute_joint_test.cc
+++ b/multibody/tree/test/revolute_joint_test.cc
@@ -229,11 +229,9 @@ TEST_F(RevoluteJointTest, DefaultAngle) {
   EXPECT_EQ(joint1_->get_default_angle(), new_default_angle);
 
   // Setting the default angle out of the bounds of the position limits
-  // should throw an exception
-  EXPECT_THROW(mutable_joint1_->set_default_angle(out_of_bounds_low_angle),
-               std::runtime_error);
-  EXPECT_THROW(mutable_joint1_->set_default_angle(out_of_bounds_high_angle),
-               std::runtime_error);
+  // should NOT throw an exception
+  EXPECT_NO_THROW(mutable_joint1_->set_default_angle(out_of_bounds_low_angle));
+  EXPECT_NO_THROW(mutable_joint1_->set_default_angle(out_of_bounds_high_angle));
 }
 
 }  // namespace

--- a/multibody/tree/test/revolute_joint_test.cc
+++ b/multibody/tree/test/revolute_joint_test.cc
@@ -134,7 +134,6 @@ TEST_F(RevoluteJointTest, AddInTorques) {
   joint1_->AddInTorque(*context_, some_value, &forces1);
   joint1_->AddInTorque(*context_, some_value, &forces1);
 
-
   MultibodyForces<double> forces2(tree());
   // Add value only once:
   joint1_->AddInTorque(*context_, some_value, &forces2);
@@ -208,6 +207,31 @@ TEST_F(RevoluteJointTest, SetVelocityAndAccelerationLimits) {
   // Lower limit is larger than upper limit.
   EXPECT_THROW(mutable_joint1_->set_acceleration_limits(Vector1<double>(2),
                                                         Vector1<double>(0)),
+               std::runtime_error);
+}
+
+TEST_F(RevoluteJointTest, DefaultAngle) {
+  const double default_angle = 0.0;
+
+  const double new_default_angle =
+      0.5 * kPositionLowerLimit + 0.5 * kPositionUpperLimit;
+
+  const double out_of_bounds_low_angle = kPositionLowerLimit - 1;
+  const double out_of_bounds_high_angle = kPositionUpperLimit + 1;
+
+  // Constructor should set the default angle to 0.0
+  EXPECT_EQ(joint1_->get_default_angle(), default_angle);
+
+  // Setting a new default angle should propogate so that `get_default_angle()`
+  // remains correct.
+  mutable_joint1_->set_default_angle(new_default_angle);
+  EXPECT_EQ(joint1_->get_default_angle(), new_default_angle);
+
+  // Setting the default angle out of the bounds of the position limits
+  // should throw an exception
+  EXPECT_THROW(mutable_joint1_->set_default_angle(out_of_bounds_low_angle),
+               std::runtime_error);
+  EXPECT_THROW(mutable_joint1_->set_default_angle(out_of_bounds_high_angle),
                std::runtime_error);
 }
 

--- a/multibody/tree/test/revolute_joint_test.cc
+++ b/multibody/tree/test/revolute_joint_test.cc
@@ -134,6 +134,7 @@ TEST_F(RevoluteJointTest, AddInTorques) {
   joint1_->AddInTorque(*context_, some_value, &forces1);
   joint1_->AddInTorque(*context_, some_value, &forces1);
 
+
   MultibodyForces<double> forces2(tree());
   // Add value only once:
   joint1_->AddInTorque(*context_, some_value, &forces2);


### PR DESCRIPTION
This is a PR to have the `Joint` class store a default value and to pass the value to its mobilizer implementation upon construction of the joint implementation.

- Solves the issue of mobilizers storing default joint positions (#13065)

\cc @amcastro-tri @EricCousineau-TRI @sherm1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13105)
<!-- Reviewable:end -->
