### PR TITLE
[geometry/dev] Cosmetic clean up and missing tests

### DIFF
--- a/geometry/render/gl_renderer/dev/BUILD.bazel
+++ b/geometry/render/gl_renderer/dev/BUILD.bazel
@@ -73,6 +73,26 @@ drake_cc_library_gl_ubuntu_only(
 )
 
 drake_cc_googletest_gl_ubuntu_only(
+    name = "buffer_dim_test",
+    tags = vtk_test_tags(),
+    deps = [
+        ":render_engine_gl",
+    ],
+)
+
+drake_cc_googletest_gl_ubuntu_only(
+    name = "load_mesh_test",
+    data = [
+        "//systems/sensors:test_models",
+    ],
+    deps = [
+        ":load_mesh",
+        "//common:find_resource",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest_gl_ubuntu_only(
     name = "render_engine_gl_test",
     data = [
         "//systems/sensors:test_models",

--- a/geometry/render/gl_renderer/dev/buffer_dim.h
+++ b/geometry/render/gl_renderer/dev/buffer_dim.h
@@ -9,7 +9,8 @@ namespace geometry {
 namespace render {
 namespace internal {
 
-/** Simple class for recording the dimensions of a render target. */
+/** Simple class for recording the dimensions of a render target. Used store
+ unique RenderTarget instances based on render size.  */
 class BufferDim {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(BufferDim)

--- a/geometry/render/gl_renderer/dev/load_mesh.h
+++ b/geometry/render/gl_renderer/dev/load_mesh.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <istream>
 #include <string>
 #include <utility>
 
@@ -12,17 +13,41 @@ namespace geometry {
 namespace render {
 namespace internal {
 
+// These are pseudo-public aliases -- they are exposed to other classes in the
+// render::internal namespace, but aren't part of the public API.
+
+/* The representation of all Nv vertex positions in the mesh encoded in a Nvx3
+ matrix such that the ith row is the position for the ith vertex in the mesh
+ (measured and expressed in the mesh's canonical frame M).
+
+ The representation is, as the name implies, intended to facilitate defining
+ OpenGl geometry constructs via vertex buffers.  */
 using VertexBuffer = Eigen::Matrix<GLfloat, Eigen::Dynamic, 3, Eigen::RowMajor>;
+
+/* The representation of all Nt mesh triangles, encoded in an Ntx3 matrix of
+ index values. The ith row represents the ith triangle such that columns 0, 1,
+ and 2 of that row are indices into the corresponding VertexBuffer. All values
+ in this data should lie in the range [0, vertices.rows() - 1], for the
+ corresponding set of vertices.
+
+ The representation is, as the name implies, intended to facilitate defining
+ OpenGl geometries via index buffers.  */
 using IndexBuffer = Eigen::Matrix<GLuint, Eigen::Dynamic, 3, Eigen::RowMajor>;
 
-/** Loads a mesh's vertices and indices (faces). Does not load textures.
- Note that while this functionality seems similar to ReadObjToSurfaceMesh,
- RenderEngineGl cannot use SurfaceMesh. Rendering requires normals and texture
- coordinates; SurfaceMesh was not designed with those quantities in mind.
- */
+// TODO(SeanCurtis-TRI): Also parse normals and texture coordinates.
+
+/* Loads a mesh's vertices and indices (faces) from an OBJ description given
+ in the input stream. It does not load textures. Note that while this
+ functionality seems similar to ReadObjToSurfaceMesh, RenderEngineGl cannot use
+ SurfaceMesh. Rendering requires normals and texture coordinates; SurfaceMesh
+ was not designed with those quantities in mind.  */
+std::pair<VertexBuffer, IndexBuffer> LoadMeshFromObj(
+    std::istream* input_stream);
+
+/* Overload of LoadMeshFromObj that reads the OBJ description from the given
+ file. */
 std::pair<VertexBuffer, IndexBuffer> LoadMeshFromObj(
     const std::string& filename);
-
 }  // namespace internal
 }  // namespace render
 }  // namespace geometry

--- a/geometry/render/gl_renderer/dev/test/buffer_dim_test.cc
+++ b/geometry/render/gl_renderer/dev/test/buffer_dim_test.cc
@@ -1,0 +1,60 @@
+#include "drake/geometry/render/gl_renderer/dev/buffer_dim.h"
+
+#include <unordered_set>
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace internal {
+namespace {
+
+GTEST_TEST(BufferDimTest, Construction) {
+  const int w = 127;
+  const int h = 328;
+  const BufferDim buffer(w, h);
+
+  EXPECT_EQ(buffer.width(), w);
+  EXPECT_EQ(buffer.height(), h);
+}
+
+GTEST_TEST(BufferDimTest, Equality) {
+  const int w = 127;
+  const int h = 328;
+  const BufferDim buffer(w, h);
+  const BufferDim same(w, h);
+  const BufferDim different1(w + 1, h);
+  const BufferDim different2(w, h + 1);
+  const BufferDim different3(w + 1, h + 1);
+
+  EXPECT_EQ(buffer, same);
+  // BufferDim has operator== (implicitly used by EXPECT_EQ) but _not_
+  // operator != used by EXPECT_NE.
+  EXPECT_FALSE(buffer == different1);
+  EXPECT_FALSE(buffer == different2);
+  EXPECT_FALSE(buffer == different3);
+}
+
+GTEST_TEST(BufferDimTest, HashableKey) {
+  const int w = 127;
+  const int h = 328;
+  const BufferDim buffer(w, h);
+  const BufferDim same(w, h);
+
+  std::unordered_set<BufferDim> buffers;
+
+  EXPECT_EQ(buffers.count(buffer), 0);
+  buffers.insert(buffer);
+  EXPECT_EQ(buffers.count(buffer), 1);
+  EXPECT_EQ(buffers.count(same), 1);
+  buffers.insert(same);
+  EXPECT_EQ(buffers.count(buffer), 1);
+  EXPECT_EQ(buffers.count(same), 1);
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/gl_renderer/dev/test/load_mesh_test.cc
+++ b/geometry/render/gl_renderer/dev/test/load_mesh_test.cc
@@ -1,0 +1,148 @@
+#include "drake/geometry/render/gl_renderer/dev/load_mesh.h"
+
+#include <sstream>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace internal {
+namespace {
+
+GTEST_TEST(LoadMeshFromObjTest, ErrorModes) {
+  {
+    // Case: Vertices only reports no faces found.
+    std::stringstream in_stream("v 1 2 3");
+    DRAKE_EXPECT_THROWS_MESSAGE(LoadMeshFromObj(&in_stream), std::runtime_error,
+                                "The OBJ data appears to have no faces.*");
+  }
+  {
+    // Case: Not an obj in any way reports as no faces.
+    std::stringstream in_stream("Not an obj\njust some\nmeaningles text.\n");
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        LoadMeshFromObj(&in_stream), std::runtime_error,
+        "The OBJ data appears to have no faces.* might not be an OBJ file");
+  }
+}
+
+// Simply confirms that the filename variant of LoadMeshFromObj successfully
+// dispatches files or errors, as appropriate. The actual parsing functionality
+// is parsed via the stream interface.
+GTEST_TEST(LoadMeshFromObjTest, ReadingFile) {
+  const std::string filename =
+      FindResourceOrThrow("drake/systems/sensors/test/models/meshes/box.obj");
+
+  auto [vertices, indices] = LoadMeshFromObj(filename);
+  EXPECT_EQ(vertices.rows(), 8);
+  EXPECT_EQ(indices.rows(), 12);
+
+  DRAKE_EXPECT_THROWS_MESSAGE(LoadMeshFromObj("Bad file name"),
+                              std::runtime_error,
+                              "Cannot load the obj file 'Bad file name'");
+}
+
+// Confirms that non-triangular faces get triangulated.
+GTEST_TEST(LoadMeshFromObjTest, TriangulatePolygons) {
+/*
+             o 4
+            ╱  ╲            A five-sided polygon and a four-sided polygon
+           ╱    ╲           should be triangulated into three and two
+          ╱      ╲          triangles respectively. But with the same
+         ╱        ╲         vertices.
+        ╱          ╲
+     5 o            o 3
+        ╲          ╱
+         ╲        ╱
+       1  o──────o 2
+          │      │
+          o──────o
+          6      7
+*/
+  std::stringstream in_stream(R"_(
+v -1 -1 0
+v 1 -1 0
+v 2 1 0
+v 0 2 0
+v -2 1 0
+v -1 -2 0
+v 1 -2 0
+f 1 2 3 4 5
+f 6 7 2 1
+  )_");
+  auto [vertices, indices] = LoadMeshFromObj(&in_stream);
+  EXPECT_EQ(vertices.rows(), 7);
+  EXPECT_EQ(indices.rows(), 5);
+}
+
+// Geometry already triangulated gets preserved.
+GTEST_TEST(LoadMeshFromObjTest, PreserveTriangulation) {
+/*
+             o 4
+            ╱  ╲
+           ╱    ╲
+          ╱      ╲
+         ╱        ╲
+        ╱          ╲       Note: Ascii art makes drawing the following edges
+     5 o────────────o 3    nearly impossible.
+        ╲          ╱
+         ╲        ╱        Connect 2 to 5 to form two triangles.
+       1  o──────o 2
+          │      │         Connect 1 to 7 to form two triangles.
+          o──────o
+          6      7
+*/
+  std::stringstream in_stream(R"_(
+v -1 -1 0
+v 1 -1 0
+v 2 1 0
+v 0 2 0
+v -2 1 0
+v -1 -2 0
+v 1 -2 0
+f 1 2 5
+f 2 3 5
+f 3 4 5
+f 1 6 7
+f 1 7 2
+  )_");
+  auto [vertices, indices] = LoadMeshFromObj(&in_stream);
+  EXPECT_EQ(vertices.rows(), 7);
+  EXPECT_EQ(indices.rows(), 5);
+}
+
+// Confirms that no mesh optimization takes place, e.g., unreferenced vertices
+// are still included and duplicate vertices are not merged.
+GTEST_TEST(LoadMeshFromObjTest, NoMeshOptimization) {
+/*
+
+        4 o───────o 3
+          │     ╱ │
+          │   ╱   │   o 5
+          │ ╱     │
+    1, 6  o───────o 2
+
+*/
+  std::stringstream in_stream(R"_(
+v -1 -1 0  # First four corners form a box around the origin.
+v 1 -1 0
+v 1 1 0
+v -1 1 0
+v 3 0 0    # Unreferenced vertex to the right of the box
+v -1 -1 0  # Duplpicate of vertex 1
+f 1 2 3
+f 6 3 4
+  )_");
+  auto [vertices, indices] = LoadMeshFromObj(&in_stream);
+  EXPECT_EQ(vertices.rows(), 6);
+  EXPECT_EQ(indices.rows(), 2);
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
1. LoadMeshFromObj made more testable by given a std::istream overload.
2. Documentation in `load_mesh.*` and `buffer_dim.h` updated.
2. Unit tests added for LoadMeshFromObj and BufferDim.

This beefs up the state of the code in dev, prepatory to moving it out of dev.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13174)
<!-- Reviewable:end -->
