### PR TITLE
[geometry] Refactor QueryObject test to a more efficient spelling.

### DIFF
--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -513,7 +513,7 @@ class QueryObject {
   // SceneGraph is the only class that may call set().
   friend class SceneGraph<T>;
   // Convenience class for testing.
-  friend class QueryObjectTester;
+  friend class QueryObjectTest;
 
   // Access the GeometryState associated with this QueryObject.
   // @pre ThrowIfNotCallable() has been invoked prior to this.

--- a/geometry/test/query_object_test.cc
+++ b/geometry/test/query_object_test.cc
@@ -14,16 +14,20 @@
 namespace drake {
 namespace geometry {
 
-// Helper class for testing the query object.
-class QueryObjectTester {
- public:
-  QueryObjectTester() = delete;
+using Eigen::Vector3d;
+using math::RigidTransformd;
+using render::DepthCameraProperties;
+using std::make_unique;
+using std::unique_ptr;
+using systems::Context;
+using systems::sensors::ImageDepth32F;
+using systems::sensors::ImageLabel16I;
+using systems::sensors::ImageRgba8U;
 
-  template <typename T>
-  static std::unique_ptr<QueryObject<T>> MakeQueryObject() {
-    return std::make_unique<QueryObject<T>>();
-  }
-
+// Friend class to QueryObject -- left in `drake::geometry` to match the friend
+// declaration.
+class QueryObjectTest : public ::testing::Test {
+ protected:
   template <typename T>
   static std::unique_ptr<QueryObject<T>> MakeQueryObject(
       const systems::Context<T>* context, const SceneGraph<T>* scene_graph) {
@@ -63,10 +67,10 @@ class QueryObjectTester {
     if (object.scene_graph_ != nullptr || object.context_ != nullptr ||
         object.state_ == nullptr) {
       return ::testing::AssertionFailure()
-          << "A baked query object should have all null scene graph and "
-             "context and non-null state. Has scene_graph: "
-          << object.scene_graph_ << ", context: " << object.context_
-          << ", state: " << object.state_.get();
+             << "A baked query object should have all null scene graph and "
+                "context and non-null state. Has scene_graph: "
+             << object.scene_graph_ << ", context: " << object.context_
+             << ", state: " << object.state_.get();
     }
     return ::testing::AssertionSuccess();
   }
@@ -88,70 +92,48 @@ class QueryObjectTester {
   }
 
   template <typename T>
-  static void set(const systems::Context<T>* context,
-                  const SceneGraph<T>* scene_graph, QueryObject<T>* object) {
-    object->set(context, scene_graph);
-  }
-
-  template <typename T>
-  static const GeometryState<T>& state(const QueryObject<T>& object) {
-    return object.geometry_state();
+  void set_live(QueryObject<T>* query_object, Context<T>* context) {
+    query_object->set(context, &scene_graph_);
   }
 
   template <typename T>
   static void ThrowIfNotCallable(const QueryObject<T>& object) {
     object.ThrowIfNotCallable();
   }
-};
 
-namespace {
-
-using Eigen::Vector3d;
-using math::RigidTransformd;
-using render::DepthCameraProperties;
-using std::make_unique;
-using std::unique_ptr;
-using systems::Context;
-using systems::sensors::ImageDepth32F;
-using systems::sensors::ImageLabel16I;
-using systems::sensors::ImageRgba8U;
-
-class QueryObjectTest : public ::testing::Test {
- protected:
-  using QOT = QueryObjectTester;
-
-  void SetUp() override {
-    context_ = scene_graph_.AllocateContext();
-    query_object_ = QOT::MakeQueryObject(context_.get(), &scene_graph_);
-
-    EXPECT_TRUE(QueryObjectTester::is_live(*query_object_));
+  template <typename T>
+  static const GeometryState<T>& get_state(const QueryObject<T>& object) {
+    return object.geometry_state();
   }
 
   SceneGraph<double> scene_graph_;
-  unique_ptr<Context<double>> context_;
-  unique_ptr<QueryObject<double>> query_object_;
 };
 
 // Confirm copy semantics.
 TEST_F(QueryObjectTest, CopySemantics) {
   // Default query object *can* be copied and assigned.
-  unique_ptr<QueryObject<double>> default_object =
-      QOT::MakeQueryObject<double>();
-  EXPECT_TRUE(QOT::is_default(*default_object));
+  QueryObject<double> default_object;
+  EXPECT_TRUE(is_default(default_object));
 
-  QueryObject<double> from_default{*default_object};
-  EXPECT_TRUE(QOT::is_default(*default_object));
+  QueryObject<double> from_default{default_object};
+  EXPECT_TRUE(is_default(from_default));
 
-  QueryObject<double> from_live{*query_object_};
-  EXPECT_TRUE(QOT::is_baked(from_live));
+  unique_ptr<Context<double>> live_context = scene_graph_.AllocateContext();
+  unique_ptr<QueryObject<double>> live_query_object =
+      MakeQueryObject(live_context.get(), &scene_graph_);
+  EXPECT_TRUE(is_live(*live_query_object));
 
-  QueryObject<double> from_baked{from_live};
-  // Simultaneously test from_baked *is* baked and shares state with from_live.
-  EXPECT_TRUE(QOT::shared_baked(from_live, from_baked));
+  QueryObject<double> baked_from_live{*live_query_object};
+  EXPECT_TRUE(is_baked(baked_from_live));
+
+  QueryObject<double> baked_from_baked{baked_from_live};
+  // Simultaneously test from_baked *is* baked and shares state with
+  // baked_from_live.
+  EXPECT_TRUE(shared_baked(baked_from_live, baked_from_baked));
 
   // Confirm a baked object can be reset to be a live object.
-  QOT::set(context_.get(), &scene_graph_, &from_baked);
-  EXPECT_TRUE(QOT::is_live(from_baked));
+  set_live(&baked_from_baked, live_context.get());
+  EXPECT_TRUE(is_live(baked_from_baked));
 }
 
 // NOTE: This doesn't test the specific queries; GeometryQuery simply wraps
@@ -160,72 +142,72 @@ TEST_F(QueryObjectTest, CopySemantics) {
 // wrapper merely confirms that the state is correct and that wrapper
 // functionality is tested in DefaultQueryThrows.
 TEST_F(QueryObjectTest, DefaultQueryThrows) {
-  unique_ptr<QueryObject<double>> default_object =
-      QOT::MakeQueryObject<double>();
-  EXPECT_TRUE(QOT::is_default(*default_object));
+  QueryObject<double> default_object;
+  EXPECT_TRUE(is_default(default_object));
 
 #define EXPECT_DEFAULT_ERROR(expression) \
   DRAKE_EXPECT_THROWS_MESSAGE(expression, std::runtime_error, \
       "Attempting to perform query on invalid QueryObject.+");
 
-  EXPECT_DEFAULT_ERROR(QOT::ThrowIfNotCallable(*default_object));
+  EXPECT_DEFAULT_ERROR(ThrowIfNotCallable(default_object));
 
   // Enumerate *all* queries to confirm they throw the proper exception.
 
   // Scalar-dependent state queries.
-  EXPECT_DEFAULT_ERROR(default_object->X_WF(FrameId::get_new_id()));
-  EXPECT_DEFAULT_ERROR(default_object->X_PF(FrameId::get_new_id()));
-  EXPECT_DEFAULT_ERROR(default_object->X_WG(GeometryId::get_new_id()));
+  EXPECT_DEFAULT_ERROR(default_object.X_WF(FrameId::get_new_id()));
+  EXPECT_DEFAULT_ERROR(default_object.X_PF(FrameId::get_new_id()));
+  EXPECT_DEFAULT_ERROR(default_object.X_WG(GeometryId::get_new_id()));
+
 
   // Penetration queries.
-  EXPECT_DEFAULT_ERROR(default_object->ComputePointPairPenetration());
-  EXPECT_DEFAULT_ERROR(default_object->ComputeContactSurfaces());
+  EXPECT_DEFAULT_ERROR(default_object.ComputePointPairPenetration());
+  EXPECT_DEFAULT_ERROR(default_object.ComputeContactSurfaces());
 
   // Signed distance queries.
   EXPECT_DEFAULT_ERROR(
-      default_object->ComputeSignedDistancePairwiseClosestPoints());
-  EXPECT_DEFAULT_ERROR(default_object->ComputeSignedDistancePairClosestPoints(
+      default_object.ComputeSignedDistancePairwiseClosestPoints());
+  EXPECT_DEFAULT_ERROR(default_object.ComputeSignedDistancePairClosestPoints(
       GeometryId::get_new_id(), GeometryId::get_new_id()));
   EXPECT_DEFAULT_ERROR(
-      default_object->ComputeSignedDistanceToPoint(Vector3<double>::Zero()));
+      default_object.ComputeSignedDistanceToPoint(Vector3<double>::Zero()));
 
-  EXPECT_DEFAULT_ERROR(default_object->FindCollisionCandidates());
-  EXPECT_DEFAULT_ERROR(default_object->HasCollisions());
-  EXPECT_DEFAULT_ERROR(default_object->X_WF(FrameId::get_new_id()));
-  EXPECT_DEFAULT_ERROR(default_object->X_PF(FrameId::get_new_id()));
-  EXPECT_DEFAULT_ERROR(default_object->X_WG(GeometryId::get_new_id()));
+  EXPECT_DEFAULT_ERROR(default_object.FindCollisionCandidates());
+  EXPECT_DEFAULT_ERROR(default_object.HasCollisions());
+  EXPECT_DEFAULT_ERROR(default_object.X_WF(FrameId::get_new_id()));
+  EXPECT_DEFAULT_ERROR(default_object.X_PF(FrameId::get_new_id()));
+  EXPECT_DEFAULT_ERROR(default_object.X_WG(GeometryId::get_new_id()));
 
   // Render queries.
   DepthCameraProperties properties(2, 2, M_PI, "dummy_renderer", 0.1, 5.0);
   RigidTransformd X_WC = RigidTransformd::Identity();
   ImageRgba8U color;
-  EXPECT_DEFAULT_ERROR(default_object->RenderColorImage(
+  EXPECT_DEFAULT_ERROR(default_object.RenderColorImage(
       properties, FrameId::get_new_id(), X_WC, false, &color));
 
   ImageDepth32F depth;
-  EXPECT_DEFAULT_ERROR(default_object->RenderDepthImage(
+  EXPECT_DEFAULT_ERROR(default_object.RenderDepthImage(
       properties, FrameId::get_new_id(), X_WC, &depth));
 
   ImageLabel16I label;
-  EXPECT_DEFAULT_ERROR(default_object->RenderLabelImage(
+  EXPECT_DEFAULT_ERROR(default_object.RenderLabelImage(
       properties, FrameId::get_new_id(), X_WC, false, &label));
+
 #undef EXPECT_DEFAULT_ERROR
 }
 
 // Confirms the inspector returned by the QueryObject is "correct" (in that
 // it accesses the correct state).
-GTEST_TEST(QueryObjectInspectTest, CreateValidInspector) {
-  SceneGraph<double> scene_graph;
-  SourceId source_id = scene_graph.RegisterSource("source");
+TEST_F(QueryObjectTest, CreateValidInspector) {
+  SourceId source_id = scene_graph_.RegisterSource("source");
   auto identity = RigidTransformd::Identity();
   FrameId frame_id =
-      scene_graph.RegisterFrame(source_id, GeometryFrame("frame"));
-  GeometryId geometry_id = scene_graph.RegisterGeometry(
+      scene_graph_.RegisterFrame(source_id, GeometryFrame("frame"));
+  GeometryId geometry_id = scene_graph_.RegisterGeometry(
       source_id, frame_id, make_unique<GeometryInstance>(
                                identity, make_unique<Sphere>(1.0), "sphere"));
-  unique_ptr<Context<double>> context = scene_graph.AllocateContext();
+  unique_ptr<Context<double>> context = scene_graph_.AllocateContext();
   unique_ptr<QueryObject<double>> query_object =
-      QueryObjectTester::MakeQueryObject<double>(context.get(), &scene_graph);
+      MakeQueryObject(context.get(), &scene_graph_);
 
   const SceneGraphInspector<double>& inspector = query_object->inspector();
 
@@ -238,19 +220,16 @@ GTEST_TEST(QueryObjectInspectTest, CreateValidInspector) {
 // This test confirms that the copied (aka baked) query object has its pose
 // data properly baked. This is confirmed by a great deal of convoluted
 // trickery.
-GTEST_TEST(QueryObjectBakeTest, BakedCopyHasFullUpdate) {
-  using QOT = QueryObjectTester;
-
-  SceneGraph<double> scene_graph;
-  SourceId s_id = scene_graph.RegisterSource("BakeTest");
-  FrameId frame_id = scene_graph.RegisterFrame(s_id, GeometryFrame("frame"));
-  unique_ptr<Context<double>> context = scene_graph.AllocateContext();
+TEST_F(QueryObjectTest, BakedCopyHasFullUpdate) {
+  SourceId s_id = scene_graph_.RegisterSource("BakeTest");
+  FrameId frame_id = scene_graph_.RegisterFrame(s_id, GeometryFrame("frame"));
+  unique_ptr<Context<double>> context = scene_graph_.AllocateContext();
   RigidTransformd X_WF{Vector3d{1, 2, 3}};
   FramePoseVector<double> poses{{frame_id, X_WF}};
-  scene_graph.get_source_pose_port(s_id).FixValue(context.get(), poses);
+  scene_graph_.get_source_pose_port(s_id).FixValue(context.get(), poses);
   const auto& query_object =
-      scene_graph.get_query_output_port().Eval<QueryObject<double>>(*context);
-  EXPECT_TRUE(QOT::is_live(query_object));
+      scene_graph_.get_query_output_port().Eval<QueryObject<double>>(*context);
+  EXPECT_TRUE(is_live(query_object));
 
   // Here's the convoluted trickery. We examine the state that's embedded in
   // the context of the live query object. It *hasn't* updated poses at all.
@@ -258,7 +237,7 @@ GTEST_TEST(QueryObjectBakeTest, BakedCopyHasFullUpdate) {
   // However, when we copy the query_object, the same query on its state
   // *will* return that value (showing that the copy has the updated poses).
 
-  const GeometryState<double>& state = QOT::state(query_object);
+  const GeometryState<double>& state = get_state(query_object);
   const auto& stale_pose = state.get_pose_in_world(frame_id);
   // Confirm the live state hasn't been updated yet.
   EXPECT_FALSE(
@@ -266,12 +245,18 @@ GTEST_TEST(QueryObjectBakeTest, BakedCopyHasFullUpdate) {
 
   const QueryObject<double> baked(query_object);
 
-  const GeometryState<double>& baked_state = QOT::state(query_object);
+  const GeometryState<double>& baked_state = get_state(baked);
   const auto& baked_pose = baked_state.get_pose_in_world(frame_id);
   EXPECT_TRUE(
       CompareMatrices(baked_pose.GetAsMatrix34(), X_WF.GetAsMatrix34()));
+  // And the previously stale pose is now updated as a pre-cursor to the baked
+  // copy.
+  EXPECT_TRUE(
+      CompareMatrices(stale_pose.GetAsMatrix34(), X_WF.GetAsMatrix34()));
+
+  // These really are different objects.
+  EXPECT_NE(&stale_pose, &baked_pose);
 }
 
-}  // namespace
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -38,9 +38,9 @@ using std::make_unique;
 using std::unique_ptr;
 
 // Friend class for working with QueryObjects in a test context.
-class QueryObjectTester {
+class QueryObjectTest {
  public:
-  QueryObjectTester() = delete;
+  QueryObjectTest() = delete;
 
   template <typename T>
   static QueryObject<T> MakeNullQueryObject() {
@@ -103,15 +103,15 @@ class SceneGraphTest : public ::testing::Test {
  public:
   SceneGraphTest()
       : ::testing::Test(),
-        query_object_(QueryObjectTester::MakeNullQueryObject<double>()) {}
+        query_object_(QueryObjectTest::MakeNullQueryObject<double>()) {}
 
  protected:
   void AllocateContext() {
     // TODO(SeanCurtis-TRI): This will probably have to be moved into an
     // explicit call so it can be run *after* topology has been set.
     context_ = scene_graph_.AllocateContext();
-    QueryObjectTester::set_query_object(&query_object_, &scene_graph_,
-                                        context_.get());
+    QueryObjectTest::set_query_object(&query_object_, &scene_graph_,
+                                      context_.get());
   }
 
   const QueryObject<double>& query_object() const {
@@ -566,7 +566,7 @@ GTEST_TEST(SceneGraphAutoDiffTest, InstantiateAutoDiff) {
   auto context = scene_graph.AllocateContext();
 
   QueryObject<AutoDiffXd> handle =
-      QueryObjectTester::MakeNullQueryObject<AutoDiffXd>();
+      QueryObjectTest::MakeNullQueryObject<AutoDiffXd>();
   SceneGraphTester::GetQueryObjectPortValue(scene_graph, *context, &handle);
 }
 


### PR DESCRIPTION
This doesn't change the *nature* of the test. Merely the spelling. It eliminates some of the overhead cruft such that the test harness has direct access to the private/protected elements of `QueryObject`.

A follow-up PR will be breaking up the QueryObject and the decomposed instances will follow this same testing pattern.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13136)
<!-- Reviewable:end -->
