### PR TITLE
controllers: FittedValueIteration supports MBP+SceneGraph

### DIFF
--- a/bindings/pydrake/systems/controllers_py.cc
+++ b/bindings/pydrake/systems/controllers_py.cc
@@ -53,7 +53,14 @@ PYBIND11_MODULE(controllers, m) {
           doc.DynamicProgrammingOptions.convergence_tol.doc)
       .def_readwrite("visualization_callback",
           &DynamicProgrammingOptions::visualization_callback,
-          doc.DynamicProgrammingOptions.visualization_callback.doc);
+          doc.DynamicProgrammingOptions.visualization_callback.doc)
+      .def_readwrite("input_port_index",
+          &DynamicProgrammingOptions::input_port_index,
+          doc.DynamicProgrammingOptions.input_port_index.doc)
+      .def_readwrite("assume_non_continuous_states_are_fixed",
+          &DynamicProgrammingOptions::assume_non_continuous_states_are_fixed,
+          doc.DynamicProgrammingOptions.assume_non_continuous_states_are_fixed
+              .doc);
 
   py::class_<InverseDynamics<double>, LeafSystem<double>> idyn(
       m, "InverseDynamics", doc.InverseDynamics.doc);

--- a/bindings/pydrake/systems/test/controllers_test.py
+++ b/bindings/pydrake/systems/test/controllers_test.py
@@ -17,6 +17,7 @@ from pydrake.systems.controllers import (
     LinearProgrammingApproximateDynamicProgramming,
     PeriodicBoundaryCondition, PidControlledSystem, PidController
 )
+from pydrake.systems.framework import InputPortSelection
 from pydrake.systems.primitives import Integrator, LinearSystem
 
 
@@ -52,6 +53,8 @@ class TestControllers(unittest.TestCase):
             PeriodicBoundaryCondition(0, 0., 2.*math.pi)
         ]
         options.visualization_callback = callback
+        options.input_port_index = InputPortSelection.kUseFirstInputIfItExists
+        options.assume_non_continuous_states_are_fixed = False
 
         policy, cost_to_go = FittedValueIteration(simulator,
                                                   quadratic_regulator_cost,

--- a/systems/controllers/BUILD.bazel
+++ b/systems/controllers/BUILD.bazel
@@ -176,11 +176,17 @@ drake_cc_googletest(
     name = "dynamic_programming_test",
     # Test timeout increased to not timeout when run with Valgrind.
     timeout = "long",
+    data = [
+        "//examples/pendulum:models",
+    ],
     deps = [
         ":dynamic_programming",
         ":linear_quadratic_regulator",
         "//common/proto:call_python",
         "//common/test_utilities:eigen_matrix_compare",
+        "//multibody/parsing",
+        "//multibody/plant",
+        "//systems/framework:diagram_builder",
         "//systems/primitives:integrator",
         "//systems/primitives:linear_system",
     ],

--- a/systems/controllers/dynamic_programming.cc
+++ b/systems/controllers/dynamic_programming.cc
@@ -45,11 +45,14 @@ FittedValueIteration(
   const int num_state_indices = state_mesh.get_num_interpolants();
 
   // TODO(russt): handle discrete state.
-  DRAKE_DEMAND(context.has_only_continuous_state());
+  DRAKE_DEMAND(context.has_only_continuous_state() ||
+               options.assume_non_continuous_states_are_fixed);
   DRAKE_DEMAND(context.num_continuous_states() == state_size);
 
-  DRAKE_DEMAND(context.num_input_ports() == 1);
-  DRAKE_DEMAND(system.num_total_inputs() == input_size);
+  const InputPort<double>* input_port =
+      system.get_input_port_selection(options.input_port_index);
+  DRAKE_DEMAND(input_port != nullptr);
+  DRAKE_DEMAND(input_port->size() == input_size);
 
   DRAKE_DEMAND(timestep > 0.);
 
@@ -86,7 +89,7 @@ FittedValueIteration(
     cost[input].resize(num_states);
 
     input_mesh.get_mesh_point(input, &input_vec);
-    system.get_input_port(0).FixValue(&context, input_vec);
+    input_port->FixValue(&context, input_vec);
 
     for (int state = 0; state < num_states; state++) {
       context.SetTime(0.0);

--- a/systems/controllers/dynamic_programming.h
+++ b/systems/controllers/dynamic_programming.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <set>
 #include <utility>
+#include <variant>
 
 #include "drake/common/symbolic.h"
 #include "drake/math/barycentric.h"
@@ -52,6 +53,19 @@ struct DynamicProgrammingOptions {
       int iteration, const math::BarycentricMesh<double>& state_mesh,
       const Eigen::RowVectorXd& cost_to_go, const Eigen::MatrixXd& policy)>
       visualization_callback{nullptr};
+
+  /// For systems with multiple input ports, we must specify which input port is
+  /// being used in the control design.  @see systems::InputPortSelection.
+  std::variant<systems::InputPortSelection, InputPortIndex> input_port_index{
+      systems::InputPortSelection::kUseFirstInputIfItExists};
+
+  /// (Advanced) Boolean which, if true, allows this algorithm to optimize
+  /// without considering the dynamics of any non-continuous states. This is
+  /// helpful for optimizing systems that might have some additional
+  /// book-keeping variables in their state. Only use this if you are sure that
+  /// the dynamics of the additional state variables cannot impact the dynamics
+  /// of the continuous states.  @default false.
+  bool assume_non_continuous_states_are_fixed{false};
 };
 
 /// Implements Fitted Value Iteration on a (triangulated) Barycentric Mesh,


### PR DESCRIPTION
Takes the input port as an argument, and can ignore the scene graph abstract state (related to #9501)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13113)
<!-- Reviewable:end -->
