### PR TITLE
[geometry] IllustrationProperties can be updated after parsing

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -763,6 +763,16 @@ void DoScalarIndependentDefinitions(py::module m) {
             },
             py::arg("group_name"), py::arg("name"), py::arg("value"),
             cls_doc.AddProperty.doc)
+        .def(
+            "UpdateProperty",
+            [abstract_value_cls](Class& self, const std::string& group_name,
+                const std::string& name, py::object value) {
+              py::object abstract = abstract_value_cls.attr("Make")(value);
+              self.UpdatePropertyAbstract(
+                  group_name, name, abstract.cast<const AbstractValue&>());
+            },
+            py::arg("group_name"), py::arg("name"), py::arg("value"),
+            cls_doc.UpdateProperty.doc)
         .def("HasProperty", &Class::HasProperty, py::arg("group_name"),
             py::arg("name"), cls_doc.HasProperty.doc)
         .def(
@@ -789,6 +799,8 @@ void DoScalarIndependentDefinitions(py::module m) {
             },
             py::arg("group_name"), py::arg("name"), py::arg("default_value"),
             cls_doc.GetPropertyOrDefault.doc)
+        .def("RemoveProperty", &Class::RemoveProperty, py::arg("group_name"),
+            py::arg("name"), cls_doc.RemoveProperty.doc)
         .def_static("default_group_name", &Class::default_group_name,
             cls_doc.default_group_name.doc)
         .def(

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -390,6 +390,25 @@ class TestGeometry(unittest.TestCase):
         for name, value in group_values.items():
             self.assertIsInstance(name, str)
             self.assertIsInstance(value, AbstractValue)
+        # Remove the property.
+        self.assertTrue(prop.RemoveProperty(group_name=default_group,
+                                            name="test"))
+        self.assertFalse(prop.HasProperty(group_name=default_group,
+                                          name="test"))
+        # Update a property.
+        prop.AddProperty(group_name=default_group, name="to_update", value=17)
+        self.assertTrue(prop.HasProperty(group_name=default_group,
+                                         name="to_update"))
+        self.assertEqual(
+            prop.GetProperty(group_name=default_group, name="to_update"), 17)
+
+        prop.UpdateProperty(group_name=default_group, name="to_update",
+                            value=20)
+        self.assertTrue(prop.HasProperty(group_name=default_group,
+                                         name="to_update"))
+        self.assertEqual(
+            prop.GetProperty(group_name=default_group, name="to_update"),
+            20)
 
     def test_render_engine_vtk_params(self):
         # Confirm default construction of params.

--- a/geometry/geometry_properties.cc
+++ b/geometry/geometry_properties.cc
@@ -1,10 +1,14 @@
 #include "drake/geometry/geometry_properties.h"
 
+#include <fmt/format.h>
+
 namespace drake {
 namespace geometry {
 
+using std::string;
+
 const GeometryProperties::Group& GeometryProperties::GetPropertiesInGroup(
-    const std::string& group_name) const {
+    const string& group_name) const {
   const auto iter = values_.find(group_name);
   if (iter != values_.end()) {
     return iter->second;
@@ -15,17 +19,78 @@ const GeometryProperties::Group& GeometryProperties::GetPropertiesInGroup(
                   group_name));
 }
 
-std::set<std::string> GeometryProperties::GetGroupNames() const {
-  std::set<std::string> group_names;
+std::set<string> GeometryProperties::GetGroupNames() const {
+  std::set<string> group_names;
   for (const auto& pair : values_) {
     group_names.insert(pair.first);
   }
   return group_names;
 }
 
-void GeometryProperties::AddPropertyAbstract(
-    const std::string& group_name, const std::string& name,
-    const AbstractValue& value) {
+void GeometryProperties::AddPropertyAbstract(const string& group_name,
+                                             const string& name,
+                                             const AbstractValue& value) {
+  WritePropertyAbstract(
+      group_name, name, value, [&group_name, &name](const Group& group) {
+        const auto value_iter = group.find(name);
+        if (value_iter != group.end()) {
+          throw std::logic_error(
+              fmt::format("AddProperty(): Trying to add property ('{}', '{}'); "
+                          "a property with that name already exists",
+                          group_name, name));
+        }
+      });
+}
+
+void GeometryProperties::UpdatePropertyAbstract(const string& group_name,
+                                                const string& name,
+                                                const AbstractValue& value) {
+  WritePropertyAbstract(
+      group_name, name, value,
+      [&group_name, &name, &value](const Group& group) {
+        const auto value_iter = group.find(name);
+        if (value_iter != group.end() &&
+            group.at(name)->type_info() != value.type_info()) {
+          throw std::logic_error(
+              fmt::format("UpdateProperty(): Trying to update property ('{}', "
+                          "'{}'); The property already exists and is of "
+                          "different type. New type {}, existing type {}",
+                          group_name, name, value.GetNiceTypeName(),
+                          group.at(name)->GetNiceTypeName()));
+        }
+      });
+}
+
+bool GeometryProperties::HasProperty(const string& group_name,
+                                     const string& name) const {
+  return GetPropertyAbstractMaybe(group_name, name, false) != nullptr;
+}
+
+const AbstractValue& GeometryProperties::GetPropertyAbstract(
+    const string& group_name, const string& name) const {
+  const AbstractValue* abstract =
+      GetPropertyAbstractMaybe(group_name, name, true);
+  if (!abstract) {
+    throw std::logic_error(fmt::format(
+        "GetProperty(): There is no property ('{}', '{}')", group_name, name));
+  }
+  return *abstract;
+}
+
+bool GeometryProperties::RemoveProperty(const string& group_name,
+                                        const string& name) {
+  const auto iter = values_.find(group_name);
+  if (iter == values_.end()) return false;
+  Group& group = iter->second;
+  const auto value_iter = group.find(name);
+  if (value_iter == group.end()) return false;
+  group.erase(value_iter);
+  return true;
+}
+
+void GeometryProperties::WritePropertyAbstract(
+    const string& group_name, const string& name, const AbstractValue& value,
+    const std::function<void(const Group&)>& throw_if_invalid) {
   auto iter = values_.find(group_name);
   if (iter == values_.end()) {
     auto result = values_.insert({group_name, Group{}});
@@ -34,45 +99,21 @@ void GeometryProperties::AddPropertyAbstract(
   }
 
   Group& group = iter->second;
-  auto value_iter = group.find(name);
-  if (value_iter == group.end()) {
-    group[name] = value.Clone();
-    return;
-  }
-  throw std::logic_error(fmt::format(
-      "AddProperty(): Trying to add property '{}' to group '{}'; "
-      "a property with that name already exists",
-      name, group_name));
-}
+  throw_if_invalid(group);
 
-bool GeometryProperties::HasProperty(const std::string& group_name,
-                                     const std::string& name) const {
-  return GetPropertyAbstractMaybe(group_name, name, false) != nullptr;
-}
-
-const AbstractValue& GeometryProperties::GetPropertyAbstract(
-    const std::string& group_name, const std::string& name) const {
-  const AbstractValue* abstract = GetPropertyAbstractMaybe(
-      group_name, name, true);
-  if (!abstract) {
-    throw std::logic_error(
-        fmt::format("GetProperty(): There is no property '{}' in group '{}'.",
-                    name, group_name));
-  }
-  return *abstract;
+  group[name] = value.Clone();
 }
 
 const AbstractValue* GeometryProperties::GetPropertyAbstractMaybe(
-    const std::string& group_name, const std::string& name,
+    const string& group_name, const string& name,
     bool throw_for_bad_group) const {
   const auto iter = values_.find(group_name);
   if (iter == values_.end()) {
     if (throw_for_bad_group) {
-      throw std::logic_error(
-          fmt::format(
-              "GetProperty(): Trying to read property '{}' from group "
-              "'{}'. But the group does not exist.",
-              name, group_name));
+      throw std::logic_error(fmt::format(
+          "GetProperty(): Trying to read property ('{}', '{}'), but the group "
+          "does not exist.",
+          group_name, name));
     } else {
       return nullptr;
     }
@@ -89,12 +130,11 @@ const AbstractValue* GeometryProperties::GetPropertyAbstractMaybe(
 std::ostream& operator<<(std::ostream& out, const GeometryProperties& props) {
   int i = 0;
   for (const auto& group_pair : props.values_) {
-    const std::string& group_name = group_pair.first;
-    const GeometryProperties::Group& group_properties =
-        group_pair.second;
+    const string& group_name = group_pair.first;
+    const GeometryProperties::Group& group_properties = group_pair.second;
     out << "[" << group_name << "]";
     for (const auto& property_pair : group_properties) {
-      const std::string& property_name = property_pair.first;
+      const string& property_name = property_pair.first;
       out << "\n  " << property_name << ": "
           << property_pair.second->GetNiceTypeName();
       // TODO(SeanCurtis-TRI): How do I print the value in an AbstractValue?

--- a/geometry/internal_geometry.h
+++ b/geometry/internal_geometry.h
@@ -171,18 +171,15 @@ class InternalGeometry {
    engine's understanding as well.  */
   //@{
 
-  /** Assigns a proximity role to this geometry, replacing any properties that
-   were previously assigned.  */
+  /** Assigns a proximity role to this geometry, replacing any proximity
+   properties that were previously assigned.  */
   void SetRole(ProximityProperties properties) {
     proximity_props_ = std::move(properties);
   }
 
-  /** Assigns a illustration role to this geometry. Fails if it has already been
-   assigned.  */
+  /** Assigns an illustration role to this geometry, replacing any illustration
+   properties that were previously assigned.  */
   void SetRole(IllustrationProperties properties) {
-    if (illustration_props_) {
-      throw std::logic_error("Geometry already has illustration role assigned");
-    }
     illustration_props_ = std::move(properties);
   }
 

--- a/geometry/proximity/test/hydroelastic_internal_test.cc
+++ b/geometry/proximity/test/hydroelastic_internal_test.cc
@@ -683,9 +683,9 @@ void TestPropertyErrors(
     // This error message comes from GeometryProperties::GetProperty().
     DRAKE_EXPECT_THROWS_MESSAGE(
         maker(shape_spec, wrong_value), std::logic_error,
-        fmt::format(".*The property '{}' .+ exists, but is of a different "
-                    "type.+string'",
-                    property_name));
+        fmt::format(".*The property \\('{}', '{}'\\) exists, but is of a "
+                    "different type.+string'",
+                    group_name, property_name));
   }
 
   // Error case: property value is not positive.

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -271,6 +271,11 @@ void SceneGraph<T>::AssignRole(Context<T>* context, SourceId source_id,
                                GeometryId geometry_id,
                                IllustrationProperties properties,
                                RoleAssign assign) const {
+  static const logging::Warn one_time(
+      "Due to a bug (see issue #13597), changing the illustration roles or "
+      "properties in the context will not have any apparent effect in, at "
+      "least, drake_visualizer. Please change the illustration role in the "
+      "model prior to allocating the Context.");
   auto& g_state = mutable_geometry_state(context);
   g_state.AssignRole(source_id, geometry_id, std::move(properties), assign);
 }

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -534,7 +534,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
 
    <h4>Changing the properties for an assigned role</h4>
 
-   If  the geometry has previously been assigned a role, the properties for
+   If the geometry has previously been assigned a role, the properties for
    that role can be modified with the following code (using ProximityProperties
    as an example):
 
@@ -560,13 +560,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
    // Remove a property previously assigned.
    new_props.RemoveProperty("old_group", "old_name_1");
    // Update the *value* of an existing property (but enforce same type).
-   new_props.AddProperty("old_group", "old_name_2", new_value,
-                         AddPolicy::kUpdate);
-   // Overwrite the type and value of an existing property. This is the most
-   // dangerous modification; only do it if you're confident a type change is
-   // appropriate.
-   new_props.AddProperty("old_group", "type_A_prop", type_B_value,
-                         AddPolicy::kOverwrite);
+   new_props.UpdateProperty("old_group", "old_name_2", new_value);
    scene_graph.AssignRole(source_id, geometry_id, new_props,
                           RoleAssign::kReplace);
    @endcode
@@ -575,9 +569,11 @@ class SceneGraph final : public systems::LeafSystem<T> {
    role; it will simply eliminate possibly necessary properties. To remove
    the role completely, call `RemoveRole()`.
 
-   @warning Currently, only __proximity__ properties can be updated via this
-   mechanism. Updating illustration and perception will throw an exception (to
-   be implemented in the near future).
+   @warning Currently, only __proximity__ and __illustration__ properties can be
+   updated via this mechanism. Updating illustration properties has limitations
+   (see @ref AssignRole(SourceId,GeometryId,IllustrationProperties,RoleAssign)
+   "AssignRole(..., IllustrationProperties)" below). Attempting to update
+   perception will throw an exception (to be implemented in the near future).
 
    All invocations of `AssignRole()` will throw an exception if:
 
@@ -637,6 +633,13 @@ class SceneGraph final : public systems::LeafSystem<T> {
                   RoleAssign assign = RoleAssign::kNew) const;
 
   /** Assigns the illustration role to the geometry indicated by `geometry_id`.
+
+   @warning When changing illustration properties
+   (`assign = RoleAssign::kReplace`), there is no guarantee that these changes
+   will affect the visualization. The visualizer needs to be able to
+   "initialize" itself after changes to properties that will affect how a
+   geometry appears. If changing a geometry's illustration properties doesn't
+   seem to be affecting the visualization, retrigger its initialization action.
    @pydrake_mkdoc_identifier{illustration_direct}
    */
   void AssignRole(SourceId source_id, GeometryId geometry_id,
@@ -647,6 +650,19 @@ class SceneGraph final : public systems::LeafSystem<T> {
    @ref AssignRole(SourceId,GeometryId,IllustrationProperties) "AssignRole()"
    for illustration properties. Rather than modifying %SceneGraph's model, it
    modifies the copy of the model stored in the provided context.
+
+   @warning When changing illustration properties
+   (`assign = RoleAssign::kReplace`), there is no guarantee that these changes
+   will affect the visualization. The visualizer needs to be able to
+   "initialize" itself after changes to properties that will affect how a
+   geometry appears. If changing a geometry's illustration properties doesn't
+   seem to be affecting the visualization, retrigger its initialization action.
+
+   @warning Due to a bug (see issue
+   <a href="https://github.com/RobotLocomotion/drake/issues/13597">#13597</a>),
+   changing the illustration roles or properties in a systems::Context will not
+   have any apparent effect in, at least, drake_visualizer. Please change the
+   illustration role in the model prior to allocating the context.
    @pydrake_mkdoc_identifier{illustration_context}
    */
   void AssignRole(systems::Context<T>* context, SourceId source_id,

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -555,7 +555,18 @@ class SceneGraph final : public systems::LeafSystem<T> {
        scene_graph.model_inspector().GetProximityProperties(geometry_id);
    DRAKE_DEMAND(old_props);
    ProximityProperties new_props(*old_props);
-   new_props.AddProperty(...);  // add additional properties.
+   // Add a new property.
+   new_props.AddProperty("group", "new_prop_name", some_value);
+   // Remove a property previously assigned.
+   new_props.RemoveProperty("old_group", "old_name_1");
+   // Update the *value* of an existing property (but enforce same type).
+   new_props.AddProperty("old_group", "old_name_2", new_value,
+                         AddPolicy::kUpdate);
+   // Overwrite the type and value of an existing property. This is the most
+   // dangerous modification; only do it if you're confident a type change is
+   // appropriate.
+   new_props.AddProperty("old_group", "type_A_prop", type_B_value,
+                         AddPolicy::kOverwrite);
    scene_graph.AssignRole(source_id, geometry_id, new_props,
                           RoleAssign::kReplace);
    @endcode

--- a/geometry/test/proximity_properties_test.cc
+++ b/geometry/test/proximity_properties_test.cc
@@ -43,7 +43,7 @@ GTEST_TEST(ProximityPropertiesTest, AddContactMaterial) {
     p.AddProperty(kMaterialGroup, kElastic, E);
     DRAKE_EXPECT_THROWS_MESSAGE(
         AddContactMaterial(E, d, mu, &p), std::logic_error,
-        ".+ Trying to add property .+ to .+ property .+ already exists");
+        ".+ Trying to add property \\('.+', '.+'\\).+ name already exists");
   }
 
   // Error case: Already has dissipation.
@@ -52,7 +52,7 @@ GTEST_TEST(ProximityPropertiesTest, AddContactMaterial) {
     p.AddProperty(kMaterialGroup, kHcDissipation, d);
     DRAKE_EXPECT_THROWS_MESSAGE(
         AddContactMaterial(E, d, mu, &p), std::logic_error,
-        ".+ Trying to add property .+ to .+ property .+ already exists");
+        ".+ Trying to add property \\('.+', '.+'\\).+ name already exists");
   }
 
   // Error case: Already has friction.
@@ -61,7 +61,7 @@ GTEST_TEST(ProximityPropertiesTest, AddContactMaterial) {
     p.AddProperty(kMaterialGroup, kFriction, mu);
     DRAKE_EXPECT_THROWS_MESSAGE(
         AddContactMaterial(E, d, mu, &p), std::logic_error,
-        ".+ Trying to add property .+ to .+ property .+ already exists");
+        ".+ Trying to add property \\('.+', '.+'\\).+ name already exists");
   }
 
   // Error case: 0 elasticity.


### PR DESCRIPTION
This PR has two curated commits:

1. The first extends `GeometryProperties` functionality to make it easier to modify properties. A mutable instance of `GeometryProperties` can have properties removed, updated, or overwritten.
2. The second enables `AssignRole(..., IllustrationProperties, AssignRole::kReplace)`. Previously, that would throw. Due to issues in the greater ecosystem, this added functionality comes with limitations and warnings.
  - there are warnings in the documentation.
  - Warnings will likewise get printed to the console.

resolves #13126

(While not the total solution, it is sufficient to empower workflows to change visual appearance of parsed geometry.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13598)
<!-- Reviewable:end -->
