### PR TITLE
Enable CalcBiasSpatialAcceleration() to have a measured-in-frame that is not the World.

### DIFF
--- a/multibody/plant/test/multibody_plant_jacobians_test.cc
+++ b/multibody/plant/test/multibody_plant_jacobians_test.cc
@@ -519,7 +519,7 @@ class SatelliteTrackerTest : public ::testing::Test {
   // errors in bias acceleration calculations are less than 3 bits (2^3 = 8).
   // In connection with real numbers whose absolute value are < 0.25, double-
   // precision calculations should be accurate to ≈ machine epsilon / 4.
-  // So, for this test, kToletance = 2^3 * machine_epsilon / 4.
+  // So, for this test, kTolerance = 2^3 * machine_epsilon / 4.
   const double kTolerance = 2 * std::numeric_limits<double>::epsilon();
   const double LB_ = 0.5;  // Bx measure of Q's position vector from Bo (meter).
   const double qB_ = 30 * M_PI / 180.0;  // rad.

--- a/multibody/plant/test/multibody_plant_jacobians_test.cc
+++ b/multibody/plant/test/multibody_plant_jacobians_test.cc
@@ -332,10 +332,6 @@ class TwoDOFPlanarPendulumTest : public ::testing::Test {
     context_ = plant_->CreateDefaultContext();
   }
 
-  const internal::MultibodyTree<double>& tree() const {
-    return internal::GetInternalTree(*plant_);
-  }
-
  protected:
   // Since the maximum absolute value of acceleration in this test is
   // approximately ω² * (2 * link_length) ≈ 72 , we test that the errors in
@@ -514,14 +510,10 @@ class SatelliteTrackerTest : public ::testing::Test {
     context_ = plant_->CreateDefaultContext();
   }
 
-  const internal::MultibodyTree<double>& tree() const {
-    return internal::GetInternalTree(*plant_);
-  }
-
  protected:
   // Since the maximum absolute value of translation acceleration in this test
   // is approximately ω² * LB_ ≈ 0.5² * 0.6 = 0.15 (which is larger than the
-  // maximum absolute value of angular acceleration of ≈0.12), we test that the
+  // maximum absolute value of angular acceleration of 0.12), we test that the
   // errors in bias acceleration calculations are less than 3 bits (2^3 = 8).
   const double kTolerance = 8 * std::numeric_limits<double>::epsilon();
   const double LB_ = 0.5;  // Bx measure of Q's position vector from Bo (meter).
@@ -557,7 +549,11 @@ TEST_F(SatelliteTrackerTest, CalcBiasSpatialAcceleration) {
     -qBBDt - cosqB * cosqB * qAADt, sinqB * cosqB * qAADt, -2 * sinqB * qABDt);
 
   // Use Drake to calculate the same quantities.
-  const double qA_irrelevant = 15 * M_PI / 180;
+  // Note: The angle qA is irrelevant because Ao is stationary in the world
+  // frame W, i.e., Ao's translational velocity and acceleration in W is 0.
+  // However, the angular rate qADt_ is relevant since A's angular velocity in W
+  // is -qADt Wy.
+  const double qA_irrelevant = 15 * M_PI / 180;  // radians.
   Eigen::VectorXd state = Eigen::Vector4d(qA_irrelevant, qB_, qADt_, qBDt_);
   joint1_->set_angle(context_.get(), state[0]);
   joint2_->set_angle(context_.get(), state[1]);

--- a/multibody/plant/test/multibody_plant_jacobians_test.cc
+++ b/multibody/plant/test/multibody_plant_jacobians_test.cc
@@ -491,14 +491,16 @@ class SatelliteTrackerTest : public ::testing::Test {
     bodyA_ = &plant_->AddRigidBody("BodyA", M_Acm);
     bodyB_ = &plant_->AddRigidBody("BodyB", M_Acm);  // same as bodyA_.
 
-    // Create a pin joint with angle -qA Wy that connects point Wo to point Ao.
+    // Create a pin (revolute) joint that connects point Wo to point Ao.
+    // Described above: The angle associated with this pin joint is -qA Wy.
     const Vector3d p_WoAo_W(0, 0, 0);  // Points Wo and Ao are collocated.
     const Vector3d p_AoWo_A(0, 0, 0);
     joint1_ = &plant_->AddJoint<RevoluteJoint>("PinJoint1",
         plant_->world_body(), math::RigidTransformd(p_WoAo_W),
         *bodyA_, math::RigidTransformd(p_AoWo_A), -Vector3d::UnitY());
 
-    // Create a pin joint with angle qB Az that connects point Ao to point Bo.
+    // Create a pin (revolute) joint that connects point Ao to point Bo.
+    // Described above: The angle associated with this pin joint is qB Az.
     const Vector3d p_AoBo_A(0, 0, 0);  // Points Ao and Bo are collocated.
     const Vector3d p_BoAo_A(0, 0, 0);
     joint2_ = &plant_->AddJoint<RevoluteJoint>("PinJoint2",

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -2539,19 +2539,20 @@ class MultibodyTree {
       const Eigen::Ref<const Vector3<T>>& p_BoBp_B,
       const SpatialAcceleration<T>& AsBias_WA_W) const;
 
-  // Calculate a body_A's bias spatial acceleration in the world frame W.
+  // For all bodies, calculate bias spatial acceleration in the world frame W.
   // @param[in] context The state of the multibody system.
   // @param[in] with_respect_to Enum equal to JacobianWrtVariable::kQDot or
   // JacobianWrtVariable::kV, indicating whether the spatial acceleration bias
   // is with respect to 𝑠 = q̇ or 𝑠 = v.
-  // @param[in] body_A The body whose bias spatial acceleration is calculated.
-  // @returns A𝑠Bias_WA_W body_A's spatial acceleration bias in frame W
-  // with respect to speeds 𝑠 (𝑠 = q̇ or 𝑠 = v), expressed in the world frame W.
+  // @param[out] AsBias_WB_all Each body's spatial acceleration bias in world
+  // frame W, with respect to speeds 𝑠 (𝑠 = q̇ or 𝑠 = v), expressed in frame W.
   // @throws std::exception if with_respect_to is not JacobianWrtVariable::kV
-  SpatialAcceleration<T> CalcBodyBiasSpatialAccelerationInWorld(
+  // @throws std::exception if AsBias_WB_all is nullptr.
+  // @throws std::exception if AsBias_WB_all.size() is not num_bodies().
+  void CalcAllBodyBiasSpatialAccelerationsInWorld(
       const systems::Context<T>& context,
       JacobianWrtVariable with_respect_to,
-      const Body<T>& body_A) const;
+      std::vector<SpatialAcceleration<T>>* AsBias_WB_all) const;
 
   // Helper method to access the mobilizer of a free body.
   // If `body` is a free body in the model, this method will return the


### PR DESCRIPTION
This PR helps address part of issue #12592, submitted by user Evan Drumwright -- CalcBiasSpatialAcceleration() methods throw assertions if measured-in-frame Frame A is not the world frame.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13453)
<!-- Reviewable:end -->
