### PR TITLE
Add some Dynamics component labels for GitHub issues

### DIFF
--- a/doc/issues.rst
+++ b/doc/issues.rst
@@ -67,22 +67,43 @@ Every issue must have at most one ``component`` label. The components are:
 
 - ``build system``
 
-  description: Bazel, CMake, dependencies, memory checkers, linters, etc.
+  Bazel, CMake, dependencies, memory checkers, linters, etc.
 
   typical team: kitware
 
 - ``continuous integration``
 
-  description: Jenkins, CDash, mirroring of externals, Drake website, etc.
+  Jenkins, CDash, mirroring of externals, Drake website, etc.
 
   typical team: kitware
 
 - ``distribution``
 
-  description: nightly binaries, monthly releases, docker, installation
+  Nightly binaries, monthly releases, docker, installation
   via apt or brew, etc.
 
   typical team: kitware
+
+- ``multibody plant``
+
+  MultibodyPlant and related code and documentation
+  usually in ``drake/multibody``.
+
+  typical team: dynamics
+
+- ``simulator``
+
+  Simulator, integrators, and related code and documentation,
+  usually in ``drake/systems/analysis``.
+
+  typical team: dynamics
+
+- ``system framework``
+
+  System, Context, and related code and documentation,
+  usually in ``drake/systems/framework``.
+
+  typical team: dynamics
 
 .. _issues-priority:
 


### PR DESCRIPTION
This PR proposes three new component label descriptions for organizing GitHub issues:
- component: multibody plant
- component: system framework
- component: simulator (includes integrators)

These are some big, mostly disjoint areas typically addressed by the Dynamics team. There are more under geometry but we haven't settled on the component names yet. These three seem natural and map fairly well to people's specialties so are likely to be useful in assigning work. We will add more when it's clear what would be useful.

I'll wait to create the actual GitHub labels until this PR is merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13256)
<!-- Reviewable:end -->
