### PR TITLE
systems: Luenberger observer uses cache entries

### DIFF
--- a/systems/estimators/BUILD.bazel
+++ b/systems/estimators/BUILD.bazel
@@ -57,6 +57,7 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:is_dynamic_castable",
         "//examples/pendulum:pendulum_plant",
+        "//systems/framework/test_utilities:scalar_conversion",
         "//systems/primitives:linear_system",
     ],
 )

--- a/systems/estimators/kalman_filter.cc
+++ b/systems/estimators/kalman_filter.cc
@@ -30,7 +30,7 @@ std::unique_ptr<LuenbergerObserver<double>> SteadyStateKalmanFilter(
       SteadyStateKalmanFilter(system->A(), system->C(), W, V);
 
   return std::make_unique<LuenbergerObserver<double>>(
-      std::move(system), system->CreateDefaultContext(), L);
+      std::move(system), *system->CreateDefaultContext(), L);
 }
 
 std::unique_ptr<LuenbergerObserver<double>> SteadyStateKalmanFilter(
@@ -52,7 +52,7 @@ std::unique_ptr<LuenbergerObserver<double>> SteadyStateKalmanFilter(
       SteadyStateKalmanFilter(linear_system->A(), linear_system->C(), W, V);
 
   return std::make_unique<LuenbergerObserver<double>>(std::move(system),
-                                                      std::move(context), L);
+                                                      *context, L);
 }
 
 }  // namespace estimators

--- a/systems/estimators/luenberger_observer.cc
+++ b/systems/estimators/luenberger_observer.cc
@@ -1,9 +1,8 @@
 #include "drake/systems/estimators/luenberger_observer.h"
 
 #include <cmath>
+#include <set>
 #include <utility>
