### PR TITLE
[geometry/dev] Add Unit Cylinder to shape_meshes

### DIFF
--- a/geometry/render/gl_renderer/dev/render_engine_gl.cc
+++ b/geometry/render/gl_renderer/dev/render_engine_gl.cc
@@ -392,63 +392,9 @@ OpenGlGeometry RenderEngineGl::GetCylinder() {
   if (!cylinder_.is_defined()) {
     const int kLongitudeBands = 50;
 
-    // A fan of triangles on each cap with kLongitudeBands triangles, and then
-    // that many rectangles along the barrels (with twice as many triangles).
-    const int tri_count = 4 * kLongitudeBands;
-    // A pair of vertices for each longitudinal band + 1 for each cap.
-    const int vert_count = 2 * kLongitudeBands + 2;
-
-    VertexBuffer vertices{vert_count, 3};
-    IndexBuffer indices{tri_count, 3};
-
-    vertices.block<1, 3>(0, 0) << 0.f, 0.f, 0.5f;
-
-    // Both caps are triangle fans around central points (leading to nicer
-    // triangles).
-    const GLfloat radius = 1.f;
-    int line_start = 1;
-    // Index of the previous vertices and triangles, respectively.
-    int v = 0;
-    int t = -1;
-
-    // Top cap.
-    GLfloat z = 0.5f;
-    for (int i = 0; i < kLongitudeBands; ++i) {
-      const auto theta = static_cast<GLfloat>(i * M_PI * 2 / kLongitudeBands);
-      const auto cos_theta = static_cast<GLfloat>(cos(theta));
-      const auto sin_theta = static_cast<GLfloat>(sin(theta));
-      vertices.block<1, 3>(++v, 0) << radius * cos_theta, radius * sin_theta, z;
-      indices.block<1, 3>(++t, 0) << 0, line_start + i,
-          line_start + (i + 1) % kLongitudeBands;
-    }
-
-    // Barrel.
-    line_start += kLongitudeBands;
-    z = -0.5;
-    const int previous_line_start = 1;
-    for (int i = 0; i < kLongitudeBands; ++i) {
-      const auto theta = static_cast<GLfloat>(i * M_PI * 2 / kLongitudeBands);
-      const auto cos_theta = static_cast<GLfloat>(cos(theta));
-      const auto sin_theta = static_cast<GLfloat>(sin(theta));
-      vertices.block<1, 3>(++v, 0) << radius * cos_theta, radius * sin_theta, z;
-      const int next = (i + 1) % kLongitudeBands;
-      indices.block<1, 3>(++t, 0) << previous_line_start + i, line_start + i,
-          line_start + next;
-      indices.block<1, 3>(++t, 0) << previous_line_start + i, line_start + next,
-          previous_line_start + next;
-    }
-
-    // Bottom cap.
-    line_start += kLongitudeBands;
-    vertices.block<1, 3>(++v, 0) << 0, 0, z;
-    for (int i = 0; i < kLongitudeBands; ++i) {
-      indices.block<1, 3>(++t, 0) << v, line_start + (i + 1) % kLongitudeBands,
-          line_start + i;
-    }
-
-    DRAKE_DEMAND(v == vert_count - 1);
-    DRAKE_DEMAND(t == tri_count - 1);
-
+    // For long skinny cylinders, it would be better to offer some subdivisions
+    // along the length. For now, we'll simply save the triangles.
+    auto [vertices, indices] = MakeUnitCylinder(kLongitudeBands, 1);
     cylinder_ = SetupVAO(vertices, indices);
   }
 

--- a/geometry/render/gl_renderer/dev/shape_meshes.h
+++ b/geometry/render/gl_renderer/dev/shape_meshes.h
@@ -66,7 +66,25 @@ std::pair<VertexBuffer, IndexBuffer> LoadMeshFromObj(
 std::pair<VertexBuffer, IndexBuffer> MakeLongLatUnitSphere(
     int longitude_bands = 50, int latitude_bands = 50);
 
-// TODO(SeanCurtis): Box, Cylinder, Half space, capsule, ellipsoid.
+// TODO(SeanCurtis): Box, Half space, capsule, ellipsoid.
+
+/* Creates an OpenGL-compatible mesh representation of a unit cylinder; its
+ radius and height are equal to 1. It is centered on the origin of its canonical
+ frame C and aligned with Frame C's z axis: Cz.
+ The cylinder's geometry consists of the two caps and the barrel and is
+ tessellated as follows. The barrel is divided in two directions: into a
+ given number of _bands_ of equal height along its length, and into a given
+ number of strips of equal width around its curvature. At the top and bottom
+ circular caps a triangular fan is created from a vertex at the center of each
+ circular cap to all of the vertices on the edge where cap and barrel meet.
+
+ @param num_strips  The number of strips the barrel's curvature is divided into.
+ @param num_bands   The number of equal-width bands spanning the height of the
+                    clinder.
+ @pre `num_strips` >= 3 (otherwise the cylinder will have no volume).
+ @pre `num_bands` >= 1.  */
+std::pair<VertexBuffer, IndexBuffer> MakeUnitCylinder(int num_strips = 50,
+                                                      int num_bands = 1);
 
 }  // namespace internal
 }  // namespace render


### PR DESCRIPTION
 - Refactors Sphere tessellation into a "revolute" shape function.
 - Express sphere in terms of revolute.
 - Express cylinder in terms of revolute.
 - RenderEngineGl now uses the new function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13293)
<!-- Reviewable:end -->
