### PR TITLE
pydrake_pybind: Use simplified alias py_rvp

### DIFF
--- a/bindings/pydrake/attic/multibody/collision_py.cc
+++ b/bindings/pydrake/attic/multibody/collision_py.cc
@@ -30,9 +30,9 @@ PYBIND11_MODULE(collision, m) {
 
   py::class_<PointPair<double>>(m, "PointPair")
       .def_readonly(
-          "elementA", &PointPair<double>::elementA, py_reference_internal)
+          "elementA", &PointPair<double>::elementA, py_rvp::reference_internal)
       .def_readonly(
-          "elementB", &PointPair<double>::elementB, py_reference_internal)
+          "elementB", &PointPair<double>::elementB, py_rvp::reference_internal)
       .def_readonly("idA", &PointPair<double>::idA)
       .def_readonly("idB", &PointPair<double>::idB)
       .def_readonly("ptA", &PointPair<double>::ptA)

--- a/bindings/pydrake/attic/multibody/rigid_body_plant_py.cc
+++ b/bindings/pydrake/attic/multibody/rigid_body_plant_py.cc
@@ -61,7 +61,7 @@ PYBIND11_MODULE(rigid_body_plant, m) {
         .def("get_element_id_2", &Class::get_element_id_2,
             cls_doc.get_element_id_2.doc)
         .def("get_resultant_force", &Class::get_resultant_force,
-            py_reference_internal, cls_doc.get_resultant_force.doc);
+            py_rvp::reference_internal, cls_doc.get_resultant_force.doc);
   }
 
   {
@@ -95,7 +95,7 @@ PYBIND11_MODULE(rigid_body_plant, m) {
         .def("get_num_contacts", &Class::get_num_contacts,
             cls_doc.get_num_contacts.doc)
         .def("get_contact_info", &Class::get_contact_info,
-            py_reference_internal, cls_doc.get_contact_info.doc)
+            py_rvp::reference_internal, cls_doc.get_contact_info.doc)
         .def(
             "set_generalized_contact_force",
             [](Class* self, const Eigen::VectorXd& f) {
@@ -103,9 +103,9 @@ PYBIND11_MODULE(rigid_body_plant, m) {
             },
             cls_doc.set_generalized_contact_force.doc)
         .def("get_generalized_contact_force",
-            &Class::get_generalized_contact_force, py_reference_internal,
+            &Class::get_generalized_contact_force, py_rvp::reference_internal,
             cls_doc.get_generalized_contact_force.doc)
-        .def("AddContact", &Class::AddContact, py_reference_internal,
+        .def("AddContact", &Class::AddContact, py_rvp::reference_internal,
             py::arg("element_a"), py::arg("element_b"), cls_doc.AddContact.doc)
         .def("Clear", &Class::Clear, cls_doc.Clear.doc);
     AddValueInstantiation<Class>(m);
@@ -122,8 +122,8 @@ PYBIND11_MODULE(rigid_body_plant, m) {
             py::arg("static_friction"), py::arg("dynamic_friction"),
             cls_doc.ctor.doc_4args)
         // youngs_modulus
-        .def("set_youngs_modulus", &Class::set_youngs_modulus, py_reference,
-            cls_doc.set_youngs_modulus.doc)
+        .def("set_youngs_modulus", &Class::set_youngs_modulus,
+            py_rvp::reference, cls_doc.set_youngs_modulus.doc)
         .def("youngs_modulus", &Class::youngs_modulus,
             py::arg("default_value") = Class::kDefaultYoungsModulus,
             cls_doc.youngs_modulus.doc)
@@ -133,7 +133,7 @@ PYBIND11_MODULE(rigid_body_plant, m) {
             &Class::set_youngs_modulus_to_default,
             cls_doc.set_youngs_modulus_to_default.doc)
         // dissipation
-        .def("set_dissipation", &Class::set_dissipation, py_reference,
+        .def("set_dissipation", &Class::set_dissipation, py_rvp::reference,
             cls_doc.set_dissipation.doc)
         .def("dissipation", &Class::dissipation,
             py::arg("default_value") = Class::kDefaultDissipation,
@@ -144,11 +144,11 @@ PYBIND11_MODULE(rigid_body_plant, m) {
             cls_doc.set_dissipation_to_default.doc)
         // friction
         .def("set_friction", py::overload_cast<double>(&Class::set_friction),
-            py::arg("value"), py_reference, cls_doc.set_friction.doc_1args)
+            py::arg("value"), py_rvp::reference, cls_doc.set_friction.doc_1args)
         .def("set_friction",
             py::overload_cast<double, double>(&Class::set_friction),
             py::arg("static_friction"), py::arg("dynamic_friction"),
-            py_reference, cls_doc.set_friction.doc_2args)
+            py_rvp::reference, cls_doc.set_friction.doc_2args)
         .def("static_friction", &Class::static_friction,
             py::arg("default_value") = Class::kDefaultStaticFriction,
             cls_doc.static_friction.doc)
@@ -179,7 +179,7 @@ PYBIND11_MODULE(rigid_body_plant, m) {
             &Class::set_default_compliant_material,
             cls_doc.set_default_compliant_material.doc)
         .def("get_rigid_body_tree", &Class::get_rigid_body_tree,
-            py_reference_internal, cls_doc.get_rigid_body_tree.doc)
+            py_rvp::reference_internal, cls_doc.get_rigid_body_tree.doc)
         .def("get_num_bodies", &Class::get_num_bodies,
             cls_doc.get_num_bodies.doc)
         .def("get_num_positions",
@@ -228,39 +228,41 @@ PYBIND11_MODULE(rigid_body_plant, m) {
             &Class::FindInstancePositionIndexFromWorldIndex,
             cls_doc.FindInstancePositionIndexFromWorldIndex.doc)
         .def("actuator_command_input_port", &Class::actuator_command_input_port,
-            py_reference_internal, cls_doc.actuator_command_input_port.doc)
+            py_rvp::reference_internal, cls_doc.actuator_command_input_port.doc)
         .def("model_instance_has_actuators",
             &Class::model_instance_has_actuators,
             cls_doc.model_instance_has_actuators.doc)
         .def("model_instance_actuator_command_input_port",
             &Class::model_instance_actuator_command_input_port,
-            py_reference_internal,
+            py_rvp::reference_internal,
             cls_doc.model_instance_actuator_command_input_port.doc)
         .def("state_output_port", &Class::state_output_port,
-            py_reference_internal, cls_doc.state_output_port.doc)
+            py_rvp::reference_internal, cls_doc.state_output_port.doc)
         .def("state_derivative_output_port",
-            &Class::state_derivative_output_port, py_reference_internal,
+            &Class::state_derivative_output_port, py_rvp::reference_internal,
             cls_doc.state_derivative_output_port.doc)
         .def("model_instance_state_output_port",
-            &Class::model_instance_state_output_port, py_reference_internal,
+            &Class::model_instance_state_output_port,
+            py_rvp::reference_internal,
             cls_doc.model_instance_state_output_port.doc)
         .def("torque_output_port", &Class::torque_output_port,
-            py_reference_internal, cls_doc.torque_output_port.doc)
+            py_rvp::reference_internal, cls_doc.torque_output_port.doc)
         .def("model_instance_torque_output_port",
-            &Class::model_instance_torque_output_port, py_reference_internal,
+            &Class::model_instance_torque_output_port,
+            py_rvp::reference_internal,
             cls_doc.model_instance_torque_output_port.doc)
         .def("kinematics_results_output_port",
-            &Class::kinematics_results_output_port, py_reference_internal,
+            &Class::kinematics_results_output_port, py_rvp::reference_internal,
             cls_doc.kinematics_results_output_port.doc)
         .def("contact_results_output_port", &Class::contact_results_output_port,
-            py_reference_internal, cls_doc.contact_results_output_port.doc)
+            py_rvp::reference_internal, cls_doc.contact_results_output_port.doc)
         .def(
             "GetStateVector",
             [](const Class* self,
                 const Context<T>& context) -> Eigen::Ref<const VectorX<T>> {
               return self->GetStateVector(context);
             },
-            py::arg("context"), py_reference,
+            py::arg("context"), py_rvp::reference,
             // Keep alive, ownership: `return` keeps `context` alive.
             py::keep_alive<0, 2>(), cls_doc.GetStateVector.doc)
         .def("is_state_discrete", &Class::is_state_discrete,

--- a/bindings/pydrake/attic/multibody/rigid_body_tree_py.cc
+++ b/bindings/pydrake/attic/multibody/rigid_body_tree_py.cc
@@ -123,7 +123,7 @@ PYBIND11_MODULE(rigid_body_tree, m) {
             py::object self = py::cast(&tree);
             for (auto& body_unique_ptr : body_unique_ptrs) {
               py::object body_py =
-                  py::cast(body_unique_ptr.get(), py_reference);
+                  py::cast(body_unique_ptr.get(), py_rvp::reference);
               py_bodies.append(py_keep_alive(body_py, self));
             }
             return py_bodies;
@@ -262,7 +262,7 @@ PYBIND11_MODULE(rigid_body_tree, m) {
       .def_readonly("actuators", &RigidBodyTree<double>::actuators,
           doc.RigidBodyTree.actuators.doc)
       .def("GetActuator", &RigidBodyTree<double>::GetActuator,
-          py_reference_internal, doc.RigidBodyTree.GetActuator.doc)
+          py_rvp::reference_internal, doc.RigidBodyTree.GetActuator.doc)
       .def("FindBaseBodies", &RigidBodyTree<double>::FindBaseBodies,
           py::arg("model_instance_id") = -1,
           doc.RigidBodyTree.FindBaseBodies.doc)
@@ -532,7 +532,7 @@ PYBIND11_MODULE(rigid_body_tree, m) {
       .def("get_frame_index", &RigidBodyFrame<double>::get_frame_index,
           doc.RigidBodyFrame.get_frame_index.doc)
       .def("get_rigid_body", &RigidBodyFrame<double>::get_rigid_body,
-          py_reference,
+          py_rvp::reference,
           // Keep alive: `self` keeps `return` alive.
           py::keep_alive<1, 0>(), doc.RigidBodyFrame.get_rigid_body.doc)
       .def("get_transform_to_body",

--- a/bindings/pydrake/attic/multibody/shapes_py.cc
+++ b/bindings/pydrake/attic/multibody/shapes_py.cc
@@ -87,7 +87,7 @@ PYBIND11_MODULE(shapes, m) {
       .def(py::init<const Geometry&, const Eigen::Isometry3d&>(),
           py::arg("geometry_in"), py::arg("T_element_to_local"))
       .def("hasGeometry", &Element::hasGeometry, doc.Element.hasGeometry.doc)
-      .def("getGeometry", &Element::getGeometry, py_reference_internal,
+      .def("getGeometry", &Element::getGeometry, py_rvp::reference_internal,
           doc.Element.getGeometry.doc)
       .def(
           "getLocalTransform",

--- a/bindings/pydrake/attic/systems/sensors_py.cc
+++ b/bindings/pydrake/attic/systems/sensors_py.cc
@@ -35,16 +35,16 @@ PYBIND11_MODULE(sensors, m) {
     using PyClass = std::decay_t<decltype(py_class)>;
     using Class = typename PyClass::type;
     py_class
-        .def(
-            "state_input_port", &Class::state_input_port, py_reference_internal)
+        .def("state_input_port", &Class::state_input_port,
+            py_rvp::reference_internal)
         .def("color_image_output_port", &Class::color_image_output_port,
-            py_reference_internal)
+            py_rvp::reference_internal)
         .def("depth_image_output_port", &Class::depth_image_output_port,
-            py_reference_internal)
+            py_rvp::reference_internal)
         .def("label_image_output_port", &Class::label_image_output_port,
-            py_reference_internal)
+            py_rvp::reference_internal)
         .def("camera_base_pose_output_port",
-            &Class::camera_base_pose_output_port, py_reference_internal);
+            &Class::camera_base_pose_output_port, py_rvp::reference_internal);
   };
 
   py::class_<RgbdCamera, LeafSystem<T>> rgbd_camera(m, "RgbdCamera");
@@ -60,18 +60,19 @@ PYBIND11_MODULE(sensors, m) {
           // Keep alive, reference: `self` keeps `tree` alive.
           py::keep_alive<1, 3>(), doc.RgbdCamera.ctor.doc_10args)
       .def("color_camera_info", &RgbdCamera::color_camera_info,
-          py_reference_internal, doc.RgbdCamera.color_camera_info.doc)
+          py_rvp::reference_internal, doc.RgbdCamera.color_camera_info.doc)
       .def("depth_camera_info", &RgbdCamera::depth_camera_info,
-          py_reference_internal, doc.RgbdCamera.depth_camera_info.doc)
+          py_rvp::reference_internal, doc.RgbdCamera.depth_camera_info.doc)
       .def("color_camera_optical_pose", &RgbdCamera::color_camera_optical_pose,
           doc.RgbdCamera.color_camera_optical_pose.doc)
       .def("depth_camera_optical_pose", &RgbdCamera::depth_camera_optical_pose,
           doc.RgbdCamera.depth_camera_optical_pose.doc)
-      .def("frame", &RgbdCamera::frame, py_reference_internal,
+      .def("frame", &RgbdCamera::frame, py_rvp::reference_internal,
           doc.RgbdCamera.frame.doc)
-      .def("frame", &RgbdCamera::frame, py_reference_internal,
+      .def("frame", &RgbdCamera::frame, py_rvp::reference_internal,
           doc.RgbdCamera.frame.doc)
-      .def("tree", &RgbdCamera::tree, py_reference, doc.RgbdCamera.tree.doc);
+      .def("tree", &RgbdCamera::tree, py_rvp::reference,
+          doc.RgbdCamera.tree.doc);
   def_camera_ports(&rgbd_camera);
 
   py::class_<RgbdCameraDiscrete, Diagram<T>> rgbd_camera_discrete(

--- a/bindings/pydrake/common/eigen_pybind.h
+++ b/bindings/pydrake/common/eigen_pybind.h
@@ -23,7 +23,7 @@ py::object ToArray(T* ptr, int size, py::tuple shape) {
   // Create flat array to be reshaped in numpy.
   using Vector = VectorX<T>;
   Eigen::Map<Vector> data(ptr, size);
-  return py::cast(Eigen::Ref<Vector>(data), py_reference)
+  return py::cast(Eigen::Ref<Vector>(data), py_rvp::reference)
       .attr("reshape")(shape);
 }
 
@@ -33,7 +33,7 @@ py::object ToArray(const T* ptr, int size, py::tuple shape) {
   // Create flat array to be reshaped in numpy.
   using Vector = const VectorX<T>;
   Eigen::Map<Vector> data(ptr, size);
-  return py::cast(Eigen::Ref<Vector>(data), py_reference)
+  return py::cast(Eigen::Ref<Vector>(data), py_rvp::reference)
       .attr("reshape")(shape);
 }
 

--- a/bindings/pydrake/common/test/wrap_test_util_py.cc
+++ b/bindings/pydrake/common/test/wrap_test_util_py.cc
@@ -72,7 +72,7 @@ namespace pydrake {
 PYBIND11_MODULE(wrap_test_util, m) {
   py::class_<MyValue>(m, "MyValue")
       .def(py::init<double>(), py::arg("value"))
-      .def_readwrite("value", &MyValue::value, py_reference_internal);
+      .def_readwrite("value", &MyValue::value, py_rvp::reference_internal);
 
   py::class_<MyContainerRawPtr> my_container(m, "MyContainerRawPtr");
   my_container  // BR
@@ -90,7 +90,7 @@ PYBIND11_MODULE(wrap_test_util, m) {
 
   m.def("MakeTypeConversionExample", &MakeTypeConversionExample);
   m.def("MakeTypeConversionExampleBadRvp", &MakeTypeConversionExample,
-      py_reference);
+      py_rvp::reference);
   m.def("CheckTypeConversionExample", &CheckTypeConversionExample,
       py::arg("obj"));
 }

--- a/bindings/pydrake/common/value_pybind.h
+++ b/bindings/pydrake/common/value_pybind.h
@@ -60,7 +60,7 @@ py::class_<Class, drake::AbstractValue> AddValueInstantiation(
   constexpr bool has_get_mutable_value =
       internal::is_generic_pybind_v<T> || std::is_same_v<T, Object>;
   if constexpr (has_get_mutable_value) {
-    py::return_value_policy return_policy = py_reference_internal;
+    py::return_value_policy return_policy = py_rvp::reference_internal;
     if (std::is_same_v<T, Object>) {
       // N.B. This implies that `Object` will be copied by value; however, it
       // is only a shallow copy of the pointer, not a deep copy of the object.

--- a/bindings/pydrake/common/wrap_pybind.h
+++ b/bindings/pydrake/common/wrap_pybind.h
@@ -162,7 +162,7 @@ void DefReadUniquePtr(PyClass* cls, const char* name,
     const std::unique_ptr<T> Class::*member, const char* doc = "") {
   auto getter = py::cpp_function(
       [member](const Class* obj) { return (obj->*member).get(); },
-      py_reference_internal);
+      py_rvp::reference_internal);
   cls->def_property_readonly(name, getter, doc);
 }
 
@@ -172,7 +172,7 @@ void DefReadUniquePtr(PyClass* cls, const char* name,
     const copyable_unique_ptr<T> Class::*member, const char* doc = "") {
   auto getter = py::cpp_function(
       [member](const Class* obj) { return (obj->*member).get(); },
-      py_reference_internal);
+      py_rvp::reference_internal);
   cls->def_property_readonly(name, getter, doc);
 }
 

--- a/bindings/pydrake/examples/acrobot_py.cc
+++ b/bindings/pydrake/examples/acrobot_py.cc
@@ -54,21 +54,21 @@ PYBIND11_MODULE(acrobot, m) {
           // Keey alive, ownership: `return` keeps `context` alive
           py::keep_alive<0, 1>(), doc.AcrobotPlant.get_mutable_state.doc)
       .def("get_parameters", &AcrobotPlant<T>::get_parameters,
-          py_reference_internal, py::arg("context"),
+          py_rvp::reference_internal, py::arg("context"),
           doc.AcrobotPlant.get_parameters.doc)
       .def("get_mutable_parameters", &AcrobotPlant<T>::get_mutable_parameters,
-          py_reference_internal, py::arg("context"),
+          py_rvp::reference_internal, py::arg("context"),
           doc.AcrobotPlant.get_mutable_parameters.doc);
 
   py::class_<AcrobotSpongController<T>, LeafSystem<T>>(
       m, "AcrobotSpongController", doc.AcrobotSpongController.doc)
       .def(py::init<>(), doc.AcrobotSpongController.ctor.doc)
       .def("get_parameters", &AcrobotSpongController<T>::get_parameters,
-          py_reference, py::arg("context"),
+          py_rvp::reference, py::arg("context"),
           // Keep alive, ownership: `return` keeps `context` alive.
           py::keep_alive<0, 2>(), doc.AcrobotSpongController.get_parameters.doc)
       .def("get_mutable_parameters",
-          &AcrobotSpongController<T>::get_mutable_parameters, py_reference,
+          &AcrobotSpongController<T>::get_mutable_parameters, py_rvp::reference,
           py::arg("context"),
           // Keep alive, ownership: `return` keeps `context` alive.
           py::keep_alive<0, 2>(),
@@ -156,8 +156,8 @@ PYBIND11_MODULE(acrobot, m) {
           py::arg("acrobot_params"), py::arg("scene_graph"),
           // Keep alive, ownership: `return` keeps `builder` alive.
           py::keep_alive<0, 1>(),
-          // See #11531 for why `py_reference` is needed.
-          py_reference, doc.AcrobotGeometry.AddToBuilder.doc_4args)
+          // See #11531 for why `py_rvp::reference` is needed.
+          py_rvp::reference, doc.AcrobotGeometry.AddToBuilder.doc_4args)
       .def_static("AddToBuilder",
           py::overload_cast<systems::DiagramBuilder<double>*,
               const systems::OutputPort<double>&,
@@ -166,8 +166,8 @@ PYBIND11_MODULE(acrobot, m) {
           py::arg("scene_graph"),
           // Keep alive, ownership: `return` keeps `builder` alive.
           py::keep_alive<0, 1>(),
-          // See #11531 for why `py_reference` is needed.
-          py_reference, doc.AcrobotGeometry.AddToBuilder.doc_3args);
+          // See #11531 for why `py_rvp::reference` is needed.
+          py_rvp::reference, doc.AcrobotGeometry.AddToBuilder.doc_3args);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/examples/compass_gait_py.cc
+++ b/bindings/pydrake/examples/compass_gait_py.cc
@@ -31,11 +31,12 @@ PYBIND11_MODULE(compass_gait, m) {
       m, "CompassGait", doc.CompassGait.doc)
       .def(py::init<>(), doc.CompassGait.ctor.doc)
       .def("get_minimal_state_output_port",
-          &CompassGait<T>::get_minimal_state_output_port, py_reference_internal,
+          &CompassGait<T>::get_minimal_state_output_port,
+          py_rvp::reference_internal,
           doc.CompassGait.get_minimal_state_output_port.doc)
       .def("get_floating_base_state_output_port",
           &CompassGait<T>::get_floating_base_state_output_port,
-          py_reference_internal,
+          py_rvp::reference_internal,
           doc.CompassGait.get_floating_base_state_output_port.doc);
 
   // TODO(russt): Remove custom bindings once #8096 is resolved.
@@ -99,8 +100,8 @@ PYBIND11_MODULE(compass_gait, m) {
           py::arg("compass_gait_params"), py::arg("scene_graph"),
           // Keep alive, ownership: `return` keeps `builder` alive.
           py::keep_alive<0, 1>(),
-          // See #11531 for why `py_reference` is needed.
-          py_reference, doc.CompassGaitGeometry.AddToBuilder.doc_4args)
+          // See #11531 for why `py_rvp::reference` is needed.
+          py_rvp::reference, doc.CompassGaitGeometry.AddToBuilder.doc_4args)
       .def_static("AddToBuilder",
           py::overload_cast<systems::DiagramBuilder<double>*,
               const systems::OutputPort<double>&,
@@ -110,8 +111,8 @@ PYBIND11_MODULE(compass_gait, m) {
           py::arg("scene_graph"),
           // Keep alive, ownership: `return` keeps `builder` alive.
           py::keep_alive<0, 1>(),
-          // See #11531 for why `py_reference` is needed.
-          py_reference, doc.CompassGaitGeometry.AddToBuilder.doc_3args);
+          // See #11531 for why `py_rvp::reference` is needed.
+          py_rvp::reference, doc.CompassGaitGeometry.AddToBuilder.doc_3args);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/examples/manipulation_station_py.cc
+++ b/bindings/pydrake/examples/manipulation_station_py.cc
@@ -69,20 +69,22 @@ PYBIND11_MODULE(manipulation_station, m) {
       .def("num_iiwa_joints", &ManipulationStation<T>::num_iiwa_joints,
           doc.ManipulationStation.num_iiwa_joints.doc)
       .def("get_multibody_plant", &ManipulationStation<T>::get_multibody_plant,
-          py_reference_internal,
+          py_rvp::reference_internal,
           doc.ManipulationStation.get_multibody_plant.doc)
       .def("get_mutable_multibody_plant",
           &ManipulationStation<T>::get_mutable_multibody_plant,
-          py_reference_internal,
+          py_rvp::reference_internal,
           doc.ManipulationStation.get_mutable_multibody_plant.doc)
       .def("get_scene_graph", &ManipulationStation<T>::get_scene_graph,
-          py_reference_internal, doc.ManipulationStation.get_scene_graph.doc)
+          py_rvp::reference_internal,
+          doc.ManipulationStation.get_scene_graph.doc)
       .def("get_mutable_scene_graph",
           &ManipulationStation<T>::get_mutable_scene_graph,
-          py_reference_internal,
+          py_rvp::reference_internal,
           doc.ManipulationStation.get_mutable_scene_graph.doc)
       .def("get_controller_plant",
-          &ManipulationStation<T>::get_controller_plant, py_reference_internal,
+          &ManipulationStation<T>::get_controller_plant,
+          py_rvp::reference_internal,
           doc.ManipulationStation.get_controller_plant.doc)
       .def("GetIiwaPosition", &ManipulationStation<T>::GetIiwaPosition,
           doc.ManipulationStation.GetIiwaPosition.doc)
@@ -116,7 +118,7 @@ PYBIND11_MODULE(manipulation_station, m) {
           doc.ManipulationStation.SetWsgVelocity.doc_2args)
       .def("GetStaticCameraPosesInWorld",
           &ManipulationStation<T>::GetStaticCameraPosesInWorld,
-          py_reference_internal,
+          py_rvp::reference_internal,
           doc.ManipulationStation.GetStaticCameraPosesInWorld.doc)
       .def("get_camera_names", &ManipulationStation<T>::get_camera_names,
           doc.ManipulationStation.get_camera_names.doc)
@@ -143,11 +145,11 @@ PYBIND11_MODULE(manipulation_station, m) {
           doc.ManipulationStationHardwareInterface.Connect.doc)
       .def("get_controller_plant",
           &ManipulationStationHardwareInterface::get_controller_plant,
-          py_reference_internal,
+          py_rvp::reference_internal,
           doc.ManipulationStationHardwareInterface.get_controller_plant.doc)
       .def("get_camera_names",
           &ManipulationStationHardwareInterface::get_camera_names,
-          py_reference_internal,
+          py_rvp::reference_internal,
           doc.ManipulationStationHardwareInterface.get_camera_names.doc)
       .def("num_iiwa_joints",
           &ManipulationStationHardwareInterface::num_iiwa_joints,

--- a/bindings/pydrake/examples/pendulum_py.cc
+++ b/bindings/pydrake/examples/pendulum_py.cc
@@ -35,13 +35,14 @@ PYBIND11_MODULE(pendulum, m) {
   py::class_<PendulumPlant<T>, LeafSystem<T>>(
       m, "PendulumPlant", doc.PendulumPlant.doc)
       .def(py::init<>(), doc.PendulumPlant.ctor.doc)
-      .def("get_input_port", &System<T>::get_input_port, py_reference_internal,
-          py::arg("port_index"),
+      .def("get_input_port", &System<T>::get_input_port,
+          py_rvp::reference_internal, py::arg("port_index"),
           pydrake_doc.drake.systems.System.get_input_port.doc)
       .def("get_input_port", &PendulumPlant<T>::get_input_port,
-          py_reference_internal, doc.PendulumPlant.get_input_port.doc)
+          py_rvp::reference_internal, doc.PendulumPlant.get_input_port.doc)
       .def("get_state_output_port", &PendulumPlant<T>::get_state_output_port,
-          py_reference_internal, doc.PendulumPlant.get_state_output_port.doc)
+          py_rvp::reference_internal,
+          doc.PendulumPlant.get_state_output_port.doc)
       .def_static("get_state",
           py::overload_cast<const Context<T>&>(&PendulumPlant<T>::get_state),
           py::arg("context"),
@@ -53,10 +54,10 @@ PYBIND11_MODULE(pendulum, m) {
           // Keey alive, ownership: `return` keeps `context` alive
           py::keep_alive<0, 1>(), doc.PendulumPlant.get_mutable_state.doc)
       .def("get_parameters", &PendulumPlant<T>::get_parameters,
-          py_reference_internal, py::arg("context"),
+          py_rvp::reference_internal, py::arg("context"),
           doc.PendulumPlant.get_parameters.doc)
       .def("get_mutable_parameters", &PendulumPlant<T>::get_mutable_parameters,
-          py_reference_internal, py::arg("context"),
+          py_rvp::reference_internal, py::arg("context"),
           doc.PendulumPlant.get_mutable_parameters.doc);
 
   // TODO(russt): Remove custom bindings once #8096 is resolved.
@@ -117,8 +118,8 @@ PYBIND11_MODULE(pendulum, m) {
           py::arg("scene_graph"),
           // Keep alive, ownership: `return` keeps `builder` alive.
           py::keep_alive<0, 1>(),
-          // See #11531 for why `py_reference` is needed.
-          py_reference, doc.PendulumGeometry.AddToBuilder.doc);
+          // See #11531 for why `py_rvp::reference` is needed.
+          py_rvp::reference, doc.PendulumGeometry.AddToBuilder.doc);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/examples/rimless_wheel_py.cc
+++ b/bindings/pydrake/examples/rimless_wheel_py.cc
@@ -32,11 +32,11 @@ PYBIND11_MODULE(rimless_wheel, m) {
       .def(py::init<>(), doc.RimlessWheel.ctor.doc)
       .def("get_minimal_state_output_port",
           &RimlessWheel<T>::get_minimal_state_output_port,
-          py_reference_internal,
+          py_rvp::reference_internal,
           doc.RimlessWheel.get_minimal_state_output_port.doc)
       .def("get_floating_base_state_output_port",
           &RimlessWheel<T>::get_floating_base_state_output_port,
-          py_reference_internal,
+          py_rvp::reference_internal,
           doc.RimlessWheel.get_floating_base_state_output_port.doc)
       .def_static("calc_alpha", &RimlessWheel<T>::calc_alpha, py::arg("params"),
           doc.RimlessWheel.calc_alpha.doc);
@@ -89,8 +89,8 @@ PYBIND11_MODULE(rimless_wheel, m) {
           py::arg("rimless_wheel_params"), py::arg("scene_graph"),
           // Keep alive, ownership: `return` keeps `builder` alive.
           py::keep_alive<0, 1>(),
-          // See #11531 for why `py_reference` is needed.
-          py_reference, doc.RimlessWheelGeometry.AddToBuilder.doc_4args)
+          // See #11531 for why `py_rvp::reference` is needed.
+          py_rvp::reference, doc.RimlessWheelGeometry.AddToBuilder.doc_4args)
       .def_static("AddToBuilder",
           py::overload_cast<systems::DiagramBuilder<double>*,
               const systems::OutputPort<double>&,
@@ -100,8 +100,8 @@ PYBIND11_MODULE(rimless_wheel, m) {
           py::arg("scene_graph"),
           // Keep alive, ownership: `return` keeps `builder` alive.
           py::keep_alive<0, 1>(),
-          // See #11531 for why `py_reference` is needed.
-          py_reference, doc.RimlessWheelGeometry.AddToBuilder.doc_3args);
+          // See #11531 for why `py_rvp::reference` is needed.
+          py_rvp::reference, doc.RimlessWheelGeometry.AddToBuilder.doc_3args);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/examples/van_der_pol_py.cc
+++ b/bindings/pydrake/examples/van_der_pol_py.cc
@@ -29,11 +29,11 @@ PYBIND11_MODULE(van_der_pol, m) {
       .def(py::init<>(), doc.VanDerPolOscillator.ctor.doc)
       .def("get_position_output_port",
           &VanDerPolOscillator<T>::get_position_output_port,
-          py_reference_internal,
+          py_rvp::reference_internal,
           doc.VanDerPolOscillator.get_position_output_port.doc)
       .def("get_full_state_output_port",
           &VanDerPolOscillator<T>::get_full_state_output_port,
-          py_reference_internal,
+          py_rvp::reference_internal,
           doc.VanDerPolOscillator.get_full_state_output_port.doc)
       .def_static("CalcLimitCycle", &VanDerPolOscillator<T>::CalcLimitCycle,
           doc.VanDerPolOscillator.CalcLimitCycle.doc);

--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -179,12 +179,12 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("GetName",
             overload_cast_explicit<const std::string&, FrameId>(
                 &Class::GetName),
-            py_reference_internal, py::arg("frame_id"),
+            py_rvp::reference_internal, py::arg("frame_id"),
             cls_doc.GetName.doc_1args_frame_id)
         .def("GetName",
             overload_cast_explicit<const std::string&, GeometryId>(
                 &Class::GetName),
-            py_reference_internal, py::arg("geometry_id"),
+            py_rvp::reference_internal, py::arg("geometry_id"),
             cls_doc.GetName.doc_1args_geometry_id)
         .def(
             "GetNameByFrameId",
@@ -192,7 +192,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
               WarnDeprecated(doc_inspector_get_name_deprecation);
               return self->GetName(frame_id);
             },
-            py_reference_internal, py::arg("frame_id"),
+            py_rvp::reference_internal, py::arg("frame_id"),
             doc_inspector_get_name_deprecation)
         .def(
             "GetNameByGeometryId",
@@ -200,22 +200,24 @@ void DoScalarDependentDefinitions(py::module m, T) {
               WarnDeprecated(doc_inspector_get_name_deprecation);
               return self->GetName(frame_id);
             },
-            py_reference_internal, py::arg("geometry_id"),
+            py_rvp::reference_internal, py::arg("geometry_id"),
             doc_inspector_get_name_deprecation)
-        .def("GetShape", &Class::GetShape, py_reference_internal,
+        .def("GetShape", &Class::GetShape, py_rvp::reference_internal,
             py::arg("geometry_id"), cls_doc.GetShape.doc)
-        .def("GetPoseInParent", &Class::GetPoseInParent, py_reference_internal,
-            py::arg("geometry_id"), cls_doc.GetPoseInParent.doc)
-        .def("GetPoseInFrame", &Class::GetPoseInFrame, py_reference_internal,
-            py::arg("geometry_id"), cls_doc.GetPoseInFrame.doc)
+        .def("GetPoseInParent", &Class::GetPoseInParent,
+            py_rvp::reference_internal, py::arg("geometry_id"),
+            cls_doc.GetPoseInParent.doc)
+        .def("GetPoseInFrame", &Class::GetPoseInFrame,
+            py_rvp::reference_internal, py::arg("geometry_id"),
+            cls_doc.GetPoseInFrame.doc)
         .def("GetProximityProperties", &Class::GetProximityProperties,
-            py_reference_internal, py::arg("geometry_id"),
+            py_rvp::reference_internal, py::arg("geometry_id"),
             cls_doc.GetProximityProperties.doc)
         .def("GetIllustrationProperties", &Class::GetIllustrationProperties,
-            py_reference_internal, py::arg("geometry_id"),
+            py_rvp::reference_internal, py::arg("geometry_id"),
             cls_doc.GetIllustrationProperties.doc)
         .def("GetPerceptionProperties", &Class::GetPerceptionProperties,
-            py_reference_internal, py::arg("geometry_id"),
+            py_rvp::reference_internal, py::arg("geometry_id"),
             cls_doc.GetPerceptionProperties.doc)
         .def("CloneGeometryInstance", &Class::CloneGeometryInstance,
             py::arg("geometry_id"), cls_doc.CloneGeometryInstance.doc);
@@ -230,17 +232,17 @@ void DoScalarDependentDefinitions(py::module m, T) {
     cls  // BR
         .def(py::init<>(), cls_doc.ctor.doc)
         .def("get_source_pose_port", &Class::get_source_pose_port,
-            py_reference_internal, cls_doc.get_source_pose_port.doc)
+            py_rvp::reference_internal, cls_doc.get_source_pose_port.doc)
         .def(
             "get_pose_bundle_output_port",
             [](Class* self) -> const systems::OutputPort<T>& {
               return self->get_pose_bundle_output_port();
             },
-            py_reference_internal, cls_doc.get_pose_bundle_output_port.doc)
+            py_rvp::reference_internal, cls_doc.get_pose_bundle_output_port.doc)
         .def("get_query_output_port", &Class::get_query_output_port,
-            py_reference_internal, cls_doc.get_query_output_port.doc)
-        .def("model_inspector", &Class::model_inspector, py_reference_internal,
-            cls_doc.model_inspector.doc)
+            py_rvp::reference_internal, cls_doc.get_query_output_port.doc)
+        .def("model_inspector", &Class::model_inspector,
+            py_rvp::reference_internal, cls_doc.model_inspector.doc)
         .def("RegisterSource",
             py::overload_cast<const std::string&>(  // BR
                 &Class::RegisterSource),
@@ -273,22 +275,22 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("ExcludeCollisionsBetween",
             py::overload_cast<const GeometrySet&, const GeometrySet&>(
                 &Class::ExcludeCollisionsBetween),
-            py_reference_internal, py::arg("setA"), py::arg("setB"),
+            py_rvp::reference_internal, py::arg("setA"), py::arg("setB"),
             cls_doc.ExcludeCollisionsBetween.doc_2args)
         .def("ExcludeCollisionsBetween",
             overload_cast_explicit<void, Context<T>*, const GeometrySet&,
                 const GeometrySet&>(&Class::ExcludeCollisionsBetween),
-            py_reference_internal, py::arg("context"), py::arg("setA"),
+            py_rvp::reference_internal, py::arg("context"), py::arg("setA"),
             py::arg("setB"), cls_doc.ExcludeCollisionsBetween.doc_3args)
         .def("ExcludeCollisionsWithin",
             py::overload_cast<const GeometrySet&>(
                 &Class::ExcludeCollisionsWithin),
-            py_reference_internal, py::arg("set"),
+            py_rvp::reference_internal, py::arg("set"),
             cls_doc.ExcludeCollisionsWithin.doc_1args)
         .def("ExcludeCollisionsWithin",
             overload_cast_explicit<void, Context<T>*, const GeometrySet&>(
                 &Class::ExcludeCollisionsWithin),
-            py_reference_internal, py::arg("context"), py::arg("set"),
+            py_rvp::reference_internal, py::arg("context"), py::arg("set"),
             cls_doc.ExcludeCollisionsWithin.doc_2args)
         .def("AddRenderer", &Class::AddRenderer, py::arg("name"),
             py::arg("renderer"), cls_doc.AddRenderer.doc)
@@ -400,14 +402,14 @@ void DoScalarDependentDefinitions(py::module m, T) {
         m, "QueryObject", param, doc.QueryObject.doc);
     cls  // BR
         .def(py::init(), doc.QueryObject.ctor.doc)
-        .def("inspector", &QueryObject<T>::inspector, py_reference_internal,
-            doc.QueryObject.inspector.doc)
+        .def("inspector", &QueryObject<T>::inspector,
+            py_rvp::reference_internal, doc.QueryObject.inspector.doc)
         .def("X_WF", &QueryObject<T>::X_WF, py::arg("id"),
-            py_reference_internal, doc.QueryObject.X_WF.doc)
+            py_rvp::reference_internal, doc.QueryObject.X_WF.doc)
         .def("X_PF", &QueryObject<T>::X_PF, py::arg("id"),
-            py_reference_internal, doc.QueryObject.X_PF.doc)
+            py_rvp::reference_internal, doc.QueryObject.X_PF.doc)
         .def("X_WG", &QueryObject<T>::X_WG, py::arg("id"),
-            py_reference_internal, doc.QueryObject.X_WG.doc)
+            py_rvp::reference_internal, doc.QueryObject.X_WG.doc)
         .def("ComputeSignedDistancePairwiseClosestPoints",
             &QueryObject<T>::ComputeSignedDistancePairwiseClosestPoints,
             py::arg("max_distance") = std::numeric_limits<double>::infinity(),
@@ -615,8 +617,8 @@ void DoScalarIndependentDefinitions(py::module m) {
       py::arg("role") = geometry::Role::kIllustration,
       // Keep alive, ownership: `return` keeps `builder` alive.
       py::keep_alive<0, 1>(),
-      // See #11531 for why `py_reference` is needed.
-      py_reference, doc.ConnectDrakeVisualizer.doc_4args);
+      // See #11531 for why `py_rvp::reference` is needed.
+      py_rvp::reference, doc.ConnectDrakeVisualizer.doc_4args);
   m.def("ConnectDrakeVisualizer",
       py::overload_cast<systems::DiagramBuilder<double>*,
           const SceneGraph<double>&, const systems::OutputPort<double>&,
@@ -626,8 +628,8 @@ void DoScalarIndependentDefinitions(py::module m) {
       py::arg("role") = geometry::Role::kIllustration,
       // Keep alive, ownership: `return` keeps `builder` alive.
       py::keep_alive<0, 1>(),
-      // See #11531 for why `py_reference` is needed.
-      py_reference, doc.ConnectDrakeVisualizer.doc_5args);
+      // See #11531 for why `py_rvp::reference` is needed.
+      py_rvp::reference, doc.ConnectDrakeVisualizer.doc_5args);
   m.def("DispatchLoadMessage", &DispatchLoadMessage, py::arg("scene_graph"),
       py::arg("lcm"), py::arg("role") = geometry::Role::kIllustration,
       doc.DispatchLoadMessage.doc);
@@ -650,7 +652,7 @@ void DoScalarIndependentDefinitions(py::module m) {
         .def("width", &Box::width, doc.Box.width.doc)
         .def("depth", &Box::depth, doc.Box.depth.doc)
         .def("height", &Box::height, doc.Box.height.doc)
-        .def("size", &Box::size, py_reference_internal, doc.Box.size.doc);
+        .def("size", &Box::size, py_rvp::reference_internal, doc.Box.size.doc);
     py::class_<Capsule, Shape>(m, "Capsule", doc.Capsule.doc)
         .def(py::init<double, double>(), py::arg("radius"), py::arg("length"),
             doc.Capsule.ctor.doc)
@@ -700,10 +702,11 @@ void DoScalarIndependentDefinitions(py::module m) {
             py::arg("X_PG"), py::arg("shape"), py::arg("name"),
             cls_doc.ctor.doc)
         .def("id", &Class::id, cls_doc.id.doc)
-        .def("pose", &Class::pose, py_reference_internal, cls_doc.pose.doc)
+        .def("pose", &Class::pose, py_rvp::reference_internal, cls_doc.pose.doc)
         .def(
             "set_pose", &Class::set_pose, py::arg("X_PG"), cls_doc.set_pose.doc)
-        .def("shape", &Class::shape, py_reference_internal, cls_doc.shape.doc)
+        .def("shape", &Class::shape, py_rvp::reference_internal,
+            cls_doc.shape.doc)
         .def("release_shape", &Class::release_shape, cls_doc.release_shape.doc)
         .def("name", &Class::name, cls_doc.name.doc)
         .def("set_name", &Class::set_name, cls_doc.set_name.doc)
@@ -714,20 +717,20 @@ void DoScalarIndependentDefinitions(py::module m) {
         .def("set_perception_properties", &Class::set_perception_properties,
             py::arg("properties"), cls_doc.set_perception_properties.doc)
         .def("mutable_proximity_properties",
-            &Class::mutable_proximity_properties, py_reference_internal,
+            &Class::mutable_proximity_properties, py_rvp::reference_internal,
             cls_doc.mutable_proximity_properties.doc)
         .def("proximity_properties", &Class::proximity_properties,
-            py_reference_internal, cls_doc.proximity_properties.doc)
+            py_rvp::reference_internal, cls_doc.proximity_properties.doc)
         .def("mutable_illustration_properties",
-            &Class::mutable_illustration_properties, py_reference_internal,
+            &Class::mutable_illustration_properties, py_rvp::reference_internal,
             cls_doc.mutable_illustration_properties.doc)
         .def("illustration_properties", &Class::illustration_properties,
-            py_reference_internal, cls_doc.illustration_properties.doc)
+            py_rvp::reference_internal, cls_doc.illustration_properties.doc)
         .def("mutable_perception_properties",
-            &Class::mutable_perception_properties, py_reference_internal,
+            &Class::mutable_perception_properties, py_rvp::reference_internal,
             cls_doc.mutable_perception_properties.doc)
         .def("perception_properties", &Class::perception_properties,
-            py_reference_internal, cls_doc.perception_properties.doc);
+            py_rvp::reference_internal, cls_doc.perception_properties.doc);
   }
 
   {
@@ -743,11 +746,11 @@ void DoScalarIndependentDefinitions(py::module m) {
             "GetPropertiesInGroup",
             [](const Class& self, const std::string& group_name) {
               py::dict out;
-              py::object py_self = py::cast(&self, py_reference);
+              py::object py_self = py::cast(&self, py_rvp::reference);
               for (auto& [name, abstract] :
                   self.GetPropertiesInGroup(group_name)) {
-                out[name.c_str()] =
-                    py::cast(abstract.get(), py_reference_internal, py_self);
+                out[name.c_str()] = py::cast(
+                    abstract.get(), py_rvp::reference_internal, py_self);
               }
               return out;
             },
@@ -779,8 +782,9 @@ void DoScalarIndependentDefinitions(py::module m) {
             "GetProperty",
             [](const Class& self, const std::string& group_name,
                 const std::string& name) {
-              py::object abstract = py::cast(
-                  self.GetPropertyAbstract(group_name, name), py_reference);
+              py::object abstract =
+                  py::cast(self.GetPropertyAbstract(group_name, name),
+                      py_rvp::reference);
               return abstract.attr("get_value")();
             },
             py::arg("group_name"), py::arg("name"), cls_doc.GetProperty.doc)
@@ -791,7 +795,7 @@ void DoScalarIndependentDefinitions(py::module m) {
               // For now, ignore typing. This is less efficient, but eh, it's
               // Python.
               if (self.HasProperty(group_name, name)) {
-                py::object py_self = py::cast(&self, py_reference);
+                py::object py_self = py::cast(&self, py_rvp::reference);
                 return py_self.attr("GetProperty")(group_name, name);
               } else {
                 return default_value;
@@ -831,7 +835,7 @@ void DoScalarIndependentDefinitions(py::module m) {
       m, "PerceptionProperties", doc.PerceptionProperties.doc)
       .def(py::init(), doc.PerceptionProperties.ctor.doc);
   m.def("MakePhongIllustrationProperties", &MakePhongIllustrationProperties,
-      py_reference_internal, py::arg("diffuse"),
+      py_rvp::reference_internal, py::arg("diffuse"),
       doc.MakePhongIllustrationProperties.doc);
 
   m.def("ReadObjToSurfaceMesh",

--- a/bindings/pydrake/manipulation/schunk_wsg_py.cc
+++ b/bindings/pydrake/manipulation/schunk_wsg_py.cc
@@ -30,17 +30,18 @@ PYBIND11_MODULE(schunk_wsg, m) {
             py::arg("kd_command") = 5., py::arg("kp_constraint") = 2000.,
             py::arg("kd_constraint") = 5., cls_doc.ctor.doc)
         .def("get_desired_position_input_port",
-            &Class::get_desired_position_input_port, py_reference_internal,
+            &Class::get_desired_position_input_port, py_rvp::reference_internal,
             cls_doc.get_desired_position_input_port.doc)
         .def("get_force_limit_input_port", &Class::get_force_limit_input_port,
-            py_reference_internal, cls_doc.get_force_limit_input_port.doc)
+            py_rvp::reference_internal, cls_doc.get_force_limit_input_port.doc)
         .def("get_state_input_port", &Class::get_state_input_port,
-            py_reference_internal, cls_doc.get_state_input_port.doc)
+            py_rvp::reference_internal, cls_doc.get_state_input_port.doc)
         .def("get_generalized_force_output_port",
-            &Class::get_generalized_force_output_port, py_reference_internal,
+            &Class::get_generalized_force_output_port,
+            py_rvp::reference_internal,
             cls_doc.get_generalized_force_output_port.doc)
         .def("get_grip_force_output_port", &Class::get_grip_force_output_port,
-            py_reference_internal, cls_doc.get_grip_force_output_port.doc);
+            py_rvp::reference_internal, cls_doc.get_grip_force_output_port.doc);
   }
 
   {
@@ -51,9 +52,10 @@ PYBIND11_MODULE(schunk_wsg, m) {
         .def(py::init<double, double>(), py::arg("initial_position") = 0.02,
             py::arg("initial_force") = 40., cls_doc.ctor.doc)
         .def("get_position_output_port", &Class::get_position_output_port,
-            py_reference_internal, cls_doc.get_position_output_port.doc)
+            py_rvp::reference_internal, cls_doc.get_position_output_port.doc)
         .def("get_force_limit_output_port", &Class::get_force_limit_output_port,
-            py_reference_internal, cls_doc.get_force_limit_output_port.doc);
+            py_rvp::reference_internal,
+            cls_doc.get_force_limit_output_port.doc);
   }
 
   {
@@ -63,11 +65,11 @@ PYBIND11_MODULE(schunk_wsg, m) {
         m, "SchunkWsgCommandSender", cls_doc.doc)
         .def(py::init(), cls_doc.ctor.doc)
         .def("get_position_input_port", &Class::get_position_input_port,
-            py_reference_internal, cls_doc.get_position_input_port.doc)
+            py_rvp::reference_internal, cls_doc.get_position_input_port.doc)
         .def("get_force_limit_input_port", &Class::get_force_limit_input_port,
-            py_reference_internal, cls_doc.get_force_limit_input_port.doc)
+            py_rvp::reference_internal, cls_doc.get_force_limit_input_port.doc)
         .def("get_command_output_port", &Class::get_command_output_port,
-            py_reference_internal, cls_doc.get_command_output_port.doc);
+            py_rvp::reference_internal, cls_doc.get_command_output_port.doc);
   }
 
   {
@@ -77,11 +79,11 @@ PYBIND11_MODULE(schunk_wsg, m) {
         m, "SchunkWsgStatusReceiver", cls_doc.doc)
         .def(py::init(), cls_doc.ctor.doc)
         .def("get_status_input_port", &Class::get_status_input_port,
-            py_reference_internal, cls_doc.get_status_input_port.doc)
+            py_rvp::reference_internal, cls_doc.get_status_input_port.doc)
         .def("get_state_output_port", &Class::get_state_output_port,
-            py_reference_internal, cls_doc.get_state_output_port.doc)
+            py_rvp::reference_internal, cls_doc.get_state_output_port.doc)
         .def("get_force_output_port", &Class::get_force_output_port,
-            py_reference_internal, cls_doc.get_force_output_port.doc);
+            py_rvp::reference_internal, cls_doc.get_force_output_port.doc);
   }
 
   {
@@ -91,9 +93,9 @@ PYBIND11_MODULE(schunk_wsg, m) {
         m, "SchunkWsgStatusSender", cls_doc.doc)
         .def(py::init(), cls_doc.ctor.doc)
         .def("get_state_input_port", &Class::get_state_input_port,
-            py_reference_internal, cls_doc.get_state_input_port.doc)
+            py_rvp::reference_internal, cls_doc.get_state_input_port.doc)
         .def("get_force_input_port", &Class::get_force_input_port,
-            py_reference_internal, cls_doc.get_force_input_port.doc);
+            py_rvp::reference_internal, cls_doc.get_force_input_port.doc);
   }
 
   {

--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -72,7 +72,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("SetFromIsometry3", &Class::SetFromIsometry3, py::arg("pose"),
             cls_doc.SetFromIsometry3.doc)
         .def_static("Identity", &Class::Identity, cls_doc.Identity.doc)
-        .def("rotation", &Class::rotation, py_reference_internal,
+        .def("rotation", &Class::rotation, py_rvp::reference_internal,
             cls_doc.rotation.doc)
         .def("set_rotation",
             py::overload_cast<const RotationMatrix<T>&>(&Class::set_rotation),

--- a/bindings/pydrake/multibody/inverse_kinematics_py.cc
+++ b/bindings/pydrake/multibody/inverse_kinematics_py.cc
@@ -82,13 +82,13 @@ PYBIND11_MODULE(inverse_kinematics, m) {
             py::arg("distance_lower"), py::arg("distance_upper"),
             cls_doc.AddPointToPointDistanceConstraint.doc)
         .def("q", &Class::q, cls_doc.q.doc)
-        .def("prog", &Class::prog, py_reference_internal, cls_doc.prog.doc)
+        .def("prog", &Class::prog, py_rvp::reference_internal, cls_doc.prog.doc)
         .def("get_mutable_prog", &Class::get_mutable_prog,
-            py_reference_internal, cls_doc.get_mutable_prog.doc)
-        .def("context", &Class::context, py_reference_internal,
+            py_rvp::reference_internal, cls_doc.get_mutable_prog.doc)
+        .def("context", &Class::context, py_rvp::reference_internal,
             cls_doc.context.doc)
         .def("get_mutable_context", &Class::get_mutable_context,
-            py_reference_internal, cls_doc.get_mutable_context.doc);
+            py_rvp::reference_internal, cls_doc.get_mutable_context.doc);
   }
   {
     using Class = AngleBetweenVectorsConstraint;

--- a/bindings/pydrake/multibody/parsing_py.cc
+++ b/bindings/pydrake/multibody/parsing_py.cc
@@ -47,7 +47,7 @@ PYBIND11_MODULE(parsing, m) {
         .def(py::init<MultibodyPlant<double>*, SceneGraph<double>*>(),
             py::arg("plant"), py::arg("scene_graph") = nullptr,
             cls_doc.ctor.doc)
-        .def("package_map", &Class::package_map, py_reference_internal,
+        .def("package_map", &Class::package_map, py_rvp::reference_internal,
             cls_doc.package_map.doc)
         .def("AddAllModelsFromFile", &Class::AddAllModelsFromFile,
             py::arg("file_name"), cls_doc.AddAllModelsFromFile.doc)

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -137,7 +137,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
               surface_properties1, surface_properties2);
         },
         py::arg("surface_properties1"), py::arg("surface_properties2"),
-        py_reference, doc.CalcContactFrictionFromSurfaceProperties.doc);
+        py_rvp::reference, doc.CalcContactFrictionFromSurfaceProperties.doc);
   }
 
   {
@@ -192,9 +192,10 @@ void DoScalarDependentDefinitions(py::module m, T) {
             [](Class * self, std::unique_ptr<Joint<T>> joint) -> auto& {
               return self->AddJoint(std::move(joint));
             },
-            py::arg("joint"), py_reference_internal, cls_doc.AddJoint.doc_1args)
+            py::arg("joint"), py_rvp::reference_internal,
+            cls_doc.AddJoint.doc_1args)
         .def("AddJointActuator", &Class::AddJointActuator,
-            py_reference_internal, py::arg("name"), py::arg("joint"),
+            py_rvp::reference_internal, py::arg("name"), py::arg("joint"),
             py::arg("effort_limit") = std::numeric_limits<double>::infinity(),
             cls_doc.AddJointActuator.doc)
         .def(
@@ -202,7 +203,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
             [](Class * self, std::unique_ptr<Frame<T>> frame) -> auto& {
               return self->AddFrame(std::move(frame));
             },
-            py_reference_internal, py::arg("frame"), cls_doc.AddFrame.doc)
+            py_rvp::reference_internal, py::arg("frame"), cls_doc.AddFrame.doc)
         .def("AddModelInstance", &Class::AddModelInstance, py::arg("name"),
             cls_doc.AddModelInstance.doc)
         .def(
@@ -211,19 +212,19 @@ void DoScalarDependentDefinitions(py::module m, T) {
                 const SpatialInertia<double>& s) -> auto& {
               return self->AddRigidBody(name, s);
             },
-            py::arg("name"), py::arg("M_BBo_B"), py_reference_internal,
+            py::arg("name"), py::arg("M_BBo_B"), py_rvp::reference_internal,
             cls_doc.AddRigidBody.doc_2args)
         .def("AddRigidBody",
             py::overload_cast<const std::string&, ModelInstanceIndex,
                 const SpatialInertia<double>&>(&Class::AddRigidBody),
             py::arg("name"), py::arg("model_instance"), py::arg("M_BBo_B"),
-            py_reference_internal, cls_doc.AddRigidBody.doc_3args)
+            py_rvp::reference_internal, cls_doc.AddRigidBody.doc_3args)
         .def("WeldFrames",
             py::overload_cast<const Frame<T>&, const Frame<T>&,
                 const RigidTransform<double>&>(&Class::WeldFrames),
             py::arg("A"), py::arg("B"),
             py::arg("X_AB") = RigidTransform<double>::Identity(),
-            py_reference_internal, cls_doc.WeldFrames.doc)
+            py_rvp::reference_internal, cls_doc.WeldFrames.doc)
         .def(
             "WeldFrames",
             [](Class* self, const Frame<T>& A, const Frame<T>& B,
@@ -231,8 +232,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
               WarnDeprecated(doc_iso3_deprecation);
               return self->WeldFrames(A, B, RigidTransform<double>(X_AB));
             },
-            py::arg("A"), py::arg("B"), py::arg("X_AB"), py_reference_internal,
-            doc_iso3_deprecation)
+            py::arg("A"), py::arg("B"), py::arg("X_AB"),
+            py_rvp::reference_internal, doc_iso3_deprecation)
         .def(
             "AddForceElement",
             [](Class * self,
@@ -240,7 +241,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
               return self->template AddForceElement<ForceElement>(
                   std::move(force_element));
             },
-            py::arg("force_element"), py_reference_internal,
+            py::arg("force_element"), py_rvp::reference_internal,
             cls_doc.AddForceElement.doc);
     // Mathy bits
     cls  // BR
