### PR TITLE
Implement SystemVisitor

### DIFF
--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -50,6 +50,7 @@ drake_cc_package_library(
         ":system_output",
         ":system_scalar_converter",
         ":system_symbolic_inspector",
+        ":system_visitor",
         ":value_checker",
         ":value_to_abstract_value",
         ":vector",
@@ -430,6 +431,7 @@ drake_cc_library(
         ":system_constraint",
         ":system_output",
         ":system_scalar_converter",
+        ":system_visitor",
         ":witness_function",
         "//common:autodiff",
         "//common:default_scalars",
@@ -598,6 +600,15 @@ drake_cc_library(
         "//common:symbolic",
         "//common:type_safe_index",
         "//common:unused",
+    ],
+)
+
+drake_cc_library(
+    name = "system_visitor",
+    srcs = ["system_visitor.cc"],
+    hdrs = ["system_visitor.h"],
+    deps = [
+        "//common:default_scalars",
     ],
 )
 
@@ -849,6 +860,15 @@ drake_cc_googletest(
         ":system_output",
         "//common:essential",
         "//systems/framework/test_utilities",
+    ],
+)
+
+drake_cc_googletest(
+    name = "system_visitor_test",
+    deps = [
+        ":diagram_builder",
+        ":system_visitor",
+        "//systems/primitives:adder",
     ],
 )
 

--- a/systems/framework/diagram.cc
+++ b/systems/framework/diagram.cc
@@ -8,6 +8,7 @@
 #include "drake/common/text_logging.h"
 #include "drake/systems/framework/subvector.h"
 #include "drake/systems/framework/system_constraint.h"
