### PR TITLE
Do not delete VisualElement move constructor

### DIFF
--- a/attic/multibody/shapes/element.h
+++ b/attic/multibody/shapes/element.h
@@ -51,10 +51,10 @@ class Element {
 
  protected:
   // Provide a copy constructor for use by our subclasses' clone().
-  // Delete all of the other operations.
   Element(const Element&);
+  Element(Element&&) = default;
+
   void operator=(const Element&) = delete;
-  Element(Element&&) = delete;
   void operator=(Element&&) = delete;
 
   void setWorldTransform(const Eigen::Isometry3d& T_elem_to_world);

--- a/attic/multibody/shapes/visual_element.h
+++ b/attic/multibody/shapes/visual_element.h
@@ -24,10 +24,11 @@ class VisualElement final : public Element {
                 const Eigen::Vector4d& material,
                 const std::string& name = "");
 
-  /** Copy constructor for use by, e.g., std::vector. */
+  /** Copy and move constructor for use by, e.g., std::vector. */
   VisualElement(const VisualElement&) = default;
+  VisualElement(VisualElement&&) = default;
+
   void operator=(const VisualElement&) = delete;
-  VisualElement(VisualElement&&) = delete;
   void operator=(VisualElement&&) = delete;
 
   ~VisualElement() override = default;


### PR DESCRIPTION
A possible solution to the following:
```
 ERROR: /media/ephemeral0/ubuntu/workspace/linux-focal-unprovisioned-gcc-bazel-continuous-release/src/attic/multibody/BUILD.bazel:164:1: Couldn't build file attic/multibody/_objs/rigid_body/rigid_body.pic.o: C++ compilation of rule '//attic/multibody:rigid_body' failed (Exit 1) gcc failed: error executing command /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer -g0 -O2 '-D_FORTIFY_SOURCE=1' -DNDEBUG -ffunction-sections ... (remaining 172 argument(s) skipped)
 In file included from /usr/include/x86_64-linux-gnu/c++/9/bits/c++allocator.h:33,
                  from /usr/include/c++/9/bits/allocator.h:46,
                  from /usr/include/c++/9/string:41,
                  from /usr/include/c++/9/bits/locale_classes.h:40,
                  from /usr/include/c++/9/bits/ios_base.h:41,
                  from /usr/include/c++/9/ios:42,
                  from /usr/include/c++/9/ostream:38,
                  from /usr/include/c++/9/iostream:39,
                  from bazel-out/k8-opt/bin/attic/multibody/_virtual_includes/rigid_body/drake/multibody/rigid_body.h:3,
                  from attic/multibody/rigid_body.cc:1:
 /usr/include/c++/9/ext/new_allocator.h: In instantiation of 'void __gnu_cxx::new_allocator<_Tp>::construct(_Up*, _Args&& ...) [with _Up = DrakeShapes::VisualElement; _Args = {DrakeShapes::VisualElement}; _Tp = DrakeShapes::VisualElement]':
 /usr/include/c++/9/bits/alloc_traits.h:226:6:   required by substitution of 'template<class _Alloc2, class> static std::true_type std::allocator_traits<Eigen::aligned_allocator<DrakeShapes::VisualElement> >::__construct_helper<DrakeShapes::VisualElement, DrakeShapes::VisualElement>::__test<_Alloc2, <template-parameter-1-2> >(int) [with _Alloc2 = Eigen::aligned_allocator<DrakeShapes::VisualElement>; <template-parameter-1-2> = <missing>]'
 /usr/include/c++/9/bits/alloc_traits.h:233:40:   required from 'struct std::allocator_traits<Eigen::aligned_allocator<DrakeShapes::VisualElement> >::__construct_helper<DrakeShapes::VisualElement, DrakeShapes::VisualElement>'
 /usr/include/c++/9/bits/alloc_traits.h:250:2:   required by substitution of 'template<class _Tp, class ... _Args> static std::_Require<std::__and_<std::__not_<typename std::allocator_traits<Eigen::aligned_allocator<DrakeShapes::VisualElement> >::__construct_helper<_Tp, _Args>::type>, std::is_constructible<_Tp, _Args ...> > > std::allocator_traits<Eigen::aligned_allocator<DrakeShapes::VisualElement> >::_S_construct<_Tp, _Args ...>(Eigen::aligned_allocator<DrakeShapes::VisualElement>&, _Tp*, _Args&& ...) [with _Tp = DrakeShapes::VisualElement; _Args = {DrakeShapes::VisualElement}]'
 /usr/include/c++/9/bits/alloc_traits.h:350:26:   required by substitution of 'template<class _Tp, class ... _Args> static decltype (std::allocator_traits<Eigen::aligned_allocator<DrakeShapes::VisualElement> >::_S_construct(__a, __p, (forward<_Args>)(std::allocator_traits::construct::__args)...)) std::allocator_traits<Eigen::aligned_allocator<DrakeShapes::VisualElement> >::construct<_Tp, _Args ...>(Eigen::aligned_allocator<DrakeShapes::VisualElement>&, _Tp*, _Args&& ...) [with _Tp = DrakeShapes::VisualElement; _Args = {DrakeShapes::VisualElement}]'
 /usr/include/c++/9/bits/alloc_traits.h:588:60:   required by substitution of 'template<class _Alloc, class _Tp, class _ValueT> struct std::__is_alloc_insertable_impl<_Alloc, _Tp, _ValueT, std::__void_t<decltype (std::allocator_traits<_Alloc>::construct(declval<_Alloc&>(), declval<_ValueT*>(), declval<_Tp>()))> > [with _Alloc = Eigen::aligned_allocator<DrakeShapes::VisualElement>; _Tp = DrakeShapes::VisualElement; _ValueT = DrakeShapes::VisualElement]'
 /usr/include/c++/9/bits/alloc_traits.h:613:12:   required from 'struct std::__is_move_insertable<Eigen::aligned_allocator<DrakeShapes::VisualElement> >'
 /usr/include/c++/9/bits/stl_vector.h:446:28:   required from 'static constexpr bool std::vector<_Tp, _Alloc>::_S_use_relocate() [with _Tp = DrakeShapes::VisualElement; _Alloc = Eigen::aligned_allocator<DrakeShapes::VisualElement>]'
 /usr/include/c++/9/bits/vector.tcc:459:44:   required from 'void std::vector<_Tp, _Alloc>::_M_realloc_insert(std::vector<_Tp, _Alloc>::iterator, _Args&& ...) [with _Args = {const DrakeShapes::VisualElement&}; _Tp = DrakeShapes::VisualElement; _Alloc = Eigen::aligned_allocator<DrakeShapes::VisualElement>; std::vector<_Tp, _Alloc>::iterator = __gnu_cxx::__normal_iterator<DrakeShapes::VisualElement*, std::vector<DrakeShapes::VisualElement, Eigen::aligned_allocator<DrakeShapes::VisualElement> > >; typename std::_Vector_base<_Tp, _Alloc>::pointer = DrakeShapes::VisualElement*]'
 /usr/include/c++/9/bits/stl_vector.h:1195:4:   required from 'void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = DrakeShapes::VisualElement; _Alloc = Eigen::aligned_allocator<DrakeShapes::VisualElement>; std::vector<_Tp, _Alloc>::value_type = DrakeShapes::VisualElement]'
 attic/multibody/rigid_body.cc:91:29:   required from 'void RigidBody<U>::AddVisualElement(const DrakeShapes::VisualElement&) [with T = double]'
 attic/multibody/rigid_body.cc:321:16:   required from here
 /usr/include/c++/9/ext/new_allocator.h:145:20: error: use of deleted function 'DrakeShapes::VisualElement::VisualElement(DrakeShapes::VisualElement&&)'
   145 |  noexcept(noexcept(::new((void *)__p)
       |                    ^~~~~~~~~~~~~~~~~~
   146 |        _Up(std::forward<_Args>(__args)...)))
       |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 In file included from bazel-out/k8-opt/bin/attic/multibody/shapes/_virtual_includes/everything/drake/multibody/shapes/drake_shapes.h:6,
                  from bazel-out/k8-opt/bin/attic/multibody/collision/_virtual_includes/model/drake/multibody/collision/element.h:13,
                  from bazel-out/k8-opt/bin/attic/multibody/collision/_virtual_includes/model/drake/multibody/collision/model.h:12,
                  from bazel-out/k8-opt/bin/attic/multibody/collision/_virtual_includes/collision_api/drake/multibody/collision/drake_collision.h:6,
                  from bazel-out/k8-opt/bin/attic/multibody/_virtual_includes/rigid_body/drake/multibody/rigid_body.h:18,
                  from attic/multibody/rigid_body.cc:1:
 bazel-out/k8-opt/bin/attic/multibody/shapes/_virtual_includes/everything/drake/multibody/shapes/visual_element.h:30:3: note: declared here
    30 |   VisualElement(VisualElement&&) = delete;
       |   ^~~~~~~~~~~~~
```

Relates #13102.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13436)
<!-- Reviewable:end -->
