### PR TITLE
Revert "systems: Use Eigen's formatting in VectorBase::operator<<() output (#13365)"

### DIFF
--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -446,7 +446,7 @@ class TestGeneral(unittest.TestCase):
 
         # Test __str__ methods.
         self.assertRegex(str(context), "integrator")
-        self.assertEqual(str(input2), "0.003 0.004 0.005")
+        self.assertEqual(str(input2), "[0.003, 0.004, 0.005]")
 
         # Initialize integrator states.
         integrator_xc = (

--- a/systems/framework/test/basic_vector_test.cc
+++ b/systems/framework/test/basic_vector_test.cc
@@ -189,34 +189,21 @@ GTEST_TEST(BasicVectorTest, PlusEqScaled) {
   EXPECT_EQ(ans5, ogvec.get_value());
 }
 
-template <typename T>
-class TypedBasicVectorTest : public ::testing::Test {};
-
-using DefaultScalars =
-    ::testing::Types<double, AutoDiffXd, symbolic::Expression>;
-TYPED_TEST_SUITE(TypedBasicVectorTest, DefaultScalars);
-
 // Tests ability to stream a BasicVector into a string.
-TYPED_TEST(TypedBasicVectorTest, StringStream) {
-  using T = TypeParam;
-  BasicVector<T> vec(3);
+GTEST_TEST(BasicVectorTest, StringStream) {
+  BasicVector<double> vec(3);
   vec.get_mutable_value() << 1.0, 2.2, 3.3;
   std::stringstream s;
   s << "hello " << vec << " world";
-  std::stringstream s_expected;
-  s_expected << "hello " << vec.get_value().transpose() << " world";
-  EXPECT_EQ(s.str(), s_expected.str());
+  EXPECT_EQ(s.str(), "hello [1, 2.2, 3.3] world");
 }
 
 // Tests ability to stream a BasicVector of size zero into a string.
-TYPED_TEST(TypedBasicVectorTest, ZeroLengthStringStream) {
-  using T = TypeParam;
-  BasicVector<T> vec(0);
+GTEST_TEST(BasicVectorTest, ZeroLengthStringStream) {
+  BasicVector<double> vec(0);
   std::stringstream s;
-  s << "foo [" << vec << "] bar";
-  std::stringstream s_expected;
-  s_expected << "foo [" << vec.get_value().transpose() << "] bar";
-  EXPECT_EQ(s.str(), s_expected.str());
+  s << "foo " << vec << " bar";
+  EXPECT_EQ(s.str(), "foo [] bar");
 }
 
 // Tests the default set of bounds (empty).

--- a/systems/framework/test/continuous_state_test.cc
+++ b/systems/framework/test/continuous_state_test.cc
@@ -239,10 +239,7 @@ TEST_F(ContinuousStateTest, Clone) {
 TEST_F(ContinuousStateTest, StringStream) {
   std::stringstream s;
   s << "hello " << continuous_state_->get_vector() << " world";
-  std::stringstream s_expected;
-  VectorXd eigen_vector = continuous_state_->CopyToVector();
-  s_expected << "hello " << eigen_vector.transpose() << " world";
-  EXPECT_EQ(s.str(), s_expected.str());
+  EXPECT_EQ(s.str(), "hello [1, 2, 3, 4] world");
 }
 
 // Tests for DiagramContinousState.

--- a/systems/framework/vector_base.h
+++ b/systems/framework/vector_base.h
@@ -225,11 +225,19 @@ class VectorBase {
   }
 };
 
-/// Allows a VectorBase<T> to be streamed into a string as though it were a
-/// RowVectorX<T>. This is useful for debugging purposes.
+// Allows a VectorBase<T> to be streamed into a string. This is useful for
+// debugging purposes.
 template <typename T>
 std::ostream& operator<<(std::ostream& os, const VectorBase<T>& vec) {
-  os << vec.CopyToVector().transpose();
+  os << "[";
+
+  for (int i = 0; i < vec.size(); ++i) {
+    if (i > 0)
+      os << ", ";
+    os << vec[i];
+  }
+
+  os << "]";
   return os;
 }
 


### PR DESCRIPTION
This reverts commit ac9316f3c8addd0bd692f669b6d4ff07347ef8c0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13384)
<!-- Reviewable:end -->
