### PR TITLE
doc: Update tutorials section to mention nbviewer

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -70,17 +70,30 @@ Tutorials
 *********
 
 We have Python tutorials that can be previewed and executed as Jupyter
-notebooks online, with no need for local installation:
+notebooks online with no need for local installation. You can use Binder to
+preview and execute the notebooks (but startup time may be long), or you can
+use nbviewer to only preview the notebook (where startup time is fast):
 
 .. raw:: html
 
     <a target="_doc" href="https://mybinder.org/v2/gh/RobotLocomotion/drake/nightly-release?filepath=tutorials">
       <img src="https://mybinder.org/badge_logo.svg"/>
     </a>
+    <a target="_doc" href="https://nbviewer.jupyter.org/github/RobotLocomotion/drake/blob/nightly-release/tutorials/">
+      <img src="https://img.shields.io/badge/view%20on-nbviewer-brightgreen.svg"/>
+    </a>
 
-You may find more information about how to run these locally with Jupyter and
-how they are published to Binder
-`in the tutorials directory of the source tree <https://github.com/RobotLocomotion/drake/tree/master/tutorials>`_.
+If you are browsing on nbviewer, you may click on the Binder button
+|nbviewer-binder-button| at the top-right of the page.
+
+.. |nbviewer-binder-button| raw:: html
+
+    <img width="15px" height="15px"
+        src="https://nbviewer.jupyter.org/static/img/icon-binder-color.png"/>
+
+You may find more information about how to run these locally with Jupyter,
+the branch the tutorials use, how they are published to Binder, etc., in
+`drake/tutorials/README.md <https://github.com/RobotLocomotion/drake/tree/master/tutorials/README.md>`_.
 
 .. _examples:
 
@@ -90,7 +103,7 @@ Examples
 
 .. TODO(russt): make this a table with different algorithms, too.
 
-We have a number of use cases demonstrated in `the examples directory of
+We have a number of use cases demonstrated under `drake/examples in the
 the source tree
 <https://github.com/RobotLocomotion/drake/tree/master/examples>`_, and
 more available through our :doc:`gallery` (contributions welcome!).

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -1,5 +1,8 @@
 # Drake Tutorials
 
+This provdies more in-depth documentation on top of the
+[Drake Documentation's Tutorials](https://drake.mit.edu/#tutorials) section.
+
 ## Running the Tutorials Locally
 
 To run the tutorials locally, you should ensure that you have Drake available, [either via Bazel or via binary packages](https://drake.mit.edu/installation.html).


### PR DESCRIPTION
Use source tree directory names more explicitly
README: Cross-reference docs

I made this PR because I've found myself wanting to reference both `drake.mit.edu` and `drake/tutorials/README.md` because I find browsing through nbviewer, *then* clicking on the Binder button, to be a more bearable workflow.

For example, I cited it in this StackOverflow comment:
https://stackoverflow.com/a/61924814/7829525

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13386)
<!-- Reviewable:end -->