+#include "drake/systems/framework/system_visitor.h"
 
 namespace drake {
 namespace systems {
@@ -23,6 +24,12 @@ std::vector<const systems::System<T>*> Diagram<T>::GetSystems() const {
     result.push_back(system.get());
   }
   return result;
+}
+
+template <typename T>
+void Diagram<T>::Accept(SystemVisitor<T>* v) const {
+  DRAKE_DEMAND(v);
+  v->VisitDiagram(*this);
 }
 
 template <typename T>

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -17,6 +17,7 @@
 #include "drake/systems/framework/event.h"
 #include "drake/systems/framework/state.h"
 #include "drake/systems/framework/system.h"
+#include "drake/systems/framework/system_visitor.h"
 
 namespace drake {
 namespace systems {
@@ -83,6 +84,9 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
 
   /// Returns the list of contained Systems.
   std::vector<const systems::System<T>*> GetSystems() const;
+
+  /// Implements a visitor pattern.  @see SystemVisitor<T>.
+  void Accept(SystemVisitor<T>* v) const final;
 
   std::multimap<int, int> GetDirectFeedthroughs() const final;
 

--- a/systems/framework/system.cc
+++ b/systems/framework/system.cc
@@ -5,12 +5,19 @@
 #include <regex>
 
 #include "drake/common/unused.h"
+#include "drake/systems/framework/system_visitor.h"
 
 namespace drake {
 namespace systems {
 
 template <typename T>
 System<T>::~System() {}
+
+template <typename T>
+void System<T>::Accept(SystemVisitor<T>* v) const {
+  DRAKE_DEMAND(v);
+  v->VisitSystem(*this);
+}
 
 template <typename T>
 std::unique_ptr<Context<T>> System<T>::AllocateContext() const {

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -30,6 +30,7 @@
 #include "drake/systems/framework/system_constraint.h"
 #include "drake/systems/framework/system_output.h"
 #include "drake/systems/framework/system_scalar_converter.h"
+#include "drake/systems/framework/system_visitor.h"
 #include "drake/systems/framework/witness_function.h"
 
 namespace drake {
@@ -71,6 +72,9 @@ class System : public SystemBase {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(System)
 
   ~System() override;
+
+  /// Implements a visitor pattern.  @see SystemVisitor<T>.
+  virtual void Accept(SystemVisitor<T>* v) const;
 
   //----------------------------------------------------------------------------
   /** @name           Resource allocation and initialization
@@ -1024,7 +1028,7 @@ class System : public SystemBase {
   //----------------------------------------------------------------------------
   /** @name                Automatic differentiation
   From a %System templatized by `double`, you can obtain an identical system
-  templatized by an automatic differentation scalar providing
+  templatized by an automatic differentiation scalar providing
   machine-precision computation of partial derivatives of any numerical
   result of the %System with respect to any of the numerical values that
   can be contained in a Context (time, inputs, parameters, and state). */

--- a/systems/framework/system_visitor.cc
+++ b/systems/framework/system_visitor.cc
@@ -1,0 +1,3 @@
+#include "drake/systems/framework/system_visitor.h"
+
+// This is an empty file to confirm that our header parses on its own.

--- a/systems/framework/system_visitor.h
+++ b/systems/framework/system_visitor.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "drake/common/default_scalars.h"
+
+namespace drake {
+namespace systems {
+
+template <typename T>
+class System;
+
+template <typename T>
+class Diagram;
+
+/** Provides a "Visitor Pattern" for System and Diagram.  Rather than adding
+more virtual methods to the System base class, or performing a dynamic_cast to
+test if a System is a Diagram, you may use the visitor pattern enabled by this
+class, e.g.:
+
+@code
+template <typename T>
+class MySystemVisitor : public SystemVisitor {
+  ...
+}
+
+MySystemVisitor<T> visitor;
+system.Accept(visitor);
+@endcode
+
+will call the correct `Visit` overload.
+
+@note This method does *not* recurse through the subsystems of a Diagram, but
+that is easy to do: just call Diagram::GetSystems() in your visitor and then
+call Accept on the subsystems.
+
+@tparam_default_scalar
+*/
+template <typename T>
+class SystemVisitor {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SystemVisitor)
+  virtual ~SystemVisitor() = default;
+
+  /** This method will be called by System<T>::accept() if the System *is not* a
+  Diagram<T>. */
+  virtual void VisitSystem(const System<T>& system) = 0;
+
+  /** This method will be called by System<T>::accept() if the System *is* a
+  Diagram<T>. */
+  virtual void VisitDiagram(const Diagram<T>& diagram) = 0;
+
+ protected:
+  SystemVisitor() = default;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/framework/test/system_visitor_test.cc
+++ b/systems/framework/test/system_visitor_test.cc
@@ -1,0 +1,65 @@
+#include "drake/systems/framework/system_visitor.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/systems/framework/diagram.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/framework/system.h"
+#include "drake/systems/primitives/adder.h"
+
+namespace drake {
+namespace systems {
+
+namespace {
+
+typedef std::vector<const System<double>*> Systems;
+
+class MyVisitor : public SystemVisitor<double> {
+ public:
+  void VisitSystem(const System<double>& system) final {
+    visited_systems_.push_back(&system);
+  }
+  void VisitDiagram(const Diagram<double>& diagram) final {
+    visited_diagrams_.push_back(&diagram);
+  }
+
+  const Systems& visited_systems() const { return visited_systems_; }
+
+  const Systems& visited_diagrams() const { return visited_diagrams_; }
+
+ private:
+  Systems visited_systems_{};
+  Systems visited_diagrams_{};
+};
+
+void VisitAndCheck(const System<double>& system,
+                   const Systems& expected_visited_systems,
+                   const Systems& expected_visited_diagrams) {
+  MyVisitor visitor;
+  system.Accept(&visitor);
+  EXPECT_EQ(visitor.visited_systems(), expected_visited_systems);
+  EXPECT_EQ(visitor.visited_diagrams(), expected_visited_diagrams);
+}
+
+}  // namespace
+
+// Construct a nested diagram and ensure the subcomponents are visited
+// correctly.
+GTEST_TEST(SystemVisitorTest, NestedDiagram) {
+  DiagramBuilder<double> builder;
+  const Adder<double>* adder = builder.AddSystem<Adder<double>>(1, 1);
+  DiagramBuilder<double> builder2;
+  const Diagram<double>* diagram = builder2.AddSystem(builder.Build());
+  auto diagram2 = builder2.Build();
+
+  VisitAndCheck(*adder, {adder}, {});
+  VisitAndCheck(*diagram, {}, {diagram});
+
+  // Confirm that we do NOT recurse automatically.
+  VisitAndCheck(*diagram2, {}, {diagram2.get()});
+}
+
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
Provides a visitor pattern to introspect into Diagrams (as Diagrams) and LeafSystems (as Systems) from a const System<T>&.  This is very useful for looping through a nested diagram.

This will be used in my next PR for the javascript diagram visualization.  (It allows me to write that as a workspace method instead of polluting the System class).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13628)
<!-- Reviewable:end -->
