### PR TITLE
solvers: Skip compiled-but-unconfigured commercial solvers by default

### DIFF
--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -239,6 +239,10 @@ class PySolverInterface : public py::wrapper<solvers::SolverInterface> {
     PYBIND11_OVERLOAD_PURE(bool, solvers::SolverInterface, available);
   }
 
+  bool enabled() const override {
+    PYBIND11_OVERLOAD_PURE(bool, solvers::SolverInterface, enabled);
+  }
+
   void Solve(const solvers::MathematicalProgram& prog,
       const std::optional<Eigen::VectorXd>& initial_guess,
       const std::optional<solvers::SolverOptions>& solver_options,

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -819,6 +819,9 @@ class DummySolverInterface(SolverInterface):
     def available(self):
         return True
 
+    def enabled(self):
+        return True
+
     def solver_id(self):
         return SolverId("dummy")
 
@@ -833,6 +836,7 @@ class TestSolverInterface(unittest.TestCase):
     def test_dummy_solver_interface(self):
         solver = DummySolverInterface()
         self.assertTrue(solver.available())
+        self.assertTrue(solver.enabled())
         self.assertEqual(solver.solver_id().name(), "dummy")
         self.assertIsInstance(solver, SolverInterface)
         prog = mp.MathematicalProgram()

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -1523,6 +1523,17 @@ drake_cc_googletest(
     ],
 )
 
