### PR TITLE
Ignore class-memaccess warning in IsMemcpyMovable

### DIFF
--- a/common/test_utilities/is_memcpy_movable.h
+++ b/common/test_utilities/is_memcpy_movable.h
@@ -32,7 +32,7 @@ template <typename T, typename InvariantPred = std::equal_to<T>>
   auto moved_storage = std::make_unique<
       typename std::aligned_storage<sizeof(T), alignof(T)>::type>();
   T* const ptr_to_moved{reinterpret_cast<T* const>(moved_storage.get())};
-  memcpy(ptr_to_moved, ptr_to_original, sizeof(T));
+  memcpy(static_cast<void*>(ptr_to_moved), ptr_to_original, sizeof(T));
 
   // 3. Free original_storage.
   original_storage.reset();


### PR DESCRIPTION
A possible solution to the following:
```
ERROR: /media/ephemeral0/ubuntu/workspace/linux-focal-unprovisioned-gcc-bazel-continuous-release/src/common/test_utilities/BUILD.bazel:200:1: Couldn't build file common/test_utilities/_objs/is_memcpy_movable_test/is_memcpy_movable_test.pic.o: C++ compilation of rule '//common/test_utilities:is_memcpy_movable_test' failed (Exit 1) gcc failed: error executing command /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer -g0 -O2 '-D_FORTIFY_SOURCE=1' -DNDEBUG -ffunction-sections ... (remaining 103 argument(s) skipped)
 In file included from common/test_utilities/test/is_memcpy_movable_test.cc:1:
 bazel-out/k8-opt/bin/common/test_utilities/_virtual_includes/is_memcpy_movable/drake/common/test_utilities/is_memcpy_movable.h: In instantiation of 'bool drake::test::IsMemcpyMovable(const T&, const InvariantPred&) [with T = drake::test::{anonymous}::MemcpyMovable; InvariantPred = drake::test::{anonymous}::MemcpyMovable::EqualTo]':
 common/test_utilities/test/is_memcpy_movable_test.cc:75:3:   required from here
 bazel-out/k8-opt/bin/common/test_utilities/_virtual_includes/is_memcpy_movable/drake/common/test_utilities/is_memcpy_movable.h:35:9: error: 'void* memcpy(void*, const void*, size_t)' writing to an object of type 'class drake::test::{anonymous}::MemcpyMovable' with no trivial copy-assignment; use copy-initialization instead [-Werror=class-memaccess]
    35 |   memcpy(ptr_to_moved, ptr_to_original, sizeof(T));
       |   ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 common/test_utilities/test/is_memcpy_movable_test.cc:19:7: note: 'class drake::test::{anonymous}::MemcpyMovable' declared here
    19 | class MemcpyMovable {
       |       ^~~~~~~~~~~~~
 In file included from common/test_utilities/test/is_memcpy_movable_test.cc:1:
 bazel-out/k8-opt/bin/common/test_utilities/_virtual_includes/is_memcpy_movable/drake/common/test_utilities/is_memcpy_movable.h: In instantiation of 'bool drake::test::IsMemcpyMovable(const T&, const InvariantPred&) [with T = drake::test::{anonymous}::NotMemcpyMovable; InvariantPred = drake::test::{anonymous}::NotMemcpyMovable::InvariantsHold]':
 common/test_utilities/test/is_memcpy_movable_test.cc:80:3:   required from here
 bazel-out/k8-opt/bin/common/test_utilities/_virtual_includes/is_memcpy_movable/drake/common/test_utilities/is_memcpy_movable.h:35:9: error: 'void* memcpy(void*, const void*, size_t)' writing to an object of type 'class drake::test::{anonymous}::NotMemcpyMovable' with no trivial copy-assignment; use copy-initialization instead [-Werror=class-memaccess]
    35 |   memcpy(ptr_to_moved, ptr_to_original, sizeof(T));
       |   ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 common/test_utilities/test/is_memcpy_movable_test.cc:39:7: note: 'class drake::test::{anonymous}::NotMemcpyMovable' declared here
    39 | class NotMemcpyMovable {
       |       ^~~~~~~~~~~~~~~~
 ERROR: /media/ephemeral0/ubuntu/workspace/linux-focal-unprovisioned-gcc-bazel-continuous-release/src/common/BUILD.bazel:1211:1: Couldn't build file common/_objs/symbolic_variable_test/symbolic_variable_test.pic.o: C++ compilation of rule '//common:symbolic_variable_test' failed (Exit 1) gcc failed: error executing command /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer -g0 -O2 '-D_FORTIFY_SOURCE=1' -DNDEBUG -ffunction-sections ... (remaining 116 argument(s) skipped)
 In file included from common/test/symbolic_variable_test.cc:12:
 bazel-out/k8-opt/bin/common/test_utilities/_virtual_includes/is_memcpy_movable/drake/common/test_utilities/is_memcpy_movable.h: In instantiation of 'bool drake::test::IsMemcpyMovable(const T&, const InvariantPred&) [with T = drake::symbolic::Variable; InvariantPred = std::equal_to<drake::symbolic::Variable>]':
 common/test/symbolic_variable_test.cc:184:5:   required from here
 bazel-out/k8-opt/bin/common/test_utilities/_virtual_includes/is_memcpy_movable/drake/common/test_utilities/is_memcpy_movable.h:35:9: error: 'void* memcpy(void*, const void*, size_t)' writing to an object of type 'class drake::symbolic::Variable' with no trivial copy-assignment; use copy-assignment or copy-initialization instead [-Werror=class-memaccess]
    35 |   memcpy(ptr_to_moved, ptr_to_original, sizeof(T));
       |   ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 In file included from bazel-out/k8-opt/bin/common/_virtual_includes/symbolic/drake/common/symbolic.h:32,
                  from common/test/symbolic_variable_test.cc:11:
 bazel-out/k8-opt/bin/common/_virtual_includes/_symbolic_private_headers_impl/drake/common/symbolic_variable.h:33:7: note: 'class drake::symbolic::Variable' declared here
    33 | class Variable {
       |       ^~~~~~~~
 ERROR: /media/ephemeral0/ubuntu/workspace/linux-focal-unprovisioned-gcc-bazel-continuous-release/src/common/BUILD.bazel:1191:1: Couldn't build file common/_objs/symbolic_formula_test/symbolic_formula_test.pic.o: C++ compilation of rule '//common:symbolic_formula_test' failed (Exit 1) gcc failed: error executing command /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer -g0 -O2 '-D_FORTIFY_SOURCE=1' -DNDEBUG -ffunction-sections ... (remaining 117 argument(s) skipped)
 In file included from common/test/symbolic_formula_test.cc:20:
 bazel-out/k8-opt/bin/common/test_utilities/_virtual_includes/is_memcpy_movable/drake/common/test_utilities/is_memcpy_movable.h: In instantiation of 'bool drake::test::IsMemcpyMovable(const T&, const InvariantPred&) [with T = drake::symbolic::Formula; InvariantPred = std::equal_to<drake::symbolic::Formula>]':
 common/test/symbolic_formula_test.cc:1350:5:   required from here
 bazel-out/k8-opt/bin/common/test_utilities/_virtual_includes/is_memcpy_movable/drake/common/test_utilities/is_memcpy_movable.h:35:9: error: 'void* memcpy(void*, const void*, size_t)' writing to an object of type 'class drake::symbolic::Formula' with no trivial copy-assignment; use copy-assignment or copy-initialization instead [-Werror=class-memaccess]
    35 |   memcpy(ptr_to_moved, ptr_to_original, sizeof(T));
       |   ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 In file included from bazel-out/k8-opt/bin/common/_virtual_includes/symbolic/drake/common/symbolic.h:42,
                  from common/test/symbolic_formula_test.cc:18:
 bazel-out/k8-opt/bin/common/_virtual_includes/_symbolic_private_headers_impl/drake/common/symbolic_formula.h:115:7: note: 'class drake::symbolic::Formula' declared here
   115 | class Formula {
       |       ^~~~~~~
 ERROR: /media/ephemeral0/ubuntu/workspace/linux-focal-unprovisioned-gcc-bazel-continuous-release/src/common/BUILD.bazel:1050:1: Couldn't build file common/_objs/symbolic_expression_test/symbolic_expression_test.pic.o: C++ compilation of rule '//common:symbolic_expression_test' failed (Exit 1) gcc failed: error executing command /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer -g0 -O2 '-D_FORTIFY_SOURCE=1' -DNDEBUG -ffunction-sections ... (remaining 118 argument(s) skipped)
 In file included from common/test/symbolic_expression_test.cc:21:
 bazel-out/k8-opt/bin/common/test_utilities/_virtual_includes/is_memcpy_movable/drake/common/test_utilities/is_memcpy_movable.h: In instantiation of 'bool drake::test::IsMemcpyMovable(const T&, const InvariantPred&) [with T = drake::symbolic::Expression; InvariantPred = std::equal_to<drake::symbolic::Expression>]':
 common/test/symbolic_expression_test.cc:1921:5:   required from here
 bazel-out/k8-opt/bin/common/test_utilities/_virtual_includes/is_memcpy_movable/drake/common/test_utilities/is_memcpy_movable.h:35:9: error: 'void* memcpy(void*, const void*, size_t)' writing to an object of type 'class drake::symbolic::Expression' with no trivial copy-assignment; use copy-assignment or copy-initialization instead [-Werror=class-memaccess]
    35 |   memcpy(ptr_to_moved, ptr_to_original, sizeof(T));
       |   ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 In file included from bazel-out/k8-opt/bin/common/_virtual_includes/symbolic/drake/common/symbolic.h:35,
                  from bazel-out/k8-opt/bin/common/_virtual_includes/default_scalars/drake/common/default_scalars.h:4,
                  from bazel-out/k8-opt/bin/common/_virtual_includes/polynomial/drake/common/polynomial.h:16,
                  from common/test/symbolic_expression_test.cc:19:
 bazel-out/k8-opt/bin/common/_virtual_includes/_symbolic_private_headers_impl/drake/common/symbolic_expression.h:190:7: note: 'class drake::symbolic::Expression' declared here
   190 | class Expression {
       |       ^~~~~~~~~~
```

Relates #13102.

<!-- Reviewable:start -->
----
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13385)
<!-- Reviewable:end -->
