### PR TITLE
Add GCC 9.3 on Focal to the support matrix

### DIFF
--- a/doc/bazel.rst
+++ b/doc/bazel.rst
@@ -37,10 +37,10 @@ typical examples below; for more reading about target patterns, see:
 https://docs.bazel.build/versions/master/user-manual.html#target-patterns.
 
 On Ubuntu, the default compiler is the first ``gcc`` compiler in the
-``PATH``, usually GCC 7.5 on Bionic. On macOS, the default compiler is the Apple
-LLVM compiler. To use Clang 6.0 on Ubuntu, set the ``CC`` and ``CXX``
-environment variables before running **bazel build**, **bazel test**, or any
-other **bazel** commands.
+``PATH``, usually GCC 7.5 on Bionic and GCC 9.3 on Focal. On macOS, the default
+compiler is the Apple LLVM compiler. To use Clang 6.0 on Ubuntu 18.04 (Bionic),
+set the ``CC`` and ``CXX`` environment variables before running **bazel build**,
+**bazel test** or any other **bazel** commands.
 
 Cheat sheet for operating on the entire project::
 
@@ -179,7 +179,7 @@ Install on Ubuntu
 3. ``export GRB_LICENSE_FILE=/path/to/gurobi.lic``.
 4. Download ``gurobi9.0.2_linux64.tar.gz``
 5. Unzip it.  We suggest that you use ``/opt/gurobi902`` to simplify working with Drake installations.
-6. If you unzipped into a location other than ``/opt/gurobi902``, then call ``export GUROBI_HOME=GUROBI_UNZIP_PATH/linux64`` to set the path you used, where in ``GUROBI_HOME`` folder you can find ``bin`` folder. 
+6. If you unzipped into a location other than ``/opt/gurobi902``, then call ``export GUROBI_HOME=GUROBI_UNZIP_PATH/linux64`` to set the path you used, where in ``GUROBI_HOME`` folder you can find ``bin`` folder.
 
 Install on macOS
 ~~~~~~~~~~~~~~~~

--- a/doc/developers.rst
+++ b/doc/developers.rst
@@ -81,8 +81,11 @@ Drake requires a compiler running in C++17 mode.
 +----------------------------------+-------+-------+---------------------+-------------------+--------+
 | Ubuntu 18.04 LTS (Bionic Beaver) | 3.0   | 3.10  | | Clang 6.0         | OpenJDK 11        | 3.6    |
 |                                  |       |       | | GCC 7.5 (default) |                   |        |
-+----------------------------------+       +-------+---------------------+-------------------+--------+
-| macOS Mojave (10.14)             |       | 3.17  | | Apple LLVM 11.0.0 | | AdoptOpenJDK 14 | 3.8    |
++----------------------------------+       +-------+---------------------+                   +--------+
+| Ubuntu 20.04 LTS (Focal Fossa)   |       | 3.16  | GCC 9.3             |                   | 3.8    |
+|                                  |       |       |                     |                   |        |
++----------------------------------+       +-------+---------------------+-------------------+        |
+| macOS Mojave (10.14)             |       | 3.17  | | Apple LLVM 11.0.0 | | AdoptOpenJDK 14 |        |
 |                                  |       |       | | (Xcode 11.3)      | | (HotSpot JVM)   |        |
 +----------------------------------+       |       +---------------------+                   |        |
 | macOS Catalina (10.15)           |       |       | | Apple LLVM 11.0.3 |                   |        |
@@ -119,8 +122,8 @@ to :ref:`ask for help <getting_help>`.
 Binary Packages
 ---------------
 
-The binary releases of Drake are built with GCC 7.5 on Ubuntu Bionic, and Apple
-LLVM 11.0.0 on macOS Mojave.
+The binary releases of Drake are built with GCC 7.5 on Ubuntu 18.04 (Bionic),
+GCC 9.3 on Ubuntu 20.04 (Focal), and Apple LLVM 11.0.0 on macOS Mojave.
 
 The links for these packages are listed in :ref:`binary-installation`.
 

