### PR TITLE
Remove redundant and pessimizing return std::moves

### DIFF
--- a/attic/multibody/joints/fixed_joint.cc
+++ b/attic/multibody/joints/fixed_joint.cc
@@ -19,5 +19,5 @@ Eigen::VectorXd FixedJoint::randomConfiguration(
 std::unique_ptr<DrakeJoint> FixedJoint::DoClone() const {
   auto joint = std::make_unique<FixedJoint>(get_name(),
                                             get_transform_to_parent_body());
-  return std::move(joint);
+  return joint;
 }

--- a/attic/multibody/joints/helical_joint.cc
+++ b/attic/multibody/joints/helical_joint.cc
@@ -19,5 +19,5 @@ std::unique_ptr<DrakeJoint> HelicalJoint::DoClone() const {
   auto joint = std::make_unique<HelicalJoint>(get_name(),
                                               get_transform_to_parent_body(),
                                               axis_, pitch_);
-  return std::move(joint);
+  return joint;
 }

--- a/attic/multibody/joints/prismatic_joint.cc
+++ b/attic/multibody/joints/prismatic_joint.cc
@@ -17,5 +17,5 @@ std::unique_ptr<DrakeJoint> PrismaticJoint::DoClone() const {
   auto joint = std::make_unique<PrismaticJoint>(get_name(),
                                                 get_transform_to_parent_body(),
                                                 translation_axis_);
-  return std::move(joint);
+  return joint;
 }

--- a/attic/multibody/joints/quaternion_ball_joint.cc
+++ b/attic/multibody/joints/quaternion_ball_joint.cc
@@ -52,5 +52,5 @@ VectorXd QuaternionBallJoint::randomConfiguration(
 std::unique_ptr<DrakeJoint> QuaternionBallJoint::DoClone() const {
   auto joint = std::make_unique<QuaternionBallJoint>(
       get_name(), get_transform_to_parent_body());
-  return std::move(joint);
+  return joint;
 }

--- a/attic/multibody/joints/quaternion_floating_joint.cc
+++ b/attic/multibody/joints/quaternion_floating_joint.cc
@@ -78,6 +78,6 @@ VectorXd QuaternionFloatingJoint::randomConfiguration(
 std::unique_ptr<DrakeJoint> QuaternionFloatingJoint::DoClone() const {
   auto joint = std::make_unique<QuaternionFloatingJoint>(get_name(),
       get_transform_to_parent_body());
-  return std::move(joint);
+  return joint;
 }
 

--- a/attic/multibody/joints/revolute_joint.cc
+++ b/attic/multibody/joints/revolute_joint.cc
@@ -17,5 +17,5 @@ std::unique_ptr<DrakeJoint> RevoluteJoint::DoClone() const {
   auto joint = std::make_unique<RevoluteJoint>(get_name(),
                                                get_transform_to_parent_body(),
                                                rotation_axis_);
-  return std::move(joint);
+  return joint;
 }

--- a/attic/multibody/joints/roll_pitch_yaw_floating_joint.cc
+++ b/attic/multibody/joints/roll_pitch_yaw_floating_joint.cc
@@ -54,5 +54,5 @@ std::unique_ptr<DrakeJoint> RollPitchYawFloatingJoint::DoClone() const {
   auto joint = std::make_unique<RollPitchYawFloatingJoint>(
       get_name(),
       get_transform_to_parent_body());
-  return std::move(joint);
+  return joint;
 }

--- a/geometry/proximity/make_sphere_mesh.h
+++ b/geometry/proximity/make_sphere_mesh.h
@@ -513,7 +513,7 @@ VolumeMesh<T> MakeUnitSphereMesh(int refinement_level,
     default:
       DRAKE_UNREACHABLE();
   }
-  return std::move(mesh);
+  return mesh;
 }
 
 /** Creates a volume mesh for the given `sphere`; the level of tessellation is

--- a/multibody/tree/ball_rpy_joint.cc
+++ b/multibody/tree/ball_rpy_joint.cc
@@ -28,7 +28,7 @@ std::unique_ptr<Joint<ToScalar>> BallRpyJoint<T>::TemplatedDoCloneToScalar(
   joint_clone->set_acceleration_limits(this->acceleration_lower_limits(),
                                        this->acceleration_upper_limits());
 
-  return std::move(joint_clone);
+  return joint_clone;
 }
 
 template <typename T>
@@ -60,7 +60,7 @@ BallRpyJoint<T>::MakeImplementationBlueprint() const {
       this->frame_on_parent(), this->frame_on_child());
   ballrpy_mobilizer->set_default_position(this->default_positions());
   blue_print->mobilizers_.push_back(std::move(ballrpy_mobilizer));
-  return std::move(blue_print);
+  return blue_print;
 }
 
 }  // namespace multibody

--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -387,7 +387,7 @@ class Joint : public MultibodyElement<Joint, T, JointIndex> {
         this->get_implementation().template CloneToScalar<ToScalar>(tree_clone);
     joint_clone->OwnImplementation(std::move(implementation_clone));
 
-    return std::move(joint_clone);
+    return joint_clone;
   }
 #endif
   // End of hidden Doxygen section.
@@ -442,7 +442,7 @@ class Joint : public MultibodyElement<Joint, T, JointIndex> {
             &tree_clone->get_mutable_variant(*mobilizer);
         implementation_clone->mobilizers_.push_back(mobilizer_clone);
       }
-      return std::move(implementation_clone);
+      return implementation_clone;
     }
 #endif
     // End of hidden Doxygen section.

--- a/multibody/tree/prismatic_joint.h
+++ b/multibody/tree/prismatic_joint.h
@@ -294,7 +294,7 @@ class PrismaticJoint final : public Joint<T> {
             this->frame_on_parent(), this->frame_on_child(), axis_);
     prismatic_mobilizer->set_default_position(this->default_positions());
     blue_print->mobilizers_.push_back(std::move(prismatic_mobilizer));
-    return std::move(blue_print);
+    return blue_print;
   }
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(

--- a/multibody/tree/revolute_joint.cc
+++ b/multibody/tree/revolute_joint.cc
@@ -27,7 +27,7 @@ std::unique_ptr<Joint<ToScalar>> RevoluteJoint<T>::TemplatedDoCloneToScalar(
   joint_clone->set_acceleration_limits(this->acceleration_lower_limits(),
                                        this->acceleration_upper_limits());
 
-  return std::move(joint_clone);
+  return joint_clone;
 }
 
 template <typename T>
@@ -59,7 +59,7 @@ RevoluteJoint<T>::MakeImplementationBlueprint() const {
       this->frame_on_parent(), this->frame_on_child(), axis_);
   revolute_mobilizer->set_default_position(this->default_positions());
   blue_print->mobilizers_.push_back(std::move(revolute_mobilizer));
-  return std::move(blue_print);
+  return blue_print;
 }
 
 }  // namespace multibody

--- a/multibody/tree/revolute_spring.cc
+++ b/multibody/tree/revolute_spring.cc
@@ -90,7 +90,7 @@ RevoluteSpring<T>::TemplatedDoCloneToScalar(
   std::unique_ptr<RevoluteSpring<ToScalar>> spring_clone(
       new RevoluteSpring<ToScalar>(this->model_instance(), joint_index_,
                                    nominal_angle(), stiffness()));
-  return std::move(spring_clone);
+  return spring_clone;
 }
 
 template <typename T>

--- a/multibody/tree/universal_joint.cc
+++ b/multibody/tree/universal_joint.cc
@@ -27,7 +27,7 @@ std::unique_ptr<Joint<ToScalar>> UniversalJoint<T>::TemplatedDoCloneToScalar(
   joint_clone->set_acceleration_limits(this->acceleration_lower_limits(),
                                        this->acceleration_upper_limits());
 
-  return std::move(joint_clone);
+  return joint_clone;
 }
 
 template <typename T>
@@ -59,7 +59,7 @@ UniversalJoint<T>::MakeImplementationBlueprint() const {
       this->frame_on_parent(), this->frame_on_child());
   univeral_mobilizer->set_default_position(this->default_positions());
   blue_print->mobilizers_.push_back(std::move(univeral_mobilizer));
-  return std::move(blue_print);
+  return blue_print;
 }
 
 }  // namespace multibody

--- a/multibody/tree/weld_joint.cc
+++ b/multibody/tree/weld_joint.cc
@@ -22,7 +22,7 @@ WeldJoint<T>::TemplatedDoCloneToScalar(
       this->name(),
       frame_on_parent_body_clone, frame_on_child_body_clone, X_PC());
 
-  return std::move(joint_clone);
+  return joint_clone;
 }
 
 template <typename T>
@@ -53,7 +53,7 @@ WeldJoint<T>::MakeImplementationBlueprint() const {
   blue_print->mobilizers_.push_back(
       std::make_unique<internal::WeldMobilizer<T>>(
           this->frame_on_parent(), this->frame_on_child(), X_PC_));
-  return std::move(blue_print);
+  return blue_print;
 }
 
 }  // namespace multibody

--- a/systems/analysis/test/scalar_view_dense_output_test.cc
+++ b/systems/analysis/test/scalar_view_dense_output_test.cc
@@ -24,7 +24,7 @@ class ScalarViewDenseOutputTest : public ::testing::Test {
                 this->kFinalStateDerivative);
     dense_output->Update(std::move(step));
     dense_output->Consolidate();
-    return std::move(dense_output);
+    return dense_output;
   }
 
   const double kInvalidTime{-1.0};


### PR DESCRIPTION
A function return that looks like
```c++
SomeType f() {
  SomeType local_variable;
  // ...
  return std::move(local_variable);  // DON'T DO THIS
}
```
is called a "pessimizing" move and prevents copy ellision, where the space for the return value can be used for the local variable so no copying is required. See [here](https://developers.redhat.com/blog/2019/04/12/understanding-when-not-to-stdmove-in-c/) for an explanation. Pessimizing moves will generate compiler warnings in the near future.

Thanks to @jwnimmer-tri for pointing this out.

There are also many other cases return `return std::move(something);` is simply redundant.

To avoid future warnings and cargo culting, this PR removes all the pessimizing and redundant `return std::move`s I could find in Drake.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13306)
<!-- Reviewable:end -->
