### PR TITLE
Add module for "accuracy" and "tolerance" conventions

### DIFF
--- a/doc/doxygen.h
+++ b/doc/doxygen.h
@@ -38,6 +38,7 @@ only updated nightly.</p>
 */
 // Define groups here so we can control the ordering.
 /**
+  @defgroup terminology_and_notation Drake Terminology and Notation
   @defgroup solvers Formulating and Solving Optimization Problems
   @defgroup systems Modeling Dynamical Systems
   @defgroup multibody Multibody Kinematics and Dynamics
@@ -47,8 +48,13 @@ only updated nightly.</p>
 */
 
 /**
-  @defgroup multibody_notation Terminology and Notation
-  @ingroup multibody
+  @defgroup accuracy_and_tolerance Accuracy, Tolerance, and Precision
+  @ingroup terminology_and_notation
+*/
+
+/**
+  @defgroup multibody_notation Multibody Terminology and Notation
+  @ingroup terminology_and_notation
 */
 
 /**
@@ -85,3 +91,95 @@ only updated nightly.</p>
 
  @}
 */
+
+/** @addtogroup accuracy_and_tolerance
+ @{
+ Most numerical methods are approximate, and many can trade speed for quality
+ under user control. We need standard, unambiguous terminology in Drake for
+ requesting and reporting solution quality. The terms "tolerance", "accuracy",
+ and "precision" are commonly used in this context but often imprecisely. Below
+ we present how these terms should be used in Drake, following
+ ref. [[1]](https://dx.doi.org/10.1016/j.piutam.2011.04.023). (Some Drake code
+ and documentation may not follow these conventions for historical reasons. If
+ you spot any violations, please add them to issue
+ [#13271](https://github.com/RobotLocomotion/drake/issues/13271) so we can
+ modernize.)
+
+ ### accuracy
+
+ `accuracy` α is a unitless quantity describing permissible relative error.
+ (This is similar to the "relative tolerance" `rtol` parameter in many
+ numerical packages, including some commonly used with Drake) Ideally you can
+ think of `accuracy` as specifying the number of correct significant digits in
+ the desired result. For example, specifying `α = 10⁻³` should yield a result
+ correct to three digits while `α = 10⁻⁶` should give six. This is a Platonic
+ ideal that cannot always be achieved perfectly in practice, but Drake
+ algorithms should attempt to respond to a user's `accuracy` request in
+ approximately this way.
+
+ We use the unambiguous terms "tight/tighter/tighten accuracy" and
+ "loose/looser/loosen accuracy" in preference to "high/more/increase" or
+ "low/less/decrease" which are prone to being misunderstood due to the fact
+ that numerically smaller values correspond to more (tighter) accuracy.
+
+ ### tolerance
+
+ We use `tolerance` to mean a permissible absolute error ε, which is a quantity
+ with units. (This is similar to the "absolute tolerance" `atol` parameter in
+ many numerical packages, including some commonly used with Drake.) So
+ "constraint tolerance" is the amount by which a user is willing to have a
+ constraint violated, in units appropriate to that constraint. Thus a tolerance
+ ε=10⁻⁴ for a position constraint means that an error of 0.1mm is acceptable.
+
+ In code we often abbreviate `tolerance` as `tol`, but prefer the longer
+ spelling in documentation.
+
+ ### precision
+
+ We do not use this term in Drake in the context of solution quality in
+ numerical algorithms. Instead we reserve it for the Machine Learning
+ term-of-art as in "precision and recall". "Precision" is also conventionally
+ used in the context of floating point arithmetic, such as "double precision"
+ and "machine precision".
+
+ ### Given accuracy, we can determine tolerance
+
+ In Drake numerical tests and and error controlled numerical methods, we
+ typically determine an absolute tolerance using the user-supplied `accuracy`
+ value α, via `ε = α|q|` where q is the quantity of interest. This works well
+ provided that `|q| ≫ 0`. When q is near zero the tolerance ε could be
+ absurdly tight, and if q were exactly zero then we would have a tolerance
+ of zero, meaning only a perfect solution would be acceptable. That is not
+ achievable on a real computer and is why many packages require a user-specified
+ "absolute tolerance" that is used only for quantities near zero. This is an
+ awkward requirement for users however, since tolerance is inherently a quantity
+ with units and most systems have variables of mixed units. So while `accuracy`
+ applies equally to all quantities and is easy to determine (how many digits
+ do you want in the answer?), `tolerance` needs to be worked out for each
+ quantity. That is rarely done in practice.
+
+ An alternative method, preferred for Drake algorithms, is to make use of known
+ system scaling. For example, if we know a "unit length" ℓ (this is also called
+ a "characteristic length") for a system we can translate accuracy into
+ tolerance via `ε = αℓ`. Similarly we can define unit angle, time, and so on.
+ This leads to the following computation of absolute tolerance ε, given only the
+ user's requested accuracy α:
+
+     (1)    ε = α max(μ, |q|)
+
+ where μ is the "unit" or "characteristic" value in the same units as the
+ quantity of interest q. Because of Drake's use of MKS units and typical
+ use for human-scale robots, μ is almost always set to 1 or 0.1. Thus it is
+ typically possible to make a good guess at μ, which we have found works about
+ as well or better than trying to collect a bunch of absolute tolerances from
+ users with more important things on their minds.
+
+ You will see variants of the above Equation (1) used in many of Drake's
+ algorithms and test cases. Please use a similar method and similar terminology
+ in your own Drake contributions, unless you can make a strong argument that
+ something else is necessary.
+
+ - [1] M. Sherman, A. Seth, S. Delp. Procedia IUTAM 2:241-261 (2011),
+   Section 3.3. https://dx.doi.org/10.1016/j.piutam.2011.04.023
+ @}
+ */

