### PR TITLE
py mbp: Add __lt__ for sorting on element references

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -288,7 +288,13 @@ class TestPlant(unittest.TestCase):
             name="ShoulderJoint", model_instance=model_instance))
         self._test_joint_actuator_api(
             T, plant.GetJointActuatorByName(name="ElbowJoint"))
+
+        # Purposely get links out of order to ensure the Python wrapper classes
+        # are constructed differently.
+        link2 = plant.GetBodyByName(name="Link2")
         link1 = plant.GetBodyByName(name="Link1")
+        self.assertTrue(link1 < link2)
+
         self._test_body_api(T, link1)
         self.assertIs(
             link1,

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -69,6 +69,15 @@ void BindMultibodyElementMixin(PyClass* pcls) {
   cls  // BR
       .def("index", &Class::index)
       .def("model_instance", &Class::model_instance)
+      .def("__lt__",
+          [](const Class& self, const Class& other) {
+            // N.B. `py::self < py::self` does not work here since there is
+            // currently not a MultibodyElement<>::operator<() defined. This
+            // is still useful in Python in ensuring that a homogeneous group
+            // of elements (from the same tree) can be used for stricter
+            // ordering, e.g. for `sorted()`.
+            return self.index() < other.index();
+          })
       .def("__repr__", [](const Class& self) {
         py::str cls_name = py::cast(&self).get_type().attr("__name__");
         const int index = self.index();


### PR DESCRIPTION
PR for discussion, split off from here:
https://github.com/robotlocomotion/drake/pull/13489#pullrequestreview-423742238

Can create issue too!

\cc @jwnimmer-tri @sherm1 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13495)
<!-- Reviewable:end -->
