### PR TITLE
[gl_renderer/dev] Clean up documentation and add unit tests

### DIFF
--- a/geometry/render/gl_renderer/dev/BUILD.bazel
+++ b/geometry/render/gl_renderer/dev/BUILD.bazel
@@ -60,9 +60,17 @@ drake_cc_library_gl_ubuntu_only(
 
 drake_cc_googletest_gl_ubuntu_only(
     name = "buffer_dim_test",
-    tags = vtk_test_tags(),
     deps = [
         ":render_engine_gl",
+    ],
+)
+
+drake_cc_googletest_gl_ubuntu_only(
+    name = "opengl_geometry_test",
+    deps = [
+        ":opengl_geometry",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 
@@ -77,6 +85,17 @@ drake_cc_googletest_gl_ubuntu_only(
         "//common:find_resource",
         "//geometry/render:render_label",
         "//systems/sensors:color_palette",
+    ],
+)
+
+drake_cc_googletest_gl_ubuntu_only(
+    name = "shader_program_test",
+    tags = vtk_test_tags(),
+    deps = [
+        ":shader_program",
+        "//common:temp_directory",
+        "//common/test_utilities:expect_throws_message",
+        "//geometry/render/gl_renderer:opengl_context",
     ],
 )
 

--- a/geometry/render/gl_renderer/dev/opengl_geometry.h
+++ b/geometry/render/gl_renderer/dev/opengl_geometry.h
@@ -10,42 +10,88 @@ namespace geometry {
 namespace render {
 namespace internal {
 
-/** For a fixed OpenGL context, defines the definition of a mesh geometry. The
+/* For a fixed OpenGL context, defines the definition of a mesh geometry. The
  geometry is defined by the handles to various objects in the OpenGL context.
  If the context is changed or otherwise invalidated, these handles will no
- longer be valid.  */
-struct OpenGlGeometry {
-  GLuint vertex_array{kInvalid};
-  GLuint vertex_buffer{kInvalid};
-  GLuint index_buffer{kInvalid};
-  int index_buffer_size{0};
+ longer be valid.
 
-  /** Reports true if `this` has been defined with meaningful values.  */
+ The code that constructs instances is completely responsible for guaranteeing
+ that the array and buffer values are valid in the OpenGl context and that the
+ index buffer size is likewise sized correctly.  */
+struct OpenGlGeometry {
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(OpenGlGeometry)
+
+  /* Default constructor; the instances is considered "undefined".  */
+  OpenGlGeometry() = default;
+
+  /* Constructs from the handles for the various OpenGl objects.
+
+   @param vertex_array_in       The handle to the OpenGl vertex array object
+                                containing the mesh's data.
+   @param vertex_buffer_in      The handle to the OpenGl vertex buffer
+                                containing mesh per-vertex data.
+   @param index_buffer_in       The handle to the OpenGl index buffer defining a
+                                set of triangles.
+   @param index_buffer_size_in  The number of indices in the index buffer.
+   @pre `index_buffer_size_in >= 0`.  */
+  OpenGlGeometry(GLuint vertex_array_in, GLuint vertex_buffer_in,
+                 GLuint index_buffer_in, int index_buffer_size_in)
+      : vertex_array{vertex_array_in},
+        vertex_buffer{vertex_buffer_in},
+        index_buffer{index_buffer_in},
+        index_buffer_size{index_buffer_size_in} {
+    if (index_buffer_size < 0) {
+      throw std::logic_error("Index buffer size must be non-negative");
+    }
+  }
+
+  /* Reports true if `this` has been defined with "meaningful" values. In this
+   case, "meaningful" is limited to "not default initialized". It can't know
+   if the values are actually object identifiers in the current OpenGl context.
+   */
   bool is_defined() const {
     return vertex_array != kInvalid && vertex_buffer != kInvalid &&
            index_buffer != kInvalid;
   }
 
-  /** Throws an exception with the given `message` if `this` hasn't been
-   populated with meaningful values.  */
-  void throw_if_undefined(const char* message) {
+  /* Throws an exception with the given `message` if `this` hasn't been
+   populated with meaningful values.
+   @see if_defined().  */
+  void throw_if_undefined(const char* message) const {
     if (!is_defined()) throw std::logic_error(message);
   }
 
-  /** The value of an object that should be considered invalid.  */
+  GLuint vertex_array{kInvalid};
+  GLuint vertex_buffer{kInvalid};
+  GLuint index_buffer{kInvalid};
+  int index_buffer_size{0};
+
+  /* The value of an object (array, buffer) that should be considered invalid.
+   */
   static constexpr GLuint kInvalid = std::numeric_limits<GLuint>::max();
 };
 
-/** An instance of a geometry in the renderer - the geometry definition and the
- pose of that geometry in the world frame.  */
+/* An instance of a geometry in the renderer - the underlying OpenGl geometry
+ definition in Frame G, its pose in the world frame W, and scale factors. The
+ scale factors are not required to be uniform. They _can_ be negative, but that
+ is not recommended; in addition to mirroring the geometry it will also turn
+ the geometry "inside out".
+
+ When rendering, the visual geometry will be scaled around G's origin and
+ subsequently posed relative to W.  */
 struct OpenGlInstance {
+  /* Constructs an instance from a geometry definition, a pose, and a scale
+   factor.
+   @pre `g_in.is_defined()` reports `true`.  */
   OpenGlInstance(const OpenGlGeometry& g_in,
                  const math::RigidTransformd& pose_in,
                  const Vector3<double>& scale_in)
-      : geometry(g_in), X_WG(pose_in), scale(scale_in) {}
+      : geometry(g_in), X_WG(pose_in), scale(scale_in) {
+    DRAKE_DEMAND(geometry.is_defined());
+  }
+
   OpenGlGeometry geometry;
   math::RigidTransformd X_WG;
-  // The scale factors providing the basis for non-unit geometry.
   Vector3<double> scale;
 };
 

--- a/geometry/render/gl_renderer/dev/shader_program.h
+++ b/geometry/render/gl_renderer/dev/shader_program.h
@@ -10,7 +10,7 @@ namespace geometry {
 namespace render {
 namespace internal {
 
-/** Definition of a GLSL shader program including a vertex and fragment shader.
+/* Definition of a GLSL shader program including a vertex and fragment shader.
  All operations on this shader program require an active OpenGL context. In
  fact, they require the same context which was active when the program was
  "loaded".  */
@@ -22,28 +22,48 @@ class ShaderProgram {
 
   ~ShaderProgram();
 
-  /** Loads a %ShaderProgram from GLSL code contained in the provided strings.
+  /* Loads a %ShaderProgram from GLSL code contained in the provided strings.
+
+   @param vertex_shader_source    The valid GLSL source code for a vertex
+                                  shader.
+   @param fragment_shader_source  The valid GLSL source code for a fragment
+                                  shader.
+   @throws std::runtime_error if either shader source doesn't compile or the
+                              resulting program has errors.
    */
   void LoadFromSources(const std::string& vertex_shader_source,
                        const std::string& fragment_shader_source);
 
-  /** Loads a %ShaderProgram from GLSL code contained in the named files.  */
+  /* Loads a %ShaderProgram from GLSL code contained in the named files.
+
+   @param vertex_shader_file    The path to a file containing valid GLSL source
+                                code for a vertex shader.
+   @param fragment_shader_file  The path to a file containing valid GLSL source
+                                code for a fragment shader.
+   @throws std::runtime_error if there is an error in reading the files, either
+                              shader source doesn't compile, or the resulting
+                              program has errors.
+   */
   void LoadFromFiles(const std::string& vertex_shader_file,
                      const std::string& fragment_shader_file);
 
-  /** Provides the location of the named shader uniform parameter.  */
+  /* Provides the location of the named shader uniform parameter.
+   @throws std::runtime_error if the named uniform isn't part of the program. */
   GLint GetUniformLocation(const std::string& uniform_name) const;
 
-  /** Sets the scalar uniform value to the given value.  */
+  /* Sets the scalar uniform value to the given value.
+   @throws std::runtime_error if the named uniform isn't part of the program. */
   void SetUniformValue1f(const std::string& uniform_name, float value) const;
 
-  /** Binds the program for usage.  */
+  /* Binds the program for usage.  */
   void Use() const;
 
-  /** Unbinds the program.  */
+  /* Unbinds the program (if this is the current program).  */
   void Unuse() const;
 
  private:
+  friend class ShaderProgramTest;
+
   GLuint program_id_{0};
 };
 

--- a/geometry/render/gl_renderer/dev/test/opengl_geometry_test.cc
+++ b/geometry/render/gl_renderer/dev/test/opengl_geometry_test.cc
@@ -1,0 +1,75 @@
+#include "drake/geometry/render/gl_renderer/dev/opengl_geometry.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace internal {
+namespace {
+
+using Eigen::Vector3d;
+using math::RigidTransformd;
+
+GTEST_TEST(OpenGlGeometryTest, Construction) {
+  const OpenGlGeometry default_geo;
+  EXPECT_EQ(default_geo.vertex_array, OpenGlGeometry::kInvalid);
+  EXPECT_EQ(default_geo.vertex_buffer, OpenGlGeometry::kInvalid);
+  EXPECT_EQ(default_geo.index_buffer, OpenGlGeometry::kInvalid);
+  EXPECT_EQ(default_geo.index_buffer_size, 0);
+
+  const OpenGlGeometry geo{1, 2, 3, 4};
+  EXPECT_EQ(geo.vertex_array, 1);
+  EXPECT_EQ(geo.vertex_buffer, 2);
+  EXPECT_EQ(geo.index_buffer, 3);
+  EXPECT_EQ(geo.index_buffer_size, 4);
+
+  DRAKE_EXPECT_THROWS_MESSAGE(OpenGlGeometry(1, 2, 3, -1), std::logic_error,
+                              "Index buffer size must be non-negative");
+}
+
+GTEST_TEST(OpenGlGeometryTest, IsDefined) {
+  const GLuint kInvalid = OpenGlGeometry::kInvalid;
+
+  EXPECT_TRUE(OpenGlGeometry(1, 2, 3, 4).is_defined());
+  EXPECT_FALSE(OpenGlGeometry(kInvalid, 2, 3, 4).is_defined());
+  EXPECT_FALSE(OpenGlGeometry(1, kInvalid, 3, 4).is_defined());
+  EXPECT_FALSE(OpenGlGeometry(1, 2, kInvalid, 4).is_defined());
+  EXPECT_FALSE(OpenGlGeometry(kInvalid, kInvalid, 3, 4).is_defined());
+  EXPECT_FALSE(OpenGlGeometry(kInvalid, 2, kInvalid, 4).is_defined());
+  EXPECT_FALSE(OpenGlGeometry(1, kInvalid, kInvalid, 4).is_defined());
+  EXPECT_FALSE(OpenGlGeometry(kInvalid, kInvalid, kInvalid, 4).is_defined());
+}
+
+GTEST_TEST(OpenGlGeometryTest, ThrowIfUndefined) {
+  const OpenGlGeometry valid{1, 2, 3, 4};
+  EXPECT_NO_THROW(valid.throw_if_undefined("test message"));
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      OpenGlGeometry().throw_if_undefined("default is undefined"),
+      std::logic_error,
+      "default is undefined");
+}
+
+GTEST_TEST(OpenGlInstanceTest, Construction) {
+  const OpenGlGeometry geometry(1, 2, 3, 4);
+  const RigidTransformd X_WG{Vector3d{-1, -2, 3}};
+  const Vector3d scale{0.25, 0.5, 0.75};
+  const OpenGlInstance instance{geometry, X_WG, scale};
+
+  EXPECT_EQ(instance.geometry.vertex_array, geometry.vertex_array);
+  EXPECT_EQ(instance.geometry.vertex_buffer, geometry.vertex_buffer);
+  EXPECT_EQ(instance.geometry.index_buffer, geometry.index_buffer);
+  EXPECT_EQ(instance.geometry.index_buffer_size, geometry.index_buffer_size);
+  EXPECT_TRUE(
+      CompareMatrices(instance.X_WG.GetAsMatrix34(), X_WG.GetAsMatrix34()));
+  EXPECT_TRUE(CompareMatrices(instance.scale, scale));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/gl_renderer/dev/test/shader_program_test.cc
+++ b/geometry/render/gl_renderer/dev/test/shader_program_test.cc
@@ -1,0 +1,191 @@
+#include "drake/geometry/render/gl_renderer/dev/shader_program.h"
+
+#include <fstream>
+#include <memory>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/temp_directory.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/render/gl_renderer/opengl_context.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace internal {
+namespace {
+
+const char* simple_vertex_source = R"_(
+  #version 330
+  void main() {
+    gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+  }
+)_";
+
+const char* simple_fragment_source = R"_(
+  #version 330
+  uniform float test_uniform;
+  void main() {
+    gl_FragColor = vec4(0.18, 0.54, 0.34, test_uniform);
+  }
+)_";
+
+}  // namespace
+
+using std::string;
+
+// Test class is *not* in the anonymous namespace so it can exploit the
+// declared friend status in ShaderProgram.
+class ShaderProgramTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // ShaderProgram requires an active OpenGL context to perform.
+    opengl_context_ = std::make_shared<OpenGlContext>();
+  }
+
+  // Reports the program id of the given program.
+  static GLuint program_id(const ShaderProgram& program) {
+    return program.program_id_;
+  }
+
+ private:
+  std::shared_ptr<OpenGlContext> opengl_context_;
+};
+
+// Test the shader program loading. This tests both sources stored in strings as
+// well as reading from disk. We've created an immensely simple shader and just
+// want to make sure it loads/compiles without difficulty.
+TEST_F(ShaderProgramTest, LoadShaders) {
+  {
+    // Case: Load from in-memory vertex and fragment shaders.
+    ShaderProgram program;
+    EXPECT_EQ(program_id(program), 0);
+    EXPECT_NO_THROW(
+        program.LoadFromSources(simple_vertex_source, simple_fragment_source));
+    EXPECT_NE(program_id(program), 0);
+  }
+
+  {
+    // Case: Load the same shaders from disk.
+    auto write_shader = [](const string& file_name, const char* shader) {
+      std::ofstream file(file_name);
+      if (!file) throw std::logic_error("Can't write file");
+      file << shader;
+    };
+
+    const string temp_dir = temp_directory();
+    const string vertex_shader(temp_dir + "/vertex.glsl");
+    const string fragment_shader(temp_dir + "/fragment.glsl");
+
+    write_shader(vertex_shader, simple_vertex_source);
+    write_shader(fragment_shader, simple_fragment_source);
+
+    ShaderProgram program;
+    EXPECT_NO_THROW(program.LoadFromFiles(vertex_shader, fragment_shader));
+    EXPECT_NE(program_id(program), 0);
+  }
+}
+
+// Confirms the error conditions for loading vertex and fragment shaders. These
+// exercise ShaderProgram::LoadFromSources, relying on the fact that
+// ShaderProgram::LoadFromFiles ultimately exercises those.
+TEST_F(ShaderProgramTest, LoadShadersError) {
+  // We'll create a "bad" shader by simply passing garbage. We're ignoring the
+  // details of the compilation error reported by the OpenGL driver. The
+  // error regular expression uses "[^]+" instead of ".+" because the error
+  // may include line breaks and ".+" does *not* include line breaks.
+    ShaderProgram program;
+  {
+    // Case: Bad vertex shader.
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        program.LoadFromSources("This is garbage", simple_fragment_source),
+        std::runtime_error,
+        "Error compiling vertex shader[^]+");
+  }
+  {
+    // Case: Bad fragment shader.
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        program.LoadFromSources(simple_vertex_source, "This is garbage"),
+        std::runtime_error,
+        "Error compiling fragment shader[^]+");
+  }
+  {
+    // Case: Both shaders are bad. This stops at reporting the vertex error.
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        program.LoadFromSources("This is garbage", "also garbage"),
+        std::runtime_error,
+        "Error compiling vertex shader[^]+");
+  }
+  {
+    // Case: linker error. To trigger the linker error, we omit the main
+    // function from the fragment shader as documented here:
+    // https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glLinkProgram.xhtml
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        program.LoadFromSources(simple_vertex_source, R"_(
+            #version 100
+            void foo() {
+              gl_FragColor = vec4(0.1, 0.2, 0.3, 1.0);
+            })_"),
+        std::runtime_error, "Error linking shaders[^]+");
+  }
+
+  {
+    // Case: file referenced is not available.
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        program.LoadFromFiles("invalid.vert", "invalid.frag"),
+        std::runtime_error, "Error opening shader file: .+");
+  }
+}
+
+TEST_F(ShaderProgramTest, UniformAccess) {
+  ShaderProgram program;
+  program.LoadFromSources(simple_vertex_source, simple_fragment_source);
+  EXPECT_NO_THROW(program.GetUniformLocation("test_uniform"));
+  DRAKE_EXPECT_THROWS_MESSAGE(program.GetUniformLocation("invalid"),
+                              std::runtime_error,
+                              "Cannot get shader uniform invalid");
+  EXPECT_NO_THROW(program.SetUniformValue1f("test_uniform", 1.5f));
+  DRAKE_EXPECT_THROWS_MESSAGE(program.SetUniformValue1f("invalid", 1.75f),
+                              std::runtime_error,
+                              "Cannot get shader uniform invalid");
+}
+
+TEST_F(ShaderProgramTest, Binding) {
+  ShaderProgram program1;
+  program1.LoadFromSources(simple_vertex_source, simple_fragment_source);
+  ShaderProgram program2;
+  program2.LoadFromSources(simple_vertex_source, simple_fragment_source);
+
+  // Report the id of the currently bound program.
+  auto current_program = []() {
+    GLint curr_program;
+    glGetIntegerv(GL_CURRENT_PROGRAM, &curr_program);
+    return static_cast<GLuint>(curr_program);
+  };
+
+  // We start with nothing bound; creating a program isn't the same as binding
+  // it.
+  ASSERT_EQ(current_program(), 0);
+
+  // Bind one of the programs.
+  ASSERT_NO_THROW(program1.Use());
+  ASSERT_EQ(current_program(), program_id(program1));
+
+  // Binding another causes the current program to switch.
+  ASSERT_NO_THROW(program2.Use());
+  ASSERT_EQ(current_program(), program_id(program2));
+
+  // Attempting to unbind with the wrong program has no effect.
+  ASSERT_NO_THROW(program1.Unuse());
+  ASSERT_EQ(current_program(), program_id(program2));
+
+  // Unbinding the current program clears it.
+  ASSERT_NO_THROW(program2.Unuse());
+  ASSERT_EQ(current_program(), 0);
+}
+
+}  // namespace internal
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
  - OpenGlGeometry and OpenGlInstance get their documentation extended and clarified.
    - missing unit tests added.
  - ShaderProgram gets updated:
    - extended documentation
    - improved error messages
    - evolved semantics
    - unit tests
 - buffer_dim_test loses superfluous vtk_tags()
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13573)
<!-- Reviewable:end -->
