### PR TITLE
pydrake: Resolve RTTI inconsistency on macOS, restore pydrake Value move

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -166,6 +166,7 @@ drake_pybind_library(
         "//bindings/pydrake/common:cpp_template_pybind",
         "//bindings/pydrake/common:default_scalars_pybind",
         "//bindings/pydrake/common:type_pack",
+        "//bindings/pydrake/common:value_pybind",
     ],
     cc_srcs = ["math_py.cc"],
     package_info = PACKAGE_INFO,
@@ -174,6 +175,7 @@ drake_pybind_library(
         "//bindings/pydrake:autodiffutils_py",
         "//bindings/pydrake:symbolic_py",
         "//bindings/pydrake/common:eigen_geometry_py",
+        "//bindings/pydrake/common:value_py",
     ],
     py_srcs = ["_math_extra.py"],
 )
@@ -188,7 +190,7 @@ drake_pybind_library(
     package_info = PACKAGE_INFO,
     py_deps = [
         ":module_py",
-        "//bindings/pydrake/systems:framework_py",
+        "//bindings/pydrake/common:value_py",
         "//bindings/pydrake/systems:sensors_py",
     ],
 )

--- a/bindings/pydrake/__init__.py
+++ b/bindings/pydrake/__init__.py
@@ -77,6 +77,23 @@ def _setattr_kwargs(obj, kwargs):
         setattr(obj, name, value)
 
 
+def _import_cc_module_vars(cc_module, py_module_name):
+    # Imports the cc_module's public symbols into the named py module
+    # (py_module_name), resetting their __module__ to be the py module in the
+    # process.
+    # Returns a list[str] of the public symbol names imported.
+    py_module = sys.modules[py_module_name]
+    var_list = []
+    for name, value in cc_module.__dict__.items():
+        if name.startswith("_"):
+            continue
+        if getattr(value, "__module__", None) == cc_module.__name__:
+            value.__module__ = py_module_name
+        setattr(py_module, name, value)
+        var_list.append(name)
+    return var_list
+
+
 class _DrakeImportWarning(Warning):
     pass
 

--- a/bindings/pydrake/attic/systems/test/sensors_test.py
+++ b/bindings/pydrake/attic/systems/test/sensors_test.py
@@ -7,13 +7,14 @@ import numpy as np
 
 from pydrake.common import FindResourceOrThrow
 from pydrake.common.eigen_geometry import Isometry3
+from pydrake.common.value import Value
 from pydrake.attic.multibody.rigid_body_tree import (
     AddModelInstancesFromSdfString,
     FloatingBaseType,
     RigidBodyTree,
     RigidBodyFrame,
 )
-from pydrake.systems.framework import InputPort, OutputPort, Value
+from pydrake.systems.framework import InputPort, OutputPort
 
 
 class TestSensors(unittest.TestCase):