+# TODO(jwnimmer-tri) Remove this test on 2020-09-01 when the deprecated
+# SolverBase constructor is also removed.
+drake_cc_googletest(
+    name = "solver_base_deprecated_test",
+    copts = ["-Wno-deprecated-declarations"],
+    deps = [
+        ":mathematical_program",
+        ":solver_base",
+    ],
+)
+
 drake_cc_googletest(
     name = "solver_id_test",
     deps = [

--- a/solvers/choose_best_solver.cc
+++ b/solvers/choose_best_solver.cc
@@ -14,48 +14,43 @@
 
 namespace drake {
 namespace solvers {
+
+template <typename SomeSolver>
+bool IsMatch(const MathematicalProgram& prog) {
+  return SomeSolver::is_available() && SomeSolver::is_enabled() &&
+      SomeSolver::ProgramAttributesSatisfied(prog);
+}
+
 SolverId ChooseBestSolver(const MathematicalProgram& prog) {
-  if (LinearSystemSolver::is_available() &&
-      LinearSystemSolver::ProgramAttributesSatisfied(prog)) {
+  if (IsMatch<LinearSystemSolver>(prog)) {
     return LinearSystemSolver::id();
-  } else if (EqualityConstrainedQPSolver::is_available() &&
-             EqualityConstrainedQPSolver::ProgramAttributesSatisfied(prog)) {
+  } else if (IsMatch<EqualityConstrainedQPSolver>(prog)) {
     return EqualityConstrainedQPSolver::id();
-  } else if (MosekSolver::is_available() &&
-             MosekSolver::ProgramAttributesSatisfied(prog)) {
+  } else if (IsMatch<MosekSolver>(prog)) {
     // TODO(hongkai.dai@tri.global): based on my limited experience, Mosek is
     // faster than Gurobi for convex optimization problem. But we should run
     // a more thorough comparison.
     return MosekSolver::id();
-  } else if (GurobiSolver::is_available() &&
-             GurobiSolver::ProgramAttributesSatisfied(prog)) {
+  } else if (IsMatch<GurobiSolver>(prog)) {
     return GurobiSolver::id();
-  } else if (OsqpSolver::is_available() &&
-             OsqpSolver::ProgramAttributesSatisfied(prog)) {
+  } else if (IsMatch<OsqpSolver>(prog)) {
     return OsqpSolver::id();
-  } else if (MobyLCPSolver<double>::is_available() &&
-             MobyLCPSolver<double>::ProgramAttributesSatisfied(prog)) {
+  } else if (IsMatch<MobyLCPSolver<double>>(prog)) {
     return MobyLcpSolverId::id();
-  } else if (SnoptSolver::is_available() &&
-             SnoptSolver::ProgramAttributesSatisfied(prog)) {
+  } else if (IsMatch<SnoptSolver>(prog)) {
     return SnoptSolver::id();
-  } else if (IpoptSolver::is_available() &&
-             IpoptSolver::ProgramAttributesSatisfied(prog)) {
+  } else if (IsMatch<IpoptSolver>(prog)) {
     return IpoptSolver::id();
-  } else if (NloptSolver::is_available() &&
-             NloptSolver::ProgramAttributesSatisfied(prog)) {
+  } else if (IsMatch<NloptSolver>(prog)) {
     return NloptSolver::id();
-  } else if (CsdpSolver::is_available() &&
-             CsdpSolver::ProgramAttributesSatisfied(prog)) {
+  } else if (IsMatch<CsdpSolver>(prog)) {
     return CsdpSolver::id();
-  } else if (ScsSolver::is_available() &&
-             ScsSolver::ProgramAttributesSatisfied(prog)) {
+  } else if (IsMatch<ScsSolver>(prog)) {
     // Use SCS as the last resort. SCS uses ADMM method, which converges fast to
     // modest accuracy quite fast, but then slows down significantly if the user
     // wants high accuracy.
     return ScsSolver::id();
   }
-
   throw std::invalid_argument(
       "There is no available solver for the optimization program");
 }
@@ -87,5 +82,6 @@ std::unique_ptr<SolverInterface> MakeSolver(const SolverId& id) {
     throw std::invalid_argument("MakeSolver: no matching solver " + id.name());
   }
 }
+
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/csdp_solver.h
+++ b/solvers/csdp_solver.h
@@ -111,6 +111,7 @@ class CsdpSolver final : public SolverBase {
   //@{
   static SolverId id();
   static bool is_available();
+  static bool is_enabled();
   static bool ProgramAttributesSatisfied(const MathematicalProgram&);
   //@}
 

--- a/solvers/csdp_solver_common.cc
+++ b/solvers/csdp_solver_common.cc
@@ -12,7 +12,7 @@ namespace drake {
 namespace solvers {
 
 CsdpSolver::CsdpSolver(CsdpSolver::RemoveFreeVariableMethod method)
-    : SolverBase(&id, &is_available, &ProgramAttributesSatisfied),
+    : SolverBase(&id, &is_available, &is_enabled, &ProgramAttributesSatisfied),
       method_{method} {}
 
 CsdpSolver::~CsdpSolver() = default;
@@ -21,6 +21,8 @@ SolverId CsdpSolver::id() {
   static const never_destroyed<SolverId> singleton{"CSDP"};
   return singleton.access();
 }
+
+bool CsdpSolver::is_enabled() { return true; }
 
 bool CsdpSolver::ProgramAttributesSatisfied(const MathematicalProgram& prog) {
   static const never_destroyed<ProgramAttributes> solver_capabilities(

--- a/solvers/dreal_solver.h
+++ b/solvers/dreal_solver.h
@@ -86,6 +86,7 @@ class DrealSolver final : public SolverBase {
   //@{
   static SolverId id();
   static bool is_available();
+  static bool is_enabled();
   static bool ProgramAttributesSatisfied(const MathematicalProgram&);
   //@}
 

--- a/solvers/dreal_solver_common.cc
+++ b/solvers/dreal_solver_common.cc
@@ -12,7 +12,8 @@ namespace drake {
 namespace solvers {
 
 DrealSolver::DrealSolver()
-    : SolverBase(&id, &is_available, &ProgramAttributesSatisfied) {}
+    : SolverBase(&id, &is_available, &is_enabled,
+                 &ProgramAttributesSatisfied) {}
 
 DrealSolver::~DrealSolver() = default;
 
@@ -20,6 +21,8 @@ SolverId DrealSolver::id() {
   static const never_destroyed<SolverId> singleton{"dReal"};
   return singleton.access();
 }
+
+bool DrealSolver::is_enabled() { return true; }
 
 bool DrealSolver::ProgramAttributesSatisfied(const MathematicalProgram& prog) {
   static const never_destroyed<ProgramAttributes> solver_capabilities(

--- a/solvers/equality_constrained_qp_solver.cc
+++ b/solvers/equality_constrained_qp_solver.cc
@@ -92,7 +92,8 @@ void GetEqualityConstrainedQPSolverOptions(
 }  // namespace
 
 EqualityConstrainedQPSolver::EqualityConstrainedQPSolver()
-    : SolverBase(&id, &is_available, &ProgramAttributesSatisfied) {}
+    : SolverBase(&id, &is_available, &is_enabled,
+                 &ProgramAttributesSatisfied) {}
 
 EqualityConstrainedQPSolver::~EqualityConstrainedQPSolver() = default;
 
@@ -304,6 +305,8 @@ SolverId EqualityConstrainedQPSolver::id() {
 }
 
 bool EqualityConstrainedQPSolver::is_available() { return true; }
+
+bool EqualityConstrainedQPSolver::is_enabled() { return true; }
 
 bool EqualityConstrainedQPSolver::ProgramAttributesSatisfied(
     const MathematicalProgram& prog) {

--- a/solvers/equality_constrained_qp_solver.h
+++ b/solvers/equality_constrained_qp_solver.h
@@ -33,6 +33,7 @@ class EqualityConstrainedQPSolver final : public SolverBase {
   //@{
   static SolverId id();
   static bool is_available();
+  static bool is_enabled();
   static bool ProgramAttributesSatisfied(const MathematicalProgram&);
   //@}
 

--- a/solvers/gurobi_solver.cc
+++ b/solvers/gurobi_solver.cc
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <cstdlib>
 #include <limits>
 #include <stdexcept>
 #include <vector>
@@ -644,8 +643,7 @@ bool GurobiSolver::is_available() { return true; }
 class GurobiSolver::License {
  public:
   License() {
-    const char* grb_license_file = std::getenv("GRB_LICENSE_FILE");
-    if (grb_license_file == nullptr) {
+    if (!GurobiSolver::is_enabled()) {
       throw std::runtime_error(
           "Could not locate Gurobi license key file because GRB_LICENSE_FILE "
           "environment variable was not set.");

--- a/solvers/gurobi_solver.h
+++ b/solvers/gurobi_solver.h
@@ -151,6 +151,9 @@ class GurobiSolver final : public SolverBase {
   //@{
   static SolverId id();
   static bool is_available();
+  /// Returns true iff the environment variable GRB_LICENSE_FILE has been set
+  /// to a non-empty value.
+  static bool is_enabled();
   static bool ProgramAttributesSatisfied(const MathematicalProgram&);
   //@}
 

--- a/solvers/gurobi_solver_common.cc
+++ b/solvers/gurobi_solver_common.cc
@@ -2,6 +2,9 @@
 #include "drake/solvers/gurobi_solver.h"
 /* clang-format on */
 
+#include <cstdlib>
+#include <cstring>
+
 #include "drake/common/never_destroyed.h"
 #include "drake/solvers/mathematical_program.h"
 
@@ -12,13 +15,20 @@ namespace drake {
 namespace solvers {
 
 GurobiSolver::GurobiSolver()
-    : SolverBase(&id, &is_available, &ProgramAttributesSatisfied) {}
+    : SolverBase(&id, &is_available, &is_enabled,
+                 &ProgramAttributesSatisfied) {}
 
 GurobiSolver::~GurobiSolver() = default;
 
 SolverId GurobiSolver::id() {
   static const never_destroyed<SolverId> singleton{"Gurobi"};
   return singleton.access();
+}
+
+bool GurobiSolver::is_enabled() {
+  const char* grb_license_file = std::getenv("GRB_LICENSE_FILE");
+  return ((grb_license_file != nullptr) &&
+          (std::strlen(grb_license_file) > 0));
 }
 
 bool GurobiSolver::ProgramAttributesSatisfied(const MathematicalProgram& prog) {

--- a/solvers/ipopt_solver.h
+++ b/solvers/ipopt_solver.h
@@ -54,6 +54,7 @@ class IpoptSolver final : public SolverBase {
   //@{
   static SolverId id();
   static bool is_available();
+  static bool is_enabled();
   static bool ProgramAttributesSatisfied(const MathematicalProgram&);
   //@}
 

--- a/solvers/ipopt_solver_common.cc
+++ b/solvers/ipopt_solver_common.cc
@@ -9,7 +9,8 @@ namespace drake {
 namespace solvers {
 
 IpoptSolver::IpoptSolver()
-    : SolverBase(&id, &is_available, &ProgramAttributesSatisfied) {}
+    : SolverBase(&id, &is_available, &is_enabled,
+                 &ProgramAttributesSatisfied) {}
 
 IpoptSolver::~IpoptSolver() = default;
 
@@ -17,6 +18,8 @@ SolverId IpoptSolver::id() {
   static const never_destroyed<SolverId> singleton{"IPOPT"};
   return singleton.access();
 }
+
+bool IpoptSolver::is_enabled() { return true; }
 
 bool IpoptSolver::ProgramAttributesSatisfied(const MathematicalProgram& prog) {
   static const never_destroyed<ProgramAttributes> solver_capabilities(

--- a/solvers/linear_system_solver.cc
+++ b/solvers/linear_system_solver.cc
@@ -15,11 +15,14 @@ namespace drake {
 namespace solvers {
 
 LinearSystemSolver::LinearSystemSolver()
-    : SolverBase(&id, &is_available, &ProgramAttributesSatisfied) {}
+    : SolverBase(&id, &is_available, &is_enabled,
+                 &ProgramAttributesSatisfied) {}
 
 LinearSystemSolver::~LinearSystemSolver() = default;
 
 bool LinearSystemSolver::is_available() { return true; }
+
+bool LinearSystemSolver::is_enabled() { return true; }
 
 void LinearSystemSolver::DoSolve(
     const MathematicalProgram& prog,

--- a/solvers/linear_system_solver.h
+++ b/solvers/linear_system_solver.h
@@ -20,6 +20,7 @@ class LinearSystemSolver final : public SolverBase {
   //@{
   static SolverId id();
   static bool is_available();
+  static bool is_enabled();
   static bool ProgramAttributesSatisfied(const MathematicalProgram&);
   //@}
 

--- a/solvers/moby_lcp_solver.cc
+++ b/solvers/moby_lcp_solver.cc
@@ -1033,7 +1033,8 @@ bool MobyLCPSolver<T>::SolveLcpLemkeRegularized(const MatrixX<T>& M,
 
 template <typename T>
 MobyLCPSolver<T>::MobyLCPSolver()
-    : SolverBase(&id, &is_available, &ProgramAttributesSatisfied) {}
+    : SolverBase(&id, &is_available, &is_enabled,
+                 &ProgramAttributesSatisfied) {}
 
 template <typename T>
 MobyLCPSolver<T>::~MobyLCPSolver() = default;
@@ -1050,6 +1051,11 @@ SolverId MobyLCPSolver<T>::id() {
 
 template <typename T>
 bool MobyLCPSolver<T>::is_available() {
+  return true;
+}
+
+template <typename T>
+bool MobyLCPSolver<T>::is_enabled() {
   return true;
 }
 

--- a/solvers/moby_lcp_solver.h
+++ b/solvers/moby_lcp_solver.h
@@ -277,6 +277,7 @@ class MobyLCPSolver final : public SolverBase {
   //@{
   static SolverId id();
   static bool is_available();
+  static bool is_enabled();
   static bool ProgramAttributesSatisfied(const MathematicalProgram&);
   //@}
 

--- a/solvers/mosek_solver.cc
+++ b/solvers/mosek_solver.cc
@@ -4,7 +4,6 @@
 #include <array>
 #include <atomic>
 #include <cmath>
-#include <cstdlib>
 #include <limits>
 #include <list>
 #include <stdexcept>
@@ -1201,8 +1200,7 @@ MSKrescodee AddEqualityConstraintBetweenMatrixVariablesForSameDecisionVariable(
 class MosekSolver::License {
  public:
   License() {
-    const char* moseklm_license_file = std::getenv("MOSEKLM_LICENSE_FILE");
-    if (moseklm_license_file == nullptr) {
+    if (!MosekSolver::is_enabled()) {
       throw std::runtime_error(
           "Could not locate MOSEK license file because MOSEKLM_LICENSE_FILE "
           "environment variable was not set.");

--- a/solvers/mosek_solver.h
+++ b/solvers/mosek_solver.h
@@ -89,6 +89,9 @@ class MosekSolver final : public SolverBase {
   //@{
   static SolverId id();
   static bool is_available();
+  /// Returns true iff the environment variable MOSEKLM_LICENSE_FILE has been
+  /// set to a non-empty value.
+  static bool is_enabled();
   static bool ProgramAttributesSatisfied(const MathematicalProgram&);
   //@}
 

--- a/solvers/mosek_solver_common.cc
+++ b/solvers/mosek_solver_common.cc
@@ -2,6 +2,9 @@
 #include "drake/solvers/mosek_solver.h"
 /* clang-format on */
 
+#include <cstdlib>
+#include <cstring>
+
 #include "drake/common/never_destroyed.h"
 #include "drake/solvers/mathematical_program.h"
 
@@ -9,13 +12,20 @@ namespace drake {
 namespace solvers {
 
 MosekSolver::MosekSolver()
-    : SolverBase(&id, &is_available, &ProgramAttributesSatisfied) {}
+    : SolverBase(&id, &is_available, &is_enabled,
+                 &ProgramAttributesSatisfied) {}
 
 MosekSolver::~MosekSolver() = default;
 
 SolverId MosekSolver::id() {
   static const never_destroyed<SolverId> singleton{"Mosek"};
   return singleton.access();
+}
+
+bool MosekSolver::is_enabled() {
+  const char* moseklm_license_file = std::getenv("MOSEKLM_LICENSE_FILE");
+  return ((moseklm_license_file != nullptr) &&
+          (std::strlen(moseklm_license_file) > 0));
 }
 
 bool MosekSolver::ProgramAttributesSatisfied(const MathematicalProgram& prog) {

--- a/solvers/nlopt_solver.h
+++ b/solvers/nlopt_solver.h
@@ -44,6 +44,7 @@ class NloptSolver final : public SolverBase {
   //@{
   static SolverId id();
   static bool is_available();
+  static bool is_enabled();
   static bool ProgramAttributesSatisfied(const MathematicalProgram&);
   //@}
 

--- a/solvers/nlopt_solver_common.cc
+++ b/solvers/nlopt_solver_common.cc
@@ -9,7 +9,8 @@ namespace drake {
 namespace solvers {
 
 NloptSolver::NloptSolver()
-    : SolverBase(&id, &is_available, &ProgramAttributesSatisfied) {}
+    : SolverBase(&id, &is_available, &is_enabled,
+                 &ProgramAttributesSatisfied) {}
 
 NloptSolver::~NloptSolver() = default;
 
@@ -17,6 +18,8 @@ SolverId NloptSolver::id() {
   static const never_destroyed<SolverId> singleton{"NLopt"};
   return singleton.access();
 }
+
+bool NloptSolver::is_enabled() { return true; }
 
 bool NloptSolver::ProgramAttributesSatisfied(const MathematicalProgram& prog) {
   static const never_destroyed<ProgramAttributes> solver_capabilities(

--- a/solvers/osqp_solver.h
+++ b/solvers/osqp_solver.h
@@ -49,6 +49,7 @@ class OsqpSolver final : public SolverBase {
   //@{
   static SolverId id();
   static bool is_available();
+  static bool is_enabled();
   static bool ProgramAttributesSatisfied(const MathematicalProgram&);
   //@}
 

--- a/solvers/osqp_solver_common.cc
+++ b/solvers/osqp_solver_common.cc
@@ -12,7 +12,8 @@ namespace drake {
 namespace solvers {
 
 OsqpSolver::OsqpSolver()
-    : SolverBase(&id, &is_available, &ProgramAttributesSatisfied) {}
+    : SolverBase(&id, &is_available, &is_enabled,
+                 &ProgramAttributesSatisfied) {}
 
 OsqpSolver::~OsqpSolver() = default;
 
@@ -20,6 +21,8 @@ SolverId OsqpSolver::id() {
   static const never_destroyed<SolverId> singleton{"OSQP"};
   return singleton.access();
 }
+
+bool OsqpSolver::is_enabled() { return true; }
 
 bool OsqpSolver::ProgramAttributesSatisfied(const MathematicalProgram& prog) {
   static const never_destroyed<ProgramAttributes> solver_capabilities(

--- a/solvers/scs_solver.h
+++ b/solvers/scs_solver.h
@@ -71,6 +71,7 @@ class ScsSolver final : public SolverBase {
   //@{
   static SolverId id();
   static bool is_available();
+  static bool is_enabled();
   static bool ProgramAttributesSatisfied(const MathematicalProgram&);
   //@}
 

--- a/solvers/scs_solver_common.cc
+++ b/solvers/scs_solver_common.cc
@@ -9,7 +9,8 @@ namespace drake {
 namespace solvers {
 
 ScsSolver::ScsSolver()
-    : SolverBase(&id, &is_available, &ProgramAttributesSatisfied) {}
+    : SolverBase(&id, &is_available, &is_enabled,
+                 &ProgramAttributesSatisfied) {}
 
 ScsSolver::~ScsSolver() = default;
 
@@ -17,6 +18,8 @@ SolverId ScsSolver::id() {
   static const never_destroyed<SolverId> singleton{"SCS"};
   return singleton.access();
 }
+
+bool ScsSolver::is_enabled() { return true; }
 
 bool ScsSolver::ProgramAttributesSatisfied(const MathematicalProgram& prog) {
   return AreRequiredAttributesSupported(

--- a/solvers/snopt_solver.h
+++ b/solvers/snopt_solver.h
@@ -52,6 +52,7 @@ class SnoptSolver final : public SolverBase  {
   //@{
   static SolverId id();
   static bool is_available();
+  static bool is_enabled();
   static bool ProgramAttributesSatisfied(const MathematicalProgram&);
   //@}
 

--- a/solvers/snopt_solver_common.cc
+++ b/solvers/snopt_solver_common.cc
@@ -9,7 +9,8 @@ namespace drake {
 namespace solvers {
 
 SnoptSolver::SnoptSolver()
-    : SolverBase(&id, &is_available, &ProgramAttributesSatisfied) {}
+    : SolverBase(&id, &is_available, &is_enabled,
+                 &ProgramAttributesSatisfied) {}
 
 SnoptSolver::~SnoptSolver() = default;
 
@@ -18,6 +19,8 @@ SolverId SnoptSolver::id() {
       SnoptSolver::is_available() ? "SNOPT/fortran" : "SNOPT/unavailable"};
   return singleton.access();
 }
+
+bool SnoptSolver::is_enabled() { return true; }
 
 bool SnoptSolver::ProgramAttributesSatisfied(const MathematicalProgram& prog) {
   static const never_destroyed<ProgramAttributes> solver_capabilities(

--- a/solvers/solver_base.h
+++ b/solvers/solver_base.h
@@ -6,6 +6,7 @@
 #include <Eigen/Core>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/solvers/mathematical_program.h"
 #include "drake/solvers/solution_result.h"
 #include "drake/solvers/solver_id.h"
@@ -34,17 +35,27 @@ class SolverBase : public SolverInterface {
       const std::optional<SolverOptions>&, MathematicalProgramResult*) const
       override;
   bool available() const override;
+  bool enabled() const override;
   SolverId solver_id() const override;
   bool AreProgramAttributesSatisfied(const MathematicalProgram&) const override;
 
  protected:
   /// Constructs a SolverBase with the given default implementations of the
-  /// solver_id(), available(), and AreProgramAttributesSatisfied() methods.
-  /// (Typically, the subclass will just pass the address of its static method,
-  /// e.g. `&id`, for these functors.)  Any of the functors can be null, in
-  /// which case the subclass should override the virtual method instead.
+  /// solver_id(), available(), enabled(), and AreProgramAttributesSatisfied()
+  /// methods.  (Typically, the subclass will just pass the address of its
+  /// static method, e.g. `&id`, for these functors.)  Any of the functors can
+  /// be nullptr, in which case the subclass should override the virtual method
+  /// instead.
   SolverBase(
-      std::function<SolverId()> id, std::function<bool()> available,
+      std::function<SolverId()> id,
+      std::function<bool()> available,
+      std::function<bool()> enabled,
+      std::function<bool(const MathematicalProgram&)> satisfied);
+
+  DRAKE_DEPRECATED("2020-09-01", "The 'enabled' argument will become required.")
+  SolverBase(
+      std::function<SolverId()> id,
+      std::function<bool()> available,
       std::function<bool(const MathematicalProgram&)> satisfied);
 
   /// Hook for subclasses to implement Solve.  Prior to the SolverBase's call
@@ -59,8 +70,10 @@ class SolverBase : public SolverInterface {
       const SolverOptions& merged_options,
       MathematicalProgramResult* result) const = 0;
 
+ private:
   std::function<SolverId()> default_id_;
   std::function<bool()> default_available_;
+  std::function<bool()> default_enabled_;
   std::function<bool(const MathematicalProgram&)> default_satisfied_;
 };
 

--- a/solvers/solver_interface.h
+++ b/solvers/solver_interface.h
@@ -20,8 +20,15 @@ class SolverInterface {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SolverInterface)
   virtual ~SolverInterface();
 
-  /// Returns true iff this solver was enabled at compile-time.
+  /// Returns true iff this solver was enabled at compile-time. Certain solvers
+  /// may be excluded at compile-time due to licensing or linking restrictions.
+  /// When this method returns false, the Solve method will throw.
   virtual bool available() const = 0;
+
+  /// Returns true iff this solver is enabled at runtime. The toggle mechanism
+  /// is specific to the solver in question, but typically uses an environment
+  /// variable. When this method returns false, the Solve method will throw.
+  virtual bool enabled() const = 0;
 
   /// Solves an optimization program with optional initial guess and solver
   /// options. Note that these initial guess and solver options are not written

--- a/solvers/test/gurobi_solver_grb_license_file_test.cc
+++ b/solvers/test/gurobi_solver_grb_license_file_test.cc
@@ -45,11 +45,12 @@ GTEST_TEST(GrbLicenseFileTest, GrbLicenseFileUnset) {
     MathematicalProgramResult result;
     solver.Solve(program, {}, {}, &result);
     ADD_FAILURE() << "Expected exception of type std::runtime_error.";
-  } catch (const std::runtime_error& err) {
-    EXPECT_EQ(err.what(), std::string("Could not locate Gurobi license key "
-        "file because GRB_LICENSE_FILE environment variable was not set."));
+  } catch (const std::exception& err) {
+    EXPECT_EQ(err.what(), std::string(
+        "drake::solvers::GurobiSolver::is_enabled() is false; "
+        "see its documentation for how to enable."));
   } catch (...) {
-    ADD_FAILURE() << "Expected exception of type std::runtime_error.";
+    ADD_FAILURE() << "Expected std::exception.";
   }
 
   const int setenv_result = ::setenv("GRB_LICENSE_FILE", grb_license_file, 1);

--- a/solvers/test/mosek_solver_moseklm_license_file_test.cc
+++ b/solvers/test/mosek_solver_moseklm_license_file_test.cc
@@ -45,11 +45,12 @@ GTEST_TEST(MoseklmLicenseFileTest, MoseklmLicenseFileUnset) {
     MathematicalProgramResult result;
     solver.Solve(program, {}, {}, &result);
     ADD_FAILURE() << "Expected exception of type std::runtime_error.";
-  } catch (const std::runtime_error& err) {
-    EXPECT_EQ(err.what(), std::string("Could not locate MOSEK license file "
-        "because MOSEKLM_LICENSE_FILE environment variable was not set."));
+  } catch (const std::exception& err) {
+    EXPECT_EQ(err.what(), std::string(
+        "drake::solvers::MosekSolver::is_enabled() is false; "
+        "see its documentation for how to enable."));
   } catch (...) {
-    ADD_FAILURE() << "Expected exception of type std::runtime_error.";
+    ADD_FAILURE() << "Expected std::exception.";
   }
 
   const int setenv_result =

--- a/solvers/test/solver_base_deprecated_test.cc
+++ b/solvers/test/solver_base_deprecated_test.cc
@@ -1,0 +1,54 @@
+/* clang-format off to disable clang-format-includes */
+#include "drake/solvers/solver_base.h"
+/* clang-format on */
+
+#include <stdexcept>
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace solvers {
+namespace test {
+namespace {
+
+// A stub subclass of SolverBase, so that we can instantiate and test it.
+class StubSolverBase final : public SolverBase {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(StubSolverBase)
+  StubSolverBase() : SolverBase(
+      &id,
+      [this](){ return available_; },
+      /* No enabled() functor here; we use the deprecated ctor. */
+      [this](const auto&){ return satisfied_; }) {}
+
+  void DoSolve(
+      const MathematicalProgram&, const Eigen::VectorXd&, const SolverOptions&,
+      MathematicalProgramResult*) const final {
+    throw std::runtime_error("Not implemented");
+  }
+
+  // Helper static method for SolverBase ctor.
+  static SolverId id() {
+    static const never_destroyed<SolverId> result{"stub"};
+    return result.access();
+  }
+
+  // The return values for stubbed methods.
+  bool available_{true};
+  bool satisfied_{true};
+};
+
+GTEST_TEST(SolverBaseTest, AlwaysEnabledByDefault) {
+  StubSolverBase dut;
+  dut.available_ = false;
+  EXPECT_FALSE(dut.available());
+  EXPECT_TRUE(dut.enabled());
+  dut.available_ = true;
+  EXPECT_TRUE(dut.available());
+  EXPECT_TRUE(dut.enabled());
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace solvers
+}  // namespace drake

--- a/solvers/test/solver_base_test.cc
+++ b/solvers/test/solver_base_test.cc
@@ -16,6 +16,7 @@ class StubSolverBase final : public SolverBase {
   StubSolverBase() : SolverBase(
       &id,
       [this](){ return available_; },
+      [this](){ return enabled_; },
       [this](const auto& prog){ return satisfied_; }) {}
 
   void DoSolve(
@@ -43,6 +44,7 @@ class StubSolverBase final : public SolverBase {
 
   // The return values for stubbed methods.
   bool available_{true};
+  bool enabled_{true};
   bool satisfied_{true};
 };
 
@@ -54,6 +56,11 @@ GTEST_TEST(SolverBaseTest, Accessors) {
   EXPECT_FALSE(dut.available());
   dut.available_ = true;
   EXPECT_TRUE(dut.available());
+
+  dut.enabled_ = false;
+  EXPECT_FALSE(dut.enabled());
+  dut.enabled_ = true;
+  EXPECT_TRUE(dut.enabled());
 
   const MathematicalProgram prog;
   dut.satisfied_ = false;

--- a/solvers/unrevised_lemke_solver.cc
+++ b/solvers/unrevised_lemke_solver.cc
@@ -872,7 +872,8 @@ bool UnrevisedLemkeSolver<T>::SolveLcpLemke(const MatrixX<T>& M,
 
 template <typename T>
 UnrevisedLemkeSolver<T>::UnrevisedLemkeSolver()
-    : SolverBase(&id, &is_available, &ProgramAttributesSatisfied) {}
+    : SolverBase(&id, &is_available, &is_enabled,
+                 &ProgramAttributesSatisfied) {}
 
 template <typename T>
 UnrevisedLemkeSolver<T>::~UnrevisedLemkeSolver() = default;
@@ -889,6 +890,11 @@ SolverId UnrevisedLemkeSolver<T>::id() {
 
 template <typename T>
 bool UnrevisedLemkeSolver<T>::is_available() {
+  return true;
+}
+
+template <typename T>
+bool UnrevisedLemkeSolver<T>::is_enabled() {
   return true;
 }
 

--- a/solvers/unrevised_lemke_solver.h
+++ b/solvers/unrevised_lemke_solver.h
@@ -93,6 +93,7 @@ class UnrevisedLemkeSolver final : public SolverBase {
   //@{
   static SolverId id();
   static bool is_available();
+  static bool is_enabled();
   static bool ProgramAttributesSatisfied(const MathematicalProgram&);
   //@}
 


### PR DESCRIPTION
For Gurobi and Mosek, when their license key environment variable is unset, do not use them during `ChooseBestSolver` nor `Solve`. Previously, we would choose them only to immediately fail with a license server error message.

It had been useful to fail-fast, but was increasingly difficult to manage. Given that the build-time choice must be project-wide, it forced projects to put the license server in their critical path even for real-time control queries that could as easily be solved with something fast and free like OSQP.  (Gurobi has higher precedence that OSQP in `ChooseBestSolver`.)

By deferring the solver selection to runtime (checking the solver-specific license key environment variables already required by the third-party libraries), it still uses the solver when the license is configured but otherwise behaves as-if the solver was omitted.

To retain the prior fail-fast behavior, users should set the env variable to either their default (server) value, or a non-empty invalid string literal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13279)
<!-- Reviewable:end -->
