### PR TITLE
Allow using Binding<C> as key in unordered_map.

### DIFF
--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -1014,6 +1014,7 @@ drake_cc_googletest(
         ":binding",
         ":constraint",
         ":cost",
+        "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:symbolic_test_util",
     ],
 )

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -96,6 +96,7 @@ drake_cc_library(
     hdrs = ["binding.h"],
     deps = [
         ":decision_variable",
+        ":evaluator_base",
     ],
 )
 

--- a/solvers/binding.h
+++ b/solvers/binding.h
@@ -86,9 +86,7 @@ class Binding {
     if (this->evaluator().get() != other.evaluator().get()) {
       return false;
     }
-    if (vars_.rows() != other.vars_.rows()) {
-      return false;
-    }
+    DRAKE_DEMAND(vars_.rows() == other.vars_.rows());
     for (int i = 0; i < vars_.rows(); ++i) {
       if (!vars_(i).equal_to(other.vars_(i))) {
         return false;
@@ -108,10 +106,14 @@ class Binding {
     using drake::hash_append;
     const EvaluatorBase* const base = item.evaluator().get();
     hash_append(hasher, reinterpret_cast<std::uintptr_t>(base));
-    hash_append(hasher, item.variables().rows());
+    // We follow the pattern in
+    // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n3980.html#hash_append_vector
+    // to append the hash for a std::vector, first to append all its elements,
+    // and then append the vector size.
     for (int i = 0; i < item.variables().rows(); ++i) {
       hash_append(hasher, item.variables()(i));
     }
+    hash_append(hasher, item.variables().rows());
   }
 
  private:

--- a/solvers/test/binding_test.cc
+++ b/solvers/test/binding_test.cc
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/symbolic_test_util.h"
 #include "drake/common/text_logging.h"
 #include "drake/solvers/constraint.h"
@@ -17,31 +18,61 @@ GTEST_TEST(TestBinding, TestConstraint) {
   const symbolic::Variable x1("x1");
   const symbolic::Variable x2("x2");
   const symbolic::Variable x3("x3");
-  auto bb_con = std::make_shared<BoundingBoxConstraint>(
+  auto bb_con1 = std::make_shared<BoundingBoxConstraint>(
       Eigen::Vector3d::Zero(), Eigen::Vector3d::Ones());
 
   // Checks if the bound variables are stored in the right order.
   Binding<BoundingBoxConstraint> binding1(
-      bb_con,
+      bb_con1,
       {VectorDecisionVariable<2>(x3, x1), VectorDecisionVariable<1>(x2)});
   EXPECT_EQ(binding1.GetNumElements(), 3u);
   VectorDecisionVariable<3> var1_expected(x3, x1, x2);
   for (int i = 0; i < 3; ++i) {
     EXPECT_PRED2(VarEqual, binding1.variables()(i), var1_expected(i));
   }
-  bb_con->set_description("dummy bb");
+  bb_con1->set_description("dummy bb");
   const std::string str_expected1 =
       "BoundingBoxConstraint described as 'dummy bb'\n0 <= x3 <= 1\n0 <= x1 <= "
       "1\n0 <= x2 <= 1\n";
   EXPECT_EQ(fmt::format("{}", binding1), str_expected1);
+  EXPECT_TRUE(binding1.equal_to(binding1));
+  EXPECT_EQ(binding1, binding1);
 
   // Creates a binding with a single VectorDecisionVariable.
   Binding<BoundingBoxConstraint> binding2(
-      bb_con, VectorDecisionVariable<3>(x3, x1, x2));
+      bb_con1, VectorDecisionVariable<3>(x3, x1, x2));
   EXPECT_EQ(binding2.GetNumElements(), 3u);
   for (int i = 0; i < 3; ++i) {
     EXPECT_PRED2(VarEqual, binding2.variables()(i), var1_expected(i));
   }
+  EXPECT_TRUE(binding1.equal_to(binding2));
+  EXPECT_EQ(binding1, binding2);
+  // binding3 has different variables.
+  Binding<BoundingBoxConstraint> binding3(
+      bb_con1, VectorDecisionVariable<3>(x3, x2, x1));
+  EXPECT_FALSE(binding1.equal_to(binding3));
+  EXPECT_NE(binding1, binding3);
+  // bb_con2 has different address from bb_con1, although they have the same
+  // bounds.
+  auto bb_con2 = std::make_shared<BoundingBoxConstraint>(
+      Eigen::Vector3d::Zero(), Eigen::Vector3d::Ones());
+  EXPECT_TRUE(CompareMatrices(bb_con2->lower_bound(), bb_con1->lower_bound()));
+  EXPECT_TRUE(CompareMatrices(bb_con2->upper_bound(), bb_con1->upper_bound()));
+  Binding<BoundingBoxConstraint> binding4(
+      bb_con2, VectorDecisionVariable<3>(x3, x1, x2));
+  EXPECT_FALSE(binding1.equal_to(binding4));
+  EXPECT_FALSE(binding2.equal_to(binding4));
+  EXPECT_FALSE(binding3.equal_to(binding4));
+
+  // Test using Binding as unordered_map key.
+  std::unordered_map<Binding<BoundingBoxConstraint>, int, drake::DefaultHash>
+      map;
+  map.emplace(binding1, 1);
+  EXPECT_EQ(map.at(binding1), 1);
+  EXPECT_EQ(map.at(binding2), 1);
+  EXPECT_EQ(map.find(binding3), map.end());
+  map.emplace(binding3, 3);
+  EXPECT_EQ(map.at(binding3), 3);
 
   // Test to_string() for LinearEqualityConstraint binding.
   Eigen::Matrix2d Aeq;

--- a/solvers/test/binding_test.cc
+++ b/solvers/test/binding_test.cc
@@ -87,7 +87,7 @@ TEST_F(TestBinding, TestPrinting) {
   EXPECT_EQ(linear_binding.to_string(), str_expected3);
 }
 
-TEST_F(TestBinding, TeshHash) {
+TEST_F(TestBinding, TestHash) {
   auto bb_con1 = std::make_shared<BoundingBoxConstraint>(
       Eigen::Vector3d::Zero(), Eigen::Vector3d::Ones());
 
@@ -119,7 +119,8 @@ TEST_F(TestBinding, TeshHash) {
   EXPECT_TRUE(CompareMatrices(bb_con2->upper_bound(), bb_con1->upper_bound()));
   Binding<BoundingBoxConstraint> binding4(
       bb_con2, VectorDecisionVariable<3>(x3_, x1_, x2_));
-  EXPECT_NE(binding3, binding4);
+  EXPECT_NE(binding4, binding1);
+  EXPECT_NE(binding4, binding2);
 
   // Test using Binding as unordered_map key.
   std::unordered_map<Binding<BoundingBoxConstraint>, int> map;


### PR DESCRIPTION
Add equal_to and hash function for Binding<C>

This is the first step to address the issues in #13285 . I plan to store the mapping from each `Binding<C>` to the dual variable solutions in `MathematicalProgramResult`. To this end, we need to use `Binding<C>` as the key in an unordered_map.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13322)
<!-- Reviewable:end -->
