### PR TITLE
Fixed method comment for CalcBiasCenterOfMassTranslationalAcceleration

### DIFF
--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -2934,8 +2934,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// point Ccm is the composite center of mass of the system of all bodies
   /// (except world_body()) in the MultibodyPlant. abias_ACcm is the part of
   /// a_ACcm (Ccm's translational acceleration) that does not multiply ṡ, equal
-  /// to abias_ACcm = J̇𝑠_v_ACcm * s. This allows a_ACcm to be written as
-  /// a_ACcm = J̇𝑠_v_ACcm * s + abias_ACcm.
+  /// to abias_ACcm = J̇𝑠_v_ACcm ⋅ s. This allows a_ACcm to be written as
+  /// a_ACcm = J𝑠_v_ACcm ⋅ ṡ + abias_ACcm.
   ///
   /// @param[in] context The state of the multibody system.
   /// @param[in] with_respect_to Enum equal to JacobianWrtVariable::kQDot or


### PR DESCRIPTION
Fixes the documentation for MultibodyPlant::CalcBiasCenterOfMassTranslationalAcceleration():
- the J vdot term was written incorrectly as Jdot v, and
- asterisks were used for multiply rather than centered dots (inconsistent with other docs in that class).

This caused confusion for a user on [Stackoverflow](https://stackoverflow.com/questions/62757744/how-to-calculate-center-of-mass-acceleration).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13645)
<!-- Reviewable:end -->
