### PR TITLE
Provide a spdlog sink that connects to Python's `logging` module

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -384,6 +384,34 @@ drake_py_unittest(
     ],
 )
 
+drake_pybind_library(
+    name = "text_logging_test_py",
+    testonly = 1,
+    add_install = False,
+    cc_so_name = "test/text_logging_test",
+    cc_srcs = ["test/text_logging_test_py.cc"],
+    package_info = PACKAGE_INFO,
+    py_srcs = ["test/__init__.py"],
+    visibility = ["//visibility:private"],
+)
+
+drake_py_binary(
+    name = "text_logging_example",
+    testonly = 1,
+    srcs = ["test/text_logging_example.py"],
+    deps = [
+        ":module_py",
+        ":text_logging_test_py",
+    ],
+)
+
+drake_py_unittest(
+    name = "text_logging_test",
+    data = [
+        ":text_logging_example",
+    ],
+)
+
 # Test ODR (One Definition Rule).
 drake_pybind_library(
     name = "odr_test_module_py",

--- a/bindings/pydrake/common/BUILD.bazel
+++ b/bindings/pydrake/common/BUILD.bazel
@@ -52,6 +52,8 @@ drake_pybind_library(
     cc_so_name = "_module_py",
     cc_srcs = [
         "module_py.cc",
+        "text_logging_pybind.h",
+        "text_logging_pybind.cc",
     ],
     package_info = PACKAGE_INFO,
     py_srcs = [

--- a/bindings/pydrake/common/module_py.cc
+++ b/bindings/pydrake/common/module_py.cc
@@ -2,6 +2,7 @@
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 
+#include "drake/bindings/pydrake/common/text_logging_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/common/constants.h"
@@ -93,10 +94,10 @@ PYBIND11_MODULE(_module_py, m) {
   constexpr auto& doc = pydrake_doc.drake;
   m.attr("_HAVE_SPDLOG") = logging::kHaveSpdlog;
 
-  // TODO(eric.cousineau): Provide a Pythonic spdlog sink that connects to
-  // Python's `logging` module; possibly use `pyspdlog`.
   m.def("set_log_level", &logging::set_log_level, py::arg("level"),
       doc.logging.set_log_level.doc);
+
+  internal::RedirectPythonLogging();
 
   py::enum_<drake::ToleranceType>(m, "ToleranceType", doc.ToleranceType.doc)
       .value("absolute", drake::ToleranceType::kAbsolute)

--- a/bindings/pydrake/common/text_logging_pybind.cc
+++ b/bindings/pydrake/common/text_logging_pybind.cc
@@ -1,0 +1,66 @@
+#ifdef HAVE_SPDLOG
+#include "drake/bindings/pydrake/common/text_logging_pybind.h"
+
+#include <memory>
+#include <mutex>
+
+#include <spdlog/sinks/base_sink.h>
+#include <spdlog/sinks/dist_sink.h>
+
+#include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/common/drake_assert.h"
+#include "drake/common/text_logging.h"
+#endif
+
+namespace drake {
+namespace pydrake {
+namespace internal {
+
+#ifdef HAVE_SPDLOG
+namespace {
+class pylogging_sink final : public spdlog::sinks::base_sink<std::mutex> {
+ public:
+  pylogging_sink() {
+    py::object py_logging = py::module::import("logging");
+    py_logger_ = py_logging.attr("getLogger")("_pydrake_spdlog_sink");
+    py::object py_formatter =
+        py_logging.attr("Formatter")(py::arg("fmt") = "%(message)s");
+    py::object py_handler = py_logging.attr("StreamHandler")();
+    py_handler.attr("setFormatter")(py_formatter);
+    py_handler.attr("terminator") = "";
+    py_logger_.attr("addHandler")(py_handler);
+    py_logger_.attr("propagate") = false;
+  }
+
+ protected:
+  void sink_it_(const spdlog::details::log_msg& msg) override {
+    spdlog::memory_buf_t formatted;
+    spdlog::sinks::base_sink<std::mutex>::formatter_->format(msg, formatted);
+    // Use CRITICAL level to ensure that messages will always be logged.
+    // Messages are filtered and formatted by drake::log() and will not
+    // contain any extra mark-up from the Python logger.
+    py_logger_.attr("critical")(fmt::to_string(formatted));
+  }
+
+  void flush_() override {}
+
+ private:
+  py::object py_logger_;
+};
+}  // namespace
+
+void RedirectPythonLogging() {
+  // Redirect all logs to Python's `logging` module
+  logging::sink* const sink_base = logging::get_dist_sink();
+  auto* const dist_sink = dynamic_cast<spdlog::sinks::dist_sink_mt*>(sink_base);
+  DRAKE_DEMAND(dist_sink != nullptr);
+  auto python_sink = std::make_shared<pylogging_sink>();
+  dist_sink->set_sinks({python_sink});
+}
+#else
+void RedirectPythonLogging() {}
+#endif
+
+}  // namespace internal
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/common/text_logging_pybind.h
+++ b/bindings/pydrake/common/text_logging_pybind.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace drake {
+namespace pydrake {
+namespace internal {
+
+void RedirectPythonLogging();
+
+}  // namespace internal
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/test/text_logging_example.py
+++ b/bindings/pydrake/test/text_logging_example.py
@@ -1,0 +1,14 @@
+import sys
+
+from pydrake.test.text_logging_test import do_log_test
+from pydrake.common import set_log_level
+
+
+def main():
+    spdlog_level = sys.argv[1]
+    set_log_level(spdlog_level)
+    do_log_test()
+
+
+if __name__ == "__main__":
+    main()

--- a/bindings/pydrake/test/text_logging_test.py
+++ b/bindings/pydrake/test/text_logging_test.py
@@ -1,0 +1,56 @@
+import re
+import subprocess
+import unittest
+
+
+class TestTextLogging(unittest.TestCase):
+    def expected_message(self, spdlog_level):
+        # Expected message format:
+        # [<date> <time>] [console] [<level>] <message>
+
+        # See bindings/pydrake/test/text_logging_test_py.cc
+        expected_messages = {"debug": "Test Debug message",
+                             "info": "Test Info message",
+                             "warn": "Test Warn message",
+                             "error": "Test Error message",
+                             "critical": "Test Critical message"}
+        level_strings = {"debug": "debug",
+                         "info": "info",
+                         "warn": "warning",
+                         "error": "error",
+                         "critical": "critical"}
+
+        message = expected_messages[spdlog_level]
+        level = level_strings[spdlog_level]
+        return fr"\[[0-9,\-,\s,:,\.]*\] \[console\] \[{level}\] {message}"
+
+    def do_test(self, spdlog_level, expected_spdlog_levels):
+        output = subprocess.check_output(
+            ["bindings/pydrake/text_logging_example", spdlog_level],
+            stderr=subprocess.STDOUT).decode("utf8")
+        expected_output = ""
+        for level in expected_spdlog_levels:
+            expected_output += self.expected_message(level) + "\n"
+        if not expected_output:
+            self.assertEqual(output, expected_output)
+        else:
+            self.assertRegex(output, expected_output)
+
+    def test_debug_logging(self):
+        self.do_test("debug",
+                     ["debug", "info", "warn", "error", "critical"])
+
+    def test_info_logging(self):
+        self.do_test("info", ["info", "warn", "error", "critical"])
+
+    def test_warning_logging(self):
+        self.do_test("warn", ["warn", "error", "critical"])
+
+    def test_error_logging(self):
+        self.do_test("err", ["error", "critical"])
+
+    def test_critical_logging(self):
+        self.do_test("critical", ["critical"])
+
+    def test_no_logging(self):
+        self.do_test("off", [])

--- a/bindings/pydrake/test/text_logging_test_py.cc
+++ b/bindings/pydrake/test/text_logging_test_py.cc
@@ -1,0 +1,21 @@
+#include "pybind11/pybind11.h"
+
+#include "drake/common/text_logging.h"
+
+namespace drake {
+namespace pydrake {
+
+PYBIND11_MODULE(text_logging_test, m) {
+  m.doc() = "Test text logging";
+
+  m.def("do_log_test", []() {
+    drake::log()->debug("Test Debug message");
+    drake::log()->info("Test Info message");
+    drake::log()->warn("Test Warn message");
+    drake::log()->error("Test Error message");
+    drake::log()->critical("Test Critical message");
+  });
+}
+
+}  // namespace pydrake
+}  // namespace drake


### PR DESCRIPTION
sdplog output will appear in the Jupyter window instead of in the terminal.

Relates to #13215

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13568)
<!-- Reviewable:end -->
