### PR TITLE
[geometry] Parcel QueryObject queries into unique classes

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -208,6 +208,12 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py_reference_internal, cls_doc.get_pose_bundle_output_port.doc)
         .def("get_query_output_port", &Class::get_query_output_port,
             py_reference_internal, cls_doc.get_query_output_port.doc)
+        .def("get_proximity_query_output_port",
+            &Class::get_proximity_query_output_port, py_reference_internal,
+            cls_doc.get_proximity_query_output_port.doc)
+        .def("get_perception_query_output_port",
+            &Class::get_perception_query_output_port, py_reference_internal,
+            cls_doc.get_perception_query_output_port.doc)
         .def("model_inspector", &Class::model_inspector, py_reference_internal,
             cls_doc.model_inspector.doc)
         .def("RegisterSource",
@@ -400,6 +406,82 @@ void DoScalarDependentDefinitions(py::module m, T) {
             doc.QueryObject.RenderLabelImage.doc);
 
     AddValueInstantiation<QueryObject<T>>(m);
+  }
+
+  //  ProximityQueryObject
+  {
+    using Class = ProximityQueryObject<T>;
+    auto cls = DefineTemplateClassWithDefault<Class, QueryObject<T>>(
+        m, "ProximityQueryObject", param, doc.ProximityQueryObject.doc);
+    cls  // BR
+        .def("ComputePointPairPenetration",
+            &ProximityQueryObject<T>::ComputePointPairPenetration,
+            doc.ProximityQueryObject.ComputePointPairPenetration.doc)
+        .def("FindCollisionCandidates",
+            &ProximityQueryObject<T>::FindCollisionCandidates,
+            doc.ProximityQueryObject.FindCollisionCandidates.doc)
+        .def("HasCollisions", &ProximityQueryObject<T>::HasCollisions,
+            doc.ProximityQueryObject.HasCollisions.doc)
+        .def("ComputeSignedDistancePairwiseClosestPoints",
+            &ProximityQueryObject<
+                T>::ComputeSignedDistancePairwiseClosestPoints,
+            py::arg("max_distance") = std::numeric_limits<double>::infinity(),
+            doc.ProximityQueryObject.ComputeSignedDistancePairwiseClosestPoints
+                .doc)
+        .def("ComputeSignedDistancePairClosestPoints",
+            &ProximityQueryObject<T>::ComputeSignedDistancePairClosestPoints,
+            py::arg("id_A"), py::arg("id_B"),
+            doc.ProximityQueryObject.ComputeSignedDistancePairClosestPoints.doc)
+        .def("ComputeSignedDistanceToPoint",
+            &ProximityQueryObject<T>::ComputeSignedDistanceToPoint,
+            py::arg("p_WQ"),
+            py::arg("threshold") = std::numeric_limits<double>::infinity(),
+            doc.ProximityQueryObject.ComputeSignedDistanceToPoint.doc);
+
+    AddValueInstantiation<ProximityQueryObject<T>>(m);
+  }
+
+  //  PerceptionQueryObject
+  {
+    using Class = PerceptionQueryObject<T>;
+    auto cls = DefineTemplateClassWithDefault<Class, QueryObject<T>>(
+        m, "PerceptionQueryObject", param, doc.PerceptionQueryObject.doc);
+    cls  // BR
+        .def("RenderColorImage",
+            [](const Class* self, const render::CameraProperties& camera,
+                FrameId parent_frame, const math::RigidTransformd& X_PC,
+                bool show_window) {
+              systems::sensors::ImageRgba8U img(camera.width, camera.height);
+              self->RenderColorImage(
+                  camera, parent_frame, X_PC, show_window, &img);
+              return img;
+            },
+            py::arg("camera"), py::arg("parent_frame"), py::arg("X_PC"),
+            py::arg("show_window") = false,
+            doc.PerceptionQueryObject.RenderColorImage.doc)
+        .def("RenderDepthImage",
+            [](const Class* self, const render::DepthCameraProperties& camera,
+                FrameId parent_frame, const math::RigidTransformd& X_PC) {
+              systems::sensors::ImageDepth32F img(camera.width, camera.height);
+              self->RenderDepthImage(camera, parent_frame, X_PC, &img);
+              return img;
+            },
+            py::arg("camera"), py::arg("parent_frame"), py::arg("X_PC"),
+            doc.PerceptionQueryObject.RenderDepthImage.doc)
+        .def("RenderLabelImage",
+            [](const Class* self, const render::CameraProperties& camera,
+                FrameId parent_frame, const math::RigidTransformd& X_PC,
+                bool show_window = false) {
+              systems::sensors::ImageLabel16I img(camera.width, camera.height);
+              self->RenderLabelImage(
+                  camera, parent_frame, X_PC, show_window, &img);
+              return img;
+            },
+            py::arg("camera"), py::arg("parent_frame"), py::arg("X_PC"),
+            py::arg("show_window") = false,
+            doc.PerceptionQueryObject.RenderLabelImage.doc);
+
+    AddValueInstantiation<PerceptionQueryObject<T>>(m);
   }
 
   // SignedDistancePair

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -176,10 +176,14 @@ drake_cc_library(
 drake_cc_library(
     name = "scene_graph",
     srcs = [
+        "perception_query_object.cc",
+        "proximity_query_object.cc",
         "query_object.cc",
         "scene_graph.cc",
     ],
     hdrs = [
+        "perception_query_object.h",
+        "proximity_query_object.h",
         "query_object.h",
         "scene_graph.h",
     ],
@@ -406,6 +410,22 @@ drake_cc_googletest(
     name = "geometry_visualization_test",
     deps = [
         ":geometry_visualization",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "perception_query_object_test",
+    deps = [
+        ":scene_graph",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "proximity_query_object_test",
+    deps = [
+        ":scene_graph",
         "//common/test_utilities:expect_throws_message",
     ],
 )

--- a/geometry/perception_query_object.cc
+++ b/geometry/perception_query_object.cc
@@ -1,11 +1,11 @@
-#include "drake/geometry/query_object.h"
+#include "drake/geometry/perception_query_object.h"
 
 #include "drake/common/default_scalars.h"
+#include "drake/geometry/geometry_state.h"
 
 namespace drake {
 namespace geometry {
 
-using math::RigidTransform;
 using math::RigidTransformd;
 using render::CameraProperties;
 using render::DepthCameraProperties;
@@ -14,41 +14,34 @@ using systems::sensors::ImageLabel16I;
 using systems::sensors::ImageRgba8U;
 
 template <typename T>
-void QueryObject<T>::RenderColorImage(const CameraProperties& camera,
+void PerceptionQueryObject<T>::RenderColorImage(const CameraProperties& camera,
                                       FrameId parent_frame,
                                       const RigidTransformd& X_PC,
                                       bool show_window,
                                       ImageRgba8U* color_image_out) const {
-  ThrowIfNotCallable();
-
-  FullPoseUpdate();
-  const GeometryState<T>& state = geometry_state();
+  this->ValidateAndUpdate();
+  const GeometryState<T>& state = this->geometry_state();
   return state.RenderColorImage(camera, parent_frame, X_PC, show_window,
                                 color_image_out);
 }
 
 template <typename T>
-void QueryObject<T>::RenderDepthImage(const DepthCameraProperties& camera,
-                                      FrameId parent_frame,
-                                      const RigidTransformd& X_PC,
-                                      ImageDepth32F* depth_image_out) const {
-  ThrowIfNotCallable();
-
-  FullPoseUpdate();
-  const GeometryState<T>& state = geometry_state();
+void PerceptionQueryObject<T>::RenderDepthImage(
+    const DepthCameraProperties& camera, FrameId parent_frame,
+    const RigidTransformd& X_PC, ImageDepth32F* depth_image_out) const {
+  this->ValidateAndUpdate();
+  const GeometryState<T>& state = this->geometry_state();
   return state.RenderDepthImage(camera, parent_frame, X_PC, depth_image_out);
 }
 
 template <typename T>
-void QueryObject<T>::RenderLabelImage(const CameraProperties& camera,
+void PerceptionQueryObject<T>::RenderLabelImage(const CameraProperties& camera,
                                       FrameId parent_frame,
                                       const RigidTransformd& X_PC,
                                       bool show_window,
                                       ImageLabel16I* label_image_out) const {
-  ThrowIfNotCallable();
-
-  FullPoseUpdate();
-  const GeometryState<T>& state = geometry_state();
+  this->ValidateAndUpdate();
+  const GeometryState<T>& state = this->geometry_state();
   return state.RenderLabelImage(camera, parent_frame, X_PC, show_window,
                                 label_image_out);
 }
@@ -57,4 +50,4 @@ void QueryObject<T>::RenderLabelImage(const CameraProperties& camera,
 }  // namespace drake
 
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
-    class ::drake::geometry::QueryObject)
+    class ::drake::geometry::PerceptionQueryObject)

--- a/geometry/perception_query_object.cc
+++ b/geometry/perception_query_object.cc
@@ -1,0 +1,60 @@
+#include "drake/geometry/query_object.h"
+
+#include "drake/common/default_scalars.h"
+
+namespace drake {
+namespace geometry {
+
+using math::RigidTransform;
+using math::RigidTransformd;
+using render::CameraProperties;
+using render::DepthCameraProperties;
+using systems::sensors::ImageDepth32F;
+using systems::sensors::ImageLabel16I;
+using systems::sensors::ImageRgba8U;
+
+template <typename T>
+void QueryObject<T>::RenderColorImage(const CameraProperties& camera,
+                                      FrameId parent_frame,
+                                      const RigidTransformd& X_PC,
+                                      bool show_window,
+                                      ImageRgba8U* color_image_out) const {
+  ThrowIfNotCallable();
+
+  FullPoseUpdate();
+  const GeometryState<T>& state = geometry_state();
+  return state.RenderColorImage(camera, parent_frame, X_PC, show_window,
+                                color_image_out);
+}
+
+template <typename T>
+void QueryObject<T>::RenderDepthImage(const DepthCameraProperties& camera,
+                                      FrameId parent_frame,
+                                      const RigidTransformd& X_PC,
+                                      ImageDepth32F* depth_image_out) const {
+  ThrowIfNotCallable();
+
+  FullPoseUpdate();
+  const GeometryState<T>& state = geometry_state();
+  return state.RenderDepthImage(camera, parent_frame, X_PC, depth_image_out);
+}
+
+template <typename T>
+void QueryObject<T>::RenderLabelImage(const CameraProperties& camera,
+                                      FrameId parent_frame,
+                                      const RigidTransformd& X_PC,
+                                      bool show_window,
+                                      ImageLabel16I* label_image_out) const {
+  ThrowIfNotCallable();
+
+  FullPoseUpdate();
+  const GeometryState<T>& state = geometry_state();
+  return state.RenderLabelImage(camera, parent_frame, X_PC, show_window,
+                                label_image_out);
+}
+
+}  // namespace geometry
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::geometry::QueryObject)

--- a/geometry/perception_query_object.h
+++ b/geometry/perception_query_object.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include "drake/math/rigid_transform.h"
+
+namespace drake {
+namespace geometry {
+
+template <typename T>
+class QueryObject {
+ public:
+  /**
+   @anchor render_queries
+   @name                Render Queries
+
+   The methods support queries along the lines of "What do I see?" They support
+   simulation of sensors. External entities define a sensor camera -- its
+   extrinsic and intrinsic properties and %QueryObject renders into the
+   provided image.
+
+   <!-- TODO(SeanCurtis-TRI): Currently, pose is requested as a transform of
+   double. This puts the burden on the caller to be compatible. Provide
+   specializations for AutoDiff and symbolic (the former extracts a
+   double-valued transform and the latter throws). -->
+   */
+  //@{
+
+  /** Renders an RGB image for the given `camera` posed with respect to the
+   indicated parent frame P.
+
+   @param camera                The intrinsic properties of the camera.
+   @param parent_frame          The id for the camera's parent frame.
+   @param X_PC                  The pose of the camera body in the world frame.
+   @param show_window           If true, the render window will be displayed.
+   @param[out] color_image_out  The rendered color image. */
+  void RenderColorImage(const render::CameraProperties& camera,
+                        FrameId parent_frame,
+                        const math::RigidTransformd& X_PC,
+                        bool show_window,
+                        systems::sensors::ImageRgba8U* color_image_out) const;
+
+  /** Renders a depth image for the given `camera` posed with respect to the
+   indicated parent frame P.
+
+   In contrast to the other rendering methods, rendering depth images doesn't
+   provide the option to display the window; generally, basic depth images are
+   not readily communicative to humans.
+
+   @param camera                The intrinsic properties of the camera.
+   @param parent_frame          The id for the camera's parent frame.
+   @param X_PC                  The pose of the camera body in the world frame.
+   @param[out] depth_image_out  The rendered depth image. */
+  void RenderDepthImage(const render::DepthCameraProperties& camera,
+                        FrameId parent_frame,
+                        const math::RigidTransformd& X_PC,
+                        systems::sensors::ImageDepth32F* depth_image_out) const;
+
+  /** Renders a label image for the given `camera` posed with respect to the
+   indicated parent frame P.
+
+   @param camera                The intrinsic properties of the camera.
+   @param parent_frame          The id for the camera's parent frame.
+   @param X_PC                  The pose of the camera body in the world frame.
+   @param show_window           If true, the render window will be displayed.
+   @param[out] label_image_out  The rendered label image. */
+  void RenderLabelImage(const render::CameraProperties& camera,
+                        FrameId parent_frame,
+                        const math::RigidTransformd& X_PC,
+                        bool show_window,
+                        systems::sensors::ImageLabel16I* label_image_out) const;
+
+  //@}
+
+};
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/perception_query_object.h
+++ b/geometry/perception_query_object.h
@@ -1,21 +1,40 @@
 #pragma once
 
+#include "drake/geometry/query_object.h"
 #include "drake/math/rigid_transform.h"
+#include "drake/systems/sensors/image.h"
 
 namespace drake {
 namespace geometry {
 
+/** An extension of QueryObject which renders the SceneGraph world -- color,
+ depth, etc. -- in addition to the queries made available by QueryObject.
+ SceneGraph has an abstract-valued port that contains a %PerceptionQueryObject
+ (i.e., a %PerceptionQueryObject-valued output port).
+
+ Other than the additional queries that this class provides above and beyond
+ those of QueryObject, acquiring a reference to a %PerceptionQueryObject,
+ working with it, the semantics of copying it, etc., are all the same as the
+ parent class. Please refer to QueryObject's documentation for details.
+
+ @tparam_nonsymbolic_scalar
+*/
 template <typename T>
-class QueryObject {
+class PerceptionQueryObject : public QueryObject<T> {
  public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PerceptionQueryObject)
+
+  /** Constructs a default %PerceptionQueryObject (all pointers are null). */
+  PerceptionQueryObject() = default;
+
   /**
    @anchor render_queries
    @name                Render Queries
 
    The methods support queries along the lines of "What do I see?" They support
    simulation of sensors. External entities define a sensor camera -- its
-   extrinsic and intrinsic properties and %QueryObject renders into the
-   provided image.
+   extrinsic and intrinsic properties and %PerceptionQueryObject renders into
+   the provided image.
 
    <!-- TODO(SeanCurtis-TRI): Currently, pose is requested as a transform of
    double. This puts the burden on the caller to be compatible. Provide
@@ -69,7 +88,6 @@ class QueryObject {
                         systems::sensors::ImageLabel16I* label_image_out) const;
 
   //@}
-
 };
 
 }  // namespace geometry

--- a/geometry/proximity_query_object.cc
+++ b/geometry/proximity_query_object.cc
@@ -1,93 +1,77 @@
-#include "drake/geometry/query_object.h"
+#include "drake/geometry/proximity_query_object.h"
 
 #include "drake/common/default_scalars.h"
+#include "drake/geometry/geometry_state.h"
 
 namespace drake {
 namespace geometry {
 
 template <typename T>
 std::vector<PenetrationAsPointPair<double>>
-QueryObject<T>::ComputePointPairPenetration() const {
-  ThrowIfNotCallable();
-
-  FullPoseUpdate();
-  const GeometryState<T>& state = geometry_state();
+ProximityQueryObject<T>::ComputePointPairPenetration() const {
+  this->ValidateAndUpdate();
+  const GeometryState<T>& state = this->geometry_state();
   return state.ComputePointPairPenetration();
 }
 
 template <typename T>
-std::vector<SortedPair<GeometryId>> QueryObject<T>::FindCollisionCandidates()
-    const {
-  ThrowIfNotCallable();
-  // TODO(amcastro-tri): Modify this when the cache system is in place.
-  FullPoseUpdate();
-  const GeometryState<T>& state = geometry_state();
+std::vector<SortedPair<GeometryId>>
+ProximityQueryObject<T>::FindCollisionCandidates() const {
+  this->ValidateAndUpdate();
+  const GeometryState<T>& state = this->geometry_state();
   return state.FindCollisionCandidates();
 }
 
 template <typename T>
-bool QueryObject<T>::HasCollisions() const {
-  ThrowIfNotCallable();
-
-  FullPoseUpdate();
-  const GeometryState<T>& state = geometry_state();
+bool ProximityQueryObject<T>::HasCollisions() const {
+  this->ValidateAndUpdate();
+  const GeometryState<T>& state = this->geometry_state();
   return state.HasCollisions();
 }
 
 template <typename T>
-std::vector<ContactSurface<T>>
-QueryObject<T>::ComputeContactSurfaces() const {
-  ThrowIfNotCallable();
-
-  FullPoseUpdate();
-  const GeometryState<T>& state = geometry_state();
+std::vector<ContactSurface<T>> ProximityQueryObject<T>::ComputeContactSurfaces()
+    const {
+  this->ValidateAndUpdate();
+  const GeometryState<T>& state = this->geometry_state();
   return state.ComputeContactSurfaces();
 }
 
 template <typename T>
-void QueryObject<T>::ComputeContactSurfacesWithFallback(
+void ProximityQueryObject<T>::ComputeContactSurfacesWithFallback(
     std::vector<ContactSurface<T>>* surfaces,
     std::vector<PenetrationAsPointPair<double>>* point_pairs) const {
   DRAKE_DEMAND(surfaces);
   DRAKE_DEMAND(point_pairs);
-
-  ThrowIfNotCallable();
-
-  FullPoseUpdate();
-  const GeometryState<T>& state = geometry_state();
+  this->ValidateAndUpdate();
+  const GeometryState<T>& state = this->geometry_state();
   state.ComputeContactSurfacesWithFallback(surfaces, point_pairs);
 }
 
 template <typename T>
 std::vector<SignedDistancePair<T>>
-QueryObject<T>::ComputeSignedDistancePairwiseClosestPoints(
+ProximityQueryObject<T>::ComputeSignedDistancePairwiseClosestPoints(
     const double max_distance) const {
-  ThrowIfNotCallable();
-
-  FullPoseUpdate();
-  const GeometryState<T>& state = geometry_state();
+  this->ValidateAndUpdate();
+  const GeometryState<T>& state = this->geometry_state();
   return state.ComputeSignedDistancePairwiseClosestPoints(max_distance);
 }
 
 template <typename T>
-SignedDistancePair<T> QueryObject<T>::ComputeSignedDistancePairClosestPoints(
+SignedDistancePair<T>
+ProximityQueryObject<T>::ComputeSignedDistancePairClosestPoints(
     GeometryId id_A, GeometryId id_B) const {
-  ThrowIfNotCallable();
-
-  FullPoseUpdate();
-  const GeometryState<T>& state = geometry_state();
+  this->ValidateAndUpdate();
+  const GeometryState<T>& state = this->geometry_state();
   return state.ComputeSignedDistancePairClosestPoints(id_A, id_B);
 }
 
 template <typename T>
 std::vector<SignedDistanceToPoint<T>>
-QueryObject<T>::ComputeSignedDistanceToPoint(
-    const Vector3<T>& p_WQ,
-    const double threshold) const {
-  ThrowIfNotCallable();
-
-  FullPoseUpdate();
-  const GeometryState<T>& state = geometry_state();
+ProximityQueryObject<T>::ComputeSignedDistanceToPoint(
+    const Vector3<T>& p_WQ, const double threshold) const {
+  this->ValidateAndUpdate();
+  const GeometryState<T>& state = this->geometry_state();
   return state.ComputeSignedDistanceToPoint(p_WQ, threshold);
 }
 
@@ -95,4 +79,4 @@ QueryObject<T>::ComputeSignedDistanceToPoint(
 }  // namespace drake
 
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
-    class ::drake::geometry::QueryObject)
+    class ::drake::geometry::ProximityQueryObject)

--- a/geometry/proximity_query_object.cc
+++ b/geometry/proximity_query_object.cc
@@ -1,0 +1,98 @@
+#include "drake/geometry/query_object.h"
+
+#include "drake/common/default_scalars.h"
+
+namespace drake {
+namespace geometry {
+
+template <typename T>
+std::vector<PenetrationAsPointPair<double>>
+QueryObject<T>::ComputePointPairPenetration() const {
+  ThrowIfNotCallable();
+
+  FullPoseUpdate();
+  const GeometryState<T>& state = geometry_state();
+  return state.ComputePointPairPenetration();
+}
+
+template <typename T>
+std::vector<SortedPair<GeometryId>> QueryObject<T>::FindCollisionCandidates()
+    const {
+  ThrowIfNotCallable();
+  // TODO(amcastro-tri): Modify this when the cache system is in place.
+  FullPoseUpdate();
+  const GeometryState<T>& state = geometry_state();
+  return state.FindCollisionCandidates();
+}
+
+template <typename T>
+bool QueryObject<T>::HasCollisions() const {
+  ThrowIfNotCallable();
+
+  FullPoseUpdate();
+  const GeometryState<T>& state = geometry_state();
+  return state.HasCollisions();
+}
+
+template <typename T>
+std::vector<ContactSurface<T>>
+QueryObject<T>::ComputeContactSurfaces() const {
+  ThrowIfNotCallable();
+
+  FullPoseUpdate();
+  const GeometryState<T>& state = geometry_state();
+  return state.ComputeContactSurfaces();
+}
+
+template <typename T>
+void QueryObject<T>::ComputeContactSurfacesWithFallback(
+    std::vector<ContactSurface<T>>* surfaces,
+    std::vector<PenetrationAsPointPair<double>>* point_pairs) const {
+  DRAKE_DEMAND(surfaces);
+  DRAKE_DEMAND(point_pairs);
+
+  ThrowIfNotCallable();
+
+  FullPoseUpdate();
+  const GeometryState<T>& state = geometry_state();
+  state.ComputeContactSurfacesWithFallback(surfaces, point_pairs);
+}
+
+template <typename T>
+std::vector<SignedDistancePair<T>>
+QueryObject<T>::ComputeSignedDistancePairwiseClosestPoints(
+    const double max_distance) const {
+  ThrowIfNotCallable();
+
+  FullPoseUpdate();
+  const GeometryState<T>& state = geometry_state();
+  return state.ComputeSignedDistancePairwiseClosestPoints(max_distance);
+}
+
+template <typename T>
+SignedDistancePair<T> QueryObject<T>::ComputeSignedDistancePairClosestPoints(
+    GeometryId id_A, GeometryId id_B) const {
+  ThrowIfNotCallable();
+
+  FullPoseUpdate();
+  const GeometryState<T>& state = geometry_state();
+  return state.ComputeSignedDistancePairClosestPoints(id_A, id_B);
+}
+
+template <typename T>
+std::vector<SignedDistanceToPoint<T>>
+QueryObject<T>::ComputeSignedDistanceToPoint(
+    const Vector3<T>& p_WQ,
+    const double threshold) const {
+  ThrowIfNotCallable();
+
+  FullPoseUpdate();
+  const GeometryState<T>& state = geometry_state();
+  return state.ComputeSignedDistanceToPoint(p_WQ, threshold);
+}
+
+}  // namespace geometry
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::geometry::QueryObject)

--- a/geometry/proximity_query_object.h
+++ b/geometry/proximity_query_object.h
@@ -3,6 +3,7 @@
 #include <limits>
 #include <vector>
 
+#include "drake/geometry/query_object.h"
 #include "drake/geometry/query_results/contact_surface.h"
 #include "drake/geometry/query_results/penetration_as_point_pair.h"
 #include "drake/geometry/query_results/signed_distance_pair.h"
@@ -11,9 +12,26 @@
 namespace drake {
 namespace geometry {
 
+/** An extension of QueryObject which performs proximity queries -- contact,
+ signed distance, etc. -- in addition to the queries made available by
+ QueryObject. SceneGraph has an abstract-valued port that contains a
+ %ProximityQueryObject (i.e., a %ProximityQueryObject-valued output port).
+
+ Other than the additional queries that this class provides above and beyond
+ those of QueryObject, acquiring a reference to a %ProximityQueryObject, working
+ with it, the semantics of copying it, etc., are all the same as the parent
+ class. Please refer to QueryObject's documentation for details.
+
+ @tparam_nonsymbolic_scalar
+*/
 template <typename T>
-class QueryObject {
+class ProximityQueryObject : public QueryObject<T> {
  public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ProximityQueryObject)
+
+  /** Constructs a default ProximityQueryObject (all pointers are null). */
+  ProximityQueryObject() = default;
+
   /**
    @anchor collision_queries
    @name                Collision Queries
@@ -30,7 +48,7 @@ class QueryObject {
 
    These methods are affected by collision filtering; element pairs that
    have been filtered will not produce contacts, even if their collision
-   geometry is penetrating.     */
+   geometry is penetrating.  */
   //@{
 
   /** Computes the penetrations across all pairs of geometries in the world
@@ -56,10 +74,11 @@ class QueryObject {
    AutoDiffXd support. At the very least, it should be declared on T and throw
    for AutoDiffXd. This is related to PR 11143
    https://github.com/RobotLocomotion/drake/pull/11143. In that PR, MBP is
-   taking responsibility to know whether or not QueryObject supports AutoDiff
-   penetration queries; MBP should not be responsible for that knowledge. By
-   moving the exception into SceneGraph, it removes the false dependency and
-   allows us to gradually increase the AutoDiff support for penetration.
+   taking responsibility to know whether or not ProximityQueryObject supports
+   AutoDiff penetration queries; MBP should not be responsible for that
+   knowledge. By moving the exception into SceneGraph, it removes the false
+   dependency and allows us to gradually increase the AutoDiff support for
+   penetration.
    -->
 
    @returns A vector populated with all detected penetrations characterized as
@@ -329,10 +348,9 @@ class QueryObject {
                               distance values (and supporting data).
                               See SignedDistanceToPoint.
    */
-  std::vector<SignedDistanceToPoint<T>>
-  ComputeSignedDistanceToPoint(const Vector3<T> &p_WQ,
-                               const double threshold
-                               = std::numeric_limits<double>::infinity()) const;
+  std::vector<SignedDistanceToPoint<T>> ComputeSignedDistanceToPoint(
+      const Vector3<T>& p_WQ,
+      const double threshold = std::numeric_limits<double>::infinity()) const;
   //@}
 };
 

--- a/geometry/proximity_query_object.h
+++ b/geometry/proximity_query_object.h
@@ -1,0 +1,340 @@
+#pragma once
+
+#include <limits>
+#include <vector>
+
+#include "drake/geometry/query_results/contact_surface.h"
+#include "drake/geometry/query_results/penetration_as_point_pair.h"
+#include "drake/geometry/query_results/signed_distance_pair.h"
+#include "drake/geometry/query_results/signed_distance_to_point.h"
+
+namespace drake {
+namespace geometry {
+
+template <typename T>
+class QueryObject {
+ public:
+  /**
+   @anchor collision_queries
+   @name                Collision Queries
+
+   These queries detect _collisions_ between geometry. Two geometries collide
+   if they overlap each other and are not explicitly excluded through
+   @ref collision_filter_concepts "collision filtering". These algorithms find
+   those colliding cases, characterize them, and report the essential
+   characteristics of that collision.
+
+   For two colliding geometries g_A and g_B, it is guaranteed that they will
+   map to `id_A` and `id_B` in a fixed, repeatable manner, where `id_A` and
+   `id_B` are GeometryId's of geometries g_A and g_B respectively.
+
+   These methods are affected by collision filtering; element pairs that
+   have been filtered will not produce contacts, even if their collision
+   geometry is penetrating.     */
+  //@{
+
+  /** Computes the penetrations across all pairs of geometries in the world
+   with the penetrations characterized by pairs of points (see
+   PenetrationAsPointPair), providing some measure of the penetration "depth" of
+   the two objects, but _not_ the overlapping volume.
+
+   Only reports results for _penetrating_ geometries; if two geometries are
+   separated, there will be no result for that pair. Geometries whose surfaces
+   are just touching (osculating) are not considered in penetration. Surfaces
+   whose penetration is within an epsilon of osculation, are likewise not
+   considered penetrating. Pairs of _anchored_ geometry are also not reported.
+   This method is affected by collision filtering.
+
+   For two penetrating geometries g_A and g_B, it is guaranteed that they will
+   map to `id_A` and `id_B` in a fixed, repeatable manner.
+
+   <h3>Scalar support</h3>
+   This method only provides double-valued penetration results.
+
+   <!--
+   TODO(SeanCurtis-TRI): This can/should be changed to offer at least partial
+   AutoDiffXd support. At the very least, it should be declared on T and throw
+   for AutoDiffXd. This is related to PR 11143
+   https://github.com/RobotLocomotion/drake/pull/11143. In that PR, MBP is
+   taking responsibility to know whether or not QueryObject supports AutoDiff
+   penetration queries; MBP should not be responsible for that knowledge. By
+   moving the exception into SceneGraph, it removes the false dependency and
+   allows us to gradually increase the AutoDiff support for penetration.
+   -->
+
+   @returns A vector populated with all detected penetrations characterized as
+            point pairs.
+   @note    Silently ignore Mesh geometries. */
+  std::vector<PenetrationAsPointPair<double>> ComputePointPairPenetration()
+      const;
+
+  /**
+   Reports pairwise intersections and characterizes each non-empty
+   intersection as a ContactSurface for hydroelastic contact model.
+   The computation is subject to collision filtering.
+
+   For two intersecting geometries g_A and g_B, it is guaranteed that they will
+   map to `id_A` and `id_B` in a fixed, repeatable manner, where `id_A` and
+   `id_B` are GeometryId's of geometries g_A and g_B respectively.
+
+   In the current incarnation, this function represents a simple implementation.
+
+     - This table shows the supported shapes and compliance modes.
+
+       |   Shape   | Soft  | Rigid |
+       | :-------: | :---: | :---- |
+       | Sphere    |  yes  |  yes  |
+       | Cylinder  |  yes  |  yes  |
+       | Box       |  yes  |  yes  |
+       | Capsule   |  no   |  no   |
+       | Ellipsoid |  yes  |  yes  |
+       | HalfSpace |  no   |  no   |
+       | Mesh      |  no   |  yes  |
+       | Convex    |  no   |  no   |
+
+     - One geometry must be soft, and the other must be rigid. There is no
+       support for soft-soft collision or rigid-rigid collision. If such
+       pairs collide, an exception will be thrown. More particularly, if such
+       a pair *cannot be culled* an exception will be thrown. No exception
+       is thrown if the pair has been filtered.
+     - The elasticity modulus E (N/m^2) of each geometry is set in
+       ProximityProperties (see AddContactMaterial()).
+     - The tessellation of the corresponding meshes is controlled by the
+       resolution hint, as defined by AddSoftHydroelasticProperties() and
+       AddRigidHydroelasticProperties().
+
+   <h3>Scalar support</h3>
+
+   This method provides support only for double. Attempting to invoke this
+   method with T = AutoDiffXd will throw an exception if there are *any*
+   geometry pairs that couldn't be culled.
+
+   @returns A vector populated with all detected intersections characterized as
+            contact surfaces.  */
+  std::vector<ContactSurface<T>> ComputeContactSurfaces() const;
+
+  /** Reports pair-wise intersections and characterizes each non-empty
+   intersection as a ContactSurface _where possible_ and as a
+   PenetrationAsPointPair where not.
+
+   This is a hybrid contact algorithm. It allows for the contact surface
+   penetration result where possible, but automatically provides a fallback for
+   where a ContactSurface cannot be defined.
+
+   The fallback cannot guarantee success in all cases. Meshes have limited
+   support in the proximity role; they are supported in the contact surface
+   computation but _ignored_ in the point pair collision query. If a mesh is
+   in contact with another shape that _cannot_ be resolved as a contact surface
+   (e.g., rigid mesh vs another rigid shape), this computation will throw as
+   there is no fallback functionality for mesh-shape.
+
+   Because point pairs can only be computed for double-valued systems, this can
+   also only support double-valued ContactSurface instances.
+
+   @param[out] surfaces     The vector that contact surfaces will be added to.
+                            The vector will _not_ be cleared.
+   @param[out] point_pairs  The vector that fall back point pair data will be
+                            added to. The vector will _not_ be cleared.
+   @pre Neither `surfaces` nor `point_pairs` is nullptr.  */
+  void ComputeContactSurfacesWithFallback(
+      std::vector<ContactSurface<T>>* surfaces,
+      std::vector<PenetrationAsPointPair<double>>* point_pairs) const;
+
+  /** Applies a conservative culling mechanism to create a subset of all
+   possible geometry pairs based on non-zero intersections. A geometry pair
+   that is *absent* from the results is either a) culled by collision filters or
+   b) *known* to be separated. The caller is responsible for confirming that
+   the remaining, unculled geometry pairs are *actually* in collision.
+
+   @returns A vector populated with collision pair candidates.
+   @note    Silently ignore Mesh geometries. */
+  std::vector<SortedPair<GeometryId>> FindCollisionCandidates() const;
+
+  /** Reports true if there are _any_ collisions between unfiltered pairs in the
+   world.
+   @note Silently ignore Mesh geometries. */
+  bool HasCollisions() const;
+
+  //@}
+
+  //---------------------------------------------------------------------------
+  // TODO(DamrongGuoy): Write a better documentation for Signed Distance
+  // Queries.
+  /**
+   @anchor signed_distance_query
+   @name                   Signed Distance Queries
+
+   These queries provide the signed distance between two objects. Each query
+   has a specific definition of the signed distance being positive, negative,
+   or zero associated with some notions of being outside, inside, or on
+   the boundary.
+
+   These queries provide bookkeeping data like geometry id(s) of the geometries
+   involved and the important locations on the boundaries of these geometries.
+
+   The signed distance function is a continuous function. Its partial
+   derivatives are continuous almost everywhere.
+  */
+  //@{
+
+  // TODO(DamrongGuoy): Refactor documentation of
+  // ComputeSignedDistancePairwiseClosestPoints(). Move the common sections
+  // into Signed Distance Queries.
+  /**
+   Computes the signed distance together with the nearest points across all
+   pairs of geometries in the world. Reports both the separating geometries
+   and penetrating geometries.
+
+   This query provides φ(A, B), the signed distance between two objects A and B.
+
+   If the objects do not overlap (i.e., A ⋂ B = ∅), φ > 0 and represents the
+   minimal distance between the two objects. More formally:
+   φ = min(|Aₚ - Bₚ|)
+   ∀ Aₚ ∈ A and Bₚ ∈ B.
+   @note The pair (Aₚ, Bₚ) is a "witness" of the distance.
+   The pair need not be unique (think of two parallel planes).
+
+   If the objects touch or overlap (i.e., A ⋂ B ≠ ∅), φ ≤ 0 and can be
+   interpreted as the negative penetration depth. It is the smallest length of
+   the vector v, such that by shifting one object along that vector relative to
+   the other, the two objects will no longer be overlapping. More formally,
+   φ(A, B) = -min |v|.
+   s.t (Tᵥ · A) ⋂ B = ∅
+   where Tᵥ is a rigid transformation that displaces A by the vector v, namely
+   Tᵥ · A = {u + v | ∀ u ∈ A}.
+   By implication, there exist points Aₚ and Bₚ on the surfaces of objects A and
+   B, respectively, such that Aₚ + v = Bₚ, Aₚ ∈ A ∩ B, Bₚ ∈ A ∩ B. These points
+   are the witnesses to the penetration.
+
+   This method is affected by collision filtering; geometry pairs that
+   have been filtered will not produce signed distance query results.
+
+   For a geometry pair (A, B), the returned results will always be reported in
+   a fixed order (e.g., always (A, B) and never (B, A)). The _basis_ for the
+   ordering is arbitrary (and therefore undocumented), but guaranteed to be
+   fixed and repeatable.
+
+   Notice that this is an O(N²) operation, where N
+   is the number of geometries remaining in the world after applying collision
+   filter. We report the distance between dynamic objects, and between dynamic
+   and anchored objects. We DO NOT report the distance between two anchored
+   objects.
+
+   <h3>Scalar support</h3>
+   This function does not support halfspaces. If an unfiltered pair contains
+   a halfspace, an exception will be thrown for all scalar types. Otherwise,
+   this query supports all other pairs of Drake geometry types for `double`.
+   For `AutoDiffXd`, it only supports distance between sphere-box and
+   sphere-sphere. If there are any unfiltered geometry pairs that include other
+   geometries, the AutoDiff throws an exception.
+
+   <!-- TODO(SeanCurtis-TRI): Document expected precision of answer based on
+   members of shape pair. See
+   https://github.com/RobotLocomotion/drake/issues/10907 -->
+   <!-- TODO(SeanCurtis-TRI): Support queries of halfspace-A, where A is _not_ a
+   halfspace. See https://github.com/RobotLocomotion/drake/issues/10905 -->
+
+   @param max_distance  The maximum distance at which distance data is reported.
+
+   @returns The signed distance (and supporting data) for all unfiltered
+            geometry pairs whose distance is less than or equal to
+            `max_distance`.  */
+  std::vector<SignedDistancePair<T>> ComputeSignedDistancePairwiseClosestPoints(
+      const double max_distance =
+          std::numeric_limits<double>::infinity()) const;
+
+  /** A variant of ComputeSignedDistancePairwiseClosestPoints() which computes
+   the signed distance (and witnesses) between a specific pair of geometries
+   indicated by id. This function has the same restrictions on scalar report
+   as ComputeSignedDistancePairwiseClosestPoints().
+
+   @throws if either geometry id is invalid, or if the pair (id_A, id_B) has
+           been marked as filtered.  */
+  SignedDistancePair<T> ComputeSignedDistancePairClosestPoints(
+      GeometryId id_A, GeometryId id_B) const;
+
+  // TODO(DamrongGuoy): Improve and refactor documentation of
+  // ComputeSignedDistanceToPoint(). Move the common sections into Signed
+  // Distance Queries. Update documentation as we add more functionality.
+  // Right now it only supports spheres and boxes.
+  /**
+   Computes the signed distances and gradients to a query point from each
+   geometry in the scene.
+
+   @warning Currently supports spheres, boxes, and cylinders only. Silently
+   ignores other kinds of geometries, which will be added later.
+
+   This query provides φᵢ(p), φᵢ:ℝ³→ℝ, the signed distance to the position
+   p of a query point from geometry Gᵢ in the scene.  It returns an array of
+   the signed distances from all geometries.
+
+   Optionally you can specify a threshold distance that will filter out any
+   object beyond the threshold. By default, we report distances from the query
+   point to every object.
+
+   This query also provides the gradient vector ∇φᵢ(p) of the signed distance
+   function from geometry Gᵢ. Note that, in general, if p is outside Gᵢ, then
+   ∇φᵢ(p) equals the unit vector in the direction from the nearest point Nᵢ on
+   Gᵢ's surface to p. If p is inside Gᵢ, then ∇φᵢ(p) is in the direction from
+   p to Nᵢ. This observation is written formally as:
+
+   ∇φᵢ(p) = (p - Nᵢ)/|p - Nᵢ| if p is outside Gᵢ
+
+   ∇φᵢ(p) = -(p - Nᵢ)/|p - Nᵢ| if p is inside Gᵢ
+
+   Note that ∇φᵢ(p) is also defined on Gᵢ's surface, but we cannot use the
+   above formula.
+
+   <h3>Scalar support</h3>
+   This query only supports computing distances from the point to spheres,
+   boxes, and cylinders for both `double` and `AutoDiffXd` scalar types. If
+   the SceneGraph contains any other geometry shapes, they will be silently
+   ignored.
+
+   @note For a sphere G, the signed distance function φᵢ(p) has an undefined
+   gradient vector at the center of the sphere--every point on the sphere's
+   surface has the same distance to the center.  In this case, we will assign
+   ∇φᵢ(p) the unit vector Gx (x-directional vector of G's frame) expressed
+   in World frame.
+
+   @note For a box, at a point p on an edge or a corner of the box, the signed
+   distance function φᵢ(p) has an undefined gradient vector.  In this case, we
+   will assign a unit vector in the direction of the average of the outward
+   face unit normals of the incident faces of the edge or the corner.
+   A point p is considered being on a face, or an edge, or a corner of the
+   box if it lies within a certain tolerance from them.
+
+   @note For a box B, if a point p is inside the box, and it is equidistant to
+   to multiple nearest faces, the signed distance function φᵢ(p) at p will have
+   an undefined gradient vector. There is a nearest point candidate associated
+   with each nearest face. In this case, we arbitrarily pick the point Nᵢ
+   associated with one of the nearest faces.  Please note that, due to the
+   possible round off error arising from applying a pose X_WG to B, there is no
+   guarantee which of the nearest faces will be used.
+
+   @note The signed distance function is a continuous function with respect to
+   the position of the query point, but its gradient vector field may
+   not be continuous. Specifically at a position equidistant to multiple
+   nearest points, its gradient vector field is not continuous.
+
+   @note For a convex object, outside the object at positive distance from
+   the boundary, the signed distance function is smooth (having continuous
+   first-order partial derivatives).
+
+   @param[in] p_WQ            Position of a query point Q in world frame W.
+   @param[in] threshold       We ignore any object beyond this distance.
+                              By default, it is infinity, so we report
+                              distances from the query point to every object.
+   @retval signed_distances   A vector populated with per-object signed
+                              distance values (and supporting data).
+                              See SignedDistanceToPoint.
+   */
+  std::vector<SignedDistanceToPoint<T>>
+  ComputeSignedDistanceToPoint(const Vector3<T> &p_WQ,
+                               const double threshold
+                               = std::numeric_limits<double>::infinity()) const;
+  //@}
+};
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/query_object.cc
+++ b/geometry/query_object.cc
@@ -46,27 +46,21 @@ QueryObject<T>& QueryObject<T>::operator=(const QueryObject<T>& query_object) {
 
 template <typename T>
 const RigidTransform<T>& QueryObject<T>::X_WF(FrameId id) const {
-  ThrowIfNotCallable();
-
-  FullPoseUpdate();
+  ValidateAndUpdate();
   const GeometryState<T>& state = geometry_state();
   return state.get_pose_in_world(id);
 }
 
 template <typename T>
 const RigidTransform<T>& QueryObject<T>::X_PF(FrameId id) const {
-  ThrowIfNotCallable();
-
-  FullPoseUpdate();
+  ValidateAndUpdate();
   const GeometryState<T>& state = geometry_state();
   return state.get_pose_in_parent(id);
 }
 
 template <typename T>
 const RigidTransform<T>& QueryObject<T>::X_WG(GeometryId id) const {
-  ThrowIfNotCallable();
-
-  FullPoseUpdate();
+  ValidateAndUpdate();
   const GeometryState<T>& state = geometry_state();
   return state.get_pose_in_world(id);
 }
@@ -74,9 +68,7 @@ const RigidTransform<T>& QueryObject<T>::X_WG(GeometryId id) const {
 template <typename T>
 std::vector<PenetrationAsPointPair<double>>
 QueryObject<T>::ComputePointPairPenetration() const {
-  ThrowIfNotCallable();
-
-  FullPoseUpdate();
+  ValidateAndUpdate();
   const GeometryState<T>& state = geometry_state();
   return state.ComputePointPairPenetration();
 }
@@ -84,18 +76,14 @@ QueryObject<T>::ComputePointPairPenetration() const {
 template <typename T>
 std::vector<SortedPair<GeometryId>> QueryObject<T>::FindCollisionCandidates()
     const {
-  ThrowIfNotCallable();
-  // TODO(amcastro-tri): Modify this when the cache system is in place.
-  FullPoseUpdate();
+  ValidateAndUpdate();
   const GeometryState<T>& state = geometry_state();
   return state.FindCollisionCandidates();
 }
 
 template <typename T>
 bool QueryObject<T>::HasCollisions() const {
-  ThrowIfNotCallable();
-
-  FullPoseUpdate();
+  ValidateAndUpdate();
   const GeometryState<T>& state = geometry_state();
   return state.HasCollisions();
 }
@@ -103,9 +91,7 @@ bool QueryObject<T>::HasCollisions() const {
 template <typename T>
 std::vector<ContactSurface<T>>
 QueryObject<T>::ComputeContactSurfaces() const {
-  ThrowIfNotCallable();
-
-  FullPoseUpdate();
+  ValidateAndUpdate();
   const GeometryState<T>& state = geometry_state();
   return state.ComputeContactSurfaces();
 }
@@ -116,10 +102,7 @@ void QueryObject<T>::ComputeContactSurfacesWithFallback(
     std::vector<PenetrationAsPointPair<double>>* point_pairs) const {
   DRAKE_DEMAND(surfaces);
   DRAKE_DEMAND(point_pairs);
-
-  ThrowIfNotCallable();
-
-  FullPoseUpdate();
+  ValidateAndUpdate();
   const GeometryState<T>& state = geometry_state();
   state.ComputeContactSurfacesWithFallback(surfaces, point_pairs);
 }
@@ -128,9 +111,7 @@ template <typename T>
 std::vector<SignedDistancePair<T>>
 QueryObject<T>::ComputeSignedDistancePairwiseClosestPoints(
     const double max_distance) const {
-  ThrowIfNotCallable();
-
-  FullPoseUpdate();
+  ValidateAndUpdate();
   const GeometryState<T>& state = geometry_state();
   return state.ComputeSignedDistancePairwiseClosestPoints(max_distance);
 }
@@ -138,9 +119,7 @@ QueryObject<T>::ComputeSignedDistancePairwiseClosestPoints(
 template <typename T>
 SignedDistancePair<T> QueryObject<T>::ComputeSignedDistancePairClosestPoints(
     GeometryId id_A, GeometryId id_B) const {
-  ThrowIfNotCallable();
-
-  FullPoseUpdate();
+  ValidateAndUpdate();
   const GeometryState<T>& state = geometry_state();
   return state.ComputeSignedDistancePairClosestPoints(id_A, id_B);
 }
@@ -150,9 +129,7 @@ std::vector<SignedDistanceToPoint<T>>
 QueryObject<T>::ComputeSignedDistanceToPoint(
     const Vector3<T>& p_WQ,
     const double threshold) const {
-  ThrowIfNotCallable();
-
-  FullPoseUpdate();
+  ValidateAndUpdate();
   const GeometryState<T>& state = geometry_state();
   return state.ComputeSignedDistanceToPoint(p_WQ, threshold);
 }
@@ -163,9 +140,7 @@ void QueryObject<T>::RenderColorImage(const CameraProperties& camera,
                                       const RigidTransformd& X_PC,
                                       bool show_window,
                                       ImageRgba8U* color_image_out) const {
-  ThrowIfNotCallable();
-
-  FullPoseUpdate();
+  ValidateAndUpdate();
   const GeometryState<T>& state = geometry_state();
   return state.RenderColorImage(camera, parent_frame, X_PC, show_window,
                                 color_image_out);
@@ -176,9 +151,7 @@ void QueryObject<T>::RenderDepthImage(const DepthCameraProperties& camera,
                                       FrameId parent_frame,
                                       const RigidTransformd& X_PC,
                                       ImageDepth32F* depth_image_out) const {
-  ThrowIfNotCallable();
-
-  FullPoseUpdate();
+  ValidateAndUpdate();
   const GeometryState<T>& state = geometry_state();
   return state.RenderDepthImage(camera, parent_frame, X_PC, depth_image_out);
 }
@@ -189,9 +162,7 @@ void QueryObject<T>::RenderLabelImage(const CameraProperties& camera,
                                       const RigidTransformd& X_PC,
                                       bool show_window,
                                       ImageLabel16I* label_image_out) const {
-  ThrowIfNotCallable();
-
-  FullPoseUpdate();
+  ValidateAndUpdate();
   const GeometryState<T>& state = geometry_state();
   return state.RenderLabelImage(camera, parent_frame, X_PC, show_window,
                                 label_image_out);
@@ -206,6 +177,12 @@ const GeometryState<T>& QueryObject<T>::geometry_state() const {
   } else {
     return *state_;
   }
+}
+
+template <typename T>
+void QueryObject<T>::FullPoseUpdate() const {
+  // TODO(SeanCurtis-TRI): Modify this when the cache system is in place.
+  if (scene_graph_) scene_graph_->FullPoseUpdate(*context_);
 }
 
 }  // namespace geometry

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -76,6 +76,14 @@ SceneGraph<T>::SceneGraph()
   query_port_index_ =
       this->DeclareAbstractOutputPort("query", &SceneGraph::CalcQueryObject)
           .get_index();
+  proximity_query_port_index_ =
+      this->DeclareAbstractOutputPort("proximity_query",
+                                      &SceneGraph::CalcProximityQueryObject)
+          .get_index();
+  perception_query_port_index_ =
+      this->DeclareAbstractOutputPort("perception_query",
+                                      &SceneGraph::CalcPerceptionQueryObject)
+          .get_index();
 
   auto& pose_update_cache_entry = this->DeclareCacheEntry(
       "Cache guard for pose updates", &SceneGraph::CalcPoseUpdate,
@@ -344,8 +352,8 @@ void SceneGraph<T>::MakeSourcePorts(SourceId source_id) {
 }
 
 template <typename T>
-void SceneGraph<T>::CalcQueryObject(const Context<T>& context,
-                                    QueryObject<T>* output) const {
+void SceneGraph<T>::MakeQueryObjectLive(const Context<T>& context,
+                                        QueryObject<T>* output) const {
   // NOTE: This is an exception to the style guide. It takes a const reference
   // but then hangs onto a const pointer. The guide says the parameter should
   // itself be a const pointer. We're breaking the guide to satisfy the
@@ -358,6 +366,30 @@ void SceneGraph<T>::CalcQueryObject(const Context<T>& context,
   //
   // See the todo in the header for an alternate formulation.
   output->set(&context, this);
+}
+
+template <typename T>
+void SceneGraph<T>::CalcQueryObject(const Context<T>& context,
+                                    QueryObject<T>* output) const {
+  // Making it "live" is the only work necessary for "Calc"ing a
+  // QueryObject-like thing.
+  MakeQueryObjectLive(context, output);
+}
+
+template <typename T>
+void SceneGraph<T>::CalcProximityQueryObject(
+    const Context<T>& context, ProximityQueryObject<T>* output) const {
+  // Making it "live" is the only work necessary for "Calc"ing a
+  // QueryObject-like thing.
+  MakeQueryObjectLive(context, output);
+}
+
+template <typename T>
+void SceneGraph<T>::CalcPerceptionQueryObject(
+    const Context<T>& context, PerceptionQueryObject<T>* output) const {
+  // Making it "live" is the only work necessary for "Calc"ing a
+  // QueryObject-like thing.
+  MakeQueryObjectLive(context, output);
 }
 
 template <typename T>

--- a/geometry/test/perception_query_object_test.cc
+++ b/geometry/test/perception_query_object_test.cc
@@ -1,10 +1,12 @@
-#include "drake/geometry/query_object.h"
+#include "drake/geometry/perception_query_object.h"
 
 #include <memory>
 
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/render/camera_properties.h"
 #include "drake/math/rigid_transform.h"
 
 namespace drake {
@@ -17,7 +19,8 @@ using systems::sensors::ImageLabel16I;
 using systems::sensors::ImageRgba8U;
 
 // Friend class to QueryObject -- left in `drake::geometry` to match the friend
-// declaration.
+// declaration. The name gives it access to the private/protected access of
+// PerceptionQueryObject's *parent* class, QueryObject.
 class QueryObjectTest : public ::testing::Test {
  protected:
   template <typename T>
@@ -25,10 +28,10 @@ class QueryObjectTest : public ::testing::Test {
     if (object.scene_graph_ != nullptr || object.context_ != nullptr ||
         object.state_ != nullptr) {
       return ::testing::AssertionFailure()
-             << "A default query object should have all null fields. Has "
-                "scene_graph: "
-             << object.scene_graph_ << ", context: " << object.context_
-             << ", state: " << object.state_.get();
+          << "A default query object should have all null fields. Has "
+             "scene_graph: "
+          << object.scene_graph_ << ", context: " << object.context_
+          << ", state: " << object.state_.get();
     }
     return ::testing::AssertionSuccess();
   }
@@ -39,13 +42,14 @@ class QueryObjectTest : public ::testing::Test {
   }
 };
 
-// NOTE: This doesn't test the specific queries; GeometryQuery simply wraps
-// the class (SceneGraph) that actually *performs* those queries. The
+// NOTE: This doesn't test the specific queries; PerceptionQueryObject simply
+// wraps the class (GeometryState) that actually *performs* those queries. The
 // correctness of those queries is handled in geometry_state_test.cc. The
 // wrapper merely confirms that the state is correct and that wrapper
 // functionality is tested in DefaultQueryThrows.
 TEST_F(QueryObjectTest, DefaultQueryThrows) {
-  QueryObject<double> default_object;
+  PerceptionQueryObject<double> default_object;
+
   EXPECT_TRUE(is_default(default_object));
 
 #define EXPECT_DEFAULT_ERROR(expression) \

--- a/geometry/test/perception_query_object_test.cc
+++ b/geometry/test/perception_query_object_test.cc
@@ -1,0 +1,78 @@
+#include "drake/geometry/query_object.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/math/rigid_transform.h"
+
+namespace drake {
+namespace geometry {
+
+using math::RigidTransformd;
+using render::DepthCameraProperties;
+using systems::sensors::ImageDepth32F;
+using systems::sensors::ImageLabel16I;
+using systems::sensors::ImageRgba8U;
+
+// Friend class to QueryObject -- left in `drake::geometry` to match the friend
+// declaration.
+class QueryObjectTest : public ::testing::Test {
+ protected:
+  template <typename T>
+  static ::testing::AssertionResult is_default(const QueryObject<T>& object) {
+    if (object.scene_graph_ != nullptr || object.context_ != nullptr ||
+        object.state_ != nullptr) {
+      return ::testing::AssertionFailure()
+             << "A default query object should have all null fields. Has "
+                "scene_graph: "
+             << object.scene_graph_ << ", context: " << object.context_
+             << ", state: " << object.state_.get();
+    }
+    return ::testing::AssertionSuccess();
+  }
+
+  template <typename T>
+  static void ThrowIfNotCallable(const QueryObject<T>& object) {
+    object.ThrowIfNotCallable();
+  }
+};
+
+// NOTE: This doesn't test the specific queries; GeometryQuery simply wraps
+// the class (SceneGraph) that actually *performs* those queries. The
+// correctness of those queries is handled in geometry_state_test.cc. The
+// wrapper merely confirms that the state is correct and that wrapper
+// functionality is tested in DefaultQueryThrows.
+TEST_F(QueryObjectTest, DefaultQueryThrows) {
+  QueryObject<double> default_object;
+  EXPECT_TRUE(is_default(default_object));
+
+#define EXPECT_DEFAULT_ERROR(expression) \
+  DRAKE_EXPECT_THROWS_MESSAGE(expression, std::runtime_error, \
+      "Attempting to perform query on invalid QueryObject.+");
+
+  EXPECT_DEFAULT_ERROR(ThrowIfNotCallable(default_object));
+
+  // Enumerate *all* queries to confirm they throw the proper exception.
+
+  // Render queries.
+  DepthCameraProperties properties(2, 2, M_PI, "dummy_renderer", 0.1, 5.0);
+  RigidTransformd X_WC = RigidTransformd::Identity();
+  ImageRgba8U color;
+  EXPECT_DEFAULT_ERROR(default_object.RenderColorImage(
+      properties, FrameId::get_new_id(), X_WC, false, &color));
+
+  ImageDepth32F depth;
+  EXPECT_DEFAULT_ERROR(default_object.RenderDepthImage(
+      properties, FrameId::get_new_id(), X_WC, &depth));
+
+  ImageLabel16I label;
+  EXPECT_DEFAULT_ERROR(default_object.RenderLabelImage(
+      properties, FrameId::get_new_id(), X_WC, false, &label));
+
+#undef EXPECT_DEFAULT_ERROR
+}
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/test/proximity_query_object_test.cc
+++ b/geometry/test/proximity_query_object_test.cc
@@ -1,0 +1,71 @@
+#include "drake/geometry/query_object.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+namespace drake {
+namespace geometry {
+
+using systems::Context;
+
+// Friend class to QueryObject -- left in `drake::geometry` to match the friend
+// declaration.
+class QueryObjectTest : public ::testing::Test {
+ protected:
+  template <typename T>
+  static ::testing::AssertionResult is_default(const QueryObject<T>& object) {
+    if (object.scene_graph_ != nullptr || object.context_ != nullptr ||
+        object.state_ != nullptr) {
+      return ::testing::AssertionFailure()
+             << "A default query object should have all null fields. Has "
+                "scene_graph: "
+             << object.scene_graph_ << ", context: " << object.context_
+             << ", state: " << object.state_.get();
+    }
+    return ::testing::AssertionSuccess();
+  }
+
+  template <typename T>
+  static void ThrowIfNotCallable(const QueryObject<T>& object) {
+    object.ThrowIfNotCallable();
+  }
+};
+
+// NOTE: This doesn't test the specific queries; GeometryQuery simply wraps
+// the class (SceneGraph) that actually *performs* those queries. The
+// correctness of those queries is handled in geometry_state_test.cc. The
+// wrapper merely confirms that the state is correct and that wrapper
+// functionality is tested in DefaultQueryThrows.
+TEST_F(QueryObjectTest, DefaultQueryThrows) {
+  QueryObject<double> default_object;
+  EXPECT_TRUE(is_default(default_object));
+
+#define EXPECT_DEFAULT_ERROR(expression) \
+  DRAKE_EXPECT_THROWS_MESSAGE(expression, std::runtime_error, \
+      "Attempting to perform query on invalid QueryObject.+");
+
+  EXPECT_DEFAULT_ERROR(ThrowIfNotCallable(default_object));
+
+  // Enumerate *all* queries to confirm they throw the proper exception.
+
+  // Penetration queries.
+  EXPECT_DEFAULT_ERROR(default_object.ComputePointPairPenetration());
+  EXPECT_DEFAULT_ERROR(default_object.ComputeContactSurfaces());
+
+  // Signed distance queries.
+  EXPECT_DEFAULT_ERROR(
+      default_object.ComputeSignedDistancePairwiseClosestPoints());
+  EXPECT_DEFAULT_ERROR(default_object.ComputeSignedDistancePairClosestPoints(
+      GeometryId::get_new_id(), GeometryId::get_new_id()));
+  EXPECT_DEFAULT_ERROR(
+      default_object.ComputeSignedDistanceToPoint(Vector3<double>::Zero()));
+
+  EXPECT_DEFAULT_ERROR(default_object.FindCollisionCandidates());
+  EXPECT_DEFAULT_ERROR(default_object.HasCollisions());
+
+#undef EXPECT_DEFAULT_ERROR
+}
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/test/proximity_query_object_test.cc
+++ b/geometry/test/proximity_query_object_test.cc
@@ -1,4 +1,4 @@
-#include "drake/geometry/query_object.h"
+#include "drake/geometry/proximity_query_object.h"
 
 #include <gtest/gtest.h>
 
@@ -7,10 +7,11 @@
 namespace drake {
 namespace geometry {
 
-using systems::Context;
+using std::vector;
 
 // Friend class to QueryObject -- left in `drake::geometry` to match the friend
-// declaration.
+// declaration. The name gives it access to the private/protected access of
+// ProximityQueryObject's *parent* class, QueryObject.
 class QueryObjectTest : public ::testing::Test {
  protected:
   template <typename T>
@@ -32,13 +33,14 @@ class QueryObjectTest : public ::testing::Test {
   }
 };
 
-// NOTE: This doesn't test the specific queries; GeometryQuery simply wraps
-// the class (SceneGraph) that actually *performs* those queries. The
+// NOTE: This doesn't test the specific queries; ProximityQueryObject simply
+// wraps the class (GeometryState) that actually *performs* those queries. The
 // correctness of those queries is handled in geometry_state_test.cc. The
 // wrapper merely confirms that the state is correct and that wrapper
 // functionality is tested in DefaultQueryThrows.
 TEST_F(QueryObjectTest, DefaultQueryThrows) {
-  QueryObject<double> default_object;
+  ProximityQueryObject<double> default_object;
+
   EXPECT_TRUE(is_default(default_object));
 
 #define EXPECT_DEFAULT_ERROR(expression) \
@@ -52,6 +54,10 @@ TEST_F(QueryObjectTest, DefaultQueryThrows) {
   // Penetration queries.
   EXPECT_DEFAULT_ERROR(default_object.ComputePointPairPenetration());
   EXPECT_DEFAULT_ERROR(default_object.ComputeContactSurfaces());
+  vector<ContactSurface<double>> surfaces;
+  vector<PenetrationAsPointPair<double>> point_pairs;
+  EXPECT_DEFAULT_ERROR(default_object.ComputeContactSurfacesWithFallback(
+      &surfaces, &point_pairs));
 
   // Signed distance queries.
   EXPECT_DEFAULT_ERROR(


### PR DESCRIPTION
This breaks up the monolithic QueryObject into three classes. Ultimately, it decouples proximity queries from perception queries. This is necessary for an up-coming feature: mesh painting. With all
queries in a single port, it increases the chance for a false algebraic loop.

This does *not* deprecate the queries on QueryObject yet (there is a follow-up PR that will do that).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13161)
<!-- Reviewable:end -->