--- a/systems/analysis/integrator_base.h
+++ b/systems/analysis/integrator_base.h
@@ -180,8 +180,9 @@ class IntegratorBase {
    The precise meaning of *accuracy* is a complicated discussion, but it
    translates roughly to the number of significant digits you want in the
    results. By convention it is supplied as `10^-digits`, meaning that an
-   accuracy of 1e-3 provides about three significant digits. For continued
-   discussion of accuracy, see [Sherman 2011].
+   accuracy of 1e-3 provides about three significant digits. For more
+   discussion of accuracy, see @ref accuracy_and_tolerance and ref.
+   [[1]](https://dx.doi.org/10.1016/j.piutam.2011.04.023).
 
    Integrators vary in the range of accuracy (loosest to tightest) that they
    can support, and each integrator will choose a default accuracy to be used
@@ -197,9 +198,8 @@ class IntegratorBase {
    certainly implies greater error in the ODE solution and might impact the
    stability of the solution negatively as well.
 
-   - [Sherman, 2011]  M. Sherman, et al. Procedia IUTAM 2:241-261 (2011),
-                      Section 3.3.
-                      http://dx.doi.org/10.1016/j.piutam.2011.04.023
+   - [1] M. Sherman, A. Seth, S. Delp. Procedia IUTAM 2:241-261 (2011),
+     Section 3.3. https://dx.doi.org/10.1016/j.piutam.2011.04.023
 
    @{
    */


### PR DESCRIPTION
Per issue #12890, this Doxygen-only PR does the following:
- Adds a top-level `Module` to collect Drake conventions for terminology and notation.
- Moves the existing "Multibody Terminology and Conventions" module under the new one.
- Adds a new module defining Drake's conventions and terminology for "accuracy" and "tolerance". 

The intent with the new section is that using these terms differently (or using other terminology like "precision" instead) would be a defect in new Drake code, and that there is now an `@ref` link we can use in Drake documentation rather than having to explain it all repeatedly.

The Modules section will look like this:
![image](https://user-images.githubusercontent.com/4088016/81458506-8a7b4600-914f-11ea-863d-a17411c9cf7c.png)

Resolves #12890.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13267)
<!-- Reviewable:end -->
