### PR TITLE
Performance tweak to MultibodyTree.CalcJacobianAngularAndOrTranslationalVelocityInWorld

### DIFF
--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -559,7 +559,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def(py::init<const T&, const Eigen::Ref<const Vector3<T>>&,
                  const UnitInertia<T>&>(),
             py::arg("mass"), py::arg("p_PScm_E"), py::arg("G_SP_E"),
-            cls_doc.ctor.doc_3args)
+            py::arg("skip_validity_check"),
+            cls_doc.ctor.doc_4args)
         .def("get_mass", &Class::get_mass, cls_doc.get_mass.doc)
         .def("get_com", &Class::get_com, cls_doc.get_com.doc)
         .def("CalcComMoment", &Class::CalcComMoment, cls_doc.CalcComMoment.doc)

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -557,7 +557,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
     cls  // BR
         .def(py::init(), cls_doc.ctor.doc_0args)
         .def(py::init<const T&, const Eigen::Ref<const Vector3<T>>&,
-                 const UnitInertia<T>&>(),
+                 const UnitInertia<T>&>(), const bool,
             py::arg("mass"), py::arg("p_PScm_E"), py::arg("G_SP_E"),
             py::arg("skip_validity_check"),
             cls_doc.ctor.doc_4args)

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -559,8 +559,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def(py::init<const T&, const Eigen::Ref<const Vector3<T>>&,
                  const UnitInertia<T>&, const bool>(),
             py::arg("mass"), py::arg("p_PScm_E"), py::arg("G_SP_E"),
-            py::arg("skip_validity_check") = false,
-            cls_doc.ctor.doc_4args)
+            py::arg("skip_validity_check") = false, cls_doc.ctor.doc_4args)
         .def("get_mass", &Class::get_mass, cls_doc.get_mass.doc)
         .def("get_com", &Class::get_com, cls_doc.get_com.doc)
         .def("CalcComMoment", &Class::CalcComMoment, cls_doc.CalcComMoment.doc)

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -557,7 +557,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
     cls  // BR
         .def(py::init(), cls_doc.ctor.doc_0args)
         .def(py::init<const T&, const Eigen::Ref<const Vector3<T>>&,
-                 const UnitInertia<T>&>(), const bool,
+                 const UnitInertia<T>&, const bool>(),
             py::arg("mass"), py::arg("p_PScm_E"), py::arg("G_SP_E"),
             py::arg("skip_validity_check"),
             cls_doc.ctor.doc_4args)

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -559,7 +559,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def(py::init<const T&, const Eigen::Ref<const Vector3<T>>&,
                  const UnitInertia<T>&, const bool>(),
             py::arg("mass"), py::arg("p_PScm_E"), py::arg("G_SP_E"),
-            py::arg("skip_validity_check"),
+            py::arg("skip_validity_check") = false,
             cls_doc.ctor.doc_4args)
         .def("get_mass", &Class::get_mass, cls_doc.get_mass.doc)
         .def("get_com", &Class::get_com, cls_doc.get_com.doc)

