### PR TITLE
pybind: Allow specifying copts

### DIFF
--- a/tools/skylark/pybind.bzl
+++ b/tools/skylark/pybind.bzl
@@ -246,6 +246,7 @@ def drake_pybind_cc_googletest(
         name,
         cc_srcs = [],
         cc_deps = [],
+        cc_copts = [],
         py_srcs = [],
         py_deps = [],
         args = [],
@@ -265,6 +266,7 @@ def drake_pybind_cc_googletest(
             "@pybind11",
             "@python//:python_direct_link",
         ],
+        copts = cc_copts,
         use_default_main = False,
         # Add 'manual', because we only want to run it with Python present.
         tags = ["manual"] + tags,


### PR DESCRIPTION
Useful for passing `copts = ["-g", "-UNDEBUG"]`

Towards #13408

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13419)
<!-- Reviewable:end -->
