### PR TITLE
[render] Make the gl_renderer package public

### DIFF
--- a/geometry/render/gl_renderer/BUILD.bazel
+++ b/geometry/render/gl_renderer/BUILD.bazel
@@ -15,7 +15,7 @@ load(
     "drake_cc_package_library_gl_per_os",
 )
 
-package(default_visibility = ["//geometry/render/gl_renderer:__subpackages__"])
+package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library_gl_per_os(
     name = "gl_renderer",


### PR DESCRIPTION
This allows downstream users access to some of the components that `RenderEngineGl` relies on -- e.g., `OpenGlGeometry`, `OpenGlContext`, `ShaderProgram`, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13695)
<!-- Reviewable:end -->
