### PR TITLE
Add missing tools relating to LLVM 9

### DIFF
--- a/setup/ubuntu/source_distribution/packages-bionic.txt
+++ b/setup/ubuntu/source_distribution/packages-bionic.txt
@@ -43,6 +43,7 @@ libxml2-dev
 libxt-dev
 libyaml-cpp-dev
 lldb
+llvm-9
 locales
 openssh-client
 patch

--- a/setup/ubuntu/source_distribution/packages-focal.txt
+++ b/setup/ubuntu/source_distribution/packages-focal.txt
@@ -43,7 +43,8 @@ libx11-dev
 libxml2-dev
 libxt-dev
 libyaml-cpp-dev
-lldb
+lldb-9
+llvm-9
 locales
 openssh-client
 patch


### PR DESCRIPTION
Needed for sanitizer builds (e.g., for `llvm-symbolizer`). Needs CI update, but no reason it cannot merge beforehand.

Relates #13434 and  #13650.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13656)
<!-- Reviewable:end -->
