### PR TITLE
manipulation: Use input (not parameter) for no-op IIWA command

### DIFF
--- a/examples/kuka_iiwa_arm/kuka_simulation.cc
+++ b/examples/kuka_iiwa_arm/kuka_simulation.cc
@@ -115,7 +115,8 @@ int DoMain() {
   plant_state_demux->set_name("plant_state_demux");
   auto desired_state_from_position = builder.AddSystem<
       StateInterpolatorWithDiscreteDerivative>(
-          num_joints, kIiwaLcmStatusPeriod);
+          num_joints, kIiwaLcmStatusPeriod,
+          true /* suppress_initial_transient */);
   desired_state_from_position->set_name("desired_state_from_position");
   auto status_pub = builder.AddSystem(
       systems::lcm::LcmPublisherSystem::Make<lcmt_iiwa_status>(
@@ -125,7 +126,9 @@ int DoMain() {
   status_sender->set_name("status_sender");
 
   builder.Connect(command_sub->get_output_port(),
-                  command_receiver->get_input_port());
+                  command_receiver->get_message_input_port());
+  builder.Connect(plant_state_demux->get_output_port(0),
+                  command_receiver->get_position_measured_input_port());
   builder.Connect(command_receiver->get_commanded_position_output_port(),
                   desired_state_from_position->get_input_port());
   builder.Connect(desired_state_from_position->get_output_port(),
@@ -169,11 +172,6 @@ int DoMain() {
   simulator.set_publish_every_time_step(false);
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
   simulator.Initialize();
-
-  command_receiver->set_initial_position(
-      &sys->GetMutableSubsystemContext(*command_receiver,
-                                       &simulator.get_mutable_context()),
-      VectorX<double>::Zero(plant.num_positions()));
 
   // Simulate for a very long time.
   simulator.AdvanceTo(FLAGS_simulation_sec);

--- a/examples/manipulation_station/end_effector_teleop_mouse.py
+++ b/examples/manipulation_station/end_effector_teleop_mouse.py
@@ -352,7 +352,14 @@ def main():
     station.GetInputPort("iiwa_feedforward_torque").FixValue(
         station_context, np.zeros(7))
 
-    simulator.AdvanceTo(1e-6)
+    # If the diagram is only the hardware interface, then we must advance it a
+    # little bit so that first LCM messages get processed. A simulated plant is
+    # already publishing correct positions even without advancing, and indeed
+    # we must not advance a simulated plant until the sliders and filters have
+    # been initialized to match the plant.
+    if args.hardware:
+        simulator.AdvanceTo(1e-6)
+
     q0 = station.GetOutputPort("iiwa_position_measured").Eval(station_context)
     differential_ik.parameters.set_nominal_joint_position(q0)
 

--- a/manipulation/kuka_iiwa/iiwa_command_receiver.cc
+++ b/manipulation/kuka_iiwa/iiwa_command_receiver.cc
@@ -29,10 +29,8 @@ IiwaCommandReceiver::IiwaCommandReceiver(int num_joints)
       DeclareNumericParameter(default_position)};
   DRAKE_DEMAND(param == 0);  // We're depending on that elsewhere.
 
-  // Our input ports are mutually exclusive; exactly one connected input port
-  // feeds our cache entry. The computation may be dependent on the above
-  // parameter as well.
   DeclareAbstractInputPort("lcmt_iiwa_command", *MakeCommandMessage());
+  DeclareInputPort("position_measured", systems::kVectorValued, num_joints_);
   groomed_input_ = &DeclareCacheEntry(
       "groomed_input", &IiwaCommandReceiver::CalcInput,
       {all_input_ports_ticket(), numeric_parameter_ticket(param)});
@@ -49,8 +47,12 @@ IiwaCommandReceiver::IiwaCommandReceiver(int num_joints)
       });
 }
 
