### PR TITLE
Unit test CalcForceElementsContribution() includes gravity.

### DIFF
--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -70,6 +70,7 @@ using multibody::benchmarks::acrobot::AcrobotParameters;
 using multibody::benchmarks::acrobot::MakeAcrobotPlant;
 using multibody::benchmarks::pendulum::MakePendulumPlant;
 using multibody::benchmarks::pendulum::PendulumParameters;
+using multibody::MultibodyForces;
 using multibody::Parser;
 using systems::BasicVector;
 using systems::ConstantVectorSource;
@@ -550,6 +551,60 @@ class AcrobotPlantTests : public ::testing::Test {
 
     EXPECT_TRUE(CompareMatrices(
         tau_g, tau_g_expected, kTolerance, MatrixCompareType::relative));
+
+    // Alternatively, we can use CalcForceElementsContribution().
+    MultibodyForces<double> forces(*plant_);
+    plant_->CalcForceElementsContribution(*plant_context_, &forces);
+    // N.B. For this particular model we know `forces` only includes generalized
+    // forces due to dissipation at the joints and spatial forces due to
+    // gravity. In general after this call, MultibodyForces will contain a soup
+    // of all forces stemming from a ForceElement making it impossible to
+    // discern separate contributions. Therefore we should always use
+    // ForceElement's API to retrieve the specific component we are interested
+    // in. Here we access the internal data in MultibodyForces directly for
+    // testing purposes only, a pattern not to be followed.
+
+    // We verify first the body spatial forces include gravity. For this case,
+    // it is all they should include. Skip the world, index = 0.
+    const Vector3<double> gacc = plant_->gravity_field().gravity_vector();
+    for (BodyIndex body_index(1); body_index < plant_->num_bodies();
+         ++body_index) {
+      const Body<double>& body = plant_->get_body(body_index);
+      const SpatialForce<double>& F_Bo_W =
+          body.GetForceInWorld(*plant_context_, forces);
+      const double mass = body.get_default_mass();
+      // TODO(amcastro-tri): provide Body::EvalCOMInWorld().
+      const Vector3<double> p_BoBcm_B =
+          body.CalcCenterOfMassInBodyFrame(*plant_context_);
+      const RigidTransform<double> X_WB =
+          plant_->EvalBodyPoseInWorld(*plant_context_, body);
+      const RotationMatrix<double> R_WB = X_WB.rotation();
+      const Vector3<double> p_BoBcm_W = R_WB * p_BoBcm_B;
+
+      const Vector3<double> f_Bo_W_expected = mass * gacc;
+      const Vector3<double> t_Bo_W_expected = p_BoBcm_W.cross(f_Bo_W_expected);
+      EXPECT_TRUE(CompareMatrices(F_Bo_W.translational(), f_Bo_W_expected,
+                                  kTolerance, MatrixCompareType::relative));
+      EXPECT_TRUE(CompareMatrices(F_Bo_W.rotational(), t_Bo_W_expected,
+                                  kTolerance, MatrixCompareType::relative));
+    }
+
+    // Now we'll use inverse dynamics to obtain the generalized forces
+    // contribution due to gravity.
+
+    // Zero generalized forces due to joint dissipation.
+    forces.mutable_generalized_forces().setZero();
+
+    // Zero accelerations.
+    const VectorX<double> zero_vdot =
+        VectorX<double>::Zero(plant_->num_velocities());
+    // Zero velocities.
+    shoulder_->set_angular_rate(plant_context_, 0.0);
+    elbow_->set_angular_rate(plant_context_, 0.0);
+    const VectorX<double> tau_g_id =
+        -plant_->CalcInverseDynamics(*plant_context_, zero_vdot, forces);
+    EXPECT_TRUE(CompareMatrices(tau_g_id, tau_g_expected, kTolerance,
+                                MatrixCompareType::relative));
   }
 
   // Verifies the computation performed by MultibodyPlant::CalcTimeDerivatives()


### PR DESCRIPTION
The effect of gravity alone is much better accessed through `MBP::CalcGravityGeneralizedForces()` or alternatively `MBP::gravity_field().CalcGravityGeneralizedForces()`. 
However, given that #13460 reports what seems a bug, this PR introduces unit tests to verify that `CalcForceElementsContribution()` does include the effect of gravity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13474)
<!-- Reviewable:end -->
