### PR TITLE
primitives: Disable DiscreteDerivative transient by default

### DIFF
--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -151,10 +151,14 @@ PYBIND11_MODULE(primitives, m) {
 
     DefineTemplateClassWithDefault<DiscreteDerivative<T>, LeafSystem<T>>(
         m, "DiscreteDerivative", GetPyParam<T>(), doc.DiscreteDerivative.doc)
-        .def(py::init<int, double>(), py::arg("num_inputs"),
-            py::arg("time_step"), doc.DiscreteDerivative.ctor.doc)
+        .def(py::init<int, double, bool>(), py::arg("num_inputs"),
+            py::arg("time_step"), py::arg("suppress_initial_transient") = false,
+            doc.DiscreteDerivative.ctor.doc)
         .def("time_step", &DiscreteDerivative<T>::time_step,
-            doc.DiscreteDerivative.time_step.doc);
+            doc.DiscreteDerivative.time_step.doc)
+        .def("suppress_initial_transient",
+            &DiscreteDerivative<T>::suppress_initial_transient,
+            doc.DiscreteDerivative.suppress_initial_transient.doc);
 
     DefineTemplateClassWithDefault<                  // BR
         FirstOrderLowPassFilter<T>, LeafSystem<T>>(  //
@@ -250,9 +254,14 @@ PYBIND11_MODULE(primitives, m) {
     DefineTemplateClassWithDefault<StateInterpolatorWithDiscreteDerivative<T>,
         Diagram<T>>(m, "StateInterpolatorWithDiscreteDerivative",
         GetPyParam<T>(), doc.StateInterpolatorWithDiscreteDerivative.doc)
-        .def(py::init<int, double>(), py::arg("num_positions"),
-            py::arg("time_step"),
+        .def(py::init<int, double, bool>(), py::arg("num_positions"),
+            py::arg("time_step"), py::arg("suppress_initial_transient") = false,
             doc.StateInterpolatorWithDiscreteDerivative.ctor.doc)
+        .def("suppress_initial_transient",
+            &StateInterpolatorWithDiscreteDerivative<
+                T>::suppress_initial_transient,
+            doc.StateInterpolatorWithDiscreteDerivative
+                .suppress_initial_transient.doc)
         .def(
             "set_initial_position",
             [](const StateInterpolatorWithDiscreteDerivative<T>* self,
@@ -262,7 +271,7 @@ PYBIND11_MODULE(primitives, m) {
             },
             py::arg("context"), py::arg("position"),
             doc.StateInterpolatorWithDiscreteDerivative.set_initial_position
-                .doc)
+                .doc_2args_context_position)
         .def(
             "set_initial_position",
             [](const StateInterpolatorWithDiscreteDerivative<T>* self,
@@ -271,7 +280,7 @@ PYBIND11_MODULE(primitives, m) {
             },
             py::arg("state"), py::arg("position"),
             doc.StateInterpolatorWithDiscreteDerivative.set_initial_position
-                .doc);
+                .doc_2args_state_position);
 
     DefineTemplateClassWithDefault<SymbolicVectorSystem<T>, LeafSystem<T>>(m,
         "SymbolicVectorSystem", GetPyParam<T>(), doc.SymbolicVectorSystem.doc)

--- a/bindings/pydrake/systems/test/primitives_test.py
+++ b/bindings/pydrake/systems/test/primitives_test.py
@@ -526,25 +526,41 @@ class TestGeneral(unittest.TestCase):
         self.assertEqual(discrete_derivative.get_input_port(0).size(), 5)
         self.assertEqual(discrete_derivative.get_output_port(0).size(), 5)
         self.assertEqual(discrete_derivative.time_step(), 0.5)
+        self.assertFalse(discrete_derivative.suppress_initial_transient())
+
+        discrete_derivative = DiscreteDerivative(
+            num_inputs=5, time_step=0.5, suppress_initial_transient=True)
+        self.assertTrue(discrete_derivative.suppress_initial_transient())
 
     def test_state_interpolator_with_discrete_derivative(self):
         state_interpolator = StateInterpolatorWithDiscreteDerivative(
             num_positions=5, time_step=0.4)
         self.assertEqual(state_interpolator.get_input_port(0).size(), 5)
         self.assertEqual(state_interpolator.get_output_port(0).size(), 10)
+        self.assertFalse(state_interpolator.suppress_initial_transient())
 
         # test set_initial_position using context
         context = state_interpolator.CreateDefaultContext()
         state_interpolator.set_initial_position(
             context=context, position=5*[1.1])
         np.testing.assert_array_equal(
-            context.get_discrete_state_vector().CopyToVector(),
-            np.array(10*[1.1]))
+            context.get_discrete_state(0).CopyToVector(),
+            np.array(5*[1.1]))
+        np.testing.assert_array_equal(
+            context.get_discrete_state(1).CopyToVector(),
+            np.array(5*[1.1]))
 
         # test set_initial_position using state
         context = state_interpolator.CreateDefaultContext()
         state_interpolator.set_initial_position(
             state=context.get_state(), position=5*[1.3])
         np.testing.assert_array_equal(
-            context.get_discrete_state_vector().CopyToVector(),
-            np.array(10*[1.3]))
+            context.get_discrete_state(0).CopyToVector(),
+            np.array(5*[1.3]))
+        np.testing.assert_array_equal(
+            context.get_discrete_state(1).CopyToVector(),
+            np.array(5*[1.3]))
+
+        state_interpolator = StateInterpolatorWithDiscreteDerivative(
+            num_positions=5, time_step=0.4, suppress_initial_transient=True)
+        self.assertTrue(state_interpolator.suppress_initial_transient())

--- a/examples/manipulation_station/test/manipulation_station_test.cc
+++ b/examples/manipulation_station/test/manipulation_station_test.cc
@@ -127,9 +127,6 @@ GTEST_TEST(ManipulationStationTest, CheckDynamics) {
 
   auto context = station.CreateDefaultContext();
 
-  // Expect state from the velocity interpolators in the iiwa and the wsg and
-  // from the multibody state of the plant.
-  EXPECT_EQ(context->num_discrete_state_groups(), 3);
   // Expect continuous state from the integral term in the PID from the
   // inverse dynamics controller.
   EXPECT_EQ(context->num_continuous_states(), 7);

--- a/systems/primitives/discrete_derivative.cc
+++ b/systems/primitives/discrete_derivative.cc
@@ -14,10 +14,12 @@ namespace systems {
 using Eigen::MatrixXd;
 
 template <typename T>
-DiscreteDerivative<T>::DiscreteDerivative(int num_inputs, double time_step)
+DiscreteDerivative<T>::DiscreteDerivative(int num_inputs, double time_step,
+                                          bool suppress_initial_transient)
     : LeafSystem<T>(SystemTypeTag<DiscreteDerivative>{}),
       n_(num_inputs),
-      time_step_(time_step) {
+      time_step_(time_step),
+      suppress_initial_transient_(suppress_initial_transient) {
   DRAKE_DEMAND(n_ > 0);
   DRAKE_DEMAND(time_step_ > 0.0);
 
@@ -25,10 +27,19 @@ DiscreteDerivative<T>::DiscreteDerivative(int num_inputs, double time_step)
   this->DeclareVectorOutputPort("dudt", systems::BasicVector<T>(n_),
                                 &DiscreteDerivative<T>::CalcOutput,
                                 {this->xd_ticket()});
-
-  // TODO(sherm): Prefer two state vectors of size n_ upon resolution of #9705.
-  this->DeclareDiscreteState(2 * n_);
+  this->DeclareDiscreteState(n_);  // u[n]
+  this->DeclareDiscreteState(n_);  // u[n-1]
+  if (suppress_initial_transient) {
+    // An update counter, matching the value of "n" iff the simulation begins
+    // at time == 0.0.
+    this->DeclareDiscreteState(1);
+  }
   this->DeclarePeriodicDiscreteUpdate(time_step_);
+}
+
+template <typename T>
+bool DiscreteDerivative<T>::suppress_initial_transient() const {
+  return suppress_initial_transient_;
 }
 
 template <typename T>
@@ -39,45 +50,73 @@ void DiscreteDerivative<T>::set_input_history(
   DRAKE_DEMAND(u_n.size() == n_);
   DRAKE_DEMAND(u_n_minus_1.size() == n_);
 
-  state->get_mutable_discrete_state().get_mutable_vector().get_mutable_value()
-      << u_n,
-      u_n_minus_1;
+  state->get_mutable_discrete_state(0).SetFromVector(u_n);
+  state->get_mutable_discrete_state(1).SetFromVector(u_n_minus_1);
+  if (suppress_initial_transient_) {
+    // Disable the transient suppression.
+    state->get_mutable_discrete_state(2)[0] = 2.0;
+  }
 }
 
 template <typename T>
 void DiscreteDerivative<T>::DoCalcDiscreteVariableUpdates(
     const drake::systems::Context<T>& context,
     const std::vector<const drake::systems::DiscreteUpdateEvent<T>*>&,
-    drake::systems::DiscreteValues<T>* discrete_state) const {
+    drake::systems::DiscreteValues<T>* state) const {
   // x₀[n+1] = u[n].
-  discrete_state->get_mutable_vector().get_mutable_value().head(n_) =
-      get_input_port().Eval(context);
+  state->get_mutable_vector(0).SetFromVector(get_input_port().Eval(context));
 
   // x₁[n+1] = x₀[n].
-  discrete_state->get_mutable_vector().get_mutable_value().tail(n_) =
-      context.get_discrete_state(0).get_value().head(n_);
+  state->get_mutable_vector(1).SetFrom(context.get_discrete_state(0));
+
+  // x₂[n+i] = x₂[n] + 1
+  if (suppress_initial_transient_) {
+    state->get_mutable_vector(2)[0] = context.get_discrete_state(2)[0] + 1.0;
+  }
 }
+
+namespace {
+template <typename T>
+VectorX<T> if_then_else_vector(
+  const boolean<T>& f_cond,
+  const Eigen::Ref<const VectorX<T>>& v_then,
+  const Eigen::Ref<const VectorX<T>>& v_else) {
+  DRAKE_DEMAND(v_then.size() == v_else.size());
+  VectorX<T> result(v_then.size());
+  for (int i = 0; i < result.size(); ++i) {
+    result[i] = if_then_else(f_cond, v_then[i], v_else[i]);
+  }
+  return result;
+}
+}  // namespace
 
 template <typename T>
 void DiscreteDerivative<T>::CalcOutput(
     const drake::systems::Context<T>& context,
     drake::systems::BasicVector<T>* output_vector) const {
-  const auto x0 = context.get_discrete_state(0).get_value().head(n_);
-  const auto x1 = context.get_discrete_state(0).get_value().tail(n_);
+  const auto& x0 = context.get_discrete_state(0).get_value();
+  const auto& x1 = context.get_discrete_state(1).get_value();
 
-  // y(t) = (x₀[n]-x₁[n])/h.
-  output_vector->SetFromVector((x0 - x1) / time_step_);
+  // y(t) = (x₀[n]-x₁[n])/h
+  const auto& derivative = ((x0 - x1) / time_step_).eval();
+  if (!suppress_initial_transient_) {
+    output_vector->SetFromVector(derivative);
+  } else {
+    const boolean<T> is_active = (context.get_discrete_state(2)[0] >= 2.0);
+    output_vector->SetFromVector(if_then_else_vector<T>(
+        is_active, derivative, VectorX<T>::Zero(n_)));
+  }
 }
 
 template <typename T>
 StateInterpolatorWithDiscreteDerivative<
-    T>::StateInterpolatorWithDiscreteDerivative(int num_positions,
-                                                double time_step) {
+    T>::StateInterpolatorWithDiscreteDerivative(
+    int num_positions, double time_step, bool suppress_initial_transient) {
   DiagramBuilder<T> builder;
 
   auto pass_through = builder.template AddSystem<PassThrough>(num_positions);
-  derivative_ =
-      builder.template AddSystem<DiscreteDerivative>(num_positions, time_step);
+  derivative_ = builder.template AddSystem<DiscreteDerivative>(
+      num_positions, time_step, suppress_initial_transient);
   auto mux = builder.template AddSystem<Multiplexer>(
       std::vector<int>{num_positions, num_positions});
 
@@ -89,6 +128,12 @@ StateInterpolatorWithDiscreteDerivative<
   builder.ExportOutput(mux->get_output_port(0), "state");
 
   builder.BuildInto(this);
+}
+
+template <typename T>
+bool StateInterpolatorWithDiscreteDerivative<
+      T>::suppress_initial_transient() const {
+  return derivative_->suppress_initial_transient();
 }
 
 template <typename T>


### PR DESCRIPTION
All current uses (but one) in Drake and Anzu for `DiscreteDerivative` and `StateInterpolatorWithDiscreteDerivative` go to great lengths to remove the first step's transient  velocity estimate, often completely breaking the System-Context abstraction by routing q0 through obscure callbacks.  (And the one place that doesn't do so is a bug, too.)

If we want state estimation to use zero velocity until it has two measurements, then we should just implement that process directly.

~This is a **backwards-incompatible** change to semantics `DiscreteDerivative`.  Users can opt-in to the old behavior by calling `set_input_history` or `set_initial_state` with all zeros.  In that case, the old behavior and new behavior are identical.~  _(Edit: No longer true as of the latest push.)_

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13336)
<!-- Reviewable:end -->
