### PR TITLE
Copy {Rigid/Soft}Mesh without rebuilding BoundingVolumeHierarchy.

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -188,6 +188,7 @@ drake_cc_library(
         ":surface_mesh",
         ":tessellation_strategy",
         ":volume_mesh",
+        "//common:copyable_unique_ptr",
         "//common:essential",
         "//geometry:geometry_ids",
         "//geometry:geometry_roles",

--- a/geometry/proximity/bounding_volume_hierarchy.cc
+++ b/geometry/proximity/bounding_volume_hierarchy.cc
@@ -291,6 +291,26 @@ Vector3d BoundingVolumeHierarchy<MeshType>::ComputeCentroid(
   return centroid;
 }
 
+template <class MeshType>
+bool BoundingVolumeHierarchy<MeshType>::EqualTrees(const BvNode<MeshType>& a,
+                                                   const BvNode<MeshType>& b) {
+  if (&a == &b) return true;
+
+  if (!a.aabb().Equal(b.aabb())) return false;
+
+  if (a.is_leaf()) {
+    if (!b.is_leaf()) {
+      return false;
+    }
+    return a.element_index() == b.element_index();
+  } else {
+    if (b.is_leaf()) {
+      return false;
+    }
+    return EqualTrees(a.left(), b.left()) && EqualTrees(a.right(), b.right());
+  }
+}
+
 }  // namespace internal
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/proximity/bounding_volume_hierarchy.h
+++ b/geometry/proximity/bounding_volume_hierarchy.h
@@ -124,6 +124,15 @@ class Aabb {
   static bool HasOverlap(const Aabb& bv, const HalfSpace& hs_C,
                          const math::RigidTransformd& X_CH);
 
+  /** Compares the values of the two Aabb instances for exact equality down to
+   the last bit. Assumes that the quantities are measured and expressed in
+   the same frame. */
+  bool Equal(const Aabb& other) const {
+    if (this == &other) return true;
+    return center_ == other.center_ &&
+           half_width_ == other.half_width_;
+  }
+
  private:
   friend class AabbTester;
 
@@ -383,6 +392,14 @@ class BoundingVolumeHierarchy {
     return result;
   }
 
+  /** Compares the two BoundingVolumeHierarchy instances for exact equality down
+   to the last bit. Assumes that the quantities are measured and expressed in
+   the same frame. */
+  bool Equal(const BoundingVolumeHierarchy<MeshType>& other) const {
+    if (this == &other) return true;
+    return EqualTrees(this->root_node(), other.root_node());
+  }
+
  private:
   // Convenience class for testing.
   friend class BVHTester;
@@ -403,6 +420,11 @@ class BoundingVolumeHierarchy {
   // and rename to CalcElementCentroid(ElementIndex).
   static Vector3<double> ComputeCentroid(const MeshType& mesh,
                                          IndexType i);
+
+  // Tests that the two hierarchy trees, rooted at nodes a and b, are equal in
+  // the sense that they have identical structure and equal bounding volumes
+  // (see Aabb::Equal()).
+  static bool EqualTrees(const BvNode<MeshType>& a, const BvNode<MeshType>& b);
 
   static constexpr int kElementVertexCount = MeshType::kDim + 1;
 

--- a/geometry/proximity/hydroelastic_internal.cc
+++ b/geometry/proximity/hydroelastic_internal.cc
@@ -24,28 +24,14 @@ namespace hydroelastic {
 using std::make_unique;
 using std::move;
 
-SoftGeometry& SoftGeometry::operator=(const SoftGeometry& g) {
-  if (this == &g) return *this;
+SoftMesh& SoftMesh::operator=(const SoftMesh& s) {
+  if (this == &s) return *this;
 
-  if (g.is_half_space()) {
-    geometry_ = SoftHalfSpace{g.pressure_scale()};
-  } else {
-    auto mesh = make_unique<VolumeMesh<double>>(g.mesh());
-    // We can't simply copy the mesh field; the copy must contain a pointer to
-    // the new mesh. So, we use CloneAndSetMesh() instead.
-    auto pressure = g.pressure_field().CloneAndSetMesh(mesh.get());
-    geometry_ = SoftMesh{move(mesh), move(pressure)};
-  }
-  return *this;
-}
-
-RigidGeometry& RigidGeometry::operator=(const RigidGeometry& g) {
-  if (this == &g) return *this;
-
-  geometry_ = std::nullopt;
-  if (!g.is_half_space()) {
-    geometry_ = RigidMesh(make_unique<SurfaceMesh<double>>(g.mesh()));
-  }
+  mesh_ = make_unique<VolumeMesh<double>>(s.mesh());
+  // We can't simply copy the mesh field; the copy must contain a pointer to
+  // the new mesh. So, we use CloneAndSetMesh() instead.
+  pressure_ = s.pressure().CloneAndSetMesh(mesh_.get());
+  bvh_ = make_unique<BoundingVolumeHierarchy<VolumeMesh<double>>>(s.bvh());
 
   return *this;
 }


### PR DESCRIPTION
When copy RigidMesh or SoftMesh, we will copy their BoundingVolumeHierarchy too. Right now we rebuild BoundingVolumeHierarchy.

Details:
- Add {copy, move}{constructor, assignment operator} of RigidMesh and SoftMesh.
  They will use the copy constructor of BoundingVolumeHierarchy instead of rebuilding.
- Change the assignment operators of RigidGeometry and SoftGeometry to use the copy constructors of RigidMesh and SoftMesh.

The motivation is that the assignment operators of RigidGeometry and SoftGeometry are called multiple times during context creation by Simulator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13564)
<!-- Reviewable:end -->