@@ -527,22 +528,22 @@ void DoScalarDependentDefinitions(py::module m, T) {
     cls  // BR
         .def("num_frames", &Class::num_frames, cls_doc.num_frames.doc)
         .def("get_body", &Class::get_body, py::arg("body_index"),
-            py_reference_internal, cls_doc.get_body.doc)
+            py_rvp::reference_internal, cls_doc.get_body.doc)
         .def("get_joint", &Class::get_joint, py::arg("joint_index"),
-            py_reference_internal, cls_doc.get_joint.doc)
+            py_rvp::reference_internal, cls_doc.get_joint.doc)
         .def("get_joint_actuator", &Class::get_joint_actuator,
-            py::arg("actuator_index"), py_reference_internal,
+            py::arg("actuator_index"), py_rvp::reference_internal,
             cls_doc.get_joint_actuator.doc)
         .def("get_frame", &Class::get_frame, py::arg("frame_index"),
-            py_reference_internal, cls_doc.get_frame.doc)
-        .def("gravity_field", &Class::gravity_field, py_reference_internal,
+            py_rvp::reference_internal, cls_doc.get_frame.doc)
+        .def("gravity_field", &Class::gravity_field, py_rvp::reference_internal,
             cls_doc.gravity_field.doc)
         .def("mutable_gravity_field", &Class::mutable_gravity_field,
-            py_reference_internal, cls_doc.mutable_gravity_field.doc)
+            py_rvp::reference_internal, cls_doc.mutable_gravity_field.doc)
         .def("GetModelInstanceName",
             overload_cast_explicit<const string&, ModelInstanceIndex>(
                 &Class::GetModelInstanceName),
-            py::arg("model_instance"), py_reference_internal,
+            py::arg("model_instance"), py_rvp::reference_internal,
             cls_doc.GetModelInstanceName.doc)
         .def("HasModelInstanceNamed", &Class::HasModelInstanceNamed,
             py::arg("name"), cls_doc.HasModelInstanceNamed.doc)
