### PR TITLE
Do not error when downloading ibex on Focal

### DIFF
--- a/tools/workspace/ibex/repository.bzl
+++ b/tools/workspace/ibex/repository.bzl
@@ -40,8 +40,10 @@ def _impl(repo_ctx):
                 result.error,
             ))
         return
-    if os_result.ubuntu_release != "18.04":
+    if os_result.ubuntu_release not in ["18.04", "20.04"]:
         fail("Operating system is NOT supported", attr = os_result)
+    if os_result.ubuntu_release == "20.04":
+        print("Using Ubuntu 18.04 (Bionic) package on Ubuntu 20.04 (Focal)")
     result = setup_new_deb_archive(repo_ctx)
     if result.error != None:
         fail("Unable to complete setup for @{} repository: {}".format(


### PR DESCRIPTION
We do have a Focal package, but `setup_new_deb_archive` needs reworking to be able to use it. 

<!-- Reviewable:start -->
----
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13345)
<!-- Reviewable:end -->
