### PR TITLE
Make CalcNextUpdateTime() "right now" returns work during initialization

### DIFF
--- a/systems/analysis/simulator.cc
+++ b/systems/analysis/simulator.cc
@@ -97,9 +97,9 @@ SimulatorStatus Simulator<T>::Initialize() {
 
   // Ensure that CalcNextUpdateTime() can return the current time by perturbing
   // current time as slightly toward negative infinity as we can allow.
-  const T slightly_before_current_time = internal::GetPreviousNormalizedValue(
-      current_time);
-  context_->SetTime(slightly_before_current_time);
+  const T slightly_before_current_time =
+      internal::GetPreviousNormalizedValue(current_time);
+  context_->PerturbTime(slightly_before_current_time, current_time);
 
   // Get the next timed event.
   next_timed_event_time_ =

--- a/systems/analysis/test/simulator_test.cc
+++ b/systems/analysis/test/simulator_test.cc
@@ -2321,6 +2321,138 @@ GTEST_TEST(SimulatorTest, MonitorFunctionAndStatusReturn) {
       "failed with message.*Something terrible happened.*");
 }
 
+// Simulator::Initialize() called at time t temporarily moves time back to
+// t̅ = t-δ prior to calling CalcNextUpdateTime() so that timed events scheduled
+// for time t will trigger. (t̅ is the next floating point value below t.)
+// This causes trouble for DoCalcNextUpdateTime() overloads that want an
+// event "right now", since those return contact.get_time(), which in this
+// case will be t̅ when it should have been t. When a Diagram runs through
+// all its subsystems looking for the "next" update time, it keeps only the
+// ones that occur at the earliest of all times reported, and forgets any
+// later ones (since obviously those are not "next"). Without special handling,
+// the "right now" events at t̅ would prevent other time t events from being
+// seen. (This was not done originally, see Drake issue #13296.)
+//
+// The case here creates a two-subsystem Diagram in which one of the subsystems
+// specifies a "right now" update time while the other has an event that occurs
+// at a specified time t. We'll verify that they play well together under
+// various circumstances that can occur during Simulator::Initialize().
+GTEST_TEST(SimulatorTest, MissedPublishEventIssue13296) {
+  // This models systems like LcmSubscriberSystem that want to generate
+  // an event as soon as possible after an external message arrives. Here we
+  // just set a flag to indicate that a "message" is waiting and generate an
+  // event whenever that flag is set.
+  class RightNowEventSystem : public LeafSystem<double> {
+   public:
+    int publish_count() const { return publish_counter_; }
+    void reset_count() { publish_counter_ = 0; }
+    void set_message_is_waiting(bool message_is_waiting) {
+      message_is_waiting_ = message_is_waiting;
+    }
+
+   private:
+    void DoCalcNextUpdateTime(const Context<double>& context,
+                              CompositeEventCollection<double>* event_info,
+                              double* next_update_time) const final {
+      const double inf = std::numeric_limits<double>::infinity();
+      *next_update_time = message_is_waiting_ ? context.get_time() : inf;
+      PublishEvent<double> event(
+          TriggerType::kTimed,
+          [this](const Context<double>& handler_context,
+                 const PublishEvent<double>& publish_event) {
+            this->MyPublishHandler(handler_context, publish_event);
+          });
+      event.AddToComposite(event_info);
+    }
+
+    void MyPublishHandler(const Context<double>& context,
+                          const PublishEvent<double>& publish_event) const {
+      ++publish_counter_;
+    }
+
+    bool message_is_waiting_{false};
+    mutable int publish_counter_{0};
+  };
+
+  // Just an ordinary system that has a periodic event with period 0.25. It
+  // should play nicely with simultaneous events from the
+  // RightNowEventSystem above.
+  class PeriodicEventSystem : public LeafSystem<double> {
+   public:
+    PeriodicEventSystem() {
+      this->DeclarePeriodicPublishEvent(0.25, 0.,
+                                        &PeriodicEventSystem::MakeItCount);
+    }
+
+    int publish_count() const { return publish_counter_; }
+    void reset_count() { publish_counter_ = 0; }
+
+   private:
+    EventStatus MakeItCount(const Context<double>&) const {
+      ++publish_counter_;
+      return EventStatus::Succeeded();
+    }
+    mutable int publish_counter_{0};
+  };
+
+  DiagramBuilder<double> builder;
+  auto right_now_system = builder.AddSystem<RightNowEventSystem>();
+  auto periodic_system = builder.AddSystem<PeriodicEventSystem>();
+  Simulator<double> simulator(builder.Build());
+
+  // Verify that CalcNextUpdateTime() returns "true time" rather than
+  // current time when time is perturbed but we return "right now".
+  // Note that the times are chosen to trigger only the "right now" event.
+  const double true_time = .125;
+  right_now_system->set_message_is_waiting(true);  // Activate event.
+  simulator.get_mutable_context().SetTime(true_time);
+  auto events = simulator.get_system().AllocateCompositeEventCollection();
+  double next_update_time = simulator.get_system().CalcNextUpdateTime
+      (simulator.get_context(), events.get());
+  EXPECT_EQ(simulator.get_context().get_time(), true_time);
+  EXPECT_EQ(next_update_time, true_time);  // Normal behavior.
+
+  // Tweak the time. (Simulator::Initialize() does this more carefully.)
+  const double perturbed_time = true_time - 1e-14;
+  ASSERT_NE(perturbed_time, true_time);  // Watch for precision loss.
+  simulator.get_mutable_context().PerturbTime(perturbed_time, true_time);
+  next_update_time = simulator.get_system().CalcNextUpdateTime
+      (simulator.get_context(), events.get());
+  EXPECT_EQ(simulator.get_context().get_time(), perturbed_time);
+  EXPECT_EQ(next_update_time, true_time);  // Return true time, not current.
+
+  // With no "message" waiting, the "right now" event won't trigger. At
+  // the offset time 0, we should get just the periodic event. This has always
+  // worked properly.
+  right_now_system->set_message_is_waiting(false);  // Deactivate event.
+  simulator.get_mutable_context().SetTime(0.);
+  simulator.Initialize();
+  EXPECT_EQ(right_now_system->publish_count(), 0);
+  EXPECT_EQ(periodic_system->publish_count(), 1);
+  periodic_system->reset_count();
+
+  // With a message waiting, the "right now" event should trigger,
+  // but the periodic event won't issue until its offset time (0) is reached.
+  // Although this wasn't reported in #13296, it did not work correctly before
+  // the fix in PR #13438.
+  right_now_system->set_message_is_waiting(true);
+  simulator.get_mutable_context().SetTime(-1.);
+  simulator.Initialize();
+  EXPECT_EQ(right_now_system->publish_count(), 1);
+  EXPECT_EQ(periodic_system->publish_count(), 0);
+  right_now_system->reset_count();
+
+  // With a message present and t=0 both should trigger. This is the case
+  // that failed in #13296: the "right now" event would come back at the
+  // perturbed time (slightly before zero), hiding the periodic event, and
+  // its handler would not get called either since that isn't the current time.
+  right_now_system->set_message_is_waiting(true);
+  simulator.get_mutable_context().SetTime(0.);
+  simulator.Initialize();
+  EXPECT_EQ(right_now_system->publish_count(), 1);
+  EXPECT_EQ(periodic_system->publish_count(), 1);
+}
+
 }  // namespace
 }  // namespace systems
 }  // namespace drake

