### PR TITLE
Fix some collision geometries of the panda arm urdf

### DIFF
--- a/manipulation/models/franka_description/urdf/hand.urdf
+++ b/manipulation/models/franka_description/urdf/hand.urdf
@@ -17,7 +17,7 @@
       </geometry>
     </visual>
     <collision>
-      <origin rpy="0 0 0" xyz="0 -0.06 0.0"/>
+      <origin rpy="0 0 0" xyz="0 -0.06 0.015"/>
       <geometry>
         <sphere radius="0.05"/>
       </geometry>

--- a/manipulation/models/franka_description/urdf/panda_arm.urdf
+++ b/manipulation/models/franka_description/urdf/panda_arm.urdf
@@ -17,7 +17,7 @@
       </geometry>
     </visual>
     <collision>
-      <origin rpy="0 0 0" xyz="0.02 0 0.04"/>
+      <origin rpy="0 0 0" xyz="0.02 0.0 0.04"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
@@ -35,7 +35,7 @@
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="-0.06 0 0.06"/>
+      <origin rpy="0 0 0" xyz="-0.06 0.0 0.06"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
@@ -71,7 +71,7 @@
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="-0.09 0 0.06"/>
+      <origin rpy="0 0 0" xyz="-0.09 0.0 0.06"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
@@ -83,7 +83,19 @@
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="-0.12 0 0.06"/>
+      <origin rpy="0 0 0" xyz="-0.12 0.0 0.06"/>
+      <geometry>
+        <sphere radius="0.06"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.0 0.0 0.113"/>
+      <geometry>
+        <sphere radius="0.06"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.0 0.0 0.083"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
@@ -102,37 +114,37 @@
       </geometry>
     </visual>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.13"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0 -0.13"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.16"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0 -0.16"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.19"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0 -0.19"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.22"/>
+      <origin rpy="0 0 0" xyz="0.0 -0.04 -0.06"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.25"/>
+      <origin rpy="0 0 0" xyz="0.0 -0.0750 -0.0"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 -0.04 -0.06"/>
+      <origin rpy="0 0 0" xyz="0.0 -0.0350 -0.0"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
@@ -159,31 +171,37 @@
       </geometry>
     </visual>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.075"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.035"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0 0.035"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0 0.075"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 0.035"/>
+      <origin rpy="0 0 0" xyz="0.0 -0.1710 0.0"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 0.075"/>
+      <origin rpy="0 0 0" xyz="0.0 -0.1360 0.0"/>
+      <geometry>
+        <sphere radius="0.06"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.0 -0.070 0.040"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
@@ -210,37 +228,31 @@
       </geometry>
     </visual>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.11"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0 -0.11"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.145"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0 -0.07"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.18"/>
+      <origin rpy="0 0 0" xyz="0.0825 0.03 -0.0"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0.015 -0.22"/>
+      <origin rpy="0 0 0" xyz="0.0825 0.06 -0.0"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0.035 -0.26"/>
-      <geometry>
-        <sphere radius="0.06"/>
-      </geometry>
-    </collision>
-    <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.07"/>
+      <origin rpy="0 0 0" xyz="0.04 0.03 -0.03"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
@@ -267,19 +279,19 @@
       </geometry>
     </visual>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 0.06"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0 0.06"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 0.03"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0 0.03"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="-0.035 0.03 0.04"/>
+      <origin rpy="0 0 0" xyz="-0.0350 0.03 0.04"/>
       <geometry>
         <sphere radius="0.05"/>
       </geometry>
@@ -291,25 +303,19 @@
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 0.00"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.03"/>
+      <origin rpy="0 0 0" xyz="-0.0825 0.0640 -0.0"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.06"/>
-      <geometry>
-        <sphere radius="0.06"/>
-      </geometry>
-    </collision>
-    <collision>
-      <origin rpy="0 0 0" xyz="0 -0.05 -0.03"/>
+      <origin rpy="0 0 0" xyz="-0.0825 0.1040 -0.0"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
@@ -336,81 +342,75 @@
       </geometry>
     </visual>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0.0 -0.32"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0 -0.24"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0.0 -0.28"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0 -0.21"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0.0 -0.24"/>
-      <geometry>
-        <sphere radius="0.06"/>
-      </geometry>
-    </collision>
-    <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.21"/>
-      <geometry>
-        <sphere radius="0.06"/>
-      </geometry>
-    </collision>
-    <collision>
-      <origin rpy="0 0 0" xyz="0 0.09 -0.055"/>
+      <origin rpy="0 0 0" xyz="0.0 0.09 -0.055"/>
       <geometry>
         <sphere radius="0.035"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0.085 -0.08"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0850 -0.08"/>
       <geometry>
         <sphere radius="0.035"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0.085 -0.11"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0850 -0.11"/>
       <geometry>
         <sphere radius="0.035"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0.08 -0.13"/>
+      <origin rpy="0 0 0" xyz="0.0 0.08 -0.13"/>
       <geometry>
         <sphere radius="0.035"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0.08 -0.15"/>
