### PR TITLE
attic: Reduce CI coverage of extra variants

### DIFF
--- a/attic/build_macros.bzl
+++ b/attic/build_macros.bzl
@@ -9,15 +9,35 @@ load(
     "drake_cc_test",
 )
 
+# The attic code is deprecated and is not receiving many (if any) updates, so
+# the chance of breaking these variants is small.  We'll conserve CI resources
+# by skipping them.
+_ATTIC_TEST_TAGS = [
+    "no_asan",
+    "no_drd",
+    "no_helgrind",
+    "no_valgrind_tools",
+    "no_kcov",
+    "no_lsan",
+    "no_memcheck",
+    "no_tsan",
+    "no_ubsan",
+]
+
 def attic_drake_cc_binary(**kwargs):
     """A wrapper to that should be exclusively used within attic/...."""
     drake_cc_binary(
         **kwargs
     )
 
-def attic_drake_cc_googletest(**kwargs):
+def attic_drake_cc_googletest(name, *, tags = [], **kwargs):
     """A wrapper to that should be exclusively used within attic/...."""
-    drake_cc_googletest(**kwargs)
+    new_tags = (tags or []) + _ATTIC_TEST_TAGS
+    drake_cc_googletest(
+        name,
+        tags = new_tags,
+        **kwargs
+    )
 
 def attic_drake_cc_library(**kwargs):
     """A wrapper to that should be exclusively used within attic/...."""
@@ -32,6 +52,11 @@ def attic_drake_cc_package_library(**kwargs):
         **kwargs
     )
 
-def attic_drake_cc_test(**kwargs):
+def attic_drake_cc_test(name, *, tags = [], **kwargs):
     """A wrapper to that should be exclusively used within attic/...."""
-    drake_cc_test(**kwargs)
+    new_tags = (tags or []) + _ATTIC_TEST_TAGS
+    drake_cc_test(
+        name,
+        tags = new_tags,
+        **kwargs
+    )


### PR DESCRIPTION
The attic code is deprecated and is not receiving many (if any) updates, so the chance of breaking these variants is small.  We'll conserve CI resources by skipping them.

In particular, coverage builds and pre-merge lsan builds should benefit; the (few) macOS sanitizer builds should also benefit.

A straw poll in `#platform_review` slack favors this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13184)
<!-- Reviewable:end -->