--- a/doc/developers.rst
+++ b/doc/developers.rst
@@ -89,7 +89,7 @@ Drake requires a compiler running in C++17 mode.
 |                                  |       |       | | (Xcode 11.3)      | | (HotSpot JVM)   |        |
 +----------------------------------+       |       +---------------------+                   |        |
 | macOS Catalina (10.15)           |       |       | | Apple LLVM 11.0.3 |                   |        |
-|                                  |       |       | | (Xcode 11.4)      |                   |        |
+|                                  |       |       | | (Xcode 11.5)      |                   |        |
 +----------------------------------+-------+-------+---------------------+-------------------+--------+
 
 CPython is the only Python implementation supported. On Ubuntu, amd64
@@ -123,7 +123,7 @@ Binary Packages
 ---------------
 
 The binary releases of Drake are built with GCC 7.5 on Ubuntu 18.04 (Bionic),
-GCC 9.3 on Ubuntu 20.04 (Focal), and Apple LLVM 11.0.0 on macOS Mojave.
+GCC 9.3 on Ubuntu 20.04 (Focal), and Apple LLVM 11.0.3 on macOS Mojave.
 
 The links for these packages are listed in :ref:`binary-installation`.
 

--- a/doc/getting_help.rst
+++ b/doc/getting_help.rst
@@ -44,7 +44,7 @@ When reporting an issue, please consider providing the following information
 *   Operating system (*Ubuntu 18.04, macOS Catalina*)
 *   Language (C++, :ref:`Python <python-bindings>`)
 
-    -   C++ compiler (*GCC 7.5.0, Clang 6.0.0*)
+    -   C++ compiler (*GCC 7.5.0, GCC 9.3.0, Clang 6.0.0*)
     -   Python version (*Python 3.6.7*)
     -   Python distribution (*apt, homebrew*)
 

--- a/doc/ubuntu.rst
+++ b/doc/ubuntu.rst
@@ -7,7 +7,3 @@ Ubuntu
 Prerequisite setup is automated, simply run::
 
     sudo ./setup/ubuntu/install_prereqs.sh
-
-You may need to respond to interactive prompts to confirm that you agree to add
-the Drake `apt` repository (``https://drake-apt.csail.mit.edu/bionic/``) to
-your system for certain development packages.

--- a/setup/ubuntu/binary_distribution/install_prereqs.sh
+++ b/setup/ubuntu/binary_distribution/install_prereqs.sh
@@ -23,9 +23,6 @@ if [[ "${codename}" != 'bionic' && "${codename}" != 'focal' ]]; then
   echo 'ERROR: This script requires Ubuntu 18.04 (Bionic) or 20.04 (Focal)' >&2
   exit 2
 fi
-if [[ "${codename}" == 'focal' ]]; then
-  echo 'WARNING: Drake is not officially supported on Ubuntu 20.04 (Focal)' >&2
-fi
 
 apt-get install --no-install-recommends $(tr '\n' ' ' <<EOF
 build-essential

--- a/tools/workspace/ibex/repository.bzl
+++ b/tools/workspace/ibex/repository.bzl
@@ -42,8 +42,6 @@ def _impl(repo_ctx):
         return
     if os_result.ubuntu_release not in ["18.04", "20.04"]:
         fail("Operating system is NOT supported", attr = os_result)
-    if os_result.ubuntu_release == "20.04":
-        print("Using Ubuntu 18.04 (Bionic) package on Ubuntu 20.04 (Focal)")
     result = setup_new_deb_archive(repo_ctx)
     if result.error != None:
         fail("Unable to complete setup for @{} repository: {}".format(

--- a/tools/workspace/os.bzl
+++ b/tools/workspace/os.bzl
@@ -83,8 +83,6 @@ def _determine_linux(repository_ctx):
     # Match supported Ubuntu release(s). These should match those listed in
     # both doc/developers.rst the root CMakeLists.txt.
     for ubuntu_release in ["18.04", "20.04"]:
-        if ubuntu_release == "20.04":
-            print("WARNING: Drake is not officially supported on Ubuntu 20.04 (Focal)")  # noqa
         if distro == "Ubuntu " + ubuntu_release:
             return _make_result(ubuntu_release = ubuntu_release)
 


### PR DESCRIPTION
Depends on #13486 (hopefully). Relates #13102. Will need some provisioned images (#13488) and probably a Focal build running against pull requests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13487)
<!-- Reviewable:end -->
