### PR TITLE
yaml: Remove NANs from unit test

### DIFF
--- a/common/yaml/test/yaml_read_archive_test.cc
+++ b/common/yaml/test/yaml_read_archive_test.cc
@@ -19,6 +19,10 @@
 
 namespace {
 
+// A value used in the test data below to include a default (placeholder) value
+// when initializing struct data members.
+constexpr double kNominalDouble = 1.2345;
+
 // These unit tests use a variety of sample Serializable structs, showing what
 // a user may write for their own schemas.
 
@@ -28,7 +32,7 @@ struct DoubleStruct {
     a->Visit(DRAKE_NVP(value));
   }
 
-  double value = NAN;
+  double value = kNominalDouble;
 };
 
 bool operator==(const DoubleStruct& a, const DoubleStruct& b) {
@@ -42,7 +46,7 @@ struct ArrayStruct {
   }
 
   ArrayStruct() {
-    value.fill(NAN);
+    value.fill(kNominalDouble);
   }
 
   std::array<double, 3> value;
@@ -55,7 +59,7 @@ struct VectorStruct {
   }
 
   VectorStruct() {
-    value.resize(1, NAN);
+    value.resize(1, kNominalDouble);
   }
 
   std::vector<double> value;
@@ -68,7 +72,7 @@ struct MapStruct {
   }
 
   MapStruct() {
-    value["NAN"] = NAN;
+    value["kNominalDouble"] = kNominalDouble;
   }
 
   std::map<std::string, double> value;
@@ -81,7 +85,7 @@ struct OptionalStruct {
   }
 
   OptionalStruct() {
-    value = NAN;
+    value = kNominalDouble;
   }
 
   std::optional<double> value;
@@ -107,7 +111,7 @@ struct VariantStruct {
   }
 
   VariantStruct() {
-    value = NAN;
+    value = kNominalDouble;
   }
 
   Variant3 value;
@@ -133,7 +137,7 @@ struct EigenStruct {
     if (value.size() == 0) {
       value.resize(1, 1);
     }
-    value.setConstant(NAN);
+    value.setConstant(kNominalDouble);
   }
 
   Eigen::Matrix<double, Rows, Cols> value;
@@ -146,7 +150,7 @@ using EigenMatrix34Struct = EigenStruct<3, 4>;
 
 struct OuterStruct {
   struct InnerStruct {
-    double inner_value = NAN;
+    double inner_value = kNominalDouble;
 
     template <typename Archive>
     void Serialize(Archive* a) {
@@ -160,7 +164,7 @@ struct OuterStruct {
     a->Visit(DRAKE_NVP(inner_struct));
   }
 
-  double outer_value = NAN;
+  double outer_value = kNominalDouble;
   InnerStruct inner_struct;
 };
 
@@ -282,7 +286,7 @@ TEST_P(YamlReadArchiveTest, Double) {
 
 TEST_P(YamlReadArchiveTest, DoubleMissing) {
   const auto& x = AcceptEmptyDoc<DoubleStruct>();
-  EXPECT_THAT(x.value, testing::NanSensitiveDoubleEq(NAN));
+  EXPECT_EQ(x.value, kNominalDouble);
 }
 
 TEST_P(YamlReadArchiveTest, StdArray) {
@@ -297,9 +301,9 @@ TEST_P(YamlReadArchiveTest, StdArray) {
 
 TEST_P(YamlReadArchiveTest, StdArrayMissing) {
   const auto& x = AcceptEmptyDoc<ArrayStruct>();
-  EXPECT_THAT(x.value[0], testing::NanSensitiveDoubleEq(NAN));
-  EXPECT_THAT(x.value[1], testing::NanSensitiveDoubleEq(NAN));
-  EXPECT_THAT(x.value[2], testing::NanSensitiveDoubleEq(NAN));
+  EXPECT_EQ(x.value[0], kNominalDouble);
+  EXPECT_EQ(x.value[1], kNominalDouble);
+  EXPECT_EQ(x.value[2], kNominalDouble);
 }
 
 TEST_P(YamlReadArchiveTest, StdVector) {
@@ -315,7 +319,7 @@ TEST_P(YamlReadArchiveTest, StdVector) {
 TEST_P(YamlReadArchiveTest, StdVectorMissing) {
   const auto& x = AcceptEmptyDoc<VectorStruct>();
   ASSERT_EQ(x.value.size(), 1);
-  EXPECT_THAT(x.value[0], testing::NanSensitiveDoubleEq(NAN));
+  EXPECT_EQ(x.value[0], kNominalDouble);
 }
 
 TEST_P(YamlReadArchiveTest, StdMap) {
@@ -332,7 +336,7 @@ TEST_P(YamlReadArchiveTest, StdMap) {
 TEST_P(YamlReadArchiveTest, StdMapMissing) {
   const auto& x = AcceptEmptyDoc<MapStruct>();
   ASSERT_EQ(x.value.size(), 1);
-  EXPECT_THAT(x.value.at("NAN"), testing::NanSensitiveDoubleEq(NAN));
+  EXPECT_EQ(x.value.at("kNominalDouble"), kNominalDouble);
 }
 
 TEST_P(YamlReadArchiveTest, StdMapWithMergeKeys) {
@@ -442,7 +446,7 @@ TEST_P(YamlReadArchiveTest, Variant) {
 
 TEST_P(YamlReadArchiveTest, VariantMissing) {
   const auto& x = AcceptEmptyDoc<VariantStruct>();
-  EXPECT_THAT(std::get<double>(x.value), testing::NanSensitiveDoubleEq(NAN));
+  EXPECT_EQ(std::get<double>(x.value), kNominalDouble);
 }
 
 TEST_P(YamlReadArchiveTest, EigenVector) {
@@ -494,10 +498,10 @@ TEST_P(YamlReadArchiveTest, EigenMissing) {
   const auto& mn = AcceptEmptyDoc<EigenMatrix34Struct>();
   ASSERT_EQ(vx.value.size(), 1);
   ASSERT_EQ(mx.value.size(), 1);
-  EXPECT_THAT(vx.value(0), testing::NanSensitiveDoubleEq(NAN));
-  EXPECT_THAT(vn.value(0), testing::NanSensitiveDoubleEq(NAN));
-  EXPECT_THAT(mx.value(0, 0), testing::NanSensitiveDoubleEq(NAN));
-  EXPECT_THAT(mn.value(0, 0), testing::NanSensitiveDoubleEq(NAN));
+  EXPECT_EQ(vx.value(0), kNominalDouble);
+  EXPECT_EQ(vn.value(0), kNominalDouble);
+  EXPECT_EQ(mx.value(0, 0), kNominalDouble);
+  EXPECT_EQ(mn.value(0, 0), kNominalDouble);
 }
 
 TEST_P(YamlReadArchiveTest, Nested) {
@@ -638,7 +642,7 @@ doc:
       GetParam().allow_yaml_with_no_cpp) {
     const auto& x = AcceptNoThrow<OuterStruct>(node);
     EXPECT_EQ(x.outer_value, 1.0);
-    EXPECT_THAT(x.inner_struct.inner_value, testing::NanSensitiveDoubleEq(NAN));
+    EXPECT_EQ(x.inner_struct.inner_value, kNominalDouble);
   } else if (GetParam().allow_cpp_with_no_yaml) {
     DRAKE_EXPECT_THROWS_MESSAGE(
         AcceptIntoDummy<OuterStruct>(node),
@@ -912,7 +916,7 @@ TEST_P(YamlReadArchiveTest, VisitStructFoundNothing) {
   if (GetParam().allow_cpp_with_no_yaml) {
     const auto& x = AcceptNoThrow<OuterStruct>(node);
     EXPECT_EQ(x.outer_value, 1.0);
-    EXPECT_THAT(x.inner_struct.inner_value, testing::NanSensitiveDoubleEq(NAN));
+    EXPECT_EQ(x.inner_struct.inner_value, kNominalDouble);
   } else {
     DRAKE_EXPECT_THROWS_MESSAGE(
         AcceptIntoDummy<OuterStruct>(node),


### PR DESCRIPTION
We had been using NAN to indicate "unset default value", but it leads to awkward test phrasing because it does not compare equal with itself. Instead, we'll just use a magic sentinel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13589)
<!-- Reviewable:end -->
