### PR TITLE
Fix range-loop-construct warnings in gurobi_solver.cc

### DIFF
--- a/solvers/gurobi_solver.cc
+++ b/solvers/gurobi_solver.cc
@@ -971,12 +971,12 @@ void GurobiSolver::DoSolve(
     error = GRBsetintparam(model_env, GRB_INT_PAR_OUTPUTFLAG, 0);
   }
 
-  for (const auto it : merged_options.GetOptionsDouble(id())) {
+  for (const auto& it : merged_options.GetOptionsDouble(id())) {
     if (!error) {
       error = GRBsetdblparam(model_env, it.first.c_str(), it.second);
     }
   }
-  for (const auto it : merged_options.GetOptionsInt(id())) {
+  for (const auto& it : merged_options.GetOptionsInt(id())) {
     if (!error) {
       error = GRBsetintparam(model_env, it.first.c_str(), it.second);
     }


### PR DESCRIPTION
#13357 fixed these in the open-source-only builds, so may as well fix the additional ones when the commercial solvers are enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13450)
<!-- Reviewable:end -->
