### PR TITLE
Use penalty method contact parameters stored in SceneGraph

### DIFF
--- a/geometry/proximity_properties.cc
+++ b/geometry/proximity_properties.cc
@@ -8,6 +8,7 @@ const char* const kMaterialGroup = "material";
 const char* const kElastic = "elastic_modulus";
 const char* const kFriction = "coulomb_friction";
 const char* const kHcDissipation = "hunt_crossley_dissipation";
+const char* const kHcStiffness = "hunt_crossley_stiffness";
 
 const char* const kHydroGroup = "hydroelastic";
 const char* const kRezHint = "resolution_hint";

--- a/geometry/proximity_properties.cc
+++ b/geometry/proximity_properties.cc
@@ -8,7 +8,7 @@ const char* const kMaterialGroup = "material";
 const char* const kElastic = "elastic_modulus";
 const char* const kFriction = "coulomb_friction";
 const char* const kHcDissipation = "hunt_crossley_dissipation";
-const char* const kHcStiffness = "hunt_crossley_stiffness";
+const char* const kPointStiffness = "point_contact_stiffness";
 
 const char* const kHydroGroup = "hydroelastic";
 const char* const kRezHint = "resolution_hint";

--- a/geometry/proximity_properties.h
+++ b/geometry/proximity_properties.h
@@ -36,7 +36,7 @@ extern const char* const kFriction;       ///< Friction coefficients property
                                           ///< name.
 extern const char* const kHcDissipation;  ///< Hunt-Crossley dissipation
                                           ///< property name.
-extern const char* const kPointStiffness;    ///< Point stiffness property
+extern const char* const kPointStiffness; ///< Point stiffness property
                                           ///< name.
 
 //@}

--- a/geometry/proximity_properties.h
+++ b/geometry/proximity_properties.h
@@ -36,6 +36,8 @@ extern const char* const kFriction;       ///< Friction coefficients property
                                           ///< name.
 extern const char* const kHcDissipation;  ///< Hunt-Crossley dissipation
                                           ///< property name.
+extern const char* const kHcStiffness;    ///< Hunt-Crossley stiffness property
+                                          ///< name.
 
 //@}
 

--- a/geometry/proximity_properties.h
+++ b/geometry/proximity_properties.h
@@ -36,7 +36,7 @@ extern const char* const kFriction;       ///< Friction coefficients property
                                           ///< name.
 extern const char* const kHcDissipation;  ///< Hunt-Crossley dissipation
                                           ///< property name.
-extern const char* const kHcStiffness;    ///< Hunt-Crossley stiffness property
+extern const char* const kPointStiffness;    ///< Point stiffness property
                                           ///< name.
 
 //@}

--- a/geometry/proximity_properties.h
+++ b/geometry/proximity_properties.h
@@ -30,14 +30,14 @@ namespace internal {
  called out in the documentation of the ProximityProperties class).  */
 //@{
 
