### PR TITLE
Add clang-9 compiler to prerequisites

### DIFF
--- a/setup/ubuntu/source_distribution/packages-bionic.txt
+++ b/setup/ubuntu/source_distribution/packages-bionic.txt
@@ -1,5 +1,6 @@
 bash-completion
 clang
+clang-9
 clang-format-9
 coinor-libclp-dev
 coinor-libipopt-dev

--- a/setup/ubuntu/source_distribution/packages-focal.txt
+++ b/setup/ubuntu/source_distribution/packages-focal.txt
@@ -1,5 +1,5 @@
 bash-completion
-clang
+clang-9
 clang-format-9
 coinor-libclp-dev
 coinor-libipopt-dev

--- a/tools/dynamic_analysis/drd.sh
+++ b/tools/dynamic_analysis/drd.sh
@@ -24,6 +24,6 @@ valgrind \
     --suppressions=/usr/lib/valgrind/python.supp \
     --tool=drd \
     --trace-children=yes \
-    --trace-children-skip=/bin/cat,/bin/cp,/bin/ln,/bin/ls,/bin/mkdir,/bin/mv,/bin/sed,/lib/ld-linux.so.\*,/lib64/ld-linux-x86-64.so.\*,/usr/bin/clang,/usr/bin/clang-6.0,/usr/bin/clang-format-9,/usr/bin/diff,/usr/bin/dot,/usr/bin/fc-list,/usr/bin/file,/usr/bin/find,/usr/bin/gcc,/usr/bin/ldd,/usr/bin/patchelf,/usr/bin/strip,/usr/bin/uname,\*/external/buildifier/buildifier \
+    --trace-children-skip=/bin/cat,/bin/cp,/bin/ln,/bin/ls,/bin/mkdir,/bin/mv,/bin/sed,/lib/ld-linux.so.\*,/lib64/ld-linux-x86-64.so.\*,/usr/bin/clang,/usr/bin/clang-6.0,/usr/bin/clang-9,/usr/bin/clang-format-9,/usr/bin/diff,/usr/bin/dot,/usr/bin/fc-list,/usr/bin/file,/usr/bin/find,/usr/bin/gcc,/usr/bin/ldd,/usr/bin/patchelf,/usr/bin/strip,/usr/bin/uname,\*/external/buildifier/buildifier \
     --trace-children-skip-by-arg=meshcat.servers.zmqserver,uname \
     "$@"

--- a/tools/dynamic_analysis/helgrind.sh
+++ b/tools/dynamic_analysis/helgrind.sh
@@ -24,6 +24,6 @@ valgrind \
     --suppressions=/usr/lib/valgrind/python.supp \
     --tool=helgrind \
     --trace-children=yes \
-    --trace-children-skip=/bin/cat,/bin/cp,/bin/ln,/bin/ls,/bin/mkdir,/bin/mv,/bin/sed,/lib/ld-linux.so.\*,/lib64/ld-linux-x86-64.so.\*,/usr/bin/clang,/usr/bin/clang-6.0,/usr/bin/clang-format-9,/usr/bin/diff,/usr/bin/dot,/usr/bin/fc-list,/usr/bin/file,/usr/bin/find,/usr/bin/gcc,/usr/bin/ldd,/usr/bin/patchelf,/usr/bin/strip,/usr/bin/uname,\*/external/buildifier/buildifier \
+    --trace-children-skip=/bin/cat,/bin/cp,/bin/ln,/bin/ls,/bin/mkdir,/bin/mv,/bin/sed,/lib/ld-linux.so.\*,/lib64/ld-linux-x86-64.so.\*,/usr/bin/clang,/usr/bin/clang-6.0,/usr/bin/clang-9,/usr/bin/clang-format-9,/usr/bin/diff,/usr/bin/dot,/usr/bin/fc-list,/usr/bin/file,/usr/bin/find,/usr/bin/gcc,/usr/bin/ldd,/usr/bin/patchelf,/usr/bin/strip,/usr/bin/uname,\*/external/buildifier/buildifier \
     --trace-children-skip-by-arg=meshcat.servers.zmqserver,uname \
     "$@"

--- a/tools/dynamic_analysis/valgrind.sh
+++ b/tools/dynamic_analysis/valgrind.sh
@@ -26,7 +26,7 @@ valgrind \
     --suppressions=/usr/lib/valgrind/python.supp \
     --tool=memcheck \
     --trace-children=yes \
-    --trace-children-skip=/bin/cat,/bin/cp,/bin/ln,/bin/ls,/bin/mkdir,/bin/mv,/bin/sed,/lib/ld-linux.so.\*,/lib64/ld-linux-x86-64.so.\*,/usr/bin/clang,/usr/bin/clang-6.0,/usr/bin/clang-format-9,/usr/bin/diff,/usr/bin/dot,/usr/bin/fc-list,/usr/bin/file,/usr/bin/find,/usr/bin/gcc,/usr/bin/ldd,/usr/bin/patchelf,/usr/bin/strip,/usr/bin/uname,\*/external/buildifier/buildifier \
+    --trace-children-skip=/bin/cat,/bin/cp,/bin/ln,/bin/ls,/bin/mkdir,/bin/mv,/bin/sed,/lib/ld-linux.so.\*,/lib64/ld-linux-x86-64.so.\*,/usr/bin/clang,/usr/bin/clang-6.0,/usr/bin/clang-9,/usr/bin/clang-format-9,/usr/bin/diff,/usr/bin/dot,/usr/bin/fc-list,/usr/bin/file,/usr/bin/find,/usr/bin/gcc,/usr/bin/ldd,/usr/bin/patchelf,/usr/bin/strip,/usr/bin/uname,\*/external/buildifier/buildifier \
     --trace-children-skip-by-arg=meshcat.servers.zmqserver,uname \
     --track-origins=yes \
     "$@"


### PR DESCRIPTION
I was not intending to pull the trigger on clang-9 for bionic, but may as well add it to the scripts so we can start to iron out any issues. CI will need an update to actually use `/usr/bin/clang-9` instead of `/usr/bin/clang`.

Relates #13434.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13477)
<!-- Reviewable:end -->
