### PR TITLE
py systems: Bind OutputPort.Allocate(), DiagramBuilder.empty(), .GetMutableSystems()

### DIFF
--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -434,7 +434,8 @@ void DefineFrameworkPySemantics(py::module m) {
             "as a BasicVector. Most users should call Eval() instead. "
             "This method is only needed when the result will be passed "
             "into some other API that only accepts a BasicVector.",
-            py_reference_internal);
+            py_reference_internal)
+        .def("Allocate", &OutputPort<T>::Allocate, doc.OutputPort.Allocate.doc);
 
     auto system_output = DefineTemplateClassWithDefault<SystemOutput<T>>(
         m, "SystemOutput", GetPyParam<T>(), doc.SystemOutput.doc);

--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -384,6 +384,20 @@ void DefineFrameworkPySemantics(py::module m) {
             py::arg("system"),
             // Keep alive, ownership: `system` keeps `self` alive.
             py::keep_alive<2, 1>(), doc.DiagramBuilder.AddSystem.doc)
+        .def("empty", &DiagramBuilder<T>::empty, doc.DiagramBuilder.empty.doc)
+        .def("GetMutableSystems",
+            [](DiagramBuilder<T>* self) {
+              py::list out;
+              py::object self_py = py::cast(self, py_reference);
+              for (auto* system : self->GetMutableSystems()) {
+                py::object system_py = py::cast(system, py_reference);
+                // Keep alive, ownership: `system` keeps `self` alive.
+                py_keep_alive(system_py, self_py);
+                out.append(system_py);
+              }
+              return out;
+            },
+            doc.DiagramBuilder.GetMutableSystems.doc)
         .def("Connect",
             py::overload_cast<const OutputPort<T>&, const InputPort<T>&>(
                 &DiagramBuilder<T>::Connect),

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -385,14 +385,20 @@ class TestGeneral(unittest.TestCase):
         size = 3
 
         builder = DiagramBuilder()
+        self.assertTrue(builder.empty())
         adder0 = builder.AddSystem(Adder(2, size))
         adder0.set_name("adder0")
+        self.assertFalse(builder.empty())
 
         adder1 = builder.AddSystem(Adder(2, size))
         adder1.set_name("adder1")
 
         integrator = builder.AddSystem(Integrator(size))
         integrator.set_name("integrator")
+
+        self.assertEqual(
+            builder.GetMutableSystems(),
+            [adder0, adder1, integrator])
 
         builder.Connect(adder0.get_output_port(0), adder1.get_input_port(0))
         builder.Connect(adder1.get_output_port(0),

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -102,7 +102,9 @@ class TestGeneral(unittest.TestCase):
         self.assertEqual(u1.get_index(), 1)
         self.assertEqual(u1.size(), 10)
         self.assertIsNotNone(u1.ticket())
-        self.assertEqual(system.GetOutputPort("sum").get_index(), 0)
+        y = system.GetOutputPort("sum")
+        self.assertEqual(y.get_index(), 0)
+        self.assertIsInstance(y.Allocate(), Value[BasicVector])
         # TODO(eric.cousineau): Consolidate the main API tests for `System`
         # to this test point.
 


### PR DESCRIPTION
Motivation is to be able to make an "auto" printer system.

Using the `FunctionSystem` [prototype I mentioned in Slack](https://drakedevelopers.slack.com/archives/C2CK4CWE7/p1588895156032800), I can do something like this:
```py
def make_printer(cls, fmt=None, print=print):
    if fmt is None:
        fmt = "{}"

    def print_value(value: cls) -> None:
        print(fmt.format(value))

    printer = FunctionSystem(print_value, set_name=False)
    return printer


def connect_printer(builder, output, dt, fmt=None):
    cls = type(output.Allocate().get_value())
    printer = make_printer(cls, fmt=fmt)
    builder.AddSystem(printer)
    builder.Connect(output, printer.get_input_port(0))

...
# No redundant info necessary.
connect_printer(builder, system.get_output_port(0), 0.1)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13270)
<!-- Reviewable:end -->
