### PR TITLE
pydrake: Add regression test for deprecated Isometry3 stubs

### DIFF
--- a/bindings/pydrake/test/math_test.py
+++ b/bindings/pydrake/test/math_test.py
@@ -192,6 +192,18 @@ class TestMath(unittest.TestCase):
             self.assertTrue(mtest.TakeIsometry3(mut.RigidTransform()))
 
     @numpy_compare.check_all_types
+    def test_rigid_transform_deprecated_isometry3_workalikes(self, T):
+        X_AB = mut.RigidTransform()
+        with catch_drake_warnings(expected_count=1):
+            mat = X_AB.matrix()
+        with catch_drake_warnings(expected_count=1):
+            lin = X_AB.linear()
+        self.assertIsInstance(mat, np.ndarray)
+        self.assertIsInstance(lin, np.ndarray)
+        self.assertEqual(mat.shape, (4, 4))
+        self.assertEqual(lin.shape, (3, 3))
+
+    @numpy_compare.check_all_types
     def test_rotation_matrix(self, T):
         # - Constructors.
         RotationMatrix = mut.RotationMatrix_[T]


### PR DESCRIPTION
This tests the fixes in #13607, for #13595.

This test passes as of cacac0aa107dcc63d37d21104efd1357377de78b (pre-#13595), modulo the the "expect 1 warning" lines being removed.  Therefore, it shows that the code (after #13607 hotfix) preserves the prior behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13608)
<!-- Reviewable:end -->
