### PR TITLE
framework: Remove GoJS from GenerateHtml; rendering is now broken

### DIFF
--- a/systems/framework/system_html.cc
+++ b/systems/framework/system_html.cc
@@ -200,12 +200,11 @@ class LinkWriter : public SystemVisitor<double> {
 
 std::string GenerateHtml(const System<double>& system, int initial_depth) {
   std::stringstream html;
-
-  // Note: Consider using this website for rapid prototyping the javascript:
-  // https://observablehq.com/@russtedrake/gojs-for-drake-system-diagrams
   html << R"!(
-<div style='height:400px;' id='myDiagramDiv' ></div>
-<script src="https://unpkg.com/gojs/release/go.js"></script>
+<div style='height:400px;' id='myDiagramDiv'>
+The implementation of GenerateHtml has been temporarily removed from Drake due
+to licensing restrictions.
+</div>
 <script>
   $ = go.GraphObject.make
   var diagram = $(go.Diagram, "myDiagramDiv", {

--- a/systems/framework/system_html.h
+++ b/systems/framework/system_html.h
@@ -11,6 +11,10 @@ namespace systems {
 diagrams.  Use @p initial_depth to set the depth to which the subdiagrams are
 expanded by default (0 for all collapsed, +∞ for all expanded). 
 
+@warning The implementation of GenerateHtml has been temporarily removed from
+Drake due to licensing restrictions.  This function will return valid HTML,
+but will not produce any useful rendering.
+
 @ingroup systems
 */
 std::string GenerateHtml(const System<double>& system, int initial_depth = 1);

--- a/tutorials/dynamical_systems.ipynb
+++ b/tutorials/dynamical_systems.ipynb
@@ -279,14 +279,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from IPython.display import HTML\n",
+    "%matplotlib notebook\n",
+    "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "\n",
     "from pydrake.systems.framework import DiagramBuilder\n",
     "from pydrake.systems.analysis import Simulator\n",
     "from pydrake.examples.pendulum import PendulumPlant\n",
     "from pydrake.systems.controllers import PidController\n",
-    "from pydrake.systems.framework import GenerateHtml\n",
+    "from pydrake.systems.drawing import plot_system_graphviz\n",
     "from pydrake.systems.primitives import LogOutput\n",
     "\n",
     "builder = DiagramBuilder()\n",
@@ -312,7 +313,8 @@
     "diagram = builder.Build()\n",
     "diagram.set_name(\"diagram\")\n",
     "\n",
-    "HTML(GenerateHtml(diagram))"
+    "plt.figure()\n",
+    "plot_system_graphviz(diagram, max_depth=2)"
    ]
   },
   {
@@ -330,9 +332,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
     "# Set up a simulator to run this diagram.\n",
     "simulator = Simulator(diagram)\n",
     "context = simulator.get_mutable_context()\n",


### PR DESCRIPTION
The implementation of `GenerateHtml` has been temporarily removed from Drake due to licensing restrictions.  The function will return valid HTML, but will not produce any useful rendering.

Revert the dynamical systems tutorial to use matplotlib again.

Relates #13705.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13720)
<!-- Reviewable:end -->
