### PR TITLE
pydrake: Override NiceTypeName::Get(ptr) when possible

### DIFF
--- a/bindings/pydrake/common/BUILD.bazel
+++ b/bindings/pydrake/common/BUILD.bazel
@@ -47,6 +47,7 @@ drake_pybind_library(
         "//bindings/pydrake:documentation_pybind",
         "//bindings/pydrake/common:deprecation_pybind",
         "//bindings/pydrake/common:value_pybind",
+        "//common:nice_type_name_override_header",
     ],
     cc_so_name = "_module_py",
     cc_srcs = [

--- a/bindings/pydrake/common/test/value_test.py
+++ b/bindings/pydrake/common/test/value_test.py
@@ -4,7 +4,7 @@ import unittest
 from pydrake.common.value import AbstractValue, Value
 
 from pydrake.common.test.value_test_util import (
-    make_unknown_abstract_value,
+    make_abstract_value_cc_type_unregistered,
     MoveOnlyType,
 )
 
@@ -74,15 +74,15 @@ class TestValue(unittest.TestCase):
         value = AbstractValue.Make({"x": 10})
         self.assertIsInstance(value, Value[object])
 
-    def test_abstract_value_unknown(self):
-        value = make_unknown_abstract_value()
+    def test_abstract_value_cc_type_unregistered(self):
+        value = make_abstract_value_cc_type_unregistered()
         self.assertIsInstance(value, AbstractValue)
         with self.assertRaises(RuntimeError) as cm:
             value.get_value()
         self.assertTrue(all(
             s in str(cm.exception) for s in [
                 "AbstractValue",
-                "UnknownType",
+                "UnregisteredType",
                 "get_value",
                 "AddValueInstantiation",
             ]), cm.exception)

--- a/bindings/pydrake/common/test/value_test_util_py.cc
+++ b/bindings/pydrake/common/test/value_test_util_py.cc
@@ -24,7 +24,10 @@ class MoveOnlyType {
   int x_{};
 };
 
-struct UnknownType {};
+// This type is explicitly not registered with pybind11.
+struct UnregisteredType {
+  int junk{};
+};
 
 }  // namespace
 
