### PR TITLE
Do not add pydrake stub if pydrake already on path.

### DIFF
--- a/tools/workspace/drake_visualizer/drake_visualizer_bazel.py
+++ b/tools/workspace/drake_visualizer/drake_visualizer_bazel.py
@@ -48,13 +48,19 @@ def main():
         "`drake_runfiles_binary` macro.")
 
     # Stub out pydrake (refer to our ./BUILD.bazel comments for rationale).
+    # If pydrake is already on the path, for instance because intentionally
+    # included as a dependency, then the stub will not be added to avoid
+    # conflicting.
     #
     # We add it to PYTHONPATH within the script, rather than
     # `imports = ["stub"]` on the stub py_library, to avoid any other target
     # accidentally pulling in the stubbed pydrake onto its PYTHONPATH.  Only
     # the visualizer, when launched via this wrapper script, should employ the
     # stub.
-    prepend_path("PYTHONPATH", "tools/workspace/drake_visualizer/stub")
+    try:
+        import pydrake
+    except ImportError:
+        prepend_path("PYTHONPATH", "tools/workspace/drake_visualizer/stub")
 
     # Don't use DRAKE_RESOURCE_ROOT; the stub getDrakePath should always win.
     # This also placates the drake-visualizer logic that puts it into Director


### PR DESCRIPTION
Per discussion in #13421 , this would be a simple work-around, when combined with https://github.com/DAIRLab/dairlib/pull/150 to continue supporting a fully featured visualizer external workflow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13428)
<!-- Reviewable:end -->
