### PR TITLE
yaml: Correctly write out empty sub-structs

### DIFF
--- a/common/yaml/test/yaml_write_archive_test.cc
+++ b/common/yaml/test/yaml_write_archive_test.cc
@@ -184,6 +184,22 @@ struct OuterStruct {
   }
 };
 
+struct OuterWithBlankInner {
+  struct Blank {
+    template <typename Archive>
+    void Serialize(Archive* a) {}
+  };
+
+  double outer_value = NAN;
+  Blank inner_struct;
+
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(outer_value));
+    a->Visit(DRAKE_NVP(inner_struct));
+  }
+};
+
 }  // namespace
 
 namespace drake {
@@ -420,6 +436,18 @@ TEST_F(YamlWriteArchiveTest, Nested) {
   outer_value: 1.0
   inner_struct:
     inner_value: 2.0
+)R";
+  EXPECT_EQ(saved, expected);
+}
+
+TEST_F(YamlWriteArchiveTest, BlankInner) {
+  OuterWithBlankInner x;
+  x.outer_value = 1.0;
+
+  const std::string saved = Save(x);
+  const std::string expected = R"R(doc:
+  outer_value: 1.0
+  inner_struct: {}
 )R";
   EXPECT_EQ(saved, expected);
 }

--- a/common/yaml/yaml_write_archive.h
+++ b/common/yaml/yaml_write_archive.h
@@ -230,7 +230,11 @@ class YamlWriteArchive final {
     using T = typename NVP::value_type;
     const T& value = *nvp.value();
     sub_archive.Accept(value);
-    root_[nvp.name()] = std::move(sub_archive.root_);
+    YAML::Node node = std::move(sub_archive.root_);
+    if (node.IsNull()) {
+      node = YAML::Node(YAML::NodeType::Map);
+    }
+    root_[nvp.name()] = std::move(node);
   }
 
   template <typename NVP>


### PR DESCRIPTION
When a child structure did not have any elements, we were recording it as Null which trips an assertion in the emitter.  Fix and add a test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13679)
<!-- Reviewable:end -->
