### PR TITLE
Pass animation arguments through to meshcat.

### DIFF
--- a/bindings/pydrake/systems/meshcat_visualizer.py
+++ b/bindings/pydrake/systems/meshcat_visualizer.py
@@ -409,12 +409,18 @@ class MeshcatVisualizer(LeafSystem):
         # Note: This syntax was chosen to match PyPlotVisualizer.
         self._is_recording = False
 
-    def publish_recording(self):
+    def publish_recording(self, play=True, repetitions=1):
         """
         Publish any recorded animation to Meshcat.  Use the controls dialog
         in the browser to review it.
+
+        Args:
+            play: boolean that determines whether the animation will play
+                automatically.
+            repetitions: number of times that the animation should play.
         """
-        self.vis.set_animation(self._animation)
+        self.vis.set_animation(self._animation, play=play,
+                               repetitions=repetitions)
 
     def reset_recording(self):
         """

--- a/bindings/pydrake/systems/test/meshcat_visualizer_test.py
+++ b/bindings/pydrake/systems/test/meshcat_visualizer_test.py
@@ -92,7 +92,7 @@ class TestMeshcat(unittest.TestCase):
         self.assertEqual(len(visualizer._animation.clips), 2)
         # After .1 seconds, we should have had 4 publish events.
         self.assertEqual(visualizer._recording_frame_num, 4)
-        visualizer.publish_recording()
+        visualizer.publish_recording(play=True, repetitions=1)
         visualizer.reset_recording()
         self.assertEqual(len(visualizer._animation.clips), 0)
 


### PR DESCRIPTION
I've named them here, instead of passing kwargs, to improve readability/usability.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13643)
<!-- Reviewable:end -->
