### PR TITLE
Apply deprecation to QueryObject proximity and perception queries

### DIFF
--- a/bindings/pydrake/examples/multibody/cart_pole_passive_simulation.py
+++ b/bindings/pydrake/examples/multibody/cart_pole_passive_simulation.py
@@ -38,7 +38,7 @@ def main():
     assert cart_pole.geometry_source_is_registered()
 
     builder.Connect(
-        scene_graph.get_query_output_port(),
+        scene_graph.get_proximity_query_output_port(),
         cart_pole.get_geometry_query_input_port())
     builder.Connect(
         cart_pole.get_geometry_poses_output_port(),

--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -346,6 +346,10 @@ void DoScalarDependentDefinitions(py::module m, T) {
 
   //  QueryObject
   {
+// Note: we haven't bound the queries that haven't been deprecated, so we'll
+// simply disable the diagnostic for all of the bindings.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     using Class = QueryObject<T>;
     auto cls = DefineTemplateClassWithDefault<Class>(
         m, "QueryObject", param, doc.QueryObject.doc);
@@ -354,27 +358,60 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("inspector", &QueryObject<T>::inspector, py_reference_internal,
             doc.QueryObject.inspector.doc)
         .def("ComputeSignedDistancePairwiseClosestPoints",
-            &QueryObject<T>::ComputeSignedDistancePairwiseClosestPoints,
+            [](const Class* self, double max_distance) {
+              WarnDeprecated(
+                  "QueryObject::ComputeSignedDistancePairwiseClosestPoints "
+                  "is deprecated. Please use ProximityQueryObject instead.");
+              return self->ComputeSignedDistancePairwiseClosestPoints(
+                  max_distance);
+            },
             py::arg("max_distance") = std::numeric_limits<double>::infinity(),
-            doc.QueryObject.ComputeSignedDistancePairwiseClosestPoints.doc)
+            doc.QueryObject.ComputeSignedDistancePairwiseClosestPoints
+                .doc_deprecated)
         .def("ComputeSignedDistancePairClosestPoints",
-            &QueryObject<T>::ComputeSignedDistancePairClosestPoints,
+            [](const Class* self, GeometryId id_A, GeometryId id_B) {
+              WarnDeprecated(
+                  "QueryObject::ComputeSignedDistancePairClosestPoints "
+                  "is deprecated. Please use ProximityQueryObject instead.");
+              return self->ComputeSignedDistancePairClosestPoints(id_A, id_B);
+            },
             py::arg("id_A"), py::arg("id_B"),
-            doc.QueryObject.ComputeSignedDistancePairClosestPoints.doc)
+            doc.QueryObject.ComputeSignedDistancePairClosestPoints
+                .doc_deprecated)
         .def("ComputePointPairPenetration",
-            &QueryObject<T>::ComputePointPairPenetration,
-            doc.QueryObject.ComputePointPairPenetration.doc)
+            [](const Class* self) {
+              WarnDeprecated(
+                  "QueryObject::ComputePointPairPenetration "
+                  "is deprecated. Please use ProximityQueryObject instead.");
+              return self->ComputePointPairPenetration();
+            },
+            doc.QueryObject.ComputePointPairPenetration.doc_deprecated)
         .def("ComputeSignedDistanceToPoint",
-            &QueryObject<T>::ComputeSignedDistanceToPoint, py::arg("p_WQ"),
+            [](const Class* self, const Vector3<T>& p_WQ,
+                const double threshold) {
+              WarnDeprecated(
+                  "QueryObject::ComputeSignedDistanceToPoint "
+                  "is deprecated. Please use ProximityQueryObject instead.");
+              return self->ComputeSignedDistanceToPoint(p_WQ, threshold);
+            },
+            py::arg("p_WQ"),
             py::arg("threshold") = std::numeric_limits<double>::infinity(),
-            doc.QueryObject.ComputeSignedDistanceToPoint.doc)
+            doc.QueryObject.ComputeSignedDistanceToPoint.doc_deprecated)
         .def("FindCollisionCandidates",
-            &QueryObject<T>::FindCollisionCandidates,
-            doc.QueryObject.FindCollisionCandidates.doc)
+            [](const Class* self) {
+              WarnDeprecated(
+                  "QueryObject::FindCollisionCandidates "
+                  "is deprecated. Please use ProximityQueryObject instead.");
+              return self->FindCollisionCandidates();
+            },
+            doc.QueryObject.FindCollisionCandidates.doc_deprecated)
         .def("RenderColorImage",
             [](const Class* self, const render::CameraProperties& camera,
                 FrameId parent_frame, const math::RigidTransformd& X_PC,
                 bool show_window) {
+              WarnDeprecated(
+                  "QueryObject::RenderColorImage "
+                  "is deprecated. Please use PerceptionQueryObject instead.");
               systems::sensors::ImageRgba8U img(camera.width, camera.height);
               self->RenderColorImage(
                   camera, parent_frame, X_PC, show_window, &img);
@@ -382,20 +419,26 @@ void DoScalarDependentDefinitions(py::module m, T) {
             },
             py::arg("camera"), py::arg("parent_frame"), py::arg("X_PC"),
             py::arg("show_window") = false,
-            doc.QueryObject.RenderColorImage.doc)
+            doc.QueryObject.RenderColorImage.doc_deprecated)
         .def("RenderDepthImage",
             [](const Class* self, const render::DepthCameraProperties& camera,
                 FrameId parent_frame, const math::RigidTransformd& X_PC) {
+              WarnDeprecated(
+                  "QueryObject::RenderDepthImage "
+                  "is deprecated. Please use PerceptionQueryObject instead.");
               systems::sensors::ImageDepth32F img(camera.width, camera.height);
               self->RenderDepthImage(camera, parent_frame, X_PC, &img);
               return img;
             },
             py::arg("camera"), py::arg("parent_frame"), py::arg("X_PC"),
-            doc.QueryObject.RenderDepthImage.doc)
+            doc.QueryObject.RenderDepthImage.doc_deprecated)
         .def("RenderLabelImage",
             [](const Class* self, const render::CameraProperties& camera,
                 FrameId parent_frame, const math::RigidTransformd& X_PC,
                 bool show_window = false) {
+              WarnDeprecated(
+                  "QueryObject::RenderLabelImage "
+                  "is deprecated. Please use PerceptionQueryObject instead.");
               systems::sensors::ImageLabel16I img(camera.width, camera.height);
               self->RenderLabelImage(
                   camera, parent_frame, X_PC, show_window, &img);
@@ -403,7 +446,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
             },
             py::arg("camera"), py::arg("parent_frame"), py::arg("X_PC"),
             py::arg("show_window") = false,
-            doc.QueryObject.RenderLabelImage.doc);
+            doc.QueryObject.RenderLabelImage.doc_deprecated);
+#pragma GCC diagnostic pop
 
     AddValueInstantiation<QueryObject<T>>(m);
   }

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -1294,7 +1294,8 @@ class TestPlant(unittest.TestCase):
         # bodies to be coincident, and thus collide.
         context = diagram.CreateDefaultContext()
         sg_context = diagram.GetMutableSubsystemContext(scene_graph, context)
-        query_object = scene_graph.get_query_output_port().Eval(sg_context)
+        query_object = scene_graph.get_proximity_query_output_port().Eval(
+            sg_context)
         # Implicitly require that this should be size 1.
         point_pair, = query_object.ComputePointPairPenetration()
         self.assertIsInstance(point_pair, PenetrationAsPointPair_[float])

