### PR TITLE
RenderEngineGl gets ability to "show_window"

### DIFF
--- a/geometry/render/gl_renderer/opengl_context.cc
+++ b/geometry/render/gl_renderer/opengl_context.cc
@@ -73,26 +73,80 @@ class OpenGlContext::Impl {
     // https://sidvind.com/index.php?title=Opengl/windowless
 
     // Get framebuffer configs.
-    const int kVisualAttribs[] = {None};
+    const int kVisualAttribs[] = {GLX_X_RENDERABLE,
+                                  True,
+                                  GLX_X_VISUAL_TYPE,
+                                  GLX_TRUE_COLOR,
+                                  GLX_RED_SIZE,
+                                  8,
+                                  GLX_GREEN_SIZE,
+                                  8,
+                                  GLX_BLUE_SIZE,
+                                  8,
+                                  GLX_ALPHA_SIZE,
+                                  8,
+                                  GLX_DEPTH_SIZE,
+                                  24,
+                                  GLX_DOUBLEBUFFER,
+                                  True,
+                                  None};
     int fb_count = 0;
-    GLXFBConfig* fb_configs = glXChooseFBConfig(
-        display(), DefaultScreen(display()), kVisualAttribs, &fb_count);
+    const int screen_id = DefaultScreen(display());
+    GLXFBConfig* fb_configs =
+        glXChooseFBConfig(display(), screen_id, kVisualAttribs, &fb_count);
     ScopeExit guard([fb_configs]() { XFree(fb_configs); });
     if (fb_configs == nullptr) {
       throw std::runtime_error(
           "Error initializing OpenGL Context for RenderEngineGL; no suitable "
           "frame buffer configuration found.");
     }
-
-    // Create an OpenGL context.
-    const int kContextAttribs[] = {GLX_CONTEXT_MAJOR_VERSION_ARB, 3,
-                                   GLX_CONTEXT_MINOR_VERSION_ARB, 3, None};
     // Since we have provided attributes in the call to glXChooseFBConfig, we
     // are guaranteed to have a valid result in fb_configs as we have already
     // checked for null.
     DRAKE_DEMAND(fb_count > 0);
+
+    // Set up window for displaying render results.
+    XVisualInfo* visual = glXGetVisualFromFBConfig(display(), fb_configs[0]);
+    if (visual == nullptr) {
+      throw std::runtime_error(
+          "Unable to generate an OpenGl display window; visual info "
+          "unavailable.");
+    }
+    ScopeExit visual_guard([visual]() { XFree(visual); });
+    XSetWindowAttributes window_attribs;
+
+    // Track to see if we have successful initialization; if not, we use this
+    // to free up resources who don't have their own destructors in the case
+    // that the constructor exits badly (e.g., via exception).
+    bool is_complete = false;
+
+    // This requires a call to XFreeColormap in the destructor.
+    window_attribs.colormap = XCreateColormap(
+        display(), RootWindow(display(), screen_id), visual->visual, AllocNone);
+    ScopeExit colormap_guard(
+        [colormap = window_attribs.colormap, &is_complete]() {
+          if (!is_complete) XFreeColormap(display(), colormap);
+        });
+
+    // Enable just the Expose event so we know when the window is ready to be
+    // redrawn.
+    window_attribs.event_mask = ExposureMask;
+    // This requires a call to XDestroyWindow in the destructor.
+    window_ = XCreateWindow(display(), RootWindow(display(), screen_id), 0, 0,
+                            window_width_, window_height_, 0, visual->depth,
+                            InputOutput, visual->visual,
+                            CWColormap | CWEventMask, &window_attribs);
+    ScopeExit window_guard(
+        [window = window_, &is_complete]() {
+          if (!is_complete) XDestroyWindow(display(), window);
+        });
+
+    // Create an OpenGL context.
+    const int kContextAttribs[] = {GLX_CONTEXT_MAJOR_VERSION_ARB, 3,
+                                   GLX_CONTEXT_MINOR_VERSION_ARB, 3, None};
     // NOTE: The consts True and False come from gl/glx.h (indirectly), but
     // ultimately from X11/Xlib.h.
+    // This requires a call to glXDestroyContext in the destructor.
     context_ = glXCreateContextAttribsARB(display(), fb_configs[0], 0, True,
                                           kContextAttribs);
     if (context_ == nullptr) {
@@ -100,6 +154,10 @@ class OpenGlContext::Impl {
           "Error initializing OpenGL Context for RenderEngineGL; failed to "
           "create context via glXCreateContextAttribsARB.");
     }
+    ScopeExit context_guard(
+        [context = context_, &is_complete]() {
+          if (!is_complete) glXDestroyContext(display(), context);
+        });
 
     XSync(display(), False);
 
@@ -112,17 +170,74 @@ class OpenGlContext::Impl {
       glEnable(GL_DEBUG_OUTPUT);
       glDebugMessageCallback(GlDebugCallback, 0);
     }
+    is_complete = true;
   }
 
   ~Impl() {
     glXDestroyContext(display(), context_);
+    XWindowAttributes window_attribs;
+    XGetWindowAttributes(display(), window_, &window_attribs);
+    XFreeColormap(display(), window_attribs.colormap);
+    XDestroyWindow(display(), window_);
   }
 
   void MakeCurrent() {
     if (glXGetCurrentContext() != context_ &&
-        !glXMakeCurrent(display(), None, context_)) {
+        !glXMakeCurrent(display(), window_, context_)) {
       throw std::runtime_error("Error making an OpenGL context current");
     }
+  }
+
+  void DisplayWindow(const int width, const int height) {
+    if (width != window_width_ || height != window_height_) {
+      XResizeWindow(display(), window_, width, height);
+      WaitForExposeEvent();
+      window_width_ = width;
+      window_height_ = height;
+    }
+    if (!IsWindowViewable()) {
+      XMapRaised(display(), window_);
+      WaitForExposeEvent();
+    }
+    // We wait for confirmation events to make sure we don't attempt to draw
+    // to the window that isn't available yet. Without waiting for the events,
+    // the XServer could process the events in such a way that the rendering
+    // doesn't make it to the visible window (based on race conditions in the
+    // XServer).
+  }
+
+  void HideWindow() {
+    if (IsWindowViewable()) {
+      XUnmapWindow(display(), window_);
+      // Unmapping a window provides no events on that window.
+    }
+  }
+
+  bool IsWindowViewable() const {
+    XWindowAttributes attr;
+    const Status status = XGetWindowAttributes(display(), window_, &attr);
+
+    // In xlib, a zero status implies function failure.
+    // https://tronche.com/gui/x/xlib/introduction/errors.html#Status
+    if (status == 0) {
+      throw std::runtime_error(
+          "Unable to determine the status of the window associated with the "
+          "OpenGl context");
+    }
+    return attr.map_state == IsViewable;
+  }
+
+  void UpdateWindow() {
+    XClearWindow(display(), window_);
+    glXSwapBuffers(display(), window_);
+  }
+
+  // Waits for the display() to transmit an Expose event.
+  void WaitForExposeEvent() const {
+    XEvent event;
+    // This blocks until the window gets an "Expose" event.
+    XWindowEvent(display(), window_, ExposureMask, &event);
+    DRAKE_DEMAND(event.type == Expose);
   }
 
   static GLint max_texture_size() {
@@ -157,6 +272,16 @@ class OpenGlContext::Impl {
   }
 
   GLXContext context_{nullptr};
+
+  // The associated window to support display of rendering results.
+  Window window_;
+  // The window's current size. We default it to an arbitrary 640x480.
+  // XCreateWindow (called in the constructor) has undocumented behavior for
+  // zero-area windows, or even very small windows (causing the constructor to
+  // fail or hang). Empirically, 640x480 allows things to work. The reason is
+  // not yet understood.
+  int window_width_{640};
+  int window_height_{480};
 };
 
 OpenGlContext::OpenGlContext(bool debug)
