### PR TITLE
workspace: Upgrade pycodestyle to latest release 2.5.0

### DIFF
--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -607,10 +607,10 @@ class TestCustom(unittest.TestCase):
             self.assertEqual(value.get_value(), expected_output_value)
 
     def test_deprecated_abstract_input_port(self):
-        """This test case confirms that the deprecated API for abstract input ports
-        continues to operate correctly, until such a time as we remove it.  For
-        an example of non-deprecated APIs to use abstract input ports, see the
-        test_abstract_io_port case, above.
+        """This test case confirms that the deprecated API for abstract input
+        ports continues to operate correctly, until such a time as we remove
+        it. For an example of non-deprecated APIs to use abstract input ports,
+        see the test_abstract_io_port case, above.
         """
         test = self
 

--- a/bindings/pydrake/systems/test/system_sliders_test.py
+++ b/bindings/pydrake/systems/test/system_sliders_test.py
@@ -57,31 +57,31 @@ class TestSystemSliders(unittest.TestCase):
             output.get_vector_data(0).get_value(), [-5, -5, -5])
 
         # Incorrect size of q when setting slider positions.
-        with self.assertRaisesRegex(ValueError, "Size of q \(2\) doesn't " +
-                                                "match input port size \(3\)"
-                                    ):
+        with self.assertRaisesRegex(
+                ValueError,
+                r"Size of q \(2\) doesn't match input port size \(3\)"):
             slider.set_position([2, 4])
 
         # Incorrect size of passed in slider names.
-        with self.assertRaisesRegex(ValueError, "Slider names size \(2\) " +
-                                                "doesn't match port size \(3\)"
-                                    ):
+        with self.assertRaisesRegex(
+                ValueError,
+                r"Slider names size \(2\) doesn't match port size \(3\)"):
             SystemSliders(port_size, slider_names=["a", "b"])
 
         # Incorrect size of passed in lower limits.
-        with self.assertRaisesRegex(ValueError, "Size of lower_limit \(4\) " +
-                                                "doesn't match port size \(3\)"
-                                    ):
+        with self.assertRaisesRegex(
+                ValueError,
+                r"Size of lower_limit \(4\) doesn't match port size \(3\)"):
             SystemSliders(port_size, lower_limit=[2, 3, 4, 5])
 
         # Incorrect size of passed in upper limits.
-        with self.assertRaisesRegex(ValueError, "Size of upper_limit \(0\) " +
-                                                "doesn't match port size \(3\)"
-                                    ):
+        with self.assertRaisesRegex(
+                ValueError,
+                r"Size of upper_limit \(0\) doesn't match port size \(3\)"):
             SystemSliders(port_size, upper_limit=[])
 
         # Incorrect size of passed in resolutions.
-        with self.assertRaisesRegex(ValueError, "Size of resolution \(5\) " +
-                                                "doesn't match port size \(3\)"
-                                    ):
+        with self.assertRaisesRegex(
+                ValueError,
+                r"Size of resolution \(5\) doesn't match port size \(3\)"):
             SystemSliders(port_size, resolution=[1, 2, 3, 4, 5])

--- a/common/test/cpplint_wrapper.py
+++ b/common/test/cpplint_wrapper.py
@@ -62,9 +62,9 @@ def worker_summarize_cpplint(cmdline_and_files, args):
 
 
 def multiprocess_cpplint(cmdline, files, args):
-    """Given a cpplint subprocess command line (just the program and arguments),
-    separate list of files, and number of processes (None for "all CPUs"), run
-    cpplint, display a progress bar, warning summary, and return a shell
+    """Given a cpplint subprocess command line (just the program and args),
+    separate list of files, and number of processes (None for "all CPUs"),
+    run cpplint, display a progress bar, warning summary, and return a shell
     exitcode (0 on success, 1 on failure).
     """
 