-extern const char* const kMaterialGroup;  ///< The contact material group name.
-extern const char* const kElastic;        ///< Elastic modulus property name.
-extern const char* const kFriction;       ///< Friction coefficients property
-                                          ///< name.
-extern const char* const kHcDissipation;  ///< Hunt-Crossley dissipation
-                                          ///< property name.
-extern const char* const kPointStiffness; ///< Point stiffness property
-                                          ///< name.
+extern const char* const kMaterialGroup;   ///< The contact material group name.
+extern const char* const kElastic;         ///< Elastic modulus property name.
+extern const char* const kFriction;        ///< Friction coefficients property
+                                           ///< name.
+extern const char* const kHcDissipation;   ///< Hunt-Crossley dissipation
+                                           ///< property name.
+extern const char* const kPointStiffness;  ///< Point stiffness property
+                                           ///< name.
 
 //@}
 

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1065,13 +1065,14 @@ void MultibodyPlant<T>::EstimatePointContactParameters(
   // Final parameters used in the penalty method:
   //
   // Before #13630 this method estimated an effective "combined" stiffness.
-  // That is, penalty_method_contact_parameters_.stiffness was the desired
+  // That is, penalty_method_contact_parameters_.geometry_stiffness (previously
+  // called penalty_method_contact_parameters_.stiffness) was the desired
   // stiffness of the contact pair. Post #13630, the semantics of this variable
   // changes to "stiffness per contact geometry". Therefore, in order to
   // maintain backwards compatibility for sims run pre #13630, we include now a
   // factor of 2 so that when two geometries have the same stiffness, the
-  //
   // combined stiffness reduces to combined_stiffness.
+  //
   // Stiffness in the penalty method is calculated as a combination of
   // individual stiffness parameters per geometry. The variable
   // `combined_stiffness` as calculated here is a combined stiffness, but

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1063,6 +1063,15 @@ void MultibodyPlant<T>::EstimatePointContactParameters(
   const double dissipation = damping_ratio * time_scale / penetration_allowance;
 
   // Final parameters used in the penalty method:
+  //
+  // Before #13630 this method estimated an effective "combined" stiffness.
+  // That is, penalty_method_contact_parameters_.stiffness was the desired
+  // stiffness of the contact pair. Post #13630, the semantics of this variable
+  // changes to "stiffness per contact geometry". Therefore, in order to
+  // maintain backwards compatibility for sims run pre #13630, we include now a
+  // factor of 2 so that when two geometries have the same stiffness, the
+  //
+  // combined stiffness reduces to combined_stiffness.
   // Stiffness in the penalty method is calculated as a combination of
   // individual stiffness parameters per geometry. The variable
   // `combined_stiffness` as calculated here is a combined stiffness, but

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -464,7 +464,7 @@ template <typename T>
 geometry::GeometryId MultibodyPlant<T>::RegisterCollisionGeometry(
     const Body<T>& body, const math::RigidTransform<double>& X_BG,
     const geometry::Shape& shape, const std::string& name,
-    const CoulombFriction<T>& coulomb_friction) {
+    const CoulombFriction<double>& coulomb_friction) {
   geometry::ProximityProperties props;
   props.AddProperty(geometry::internal::kMaterialGroup,
                     geometry::internal::kFriction, coulomb_friction);
@@ -475,7 +475,7 @@ template <typename T>
 geometry::GeometryId MultibodyPlant<T>::RegisterCollisionGeometry(
     const Body<T>& body, const math::RigidTransform<double>& X_BG,
     const geometry::Shape& shape, const std::string& name,
-    const CoulombFriction<T>& coulomb_friction, const T& stiffness,
+    const CoulombFriction<double>& coulomb_friction, const T& stiffness,
     const T& dissipation) {
   geometry::ProximityProperties props;
   props.AddProperty(geometry::internal::kMaterialGroup,

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1215,12 +1215,12 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   geometry::GeometryId RegisterCollisionGeometry(
       const Body<T>& body, const math::RigidTransform<double>& X_BG,
       const geometry::Shape& shape, const std::string& name,
-      const CoulombFriction<T>& coulomb_friction);
+      const CoulombFriction<double>& coulomb_friction);
 
   geometry::GeometryId RegisterCollisionGeometry(
       const Body<T>& body, const math::RigidTransform<double>& X_BG,
       const geometry::Shape& shape, const std::string& name,
-      const CoulombFriction<T>& coulomb_friction, const T& stiffness,
+      const CoulombFriction<double>& coulomb_friction, const T& stiffness,
       const T& dissipation);
 
   /// Returns an array of GeometryId's identifying the different contact

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -1358,9 +1358,10 @@ GTEST_TEST(MultibodyPlantTest, CollisionGeometryRegistration) {
   const RigidBody<double>& sphere1 =
       plant.AddRigidBody("Sphere1", SpatialInertia<double>());
   CoulombFriction<double> sphere1_friction(0.8, 0.5);
-  // estimated parameters for mass=1kg and penetration_tolerance=0.01m
-  const double sphere1_stiffness = 980;
-  const double sphere1_dissipation = 3.2;
+  // estimated parameters for mass=1kg, penetration_tolerance=0.01m
+  // and gravity g=9.8 m/s^2.
+  const double sphere1_stiffness = 980;  // N/m
+  const double sphere1_dissipation = 3.2;  // s/m
   GeometryId sphere1_id = plant.RegisterCollisionGeometry(
       sphere1, RigidTransformd::Identity(), geometry::Sphere(radius),
       "collision", sphere1_friction, sphere1_stiffness, sphere1_dissipation);
@@ -1368,12 +1369,15 @@ GTEST_TEST(MultibodyPlantTest, CollisionGeometryRegistration) {
   geometry::ProximityProperties properties;
   properties.AddProperty("test", "dummy", 7);
   CoulombFriction<double> sphere2_friction(0.7, 0.6);
-  // estimated parameters for mass=1kg and penetration_tolerance=0.05m
-  const double sphere2_stiffness = 196;
-  const double sphere2_dissipation = 1.4;
-  geometry::AddContactMaterial({}, {}, sphere2_friction, &properties);
+  // estimated parameters for mass=1kg, penetration_tolerance=0.05m
+  // and gravity g=9.8 m/s^2.
+  const double sphere2_stiffness = 196;  // N/m
+  const double sphere2_dissipation = 1.4;  // s/m
   properties.AddProperty(geometry::internal::kMaterialGroup,
-                         geometry::internal::kHcStiffness, sphere2_stiffness);
+                         geometry::internal::kFriction, sphere2_friction);
+  properties.AddProperty(geometry::internal::kMaterialGroup,
+                         geometry::internal::kPointStiffness,
+                         sphere2_stiffness);
   properties.AddProperty(geometry::internal::kMaterialGroup,
                          geometry::internal::kHcDissipation,
                          sphere2_dissipation);
@@ -1460,10 +1464,10 @@ GTEST_TEST(MultibodyPlantTest, CollisionGeometryRegistration) {
 
   EXPECT_TRUE(sphere1_props.GetProperty<double>(
                   geometry::internal::kMaterialGroup,
-                  geometry::internal::kHcStiffness) == sphere1_stiffness);
+                  geometry::internal::kPointStiffness) == sphere1_stiffness);
   EXPECT_TRUE(sphere2_props.GetProperty<double>(
                   geometry::internal::kMaterialGroup,
-                  geometry::internal::kHcStiffness) == sphere2_stiffness);
+                  geometry::internal::kPointStiffness) == sphere2_stiffness);
 
   EXPECT_TRUE(sphere1_props.GetProperty<double>(
                   geometry::internal::kMaterialGroup,

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -1360,32 +1360,43 @@ GTEST_TEST(MultibodyPlantTest, CollisionGeometryRegistration) {
   CoulombFriction<double> sphere1_friction(0.8, 0.5);
   // estimated parameters for mass=1kg, penetration_tolerance=0.01m
   // and gravity g=9.8 m/s^2.
-  const double sphere1_stiffness = 980;  // N/m
+  const double sphere1_stiffness = 980;    // N/m
   const double sphere1_dissipation = 3.2;  // s/m
+  geometry::ProximityProperties sphere1_properties;
+  sphere1_properties.AddProperty(geometry::internal::kMaterialGroup,
+                                 geometry::internal::kFriction,
+                                 sphere1_friction);
+  sphere1_properties.AddProperty(geometry::internal::kMaterialGroup,
+                                 geometry::internal::kPointStiffness,
+                                 sphere1_stiffness);
+  sphere1_properties.AddProperty(geometry::internal::kMaterialGroup,
+                                 geometry::internal::kHcDissipation,
+                                 sphere1_dissipation);
   GeometryId sphere1_id = plant.RegisterCollisionGeometry(
       sphere1, RigidTransformd::Identity(), geometry::Sphere(radius),
-      "collision", sphere1_friction, sphere1_stiffness, sphere1_dissipation);
+      "collision", std::move(sphere1_properties));
 
-  geometry::ProximityProperties properties;
-  properties.AddProperty("test", "dummy", 7);
+  geometry::ProximityProperties sphere2_properties;
+  sphere2_properties.AddProperty("test", "dummy", 7);
   CoulombFriction<double> sphere2_friction(0.7, 0.6);
   // estimated parameters for mass=1kg, penetration_tolerance=0.05m
   // and gravity g=9.8 m/s^2.
-  const double sphere2_stiffness = 196;  // N/m
+  const double sphere2_stiffness = 196;    // N/m
   const double sphere2_dissipation = 1.4;  // s/m
-  properties.AddProperty(geometry::internal::kMaterialGroup,
-                         geometry::internal::kFriction, sphere2_friction);
-  properties.AddProperty(geometry::internal::kMaterialGroup,
-                         geometry::internal::kPointStiffness,
-                         sphere2_stiffness);
-  properties.AddProperty(geometry::internal::kMaterialGroup,
-                         geometry::internal::kHcDissipation,
-                         sphere2_dissipation);
+  sphere2_properties.AddProperty(geometry::internal::kMaterialGroup,
+                                 geometry::internal::kFriction,
+                                 sphere2_friction);
+  sphere2_properties.AddProperty(geometry::internal::kMaterialGroup,
+                                 geometry::internal::kPointStiffness,
+                                 sphere2_stiffness);
+  sphere2_properties.AddProperty(geometry::internal::kMaterialGroup,
+                                 geometry::internal::kHcDissipation,
+                                 sphere2_dissipation);
   const RigidBody<double>& sphere2 =
       plant.AddRigidBody("Sphere2", SpatialInertia<double>());
   GeometryId sphere2_id = plant.RegisterCollisionGeometry(
       sphere2, RigidTransformd::Identity(), geometry::Sphere(radius),
-      "collision", std::move(properties));
+      "collision", std::move(sphere2_properties));
 
   // Confirm externally-defined proximity properties propagate through.
   {


### PR DESCRIPTION
This PR adds functionality to store penalty method contact parameters on a per-geometry basis in SceneGraph, as well as use these parameters in MBP contact computations. This effectively allows a user to modify these parameters in a Context, via SceneGraph (GeometryState).

See #13289.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13630)
<!-- Reviewable:end -->
