### PR TITLE
yaml: Permit writing variant values beyond the 0'th index

### DIFF
--- a/common/yaml/BUILD.bazel
+++ b/common/yaml/BUILD.bazel
@@ -38,6 +38,7 @@ drake_cc_library(
     deps = [
         "//common:essential",
         "//common:name_value",
+        "//common:nice_type_name",
         "//third_party/com_github_jbeder_yaml_cpp:emitfromevents",
         "@yaml_cpp",
     ],
@@ -71,6 +72,7 @@ drake_cc_googletest(
     deps = [
         ":yaml_write_archive",
         "//common:name_value",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/common/yaml/test/yaml_write_archive_test.cc
+++ b/common/yaml/test/yaml_write_archive_test.cc
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/name_value.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 
 using drake::yaml::YamlWriteArchive;
 
@@ -352,6 +353,14 @@ TEST_F(YamlWriteArchiveTest, Variant) {
   };
 
   test(Variant3(std::string("foo")), "foo");
+  test(Variant3(DoubleStruct{1.0}), "!DoubleStruct\n    value: 1.0");
+
+  // TODO(jwnimmer-tri) We'd like to see "!!float 1.0" here, but our writer
+  // does not yet support that output syntax.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+    Save(VariantStruct{double{1.0}}),
+    std::exception,
+    "Cannot YamlWriteArchive the variant type double with a non-zero index");
 }
 
 TEST_F(YamlWriteArchiveTest, EigenVector) {

--- a/common/yaml/yaml_write_archive.h
+++ b/common/yaml/yaml_write_archive.h
@@ -16,6 +16,7 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/name_value.h"
+#include "drake/common/nice_type_name.h"
 
 namespace drake {
 namespace yaml {
@@ -259,26 +260,42 @@ class YamlWriteArchive final {
     // the visit_order a second time, duplicating work performed by the Visit()
     // for the *wrapped* value.  We'll undo that duplication now.
     this->visit_order_.pop_back();
-}
+  }
 
   template <typename NVP>
   void VisitVariant(const NVP& nvp) {
+    // Visit the unpacked variant as if it weren't wrapped in variant<>,
+    // setting a YAML type tag iff required.
+    const char* const name = nvp.name();
     auto& variant = *nvp.value();
-    if (variant.index() != 0) {
-      throw std::runtime_error(fmt::format(
-          "Cannot YamlWriteArchive the variant field {} "
-          "with a non-zero type index {}",
-          nvp.name(), variant.index()));
-    }
+    const size_t index = variant.index();
+    std::visit([this, name, index](auto&& unwrapped) {
+      this->Visit(drake::MakeNameValue(name, &unwrapped));
+      if (index != 0) {
+        using T = decltype(unwrapped);
+        root_[name].SetTag(YamlWriteArchive::GetVariantTag<T>());
+      }
+    }, variant);
 
-    // Visit the unpacked variant as if it weren't wrapped in variant<>.
-    auto& unboxed = std::get<0>(variant);
-    this->Visit(drake::MakeNameValue(nvp.name(), &unboxed));
-
-    // The above call to Visit() for the *unwrapped* value pushed our name onto
-    // the visit_order a second time, duplicating work performed by the Visit()
-    // for the *wrapped* value.  We'll undo that duplication now.
+    // The above call to this->Visit() for the *unwrapped* value pushed our
+    // name onto the visit_order a second time, duplicating work performed by
+    // the Visit() for the *wrapped* value.  We'll undo that duplication now.
     this->visit_order_.pop_back();
+  }
+
+  template <typename T>
+  static std::string GetVariantTag() {
+    const std::string full_name = NiceTypeName::Get<T>();
+    if ((full_name == "std::string")
+        || (full_name == "double")
+        || (full_name == "int")) {
+      // TODO(jwnimmer-tri) Add support for well-known YAML primitive types
+      // within variants (when placed other than at the 0'th index).
+      throw std::runtime_error(fmt::format(
+          "Cannot YamlWriteArchive the variant type {} with a non-zero index",
+          full_name));
+    }
+    return NiceTypeName::RemoveNamespaces(full_name);
   }
 
   template <typename T>

--- a/third_party/com_github_jbeder_yaml_cpp/BUILD.bazel
+++ b/third_party/com_github_jbeder_yaml_cpp/BUILD.bazel
@@ -9,6 +9,9 @@ licenses(["notice"])  # MIT
 # hidden on Ubuntu 20.04 (Focal) where, due to a quilt patch, the default
 # visibility is "hidden" and only declarations decorated with YAML_CPP_API have
 # "default" (i.e., external) visibility.
+#
+# Furthermore, we need to tweak the YAML tag output so we've applied a 1-line
+# patch to our vendored copy.
 cc_library(
     name = "emitfromevents",
     srcs = ["src/emitfromevents.cpp"],

--- a/third_party/com_github_jbeder_yaml_cpp/src/emitfromevents.cpp
+++ b/third_party/com_github_jbeder_yaml_cpp/src/emitfromevents.cpp
@@ -109,8 +109,14 @@ void EmitFromEvents::BeginNode() {
 }
 
 void EmitFromEvents::EmitProps(const std::string& tag, anchor_t anchor) {
-  if (!tag.empty() && tag != "?" && tag != "!")
-    m_emitter << VerbatimTag(tag);
+  if (!tag.empty() && tag != "?" && tag != "!") {
+    // N.B. The upstream yaml-cpp uses VerbatimTag here, but Drake has patched
+    // this file to use LocalTag instead.  Upstream support for custom tags
+    // during emitting is "pretty bad" (i.e., non-existent); for details see
+    // https://github.com/jbeder/yaml-cpp/issues/311 and
+    // https://github.com/jbeder/yaml-cpp/issues/447.
+    m_emitter << LocalTag(tag);
+  }
   if (anchor)
     m_emitter << Anchor(ToString(anchor));
 }


### PR DESCRIPTION
Previously yaml_read_archive could read variants using tags, but could only ever write out the default (first) variant type.  This brings yaml_write_archive up to par.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13631)
<!-- Reviewable:end -->
