### PR TITLE
pydrake doc: Add pointers to deprecation code

### DIFF
--- a/bindings/pydrake/common/test/deprecation_example/README.md
+++ b/bindings/pydrake/common/test/deprecation_example/README.md
@@ -1,0 +1,11 @@
+# `pydrake` Deprecation Example
+
+This package is used by `../deprecation_test.py` and shows the following:
+
+* How to use `pydrake.common.deprecation` in a module, leveraging `ModuleShim`
+    * `__init__.py` shows using `ModuleShim`
+* How to use `drake/bindings/pydrake/common/deprecation_pybind.h` to deprecate
+bound code and/or bind deprecated code:
+    * `example_class.h` shows a class with example deprecations
+    * `cc_module_py.cc` shows binding this class with its deprecations,
+    including how the docstrings are affected.

--- a/bindings/pydrake/common/test/deprecation_example/sub_module.py
+++ b/bindings/pydrake/common/test/deprecation_example/sub_module.py
@@ -1,1 +1,5 @@
 # This file serves as an empty Python submodule for testing.
+
+# It will be imported via `__init__.py`, and is meant to be caught via the
+# `ModuleShim` mechanism. This shows that submodules are still routed through
+# that mechanism, and do not escape this deprecation code path.

--- a/bindings/pydrake/pydrake_doxygen.h
+++ b/bindings/pydrake/pydrake_doxygen.h
@@ -1,5 +1,6 @@
 /// @file
-/// Generic doxygen-only documentation.
+/// Doxygen-only documentation for the development of Python bindings.
+/// @sa @ref python_bindings
 
 /** @defgroup python_bindings Python Bindings
 @ingroup technical_notes
@@ -273,6 +274,27 @@ generated documentation.
 @c \@pydrake_mkdoc_identifier{foobar} to the Doxygen comment.
 - The docstring for a method that is marked as deprecated in C++ Doxygen will
 be named `.doc_deprecated...` instead of just `.doc...`.
+
+@anchor PydrakeDeprecation
+## Deprecation
+
+Decorators and utilites for deprecation in pure Python are available in
+[`pydrake.common.deprecation`](https://drake.mit.edu/pydrake/pydrake.common.deprecation.html).
+
+Deprecations for Python bindings in C++ are available in
+[`drake/bindings/pydrake/common/deprecation_pybind.h`](https://drake.mit.edu/doxygen_cxx/deprecation__pybind_8h.html).
+
+For examples of how to use the deprecations and what side effects they will
+have, please see:
+
+- [`drake/bindings/.../deprecation_example/`](https://github.com/RobotLocomotion/drake/tree/master/bindings/pydrake/common/test/deprecation_example)
+- [`drake/bindings/.../deprecation_test.py`](https://github.com/RobotLocomotion/drake/blob/master/bindings/pydrake/common/test/deprecation_test.py)
+
+@note All deprecations in Drake should ultimately use the
+[Python `warnings` module](https://docs.python.org/3.6/library/warnings.html),
+and the
+[`DrakeDeprecationWarning`](https://drake.mit.edu/pydrake/pydrake.common.deprecation.html#pydrake.common.deprecation.DrakeDeprecationWarning)
+class. The utilities mentioned above use them.
 
 @anchor PydrakeKeepAlive
 ## Keep Alive Behavior

--- a/doc/code_review_checklist.rst
+++ b/doc/code_review_checklist.rst
@@ -26,6 +26,10 @@ Is the code the minimal set of what you want?
   - If you are modifying an API, consider deprecating the old interface instead
     of migrating all call sites immediately.
 
+    - For deprecation, please see
+      `DRAKE_DEPRECATED <https://drake.mit.edu/doxygen_cxx/drake__deprecated_8h.html>`_ for C++
+      and `pydrake deprecation <https://drake.mit.edu/doxygen_cxx/group__python__bindings.html#PydrakeDeprecation>`_ for Python.
+
   - If you are introducing a new feature, consider adding only test cases
     now, and deferring the first application use to a follow-up PR.
 


### PR DESCRIPTION
Joe reached out to me about this, and I think it's the 5th time I've provided this link in about 1 month ;) Codifying it.

Also:
* We don't have a discoverable link from our code review checklist. I've added briefly links.
* If you go to `pydrake_doxygen.h`, it has no reference to the actual section. I've added the relevant `@ref`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13389)
<!-- Reviewable:end -->
