### PR TITLE
py common: Use `py::object_api::get_type()`, not indirect Python C++ API

### DIFF
--- a/bindings/pydrake/common/module_py.cc
+++ b/bindings/pydrake/common/module_py.cc
@@ -39,8 +39,7 @@ py::handle ResolvePyObject(const type_erased_ptr& ptr) {
 // Gets a class's fully-qualified name.
 std::string GetPyClassName(py::handle obj) {
   DRAKE_DEMAND(!!obj);
-  py::handle type = py::module::import("builtins").attr("type");
-  py::handle cls = type(obj);
+  py::handle cls = obj.get_type();
   return py::str("{}.{}").format(
       cls.attr("__module__"), cls.attr("__qualname__"));
 }


### PR DESCRIPTION
Found this in the course of #13454

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13455)
<!-- Reviewable:end -->
