### PR TITLE
Use linear f(x,y,z) on tetrahedron directly instead of barycentric interpolation.

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -651,6 +651,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "mesh_field_linear_test",
     deps = [
+        ":make_box_mesh",
         ":mesh_field",
         "//common/test_utilities:eigen_matrix_compare",
         "//math:geometric_transform",

--- a/geometry/proximity/mesh_field_linear.cc
+++ b/geometry/proximity/mesh_field_linear.cc
@@ -5,8 +5,8 @@
 namespace drake {
 namespace geometry {
 
-template <class FieldValue, class MeshType>
-void MeshFieldLinear<FieldValue, MeshType>::CalcGradientField() {
+template <class T, class MeshType>
+void MeshFieldLinear<T, MeshType>::CalcGradientField() {
   gradients_.clear();
   gradients_.reserve(this->mesh().num_elements());
   for (typename MeshType::ElementIndex e(0); e < this->mesh().num_elements();
@@ -15,14 +15,35 @@ void MeshFieldLinear<FieldValue, MeshType>::CalcGradientField() {
   }
 }
 
-template <class FieldValue, class MeshType>
-Vector3<FieldValue> MeshFieldLinear<FieldValue, MeshType>::CalcGradientVector(
+template <class T, class MeshType>
+Vector3<T> MeshFieldLinear<T, MeshType>::CalcGradientVector(
     typename MeshType::ElementIndex e) const {
-  std::array<FieldValue, MeshType::kVertexPerElement> u;
+  std::array<T, MeshType::kVertexPerElement> u;
   for (int i = 0; i < MeshType::kVertexPerElement; ++i) {
     u[i] = values_[this->mesh().element(e).vertex(i)];
   }
   return this->mesh().CalcGradientVectorOfLinearField(u, e);
+}
+
+template <class T, class MeshType>
+void MeshFieldLinear<T, MeshType>::CalcValueAtMeshOriginForAllElements() {
+  values_at_Mo_.clear();
+  values_at_Mo_.reserve(this->mesh().num_elements());
+  for (typename MeshType::ElementIndex e(0); e < this->mesh().num_elements();
+       ++e) {
+    values_at_Mo_.push_back(CalcValueAtMeshOrigin(e));
+  }
+}
+
+template <class T, class MeshType>
+T MeshFieldLinear<T, MeshType>::CalcValueAtMeshOrigin(
+    typename MeshType::ElementIndex e) const {
+  DRAKE_DEMAND(e < gradients_.size());
+  const typename MeshType::VertexIndex v0 = this->mesh().element(e).vertex(0);
+  const Vector3<T>& p_MV0 = this->mesh().vertex(v0).r_MV();
+  // f(V₀) = ∇fᵉ⋅p_MV₀ + fᵉ(Mo)
+  // fᵉ(Mo) = f(V₀) - ∇fᵉ⋅p_MV₀
+  return values_[v0] - gradients_[e].dot(p_MV0);
 }
 
 template class MeshFieldLinear<double, SurfaceMesh<double>>;

--- a/geometry/proximity/test/mesh_field_linear_test.cc
+++ b/geometry/proximity/test/mesh_field_linear_test.cc
@@ -1,5 +1,6 @@
 #include "drake/geometry/proximity/mesh_field_linear.h"
 
+#include <cmath>
 #include <memory>
 #include <utility>
 
@@ -7,6 +8,7 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/geometry/proximity/make_box_mesh.h"
 #include "drake/geometry/proximity/surface_mesh.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/math/roll_pitch_yaw.h"
@@ -167,6 +169,130 @@ GTEST_TEST(MeshFieldLinearTest, TestTransformGradients) {
   Vector3d expect_gradient_N = X_MN.rotation() * expect_gradient_M;
 
   EXPECT_TRUE(CompareMatrices(expect_gradient_N, gradient_N, 1e-14));
+}
+
+// Confirms that invoking EvaluateCartesian() produces equivalent expected
+// values whether gradients have been pre-computed or not.
+GTEST_TEST(MeshFieldLinearTest, EvaluateCartesianWithAndWithoutGradient) {
+  // This mesh is symmetric with respect to the x=0 plane in frame M, so we
+  // can use it to define the testing field (defined below) accurately. No
+  // edges of tetrahedra cross the x=0 plane.
+  const VolumeMesh<double> mesh_M =
+      internal::MakeBoxVolumeMesh<double>(Box(0.5, 1.5, 2), 0.125);
+
+  // Verify the symmetry and classify tetrahedra. Each tetrahedron is either
+  // in the x ≥ 0 half-space or the x ≤ 0 half-space. Here we call the former
+  // "positive tetrahedron" and the latter "negative tetrahedron".
+  // No tetrahedron crosses the x=0 plane in frame M. Obviously we assume
+  // the tetrahedra fill the volume of the box.
+  std::set<VolumeElementIndex> positive_set;  // set of positive tetrahedra.
+  for (VolumeElementIndex e(0); e < mesh_M.num_elements(); ++e) {
+    int num_positive_or_zero = 0;
+    int num_negative_or_zero = 0;
+    for (int i = 0; i < 4; ++i) {
+      const Vector3d p_MV = mesh_M.vertex(mesh_M.element(e).vertex(i)).r_MV();
+      if (p_MV.x() >= 0) ++num_positive_or_zero;
+      if (p_MV.x() <= 0) ++num_negative_or_zero;
+    }
+    // If, in the future, the implementation of MakeBoxVolumeMesh changes so
+    // that the mesh generated here no longer has strictly positive/negative
+    // tetrahedra, the mesh used for this test will need to be changed to one
+    // that does satisfy that requirement.
+    ASSERT_TRUE(num_positive_or_zero == 4 || num_negative_or_zero == 4)
+        << "Mesh no longer satisfies the requirements for this test";
+    // Assume no tetrahedron has both num_positive_or_zero == 4 and
+    // num_negative_or_zero == 4. It would be a zero-volume tetrahedron with
+    // all four vertices lying on the x=0 plane.
+    ASSERT_FALSE(num_positive_or_zero == 4 && num_negative_or_zero == 4)
+        << "Mesh no longer satisfies the requirements for this test";
+    if (num_positive_or_zero == 4) positive_set.insert(e);
+  }
+
+  // We will test with this piecweise-linear function:
+  //          f(x,y,z) = 3.5|x| - 2.7y + 0.7z + 1.23.
+  // For tetrahedral elements in the x ≥ 0 half-space, they will represent
+  //          f⁺(x,y,z) =  3.5x - 2.7y + 0.7z + 1.23.
+  // For tetrahedral elements in the x ≤ 0 half-space, they will represent
+  //          f⁻(x,y,z) = -3.5x - 2.7y + 0.7z + 1.23.
+  // On the x=0 plane, the three functions agree:
+  //          f(0,y,z) = f⁺(0,y,z) = f⁻(0,y,z),
+  // and that is why we need the mesh with the above property.
+  using std::abs;
+  auto f = [](const Vector3d& p_MQ) -> double {
+    return 3.5 * abs(p_MQ.x()) - 2.7 * p_MQ.y() + 0.7 * p_MQ.z() + 1.23;
+  };
+  auto f_p = [](const Vector3d& p_MQ) -> double {
+    return 3.5 * p_MQ.x() - 2.7 * p_MQ.y() + 0.7 * p_MQ.z() + 1.23;
+  };
+  auto f_n = [](const Vector3d& p_MQ) -> double {
+    return -3.5 * p_MQ.x() - 2.7 * p_MQ.y() + 0.7 * p_MQ.z() + 1.23;
+  };
+
+  std::vector<double> values;
+  for (const VolumeVertex<double> v : mesh_M.vertices()) {
+    values.push_back(f(v.r_MV()));
+  }
+  std::vector<double> values_copy = values;
+
+  const MeshFieldLinear<double, VolumeMesh<double>> field_without_gradient(
+      "3.5|x| - 2.7y + 0.7z + 1.23", std::move(values_copy), &mesh_M, false);
+  const MeshFieldLinear<double, VolumeMesh<double>> field_with_gradient(
+      "3.5|x| - 2.7y + 0.7z + 1.23", std::move(values), &mesh_M, true);
+
+  ASSERT_THROW(field_without_gradient.EvaluateGradient(VolumeElementIndex(0)),
+               std::runtime_error);
+  ASSERT_NO_THROW(field_with_gradient.EvaluateGradient(VolumeElementIndex(0)));
+
+  {
+    // Evaluating the field for points within tetrahedra.  The tolerance
+    // 2e-15 is empirically determined.
+    using Barycentric = VolumeMesh<double>::Barycentric;
+    for (const Barycentric& b_Q :
+         {Barycentric{0.25, 0.25, 0.25, 0.25} /* centroid */,
+          Barycentric{0.5, 0.5, 0, 0} /* on edge */,
+          Barycentric{0.49999, 0.49999, 1e-5, 1e-5} /* near edge */}) {
+      // TODO(SeanCurtis-TRI): it's ridiculous that we don't have a mesh method
+      //  that turns (element index, barycentric) --> cartesian.
+      for (VolumeElementIndex e(0); e < mesh_M.num_elements(); ++e) {
+        Vector3d p_MQ{0, 0, 0};
+        for (int i = 0; i < 4; ++i) {
+          p_MQ += mesh_M.vertex(mesh_M.element(e).vertex(i)).r_MV() * b_Q(i);
+        }
+        const double expect = f(p_MQ);
+        constexpr double tolerance = 2e-15;
+        EXPECT_NEAR(expect, field_without_gradient.EvaluateCartesian(e, p_MQ),
+                    tolerance);
+        EXPECT_NEAR(expect, field_with_gradient.EvaluateCartesian(e, p_MQ),
+                    tolerance);
+      }
+    }
+  }
+
+  // Evaluating the field for points that don't necessarily lie within
+  // tetrahedra. The relative tolerance 1e-13 is empirically determined.
+  for (const Vector3d& p_MQ :
+       {Vector3d{1e-15, 1e-15, 1e-15}, Vector3d{0.1, 0.2, 0.3},
+        Vector3d{-10.23, 27, 77}, Vector3d{321.3, -843.2, 202.02}}) {
+    for (VolumeElementIndex e(0); e < mesh_M.num_elements(); ++e) {
+      if (positive_set.count(e) == 1) {
+        // f⁺(x,y,z) =  3.5x - 2.7y + 0.7z + 1.23
+        const double expect = f_p(p_MQ);
+        const double tolerance = 1e-13 * abs(expect);
+        EXPECT_NEAR(expect, field_without_gradient.EvaluateCartesian(e, p_MQ),
+                    tolerance);
+        EXPECT_NEAR(expect, field_with_gradient.EvaluateCartesian(e, p_MQ),
+                    tolerance);
+      } else {
+        // f⁻(x,y,z) = -3.5x - 2.7y + 0.7z + 1.23
+        const double expect = f_n(p_MQ);
+        const double tolerance = 1e-13 * abs(expect);
+        EXPECT_NEAR(expect, field_without_gradient.EvaluateCartesian(e, p_MQ),
+                    tolerance);
+        EXPECT_NEAR(expect, field_with_gradient.EvaluateCartesian(e, p_MQ),
+                    tolerance);
+      }
+    }
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
Use linear functions:
   f(x,y,z) = ∇f⋅(x,y,z) + D, where D = f(0,0,0)
on tetrahedra directly, instead of converting (x,y,z) to barycentric coordinates and perform barycentric interpolation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13140)
<!-- Reviewable:end -->
