### PR TITLE
common::polynomial : Add Subsitute(var, Polynomial)

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -209,6 +209,7 @@ drake_pybind_library(
     cc_deps = [
         ":polynomial_types_pybind",
         "//bindings/pydrake:documentation_pybind",
+        "//bindings/pydrake/common:deprecation_pybind",
     ],
     cc_srcs = ["polynomial_py.cc"],
     package_info = PACKAGE_INFO,

--- a/bindings/pydrake/common/module_py.cc
+++ b/bindings/pydrake/common/module_py.cc
@@ -5,6 +5,7 @@
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/common/constants.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_assertion_error.h"
 #include "drake/common/drake_path.h"
@@ -35,6 +36,10 @@ PYBIND11_MODULE(_module_py, m) {
   // Python's `logging` module; possibly use `pyspdlog`.
   m.def("set_log_level", &logging::set_log_level, py::arg("level"),
       doc.logging.set_log_level.doc);
+
+  py::enum_<drake::ToleranceType>(m, "ToleranceType", doc.ToleranceType.doc)
+      .value("absolute", drake::ToleranceType::kAbsolute)
+      .value("relative", drake::ToleranceType::kRelative);
 
   py::enum_<drake::RandomDistribution>(
       m, "RandomDistribution", doc.RandomDistribution.doc)

--- a/bindings/pydrake/common/test/module_test.py
+++ b/bindings/pydrake/common/test/module_test.py
@@ -32,6 +32,11 @@ class TestCommon(unittest.TestCase):
         self.assertEqual(os.environ.get('TEST_TMPDIR'),
                          pydrake.common.temp_directory())
 
+    def test_tolerance_type(self):
+        # Simply test the spelling
+        pydrake.common.ToleranceType.absolute
+        pydrake.common.ToleranceType.relative
+
     def test_random_distribution(self):
         # Simply test the spelling
         pydrake.common.RandomDistribution.kUniform

--- a/bindings/pydrake/polynomial_py.cc
+++ b/bindings/pydrake/polynomial_py.cc
@@ -13,6 +13,8 @@ namespace pydrake {
 
 PYBIND11_MODULE(polynomial, m) {
   {
+    py::module::import("pydrake.common");
+
     using T = double;
     using Class = Polynomial<T>;
     constexpr auto& cls_doc = pydrake_doc.drake.Polynomial;
@@ -31,7 +33,9 @@ PYBIND11_MODULE(polynomial, m) {
             cls_doc.Derivative.doc)
         .def("Integral", &Class::Integral,
             py::arg("integration_constant") = 0.0, cls_doc.Integral.doc)
-        .def("IsApprox", &Class::IsApprox, py::arg("other"), py::arg("tol"),
+        .def("IsApprox", &Class::IsApprox, py::arg("other"),
+            py::arg("tol") = 0.0,
+            py::arg("tol_type") = ToleranceType::kRelative,
             cls_doc.IsApprox.doc)
         // Arithmetic
         .def(-py::self)

--- a/bindings/pydrake/polynomial_py.cc
+++ b/bindings/pydrake/polynomial_py.cc
@@ -3,6 +3,7 @@
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 
+#include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/polynomial_types_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
@@ -33,10 +34,20 @@ PYBIND11_MODULE(polynomial, m) {
             cls_doc.Derivative.doc)
         .def("Integral", &Class::Integral,
             py::arg("integration_constant") = 0.0, cls_doc.Integral.doc)
-        .def("IsApprox", &Class::IsApprox, py::arg("other"),
-            py::arg("tol") = 0.0,
-            py::arg("tol_type") = ToleranceType::kRelative,
-            cls_doc.IsApprox.doc)
+        .def("CoefficientsAlmostEqual", &Class::CoefficientsAlmostEqual,
+            py::arg("other"), py::arg("tol") = 0.0,
+            py::arg("tol_type") = ToleranceType::kAbsolute,
+            cls_doc.CoefficientsAlmostEqual.doc)
+        .def("IsApprox",
+            [](Polynomial<T>* self, const Polynomial<T>& other,
+                const Polynomial<T>::RealScalar& tol) {
+              WarnDeprecated(
+                  "Use CoefficientAlmostEqual with tol_type=kRelative instead "
+                  "of IsApprox.  Support will be removed after 2020-08-01.");
+              return self->CoefficientsAlmostEqual(
+                  other, tol, ToleranceType::kRelative);
+            },
+            py::arg("other"), py::arg("tol"))
         // Arithmetic
         .def(-py::self)
         .def(py::self + py::self)

--- a/bindings/pydrake/test/polynomial_test.py
+++ b/bindings/pydrake/test/polynomial_test.py
@@ -1,6 +1,7 @@
 import numpy as np
 import unittest
 
+from pydrake.common import ToleranceType
 from pydrake.common.test_utilities import numpy_compare
 from pydrake.polynomial import Polynomial
 
@@ -21,7 +22,7 @@ class TestPolynomial(unittest.TestCase):
         self.assertEqual(p_d.GetDegree(), 1)
         p_i = p.Integral(integration_constant=0)
         self.assertEqual(p_i.GetDegree(), 3)
-        self.assertTrue(p.IsApprox(p, 1e-14))
+        self.assertTrue(p.IsApprox(p, 1e-14, ToleranceType.relative))
 
     def test_arithmetic(self):
         p = Polynomial([0, 1])

--- a/bindings/pydrake/test/polynomial_test.py
+++ b/bindings/pydrake/test/polynomial_test.py
@@ -22,7 +22,8 @@ class TestPolynomial(unittest.TestCase):
         self.assertEqual(p_d.GetDegree(), 1)
         p_i = p.Integral(integration_constant=0)
         self.assertEqual(p_i.GetDegree(), 3)
-        self.assertTrue(p.IsApprox(p, 1e-14, ToleranceType.relative))
+        self.assertTrue(
+            p.CoefficientsAlmostEqual(p, 1e-14, ToleranceType.relative))
 
     def test_arithmetic(self):
         p = Polynomial([0, 1])

--- a/bindings/pydrake/test/trajectories_test.py
+++ b/bindings/pydrake/test/trajectories_test.py
@@ -1,6 +1,7 @@
 import numpy as np
 import unittest
 
+from pydrake.common import ToleranceType
 from pydrake.common.test_utilities import numpy_compare
 from pydrake.polynomial import Polynomial
 from pydrake.trajectories import (
@@ -97,7 +98,8 @@ class TestTrajectories(unittest.TestCase):
         x = np.array([[10.], [20.], [30.]]).transpose()
         pp1 = PiecewisePolynomial.FirstOrderHold([0., 1., 2.], x)
         pp2 = PiecewisePolynomial.FirstOrderHold([2., 3., 4.], x)
-        self.assertTrue(pp1.isApprox(other=pp1, tol=1e-14))
+        self.assertTrue(pp1.isApprox(
+            other=pp1, tol=1e-14, tol_type=ToleranceType.relative))
         pp1.ConcatenateInTime(other=pp2)
         self.assertEqual(pp1.end_time(), 4.)
 

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -177,7 +177,8 @@ PYBIND11_MODULE(trajectories, m) {
       .def("cols", &PiecewisePolynomial<T>::cols,
           doc.PiecewisePolynomial.cols.doc)
       .def("isApprox", &PiecewisePolynomial<T>::isApprox, py::arg("other"),
-          py::arg("tol"), doc.PiecewisePolynomial.isApprox.doc)
+          py::arg("tol"), py::arg("tol_type") = drake::ToleranceType::kRelative,
+          doc.PiecewisePolynomial.isApprox.doc)
       .def("ConcatenateInTime", &PiecewisePolynomial<T>::ConcatenateInTime,
           py::arg("other"), doc.PiecewisePolynomial.ConcatenateInTime.doc)
       .def("AppendCubicHermiteSegment",

--- a/common/constants.h
+++ b/common/constants.h
@@ -16,4 +16,6 @@ constexpr int kHomogeneousTransformSize = 16;
 
 const int kRotmatSize = kSpaceDimension * kSpaceDimension;
 
+enum class ToleranceType { kAbsolute, kRelative };
+
 }  // namespace drake

--- a/common/polynomial.cc
+++ b/common/polynomial.cc
@@ -557,9 +557,9 @@ typename Polynomial<T>::RootsType Polynomial<T>::Roots() const {
 }
 
 template <typename T>
-boolean<T> Polynomial<T>::IsApprox(const Polynomial<T>& other,
-                                   const Polynomial<T>::RealScalar& tol,
-                                   const ToleranceType& tol_type) const {
+boolean<T> Polynomial<T>::CoefficientsAlmostEqual(
+    const Polynomial<T>& other, const Polynomial<T>::RealScalar& tol,
+    const ToleranceType& tol_type) const {
   using std::abs;
   using std::min;
   std::vector<bool> monomial_has_match(monomials_.size(), false);

--- a/common/polynomial.h
+++ b/common/polynomial.h
@@ -43,6 +43,8 @@ namespace drake {
 template <typename T = double>
 class Polynomial {
  public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Polynomial);
+
   typedef unsigned int VarType;
   /// This should be 'unsigned int' but MSVC considers a call to std::pow(...,
   /// unsigned int) ambiguous because it won't cast unsigned int to int.
@@ -95,6 +97,7 @@ class Polynomial {
     int GetDegree() const;
     int GetDegreeOf(VarType var) const;
     bool HasSameExponents(const Monomial& other) const;
+    bool HasVariable(const VarType& var) const;
 
     /// Factors this by other; returns 0 iff other does not divide this.
     Monomial Factor(const Monomial& divisor) const;
@@ -278,6 +281,10 @@ class Polynomial {
   /// Replaces all instances of variable orig with replacement.
   void Subs(const VarType& orig, const VarType& replacement);
 
+  /// Replaces all instances of variable orig with replacement.
+  Polynomial Substitute(const VarType& orig,
+                        const Polynomial& replacement) const;
+
   /** Takes the derivative of this (univariate) Polynomial.
    *
    * Returns a new Polynomial that is the derivative of this one in its sole
@@ -383,13 +390,18 @@ class Polynomial {
    */
   RootsType Roots() const;
 
-  /** Checks if a (univariate) Polynomial is approximately equal to this one.
+  /** Checks if a Polynomial is approximately equal to this one.
    *
-   * Checks that every coefficient of other is within tol of the
+   * Checks that every coefficient of `other` is within `tol` of the
    * corresponding coefficient of this Polynomial.
-   * @throws std::exception if either Polynomial is not univariate.
+   *
+   * Note: Even when @p tol_type is ToleranceType::relative, we still use an
+   * absolute tolerance (coefficient < tol) for monomials that appear only in
+   * `this` or only in `other`, because we cannot test relative to zero.
    */
-  boolean<T> IsApprox(const Polynomial<T>& other, const RealScalar& tol) const;
+  boolean<T> IsApprox(
+      const Polynomial<T>& other, const RealScalar& tol = 0.0,
+      const ToleranceType& tol_type = ToleranceType::relative) const;
 
   /** Constructs a Polynomial representing the symbolic expression `e`.
    * Note that the ID of a variable is preserved in this translation.
@@ -496,11 +508,6 @@ std::ostream& operator<<(
   }
   return os;
 }
-
-template <>
-boolean<symbolic::Expression> Polynomial<symbolic::Expression>::IsApprox(
-    const Polynomial<symbolic::Expression>& other,
-    const Polynomial<symbolic::Expression>::RealScalar& tol) const;
 
 #ifndef DRAKE_DOXYGEN_CXX
 namespace symbolic {

--- a/common/polynomial.h
+++ b/common/polynomial.h
@@ -395,13 +395,21 @@ class Polynomial {
    * Checks that every coefficient of `other` is within `tol` of the
    * corresponding coefficient of this Polynomial.
    *
-   * Note: Even when @p tol_type is ToleranceType::relative, we still use an
-   * absolute tolerance (coefficient < tol) for monomials that appear only in
-   * `this` or only in `other`, because we cannot test relative to zero.
+   * Note: When `tol_type` is kRelative, if any monomials appear in `this` or
+   * `other` but not both, then the method returns false (since the comparison
+   * is relative to a missing zero coefficient).  Use kAbsolute if you want to
+   * ignore non-matching monomials with coefficients less than `tol`.
    */
-  boolean<T> IsApprox(
+  boolean<T> CoefficientsAlmostEqual(
       const Polynomial<T>& other, const RealScalar& tol = 0.0,
-      const ToleranceType& tol_type = ToleranceType::relative) const;
+      const ToleranceType& tol_type = ToleranceType::kAbsolute) const;
+
+  DRAKE_DEPRECATED("2020-08-01",
+                   "Use CoefficientsAlmostEqual with tol_type=kRelative "
+                   "instead of IsApprox.")
+  boolean<T> IsApprox(const Polynomial<T>& other, const RealScalar& tol) const {
+    return CoefficientsAlmostEqual(other, tol, ToleranceType::kRelative);
+  }
 
   /** Constructs a Polynomial representing the symbolic expression `e`.
    * Note that the ID of a variable is preserved in this translation.

--- a/common/test/polynomial_test.cc
+++ b/common/test/polynomial_test.cc
@@ -561,5 +561,51 @@ GTEST_TEST(PolynomialTest, ScalarTypes) {
   const Polynomial<symbolic::Expression> p_symbolic(0);
 }
 
+GTEST_TEST(PolynomialTest, IsApproxTest) {
+  Polynomiald x = Polynomiald("x");
+  Polynomiald y = Polynomiald("y");
+
+  EXPECT_FALSE(x.IsApprox(y));
+  EXPECT_TRUE((x + y).IsApprox(y + x));
+
+  EXPECT_TRUE((x + x * x + 3 * pow(x, 3)).IsApprox(3 * pow(x, 3) + x + x * x));
+
+  // Test relative and absolute tolerance.
+  EXPECT_TRUE((100*x).IsApprox(99*x, 0.1, ToleranceType::kRelative));
+  EXPECT_FALSE((100*x).IsApprox(99*x, 0.1, ToleranceType::kAbsolute));
+  EXPECT_FALSE((0.01*x).IsApprox(0.02*x, 0.1, ToleranceType::kRelative));
+  EXPECT_TRUE((0.01*x).IsApprox(0.02*x, 0.1, ToleranceType::kAbsolute));
+
+  // Test missing monomials.
+  EXPECT_FALSE((x + y + 0.01 * x * x).IsApprox(x + y));
+  EXPECT_FALSE((x + y).IsApprox(x + y + 0.01 * x * x));
+  // Missing monomials is ok only for absolute tolerance.
+  EXPECT_TRUE(
+      (x + y + 0.01 * x * x).IsApprox(x + y, 0.02, ToleranceType::kAbsolute));
+  EXPECT_TRUE(
+      (x + y).IsApprox(x + y + 0.01 * x * x, 0.02, ToleranceType::kAbsolute));
+  EXPECT_FALSE(
+      (x + y + 0.01 * x * x).IsApprox(x + y, 0.02, ToleranceType::kRelative));
+  EXPECT_FALSE(
+      (x + y).IsApprox(x + y + 0.01 * x * x, 0.02, ToleranceType::kRelative));
+}
+
+GTEST_TEST(PolynomialTest, SubsitutionTest) {
+  Polynomiald x = Polynomiald("x");
+  Polynomiald y = Polynomiald("y");
+
+  Polynomiald::VarType xvar = x.GetSimpleVariable();
+  Polynomiald::VarType yvar = y.GetSimpleVariable();
+
+  EXPECT_TRUE(x.Substitute(xvar, y).IsApprox(y));
+
+  Polynomiald p1 = x + 3 * x * x + 3 * y;
+  EXPECT_TRUE(p1.Substitute(xvar, 1 + x)
+                  .IsApprox(1 + x + 3 * (1 + x) * (1 + x) + 3 * y));
+  EXPECT_TRUE(p1.Substitute(yvar, 1 + x).IsApprox(3 + 4 * x + 3 * x * x));
+  EXPECT_TRUE(
+      p1.Substitute(xvar, x * x).IsApprox(x * x + 3 * pow(x, 4) + 3 * y));
+}
+
 }  // anonymous namespace
 }  // namespace drake

--- a/common/test/polynomial_test.cc
+++ b/common/test/polynomial_test.cc
@@ -537,7 +537,7 @@ void TestScalarType() {
               1e-14);
 
   EXPECT_THROW(p.Roots(), std::runtime_error);
-  EXPECT_TRUE(static_cast<bool>(p.IsApprox(p, 1e-14)));
+  EXPECT_TRUE(static_cast<bool>(p.CoefficientsAlmostEqual(p, 1e-14)));
 
   Polynomial<T> x("x", 1);
   Polynomial<T> y("y", 1);
@@ -561,33 +561,46 @@ GTEST_TEST(PolynomialTest, ScalarTypes) {
   const Polynomial<symbolic::Expression> p_symbolic(0);
 }
 
-GTEST_TEST(PolynomialTest, IsApproxTest) {
+GTEST_TEST(PolynomialTest, CoefficientsAlmostEqualTest) {
   Polynomiald x = Polynomiald("x");
   Polynomiald y = Polynomiald("y");
 
-  EXPECT_FALSE(x.IsApprox(y));
-  EXPECT_TRUE((x + y).IsApprox(y + x));
+  EXPECT_FALSE(x.CoefficientsAlmostEqual(y));
+  EXPECT_TRUE((x + y).CoefficientsAlmostEqual(y + x));
 
-  EXPECT_TRUE((x + x * x + 3 * pow(x, 3)).IsApprox(3 * pow(x, 3) + x + x * x));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  EXPECT_FALSE(x.IsApprox(y, 0.0));
+  EXPECT_TRUE((x + y).IsApprox(y + x, 0.0));
+#pragma GCC diagnostic pop
+
+  EXPECT_TRUE((x + x * x + 3 * pow(x, 3))
+                  .CoefficientsAlmostEqual(3 * pow(x, 3) + x + x * x));
 
   // Test relative and absolute tolerance.
-  EXPECT_TRUE((100*x).IsApprox(99*x, 0.1, ToleranceType::kRelative));
-  EXPECT_FALSE((100*x).IsApprox(99*x, 0.1, ToleranceType::kAbsolute));
-  EXPECT_FALSE((0.01*x).IsApprox(0.02*x, 0.1, ToleranceType::kRelative));
-  EXPECT_TRUE((0.01*x).IsApprox(0.02*x, 0.1, ToleranceType::kAbsolute));
+  EXPECT_TRUE(
+      (100 * x).CoefficientsAlmostEqual(99 * x, 0.1, ToleranceType::kRelative));
+  EXPECT_FALSE(
+      (100 * x).CoefficientsAlmostEqual(99 * x, 0.1, ToleranceType::kAbsolute));
+  EXPECT_FALSE((0.01 * x).CoefficientsAlmostEqual(0.02 * x, 0.1,
+                                                  ToleranceType::kRelative));
+  EXPECT_TRUE((0.01 * x).CoefficientsAlmostEqual(0.02 * x, 0.1,
+                                                 ToleranceType::kAbsolute));
 
   // Test missing monomials.
-  EXPECT_FALSE((x + y + 0.01 * x * x).IsApprox(x + y));
-  EXPECT_FALSE((x + y).IsApprox(x + y + 0.01 * x * x));
+  EXPECT_FALSE((x + y + 0.01 * x * x).CoefficientsAlmostEqual(x + y));
+  EXPECT_FALSE((x + y).CoefficientsAlmostEqual(x + y + 0.01 * x * x));
   // Missing monomials is ok only for absolute tolerance.
   EXPECT_TRUE(
-      (x + y + 0.01 * x * x).IsApprox(x + y, 0.02, ToleranceType::kAbsolute));
-  EXPECT_TRUE(
-      (x + y).IsApprox(x + y + 0.01 * x * x, 0.02, ToleranceType::kAbsolute));
+      (x + y + 0.01 * x * x)
+          .CoefficientsAlmostEqual(x + y, 0.02, ToleranceType::kAbsolute));
+  EXPECT_TRUE((x + y).CoefficientsAlmostEqual(x + y + 0.01 * x * x, 0.02,
+                                              ToleranceType::kAbsolute));
   EXPECT_FALSE(
-      (x + y + 0.01 * x * x).IsApprox(x + y, 0.02, ToleranceType::kRelative));
-  EXPECT_FALSE(
-      (x + y).IsApprox(x + y + 0.01 * x * x, 0.02, ToleranceType::kRelative));
+      (x + y + 0.01 * x * x)
+          .CoefficientsAlmostEqual(x + y, 0.02, ToleranceType::kRelative));
+  EXPECT_FALSE((x + y).CoefficientsAlmostEqual(x + y + 0.01 * x * x, 0.02,
+                                               ToleranceType::kRelative));
 }
 
 GTEST_TEST(PolynomialTest, SubsitutionTest) {
@@ -597,14 +610,16 @@ GTEST_TEST(PolynomialTest, SubsitutionTest) {
   Polynomiald::VarType xvar = x.GetSimpleVariable();
   Polynomiald::VarType yvar = y.GetSimpleVariable();
 
-  EXPECT_TRUE(x.Substitute(xvar, y).IsApprox(y));
+  EXPECT_TRUE(x.Substitute(xvar, y).CoefficientsAlmostEqual(y));
 
   Polynomiald p1 = x + 3 * x * x + 3 * y;
-  EXPECT_TRUE(p1.Substitute(xvar, 1 + x)
-                  .IsApprox(1 + x + 3 * (1 + x) * (1 + x) + 3 * y));
-  EXPECT_TRUE(p1.Substitute(yvar, 1 + x).IsApprox(3 + 4 * x + 3 * x * x));
   EXPECT_TRUE(
-      p1.Substitute(xvar, x * x).IsApprox(x * x + 3 * pow(x, 4) + 3 * y));
+      p1.Substitute(xvar, 1 + x)
+          .CoefficientsAlmostEqual(1 + x + 3 * (1 + x) * (1 + x) + 3 * y));
+  EXPECT_TRUE(p1.Substitute(yvar, 1 + x)
+                  .CoefficientsAlmostEqual(3 + 4 * x + 3 * x * x));
+  EXPECT_TRUE(p1.Substitute(xvar, x * x)
+                  .CoefficientsAlmostEqual(x * x + 3 * pow(x, 4) + 3 * y));
 }
 
 }  // anonymous namespace

--- a/common/trajectories/piecewise_polynomial.cc
+++ b/common/trajectories/piecewise_polynomial.cc
@@ -263,7 +263,8 @@ bool PiecewisePolynomial<T>::isApprox(const PiecewisePolynomial<T>& other,
     const PolynomialMatrix& other_matrix = other.polynomials_[segment_index];
     for (Eigen::Index row = 0; row < rows(); row++) {
       for (Eigen::Index col = 0; col < cols(); col++) {
-        if (!matrix(row, col).IsApprox(other_matrix(row, col), tol, tol_type)) {
+        if (!matrix(row, col).CoefficientsAlmostEqual(other_matrix(row, col),
+                                                      tol, tol_type)) {
           return false;
         }
       }

--- a/common/trajectories/piecewise_polynomial.h
+++ b/common/trajectories/piecewise_polynomial.h
@@ -717,9 +717,10 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
   // Formula when T=symbolic::Expression.
   /**
    * Checks whether a %PiecewisePolynomial is approximately equal to this one by
-   * calling Polynomial<T>::IsApprox() on every element of every segment.
-   * 
-   * @see Polynamial<T>::IsApprox().
+   * calling Polynomial<T>::CoefficientsAlmostEqual() on every element of every
+   * segment.
+   *
+   * @see Polynomial<T>::CoefficientsAlmostEqual().
    *
    */
   bool isApprox(const PiecewisePolynomial& other, double tol,

--- a/common/trajectories/piecewise_polynomial.h
+++ b/common/trajectories/piecewise_polynomial.h
@@ -716,14 +716,14 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
   // TODO(russt): Update return type to boolean<T> so that callers can obtain a
   // Formula when T=symbolic::Expression.
   /**
-   * Checks whether a %PiecewisePolynomial is approximately equal to this one.
+   * Checks whether a %PiecewisePolynomial is approximately equal to this one by
+   * calling Polynomial<T>::IsApprox() on every element of every segment.
+   * 
+   * @see Polynamial<T>::IsApprox().
    *
-   * Checks that every coefficient of `other` is within `tol` of the
-   * corresponding coefficient of this %PiecewisePolynomial.
-   * @throws std::exception if any Polynomial in either %PiecewisePolynomial is
-   * not univariate.
    */
-  bool isApprox(const PiecewisePolynomial& other, double tol) const;
+  bool isApprox(const PiecewisePolynomial& other, double tol,
+                const ToleranceType& tol_type = ToleranceType::kRelative) const;
 
   /**
    * Concatenates `other` to the end of `this`.

--- a/common/trajectories/test/piecewise_polynomial_generation_test.cc
+++ b/common/trajectories/test/piecewise_polynomial_generation_test.cc
@@ -463,8 +463,8 @@ GTEST_TEST(SplineTests, RandomizedCubicSplineTest) {
 
   // Test CubicHermite(T, Y, Ydots)
   for (int ctr = 0; ctr < num_tests; ++ctr) {
-    std::vector<double> T =
-        PiecewiseTrajectory<double>::RandomSegmentTimes(N - 1, generator);
+    std::vector<double> T(N);
+    std::iota(T.begin(), T.end(), 0);
     std::vector<MatrixX<double>> Y(N);
     std::vector<MatrixX<double>> Ydot(N);
 

--- a/common/trajectories/test/piecewise_polynomial_test.cc
+++ b/common/trajectories/test/piecewise_polynomial_test.cc
@@ -415,6 +415,20 @@ GTEST_TEST(testPiecewisePolynomial, ReshapeTest) {
   EXPECT_TRUE(CompareMatrices(zoh.value(0.75), samples[1]));
 }
 
+GTEST_TEST(testPiecewisePolynomial, IsApproxTest) {
+  Eigen::VectorXd breaks(3);
+  breaks << 0, .5, 1.;
+  Eigen::MatrixXd samples(2, 3);
+  samples << 1, 2, 3, -5, -4, -3;
+  // Make the numbers bigger to exaggerate the tolerance test.
+  samples *= 1000;
+
+  const PiecewisePolynomial<double> pp1 =
+      PiecewisePolynomial<double>::FirstOrderHold(breaks, samples);
+  const PiecewisePolynomial<double> pp2 = pp1 + Eigen::Vector2d::Ones();
+  EXPECT_FALSE(pp1.isApprox(pp2, 0.1, ToleranceType::kAbsolute));
+  EXPECT_TRUE(pp1.isApprox(pp2, 0.1, ToleranceType::kRelative));
+}
 
 template <typename T>
 void TestScalarType() {


### PR DESCRIPTION
Also generalizes Polynomial::IsApprox to support multivariate polynomials.
NOTE: The behavior of IsApprox has changed from the previous implementation for univariate polynomials in two ways:
  1) IsApprox will now fail if the polynomials have different variables.
  2) The comparison is now absolute instead of relative.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13108)
<!-- Reviewable:end -->
