### PR TITLE
Fix clang versions for which -Wself-assign-overloaded should be ignored

### DIFF
--- a/bindings/pydrake/symbolic_py.cc
+++ b/bindings/pydrake/symbolic_py.cc
@@ -13,14 +13,16 @@
 #include "drake/bindings/pydrake/symbolic_types_pybind.h"
 
 #pragma GCC diagnostic push
-// Apple LLVM version 10.0.1 (clang-1001.0.46.3) and Clang version 10.0.0 add
+// Apple LLVM version 10.0.1 (clang-1001.0.46.3) and Clang version 7.0.0 add
 // `-Wself-assign-overloaded` to `-Wall`, which generates warnings on
 // Pybind11's operator-overloading idiom that is using py::self (example:
 // `def(py::self + py::self)`). Here, we suppress the warning using
 // `#pragma diagnostic`.
-#if (__clang__) && (__clang_major__ >= 10) &&                 \
-    !((__apple_build_version__) && (__clang_major__ == 10) && \
-        (__clang_minor__ == 0) && (__clang_patchlevel__ == 0))
+#if defined(__clang__) &&                                          \
+    ((!(__apple_build_version__) && (__clang_major__ >= 7)) ||     \
+        ((__apple_build_version__) && (__clang_major__ >= 10) &&   \
+            !((__clang_major__ == 10) && (__clang_minor__ == 0) && \
+                (__clang_patchlevel__ == 0))))
 #pragma GCC diagnostic ignored "-Wself-assign-overloaded"
 #endif
 


### PR DESCRIPTION
Relates #13102 and #13434.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13502)
<!-- Reviewable:end -->
