### PR TITLE
setup: On Bionic, the kcov dependency is now opt-in

### DIFF
--- a/doc/bazel.rst
+++ b/doc/bazel.rst
@@ -266,6 +266,9 @@ kcov
 ``kcov`` can analyze coverage for any binary that contains DWARF format
 debuggging symbols, and produce nicely formatted browse-able coverage reports.
 
+To use kcov, you must first run Drake's ``install_prereqs`` setup script using
+the ``--with-kcov`` option.
+
 To analyze test coverage, run the tests under ``kcov``::
 
   bazel test --config kcov //...

--- a/setup/ubuntu/install_prereqs.sh
+++ b/setup/ubuntu/install_prereqs.sh
@@ -27,7 +27,11 @@ source "${BASH_SOURCE%/*}/binary_distribution/install_prereqs.sh"
 # The following additional dependencies are only needed when developing with
 # source distributions.
 
-source "${BASH_SOURCE%/*}/source_distribution/install_prereqs.sh"
+if [[ "$#" -eq 1 ]] && [[ "$1" == "--with-kcov" ]]; then
+  source "${BASH_SOURCE%/*}/source_distribution/install_prereqs.sh" --with-kcov
+else
+  source "${BASH_SOURCE%/*}/source_distribution/install_prereqs.sh"
+fi
 
 # Configure user environment, executing as user if we're under `sudo`.
 user_env_script="${BASH_SOURCE%/*}/source_distribution/install_prereqs_user_environment.sh"

--- a/setup/ubuntu/source_distribution/install_prereqs.sh
+++ b/setup/ubuntu/source_distribution/install_prereqs.sh
@@ -23,10 +23,15 @@ EOF
 
 codename=$(lsb_release -sc)
 
-if [[ "${codename}" == 'bionic' ]]; then
-  # We only need this apt site for kcov-35 on Bionic.
+# On Bionic, developers must opt-in to kcov support; it comes in with the
+# non-standard package name kcov-35 via a Drake-specific PPA.
+if [[ "${codename}" == 'bionic' ]] &&
+    [[ "$#" -eq 1 ]] &&
+    [[ "$1" == "--with-kcov" ]]; then
   wget -O - https://drake-apt.csail.mit.edu/drake.pub.gpg | apt-key add
   echo "deb [arch=amd64] https://drake-apt.csail.mit.edu/${codename} ${codename} main" > /etc/apt/sources.list.d/drake.list
+  apt-get update
+  apt-get install --no-install-recommends kcov-35
 fi
 
 apt-get update

--- a/setup/ubuntu/source_distribution/packages-bionic.txt
+++ b/setup/ubuntu/source_distribution/packages-bionic.txt
@@ -12,7 +12,6 @@ gdb
 gfortran
 git
 jupyter
-kcov-35
 libblas-dev
 libbz2-dev
 libclang-6.0-dev


### PR DESCRIPTION
This resolves the immediate problem of `drake-apt.csail.mit.edu` certificate "expiry" (for buggy clients).

However, it is also a useful improvement towards #13168 optional prerequisites.  While the mechanism of this may change (`--with-kcov` spelling), the idea that extra developer tools should be opt-in is one that should remain.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13462)
<!-- Reviewable:end -->
