### PR TITLE
tools: Change order of third-party includes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -41,5 +41,4 @@ IncludeCategories:
     Priority: 50
   # Other libraries' h files (with quotes).
   - Regex:    '^"'
-    Priority: 41
-
+    Priority: 40

--- a/attic/systems/sensors/test/depth_sensor_to_lcm_point_cloud_message_test.cc
+++ b/attic/systems/sensors/test/depth_sensor_to_lcm_point_cloud_message_test.cc
@@ -4,8 +4,8 @@
 #include <memory>
 #include <utility>
 
-#include <gtest/gtest.h>
 #include "bot_core/pointcloud_t.hpp"
+#include <gtest/gtest.h>
 
 #include "drake/systems/rendering/pose_vector.h"
 #include "drake/systems/sensors/depth_sensor_output.h"

--- a/bindings/pydrake/.clang-format
+++ b/bindings/pydrake/.clang-format
@@ -60,5 +60,4 @@ IncludeCategories:
     Priority: 50
   # Other libraries' h files (with quotes).
   - Regex:    '^"'
-    Priority: 41
-
+    Priority: 40

--- a/bindings/pydrake/autodiff_types_pybind.h
+++ b/bindings/pydrake/autodiff_types_pybind.h
@@ -2,9 +2,9 @@
 
 #include <algorithm>
 
-#include <Eigen/Core>
 #include "pybind11/eigen.h"
 #include "pybind11/pybind11.h"
+#include <Eigen/Core>
 
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 

--- a/bindings/pydrake/common/eigen_geometry_pybind.h
+++ b/bindings/pydrake/common/eigen_geometry_pybind.h
@@ -10,8 +10,8 @@
 #include <string>
 #include <utility>
 
-#include <Eigen/Dense>
 #include "pybind11/eigen.h"
+#include <Eigen/Dense>
 
 #include "drake/bindings/pydrake/common/wrap_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/common/eigen_pybind.h
+++ b/bindings/pydrake/common/eigen_pybind.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <Eigen/Dense>
 #include "pybind11/eigen.h"
+#include <Eigen/Dense>
 
 #include "drake/common/eigen_types.h"
 

--- a/bindings/pydrake/common/test/cpp_param_pybind_test.cc
+++ b/bindings/pydrake/common/test/cpp_param_pybind_test.cc
@@ -6,10 +6,10 @@
 #include <stdexcept>
 #include <string>
 
-#include <gtest/gtest.h>
 #include "pybind11/embed.h"
 #include "pybind11/eval.h"
 #include "pybind11/pybind11.h"
+#include <gtest/gtest.h>
 
 #include "drake/bindings/pydrake/test/test_util_pybind.h"
 

--- a/bindings/pydrake/common/test/cpp_template_pybind_test.cc
+++ b/bindings/pydrake/common/test/cpp_template_pybind_test.cc
@@ -8,10 +8,10 @@
 #include <utility>
 #include <vector>
 
-#include <gtest/gtest.h>
 #include "pybind11/embed.h"
 #include "pybind11/eval.h"
 #include "pybind11/pybind11.h"
+#include <gtest/gtest.h>
 
 #include "drake/bindings/pydrake/test/test_util_pybind.h"
 #include "drake/common/nice_type_name.h"

--- a/bindings/pydrake/common/test/eigen_geometry_test_util_py.cc
+++ b/bindings/pydrake/common/test/eigen_geometry_test_util_py.cc
@@ -1,5 +1,5 @@
-#include <Eigen/Dense>
 #include "pybind11/pybind11.h"
+#include <Eigen/Dense>
 
 #include "drake/bindings/pydrake/common/eigen_geometry_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"

--- a/bindings/pydrake/common/test/type_safe_index_pybind_test.cc
+++ b/bindings/pydrake/common/test/type_safe_index_pybind_test.cc
@@ -6,10 +6,10 @@
 #include <string>
 #include <vector>
 
-#include <gtest/gtest.h>
 #include "pybind11/embed.h"
 #include "pybind11/eval.h"
 #include "pybind11/pybind11.h"
+#include <gtest/gtest.h>
 
 #include "drake/bindings/pydrake/test/test_util_pybind.h"
 

--- a/bindings/pydrake/systems/rendering_py.cc
+++ b/bindings/pydrake/systems/rendering_py.cc
@@ -1,6 +1,6 @@
-#include <Eigen/Dense>
 #include "pybind11/eigen.h"
 #include "pybind11/pybind11.h"
