### PR TITLE
Deprecate the Isometry3 in systems/rendering

### DIFF
--- a/attic/systems/sensors/depth_sensor_to_lcm_point_cloud_message.cc
+++ b/attic/systems/sensors/depth_sensor_to_lcm_point_cloud_message.cc
@@ -70,7 +70,7 @@ void DepthSensorToLcmPointCloudMessage::CalcPointCloudMessage(
   message.points.clear();
   for (int i = 0; i < point_cloud_S.cols(); ++i) {
     const auto& point_S = point_cloud_S.col(i);
-    Eigen::Vector3d point_W = X_WS->get_isometry() * point_S;
+    Eigen::Vector3d point_W = X_WS->get_transform() * point_S;
     message.points.push_back(std::vector<float>{
         static_cast<float>(point_W(0)),
         static_cast<float>(point_W(1)),

--- a/attic/systems/sensors/test/rgbd_camera_test.cc
+++ b/attic/systems/sensors/test/rgbd_camera_test.cc
@@ -14,6 +14,7 @@
 #include "drake/common/find_resource.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/unused.h"
+#include "drake/math/rigid_transform.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/parsers/sdf_parser.h"
 #include "drake/multibody/rigid_body_plant/rigid_body_plant.h"
@@ -303,7 +304,8 @@ TEST_F(RgbdCameraDiagramTest, FixedCameraOutputTest) {
         dynamic_cast<rendering::PoseVector<double>*>(
             output_->GetMutableVectorData(3));
 
-    const Eigen::Isometry3d actual = camera_base_pose->get_isometry();
+    const Eigen::Isometry3d actual =
+        camera_base_pose->get_transform().GetAsIsometry3();
     EXPECT_TRUE(CompareMatrices(position.matrix(),
                                 actual.translation().matrix(), kTolerance));
     const math::RollPitchYaw<double> rpy(orientation);
@@ -325,9 +327,9 @@ TEST_F(RgbdCameraDiagramTest, MovableCameraOutputTest) {
         dynamic_cast<rendering::PoseVector<double>*>(
             output_->GetMutableVectorData(3));
 
-    const Eigen::Isometry3d actual = camera_base_pose->get_isometry();
-    EXPECT_TRUE(CompareMatrices(X_WB.matrix(),
-                                actual.matrix(), kTolerance));
+    const Eigen::Isometry3d actual =
+        camera_base_pose->get_transform().GetAsIsometry3();
+    EXPECT_TRUE(CompareMatrices(X_WB.matrix(), actual.matrix(), kTolerance));
   }
 }
 

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -139,6 +139,7 @@ drake_pybind_library(
     name = "rendering_py",
     cc_deps = [
         "//bindings/pydrake:documentation_pybind",
+        "//bindings/pydrake/common:deprecation_pybind",
         "//bindings/pydrake/common:eigen_geometry_pybind",
         "//bindings/pydrake/common:value_pybind",
     ],
@@ -147,6 +148,7 @@ drake_pybind_library(
     py_deps = [
         ":framework_py",
         ":module_py",
+        "//bindings/pydrake/common:deprecation_py",
         "//bindings/pydrake/common:eigen_geometry_py",
     ],
 )
@@ -526,6 +528,7 @@ drake_py_unittest(
     data = ["//multibody/benchmarks/acrobot:models"],
     deps = [
         ":rendering_py",
+        "//bindings/pydrake/common/test_utilities",
         "//bindings/pydrake/multibody:math_py",
         "//bindings/pydrake/multibody:parsing_py",
         "//bindings/pydrake/multibody:plant_py",

--- a/bindings/pydrake/systems/meshcat_visualizer.py
+++ b/bindings/pydrake/systems/meshcat_visualizer.py
@@ -369,9 +369,9 @@ class MeshcatVisualizer(LeafSystem):
             model_id = pose_bundle.get_model_instance_id(frame_i)
             # The MBP parsers only register the plant as a nameless source.
             # TODO(russt): Use a more textual naming convention here?
-            pose_matrix = pose_bundle.get_pose(frame_i)
+            pose_matrix = pose_bundle.get_transform(frame_i)
             self.vis[self.prefix][source_name][str(model_id)][frame_name]\
-                .set_transform(pose_matrix.matrix())
+                .set_transform(pose_matrix.GetAsMatrix4())
 
 
 class MeshcatContactVisualizer(LeafSystem):
@@ -453,7 +453,7 @@ class MeshcatContactVisualizer(LeafSystem):
             (source_name, frame_name) = self._meshcat_viz._parse_name(
                 pose_bundle.get_name(frame_i))
             model_instance = pose_bundle.get_model_instance_id(frame_i)
-            pose_matrix = pose_bundle.get_pose(frame_i)
+            pose_matrix = pose_bundle.get_transform(frame_i)
             _, frame_name = frame_name.split("::")
             key = (model_instance, frame_name)
             X_WB_map[key] = pose_matrix

--- a/bindings/pydrake/systems/planar_scenegraph_visualizer.py
+++ b/bindings/pydrake/systems/planar_scenegraph_visualizer.py
@@ -352,7 +352,7 @@ class PlanarSceneGraphVisualizer(PyPlotVisualizer):
             full_name = pose_bundle.get_name(frame_i)
             model_id = pose_bundle.get_model_instance_id(frame_i)
 
-            X_WB = RigidTransform(pose_bundle.get_pose(frame_i))
+            X_WB = pose_bundle.get_transform(frame_i)
             patch_Wlist, _ = self._get_view_patches(full_name, X_WB)
             for i, patch_W in enumerate(patch_Wlist):
                 # Project the object vertices from 3d in world frame W to 2d in

--- a/bindings/pydrake/systems/rendering_py.cc
+++ b/bindings/pydrake/systems/rendering_py.cc
@@ -2,6 +2,7 @@
 #include "pybind11/pybind11.h"
 #include <Eigen/Dense>
 
+#include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/eigen_geometry_pybind.h"
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
@@ -35,9 +36,19 @@ PYBIND11_MODULE(rendering, m) {
       .def(py::init<const Eigen::Quaternion<T>&,
                const Eigen::Translation<T, 3>&>(),
           py::arg("rotation"), py::arg("translation"),
-          doc.PoseVector.ctor.doc_2args)
-      .def("get_isometry", &PoseVector<T>::get_isometry,
-          doc.PoseVector.get_isometry.doc)
+          doc.PoseVector.ctor.doc_2args);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  pose_vector.def("get_isometry",
+      WrapDeprecated(doc.PoseVector.get_isometry.doc_deprecated,
+          &PoseVector<T>::get_isometry),
+      doc.PoseVector.get_isometry.doc_deprecated);
+#pragma GCC diagnostic pop
+  pose_vector
+      .def("get_transform", &PoseVector<T>::get_transform,
+          doc.PoseVector.get_transform.doc)
+      .def("set_transform", &PoseVector<T>::set_transform,
+          doc.PoseVector.set_transform.doc)
       .def("get_translation", &PoseVector<T>::get_translation,
           doc.PoseVector.get_translation.doc)
       .def("set_translation", &PoseVector<T>::set_translation,
@@ -62,12 +73,28 @@ PYBIND11_MODULE(rendering, m) {
 
   frame_velocity.attr("kSize") = int{FrameVelocity<T>::kSize};
 
-  py::class_<PoseBundle<T>>(m, "PoseBundle", doc.PoseBundle.doc)
+  py::class_<PoseBundle<T>> pose_bundle(m, "PoseBundle", doc.PoseBundle.doc);
+  pose_bundle
       .def(py::init<int>(), py::arg("num_poses"), doc.PoseBundle.ctor.doc)
       .def("get_num_poses", &PoseBundle<T>::get_num_poses,
-          doc.PoseBundle.get_num_poses.doc)
-      .def("get_pose", &PoseBundle<T>::get_pose, doc.PoseBundle.get_pose.doc)
-      .def("set_pose", &PoseBundle<T>::set_pose, doc.PoseBundle.set_pose.doc)
+          doc.PoseBundle.get_num_poses.doc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  pose_bundle
+      .def("get_pose",
+          WrapDeprecated(
+              doc.PoseBundle.get_pose.doc_deprecated, &PoseBundle<T>::get_pose),
+          doc.PoseBundle.get_pose.doc_deprecated)
+      .def("set_pose",
+          WrapDeprecated(
+              doc.PoseBundle.set_pose.doc_deprecated, &PoseBundle<T>::set_pose),
+          doc.PoseBundle.set_pose.doc_deprecated);
+#pragma GCC diagnostic pop
+  pose_bundle
+      .def("get_transform", &PoseBundle<T>::get_transform,
+          doc.PoseBundle.get_transform.doc)
+      .def("set_transform", &PoseBundle<T>::set_transform,
+          doc.PoseBundle.set_transform.doc)
       .def("get_velocity", &PoseBundle<T>::get_velocity,
           doc.PoseBundle.get_velocity.doc)
       .def("set_velocity", &PoseBundle<T>::set_velocity,

--- a/bindings/pydrake/systems/test/rendering_test.py
+++ b/bindings/pydrake/systems/test/rendering_test.py
@@ -13,8 +13,10 @@ import unittest
 import numpy as np
 
 from pydrake.common import FindResourceOrThrow
+from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 from pydrake.common.value import AbstractValue
 from pydrake.geometry import SceneGraph
+from pydrake.math import RigidTransform
 from pydrake.multibody.plant import MultibodyPlant
 from pydrake.multibody.math import (
     SpatialVelocity,
@@ -42,31 +44,48 @@ class TestRendering(unittest.TestCase):
         self.assertTrue(isinstance(value.Clone(), PoseVector))
         self.assertEqual(value.size(), PoseVector.kSize)
         # - Accessors.
-        self.assertTrue(isinstance(
-            value.get_isometry(), Isometry3))
+        with catch_drake_warnings(expected_count=1):
+            self.assertTrue(isinstance(value.get_isometry(), Isometry3))
+        self.assertTrue(isinstance(value.get_transform(), RigidTransform))
         self.assertTrue(isinstance(
             value.get_rotation(), Quaternion))
         self.assertTrue(isinstance(
             value.get_translation(), np.ndarray))
         # - Value.
+        with catch_drake_warnings(expected_count=1):
+            self.assertTrue(np.allclose(
+                value.get_isometry().matrix(), np.eye(4, 4)))
         self.assertTrue(np.allclose(
-            value.get_isometry().matrix(), np.eye(4, 4)))
+            value.get_transform().GetAsMatrix4(), np.eye(4, 4)))
         # - Mutators.
         p = [0, 1, 2]
         q = Quaternion(wxyz=normalized([0.1, 0.3, 0.7, 0.9]))
-        X_expected = Isometry3(q, p)
+        X_expected = RigidTransform(quaternion=q, p=p)
         value.set_translation(p)
         value.set_rotation(q)
+        with catch_drake_warnings(expected_count=1):
+            self.assertTrue(np.allclose(
+                value.get_isometry().matrix(), X_expected.GetAsMatrix4()))
         self.assertTrue(np.allclose(
-            value.get_isometry().matrix(), X_expected.matrix()))
+            value.get_transform().GetAsMatrix4(), X_expected.GetAsMatrix4()))
         # - Ensure ordering is ((px, py, pz), (qw, qx, qy, qz))
         vector_expected = np.hstack((p, q.wxyz()))
         vector_actual = value.get_value()
         self.assertTrue(np.allclose(vector_actual, vector_expected))
         # - Fully-parameterized constructor.
         value1 = PoseVector(rotation=q, translation=p)
+        with catch_drake_warnings(expected_count=1):
+            self.assertTrue(np.allclose(
+                value1.get_isometry().matrix(), X_expected.GetAsMatrix4()))
         self.assertTrue(np.allclose(
-            value1.get_isometry().matrix(), X_expected.matrix()))
+            value1.get_transform().GetAsMatrix4(), X_expected.GetAsMatrix4()))
+        # Test mutation via RigidTransform
+        p2 = [10, 20, 30]
+        q2 = Quaternion(wxyz=normalized([0.2, 0.3, 0.5, 0.8]))
+        X2_expected = RigidTransform(quaternion=q2, p=p2)
+        value.set_transform(X2_expected)
+        self.assertTrue(np.allclose(
+            value.get_transform().GetAsMatrix4(), X2_expected.GetAsMatrix4()))
 
     def test_frame_velocity(self):
         frame_velocity = FrameVelocity()
@@ -106,19 +125,26 @@ class TestRendering(unittest.TestCase):
         bundle = PoseBundle(num_poses)
         # - Accessors.
         self.assertEqual(bundle.get_num_poses(), num_poses)
-        self.assertTrue(isinstance(bundle.get_pose(0), Isometry3))
+        with catch_drake_warnings(expected_count=1):
+            self.assertTrue(isinstance(bundle.get_pose(0), Isometry3))
+        self.assertTrue(isinstance(bundle.get_transform(0), RigidTransform))
         self.assertTrue(isinstance(bundle.get_velocity(0), FrameVelocity))
         # - Mutators.
         kIndex = 5
         p = [0, 1, 2]
         q = Quaternion(wxyz=normalized([0.1, 0.3, 0.7, 0.9]))
-        bundle.set_pose(kIndex, Isometry3(q, p))
+        with catch_drake_warnings(expected_count=2):
+            bundle.set_pose(kIndex, Isometry3(q, p))
+            self.assertTrue((bundle.get_pose(kIndex).matrix()
+                             == Isometry3(q, p).matrix()).all())
+        pose = RigidTransform(quaternion=q, p=p)
+        bundle.set_transform(kIndex, pose)
+        self.assertTrue((bundle.get_transform(kIndex).GetAsMatrix34()
+                         == pose.GetAsMatrix34()).all())
         w = [0.1, 0.3, 0.5]
         v = [0., 1., 2.]
         frame_velocity = FrameVelocity(SpatialVelocity(w=w, v=v))
         bundle.set_velocity(kIndex, frame_velocity)
-        self.assertTrue((bundle.get_pose(kIndex).matrix()
-                         == Isometry3(q, p).matrix()).all())
         vel_actual = bundle.get_velocity(kIndex).get_velocity()
         self.assertTrue(np.allclose(vel_actual.rotational(), w))
         self.assertTrue(np.allclose(vel_actual.translational(), v))
@@ -169,7 +195,7 @@ class TestRendering(unittest.TestCase):
         p3 = [50, 70, 90]
         q3 = Quaternion(wxyz=normalized([0.1, 0.3, 0.7, 0.9]))
         bundle = PoseBundle(num_poses)
-        bundle.set_pose(0, Isometry3(q3, p3))
+        bundle.set_transform(0, RigidTransform(quaternion=q3, p=p3))
         bundle_value = AbstractValue.Make(bundle)
 
         aggregator.get_input_port(0).FixValue(context, pose1)
@@ -181,19 +207,18 @@ class TestRendering(unittest.TestCase):
 
         value = output.get_data(0).get_value()
         self.assertEqual(value.get_num_poses(), 3)
-        isom1_actual = Isometry3()
-        isom1_actual.set_translation(p1)
-        self.assertTrue(
-            (value.get_pose(0).matrix() == isom1_actual.matrix()).all())
-        isom2_actual = Isometry3()
-        isom2_actual.set_translation(p2)
-        self.assertTrue(
-            (value.get_pose(1).matrix() == isom2_actual.matrix()).all())
+        pose1_actual = RigidTransform(p=p1)
+        self.assertTrue((value.get_transform(0).GetAsMatrix34()
+                         == pose1_actual.GetAsMatrix34()).all())
+        pose2_actual = RigidTransform(p=p2)
+        self.assertTrue((value.get_transform(1).GetAsMatrix34()
+                         == pose2_actual.GetAsMatrix34()).all())
         vel_actual = value.get_velocity(1).get_velocity()
         self.assertTrue(np.allclose(vel_actual.rotational(), w))
         self.assertTrue(np.allclose(vel_actual.translational(), v))
-        self.assertTrue(
-            (value.get_pose(2).matrix() == Isometry3(q3, p3).matrix()).all())
+        pose3_actual = RigidTransform(quaternion=q3, p=p3)
+        self.assertTrue((value.get_transform(2).GetAsMatrix34()
+                         == pose3_actual.GetAsMatrix34()).all())
 
     def testMultibodyPositionToGeometryPose(self):
         file_name = FindResourceOrThrow(

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -393,9 +393,7 @@ void SceneGraph<T>::CalcPoseBundle(const Context<T>& context,
     const std::string& frame_name = g_state.GetName(f_id);
     output->set_name(i, source_name + "::" + frame_name);
     output->set_model_instance_id(i, g_state.GetFrameGroup(f_id));
-    // TODO(#11888): Remove GetAsIsometry3() when PoseBundle supports
-    //  RigidTransform.
-    output->set_pose(i, g_state.get_pose_in_world(f_id).GetAsIsometry3());
+    output->set_transform(i, g_state.get_pose_in_world(f_id));
     // TODO(SeanCurtis-TRI): Handle velocity.
   }
 }

--- a/systems/rendering/BUILD.bazel
+++ b/systems/rendering/BUILD.bazel
@@ -55,6 +55,7 @@ drake_cc_library(
     hdrs = ["pose_vector.h"],
     deps = [
         "//common:default_scalars",
+        "//math:geometric_transform",
         "//systems/framework:vector",
     ],
 )

--- a/systems/rendering/pose_aggregator.cc
+++ b/systems/rendering/pose_aggregator.cc
@@ -75,7 +75,7 @@ void PoseAggregator<T>::CalcPoseBundle(const Context<T>& context,
         const auto& value = port.template Eval<PoseVector<T>>(context);
         DRAKE_ASSERT(pose_index < bundle.get_num_poses());
         bundle.set_name(pose_index, record.name);
-        bundle.set_pose(pose_index, value.get_isometry());
+        bundle.set_transform(pose_index, value.get_transform());
         bundle.set_model_instance_id(pose_index, record.model_instance_id);
         pose_index++;
         continue;
@@ -108,7 +108,7 @@ void PoseAggregator<T>::CalcPoseBundle(const Context<T>& context,
         const std::string& bundle_name = record.name;
         for (int j = 0; j < num_poses; ++j) {
           DRAKE_ASSERT(pose_index < bundle.get_num_poses());
-          bundle.set_pose(pose_index, value.get_pose(j));
+          bundle.set_transform(pose_index, value.get_transform(j));
           bundle.set_velocity(pose_index, value.get_velocity(j));
           bundle.set_name(pose_index, bundle_name + "::" + value.get_name(j));
           bundle.set_model_instance_id(pose_index,

--- a/systems/rendering/pose_bundle.cc
+++ b/systems/rendering/pose_bundle.cc
@@ -9,6 +9,8 @@ namespace drake {
 namespace systems {
 namespace rendering {
 
+using math::RigidTransform;
+
 template <typename T>
 PoseBundle<T>::PoseBundle(int num_poses)
     : poses_(num_poses),
@@ -25,13 +27,23 @@ int PoseBundle<T>::get_num_poses() const {
 }
 
 template <typename T>
-const Isometry3<T>& PoseBundle<T>::get_pose(int index) const {
+const Isometry3<T> PoseBundle<T>::get_pose(int index) const {
+  return get_transform(index).GetAsIsometry3();
+}
+
+template <typename T>
+void PoseBundle<T>::set_pose(int index, const Isometry3<T>& pose) {
+  set_transform(index, RigidTransform<T>(pose));
+}
+
+template <typename T>
+const RigidTransform<T>& PoseBundle<T>::get_transform(int index) const {
   DRAKE_DEMAND(index >= 0 && index < get_num_poses());
   return poses_[index];
 }
 
 template <typename T>
-void PoseBundle<T>::set_pose(int index, const Isometry3<T>& pose) {
+void PoseBundle<T>::set_transform(int index, const RigidTransform<T>& pose) {
   DRAKE_DEMAND(index >= 0 && index < get_num_poses());
   poses_[index] = pose;
 }

--- a/systems/rendering/pose_bundle.h
+++ b/systems/rendering/pose_bundle.h
@@ -8,8 +8,10 @@
 
 #include "drake/common/autodiff.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/symbolic.h"
+#include "drake/math/rigid_transform.h"
 #include "drake/systems/rendering/frame_velocity.h"
 
 namespace drake {
@@ -38,7 +40,12 @@ class PoseBundle {
   ~PoseBundle();
 
   int get_num_poses() const;
-  const Isometry3<T>& get_pose(int index) const;
+  const math::RigidTransform<T>& get_transform(int index) const;
+  void set_transform(int index, const math::RigidTransform<T>& pose);
+
+  DRAKE_DEPRECATED("2020-09-01", "Please use get_transform()")
+  const Isometry3<T> get_pose(int index) const;
+  DRAKE_DEPRECATED("2020-09-01", "Please use set_transform()")
   void set_pose(int index, const Isometry3<T>& pose);
 
   const FrameVelocity<T>& get_velocity(int index) const;
@@ -51,7 +58,7 @@ class PoseBundle {
   void set_model_instance_id(int index, int id);
 
  private:
-  std::vector<Isometry3<T>> poses_;
+  std::vector<math::RigidTransform<T>> poses_;
   std::vector<FrameVelocity<T>> velocities_;
   std::vector<std::string> names_;
   std::vector<int> ids_;

--- a/systems/rendering/pose_bundle_to_draw_message.cc
+++ b/systems/rendering/pose_bundle_to_draw_message.cc
@@ -1,6 +1,8 @@
 #include "drake/systems/rendering/pose_bundle_to_draw_message.h"
 
 #include "drake/lcmt_viewer_draw.hpp"
+#include "drake/math/rigid_transform.h"
+#include "drake/math/rotation_matrix.h"
 #include "drake/systems/rendering/pose_bundle.h"
 
 namespace drake {
@@ -37,13 +39,14 @@ void PoseBundleToDrawMessage::CalcViewerDrawMessage(
 
     message.link_name[i] = poses.get_name(i);
 
-    Eigen::Translation<double, 3> t(poses.get_pose(i).translation());
+    Eigen::Translation<double, 3> t(poses.get_transform(i).translation());
     message.position[i].resize(3);
     message.position[i][0] = t.x();
     message.position[i][1] = t.y();
     message.position[i][2] = t.z();
 
-    Eigen::Quaternion<double> q(poses.get_pose(i).linear());
+    Eigen::Quaternion<double> q(
+        poses.get_transform(i).rotation().ToQuaternion());
     message.quaternion[i].resize(4);
     message.quaternion[i][0] = q.w();
     message.quaternion[i][1] = q.x();

--- a/systems/rendering/pose_vector.cc
+++ b/systems/rendering/pose_vector.cc
@@ -33,6 +33,19 @@ Isometry3<T> PoseVector<T>::get_isometry() const {
 }
 
 template <typename T>
+math::RigidTransform<T> PoseVector<T>::get_transform() const {
+  const auto& data = *this;
+  return math::RigidTransform<T>{get_rotation(),
+                                 Vector3<T>{data[0], data[1], data[2]}};
+}
+
+template <typename T>
+void PoseVector<T>::set_transform(const math::RigidTransform<T>& transform) {
+  this->set_translation(Eigen::Translation<T, 3>(transform.translation()));
+  this->set_rotation(transform.rotation().ToQuaternion());
+}
+
+template <typename T>
 Eigen::Translation<T, 3> PoseVector<T>::get_translation() const {
   return Eigen::Translation<T, 3>((*this)[0], (*this)[1], (*this)[2]);
 }

--- a/systems/rendering/pose_vector.h
+++ b/systems/rendering/pose_vector.h
@@ -2,6 +2,8 @@
 
 #include <Eigen/Dense>
 
+#include "drake/common/drake_deprecated.h"
+#include "drake/math/rigid_transform.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
@@ -29,8 +31,13 @@ class PoseVector : public BasicVector<T> {
              const Eigen::Translation<T, 3>& translation);
 
   /// Returns the transform X_WA.
+  DRAKE_DEPRECATED("2020-09-01", "Please use get_transform()")
   Isometry3<T> get_isometry() const;
-  // TODO(david-german-tri): Provide set_isometry, once #5274 is resolved.
+
+  /// Returns the transform X_WA.
+  math::RigidTransform<T> get_transform() const;
+  /// Assigns the transform X_WA.
+  void set_transform(const math::RigidTransform<T>& transform);
 
   /// Returns the translation p_WA.
   Eigen::Translation<T, 3> get_translation() const;

--- a/systems/rendering/render_pose_to_geometry_pose.cc
+++ b/systems/rendering/render_pose_to_geometry_pose.cc
@@ -29,7 +29,7 @@ RenderPoseToGeometryPose<T>::RenderPoseToGeometryPose(
       [this, frame_id](const Context<T>& context, AbstractValue* calculated) {
         const Input& input = get_input_port().template Eval<Input>(context);
         calculated->get_mutable_value<Output>() =
-            {{frame_id, RigidTransform<T>(input.get_isometry())}};
+            {{frame_id, input.get_transform()}};
       });
 }
 

--- a/systems/rendering/test/pose_bundle_to_draw_message_test.cc
+++ b/systems/rendering/test/pose_bundle_to_draw_message_test.cc
@@ -10,7 +10,9 @@ namespace systems {
 namespace rendering {
 namespace {
 
-GTEST_TEST(PoseBundleToDrawMessageTest, Conversion) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+GTEST_TEST(PoseBundleToDrawMessageTest, ConversionIsometry3) {
   PoseBundle<double> bundle(2);
   Eigen::Isometry3d foo_pose = Eigen::Isometry3d::Identity();
   foo_pose.translation()[0] = 123;
@@ -23,6 +25,56 @@ GTEST_TEST(PoseBundleToDrawMessageTest, Conversion) {
   bar_pose *= Eigen::AngleAxisd(roll, Eigen::Vector3d::UnitX());
   bundle.set_name(1, "bar");
   bundle.set_pose(1, bar_pose);
+  bundle.set_model_instance_id(1, 43);
+
+  PoseBundleToDrawMessage converter;
+  auto context = converter.AllocateContext();
+  converter.get_input_port(0).FixValue(context.get(), bundle);
+  auto output = converter.AllocateOutput();
+  converter.CalcOutput(*context, output.get());
+
+  const auto& message = output->get_data(0)->get_value<lcmt_viewer_draw>();
+  EXPECT_EQ(2, message.num_links);
+
+  EXPECT_EQ("foo", message.link_name[0]);
+  EXPECT_EQ(42, message.robot_num[0]);
+  // foo is translated in x.
+  EXPECT_EQ(123, message.position[0][0]);  // x
+  EXPECT_EQ(0, message.position[0][1]);    // y
+  EXPECT_EQ(0, message.position[0][2]);    // z
+  // foo has no rotation.
+  EXPECT_EQ(1, message.quaternion[0][0]);  // w
+  EXPECT_EQ(0, message.quaternion[0][1]);  // x
+  EXPECT_EQ(0, message.quaternion[0][2]);  // y
+  EXPECT_EQ(0, message.quaternion[0][3]);  // z
+
+  EXPECT_EQ("bar", message.link_name[1]);
+  EXPECT_EQ(43, message.robot_num[1]);
+  // bar has no translation.
+  EXPECT_EQ(0, message.position[1][0]);  // x
+  EXPECT_EQ(0, message.position[1][1]);  // y
+  EXPECT_EQ(0, message.position[1][2]);  // z
+  // bar has a rotation around x.
+  EXPECT_NEAR(std::cos(roll / 2), message.quaternion[1][0], 1.0e-6);  // w
+  EXPECT_NEAR(std::sin(roll / 2), message.quaternion[1][1], 1.0e-6);  // x
+  EXPECT_EQ(0, message.quaternion[0][2]);  // y
+  EXPECT_EQ(0, message.quaternion[0][3]);  // z
+}
+#pragma GCC diagnostic pop
+
+GTEST_TEST(PoseBundleToDrawMessageTest, Conversion) {
+  PoseBundle<double> bundle(2);
+  math::RigidTransformd foo_pose{Eigen::Vector3d{123, 0, 0}};
+  bundle.set_name(0, "foo");
+  bundle.set_transform(0, foo_pose);
+  bundle.set_model_instance_id(0, 42);
+
+  const double roll = -M_PI_2;
+  math::RigidTransformd bar_pose{
+      Eigen::AngleAxisd(roll, Eigen::Vector3d::UnitX()),
+      Eigen::Vector3d{0, 0, 0}};
+  bundle.set_name(1, "bar");
+  bundle.set_transform(1, bar_pose);
   bundle.set_model_instance_id(1, 43);
 
   PoseBundleToDrawMessage converter;

--- a/systems/rendering/test/render_pose_to_geometry_pose_test.cc
+++ b/systems/rendering/test/render_pose_to_geometry_pose_test.cc
@@ -30,7 +30,7 @@ GTEST_TEST(RenderPoseToGeometryPoseTest, InputOutput) {
   ASSERT_TRUE(output.has_id(frame_id));
   EXPECT_TRUE(CompareMatrices(
       output.value(frame_id).matrix(),
-      input.get_isometry().matrix()));
+      input.get_transform().matrix()));
 
   EXPECT_TRUE(dut.HasAnyDirectFeedthrough());
 }


### PR DESCRIPTION
 - PoseBundle::{set|get)_pose deprecated; replaced with (set_)transform()
   - get_pose() no longer returns a reference to an Isometry3.
 - PoseVector::get_isometry deprecated; replaced with transform()
   - Also added set_transform() based on old TODO.
 - Multiple downstream consumers (and their tests) updated to use new API.
 - Bindings updated (with deprecations) and test
   - pose_bundle_to_draw_message_test

Resolves #11888

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13327)
<!-- Reviewable:end -->
