### PR TITLE
[WIP] Makes MBP::num_collision_geometries query scene graph for collision geometry

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -161,6 +161,16 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.num_geometries.doc)
         .def("GetAllGeometryIds", &Class::GetAllGeometryIds,
             cls_doc.GetAllGeometryIds.doc)
+        .def("GetGeometriesForFrame", &Class::GetGeometriesForFrame,
+            py::arg("id"), cls_doc.GetGeometriesForFrame.doc)
+        .def("GetGeometriesForFrameWithRole",
+            &Class::GetGeometriesForFrameWithRole, py::arg("id"),
+            py::arg("role"), cls_doc.GetGeometriesForFrameWithRole.doc)
+        .def("GetGeometriesForSource", &Class::GetGeometriesForSource,
+            py::arg("source_id"), cls_doc.GetGeometriesForSource.doc)
+        .def("GetGeometriesForSourceWithRole",
+            &Class::GetGeometriesForSourceWithRole, py::arg("source_id"),
+            py::arg("role"), cls_doc.GetGeometriesForSourceWithRole.doc)
         .def("NumGeometriesWithRole",
             overload_cast_explicit<int, Role>(&Class::NumGeometriesWithRole),
             py_reference_internal, py::arg("role"),

--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -161,8 +161,15 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.num_geometries.doc)
         .def("GetAllGeometryIds", &Class::GetAllGeometryIds,
             cls_doc.GetAllGeometryIds.doc)
-        .def("NumGeometriesWithRole", &Class::NumGeometriesWithRole,
-            py::arg("role"), cls_doc.NumGeometriesWithRole.doc)
+        .def("NumGeometriesWithRole",
+            overload_cast_explicit<int, Role>(&Class::NumGeometriesWithRole),
+            py_reference_internal, py::arg("role"),
+            cls_doc.NumGeometriesWithRole.doc_1args)
+        .def("NumGeometriesWithRole",
+            overload_cast_explicit<int, SourceId, Role>(
+                &Class::NumGeometriesWithRole),
+            py_reference_internal, py::arg("source_id"), py::arg("role"),
+            cls_doc.NumGeometriesWithRole.doc_2args)
         .def("NumDynamicGeometries", &Class::NumDynamicGeometries,
             cls_doc.NumDynamicGeometries.doc)
         .def("NumAnchoredGeometries", &Class::NumAnchoredGeometries,

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -660,8 +660,27 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("body_index"), py_reference_internal,
             cls_doc.GetBodyFrameIdIfExists.doc)
         .def("GetCollisionGeometriesForBody",
-            &Class::GetCollisionGeometriesForBody, py::arg("body"),
-            py_reference_internal, cls_doc.GetCollisionGeometriesForBody.doc)
+            overload_cast_explicit<std::vector<geometry::GeometryId>,
+                const Body<T>&>(&Class::GetCollisionGeometriesForBody),
+            py::arg("body"), py_reference_internal,
+            cls_doc.GetCollisionGeometriesForBody.doc_1args)
+        .def("GetCollisionGeometriesForBody",
+            overload_cast_explicit<std::vector<geometry::GeometryId>,
+                const systems::Context<T>&, const Body<T>&>(
+                &Class::GetCollisionGeometriesForBody),
+            py::arg("context"), py::arg("body"), py_reference_internal,
+            cls_doc.GetCollisionGeometriesForBody.doc_2args)
+        .def("GetVisualGeometriesForBody",
+            overload_cast_explicit<std::vector<geometry::GeometryId>,
+                const Body<T>&>(&Class::GetVisualGeometriesForBody),
+            py::arg("body"), py_reference_internal,
+            cls_doc.GetCollisionGeometriesForBody.doc_1args)
+        .def("GetVisualGeometriesForBody",
+            overload_cast_explicit<std::vector<geometry::GeometryId>,
+                const systems::Context<T>&, const Body<T>&>(
+                &Class::GetVisualGeometriesForBody),
+            py::arg("context"), py::arg("body"), py_reference_internal,
+            cls_doc.GetCollisionGeometriesForBody.doc_2args)
         .def("EvalNumCollisionGeometries", &Class::EvalNumCollisionGeometries,
             py::arg("context") = nullptr,
             cls_doc.EvalNumCollisionGeometries.doc)

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -662,8 +662,14 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("GetCollisionGeometriesForBody",
             &Class::GetCollisionGeometriesForBody, py::arg("body"),
             py_reference_internal, cls_doc.GetCollisionGeometriesForBody.doc)
-        .def("num_collision_geometries", &Class::num_collision_geometries,
-            cls_doc.num_collision_geometries.doc)
+        .def("num_collision_geometries",
+            overload_cast_explicit<int>(&Class::num_collision_geometries),
+            py_reference_internal, cls_doc.num_collision_geometries.doc_0args)
+        .def("num_collision_geometries",
+            overload_cast_explicit<int, const systems::Context<T>&>(
+                &Class::num_collision_geometries),
+            py::arg("context"), py_reference_internal,
+            cls_doc.num_collision_geometries.doc_1args)
         .def("CollectRegisteredGeometries", &Class::CollectRegisteredGeometries,
             py::arg("bodies"), cls_doc.CollectRegisteredGeometries.doc);
 #pragma GCC diagnostic push

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -662,21 +662,18 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("GetCollisionGeometriesForBody",
             &Class::GetCollisionGeometriesForBody, py::arg("body"),
             py_reference_internal, cls_doc.GetCollisionGeometriesForBody.doc)
-        .def("num_collision_geometries",
-            overload_cast_explicit<int>(&Class::num_collision_geometries),
-            py_reference_internal, cls_doc.num_collision_geometries.doc_0args)
-        .def("num_collision_geometries",
-            overload_cast_explicit<int, const systems::Context<T>&>(
-                &Class::num_collision_geometries),
-            py::arg("context"), py_reference_internal,
-            cls_doc.num_collision_geometries.doc_1args)
+        .def("EvalNumCollisionGeometries", &Class::EvalNumCollisionGeometries,
+            py::arg("context") = nullptr,
+            cls_doc.EvalNumCollisionGeometries.doc)
         .def("CollectRegisteredGeometries", &Class::CollectRegisteredGeometries,
             py::arg("bodies"), cls_doc.CollectRegisteredGeometries.doc);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     cls.def("default_coulomb_friction", &Class::default_coulomb_friction,
-        py::arg("geometry_id"), py_reference_internal,
-        cls_doc.default_coulomb_friction.doc_deprecated);
+           py::arg("geometry_id"), py_reference_internal,
+           cls_doc.default_coulomb_friction.doc_deprecated)
+        .def("num_collision_geometries", &Class::num_collision_geometries,
+            cls_doc.num_collision_geometries.doc_deprecated);
 #pragma GCC diagnostic pop
     DeprecateAttribute(cls, "default_coulomb_friction",
         cls_doc.default_coulomb_friction.doc_deprecated);

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -194,7 +194,7 @@ class TestPlant(unittest.TestCase):
             plant.RegisterCollisionGeometry(
                 body=body, X_BG=body_X_BG, shape=box,
                 name="new_body_collision", coulomb_friction=body_friction)
-            self.assertGreater(plant.num_collision_geometries(), 0)
+            self.assertGreater(plant.EvalNumCollisionGeometries(), 0)
             body0_props = scene_graph.model_inspector().GetProximityProperties(
                 plant.GetCollisionGeometriesForBody(body)[0])
             body0_friction = body0_props.GetProperty(
@@ -211,7 +211,7 @@ class TestPlant(unittest.TestCase):
                 plant.GetCollisionGeometriesForBody(body)[1])
             body1_friction = body1_props.GetProperty(
                 "material", "coulomb_friction")
-            self.assertGreater(plant.num_collision_geometries(), 1)
+            self.assertGreater(plant.EvalNumCollisionGeometries(), 1)
             self.assertEqual(body1_friction.static_friction(), 1.1)
             self.assertEqual(body1_friction.dynamic_friction(), 0.8)
 

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -1567,7 +1567,8 @@ class TestPlant(unittest.TestCase):
             bodies,
             {plant.GetBodyByName("body1"), plant.GetBodyByName("body2")})
 
