### PR TITLE
[render] Extend camera intrinsics into geometry and geometry/render

### DIFF
--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -27,6 +27,8 @@ using internal::InternalGeometry;
 using internal::ProximityEngine;
 using math::RigidTransform;
 using math::RigidTransformd;
+using render::ColorRenderCamera;
+using render::DepthRenderCamera;
 using std::make_pair;
 using std::make_unique;
 using std::move;
@@ -943,9 +945,8 @@ void GeometryState<T>::RenderColorImage(const render::CameraProperties& camera,
 
 template <typename T>
 void GeometryState<T>::RenderDepthImage(
-    const render::DepthCameraProperties& camera,
-    FrameId parent_frame, const RigidTransformd& X_PC,
-    ImageDepth32F* depth_image_out) const {
+    const render::DepthCameraProperties& camera, FrameId parent_frame,
+    const RigidTransformd& X_PC, ImageDepth32F* depth_image_out) const {
   const RigidTransformd X_WC = GetDoubleWorldPose(parent_frame) * X_PC;
   const render::RenderEngine& engine =
       GetRenderEngineOrThrow(camera.renderer_name);
@@ -966,6 +967,46 @@ void GeometryState<T>::RenderLabelImage(const render::CameraProperties& camera,
   // See note in RenderColorImage() about this const cast.
   const_cast<render::RenderEngine&>(engine).UpdateViewpoint(X_WC);
   engine.RenderLabelImage(camera, show_window, label_image_out);
+}
+
+template <typename T>
+void GeometryState<T>::RenderColorImage(const ColorRenderCamera& camera,
+                                        FrameId parent_frame,
+                                        const RigidTransformd& X_PC,
+                                        ImageRgba8U* color_image_out) const {
+  const RigidTransformd X_WC = GetDoubleWorldPose(parent_frame) * X_PC;
+  const render::RenderEngine& engine =
+      GetRenderEngineOrThrow(camera.core().renderer_name());
+  // TODO(SeanCurtis-TRI): Invoke UpdateViewpoint() as part of a calc cache
+  //  entry. Challenge: how to do that with a parameter passed here?
+  const_cast<render::RenderEngine&>(engine).UpdateViewpoint(X_WC);
+  engine.RenderColorImage(camera, color_image_out);
+}
+
+template <typename T>
+void GeometryState<T>::RenderDepthImage(const DepthRenderCamera& camera,
+                                        FrameId parent_frame,
+                                        const RigidTransformd& X_PC,
+                                        ImageDepth32F* depth_image_out) const {
+  const RigidTransformd X_WC = GetDoubleWorldPose(parent_frame) * X_PC;
+  const render::RenderEngine& engine =
+      GetRenderEngineOrThrow(camera.core().renderer_name());
+  // See note in RenderColorImage() about this const cast.
+  const_cast<render::RenderEngine&>(engine).UpdateViewpoint(X_WC);
+  engine.RenderDepthImage(camera, depth_image_out);
+}
+
+template <typename T>
+void GeometryState<T>::RenderLabelImage(const ColorRenderCamera& camera,
+                                        FrameId parent_frame,
+                                        const RigidTransformd& X_PC,
+                                        ImageLabel16I* label_image_out) const {
+  const RigidTransformd X_WC = GetDoubleWorldPose(parent_frame) * X_PC;
+  const render::RenderEngine& engine =
+      GetRenderEngineOrThrow(camera.core().renderer_name());
+  // See note in RenderColorImage() about this const cast.
+  const_cast<render::RenderEngine&>(engine).UpdateViewpoint(X_WC);
+  engine.RenderLabelImage(camera, label_image_out);
 }
 
 template <typename T>

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -19,6 +19,7 @@
 #include "drake/geometry/internal_frame.h"
 #include "drake/geometry/internal_geometry.h"
 #include "drake/geometry/proximity_engine.h"
+#include "drake/geometry/render/render_camera.h"
 #include "drake/geometry/render/render_engine.h"
 #include "drake/geometry/utilities.h"
 
@@ -508,6 +509,24 @@ class GeometryState {
   void RenderLabelImage(const render::CameraProperties& camera,
                         FrameId parent_frame, const math::RigidTransformd& X_PC,
                         bool show_window,
+                        systems::sensors::ImageLabel16I* label_image_out) const;
+
+  /** Implementation of QueryObject::RenderColorImage().
+   @pre All poses have already been updated.  */
+  void RenderColorImage(const render::ColorRenderCamera& camera,
+                        FrameId parent_frame, const math::RigidTransformd& X_PC,
+                        systems::sensors::ImageRgba8U* color_image_out) const;
+
+  /** Implementation of QueryObject::RenderDepthImage().
+   @pre All poses have already been updated.  */
+  void RenderDepthImage(const render::DepthRenderCamera& camera,
+                        FrameId parent_frame, const math::RigidTransformd& X_PC,
+                        systems::sensors::ImageDepth32F* depth_image_out) const;
+
+  /** Implementation of QueryObject::RenderLabelImage().
+   @pre All poses have already been updated.  */
+  void RenderLabelImage(const render::ColorRenderCamera& camera,
+                        FrameId parent_frame, const math::RigidTransformd& X_PC,
                         systems::sensors::ImageLabel16I* label_image_out) const;
 
   //@}

--- a/geometry/query_object.cc
+++ b/geometry/query_object.cc
@@ -10,7 +10,9 @@ namespace geometry {
 using math::RigidTransform;
 using math::RigidTransformd;
 using render::CameraProperties;
+using render::ColorRenderCamera;
 using render::DepthCameraProperties;
+using render::DepthRenderCamera;
 using systems::sensors::ImageDepth32F;
 using systems::sensors::ImageLabel16I;
 using systems::sensors::ImageRgba8U;
@@ -172,7 +174,31 @@ void QueryObject<T>::RenderColorImage(const CameraProperties& camera,
 }
 
 template <typename T>
+void QueryObject<T>::RenderColorImage(const ColorRenderCamera& camera,
+                                      FrameId parent_frame,
+                                      const RigidTransformd& X_PC,
+                                      ImageRgba8U* color_image_out) const {
+  ThrowIfNotCallable();
+
+  FullPoseUpdate();
+  const GeometryState<T>& state = geometry_state();
+  return state.RenderColorImage(camera, parent_frame, X_PC, color_image_out);
+}
+
+template <typename T>
 void QueryObject<T>::RenderDepthImage(const DepthCameraProperties& camera,
+                                      FrameId parent_frame,
+                                      const RigidTransformd& X_PC,
+                                      ImageDepth32F* depth_image_out) const {
+  ThrowIfNotCallable();
+
+  FullPoseUpdate();
+  const GeometryState<T>& state = geometry_state();
+  return state.RenderDepthImage(camera, parent_frame, X_PC, depth_image_out);
+}
+
+template <typename T>
+void QueryObject<T>::RenderDepthImage(const DepthRenderCamera& camera,
                                       FrameId parent_frame,
                                       const RigidTransformd& X_PC,
                                       ImageDepth32F* depth_image_out) const {
@@ -195,6 +221,18 @@ void QueryObject<T>::RenderLabelImage(const CameraProperties& camera,
   const GeometryState<T>& state = geometry_state();
   return state.RenderLabelImage(camera, parent_frame, X_PC, show_window,
                                 label_image_out);
+}
+
+template <typename T>
+void QueryObject<T>::RenderLabelImage(const ColorRenderCamera& camera,
+                                      FrameId parent_frame,
+                                      const RigidTransformd& X_PC,
+                                      ImageLabel16I* label_image_out) const {
+  ThrowIfNotCallable();
+
+  FullPoseUpdate();
+  const GeometryState<T>& state = geometry_state();
+  return state.RenderLabelImage(camera, parent_frame, X_PC, label_image_out);
 }
 
 template <typename T>

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -9,6 +9,7 @@
 #include "drake/geometry/query_results/penetration_as_point_pair.h"
 #include "drake/geometry/query_results/signed_distance_pair.h"
 #include "drake/geometry/query_results/signed_distance_to_point.h"
+#include "drake/geometry/render/render_camera.h"
 #include "drake/geometry/scene_graph_inspector.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/systems/framework/context.h"
@@ -480,6 +481,10 @@ class QueryObject {
                         bool show_window,
                         systems::sensors::ImageRgba8U* color_image_out) const;
 
+  void RenderColorImage(const render::ColorRenderCamera& camera,
+                        FrameId parent_frame, const math::RigidTransformd& X_PC,
+                        systems::sensors::ImageRgba8U* color_image_out) const;
+
   /** Renders a depth image for the given `camera` posed with respect to the
    indicated parent frame P.
 
@@ -496,6 +501,10 @@ class QueryObject {
                         const math::RigidTransformd& X_PC,
                         systems::sensors::ImageDepth32F* depth_image_out) const;
 
+  void RenderDepthImage(const render::DepthRenderCamera& camera,
+                        FrameId parent_frame, const math::RigidTransformd& X_PC,
+                        systems::sensors::ImageDepth32F* depth_image_out) const;
+
   /** Renders a label image for the given `camera` posed with respect to the
    indicated parent frame P.
 
@@ -508,6 +517,10 @@ class QueryObject {
                         FrameId parent_frame,
                         const math::RigidTransformd& X_PC,
                         bool show_window,
+                        systems::sensors::ImageLabel16I* label_image_out) const;
+
+  void RenderLabelImage(const render::ColorRenderCamera& camera,
+                        FrameId parent_frame, const math::RigidTransformd& X_PC,
                         systems::sensors::ImageLabel16I* label_image_out) const;
 
 

--- a/geometry/render/render_engine.cc
+++ b/geometry/render/render_engine.cc
@@ -2,13 +2,20 @@
 
 #include <typeinfo>
 
+#include <fmt/format.h>
+
 #include "drake/common/nice_type_name.h"
+#include "drake/common/text_logging.h"
 
 namespace drake {
 namespace geometry {
 namespace render {
 
 using math::RigidTransformd;
+using systems::sensors::CameraInfo;
+using systems::sensors::ImageRgba8U;
+using systems::sensors::ImageDepth32F;
+using systems::sensors::ImageLabel16I;
 
 std::unique_ptr<RenderEngine> RenderEngine::Clone() const {
   std::unique_ptr<RenderEngine> clone(DoClone());
@@ -72,6 +79,57 @@ RenderLabel RenderEngine::GetRenderLabelOrThrow(
         "missing render labels in the properties.");
   }
   return label;
+}
+
+void RenderEngine::DoRenderColorImage(const ColorRenderCamera& camera,
+                                      ImageRgba8U* color_image_out) const {
+  // TODO(SeanCurtis-TRI): Consider modifying this warning (and those for the
+  //  other image types) so that it only gets broadcast if the intrinsics *have*
+  //  properties that would lose information.
+  static const logging::Warn log_once(
+      "{}::DoRenderColorImage has not been implemented; using simple camera "
+      "model variant; if the camera intrinsics have anisotropic focal lengths "
+      "or a non-centered principal point, those details will be lost.",
+      NiceTypeName::Get(*this));
+
+  const CameraInfo& intrinsics = camera.core().intrinsics();
+  CameraProperties simple_props{intrinsics.width(), intrinsics.height(),
+                                intrinsics.fov_y(),
+                                camera.core().renderer_name()};
+  RenderColorImage(simple_props, camera.show_window(), color_image_out);
+}
+
+void RenderEngine::DoRenderDepthImage(const DepthRenderCamera& camera,
+                                      ImageDepth32F* depth_image_out) const {
+  static const logging::Warn log_once(
+      "{}::DoRenderDepthImage has not been implemented; using simple camera "
+      "model variant; if the camera intrinsics have anisotropic focal lengths "
+      "or a non-centered principal point, those details will be lost.",
+      NiceTypeName::Get(*this));
+
+  const CameraInfo& intrinsics = camera.core().intrinsics();
+  DepthCameraProperties simple_props{intrinsics.width(),
+                                     intrinsics.height(),
+                                     intrinsics.fov_y(),
+                                     camera.core().renderer_name(),
+                                     camera.depth_range().min_depth(),
+                                     camera.depth_range().max_depth()};
+  RenderDepthImage(simple_props, depth_image_out);
+}
+
+void RenderEngine::DoRenderLabelImage(const ColorRenderCamera& camera,
+                                      ImageLabel16I* label_image_out) const {
+  static const logging::Warn log_once(
+      "{}::DoRenderLabelImage has not been implemented; using simple camera "
+      "model variant; if the camera intrinsics have anisotropic focal lengths "
+      "or a non-centered principal point, those details will be lost.",
+      NiceTypeName::Get(*this));
+
+  const CameraInfo& intrinsics = camera.core().intrinsics();
+  CameraProperties simple_props{intrinsics.width(), intrinsics.height(),
+                                intrinsics.fov_y(),
+                                camera.core().renderer_name()};
+  RenderLabelImage(simple_props, camera.show_window(), label_image_out);
 }
 
 void RenderEngine::SetDefaultLightPosition(const Vector3<double>&) {}

--- a/geometry/test/query_object_test.cc
+++ b/geometry/test/query_object_test.cc
@@ -16,7 +16,9 @@ namespace geometry {
 
 using Eigen::Vector3d;
 using math::RigidTransformd;
+using render::ColorRenderCamera;
 using render::DepthCameraProperties;
+using render::DepthRenderCamera;
 using std::make_unique;
 using std::unique_ptr;
 using systems::Context;
@@ -178,19 +180,30 @@ TEST_F(QueryObjectTest, DefaultQueryThrows) {
   EXPECT_DEFAULT_ERROR(default_object.X_WG(GeometryId::get_new_id()));
 
   // Render queries.
-  DepthCameraProperties properties(2, 2, M_PI, "dummy_renderer", 0.1, 5.0);
-  RigidTransformd X_WC = RigidTransformd::Identity();
+  const ColorRenderCamera color_camera{
+      {"n/a", {2, 2, M_PI}, {0.1, 10}, RigidTransformd{}}, false};
+  const DepthRenderCamera depth_camera{
+      {"n/a", {2, 2, M_PI}, {0.1, 10}, RigidTransformd{}}, {0.2, 0.9}};
+  const DepthCameraProperties properties(2, 2, M_PI, "dummy_renderer", 0.1,
+                                         5.0);
+  const RigidTransformd X_WC = RigidTransformd::Identity();
   ImageRgba8U color;
   EXPECT_DEFAULT_ERROR(default_object.RenderColorImage(
       properties, FrameId::get_new_id(), X_WC, false, &color));
+  EXPECT_DEFAULT_ERROR(default_object.RenderColorImage(
+      color_camera, FrameId::get_new_id(), X_WC, &color));
 
   ImageDepth32F depth;
   EXPECT_DEFAULT_ERROR(default_object.RenderDepthImage(
       properties, FrameId::get_new_id(), X_WC, &depth));
+  EXPECT_DEFAULT_ERROR(default_object.RenderDepthImage(
+      depth_camera, FrameId::get_new_id(), X_WC, &depth));
 
   ImageLabel16I label;
   EXPECT_DEFAULT_ERROR(default_object.RenderLabelImage(
       properties, FrameId::get_new_id(), X_WC, false, &label));
+  EXPECT_DEFAULT_ERROR(default_object.RenderLabelImage(
+      color_camera, FrameId::get_new_id(), X_WC, &label));
 
   EXPECT_DEFAULT_ERROR(default_object.GetRenderEngineByName("dummy"));
 

--- a/systems/sensors/rgbd_sensor.h
+++ b/systems/sensors/rgbd_sensor.h
@@ -144,12 +144,8 @@ class RgbdSensor final : public LeafSystem<double> {
              const geometry::render::DepthCameraProperties& properties,
              const CameraPoses& camera_poses = {}, bool show_window = false);
 
-  /** Constructs an %RgbdSensor with a fully specified render camera model for
+  /** Constructs an %RgbdSensor with fully specified render camera models for
    both color/label and depth cameras.
-
-   @warning Currently, only "simple" cameras are supported. If the camera
-            intrinsics is not compatible with a simple camera model, a warning
-            will be printed and the camera will be "simplified".
    @pydrake_mkdoc_identifier{individual_intrinsics}  */
   RgbdSensor(geometry::FrameId parent_id, const math::RigidTransformd& X_PB,
              geometry::render::ColorRenderCamera color_camera,


### PR DESCRIPTION
This ties the intrinsics API defined in #13557 into `geometry`. 

 - RenderEngine given new API to handle full camera model specification.
   - handles sub-classes that haven't implemented full intrinsics by defaulting to legacy rendering (with a warning about throwing out information).
   - The "simple" camera model now invokes the full-intrinsics version.
 - Geometry infrastructure extended to exercise render engine API
   - QueryObject and GeometryState have appropriate APIs.
   - New API essentially duplicates old API. Deprecation of old API will come in follow up PR.
 - RgbdSensor now assumes RenderEngine handles full intrinsics and no longer protects it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13635)
<!-- Reviewable:end -->
