### PR TITLE
Ignore -Wmaybe-uninitialized related to std::optional with GCC 8 and above

### DIFF
--- a/multibody/parsing/detail_scene_graph.cc
+++ b/multibody/parsing/detail_scene_graph.cc
@@ -382,6 +382,12 @@ ProximityProperties MakeProximityPropertiesForCollision(
 
   geometry::ProximityProperties properties;
   if (drake_element != nullptr) {
+#pragma GCC diagnostic push
+// Ignore false-positive -Wmaybe-uninitialized diagnostic related to
+// std::optional when compiling with GCC 8 and above.
+#if __GNUC__ > 7
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
     auto read_double =
         [drake_element](const char* element_name) -> std::optional<double> {
       if (MaybeGetChildElement(*drake_element, element_name) != nullptr) {
@@ -390,6 +396,7 @@ ProximityProperties MakeProximityPropertiesForCollision(
       }
       return {};
     };
+#pragma GCC diagnostic pop
 
     const bool is_rigid = drake_element->HasElement("drake:rigid_hydroelastic");
     const bool is_soft = drake_element->HasElement("drake:soft_hydroelastic");

--- a/multibody/parsing/detail_urdf_geometry.cc
+++ b/multibody/parsing/detail_urdf_geometry.cc
@@ -521,6 +521,12 @@ geometry::GeometryInstance ParseCollision(
   const XMLElement* drake_element =
       node->FirstChildElement("drake:proximity_properties");
   if (drake_element) {
+#pragma GCC diagnostic push
+// Ignore false-positive -Wmaybe-uninitialized diagnostic related to
+// std::optional when compiling with GCC 8 and above.
+#if __GNUC__ > 7
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
     auto read_double =
         [drake_element](const char* element_name) -> std::optional<double> {
       const XMLElement* value_node =
@@ -538,6 +544,7 @@ geometry::GeometryInstance ParseCollision(
       }
       return {};
     };
+#pragma GCC diagnostic pop
 
     const XMLElement* const rigid_element =
         drake_element->FirstChildElement("drake:rigid_hydroelastic");

--- a/multibody/parsing/test/detail_common_test.cc
+++ b/multibody/parsing/test/detail_common_test.cc
@@ -30,10 +30,17 @@ optional<double> empty_read_double(const char*) { return {}; }
 // expect for the given name (which returns the given value).
 ReadDoubleFunc param_read_double(
     const std::string& tag, double value) {
+#pragma GCC diagnostic push
+// Ignore false-positive -Wmaybe-uninitialized diagnostic related to
+// std::optional when compiling with GCC 8 and above.
+#if __GNUC__ > 7
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
   return [&tag, value](const char* name) -> optional<double> {
     if (tag == name) return value;
     return {};
   };
+#pragma GCC diagnostic pop
 }
 
 // Tests for a particular value in the given properties.
@@ -178,6 +185,12 @@ GTEST_TEST(ParseProximityPropertiesTest, Friction) {
   // covered in the NoProperties test.
   auto friction_read_double = [](optional<double> mu_d,
       optional<double> mu_s) -> ReadDoubleFunc {
+#pragma GCC diagnostic push
+// Ignore false-positive -Wmaybe-uninitialized diagnostic related to
+// std::optional when compiling with GCC 8 and above.
+#if __GNUC__ > 7
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
     return [mu_d, mu_s](const char* name) -> optional<double> {
       if (mu_d.has_value() && std::string("drake:mu_dynamic") == name) {
         return *mu_d;
@@ -186,6 +199,7 @@ GTEST_TEST(ParseProximityPropertiesTest, Friction) {
       }
       return {};
     };
+#pragma GCC diagnostic pop
   };
 
   auto expect_friction =


### PR DESCRIPTION
Relates #13102. Seems like https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80635 at first glance. My view is that the issue is (borderline) narrow enough to selectively disable `-Wmaybe-uninitialized` at present.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13367)
<!-- Reviewable:end -->
