### PR TITLE
common: Use BsplineBasis<T> in BsplineTrajectory<T>

### DIFF
--- a/common/trajectories/BUILD.bazel
+++ b/common/trajectories/BUILD.bazel
@@ -149,6 +149,7 @@ drake_cc_googletest(
     deps = [
         ":bspline_trajectory",
         "//common:find_resource",
+        "//common/proto:call_python",
         "//common/test_utilities",
         "//math:compute_numerical_gradient",
         "//math:gradient",

--- a/common/trajectories/BUILD.bazel
+++ b/common/trajectories/BUILD.bazel
@@ -149,9 +149,9 @@ drake_cc_googletest(
     deps = [
         ":bspline_trajectory",
         "//common:find_resource",
-        "//common/proto:call_python",
         "//common/test_utilities",
         "//math:compute_numerical_gradient",
+        "//math:gradient",
     ],
 )
 

--- a/common/trajectories/bspline_trajectory.cc
+++ b/common/trajectories/bspline_trajectory.cc
@@ -21,7 +21,7 @@ namespace trajectories {
 using math::BsplineBasis;
 
 template <typename T>
-BsplineTrajectory<T>::BsplineTrajectory(BsplineBasis<double> basis,
+BsplineTrajectory<T>::BsplineTrajectory(BsplineBasis<T> basis,
                                         std::vector<MatrixX<T>> control_points)
     : basis_(std::move(basis)), control_points_(std::move(control_points)) {
   DRAKE_DEMAND(static_cast<int>(control_points_.size()) ==
@@ -37,9 +37,8 @@ template <typename T>
 MatrixX<T> BsplineTrajectory<T>::value(const T& time) const {
   using std::max;
   using std::min;
-  return basis().EvaluateCurve(
-      control_points(),
-      drake::ExtractDoubleOrThrow(min(max(time, start_time()), end_time())));
+  return basis().EvaluateCurve(control_points(),
+                               min(max(time, start_time()), end_time()));
 }
 
 template <typename T>
@@ -50,7 +49,7 @@ std::unique_ptr<Trajectory<T>> BsplineTrajectory<T>::MakeDerivative(
   } else if (derivative_order > 1) {
     return MakeDerivative(1)->MakeDerivative(derivative_order - 1);
   } else if (derivative_order == 1) {
-    std::vector<double> derivative_knots;
+    std::vector<T> derivative_knots;
     const int num_derivative_knots = basis_.knots().size() - 2;
     derivative_knots.reserve(num_derivative_knots);
     for (int i = 1; i <= num_derivative_knots; ++i) {
@@ -65,7 +64,7 @@ std::unique_ptr<Trajectory<T>> BsplineTrajectory<T>::MakeDerivative(
           (control_points()[i + 1] - control_points()[i]));
     }
     return std::make_unique<BsplineTrajectory<T>>(
-        BsplineBasis<double>(basis_.order() - 1, derivative_knots),
+        BsplineBasis<T>(basis_.order() - 1, derivative_knots),
         derivative_control_points);
   } else {
     throw std::invalid_argument(
@@ -86,11 +85,10 @@ MatrixX<T> BsplineTrajectory<T>::FinalValue() const {
 }
 
 template <typename T>
-void BsplineTrajectory<T>::InsertKnots(
-    const std::vector<double>& additional_knots) {
+void BsplineTrajectory<T>::InsertKnots(const std::vector<T>& additional_knots) {
   if (additional_knots.size() != 1) {
     for (const auto& time : additional_knots) {
-      InsertKnots(std::vector<double>{time});
+      InsertKnots(std::vector<T>{time});
     }
   } else {
     // Implements Boehm's Algorithm for knot insertion as described in by
@@ -99,19 +97,19 @@ void BsplineTrajectory<T>::InsertKnots(
     // [1] http://web.mit.edu/hyperbook/Patrikalakis-Maekawa-Cho/node18.html
 
     // Define short-hand references to match Patrikalakis et al.:
-    const std::vector<double>& t = basis_.knots();
-    const double t_bar = additional_knots.front();
+    const std::vector<T>& t = basis_.knots();
+    const T& t_bar = additional_knots.front();
     const int k = basis_.order();
     DRAKE_DEMAND(start_time() <= t_bar && t_bar <= end_time());
 
     /* Find the index, 𝑙, of the greatest knot that is less than or equal to
     t_bar and strictly less than end_time(). */
     const int ell = basis().FindContainingInterval(t_bar);
-    std::vector<double> new_knots = t;
+    std::vector<T> new_knots = t;
     new_knots.insert(std::next(new_knots.begin(), ell + 1), t_bar);
     std::vector<MatrixX<T>> new_control_points{this->control_points().front()};
     for (int i = 1; i < this->num_control_points(); ++i) {
-      double a{0};
+      T a{0};
       if (i < ell - k + 2) {
         a = 1;
       } else if (i <= ell) {
@@ -134,7 +132,7 @@ void BsplineTrajectory<T>::InsertKnots(
     // new_control_points. Do that now.
     new_control_points.push_back(this->control_points().back());
     control_points_.swap(new_control_points);
-    basis_ = BsplineBasis<double>(basis_.order(), new_knots);
+    basis_ = BsplineBasis<T>(basis_.order(), new_knots);
   }
 }
 

--- a/common/trajectories/bspline_trajectory.h
+++ b/common/trajectories/bspline_trajectory.h
@@ -26,11 +26,11 @@ class BsplineTrajectory final : public trajectories::Trajectory<T> {
                     std::vector<MatrixX<T>> control_points);
 
 #ifdef DRAKE_DOXYGEN_CXX
-  /** Constructs a B-spline trajectory with the given (double) `basis` and
-  `control_points`.
+  /** Constructs a T-valued B-spline trajectory from a double-valued `basis` and
+  T-valued `control_points`.
   @pre control_points.size() == basis.num_basis_functions() */
   BsplineTrajectory(math::BsplineBasis<double> basis,
-                    std::vector<MatrixX<T>> control_points,
+                    std::vector<MatrixX<T>> control_points);
 #else
   template <typename U = T>
   BsplineTrajectory(math::BsplineBasis<double> basis,

--- a/common/trajectories/bspline_trajectory.h
+++ b/common/trajectories/bspline_trajectory.h
@@ -22,8 +22,22 @@ class BsplineTrajectory final : public trajectories::Trajectory<T> {
   /** Constructs a B-spline trajectory with the given `basis` and
   `control_points`.
   @pre control_points.size() == basis.num_basis_functions() */
-  BsplineTrajectory(math::BsplineBasis<double> basis,
+  BsplineTrajectory(math::BsplineBasis<T> basis,
                     std::vector<MatrixX<T>> control_points);
+
+#ifdef DRAKE_DOXYGEN_CXX
+  /** Constructs a B-spline trajectory with the given (double) `basis` and
+  `control_points`.
+  @pre control_points.size() == basis.num_basis_functions() */
+  BsplineTrajectory(math::BsplineBasis<double> basis,
+                    std::vector<MatrixX<T>> control_points,
+#else
+  template <typename U = T>
+  BsplineTrajectory(math::BsplineBasis<double> basis,
+                    std::vector<MatrixX<T>> control_points,
+                    typename std::enable_if_t<!std::is_same_v<U, double>>* = {})
+      : BsplineTrajectory(math::BsplineBasis<T>(basis), control_points) {}
+#endif
 
   virtual ~BsplineTrajectory() = default;
 
@@ -31,8 +45,9 @@ class BsplineTrajectory final : public trajectories::Trajectory<T> {
   std::unique_ptr<trajectories::Trajectory<T>> Clone() const override;
 
   /** Evaluates the BsplineTrajectory at the given time t.
-  @param t The time at which to evaluate the %PiecewisePolynomial.
+  @param t The time at which to evaluate the %BsplineTrajectory.
   @return The matrix of evaluated values.
+  @pre If T == symbolic::Expression, `t.is_constant()` must be true.
   @warning If t does not lie in the range [start_time(), end_time()], the
            trajectory will silently be evaluated at the closest
            valid value of time to t. For example, `value(-1)` will return
@@ -69,7 +84,7 @@ class BsplineTrajectory final : public trajectories::Trajectory<T> {
   MatrixX<T> FinalValue() const;
 
   /** Returns the basis of this curve. */
-  const math::BsplineBasis<double>& basis() const { return basis_; }
+  const math::BsplineBasis<T>& basis() const { return basis_; }
 
   /** Adds new knots at the specified `additional_knots` without changing the
   behavior of the trajectory. The basis and control points of the trajectory are
@@ -78,7 +93,7 @@ class BsplineTrajectory final : public trajectories::Trajectory<T> {
   the same level of continuity as the original, even if knot values are
   duplicated. Note that `additional_knots` need not be sorted.
   @pre start_time() <= t <= end_time() for all t in `additional_knots` */
-  void InsertKnots(const std::vector<double>& additional_knots);
+  void InsertKnots(const std::vector<T>& additional_knots);
 
   /** Returns a new BsplineTrajectory that uses the same basis as `this`, and
   whose control points are the result of calling `select(point)` on each `point`
@@ -103,7 +118,7 @@ class BsplineTrajectory final : public trajectories::Trajectory<T> {
   boolean<T> operator==(const BsplineTrajectory<T>& other) const;
 
  private:
-  math::BsplineBasis<double> basis_;
+  math::BsplineBasis<T> basis_;
   std::vector<MatrixX<T>> control_points_;
 };
 }  // namespace trajectories

--- a/common/trajectories/test/bspline_trajectory_test.cc
+++ b/common/trajectories/test/bspline_trajectory_test.cc
@@ -18,7 +18,6 @@ namespace trajectories {
 using math::autoDiffToGradientMatrix;
 using math::BsplineBasis;
 using math::ComputeNumericalGradient;
-using math::DiscardGradient;
 using math::KnotVectorType;
 using math::NumericalGradientMethod;
 using math::NumericalGradientOption;
@@ -234,21 +233,21 @@ TYPED_TEST(BsplineTrajectoryTests, InsertKnotsTest) {
 // evaluating it at the same point.
 GTEST_TEST(BsplineTrajectoryDerivativeTests, AutoDiffTest) {
   BsplineTrajectory<AutoDiffXd> trajectory = MakeCircleTrajectory<AutoDiffXd>();
-  std::unique_ptr<Trajectory<AutoDiffXd>> derivative_trajectory =
-      trajectory.MakeDerivative();
+  std::unique_ptr<Trajectory<double>> derivative_trajectory =
+      MakeCircleTrajectory<double>().MakeDerivative();
   const int num_times = 100;
   VectorX<double> t = VectorX<double>::LinSpaced(
       num_times, ExtractDoubleOrThrow(trajectory.start_time()),
       ExtractDoubleOrThrow(trajectory.end_time()));
-  const double tolerance = 20 * std::numeric_limits<double>::epsilon();
+  const double kTolerance = 20 * std::numeric_limits<double>::epsilon();
   for (int k = 0; k < num_times; ++k) {
     AutoDiffXd t_k = math::initializeAutoDiff(Vector1d{t(k)})[0];
     MatrixX<double> derivative_value =
         autoDiffToGradientMatrix(trajectory.value(t_k));
     MatrixX<double> expected_derivative_value =
-        DiscardGradient(derivative_trajectory->value(t(k)));
+        derivative_trajectory->value(t(k));
     EXPECT_TRUE(CompareMatrices(derivative_value, expected_derivative_value,
-                                tolerance));
+                                kTolerance));
   }
 }
 

--- a/common/trajectories/test/bspline_trajectory_test.cc
+++ b/common/trajectories/test/bspline_trajectory_test.cc
@@ -3,64 +3,69 @@
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
 
-#include "drake/common/proto/call_python.h"
+#include "drake/common/autodiff.h"
+#include "drake/common/symbolic.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/trajectories/trajectory.h"
+#include "drake/math/autodiff_gradient.h"
 #include "drake/math/bspline_basis.h"
 #include "drake/math/compute_numerical_gradient.h"
 #include "drake/math/knot_vector_type.h"
 
-DEFINE_bool(visualize, false,
-            "If true, emit Python plotting commands using CallPython(). "
-            "You must build and run //common/proto:call_python_client_cli "
-            "first in order to see the resulting plots (you will also need to "
-            "set up an rpc file - see the --help for call_python_client_cli "
-            "for more information). This option does not work with "
-            "`bazel run`. Run the binary from bazel-bin instead.");
-
 namespace drake {
 namespace trajectories {
 
+using math::autoDiffToGradientMatrix;
 using math::BsplineBasis;
 using math::ComputeNumericalGradient;
+using math::DiscardGradient;
 using math::KnotVectorType;
 using math::NumericalGradientMethod;
 using math::NumericalGradientOption;
+using symbolic::Expression;
 
 namespace {
-BsplineTrajectory<double> MakeCircleTrajectory() {
+template <typename T = double>
+BsplineTrajectory<T> MakeCircleTrajectory() {
+  using std::cos;
+  using std::sin;
   const int order = 4;
   const int num_control_points = 11;
-  std::vector<MatrixX<double>> control_points{};
-  const auto t_dummy =
-      VectorX<double>::LinSpaced(num_control_points, 0, 2 * M_PI);
+  std::vector<MatrixX<T>> control_points{};
+  const auto t_dummy = VectorX<T>::LinSpaced(num_control_points, 0, 2 * M_PI);
   for (int i = 0; i < num_control_points; ++i) {
     control_points.push_back(
-        (MatrixX<double>(2, 1) << std::sin(t_dummy(i)), std::cos(t_dummy(i)))
-            .finished());
+        (MatrixX<T>(2, 1) << sin(t_dummy(i)), cos(t_dummy(i))).finished());
   }
-  return {BsplineBasis<double>{order, num_control_points}, control_points};
+  return {BsplineBasis<T>{order, num_control_points}, control_points};
 }
+
 }  // namespace
 
+template <typename T>
+class BsplineTrajectoryTests : public ::testing::Test {};
+
+using DefaultScalars = ::testing::Types<double, AutoDiffXd, Expression>;
+TYPED_TEST_SUITE(BsplineTrajectoryTests, DefaultScalars);
+
 // Verifies that the constructors work as expected.
-GTEST_TEST(BsplineTrajectoryTests, ConstructorTest) {
+TYPED_TEST(BsplineTrajectoryTests, ConstructorTest) {
+  using T = TypeParam;
   const int expected_order = 4;
   const int expected_num_control_points = 11;
-  const std::vector<double> expected_knots{
+  const std::vector<T> expected_knots{
       0, 0, 0, 0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875, 1, 1, 1, 1};
   const int expected_rows = 2;
   const int expected_cols = 1;
-  const double expected_start_time = 0;
-  const double expected_end_time = 1;
-  std::vector<MatrixX<double>> expected_control_points{};
+  const T expected_start_time = 0;
+  const T expected_end_time = 1;
+  std::vector<MatrixX<T>> expected_control_points{};
   for (int i = 0; i < expected_num_control_points; ++i) {
     expected_control_points.push_back(
-        i * MatrixX<double>::Ones(expected_rows, expected_cols));
+        i * MatrixX<T>::Ones(expected_rows, expected_cols));
   }
-  BsplineBasis<double> bspline_basis_1{expected_order, expected_knots};
-  BsplineTrajectory<double> trajectory{bspline_basis_1,
-                                       expected_control_points};
+  BsplineBasis<T> bspline_basis_1{expected_order, expected_knots};
+  BsplineTrajectory<T> trajectory{bspline_basis_1, expected_control_points};
 
   // Verify method return values.
   EXPECT_EQ(trajectory.rows(), expected_rows);
@@ -68,44 +73,56 @@ GTEST_TEST(BsplineTrajectoryTests, ConstructorTest) {
   EXPECT_EQ(trajectory.start_time(), expected_start_time);
   EXPECT_EQ(trajectory.end_time(), expected_end_time);
   EXPECT_EQ(trajectory.control_points(), expected_control_points);
+
+  // Verify that construction from BsplineBasis<double> works.
+  std::vector<double> knots_double{};
+  for (const auto& knot : expected_knots) {
+    knots_double.push_back(ExtractDoubleOrThrow(knot));
+  }
+  BsplineBasis<double> bspline_basis_2{expected_order, knots_double};
+  BsplineTrajectory<T> trajectory_from_double{bspline_basis_2,
+                                              expected_control_points};
+  EXPECT_EQ(trajectory_from_double, trajectory);
 }
 
 // Verifies that value() works as expected (i.e. as a thin wrapper on
 // basis().EvaluateCurve() with clamping).
-GTEST_TEST(BsplineTrajectoryTests, ValueTest) {
-  BsplineTrajectory<double> trajectory = MakeCircleTrajectory();
+TYPED_TEST(BsplineTrajectoryTests, ValueTest) {
+  using T = TypeParam;
+  BsplineTrajectory<T> trajectory = MakeCircleTrajectory<T>();
 
   // Verify that value() returns the expected results.
   const int num_times = 100;
-  VectorX<double> t = VectorX<double>::LinSpaced(
-      num_times, trajectory.start_time() - 0.1, trajectory.end_time() + 0.1);
+  VectorX<T> t = VectorX<T>::LinSpaced(num_times, trajectory.start_time() - 0.1,
+                                       trajectory.end_time() + 0.1);
   for (int k = 0; k < num_times; ++k) {
-    MatrixX<double> value = trajectory.value(t(k));
-    double t_clamped = std::min(std::max(t(k), trajectory.start_time()),
-                                trajectory.end_time());
-    MatrixX<double> expected_value = trajectory.basis().EvaluateCurve(
+    MatrixX<T> value = trajectory.value(t(k));
+    T t_clamped = std::min(std::max(t(k), trajectory.start_time()),
+                           trajectory.end_time());
+    MatrixX<T> expected_value = trajectory.basis().EvaluateCurve(
         trajectory.control_points(), t_clamped);
     EXPECT_TRUE(CompareMatrices(value, expected_value,
-                                std::numeric_limits<double>::epsilon()));
+                                std::numeric_limits<T>::epsilon()));
   }
 }
 
 // Verifies that MakeDerivative() works as expected.
-GTEST_TEST(BsplineTrajectoryTests, MakeDerivativeTest) {
-  BsplineTrajectory<double> trajectory = MakeCircleTrajectory();
+TYPED_TEST(BsplineTrajectoryTests, MakeDerivativeTest) {
+  using T = TypeParam;
+  BsplineTrajectory<T> trajectory = MakeCircleTrajectory<T>();
 
   // Verify that MakeDerivative() returns the expected results.
-  std::unique_ptr<Trajectory<double>> derivative_trajectory =
+  std::unique_ptr<Trajectory<T>> derivative_trajectory =
       trajectory.MakeDerivative();
-  std::function<void(const Vector1<double>&, VectorX<double>*)> calc_value =
-      [&trajectory](const Vector1<double>& t, VectorX<double>* value) {
+  std::function<void(const Vector1<T>&, VectorX<T>*)> calc_value =
+      [&trajectory](const Vector1<T>& t, VectorX<T>* value) {
         *value = trajectory.value(t(0));
       };
   const int num_times = 100;
-  VectorX<double> t = VectorX<double>::LinSpaced(
-      num_times, trajectory.start_time(), trajectory.end_time());
+  VectorX<T> t = VectorX<T>::LinSpaced(num_times, trajectory.start_time(),
+                                       trajectory.end_time());
   for (int k = 0; k < num_times; ++k) {
-    MatrixX<double> derivative = derivative_trajectory->value(t(k));
+    MatrixX<T> derivative = derivative_trajectory->value(t(k));
     // To avoid evaluating the B-spline trajectory outside of its domain, we
     // use forward/backward finite differences at the start/end points.
     NumericalGradientMethod method = NumericalGradientMethod::kCentral;
@@ -117,28 +134,30 @@ GTEST_TEST(BsplineTrajectoryTests, MakeDerivativeTest) {
       method = NumericalGradientMethod::kBackward;
       tolerance = 1e-5;
     }
-    MatrixX<double> expected_derivative = ComputeNumericalGradient(
-        calc_value, Vector1<double>{t(k)}, NumericalGradientOption{method});
+    MatrixX<T> expected_derivative = ComputeNumericalGradient(
+        calc_value, Vector1<T>{t(k)}, NumericalGradientOption{method});
     EXPECT_TRUE(CompareMatrices(derivative, expected_derivative, tolerance));
   }
 }
 
 // Verifies that CopyBlock() works as expected.
-GTEST_TEST(BsplineTrajectoryTests, CopyBlockTest) {
+TYPED_TEST(BsplineTrajectoryTests, CopyBlockTest) {
+  using T = TypeParam;
+  using std::cos;
+  using std::sin;
   const int order = 4;
   const int num_control_points = 11;
   const int rows = 3;
   const int cols = 3;
-  std::vector<MatrixX<double>> control_points{};
-  std::vector<MatrixX<double>> expected_control_points{};
-  const auto t_dummy =
-      VectorX<double>::LinSpaced(num_control_points, 0, 2 * M_PI);
+  std::vector<MatrixX<T>> control_points{};
+  std::vector<MatrixX<T>> expected_control_points{};
+  const auto t_dummy = VectorX<T>::LinSpaced(num_control_points, 0, 2 * M_PI);
   for (int i = 0; i < num_control_points; ++i) {
-    double s = std::sin(t_dummy(i));
-    double c = std::cos(t_dummy(i));
+    T s = sin(t_dummy(i));
+    T c = cos(t_dummy(i));
     // clang-format off
     control_points.push_back(
-        (MatrixX<double>(rows, cols) <<
+        (MatrixX<T>(rows, cols) <<
          s, c, s,
          s, s, c,
          c, s, s).finished());
@@ -147,29 +166,29 @@ GTEST_TEST(BsplineTrajectoryTests, CopyBlockTest) {
   }
   for (const auto& knot_vector_type :
        {KnotVectorType::kUniform, KnotVectorType::kClampedUniform}) {
-    BsplineTrajectory<double> trajectory =
-        BsplineTrajectory<double>{
-            BsplineBasis<double>{order, num_control_points, knot_vector_type},
+    BsplineTrajectory<T> trajectory =
+        BsplineTrajectory<T>{
+            BsplineBasis<T>{order, num_control_points, knot_vector_type},
             control_points}
             .CopyBlock(0, 0, 2, 3);
-    BsplineTrajectory<double> expected_trajectory = BsplineTrajectory<double>{
-        BsplineBasis<double>{order, num_control_points, knot_vector_type},
+    BsplineTrajectory<T> expected_trajectory = BsplineTrajectory<T>{
+        BsplineBasis<T>{order, num_control_points, knot_vector_type},
         expected_control_points};
     EXPECT_EQ(trajectory, expected_trajectory);
   }
 }
 
 // Verifies that InsertKnots() works as expected.
-GTEST_TEST(BsplineTrajectoryTests, InsertKnotsTest) {
-  using common::CallPython;
-  BsplineTrajectory<double> original_trajectory = MakeCircleTrajectory();
+TYPED_TEST(BsplineTrajectoryTests, InsertKnotsTest) {
+  using T = TypeParam;
+  BsplineTrajectory<T> original_trajectory = MakeCircleTrajectory<T>();
 
   // Create a vector of new knots to add. Note that it contains a knot with a
   // multiplicity of 2.
-  std::vector<double> new_knots{original_trajectory.start_time(), M_PI_4, 0.25,
-                                0.25, original_trajectory.end_time()};
+  std::vector<T> new_knots{original_trajectory.start_time(), M_PI_4, 0.25, 0.25,
+                           original_trajectory.end_time()};
   // Add the new knots.
-  BsplineTrajectory<double> trajectory_with_new_knots = original_trajectory;
+  BsplineTrajectory<T> trajectory_with_new_knots = original_trajectory;
   trajectory_with_new_knots.InsertKnots({new_knots});
 
   // Verify that the number of control points after insertion is equal to the
@@ -198,26 +217,38 @@ GTEST_TEST(BsplineTrajectoryTests, InsertKnotsTest) {
   // and the trajectory with additional knots for `num_times` sampled values
   // of `t` between start_time() and end_time().
   const int num_times = 100;
-  VectorX<double> t =
-      VectorX<double>::LinSpaced(num_times, original_trajectory.start_time(),
-                                 original_trajectory.end_time());
+  VectorX<T> t =
+      VectorX<T>::LinSpaced(num_times, original_trajectory.start_time(),
+                            original_trajectory.end_time());
   const double tolerance = 2 * std::numeric_limits<double>::epsilon();
-  if (FLAGS_visualize) {
-    CallPython("figure");
-  }
   for (int k = 0; k < num_times; ++k) {
-    MatrixX<double> value = trajectory_with_new_knots.value(t(k));
-    MatrixX<double> expected_value = original_trajectory.value(t(k));
+    MatrixX<T> value = trajectory_with_new_knots.value(t(k));
+    MatrixX<T> expected_value = original_trajectory.value(t(k));
     EXPECT_TRUE(CompareMatrices(value, expected_value, tolerance));
-    if (FLAGS_visualize) {
-      CallPython(
-          "plot", t(k), value.transpose(),
-          CompareMatrices(value, expected_value, tolerance) ? "gs" : "rs");
-      CallPython("plot", t(k), expected_value.transpose(), "ko");
-    }
   }
-  if (FLAGS_visualize) {
-    CallPython("grid", true);
+}
+
+// Verifies that the derivatives obtained by evaluating a
+// `BsplineTrajectory<AutoDiffXd>` and extracting the gradient of the result
+// match those obtained by taking the derivative of the whole trajectory and
+// evaluating it at the same point.
+GTEST_TEST(BsplineTrajectoryDerivativeTests, AutoDiffTest) {
+  BsplineTrajectory<AutoDiffXd> trajectory = MakeCircleTrajectory<AutoDiffXd>();
+  std::unique_ptr<Trajectory<AutoDiffXd>> derivative_trajectory =
+      trajectory.MakeDerivative();
+  const int num_times = 100;
+  VectorX<double> t = VectorX<double>::LinSpaced(
+      num_times, ExtractDoubleOrThrow(trajectory.start_time()),
+      ExtractDoubleOrThrow(trajectory.end_time()));
+  const double tolerance = 20 * std::numeric_limits<double>::epsilon();
+  for (int k = 0; k < num_times; ++k) {
+    AutoDiffXd t_k = math::initializeAutoDiff(Vector1d{t(k)})[0];
+    MatrixX<double> derivative_value =
+        autoDiffToGradientMatrix(trajectory.value(t_k));
+    MatrixX<double> expected_derivative_value =
+        DiscardGradient(derivative_trajectory->value(t(k)));
+    EXPECT_TRUE(CompareMatrices(derivative_value, expected_derivative_value,
+                                tolerance));
   }
 }
 

--- a/common/trajectories/test/bspline_trajectory_test.cc
+++ b/common/trajectories/test/bspline_trajectory_test.cc
@@ -4,8 +4,8 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/autodiff.h"
-#include "drake/common/symbolic.h"
 #include "drake/common/proto/call_python.h"
+#include "drake/common/symbolic.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/trajectories/trajectory.h"
 #include "drake/math/autodiff_gradient.h"


### PR DESCRIPTION
This fixes the behavior of `BsplineTrajectory<AutoDiffXd>::value()`, when its input has non-empty derivatives.

Resolves #13150.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13149)
<!-- Reviewable:end -->
