### PR TITLE
geometry_properties: Explicitly test number of copies / moves

### DIFF
--- a/geometry/test/geometry_properties_test.cc
+++ b/geometry/test/geometry_properties_test.cc
@@ -5,6 +5,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/common/unused.h"
 
 namespace drake {
 namespace geometry {
@@ -288,6 +289,110 @@ GTEST_TEST(GeometryProperties, CopyMoveSemantics) {
   move_assign = std::move(move_construct);
   EXPECT_FALSE(properties_equal(reference, move_construct));
   EXPECT_TRUE(properties_equal(reference, move_assign));
+}
+
+// Counts the number of instances constructed. Ignores destruction.
+// TODO(eric.cousineau): Hoist this to more general testing code (e.g. for
+// value_test.cc).
+class GloballyCounted {
+ public:
+  struct Stats {
+    int num_copies{};
+    int num_moves{};
+
+    ::testing::AssertionResult Equal(Stats other) {
+      if (num_copies != other.num_copies || num_moves != other.num_moves) {
+        return ::testing::AssertionFailure() <<
+            fmt::format(
+                "(num_copies, num_moves): ({}, {}) != ({}, {})",
+                num_copies, num_moves, other.num_copies, other.num_moves);
+      }
+      return ::testing::AssertionSuccess();
+    }
+  };
+
+  static Stats get_stats_and_reset() {
+    Stats out = stats;
+    stats = {0, 0};
+    return out;
+  }
+
+  GloballyCounted() {}
+
+  GloballyCounted(GloballyCounted&&) { stats.num_moves++; }
+  GloballyCounted& operator=(GloballyCounted&&) {
+    stats.num_moves++;
+    return *this;
+  }
+
+  GloballyCounted(const GloballyCounted&) { stats.num_copies++; }
+  GloballyCounted& operator=(const GloballyCounted&) {
+    stats.num_copies++;
+    return *this;
+  }
+
+ private:
+  static Stats stats;
+};
+
+GloballyCounted::Stats GloballyCounted::stats;
+
+GTEST_TEST(GeometryProperties, GloballyCounted) {
+  // Unittest basic utility.
+  const GloballyCounted value;
+  EXPECT_TRUE(GloballyCounted::get_stats_and_reset().Equal({0, 0}));
+
+  // Copy construction.
+  {
+    const GloballyCounted copy = value;
+    unused(copy);
+    EXPECT_TRUE(GloballyCounted::get_stats_and_reset().Equal({1, 0}));
+  }
+
+  // Copy assignment.
+  {
+    GloballyCounted copy;
+    copy = value;
+    EXPECT_TRUE(GloballyCounted::get_stats_and_reset().Equal({1, 0}));
+  }
+
+  // Move construction.
+  {
+    GloballyCounted moved_from;
+    GloballyCounted moved_to = std::move(moved_from);
+    unused(moved_to);
+    EXPECT_TRUE(GloballyCounted::get_stats_and_reset().Equal({0, 1}));
+  }
+
+  // Move assigment.
+  {
+    GloballyCounted moved_from;
+    GloballyCounted moved_to;
+    moved_to = std::move(moved_from);
+    EXPECT_TRUE(GloballyCounted::get_stats_and_reset().Equal({0, 1}));
+  }
+}
+
+// Confirms the amount of copying that occurs.
+GTEST_TEST(GeometryProperties, CopyCountCheck) {
+  TestProperties properties;
+  const std::string& group_name{"some_group"};
+  const std::string name_1("name_1");
+  const std::string name_2("name_2");
+
+  // When adding a property, 2 copies should occur: once when constructing a
+  // value, then another when cloning it.
+  const GloballyCounted value;
+  properties.AddPropertyAbstract(group_name, name_1, Value(value));
+  EXPECT_TRUE(GloballyCounted::get_stats_and_reset().Equal({2, 0}));
+
+  // Same as above.
+  properties.AddProperty(group_name, name_2, value);
+  EXPECT_TRUE(GloballyCounted::get_stats_and_reset().Equal({2, 0}));
+
+  // No copies upon retrieving the type.
+  properties.GetProperty<GloballyCounted>(group_name, name_1);
+  EXPECT_TRUE(GloballyCounted::get_stats_and_reset().Equal({0, 0}));
 }
 
 }  // namespace


### PR DESCRIPTION
As part of https://github.com/robotlocomotion/drake/pull/13166

Keeping this simple for now. I don't want to generalize this at the moment, but it would be good to confirm copy / move stats for `Value<>`. (I don't see anything explicitly testing that). I assume we have similar tests elsewhere.

Kinda creeps towards what `pybind11` has:
https://github.com/pybind/pybind11/blob/a54eab92d265337996b8e4b4149d9176c2d428a6/tests/constructor_stats.h

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13232)
<!-- Reviewable:end -->
