### PR TITLE
Suppress symbolic feedthrough check if non-default output prerequisites were specified.

### DIFF
--- a/systems/controllers/finite_horizon_linear_quadratic_regulator.cc
+++ b/systems/controllers/finite_horizon_linear_quadratic_regulator.cc
@@ -404,11 +404,5 @@ std::unique_ptr<System<double>> MakeFiniteHorizonLinearQuadraticRegulator(
 
 }  // namespace controllers
 
-// Explicitly disable symbolic::Expression (pending resolution of #12253).
-namespace scalar_conversion {
-template <>
-struct Traits<controllers::Controller> : public NonSymbolicTraits {};
-}  // namespace scalar_conversion
-
 }  // namespace systems
 }  // namespace drake

--- a/systems/controllers/test/finite_horizon_linear_quadratic_regulator_test.cc
+++ b/systems/controllers/test/finite_horizon_linear_quadratic_regulator_test.cc
@@ -296,8 +296,8 @@ GTEST_TEST(FiniteHorizonLQRTest, ResultSystemIsScalarConvertible) {
     EXPECT_EQ(converted.num_output_ports(), 1);
     EXPECT_EQ(converted.num_total_outputs(), 1);
   }));
-  // TODO(russt): Re-enable symbolic pending resolution of #12253:
-  EXPECT_FALSE(is_symbolic_convertible(*regulator));
+
+  EXPECT_TRUE(is_symbolic_convertible(*regulator));
 }
 
 }  // namespace

