### PR TITLE
[render] RenderEngineVtk now uses full camera intrinsics

### DIFF
--- a/geometry/render/render_engine_vtk.h
+++ b/geometry/render/render_engine_vtk.h
@@ -107,6 +107,10 @@ class RenderEngineVtk : public RenderEngine,
   /** @see RenderEngine::UpdateViewpoint().  */
   void UpdateViewpoint(const math::RigidTransformd& X_WR) override;
 
+  using RenderEngine::RenderColorImage;
+  using RenderEngine::RenderDepthImage;
+  using RenderEngine::RenderLabelImage;
+
   /** @see RenderEngine::RenderColorImage().  */
   void RenderColorImage(
       const CameraProperties& camera, bool show_window,
@@ -175,6 +179,21 @@ class RenderEngineVtk : public RenderEngine,
   // @see RenderEngine::DoClone().
   std::unique_ptr<RenderEngine> DoClone() const override;
 
+  // @see RenderEngine::DoRenderColorImage().
+  void DoRenderColorImage(
+      const ColorRenderCamera& camera,
+      systems::sensors::ImageRgba8U* color_image_out) const override;
+
+  // @see RenderEngine::DoRenderDepthImage().
+  void DoRenderDepthImage(
+      const DepthRenderCamera& render_camera,
+      systems::sensors::ImageDepth32F* depth_image_out) const override;
+
+  // @see RenderEngine::DoRenderLabelImage().
+  void DoRenderLabelImage(
+      const ColorRenderCamera& camera,
+      systems::sensors::ImageLabel16I* label_image_out) const override;
+
   // Initializes the VTK pipelines.
   void InitializePipelines();
 
@@ -206,6 +225,17 @@ class RenderEngineVtk : public RenderEngine,
 
   // Modifies the camera for the special case of the depth camera.
   void UpdateWindow(const DepthCameraProperties& camera,
+                    const RenderingPipeline* p) const;
+
+  // Configures the VTK model to reflect the given `camera`, this includes
+  // render size camera intrinsics, visible windows, etc.
+  void UpdateWindow(const RenderCameraCore& camera,
+                    bool show_window, const RenderingPipeline* p,
+                    const char* name) const;
+
+  // Variant of configuring the VTK model (see previous method) that *also*
+  // configures the depth range.
+  void UpdateWindow(const DepthRenderCamera& camera,
                     const RenderingPipeline* p) const;
 
   void SetDefaultLightPosition(const Vector3<double>& X_DL) override;

--- a/geometry/render/shaders/depth_shaders.h
+++ b/geometry/render/shaders/depth_shaders.h
@@ -5,19 +5,6 @@ namespace geometry {
 namespace render {
 namespace shaders {
 
-// NOTE: The _original_ vertex shader computed the camera-space normal and
-// propagated the texture coordinate to the fragment shader. These quantities
-// are *not* used and represented wasted computation. However, in the future,
-// these *could* be used to handle more complex depth computations based on how
-// much of a structured IR pattern is fed back to the camera. For example,
-// a surface with a normal perpendicular to the view direction wouldn't reflect
-// anything back and a surface with varying reflectance properties would be
-// captured as a texture. To simplify the inclusion of this data when we're
-// ready, the requisite shader code has been _commented out_ below for future
-// reference.
-// TODO(SeanCurtis-TRI): Re-enable providing normals and texture coordinates
-//  to the fragment shader when these quantities are used.
-
 // NOTE: For the VTK infrastructure, the shader should always start with the
 // line:
 //   //VTK::System::Dec
@@ -26,17 +13,10 @@ namespace shaders {
 constexpr char kDepthVS[] = R"__(
     //VTK::System::Dec
     attribute vec4 vertexMC;
-    // attribute vec3 normalMC;
-    // uniform mat3 normalMatrix;
     uniform mat4 MCDCMatrix;
     uniform mat4 MCVCMatrix;
-    // varying vec3 normalVCVSOutput;
     varying vec4 vertexVCVSOutput;
-    // attribute vec2 tcoordMC;
-    // varying vec2 tcoordVCVSOutput;
     void main () {
-      // normalVCVSOutput = normalMatrix * normalMC;
-      // tcoordVCVSOutput = tcoordMC;
       vertexVCVSOutput = MCVCMatrix * vertexMC;
       gl_Position = MCDCMatrix * vertexMC;
     }
@@ -66,9 +46,7 @@ constexpr char kDepthVS[] = R"__(
 constexpr char kDepthFS[] = R"__(
     //VTK::System::Dec
     //VTK::Output::Dec
-    varying vec3 normalVCVSOutput;
     varying vec4 vertexVCVSOutput;
-    varying vec2 tcoordVCVSOutput;
     out vec4 color_out;
     uniform float z_near;
     uniform float z_far;

--- a/geometry/render/test/render_engine_vtk_test.cc
+++ b/geometry/render/test/render_engine_vtk_test.cc
@@ -1,5 +1,7 @@
 #include "drake/geometry/render/render_engine_vtk.h"
 
+#include <cstring>
+#include <limits>
 #include <optional>
 #include <string>
 #include <tuple>
@@ -40,9 +42,10 @@ using std::make_unique;
 using std::unique_ptr;
 using std::unordered_map;
 using std::vector;
+using systems::sensors::CameraInfo;
 using systems::sensors::Color;
-using systems::sensors::ColorI;
 using systems::sensors::ColorD;
+using systems::sensors::ColorI;
 using systems::sensors::ImageDepth32F;
 using systems::sensors::ImageLabel16I;
 using systems::sensors::ImageRgba8U;
@@ -88,6 +91,8 @@ const ColorI kTextureColor{4, 241, 33};
 // different from the default color of the VTK render engine.
 const ColorI kDefaultVisualColor = {229u, 229u, 229u};
 const float kDefaultDistance{3.f};
+
+const RenderLabel kDefaultLabel{13531};
 
 // Values to be used with the "centered shape" tests.
 // The amount inset from the edge of the images to *still* expect ground plane
@@ -205,37 +210,41 @@ class RenderEngineVtkTest : public ::testing::Test {
   }
 
   // Confirms that all pixels in the member color image have the same value.
-  void VerifyUniformColor(const ColorI& pixel, int alpha) {
+  void VerifyUniformColor(const ColorI& pixel, int alpha,
+                          const ImageRgba8U* color = nullptr) {
+    if (color == nullptr) color = &color_;
     const RgbaColor test_color{pixel, alpha};
-    for (int y = 0; y < kHeight; ++y) {
-      for (int x = 0; x < kWidth; ++x) {
-        ASSERT_TRUE(CompareColor(test_color, color_, ScreenCoord{x, y}));
+    for (int y = 0; y < color->height(); ++y) {
+      for (int x = 0; x < color->width(); ++x) {
+        ASSERT_TRUE(CompareColor(test_color, *color, ScreenCoord{x, y}));
       }
     }
   }
 
   // Confirms that all pixels in the member label image have the same value.
-  void VerifyUniformLabel(int16_t label) {
-    for (int y = 0; y < kHeight; ++y) {
-      for (int x = 0; x < kWidth; ++x) {
-        ASSERT_EQ(label_.at(x, y)[0], label)
+  void VerifyUniformLabel(int16_t value, const ImageLabel16I* label = nullptr) {
+    if (label == nullptr) label = &label_;
+    for (int y = 0; y < label->height(); ++y) {
+      for (int x = 0; x < label->width(); ++x) {
+        ASSERT_EQ(label->at(x, y)[0], value)
                       << "At pixel (" << x << ", " << y << ")";
       }
     }
   }
 
   // Confirms that all pixels in the member depth image have the same value.
-  void VerifyUniformDepth(float depth) {
-    if (depth == std::numeric_limits<float>::infinity()) {
-      for (int y = 0; y < kHeight; ++y) {
-        for (int x = 0; x < kWidth; ++x) {
-          ASSERT_EQ(depth_.at(x, y)[0], depth);
+  void VerifyUniformDepth(float value, const ImageDepth32F* depth = nullptr) {
+    if (depth == nullptr) depth = &depth_;
+    if (value == std::numeric_limits<float>::infinity()) {
+      for (int y = 0; y < depth->height(); ++y) {
+        for (int x = 0; x < depth->width(); ++x) {
+          ASSERT_EQ(depth->at(x, y)[0], value);
         }
       }
     } else {
-      for (int y = 0; y < kHeight; ++y) {
-        for (int x = 0; x < kWidth; ++x) {
-          ASSERT_NEAR(depth_.at(x, y)[0], depth, kDepthTolerance);
+      for (int y = 0; y < depth->height(); ++y) {
+        for (int x = 0; x < depth->width(); ++x) {
+          ASSERT_NEAR(depth->at(x, y)[0], value, kDepthTolerance);
         }
       }
     }
@@ -290,12 +299,12 @@ class RenderEngineVtkTest : public ::testing::Test {
   void VerifyOutliers(const RenderEngineVtk& renderer,
                       const DepthCameraProperties& camera,
                       const char* name,
-                      ImageRgba8U* color_in = nullptr,
-                      ImageDepth32F* depth_in = nullptr,
-                      ImageLabel16I* label_in = nullptr) {
-    ImageRgba8U& color = color_in ? *color_in : color_;
-    ImageDepth32F& depth = depth_in ? *depth_in : depth_;
-    ImageLabel16I& label = label_in ? *label_in : label_;
+                      const ImageRgba8U* color_in = nullptr,
+                      const ImageDepth32F* depth_in = nullptr,
+                      const ImageLabel16I* label_in = nullptr) const {
+    const ImageRgba8U& color = color_in ? *color_in : color_;
+    const ImageDepth32F& depth = depth_in ? *depth_in : depth_;
+    const ImageLabel16I& label = label_in ? *label_in : label_;
 
     for (const auto& screen_coord : GetOutliers(camera)) {
       const int x = screen_coord.x;
@@ -388,6 +397,26 @@ class RenderEngineVtkTest : public ::testing::Test {
     renderer->UpdatePoses(X_WV_);
   }
 
+  void PopulateSimpleBoxTest(RenderEngineVtk* renderer) {
+    // Simple cube.
+    const double length = 1.0;
+    const Box box = Box::MakeCube(length);
+    expected_label_ = kDefaultLabel;
+    const GeometryId id = GeometryId::get_new_id();
+    PerceptionProperties props = simple_material(false);
+    renderer->RegisterVisual(id, box, props, RigidTransformd::Identity(),
+                             true /* needs update */);
+    // Leave the box centered on the xy plane, but raise it up for the expected
+    // depth in the camera (distance from eye to near surface):
+    //      expected depth = p_WC.z - length / 2 - p_WV.z;
+    const double p_WVo_z =
+        X_WC_.translation()(2) - length / 2 - expected_object_depth_;
+    RigidTransformd X_WV{Vector3d{0, 0, p_WVo_z}};
+    renderer->UpdatePoses(
+        unordered_map<GeometryId, RigidTransformd>{{id, X_WV}});
+    expected_color_ = default_color_;
+  }
+
   // Performs the work to test the rendering with a shape centered in the
   // image. To pass, the renderer will have to have been populated with a
   // compatible shape and camera configuration (e.g., PopulateSphereTest()).
@@ -402,10 +431,19 @@ class RenderEngineVtkTest : public ::testing::Test {
     ImageLabel16I label(cam.width, cam.height);
     Render(renderer, &cam, &color, &depth, &label);
 
-    VerifyOutliers(*renderer, cam, name, &color, &depth, &label);
+    VerifyCenterShapeTest(*renderer, name, cam, color, depth, label);
+  }
+
+  void VerifyCenterShapeTest(const RenderEngineVtk& renderer,
+                              const char* name,
+                              const DepthCameraProperties& camera,
+                              const ImageRgba8U& color,
+                              const ImageDepth32F& depth,
+                              const ImageLabel16I& label) const {
+    VerifyOutliers(renderer, camera, name, &color, &depth, &label);
 
     // Verifies inside the sphere.
-    const ScreenCoord inlier = GetInlier(cam);
+    const ScreenCoord inlier = GetInlier(camera);
     const int x = inlier.x;
     const int y = inlier.y;
     EXPECT_TRUE(CompareColor(expected_color_, color, inlier))
@@ -469,11 +507,12 @@ TEST_F(RenderEngineVtkTest, TerrainTest) {
   Init(X_WC_, true);
   const Vector3d p_WR = X_WC_.translation();
 
-  // At two different distances.
-  for (auto depth : std::array<float, 2>({{2.f, 4.9999f}})) {
+  // At several different distances.
+  for (const float depth : {1.f, 2.f, 3.f, 4.f, 4.9999f}) {
     X_WC_.set_translation({p_WR(0), p_WR(1), depth});
     renderer_->UpdateViewpoint(X_WC_);
     Render();
+    SCOPED_TRACE(fmt::format("Valid depth return: {}", depth));
     VerifyUniformColor(kTerrainColorI, 255u);
     VerifyUniformLabel(RenderLabel::kDontCare);
     VerifyUniformDepth(depth);
@@ -483,6 +522,7 @@ TEST_F(RenderEngineVtkTest, TerrainTest) {
   X_WC_.set_translation({p_WR(0), p_WR(1), kZNear - 1e-5});
   renderer_->UpdateViewpoint(X_WC_);
   Render();
+  SCOPED_TRACE("Closer than near");
   VerifyUniformColor(kTerrainColorI, 255u);
   VerifyUniformLabel(RenderLabel::kDontCare);
   VerifyUniformDepth(InvalidDepth::kTooClose);
@@ -491,14 +531,10 @@ TEST_F(RenderEngineVtkTest, TerrainTest) {
   X_WC_.set_translation({p_WR(0), p_WR(1), kZFar + 1e-3});
   renderer_->UpdateViewpoint(X_WC_);
   Render();
+  SCOPED_TRACE("Farther than far");
   VerifyUniformColor(kTerrainColorI, 255u);
   VerifyUniformLabel(RenderLabel::kDontCare);
-  // Verifies depth.
-  for (int y = 0; y < kHeight; ++y) {
-    for (int x = 0; x < kWidth; ++x) {
-      ASSERT_EQ(InvalidDepth::kTooFar, depth_.at(x, y)[0]);
-    }
-  }
+  VerifyUniformDepth(InvalidDepth::kTooFar);
 }
 
 // Creates a terrain and then positions the camera such that a horizon between
@@ -509,13 +545,24 @@ TEST_F(RenderEngineVtkTest, HorizonTest) {
       AngleAxisd(M_PI_2, Vector3d::UnitY())}};
   Init(X_WR, true);
 
-  // Returns y in [0, kHeight / 2], index of horizon location in image
-  // coordinate system under two assumptions: 1) the ground plane is not clipped
-  // by `kClippingPlaneFar`, 2) camera is located above the ground.
-  auto CalcHorizon = [](double z) {
+  CameraProperties camera{camera_.width, camera_.height, camera_.fov_y,
+                          "ignored"};
+  // Returns y in [0, camera.height), index of horizon location in image
+  // coordinate system under several assumptions:
+  //   - the ground plane is not clipped by kClippingPlaneFar,
+  //   - camera is located above the ground (z > 0).
+  //   - the ground is a square 100m on a side, centered on world origin.
+  //   - camera is located above world origin with a view direction parallel to
+  //     the ground (such that the horizon is a horizontal line).
+  auto CalcHorizon = [&camera](double z) {
     const double kTerrainSize = 50.;
-    const double kFocalLength = kHeight * 0.5 / std::tan(0.5 * kFovY);
-    return 0.5 * kHeight + z / kTerrainSize * kFocalLength;
+    const double kFocalLength =
+        camera.height * 0.5 / std::tan(0.5 * camera.fov_y);
+    // We assume the horizon is *below* the middle of the screen. So, we compute
+    // the number of pixels below the screen center the horizon must lie, and
+    // then add half screen height to that value to get the number of rows
+    // from the top row of the image.
+    return 0.5 * camera.height + z / kTerrainSize * kFocalLength;
   };
 
   // Verifies v index of horizon at three different camera heights.
@@ -523,21 +570,24 @@ TEST_F(RenderEngineVtkTest, HorizonTest) {
   for (const double z : {2., 1., 0.5}) {
     X_WR.set_translation({p_WR(0), p_WR(1), z});
     renderer_->UpdateViewpoint(X_WR);
-    Render();
+    ImageRgba8U color(camera.width, camera.height);
+    renderer_->RenderColorImage(camera, kShowWindow, &color);
 
     int actual_horizon{0};
-    for (int y = 0; y < kHeight; ++y) {
-      // Looking for the boundary between the sky and the ground.
-      if ((static_cast<uint8_t>(kBgColor.r != color_.at(0, y)[0])) ||
-          (static_cast<uint8_t>(kBgColor.g != color_.at(0, y)[1])) ||
-          (static_cast<uint8_t>(kBgColor.b != color_.at(0, y)[2]))) {
+    // This test is looking for the *first* row that isn't exactly sky color.
+    // That implies it's starting its search *in the sky*. That implies that the
+    // top row is zero and the bottom row is height - 1.
+    for (int y = 0; y < camera.height; ++y) {
+      if ((static_cast<uint8_t>(kBgColor.r != color.at(0, y)[0])) ||
+          (static_cast<uint8_t>(kBgColor.g != color.at(0, y)[1])) ||
+          (static_cast<uint8_t>(kBgColor.b != color.at(0, y)[2]))) {
         actual_horizon = y;
         break;
       }
     }
 
     const double expected_horizon = CalcHorizon(z);
-    ASSERT_NEAR(expected_horizon, actual_horizon, 1.001);
+    ASSERT_NEAR(expected_horizon, actual_horizon, 1.001) << "z = " << z;
   }
 }
 
@@ -578,19 +628,20 @@ TEST_F(RenderEngineVtkTest, BoxTest) {
       renderer_->RegisterVisual(id, box, props,
                                 RigidTransformd::Identity(),
                                 true /* needs update */);
-      // Position the box so that one corner is in the center of the image. The
-      // corner will report the expected depth, color, and label. Typically, the
-      // center of the box would render to the center of the image, so putting
-      // the corner of the box at the center of the image would require moving
-      // the box half its dimension lengths. Moving it *exactly* that length
-      // means that the center pixel would only partially be filled (the vertex
-      // would be in the center). We want the whole pixel filled so we place the
-      // vertex just *beyond* the center so that the whole pixel is filled by
-      // box face. The z-value comes from taking the *rotated* box and making
-      // sure the near face has the expected depth.
-      RigidTransformd X_WV{
-          RotationMatrixd{AngleAxisd(M_PI, Vector3d::UnitX())},
-          Vector3d{-box.width() * 0.49, -box.depth() * 0.49, 0.625}};
+      // We want to position the box so that one corner of the box exactly
+      // covers the pixel used for the "inlier test" (w/2, h/2). We can't put
+      // the corner at (0, 0, z) (for some depth z) because pixel (w/2, h/2)
+      // isn't *centered* on the world origin. We actually want the corner to be
+      // half a pixel away from the origin at (px/2, py/2, z), where px and py
+      // are the measures of a pixel in meters at the expected depth of the
+      // box's leading face.
+      // Because we have a radially symmetric lens, px = py and we can compute
+      // that measure by with simple trigonometry.
+      const double pixel_size = 4 * expected_object_depth_ *
+                                tan(camera_.fov_y / 2.0) / camera_.height;
+      RigidTransformd X_WV{RotationMatrixd{AngleAxisd(M_PI, Vector3d::UnitX())},
+                           Vector3d{(-box.width() + pixel_size) * 0.5,
+                                    (-box.depth() + pixel_size) * 0.5, 0.625}};
       renderer_->UpdatePoses(
           unordered_map<GeometryId, RigidTransformd>{{id, X_WV}});
 
@@ -604,10 +655,10 @@ TEST_F(RenderEngineVtkTest, BoxTest) {
         // When we scale the image differently, we'll radically change the
         // color at that same corner.
 
-        expected_color_ = RgbaColor(ColorI{132, 119, 16}, 255);
+        expected_color_ = RgbaColor(ColorI{130, 119, 16}, 255);
         // Quick proof that we're testing for a different color -- we're drawing
         // the red channel from our expected color.
-        ASSERT_NE(kTextureColor.r, 132);
+        ASSERT_NE(kTextureColor.r, expected_color_.r);
       } else {
         // Otherwise the expected is simply the texture color of box.png.
         expected_color_ =
@@ -1178,14 +1229,14 @@ TEST_F(RenderEngineVtkTest, DefaultProperties_RenderLabel) {
   }
 }
 
-// This class exists solely for the purpopse of injecting an arbitrary texture
+// This class exists solely for the purpose of injecting an arbitrary texture
 // onto an actor and confirm that the texture is preserved over the copy.
 class TextureSetterEngine : public RenderEngineVtk {
  public:
   TextureSetterEngine() = default;
 
-  /* Reports if the color actor for the geometry with the given `id` has the
-   property texture append by this class's DoRegisterVisual() implementaiton. */
+  // Reports if the color actor for the geometry with the given `id` has the
+  // property texture append by this class's DoRegisterVisual() implementaiton.
   bool GeometryHasColorTexture(GeometryId id,
                                const std::string& texture_name) const {
     const auto color_actor = actors().at(id)[0];
@@ -1193,8 +1244,8 @@ class TextureSetterEngine : public RenderEngineVtk {
            nullptr;
   }
 
-  /* Applies a texture with the given name to the color actor for the geometry
-   indicated by the given id. */
+  // Applies a texture with the given name to the color actor for the geometry
+  // indicated by the given id.
   void ApplyColorTextureToGeometry(GeometryId id,
                                    const std::string& texture_name) {
     const auto color_actor = actors().at(id)[0];
@@ -1232,6 +1283,367 @@ TEST_F(RenderEngineVtkTest, PreservePropertyTexturesOverClone) {
       dynamic_cast<TextureSetterEngine*>(clone_ptr.get());
   ASSERT_NE(clone, nullptr);
   ASSERT_TRUE(clone->GeometryHasColorTexture(id, texture_name));
+}
+
+// A reality check that confirms that the conversion from CameraProperties
+// to intrinsics is as expected -- they produce equivalent images.
+TEST_F(RenderEngineVtkTest, CameraPropertiesVsCameraIntrinsics) {
+  Init(X_WC_, true /* add_terrain */);
+  PopulateSimpleBoxTest(renderer_.get());
+
+  // We're going to render some baseline images using the CameraProperties.
+  ImageRgba8U ref_color(camera_.width, camera_.height);
+  ImageDepth32F ref_depth(camera_.width, camera_.height);
+  ImageLabel16I ref_label(camera_.width, camera_.height);
+  Render(renderer_.get(), &camera_, &ref_color, &ref_depth, &ref_label);
+
+  // Instantiating camear models with the same data as in DepthCameraProperties
+  // should produce the *same* images.
+  const CameraInfo intrinsics{camera_.width, camera_.height, camera_.fov_y};
+  const ColorRenderCamera color_camera{{"n/a", intrinsics, {0.1, 100.0}, {}},
+                                       kShowWindow};
+  const DepthRenderCamera depth_camera{{"n/a", intrinsics, {0.1, 100.0}, {}},
+                                       {camera_.z_near, camera_.z_far}};
+
+  ImageRgba8U equiv_color(camera_.width, camera_.height);
+  ImageDepth32F equiv_depth(camera_.width, camera_.height);
+  ImageLabel16I equiv_label(camera_.width, camera_.height);
+  renderer_->RenderColorImage(color_camera, &equiv_color);
+  renderer_->RenderDepthImage(depth_camera, &equiv_depth);
+  renderer_->RenderLabelImage(color_camera, &equiv_label);
+
+  // The color and label images should be *bit* identical.
+  EXPECT_EQ(memcmp(ref_color.at(0, 0), equiv_color.at(0, 0), ref_color.size()),
+            0);
+
+  EXPECT_EQ(memcmp(ref_label.at(0, 0), equiv_label.at(0, 0), ref_label.size()),
+            0);
+  // The depth values take a slightly more numerically complex path and can
+  // lead to small rounding errors that the color channels are less
+  // susceptible to. To show the images are equal, we need to compare with
+  // tolerance.
+  for (int d = 0; d < ref_depth.size(); ++d) {
+    ASSERT_NEAR(ref_depth.at(0, 0)[d], equiv_depth.at(0, 0)[d],
+                4 * std::numeric_limits<float>::epsilon());
+  }
+}
+
+namespace {
+
+// Defines the relationship between two adjacent pixels in a rendering of a box.
+// Used to help find the edges of a rendered box.
+enum AdjacentPixel { Same, GroundToBox, BoxToGround };
+
+// Note: These overloads work because the pixel "types" ::T for each image type
+// is distinct.
+
+AdjacentPixel Compare(const typename ImageDepth32F::T* curr_pixel,
+                      const typename ImageDepth32F::T* next_pixel) {
+  // Box depth < ground depth.
+  if (*curr_pixel < *next_pixel) return BoxToGround;
+  if (*curr_pixel > *next_pixel) return GroundToBox;
+  return Same;
+}
+
+AdjacentPixel Compare(const typename ImageRgba8U::T* curr_pixel,
+                      const typename ImageRgba8U::T* next_pixel) {
+  const RgbaColor ground(kTerrainColorI, 255);
+  const RgbaColor curr(curr_pixel);
+  const RgbaColor next(next_pixel);
+
+  const bool curr_is_ground =
+      curr.r == ground.r && curr.g == ground.g && curr.b == ground.b;
+  const bool next_is_ground =
+      next.r == ground.r && next.g == ground.g && next.b == ground.b;
+  if (!curr_is_ground && next_is_ground) return BoxToGround;
+  if (curr_is_ground && !next_is_ground) return GroundToBox;
+  return Same;
+}
+
+AdjacentPixel Compare(const typename ImageLabel16I::T* curr_pixel,
+                      const typename ImageLabel16I::T* next_pixel) {
+  const bool curr_is_box = *curr_pixel == kDefaultLabel;
+  const bool next_is_box = *next_pixel == kDefaultLabel;
+
+  if (curr_is_box && !next_is_box) return BoxToGround;
+  if (!curr_is_box && next_is_box) return GroundToBox;
+  return Same;
+}
+
+// Find the edges of the box in the image. Using the single-channel depth
+// image simplifies finding the edges. The edges are encoded as follows:
+// left, top, right, bottom. (such that right > left, and top > bottom). It
+// represents the row/column in the image that represents the left-most,
+// top-most, etc. extents of the box. It is assumed that the box edges run
+// parallel with the image rows and columns and the box is wholly contained
+// within the image.
+template <typename ImageType>
+Vector4<int> FindBoxEdges(const ImageType& image) {
+  using T = typename ImageType::T;
+  Vector4<int> edges{-1, -1, -1, -1};
+
+  for (int x = 0; x < image.width() - 1; ++x) {
+    for (int y = 0; y < image.height() - 1; ++y) {
+      const T* curr_pixel = image.at(x, y);
+
+      // Look for edge between current pixel and pixel below.
+      const T* bottom_pixel = image.at(x, y + 1);
+      const AdjacentPixel bottom_result =
+          Compare(curr_pixel, bottom_pixel);
+      if (bottom_result == GroundToBox) {
+        // Current lies on the ground, next lies on the box; bottom edge.
+        DRAKE_DEMAND(edges(3) == -1 || edges(3) == y + 1);
+        edges(3) = y + 1;
+      } else if (bottom_result == BoxToGround) {
+        // Current lies on the box, next lies on the ground; top edges.
+        DRAKE_DEMAND(edges(1) == -1 || edges(1) == y);
+        edges(1) = y;
+      }
+
+      // Look for edge between current pixel and pixel to the right.
+      const T* right_pixel = image.at(x + 1, y);
+      const AdjacentPixel right_result =
+          Compare(curr_pixel, right_pixel);
+      if (right_result == GroundToBox) {
+        // Current lies on the ground, next lies on the box; left edge.
+        DRAKE_DEMAND(edges(0) == -1 || edges(0) == x + 1);
+        edges(0) = x + 1;
+      } else if (right_result == BoxToGround) {
+        // Current lies on the box, next lies on the ground; right edge.
+        DRAKE_DEMAND(edges(2) == -1 || edges(2) == x);
+        edges(2) = x;
+      }
+    }
+  }
+
+  return edges;
+  }
+
+}  // namespace
+
+// Confirm that all of the intrinsics values have the expected contribution.
+// We'll render a cube multiple times. Each rendering will have its own camera
+// configuration and we'll predict the contents of the image relative to a
+// baseline image, based on the change in rendering properties.
+TEST_F(RenderEngineVtkTest, IntrinsicsAndRenderProperties) {
+  Init(X_WC_, true /* add_terrain */);
+  PopulateSimpleBoxTest(renderer_.get());
+
+  // Reference case: Vanilla, ideal camera: isotropic, centered lens. We'll
+  // define future expectations relative to this one. The actual parameters are
+  // arbitrary. The goal is to place the box inside the image. The focal
+  // length should not be too large, otherwise the box edges cannot be
+  // identified in the image.
+  const int w = 300;
+  const int h = w;
+  const double fx = 270;
+  const double fy = fx;
+  const double cx = w / 2.0 + 0.5;
+  const double cy = h / 2.0 + 0.5;
+  const double min_depth = 0.1;
+  const double max_depth = 5;
+  const double clip_n = 0.01;
+  const double clip_f = 10.0;
+
+  const CameraInfo ref_intrinsics{w, h, fx, fy, cx, cy};
+  const ColorRenderCamera ref_color_camera{
+      {"n/a", ref_intrinsics, {clip_n, clip_f}, {}}, kShowWindow};
+  const DepthRenderCamera ref_depth_camera{
+      {"n/a", ref_intrinsics, {clip_n, clip_f}, {}}, {min_depth, max_depth}};
+
+  ImageRgba8U ref_color(ref_intrinsics.width(), ref_intrinsics.height());
+  ImageDepth32F ref_depth(ref_intrinsics.width(), ref_intrinsics.height());
+  ImageLabel16I ref_label(ref_intrinsics.width(), ref_intrinsics.height());
+  renderer_->RenderColorImage(ref_color_camera, &ref_color);
+  renderer_->RenderDepthImage(ref_depth_camera, &ref_depth);
+  renderer_->RenderLabelImage(ref_color_camera, &ref_label);
+
+  // Confirm all edges were found, the box is square and centered in the
+  // image.
+  const Vector4<int> ref_box_edges = FindBoxEdges(ref_depth);
+  ASSERT_TRUE((ref_box_edges.array() > -1).all()) << ref_box_edges.transpose();
+  const int ref_box_width = ref_box_edges(2) - ref_box_edges(0);
+  const int ref_box_height = ref_box_edges(1) - ref_box_edges(3);
+  ASSERT_EQ(ref_box_width, ref_box_height);
+  ASSERT_EQ((ref_box_edges(2) + ref_box_edges(0)) / 2, w / 2);
+  ASSERT_EQ((ref_box_edges(1) + ref_box_edges(3)) / 2, h / 2);
+
+  {
+    // Also confirm the box is positioned the same in color and label images.
+    const Vector4<int> color_edges = FindBoxEdges(ref_color);
+    ASSERT_EQ(color_edges, ref_box_edges) << color_edges;
+    const Vector4<int> label_edges = FindBoxEdges(ref_label);
+    ASSERT_EQ(label_edges, ref_box_edges) << label_edges;
+  }
+
+  {
+    // Case: Modify image dimensions, focal length, and principal point; the
+    // box should move and stretch.
+    const int w2 = w + 100;
+    const int h2 = h + 50;
+    // There are limits on how much *bigger* a focal length can be. Too big
+    // and the box will no longer fit in the image and the test will fail
+    // because FindBoxEdges()'s assumptions will be broken.
+    const double fx2 = fx * 1.1;
+    const double fy2 = fy * 0.75;
+    const double offset_x = 10;
+    const double offset_y = -15;
+    const double cx2 = w2 / 2.0 + 0.5 + offset_x;
+    const double cy2 = h2 / 2.0 + 0.5 + offset_y;
+    const CameraInfo intrinsics{w2, h2, fx2, fy2, cx2, cy2};
+    const ColorRenderCamera color_camera{
+        {"n/a", intrinsics, {clip_n, clip_f}, {}}, kShowWindow};
+    const DepthRenderCamera depth_camera{
+        {"n/a", intrinsics, {clip_n, clip_f}, {}}, {min_depth, max_depth}};
+
+    // We don't test for image/camera size mismatches here. That has been
+    // tested in render_engine_test.cc.
+    ImageRgba8U color(intrinsics.width(), intrinsics.height());
+    ImageDepth32F depth(intrinsics.width(), intrinsics.height());
+    ImageLabel16I label(intrinsics.width(), intrinsics.height());
+    renderer_->RenderColorImage(color_camera, &color);
+    renderer_->RenderDepthImage(depth_camera, &depth);
+    renderer_->RenderLabelImage(color_camera, &label);
+
+    // We expect the following effects based on the change in intrinsics.
+    //
+    //  - The center of the box moves <offset_x, offset_y> pixels from the
+    //    center of the new image.
+    //  - Changing the focal length will change the measure of the box in the
+    //    corresponding dimension. So, if ratio_x = fx2 / fx, then
+    //    width2 = width * ratio_x. (Similarly for height.)
+    //  - Changing the image size alone will *not* change the appearance of the
+    //    box (unless the image size is reduced sufficiently to truncate the
+    //    box). With a fixed focal length, changing image size will merely
+    //    increase or decrease the amount of image around the box.
+
+    const Vector4<int> test_edges = FindBoxEdges(depth);
+    ASSERT_TRUE((test_edges.array() > -1).all()) << test_edges.transpose();
+    const int test_box_width = test_edges(2) - test_edges(0);
+    const int test_box_height = test_edges(1) - test_edges(3);
+
+    // Confirm the box gets squished.
+    const double fx_ratio = fx2 / fx;
+    const double fy_ratio = fy2 / fy;
+    EXPECT_NEAR(test_box_width, ref_box_width * fx_ratio, 1);
+    EXPECT_NEAR(test_box_height, ref_box_height * fy_ratio, 1);
+
+    // Confirm that its center is translated.
+    EXPECT_NEAR((test_edges(0) + test_edges(2)) / 2.0, w2 / 2.0 + offset_x, 1.0)
+        << test_edges.transpose();
+    EXPECT_NEAR((test_edges(1) + test_edges(3)) / 2.0, h2 / 2.0 + offset_y, 1.0)
+        << test_edges.transpose();
+
+    {
+      // Also confirm it matches for color and label.
+      const Vector4<int> color_edges = FindBoxEdges(color);
+      ASSERT_EQ(color_edges, test_edges) << color_edges.transpose();
+      const Vector4<int> label_edges = FindBoxEdges(label);
+      ASSERT_EQ(label_edges, test_edges) << label_edges.transpose();
+    }
+  }
+
+  {
+    // Case: far plane is in front of all geometry; nothing visible.
+    const double n_alt = expected_object_depth_ * 0.1;
+    const double f_alt = expected_object_depth_ * 0.9;
+    const ColorRenderCamera color_camera{
+        {"n/a", ref_intrinsics, {n_alt, f_alt}, {}}, kShowWindow};
+    // Set depth range to clipping range so we don't take a chance with the
+    // depth range lying outside the clipping range.
+    const DepthRenderCamera depth_camera{
+        {"n/a", ref_intrinsics, {n_alt, f_alt}, {}}, {n_alt, f_alt}};
+    ImageRgba8U color(ref_intrinsics.width(), ref_intrinsics.height());
+    ImageDepth32F depth(ref_intrinsics.width(), ref_intrinsics.height());
+    ImageLabel16I label(ref_intrinsics.width(), ref_intrinsics.height());
+    renderer_->RenderColorImage(color_camera, &color);
+    renderer_->RenderDepthImage(depth_camera, &depth);
+    renderer_->RenderLabelImage(color_camera, &label);
+
+    SCOPED_TRACE("Far plane in front of scene");
+    VerifyUniformColor(kBgColor, 255u, &color);
+    VerifyUniformLabel(RenderLabel::kEmpty, &label);
+    VerifyUniformDepth(std::numeric_limits<float>::infinity(), &depth);
+  }
+
+  {
+    // Case: near plane too far; nothing visible.
+    // We're assuming the box has an edge length <= 2.
+    const double n_alt = expected_object_depth_ + 2.1;
+    const double f_alt = expected_object_depth_ + 4.1;
+    const ColorRenderCamera color_camera{
+        {"n/a", ref_intrinsics, {n_alt, f_alt}, {}}, kShowWindow};
+    // Set depth range to clipping range so we don't take a chance with the
+    // depth range lying outside the clipping range.
+    const DepthRenderCamera depth_camera{
+        {"n/a", ref_intrinsics, {n_alt, f_alt}, {}}, {n_alt, f_alt}};
+    ImageRgba8U color(ref_intrinsics.width(), ref_intrinsics.height());
+    ImageDepth32F depth(ref_intrinsics.width(), ref_intrinsics.height());
+    ImageLabel16I label(ref_intrinsics.width(), ref_intrinsics.height());
+    renderer_->RenderColorImage(color_camera, &color);
+    renderer_->RenderDepthImage(depth_camera, &depth);
+    renderer_->RenderLabelImage(color_camera, &label);
+
+    SCOPED_TRACE("Near plane beyond scene");
+    VerifyUniformColor(kBgColor, 255u, &color);
+    VerifyUniformLabel(RenderLabel::kEmpty, &label);
+    VerifyUniformDepth(std::numeric_limits<float>::infinity(), &depth);
+  }
+
+  {
+    // Case: configure the depth range to lie _between_ the depth of the box's
+    // leading face and the ground. The box face should register as too close
+    // and the ground should be too far.
+    const double min_alt = expected_object_depth_ + 0.1;
+    const double max_alt = expected_outlier_depth_ - 0.1;
+    const DepthRenderCamera depth_camera{
+        {"n/a", ref_intrinsics, {clip_n, clip_f}, {}}, {min_alt, max_alt}};
+    ImageDepth32F depth(ref_intrinsics.width(), ref_intrinsics.height());
+    renderer_->RenderDepthImage(depth_camera, &depth);
+
+    // Confirm pixel in corner (ground) and pixel in center (box).
+    EXPECT_TRUE(IsExpectedDepth(depth, ScreenCoord{w / 2, h / 2},
+                                InvalidDepth::kTooClose, 0.0));
+    EXPECT_TRUE(
+        IsExpectedDepth(depth, ScreenCoord{0, 0}, InvalidDepth::kTooFar, 0.0));
+  }
+
+  {
+    // Case: The whole sensor depth range lies *in front* of the box's leading
+    // face. The whole depth image should report as too far.
+    const double min_alt = expected_object_depth_ * 0.5;
+    const double max_alt = expected_object_depth_ * 0.9;
+    const DepthRenderCamera depth_camera{
+        {"n/a", ref_intrinsics, {clip_n, clip_f}, {}}, {min_alt, max_alt}};
+    ImageDepth32F depth(ref_intrinsics.width(), ref_intrinsics.height());
+    renderer_->RenderDepthImage(depth_camera, &depth);
+
+    // Confirm pixel in corner (ground) and pixel in center (box).
+    EXPECT_TRUE(IsExpectedDepth(depth, ScreenCoord{w / 2, h / 2},
+                                InvalidDepth::kTooFar, 0.0));
+    EXPECT_TRUE(
+        IsExpectedDepth(depth, ScreenCoord{0, 0}, InvalidDepth::kTooFar, 0.0));
+  }
+
+  {
+    // Case: The whole sensor depth range lies beyond the ground. The whole
+    // depth image should report as too close. This result is in stark contrast
+    // to *clipping* the geometry away -- there, the distance reports as too
+    // far.
+    // We're assuming the box has an edge length <= 2.
+    const double min_alt = expected_object_depth_ + 2.1;
+    const double max_alt = expected_object_depth_ + 4.1;
+    const DepthRenderCamera depth_camera{
+        {"n/a", ref_intrinsics, {clip_n, clip_f}, {}}, {min_alt, max_alt}};
+    ImageDepth32F depth(ref_intrinsics.width(), ref_intrinsics.height());
+    renderer_->RenderDepthImage(depth_camera, &depth);
+
+    // Confirm pixel in corner (ground) and pixel in center (box).
+    EXPECT_TRUE(IsExpectedDepth(depth, ScreenCoord{w / 2, h / 2},
+                                InvalidDepth::kTooClose, 0.0));
+    EXPECT_TRUE(IsExpectedDepth(depth, ScreenCoord{0, 0},
+                                InvalidDepth::kTooClose, 0.0));
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
 - RenderEngineVtk - implements full camera intrinsics
   - Implement simple camera model in terms of full camera model.
   - Also cleaned up the old zombie code in its depth shader.
   - Tests extended accordingly.
 - Incidental clean up on depth shader code.

This is the final step in making full camera intrinsics actually functional (as detailed in #11880). There are several subsequent steps for finishing the software engineering. But this represents the minimum change to make intrinsics available for use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13655)
<!-- Reviewable:end -->
