### PR TITLE
workspace: Upgrade imported bazel rules to latest

### DIFF
--- a/tools/install/bazel/test/drake_bazel_installed_test.py
+++ b/tools/install/bazel/test/drake_bazel_installed_test.py
@@ -16,9 +16,9 @@ def main():
 
     # TODO(jamiesnape): Automatically keep this synchronized with the version
     # used by @drake (or the nearest stable version).
-    rules_python_commit = "38f86fb55b698c51e8510c807489c9f4e047480e"
+    rules_python_commit = "0.0.2"
     rules_python_url = f"https://github.com/bazelbuild/rules_python/archive/{rules_python_commit}.tar.gz"  # noqa
-    rules_python_sha256 = "c911dc70f62f507f3a361cbc21d6e0d502b91254382255309bc60b7a0f48de28"  # noqa
+    rules_python_sha256 = "a1b2797d85abb395468915f2ab652cee65e9a44e31bff559cd7de0dedf056363"  # noqa
 
     with open(join(scratch_dir, "WORKSPACE"), "w") as f:
         f.write(f"""

--- a/tools/workspace/bazel_skylib/repository.bzl
+++ b/tools/workspace/bazel_skylib/repository.bzl
@@ -6,7 +6,7 @@ def bazel_skylib_repository(name, mirrors = None):
     github_archive(
         name = name,
         repository = "bazelbuild/bazel-skylib",
-        commit = "0.9.0",
-        sha256 = "9245b0549e88e356cd6a25bf79f97aa19332083890b7ac6481a2affb6ada9752",  # noqa
+        commit = "1.0.2",
+        sha256 = "e5d90f0ec952883d56747b7604e2a15ee36e288bb556c3d0ed33e818a4d971f2",  # noqa
         mirrors = mirrors,
     )

--- a/tools/workspace/rules_python/repository.bzl
+++ b/tools/workspace/rules_python/repository.bzl
@@ -12,7 +12,7 @@ def rules_python_repository(
     github_archive(
         name = name,
         repository = "bazelbuild/rules_python",  # License: Apache-2.0
-        commit = "748aa53d7701e71101dfd15d800e100f6ff8e5d1",
-        sha256 = "64a3c26f95db470c32ad86c924b23a821cd16c3879eed732a7841779a32a60f8",  # noqa
+        commit = "0.0.2",
+        sha256 = "a1b2797d85abb395468915f2ab652cee65e9a44e31bff559cd7de0dedf056363",  # noqa
         mirrors = mirrors,
     )


### PR DESCRIPTION
Upgrade bazel_skylib to latest release 1.0.2.
Upgrade rules_python to latest release 0.0.2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13429)
<!-- Reviewable:end -->
