### PR TITLE
Patch Mac CI - switch render_engine_gl_test to be ubuntu only

### DIFF
--- a/geometry/render/gl_renderer/BUILD.bazel
+++ b/geometry/render/gl_renderer/BUILD.bazel
@@ -137,7 +137,7 @@ drake_cc_googletest_gl_ubuntu_only(
     ],
 )
 
-drake_cc_googletest(
+drake_cc_googletest_gl_ubuntu_only(
     name = "render_engine_gl_test",
     args = select({
         "//tools/cc_toolchain:apple": ["--gtest_filter=-*"],


### PR DESCRIPTION
There are a number of Mac CI failures due to #13616.  E.g.,

https://drake-jenkins.csail.mit.edu/job/mac-catalina-clang-bazel-nightly-debug/259/
https://drake-jenkins.csail.mit.edu/job/mac-mojave-clang-bazel-nightly-release/352/
etc.

The `render_engine_gl_test` build target was *not* configured to be ubuntu only. This changes it to be so.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13629)
<!-- Reviewable:end -->
