### PR TITLE
manipulation_station: Move clutter clearing bins lower relative to robot

### DIFF
--- a/bindings/pydrake/examples/_manipulation_station_extra.py
+++ b/bindings/pydrake/examples/_manipulation_station_extra.py
@@ -52,33 +52,33 @@ def CreateClutterClearingYcbObjectList():
     ycb_object_pairs = []
 
     # The cracker box pose.
-    X_WCracker = _xyz_rpy_deg([-0.3, -0.55, 0.36], [-90, 0, 170])
+    X_WCracker = _xyz_rpy_deg([-0.3, -0.55, 0.2], [-90, 0, 170])
     ycb_object_pairs.append(
         ("drake/manipulation/models/ycb/sdf/003_cracker_box.sdf", X_WCracker))
 
     # The sugar box pose.
-    X_WSugar = _xyz_rpy_deg([-0.3, -0.7, 0.33], [90, 90, 0])
+    X_WSugar = _xyz_rpy_deg([-0.3, -0.7, 0.17], [90, 90, 0])
     ycb_object_pairs.append(
         ("drake/manipulation/models/ycb/sdf/004_sugar_box.sdf", X_WSugar))
 
     # The tomato soup can pose.
-    X_WSoup = _xyz_rpy_deg([-0.03, -0.57, 0.31], [-90, 0, 180])
+    X_WSoup = _xyz_rpy_deg([-0.03, -0.57, 0.15], [-90, 0, 180])
     ycb_object_pairs.append(
         ("drake/manipulation/models/ycb/sdf/005_tomato_soup_can.sdf", X_WSoup))
 
     # The mustard bottle pose.
-    X_WMustard = _xyz_rpy_deg([0.05, -0.66, 0.35], [-90, 0, 190])
+    X_WMustard = _xyz_rpy_deg([0.05, -0.66, 0.19], [-90, 0, 190])
     ycb_object_pairs.append(
         ("drake/manipulation/models/ycb/sdf/006_mustard_bottle.sdf",
          X_WMustard))
 
     # The gelatin box pose.
-    X_WGelatin = _xyz_rpy_deg([-0.15, -0.62, 0.38], [-90, 0, 210])
+    X_WGelatin = _xyz_rpy_deg([-0.15, -0.62, 0.22], [-90, 0, 210])
     ycb_object_pairs.append(
         ("drake/manipulation/models/ycb/sdf/009_gelatin_box.sdf", X_WGelatin))
 
     # The potted meat can pose.
-    X_WMeat = _xyz_rpy_deg([-0.15, -0.62, 0.3], [-90, 0, 145])
+    X_WMeat = _xyz_rpy_deg([-0.15, -0.62, 0.14], [-90, 0, 145])
     ycb_object_pairs.append(
         ("drake/manipulation/models/ycb/sdf/010_potted_meat_can.sdf", X_WMeat))
 

--- a/examples/manipulation_station/manipulation_station.cc
+++ b/examples/manipulation_station/manipulation_station.cc
@@ -201,12 +201,12 @@ void ManipulationStation<T>::SetupClutterClearingStation(
         "drake/examples/manipulation_station/models/bin.sdf");
 
     RigidTransform<double> X_WC(RotationMatrix<double>::MakeZRotation(M_PI_2),
-                                Vector3d(-0.145, -0.63, 0.235));
+                                Vector3d(-0.145, -0.63, 0.075));
     internal::AddAndWeldModelFrom(sdf_path, "bin1", plant_->world_frame(),
                                   "bin_base", X_WC, plant_);
 
     X_WC = RigidTransform<double>(RotationMatrix<double>::MakeZRotation(M_PI),
-                                  Vector3d(0.5, -0.1, 0.235));
+                                  Vector3d(0.5, -0.1, 0.075));
     internal::AddAndWeldModelFrom(sdf_path, "bin2", plant_->world_frame(),
                                   "bin_base", X_WC, plant_);
   }


### PR DESCRIPTION
…to dramatically improve kinematic feasibility.  (Teleoping was annoying/impossible before because diff IK would constantly hit singularities)

You can see the new arrangement in http://people.csail.mit.edu/russt/uploads/clutter.html
(btw -- that file is slow to load because the ycb object meshes are enormous;[ it's not the iiwa](http://people.csail.mit.edu/russt/uploads/iiwa.html)).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13666)
<!-- Reviewable:end -->
