### PR TITLE
Fix binding for CalcJacobianTranslationalVelocity output matrix not sized correctly

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -415,8 +415,9 @@ void DoScalarDependentDefinitions(py::module m, T) {
                 JacobianWrtVariable with_respect_to, const Frame<T>& frame_B,
                 const Eigen::Ref<const Matrix3X<T>>& p_BoBi_B,
                 const Frame<T>& frame_A, const Frame<T>& frame_E) {
-              Matrix3X<T> Js_v_ABi_E(
-                  3, GetVariableSize<T>(*self, with_respect_to));
+              const int num_points = p_BoBi_B.cols();
+              MatrixX<T> Js_v_ABi_E(
+                  3 * num_points, GetVariableSize<T>(*self, with_respect_to));
               self->CalcJacobianTranslationalVelocity(context, with_respect_to,
                   frame_B, p_BoBi_B, frame_A, frame_E, &Js_v_ABi_E);
               return Js_v_ABi_E;

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -587,6 +587,13 @@ class TestPlant(unittest.TestCase):
             self.assert_sane(Js_v_AB_E)
             self.assertEqual(Js_v_AB_E.shape, (3, nw))
 
+            Js_v_AB_E = plant.CalcJacobianTranslationalVelocity(
+                context=context, with_respect_to=wrt, frame_B=base_frame,
+                p_BoBi_B=np.zeros((3, 3)), frame_A=world_frame,
+                frame_E=world_frame)
+            self.assert_sane(Js_v_AB_E)
+            self.assertEqual(Js_v_AB_E.shape, (9, nw))
+
         # Compute body pose.
         X_WBase = plant.EvalBodyPoseInWorld(context, base)
         self.assertIsInstance(X_WBase, RigidTransform)


### PR DESCRIPTION
According to [multibody_tree.cc:1726](https://github.com/RobotLocomotion/drake/blob/master/multibody/tree/multibody_tree.cc#L1726), `CalcJacobianTranslationalVelocity` expects an output matrix
```
Js_v_ABi_E->rows() == 3 * num_points
```

However, in [plant_py.cc:418](https://github.com/RobotLocomotion/drake/blob/master/bindings/pydrake/multibody/plant_py.cc#L418):
```
              Matrix3X<T> Js_v_ABi_E(
                  3, GetVariableSize<T>(*self, with_respect_to));
              self->CalcJacobianTranslationalVelocity(context, with_respect_to,
                  frame_B, p_BoBi_B, frame_A, frame_E, &Js_v_ABi_E);
```
 shows that an output matrix of size 3 is always created.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13653)
<!-- Reviewable:end -->
