### PR TITLE
Fix location of VTK on Focal in drake-visualizer launcher

### DIFF
--- a/tools/workspace/drake_visualizer/drake_visualizer_bazel.py
+++ b/tools/workspace/drake_visualizer/drake_visualizer_bazel.py
@@ -70,7 +70,9 @@ def main():
         # PYTHONPATH for @vtk.
         set_path("LD_LIBRARY_PATH", "external/lcm")
         prepend_path("LD_LIBRARY_PATH", "external/vtk/lib")
-        prepend_path("PYTHONPATH", "external/vtk/lib/python3.6/site-packages")
+        prepend_path(
+            "PYTHONPATH", "external/vtk/lib/python{}.{}/site-packages".format(
+                *sys.version_info[:2]))
     elif sys.platform == "darwin":
         # Ensure that we handle DYLD_LIBRARY_PATH for @lcm.
         set_path("DYLD_LIBRARY_PATH", "external/lcm")


### PR DESCRIPTION
Relates #13102. I think it is reasonable for us to assume that Bionic and Focal are running under 3.6 and 3.8 for these purposes (drake-visualizer would be broken anyway, if not).

When I build VTK 9 (#13253) and start packaging Drake (#12783), I hope to switch us to an unversioned python3 directory (`lib/python3.8/site-packages -> lib/python3/{dist|site}-packages`) with correctly versioned suffixes (e.g., `$(python3-config --extension-suffix) == .cpython-38-x86_64-linux-gnu.so`) for the shared libraries in avoid having to worry so much about issues like this.

(BTW this change is covered by CI.)

<!-- Reviewable:start -->
----
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13339)
<!-- Reviewable:end -->
