### PR TITLE
Fix hash_template_argument_from_pretty_func for GCC 9

### DIFF
--- a/common/test/value_test.cc
+++ b/common/test/value_test.cc
@@ -407,6 +407,11 @@ constexpr bool kClang = true;
 #else
 constexpr bool kClang = false;
 #endif
+#if __GNUC__ >= 9
+constexpr bool kGcc9 = true;
+#else
+constexpr bool kGcc9 = false;
+#endif
 
 GTEST_TEST(TypeHashTest, WellKnownValues) {
   // Simple primitives, structs, and classes.
@@ -478,7 +483,7 @@ GTEST_TEST(TypeHashTest, WellKnownValues) {
   // Templated on a value, but with the 'using NonTypeTemplateParameter'
   // decoration so that the hash works.
   const std::string kfoo =
-      kClang ? "drake::test::{anonymous}::AnonEnum::kFoo" : "0";
+      kClang || kGcc9 ? "drake::test::{anonymous}::AnonEnum::kFoo" : "0";
   CheckHash<NiceAnonEnumTemplate<AnonEnum::kFoo>>(
       "drake::test::{anonymous}::NiceAnonEnumTemplate<"
         "drake::test::{anonymous}::AnonEnum=" + kfoo + ">");


### PR DESCRIPTION
Relates #13102.

`__PRETTY_FUNCTION__` changed between GCC 7 and 9 as follows:

* GCC 7:
  ```cpp
  drake::test::{anonymous}::NiceAnonEnumTemplate<(drake::test::<unnamed>::AnonEnum)0>
  ```
* GCC 9:
  ```
  drake::test::{anonymous}::NiceAnonEnumTemplate<drake::test::<unnamed>::AnonEnum::kFoo>
  ```

So it similar to Clang modulo `{anonymous}` and `<unnamed>` both mapping to `(anonymous namespace)`:
 ```
drake::test::(anonymous namespace)::NiceAnonEnumTemplate<drake::test::(anonymous namespace)::AnonEnum::kFoo>
```
This therefore means that the `drake::test::<unnamed>::AnonEnum` is no longer discarded since it is not parenthesized and the difference between `<unnamed>` and `{anonymous}` matters, not least because the (unexpected) `<>` causes `hash_template_argument_from_pretty_func` to fail.

<!-- Reviewable:start -->
----
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13449)
<!-- Reviewable:end -->