@@ -38,8 +41,8 @@ PYBIND11_MODULE(value_test_util, m) {
   // Define `Value` instantiation.
   AddValueInstantiation<MoveOnlyType>(m);
 
-  m.def("make_unknown_abstract_value",
-      []() { return AbstractValue::Make(UnknownType{}); });
+  m.def("make_abstract_value_cc_type_unregistered",
+      []() { return AbstractValue::Make(UnregisteredType{}); });
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -274,6 +274,8 @@ struct Impl {
     auto system_cls = DefineTemplateClassWithDefault<System<T>, PySystem>(
         m, "System", GetPyParam<T>(), doc.SystemBase.doc);
     system_cls  // BR
+        .def("GetSystemType", &System<T>::GetSystemType,
+            doc.SystemBase.GetSystemType.doc)
         .def("get_name", &System<T>::get_name, doc.SystemBase.get_name.doc)
         .def("set_name", &System<T>::set_name, doc.SystemBase.set_name.doc)
         // Topology.

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -133,6 +133,7 @@ class TestCustom(unittest.TestCase):
 
     def test_diagram_adder(self):
         system = CustomDiagram(2, 3)
+        self.assertEqual(system.GetSystemType(), f"{__name__}.CustomDiagram")
         self.assertEqual(system.num_input_ports(), 2)
         self.assertEqual(system.get_input_port(0).size(), 3)
         self.assertEqual(system.num_output_ports(), 1)
@@ -140,6 +141,7 @@ class TestCustom(unittest.TestCase):
 
     def test_adder_execution(self):
         system = self._create_adder_system()
+        self.assertEqual(system.GetSystemType(), f"{__name__}.CustomAdder")
         context = system.CreateDefaultContext()
         self.assertEqual(context.num_output_ports(), 1)
         self._fix_adder_inputs(system, context)
@@ -382,6 +384,8 @@ class TestCustom(unittest.TestCase):
         dt = 0.5
         for is_discrete in [False, True]:
             system = CustomVectorSystem(is_discrete)
+            self.assertEqual(
+                system.GetSystemType(), f"{__name__}.CustomVectorSystem")
             context = system.CreateDefaultContext()
 
             u = np.array([1.])

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -94,6 +94,9 @@ class TestGeneral(unittest.TestCase):
     def test_system_base_api(self):
         # Test a system with a different number of inputs from outputs.
         system = Adder(3, 10)
+        self.assertEqual(
+            system.GetSystemType(),
+            "drake::systems::Adder<double>")
         self.assertEqual(system.num_input_ports(), 3)
         self.assertEqual(system.num_output_ports(), 1)
         u1 = system.GetInputPort("u1")

--- a/bindings/pydrake/systems/test/scalar_conversion_test.py
+++ b/bindings/pydrake/systems/test/scalar_conversion_test.py
@@ -64,6 +64,12 @@ class TestScalarConversion(unittest.TestCase):
         param_list = [(T,) for T in SystemScalarConverter.SupportedScalars]
         self.assertListEqual(Example_.param_list, param_list)
 
+        for T in SystemScalarConverter.SupportedScalars:
+            system_T = Example_[T](0)
+            self.assertEqual(
+                system_T.GetSystemType(),
+                f"pydrake.systems.scalar_conversion.Example_[{T.__name__}]")
+
         # Test private properties (do NOT use these in your code!).
         self.assertTupleEqual(
             tuple(Example_._T_list), SystemScalarConverter.SupportedScalars)

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -397,12 +397,30 @@ drake_cc_library(
     ],
 )
 
+# N.B. This library does not have all of its dependencies declared. Instead,
+# it defines only the headers such that it can be used by `pydrake` without
+# installing the file. (If we just used `install_hdrs_exclude`, the header
+# would not make it into `//:drake_shared_library`.)
+drake_cc_library(
+    name = "nice_type_name_override_header",
+    hdrs = ["nice_type_name_override.h"],
+    install_hdrs_exclude = ["nice_type_name_override.h"],
+    tags = ["exclude_from_package"],
+    visibility = ["//bindings/pydrake/common:__pkg__"],
+)
+
 drake_cc_library(
     name = "nice_type_name",
-    srcs = ["nice_type_name.cc"],
-    hdrs = ["nice_type_name.h"],
+    srcs = [
+        "nice_type_name.cc",
+        "nice_type_name_override.cc",
+    ],
+    hdrs = [
+        "nice_type_name.h",
+    ],
     deps = [
         ":essential",
+        ":nice_type_name_override_header",
     ],
 )
 

--- a/common/nice_type_name.h
+++ b/common/nice_type_name.h
@@ -64,7 +64,7 @@ class NiceTypeName {
   differ. */
   template <typename T>
   static std::string Get(const T& thing) {
-    return Get(typeid(thing));
+    return GetWithPossibleOverride(&thing, typeid(thing));
   }
 
   /** Returns the nicely demangled and canonicalized type name of `info`. This
@@ -101,6 +101,9 @@ class NiceTypeName {
  private:
   // No instances of this class should be created.
   NiceTypeName() = delete;
+
+  static std::string GetWithPossibleOverride(
+      const void* ptr, const std::type_info& info);
 };
 
 }  // namespace drake

--- a/common/nice_type_name_override.cc
+++ b/common/nice_type_name_override.cc
@@ -1,0 +1,27 @@
+#include "drake/common/nice_type_name_override.h"
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/never_destroyed.h"
+
+namespace drake {
+namespace internal {
+
+namespace {
+NiceTypeNamePtrOverride& ptr_override() {
+  static never_destroyed<NiceTypeNamePtrOverride> value;
+  return value.access();
+}
+}  // namespace
+
+void SetNiceTypeNamePtrOverride(NiceTypeNamePtrOverride new_ptr_override) {
+  DRAKE_DEMAND(!!new_ptr_override);
+  DRAKE_DEMAND(!ptr_override());
+  ptr_override() = new_ptr_override;
+}
+
+const NiceTypeNamePtrOverride& GetNiceTypeNamePtrOverride() {
+  return ptr_override();
+}
+
+}  // namespace internal
+}  // namespace drake

--- a/common/nice_type_name_override.h
+++ b/common/nice_type_name_override.h
@@ -1,0 +1,34 @@
+#pragma once
+
+/**
+@file
+(Advanced) Provides the ability to override NiceTypeName::Get(T*) so that
+Python objects can have human-readable names.
+*/
+
+#include <functional>
+#include <string>
+#include <typeinfo>
+
+namespace drake {
+namespace internal {
+
+// Structure for passing a type-erased pointer with RTTI.
+struct type_erased_ptr {
+  const void* raw{};
+  const std::type_info& info;
+};
+
+// Callback for overriding an object's nice type name.
+using NiceTypeNamePtrOverride =
+    std::function<std::string(const type_erased_ptr&)>;
+
+// Sets override for nice type names. This can only ever be set once, and
+// must be given a non-empty function<> object.
+void SetNiceTypeNamePtrOverride(NiceTypeNamePtrOverride new_ptr_override);
+
+// Gets the override. If unset, it will be an empty function<> object.
+const NiceTypeNamePtrOverride& GetNiceTypeNamePtrOverride();
+
+}  // namespace internal
+}  // namespace drake


### PR DESCRIPTION
Resolves #13237

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13194)
<!-- Reviewable:end -->
