### PR TITLE
CoulombFriction aquired from Contex<T> should be templated on T.

### DIFF
--- a/multibody/hydroelastics/BUILD.bazel
+++ b/multibody/hydroelastics/BUILD.bazel
@@ -46,6 +46,7 @@ drake_cc_library(
         "hydroelastic_engine.h",
     ],
     deps = [
+        "//geometry:proximity_properties",
         "//geometry:scene_graph",
         "//geometry:scene_graph_inspector",
     ],

--- a/multibody/hydroelastics/hydroelastic_engine.h
+++ b/multibody/hydroelastics/hydroelastic_engine.h
@@ -34,14 +34,14 @@ class HydroelasticEngine  {
   /// `id_B`.
   /// Refer to @ref mbp_hydroelastic_materials_properties "Hydroelastic model
   /// material properties" for further details.
-  double CalcCombinedElasticModulus(
+  T CalcCombinedElasticModulus(
       geometry::GeometryId id_A, geometry::GeometryId id_B,
       const geometry::SceneGraphInspector<T>& inspector) const;
 
   /// Computes the combined Hunt & Crossley dissipation for geometries with ids
   /// `id_A` and `id_B`. Refer to @ref mbp_hydroelastic_materials_properties
   /// "Hydroelastic model material properties" for further details.
-  double CalcCombinedDissipation(
+  T CalcCombinedDissipation(
       geometry::GeometryId id_A, geometry::GeometryId id_B,
       const geometry::SceneGraphInspector<T>& inspector) const;
 };

--- a/multibody/plant/hydroelastic_traction_calculator.cc
+++ b/multibody/plant/hydroelastic_traction_calculator.cc
@@ -27,7 +27,7 @@ namespace internal {
 template <class T>
 void HydroelasticTractionCalculator<T>::
     ComputeSpatialForcesAtCentroidFromHydroelasticModel(
-        const Data& data, double dissipation, double mu_coulomb,
+        const Data& data, const T& dissipation, const T& mu_coulomb,
         std::vector<HydroelasticQuadraturePointData<T>>*
             traction_at_quadrature_points,
         SpatialForce<T>* F_Ac_W) const {
@@ -135,7 +135,7 @@ HydroelasticTractionCalculator<T>::CalcTractionAtPoint(
     const Data& data,
     SurfaceFaceIndex face_index,
     const typename SurfaceMesh<T>::Barycentric& Q_barycentric,
-    double dissipation, double mu_coulomb) const {
+    const T& dissipation, const T& mu_coulomb) const {
   // Compute the point of contact in the world frame.
   const Vector3<T> p_WQ = data.surface.mesh_W().CalcCartesianFromBarycentric(
       face_index, Q_barycentric);
@@ -173,7 +173,7 @@ template <typename T>
 HydroelasticQuadraturePointData<T>
 HydroelasticTractionCalculator<T>::CalcTractionAtQHelper(
     const Data& data, SurfaceFaceIndex face_index, const T& e,
-    const Vector3<T>& nhat_W, double dissipation, double mu_coulomb,
+    const Vector3<T>& nhat_W, const T& dissipation, const T& mu_coulomb,
     const Vector3<T>& p_WQ) const {
   HydroelasticQuadraturePointData<T> traction_data;
 

--- a/multibody/plant/hydroelastic_traction_calculator.h
+++ b/multibody/plant/hydroelastic_traction_calculator.h
@@ -104,7 +104,7 @@ class HydroelasticTractionCalculator {
                the centroid (Point c) of the contact surface.
    */
   void ComputeSpatialForcesAtCentroidFromHydroelasticModel(
-      const Data& data, double dissipation, double mu_coulomb,
+      const Data& data, const T& dissipation, const T& mu_coulomb,
       std::vector<HydroelasticQuadraturePointData<T>>*
           quadrature_point_data,
       multibody::SpatialForce<T>* F_Ac_W) const;
@@ -141,11 +141,11 @@ class HydroelasticTractionCalculator {
   HydroelasticQuadraturePointData<T> CalcTractionAtPoint(
       const Data& data, geometry::SurfaceFaceIndex face_index,
       const typename geometry::SurfaceMesh<T>::Barycentric& Q_barycentric,
-      double dissipation, double mu_coulomb) const;
+      const T& dissipation, const T& mu_coulomb) const;
 
   HydroelasticQuadraturePointData<T> CalcTractionAtQHelper(
       const Data& data, geometry::SurfaceFaceIndex face_index, const T& e,
-      const Vector3<T>& nhat_W, double dissipation, double mu_coulomb,
+      const Vector3<T>& nhat_W, const T& dissipation, const T& mu_coulomb,
       const Vector3<T>& p_WQ) const;
 
   multibody::SpatialForce<T> ComputeSpatialTractionAtAcFromTractionAtAq(

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -4125,7 +4125,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // CalcContactFrictionFromSurfaceProperties().
   // The i-th entry in the returned std::vector corresponds to the combined
   // friction properties for the i-th point pair in `point_pairs`.
-  std::vector<CoulombFriction<double>> CalcCombinedFrictionCoefficients(
+  std::vector<CoulombFriction<T>> CalcCombinedFrictionCoefficients(
       const drake::systems::Context<T>& context,
       const std::vector<geometry::PenetrationAsPointPair<T>>& point_pairs)
       const;
@@ -4302,7 +4302,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     /// See contact_model_doxygen.h @section tangent_force for details.
     T ComputeFrictionCoefficient(
         const T& speed_BcAc,
-        const CoulombFriction<double>& friction) const;
+        const CoulombFriction<T>& friction) const;
 
     /// Evaluates an S-shaped quintic curve, f(x), mapping the domain [0, 1] to
     /// the range [0, 1] where f(0) = f''(0) = f''(1) = f'(0) = f'(1) = 0 and
@@ -4609,7 +4609,7 @@ std::vector<geometry::PenetrationAsPointPair<AutoDiffXd>>
 MultibodyPlant<AutoDiffXd>::CalcPointPairPenetrations(
     const systems::Context<AutoDiffXd>&) const;
 template <>
-std::vector<CoulombFriction<double>>
+std::vector<CoulombFriction<symbolic::Expression>>
 MultibodyPlant<symbolic::Expression>::CalcCombinedFrictionCoefficients(
     const drake::systems::Context<symbolic::Expression>&,
     const std::vector<geometry::PenetrationAsPointPair<symbolic::Expression>>&)


### PR DESCRIPTION
A small fix after #13371.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13713)
<!-- Reviewable:end -->
