### PR TITLE
examples: Fix timeout in manipulation_station_test.

### DIFF
--- a/examples/manipulation_station/BUILD.bazel
+++ b/examples/manipulation_station/BUILD.bazel
@@ -120,6 +120,9 @@ drake_cc_binary(
 
 drake_cc_googletest(
     name = "manipulation_station_test",
+    # Frequently exceeds short timeout in
+    # linux-bionic-clang-bazel-nightly-coverage
+    timeout = "moderate",
     tags = vtk_test_tags(),
     deps = [
         ":manipulation_station",

--- a/examples/manipulation_station/BUILD.bazel
+++ b/examples/manipulation_station/BUILD.bazel
@@ -120,9 +120,6 @@ drake_cc_binary(
 
 drake_cc_googletest(
     name = "manipulation_station_test",
-    # Frequently exceeds short timeout in
-    # linux-bionic-clang-bazel-nightly-coverage
-    timeout = "moderate",
     tags = vtk_test_tags(),
     deps = [
         ":manipulation_station",


### PR DESCRIPTION
Fix test timeout of  //examples/manipulation_station:manipulation_station_test on linux-bionic-clang-bazel-nightly-coverage.

Nightly Production has https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-bionic-clang-bazel-nightly-coverage/ failed four times in the past seven days (June 9 - 15, 2020) due to timeout in the coverage test of manipulation_station_test.

Added `timeout = "moderate"` in BUILD.bazel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13563)
<!-- Reviewable:end -->
