### PR TITLE
py common: Use kDrakeAssertIsArmed instead of _DRAKE_ASSERT_IS_ARMED

### DIFF
--- a/bindings/pydrake/common/__init__.py
+++ b/bindings/pydrake/common/__init__.py
@@ -1,2 +1,1 @@
 from ._module_py import *
-from ._module_py import _DRAKE_ASSERT_IS_ARMED

--- a/bindings/pydrake/common/module_py.cc
+++ b/bindings/pydrake/common/module_py.cc
@@ -109,13 +109,7 @@ PYBIND11_MODULE(_module_py, m) {
   m.def("trigger_an_assertion_failure", &trigger_an_assertion_failure,
       "Trigger a Drake C++ assertion failure");
 
-  bool is_assert_armed{false};
-#ifdef DRAKE_ASSERT_IS_ARMED
-  is_assert_armed = true;
-#endif
-  // TODO(eric.cousineau): Consider making this public, as the C++ flavor is
-  // also public.
-  m.attr("_DRAKE_ASSERT_IS_ARMED") = is_assert_armed;
+  m.attr("kDrakeAssertIsArmed") = kDrakeAssertIsArmed;
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/common/test/module_test.py
+++ b/bindings/pydrake/common/test/module_test.py
@@ -54,5 +54,5 @@ class TestCommon(unittest.TestCase):
         g2 = mut.RandomGenerator(10)
         self.assertEqual(g2(), 3312796937)
 
-    def test_private_members(self):
-        self.assertIsInstance(mut._DRAKE_ASSERT_IS_ARMED, bool)
+    def test_assert_is_armed(self):
+        self.assertIsInstance(mut.kDrakeAssertIsArmed, bool)

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -17,7 +17,7 @@ import warnings
 import numpy as np
 
 import pydrake
-from pydrake.common import _DRAKE_ASSERT_IS_ARMED
+from pydrake.common import kDrakeAssertIsArmed
 from pydrake.autodiffutils import AutoDiffXd
 from pydrake.common.test_utilities import numpy_compare
 from pydrake.forwarddiff import jacobian
@@ -612,7 +612,7 @@ class TestMathematicalProgram(unittest.TestCase):
             x0 = array_T([0.])
             x0_bad = array_T([0., 1.])
             # Bad input (before function is called).
-            if _DRAKE_ASSERT_IS_ARMED:
+            if kDrakeAssertIsArmed:
                 # See note in `WrapUserFunc`.
                 input_error_cls = SystemExit
                 input_error_expected = (
@@ -651,7 +651,7 @@ class TestMathematicalProgram(unittest.TestCase):
             x0 = array_T([0.])
             x0_bad = array_T([0., 1.])
             # Bad input (before function is called).
-            if _DRAKE_ASSERT_IS_ARMED:
+            if kDrakeAssertIsArmed:
                 # See note in `WrapUserFunc`.
                 input_error_cls = SystemExit
                 input_error_expected = (


### PR DESCRIPTION
From follow-up comment: https://github.com/RobotLocomotion/drake/pull/13183#issuecomment-622195628

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13195)
<!-- Reviewable:end -->
