### PR TITLE
skylark: Require visibility for drake_cc_package_library

### DIFF
--- a/attic/manipulation/planner/BUILD.bazel
+++ b/attic/manipulation/planner/BUILD.bazel
@@ -14,6 +14,7 @@ package(
 
 drake_cc_package_library(
     name = "planner",
+    visibility = ["//visibility:public"],
     deps = [
         ":rbt_differential_inverse_kinematics",
     ],

--- a/attic/multibody/BUILD.bazel
+++ b/attic/multibody/BUILD.bazel
@@ -18,6 +18,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "multibody",
+    visibility = ["//visibility:public"],
     deps = [
         ":approximate_ik",
         ":global_inverse_kinematics",

--- a/attic/multibody/collision/BUILD.bazel
+++ b/attic/multibody/collision/BUILD.bazel
@@ -15,6 +15,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "collision",
+    visibility = ["//visibility:public"],
     deps = [
         ":bullet_collision",
         ":collision_api",

--- a/attic/multibody/joints/BUILD.bazel
+++ b/attic/multibody/joints/BUILD.bazel
@@ -15,6 +15,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "joints",
+    visibility = ["//visibility:public"],
     deps = [
         ":everything",
     ],

--- a/attic/multibody/parsers/BUILD.bazel
+++ b/attic/multibody/parsers/BUILD.bazel
@@ -16,6 +16,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "parsers",
+    visibility = ["//visibility:public"],
     deps = [
         ":find_files",
         ":parsing",

--- a/attic/multibody/shapes/BUILD.bazel
+++ b/attic/multibody/shapes/BUILD.bazel
@@ -15,6 +15,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "shapes",
+    visibility = ["//visibility:public"],
     deps = [
         ":everything",
     ],

--- a/attic/systems/controllers/BUILD.bazel
+++ b/attic/systems/controllers/BUILD.bazel
@@ -12,6 +12,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "controllers",
+    visibility = ["//visibility:public"],
     deps = [
         ":rbt_inverse_dynamics",
         ":rbt_inverse_dynamics_controller",

--- a/attic/systems/rendering/BUILD.bazel
+++ b/attic/systems/rendering/BUILD.bazel
@@ -12,6 +12,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "rendering",
+    visibility = ["//visibility:public"],
     deps = [
         ":drake_visualizer_client",
     ],

--- a/attic/systems/sensors/BUILD.bazel
+++ b/attic/systems/sensors/BUILD.bazel
@@ -14,6 +14,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "sensors",
+    visibility = ["//visibility:public"],
     deps = [
         ":accelerometer",
         ":depth_sensor",

--- a/attic/systems/trajectory_optimization/BUILD.bazel
+++ b/attic/systems/trajectory_optimization/BUILD.bazel
@@ -12,6 +12,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "trajectory_optimization",
+    visibility = ["//visibility:public"],
     deps = [
         ":generalized_constraint_force_evaluator",
         ":joint_limit_constraint_force_evaluator",

--- a/attic/util/BUILD.bazel
+++ b/attic/util/BUILD.bazel
@@ -12,6 +12,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "util",
+    visibility = ["//visibility:public"],
     deps = [
         ":everything",
     ],

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -20,6 +20,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "common",
+    visibility = ["//visibility:public"],
     deps = [
         ":autodiff",
         ":autodiffxd_make_coherent",

--- a/common/proto/BUILD.bazel
+++ b/common/proto/BUILD.bazel
@@ -19,6 +19,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "proto",
+    visibility = ["//visibility:public"],
     deps = [
         ":call_python",
         ":rpc_pipe_temp_directory",

--- a/common/test_utilities/BUILD.bazel
+++ b/common/test_utilities/BUILD.bazel
@@ -23,6 +23,7 @@ exports_files([
 drake_cc_package_library(
     name = "test_utilities",
     testonly = 1,
+    visibility = ["//visibility:public"],
     deps = [
         ":eigen_geometry_compare",
         ":eigen_matrix_compare",

--- a/common/trajectories/BUILD.bazel
+++ b/common/trajectories/BUILD.bazel
@@ -12,6 +12,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "trajectories",
+    visibility = ["//visibility:public"],
     deps = [
         ":bspline_trajectory",
         ":discrete_time_trajectory",

--- a/common/yaml/BUILD.bazel
+++ b/common/yaml/BUILD.bazel
@@ -13,6 +13,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "yaml",
+    visibility = ["//visibility:public"],
     deps = [
         ":yaml_read_archive",
         ":yaml_write_archive",

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -12,6 +12,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "geometry",
+    visibility = ["//visibility:public"],
     deps = [
         ":frame_kinematics",
         ":geometry_frame",

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -12,6 +12,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "proximity",
+    visibility = ["//visibility:public"],
     deps = [
         ":bounding_volume_hierarchy",
         ":collision_filter_legacy",

--- a/geometry/query_results/BUILD.bazel
+++ b/geometry/query_results/BUILD.bazel
@@ -12,6 +12,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "query_results",
+    visibility = ["//visibility:public"],
     deps = [
         ":contact_surface",
         ":penetration_as_point_pair",

--- a/geometry/render/BUILD.bazel
+++ b/geometry/render/BUILD.bazel
@@ -13,6 +13,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "render",
+    visibility = ["//visibility:public"],
     deps = [
         ":render_camera",
         ":render_engine",

--- a/geometry/render/gl_renderer/BUILD.bazel
+++ b/geometry/render/gl_renderer/BUILD.bazel
@@ -29,6 +29,7 @@ drake_cc_package_library_gl_per_os(
         ":shader_program",
         ":shape_meshes",
     ],
+    visibility = ["//visibility:public"],
 )
 
 drake_cc_library_gl_ubuntu_only(

--- a/geometry/render/shaders/BUILD.bazel
+++ b/geometry/render/shaders/BUILD.bazel
@@ -11,6 +11,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "shaders",
+    visibility = ["//visibility:public"],
     deps = [
         ":depth_shaders",
     ],

--- a/geometry/test_utilities/BUILD.bazel
+++ b/geometry/test_utilities/BUILD.bazel
@@ -14,6 +14,7 @@ package(default_visibility = ["//visibility:public"])
 drake_cc_package_library(
     name = "test_utilities",
     testonly = 1,
+    visibility = ["//visibility:public"],
     deps = [
         ":dummy_render_engine",
         ":geometry_set_tester",

--- a/lcm/BUILD.bazel
+++ b/lcm/BUILD.bazel
@@ -13,6 +13,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "lcm",
+    visibility = ["//visibility:public"],
     deps = [
         ":drake_lcm",
         ":interface",

--- a/manipulation/kinova_jaco/BUILD.bazel
+++ b/manipulation/kinova_jaco/BUILD.bazel
@@ -14,6 +14,7 @@ package(
 
 drake_cc_package_library(
     name = "kinova_jaco",
+    visibility = ["//visibility:public"],
     deps = [
         ":jaco_command_receiver",
         ":jaco_command_sender",

--- a/manipulation/kuka_iiwa/BUILD.bazel
+++ b/manipulation/kuka_iiwa/BUILD.bazel
@@ -14,6 +14,7 @@ package(
 
 drake_cc_package_library(
     name = "kuka_iiwa",
+    visibility = ["//visibility:public"],
     deps = [
         ":iiwa_command_receiver",
         ":iiwa_command_sender",

--- a/manipulation/perception/BUILD.bazel
+++ b/manipulation/perception/BUILD.bazel
@@ -13,6 +13,7 @@ load("//tools/lint:lint.bzl", "add_lint_tests")
 
 drake_cc_package_library(
     name = "perception",
+    visibility = ["//visibility:public"],
     deps = [
         ":optitrack_pose_extractor",
         ":pose_smoother",

--- a/manipulation/planner/BUILD.bazel
+++ b/manipulation/planner/BUILD.bazel
@@ -14,6 +14,7 @@ package(
 
 drake_cc_package_library(
     name = "planner",
+    visibility = ["//visibility:public"],
     deps = [
         ":constraint_relaxing_ik",
         ":differential_inverse_kinematics",

--- a/manipulation/schunk_wsg/BUILD.bazel
+++ b/manipulation/schunk_wsg/BUILD.bazel
@@ -18,6 +18,7 @@ package(
 
 drake_cc_package_library(
     name = "schunk_wsg",
+    visibility = ["//visibility:public"],
     deps = [
         ":schunk_wsg_constants",
         ":schunk_wsg_controller",

--- a/manipulation/util/BUILD.bazel
+++ b/manipulation/util/BUILD.bazel
@@ -27,6 +27,7 @@ drake_py_library(
 
 drake_cc_package_library(
     name = "util",
+    visibility = ["//visibility:public"],
     deps = [
         ":bot_core_lcm_encode_decode",
         ":move_ik_demo_base",

--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -12,6 +12,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "math",
+    visibility = ["//visibility:public"],
     deps = [
         ":autodiff",
         ":barycentric",

--- a/multibody/benchmarks/acrobot/BUILD.bazel
+++ b/multibody/benchmarks/acrobot/BUILD.bazel
@@ -12,6 +12,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "acrobot",
+    visibility = ["//visibility:public"],
     deps = [
         ":analytical_acrobot",
         ":make_acrobot_plant",

--- a/multibody/benchmarks/free_body/BUILD.bazel
+++ b/multibody/benchmarks/free_body/BUILD.bazel
@@ -24,6 +24,7 @@ filegroup(
 
 drake_cc_package_library(
     name = "free_body",
+    visibility = ["//visibility:public"],
     deps = [
         ":free_body_only",
     ],

--- a/multibody/benchmarks/inclined_plane/BUILD.bazel
+++ b/multibody/benchmarks/inclined_plane/BUILD.bazel
@@ -13,6 +13,7 @@ package(default_visibility = ["//visibility:private"])
 
 drake_cc_package_library(
     name = "inclined_plane",
+    visibility = ["//visibility:public"],
     deps = [
         ":inclined_plane_plant",
     ],

--- a/multibody/benchmarks/kuka_iiwa_robot/BUILD.bazel
+++ b/multibody/benchmarks/kuka_iiwa_robot/BUILD.bazel
@@ -14,6 +14,7 @@ package(default_visibility = ["//visibility:private"])
 
 drake_cc_package_library(
     name = "kuka_iiwa_robot",
+    visibility = ["//visibility:public"],
     deps = [
         ":make_kuka_iiwa_model",
     ],

--- a/multibody/benchmarks/mass_damper_spring/BUILD.bazel
+++ b/multibody/benchmarks/mass_damper_spring/BUILD.bazel
@@ -14,6 +14,7 @@ package(default_visibility = ["//visibility:private"])
 
 drake_cc_package_library(
     name = "mass_damper_spring",
+    visibility = ["//visibility:public"],
     deps = [
         ":mass_damper_spring_analytical_solution",
     ],

--- a/multibody/benchmarks/pendulum/BUILD.bazel
+++ b/multibody/benchmarks/pendulum/BUILD.bazel
@@ -13,6 +13,7 @@ package(default_visibility = ["//visibility:private"])
 
 drake_cc_package_library(
     name = "pendulum",
+    visibility = ["//visibility:public"],
     deps = [
         ":make_pendulum_plant",
     ],

--- a/multibody/constraint/BUILD.bazel
+++ b/multibody/constraint/BUILD.bazel
@@ -13,6 +13,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "constraint",
+    visibility = ["//visibility:public"],
     deps = [
         ":constraint_problem_data",
         ":constraint_solver",

--- a/multibody/hydroelastics/BUILD.bazel
+++ b/multibody/hydroelastics/BUILD.bazel
@@ -12,6 +12,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "hydroelastics",
+    visibility = ["//visibility:public"],
     deps = [
         ":contact_surface_from_level_set",
         ":hydroelastic_engine",

--- a/multibody/inverse_kinematics/BUILD.bazel
+++ b/multibody/inverse_kinematics/BUILD.bazel
@@ -15,6 +15,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "inverse_kinematics",
+    visibility = ["//visibility:public"],
     deps = [
         ":inverse_kinematics_core",
         ":kinematic_constraint",

--- a/multibody/math/BUILD.bazel
+++ b/multibody/math/BUILD.bazel
@@ -14,6 +14,7 @@ package(
 
 drake_cc_package_library(
     name = "math",
+    visibility = ["//visibility:public"],
     deps = [
         ":spatial_acceleration",
         ":spatial_algebra",

--- a/multibody/optimization/BUILD.bazel
+++ b/multibody/optimization/BUILD.bazel
@@ -12,6 +12,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "optimization",
+    visibility = ["//visibility:public"],
     deps = [
         ":contact_wrench",
         ":contact_wrench_evaluator",

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -15,6 +15,7 @@ package(
 
 drake_cc_package_library(
     name = "plant",
+    visibility = ["//visibility:public"],
     deps = [
         ":calc_distance_and_time_derivative",
         ":contact_jacobians",

--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -14,6 +14,7 @@ package(
 
 drake_cc_package_library(
     name = "tree",
+    visibility = ["//visibility:public"],
     deps = [
         ":articulated_body_inertia",
         ":multibody_element",

--- a/multibody/triangle_quadrature/BUILD.bazel
+++ b/multibody/triangle_quadrature/BUILD.bazel
@@ -15,6 +15,7 @@ package(
 
 drake_cc_package_library(
     name = "triangle_quadrature",
+    visibility = ["//visibility:public"],
     deps = [
         ":triangle_quadrature_routine",
         ":triangle_quadrature_rules",

--- a/perception/BUILD.bazel
+++ b/perception/BUILD.bazel
@@ -13,6 +13,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "perception",
+    visibility = ["//visibility:public"],
     deps = [
         ":depth_image_to_point_cloud",
         ":point_cloud",

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -19,6 +19,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "solvers",
+    visibility = ["//visibility:public"],
     deps = [
         ":bilinear_product_util",
         ":binding",

--- a/solvers/fbstab/BUILD.bazel
+++ b/solvers/fbstab/BUILD.bazel
@@ -12,6 +12,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "fbstab",
+    visibility = ["//visibility:public"],
     deps = [
         ":fbstab_algorithm",
         ":fbstab_dense",

--- a/solvers/test_utilities/BUILD.bazel
+++ b/solvers/test_utilities/BUILD.bazel
@@ -14,6 +14,7 @@ package(default_visibility = ["//visibility:public"])
 drake_cc_package_library(
     name = "test_utilities",
     testonly = 1,
+    visibility = ["//visibility:public"],
     deps = [
         ":check_constraint_eval_nonsymbolic",
     ],

--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -12,6 +12,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "analysis",
+    visibility = ["//visibility:public"],
     deps = [
         ":antiderivative_function",
         ":bogacki_shampine3_integrator",

--- a/systems/analysis/test_utilities/BUILD.bazel
+++ b/systems/analysis/test_utilities/BUILD.bazel
@@ -13,6 +13,7 @@ package(default_visibility = ["//visibility:public"])
 drake_cc_package_library(
     name = "test_utilities",
     testonly = 1,
+    visibility = ["//visibility:public"],
     deps = [
         ":controlled_spring_mass_system",
         ":cubic_scalar_system",

--- a/systems/controllers/BUILD.bazel
+++ b/systems/controllers/BUILD.bazel
@@ -12,6 +12,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "controllers",
+    visibility = ["//visibility:public"],
     deps = [
         ":dynamic_programming",
         ":finite_horizon_linear_quadratic_regulator",

--- a/systems/controllers/test_utilities/BUILD.bazel
+++ b/systems/controllers/test_utilities/BUILD.bazel
@@ -13,6 +13,7 @@ package(default_visibility = ["//visibility:public"])
 drake_cc_package_library(
     name = "test_utilities",
     testonly = 1,
+    visibility = ["//visibility:public"],
     deps = [
         ":compute_torque",
     ],

--- a/systems/estimators/BUILD.bazel
+++ b/systems/estimators/BUILD.bazel
@@ -12,6 +12,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "estimators",
+    visibility = ["//visibility:public"],
     deps = [
         ":kalman_filter",
         ":luenberger_observer",

--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -16,6 +16,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "framework",
+    visibility = ["//visibility:public"],
     deps = [
         ":abstract_values",
         ":cache_and_dependency_tracker",

--- a/systems/framework/test_utilities/BUILD.bazel
+++ b/systems/framework/test_utilities/BUILD.bazel
@@ -13,6 +13,7 @@ package(default_visibility = ["//visibility:public"])
 drake_cc_package_library(
     name = "test_utilities",
     testonly = 1,
+    visibility = ["//visibility:public"],
     deps = [
         ":my_vector",
         ":pack_value",

--- a/systems/lcm/BUILD.bazel
+++ b/systems/lcm/BUILD.bazel
@@ -12,6 +12,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "lcm",
+    visibility = ["//visibility:public"],
     deps = [
         ":connect_lcm_scope",
         ":lcm_interface_system",

--- a/systems/optimization/BUILD.bazel
+++ b/systems/optimization/BUILD.bazel
@@ -12,6 +12,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "optimization",
+    visibility = ["//visibility:public"],
     deps = [
         ":system_constraint_adapter",
         ":system_constraint_wrapper",

--- a/systems/plants/spring_mass_system/BUILD.bazel
+++ b/systems/plants/spring_mass_system/BUILD.bazel
@@ -12,6 +12,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "spring_mass_system",
+    visibility = ["//visibility:public"],
     deps = [
         ":everything",
     ],

--- a/systems/primitives/BUILD.bazel
+++ b/systems/primitives/BUILD.bazel
@@ -12,6 +12,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "primitives",
+    visibility = ["//visibility:public"],
     deps = [
         ":adder",
         ":affine_system",

--- a/systems/rendering/BUILD.bazel
+++ b/systems/rendering/BUILD.bazel
@@ -12,6 +12,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "rendering",
+    visibility = ["//visibility:public"],
     deps = [
         ":frame_velocity",
         ":multibody_position_to_geometry_pose",

--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -22,6 +22,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "sensors",
+    visibility = ["//visibility:public"],
     deps = [
         ":accelerometer",
         ":beam_model",

--- a/systems/trajectory_optimization/BUILD.bazel
+++ b/systems/trajectory_optimization/BUILD.bazel
@@ -12,6 +12,7 @@ package(default_visibility = ["//visibility:public"])
 
 drake_cc_package_library(
     name = "trajectory_optimization",
+    visibility = ["//visibility:public"],
     deps = [
         ":direct_collocation",
         ":direct_transcription",

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -418,7 +418,7 @@ def drake_cc_package_library(
         name,
         deps = [],
         testonly = 0,
-        visibility = ["//visibility:public"]):
+        visibility = None):
     """Creates a rule to declare a C++ "package" library -- a library whose
     name matches the current Bazel package name (i.e., directory name) and
     whose dependencies are (usually) all of the other drake_cc_library targets
@@ -436,9 +436,18 @@ def drake_cc_package_library(
     The name must be the same as the final element of the current package.
     This rule does not accept srcs, hdrs, etc. -- only deps.
     The testonly argument has the same meaning as the native cc_library.
-    By default, this target has public visibility, but that may be overridden.
+
+    The visibility must be explicitly provided, not relying on the BUILD file
+    default.  Setting to "//visibility:public" is strongly recommended.
     """
     _check_package_library_name(name)
+    if not visibility:
+        fail(("//{}:{} must provide a visibility setting; " +
+              "add this line to the BUILD.bazel file:\n" +
+              "        visibility = \"//visibility:public\",").format(
+            native.package_name(),
+            name,
+        ))
     drake_cc_library(
         name = name,
         testonly = testonly,


### PR DESCRIPTION
Using an implicit visibility that differs from the package(default_visibility) is too confusing.

As mentioned in  #13700 and #13695.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13701)
<!-- Reviewable:end -->
