### PR TITLE
Make DiagramContext use the DiagramDiscreteValues type

### DIFF
--- a/systems/framework/diagram_context.h
+++ b/systems/framework/diagram_context.h
@@ -14,6 +14,7 @@
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/diagram_continuous_state.h"
+#include "drake/systems/framework/diagram_discrete_values.h"
 #include "drake/systems/framework/fixed_input_port_value.h"
 #include "drake/systems/framework/framework_common.h"
 #include "drake/systems/framework/parameters.h"
@@ -70,16 +71,14 @@ class DiagramState : public State<T> {
     finalized_ = true;
     std::vector<ContinuousState<T>*> sub_xcs;
     sub_xcs.reserve(num_substates());
-    std::vector<BasicVector<T>*> sub_xds;
+    std::vector<DiscreteValues<T>*> sub_xds;
     std::vector<AbstractValue*> sub_xas;
     for (State<T>* substate : substates_) {
       // Continuous
       sub_xcs.push_back(&substate->get_mutable_continuous_state());
       // Discrete
-      const std::vector<BasicVector<T>*>& xd_data =
-          substate->get_mutable_discrete_state().get_data();
-      sub_xds.insert(sub_xds.end(), xd_data.begin(), xd_data.end());
-      // Abstract
+      sub_xds.push_back(&substate->get_mutable_discrete_state());
+      // Abstract (no substructure)
       AbstractValues& xa = substate->get_mutable_abstract_state();
       for (int i_xa = 0; i_xa < xa.size(); ++i_xa) {
         sub_xas.push_back(&xa.get_mutable_value(i_xa));
@@ -93,7 +92,8 @@ class DiagramState : public State<T> {
     // pointers to that memory.
     this->set_continuous_state(
         std::make_unique<DiagramContinuousState<T>>(sub_xcs));
-    this->set_discrete_state(std::make_unique<DiscreteValues<T>>(sub_xds));
+    this->set_discrete_state(
+        std::make_unique<DiagramDiscreteValues<T>>(sub_xds));
     this->set_abstract_state(std::make_unique<AbstractValues>(sub_xas));
   }
 

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -1065,8 +1065,31 @@ TEST_F(DiagramTest, Clone) {
   diagram_->CalcOutput(*context_, output_.get());
   ExpectDefaultOutputs();
 
+  // Verify that we start with a DiagramContext with Diagram ingredients.
+  EXPECT_TRUE(is_dynamic_castable<DiagramContext<double>>(context_));
+  EXPECT_TRUE(is_dynamic_castable<DiagramContinuousState<double>>(
+      diagram_->AllocateTimeDerivatives()));
+  EXPECT_TRUE(is_dynamic_castable<DiagramDiscreteValues<double>>(
+      diagram_->AllocateDiscreteVariables()));
+  const State<double>& state = context_->get_state();
+  EXPECT_TRUE(is_dynamic_castable<DiagramState<double>>(&state));
+  EXPECT_TRUE(is_dynamic_castable<DiagramContinuousState<double>>(
+      &state.get_continuous_state()));
+  EXPECT_TRUE(is_dynamic_castable<DiagramDiscreteValues<double>>(
+      &state.get_discrete_state()));
+  // FYI there is no DiagramAbstractValues.
+
   // Create a clone of the context and change an input.
   auto clone = context_->Clone();
+
+  // Verify that the clone is also a DiagramContext with Diagram ingredients.
+  EXPECT_TRUE(is_dynamic_castable<DiagramContext<double>>(clone));
+  const State<double>& clone_state = context_->get_state();
+  EXPECT_TRUE(is_dynamic_castable<DiagramState<double>>(&clone_state));
+  EXPECT_TRUE(is_dynamic_castable<DiagramContinuousState<double>>(
+      &clone_state.get_continuous_state()));
+  EXPECT_TRUE(is_dynamic_castable<DiagramDiscreteValues<double>>(
+      &clone_state.get_discrete_state()));
 
   DRAKE_DEMAND(kSize == 3);
   clone->FixInputPort(0, {3, 6, 9});


### PR DESCRIPTION
DiagramContext used the continuous variable object type DiagramContinuousState but failed to keep the discrete variables in a DiagramDiscreteValues object, instead flatting them into a plain DiscreteValues object. In contrast diagram.AllocateDiscreteVariables() does return a DiagramDiscreteValues object, of the kind required for doing discrete variable updates. The result is that you can't do an update directly into the discrete state of a diagram context, as would reasonably be expected.

This PR fixes that and adds missing unit tests that would have caught this. There are no visible behavior changes in normal operation since DiscreteVariables and DiagramDiscreteVariables have nearly-identical interfaces.

This change affects the discrete variable object returned by diagram.CreateDefaultContext() and also diagram_context.Clone().

Fixes #11457

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13536)
<!-- Reviewable:end -->
