### PR TITLE
tools: Upgrade to clang-format-9 for includes

### DIFF
--- a/attic/multibody/kinematics_cache.cc
+++ b/attic/multibody/kinematics_cache.cc
@@ -1,5 +1,7 @@
+/* clang-format: off */
 // NOLINTNEXTLINE(build/include) False positive on inl file.
 #include "drake/multibody/kinematics_cache-inl.h"
+/* clang-format: on */
 
 #include "drake/common/autodiff.h"
 

--- a/tools/lint/clang_format.py
+++ b/tools/lint/clang_format.py
@@ -5,11 +5,19 @@ import os
 import sys
 
 
-def get_clang_format_path():
+def get_clang_format_path(version=None):
+    """Call with version=None to use Drake's default version.
+    Otherwise, pass the desired major verison as an int.
+    """
+    if version is None:
+        version = 6
     if sys.platform == "darwin":
-        path = "/usr/local/opt/llvm@6/bin/clang-format"
+        path = f"/usr/local/opt/llvm@{version}/bin/clang-format"
     else:
-        path = "/usr/bin/clang-format-6.0"
+        if version <= 6:
+            path = f"/usr/bin/clang-format-{version}.0"
+        else:
+            path = f"/usr/bin/clang-format-{version}"
     if os.path.isfile(path):
         return path
     raise RuntimeError("Could not find required clang-format at " + path)

--- a/tools/lint/drakelint.py
+++ b/tools/lint/drakelint.py
@@ -38,7 +38,7 @@ def _check_includes(filename):
     tool.format_includes()
     first_difference = tool.get_first_differing_original_index()
     if first_difference is not None:
-        print("ERROR: {filename}:{first_difference + 1}: "
+        print(f"ERROR: {filename}:{first_difference + 1}: "
               "the #include ordering is incorrect")
         print("note: fix via bazel-bin/tools/lint/clang-format-includes "
               + filename)

--- a/tools/lint/formatter.py
+++ b/tools/lint/formatter.py
@@ -202,9 +202,11 @@ class FormatterBase(object):
 
         # Run clang-format.
         command = [
-            clang_format_lib.get_clang_format_path(),
-            "-style=file",
-            "-assume-filename=%s" % self._filename] + \
+            # TODO(jwnimmer-tri) Remove the version=9 argument once it's our
+            # project-wide default.
+            clang_format_lib.get_clang_format_path(version=9),
+            "--style=file",
+            "--assume-filename=%s" % self._filename] + \
             lines_args
         formatter = Popen(command, stdin=PIPE, stdout=PIPE)
         text = "".join(self._working_lines)
@@ -304,6 +306,16 @@ class IncludeFormatter(FormatterBase):
         # Run the formatter over only the in-scope #include statements.
         self.clang_format()
 
+        # Undo any internal whitespace buffer that clang-format added around
+        # each group of include statements.
+        include_indices = self.get_format_indices()
+        blank_indices_to_remove = []
+        for i, j in zip(include_indices, include_indices[1:]):
+            # If a pair of include statements spans a blank line, remove it.
+            if i + 2 == j and self.get_line(i + 1) == "\n":
+                blank_indices_to_remove.append(i + 1)
+        self.remove_all(blank_indices_to_remove)
+
         # Turn each run of spacers within an include block into a blank line.
         # Remove any runs of spaces at the start or end.
         include_indices = self.get_format_indices()
@@ -317,7 +329,7 @@ class IncludeFormatter(FormatterBase):
             if all([x in include_indices
                     for x in [before_spacer, after_spacer]]):
                 # Interior group of spacers.  Replace with a blank line.
-                self.set_line(one_range[0], u"\n")
+                self.set_line(one_range[0], "\n")
                 one_range = one_range[1:]
             spacer_indices_to_remove.extend(one_range)
         self.remove_all(spacer_indices_to_remove)

--- a/tools/lint/test/formatter_test.py
+++ b/tools/lint/test/formatter_test.py
@@ -183,27 +183,6 @@ namespace { }
 """
         self._check("dut.cc", original, original, None)
 
-    def test_cc_uses_single_inl(self):
-        # Only a single "-inl.h" include.
-        original = """
-#include "drake/dummy/dut-inl.h"
-
-namespace { }
-"""
-        self._check("dut.cc", original, original, None)
-
-    def test_cc_uses_inl_and_more(self):
-        # Presence of "-inl.h" pattern and other things.
-        original = """
-#include "drake/dummy/dut-inl.h"
-
-#include "drake/common/drake_assert.h"
-#include "drake/common/drake_deprecated.h"
-
-namespace { }
-"""
-        self._check("xxx.cc", original, original, None)
-
     def test_target_is_header(self):
         # A header file.
         original = """
@@ -220,17 +199,6 @@ namespace { }
 namespace { }
 """
         self._check("dut.h", original, expected, 0)
-
-    def test_target_is_inl(self):
-        # An *-inl.h file.
-        original = """
-#include "drake/dummy/dut.h"
-
-#include <vector>
-
-namespace { }
-"""
-        self._check("dut-inl.h", original, original, None)
 
     def test_associated_comment(self):
         # A comment prior to a line.


### PR DESCRIPTION
Towards #13236.  Requires #13260.

Remove test cases for the inl pattern.  Drake does not permit this pattern anymore, and supporting it under clang-format-9 is difficult.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13259)
<!-- Reviewable:end -->
