### PR TITLE
Declare MultibodyPlant's SceneGraph ports in constructor.

### DIFF
--- a/bindings/pydrake/examples/multibody/pendulum_lqr_monte_carlo_analysis.py
+++ b/bindings/pydrake/examples/multibody/pendulum_lqr_monte_carlo_analysis.py
@@ -95,7 +95,7 @@ def main():
                     torque_limiter.get_input_port(0))
     builder.Connect(torque_limiter.get_output_port(0),
                     pendulum.get_actuation_input_port())
-    builder.Connect(pendulum.get_output_port(0),
+    builder.Connect(pendulum.get_state_output_port(),
                     controller.get_input_port(0))
     diagram = builder.Build()
 

--- a/examples/acrobot/test/multibody_dynamics_test.cc
+++ b/examples/acrobot/test/multibody_dynamics_test.cc
@@ -59,10 +59,11 @@ GTEST_TEST(MultibodyDynamicsTest, AllTests) {
       mbp.CalcOutput(*context_mbp, y_mbp.get());
       p.CalcOutput(*context_p, y_p.get());
 
-      EXPECT_TRUE(CompareMatrices(y_mbp->get_vector_data(0)->CopyToVector(),
-                                  y_p->get_vector_data(0)->CopyToVector(),
-                                  1e-8,
-                                  MatrixCompareType::absolute));
+      EXPECT_TRUE(CompareMatrices(
+          y_mbp->get_vector_data(mbp.get_state_output_port().get_index())
+              ->CopyToVector(),
+          y_p->get_vector_data(0)->CopyToVector(), 1e-8,
+          MatrixCompareType::absolute));
     }
   }
 }


### PR DESCRIPTION
Addresses #13530.

- Declares the SceneGraph ports for MultibodyPlant in the constructor so that they have consistent ordering with the ScalarConverting constructor.
- Removes the requirement that `this` MBP has been registered with a SceneGraph to access SG input/output ports
- Adds tests for port indexing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13558)
<!-- Reviewable:end -->
