### PR TITLE
drake_visualizer: Remove stub/pydrake

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -28,7 +28,6 @@ py_binary(
     deps = [
         "//lcmtypes:lcmtypes_drake_py",
         "//tools/workspace/drake_visualizer:builtin_scripts_py",
-        "//tools/workspace/drake_visualizer:stub_pydrake",
         "@drake_visualizer//:drake_visualizer_python_deps",
         "@optitrack_driver//lcmtypes:py_optitrack_lcmtypes",
     ],

--- a/tools/workspace/drake_visualizer/BUILD.bazel
+++ b/tools/workspace/drake_visualizer/BUILD.bazel
@@ -27,19 +27,6 @@ py_library(
     ],
 )
 
-# When developing within Drake, we don't want //tools:drake_visualizer to
-# depend on the entire pydrake library, because that adds a dependency on a
-# whole bunch of C++ code that is irrelevant for the visualizer.  So, here we
-# provide a small stub version of pydrake with only getDrakePath implemented
-# (the only piece drake_visualizer needs).  Note that the installed version of
-# drake-visualizer *does* use the installed (full) version of pydrake -- this
-# is development-sandbox-only stub.
-py_library(
-    name = "stub_pydrake",
-    srcs = ["stub/pydrake/__init__.py"],
-    visibility = ["//tools:__pkg__"],
-)
-
 # TODO(eric.cousineau): Use something simpler than cmake_configure_file to do
 # basic subsitutions as a genrule.
 cmake_configure_file(

--- a/tools/workspace/drake_visualizer/drake_visualizer_bazel.py
+++ b/tools/workspace/drake_visualizer/drake_visualizer_bazel.py
@@ -47,15 +47,6 @@ def main():
         "This must be called by a script generated using the "
         "`drake_runfiles_binary` macro.")
 
-    # Stub out pydrake (refer to our ./BUILD.bazel comments for rationale).
-    #
-    # We add it to PYTHONPATH within the script, rather than
-    # `imports = ["stub"]` on the stub py_library, to avoid any other target
-    # accidentally pulling in the stubbed pydrake onto its PYTHONPATH.  Only
-    # the visualizer, when launched via this wrapper script, should employ the
-    # stub.
-    prepend_path("PYTHONPATH", "tools/workspace/drake_visualizer/stub")
-
     # Don't use DRAKE_RESOURCE_ROOT; the stub getDrakePath should always win.
     # This also placates the drake-visualizer logic that puts it into Director
     # mode when DRAKE_RESOURCE_ROOT is set (thus requiring more than just

--- a/tools/workspace/drake_visualizer/stub/pydrake/__init__.py
+++ b/tools/workspace/drake_visualizer/stub/pydrake/__init__.py
@@ -1,9 +1,0 @@
-# Refer to ../../BUILD.bazel comments for rationale.
-
-import os
-
-
-def getDrakePath():
-    # Because //tools:drake_visualizer is a drake_runfiles_binary, the correct
-    # answer to getDrakePath is always the runfiles root.  Nice!
-    return os.environ["DRAKE_BAZEL_RUNFILES"]


### PR DESCRIPTION
I think this made sense with Python 2.7 and Python 3 were around together. Now that we only have one, I find this to occasionally get in my way. I have hacks in Anzu that works around this; am willing to talk about it more.

PR for discussion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13421)
<!-- Reviewable:end -->
