### PR TITLE
[WIP](do not review yet)[geometry] Optimize mesh_intersection to use std::vector as member variables.

### DIFF
--- a/geometry/benchmarking/mesh_intersection_benchmark.cc
+++ b/geometry/benchmarking/mesh_intersection_benchmark.cc
@@ -277,7 +277,8 @@ BENCHMARK_DEFINE_F(MeshIntersectionBenchmark, WithoutBVH)
   std::unique_ptr<SurfaceMesh<double>> surface_SR;
   std::unique_ptr<SurfaceMeshFieldLinear<double, double>> e_SR;
   for (auto _ : state) {
-    SampleVolumeFieldOnSurface(field_S_, mesh_R_, X_SR_, &surface_SR, &e_SR);
+    IntersectVolumeFieldSurfaceMesh<double>().SampleVolumeFieldOnSurface(
+        field_S_, mesh_R_, X_SR_, &surface_SR, &e_SR);
   }
   RecordContactSurfaceResult(surface_SR.get(), "WithoutBVH", state);
 }
@@ -310,8 +311,8 @@ BENCHMARK_DEFINE_F(MeshIntersectionBenchmark, ___WithBVH)
   std::unique_ptr<SurfaceMesh<double>> surface_SR;
   std::unique_ptr<SurfaceMeshFieldLinear<double, double>> e_SR;
   for (auto _ : state) {
-    SampleVolumeFieldOnSurface(field_S_, bvh_S, mesh_R_, bvh_R, X_SR_,
-                               &surface_SR, &e_SR);
+    IntersectVolumeFieldSurfaceMesh<double>().SampleVolumeFieldOnSurface(
+        field_S_, bvh_S, mesh_R_, bvh_R, X_SR_, &surface_SR, &e_SR);
   }
   RecordContactSurfaceResult(surface_SR.get(), "___WithBVH", state);
 }

