### PR TITLE
pydrake: Added some simulator bindings

### DIFF
--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -13,6 +13,7 @@
 #include "drake/systems/analysis/runge_kutta3_integrator.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/analysis/simulator_flags.h"
+#include "drake/systems/analysis/simulator_print_stats.h"
 
 using std::unique_ptr;
 
@@ -134,7 +135,9 @@ PYBIND11_MODULE(analysis, m) {
             doc.Simulator.get_target_realtime_rate.doc)
         .def("get_actual_realtime_rate",
             &Simulator<T>::get_actual_realtime_rate,
-            doc.Simulator.get_actual_realtime_rate.doc);
+            doc.Simulator.get_actual_realtime_rate.doc)
+        .def("ResetStatistics", &Simulator<T>::ResetStatistics,
+            doc.Simulator.ResetStatistics.doc);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     const char* const reset_integrator_doc =
@@ -172,6 +175,10 @@ PYBIND11_MODULE(analysis, m) {
           pydrake_doc.drake.systems.ResetIntegratorFromFlags.doc)
       .def("GetIntegrationSchemes", &GetIntegrationSchemes,
           pydrake_doc.drake.systems.GetIntegrationSchemes.doc);
+  // Print Simulator Statistics
+  m  // BR
+      .def("PrintSimulatorStatistics", &PrintSimulatorStatistics,
+          pydrake_doc.drake.systems.PrintSimulatorStatistics.doc);
 
   // Monte Carlo Testing
   {

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -17,6 +17,7 @@ from pydrake.symbolic import Expression
 from pydrake.systems.analysis import (
     GetIntegrationSchemes,
     IntegratorBase, IntegratorBase_,
+    PrintSimulatorStatistics,
     ResetIntegratorFromFlags,
     RungeKutta2Integrator, RungeKutta3Integrator,
     SimulatorStatus, Simulator, Simulator_,
@@ -353,6 +354,9 @@ class TestGeneral(unittest.TestCase):
                             simulator.get_mutable_context())
             check_output(simulator.get_context())
             simulator.AdvanceTo(1)
+            simulator.ResetStatistics()
+            simulator.AdvanceTo(2)
+
             self.assertEqual(simulator.get_target_realtime_rate(), 0)
             self.assertTrue(simulator.get_actual_realtime_rate() > 0.)
 
@@ -456,6 +460,9 @@ class TestGeneral(unittest.TestCase):
             simulator.AdvanceTo(t)
             # Record snapshot of *entire* context.
             context_log.append(context.Clone())
+
+        # Test binding for PrintSimulatorStatistics
+        PrintSimulatorStatistics(simulator)
 
         xc_initial = np.array([0, 1, 2])
         xc_final = np.array([0.123, 1.234, 2.345])


### PR DESCRIPTION
Bindings and tests for:
 - `PrintSimulatorStatistics`
 - `ResetStatistics` in simulator

For the test, I just called the commands in some of the existing simulator tests

I put the `PrintSimulatorStatistics` under a heading labeled Simulator Flags, since I didn't know where else to put it. If you want me to put it somewhere else or make a new section, I can

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13343)
<!-- Reviewable:end -->
