### PR TITLE
yaml: Add SubtractDefaults to YamlWriteArchive

### DIFF
--- a/common/yaml/BUILD.bazel
+++ b/common/yaml/BUILD.bazel
@@ -89,4 +89,12 @@ drake_cc_googletest(
     ],
 )
 
+drake_cc_googletest(
+    name = "yaml_write_archive_defaults_test",
+    deps = [
+        ":example_structs",
+        ":yaml_write_archive",
+    ],
+)
+
 add_lint_tests()

--- a/common/yaml/test/yaml_read_archive_test.cc
+++ b/common/yaml/test/yaml_read_archive_test.cc
@@ -381,7 +381,7 @@ TEST_P(YamlReadArchiveTest, Optional) {
 
 TEST_P(YamlReadArchiveTest, Variant) {
   const auto test = [](const std::string& doc,
-                       const Variant3& expected) {
+                       const Variant4& expected) {
     const auto& x = AcceptNoThrow<VariantStruct>(Load(doc));
     EXPECT_EQ(x.value, expected) << doc;
   };
@@ -734,7 +734,7 @@ TEST_P(YamlReadArchiveTest, VisitVariantFoundNoTag) {
   // std::string values should load correctly even without a YAML type tag.
   const auto& str = AcceptNoThrow<VariantWrappingStruct>(
       Load("doc:\n  inner:\n    value: foo"));
-  EXPECT_EQ(str.inner.value, Variant3("foo"));
+  EXPECT_EQ(str.inner.value, Variant4("foo"));
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       AcceptIntoDummy<VariantWrappingStruct>(
@@ -763,8 +763,8 @@ TEST_P(YamlReadArchiveTest, VisitVariantFoundUnknownTag) {
       "YAML node of type Map \\(with size 1 and keys \\{value\\}\\) "
       "has unsupported type tag !UnknownTag "
       "while selecting a variant<> entry for "
-      "std::variant<std::string,double,drake::yaml::test::DoubleStruct> "
-      "value.");
+      "std::variant<std::string,double,drake::yaml::test::DoubleStruct,"
+      "drake::yaml::test::StringStruct> value.");
 }
 
 // This finds nothing when an Eigen::Vector or Eigen::Matrix was wanted.

--- a/common/yaml/test/yaml_write_archive_defaults_test.cc
+++ b/common/yaml/test/yaml_write_archive_defaults_test.cc
@@ -1,0 +1,215 @@
+// This file tests the yaml_write_archive.h method EraseMatchingMaps(), which
+// is used to write out YAML details without repeating the default values.
+
+#include <cmath>
+#include <vector>
+
+#include <Eigen/Core>
+#include <gtest/gtest.h>
+
+#include "drake/common/yaml/test/example_structs.h"
+#include "drake/common/yaml/yaml_write_archive.h"
+
+namespace drake {
+namespace yaml {
+namespace test {
+namespace {
+
+// A test fixture with common helpers.
+class YamlWriteArchiveDefaultsTest : public ::testing::Test {
+ public:
+  template <typename DataSerializable, typename DefaultsSerializable>
+  static std::string SaveDataWithoutDefaults(
+        const DataSerializable& data,
+        const DefaultsSerializable& defaults) {
+    YamlWriteArchive defaults_archive;
+    defaults_archive.Accept(defaults);
+    YamlWriteArchive archive;
+    archive.Accept(data);
+    archive.EraseMatchingMaps(defaults_archive);
+    return archive.EmitString("doc");
+  }
+};
+
+// Shows the typical use -- that only the novel data is output.
+// The inner_struct is the same for both x and y, so is not output.
+TEST_F(YamlWriteArchiveDefaultsTest, BasicExample1) {
+  OuterStruct defaults;
+  defaults.outer_value = 1.0;
+  defaults.inner_struct.inner_value = 2.0;
+
+  OuterStruct data = defaults;
+  data.outer_value = 3.0;
+
+  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"R(doc:
+  outer_value: 3.0
+)R");
+}
+
+// Shows the typical use -- that only the novel data is output.
+// The outer_value is the same for both x and y, so is not output.
+TEST_F(YamlWriteArchiveDefaultsTest, BasicExample2) {
+  OuterStruct defaults;
+  defaults.outer_value = 1.0;
+  defaults.inner_struct.inner_value = 2.0;
+
+  OuterStruct data = defaults;
+  data.inner_struct.inner_value = 3.0;
+
+  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"R(doc:
+  inner_struct:
+    inner_value: 3.0
+)R");
+}
+
+// Same as the BasicExample1 from above, except that the map order of the
+// defaults vs data differs.  The defaults still take effect.
+TEST_F(YamlWriteArchiveDefaultsTest, DifferentMapOrder1) {
+  OuterStructOpposite defaults;
+  defaults.inner_struct.inner_value = 1.0;
+  defaults.outer_value = 2.0;
+
+  OuterStruct data;
+  data.outer_value = 3.0;
+  data.inner_struct.inner_value = defaults.inner_struct.inner_value;
+
+  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"R(doc:
+  outer_value: 3.0
+)R");
+}
+
+// Same as the BasicExample2 from above, except that the map order of the
+// defaults vs data differs.  The defaults still take effect.
+TEST_F(YamlWriteArchiveDefaultsTest, DifferentMapOrder2) {
+  OuterStructOpposite defaults;
+  defaults.inner_struct.inner_value = 1.0;
+  defaults.outer_value = 2.0;
+
+  OuterStruct data;
+  data.outer_value = defaults.outer_value;
+  data.inner_struct.inner_value = 3.0;
+
+  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"R(doc:
+  inner_struct:
+    inner_value: 3.0
+)R");
+}
+
+// YAML nulls are handled reasonably, without throwing.
+TEST_F(YamlWriteArchiveDefaultsTest, Nulls) {
+  OptionalStruct data;
+  data.value = std::nullopt;
+
+  OptionalStruct defaults = data;
+
+  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"R(doc:
+)R");
+}
+
+// Arrays differing in their values are not erased.
+TEST_F(YamlWriteArchiveDefaultsTest, DifferentArrays) {
+  ArrayStruct data;
+  data.value = { 1.0, 2.0, 3.0 };
+
+  ArrayStruct defaults;
+  defaults.value = { 0.0, 0.0, 0.0 };
+
+  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"R(doc:
+  value: [1.0, 2.0, 3.0]
+)R");
+}
+
+// Vectors differing in size (but sharing a prefix) are not erased.
+TEST_F(YamlWriteArchiveDefaultsTest, DifferentSizeVectors) {
+  VectorStruct data;
+  data.value = { 1.0, 2.0, 3.0 };
+
+  VectorStruct defaults;
+  defaults.value = { 1.0, 2.0 };
+
+  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"R(doc:
+  value: [1.0, 2.0, 3.0]
+)R");
+}
+
+// Variants differing by tag are not erased.
+TEST_F(YamlWriteArchiveDefaultsTest, DifferentVariantTag) {
+  VariantStruct data;
+  data.value = DoubleStruct{1.0};
+
+  VariantStruct defaults;
+  defaults.value = StringStruct{"1.0"};
+
+  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"R(doc:
+  value: !DoubleStruct
+    value: 1.0
+)R");
+}
+
+// Maps differing in key only (same value) are not erased.
+TEST_F(YamlWriteArchiveDefaultsTest, DifferentMapKeys) {
+  MapStruct data;
+  data.value["a"] = 1.0;
+
+  MapStruct defaults;
+  defaults.value["b"] = 1.0;
+
+  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"R(doc:
+  value:
+    a: 1.0
+)R");
+}
+
+// Maps differing in value only (same key) are not erased.
+TEST_F(YamlWriteArchiveDefaultsTest, DifferentMapValues) {
+  MapStruct data;
+  data.value["a"] = 1.0;
+
+  MapStruct defaults;
+  defaults.value["a"] = 2.0;
+
+  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"R(doc:
+  value:
+    a: 1.0
+)R");
+}
+
+// In the ununsual case that the user provided two different schemas to
+// subtract, we notice the discrepancy without throwing any exceptions.
+// This test case serves to help achieve code coverage; we do not intend
+// for users to necessarily depend on this behavior.
+// Here, we do DoubleStruct - ArrayStruct.
+TEST_F(YamlWriteArchiveDefaultsTest, DifferentSchemas) {
+  DoubleStruct data;
+  data.value = 1.0;
+
+  ArrayStruct defaults;
+
+  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"R(doc:
+  value: 1.0
+)R");
+}
+
+// In the ununsual case that the user provided two different (but similar)
+// schemas to subtract, we notice the discrepancy without throwing any
+// exceptions.  This test case serves to help achieve code coverage; we do not
+// intend for users to necessarily depend on this behavior.  Here, we do
+// OuterStruct - OuterWithBlankInner.
+TEST_F(YamlWriteArchiveDefaultsTest, DifferentInnerSchemas) {
+  OuterStruct data;
+  data.outer_value = 1.0;
+  data.inner_struct.inner_value = 2.0;
+
+  OuterWithBlankInner defaults;
+
+  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"R(doc:
+  outer_value: 1.0
+  inner_struct:
+    inner_value: 2.0
+)R");
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace yaml
+}  // namespace drake

