### PR TITLE
Fix shadow warning and include <fstream> for std::ifstream and std::ofstream

### DIFF
--- a/geometry/render/render_engine_ospray.cc
+++ b/geometry/render/render_engine_ospray.cc
@@ -1,5 +1,6 @@
 #include "drake/geometry/render/render_engine_ospray.h"
 
+#include <fstream>
 #include <limits>
 #include <optional>
 #include <stdexcept>

--- a/geometry/render/render_engine_vtk.cc
+++ b/geometry/render/render_engine_vtk.cc
@@ -1,5 +1,6 @@
 #include "drake/geometry/render/render_engine_vtk.h"
 
+#include <fstream>
 #include <limits>
 #include <optional>
 #include <stdexcept>

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -1,5 +1,6 @@
 #include "drake/multibody/parsing/detail_sdf_parser.h"
 
+#include <fstream>
 #include <memory>
 
 #include <gtest/gtest.h>

--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -1,5 +1,6 @@
 #include "drake/multibody/parsing/detail_urdf_parser.h"
 
+#include <fstream>
 #include <limits>
 
 #include <gtest/gtest.h>

--- a/perception/test/depth_image_to_point_cloud_test.cc
+++ b/perception/test/depth_image_to_point_cloud_test.cc
@@ -219,7 +219,7 @@ TYPED_TEST_SUITE(DepthImageToPointCloudTest, AllConfigs);
 
 // Verifies computed point cloud when pixel values are valid.
 TYPED_TEST(DepthImageToPointCloudTest, Basic) {
-  using Pixel = typename TestFixture::Pixel;
+  using TestFixturePixel = typename TestFixture::Pixel;
 
   static constexpr int kImageWidth = 60;
   static constexpr int kImageHeight = 40;
@@ -230,9 +230,10 @@ TYPED_TEST(DepthImageToPointCloudTest, Basic) {
                           kImageWidth * 0.5, kImageHeight * 0.5);
 
   // A constant-value depth image.
-  constexpr Pixel kDepthValue = 1;
-  const auto& depth_image =
-      MatrixX<Pixel>::Constant(kImageWidth, kImageHeight, kDepthValue).eval();
+  constexpr TestFixturePixel kDepthValue = 1;
+  const auto& depth_image = MatrixX<TestFixturePixel>::Constant(
+                                kImageWidth, kImageHeight, kDepthValue)
+                                .eval();
 
   // A constant-value RGB image.
   constexpr uint8_t kRedValue = 0;
@@ -303,23 +304,25 @@ TYPED_TEST(DepthImageToPointCloudTest, Basic) {
 
 // Verifies computed point cloud when pixel value is NaN.
 TYPED_TEST(DepthImageToPointCloudTest, NanValue) {
-  using Pixel = typename TestFixture::Pixel;
+  using TestFixturePixel = typename TestFixture::Pixel;
 
   // This test only applies for 32F images; there is no NaN for 16U images.
-  constexpr bool is_meaningful_nan = !std::is_same<Pixel, uint16_t>::value;
+  constexpr bool is_meaningful_nan =
+      !std::is_same<TestFixturePixel, uint16_t>::value;
   if (!is_meaningful_nan) {
     return;
   }
   // Use the ?: operator to avoid a -Woverflow warning.  (The exception case is
   // never reached, but mitigates the warning.)
-  const Pixel single_pixel =
+  const TestFixturePixel single_pixel =
       is_meaningful_nan ? kFloatNaN : throw std::runtime_error("");
 
   // Test all combinations of {without pose, with pose} x
   // {without scale, with scale}.
   const auto& camera = this->single_pixel_camera_;
   const auto& pose = this->random_transform_;
-  const auto& depth_image = Vector1<Pixel>::Constant(single_pixel).eval();
+  const auto& depth_image =
+      Vector1<TestFixturePixel>::Constant(single_pixel).eval();
 
   // A single-pixel RGB image.
   const uint8_t kRedValue = 234;
@@ -354,14 +357,14 @@ TYPED_TEST(DepthImageToPointCloudTest, NanValue) {
 
 // Verifies computed point cloud when pixel value is kTooClose or kTooFar.
 TYPED_TEST(DepthImageToPointCloudTest, TooNearFar) {
-  using Pixel = typename TestFixture::Pixel;
+  using TestFixturePixel = typename TestFixture::Pixel;
   using Traits = typename TestFixture::ConfiguredImageTraits;
   const auto& camera = this->single_pixel_camera_;
   const auto& pose = this->random_transform_;
   const auto& depth_image_near =
-      Vector1<Pixel>::Constant(Traits::kTooClose).eval();
+      Vector1<TestFixturePixel>::Constant(Traits::kTooClose).eval();
   const auto& depth_image_far =
-      Vector1<Pixel>::Constant(Traits::kTooFar).eval();
+      Vector1<TestFixturePixel>::Constant(Traits::kTooFar).eval();
 
   // A single-pixel RGB image.
   const uint8_t kRedValue = 200;
@@ -417,9 +420,9 @@ TYPED_TEST(DepthImageToPointCloudTest, TooNearFar) {
 
 // Verifies the System method CalcOutput resets invalid storage.
 TYPED_TEST(DepthImageToPointCloudTest, ResetStorage) {
-  using Pixel = typename TestFixture::Pixel;
+  using TestFixturePixel = typename TestFixture::Pixel;
   const auto& camera = this->single_pixel_camera_;
-  const auto& depth_image = Vector1<Pixel>::Constant(1).eval();
+  const auto& depth_image = Vector1<TestFixturePixel>::Constant(1).eval();
   std::unique_ptr<AbstractValue> abstract_value;
   const PointCloud* cloud{};
 


### PR DESCRIPTION
Relates #13102. Not entirely sure what changed in the stdlib headers with regard `<fstream>`, but everything should have been IWYU anyway.

Pretty much just the attic left to fix as far the compiler goes. A few linker issues and plenty of test issues, though. 

(Well, apparently, clang has a whole different set of copy-move related warnings, so still lots of compiler fun to be had.)

<!-- Reviewable:start -->
----
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13348)
<!-- Reviewable:end -->
