### PR TITLE
py geometry: Bind QueryObject constructor

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -344,6 +344,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
     auto cls = DefineTemplateClassWithDefault<Class>(
         m, "QueryObject", param, doc.QueryObject.doc);
     cls  // BR
+        .def(py::init(), doc.QueryObject.ctor.doc)
         .def("inspector", &QueryObject<T>::inspector, py_reference_internal,
             doc.QueryObject.inspector.doc)
         .def("ComputeSignedDistancePairwiseClosestPoints",

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -178,12 +178,6 @@ class TestGeometry(unittest.TestCase):
         obj.clear()
         self.assertEqual(obj.size(), 0)
 
-    def test_query_object_api(self):
-        # TODO(eric.cousineau): Create self-contained unittests (#9899).
-        # Pending that, the relevant API is exercised via
-        # `test_scene_graph_queries` in `plant_test.py`.
-        pass
-
     def test_identifier_api(self):
         cls_list = [
             mut.SourceId,
@@ -361,6 +355,10 @@ class TestGeometry(unittest.TestCase):
         SceneGraph = mut.SceneGraph_[T]
         QueryObject = mut.QueryObject_[T]
         SceneGraphInspector = mut.SceneGraphInspector_[T]
+
+        # First, ensure we can default-construct it.
+        model = QueryObject()
+        self.assertIsInstance(model, QueryObject)
 
         scene_graph = SceneGraph()
         render_params = mut.render.RenderEngineVtkParams()


### PR DESCRIPTION
Enables writing Python LeafSystems which declare ports using this object

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13156)
<!-- Reviewable:end -->
