### PR TITLE
pydrake doc: Add user and dev docs for C++ template considerations

### DIFF
--- a/bindings/pydrake/pydrake_doxygen.h
+++ b/bindings/pydrake/pydrake_doxygen.h
@@ -314,6 +314,64 @@ This works about 80% of the time.
 - Lambdas, e.g. `[](Args... args) -> auto&& { return func(args...); }`
 (using perfect forwarding when appropriate).
 
+### Public C++ API Considerations for Function and Method Templates
+
+The motivation behind this section can be found under the
+"C++ Function and Method Template Instantiations in Python" section in
+`doc/python_bindings.rst`.
+
+In general, Drake uses techniques like parameter packs and type erasure to
+create sugar functions. These functions map their inputs to parameters of some
+concrete, under-the-hood method that actually does the work, and is devoid of
+such tricks. To facilitate python bindings, this underlying function should
+also be exposed in the public API.
+
+As an example for parameter packs,
+`MultibodyPlant<T>::AddJoint<JointType, Args...>(...)`
+([code permalink](https://git.io/JfqhI))
+is a C++ sugar method
+that uses parameter packs and ultimately passes the result to
+`MultibodyPlant<T>::AddJoint<JointType>(unique_ptr<JointType>)`
+([code permalink](https://git.io/JfqhU)), and only the
+`unique_ptr` function is bound ([code permalink](https://git.io/Jfqie)):
+
+```
+using Class = MultibodyPlant<T>;
+...
+    .def("AddJoint",
+        [](Class* self, std::unique_ptr<Joint<T>> joint) -> auto& {
+          return self->AddJoint(std::move(joint));
+        },
+        py::arg("joint"), py_reference_internal, cls_doc.AddJoint.doc_1args)
+...
+```
+
+As an example for parameter packs,
+`GeometryProperties::AddProperty<ValueType>`
+([code permalink](https://git.io/JfqhL)) is a C++ sugar method that uses
+type erasure and ultimately passes the result to
+`GeometryProperties::AddPropertyAbstract`
+([code permalink](https://git.io/Jfqhm)), and only the `AddPropertyAbstract`
+flavor is used in the bindings, but in such a way that it is similar to the C++
+API for `AddProperty` ([code permalink](https://git.io/JfqiT)):
+
+```
+using Class = GeometryProperties;
+py::handle abstract_value_cls =
+    py::module::import("pydrake.systems.framework").attr("AbstractValue");
+...
+    .def("AddProperty",
+        [abstract_value_cls](Class* self, const std::string& group_name,
+            const std::string& name, py::object value) {
+          py::object abstract = abstract_value_cls.attr("Make")(value);
+          self->AddPropertyAbstract(
+              group_name, name, abstract.cast<const AbstractValue&>());
+        },
+        py::arg("group_name"), py::arg("name"), py::arg("value"),
+        cls_doc.AddProperty.doc)
+...
+```
+
 ## Python Subclassing of C++ Classes
 
 In general, minimize the amount in which users may subclass C++ classes in

--- a/doc/python_bindings.rst
+++ b/doc/python_bindings.rst
@@ -263,8 +263,8 @@ Differences with C++ API
 In general, the `Python API <pydrake/index.html#://>`_ should be close to the
 `C++ API <doxygen_cxx/index.html#://>`_. There are some exceptions:
 
-C++ Template Instantiations in Python
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+C++ Class Template Instantiations in Python
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When you define a general class template, e.g.
 ``template <typename T> class Value``, something like ``Value<std::string>`` is
@@ -342,6 +342,56 @@ Additionally, you may convert an instance (if the conversion is available) using
     <pydrake.systems.primitives.Adder_[AutoDiffXd] object at 0x...>
     >>> print(adder.ToSymbolic())
     <pydrake.systems.primitives.Adder_[Expression] object at 0x...>
+
+C++ Function and Method Template Instantiations in Python
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The above section indicates that C++ types are generally registered with
+Python, and a similar approach could be used for function and method templates.
+However, these templates usually fit a certain pattern and can be Pythonized in
+such a way that simplifies implementation, but may change the "feel" of the
+signature.
+
+Two common (non-metaprogramming) applications of templated functions and
+methods present in Drake are `emplace <https://en.cppreference.com/w/cpp/container/vector/emplace>`_-like
+functionality (using `parameter packs
+<https://en.cppreference.com/w/cpp/language/parameter_pack>`_) and
+`type erasure <https://en.wikipedia.org/wiki/Type_erasure>`_.
+However, Python doesn't literally support these C++ language features. So, in
+binding them, they get "Pythonized".
+
+C++ APIs which use parameter packs, such as:
+
+.. code-block:: cpp
+
+    DiagramBuilder<T>::AddSystem<SystemType>(args...)
+    MultibodyPlant<T>::AddJoint<JointType>(args...)
+    MultibodyPlant<T>::AddFrame<FrameType>(args...)
+
+will become the following in Python:
+
+.. code-block:: pycon
+
+    DiagramBuilder_[T].AddSystem(SystemType(args, ...))
+    MultibodyPlant_[T].AddJoint(JointType(args, ...))
+    MultibodyPlant_[T].AddFrame(FrameType(args, ...))
+
+where the ``*Type`` tokens are replaced with the concrete type in question
+(e.g. ``Adder_[T]``, ``RevoluteJoint_[T]``, ``FixedOffsetFrame_[T]``).
+
+Similarly, type-erasure C++ APIs that look like:
+
+.. code-block:: cpp
+
+    InputPort<T>::Eval<ValueType>(context)
+    GeometryProperties::AddProperty<ValueType>(group_name, name, value)
+
+will become the following in Python:
+
+.. code-block:: pycon
+
+    InputPort_[T].Eval(context)
+    GeometryProperties.AddProperty(group_name, name, value)
 
 Debugging with the Python Bindings
 ----------------------------------


### PR DESCRIPTION
Motivated by this StackOverflow question:
https://stackoverflow.com/questions/61346034/is-it-possible-to-support-python-binding-for-addjoint-that-takes-x-pf-x-bm-as-a

Also, for the fact that I had to make mods to C++ APIs to enable this, e.g. 04e20b8a (#9345) and 3f1547f4 (#12389) ;)

FYI @RussTedrake @sherm1 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13134)
<!-- Reviewable:end -->
