### PR TITLE
doc: Make sure each doxygen-only file has a xref to defined sections

### DIFF
--- a/bindings/pydrake/pydrake_doxygen.h
+++ b/bindings/pydrake/pydrake_doxygen.h
@@ -1,6 +1,5 @@
-/// @file
-/// Doxygen-only documentation for the development of Python bindings.
-/// @sa @ref python_bindings
+/** @file
+ Doxygen-only documentation for @ref python_bindings.  */
 
 /** @defgroup python_bindings Python Bindings
 @ingroup technical_notes

--- a/geometry/geometry_doxygen.h
+++ b/geometry/geometry_doxygen.h
@@ -1,3 +1,6 @@
+/** @file
+ Doxygen-only documentation for @ref geometry.  */
+
 // Define groups here so we can control the ordering.
 namespace drake {
 namespace geometry {

--- a/geometry/geometry_infrastructure_doxygen.h
+++ b/geometry/geometry_infrastructure_doxygen.h
@@ -1,3 +1,6 @@
+/** @file
+ Doxygen-only documentation for @ref geometry_infrastructure.  */
+
 namespace drake {
 namespace geometry {
 

--- a/geometry/proximity/contact_surface_doxygen.h
+++ b/geometry/proximity/contact_surface_doxygen.h
@@ -1,3 +1,6 @@
+/** @file
+ Doxygen-only documentation for @ref module_contact_surface.  */
+
 namespace drake {
 namespace geometry {
 namespace proximity {

--- a/geometry/proximity/penetration_doxygen.h
+++ b/geometry/proximity/penetration_doxygen.h
@@ -1,3 +1,6 @@
+/** @file
+ Doxygen-only documentation for @ref module_penetration_queries.  */
+
 namespace drake {
 namespace geometry {
 namespace proximity {

--- a/geometry/proximity/proximity_doxygen.h
+++ b/geometry/proximity/proximity_doxygen.h
@@ -1,3 +1,6 @@
+/** @file
+ Doxygen-only documentation for @ref proximity_queries.  */
+
 namespace drake {
 namespace geometry {
 namespace proximity {

--- a/geometry/render/render_doxygen.h
+++ b/geometry/render/render_doxygen.h
@@ -1,3 +1,6 @@
+/** @file
+ Doxygen-only documentation for @ref render_engines.  */
+
 namespace drake {
 namespace geometry {
 namespace render {

--- a/multibody/constraint/constraint_doxygen.h
+++ b/multibody/constraint/constraint_doxygen.h
@@ -1,3 +1,6 @@
+/** @file
+ Doxygen-only documentation for @ref constraint_overview */
+
 /** @addtogroup constraint_overview
 
 This documentation describes the types of multibody constraints supported in

--- a/multibody/multibody_doxygen.h
+++ b/multibody/multibody_doxygen.h
@@ -1,3 +1,7 @@
+/** @file
+ Doxygen-only documentation for @ref multibody_notation, 
+ @ref multibody_spatial_inertia.  */
+
 // Developers: the subsections here can be linkably referenced from your Doxygen
 // comments using
 //    @ref group_name.

--- a/multibody/plant/contact_model_doxygen.h
+++ b/multibody/plant/contact_model_doxygen.h
@@ -1,3 +1,6 @@
+/** @file
+ Doxygen-only documentation for @ref drake_contacts.  */
+
 /** @defgroup drake_contacts   Contact Modeling in Drake
     @ingroup multibody
 

--- a/solvers/mathematical_program_doxygen.h
+++ b/solvers/mathematical_program_doxygen.h
@@ -1,3 +1,6 @@
+/** @file
+ Doxygen-only documentation for @ref solvers.  */
+
 /** @addtogroup solvers
  * @{
  * Drake's MathematicalProgram class is used to solve the mathematical

--- a/systems/framework/cache_doxygen.h
+++ b/systems/framework/cache_doxygen.h
@@ -1,3 +1,6 @@
+/** @file
+ Doxygen-only documentation for @ref cache_design_notes.  */
+
 #pragma once
 
 // Putting this document in drake::systems namespace makes the links work.

--- a/systems/framework/system_scalar_conversion_doxygen.h
+++ b/systems/framework/system_scalar_conversion_doxygen.h
@@ -1,3 +1,6 @@
+/** @file
+ Doxygen-only documentation for @ref system_scalar_conversion.  */
+
 //------------------------------------------------------------------------------
 /** @defgroup system_scalar_conversion System Scalar Conversion
     @ingroup technical_notes


### PR DESCRIPTION
In searching Doxygen for `proximity`, one of the first things to come up was `proximity_doxygen.h`. On master, this is currently a blank page.

This makes the pages at least a bit more useful.

Searched for this as part of https://drakedevelopers.slack.com/archives/C2WBPQDB7/p1591895065204300

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13547)
<!-- Reviewable:end -->