@@ -574,23 +575,23 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("GetFrameByName",
             overload_cast_explicit<const Frame<T>&, const string&>(
                 &Class::GetFrameByName),
-            py::arg("name"), py_reference_internal,
+            py::arg("name"), py_rvp::reference_internal,
             cls_doc.GetFrameByName.doc_1args)
         .def("GetFrameByName",
             overload_cast_explicit<const Frame<T>&, const string&,
                 ModelInstanceIndex>(&Class::GetFrameByName),
-            py::arg("name"), py::arg("model_instance"), py_reference_internal,
-            cls_doc.GetFrameByName.doc_2args)
+            py::arg("name"), py::arg("model_instance"),
+            py_rvp::reference_internal, cls_doc.GetFrameByName.doc_2args)
         .def("GetBodyByName",
             overload_cast_explicit<const Body<T>&, const string&>(
                 &Class::GetBodyByName),
-            py::arg("name"), py_reference_internal,
+            py::arg("name"), py_rvp::reference_internal,
             cls_doc.GetBodyByName.doc_1args)
         .def("GetBodyByName",
             overload_cast_explicit<const Body<T>&, const string&,
                 ModelInstanceIndex>(&Class::GetBodyByName),
-            py::arg("name"), py::arg("model_instance"), py_reference_internal,
-            cls_doc.GetBodyByName.doc_2args)
+            py::arg("name"), py::arg("model_instance"),
+            py_rvp::reference_internal, cls_doc.GetBodyByName.doc_2args)
         .def("GetBodyFrameIdOrThrow", &Class::GetBodyFrameIdOrThrow,
             py::arg("body_index"), cls_doc.GetBodyFrameIdOrThrow.doc)
         .def("GetBodyIndices", &Class::GetBodyIndices,
@@ -602,7 +603,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
               return self->GetJointByName(name, model_instance);
             },
             py::arg("name"), py::arg("model_instance") = std::nullopt,
