### PR TITLE
Add Focal-based Dockerfile for Docker Hub

### DIFF
--- a/tools/install/dockerhub/.gitignore
+++ b/tools/install/dockerhub/.gitignore
@@ -1,1 +1,0 @@
-drake-latest-bionic.tar.gz

--- a/tools/install/dockerhub/bionic/.dockerignore
+++ b/tools/install/dockerhub/bionic/.dockerignore
@@ -1,2 +1,3 @@
 .dockerignore
 Dockerfile
+README.md

--- a/tools/install/dockerhub/bionic/Dockerfile
+++ b/tools/install/dockerhub/bionic/Dockerfile
@@ -6,8 +6,8 @@ ADD drake-latest-bionic.tar.gz /opt
 RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get update -qq \
   && apt-get install --no-install-recommends -o Dpkg::Use-Pty=0 -qy \
-    $(cat /opt/drake/share/drake/setup/packages-bionic.txt | tr "\n" " ") \
+    $(cat /opt/drake/share/drake/setup/packages-bionic.txt) \
   && rm -rf /opt/drake/share/drake/setup /var/lib/apt/lists/*
-ENV LD_LIBRARY_PATH="/opt/drake/lib:$LD_LIBRARY_PATH" \
-  PATH="/opt/drake/bin:$PATH" \
-  PYTHONPATH="/opt/drake/lib/python3.6/site-packages:$PYTHONPATH"
+ENV LD_LIBRARY_PATH="/opt/drake/lib:${LD_LIBRARY_PATH}" \
+  PATH="/opt/drake/bin:${PATH}" \
+  PYTHONPATH="/opt/drake/lib/python3.6/site-packages:${PYTHONPATH}"

--- a/tools/install/dockerhub/bionic/README.md
+++ b/tools/install/dockerhub/bionic/README.md
@@ -1,13 +1,13 @@
-# Docker Image for Docker Hub
+# Docker Image for Docker Hub (Bionic)
 
-To create a Docker image similar to that hosted on
+To create a Docker image similar to those hosted on
 [Docker Hub](https://hub.docker.com/r/robotlocomotion/drake), download the
 latest [binary package](https://drake.mit.edu/from_binary.html)
 `drake-latest-bionic.tar.gz` to this directory, and then run the following
 command:
 
 ```bash
-docker build -t robotlocomotion/drake:latest .
+docker build -t robotlocomotion/drake:bionic -t robotlocomotion/drake:latest .
 ```
 
 To start a Docker container with an interactive pseudo-terminal, run the

--- a/tools/install/dockerhub/focal/.dockerignore
+++ b/tools/install/dockerhub/focal/.dockerignore
@@ -1,0 +1,3 @@
+.dockerignore
+Dockerfile
+README.md

--- a/tools/install/dockerhub/focal/Dockerfile
+++ b/tools/install/dockerhub/focal/Dockerfile
@@ -1,0 +1,13 @@
+# -*- mode: dockerfile -*-
+# vi: set ft=dockerfile :
+
+FROM ubuntu:focal
+ADD drake-latest-focal.tar.gz /opt
+RUN export DEBIAN_FRONTEND=noninteractive \
+  && apt-get update -qq \
+  && apt-get install --no-install-recommends -o Dpkg::Use-Pty=0 -qy \
+    $(cat /opt/drake/share/drake/setup/packages-focal.txt) \
+  && rm -rf /opt/drake/share/drake/setup /var/lib/apt/lists/*
+ENV LD_LIBRARY_PATH="/opt/drake/lib:${LD_LIBRARY_PATH}" \
+  PATH="/opt/drake/bin:${PATH}" \
+  PYTHONPATH="/opt/drake/lib/python3.8/site-packages:${PYTHONPATH}"

--- a/tools/install/dockerhub/focal/README.md
+++ b/tools/install/dockerhub/focal/README.md
@@ -1,0 +1,22 @@
+# Docker Image for Docker Hub (Focal)
+
+To create a Docker image similar to those hosted on
+[Docker Hub](https://hub.docker.com/r/robotlocomotion/drake), download the
+latest [binary package](https://drake.mit.edu/from_binary.html)
+`drake-latest-focal.tar.gz` to this directory, and then run the following
+command:
+
+```bash
+docker build -t robotlocomotion/drake:focal .
+```
+
+To start a Docker container with an interactive pseudo-terminal, run the
+following command:
+
+```bash
+docker run -it robotlocomotion/drake:focal
+```
+
+The environment variables `LD_LIBRARY`, `PATH`, and `PYTHONPATH` are preset to
+suitable values for using Drake, including, in particular, its Python
+bindings.


### PR DESCRIPTION
Relates #13102. There are duplicate Dockerfiles here rather than a single parameterized Dockerfile to match Docker Hub conventions. Building Focal-based Docker images on CI is currently disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13508)
<!-- Reviewable:end -->