-        id_, = plant.GetCollisionGeometriesForBody(
+        plant_context = diagram.GetMutableSubsystemContext(plant, context)
+        id_, = plant.GetCollisionGeometriesForBody(context=plant_context,
             body=plant.GetBodyByName("body1"))
         self.assertIsInstance(id_, GeometryId)
 

--- a/examples/manipulation_station/test/manipulation_station_test.cc
+++ b/examples/manipulation_station/test/manipulation_station_test.cc
@@ -238,18 +238,18 @@ GTEST_TEST(ManipulationStationTest, CheckCollisionVariants) {
   // In this variant, there are collision geometries from the world and the
   // gripper, but not from the iiwa.
   const int num_collisions =
-      station1.get_multibody_plant().num_collision_geometries();
+      station1.get_multibody_plant().EvalNumCollisionGeometries();
 
   ManipulationStation<double> station2(0.002);
   station2.SetupManipulationClassStation(IiwaCollisionModel::kBoxCollision);
   // Check for additional collision elements (one for each link, which includes
   // the base).
-  EXPECT_EQ(station2.get_multibody_plant().num_collision_geometries(),
+  EXPECT_EQ(station2.get_multibody_plant().EvalNumCollisionGeometries(),
             num_collisions + 8);
 
   // The controlled model does not register with a scene graph, so has zero
   // collisions.
-  EXPECT_EQ(station2.get_controller_plant().num_collision_geometries(), 0);
+  EXPECT_EQ(station2.get_controller_plant().EvalNumCollisionGeometries(), 0);
 }
 
 GTEST_TEST(ManipulationStationTest, AddManipulandFromFile) {

--- a/examples/multibody/acrobot/passive_simulation.cc
+++ b/examples/multibody/acrobot/passive_simulation.cc
@@ -84,6 +84,8 @@ int do_main() {
   builder.Connect(
       acrobot.get_geometry_poses_output_port(),
       scene_graph.get_source_pose_port(acrobot.get_source_id().value()));
+  builder.Connect(scene_graph.get_query_output_port(),
+      acrobot.get_geometry_query_input_port());
 
   geometry::ConnectDrakeVisualizer(&builder, scene_graph);
   auto diagram = builder.Build();

--- a/examples/multibody/acrobot/run_lqr.cc
+++ b/examples/multibody/acrobot/run_lqr.cc
@@ -144,6 +144,8 @@ int do_main() {
   builder.Connect(
       acrobot.get_geometry_poses_output_port(),
       scene_graph.get_source_pose_port(acrobot.get_source_id().value()));
+  builder.Connect(scene_graph.get_query_output_port(),
+      acrobot.get_geometry_query_input_port());
 
   geometry::ConnectDrakeVisualizer(&builder, scene_graph);
   auto diagram = builder.Build();

--- a/examples/multibody/cart_pole/cart_pole_passive_simulation.cc
+++ b/examples/multibody/cart_pole/cart_pole_passive_simulation.cc
@@ -63,6 +63,9 @@ int do_main() {
   builder.Connect(
       cart_pole.get_geometry_poses_output_port(),
       scene_graph.get_source_pose_port(cart_pole.get_source_id().value()));
+  builder.Connect(scene_graph.get_query_output_port(),
+      cart_pole.get_geometry_query_input_port());
+
 
   geometry::ConnectDrakeVisualizer(&builder, scene_graph);
   auto diagram = builder.Build();

--- a/examples/multibody/pendulum/passive_simulation.cc
+++ b/examples/multibody/pendulum/passive_simulation.cc
@@ -86,6 +86,9 @@ int do_main() {
   builder.Connect(
       pendulum.get_geometry_poses_output_port(),
       scene_graph.get_source_pose_port(pendulum.get_source_id().value()));
+  builder.Connect(scene_graph.get_query_output_port(),
+      pendulum.get_geometry_query_input_port());
+
 
   geometry::ConnectDrakeVisualizer(&builder, scene_graph);
   auto diagram = builder.Build();

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -139,6 +139,21 @@ int GeometryState<T>::NumGeometriesWithRole(Role role) const {
 }
 
 template <typename T>
+int GeometryState<T>::NumGeometriesWithRole(SourceId source_id,
+                                            Role role) const {
+  int count = 0;
+  FindOrThrow(source_id, source_names_, [source_id, role]() {
+    return "Cannot report number of geometries with the " + to_string(role) +
+           " role for invalid source id: " + to_string(source_id);
+  });
+  for (const auto& pair : geometries_) {
+    if (pair.second.source_id() == source_id && pair.second.has_role(role))
+      ++count;
+  }
+  return count;
+}
+
+template <typename T>
 int GeometryState<T>::NumDynamicGeometries() const {
   int count = 0;
   for (const auto& pair : frames_) {

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -147,7 +147,7 @@ int GeometryState<T>::NumGeometriesWithRole(SourceId source_id,
            " role for invalid source id: " + to_string(source_id);
   });
   for (const auto& pair : geometries_) {
-    if (pair.second.source_id() == source_id && pair.second.has_role(role))
+    if (pair.second.belongs_to_source(source_id) && pair.second.has_role(role))
       ++count;
   }
   return count;
@@ -267,6 +267,26 @@ int GeometryState<T>::NumGeometriesForFrameWithRole(FrameId frame_id,
     if (geometries_.at(geometry_id).has_role(role)) ++count;
   }
   return count;
+}
+
+template <typename T>
+const std::unordered_set<GeometryId>& GeometryState<T>::GetGeometriesForFrame(
+    FrameId frame_id) const {
+  const InternalFrame& frame = GetValueOrThrow(frame_id, frames_);
+  return frame.child_geometries();
+}
+
+template <typename T>
+std::vector<GeometryId> GeometryState<T>::GetGeometriesForFrameWithRole(
+    FrameId frame_id, Role role) const {
+  const InternalFrame& frame = GetValueOrThrow(frame_id, frames_);
+  std::vector<GeometryId> ids;
+  for (GeometryId geometry_id : frame.child_geometries()) {
+    if (geometries_.at(geometry_id).has_role(role)) {
+      ids.push_back(geometry_id);
+    }
+  }
+  return ids;
 }
 
 template <typename T>

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -277,13 +277,13 @@ const std::unordered_set<GeometryId>& GeometryState<T>::GetGeometriesForFrame(
 }
 
 template <typename T>
-std::vector<GeometryId> GeometryState<T>::GetGeometriesForFrameWithRole(
+std::unordered_set<GeometryId> GeometryState<T>::GetGeometriesForFrameWithRole(
     FrameId frame_id, Role role) const {
   const InternalFrame& frame = GetValueOrThrow(frame_id, frames_);
-  std::vector<GeometryId> ids;
+  std::unordered_set<GeometryId> ids;
   for (GeometryId geometry_id : frame.child_geometries()) {
     if (geometries_.at(geometry_id).has_role(role)) {
-      ids.push_back(geometry_id);
+      ids.insert(geometry_id);
     }
   }
   return ids;

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -118,11 +118,12 @@ class GeometryState {
   }
 
   /** Implementation of SceneGraphInspector::GetGeometriesForSource().  */
-  std::vector<GeometryId> GetGeometriesForSource(SourceId source_id) const {
-    std::vector<GeometryId> ids;
+  std::unordered_set<GeometryId> GetGeometriesForSource(
+      SourceId source_id) const {
+    std::unordered_set<GeometryId> ids;
     for (const auto& id_geometry_pair : geometries_) {
       if (id_geometry_pair.second.belongs_to_source(source_id)) {
-        ids.push_back(id_geometry_pair.first);
+        ids.insert(id_geometry_pair.first);
       }
     }
     return ids;
@@ -130,13 +131,13 @@ class GeometryState {
 
   /** Implementation of SceneGraphInspector::GetGeometriesForSourceWithRole().
    */
-  std::vector<GeometryId> GetGeometriesForSourceWithRole(SourceId source_id,
-                                                         Role role) const {
-    std::vector<GeometryId> ids;
+  std::unordered_set<GeometryId> GetGeometriesForSourceWithRole(
+      SourceId source_id, Role role) const {
+    std::unordered_set<GeometryId> ids;
     for (const auto& id_geometry_pair : geometries_) {
       if (id_geometry_pair.second.belongs_to_source(source_id) &&
           id_geometry_pair.second.has_role(role)) {
-        ids.push_back(id_geometry_pair.first);
+        ids.insert(id_geometry_pair.first);
       }
     }
     return ids;
@@ -206,8 +207,8 @@ class GeometryState {
 
   /** Implementation of SceneGraphInspector::GetGeometriesForFrameWithRole().
    */
-  std::vector<GeometryId> GetGeometriesForFrameWithRole(FrameId frame_id,
-      Role role) const;
+  std::unordered_set<GeometryId> GetGeometriesForFrameWithRole(FrameId frame_id,
+                                                               Role role) const;
 
   // TODO(SeanCurtis-TRI): Redundant w.r.t. NumGeometriesForFrameWithRole().
   /** Reports the number of child geometries for this frame that have the

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -117,6 +117,31 @@ class GeometryState {
     return ids;
   }
 
+  /** Implementation of SceneGraphInspector::GetGeometriesForSource().  */
+  std::vector<GeometryId> GetGeometriesForSource(SourceId source_id) const {
+    std::vector<GeometryId> ids;
+    for (const auto& id_geometry_pair : geometries_) {
+      if (id_geometry_pair.second.belongs_to_source(source_id)) {
+        ids.push_back(id_geometry_pair.first);
+      }
+    }
+    return ids;
+  }
+
+  /** Implementation of SceneGraphInspector::GetGeometriesForSourceWithRole().
+   */
+  std::vector<GeometryId> GetGeometriesForSourceWithRole(SourceId source_id,
+                                                         Role role) const {
+    std::vector<GeometryId> ids;
+    for (const auto& id_geometry_pair : geometries_) {
+      if (id_geometry_pair.second.belongs_to_source(source_id) &&
+          id_geometry_pair.second.has_role(role)) {
+        ids.push_back(id_geometry_pair.first);
+      }
+    }
+    return ids;
+  }
+
   /** Implementation of SceneGraphInspector::NumGeometriesWithRole().  */
   int NumGeometriesWithRole(Role role) const;
 
@@ -174,6 +199,15 @@ class GeometryState {
   /** Implementation of SceneGraphInspector::NumGeometriesForFrameWithRole().
    */
   int NumGeometriesForFrameWithRole(FrameId frame_id, Role role) const;
+
+  /** Implementation of SceneGraphInspector::GetGeometriesForFrame().  */
+  const std::unordered_set<GeometryId>& GetGeometriesForFrame(
+      FrameId frame_id) const;
+
+  /** Implementation of SceneGraphInspector::GetGeometriesForFrameWithRole().
+   */
+  std::vector<GeometryId> GetGeometriesForFrameWithRole(FrameId frame_id,
+      Role role) const;
 
   // TODO(SeanCurtis-TRI): Redundant w.r.t. NumGeometriesForFrameWithRole().
   /** Reports the number of child geometries for this frame that have the

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -120,6 +120,9 @@ class GeometryState {
   /** Implementation of SceneGraphInspector::NumGeometriesWithRole().  */
   int NumGeometriesWithRole(Role role) const;
 
+  /** Implementation of SceneGraphInspector::NumGeometriesWithRole().  */
+  int NumGeometriesWithRole(SourceId source_id, Role role) const;
+
   /** Implementation of SceneGraphInspector::NumDynamicGeometries().  */
   int NumDynamicGeometries() const;
 

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -112,6 +112,21 @@ class SceneGraphInspector {
     return state_->GetAllGeometryIds();
   }
 
+  /** Returns the set of all ids for registered geometries belonging to the
+   source with id `source_id`. */
+  std::vector<GeometryId> GetGeometriesForSource(SourceId source_id) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->GetGeometriesForSource(source_id);
+  }
+
+  /** Returns the set of all ids for registered geometries belonging to the
+   source with id `source_id` and having the role `role`. */
+  std::vector<GeometryId> GetGeometriesForSourceWithRole(SourceId source_id,
+                                                         Role role) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->GetGeometriesForSourceWithRole(source_id, role);
+  }
+
   /** Reports the _total_ number of geometries in the scene graph with the
    indicated role.  */
   int NumGeometriesWithRole(Role role) const {
@@ -245,6 +260,26 @@ class SceneGraphInspector {
   int NumGeometriesForFrameWithRole(FrameId id, Role role) const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->NumGeometriesForFrameWithRole(id, role);
+  }
+
+  /** Returns all geometries affixed to the frame with the given `id`.
+   This does _not_ include geometries attached to frames that are
+   descendants of this frame.
+   @throws std::logic_error if `id` does not map to a registered frame.  */
+  const std::unordered_set<GeometryId>& GetGeometriesForFrame(
+      FrameId id) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->GetGeometriesForFrame(id);
+  }
+
+  /** Returns all geometries with the given `role` directly
+   registered to the frame with the given `id`. This does _not_ include
+   geometries attached to frames that are descendants of this frame.
+   @throws std::logic_error if `id` does not map to a registered frame.  */
+  std::vector<GeometryId> GetGeometriesForFrameWithRole(
+      FrameId id, Role role) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->GetGeometriesForFrameWithRole(id, role);
   }
 
   /** Reports the id of the geometry with the given `name` and `role`, attached

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -119,6 +119,13 @@ class SceneGraphInspector {
     return state_->NumGeometriesWithRole(role);
   }
 
+  /** Reports the _total_ number of geometries associated with the given
+   source_id in the scene graph with the indicated role.  */
+  int NumGeometriesWithRole(SourceId source_id, Role role) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->NumGeometriesWithRole(source_id, role);
+  }
+
   /** Reports the total number of _dynamic_ geometries in the scene graph.  */
   int NumDynamicGeometries() const {
     DRAKE_DEMAND(state_ != nullptr);

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -114,15 +114,16 @@ class SceneGraphInspector {
 
   /** Returns the set of all ids for registered geometries belonging to the
    source with id `source_id`. */
-  std::vector<GeometryId> GetGeometriesForSource(SourceId source_id) const {
+  std::unordered_set<GeometryId> GetGeometriesForSource(
+      SourceId source_id) const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->GetGeometriesForSource(source_id);
   }
 
   /** Returns the set of all ids for registered geometries belonging to the
    source with id `source_id` and having the role `role`. */
-  std::vector<GeometryId> GetGeometriesForSourceWithRole(SourceId source_id,
-                                                         Role role) const {
+  std::unordered_set<GeometryId> GetGeometriesForSourceWithRole(
+      SourceId source_id, Role role) const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->GetGeometriesForSourceWithRole(source_id, role);
   }
@@ -276,7 +277,7 @@ class SceneGraphInspector {
    registered to the frame with the given `id`. This does _not_ include
    geometries attached to frames that are descendants of this frame.
    @throws std::logic_error if `id` does not map to a registered frame.  */
-  std::vector<GeometryId> GetGeometriesForFrameWithRole(
+  std::unordered_set<GeometryId> GetGeometriesForFrameWithRole(
       FrameId id, Role role) const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->GetGeometriesForFrameWithRole(id, role);

--- a/multibody/parsing/test/common_parser_test.cc
+++ b/multibody/parsing/test/common_parser_test.cc
@@ -86,11 +86,14 @@ class MultibodyPlantLinkTests :
 };
 
 TEST_P(MultibodyPlantLinkTests, LinkWithVisuals) {
-  LoadMultibodyPlantAndSceneGraph();
+  LoadMultibodyPlantAndSceneGraphDiagram();
   MultibodyPlant<double>& plant_ = plant();
+  auto diagram_context = diagram_ptr_->CreateDefaultContext();
+  auto& plant_context =
+      plant_.GetMyMutableContextFromRoot(diagram_context.get());
 
   EXPECT_EQ(plant_.num_bodies(), 4);  // It includes the world body.
-  EXPECT_EQ(plant_.num_visual_geometries(), 5);
+  EXPECT_EQ(plant_.EvalNumVisualGeometries(&plant_context), 5);
 
   const std::vector<GeometryId>& link1_visual_geometry_ids =
       plant_.GetVisualGeometriesForBody(plant_.GetBodyByName("link1"));
@@ -115,7 +118,6 @@ TEST_P(MultibodyPlantLinkTests, ParseWithoutASceneGraph) {
   MultibodyPlant<double>& plant_ = plant();
 
   EXPECT_EQ(plant_.num_bodies(), 4);  // It includes the world body.
-  EXPECT_EQ(plant_.num_visual_geometries(), 0);
 }
 
 // Verifies that the source registration with a SceneGraph can happen before a
@@ -123,9 +125,12 @@ TEST_P(MultibodyPlantLinkTests, ParseWithoutASceneGraph) {
 TEST_P(MultibodyPlantLinkTests, RegisterWithASceneGraphBeforeParsing) {
   LoadMultibodyPlantAndSceneGraphDiagram();
   MultibodyPlant<double>& plant_ = plant();
+  auto diagram_context = diagram_ptr_->CreateDefaultContext();
+  auto& plant_context =
+      plant_.GetMyMutableContextFromRoot(diagram_context.get());
 
   EXPECT_EQ(plant_.num_bodies(), 4);  // It includes the world body.
-  EXPECT_EQ(plant_.num_visual_geometries(), 5);
+  EXPECT_EQ(plant_.EvalNumVisualGeometries(&plant_context), 5);
 
   const std::vector<GeometryId>& link1_visual_geometry_ids =
       plant_.GetVisualGeometriesForBody(plant_.GetBodyByName("link1"));

--- a/multibody/parsing/test/common_parser_test.cc
+++ b/multibody/parsing/test/common_parser_test.cc
@@ -118,7 +118,7 @@ TEST_P(MultibodyPlantLinkTests, LinksWithCollisions) {
   LoadMultibodyPlantAndSceneGraph();
 
   EXPECT_EQ(plant_.num_bodies(), 4);  // It includes the world body.
-  EXPECT_EQ(plant_.num_collision_geometries(), 3);
+  EXPECT_EQ(plant_.num_collision_geometries(*plant_.CreateDefaultContext()), 3);
 
   const std::vector<GeometryId>& link1_collision_geometry_ids =
       plant_.GetCollisionGeometriesForBody(plant_.GetBodyByName("link1"));

--- a/multibody/parsing/test/common_parser_test.cc
+++ b/multibody/parsing/test/common_parser_test.cc
@@ -96,15 +96,18 @@ TEST_P(MultibodyPlantLinkTests, LinkWithVisuals) {
   EXPECT_EQ(plant_.EvalNumVisualGeometries(&plant_context), 5);
 
   const std::vector<GeometryId>& link1_visual_geometry_ids =
-      plant_.GetVisualGeometriesForBody(plant_.GetBodyByName("link1"));
+      plant_.GetVisualGeometriesForBody(plant_context,
+                                        plant_.GetBodyByName("link1"));
   EXPECT_EQ(link1_visual_geometry_ids.size(), 2);
 
   const std::vector<GeometryId>& link2_visual_geometry_ids =
-      plant_.GetVisualGeometriesForBody(plant_.GetBodyByName("link2"));
+      plant_.GetVisualGeometriesForBody(plant_context,
+                                        plant_.GetBodyByName("link2"));
   EXPECT_EQ(link2_visual_geometry_ids.size(), 3);
 
   const std::vector<GeometryId>& link3_visual_geometry_ids =
-      plant_.GetVisualGeometriesForBody(plant_.GetBodyByName("link3"));
+      plant_.GetVisualGeometriesForBody(plant_context,
+                                        plant_.GetBodyByName("link3"));
   EXPECT_EQ(link3_visual_geometry_ids.size(), 0);
 
   // TODO(SeanCurtis-TRI): Once SG supports it, confirm `GeometryId` maps to the
@@ -133,7 +136,8 @@ TEST_P(MultibodyPlantLinkTests, RegisterWithASceneGraphBeforeParsing) {
   EXPECT_EQ(plant_.EvalNumVisualGeometries(&plant_context), 5);
 
   const std::vector<GeometryId>& link1_visual_geometry_ids =
-      plant_.GetVisualGeometriesForBody(plant_.GetBodyByName("link1"));
+      plant_.GetVisualGeometriesForBody(plant_context,
+                                        plant_.GetBodyByName("link1"));
   EXPECT_EQ(link1_visual_geometry_ids.size(), 2);
 
   // TODO(sam.creasey) Verify that the path to the mesh for the second
@@ -145,11 +149,13 @@ TEST_P(MultibodyPlantLinkTests, RegisterWithASceneGraphBeforeParsing) {
   // resulting lcmt_viewer_load_robot message, but I don't want to.
 
   const std::vector<GeometryId>& link2_visual_geometry_ids =
-      plant_.GetVisualGeometriesForBody(plant_.GetBodyByName("link2"));
+      plant_.GetVisualGeometriesForBody(plant_context,
+                                        plant_.GetBodyByName("link2"));
   EXPECT_EQ(link2_visual_geometry_ids.size(), 3);
 
   const std::vector<GeometryId>& link3_visual_geometry_ids =
-      plant_.GetVisualGeometriesForBody(plant_.GetBodyByName("link3"));
+      plant_.GetVisualGeometriesForBody(plant_context,
+                                        plant_.GetBodyByName("link3"));
   EXPECT_EQ(link3_visual_geometry_ids.size(), 0);
 
   // TODO(SeanCurtis-TRI): Once SG supports it, confirm `GeometryId` maps to the
@@ -170,26 +176,39 @@ TEST_P(MultibodyPlantLinkTests, LinksWithCollisions) {
   EXPECT_EQ(plant_.EvalNumCollisionGeometries(&plant_context), 3);
 
   const std::vector<GeometryId>& link1_collision_geometry_ids =
-      plant_.GetCollisionGeometriesForBody(plant_.GetBodyByName("link1"));
+      plant_.GetCollisionGeometriesForBody(plant_context,
+                                           plant_.GetBodyByName("link1"));
   ASSERT_EQ(link1_collision_geometry_ids.size(), 2);
 
-  EXPECT_TRUE(scene_graph_.model_inspector()
-                  .GetProximityProperties(link1_collision_geometry_ids[0])
-                  ->GetProperty<CoulombFriction<double>>("material",
-                                                         "coulomb_friction") ==
-              CoulombFriction<double>(0.8, 0.3));
-  EXPECT_TRUE(scene_graph_.model_inspector()
-                  .GetProximityProperties(link1_collision_geometry_ids[1])
-                  ->GetProperty<CoulombFriction<double>>("material",
-                                                         "coulomb_friction") ==
-              CoulombFriction<double>(1.5, 0.6));
+  EXPECT_TRUE(
+      scene_graph_.model_inspector()
+          .GetProximityProperties(
+              scene_graph_.model_inspector().GetGeometryIdByName(
+                  plant_.GetBodyFrameIdOrThrow(
+                      plant_.GetBodyByName("link1").index()),
+                  geometry::Role::kProximity, "test_robot::link1_collision1"))
+          ->GetProperty<CoulombFriction<double>>("material",
+                                                 "coulomb_friction") ==
+      CoulombFriction<double>(0.8, 0.3));
+  EXPECT_TRUE(
+      scene_graph_.model_inspector()
+          .GetProximityProperties(
+              scene_graph_.model_inspector().GetGeometryIdByName(
+                  plant_.GetBodyFrameIdOrThrow(
+                      plant_.GetBodyByName("link1").index()),
+                  geometry::Role::kProximity, "test_robot::link1_collision2"))
+          ->GetProperty<CoulombFriction<double>>("material",
+                                                 "coulomb_friction") ==
+      CoulombFriction<double>(1.5, 0.6));
 
   const std::vector<GeometryId>& link2_collision_geometry_ids =
-      plant_.GetCollisionGeometriesForBody(plant_.GetBodyByName("link2"));
+      plant_.GetCollisionGeometriesForBody(plant_context,
+                                           plant_.GetBodyByName("link2"));
   ASSERT_EQ(link2_collision_geometry_ids.size(), 0);
 
   const std::vector<GeometryId>& link3_collision_geometry_ids =
-      plant_.GetCollisionGeometriesForBody(plant_.GetBodyByName("link3"));
+      plant_.GetCollisionGeometriesForBody(plant_context,
+                                           plant_.GetBodyByName("link3"));
   ASSERT_EQ(link3_collision_geometry_ids.size(), 1);
   // Verifies the default value of the friction coefficients when the user does
   // not specify them in the SDF file.

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -442,21 +442,29 @@ GTEST_TEST(SdfParser, TestOptionalSceneGraph) {
   int num_visuals_explicit{};
   {
     // Test explicitly specifying `scene_graph`.
-    MultibodyPlant<double> plant(0.0);
-    SceneGraph<double> scene_graph;
+    systems::DiagramBuilder<double> builder;
+    auto [plant, scene_graph] = AddMultibodyPlantSceneGraph(&builder, 0.0);
     AddModelsFromSdfFile(full_name, package_map, &plant, &scene_graph);
     plant.Finalize();
-    num_visuals_explicit = plant.num_visual_geometries();
+    auto diagram = builder.Build();
+    auto diagram_context = diagram->CreateDefaultContext();
+    auto& plant_context =
+        plant.GetMyMutableContextFromRoot(diagram_context.get());
+    num_visuals_explicit = plant.EvalNumVisualGeometries(&plant_context);
   }
   EXPECT_NE(num_visuals_explicit, 0);
   {
     // Test implicitly specifying.
-    MultibodyPlant<double> plant(0.0);
-    SceneGraph<double> scene_graph;
-    plant.RegisterAsSourceForSceneGraph(&scene_graph);
+    systems::DiagramBuilder<double> builder;
+    MultibodyPlant<double>& plant = AddMultibodyPlantSceneGraph(&builder, 0.0);
     AddModelsFromSdfFile(full_name, package_map, &plant);
     plant.Finalize();
-    EXPECT_EQ(plant.num_visual_geometries(), num_visuals_explicit);
+    auto diagram = builder.Build();
+    auto diagram_context = diagram->CreateDefaultContext();
+    auto& plant_context =
+        plant.GetMyMutableContextFromRoot(diagram_context.get());
+    EXPECT_EQ(plant.EvalNumVisualGeometries(&plant_context),
+              num_visuals_explicit);
   }
 }
 

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -420,24 +420,30 @@ geometry::GeometryId MultibodyPlant<T>::RegisterVisualGeometry(
 }
 
 template <typename T>
-const std::vector<geometry::GeometryId>&
-MultibodyPlant<T>::GetVisualGeometriesForBody(const Body<T>& body) const {
+std::vector<geometry::GeometryId> MultibodyPlant<T>::GetVisualGeometriesForBody(
+    const Body<T>& body) const {
   DRAKE_MBP_THROW_IF_FINALIZED();
   DRAKE_ASSERT(body.index() < num_bodies());
-  FrameId frame_id = body_index_to_frame_id_[body.index()];
-  return member_scene_graph().model_inspector().GetGeometriesForFrameWithRole(
-      frame_id, geometry::Role::kIllustration);
+  FrameId frame_id = body_index_to_frame_id_.at(body.index());
+
+  const std::unordered_set<GeometryId>& ids =
+      const_cast<MultibodyPlant<T>*>(this)
+          ->member_scene_graph()
+          .model_inspector()
+          .GetGeometriesForFrameWithRole(frame_id,
+                                         geometry::Role::kIllustration);
+  return std::vector<GeometryId>(ids.begin(), ids.end());
 }
 
 template <typename T>
-const std::vector<geometry::GeometryId>&
-MultibodyPlant<T>::GetVisualGeometriesForBody(
-    const systems::Context<T>& context, Body<T>& body) const {
+std::vector<geometry::GeometryId> MultibodyPlant<T>::GetVisualGeometriesForBody(
+    const systems::Context<T>& context, const Body<T>& body) const {
   DRAKE_ASSERT(body.index() < num_bodies());
-  FrameId frame_id = body_index_to_frame_id_[body.index()];
-  return EvalGeometryQueryInput(context)
-      .inspector()
-      .GetGeometriesForFrameWithRole(frame_id, geometry::Role::kIllustration);
+  FrameId frame_id = body_index_to_frame_id_.at(body.index());
+  const std::unordered_set<GeometryId>& ids =
+      EvalGeometryQueryInput(context).inspector().GetGeometriesForFrameWithRole(
+          frame_id, geometry::Role::kIllustration);
+  return std::vector<GeometryId>(ids.begin(), ids.end());
 }
 
 template <typename T>
@@ -487,24 +493,29 @@ geometry::GeometryId MultibodyPlant<T>::RegisterCollisionGeometry(
 }
 
 template <typename T>
-const std::vector<geometry::GeometryId>&
+std::vector<geometry::GeometryId>
 MultibodyPlant<T>::GetCollisionGeometriesForBody(const Body<T>& body) const {
   DRAKE_MBP_THROW_IF_FINALIZED();
   DRAKE_ASSERT(body.index() < num_bodies());
-  FrameId frame_id = body_index_to_frame_id_[body.index()];
-  return member_scene_graph().model_inspector().GetGeometriesForFrameWithRole(
-      frame_id, geometry::Role::kProximity);
+  FrameId frame_id = body_index_to_frame_id_.at(body.index());
+  const std::unordered_set<GeometryId>& ids =
+      const_cast<MultibodyPlant<T>*>(this)
+          ->member_scene_graph()
+          .model_inspector()
+          .GetGeometriesForFrameWithRole(frame_id, geometry::Role::kProximity);
+  return std::vector<GeometryId>(ids.begin(), ids.end());
 }
 
 template <typename T>
-const std::vector<geometry::GeometryId>&
+std::vector<geometry::GeometryId>
 MultibodyPlant<T>::GetCollisionGeometriesForBody(
-    const systems::Context<T>& context, Body<T>& body) const {
+    const systems::Context<T>& context, const Body<T>& body) const {
   DRAKE_ASSERT(body.index() < num_bodies());
-  FrameId frame_id = body_index_to_frame_id_[body.index()];
-  return EvalGeometryQueryInput(context)
-      .inspector()
-      .GetGeometriesForFrameWithRole(frame_id, geometry::Role::kProximity);
+  FrameId frame_id = body_index_to_frame_id_.at(body.index());
+  const std::unordered_set<GeometryId>& ids =
+      EvalGeometryQueryInput(context).inspector().GetGeometriesForFrameWithRole(
+          frame_id, geometry::Role::kProximity);
+  return std::vector<GeometryId>(ids.begin(), ids.end());
 }
 
 template <typename T>
@@ -811,6 +822,16 @@ struct MultibodyPlant<T>::SceneGraphStub {
     }
     int NumGeometriesWithRole(geometry::SourceId, geometry::Role) const {
       return 0;
+    }
+
+    std::unordered_set<GeometryId> GetGeometriesForSourceWithRole(
+        geometry::SourceId, geometry::Role) const {
+      return {};
+    }
+
+    std::unordered_set<GeometryId> GetGeometriesForFrameWithRole(
+        geometry::FrameId, geometry::Role) const {
+      return {};
     }
   };
 

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -781,6 +781,9 @@ struct MultibodyPlant<T>::SceneGraphStub {
     int NumGeometriesWithRole(geometry::Role) const {
       return 0;
     }
+    int NumGeometriesWithRole(geometry::SourceId, geometry::Role) const {
+      return 0;
+    }
   };
 
   static void Throw(const char* operation_name) {
@@ -824,66 +827,6 @@ typename MultibodyPlant<symbolic::Expression>::MemberSceneGraph&
 MultibodyPlant<symbolic::Expression>::member_scene_graph() {
   static never_destroyed<SceneGraphStub> stub_;
   return stub_.access();
-}
-
-template <typename T>
-int MultibodyPlant<T>::EvalNumVisualGeometries(
-    const systems::Context<T>* context) const {
-  if (!context) {
-    DRAKE_MBP_THROW_IF_FINALIZED();
-  }
-
-  if (!geometry_source_is_registered()) return 0;
-
-  if (!context) {
-    return const_cast<MultibodyPlant<T>*>(this)
-        ->member_scene_graph()
-        .model_inspector()
-        .NumGeometriesWithRole(get_source_id().value(),
-                               geometry::Role::kIllustration);
-  } else {
-    return EvalGeometryQueryInput(*context).inspector().NumGeometriesWithRole(
-        get_source_id().value(), geometry::Role::kIllustration);
-  }
-}
-
-// This does *not* support symbolic::Expression because SceneGraph does *not*
-// support symbolic::Expression.
-template <>
-int MultibodyPlant<symbolic::Expression>::EvalNumVisualGeometries(
-    const systems::Context<symbolic::Expression>*) const {
-  throw std::logic_error(
-      "This method doesn't support T = symbolic::Expression.");
-}
-
-template <typename T>
-int MultibodyPlant<T>::EvalNumCollisionGeometries(
-    const systems::Context<T>* context) const {
-  if (!context) {
-    DRAKE_MBP_THROW_IF_FINALIZED();
-  }
-
-  if (!geometry_source_is_registered()) return 0;
-
-  if (!context) {
-    return const_cast<MultibodyPlant<T>*>(this)
-        ->member_scene_graph()
-        .model_inspector()
-        .NumGeometriesWithRole(get_source_id().value(),
-                               geometry::Role::kProximity);
-  } else {
-    return EvalGeometryQueryInput(*context).inspector().NumGeometriesWithRole(
-        get_source_id().value(), geometry::Role::kProximity);
-  }
-}
-
-// This does *not* support symbolic::Expression because SceneGraph does *not*
-// support symbolic::Expression.
-template <>
-int MultibodyPlant<symbolic::Expression>::EvalNumCollisionGeometries(
-    const systems::Context<symbolic::Expression>*) const {
-  throw std::logic_error(
-      "This method doesn't support T = symbolic::Expression.");
 }
 
 template <typename T>

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -827,6 +827,36 @@ MultibodyPlant<symbolic::Expression>::member_scene_graph() {
 }
 
 template <typename T>
+int MultibodyPlant<T>::EvalNumVisualGeometries(
+    const systems::Context<T>* context) const {
+  if (!context) {
+    DRAKE_MBP_THROW_IF_FINALIZED();
+  }
+
+  if (!geometry_source_is_registered()) return 0;
+
+  if (!context) {
+    return const_cast<MultibodyPlant<T>*>(this)
+        ->member_scene_graph()
+        .model_inspector()
+        .NumGeometriesWithRole(get_source_id().value(),
+                               geometry::Role::kIllustration);
+  } else {
+    return EvalGeometryQueryInput(*context).inspector().NumGeometriesWithRole(
+        get_source_id().value(), geometry::Role::kIllustration);
+  }
+}
+
+// This does *not* support symbolic::Expression because SceneGraph does *not*
+// support symbolic::Expression.
+template <>
+int MultibodyPlant<symbolic::Expression>::EvalNumVisualGeometries(
+    const systems::Context<symbolic::Expression>*) const {
+  throw std::logic_error(
+      "This method doesn't support T = symbolic::Expression.");
+}
+
+template <typename T>
 int MultibodyPlant<T>::EvalNumCollisionGeometries(
     const systems::Context<T>* context) const {
   if (!context) {

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -830,6 +830,62 @@ MultibodyPlant<symbolic::Expression>::member_scene_graph() {
 }
 
 template <typename T>
+int MultibodyPlant<T>::EvalNumVisualGeometries(
+    const systems::Context<T>* context) const {
+  if (!context) {
+    DRAKE_MBP_THROW_IF_FINALIZED();
+  }
+
+  // symbolic::Expression is not supported by SceneGraph.
+  // For now, so anything internally using EvalNumVisualGeometries
+  // doesn't fail on a symbolic plant, return 0.
+  if constexpr (std::is_same_v<T, symbolic::Expression>) {
+    return 0;
+  }
+
+  if (!geometry_source_is_registered()) return 0;
+
+  if (!context) {
+    return const_cast<MultibodyPlant<T>*>(this)
+        ->member_scene_graph()
+        .model_inspector()
+        .NumGeometriesWithRole(get_source_id().value(),
+                               geometry::Role::kIllustration);
+  } else {
+    return EvalGeometryQueryInput(*context).inspector().NumGeometriesWithRole(
+        get_source_id().value(), geometry::Role::kIllustration);
+  }
+}
+
+template <typename T>
+int MultibodyPlant<T>::EvalNumCollisionGeometries(
+    const systems::Context<T>* context) const {
+  if (!context) {
+    DRAKE_MBP_THROW_IF_FINALIZED();
+  }
+
+  // symbolic::Expression is not supported by SceneGraph.
+  // For now, so anything internally using EvalNumCollisionGeometries
+  // doesn't fail on a symbolic plant, return 0.
+  if constexpr (std::is_same_v<T, symbolic::Expression>) {
+    return 0;
+  }
+
+  if (!geometry_source_is_registered()) return 0;
+
+  if (!context) {
+    return const_cast<MultibodyPlant<T>*>(this)
+        ->member_scene_graph()
+        .model_inspector()
+        .NumGeometriesWithRole(get_source_id().value(),
+                               geometry::Role::kProximity);
+  } else {
+    return EvalGeometryQueryInput(*context).inspector().NumGeometriesWithRole(
+        get_source_id().value(), geometry::Role::kProximity);
+  }
+}
+
+template <typename T>
 void MultibodyPlant<T>::CheckValidState(const systems::State<T>* state) const {
   DRAKE_THROW_UNLESS(state != nullptr);
   DRAKE_THROW_UNLESS(

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -839,10 +839,11 @@ int MultibodyPlant<T>::EvalNumCollisionGeometries(
     return const_cast<MultibodyPlant<T>*>(this)
         ->member_scene_graph()
         .model_inspector()
-        .NumGeometriesWithRole(geometry::Role::kProximity);
+        .NumGeometriesWithRole(get_source_id().value(),
+                               geometry::Role::kProximity);
   } else {
-    return EvalGeometryQueryInput(context).inspector().NumGeometriesWithRole(
-        geometry::Role::kProximity);
+    return EvalGeometryQueryInput(*context).inspector().NumGeometriesWithRole(
+        get_source_id().value(), geometry::Role::kProximity);
   }
 }
 
@@ -1815,8 +1816,7 @@ void MultibodyPlant<double>::CalcHydroelasticWithFallback(
   DRAKE_DEMAND(data != nullptr);
 
   if (EvalNumCollisionGeometries(&context) > 0) {
-    const auto& query_object = const auto& query_object =
-        EvalGeometryQueryInput(context);
+    const auto& query_object = EvalGeometryQueryInput(context);
     data->contact_surfaces.clear();
     data->point_pairs.clear();
 

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3737,6 +3737,14 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       std::is_same<T, symbolic::Expression>::value,
       SceneGraphStub, geometry::SceneGraph<T>>::type;
 
+  // A dummy, placeholder type.
+  struct QueryObjectStub;
+  // An alias for QueryObject<T>, except when T = Expression.
+  using ModelQueryObject =
+      typename std::conditional<std::is_same<T, symbolic::Expression>::value,
+                                QueryObjectStub,
+                                geometry::QueryObject<T>>::type;
+
   // Returns the SceneGraph that pre-Finalize geometry operations should
   // interact with.  In most cases, that will be whatever the user has passed
   // into RegisterAsSourceForSceneGraph.  However, when T = Expression, the
@@ -4371,7 +4379,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   // Gets the BodyIndex associated with the provided GeometryId by querying
   // for the FrameId of the geometry, and using the frame_id_to_body_index_ map.
-  BodyIndex geometry_id_to_body_index(geometry::QueryObject<T> query_object,
+  BodyIndex geometry_id_to_body_index(const ModelQueryObject& query_object,
                                       geometry::GeometryId geometry_id) const {
     geometry::FrameId frame_id =
         query_object.inspector().GetFrameId(geometry_id);
@@ -4655,6 +4663,24 @@ struct AddMultibodyPlantSceneGraphResult final {
 #ifndef DRAKE_DOXYGEN_CXX
 // Forward-declare specializations, prior to DRAKE_DECLARE... below.
 // See the .cc file for an explanation why we specialize these methods.
+template <>
+std::vector<geometry::GeometryId>
+MultibodyPlant<symbolic::Expression>::GetCollisionGeometriesForBody(
+    const Body<symbolic::Expression>&) const;
+template <>
+std::vector<geometry::GeometryId>
+MultibodyPlant<symbolic::Expression>::GetCollisionGeometriesForBody(
+    const systems::Context<symbolic::Expression>&,
+    const Body<symbolic::Expression>&) const;
+template <>
+std::vector<geometry::GeometryId>
+MultibodyPlant<symbolic::Expression>::GetVisualGeometriesForBody(
+    const Body<symbolic::Expression>&) const;
+template <>
+std::vector<geometry::GeometryId>
+MultibodyPlant<symbolic::Expression>::GetVisualGeometriesForBody(
+    const systems::Context<symbolic::Expression>&,
+    const Body<symbolic::Expression>&) const;
 template <>
 typename MultibodyPlant<symbolic::Expression>::SceneGraphStub&
 MultibodyPlant<symbolic::Expression>::member_scene_graph();

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3601,7 +3601,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// geometry::SceneGraph, this method will report the number of geometries
   /// registered with the role geometry::Role::kIllustration, of all the
   /// geometries registered to `this` plant's source_id.
-  int EvalNumVisualGeometries(const systems::Context<T>* context) const {
+  int EvalNumVisualGeometries(
+      const systems::Context<T>* context = nullptr) const {
     if (!context) {
       DRAKE_MBP_THROW_IF_FINALIZED();
     }
@@ -3649,7 +3650,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// geometry::SceneGraph, this method will report the number of geometries
   /// registered with the role geometry::Role::kProximity, of all the
   /// geometries registered to `this` plant's source_id.
-  int EvalNumCollisionGeometries(const systems::Context<T>* context) const {
+  int EvalNumCollisionGeometries(
+      const systems::Context<T>* context = nullptr) const {
     if (!context) {
       DRAKE_MBP_THROW_IF_FINALIZED();
     }

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3565,7 +3565,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// model registered for contact modeling.
   /// @see RegisterCollisionGeometry() for details on geometry registration.
   DRAKE_DEPRECATED(
-      "2020-09-01",
+      "2020-10-01",
       "default_coulomb_friction() will be removed. Please use SceneGraph which "
       "now stores friction properties in ProximityProperties. See the section "
       "\"Accessing point contact parameters\" in the documentation for "
@@ -3591,9 +3591,26 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// This method can be called at any time during the lifetime of `this` plant,
   /// either pre- or post-finalize, see Finalize().
   /// Post-finalize calls will always return the same value.
+  DRAKE_DEPRECATED("2020-10-01",
+                   "num_collision_geometries() will be removed and replaced by EvalNumCollisionGeometries(const Context<T>*).");
+  // Deprecation notes:
+  //   - remove `geometry_id_to_collision_index_`
   int num_collision_geometries() const {
     return geometry_id_to_collision_index_.size();
   }
+
+  /// Returns the number of geometries registered for contact modeling.
+  /// This method can be called at any time during the lifetime of `this` plant,
+  /// either pre- or post-finalize, so long as a systems::Context is available.
+  /// If `this` MultibodyPlant has not registered as a source for
+  /// geometry::SceneGraph (see RegisterAsSourceForSceneGraph()), this method
+  /// will return 0. If `this` plant *has* been registered as a source for
+  /// geometry::SceneGraph, this method will report the number of geometries
+  /// registered with the role geometry::Role::kProximity, of all the
+  /// geometries registered to `this` plant's source_id.
+  /// @throws std::runtime_error if `this` plant is registered as a source for
+  /// geometry::SceneGraph, but its `geometry_query` InputPort is not connected.
+  int EvalNumCollisionGeometries(const systems::Context<T>* context = nullptr) const;
 
   /// Returns the unique id identifying `this` plant as a source for a
   /// SceneGraph.
@@ -4563,6 +4580,9 @@ struct AddMultibodyPlantSceneGraphResult final {
 template <>
 typename MultibodyPlant<symbolic::Expression>::SceneGraphStub&
 MultibodyPlant<symbolic::Expression>::member_scene_graph();
+template <>
+int MultibodyPlant<symbolic::Expression>::EvalNumCollisionGeometries(
+    const systems::Context<symbolic::Expression>*) const;
 template <>
 std::vector<geometry::PenetrationAsPointPair<double>>
 MultibodyPlant<double>::CalcPointPairPenetrations(

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3592,42 +3592,6 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     return static_cast<int>(geometry_id_to_visual_index_.size());
   }
 
-  /// Returns the number of geometries registered for visualization.
-  /// This method can be called at any time during the lifetime of `this` plant,
-  /// either pre- or post-finalize, so long as a systems::Context is available.
-  /// If `this` MultibodyPlant has not registered as a source for
-  /// geometry::SceneGraph (see RegisterAsSourceForSceneGraph()), this method
-  /// will return 0. If `this` plant *has* been registered as a source for
-  /// geometry::SceneGraph, this method will report the number of geometries
-  /// registered with the role geometry::Role::kIllustration, of all the
-  /// geometries registered to `this` plant's source_id.
-  int EvalNumVisualGeometries(
-      const systems::Context<T>* context = nullptr) const {
-    if (!context) {
-      DRAKE_MBP_THROW_IF_FINALIZED();
-    }
-
-    // symbolic::Expression is not supported by SceneGraph.
-    // For now, so anything internally using EvalNumVisualGeometries
-    // doesn't fail on a symbolic plant, return 0.
-    if constexpr (std::is_same_v<T, symbolic::Expression>) {
-      return 0;
-    }
-
-    if (!geometry_source_is_registered()) return 0;
-
-    if (!context) {
-      return const_cast<MultibodyPlant<T>*>(this)
-          ->member_scene_graph()
-          .model_inspector()
-          .NumGeometriesWithRole(get_source_id().value(),
-                                 geometry::Role::kIllustration);
-    } else {
-      return EvalGeometryQueryInput(*context).inspector().NumGeometriesWithRole(
-          get_source_id().value(), geometry::Role::kIllustration);
-    }
-  }
-
   /// Returns the number of geometries registered for contact modeling.
   /// This method can be called at any time during the lifetime of `this` plant,
   /// either pre- or post-finalize, see Finalize().
@@ -3639,42 +3603,6 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
                    "EvalNumCollisionGeometries(const Context<T>*).")
   int num_collision_geometries() const {
     return geometry_id_to_collision_index_.size();
-  }
-
-  /// Returns the number of geometries registered for contact modeling.
-  /// This method can be called at any time during the lifetime of `this` plant,
-  /// either pre- or post-finalize, so long as a systems::Context is available.
-  /// If `this` MultibodyPlant has not registered as a source for
-  /// geometry::SceneGraph (see RegisterAsSourceForSceneGraph()), this method
-  /// will return 0. If `this` plant *has* been registered as a source for
-  /// geometry::SceneGraph, this method will report the number of geometries
-  /// registered with the role geometry::Role::kProximity, of all the
-  /// geometries registered to `this` plant's source_id.
-  int EvalNumCollisionGeometries(
-      const systems::Context<T>* context = nullptr) const {
-    if (!context) {
-      DRAKE_MBP_THROW_IF_FINALIZED();
-    }
-
-    // symbolic::Expression is not supported by SceneGraph.
-    // For now, so anything internally using EvalNumCollisionGeometries
-    // doesn't fail on a symbolic plant, return 0.
-    if constexpr (std::is_same_v<T, symbolic::Expression>) {
-      return 0;
-    }
-
-    if (!geometry_source_is_registered()) return 0;
-
-    if (!context) {
-      return const_cast<MultibodyPlant<T>*>(this)
-          ->member_scene_graph()
-          .model_inspector()
-          .NumGeometriesWithRole(get_source_id().value(),
-                                 geometry::Role::kProximity);
-    } else {
-      return EvalGeometryQueryInput(*context).inspector().NumGeometriesWithRole(
-          get_source_id().value(), geometry::Role::kProximity);
-    }
   }
 
   /// Returns the unique id identifying `this` plant as a source for a
@@ -3790,6 +3718,78 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     }
     return get_geometry_query_input_port()
         .template Eval<geometry::QueryObject<T>>(context);
+  }
+
+  /// Returns the number of geometries registered for visualization.
+  /// This method can be called at any time during the lifetime of `this` plant,
+  /// either pre- or post-finalize, so long as a systems::Context is available.
+  /// If `this` MultibodyPlant has not registered as a source for
+  /// geometry::SceneGraph (see RegisterAsSourceForSceneGraph()), this method
+  /// will return 0. If `this` plant *has* been registered as a source for
+  /// geometry::SceneGraph, this method will report the number of geometries
+  /// registered with the role geometry::Role::kIllustration, of all the
+  /// geometries registered to `this` plant's source_id.
+  int EvalNumVisualGeometries(
+      const systems::Context<T>* context = nullptr) const {
+    if (!context) {
+      DRAKE_MBP_THROW_IF_FINALIZED();
+    }
+
+    // symbolic::Expression is not supported by SceneGraph.
+    // For now, so anything internally using EvalNumVisualGeometries
+    // doesn't fail on a symbolic plant, return 0.
+    if constexpr (std::is_same_v<T, symbolic::Expression>) {
+      return 0;
+    }
+
+    if (!geometry_source_is_registered()) return 0;
+
+    if (!context) {
+      return const_cast<MultibodyPlant<T>*>(this)
+          ->member_scene_graph()
+          .model_inspector()
+          .NumGeometriesWithRole(get_source_id().value(),
+                                 geometry::Role::kIllustration);
+    } else {
+      return EvalGeometryQueryInput(*context).inspector().NumGeometriesWithRole(
+          get_source_id().value(), geometry::Role::kIllustration);
+    }
+  }
+
+  /// Returns the number of geometries registered for contact modeling.
+  /// This method can be called at any time during the lifetime of `this` plant,
+  /// either pre- or post-finalize, so long as a systems::Context is available.
+  /// If `this` MultibodyPlant has not registered as a source for
+  /// geometry::SceneGraph (see RegisterAsSourceForSceneGraph()), this method
+  /// will return 0. If `this` plant *has* been registered as a source for
+  /// geometry::SceneGraph, this method will report the number of geometries
+  /// registered with the role geometry::Role::kProximity, of all the
+  /// geometries registered to `this` plant's source_id.
+  int EvalNumCollisionGeometries(
+      const systems::Context<T>* context = nullptr) const {
+    if (!context) {
+      DRAKE_MBP_THROW_IF_FINALIZED();
+    }
+
+    // symbolic::Expression is not supported by SceneGraph.
+    // For now, so anything internally using EvalNumCollisionGeometries
+    // doesn't fail on a symbolic plant, return 0.
+    if constexpr (std::is_same_v<T, symbolic::Expression>) {
+      return 0;
+    }
+
+    if (!geometry_source_is_registered()) return 0;
+
+    if (!context) {
+      return const_cast<MultibodyPlant<T>*>(this)
+          ->member_scene_graph()
+          .model_inspector()
+          .NumGeometriesWithRole(get_source_id().value(),
+                                 geometry::Role::kProximity);
+    } else {
+      return EvalGeometryQueryInput(*context).inspector().NumGeometriesWithRole(
+          get_source_id().value(), geometry::Role::kProximity);
+    }
   }
 
   // Checks that the provided State is consistent with this plant.

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3583,9 +3583,26 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// This method can be called at any time during the lifetime of `this` plant,
   /// either pre- or post-finalize, see Finalize().
   /// Post-finalize calls will always return the same value.
+  // Deprecation notes:
+  //   - remove `geometry_id_to_visual_index_`
+  DRAKE_DEPRECATED("2020-10-01",
+                   "num_collision_geometries() will be removed and replaced by "
+                   "EvalNumCollisionGeometries(const Context<T>*).")
   int num_visual_geometries() const {
     return static_cast<int>(geometry_id_to_visual_index_.size());
   }
+
+  /// Returns the number of geometries registered for visualization.
+  /// This method can be called at any time during the lifetime of `this` plant,
+  /// either pre- or post-finalize, so long as a systems::Context is available.
+  /// If `this` MultibodyPlant has not registered as a source for
+  /// geometry::SceneGraph (see RegisterAsSourceForSceneGraph()), this method
+  /// will return 0. If `this` plant *has* been registered as a source for
+  /// geometry::SceneGraph, this method will report the number of geometries
+  /// registered with the role geometry::Role::kIllustration, of all the
+  /// geometries registered to `this` plant's source_id.
+  int EvalNumVisualGeometries(
+    const systems::Context<T>* context = nullptr) const;
 
   /// Returns the number of geometries registered for contact modeling.
   /// This method can be called at any time during the lifetime of `this` plant,
@@ -3609,8 +3626,6 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// geometry::SceneGraph, this method will report the number of geometries
   /// registered with the role geometry::Role::kProximity, of all the
   /// geometries registered to `this` plant's source_id.
-  /// @throws std::runtime_error if `this` plant is registered as a source for
-  /// geometry::SceneGraph, but its `geometry_query` InputPort is not connected.
   int EvalNumCollisionGeometries(
       const systems::Context<T>* context = nullptr) const;
 
@@ -4582,6 +4597,9 @@ struct AddMultibodyPlantSceneGraphResult final {
 template <>
 typename MultibodyPlant<symbolic::Expression>::SceneGraphStub&
 MultibodyPlant<symbolic::Expression>::member_scene_graph();
+template <>
+int MultibodyPlant<symbolic::Expression>::EvalNumVisualGeometries(
+    const systems::Context<symbolic::Expression>*) const;
 template <>
 int MultibodyPlant<symbolic::Expression>::EvalNumCollisionGeometries(
     const systems::Context<symbolic::Expression>*) const;

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3586,11 +3586,23 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // Deprecation notes:
   //   - remove `geometry_id_to_visual_index_`
   DRAKE_DEPRECATED("2020-10-01",
-                   "num_collision_geometries() will be removed and replaced by "
-                   "EvalNumCollisionGeometries(const Context<T>*).")
+                   "num_visual_geometries() will be removed and replaced by "
+                   "EvalNumVisualGeometries(const Context<T>*).")
   int num_visual_geometries() const {
     return static_cast<int>(geometry_id_to_visual_index_.size());
   }
+
+  /// Returns the number of geometries registered for visualization.
+  /// This method can be called at any time during the lifetime of `this` plant,
+  /// either pre- or post-finalize, so long as a systems::Context is available.
+  /// If `this` MultibodyPlant has not registered as a source for
+  /// geometry::SceneGraph (see RegisterAsSourceForSceneGraph()), this method
+  /// will return 0. If `this` plant *has* been registered as a source for
+  /// geometry::SceneGraph, this method will report the number of geometries
+  /// registered with the role geometry::Role::kIllustration, of all the
+  /// geometries registered to `this` plant's source_id.
+  int EvalNumVisualGeometries(
+      const systems::Context<T>* context = nullptr) const;
 
   /// Returns the number of geometries registered for contact modeling.
   /// This method can be called at any time during the lifetime of `this` plant,
@@ -3604,6 +3616,18 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   int num_collision_geometries() const {
     return geometry_id_to_collision_index_.size();
   }
+
+  /// Returns the number of geometries registered for contact modeling.
+  /// This method can be called at any time during the lifetime of `this` plant,
+  /// either pre- or post-finalize, so long as a systems::Context is available.
+  /// If `this` MultibodyPlant has not registered as a source for
+  /// geometry::SceneGraph (see RegisterAsSourceForSceneGraph()), this method
+  /// will return 0. If `this` plant *has* been registered as a source for
+  /// geometry::SceneGraph, this method will report the number of geometries
+  /// registered with the role geometry::Role::kProximity, of all the
+  /// geometries registered to `this` plant's source_id.
+  int EvalNumCollisionGeometries(
+      const systems::Context<T>* context = nullptr) const;
 
   /// Returns the unique id identifying `this` plant as a source for a
   /// SceneGraph.
@@ -3718,78 +3742,6 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     }
     return get_geometry_query_input_port()
         .template Eval<geometry::QueryObject<T>>(context);
-  }
-
-  /// Returns the number of geometries registered for visualization.
-  /// This method can be called at any time during the lifetime of `this` plant,
-  /// either pre- or post-finalize, so long as a systems::Context is available.
-  /// If `this` MultibodyPlant has not registered as a source for
-  /// geometry::SceneGraph (see RegisterAsSourceForSceneGraph()), this method
-  /// will return 0. If `this` plant *has* been registered as a source for
-  /// geometry::SceneGraph, this method will report the number of geometries
-  /// registered with the role geometry::Role::kIllustration, of all the
-  /// geometries registered to `this` plant's source_id.
-  int EvalNumVisualGeometries(
-      const systems::Context<T>* context = nullptr) const {
-    if (!context) {
-      DRAKE_MBP_THROW_IF_FINALIZED();
-    }
-
-    // symbolic::Expression is not supported by SceneGraph.
-    // For now, so anything internally using EvalNumVisualGeometries
-    // doesn't fail on a symbolic plant, return 0.
-    if constexpr (std::is_same_v<T, symbolic::Expression>) {
-      return 0;
-    }
-
-    if (!geometry_source_is_registered()) return 0;
-
-    if (!context) {
-      return const_cast<MultibodyPlant<T>*>(this)
-          ->member_scene_graph()
-          .model_inspector()
-          .NumGeometriesWithRole(get_source_id().value(),
-                                 geometry::Role::kIllustration);
-    } else {
-      return EvalGeometryQueryInput(*context).inspector().NumGeometriesWithRole(
-          get_source_id().value(), geometry::Role::kIllustration);
-    }
-  }
-
-  /// Returns the number of geometries registered for contact modeling.
-  /// This method can be called at any time during the lifetime of `this` plant,
-  /// either pre- or post-finalize, so long as a systems::Context is available.
-  /// If `this` MultibodyPlant has not registered as a source for
-  /// geometry::SceneGraph (see RegisterAsSourceForSceneGraph()), this method
-  /// will return 0. If `this` plant *has* been registered as a source for
-  /// geometry::SceneGraph, this method will report the number of geometries
-  /// registered with the role geometry::Role::kProximity, of all the
-  /// geometries registered to `this` plant's source_id.
-  int EvalNumCollisionGeometries(
-      const systems::Context<T>* context = nullptr) const {
-    if (!context) {
-      DRAKE_MBP_THROW_IF_FINALIZED();
-    }
-
-    // symbolic::Expression is not supported by SceneGraph.
-    // For now, so anything internally using EvalNumCollisionGeometries
-    // doesn't fail on a symbolic plant, return 0.
-    if constexpr (std::is_same_v<T, symbolic::Expression>) {
-      return 0;
-    }
-
-    if (!geometry_source_is_registered()) return 0;
-
-    if (!context) {
-      return const_cast<MultibodyPlant<T>*>(this)
-          ->member_scene_graph()
-          .model_inspector()
-          .NumGeometriesWithRole(get_source_id().value(),
-                                 geometry::Role::kProximity);
-    } else {
-      return EvalGeometryQueryInput(*context).inspector().NumGeometriesWithRole(
-          get_source_id().value(), geometry::Role::kProximity);
-    }
   }
 
   // Checks that the provided State is consistent with this plant.

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3591,10 +3591,11 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// This method can be called at any time during the lifetime of `this` plant,
   /// either pre- or post-finalize, see Finalize().
   /// Post-finalize calls will always return the same value.
-  DRAKE_DEPRECATED("2020-10-01",
-                   "num_collision_geometries() will be removed and replaced by EvalNumCollisionGeometries(const Context<T>*).");
   // Deprecation notes:
   //   - remove `geometry_id_to_collision_index_`
+  DRAKE_DEPRECATED("2020-10-01",
+                   "num_collision_geometries() will be removed and replaced by "
+                   "EvalNumCollisionGeometries(const Context<T>*).")
   int num_collision_geometries() const {
     return geometry_id_to_collision_index_.size();
   }
@@ -3610,7 +3611,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// geometries registered to `this` plant's source_id.
   /// @throws std::runtime_error if `this` plant is registered as a source for
   /// geometry::SceneGraph, but its `geometry_query` InputPort is not connected.
-  int EvalNumCollisionGeometries(const systems::Context<T>* context = nullptr) const;
+  int EvalNumCollisionGeometries(
+      const systems::Context<T>* context = nullptr) const;
 
   /// Returns the unique id identifying `this` plant as a source for a
   /// SceneGraph.

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1171,22 +1171,21 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const Body<T>& body, const math::RigidTransform<double>& X_BG,
       const geometry::Shape& shape, const std::string& name);
 
-  /// Returns an array of GeometryId's identifying the different visual
+  /// Returns a vector of GeometryId's identifying the different visual
   /// geometries for `body` previously registered with a SceneGraph.
   /// @note This method can only be called pre-finalize, see Finalize().
   /// @see RegisterVisualGeometry(), Finalize()
-  const std::vector<geometry::GeometryId>& GetVisualGeometriesForBody(
+  std::vector<geometry::GeometryId> GetVisualGeometriesForBody(
       const Body<T>& body) const;
 
-  /// Returns an array of GeometryId's identifying the different visual
+  /// Returns a vector of GeometryId's identifying the different visual
   /// geometries for `body` previously registered with a SceneGraph.
   /// @note This method can be called at any time during the lifetime of `this`
   /// plant, either pre- or post-finalize, see Finalize().
   /// Post-finalize calls will always return the same value.
   /// @see RegisterVisualGeometry(), Finalize()
-  const std::vector<geometry::GeometryId>&
-  MultibodyPlant<T>::GetVisualGeometriesForBody(
-      const systems::Context<T>& context, Body<T>& body) const;
+  std::vector<geometry::GeometryId> GetVisualGeometriesForBody(
+      const systems::Context<T>& context, const Body<T>& body) const;
 
   /// Registers geometry in a SceneGraph with a given geometry::Shape to be
   /// used for the contact modeling of a given `body`.
@@ -1219,22 +1218,21 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const geometry::Shape& shape, const std::string& name,
       const CoulombFriction<double>& coulomb_friction);
 
-  /// Returns an array of GeometryId's identifying the different contact
+  /// Returns a vector of GeometryId's identifying the different contact
   /// geometries for `body` previously registered with a SceneGraph.
   /// @note This method can only be called pre-finalize, see Finalize().
   /// @see RegisterCollisionGeometry(), Finalize()
-  const std::vector<geometry::GeometryId>& GetCollisionGeometriesForBody(
+  std::vector<geometry::GeometryId> GetCollisionGeometriesForBody(
       const Body<T>& body) const;
 
-  /// Returns an array of GeometryId's identifying the different contact
+  /// Returns a vector of GeometryId's identifying the different contact
   /// geometries for `body` previously registered with a SceneGraph.
   /// @note This method can be called at any time during the lifetime of `this`
   /// plant, either pre- or post-finalize, see Finalize().
   /// Post-finalize calls will always return the same value.
   /// @see RegisterCollisionGeometry(), Finalize()
-  const std::vector<geometry::GeometryId>&
-  MultibodyPlant<T>::GetCollisionGeometriesForBody(
-      const systems::Context<T>& context, Body<T>& body) const;
+  std::vector<geometry::GeometryId> GetCollisionGeometriesForBody(
+      const systems::Context<T>& context, const Body<T>& body) const;
 
   /// Excludes the collision geometries between two given collision filter
   /// groups.
@@ -4382,32 +4380,40 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   // Gets all geometry ids for visual geometries registered by this plant.
   // This method can only be called pre-finalize.
-  vector<geometry::GeometryId> visual_geometries() const {
-    DRAKE_MBP_THROW_IF_FINALIZED();
-    return member_scene_graph.model_inspector().GetGeometriesForSourceWithRole(
-        get_source_id(), geometry::Role::kIllustration);
+  std::unordered_set<geometry::GeometryId> visual_geometries() const {
+    DRAKE_DEMAND(geometry_source_is_registered());
+    return const_cast<MultibodyPlant<T>*>(this)
+        ->member_scene_graph()
+        .model_inspector()
+        .GetGeometriesForSourceWithRole(get_source_id().value(),
+                                        geometry::Role::kIllustration);
   }
 
   // Gets all geometry ids for visual geometries registered by this plant.
-  vector<geometry::GeometryId> visual_geometries(
+  std::unordered_set<geometry::GeometryId> visual_geometries(
       geometry::QueryObject<T> query_object) const {
+    DRAKE_DEMAND(geometry_source_is_registered());
     return query_object.inspector().GetGeometriesForSourceWithRole(
-        get_source_id(), geometry::Role::kIllustration);
+        get_source_id().value(), geometry::Role::kIllustration);
   }
 
   // Gets all geometry ids for collision geometries registered by this plant.
   // This method can only be called pre-finalize.
-  vector<geometry::GeometryId> collision_geometries() const {
-    DRAKE_MBP_THROW_IF_FINALIZED();
-    return member_scene_graph.model_inspector().GetGeometriesForSourceWithRole(
-        get_source_id(), geometry::Role::kProximity);
+  std::unordered_set<geometry::GeometryId> collision_geometries() const {
+    DRAKE_DEMAND(geometry_source_is_registered());
+    return const_cast<MultibodyPlant<T>*>(this)
+        ->member_scene_graph()
+        .model_inspector()
+        .GetGeometriesForSourceWithRole(get_source_id().value(),
+                                        geometry::Role::kProximity);
   }
 
   // Gets all geometry ids for collision geometries registered by this plant.
-  vector<geometry::GeometryId> collision_geometries(
+  std::unordered_set<geometry::GeometryId> collision_geometries(
       geometry::QueryObject<T> query_object) const {
+    DRAKE_DEMAND(geometry_source_is_registered());
     return query_object.inspector().GetGeometriesForSourceWithRole(
-        get_source_id(), geometry::Role::kProximity);
+        get_source_id().value(), geometry::Role::kProximity);
   }
 
   // Iteration order on this map DOES matter, and therefore we use an std::map.

--- a/multibody/plant/test/multibody_plant_tamsi_test.cc
+++ b/multibody/plant/test/multibody_plant_tamsi_test.cc
@@ -52,10 +52,10 @@ GTEST_TEST(MbpWithTamsiSolver, FixedWorld) {
   EXPECT_EQ(plant.num_velocities(), 0);
   EXPECT_EQ(plant.num_positions(), 0);
 
-  // However it is not empty, it has all anchored geometry.
-  EXPECT_EQ(plant.num_collision_geometries(), 3);
-
   auto context = diagram->CreateDefaultContext();
+
+  // However it is not empty, it has all anchored geometry.
+  EXPECT_EQ(plant.num_collision_geometries(*context), 3);
 
   auto& discrete_state_vector = context->get_discrete_state_vector();
   EXPECT_EQ(discrete_state_vector.size(), 0);

--- a/multibody/plant/test/multibody_plant_tamsi_test.cc
+++ b/multibody/plant/test/multibody_plant_tamsi_test.cc
@@ -53,9 +53,10 @@ GTEST_TEST(MbpWithTamsiSolver, FixedWorld) {
   EXPECT_EQ(plant.num_positions(), 0);
 
   auto context = diagram->CreateDefaultContext();
+  auto& plant_context = plant.GetMyMutableContextFromRoot(context.get());
 
   // However it is not empty, it has all anchored geometry.
-  EXPECT_EQ(plant.num_collision_geometries(*context), 3);
+  EXPECT_EQ(plant.EvalNumCollisionGeometries(&plant_context), 3);
 
   auto& discrete_state_vector = context->get_discrete_state_vector();
   EXPECT_EQ(discrete_state_vector.size(), 0);

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -92,9 +92,11 @@ class MultibodyPlantTester {
   MultibodyPlantTester() = delete;
 
   template <typename T>
-  static BodyIndex geometry_id_to_body_index(
-      const MultibodyPlant<T>& plant, GeometryId id) {
-    return plant.geometry_id_to_body_index_.at(id);
+  static BodyIndex geometry_id_to_body_index(const MultibodyPlant<T>& plant,
+                                             const Context<T>& context,
+                                             GeometryId id) {
+    const auto& query_object = EvalGeometryQueryInput(plant, context);
+    return plant.geometry_id_to_body_index(query_object, id);
   }
 
   static void CalcNormalAndTangentContactJacobians(
@@ -106,9 +108,9 @@ class MultibodyPlantTester {
         context, point_pairs, Jn, Jt, R_WC_set);
   }
 
-  static const geometry::QueryObject<double>& EvalGeometryQueryInput(
-      const MultibodyPlant<double>& plant,
-      const systems::Context<double>& context) {
+  template <typename T>
+  static const geometry::QueryObject<T>& EvalGeometryQueryInput(
+      const MultibodyPlant<T>& plant, const systems::Context<T>& context) {
     return plant.EvalGeometryQueryInput(context);
   }
 };
@@ -2169,7 +2171,7 @@ class MultibodyPlantContactJacobianTests : public ::testing::Test {
       PenetrationAsPointPair<T> pair_on_T;
 
       BodyIndex bodyA_index = MultibodyPlantTester::geometry_id_to_body_index(
-          plant_on_T, pair.id_A);
+          plant_on_T, context_on_T, pair.id_A);
       const RigidTransform<T>& X_WA = plant_on_T.EvalBodyPoseInWorld(
           context_on_T, plant_on_T.get_body(bodyA_index));
       const SpatialVelocity<T> V_WA =
@@ -2177,7 +2179,7 @@ class MultibodyPlantContactJacobianTests : public ::testing::Test {
               context_on_T, plant_on_T.get_body(bodyA_index));
 
       BodyIndex bodyB_index = MultibodyPlantTester::geometry_id_to_body_index(
-          plant_on_T, pair.id_B);
+          plant_on_T, context_on_T, pair.id_B);
       const RigidTransform<T>& X_WB = plant_on_T.EvalBodyPoseInWorld(
           context_on_T, plant_on_T.get_body(bodyB_index));
       const SpatialVelocity<T> V_WB =
@@ -2221,7 +2223,7 @@ class MultibodyPlantContactJacobianTests : public ::testing::Test {
       PenetrationAsPointPair<T> pair_on_T;
 
       BodyIndex bodyA_index = MultibodyPlantTester::geometry_id_to_body_index(
-          plant_on_T, pair.id_A);
+          plant_on_T, context_on_T, pair.id_A);
       const RigidTransform<T>& X_WA = plant_on_T.EvalBodyPoseInWorld(
           context_on_T, plant_on_T.get_body(bodyA_index));
       const SpatialVelocity<T> V_WA =
@@ -2229,7 +2231,7 @@ class MultibodyPlantContactJacobianTests : public ::testing::Test {
               context_on_T, plant_on_T.get_body(bodyA_index));
 
       BodyIndex bodyB_index = MultibodyPlantTester::geometry_id_to_body_index(
-          plant_on_T, pair.id_B);
+          plant_on_T, context_on_T, pair.id_B);
       const RigidTransform<T>& X_WB = plant_on_T.EvalBodyPoseInWorld(
           context_on_T, plant_on_T.get_body(bodyB_index));
       const SpatialVelocity<T> V_WB =

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -1927,21 +1927,39 @@ GTEST_TEST(MultibodyPlantTest, ScalarConversionConstructor) {
   EXPECT_EQ(plant.EvalNumCollisionGeometries(&plant_context), 3);
 
   const int link1_num_collisions =
-      plant.GetCollisionGeometriesForBody(plant.GetBodyByName("link1")).size();
+      plant
+          .GetCollisionGeometriesForBody(plant_context,
+                                         plant.GetBodyByName("link1"))
+          .size();
   const int link2_num_collisions =
-      plant.GetCollisionGeometriesForBody(plant.GetBodyByName("link2")).size();
+      plant
+          .GetCollisionGeometriesForBody(plant_context,
+                                         plant.GetBodyByName("link2"))
+          .size();
   const int link3_num_collisions =
-      plant.GetCollisionGeometriesForBody(plant.GetBodyByName("link3")).size();
+      plant
+          .GetCollisionGeometriesForBody(plant_context,
+                                         plant.GetBodyByName("link3"))
+          .size();
   ASSERT_EQ(link1_num_collisions, 2);
   ASSERT_EQ(link2_num_collisions, 0);
   ASSERT_EQ(link3_num_collisions, 1);
 
   const int link1_num_visuals =
-      plant.GetVisualGeometriesForBody(plant.GetBodyByName("link1")).size();
+      plant
+          .GetVisualGeometriesForBody(plant_context,
+                                      plant.GetBodyByName("link1"))
+          .size();
   const int link2_num_visuals =
-      plant.GetVisualGeometriesForBody(plant.GetBodyByName("link2")).size();
+      plant
+          .GetVisualGeometriesForBody(plant_context,
+                                      plant.GetBodyByName("link2"))
+          .size();
   const int link3_num_visuals =
-      plant.GetVisualGeometriesForBody(plant.GetBodyByName("link3")).size();
+      plant
+          .GetVisualGeometriesForBody(plant_context,
+                                      plant.GetBodyByName("link3"))
+          .size();
   ASSERT_EQ(link1_num_visuals, 2);
   ASSERT_EQ(link2_num_visuals, 3);
   ASSERT_EQ(link3_num_visuals, 0);
@@ -1979,18 +1997,42 @@ GTEST_TEST(MultibodyPlantTest, ScalarConversionConstructor) {
   EXPECT_TRUE(plant_autodiff.geometry_source_is_registered());
   EXPECT_EQ(plant_autodiff.EvalNumCollisionGeometries(&plant_context_autodiff),
             plant.EvalNumCollisionGeometries(&plant_context));
-  EXPECT_EQ(plant_autodiff.GetCollisionGeometriesForBody(
-      plant_autodiff.GetBodyByName("link1")).size(), link1_num_collisions);
-  EXPECT_EQ(plant_autodiff.GetCollisionGeometriesForBody(
-      plant_autodiff.GetBodyByName("link2")).size(), link2_num_collisions);
-  EXPECT_EQ(plant_autodiff.GetCollisionGeometriesForBody(
-      plant_autodiff.GetBodyByName("link3")).size(), link3_num_collisions);
-  EXPECT_EQ(plant_autodiff.GetVisualGeometriesForBody(
-      plant_autodiff.GetBodyByName("link1")).size(), link1_num_visuals);
-  EXPECT_EQ(plant_autodiff.GetVisualGeometriesForBody(
-      plant_autodiff.GetBodyByName("link2")).size(), link2_num_visuals);
-  EXPECT_EQ(plant_autodiff.GetVisualGeometriesForBody(
-      plant_autodiff.GetBodyByName("link3")).size(), link3_num_visuals);
+  EXPECT_EQ(
+      plant_autodiff
+          .GetCollisionGeometriesForBody(plant_context_autodiff,
+                                         plant_autodiff.GetBodyByName("link1"))
+          .size(),
+      link1_num_collisions);
+  EXPECT_EQ(
+      plant_autodiff
+          .GetCollisionGeometriesForBody(plant_context_autodiff,
+                                         plant_autodiff.GetBodyByName("link2"))
+          .size(),
+      link2_num_collisions);
+  EXPECT_EQ(
+      plant_autodiff
+          .GetCollisionGeometriesForBody(plant_context_autodiff,
+                                         plant_autodiff.GetBodyByName("link3"))
+          .size(),
+      link3_num_collisions);
+  EXPECT_EQ(
+      plant_autodiff
+          .GetVisualGeometriesForBody(plant_context_autodiff,
+                                      plant_autodiff.GetBodyByName("link1"))
+          .size(),
+      link1_num_visuals);
+  EXPECT_EQ(
+      plant_autodiff
+          .GetVisualGeometriesForBody(plant_context_autodiff,
+                                      plant_autodiff.GetBodyByName("link2"))
+          .size(),
+      link2_num_visuals);
+  EXPECT_EQ(
+      plant_autodiff
+          .GetVisualGeometriesForBody(plant_context_autodiff,
+                                      plant_autodiff.GetBodyByName("link3"))
+          .size(),
+      link3_num_visuals);
 
   // Make sure the geometry ports were included in the autodiffed plant.
   DRAKE_EXPECT_NO_THROW(plant_autodiff.get_geometry_query_input_port());

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -1692,7 +1692,8 @@ TEST_F(AcrobotPlantTests, EvalStateAndAccelerationOutputPorts) {
   plant_->get_state_output_port().Calc(*plant_context_, state_value.get());
 
   // Get continuous state_out from context.
-  const VectorBase<double>& state = plant_context_->get_continuous_state_vector();
+  const VectorBase<double>& state =
+      plant_context_->get_continuous_state_vector();
 
   // Verify state_out indeed matches state.
   EXPECT_EQ(state_out.CopyToVector(), state.CopyToVector());


### PR DESCRIPTION
This PR changes `MultibodyPlant::num_collision_geometries` to query SceneGraph for the number of registered geometries with the role `kProximity`, instead of bookkeeping the registered geometry itself.

It also introduces an overloaded `num_collision_geometries(const Context<T>&)` method to query the collision geometries when a context is availalble (either pre or post finalize).
`num_collision_geometries()` can now only be called pre-finalize, as it uses `member_scene_graph()` for the query. Either method returns 0 if the plant in question has not registered as a source for SceneGraph.

As well, it changes all of the post-finalize uses of `num_collision_geometries` in the rest of the code base.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13545)
<!-- Reviewable:end -->
