### PR TITLE
scene_graph: Mention adding geometry in the context of collision filters

### DIFF
--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -713,21 +713,33 @@ class SceneGraph final : public systems::LeafSystem<T> {
    These filter methods essentially create new sets of pairs and then subtract
    them from the candidate set C. See each method for details.
 
-   Modifications to C _must_ be performed before context allocation.  */
+   Modifications to C _must_ be performed before context allocation.
+
+   @warning All collision filtering is done based on geometry state at the time
+   of the collision filtering calls. More concretely:
+    - For a FrameId in the set, only those geometries attached to the
+      identified frame with the proximity role assigned at the time of the call
+      will be included in the filter. If geometries are subsequently added or
+      assigned the proximity role, they will not be retroactively added to the
+      filter.
+    - If the set includes geometries which have _not_ been assigned a proximity
+      role, those geometries will be ignored. If a proximity role is
+      subsequently assigned, those geometries will _still_ not be part of any
+      collision filters.
+    - In general, adding collisions and assinging proximity roles should
+      happen prior to collision filter configuration.
+   */
   //@{
 
   /** Excludes geometry pairs from collision evaluation by updating the
    candidate pair set `C = C - P`, where `P = {(gᵢ, gⱼ)}, ∀ gᵢ, gⱼ ∈ G` and
    `G = {g₀, g₁, ..., gₘ}` is the input `set` of geometries.
 
-   If the set includes geometries which have _not_ been assigned a proximity
-   role, those geometries will be ignored. If a proximity role is subsequently
-   assigned, those geometries will _still_ not be part of any collision filters.
-   Proximity roles should _generally_ be assigned prior to collision filter
-   configuration.
-
    This method modifies the underlying model and requires a new Context to be
    allocated.
+
+   @sa @ref scene_graph_collision_filtering for requirements and how collision
+   filtering works.
 
    @throws std::logic_error if the set includes ids that don't exist in the
                             scene graph.  */
@@ -745,17 +757,11 @@ class SceneGraph final : public systems::LeafSystem<T> {
    geometries `setA` and `setB`, respectively. This does _not_ preclude
    collisions between members of the _same_ set.
 
-   If the sets include geometries which have _not_ been assigned a proximity
-   role, those geometries will be ignored. If a proximity role is subsequently
-   assigned, those geometries will _still_ not be part of any collision filters.
-   Proximity roles should _generally_ be assigned prior to collision filter
-   configuration.
-
-   This method modifies the underlying model and requires a new Context to be
-   allocated.
+   @sa @ref scene_graph_collision_filtering for requirements and how collision
+   filtering works.
 
    @throws std::logic_error if the groups include ids that don't exist in the
-                            scene graph.   */
+                            scene graph.  */
   void ExcludeCollisionsBetween(const GeometrySet& setA,
                                 const GeometrySet& setB);
 


### PR DESCRIPTION
Follow-up to this comment:
https://github.com/RobotLocomotion/drake/issues/13280#issuecomment-627632500

Basically, updates the text to (I think) reflect some of the changes effectively enabled by #9754 (but I guess they were possibly before then anywho).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13292)
<!-- Reviewable:end -->
