### PR TITLE
Tell gojs to autoscale for javascript system diagrams

### DIFF
--- a/systems/framework/system_html.cc
+++ b/systems/framework/system_html.cc
@@ -209,7 +209,8 @@ std::string GenerateHtml(const System<double>& system, int initial_depth) {
 <script>
   $ = go.GraphObject.make
   var diagram = $(go.Diagram, "myDiagramDiv", {
-    "undoManager.isEnabled": true
+    "undoManager.isEnabled": true,
+    initialAutoScale: go.Diagram.Uniform
   });
   diagram.layout = $(go.LayeredDigraphLayout, {
     layerSpacing: 20,


### PR DESCRIPTION
Big diagrams, like the manipulation station example, were giving an initial render that was barely visible on the screen.  Now it looks like this:
https://people.csail.mit.edu/russt/uploads/manip_station.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13704)
<!-- Reviewable:end -->
