### PR TITLE
Add parsing of string options to SNOPT.

### DIFF
--- a/solvers/snopt_solver.cc
+++ b/solvers/snopt_solver.cc
@@ -194,6 +194,11 @@ struct SnoptImpl<false> {
       Int* iw, int leniw, double* rw, int lenrw) {
     ::f_snsetr(buffer, &len, &rvalue, errors, iw, &leniw, rw, &lenrw);
   }
+  template <typename Int>
+  static void snset(const char* buffer, int len, int* errors,
+      Int* iw, int leniw, double* rw, int lenrw) {
+    ::f_snset(buffer, &len, errors, iw, &leniw, rw, &lenrw);
+  }
 };
 
 // Choose the correct SnoptImpl specialization.
@@ -1022,7 +1027,6 @@ void SolveWithGivenOptions(
         option_string.c_str(), option_string.length(), &errors,
         storage.iw(), storage.leniw(),
         storage.rw(), storage.lenrw());
-    }
   }
 
   int Cold = 0;

--- a/solvers/snopt_solver.cc
+++ b/solvers/snopt_solver.cc
@@ -1014,11 +1014,14 @@ void SolveWithGivenOptions(
   for (const auto& it : snopt_options_string) {
     int errors = 0;
     auto option_string = it.first + " " + it.second;
-    if (it.first.compare("Print file")) {
-      Snopt::snset(
-          option_string.c_str(), option_string.length(), &errors,
-          storage.iw(), storage.leniw(),
-          storage.rw(), storage.lenrw());
+    if (it.first == "Print file") {
+      // Already handled during sninit, above
+      continue;
+    }
+    Snopt::snset(
+        option_string.c_str(), option_string.length(), &errors,
+        storage.iw(), storage.leniw(),
+        storage.rw(), storage.lenrw());
     }
   }
 

--- a/solvers/snopt_solver.cc
+++ b/solvers/snopt_solver.cc
@@ -100,6 +100,7 @@ struct SnoptImpl<true> {
   static constexpr auto snmema = ::f_snmema;
   static constexpr auto snseti = ::f_snseti;
   static constexpr auto snsetr = ::f_snsetr;
+  static constexpr auto snset = ::f_snset;
 #pragma GCC diagnostic pop
 };
 
@@ -1008,6 +1009,17 @@ void SolveWithGivenOptions(
         storage.iw(), storage.leniw(),
         storage.rw(), storage.lenrw());
     // TODO(hongkai.dai): report the error in SnoptSolverDetails.
+  }
+
+  for (const auto& it : snopt_options_string) {
+    int errors = 0;
+    auto option_string = it.first + " " + it.second;
+    if (it.first.compare("Print file")) {
+      Snopt::snset(
+          option_string.c_str(), option_string.length(), &errors,
+          storage.iw(), storage.leniw(),
+          storage.rw(), storage.lenrw());
+    }
   }
 
   int Cold = 0;

--- a/solvers/test/snopt_solver_test.cc
+++ b/solvers/test/snopt_solver_test.cc
@@ -148,6 +148,32 @@ GTEST_TEST(SnoptTest, TestPrintFile) {
   EXPECT_TRUE(filesystem::exists({print_file}));
 }
 
+GTEST_TEST(SnoptTest, TestStringOption) {
+  const SnoptSolver solver;
+
+  MathematicalProgram prog_minimize;
+  const auto x_minimize = prog_minimize.NewContinuousVariables<1>();
+  prog_minimize.AddLinearConstraint(x_minimize(0) <= 1);
+  prog_minimize.AddLinearConstraint(x_minimize(0) >= -1);
+  prog_minimize.AddLinearCost(x_minimize(0));
+
+
+  prog_minimize.SetSolverOption(SnoptSolver::id(), "Minimize", "");
+  auto result_minimize = solver.Solve(prog_minimize, {}, {});
+  EXPECT_TRUE(result_minimize.get_optimal_cost() == -1);
+
+  MathematicalProgram prog_maximize;
+  const auto x_maximize = prog_maximize.NewContinuousVariables<1>();
+  prog_maximize.AddLinearConstraint(x_maximize(0) <= 1);
+  prog_maximize.AddLinearConstraint(x_maximize(0) >= -1);
+  prog_maximize.AddLinearCost(x_maximize(0));
+
+
+  prog_maximize.SetSolverOption(SnoptSolver::id(), "Maximize", "");
+  auto result_maximize = solver.Solve(prog_maximize, {}, {});
+  EXPECT_TRUE(result_maximize.get_optimal_cost() == 1);  
+}
+
 GTEST_TEST(SnoptTest, TestSparseCost) {
   // Test nonlinear optimization problem, whose cost has sparse gradient.
   MathematicalProgram prog;

--- a/solvers/test/snopt_solver_test.cc
+++ b/solvers/test/snopt_solver_test.cc
@@ -160,7 +160,7 @@ GTEST_TEST(SnoptTest, TestStringOption) {
 
   prog_minimize.SetSolverOption(SnoptSolver::id(), "Minimize", "");
   auto result_minimize = solver.Solve(prog_minimize, {}, {});
-  EXPECT_TRUE(result_minimize.get_optimal_cost() == -1);
+  EXPECT_EQ(result_minimize.get_optimal_cost(), -1);
 
   MathematicalProgram prog_maximize;
   const auto x_maximize = prog_maximize.NewContinuousVariables<1>();
@@ -171,7 +171,7 @@ GTEST_TEST(SnoptTest, TestStringOption) {
 
   prog_maximize.SetSolverOption(SnoptSolver::id(), "Maximize", "");
   auto result_maximize = solver.Solve(prog_maximize, {}, {});
-  EXPECT_TRUE(result_maximize.get_optimal_cost() == 1);  
+  EXPECT_EQ(result_maximize.get_optimal_cost(), 1);
 }
 
 GTEST_TEST(SnoptTest, TestSparseCost) {


### PR DESCRIPTION
Quick addition, adding use of SNOPT's `snset` to set string values. I wasn't sure if a 7.4 workaround was also needed, like some of the other methods, and so did not add that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13397)
<!-- Reviewable:end -->
