### PR TITLE
Python bindings for CalcBiasSpatialAcceleration, CalcBiasTranslationalAcceleration

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -471,8 +471,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
                 JacobianWrtVariable with_respect_to, const Frame<T>& frame_F,
                 const Eigen::Ref<const Vector3<T>>& p_BoBp_B,
                 const Frame<T>& frame_A, const Frame<T>& frame_E) {
-              return self->CalcBiasSpatialAcceleration(context,
-                  with_respect_to, frame_F, p_BoBp_B, frame_A, frame_E);
+              return self->CalcBiasSpatialAcceleration(context, with_respect_to,
+                  frame_F, p_BoBp_B, frame_A, frame_E);
             },
             py::arg("context"), py::arg("with_respect_to"), py::arg("frame_F"),
             py::arg("p_BoBp_B"), py::arg("frame_A"), py::arg("frame_E"),

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -471,10 +471,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
                 JacobianWrtVariable with_respect_to, const Frame<T>& frame_B,
                 const Eigen::Ref<const Vector3<T>>& p_BoBp_B,
                 const Frame<T>& frame_A, const Frame<T>& frame_E) {
-              return self
-                  ->CalcBiasSpatialAcceleration(context, with_respect_to,
-                      frame_B, p_BoBp_B, frame_A, frame_E)
-                  .get_coeffs();
+              return self->CalcBiasSpatialAcceleration(context, with_respect_to,
+                  frame_B, p_BoBp_B, frame_A, frame_E);
             },
             py::arg("context"), py::arg("with_respect_to"), py::arg("frame_B"),
             py::arg("p_BoBp_B"), py::arg("frame_A"), py::arg("frame_E"),

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -471,8 +471,10 @@ void DoScalarDependentDefinitions(py::module m, T) {
                 JacobianWrtVariable with_respect_to, const Frame<T>& frame_B,
                 const Eigen::Ref<const Vector3<T>>& p_BoBp_B,
                 const Frame<T>& frame_A, const Frame<T>& frame_E) {
-              return self->CalcBiasSpatialAcceleration(context, with_respect_to,
-                  frame_B, p_BoBp_B, frame_A, frame_E);
+              return self
+                  ->CalcBiasSpatialAcceleration(context, with_respect_to,
+                      frame_B, p_BoBp_B, frame_A, frame_E)
+                  .get_coeffs();
             },
             py::arg("context"), py::arg("with_respect_to"), py::arg("frame_B"),
             py::arg("p_BoBp_B"), py::arg("frame_A"), py::arg("frame_E"),

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -468,25 +468,25 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def(
             "CalcBiasSpatialAcceleration",
             [](const Class* self, const systems::Context<T>& context,
-                JacobianWrtVariable with_respect_to, const Frame<T>& frame_F,
+                JacobianWrtVariable with_respect_to, const Frame<T>& frame_B,
                 const Eigen::Ref<const Vector3<T>>& p_BoBp_B,
                 const Frame<T>& frame_A, const Frame<T>& frame_E) {
               return self->CalcBiasSpatialAcceleration(context, with_respect_to,
-                  frame_F, p_BoBp_B, frame_A, frame_E);
+                  frame_B, p_BoBp_B, frame_A, frame_E);
             },
-            py::arg("context"), py::arg("with_respect_to"), py::arg("frame_F"),
+            py::arg("context"), py::arg("with_respect_to"), py::arg("frame_B"),
             py::arg("p_BoBp_B"), py::arg("frame_A"), py::arg("frame_E"),
             cls_doc.CalcBiasSpatialAcceleration.doc)
         .def(
             "CalcBiasTranslationalAcceleration",
             [](const Class* self, const Context<T>& context,
-                JacobianWrtVariable with_respect_to, const Frame<T>& frame_F,
+                JacobianWrtVariable with_respect_to, const Frame<T>& frame_B,
                 const Eigen::Ref<const Matrix3X<T>>& p_BoBi_B,
                 const Frame<T>& frame_A, const Frame<T>& frame_E) {
               return self->CalcBiasTranslationalAcceleration(context,
-                  with_respect_to, frame_F, p_BoBi_B, frame_A, frame_E);
+                  with_respect_to, frame_B, p_BoBi_B, frame_A, frame_E);
             },
