### PR TITLE
systems: Use Eigen's formatting in VectorBase::operator<<() output

### DIFF
--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -407,6 +407,8 @@ class TestGeneral(unittest.TestCase):
         integrator = Integrator(3)
         integrator.set_name("integrator")
         context = integrator.CreateDefaultContext()
+        # N.B. This is only to show behavior of C++ string formatting in
+        # Python. It is OK to update this when the upstream C++ code changes.
         self.assertEqual(
             str(context),
             dedent("""\
@@ -415,7 +417,7 @@ class TestGeneral(unittest.TestCase):
             Time: 0
             States:
               3 continuous states
-                [0, 0, 0]
+                0 0 0
 
             """),
         )

--- a/systems/framework/test/basic_vector_test.cc
+++ b/systems/framework/test/basic_vector_test.cc
@@ -189,21 +189,34 @@ GTEST_TEST(BasicVectorTest, PlusEqScaled) {
   EXPECT_EQ(ans5, ogvec.get_value());
 }
 
+template <typename T>
+class TypedBasicVectorTest : public ::testing::Test {};
+
+using DefaultScalars =
+    ::testing::Types<double, AutoDiffXd, symbolic::Expression>;
+TYPED_TEST_SUITE(TypedBasicVectorTest, DefaultScalars);
+
 // Tests ability to stream a BasicVector into a string.
-GTEST_TEST(BasicVectorTest, StringStream) {
-  BasicVector<double> vec(3);
+TYPED_TEST(TypedBasicVectorTest, StringStream) {
+  using T = TypeParam;
+  BasicVector<T> vec(3);
   vec.get_mutable_value() << 1.0, 2.2, 3.3;
   std::stringstream s;
   s << "hello " << vec << " world";
-  EXPECT_EQ(s.str(), "hello [1, 2.2, 3.3] world");
+  std::stringstream s_expected;
+  s_expected << "hello " << vec.get_value().transpose() << " world";
+  EXPECT_EQ(s.str(), s_expected.str());
 }
 
 // Tests ability to stream a BasicVector of size zero into a string.
-GTEST_TEST(BasicVectorTest, ZeroLengthStringStream) {
-  BasicVector<double> vec(0);
+TYPED_TEST(TypedBasicVectorTest, ZeroLengthStringStream) {
+  using T = TypeParam;
+  BasicVector<T> vec(0);
   std::stringstream s;
-  s << "foo " << vec << " bar";
-  EXPECT_EQ(s.str(), "foo [] bar");
+  s << "foo [" << vec << "] bar";
+  std::stringstream s_expected;
+  s_expected << "foo [" << vec.get_value().transpose() << "] bar";
+  EXPECT_EQ(s.str(), s_expected.str());
 }
 
 // Tests the default set of bounds (empty).

--- a/systems/framework/test/continuous_state_test.cc
+++ b/systems/framework/test/continuous_state_test.cc
@@ -239,7 +239,10 @@ TEST_F(ContinuousStateTest, Clone) {
 TEST_F(ContinuousStateTest, StringStream) {
   std::stringstream s;
   s << "hello " << continuous_state_->get_vector() << " world";
-  EXPECT_EQ(s.str(), "hello [1, 2, 3, 4] world");
+  std::stringstream s_expected;
+  VectorXd eigen_vector = continuous_state_->CopyToVector();
+  s_expected << "hello " << eigen_vector.transpose() << " world";
+  EXPECT_EQ(s.str(), s_expected.str());
 }
 
 // Tests for DiagramContinousState.

--- a/systems/framework/vector_base.h
+++ b/systems/framework/vector_base.h
@@ -225,19 +225,11 @@ class VectorBase {
   }
 };
 
-// Allows a VectorBase<T> to be streamed into a string. This is useful for
-// debugging purposes.
+/// Allows a VectorBase<T> to be streamed into a string as though it were a
+/// RowVectorX<T>. This is useful for debugging purposes.
 template <typename T>
 std::ostream& operator<<(std::ostream& os, const VectorBase<T>& vec) {
-  os << "[";
-
-  for (int i = 0; i < vec.size(); ++i) {
-    if (i > 0)
-      os << ", ";
-    os << vec[i];
-  }
-
-  os << "]";
+  os << vec.CopyToVector().transpose();
   return os;
 }
 


### PR DESCRIPTION
This restores PR #13365
This reverts commit fca17492ebb64e1d634d3422e376769e99238a0d (#13384)

Resolves #13395

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13464)
<!-- Reviewable:end -->
