### PR TITLE
Bind ContextBase cache control methods

### DIFF
--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -175,10 +175,23 @@ void DefineFrameworkPySemantics(py::module m) {
         m, "Context", GetPyParam<T>(), doc.Context.doc);
     context_cls
         // Bindings for Context methods inherited from ContextBase.
-        .def("num_input_ports", &Context<T>::num_input_ports,
+        .def("num_input_ports", &ContextBase::num_input_ports,
             doc.ContextBase.num_input_ports.doc)
-        .def("num_output_ports", &Context<T>::num_output_ports,
+        .def("num_output_ports", &ContextBase::num_output_ports,
             doc.ContextBase.num_output_ports.doc)
+        .def("DisableCaching", &ContextBase::DisableCaching,
+            doc.ContextBase.DisableCaching.doc)
+        .def("EnableCaching", &ContextBase::EnableCaching,
+            doc.ContextBase.EnableCaching.doc)
+        .def("SetAllCacheEntriesOutOfDate",
+            &ContextBase::SetAllCacheEntriesOutOfDate,
+            doc.ContextBase.SetAllCacheEntriesOutOfDate.doc)
+        .def("FreezeCache", &ContextBase::FreezeCache,
+            doc.ContextBase.FreezeCache.doc)
+        .def("UnfreezeCache", &ContextBase::UnfreezeCache,
+            doc.ContextBase.UnfreezeCache.doc)
+        .def("is_cache_frozen", &ContextBase::is_cache_frozen,
+            doc.ContextBase.is_cache_frozen.doc)
         // TODO(russt): Add remaining methods from ContextBase here.
         // Bindings for the Context methods in the Doxygen group titled
         // "Accessors for locally-stored values", placed in the same order

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -185,6 +185,13 @@ class TestGeneral(unittest.TestCase):
         # abstract parameter to actually call this method.
         self.assertTrue(hasattr(context, "get_abstract_parameter"))
         self.assertTrue(hasattr(context, "get_mutable_abstract_parameter"))
+        context.DisableCaching()
+        context.EnableCaching()
+        context.SetAllCacheEntriesOutOfDate()
+        context.FreezeCache()
+        self.assertTrue(context.is_cache_frozen())
+        context.UnfreezeCache()
+        self.assertFalse(context.is_cache_frozen())
         x = np.array([0.1, 0.2])
         context.SetContinuousState(x)
         np.testing.assert_equal(


### PR DESCRIPTION
Add some missing Pydrake bindings for ContextBase methods for expert mucking around with the cache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13528)
<!-- Reviewable:end -->
