### PR TITLE
parsing: Add regression test for libsdformat version upgrades

### DIFF
--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -63,6 +63,21 @@ GTEST_TEST(MultibodyPlantSdfParserTest, PackageMapSpecified) {
   EXPECT_EQ(plant.num_model_instances(), 3);
 }
 
+// Acceptance test that libsdformat can upgrade very old files.  This ensures
+// the upgrade machinery keeps working (in particular our re-implementation of
+// the embedSdf.rb tool within tools/workspace/sdformat).
+GTEST_TEST(MultibodyPlantSdfParserTest, VeryOldVersion) {
+  MultibodyPlant<double> plant(0.0);
+  PackageMap package_map;
+  const std::string full_sdf_filename = FindResourceOrThrow(
+      "drake/multibody/parsing/test/sdf_parser_test/very_old_version.sdf");
+
+  EXPECT_EQ(plant.num_model_instances(), 2);
+  AddModelFromSdfFile(full_sdf_filename, "", package_map, &plant, nullptr);
+  plant.Finalize();
+  EXPECT_EQ(plant.num_model_instances(), 3);
+}
+
 // Verifies model instances are correctly created in the plant.
 GTEST_TEST(MultibodyPlantSdfParserTest, ModelInstanceTest) {
   // We start with the world and default model instances (model_instance.h

--- a/multibody/parsing/test/sdf_parser_test/very_old_version.sdf
+++ b/multibody/parsing/test/sdf_parser_test/very_old_version.sdf
@@ -1,0 +1,6 @@
+<!-- An acceptance test that libsdformat can upgrade very old files. -->
+<sdf version='1.2'>
+  <model name='robot'>
+    <link name="need_at_least_one_link"/>
+  </model>
+</sdf>


### PR DESCRIPTION
Follow-up from #13262.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13265)
<!-- Reviewable:end -->
