### PR TITLE
[geometry] Support more RenderEngineVtk and ShapeReifier customizations

### DIFF
--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -475,6 +475,15 @@ class GeometryState {
     return render_engines_.count(name) > 0;
   }
 
+  /** Implementation of QueryObject::GetRenderEngineByName.  */
+  const render::RenderEngine* GetRenderEngineByName(
+      const std::string& name) const {
+    if (render_engines_.count(name) > 0) {
+      return render_engines_.at(name).get();
+    }
+    return nullptr;
+  }
+
   /** Implementation of SceneGraph::RendererCount().  */
   int RendererCount() const { return static_cast<int>(render_engines_.size()); }
 

--- a/geometry/query_object.cc
+++ b/geometry/query_object.cc
@@ -198,6 +198,16 @@ void QueryObject<T>::RenderLabelImage(const CameraProperties& camera,
 }
 
 template <typename T>
+const render::RenderEngine* QueryObject<T>::GetRenderEngineByName(
+    const std::string& name) const {
+  ThrowIfNotCallable();
+  FullPoseUpdate();
+
+  const GeometryState<T>& state = geometry_state();
+  return state.GetRenderEngineByName(name);
+}
+
+template <typename T>
 const GeometryState<T>& QueryObject<T>::geometry_state() const {
   // Some extra insurance in case some query *hadn't* called this.
   DRAKE_ASSERT_VOID(ThrowIfNotCallable());

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -507,6 +507,12 @@ class QueryObject {
                         bool show_window,
                         systems::sensors::ImageLabel16I* label_image_out) const;
 
+
+  /** Returns the named render engine, if it exists. The RenderEngine is
+   guaranteed to be up to date w.r.t. the poses and data in the context. */
+  const render::RenderEngine* GetRenderEngineByName(
+      const std::string& name) const;
+
   //@}
 
  private:

--- a/geometry/render/render_engine_vtk.cc
+++ b/geometry/render/render_engine_vtk.cc
@@ -341,18 +341,22 @@ RenderEngineVtk::RenderEngineVtk(const RenderEngineVtk& other)
       vtkActor& source = *source_actors[i];
       vtkActor& clone = *clone_actors[i];
 
+      // NOTE: The clone renderer and original renderer *share* polygon data
+      // (via the shared mapper) and all textures. If the meshes or textures get
+      // modified _in place_ in a clone, the change would be visible to all
+      // copies of the renderer. If that proves to be problematic we'll have to
+      // make the copy "deeper" as appropriate.
       if (source.GetTexture() == nullptr) {
         clone.GetProperty()->SetColor(source.GetProperty()->GetColor());
         clone.GetProperty()->SetOpacity(source.GetProperty()->GetOpacity());
       } else {
         clone.SetTexture(source.GetTexture());
       }
+      const auto& source_textures = source.GetProperty()->GetAllTextures();
+      for (auto& [name, texture] : source_textures) {
+        clone.GetProperty()->SetTexture(name.c_str(), texture);
+      }
 
-      // NOTE: The clone renderer and original renderer *share* polygon
-      // data. If the meshes were *deformable* this would be invalid.
-      // Furthermore, even if dynamic adding/removing of geometry were
-      // valid, VTK's reference counting preserves the underlying geometry
-      // in the copy that still references it.
       clone.SetMapper(source.GetMapper());
       clone.SetUserTransform(source.GetUserTransform());
       // This is necessary because *terrain* has its lighting turned off. To

--- a/geometry/render/render_engine_vtk.h
+++ b/geometry/render/render_engine_vtk.h
@@ -81,13 +81,13 @@ class ShaderCallback : public vtkCommand {
 #endif  // !DRAKE_DOXYGEN_CXX
 
 /** See documentation of MakeRenderEngineVtk().  */
-class RenderEngineVtk final : public RenderEngine,
-                              private internal::ModuleInitVtkRenderingOpenGL2 {
+class RenderEngineVtk : public RenderEngine,
+                        private internal::ModuleInitVtkRenderingOpenGL2 {
  public:
   /** \name Does not allow copy, move, or assignment  */
   //@{
 #ifdef DRAKE_DOXYGEN_CXX
-  // Note: the copy assignment operator is actually private to serve as the
+  // Note: the copy constructor operator is actually protected to serve as the
   // basis for implementing the DoClone() method.
   RenderEngineVtk(const RenderEngineVtk&) = delete;
 #endif
@@ -105,34 +105,34 @@ class RenderEngineVtk final : public RenderEngine,
       const RenderEngineVtkParams& parameters = RenderEngineVtkParams());
 
   /** @see RenderEngine::UpdateViewpoint().  */
-  void UpdateViewpoint(const math::RigidTransformd& X_WR) final;
+  void UpdateViewpoint(const math::RigidTransformd& X_WR) override;
 
   /** @see RenderEngine::RenderColorImage().  */
   void RenderColorImage(
       const CameraProperties& camera, bool show_window,
-      systems::sensors::ImageRgba8U* color_image_out) const final;
+      systems::sensors::ImageRgba8U* color_image_out) const override;
 
   /** @see RenderEngine::RenderDepthImage().  */
   void RenderDepthImage(
       const DepthCameraProperties& camera,
-      systems::sensors::ImageDepth32F* depth_image_out) const final;
+      systems::sensors::ImageDepth32F* depth_image_out) const override;
 
   /** @see RenderEngine::RenderLabelImage().  */
   void RenderLabelImage(
       const CameraProperties& camera, bool show_window,
-      systems::sensors::ImageLabel16I* label_image_out) const final;
+      systems::sensors::ImageLabel16I* label_image_out) const override;
 
   /** @name    Shape reification  */
   //@{
   using RenderEngine::ImplementGeometry;
