### PR TITLE
py mbp, geometry: Bind __repr__ for indices + elements, __lt__ for indices

### DIFF
--- a/bindings/pydrake/common/test/type_safe_index_pybind_test.cc
+++ b/bindings/pydrake/common/test/type_safe_index_pybind_test.cc
@@ -68,9 +68,13 @@ GTEST_TEST(TypeSafeIndexTest, CheckCasting) {
   py::object py_index = py::eval("Index(10)");
   ASSERT_THROW(py_index.cast<OtherIndex>(), std::runtime_error);
 
+  // Check basic comparison.
   CheckValue("Index(10) == Index(10)", true);
   CheckValue("Index(10) == 10", true);
   CheckValue("10 == Index(10)", true);
+  CheckValue("Index(9) < Index(10)", true);
+  CheckValue("Index(11) < Index(10)", false);
+
   // Store values for hash computation so that their id()s cannot be recycled
   // by the GC; otherwise, if the correct `__hash__` implementation were
   // missing and it used the default implementation (using `id()`), we'd get a

--- a/bindings/pydrake/common/test/type_safe_index_pybind_test.cc
+++ b/bindings/pydrake/common/test/type_safe_index_pybind_test.cc
@@ -24,7 +24,7 @@ using test::SynchronizeGlobalsForPython3;
 
 template <typename T>
 void CheckValue(const string& expr, const T& expected) {
-  SCOPED_TRACE(expr);
+  SCOPED_TRACE("Python expression:\n  " + expr);
   EXPECT_EQ(py::eval(expr).cast<T>(), expected);
 }
 
@@ -78,6 +78,9 @@ GTEST_TEST(TypeSafeIndexTest, CheckCasting) {
   py::exec("a = Index(10); b = Index(10); c = Index(9)");
   CheckValue("hash(a) == hash(b)", true);
   CheckValue("hash(a) == hash(c)", false);
+
+  // Check string representation.
+  CheckValue("repr(Index(10)) == 'Index(10)'", true);
 }
 
 int main(int argc, char** argv) {

--- a/bindings/pydrake/common/type_safe_index_pybind.h
+++ b/bindings/pydrake/common/type_safe_index_pybind.h
@@ -13,26 +13,24 @@ namespace drake {
 namespace pydrake {
 
 /// Binds a TypeSafeIndex instantiation.
-template <typename Type>
+template <typename Class>
 auto BindTypeSafeIndex(
     py::module m, const std::string& name, const std::string& class_doc = "") {
-  py::class_<Type> cls(m, name.c_str(), class_doc.c_str());
+  py::class_<Class> cls(m, name.c_str(), class_doc.c_str());
   cls  // BR
       .def(py::init<int>(), pydrake_doc.drake.TypeSafeIndex.ctor.doc_0args)
-      .def("__int__", &Type::operator int)
-      .def(
-          "__eq__",
-          [](const Type* self, const Type* other) { return *self == *other; },
-          py::is_operator())
-      .def(
-          "__eq__", [](const Type* self, int other) { return *self == other; },
-          py::is_operator())
+      .def("__int__", &Class::operator int)
+      .def(py::self == py::self)
+      .def(py::self == int{})
       // TODO(eric.cousineau): Use `py::hash()` instead of `py::detail::hash()`
       // pending merge of: https://github.com/pybind/pybind11/pull/2217
       .def(py::detail::hash(py::self))
       // TODO(eric.cousineau): Add more operators.
-      .def("is_valid", &Type::is_valid,
-          pydrake_doc.drake.TypeSafeIndex.is_valid.doc);
+      .def("is_valid", &Class::is_valid,
+          pydrake_doc.drake.TypeSafeIndex.is_valid.doc)
+      .def("__repr__", [name](const Class& self) {
+        return py::str("{}({})").format(name, static_cast<int>(self));
+      });
   return cls;
 }
 

--- a/bindings/pydrake/common/type_safe_index_pybind.h
+++ b/bindings/pydrake/common/type_safe_index_pybind.h
@@ -22,6 +22,7 @@ auto BindTypeSafeIndex(
       .def("__int__", &Class::operator int)
       .def(py::self == py::self)
       .def(py::self == int{})
+      .def(py::self < py::self)
       // TODO(eric.cousineau): Use `py::hash()` instead of `py::detail::hash()`
       // pending merge of: https://github.com/pybind/pybind11/pull/2217
       .def(py::detail::hash(py::self))

--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -47,7 +47,10 @@ void BindIdentifier(py::module m, const std::string& name, const char* id_doc) {
       // TODO(eric.cousineau): Use `py::hash()` instead of `py::detail::hash()`
       // pending merge of: https://github.com/pybind/pybind11/pull/2217
       .def(py::detail::hash(py::self))
-      .def_static("get_new_id", &Class::get_new_id, cls_doc.get_new_id.doc);
+      .def_static("get_new_id", &Class::get_new_id, cls_doc.get_new_id.doc)
+      .def("__repr__", [name](const Class& self) {
+        return py::str("<{} value={}>").format(name, self.get_value());
+      });
 }
 
 void def_geometry_render(py::module m) {

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -143,7 +143,9 @@ class TestPlant(unittest.TestCase):
 
     def test_type_safe_indices(self):
         self.assertEqual(world_index(), BodyIndex(0))
+        self.assertEqual(repr(world_index()), "BodyIndex(0)")
         self.assertEqual(world_model_instance(), ModelInstanceIndex(0))
+        self.assertEqual(repr(world_model_instance()), "ModelInstanceIndex(0)")
         self.assertEqual(default_model_instance(), ModelInstanceIndex(1))
 
     def assert_sane(self, x, nonzero=True):
@@ -169,7 +171,6 @@ class TestPlant(unittest.TestCase):
         body_com = body.default_com()
         body_default_unit_inertia = body.default_unit_inertia()
         body_default_spatial_inertial = body.default_spatial_inertia()
-
         new_model_instance = plant.AddModelInstance("new_model_instance")
         body = plant.AddRigidBody(name="new_body_2",
                                   M_BBo_B=spatial_inertia,
@@ -223,6 +224,10 @@ class TestPlant(unittest.TestCase):
         InputPort = InputPort_[T]
         OutputPort = OutputPort_[T]
 
+        def check_repr(element, expected):
+            if T == float:
+                self.assertEqual(repr(element), expected)
+
         # TODO(eric.cousineau): Decouple this when construction can be done
         # without parsing.
         # This a subset of `multibody_plant_sdf_parser_test.cc`.
@@ -232,6 +237,7 @@ class TestPlant(unittest.TestCase):
         plant_f = MultibodyPlant_[float](time_step=0.01)
         model_instance = Parser(plant_f).AddModelFromFile(file_name)
         self.assertIsInstance(model_instance, ModelInstanceIndex)
+        check_repr(model_instance, "ModelInstanceIndex(2)")
         plant_f.Finalize()
         plant = to_type(plant_f, T)
 
@@ -269,6 +275,10 @@ class TestPlant(unittest.TestCase):
             name="ShoulderJoint", model_instance=model_instance))
         shoulder = plant.GetJointByName(name="ShoulderJoint")
         self._test_joint_api(T, shoulder)
+        check_repr(
+            shoulder,
+            "<RevoluteJoint_[float] name='ShoulderJoint' index=0 "
+            "model_instance=2>")
         np.testing.assert_array_equal(
             shoulder.position_lower_limits(), [-np.inf])
         np.testing.assert_array_equal(
@@ -277,14 +287,22 @@ class TestPlant(unittest.TestCase):
             name="ShoulderJoint", model_instance=model_instance))
         self._test_joint_actuator_api(
             T, plant.GetJointActuatorByName(name="ElbowJoint"))
-        self._test_body_api(T, plant.GetBodyByName(name="Link1"))
+        link1 = plant.GetBodyByName(name="Link1")
+        self._test_body_api(T, link1)
         self.assertIs(
-            plant.GetBodyByName(name="Link1"),
+            link1,
             plant.GetBodyByName(name="Link1", model_instance=model_instance))
         self.assertEqual(len(plant.GetBodyIndices(model_instance)), 2)
+        check_repr(
+            link1,
+            "<RigidBody_[float] name='Link1' index=1 model_instance=2>")
         self._test_frame_api(T, plant.GetFrameByName(name="Link1"))
+        link1_frame = plant.GetFrameByName(name="Link1")
+        check_repr(
+            link1_frame,
+            "<BodyFrame_[float] name='Link1' index=1 model_instance=2>")
         self.assertIs(
-            plant.GetFrameByName(name="Link1"),
+            link1_frame,
             plant.GetFrameByName(name="Link1", model_instance=model_instance))
         self.assertTrue(plant.HasModelInstanceNamed(name="acrobot"))
         self.assertEqual(
@@ -302,8 +320,13 @@ class TestPlant(unittest.TestCase):
         self.assertIsInstance(plant.num_frames(), int)
         self.assertIsInstance(plant.get_body(body_index=BodyIndex(0)), Body)
         self.assertIs(shoulder, plant.get_joint(joint_index=JointIndex(0)))
-        self.assertIsInstance(plant.get_joint_actuator(
-            actuator_index=JointActuatorIndex(0)), JointActuator)
+        joint_actuator = plant.get_joint_actuator(
+            actuator_index=JointActuatorIndex(0))
+        self.assertIsInstance(joint_actuator, JointActuator)
+        check_repr(
+            joint_actuator,
+            "<JointActuator_[float] name='ElbowJoint' index=0 "
+            "model_instance=2>")
         self.assertIsInstance(
             plant.get_frame(frame_index=FrameIndex(0)), Frame)
         self.assertEqual("acrobot", plant.GetModelInstanceName(
@@ -453,6 +476,10 @@ class TestPlant(unittest.TestCase):
             bodyA=body_a, p_AP=[0., 0., 0.],
             bodyB=body_b, p_BQ=[0., 0., 0.],
             free_length=1., stiffness=2., damping=3.))
+        if T == float:
+            self.assertEqual(
+                repr(linear_spring),
+                "<LinearSpringDamper_[float] index=1 model_instance=1>")
         revolute_joint = plant.AddJoint(RevoluteJoint_[T](
                 name="revolve_joint", frame_on_parent=body_a.body_frame(),
                 frame_on_child=body_b.body_frame(), axis=[0, 0, 1],

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -147,6 +147,7 @@ class TestPlant(unittest.TestCase):
         self.assertEqual(world_model_instance(), ModelInstanceIndex(0))
         self.assertEqual(repr(world_model_instance()), "ModelInstanceIndex(0)")
         self.assertEqual(default_model_instance(), ModelInstanceIndex(1))
+        self.assertTrue(ModelInstanceIndex(0) < ModelInstanceIndex(1))
 
     def assert_sane(self, x, nonzero=True):
         self.assertTrue(np.all(np.isfinite(numpy_compare.to_float(x))))

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -45,6 +45,16 @@ This API using Isometry3 is / will be deprecated soon with the resolution of
 
 namespace {
 
+// Negative case for checking T::name().
+// https://stackoverflow.com/a/16000226/7829525
+template <typename T, typename = void>
+struct has_name_func : std::false_type {};
+
+// Positive case for checking T::name().
+template <typename T>
+struct has_name_func<T, decltype(std::declval<T>().name(), void())>
+    : std::true_type {};
+
 // Binds `MultibodyElement` methods.
 // N.B. We do this rather than inheritance because this template is more of a
 // mixin than it is a parent class (since it is not used for its dynamic
@@ -58,7 +68,19 @@ void BindMultibodyElementMixin(PyClass* pcls) {
   auto& cls = *pcls;
   cls  // BR
       .def("index", &Class::index)
-      .def("model_instance", &Class::model_instance);
+      .def("model_instance", &Class::model_instance)
+      .def("__repr__", [](const Class& self) {
+        py::str cls_name = py::cast(&self).get_type().attr("__name__");
+        const int index = self.index();
+        const int model_instance = self.model_instance();
+        if constexpr (has_name_func<Class>::value) {
+          return py::str("<{} name='{}' index={} model_instance={}>")
+              .format(cls_name, self.name(), index, model_instance);
+        } else {
+          return py::str("<{} index={} model_instance={}>")
+              .format(cls_name, index, model_instance);
+        }
+      });
 }
 
 void DoScalarIndependentDefinitions(py::module m) {

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -200,6 +200,10 @@ class TestGeometry(unittest.TestCase):
         self.assertIsNot(fake_id_1, fake_id_2)
         self.assertEqual(hash(fake_id_1), hash(fake_id_2))
 
+        self.assertEqual(
+            repr(fake_id_1),
+            f"<FakeId value={fake_id_1.get_value()}>")
+
     @numpy_compare.check_nonsymbolic_types
     def test_penetration_as_point_pair_api(self, T):
         obj = mut.PenetrationAsPointPair_[T]()


### PR DESCRIPTION
Motivated by subgraph prototype code:
* `__repr__` for easier debugging
* `__lt__` for sorting in Python lists

Towards #8586

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13489)
<!-- Reviewable:end -->
