### PR TITLE
Implements spatial velocity and acceleration ports

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -688,7 +688,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
             overload_cast_explicit<const systems::InputPort<T>&,
                 multibody::ModelInstanceIndex>(
                 &Class::get_actuation_input_port),
-            py_reference_internal, cls_doc.get_actuation_input_port.doc_1args)
+            py::arg("model_instance"), py_reference_internal,
+            cls_doc.get_actuation_input_port.doc_1args)
         .def("get_applied_generalized_force_input_port",
             overload_cast_explicit<const systems::InputPort<T>&>(
                 &Class::get_applied_generalized_force_input_port),
@@ -703,6 +704,16 @@ void DoScalarDependentDefinitions(py::module m, T) {
             overload_cast_explicit<const systems::OutputPort<T>&>(
                 &Class::get_body_poses_output_port),
             py_reference_internal, cls_doc.get_body_poses_output_port.doc)
+        .def("get_body_spatial_velocities_output_port",
+            overload_cast_explicit<const systems::OutputPort<T>&>(
+                &Class::get_body_spatial_velocities_output_port),
+            py_reference_internal,
+            cls_doc.get_body_spatial_velocities_output_port.doc)
+        .def("get_body_spatial_accelerations_output_port",
+            overload_cast_explicit<const systems::OutputPort<T>&>(
+                &Class::get_body_spatial_accelerations_output_port),
+            py_reference_internal,
+            cls_doc.get_body_spatial_accelerations_output_port.doc)
         .def("get_state_output_port",
             overload_cast_explicit<const systems::OutputPort<T>&>(
                 &Class::get_state_output_port),
@@ -710,7 +721,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("get_state_output_port",
             overload_cast_explicit<const systems::OutputPort<T>&,
                 multibody::ModelInstanceIndex>(&Class::get_state_output_port),
-            py_reference_internal, cls_doc.get_state_output_port.doc_1args)
+            py::arg("model_instance"), py_reference_internal,
+            cls_doc.get_state_output_port.doc_1args)
         .def("get_generalized_acceleration_output_port",
             overload_cast_explicit<const systems::OutputPort<T>&>(
                 &Class::get_generalized_acceleration_output_port),

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -653,6 +653,8 @@ class TestPlant(unittest.TestCase):
 
     @numpy_compare.check_all_types
     def test_model_instance_port_access(self, T):
+        # N.B. We actually test the values because some of the value bindings
+        # are somewhat special snowflakes.
         MultibodyPlant = MultibodyPlant_[T]
         InputPort = InputPort_[T]
         OutputPort = OutputPort_[T]
@@ -676,21 +678,51 @@ class TestPlant(unittest.TestCase):
             file_name=wsg50_sdf_path, model_name='gripper')
         plant_f.Finalize()
         plant = to_type(plant_f, T)
+        models = [iiwa_model, gripper_model]
 
-        # Test that we can get the input and output ports.
-        self.assertIsInstance(
-            plant.get_actuation_input_port(iiwa_model), InputPort)
-        self.assertIsInstance(
-            plant.get_state_output_port(gripper_model), OutputPort)
-        self.assertIsInstance(
-            plant.get_generalized_acceleration_output_port(
-                model_instance=gripper_model),
-            OutputPort)
-        self.assertIsInstance(
-            plant.get_generalized_contact_forces_output_port(
-                model_instance=gripper_model),
-            OutputPort)
-        self.assertIsInstance(plant.get_body_poses_output_port(), OutputPort)
+        # Fix inputs.
+        context = plant.CreateDefaultContext()
+        for model in models:
+            nu = plant.num_actuated_dofs(model)
+            plant.get_actuation_input_port(model_instance=model).FixValue(
+                context, np.zeros(nu))
+
+        # Evaluate outputs.
+        for model in models:
+            self.assertIsInstance(
+                plant.get_state_output_port(
+                    model_instance=model).Eval(context),
+                np.ndarray)
+            if T == Expression:
+                continue
+            self.assertIsInstance(
+                plant.get_generalized_acceleration_output_port(
+                    model_instance=model).Eval(context),
+                np.ndarray)
+            self.assertIsInstance(
+                plant.get_generalized_contact_forces_output_port(
+                    model_instance=model).Eval(context),
+                np.ndarray)
+
+        def check_output_port_that_cannot_be_used_in_python(port):
+            self.assertIsInstance(port, OutputPort)
+            if T == Expression:
+                return
+            with self.assertRaises(RuntimeError) as cm:
+                port.Eval(context)
+            self.assertIn("`get_value` cannot be called", str(cm.exception))
+
+        # TODO(eric.cousineau): Make `Value[List[T]]` work so we can test Eval
+        # for these items (#13387). Currently, these ports cannot be used for
+        # Python systems.
+        check_output_port_that_cannot_be_used_in_python(
+            plant.get_body_poses_output_port())
+        check_output_port_that_cannot_be_used_in_python(
+            plant.get_body_spatial_velocities_output_port())
+        check_output_port_that_cannot_be_used_in_python(
+            plant.get_body_spatial_accelerations_output_port())
+        # TODO(eric.cousineau): Merge `check_applied_force_input_ports` into
+        # this test.
 
     @TemplateSystem.define("AppliedForceTestSystem_")
     def AppliedForceTestSystem_(T):

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -109,6 +109,8 @@ enum class ContactModel {
 ///   @input_port{<span style="color:green">geometry_query</span>},
 ///   @output_port{continuous_state}
 ///   @output_port{body_poses}
+///   @output_port{body_spatial_velocities}
+///   @output_port{body_spatial_accelerations}
 ///   @output_port{generalized_acceleration}
 ///   @output_port{reaction_forces}
 ///   @output_port{contact_results}
@@ -424,7 +426,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// You can obtain the pose `X_WB` of a body B in the world frame W with:
   /// @code
   ///   const auto& X_WB_all = plant.get_body_poses_output_port().
-  ///       .Eval<std::vector<math::RigidTransform<double>>(plant_context);
+  ///       .Eval<std::vector<math::RigidTransform<double>>>(plant_context);
   ///   const BodyIndex arm_body_index = plant.GetBodyByName("arm").index();
   ///   const math::RigidTransform<double>& X_WArm = X_WB_all[arm_body_index];
   /// @endcode
@@ -432,7 +434,42 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// is indexed by BodyIndex, and it has size num_bodies().
   /// BodyIndex "zero" (0) always corresponds to the world body, with pose
   /// equal to the identity at all times.
+  /// @throws std::exception if called pre-finalize.
   const systems::OutputPort<T>& get_body_poses_output_port() const;
+
+  /// Returns the output port of all body spatial velocities in the world frame.
+  /// You can obtain the spatial velocity `V_WB` of a body B in the world frame
+  /// W with:
+  /// @code
+  ///   const auto& V_WB_all = plant.get_body_spatial_velocities_output_port().
+  ///       .Eval<std::vector<SpatialVelocity<double>>>(plant_context);
+  ///   const BodyIndex arm_body_index = plant.GetBodyByName("arm").index();
+  ///   const SpatialVelocity<double>& V_WArm = V_WB_all[arm_body_index];
+  /// @endcode
+  /// As shown in the example above, the resulting `std::vector` of body spatial
+  /// velocities is indexed by BodyIndex, and it has size num_bodies().
+  /// BodyIndex "zero" (0) always corresponds to the world body, with zero
+  /// spatial velocity at all times.
+  /// @throws std::exception if called pre-finalize.
+  const systems::OutputPort<T>& get_body_spatial_velocities_output_port() const;
+
+  /// Returns the output port of all body spatial accelerations in the world
+  /// frame. You can obtain the spatial acceleration `A_WB` of a body B in the
+  /// world frame W with:
+  /// @code
+  ///   const auto& A_WB_all =
+  ///   plant.get_body_spatial_accelerations_output_port().
+  ///       .Eval<std::vector<SpatialAcceleration<double>>>(plant_context);
+  ///   const BodyIndex arm_body_index = plant.GetBodyByName("arm").index();
+  ///   const SpatialVelocity<double>& A_WArm = A_WB_all[arm_body_index];
+  /// @endcode
+  /// As shown in the example above, the resulting `std::vector` of body spatial
+  /// accelerations is indexed by BodyIndex, and it has size num_bodies().
+  /// BodyIndex "zero" (0) always corresponds to the world body, with zero
+  /// spatial acceleration at all times.
+  /// @throws std::exception if called pre-finalize.
+  const systems::OutputPort<T>& get_body_spatial_accelerations_output_port()
+      const;
 
   /// Returns a constant reference to the input port for external actuation for
   /// a specific model instance.  This input port is a vector valued port, which
@@ -3650,6 +3687,13 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   void CalcForwardDynamics(const systems::Context<T>& context,
                            internal::AccelerationKinematicsCache<T>* ac) const;
 
+  // Discrete system version of CalcForwardDynamics(). This method does not use
+  // O(n) forward dynamics but the discrete TAMSI solver, for further details
+  // please refer to @ref castro_etal_2019 "[Castro et al., 2019]"
+  void CalcForwardDynamicsDiscrete(
+      const drake::systems::Context<T>& context,
+      internal::AccelerationKinematicsCache<T>* ac) const;
+
   // Eval version of the method CalcForwardDynamics().
   const internal::AccelerationKinematicsCache<T>& EvalForwardDynamics(
       const systems::Context<T>& context) const {
@@ -3797,14 +3841,6 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   void CalcGeneralizedAccelerations(const drake::systems::Context<T>& context,
                                     VectorX<T>* vdot) const;
 
-  // Discrete system version of CalcGeneralizedAccelerations().
-  void CalcGeneralizedAccelerationsDiscrete(
-      const drake::systems::Context<T>& context, VectorX<T>* vdot) const;
-
-  // Continuous system version of CalcGeneralizedAccelerations().
-  void CalcGeneralizedAccelerationsContinuous(
-      const drake::systems::Context<T>& context, VectorX<T>* vdot) const;
-
   // Eval() version of the method CalcGeneralizedAccelerations().
   const VectorX<T>& EvalGeneralizedAccelerations(
       const systems::Context<T>& context) const {
@@ -3881,6 +3917,18 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   void CalcBodyPosesOutput(
       const systems::Context<T>& context,
       std::vector<math::RigidTransform<T>>* X_WB_all) const;
+
+  // Evaluates the spatial velocity V_WB of each body in the model and copies it
+  // into V_WB_all, indexed by BodyIndex.
+  void CalcBodySpatialVelocitiesOutput(
+      const systems::Context<T>& context,
+      std::vector<SpatialVelocity<T>>* V_WB_all) const;
+
+  // Evaluates the spatial acceleration A_WB of each body in the model and
+  // copies it into A_WB_all, indexed by BodyIndex.
+  void CalcBodySpatialAccelerationsOutput(
+      const systems::Context<T>& context,
+      std::vector<SpatialAcceleration<T>>* A_WB_all) const;
 
   // Method to compute spatial contact forces for continuous plants.
   void CalcSpatialContactForcesContinuous(
@@ -4234,8 +4282,10 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // Port for externally applied spatial forces F.
   systems::InputPortIndex applied_spatial_force_input_port_;
 
-  // Port for the pose of all bodies in the model.
+  // Ports for spatial kinematics.
   systems::OutputPortIndex body_poses_port_;
+  systems::OutputPortIndex body_spatial_velocities_port_;
+  systems::OutputPortIndex body_spatial_accelerations_port_;
 
   // A port presenting state x=[q v] for the whole system, and a vector of
   // ports presenting state subsets xᵢ=[qᵢ vᵢ] ⊆ x for each model instance i,

--- a/multibody/plant/test/frame_kinematics_test.cc
+++ b/multibody/plant/test/frame_kinematics_test.cc
@@ -32,7 +32,7 @@ TEST_F(KukaIiwaModelTests, FramesKinematics) {
       X_WH.GetAsMatrix34(), X_WH_expected.GetAsMatrix34(),
       kTolerance, MatrixCompareType::relative));
 
-  // Alternative, we can get the pose X_WE using the plant's output port for
+  // Alternatively, we can get the pose X_WE using the plant's output port for
   // poses.
   const auto& X_WB_all =
       plant_->get_body_poses_output_port()
@@ -86,6 +86,16 @@ TEST_F(KukaIiwaModelTests, FramesKinematics) {
   EXPECT_TRUE(CompareMatrices(
       V_WH.get_coeffs(), V_WH_expected.get_coeffs(),
       kTolerance, MatrixCompareType::relative));
+
+  // Alternatively, we can get the spatial velocity V_WE using the plant's
+  // output port for spatial velocities.
+  const auto& V_WB_all =
+      plant_->get_body_spatial_velocities_output_port()
+          .Eval<std::vector<SpatialVelocity<double>>>(*context_);
+  ASSERT_EQ(V_WB_all.size(), plant_->num_bodies());
+  const SpatialVelocity<double>& V_WE_from_port =
+      V_WB_all[end_effector_link_->index()];
+  EXPECT_EQ(V_WE.get_coeffs(), V_WE_from_port.get_coeffs());
 
   // Spatial velocity of link 3 measured in the H frame and expressed in the
   // end-effector frame E.

--- a/multibody/plant/test/multibody_plant_reaction_forces_test.cc
+++ b/multibody/plant/test/multibody_plant_reaction_forces_test.cc
@@ -328,7 +328,7 @@ class SpinningRodTest : public ::testing::Test {
     const SpatialInertia<double> M_BBo_B(
         kMass, Vector3d::Zero(),
         UnitInertia<double>::ThinRod(kLength, Vector3d::UnitZ()));
-    const RigidBody<double>& rod = plant_->AddRigidBody("rod", M_BBo_B);
+    rod_ = &plant_->AddRigidBody("rod", M_BBo_B);
 
     // Notice that axis Bz is aligned with the rod. We want to define frame Jb
     // on body B at the attachment point to have its z axis aligned with the
@@ -337,7 +337,7 @@ class SpinningRodTest : public ::testing::Test {
     const RigidTransformd X_BJb(RollPitchYawd(M_PI_2, 0.0, 0.0),
                                 Vector3d(0.0, 0.0, -kLength / 2.0));
     pin_ = &plant_->AddJoint<RevoluteJoint>("pin", plant_->world_body(), {},
-                                            rod, X_BJb, Vector3d::UnitZ());
+                                            *rod_, X_BJb, Vector3d::UnitZ());
 
     plant_->mutable_gravity_field().set_gravity_vector(
         Vector3d(0.0, 0.0, -kGravity));
@@ -353,6 +353,29 @@ class SpinningRodTest : public ::testing::Test {
 
   void VerifyJointReactionForces() {
     const double kTolerance = 20 * std::numeric_limits<double>::epsilon();
+
+    // Evaluate the spatial acceleration of the rod.
+    const auto& A_WB_all =
+        plant_->get_body_spatial_accelerations_output_port()
+            .Eval<std::vector<SpatialAcceleration<double>>>(*context_);
+    const SpatialAcceleration<double>& A_WRod = A_WB_all[rod_->index()];
+
+    // Bz is the unit vector along the rod's length.
+    const Vector3d Bz_W =
+        rod_->EvalPoseInWorld(*context_).rotation().matrix().col(2);
+
+    // There is no damping, therefore we expect the angular acceleration to be
+    // zero.
+    const Vector3d alpha_WB = Vector3d::Zero();
+
+    // And the translational acceleration to contain the centrifugal
+    // acceleration.
+    const Vector3d a_WB = -Bz_W * kLength / 2.0 * kOmega * kOmega;
+
+    // Verify the result.
+    EXPECT_TRUE(CompareMatrices(A_WRod.rotational(), alpha_WB, kTolerance));
+    EXPECT_TRUE(CompareMatrices(A_WRod.translational(), a_WB, kTolerance));
+
     // Evaluate reaction force at the pin.
     const auto& reaction_forces =
         plant_->get_reaction_forces_output_port()
@@ -381,6 +404,7 @@ class SpinningRodTest : public ::testing::Test {
   const double kOmega{5.0};     // [rad/s]
 
   std::unique_ptr<MultibodyPlant<double>> plant_;
+  const RigidBody<double>* rod_{nullptr};
   const RevoluteJoint<double>* pin_{nullptr};
   std::unique_ptr<Context<double>> context_;
 };

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -1314,6 +1314,8 @@ bool OnlyAccelerationAndReactionPortsFeedthrough(
   for (ModelInstanceIndex i(0); i < plant.num_model_instances(); ++i)
     ok_to_feedthrough.insert(
         plant.get_generalized_acceleration_output_port(i).get_index());
+  ok_to_feedthrough.insert(
+      plant.get_body_spatial_accelerations_output_port().get_index());
 
   // Now find all the feedthrough ports and make sure they are on the whitelist.
   const std::multimap<int, int> feedthroughs = plant.GetDirectFeedthroughs();


### PR DESCRIPTION
This is the original PR #13364 (no changes at all from #13364) which was reverted in #13399. 
The CI failure was caused by an indirect request to perform velocity kinematics on a model with zero dofs. The bug fix was merged in #13405.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13423)
<!-- Reviewable:end -->
