### PR TITLE
Disable global_inverse_kinematics_feasible_posture_test in debug

### DIFF
--- a/attic/multibody/dev/BUILD.bazel
+++ b/attic/multibody/dev/BUILD.bazel
@@ -84,6 +84,8 @@ drake_cc_googletest(
     name = "global_inverse_kinematics_feasible_posture_test",
     timeout = "long",
     srcs = ["test/global_inverse_kinematics_feasible_posture_test.cc"],
+    # This test is prohibitively slow with --compilation_mode=dbg.
+    disable_in_compilation_mode_dbg = True,
     tags = gurobi_test_tags() + [
         "no_asan",
         # Takes too long to run with Valgrind.


### PR DESCRIPTION
After #13377, this test consistently times out for everything-debug builds. As it is
"attic + dev" code, switch off the test for debug builds.

Examples of failing builds:
https://drake-jenkins.csail.mit.edu/job/linux-bionic-clang-bazel-continuous-everything-debug/2246/
https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-bionic-gcc-bazel-continuous-everything-debug/2250/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13412)
<!-- Reviewable:end -->