-const systems::InputPort<double>& IiwaCommandReceiver::get_input_port() const {
+using InPort = systems::InputPort<double>;
+const InPort& IiwaCommandReceiver::get_message_input_port() const {
   return LeafSystem<double>::get_input_port(0);
+}
+const InPort& IiwaCommandReceiver::get_position_measured_input_port() const {
+  return LeafSystem<double>::get_input_port(1);
 }
 using OutPort = systems::OutputPort<double>;
 const OutPort& IiwaCommandReceiver::get_commanded_position_output_port() const {
@@ -67,26 +69,28 @@ void IiwaCommandReceiver::set_initial_position(
 }
 
 // Returns (in "result") the command message input, or if a message has not
-// been received yet returns the initial command (as optionally set by the
-// user).  The result will always have have num_joints_ positions and torques.
+// been received yet returns the a fallback value.  The result always has
+// num_joints_ positions and torques.
 void IiwaCommandReceiver::CalcInput(
   const Context<double>& context, lcmt_iiwa_command* result) const {
-  if (!get_input_port().HasValue(context)) {
+  if (!get_message_input_port().HasValue(context)) {
     throw std::logic_error("IiwaCommandReceiver has no input connected");
   }
 
-  // Copies the (sole) input value, converting from IiwaCommand if necessary.
-  *result = get_input_port().Eval<lcmt_iiwa_command>(context);
+  // Copies the input value into our tentative result.
+  *result = get_message_input_port().Eval<lcmt_iiwa_command>(context);
 
-  // If we haven't received a non-default message yet, use the initial command.
-  // N.B. This works due to lcm::Serializer<>::CreateDefaultValue() using
-  // value-initialization.
+  // If we haven't received a non-default message yet, use nominal values
+  // instead.  N.B. This works due to lcm::Serializer<>::CreateDefaultValue()
+  // using value-initialization.
   if (lcm::AreLcmMessagesEqual(*result, lcmt_iiwa_command{})) {
-    const VectorXd param = context.get_numeric_parameter(0).get_value();
-    result->num_joints = param.size();
-    result->joint_position = {param.data(), param.data() + param.size()};
-    result->num_torques = 0;
-    result->joint_torque.clear();
+    const VectorXd positions =
+        get_position_measured_input_port().HasValue(context) ?
+            get_position_measured_input_port().Eval(context) :
+            context.get_numeric_parameter(0).get_value();
+    result->num_joints = positions.size();
+    result->joint_position =
+        {positions.data(), positions.data() + positions.size()};
   }
 
   // Sanity check the joint sizes.  If torques were not sent, pad with zeros.

--- a/manipulation/kuka_iiwa/iiwa_command_receiver.h
+++ b/manipulation/kuka_iiwa/iiwa_command_receiver.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/lcmt_iiwa_command.hpp"
 #include "drake/manipulation/kuka_iiwa/iiwa_constants.h"
@@ -21,13 +22,19 @@ namespace kuka_iiwa {
 /// receive the message, the input of this system should be connected to a
 /// LcmSubscriberSystem::Make<drake::lcmt_iiwa_command>().
 ///
-/// It has one input port, "lcmt_iiwa_command".
+/// It has one required input port, "lcmt_iiwa_command".
+///
+/// It offers an optional "position_measured" input, which (when connected)
+/// will be used to set the output position when no command messages have been
+/// received yet.  When this port is not connected, the default position will
+/// be all zeros.
 ///
 /// It has two output ports: one for the commanded position for each joint, and
 /// one for commanded additional feedforward joint torque.
 ///
 /// @system { IiwaCommandReceiver,
 ///   @input_port{lcmt_iiwa_command}
+///   @input_port{position_measured}
 ///   @output_port{position}
 ///   @output_port{torque}
 /// }
@@ -41,15 +48,24 @@ class IiwaCommandReceiver : public systems::LeafSystem<double> {
   /// command messages being received.  If this function is not called, the
   /// starting position will be the zero configuration.  The initial commanded
   /// torque is always zero and cannot be set.
+  DRAKE_DEPRECATED("2020-09-01",
+      "To provide position commands prior to receiving the first message, "
+      "connect the position_measured instead of setting this parameter")
   void set_initial_position(systems::Context<double>* context,
                             const Eigen::Ref<const Eigen::VectorXd>& q) const;
 
   /// @name Named accessors for this System's input and output ports.
   //@{
-  const systems::InputPort<double>& get_input_port() const;
+  const systems::InputPort<double>& get_message_input_port() const;
+  const systems::InputPort<double>& get_position_measured_input_port() const;
   const systems::OutputPort<double>& get_commanded_position_output_port() const;
   const systems::OutputPort<double>& get_commanded_torque_output_port() const;
   //@}
+
+  DRAKE_DEPRECATED("2020-09-01", "Use get_message_input_port() instead.")
+  const systems::InputPort<double>& get_input_port() const {
+    return get_message_input_port();
+  }
 
  private:
   using MapVectorXd = Eigen::Map<const Eigen::VectorXd>;

--- a/manipulation/kuka_iiwa/test/iiwa_command_receiver_test.cc
+++ b/manipulation/kuka_iiwa/test/iiwa_command_receiver_test.cc
@@ -23,7 +23,8 @@ class IiwaCommandReceiverTest : public testing::Test {
 
   // For use only by our constructor.
   systems::FixedInputPortValue& FixInput() {
-    return dut_.get_input_port().FixValue(&context_, lcmt_iiwa_command{});
+    return dut_.get_message_input_port().FixValue(
+        &context_, lcmt_iiwa_command{});
   }
 
   // Test cases should call this to set the DUT's input value.
@@ -51,6 +52,42 @@ class IiwaCommandReceiverTest : public testing::Test {
 };
 
 TEST_F(IiwaCommandReceiverTest, AcceptanceTest) {
+  // When no message has been received and *no* position measurement is
+  // connected, the command is all zeros.
+  const VectorXd zero = VectorXd::Zero(N);
+  EXPECT_TRUE(CompareMatrices(position(), zero));
+  EXPECT_TRUE(CompareMatrices(torque(), zero));
+
+  // When no message has been received and a measurement *is* connected, the
+  // command is to hold at the current position.
+  const VectorXd q0 = VectorXd::LinSpaced(N, 0.2, 0.3);
+  dut_.get_position_measured_input_port().FixValue(&context_, q0);
+  EXPECT_TRUE(CompareMatrices(position(), q0));
+  EXPECT_TRUE(CompareMatrices(torque(), zero));
+
+  // Check that a real command trumps the initial position.
+  // First, try with empty torques.
+  const VectorXd q1 = VectorXd::LinSpaced(N, 0.3, 0.4);
+  lcmt_iiwa_command command{};
+  command.utime = 0;
+  command.num_joints = N;
+  command.joint_position = {q1.data(), q1.data() + q1.size()};
+  SetInput(command);
+  EXPECT_TRUE(CompareMatrices(position(), q1));
+  EXPECT_TRUE(CompareMatrices(torque(), zero));
+
+  // Now provide torques.
+  const VectorXd t1 = VectorXd::LinSpaced(N, 0.5, 0.6);
+  command.num_torques = N;
+  command.joint_torque = {t1.data(), t1.data() + t1.size()};
+  SetInput(command);
+  EXPECT_TRUE(CompareMatrices(position(), q1));
+  EXPECT_TRUE(CompareMatrices(torque(), t1));
+}
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+TEST_F(IiwaCommandReceiverTest, DeprecatedAcceptanceTest) {
   // Check that the commanded pose starts out at zero
   const VectorXd zero = VectorXd::Zero(N);
   EXPECT_TRUE(CompareMatrices(position(), zero));
@@ -81,6 +118,7 @@ TEST_F(IiwaCommandReceiverTest, AcceptanceTest) {
   EXPECT_TRUE(CompareMatrices(position(), q1));
   EXPECT_TRUE(CompareMatrices(torque(), t1));
 }
+#pragma GCC diagnostic pop
 
 }  // namespace
 }  // namespace kuka_iiwa

--- a/manipulation/schunk_wsg/schunk_wsg_position_controller.cc
+++ b/manipulation/schunk_wsg/schunk_wsg_position_controller.cc
@@ -98,7 +98,7 @@ SchunkWsgPositionController::SchunkWsgPositionController(double time_step,
       kp_command, kd_command, kp_constraint, kd_constraint);
   state_interpolator_ =
       builder.AddSystem<systems::StateInterpolatorWithDiscreteDerivative>(
-          1, time_step);
+          1, time_step, true /* suppress_initial_transient */);
 
   builder.Connect(state_interpolator_->get_output_port(),
                   pd_controller->get_desired_state_input_port());

--- a/manipulation/schunk_wsg/schunk_wsg_position_controller.h
+++ b/manipulation/schunk_wsg/schunk_wsg_position_controller.h
@@ -137,14 +137,21 @@ class SchunkWsgPositionController : public systems::Diagram<double> {
 
   // The controller stores the last commanded desired position as state.
   // This is a helper method to reset that state.
+  DRAKE_DEPRECATED("2020-09-01",
+      "There's no need anymore to zero the velocity estimate via this method.")
   void set_initial_position(systems::State<double>* state,
                             double desired_position) const;
 
   // The controller stores the last commanded desired position as state.
   // This is a helper method to reset that state.
+  DRAKE_DEPRECATED("2020-09-01",
+      "There's no need anymore to zero the velocity estimate via this method.")
   void set_initial_position(systems::Context<double>* context,
                             double desired_position) const {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     set_initial_position(&context->get_mutable_state(), desired_position);
+#pragma GCC diagnostic pop
   }
 
   const systems::InputPort<double>& get_desired_position_input_port() const {

--- a/manipulation/schunk_wsg/test/schunk_wsg_position_controller_test.cc
+++ b/manipulation/schunk_wsg/test/schunk_wsg_position_controller_test.cc
@@ -47,7 +47,6 @@ void FixInputsAndHistory(const SchunkWsgPositionController& controller,
                                                         desired_position);
   controller.get_force_limit_input_port().FixValue(controller_context,
                                                    force_limit);
-  controller.set_initial_position(controller_context, desired_position);
 }
 
 /// Runs the controller for a brief period with the specified initial conditions


### PR DESCRIPTION
This changes the iiwa- and wsg-related classes; similar classes such as jaco are unchanged.

Current uses go to great lengths to remove the first step's current position command and transient velocity estimate, often completely breaking the System-Context abstraction by routing q0 through obscure callbacks.  By populating the "default position command" input with the "current position" output, we're sure that the command is always a no-op, no matter how the user set up the State for their plant.  Very important when state is a random variable!

Builds atop (requires) #13336 and #13378 and #13380.

Relates to #9859 somewhat.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13340)
<!-- Reviewable:end -->