+#include <Eigen/Dense>
 
 #include "drake/bindings/pydrake/common/eigen_geometry_pybind.h"
 #include "drake/bindings/pydrake/common/value_pybind.h"

--- a/bindings/pydrake/test/pydrake_pybind_test.cc
+++ b/bindings/pydrake/test/pydrake_pybind_test.cc
@@ -6,11 +6,11 @@
 
 #include <string>
 
-#include <gtest/gtest.h>
 #include "pybind11/embed.h"
 #include "pybind11/eval.h"
 #include "pybind11/operators.h"
 #include "pybind11/pybind11.h"
+#include <gtest/gtest.h>
 
 #include "drake/bindings/pydrake/test/test_util_pybind.h"
 #include "drake/common/drake_copyable.h"

--- a/common/yaml/yaml_read_archive.h
+++ b/common/yaml/yaml_read_archive.h
@@ -10,9 +10,9 @@
 #include <variant>
 #include <vector>
 
+#include "yaml-cpp/yaml.h"
 #include <Eigen/Core>
 #include <fmt/format.h>
-#include "yaml-cpp/yaml.h"
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_throw.h"

--- a/common/yaml/yaml_write_archive.h
+++ b/common/yaml/yaml_write_archive.h
@@ -10,10 +10,10 @@
 #include <variant>
 #include <vector>
 
-#include <Eigen/Core>
-#include <fmt/format.h>
 #include "yaml-cpp/emitfromevents.h"
 #include "yaml-cpp/yaml.h"
+#include <Eigen/Core>
+#include <fmt/format.h>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/name_value.h"

--- a/examples/allegro_hand/joint_control/run_twisting_mug.cc
+++ b/examples/allegro_hand/joint_control/run_twisting_mug.cc
@@ -10,9 +10,9 @@
 /// has finished the current motion, either by reaching the target position or
 /// get stuck by collisions.
 
+#include "lcm/lcm-cpp.hpp"
 #include <Eigen/Dense>
 #include <gflags/gflags.h>
-#include "lcm/lcm-cpp.hpp"
 
 #include "drake/examples/allegro_hand/allegro_common.h"
 #include "drake/examples/allegro_hand/allegro_lcm.h"

--- a/examples/kinova_jaco_arm/jaco_controller.cc
+++ b/examples/kinova_jaco_arm/jaco_controller.cc
@@ -4,8 +4,8 @@
 
 #include <memory>
 
-#include <gflags/gflags.h>
 #include "robotlocomotion/robot_plan_t.hpp"
+#include <gflags/gflags.h>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/find_resource.h"

--- a/examples/kinova_jaco_arm/move_jaco_ee.cc
+++ b/examples/kinova_jaco_arm/move_jaco_ee.cc
@@ -6,8 +6,8 @@
 /// current calculated position of the end effector is printed before, during,
 /// and after the commanded motion.
 
-#include <gflags/gflags.h>
 #include "lcm/lcm-cpp.hpp"
+#include <gflags/gflags.h>
 
 #include "drake/common/find_resource.h"
 #include "drake/common/text_logging.h"

--- a/examples/kuka_iiwa_arm/iiwa_controller.cc
+++ b/examples/kuka_iiwa_arm/iiwa_controller.cc
@@ -6,8 +6,8 @@
 #include <iostream>
 #include <memory>
 
-#include <gflags/gflags.h>
 #include "robotlocomotion/robot_plan_t.hpp"
+#include <gflags/gflags.h>
 
 #include "drake/common/find_resource.h"
 #include "drake/common/text_logging.h"

--- a/examples/kuka_iiwa_arm/move_iiwa_ee.cc
+++ b/examples/kuka_iiwa_arm/move_iiwa_ee.cc
@@ -8,9 +8,9 @@
 
 #include <map>
 
-#include <gflags/gflags.h>
 #include "lcm/lcm-cpp.hpp"
 #include "robotlocomotion/robot_plan_t.hpp"
+#include <gflags/gflags.h>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/find_resource.h"

--- a/examples/kuka_iiwa_arm/test/optitrack_test.cc
+++ b/examples/kuka_iiwa_arm/test/optitrack_test.cc
@@ -1,5 +1,5 @@
-#include <gtest/gtest.h>
 #include "optitrack/optitrack_frame_t.hpp"