--- a/geometry/proximity/mesh_intersection.cc
+++ b/geometry/proximity/mesh_intersection.cc
@@ -46,8 +46,9 @@ namespace internal {
 
 // TODO(DamrongGuoy): Handle the case that the line is parallel to the plane.
 template <typename T>
-Vector3<T> CalcIntersection(const Vector3<T>& p_FA, const Vector3<T>& p_FB,
-                            const PosedHalfSpace<T>& H_F) {
+Vector3<T> IntersectVolumeFieldSurfaceMesh<T>::CalcIntersection(
+    const Vector3<T>& p_FA, const Vector3<T>& p_FB,
+    const PosedHalfSpace<T>& H_F) {
   const T a = H_F.CalcSignedDistance(p_FA);
   const T b = H_F.CalcSignedDistance(p_FB);
   // We require that A and B classify in opposite directions (one inside and one
@@ -88,7 +89,8 @@ Vector3<T> CalcIntersection(const Vector3<T>& p_FA, const Vector3<T>& p_FB,
 }
 
 template <typename T>
-std::vector<Vector3<T>> ClipPolygonByHalfSpace(
+std::vector<Vector3<T>>
+IntersectVolumeFieldSurfaceMesh<T>::ClipPolygonByHalfSpace(
     const std::vector<Vector3<T>>& polygon_vertices_F,
     const PosedHalfSpace<T>& H_F) {
   // Note: this is the inner loop of a modified Sutherland-Hodgman algorithm for
@@ -127,7 +129,8 @@ std::vector<Vector3<T>> ClipPolygonByHalfSpace(
 }
 
 template <typename T>
-std::vector<Vector3<T>> RemoveDuplicateVertices(
+std::vector<Vector3<T>>
+IntersectVolumeFieldSurfaceMesh<T>::RemoveDuplicateVertices(
     std::vector<Vector3<T>> polygon) {
   // TODO(SeanCurtis-TRI): The resulting polygon depends on the order of the
   //  inputs. Imagine I have vertices A, A', A'' (such that |X - X'| < eps.
@@ -176,7 +179,8 @@ std::vector<Vector3<T>> RemoveDuplicateVertices(
 }
 
 template <typename T>
-std::vector<Vector3<T>> ClipTriangleByTetrahedron(
+std::vector<Vector3<T>>
+IntersectVolumeFieldSurfaceMesh<T>::ClipTriangleByTetrahedron(
     VolumeElementIndex element, const VolumeMesh<T>& volume_M,
     SurfaceFaceIndex face, const SurfaceMesh<T>& surface_N,
     const math::RigidTransform<T>& X_MN) {
@@ -256,7 +260,7 @@ std::vector<Vector3<T>> ClipTriangleByTetrahedron(
 }
 
 template <typename T>
-bool IsFaceNormalAlongPressureGradient(
+bool IntersectVolumeFieldSurfaceMesh<T>::IsFaceNormalAlongPressureGradient(
     const VolumeMeshField<T, T>& volume_field_M,
     const SurfaceMesh<T>& surface_N, const math::RigidTransform<T>& X_MN,
     const VolumeElementIndex& tet_index, const SurfaceFaceIndex& tri_index) {
@@ -272,7 +276,7 @@ bool IsFaceNormalAlongPressureGradient(
 }
 
 template <typename T>
-void SampleVolumeFieldOnSurface(
+void IntersectVolumeFieldSurfaceMesh<T>::SampleVolumeFieldOnSurface(
     const VolumeMeshField<T, T>& volume_field_M,
     const SurfaceMesh<T>& surface_N,
     const math::RigidTransform<T>& X_MN,
@@ -347,7 +351,7 @@ void SampleVolumeFieldOnSurface(
 /** A variant of SampleVolumeFieldOnSurface but with broad-phase culling to
  reduce the number of element-pairs evaluated.  */
 template <typename T>
-void SampleVolumeFieldOnSurface(
+void IntersectVolumeFieldSurfaceMesh<T>::SampleVolumeFieldOnSurface(
     const VolumeMeshField<T, T>& volume_field_M,
     const BoundingVolumeHierarchy<VolumeMesh<T>>& bvh_M,
     const SurfaceMesh<T>& surface_N,
@@ -361,11 +365,11 @@ void SampleVolumeFieldOnSurface(
   const auto& mesh_M = volume_field_M.mesh();
 
   auto callback = [&volume_field_M, &surface_N, &surface_faces,
-                   &surface_vertices_M, &surface_e, &mesh_M,
-                   &X_MN](VolumeElementIndex tet_index,
-                          SurfaceFaceIndex tri_index) -> BvttCallbackResult {
-    if (!IsFaceNormalAlongPressureGradient(volume_field_M, surface_N, X_MN,
-                                           tet_index, tri_index)) {
+                   &surface_vertices_M, &surface_e, &mesh_M, &X_MN,
+                   this](VolumeElementIndex tet_index,
+                         SurfaceFaceIndex tri_index) -> BvttCallbackResult {
+    if (!this->IsFaceNormalAlongPressureGradient(volume_field_M, surface_N,
+                                                 X_MN, tet_index, tri_index)) {
       return BvttCallbackResult::Continue;
     }
 
@@ -379,8 +383,9 @@ void SampleVolumeFieldOnSurface(
     //  if the broadphase culling determines the surface and volume are
     //  disjoint regions, *no* vertices will be transformed. Unclear what the
     //  best balance for best average performance.
-    std::vector<Vector3<T>> polygon_vertices_M = ClipTriangleByTetrahedron(
-        tet_index, mesh_M, tri_index, surface_N, X_MN);
+    std::vector<Vector3<T>> polygon_vertices_M =
+        this->ClipTriangleByTetrahedron(tet_index, mesh_M, tri_index, surface_N,
+                                        X_MN);
 
     const int poly_vertex_count = static_cast<int>(polygon_vertices_M.size());
     if (poly_vertex_count < 3) return BvttCallbackResult::Continue;
@@ -448,7 +453,8 @@ ComputeContactSurfaceFromSoftVolumeRigidSurface(
   std::unique_ptr<SurfaceMesh<T>> surface_SR;
   std::unique_ptr<SurfaceMeshFieldLinear<T, T>> e_SR;
 
-  SampleVolumeFieldOnSurface(field_S, mesh_R, X_SR, &surface_SR, &e_SR);
+  IntersectVolumeFieldSurfaceMesh<T>().SampleVolumeFieldOnSurface(
+      field_S, mesh_R, X_SR, &surface_SR, &e_SR);
 
   if (surface_SR == nullptr) return nullptr;
 
@@ -494,8 +500,8 @@ ComputeContactSurfaceFromSoftVolumeRigidSurface(
   std::unique_ptr<SurfaceMesh<T>> surface_SR;
   std::unique_ptr<SurfaceMeshFieldLinear<T, T>> e_SR;
 
-  SampleVolumeFieldOnSurface(field_S, bvh_S, mesh_R, bvh_R, X_SR, &surface_SR,
-                             &e_SR);
+  IntersectVolumeFieldSurfaceMesh<T>().SampleVolumeFieldOnSurface(
+      field_S, bvh_S, mesh_R, bvh_R, X_SR, &surface_SR, &e_SR);
 
   if (surface_SR == nullptr) return nullptr;
 
@@ -515,43 +521,12 @@ ComputeContactSurfaceFromSoftVolumeRigidSurface(
                                              std::move(e_SR));
 }
 
-template Vector3<double> CalcIntersection(const Vector3<double>& p_FA,
-                                          const Vector3<double>& p_FB,
-                                          const PosedHalfSpace<double>& H_F);
-
-template std::vector<Vector3<double>> ClipPolygonByHalfSpace(
-    const std::vector<Vector3<double>>& polygon_vertices_F,
-    const PosedHalfSpace<double>& H_F);
-
-template std::vector<Vector3<double>> RemoveDuplicateVertices(
-    std::vector<Vector3<double>> polygon);
-
-template std::vector<Vector3<double>> ClipTriangleByTetrahedron(
-    VolumeElementIndex element, const VolumeMesh<double>& volume_M,
-    SurfaceFaceIndex face, const SurfaceMesh<double>& surface_N,
-    const math::RigidTransform<double>& X_MN);
-
-template bool IsFaceNormalAlongPressureGradient(
-    const VolumeMeshField<double, double>& volume_field_M,
-    const SurfaceMesh<double>& surface_N,
-    const math::RigidTransform<double>& X_MN,
-    const VolumeElementIndex& tet_index, const SurfaceFaceIndex& tri_index);
-
-template void SampleVolumeFieldOnSurface(
-    const VolumeMeshField<double, double>& volume_field_M,
-    const SurfaceMesh<double>& surface_N,
-    const math::RigidTransform<double>& X_MN,
-    std::unique_ptr<SurfaceMesh<double>>* surface_MN_M,
-    std::unique_ptr<SurfaceMeshFieldLinear<double, double>>* e_MN);
-
-template void SampleVolumeFieldOnSurface(
-    const VolumeMeshField<double, double>& volume_field_M,
-    const BoundingVolumeHierarchy<VolumeMesh<double>>& bvh_M,
-    const SurfaceMesh<double>& surface_N,
-    const BoundingVolumeHierarchy<SurfaceMesh<double>>& bvh_N,
-    const math::RigidTransform<double>& X_MN,
-    std::unique_ptr<SurfaceMesh<double>>* surface_MN_M,
-    std::unique_ptr<SurfaceMeshFieldLinear<double, double>>* e_MN);
+template class IntersectVolumeFieldSurfaceMesh<double>;
+// This template instantiation:
+//   template class IntersectVolumeFieldSurfaceMesh<AutoDiffXd>;
+// triggers compile error because:
+//   BoundingVolumeHierarchy<VolumeMesh<T>>& bvh_M
+// does not support VolumeMesh<AutoDiffXd>.
 
 template std::unique_ptr<ContactSurface<double>>
 ComputeContactSurfaceFromSoftVolumeRigidSurface(
@@ -608,3 +583,4 @@ ComputeContactSurfaceFromSoftVolumeRigidSurface(
 }  // namespace internal
 }  // namespace geometry
 }  // namespace drake
+

--- a/geometry/proximity/mesh_intersection.h
+++ b/geometry/proximity/mesh_intersection.h
@@ -18,6 +18,66 @@ namespace drake {
 namespace geometry {
 namespace internal {
 
+// Forward declaration of Tester class, so we can grant friend access.
+template <typename T> class IntersectVolumeFieldSurfaceMeshTester;
+
+template <typename T>
+class IntersectVolumeFieldSurfaceMesh {
+ public:
+// TODO(DamrongGuoy): Maintain book keeping to avoid duplicate vertices and
+//  remove the note in the function documentation.
+
+/** Samples a field on a two-dimensional manifold. The field is defined over
+ a volume mesh and the manifold is the intersection of the volume mesh and a
+ surface mesh. The resulting manifold's topology is a function of both the
+ volume and surface mesh topologies. The winding of the resulting manifold's
+ faces will be such that its face normals will point in the same direction as
+ the input surface mesh's corresponding faces.
+ Computes the intersecting surface `surface_MN` between a soft geometry M
+ and a rigid geometry N, and sets the pressure field and the normal vector
+ field on `surface_MN`. This does not use any broadphase culling but compares
+ each element of the meshes.
+ @param[in] volume_field_M
+     The field to sample from. The field contains the volume mesh M that defines
+     its domain. The vertex positions of the mesh are measured and expressed in
+     frame M. And the field can be evaluated at positions likewise measured and
+     expressed in frame M.
+ @param[in] surface_N
+     The surface mesh intersected with the volume mesh to define the sample
+     domain. Its vertex positions are measured and expressed in frame N.
+ @param[in] X_MN
+     The pose of frame N in frame M.
+ @param[out] surface_MN_M
+     The intersecting surface between the volume mesh M and the surface N.
+     Vertex positions are measured and expressed in M's frame. If no
+     intersection exists, this will not change.
+ @param[out] e_MN
+     The sampled field values on the intersecting surface (samples to support
+     a linear mesh field -- i.e., one per vertex). If no intersection exists,
+     this will not change.
+ @note
+     The output surface mesh may have duplicate vertices.
+ @tparam T Currently, only T = double is supported.
+ */
+  void SampleVolumeFieldOnSurface(
+      const VolumeMeshField<T, T>& volume_field_M,
+      const SurfaceMesh<T>& surface_N,
+      const math::RigidTransform<T>& X_MN,
+      std::unique_ptr<SurfaceMesh<T>>* surface_MN_M,
+      std::unique_ptr<SurfaceMeshFieldLinear<T, T>>* e_MN);
+
+/** A variant of SampleVolumeFieldOnSurface but with broad-phase culling to
+ reduce the number of element-pairs evaluated.  */
+  void SampleVolumeFieldOnSurface(
+      const VolumeMeshField<T, T>& volume_field_M,
+      const BoundingVolumeHierarchy<VolumeMesh<T>>& bvh_M,
+      const SurfaceMesh<T>& surface_N,
+      const BoundingVolumeHierarchy<SurfaceMesh<T>>& bvh_N,
+      const math::RigidTransform<T>& X_MN,
+      std::unique_ptr<SurfaceMesh<T>>* surface_MN_M,
+      std::unique_ptr<SurfaceMeshFieldLinear<T, T>>* e_MN);
+
+ private:
 /** Calculates the intersection point between an infinite straight line spanning
  points A and B and the bounding plane of the half space H.
  @param p_FA
@@ -36,9 +96,8 @@ namespace internal {
         of the half space.
  @tparam T Currently, only T = double is supported.
  */
-template <typename T>
-Vector3<T> CalcIntersection(const Vector3<T>& p_FA, const Vector3<T>& p_FB,
-                            const PosedHalfSpace<T>& H_F);
+  Vector3<T> CalcIntersection(const Vector3<T>& p_FA, const Vector3<T>& p_FB,
+                              const PosedHalfSpace<T>& H_F);
 
 // TODO(SeanCurtis-TRI): This function duplicates functionality implemented in
 //  mesh_half_space_intersection.h. Reconcile the two implementations.
@@ -80,10 +139,9 @@ Vector3<T> CalcIntersection(const Vector3<T>& p_FA, const Vector3<T>& p_FB,
         triangle with three duplicate vertices.
  @tparam T Currently, only T = double is supported.
 */
-template <typename T>
-std::vector<Vector3<T>> ClipPolygonByHalfSpace(
-    const std::vector<Vector3<T>>& polygon_vertices_F,
-    const PosedHalfSpace<T>& H_F);
+  std::vector<Vector3<T>> ClipPolygonByHalfSpace(
+      const std::vector<Vector3<T>>& polygon_vertices_F,
+      const PosedHalfSpace<T>& H_F);
 
 /** Remove duplicate vertices from a polygon represented as a cyclical sequence
  of vertex positions. In other words, for a sequence `A,B,B,C,A`, the pair of
@@ -97,9 +155,8 @@ std::vector<Vector3<T>> ClipPolygonByHalfSpace(
      The equivalent polygon with no duplicate vertices.
  @tparam T Currently, only T = double is supported.
  */
-template <typename T>
-std::vector<Vector3<T>> RemoveDuplicateVertices(
-    std::vector<Vector3<T>> polygon);
+  std::vector<Vector3<T>> RemoveDuplicateVertices(
+      std::vector<Vector3<T>> polygon);
 
 /** Intersects a triangle with a tetrahedron, returning the portion of the
  triangle with non-zero area contained in the tetrahedron.
@@ -129,11 +186,10 @@ std::vector<Vector3<T>> RemoveDuplicateVertices(
         tetrahedron (non-zero area restriction still applies).
  @tparam T Currently, only T = double is supported.
  */
-template <typename T>
-std::vector<Vector3<T>> ClipTriangleByTetrahedron(
-    VolumeElementIndex element, const VolumeMesh<T>& volume_M,
-    SurfaceFaceIndex face, const SurfaceMesh<T>& surface_N,
-    const math::RigidTransform<T>& X_MN);
+  std::vector<Vector3<T>> ClipTriangleByTetrahedron(
+      VolumeElementIndex element, const VolumeMesh<T>& volume_M,
+      SurfaceFaceIndex face, const SurfaceMesh<T>& surface_N,
+      const math::RigidTransform<T>& X_MN);
 
 /** Determines whether a triangle of a rigid surface N and a tetrahedron of a
  soft volume M are suitable for building contact surface based on the face
@@ -213,69 +269,13 @@ std::vector<Vector3<T>> ClipTriangleByTetrahedron(
           See @ref module_contact_surface.
  @tparam T Currently, only T = double is supported.
  */
-template <typename T>
-bool IsFaceNormalAlongPressureGradient(
-    const VolumeMeshField<T, T>& volume_field_M,
-    const SurfaceMesh<T>& surface_N, const math::RigidTransform<T>& X_MN,
-    const VolumeElementIndex& tet_index, const SurfaceFaceIndex& tri_index);
+  bool IsFaceNormalAlongPressureGradient(
+      const VolumeMeshField<T, T>& volume_field_M,
+      const SurfaceMesh<T>& surface_N, const math::RigidTransform<T>& X_MN,
+      const VolumeElementIndex& tet_index, const SurfaceFaceIndex& tri_index);
 
-// TODO(DamrongGuoy): Maintain book keeping to avoid duplicate vertices and
-//  remove the note in the function documentation.
-
-// TODO(tehbelinda): Restructure how the intersecting mesh and field are
-// returned and stop passing around bare pointers to unique_ptrs.
-
-/** Samples a field on a two-dimensional manifold. The field is defined over
- a volume mesh and the manifold is the intersection of the volume mesh and a
- surface mesh. The resulting manifold's topology is a function of both the
- volume and surface mesh topologies. The winding of the resulting manifold's
- faces will be such that its face normals will point in the same direction as
- the input surface mesh's corresponding faces.
- Computes the intersecting surface `surface_MN` between a soft geometry M
- and a rigid geometry N, and sets the pressure field and the normal vector
- field on `surface_MN`. This does not use any broadphase culling but compares
- each element of the meshes.
- @param[in] volume_field_M
-     The field to sample from. The field contains the volume mesh M that defines
-     its domain. The vertex positions of the mesh are measured and expressed in
-     frame M. And the field can be evaluated at positions likewise measured and
-     expressed in frame M.
- @param[in] surface_N
-     The surface mesh intersected with the volume mesh to define the sample
-     domain. Its vertex positions are measured and expressed in frame N.
- @param[in] X_MN
-     The pose of frame N in frame M.
- @param[out] surface_MN_M
-     The intersecting surface between the volume mesh M and the surface N.
-     Vertex positions are measured and expressed in M's frame. If no
-     intersection exists, this will not change.
- @param[out] e_MN
-     The sampled field values on the intersecting surface (samples to support
-     a linear mesh field -- i.e., one per vertex). If no intersection exists,
-     this will not change.
- @note
-     The output surface mesh may have duplicate vertices.
- @tparam T Currently, only T = double is supported.
- */
-template <typename T>
-void SampleVolumeFieldOnSurface(
-    const VolumeMeshField<T, T>& volume_field_M,
-    const SurfaceMesh<T>& surface_N,
-    const math::RigidTransform<T>& X_MN,
-    std::unique_ptr<SurfaceMesh<T>>* surface_MN_M,
-    std::unique_ptr<SurfaceMeshFieldLinear<T, T>>* e_MN);
-
-/** A variant of SampleVolumeFieldOnSurface but with broad-phase culling to
- reduce the number of element-pairs evaluated.  */
-template <typename T>
-void SampleVolumeFieldOnSurface(
-    const VolumeMeshField<T, T>& volume_field_M,
-    const BoundingVolumeHierarchy<VolumeMesh<T>>& bvh_M,
-    const SurfaceMesh<T>& surface_N,
-    const BoundingVolumeHierarchy<SurfaceMesh<T>>& bvh_N,
-    const math::RigidTransform<T>& X_MN,
-    std::unique_ptr<SurfaceMesh<T>>* surface_MN_M,
-    std::unique_ptr<SurfaceMeshFieldLinear<T, T>>* e_MN);
+  friend class IntersectVolumeFieldSurfaceMeshTester<T>;
+};
 
 /** Computes the contact surface between a soft geometry S and a rigid
  geometry R. This does not use any broadphase culling.

--- a/geometry/proximity/test/mesh_intersection_test.cc
+++ b/geometry/proximity/test/mesh_intersection_test.cc
@@ -18,6 +18,42 @@
 namespace drake {
 namespace geometry {
 namespace internal {
+
+template<typename T>
+class IntersectVolumeFieldSurfaceMeshTester {
+ public:
+  Vector3<T> CalcIntersection(const Vector3<T>& p_FA, const Vector3<T>& p_FB,
+                              const PosedHalfSpace<T>& H_F) {
+    return intersect_.CalcIntersection(p_FA, p_FB, H_F);
+  }
+  std::vector<Vector3<T>> ClipPolygonByHalfSpace(
+      const std::vector<Vector3<T>>& polygon_vertices_F,
+      const PosedHalfSpace<T>& H_F) {
+    return intersect_.ClipPolygonByHalfSpace(polygon_vertices_F, H_F);
+  }
+  std::vector<Vector3<T>> RemoveDuplicateVertices(
+      std::vector<Vector3<T>> polygon) {
+    return intersect_.RemoveDuplicateVertices(polygon);
+  }
+  std::vector<Vector3<T>> ClipTriangleByTetrahedron(
+      VolumeElementIndex element, const VolumeMesh<T>& volume_M,
+      SurfaceFaceIndex face, const SurfaceMesh<T>& surface_N,
+      const math::RigidTransform<T>& X_MN) {
+    return intersect_.ClipTriangleByTetrahedron(element, volume_M, face,
+                                                surface_N, X_MN);
+  }
+  bool IsFaceNormalAlongPressureGradient(
+      const VolumeMeshField<T, T>& volume_field_M,
+      const SurfaceMesh<T>& surface_N, const math::RigidTransform<T>& X_MN,
+      const VolumeElementIndex& tet_index, const SurfaceFaceIndex& tri_index) {
+    return intersect_.IsFaceNormalAlongPressureGradient(
+        volume_field_M, surface_N, X_MN, tet_index, tri_index);
+  }
+
+ private:
+  IntersectVolumeFieldSurfaceMesh<T> intersect_;
+};
+
 namespace {
 
 using Eigen::Vector3d;
@@ -45,7 +81,9 @@ GTEST_TEST(MeshIntersectionTest, CalcIntersection) {
   {
     const Vector3d p_HA = Vector3d::Zero();
     const Vector3d p_HB(4, 6, 10);
-    const Vector3d intersection = CalcIntersection(p_HA, p_HB, half_space_H);
+    const Vector3d intersection =
+        IntersectVolumeFieldSurfaceMeshTester<double>().CalcIntersection(
+            p_HA, p_HB, half_space_H);
     const Vector3d expect_intersection(2, 3, 5);
     EXPECT_LE((expect_intersection - intersection).norm(), kEps);
   }
@@ -54,7 +92,9 @@ GTEST_TEST(MeshIntersectionTest, CalcIntersection) {
   {
     const Vector3d p_HA(plane_offset + 2.0 * kEps, 0., 0.);
     const Vector3d p_HB(plane_offset - 2.0 * kEps, 1., 1.);
-    const Vector3d intersection = CalcIntersection(p_HA, p_HB, half_space_H);
+    const Vector3d intersection =
+        IntersectVolumeFieldSurfaceMeshTester<double>().CalcIntersection(
+            p_HA, p_HB, half_space_H);
     const Vector3d expect_intersection(2., 0.5, 0.5);
     EXPECT_LE((expect_intersection - intersection).norm(), kEps);
   }
@@ -109,7 +149,8 @@ GTEST_TEST(MeshIntersectionTest, ClipPolygonByHalfSpace) {
     // Also, by construction, the winding matches, so we will also not be
     // explicitly testing that.
     const std::vector<Vector3d> output_polygon =
-        ClipPolygonByHalfSpace(input_polygon, half_space_H);
+        IntersectVolumeFieldSurfaceMeshTester<double>().ClipPolygonByHalfSpace(
+            input_polygon, half_space_H);
     EXPECT_TRUE(CompareConvexPolygon(expect_output_polygon, output_polygon));
   }
   // The input polygon is on the plane X=0, which is parallel to the plane of
@@ -127,7 +168,8 @@ GTEST_TEST(MeshIntersectionTest, ClipPolygonByHalfSpace) {
     // Because we expect the output polygon to *be* the input polygon, we don't
     // need to explicitly test planarity or winding.
     const std::vector<Vector3d> output_polygon =
-        ClipPolygonByHalfSpace(input_polygon, half_space_H);
+        IntersectVolumeFieldSurfaceMeshTester<double>().ClipPolygonByHalfSpace(
+            input_polygon, half_space_H);
     EXPECT_TRUE(CompareConvexPolygon(input_polygon, output_polygon));
   }
   // The input polygon is on the plane X=3, which is parallel to the plane of
@@ -144,7 +186,8 @@ GTEST_TEST(MeshIntersectionTest, ClipPolygonByHalfSpace) {
     // clang-format on
     // Empty polygons have no winding and no planarity.
     const std::vector<Vector3d> output_polygon =
-        ClipPolygonByHalfSpace(input_polygon, half_space_H);
+        IntersectVolumeFieldSurfaceMeshTester<double>().ClipPolygonByHalfSpace(
+            input_polygon, half_space_H);
     const std::vector<Vector3d> empty_polygon;
     EXPECT_TRUE(CompareConvexPolygon(empty_polygon, output_polygon));
   }
@@ -162,7 +205,8 @@ GTEST_TEST(MeshIntersectionTest, ClipPolygonByHalfSpace) {
     // Because we expect the output polygon to *be* the input polygon, we don't
     // need to explicitly test planarity or winding.
     const std::vector<Vector3d> output_polygon =
-        ClipPolygonByHalfSpace(input_polygon, half_space_H);
+        IntersectVolumeFieldSurfaceMeshTester<double>().ClipPolygonByHalfSpace(
+            input_polygon, half_space_H);
     EXPECT_TRUE(CompareConvexPolygon(input_polygon, output_polygon));
   }
   // The input polygon is outside the half space, but it has one edge on the
@@ -186,7 +230,8 @@ GTEST_TEST(MeshIntersectionTest, ClipPolygonByHalfSpace) {
     // By construction, expected output is planar (z = 0 for all vertices). It
     // has no area, so winding is immaterial.
     const std::vector<Vector3d> output_polygon =
-        ClipPolygonByHalfSpace(input_polygon, half_space_H);
+        IntersectVolumeFieldSurfaceMeshTester<double>().ClipPolygonByHalfSpace(
+            input_polygon, half_space_H);
     EXPECT_TRUE(CompareConvexPolygon(expect_output_polygon, output_polygon));
   }
   // The input polygon is outside the half space, but it has one vertex on the
@@ -208,7 +253,8 @@ GTEST_TEST(MeshIntersectionTest, ClipPolygonByHalfSpace) {
     // By construction, expected output is planar (z = 0 for all vertices). It
     // has no area, so winding is immaterial.
     const std::vector<Vector3d> output_polygon =
-        ClipPolygonByHalfSpace(input_polygon, half_space_H);
+        IntersectVolumeFieldSurfaceMeshTester<double>().ClipPolygonByHalfSpace(
+            input_polygon, half_space_H);
     EXPECT_TRUE(CompareConvexPolygon(expect_output_polygon, output_polygon));
   }
   // TODO(SeanCurtis-TRI): Clip a triangle into a quad. Clip a triangle into a
@@ -227,7 +273,8 @@ GTEST_TEST(MeshIntersectionTest, RemoveDuplicateVertices) {
     };
     // clang-format on
     const std::vector<Vector3d> output_polygon =
-        RemoveDuplicateVertices(input_polygon);
+        IntersectVolumeFieldSurfaceMeshTester<double>().RemoveDuplicateVertices(
+            input_polygon);
     EXPECT_TRUE(CompareConvexPolygon(input_polygon, output_polygon));
   }
   // AAA: Three identical vertices reduced to a single vertex A.
@@ -243,7 +290,8 @@ GTEST_TEST(MeshIntersectionTest, RemoveDuplicateVertices) {
     };
     // clang-format on
     const std::vector<Vector3d> output_polygon =
-        RemoveDuplicateVertices(input_polygon);
+        IntersectVolumeFieldSurfaceMeshTester<double>().RemoveDuplicateVertices(
+            input_polygon);
     EXPECT_TRUE(CompareConvexPolygon(expect_single_vertex, output_polygon));
   }
   // AABB: Two pairs of duplicate vertices. Reduced to two vertices AB.
@@ -261,7 +309,8 @@ GTEST_TEST(MeshIntersectionTest, RemoveDuplicateVertices) {
     };
     // clang-format on
     const std::vector<Vector3d> output_polygon =
-        RemoveDuplicateVertices(input_polygon);
+        IntersectVolumeFieldSurfaceMeshTester<double>().RemoveDuplicateVertices(
+            input_polygon);
     EXPECT_TRUE(CompareConvexPolygon(expect_two_vertices, output_polygon));
   }
   // TODO(SeanCurtis-TRI): Add tests:
@@ -288,7 +337,8 @@ GTEST_TEST(MeshIntersectionTest, RemoveDuplicateVertices) {
     };
     // clang-format on
     const std::vector<Vector3d> output_polygon =
-        RemoveDuplicateVertices(input_polygon);
+        IntersectVolumeFieldSurfaceMeshTester<double>().RemoveDuplicateVertices(
+            input_polygon);
     EXPECT_TRUE(CompareConvexPolygon(expect_three_vertices, output_polygon));
   }
 }
@@ -462,8 +512,9 @@ GTEST_TEST(MeshIntersectionTest, ClipTriangleByTetrahedron) {
   // face of the tetrahedron. Expect the output polygon to be empty.
   {
     const auto X_MN = RigidTransformd(Vector3d::UnitX());
-    const auto polygon =
-        ClipTriangleByTetrahedron(element0, *volume_M, face, *surface_N, X_MN);
+    const auto polygon = IntersectVolumeFieldSurfaceMeshTester<double>()
+                             .ClipTriangleByTetrahedron(element0, *volume_M,
+                                                        face, *surface_N, X_MN);
     const std::vector<Vector3d> expect_empty_polygon;
     EXPECT_TRUE(CompareConvexPolygon(expect_empty_polygon, polygon));
   }
@@ -473,8 +524,9 @@ GTEST_TEST(MeshIntersectionTest, ClipTriangleByTetrahedron) {
   {
     const auto X_MN = RigidTransformd(RollPitchYawd(0, 0, M_PI_2),
                                              Vector3d::Zero());
-    const auto polygon =
-        ClipTriangleByTetrahedron(element0, *volume_M, face, *surface_N, X_MN);
+    const auto polygon = IntersectVolumeFieldSurfaceMeshTester<double>()
+                             .ClipTriangleByTetrahedron(element0, *volume_M,
+                                                        face, *surface_N, X_MN);
     EXPECT_TRUE(CompareConvexPolygon(empty_polygon, polygon));
   }
 
@@ -486,9 +538,13 @@ GTEST_TEST(MeshIntersectionTest, ClipTriangleByTetrahedron) {
   {
     const auto X_MN = RigidTransformd::Identity();
     const auto polygon0_M =
-        ClipTriangleByTetrahedron(element0, *volume_M, face, *surface_N, X_MN);
+        IntersectVolumeFieldSurfaceMeshTester<double>()
+            .ClipTriangleByTetrahedron(element0, *volume_M, face, *surface_N,
+                                       X_MN);
     const auto polygon1_M =
-        ClipTriangleByTetrahedron(element1, *volume_M, face, *surface_N, X_MN);
+        IntersectVolumeFieldSurfaceMeshTester<double>()
+            .ClipTriangleByTetrahedron(element1, *volume_M, face, *surface_N,
+                                       X_MN);
     // clang-format off
     const std::vector<Vector3d> expect_triangle_M{
         {0, 0, 0},
@@ -504,7 +560,9 @@ GTEST_TEST(MeshIntersectionTest, ClipTriangleByTetrahedron) {
   {
     const auto X_MN = RigidTransformd(Vector3d(0, 0, 0.5));
     const auto polygon0_M =
-        ClipTriangleByTetrahedron(element0, *volume_M, face, *surface_N, X_MN);
+        IntersectVolumeFieldSurfaceMeshTester<double>()
+            .ClipTriangleByTetrahedron(element0, *volume_M, face, *surface_N,
+                                       X_MN);
     // clang-format off
     const std::vector<Vector3d> expect_triangle_M{
         {0,   0,   0.5},
@@ -519,7 +577,9 @@ GTEST_TEST(MeshIntersectionTest, ClipTriangleByTetrahedron) {
   {
     const auto X_MN = RigidTransformd(Vector3d(0, 0, 0.5));
     const auto polygon1_M =
-        ClipTriangleByTetrahedron(element1, *volume_M, face, *surface_N, X_MN);
+        IntersectVolumeFieldSurfaceMeshTester<double>()
+            .ClipTriangleByTetrahedron(element1, *volume_M, face, *surface_N,
+                                       X_MN);
     EXPECT_TRUE(CompareConvexPolygon(empty_polygon, polygon1_M));
   }
 
@@ -529,7 +589,9 @@ GTEST_TEST(MeshIntersectionTest, ClipTriangleByTetrahedron) {
     const auto X_MN = RigidTransformd(RollPitchYawd(0, 0, M_PI),
                                              Vector3d(0.5, 0.5, 0));
     const auto polygon0_M =
-        ClipTriangleByTetrahedron(element0, *volume_M, face, *surface_N, X_MN);
+        IntersectVolumeFieldSurfaceMeshTester<double>()
+            .ClipTriangleByTetrahedron(element0, *volume_M, face, *surface_N,
+                                       X_MN);
     // clang-format off
     const std::vector<Vector3d> expect_square_M{
         {0,   0,   0},
@@ -631,8 +693,9 @@ GTEST_TEST(MeshIntersectionTest, ClipTriangleByTetrahedronIntoHeptagon) {
   const VolumeElementIndex tetrahedron(0);
   const SurfaceFaceIndex triangle(0);
   const auto X_MN = RigidTransformd::Identity();
-  const auto polygon_M = ClipTriangleByTetrahedron(tetrahedron, *volume_M,
-                                                   triangle, *surface_N, X_MN);
+  const auto polygon_M =
+      IntersectVolumeFieldSurfaceMeshTester<double>().ClipTriangleByTetrahedron(
+          tetrahedron, *volume_M, triangle, *surface_N, X_MN);
   // clang-format off
   const std::vector<Vector3d> expect_heptagon_M{
       {1.,    1.,   0.},
@@ -692,9 +755,11 @@ GTEST_TEST(MeshIntersectionTest, IsFaceNormalAlongPressureGradient) {
     // general X_MN as an argument to the tested function
     // IsFaceNormalAlongPressureGradient().
     const auto X_MN = X_MF * X_FN;
-    EXPECT_EQ(t.expect_result, IsFaceNormalAlongPressureGradient<double>(
-                                   *volume_field_M, *rigid_N, X_MN,
-                                   VolumeElementIndex(0), SurfaceFaceIndex(0)));
+    EXPECT_EQ(t.expect_result,
+              IntersectVolumeFieldSurfaceMeshTester<double>()
+                  .IsFaceNormalAlongPressureGradient(
+                      *volume_field_M, *rigid_N, X_MN, VolumeElementIndex(0),
+                      SurfaceFaceIndex(0)));
   }
 }
 
@@ -709,8 +774,8 @@ GTEST_TEST(MeshIntersectionTest, SampleVolumeFieldOnSurface) {
 
   unique_ptr<SurfaceMesh<double>> surface;
   unique_ptr<SurfaceMeshFieldLinear<double, double>> e_field;
-  SampleVolumeFieldOnSurface(*volume_field_M, *rigid_N, X_MN, &surface,
-                             &e_field);
+  IntersectVolumeFieldSurfaceMesh<double>().SampleVolumeFieldOnSurface(
+      *volume_field_M, *rigid_N, X_MN, &surface, &e_field);
 
   const double kEps = std::numeric_limits<double>::epsilon();
   EXPECT_EQ(3, surface->num_faces());


### PR DESCRIPTION
Refactor mesh_intersection to a class and use std::vector as member variables to minimize heap allocation.

r1. Refactor into a class without member variables.
r2. Add std::vector member variables and modify signatures of member functions.
