### PR TITLE
parsing: Rewrite package.xml crawl to avoid using @tinydir

### DIFF
--- a/attic/multibody/parsers/BUILD.bazel
+++ b/attic/multibody/parsers/BUILD.bazel
@@ -44,7 +44,6 @@ drake_cc_library(
         "//attic/multibody:rigid_body_tree",
         "//attic/multibody/rigid_body_plant:compliant_material",
         "//multibody/parsing:detail_misc",
-        "@tinydir",
         "@tinyxml2",
     ],
 )

--- a/attic/multibody/parsers/xml_util.cc
+++ b/attic/multibody/parsers/xml_util.cc
@@ -5,8 +5,6 @@
 #include <stdexcept>
 #include <string>
 
-#include <tinydir.h>
-
 #include "drake/common/drake_assert.h"
 #include "drake/math/rotation_matrix.h"
 

--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -52,7 +52,6 @@ drake_cc_library(
     ],
     deps = [
         "//common",
-        "@tinydir",
         "@tinyxml2",
     ],
 )

--- a/multibody/parsing/package_map.cc
+++ b/multibody/parsing/package_map.cc
@@ -2,13 +2,10 @@
 
 #include <algorithm>
 #include <cstdlib>
-#include <iostream>
 #include <optional>
 #include <sstream>
 #include <utility>
-#include <vector>
 
-#include <tinydir.h>
 #include <tinyxml2.h>
 
 #include "drake/common/drake_assert.h"
@@ -20,13 +17,8 @@
 namespace drake {
 namespace multibody {
 
-using std::cerr;
-using std::endl;
-using std::getenv;
-using std::istringstream;
 using std::runtime_error;
 using std::string;
-using std::vector;
 using tinyxml2::XMLDocument;
 using tinyxml2::XMLElement;
 
@@ -62,10 +54,17 @@ void PackageMap::PopulateFromFolder(const string& path) {
 
 void PackageMap::PopulateFromEnvironment(const string& environment_variable) {
   DRAKE_DEMAND(!environment_variable.empty());
-  const char* path_char = getenv(environment_variable.c_str());
-  DRAKE_DEMAND(path_char);
-  string path = string(path_char);
-  CrawlForPackages(path);
+  const char* const value = std::getenv(environment_variable.c_str());
+  if (value == nullptr) {
+    return;
+  }
+  std::istringstream iss{string(value)};
+  string path;
+  while (std::getline(iss, path, ':')) {
+    if (!path.empty()) {
+      CrawlForPackages(path);
+    }
+  }
 }
 
 namespace {
@@ -189,43 +188,25 @@ void PackageMap::PopulateUpstreamToDrake(const string& model_file) {
 
 void PackageMap::CrawlForPackages(const string& path) {
   DRAKE_DEMAND(!path.empty());
-  string directory_path = path;
-
-  // Removes all trailing "/" characters if any exist.
-  while (directory_path.length() > 0 && *(directory_path.end() - 1) == '/') {
-    directory_path.erase(directory_path.end() - 1);
+  std::error_code ec;
+  filesystem::directory_iterator iter(filesystem::path(path), ec);
+  if (ec) {
+    log()->warn("Unable to open directory: {}", path);
+    return;
   }
-  DRAKE_DEMAND(directory_path.length() > 0);
-
-  istringstream iss(directory_path);
-  const string target_filename("package.xml");
-  const char pathsep = ':';
-
-  string token;
-  while (getline(iss, token, pathsep)) {
-    tinydir_dir dir;
-    if (tinydir_open(&dir, token.c_str()) < 0) {
-      cerr << "Unable to open directory: " << token << endl;
-      continue;
-    }
-
-    while (dir.has_next) {
-      tinydir_file file;
-      tinydir_readfile(&dir, &file);
-
+  for (const auto& entry : iter) {
+    if (entry.is_directory()) {
+      const string filename = entry.path().filename().string();
       // Skips hidden directories (including "." and "..").
-      if (file.is_dir && (string(file.name) != "")
-          && (file.name[0] != '.')) {
-        CrawlForPackages(file.path);
-      } else if (file.name == target_filename) {
-        const string package_name = GetPackageName(file.path);
-        const string package_path =
-            filesystem::path(file.path).parent_path().string();
-        AddPackageIfNew(package_name, package_path + "/");
+      if (filename.at(0) == '.') {
+        continue;
       }
-      tinydir_next(&dir);
+      CrawlForPackages(entry.path().string());
+    } else if (entry.path().filename().string() == "package.xml") {
+      const string package_name = GetPackageName(entry.path().string());
+      const string package_path = entry.path().parent_path().string();
+      AddPackageIfNew(package_name, package_path + "/");
     }
-    tinydir_close(&dir);
   }
 }
 

--- a/tools/workspace/BUILD.bazel
+++ b/tools/workspace/BUILD.bazel
@@ -62,7 +62,6 @@ _DRAKE_EXTERNAL_PACKAGE_INSTALLS = ["@%s//:install" % p for p in [
     "pybind11",
     "sdformat",
     "spdlog",
-    "tinydir",
     "tinyobjloader",
     "vtk",
 ]] + ["//tools/workspace/%s:install" % p for p in [

--- a/tools/workspace/tinydir/BUILD.bazel
+++ b/tools/workspace/tinydir/BUILD.bazel
@@ -1,5 +1,15 @@
 # -*- python -*-
 
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_library",
+)
 load("//tools/lint:lint.bzl", "add_lint_tests")
+
+drake_cc_library(
+    name = "stub",
+    srcs = ["stub.cc"],
+    deps = ["@tinydir//:tinydir_for_stub_test"],
+)
 
 add_lint_tests()

--- a/tools/workspace/tinydir/package.BUILD.bazel
+++ b/tools/workspace/tinydir/package.BUILD.bazel
@@ -10,11 +10,12 @@ cc_library(
     name = "tinydir",
     hdrs = ["tinydir.h"],
     includes = ["."],
+    deprecation = "DRAKE DEPRECATED: The @tinydir external is being removed from Drake on or after 2020-08-01.  Downstream projects should add it to their own WORKSPACE if needed.",  # noqa
 )
 
-# We do not install the header file (its a private dependency), but we still
-# need to install its license file.
-install(
-    name = "install",
-    docs = ["COPYING"],
+# N.B. Not intended for public use!  This is only intended for the regression
+# test in @drake//tools/workspace/tinydir, and will be removed on 2020-08-01.
+cc_library(
+    name = "tinydir_for_stub_test",
+    deps = [":tinydir"],
 )

--- a/tools/workspace/tinydir/stub.cc
+++ b/tools/workspace/tinydir/stub.cc
@@ -1,0 +1,6 @@
+#include <tinydir.h>
+
+void stub() {
+  tinydir_dir dir;
+  (void)(dir);
+}


### PR DESCRIPTION
The tinydir external is now deprecated and will be removed on 2020-08-01.

Closes #13173.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13180)
<!-- Reviewable:end -->
