### PR TITLE
[render] Implement RenderImageLabel in RenderEngineGl

### DIFF
--- a/geometry/render/gl_renderer/BUILD.bazel
+++ b/geometry/render/gl_renderer/BUILD.bazel
@@ -51,6 +51,7 @@ drake_cc_library_gl_ubuntu_only(
     hdrs = ["opengl_geometry.h"],
     deps = [
         ":opengl_context",
+        "//geometry/render:render_label",
         "//math:geometric_transform",
     ],
 )
@@ -82,6 +83,8 @@ drake_cc_library(
             ":shape_meshes",
             "//common:essential",
             "//geometry/render:render_engine",
+            "//geometry/render:render_label",
+            "//systems/sensors:image",
         ],
     }),
 )

--- a/geometry/render/gl_renderer/opengl_geometry.h
+++ b/geometry/render/gl_renderer/opengl_geometry.h
@@ -3,6 +3,7 @@
 #include <limits>
 
 #include "drake/geometry/render/gl_renderer/opengl_includes.h"
+#include "drake/geometry/render/render_label.h"
 #include "drake/math/rigid_transform.h"
 
 namespace drake {
@@ -87,14 +88,15 @@ struct OpenGlInstance {
    @pre `g_in.is_defined()` reports `true`.  */
   OpenGlInstance(const OpenGlGeometry& g_in,
                  const math::RigidTransformd& pose_in,
-                 const Vector3<double>& scale_in)
-      : geometry(g_in), X_WG(pose_in), scale(scale_in) {
+                 const Vector3<double>& scale_in, const RenderLabel& label_in)
+      : geometry(g_in), X_WG(pose_in), scale(scale_in), label(label_in) {
     DRAKE_DEMAND(geometry.is_defined());
   }
 
   OpenGlGeometry geometry;
   math::RigidTransformd X_WG;
   Vector3<double> scale;
+  RenderLabel label;
 };
 
 }  // namespace internal

--- a/geometry/render/gl_renderer/render_engine_gl.cc
+++ b/geometry/render/gl_renderer/render_engine_gl.cc
@@ -95,6 +95,8 @@ void main() {
   shader_program_->LoadFromSources(kVertexShader, kFragmentShader);
 }
 
+RenderEngineGl::~RenderEngineGl() = default;
+
 void RenderEngineGl::UpdateViewpoint(const RigidTransformd& X_WR) {
   X_CW_ = X_WR.inverse();
 }
