### PR TITLE
[render] Add base infrastructure for declaring full camera intrinsics

### DIFF
--- a/bindings/pydrake/systems/sensors_py.cc
+++ b/bindings/pydrake/systems/sensors_py.cc
@@ -208,13 +208,15 @@ PYBIND11_MODULE(sensors, m) {
           py::arg("parent_id"), py::arg("X_PB"), py::arg("color_properties"),
           py::arg("depth_properties"),
           py::arg("camera_poses") = RgbdSensor::CameraPoses{},
-          py::arg("show_window") = false, doc.RgbdSensor.ctor.doc_6args)
+          py::arg("show_window") = false,
+          doc.RgbdSensor.ctor.doc_legacy_individual_intrinsics)
       .def(py::init<FrameId, const RigidTransformd&,
                const DepthCameraProperties&, const RgbdSensor::CameraPoses&,
                bool>(),
           py::arg("parent_id"), py::arg("X_PB"), py::arg("properties"),
           py::arg("camera_poses") = RgbdSensor::CameraPoses{},
-          py::arg("show_window") = false, doc.RgbdSensor.ctor.doc_5args)
+          py::arg("show_window") = false,
+          doc.RgbdSensor.ctor.doc_legacy_combined_intrinsics)
       .def("color_camera_info", &RgbdSensor::color_camera_info,
           py_reference_internal, doc.RgbdSensor.color_camera_info.doc)
       .def("depth_camera_info", &RgbdSensor::depth_camera_info,

--- a/geometry/render/BUILD.bazel
+++ b/geometry/render/BUILD.bazel
@@ -14,12 +14,24 @@ package(default_visibility = ["//visibility:public"])
 drake_cc_package_library(
     name = "render",
     deps = [
+        ":render_camera",
         ":render_engine",
         ":render_engine_ospray",
         ":render_engine_vtk",
         ":render_engine_vtk_base",
         ":render_label",
         ":render_label_class",
+    ],
+)
+
+drake_cc_library(
+    name = "render_camera",
+    srcs = ["render_camera.cc"],
+    hdrs = ["render_camera.h"],
+    deps = [
+        "//common:essential",
+        "//math:geometric_transform",
+        "//systems/sensors:camera_info",
     ],
 )
 
@@ -33,12 +45,15 @@ drake_cc_library(
         "render_engine.h",
     ],
     deps = [
+        ":render_camera",
         ":render_label",
+        "//common:essential",
         "//geometry:geometry_ids",
         "//geometry:geometry_roles",
         "//geometry:shape_specification",
         "//geometry:utilities",
         "//math:geometric_transform",
+        "//systems/sensors:camera_info",
         "//systems/sensors:color_palette",
         "//systems/sensors:image",
     ],
@@ -166,6 +181,14 @@ filegroup(
     name = "test_models",
     testonly = 1,
     srcs = ["test/diag_gradient.png"],
+)
+
+drake_cc_googletest(
+    name = "render_camera_test",
+    deps = [
+        ":render_camera",
+        "//common/test_utilities",
+    ],
 )
 
 drake_cc_googletest(

--- a/geometry/render/render_camera.cc
+++ b/geometry/render/render_camera.cc
@@ -1,0 +1,46 @@
+#include "drake/geometry/render/render_camera.h"
+
+#include <utility>
+
+#include <fmt/format.h>
+
+namespace drake {
+namespace geometry {
+namespace render {
+
+ClippingRange::ClippingRange(double near, double far) : near_(near), far_(far) {
+  if (near <= 0 || far <= 0 || far <= near) {
+    throw std::runtime_error(fmt::format(
+        "The clipping range values must both be positive and far must be "
+        "greater than near. Instantiated with near = {} and far = {}",
+        near, far));
+  }
+}
+
+DepthRange::DepthRange(double min_in, double max_in)
+    : min_depth_(min_in), max_depth_(max_in) {
+  if (min_depth_ <= 0 || max_depth_ <= 0 || max_depth_ <= min_depth_) {
+    throw std::runtime_error(
+        fmt::format("The depth range values must both be positive and "
+                    "the maximum depth must be greater than the minimum depth. "
+                    "Instantiated with min = {} and max = {}",
+                    min_depth_, max_depth_));
+  }
+}
+
+DepthRenderCamera::DepthRenderCamera(RenderCameraCore core,
+                                     DepthRange depth_range)
+    : core_(std::move(core)), depth_range_(std::move(depth_range)) {
+  if (depth_range_.min_depth() < core_.clipping().near() ||
+      depth_range_.max_depth() > core_.clipping().far()) {
+    throw std::runtime_error(fmt::format(
+        "Depth camera's depth range extends beyond the clipping planes; near = "
+        "{}, far = {}, min. depth = {}, max. depth = {}",
+        core_.clipping().near(), core_.clipping().far(),
+        depth_range_.min_depth(), depth_range_.max_depth()));
+  }
+}
+
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/render_camera.h
+++ b/geometry/render/render_camera.h
@@ -1,0 +1,167 @@
+#pragma once
+
+#include <string>
+#include <utility>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/systems/sensors/camera_info.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+
+/** Defines the near and far clipping planes for frustum-based (e.g. OpenGL)
+ RenderEngine cameras.  */
+class ClippingRange {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ClippingRange);
+
+  /** Constructs the %ClippingRange.
+   @throws std::runtime_error if either value isn't positive, or if
+                              `near >= far`.  */
+  ClippingRange(double near, double far);
+
+  double near() const { return near_; }
+  double far() const { return far_; }
+
+ private:
+  double near_{};
+  double far_{};
+};
+
+/** Collection of core parameters for modeling a pinhole-model camera in a
+ RenderEngine. These parameters are applicable to both depth and color/label
+ renderings. Parameters specific to those output image types can be found
+ below.
+
+ While these parameters are generally applicable to all RenderEngine
+ implementations, this is not guaranteed to be true. For example, the clipping
+ range property only applies to frustum-based RenderEngine implementations.
+ I.e., it wouldn't apply to a ray-tracing based implementation.  */
+class RenderCameraCore {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(RenderCameraCore);
+
+  /** Fully-specified constructor. See the documentation on the member getter
+   methods for documentation of parameters.  */
+  RenderCameraCore(std::string renderer_name,
+                   systems::sensors::CameraInfo intrinsics,
+                   ClippingRange clipping, math::RigidTransformd X_BS)
+      : renderer_name_(std::move(renderer_name)),
+        intrinsics_(std::move(intrinsics)),
+        clipping_(std::move(clipping)),
+        X_BS_(std::move(X_BS)) {}
+
+  /** The name of the render engine this camera should be used with.  */
+  const std::string& renderer_name() const { return renderer_name_; }
+
+  /** The camera's intrinsic properties (e.g., focal length, sensor size, etc.)
+   See systems::sensors::CameraInfo for details.  */
+  const systems::sensors::CameraInfo& intrinsics() const { return intrinsics_; }
+
+  /** The near and far clipping planes for this camera. This property is ignored
+   by RenderEngine implementations that don't use a clipping frustum.  */
+  const ClippingRange& clipping() const { return clipping_; }
+
+  /** The pose of the sensor frame (S) in the camera's body frame (B). This is
+   the "imager" referred to in systems::sensors::CameraInfo's documentation.  */
+  const math::RigidTransformd& sensor_pose_in_camera_body() const {
+    return X_BS_;
+  }
+
+ private:
+  // See getter methods for documentation on these members.
+  std::string renderer_name_;
+  systems::sensors::CameraInfo intrinsics_;
+  ClippingRange clipping_;
+  math::RigidTransformd X_BS_;
+
+  // TODO(SeanCurtis-TRI): in the future, add a sub-class of GeometryProperties
+  //  so that arbitrary properties can be added to support arbitrary
+  //  RenderEngine implementations.
+};
+
+/** Collection of camera properties for cameras to be used with color/label
+ images.  */
+class ColorRenderCamera {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ColorRenderCamera);
+
+  /** Fully-specified constructor. See the documentation on the member getter
+   methods for documentation of parameters.  */
+  explicit ColorRenderCamera(RenderCameraCore core, bool show_window = false)
+      : core_(std::move(core)), show_window_(show_window) {}
+
+  /** This camera's core render properties.  */
+  const RenderCameraCore& core() const { return core_; }
+
+  /** If true, requests that the RenderEngine display the rendered image.  */
+  bool show_window() const { return show_window_; }
+
+ private:
+  // See getter methods for documentation on these members.
+  RenderCameraCore core_;
+  bool show_window_{false};
+};
+
+/** Defines a depth sensor's functional range. Only points that lie within the
+ range `[min_depth, max_depth]` will register meaningful values.
+
+ @note It's important to carefully coordinate depth range and clipping planes.
+ It might seem reasonable to use the depth range as clipping planes, but that
+ would be a mistake. Objects closer than the depth range's minimum value have
+ an occluding effect in reality. If the near clipping plane is set to the
+ minimum depth range value, those objects will be clipped away and won't
+ occlude as they should. In essence, the camera will see through them and return
+ incorrect values from beyond the missing geometry. The near clipping plane
+ should _always_ be closer than the minimum depth range. How much closer depends
+ on the scenario. Given the scenario, evaluate the closest possible distance
+ to the camera that geometry in the scene could possibly achieve; the clipping
+ plane should be slightly closer than that. When in doubt, some very small
+ value (e.g., 1 mm) is typically safe.  */
+class DepthRange {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DepthRange);
+
+  /** Constructs the %DepthRange.
+   @throws std::runtime_error if either value isn't positive, or if
+                              `min_in >= max_in`.  */
+  DepthRange(double min_in, double max_in);
+
+  double min_depth() const { return min_depth_; }
+  double max_depth() const { return max_depth_; }
+
+ private:
+  double min_depth_{};
+  double max_depth_{};
+};
+
+/** Collection of camera properties for cameras to be used with depth images.
+ */
+class DepthRenderCamera {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DepthRenderCamera);
+
+  /** Fully-specified constructor. See the documentation on the member getter
+   methods for documentation of parameters.
+
+   @throws std::runtime_error if the depth_range is not fully contained within
+                              the clipping range.  */
+  DepthRenderCamera(RenderCameraCore core, DepthRange depth_range);
+
+  /** This camera's core render properties.  */
+  const RenderCameraCore& core() const { return core_; }
+
+  /** The range of valid values for the depth camera.  */
+  const DepthRange& depth_range() const { return depth_range_; }
+
+ private:
+  // See getter methods for documentation on these members.
+  RenderCameraCore core_;
+  DepthRange depth_range_;
+};
+
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/test/render_camera_test.cc
+++ b/geometry/render/test/render_camera_test.cc
@@ -1,0 +1,146 @@
+#include "drake/geometry/render/render_camera.h"
+
+#include <stdexcept>
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace {
+
+using Eigen::Vector3d;
+using math::RigidTransformd;
+using systems::sensors::CameraInfo;
+
+GTEST_TEST(ClippingRangeTest, Constructor) {
+  {
+    // Case: Valid values.
+    const ClippingRange range{0.25, 10.75};
+    EXPECT_EQ(range.near(), 0.25);
+    EXPECT_EQ(range.far(), 10.75);
+  }
+
+  {
+    // Case: Bad values.
+    const char* error_message =
+        "The clipping range values must both be positive and far must be "
+        "greater than near. Instantiated with near = {} and far = {}";
+    DRAKE_EXPECT_THROWS_MESSAGE(ClippingRange(-0.1, 10), std::runtime_error,
+                                fmt::format(error_message, -0.1, 10.));
+    DRAKE_EXPECT_THROWS_MESSAGE(ClippingRange(0.1, -10), std::runtime_error,
+                                fmt::format(error_message, 0.1, -10.0));
+    DRAKE_EXPECT_THROWS_MESSAGE(ClippingRange(1.5, 1.0), std::runtime_error,
+                                fmt::format(error_message, 1.5, 1.0));
+  }
+}
+
+GTEST_TEST(RenderCameraCoreTest, Constructor) {
+  const std::string renderer_name = "some_renderer";
+  const CameraInfo intrinsics{320, 240, M_PI};
+  const ClippingRange clipping{0.25, 5.};
+  const RigidTransformd X_BS{Vector3d{1.5, 2.5, 3.5}};
+  const RenderCameraCore core{renderer_name, intrinsics, clipping, X_BS};
+
+  EXPECT_EQ(core.renderer_name(), renderer_name);
+  EXPECT_TRUE(CompareMatrices(core.intrinsics().intrinsic_matrix(),
+                              intrinsics.intrinsic_matrix()));
+  EXPECT_EQ(core.clipping().near(), clipping.near());
+  EXPECT_EQ(core.clipping().far(), clipping.far());
+  EXPECT_TRUE(CompareMatrices(core.sensor_pose_in_camera_body().GetAsMatrix4(),
+                              X_BS.GetAsMatrix4()));
+}
+
+GTEST_TEST(ColorRenderCameraTest, Constructor) {
+  const std::string renderer_name = "some_renderer";
+  const CameraInfo intrinsics{320, 240, M_PI};
+  const ClippingRange clipping{0.25, 5.};
+  const RigidTransformd X_BS{Vector3d{1.5, 2.5, 3.5}};
+  const RenderCameraCore core{renderer_name, intrinsics, clipping, X_BS};
+  const bool show_window = true;
+
+  const ColorRenderCamera camera(core, show_window);
+
+  EXPECT_EQ(camera.core().renderer_name(), renderer_name);
+  EXPECT_TRUE(CompareMatrices(camera.core().intrinsics().intrinsic_matrix(),
+                              intrinsics.intrinsic_matrix()));
+  EXPECT_EQ(camera.core().clipping().near(), clipping.near());
+  EXPECT_EQ(camera.core().clipping().far(), clipping.far());
+  EXPECT_TRUE(
+      CompareMatrices(camera.core().sensor_pose_in_camera_body().GetAsMatrix4(),
+                      X_BS.GetAsMatrix4()));
+  EXPECT_EQ(camera.show_window(), show_window);
+}
+
+GTEST_TEST(DepthRangeTest, Constructor) {
+  {
+    // Case: Valid values.
+    const DepthRange range{0.25, 10.75};
+    EXPECT_EQ(range.min_depth(), 0.25);
+    EXPECT_EQ(range.max_depth(), 10.75);
+  }
+
+  {
+    // Case: Bad values.
+    const char* error_message =
+        "The depth range values must both be positive and the maximum depth "
+        "must be greater than the minimum depth. Instantiated with min = {} "
+        "and max = {}";
+    DRAKE_EXPECT_THROWS_MESSAGE(DepthRange(-0.1, 10), std::runtime_error,
+                                fmt::format(error_message, -0.1, 10.));
+    DRAKE_EXPECT_THROWS_MESSAGE(DepthRange(0.1, -10), std::runtime_error,
+                                fmt::format(error_message, 0.1, -10.0));
+    DRAKE_EXPECT_THROWS_MESSAGE(DepthRange(1.5, 1.0), std::runtime_error,
+                                fmt::format(error_message, 1.5, 1.0));
+  }
+}
+
+GTEST_TEST(DepthRenderCameraTest, Constructor) {
+  const std::string renderer_name = "some_renderer";
+  const CameraInfo intrinsics{320, 240, M_PI};
+  const ClippingRange clipping{0.25, 5.};
+  const RigidTransformd X_BS{Vector3d{1.5, 2.5, 3.5}};
+  const RenderCameraCore core{renderer_name, intrinsics, clipping, X_BS};
+  const DepthRange range{0.5, 4.5};
+
+  const DepthRenderCamera camera(core, range);
+
+  EXPECT_EQ(camera.core().renderer_name(), renderer_name);
+  EXPECT_TRUE(CompareMatrices(camera.core().intrinsics().intrinsic_matrix(),
+                              intrinsics.intrinsic_matrix()));
+  EXPECT_EQ(camera.core().clipping().near(), clipping.near());
+  EXPECT_EQ(camera.core().clipping().far(), clipping.far());
+  EXPECT_TRUE(
+      CompareMatrices(camera.core().sensor_pose_in_camera_body().GetAsMatrix4(),
+                      X_BS.GetAsMatrix4()));
+  EXPECT_EQ(camera.depth_range().min_depth(), range.min_depth());
+  EXPECT_EQ(camera.depth_range().max_depth(), range.max_depth());
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      DepthRenderCamera(core,
+                        DepthRange(clipping.near() - 0.1, clipping.far())),
+      std::runtime_error,
+      "Depth camera's depth range extends beyond the clipping planes; near = "
+      ".+, far = .+, min. depth = .+, max. depth = .+");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      DepthRenderCamera(core,
+                        DepthRange(clipping.near(), clipping.far() + 0.1)),
+      std::runtime_error,
+      "Depth camera's depth range extends beyond the clipping planes; near = "
+      ".+, far = .+, min. depth = .+, max. depth = .+");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      DepthRenderCamera(
+          core, DepthRange(clipping.near() - 0.1, clipping.far() + 0.1)),
+      std::runtime_error,
+      "Depth camera's depth range extends beyond the clipping planes; near = "
+      ".+, far = .+, min. depth = .+, max. depth = .+");
+}
+
+}  // namespace
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/systems/sensors/camera_info.h
+++ b/systems/sensors/camera_info.h
@@ -10,8 +10,9 @@ namespace sensors {
 
 // TODO(kunimatsu-tri) Add camera distortion parameters and other parameters as
 // needed.
+// TODO(SeanCurtis-TRI) Deprecate the name CameraInfo in favor of Intrinsics.
 /**
- Simple struct for characterizing the Drake camera model. The camera model is
+ Simple class for characterizing the Drake camera model. The camera model is
  based on the
  [pinhole _model_](http://docs.opencv.org/2.4/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html)
  , which is related to but distinct from an actual
@@ -61,8 +62,8 @@ namespace sensors {
  - (c_x, c_y) defines the principal point.
  - (f_x, f_y) defines the model focal length.
 
- In other words, for point Q in the world frame, its texture coordinates
- `(u_Q, v_Q)` are calculated as:
+ In other words, for point Q in the world frame, its projected position in the
+ 2D image `(u_Q, v_Q)` is calculated as:
 
       │ u_Q │
      s│ v_Q │ = K ⋅ X_CW ⋅ p_WQ
@@ -125,11 +126,15 @@ namespace sensors {
  When looking at the resulting image and reasoning about the camera that
  produced it, one can say that Cz points into the image, Cx is parallel with the
  image rows, pointing to the right, and Cy is parallel with the image columns,
- pointing down leading to language such as: "X-right", "Y-down", and "Z-forward".
+ pointing down leading to language such as: "X-right", "Y-down", and
+ "Z-forward".
 */
 class CameraInfo final {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CameraInfo)
+
+  // TODO(SeanCurtis-TRI): Add constructor from Matrix3<double> -- an intrinsic
+  //  matrix.
 
   /**
    Constructor that directly sets the image size, principal point, and focal
@@ -174,6 +179,12 @@ class CameraInfo final {
 
   /** Returns the focal length y in pixels. */
   double focal_y() const { return intrinsic_matrix_(1, 1); }
+
+  /** Returns the field of view in the x-direction (in radians).  */
+  double fov_x() const { return 2 * std::atan(width_ / (2 * focal_x())); }
+
+  /** Returns the field of view in the y-direction (in radians).  */
+  double fov_y() const { return 2 * std::atan(height_ / (2 * focal_y())); }
 
   // TODO(eric.cousineau): Deprecate "center_{x,y}" and use
   // "principal_point_{x,y}" or "pp{x,y}".

--- a/systems/sensors/rgbd_sensor.cc
+++ b/systems/sensors/rgbd_sensor.cc
@@ -24,62 +24,131 @@ namespace sensors {
 using Eigen::Translation3d;
 using geometry::FrameId;
 using geometry::QueryObject;
-using geometry::render::CameraProperties;
-using geometry::render::DepthCameraProperties;
 using geometry::SceneGraph;
+using geometry::render::CameraProperties;
+using geometry::render::ColorRenderCamera;
+using geometry::render::DepthCameraProperties;
+using geometry::render::DepthRange;
+using geometry::render::DepthRenderCamera;
 using math::RigidTransformd;
+using std::make_pair;
 using std::move;
+using std::pair;
 
-RgbdSensor::RgbdSensor(FrameId parent_id,
-                       const RigidTransformd& X_PB,
+namespace {
+
+// Some utilities to create the full camera specification from a set of "simple"
+// camera properties.
+
+ColorRenderCamera make_color_render_camera(const CameraProperties& props_in,
+                                           bool show_window,
+                                           const RigidTransformd& X_BC) {
+  // These are the legacy clipping plane values in RenderEngineVtk.
+  const double kNear{0.01};
+  const double kFar{10.0};
+  return ColorRenderCamera{{props_in.renderer_name,
+                            {props_in.width, props_in.height, props_in.fov_y},
+                            {kNear, kFar},
+                            X_BC},
+                           show_window};
+}
+
+DepthRenderCamera make_depth_camera_model(const DepthCameraProperties& props_in,
+                                          const RigidTransformd& X_BC) {
+  // These are the legacy clipping plane values in RenderEngineVtk.
+  const double kNear{0.01};
+  const double kFar{10.0};
+  return DepthRenderCamera{{props_in.renderer_name,
+                            {props_in.width, props_in.height, props_in.fov_y},
+                            {kNear, kFar},
+                            X_BC},
+                           {props_in.z_near, props_in.z_far}};
+}
+
+}  // namespace
+
+RgbdSensor::RgbdSensor(FrameId parent_id, const RigidTransformd& X_PB,
                        const CameraProperties& color_properties,
                        const DepthCameraProperties& depth_properties,
-                       const CameraPoses& camera_poses,
-                       bool show_window)
+                       const CameraPoses& camera_poses, bool show_window)
+    : RgbdSensor(parent_id, X_PB,
+                 make_color_render_camera(color_properties, show_window,
+                                          camera_poses.X_BC),
+                 make_depth_camera_model(depth_properties, camera_poses.X_BD)) {
+}
+
+RgbdSensor::RgbdSensor(geometry::FrameId parent_id, const RigidTransformd& X_PB,
+                       const DepthCameraProperties& properties,
+                       const CameraPoses& camera_poses, bool show_window)
+    : RgbdSensor(
+          parent_id, X_PB,
+          make_color_render_camera(properties, show_window, camera_poses.X_BC),
+          make_depth_camera_model(properties, camera_poses.X_BD)) {}
+
+RgbdSensor::RgbdSensor(FrameId parent_id, const RigidTransformd& X_PB,
+                       ColorRenderCamera color_camera,
+                       DepthRenderCamera depth_camera)
     : parent_frame_id_(parent_id),
-      show_window_(show_window),
-      color_camera_info_(color_properties.width, color_properties.height,
-                         color_properties.fov_y),
-      depth_camera_info_(depth_properties.width, depth_properties.height,
-                         depth_properties.fov_y),
-      color_properties_(color_properties),
-      depth_properties_(depth_properties),
-      X_PB_(X_PB),
-      X_BC_(camera_poses.X_BC),
-      X_BD_(camera_poses.X_BD) {
+      color_camera_(move(color_camera)),
+      depth_camera_(move(depth_camera)),
+      X_PB_(X_PB) {
+  // TODO(SeanCurtis-TRI): Remove this test and warning when the rendering
+  //  infrastructure handles arbitrary camera intrinsics.
+  const CameraInfo& color_intrinsics = color_camera_.core().intrinsics();
+  const CameraInfo& depth_intrinsics = depth_camera_.core().intrinsics();
+  if (color_intrinsics.focal_x() != color_intrinsics.focal_y() ||
+      color_intrinsics.center_x() != color_intrinsics.width() / 2.0 + 0.5 ||
+      color_intrinsics.center_y() != color_intrinsics.height() / 2.0 + 0.5 ||
+      depth_intrinsics.focal_x() != depth_intrinsics.focal_y() ||
+      depth_intrinsics.center_x() != depth_intrinsics.width() / 2.0 + 0.5 ||
+      depth_intrinsics.center_y() != depth_intrinsics.height() / 2.0 + 0.5) {
+    logging::Warn(
+        "Constructing an instance of RgbdSensor with a \"complex\" camera "
+        "specification. For now, the camera must be radially symmetric and "
+        "centered on the image. Cameras provided:\n  Color - focal lengths "
+        "({}, {}), principal point ({}, {})\n  Depth - focal lengths ({}, {}), "
+        "principal point ({}, {})",
+        color_intrinsics.focal_x(), color_intrinsics.focal_y(),
+        color_intrinsics.center_x(), color_intrinsics.center_y(),
+        depth_intrinsics.focal_x(), depth_intrinsics.focal_y(),
+        depth_intrinsics.center_x(), depth_intrinsics.center_y());
+  }
+
   query_object_input_port_ = &this->DeclareAbstractInputPort(
       "geometry_query", Value<geometry::QueryObject<double>>{});
 
-  ImageRgba8U color_image(color_camera_info_.width(),
-                          color_camera_info_.height());
+  ImageRgba8U color_image(color_intrinsics.width(), color_intrinsics.height());
   color_image_port_ = &this->DeclareAbstractOutputPort(
       "color_image", color_image, &RgbdSensor::CalcColorImage);
 
-  ImageDepth32F depth32(depth_camera_info_.width(),
-                        depth_camera_info_.height());
+  ImageDepth32F depth32(depth_intrinsics.width(), depth_intrinsics.height());
   depth_image_32F_port_ = &this->DeclareAbstractOutputPort(
       "depth_image_32f", depth32, &RgbdSensor::CalcDepthImage32F);
 
-  ImageDepth16U depth16(depth_camera_info_.width(),
-                        depth_camera_info_.height());
+  ImageDepth16U depth16(depth_intrinsics.width(), depth_intrinsics.height());
   depth_image_16U_port_ = &this->DeclareAbstractOutputPort(
       "depth_image_16u", depth16, &RgbdSensor::CalcDepthImage16U);
 
-  ImageLabel16I label_image(color_camera_info_.width(),
-                            color_camera_info_.height());
+  ImageLabel16I label_image(color_intrinsics.width(),
+                            color_intrinsics.height());
   label_image_port_ = &this->DeclareAbstractOutputPort(
       "label_image", label_image, &RgbdSensor::CalcLabelImage);
 
   X_WB_pose_port_ = &this->DeclareVectorOutputPort(
       "X_WB", rendering::PoseVector<double>(), &RgbdSensor::CalcX_WB);
 
-  const float kMaxValidDepth16UInMM =
+  // The depth_16U represents depth in *millimeters*. With 16 bits there is
+  // an absolute limit on the farthest distance it can register. This tests to
+  // see if the user has specified a maximum depth value that exceeds that
+  // value.
+  const float kMaxValidDepth16UInM =
       (std::numeric_limits<uint16_t>::max() - 1) / 1000.;
-  if (depth_properties.z_far > kMaxValidDepth16UInMM) {
+  const double max_depth = depth_camera_.depth_range().max_depth();
+  if (max_depth > kMaxValidDepth16UInM) {
     drake::log()->warn(
-        "Specified max depth is {} > max valid depth for 16 bits {}. "
+        "Specified max depth is {} m > max valid depth for 16 bits {} m. "
         "depth_image_16u might not be able to capture the full depth range.",
-        depth_properties.z_far, kMaxValidDepth16UInMM);
+        max_depth, kMaxValidDepth16UInM);
   }
 }
 
@@ -110,15 +179,29 @@ const OutputPort<double>& RgbdSensor::X_WB_output_port() const {
 void RgbdSensor::CalcColorImage(const Context<double>& context,
                                 ImageRgba8U* color_image) const {
   const QueryObject<double>& query_object = get_query_object(context);
-  query_object.RenderColorImage(color_properties_, parent_frame_id_,
-                                X_PB_ * X_BC_, show_window_, color_image);
+  const CameraInfo& intrinsics = color_camera_.core().intrinsics();
+  CameraProperties simple_camera{intrinsics.width(), intrinsics.height(),
+                                 intrinsics.fov_y(),
+                                 color_camera_.core().renderer_name()};
+  query_object.RenderColorImage(
+      simple_camera, parent_frame_id_,
+      X_PB_ * color_camera_.core().sensor_pose_in_camera_body(),
+      color_camera_.show_window(), color_image);
 }
 
 void RgbdSensor::CalcDepthImage32F(const Context<double>& context,
                                    ImageDepth32F* depth_image) const {
   const QueryObject<double>& query_object = get_query_object(context);
-  query_object.RenderDepthImage(depth_properties_, parent_frame_id_,
-                                X_PB_ * X_BD_, depth_image);
+  const CameraInfo& intrinsics = depth_camera_.core().intrinsics();
+  DepthCameraProperties simple_camera{intrinsics.width(),
+                                      intrinsics.height(),
+                                      intrinsics.fov_y(),
+                                      depth_camera_.core().renderer_name(),
+                                      depth_camera_.depth_range().min_depth(),
+                                      depth_camera_.depth_range().max_depth()};
+  query_object.RenderDepthImage(
+      simple_camera, parent_frame_id_,
+      X_PB_ * depth_camera_.core().sensor_pose_in_camera_body(), depth_image);
 }
 
 void RgbdSensor::CalcDepthImage16U(const Context<double>& context,
@@ -131,13 +214,18 @@ void RgbdSensor::CalcDepthImage16U(const Context<double>& context,
 void RgbdSensor::CalcLabelImage(const Context<double>& context,
                                 ImageLabel16I* label_image) const {
   const QueryObject<double>& query_object = get_query_object(context);
-  query_object.RenderLabelImage(color_properties_, parent_frame_id_,
-                                X_PB_ * X_BC_, show_window_, label_image);
+  const CameraInfo& intrinsics = color_camera_.core().intrinsics();
+  CameraProperties simple_camera{intrinsics.width(), intrinsics.height(),
+                                 intrinsics.fov_y(),
+                                 color_camera_.core().renderer_name()};
+  query_object.RenderLabelImage(
+      simple_camera, parent_frame_id_,
+      X_PB_ * color_camera_.core().sensor_pose_in_camera_body(),
+      color_camera_.show_window(), label_image);
 }
 
-void RgbdSensor::CalcX_WB(
-    const Context<double>& context,
-    rendering::PoseVector<double>* pose_vector) const {
+void RgbdSensor::CalcX_WB(const Context<double>& context,
+                          rendering::PoseVector<double>* pose_vector) const {
   // Calculates X_WB.
   RigidTransformd X_WB;
   if (parent_frame_id_ == SceneGraph<double>::world_frame_id()) {
@@ -172,8 +260,7 @@ void RgbdSensor::ConvertDepth32FTo16U(const ImageDepth32F& d32,
 // friend to GeometryState.
 const geometry::QueryObject<double>& RgbdSensor::get_query_object(
     const Context<double>& context) const {
-  return query_object_input_port().
-      Eval<geometry::QueryObject<double>>(context);
+  return query_object_input_port().Eval<geometry::QueryObject<double>>(context);
 }
 
 RgbdSensorDiscrete::RgbdSensorDiscrete(std::unique_ptr<RgbdSensor> camera,
@@ -183,7 +270,7 @@ RgbdSensorDiscrete::RgbdSensorDiscrete(std::unique_ptr<RgbdSensor> camera,
   const auto& depth_camera_info = camera->depth_camera_info();
 
   DiagramBuilder<double> builder;
-  builder.AddSystem(std::move(camera));
+  builder.AddSystem(move(camera));
   query_object_port_ =
       builder.ExportInput(camera_->query_object_input_port(), "geometry_query");
 
@@ -230,8 +317,7 @@ RgbdSensorDiscrete::RgbdSensorDiscrete(std::unique_ptr<RgbdSensor> camera,
   }
 
   // No need to place a ZOH on pose output.
-  X_WB_output_port_ =
-      builder.ExportOutput(camera_->X_WB_output_port(), "X_WB");
+  X_WB_output_port_ = builder.ExportOutput(camera_->X_WB_output_port(), "X_WB");
 
   builder.BuildInto(this);
 }

--- a/systems/sensors/rgbd_sensor.h
+++ b/systems/sensors/rgbd_sensor.h
@@ -12,6 +12,7 @@
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/query_object.h"
 #include "drake/geometry/render/camera_properties.h"
+#include "drake/geometry/render/render_camera.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/math/roll_pitch_yaw.h"
 #include "drake/systems/framework/diagram.h"
@@ -104,10 +105,13 @@ class RgbdSensor final : public LeafSystem<double> {
     math::RigidTransformd X_BD;
   };
 
+  // TODO(SeanCurtis-TRI): Deprecate the CameraProperties constructors.
   /** Constructs an %RgbdSensor whose frame `B` is rigidly affixed to the frame
-   P, indicated by `parent_id`, and with the given camera properties. The camera
-   will move as frame P moves. For a stationary camera, use the frame id from
-   SceneGraph::world_frame_id().
+   P, indicated by `parent_id`, and with the given "simple" camera properties.
+   The camera is "simple" in the sense that it models a camera with a radially
+   symmetric lens and a principal point that projects onto the center of the
+   image. The camera will move as frame P moves. For a stationary camera, use
+   the frame id from SceneGraph::world_frame_id().
 
    @param parent_id      The identifier of a parent frame `P` in
                          geometry::SceneGraph to which this camera is rigidly
@@ -122,6 +126,7 @@ class RgbdSensor final : public LeafSystem<double> {
                          three frames will be aligned and coincident.
    @param show_window    A flag for showing a visible window. If this is false,
                          off-screen rendering is executed. The default is false.
+   @pydrake_mkdoc_identifier{legacy_individual_intrinsics}
    */
   RgbdSensor(geometry::FrameId parent_id,
              const math::RigidTransformd& X_PB,
@@ -133,34 +138,57 @@ class RgbdSensor final : public LeafSystem<double> {
   /** Constructs an %RgbdSensor in the same way as the above overload, but
    using the `CameraProperties` portion of `properties` for color (and label)
    properties, and all of `properties` for depth properties.
+   @pydrake_mkdoc_identifier{legacy_combined_intrinsics}
    */
-  RgbdSensor(geometry::FrameId parent_id,
-             const math::RigidTransformd& X_PB,
+  RgbdSensor(geometry::FrameId parent_id, const math::RigidTransformd& X_PB,
              const geometry::render::DepthCameraProperties& properties,
-             const CameraPoses& camera_poses = {},
-             bool show_window = false)
-    : RgbdSensor(
-          parent_id, X_PB, properties, properties, camera_poses, show_window)
-      {}
+             const CameraPoses& camera_poses = {}, bool show_window = false);
+
+  /** Constructs an %RgbdSensor with a fully specified render camera model for
+   both color/label and depth cameras.
+
+   @warning Currently, only "simple" cameras are supported. If the camera
+            intrinsics is not compatible with a simple camera model, a warning
+            will be printed and the camera will be "simplified".
+   @pydrake_mkdoc_identifier{individual_intrinsics}  */
+  RgbdSensor(geometry::FrameId parent_id, const math::RigidTransformd& X_PB,
+             geometry::render::ColorRenderCamera color_camera,
+             geometry::render::DepthRenderCamera depth_camera);
 
   ~RgbdSensor() = default;
 
   // TODO(eric.cousineau): Expose which renderer color / depth uses?
 
-  /** Returns the color sensor's info.  */
-  const CameraInfo& color_camera_info() const { return color_camera_info_; }
+  // TODO(SeanCurtis-TRI): Deprecate this in favor of the color render camera.
+  /** Returns the intrinsics properties of the color camera model.  */
+  const CameraInfo& color_camera_info() const {
+    return color_camera_.core().intrinsics();
+  }
 
-  /** Returns the depth sensor's info.  */
-  const CameraInfo& depth_camera_info() const { return depth_camera_info_; }
+  // TODO(SeanCurtis-TRI): Deprecate this in favor of the depth render camera.
+  /** Returns the intrinsics properties of the depth camera model.  */
+  const CameraInfo& depth_camera_info() const {
+    return depth_camera_.core().intrinsics();
+  }
+
+  /** Returns the render camera for color/label renderings.  */
+  const geometry::render::ColorRenderCamera& color_render_camera() const {
+    return color_camera_;
+  }
+
+  /** Returns the render camera for depth renderings.  */
+  const geometry::render::DepthRenderCamera& depth_render_camera() const {
+    return depth_camera_;
+  }
 
   /** Returns `X_BC`.  */
   const math::RigidTransformd& X_BC() const {
-    return X_BC_;
+    return color_camera_.core().sensor_pose_in_camera_body();
   }
 
   /** Returns `X_BD`.  */
   const math::RigidTransformd& X_BD() const {
-    return X_BD_;
+    return depth_camera_.core().sensor_pose_in_camera_body();
   }
 
   /** Returns the id of the frame to which the base is affixed.  */
@@ -224,17 +252,11 @@ class RgbdSensor final : public LeafSystem<double> {
   // The identifier for the parent frame `P`.
   const geometry::FrameId parent_frame_id_;
 
-  // If true, a window will be shown for the camera.
-  const bool show_window_;
-  const CameraInfo color_camera_info_;
-  const CameraInfo depth_camera_info_;
-  const geometry::render::CameraProperties color_properties_;
-  const geometry::render::DepthCameraProperties depth_properties_;
+  // The camera specifications for color/label and depth.
+  const geometry::render::ColorRenderCamera color_camera_;
+  const geometry::render::DepthRenderCamera depth_camera_;
   // The position of the camera's B frame relative to its parent frame P.
   const math::RigidTransformd X_PB_;
-  // Camera poses.
-  const math::RigidTransformd X_BC_;
-  const math::RigidTransformd X_BD_;
 };
 
 /**

--- a/systems/sensors/test/camera_info_test.cc
+++ b/systems/sensors/test/camera_info_test.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/sensors/camera_info.h"
 
+#include <limits>
+
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 
@@ -20,7 +22,6 @@ const double kCx = kWidth * 0.5 - 0.5;
 const double kCy = kHeight * 0.5 - 0.5;
 const double kVerticalFov = 0.78539816339744828;  // 45.0 degrees.
 
-
 void Verify(const Eigen::Matrix3d& expected, const CameraInfo& dut) {
   EXPECT_EQ(kWidth, dut.width());
   EXPECT_EQ(kHeight, dut.height());
@@ -28,8 +29,7 @@ void Verify(const Eigen::Matrix3d& expected, const CameraInfo& dut) {
   EXPECT_NEAR(expected(1, 1), dut.focal_y(), kTolerance);
   EXPECT_NEAR(expected(0, 2), dut.center_x(), kTolerance);
   EXPECT_NEAR(expected(1, 2), dut.center_y(), kTolerance);
-  EXPECT_TRUE(CompareMatrices(expected, dut.intrinsic_matrix(),
-                              kTolerance));
+  EXPECT_TRUE(CompareMatrices(expected, dut.intrinsic_matrix(), kTolerance));
 }
 
 GTEST_TEST(TestCameraInfo, ConstructionTest) {
@@ -47,6 +47,31 @@ GTEST_TEST(TestCameraInfo, ConstructionWithFovTest) {
 
   CameraInfo dut(kWidth, kHeight, kVerticalFov);
   Verify(expected, dut);
+}
+
+// Confirms that the reported field of view (in radians) is the same as is
+// given.
+GTEST_TEST(TestCameraInfo, FieldOfView) {
+  // Pick some arbitrary angle that isn't a "nice" angle.
+  const double fov_y = M_PI / 7;
+
+  {
+    // Square camera: fields of view are equal in x- and y-directions.
+    CameraInfo camera(100, 100, fov_y);
+    EXPECT_EQ(camera.fov_y(), fov_y);
+    EXPECT_EQ(camera.fov_x(), fov_y);
+  }
+
+  {
+    // Rectangular camera: has an identical *focal lengths* in the x- and y-
+    // directions. But the rectangular image leads to different fields of view.
+    const int w = 100;
+    const int h = 200;
+    CameraInfo camera{w, h, fov_y};
+    const double fov_x = 2 * atan(w * tan(fov_y / 2) / h);
+    EXPECT_EQ(camera.fov_y(), fov_y);
+    EXPECT_NEAR(camera.fov_x(), fov_x, std::numeric_limits<double>::epsilon());
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
This is the first of a sequence of PRs to allow full intrinsics specification of cameras for rendering.

This represents a top-down approach. We introduce the public API components of specifying the camera. In this PR, if "complex" intrinsics are provided, a warning will be spewed and the camera
will be "simplified". Subsequent PRs will fill in the required rendering infrastsructure.

 - CameraInfo used for full intrinsics (DepthCamera extended from it).
 - RenderCameraProperties used to carry RenderEngine-specific, per-camera properties (e.g., clipping planes).
 - RgbdSensor given new constructor for handling fully-specified camera model.

relates #11880

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13557)
<!-- Reviewable:end -->