+      <origin rpy="0 0 0" xyz="0.0 0.08 -0.15"/>
       <geometry>
         <sphere radius="0.035"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0.07 -0.16"/>
+      <origin rpy="0 0 0" xyz="0.0 0.07 -0.16"/>
       <geometry>
         <sphere radius="0.04"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0.08 -0.02"/>
+      <origin rpy="0 0 0" xyz="0.0 0.08 -0.02"/>
       <geometry>
         <sphere radius="0.05"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0.08 -0.00"/>
+      <origin rpy="0 0 0" xyz="0.0 0.08 -0.0"/>
       <geometry>
         <sphere radius="0.055"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0.05 -0.20"/>
+      <origin rpy="0 0 0" xyz="0.0 0.05 -0.20"/>
       <geometry>
         <sphere radius="0.055"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.0 0.07 -0.0"/>
+      <geometry>
+        <sphere radius="0.06"/>
       </geometry>
     </collision>
   </link>
@@ -420,7 +420,7 @@
     <parent link="panda_link4"/>
     <child link="panda_link5"/>
     <axis xyz="0 0 1"/>
-    <limit effort="12" lower="-2.8973" upper="2.8973" velocity="2.6100"/>
+    <limit effort="12" lower="-2.8973" upper="2.8973" velocity="2.610"/>
   </joint>
   <link name="panda_link6">
     <inertial>
@@ -453,21 +453,15 @@
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 0.01"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0 0.01"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.03"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0 -0.03"/>
       <geometry>
         <sphere radius="0.05"/>
-      </geometry>
-    </collision>
-    <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.07"/>
-      <geometry>
-        <sphere radius="0.06"/>
       </geometry>
     </collision>
   </link>
@@ -477,7 +471,7 @@
     <parent link="panda_link5"/>
     <child link="panda_link6"/>
     <axis xyz="0 0 1"/>
-    <limit effort="12" lower="-0.0175" upper="3.7525" velocity="2.6100"/>
+    <limit effort="12" lower="-0.0175" upper="3.7525" velocity="2.610"/>
   </joint>
   <link name="panda_link7">
     <inertial>
@@ -510,7 +504,7 @@
     <parent link="panda_link6"/>
     <child link="panda_link7"/>
     <axis xyz="0 0 1"/>
-    <limit effort="12" lower="-2.8973" upper="2.8973" velocity="2.6100"/>
+    <limit effort="12" lower="-2.8973" upper="2.8973" velocity="2.610"/>
   </joint>
   <link name="panda_link8">
     <collision>

--- a/manipulation/models/franka_description/urdf/panda_arm_hand.urdf
+++ b/manipulation/models/franka_description/urdf/panda_arm_hand.urdf
@@ -17,7 +17,7 @@
       </geometry>
     </visual>
     <collision>
-      <origin rpy="0 0 0" xyz="0.02 0 0.04"/>
+      <origin rpy="0 0 0" xyz="0.02 0.0 0.04"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
@@ -35,7 +35,7 @@
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="-0.06 0 0.06"/>
+      <origin rpy="0 0 0" xyz="-0.06 0.0 0.06"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
@@ -71,7 +71,7 @@
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="-0.09 0 0.06"/>
+      <origin rpy="0 0 0" xyz="-0.09 0.0 0.06"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
@@ -83,7 +83,19 @@
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="-0.12 0 0.06"/>
+      <origin rpy="0 0 0" xyz="-0.12 0.0 0.06"/>
+      <geometry>
+        <sphere radius="0.06"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.0 0.0 0.113"/>
+      <geometry>
+        <sphere radius="0.06"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.0 0.0 0.083"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
@@ -102,37 +114,37 @@
       </geometry>
     </visual>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.13"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0 -0.13"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.16"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0 -0.16"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.19"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0 -0.19"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.22"/>
+      <origin rpy="0 0 0" xyz="0.0 -0.04 -0.06"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.25"/>
+      <origin rpy="0 0 0" xyz="0.0 -0.0750 -0.0"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 -0.04 -0.06"/>
+      <origin rpy="0 0 0" xyz="0.0 -0.0350 -0.0"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
@@ -159,31 +171,37 @@
       </geometry>
     </visual>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.075"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.035"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0 0.035"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0 0.075"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 0.035"/>
+      <origin rpy="0 0 0" xyz="0.0 -0.1710 0.0"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 0.075"/>
+      <origin rpy="0 0 0" xyz="0.0 -0.1360 0.0"/>
+      <geometry>
+        <sphere radius="0.06"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.0 -0.070 0.040"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
@@ -210,37 +228,31 @@
       </geometry>
     </visual>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.11"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0 -0.11"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.145"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0 -0.07"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.18"/>
+      <origin rpy="0 0 0" xyz="0.0825 0.03 -0.0"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0.015 -0.22"/>
+      <origin rpy="0 0 0" xyz="0.0825 0.06 -0.0"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0.035 -0.26"/>
-      <geometry>
-        <sphere radius="0.06"/>
-      </geometry>
-    </collision>
-    <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.07"/>
+      <origin rpy="0 0 0" xyz="0.04 0.03 -0.03"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
@@ -267,19 +279,19 @@
       </geometry>
     </visual>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 0.06"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0 0.06"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 0.03"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0 0.03"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="-0.035 0.03 0.04"/>
