### PR TITLE
workspace: Remove dependency on ruby

### DIFF
--- a/setup/ubuntu/source_distribution/packages-bionic.txt
+++ b/setup/ubuntu/source_distribution/packages-bionic.txt
@@ -65,7 +65,6 @@ python3-sphinx-rtd-theme
 python3-tk-dbg
 python3-yaml-dbg
 python3-zmq-dbg
-ruby
 unzip
 valgrind
 valgrind-dbg

--- a/setup/ubuntu/source_distribution/packages-focal.txt
+++ b/setup/ubuntu/source_distribution/packages-focal.txt
@@ -65,7 +65,6 @@ python3-sphinx-rtd-theme
 python3-tk-dbg
 python3-yaml-dbg
 python3-zmq-dbg
-ruby
 unzip
 valgrind
 valgrind-dbg

--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -65,7 +65,6 @@ load("@drake//tools/workspace/pycps:repository.bzl", "pycps_repository")
 load("@drake//tools/workspace/python:repository.bzl", "python_repository")
 load("@drake//tools/workspace/qdldl:repository.bzl", "qdldl_repository")
 load("@drake//tools/workspace/ros_xacro:repository.bzl", "ros_xacro_repository")  # noqa
-load("@drake//tools/workspace/ruby:repository.bzl", "ruby_repository")
 load("@drake//tools/workspace/rules_pkg:repository.bzl", "rules_pkg_repository")  # noqa
 load("@drake//tools/workspace/rules_python:repository.bzl", "rules_python_repository")  # noqa
 load("@drake//tools/workspace/scs:repository.bzl", "scs_repository")
@@ -224,8 +223,6 @@ def add_default_repositories(excludes = [], mirrors = DEFAULT_MIRRORS):
         qdldl_repository(name = "qdldl", mirrors = mirrors)
     if "ros_xacro" not in excludes:
         ros_xacro_repository(name = "ros_xacro", mirrors = mirrors)
-    if "ruby" not in excludes:
-        ruby_repository(name = "ruby")
     if "rules_pkg" not in excludes:
         rules_pkg_repository(name = "rules_pkg", mirrors = mirrors)
     if "rules_python" not in excludes:

--- a/tools/workspace/ruby/repository.bzl
+++ b/tools/workspace/ruby/repository.bzl
@@ -3,6 +3,9 @@
 load("@drake//tools/workspace:which.bzl", "which_repository")
 
 def ruby_repository(name):