-  void ImplementGeometry(const Sphere& sphere, void* user_data) final;
-  void ImplementGeometry(const Cylinder& cylinder, void* user_data) final;
-  void ImplementGeometry(const HalfSpace& half_space, void* user_data) final;
-  void ImplementGeometry(const Box& box, void* user_data) final;
-  void ImplementGeometry(const Capsule& capsule, void* user_data) final;
-  void ImplementGeometry(const Ellipsoid& ellipsoid, void* user_data) final;
-  void ImplementGeometry(const Mesh& mesh, void* user_data) final;
-  void ImplementGeometry(const Convex& convex, void* user_data) final;
+  void ImplementGeometry(const Sphere& sphere, void* user_data) override;
+  void ImplementGeometry(const Cylinder& cylinder, void* user_data) override;
+  void ImplementGeometry(const HalfSpace& half_space, void* user_data) override;
+  void ImplementGeometry(const Box& box, void* user_data) override;
+  void ImplementGeometry(const Capsule& capsule, void* user_data) override;
+  void ImplementGeometry(const Ellipsoid& ellipsoid, void* user_data) override;
+  void ImplementGeometry(const Mesh& mesh, void* user_data) override;
+  void ImplementGeometry(const Convex& convex, void* user_data) override;
   //@}
 
   /** @name    Access the default properties
@@ -146,24 +146,34 @@ class RenderEngineVtk final : public RenderEngine,
   using RenderEngine::default_render_label;
   //@}
 
+ protected:
+  /** Returns all actors registered with the engine, keyed by the SceneGraph
+   GeometryId. Each GeometryId maps to a triple of actors: color, depth, and
+   label. */
+  const std::unordered_map<GeometryId,
+                           std::array<vtkSmartPointer<vtkActor>, 3>>&
+  actors() const {
+    return actors_;
+  }
+
+  /** Copy constructor for the purpose of cloning. */
+  RenderEngineVtk(const RenderEngineVtk& other);
+
  private:
   // @see RenderEngine::DoRegisterVisual().
