### PR TITLE
VIE Integrator should reset cached matrices when user changes Jacobian scheme

### DIFF
--- a/systems/analysis/implicit_euler_integrator.h
+++ b/systems/analysis/implicit_euler_integrator.h
@@ -110,6 +110,10 @@ class ImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
     return num_err_est_iter_factorizations_;
   }
 
+  void DoResetCachedJacobianRelatedMatrices() final {
+      ie_iteration_matrix_ = {};
+      itr_iteration_matrix_ = {};
+  }
   void DoResetImplicitIntegratorStatistics() final;
   static void ComputeAndFactorImplicitEulerIterationMatrix(
       const MatrixX<T>& J, const T& h,

--- a/systems/analysis/implicit_integrator.cc
+++ b/systems/analysis/implicit_integrator.cc
@@ -19,6 +19,14 @@ void ImplicitIntegrator<T>::DoResetStatistics() {
   DoResetImplicitIntegratorStatistics();
 }
 
+template <class T>
+void ImplicitIntegrator<T>::DoReset() {
+  J_.resize(0, 0);
+  DoResetCachedJacobianRelatedMatrices();
+  // Call any Reset() provided by child integrator classes.
+  DoImplicitIntegratorReset();
+}
+
 // Computes the Jacobian of the ordinary differential equations around time
 // and continuous state `(t, xt)` using automatic differentiation.
 // @param system The dynamical system.

--- a/systems/analysis/radau_integrator.h
+++ b/systems/analysis/radau_integrator.h
@@ -125,6 +125,10 @@ class RadauIntegrator final : public ImplicitIntegrator<T> {
   const VectorX<T>& ComputeFofZ(
       const T& t0, const T& h, const VectorX<T>& xt0, const VectorX<T>& Z);
   void DoInitialize() final;
+  void DoResetCachedJacobianRelatedMatrices() final {
+      iteration_matrix_radau_ = {};
+      iteration_matrix_implicit_trapezoid_ = {};
+  }
   void DoResetImplicitIntegratorStatistics() final;
   bool DoImplicitIntegratorStep(const T& h) final;
   bool StepRadau(const T& t0, const T& h, const VectorX<T>& xt0,

--- a/systems/analysis/simulator_print_stats.cc
+++ b/systems/analysis/simulator_print_stats.cc
@@ -54,6 +54,8 @@ void PrintSimulatorStatistics(const Simulator<double>& simulator) {
     fmt::print("Number of steps shrunk due to error control = {:d}\n",
                integrator.get_num_step_shrinkages_from_error_control());
   }
+  fmt::print("Number of derivative evaluations = {:d}\n",
+      integrator.get_num_derivative_evaluations());
 
   // These two statistics can only be nonzero with implicit integrators, but
   // because they're available in IntegratorBase, we print them for all

--- a/systems/analysis/test/implicit_integrator_test.cc
+++ b/systems/analysis/test/implicit_integrator_test.cc
@@ -23,6 +23,11 @@ class DummyImplicitIntegrator final : public ImplicitIntegrator<double> {
 
   using ImplicitIntegrator<double>::IsUpdateZero;
 
+  // Returns whether DoResetCachedMatrices() has been called.
+  bool get_has_reset_cached_matrices() {
+    return has_reset_cached_matrices_;
+  }
+
  private:
   // There is no stepping so no stats should accumulate.
   int64_t do_get_num_newton_raphson_iterations() const final { return 0; }
@@ -44,12 +49,18 @@ class DummyImplicitIntegrator final : public ImplicitIntegrator<double> {
     return 0;
   }
 
+  void DoResetCachedJacobianRelatedMatrices() final {
+    has_reset_cached_matrices_ = true;
+  }
+
   bool DoImplicitIntegratorStep(const double& h) override {
     throw std::logic_error("Dummy integrator not meant to be stepped.");
   }
+
+  bool has_reset_cached_matrices_{false};
 };
 
-GTEST_TEST(ImplicitIntegratortest, IsUpdateZero) {
+GTEST_TEST(ImplicitIntegratorTest, IsUpdateZero) {
   const double mass = 1.0;
   const double spring_k = 1.0;
   SpringMassSystem<double> dummy_system(spring_k, mass, false /* unforced */);
@@ -93,6 +104,37 @@ GTEST_TEST(ImplicitIntegratortest, IsUpdateZero) {
   EXPECT_FALSE(dummy_integrator.IsUpdateZero(xc, dxc, 0.0));
 }
 
+// This test verifies that if we change the Jacobian computation scheme from
+// the default scheme (kForwardDifference), then ImplicitIntegrator calls
+// DoResetCachedMatrices() to reset any cached matrices.
+GTEST_TEST(ImplicitIntegratorTest, SetComputationSchemeResetsCachedMatrices) {
+  const double mass = 1.0;
+  const double spring_k = 1.0;
+  SpringMassSystem<double> dummy_system(spring_k, mass, false /* unforced */);
+  std::unique_ptr<Context<double>> context =
+      dummy_system.CreateDefaultContext();
+  DummyImplicitIntegrator dummy_integrator(dummy_system, context.get());
+
+  // The default scheme should be kForwardDifference.
+  EXPECT_EQ(dummy_integrator.get_jacobian_computation_scheme(),
+            ImplicitIntegrator<double>
+            ::JacobianComputationScheme::kForwardDifference);
+
+  // Verify that DoResetCachedMatrices() has not been called yet.
+  EXPECT_FALSE(dummy_integrator.get_has_reset_cached_matrices());
+
+  // Set the scheme to something other than kForwardDifference.
+  dummy_integrator.set_jacobian_computation_scheme(
+      ImplicitIntegrator<double>::JacobianComputationScheme::kAutomatic);
+
+  // Verify that DoResetCachedMatrices() has been called.
+  EXPECT_TRUE(dummy_integrator.get_has_reset_cached_matrices());
+
+  // Verify that the scheme has been properly changed.
+  EXPECT_EQ(dummy_integrator.get_jacobian_computation_scheme(),
+            ImplicitIntegrator<double>
+            ::JacobianComputationScheme::kAutomatic);
+}
 }  // namespace
 }  // namespace systems
 }  // namespace drake

--- a/systems/analysis/test_utilities/implicit_integrator_test.h
+++ b/systems/analysis/test_utilities/implicit_integrator_test.h
@@ -223,16 +223,6 @@ class ImplicitIntegratorTest : public ::testing::Test {
     spring_mass_damper_->set_velocity(spring_mass_damper_context_.get(),
                                       initial_velocity);
 
-    // Initialize to reset cached Jacobians. This is necessary; otherwise, for
-    // some problems, the Jacobian may not be computed again because the
-    // previous one was good enough for Newton-Raphson to converge.
-    // TODO(antequ): This issue only exists for velocity-implicit Euler
-    // integrator; other implicit integrators reset their Jacobians in
-    // set_jacobian_computation_scheme(). Clear the velocity-implicit Euler
-    // integrator's Jacobian cache too in set_jacobian_computation_scheme(),
-    // and remove this call. See issue #13069.
-    integrator.Initialize();
-
     // Integrate for t_final seconds again.
     integrator.IntegrateWithMultipleStepsToTime(t_final);
     x_final = xc_final.GetAtIndex(0);
@@ -254,16 +244,6 @@ class ImplicitIntegratorTest : public ::testing::Test {
                                       initial_position);
     spring_mass_damper_->set_velocity(spring_mass_damper_context_.get(),
                                       initial_velocity);
-
-    // Initialize to reset cached Jacobians. This is necessary; otherwise, for
-    // some problems, the Jacobian may not be computed again because the
-    // previous one was good enough for Newton-Raphson to converge.
-    // TODO(antequ): This issue only exists for velocity-implicit Euler
-    // integrator; other implicit integrators reset their Jacobians in
-    // set_jacobian_computation_scheme(). Clear the velocity-implicit Euler
-    // integrator's Jacobian cache too in set_jacobian_computation_scheme(),
-    // and remove this call. See issue #13069.
-    integrator.Initialize();
 
     // Integrate for t_final seconds again.
     integrator.IntegrateWithMultipleStepsToTime(t_final);
@@ -354,16 +334,6 @@ class ImplicitIntegratorTest : public ::testing::Test {
     mod_spring_mass_damper_->set_velocity(
         mod_spring_mass_damper_context_.get(), initial_velocity);
 
-    // Initialize to reset cached Jacobians. This is necessary; otherwise, for
-    // some problems, the Jacobian may not be computed again because the
-    // previous one was good enough for Newton-Raphson to converge.
-    // TODO(antequ): This issue only exists for velocity-implicit Euler
-    // integrator; other implicit integrators reset their Jacobians in
-    // set_jacobian_computation_scheme(). Clear the velocity-implicit Euler
-    // integrator's Jacobian cache too in set_jacobian_computation_scheme(),
-    // and remove this call. See issue #13069.
-    integrator.Initialize();
-
     // Integrate again.
     integrator.IntegrateWithMultipleStepsToTime(t_final);
 
@@ -389,16 +359,6 @@ class ImplicitIntegratorTest : public ::testing::Test {
         mod_spring_mass_damper_context_.get(), initial_position);
     mod_spring_mass_damper_->set_velocity(
         mod_spring_mass_damper_context_.get(), initial_velocity);
-
-    // Initialize to reset cached Jacobians. This is necessary; otherwise, for
-    // some problems, the Jacobian may not be computed again because the
-    // previous one was good enough for Newton-Raphson to converge.
-    // TODO(antequ): This issue only exists for velocity-implicit Euler
-    // integrator; other implicit integrators reset their Jacobians in
-    // set_jacobian_computation_scheme(). Clear the velocity-implicit Euler
-    // integrator's Jacobian cache too in set_jacobian_computation_scheme(),
-    // and remove this call. See issue #13069.
-    integrator.Initialize();
 
     // Integrate again.
     integrator.IntegrateWithMultipleStepsToTime(t_final);
@@ -482,16 +442,6 @@ class ImplicitIntegratorTest : public ::testing::Test {
     spring_mass.set_position(context.get(), initial_position);
     spring_mass.set_velocity(context.get(), initial_velocity);
 
-    // Initialize to reset cached Jacobians. This is necessary; otherwise, for
-    // some problems, the Jacobian may not be computed again because the
-    // previous one was good enough for Newton-Raphson to converge.
-    // TODO(antequ): This issue only exists for velocity-implicit Euler
-    // integrator; other implicit integrators reset their Jacobians in
-    // set_jacobian_computation_scheme(). Clear the velocity-implicit Euler
-    // integrator's Jacobian cache too in set_jacobian_computation_scheme(),
-    // and remove this call. See issue #13069.
-    integrator.Initialize();
-
     // Integrate for t_final seconds again.
     integrator.IntegrateWithMultipleStepsToTime(t_final);
 
@@ -511,16 +461,6 @@ class ImplicitIntegratorTest : public ::testing::Test {
     context->SetTime(0.0);
     spring_mass.set_position(context.get(), initial_position);
     spring_mass.set_velocity(context.get(), initial_velocity);
-
-    // Initialize to reset cached Jacobians. This is necessary; otherwise, for
-    // some problems, the Jacobian may not be computed again because the
-    // previous one was good enough for Newton-Raphson to converge.
-    // TODO(antequ): This issue only exists for velocity-implicit Euler
-    // integrator; other implicit integrators reset their Jacobians in
-    // set_jacobian_computation_scheme(). Clear the velocity-implicit Euler
-    // integrator's Jacobian cache too in set_jacobian_computation_scheme(),
-    // and remove this call. See issue #13069.
-    integrator.Initialize();
 
     // Integrate for t_final seconds again.
     integrator.IntegrateWithMultipleStepsToTime(t_final);
@@ -950,16 +890,6 @@ TYPED_TEST_P(ImplicitIntegratorTest, Stationary) {
     integrator.set_target_accuracy(1e-3);
     integrator.request_initial_step_size_target(1e-3);
   }
-
-  // Initialize to reset cached Jacobians. This is necessary; otherwise, for
-  // some problems, the Jacobian may not be computed again because the
-  // previous one was good enough for Newton-Raphson to converge.
-  // TODO(antequ): This issue only exists for velocity-implicit Euler
-  // integrator; other implicit integrators reset their Jacobians in
-  // set_jacobian_computation_scheme(). Clear the velocity-implicit Euler
-  // integrator's Jacobian cache too in set_jacobian_computation_scheme(),
-  // and remove this call. See issue #13069.
-  integrator.Initialize();
 
   // Integrate the system
   integrator.IntegrateWithMultipleStepsToTime(1.0);

--- a/systems/analysis/velocity_implicit_euler_integrator.h
+++ b/systems/analysis/velocity_implicit_euler_integrator.h
@@ -325,6 +325,11 @@ class VelocityImplicitEulerIntegrator final : public ImplicitIntegrator<T> {
            num_half_vie_iter_factorizations_;
   }
 
+  void DoResetCachedJacobianRelatedMatrices() final {
+      Jy_vie_.resize(0, 0);
+      iteration_matrix_vie_ = {};
+  }
+
   void DoResetImplicitIntegratorStatistics() final;
 
   static void ComputeAndFactorImplicitEulerIterationMatrix(


### PR DESCRIPTION
VIE Integrator should reset cached matrices when user changes Jacobian scheme
1) This commit fixes issue #13069, where the VelocityImplicitEulerIntegrator still keeps an old Jacobian after the computation scheme changes.
2) This change also adds a line to simulator print stats to print the number of derivative evaluations for explicit integrators; otherwise, there is no metric on how much work explicit integrators are performing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13392)
<!-- Reviewable:end -->
