### PR TITLE
workspace: Bump meshcat_python to latest commit

### DIFF
--- a/tools/workspace/meshcat_python/repository.bzl
+++ b/tools/workspace/meshcat_python/repository.bzl
@@ -42,9 +42,9 @@ def _impl(repository_ctx):
     github_download_and_extract(
         repository_ctx,
         "rdeits/meshcat-python",
-        "83cf73bcd553b0214c6bd2f9de3ae85e0f5c492e",
+        "ceb8bd68e3f4711b30001876efc5b49530038866",
         repository_ctx.attr.mirrors,
-        sha256 = "bcdd53b595ff45cf3bc16de0cba9c52e239de8503aabc0c313df16a4f9fabeae",  # noqa
+        sha256 = "adcae8290f6e3bcba349ce97a9543150da03606d7fed352a7d26c5e0413dce46",  # noqa
     )
 
     repository_ctx.symlink(


### PR DESCRIPTION
Per request from @rdeits: https://github.com/RobotLocomotion/drake/pull/13050#issuecomment-620339421
Also, includes caching fix from: https://github.com/rdeits/meshcat-python/issues/55

Requires: 
- [x] https://github.com/rdeits/meshcat-python/pull/58

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13155)
<!-- Reviewable:end -->
