### PR TITLE
solvers: Fix memcpy undefined behavior in unconstrained optimization

### DIFF
--- a/multibody/inverse_kinematics/BUILD.bazel
+++ b/multibody/inverse_kinematics/BUILD.bazel
@@ -156,10 +156,6 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "inverse_kinematics_test",
-    # TODO(betsymcphail) Ubsan fails for this test. See #9475.
-    tags = [
-        "no_ubsan",
-    ],
     deps = [
         ":inverse_kinematics_core",
         ":inverse_kinematics_test_utilities",


### PR DESCRIPTION
Calling memcpy on nullptr is undefined.

Closes #9475.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13111)
<!-- Reviewable:end -->
