### PR TITLE
pydrake: Added binding for VectorRigidTransform

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -80,6 +80,7 @@ from pydrake.geometry import (
 from pydrake.math import (
     RigidTransform_,
     RollPitchYaw_,
+    VectorRigidTransform_
 )
 from pydrake.systems.analysis import Simulator_
 from pydrake.systems.framework import (
@@ -674,6 +675,12 @@ class TestPlant(unittest.TestCase):
                 model_instance=gripper_model),
             OutputPort)
         self.assertIsInstance(plant.get_body_poses_output_port(), OutputPort)
+
+        # Check type of body_poses port
+        plant_context = plant.CreateDefaultContext()
+        body_poses_port = plant.get_body_poses_output_port()
+        poses = body_poses_port.Eval(plant_context)
+        self.assertIsInstance(poses, VectorRigidTransform_[T])
 
     @TemplateSystem.define("AppliedForceTestSystem_")
     def AppliedForceTestSystem_(T):


### PR DESCRIPTION
## What
Binding and test for `VectorRigidTransform`. I followed how `VectorExternallyAppliedForced` is done. 

## Use case
Since there is now a `get_body_poses_output_port` for the MBP, if you want to use this, something like 
```        self.body_positions_input_port = self.DeclareAbstractInputPort(
            "body_positions",
            AbstractValue.Make(
                VectorRigidTransform()
            )
        )
```
is needed so `VectorRigidTransform` needs to be bound. 

## Note:
I noticed that it was called `VectorExternallyAppliedSpatialForced` instead of `VectorExternallyAppliedSpatialForce`. I couldn't figure out if it's a typo or not. I chose not to call it `VectorRigidTransformd` because that seems weird

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13369)
<!-- Reviewable:end -->