-            py_reference_internal, cls_doc.GetJointByName.doc)
+            py_rvp::reference_internal, cls_doc.GetJointByName.doc)
         .def(
             "GetMutableJointByName",
             [](Class * self, const string& name,
@@ -610,16 +611,16 @@ void DoScalarDependentDefinitions(py::module m, T) {
               return self->GetMutableJointByName(name, model_instance);
             },
             py::arg("name"), py::arg("model_instance") = std::nullopt,
-            py_reference_internal, cls_doc.GetJointByName.doc)
+            py_rvp::reference_internal, cls_doc.GetJointByName.doc)
         .def("GetJointActuatorByName",
             overload_cast_explicit<const JointActuator<T>&, const string&>(
                 &Class::GetJointActuatorByName),
-            py::arg("name"), py_reference_internal,
+            py::arg("name"), py_rvp::reference_internal,
             cls_doc.GetJointActuatorByName.doc_1args)
         .def("GetModelInstanceByName",
             overload_cast_explicit<ModelInstanceIndex, const string&>(
                 &Class::GetModelInstanceByName),
-            py::arg("name"), py_reference_internal,
+            py::arg("name"), py_rvp::reference_internal,
             cls_doc.GetModelInstanceByName.doc)
         .def("GetTopologyGraphvizString", &Class::GetTopologyGraphvizString,
             cls_doc.GetTopologyGraphvizString.doc);
@@ -675,22 +676,23 @@ void DoScalarDependentDefinitions(py::module m, T) {
                 .doc_5args_body_X_BG_shape_name_coulomb_friction)
         .def("get_source_id", &Class::get_source_id, cls_doc.get_source_id.doc)
         .def("get_geometry_query_input_port",
-            &Class::get_geometry_query_input_port, py_reference_internal,
+            &Class::get_geometry_query_input_port, py_rvp::reference_internal,
             cls_doc.get_geometry_query_input_port.doc)
         .def("get_geometry_poses_output_port",
-            &Class::get_geometry_poses_output_port, py_reference_internal,
+            &Class::get_geometry_poses_output_port, py_rvp::reference_internal,
             cls_doc.get_geometry_poses_output_port.doc)
         .def("geometry_source_is_registered",
             &Class::geometry_source_is_registered,
             cls_doc.geometry_source_is_registered.doc)
         .def("GetBodyFromFrameId", &Class::GetBodyFromFrameId,
-            py_reference_internal, cls_doc.GetBodyFromFrameId.doc)
+            py_rvp::reference_internal, cls_doc.GetBodyFromFrameId.doc)
         .def("GetBodyFrameIdIfExists", &Class::GetBodyFrameIdIfExists,
-            py::arg("body_index"), py_reference_internal,
+            py::arg("body_index"), py_rvp::reference_internal,
             cls_doc.GetBodyFrameIdIfExists.doc)
         .def("GetCollisionGeometriesForBody",
             &Class::GetCollisionGeometriesForBody, py::arg("body"),
-            py_reference_internal, cls_doc.GetCollisionGeometriesForBody.doc)
+            py_rvp::reference_internal,
+            cls_doc.GetCollisionGeometriesForBody.doc)
         .def("num_collision_geometries", &Class::num_collision_geometries,
             cls_doc.num_collision_geometries.doc)
         .def("CollectRegisteredGeometries", &Class::CollectRegisteredGeometries,
@@ -698,7 +700,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     cls.def("default_coulomb_friction", &Class::default_coulomb_friction,
-        py::arg("geometry_id"), py_reference_internal,
+        py::arg("geometry_id"), py_rvp::reference_internal,
         cls_doc.default_coulomb_friction.doc_deprecated);
 #pragma GCC diagnostic pop
     DeprecateAttribute(cls, "default_coulomb_friction",
@@ -708,76 +710,79 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("get_actuation_input_port",
             overload_cast_explicit<const systems::InputPort<T>&>(
                 &Class::get_actuation_input_port),
-            py_reference_internal, cls_doc.get_actuation_input_port.doc_0args)
+            py_rvp::reference_internal,
+            cls_doc.get_actuation_input_port.doc_0args)
         .def("get_actuation_input_port",
             overload_cast_explicit<const systems::InputPort<T>&,
                 multibody::ModelInstanceIndex>(
                 &Class::get_actuation_input_port),
-            py::arg("model_instance"), py_reference_internal,
+            py::arg("model_instance"), py_rvp::reference_internal,
             cls_doc.get_actuation_input_port.doc_1args)
         .def("get_applied_generalized_force_input_port",
             overload_cast_explicit<const systems::InputPort<T>&>(
                 &Class::get_applied_generalized_force_input_port),
-            py_reference_internal,
+            py_rvp::reference_internal,
             cls_doc.get_applied_generalized_force_input_port.doc)
         .def("get_applied_spatial_force_input_port",
             overload_cast_explicit<const systems::InputPort<T>&>(
                 &Class::get_applied_spatial_force_input_port),
-            py_reference_internal,
+            py_rvp::reference_internal,
             cls_doc.get_applied_spatial_force_input_port.doc)
         .def("get_body_poses_output_port",
             overload_cast_explicit<const systems::OutputPort<T>&>(
                 &Class::get_body_poses_output_port),
-            py_reference_internal, cls_doc.get_body_poses_output_port.doc)
+            py_rvp::reference_internal, cls_doc.get_body_poses_output_port.doc)
         .def("get_body_spatial_velocities_output_port",
             overload_cast_explicit<const systems::OutputPort<T>&>(
                 &Class::get_body_spatial_velocities_output_port),
-            py_reference_internal,
+            py_rvp::reference_internal,
             cls_doc.get_body_spatial_velocities_output_port.doc)
         .def("get_body_spatial_accelerations_output_port",
             overload_cast_explicit<const systems::OutputPort<T>&>(
                 &Class::get_body_spatial_accelerations_output_port),
-            py_reference_internal,
+            py_rvp::reference_internal,
             cls_doc.get_body_spatial_accelerations_output_port.doc)
         .def("get_state_output_port",
             overload_cast_explicit<const systems::OutputPort<T>&>(
                 &Class::get_state_output_port),
-            py_reference_internal, cls_doc.get_state_output_port.doc_0args)
+            py_rvp::reference_internal, cls_doc.get_state_output_port.doc_0args)
         .def("get_state_output_port",
             overload_cast_explicit<const systems::OutputPort<T>&,
                 multibody::ModelInstanceIndex>(&Class::get_state_output_port),
-            py::arg("model_instance"), py_reference_internal,
+            py::arg("model_instance"), py_rvp::reference_internal,
             cls_doc.get_state_output_port.doc_1args)
         .def("get_generalized_acceleration_output_port",
             overload_cast_explicit<const systems::OutputPort<T>&>(
                 &Class::get_generalized_acceleration_output_port),
-            py_reference_internal,
+            py_rvp::reference_internal,
             cls_doc.get_generalized_acceleration_output_port.doc_0args)
         .def("get_generalized_acceleration_output_port",
             overload_cast_explicit<const systems::OutputPort<T>&,
                 multibody::ModelInstanceIndex>(
                 &Class::get_generalized_acceleration_output_port),
-            py::arg("model_instance"), py_reference_internal,
+            py::arg("model_instance"), py_rvp::reference_internal,
             cls_doc.get_generalized_acceleration_output_port.doc_1args)
         .def("get_reaction_forces_output_port",
             overload_cast_explicit<const systems::OutputPort<T>&>(
                 &Class::get_reaction_forces_output_port),
-            py_reference_internal, cls_doc.get_reaction_forces_output_port.doc)
+            py_rvp::reference_internal,
+            cls_doc.get_reaction_forces_output_port.doc)
         .def("get_contact_results_output_port",
             overload_cast_explicit<const systems::OutputPort<T>&>(
                 &Class::get_contact_results_output_port),
-            py_reference_internal, cls_doc.get_contact_results_output_port.doc)
+            py_rvp::reference_internal,
+            cls_doc.get_contact_results_output_port.doc)
         .def("get_generalized_contact_forces_output_port",
             overload_cast_explicit<const systems::OutputPort<T>&,
                 multibody::ModelInstanceIndex>(
                 &Class::get_generalized_contact_forces_output_port),
-            py_reference_internal, py::arg("model_instance"),
+            py_rvp::reference_internal, py::arg("model_instance"),
             cls_doc.get_generalized_contact_forces_output_port.doc);
     // Property accessors.
     cls  // BR
-        .def("world_body", &Class::world_body, py_reference_internal,
+        .def("world_body", &Class::world_body, py_rvp::reference_internal,
             cls_doc.world_body.doc)
-        .def("world_frame", &Class::world_frame, py_reference_internal,
+        .def("world_frame", &Class::world_frame, py_rvp::reference_internal,
             cls_doc.world_frame.doc)
         .def("is_finalized", &Class::is_finalized, cls_doc.is_finalized.doc)
         .def("Finalize", py::overload_cast<>(&Class::Finalize),
@@ -798,7 +803,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
                 Context<T>* context) -> Eigen::Ref<VectorX<T>> {
               return self->GetMutablePositionsAndVelocities(context);
             },
-            py_reference, py::arg("context"),
+            py_rvp::reference, py::arg("context"),
             // Keep alive, ownership: `return` keeps `context` alive.
             py::keep_alive<0, 2>(),
             cls_doc.GetMutablePositionsAndVelocities.doc)
@@ -808,7 +813,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
                 Context<T>* context) -> Eigen::Ref<VectorX<T>> {
               return self->GetMutablePositions(context);
             },
-            py_reference, py::arg("context"),
+            py_rvp::reference, py::arg("context"),
             // Keep alive, ownership: `return` keeps `context` alive.
             py::keep_alive<0, 2>(), cls_doc.GetMutablePositions.doc_1args)
         .def(
@@ -817,27 +822,28 @@ void DoScalarDependentDefinitions(py::module m, T) {
                 Context<T>* context) -> Eigen::Ref<VectorX<T>> {
               return self->GetMutableVelocities(context);
             },
-            py_reference, py::arg("context"),
+            py_rvp::reference, py::arg("context"),
             // Keep alive, ownership: `return` keeps `context` alive.
             py::keep_alive<0, 2>(), cls_doc.GetMutableVelocities.doc_1args)
         .def(
             "GetPositions",
             [](const MultibodyPlant<T>* self, const Context<T>& context)
                 -> VectorX<T> { return self->GetPositions(context); },
-            py_reference, py::arg("context"), cls_doc.GetPositions.doc_1args)
+            py_rvp::reference, py::arg("context"),
+            cls_doc.GetPositions.doc_1args)
         .def(
             "GetPositions",
             [](const MultibodyPlant<T>* self, const Context<T>& context,
                 multibody::ModelInstanceIndex model_instance) -> VectorX<T> {
               return self->GetPositions(context, model_instance);
             },
-            py_reference, py::arg("context"), py::arg("model_instance"),
+            py_rvp::reference, py::arg("context"), py::arg("model_instance"),
             cls_doc.GetPositions.doc_2args)
         .def(
             "SetPositions",
             [](const MultibodyPlant<T>* self, Context<T>* context,
                 const VectorX<T>& q) { self->SetPositions(context, q); },
-            py_reference, py::arg("context"), py::arg("q"),
+            py_rvp::reference, py::arg("context"), py::arg("q"),
             cls_doc.SetPositions.doc_2args)
         .def(
             "SetPositions",
@@ -846,26 +852,27 @@ void DoScalarDependentDefinitions(py::module m, T) {
                 const VectorX<T>& q) {
               self->SetPositions(context, model_instance, q);
             },
-            py_reference, py::arg("context"), py::arg("model_instance"),
+            py_rvp::reference, py::arg("context"), py::arg("model_instance"),
             py::arg("q"), cls_doc.SetPositions.doc_2args)
         .def(
             "GetVelocities",
             [](const MultibodyPlant<T>* self, const Context<T>& context)
                 -> VectorX<T> { return self->GetVelocities(context); },
-            py_reference, py::arg("context"), cls_doc.GetVelocities.doc_1args)
+            py_rvp::reference, py::arg("context"),
+            cls_doc.GetVelocities.doc_1args)
         .def(
             "GetVelocities",
             [](const MultibodyPlant<T>* self, const Context<T>& context,
                 multibody::ModelInstanceIndex model_instance) -> VectorX<T> {
               return self->GetVelocities(context, model_instance);
             },
-            py_reference, py::arg("context"), py::arg("model_instance"),
+            py_rvp::reference, py::arg("context"), py::arg("model_instance"),
             cls_doc.GetVelocities.doc_2args)
         .def(
             "SetVelocities",
             [](const MultibodyPlant<T>* self, Context<T>* context,
                 const VectorX<T>& v) { self->SetVelocities(context, v); },
-            py_reference, py::arg("context"), py::arg("v"),
+            py_rvp::reference, py::arg("context"), py::arg("v"),
             cls_doc.SetVelocities.doc_2args)
         .def(
             "SetVelocities",
@@ -873,7 +880,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
                 ModelInstanceIndex model_instance, const VectorX<T>& v) {
               self->SetVelocities(context, model_instance, v);
             },
-            py_reference, py::arg("context"), py::arg("model_instance"),
+            py_rvp::reference, py::arg("context"), py::arg("model_instance"),
             py::arg("v"), cls_doc.SetVelocities.doc_3args)
         .def(
             "GetPositionsAndVelocities",
@@ -881,7 +888,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
                 const Context<T>& context) -> VectorX<T> {
               return self->GetPositionsAndVelocities(context);
             },
-            py_reference, py::arg("context"),
+            py_rvp::reference, py::arg("context"),
             cls_doc.GetPositionsAndVelocities.doc_1args)
         .def(
             "GetPositionsAndVelocities",
@@ -889,7 +896,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
                 multibody::ModelInstanceIndex model_instance) -> VectorX<T> {
               return self->GetPositionsAndVelocities(context, model_instance);
             },
-            py_reference, py::arg("context"), py::arg("model_instance"),
+            py_rvp::reference, py::arg("context"), py::arg("model_instance"),
             cls_doc.GetPositionsAndVelocities.doc_2args)
         .def(
             "SetPositionsAndVelocities",
@@ -897,7 +904,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
                 const VectorX<T>& q_v) {
               self->SetPositionsAndVelocities(context, q_v);
             },
-            py_reference, py::arg("context"), py::arg("q_v"),
+            py_rvp::reference, py::arg("context"), py::arg("q_v"),
             cls_doc.SetPositionsAndVelocities.doc_2args)
         .def(
             "SetPositionsAndVelocities",
@@ -906,7 +913,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
                 const VectorX<T>& q_v) {
               self->SetPositionsAndVelocities(context, model_instance, q_v);
             },