+      <origin rpy="0 0 0" xyz="-0.0350 0.03 0.04"/>
       <geometry>
         <sphere radius="0.05"/>
       </geometry>
@@ -291,25 +303,19 @@
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 0.00"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.03"/>
+      <origin rpy="0 0 0" xyz="-0.0825 0.0640 -0.0"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.06"/>
-      <geometry>
-        <sphere radius="0.06"/>
-      </geometry>
-    </collision>
-    <collision>
-      <origin rpy="0 0 0" xyz="0 -0.05 -0.03"/>
+      <origin rpy="0 0 0" xyz="-0.0825 0.1040 -0.0"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
@@ -336,81 +342,75 @@
       </geometry>
     </visual>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0.0 -0.32"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0 -0.24"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0.0 -0.28"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0 -0.21"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0.0 -0.24"/>
-      <geometry>
-        <sphere radius="0.06"/>
-      </geometry>
-    </collision>
-    <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.21"/>
-      <geometry>
-        <sphere radius="0.06"/>
-      </geometry>
-    </collision>
-    <collision>
-      <origin rpy="0 0 0" xyz="0 0.09 -0.055"/>
+      <origin rpy="0 0 0" xyz="0.0 0.09 -0.055"/>
       <geometry>
         <sphere radius="0.035"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0.085 -0.08"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0850 -0.08"/>
       <geometry>
         <sphere radius="0.035"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0.085 -0.11"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0850 -0.11"/>
       <geometry>
         <sphere radius="0.035"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0.08 -0.13"/>
+      <origin rpy="0 0 0" xyz="0.0 0.08 -0.13"/>
       <geometry>
         <sphere radius="0.035"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0.08 -0.15"/>
+      <origin rpy="0 0 0" xyz="0.0 0.08 -0.15"/>
       <geometry>
         <sphere radius="0.035"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0.07 -0.16"/>
+      <origin rpy="0 0 0" xyz="0.0 0.07 -0.16"/>
       <geometry>
         <sphere radius="0.04"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0.08 -0.02"/>
+      <origin rpy="0 0 0" xyz="0.0 0.08 -0.02"/>
       <geometry>
         <sphere radius="0.05"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0.08 -0.00"/>
+      <origin rpy="0 0 0" xyz="0.0 0.08 -0.0"/>
       <geometry>
         <sphere radius="0.055"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0.05 -0.20"/>
+      <origin rpy="0 0 0" xyz="0.0 0.05 -0.20"/>
       <geometry>
         <sphere radius="0.055"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.0 0.07 -0.0"/>
+      <geometry>
+        <sphere radius="0.06"/>
       </geometry>
     </collision>
   </link>
@@ -453,21 +453,15 @@
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 0.01"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0 0.01"/>
       <geometry>
         <sphere radius="0.06"/>
       </geometry>
     </collision>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.03"/>
+      <origin rpy="0 0 0" xyz="0.0 0.0 -0.03"/>
       <geometry>
         <sphere radius="0.05"/>
-      </geometry>
-    </collision>
-    <collision>
-      <origin rpy="0 0 0" xyz="0 0 -0.07"/>
-      <geometry>
-        <sphere radius="0.06"/>
       </geometry>
     </collision>
   </link>
@@ -477,7 +471,7 @@
     <parent link="panda_link5"/>
     <child link="panda_link6"/>
     <axis xyz="0 0 1"/>
-    <limit effort="12" lower="-0.0175" upper="3.7525" velocity="2.6100"/>
+    <limit effort="12" lower="-0.0175" upper="3.7525" velocity="2.610"/>
   </joint>
   <link name="panda_link7">
     <inertial>
@@ -510,7 +504,7 @@
     <parent link="panda_link6"/>
     <child link="panda_link7"/>
     <axis xyz="0 0 1"/>
-    <limit effort="12" lower="-2.8973" upper="2.8973" velocity="2.6100"/>
+    <limit effort="12" lower="-2.8973" upper="2.8973" velocity="2.610"/>
   </joint>
   <link name="panda_link8">
     <collision>
@@ -613,7 +607,7 @@
       </geometry>
     </visual>
     <collision>
-      <origin rpy="0 0 0" xyz="0 -0.06 0.0"/>
+      <origin rpy="0 0 0" xyz="0 -0.06 0.015"/>
       <geometry>
         <sphere radius="0.05"/>
       </geometry>


### PR DESCRIPTION
Issues: 
1) Some of the collisions are defined for the wrong link. See the following two pictures of link1
Before:
![wrong_panda_link1](https://user-images.githubusercontent.com/51714458/84450560-5b9c3800-ac05-11ea-8d2b-e06e9b9b05db.png)
After:
![updated_panda_link1](https://user-images.githubusercontent.com/51714458/84450575-622aaf80-ac05-11ea-8258-533b13a0e09c.png)

2) One contact geometry on the hand extended too much. Moving it a little bit expands the workspace of the wrist.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13550)
<!-- Reviewable:end -->
