### PR TITLE
doc issues: Add pydrake and jupyter components

### DIFF
--- a/doc/issues.rst
+++ b/doc/issues.rst
@@ -115,6 +115,14 @@ Every issue must have at most one ``component`` label. The components are:
 
   typical team: dynamics
 
+- ``jupyter``
+
+  Jupyter notebook infrastructure, Binder integration, etc.
+
+  *Note*: This label does not imply content authoring for tutorials.
+
+  typical team: kitware
+
 - ``mathematical program``
 
   Formulating and solving mathematical programs through numerical optimization,
@@ -128,6 +136,13 @@ Every issue must have at most one ``component`` label. The components are:
   usually in ``drake/multibody``.
 
   typical team: dynamics
+
+- ``pydrake``
+
+  Python API and documentation under ``//bindings/pydrake`` (and
+  its supporting Starlark macros), the ``RobotLocomotion/pybind11`` fork, etc.
+
+  typical team: kitware
 
 - ``simulator``
 


### PR DESCRIPTION
Added Labels:
- https://github.com/RobotLocomotion/drake/labels/component%3A%20jupyter
- https://github.com/RobotLocomotion/drake/labels/component%3A%20pydrake

(No sorting has been done yet)

\cc @SeanCurtis-TRI 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13208)
<!-- Reviewable:end -->
