### PR TITLE
py geometry: Allow setting color in properties

### DIFF
--- a/bindings/pydrake/common/_value_extra.py
+++ b/bindings/pydrake/common/_value_extra.py
@@ -1,12 +1,24 @@
 # See `ExecuteExtraPythonCode` in `pydrake_pybind.h` for usage details and
 # rationale.
 
-from pydrake.common.cpp_param import List
+import numpy as np
+
+from pydrake.common.cpp_param import List, Vector4d
+
+
+def _is_maybe_vector4d(value):
+    if isinstance(value, (list, np.ndarray)) and len(value) == 4:
+        value = np.asarray(value)
+        if value.dtype == float:
+            return True
+    return False
 
 
 def _AbstractValue_Make(value):
     """Returns an AbstractValue containing the given ``value``."""
-    if isinstance(value, list) and len(value) > 0:
+    if _is_maybe_vector4d(value):
+        cls = Vector4d
+    elif isinstance(value, list) and len(value) > 0:
         inner_cls = type(value[0])
         cls = List[inner_cls]
     else:

--- a/bindings/pydrake/common/cpp_param.py
+++ b/bindings/pydrake/common/cpp_param.py
@@ -145,4 +145,24 @@ class _Generic:
         return f"<Generic {self._name}>"
 
 
+class _Token:
+    def __init__(self, name, factory):
+        self._name = name
+        self._factory = factory
+
+    def __call__(self, *args, **kwargs):
+        return self._factory(*args, **kwargs)
+
+    def __repr__(self):
+        return self._name
+
+
+def _vector4d(x):
+    x = np.asarray(x)
+    if x.size != 4:
+        raise RuntimeError(f"Must be size 4: {x}")
+    return x
+
+
 List = _Generic("List", factory=list, num_param=1)
+Vector4d = _Token("Vector4d", factory=_vector4d)

--- a/bindings/pydrake/common/test/value_test.py
+++ b/bindings/pydrake/common/test/value_test.py
@@ -1,7 +1,9 @@
 import copy
 import unittest
 
-from pydrake.common.cpp_param import List
+import numpy as np
+
+from pydrake.common.cpp_param import List, Vector4d
 from pydrake.common.value import AbstractValue, Value
 
 from pydrake.common.test.value_test_util import (
@@ -117,8 +119,32 @@ class TestValue(unittest.TestCase):
                 "AddValueInstantiation",
             ]), cm.exception)
 
+    def test_vector4d(self):
+        # Test construction.
+        zeros = np.zeros(4)
+        ones = np.ones(4)
+        value = Value[Vector4d](zeros)
+        np.testing.assert_array_equal(value.get_value(), zeros)
+        value.set_value(ones)
+        np.testing.assert_array_equal(value.get_value(), ones)
+        with self.assertRaises(RuntimeError) as cm:
+            Value[Vector4d](np.zeros(3))
+        self.assertIn("Must be size 4: ", str(cm.exception))
+        # Test inference via `AbstractValue.Make`.
+        self.assertIsInstance(
+            AbstractValue.Make([1., 0, 0, 1]), Value[Vector4d])
+        self.assertIsInstance(
+            AbstractValue.Make(np.array([1., 0, 0, 1])), Value[Vector4d])
+        # List of integers implies Value[object]
+        self.assertIsInstance(
+            AbstractValue.Make([1, 0, 0, 1]), Value[object])
+        # A vector of floats, but of size != 4, also implies Vector[object].
+        self.assertIsInstance(
+            AbstractValue.Make([1., 0, 0, 1, 0]), Value[object])
+
     def test_value_registration(self):
         # Existence check.
         Value[object]
         Value[str]
         Value[bool]
+        Value[Vector4d]

--- a/bindings/pydrake/common/value_py.cc
+++ b/bindings/pydrake/common/value_py.cc
@@ -1,7 +1,9 @@
 #include <string>
 
+#include "pybind11/eigen.h"
 #include "pybind11/eval.h"
 #include "pybind11/pybind11.h"
+#include <Eigen/Dense>
 
 #include "drake/bindings/pydrake/common/cpp_param_pybind.h"
 #include "drake/bindings/pydrake/common/value_pybind.h"
@@ -10,7 +12,6 @@
 
 namespace drake {
 namespace pydrake {
-
 namespace {
 
 // Local specialization of C++ implementation for `Value[object]`
@@ -33,6 +34,10 @@ void AddPrimitiveValueInstantiations(py::module m) {
   AddValueInstantiation<std::string>(m);            // Value[str]
   AddValueInstantiation<bool>(m);                   // Value[bool]
   AddValueInstantiation<Object, PyObjectValue>(m);  // Value[object]
+
+  // For current definition of `color`.
+  AddValueInstantiation<Eigen::Vector4d>(
+      m, py::module::import("pydrake.common.cpp_param").attr("Vector4d"));
 }
 
 }  // namespace

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -304,9 +304,19 @@ class TestGeometry(unittest.TestCase):
                               mut.PerceptionProperties)
 
     def test_geometry_properties_api(self):
-        self.assertIsInstance(
-            mut.MakePhongIllustrationProperties([0, 0, 1, 1]),
-            mut.IllustrationProperties)
+        test_color = [0., 0, 1, 1]
+        phong_props = mut.MakePhongIllustrationProperties(test_color)
+        self.assertIsInstance(phong_props, mut.IllustrationProperties)
+        actual_color = phong_props.GetProperty("phong", "diffuse")
+        self.assertIsInstance(actual_color, np.ndarray)
+        np.testing.assert_equal(actual_color, test_color)
+        # Ensure that we can create it manually.
+        phong_props = mut.IllustrationProperties()
+        phong_props.AddProperty("phong", "diffuse", test_color)
+        actual_color = phong_props.GetProperty("phong", "diffuse")
+        self.assertIsInstance(actual_color, np.ndarray)
+        np.testing.assert_equal(actual_color, test_color)
+
         prop = mut.ProximityProperties()
         self.assertEqual(str(prop), "[__default__]")
         default_group = prop.default_group_name()


### PR DESCRIPTION
Towards #13162

This is a simpler version of #13398 / #13166 / #13160 - do not try to change any existing `Value<>` semantics. This "gives up" on solving the general problem for now, and only tackles the acute lack of coverage in `pydrake`.
For discussion to see if this is a viable alternative, or a dumb excess of work rather than just enabling the use of `Color`.

Ultimately, I think it'd be easy to mirror any deprecations for `Value<Vector4d>` in `GeometryProperties` in Python too, but it *is* extra work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13440)
<!-- Reviewable:end -->