--- a/systems/framework/leaf_system.cc
+++ b/systems/framework/leaf_system.cc
@@ -223,78 +223,82 @@ std::unique_ptr<SystemSymbolicInspector> MakeSystemSymbolicInspector(
 template <typename T>
 std::multimap<int, int> LeafSystem<T>::GetDirectFeedthroughs() const {
   // The input -> output feedthrough result we'll return to the user.
-  std::multimap<int, int> result;
+  std::multimap<int, int> feedthrough;
 
-  // The list of pairs where we don't know an answer yet.
-  std::multimap<InputPortIndex, OutputPortIndex> unknown;
+  // The set of pairs for which we don't know an answer yet; currently all.
+  std::set<std::pair<InputPortIndex, OutputPortIndex>> unknown;
   for (InputPortIndex u{0}; u < this->num_input_ports(); ++u) {
     for (OutputPortIndex v{0}; v < this->num_output_ports(); ++v) {
-      unknown.emplace(u, v);
+      unknown.emplace(std::make_pair(u, v));
     }
   }
 
-  // A helper function to remove an item from `unknown`.
-  auto remove_unknown = [&unknown](const auto& in_out_pair) {
-    for (auto iter = unknown.lower_bound(in_out_pair.first); ; ++iter) {
-      DRAKE_DEMAND(iter != unknown.end());
-      DRAKE_DEMAND(iter->first == in_out_pair.first);
-      if (*iter == in_out_pair) {
-        unknown.erase(iter);
-        break;
-      }
-    }
+  // A System with no input ports or no output ports has no feedthrough!
+  if (unknown.empty())
+    return feedthrough;  // Also empty.
+
+  // A helper function that removes an item from `unknown`.
+  const auto remove_unknown = [&unknown](const auto& in_out_pair) {
+    const auto num_erased = unknown.erase(in_out_pair);
+    DRAKE_DEMAND(num_erased == 1);
   };
 
-  // Ask the dependency graph if we can exclude any pairs.
-  if (!unknown.empty()) {
-    auto context = this->AllocateContext();
-    const auto orig_unknown = unknown;
-    for (const auto& input_output : orig_unknown) {
-      const auto& input = this->get_input_port(input_output.first);
-      const auto& input_tracker = context->get_tracker(input.ticket());
-      const auto& output = this->get_output_port(input_output.second);
-      DRAKE_ASSERT(typeid(output) == typeid(LeafOutputPort<T>));
-      const auto& leaf_output = static_cast<const LeafOutputPort<T>&>(output);
-      const auto& cache_entry = leaf_output.cache_entry();
-      auto& value = cache_entry.get_mutable_cache_entry_value(*context);
-      value.mark_up_to_date();
-      const int64_t change_event = context->start_new_change_event();
-      input_tracker.NoteValueChange(change_event);
-      if (!value.is_out_of_date()) {
-        // We've proved there is no dependency, so we don't need to add it to
-        // result and we can remove it from unknown.  (Or maybe the System's
-        // stated dependencies were inaccurate, but we can't really repair
-        // that here.)
-        remove_unknown(input_output);
-      }
-      // Undo the mark_up_to_date() we just did a few lines up.  It shouldn't
-      // matter at all on this throwaway context, but perhaps it's best not
-      // to leave garbage values marked valid for longer than required.
-      value.mark_out_of_date();
-    }
+  // A helper function that adds this in/out pair to the feedthrough result.
+  const auto add_to_feedthrough = [&feedthrough](const auto& in_out_pair) {
+    feedthrough.emplace(in_out_pair.first, in_out_pair.second);
+  };
+
+  // Ask the dependency graph if it can provide definitive information about
+  // the input/output pairs. If so remove those pairs from the `unknown` set.
+  auto context = this->AllocateContext();
+  const auto orig_unknown = unknown;
+  for (const auto& input_output : orig_unknown) {
+    // Get the CacheEntry associated with the output port in this pair.
+    const auto& output = this->get_output_port(input_output.second);
+    DRAKE_ASSERT(typeid(output) == typeid(LeafOutputPort<T>));
+    const auto& leaf_output = static_cast<const LeafOutputPort<T>&>(output);
+    const auto& cache_entry = leaf_output.cache_entry();
+
+    // If the user left the output prerequisites unspecified, then the cache
+    // entry tells us nothing useful about feedthrough for this pair.
+    if (cache_entry.has_default_prerequisites())
+      continue;  // Leave this one "unknown".
+
+    // Probe the dependency path and believe the result.
+    const auto& input = this->get_input_port(input_output.first);
+    const auto& input_tracker = context->get_tracker(input.ticket());
+    auto& value = cache_entry.get_mutable_cache_entry_value(*context);
+    value.mark_up_to_date();
+    const int64_t change_event = context->start_new_change_event();
+    input_tracker.NoteValueChange(change_event);
+
+    if (value.is_out_of_date())
+      add_to_feedthrough(input_output);
+
+    // Regardless of the result we have all we need to know now.
+    remove_unknown(input_output);
+
+    // Undo the mark_up_to_date() we just did a few lines up.  It shouldn't
+    // matter at all on this throwaway context, but perhaps it's best not
+    // to leave garbage values marked valid for longer than required.
+    value.mark_out_of_date();
   }
 
-  // If unknown pairs remain, ask symbolic inspector if we can exclude them.
-  if (!unknown.empty()) {
-    if (auto inspector = MakeSystemSymbolicInspector(*this)) {
-      const auto orig_unknown = unknown;
-      for (const auto& input_output : orig_unknown) {
-        if (!inspector->IsConnectedInputToOutput(
-                input_output.first, input_output.second)) {
-          // We've proved there is no dependency, so we don't need to add it
-          // to result and we can remove it from unknown.
-          remove_unknown(input_output);
-        }
-      }
-    }
-  }
+  // If the dependency graph resolved all pairs, no need for symbolic analysis.
+  if (unknown.empty())
+    return feedthrough;
 
-  // If unknown pairs remain, conservatively assume they are feedthrough.
+  // Otherwise, see if we can get a symbolic inspector to analyze them.
+  // If not, we have to assume they are feedthrough.
+  auto inspector = MakeSystemSymbolicInspector(*this);
   for (const auto& input_output : unknown) {
-    result.emplace(input_output.first, input_output.second);
+    if (!inspector || inspector->IsConnectedInputToOutput(
+                          input_output.first, input_output.second)) {
+      add_to_feedthrough(input_output);
+    }
+    // No need to clean up the `unknown` set here.
   }
-
-  return result;
+  return feedthrough;
 }
 
 template <typename T>

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -1261,27 +1261,34 @@ class LeafSystem : public System<T> {
   @anchor DeclareLeafOutputPort_feedthrough
   <em><u>Direct feedthrough</u></em>
 
-  The direct-feedthrough relation from input ports to output ports is
-  reported via methods such as System::HasDirectFeedthrough().
-
   By default, %LeafSystem assumes there is direct feedthrough of values
   from every input to every output. This is a conservative assumption that
   ensures we detect and can prevent the formation of algebraic loops
   (implicit computations) in system Diagrams. Systems which do not have
   direct feedthrough may override that assumption in either of two ways:
 
-  (1) When declaring output ports (e.g., DeclareVectorOutputPort()),
-  provide a non-default value to the `prerequisites_of_calc` argument.
-  When `the prerequisites_of_calc` implies no dependency on some inputs,
-  the framework automatically infers that the output is not
-  direct-feedthrough for those inputs.  For example:
+  (1) When declaring an output port (e.g., DeclareVectorOutputPort()),
+  provide a non-default value for the `prerequisites_of_calc` argument.
+  In that case the dependency path from each input port to that output port is
+  probed via the fast cache invalidation mechanism to see if it has a direct or
+  indirect dependence that input port. For example:
   @code
   PendulumPlant<T>::PendulumPlant() {
-    // ...
+    // No feedthrough because the output port depends only on state,
+    // and state has no dependencies.
     this->DeclareVectorOutputPort(
         "state", &PendulumPlant::CopyStateOut,
         {this->all_state_ticket()});
-    // ...
+
+    // Has feedthrough from input port 0 but not from any others.
+    this->DeclareVectorOutputPort(
+        "tau", &PendulumPlant::CopyTauOut,
+        {this->input_port_ticket(InputPortIndex(0))});
+
+    // Doesn't specify prerequisites. We'll assume feedthrough from all
+    // inputs unless we can apply symbolic analysis (see below).
+    this->DeclareVectorOutputPort(
+        "result", &PendulumPlant::CalcResult);
   }
   @endcode
 
@@ -1292,11 +1299,18 @@ class LeafSystem : public System<T> {
   @ref system_scalar_conversion_how_to_write_a_system
   "How to write a System that supports scalar conversion".
   This allows the %LeafSystem to infer the sparsity from the symbolic
-  equations.
+  equations for any of the output ports that don't specify an explicit
+  list of prerequisites.
 
   Option 2 is a convenient default for simple systems that already support
   symbolic::Expression, but option 1 should be preferred as the most direct
-  mechanism to control feedthrough reporting. */
+  mechanism to control feedthrough reporting.
+
+  Normally the direct-feedthrough relations are checked automatically to
+  detect algebraic loops. If you want to examine the computed feedthrough
+  status for all ports or a particular port, see
+  System::GetDirectFeedthroughs(), System::HasDirectFeedthrough(), and
+  related methods. */
   //@{
 
   /** Declares a vector-valued output port by specifying (1) a model vector of


### PR DESCRIPTION
Currently if the cache dependency graph shows direct feedthrough from an input port to an output port, the System framework doesn't believe it and attempts a symbolic analysis to make its own determination. That makes sense when a user hasn't provided explicit prerequisites for that output port, because the default is "all sources" so always shows feedthrough. However, if a user _has_ provided prerequisites then we should believe the result and not bother with the symbolic analysis, which brings its own set of problems. For example, @RussTedrake had to suppress symbolics for his FiniteHorizonLinearQuadraticRegulator because the System's use case for feedthrough analysis stomped through forbidden territory (see discussion in #12253).

This PR modifies the feedthrough determination algorithm, and re-enables symbolics for FiniteHorizonLinearQuadraticRegulator.

The new algorithm is this:
- Examine all input port / output port pairs.
- For any output port that has non-default prerequisites specified, let the cache dependency graph determine whether there is feedthrough from any input port.
- For any output port for which prerequisites have the default value of `all_sources_ticket()` (meaning it has feedthrough from every input port) assume that is unreliable.
- If we can convert the System to symbolic, pull the default-prerequisite output ports to see which input ports are actually feedthrough.

Resolves #12253.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13370)
<!-- Reviewable:end -->