--- a/manipulation/util/meshlab_to_sdf.py
+++ b/manipulation/util/meshlab_to_sdf.py
@@ -103,10 +103,10 @@ def convert(log_text, scale, mass_kg):
     # LOG: 2     | -72.085564  -0.000000  1909.948364 |
     elements = _search(
         log_text,
-        "LOG. 2 +Inertia Tensor is .\n"
-        "LOG. 2 +\| +([-.0-9]+) +([-.0-9]+) +([-.0-9]+) +\|\n"
-        "LOG. 2 +\| +([-.0-9]+) +([-.0-9]+) +([-.0-9]+) +\|\n"
-        "LOG. 2 +\| +([-.0-9]+) +([-.0-9]+) +([-.0-9]+) +\|\n"
+        r"LOG. 2 +Inertia Tensor is .\n"
+        r"LOG. 2 +\| +([-.0-9]+) +([-.0-9]+) +([-.0-9]+) +\|\n"
+        r"LOG. 2 +\| +([-.0-9]+) +([-.0-9]+) +([-.0-9]+) +\|\n"
+        r"LOG. 2 +\| +([-.0-9]+) +([-.0-9]+) +([-.0-9]+) +\|\n"
     )
     inertia_scale = (scale ** 5) * mass_kg / volume_m3
     ixx = _rescale(elements[0], inertia_scale)

--- a/third_party/com_github_pybind_pybind11/mkdoc.py
+++ b/third_party/com_github_pybind_pybind11/mkdoc.py
@@ -598,16 +598,16 @@ def process_comment(comment):
         '---',
         '--',
         '::',
-        '\.',
+        r'\.',
         '"',
         '&',
         '#',
         '%',
         '<',
         '>',
-        '\$',
+        r'\$',
         '@',
-        '\\\\',
+        r'\\',
     ):
         s = re.sub(r'[@\\](%s)' % escaped_, r'\1', s)
 
@@ -636,7 +636,7 @@ def process_comment(comment):
             for y in re.split(r'(?: *\n *){2,}', x):
                 lines = re.split(r'(?: *\n *)', y)
                 # Do not reflow lists or section headings.