-            py_reference, py::arg("context"), py::arg("model_instance"),
+            py_rvp::reference, py::arg("context"), py::arg("model_instance"),
             py::arg("q_v"), cls_doc.SetPositionsAndVelocities.doc_3args)
         .def(
             "SetDefaultState",
@@ -925,9 +932,10 @@ void DoScalarDependentDefinitions(py::module m, T) {
           auto pair = AddMultibodyPlantSceneGraph<T>(
               builder, std::move(plant), std::move(scene_graph));
           // Must do manual keep alive to dig into tuple.
-          py::object builder_py = py::cast(builder, py_reference);
-          py::object plant_py = py::cast(pair.plant, py_reference);
-          py::object scene_graph_py = py::cast(pair.scene_graph, py_reference);
+          py::object builder_py = py::cast(builder, py_rvp::reference);
+          py::object plant_py = py::cast(pair.plant, py_rvp::reference);
+          py::object scene_graph_py =
+              py::cast(pair.scene_graph, py_rvp::reference);
           return py::make_tuple(
               // Keep alive, ownership: `plant` keeps `builder` alive.
               py_keep_alive(plant_py, builder_py),
@@ -945,9 +953,10 @@ void DoScalarDependentDefinitions(py::module m, T) {
           auto pair = AddMultibodyPlantSceneGraph<T>(
               builder, time_step, std::move(scene_graph));
           // Must do manual keep alive to dig into tuple.
-          py::object builder_py = py::cast(builder, py_reference);
-          py::object plant_py = py::cast(pair.plant, py_reference);
-          py::object scene_graph_py = py::cast(pair.scene_graph, py_reference);
+          py::object builder_py = py::cast(builder, py_rvp::reference);
+          py::object plant_py = py::cast(pair.plant, py_rvp::reference);
+          py::object scene_graph_py =
+              py::cast(pair.scene_graph, py_rvp::reference);
           return py::make_tuple(
               // Keep alive, ownership: `plant` keeps `builder` alive.
               py_keep_alive(plant_py, builder_py),
@@ -994,11 +1003,13 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("num_propellers", &Class::num_propellers,
             doc.Propeller.num_propellers.doc)
         .def("get_command_input_port", &Class::get_command_input_port,
-            py_reference_internal, doc.Propeller.get_command_input_port.doc)
+            py_rvp::reference_internal,
+            doc.Propeller.get_command_input_port.doc)
         .def("get_body_poses_input_port", &Class::get_body_poses_input_port,
-            py_reference_internal, doc.Propeller.get_body_poses_input_port.doc)
+            py_rvp::reference_internal,
+            doc.Propeller.get_body_poses_input_port.doc)
         .def("get_spatial_forces_output_port",
-            &Class::get_spatial_forces_output_port, py_reference_internal,
+            &Class::get_spatial_forces_output_port, py_rvp::reference_internal,
             doc.Propeller.get_spatial_forces_output_port.doc);
   }
   // NOLINTNEXTLINE(readability/fn_size)
@@ -1034,10 +1045,11 @@ PYBIND11_MODULE(plant, m) {
             // Keep alive, reference: `self` keeps `plant` alive.
             py::keep_alive<1, 2>(), cls_doc.ctor.doc)
         .def("get_contact_result_input_port",
-            &Class::get_contact_result_input_port, py_reference_internal,
+            &Class::get_contact_result_input_port, py_rvp::reference_internal,
             cls_doc.get_contact_result_input_port.doc)
         .def("get_lcm_message_output_port", &Class::get_lcm_message_output_port,
-            py_reference_internal, cls_doc.get_lcm_message_output_port.doc);
+            py_rvp::reference_internal,
+            cls_doc.get_lcm_message_output_port.doc);
   }
 
   m.def(
@@ -1048,7 +1060,7 @@ PYBIND11_MODULE(plant, m) {
             builder, plant, lcm);
       },
       py::arg("builder"), py::arg("plant"), py::arg("lcm") = nullptr,
-      py_reference,
+      py_rvp::reference,
       // Keep alive, ownership: `return` keeps `builder` alive.
       py::keep_alive<0, 1>(),
       // Keep alive, transitive: `plant` keeps `builder` alive.

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -160,7 +160,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
     BindMultibodyElementMixin(&cls);
     cls  // BR
         .def("name", &Class::name, cls_doc.name.doc)
-        .def("body", &Class::body, py_reference_internal, cls_doc.body.doc)
+        .def("body", &Class::body, py_rvp::reference_internal, cls_doc.body.doc)
         .def("GetFixedPoseInBodyFrame", &Frame<T>::GetFixedPoseInBodyFrame,
             cls_doc.GetFixedPoseInBodyFrame.doc);
   }
@@ -204,7 +204,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
     BindMultibodyElementMixin(&cls);
     cls  // BR
         .def("name", &Class::name, cls_doc.name.doc)
-        .def("body_frame", &Class::body_frame, py_reference_internal,
+        .def("body_frame", &Class::body_frame, py_rvp::reference_internal,
             cls_doc.body_frame.doc)
         .def("is_floating", &Class::is_floating, cls_doc.is_floating.doc)
         .def("GetForceInWorld", &Class::GetForceInWorld, py::arg("context"),
@@ -223,12 +223,12 @@ void DoScalarDependentDefinitions(py::module m, T) {
         m, "RigidBody", param, cls_doc.doc);
     cls  // BR
         .def("default_mass", &Class::default_mass, cls_doc.default_mass.doc)
-        .def("default_com", &Class::default_com, py_reference_internal,
+        .def("default_com", &Class::default_com, py_rvp::reference_internal,
             cls_doc.default_com.doc)
         .def("default_unit_inertia", &Class::default_unit_inertia,
-            py_reference_internal, cls_doc.default_unit_inertia.doc)
+            py_rvp::reference_internal, cls_doc.default_unit_inertia.doc)
         .def("default_spatial_inertia", &Class::default_spatial_inertia,
-            py_reference_internal, cls_doc.default_spatial_inertia.doc);
+            py_rvp::reference_internal, cls_doc.default_spatial_inertia.doc);
   }
 
   // Joints.
@@ -240,14 +240,14 @@ void DoScalarDependentDefinitions(py::module m, T) {
     BindMultibodyElementMixin(&cls);
     cls  // BR
         .def("name", &Class::name, cls_doc.name.doc)
-        .def("parent_body", &Class::parent_body, py_reference_internal,
+        .def("parent_body", &Class::parent_body, py_rvp::reference_internal,
             cls_doc.parent_body.doc)
-        .def("child_body", &Class::child_body, py_reference_internal,
+        .def("child_body", &Class::child_body, py_rvp::reference_internal,
             cls_doc.child_body.doc)
-        .def("frame_on_parent", &Class::frame_on_parent, py_reference_internal,
-            cls_doc.frame_on_parent.doc)
-        .def("frame_on_child", &Class::frame_on_child, py_reference_internal,
-            cls_doc.frame_on_child.doc)
+        .def("frame_on_parent", &Class::frame_on_parent,
+            py_rvp::reference_internal, cls_doc.frame_on_parent.doc)
+        .def("frame_on_child", &Class::frame_on_child,
+            py_rvp::reference_internal, cls_doc.frame_on_child.doc)
         .def("position_start", &Class::position_start,
             cls_doc.position_start.doc)
         .def("velocity_start", &Class::velocity_start,
@@ -421,7 +421,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
     BindMultibodyElementMixin(&cls);
     cls  // BR
         .def("name", &Class::name, cls_doc.name.doc)
-        .def("joint", &Class::joint, py_reference_internal, cls_doc.joint.doc)
+        .def("joint", &Class::joint, py_rvp::reference_internal,
+            cls_doc.joint.doc)
         .def("effort_limit", &Class::effort_limit, cls_doc.effort_limit.doc);
   }
 
@@ -445,8 +446,10 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("bodyA"), py::arg("p_AP"), py::arg("bodyB"),
             py::arg("p_BQ"), py::arg("free_length"), py::arg("stiffness"),
             py::arg("damping"), cls_doc.ctor.doc)
-        .def("bodyA", &Class::bodyA, py_reference_internal, cls_doc.bodyA.doc)
-        .def("bodyB", &Class::bodyB, py_reference_internal, cls_doc.bodyB.doc)
+        .def("bodyA", &Class::bodyA, py_rvp::reference_internal,
+            cls_doc.bodyA.doc)
+        .def("bodyB", &Class::bodyB, py_rvp::reference_internal,
+            cls_doc.bodyB.doc)
         .def("p_AP", &Class::p_AP, cls_doc.p_AP.doc)
         .def("p_BQ", &Class::p_BQ, cls_doc.p_BQ.doc)
         .def("free_length", &Class::free_length, cls_doc.free_length.doc)
@@ -463,7 +466,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def(py::init<const RevoluteJoint<T>&, double, double>(),
             py::arg("joint"), py::arg("nominal_angle"), py::arg("stiffness"),
             cls_doc.ctor.doc)
-        .def("joint", &Class::joint, py_reference_internal, cls_doc.joint.doc)
+        .def("joint", &Class::joint, py_rvp::reference_internal,
+            cls_doc.joint.doc)
         .def("nominal_angle", &Class::nominal_angle, cls_doc.nominal_angle.doc)
         .def("stiffness", &Class::stiffness, cls_doc.stiffness.doc);
   }
@@ -489,9 +493,10 @@ void DoScalarDependentDefinitions(py::module m, T) {
         m, "DoorHinge", param, cls_doc.doc);
     cls.def(py::init<const RevoluteJoint<T>&, const DoorHingeConfig&>(),
            py::arg("joint"), py::arg("config"), cls_doc.ctor.doc)
-        .def("joint", &Class::joint, py_reference_internal, cls_doc.joint.doc)
-        .def(
-            "config", &Class::config, py_reference_internal, cls_doc.config.doc)
+        .def("joint", &Class::joint, py_rvp::reference_internal,
+            cls_doc.joint.doc)
+        .def("config", &Class::config, py_rvp::reference_internal,
+            cls_doc.config.doc)
         .def("CalcHingeFrictionalTorque", &Class::CalcHingeFrictionalTorque,
             py::arg("angular_rate"), cls_doc.CalcHingeFrictionalTorque.doc)
         .def("CalcHingeSpringTorque", &Class::CalcHingeSpringTorque,
@@ -520,7 +525,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("generalized_forces", &Class::generalized_forces,
             cls_doc.generalized_forces.doc)
         .def("mutable_generalized_forces", &Class::mutable_generalized_forces,
-            py_reference_internal, cls_doc.mutable_generalized_forces.doc)
+            py_rvp::reference_internal, cls_doc.mutable_generalized_forces.doc)
         // WARNING: Do not bind `body_forces` or `mutable_body_forces` because
         // they use `internal::BodyNodeIndex`. Instead, use force API in Body.
         .def("AddInForces", &Class::AddInForces, py::arg("addend"),

--- a/bindings/pydrake/perception_py.cc
+++ b/bindings/pydrake/perception_py.cc
@@ -85,29 +85,29 @@ void init_perception(py::module m) {
             py::arg("new_size"), cls_doc.resize.doc)
         // XYZs
         .def("has_xyzs", &Class::has_xyzs, cls_doc.has_xyzs.doc)
-        .def("xyzs", &Class::xyzs, py_reference_internal, cls_doc.xyzs.doc)
-        .def("mutable_xyzs", &Class::mutable_xyzs, py_reference_internal,
+        .def("xyzs", &Class::xyzs, py_rvp::reference_internal, cls_doc.xyzs.doc)
+        .def("mutable_xyzs", &Class::mutable_xyzs, py_rvp::reference_internal,
             cls_doc.mutable_xyzs.doc)
         .def("xyz", &Class::xyz, py::arg("i"), cls_doc.xyz.doc)
         .def("mutable_xyz", &Class::mutable_xyz, py::arg("i"),
-            py_reference_internal, cls_doc.mutable_xyz.doc)
+            py_rvp::reference_internal, cls_doc.mutable_xyz.doc)
         // Normals
         .def("has_normals", &Class::has_normals, cls_doc.has_normals.doc)
-        .def("normals", &Class::normals, py_reference_internal,
+        .def("normals", &Class::normals, py_rvp::reference_internal,
             cls_doc.normals.doc)
-        .def("mutable_normals", &Class::mutable_normals, py_reference_internal,
-            cls_doc.mutable_normals.doc)
+        .def("mutable_normals", &Class::mutable_normals,
+            py_rvp::reference_internal, cls_doc.mutable_normals.doc)
         .def("normal", &Class::normal, py::arg("i"), cls_doc.normal.doc)
         .def("mutable_normal", &Class::mutable_normal, py::arg("i"),
-            py_reference_internal, cls_doc.mutable_normal.doc)
+            py_rvp::reference_internal, cls_doc.mutable_normal.doc)
         // RGBs
         .def("has_rgbs", &Class::has_rgbs, cls_doc.has_rgbs.doc)
-        .def("rgbs", &Class::rgbs, py_reference_internal, cls_doc.rgbs.doc)
-        .def("mutable_rgbs", &Class::mutable_rgbs, py_reference_internal,
+        .def("rgbs", &Class::rgbs, py_rvp::reference_internal, cls_doc.rgbs.doc)
+        .def("mutable_rgbs", &Class::mutable_rgbs, py_rvp::reference_internal,
             cls_doc.mutable_rgbs.doc)
         .def("rgb", &Class::rgb, py::arg("i"), cls_doc.rgb.doc)
         .def("mutable_rgb", &Class::mutable_rgb, py::arg("i"),
-            py_reference_internal, cls_doc.mutable_rgb.doc)
+            py_rvp::reference_internal, cls_doc.mutable_rgb.doc)
         // Mutators.
         .def(
             "SetFrom",
@@ -131,11 +131,11 @@ void init_perception(py::module m) {
             py::arg("scale") = 1.0, py::arg("fields") = pc_flags::kXYZs,
             cls_doc.ctor.doc)
         .def("depth_image_input_port", &Class::depth_image_input_port,
-            py_reference_internal, cls_doc.depth_image_input_port.doc)
+            py_rvp::reference_internal, cls_doc.depth_image_input_port.doc)
         .def("color_image_input_port", &Class::color_image_input_port,
-            py_reference_internal, cls_doc.color_image_input_port.doc)
+            py_rvp::reference_internal, cls_doc.color_image_input_port.doc)
         .def("point_cloud_output_port", &Class::point_cloud_output_port,
-            py_reference_internal, cls_doc.point_cloud_output_port.doc);
+            py_rvp::reference_internal, cls_doc.point_cloud_output_port.doc);
   }
 }
 

--- a/bindings/pydrake/pydrake_doxygen.h
+++ b/bindings/pydrake/pydrake_doxygen.h
@@ -410,7 +410,7 @@ using Class = MultibodyPlant<T>;
         [](Class* self, std::unique_ptr<Joint<T>> joint) -> auto& {
           return self->AddJoint(std::move(joint));
         },
-        py::arg("joint"), py_reference_internal, cls_doc.AddJoint.doc_1args)
+        py::arg("joint"), py_rvp::reference_internal, cls_doc.AddJoint.doc_1args)
 ...
 ```
 
@@ -454,13 +454,12 @@ Some aliases are provided; prefer these to the full spellings.
 
 `namespace py` is a shorthand alias to `pybind11` for consistency.
 
-@see @ref drake::pydrake::py_reference "py_reference",
-@ref drake::pydrake::py_reference_internal "py_reference_internal" for dealing
-with %common ownership issues.
+@see @ref drake::pydrake::py_rvp "py_rvp" for dealing with %common ownership
+issues.
 
 @note Downstream users should avoid `using namespace drake::pydrake`, as
 this may create ambiguous aliases (especially for GCC). Instead, consider
-an alias.
+using your own alias directly to the `pybind11` namespace.
 
 @anchor PydrakeBazelDebug
 # Interactive Debugging with Bazel

--- a/bindings/pydrake/pydrake_pybind.h
+++ b/bindings/pydrake/pydrake_pybind.h
@@ -4,6 +4,8 @@
 
 #include "pybind11/pybind11.h"
 
+#include "drake/common/drake_deprecated.h"
+
 // N.B. Avoid including other headers, such as `pybind11/eigen.sh` or
 // `pybind11/functional.sh`, such that modules can opt-in to (and pay the cost
 // for) these binding capabilities.
@@ -12,17 +14,25 @@ namespace drake {
 namespace pydrake {
 
 // Note: Doxygen apparently doesn't process comments for namespace aliases. If
-// you put Doxygen comments here they will apply instead to py_reference. See
-// the "Convenience aliases" section above for documentation.
+// you put Doxygen comments here they will apply instead to py_rvp::reference.
+// See the "Convenience aliases" section above for documentation.
 namespace py = pybind11;
+
+/// Shortened alias for py::return_value_policy. For more information, see:
+/// https://pybind11.readthedocs.io/en/stable/advanced/functions.html#return-value-policies
+/// The most used (non-default) policies in pydrake are `reference` and
+/// `reference_internal`.
+using py_rvp = py::return_value_policy;
 
 /// Used when returning `T& or `const T&`, as pybind's default behavior is to
 /// copy lvalue references.
+DRAKE_DEPRECATED("2020-11-01", "Please use py_rvp::reference instead")
 const auto py_reference = py::return_value_policy::reference;
 
 /// Used when returning references to objects that are internally owned by
-/// `self`. Implies both `py_reference` and `py::keep_alive<0, 1>`, which
+/// `self`. Implies both `py_rvp::reference` and `py::keep_alive<0, 1>`, which
 /// implies "Keep alive, reference: `return` keeps` self` alive".
+DRAKE_DEPRECATED("2020-11-01", "Please use py_rvp::reference_internal instead")
 const auto py_reference_internal = py::return_value_policy::reference_internal;
 
 /// Use this when you must do manual casting - e.g. lists or tuples of nurses,
@@ -105,7 +115,7 @@ auto ParamInit() {
     // reference may evaporate by the time the true holding pybind11 record is
     // constructed. Would be alleviated using old-style pybind11 init :(
     Class obj{};
-    py::object py_obj = py::cast(&obj, py_reference);
+    py::object py_obj = py::cast(&obj, py_rvp::reference);
     py::module::import("pydrake").attr("_setattr_kwargs")(py_obj, kwargs);
     return obj;
   });

--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -409,11 +409,11 @@ top-level documentation for :py:mod:`pydrake.math`.
           "get_solver_details",
           [](const MathematicalProgramResult& self) {
             const auto& abstract = self.get_abstract_solver_details();
-            // TODO(#9398): Figure out why `py_reference` is necessary.
-            py::object value_ref = py::cast(&abstract, py_reference);
+            // TODO(#9398): Figure out why `py_rvp::reference` is necessary.
+            py::object value_ref = py::cast(&abstract, py_rvp::reference);
             return value_ref.attr("get_value")();
           },
-          py_reference_internal,
+          py_rvp::reference_internal,
           doc.MathematicalProgramResult.get_solver_details.doc)
       .def(
           "GetSolution",

--- a/bindings/pydrake/symbolic_py.cc
+++ b/bindings/pydrake/symbolic_py.cc
@@ -521,7 +521,7 @@ PYBIND11_MODULE(symbolic, m) {
                          const Monomial& monomial) { return self == monomial; })
       .def("GetVariables", &Monomial::GetVariables,
           doc.Monomial.GetVariables.doc)
-      .def("get_powers", &Monomial::get_powers, py_reference_internal,
+      .def("get_powers", &Monomial::get_powers, py_rvp::reference_internal,
           doc.Monomial.get_powers.doc)
       .def("ToExpression", &Monomial::ToExpression,
           doc.Monomial.ToExpression.doc)
@@ -531,7 +531,7 @@ PYBIND11_MODULE(symbolic, m) {
             return self.Evaluate(Environment{env});
           },
           doc.Monomial.Evaluate.doc)
