### PR TITLE
Step doubling for Implicit Euler Error Estimation

### DIFF
--- a/systems/analysis/implicit_euler_integrator.cc
+++ b/systems/analysis/implicit_euler_integrator.cc
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <limits>
 #include <stdexcept>
+#include <utility>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/text_logging.h"
@@ -15,11 +16,8 @@ namespace systems {
 template <class T>
 void ImplicitEulerIntegrator<T>::DoResetImplicitIntegratorStatistics() {
   num_nr_iterations_ = 0;
-  num_err_est_nr_iterations_ = 0;
-  num_err_est_function_evaluations_ = 0;
-  num_err_est_jacobian_function_evaluations_ = 0;
-  num_err_est_jacobian_reforms_ = 0;
-  num_err_est_iter_factorizations_ = 0;
+  hie_statistics_ = {};
+  itr_statistics_ = {};
 }
 
 template <class T>
@@ -210,9 +208,22 @@ bool ImplicitEulerIntegrator<T>::StepAbstract(
 template <class T>
 bool ImplicitEulerIntegrator<T>::StepImplicitEuler(const T& t0, const T& h,
     const VectorX<T>& xt0, VectorX<T>* xtplus) {
+  DRAKE_LOGGER_DEBUG("StepImplicitEuler(h={}) t={}", h, t0);
+
+  // Use the current state as the candidate value for the next state.
+  // [Hairer 1996] validates this choice (p. 120).
+  const VectorX<T>& xtplus_guess = xt0;
+
+  return this->StepImplicitEulerWithGuess(t0, h, xt0, xtplus_guess, xtplus);
+}
+
+template <class T>
+bool ImplicitEulerIntegrator<T>::StepImplicitEulerWithGuess(
+    const T& t0, const T& h, const VectorX<T>& xt0,
+    const VectorX<T>& xtplus_guess, VectorX<T>* xtplus) {
   using std::abs;
 
-  DRAKE_LOGGER_DEBUG("StepImplicitEuler(h={}) t={}", h, t0);
+  DRAKE_LOGGER_DEBUG("StepImplicitEulerWithGuess(h={}) t={}", h, t0);
 
   // Set g for the implicit Euler method.
   Context<T>* context = this->get_mutable_context();
@@ -222,14 +233,101 @@ bool ImplicitEulerIntegrator<T>::StepImplicitEuler(const T& t0, const T& h,
             h * this->EvalTimeDerivatives(*context).CopyToVector()).eval();
       };
 
-  // Use the current state as the candidate value for the next state.
-  // [Hairer 1996] validates this choice (p. 120).
-  const VectorX<T>& xtplus_guess = xt0;
-
   // Attempt the step.
   return StepAbstract(t0, h, xt0, g,
                       ComputeAndFactorImplicitEulerIterationMatrix,
                       xtplus_guess, &ie_iteration_matrix_, &*xtplus);
+}
+
+template <class T>
+bool ImplicitEulerIntegrator<T>::StepHalfSizedImplicitEulers(
+    const T& t0, const T& h, const VectorX<T>& xt0,
+    const VectorX<T>& xtplus_ie, VectorX<T>* xtplus) {
+  using std::abs;
+
+  DRAKE_LOGGER_DEBUG("StepHalfSizedImplicitEulers(h={}) t={}", h, t0);
+
+
+  // Store statistics before calling StepAbstract(). The difference between
+  // the modified statistics and the stored statistics will be used to compute
+  // the half-sized-implicit-Euler-specific statistics.
+  const int stored_num_jacobian_evaluations =
+      this->get_num_jacobian_evaluations();
+  const int stored_num_iter_factorizations =
+      this->get_num_iteration_matrix_factorizations();
+  const int64_t stored_num_function_evaluations =
+      this->get_num_derivative_evaluations();
+  const int64_t stored_num_jacobian_function_evaluations =
+      this->get_num_derivative_evaluations_for_jacobian();
+  const int stored_num_nr_iterations =
+      this->get_num_newton_raphson_iterations();
+
+  // We set our guess for the state after a half-step to the average of the
+  // guess for the final state, xtplus_ie, and the initial state, xt0.
+  VectorX<T> xtmp = 0.5 * (xt0 + xtplus_ie);
+  // Attempt to step.
+  bool success = StepImplicitEulerWithGuess(t0, 0.5 * h, xt0, xtmp, xtplus);
+  if (!success) {
+    DRAKE_LOGGER_DEBUG("First Half IE convergence failed.");
+  } else {
+    // Swap the current output, xtplus, into xthalf, which functions as the new
+    // xⁿ.
+    std::swap(xtmp, *xtplus);
+    const VectorX<T>& xthalf = xtmp;
+
+    // Since the first half-step succeeded, either we recomputed a Jacobian at
+    // (t0, x0), or we reused an older Jacobian. Therefore, as far as the next
+    // half-sized step is concerned, the Jacobian is not at state
+    // (t+h/2, x(t+h/2)). Since jacobian_is_fresh_ means that the Jacobian is
+    // computed at the (t0,x0) of the beginning of the step we want to take, we
+    // mark it as not-fresh.
+    this->set_jacobian_is_fresh(false);
+
+    // TODO(antequ): One possible optimization is, if the Jacobian is fresh at
+    // this point, we can set a flag to cache the Jacobian if it gets
+    // recomputed, so that if the second substep fails, we simply restore the
+    // cached Jacobian instead of marking it stale. Since the second substep
+    // very rarely fails if the large step and the first substep succeeded,
+    // our tests indicates that this optimization saves only about 2% of the
+    // effort (0-5% in most cases), on a stiff 3-body pile of objects example.
+    // Therefore we omitted this optimization for code simplicity. See
+    // Revision 1 of PR 13224 for an implementation of this optimization.
+
+    success = StepImplicitEulerWithGuess(t0 + 0.5 * h, 0.5 * h, xthalf,
+        xtplus_ie, xtplus);
+    if (!success) {
+      DRAKE_LOGGER_DEBUG("Second Half IE convergence failed.");
+      // After a failure, the Jacobians were updated, so we have to mark that
+      // the current Jacobian is not fresh by setting
+      // failed_jacobian_is_from_second_small_step_ to true, so that at the
+      // beginning of the next step, we know to set jacobian_is_fresh_ to
+      // false, in DoImplicitIntegratorStep(). (Note that here we were slightly
+      // abusing the jacobian_is_fresh_ flag --- for the second half-sized step,
+      // we called MaybeFreshenMatrices() at t = t0 + h/2, meaning that
+      // jacobian_is_fresh_ now marks whether the Jacobian was last computed at
+      // t = t0 + h/2 instead of its usual definition of t = t0. This is why
+      // when the step fails, ImplicitIntegrator<T>::DoStep() will incorrectly
+      // mark the Jacobian as fresh, and we will need to fix this in
+      // DoImplicitIntegratorStep() for the next step.)
+      failed_jacobian_is_from_second_small_step_ = true;
+    }
+  }
+  // Move statistics to half-sized-implicit-Euler-specific statistics.
+  // Notice that we log the statistics even if either step fails.
+  hie_statistics_.num_jacobian_reforms +=
+      this->get_num_jacobian_evaluations() - stored_num_jacobian_evaluations;
+  hie_statistics_.num_iter_factorizations +=
+      this->get_num_iteration_matrix_factorizations() -
+      stored_num_iter_factorizations;
+  hie_statistics_.num_function_evaluations +=
+      this->get_num_derivative_evaluations() - stored_num_function_evaluations;
+  hie_statistics_.num_jacobian_function_evaluations +=
+      this->get_num_derivative_evaluations_for_jacobian() -
+      stored_num_jacobian_function_evaluations;
+  hie_statistics_.num_nr_iterations +=
+      this->get_num_newton_raphson_iterations() - stored_num_nr_iterations;
+
+  return success;
 }
 
 template <class T>
@@ -254,14 +352,16 @@ bool ImplicitEulerIntegrator<T>::StepImplicitTrapezoid(
   // Store statistics before calling StepAbstract(). The difference between
   // the modified statistics and the stored statistics will be used to compute
   // the trapezoid method-specific statistics.
-  int stored_num_jacobian_evaluations = this->get_num_jacobian_evaluations();
-  int stored_num_iter_factorizations =
+  const int stored_num_jacobian_evaluations =
+      this->get_num_jacobian_evaluations();
+  const int stored_num_iter_factorizations =
       this->get_num_iteration_matrix_factorizations();
-  int64_t stored_num_function_evaluations =
+  const int64_t stored_num_function_evaluations =
       this->get_num_derivative_evaluations();
-  int64_t stored_num_jacobian_function_evaluations =
+  const int64_t stored_num_jacobian_function_evaluations =
       this->get_num_derivative_evaluations_for_jacobian();
-  int stored_num_nr_iterations = this->get_num_newton_raphson_iterations();
+  const int stored_num_nr_iterations =
+      this->get_num_newton_raphson_iterations();
 
   // Attempt to step.
   bool success = StepAbstract(t0, h, xt0, g,
@@ -269,28 +369,29 @@ bool ImplicitEulerIntegrator<T>::StepImplicitTrapezoid(
                               xtplus_ie, &itr_iteration_matrix_, xtplus);
 
   // Move statistics to implicit trapezoid-specific.
-  num_err_est_jacobian_reforms_ +=
+  // Notice that we log the statistics even if the step fails.
+  itr_statistics_.num_jacobian_reforms +=
       this->get_num_jacobian_evaluations() - stored_num_jacobian_evaluations;
-  num_err_est_iter_factorizations_ +=
+  itr_statistics_.num_iter_factorizations +=
       this->get_num_iteration_matrix_factorizations() -
       stored_num_iter_factorizations;
-  num_err_est_function_evaluations_ +=
+  itr_statistics_.num_function_evaluations +=
       this->get_num_derivative_evaluations() - stored_num_function_evaluations;
-  num_err_est_jacobian_function_evaluations_ +=
+  itr_statistics_.num_jacobian_function_evaluations +=
       this->get_num_derivative_evaluations_for_jacobian() -
       stored_num_jacobian_function_evaluations;
-  num_err_est_nr_iterations_ += this->get_num_newton_raphson_iterations() -
-      stored_num_nr_iterations;
+  itr_statistics_.num_nr_iterations +=
+      this->get_num_newton_raphson_iterations() - stored_num_nr_iterations;
 
   return success;
 }
 
 template <class T>
 bool ImplicitEulerIntegrator<T>::AttemptStepPaired(const T& t0, const T& h,
-    const VectorX<T>& xt0, VectorX<T>* xtplus_ie, VectorX<T>* xtplus_itr) {
+    const VectorX<T>& xt0, VectorX<T>* xtplus_ie, VectorX<T>* xtplus_hie) {
   using std::abs;
   DRAKE_ASSERT(xtplus_ie);
-  DRAKE_ASSERT(xtplus_itr);
+  DRAKE_ASSERT(xtplus_hie);
 
   // Compute the derivative at time and state (t0, x(t0)). NOTE: the derivative
   // is calculated at this point (early on in the integration process) in order
@@ -306,33 +407,47 @@ bool ImplicitEulerIntegrator<T>::AttemptStepPaired(const T& t0, const T& h,
     return false;
   }
 
-  // The error estimation process uses the implicit trapezoid method, which
-  // is defined as:
-  // x(t0+h) = x(t0) + h/2 (f(t0, x(t0) + f(t0+h, x(t0+h))
-  // x(t0+h) from the implicit Euler method is presumably a good starting point.
-
-  // The error estimate is derived as follows (thanks to Michael Sherman):
-  // x*(t0+h) = xᵢₑ(t0+h) + O(h²)      [implicit Euler]
-  //          = xₜᵣ(t0+h) + O(h³)      [implicit trapezoid]
-  // where x*(t0+h) is the true (generally unknown) answer that we seek.
-  // This implies:
-  // xᵢₑ(t0+h) + O(h²) = xₜᵣ(t0+h) + O(h³).
-  // Given that the second order term subsumes the third order one, we have:
-  // xᵢₑ(t0+h) - xₜᵣ(t0+h) = O(h²).
-
-  // Attempt to compute the implicit trapezoid solution.
-  if (StepImplicitTrapezoid(t0, h, xt0, dx0, *xtplus_ie, xtplus_itr)) {
-    // Reset the state to that computed by implicit Euler.
-    // TODO(edrumwri): Explore using the implicit trapezoid method solution
-    //                 instead as *the* solution, rather than the implicit
-    //                 Euler. Refer to [Lambert, 1991], Ch 6.
-    Context<T>* context = this->get_mutable_context();
-    context->SetTimeAndContinuousState(t0 + h, *xtplus_ie);
-    return true;
+  if (!use_implicit_trapezoid_error_estimation_) {
+    // In this case, step two half-sized implicit Euler steps along
+    // with the full step for error estimation.
+    if (StepHalfSizedImplicitEulers(t0, h, xt0, *xtplus_ie, xtplus_hie)) {
+      Context<T>* context = this->get_mutable_context();
+      context->SetTimeAndContinuousState(t0 + h, *xtplus_hie);
+      return true;
+    } else {
+      DRAKE_LOGGER_DEBUG("Implicit Euler half-step approach FAILED with a step"
+          "size that succeeded on full-sized implicit Euler.");
+      return false;
+    }
   } else {
-    DRAKE_LOGGER_DEBUG("Implicit trapezoid approach FAILED with a step"
-        "size that succeeded on implicit Euler.");
-    return false;
+    // In this case, use the implicit trapezoid method, which is defined as:
+    // x(t0+h) = x(t0) + h/2 (f(t0, x(t0) + f(t0+h, x(t0+h))
+    // x(t0+h) from the implicit Euler method is presumably a good starting
+    // point.
+
+    // The error estimate is derived as follows (thanks to Michael Sherman):
+    // x*(t0+h) = xᵢₑ(t0+h) + O(h²)      [implicit Euler]
+    //          = xₜᵣ(t0+h) + O(h³)      [implicit trapezoid]
+    // where x*(t0+h) is the true (generally unknown) answer that we seek.
+    // This implies:
+    // xᵢₑ(t0+h) + O(h²) = xₜᵣ(t0+h) + O(h³).
+    // Given that the second order term subsumes the third order one, we have:
+    // xᵢₑ(t0+h) - xₜᵣ(t0+h) = O(h²).
+
+    // Attempt to compute the implicit trapezoid solution.
+    if (StepImplicitTrapezoid(t0, h, xt0, dx0, *xtplus_ie, xtplus_hie)) {
+      // Reset the state to that computed by implicit Euler.
+      // TODO(edrumwri): Explore using the implicit trapezoid method solution
+      //                 instead as *the* solution, rather than the implicit
+      //                 Euler. Refer to [Lambert, 1991], Ch 6.
+      Context<T>* context = this->get_mutable_context();
+      context->SetTimeAndContinuousState(t0 + h, *xtplus_ie);
+      return true;
+    } else {
+      DRAKE_LOGGER_DEBUG("Implicit trapezoid approach FAILED with a step"
+          "size that succeeded on implicit Euler.");
+      return false;
+    }
   }
 }
 
@@ -345,7 +460,26 @@ bool ImplicitEulerIntegrator<T>::DoImplicitIntegratorStep(const T& h) {
 
   xt0_ = context->get_continuous_state().CopyToVector();
   xtplus_ie_.resize(xt0_.size());
-  xtplus_tr_.resize(xt0_.size());
+  xtplus_hie_.resize(xt0_.size());
+
+  // If the most recent step failed only after the second small step, this
+  // indicates that the Jacobian was computed from the second small step, and
+  // not at (t0, xt0). ImplicitIntegrator<T>::DoStep() would have incorrectly
+  // marked the Jacobian as fresh, and so we must correct it by marking
+  // jacobian_is_fresh_ as false. (Note that this occurs because we were
+  // slightly abusing the jacobian_is_fresh_ flag --- for the second half-sized
+  // step, we called MaybeFreshenMatrices() at t = t0 + h/2, meaning that
+  // jacobian_is_fresh_ marked whether the Jacobian was last computed at
+  // t = t0 + h/2 instead of its usual definition of t = t0. This is why when
+  // the step failed, ImplicitIntegrator<T>::DoStep() would have incorrectly
+  // marked the Jacobian as fresh.)
+  if (failed_jacobian_is_from_second_small_step_) {
+    this->set_jacobian_is_fresh(false);
+
+    // Now that we've correctly set the jacobian_is_fresh_ flag, make sure that
+    // the failed_jacobian_is_from_second_small_step_ is reset back to false.
+    failed_jacobian_is_from_second_small_step_ = false;
+  }
 
   // If the requested h is less than the minimum step size, we'll advance time
   // using an explicit Euler step.
@@ -368,24 +502,40 @@ bool ImplicitEulerIntegrator<T>::DoImplicitIntegratorStep(const T& h) {
     xdot_ = this->EvalTimeDerivatives(*context).CopyToVector();
     xtplus_ie_ = xt0_ + h * xdot_;
 
-    // Compute the RK2 step.
-    const int evals_before_rk2 = rk2_->get_num_derivative_evaluations();
-    if (!rk2_->IntegrateWithSingleFixedStepToTime(t0 + h)) {
-      throw std::runtime_error("Embedded RK2 integrator failed to take a single"
-          "fixed step to the requested time.");
+    // Compute the RK2 or two half-sized Euler steps.
+    if (use_implicit_trapezoid_error_estimation_) {
+      // Compute the RK2 step
+      const int evals_before_rk2 = rk2_->get_num_derivative_evaluations();
+      if (!rk2_->IntegrateWithSingleFixedStepToTime(t0 + h)) {
+        throw std::runtime_error("Embedded RK2 integrator failed to take a"
+            "single fixed step to the requested time.");
+      }
+
+      const int evals_after_rk2 = rk2_->get_num_derivative_evaluations();
+      xtplus_hie_ = context->get_continuous_state().CopyToVector();
+
+      // Update the implicit Trapezoid ODE counts.
+      itr_statistics_.num_function_evaluations +=
+          (evals_after_rk2 - evals_before_rk2);
+
+      // Revert the state to that computed by explicit Euler.
+      context->SetTimeAndContinuousState(t0 + h, xtplus_ie_);
+    } else {
+      // complete two half-sized explicit Euler steps.
+      xtplus_hie_ = xt0_ + 0.5 * h * xdot_;
+      context->SetTimeAndContinuousState(t0 + 0.5 * h, xtplus_hie_);
+      xtplus_hie_ +=
+          0.5 * h * this->EvalTimeDerivatives(*context).CopyToVector();
+
+      // Update the half-sized step ODE counts.
+      ++(hie_statistics_.num_function_evaluations);
+
+      context->SetTimeAndContinuousState(t0 + h, xtplus_hie_);
     }
 
-    const int evals_after_rk2 = rk2_->get_num_derivative_evaluations();
-    xtplus_tr_ = context->get_continuous_state().CopyToVector();
-
-    // Update the error estimation ODE counts.
-    num_err_est_function_evaluations_ += (evals_after_rk2 - evals_before_rk2);
-
-    // Revert the state to that computed by explicit Euler.
-    context->SetTimeAndContinuousState(t0 + h, xtplus_ie_);
   } else {
     // Try taking the requested step.
-    bool success = AttemptStepPaired(t0, h, xt0_, &xtplus_ie_, &xtplus_tr_);
+    bool success = AttemptStepPaired(t0, h, xt0_, &xtplus_ie_, &xtplus_hie_);
 
     // If the step was not successful, reset the time and state.
     if (!success) {
@@ -395,7 +545,7 @@ bool ImplicitEulerIntegrator<T>::DoImplicitIntegratorStep(const T& h) {
   }
 
   // Compute and update the error estimate.
-  err_est_vec_ = xtplus_ie_ - xtplus_tr_;
+  err_est_vec_ = xtplus_ie_ - xtplus_hie_;
 
   // Update the caller-accessible error estimate.
   this->get_mutable_error_estimate()->get_mutable_vector().

--- a/systems/analysis/implicit_euler_integrator.h
+++ b/systems/analysis/implicit_euler_integrator.h
@@ -25,7 +25,7 @@ namespace systems {
  * equations to determine *both* the state at t+h and the time derivatives
  * of that state at that time. Cast as a nonlinear system of equations,
  * we seek the solution to:<pre>
- * x(t+h) - x(t) - h f(t+h,x(t+h)) = 0
+ * x(t+h) − x(t) − h f(t+h,x(t+h)) = 0
  * </pre>
  * given unknowns x(t+h).
  *
@@ -42,17 +42,60 @@ namespace systems {
  *
  * This implementation uses Newton-Raphson (NR) and relies upon the obvious
  * convergence to a solution for `g = 0` where
- * `g(x(t+h)) ≡ x(t+h) - x(t) - h f(t+h,x(t+h))` as `h` becomes sufficiently
- * small. It also uses the implicit trapezoid method- fed the result from
- * implicit Euler for (hopefully) faster convergence- to compute the error
- * estimate. General implementational details were gleaned from [Hairer, 1996].
+ * `g(x(t+h)) ≡ x(t+h) − x(t) − h f(t+h,x(t+h))` as `h` becomes sufficiently
+ * small. General implementational details for the Newton method were gleaned
+ * from Section IV.8 in [Hairer, 1996].
+ *
+ * ### Error Estimation
+ *
+ * In this integrator, we simultaneously take a large step at the requested
+ * step size of h as well as two half-sized steps each with step size `h/2`.
+ * The result from two half-sized steps is propagated as the solution, while
+ * the difference between the two results is used as the error estimate for the
+ * propagated solution. This error estimate is accurate to the second order.
+ *
+ * To be precise, let `x̅ⁿ⁺¹` be the computed solution from a large step,
+ * `x̃ⁿ⁺¹` be the computed solution from two small steps, and `xⁿ⁺¹` be the true
+ * solution. Since the integrator propagates `x̃ⁿ⁺¹` as its solution, we denote
+ * the true error vector as `ε = x̃ⁿ⁺¹ − xⁿ⁺¹`. %ImplicitEulerIntegrator uses
+ * `ε* = x̅ⁿ⁺¹ − x̃ⁿ⁺¹`, the difference between the two solutions, as the
+ * second-order error estimate, because for a smooth system, `‖ε*‖ = O(h²)`,
+ * and `‖ε − ε*‖ = O(h³)`. See the notes in get_error_estimate_order() for a
+ * detailed derivation of the error estimate's truncation error.
+ *
+ * In this implementation, %ImplicitEulerIntegrator attempts the large
+ * full-sized step before attempting the two small half-sized steps, because
+ * the large step is more likely to fail to converge, and if it is performed
+ * first, convergence failures are detected early, avoiding the unnecessary
+ * effort of computing potentially-successful small steps.
+ *
+ * Optionally, %ImplicitEulerIntegrator can instead use the implicit trapezoid
+ * method for error estimation. However, in our testing the step doubling method
+ * substantially outperforms the implicit trapezoid method.
  *
  * - [Hairer, 1996]   E. Hairer and G. Wanner. Solving Ordinary Differential
  *                    Equations II (Stiff and Differential-Algebraic Problems).
- *                    Springer, 1996.
+ *                    Springer, 1996, Section IV.8, p. 118–130.
  * - [Lambert, 1991]  J. D. Lambert. Numerical Methods for Ordinary Differential
  *                    Equations. John Wiley & Sons, 1991.
  *
+ * @note In the statistics reported by IntegratorBase, all statistics that deal
+ * with the number of steps or the step sizes will track the large full-sized
+ * steps. This is because the large full-sized `h` is the smallest irrevocable
+ * time-increment advanced by this integrator: if, for example, the second small
+ * half-sized step fails, this integrator revokes to the state before the first
+ * small step. This behavior is similar to other integrators with multi-stage
+ * evaluation: the step-counting statistics treat a "step" as the combination of
+ * all the stages.
+ * @note Furthermore, because the small half-sized steps are propagated as the
+ * solution, the large full-sized step is the error estimator, and the error
+ * estimation statistics track the effort during the large full-sized step. If
+ * the integrator is not in full-Newton mode (see
+ * ImplicitIntegrator::set_use_full_newton()), most of the work incurred by
+ * constructing and factorizing matrices and by failing Newton-Raphson
+ * iterations will be counted toward the error estimation statistics, because
+ * the large step is performed first.
+ * 
  * @note This integrator uses the integrator accuracy setting, even when run
  *       in fixed-step mode, to limit the error in the underlying Newton-Raphson
  *       process. See IntegratorBase::set_target_accuracy() for more info.
@@ -62,6 +105,11 @@ namespace systems {
  * @tparam_nonsymbolic_scalar
  * @ingroup integrators
  */
+
+// TODO(antequ): Investigate revamping the error estimation and normal
+// statistics so that the effort spent recomputing Jacobians and iteration
+// matrices near stiff steps is not overwhelmingly allocated into the error
+// estimator's statistics for Jacobian computations.
 template <class T>
 class ImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
  public:
@@ -73,41 +121,267 @@ class ImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
                                    Context<T>* context = nullptr)
       : ImplicitIntegrator<T>(system, context) {}
 
-  /// The integrator supports error estimation.
+  /**
+   * Returns true, because this integrator supports error estimation.
+   */
   bool supports_error_estimation() const final { return true; }
 
-  /// This first-order integrator uses embedded second order methods to compute
-  /// estimates of the local truncation error. The order of the asymptotic
-  /// difference between these two methods (from which the error estimate is
-  /// computed) is O(h²).
+  /**
+   * Returns the asymptotic order of the difference between the large and small
+   * steps (from which the error estimate is computed), which is 2. That is, the
+   * error estimate, `ε* = x̅ⁿ⁺¹ − x̃ⁿ⁺¹` has the property that `‖ε*‖ = O(h²)`,
+   * and it deviates from the true error, `ε`, by `‖ε − ε*‖ = O(h³)`. 
+   *
+   * ### Derivation of the asymptotic order
+   * 
+   * This derivation is based on the same derivation for
+   * VelocityImplicitEulerIntegrator, and so the equation numbers are from
+   * there.
+   *
+   * To derive the second-order error estimate, let us first define the
+   * vector-valued function `e(tⁿ, h, xⁿ) = x̅ⁿ⁺¹ − xⁿ⁺¹`, the local truncation
+   * error for a single, full-sized implicit Euler integration step, with
+   * initial conditions `(tⁿ, xⁿ)`, and a step size of `h`. Furthermore, use
+   * `ẍ` to denote `df/dt`, and `∇f` and `∇ẍ` to denote the Jacobians `df/dx`
+   * and `dẍ/dx` of the ODE system `ẋ = f(t, x)`. Note that `ẍ` uses a total
+   * time derivative, i.e., `ẍ = ∂f/∂t + ∇f f`.
+   *
+   * Let us use `x*` to denote the true solution after a half-step, `x(tⁿ+½h)`,
+   * and `x̃*` to denote the implicit Euler solution after a single
+   * half-sized step. Furthermore, let us use `xⁿ*¹` to denote the true solution
+   * of the system at time `t = tⁿ+h` if the system were at `x̃*` when
+   * `t = tⁿ+½h`. See the following diagram for an illustration.
+   *
+   *      Legend:
+   *      ───── propagation along the true system
+   *      :···· propagation using implicit Euler with a half step
+   *      :---- propagation using implicit Euler with a full step
+   *
+   *      Time  tⁿ         tⁿ+½h         tⁿ+h
+   *
+   *      State :----------------------- x̅ⁿ⁺¹  <─── used for error estimation
+   *            :
+   *            :
+   *            :
+   *            :            :·········· x̃ⁿ⁺¹  <─── propagated result
+   *            :            :
+   *            :·········  x̃*   ─────── xⁿ*¹
+   *            :
+   *            xⁿ ───────  x*   ─────── xⁿ⁺¹  <─── true solution
+   *
+   * We will use superscripts to denote evaluating an expression with `x` at
+   * that superscript and `t` at the corresponding time, e.g. `ẍⁿ` denotes
+   * `ẍ(tⁿ, xⁿ)`, and `f*` denotes `f(tⁿ+½h, x*)`. We first present a shortened
+   * derivation, followed by the longer, detailed version.
+   *
+   * We know the local truncation error for the implicit Euler method is:
+   *
+   *     e(tⁿ, h, xⁿ) = x̅ⁿ⁺¹ − xⁿ⁺¹ = ½ h²ẍⁿ + O(h³).                  (10)
+   *
+   * The local truncation error ε from taking two half steps is composed of
+   * these two terms:
+   *
+   *     e₁ = xⁿ*¹ − xⁿ⁺¹ = (1/8) h²ẍⁿ + O₁(h³),                       (15)
+   *     e₂ = x̃ⁿ⁺¹ − xⁿ*¹ = (1/8) h²ẍ* + O₂(h³) = (1/8) h²ẍⁿ + O₃(h³). (20)
+   *
+   * In the long derivation, we will show that these second derivatives
+   * differ by at most O(h³).
+   *
+   * Taking the sum,
+   *
+   *     ε = x̃ⁿ⁺¹ − xⁿ⁺¹ = e₁ + e₂ = (1/4) h²ẍⁿ + O(h³).               (21)
+   *
+   * These two estimations allow us to obtain an estimation of the local error
+   * from the difference between the available quantities x̅ⁿ⁺¹ and x̃ⁿ⁺¹:
+   *
+   *     ε* = x̅ⁿ⁺¹ − x̃ⁿ⁺¹ = e(tⁿ, h, xⁿ) − ε,
+   *                      = (1/4) h²ẍⁿ + O(h³),                        (22)
+   *
+   * and therefore our error estimate is second order.
+   *
+   * Below we will show this derivation in detail along with the proof that
+   * `‖ε − ε*‖ = O(h³)`:
+   *
+   * Let us look at a single implicit Euler step. Upon Newton-Raphson
+   * convergence, the truncation error for implicit Euler is
+   *
+   *     e(tⁿ, h, xⁿ) = ½ h²ẍⁿ⁺¹ + O(h³)
+   *                  = ½ h²ẍⁿ + O(h³).                                (10)
+   *
+   * To see why the two are equivalent, we can Taylor expand about `(tⁿ, xⁿ)`,
+   *
+   *     ẍⁿ⁺¹ = ẍⁿ + h dẍ/dtⁿ + O(h²) = ẍⁿ + O(h).
+   *     e(tⁿ, h, xⁿ) = ½ h²ẍⁿ⁺¹ + O(h³) = ½ h²(ẍⁿ + O(h)) + O(h³)
+   *                  = ½ h²ẍⁿ + O(h³).
+   *
+   * Moving on with our derivation, after one small half-sized implicit Euler
+   * step, the solution `x̃*` is
+   *
+   *     x̃* = x* + e(tⁿ, ½h, xⁿ)
+   *        = x* + (1/8) h²ẍⁿ + O(h³),
+   *     x̃* − x* = (1/8) h²ẍⁿ + O(h³).                                 (11)
+   *
+   * Taylor expanding about `t = tⁿ+½h` in this `x = x̃*` alternate reality,
+   *
+   *     xⁿ*¹ = x̃* + ½h f(tⁿ+½h, x̃*) + O(h²).                          (12)
+   *
+   * Similarly, Taylor expansions about `t = tⁿ+½h` and the true solution
+   * `x = x*` also give us
+   *
+   *     xⁿ⁺¹ = x* + ½h f* + O(h²),                                    (13)
+   *     f(tⁿ+½h, x̃*) = f* + (∇f*) (x̃* − x*) + O(‖x̃* − x*‖²)
+   *                  = f* + O(h²),                                    (14)
+   * where in the last line we substituted Eq. (11).
+   *
+   * Eq. (12) minus Eq. (13) gives us,
+   *
+   *     xⁿ*¹ − xⁿ⁺¹ = x̃* − x* + ½h(f(tⁿ+½h, x̃*) − f*) + O(h³),
+   *                 = x̃* − x* + O(h³),
+   * where we just substituted in Eq. (14). Finally, substituting in Eq. (11),
+   *
+   *     e₁ = xⁿ*¹ − xⁿ⁺¹ = (1/8) h²ẍⁿ + O(h³).                        (15)
+   *
+   * After the second small step, the solution `x̃ⁿ⁺¹` is
+   *
+   *     x̃ⁿ⁺¹ = xⁿ*¹ + e(tⁿ+½h, ½h, x̃*),
+   *          = xⁿ*¹ + (1/8)h² ẍ(tⁿ+½h, x̃*) + O(h³).                   (16)
+   *
+   * Taking Taylor expansions about `(tⁿ, xⁿ)`,
+   *
+   *     x* = xⁿ + ½h fⁿ + O(h²) = xⁿ + O(h).                          (17)
+   *     x̃* − xⁿ = (x̃* − x*) + (x* − xⁿ) = O(h),                       (18)
+   * where we substituted in Eqs. (11) and (17), and
+   *
+   *     ẍ(tⁿ+½h, x̃*) = ẍⁿ + ½h ∂ẍ/∂tⁿ + ∇ẍⁿ (x̃* − xⁿ) + O(h ‖x̃* − xⁿ‖)
+   *                  = ẍⁿ + O(h),                                     (19)
+   * where we substituted in Eq. (18).
+   *
+   * Substituting Eqs. (19) and (15) into Eq. (16),
+   *
+   *     x̃ⁿ⁺¹ = xⁿ*¹ + (1/8) h²ẍⁿ + O(h³)                              (20)
+   *          = xⁿ⁺¹ + (1/4) h²ẍⁿ + O(h³),
+   * therefore
+   *
+   *     ε = x̃ⁿ⁺¹ − xⁿ⁺¹ = (1/4) h² ẍⁿ + O(h³).                        (21)
+   *
+   * Subtracting Eq. (21) from Eq. (10),
+   *
+   *     e(tⁿ, h, xⁿ) − ε = (½ − 1/4) h²ẍⁿ + O(h³);
+   *     ⇒ ε* = x̅ⁿ⁺¹ − x̃ⁿ⁺¹ = (1/4) h²ẍⁿ + O(h³).                      (22)
+   *
+   * Eq. (22) shows that our error estimate is second-order. Since the first
+   * term on the RHS matches `ε` (Eq. (21)),
+   *
+   *     ε* = ε + O(h³).                                               (23)
+   */
   int get_error_estimate_order() const final { return 2; }
 
+  /**
+   * Set this to true to use implicit trapezoid for error estimation;
+   * otherwise this integrator will use step doubling for error estimation.
+   * By default this integrator will use step doubling.
+   */
+  void set_use_implicit_trapezoid_error_estimation(bool flag) {
+    use_implicit_trapezoid_error_estimation_ = flag;
+  }
+
+  /**
+   * Returns true if the integrator will use implicit trapezoid for error
+   * estimation; otherwise it indicates the integrator will use step doubling
+   * for error estimation.
+   */
+  bool get_use_implicit_trapezoid_error_estimation() {
+    return use_implicit_trapezoid_error_estimation_;
+  }
+
  private:
+  // These are statistics that the base class, ImplicitIntegrator, require
+  // this child class to keep track of.
+  struct Statistics {
+    // See ImplicitIntegrator::get_num_jacobian_evaluations() or
+    // ImplicitIntegrator::get_num_error_estimator_jacobian_evaluations()
+    // for the definition of this statistic.
+    int64_t num_jacobian_reforms{0};
+
+    // See ImplicitIntegrator::get_num_iteration_matrix_factorizations() or
+    // ImplicitIntegrator::
+    // get_num_error_estimator_iteration_matrix_factorizations() for the
+    // definition of this statistic.
+    int64_t num_iter_factorizations{0};
+
+    // See IntegratorBase::get_num_derivative_evaluations() or
+    // ImplicitIntegrator::get_num_error_estimator_derivative_evaluations()
+    // for the definition of this statistic. Note that, as the definitions
+    // state, this count also includes all the function evaluations counted in
+    // the statistic, num_jacobian_function_evaluations.
+    int64_t num_function_evaluations{0};
+
+    // See ImplicitIntegrator::get_num_derivative_evaluations_for_jacobian()
+    // or ImplicitIntegrator::
+    // get_num_error_estimator_derivative_evaluations_for_jacobian()
+    // for the definition of this statistic.
+    int64_t num_jacobian_function_evaluations{0};
+
+    // See ImplicitIntegrator::get_num_newton_raphson_iterations()
+    // or ImplicitIntegrator::
+    // get_num_error_estimator_newton_raphson_iterations() for the definition
+    // of this statistic.
+    int64_t num_nr_iterations{0};
+  };
+
   int64_t do_get_num_newton_raphson_iterations() const final {
     return num_nr_iterations_;
   }
 
   int64_t do_get_num_error_estimator_derivative_evaluations() const final {
-    return num_err_est_function_evaluations_;
+    // When implicit trapezoid is chosen, implicit trapezoid is the error
+    // estimator, and statistics for it are directly reported; otherwise, the
+    // small half-sized steps are propagated and the large step is the error
+    // estimator, so we report error estimator stats by subtracting those of
+    // the small half-sized steps from the total statistics.
+    return use_implicit_trapezoid_error_estimation_
+               ? itr_statistics_.num_function_evaluations
+               : (this->get_num_derivative_evaluations() -
+                  hie_statistics_.num_function_evaluations);
   }
 
   int64_t do_get_num_error_estimator_derivative_evaluations_for_jacobian()
       const final {
-    return num_err_est_jacobian_function_evaluations_;
+    // See the above comments in
+    // do_get_num_error_estimator_derivative_evaluations().
+    return use_implicit_trapezoid_error_estimation_
+               ? itr_statistics_.num_jacobian_function_evaluations
+               : (this->get_num_derivative_evaluations_for_jacobian() -
+                  hie_statistics_.num_jacobian_function_evaluations);
   }
 
   int64_t do_get_num_error_estimator_newton_raphson_iterations()
       const final {
-    return num_err_est_nr_iterations_;
+    // See the above comments in
+    // do_get_num_error_estimator_derivative_evaluations().
+    return use_implicit_trapezoid_error_estimation_
+               ? itr_statistics_.num_nr_iterations
+               : (this->get_num_newton_raphson_iterations() -
+                  hie_statistics_.num_nr_iterations);
   }
 
   int64_t do_get_num_error_estimator_jacobian_evaluations() const final {
-    return num_err_est_jacobian_reforms_;
+    // See the above comments in
+    // do_get_num_error_estimator_derivative_evaluations().
+    return use_implicit_trapezoid_error_estimation_
+               ? itr_statistics_.num_jacobian_reforms
+               : (this->get_num_jacobian_evaluations() -
+                  hie_statistics_.num_jacobian_reforms);
   }
 
   int64_t do_get_num_error_estimator_iteration_matrix_factorizations()
       const final {
-    return num_err_est_iter_factorizations_;
+    // See the above comments in
+    // do_get_num_error_estimator_derivative_evaluations().
+    return use_implicit_trapezoid_error_estimation_
+               ? itr_statistics_.num_iter_factorizations
+               : (this->get_num_iteration_matrix_factorizations() -
+                  hie_statistics_.num_iter_factorizations);
   }
 
   void DoResetCachedJacobianRelatedMatrices() final;
@@ -128,13 +402,13 @@ class ImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   // @param t0 the time at the left end of the integration interval.
   // @param h the integration step size to attempt.
   // @param xt0 the continuous state at t0.
-  // @param [out] xtplus_euler contains the Euler integrator solution (i.e.,
-  //              `x(t0+h)`) on return.
-  // @param [out] xtplus_trap contains the implicit trapezoid solution (i.e.,
-  //              `x(t0+h)`) on return.
+  // @param [out] xtplus_ie contains the full-sized step implicit Euler
+  //              integrator solution (i.e., `x(t0+h)`) on return.
+  // @param [out] xtplus_hie contains the half-sized step solution (i.e.,
+  //              `x(t0+h)`) on return, or the implicit Trapezoid solution.
   // @returns `true` if the step of size `h` was successful.
   bool AttemptStepPaired(const T& t0, const T& h, const VectorX<T>& xt0,
-      VectorX<T>* xtplus_euler, VectorX<T>* xtplus_trap);
+      VectorX<T>* xtplus_ie, VectorX<T>* xtplus_hie);
 
   // Performs the bulk of the stepping computation for both implicit Euler and
   // implicit trapezoid method; all those methods need to do is provide a
@@ -147,9 +421,10 @@ class ImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   // @param g the particular implicit function to compute the root of.
   // @param compute_and_factor_iteration_matrix the function for computing and
   //        factorizing the iteration matrix.
-  // @param xtplus_guess the starting guess for x(t0+h) -- implicit Euler passes
-  //        x(t0) since it has no better guess; implicit trapezoid passes
-  //        implicit Euler's result for x(t0+h).
+  // @param xtplus_guess the starting guess for x(t0+h) -- the full-sized step
+  //        of implicit Euler passes x(t0) since it has no better guess;
+  //        implicit Trapezoid and the half-sized steps of implicit Euler use
+  //        the result from the full-sized step of implicit Euler.
   // @param[out] iteration_matrix the iteration matrix to be used for the
   //             particular integration scheme (implicit Euler, implicit
   //             trapezoid), which will be computed and factored, if necessary.
@@ -158,7 +433,7 @@ class ImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   //        computationally expensive methods as the trial numbers increase.
   // @returns `true` if the method was successfully able to take an integration
   //           step of size h.
-  // @note The time and continuous state in the context are indeterminate upon
+  // @post The time and continuous state in the context are indeterminate upon
   //       exit.
   // TODO(edrumwri) Explicitly test this method's fallback logic (i.e., how it
   //                calls MaybeFreshenMatrices()) in a unit test).
@@ -186,10 +461,38 @@ class ImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   // @param xt0 the continuous state at t0.
   // @param[out] xtplus the computed value for `x(t0+h)` on successful return.
   // @returns `true` if the step of size `h` was successful.
-  // @note The time and continuous state in the context are indeterminate upon
+  // @post The time and continuous state in the context are indeterminate upon
   //       exit.
   bool StepImplicitEuler(const T& t0, const T& h, const VectorX<T>& xt0,
       VectorX<T>* xtplus);
+
+  // Steps the system forward by a single step of at most h using the implicit
+  // Euler method, starting with a guess for the state xtplus.
+  // @param t0 the time at the left end of the integration interval.
+  // @param h the maximum time increment to step forward.
+  // @param xt0 the continuous state at t0.
+  // @param xtplus_guess the starting guess for `x(t0+h)`.
+  // @param[out] xtplus the computed value for `x(t0+h)` on successful return.
+  // @returns `true` if the step of size `h` was successful.
+  // @post The time and continuous state in the context are indeterminate upon
+  //       exit.
+  bool StepImplicitEulerWithGuess(const T& t0, const T& h,
+      const VectorX<T>& xt0, const VectorX<T>& xtplus_guess,
+      VectorX<T>* xtplus);
+
+  // Steps forward by two steps of `h/2` using the implicit Euler
+  // method, if possible.
+  // @param t0 the time at the left end of the integration interval.
+  // @param h the maximum time increment to step forward.
+  // @param xt0 the continuous state at t0.
+  // @param xtplus_ie x(t0+h) computed by the implicit Euler method.
+  // @param[out] xtplus x(t0+h) computed by the two half-sized implicit Euler
+  //             steps on successful return.
+  // @returns `true` if the step was successful.
+  // @post The time and continuous state in the context are indeterminate upon
+  //       exit.
+  bool StepHalfSizedImplicitEulers(const T& t0, const T& h,
+      const VectorX<T>& xt0, const VectorX<T>& xtplus_ie, VectorX<T>* xtplus);
 
   // Steps forward by a single step of `h` using the implicit trapezoid
   // method, if possible.
@@ -201,7 +504,7 @@ class ImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   // @param[out] xtplus x(t0+h) computed by the implicit trapezoid method on
   //             successful return.
   // @returns `true` if the step was successful.
-  // @note The time and continuous state in the context are indeterminate upon
+  // @post The time and continuous state in the context are indeterminate upon
   //       exit.
   bool StepImplicitTrapezoid(const T& t0, const T& h, const VectorX<T>& xt0,
       const VectorX<T>& dx0, const VectorX<T>& xtplus_ie, VectorX<T>* xtplus);
@@ -220,21 +523,41 @@ class ImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
   std::unique_ptr<ContinuousState<T>> dx_state_;
 
   // Variables to avoid heap allocations.
-  VectorX<T> xt0_, xdot_, xtplus_ie_, xtplus_tr_;
-
-  // Various statistics.
-  int64_t num_nr_iterations_{0};
+  VectorX<T> xt0_, xdot_, xtplus_ie_, xtplus_hie_;
 
   // Second order Runge-Kutta method for estimating the integration error when
   // the requested step size lies below the working step size.
   std::unique_ptr<RungeKutta2Integrator<T>> rk2_;
 
-  // Implicit trapezoid specific statistics.
-  int64_t num_err_est_jacobian_reforms_{0};
-  int64_t num_err_est_iter_factorizations_{0};
-  int64_t num_err_est_function_evaluations_{0};
-  int64_t num_err_est_jacobian_function_evaluations_{0};
-  int64_t num_err_est_nr_iterations_{0};
+  // Various statistics.
+  // This statistic tracks the number of Newton-Raphson iterations total,
+  // combining the base implicit Euler and either the implicit Trapezoid
+  // or the half-sized implicit Eulers. This is used in ImplicitIntegrator::
+  // get_num_newton_raphson_iterations(). Other statistics integers for the
+  // total are defined in ImplicitIntegrator.
+  int64_t num_nr_iterations_{0};
+
+  // These track statistics specific to implicit trapezoid or the two half-
+  // sized steps. Only one of the following two will be used at a time, the
+  // other one will remain at 0 as long as
+  // use_implicit_trapezoid_error_estimation_ does not change.
+  Statistics itr_statistics_;
+  Statistics hie_statistics_;
+
+  // Since this integrator computes two small steps for its solution and
+  // simultaneously computes a large step to estimate the error, this is a
+  // flag to indicate that the failed Jacobian is not computed from the
+  // beginning of the time step, but rather from the second small step. Usually,
+  // the Jacobian after a failed step was computed from (t0,x0), so
+  // ImplicitIntegrator marks it as "fresh" so that the next attempt
+  // will not attempt to compute a Jacobian. This flag tells the next step that
+  // the Jacobian is still not "fresh", or computed from (t0,x0) at the
+  // beginning of the step, even after the step has failed.
+  bool failed_jacobian_is_from_second_small_step_{false};
+
+  // If set to true, the integrator uses implicit trapezoid instead of two
+  // half-sized steps for error estimation.
+  bool use_implicit_trapezoid_error_estimation_{false};
 };
 
 }  // namespace systems

--- a/systems/analysis/implicit_integrator.cc
+++ b/systems/analysis/implicit_integrator.cc
@@ -325,6 +325,10 @@ const MatrixX<T>& ImplicitIntegrator<T>::CalcJacobian(const T& t,
   // Reset the time and state.
   context->SetTimeAndContinuousState(t_current, x_current);
 
+  // Mark the Jacobian as fresh, so that we don't recompute it unnecessarily
+  // during the step.
+  jacobian_is_fresh_ = true;
+
   return J_;
 }
 
@@ -366,6 +370,16 @@ bool ImplicitIntegrator<T>::MaybeFreshenMatrices(
 
   // Reuse is activated, Jacobian is fully sized, and Jacobian is not "bad".
   // If the iteration matrix has not been set and factored, do only that.
+  // In most cases, the iteration matrix is already factorized if the Jacobian
+  // has been properly computed. However, one example where this code block
+  // might be triggered would be if the child integrator uses the same Jacobian,
+  // but two different iteration matrices, for two methods, such as implicit
+  // Euler with implicit Trapezoid error estimation. During the first implicit
+  // Euler step, the Jacobian is computed and the implicit Euler matrix is
+  // factorized. Afterwards, during the first implicit Trapezoid step,
+  // the Jacobian (which it shares with implicit Euler) is fresh, but the
+  // implicit Trapezoid iteration matrix is not factorized, and so this block
+  // of code will factorize it.
   if (!iteration_matrix->matrix_factored()) {
     ++num_iter_factorizations_;
     compute_and_factor_iteration_matrix(J, h, iteration_matrix);
@@ -376,25 +390,50 @@ bool ImplicitIntegrator<T>::MaybeFreshenMatrices(
     case 1:
       // For the first trial, we do nothing: this will cause the Newton-Raphson
       // process to use the last computed (and already factored) iteration
-      // matrix.
+      // matrix. This matrix may be from a previous time-step or a previously-
+      // attempted step size.
       return true;  // Indicate success.
 
     case 2: {
-      // For the second trial, we perform the (likely) next least expensive
-      // operation, re-constructing and factoring the iteration matrix.
+      // For the second trial, we know the first trial, which uses the last
+      // computed iteration matrix, has already failed. The last computed
+      // iteration matrix may be from many time steps ago, or it may be from a
+      // different step size. We perform the (likely) next least expensive
+      // operation, which is re-constructing and factoring the iteration
+      // matrix, using the last computed Jacobian. The last computed Jacobian
+      // may also be from many time steps ago, or it may be from a previously-
+      // attempted step size.
+      // TODO(antequ): In two particular cases, this may compute the same
+      // iteration matrix twice. Currently they are rare and unimportant, but
+      // in the future, it may be worth it to investigate optimizing these two
+      // cases if they make a performance difference:
+      // 1. During the first time step of the simulation, trial 1 will compute
+      // the initial iteration matrix, and trial 2 will compute the same
+      // iteration matrix again if trial 1 fails.
+      // 2. For implicit Euler with step doubling, it is possible that trial 3
+      // gets triggered on the first small step, which then fails, and after the
+      // step size is halved, trial 2 is triggered on the first large step,
+      // which requires the same iteration matrix (so the matrix is correct
+      // and does not actually need recomputation).
+      // In both cases, the right thing to do would be to skip to trial 3.
       ++num_iter_factorizations_;
       compute_and_factor_iteration_matrix(J, h, iteration_matrix);
       return true;
     }
 
     case 3: {
-      // For the third trial, the Jacobian matrix may already be "fresh",
-      // meaning that there is nothing more that can be tried (Jacobian and
-      // iteration matrix are both fresh) and we need to indicate failure.
+      // For the third trial, we know that the first two trials, which
+      // exhausted all our options short of recomputing the Jacobian, have
+      // failed.
+
+      // The Jacobian matrix may already be "fresh", meaning that there is
+      // nothing more that can be tried (Jacobian and iteration matrix are both
+      // fresh), and we need to indicate failure.
       if (jacobian_is_fresh_)
         return false;
 
-      // Reform the Jacobian matrix and refactor the iteration matrix.
+      // Otherwise, we can reform the Jacobian matrix and refactor the
+      // iteration matrix.
       J = CalcJacobian(t, xt);
       ++num_iter_factorizations_;
       compute_and_factor_iteration_matrix(J, h, iteration_matrix);

--- a/systems/analysis/test/radau_integrator_test.cc
+++ b/systems/analysis/test/radau_integrator_test.cc
@@ -223,6 +223,10 @@ GTEST_TEST(RadauIntegratorTest, Radau1MatchesImplicitEuler) {
                                              context_radau1.get());
   ImplicitEulerIntegrator<double> ie(spring_damper, context_ie.get());
 
+  // Tell IE to use implicit trapezoid for error estimation to match
+  // Radau1.
+  ie.set_use_implicit_trapezoid_error_estimation(true);
+
   // Ensure that both integrators support error estimation.
   EXPECT_TRUE(radau1.supports_error_estimation());
   EXPECT_TRUE(ie.supports_error_estimation());


### PR DESCRIPTION
This PR implements Implicit Euler with step doubling for error estimation. This change is very similar to error estimation for Velocity-Implicit Euler (VIE) Integrator, and if Evan has time, it would be great if he can review the high-level decisions made here. The VIE step-doubling error estimation is well-documented here, and the same documentation will apply for Implicit Euler: https://drake.mit.edu/doxygen_cxx/classdrake_1_1systems_1_1_velocity_implicit_euler_integrator.html

Brief justification:
After running some tests with a pile of 3 objects and typical friction parameters, we found that step doubling works much better than implicit Trapezoid (IE+ITR) error estimation from the master branch. Under various accuracy settings (using a large max time step), IE+ITR performs very inconsistently, e.g. for one test, an accuracy of 0.1 takes 236423 derivative evaluations, while an accuracy of 0.099 takes only 82392. In most of these cases, step doubling is very consistent, achieving about 3x the performance of IE+ITR in the average case, 7-9x in the worst IE+ITR cases, and still 1.03x faster in the best IE+ITR case that I tested.
I suspect that the main reasons step doubling works better are:
1) IE with small steps is very likely to converge, after the big step already succeeded.
2) The same Jacobian can be used for both the big and small steps, and recomputed Jacobians are not wasted.

Some more important details about this change, which may be hard to understand from the code alone:

The major change from VIE's implementation is that Implicit Euler takes advantage of marking a Jacobian as "fresh" after a failed step, and never recomputing the Jacobian as it shrinks step sizes. The problem is, now, after it succeeds on the large step and the first small step, there is a rare (but nonzero) probability that it fails on the second small step, computing the Jacobian at a state that is not xt0. (In a stiff simulation of about 2000 steps with about 2000-4000 convergence-based failures, this scenario will occur maybe about ~20 times.) Based on some thought (and confirmed by experimentation), I've proposed a set of small changes that captures the performance gains of marking the Jacobian as "fresh" without triggering too much extra overhead. Note that this is much simpler than the first revision of the PR (I've removed a lot of caching logic which only improves performance by 2%, and replaced it with a TODO, as Sherm suggested):
1. After the Jacobian is computed, it is immediately marked as "fresh" (set_jacobian_is_fresh(true)).
2. Before starting the second step, we mark the Jacobian as "not fresh" (set_jacobian_is_fresh(false)). This way MaybeFreshenMatrices will recompute the Jacobian if the second small step is needed.
3. If the second small step actually fails, then we set a flag (failed_jacobian_is_from_second_small_step_) to indicate that in the next step, the Jacobian is NOT fresh, even though ImplicitIntegrator::DoStep() marks it as fresh.

This set of changes incurs minimal expenses during successful steps (only setting booleans), and it only forces the Jacobian to be recomputed again if the second small step actually fails. 

More justification:

Running Alejandro's difficult, 3-object pile-of-objects example, these are the resulting number of derivative evaluations:
https://docs.google.com/spreadsheets/d/12BSupktPFpbaTW2UbKaYLgUTAAF8upexcOAHXOjjJVI/edit?usp=sharing

All these rans ran it for 0.8 seconds, with maximum time step size 0.2.


Integrator: | IE (master, 6/5) |   | IE (PR #13224, 6/5) |  
-- | -- | -- | -- | --
  | Nsteps | Nderivatives | Nsteps | Nderivatives
Accuracy |   |   |   |  
0.5 | objects fly out |   | 1283 | 84686
0.25 | objects fly out |   | 1501 | 97803
0.2 | objects fly out |   | 1424 | 92206
0.15 | 2201 | 141691 | 1257 | 82922
0.13 | 1770 | 95981 | 1158 | 73327
0.11 | 1887 | 103152 | 1343 | 85775
0.1 | 2512 | 158336 | 1168 | 77289
0.099 | 2136 | 114818 | 1250 | 80553
0.094 | objects fly out |   | 1191 | 75051
0.06 | objects fly out |   | 1310 | 81758
0.03 | 2054 | 102249 | 1366 | 79836
0.01 | 21697 | 938885 | 1665 | 84754
0.005 | 29998 | 728335 | 2116 | 91576
0.002 | 51585 | 887838 | 3311 | 113554
0.001 | 224595 | 2094390 | 4360 | 129234



For almost all examples, the step doubling performed better (often much better) than trapezoid (master), and much more consistently.

Running the simple gripper example for two accuracies, these are the number of derivative evaluations:

bazel run //examples/simple_gripper:simple_gripper -- --mbp_discrete_update_period=0 --simulator_integration_scheme=implicit_euler --simulator_use_error_control=true --simulator_max_time_step=0.1 --simulator_accuracy=0.03

step doubling, 12318 derivative evals
trapezoid, 22757 derivative evals

bazel run //examples/simple_gripper:simple_gripper -- --mbp_discrete_update_period=0 --simulator_integration_scheme=implicit_euler --simulator_use_error_control=true --simulator_max_time_step=0.1 --simulator_accuracy=0.005

step doubling, 32185 derivative evals
trapezoid, 35555 derivative evals

When the accuracy is loose, step doubling performs much better.

Evan's suggestion of running all the tests in drake resulted in inconclusive results since runtime was dominated by the pydrake tests triggered by the simulator changes. I tried limiting it to just multibody and systems/analysis tests, and the new Implicit Euler appeared slightly better than the old implicit Euler (by 5% average runtime), but it's hard to say because those tests do not stress test this integrator, and timing produces results that vary per run.

-----------------------------------
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13224)
<!-- Reviewable:end -->
