### PR TITLE
pydrake: Collision filtering bindings

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -703,6 +703,14 @@ void DoScalarIndependentDefinitions(py::module m) {
             "Returns formatted string.");
   }
 
+  // GeometrySet
+  {
+    using Class = GeometrySet;
+    constexpr auto& cls_doc = doc.GeometrySet;
+    py::class_<Class>(m, "GeometrySet", cls_doc.doc)
+        .def(py::init(), doc.GeometrySet.ctor.doc);
+  }
+
   py::class_<ProximityProperties, GeometryProperties>(
       m, "ProximityProperties", doc.ProximityProperties.doc)
       .def(py::init(), doc.ProximityProperties.ctor.doc);

--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -234,6 +234,26 @@ void DoScalarDependentDefinitions(py::module m, T) {
                 &Class::RegisterAnchoredGeometry),
             py::arg("source_id"), py::arg("geometry"),
             cls_doc.RegisterAnchoredGeometry.doc)
+        .def("ExcludeCollisionsBetween",
+            py::overload_cast<const GeometrySet&, const GeometrySet&>(
+                &Class::ExcludeCollisionsBetween),
+            py_reference_internal, py::arg("setA"), py::arg("setB"),
+            cls_doc.ExcludeCollisionsBetween.doc_2args)
+        .def("ExcludeCollisionsBetween",
+            overload_cast_explicit<void, Context<T>*, const GeometrySet&,
+                const GeometrySet&>(&Class::ExcludeCollisionsBetween),
+            py_reference_internal, py::arg("context"), py::arg("setA"),
+            py::arg("setB"), cls_doc.ExcludeCollisionsBetween.doc_3args)
+        .def("ExcludeCollisionsWithin",
+            py::overload_cast<const GeometrySet&>(
+                &Class::ExcludeCollisionsWithin),
+            py_reference_internal, py::arg("set"),
+            cls_doc.ExcludeCollisionsWithin.doc_1args)
+        .def("ExcludeCollisionsWithin",
+            overload_cast_explicit<void, Context<T>*, const GeometrySet&>(
+                &Class::ExcludeCollisionsWithin),
+            py_reference_internal, py::arg("context"), py::arg("set"),
+            cls_doc.ExcludeCollisionsWithin.doc_2args)
         .def("AddRenderer", &Class::AddRenderer, py::arg("name"),
             py::arg("renderer"), cls_doc.AddRenderer.doc)
         .def("HasRenderer", &Class::HasRenderer, py::arg("name"),

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -669,7 +669,9 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.num_collision_geometries.doc)
         .def("default_coulomb_friction", &Class::default_coulomb_friction,
             py::arg("geometry_id"), py_reference_internal,
-            cls_doc.default_coulomb_friction.doc);
+            cls_doc.default_coulomb_friction.doc)
+        .def("CollectRegisteredGeometries", &Class::CollectRegisteredGeometries,
+            py::arg("bodies"), cls_doc.CollectRegisteredGeometries.doc);
     // Port accessors.
     cls  // BR
         .def("get_actuation_input_port",

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -69,6 +69,7 @@ from pydrake.common.value import AbstractValue
 from pydrake.geometry import (
     Box,
     GeometryId,
+    GeometrySet,
     Role,
     PenetrationAsPointPair_,
     ProximityProperties,
@@ -1349,6 +1350,23 @@ class TestPlant(unittest.TestCase):
 
         publisher = ConnectContactResultsToDrakeVisualizer(builder, plant)
         self.assertIsInstance(publisher, LcmPublisherSystem)
+
+    def test_collision_filter(self):
+        builder_f = DiagramBuilder_[float]()
+        # N.B. `Parser` only supports `MultibodyPlant_[float]`.
+        plant_f, scene_graph_f = AddMultibodyPlantSceneGraph(builder_f, 0.0)
+        parser = Parser(plant=plant_f, scene_graph=scene_graph_f)
+
+        parser.AddModelFromFile(
+            FindResourceOrThrow(
+                "drake/bindings/pydrake/multibody/test/two_bodies.sdf"))
+        plant_f.Finalize()
+
+        # Build a set with geometries from bodies 1 and 2.
+        body_a = plant_f.GetBodyByName("body1")
+        body_b = plant_f.GetBodyByName("body2")
+        geometries = plant_f.CollectRegisteredGeometries([body_a, body_b])
+        self.assertIsInstance(geometries, GeometrySet)
 
     @numpy_compare.check_nonsymbolic_types
     def test_scene_graph_queries(self, T):

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -440,3 +440,13 @@ class TestGeometry(unittest.TestCase):
         ]
         for i, expected in enumerate(expected_vertices):
             self.assertListEqual(list(vertices[i].r_MV()), expected)
+
+    def test_collision_filtering(self):
+        sg = mut.SceneGraph()
+        sg_context = sg.CreateDefaultContext()
+        geometries = mut.GeometrySet()
+
+        sg.ExcludeCollisionsBetween(geometries, geometries)
+        sg.ExcludeCollisionsBetween(sg_context, geometries, geometries)
+        sg.ExcludeCollisionsWithin(geometries)
+        sg.ExcludeCollisionsWithin(sg_context, geometries)


### PR DESCRIPTION
Added pydrake bindings needed for basic collision filtering in MBP and included a test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13358)
<!-- Reviewable:end -->