-      .def("pow_in_place", &Monomial::pow_in_place, py_reference_internal,
+      .def("pow_in_place", &Monomial::pow_in_place, py_rvp::reference_internal,
           doc.Monomial.pow_in_place.doc)
       .def("__pow__",
           [](const Monomial& self, const int p) { return pow(self, p); });

--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -52,7 +52,7 @@ PYBIND11_MODULE(analysis, m) {
         .def("boundary_time", &Class::boundary_time, cls_doc.boundary_time.doc)
         .def("return_time", &Class::return_time, cls_doc.return_time.doc)
         .def("reason", &Class::reason, cls_doc.reason.doc)
-        .def("system", &Class::system, py_reference, cls_doc.system.doc)
+        .def("system", &Class::system, py_rvp::reference, cls_doc.system.doc)
         .def("message", &Class::message, cls_doc.message.doc)
         .def("IsIdenticalStatus", &Class::IsIdenticalStatus, py::arg("other"),
             cls_doc.IsIdenticalStatus.doc);
@@ -90,7 +90,7 @@ PYBIND11_MODULE(analysis, m) {
         .def("StartDenseIntegration", &IntegratorBase<T>::StartDenseIntegration,
             doc.IntegratorBase.StartDenseIntegration.doc)
         .def("get_dense_output", &IntegratorBase<T>::get_dense_output,
-            py_reference_internal, doc.IntegratorBase.get_dense_output.doc)
+            py_rvp::reference_internal, doc.IntegratorBase.get_dense_output.doc)
         .def("StopDenseIntegration", &IntegratorBase<T>::StopDenseIntegration,
             doc.IntegratorBase.StopDenseIntegration.doc);
 
@@ -142,14 +142,15 @@ PYBIND11_MODULE(analysis, m) {
             doc.Simulator.clear_monitor.doc)
         .def("get_monitor", &Simulator<T>::get_monitor,
             doc.Simulator.get_monitor.doc)
-        .def("get_context", &Simulator<T>::get_context, py_reference_internal,
-            doc.Simulator.get_context.doc)
+        .def("get_context", &Simulator<T>::get_context,
+            py_rvp::reference_internal, doc.Simulator.get_context.doc)
         .def("get_integrator", &Simulator<T>::get_integrator,
-            py_reference_internal, doc.Simulator.get_integrator.doc)
+            py_rvp::reference_internal, doc.Simulator.get_integrator.doc)
         .def("get_mutable_integrator", &Simulator<T>::get_mutable_integrator,
-            py_reference_internal, doc.Simulator.get_mutable_integrator.doc)
+            py_rvp::reference_internal,
+            doc.Simulator.get_mutable_integrator.doc)
         .def("get_mutable_context", &Simulator<T>::get_mutable_context,
-            py_reference_internal, doc.Simulator.get_mutable_context.doc)
+            py_rvp::reference_internal, doc.Simulator.get_mutable_context.doc)
         .def("has_context", &Simulator<T>::has_context,
             doc.Simulator.has_context.doc)
         .def("reset_context", &Simulator<T>::reset_context, py::arg("context"),
@@ -171,7 +172,7 @@ PYBIND11_MODULE(analysis, m) {
             doc.Simulator.get_actual_realtime_rate.doc)
         .def("ResetStatistics", &Simulator<T>::ResetStatistics,
             doc.Simulator.ResetStatistics.doc)
-        .def("get_system", &Simulator<T>::get_system, py_reference,
+        .def("get_system", &Simulator<T>::get_system, py_rvp::reference,
             doc.Simulator.get_system.doc);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -204,7 +205,7 @@ PYBIND11_MODULE(analysis, m) {
             return &result;
           },
           py::arg("simulator"), py::arg("scheme"), py::arg("max_step_size"),
-          py_reference,
+          py_rvp::reference,
           // Keep alive, reference: `return` keeps `simulator` alive.
           py::keep_alive<0, 1>(),
           pydrake_doc.drake.systems.ResetIntegratorFromFlags.doc)

--- a/bindings/pydrake/systems/controllers_py.cc
+++ b/bindings/pydrake/systems/controllers_py.cc
@@ -99,19 +99,19 @@ PYBIND11_MODULE(controllers, m) {
       .def("get_input_port_desired_acceleration",
           &InverseDynamicsController<
               double>::get_input_port_desired_acceleration,
-          py_reference_internal,
+          py_rvp::reference_internal,
           doc.InverseDynamicsController.get_input_port_desired_acceleration.doc)
       .def("get_input_port_estimated_state",
           &InverseDynamicsController<double>::get_input_port_estimated_state,
-          py_reference_internal,
+          py_rvp::reference_internal,
           doc.InverseDynamicsController.get_input_port_estimated_state.doc)
       .def("get_input_port_desired_state",
           &InverseDynamicsController<double>::get_input_port_desired_state,
-          py_reference_internal,
+          py_rvp::reference_internal,
           doc.InverseDynamicsController.get_input_port_desired_state.doc)
       .def("get_output_port_control",
           &InverseDynamicsController<double>::get_output_port_control,
-          py_reference_internal,
+          py_rvp::reference_internal,
           doc.InverseDynamicsController.get_output_port_control.doc);
 
   py::class_<PidControlledSystem<double>, Diagram<double>>(
@@ -147,15 +147,15 @@ PYBIND11_MODULE(controllers, m) {
           doc.PidControlledSystem.ctor.doc_6args_vector_gains)
       .def("get_control_input_port",
           &PidControlledSystem<double>::get_control_input_port,
-          py_reference_internal,
+          py_rvp::reference_internal,
           doc.PidControlledSystem.get_control_input_port.doc)
       .def("get_state_input_port",
           &PidControlledSystem<double>::get_state_input_port,
-          py_reference_internal,
+          py_rvp::reference_internal,
           doc.PidControlledSystem.get_state_input_port.doc)
       .def("get_state_output_port",
           &PidControlledSystem<double>::get_state_output_port,
-          py_reference_internal,
+          py_rvp::reference_internal,
           doc.PidControlledSystem.get_state_output_port.doc);
 
   // TODO(eric.cousineau): Expose multiple inheritance from
@@ -184,15 +184,16 @@ PYBIND11_MODULE(controllers, m) {
           doc.PidController.get_Kd_vector.doc)
       .def("get_input_port_estimated_state",
           &PidController<double>::get_input_port_estimated_state,
-          py_reference_internal,
+          py_rvp::reference_internal,
           doc.PidController.get_input_port_estimated_state.doc)
       .def("get_input_port_desired_state",
           &PidController<double>::get_input_port_desired_state,
-          py_reference_internal,
+          py_rvp::reference_internal,
           doc.PidController.get_input_port_desired_state.doc)
       .def("get_output_port_control",
           &PidController<double>::get_output_port_control,
-          py_reference_internal, doc.PidController.get_output_port_control.doc);
+          py_rvp::reference_internal,
+          doc.PidController.get_output_port_control.doc);
 
   m.def("FittedValueIteration", WrapCallbacks(&FittedValueIteration),
       doc.FittedValueIteration.doc);

--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -82,7 +82,8 @@ void DefineFrameworkPySemantics(py::module m) {
   py::class_<FixedInputPortValue>(
       m, "FixedInputPortValue", doc.FixedInputPortValue.doc)
       .def("GetMutableData", &FixedInputPortValue::GetMutableData,
-          py_reference_internal, doc.FixedInputPortValue.GetMutableData.doc);
+          py_rvp::reference_internal,
+          doc.FixedInputPortValue.GetMutableData.doc);
 
   using AbstractValuePtrList = vector<unique_ptr<AbstractValue>>;
   // N.B. `AbstractValues` provides the ability to reference non-owned values,
@@ -96,9 +97,9 @@ void DefineFrameworkPySemantics(py::module m) {
       .def(py::init<AbstractValuePtrList>(), doc.AbstractValues.ctor.doc_1args)
       .def("size", &AbstractValues::size, doc.AbstractValues.size.doc)
       .def("get_value", &AbstractValues::get_value, py::arg("index"),
-          py_reference_internal, doc.AbstractValues.get_value.doc)
+          py_rvp::reference_internal, doc.AbstractValues.get_value.doc)
       .def("get_mutable_value", &AbstractValues::get_mutable_value,
-          py::arg("index"), py_reference_internal,
+          py::arg("index"), py_rvp::reference_internal,
           doc.AbstractValues.get_mutable_value.doc)
       .def("SetFrom", &AbstractValues::SetFrom, doc.AbstractValues.SetFrom.doc);
 
@@ -162,7 +163,7 @@ void DefineFrameworkPySemantics(py::module m) {
         .def_static("Failed", &Class::Failed, py::arg("system"),
             py::arg("message"), cls_doc.Failed.doc)
         .def("severity", &Class::severity, cls_doc.severity.doc)
-        .def("system", &Class::system, py_reference, cls_doc.system.doc)
+        .def("system", &Class::system, py_rvp::reference, cls_doc.system.doc)
         .def("message", &Class::message, cls_doc.message.doc)
         .def("KeepMoreSevere", &Class::KeepMoreSevere, py::arg("candidate"),
             cls_doc.KeepMoreSevere.doc);
@@ -197,7 +198,7 @@ void DefineFrameworkPySemantics(py::module m) {
         // "Accessors for locally-stored values", placed in the same order
         // as the header file.
         .def("get_time", &Context<T>::get_time, doc.Context.get_time.doc)
-        .def("get_state", &Context<T>::get_state, py_reference_internal,
+        .def("get_state", &Context<T>::get_state, py_rvp::reference_internal,
             doc.Context.get_state.doc)
         .def("is_stateless", &Context<T>::is_stateless,
             doc.Context.is_stateless.doc)
@@ -211,9 +212,10 @@ void DefineFrameworkPySemantics(py::module m) {
         .def("num_continuous_states", &Context<T>::num_continuous_states,
             doc.Context.num_continuous_states.doc)
         .def("get_continuous_state", &Context<T>::get_continuous_state,
-            py_reference_internal, doc.Context.get_continuous_state.doc)
+            py_rvp::reference_internal, doc.Context.get_continuous_state.doc)
         .def("get_continuous_state_vector",
-            &Context<T>::get_continuous_state_vector, py_reference_internal,
+            &Context<T>::get_continuous_state_vector,
+            py_rvp::reference_internal,
             doc.Context.get_continuous_state_vector.doc)
         .def("num_discrete_state_groups",
             &Context<T>::num_discrete_state_groups,
@@ -221,41 +223,44 @@ void DefineFrameworkPySemantics(py::module m) {
         .def("get_discrete_state",
             overload_cast_explicit<const DiscreteValues<T>&>(
                 &Context<T>::get_discrete_state),
-            py_reference_internal, doc.Context.get_discrete_state.doc_0args)
+            py_rvp::reference_internal,
+            doc.Context.get_discrete_state.doc_0args)
         .def("get_discrete_state_vector",
-            &Context<T>::get_discrete_state_vector, py_reference_internal,
+            &Context<T>::get_discrete_state_vector, py_rvp::reference_internal,
             doc.Context.get_discrete_state_vector.doc)
         .def("get_discrete_state",
             overload_cast_explicit<const BasicVector<T>&, int>(
                 &Context<T>::get_discrete_state),
-            py_reference_internal, doc.Context.get_discrete_state.doc_1args)
+            py_rvp::reference_internal,
+            doc.Context.get_discrete_state.doc_1args)
         .def("num_abstract_states", &Context<T>::num_abstract_states,
             doc.Context.num_abstract_states.doc)
         .def("get_abstract_state",
             static_cast<const AbstractValues& (Context<T>::*)() const>(
                 &Context<T>::get_abstract_state),
-            py_reference_internal, doc.Context.get_abstract_state.doc_0args)
+            py_rvp::reference_internal,
+            doc.Context.get_abstract_state.doc_0args)
         .def(
             "get_abstract_state",
             [](const Context<T>* self, int index) -> auto& {
               return self->get_abstract_state().get_value(index);
             },
-            py::arg("index"), py_reference_internal,
+            py::arg("index"), py_rvp::reference_internal,
             doc.Context.get_abstract_state.doc_1args)
         .def("get_accuracy", &Context<T>::get_accuracy,
             doc.Context.get_accuracy.doc)
         .def("get_parameters", &Context<T>::get_parameters,
-            py_reference_internal, doc.Context.get_parameters.doc)
+            py_rvp::reference_internal, doc.Context.get_parameters.doc)
         .def("num_numeric_parameter_groups",
             &Context<T>::num_numeric_parameter_groups,
             doc.Context.num_numeric_parameter_groups.doc)
         .def("get_numeric_parameter", &Context<T>::get_numeric_parameter,
-            py::arg("index"), py_reference_internal,
+            py::arg("index"), py_rvp::reference_internal,
             doc.Context.get_numeric_parameter.doc)
         .def("num_abstract_parameters", &Context<T>::num_abstract_parameters,
             doc.Context.num_abstract_parameters.doc)
         .def("get_abstract_parameter", &Context<T>::get_abstract_parameter,
-            py::arg("index"), py_reference_internal,
+            py::arg("index"), py_rvp::reference_internal,
             doc.Context.get_numeric_parameter.doc)
         // Bindings for the Context methods in the Doxygen group titled
         // "Methods for changing locally-stored values", placed in the same
@@ -292,18 +297,18 @@ void DefineFrameworkPySemantics(py::module m) {
         .def("FixInputPort",
             py::overload_cast<int, const BasicVector<T>&>(
                 &Context<T>::FixInputPort),
-            py::arg("index"), py::arg("vec"), py_reference_internal,
+            py::arg("index"), py::arg("vec"), py_rvp::reference_internal,
             doc.Context.FixInputPort.doc_2args_index_vec)
         .def("FixInputPort",
             py::overload_cast<int, unique_ptr<AbstractValue>>(
                 &Context<T>::FixInputPort),
-            py::arg("index"), py::arg("value"), py_reference_internal,
+            py::arg("index"), py::arg("value"), py_rvp::reference_internal,
             // Keep alive, ownership: `AbstractValue` keeps `self` alive.
             py::keep_alive<3, 1>(), doc.ContextBase.FixInputPort.doc)
         .def("FixInputPort",
             py::overload_cast<int, const Eigen::Ref<const VectorX<T>>&>(
                 &Context<T>::FixInputPort),
-            py::arg("index"), py::arg("data"), py_reference_internal,
+            py::arg("index"), py::arg("data"), py_rvp::reference_internal,
             doc.Context.FixInputPort.doc_2args_index_data)
         .def("SetAccuracy", &Context<T>::SetAccuracy, py::arg("accuracy"),
             doc.Context.SetAccuracy.doc)
@@ -311,34 +316,35 @@ void DefineFrameworkPySemantics(py::module m) {
         // "Dangerous methods for changing locally-stored values", placed in the
         // same order as the header file.
         .def("get_mutable_state", &Context<T>::get_mutable_state,
-            py_reference_internal, doc.Context.get_mutable_state.doc)
+            py_rvp::reference_internal, doc.Context.get_mutable_state.doc)
         .def("get_mutable_continuous_state",
-            &Context<T>::get_mutable_continuous_state, py_reference_internal,
+            &Context<T>::get_mutable_continuous_state,
+            py_rvp::reference_internal,
             doc.Context.get_mutable_continuous_state.doc)
         .def("get_mutable_continuous_state_vector",
             &Context<T>::get_mutable_continuous_state_vector,
-            py_reference_internal,
+            py_rvp::reference_internal,
             doc.Context.get_mutable_continuous_state_vector.doc)
         .def("get_mutable_discrete_state",
             overload_cast_explicit<DiscreteValues<T>&>(
                 &Context<T>::get_mutable_discrete_state),
-            py_reference_internal,
+            py_rvp::reference_internal,
             doc.Context.get_mutable_discrete_state.doc_0args)
         .def("get_mutable_discrete_state_vector",
             &Context<T>::get_mutable_discrete_state_vector,
-            py_reference_internal,
+            py_rvp::reference_internal,
             doc.Context.get_mutable_discrete_state_vector.doc)
         .def("get_mutable_discrete_state",
             overload_cast_explicit<BasicVector<T>&, int>(
                 &Context<T>::get_mutable_discrete_state),
-            py_reference_internal,
+            py_rvp::reference_internal,
             doc.Context.get_mutable_discrete_state.doc_1args)
         .def(
             "get_mutable_abstract_state",
             [](Context<T>* self) -> AbstractValues& {
               return self->get_mutable_abstract_state();
             },
-            py_reference_internal,
+            py_rvp::reference_internal,
             doc.Context.get_mutable_abstract_state.doc_0args)
         .def(
             "get_mutable_abstract_state",
@@ -346,17 +352,17 @@ void DefineFrameworkPySemantics(py::module m) {
               return self->get_mutable_abstract_state().get_mutable_value(
                   index);
             },
-            py::arg("index"), py_reference_internal,
+            py::arg("index"), py_rvp::reference_internal,
             doc.Context.get_mutable_abstract_state.doc_1args)
         .def("get_mutable_parameters", &Context<T>::get_mutable_parameters,
-            py_reference_internal, doc.Context.get_mutable_parameters.doc)
+            py_rvp::reference_internal, doc.Context.get_mutable_parameters.doc)
         .def("get_mutable_numeric_parameter",
             &Context<T>::get_mutable_numeric_parameter, py::arg("index"),
-            py_reference_internal,
+            py_rvp::reference_internal,
             doc.Context.get_mutable_numeric_parameter.doc)
         .def("get_mutable_abstract_parameter",
             &Context<T>::get_mutable_abstract_parameter, py::arg("index"),
-            py_reference_internal,
+            py_rvp::reference_internal,
             doc.Context.get_mutable_abstract_parameter.doc)
         // Note: No bindings yet for "Advanced methods for changing
         //   locally-stored values"
@@ -438,9 +444,9 @@ void DefineFrameworkPySemantics(py::module m) {
             "GetMutableSystems",
             [](DiagramBuilder<T>* self) {
               py::list out;
-              py::object self_py = py::cast(self, py_reference);
+              py::object self_py = py::cast(self, py_rvp::reference);
               for (auto* system : self->GetMutableSystems()) {
-                py::object system_py = py::cast(system, py_reference);
+                py::object system_py = py::cast(system, py_rvp::reference);
                 // Keep alive, ownership: `system` keeps `self` alive.
                 py_keep_alive(system_py, self_py);
                 out.append(system_py);
@@ -453,11 +459,11 @@ void DefineFrameworkPySemantics(py::module m) {
                 &DiagramBuilder<T>::Connect),
             doc.DiagramBuilder.Connect.doc)
         .def("ExportInput", &DiagramBuilder<T>::ExportInput, py::arg("input"),
-            py::arg("name") = kUseDefaultName, py_reference_internal,
+            py::arg("name") = kUseDefaultName, py_rvp::reference_internal,
             doc.DiagramBuilder.ExportInput.doc)
         .def("ExportOutput", &DiagramBuilder<T>::ExportOutput,
             py::arg("output"), py::arg("name") = kUseDefaultName,
-            py_reference_internal, doc.DiagramBuilder.ExportOutput.doc)
+            py_rvp::reference_internal, doc.DiagramBuilder.ExportOutput.doc)
         .def("Build", &DiagramBuilder<T>::Build,
             // Keep alive, ownership (tr.): `return` keeps `self` alive.
             py::keep_alive<1, 0>(), doc.DiagramBuilder.Build.doc)
@@ -489,7 +495,7 @@ void DefineFrameworkPySemantics(py::module m) {
             "as an AbstractValue. Most users should call Eval() instead. "
             "This method is only needed when the result will be passed "
             "into some other API that only accepts an AbstractValue.",
-            py_reference_internal)
+            py_rvp::reference_internal)
         .def(
             "EvalBasicVector",
             [](const OutputPort<T>* self, const Context<T>& c) {
@@ -501,9 +507,9 @@ void DefineFrameworkPySemantics(py::module m) {
             "as a BasicVector. Most users should call Eval() instead. "
             "This method is only needed when the result will be passed "
             "into some other API that only accepts a BasicVector.",
-            py_reference_internal)
+            py_rvp::reference_internal)
         .def("Allocate", &OutputPort<T>::Allocate, doc.OutputPort.Allocate.doc)
-        .def("get_system", &OutputPort<T>::get_system, py_reference,
+        .def("get_system", &OutputPort<T>::get_system, py_rvp::reference,
             doc.OutputPort.get_system.doc);
 
     auto system_output = DefineTemplateClassWithDefault<SystemOutput<T>>(
@@ -511,10 +517,10 @@ void DefineFrameworkPySemantics(py::module m) {
     system_output
         .def("num_ports", &SystemOutput<T>::num_ports,
             doc.SystemOutput.num_ports.doc)
-        .def("get_data", &SystemOutput<T>::get_data, py_reference_internal,
+        .def("get_data", &SystemOutput<T>::get_data, py_rvp::reference_internal,
             doc.SystemOutput.get_data.doc)
         .def("get_vector_data", &SystemOutput<T>::get_vector_data,
-            py_reference_internal, doc.SystemOutput.get_vector_data.doc);
+            py_rvp::reference_internal, doc.SystemOutput.get_vector_data.doc);
 
     DefineTemplateClassWithDefault<InputPort<T>>(
         m, "InputPort", GetPyParam<T>(), doc.InputPort.doc)
@@ -540,7 +546,7 @@ void DefineFrameworkPySemantics(py::module m) {
             "as an AbstractValue. Most users should call Eval() instead. "
             "This method is only needed when the result will be passed "
             "into some other API that only accepts an AbstractValue.",
-            py_reference_internal)
+            py_rvp::reference_internal)
         .def(
             "EvalBasicVector",
             [](const InputPort<T>* self, const Context<T>& c) {
@@ -552,7 +558,7 @@ void DefineFrameworkPySemantics(py::module m) {
             "as a BasicVector. Most users should call Eval() instead. "
             "This method is only needed when the result will be passed "
             "into some other API that only accepts a BasicVector.",
-            py_reference_internal)
+            py_rvp::reference_internal)
         // For FixValue, treat an already-erased AbstractValue specially ...
         .def(
             "FixValue",
@@ -561,7 +567,7 @@ void DefineFrameworkPySemantics(py::module m) {
               FixedInputPortValue& result = self->FixValue(context, value);
               return &result;
             },
-            py::arg("context"), py::arg("value"), py_reference,
+            py::arg("context"), py::arg("value"), py_rvp::reference,
             // Keep alive, ownership: `return` keeps `context` alive.
             py::keep_alive<0, 2>(), doc.InputPort.FixValue.doc)
         // ... but then for anything not yet erased, use set_value to copy.
@@ -573,14 +579,15 @@ void DefineFrameworkPySemantics(py::module m) {
               // Allocate is a bit wasteful, but FixValue is already expensive.
               std::unique_ptr<AbstractValue> storage =
                   system.AllocateInputAbstract(*self);
-              py::cast(storage.get(), py_reference).attr("set_value")(value);
+              py::cast(storage.get(), py_rvp::reference)
+                  .attr("set_value")(value);
               FixedInputPortValue& result = self->FixValue(context, *storage);
               return &result;
             },
-            py::arg("context"), py::arg("value"), py_reference,
+            py::arg("context"), py::arg("value"), py_rvp::reference,
             // Keep alive, ownership: `return` keeps `context` alive.
             py::keep_alive<0, 2>(), doc.InputPort.FixValue.doc)
-        .def("get_system", &InputPort<T>::get_system, py_reference,
+        .def("get_system", &InputPort<T>::get_system, py_rvp::reference,
             doc.InputPort.get_system.doc);
 
     // TODO(russt): Bind relevant WitnessFunction methods.  This is the
@@ -616,14 +623,15 @@ void DefineFrameworkPySemantics(py::module m) {
         .def("num_abstract_parameters", &Parameters<T>::num_abstract_parameters,
             doc.Parameters.num_abstract_parameters.doc)
         .def("get_numeric_parameter", &Parameters<T>::get_numeric_parameter,
-            py_reference_internal, py::arg("index"),
+            py_rvp::reference_internal, py::arg("index"),
             doc.Parameters.get_numeric_parameter.doc)
         .def("get_mutable_numeric_parameter",
             &Parameters<T>::get_mutable_numeric_parameter,
-            py_reference_internal, py::arg("index"),
+            py_rvp::reference_internal, py::arg("index"),
             doc.Parameters.get_mutable_numeric_parameter.doc)
         .def("get_numeric_parameters", &Parameters<T>::get_numeric_parameters,
-            py_reference_internal, doc.Parameters.get_numeric_parameters.doc)
+            py_rvp::reference_internal,
+            doc.Parameters.get_numeric_parameters.doc)
         // TODO(eric.cousineau): Should this C++ code constrain the number of
         // parameters???
         .def("set_numeric_parameters", &Parameters<T>::set_numeric_parameters,
@@ -637,17 +645,18 @@ void DefineFrameworkPySemantics(py::module m) {
             [](const Parameters<T>* self, int index) -> auto& {
               return self->get_abstract_parameter(index);
             },
-            py_reference_internal, py::arg("index"),
+            py_rvp::reference_internal, py::arg("index"),
             doc.Parameters.get_abstract_parameter.doc_1args_index)
         .def(
             "get_mutable_abstract_parameter",
             [](Parameters<T>* self, int index) -> AbstractValue& {
               return self->get_mutable_abstract_parameter(index);
             },
-            py_reference_internal, py::arg("index"),
+            py_rvp::reference_internal, py::arg("index"),
             doc.Parameters.get_mutable_abstract_parameter.doc_1args_index)
         .def("get_abstract_parameters", &Parameters<T>::get_abstract_parameters,
-            py_reference_internal, doc.Parameters.get_abstract_parameters.doc)
+            py_rvp::reference_internal,
+            doc.Parameters.get_abstract_parameters.doc)
         .def("set_abstract_parameters", &Parameters<T>::set_abstract_parameters,
             // WARNING: This will DELETE the existing parameters. See C++
             // `AddValueInstantiation` for more information.
@@ -666,28 +675,30 @@ void DefineFrameworkPySemantics(py::module m) {
         m, "State", GetPyParam<T>(), doc.State.doc)
         .def(py::init<>(), doc.State.ctor.doc)
         .def("get_continuous_state", &State<T>::get_continuous_state,
-            py_reference_internal, doc.State.get_continuous_state.doc)
+            py_rvp::reference_internal, doc.State.get_continuous_state.doc)
         .def("get_mutable_continuous_state",
-            &State<T>::get_mutable_continuous_state, py_reference_internal,
+            &State<T>::get_mutable_continuous_state, py_rvp::reference_internal,
             doc.State.get_mutable_continuous_state.doc)
         .def("get_discrete_state",
             overload_cast_explicit<const DiscreteValues<T>&>(
                 &State<T>::get_discrete_state),
-            py_reference_internal, doc.State.get_discrete_state.doc)
+            py_rvp::reference_internal, doc.State.get_discrete_state.doc)
         .def("get_mutable_discrete_state",
             overload_cast_explicit<DiscreteValues<T>&>(
                 &State<T>::get_mutable_discrete_state),
-            py_reference_internal, doc.State.get_mutable_discrete_state.doc)
+            py_rvp::reference_internal,
+            doc.State.get_mutable_discrete_state.doc)
         .def("get_abstract_state",
             static_cast<const AbstractValues& (State<T>::*)() const>(
                 &State<T>::get_abstract_state),
-            py_reference_internal, doc.State.get_abstract_state.doc)
+            py_rvp::reference_internal, doc.State.get_abstract_state.doc)
         .def(
             "get_mutable_abstract_state",
             [](State<T>* self) -> AbstractValues& {
               return self->get_mutable_abstract_state();
             },
-            py_reference_internal, doc.State.get_mutable_abstract_state.doc);
+            py_rvp::reference_internal,
+            doc.State.get_mutable_abstract_state.doc);
 
     // - Constituents.
     DefineTemplateClassWithDefault<ContinuousState<T>>(
@@ -695,9 +706,10 @@ void DefineFrameworkPySemantics(py::module m) {
         .def(py::init<>(), doc.ContinuousState.ctor.doc_0args)
         .def("size", &ContinuousState<T>::size, doc.ContinuousState.size.doc)
         .def("get_vector", &ContinuousState<T>::get_vector,
-            py_reference_internal, doc.ContinuousState.get_vector.doc)
+            py_rvp::reference_internal, doc.ContinuousState.get_vector.doc)
         .def("get_mutable_vector", &ContinuousState<T>::get_mutable_vector,
-            py_reference_internal, doc.ContinuousState.get_mutable_vector.doc)
+            py_rvp::reference_internal,
+            doc.ContinuousState.get_mutable_vector.doc)
         .def("CopyToVector", &ContinuousState<T>::CopyToVector,
             doc.ContinuousState.CopyToVector.doc);
 
@@ -708,17 +720,17 @@ void DefineFrameworkPySemantics(py::module m) {
         .def("num_groups", &DiscreteValues<T>::num_groups,
             doc.DiscreteValues.num_groups.doc)
         .def("size", &DiscreteValues<T>::size, doc.DiscreteValues.size.doc)
-        .def("get_data", &DiscreteValues<T>::get_data, py_reference_internal,
-            doc.DiscreteValues.get_data.doc)
+        .def("get_data", &DiscreteValues<T>::get_data,
+            py_rvp::reference_internal, doc.DiscreteValues.get_data.doc)
         .def("get_vector",
             overload_cast_explicit<const BasicVector<T>&, int>(
                 &DiscreteValues<T>::get_vector),
-            py_reference_internal, py::arg("index") = 0,
+            py_rvp::reference_internal, py::arg("index") = 0,
             doc.DiscreteValues.get_vector.doc_1args)
         .def("get_mutable_vector",
             overload_cast_explicit<BasicVector<T>&, int>(
                 &DiscreteValues<T>::get_mutable_vector),
-            py_reference_internal, py::arg("index") = 0,
+            py_rvp::reference_internal, py::arg("index") = 0,
             doc.DiscreteValues.get_mutable_vector.doc_1args);
   };
   type_visit(bind_common_scalar_types, CommonScalarPack{});

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -275,27 +275,29 @@ struct Impl {
             m, "System", GetPyParam<T>(), doc.System.doc);
     system_cls  // BR
         .def("get_input_port", &System<T>::get_input_port,
-            py_reference_internal, py::arg("port_index"),
+            py_rvp::reference_internal, py::arg("port_index"),
             doc.System.get_input_port.doc)
-        .def("GetInputPort", &System<T>::GetInputPort, py_reference_internal,
-            py::arg("port_name"), doc.System.GetInputPort.doc)
+        .def("GetInputPort", &System<T>::GetInputPort,
+            py_rvp::reference_internal, py::arg("port_name"),
+            doc.System.GetInputPort.doc)
         .def("get_output_port", &System<T>::get_output_port,
-            py_reference_internal, py::arg("port_index"),
+            py_rvp::reference_internal, py::arg("port_index"),
             doc.System.get_output_port.doc)
-        .def("GetOutputPort", &System<T>::GetOutputPort, py_reference_internal,
-            py::arg("port_name"), doc.System.GetOutputPort.doc)
+        .def("GetOutputPort", &System<T>::GetOutputPort,
+            py_rvp::reference_internal, py::arg("port_name"),
+            doc.System.GetOutputPort.doc)
         .def("DeclareInputPort",
             overload_cast_explicit<InputPort<T>&,
                 std::variant<std::string, UseDefaultName>, PortDataType, int,
                 std::optional<RandomDistribution>>(&PySystem::DeclareInputPort),
-            py_reference_internal, py::arg("name"), py::arg("type"),
+            py_rvp::reference_internal, py::arg("name"), py::arg("type"),
             py::arg("size"), py::arg("random_type") = std::nullopt,
             doc.System.DeclareInputPort.doc_4args)
         .def("DeclareInputPort",
             overload_cast_explicit<  // BR
                 InputPort<T>&, PortDataType, int,
                 std::optional<RandomDistribution>>(&PySystem::DeclareInputPort),
-            py_reference_internal, py::arg("type"), py::arg("size"),
+            py_rvp::reference_internal, py::arg("type"), py::arg("size"),
             py::arg("random_type") = std::nullopt)
         // - Feedthrough.
         .def("HasAnyDirectFeedthrough", &System<T>::HasAnyDirectFeedthrough,
@@ -336,7 +338,7 @@ struct Impl {
             [](const System<T>* self, const Context<T>& arg1, int arg2) {
               return self->EvalVectorInput(arg1, arg2);
             },
-            py_reference,
+            py_rvp::reference,
             // Keep alive, ownership: `return` keeps `Context` alive.
             py::keep_alive<0, 2>(), doc.System.EvalVectorInput.doc)
         .def(
@@ -344,7 +346,7 @@ struct Impl {
             [](const System<T>* self, const Context<T>& arg1, int arg2) {
               return self->EvalAbstractInput(arg1, arg2);
             },
-            py_reference,
+            py_rvp::reference,
             // Keep alive, ownership: `return` keeps `Context` alive.
             py::keep_alive<0, 2>(), doc.SystemBase.EvalAbstractInput.doc)
         // Computation.
@@ -369,25 +371,25 @@ struct Impl {
         .def("GetSubsystemContext",
             overload_cast_explicit<const Context<T>&, const System<T>&,
                 const Context<T>&>(&System<T>::GetSubsystemContext),
-            py_reference,
+            py_rvp::reference,
             // Keep alive, ownership: `return` keeps `Context` alive.
             py::keep_alive<0, 3>(), doc.System.GetMutableSubsystemContext.doc)
         .def("GetMutableSubsystemContext",
             overload_cast_explicit<Context<T>&, const System<T>&, Context<T>*>(
                 &System<T>::GetMutableSubsystemContext),
-            py_reference,
+            py_rvp::reference,
             // Keep alive, ownership: `return` keeps `Context` alive.
             py::keep_alive<0, 3>(), doc.System.GetMutableSubsystemContext.doc)
         .def("GetMyContextFromRoot",
             overload_cast_explicit<const Context<T>&, const Context<T>&>(
                 &System<T>::GetMyContextFromRoot),
-            py_reference,
+            py_rvp::reference,
             // Keep alive, ownership: `return` keeps `Context` alive.
             py::keep_alive<0, 2>(), doc.System.GetMyMutableContextFromRoot.doc)
         .def("GetMyMutableContextFromRoot",
             overload_cast_explicit<Context<T>&, Context<T>*>(
                 &System<T>::GetMyMutableContextFromRoot),
-            py_reference,
+            py_rvp::reference,
             // Keep alive, ownership: `return` keeps `Context` alive.
             py::keep_alive<0, 2>(), doc.System.GetMyMutableContextFromRoot.doc)
         // Sugar.
@@ -422,7 +424,7 @@ Note: The above is for the C++ documentation. For Python, use
                 .c_str())
         // Cached evaluations.
         .def("EvalTimeDerivatives", &System<T>::EvalTimeDerivatives,
-            py_reference_internal, doc.System.EvalTimeDerivatives.doc)
+            py_rvp::reference_internal, doc.System.EvalTimeDerivatives.doc)
         .def("EvalPotentialEnergy", &System<T>::EvalPotentialEnergy,
             py::arg("context"), doc.System.EvalPotentialEnergy.doc)
         .def("EvalKineticEnergy", &System<T>::EvalKineticEnergy,
@@ -479,7 +481,7 @@ Note: The above is for the C++ documentation. For Python, use
                 const AbstractValue& model_value) -> const InputPort<T>& {
               return self->DeclareAbstractInputPort(name, model_value);
             },
-            py_reference_internal, py::arg("name"), py::arg("model_value"),
+            py_rvp::reference_internal, py::arg("name"), py::arg("model_value"),
             doc.LeafSystem.DeclareAbstractInputPort.doc_2args)
         .def("DeclareAbstractParameter",
             &PyLeafSystem::DeclareAbstractParameter, py::arg("model_value"),
@@ -493,7 +495,7 @@ Note: The above is for the C++ documentation. For Python, use
                               -> const OutputPort<T>& {
               return self->DeclareAbstractOutputPort(name, arg1, arg2, arg3);
             }),
-            py_reference_internal, py::arg("name"), py::arg("alloc"),
+            py_rvp::reference_internal, py::arg("name"), py::arg("alloc"),
             py::arg("calc"),
             py::arg("prerequisites_of_calc") =
                 std::set<DependencyTicket>{SystemBase::all_sources_ticket()},
@@ -504,7 +506,7 @@ Note: The above is for the C++ documentation. For Python, use
                               CalcCallback arg2) -> const OutputPort<T>& {
               return self->DeclareAbstractOutputPort(arg1, arg2);
             }),
-            py_reference_internal, py::arg("alloc"), py::arg("calc"),
+            py_rvp::reference_internal, py::arg("alloc"), py::arg("calc"),
             doc.LeafSystem.DeclareAbstractOutputPort
                 .doc_4args_name_alloc_function_calc_function_prerequisites_of_calc)
         .def(
@@ -516,8 +518,8 @@ Note: The above is for the C++ documentation. For Python, use
               return self->DeclareVectorInputPort(
                   name, model_vector, random_type);
             },
