### PR TITLE
Prep TAMSI for discrete hydro info

### DIFF
--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3885,12 +3885,11 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // During the time span dt the problem data M, Jn, Jt and minus_tau, are
   // approximated to be constant, a first order approximation.
   TamsiSolverResult SolveUsingSubStepping(
-      int num_substeps,
-      const MatrixX<T>& M0, const MatrixX<T>& Jn, const MatrixX<T>& Jt,
-      const VectorX<T>& minus_tau,
+      int num_substeps, const MatrixX<T>& M0, const MatrixX<T>& Jn,
+      const MatrixX<T>& Jt, const VectorX<T>& minus_tau,
       const VectorX<T>& stiffness, const VectorX<T>& damping,
-      const VectorX<T>& mu,
-      const VectorX<T>& v0, const VectorX<T>& phi0) const;
+      const VectorX<T>& mu, const VectorX<T>& v0, const VectorX<T>& phi0,
+      const VectorX<T>& fn0) const;
 
   // This method uses the time stepping method described in
   // TamsiSolver to advance the model's state stored in

--- a/multibody/plant/tamsi_solver.cc
+++ b/multibody/plant/tamsi_solver.cc
@@ -278,9 +278,9 @@ template <typename T>
 void TamsiSolver<T>::SetTwoWayCoupledProblemData(
     EigenPtr<const MatrixX<T>> M, EigenPtr<const MatrixX<T>> Jn,
     EigenPtr<const MatrixX<T>> Jt, EigenPtr<const VectorX<T>> p_star,
-    EigenPtr<const VectorX<T>> x0, EigenPtr<const VectorX<T>> stiffness,
+    EigenPtr<const VectorX<T>> fn0, EigenPtr<const VectorX<T>> stiffness,
     EigenPtr<const VectorX<T>> dissipation, EigenPtr<const VectorX<T>> mu) {
-  nc_ = x0->size();
+  nc_ = fn0->size();
   DRAKE_THROW_UNLESS(p_star->size() == nv_);
   DRAKE_THROW_UNLESS(M->rows() == nv_ && M->cols() == nv_);
   DRAKE_THROW_UNLESS(Jn->rows() == nc_ && Jn->cols() == nv_);
@@ -289,7 +289,7 @@ void TamsiSolver<T>::SetTwoWayCoupledProblemData(
   DRAKE_THROW_UNLESS(stiffness->size() == nc_);
   DRAKE_THROW_UNLESS(dissipation->size() == nc_);
   // Keep references to the problem data.
-  problem_data_aliases_.SetTwoWayCoupledData(M, Jn, Jt, p_star, x0, stiffness,
+  problem_data_aliases_.SetTwoWayCoupledData(M, Jn, Jt, p_star, fn0, stiffness,
                                              dissipation, mu);
   variable_size_workspace_.ResizeIfNeeded(nc_, nv_);
 }
@@ -454,7 +454,6 @@ void TamsiSolver<T>::CalcFrictionForcesGradient(
 
 template <typename T>
 void TamsiSolver<T>::CalcNormalForces(
-    const Eigen::Ref<const VectorX<T>>& x,
     const Eigen::Ref<const VectorX<T>>& vn,
     const Eigen::Ref<const MatrixX<T>>& Jn,
     double dt,
@@ -472,47 +471,47 @@ void TamsiSolver<T>::CalcNormalForces(
   }
 
   // Convenient aliases to problem data.
+  const auto& fn0 = problem_data_aliases_.fn0();
   const auto& stiffness = problem_data_aliases_.stiffness();
   const auto& dissipation = problem_data_aliases_.dissipation();
 
-  VectorX<T> x_capped(nc);  // = x₊
-  VectorX<T> H_x(nc);  // = H(x), with H the Heaviside function.
-  VectorX<T> k_vn_capped(nc);  // = k(vₙ)₊ = k (1 − d vₙ)₊
-  VectorX<T> H_k_vn(nc);  // = H(k(vₙ)).
+  // Below we use the following notation:
+  //   (x)₊ =  max(x, 0),
+  //   H(x) = d(x)₊/dx, the Heaviside function.
+  // We define the undamped normal force as undamped_fn = (fₙ₀ − h k vₙ)₊.
+  VectorX<T> undamped_fn(nc);
+  // We define damping_factor = (1 − d vₙ)₊.
+  VectorX<T> damping_factor(nc);
+  VectorX<T> H_damping_factor(nc);  // = H(1 − d vₙ)
+  VectorX<T> H_undamped_fn(nc);     // = H(fₙ₀ − h k vₙ)
 
   auto& fn = *fn_ptr;
   for (int ic = 0; ic < nc; ++ic) {
-    // Stiffness as a function of vn, k(vₙ) = k (1 − d vₙ)₊
-    // where x₊ = max(x, 0).
-    T k_vn = stiffness(ic) * (1.0 - dissipation(ic) * vn(ic));
+    const T signed_damping_factor = (1.0 - dissipation(ic) * vn(ic));
+    damping_factor(ic) = max(0.0, signed_damping_factor);
 
-    k_vn_capped(ic) = max(0.0, k_vn);
-    x_capped(ic) = max(0.0, x(ic));
-    // fₙ = k(vₙ)₊ x₊
-    fn(ic) = k_vn_capped(ic) * x_capped(ic);
-    // Factors in the derivatives of x₊ and k(vₙ)₊
-    H_x(ic) = x(ic) > 0 ? 1.0 : 0.0;
-    H_k_vn(ic) = k_vn > 0 ? 1.0 : 0.0;
+    // fₙ = (1 − d vₙ)₊ (fₙ₀ − h k vₙ)₊
+    const T signed_undamped_fn = fn0(ic) - dt * stiffness(ic) * vn(ic);
+    undamped_fn(ic) = max(0.0, signed_undamped_fn);
+    fn(ic) = damping_factor(ic) * undamped_fn(ic);
+
+    // Factors in the derivatives of damping factor (1 − d vₙ)₊ and the
+    // undamped normal force defined as (fₙ₀ − h k vₙ)₊.
+    H_damping_factor(ic) = signed_damping_factor >= 0 ? 1.0 : 0.0;
+    H_undamped_fn(ic) = signed_undamped_fn >= 0 ? 1.0 : 0.0;
   }
 
-  // ∇ᵥxˢ⁺¹₊ = −δt diag(H(xˢ⁺¹)) Jₙ, with xˢ⁺¹ = xˢ − δt vₙˢ⁺¹.
-  // of size nc x nv.
-  MatrixX<T> nabla_x_capped = -dt * H_x.asDiagonal() * Jn;
+  // We simply use the product rule to compute the derivative of fₙ as a
+  // function of vₙ (on a per contact basis, that's why the use of .array()
+  // operations below). dfₙ/dvₙ = -d⋅H(1 − d vₙ)⋅(fₙ₀ − h k vₙ)₊  - h⋅k⋅(1 − d
+  // vₙ)₊⋅H(fₙ₀ − h k vₙ) Note that dfₙ/dvₙ < 0 always.
+  const VectorX<T> dfn_dvn = -(
+      dissipation.array() * H_damping_factor.array() * undamped_fn.array() +
+      dt * stiffness.array() * damping_factor.array() * H_undamped_fn.array());
 
-  // ∇ᵥk(vₙˢ⁺¹)₊ = −diag(H(k(vₙˢ⁺¹))) diag(k) diag(d) Jₙ
-  // of size nc x nv.
-  MatrixX<T> nabla_k_vn_capped = -(
-      (H_k_vn.array() *
-          stiffness.array() * dissipation.array()).matrix().asDiagonal() * Jn);
-
+  // We use the chain rule to compute Gn = ∇ᵥfₙ. Since ∇ᵥvₙ = Jn, we have:
   auto& Gn = *Gn_ptr;
-
-  // fₙ = k(vₙ)₊ x₊
-  // Gn = ∇ᵥfₙ(xˢ⁺¹, vₙˢ⁺¹) =
-  //        diag(x₊) ∇ᵥk(vₙˢ⁺¹)₊ + diag(k(vₙ)₊) ∇ᵥxˢ⁺¹₊
-  // Gn is of size nc x nv.
-  Gn = x_capped.asDiagonal() * nabla_k_vn_capped +
-      k_vn_capped.asDiagonal() * nabla_x_capped;
+  Gn = dfn_dvn.asDiagonal() * Jn;
 }
 
 template <typename T>
@@ -660,7 +659,6 @@ TamsiSolverResult TamsiSolver<T>::SolveWithGuess(
   auto mu_vt = variable_size_workspace_.mutable_mu();
   auto t_hat = variable_size_workspace_.mutable_t_hat();
   auto fn = variable_size_workspace_.mutable_fn();
-  auto x = variable_size_workspace_.mutable_x();
   auto v_slip = variable_size_workspace_.mutable_v_slip();
 
   // Initialize vt_error to an arbitrary value larger than tolerance so that the
@@ -676,14 +674,7 @@ TamsiSolverResult TamsiSolver<T>::SolveWithGuess(
     vn = Jn * v;
     vt = Jt * v;
 
-    if (has_two_way_coupling()) {
-      // Update the penetration for the two-way coupling scheme.
-      const auto& x0 = problem_data_aliases_.x0();
-      x = x0 - dt * vn;
-    }
-
-    CalcNormalForces(x, vn, Jn, dt, &fn, &Gn);
-
+    CalcNormalForces(vn, Jn, dt, &fn, &Gn);
 
     // Update v_slip, t_hat, mus and ft as a function of vt and fn.
     CalcFrictionForces(vt, fn, &v_slip, &t_hat, &mu_vt, &ft);

--- a/multibody/plant/tamsi_solver.h
+++ b/multibody/plant/tamsi_solver.h
@@ -574,9 +574,9 @@ class TamsiSolver {
   /// @param[in] p_star
   ///   The generalized momentum the system would have at `n + 1` if contact
   ///   forces were zero.
-  /// @param[in] x0
-  ///   The signed penetration distance at the previous time step. It is defined
-  ///   positive when bodies overlap.
+  /// @param[in] fn0
+  ///   Normal force at the previous time step. Always positive since bodies
+  ///   cannot attract each other.
   /// @param[in] stiffness
   ///   A vector of size `nc` storing at each ith entry the stiffness
   ///   coefficient for the ith contact pair.
@@ -606,7 +606,7 @@ class TamsiSolver {
   void SetTwoWayCoupledProblemData(
       EigenPtr<const MatrixX<T>> M, EigenPtr<const MatrixX<T>> Jn,
       EigenPtr<const MatrixX<T>> Jt, EigenPtr<const VectorX<T>> p_star,
-      EigenPtr<const VectorX<T>> x0, EigenPtr<const VectorX<T>> stiffness,
+      EigenPtr<const VectorX<T>> fn0, EigenPtr<const VectorX<T>> stiffness,
       EigenPtr<const VectorX<T>> dissipation, EigenPtr<const VectorX<T>> mu);
 
   /// Given an initial guess `v_guess`, this method uses a Newton-Raphson
@@ -748,14 +748,14 @@ class TamsiSolver {
         EigenPtr<const MatrixX<T>> M,
         EigenPtr<const MatrixX<T>> Jn, EigenPtr<const MatrixX<T>> Jt,
         EigenPtr<const VectorX<T>> p_star,
-        EigenPtr<const VectorX<T>> x0,
+        EigenPtr<const VectorX<T>> fn0,
         EigenPtr<const VectorX<T>> stiffness,
         EigenPtr<const VectorX<T>> dissipation, EigenPtr<const VectorX<T>> mu) {
       DRAKE_DEMAND(M != nullptr);
       DRAKE_DEMAND(Jn != nullptr);
       DRAKE_DEMAND(Jt != nullptr);
       DRAKE_DEMAND(p_star != nullptr);
-      DRAKE_DEMAND(x0 != nullptr);
+      DRAKE_DEMAND(fn0 != nullptr);
       DRAKE_DEMAND(stiffness != nullptr);
       DRAKE_DEMAND(dissipation != nullptr);
       DRAKE_DEMAND(mu != nullptr);
@@ -766,7 +766,7 @@ class TamsiSolver {
       Jn_ptr_ = Jn;
       Jt_ptr_ = Jt;
       p_star_ptr_ = p_star;
-      x0_ptr_ = x0;
+      fn0_ptr_ = fn0;
       stiffness_ptr_ = stiffness;
       dissipation_ptr_ = dissipation;
       mu_ptr_ = mu;
@@ -794,9 +794,9 @@ class TamsiSolver {
     // For the two-way coupled scheme, it returns a constant reference to the
     // data for the penetration distance. It aborts if called on data for the
     // one-way coupled scheme, see has_two_way_coupling_data().
-    Eigen::Ref<const VectorX<T>> x0() const {
-      DRAKE_DEMAND(x0_ptr_ != nullptr);
-      return *x0_ptr_;
+    Eigen::Ref<const VectorX<T>> fn0() const {
+      DRAKE_DEMAND(fn0_ptr_ != nullptr);
+      return *fn0_ptr_;
     }
 
     // For the two-way coupled scheme, it returns a constant reference to the
@@ -837,10 +837,9 @@ class TamsiSolver {
     // Normal force at each contact point. fn_ptr_ is nullptr for two-way
     // coupled problems.
     EigenPtr<const VectorX<T>> fn_ptr_{nullptr};
-    // Penetration distance. Positive when there is penetration and negative
-    // when there is separation, i.e. it is minus the signed distance function.
-    // x0_ptr_ is nullptr for one-way coupled problems.
-    EigenPtr<const VectorX<T>> x0_ptr_{nullptr};
+    // Normal force at previous time step t0. Always positive.
+    // fn0_ptr_ is nullptr for one-way coupled problems.
+    EigenPtr<const VectorX<T>> fn0_ptr_{nullptr};
     // Stiffness in the normal direction. nullptr for one-way coupled problems.
     EigenPtr<const VectorX<T>> stiffness_ptr_{nullptr};
     // Damping in the normal direction. nullptr for one-way coupled problems.
@@ -921,7 +920,6 @@ class TamsiSolver {
       vt_.resize(nf);
       fn_.resize(nc);
       ft_.resize(nf);
-      x_.resize(nc);
       Delta_vn_.resize(nc);
       Delta_vt_.resize(nf);
       t_hat_.resize(nf);
@@ -983,12 +981,6 @@ class TamsiSolver {
       return fn_.segment(0, nc_);
     }
 
-    // Returns a mutable reference to the vector containing the penetration
-    // depths for all contact points, of size nc.
-    Eigen::VectorBlock<VectorX<T>> mutable_x() {
-      return x_.segment(0, nc_);
-    }
-
     // Returns a constant reference to the vector containing the tangential
     // friction forces fₜ for all contact points. fₜ has size 2nc since it
     // stores the two tangential components of the friction force for each
@@ -1043,7 +1035,6 @@ class TamsiSolver {
     VectorX<T> vt_;        // vₜᵏ, in ℝ²ⁿᶜ.
     VectorX<T> fn_;        // fₙᵏ, in ℝⁿᶜ.
     VectorX<T> ft_;        // fₜᵏ, in ℝ²ⁿᶜ.
-    VectorX<T> x_;         // xˢ⁺¹ = xˢ − δt vₙˢ
     VectorX<T> t_hat_;     // Tangential directions, t̂ᵏ. In ℝ²ⁿᶜ.
     VectorX<T> v_slip_;    // vₛᵏ = ‖vₜᵏ‖, in ℝⁿᶜ.
     VectorX<T> mus_;       // (modified) regularized friction, in ℝⁿᶜ.
@@ -1066,7 +1057,6 @@ class TamsiSolver {
   // In addition, this method also computes the gradient
   // Gn = ∇ᵥfₙ(xˢ⁺¹, vₙˢ⁺¹).
   void CalcNormalForces(
-      const Eigen::Ref<const VectorX<T>>& x,
       const Eigen::Ref<const VectorX<T>>& vn,
       const Eigen::Ref<const MatrixX<T>>& Jn,
       double dt,

--- a/multibody/plant/test/tamsi_solver_test.cc
+++ b/multibody/plant/test/tamsi_solver_test.cc
@@ -38,20 +38,13 @@ class TamsiSolverTester {
     auto v_slip = solver.variable_size_workspace_.mutable_v_slip();
     std::vector<Matrix2<double>>& dft_dvt =
         solver.variable_size_workspace_.mutable_dft_dvt();
-    auto x = solver.variable_size_workspace_.mutable_x();
 
     // Normal separation velocity.
     vn = Jn * v;
 
-    if (solver.has_two_way_coupling()) {
-      const auto x0 = solver.problem_data_aliases_.x0();
-      // Penetration distance (positive when there is penetration).
-      x = x0 - dt * vn;
-    }
-
     // Computes friction forces fn and gradients Gn as a function of x, vn,
     // Jn and dt.
-    solver.CalcNormalForces(x, vn, Jn, dt, &fn, &Gn);
+    solver.CalcNormalForces(vn, Jn, dt, &fn, &Gn);
 
     // Tangential velocity.
     vt = Jt * v;
@@ -863,6 +856,7 @@ class RollingCylinder : public ::testing::Test {
     x0_ = VectorX<double>::Constant(nc_, xini / nc_);
     const double k = m_ * g_ / penetration_allowance;
     stiffness_ = VectorX<double>::Constant(nc_, k);
+    fn0_ = stiffness_.array() * x0_.array();
     const double omega = sqrt(stiffness_(0) / m_);
     const double time_scale = 1.0 / omega;
     const double damping_ratio = 1.0;
@@ -870,7 +864,7 @@ class RollingCylinder : public ::testing::Test {
         damping_ratio * time_scale / penetration_allowance;
     dissipation_ = VectorX<double>::Constant(nc_, dissipation);
 
-    solver_.SetTwoWayCoupledProblemData(&M_, &Jn_, &Jt_, &p_star_, &x0_,
+    solver_.SetTwoWayCoupledProblemData(&M_, &Jn_, &Jt_, &p_star_, &fn0_,
                                         &stiffness_, &dissipation_,
                                         &mu_vector_);
   }
@@ -915,6 +909,7 @@ class RollingCylinder : public ::testing::Test {
   VectorX<double> stiffness_;
   VectorX<double> dissipation_;
   VectorX<double> x0_;
+  VectorX<double> fn0_;
 
   // TAMSI solver for this problem.
   TamsiSolver<double> solver_{nv_};
@@ -1110,11 +1105,11 @@ GTEST_TEST(EmptyWorld, Solve) {
   TamsiSolver<double> solver{nv};
 
   // (Empty) problem data.
-  VectorX<double> p_star, mu_vector, x0, stiffness, dissipation;
+  VectorX<double> p_star, mu_vector, fn0, stiffness, dissipation;
   MatrixX<double> M, Jn, Jt;
 
   DRAKE_EXPECT_NO_THROW(solver.SetTwoWayCoupledProblemData(
-      &M, &Jn, &Jt, &p_star, &x0, &stiffness, &dissipation, &mu_vector));
+      &M, &Jn, &Jt, &p_star, &fn0, &stiffness, &dissipation, &mu_vector));
 }
 
 }  // namespace


### PR DESCRIPTION
This PR is a refactor of the math TAMSI does so that the solver is agnostic to whether the point pair info corresponds to penetration pairs (point contact) or quadrature pairs (e.g. hydro). 

This follows the math in the draft paper I shared with the dynamics team. The refactor is simply swapping `phi0` with `fn0 = k * phi0` so that the solver does not think anymore in terms of distances but in terms of (undamped) normal forces at the previous step, i.e. fn0.

I used the word "refactor" because this simply is a change of variables, all unit tests in master should result in the same results from the TAMSI solver.

cc'ing @DamrongGuoy, @SeanCurtis-TRI 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13696)
<!-- Reviewable:end -->
