### PR TITLE
drake_shared_library: Expose vtk-dependent headers for drake-bazel-external workflow

### DIFF
--- a/geometry/render/BUILD.bazel
+++ b/geometry/render/BUILD.bazel
@@ -248,4 +248,20 @@ drake_cc_googletest(
     ],
 )
 
+# Provides a target for drake-bazel-external workflows to still access targets
+# like `render_engine_vtk` (e.g. for writing bindings that leverage those
+# headers).
+# N.B. We only expose the headers, not the requisite dependencies, so they can
+# easily be incorporated into `//:drake_shared_library`.
+drake_cc_library(
+    name = "uninstalled_shared_library_hdrs",
+    hdrs = [
+        "render_engine_ospray.h",
+        "render_engine_vtk.h",
+        "render_engine_vtk_base.h",
+    ],
+    tags = ["exclude_from_package"],
+    visibility = ["//tools/install/libdrake:__pkg__"],
+)
+
 add_lint_tests()

--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -87,6 +87,10 @@ cc_library(
     deps = [
         ":libdrake_header_only_deps",
         ":libdrake_runtime_so_deps",
+        # N.B. We include this here so that we can access the headers using
+        # the drake-bazel-external workflow, but not from drake-*-installed
+        # workflows.
+        "//geometry/render:uninstalled_shared_library_hdrs",
     ],
 )
 


### PR DESCRIPTION
This is for an Anzu workflow, where I would like to expose some of our mesh painting in Python in Anzu.
This is the only blocker, I believe.

See Anzu PR 5056

FYI @siyuanfeng-tri 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13717)
<!-- Reviewable:end -->
