### PR TITLE
[doc] Fix formatting on mangled markdown table

### DIFF
--- a/geometry/geometry_visualization.h
+++ b/geometry/geometry_visualization.h
@@ -51,10 +51,10 @@ class GeometryVisualizationImpl {
  @ref geometry_roles for details). Specifically, only geometries with
  the illustration role assigned will be included. The visualization function
  looks for the following properties in the IllustrationProperties instance.
- | Group name | Required | Property Name |  Property Type  | Property
- Description | | :--------: | :------: | :-----------: | :-------------: |
- :------------------- | |    phong   | no       | diffuse       |
- Eigen::Vector4d | The rgba value of the object surface |
+
+ | Group name | Required | Property Name |  Property Type  | Property Description |
+ | :--------: | :------: | :-----------: | :-------------: | :------------------- |
+ |    phong   | no       | diffuse       | Eigen::Vector4d | The rgba value of the object surface |
 
  See MakePhongIllustrationProperties() to facilitate making a compliant set of
  illustration properties.


### PR DESCRIPTION
In the past (#11763), the markdown table got mangled so it no longer rendered correctly. Currently it looks like this:

![image](https://user-images.githubusercontent.com/22159799/84934580-63882c00-b08c-11ea-8443-9225fd30b15f.png)
https://drake.mit.edu/doxygen_cxx/group__visualization.html#ga20c8d0e933cfdd8684cf77b15d8bef15

This fix makes it look like this again:

![image](https://user-images.githubusercontent.com/22159799/84934644-7b5fb000-b08c-11ea-8276-0f00eb0dab3d.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13566)
<!-- Reviewable:end -->
