### PR TITLE
Fix symbolic::Expression::Expand()

### DIFF
--- a/common/symbolic_expression_cell.cc
+++ b/common/symbolic_expression_cell.cc
@@ -139,6 +139,35 @@ Expression ExpandMultiplication(const Expression& e1, const Expression& e2) {
     }
     return fac.GetExpression();
   }
+  if (is_division(e1)) {
+    const Expression& e1_1{get_first_argument(e1)};
+    const Expression& e1_2{get_second_argument(e1)};
+    if (is_division(e2)) {
+      //    ((e1_1 / e1_2) * (e2_1 / e2_2)).Expand()
+      // => (e1_1 * e2_1).Expand() / (e1_2 * e2_2).Expand().
+      //
+      // Note that e1_1, e1_2, e2_1, and e_2 are already expanded by the
+      // precondition.
+      const Expression& e2_1{get_first_argument(e2)};
+      const Expression& e2_2{get_second_argument(e2)};
+      return ExpandMultiplication(e1_1, e2_1) /
+             ExpandMultiplication(e1_2, e2_2);
+    }
+    //    ((e1_1 / e1_2) * e2).Expand()
+    // => (e1_1 * e2).Expand() / e2.
+    //
+    // Note that e1_1, e1_2, and e_2 are already expanded by the precondition.
+    return ExpandMultiplication(e1_1, e2) / e1_2;
+  }
+  if (is_division(e2)) {
+    //    (e1 * (e2_1 / e2_2)).Expand()
+    // => (e1 * e2_1).Expand() / e2_2.
+    //
+    // Note that e1, e2_1, and e2_2 are already expanded by the precondition.
+    const Expression& e2_1{get_first_argument(e2)};
+    const Expression& e2_2{get_second_argument(e2)};
+    return ExpandMultiplication(e1, e2_1) / e2_2;
+  }
   return e1 * e2;
 }
 

--- a/common/test/symbolic_expansion_test.cc
+++ b/common/test/symbolic_expansion_test.cc
@@ -320,6 +320,24 @@ TEST_F(SymbolicExpansionTest, RepeatedExpandShouldBeNoop) {
   }
 }
 
+TEST_F(SymbolicExpansionTest, ExpandMultiplicationsWithDivisions) {
+  const Expression e1{((x_ + 1) / y_) * (x_ + 3)};
+  const Expression e2{(x_ + 3) * ((x_ + 1) / z_)};
+  const Expression e3{((x_ + 1) / (y_ + 6)) * ((x_ + 3) / (z_ + 7))};
+  const Expression e4{(x_ + y_ / ((z_ + x_) * (y_ + x_))) * (x_ - y_ / z_) *
+                      (x_ * y_ / z_)};
+
+  EXPECT_TRUE(CheckExpandIsFixpoint(e1));
+  EXPECT_TRUE(CheckExpandIsFixpoint(e2));
+  EXPECT_TRUE(CheckExpandIsFixpoint(e3));
+  EXPECT_TRUE(CheckExpandIsFixpoint(e4));
+
+  EXPECT_TRUE(CheckExpandPreserveEvaluation(e1, 1e-8));
+  EXPECT_TRUE(CheckExpandPreserveEvaluation(e2, 1e-8));
+  EXPECT_TRUE(CheckExpandPreserveEvaluation(e3, 1e-8));
+  EXPECT_TRUE(CheckExpandPreserveEvaluation(e4, 1e-8));
+}
+
 }  // namespace
 }  // namespace symbolic
 }  // namespace drake


### PR DESCRIPTION
In `ExpandMultiplication(e1, e2)`, it returns `e1 * e2` if both `e1` and `e2` are non-additive expressions. However, if at least one of them is a division expression, it is possible that `e1 * e2` is not an expanded expression.

For example, let `e1 = (x + 1) / y` and `e2 = (x + 3) / z`, `e1 * e2` becomes `(x + 1) * (x + 3) / yz` whose numerator is not expanded yet.

This commit fixes this problem by handling those cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13503)
<!-- Reviewable:end -->