+#include <gtest/gtest.h>
 
 GTEST_TEST(OptitrackTest, OptitrackLcmTest) {
   // Dummy test to make sure the library is pulled in correctly.

--- a/examples/simple_gripper/simple_gripper.cc
+++ b/examples/simple_gripper/simple_gripper.cc
@@ -1,8 +1,8 @@
 #include <memory>
 #include <string>
 
-#include <gflags/gflags.h>
 #include "fmt/ostream.h"
+#include <gflags/gflags.h>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/find_resource.h"

--- a/geometry/benchmarking/mesh_intersection_benchmark.cc
+++ b/geometry/benchmarking/mesh_intersection_benchmark.cc
@@ -1,5 +1,5 @@
-#include <benchmark/benchmark.h>
 #include "fmt/format.h"
+#include <benchmark/benchmark.h>
 
 #include "drake/geometry/proximity/make_ellipsoid_field.h"
 #include "drake/geometry/proximity/make_ellipsoid_mesh.h"

--- a/geometry/benchmarking/render_benchmark.cc
+++ b/geometry/benchmarking/render_benchmark.cc
@@ -1,8 +1,8 @@
 #include <unistd.h>
 
+#include "fmt/format.h"
 #include <benchmark/benchmark.h>
 #include <gflags/gflags.h>
-#include "fmt/format.h"
 
 #include "drake/common/filesystem.h"
 #include "drake/geometry/render/render_engine_ospray_factory.h"

--- a/geometry/render/render_engine_vtk_base.cc
+++ b/geometry/render/render_engine_vtk_base.cc
@@ -4,6 +4,7 @@
 #include <utility>
 #include <vector>
 
+#include "third_party/com_github_finetjul_bender/vtkCapsuleSource.h"
 #include <vtkCellArray.h>
 #include <vtkFloatArray.h>
 #include <vtkInformation.h>
@@ -14,7 +15,6 @@
 #include <vtkPolyData.h>
 #include <vtkPolyDataAlgorithm.h>
 #include <vtkStreamingDemandDrivenPipeline.h>
-#include "third_party/com_github_finetjul_bender/vtkCapsuleSource.h"
 
 #include "drake/common/scope_exit.h"
 

--- a/lcm/test/drake_lcm_test.cc
+++ b/lcm/test/drake_lcm_test.cc
@@ -4,8 +4,8 @@
 #include <stdexcept>
 #include <thread>
 
-#include <gtest/gtest.h>
 #include "lcm/lcm-cpp.hpp"
+#include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/lcm/lcmt_drake_signal_utils.h"

--- a/lcm/test/drake_lcm_thread_test.cc
+++ b/lcm/test/drake_lcm_thread_test.cc
@@ -4,8 +4,8 @@
 #include <stdexcept>
 #include <thread>
 
-#include <gtest/gtest.h>
 #include "lcm/lcm-cpp.hpp"
+#include <gtest/gtest.h>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/lcm/drake_lcm.h"

--- a/manipulation/perception/test/optitrack_pose_extractor_test.cc
+++ b/manipulation/perception/test/optitrack_pose_extractor_test.cc
@@ -2,8 +2,8 @@
 
 #include <memory>
 
-#include <gtest/gtest.h>
 #include "optitrack/optitrack_frame_t.hpp"
+#include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"

--- a/manipulation/planner/test/robot_plan_interpolator_test.cc
+++ b/manipulation/planner/test/robot_plan_interpolator_test.cc
@@ -1,7 +1,7 @@
 #include "drake/manipulation/planner/robot_plan_interpolator.h"
 
-#include <gtest/gtest.h>
 #include "robotlocomotion/robot_plan_t.hpp"
+#include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"
 

--- a/manipulation/util/bot_core_lcm_encode_decode.h
+++ b/manipulation/util/bot_core_lcm_encode_decode.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <Eigen/Core>
-#include <Eigen/Geometry>
 #include "bot_core/position_3d_t.hpp"
 #include "bot_core/quaternion_t.hpp"
 #include "bot_core/twist_t.hpp"
 #include "bot_core/vector_3d_t.hpp"
+#include <Eigen/Core>
+#include <Eigen/Geometry>
 
 #include "drake/common/eigen_types.h"
 

--- a/multibody/parsing/test/detail_scene_graph_test.cc
+++ b/multibody/parsing/test/detail_scene_graph_test.cc
@@ -5,8 +5,8 @@
 #include <optional>
 #include <sstream>
 
-#include <gtest/gtest.h>
 #include "fmt/ostream.h"
+#include <gtest/gtest.h>
 
 #include "drake/common/filesystem.h"
 #include "drake/common/find_resource.h"

--- a/systems/analysis/test_utilities/test/controlled_spring_mass_system_test.cc
+++ b/systems/analysis/test_utilities/test/controlled_spring_mass_system_test.cc
@@ -1,7 +1,7 @@
 #include "drake/systems/analysis/test_utilities/controlled_spring_mass_system.h"
 
-#include <Eigen/Dense>
 #include "gtest/gtest.h"
+#include <Eigen/Dense>
 
 using std::make_unique;
 

--- a/systems/sensors/image_to_lcm_image_array_t.cc
+++ b/systems/sensors/image_to_lcm_image_array_t.cc
@@ -4,9 +4,9 @@
 #include <string>
 #include <vector>
 
-#include <zlib.h>
 #include "robotlocomotion/image_array_t.hpp"
 #include "robotlocomotion/image_t.hpp"
+#include <zlib.h>
 
 #include "drake/systems/sensors/lcm_image_traits.h"
 

--- a/systems/sensors/image_writer.cc
+++ b/systems/sensors/image_writer.cc
@@ -7,12 +7,12 @@
 #include <utility>
 #include <vector>
 
+#include "fmt/ostream.h"
 #include <vtkImageData.h>
 #include <vtkNew.h>
 #include <vtkPNGWriter.h>
 #include <vtkSmartPointer.h>
 #include <vtkTIFFWriter.h>
-#include "fmt/ostream.h"
 
 #include "drake/common/filesystem.h"
 

--- a/systems/sensors/lcm_image_array_receive_example.cc
+++ b/systems/sensors/lcm_image_array_receive_example.cc
@@ -4,8 +4,8 @@
 /// depth frames, and retransmits the images.  The output can be viewed in
 /// drake_visualizer.
 
-#include <gflags/gflags.h>
 #include "robotlocomotion/image_array_t.hpp"
+#include <gflags/gflags.h>
 
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram_builder.h"

--- a/systems/sensors/lcm_image_array_to_images.cc
+++ b/systems/sensors/lcm_image_array_to_images.cc
@@ -2,12 +2,12 @@
 
 #include <vector>
 
+#include "robotlocomotion/image_array_t.hpp"
 #include <png.h>
 #include <vtkImageExport.h>
 #include <vtkJPEGReader.h>
 #include <vtkNew.h>
 #include <zlib.h>
-#include "robotlocomotion/image_array_t.hpp"
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/text_logging.h"

--- a/systems/sensors/test/image_to_lcm_image_array_t_test.cc
+++ b/systems/sensors/test/image_to_lcm_image_array_t_test.cc
@@ -1,7 +1,7 @@
 #include "drake/systems/sensors/image_to_lcm_image_array_t.h"
 
-#include <gtest/gtest.h>
 #include "robotlocomotion/image_array_t.hpp"
+#include <gtest/gtest.h>
 
 #include "drake/systems/sensors/image.h"
 

--- a/systems/sensors/test/lcm_image_array_to_images_test.cc
+++ b/systems/sensors/test/lcm_image_array_to_images_test.cc
@@ -3,8 +3,8 @@
 #include <fstream>
 #include <memory>
 
-#include <gtest/gtest.h>
 #include "robotlocomotion/image_array_t.hpp"
+#include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"
 #include "drake/systems/sensors/image.h"

--- a/systems/sensors/test/optitrack_sender_test.cc
+++ b/systems/sensors/test/optitrack_sender_test.cc
@@ -1,7 +1,7 @@
 #include "drake/systems/sensors/optitrack_sender.h"
 
-#include <gtest/gtest.h>
 #include "optitrack/optitrack_frame_t.hpp"
+#include <gtest/gtest.h>
 
 #include "drake/geometry/frame_kinematics_vector.h"
 #include "drake/math/rigid_transform.h"


### PR DESCRIPTION
Towards #13236. Requires #13259.

The new clang-format-9 prefers quote includes before angle includes. To use a different order, we'd have to insert an empty line between them, and we don't want to do that. So, we'll relent and allow the quote includes to appear first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13286)
<!-- Reviewable:end -->