@@ -165,6 +290,18 @@ OpenGlContext::OpenGlContext(bool debug)
 OpenGlContext::~OpenGlContext() = default;
 
 void OpenGlContext::MakeCurrent() { impl_->MakeCurrent(); }
+
+void OpenGlContext::DisplayWindow(const int width, const int height) {
+  impl_->DisplayWindow(width, height);
+}
+
+void OpenGlContext::HideWindow() { impl_->HideWindow(); }
+
+bool OpenGlContext::IsWindowViewable() const {
+  return impl_->IsWindowViewable();
+}
+
+void OpenGlContext::UpdateWindow() { impl_->UpdateWindow(); }
 
 GLint OpenGlContext::max_texture_size() {
   return OpenGlContext::Impl::max_texture_size();

--- a/geometry/render/gl_renderer/opengl_context.h
+++ b/geometry/render/gl_renderer/opengl_context.h
@@ -9,14 +9,14 @@ namespace geometry {
 namespace render {
 namespace internal {
 
-/** Handle OpenGL context initialization, clean-up, and generic OpenGL queries.
+/* Handle OpenGL context initialization, clean-up, and generic OpenGL queries.
  This class creates and owns a new context upon construction. Rendering classes
  need to keep their own OpenGlContext and ensure that they switch to it using
  `MakeCurrent()` before any OpenGL calls.
  */
 class OpenGlContext {
  public:
-  /** Constructor. Initializes an OpenGL context.
+  /* Constructor. Initializes an OpenGL context.
    @param debug  If debug is true, the OpenGl context will be a "debug" context,
    in that the OpenGl implementation's errors will be written to the Drake log.
    See https://www.khronos.org/opengl/wiki/Debug_Output for more information.
@@ -25,11 +25,31 @@ class OpenGlContext {
 
   ~OpenGlContext();
 
-  /** Makes this context current.
+  /* Makes this context current.
    @throw std::runtime_error if not successful.  */
   void MakeCurrent();
 
-  /** Returns the specified values for the current OpenGL context.
+  /* Displays the window at the given dimensions. Calling this redundantly (on
+   an already visible window of the given size) has no effect.  */
+  void DisplayWindow(const int width, const int height);
+
+  /* Hides the window (if visible). Calling this on a hidden window has no
+   effect.  */
+  void HideWindow();
+
+  /* Reports `true` if the window is viewable.
+
+   Being "viewable" is not necessarily the same as visible to the user. The
+   window might be occluded. But, at the very least, there is a window to view.
+
+   @throws std::runtime_error if the visibility status cannot be determined. */
+  bool IsWindowViewable() const;
+
+  /* Updates the window contents by drawing the back GL buffer into the window.
+   */
+  void UpdateWindow();
+
+  /* Returns the indicated values for the current OpenGL context.
    @note Even if invoked via an instance, they may not reflect that instance's
    configuration if the instance differs from whichever context is current.  */
   static GLint max_texture_size();

--- a/geometry/render/gl_renderer/render_engine_gl.cc
+++ b/geometry/render/gl_renderer/render_engine_gl.cc
@@ -317,6 +317,26 @@ void RenderEngineGl::RenderAt(const Eigen::Matrix4f& X_CW) const {
   shader_program_->Unuse();
 }
 
+void RenderEngineGl::SetWindowVisibility(const CameraProperties& camera,
+                                         bool show_window,
+                                         const RenderTarget& target) const {
+  if (show_window) {
+    // Use the render target buffer as the read buffer and the default buffer
+    // (0) as the draw buffer for displaying in the window. We transfer the full
+    // image from source to destination. The semantics of glBlitNamedFrameBuffer
+    // are inclusive of the "minimum" pixel (0, 0) and exclusive of the
+    // "maximum" pixel (width, height).
+    opengl_context_->DisplayWindow(camera.width, camera.height);
+    glBlitNamedFramebuffer(target.frame_buffer, 0,
+                           0, 0, camera.width, camera.height,  // Src bounds.
+                           0, 0, camera.width, camera.height,  // Dest bounds.
+                           GL_COLOR_BUFFER_BIT, GL_NEAREST);
+    opengl_context_->UpdateWindow();
+  } else {
+    opengl_context_->HideWindow();
+  }
+}
+
 void RenderEngineGl::ImplementGeometry(const Sphere& sphere, void* user_data) {
   OpenGlGeometry geometry = GetSphere();
   const RegistrationData& data = *static_cast<RegistrationData*>(user_data);

--- a/geometry/render/gl_renderer/render_engine_gl.h
+++ b/geometry/render/gl_renderer/render_engine_gl.h
@@ -43,7 +43,11 @@ class RenderEngineGl final : public RenderEngine {
   void UpdateViewpoint(const math::RigidTransformd& X_WR) final;
 
   /** @see RenderEngine::RenderColorImage(). Currently unimplemented. Calling
-   this will throw an exception.  */
+   this will throw an exception.
+
+   Note that the display window triggered by `show_window` is shared with
+   RenderLabelImage(), and only the last color or label image rendered will be
+   visible in the window (once these methods are implemented).  */
   void RenderColorImage(
       const CameraProperties& camera, bool show_window,
       systems::sensors::ImageRgba8U* color_image_out) const final;
@@ -54,7 +58,11 @@ class RenderEngineGl final : public RenderEngine {
       systems::sensors::ImageDepth32F* depth_image_out) const final;
 
   /** @see RenderEngine::RenderLabelImage(). Currently unimplemented. Calling
-   this will throw an exception.  */
+   this will throw an exception.
+
+   Note that the display window triggered by `show_window` is shared with
+   RenderColorImage(), and only the last color or label image rendered will be
+   visible in the window (once these methods are implemented).  */
   void RenderLabelImage(
       const CameraProperties& camera, bool show_window,
       systems::sensors::ImageLabel16I* label_image_out) const final;
@@ -124,6 +132,18 @@ class RenderEngineGl final : public RenderEngine {
   static internal::OpenGlGeometry CreateGlGeometry(
       const internal::VertexBuffer& vertices,
       const internal::IndexBuffer& indices);
+
+  // Sets the display window visibility and populates it with the _last_ image
+  // rendered, if visible.
+  // If `show_window` is true:
+  //  - the window is made visible (or remains visible).
+  //  - the window's contents display the last image rendered to `target`.
+  // If `show_window` is false:
+  //  - the window is made hidden (or remains hidden).
+  // @pre RenderTarget's frame buffer has the same dimensions as reported by the
+  // camera.
+  void SetWindowVisibility(const CameraProperties& camera, bool show_window,
+                           const internal::RenderTarget& target) const;
 
   // The cached value transformation between camera and world frame.
   math::RigidTransformd X_CW_;

--- a/geometry/render/gl_renderer/test/opengl_context_test.cc
+++ b/geometry/render/gl_renderer/test/opengl_context_test.cc
@@ -27,6 +27,29 @@ GTEST_TEST(OpenGlContext, GetContext) {
   EXPECT_FALSE(glIsEnabled(GL_BLEND));
 }
 
+GTEST_TEST(OpenGlContext, WindowVisibility) {
+  OpenGlContext opengl_context;
+
+  // Initially, there is no viewable window.
+  EXPECT_FALSE(opengl_context.IsWindowViewable());
+
+  // Calling once, makes it viewable.
+  opengl_context.DisplayWindow(640, 480);
+  EXPECT_TRUE(opengl_context.IsWindowViewable());
+
+  // Calling it again doesn't change that.
+  opengl_context.DisplayWindow(640, 480);
+  EXPECT_TRUE(opengl_context.IsWindowViewable());
+
+  // Hiding it makes it no longer viewable.
+  opengl_context.HideWindow();
+  EXPECT_FALSE(opengl_context.IsWindowViewable());
+
+  // Calling it again doesn't have any effect.
+  opengl_context.HideWindow();
+  EXPECT_FALSE(opengl_context.IsWindowViewable());
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace render

--- a/geometry/render/gl_renderer/test/render_engine_gl_test.cc
+++ b/geometry/render/gl_renderer/test/render_engine_gl_test.cc
@@ -760,6 +760,10 @@ TEST_F(RenderEngineGlTest, RenderLabelImageThrows) {
                               "RenderEngineGl cannot render label images");
 }
 
+// TODO(SeanCurtis-TRI): When either the color or label images are supported
+// provide a test indicating that the RenderEngineGl test is appropriately
+// calling the window display API on OpenGlContext.
+
 }  // namespace
 }  // namespace render
 }  // namespace geometry


### PR DESCRIPTION
The `RenderEngine` API has the ability to request showing the display for color and label images. Up to this point, `RenderEngineGl` hasn't supported that. This adds the infrastructure necessary to display the images.

Currently only exercised in test. Its inclusion now facilitates the development of label and color rendering in subsequent PRs; it's
nice to be able to see the images.

(Incidentally changes opengel_context.h documentation to `/*` from `/**` because it is in `internal::` namespace.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13626)
<!-- Reviewable:end -->
