### PR TITLE
manipulation: De-duplicate model preview functionality

### DIFF
--- a/manipulation/BUILD.bazel
+++ b/manipulation/BUILD.bazel
@@ -1,0 +1,16 @@
+# -*- python -*-
+
+load(
+    "@drake//tools/skylark:drake_py.bzl",
+    "drake_py_library",
+)
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+drake_py_library(
+    name = "module_py",
+    srcs = ["__init__.py"],
+    # N.B. deps = ["//:module_py"] is currently implicit.
+    visibility = ["//manipulation/util:__pkg__"],
+)
+
+add_lint_tests()

--- a/manipulation/__init__.py
+++ b/manipulation/__init__.py
@@ -1,0 +1,1 @@
+# Empty Python module `__init__`, required to make this a module.

--- a/manipulation/util/BUILD.bazel
+++ b/manipulation/util/BUILD.bazel
@@ -9,11 +9,21 @@ load(
 load(
     "@drake//tools/skylark:drake_py.bzl",
     "drake_py_binary",
+    "drake_py_library",
     "drake_py_unittest",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 package(default_visibility = ["//visibility:public"])
+
+drake_py_library(
+    name = "module_py",
+    srcs = ["__init__.py"],
+    visibility = [":__pkg__"],
+    deps = [
+        "//manipulation:module_py",
+    ],
+)
 
 drake_cc_package_library(
     name = "util",
@@ -40,6 +50,7 @@ drake_py_binary(
     name = "geometry_inspector",
     srcs = ["geometry_inspector.py"],
     deps = [
+        ":show_model",
         "//bindings/pydrake",
     ],
 )
@@ -92,7 +103,10 @@ drake_cc_library(
 drake_py_binary(
     name = "show_model",
     srcs = ["show_model.py"],
-    deps = ["//bindings/pydrake"],
+    deps = [
+        ":module_py",
+        "//bindings/pydrake",
+    ],
 )
 
 drake_py_binary(

--- a/manipulation/util/__init__.py
+++ b/manipulation/util/__init__.py
@@ -1,0 +1,1 @@
+# Empty Python module `__init__`, required to make this a module.

--- a/manipulation/util/show_model.py
+++ b/manipulation/util/show_model.py
@@ -4,12 +4,16 @@ available visualizers.
 To view the model with a simple gui to change joint positions, please see
 `geometry_inspector`.
 
-Example usage:
+To build all necessary targets and see available command-line options:
 
     cd drake
     bazel build \
         //tools:drake_visualizer @meshcat_python//:meshcat-server \
         //manipulation/util:show_model
+
+    ./bazel-bin/manipulation/util/show_model --help
+
+Example usage:
 
     # Terminal 1
     ./bazel-bin/tools/drake_visualizer
@@ -18,67 +22,172 @@ Example usage:
     # Terminal 3 (wait for visualizers to start)
     ./bazel-bin/manipulation/util/show_model \
         --meshcat default \
-        ./manipulation/models/iiwa_description/iiwa7/iiwa7_no_collision.sdf
+        --find_resource \
+        drake/manipulation/models/iiwa_description/iiwa7/iiwa7_no_collision.sdf
 
-NOTE: If `--meshcat` is not specified, no meshcat visualization will take
+If your model has all of its data available in your source tree, then you can
+remove the need for `--find_resource`:
+
+    ./bazel-bin/manipulation/util/show_model \
+        --meshcat default \
+        ${PWD}/manipulation/models/iiwa_description/sdf/iiwa7_no_collision.sdf
+
+Note:
+    If `--meshcat` is not specified, no meshcat visualization will take
 place.
 
-NOTE: If you use `bazel run`, it is highly encouraged that you use absolute
-paths, as certain models may not be prerequisites of this binary.
+Note:
+    If you use `bazel run` without `--find_resource`, it is highly encouraged
+that you use absolute paths, as certain models may not be prerequisites of this
+binary.
 """
 
 import argparse
 import os
-import sys
 
-from pydrake.lcm import DrakeLcm
-from pydrake.geometry import ConnectDrakeVisualizer, SceneGraph
+from pydrake.common import FindResourceOrThrow
+from pydrake.geometry import MakePhongIllustrationProperties
+from pydrake.geometry import ConnectDrakeVisualizer
 from pydrake.multibody.parsing import Parser
-from pydrake.multibody.plant import MultibodyPlant
+from pydrake.multibody.plant import AddMultibodyPlantSceneGraph
 from pydrake.systems.analysis import Simulator
 from pydrake.systems.framework import DiagramBuilder
 from pydrake.systems.meshcat_visualizer import MeshcatVisualizer
+from pydrake.systems.planar_scenegraph_visualizer import (
+    PlanarSceneGraphVisualizer,
+)
+
+
+def add_filename_and_parser_argparse_arguments(args_parser):
+    """
+    Adds argparse arguments for filename and model parsing.
+    """
+    args_parser.add_argument(
+        "filename", type=str, default=None,
+        help="Path to an SDF or URDF file.")
+    args_parser.add_argument(
+        "--find_resource", action="store_true",
+        help="Use FindResourceOrThrow to resolve the filename to a Drake "
+             "resource. Use this if the supporting data files are a generated "
+             "by Bazel (e.g. the OBJs or PNGs are in @models).")
+    args_parser.add_argument(
+        "--package_path", type=str, default=None,
+        help="Full path to the root package for reading in SDF resources.")
+
+
+def parse_filename_and_parser(args_parser, args):
+    """
+    Parses results from arguments added by
+    `add_filename_and_parser_argparse_arguments`:
+    * Parses filename (and possibly --find_resource) and returns filename.
+    * Parses --package_path and returns make_parser factory.
+    """
+
+    def make_parser(plant):
+        parser = Parser(plant)
+        # Get the package pathname.
+        if args.package_path:
+            # Verify that package.xml is found in the designated path.
+            package_path = os.path.abspath(args.package_path)
+            if not os.path.isfile(os.path.join(package_path, "package.xml")):
+                args_parser.error(f"package.xml not found at: {package_path}")
+
+            # Get the package map and populate it using the package path.
+            parser.package_map().PopulateFromFolder(package_path)
+        return parser
+
+    if args.find_resource:
+        res_path = os.path.normpath(args.filename)
+        print(f"Using FindResourceOrThrow('{res_path}')")
+        filename = FindResourceOrThrow(res_path)
+    else:
+        filename = os.path.abspath(args.filename)
+        if not os.path.isfile(filename):
+            args_parser.error(f"File does not exist: {filename}")
+
+    return filename, make_parser
+
+
+def add_visualizers_argparse_arguments(args_parser):
+    """
+    Adds argparse arguments for visualizers.
+    """
+    MeshcatVisualizer.add_argparse_argument(args_parser)
+    args_parser.add_argument(
+        "--pyplot", action="store_true",
+        help="Opens a pyplot figure for rendering using "
+             "PlanarSceneGraphVisualizer.")
+    # TODO(russt): Consider supporting the PlanarSceneGraphVisualizer
+    #  options as additional arguments.
+    args_parser.add_argument(
+        "--visualize_collisions", action="store_true",
+        help="Visualize the collision geometry in the visualizer. The "
+        "collision geometries will be shown in red to differentiate "
+        "them from the visual geometries.")
+
+
+def parse_visualizers(args_parser, args):
+    """
+    Parses argparse arguments for visualizers, returning update_visulization
+    and connect_visualizers.
+    """
+
+    def update_visualization(plant, scene_graph):
+        if args.visualize_collisions:
+            # Find all the geometries that have not already been marked as
+            # 'illustration' (visual) and assume they are collision geometries.
+            # Then add illustration properties to them that will draw them in
+            # red and fifty percent translucent.
+            source_id = plant.get_source_id()
+            inspector = scene_graph.model_inspector()
+            diffuse_rgba = [1, 0, 0, 0.5]
+            red_illustration = MakePhongIllustrationProperties(diffuse_rgba)
+            for geometry_id in inspector.GetAllGeometryIds():
+                if inspector.GetIllustrationProperties(geometry_id) is None:
+                    scene_graph.AssignRole(
+                        source_id, geometry_id, red_illustration)
+
+    def connect_visualizers(builder, plant, scene_graph):
+        # Connect this to drake_visualizer.
+        ConnectDrakeVisualizer(builder=builder, scene_graph=scene_graph)
+
+        # Connect to Meshcat.
+        if args.meshcat is not None:
+            meshcat_viz = builder.AddSystem(
+                MeshcatVisualizer(scene_graph, zmq_url=args.meshcat))
+            builder.Connect(
+                scene_graph.get_pose_bundle_output_port(),
+                meshcat_viz.get_input_port(0))
+
+        # Connect to PyPlot.
+        if args.pyplot:
+            pyplot = builder.AddSystem(PlanarSceneGraphVisualizer(scene_graph))
+            builder.Connect(scene_graph.get_pose_bundle_output_port(),
+                            pyplot.get_input_port(0))
+
+    return update_visualization, connect_visualizers
 
 
 def main():
-    parser = argparse.ArgumentParser(
+    args_parser = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument(
-        "filename", type=str,
-        help="Path to an SDF or URDF file.")
-    MeshcatVisualizer.add_argparse_argument(parser)
-    args = parser.parse_args()
-    filename = args.filename
-    if not os.path.isfile(filename):
-        parser.error("File does not exist: {}".format(filename))
+    add_filename_and_parser_argparse_arguments(args_parser)
+    add_visualizers_argparse_arguments(args_parser)
+    args = args_parser.parse_args()
+    filename, make_parser = parse_filename_and_parser(args_parser, args)
+    update_visualization, connect_visualizers = parse_visualizers(
+        args_parser, args)
 
     # Construct Plant + SceneGraph.
     builder = DiagramBuilder()
-    plant = builder.AddSystem(MultibodyPlant(0.0))
-    scene_graph = builder.AddSystem(SceneGraph())
-    plant.RegisterAsSourceForSceneGraph(scene_graph)
-    builder.Connect(
-        scene_graph.get_query_output_port(),
-        plant.get_geometry_query_input_port())
-    builder.Connect(
-        plant.get_geometry_poses_output_port(),
-        scene_graph.get_source_pose_port(plant.get_source_id()))
+    plant, scene_graph = AddMultibodyPlantSceneGraph(builder, time_step=0.0)
     # Load the model file.
-    Parser(plant).AddModelFromFile(filename)
+    make_parser(plant).AddModelFromFile(filename)
+    update_visualization(plant, scene_graph)
     plant.Finalize()
 
-    # Publish to Drake Visualizer.
-    drake_viz_pub = ConnectDrakeVisualizer(builder, scene_graph)
-
-    # Publish to Meshcat.
-    if args.meshcat is not None:
-        meshcat_viz = builder.AddSystem(
-            MeshcatVisualizer(scene_graph, zmq_url=args.meshcat))
-        builder.Connect(
-            scene_graph.get_pose_bundle_output_port(),
-            meshcat_viz.get_input_port(0))
-
+    connect_visualizers(builder, plant, scene_graph)
     diagram = builder.Build()
     context = diagram.CreateDefaultContext()
 


### PR DESCRIPTION
Add explicit --find_runfiles

Motivated by / extracted from #13050

Initially, this was to add the `--find_resource` command. However, I noticed there to be shareable functionality that wasn't shared, so I made it common.

(I disprefer opening slider bars if I only need to preview the models.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13148)
<!-- Reviewable:end -->
