### PR TITLE
drake_py_unittest: Force Drake deprecation warnings at import to be errors

### DIFF
--- a/common/test_utilities/drake_py_unittest_main.py
+++ b/common/test_utilities/drake_py_unittest_main.py
@@ -58,6 +58,11 @@ if __name__ == '__main__':
               "marked executable in the filesystem; fix this via chmod a-x " +
               test_basename)
         sys.exit(1)
+
+    # On import, force all drake deprecation warnings to trigger an error.
+    if has_pydrake:
+        warnings.simplefilter("error", DrakeDeprecationWarning)
+
     module = SourceFileLoader(test_name, runfiles_test_filename).load_module(
         test_name)
 


### PR DESCRIPTION
This change implies stricter error checking for future tests.
Previously, Drake deprecations that occurred at import-time in a module (not when running a unittest) did not get translated into an error. This causes them to be an error.

Split off from https://github.com/RobotLocomotion/drake/pull/12430#issuecomment-621830535

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13191)
<!-- Reviewable:end -->
