### PR TITLE
Fix missing member in ManipulationStationHardwareInterface

### DIFF
--- a/bindings/pydrake/examples/manipulation_station_py.cc
+++ b/bindings/pydrake/examples/manipulation_station_py.cc
@@ -148,7 +148,10 @@ PYBIND11_MODULE(manipulation_station, m) {
       .def("get_camera_names",
           &ManipulationStationHardwareInterface::get_camera_names,
           py_reference_internal,
-          doc.ManipulationStationHardwareInterface.get_camera_names.doc);
+          doc.ManipulationStationHardwareInterface.get_camera_names.doc)
+      .def("num_iiwa_joints",
+          &ManipulationStationHardwareInterface::num_iiwa_joints,
+          doc.ManipulationStationHardwareInterface.num_iiwa_joints.doc);
 
   ExecuteExtraPythonCode(m);
 }

--- a/bindings/pydrake/examples/test/manipulation_station_test.py
+++ b/bindings/pydrake/examples/test/manipulation_station_test.py
@@ -159,6 +159,7 @@ class TestManipulationStation(unittest.TestCase):
         # Don't actually call Connect here, since it would block.
         station.get_controller_plant()
         self.assertEqual(len(station.get_camera_names()), 2)
+        self.assertEqual(station.num_iiwa_joints(), 7)
 
     def test_ycb_object_creation(self):
         ycb_objects = CreateClutterClearingYcbObjectList()

--- a/examples/manipulation_station/manipulation_station.h
+++ b/examples/manipulation_station/manipulation_station.h
@@ -319,7 +319,7 @@ class ManipulationStation : public systems::Diagram<T> {
     return *owned_controller_plant_;
   }
 
-  /// Get the number of joints in the IIWA (only -- does not include the
+  /// Gets the number of joints in the IIWA (only -- does not include the
   /// gripper).
   /// @pre must call one of the "setup" methods first to register an IIWA
   /// model.

--- a/examples/manipulation_station/manipulation_station_hardware_interface.cc
+++ b/examples/manipulation_station/manipulation_station_hardware_interface.cc
@@ -134,12 +134,12 @@ ManipulationStationHardwareInterface::ManipulationStationHardwareInterface(
   const std::string iiwa_sdf_path = FindResourceOrThrow(
       "drake/manipulation/models/iiwa_description/sdf/iiwa14_no_collision.sdf");
   Parser parser(owned_controller_plant_.get());
-  const auto controller_iiwa_model =
-      parser.AddModelFromFile(iiwa_sdf_path, "iiwa");
+  iiwa_model_instance_ = parser.AddModelFromFile(iiwa_sdf_path, "iiwa");
+
   // TODO(russt): Provide API for changing the base coordinates of the plant.
   owned_controller_plant_->WeldFrames(owned_controller_plant_->world_frame(),
                                       owned_controller_plant_->GetFrameByName(
-                                          "iiwa_link_0", controller_iiwa_model),
+                                          "iiwa_link_0", iiwa_model_instance_),
                                       math::RigidTransformd::Identity());
   owned_controller_plant_->Finalize();
 }
@@ -163,6 +163,11 @@ void ManipulationStationHardwareInterface::Connect(bool wait_for_cameras) {
       wait_for_new_message(*sub);
     }
   }
+}
+
+int ManipulationStationHardwareInterface::num_iiwa_joints() const {
+  DRAKE_DEMAND(iiwa_model_instance_.is_valid());
+  return owned_controller_plant_->num_positions(iiwa_model_instance_);
 }
 
 }  // namespace manipulation_station

--- a/examples/manipulation_station/manipulation_station_hardware_interface.h
+++ b/examples/manipulation_station/manipulation_station_hardware_interface.h
@@ -72,6 +72,10 @@ class ManipulationStationHardwareInterface : public systems::Diagram<double> {
     return camera_names_;
   }
 
+  /// Gets the number of joints in the IIWA (only -- does not include the
+  /// gripper).
+  int num_iiwa_joints() const;
+
  private:
   std::unique_ptr<multibody::MultibodyPlant<double>> owned_controller_plant_;
   std::unique_ptr<lcm::DrakeLcm> owned_lcm_;
@@ -80,6 +84,7 @@ class ManipulationStationHardwareInterface : public systems::Diagram<double> {
   std::vector<systems::lcm::LcmSubscriberSystem*> camera_subscribers_;
 
   const std::vector<std::string> camera_names_;
+  multibody::ModelInstanceIndex iiwa_model_instance_{};
 };
 
 }  // namespace manipulation_station


### PR DESCRIPTION
The teleop scripts in examples/manipulation_station work over LCM again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13372)
<!-- Reviewable:end -->
