### PR TITLE
trajectories: add Lagrange Interpolating Polynomial and Block(i,j,p,q)

### DIFF
--- a/bindings/pydrake/test/trajectories_test.py
+++ b/bindings/pydrake/test/trajectories_test.py
@@ -70,7 +70,7 @@ class TestTrajectories(unittest.TestCase):
 
     def test_cubic(self):
         t = [0., 1., 2.]
-        x = np.diag((4., 5., 6.))
+        x = np.diag([4., 5., 6.])
         periodic_end = False
         # Just test the spelling for these.
         pp1 = PiecewisePolynomial.CubicWithContinuousSecondDerivatives(
@@ -80,6 +80,37 @@ class TestTrajectories(unittest.TestCase):
         pp3 = PiecewisePolynomial.CubicWithContinuousSecondDerivatives(
             breaks=t, samples=x, sample_dot_at_start=[0., 0., 0.],
             sample_dot_at_end=[0., 0., 0.])
+
+    def test_lagrange_interpolating_polynomial(self):
+        t = [0., 1., 2.]
+        x = np.diag([4., 5., 6.])
+        pp = PiecewisePolynomial.LagrangeInterpolatingPolynomial(times=t,
+                                                                 samples=x)
+        self.assertEqual(pp.get_number_of_segments(), 1)
+        np.testing.assert_array_almost_equal(x[:, [1]], pp.value(1.), 1e-12)
+
+    def test_reverse_and_scale_time(self):
+        x = np.array([[10.], [20.], [30.]]).transpose()
+        pp = PiecewisePolynomial.FirstOrderHold([0.5, 1., 2.], x)
+        pp.ReverseTime()
+        self.assertEqual(pp.start_time(), -2.0)
+        self.assertEqual(pp.end_time(), -0.5)
+        pp.ScaleTime(2.0)
+        self.assertEqual(pp.start_time(), -4.0)
+        self.assertEqual(pp.end_time(), -1.0)
+
+    def test_reshape_and_block(self):
+        t = [0., 1., 2., 3.]
+        x = np.diag([4., 5., 6., 7.])
+        pp = PiecewisePolynomial.FirstOrderHold(t, x)
+        self.assertEqual(pp.rows(), 4)
+        self.assertEqual(pp.cols(), 1)
+        pp.Reshape(rows=2, cols=2)
+        self.assertEqual(pp.rows(), 2)
+        self.assertEqual(pp.cols(), 2)
+        pp2 = pp.Block(start_row=0, start_col=0, block_rows=2, block_cols=1)
+        self.assertEqual(pp2.rows(), 2)
+        self.assertEqual(pp2.cols(), 1)
 
     def test_slice_and_shift(self):
         x = np.array([[10.], [20.], [30.]]).transpose()

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -158,6 +158,12 @@ PYBIND11_MODULE(trajectories, m) {
                 breaks, samples, periodic_end);
           },
           py::arg("breaks"), py::arg("knots"), py::arg("periodic_end"))
