### PR TITLE
Allows calling MBP::set_penetration_allowance() pre-finalize.

### DIFF
--- a/multibody/plant/test/inclined_plane_test.cc
+++ b/multibody/plant/test/inclined_plane_test.cc
@@ -94,8 +94,11 @@ TEST_P(InclinedPlaneTest, RollingSphereTest) {
       coefficient_friction_inclined_plane, coefficient_friction_sphere,
       mass, radius, &plant);
 
-  plant.Finalize();
+  // We should be able to set the penetration allowance pre- and post-finalize.
+  // For this test we decide to set it pre-finalize.
   plant.set_penetration_allowance(penetration_allowance_);  // (in meters)
+
+  plant.Finalize();
   plant.set_stiction_tolerance(stiction_tolerance_);
   const RigidBody<double>& ball = plant.GetRigidBodyByName("BodyB");
 


### PR DESCRIPTION
Addresses #13416.

This allows `MBP::set_penetration_allowance()` pre- and post-finalize. Therefore it is entirely backwards compatible with the functionality in master today.

Minimum work needed to address this. Lots of this code will get properly cleaned up and exposed per #13064 as outlined in the TODO introduced in this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13435)
<!-- Reviewable:end -->
