### PR TITLE
checks for strictly positive penetration_allowance in MBP::set_penetration_allowance()

### DIFF
--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1003,6 +1003,12 @@ void MultibodyPlant<T>::CalcNormalAndTangentContactJacobians(
 template <typename T>
 void MultibodyPlant<T>::set_penetration_allowance(
     double penetration_allowance) {
+  if (penetration_allowance <= 0) {
+    throw std::logic_error(
+        "set_penetration_allowance(): penetration_allowance must be strictly "
+        "positive.");
+  }
+
   penetration_allowance_ = penetration_allowance;
   // We update the point contact parameters when this method is called
   // post-finalize.

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1492,6 +1492,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// penalty method used to impose non-penetration among bodies. Refer to the
   /// section @ref mbp_penalty_method "Contact by penalty method" for further
   /// details.
+  ///
+  /// @throws std::logic_error if penetration_allowance is not positive.
   void set_penetration_allowance(double penetration_allowance = 0.001);
 
   /// Returns a time-scale estimate `tc` based on the requested penetration

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -143,6 +143,16 @@ GTEST_TEST(MultibodyPlant, SimpleModelCreation) {
   // We should throw an exception if finalize is called twice.  Verify this.
   EXPECT_THROW(plant->Finalize(), std::logic_error);
 
+  // Verify that a non-positive penetration_allowance throws an exception.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      plant->set_penetration_allowance(-1), std::logic_error,
+      "set_penetration_allowance\\(\\): penetration_allowance must be strictly "
+      "positive.");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      plant->set_penetration_allowance(0), std::logic_error,
+      "set_penetration_allowance\\(\\): penetration_allowance must be strictly "
+      "positive.");
+
   // Verify the final model size for the model as a whole and for each instance.
   EXPECT_EQ(plant->num_bodies(), 5);
   EXPECT_EQ(plant->num_joints(), 4);


### PR DESCRIPTION
Adds a check for strictly positive penetration allowance, and throws an exception if not.
Adds simple test to verify the exception.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13694)
<!-- Reviewable:end -->
