### PR TITLE
geometry: Fix minor broken URL for benchmarking

### DIFF
--- a/geometry/benchmarking/README.md
+++ b/geometry/benchmarking/README.md
@@ -26,13 +26,13 @@ info see: https://github.com/google/benchmark#fixtures.
 
 # Available Benchmarks
 
-* [render_benchmark.cc](https://drake.mit.edu/doxygen_cxx/html/group__render__engine__benchmarks.html):
+* [render_benchmark.cc](./render_benchmark.cc):
 Benchmark program to help characterize the relative costs of different
 RenderEngine implementations with varying scene complexity and rendering. It is
 designed so users can assess the relative cost of the renderers on their own
 hardware configuration, aiding in design decisions for understanding the cost of
 renderer choice.
-* [mesh_intersection_benchmark.cc](https://drake.mit.edu/doxygen_cxx/html/group__mesh__intersection__benchmarks.html):
+* [mesh_intersection_benchmark.cc](./mesh_intersection_benchmark.cc):
 Benchmark program to compare different mesh intersection optimizations with
 varying mesh attributes and overlaps. It is targeted toward developers during
 the process of optimizing the performance of hydroelastic contact and may be


### PR DESCRIPTION
Came across per Jeremy's mention in Slack:
https://drakedevelopers.slack.com/archives/C2NN588UA/p1595350566134800?thread_ts=1595350442.134600&cid=C2NN588UA

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13723)
<!-- Reviewable:end -->