--- a/bindings/pydrake/common/BUILD.bazel
+++ b/bindings/pydrake/common/BUILD.bazel
@@ -140,8 +140,9 @@ drake_cc_library(
 drake_pybind_library(
     name = "value_py",
     cc_deps = [
+        ":cpp_param_pybind",
+        ":value_pybind",
         "//bindings/pydrake:documentation_pybind",
-        "//bindings/pydrake/common:value_pybind",
     ],
     cc_so_name = "value",
     cc_srcs = ["value_py.cc"],
@@ -182,6 +183,7 @@ drake_cc_library(
     declare_installed_headers = 0,
     visibility = ["//visibility:public"],
     deps = [
+        ":wrap_pybind",
         "//:drake_shared_library",
         "//bindings/pydrake:pydrake_pybind",
     ],
@@ -216,6 +218,7 @@ drake_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":type_pack",
+        ":wrap_pybind",
         "//bindings/pydrake:pydrake_pybind",
         "@pybind11",
     ],

--- a/bindings/pydrake/common/BUILD.bazel
+++ b/bindings/pydrake/common/BUILD.bazel
@@ -45,9 +45,13 @@ drake_pybind_library(
     name = "_init_py",
     cc_deps = [
         "//bindings/pydrake:documentation_pybind",
+        "//bindings/pydrake/common:deprecation_pybind",
+        "//bindings/pydrake/common:value_pybind",
     ],
     cc_so_name = "_module_py",
-    cc_srcs = ["module_py.cc"],
+    cc_srcs = [
+        "module_py.cc",
+    ],
     package_info = PACKAGE_INFO,
     py_srcs = [
         "__init__.py",
@@ -133,6 +137,21 @@ drake_cc_library(
     ],
 )
 
+drake_pybind_library(
+    name = "value_py",
+    cc_deps = [
+        "//bindings/pydrake:documentation_pybind",
+        "//bindings/pydrake/common:value_pybind",
+    ],
+    cc_so_name = "value",
+    cc_srcs = ["value_py.cc"],
+    package_info = PACKAGE_INFO,
+    py_deps = [
+        ":module_py",
+        ":cpp_template_py",
+    ],
+)
+
 # N.B. Any C++ libraries that include this must include `cpp_template_py` when
 # being used in Python.
 drake_cc_library(
@@ -175,12 +194,14 @@ drake_pybind_library(
         ":default_scalars_pybind",
         ":eigen_geometry_pybind",
         ":type_pack",
+        ":value_pybind",
     ],
     cc_srcs = ["eigen_geometry_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
         ":module_py",
         ":cpp_template_py",
+        ":value_py",
         "//bindings/pydrake:autodiffutils_py",
         "//bindings/pydrake:symbolic_py",
     ],
@@ -290,6 +311,7 @@ drake_py_library(
 PY_LIBRARIES_WITH_INSTALL = [
     ":_init_py",
     ":eigen_geometry_py",
+    ":value_py",
 ]
 
 PY_LIBRARIES = [
@@ -515,10 +537,31 @@ drake_py_unittest(
 )
 
 drake_pybind_library(
+    name = "value_test_util_py",
+    testonly = 1,
+    add_install = False,
+    cc_deps = [":value_pybind"],
+    cc_so_name = "test/value_test_util",
+    cc_srcs = ["test/value_test_util_py.cc"],
+    package_info = PACKAGE_INFO,
+    visibility = ["//visibility:private"],
+)
+
+drake_py_unittest(
+    name = "value_test",
+    deps = [
+        ":module_py",
+        ":value_py",
+        ":value_test_util_py",
+    ],
+)
+
+drake_pybind_library(
     name = "wrap_test_util_py",
     testonly = 1,
     add_install = False,
     cc_deps = [":wrap_pybind"],
+    cc_so_name = "test/wrap_test_util",
     cc_srcs = ["test/wrap_test_util_py.cc"],
     package_info = PACKAGE_INFO,
     visibility = ["//visibility:private"],

--- a/bindings/pydrake/common/all.py
+++ b/bindings/pydrake/common/all.py
@@ -6,6 +6,7 @@ from .containers import *
 # - `cpp_template` does not offer public Drake symbols.
 # - `deprecation` does not offer public Drake symbols.
 from .eigen_geometry import *
+from .value import *
 # N.B. Since this is generic and relatively scoped, we import the module as a
 # symbol.
 from . import pybind11_version

--- a/bindings/pydrake/common/cpp_param_pybind.h
+++ b/bindings/pydrake/common/cpp_param_pybind.h
@@ -10,11 +10,83 @@
 #include "pybind11/pybind11.h"
 
 #include "drake/bindings/pydrake/common/type_pack.h"
+#include "drake/bindings/pydrake/common/wrap_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 
 namespace drake {
 namespace pydrake {
+
+/// Provides a publicly visible, but minimal, re-implementation of `py::object`
+/// so that a public type can be used with `drake::Value<T>`, while still
+/// maintaining the revelant semantics with its generic implementation (#13207).
+/// This should *only* be used in place of `py::object` for public APIs that
+/// rely on RTTI (e.g. `typeid`).
+/// See implementation of `class object` in pybind11/include/pybind11/pytypes.h.
+class Object {
+ public:
+  Object() {}
+
+  /// Decrements reference count (if pointing to a real object).
+  ~Object();
+
+  /// Constructs from raw pointer, incrementing the reference count.
+  /// @note This does not implement any of the `py::reinterpret_borrow<>`
+  /// semantics.
+  explicit Object(::PyObject* ptr);
+
+  /// Constructs from another Object, incrementing the reference count.
+  explicit Object(const Object& other);
+
+  /// Steals object (and reference count) from another Object.
+  Object(Object&& other);
+
+  /// Copies object reference and increments reference count.
+  Object& operator=(const Object& other);
+
+  /// Steals object (and reference count) from another Object.
+  Object& operator=(Object&& other);
+
+  /// Accesses raw PyObject pointer (no reference counting).
+  ::PyObject* ptr() const { return ptr_; }
+
+  /// Converts to a pybind11 Python type, using py::reinterpret_borrow.
+  template <typename T>
+  T to_pyobject() const {
+    return py::reinterpret_borrow<T>(ptr());
+  }
+
+  /// Converts from a pybind11 Python type, using py::reinterpret_borrow.
+  template <typename T>
+  static Object from_pyobject(const T& h) {
+    return Object(h.ptr());
+  }
+
+ private:
+  // Increments reference count. See `py::handle::inc_ref()` for more details.
+  void inc_ref();
+
+  // Decrements reference count. See `py::handle::dec_ref()` for more details.
+  void dec_ref();
+
+  ::PyObject* ptr_{};
+};
+
 namespace internal {
+
+// Wrapper for Object.
+struct wrapper_pydrake_object {
+  using Type = Object;
+  static constexpr auto original_name = py::detail::_("pydrake::Object");
+  using WrappedType = py::object;
+  static constexpr auto wrapped_name = py::detail::_("object");
+
+  static Object unwrap(const py::object& obj) {
+    return Object::from_pyobject(obj);
+  }
+  static py::object wrap(const Object& obj) {
+    return obj.to_pyobject<py::object>();
+  }
+};
 
 // Gets singleton for type aliases from `cpp_param`.
 py::object GetParamAliases();
@@ -27,6 +99,9 @@ py::object GetPyParamScalarImpl(const std::type_info& tinfo);
 // Gets Python type for a C++ type (base case).
 template <typename T>
 inline py::object GetPyParamScalarImpl(type_pack<T> = {}) {
+  static_assert(!py::detail::is_pyobject<T>::value,
+      "You cannot use `pybind11` types (e.g. `py::object`). Use a publicly "
+      "visible replacement type instead, please.");
   return GetPyParamScalarImpl(typeid(T));
 }
 
@@ -43,6 +118,12 @@ inline py::object GetPyParamScalarImpl(
 /// @returns Python tuple of canonical parameters.
 /// @throws std::runtime_error on the first type it encounters that is neither
 /// aliased nor registered in `pybind11`.
+/// @tparam Ts The types to get C++ types for.
+/// @pre Ts must be public symbols.
+/// @pre Ts cannot be a `py::` symbol (e.g. `py::object`). On Mac, this may
+/// cause failure depending on import order (e.g. trying to use
+/// `Value<py::object>` between different modules). See #8704 and #13207 for
+/// more details.
 template <typename... Ts>
 inline py::tuple GetPyParam(type_pack<Ts...> = {}) {
   return py::make_tuple(internal::GetPyParamScalarImpl(type_pack<Ts>{})...);
@@ -50,3 +131,14 @@ inline py::tuple GetPyParam(type_pack<Ts...> = {}) {
 
 }  // namespace pydrake
 }  // namespace drake
+
+namespace pybind11 {
+namespace detail {
+
+template <>
+struct type_caster<drake::pydrake::Object>
+    : public drake::pydrake::internal::type_caster_wrapped<
+          drake::pydrake::internal::wrapper_pydrake_object> {};
+
+}  // namespace detail
+}  // namespace pybind11

--- a/bindings/pydrake/common/deprecation.py
+++ b/bindings/pydrake/common/deprecation.py
@@ -20,6 +20,8 @@ import warnings
 
 # TODO(eric.cousineau): Make autocomplete ignore `ModuleShim` attributes
 # (e.g. `install`).
+# TODO(eric.cousineau): Remove ModuleShim once Drake requires Python >= 3.7
+# (for PEP 562).
 
 
 class ModuleShim(object):
@@ -30,6 +32,14 @@ class ModuleShim(object):
 
     See Also:
         https://stackoverflow.com/a/7668273/7829525
+
+    Note:
+        This is not necessary in Python >= 3.7 due to PEP 562.
+    Warning:
+        This will not work if called on a cc module during import (e.g. using
+        ExecuteExtraPythonCode). Instead, you should rename the module from
+        `{name}` to `_{name}`, and import the symbols into the new module using
+        _import_cc_module_vars.
     """
 
     def __init__(self, orig_module, handler):

--- a/bindings/pydrake/common/eigen_geometry_py.cc
+++ b/bindings/pydrake/common/eigen_geometry_py.cc
@@ -7,6 +7,7 @@
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/eigen_geometry_pybind.h"
 #include "drake/bindings/pydrake/common/type_pack.h"
+#include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/common/drake_assertion_error.h"
 #include "drake/common/drake_throw.h"
@@ -185,6 +186,9 @@ void DoScalarDependentDefinitions(py::module m, T) {
     py::implicitly_convertible<Matrix4<T>, Class>();
     DefCopyAndDeepCopy(&cls);
     DefCast<T>(&cls, kCastDoc);
+    // TODO(eric): Consider deprecating / removing `Value[Isometry3]` pending
+    // resolution of #9865.
+    AddValueInstantiation<Isometry3<T>>(m);
   }
 
   // Quaternion.

--- a/bindings/pydrake/common/eigen_geometry_pybind.h
+++ b/bindings/pydrake/common/eigen_geometry_pybind.h
@@ -13,71 +13,12 @@
 #include <Eigen/Dense>
 #include "pybind11/eigen.h"
 
+#include "drake/bindings/pydrake/common/wrap_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
-#include "drake/common/drake_assert.h"
 
 namespace drake {
 namespace pydrake {
 namespace internal {
-
-// Implements a `type_caster<>` specialization used to convert types using a
-// specific wrapping policy.
-// @tparam Wrapper
-//  Struct which must provide `Type`, `WrappedType`, `unwrap`, and `wrap`.
-// @tparam copy_only
-//  This may only pass between C++ and Python as copies, not references.
-// See `eigen_wrapper_*` structs below for more details.
-template <typename Wrapper>
-struct type_caster_wrapped {
-  using Type = typename Wrapper::Type;
-  using WrappedType = typename Wrapper::WrappedType;
-  using WrappedTypeCaster = py::detail::type_caster<WrappedType>;
-
-  // Python to C++.
-  bool load(py::handle src, bool converter) {
-    WrappedTypeCaster caster;
-    if (!caster.load(src, converter)) {
-      return false;
-    }
-    value_ = Wrapper::unwrap(caster.operator WrappedType&());
-    loaded_ = true;
-    return true;
-  }
-
-  // See `pybind11/eigen.h`, `type_caster<>` implementations.
-  // N.B. Do not use `PYBIND11_TYPE_CASTER(...)` so we can avoid casting
-  // garbage values.
-  operator Type&() {
-    DRAKE_DEMAND(loaded_);
-    return value_;
-  }
-  template <typename T>
-  using cast_op_type = py::detail::movable_cast_op_type<T>;
-  static constexpr auto name = WrappedTypeCaster::props::descriptor;
-
-  // C++ to Python.
-  template <typename TType>
-  static py::handle cast(
-      TType&& src, py::return_value_policy policy, py::handle parent) {
-    if (policy == py::return_value_policy::reference ||
-        policy == py::return_value_policy::reference_internal) {
-      // N.B. We must declare a local `static constexpr` here to prevent
-      // linking errors. This does not appear achievable with
-      // `constexpr char[]`, so we use `py::detail::descr`.
-      // See `pybind11/pybind11.h`, `cpp_function::initialize(...)` for an
-      // example.
-      static constexpr auto original_name = Wrapper::original_name;
-      throw py::cast_error(
-          std::string("Can only pass ") + original_name.text + " by value.");
-    }
-    return WrappedTypeCaster::cast(
-        Wrapper::wrap(std::forward<TType>(src)), policy, parent);
-  }
-
- private:
-  bool loaded_{false};
-  Type value_;
-};
 
 // Wrapper for Eigen::Translation<>, to be used as first parameter to
 // `type_caster_wrapped`.
@@ -86,8 +27,11 @@ struct type_caster_wrapped {
 template <typename T, int Dim>
 struct wrapper_eigen_translation {
   using Type = Eigen::Translation<T, Dim>;
-  using WrappedType = Eigen::Matrix<T, Dim, 1>;
   static constexpr auto original_name = py::detail::_("Eigen::Translation<>");
+  using WrappedType = Eigen::Matrix<T, Dim, 1>;
+  static constexpr auto wrapped_name =
+      py::detail::type_caster<WrappedType>::props::descriptor;
+
   static Type unwrap(const WrappedType& arg_wrapped) {
     return Type(arg_wrapped);
   }

--- a/bindings/pydrake/common/module_py.cc
+++ b/bindings/pydrake/common/module_py.cc
@@ -26,6 +26,7 @@ void trigger_an_assertion_failure() {
 }  // namespace
 
 PYBIND11_MODULE(_module_py, m) {
+  PYDRAKE_PREVENT_PYTHON3_MODULE_REIMPORT(m);
   m.doc() = "Bindings for //common:common";
 
   constexpr auto& doc = pydrake_doc.drake;

--- a/bindings/pydrake/common/test/cpp_param_pybind_test.cc
+++ b/bindings/pydrake/common/test/cpp_param_pybind_test.cc
@@ -43,7 +43,8 @@ GTEST_TEST(CppParamTest, PrimitiveTypes) {
   ASSERT_TRUE(CheckPyParam<int>("int,"));
   ASSERT_TRUE(CheckPyParam<uint32_t>("np.uint32,"));
   ASSERT_TRUE(CheckPyParam<int64_t>("np.int64,"));
-  ASSERT_TRUE(CheckPyParam<py::object>("object,"));
+  // N.B. CheckPyParam<py::object>(...) should cause a compile-time failure.
+  ASSERT_TRUE(CheckPyParam<Object>("object,"));
 }
 
 // Dummy type.

--- a/bindings/pydrake/common/test/eigen_geometry_test.py
+++ b/bindings/pydrake/common/test/eigen_geometry_test.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from pydrake.autodiffutils import AutoDiffXd
 from pydrake.symbolic import Expression
+from pydrake.common.value import Value
 import pydrake.common.test.eigen_geometry_test_util as test_util
 from pydrake.common.test_utilities import numpy_compare
 from pydrake.common.test_utilities.deprecation import catch_drake_warnings
@@ -271,3 +272,8 @@ class TestEigenGeometry(unittest.TestCase):
             return np.hstack((value.angle(), value.axis()))
 
         assert_pickle(self, value, get_vector, T=T)
+
+    @numpy_compare.check_all_types
+    def test_value_instantiations(self, T):
+        # Existence checks.
+        Value[mut.Isometry3_[T]]

--- a/bindings/pydrake/common/test/value_test.py
+++ b/bindings/pydrake/common/test/value_test.py
@@ -1,0 +1,85 @@
+import copy
+import unittest
+
+from pydrake.common.value import AbstractValue, Value
+
+from pydrake.common.test.value_test_util import (
+    make_unknown_abstract_value,
+    MoveOnlyType,
+)
+
+
+class TestValue(unittest.TestCase):
+    def test_abstract_value_copyable(self):
+        expected = "Hello world"
+        value = Value[str](expected)
+        self.assertIsInstance(value, AbstractValue)
+        self.assertEqual(value.get_value(), expected)
+        expected_new = "New value"
+        value.set_value(expected_new)
+        self.assertEqual(value.get_value(), expected_new)
+        # Test docstring.
+        self.assertFalse("unique_ptr" in value.set_value.__doc__)
+
+    def test_abstract_value_move_only(self):
+        obj = MoveOnlyType(10)
+        self.assertEqual(
+            str(Value[MoveOnlyType]),
+            "<class 'pydrake.common.value.Value[MoveOnlyType]'>")
+        # This *always* clones `obj`.
+        value = Value[MoveOnlyType](obj)
+        self.assertTrue(value.get_value() is not obj)
+        self.assertEqual(value.get_value().x(), 10)
+        # Set value.
+        value.get_mutable_value().set_x(20)
+        self.assertEqual(value.get_value().x(), 20)
+        # Test custom emplace constructor.
+        emplace_value = Value[MoveOnlyType](30)
+        self.assertEqual(emplace_value.get_value().x(), 30)
+        # Test docstring.
+        self.assertTrue("unique_ptr" in value.set_value.__doc__)
+
+    def test_abstract_value_py_object(self):
+        expected = {"x": 10}
+        value = Value[object](expected)
+        # Value is by reference, *not* by copy.
+        self.assertTrue(value.get_value() is expected)
+        # Update mutable version.
+        value.get_mutable_value()["y"] = 30
+        self.assertEqual(value.get_value(), expected)
+        # Cloning the value should perform a deep copy of the Python object.
+        value_clone = copy.deepcopy(value)
+        self.assertEqual(value_clone.get_value(), expected)
+        self.assertTrue(value_clone.get_value() is not expected)
+        # Using `set_value` on the original value changes object reference.
+        expected_new = {"a": 20}
+        value.set_value(expected_new)
+        self.assertEqual(value.get_value(), expected_new)
+        self.assertTrue(value.get_value() is not expected)
+
+    def test_abstract_value_make(self):
+        value = AbstractValue.Make("Hello world")
+        self.assertIsInstance(value, Value[str])
+        value = AbstractValue.Make(MoveOnlyType(10))
+        self.assertIsInstance(value, Value[MoveOnlyType])
+        value = AbstractValue.Make({"x": 10})
+        self.assertIsInstance(value, Value[object])
+
+    def test_abstract_value_unknown(self):
+        value = make_unknown_abstract_value()
+        self.assertIsInstance(value, AbstractValue)
+        with self.assertRaises(RuntimeError) as cm:
+            value.get_value()
+        self.assertTrue(all(
+            s in str(cm.exception) for s in [
+                "AbstractValue",
+                "UnknownType",
+                "get_value",
+                "AddValueInstantiation",
+            ]), cm.exception)
+
+    def test_value_registration(self):
+        # Existence check.
+        Value[object]
+        Value[str]
+        Value[bool]

--- a/bindings/pydrake/common/test/value_test_util_py.cc
+++ b/bindings/pydrake/common/test/value_test_util_py.cc
@@ -1,0 +1,46 @@
+#include "pybind11/pybind11.h"
+
+#include "drake/bindings/pydrake/common/value_pybind.h"
+#include "drake/bindings/pydrake/pydrake_pybind.h"
+
+namespace drake {
+namespace pydrake {
+namespace {
+
+class MoveOnlyType {
+ public:
+  explicit MoveOnlyType(int x) : x_(x) {}
+  MoveOnlyType(MoveOnlyType&&) = default;
+  MoveOnlyType& operator=(MoveOnlyType&&) = default;
+  MoveOnlyType(const MoveOnlyType&) = delete;
+  MoveOnlyType& operator=(const MoveOnlyType&) = delete;
+  int x() const { return x_; }
+  void set_x(int x) { x_ = x; }
+  std::unique_ptr<MoveOnlyType> Clone() const {
+    return std::make_unique<MoveOnlyType>(x_);
+  }
+
+ private:
+  int x_{};
+};
+
+struct UnknownType {};
+
+}  // namespace
+
+PYBIND11_MODULE(value_test_util, m) {
+  py::module::import("pydrake.common");
+
+  py::class_<MoveOnlyType>(m, "MoveOnlyType")
+      .def(py::init<int>())
+      .def("x", &MoveOnlyType::x)
+      .def("set_x", &MoveOnlyType::set_x);
+  // Define `Value` instantiation.
+  AddValueInstantiation<MoveOnlyType>(m);
+
+  m.def("make_unknown_abstract_value",
+      []() { return AbstractValue::Make(UnknownType{}); });
+}
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/common/test/wrap_pybind_test.py
+++ b/bindings/pydrake/common/test/wrap_pybind_test.py
@@ -2,7 +2,7 @@ import copy
 import gc
 import unittest
 
-from pydrake.common.wrap_test_util import (
+from pydrake.common.test.wrap_test_util import (
     MyContainerRawPtr,
     MyContainerUniquePtr,
     MyValue,

--- a/bindings/pydrake/common/test/wrap_pybind_test.py
+++ b/bindings/pydrake/common/test/wrap_pybind_test.py
@@ -6,6 +6,9 @@ from pydrake.common.test.wrap_test_util import (
     MyContainerRawPtr,
     MyContainerUniquePtr,
     MyValue,
+    MakeTypeConversionExample,
+    MakeTypeConversionExampleBadRvp,
+    CheckTypeConversionExample,
 )
 
 
@@ -43,3 +46,14 @@ class TestWrapPybind(unittest.TestCase):
         # Ensure that we have not lost our value.
         self.assertEqual(member.value, 42)
         self.assertEqual(copyable_member.value, 9.7)
+
+    def test_type_caster_wrapped(self):
+        value = MakeTypeConversionExample()
+        self.assertIsInstance(value, str)
+        self.assertEqual(value, "hello")
+        with self.assertRaises(RuntimeError) as cm:
+            MakeTypeConversionExampleBadRvp()
+        self.assertEqual(
+            str(cm.exception),
+            "Can only pass TypeConversionExample by value.")
+        self.assertTrue(CheckTypeConversionExample(obj=value))

--- a/bindings/pydrake/common/value_py.cc
+++ b/bindings/pydrake/common/value_py.cc
@@ -1,0 +1,91 @@
+#include <string>
+
+#include "pybind11/eval.h"
+#include "pybind11/pybind11.h"
+
+#include "drake/bindings/pydrake/common/value_pybind.h"
+#include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/pydrake_pybind.h"
+
+namespace drake {
+namespace pydrake {
+
+namespace {
+
+// Specialize C++ implementation for `Value[object]` instantiation.
+class PyObjectValue : public drake::Value<py::object> {
+ public:
+  using Base = Value<py::object>;
+  using Base::Base;
+  // Override `Value<py::object>::Clone()` to perform a deep copy on the
+  // object.
+  std::unique_ptr<AbstractValue> Clone() const override {
+    py::object py_copy = py::module::import("copy").attr("deepcopy");
+    return std::make_unique<PyObjectValue>(py_copy(get_value()));
+  }
+};
+
+// Add instantiations of primitive types on an as-needed basis; please be
+// conservative.
+void AddPrimitiveValueInstantiations(py::module m) {
+  AddValueInstantiation<std::string>(m);
+  AddValueInstantiation<bool>(m);
+  AddValueInstantiation<py::object, PyObjectValue>(m);
+}
+
+}  // namespace
+
+PYBIND11_MODULE(value, m) {
+  PYDRAKE_PREVENT_PYTHON3_MODULE_REIMPORT(m);
+  m.doc() = "Bindings for //common:value";
+  constexpr auto& doc = pydrake_doc.drake;
+
+  // `AddValueInstantiation` will define methods specific to `T` for
+  // `Value<T>`. Since Python is nominally dynamic, these methods are
+  // effectively "virtual".
+  auto abstract_stub = [](const std::string& method) {
+    return [method](const AbstractValue* self, py::args, py::kwargs) {
+      std::string type_name = NiceTypeName::Get(*self);
+      throw std::runtime_error(
+          "This derived class of `AbstractValue`, `" + type_name + "`, " +
+          "is not exposed to pybind11, so `" + method + "` cannot be " +
+          "called. See `AddValueInstantiation` for how to bind it.");
+    };
+  };
+
+  py::class_<AbstractValue> abstract_value(m, "AbstractValue");
+  DefClone(&abstract_value);
+  abstract_value  // BR
+      .def("SetFrom", &AbstractValue::SetFrom, doc.AbstractValue.SetFrom.doc)
+      .def("get_value", abstract_stub("get_value"),
+          doc.AbstractValue.get_value.doc)
+      .def("get_mutable_value", abstract_stub("get_mutable_value"),
+          doc.AbstractValue.get_mutable_value.doc)
+      .def("set_value", abstract_stub("set_value"),
+          doc.AbstractValue.set_value.doc);
+
+  // Add value instantiations for nominal data types.
+  AddPrimitiveValueInstantiations(m);
+
+  py::object py_type_func = py::eval("type");
+  py::object py_object_type = py::eval("object");
+  // `Value` was defined by the first call to `AddValueInstantiation`.
+  py::object py_value_template = m.attr("Value");
+  abstract_value.def_static("Make",
+      [py_type_func, py_value_template, py_object_type](py::object value) {
+        // Try to infer type from the object. If that does not work, just return
+        // `Value[object]`.
+        py::object py_type = py_type_func(value);
+        py::tuple py_result =
+            py_value_template.attr("get_instantiation")(py_type, false);
+        py::object py_value_class = py_result[0];
+        if (py_value_class.is_none()) {
+          py_value_class = py_value_template[py_object_type];
+        }
+        return py_value_class(value);
+      },
+      doc.AbstractValue.Make.doc);
+}
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/common/value_py.cc
+++ b/bindings/pydrake/common/value_py.cc
@@ -3,6 +3,7 @@
 #include "pybind11/eval.h"
 #include "pybind11/pybind11.h"
 
+#include "drake/bindings/pydrake/common/cpp_param_pybind.h"
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
@@ -12,25 +13,26 @@ namespace pydrake {
 
 namespace {
 
-// Specialize C++ implementation for `Value[object]` instantiation.
-class PyObjectValue : public drake::Value<py::object> {
+// Local specialization of C++ implementation for `Value[object]`
+// instantiation.
+class PyObjectValue : public drake::Value<Object> {
  public:
-  using Base = Value<py::object>;
+  using Base = Value<Object>;
   using Base::Base;
-  // Override `Value<py::object>::Clone()` to perform a deep copy on the
-  // object.
+  // Override `Clone()` to perform a deep copy on the object.
   std::unique_ptr<AbstractValue> Clone() const override {
     py::object py_copy = py::module::import("copy").attr("deepcopy");
-    return std::make_unique<PyObjectValue>(py_copy(get_value()));
+    py::object copied = py_copy(get_value().to_pyobject<py::object>());
+    return std::make_unique<PyObjectValue>(Object::from_pyobject(copied));
   }
 };
 
 // Add instantiations of primitive types on an as-needed basis; please be
 // conservative.
 void AddPrimitiveValueInstantiations(py::module m) {
-  AddValueInstantiation<std::string>(m);
-  AddValueInstantiation<bool>(m);
-  AddValueInstantiation<py::object, PyObjectValue>(m);
+  AddValueInstantiation<std::string>(m);            // Value[str]
+  AddValueInstantiation<bool>(m);                   // Value[bool]
+  AddValueInstantiation<Object, PyObjectValue>(m);  // Value[object]
 }
 
 }  // namespace

--- a/bindings/pydrake/common/value_pybind.h
+++ b/bindings/pydrake/common/value_pybind.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /// @file
-/// Helpers for defining scalars and values.
+/// Helpers for defining instantiations of drake::Value<>.
 
 #include <string>
 
@@ -14,8 +14,8 @@
 namespace drake {
 namespace pydrake {
 
-/// Defines an instantiation of `pydrake.systems.framework.Value[...]`. This is
-/// only meant to bind `Value<T>` (or specializations thereof).
+/// Defines an instantiation of `pydrake.common.value.Value[...]`. This is only
+/// meant to bind `Value<T>` (or specializations thereof).
 /// @prereq `T` must have already been exposed to `pybind11`.
 /// @param scope Parent scope.
 /// @tparam T Inner parameter of `Value<T>`.
@@ -24,11 +24,11 @@ namespace pydrake {
 template <typename T, typename Class = drake::Value<T>>
 py::class_<Class, drake::AbstractValue> AddValueInstantiation(
     py::module scope) {
+  py::module py_common = py::module::import("pydrake.common.value");
   py::class_<Class, drake::AbstractValue> py_class(
       scope, TemporaryClassName<Class>().c_str());
   // Register instantiation.
-  py::module py_framework = py::module::import("pydrake.systems.framework");
-  AddTemplateClass(py_framework, "Value", py_class, GetPyParam<T>());
+  AddTemplateClass(py_common, "Value", py_class, GetPyParam<T>());
   // Only use copy (clone) construction.
   // Ownership with `unique_ptr<T>` has some annoying caveats, and some are
   // simplified by always copying.

--- a/bindings/pydrake/common/value_pybind.h
+++ b/bindings/pydrake/common/value_pybind.h
@@ -5,8 +5,11 @@
 
 #include <string>
 
+#include <fmt/format.h>
+
 #include "drake/bindings/pydrake/common/cpp_param_pybind.h"
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
+#include "drake/bindings/pydrake/common/wrap_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/value.h"
@@ -24,6 +27,7 @@ namespace pydrake {
 template <typename T, typename Class = drake::Value<T>>
 py::class_<Class, drake::AbstractValue> AddValueInstantiation(
     py::module scope) {
+  static_assert(!py::detail::is_pyobject<T>::value, "See docs for GetPyParam");
   py::module py_common = py::module::import("pydrake.common.value");
   py::class_<Class, drake::AbstractValue> py_class(
       scope, TemporaryClassName<Class>().c_str());
@@ -53,24 +57,44 @@ py::class_<Class, drake::AbstractValue> AddValueInstantiation(
     const T& v = caster;  // Use implicit conversion from `type_caster<>`.
     return new Class(v);
   }));
-  // N.B. `reference_internal` for pybind POD types (int, str, etc.) does not
-  // really do anything meaningful.
-  // TODO(eric.cousineau): Add check to warn about this.
-  py_class  // BR
-      .def("get_value", &Class::get_value, py_reference_internal)
-      .def("get_mutable_value", &Class::get_mutable_value,
-          py_reference_internal);
-  std::string set_value_docstring = "Replaces stored value with a new one.";
-  if (!std::is_copy_constructible<T>::value) {
-    set_value_docstring += R"""(
+  // If the type is registered via `py::class_`, or is of type `Object`
+  // (`py::object`), then we can obtain a mutable view into the value.
+  constexpr bool has_get_mutable_value =
+      internal::is_generic_pybind<T>::value || std::is_same_v<T, Object>;
+  if constexpr (has_get_mutable_value) {
+    py::return_value_policy return_policy = py_reference_internal;
+    if (std::is_same_v<T, Object>) {
+      // N.B. This implies that `Object` will be copied by value; however, it
+      // is only a shallow copy of the pointer, not a deep copy of the object.
+      return_policy = py::return_value_policy::copy;
+    }
+    std::string set_value_docstring = "Replaces stored value with a new one.";
+    if (!std::is_copy_constructible<T>::value) {
+      set_value_docstring += R"""(
 
 @note The value type for this class is non-copyable.
 You should ensure that you do not have any dangling references to previous
-values returned by `get_value` or `get_mutable_value`, because this memory will
+values returned by `get_value` or `get_mutable_value`, because this memory
+will
 be destroyed when it is replaced, since it is stored using `unique_ptr<>`.
-)""";
+  )""";
+    }
+    py_class  // BR
+        .def("get_value", &Class::get_value, return_policy)
+        .def("get_mutable_value", &Class::get_mutable_value, return_policy)
+        .def("set_value", &Class::set_value, set_value_docstring.c_str());
+  } else {
+    py_class  // BR
+        .def("get_value", &Class::get_value)
+        .def("get_mutable_value",
+            [py_T](const Class&) {
+              throw std::logic_error(
+                  fmt::format("Cannot get mutable value (or reference) for a "
+                              "type-conversion type: {}",
+                      py::str(py_T).cast<std::string>()));
+            })
+        .def("set_value", &Class::set_value);
   }
-  py_class.def("set_value", &Class::set_value, set_value_docstring.c_str());
   return py_class;
 }
 

--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -696,7 +696,7 @@ void DoScalarIndependentDefinitions(py::module m) {
     using Class = GeometryProperties;
     constexpr auto& cls_doc = doc.GeometryProperties;
     py::handle abstract_value_cls =
-        py::module::import("pydrake.systems.framework").attr("AbstractValue");
+        py::module::import("pydrake.common.value").attr("AbstractValue");
     py::class_<Class>(m, "GeometryProperties", cls_doc.doc)
         .def("HasGroup", &Class::HasGroup, py::arg("group_name"),
             cls_doc.HasGroup.doc)

--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -9,6 +9,7 @@
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/type_pack.h"
+#include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/symbolic_types_pybind.h"
@@ -132,6 +133,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
     DefCast<T>(&cls, cls_doc.cast.doc);
     // .def("IsNearlyEqualTo", ...)
     // .def("IsExactlyEqualTo", ...)
+    AddValueInstantiation<RigidTransform<T>>(m);
   }
 
   {
@@ -197,6 +199,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
     cls.attr("__matmul__") = cls.attr("multiply");
     DefCopyAndDeepCopy(&cls);
     DefCast<T>(&cls, cls_doc.cast.doc);
+    AddValueInstantiation<RotationMatrix<T>>(m);
   }
 
   {

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -927,6 +927,7 @@ PYBIND11_MODULE(plant, m) {
   m.doc() = "Bindings for MultibodyPlant and related classes.";
 
   py::module::import("pydrake.geometry");
+  py::module::import("pydrake.math");
   py::module::import("pydrake.multibody.math");
   py::module::import("pydrake.multibody.tree");
   py::module::import("pydrake.systems.framework");

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -64,6 +64,7 @@ from pydrake.multibody.benchmarks.acrobot import (
 from pydrake.common import FindResourceOrThrow
 from pydrake.common.deprecation import install_numpy_warning_filters
 from pydrake.common.test_utilities import numpy_compare
+from pydrake.common.value import AbstractValue
 from pydrake.geometry import (
     Box,
     GeometryId,
@@ -81,7 +82,6 @@ from pydrake.math import (
 )
 from pydrake.systems.analysis import Simulator_
 from pydrake.systems.framework import (
-    AbstractValue,
     BasicVector_,
     DiagramBuilder_,
     System_,

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -53,6 +53,7 @@ drake_pybind_library(
         "//bindings/pydrake/common:value_pybind",
         "//bindings/pydrake/common:wrap_pybind",
     ],
+    cc_so_name = "_framework",
     cc_srcs = [
         "framework_py.cc",
         "framework_py_semantics.cc",
@@ -70,7 +71,9 @@ drake_pybind_library(
         "//bindings/pydrake:symbolic_py",
         "//bindings/pydrake/common:cpp_template_py",
         "//bindings/pydrake/common:eigen_geometry_py",
+        "//bindings/pydrake/common:value_py",
     ],
+    py_srcs = ["framework.py"],
 )
 
 drake_py_library(
@@ -426,7 +429,6 @@ drake_py_unittest(
     name = "value_test",
     deps = [
         ":framework_py",
-        ":test_util_py",
     ],
 )
 

--- a/bindings/pydrake/systems/_lcm_extra.py
+++ b/bindings/pydrake/systems/_lcm_extra.py
@@ -1,6 +1,6 @@
 # See `ExecuteExtraPythonCode` in `pydrake_pybind.h` for usage details and
 # rationale.
-from pydrake.systems.framework import AbstractValue
+from pydrake.common.value import AbstractValue
 
 
 class PySerializer(SerializerInterface):

--- a/bindings/pydrake/systems/framework.py
+++ b/bindings/pydrake/systems/framework.py
@@ -1,0 +1,27 @@
+"""
+This module only exists to handle deprecation.
+
+Actual docstring will be overridden programmatically.
+"""
+from pydrake import _import_cc_module_vars
+import pydrake.common.deprecation as _deprecation
+import pydrake.common.value as _value
+from pydrake.systems import _framework as _cc
+
+__doc__ = _cc.__doc__
+__all__ = _import_cc_module_vars(_cc, __name__)
+
+
+def _getattr(name):
+    if name in ["AbstractValue", "Value"]:
+        old_symbol = f"{__name__}.{name}"
+        new_symbol = f"{_value.__name__}.{name}"
+        _deprecation._warn_deprecated(
+            f"{old_symbol} has moved to {new_symbol}. Please use it instead. "
+            f"This will be removed on or after 2020-08-01.")
+        return getattr(_value, name)
+    else:
+        raise AttributeError()
+
+
+_deprecation.ModuleShim._install(__name__, _getattr)

--- a/bindings/pydrake/systems/framework_py.cc
+++ b/bindings/pydrake/systems/framework_py.cc
@@ -6,7 +6,9 @@
 namespace drake {
 namespace pydrake {
 
-PYBIND11_MODULE(framework, m) {
+// TODO(eric.cousineau): Remove leading underscore once deprecation shim module
+// is removed.
+PYBIND11_MODULE(_framework, m) {
   PYDRAKE_PREVENT_PYTHON3_MODULE_REIMPORT(m);
   m.doc() = "Bindings for the core Systems framework.";
 

--- a/bindings/pydrake/systems/meshcat_visualizer.py
+++ b/bindings/pydrake/systems/meshcat_visualizer.py
@@ -12,13 +12,12 @@ import webbrowser
 import numpy as np
 
 from drake import lcmt_viewer_load_robot
+from pydrake.common.value import AbstractValue
 from pydrake.common.eigen_geometry import Quaternion, Isometry3
 from pydrake.geometry import DispatchLoadMessage, SceneGraph
 from pydrake.lcm import DrakeLcm, Subscriber
 from pydrake.math import RigidTransform, RotationMatrix
-from pydrake.systems.framework import (
-    AbstractValue, LeafSystem, PublishEvent, TriggerType
-)
+from pydrake.systems.framework import LeafSystem, PublishEvent, TriggerType
 from pydrake.systems.rendering import PoseBundle
 from pydrake.multibody.plant import ContactResults
 import pydrake.perception as mut

--- a/bindings/pydrake/systems/perception.py
+++ b/bindings/pydrake/systems/perception.py
@@ -1,8 +1,9 @@
 import numpy as np
 
+from pydrake.common.value import AbstractValue
 from pydrake.math import RigidTransform
 from pydrake.perception import BaseField, Fields, PointCloud
-from pydrake.systems.framework import AbstractValue, LeafSystem
+from pydrake.systems.framework import LeafSystem
 
 
 def _TransformPoints(points_Ci, X_CiSi):

--- a/bindings/pydrake/systems/planar_scenegraph_visualizer.py
+++ b/bindings/pydrake/systems/planar_scenegraph_visualizer.py
@@ -17,10 +17,10 @@ with warnings.catch_warnings():  # noqa
 
 from drake import lcmt_viewer_load_robot
 from pydrake.common.eigen_geometry import Quaternion
+from pydrake.common.value import AbstractValue
 from pydrake.geometry import DispatchLoadMessage, ReadObjToSurfaceMesh
 from pydrake.lcm import DrakeLcm, Subscriber
 from pydrake.math import RigidTransform, RotationMatrix
-from pydrake.systems.framework import AbstractValue
 from pydrake.systems.pyplot_visualizer import PyPlotVisualizer
 from pydrake.systems.rendering import PoseBundle
 

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -6,6 +6,7 @@ import warnings
 import numpy as np
 
 from pydrake.autodiffutils import AutoDiffXd
+from pydrake.common.value import AbstractValue
 from pydrake.symbolic import Expression
 from pydrake.systems.analysis import (
     Simulator,
@@ -13,7 +14,6 @@ from pydrake.systems.analysis import (
 from pydrake.systems.framework import (
     AbstractParameterIndex,
     AbstractStateIndex,
-    AbstractValue,
     BasicVector, BasicVector_,
     CacheIndex,
     Context,

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -22,7 +22,6 @@ from pydrake.systems.analysis import (
     SimulatorStatus, Simulator, Simulator_,
     )
 from pydrake.systems.framework import (
-    AbstractValue,
     BasicVector, BasicVector_,
     Context, Context_,
     ContinuousState, ContinuousState_,
@@ -59,6 +58,9 @@ from pydrake.systems.primitives import (
     SignalLogger,
     ZeroOrderHold,
     )
+
+with catch_drake_warnings(expected_count=2):
+    from pydrake.systems.framework import AbstractValue, Value
 
 # TODO(eric.cousineau): The scope of this test file and and `custom_test.py`
 # is poor. Move these tests into `framework_test` and `analysis_test`, and

--- a/bindings/pydrake/systems/test/lcm_test.py
+++ b/bindings/pydrake/systems/test/lcm_test.py
@@ -13,10 +13,10 @@ import numpy as np
 from robotlocomotion import header_t, quaternion_t
 
 from pydrake.common.test_utilities.deprecation import catch_drake_warnings
+from pydrake.common.value import AbstractValue
 from pydrake.lcm import DrakeLcm, Subscriber
 from pydrake.systems.analysis import Simulator
-from pydrake.systems.framework import (
-    AbstractValue, BasicVector, DiagramBuilder, LeafSystem)
+from pydrake.systems.framework import BasicVector, DiagramBuilder, LeafSystem
 from pydrake.systems.primitives import ConstantVectorSource, LogOutput
 
 

--- a/bindings/pydrake/systems/test/meshcat_visualizer_test.py
+++ b/bindings/pydrake/systems/test/meshcat_visualizer_test.py
@@ -20,6 +20,7 @@ import meshcat
 import numpy as np
 
 from pydrake.common import FindResourceOrThrow
+from pydrake.common.value import AbstractValue
 from pydrake.geometry import (
     Box,
     GeometryInstance,
@@ -30,7 +31,7 @@ from pydrake.multibody.plant import (
     AddMultibodyPlantSceneGraph)
 from pydrake.multibody.parsing import Parser
 from pydrake.systems.analysis import Simulator
-from pydrake.systems.framework import AbstractValue, DiagramBuilder
+from pydrake.systems.framework import DiagramBuilder
 from pydrake.systems.meshcat_visualizer import (
     MeshcatVisualizer,
     MeshcatContactVisualizer,

--- a/bindings/pydrake/systems/test/perception_test.py
+++ b/bindings/pydrake/systems/test/perception_test.py
@@ -3,10 +3,11 @@
 import unittest
 import numpy as np
 
+from pydrake.common.value import AbstractValue
 from pydrake.math import RigidTransform, RollPitchYaw, RotationMatrix
 from pydrake.perception import BaseField, Fields, PointCloud
 from pydrake.systems.analysis import Simulator
-from pydrake.systems.framework import AbstractValue, DiagramBuilder
+from pydrake.systems.framework import DiagramBuilder
 from pydrake.systems.perception import (
     PointCloudConcatenation, _ConcatenatePointClouds, _TileColors,
     _TransformPoints)

--- a/bindings/pydrake/systems/test/primitives_test.py
+++ b/bindings/pydrake/systems/test/primitives_test.py
@@ -6,10 +6,10 @@ from pydrake.autodiffutils import AutoDiffXd
 from pydrake.common import RandomDistribution, RandomGenerator
 from pydrake.common.test_utilities import numpy_compare
 from pydrake.common.test_utilities.deprecation import catch_drake_warnings
+from pydrake.common.value import AbstractValue
 from pydrake.symbolic import Expression, Variable
 from pydrake.systems.analysis import Simulator
 from pydrake.systems.framework import (
-    AbstractValue,
     BasicVector,
     DiagramBuilder,
     VectorBase,

--- a/bindings/pydrake/systems/test/rendering_test.py
+++ b/bindings/pydrake/systems/test/rendering_test.py
@@ -13,6 +13,7 @@ import unittest
 import numpy as np
 
 from pydrake.common import FindResourceOrThrow
+from pydrake.common.value import AbstractValue
 from pydrake.geometry import SceneGraph
 from pydrake.multibody.plant import MultibodyPlant
 from pydrake.multibody.math import (
@@ -20,7 +21,6 @@ from pydrake.multibody.math import (
 )
 from pydrake.multibody.parsing import Parser
 from pydrake.systems.framework import (
-    AbstractValue,
     BasicVector,
     PortDataType,
 )

--- a/bindings/pydrake/systems/test/sensors_test.py
+++ b/bindings/pydrake/systems/test/sensors_test.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from pydrake.common import FindResourceOrThrow
 from pydrake.common.test_utilities.pickle_compare import assert_pickle
+from pydrake.common.value import AbstractValue, Value
 from pydrake.geometry import FrameId
 from pydrake.geometry.render import CameraProperties, DepthCameraProperties
 from pydrake.math import (
@@ -13,10 +14,8 @@ from pydrake.math import (
     RollPitchYaw,
     )
 from pydrake.systems.framework import (
-    AbstractValue,
     InputPort,
     OutputPort,
-    Value,
     )
 
 # Shorthand aliases, to reduce verbosity.

--- a/bindings/pydrake/systems/test/test_util_py.cc
+++ b/bindings/pydrake/systems/test/test_util_py.cc
@@ -46,25 +46,6 @@ class DeleteListenerVector : public BasicVector<T> {
   std::function<void()> delete_callback_;
 };
 
-class MoveOnlyType {
- public:
-  explicit MoveOnlyType(int x) : x_(x) {}
-  MoveOnlyType(MoveOnlyType&&) = default;
-  MoveOnlyType& operator=(MoveOnlyType&&) = default;
-  MoveOnlyType(const MoveOnlyType&) = delete;
-  MoveOnlyType& operator=(const MoveOnlyType&) = delete;
-  int x() const { return x_; }
-  void set_x(int x) { x_ = x; }
-  std::unique_ptr<MoveOnlyType> Clone() const {
-    return std::make_unique<MoveOnlyType>(x_);
-  }
-
- private:
-  int x_{};
-};
-
-struct UnknownType {};
-
 // A simple 2-dimensional subclass of BasicVector for testing.
 template <typename T>
 class MyVector2 : public BasicVector<T> {
@@ -94,19 +75,9 @@ PYBIND11_MODULE(test_util, m) {
   py::class_<DeleteListenerVector, BasicVector<T>>(m, "DeleteListenerVector")
       .def(py::init<std::function<void()>>());
 
-  py::class_<MoveOnlyType>(m, "MoveOnlyType")
-      .def(py::init<int>())
-      .def("x", &MoveOnlyType::x)
-      .def("set_x", &MoveOnlyType::set_x);
-  // Define `Value` instantiation.
-  AddValueInstantiation<MoveOnlyType>(m);
-
   // A 2-dimensional subclass of BasicVector.
   py::class_<MyVector2<T>, BasicVector<T>>(m, "MyVector2")
       .def(py::init<const Eigen::Vector2d&>(), py::arg("data"));
-
-  m.def("make_unknown_abstract_value",
-      []() { return AbstractValue::Make(UnknownType{}); });
 
   // Call overrides to ensure a custom Python class can override these methods.
 

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -11,6 +11,7 @@ from drake import lcmt_viewer_load_robot, lcmt_viewer_draw
 from pydrake.autodiffutils import AutoDiffXd
 from pydrake.common import FindResourceOrThrow
 from pydrake.common.test_utilities import numpy_compare
+from pydrake.common.value import AbstractValue
 from pydrake.lcm import DrakeLcm, Subscriber
 from pydrake.math import RigidTransform_
 from pydrake.symbolic import Expression
@@ -18,7 +19,6 @@ from pydrake.systems.analysis import (
     Simulator_,
 )
 from pydrake.systems.framework import (
-    AbstractValue,
     DiagramBuilder_,
     InputPort_,
     OutputPort_,

--- a/bindings/pydrake/test/math_test.py
+++ b/bindings/pydrake/test/math_test.py
@@ -2,6 +2,7 @@ import pydrake.math as mut
 import pydrake.math._test as mtest
 from pydrake.math import (BarycentricMesh, wrap_to)
 from pydrake.common.eigen_geometry import Isometry3_, Quaternion_, AngleAxis_
+from pydrake.common.value import Value
 from pydrake.autodiffutils import AutoDiffXd
 from pydrake.symbolic import Expression
 from pydrake.common.test_utilities.deprecation import catch_drake_warnings
@@ -357,3 +358,9 @@ class TestMath(unittest.TestCase):
         R = [0.3]
 
         mut.DiscreteAlgebraicRiccatiEquation(A=A, B=B, Q=Q, R=R)
+
+    @numpy_compare.check_all_types
+    def test_value_instantiations(self, T):
+        # Existence checks.
+        Value[mut.RigidTransform_[T]]
+        Value[mut.RotationMatrix_[T]]

--- a/bindings/pydrake/test/perception_test.py
+++ b/bindings/pydrake/test/perception_test.py
@@ -4,9 +4,9 @@ import unittest
 
 import numpy as np
 
+from pydrake.common.value import AbstractValue, Value
 from pydrake.systems.sensors import CameraInfo, PixelType
-from pydrake.systems.framework import (
-    AbstractValue, InputPort, OutputPort, Value)
+from pydrake.systems.framework import InputPort, OutputPort
 
 
 class TestPerception(unittest.TestCase):


### PR DESCRIPTION
Resolves #13207

Follow-up to https://github.com/RobotLocomotion/drake/pull/13217
Restores https://github.com/RobotLocomotion/drake/pull/12430

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13225)
<!-- Reviewable:end -->
