### PR TITLE
Resolve signed-unsigned comparison issues in TypeSafeIndex

### DIFF
--- a/common/test/type_safe_index_test.cc
+++ b/common/test/type_safe_index_test.cc
@@ -503,6 +503,67 @@ GTEST_TEST(IntegralComparisons, CompareSizeT) {
       AIndex junk(big_overflow_value), std::runtime_error,
       "Explicitly constructing an invalid index. Type .* has an invalid "
           "value; it must lie in the range .*");
+
+  // Now we test right out at the limit of the *smaller* type -- the int.
+  const AIndex biggest_index{std::numeric_limits<int>::max()};
+  const size_t equal(static_cast<int>(biggest_index));
+  const size_t bigger = equal + 1;
+  const size_t smaller = equal - 1;
+
+  EXPECT_FALSE(biggest_index == smaller);
+  EXPECT_TRUE(biggest_index != smaller);
+  EXPECT_FALSE(biggest_index < smaller);
+  EXPECT_FALSE(biggest_index <= smaller);
+  EXPECT_TRUE(biggest_index > smaller);
+  EXPECT_TRUE(biggest_index >= smaller);
+
+  EXPECT_TRUE(biggest_index == equal);
+  EXPECT_FALSE(biggest_index != equal);
+  EXPECT_FALSE(biggest_index < equal);
+  EXPECT_TRUE(biggest_index <= equal);
+  EXPECT_FALSE(biggest_index > equal);
+  EXPECT_TRUE(biggest_index >= equal);
+
+  EXPECT_FALSE(biggest_index == bigger);
+  EXPECT_TRUE(biggest_index != bigger);
+  EXPECT_TRUE(biggest_index < bigger);
+  EXPECT_TRUE(biggest_index <= bigger);
+  EXPECT_FALSE(biggest_index > bigger);
+  EXPECT_FALSE(biggest_index >= bigger);
+}
+
+// Confirms that comparisons with unsigned types that have fewer bits than
+// TypeSafeIndex's underlying int report propertly.
+GTEST_TEST(TypeSafeIndex, CompareUnsignedShort) {
+  TestScalarComparisons<uint16_t>();
+  TestScalarIncrement<uint16_t>();
+
+  // Test right out at the limit of the *smaller* type -- the uint16_t.
+  const uint16_t big_unsigned = std::numeric_limits<uint16_t>::max();
+  const AIndex bigger_index{static_cast<int>(big_unsigned) + 1};
+  const AIndex smaller_index{static_cast<int>(big_unsigned) - 1};
+  const AIndex equal_index(static_cast<int>(big_unsigned));
+
+  EXPECT_FALSE(bigger_index == big_unsigned);
+  EXPECT_TRUE(bigger_index != big_unsigned);
+  EXPECT_FALSE(bigger_index < big_unsigned);
+  EXPECT_FALSE(bigger_index <= big_unsigned);
+  EXPECT_TRUE(bigger_index > big_unsigned);
+  EXPECT_TRUE(bigger_index >= big_unsigned);
+
+  EXPECT_TRUE(equal_index == big_unsigned);
+  EXPECT_FALSE(equal_index != big_unsigned);
+  EXPECT_FALSE(equal_index < big_unsigned);
+  EXPECT_TRUE(equal_index <= big_unsigned);
+  EXPECT_FALSE(equal_index > big_unsigned);
+  EXPECT_TRUE(equal_index >= big_unsigned);
+
+  EXPECT_FALSE(smaller_index == big_unsigned);
+  EXPECT_TRUE(smaller_index != big_unsigned);
+  EXPECT_TRUE(smaller_index < big_unsigned);
+  EXPECT_TRUE(smaller_index <= big_unsigned);
+  EXPECT_FALSE(smaller_index > big_unsigned);
+  EXPECT_FALSE(smaller_index >= big_unsigned);
 }
 
 // This tests that one index cannot be *constructed* from another index type,


### PR DESCRIPTION
When comparing an unsigned integral value with a TypeSafeIndex, we needed to account for the possibility that the unsigned integral value could contain larger values than the TypeSafeIndex. This was done by comparing the unsigned integer with the maximum int (the largest type safe
index value). This is intrinsically a signed-unsigned comparision which is problematic.

Instead, we cast the maximum int to the unsigned integral type. If the unsigned type is larger (more bits), the relationship will be fully preserved and unsigned values that are larger than can be represented will be detected.

If the unsigned type has fewer bits, the maximum int (01111.1111) will be truncated to a number consisting of all 1s, the maximum unsigned value of that number of bits. We are guaranteed that the unsigned _value_ must be less than or equal to that truncated value which means its less than or
equal to the full maximum index.

In other words:

value <= static_cast<U>(kMaxIndex) is always *true* if
    sizeof(U) < sizeof(int).

resolves #13482

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13486)
<!-- Reviewable:end -->
