### PR TITLE
py cpp_template: Enable deprecating instantiations

### DIFF
--- a/bindings/pydrake/common/BUILD.bazel
+++ b/bindings/pydrake/common/BUILD.bazel
@@ -465,7 +465,7 @@ drake_py_unittest(
     name = "cpp_template_test",
     deps = [
         ":cpp_template_py",
-        "//bindings/pydrake/common/test_utilities:pickle_compare_py",
+        "//bindings/pydrake/common/test_utilities",
     ],
 )
 


### PR DESCRIPTION
Towards #13407 (PR)

Necessary to deprecate (the, uh, misspelled) `VectorExternallyAppliedSpatialForced` opaque binding.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13410)
<!-- Reviewable:end -->
