### PR TITLE
py cpp_template: Fix badly scoped name overrides

### DIFF
--- a/bindings/pydrake/__init__.py
+++ b/bindings/pydrake/__init__.py
@@ -53,6 +53,9 @@ def getDrakePath():
 def _execute_extra_python_code(m):
     # See `ExecuteExtraPythonCode` in `pydrake_pybind.h` for usage details and
     # rationale.
+    if m.__name__ not in sys.modules:
+        # N.B. This is necessary for C++ extensions in Python 3.
+        sys.modules[m.__name__] = m
     module_path = m.__name__.split(".")
     if len(module_path) == 1:
         raise RuntimeError((

--- a/bindings/pydrake/common/cpp_template.py
+++ b/bindings/pydrake/common/cpp_template.py
@@ -252,7 +252,7 @@ class TemplateBase(object):
         return instantiation
 
     @classmethod
-    def define(cls, name, param_list, *args, **kwargs):
+    def define(cls, name, param_list, *args, scope=None, **kwargs):
         """Provides a decorator for functions that defines a template using
         `name`. The template instantiations are added using
         `add_instantiations`, where the instantiation function is the decorated
@@ -282,7 +282,9 @@ class TemplateBase(object):
                             self.T = T
                     return Impl
         """
-        template = cls(name, *args, **kwargs)
+        if scope is None:
+            scope = _get_module_from_stack()
+        template = cls(name, *args, scope=scope, **kwargs)
 
         def decorator(instantiation_func):
             template.add_instantiations(instantiation_func, param_list)

--- a/bindings/pydrake/common/test/cpp_template_test.py
+++ b/bindings/pydrake/common/test/cpp_template_test.py
@@ -132,6 +132,8 @@ class TestCppTemplate(unittest.TestCase):
 
             return Impl
 
+        self.assertEqual(
+            str(MyTemplate), f"<TemplateClass {_TEST_MODULE}.MyTemplate>")
         self.assertIsInstance(MyTemplate, m.TemplateClass)
         MyDefault = MyTemplate[None]
         MyInt = MyTemplate[int]

--- a/bindings/pydrake/systems/scalar_conversion.py
+++ b/bindings/pydrake/systems/scalar_conversion.py
@@ -110,7 +110,8 @@ class TemplateSystem(TemplateClass):
         self._converter = self._make_converter()
 
     @classmethod
-    def define(cls, name, T_list=None, T_pairs=None, *args, **kwargs):
+    def define(
+            cls, name, T_list=None, T_pairs=None, *args, scope=None, **kwargs):
         """Provides a decorator which can be used define a scalar-type
         convertible System as a template.
 
@@ -126,7 +127,9 @@ class TemplateSystem(TemplateClass):
             args, kwargs: These are passed to the constructor of
                 ``TemplateSystem``.
         """
-        template = cls(name, T_list, T_pairs, *args, **kwargs)
+        if scope is None:
+            scope = _get_module_from_stack()
+        template = cls(name, T_list, T_pairs, *args, scope=scope, **kwargs)
         param_list = [(T,) for T in template._T_list]
 
         def decorator(instantiation_func):

--- a/bindings/pydrake/systems/test/scalar_conversion_test.py
+++ b/bindings/pydrake/systems/test/scalar_conversion_test.py
@@ -58,6 +58,8 @@ class TestScalarConversion(unittest.TestCase):
         """Tests the Example_ system."""
         # Test template.
         self.assertIsInstance(Example_, TemplateClass)
+        self.assertEqual(
+            str(Example_), f"<TemplateSystem {__name__}.Example_>")
         self.assertIs(Example_[float], Example)
 
         # Test parameters.
@@ -68,7 +70,7 @@ class TestScalarConversion(unittest.TestCase):
             system_T = Example_[T](0)
             self.assertEqual(
                 system_T.GetSystemType(),
-                f"pydrake.systems.scalar_conversion.Example_[{T.__name__}]")
+                f"{__name__}.Example_[{T.__name__}]")
 
         # Test private properties (do NOT use these in your code!).
         self.assertTupleEqual(


### PR DESCRIPTION
Towards #13407

Resolves #11706

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13409)
<!-- Reviewable:end -->