-  bool DoRegisterVisual(
-      GeometryId id, const Shape& shape, const PerceptionProperties& properties,
-      const math::RigidTransformd& X_WG) final;
+  bool DoRegisterVisual(GeometryId id, const Shape& shape,
+                        const PerceptionProperties& properties,
+                        const math::RigidTransformd& X_WG) override;
 
   // @see RenderEngine::DoUpdateVisualPose().
   void DoUpdateVisualPose(GeometryId id,
-                          const math::RigidTransformd& X_WG) final;
+                          const math::RigidTransformd& X_WG) override;
 
   // @see RenderEngine::DoRemoveGeometry().
-  bool DoRemoveGeometry(GeometryId id) final;
+  bool DoRemoveGeometry(GeometryId id) override;
 
   // @see RenderEngine::DoClone().
-  std::unique_ptr<RenderEngine> DoClone() const final;
-
-  // Copy constructor for the purpose of cloning.
-  RenderEngineVtk(const RenderEngineVtk& other);
+  std::unique_ptr<RenderEngine> DoClone() const override;
 
   // Initializes the VTK pipelines.
   void InitializePipelines();
@@ -198,7 +208,7 @@ class RenderEngineVtk final : public RenderEngine,
   void UpdateWindow(const DepthCameraProperties& camera,
                     const RenderingPipeline* p) const;
 
-  void SetDefaultLightPosition(const Vector3<double>& X_DL);
+  void SetDefaultLightPosition(const Vector3<double>& X_DL) override;
 
   // Three pipelines: rgb, depth, and label.
   static constexpr int kNumPipelines = 3;

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -371,8 +371,10 @@ class ShapeReifier {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ShapeReifier)
   ShapeReifier() = default;
 
- private:
-  void ThrowUnsupportedGeometry(const std::string& shape_name);
+  /** Derived ShapeReifiers can replace the default message for unsupported
+   geometries by overriding this method. The name of the unsupported shape type
+   is given as the single parameter.  */
+  virtual void ThrowUnsupportedGeometry(const std::string& shape_name);
 };
 
 template <typename S>

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -3101,6 +3101,12 @@ TEST_F(GeometryStateTest, AddRendererError) {
       std::logic_error,
       fmt::format("AddRenderer..: A renderer with the name '{}' already exists",
                   kName));
+
+  EXPECT_EQ(geometry_state_.GetRenderEngineByName("invliad_name"), nullptr);
+  const render::RenderEngine* engine =
+      geometry_state_.GetRenderEngineByName(kName);
+  EXPECT_NE(engine, nullptr);
+  EXPECT_NE(dynamic_cast<const DummyRenderEngine*>(engine), nullptr);
 }
 
 // Tests that when assigning a geometry the perception role, that the process

--- a/geometry/test/query_object_test.cc
+++ b/geometry/test/query_object_test.cc
@@ -192,6 +192,8 @@ TEST_F(QueryObjectTest, DefaultQueryThrows) {
   EXPECT_DEFAULT_ERROR(default_object.RenderLabelImage(
       properties, FrameId::get_new_id(), X_WC, false, &label));
 
+  EXPECT_DEFAULT_ERROR(default_object.GetRenderEngineByName("dummy"));
+
 #undef EXPECT_DEFAULT_ERROR
 }
 


### PR DESCRIPTION
These are the required changes to Drake to support Anzu PR 4729.

1. GeometryState can release pointers to RenderEngine implementaitons
   - It is generally accessed via SceneGraphInspector.
2. RenderEngineVtk is changed to be sub-classable
  - It's *private* copy constructor has been made protected so sub-classes
    can use it.
  - It gives derived classes access to the actors.
  - Fixes a bug that previously went unnoticed; `SetDefaultLightPosition`
    didn't declare override of the virtual RenderEngine method.
3. Allow for customization of unsupported geometry messages in
   ShapeReifier.

TODO:
  Consider python bindings

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13288)
<!-- Reviewable:end -->