-
-#include "drake/common/default_scalars.h"
 
 namespace drake {
 namespace systems {
@@ -11,22 +10,22 @@ namespace estimators {
 
 template <typename T>
 LuenbergerObserver<T>::LuenbergerObserver(
-    std::unique_ptr<systems::System<T>> observed_system,
-    std::unique_ptr<systems::Context<T>> observed_system_context,
+    const System<T>* system, std::unique_ptr<System<T>> owned_system,
+    const Context<T>& observed_system_context,
     const Eigen::Ref<const Eigen::MatrixXd>& observer_gain)
-    : observed_system_(std::move(observed_system)),
-      observer_gain_(observer_gain),
-      observed_system_context_(std::move(observed_system_context)),
-      observed_system_output_(observed_system_->AllocateOutput()),
-      observed_system_derivatives_(
-          observed_system_->AllocateTimeDerivatives()) {
-  DRAKE_DEMAND(observed_system_ != nullptr);
+    : owned_system_(std::move(owned_system)),
+      observed_system_(owned_system_ ? owned_system_.get() : system),
+      observer_gain_(observer_gain) {
+  DRAKE_DEMAND(observed_system_);
+  observed_system_->ValidateContext(observed_system_context);
 
   // Note: Could potentially extend this to MIMO systems.
   DRAKE_DEMAND(observed_system_->num_input_ports() <= 1);
   DRAKE_DEMAND(observed_system_->num_output_ports() == 1);
+  DRAKE_DEMAND(observed_system_->get_output_port(0).get_data_type() ==
+               kVectorValued);
 
-  DRAKE_DEMAND(observed_system_context_->has_only_continuous_state());
+  DRAKE_DEMAND(observed_system_context.has_only_continuous_state());
   // Otherwise there is nothing to estimate.
 
   // TODO(russt): Add support for discrete-time systems (should be easy enough
@@ -35,7 +34,7 @@ LuenbergerObserver<T>::LuenbergerObserver(
   // Observer state is the (estimated) state of the observed system,
   // but the best we can do for now is to allocate a similarly-sized
   // BasicVector (see #6998).
-  const auto& xc = observed_system_context_->get_continuous_state();
+  const auto& xc = observed_system_context.get_continuous_state();
   const int num_q = xc.get_generalized_position().size();
   const int num_v = xc.get_generalized_velocity().size();
   const int num_z = xc.get_misc_continuous_state().size();
@@ -44,13 +43,15 @@ LuenbergerObserver<T>::LuenbergerObserver(
   // Output port is the (estimated) state of the observed system.
   // Note: Again, the derived type of the state vector is lost here, because xc
   // is only guaranteed to be a VectorBase, not a BasicVector.
-  this->DeclareVectorOutputPort(BasicVector<T>(xc.size()),
+  this->DeclareVectorOutputPort("estimated_state", BasicVector<T>(xc.size()),
                                 &LuenbergerObserver::CalcEstimatedState,
                                 {this->xc_ticket()});
 
   // First input port is the output of the observed system.
-  // Note: Throws bad_cast if the output is not vector-valued.
-  this->DeclareVectorInputPort(*observed_system_output_->get_vector_data(0));
+  const auto& y_input_port = this->DeclareVectorInputPort(
+      "observed_system_output",
+      *observed_system_->AllocateOutput()->get_vector_data(0));
+  std::set<DependencyTicket> input_port_tickets{y_input_port.ticket()};
 
   // Check the size of the gain matrix.
   DRAKE_DEMAND(observer_gain_.rows() == xc.size());
@@ -59,22 +60,61 @@ LuenbergerObserver<T>::LuenbergerObserver(
 
   // Second input port is the input to the observed system (if it exists).
   if (observed_system_->num_input_ports() > 0) {
+    DRAKE_DEMAND(observed_system_->get_input_port(0).get_data_type() ==
+                 kVectorValued);
     auto input_vec = observed_system_->AllocateInputVector(
         observed_system_->get_input_port(0));
-    this->DeclareVectorInputPort(*input_vec);
+    const auto& u_input_port =
+        this->DeclareVectorInputPort("observed_system_input", *input_vec);
+    input_port_tickets.emplace(u_input_port.ticket());
   }
+
+  // Copy the observed system context into a cache entry where we can safely
+  // modify it without runtime reallocation or a (non-thread-safe) mutable
+  // member.
+  observed_system_context_cache_entry_ = &this->DeclareCacheEntry(
+      "observed system context", observed_system_context,
+      &LuenbergerObserver::UpdateObservedSystemContext, input_port_tickets);
 }
 
 template <typename T>
-void LuenbergerObserver<T>::CalcEstimatedState(
-    const systems::Context<T>& context, systems::BasicVector<T>* output) const {
+LuenbergerObserver<T>::LuenbergerObserver(
+    const System<T>& observed_system, const Context<T>& observed_system_context,
+    const Eigen::Ref<const Eigen::MatrixXd>& observer_gain)
+    : LuenbergerObserver(&observed_system, nullptr, observed_system_context,
+                         observer_gain) {}
+
+template <typename T>
+LuenbergerObserver<T>::LuenbergerObserver(
+    std::unique_ptr<System<T>> observed_system,
+    const Context<T>& observed_system_context,
+    const Eigen::Ref<const Eigen::MatrixXd>& observer_gain)
+    : LuenbergerObserver(nullptr, std::move(observed_system),
+                         observed_system_context, observer_gain) {}
+
+// Note: observed_system_context is not moved -- it only needs to live long
+// enough to be copied into the Context in the delegated constructor.
+template <typename T>
+LuenbergerObserver<T>::LuenbergerObserver(
+    std::unique_ptr<System<T>> observed_system,
+    std::unique_ptr<Context<T>> observed_system_context,
+    const Eigen::Ref<const Eigen::MatrixXd>& observer_gain)
+    : LuenbergerObserver(nullptr, std::move(observed_system),
+                         *observed_system_context, observer_gain) {
+  static const logging::Warn log_once(
+      "Called a deprecated constructor for LuenbergerObserver.  Use a "
+      "constructor which passes the context by reference.");
+}
+
+template <typename T>
+void LuenbergerObserver<T>::CalcEstimatedState(const Context<T>& context,
+                                               BasicVector<T>* output) const {
   output->set_value(context.get_continuous_state_vector().CopyToVector());
 }
 
 template <typename T>
-void LuenbergerObserver<T>::DoCalcTimeDerivatives(
-    const systems::Context<T>& context,
-    systems::ContinuousState<T>* derivatives) const {
+void LuenbergerObserver<T>::UpdateObservedSystemContext(
+    const Context<T>& context, Context<T>* observed_system_context) const {
   // (Note that all relevant data in the observed_system_context is set here
   // from the observer state/inputs.  The observer_context does not hold any
   // hidden undeclared state).
@@ -84,33 +124,38 @@ void LuenbergerObserver<T>::DoCalcTimeDerivatives(
     // TODO(russt): Avoid this dynamic allocation by fixing the input port once
     // and updating it here.
     observed_system_->get_input_port(0).FixValue(
-        observed_system_context_.get(), this->get_input_port(1).Eval(context));
+        observed_system_context,
+        this->get_observed_system_input_input_port().Eval(context));
   }
   // Set observed system state.
-  observed_system_context_->get_mutable_continuous_state_vector().SetFrom(
+  observed_system_context->get_mutable_continuous_state_vector().SetFrom(
       context.get_continuous_state_vector());
+}
+
+template <typename T>
+void LuenbergerObserver<T>::DoCalcTimeDerivatives(
+    const Context<T>& context, ContinuousState<T>* derivatives) const {
+  const Context<T>& observed_system_context =
+      observed_system_context_cache_entry_->Eval<Context<T>>(context);
 
   // Evaluate the observed system.
-  observed_system_->CalcOutput(*observed_system_context_,
-                               observed_system_output_.get());
-  observed_system_->CalcTimeDerivatives(*observed_system_context_,
-                                        observed_system_derivatives_.get());
+  Eigen::VectorBlock<const VectorX<T>> yhat =
+      observed_system_->get_output_port(0).Eval(observed_system_context);
+  VectorX<T> xdothat =
+      observed_system_->EvalTimeDerivatives(observed_system_context)
+          .CopyToVector();
 
   // Get the measurements.
-  auto y = this->get_input_port(0).Eval(context);
-  auto yhat = observed_system_output_->GetMutableVectorData(0)->CopyToVector();
-
-  // Add in the observed gain terms.
-  auto& xdothat = observed_system_derivatives_->get_mutable_vector();
+  Eigen::VectorBlock<const VectorX<T>> y =
+      this->get_observed_system_output_input_port().Eval(context);
 
   // xdothat = f(xhat,u) + L(y-yhat).
-  derivatives->SetFromVector(xdothat.CopyToVector() +
-                             observer_gain_ * (y - yhat));
+  derivatives->SetFromVector(xdothat + observer_gain_ * (y - yhat));
 }
 
 }  // namespace estimators
 }  // namespace systems
 }  // namespace drake
 
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::estimators::LuenbergerObserver)

--- a/systems/estimators/test/luenberger_observer_test.cc
+++ b/systems/estimators/test/luenberger_observer_test.cc
@@ -9,9 +9,12 @@
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/is_dynamic_castable.h"
 #include "drake/examples/pendulum/pendulum_plant.h"
+#include "drake/systems/framework/test_utilities/scalar_conversion.h"
 #include "drake/systems/primitives/linear_system.h"
 
 namespace drake {
+namespace systems {
+namespace estimators {
 namespace {
 
 // Test the estimator dynamics observing a linear system.
@@ -39,41 +42,71 @@ GTEST_TEST(LuenbergerObserverTest, ErrorDynamics) {
        27., 28., 29.;
   // clang-format on
 
-  auto plant = std::make_unique<systems::LinearSystem<double>>(A, B, C, D);
-  auto plant_context = plant->CreateDefaultContext();
-  auto observer =
-      std::make_unique<systems::estimators::LuenbergerObserver<double>>(
-          std::move(plant), std::move(plant_context), L);
+  // Run the test using all three constructors.
+  for (int i = 0; i < 3; ++i) {
+    auto plant = std::make_unique<systems::LinearSystem<double>>(A, B, C, D);
+    auto plant_context = plant->CreateDefaultContext();
+    std::unique_ptr<systems::estimators::LuenbergerObserver<double>> observer{
+        nullptr};
+    switch (i) {
+      case 0:  // pass system and context by reference.
+        observer =
+            std::make_unique<systems::estimators::LuenbergerObserver<double>>(
+                *plant, *plant_context, L);
+        break;
+      case 1:  // owned system version.
+        observer =
+            std::make_unique<systems::estimators::LuenbergerObserver<double>>(
+                std::move(plant), *plant_context, L);
+        break;
+      case 2:  // deprecated constructor (passes both system and context
+               // for ownership).
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+        // NOTE: make_unique actually swallows the deprecation warnings anyhow,
+        // so the pragma is not actually needed.  But I'm leaving it here for
+        // easy removal once the deprecation period expires.
+        observer =
+            std::make_unique<systems::estimators::LuenbergerObserver<double>>(
+                std::move(plant), std::move(plant_context), L);
+#pragma GCC diagnostic pop
+        break;
+    }
 
-  auto context = observer->CreateDefaultContext();
-  auto derivatives = observer->AllocateTimeDerivatives();
-  auto output = observer->AllocateOutput();
+    auto context = observer->CreateDefaultContext();
+    auto derivatives = observer->AllocateTimeDerivatives();
+    auto output = observer->AllocateOutput();
 
-  EXPECT_FALSE(observer->HasAnyDirectFeedthrough());
+    EXPECT_FALSE(observer->HasAnyDirectFeedthrough());
 
-  // The expected dynamics are:
-  //  xhatdot = Axhat + Bu + L(y-yhat)
-  //  y = xhat
+    // The expected dynamics are:
+    //  xhatdot = Axhat + Bu + L(y-yhat)
+    //  y = xhat
 
-  Eigen::Vector3d xhat(1.0, 2.0, 3.0);
-  Vector1d u(4.0);
+    Eigen::Vector3d xhat(1.0, 2.0, 3.0);
+    Vector1d u(4.0);
 
-  Eigen::Vector2d y(5.0, 6.0);
+    Eigen::Vector2d y(5.0, 6.0);
 
-  Eigen::Vector3d xhatdot = A * xhat + B * u + L * (y - C * xhat - D * u);
+    Eigen::Vector3d xhatdot = A * xhat + B * u + L * (y - C * xhat - D * u);
 
-  observer->get_input_port(0).FixValue(context.get(), y);
-  observer->get_input_port(1).FixValue(context.get(), u);
-  context->get_mutable_continuous_state_vector().SetFromVector(xhat);
+    observer->get_input_port(0).FixValue(context.get(), y);
+    observer->get_input_port(1).FixValue(context.get(), u);
+    context->get_mutable_continuous_state_vector().SetFromVector(xhat);
 
-  observer->CalcTimeDerivatives(*context, derivatives.get());
-  observer->CalcOutput(*context, output.get());
+    observer->CalcTimeDerivatives(*context, derivatives.get());
+    observer->CalcOutput(*context, output.get());
 
-  double tol = 1e-10;
+    double tol = 1e-10;
 
-  EXPECT_TRUE(CompareMatrices(xhatdot, derivatives->CopyToVector(), tol));
-  EXPECT_TRUE(CompareMatrices(
-      xhat, output->GetMutableVectorData(0)->CopyToVector(), tol));
+    EXPECT_TRUE(CompareMatrices(xhatdot, derivatives->CopyToVector(), tol));
+    EXPECT_TRUE(CompareMatrices(
+        xhat, output->GetMutableVectorData(0)->CopyToVector(), tol));
+
+    // TODO(russt): Support scalar conversion.
+    EXPECT_FALSE(is_autodiffxd_convertible(*observer));
+    EXPECT_FALSE(is_symbolic_convertible(*observer));
+  }
 }
 
 // Check that the observer inherits the dynamic types of the pendulum.
@@ -100,5 +133,21 @@ GTEST_TEST(LuenbergerObserverTest, DerivedTypes) {
   // is not that way yet (see #6998).
 }
 
+GTEST_TEST(LuenbergerObserverTest, InputOutputPorts) {
+  examples::pendulum::PendulumPlant<double> plant;
+  auto context = plant.CreateDefaultContext();
+  const Eigen::Matrix2d L = Eigen::Matrix2d::Identity();
+  LuenbergerObserver<double> observer(plant, *context, L);
+
+  EXPECT_EQ(observer.GetInputPort("observed_system_input").get_index(),
+            observer.get_observed_system_input_input_port().get_index());
+  EXPECT_EQ(observer.GetInputPort("observed_system_output").get_index(),
+            observer.get_observed_system_output_input_port().get_index());
+  EXPECT_EQ(observer.GetOutputPort("estimated_state").get_index(),
+            observer.get_estimated_state_output_port().get_index());
+}
+
 }  // namespace
+}  // namespace estimators
+}  // namespace systems
 }  // namespace drake


### PR DESCRIPTION
instead of mutable member variables.
related to #13131

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13307)
<!-- Reviewable:end -->