-                if (re.match('^(?:[*+\-]|[0-9]+[.)]) ', lines[0]) or
+                if (re.match(r'^(?:[*+\-]|[0-9]+[.)]) ', lines[0]) or
                     (len(lines) > 1 and
                      (lines[1] == '=' * len(lines[0]) or
                       lines[1] == '-' * len(lines[0])))):

--- a/tools/lint/bazel_lint.bzl
+++ b/tools/lint/bazel_lint.bzl
@@ -10,6 +10,7 @@ def _bazel_lint(name, files, ignore):
     if files:
         if ignore:
             ignore = ["--ignore=" + ",".join(["E%s" % e for e in ignore])]
+        ignore[0] += ",W504"  # TODO(jwnimmer-tri) Re-enable soon.
 
         locations = ["$(locations %s)" % f for f in files]
 

--- a/tools/lint/buildifier.py
+++ b/tools/lint/buildifier.py
@@ -62,9 +62,9 @@ def _find_buildifier_sources(workspace_name):
 
 
 def _passes_check_mode(args):
-    """The `args` list should be as per subprocess.check_call.  Returns True iff
-    builfidier runs with exitcode 0 and no output, or else returns False iff
-    reformat is needed, or else raises an exception.
+    """The `args` list should be as per subprocess.check_call.  Returns True
+    iff builfidier runs with exitcode 0 and no output, or else returns False
+    iff reformat is needed, or else raises an exception.
     """
     try:
         output = subprocess.check_output(args)

--- a/tools/lint/library_lint.bzl
+++ b/tools/lint/library_lint.bzl
@@ -7,9 +7,9 @@ _TAG_EXCLUDE_FROM_PACKAGE = "exclude_from_package"
 
 def library_lint(
         existing_rules = None):
-    """Within the current package, checks that drake_cc_package_library has been
-    used correctly, reports a lint (test) error if not.  (To understand proper
-    use of drake_cc_package_library, consult its API documentation.)
+    """Within the current package, checks that drake_cc_package_library has
+    been used correctly, reports a lint (test) error if not.  (To understand
+    proper use of drake_cc_package_library, consult its API documentation.)
 
     Note that //examples/... packages are excluded from some checks, because
     they should generally not use drake_cc_package_library.

--- a/tools/lint/python_lint.bzl
+++ b/tools/lint/python_lint.bzl
@@ -9,6 +9,7 @@ PYTHON_LINT_IGNORE_DEFAULT = "E121,E123,E126,E226,E24,E704,W503".split(",")
 # Internal helper.
 def _python_lint(name_prefix, files, ignore, disallow_executable):
     ignore_types = PYTHON_LINT_IGNORE_DEFAULT + (ignore or [])
+    ignore_types += ["W504"]  # TODO(jwnimmer-tri) Re-enable soon.
     ignore_args = ["--ignore={}".format(",".join(ignore_types))]
 
     # Pycodestyle.

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -290,10 +290,10 @@ def _raw_drake_cc_library(
         declare_installed_headers = 0,
         install_hdrs_exclude = [],
         **kwargs):
-    """Creates a rule to declare a C++ library.  Uses Drake's include_prefix and
-    checks the deps blacklist.  If declare_installed_headers is true, also adds
-    a drake_installed_headers() target.  (This should be set if and only if the
-    caller is drake_cc_library.)
+    """Creates a rule to declare a C++ library.  Uses Drake's include_prefix
+    and checks the deps blacklist.  If declare_installed_headers is true, also
+    adds a drake_installed_headers() target.  (This should be set if and only
+    if the caller is drake_cc_library.)
     """
     _check_library_deps_blacklist(name, deps)
     _, private_hdrs = _prune_private_hdrs(srcs)

--- a/tools/workspace/deb.bzl
+++ b/tools/workspace/deb.bzl
@@ -6,10 +6,10 @@ load(
 )
 
 def setup_new_deb_archive(repo_ctx):
-    """Behaves like new_deb_archive, except that (1) this is a macro instead of a
-    rule and (2) this macro returns an error status instead of fail()ing.  The
-    return value is a struct with a field `error` that will be None on success
-    or else a detailed message on any failure.
+    """Behaves like new_deb_archive, except that (1) this is a macro instead of
+    a rule and (2) this macro returns an error status instead of fail()ing.
+    The return value is a struct with a field `error` that will be None on
+    success or else a detailed message on any failure.
     """
     name = repo_ctx.attr.name
     filenames = repo_ctx.attr.filenames

--- a/tools/workspace/github.bzl
+++ b/tools/workspace/github.bzl
@@ -138,11 +138,11 @@ Consult the macro documentation for full API details.
 """
 
 def setup_github_repository(repository_ctx):
-    """This is reusable formulation of the github_archive() macro.  It is identical
-    to the macro except that (1) it does not support local_repository_override,
-    and (2) it returns a status struct, instead of failing internally.  The
-    result struct has a field `error` that will be non-None iff there were any
-    errors.  Consult the macro documentation for additional API details.
+    """This is a reusable formulation of the github_archive() macro. It is
+    identical to the macro except that (1) it does not support local repository
+    override, and (2) it returns a status struct instead of failing internally.
+    The result struct has a field `error` that will be non-None iff there were
+    any errors.  Consult the macro documentation for additional API details.
     """
 
     # Do the download step first.  (This also writes the metadata.)

--- a/tools/workspace/pycodestyle/repository.bzl
+++ b/tools/workspace/pycodestyle/repository.bzl
@@ -8,8 +8,8 @@ def pycodestyle_repository(
     github_archive(
         name = name,
         repository = "PyCQA/pycodestyle",
-        commit = "2.3.1",
-        sha256 = "e9fc1ca3fd85648f45c0d2e33591b608a17d8b9b78e22c5f898e831351bacb03",  # noqa
+        commit = "2.5.0",
+        sha256 = "a603453c07e8d8e15a43cf062aa7174741b74b4a27b110f9ad03d74d519173b5",  # noqa
         build_file = "@drake//tools/workspace/pycodestyle:package.BUILD.bazel",  # noqa
         mirrors = mirrors,
     )

--- a/tools/workspace/semantic_version/repository.bzl
+++ b/tools/workspace/semantic_version/repository.bzl
@@ -8,8 +8,8 @@ def semantic_version_repository(
     pypi_archive(
         name = name,
         package = "semantic_version",
-        version = "2.8.4",
-        sha256 = "352459f640f3db86551d8054d1288608b29a96e880c7746f0a59c92879d412a3",  # noqa
+        version = "2.8.5",
+        sha256 = "d2cb2de0558762934679b9a104e82eca7af448c9f4974d1f3eeccff651df8a54",  # noqa
         strip_prefix = "semantic_version",
         build_file = "@drake//tools/workspace/semantic_version:package.BUILD.bazel",  # noqa
         mirrors = mirrors,


### PR DESCRIPTION
Fix new formatting nits and invalid string literals that it now flags.

Upgrade semantic_version to latest release 2.8.5.

The W514 (must place binary operator like `+` to start a line, instead of at end of prior line) is tripped everywhere in drake, so I'm deferring it to a separate PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13197)
<!-- Reviewable:end -->