+    print("The @ruby repository is deprecated and will be removed from " +
+          "Drake on or after 2020-09-01.")
+
     # Find the ruby binary.
     which_repository(
         name = name,

--- a/tools/workspace/sdformat/3bbd303.patch
+++ b/tools/workspace/sdformat/3bbd303.patch
@@ -1,0 +1,207 @@
+From 3bbd303c8b94b20244d102eae095ffcbaa4c550d Mon Sep 17 00:00:00 2001
+From: Jeremy Nimmer <jeremy.nimmer@tri.global>
+Date: Thu, 7 May 2020 19:09:57 -0400
+Subject: [PATCH] Simplify data embedding (#270)
+
+This is an internal-only refactoring that changes the mechanics of how
+the sdf/** file data is embedded into the library.
+
+For one, it solves the "static initialization order fiasco" for the
+embedded data. The data is only loaded into memory upon first use,
+instead of as the library is being loaded.
+
+It also simplifies the ruby embedding code, making it more concise.
+I hope this is easier to maintain, but it also helps me when sharing
+Drake with consumers that always build from source, but will not
+install ruby as a compile-time prerequisite
+
+The EmbeddedSdf codegen now emits the cc file with the data; the header
+is stored in git. This provides an easier way to use a function to
+retrieve the embedded strings as static locals.
+
+The embedded SDF data is now combined into a single map.  Embedding
+files should be boring, ala the WIP std::embed specification.  It
+should not include application-layer logic encoding upgrade paths.
+
+This will also make it easier to avoid the "static destruction fiasco"
+in future commits, due to fewer functions to repair.
+
+diff --git a/src/Converter.cc b/src/Converter.cc
+index 4e5abcbf..4dc66a1d 100644
+--- src/Converter.cc
++++ src/Converter.cc
+@@ -29,12 +29,18 @@
+ #include "sdf/Converter.hh"
+ #include "sdf/SDFImpl.hh"
+ #include "sdf/Types.hh"
+-
+-// This include file is generated at configure time.
+-#include "sdf/EmbeddedSdf.hh"
++#include "EmbeddedSdf.hh"
+ 
+ using namespace sdf;
+ 
++namespace {
++bool EndsWith(const std::string& _a, const std::string& _b)
++{
++  return (_a.size() >= _b.size()) &&
++      (_a.compare(_a.size() - _b.size(), _b.size(), _b) == 0);
++}
++}
++
+ /////////////////////////////////////////////////
+ bool Converter::Convert(TiXmlDocument *_doc, const std::string &_toVersion,
+                         bool _quiet)
+@@ -73,28 +79,36 @@ bool Converter::Convert(TiXmlDocument *_doc, const std::string &_toVersion,
+ 
+   elem->SetAttribute("version", _toVersion);
+ 
+-  // The conversionMap in EmbeddedSdf.hh has keys that represent a version
+-  // of SDF to convert from. The values in conversionmap are pairs, where
+-  // the first element is the SDF version that the second element will
+-  // convert to. For example, the following will convert from 1.4 to 1.5
+-  // according to "conversion_xml":
+-  //
+-  // {"1.4", {"1.5", "conversion_xml"}}
+-  std::map<std::string, std::pair<std::string, std::string> >::const_iterator
+-    fromIter = conversionMap.find(origVersion);
+-
+-  std::string toVer = "";
++  // The conversion recipes within the embedded files database are named, e.g.,
++  // "1.8/1_7.convert" to upgrade from 1.7 to 1.8.
++  const std::map<std::string, std::string> &embedded = GetEmbeddedSdf();
+ 
+-  // Starting with the original SDF version, perform all the conversions
+-  // necessary in order to reach the _toVersion.
+-  while (fromIter != conversionMap.end() && fromIter->first != _toVersion)
++  // Apply the conversions one at a time until we reach the desired _toVersion.
++  std::string curVersion = origVersion;
++  while (curVersion != _toVersion)
+   {
+-    // Get the SDF to version.
+-    toVer = fromIter->second.first;
++    // Find the (at most one) file named, e.g., ".../1_7.convert".
++    std::string snakeVersion = curVersion;
++    std::replace(snakeVersion.begin(), snakeVersion.end(), '.', '_');
++    const std::string suffix = "/" + snakeVersion + ".convert";
++    const char* convertXml = nullptr;
++    for (const auto& [pathname, data] : embedded)
++    {
++      if (EndsWith(pathname, suffix))
++      {
++        curVersion = pathname.substr(0, pathname.size() - suffix.size());
++        convertXml = data.c_str();
++        break;
++      }
++    }
++    if (convertXml == nullptr)
++    {
++      break;
++    }
+ 
+     // Parse and apply the conversion XML.
+     TiXmlDocument xmlDoc;
+-    xmlDoc.Parse(fromIter->second.second.c_str());
++    xmlDoc.Parse(convertXml);
+     if (xmlDoc.Error())
+     {
+       sdferr << "Error parsing XML from string: "
+@@ -102,13 +116,10 @@ bool Converter::Convert(TiXmlDocument *_doc, const std::string &_toVersion,
+       return false;
+     }
+     ConvertImpl(elem, xmlDoc.FirstChildElement("convert"));
+-
+-    // Get the next conversion XML map element.
+-    fromIter = conversionMap.find(toVer);
+   }
+ 
+   // Check that we actually converted to the desired final version.
+-  if (toVer != _toVersion)
++  if (curVersion != _toVersion)
+   {
+     sdferr << "Unable to convert from SDF version " << origVersion
+            << " to " << _toVersion << "\n";
+diff --git a/src/EmbeddedSdf.hh b/src/EmbeddedSdf.hh
+new file mode 100755
+index 00000000..b0c447b1
+--- /dev/null
++++ src/EmbeddedSdf.hh
+@@ -0,0 +1,40 @@
++/*
++ * Copyright 2020 Open Source Robotics Foundation
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ *
++*/
++
++#ifndef SDF_EMBEDDEDSDF_HH_
++#define SDF_EMBEDDEDSDF_HH_
++
++#include <map>
++#include <string>
++
++#include "sdf/Types.hh"
++
++namespace sdf
++{
++  // Inline bracket to help doxygen filtering.
++  inline namespace SDF_VERSION_NAMESPACE {
++  //
++
++  /// \internal
++
++  /// A map where the keys are a source-relative pathnames within the "sdf"
++  /// directory such as "1.8/root.sdf", and the values are the contents of
++  /// that source file.
++  const std::map<std::string, std::string> &GetEmbeddedSdf();
++}
++}
++#endif
+diff --git a/src/SDF.cc b/src/SDF.cc
+index 48c1943b..20dcd4c6 100644
+--- src/SDF.cc
++++ src/SDF.cc
+@@ -31,9 +31,7 @@
+ #include "sdf/SDFImpl.hh"
+ #include "SDFImplPrivate.hh"
+ #include "sdf/sdf_config.h"
+-
+-// This include file is generated at configure time.
+-#include "sdf/EmbeddedSdf.hh"
++#include "EmbeddedSdf.hh"
+ 
+ namespace sdf
+ {
+@@ -453,7 +451,8 @@ const std::string &SDF::EmbeddedSpec(
+ {
+   try
+   {
+-    return embeddedSdf.at(SDF::Version()).at(_filename);
++    const std::string pathname = SDF::Version() + "/" + _filename;
++    return GetEmbeddedSdf().at(pathname);
+   }
+   catch(const std::out_of_range &)
+   {
+@@ -461,6 +460,9 @@ const std::string &SDF::EmbeddedSpec(
+       sdferr << "Unable to find SDF filename[" << _filename << "] with "
+         << "version " << SDF::Version() << "\n";
+   }
++
++  // An empty SDF string is returned if a query into the embeddedSdf map fails.
++  static const std::string emptySdfString;
+   return emptySdfString;
+ }
+ }
+-- 
+2.17.1
+

--- a/tools/workspace/sdformat/BUILD.bazel
+++ b/tools/workspace/sdformat/BUILD.bazel
@@ -3,7 +3,10 @@
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 exports_files(
-    ["package-create-cps.py"],
+    [
+        "embed_sdf.py",
+        "package-create-cps.py",
+    ],
     visibility = ["@sdformat//:__pkg__"],
 )
 

--- a/tools/workspace/sdformat/embed_sdf.py
+++ b/tools/workspace/sdformat/embed_sdf.py
@@ -1,0 +1,27 @@
+# A re-implementation of upstream's sdf/embedSdf.rb tool in Python.
+
+import sys
+
+assert __name__ == '__main__'
+
+print("""
+#include "src/EmbeddedSdf.hh"
+namespace sdf { inline namespace SDF_VERSION_NAMESPACE {
+const std::map<std::string, std::string>& GetEmbeddedSdf() {
+  static const std::map<std::string, std::string> result{
+""")
+for filename in sorted(sys.argv[1:]):
+    _, relative_path = filename.split('/sdf/')
+    print('{')
+    print(f'"{relative_path}",')
+    with open(filename, 'r', encoding='utf-8') as data:
+        print('R"raw(')
+        sys.stdout.flush()
+        sys.stdout.buffer.write(data.read().encode('utf-8'))
+        print(')raw"')
+    print('},')
+print("""
+  };
+  return result;
+}}}
+""")

--- a/tools/workspace/sdformat/package.BUILD.bazel
+++ b/tools/workspace/sdformat/package.BUILD.bazel
@@ -1,6 +1,10 @@
 # -*- python -*-
 
 load(
+    "@drake//tools/skylark:py.bzl",
+    "py_binary",
+)
+load(
     "@drake//tools/workspace:cmake_configure_file.bzl",
     "cmake_configure_file",
 )
@@ -138,25 +142,21 @@ drake_generate_include_header(
     visibility = ["//visibility:private"],
 )
 
-# Generates EmbeddedSdf.hh.
-# TODO(jwnimmer-tri) Since the ruby code uses globbing to decide which files to
-# stringize, ideally we should create a temporary folder, copy the declared
-# `srcs` there, and then run the codegen tool -- so that its glob only finds
-# our declared `srcs`.  However, for now just relying on Bazel's runfiles tree
-# being reasonably well-defined seems good enough.
+# Generates EmbeddedSdf.cc.
 genrule(
-    name = "embed_sdf",
-    srcs = [
-        "sdf/embedSdf.rb",
-    ] + glob([
+    name = "embed_sdf_genrule",
+    srcs = glob([
         "sdf/**/*.sdf",
         "sdf/**/*.convert",
     ]),
-    outs = ["include/sdf/EmbeddedSdf.hh"],
-    cmd = "$(location @ruby) -C$$(dirname $(location sdf/embedSdf.rb)) embedSdf.rb > $@",  # noqa
-    tools = [
-        "@ruby",
-    ],
+    outs = ["src/EmbeddedSdf.cc"],
+    cmd = "$(execpath :embed_sdf) $(SRCS) > $@",  # noqa
+    tools = [":embed_sdf"],
+)
+
+py_binary(
+    name = "embed_sdf",
+    srcs = ["@drake//tools/workspace/sdformat:embed_sdf.py"],
 )
 
 SDFORMAT_ALL_PUBLIC_HDRS = SDFORMAT_MOST_PUBLIC_HDRS + [
@@ -173,7 +173,6 @@ cc_library(
     name = "sdformat",
     srcs = [
         "include/sdf/Converter.hh",
-        "include/sdf/EmbeddedSdf.hh",
         "include/sdf/SDFExtension.hh",
         "include/sdf/parser_private.hh",
         "include/sdf/parser_urdf.hh",
@@ -188,6 +187,7 @@ cc_library(
         "src/Converter.cc",
         "src/Cylinder.cc",
         "src/Element.cc",
+        "src/EmbeddedSdf.hh",
         "src/Error.cc",
         "src/Exception.cc",
         "src/ExceptionPrivate.hh",
@@ -227,6 +227,7 @@ cc_library(
         "src/World.cc",
         "src/parser.cc",
         "src/parser_urdf.cc",
+        ":src/EmbeddedSdf.cc",
     ],
     hdrs = SDFORMAT_ALL_PUBLIC_HDRS,
     # TODO(jamiesnape): Enable visibility after resolving warnings such as

--- a/tools/workspace/sdformat/repository.bzl
+++ b/tools/workspace/sdformat/repository.bzl
@@ -11,5 +11,11 @@ def sdformat_repository(
         commit = "sdformat9_9.1.0",
         sha256 = "e5ac1e7b9b37edf2236a87c7ef4c82d20710439d16933a7e4602a31c82e95367",  # noqa
         build_file = "@drake//tools/workspace/sdformat:package.BUILD.bazel",
+        patches = [
+            # TODO(jwnimmer-tri) This patch is cherry-picked from upstream; we
+            # should remove it once we reach a new enough version, probably for
+            # sdformat10 or so.
+            "@drake//tools/workspace/sdformat:3bbd303.patch",
+        ],
         mirrors = mirrors,
     )


### PR DESCRIPTION
Cherry-pick a patch from sdformat upstream to make the data embedding easier, and then re-implement the embedder in python.

Deprecate the `@ruby` external.

Closes #13231.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13262)
<!-- Reviewable:end -->