--- a/common/yaml/test/yaml_write_archive_test.cc
+++ b/common/yaml/test/yaml_write_archive_test.cc
@@ -171,13 +171,13 @@ TEST_F(YamlWriteArchiveTest, Optional) {
 }
 
 TEST_F(YamlWriteArchiveTest, Variant) {
-  const auto test = [](const Variant3& value, const std::string& expected) {
+  const auto test = [](const Variant4& value, const std::string& expected) {
     const VariantStruct x{value};
     EXPECT_EQ(Save(x), WrapDoc(expected));
   };
 
-  test(Variant3(std::string("foo")), "foo");
-  test(Variant3(DoubleStruct{1.0}), "!DoubleStruct\n    value: 1.0");
+  test(Variant4(std::string("foo")), "foo");
+  test(Variant4(DoubleStruct{1.0}), "!DoubleStruct\n    value: 1.0");
 
   // TODO(jwnimmer-tri) We'd like to see "!!float 1.0" here, but our writer
   // does not yet support that output syntax.

--- a/common/yaml/yaml_write_archive.cc
+++ b/common/yaml/yaml_write_archive.cc
@@ -57,9 +57,13 @@ void RecursiveEmit(const YAML::Node& node, YAML::EmitFromEvents* sink) {
       std::vector<std::string> key_order;
       const YAML::Node key_order_node = node[kKeyOrder];
       if (key_order_node) {
-        // Use Accept()'s ordering.
+        // Use Accept()'s ordering.  (If SubstractDefaults has been called,
+        // some of the keys may have disappeared.)
         for (const auto& item : key_order_node) {
-          key_order.push_back(item.Scalar());
+          const std::string& key = item.Scalar();
+          if (node[key].IsDefined()) {
+            key_order.push_back(key);
+          }
         }
       } else {
         // Use alphabetical ordering.
@@ -106,6 +110,148 @@ std::string YamlWriteArchive::EmitString(const std::string& root_name) const {
     result = YamlDumpWithSortedMaps(document) + "\n";
   }
   return result;
+}
+
+namespace {
+
+// Returns true iff x and y have a identical node types and values throughout
+// their entire tree structure, but without trying to match representationally
+// distinct but semantically equal values (e.g., 0x0a compared to 10 may return
+// false even though they refer to the same integer).
+//
+// See https://github.com/jbeder/yaml-cpp/issues/274 for a feature request to
+// provide this kind of function directly as part of yaml-cpp.
+bool AreLexicallyEqual(const YAML::Node& x, const YAML::Node& y) {
+  DRAKE_DEMAND(x.IsDefined() && y.IsDefined());
+  const YAML::NodeType::value type = x.Type();
+  if (y.Type() != type) {
+    return false;
+  }
+  switch (type) {
+    case YAML::NodeType::Undefined: { DRAKE_UNREACHABLE(); }
+    case YAML::NodeType::Null: {
+      // Two nulls are always equal to each other.
+      return true;
+    }
+    case YAML::NodeType::Scalar: {
+      return x.Scalar() == y.Scalar();
+    }
+    case YAML::NodeType::Sequence: {
+      size_t size = x.size();
+      if (y.size() != size) {
+        return false;
+      }
+      for (size_t i = 0; i < size; ++i) {
+        if (!AreLexicallyEqual(x[i], y[i])) {
+          return false;
+        }
+      }
+      return true;
+    }
+    case YAML::NodeType::Map: {
+      if (x.size() != y.size()) {
+        return false;
+      }
+      if (x.Tag() != y.Tag()) {
+        return false;
+      }
+      for (const auto& x_key_value : x) {
+        const std::string& key = x_key_value.first.Scalar();
+        const YAML::Node& x_val = x_key_value.second;
+        const YAML::Node& y_val = y[key];
+        if (!y_val.IsDefined()) {
+          return false;
+        }
+        if (!AreLexicallyEqual(x_val, y_val)) {
+          return false;
+        }
+      }
+      return true;
+    }
+  }
+  DRAKE_UNREACHABLE();
+}
+
+// Implements YamlWriteArchive::EraseMatchingMaps recursively.
+void DoEraseMatchingMaps(YAML::Node* x, const YAML::Node* y) {
+  // If x and y are different types, then no subtraction that can be done.
+  DRAKE_DEMAND((x != nullptr) && (y != nullptr));
+  DRAKE_DEMAND(x->IsDefined() && y->IsDefined());
+  const YAML::NodeType::value type = x->Type();
+  if (y->Type() != type) {
+    // If the types differ, we should not subtract.
+    return;
+  }
+  // If their type is non-map, then we do not subtract them.  The reader's
+  // retain_map_defaults mode only merges default maps; it does not, e.g.,
+  // concatenate sequences.
+  switch (type) {
+    case YAML::NodeType::Undefined: { DRAKE_UNREACHABLE(); }
+    case YAML::NodeType::Null: { return; }
+    case YAML::NodeType::Scalar: { return; }
+    case YAML::NodeType::Sequence: { return; }
+    case YAML::NodeType::Map: {
+      break;
+    }
+  }
+  // Both x are y are maps.  Remove from x any key-value pair that is identical
+  // within both x and y.
+  std::vector<std::string> keys_to_prune;
+  for (const auto& x_key_value : *x) {
+    const std::string& key = x_key_value.first.Scalar();
+    if (key == kKeyOrder) {
+      // Subtraction should always leave the special kKeyOrder node alone when
+      // considering which keys to prune.  If any keys are unpruned, we still
+      // want to know in what order they should appear.  The only way to remove
+      // a kKeyOrder node is when its enclosing Map is removed wholesale.
+      continue;
+    }
+    const YAML::Node& x_val = x_key_value.second;
+    const YAML::Node& y_val = (*y)[key];
+    if (!y_val.IsDefined()) {
+      // The key only appears in x, so we should not prune.
+      continue;
+    }
+    if (!AreLexicallyEqual(x_val, y_val)) {
+      // The values do not match, so we should not prune.
+      continue;
+    }
+    keys_to_prune.push_back(key);
+  }
+  for (const auto& key : keys_to_prune) {
+    x->remove(key);
+  }
+  // Recurse into any children of x and y with the same key name.
+  for (auto&& x_key_value : *x) {
+    const std::string& key = x_key_value.first.Scalar();
+    if (key == kKeyOrder) {
+      // Subtraction should always leave the special kKeyOrder node alone.
+      // (See the other kKeyOrder guard a few lines above for details.)
+      continue;
+    }
+    YAML::Node& x_val = x_key_value.second;
+    const YAML::Node& y_val = (*y)[key];
+    if (!y_val.IsDefined()) {
+      // The key only appears in x, so we cannot recurse.
+      continue;
+    }
+    if (x_val.Tag() != y_val.Tag()) {
+      // The maps are tagged differently, so we should not subtract their
+      // children, since they may have different semantics.
+      continue;
+    }
+    DoEraseMatchingMaps(&x_val, &y_val);
+  }
+}
+
+}  // namespace
+
+void YamlWriteArchive::EraseMatchingMaps(const YamlWriteArchive& other) {
+  // Note that the implementations of DoEraseMatchingMaps and AreLexicallyEqual
+  // are both recursive.  It's possible that we could improve performance by
+  // merging them into a single recursive traveral.  However, for readability
+  // they are kept separate until we see a proven need for that optimization.
+  DoEraseMatchingMaps(&(this->root_), &(other.root_));
 }
 
 }  // namespace yaml

--- a/common/yaml/yaml_write_archive.h
+++ b/common/yaml/yaml_write_archive.h
@@ -98,6 +98,15 @@ class YamlWriteArchive final {
   /// key-value entries within it.
   std::string EmitString(const std::string& root_name = "root") const;
 
+  /// (Advanced.)  Remove from this archive any map entries that are identical
+  /// to an entry in `other`, iff they reside at the same location within the
+  /// node tree hierarchy, and iff their parent nodes (and grandparent, etc.,
+  /// all the way up to the root) are also all maps.  This enables emitting a
+  /// minimal YAML representation when the output will be later loaded using
+  /// YamlReadArchive's option to retain_map_defaults; the "all parents are
+  /// maps" condition is the complement to what retain_map_defaults admits.
+  void EraseMatchingMaps(const YamlWriteArchive& other);
+
   /// (Advanced.)  Copies the value pointed to by `nvp.value()` into the YAML
   /// object.  Most users should should call Accept, not Visit.
   template <typename NameValuePair>


### PR DESCRIPTION
This allows for emitting a minimal yaml representation when loaded with `retain_map_defaults` set on the eventual reader.  This is the minimal API to accomplish that.  I intend to provide better usability shims for this in a future commit.

See Anzu 5040 for an example use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13699)
<!-- Reviewable:end -->
