### PR TITLE
parsing: Work around some GCC 8 maybe-uninitialized warnings

### DIFF
--- a/multibody/parsing/detail_scene_graph.cc
+++ b/multibody/parsing/detail_scene_graph.cc
@@ -384,11 +384,11 @@ ProximityProperties MakeProximityPropertiesForCollision(
   if (drake_element != nullptr) {
     auto read_double =
         [drake_element](const char* element_name) -> std::optional<double> {
+      std::optional<double> result;
       if (MaybeGetChildElement(*drake_element, element_name) != nullptr) {
-        return GetChildElementValue<double>(*drake_element,
-                                                   element_name);
+        result = GetChildElementValue<double>(*drake_element, element_name);
       }
-      return {};
+      return result;
     };
 
     const bool is_rigid = drake_element->HasElement("drake:rigid_hydroelastic");

--- a/multibody/parsing/detail_urdf_geometry.cc
+++ b/multibody/parsing/detail_urdf_geometry.cc
@@ -523,12 +523,13 @@ geometry::GeometryInstance ParseCollision(
   if (drake_element) {
     auto read_double =
         [drake_element](const char* element_name) -> std::optional<double> {
+      std::optional<double> result;
       const XMLElement* value_node =
           drake_element->FirstChildElement(element_name);
       if (value_node != nullptr) {
         double value{};
         if (ParseScalarAttribute(value_node, "value", &value)) {
-          return value;
+          result = value;
         } else {
           throw std::runtime_error(
               fmt::format("Unable to read the 'value' attribute for the <{}> "
@@ -536,7 +537,7 @@ geometry::GeometryInstance ParseCollision(
                           element_name, value_node->GetLineNum()));
         }
       }
-      return {};
+      return result;
     };
 
     const XMLElement* const rigid_element =

--- a/multibody/parsing/test/detail_common_test.cc
+++ b/multibody/parsing/test/detail_common_test.cc
@@ -31,8 +31,7 @@ optional<double> empty_read_double(const char*) { return {}; }
 ReadDoubleFunc param_read_double(
     const std::string& tag, double value) {
   return [&tag, value](const char* name) -> optional<double> {
-    if (tag == name) return value;
-    return {};
+    return (tag == name) ? optional<double>(value) : std::nullopt;
   };
 }
 
@@ -179,12 +178,13 @@ GTEST_TEST(ParseProximityPropertiesTest, Friction) {
   auto friction_read_double = [](optional<double> mu_d,
       optional<double> mu_s) -> ReadDoubleFunc {
     return [mu_d, mu_s](const char* name) -> optional<double> {
+      optional<double> result;
       if (mu_d.has_value() && std::string("drake:mu_dynamic") == name) {
-        return *mu_d;
+        result = *mu_d;
       } else if (mu_s.has_value() && std::string("drake:mu_static") == name) {
-        return *mu_s;
+        result = *mu_s;
       }
-      return {};
+      return result;
     };
   };
 


### PR DESCRIPTION
Use NVRO (or RVO) in lambdas to avoid false positives on `std::optional` initialization.

The warnings are visible at [linux-focal-unprovisioned-gcc-bazel-continuous-release](https://drake-jenkins.csail.mit.edu/view/Linux%20Focal%20Unprovisioned/job/linux-focal-unprovisioned-gcc-bazel-continuous-release/) until this PR merges.

Closes #13367.
Relates #13102.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13418)
<!-- Reviewable:end -->
