### PR TITLE
multibody: Implement PlanarMobilizer

### DIFF
--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -103,6 +103,7 @@ drake_cc_library(
         "multibody_forces.cc",
         "multibody_tree.cc",
         "multibody_tree_system.cc",
+        "planar_mobilizer.cc",
         "prismatic_joint.cc",
         "prismatic_mobilizer.cc",
         "quaternion_floating_mobilizer.cc",
@@ -139,6 +140,7 @@ drake_cc_library(
         "multibody_tree.h",
         "multibody_tree-inl.h",
         "multibody_tree_system.h",
+        "planar_mobilizer.h",
         "prismatic_joint.h",
         "prismatic_mobilizer.h",
         "quaternion_floating_mobilizer.h",
@@ -361,6 +363,15 @@ drake_cc_library(
     hdrs = ["test/mobilizer_tester.h"],
     deps = [
         ":tree",
+    ],
+)
+
+drake_cc_googletest(
+    name = "planar_mobilizer_test",
+    deps = [
+        ":mobilizer_tester",
+        ":tree",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/multibody/tree/planar_mobilizer.cc
+++ b/multibody/tree/planar_mobilizer.cc
@@ -1,0 +1,192 @@
+#include "drake/multibody/tree/planar_mobilizer.h"
+
+#include <memory>
+
+#include "drake/common/eigen_types.h"
+#include "drake/math/rotation_matrix.h"
+#include "drake/multibody/tree/multibody_tree.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+template <typename T>
+Vector2<T> PlanarMobilizer<T>::get_translations(
+    const systems::Context<T>& context) const {
+  auto q = this->get_positions(context);
+  DRAKE_ASSERT(q.size() == kNq);
+  return q.head(2);
+}
+
+template <typename T>
+const PlanarMobilizer<T>& PlanarMobilizer<T>::set_translations(
+    systems::Context<T>* context,
+    const Eigen::Ref<const Vector2<T>>& translations) const {
+  auto q = this->get_mutable_positions(&*context);
+  DRAKE_ASSERT(q.size() == kNq);
+  q.head(2) = translations;
+  return *this;
+}
+
+template <typename T>
+const T& PlanarMobilizer<T>::get_angle(
+    const systems::Context<T>& context) const {
+  auto q = this->get_positions(context);
+  DRAKE_ASSERT(q.size() == kNq);
+  return q.coeffRef(2);
+}
+
+template <typename T>
+const PlanarMobilizer<T>& PlanarMobilizer<T>::set_angle(
+    systems::Context<T>* context, const T& angle) const {
+  auto q = this->get_mutable_positions(&*context);
+  DRAKE_ASSERT(q.size() == kNq);
+  q[2] = angle;
+  return *this;
+}
+
+template <typename T>
+Vector2<T> PlanarMobilizer<T>::get_translation_rates(
+    const systems::Context<T>& context) const {
+  const auto& v = this->get_velocities(context);
+  DRAKE_ASSERT(v.size() == kNv);
+  return v.head(2);
+}
+
+template <typename T>
+const PlanarMobilizer<T>& PlanarMobilizer<T>::set_translation_rates(
+    systems::Context<T>* context,
+    const Eigen::Ref<const Vector2<T>>& v_FM_F) const {
+  auto v = this->get_mutable_velocities(&*context);
+  DRAKE_ASSERT(v.size() == kNv);
+  v.head(2) = v_FM_F;
+  return *this;
+}
+
+template <typename T>
+const T& PlanarMobilizer<T>::get_angular_rate(
+    const systems::Context<T>& context) const {
+  const auto& v = this->get_velocities(context);
+  DRAKE_ASSERT(v.size() == kNv);
+  return v.coeffRef(2);
+}
+
+template <typename T>
+const PlanarMobilizer<T>& PlanarMobilizer<T>::set_angular_rate(
+    systems::Context<T>* context, const T& theta_dot) const {
+  auto v = this->get_mutable_velocities(&*context);
+  DRAKE_ASSERT(v.size() == kNv);
+  v[2] = theta_dot;
+  return *this;
+}
+
+template <typename T>
+math::RigidTransform<T> PlanarMobilizer<T>::CalcAcrossMobilizerTransform(
+    const systems::Context<T>& context) const {
+  const auto& q = this->get_positions(context);
+  DRAKE_ASSERT(q.size() == kNq);
+  Vector3<T> X_FM_translation;
+  X_FM_translation << q[0], q[1], 0.0;
+  return math::RigidTransform<T>(math::RotationMatrix<T>::MakeZRotation(q[2]),
+                                 X_FM_translation);
+}
+
+template <typename T>
+SpatialVelocity<T> PlanarMobilizer<T>::CalcAcrossMobilizerSpatialVelocity(
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& v) const {
+  DRAKE_ASSERT(v.size() == kNv);
+  Vector6<T> V_FM_vector;
+  V_FM_vector << 0.0, 0.0, v[2], v[0], v[1], 0.0;
+  return SpatialVelocity<T>(V_FM_vector);
+}
+
+template <typename T>
+SpatialAcceleration<T>
+PlanarMobilizer<T>::CalcAcrossMobilizerSpatialAcceleration(
+    const systems::Context<T>&,
+    const Eigen::Ref<const VectorX<T>>& vdot) const {
+  DRAKE_ASSERT(vdot.size() == kNv);
+  Vector6<T> A_FM_vector;
+  A_FM_vector << 0.0, 0.0, vdot[2], vdot[0], vdot[1], 0.0;
+  return SpatialAcceleration<T>(A_FM_vector);
+}
+
+template <typename T>
+void PlanarMobilizer<T>::ProjectSpatialForce(const systems::Context<T>&,
+                                             const SpatialForce<T>& F_Mo_F,
+                                             Eigen::Ref<VectorX<T>> tau) const {
+  DRAKE_ASSERT(tau.size() == kNv);
+  tau.head(2) = F_Mo_F.translational().head(2);
+  tau[2] = F_Mo_F.rotational()[2];
+}
+
+template <typename T>
+void PlanarMobilizer<T>::DoCalcNMatrix(const systems::Context<T>&,
+                                       EigenPtr<MatrixX<T>> N) const {
+  *N = Matrix3<T>::Identity();
+}
+
+template <typename T>
+void PlanarMobilizer<T>::DoCalcNplusMatrix(const systems::Context<T>&,
+                                           EigenPtr<MatrixX<T>> Nplus) const {
+  *Nplus = Matrix3<T>::Identity();
+}
+
+template <typename T>
+void PlanarMobilizer<T>::MapVelocityToQDot(
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& v,
+    EigenPtr<VectorX<T>> qdot) const {
+  DRAKE_ASSERT(v.size() == kNv);
+  DRAKE_ASSERT(qdot != nullptr);
+  DRAKE_ASSERT(qdot->size() == kNq);
+  *qdot = v;
+}
+
+template <typename T>
+void PlanarMobilizer<T>::MapQDotToVelocity(
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& qdot,
+    EigenPtr<VectorX<T>> v) const {
+  DRAKE_ASSERT(qdot.size() == kNq);
+  DRAKE_ASSERT(v != nullptr);
+  DRAKE_ASSERT(v->size() == kNv);
+  *v = qdot;
+}
+
+template <typename T>
+template <typename ToScalar>
+std::unique_ptr<Mobilizer<ToScalar>>
+PlanarMobilizer<T>::TemplatedDoCloneToScalar(
+    const MultibodyTree<ToScalar>& tree_clone) const {
+  const Frame<ToScalar>& inboard_frame_clone =
+      tree_clone.get_variant(this->inboard_frame());
+  const Frame<ToScalar>& outboard_frame_clone =
+      tree_clone.get_variant(this->outboard_frame());
+  return std::make_unique<PlanarMobilizer<ToScalar>>(inboard_frame_clone,
+                                                     outboard_frame_clone);
+}
+
+template <typename T>
+std::unique_ptr<Mobilizer<double>> PlanarMobilizer<T>::DoCloneToScalar(
+    const MultibodyTree<double>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
+template <typename T>
+std::unique_ptr<Mobilizer<AutoDiffXd>> PlanarMobilizer<T>::DoCloneToScalar(
+    const MultibodyTree<AutoDiffXd>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
+template <typename T>
+std::unique_ptr<Mobilizer<symbolic::Expression>>
+PlanarMobilizer<T>::DoCloneToScalar(
+    const MultibodyTree<symbolic::Expression>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::internal::PlanarMobilizer)

--- a/multibody/tree/planar_mobilizer.h
+++ b/multibody/tree/planar_mobilizer.h
@@ -1,0 +1,208 @@
+#pragma once
+
+#include <memory>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/tree/frame.h"
+#include "drake/multibody/tree/mobilizer_impl.h"
+#include "drake/multibody/tree/multibody_tree_topology.h"
+#include "drake/systems/framework/context.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+/* This mobilizer models a planar joint between an inboard frame F and an
+ outboard frame M that enables translation along F's x and y axes and rotation
+ about F's z-axis.
+
+ The generalized coordinates for this mobilizer (x, y, θ) correspond to
+ translations along the x and y axes of frame F and rotaition about the z-axis
+ of frame F.
+ Zero (x, y, θ) define the "zero configuration" which corresponds to frame F and
+ M being coincident and aligned, see set_zero_state(). The translations (x, y)
+ are defined to be positive in the direction of their respective axes and the
+ rotation θ is defined to be positive according to the right-hand-rule with the
+ thumb aligned in the direction of frame F's z-axis.
+ The generalized velocities for this mobilizer are the rate of change of the
+ coordinates, v = q̇.
+
+ @tparam_default_scalar */
+template <typename T>
+class PlanarMobilizer final : public MobilizerImpl<T, 3, 3> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PlanarMobilizer)
+
+  /* Constructor for a %PlanarMobilizer between an inboard frame F
+   `inboard_frame_F` and an outboard frame M `outboard_frame_M` granting two
+   translational and one rotational degrees of freedom as described in this
+   class's documentation. */
+  PlanarMobilizer(const Frame<T>& inboard_frame_F,
+                  const Frame<T>& outboard_frame_M)
+      : MobilizerBase(inboard_frame_F, outboard_frame_M) {}
+
+  /* Retrieves from `context` the two translations (x, y) which describe the
+   position for `this` mobilizer as documented in this class's documentation.
+
+   @param[in] context The context of the model this mobilizer belongs to.
+   @returns The two translations (x, y) packed and returned as a vector with
+            entries `translations(0) = x`, `translations(1) = y`. */
+  Vector2<T> get_translations(const systems::Context<T>& context) const;
+
+  /* Sets in `context` the position for `this` mobilizer to the translations
+   (x, y) provided in the input argument `translations`, which stores them with
+   the format `translations = [x, y]`.
+
+   @param[in] context The context of the model this mobilizer belongs to.
+   @param[in] translations A vector which must pack values for the translations
+                           (x, y) described in this class's documentation, at
+                           entries `translations(0)` and `translations(1)`,
+                           respectively.
+   @returns A constant reference to `this` mobilizer. */
+  const PlanarMobilizer<T>& set_translations(
+      systems::Context<T>* context,
+      const Eigen::Ref<const Vector2<T>>& translations) const;
+
+  /* Retrieves from `context` the angle θ which describe the orientation for
+   `this` mobilizer as documented in this class's documentation.
+
+   @param[in] context The context of the model this mobilizer belongs to.
+   @returns The angle θ of the mobilizer. */
+  const T& get_angle(const systems::Context<T>& context) const;
+
+  /* Sets in `context` the orientation for `this` mobilizer to the angle θ
+   provided by the input argument `angle`.
+
+   @param[in] context The context of the model this mobilizer belongs to.
+   @param[in] angle The desired angle in radians.
+   @returns a constant reference to `this` mobilizer. */
+  const PlanarMobilizer<T>& set_angle(systems::Context<T>* context,
+                                      const T& angle) const;
+
+  /* Retrieves from `context` the rate of change, in meters per second, of
+   `this` mobilizer's translations (see get_translations()).
+   @param[in] context The context of the model this mobilizer belongs to.
+   @returns The rate of change of the two translations (ẋ, ẏ) returned as
+            the vector [ẋ, ẏ], which is v_FM_F. */
+  Vector2<T> get_translation_rates(const systems::Context<T>& context) const;
+
+  /* Sets in `context` the rate of change, in meters per second, of `this`
+   mobilizer's translations (see get_translations()) to `v_FM_F`.
+   @param[in] context The context of the model this mobilizer belongs to.
+   @param[in] v_FM_F The desired rate of change of `this` mobilizer's
+                     translations, packed as the vector [ẋ, ẏ].
+   @returns A constant reference to `this` mobilizer. */
+  const PlanarMobilizer<T>& set_translation_rates(
+      systems::Context<T>* context,
+      const Eigen::Ref<const Vector2<T>>& v_FM_F) const;
+
+  /* Retrieves from `context` the rate of change, in radians per second, of
+   `this` mobilizer's angle (see get_angle()).
+   @param[in] context The context of the model this mobilizer belongs to.
+   @returns The rate of change of `this` mobilizer's angle. */
+  const T& get_angular_rate(const systems::Context<T>& context) const;
+
+  /* Sets in `context` the rate of change, in radians per second, of `this`
+   mobilizer's angle (see angle()) to `theta_dot`.
+   @param[in] context The context of the model this mobilizer belongs to.
+   @param[in] theta_dot The desired rate of change of `this` mobilizer's angle
+                        in radians per second.
+   @returns A constant reference to `this` mobilizer. */
+  const PlanarMobilizer<T>& set_angular_rate(systems::Context<T>* context,
+                                             const T& theta_dot) const;
+
+  /* Computes the across-mobilizer transform `X_FM(q)` between the inboard
+   frame F and the outboard frame M as a function of the configuration q stored
+   in `context`. */
+  math::RigidTransform<T> CalcAcrossMobilizerTransform(
+      const systems::Context<T>& context) const override;
+
+  /* Computes the across-mobilizer velocity `V_FM(q, v)` of the outboard frame
+   M measured and expressed in frame F as a function of the configuration q
+   stored in `context` and of the input velocity v, formatted as described in
+   the class documentation.
+   This method aborts in Debug builds if `v.size()` is not three. */
+  SpatialVelocity<T> CalcAcrossMobilizerSpatialVelocity(
+      const systems::Context<T>& context,
+      const Eigen::Ref<const VectorX<T>>& v) const override;
+
+  /* Computes the across-mobilizer acceleration `A_FM(q, v, v̇)` of the outboard
+   frame M in the inboard frame F.
+   By definition `A_FM = d_F(V_FM)/dt = H_FM(q) * v̇ + Ḣ_FM * v`. The
+   acceleration `A_FM` will be a function of the configuration q and the
+   velocity v from the `context` as well as the generalized accelerations
+   `v̇ = dv/dt`, the rates of change of v.
+   This method aborts in Debug builds if `vdot.size()` is not three. */
+  SpatialAcceleration<T> CalcAcrossMobilizerSpatialAcceleration(
+      const systems::Context<T>& context,
+      const Eigen::Ref<const VectorX<T>>& vdot) const override;
+
+  /* Projects the spatial force `F_Mo = [τ_Mo, f_Mo]` on `this` mobilizer's
+   outboard frame M onto the rotational axis, z, and translational axes, x and
+   y. Mathematically:
+   <pre>
+      tau = [f_Mo⋅Fx]
+            [f_Mo⋅Fy]
+            [τ_Mo⋅Fz]
+   </pre>
+   Therefore, the result of this method is the vector of torques and forces for
+   each degree of freedom of `this` mobilizer.
+   This method aborts in Debug builds if `tau.size()` is not three. */
+  void ProjectSpatialForce(const systems::Context<T>& context,
+                           const SpatialForce<T>& F_Mo_F,
+                           Eigen::Ref<VectorX<T>> tau) const override;
+
+  /* Performs the identity mapping from v to qdot since, for this mobilizer,
+   v = q̇. */
+  void MapVelocityToQDot(const systems::Context<T>& context,
+                         const Eigen::Ref<const VectorX<T>>& v,
+                         EigenPtr<VectorX<T>> qdot) const override;
+
+  /* Performs the identity mapping from qdot to v since, for this mobilizer,
+   v = q̇. */
+  void MapQDotToVelocity(const systems::Context<T>& context,
+                         const Eigen::Ref<const VectorX<T>>& qdot,
+                         EigenPtr<VectorX<T>> v) const override;
+
+ protected:
+  void DoCalcNMatrix(const systems::Context<T>& context,
+                     EigenPtr<MatrixX<T>> N) const final;
+
+  void DoCalcNplusMatrix(const systems::Context<T>& context,
+                         EigenPtr<MatrixX<T>> Nplus) const final;
+
+  std::unique_ptr<Mobilizer<double>> DoCloneToScalar(
+      const MultibodyTree<double>& tree_clone) const override;
+
+  std::unique_ptr<Mobilizer<AutoDiffXd>> DoCloneToScalar(
+      const MultibodyTree<AutoDiffXd>& tree_clone) const override;
+
+  std::unique_ptr<Mobilizer<symbolic::Expression>> DoCloneToScalar(
+      const MultibodyTree<symbolic::Expression>& tree_clone) const override;
+
+ private:
+  typedef MobilizerImpl<T, 3, 3> MobilizerBase;
+  /* Bring the handy number of position and velocities MobilizerImpl enums into
+   this class' scope. This is useful when writing mathematical expressions with
+   fixed-sized vectors since we can do things like Vector<T, nq>.
+   Operations with fixed-sized quantities can be optimized at compile time and
+   therefore they are highly preferred compared to the very slow dynamic sized
+   quantities. */
+  using MobilizerBase::kNq;
+  using MobilizerBase::kNv;
+
+  /* Helper method to make a clone templated on ToScalar. */
+  template <typename ToScalar>
+  std::unique_ptr<Mobilizer<ToScalar>> TemplatedDoCloneToScalar(
+      const MultibodyTree<ToScalar>& tree_clone) const;
+};
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::internal::PlanarMobilizer)

--- a/multibody/tree/test/planar_mobilizer_test.cc
+++ b/multibody/tree/test/planar_mobilizer_test.cc
@@ -1,0 +1,283 @@
+#include "drake/multibody/tree/planar_mobilizer.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/multibody/tree/multibody_tree-inl.h"
+#include "drake/multibody/tree/multibody_tree_system.h"
+#include "drake/multibody/tree/test/mobilizer_tester.h"
+#include "drake/systems/framework/context.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+namespace {
+
+using Eigen::Matrix3d;
+using Eigen::Vector2d;
+using Eigen::Vector3d;
+using Eigen::VectorXd;
+using math::RigidTransformd;
+using math::RotationMatrixd;
+
+constexpr double kTolerance = 10 * std::numeric_limits<double>::epsilon();
+
+// Fixture to setup a simple MBT model containing a planar mobilizer.
+class PlanarMobilizerTest : public MobilizerTester {
+ public:
+  // Creates a simple model consisting of a single body with a planar
+  // mobilizer connecting it to the world.
+  void SetUp() override {
+    mobilizer_ =
+        &AddMobilizerAndFinalize(std::make_unique<PlanarMobilizer<double>>(
+            tree().world_body().body_frame(), body_->body_frame()));
+  }
+
+ protected:
+  const PlanarMobilizer<double>* mobilizer_{nullptr};
+};
+
+// Verifies method to mutate and access the context.
+TEST_F(PlanarMobilizerTest, StateAccess) {
+  const Vector2d some_values1(1.5, 2.5);
+  const Vector2d some_values2(std::sqrt(2), 3.);
+  const double some_values3 = 4.5;
+  const double some_values4 = std::sqrt(5);
+  // Verify we can set a planar mobilizer configuration given the model's
+  // context.
+  mobilizer_->set_translations(context_.get(), some_values1);
+  EXPECT_EQ(mobilizer_->get_translations(*context_), some_values1);
+  mobilizer_->set_translations(context_.get(), some_values2);
+  EXPECT_EQ(mobilizer_->get_translations(*context_), some_values2);
+  mobilizer_->set_angle(context_.get(), some_values3);
+  EXPECT_EQ(mobilizer_->get_angle(*context_), some_values3);
+  mobilizer_->set_angle(context_.get(), some_values4);
+  EXPECT_EQ(mobilizer_->get_angle(*context_), some_values4);
+
+  // Verify we can set a planar mobilizer velocities given the model's context.
+  mobilizer_->set_translation_rates(context_.get(), some_values1);
+  EXPECT_EQ(mobilizer_->get_translation_rates(*context_), some_values1);
+  mobilizer_->set_translation_rates(context_.get(), some_values2);
+  EXPECT_EQ(mobilizer_->get_translation_rates(*context_), some_values2);
+  mobilizer_->set_angular_rate(context_.get(), some_values3);
+  EXPECT_EQ(mobilizer_->get_angular_rate(*context_), some_values3);
+  mobilizer_->set_angular_rate(context_.get(), some_values4);
+  EXPECT_EQ(mobilizer_->get_angular_rate(*context_), some_values4);
+}
+
+TEST_F(PlanarMobilizerTest, ZeroState) {
+  const Vector2d some_values1(1.5, 2.5);
+  const Vector2d some_values2(std::sqrt(2), 3.);
+  const double some_values3 = 4.5;
+  const double some_values4 = std::sqrt(5);
+  // Set the state to some arbitrary non-zero value.
+  mobilizer_->set_translations(context_.get(), some_values1);
+  mobilizer_->set_translation_rates(context_.get(), some_values2);
+  mobilizer_->set_angle(context_.get(), some_values3);
+  mobilizer_->set_angular_rate(context_.get(), some_values4);
+  EXPECT_EQ(mobilizer_->get_translations(*context_), some_values1);
+  EXPECT_EQ(mobilizer_->get_translation_rates(*context_), some_values2);
+  EXPECT_EQ(mobilizer_->get_angle(*context_), some_values3);
+  EXPECT_EQ(mobilizer_->get_angular_rate(*context_), some_values4);
+
+  // Set the "zero state" for this mobilizer, which does happen to be that of
+  // zero position and velocity.
+  mobilizer_->set_zero_state(*context_, &context_->get_mutable_state());
+  EXPECT_EQ(mobilizer_->get_translations(*context_), Vector2d::Zero());
+  EXPECT_EQ(mobilizer_->get_translation_rates(*context_), Vector2d::Zero());
+  EXPECT_EQ(mobilizer_->get_angle(*context_), 0.0);
+  EXPECT_EQ(mobilizer_->get_angular_rate(*context_), 0.0);
+}
+
+TEST_F(PlanarMobilizerTest, DefaultPosition) {
+  PlanarMobilizer<double>* mutable_mobilizer =
+      &mutable_tree().get_mutable_variant(*mobilizer_);
+
+  EXPECT_EQ(mobilizer_->get_translations(*context_), Vector2d::Zero());
+  EXPECT_EQ(mobilizer_->get_angle(*context_), 0.0);
+
+  Vector3d new_default(.4, .5, .6);
+  mutable_mobilizer->set_default_position(new_default);
+  mobilizer_->set_default_state(*context_, &context_->get_mutable_state());
+
+  EXPECT_EQ(mobilizer_->get_translations(*context_), new_default.head(2));
+  EXPECT_EQ(mobilizer_->get_angle(*context_), new_default[2]);
+}
+
+TEST_F(PlanarMobilizerTest, RandomState) {
+  RandomGenerator generator;
+  std::uniform_real_distribution<symbolic::Expression> uniform;
+
+  PlanarMobilizer<double>* mutable_mobilizer =
+      &mutable_tree().get_mutable_variant(*mobilizer_);
+
+  // Default behavior is to set to zero.
+  mutable_mobilizer->set_random_state(*context_, &context_->get_mutable_state(),
+                                      &generator);
+  EXPECT_EQ(mobilizer_->get_translations(*context_), Vector2d::Zero());
+  EXPECT_EQ(mobilizer_->get_translation_rates(*context_), Vector2d::Zero());
+  EXPECT_EQ(mobilizer_->get_angle(*context_), 0.0);
+  EXPECT_EQ(mobilizer_->get_angular_rate(*context_), 0.0);
+
+  // Set position to be random, but not velocity (yet).
+  mutable_mobilizer->set_random_position_distribution(
+      Vector3<symbolic::Expression>(uniform(generator) + 1.0,
+                                    uniform(generator) + 2.0,
+                                    uniform(generator) + 3.0));
+  mutable_mobilizer->set_random_state(*context_, &context_->get_mutable_state(),
+                                      &generator);
+  EXPECT_GE(mobilizer_->get_translations(*context_)[0], 1.0);
+  EXPECT_LE(mobilizer_->get_translations(*context_)[0], 2.0);
+  EXPECT_GE(mobilizer_->get_translations(*context_)[1], 2.0);
+  EXPECT_LE(mobilizer_->get_translations(*context_)[1], 3.0);
+  EXPECT_GE(mobilizer_->get_angle(*context_), 3.0);
+  EXPECT_LE(mobilizer_->get_angle(*context_), 4.0);
+  EXPECT_EQ(mobilizer_->get_translation_rates(*context_), Vector2d::Zero());
+  EXPECT_EQ(mobilizer_->get_angular_rate(*context_), 0.0);
+
+  // Set the velocity distribution.  Now both should be random.
+  mutable_mobilizer->set_random_velocity_distribution(
+      Vector3<symbolic::Expression>(uniform(generator) - 2.0,
+                                    uniform(generator) - 3.0,
+                                    uniform(generator) - 4.0));
+  mutable_mobilizer->set_random_state(*context_, &context_->get_mutable_state(),
+                                      &generator);
+  EXPECT_GE(mobilizer_->get_translations(*context_)[0], 1.0);
+  EXPECT_LE(mobilizer_->get_translations(*context_)[0], 2.0);
+  EXPECT_GE(mobilizer_->get_translations(*context_)[1], 2.0);
+  EXPECT_LE(mobilizer_->get_translations(*context_)[1], 3.0);
+  EXPECT_GE(mobilizer_->get_angle(*context_), 3.0);
+  EXPECT_LE(mobilizer_->get_angle(*context_), 4.0);
+  EXPECT_GE(mobilizer_->get_translation_rates(*context_)[0], -2.0);
+  EXPECT_LE(mobilizer_->get_translation_rates(*context_)[0], -1.0);
+  EXPECT_GE(mobilizer_->get_translation_rates(*context_)[1], -3.0);
+  EXPECT_LE(mobilizer_->get_translation_rates(*context_)[1], -2.0);
+  EXPECT_GE(mobilizer_->get_angular_rate(*context_), -4.0);
+  EXPECT_LE(mobilizer_->get_angular_rate(*context_), -3.0);
+
+  // Check that they change on a second draw from the distribution.
+  const Vector2d last_translations = mobilizer_->get_translations(*context_);
+  const Vector2d last_translational_rates =
+      mobilizer_->get_translation_rates(*context_);
+  const double last_angle = mobilizer_->get_angle(*context_);
+  const double last_angular_rates = mobilizer_->get_angular_rate(*context_);
+  mutable_mobilizer->set_random_state(*context_, &context_->get_mutable_state(),
+                                      &generator);
+  EXPECT_NE(mobilizer_->get_translations(*context_), last_translations);
+  EXPECT_NE(mobilizer_->get_translation_rates(*context_),
+            last_translational_rates);
+  EXPECT_NE(mobilizer_->get_angle(*context_), last_angle);
+  EXPECT_NE(mobilizer_->get_angular_rate(*context_), last_angular_rates);
+}
+
+TEST_F(PlanarMobilizerTest, CalcAcrossMobilizerTransform) {
+  const Vector2d translations(1, 0.5);
+  const double angle = 1.5;
+  mobilizer_->set_translations(context_.get(), translations);
+  mobilizer_->set_angle(context_.get(), angle);
+  const RigidTransformd X_FM(
+      mobilizer_->CalcAcrossMobilizerTransform(*context_));
+
+  Vector3d X_FM_translation;
+  X_FM_translation << translations[0], translations[1], 0.0;
+  const RigidTransformd X_FM_expected(RotationMatrixd::MakeZRotation(angle),
+                                      X_FM_translation);
+
+  EXPECT_TRUE(CompareMatrices(X_FM.GetAsMatrix34(),
+                              X_FM_expected.GetAsMatrix34(), kTolerance,
+                              MatrixCompareType::relative));
+}
+
+TEST_F(PlanarMobilizerTest, CalcAcrossMobilizerSpatialVeloctiy) {
+  const Vector2d translations(1, 0.5);
+  const double angle = 1.5;
+  const Vector3d velocity(2.5, 2, 3);
+  mobilizer_->set_translations(context_.get(), translations);
+  mobilizer_->set_angle(context_.get(), angle);
+  const SpatialVelocity<double> V_FM =
+      mobilizer_->CalcAcrossMobilizerSpatialVelocity(*context_, velocity);
+
+  VectorXd v_expected(6);
+  v_expected << 0.0, 0.0, velocity[2], velocity[0], velocity[1], 0.0;
+  const SpatialVelocity<double> V_FM_expected(v_expected);
+
+  EXPECT_TRUE(V_FM.IsApprox(V_FM_expected, kTolerance));
+}
+
+TEST_F(PlanarMobilizerTest, CalcAcrossMobilizerSpatialAcceleration) {
+  const Vector2d translations(1, 0.5);
+  const double angle = 1.5;
+  const Vector2d translation_rates(2.5, 2);
+  const double angle_rate = 3;
+  const Vector3d acceleration(3.5, 4, 4.5);
+  mobilizer_->set_translations(context_.get(), translations);
+  mobilizer_->set_angle(context_.get(), angle);
+  mobilizer_->set_translation_rates(context_.get(), translation_rates);
+  mobilizer_->set_angular_rate(context_.get(), angle_rate);
+
+  const SpatialAcceleration<double> A_FM =
+      mobilizer_->CalcAcrossMobilizerSpatialAcceleration(*context_,
+                                                         acceleration);
+
+  VectorXd a_expected(6);
+  a_expected << 0.0, 0.0, acceleration[2], acceleration[0], acceleration[1],
+      0.0;
+  const SpatialAcceleration<double> A_FM_expected(a_expected);
+
+  EXPECT_TRUE(A_FM.IsApprox(A_FM_expected, kTolerance));
+}
+
+TEST_F(PlanarMobilizerTest, ProjectSpatialForce) {
+  const Vector2d translations(1, 0.5);
+  const double angle = 1.5;
+  mobilizer_->set_translations(context_.get(), translations);
+  mobilizer_->set_angle(context_.get(), angle);
+
+  const Vector3d torque_Mo_F(1.0, 2.0, 3.0);
+  const Vector3d force_Mo_F(1.0, 2.0, 3.0);
+  const SpatialForce<double> F_Mo_F(torque_Mo_F, force_Mo_F);
+  Vector3d tau;
+  mobilizer_->ProjectSpatialForce(*context_, F_Mo_F, tau);
+
+  const Vector3d tau_expected(force_Mo_F[0], force_Mo_F[1], torque_Mo_F[2]);
+  EXPECT_TRUE(CompareMatrices(tau, tau_expected, kTolerance,
+                              MatrixCompareType::relative));
+}
+
+TEST_F(PlanarMobilizerTest, MapVelocityToQDotAndBack) {
+  Vector3d v(1.5, 2.5, 3.5);
+  Vector3d qdot;
+  mobilizer_->MapVelocityToQDot(*context_, v, &qdot);
+  EXPECT_TRUE(
+      CompareMatrices(qdot, v, kTolerance, MatrixCompareType::relative));
+
+  qdot(0) = -std::sqrt(2);
+  mobilizer_->MapQDotToVelocity(*context_, qdot, &v);
+  EXPECT_TRUE(
+      CompareMatrices(v, qdot, kTolerance, MatrixCompareType::relative));
+}
+
+TEST_F(PlanarMobilizerTest, KinematicMapping) {
+  // For this joint, Nplus = I independently of the state. We therefore set the
+  // state to NaN in order to verify this.
+  tree()
+      .GetMutablePositionsAndVelocities(context_.get())
+      .setConstant(std::numeric_limits<double>::quiet_NaN());
+
+  // Compute N.
+  MatrixX<double> N(3, 3);
+  mobilizer_->CalcNMatrix(*context_, &N);
+  EXPECT_EQ(N, Matrix3d::Identity());
+
+  // Compute Nplus.
+  MatrixX<double> Nplus(3, 3);
+  mobilizer_->CalcNplusMatrix(*context_, &Nplus);
+  EXPECT_EQ(Nplus, Matrix3d::Identity());
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Adds a 3 dof planar mobilizer that allows motion in the xy plane and rotation about the z-axis of the parent frame.

Towards #12404
Relates #12401

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13711)
<!-- Reviewable:end -->
