### PR TITLE
tools: Disable python imports from ~/.local (pip -U)

### DIFF
--- a/tools/ubuntu-bionic.bazelrc
+++ b/tools/ubuntu-bionic.bazelrc
@@ -7,3 +7,9 @@ build:_helgrind --extra_toolchains=//tools/py_toolchain:linux_dbg_toolchain
 # Configure ${PATH} for actions.
 # N.B. Ensure this is consistent with `execute.bzl`.
 build --action_env=PATH=/usr/bin:/bin
+
+# Disable python imports from ~/.local (pip -U) during build and test.
+# https://github.com/bazelbuild/bazel/issues/4939
+# https://github.com/RobotLocomotion/drake/issues/8475
+build --action_env=PYTHONNOUSERSITE=1
+build --test_env=PYTHONNOUSERSITE=1


### PR DESCRIPTION
On Ubuntu, we purposefully do not use pip.  By removing the homedir from imports, we can ensure more reproducible builds and tests.

Closes #8475.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13190)
<!-- Reviewable:end -->
