### PR TITLE
Use S3 bucket directly for drake-apt due to SSL certificate issues

### DIFF
--- a/doc/ubuntu.rst
+++ b/doc/ubuntu.rst
@@ -9,5 +9,5 @@ Prerequisite setup is automated, simply run::
     sudo ./setup/ubuntu/install_prereqs.sh
 
 You may need to respond to interactive prompts to confirm that you agree to add
-the Drake `apt` repository (``https://drake-apt.csail.mit.edu/bionic/``) to
+the Drake `apt` repository (``https://drake-apt.s3.amazonaws.com/bionic/``) to
 your system for certain development packages.

--- a/setup/ubuntu/source_distribution/install_prereqs.sh
+++ b/setup/ubuntu/source_distribution/install_prereqs.sh
@@ -28,8 +28,8 @@ codename=$(lsb_release -sc)
 if [[ "${codename}" == 'bionic' ]] &&
     [[ "$#" -eq 1 ]] &&
     [[ "$1" == "--with-kcov" ]]; then
-  wget -O - https://drake-apt.csail.mit.edu/drake.pub.gpg | apt-key add
-  echo "deb [arch=amd64] https://drake-apt.csail.mit.edu/${codename} ${codename} main" > /etc/apt/sources.list.d/drake.list
+  wget -O - https://drake-apt.s3.amazonaws.com/drake.pub.gpg | apt-key add
+  echo "deb [arch=amd64] https://drake-apt.s3.amazonaws.com/${codename} ${codename} main" > /etc/apt/sources.list.d/drake.list
   apt-get update
   apt-get install --no-install-recommends kcov-35
 fi

--- a/tools/workspace/ibex/repository.bzl
+++ b/tools/workspace/ibex/repository.bzl
@@ -84,7 +84,6 @@ ibex_repository = repository_rule(
         # documented in the new_deb_archive rule.
         "mirrors": attr.string_list(
             default = [
-                "https://drake-apt.csail.mit.edu/bionic/pool/main",
                 "https://s3.amazonaws.com/drake-apt/bionic/pool/main",
             ],
         ),


### PR DESCRIPTION
For some reason, this certificate is being difficult, so may need to be re-issued, which will take more time. Use the underlying S3 bucket URL directly for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13466)
<!-- Reviewable:end -->
