### PR TITLE
Added support for all types in VectorExternallyAppliedSpatialForce

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -11,6 +11,7 @@
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/common/eigen_types.h"
 #include "drake/geometry/query_results/penetration_as_point_pair.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/math/rigid_transform.h"
@@ -24,6 +25,11 @@
 
 PYBIND11_MAKE_OPAQUE(
     std::vector<drake::multibody::ExternallyAppliedSpatialForce<double>>);
+PYBIND11_MAKE_OPAQUE(std::vector<
+    drake::multibody::ExternallyAppliedSpatialForce<drake::AutoDiffXd>>);
+PYBIND11_MAKE_OPAQUE(
+    std::vector<drake::multibody::ExternallyAppliedSpatialForce<
+        drake::symbolic::Expression>>);
 
 namespace drake {
 namespace pydrake {

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -714,10 +714,8 @@ class TestPlant(unittest.TestCase):
         return Impl
 
     def test_applied_force_input_ports(self):
-        # TODO(eric.cousineau): Figure out why `pybind11/stl_bind.h` does not
-        # like `VectorExternallyAppliedSpatialForced_` and throws
-        # `ValueError: vector::reserve` #11648.
         self.check_applied_force_input_ports(float)
+        self.check_applied_force_input_ports(AutoDiffXd)
 
     def check_applied_force_input_ports(self, T):
         # Create a MultibodyPlant, and ensure that a secondary system can


### PR DESCRIPTION
Resolves https://github.com/RobotLocomotion/drake/issues/11648

The test is technically not testing out the Expression type because the Simulator doesn't have the Expression type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13359)
<!-- Reviewable:end -->
