### PR TITLE
pybind: Avoid duplicate linting with `add_pybind_coverage_data`

### DIFF
--- a/tools/skylark/pybind.bzl
+++ b/tools/skylark/pybind.bzl
@@ -428,6 +428,9 @@ def add_pybind_coverage_data(
             subpackage + ":pybind_coverage_data"
             for subpackage in subpackages
         ],
+        # N.B. Without this, we will duplicate error messages between
+        # *cc_libraries and this rule.
+        tags = ["nolint"],
         visibility = ["//bindings/pydrake:__pkg__"],
     )
 


### PR DESCRIPTION
Came across this while working on #13225 

I saw a duplication of an error for `value_py.cc`:
```
==================== Test output for //bindings/pydrake/common:py/pybind_coverage_data_clang_format_lint:
...
clang_format_lint.py: Linting bindings/pydrake/common/value_py.cc
ERROR: bindings/pydrake/common/value_py.cc needs clang-format
note: fix via /usr/bin/clang-format-6.0 -style=file -i bindings/pydrake/common/value_py.cc
================================================================================
...
==================== Test output for //bindings/pydrake/common:py/value.so_clang_format_lint:
clang_format_lint.py: Linting bindings/pydrake/common/value_py.cc
ERROR: bindings/pydrake/common/value_py.cc needs clang-format
note: fix via /usr/bin/clang-format-6.0 -style=file -i bindings/pydrake/common/value_py.cc
================================================================================
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13228)
<!-- Reviewable:end -->
