### PR TITLE
trajectories: Fix use-after-free

### DIFF
--- a/common/trajectories/piecewise_polynomial.cc
+++ b/common/trajectories/piecewise_polynomial.cc
@@ -360,10 +360,10 @@ void PiecewisePolynomial<T>::ReverseTime() {
         // Must shift this segment by h, because it will now be evaluated
         // relative to breaks[i+1] instead of breaks[i], via p_after(t) =
         // p_before(t+h).  But we can perform the time-reversal at the same
-        // time, using the variant p_after(t) = p_before(h-t). Note: We use
-        // begin() here to get the only variable in the univariate polynomial.
-        const typename Polynomial<T>::VarType& t =
-            *matrix(row, col).GetVariables().begin();
+        // time, using the variant p_after(t) = p_before(h-t).
+        const auto& vars = matrix(row, col).GetVariables();
+        DRAKE_ASSERT(vars.size() == 1);
+        const typename Polynomial<T>::VarType& t = *vars.begin();
         matrix(row, col) =
             matrix(row, col).Substitute(t, h - Polynomial<T>(1.0, t));
       }


### PR DESCRIPTION
Fixes commit c523f2aae3bc073cd42fee45a21ee255dc1a5ba6 (#13108).

Example of the error:
https://drake-jenkins.csail.mit.edu/view/Production/job/linux-bionic-clang-bazel-continuous-address-sanitizer/2065/
```
[6:35:29 PM]  FAIL: //common/trajectories:piecewise_polynomial_test (see /media/ephemeral0/ubuntu/workspace/linux-bionic-clang-bazel-continuous-address-sanitizer/_bazel_ubuntu/e359602e3b676a6fb93325203587fb48/execroot/drake/bazel-out/k8-dbg/testlogs/common/trajectories/piecewise_polynomial_test/test.log)
[6:35:29 PM]  INFO: From Testing //common/trajectories:piecewise_polynomial_test:
[6:35:29 PM]  ==================== Test output for //common/trajectories:piecewise_polynomial_test:
[6:35:29 PM]  Using drake_cc_googletest_main.cc
[6:35:29 PM]  
[6:35:29 PM]  [==========] Running 10 tests from 2 test suites.
[6:35:29 PM]  [----------] Global test environment set-up.
[6:35:29 PM]  [----------] 8 tests from testPiecewisePolynomial
[6:35:29 PM]  [ RUN      ] testPiecewisePolynomial.CubicSplinePeriodicBoundaryConditionTest
[6:35:29 PM]  [       OK ] testPiecewisePolynomial.CubicSplinePeriodicBoundaryConditionTest (6 ms)
[6:35:29 PM]  [ RUN      ] testPiecewisePolynomial.ExceptionsTest
[6:35:29 PM]  [       OK ] testPiecewisePolynomial.ExceptionsTest (3 ms)
[6:35:29 PM]  [ RUN      ] testPiecewisePolynomial.AllTests
[6:35:29 PM]  [       OK ] testPiecewisePolynomial.AllTests (7479 ms)
[6:35:29 PM]  [ RUN      ] testPiecewisePolynomial.VectorValueTest
[6:35:29 PM]  [       OK ] testPiecewisePolynomial.VectorValueTest (2 ms)
[6:35:29 PM]  [ RUN      ] testPiecewisePolynomial.RemoveFinalSegmentTest
[6:35:29 PM]  [       OK ] testPiecewisePolynomial.RemoveFinalSegmentTest (1 ms)
[6:35:29 PM]  [ RUN      ] testPiecewisePolynomial.ReverseAndScaleTimeTest
[6:35:29 PM]  =================================================================
[6:35:29 PM]  ==17==ERROR: AddressSanitizer: heap-use-after-free on address 0x6040000c4f70 at pc 0x55764ffa8253 bp 0x7fffa9120130 sp 0x7fffa9120128
[6:35:29 PM]  READ of size 4 at 0x6040000c4f70 thread T0
[6:35:29 PM]      #0 0x55764ffa8252 in drake::Polynomial<double>::Polynomial(double const&, unsigned int const&) common/polynomial.cc:113:11
[6:35:29 PM]      #1 0x55764fbdaaf9 in drake::trajectories::PiecewisePolynomial<double>::ReverseTime() common/trajectories/piecewise_polynomial.cc:368:48
[6:35:29 PM]      #2 0x55764fa83e5d in drake::trajectories::(anonymous namespace)::TestReverseTime(drake::trajectories::PiecewisePolynomial<double> const&) common/trajectories/test/piecewise_polynomial_test.cc:332:7
[6:35:29 PM]      #3 0x55764fa83394 in drake::trajectories::(anonymous namespace)::testPiecewisePolynomial_ReverseAndScaleTimeTest_Test::TestBody() common/trajectories/test/piecewise_polynomial_test.cc:381:3
```
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13132)
<!-- Reviewable:end -->
