### PR TITLE
Use static library for yaml-cpp on Focal due to hidden visibility patch

### DIFF
--- a/tools/workspace/yaml_cpp/package-ubuntu-20.04.BUILD.bazel
+++ b/tools/workspace/yaml_cpp/package-ubuntu-20.04.BUILD.bazel
@@ -8,7 +8,10 @@ cc_library(
     includes = ["include"],
     linkopts = [
         "-L/usr/lib/x86_64-linux-gnu",
-        "-lyaml-cpp",
+        # Work around undefined reference to "vtable for YAML::EmitFromEvents"
+        # when linking to libyaml-cpp.so. Most likely due to
+        # "symbol-visibility.patch" applied by Debian.
+        "-l:libyaml-cpp.a",
     ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Maybe you could call it a bug that several classes (including `EmitFromEvents`) are arbitrarily missing a `YAML_CPP_API` decoration, but upstream do not consider symbol visibility at all and `YAML_CPP_API` is defined to nothing (except on Windows) until Debian decided to do differently.

Relates #13102.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13366)
<!-- Reviewable:end -->
