### PR TITLE
third_party: Remove spurious include path

### DIFF
--- a/third_party/com_github_finetjul_bender/BUILD.bazel
+++ b/third_party/com_github_finetjul_bender/BUILD.bazel
@@ -11,7 +11,6 @@ cc_library(
         "vtkCapsuleSource.cxx",
     ],
     hdrs = ["vtkCapsuleSource.h"],
-    include_prefix = "third_party/com_github_finetjul_bender/",
     licenses = ["notice"],  # Apache-2.0
     tags = ["nolint"],
     visibility = ["//geometry:__subpackages__"],


### PR DESCRIPTION
The default include paths are already correct.  Adding an extra suffix results in "undeclared inclusion" warnings downstream.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13189)
<!-- Reviewable:end -->