--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -339,6 +339,7 @@ drake_cc_googletest(
     name = "spatial_inertia_test",
     deps = [
         ":spatial_inertia",
+        "//common/test_utilities:expect_no_throw",
         "//math:geometric_transform",
         "//math:gradient",
     ],

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -1691,19 +1691,16 @@ void MultibodyTree<T>::CalcJacobianTranslationalVelocityHelper(
   // TODO(Mitiguy): When performance becomes an issue, optimize this method by
   // only using the kinematics path from A to B.
 
-  // In the common, but special, case where A is the world W, only call 
-  // CalcJacobianAngularAndOrTranslationalVelocityInWorld once using the pointer
-  // to the result Js_v_ABi_W.
-  if (&frame_A == &world_frame()) {
-  CalcJacobianAngularAndOrTranslationalVelocityInWorld(context,
-    with_respect_to, frame_B, p_WoBi_W, nullptr, Js_v_ABi_W);
-    return;
-  }
-
   // Calculate each point Bi's translational velocity Jacobian in world W.
   // The result is Js_v_WBi_W, but we store into Js_v_ABi_W for performance.
   CalcJacobianAngularAndOrTranslationalVelocityInWorld(context,
     with_respect_to, frame_B, p_WoBi_W, nullptr, Js_v_ABi_W);
+
+  // In the common, but special, case where A is the world W, we are done since
+  /// Js_v_ABi_W = Js_v_WBi_W
+  if (&frame_A == &world_frame()) {
+    return;
+  }
 
   // Calculate each point Ai's translational velocity Jacobian in world W.
   MatrixX<T> Js_v_WAi_W(3 * num_points, num_columns);

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -1876,12 +1876,11 @@ void MultibodyTree<T>::CalcJacobianAngularAndOrTranslationalVelocityInWorld(
       const Vector3<T>& p_WoBo = pc.get_X_WB(node.index()).translation();
 
       for (int ipoint = 0; ipoint < num_points; ++ipoint) {
-        // Warning: p_WoFp and p_BoFp_W are stored using Eigen temporaries!
         // Position from Wo to Fp (ith point of Fpi), expressed in world W.
-        const Vector3<T>& p_WoFp = p_WoFpi_W.col(ipoint);
+        const Vector3<T> p_WoFp = p_WoFpi_W.col(ipoint);
 
         // Position from Bo to Fp, expressed in world W.
-        const Vector3<T>& p_BoFp_W = p_WoFp - p_WoBo;
+        const Vector3<T> p_BoFp_W = p_WoFp - p_WoBo;
 
         // Point Fp's Jacobian translational velocity is placed in the output
         // memory block in the same order input points Fpi are listed on input.

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -1877,6 +1877,7 @@ void MultibodyTree<T>::CalcJacobianAngularAndOrTranslationalVelocityInWorld(
       const Vector3<T>& p_WoBo = pc.get_X_WB(node.index()).translation();
 
       for (int ipoint = 0; ipoint < num_points; ++ipoint) {
+        // Warning: p_WoFp and p_BoFp_W are stored using Eigen temporaries!
         // Position from Wo to Fp (ith point of Fpi), expressed in world W.
         const auto p_WoFp = p_WoFpi_W.col(ipoint);
 

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -1691,16 +1691,15 @@ void MultibodyTree<T>::CalcJacobianTranslationalVelocityHelper(
   // TODO(Mitiguy): When performance becomes an issue, optimize this method by
   // only using the kinematics path from A to B.
 
+
   // Calculate each point Bi's translational velocity Jacobian in world W.
   // The result is Js_v_WBi_W, but we store into Js_v_ABi_W for performance.
   CalcJacobianAngularAndOrTranslationalVelocityInWorld(context,
     with_respect_to, frame_B, p_WoBi_W, nullptr, Js_v_ABi_W);
 
-  // In the common, but special, case where A is the world W, we are done since
-  /// Js_v_ABi_W = Js_v_WBi_W
-  if (&frame_A == &world_frame()) {
-    return;
-  }
+  // For the common special case in which frame A is the world W, optimize as
+  // Js_v_ABi_W = Js_v_WBi_W
+  if (frame_A.index() == world_frame().index() ) return;
 
   // Calculate each point Ai's translational velocity Jacobian in world W.
   MatrixX<T> Js_v_WAi_W(3 * num_points, num_columns);
@@ -1709,7 +1708,7 @@ void MultibodyTree<T>::CalcJacobianTranslationalVelocityHelper(
 
   // Calculate each point Bi's translational velocity Jacobian in frame A,
   // expressed in world W. Note, again, that before this line Js_v_ABi_W
-  // is actually storing Js_v_WBi_W
+  // is actually storing Js_v_WBi_W.
   *Js_v_ABi_W -= Js_v_WAi_W;  // This calculates Js_v_ABi_W.
 }
 
@@ -1879,10 +1878,10 @@ void MultibodyTree<T>::CalcJacobianAngularAndOrTranslationalVelocityInWorld(
       for (int ipoint = 0; ipoint < num_points; ++ipoint) {
         // Warning: p_WoFp and p_BoFp_W are stored using Eigen temporaries!
         // Position from Wo to Fp (ith point of Fpi), expressed in world W.
-        const auto p_WoFp = p_WoFpi_W.col(ipoint);
+        const Vector3<T>& p_WoFp = p_WoFpi_W.col(ipoint);
 
         // Position from Bo to Fp, expressed in world W.
-        const auto p_BoFp_W = p_WoFp - p_WoBo;
+        const Vector3<T>& p_BoFp_W = p_WoFp - p_WoBo;
 
         // Point Fp's Jacobian translational velocity is placed in the output
         // memory block in the same order input points Fpi are listed on input.

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -1855,7 +1855,7 @@ void MultibodyTree<T>::CalcJacobianAngularAndOrTranslationalVelocityInWorld(
       // corresponding to the contribution of the mobilities in level ilevel.
       auto Js_w_PB_W = Js_w_WF_W->block(0, start_index, 3,
                                         mobilizer_jacobian_ncols);
-      if (is_wrt_qdot){
+      if (is_wrt_qdot) {
         Js_w_PB_W = Hw_PB_W * Nplus;
       } else {
         Js_w_PB_W = Hw_PB_W;

--- a/multibody/tree/spatial_inertia.h
+++ b/multibody/tree/spatial_inertia.h
@@ -149,7 +149,7 @@ class SpatialInertia {
   ///                                above. Defaults to false.
   SpatialInertia(
       const T& mass, const Vector3<T>& p_PScm_E, const UnitInertia<T>& G_SP_E,
-      bool check_validity = false) :
+      bool skip_validity_check = false) :
       mass_(mass), p_PScm_E_(p_PScm_E), G_SP_E_(G_SP_E) {
     if (!skip_validity_check) {
       CheckInvariants();

--- a/multibody/tree/spatial_inertia.h
+++ b/multibody/tree/spatial_inertia.h
@@ -145,10 +145,15 @@ class SpatialInertia {
   ///                     of body or composite body S expressed in frame E.
   /// @param[in] G_SP_E UnitInertia of the body or composite body S computed
   ///                   about origin point P and expressed in frame E.
+  /// @param[in] skip_validity_check If true, skips the validity check described
+  ///                                above. Defaults to false.
   SpatialInertia(
-      const T& mass, const Vector3<T>& p_PScm_E, const UnitInertia<T>& G_SP_E) :
+      const T& mass, const Vector3<T>& p_PScm_E, const UnitInertia<T>& G_SP_E,
+      bool check_validity = false) :
       mass_(mass), p_PScm_E_(p_PScm_E), G_SP_E_(G_SP_E) {
-    CheckInvariants();
+    if (!skip_validity_check) {
+      CheckInvariants();
+    }
   }
 
   /// Returns a new %SpatialInertia object templated on `Scalar` initialized
@@ -168,7 +173,8 @@ class SpatialInertia {
     return SpatialInertia<Scalar>(
         get_mass(),
         get_com().template cast<Scalar>(),
-        get_unit_inertia().template cast<Scalar>());
+        get_unit_inertia().template cast<Scalar>(),
+        false);  // Skip validity check since this inertia is already valid.
   }
 
   /// Get a constant reference to the mass of this spatial inertia.

--- a/multibody/tree/spatial_inertia.h
+++ b/multibody/tree/spatial_inertia.h
@@ -149,7 +149,7 @@ class SpatialInertia {
   ///                                above. Defaults to false.
   SpatialInertia(
       const T& mass, const Vector3<T>& p_PScm_E, const UnitInertia<T>& G_SP_E,
-      bool skip_validity_check = false) :
+      const bool skip_validity_check = false) :
       mass_(mass), p_PScm_E_(p_PScm_E), G_SP_E_(G_SP_E) {
     if (!skip_validity_check) {
       CheckInvariants();

--- a/multibody/tree/spatial_inertia.h
+++ b/multibody/tree/spatial_inertia.h
@@ -138,7 +138,9 @@ class SpatialInertia {
   /// This constructor checks for the physical validity of the resulting
   /// %SpatialInertia with IsPhysicallyValid() and throws a std::runtime_error
   /// exception in the event the provided input parameters lead to
-  /// non-physically viable spatial inertia.
+  /// non-physically viable spatial inertia. Since this check has non-negligable
+  /// runtime costs, it can be disabled by setting the optional argument
+  /// `skip_validity_check` to `true`.
   ///
   /// @param[in] mass The mass of the body or composite body S.
   /// @param[in] p_PScm_E The position vector from point P to the center of mass

--- a/multibody/tree/spatial_inertia.h
+++ b/multibody/tree/spatial_inertia.h
@@ -174,7 +174,7 @@ class SpatialInertia {
         get_mass(),
         get_com().template cast<Scalar>(),
         get_unit_inertia().template cast<Scalar>(),
-        false);  // Skip validity check since this inertia is already valid.
+        true);  // Skip validity check since this inertia is already valid.
   }
 
   /// Get a constant reference to the mass of this spatial inertia.

--- a/multibody/tree/test/spatial_inertia_test.cc
+++ b/multibody/tree/test/spatial_inertia_test.cc
@@ -13,6 +13,7 @@
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/tree/rotational_inertia.h"
 #include "drake/multibody/tree/unit_inertia.h"
+#include "drake/common/test_utilities/expect_no_throw.h"
 
 namespace drake {
 namespace multibody {
@@ -343,13 +344,13 @@ GTEST_TEST(SpatialInertia, IsPhysicallyValidWithCOMTooFarOut) {
   }
 }
 
-// Tessts that by setting skip_validity_check = false, it is possible to create
+// Tessts that by setting skip_validity_check = true, it is possible to create
 // invalid spatial inertias with negative mass and malformed COM
 GTEST_TEST(SpatialInertia, SkipValidityCheck) {
-  SpatialInertia<double> M_neg_mass(-1.0, Vector3d::Zero(),
-                           UnitInertia<double>::SolidSphere(1.0), true);
-  SpatialInertia<double> M_bad_com(1.0, Vector3d(2.0, 0.0, 0.0),
-                           UnitInertia<double>::SolidSphere(1.0), true);
+  DRAKE_EXPECT_NO_THROW(SpatialInertia<double>(-1.0, Vector3d::Zero(),
+                           UnitInertia<double>::SolidSphere(1.0), true));
+  DRAKE_EXPECT_NO_THROW(SpatialInertia<double>(1.0, Vector3d(2.0, 0.0, 0.0),
+                           UnitInertia<double>::SolidSphere(1.0), true));
 }
 
 // Tests the method SpatialInertia::MakeFromCentralInertia(...).

--- a/multibody/tree/test/spatial_inertia_test.cc
+++ b/multibody/tree/test/spatial_inertia_test.cc
@@ -60,10 +60,10 @@ GTEST_TEST(SpatialInertia, DefaultConstructor) {
 GTEST_TEST(SpatialInertia, ConstructionFromMasComAndUnitInertia) {
   const double mass = 2.5;
   const Vector3d com(0.1, -0.2, 0.3);
-  const Vector3d m(2.0,  2.3, 2.4);  // m for moments.
-  const Vector3d p(0.1, -0.1, 0.2);  // p for products.
-  UnitInertia<double> G(m(0), m(1), m(2), /* moments of inertia */
-                        p(0), p(1), p(2));/* products of inertia */
+  const Vector3d m(2.0, 2.3, 2.4);         // m for moments.
+  const Vector3d p(0.1, -0.1, 0.2);        // p for products.
+  UnitInertia<double> G(m(0), m(1), m(2),  /* moments of inertia */
+                        p(0), p(1), p(2)); /* products of inertia */
   SpatialInertia<double> M(mass, com, G);
   ASSERT_TRUE(M.IsPhysicallyValid());
 
@@ -96,11 +96,11 @@ GTEST_TEST(SpatialInertia, ConstructionFromMasComAndUnitInertia) {
 GTEST_TEST(SpatialInertia, CastToAutoDiff) {
   const double mass_double = 2.5;
   const Vector3d com_double(0.1, -0.2, 0.3);
-  const Vector3d m_double(2.0,  2.3, 2.4);  // m for moments.
+  const Vector3d m_double(2.0, 2.3, 2.4);   // m for moments.
   const Vector3d p_double(0.1, -0.1, 0.2);  // p for products.
   const UnitInertia<double> G_double(
-      m_double(0), m_double(1), m_double(2), /* moments of inertia */
-      p_double(0), p_double(1), p_double(2));/* products of inertia */
+      m_double(0), m_double(1), m_double(2),  /* moments of inertia */
+      p_double(0), p_double(1), p_double(2)); /* products of inertia */
   const SpatialInertia<double> M_double(mass_double, com_double, G_double);
   ASSERT_TRUE(M_double.IsPhysicallyValid());
 
@@ -139,10 +139,10 @@ GTEST_TEST(SpatialInertia, CastToAutoDiff) {
 GTEST_TEST(SpatialInertia, ShiftOperator) {
   const double mass = 2.5;
   const Vector3d com(0.1, -0.2, 0.3);
-  const Vector3d m(2.0,  2.3, 2.4);  // m for moments.
-  const Vector3d p(0.1, -0.1, 0.2);  // p for products.
-  UnitInertia<double> G(m(0), m(1), m(2), /* moments of inertia */
-                        p(0), p(1), p(2));/* products of inertia */
+  const Vector3d m(2.0, 2.3, 2.4);         // m for moments.
+  const Vector3d p(0.1, -0.1, 0.2);        // p for products.
+  UnitInertia<double> G(m(0), m(1), m(2),  /* moments of inertia */
+                        p(0), p(1), p(2)); /* products of inertia */
   SpatialInertia<double> M(mass, com, G);
 
   std::stringstream stream;
@@ -168,10 +168,8 @@ GTEST_TEST(SpatialInertia, PlusEqualOperator) {
   const double mass_right = 1.5;  // Mass of the cube on the right.
   // So far the "about point" is the cube's centroid.
   // We'll shift the about point below.
-  SpatialInertia<double> MRightBox_Wo_W(
-      mass_right,
-      Vector3d::Zero(),
-      UnitInertia<double>::SolidCube(L));
+  SpatialInertia<double> MRightBox_Wo_W(mass_right, Vector3d::Zero(),
+                                        UnitInertia<double>::SolidCube(L));
   MRightBox_Wo_W.ShiftInPlace(-Vector3d::UnitX());
   // Check if after transformation this still is a physically valid inertia.
   EXPECT_TRUE(MRightBox_Wo_W.IsPhysicallyValid());
@@ -181,10 +179,8 @@ GTEST_TEST(SpatialInertia, PlusEqualOperator) {
   const double mass_left = 0.5;  // Mass of the cube on the left.
   // So far the "about point" is the cube's centroid.
   // We'll shift the about point below.
-  SpatialInertia<double> MLeftBox_Wo_W(
-      mass_left,
-      Vector3d::Zero(),
-      UnitInertia<double>::SolidCube(L));
+  SpatialInertia<double> MLeftBox_Wo_W(mass_left, Vector3d::Zero(),
+                                       UnitInertia<double>::SolidCube(L));
   MLeftBox_Wo_W.ShiftInPlace(Vector3d::UnitX());
   // Check if after transformation this still is a physically valid inertia.
   EXPECT_TRUE(MLeftBox_Wo_W.IsPhysicallyValid());
@@ -207,13 +203,11 @@ GTEST_TEST(SpatialInertia, PlusEqualOperator) {
   // We compute here in `com` the center of mass of the combined system
   // consisting of the two boxes.
   const double mass = mass_left + mass_right;
-  const Vector3d com(
-      (mass_left * MLeftBox_Wo_W.get_com() +
-       mass_right * MRightBox_Wo_W.get_com()) / mass);
+  const Vector3d com((mass_left * MLeftBox_Wo_W.get_com() +
+                      mass_right * MRightBox_Wo_W.get_com()) /
+                     mass);
   SpatialInertia<double> MExpected_Wo_W(
-      mass,
-      com,
-      UnitInertia<double>::SolidBox(2 * L, L, L));
+      mass, com, UnitInertia<double>::SolidBox(2 * L, L, L));
   EXPECT_TRUE(MBox_Wo_W.CopyToFullMatrix6().isApprox(
       MExpected_Wo_W.CopyToFullMatrix6(), kEpsilon));
 }
@@ -223,7 +217,7 @@ GTEST_TEST(SpatialInertia, ReExpress) {
   // Spatial inertia for a cube C computed about a point P and expressed in a
   // frame E.
   const double Lx = 0.2, Ly = 1.0, Lz = 0.5;  // Cube's lengths.
-  const double mass = 1.3;  // Cube's mass
+  const double mass = 1.3;                    // Cube's mass
   SpatialInertia<double> M_CP_E(  // First computed about its centroid.
       mass, Vector3d::Zero(), UnitInertia<double>::SolidBox(Lx, Ly, Lz));
   // Shift to point P placed one unit in the y direction along the y axis in
@@ -277,7 +271,7 @@ GTEST_TEST(SpatialInertia, Shift) {
   M_BBcm_W.ReExpressInPlace(R_WB);
 
   // Vector from Bcm to the the top of the cylinder Btop.
-  Vector3d p_BcmBtop_W(0, length/2.0, 0);
+  Vector3d p_BcmBtop_W(0, length / 2.0, 0);
 
   // Computes spatial inertia about Btop, still expressed in W.
   SpatialInertia<double> M_BBtop_W = M_BBcm_W.Shift(p_BcmBtop_W);
@@ -294,8 +288,8 @@ GTEST_TEST(SpatialInertia, Shift) {
 
   // Expected moment of inertia for a rod when computed about one of its ends.
   const double I_end =
-      mass * (3 * radius * radius + length * length) / 12  /*About centroid.*/
-      + mass * length * length / 4;  /*Parallel axis theorem shift.*/
+      mass * (3 * radius * radius + length * length) / 12 /*About centroid.*/
+      + mass * length * length / 4; /*Parallel axis theorem shift.*/
   const auto I_Xo_W = M_BBtop_W.CalcRotationalInertia();
   EXPECT_NEAR(I_Xo_W(0, 0), I_end, kEpsilon);
   EXPECT_NEAR(I_Xo_W(2, 2), I_end, kEpsilon);
@@ -311,9 +305,8 @@ GTEST_TEST(SpatialInertia, Shift) {
 // since IsPhysicallyValid() will fail in the constructor.
 GTEST_TEST(SpatialInertia, IsPhysicallyValidWithNegativeMass) {
   try {
-    SpatialInertia<double> M(
-        -1.0, Vector3d::Zero(),
-        UnitInertia<double>::SolidSphere(1.0));
+    SpatialInertia<double> M(-1.0, Vector3d::Zero(),
+                             UnitInertia<double>::SolidSphere(1.0));
     GTEST_FAIL();
   } catch (std::runtime_error& e) {
     std::string expected_msg =
@@ -333,9 +326,8 @@ GTEST_TEST(SpatialInertia, IsPhysicallyValidWithNegativeMass) {
 // inconsistently too far out for the unit inertia provided.
 GTEST_TEST(SpatialInertia, IsPhysicallyValidWithCOMTooFarOut) {
   try {
-    SpatialInertia<double> M(
-        1.0, Vector3d(2.0, 0.0, 0.0),
-        UnitInertia<double>::SolidSphere(1.0));
+    SpatialInertia<double> M(1.0, Vector3d(2.0, 0.0, 0.0),
+                             UnitInertia<double>::SolidSphere(1.0));
     GTEST_FAIL();
   } catch (std::runtime_error& e) {
     std::string expected_msg =
@@ -349,6 +341,15 @@ GTEST_TEST(SpatialInertia, IsPhysicallyValidWithCOMTooFarOut) {
         " is not physically valid. See SpatialInertia::IsPhysicallyValid()";
     EXPECT_EQ(e.what(), expected_msg);
   }
+}
+
+// Tessts that by setting skip_validity_check = false, it is possible to create
+// invalid spatial inertias with negative mass and malformed COM
+GTEST_TEST(SpatialInertia, SkipValidityCheck) {
+  SpatialInertia<double> M_neg_mass(-1.0, Vector3d::Zero(),
+                           UnitInertia<double>::SolidSphere(1.0), true);
+  SpatialInertia<double> M_bad_com(1.0, Vector3d(2.0, 0.0, 0.0),
+                           UnitInertia<double>::SolidSphere(1.0), true);
 }
 
 // Tests the method SpatialInertia::MakeFromCentralInertia(...).
@@ -369,8 +370,8 @@ GTEST_TEST(SpatialInertia, MakeFromCentralInertia) {
   // Check spatial inertia for proper moments/products of inertia.
   // Note: The values below for Ixx, Iyy, Izz were calculated by MotionGenesis.
   const RotationalInertia<double> I_BBo_B = M_BBo_B.CalcRotationalInertia();
-  const Vector3d moments  = I_BBo_B.get_moments();
-  const double Ixx = 88, Iyy = 75,  Izz = 58;
+  const Vector3d moments = I_BBo_B.get_moments();
+  const double Ixx = 88, Iyy = 75, Izz = 58;
   EXPECT_NEAR(moments(0), Ixx, kEpsilon);
   EXPECT_NEAR(moments(1), Iyy, kEpsilon);
   EXPECT_NEAR(moments(2), Izz, kEpsilon);
@@ -421,8 +422,7 @@ GTEST_TEST(SpatialInertia, KineticEnergy) {
   const Vector3<double>& w_WB = V_WBcm.rotational();
   const Vector3<double>& v_WBcm = V_WBcm.translational();
   const double ke_WB_expected =
-      0.5 * w_WB.dot(I_Bcm_W * w_WB) +
-      0.5 * mass * v_WBcm.squaredNorm();
+      0.5 * w_WB.dot(I_Bcm_W * w_WB) + 0.5 * mass * v_WBcm.squaredNorm();
 
   EXPECT_NEAR(ke_WB, ke_WB_expected, 50 * kEpsilon);
 }
@@ -455,9 +455,9 @@ GTEST_TEST(SpatialInertia, SymbolicNan) {
 
   const Variable mass{"m"};
   const Vector3<T> p_PScm_E = symbolic::MakeVectorContinuousVariable(3, "p");
-  const UnitInertia<T> G_SP_E{
-      Variable{"Ixx"}, Variable{"Iyy"}, Variable{"Izz"},
-      Variable{"Ixy"}, Variable{"Ixz"}, Variable{"Iyz"}};
+  const UnitInertia<T> G_SP_E{Variable{"Ixx"}, Variable{"Iyy"},
+                              Variable{"Izz"}, Variable{"Ixy"},
+                              Variable{"Ixz"}, Variable{"Iyz"}};
   const SpatialInertia<T> I{mass, p_PScm_E, G_SP_E};
   ASSERT_EQ(
       I.IsNaN().to_string(),
@@ -473,10 +473,10 @@ GTEST_TEST(SpatialInertia, SymbolicConstant) {
   // Make a "constant" symbolic expression of a spatial inertia.
   const T mass(2.5);
   const Vector3<T> com(0.1, -0.2, 0.3);
-  const Vector3<T> m(2.0,  2.3, 2.4);  // m for moments.
+  const Vector3<T> m(2.0, 2.3, 2.4);   // m for moments.
   const Vector3<T> p(0.1, -0.1, 0.2);  // p for products.
-  UnitInertia<T> G(m(0), m(1), m(2), /* moments of inertia */
-                   p(0), p(1), p(2));/* products of inertia */
+  UnitInertia<T> G(m(0), m(1), m(2),   /* moments of inertia */
+                   p(0), p(1), p(2));  /* products of inertia */
   SpatialInertia<T> M(mass, com, G);
 
   // The expression can still be evaluated since all terms are constants.

--- a/multibody/tree/test/spatial_inertia_test.cc
+++ b/multibody/tree/test/spatial_inertia_test.cc
@@ -8,12 +8,12 @@
 #include "drake/common/autodiff.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/symbolic.h"
+#include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/math/autodiff.h"
 #include "drake/math/autodiff_gradient.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/tree/rotational_inertia.h"
 #include "drake/multibody/tree/unit_inertia.h"
-#include "drake/common/test_utilities/expect_no_throw.h"
 
 namespace drake {
 namespace multibody {


### PR DESCRIPTION
Identified CalcJacobianTranslationalVelocity and MultibodyTree inertia calculations as hotspots in MultibodyPlant Profiling. This PR contains three changes:

### CalcJacobianAngularAndOrTranslationalVelocityInWorld
On Cassie, as evaluated by callgrind, this reduced the estimated cycles per call from 4313 to 3076. Results in a >10% runtime reduction for benchmark trajectory optimization tasks.

This change uses auto instead of Vector3<T> to avoid resolving Eigen expressions (Eigen's dense assignment loop was identified as the bulk of the computational cost. It also avoids the very common multiplication by the identity matrix, whenever the Jacobian is w.r.t. v.

### SpatialInertia
MultibodyTree.CalcSpatialInertiaInBodyFrame() should be a free operation, but by calling SpatialInertia.cast(), it was triggering a re-validation of the inertia.

Added a flag to skip validation during construction.

### CalcJacobianTranslationalVelocityHelper
Eigen's dense assignment was identified here as a hotspot. There are two changes:

1. The previous version assigned three copies of J (J_A, J_B, and J_B - J_A). By re-using the return parameter, this can be reduced to two assignments.
2. If Frame A = World (very common), skips the second call to CalcJacobianAngularAndOrTranslationalVelocityInWorld. While CalcJacobianAngularAndOrTranslationalVelocityInWorld does not perform computation if called on the world frame, skipping this second call avoids another assignment operation.

In the case where A = World, this reduced cycles for CalcJacobianTranslationalVelocityHelper from about 7000 to less than 5000.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13682)
<!-- Reviewable:end -->
