### PR TITLE
Add python binding for GurobiSolverDetails.

### DIFF
--- a/bindings/pydrake/solvers/BUILD.bazel
+++ b/bindings/pydrake/solvers/BUILD.bazel
@@ -105,10 +105,16 @@ drake_pybind_library(
     cc_deps = [
         ":solvers_pybind",
         "//bindings/pydrake:documentation_pybind",
+        "//bindings/pydrake/common:value_pybind",
     ],
     cc_srcs = ["gurobi_py.cc"],
     package_info = PACKAGE_INFO,
-    py_deps = [":mathematicalprogram_py"],
+    py_deps = [
+        ":mathematicalprogram_py",
+        # TODO(jwnimmer-tri) Only for AbstractValue; we should switch this to
+        # depend on on pydrake/common once the Value bindings have moved there.
+        "//bindings/pydrake/systems:framework_py",
+    ],
 )
 
 drake_pybind_library(

--- a/bindings/pydrake/solvers/gurobi_py.cc
+++ b/bindings/pydrake/solvers/gurobi_py.cc
@@ -1,6 +1,7 @@
 #include "pybind11/eigen.h"
 #include "pybind11/pybind11.h"
 
+#include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/solvers/solvers_pybind.h"
@@ -17,11 +18,25 @@ PYBIND11_MODULE(gurobi, m) {
   m.doc() = "Gurobi solver bindings for MathematicalProgram";
 
   py::module::import("pydrake.solvers.mathematicalprogram");
+  py::module::import("pydrake.systems.framework");
 
   py::class_<GurobiSolver, SolverInterface> cls(
       m, "GurobiSolver", doc.GurobiSolver.doc);
   cls.def(py::init<>(), doc.GurobiSolver.ctor.doc);
   pysolvers::BindAcquireLicense(&cls, doc.GurobiSolver);
+
+  py::class_<GurobiSolverDetails>(
+      m, "GurobiSolverDetails", doc.GurobiSolverDetails.doc)
+      .def_readonly("optimizer_time", &GurobiSolverDetails::optimizer_time,
+          doc.GurobiSolverDetails.optimizer_time.doc)
+      .def_readonly("error_code", &GurobiSolverDetails::error_code,
+          doc.GurobiSolverDetails.error_code.doc)
+      .def_readonly("optimization_status",
+          &GurobiSolverDetails::optimization_status,
+          doc.GurobiSolverDetails.optimization_status.doc)
+      .def_readonly("objective_bound", &GurobiSolverDetails::objective_bound,
+          doc.GurobiSolverDetails.objective_bound.doc);
+  AddValueInstantiation<GurobiSolverDetails>(m);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/solvers/ipopt_py.cc
+++ b/bindings/pydrake/solvers/ipopt_py.cc
@@ -25,14 +25,14 @@ PYBIND11_MODULE(ipopt, m) {
 
   py::class_<IpoptSolverDetails>(
       m, "IpoptSolverDetails", doc.IpoptSolverDetails.doc)
-      .def_readwrite("status", &IpoptSolverDetails::status,
+      .def_readonly("status", &IpoptSolverDetails::status,
           doc.IpoptSolverDetails.status.doc)
-      .def_readwrite(
+      .def_readonly(
           "z_L", &IpoptSolverDetails::z_L, doc.IpoptSolverDetails.z_L.doc)
-      .def_readwrite(
+      .def_readonly(
           "z_U", &IpoptSolverDetails::z_U, doc.IpoptSolverDetails.z_U.doc)
-      .def_readwrite("g", &IpoptSolverDetails::g, doc.IpoptSolverDetails.g.doc)
-      .def_readwrite("lambda_val", &IpoptSolverDetails::lambda,
+      .def_readonly("g", &IpoptSolverDetails::g, doc.IpoptSolverDetails.g.doc)
+      .def_readonly("lambda_val", &IpoptSolverDetails::lambda,
           doc.IpoptSolverDetails.lambda.doc)
       .def("ConvertStatusToString", &IpoptSolverDetails::ConvertStatusToString,
           doc.IpoptSolverDetails.ConvertStatusToString.doc);

--- a/bindings/pydrake/solvers/mosek_py.cc
+++ b/bindings/pydrake/solvers/mosek_py.cc
@@ -30,11 +30,11 @@ PYBIND11_MODULE(mosek, m) {
 
   py::class_<MosekSolverDetails>(
       m, "MosekSolverDetails", doc.MosekSolverDetails.doc)
-      .def_readwrite("optimizer_time", &MosekSolverDetails::optimizer_time,
+      .def_readonly("optimizer_time", &MosekSolverDetails::optimizer_time,
           doc.MosekSolverDetails.optimizer_time.doc)
-      .def_readwrite("rescode", &MosekSolverDetails::rescode,
+      .def_readonly("rescode", &MosekSolverDetails::rescode,
           doc.MosekSolverDetails.rescode.doc)
-      .def_readwrite("solution_status", &MosekSolverDetails::solution_status,
+      .def_readonly("solution_status", &MosekSolverDetails::solution_status,
           doc.MosekSolverDetails.solution_status.doc);
   AddValueInstantiation<MosekSolverDetails>(m);
 }

--- a/bindings/pydrake/solvers/nlopt_py.cc
+++ b/bindings/pydrake/solvers/nlopt_py.cc
@@ -25,7 +25,7 @@ PYBIND11_MODULE(nlopt, m) {
 
   py::class_<NloptSolverDetails>(
       m, "NloptSolverDetails", doc.NloptSolverDetails.doc)
-      .def_readwrite("status", &NloptSolverDetails::status,
+      .def_readonly("status", &NloptSolverDetails::status,
           doc.NloptSolverDetails.status.doc);
   AddValueInstantiation<NloptSolverDetails>(m);
 }

--- a/bindings/pydrake/solvers/osqp_py.cc
+++ b/bindings/pydrake/solvers/osqp_py.cc
@@ -24,23 +24,23 @@ PYBIND11_MODULE(osqp, m) {
 
   py::class_<OsqpSolverDetails>(
       m, "OsqpSolverDetails", doc.OsqpSolverDetails.doc)
-      .def_readwrite(
+      .def_readonly(
           "iter", &OsqpSolverDetails::iter, doc.OsqpSolverDetails.iter.doc)
-      .def_readwrite("status_val", &OsqpSolverDetails::status_val,
+      .def_readonly("status_val", &OsqpSolverDetails::status_val,
           doc.OsqpSolverDetails.status_val.doc)
-      .def_readwrite("primal_res", &OsqpSolverDetails::primal_res,
+      .def_readonly("primal_res", &OsqpSolverDetails::primal_res,
           doc.OsqpSolverDetails.primal_res.doc)
-      .def_readwrite("dual_res", &OsqpSolverDetails::dual_res,
+      .def_readonly("dual_res", &OsqpSolverDetails::dual_res,
           doc.OsqpSolverDetails.dual_res.doc)
-      .def_readwrite("setup_time", &OsqpSolverDetails::setup_time,
+      .def_readonly("setup_time", &OsqpSolverDetails::setup_time,
           doc.OsqpSolverDetails.setup_time.doc)
-      .def_readwrite("solve_time", &OsqpSolverDetails::solve_time,
+      .def_readonly("solve_time", &OsqpSolverDetails::solve_time,
           doc.OsqpSolverDetails.solve_time.doc)
-      .def_readwrite("polish_time", &OsqpSolverDetails::polish_time,
+      .def_readonly("polish_time", &OsqpSolverDetails::polish_time,
           doc.OsqpSolverDetails.polish_time.doc)
-      .def_readwrite("run_time", &OsqpSolverDetails::run_time,
+      .def_readonly("run_time", &OsqpSolverDetails::run_time,
           doc.OsqpSolverDetails.run_time.doc)
-      .def_readwrite("y", &OsqpSolverDetails::y, doc.OsqpSolverDetails.y.doc);
+      .def_readonly("y", &OsqpSolverDetails::y, doc.OsqpSolverDetails.y.doc);
   AddValueInstantiation<OsqpSolverDetails>(m);
 }
 

--- a/bindings/pydrake/solvers/scs_py.cc
+++ b/bindings/pydrake/solvers/scs_py.cc
@@ -23,30 +23,30 @@ PYBIND11_MODULE(scs, m) {
       .def(py::init<>(), doc.ScsSolver.ctor.doc);
 
   py::class_<ScsSolverDetails>(m, "ScsSolverDetails", doc.ScsSolverDetails.doc)
-      .def_readwrite("scs_status", &ScsSolverDetails::scs_status,
+      .def_readonly("scs_status", &ScsSolverDetails::scs_status,
           doc.ScsSolverDetails.scs_status.doc)
-      .def_readwrite(
+      .def_readonly(
           "iter", &ScsSolverDetails::iter, doc.ScsSolverDetails.iter.doc)
-      .def_readwrite("primal_objective", &ScsSolverDetails::primal_objective,
+      .def_readonly("primal_objective", &ScsSolverDetails::primal_objective,
           doc.ScsSolverDetails.primal_objective.doc)
-      .def_readwrite("dual_objective", &ScsSolverDetails::dual_objective,
+      .def_readonly("dual_objective", &ScsSolverDetails::dual_objective,
           doc.ScsSolverDetails.dual_objective.doc)
-      .def_readwrite("primal_residue", &ScsSolverDetails::primal_residue,
+      .def_readonly("primal_residue", &ScsSolverDetails::primal_residue,
           doc.ScsSolverDetails.primal_residue.doc)
-      .def_readwrite("residue_infeasibility",
+      .def_readonly("residue_infeasibility",
           &ScsSolverDetails::residue_infeasibility,
           doc.ScsSolverDetails.residue_infeasibility.doc)
-      .def_readwrite("residue_unbounded", &ScsSolverDetails::residue_unbounded,
+      .def_readonly("residue_unbounded", &ScsSolverDetails::residue_unbounded,
           doc.ScsSolverDetails.residue_unbounded.doc)
-      .def_readwrite("relative_duality_gap",
+      .def_readonly("relative_duality_gap",
           &ScsSolverDetails::relative_duality_gap,
           doc.ScsSolverDetails.relative_duality_gap.doc)
-      .def_readwrite("scs_setup_time", &ScsSolverDetails::scs_setup_time,
+      .def_readonly("scs_setup_time", &ScsSolverDetails::scs_setup_time,
           doc.ScsSolverDetails.scs_setup_time.doc)
-      .def_readwrite("scs_solve_time", &ScsSolverDetails::scs_solve_time,
+      .def_readonly("scs_solve_time", &ScsSolverDetails::scs_solve_time,
           doc.ScsSolverDetails.scs_solve_time.doc)
-      .def_readwrite("y", &ScsSolverDetails::y, doc.ScsSolverDetails.y.doc)
-      .def_readwrite("s", &ScsSolverDetails::s, doc.ScsSolverDetails.s.doc);
+      .def_readonly("y", &ScsSolverDetails::y, doc.ScsSolverDetails.y.doc)
+      .def_readonly("s", &ScsSolverDetails::s, doc.ScsSolverDetails.s.doc);
   AddValueInstantiation<ScsSolverDetails>(m);
 }
 

--- a/bindings/pydrake/solvers/snopt_py.cc
+++ b/bindings/pydrake/solvers/snopt_py.cc
@@ -25,12 +25,12 @@ PYBIND11_MODULE(snopt, m) {
 
   py::class_<SnoptSolverDetails>(
       m, "SnoptSolverDetails", doc.SnoptSolverDetails.doc)
-      .def_readwrite(
+      .def_readonly(
           "info", &SnoptSolverDetails::info, doc.SnoptSolverDetails.info.doc)
-      .def_readwrite(
+      .def_readonly(
           "xmul", &SnoptSolverDetails::xmul, doc.SnoptSolverDetails.xmul.doc)
-      .def_readwrite("F", &SnoptSolverDetails::F, doc.SnoptSolverDetails.F.doc)
-      .def_readwrite(
+      .def_readonly("F", &SnoptSolverDetails::F, doc.SnoptSolverDetails.F.doc)
+      .def_readonly(
           "Fmul", &SnoptSolverDetails::Fmul, doc.SnoptSolverDetails.Fmul.doc);
   AddValueInstantiation<SnoptSolverDetails>(m);
 }

--- a/bindings/pydrake/solvers/test/gurobi_solver_test.py
+++ b/bindings/pydrake/solvers/test/gurobi_solver_test.py
@@ -18,6 +18,10 @@ class TestMathematicalProgram(unittest.TestCase):
         self.assertTrue(result.is_success())
         x_expected = np.array([1, 1])
         self.assertTrue(np.allclose(result.GetSolution(x), x_expected))
+        self.assertGreater(result.get_solver_details().optimizer_time, 0.)
+        self.assertEqual(result.get_solver_details().error_code, 0)
+        self.assertEqual(result.get_solver_details().optimization_status, 2)
+        self.assertTrue(np.isnan(result.get_solver_details().objective_bound))
 
     def test_gurobi_license(self):
         # Nominal use case.


### PR DESCRIPTION
Backwards-incompatible: This changes all `*SolverDetails` structures to be read-only for Python. This was deemed OK to break for now.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13152)
<!-- Reviewable:end -->