@@ -124,217 +126,6 @@ void RenderEngineGl::RenderDepthImage(const DepthCameraProperties& camera,
 void RenderEngineGl::RenderLabelImage(const CameraProperties&, bool,
                                       ImageLabel16I*) const {
   throw std::runtime_error("RenderEngineGl cannot render label images");
-}
-
-void RenderEngineGl::SetGlProjectionMatrix(
-    const DepthCameraProperties& camera) const {
-  shader_program_->Use();
-  shader_program_->SetUniformValue("depth_z_near", camera.z_near);
-  shader_program_->SetUniformValue("depth_z_far", camera.z_far);
-
-  // TODO(SeanCurtis-TRI): When clipping planes get set by the user, conflict
-  //  between depth camera range and clipping range should be an error. For now,
-  //  we simply define the clipping planes to tightly (but not exactly) bound
-  //  the depth ranges. The tightness gives us the most precision in the
-  //  z-buffer in the depth range. The slightly larger domain will allow us
-  //  to recognize at least *some* fragments which rendered outside the depth
-  //  range.
-  const float clip_near = camera.z_near - 0.1;
-  const float clip_far = camera.z_far + 0.1;
-  const float inverse_frustum_depth = 1 / (clip_far - clip_near);
-
-  // https://unspecified.wordpress.com/2012/06/21/calculating-the-gluperspective-matrix-and-other-opengl-matrix-maths/
-  // An OpenGL projection matrix maps points in a camera coordinate to a "clip
-  // coordinate", in which the projection step maps a 3D point into 2D
-  // normalized device coordinate (NDC). Effectively, image corners are mapped
-  // into a square from -1 to 1 in NDC. Hence, the clip coordinate is
-  // essentially a scaled version of the camera coordinate, where the camera
-  // image frustum is scaled into a "square" frustum.
-  //
-  // Because the xy elements of the image corner [f*w/2, f*h/2] is mapped to
-  // [fx*f*w/2, fy*f*h/2] in the "square" clip coordinate by the OpenGL
-  // projection matrix P, we have: fx*f*w/2 == fy*f*h/2, i.e. fx*w == fy*h.
-
-  const float fy = 1.0f / static_cast<float>(tan(camera.fov_y * 0.5));
-  const float fx = fy * camera.height / camera.width;
-  const float A = -(clip_near + clip_far) * inverse_frustum_depth;
-  const float B = -2.0f * clip_near * clip_far * inverse_frustum_depth;
-  Eigen::Matrix4f P;
-  // Eigen matrices are col-major, similar to OpenGL.
-  // clang-format off
-  P << fx, 0.0,  0.0, 0.0,
-      0.0, fy,   0.0, 0.0,
-      0.0, 0.0,    A,   B,
-      0.0, 0.0, -1.0, 0.0;
-  // clang-format on
-  auto projection_matrix_id =
-      shader_program_->GetUniformLocation("projection_matrix");
-  glUniformMatrix4fv(projection_matrix_id, 1, GL_FALSE, P.data());
-}
-
-OpenGlGeometry RenderEngineGl::CreateGlGeometry(const VertexBuffer& vertices,
-                                        const IndexBuffer& indices) {
-  OpenGlGeometry geometry;
-  // Create the vertex array object (VAO).
-  glCreateVertexArrays(1, &geometry.vertex_array);
-
-  // Create the vertex buffer object (VBO).
-  glCreateBuffers(1, &geometry.vertex_buffer);
-  glNamedBufferStorage(geometry.vertex_buffer,
-                       vertices.size() * sizeof(GLfloat), vertices.data(), 0);
-  // Bind the VBO with the VAO.
-  const int kBindingIndex = 0;  // The binding point.
-  glVertexArrayVertexBuffer(geometry.vertex_array, kBindingIndex,
-                            geometry.vertex_buffer, 0, 3 * sizeof(GLfloat));
-
-  // Bind the attribute in vertex shader to the VAO at the same binding point.
-  const int kLocP_ModelAttrib = 0;  // p_Model's location in vertex shader.
-  glVertexArrayAttribFormat(geometry.vertex_array, kLocP_ModelAttrib, 3,
-                            GL_FLOAT, GL_FALSE, 0);
-  glVertexArrayAttribBinding(geometry.vertex_array, kLocP_ModelAttrib,
-                             kBindingIndex);
-  glEnableVertexArrayAttrib(geometry.vertex_array, kLocP_ModelAttrib);
-
-  // Create the index buffer object (IBO).
-  glCreateBuffers(1, &geometry.index_buffer);
-  glNamedBufferStorage(geometry.index_buffer, indices.size() * sizeof(GLuint),
-                       indices.data(), 0);
-  // Bind IBO with the VAO.
-  glVertexArrayElementBuffer(geometry.vertex_array, geometry.index_buffer);
-
-  geometry.index_buffer_size = indices.size();
-
-  // Note: We won't need to call the corresponding glDeleteVertexArrays or
-  // glDeleteBuffers. The meshes we store are "canonical" meshes. Even if a
-  // particular GeometryId is removed, it was only referencing its corresponding
-  // canonical mesh. We keep all canonical meshes alive for the lifetime of the
-  // OpenGL context for convenient reuse.
-  return geometry;
-}
-
-RenderTarget RenderEngineGl::CreateRenderTarget(
-    const DepthCameraProperties& camera) {
-  // Create a framebuffer object (FBO).
-  RenderTarget target;
-  glCreateFramebuffers(1, &target.frame_buffer);
-
-  // Create the texture object that will store the rendered result.
-  const int width = camera.width;
-  const int height = camera.height;
-  glGenTextures(1, &target.value_texture);
-  glBindTexture(GL_TEXTURE_2D, target.value_texture);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_R32F, width, height, 0, GL_RED, GL_FLOAT,
-               0);
-  glBindTexture(GL_TEXTURE_2D, 0);
-
-  // Attach the texture to FBO color attachment point.
-  glNamedFramebufferTexture(target.frame_buffer, GL_COLOR_ATTACHMENT0,
-                            target.value_texture, 0);
-
-  // Create the render buffer object (RBO), acting as the z buffer.
-  glCreateRenderbuffers(1, &target.z_buffer);
-  glNamedRenderbufferStorage(target.z_buffer, GL_DEPTH_COMPONENT, width,
-                             height);
-  // Attach the RBO to FBO's depth attachment point.
-  glNamedFramebufferRenderbuffer(target.frame_buffer, GL_DEPTH_ATTACHMENT,
-                                 GL_RENDERBUFFER, target.z_buffer);
-
-  // Check FBO status.
-  GLenum status =
-      glCheckNamedFramebufferStatus(target.frame_buffer, GL_FRAMEBUFFER);
-  if (status != GL_FRAMEBUFFER_COMPLETE) {
-    throw std::runtime_error("FBO creation failed.");
-  }
-
-  // Specify which buffer to be associated with the fragment shader output.
-  GLenum buffer = GL_COLOR_ATTACHMENT0;
-  glNamedFramebufferDrawBuffers(target.frame_buffer, 1, &buffer);
-
-  return target;
-}
-
-void RenderEngineGl::SetGlModelViewMatrix(const Eigen::Matrix4f& X_CM) const {
-  auto model_view_matrix_id =
-      shader_program_->GetUniformLocation("model_view_matrix");
-
-  // Our camera frame C wrt the OpenGL's camera frame Cgl.
-  static const Eigen::Matrix4f kX_CglC =
-      (Eigen::Matrix4f() << 1, 0, 0, 0, 0, -1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1)
-          .finished();
-
-  Eigen::Matrix4f X_CglM = kX_CglC * X_CM;
-  glUniformMatrix4fv(model_view_matrix_id, 1, GL_FALSE, X_CglM.data());
-}
-
-RenderTarget RenderEngineGl::SetCameraProperties(
-    const DepthCameraProperties& camera) const {
-  SetGlProjectionMatrix(camera);
-
-  const BufferDim dim{camera.width, camera.height};
-  RenderTarget target;
-  auto iter = render_targets_->find(dim);
-  if (iter == render_targets_->end()) {
-    target = CreateRenderTarget(camera);
-    render_targets_->insert({dim, target});
-  } else {
-    target = iter->second;
-  }
-  glBindFramebuffer(GL_FRAMEBUFFER, target.frame_buffer);
-  glViewport(0, 0, camera.width, camera.height);
-  return target;
-}
-
-void RenderEngineGl::RenderAt(const Eigen::Matrix4f& X_CW) const {
-  shader_program_->Use();
-
-  glClipControl(GL_UPPER_LEFT, GL_NEGATIVE_ONE_TO_ONE);
-  glEnable(GL_DEPTH_TEST);
-  // Note: We're *not* clearing the color buffer here. We rely on the caller of
-  // RenderAt() to have cleared the frame buffer's color buffer to an
-  // appropriate color for an "empty" pixel.
-  glClear(GL_DEPTH_BUFFER_BIT);
-
-  for (const auto& pair : visuals_) {
-    const internal::OpenGlInstance& instance = pair.second;
-    glBindVertexArray(instance.geometry.vertex_array);
-
-    Eigen::DiagonalMatrix<float, 4, 4> scale(Vector4<float>(
-        instance.scale(0), instance.scale(1), instance.scale(2), 1.0));
-    // The pose of the geometry in the camera frame is a _scaled_
-    // transform; the geometry gets scaled, then posed in the world, and finally
-    // the camera frame.
-    SetGlModelViewMatrix(X_CW * instance.X_WG.GetAsMatrix4().cast<float>() *
-                         scale);
-    glDrawElements(GL_TRIANGLES, instance.geometry.index_buffer_size,
-                   GL_UNSIGNED_INT, 0);
-  }
-  // Unbind the vertex array back to the default of 0.
-  glBindVertexArray(0);
-  shader_program_->Unuse();
-}
-
-void RenderEngineGl::SetWindowVisibility(const CameraProperties& camera,
-                                         bool show_window,
-                                         const RenderTarget& target) const {
-  if (show_window) {
-    // Use the render target buffer as the read buffer and the default buffer
-    // (0) as the draw buffer for displaying in the window. We transfer the full
-    // image from source to destination. The semantics of glBlitNamedFrameBuffer
-    // are inclusive of the "minimum" pixel (0, 0) and exclusive of the
-    // "maximum" pixel (width, height).
-    opengl_context_->DisplayWindow(camera.width, camera.height);
-    glBlitNamedFramebuffer(target.frame_buffer, 0,
-                           0, 0, camera.width, camera.height,  // Src bounds.
-                           0, 0, camera.width, camera.height,  // Dest bounds.
-                           GL_COLOR_BUFFER_BIT, GL_NEAREST);
-    opengl_context_->UpdateWindow();
-  } else {
-    opengl_context_->HideWindow();
-  }
 }
 
 void RenderEngineGl::ImplementGeometry(const Sphere& sphere, void* user_data) {
@@ -412,6 +203,35 @@ unique_ptr<RenderEngine> RenderEngineGl::DoClone() const {
   return unique_ptr<RenderEngineGl>(new RenderEngineGl(*this));
 }
 
+void RenderEngineGl::RenderAt(const Eigen::Matrix4f& X_CW) const {
+  shader_program_->Use();
+
+  glClipControl(GL_UPPER_LEFT, GL_NEGATIVE_ONE_TO_ONE);
+  glEnable(GL_DEPTH_TEST);
+  // Note: We're *not* clearing the color buffer here. We rely on the caller of
+  // RenderAt() to have cleared the frame buffer's color buffer to an
+  // appropriate color for an "empty" pixel.
+  glClear(GL_DEPTH_BUFFER_BIT);
+
+  for (const auto& pair : visuals_) {
+    const internal::OpenGlInstance& instance = pair.second;
+    glBindVertexArray(instance.geometry.vertex_array);
+
+    Eigen::DiagonalMatrix<float, 4, 4> scale(Vector4<float>(
+        instance.scale(0), instance.scale(1), instance.scale(2), 1.0));
+    // The pose of the geometry in the camera frame is a _scaled_
+    // transform; the geometry gets scaled, then posed in the world, and finally
+    // the camera frame.
+    SetGlModelViewMatrix(X_CW * instance.X_WG.GetAsMatrix4().cast<float>() *
+                         scale);
+    glDrawElements(GL_TRIANGLES, instance.geometry.index_buffer_size,
+                   GL_UNSIGNED_INT, 0);
+  }
+  // Unbind the vertex array back to the default of 0.
+  glBindVertexArray(0);
+  shader_program_->Unuse();
+}
+
 OpenGlGeometry RenderEngineGl::GetSphere() {
   if (!sphere_.is_defined()) {
     const int kLatitudeBands = 50;
@@ -486,7 +306,187 @@ OpenGlGeometry RenderEngineGl::GetMesh(const string& filename) {
   return mesh;
 }
 
-RenderEngineGl::~RenderEngineGl() = default;
+RenderTarget RenderEngineGl::CreateRenderTarget(
+    const DepthCameraProperties& camera) {
+  // Create a framebuffer object (FBO).
+  RenderTarget target;
+  glCreateFramebuffers(1, &target.frame_buffer);
+
+  // Create the texture object that will store the rendered result.
+  const int width = camera.width;
+  const int height = camera.height;
+  glGenTextures(1, &target.value_texture);
+  glBindTexture(GL_TEXTURE_2D, target.value_texture);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_R32F, width, height, 0, GL_RED, GL_FLOAT,
+               0);
+  glBindTexture(GL_TEXTURE_2D, 0);
+
+  // Attach the texture to FBO color attachment point.
+  glNamedFramebufferTexture(target.frame_buffer, GL_COLOR_ATTACHMENT0,
+                            target.value_texture, 0);
+
+  // Create the render buffer object (RBO), acting as the z buffer.
+  glCreateRenderbuffers(1, &target.z_buffer);
+  glNamedRenderbufferStorage(target.z_buffer, GL_DEPTH_COMPONENT, width,
+                             height);
+  // Attach the RBO to FBO's depth attachment point.
+  glNamedFramebufferRenderbuffer(target.frame_buffer, GL_DEPTH_ATTACHMENT,
+                                 GL_RENDERBUFFER, target.z_buffer);
+
+  // Check FBO status.
+  GLenum status =
+      glCheckNamedFramebufferStatus(target.frame_buffer, GL_FRAMEBUFFER);
+  if (status != GL_FRAMEBUFFER_COMPLETE) {
+    throw std::runtime_error("FBO creation failed.");
+  }
+
+  // Specify which buffer to be associated with the fragment shader output.
+  GLenum buffer = GL_COLOR_ATTACHMENT0;
+  glNamedFramebufferDrawBuffers(target.frame_buffer, 1, &buffer);
+
+  return target;
+}
+
+void RenderEngineGl::SetGlProjectionMatrix(
+    const DepthCameraProperties& camera) const {
+  shader_program_->Use();
+  shader_program_->SetUniformValue("depth_z_near", camera.z_near);
+  shader_program_->SetUniformValue("depth_z_far", camera.z_far);
+
+  // TODO(SeanCurtis-TRI): When clipping planes get set by the user, conflict
+  //  between depth camera range and clipping range should be an error. For now,
+  //  we simply define the clipping planes to tightly (but not exactly) bound
+  //  the depth ranges. The tightness gives us the most precision in the
+  //  z-buffer in the depth range. The slightly larger domain will allow us
+  //  to recognize at least *some* fragments which rendered outside the depth
+  //  range.
+  const float clip_near = camera.z_near - 0.1;
+  const float clip_far = camera.z_far + 0.1;
+  const float inverse_frustum_depth = 1 / (clip_far - clip_near);
+
+  // https://unspecified.wordpress.com/2012/06/21/calculating-the-gluperspective-matrix-and-other-opengl-matrix-maths/
+  // An OpenGL projection matrix maps points in a camera coordinate to a "clip
+  // coordinate", in which the projection step maps a 3D point into 2D
+  // normalized device coordinate (NDC). Effectively, image corners are mapped
+  // into a square from -1 to 1 in NDC. Hence, the clip coordinate is
+  // essentially a scaled version of the camera coordinate, where the camera
+  // image frustum is scaled into a "square" frustum.
+  //
+  // Because the xy elements of the image corner [f*w/2, f*h/2] is mapped to
+  // [fx*f*w/2, fy*f*h/2] in the "square" clip coordinate by the OpenGL
+  // projection matrix P, we have: fx*f*w/2 == fy*f*h/2, i.e. fx*w == fy*h.
+
+  const float fy = 1.0f / static_cast<float>(tan(camera.fov_y * 0.5));
+  const float fx = fy * camera.height / camera.width;
+  const float A = -(clip_near + clip_far) * inverse_frustum_depth;
+  const float B = -2.0f * clip_near * clip_far * inverse_frustum_depth;
+  Eigen::Matrix4f P;
+  // Eigen matrices are col-major, similar to OpenGL.
+  // clang-format off
+  P << fx, 0.0,  0.0, 0.0,
+      0.0, fy,   0.0, 0.0,
+      0.0, 0.0,    A,   B,
+      0.0, 0.0, -1.0, 0.0;
+  // clang-format on
+  auto projection_matrix_id =
+      shader_program_->GetUniformLocation("projection_matrix");
+  glUniformMatrix4fv(projection_matrix_id, 1, GL_FALSE, P.data());
+}
+
+void RenderEngineGl::SetGlModelViewMatrix(const Eigen::Matrix4f& X_CM) const {
+  auto model_view_matrix_id =
+      shader_program_->GetUniformLocation("model_view_matrix");
+
+  // Our camera frame C wrt the OpenGL's camera frame Cgl.
+  static const Eigen::Matrix4f kX_CglC =
+      (Eigen::Matrix4f() << 1, 0, 0, 0, 0, -1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1)
+          .finished();
+
+  Eigen::Matrix4f X_CglM = kX_CglC * X_CM;
+  glUniformMatrix4fv(model_view_matrix_id, 1, GL_FALSE, X_CglM.data());
+}
+
+RenderTarget RenderEngineGl::SetCameraProperties(
+    const DepthCameraProperties& camera) const {
+  SetGlProjectionMatrix(camera);
+
+  const BufferDim dim{camera.width, camera.height};
+  RenderTarget target;
+  auto iter = render_targets_->find(dim);
+  if (iter == render_targets_->end()) {
+    target = CreateRenderTarget(camera);
+    render_targets_->insert({dim, target});
+  } else {
+    target = iter->second;
+  }
+  glBindFramebuffer(GL_FRAMEBUFFER, target.frame_buffer);
+  glViewport(0, 0, camera.width, camera.height);
+  return target;
+}
+
+OpenGlGeometry RenderEngineGl::CreateGlGeometry(const VertexBuffer& vertices,
+                                        const IndexBuffer& indices) {
+  OpenGlGeometry geometry;
+  // Create the vertex array object (VAO).
+  glCreateVertexArrays(1, &geometry.vertex_array);
+
+  // Create the vertex buffer object (VBO).
+  glCreateBuffers(1, &geometry.vertex_buffer);
+  glNamedBufferStorage(geometry.vertex_buffer,
+                       vertices.size() * sizeof(GLfloat), vertices.data(), 0);
+  // Bind the VBO with the VAO.
+  const int kBindingIndex = 0;  // The binding point.
+  glVertexArrayVertexBuffer(geometry.vertex_array, kBindingIndex,
+                            geometry.vertex_buffer, 0, 3 * sizeof(GLfloat));
+
+  // Bind the attribute in vertex shader to the VAO at the same binding point.
+  const int kLocP_ModelAttrib = 0;  // p_Model's location in vertex shader.
+  glVertexArrayAttribFormat(geometry.vertex_array, kLocP_ModelAttrib, 3,
+                            GL_FLOAT, GL_FALSE, 0);
+  glVertexArrayAttribBinding(geometry.vertex_array, kLocP_ModelAttrib,
+                             kBindingIndex);
+  glEnableVertexArrayAttrib(geometry.vertex_array, kLocP_ModelAttrib);
+
+  // Create the index buffer object (IBO).
+  glCreateBuffers(1, &geometry.index_buffer);
+  glNamedBufferStorage(geometry.index_buffer, indices.size() * sizeof(GLuint),
+                       indices.data(), 0);
+  // Bind IBO with the VAO.
+  glVertexArrayElementBuffer(geometry.vertex_array, geometry.index_buffer);
+
+  geometry.index_buffer_size = indices.size();
+
+  // Note: We won't need to call the corresponding glDeleteVertexArrays or
+  // glDeleteBuffers. The meshes we store are "canonical" meshes. Even if a
+  // particular GeometryId is removed, it was only referencing its corresponding
+  // canonical mesh. We keep all canonical meshes alive for the lifetime of the
+  // OpenGL context for convenient reuse.
+  return geometry;
+}
+
+void RenderEngineGl::SetWindowVisibility(const CameraProperties& camera,
+                                         bool show_window,
+                                         const RenderTarget& target) const {
+  if (show_window) {
+    // Use the render target buffer as the read buffer and the default buffer
+    // (0) as the draw buffer for displaying in the window. We transfer the full
+    // image from source to destination. The semantics of glBlitNamedFrameBuffer
+    // are inclusive of the "minimum" pixel (0, 0) and exclusive of the
+    // "maximum" pixel (width, height).
+    opengl_context_->DisplayWindow(camera.width, camera.height);
+    glBlitNamedFramebuffer(target.frame_buffer, 0,
+                           0, 0, camera.width, camera.height,  // Src bounds.
+                           0, 0, camera.width, camera.height,  // Dest bounds.
+                           GL_COLOR_BUFFER_BIT, GL_NEAREST);
+    opengl_context_->UpdateWindow();
+  } else {
+    opengl_context_->HideWindow();
+  }
+}
 
 }  // namespace render
 }  // namespace geometry

