### PR TITLE
Fix deprecated pydrake Isometry3 stubs

### DIFF
--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -127,7 +127,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
                   "The RigidTransform::matrix() method was added for "
                   "compatibility with Eigen::Isometry3, and is now deprecated. "
                   "Use RigidTransform::GetAsMatrix4() instead.");
-              return self->GetAsIsometry3();
+              return self->GetAsMatrix4();
             },
             "The RigidTransform::matrix() method was added for "
             "compatibility with Eigen::Isometry3, and is now deprecated. "
@@ -139,7 +139,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
                   "The RigidTransform::linear() method was added for "
                   "compatibility with Eigen::Isometry3, and is now deprecated. "
                   "Use RigidTransform::rotation().matrix() instead.");
-              return self->GetAsMatrix4();
+              return self->rotation().matrix();
             },
             "The RigidTransform::linear() method was added for "
             "compatibility with Eigen::Isometry3, and is now deprecated. "


### PR DESCRIPTION
In #13595, the replacement stubs were calling the wrong methods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13607)
<!-- Reviewable:end -->
