### PR TITLE
Add alternative convex Eval functions to LorentzConeConstraint.

### DIFF
--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -792,7 +792,11 @@ class TestMathematicalProgram(unittest.TestCase):
         prog.AddLorentzConeConstraint(np.array([z[0], x[0], x[1]]))
 
         # Test result
-        result = mp.Solve(prog)
+        # The default initial guess is [0, 0, 0]. This initial guess is bad
+        # because LorentzConeConstraint with eval_type=kConvex is not
+        # differentiable at [0, 0, 0]. Use initial guess [0.5, 0.5, 0.5]
+        # instead.
+        result = mp.Solve(prog, [0.5, 0.5, 0.5])
         self.assertTrue(result.is_success())
 
         # Check answer

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -149,6 +149,7 @@ drake_cc_library(
         "//common:essential",
         "//common:polynomial",
         "//common:symbolic",
+        "//math:gradient",
         "//math:matrix_util",
     ],
 )

--- a/solvers/constraint.cc
+++ b/solvers/constraint.cc
@@ -7,6 +7,7 @@
 
 #include <fmt/format.h>
 
+#include "drake/math/autodiff_gradient.h"
 #include "drake/math/matrix_util.h"
 #include "drake/solvers/symbolic_extraction.h"
 
@@ -14,6 +15,8 @@ using std::abs;
 
 namespace drake {
 namespace solvers {
+
+const double kInf = std::numeric_limits<double>::infinity();
 
 namespace {
 // Returns `True` if lb is -∞. Otherwise returns a symbolic formula `lb <= e`.
@@ -113,6 +116,50 @@ std::ostream& QuadraticConstraint::DoDisplay(
   return DisplayConstraint(*this, os, "QuadraticConstraint", vars, false);
 }
 
+namespace {
+int get_lorentz_cone_constraint_size(
+    LorentzConeConstraint::EvalType eval_type) {
+  return eval_type == LorentzConeConstraint::EvalType::kNonconvex ? 2 : 1;
+}
+}  // namespace
+
+LorentzConeConstraint::LorentzConeConstraint(
+    const Eigen::Ref<const Eigen::MatrixXd>& A,
+    const Eigen::Ref<const Eigen::VectorXd>& b, EvalType eval_type)
+    : Constraint(
+          get_lorentz_cone_constraint_size(eval_type), A.cols(),
+          Eigen::VectorXd::Zero(get_lorentz_cone_constraint_size(eval_type)),
+          Eigen::VectorXd::Constant(get_lorentz_cone_constraint_size(eval_type),
+                                    kInf)),
+      A_(A.sparseView()),
+      A_dense_(A),
+      b_(b),
+      eval_type_{eval_type} {
+  DRAKE_DEMAND(A_.rows() >= 2);
+  DRAKE_ASSERT(A_.rows() == b_.rows());
+}
+
+namespace {
+template <typename DerivedX>
+void LorentzConeConstraintEvalConvex2Autodiff(
+    const Eigen::MatrixXd& A_dense, const Eigen::VectorXd& b,
+    const Eigen::MatrixBase<DerivedX>& x, VectorX<AutoDiffXd>* y) {
+  const Eigen::VectorXd x_val = math::autoDiffToValueMatrix(x);
+  const Eigen::VectorXd z_val = A_dense * x_val + b;
+  const double z_tail_squared_norm = z_val.tail(z_val.rows() - 1).squaredNorm();
+  Vector1d y_val(z_val(0) - std::sqrt(z_tail_squared_norm));
+  Eigen::RowVectorXd dy_dz(z_val.rows());
+  dy_dz(0) = 1;
+  // We use a small value epsilon to approximate the gradient of sqrt(z) as
+  // ∂sqrt(zᵀz) / ∂z ≈ z(i) / sqrt(zᵀz + eps)
+  const double eps = 1E-12;
+  dy_dz.tail(z_val.rows() - 1) =
+      -z_val.tail(z_val.rows() - 1) / std::sqrt(z_tail_squared_norm + eps);
+  Eigen::RowVectorXd dy = dy_dz * A_dense * math::autoDiffToGradientMatrix(x);
+  (*y) = math::initializeAutoDiffGivenGradientMatrix(y_val, dy);
+}
+}  // namespace
+
 template <typename DerivedX, typename ScalarY>
 void LorentzConeConstraint::DoEvalGeneric(const Eigen::MatrixBase<DerivedX>& x,
                                           VectorX<ScalarY>* y) const {
@@ -120,8 +167,25 @@ void LorentzConeConstraint::DoEvalGeneric(const Eigen::MatrixBase<DerivedX>& x,
 
   const VectorX<ScalarY> z = A_dense_ * x.template cast<ScalarY>() + b_;
   y->resize(num_constraints());
-  (*y)(0) = z(0);
-  (*y)(1) = pow(z(0), 2) - z.tail(z.size() - 1).squaredNorm();
+  switch (eval_type_) {
+    case EvalType::kConvex: {
+      (*y)(0) = z(0) - z.tail(z.rows() - 1).norm();
+      break;
+    }
+    case EvalType::kConvexSmooth: {
+      if constexpr (std::is_same<ScalarY, AutoDiffXd>::value) {
+        LorentzConeConstraintEvalConvex2Autodiff(A_dense_, b_, x, y);
+      } else {
+        (*y)(0) = z(0) - z.tail(z.rows() - 1).norm();
+      }
+      break;
+    }
+    case EvalType::kNonconvex: {
+      (*y)(0) = z(0);
+      (*y)(1) = pow(z(0), 2) - z.tail(z.size() - 1).squaredNorm();
+      break;
+    }
+  }
 }
 
 void LorentzConeConstraint::DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,

--- a/solvers/constraint.h
+++ b/solvers/constraint.h
@@ -273,33 +273,39 @@ class QuadraticConstraint : public Constraint {
  where A ∈ ℝ ⁿˣᵐ, b ∈ ℝ ⁿ are given matrices.
  Ideally this constraint should be handled by a second-order cone solver.
  In case the user wants to enforce this constraint through general nonlinear
- optimization, with smooth gradient, we alternatively impose the following
- constraint, with smooth gradient everywhere
- @f[
- a_0^Tx+b_0\ge 0\\
- (a_0^Tx+b_0)^2-(a_1^Tx+b_1)^2-...-(a_{n-1}^Tx+b_{n-1})^2 \ge 0
- @f]
- where @f$ a_i^T@f$ is the i'th row of matrix @f$ A@f$. @f$ b_i @f$ is the i'th
- entry of vector @f$ b @f$.
-
- For more information and visualization, please refer to
+ optimization, we provide three different formulations on the Lorentz cone
+ constraint
+ 1. g(z) = z₀ - sqrt(z₁² + ... + zₙ₋₁²) ≥ 0
+    This formulation is not differentiable at z₁=...=zₙ₋₁=0
+ 2. g(z) = z₀ - sqrt(z₁² + ... + zₙ₋₁²) ≥ 0
+    but the gradient of g(z) is approximated as
+    ∂g(z)/∂z = [1, -z₁/sqrt(z₁² + ... zₙ₋₁² + ε), ...,
+ -zₙ₋₁/sqrt(z₁²+...+zₙ₋₁²+ε)] where ε is a small positive number.
+ 3. z₀²-(z₁²+...+zₙ₋₁²) ≥ 0
+    z₀ ≥ 0
+    This constraint is differentiable everywhere, but z₀²-(z₁²+...+zₙ₋₁²) ≥ 0 is
+ non-convex. The default is to use the first formulation. For more information
+ and visualization, please refer to
  https://inst.eecs.berkeley.edu/~ee127a/book/login/l_socp_soc.html
  */
 class LorentzConeConstraint : public Constraint {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LorentzConeConstraint)
 
+  /**
+   * We provide three possible Eval functions to represent the Lorentz cone
+   * constraint z₀ ≥ sqrt(z₁² + ... + zₙ₋₁²). For more explanation on the three
+   * formulations, refer to LorentzConeConstraint documentation.
+   */
+  enum class EvalType {
+    kConvex,  ///< The constraint is g(z) = z₀ - sqrt(z₁² + ... + zₙ₋₁²) ≥ 0
+    kConvexSmooth,  ///< Same as kConvex1, but with approximated gradient.
+    kNonconvex  ///< Nonconvex constraint z₀²-(z₁²+...+zₙ₋₁²) ≥ 0 and z₀ ≥ 0
+  };
+
   LorentzConeConstraint(const Eigen::Ref<const Eigen::MatrixXd>& A,
-                        const Eigen::Ref<const Eigen::VectorXd>& b)
-      : Constraint(
-            2, A.cols(), Eigen::Vector2d::Constant(0.0),
-            Eigen::Vector2d::Constant(std::numeric_limits<double>::infinity())),
-        A_(A.sparseView()),
-        A_dense_(A),
-        b_(b) {
-    DRAKE_DEMAND(A_.rows() >= 2);
-    DRAKE_ASSERT(A_.rows() == b_.rows());
-  }
+                        const Eigen::Ref<const Eigen::VectorXd>& b,
+                        EvalType eval_type = EvalType::kConvex);
 
   ~LorentzConeConstraint() override {}
 
@@ -331,6 +337,7 @@ class LorentzConeConstraint : public Constraint {
   // using AutoDiffXd, and return the gradient as a dense matrix.
   const Eigen::MatrixXd A_dense_;
   const Eigen::VectorXd b_;
+  const EvalType eval_type_;
 };
 
 /**


### PR DESCRIPTION
So as to improve the convergence of solving nonlinear gradient based optimization with Lorentz cone constraint.

This PR is motivated by the Slack discussion https://drakedevelopers.slack.com/archives/C3L92BM2Q/p1590795131052300

cc @mposa

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13458)
<!-- Reviewable:end -->