-            py_reference_internal, py::arg("name"), py::arg("model_vector"),
-            py::arg("random_type") = std::nullopt,
+            py_rvp::reference_internal, py::arg("name"),
+            py::arg("model_vector"), py::arg("random_type") = std::nullopt,
             doc.LeafSystem.DeclareVectorInputPort.doc_3args)
         .def("DeclareVectorOutputPort",
             WrapCallbacks(
@@ -527,7 +529,7 @@ Note: The above is for the C++ documentation. For Python, use
                     -> const OutputPort<T>& {
                   return self->DeclareVectorOutputPort(name, arg1, arg2, arg3);
                 }),
-            py_reference_internal, py::arg("name"), py::arg("model_value"),
+            py_rvp::reference_internal, py::arg("name"), py::arg("model_value"),
             py::arg("calc"),
             py::arg("prerequisites_of_calc") =
                 std::set<DependencyTicket>{SystemBase::all_sources_ticket()},
@@ -538,7 +540,7 @@ Note: The above is for the C++ documentation. For Python, use
                               CalcVectorCallback arg2) -> const OutputPort<T>& {
               return self->DeclareVectorOutputPort(arg1, arg2);
             }),
-            py_reference_internal,
+            py_rvp::reference_internal,
             doc.LeafSystem.DeclareVectorOutputPort
                 .doc_4args_name_model_vector_vector_calc_function_prerequisites_of_calc)
         .def(
@@ -577,7 +579,7 @@ Note: The above is for the C++ documentation. For Python, use
               return self->MakeWitnessFunction(
                   description, direction_type, calc);
             }),
