### PR TITLE
Add alternate Sphere volume mesh generation

### DIFF
--- a/geometry/benchmarking/mesh_intersection_benchmark.cc
+++ b/geometry/benchmarking/mesh_intersection_benchmark.cc
@@ -204,7 +204,8 @@ class MeshIntersectionBenchmark : public benchmark::Fixture {
       : ellipsoid_{kEllipsoidDimension[0], kEllipsoidDimension[1],
                    kEllipsoidDimension[2]},
         sphere_{kSphereDimension},
-        mesh_S_(MakeEllipsoidVolumeMesh<double>(ellipsoid_, 1)),
+        mesh_S_(MakeEllipsoidVolumeMesh<double>(
+            ellipsoid_, 1, TessellationStrategy::kDenseInteriorVertices)),
         field_S_(MakeEllipsoidPressureField<double>(ellipsoid_, &mesh_S_,
                                                     kElasticModulus)),
         mesh_R_(MakeEllipsoidSurfaceMesh<double>(ellipsoid_, 1)) {}
@@ -222,7 +223,9 @@ class MeshIntersectionBenchmark : public benchmark::Fixture {
     const auto [resolution, contact_overlap, rotation_factor] =
         ReadState(state);
     const double resolution_hint = kResolutionHint[resolution];
-    mesh_S_ = MakeEllipsoidVolumeMesh<double>(ellipsoid_, resolution_hint);
+    mesh_S_ = MakeEllipsoidVolumeMesh<double>(
+        ellipsoid_, resolution_hint,
+        TessellationStrategy::kDenseInteriorVertices);
     field_S_ = MakeEllipsoidPressureField<double>(ellipsoid_, &mesh_S_,
                                                   kElasticModulus);
     mesh_R_ = MakeSphereSurfaceMesh<double>(sphere_, resolution_hint);

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -43,6 +43,7 @@ drake_cc_package_library(
         ":proximity_utilities",
         ":sorted_triplet",
         ":surface_mesh",
+        ":tessellation_strategy",
         ":volume_mesh",
         ":volume_to_surface_mesh",
     ],
@@ -185,6 +186,7 @@ drake_cc_library(
         ":obj_to_surface_mesh",
         ":proximity_utilities",
         ":surface_mesh",
+        ":tessellation_strategy",
         ":volume_mesh",
         "//common:essential",
         "//geometry:geometry_ids",
@@ -280,6 +282,7 @@ drake_cc_library(
     hdrs = ["make_sphere_mesh.h"],
     deps = [
         ":surface_mesh",
+        ":tessellation_strategy",
         ":volume_mesh",
         ":volume_to_surface_mesh",
         "//common:essential",
@@ -437,6 +440,11 @@ drake_cc_library(
         "//common",
         "//math:geometric_transform",
     ],
+)
+
+drake_cc_library(
+    name = "tessellation_strategy",
+    hdrs = ["tessellation_strategy.h"],
 )
 
 drake_cc_library(

--- a/geometry/proximity/hydroelastic_internal.cc
+++ b/geometry/proximity/hydroelastic_internal.cc
@@ -13,6 +13,7 @@
 #include "drake/geometry/proximity/make_sphere_field.h"
 #include "drake/geometry/proximity/make_sphere_mesh.h"
 #include "drake/geometry/proximity/obj_to_surface_mesh.h"
+#include "drake/geometry/proximity/tessellation_strategy.h"
 #include "drake/geometry/proximity/volume_to_surface_mesh.h"
 
 namespace drake {
@@ -256,8 +257,12 @@ std::optional<SoftGeometry> MakeSoftRepresentation(
   PositiveDouble validator("Sphere", "soft");
   // First, create the mesh.
   const double edge_length = validator.Extract(props, kHydroGroup, kRezHint);
+  // If nothing is said, let's go for the *cheap* tessellation strategy.
+  const TessellationStrategy strategy =
+      props.GetPropertyOrDefault(kHydroGroup, "tessellation_strategy",
+                                 TessellationStrategy::kSingleInteriorVertex);
   auto mesh = make_unique<VolumeMesh<double>>(
-      MakeSphereVolumeMesh<double>(sphere, edge_length));
+      MakeSphereVolumeMesh<double>(sphere, edge_length, strategy));
 
   const double elastic_modulus =
       validator.Extract(props, kMaterialGroup, kElastic);
@@ -307,8 +312,12 @@ std::optional<SoftGeometry> MakeSoftRepresentation(
   PositiveDouble validator("Ellipsoid", "soft");
   // First, create the mesh.
   const double edge_length = validator.Extract(props, kHydroGroup, kRezHint);
+  // If nothing is said, let's go for the *cheap* tessellation strategy.
+  const TessellationStrategy strategy =
+      props.GetPropertyOrDefault(kHydroGroup, "tessellation_strategy",
+                                 TessellationStrategy::kSingleInteriorVertex);
   auto mesh = make_unique<VolumeMesh<double>>(
-      MakeEllipsoidVolumeMesh<double>(ellipsoid, edge_length));
+      MakeEllipsoidVolumeMesh<double>(ellipsoid, edge_length, strategy));
 
   const double elastic_modulus =
       validator.Extract(props, kMaterialGroup, kElastic);

--- a/geometry/proximity/make_ellipsoid_mesh.h
+++ b/geometry/proximity/make_ellipsoid_mesh.h
@@ -7,6 +7,7 @@
 
 #include "drake/geometry/proximity/make_sphere_mesh.h"
 #include "drake/geometry/proximity/surface_mesh.h"
+#include "drake/geometry/proximity/tessellation_strategy.h"
 #include "drake/geometry/proximity/volume_mesh.h"
 #include "drake/geometry/proximity/volume_to_surface_mesh.h"
 #include "drake/geometry/shape_specification.h"
@@ -40,13 +41,16 @@ namespace internal {
                             octahedron) is guaranteed for any value of
                             `resolution_hint` greater than or equal to the
                             `ellipsoid`'s major axis.
+ @param strategy            The strategy to use to tessellate the sphere. See
+                            TesselationStrategy for details.
  @return The volume mesh for the given ellipsoid.
  @tparam T The Eigen-compatible scalar for representing the mesh vertex
            positions.
 */
 template <typename T>
 VolumeMesh<T> MakeEllipsoidVolumeMesh(const Ellipsoid& ellipsoid,
-                                      double resolution_hint) {
+                                      double resolution_hint,
+                                      TessellationStrategy strategy) {
   DRAKE_DEMAND(resolution_hint > 0.0);
   const double a = ellipsoid.a();
   const double b = ellipsoid.b();
@@ -55,7 +59,7 @@ VolumeMesh<T> MakeEllipsoidVolumeMesh(const Ellipsoid& ellipsoid,
 
   const double unit_sphere_resolution = resolution_hint / r;
   auto unit_sphere_mesh =
-      MakeSphereVolumeMesh<T>(Sphere(1.0), unit_sphere_resolution);
+      MakeSphereVolumeMesh<T>(Sphere(1.0), unit_sphere_resolution, strategy);
 
   const Vector3<T> scale{a, b, c};
   std::vector<VolumeVertex<T>> vertices;
@@ -86,8 +90,8 @@ template <typename T>
 SurfaceMesh<T> MakeEllipsoidSurfaceMesh(const Ellipsoid& ellipsoid,
                                         double resolution_hint) {
   DRAKE_DEMAND(resolution_hint > 0.0);
-  return ConvertVolumeToSurfaceMesh<T>(
-      MakeEllipsoidVolumeMesh<T>(ellipsoid, resolution_hint));
+  return ConvertVolumeToSurfaceMesh<T>(MakeEllipsoidVolumeMesh<T>(
+      ellipsoid, resolution_hint, TessellationStrategy::kSingleInteriorVertex));
 }
 
 }  // namespace internal

--- a/geometry/proximity/tessellation_strategy.h
+++ b/geometry/proximity/tessellation_strategy.h
@@ -1,0 +1,22 @@
+#pragma once
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+/* Describes the possible tessellation strategies available when creating a
+ VolumeMesh from a Shape specification. Not all tessellation algorithms support
+ all strategies. When presented with an unsupported strategy, the algorithm is
+ free to choose to select an alternate default algorithm, throw, warn, or
+ whatever.  */
+enum class TessellationStrategy {
+  /* The interior of the volume mesh has a single vertex.  */
+  kSingleInteriorVertex,
+  /* The interior of the volume mesh has many vertices to maintain well-aspected
+   tetrahedra.  */
+  kDenseInteriorVertices
+};
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/bounding_volume_hierarchy_test.cc
+++ b/geometry/proximity/test/bounding_volume_hierarchy_test.cc
@@ -88,7 +88,8 @@ TEST_F(BVHTest, TestComputeBoundingVolume) {
   // bounding box should encompass the whole ellipsoid with a center of 0 and
   // half width of 1, 2, 3.
   std::vector<std::pair<VolumeElementIndex, Vector3d>> tet_centroids;
-  auto volume_mesh = MakeEllipsoidVolumeMesh<double>(Ellipsoid(1., 2., 3.), 6);
+  auto volume_mesh = MakeEllipsoidVolumeMesh<double>(
+      Ellipsoid(1., 2., 3.), 6, TessellationStrategy::kSingleInteriorVertex);
   for (VolumeElementIndex i(0); i < volume_mesh.num_elements(); ++i) {
     tet_centroids.emplace_back(i, Vector3d(0.5, 0.5, 0.5));
   }
@@ -248,7 +249,8 @@ TEST_F(BVHTest, TestCollideEarlyExit) {
 TEST_F(BVHTest, TestCollideSurfaceVolume) {
   // The two octahedrons are tangentially touching along the X-axis, so there
   // should be 4 elements each that are colliding, resulting in 4^2 = 16.
-  auto volume_mesh = MakeEllipsoidVolumeMesh<double>(Ellipsoid(1.5, 2., 3.), 6);
+  auto volume_mesh = MakeEllipsoidVolumeMesh<double>(
+      Ellipsoid(1.5, 2., 3.), 6, TessellationStrategy::kSingleInteriorVertex);
   BoundingVolumeHierarchy<VolumeMesh<double>> tet_bvh(volume_mesh);
   auto surface_mesh = MakeSphereSurfaceMesh<double>(Sphere(1.5), 3);
   RigidTransformd X_WV{Vector3d{3, 0, 0}};
@@ -270,7 +272,8 @@ GTEST_TEST(BoundingVolumeHierarchyTest, TestComputeCentroid) {
   // 2/3, and 3/3.
   EXPECT_TRUE(CompareMatrices(centroid, Vector3d(1. / 3., 2. / 3., 1.)));
 
-  auto volume_mesh = MakeEllipsoidVolumeMesh<double>(Ellipsoid(1., 2., 3.), 6);
+  auto volume_mesh = MakeEllipsoidVolumeMesh<double>(
+      Ellipsoid(1., 2., 3.), 6, TessellationStrategy::kSingleInteriorVertex);
   centroid = BVHTester::ComputeCentroid<VolumeMesh<double>>(
       volume_mesh, VolumeElementIndex(0));
   // The first face of our octahedron is a tet with vertices at 1, 2, and 3

--- a/geometry/proximity/test/make_ellipsoid_field_test.cc
+++ b/geometry/proximity/test/make_ellipsoid_field_test.cc
@@ -70,7 +70,8 @@ GTEST_TEST(MakeEllipsoidFieldTest, MakeEllipsoidPressureField) {
   // not exactly on the surface of the ellipsoid due to numerical roundings.
   // We do not want to use the coarsest mesh (octahedron) since all vertices
   // are exactly on the coordinate axes.
-  auto mesh = MakeEllipsoidVolumeMesh<double>(ellipsoid, 0.04);
+  auto mesh = MakeEllipsoidVolumeMesh<double>(
+      ellipsoid, 0.04, TessellationStrategy::kDenseInteriorVertices);
   // Confirm that the mesh is not the coarsest one (octahedron).
   ASSERT_GT(mesh.num_vertices(), 7);
   ASSERT_GT(mesh.num_elements(), 8);

--- a/geometry/proximity/test/make_ellipsoid_mesh_test.cc
+++ b/geometry/proximity/test/make_ellipsoid_mesh_test.cc
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/geometry/proximity/tessellation_strategy.h"
 #include "drake/geometry/shape_specification.h"
 
 namespace drake {
@@ -20,14 +21,16 @@ GTEST_TEST(MakeEllipsoidMeshTest, MakeEllipsoidVolumeMesh) {
   // axis 16cm. The coarsest mesh is an octahedron with 7 vertices and 8
   // tetrahedra.
   {
-    const auto coarse_mesh = MakeEllipsoidVolumeMesh<double>(ellipsoid, 0.16);
+    const auto coarse_mesh = MakeEllipsoidVolumeMesh<double>(
+        ellipsoid, 0.16, TessellationStrategy::kDenseInteriorVertices);
     EXPECT_EQ(7, coarse_mesh.num_vertices());
     EXPECT_EQ(8, coarse_mesh.num_elements());
   }
   // Cutting the resolution_hint in half from 16cm down to 8cm increases
   // the number of tetrahedra by 8X.
   {
-    const auto medium_mesh = MakeEllipsoidVolumeMesh<double>(ellipsoid, 0.08);
+    const auto medium_mesh = MakeEllipsoidVolumeMesh<double>(
+        ellipsoid, 0.08, TessellationStrategy::kDenseInteriorVertices);
     EXPECT_EQ(64, medium_mesh.num_elements());
   }
 }

--- a/geometry/proximity/test/make_sphere_field_test.cc
+++ b/geometry/proximity/test/make_sphere_field_test.cc
@@ -69,7 +69,8 @@ GTEST_TEST(MakeSphereFieldTest, MakeSpherePressureField) {
   // not exactly on the surface of the sphere due to numerical roundings. We do
   // not want to use the coarsest mesh (octahedron) since all vertices are
   // exactly on the coordinate axes.
-  auto mesh = MakeSphereVolumeMesh<double>(sphere, 0.25);
+  auto mesh = MakeSphereVolumeMesh<double>(
+      sphere, 0.25, TessellationStrategy::kDenseInteriorVertices);
   // Confirm that the mesh is not the coarsest one (octahedron).
   ASSERT_GT(mesh.num_vertices(), 7);
   ASSERT_GT(mesh.num_elements(), 8);

--- a/geometry/proximity/test/make_sphere_mesh_test.cc
+++ b/geometry/proximity/test/make_sphere_mesh_test.cc
@@ -8,6 +8,7 @@
 #include "drake/common/eigen_types.h"
 #include "drake/common/sorted_pair.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/geometry/proximity/tessellation_strategy.h"
 
 namespace drake {
 namespace geometry {
@@ -31,6 +32,30 @@ using Eigen::Vector3d;
 // N.B. All of these were confirmed during the development however they did not
 // make it into a clean unit test.
 
+GTEST_TEST(MakeSphereMesh, InvariantsOfLevelZeroMesh) {
+  auto [mesh, is_boundary] = MakeSphereMeshLevel0<double>();
+
+  // There is only one vertex marked `false` in is_boundary -- the vertex at
+  // (0, 0, 0).
+  int count = 0;
+  VolumeVertexIndex center_index;
+  for (VolumeVertexIndex i(0); i < static_cast<int>(is_boundary.size()); ++i) {
+    if (is_boundary[i] == false) {
+      ++count;
+      center_index = i;
+    }
+  }
+  EXPECT_EQ(count, 1);
+  EXPECT_EQ(mesh.vertex(center_index).r_MV(), Vector3d(0, 0, 0));
+
+  // Every vertex references the center index _and_ it is the fourth vertex
+  // in each tet.
+  for (VolumeElementIndex t(0); t < mesh.num_elements(); ++t) {
+    const VolumeElement& tet = mesh.element(t);
+    EXPECT_EQ(tet.vertex(3), center_index);
+  }
+}
+
 // Computes the total volume of a VolumeMesh by summing up the contribution
 // of each tetrahedron.
 double CalcTetrahedronMeshVolume(const VolumeMesh<double>& mesh) {
@@ -46,36 +71,43 @@ double CalcTetrahedronMeshVolume(const VolumeMesh<double>& mesh) {
 GTEST_TEST(MakeSphereMesh, VolumeConvergence) {
   const double kTolerance = 5.0 * std::numeric_limits<double>::epsilon();
 
-  auto mesh0 = MakeUnitSphereMesh<double>(0);
-  const double volume0 = CalcTetrahedronMeshVolume(mesh0);
-  const double sphere_volume = 4.0 / 3.0 * M_PI;
-  // Initial error in the computation of the volume.
-  double prev_error = sphere_volume - volume0;
+  for (auto strategy : {TessellationStrategy::kSingleInteriorVertex,
+                        TessellationStrategy::kDenseInteriorVertices}) {
+    auto mesh0 = MakeUnitSphereMesh<double>(0, strategy);
+    const double volume0 = CalcTetrahedronMeshVolume(mesh0);
+    const double sphere_volume = 4.0 / 3.0 * M_PI;
+    // Initial error in the computation of the volume.
+    double prev_error = sphere_volume - volume0;
 
-  // The volume of a pyramid with base of size l x w and height h is V = lwh/3.
-  // For our level zero octahedron we have two pyramids with sizes
-  // l = w = sqrt(2) and height = 1.0. Thus its volume is 4/3.
-  const double expected_volume = 4.0 / 3.0;
+    // The volume of a pyramid with base of size l x w and height h is V =
+    // lwh/3. For our level zero octahedron we have two pyramids with sizes l =
+    // w = sqrt(2) and height = 1.0. Thus its volume is 4/3.
+    const double expected_volume = 4.0 / 3.0;
 
-  EXPECT_NEAR(volume0, expected_volume, kTolerance);
+    EXPECT_NEAR(volume0, expected_volume, kTolerance);
 
-  for (int level = 1; level < 6; ++level) {
-    auto mesh = MakeUnitSphereMesh<double>(level);
+    const int tet_growth =
+        strategy == TessellationStrategy::kSingleInteriorVertex ? 4 : 8;
 
-    // Verify correct size.
-    const size_t num_tetrahedra = std::pow(8, level + 1);
-    EXPECT_EQ(mesh.tetrahedra().size(), num_tetrahedra);
+    for (int level = 1; level < 6; ++level) {
+      auto mesh = MakeUnitSphereMesh<double>(level, strategy);
 
-    // Verify that the volume monotonically converges towards the exact volume
-    // of the unit radius sphere.
-    const double volume = CalcTetrahedronMeshVolume(mesh);
-    const double error = sphere_volume - volume;
+      // Verify correct size.
+      const size_t num_tetrahedra = 8 * std::pow(tet_growth, level);
+      EXPECT_EQ(mesh.tetrahedra().size(), num_tetrahedra);
 
-    EXPECT_GT(error, 0.0);
-    EXPECT_LT(error, prev_error);
+      // Verify that the volume monotonically converges towards the exact volume
+      // of the unit radius sphere.
+      const double volume = CalcTetrahedronMeshVolume(mesh);
+      const double error = sphere_volume - volume;
 
-    // Always compare against last computed error to show monotonic convergence.
-    prev_error = error;
+      EXPECT_GT(error, 0.0);
+      EXPECT_LT(error, prev_error);
+
+      // Always compare against last computed error to show monotonic
+      // convergence.
+      prev_error = error;
+    }
   }
 }
 
@@ -87,7 +119,8 @@ GTEST_TEST(MakeSphereMesh, NoDuplicateVertices) {
   // Expected number of vertices based on [Everett, 1997].
   const std::vector<int> expected_v_count{7, 25, 129, 833};
   for (int i = 0; i < 4; ++i) {
-    VolumeMesh<double> mesh = MakeUnitSphereMesh<double>(i);
+    VolumeMesh<double> mesh = MakeUnitSphereMesh<double>(
+        i, TessellationStrategy::kDenseInteriorVertices);
     EXPECT_EQ(mesh.num_vertices(), expected_v_count[i]);
     EXPECT_EQ(mesh.num_elements(), std::pow(8, i + 1));
   }
@@ -97,7 +130,8 @@ GTEST_TEST(MakeSphereMesh, NoDuplicateVertices) {
 
 // Smoke test to confirm the calculations work with the Autodiff scalar.
 GTEST_TEST(MakeSphereMesh, AutoDiffRefinement) {
-  VolumeMesh<AutoDiffXd> mesh1 = MakeUnitSphereMesh<AutoDiffXd>(1);
+  VolumeMesh<AutoDiffXd> mesh1 = MakeUnitSphereMesh<AutoDiffXd>(
+      1, TessellationStrategy::kDenseInteriorVertices);
   EXPECT_EQ(mesh1.num_vertices(), 25);
   EXPECT_EQ(mesh1.num_elements(), 64);
 }
@@ -240,13 +274,17 @@ GTEST_TEST(MakeSphereVolumeMesh, ConfirmEdgeLength) {
   // a length slightly longer (1.5 * r) to test the base case. After that simply
   // values that decrease by half. We also confirm tet count increases when we
   // cut things in half.
-  int previous_tet_count = 0;
-  for (const double edge_length : {1.5 * r, r, r / 2, r / 4}) {
-    VolumeMesh<double> mesh = MakeSphereVolumeMesh<double>(sphere, edge_length);
-    int current_tet_count = mesh.num_elements();
-    EXPECT_LT(previous_tet_count, current_tet_count);
-    previous_tet_count = current_tet_count;
-    test_equator(mesh, edge_length);
+  for (auto strategy : {TessellationStrategy::kSingleInteriorVertex,
+                        TessellationStrategy::kDenseInteriorVertices}) {
+    int previous_tet_count = 0;
+    for (const double edge_length : {1.5 * r, r, r / 2, r / 4}) {
+      VolumeMesh<double> mesh =
+          MakeSphereVolumeMesh<double>(sphere, edge_length, strategy);
+      int current_tet_count = mesh.num_elements();
+      EXPECT_LT(previous_tet_count, current_tet_count);
+      previous_tet_count = current_tet_count;
+      test_equator(mesh, edge_length);
+    }
   }
 }
 
@@ -255,7 +293,8 @@ GTEST_TEST(MakeSphereVolumeMesh, ConfirmEdgeLength) {
 GTEST_TEST(MakeSphereVolumeMesh, MassiveEdgeLength) {
   const Sphere sphere(1.5);
   const double edge_length = 3 * sphere.radius();
-  VolumeMesh<double> mesh = MakeSphereVolumeMesh<double>(sphere, edge_length);
+  VolumeMesh<double> mesh = MakeSphereVolumeMesh<double>(
+      sphere, edge_length, TessellationStrategy::kDenseInteriorVertices);
   EXPECT_EQ(mesh.num_elements(), 8);
   EXPECT_EQ(mesh.num_vertices(), 7);
 }
@@ -270,6 +309,99 @@ GTEST_TEST(MakeSphereSurfaceMesh, GenerateSurface) {
       MakeSphereSurfaceMesh<double>(sphere, edge_length);
   EXPECT_EQ(surface_mesh.num_faces(), 8);
   EXPECT_EQ(surface_mesh.num_vertices(), 6);
+}
+
+// The sparse sphere should enclose the exact same volume as the dense mesh.
+// Therefore, we'll test it by comparing certain properties against the dense
+// volume mesh.
+
+// Confirm that the coarsest mesh (level 0 refinement) is the same whether
+// "dense internal vertices" are requested or not.
+GTEST_TEST(SparseSphereTest, Level0Identical) {
+  VolumeMesh<double> dense_0 = MakeUnitSphereMesh<double>(
+      0, TessellationStrategy::kDenseInteriorVertices);
+  VolumeMesh<double> sparse_0 = MakeUnitSphereMesh<double>(
+      0, TessellationStrategy::kSingleInteriorVertex);
+  EXPECT_TRUE(dense_0.Equal(sparse_0));
+}
+
+// We want the surface of the volume mesh to be the same, regardless of the
+// internal sampling.
+GTEST_TEST(SparseSphereTest, SurfaceMatchesDenseMesh) {
+  // We're skipping level 0 because it is perfectly handled by the
+  // (SparseSphereTest, Level0Identical).
+  for (int level = 1; level < 3; ++level) {
+    const VolumeMesh<double> dense_mesh = MakeUnitSphereMesh<double>(
+        level, TessellationStrategy::kDenseInteriorVertices);
+    const SurfaceMesh<double> dense_surface =
+        ConvertVolumeToSurfaceMesh<double>(dense_mesh);
+    const VolumeMesh<double> sparse_mesh = MakeUnitSphereMesh<double>(
+        level, TessellationStrategy::kSingleInteriorVertex);
+    SurfaceMesh<double> sparse_surface =
+        ConvertVolumeToSurfaceMesh<double>(sparse_mesh);
+
+    // We can't use SurfaceMesh::Equal because we're not guaranteed the vertex
+    // or triangle ordering is the same.
+    ASSERT_EQ(dense_surface.num_elements(), sparse_surface.num_elements());
+    ASSERT_EQ(dense_surface.num_vertices(), sparse_surface.num_vertices());
+
+    // TODO(SeanCurtis-TRI): For completeness, consider actually doing
+    //  vertex-to-vertex and triangle-to-triangle mapping. As it stands, this
+    //  isn't *proof* of correctness, merely a positive indicator.
+  }
+}
+
+// Count the number of vertices that lie on the surface of a sphere with the
+// given radius.
+int CountSurfaceVertices(const VolumeMesh<double>& mesh, double radius = 1.0) {
+  const double kEps = std::numeric_limits<double>::epsilon() * radius;
+  int count = 0;
+  for (VolumeVertexIndex v(0); v < mesh.num_vertices(); ++v) {
+    const double r = mesh.vertex(v).r_MV().norm();
+    // This is a very tight tolerance. That's good. We want to know that the
+    // surface vertices are as close to the surface of the sphere as can
+    // possibly be represented by doubles. If changes in the algorithm cause
+    // this test to fail, the algorithm should change to meet this high standard
+    // instead of loosening the tolerance.
+    if (std::abs(r - radius) <= kEps) ++count;
+  }
+  return count;
+}
+
+// Refines with single interior vertex. We confirm that only a single vertex is
+// not radius distance from the origin. We also confirm the implication of this
+// that each level of refinment has 4X the previous number of tets.
+GTEST_TEST(SparseSphereTest, RefinesWithSingleInteriorVertex) {
+  const TessellationStrategy strategy =
+      TessellationStrategy::kSingleInteriorVertex;
+
+  // Level 0 mesh
+  VolumeMesh<double> mesh0 = MakeUnitSphereMesh<double>(0, strategy);
+  EXPECT_EQ(CountSurfaceVertices(mesh0), mesh0.num_vertices() - 1);
+  EXPECT_EQ(mesh0.num_elements(), 8);
+
+  int prev_tet_count = 8;
+  for (int level = 1; level < 6; ++level) {
+    VolumeMesh<double> mesh_i =
+        MakeUnitSphereMesh<double>(level, strategy);
+    EXPECT_EQ(mesh_i.num_elements(), prev_tet_count * 4);
+    prev_tet_count *= 4;
+    EXPECT_EQ(CountSurfaceVertices(mesh_i), mesh_i.num_vertices() - 1);
+  }
+}
+
+// Simply confirms that calling MakeSphereVolumeMesh respects the
+// strategy parameter. All other aspects of that function  (e.g., limits on
+// refinment level and effect of resolution_hint has been tested elsewhere).
+GTEST_TEST(SparseSphereTest, SparseSphereOfArbitraryRadius) {
+  const double r = 1.5;
+  Sphere sphere(r);
+
+  // A resolution hint equal to the radius will produce a level-1 refinement
+  // which has 8 * 4 tets (in contrast to 8 * 8 for a dense mesh).
+  VolumeMesh<double> mesh = MakeSphereVolumeMesh<double>(
+      sphere, r, TessellationStrategy::kSingleInteriorVertex);
+  EXPECT_EQ(mesh.num_elements(), 32);
 }
 
 }  // namespace

--- a/multibody/hydroelastics/hydroelastic_field_sphere.h
+++ b/multibody/hydroelastics/hydroelastic_field_sphere.h
@@ -12,6 +12,8 @@ namespace multibody {
 namespace hydroelastics {
 namespace internal {
 
+// TODO(SeanCurtis-TRI): This appears to be unused and untested. Delete me!
+
 /// Creates a HydroelasticField for a sphere of a given radius.
 /// The input parameter `refinement_level`, ℓ ∈ ℕ₀, controls the resolution of
 /// the mesh generated. The resulting number of tetrahedra nₜ can
@@ -31,9 +33,10 @@ namespace internal {
 /// requirements; a quadratic function of the radius, ε(r) = 0.5 [1 - (r / R)²].
 template <typename T>
 std::unique_ptr<HydroelasticField<T>> MakeSphereHydroelasticField(
-    int refinement_level, double sphere_radius) {
+    int refinement_level, double sphere_radius,
+    geometry::internal::TessellationStrategy strategy) {
   geometry::VolumeMesh<T> unit_sphere_mesh =
-      geometry::internal::MakeUnitSphereMesh<T>(refinement_level);
+      geometry::internal::MakeUnitSphereMesh<T>(refinement_level, strategy);
 
   // Scale the unit sphere to have the desired radius.
   std::vector<geometry::VolumeElement> tetrahedra =

--- a/multibody/hydroelastics/test/contact_surface_from_level_set_test.cc
+++ b/multibody/hydroelastics/test/contact_surface_from_level_set_test.cc
@@ -21,6 +21,7 @@ namespace internal {
 namespace {
 
 using drake::geometry::internal::MakeUnitSphereMesh;
+using drake::geometry::internal::TessellationStrategy;
 using drake::geometry::SurfaceFace;
 using drake::geometry::SurfaceFaceIndex;
 using drake::geometry::SurfaceMesh;
@@ -514,7 +515,8 @@ GTEST_TEST(SpherePlaneIntersectionTest, VerifyInterpolations) {
 
   // A tessellation of a unit sphere. Vertices are in the mesh frame M.
   // This creates a volume mesh with over 32K tetrahedra.
-  const VolumeMesh<double> sphere_M = MakeUnitSphereMesh<double>(4);
+  const VolumeMesh<double> sphere_M = MakeUnitSphereMesh<double>(
+      4, TessellationStrategy::kDenseInteriorVertices);
 
   // We generate scalar and vector fields linear in the position coordinates.
   // Since CalcZeroLevelSetInMeshDomain() uses linear interpolations, we


### PR DESCRIPTION
Rather than creating a sphere by sub-dividing *all* edges of the previous level of refinement, we refine only those edges on the surface of the sphere.

The resultant mesh has a single interior vertex (at the sphere origin) and all of the resolution increases curvature. In contrast to the interior vertices which increases the number of tets by a factor of 8 each time, this only increases it by a factor of 4.

It retains an option to tessellate on the interior as well, but no longer defaults to that.

This also provides a mechanism through proximity properties to toggle what type of sphere tessellation is used. An optional parameter (kHydroGroup, "sparse_mesh") has been added which will control whether the sphere gets tessellated on the interior or not (defaults to not).

This cascaded to a number of other pieces of code that made use of the sphere. The ellipsoid representation as well as the tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13114)
<!-- Reviewable:end -->
