### PR TITLE
Add instructions for getting Stackoverflow drake-tag notifications.

### DIFF
--- a/doc/developers.rst
+++ b/doc/developers.rst
@@ -262,21 +262,18 @@ new link on the GitHub issue, and close the issue.
 Handling User StackOverflow Questions
 -------------------------------------
 
-Please subscribe to the ``drake`` tag by following
-`these general instructions <https://meta.stackoverflow.com/a/336515/7829525>`_,
-if you are able to.
+Please subscribe to the ``drake`` tag by following these instructions:
+
+.. toctree::
+    :maxdepth: 1
+
+    stackoverflow_notifications
 
 Please also monitor for `unanswered StackOverflow posts
 <https://stackoverflow.com/unanswered/tagged/drake?tab=noanswers>`_
 once per day. If there are unanswered questions that you are unsure of the
 answer, consider posting on the Slack ``#onramp`` channel to see if someone
 can can look into the question.
-
-The following developers are subscribed to the ``drake`` tag, and will monitor
-it:
-
-  - Russ Tedrake
-  - Eric Cousineau
 
 Continuous Integration Notes
 ============================

--- a/doc/stackoverflow_notifications.rst
+++ b/doc/stackoverflow_notifications.rst
@@ -1,0 +1,34 @@
+.. _stackoverflow_notifications:
+
+*******************************************************************
+How to get notifications for "drake"-tagged Stackoverflow questions
+*******************************************************************
+
+(Set up a Stackoverflow account if you don't already have one.)
+
+1. Go to `StackOverflow <https://stackoverflow.com>`_.
+2. Click on your profile picture (upper right).
+3. Select "Edit profile and settings".
+4. Under "EMAIL SETTINGS", select "Question subscriptions".
+
+   - (This will take you to StackExchange.)
+
+5. Look for "Filtered questions" at the top; select that.
+
+   - If you don't see it, look for "Log in" and make sure
+     you are logged in to StackExchange as well as StackOverflow.
+   - After logging in, select "Filtered questions".
+
+6. Click on "New filter", which brings up a form.
+7. On the form: 
+
+   - Pick "Just questions tagged with the ____ tag." and type "drake".
+   - Keep the default "All sites"; don't select "Add rule".
+   - Choose a name for your filter, like "Drake questions".
+   - Request notification to your email, and pick a frequency. Consider
+     the shortest delay so users can get quick answers -- you can always
+     make it longer later if it is bothering you.
+
+8. Click "Save changes".
+9. You should receive an email confirmation with a subject like
+   "Confirm your filter subscription - StackExchange"


### PR DESCRIPTION
Adds to the Drake "For Developers" guidance instructions for how to get an email notification when a user asks a `drake`-tagged question on Stackoverflow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13216)
<!-- Reviewable:end -->