-            py::arg("context"), py::arg("with_respect_to"), py::arg("frame_F"),
+            py::arg("context"), py::arg("with_respect_to"), py::arg("frame_B"),
             py::arg("p_BoBi_B"), py::arg("frame_A"), py::arg("frame_E"),
             cls_doc.CalcBiasTranslationalAcceleration.doc)
         .def(

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -466,6 +466,30 @@ void DoScalarDependentDefinitions(py::module m, T) {
             },
             py::arg("context"))
         .def(
+            "CalcBiasSpatialAcceleration",
+            [](const Class* self, const systems::Context<T>& context,
+                JacobianWrtVariable with_respect_to, const Frame<T>& frame_F,
+                const Eigen::Ref<const Vector3<T>>& p_BoBp_B,
+                const Frame<T>& frame_A, const Frame<T>& frame_E) {
+              return self->CalcBiasSpatialAcceleration(context,
+                  with_respect_to, frame_F, p_BoBp_B, frame_A, frame_E);
+            },
+            py::arg("context"), py::arg("with_respect_to"), py::arg("frame_F"),
+            py::arg("p_BoBp_B"), py::arg("frame_A"), py::arg("frame_E"),
+            cls_doc.CalcBiasSpatialAcceleration.doc)
+        .def(
+            "CalcBiasTranslationalAcceleration",
+            [](const Class* self, const Context<T>& context,
+                JacobianWrtVariable with_respect_to, const Frame<T>& frame_F,
+                const Eigen::Ref<const Matrix3X<T>>& p_BoBi_B,
+                const Frame<T>& frame_A, const Frame<T>& frame_E) {
+              return self->CalcBiasTranslationalAcceleration(context,
+                  with_respect_to, frame_F, p_BoBi_B, frame_A, frame_E);
+            },
+            py::arg("context"), py::arg("with_respect_to"), py::arg("frame_F"),
+            py::arg("p_BoBi_B"), py::arg("frame_A"), py::arg("frame_E"),
+            cls_doc.CalcBiasTranslationalAcceleration.doc)
+        .def(
             "CalcBiasTerm",
             [](const Class* self, const Context<T>& context) {
               VectorX<T> Cv(self->num_velocities());

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -586,6 +586,16 @@ class TestPlant(unittest.TestCase):
                 p_BoBi_B=np.zeros(3), frame_A=world_frame, frame_E=world_frame)
             self.assert_sane(Js_v_AB_E)
             self.assertEqual(Js_v_AB_E.shape, (3, nw))
+            Abias_V_AFp = plant.CalcBiasSpatialAcceleration(
+                context=context, with_respect_to=wrt, frame_F=base_frame,
+                p_BoBp_B=np.zeros(3), frame_A=world_frame, frame_E=world_frame)
+            self.assert_sane(Abias_V_AFp)
+            self.assertEqual(Abias_V_AFp.shape, (3, nw))
+            Abias_v_AFp = plant.CalcBiasTranslationalAcceleration(
+                context=context, with_respect_to=wrt, frame_F=base_frame,
+                p_BoBi_B=np.zeros(3), frame_A=world_frame, frame_E=world_frame)
+            self.assert_sane(Abias_v_AFp)
+            self.assertEqual(Abias_v_AFp.shape, (3, nw))
 
             Js_v_AB_E = plant.CalcJacobianTranslationalVelocity(
                 context=context, with_respect_to=wrt, frame_B=base_frame,

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -587,16 +587,18 @@ class TestPlant(unittest.TestCase):
             self.assert_sane(Js_v_AB_E)
             self.assertEqual(Js_v_AB_E.shape, (3, nw))
 
-        Abias_V_AFp = plant.CalcBiasSpatialAcceleration(
-            context=context, with_respect_to=JacobianWrtVariable.kV, frame_B=base_frame,
-            p_BoBp_B=np.zeros(3), frame_A=world_frame, frame_E=world_frame)
-        self.assert_sane(Abias_V_AFp)
-        self.assertEqual(Abias_V_AFp.shape, (3, nv))
-        Abias_v_AFp = plant.CalcBiasTranslationalAcceleration(
-            context=context, with_respect_to=JacobianWrtVariable.kV, frame_B=base_frame,
-            p_BoBi_B=np.zeros(3), frame_A=world_frame, frame_E=world_frame)
-        self.assert_sane(Abias_v_AFp)
-        self.assertEqual(Abias_v_AFp.shape, (3, nv))
+        AsBias_ABp = plant.CalcBiasSpatialAcceleration(
+            context=context, with_respect_to=JacobianWrtVariable.kV,
+            frame_B=base_frame, p_BoBp_B=np.zeros(3), frame_A=world_frame,
+            frame_E=world_frame)
+        self.assert_sane(AsBias_ABp)
+        self.assertEqual(AsBias_ABp.shape, (6,))
+        asBias_ABi = plant.CalcBiasTranslationalAcceleration(
+            context=context, with_respect_to=JacobianWrtVariable.kV,
+            frame_B=base_frame, p_BoBi_B=np.zeros(3), frame_A=world_frame,
+            frame_E=world_frame)
+        self.assert_sane(asBias_ABi)
+        self.assertEqual(asBias_ABi.shape, (3, 1))
 
             Js_v_AB_E = plant.CalcJacobianTranslationalVelocity(
                 context=context, with_respect_to=wrt, frame_B=base_frame,

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -591,13 +591,13 @@ class TestPlant(unittest.TestCase):
             context=context, with_respect_to=JacobianWrtVariable.kV,
             frame_B=base_frame, p_BoBp_B=np.zeros(3), frame_A=world_frame,
             frame_E=world_frame)
-        self.assert_sane(AsBias_ABp)
+        self.assert_sane(AsBias_ABp, nonzero=False)
         self.assertEqual(AsBias_ABp.shape, (6,))
         asBias_ABi = plant.CalcBiasTranslationalAcceleration(
             context=context, with_respect_to=JacobianWrtVariable.kV,
             frame_B=base_frame, p_BoBi_B=np.zeros(3), frame_A=world_frame,
             frame_E=world_frame)
-        self.assert_sane(asBias_ABi)
+        self.assert_sane(asBias_ABi, nonzero=False)
         self.assertEqual(asBias_ABi.shape, (3, 1))
 
             Js_v_AB_E = plant.CalcJacobianTranslationalVelocity(

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -586,16 +586,17 @@ class TestPlant(unittest.TestCase):
                 p_BoBi_B=np.zeros(3), frame_A=world_frame, frame_E=world_frame)
             self.assert_sane(Js_v_AB_E)
             self.assertEqual(Js_v_AB_E.shape, (3, nw))
-            Abias_V_AFp = plant.CalcBiasSpatialAcceleration(
-                context=context, with_respect_to=wrt, frame_B=base_frame,
-                p_BoBp_B=np.zeros(3), frame_A=world_frame, frame_E=world_frame)
-            self.assert_sane(Abias_V_AFp)
-            self.assertEqual(Abias_V_AFp.shape, (3, nw))
-            Abias_v_AFp = plant.CalcBiasTranslationalAcceleration(
-                context=context, with_respect_to=wrt, frame_B=base_frame,
-                p_BoBi_B=np.zeros(3), frame_A=world_frame, frame_E=world_frame)
-            self.assert_sane(Abias_v_AFp)
-            self.assertEqual(Abias_v_AFp.shape, (3, nw))
+
+        Abias_V_AFp = plant.CalcBiasSpatialAcceleration(
+            context=context, with_respect_to=JacobianWrtVariable.kV, frame_B=base_frame,
+            p_BoBp_B=np.zeros(3), frame_A=world_frame, frame_E=world_frame)
+        self.assert_sane(Abias_V_AFp)
+        self.assertEqual(Abias_V_AFp.shape, (3, nv))
+        Abias_v_AFp = plant.CalcBiasTranslationalAcceleration(
+            context=context, with_respect_to=JacobianWrtVariable.kV, frame_B=base_frame,
+            p_BoBi_B=np.zeros(3), frame_A=world_frame, frame_E=world_frame)
+        self.assert_sane(Abias_v_AFp)
+        self.assertEqual(Abias_v_AFp.shape, (3, nv))
 
             Js_v_AB_E = plant.CalcJacobianTranslationalVelocity(
                 context=context, with_respect_to=wrt, frame_B=base_frame,

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -587,6 +587,13 @@ class TestPlant(unittest.TestCase):
             self.assert_sane(Js_v_AB_E)
             self.assertEqual(Js_v_AB_E.shape, (3, nw))
 
+            Js_v_AB_E = plant.CalcJacobianTranslationalVelocity(
+                context=context, with_respect_to=wrt, frame_B=base_frame,
+                p_BoBi_B=np.zeros((3, 3)), frame_A=world_frame,
+                frame_E=world_frame)
+            self.assert_sane(Js_v_AB_E)
+            self.assertEqual(Js_v_AB_E.shape, (9, nw))
+
         AsBias_ABp_E = plant.CalcBiasSpatialAcceleration(
             context=context, with_respect_to=JacobianWrtVariable.kV,
             frame_B=base_frame, p_BoBp_B=np.zeros(3), frame_A=world_frame,
@@ -599,13 +606,6 @@ class TestPlant(unittest.TestCase):
             frame_E=world_frame)
         self.assert_sane(asBias_ABi_E, nonzero=False)
         self.assertEqual(asBias_ABi_E.shape, (3, 1))
-
-            Js_v_AB_E = plant.CalcJacobianTranslationalVelocity(
-                context=context, with_respect_to=wrt, frame_B=base_frame,
-                p_BoBi_B=np.zeros((3, 3)), frame_A=world_frame,
-                frame_E=world_frame)
-            self.assert_sane(Js_v_AB_E)
-            self.assertEqual(Js_v_AB_E.shape, (9, nw))
 
         # Compute body pose.
         X_WBase = plant.EvalBodyPoseInWorld(context, base)

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -587,18 +587,18 @@ class TestPlant(unittest.TestCase):
             self.assert_sane(Js_v_AB_E)
             self.assertEqual(Js_v_AB_E.shape, (3, nw))
 
-        AsBias_ABp = plant.CalcBiasSpatialAcceleration(
+        AsBias_ABp_E = plant.CalcBiasSpatialAcceleration(
             context=context, with_respect_to=JacobianWrtVariable.kV,
             frame_B=base_frame, p_BoBp_B=np.zeros(3), frame_A=world_frame,
             frame_E=world_frame)
-        self.assert_sane(AsBias_ABp.rotational(), nonzero=False)
-        self.assert_sane(AsBias_ABp.translational(), nonzero=False)
-        asBias_ABi = plant.CalcBiasTranslationalAcceleration(
+        self.assert_sane(AsBias_ABp_E.rotational(), nonzero=False)
+        self.assert_sane(AsBias_ABp_E.translational(), nonzero=False)
+        asBias_ABi_E = plant.CalcBiasTranslationalAcceleration(
             context=context, with_respect_to=JacobianWrtVariable.kV,
             frame_B=base_frame, p_BoBi_B=np.zeros(3), frame_A=world_frame,
             frame_E=world_frame)
-        self.assert_sane(asBias_ABi, nonzero=False)
-        self.assertEqual(asBias_ABi.shape, (3, 1))
+        self.assert_sane(asBias_ABi_E, nonzero=False)
+        self.assertEqual(asBias_ABi_E.shape, (3, 1))
 
             Js_v_AB_E = plant.CalcJacobianTranslationalVelocity(
                 context=context, with_respect_to=wrt, frame_B=base_frame,

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -587,12 +587,12 @@ class TestPlant(unittest.TestCase):
             self.assert_sane(Js_v_AB_E)
             self.assertEqual(Js_v_AB_E.shape, (3, nw))
             Abias_V_AFp = plant.CalcBiasSpatialAcceleration(
-                context=context, with_respect_to=wrt, frame_F=base_frame,
+                context=context, with_respect_to=wrt, frame_B=base_frame,
                 p_BoBp_B=np.zeros(3), frame_A=world_frame, frame_E=world_frame)
             self.assert_sane(Abias_V_AFp)
             self.assertEqual(Abias_V_AFp.shape, (3, nw))
             Abias_v_AFp = plant.CalcBiasTranslationalAcceleration(
-                context=context, with_respect_to=wrt, frame_F=base_frame,
+                context=context, with_respect_to=wrt, frame_B=base_frame,
                 p_BoBi_B=np.zeros(3), frame_A=world_frame, frame_E=world_frame)
             self.assert_sane(Abias_v_AFp)
             self.assertEqual(Abias_v_AFp.shape, (3, nw))

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -591,8 +591,8 @@ class TestPlant(unittest.TestCase):
             context=context, with_respect_to=JacobianWrtVariable.kV,
             frame_B=base_frame, p_BoBp_B=np.zeros(3), frame_A=world_frame,
             frame_E=world_frame)
-        self.assert_sane(AsBias_ABp, nonzero=False)
-        self.assertEqual(AsBias_ABp.shape, (6,))
+        self.assert_sane(AsBias_ABp.rotational(), nonzero=False)
+        self.assert_sane(AsBias_ABp.translational(), nonzero=False)
         asBias_ABi = plant.CalcBiasTranslationalAcceleration(
             context=context, with_respect_to=JacobianWrtVariable.kV,
             frame_B=base_frame, p_BoBi_B=np.zeros(3), frame_A=world_frame,


### PR DESCRIPTION
I needed the python bindings for [`CalcBiasForJacobianSpatialVelocity`](https://drake.mit.edu/doxygen_cxx/classdrake_1_1multibody_1_1_multibody_plant.html#ab1acb4f78f307092671567a002b39c4b) which I believe has been renamed to `CalcBiasSpatialAcceleration` as per 653c35dfc7.

I suppose support for `JacobianWrtVariable::kQDot` is not available yet, so the test fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13638)
<!-- Reviewable:end -->