-            py_reference_internal, py::arg("description"),
+            py_rvp::reference_internal, py::arg("description"),
             py::arg("direction_type"), py::arg("calc"),
             doc.LeafSystem.MakeWitnessFunction.doc_3args)
         .def("MakeWitnessFunction",
@@ -589,7 +591,7 @@ Note: The above is for the C++ documentation. For Python, use
                   return self->MakeWitnessFunction(
                       description, direction_type, calc, e);
                 }),
-            py_reference_internal, py::arg("description"),
+            py_rvp::reference_internal, py::arg("description"),
             py::arg("direction_type"), py::arg("calc"), py::arg("e"),
             doc.LeafSystem.MakeWitnessFunction.doc_4args)
         .def("DoPublish", &LeafSystemPublic::DoPublish,
@@ -648,20 +650,20 @@ Note: The above is for the C++ documentation. For Python, use
         .def("GetMutableSubsystemState",
             overload_cast_explicit<State<T>&, const System<T>&, Context<T>*>(
                 &Diagram<T>::GetMutableSubsystemState),
-            py_reference,
+            py_rvp::reference,
             // Keep alive, ownership: `return` keeps `Context` alive.
             py::keep_alive<0, 3>(),
             doc.Diagram.GetMutableSubsystemState.doc_2args_subsystem_context)
         .def("GetSubsystemByName", &Diagram<T>::GetSubsystemByName,
-            py::arg("name"), py_reference_internal,
+            py::arg("name"), py_rvp::reference_internal,
             doc.Diagram.GetSubsystemByName.doc)
         .def(
             "GetSystems",
             [](Diagram<T>* self) {
               py::list out;
-              py::object self_py = py::cast(self, py_reference);
+              py::object self_py = py::cast(self, py_rvp::reference);
               for (auto* system : self->GetSystems()) {
-                py::object system_py = py::cast(system, py_reference);
+                py::object system_py = py::cast(system, py_rvp::reference);
                 // Keep alive, ownership: `system` keeps `self` alive.
                 py_keep_alive(system_py, self_py);
                 out.append(system_py);

--- a/bindings/pydrake/systems/framework_py_values.cc
+++ b/bindings/pydrake/systems/framework_py_values.cc
@@ -38,7 +38,7 @@ void DefineFrameworkPyValues(py::module m) {
             })
         .def("__repr__",
             [](const VectorBase<T>& self) {
-              py::handle cls = py::cast(&self, py_reference).get_type();
+              py::handle cls = py::cast(&self, py_rvp::reference).get_type();
               return py::str("{}({})").format(cls.attr("__name__"),
                   py::cast(self.CopyToVector()).attr("tolist")());
             })
@@ -69,7 +69,7 @@ void DefineFrameworkPyValues(py::module m) {
             [](const BasicVector<T>* self) -> Eigen::Ref<const VectorX<T>> {
               return self->get_value();
             },
-            py_reference_internal, doc.BasicVector.get_value.doc)
+            py_rvp::reference_internal, doc.BasicVector.get_value.doc)
         // TODO(eric.cousineau): Remove this once `get_value` is changed, or
         // reference semantics are changed for custom dtypes.
         .def("_get_value_copy",
@@ -81,13 +81,13 @@ void DefineFrameworkPyValues(py::module m) {
             [](BasicVector<T>* self) -> Eigen::Ref<VectorX<T>> {
               return self->get_mutable_value();
             },
-            py_reference_internal, doc.BasicVector.get_mutable_value.doc)
+            py_rvp::reference_internal, doc.BasicVector.get_mutable_value.doc)
         .def(
             "GetAtIndex",
             [](BasicVector<T>* self, int index) -> T& {
               return self->GetAtIndex(index);
             },
-            py_reference_internal, doc.VectorBase.GetAtIndex.doc)
+            py_rvp::reference_internal, doc.VectorBase.GetAtIndex.doc)
         .def("SetZero", &BasicVector<T>::SetZero, doc.BasicVector.SetZero.doc);
 
     DefineTemplateClassWithDefault<Supervector<T>, VectorBase<T>>(

--- a/bindings/pydrake/systems/lcm_py.cc
+++ b/bindings/pydrake/systems/lcm_py.cc
@@ -171,8 +171,8 @@ PYBIND11_MODULE(lcm, m) {
 
   m.def("ConnectLcmScope", &ConnectLcmScope, py::arg("src"), py::arg("channel"),
       py::arg("builder"), py::arg("lcm") = nullptr, py::keep_alive<0, 2>(),
-      // See #11531 for why `py_reference` is needed.
-      py_reference, doc.ConnectLcmScope.doc);
+      // See #11531 for why `py_rvp::reference` is needed.
+      py_rvp::reference, doc.ConnectLcmScope.doc);
 
   // Bind C++ serializers.
   BindCppSerializers();

--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -87,10 +87,10 @@ PYBIND11_MODULE(primitives, m) {
         // TODO(russt): Move to TimeVaryingAffineSystem if/when that class is
         // wrapped.
         .def("get_input_port", &TimeVaryingAffineSystem<T>::get_input_port,
-            py_reference_internal,
+            py_rvp::reference_internal,
             doc.TimeVaryingAffineSystem.get_input_port.doc)
         .def("get_output_port", &TimeVaryingAffineSystem<T>::get_output_port,
-            py_reference_internal,
+            py_rvp::reference_internal,
             doc.TimeVaryingAffineSystem.get_output_port.doc)
         .def("time_period", &AffineSystem<T>::time_period,
             doc.TimeVaryingAffineSystem.time_period.doc)
@@ -104,10 +104,10 @@ PYBIND11_MODULE(primitives, m) {
         // Need to specifically redeclare the System to have both overloads
         // available.
         .def("get_input_port", &System<T>::get_input_port,
-            py_reference_internal, py::arg("port_index"),
+            py_rvp::reference_internal, py::arg("port_index"),
             pydrake_doc.drake.systems.System.get_input_port.doc)
         .def("get_output_port", &System<T>::get_output_port,
-            py_reference_internal, py::arg("port_index"),
+            py_rvp::reference_internal, py::arg("port_index"),
             pydrake_doc.drake.systems.System.get_output_port.doc);
 
     DefineTemplateClassWithDefault<ConstantValueSource<T>, LeafSystem<T>>(
@@ -120,11 +120,11 @@ PYBIND11_MODULE(primitives, m) {
         .def(py::init<VectorX<T>>(), py::arg("source_value"),
             doc.ConstantVectorSource.ctor.doc)
         .def("get_source_value", &ConstantVectorSource<T>::get_source_value,
-            py::arg("context"), py_reference_internal,
+            py::arg("context"), py_rvp::reference_internal,
             doc.ConstantVectorSource.get_source_value.doc)
         .def("get_mutable_source_value",
             &ConstantVectorSource<T>::get_mutable_source_value,
-            py::arg("context"), py_reference_internal,
+            py::arg("context"), py_rvp::reference_internal,
             doc.ConstantVectorSource.get_mutable_source_value.doc);
 
     DefineTemplateClassWithDefault<Demultiplexer<T>, LeafSystem<T>>(
@@ -246,8 +246,8 @@ PYBIND11_MODULE(primitives, m) {
             &SignalLogger<T>::set_forced_publish_only,
             doc.SignalLogger.set_forced_publish_only.doc)
         .def("sample_times", &SignalLogger<T>::sample_times,
-            py_reference_internal, doc.SignalLogger.sample_times.doc)
-        .def("data", &SignalLogger<T>::data, py_reference_internal,
+            py_rvp::reference_internal, doc.SignalLogger.sample_times.doc)
+        .def("data", &SignalLogger<T>::data, py_rvp::reference_internal,
             doc.SignalLogger.data.doc)
         .def("reset", &SignalLogger<T>::reset, doc.SignalLogger.reset.doc);
 
@@ -383,8 +383,8 @@ PYBIND11_MODULE(primitives, m) {
   m.def("LogOutput", &LogOutput<double>, py::arg("src"), py::arg("builder"),
       // Keep alive, ownership: `return` keeps `builder` alive.
       py::keep_alive<0, 2>(),
-      // See #11531 for why `py_reference` is needed.
-      py_reference, doc.LogOutput.doc);
+      // See #11531 for why `py_rvp::reference` is needed.
+      py_rvp::reference, doc.LogOutput.doc);
 
   // TODO(eric.cousineau): Add more systems as needed.
 }

--- a/bindings/pydrake/systems/rendering_py.cc
+++ b/bindings/pydrake/systems/rendering_py.cc
@@ -128,12 +128,12 @@ PYBIND11_MODULE(rendering, m) {
       m, "PoseAggregator", doc.PoseAggregator.doc)
       .def(py::init<>(), doc.PoseAggregator.ctor.doc)
       .def("AddSingleInput", &PoseAggregator<T>::AddSingleInput,
-          py_reference_internal, doc.PoseAggregator.AddSingleInput.doc)
+          py_rvp::reference_internal, doc.PoseAggregator.AddSingleInput.doc)
       .def("AddSinglePoseAndVelocityInput",
           &PoseAggregator<T>::AddSinglePoseAndVelocityInput,
           doc.PoseAggregator.AddSinglePoseAndVelocityInput.doc)
       .def("AddBundleInput", &PoseAggregator<T>::AddBundleInput,
-          py_reference_internal, doc.PoseAggregator.AddBundleInput.doc);
+          py_rvp::reference_internal, doc.PoseAggregator.AddBundleInput.doc);
 
   py::class_<MultibodyPositionToGeometryPose<T>, LeafSystem<T>>(m,
       "MultibodyPositionToGeometryPose",
@@ -146,11 +146,11 @@ PYBIND11_MODULE(rendering, m) {
               .doc_2args_plant_input_multibody_state)
       .def("get_input_port",
           &MultibodyPositionToGeometryPose<T>::get_input_port,
-          py_reference_internal,
+          py_rvp::reference_internal,
           doc.MultibodyPositionToGeometryPose.get_input_port.doc)
       .def("get_output_port",
           &MultibodyPositionToGeometryPose<T>::get_output_port,
-          py_reference_internal,
+          py_rvp::reference_internal,
           doc.MultibodyPositionToGeometryPose.get_output_port.doc);
 
   // TODO(eric.cousineau): Add more systems as needed.

--- a/bindings/pydrake/systems/sensors_py.cc
+++ b/bindings/pydrake/systems/sensors_py.cc
@@ -141,13 +141,13 @@ PYBIND11_MODULE(sensors, m) {
           .def("height", &ImageT::height, doc.Image.height.doc)
           .def("size", &ImageT::size, doc.Image.size.doc)
           .def("resize", &ImageT::resize, doc.Image.resize.doc)
-          .def("at", at, py::arg("x"), py::arg("y"), py_reference_internal,
+          .def("at", at, py::arg("x"), py::arg("y"), py_rvp::reference_internal,
               doc.Image.at.doc_2args_x_y_nonconst)
           // Non-C++ properties. Make them Pythonic.
           .def_property_readonly("shape", get_shape)
-          .def_property_readonly("data", get_data, py_reference_internal)
+          .def_property_readonly("data", get_data, py_rvp::reference_internal)
           .def_property_readonly(
-              "mutable_data", get_mutable_data, py_reference_internal);
+              "mutable_data", get_mutable_data, py_rvp::reference_internal);
       // Constants.
       image.attr("Traits") = traits;
       // - Do not duplicate aliases (e.g. `kNumChannels`) for now.
@@ -179,17 +179,17 @@ PYBIND11_MODULE(sensors, m) {
     using Class = typename PyClass::type;
     py_class
         .def("query_object_input_port", &Class::query_object_input_port,
-            py_reference_internal, cls_doc.query_object_input_port.doc)
+            py_rvp::reference_internal, cls_doc.query_object_input_port.doc)
         .def("color_image_output_port", &Class::color_image_output_port,
-            py_reference_internal, cls_doc.color_image_output_port.doc)
+            py_rvp::reference_internal, cls_doc.color_image_output_port.doc)
         .def("depth_image_32F_output_port", &Class::depth_image_32F_output_port,
-            py_reference_internal, cls_doc.depth_image_32F_output_port.doc)
+            py_rvp::reference_internal, cls_doc.depth_image_32F_output_port.doc)
         .def("depth_image_16U_output_port", &Class::depth_image_16U_output_port,
-            py_reference_internal, cls_doc.depth_image_16U_output_port.doc)
+            py_rvp::reference_internal, cls_doc.depth_image_16U_output_port.doc)
         .def("label_image_output_port", &Class::label_image_output_port,
-            py_reference_internal, cls_doc.label_image_output_port.doc)
+            py_rvp::reference_internal, cls_doc.label_image_output_port.doc)
         .def("X_WB_output_port", &Class::X_WB_output_port,
-            py_reference_internal, cls_doc.X_WB_output_port.doc);
+            py_rvp::reference_internal, cls_doc.X_WB_output_port.doc);
   };
 
   py::class_<RgbdSensor, LeafSystem<T>> rgbd_sensor(
@@ -218,13 +218,13 @@ PYBIND11_MODULE(sensors, m) {
           py::arg("show_window") = false,
           doc.RgbdSensor.ctor.doc_legacy_combined_intrinsics)
       .def("color_camera_info", &RgbdSensor::color_camera_info,
-          py_reference_internal, doc.RgbdSensor.color_camera_info.doc)
+          py_rvp::reference_internal, doc.RgbdSensor.color_camera_info.doc)
       .def("depth_camera_info", &RgbdSensor::depth_camera_info,
-          py_reference_internal, doc.RgbdSensor.depth_camera_info.doc)
+          py_rvp::reference_internal, doc.RgbdSensor.depth_camera_info.doc)
       .def("X_BC", &RgbdSensor::X_BC, doc.RgbdSensor.X_BC.doc)
       .def("X_BD", &RgbdSensor::X_BD, doc.RgbdSensor.X_BD.doc)
       .def("parent_frame_id", &RgbdSensor::parent_frame_id,
-          py_reference_internal, doc.RgbdSensor.parent_frame_id.doc);
+          py_rvp::reference_internal, doc.RgbdSensor.parent_frame_id.doc);
   def_camera_ports(&rgbd_sensor, doc.RgbdSensor);
 
   py::class_<RgbdSensorDiscrete, Diagram<T>> rgbd_camera_discrete(
@@ -237,7 +237,7 @@ PYBIND11_MODULE(sensors, m) {
           py::keep_alive<2, 1>(), doc.RgbdSensorDiscrete.ctor.doc)
       // N.B. Since `camera` is already connected, we do not need additional
       // `keep_alive`s.
-      .def("sensor", &RgbdSensorDiscrete::sensor, py_reference_internal,
+      .def("sensor", &RgbdSensorDiscrete::sensor, py_rvp::reference_internal,
           doc.RgbdSensorDiscrete.sensor.doc)
       .def("period", &RgbdSensorDiscrete::period,
           doc.RgbdSensorDiscrete.period.doc);
@@ -290,13 +290,13 @@ PYBIND11_MODULE(sensors, m) {
         .def(py::init<bool>(), py::arg("do_compress") = false,
             cls_doc.ctor.doc_1args)
         .def("color_image_input_port", &Class::color_image_input_port,
-            py_reference_internal, cls_doc.color_image_input_port.doc)
+            py_rvp::reference_internal, cls_doc.color_image_input_port.doc)
         .def("depth_image_input_port", &Class::depth_image_input_port,
-            py_reference_internal, cls_doc.depth_image_input_port.doc)
+            py_rvp::reference_internal, cls_doc.depth_image_input_port.doc)
         .def("label_image_input_port", &Class::label_image_input_port,
-            py_reference_internal, cls_doc.label_image_input_port.doc)
+            py_rvp::reference_internal, cls_doc.label_image_input_port.doc)
         .def("image_array_t_msg_output_port",
-            &Class::image_array_t_msg_output_port, py_reference_internal,
+            &Class::image_array_t_msg_output_port, py_rvp::reference_internal,
             cls_doc.image_array_t_msg_output_port.doc);
     // Because the public interface requires templates and it's hard to
     // reproduce the logic publicly (e.g. no overload that just takes
@@ -307,7 +307,7 @@ PYBIND11_MODULE(sensors, m) {
           decltype(param)::template type_at<0>::value;
       AddTemplateMethod(cls, "DeclareImageInputPort",
           &Class::DeclareImageInputPort<kPixelType>, GetPyParam(param),
-          py::arg("name"), py_reference_internal,
+          py::arg("name"), py_rvp::reference_internal,
           cls_doc.DeclareImageInputPort.doc);
     };
     type_visit(def_image_input_port, PixelTypeList{});

--- a/bindings/pydrake/test/pydrake_pybind_test.cc
+++ b/bindings/pydrake/test/pydrake_pybind_test.cc
@@ -19,6 +19,17 @@ namespace drake {
 namespace pydrake {
 namespace {
 
+GTEST_TEST(PydrakePybindTest, PyReturnValuePolicy) {
+  static_assert(
+      std::is_same_v<py_rvp, py::return_value_policy>, "Alias is wrong?");
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  EXPECT_EQ(py_rvp::reference, py_reference);
+  EXPECT_EQ(py_rvp::reference_internal, py_reference_internal);
+#pragma GCC diagnostic pop
+}
+
 // Expects that a given Python expression `expr` evaluates to true, using
 // globals and the variables available in `m`.
 void PyExpectTrue(py::module m, const char* expr) {
@@ -27,8 +38,7 @@ void PyExpectTrue(py::module m, const char* expr) {
   EXPECT_TRUE(value) << expr;
 }
 
-// TODO(eric.cousineau): Test coverage of `py_reference`,
-// `py_reference_internal`, `py_keep_alive`, etc.
+// TODO(eric.cousineau): Test coverage of `py_keep_alive`, etc.
 
 // Class which has a copy constructor, for testing `DefCopyAndDeepCopy`.
 struct ExampleDefCopyAndDeepCopy {


### PR DESCRIPTION
Deprecate usage of py_reference and py_reference_internal

Resolves #13715

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13716)
<!-- Reviewable:end -->