--- a/systems/framework/context.cc
+++ b/systems/framework/context.cc
@@ -1,7 +1,4 @@
 #include "drake/systems/framework/context.h"
 
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
-    struct ::drake::systems::StepInfo)
-
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::Context)

--- a/systems/framework/diagram_context.h
+++ b/systems/framework/diagram_context.h
@@ -460,10 +460,13 @@ class DiagramContext final : public Context<T> {
   }
 
   // Recursively sets the time on all subcontexts.
-  void DoPropagateTimeChange(const T& time_sec, int64_t change_event) final {
+  void DoPropagateTimeChange(const T& time_sec,
+                             const std::optional<T>& true_time,
+                             int64_t change_event) final {
     for (auto& subcontext : contexts_) {
       DRAKE_ASSERT(subcontext != nullptr);
-      Context<T>::PropagateTimeChange(&*subcontext, time_sec, change_event);
+      Context<T>::PropagateTimeChange(&*subcontext, time_sec, true_time,
+                                      change_event);
     }
   }
 

--- a/systems/framework/system.cc
+++ b/systems/framework/system.cc
@@ -333,6 +333,14 @@ T System<T>::CalcNextUpdateTime(const Context<T>& context,
   DoCalcNextUpdateTime(context, events, &time);
   using std::isnan;
   DRAKE_ASSERT(!isnan(time));
+
+  // If the context contains a perturbed current time, and
+  // DoCalcNextUpdateTime() returned "right now" (which would be the
+  // perturbed time here), we need to adjust the returned time to the actual
+  // time. (Simulator::Initialize() perturbs time in that way.)
+  if (context.get_true_time() && time == context.get_time())
+    time = *context.get_true_time();
+
   return time;
 }
 

--- a/systems/framework/test/leaf_context_test.cc
+++ b/systems/framework/test/leaf_context_test.cc
@@ -953,6 +953,23 @@ TEST_F(LeafContextTest, TestStateSettingSugar) {
       ".*cast to.*std::string.*failed.*actual type.*int.*");
 }
 
+// Check that hidden internal functionality needed by Simulator::Initialize()
+// and CalcNextUpdateTime() is functional in the Context.
+TEST_F(LeafContextTest, PerturbTime) {
+  // This is a hidden method. Should set time to perturbed_time but current
+  // time to true_time.
+  const double true_time = 2.;
+  const double perturbed_time = true_time - 1e-14;
+  ASSERT_NE(perturbed_time, true_time);  // Watch for fatal roundoff.
+  context_.PerturbTime(perturbed_time, true_time);
+  EXPECT_EQ(context_.get_time(), perturbed_time);
+  EXPECT_EQ(*context_.get_true_time(), true_time);  // This is an std::optional.
+
+  // Setting time the normal way clears the "true time".
+  context_.SetTime(1.);
+  EXPECT_FALSE(context_.get_true_time());
+}
+
 }  // namespace
 }  // namespace systems
 }  // namespace drake


### PR DESCRIPTION
Implements solution (2) to the event timing problem reported and discussed in #13296.

- Adds an std::optional `true_time` field to Context, and internal PerturbTime() method for setting it.
- Modifies Simulator::Initialize() to use PerturbTime().
- Modifies System::CalcNextUpdateTime() to report true_time rather than the perturbed time.
- Adds unit tests that duplicate the reported problem.
- Cleans up some time-related Context code.

Resolves #13296

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13438)
<!-- Reviewable:end -->
