### PR TITLE
tools: Trim FCL to only compile the parts we need

### DIFF
--- a/tools/workspace/BUILD.bazel
+++ b/tools/workspace/BUILD.bazel
@@ -57,7 +57,6 @@ _DRAKE_EXTERNAL_PACKAGE_INSTALLS = ["@%s//:install" % p for p in [
     "lcmtypes_robotlocomotion",
     "meshcat",
     "meshcat_python",
-    "octomap",
     "pybind11",
     "sdformat",
     "spdlog",

--- a/tools/workspace/fcl/package.BUILD.bazel
+++ b/tools/workspace/fcl/package.BUILD.bazel
@@ -56,14 +56,58 @@ cmake_configure_file(
     out = "include/fcl/config.h",
     cmakelists = [
         ":version-from-xml.cmake",
-        "@octomap//:cmakelists_with_version",
     ],
     defines = [
-        "FCL_HAVE_OCTOMAP",
+        "OCTOMAP_MAJOR_VERSION=0",
+        "OCTOMAP_MINOR_VERSION=0",
+        "OCTOMAP_PATCH_VERSION=0",
         "GENERATED_FILE_MARKER=GENERATED FILE DO NOT EDIT",
     ],
     visibility = ["//visibility:private"],
 )
+
+# Provide all headers (except octomap-related ones) for simplicitly, even
+# though many of these will not have their '*.cpp' mate compiled.
+_HDRS = glob(
+    include = [
+        "include/**/*.h",
+    ],
+    exclude = [
+        "**/octree/**",
+    ],
+    allow_empty = False,
+)
+
+# To minimize the build footprint, only build the fraction of FCL that is
+# needed by Drake.
+_DRAKE_RELEVANT_SRCS = glob(
+    include = [
+        "src/**/*.cpp",
+    ],
+    exclude = [
+        # We use none of this code.
+        "**/*conservative_advancement*.cpp",
+        "**/*continuous_collision*.cpp",
+        "**/octree/**",
+        "src/common/**",
+        "src/math/motion/**",
+        "src/math/sampler/**",
+        # We list out the few of these that we need immediately below.
+        "src/broadphase/*.cpp",
+        "src/broadphase/detail/*.cpp",
+        "src/math/*.cpp",
+        "src/math/detail/*.cpp",
+    ],
+    allow_empty = False,
+) + [
+    "src/broadphase/broadphase_collision_manager.cpp",
+    "src/broadphase/broadphase_dynamic_AABB_tree.cpp",
+    "src/broadphase/detail/morton.cpp",
+    "src/math/geometry.cpp",
+    "src/math/triangle.cpp",
+    "src/math/detail/polysolver.cpp",
+    "src/math/detail/project.cpp",
+]
 
 # Generates fcl.h, which consists of #include statements for *all* of the other
 # headers in the library (!!!).  The first line is '#pragma once' followed by
@@ -71,31 +115,26 @@ cmake_configure_file(
 drake_generate_include_header(
     name = "fcl_h_genrule",
     out = "include/fcl/fcl.h",
-    hdrs = glob(["include/**/*.h"]),
+    hdrs = _HDRS,
 )
 
-# The globbed srcs= and hdrs= matches upstream's explicit globs of the same.
-# fcl/export.h is a generated file so it is not automatically included by
-# the hdrs glob expression
 cc_library(
     name = "fcl",
-    srcs = glob(["src/**/*.cpp"]),
-    hdrs = glob(["include/**/*.h"]) + [
+    srcs = _DRAKE_RELEVANT_SRCS,
+    hdrs = _HDRS + [
         ":config",
         ":fcl_h_genrule",
-        "include/fcl/export.h",
+        ":include/fcl/export.h",
     ],
     copts = ["-fvisibility=hidden"],
     defines = [
         "FCL_STATIC_DEFINE",
-        "FCL_HAVE_OCTOMAP",
     ],
     includes = ["include"],
     linkstatic = 1,
     deps = [
         "@ccd",
         "@eigen",
-        "@octomap",
     ],
 )
 

--- a/tools/workspace/octomap/BUILD.bazel
+++ b/tools/workspace/octomap/BUILD.bazel
@@ -1,5 +1,15 @@
 # -*- python -*-
 
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_library",
+)
 load("//tools/lint:lint.bzl", "add_lint_tests")
+
+drake_cc_library(
+    name = "stub",
+    srcs = ["stub.cc"],
+    deps = ["@octomap//:octomap_for_stub_test"],
+)
 
 add_lint_tests()

--- a/tools/workspace/octomap/package.BUILD.bazel
+++ b/tools/workspace/octomap/package.BUILD.bazel
@@ -1,10 +1,5 @@
 # -*- python -*-
 
-load(
-    "@drake//tools/install:install.bzl",
-    "install",
-)
-
 licenses(["notice"])  # BSD-3-Clause
 
 package(default_visibility = ["//visibility:public"])
@@ -52,10 +47,12 @@ cc_library(
     includes = ["octomap/include"],
     linkstatic = 1,
     deps = [":octomath"],
+    deprecation = "DRAKE DEPRECATED: The @octomap external is being removed from Drake on or after 2020-09-01.  Downstream projects should add it to their own WORKSPACE if needed.",  # noqa
 )
 
-install(
-    name = "install",
-    docs = ["octomap/LICENSE.txt"],
-    doc_strip_prefix = ["octomap"],
+# N.B. Not intended for public use!  This is only intended for the regression
+# test in @drake//tools/workspace/octomap, and will be removed on 2020-09-01.
+cc_library(
+    name = "octomap_for_stub_test",
+    deps = [":octomap"],
 )

--- a/tools/workspace/octomap/stub.cc
+++ b/tools/workspace/octomap/stub.cc
@@ -1,0 +1,5 @@
+#include <octomap/octomap.h>
+
+void stub() {
+  octomap::OcTree tree(1.0);
+}


### PR DESCRIPTION
Closes #13227.

On my laptop, a `bazel build @fcl//:fcl` went from:

Release mode:
- total child process down from 130 to 71
- total cpu-seconds down from 315 to 170 (so -46%)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13230)
<!-- Reviewable:end -->
