### PR TITLE
trajectories: add Trajectory::has_derivative and EvalDerivative

### DIFF
--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -22,7 +22,11 @@ PYBIND11_MODULE(trajectories, m) {
 
   using T = double;
 
-  py::class_<Trajectory<T>>(m, "Trajectory", doc.Trajectory.doc);
+  py::class_<Trajectory<T>>(m, "Trajectory", doc.Trajectory.doc)
+      .def("EvalDerivative", &Trajectory<T>::EvalDerivative, py::arg("t"),
+          py::arg("derivative_order") = 1, doc.Trajectory.EvalDerivative.doc)
+      .def("rows", &Trajectory<T>::rows, doc.Trajectory.rows.doc)
+      .def("cols", &Trajectory<T>::cols, doc.Trajectory.cols.doc);
 
   py::class_<PiecewiseTrajectory<T>, Trajectory<T>>(
       m, "PiecewiseTrajectory", doc.PiecewiseTrajectory.doc)
@@ -156,9 +160,6 @@ PYBIND11_MODULE(trajectories, m) {
           py::arg("breaks"), py::arg("knots"), py::arg("periodic_end"))
       .def("value", &PiecewisePolynomial<T>::value, py::arg("t"),
           doc.PiecewisePolynomial.value.doc)
-      .def("EvalDerivative", &PiecewisePolynomial<T>::EvalDerivative,
-          py::arg("t"), py::arg("derivative_order") = 1,
-          doc.PiecewisePolynomial.EvalDerivative.doc)
       .def("derivative", &PiecewisePolynomial<T>::derivative,
           py::arg("derivative_order") = 1,
           doc.PiecewisePolynomial.derivative.doc)
@@ -172,10 +173,6 @@ PYBIND11_MODULE(trajectories, m) {
           &PiecewisePolynomial<T>::getSegmentPolynomialDegree,
           py::arg("segment_index"), py::arg("row") = 0, py::arg("col") = 0,
           doc.PiecewisePolynomial.getSegmentPolynomialDegree.doc)
-      .def("rows", &PiecewisePolynomial<T>::rows,
-          doc.PiecewisePolynomial.rows.doc)
-      .def("cols", &PiecewisePolynomial<T>::cols,
-          doc.PiecewisePolynomial.cols.doc)
       .def("isApprox", &PiecewisePolynomial<T>::isApprox, py::arg("other"),
           py::arg("tol"), py::arg("tol_type") = drake::ToleranceType::kRelative,
           doc.PiecewisePolynomial.isApprox.doc)

--- a/common/trajectories/BUILD.bazel
+++ b/common/trajectories/BUILD.bazel
@@ -23,9 +23,12 @@ drake_cc_package_library(
 
 drake_cc_library(
     name = "trajectory",
+    srcs = ["trajectory.cc"],
     hdrs = ["trajectory.h"],
     deps = [
+        "//common:default_scalars",
         "//common:essential",
+        "//common:unused",
     ],
 )
 
@@ -93,6 +96,14 @@ drake_cc_library(
     hdrs = ["test/random_piecewise_polynomial.h"],
     deps = [
         "//common/test_utilities:random_polynomial_matrix",
+    ],
+)
+
+drake_cc_googletest(
+    name = "trajectory_test",
+    deps = [
+        ":trajectory",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/common/trajectories/bspline_trajectory.cc
+++ b/common/trajectories/bspline_trajectory.cc
@@ -42,12 +42,12 @@ MatrixX<T> BsplineTrajectory<T>::value(const T& time) const {
 }
 
 template <typename T>
-std::unique_ptr<Trajectory<T>> BsplineTrajectory<T>::MakeDerivative(
+std::unique_ptr<Trajectory<T>> BsplineTrajectory<T>::DoMakeDerivative(
     int derivative_order) const {
   if (derivative_order == 0) {
     return this->Clone();
   } else if (derivative_order > 1) {
-    return MakeDerivative(1)->MakeDerivative(derivative_order - 1);
+    return this->MakeDerivative(1)->MakeDerivative(derivative_order - 1);
   } else if (derivative_order == 1) {
     std::vector<T> derivative_knots;
     const int num_derivative_knots = basis_.knots().size() - 2;

--- a/common/trajectories/bspline_trajectory.h
+++ b/common/trajectories/bspline_trajectory.h
@@ -54,12 +54,6 @@ class BsplineTrajectory final : public trajectories::Trajectory<T> {
            `value(0)` for a trajectory defined over [0, 1]. */
   MatrixX<T> value(const T& time) const override;
 
-  // TODO(avalenzu): The default parameter here violates the GSG, but is
-  // included to match the parent class. It should be removed along with the
-  // corresponding one in trajectories::Trajectory.
-  std::unique_ptr<trajectories::Trajectory<T>> MakeDerivative(
-      int derivative_order = 1) const override;
-
   Eigen::Index rows() const override { return control_points()[0].rows(); }
 
   Eigen::Index cols() const override { return control_points()[0].cols(); }
@@ -118,6 +112,9 @@ class BsplineTrajectory final : public trajectories::Trajectory<T> {
   boolean<T> operator==(const BsplineTrajectory<T>& other) const;
 
  private:
+  std::unique_ptr<trajectories::Trajectory<T>> DoMakeDerivative(
+      int derivative_order) const override;
+
   math::BsplineBasis<T> basis_;
   std::vector<MatrixX<T>> control_points_;
 };

--- a/common/trajectories/exponential_plus_piecewise_polynomial.h
+++ b/common/trajectories/exponential_plus_piecewise_polynomial.h
@@ -60,11 +60,6 @@ class ExponentialPlusPiecewisePolynomial final
 
   ExponentialPlusPiecewisePolynomial derivative(int derivative_order = 1) const;
 
-  std::unique_ptr<Trajectory<T>> MakeDerivative(
-      int derivative_order = 1) const override {
-    return derivative(derivative_order).Clone();
-  };
-
   Eigen::Index rows() const override;
 
   Eigen::Index cols() const override;
@@ -72,6 +67,11 @@ class ExponentialPlusPiecewisePolynomial final
   void shiftRight(double offset);
 
  private:
+  std::unique_ptr<Trajectory<T>> DoMakeDerivative(
+      int derivative_order = 1) const override {
+    return derivative(derivative_order).Clone();
+  };
+
   MatrixX<T> K_;
   MatrixX<T> A_;
   MatrixX<T> alpha_;

--- a/common/trajectories/piecewise_polynomial.cc
+++ b/common/trajectories/piecewise_polynomial.cc
@@ -113,8 +113,8 @@ T PiecewisePolynomial<T>::scalarValue(const T& t, Eigen::Index row,
 }
 
 template <typename T>
-MatrixX<T> PiecewisePolynomial<T>::EvalDerivative(const T& t,
-                                                  int derivative_order) const {
+MatrixX<T> PiecewisePolynomial<T>::DoEvalDerivative(
+    const T& t, int derivative_order) const {
   const int segment_index = this->get_segment_index(t);
   const T time = min(max(t, this->start_time()), this->end_time());
   Eigen::Matrix<T, PolynomialMatrix::RowsAtCompileTime,

--- a/common/trajectories/piecewise_polynomial.h
+++ b/common/trajectories/piecewise_polynomial.h
@@ -516,11 +516,6 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    */
   PiecewisePolynomial<T> derivative(int derivative_order = 1) const;
 
-  std::unique_ptr<Trajectory<T>> MakeDerivative(
-      int derivative_order = 1) const override {
-    return derivative(derivative_order).Clone();
-  };
-
   /**
    * Returns a %PiecewisePolynomial that is the indefinite integral of this one.
    * Any rules or limitations of Polynomial::integral() also apply to this
@@ -571,17 +566,8 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    */
   MatrixX<T> value(const T& t) const override {
       const int derivative_order = 0;
-      return EvalDerivative(t, derivative_order);
+      return DoEvalDerivative(t, derivative_order);
   }
-
-  /**
-   * Evaluates the %PiecwisePolynomial derivative at the given time @p t.
-   * Returns the nth derivative, where `n` is the value of @p derivative_order.
-   *
-   * @warning This method comes with the same caveats as value(). See value().
-   * @pre derivative_order must be non-negative.
-   */
-  MatrixX<T> EvalDerivative(const T& t, int derivative_order = 1) const;
 
   /**
    * Gets the matrix of Polynomials corresponding to the given segment index.
@@ -621,7 +607,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
 
   /**
    * Reshapes the dimensions of the Eigen::MatrixX<T> returned by value(),
-   * EvalDerivatives(), etc.
+   * EvalDerivative(), etc.
    *
    * @pre @p rows x @p cols must equal this.rows() * this.cols().
    * @see Eigen::PlainObjectBase::resize().
@@ -812,6 +798,18 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
   PiecewisePolynomial slice(int start_segment_index, int num_segments) const;
 
  private:
+  // Evaluates the %PiecwisePolynomial derivative at the given time @p t.
+  // Returns the nth derivative, where `n` is the value of @p derivative_order.
+  //
+  // @warning This method comes with the same caveats as value(). See value()
+  // @pre derivative_order must be non-negative.
+  MatrixX<T> DoEvalDerivative(const T& t, int derivative_order) const override;
+
+  std::unique_ptr<Trajectory<T>> DoMakeDerivative(
+      int derivative_order) const override {
+    return derivative(derivative_order).Clone();
+  };
+
   T EvaluateSegmentAbsoluteTime(int segment_index, const T& t, Eigen::Index row,
                                 Eigen::Index col,
                                 int derivative_order = 0) const;

--- a/common/trajectories/piecewise_quaternion.cc
+++ b/common/trajectories/piecewise_quaternion.cc
@@ -142,13 +142,6 @@ Vector3<T> PiecewiseQuaternionSlerp<T>::angular_velocity(double t) const {
 }
 
 template <typename T>
-std::unique_ptr<Trajectory<T>> PiecewiseQuaternionSlerp<T>::MakeDerivative(
-    int) const {
-  throw std::runtime_error("Derivatives of PiecewiseQuaternionSlerp are not "
-                               "implemented yet.");
-}
-
-template <typename T>
 Vector3<T> PiecewiseQuaternionSlerp<T>::angular_acceleration(double) const {
   return Vector3<T>::Zero();
 }

--- a/common/trajectories/piecewise_quaternion.h
+++ b/common/trajectories/piecewise_quaternion.h
@@ -94,13 +94,6 @@ class PiecewiseQuaternionSlerp final : public PiecewiseTrajectory<T> {
   Vector3<T> angular_velocity(double t) const;
 
   /**
-   * @throws std::runtime_error (always) because it is not implemented yet.
-   */
-  // TODO(russt): Implement this if/when someone needs it!
-  std::unique_ptr<Trajectory<T>> MakeDerivative(
-      int derivative_order = 1) const override;
-
-  /**
    * Interpolates angular acceleration.
    * @param t Time for interpolation.
    * @return The interpolated angular acceleration at `t`,

--- a/common/trajectories/test/piecewise_trajectory_test.cc
+++ b/common/trajectories/test/piecewise_trajectory_test.cc
@@ -26,9 +26,6 @@ class PiecewiseTrajectoryTester : public PiecewiseTrajectory<T> {
   std::unique_ptr<Trajectory<T>> Clone() const override {
     return nullptr;
   }
-  std::unique_ptr<Trajectory<T>> MakeDerivative(int) const override {
-    return nullptr;
-  }
 };
 
 void TestPiecewiseTrajectoryTimeRelatedGetters(

--- a/common/trajectories/test/trajectory_test.cc
+++ b/common/trajectories/test/trajectory_test.cc
@@ -1,0 +1,82 @@
+#include "drake/common/trajectories/trajectory.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+namespace drake {
+namespace trajectories {
+
+namespace {
+
+// Dummy implementation of Trajectory to test the basic functions.
+template <typename T = double>
+class TrajectoryTester : public Trajectory<T> {
+ public:
+  explicit TrajectoryTester(bool has_derivative)
+      : has_derivative_(has_derivative) {}
+
+  MatrixX<T> value(const T& t) const override {
+    return MatrixX<T>(0, 0);
+  }
+  std::unique_ptr<Trajectory<T>> Clone() const override {
+    return nullptr;
+  }
+  Eigen::Index rows() const override { return 0; }
+  Eigen::Index cols() const override { return 0; }
+  T start_time() const override { return 0; }
+  T end_time() const override { return 1; }
+
+ private:
+  bool do_has_derivative() const override {
+    return has_derivative_;
+  }
+
+  bool has_derivative_;
+};
+
+GTEST_TEST(TrajectoryTest, EvalDerivativesTest) {
+  TrajectoryTester traj_yes_deriv(true);
+  EXPECT_TRUE(traj_yes_deriv.has_derivative());
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      traj_yes_deriv.EvalDerivative(traj_yes_deriv.start_time()),
+      std::logic_error, ".* must implement .*");
+
+  TrajectoryTester traj_no_deriv(false);
+  EXPECT_FALSE(traj_no_deriv.has_derivative());
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      traj_no_deriv.EvalDerivative(traj_no_deriv.start_time()),
+      std::logic_error, ".* does not support .*");
+}
+
+GTEST_TEST(TrajectoryTest, MakeDerivativesTest) {
+  TrajectoryTester traj_yes_deriv(true);
+  EXPECT_TRUE(traj_yes_deriv.has_derivative());
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      traj_yes_deriv.MakeDerivative(),
+      std::logic_error, ".* must implement .*");
+
+  TrajectoryTester traj_no_deriv(false);
+  EXPECT_FALSE(traj_no_deriv.has_derivative());
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      traj_no_deriv.MakeDerivative(),
+      std::logic_error, ".* does not support .*");
+}
+
+template <typename T>
+void TestScalarType() {
+  TrajectoryTester<T> traj(true);
+
+  const MatrixX<T> value = traj.value(traj.start_time());
+  EXPECT_EQ(value.rows(), 0);
+  EXPECT_EQ(value.cols(), 0);
+}
+
+GTEST_TEST(PiecewiseTrajectoryTest, ScalarTypes) {
+  TestScalarType<AutoDiffXd>();
+  TestScalarType<symbolic::Expression>();
+}
+
+}  // namespace
+}  // namespace trajectories
+}  // namespace drake

--- a/common/trajectories/trajectory.cc
+++ b/common/trajectories/trajectory.cc
@@ -1,0 +1,85 @@
+#include "drake/common/trajectories/trajectory.h"
+
+#include "drake/common/unused.h"
+
+namespace drake {
+namespace trajectories {
+
+template <typename T>
+MatrixX<T> Trajectory<T>::vector_values(const std::vector<T>& t) const {
+  if (cols() != 1 && rows() != 1) {
+    throw std::runtime_error(
+        "This method only supports vector-valued trajectories.");
+  }
+  if (cols() == 1) {
+    MatrixX<T> values(rows(), t.size());
+    for (int i = 0; i < static_cast<int>(t.size()); i++) {
+      values.col(i) = value(t[i]);
+    }
+    return values;
+  }
+  MatrixX<T> values(t.size(), cols());
+  for (int i = 0; i < static_cast<int>(t.size()); i++) {
+    values.row(i) = value(t[i]);
+  }
+  return values;
+}
+
+template <typename T>
+bool Trajectory<T>::has_derivative() const {
+  return do_has_derivative();
+}
+
+template <typename T>
+bool Trajectory<T>::do_has_derivative() const {
+  return false;
+}
+
+template <typename T>
+MatrixX<T> Trajectory<T>::EvalDerivative(const T& t,
+                                         int derivative_order) const {
+  return DoEvalDerivative(t, derivative_order);
+}
+
+template <typename T>
+MatrixX<T> Trajectory<T>::DoEvalDerivative(const T& t,
+                                           int derivative_order) const {
+  unused(t);
+  unused(derivative_order);
+  if (has_derivative()) {
+    throw std::logic_error(
+        "Trajectory classes that promise derivatives via do_has_derivative() "
+        "must implement DoEvalDerivative().");
+  } else {
+    throw std::logic_error(
+        "You asked for derivatives from a class that does not support "
+        "derivatives.");
+  }
+}
+
+template <typename T>
+std::unique_ptr<Trajectory<T>> Trajectory<T>::MakeDerivative(
+    int derivative_order) const {
+  return DoMakeDerivative(derivative_order);
+}
+
+template <typename T>
+std::unique_ptr<Trajectory<T>> Trajectory<T>::DoMakeDerivative(
+    int derivative_order) const {
+  unused(derivative_order);
+  if (has_derivative()) {
+    throw std::logic_error(
+        "Trajectory classes that promise derivatives via do_has_derivative() "
+        "must implement DoMakeDerivative().");
+  } else {
+    throw std::logic_error(
+        "You asked for derivatives from a class that does not support "
+        "derivatives.");
+  }
+}
+
+}  // namespace trajectories
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class drake::trajectories::Trajectory)

--- a/common/trajectories/trajectory.h
+++ b/common/trajectories/trajectory.h
@@ -5,6 +5,7 @@
 
 #include <Eigen/Core>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 
@@ -15,8 +16,7 @@ namespace trajectories {
  * A Trajectory represents a time-varying matrix, indexed by a single scalar
  * time.
  *
- * @tparam T is any scalar type. This is a header-only abstract class (so no
- * concrete scalar type instantiations need to be provided).
+ * @tparam_default_scalars
  */
 template <typename T>
 class Trajectory {
@@ -43,24 +43,23 @@ class Trajectory {
   * the ith time.
   * @throws std::runtime_error if both cols and rows are not equal to 1.
   */
-  MatrixX<T> vector_values(const std::vector<T>& t) const {
-    if (cols() != 1 && rows() != 1) {
-      throw std::runtime_error(
-          "This method only supports vector-valued trajectories.");
-    }
-    if (cols() == 1) {
-      MatrixX<T> values(rows(), t.size());
-      for (int i = 0; i < static_cast<int>(t.size()); i++) {
-        values.col(i) = value(t[i]);
-      }
-      return values;
-    }
-    MatrixX<T> values(t.size(), cols());
-    for (int i = 0; i < static_cast<int>(t.size()); i++) {
-      values.row(i) = value(t[i]);
-    }
-    return values;
-  }
+  MatrixX<T> vector_values(const std::vector<T>& t) const;
+
+  /**
+   * Returns true iff the Trajectory provides and implementation for
+   * EvalDerivative() and MakeDerivative().  The derivative need not be
+   * continuous, but should return a result for all t for which value(t) returns
+   * a result.
+   */
+  bool has_derivative() const;
+
+  /**
+   * Evaluates the derivative of `this` at the given time @p t.
+   * Returns the nth derivative, where `n` is the value of @p derivative_order.
+   *
+   * @pre derivative_order must be non-negative.
+   */
+  MatrixX<T> EvalDerivative(const T& t, int derivative_order = 1) const;
 
   /**
    * Takes the derivative of this Trajectory.
@@ -68,8 +67,8 @@ class Trajectory {
    * returning.
    * @return The nth derivative of this object.
    */
-  virtual std::unique_ptr<Trajectory<T>> MakeDerivative(
-      int derivative_order = 1) const = 0;
+  std::unique_ptr<Trajectory<T>> MakeDerivative(
+      int derivative_order = 1) const;
 
   /**
    * @return The number of rows in the matrix returned by value().
@@ -89,7 +88,17 @@ class Trajectory {
   // Final subclasses are allowed to make copy/move/assign public.
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Trajectory)
   Trajectory() = default;
+
+  virtual bool do_has_derivative() const;
+
+  virtual MatrixX<T> DoEvalDerivative(const T& t, int derivative_order) const;
+
+  virtual std::unique_ptr<Trajectory<T>> DoMakeDerivative(
+      int derivative_order) const;
 };
 
 }  // namespace trajectories
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class drake::trajectories::Trajectory)


### PR DESCRIPTION
I've started the NVI pattern here, rather than adding another public virtual.
It's inconsistent with the rest of the class, but the goal is to move this direction.

Also started trajectory.cc => trajectory is now @tparam default_scalar, instead of @tparam ANY

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13144)
<!-- Reviewable:end -->