+      .def_static("LagrangeInterpolatingPolynomial",
+          py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
+              const Eigen::Ref<const MatrixX<T>>&>(
+              &PiecewisePolynomial<T>::LagrangeInterpolatingPolynomial),
+          py::arg("times"), py::arg("samples"),
+          doc.PiecewisePolynomial.LagrangeInterpolatingPolynomial.doc)
       .def("value", &PiecewisePolynomial<T>::value, py::arg("t"),
           doc.PiecewisePolynomial.value.doc)
       .def("derivative", &PiecewisePolynomial<T>::derivative,
@@ -176,6 +182,11 @@ PYBIND11_MODULE(trajectories, m) {
       .def("isApprox", &PiecewisePolynomial<T>::isApprox, py::arg("other"),
           py::arg("tol"), py::arg("tol_type") = drake::ToleranceType::kRelative,
           doc.PiecewisePolynomial.isApprox.doc)
+      .def("Reshape", &PiecewisePolynomial<T>::Reshape, py::arg("rows"),
+          py::arg("cols"), doc.PiecewisePolynomial.Reshape.doc)
+      .def("Block", &PiecewisePolynomial<T>::Block, py::arg("start_row"),
+          py::arg("start_col"), py::arg("block_rows"), py::arg("block_cols"),
+          doc.PiecewisePolynomial.Block.doc)
       .def("ConcatenateInTime", &PiecewisePolynomial<T>::ConcatenateInTime,
           py::arg("other"), doc.PiecewisePolynomial.ConcatenateInTime.doc)
       .def("AppendCubicHermiteSegment",
@@ -184,6 +195,10 @@ PYBIND11_MODULE(trajectories, m) {
           doc.PiecewisePolynomial.AppendCubicHermiteSegment.doc)
       .def("RemoveFinalSegment", &PiecewisePolynomial<T>::RemoveFinalSegment,
           doc.PiecewisePolynomial.RemoveFinalSegment.doc)
+      .def("ReverseTime", &PiecewisePolynomial<T>::ReverseTime,
+          doc.PiecewisePolynomial.ReverseTime.doc)
+      .def("ScaleTime", &PiecewisePolynomial<T>::ScaleTime, py::arg("scale"),
+          doc.PiecewisePolynomial.ScaleTime.doc)
       .def("slice", &PiecewisePolynomial<T>::slice,
           py::arg("start_segment_index"), py::arg("num_segments"),
           doc.PiecewisePolynomial.slice.doc)

--- a/common/trajectories/BUILD.bazel
+++ b/common/trajectories/BUILD.bazel
@@ -137,7 +137,7 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
-    name = "piecewise_generation_test",
+    name = "piecewise_polynomial_generation_test",
     # Test timeout increased to not timeout when run with Valgrind.
     timeout = "moderate",
     srcs = ["test/piecewise_polynomial_generation_test.cc"],

--- a/common/trajectories/piecewise_polynomial.h
+++ b/common/trajectories/piecewise_polynomial.h
@@ -223,8 +223,8 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
 
   /**
    * Version of ZeroOrderHold(breaks, samples) that uses vector samples and
-   * Eigen VectorXd/MatrixX<T> inputs. Each column of `samples` represents a sample
-   * point.
+   * Eigen VectorXd/MatrixX<T> arguments. Each column of `samples` represents a
+   * sample point.
    *
    * @pre `samples.cols() == breaks.size()`
    * @throws std::runtime_error under the conditions specified under
@@ -247,8 +247,8 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
 
   /**
    * Version of FirstOrderHold(breaks, samples) that uses vector samples and
-   * Eigen VectorXd / MatrixX<T> inputs. Each column of `samples`
-   * represents a sample point.
+   * Eigen VectorXd / MatrixX<T> arguments. Each column of `samples` represents
+   * a sample point.
    *
    * @pre `samples.cols() == breaks.size()`
    * @throws std::runtime_error under the conditions specified under
@@ -316,8 +316,8 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
 
   /**
    * Version of CubicShapePreserving(breaks, samples,
-   * zero_end_point_derivatives) that uses vector samples and Eigen VectorXd
-   * and MatrixX<T> inputs. Each column of `samples` represents a sample point.
+   * zero_end_point_derivatives) that uses vector samples and Eigen VectorXd and
+   * MatrixX<T> arguments. Each column of `samples` represents a sample point.
    *
    * @pre `samples.cols() == breaks.size()`.
    * @throws std::runtime_error under the conditions specified under
@@ -369,7 +369,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
 
   /**
    * Version of CubicWithContinuousSecondDerivatives() that uses vector
-   * samples and Eigen VectorXd / MatrixX<T> inputs. Each column of
+   * samples and Eigen VectorXd / MatrixX<T> arguments. Each column of
    * `samples` represents a sample point.
    *
    * @pre `samples.cols() == breaks.size()`.
@@ -395,11 +395,11 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
 
   /**
    * Constructs a third order %PiecewisePolynomial using matrix samples and
-   * derivatives of samples (`samples_dot`); each matrix element of `samples_dot`
-   * represents the derivative with respect to the independent variable (e.g.,
-   * the time derivative) of the corresponding entry in `samples`.
-   * Each segment is fully specified by `samples` and `sample_dot` at both ends.
-   * Second derivatives are not continuous.
+   * derivatives of samples (`samples_dot`); each matrix element of
+   * `samples_dot` represents the derivative with respect to the independent
+   * variable (e.g., the time derivative) of the corresponding entry in
+   * `samples`. Each segment is fully specified by `samples` and `sample_dot` at
+   * both ends. Second derivatives are not continuous.
    *
    * @exclude_from_pydrake_mkdoc{This overload is not bound in pydrake.}
    */
@@ -418,10 +418,10 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
   }
 
   /**
-   * Version of CubicHermite(breaks, samples, samples_dot) that uses vector samples and
-   * Eigen VectorXd / MatrixX<T> inputs. Corresponding columns of `samples` and
-   * `samples_dot` are used as the sample point and independent variable derivative,
-   * respectively.
+   * Version of CubicHermite(breaks, samples, samples_dot) that uses vector
+   * samples and Eigen VectorXd / MatrixX<T> arguments. Corresponding columns of
+   * `samples` and `samples_dot` are used as the sample point and independent
+   * variable derivative, respectively.
    *
    * @pre `samples.cols() == samples_dot.cols() == breaks.size()`.
    */
@@ -481,7 +481,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
 
   /**
    * Version of CubicWithContinuousSecondDerivatives(breaks, samples) that
-   * uses vector samples and Eigen VectorXd / MatrixX<T> inputs. Each column
+   * uses vector samples and Eigen VectorXd / MatrixX<T> arguments. Each column
    * of `samples` represents a sample point.
    *
    * @pre `samples.cols() == breaks.size()`.
@@ -498,6 +498,30 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
     return CubicWithContinuousSecondDerivatives(breaks, samples,
         periodic_end_condition);
   }
+
+  /**
+   * Constructs a polynomial with a *single segment* of the lowest possible
+   * degree that passes through all of the sample points.  See "polynomial
+   * interpolation" and/or "Lagrange polynomial" on Wikipedia for more
+   * information.
+   * @pre `times` must be monotonically increasing.
+   * @pre `samples.size() == times.size()`.
+   * @exclude_from_pydrake_mkdoc{This overload is not bound in pydrake.}
+   */
+  static PiecewisePolynomial LagrangeInterpolatingPolynomial(
+      const std::vector<T>& times, const std::vector<MatrixX<T>>& samples);
+
+  /**
+   * Version of LagrangeInterpolatingPolynomial(times, samples) that
+   * uses vector samples and Eigen VectorXd / MatrixX<T> arguments. Each column
+   * of `samples` represents a sample point.
+   *
+   * @pre `samples.cols() == times.size()`.
+   */
+  static PiecewisePolynomial<T> LagrangeInterpolatingPolynomial(
+      const Eigen::Ref<const VectorX<T>>& times,
+      const Eigen::Ref<const MatrixX<T>>& samples);
+
   // @}
 
   /**
@@ -613,6 +637,15 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * @see Eigen::PlainObjectBase::resize().
    */
   void Reshape(int rows, int cols);
+
+  /**
+   * Extracts a trajectory representing a block of size (block_rows, block_cols)
+   * starting at (start_row, start_col) from the PiecewisePolynomial.
+   * @returns a PiecewisePolynomial such that
+   *   ret.value(t) = this.value(t).block(i,j,p,q);
+   */
+  PiecewisePolynomial Block(int start_row, int start_col, int block_rows,
+                            int block_cols) const;
 
   /**
    * Adds each Polynomial in the PolynomialMatrix of `other` to the

--- a/common/trajectories/test/piecewise_polynomial_generation_test.cc
+++ b/common/trajectories/test/piecewise_polynomial_generation_test.cc
@@ -686,6 +686,43 @@ GTEST_TEST(SplineTests, TestException) {
                std::runtime_error);
 }
 
+GTEST_TEST(SplineTests, LagrangeInterpolatingPolynomialTest) {
+  Eigen::Vector4d times(0.1, 0.5, 0.8, 1.34);
+  Eigen::RowVector4d samples(4.1, -1.3, 0.5, -3.4);
+
+  PiecewisePolynomial<double> scalar_trajectory =
+      PiecewisePolynomial<double>::LagrangeInterpolatingPolynomial(times,
+                                                                   samples);
+
+  EXPECT_EQ(scalar_trajectory.start_time(), times[0]);
+  EXPECT_EQ(scalar_trajectory.end_time(), times[times.size() - 1]);
+  EXPECT_EQ(scalar_trajectory.get_number_of_segments(), 1);
+  EXPECT_EQ(scalar_trajectory.getPolynomial(0, 0, 0).GetDegree(),
+            times.size() - 1);
+  EXPECT_TRUE(CompareMatrices(
+      scalar_trajectory.vector_values({times[0], times[1], times[2], times[3]}),
+      samples, 1e-12));
+
+  std::vector<double> mtimes = {-3.2, 0.4, 6.7};
+  std::vector<Eigen::MatrixXd> msamples(3);
+  const int rows = 3;
+  const int cols = 2;
+  for (size_t i = 0; i < mtimes.size(); ++i) {
+    msamples[i] = Eigen::MatrixXd::Random(rows, cols);
+  }
+  PiecewisePolynomial<double> matrix_trajectory =
+      PiecewisePolynomial<double>::LagrangeInterpolatingPolynomial(mtimes,
+                                                                   msamples);
+  EXPECT_EQ(matrix_trajectory.start_time(), mtimes[0]);
+  EXPECT_EQ(matrix_trajectory.end_time(), mtimes[mtimes.size() - 1]);
+  EXPECT_EQ(matrix_trajectory.get_number_of_segments(), 1);
+
+  for (size_t i = 0; i < mtimes.size(); ++i) {
+    EXPECT_TRUE(CompareMatrices(matrix_trajectory.value(mtimes[i]), msamples[i],
+                                1e-12));
+  }
+}
+
 }  // namespace
 }  // namespace trajectories
 }  // namespace drake

--- a/common/trajectories/test/piecewise_polynomial_test.cc
+++ b/common/trajectories/test/piecewise_polynomial_test.cc
@@ -393,7 +393,7 @@ GTEST_TEST(testPiecewisePolynomial, ReverseAndScaleTimeTest) {
   TestScaling(spline, 4.3);
 }
 
-GTEST_TEST(testPiecewisePolynomial, ReshapeTest) {
+GTEST_TEST(testPiecewisePolynomial, ReshapeAndBlockTest) {
   std::vector<double> breaks = {0, .5, 1.};
   std::vector<Eigen::MatrixXd> samples(3);
   samples[0].resize(2, 3);
@@ -416,6 +416,17 @@ GTEST_TEST(testPiecewisePolynomial, ReshapeTest) {
   samples[1].resize(3, 2);
   EXPECT_TRUE(CompareMatrices(zoh.value(0.25), samples[0]));
   EXPECT_TRUE(CompareMatrices(zoh.value(0.75), samples[1]));
+
+  PiecewisePolynomial<double> block = zoh.Block(1, 1, 2, 1);
+  EXPECT_EQ(block.rows(), 2);
+  EXPECT_EQ(block.cols(), 1);
+  EXPECT_EQ(block.start_time(), zoh.start_time());
+  EXPECT_EQ(block.end_time(), zoh.end_time());
+  EXPECT_EQ(block.get_number_of_segments(), zoh.get_number_of_segments());
+
+  EXPECT_EQ(zoh.Block(0, 0, 1, 1).value(0.25), samples[0].block(0, 0, 1, 1));
+  EXPECT_EQ(zoh.Block(2, 1, 1, 1).value(0.75), samples[1].block(2, 1, 1, 1));
+  EXPECT_EQ(zoh.Block(1, 1, 2, 1).value(0.75), samples[1].block(1, 1, 2, 1));
 }
 
 GTEST_TEST(testPiecewisePolynomial, IsApproxTest) {


### PR DESCRIPTION
These are in service of the implementation of the affine terms in the finite-horizon LQR code (which will be PR'd once this lands).

also includes the python bindings (and some bindings that I had skipped in my previous commit).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13269)
<!-- Reviewable:end -->
