### PR TITLE
Changed tools/workspace/drake_visualizer visibility to public.

### DIFF
--- a/tools/workspace/drake_visualizer/BUILD.bazel
+++ b/tools/workspace/drake_visualizer/BUILD.bazel
@@ -11,17 +11,17 @@ load(
 )
 load("//tools/skylark:test_tags.bzl", "vtk_test_tags")
 
+package(default_visibility = ["//visibility:public"])
+
 exports_files(
     # To be consumed by `//tools:drake_visualizer_py`.
     ["drake_visualizer_bazel.py"],
-    visibility = ["//tools:__pkg__"],
 )
 
 # TODO(eric.cousineau): Merge this with `drake_visualizer_py` once it moves
 # from `//tools` to here.
 py_library(
     name = "builtin_scripts_py",
-    visibility = ["//tools:__pkg__"],
     deps = [
         "//tools/workspace/drake_visualizer/_drake_visualizer_builtin_scripts",
     ],
@@ -37,7 +37,6 @@ py_library(
 py_library(
     name = "stub_pydrake",
     srcs = ["stub/pydrake/__init__.py"],
-    visibility = ["//tools:__pkg__"],
 )
 
 # TODO(eric.cousineau): Use something simpler than cmake_configure_file to do


### PR DESCRIPTION
This is to support external use of drake_visualizer, specifically to enable running visualizer with both drake and external dependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13401)
<!-- Reviewable:end -->
