### PR TITLE
[dev] Add HalfSpace and Box generation to shape_meshes.*

### DIFF
--- a/geometry/render/gl_renderer/dev/BUILD.bazel
+++ b/geometry/render/gl_renderer/dev/BUILD.bazel
@@ -88,6 +88,7 @@ drake_cc_googletest_gl_ubuntu_only(
     deps = [
         ":shape_meshes",
         "//common:find_resource",
+        "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
     ],
 )

--- a/geometry/render/gl_renderer/dev/render_engine_gl.cc
+++ b/geometry/render/gl_renderer/dev/render_engine_gl.cc
@@ -405,23 +405,11 @@ OpenGlGeometry RenderEngineGl::GetCylinder() {
 
 OpenGlGeometry RenderEngineGl::GetHalfSpace() {
   if (!half_space_.is_defined()) {
-    //                 _  y
-    //                  /|
-    //                 /
-    //     3_________________________ 2
-    //     /         ^ z            /
-    //    /          |_            /  --> x
-    //   /           Go           /
-    //  /                        /
-    // /________________________/
-    // 0                         1
-    const GLfloat kHalfSize = 100.f;
-    VertexBuffer vertices{4, 3};
-    vertices << -kHalfSize, -kHalfSize, 0.f, kHalfSize, -kHalfSize, 0.f,
-        kHalfSize, kHalfSize, 0.f, -kHalfSize, kHalfSize, 0.f;
-
-    IndexBuffer indices{2, 3};
-    indices << 0, 1, 2, 0, 2, 3;
+    const GLfloat kMeasure = 200.f;
+    // TODO(SeanCurtis-TRI): For vertex-lighting (as opposed to fragment
+    //  lighting), this will render better with tighter resolution. Consider
+    //  making this configurable.
+    auto [vertices, indices] = MakeSquarePatch(kMeasure, 1);
     half_space_ = SetupVAO(vertices, indices);
   }
 
@@ -433,22 +421,7 @@ OpenGlGeometry RenderEngineGl::GetHalfSpace() {
 
 OpenGlGeometry RenderEngineGl::GetBox() {
   if (!box_.is_defined()) {
-    //     7      6
-    //     _____
-    //    /|    /|
-    //  2/_|__3/ |
-    //  |  |   | |
-    //  | 4|___|_| 5
-    //  | /    | /
-    //  |/_____|/
-    //  0      1
-    VertexBuffer vertices{8, 3};
-    vertices << -0.5f, -0.5f, -0.5f, 0.5f, -0.5f, -0.5f, 0.5f, 0.5f, -0.5f,
-        -0.5f, 0.5f, -0.5f, -0.5f, -0.5f, 0.5f, 0.5f, -0.5f, 0.5f, 0.5f, 0.5f,
-        0.5f, -0.5f, 0.5f, 0.5f;
-    IndexBuffer indices{12, 3};
-    indices << 0, 1, 2, 0, 2, 3, 1, 5, 6, 1, 6, 2, 2, 6, 7, 2, 7, 3, 3, 7, 4, 3,
-        4, 0, 7, 6, 5, 7, 5, 4, 1, 0, 4, 1, 4, 5;
+    auto [vertices, indices] = MakeUnitBox();
     box_ = SetupVAO(vertices, indices);
   }
 

--- a/geometry/render/gl_renderer/dev/shape_meshes.h
+++ b/geometry/render/gl_renderer/dev/shape_meshes.h
@@ -66,8 +66,6 @@ std::pair<VertexBuffer, IndexBuffer> LoadMeshFromObj(
 std::pair<VertexBuffer, IndexBuffer> MakeLongLatUnitSphere(
     int longitude_bands = 50, int latitude_bands = 50);
 
-// TODO(SeanCurtis): Box, Half space, capsule, ellipsoid.
-
 /* Creates an OpenGL-compatible mesh representation of a unit cylinder; its
  radius and height are equal to 1. It is centered on the origin of its canonical
  frame C and aligned with Frame C's z axis: Cz.
@@ -85,6 +83,31 @@ std::pair<VertexBuffer, IndexBuffer> MakeLongLatUnitSphere(
  @pre `num_bands` >= 1.  */
 std::pair<VertexBuffer, IndexBuffer> MakeUnitCylinder(int num_strips = 50,
                                                       int num_bands = 1);
+
+/* Creates an OpenGL-compaptible mesh reprepsenting a square patch. The patch
+ has edge length `measure` units long. The square patch is defined lying on the
+ z = 0 plane in its canonical frame C, centered on the origin Co. The faces are
+ wound such that the right-handed face normal points in the dirction of the
+ positive z-axis of Frame C.
+
+ The domain of the patch is divided into square sub regions based on the given
+ `resolution`. There will be `resolution^2` square patches (each defined by
+ two triangles).
+ @pre `measure` > 0
+ @pre `resolution >= 1`. */
+std::pair<VertexBuffer, IndexBuffer> MakeSquarePatch(GLfloat measure = 200,
+                                                     int resolution = 1);
+
+/* Creates an OpenGL_compatible mesh representation of the unit box - all edges
+ are length 1. The box is centered on the origin of its canonical frame C with
+ its edges aligned to the frame's basis. Each face of the box is divided into a
+ single pair of triangles.
+
+<!-- TODO(SeanCurtis-TRI): consider offering subdivisions if per-vertex
+    properties yield undesirable artifacts for large boxes.  --> */
+std::pair<VertexBuffer, IndexBuffer> MakeUnitBox();
+
+// TODO(SeanCurtis): capsule, ellipsoid.
 
 }  // namespace internal
 }  // namespace render


### PR DESCRIPTION
 - Adds two utility functions for generating meshes for a square patch and a unit box.
 - Modify RenderEngineGl to make use of the shapes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13334)
<!-- Reviewable:end -->