--- a/bindings/pydrake/systems/drawing_graphviz_example.py
+++ b/bindings/pydrake/systems/drawing_graphviz_example.py
@@ -23,7 +23,7 @@ cart_pole.Finalize()
 assert cart_pole.geometry_source_is_registered()
 
 builder.Connect(
-    scene_graph.get_query_output_port(),
+    scene_graph.get_proximity_query_output_port(),
     cart_pole.get_geometry_query_input_port())
 builder.Connect(
     cart_pole.get_geometry_poses_output_port(),

--- a/examples/allegro_hand/joint_control/allegro_single_object_simulation.cc
+++ b/examples/allegro_hand/joint_control/allegro_single_object_simulation.cc
@@ -105,7 +105,7 @@ void DoMain() {
   builder.Connect(
       plant.get_geometry_poses_output_port(),
       scene_graph.get_source_pose_port(plant.get_source_id().value()));
-  builder.Connect(scene_graph.get_query_output_port(),
+  builder.Connect(scene_graph.get_proximity_query_output_port(),
                   plant.get_geometry_query_input_port());
 
   // Publish contact results for visualization.

--- a/examples/allegro_hand/run_allegro_constant_load_demo.cc
+++ b/examples/allegro_hand/run_allegro_constant_load_demo.cc
@@ -101,7 +101,7 @@ void DoMain() {
   builder.Connect(
       plant.get_geometry_poses_output_port(),
       scene_graph.get_source_pose_port(plant.get_source_id().value()));
-  builder.Connect(scene_graph.get_query_output_port(),
+  builder.Connect(scene_graph.get_proximity_query_output_port(),
                   plant.get_geometry_query_input_port());
 
   geometry::ConnectDrakeVisualizer(&builder, scene_graph);

--- a/examples/kinova_jaco_arm/jaco_simulation.cc
+++ b/examples/kinova_jaco_arm/jaco_simulation.cc
@@ -59,7 +59,7 @@ int DoMain() {
       scene_graph->get_source_pose_port(
           jaco_plant->get_source_id().value()));
   builder.Connect(
-      scene_graph->get_query_output_port(),
+      scene_graph->get_proximity_query_output_port(),
       jaco_plant->get_geometry_query_input_port());
 
   const multibody::ModelInstanceIndex jaco_id =

--- a/examples/manipulation_station/manipulation_station.cc
+++ b/examples/manipulation_station/manipulation_station.cc
@@ -542,7 +542,7 @@ void ManipulationStation<T>::Finalize(
   builder.Connect(
       plant_->get_geometry_poses_output_port(),
       scene_graph_->get_source_pose_port(plant_->get_source_id().value()));
-  builder.Connect(scene_graph_->get_query_output_port(),
+  builder.Connect(scene_graph_->get_proximity_query_output_port(),
                   plant_->get_geometry_query_input_port());
 
   const int num_iiwa_positions =
@@ -686,7 +686,7 @@ void ManipulationStation<T>::Finalize(
 
       auto camera = builder.template AddSystem<systems::sensors::RgbdSensor>(
           parent_body_id.value(), X_PC, info.properties);
-      builder.Connect(scene_graph_->get_query_output_port(),
+      builder.Connect(scene_graph_->get_perception_query_output_port(),
                       camera->query_object_input_port());
 
       builder.ExportOutput(camera->color_image_output_port(),

--- a/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
+++ b/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
@@ -88,7 +88,7 @@ int do_main() {
   // Sanity check on the availability of the optional source id before using it.
   DRAKE_DEMAND(!!plant.get_source_id());
 
-  builder.Connect(scene_graph.get_query_output_port(),
+  builder.Connect(scene_graph.get_proximity_query_output_port(),
                   plant.get_geometry_query_input_port());
 
   DrakeLcm lcm;

--- a/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
+++ b/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
@@ -165,7 +165,7 @@ int do_main() {
   // Sanity check on the availability of the optional source id before using it.
   DRAKE_DEMAND(!!plant.get_source_id());
 
-  builder.Connect(scene_graph.get_query_output_port(),
+  builder.Connect(scene_graph.get_proximity_query_output_port(),
                   plant.get_geometry_query_input_port());
 
   builder.Connect(

--- a/examples/planar_gripper/planar_gripper_simulation.cc
+++ b/examples/planar_gripper/planar_gripper_simulation.cc
@@ -300,7 +300,7 @@ int DoMain() {
   builder.Connect(
       plant.get_geometry_poses_output_port(),
       scene_graph.get_source_pose_port(plant.get_source_id().value()));
-  builder.Connect(scene_graph.get_query_output_port(),
+  builder.Connect(scene_graph.get_proximity_query_output_port(),
                   plant.get_geometry_query_input_port());
 
   systems::lcm::LcmInterfaceSystem* lcm =

--- a/examples/scene_graph/bouncing_ball_plant.cc
+++ b/examples/scene_graph/bouncing_ball_plant.cc
@@ -41,7 +41,7 @@ BouncingBallPlant<T>::BouncingBallPlant(SourceId source_id,
   DRAKE_DEMAND(source_id.is_valid());
 
   geometry_query_port_ = this->DeclareAbstractInputPort(
-      systems::kUseDefaultName, Value<geometry::QueryObject<T>>{})
+      systems::kUseDefaultName, Value<geometry::ProximityQueryObject<T>>{})
           .get_index();
   state_port_ =
       this->DeclareVectorOutputPort(BouncingBallVector<T>(),
@@ -126,7 +126,7 @@ void BouncingBallPlant<T>::DoCalcTimeDerivatives(
   BouncingBallVector<T>& derivative_vector = get_mutable_state(derivatives);
 
   const auto& query_object = get_geometry_query_input_port().
-      template Eval<geometry::QueryObject<T>>(context);
+      template Eval<geometry::ProximityQueryObject<T>>(context);
 
   std::vector<PenetrationAsPointPair<T>> penetrations =
       query_object.ComputePointPairPenetration();

--- a/examples/scene_graph/bouncing_ball_run_dynamics.cc
+++ b/examples/scene_graph/bouncing_ball_run_dynamics.cc
@@ -93,12 +93,12 @@ int do_main() {
 
   builder.Connect(bouncing_ball1->get_geometry_pose_output_port(),
                   scene_graph->get_source_pose_port(ball_source_id1));
-  builder.Connect(scene_graph->get_query_output_port(),
+  builder.Connect(scene_graph->get_proximity_query_output_port(),
                   bouncing_ball1->get_geometry_query_input_port());
 
   builder.Connect(bouncing_ball2->get_geometry_pose_output_port(),
                   scene_graph->get_source_pose_port(ball_source_id2));
-  builder.Connect(scene_graph->get_query_output_port(),
+  builder.Connect(scene_graph->get_proximity_query_output_port(),
                   bouncing_ball2->get_geometry_query_input_port());
 
   DrakeLcm lcm;
@@ -131,7 +131,7 @@ int do_main() {
 
     auto camera = builder.AddSystem<RgbdSensor>(
         scene_graph->world_frame_id(), X_WB, camera_properties);
-    builder.Connect(scene_graph->get_query_output_port(),
+    builder.Connect(scene_graph->get_perception_query_output_port(),
                     camera->query_object_input_port());
 
     // Broadcast the images.

--- a/examples/scene_graph/simple_contact_surface_vis.cc
+++ b/examples/scene_graph/simple_contact_surface_vis.cc
@@ -55,7 +55,7 @@ using geometry::AddSoftHydroelasticProperties;
 using geometry::IllustrationProperties;
 using geometry::PenetrationAsPointPair;
 using geometry::ProximityProperties;
-using geometry::QueryObject;
+using geometry::ProximityQueryObject;
 using geometry::SceneGraph;
 using geometry::SourceId;
 using geometry::Sphere;
@@ -165,7 +165,7 @@ class ContactResultMaker final : public LeafSystem<double> {
       : use_strict_hydro_{use_strict_hydro} {
     geometry_query_input_port_ =
         this->DeclareAbstractInputPort("query_object",
-                                       Value<QueryObject<double>>())
+                                       Value<ProximityQueryObject<double>>())
             .get_index();
     contact_result_output_port_ =
         this->DeclareAbstractOutputPort("contact_result",
@@ -181,7 +181,7 @@ class ContactResultMaker final : public LeafSystem<double> {
   void CalcContactResults(const Context<double>& context,
                           lcmt_contact_results_for_viz* results) const {
     const auto& query_object =
-        get_geometry_query_port().Eval<QueryObject<double>>(context);
+        get_geometry_query_port().Eval<ProximityQueryObject<double>>(context);
     std::vector<ContactSurface<double>> surfaces;
     std::vector<PenetrationAsPointPair<double>> points;
     if (use_strict_hydro_) {
@@ -307,7 +307,7 @@ int do_main() {
 
   // Make and visualize contacts.
   auto& contact_results = *builder.AddSystem<ContactResultMaker>(!FLAGS_hybrid);
-  builder.Connect(scene_graph.get_query_output_port(),
+  builder.Connect(scene_graph.get_proximity_query_output_port(),
                   contact_results.get_geometry_query_port());
 
   // Now visualize.

--- a/examples/simple_gripper/simple_gripper.cc
+++ b/examples/simple_gripper/simple_gripper.cc
@@ -240,7 +240,7 @@ int do_main() {
   // Sanity check on the availability of the optional source id before using it.
   DRAKE_DEMAND(!!plant.get_source_id());
 
-  builder.Connect(scene_graph.get_query_output_port(),
+  builder.Connect(scene_graph.get_proximity_query_output_port(),
                   plant.get_geometry_query_input_port());
 
   DrakeLcm lcm;

--- a/geometry/profiling/contact_surface_rigid_bowl_soft_ball.cc
+++ b/geometry/profiling/contact_surface_rigid_bowl_soft_ball.cc
@@ -25,7 +25,7 @@
 #include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/geometry_visualization.h"
 #include "drake/geometry/proximity_properties.h"
-#include "drake/geometry/query_object.h"
+#include "drake/geometry/proximity_query_object.h"
 #include "drake/geometry/query_results/contact_surface.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/geometry/shape_specification.h"
@@ -59,7 +59,7 @@ using geometry::AddSoftHydroelasticProperties;
 using geometry::IllustrationProperties;
 using geometry::Mesh;
 using geometry::ProximityProperties;
-using geometry::QueryObject;
+using geometry::ProximityQueryObject;
 using geometry::SceneGraph;
 using geometry::SourceId;
 using geometry::Sphere;
@@ -187,7 +187,7 @@ class ContactResultMaker final : public LeafSystem<double> {
   ContactResultMaker() {
     geometry_query_input_port_ =
         this->DeclareAbstractInputPort("query_object",
-                                       Value<QueryObject<double>>())
+                                       Value<ProximityQueryObject<double>>())
             .get_index();
     contact_result_output_port_ =
         this->DeclareAbstractOutputPort("contact_result",
@@ -203,7 +203,7 @@ class ContactResultMaker final : public LeafSystem<double> {
   void CalcContactResults(const Context<double>& context,
                           lcmt_contact_results_for_viz* results) const {
     const auto& query_object =
-        get_geometry_query_port().Eval<QueryObject<double>>(context);
+        get_geometry_query_port().Eval<ProximityQueryObject<double>>(context);
     std::vector<ContactSurface<double>> contacts =
         query_object.ComputeContactSurfaces();
     const int num_contacts = static_cast<int>(contacts.size());
@@ -292,7 +292,7 @@ int do_main() {
 
   // Make and visualize contacts.
   auto& contact_results = *builder.AddSystem<ContactResultMaker>();
-  builder.Connect(scene_graph.get_query_output_port(),
+  builder.Connect(scene_graph.get_proximity_query_output_port(),
                   contact_results.get_geometry_query_port());
 
   // Now visualize.

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -129,390 +129,70 @@ class QueryObject {
 
   //@}
 
-  /**
-   @anchor collision_queries
-   @name                Collision Queries
-
-   These queries detect _collisions_ between geometry. Two geometries collide
-   if they overlap each other and are not explicitly excluded through
-   @ref collision_filter_concepts "collision filtering". These algorithms find
-   those colliding cases, characterize them, and report the essential
-   characteristics of that collision.
-
-   For two colliding geometries g_A and g_B, it is guaranteed that they will
-   map to `id_A` and `id_B` in a fixed, repeatable manner, where `id_A` and
-   `id_B` are GeometryId's of geometries g_A and g_B respectively.
-
-   These methods are affected by collision filtering; element pairs that
-   have been filtered will not produce contacts, even if their collision
-   geometry is penetrating.     */
-  //@{
-
-  /** Computes the penetrations across all pairs of geometries in the world
-   with the penetrations characterized by pairs of points (see
-   PenetrationAsPointPair), providing some measure of the penetration "depth" of
-   the two objects, but _not_ the overlapping volume.
-
-   Only reports results for _penetrating_ geometries; if two geometries are
-   separated, there will be no result for that pair. Geometries whose surfaces
-   are just touching (osculating) are not considered in penetration. Surfaces
-   whose penetration is within an epsilon of osculation, are likewise not
-   considered penetrating. Pairs of _anchored_ geometry are also not reported.
-   This method is affected by collision filtering.
-
-   For two penetrating geometries g_A and g_B, it is guaranteed that they will
-   map to `id_A` and `id_B` in a fixed, repeatable manner.
-
-   <h3>Scalar support</h3>
-   This method only provides double-valued penetration results.
-
-   <!--
-   TODO(SeanCurtis-TRI): This can/should be changed to offer at least partial
-   AutoDiffXd support. At the very least, it should be declared on T and throw
-   for AutoDiffXd. This is related to PR 11143
-   https://github.com/RobotLocomotion/drake/pull/11143. In that PR, MBP is
-   taking responsibility to know whether or not QueryObject supports AutoDiff
-   penetration queries; MBP should not be responsible for that knowledge. By
-   moving the exception into SceneGraph, it removes the false dependency and
-   allows us to gradually increase the AutoDiff support for penetration.
-   -->
-
-   @returns A vector populated with all detected penetrations characterized as
-            point pairs.
-   @note    Silently ignore Mesh geometries. */
+  /** See ProximityQueryObject::ComputePointPairPenetration().  */
+  DRAKE_DEPRECATED("2020-08-01", "Use the ProximityQueryObject instead.")
   std::vector<PenetrationAsPointPair<double>> ComputePointPairPenetration()
       const;
 
-  /**
-   Reports pairwise intersections and characterizes each non-empty
-   intersection as a ContactSurface for hydroelastic contact model.
-   The computation is subject to collision filtering.
-
-   For two intersecting geometries g_A and g_B, it is guaranteed that they will
-   map to `id_A` and `id_B` in a fixed, repeatable manner, where `id_A` and
-   `id_B` are GeometryId's of geometries g_A and g_B respectively.
-
-   In the current incarnation, this function represents a simple implementation.
-
-     - This table shows the supported shapes and compliance modes.
-
-       |   Shape   | Soft  | Rigid |
-       | :-------: | :---: | :---- |
-       | Sphere    |  yes  |  yes  |
-       | Cylinder  |  yes  |  yes  |
-       | Box       |  yes  |  yes  |
-       | Capsule   |  no   |  no   |
-       | Ellipsoid |  yes  |  yes  |
-       | HalfSpace |  no   |  no   |
-       | Mesh      |  no   |  yes  |
-       | Convex    |  no   |  no   |
-
-     - One geometry must be soft, and the other must be rigid. There is no
-       support for soft-soft collision or rigid-rigid collision. If such
-       pairs collide, an exception will be thrown. More particularly, if such
-       a pair *cannot be culled* an exception will be thrown. No exception
-       is thrown if the pair has been filtered.
-     - The elasticity modulus E (N/m^2) of each geometry is set in
-       ProximityProperties (see AddContactMaterial()).
-     - The tessellation of the corresponding meshes is controlled by the
-       resolution hint, as defined by AddSoftHydroelasticProperties() and
-       AddRigidHydroelasticProperties().
-
-   <h3>Scalar support</h3>
-
-   This method provides support only for double. Attempting to invoke this
-   method with T = AutoDiffXd will throw an exception if there are *any*
-   geometry pairs that couldn't be culled.
-
-   @returns A vector populated with all detected intersections characterized as
-            contact surfaces.  */
+  /** See ProximityQueryObject::ComputeContactSurfaces().  */
+  DRAKE_DEPRECATED("2020-08-01", "Use the ProximityQueryObject instead.")
   std::vector<ContactSurface<T>> ComputeContactSurfaces() const;
 
-  /** Reports pair-wise intersections and characterizes each non-empty
-   intersection as a ContactSurface _where possible_ and as a
-   PenetrationAsPointPair where not.
-
-   This is a hybrid contact algorithm. It allows for the contact surface
-   penetration result where possible, but automatically provides a fallback for
-   where a ContactSurface cannot be defined.
-
-   The fallback cannot guarantee success in all cases. Meshes have limited
-   support in the proximity role; they are supported in the contact surface
-   computation but _ignored_ in the point pair collision query. If a mesh is
-   in contact with another shape that _cannot_ be resolved as a contact surface
-   (e.g., rigid mesh vs another rigid shape), this computation will throw as
-   there is no fallback functionality for mesh-shape.
-
-   Because point pairs can only be computed for double-valued systems, this can
-   also only support double-valued ContactSurface instances.
-
-   @param[out] surfaces     The vector that contact surfaces will be added to.
-                            The vector will _not_ be cleared.
-   @param[out] point_pairs  The vector that fall back point pair data will be
-                            added to. The vector will _not_ be cleared.
-   @pre Neither `surfaces` nor `point_pairs` is nullptr.  */
+  /** See ProximityQueryObject::ComputeContactSurfacesWithFallback().  */
+  DRAKE_DEPRECATED("2020-08-01", "Use the ProximityQueryObject instead.")
   void ComputeContactSurfacesWithFallback(
       std::vector<ContactSurface<T>>* surfaces,
       std::vector<PenetrationAsPointPair<double>>* point_pairs) const;
 
-  /** Applies a conservative culling mechanism to create a subset of all
-   possible geometry pairs based on non-zero intersections. A geometry pair
-   that is *absent* from the results is either a) culled by collision filters or
-   b) *known* to be separated. The caller is responsible for confirming that
-   the remaining, unculled geometry pairs are *actually* in collision.
-
-   @returns A vector populated with collision pair candidates.
-   @note    Silently ignore Mesh geometries. */
+  /** See ProximityQueryObject::FindCollisionCandidates().  */
+  DRAKE_DEPRECATED("2020-08-01", "Use the ProximityQueryObject instead.")
   std::vector<SortedPair<GeometryId>> FindCollisionCandidates() const;
 
-  /** Reports true if there are _any_ collisions between unfiltered pairs in the
-   world.
-   @note Silently ignore Mesh geometries. */
+  /** See ProximityQueryObject::HasCollisions().  */
+  DRAKE_DEPRECATED("2020-08-01", "Use the ProximityQueryObject instead.")
   bool HasCollisions() const;
 
-  //@}
-
-  //---------------------------------------------------------------------------
-  // TODO(DamrongGuoy): Write a better documentation for Signed Distance
-  // Queries.
-  /**
-   @anchor signed_distance_query
-   @name                   Signed Distance Queries
-
-   These queries provide the signed distance between two objects. Each query
-   has a specific definition of the signed distance being positive, negative,
-   or zero associated with some notions of being outside, inside, or on
-   the boundary.
-
-   These queries provide bookkeeping data like geometry id(s) of the geometries
-   involved and the important locations on the boundaries of these geometries.
-
-   The signed distance function is a continuous function. Its partial
-   derivatives are continuous almost everywhere.
-  */
-  //@{
-
-  // TODO(DamrongGuoy): Refactor documentation of
-  // ComputeSignedDistancePairwiseClosestPoints(). Move the common sections
-  // into Signed Distance Queries.
-  /**
-   Computes the signed distance together with the nearest points across all
-   pairs of geometries in the world. Reports both the separating geometries
-   and penetrating geometries.
-
-   This query provides φ(A, B), the signed distance between two objects A and B.
-
-   If the objects do not overlap (i.e., A ⋂ B = ∅), φ > 0 and represents the
-   minimal distance between the two objects. More formally:
-   φ = min(|Aₚ - Bₚ|)
-   ∀ Aₚ ∈ A and Bₚ ∈ B.
-   @note The pair (Aₚ, Bₚ) is a "witness" of the distance.
-   The pair need not be unique (think of two parallel planes).
-
-   If the objects touch or overlap (i.e., A ⋂ B ≠ ∅), φ ≤ 0 and can be
-   interpreted as the negative penetration depth. It is the smallest length of
-   the vector v, such that by shifting one object along that vector relative to
-   the other, the two objects will no longer be overlapping. More formally,
-   φ(A, B) = -min |v|.
-   s.t (Tᵥ · A) ⋂ B = ∅
-   where Tᵥ is a rigid transformation that displaces A by the vector v, namely
-   Tᵥ · A = {u + v | ∀ u ∈ A}.
-   By implication, there exist points Aₚ and Bₚ on the surfaces of objects A and
-   B, respectively, such that Aₚ + v = Bₚ, Aₚ ∈ A ∩ B, Bₚ ∈ A ∩ B. These points
-   are the witnesses to the penetration.
-
-   This method is affected by collision filtering; geometry pairs that
-   have been filtered will not produce signed distance query results.
-
-   For a geometry pair (A, B), the returned results will always be reported in
-   a fixed order (e.g., always (A, B) and never (B, A)). The _basis_ for the
-   ordering is arbitrary (and therefore undocumented), but guaranteed to be
-   fixed and repeatable.
-
-   Notice that this is an O(N²) operation, where N
-   is the number of geometries remaining in the world after applying collision
-   filter. We report the distance between dynamic objects, and between dynamic
-   and anchored objects. We DO NOT report the distance between two anchored
-   objects.
-
-   <h3>Scalar support</h3>
-   This function does not support halfspaces. If an unfiltered pair contains
-   a halfspace, an exception will be thrown for all scalar types. Otherwise,
-   this query supports all other pairs of Drake geometry types for `double`.
-   For `AutoDiffXd`, it only supports distance between sphere-box and
-   sphere-sphere. If there are any unfiltered geometry pairs that include other
-   geometries, the AutoDiff throws an exception.
-
-   <!-- TODO(SeanCurtis-TRI): Document expected precision of answer based on
-   members of shape pair. See
-   https://github.com/RobotLocomotion/drake/issues/10907 -->
-   <!-- TODO(SeanCurtis-TRI): Support queries of halfspace-A, where A is _not_ a
-   halfspace. See https://github.com/RobotLocomotion/drake/issues/10905 -->
-
-   @param max_distance  The maximum distance at which distance data is reported.
-
-   @returns The signed distance (and supporting data) for all unfiltered
-            geometry pairs whose distance is less than or equal to
-            `max_distance`.  */
+  /** See ProximityQueryObject::ComputeSignedDistancePairwiseClosestPoints().
+   */
+  DRAKE_DEPRECATED("2020-08-01", "Use the ProximityQueryObject instead.")
   std::vector<SignedDistancePair<T>> ComputeSignedDistancePairwiseClosestPoints(
       const double max_distance =
           std::numeric_limits<double>::infinity()) const;
 
-  /** A variant of ComputeSignedDistancePairwiseClosestPoints() which computes
-   the signed distance (and witnesses) between a specific pair of geometries
-   indicated by id. This function has the same restrictions on scalar report
-   as ComputeSignedDistancePairwiseClosestPoints().
-
-   @throws if either geometry id is invalid, or if the pair (id_A, id_B) has
-           been marked as filtered.  */
+  /** See ProximityQueryObject::ComputeSignedDistancePairClosestPoints().  */
+  DRAKE_DEPRECATED("2020-08-01", "Use the ProximityQueryObject instead.")
   SignedDistancePair<T> ComputeSignedDistancePairClosestPoints(
       GeometryId id_A, GeometryId id_B) const;
 
-  // TODO(DamrongGuoy): Improve and refactor documentation of
-  // ComputeSignedDistanceToPoint(). Move the common sections into Signed
-  // Distance Queries. Update documentation as we add more functionality.
-  // Right now it only supports spheres and boxes.
-  /**
-   Computes the signed distances and gradients to a query point from each
-   geometry in the scene.
-
-   @warning Currently supports spheres, boxes, and cylinders only. Silently
-   ignores other kinds of geometries, which will be added later.
-
-   This query provides φᵢ(p), φᵢ:ℝ³→ℝ, the signed distance to the position
-   p of a query point from geometry Gᵢ in the scene.  It returns an array of
-   the signed distances from all geometries.
-
-   Optionally you can specify a threshold distance that will filter out any
-   object beyond the threshold. By default, we report distances from the query
-   point to every object.
-
-   This query also provides the gradient vector ∇φᵢ(p) of the signed distance
-   function from geometry Gᵢ. Note that, in general, if p is outside Gᵢ, then
-   ∇φᵢ(p) equals the unit vector in the direction from the nearest point Nᵢ on
-   Gᵢ's surface to p. If p is inside Gᵢ, then ∇φᵢ(p) is in the direction from
-   p to Nᵢ. This observation is written formally as:
-
-   ∇φᵢ(p) = (p - Nᵢ)/|p - Nᵢ| if p is outside Gᵢ
-
-   ∇φᵢ(p) = -(p - Nᵢ)/|p - Nᵢ| if p is inside Gᵢ
-
-   Note that ∇φᵢ(p) is also defined on Gᵢ's surface, but we cannot use the
-   above formula.
-
-   <h3>Scalar support</h3>
-   This query only supports computing distances from the point to spheres,
-   boxes, and cylinders for both `double` and `AutoDiffXd` scalar types. If
-   the SceneGraph contains any other geometry shapes, they will be silently
-   ignored.
-
-   @note For a sphere G, the signed distance function φᵢ(p) has an undefined
-   gradient vector at the center of the sphere--every point on the sphere's
-   surface has the same distance to the center.  In this case, we will assign
-   ∇φᵢ(p) the unit vector Gx (x-directional vector of G's frame) expressed
-   in World frame.
-
-   @note For a box, at a point p on an edge or a corner of the box, the signed
-   distance function φᵢ(p) has an undefined gradient vector.  In this case, we
-   will assign a unit vector in the direction of the average of the outward
-   face unit normals of the incident faces of the edge or the corner.
-   A point p is considered being on a face, or an edge, or a corner of the
-   box if it lies within a certain tolerance from them.
-
-   @note For a box B, if a point p is inside the box, and it is equidistant to
-   to multiple nearest faces, the signed distance function φᵢ(p) at p will have
-   an undefined gradient vector. There is a nearest point candidate associated
-   with each nearest face. In this case, we arbitrarily pick the point Nᵢ
-   associated with one of the nearest faces.  Please note that, due to the
-   possible round off error arising from applying a pose X_WG to B, there is no
-   guarantee which of the nearest faces will be used.
-
-   @note The signed distance function is a continuous function with respect to
-   the position of the query point, but its gradient vector field may
-   not be continuous. Specifically at a position equidistant to multiple
-   nearest points, its gradient vector field is not continuous.
-
-   @note For a convex object, outside the object at positive distance from
-   the boundary, the signed distance function is smooth (having continuous
-   first-order partial derivatives).
-
-   @param[in] p_WQ            Position of a query point Q in world frame W.
-   @param[in] threshold       We ignore any object beyond this distance.
-                              By default, it is infinity, so we report
-                              distances from the query point to every object.
-   @retval signed_distances   A vector populated with per-object signed
-                              distance values (and supporting data).
-                              See SignedDistanceToPoint.
-   */
+  /** See ProximityQueryObject::ComputeSignedDistanceToPoint().  */
+  DRAKE_DEPRECATED("2020-08-01", "Use the ProximityQueryObject instead.")
   std::vector<SignedDistanceToPoint<T>>
   ComputeSignedDistanceToPoint(const Vector3<T> &p_WQ,
                                const double threshold
                                = std::numeric_limits<double>::infinity()) const;
-  //@}
 
-
-  //---------------------------------------------------------------------------
-  /**
-   @anchor render_queries
-   @name                Render Queries
-
-   The methods support queries along the lines of "What do I see?" They support
-   simulation of sensors. External entities define a sensor camera -- its
-   extrinsic and intrinsic properties and %QueryObject renders into the
-   provided image.
-
-   <!-- TODO(SeanCurtis-TRI): Currently, pose is requested as a transform of
-   double. This puts the burden on the caller to be compatible. Provide
-   specializations for AutoDiff and symbolic (the former extracts a
-   double-valued transform and the latter throws). -->
-   */
-  //@{
-
-  /** Renders an RGB image for the given `camera` posed with respect to the
-   indicated parent frame P.
-
-   @param camera                The intrinsic properties of the camera.
-   @param parent_frame          The id for the camera's parent frame.
-   @param X_PC                  The pose of the camera body in the world frame.
-   @param show_window           If true, the render window will be displayed.
-   @param[out] color_image_out  The rendered color image. */
+  /** See PerceptionQueryObject::RenderColorImage().  */
+  DRAKE_DEPRECATED("2020-08-01", "Use the PerceptionQueryObject instead.")
   void RenderColorImage(const render::CameraProperties& camera,
                         FrameId parent_frame,
                         const math::RigidTransformd& X_PC,
                         bool show_window,
                         systems::sensors::ImageRgba8U* color_image_out) const;
 
-  /** Renders a depth image for the given `camera` posed with respect to the
-   indicated parent frame P.
-
-   In contrast to the other rendering methods, rendering depth images doesn't
-   provide the option to display the window; generally, basic depth images are
-   not readily communicative to humans.
-
-   @param camera                The intrinsic properties of the camera.
-   @param parent_frame          The id for the camera's parent frame.
-   @param X_PC                  The pose of the camera body in the world frame.
-   @param[out] depth_image_out  The rendered depth image. */
+  /** See PerceptionQueryObject::RenderDepthImage().  */
+  DRAKE_DEPRECATED("2020-08-01", "Use the PerceptionQueryObject instead.")
   void RenderDepthImage(const render::DepthCameraProperties& camera,
                         FrameId parent_frame,
                         const math::RigidTransformd& X_PC,
                         systems::sensors::ImageDepth32F* depth_image_out) const;
 
-  /** Renders a label image for the given `camera` posed with respect to the
-   indicated parent frame P.
-
-   @param camera                The intrinsic properties of the camera.
-   @param parent_frame          The id for the camera's parent frame.
-   @param X_PC                  The pose of the camera body in the world frame.
-   @param show_window           If true, the render window will be displayed.
-   @param[out] label_image_out  The rendered label image. */
+  /** See PerceptionQueryObject::RenderLabelImage().  */
+  DRAKE_DEPRECATED("2020-08-01", "Use the PerceptionQueryObject instead.")
   void RenderLabelImage(const render::CameraProperties& camera,
                         FrameId parent_frame,
                         const math::RigidTransformd& X_PC,
                         bool show_window,
                         systems::sensors::ImageLabel16I* label_image_out) const;
-
-  //@}
 
  protected:
   /** Confirms that the %QueryObject (and its child classes) can operate on

--- a/geometry/test/query_object_test.cc
+++ b/geometry/test/query_object_test.cc
@@ -158,6 +158,9 @@ TEST_F(QueryObjectTest, DefaultQueryThrows) {
   EXPECT_DEFAULT_ERROR(default_object.X_PF(FrameId::get_new_id()));
   EXPECT_DEFAULT_ERROR(default_object.X_WG(GeometryId::get_new_id()));
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  // Test the deprecated interface.
 
   // Penetration queries.
   EXPECT_DEFAULT_ERROR(default_object.ComputePointPairPenetration());
@@ -191,6 +194,7 @@ TEST_F(QueryObjectTest, DefaultQueryThrows) {
   ImageLabel16I label;
   EXPECT_DEFAULT_ERROR(default_object.RenderLabelImage(
       properties, FrameId::get_new_id(), X_WC, false, &label));
+#pragma GCC diagnostic pop
 
 #undef EXPECT_DEFAULT_ERROR
 }

--- a/manipulation/util/show_model.py
+++ b/manipulation/util/show_model.py
@@ -59,7 +59,7 @@ def main():
     scene_graph = builder.AddSystem(SceneGraph())
     plant.RegisterAsSourceForSceneGraph(scene_graph)
     builder.Connect(
-        scene_graph.get_query_output_port(),
+        scene_graph.get_proximity_query_output_port(),
         plant.get_geometry_query_input_port())
     builder.Connect(
         plant.get_geometry_poses_output_port(),

--- a/multibody/inverse_kinematics/distance_constraint.cc
+++ b/multibody/inverse_kinematics/distance_constraint.cc
@@ -4,6 +4,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/geometry/proximity_query_object.h"
 #include "drake/multibody/inverse_kinematics/distance_constraint_utilities.h"
 #include "drake/multibody/inverse_kinematics/kinematic_constraint_utilities.h"
 
@@ -50,7 +51,7 @@ void EvalDistance(const MultibodyPlant<T>& plant,
   internal::UpdateContextConfiguration(context, plant, x);
   const auto& query_port = plant.get_geometry_query_input_port();
   const auto& query_object =
-      query_port.template Eval<geometry::QueryObject<T>>(*context);
+      query_port.template Eval<geometry::ProximityQueryObject<T>>(*context);
   const geometry::SignedDistancePair<T> signed_distance_pair =
       query_object.ComputeSignedDistancePairClosestPoints(
           geometry_pair.first(), geometry_pair.second());

--- a/multibody/inverse_kinematics/distance_constraint_utilities.h
+++ b/multibody/inverse_kinematics/distance_constraint_utilities.h
@@ -76,10 +76,10 @@ void CheckPlantIsConnectedToSceneGraph(
   if (!query_port.HasValue(plant_context)) {
     throw std::invalid_argument(
         "Kinematic constraint: Cannot get a valid "
-        "geometry::QueryObject. Either the plant's geometry query input port "
-        "is not properly connected to the SceneGraph's geometry query output "
-        "port, or the plant_context_ is incorrect. Please refer to "
-        "AddMultibodyPlantSceneGraph on connecting MultibodyPlant to "
+        "geometry::ProximityQueryObject. Either the plant's geometry query "
+        "input port is not properly connected to the SceneGraph's spatial "
+        "query output port, or the plant_context_ is incorrect. Please refer "
+        "to AddMultibodyPlantSceneGraph on connecting MultibodyPlant to "
         "SceneGraph.");
   }
 }

--- a/multibody/inverse_kinematics/minimum_distance_constraint.cc
+++ b/multibody/inverse_kinematics/minimum_distance_constraint.cc
@@ -5,6 +5,7 @@
 
 #include <Eigen/Dense>
 
+#include "drake/geometry/proximity_query_object.h"
 #include "drake/multibody/inverse_kinematics/distance_constraint_utilities.h"
 #include "drake/multibody/inverse_kinematics/kinematic_constraint_utilities.h"
 
@@ -21,14 +22,15 @@ VectorX<S> Distances(const MultibodyPlant<T>& plant,
   const auto& query_port = plant.get_geometry_query_input_port();
   if (!query_port.HasValue(*context)) {
     throw std::invalid_argument(
-        "MinimumDistanceConstraint: Cannot get a valid geometry::QueryObject. "
-        "Either the plant geometry_query_input_port() is not properly "
-        "connected to the SceneGraph's output port, or the plant_context_ is "
-        "incorrect. Please refer to AddMultibodyPlantSceneGraph on connecting "
-        "MultibodyPlant to SceneGraph.");
+        "MinimumDistanceConstraint: Cannot get a valid "
+        "geometry::ProximityQueryObject. Either the plant "
+        "geometry_query_input_port() is not properly connected to the "
+        "SceneGraph's ProximityQueryObject output port, or the plant_context_ "
+        "is incorrect. Please refer to AddMultibodyPlantSceneGraph on "
+        "connecting MultibodyPlant to SceneGraph.");
   }
   const auto& query_object =
-      query_port.template Eval<geometry::QueryObject<T>>(*context);
+      query_port.template Eval<geometry::ProximityQueryObject<T>>(*context);
 
   const std::vector<geometry::SignedDistancePair<T>> signed_distance_pairs =
       query_object.ComputeSignedDistancePairwiseClosestPoints(
@@ -82,7 +84,8 @@ void MinimumDistanceConstraint::Initialize(
   // Maximum number of SignedDistancePairs returned by calls to
   // ComputeSignedDistancePairwiseClosestPoints().
   const int num_collision_candidates =
-      query_port.template Eval<geometry::QueryObject<T>>(*plant_context)
+      query_port
+          .template Eval<geometry::ProximityQueryObject<T>>(*plant_context)
           .inspector()
           .GetCollisionCandidates()
           .size();

--- a/multibody/optimization/manipulator_equation_constraint.cc
+++ b/multibody/optimization/manipulator_equation_constraint.cc
@@ -2,6 +2,7 @@
 
 #include <unordered_map>
 
+#include "drake/geometry/proximity_query_object.h"
 #include "drake/multibody/inverse_kinematics/kinematic_constraint_utilities.h"
 
 namespace drake {
@@ -87,11 +88,12 @@ void ManipulatorEquationConstraint::DoEval(
   if (!query_port.HasValue(*context_)) {
     throw std::invalid_argument(
         "ManipulatorEquationConstraint: Cannot get a valid "
-        "geometry::QueryObject. Please refer to AddMultibodyPlantSceneGraph "
-        "on connecting MultibodyPlant to SceneGraph.");
+        "geometry::ProximityQueryObject. Please refer to "
+        "AddMultibodyPlantSceneGraph on connecting MultibodyPlant to "
+        "SceneGraph.");
   }
   const auto& query_object =
-      query_port.Eval<geometry::QueryObject<AutoDiffXd>>(*context_);
+      query_port.Eval<geometry::ProximityQueryObject<AutoDiffXd>>(*context_);
   const std::vector<geometry::SignedDistancePair<AutoDiffXd>>
       signed_distance_pairs =
           query_object.ComputeSignedDistancePairwiseClosestPoints();

--- a/multibody/optimization/sliding_friction_complementarity_constraint.cc
+++ b/multibody/optimization/sliding_friction_complementarity_constraint.cc
@@ -4,6 +4,7 @@
 #include <limits>
 #include <memory>
 
+#include "drake/geometry/proximity_query_object.h"
 #include "drake/multibody/inverse_kinematics/kinematic_constraint_utilities.h"
 
 namespace drake {
@@ -160,11 +161,12 @@ void SlidingFrictionComplementarityNonlinearConstraint::DoEval(
   if (!query_port.HasValue(context)) {
     throw std::invalid_argument(
         "StaticEquilibriumConstraint: Cannot get a valid "
-        "geometry::QueryObject. Please refer to AddMultibodyPlantSceneGraph "
-        "on connecting MultibodyPlant to SceneGraph.");
+        "geometry::ProximityQueryObject. Please refer to "
+        "AddMultibodyPlantSceneGraph on connecting MultibodyPlant to "
+        "SceneGraph.");
   }
   const auto& query_object =
-      query_port.Eval<geometry::QueryObject<AutoDiffXd>>(context);
+      query_port.Eval<geometry::ProximityQueryObject<AutoDiffXd>>(context);
   const std::vector<geometry::SignedDistancePair<AutoDiffXd>>
       signed_distance_pairs =
           query_object.ComputeSignedDistancePairwiseClosestPoints();

--- a/multibody/optimization/static_equilibrium_constraint.cc
+++ b/multibody/optimization/static_equilibrium_constraint.cc
@@ -2,6 +2,7 @@
 
 #include <unordered_map>
 
+#include "drake/geometry/proximity_query_object.h"
 #include "drake/multibody/inverse_kinematics/kinematic_constraint_utilities.h"
 
 namespace drake {
@@ -57,11 +58,12 @@ void StaticEquilibriumConstraint::DoEval(
   if (!query_port.HasValue(*context_)) {
     throw std::invalid_argument(
         "StaticEquilibriumConstraint: Cannot get a valid "
-        "geometry::QueryObject. Please refer to AddMultibodyPlantSceneGraph "
-        "on connecting MultibodyPlant to SceneGraph.");
+        "geometry::ProximityQueryObject. Please refer to "
+        "AddMultibodyPlantSceneGraph on connecting MultibodyPlant to "
+        "SceneGraph.");
   }
   const auto& query_object =
-      query_port.Eval<geometry::QueryObject<AutoDiffXd>>(*context_);
+      query_port.Eval<geometry::ProximityQueryObject<AutoDiffXd>>(*context_);
   const std::vector<geometry::SignedDistancePair<AutoDiffXd>>
       signed_distance_pairs =
           query_object.ComputeSignedDistancePairwiseClosestPoints();

--- a/multibody/optimization/static_equilibrium_problem.cc
+++ b/multibody/optimization/static_equilibrium_problem.cc
@@ -1,5 +1,6 @@
 #include "drake/multibody/optimization/static_equilibrium_problem.h"
 
+#include "drake/geometry/proximity_query_object.h"
 #include "drake/multibody/optimization/static_equilibrium_constraint.h"
 #include "drake/multibody/optimization/static_friction_cone_complementarity_constraint.h"
 
@@ -24,11 +25,12 @@ StaticEquilibriumProblem::StaticEquilibriumProblem(
   if (!query_port.HasValue(*context_)) {
     throw std::invalid_argument(
         "StaticEquilibriumConstraint: Cannot get a valid "
-        "geometry::QueryObject. Please refer to AddMultibodyPlantSceneGraph "
-        "on connecting MultibodyPlant to SceneGraph.");
+        "geometry::ProximityQueryObject. Please refer to "
+        "AddMultibodyPlantSceneGraph on connecting MultibodyPlant to "
+        "SceneGraph.");
   }
   const auto& query_object =
-      query_port.Eval<geometry::QueryObject<AutoDiffXd>>(*context_);
+      query_port.Eval<geometry::ProximityQueryObject<AutoDiffXd>>(*context_);
   const geometry::SceneGraphInspector<AutoDiffXd>& inspector =
       query_object.inspector();
   const std::set<std::pair<geometry::GeometryId, geometry::GeometryId>>
@@ -77,11 +79,12 @@ std::vector<ContactWrench> StaticEquilibriumProblem::GetContactWrenchSolution(
   if (!query_port.HasValue(*context_)) {
     throw std::invalid_argument(
         "StaticEquilibriumConstraint: Cannot get a valid "
-        "geometry::QueryObject. Please refer to AddMultibodyPlantSceneGraph "
-        "on connecting MultibodyPlant to SceneGraph.");
+        "geometry::ProximityQueryObject. Please refer to "
+        "AddMultibodyPlantSceneGraph on connecting MultibodyPlant to "
+        "SceneGraph.");
   }
   const auto& query_object =
-      query_port.Eval<geometry::QueryObject<AutoDiffXd>>(*context_);
+      query_port.Eval<geometry::ProximityQueryObject<AutoDiffXd>>(*context_);
   // TODO(hongkai.dai) compute the signed distance between a specific pair of
   // contact, rather than all pairs of contact.
   const std::vector<geometry::SignedDistancePair<AutoDiffXd>>

--- a/multibody/optimization/static_friction_cone_complementarity_constraint.cc
+++ b/multibody/optimization/static_friction_cone_complementarity_constraint.cc
@@ -91,11 +91,12 @@ void StaticFrictionConeComplementarityNonlinearConstraint::DoEval(
   if (!query_port.HasValue(context)) {
     throw std::invalid_argument(
         "StaticEquilibriumConstraint: Cannot get a valid "
-        "geometry::QueryObject. Please refer to AddMultibodyPlantSceneGraph "
-        "on connecting MultibodyPlant to SceneGraph.");
+        "geometry::ProximityQueryObject. Please refer to "
+        "AddMultibodyPlantSceneGraph on connecting MultibodyPlant to "
+        "SceneGraph.");
   }
   const auto& query_object =
-      query_port.Eval<geometry::QueryObject<AutoDiffXd>>(context);
+      query_port.Eval<geometry::ProximityQueryObject<AutoDiffXd>>(context);
   const std::vector<geometry::SignedDistancePair<AutoDiffXd>>
       signed_distance_pairs =
           query_object.ComputeSignedDistancePairwiseClosestPoints();

--- a/multibody/optimization/static_friction_cone_constraint.cc
+++ b/multibody/optimization/static_friction_cone_constraint.cc
@@ -3,6 +3,7 @@
 #include <limits>
 #include <vector>
 
+#include "drake/geometry/proximity_query_object.h"
 #include "drake/multibody/inverse_kinematics/kinematic_constraint_utilities.h"
 
 namespace drake {
@@ -55,11 +56,12 @@ void StaticFrictionConeConstraint::DoEval(
   if (!query_port.HasValue(context)) {
     throw std::invalid_argument(
         "StaticFrictionConeConstraint: Cannot get a valid "
-        "geometry::QueryObject. Please refer to AddMultibodyPlantSceneGraph "
-        "on connecting MultibodyPlant to SceneGraph.");
+        "geometry::ProximityQueryObject. Please refer to "
+        "AddMultibodyPlantSceneGraph on connecting MultibodyPlant to "
+        "SceneGraph.");
   }
   const auto& query_object =
-      query_port.Eval<geometry::QueryObject<AutoDiffXd>>(context);
+      query_port.Eval<geometry::ProximityQueryObject<AutoDiffXd>>(context);
   const std::vector<geometry::SignedDistancePair<AutoDiffXd>>
       signed_distance_pairs =
           query_object.ComputeSignedDistancePairwiseClosestPoints();

--- a/multibody/optimization/test/manipulator_equation_constraint_test.cc
+++ b/multibody/optimization/test/manipulator_equation_constraint_test.cc
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/geometry/proximity_query_object.h"
 #include "drake/math/autodiff_gradient.h"
 #include "drake/math/compute_numerical_gradient.h"
 #include "drake/multibody/optimization/test/optimization_with_contact_utilities.h"
@@ -27,7 +28,7 @@ class TwoFreeSpheresTest : public ::testing::Test {
         spheres_->spheres(), spheres_->boxes(), spheres_->ground_friction());
     const auto& query_port = spheres_->plant().get_geometry_query_input_port();
     const auto& query_object =
-        query_port.Eval<geometry::QueryObject<AutoDiffXd>>(
+        query_port.Eval<geometry::ProximityQueryObject<AutoDiffXd>>(
             spheres_->plant_context());
     const std::set<std::pair<geometry::GeometryId, geometry::GeometryId>>
         collision_candidate_pairs =
@@ -86,7 +87,7 @@ class TwoFreeSpheresTest : public ::testing::Test {
 
     const auto& query_port = spheres_->plant().get_geometry_query_input_port();
     const auto& query_object =
-        query_port.Eval<geometry::QueryObject<AutoDiffXd>>(
+        query_port.Eval<geometry::ProximityQueryObject<AutoDiffXd>>(
             spheres_->plant_context());
     const std::vector<geometry::SignedDistancePair<AutoDiffXd>>
         signed_distance_pairs =

--- a/multibody/optimization/test/static_equilibrium_constraint_test.cc
+++ b/multibody/optimization/test/static_equilibrium_constraint_test.cc
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/geometry/proximity_query_object.h"
 #include "drake/math/autodiff_gradient.h"
 #include "drake/math/compute_numerical_gradient.h"
 #include "drake/multibody/optimization/test/optimization_with_contact_utilities.h"
@@ -27,7 +28,7 @@ class TwoFreeSpheresTest : public ::testing::Test {
         spheres_->spheres(), spheres_->boxes(), spheres_->ground_friction());
     const auto& query_port = spheres_->plant().get_geometry_query_input_port();
     const auto& query_object =
-        query_port.Eval<geometry::QueryObject<AutoDiffXd>>(
+        query_port.Eval<geometry::ProximityQueryObject<AutoDiffXd>>(
             spheres_->plant_context());
     const std::set<std::pair<geometry::GeometryId, geometry::GeometryId>>
         collision_candidate_pairs =
@@ -68,7 +69,7 @@ class TwoFreeSpheresTest : public ::testing::Test {
 
     const auto& query_port = spheres_->plant().get_geometry_query_input_port();
     const auto& query_object =
-        query_port.Eval<geometry::QueryObject<AutoDiffXd>>(
+        query_port.Eval<geometry::ProximityQueryObject<AutoDiffXd>>(
             spheres_->plant_context());
     const std::vector<geometry::SignedDistancePair<AutoDiffXd>>
         signed_distance_pairs =

--- a/multibody/plant/calc_distance_and_time_derivative.cc
+++ b/multibody/plant/calc_distance_and_time_derivative.cc
@@ -16,7 +16,7 @@ SignedDistanceWithTimeDerivative CalcDistanceAndTimeDerivative(
   }
   const auto& query_port = plant.get_geometry_query_input_port();
   const auto& query_object =
-      query_port.Eval<geometry::QueryObject<double>>(context);
+      query_port.Eval<geometry::ProximityQueryObject<double>>(context);
   const geometry::SignedDistancePair<double> signed_distance_pair =
       query_object.ComputeSignedDistancePairClosestPoints(
           geometry_pair.first(), geometry_pair.second());

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1072,7 +1072,7 @@ MultibodyPlant<double>::CalcPointPairPenetrations(
           "is not connected.");
     }
     const auto& query_object = get_geometry_query_input_port().
-        Eval<geometry::QueryObject<double>>(context);
+        Eval<geometry::ProximityQueryObject<double>>(context);
     return query_object.ComputePointPairPenetration();
   }
   return std::vector<PenetrationAsPointPair<double>>();
@@ -1087,7 +1087,7 @@ MultibodyPlant<AutoDiffXd>::CalcPointPairPenetrations(
     const systems::Context<AutoDiffXd>& context) const {
   if (num_collision_geometries() > 0) {
     const auto &query_object = get_geometry_query_input_port().
-        Eval<geometry::QueryObject<AutoDiffXd>>(context);
+        Eval<geometry::ProximityQueryObject<AutoDiffXd>>(context);
     auto results = query_object.ComputePointPairPenetration();
     if (results.size() > 0) {
       throw std::logic_error(
@@ -1491,7 +1491,7 @@ void MultibodyPlant<T>::CalcHydroelasticContactForces(
 
     // Combined Hunt & Crossley dissipation.
     const auto& query_object = get_geometry_query_input_port().
-        template Eval<geometry::QueryObject<T>>(context);
+        template Eval<geometry::ProximityQueryObject<T>>(context);
     const double dissipation = hydroelastics_engine_.CalcCombinedDissipation(
         geometryM_id, geometryN_id, query_object.inspector());
 
@@ -1727,7 +1727,7 @@ void MultibodyPlant<T>::CalcContactSurfaces(
 
   const auto& query_object =
       this->get_geometry_query_input_port()
-          .template Eval<geometry::QueryObject<T>>(context);
+          .template Eval<geometry::ProximityQueryObject<T>>(context);
 
   *contact_surfaces = query_object.ComputeContactSurfaces();
 }
@@ -1756,7 +1756,7 @@ void MultibodyPlant<double>::CalcHydroelasticWithFallback(
 
     const auto &query_object =
         this->get_geometry_query_input_port()
-            .template Eval<geometry::QueryObject<double>>(context);
+            .template Eval<geometry::ProximityQueryObject<double>>(context);
     data->contact_surfaces.clear();
     data->point_pairs.clear();
 
@@ -2774,11 +2774,11 @@ MultibodyPlant<T>::get_reaction_forces_output_port() const {
 namespace {
 // A dummy, placeholder type.
 struct SymbolicGeometryValue {};
-// An alias for QueryObject<T>, except when T = Expression.
+// An alias for ProximityQueryObject<T>, except when T = Expression.
 template <typename T>
 using ModelQueryObject = typename std::conditional<
     std::is_same<T, symbolic::Expression>::value,
-    SymbolicGeometryValue, geometry::QueryObject<T>>::type;
+    SymbolicGeometryValue, geometry::ProximityQueryObject<T>>::type;
 }  // namespace
 
 template <typename T>
@@ -3007,7 +3007,7 @@ AddMultibodyPlantSceneGraph(
       scene_graph_ptr->get_source_pose_port(
           plant_ptr->get_source_id().value()));
   builder->Connect(
-      scene_graph_ptr->get_query_output_port(),
+      scene_graph_ptr->get_proximity_query_output_port(),
       plant_ptr->get_geometry_query_input_port());
   return {plant_ptr, scene_graph_ptr};
 }

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -79,7 +79,7 @@ enum class ContactModel {
   /// Contact forces are computed using the hydroelastic model, where possible.
   /// For most other unsupported colliding pairs, the point model from
   /// kPointContactOnly is used. See
-  /// geometry::QueryObject:ComputeContactSurfacesWithFallback for more
+  /// geometry::ProximityQueryObject:ComputeContactSurfacesWithFallback for more
   /// details.
   kHydroelasticWithFallback
 };
@@ -328,16 +328,16 @@ enum class ContactModel {
 /// If %MultibodyPlant registers geometry with a SceneGraph via calls to
 /// RegisterCollisionGeometry(), an input port for geometric queries will be
 /// declared at Finalize() time, see get_geometry_query_input_port(). Users must
-/// connect this input port to the output port for geometric queries of the
+/// connect this input port to the output port for spatial queries of the
 /// SceneGraph used for registration, which can be obtained with
-/// SceneGraph::get_query_output_port().
+/// SceneGraph::get_proximity_query_output_port().
 /// In summary, if %MultibodyPlant registers collision geometry, the setup
 /// process will include:
 ///
 /// 1. Call to RegisterAsSourceForSceneGraph().
 /// 2. Calls to RegisterCollisionGeometry(), as many as needed.
 /// 3. Call to Finalize(), user is done specifying the model.
-/// 4. Connect SceneGraph::get_query_output_port() to
+/// 4. Connect SceneGraph::get_proximity_query_output_port() to
 ///    get_geometry_query_input_port().
 ///
 /// Refer to the documentation provided in each of the methods above for further
@@ -467,8 +467,9 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// can be applied to any number of bodies in the plant.
   const systems::InputPort<T>& get_applied_spatial_force_input_port() const;
 
-  /// Returns a constant reference to the input port used to perform geometric
-  /// queries on a SceneGraph. See SceneGraph::get_query_output_port().
+  /// Returns a constant reference to the input port used to perform spatial
+  /// queries on a SceneGraph.
+  /// See SceneGraph::get_proximity_query_output_port().
   /// Refer to section @ref mbp_geometry "Geometry" of this class's
   /// documentation for further details on collision geometry registration and
   /// connection with a SceneGraph.
@@ -974,7 +975,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// All geometry registration methods return a @ref geometry::GeometryId
   /// GeometryId. This is how SceneGraph refers to the geometries. The
   /// properties of an individual geometry can be accessed with its id and
-  /// geometry::SceneGraphInspector and geometry::QueryObject (for its
+  /// geometry::SceneGraphInspector and geometry::ProximityQueryObject (for its
   /// state-dependent pose in world).
   ///
   /// <h4>%Body frames and SceneGraph frames</h4>

--- a/multibody/plant/test/hydroelastic_traction_test.cc
+++ b/multibody/plant/test/hydroelastic_traction_test.cc
@@ -207,7 +207,7 @@ public ::testing::TestWithParam<RigidTransform<double>> {
     // Get the bodies that the two geometries are affixed to. We'll call these
     // A and B.
     const auto& query_object = plant_->get_geometry_query_input_port().
-        template Eval<geometry::QueryObject<double>>(*plant_context_);
+        template Eval<geometry::ProximityQueryObject<double>>(*plant_context_);
     const geometry::FrameId frameM_id = query_object.inspector().GetFrameId(
         contact_surface_->id_M());
     const geometry::FrameId frameN_id = query_object.inspector().GetFrameId(

--- a/multibody/plant/test/multibody_plant_hydroelastic_contact_results_output_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_contact_results_output_test.cc
@@ -58,7 +58,7 @@ class HydroelasticContactResultsOutputTester : public ::testing::Test {
     // it.
     DRAKE_DEMAND(!!plant_->get_source_id());
 
-    builder.Connect(scene_graph.get_query_output_port(),
+    builder.Connect(scene_graph.get_proximity_query_output_port(),
                     plant_->get_geometry_query_input_port());
     builder.Connect(
         plant_->get_geometry_poses_output_port(),
@@ -107,7 +107,8 @@ TEST_F(HydroelasticContactResultsOutputTester, ContactSurfaceEquivalent) {
   // Get the query object so that we can compute the contact surfaces.
   const auto& query_object =
       plant_->get_geometry_query_input_port()
-          .template Eval<geometry::QueryObject<double>>(*plant_context_);
+          .template Eval<geometry::ProximityQueryObject<double>>(
+              *plant_context_);
 
   // Compute the contact surface using the hydroelastic engine.
   std::vector<geometry::ContactSurface<double>> contact_surfaces =

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -19,7 +19,7 @@
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/geometry_frame.h"
 #include "drake/geometry/geometry_roles.h"
-#include "drake/geometry/query_object.h"
+#include "drake/geometry/proximity_query_object.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/geometry/test_utilities/dummy_render_engine.h"
 #include "drake/geometry/test_utilities/geometry_set_tester.h"
@@ -57,7 +57,7 @@ using geometry::GeometryId;
 using geometry::IllustrationProperties;
 using geometry::internal::DummyRenderEngine;
 using geometry::PenetrationAsPointPair;
-using geometry::QueryObject;
+using geometry::ProximityQueryObject;
 using geometry::SceneGraph;
 using geometry::SceneGraphInspector;
 using math::RigidTransform;
@@ -1038,7 +1038,7 @@ class SphereChainScenario {
   ComputePointPairPenetration() const {
     // Grab query object to test for collisions.
     const auto& query_object = plant_->get_geometry_query_input_port().
-        Eval<geometry::QueryObject<double>>(*plant_context_);
+        Eval<geometry::ProximityQueryObject<double>>(*plant_context_);
     return query_object.ComputePointPairPenetration();
   }
 
@@ -1460,11 +1460,12 @@ GTEST_TEST(MultibodyPlantTest, VisualGeometryRegistration) {
 
   unique_ptr<Context<double>> context = scene_graph.CreateDefaultContext();
   unique_ptr<AbstractValue> state_value =
-      scene_graph.get_query_output_port().Allocate();
-  DRAKE_EXPECT_NO_THROW(state_value->get_value<QueryObject<double>>());
-  const QueryObject<double>& query_object =
-      state_value->get_value<QueryObject<double>>();
-  scene_graph.get_query_output_port().Calc(*context, state_value.get());
+      scene_graph.get_proximity_query_output_port().Allocate();
+  DRAKE_EXPECT_NO_THROW(state_value->get_value<ProximityQueryObject<double>>());
+  const ProximityQueryObject<double>& query_object =
+      state_value->get_value<ProximityQueryObject<double>>();
+  scene_graph.get_proximity_query_output_port().Calc(*context,
+                                                     state_value.get());
 
   const SceneGraphInspector<double>& inspector = query_object.inspector();
   {

--- a/systems/sensors/rgbd_sensor.cc
+++ b/systems/sensors/rgbd_sensor.cc
@@ -23,7 +23,7 @@ namespace sensors {
 
 using Eigen::Translation3d;
 using geometry::FrameId;
-using geometry::QueryObject;
+using geometry::PerceptionQueryObject;
 using geometry::render::CameraProperties;
 using geometry::render::DepthCameraProperties;
 using geometry::SceneGraph;
@@ -48,7 +48,7 @@ RgbdSensor::RgbdSensor(FrameId parent_id,
       X_BC_(camera_poses.X_BC),
       X_BD_(camera_poses.X_BD) {
   query_object_input_port_ = &this->DeclareAbstractInputPort(
-      "geometry_query", Value<geometry::QueryObject<double>>{});
+      "geometry_query", Value<PerceptionQueryObject<double>>{});
 
   ImageRgba8U color_image(color_camera_info_.width(),
                           color_camera_info_.height());
@@ -109,14 +109,14 @@ const OutputPort<double>& RgbdSensor::X_WB_output_port() const {
 
 void RgbdSensor::CalcColorImage(const Context<double>& context,
                                 ImageRgba8U* color_image) const {
-  const QueryObject<double>& query_object = get_query_object(context);
+  const PerceptionQueryObject<double>& query_object = get_query_object(context);
   query_object.RenderColorImage(color_properties_, parent_frame_id_,
                                 X_PB_ * X_BC_, show_window_, color_image);
 }
 
 void RgbdSensor::CalcDepthImage32F(const Context<double>& context,
                                    ImageDepth32F* depth_image) const {
-  const QueryObject<double>& query_object = get_query_object(context);
+  const PerceptionQueryObject<double>& query_object = get_query_object(context);
   query_object.RenderDepthImage(depth_properties_, parent_frame_id_,
                                 X_PB_ * X_BD_, depth_image);
 }
@@ -130,7 +130,7 @@ void RgbdSensor::CalcDepthImage16U(const Context<double>& context,
 
 void RgbdSensor::CalcLabelImage(const Context<double>& context,
                                 ImageLabel16I* label_image) const {
-  const QueryObject<double>& query_object = get_query_object(context);
+  const PerceptionQueryObject<double>& query_object = get_query_object(context);
   query_object.RenderLabelImage(color_properties_, parent_frame_id_,
                                 X_PB_ * X_BC_, show_window_, label_image);
 }
@@ -143,7 +143,8 @@ void RgbdSensor::CalcX_WB(
   if (parent_frame_id_ == SceneGraph<double>::world_frame_id()) {
     X_WB = X_PB_;
   } else {
-    const QueryObject<double>& query_object = get_query_object(context);
+    const PerceptionQueryObject<double>& query_object =
+        get_query_object(context);
     X_WB = query_object.X_WF(parent_frame_id_) * X_PB_;
   }
 
@@ -170,10 +171,10 @@ void RgbdSensor::ConvertDepth32FTo16U(const ImageDepth32F& d32,
 // to do something weird with GeometryState such that the rgbd_sensor_test.cc
 // was unable to instantiate an GeometryStateTester that GCC recognized as a
 // friend to GeometryState.
-const geometry::QueryObject<double>& RgbdSensor::get_query_object(
+const PerceptionQueryObject<double>& RgbdSensor::get_query_object(
     const Context<double>& context) const {
   return query_object_input_port().
-      Eval<geometry::QueryObject<double>>(context);
+      Eval<PerceptionQueryObject<double>>(context);
 }
 
 RgbdSensorDiscrete::RgbdSensorDiscrete(std::unique_ptr<RgbdSensor> camera,

--- a/systems/sensors/rgbd_sensor.h
+++ b/systems/sensors/rgbd_sensor.h
@@ -10,7 +10,7 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/geometry/geometry_ids.h"
-#include "drake/geometry/query_object.h"
+#include "drake/geometry/perception_query_object.h"
 #include "drake/geometry/render/camera_properties.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/math/roll_pitch_yaw.h"
@@ -166,7 +166,7 @@ class RgbdSensor final : public LeafSystem<double> {
   /** Returns the id of the frame to which the base is affixed.  */
   geometry::FrameId parent_frame_id() const { return parent_frame_id_; }
 
-  /** Returns the geometry::QueryObject<double>-valued input port.  */
+  /** Returns the geometry::PerceptionQueryObject<double>-valued input port.  */
   const InputPort<double>& query_object_input_port() const;
 
   /** Returns the abstract-valued output port that contains an ImageRgba8U.  */
@@ -211,7 +211,7 @@ class RgbdSensor final : public LeafSystem<double> {
 
   // Extract the query object from the given context (via the appropriate input
   // port.
-  const geometry::QueryObject<double>& get_query_object(
+  const geometry::PerceptionQueryObject<double>& get_query_object(
       const Context<double>& context) const;
 
   const InputPort<double>* query_object_input_port_{};

--- a/systems/sensors/test/rgbd_sensor_test.cc
+++ b/systems/sensors/test/rgbd_sensor_test.cc
@@ -74,7 +74,6 @@ using geometry::FramePoseVector;
 using geometry::GeometryFrame;
 using geometry::GeometryStateTester;
 using geometry::internal::DummyRenderEngine;
-using geometry::QueryObject;
 using geometry::render::CameraProperties;
 using geometry::render::DepthCameraProperties;
 using geometry::render::RenderEngine;
@@ -127,7 +126,7 @@ class RgbdSensorTest : public ::testing::Test {
     scene_graph_ = builder.AddSystem<SceneGraph<double>>();
     scene_graph_->AddRenderer(kRendererName, make_unique<DummyRenderEngine>());
     sensor_ = builder.AddSystem(make_sensor(scene_graph_));
-    builder.Connect(scene_graph_->get_query_output_port(),
+    builder.Connect(scene_graph_->get_perception_query_output_port(),
                     sensor_->query_object_input_port());
     diagram_ = builder.Build();
     context_ = diagram_->AllocateContext();

--- a/tutorials/rendering_multibody_plant.ipynb
+++ b/tutorials/rendering_multibody_plant.ipynb
@@ -230,7 +230,7 @@
     "    color_properties=depth_prop, depth_properties=depth_prop)\n",
     "builder.AddSystem(sensor)\n",
     "builder.Connect(\n",
-    "    scene_graph.get_query_output_port(),\n",
+    "    scene_graph.get_perception_query_output_port(),\n",
     "    sensor.query_object_input_port())"
    ]
   },


### PR DESCRIPTION
This applies deprecation warnings to the query methods in QueryObject that now belong uniquely to the PerceptionQueryObject and ProximityQueryObject. It modifies all call sites to conform to the
deprecations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13205)
<!-- Reviewable:end -->