--- a/geometry/render/gl_renderer/render_engine_gl.h
+++ b/geometry/render/gl_renderer/render_engine_gl.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <array>
 #include <memory>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 
 #include "drake/common/eigen_types.h"
@@ -79,6 +81,13 @@ class RenderEngineGl final : public RenderEngine {
   //@}
 
  private:
+  friend class RenderEngineGlTester;
+
+  // Image types available. Used to index into the image-type-dependent
+  // data structures.
+  // TODO(SeanCurtis-TRI): Implement color image type: kColor.
+  enum ImageType { kLabel = 0, kDepth, kTypeCount };
+
   // @see RenderEngine::DoRegisterVisual().
   bool DoRegisterVisual(GeometryId id, const Shape& shape,
                         const PerceptionProperties& properties,
@@ -91,16 +100,22 @@ class RenderEngineGl final : public RenderEngine {
   // @see RenderEngine::DoRemoveGeometry().
   bool DoRemoveGeometry(GeometryId id) final;
 
-  // see RenderEngine::DoClone().
+  // @see RenderEngine::DoClone().
   std::unique_ptr<RenderEngine> DoClone() const final;
 
   // Copy constructor used for cloning.
   RenderEngineGl(const RenderEngineGl& other) = default;
 
-  // Render inverse depth of the object at a specific pose in the camera frame.
-  void RenderAt(const Eigen::Matrix4f& X_CM) const;
+  // Renders the object at a specific pose in the camera frame using the given
+  // shader program.
+  void RenderAt(const internal::ShaderProgram& shader_program,
+                const Eigen::Matrix4f& X_CM, ImageType image_type) const;
 
-  // Provide triangle mesh definitions of the various canonical geometries
+  // Performs the common setup for all shape types.
+  void ImplementGeometry(const internal::OpenGlGeometry& geometry,
+                         void* user_data, const Vector3<double>& scale);
+
+  // Provides triangle mesh definitions of the various canonical geometries
   // supported by this renderer: sphere, cylinder, half space, box, and mesh.
   // These update the stored OpenGlGeometry members of this class. They are
   // *not* threadsafe.
@@ -110,22 +125,53 @@ class RenderEngineGl final : public RenderEngine {
   internal::OpenGlGeometry GetBox();
   internal::OpenGlGeometry GetMesh(const std::string& filename);
 
+  // Activates the shader for the given image type; this should be called at
+  // the *top* of each Render*Image() method.
+  const internal::ShaderProgram& ActivateShader(ImageType image_type) const;
+
+  // Given the image type, returns the texture configuration for that image
+  // type. These are the key arguments for glTexImage2D based on the type of
+  // image. It includes:
+  //   - The internal format (the number of color components)
+  //   - format (the format of pixel data)
+  //   - pixel type (the data type of each pixel)
+  // For more details on these quantities, see
+  // https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexImage2D.xhtml.
+  static std::tuple<GLint, GLenum, GLenum> get_texture_format(
+      ImageType image_type);
+
   // Creates a *new* render target for the given camera. This creates OpenGL
   // objects (render buffer, frame_buffer, and texture). It should only be
   // called if there is not already a cached render target for the camera's
   // reported image size (w, h) in render_targets_.
   static internal::RenderTarget CreateRenderTarget(
-      const DepthCameraProperties& camera);
+      const CameraProperties& camera, ImageType image_type);
 
-  // Configure the model view and projection matrices.
-  void SetGlProjectionMatrix(const DepthCameraProperties& camera) const;
-  void SetGlModelViewMatrix(const Eigen::Matrix4f& X_CM) const;
+  // Configures the projection matrix -- computes the matrix and sets the value
+  // in the shader program's "projection_matrix" uniform. This value changes
+  // on a *per-camera* basis.
+  void SetGlProjectionMatrix(const internal::ShaderProgram& shader_program,
+                             const CameraProperties& camera, double clip_near,
+                             double clip_far) const;
 
-  // Configure the OpenGL properties dependent on the camera properties. This
+  // Configures the "modelview" matrix and sets the value in the shader
+  // program's "model_view_matrix" uniform. For a single camera, this changes on
+  // a *per-geometry* basis.
+  void SetGlModelViewMatrix(const internal::ShaderProgram& shader_program,
+                            const Eigen::Matrix4f& X_CM) const;
+
+  // Obtains the label image rendered from a specific object pose. This is
+  // slower than it has to be because it does per-pixel processing on the CPU.
+  // TODO(SeanCurtis-TRI): Figure out how to do all of this directly on the GPU.
+  void GetLabelImage(drake::systems::sensors::ImageLabel16I* label_image_out,
+                     const internal::RenderTarget& target) const;
+
+  // Configures the OpenGL properties dependent on the camera properties. This
   // updates the cache of RenderTargets (creating one for the camera if one
   // does not already exist). As such, it is _not_ threadsafe.
   internal::RenderTarget SetCameraProperties(
-      const DepthCameraProperties& camera) const;
+      const CameraProperties& camera, const internal::ShaderProgram& program,
+      double near_clip, double far_clip, ImageType image_type) const;
 
   // Creates an OpenGlGeometry from the mesh defined by the given vertices and
   // triangle indices.
@@ -156,7 +202,9 @@ class RenderEngineGl final : public RenderEngine {
   // All of the objects below here *require* the OpenGL context. These members
   // essentially store the OpenGl "objects" (i.e., integers) that live in
   // graphics memory.
-  std::shared_ptr<internal::ShaderProgram> shader_program_;
+
+  // Shader programs for each image type.
+  std::array<internal::ShaderProgram, kTypeCount> shader_programs_;
 
   // One OpenGlGeometry per primitive type. They represent a canonical, "unit"
   // version of the primitive type. Each instance scales and poses the
@@ -167,19 +215,23 @@ class RenderEngineGl final : public RenderEngine {
   internal::OpenGlGeometry box_;
 
   // Mapping from obj filename to the mesh loaded into an OpenGlGeometry.
-  std::shared_ptr<std::unordered_map<std::string, internal::OpenGlGeometry>>
-      meshes_;
+  std::unordered_map<std::string, internal::OpenGlGeometry> meshes_;
 
-  // This is a cache of reusable RenderTargets. There is a unique render target
-  // for each unique render image size (BufferDim). It is mutable so that it
-  // can be updated in what would otherwise be a const action of updating the
-  // OpenGL state for the camera.
+  // These are caches of reusable RenderTargets. There is a unique render target
+  // for each unique render image size (BufferDim) and output image type. They
+  // are mutable so that they can be updated in what would otherwise be a const
+  // action of updating the OpenGL state for the camera.
+  //
+  // We need unique RenderTargets for unique output image types because the
+  // type of the texture we render to differs according to output image type.
+  // Thus a RenderTarget for depth cannot be used for labels (or color).
   //
   // Note: copies of this render engine share the same frame buffer objects.
   // This is *not* threadsafe!
-  mutable std::shared_ptr<
-      std::unordered_map<internal::BufferDim, internal::RenderTarget>>
-      render_targets_;
+  mutable std::array<
+      std::unordered_map<internal::BufferDim, internal::RenderTarget>,
+      kTypeCount>
+      frame_buffers_;
 
   // Mapping from GeometryId to the visual data associated with that geometry.
   // When copying the render engine, this data is copied verbatim allowing the

--- a/geometry/render/gl_renderer/shader_program.cc
+++ b/geometry/render/gl_renderer/shader_program.cc
@@ -112,6 +112,11 @@ void ShaderProgram::SetUniformValue(const std::string& uniform_name,
   glUniform1f(GetUniformLocation(uniform_name), value);
 }
 
+void ShaderProgram::SetUniformValue(const std::string& uniform_name,
+                                    const Vector4<float>& value) const {
+  glUniform4fv(GetUniformLocation(uniform_name), 1, value.data());
+}
+
 void ShaderProgram::Use() const { glUseProgram(program_id_); }
 
 void ShaderProgram::Unuse() const {
@@ -120,11 +125,6 @@ void ShaderProgram::Unuse() const {
   if (curr_program == static_cast<GLint>(program_id_)) {
     glUseProgram(0);
   }
-}
-
-ShaderProgram::~ShaderProgram() {
-  Unuse();
-  glDeleteProgram(program_id_);
 }
 
 }  // namespace internal

--- a/geometry/render/gl_renderer/shader_program.h
+++ b/geometry/render/gl_renderer/shader_program.h
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
 #include "drake/geometry/render/gl_renderer/opengl_includes.h"
 
 namespace drake {
@@ -20,7 +21,12 @@ class ShaderProgram {
 
   ShaderProgram() = default;
 
-  ~ShaderProgram();
+  /* Note: we're using the default destructor and explicitly *not* cleaning up
+   the OpenGl context. This is consistent with how we treat all OpenGl objects:
+   RenderTarget, OpenGlGeometry, etc. We assume that destruction of the OpenGL
+   context will clean it up and the RenderEngineGl's footprint is sufficiently
+   small that no actual object management will be required.  */
+  ~ShaderProgram() = default;
 
   /* Loads a %ShaderProgram from GLSL code contained in the provided strings.
 
@@ -54,6 +60,10 @@ class ShaderProgram {
   /* Sets the scalar uniform value to the given value.
    @throws std::runtime_error if the named uniform isn't part of the program. */
   void SetUniformValue(const std::string& uniform_name, float value) const;
+
+  /* Sets the vector4 uniform value to the given value.  */
+  void SetUniformValue(const std::string& uniform_name,
+                       const Vector4<float>& value) const;
 
   /* Binds the program for usage.  */
   void Use() const;

--- a/geometry/render/gl_renderer/test/opengl_geometry_test.cc
+++ b/geometry/render/gl_renderer/test/opengl_geometry_test.cc
@@ -4,6 +4,7 @@
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/render/render_label.h"
 
 namespace drake {
 namespace geometry {
@@ -62,7 +63,8 @@ GTEST_TEST(OpenGlInstanceTest, Construction) {
   const OpenGlGeometry geometry(1, 2, 3, 4);
   const RigidTransformd X_WG{Vector3d{-1, -2, 3}};
   const Vector3d scale{0.25, 0.5, 0.75};
-  const OpenGlInstance instance{geometry, X_WG, scale};
+  const RenderLabel label(17);
+  const OpenGlInstance instance{geometry, X_WG, scale, label};
 
   EXPECT_EQ(instance.geometry.vertex_array, geometry.vertex_array);
   EXPECT_EQ(instance.geometry.vertex_buffer, geometry.vertex_buffer);
@@ -71,6 +73,7 @@ GTEST_TEST(OpenGlInstanceTest, Construction) {
   EXPECT_TRUE(
       CompareMatrices(instance.X_WG.GetAsMatrix34(), X_WG.GetAsMatrix34()));
   EXPECT_TRUE(CompareMatrices(instance.scale, scale));
+  EXPECT_EQ(instance.label, label);
 }
 
 }  // namespace

--- a/geometry/render/gl_renderer/test/shader_program_test.cc
+++ b/geometry/render/gl_renderer/test/shader_program_test.cc
@@ -26,8 +26,9 @@ constexpr char kVertexSource[] = R"_(
 constexpr char kFragmentSource[] = R"_(
   #version 330
   uniform float test_uniform;
+  uniform vec4 test_uniform4;
   void main() {
-    gl_FragColor = vec4(0.18, 0.54, 0.34, test_uniform);
+    gl_FragColor = vec4(0.18, 0.54, 0.34, test_uniform) + test_uniform4;
   }
 )_";
 
@@ -149,6 +150,12 @@ TEST_F(ShaderProgramTest, UniformAccess) {
   DRAKE_EXPECT_THROWS_MESSAGE(program.SetUniformValue("invalid", 1.75f),
                               std::runtime_error,
                               "Cannot get shader uniform invalid");
+
+  EXPECT_NO_THROW(program.SetUniformValue("test_uniform4",
+                                          Vector4<float>(0.2, 0.1, 0.1, 0.3)));
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      program.SetUniformValue("invalid", Vector4<float>(0.2, 0.1, 0.1, 0.3)),
+      std::runtime_error, "Cannot get shader uniform invalid");
 }
 
 TEST_F(ShaderProgramTest, Binding) {


### PR DESCRIPTION
Implement RenderLabelImage in RenderEngineGl

The implementation is straight forward. It provides a springboard for also adding the color label, because the infrastructure no longer assumes all depth all the time.

  - Adds infrastructure to distinguish shaders (depth vs label).
    - Adds a new shader for label images.
  - Stores per-geometry render labels (OpenGlGeometry)
  - Extend ShaderProgram to set a new kind of uniform value (vec4).
    - Also cleans up the otherwise inconsistent ~ShaderProgram.

relates #13617 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13659)
<!-- Reviewable:end -->
