### PR TITLE
py deprecation: Require YYYY-MM-DD to be present in message

### DIFF
--- a/bindings/pydrake/common/cpp_template.py
+++ b/bindings/pydrake/common/cpp_template.py
@@ -221,7 +221,11 @@ class TemplateBase:
         Args:
             param: Parameters for an instantiation that is already registered.
             message: Message to be shown when issuing a deprecation warning.
-            date: (Optional) Date for deprecation message (see ``deprecated``).
+            date: (Optional) String of the form "YYYY-MM-DD".
+                If supplied, will reformat the message to add the date as is
+                done with DRAKE_DEPRECATED and its processing in mkdoc.py. This
+                must be present if ``message`` does not contain the date
+                itself.
         Returns:
             (instantiation, param), where ``param`` is the resolved parameters.
         """

--- a/bindings/pydrake/common/cpp_template.py
+++ b/bindings/pydrake/common/cpp_template.py
@@ -43,6 +43,13 @@ def get_or_init(scope, name, template_cls, *args, **kwargs):
     return template
 
 
+class _Deprecation:
+    # Denotes a (message, date) tuple.
+    def __init__(self, message, date):
+        self.message = message
+        self.date = date
+
+
 class TemplateBase:
     """Provides a mechanism to map parameters (types or literals) to
     instantiations, following C++ mechanics.
@@ -153,7 +160,7 @@ class TemplateBase:
                 self._instantiation_name(param)))
         deprecation = self._deprecation_map.get(param)
         if deprecation is not None:
-            _warn_deprecated(deprecation)
+            _warn_deprecated(deprecation.message, date=deprecation.date)
         return (instantiation, param)
 
     def add_instantiation(self, param, instantiation):
@@ -205,7 +212,7 @@ class TemplateBase:
         for param in param_list:
             self.add_instantiation(param, TemplateBase._deferred)
 
-    def deprecate_instantiation(self, param, message):
+    def deprecate_instantiation(self, param, message, *, date=None):
         """Deprecates an instantiation for the given set of parameters.
 
         Note:
@@ -214,6 +221,7 @@ class TemplateBase:
         Args:
             param: Parameters for an instantiation that is already registered.
             message: Message to be shown when issuing a deprecation warning.
+            date: Date for deprecation message (see ``deprecated``).
         Returns:
             (instantiation, param), where ``param`` is the resolved parameters.
         """
@@ -223,7 +231,7 @@ class TemplateBase:
                 f"Deprecation already registered: "
                 f"{self._instantiation_name(param)}")
         instantiation, param = self.get_instantiation(param)
-        self._deprecation_map[param] = message
+        self._deprecation_map[param] = _Deprecation(message=message, date=date)
         return (instantiation, param)
 
     def get_param_set(self, instantiation):

--- a/bindings/pydrake/common/cpp_template.py
+++ b/bindings/pydrake/common/cpp_template.py
@@ -45,7 +45,7 @@ def get_or_init(scope, name, template_cls, *args, **kwargs):
 
 class _Deprecation:
     # Denotes a (message, date) tuple.
-    def __init__(self, message, date):
+    def __init__(self, *, message, date):
         self.message = message
         self.date = date
 
@@ -221,7 +221,7 @@ class TemplateBase:
         Args:
             param: Parameters for an instantiation that is already registered.
             message: Message to be shown when issuing a deprecation warning.
-            date: Date for deprecation message (see ``deprecated``).
+            date: (Optional) Date for deprecation message (see ``deprecated``).
         Returns:
             (instantiation, param), where ``param`` is the resolved parameters.
         """

--- a/bindings/pydrake/common/deprecation.py
+++ b/bindings/pydrake/common/deprecation.py
@@ -178,8 +178,10 @@ def deprecated(message, *, date=None):
 
     Args:
         message: Warning message when member is accessed.
-        date: (Optional) If supplied, will preformat the message as is done
-            with DRAKE_DEPRECATED and in mkdoc.py.
+        date: (Optional) String of the form "YYYY-MM-DD".
+            If supplied, will reformat the message to add the date as is done
+            with DRAKE_DEPRECATED and its processing in mkdoc.py. This must be
+            present if ``message`` does not contain the date itself.
 
     Note:
         This differs from other implementations in that it warns on access,
@@ -258,5 +260,5 @@ else:
     warnings.simplefilter('once', DrakeDeprecationWarning)
 _installed_numpy_warning_filters = False
 
-# Used to enforce presence of yyyy-mm-dd timestamp for deprecation.
+# Used to enforce presence of YYYY-MM-DD timestamp for deprecation.
 _date_pattern = re.compile(r"\d\d\d\d\-\d\d\-\d\d")

--- a/bindings/pydrake/common/deprecation_pybind.h
+++ b/bindings/pydrake/common/deprecation_pybind.h
@@ -57,6 +57,8 @@ auto WrapDeprecatedImpl(py::str message,
   };
 }
 
+// N.B. `decltype(auto)` is used in both places to (easily) achieve perfect
+// forwarding of the return type.
 template <typename Func, typename Return, typename... Args>
 decltype(auto) WrapDeprecatedImpl(py::str message,
     function_info<Func, Return, Args...>&& info,

--- a/bindings/pydrake/common/deprecation_pybind.h
+++ b/bindings/pydrake/common/deprecation_pybind.h
@@ -45,16 +45,6 @@ inline void WarnDeprecated(
   warn_deprecated(message, py::arg("date") = date);
 }
 
-/// Takes a date and message and formats it to be consistent with other
-/// deprecation messages.
-inline py::str FormatDeprecationMessage(
-    py::str message, std::optional<std::string> date = {}) {
-  py::object format_deprecation_message =
-      py::module::import("pydrake.common.deprecation")
-          .attr("_format_deprecation_message");
-  return format_deprecation_message(message, py::arg("date") = date);
-}
-
 namespace internal {
 
 template <typename Func, typename Return, typename... Args>

--- a/bindings/pydrake/common/deprecation_pybind.h
+++ b/bindings/pydrake/common/deprecation_pybind.h
@@ -68,10 +68,10 @@ auto WrapDeprecatedImpl(py::str message,
 }
 
 template <typename Func, typename Return, typename... Args>
-auto WrapDeprecatedImpl(py::str message,
+decltype(auto) WrapDeprecatedImpl(py::str message,
     function_info<Func, Return, Args...>&& info,
     std::enable_if_t<!std::is_same<Return, void>::value, void*> = {}) {
-  return [info = std::move(info), message](Args... args) -> Return {
+  return [info = std::move(info), message](Args... args) -> decltype(auto) {
     WarnDeprecated(message);
     return info.func(std::forward<Args>(args)...);
   };

--- a/bindings/pydrake/common/deprecation_pybind.h
+++ b/bindings/pydrake/common/deprecation_pybind.h
@@ -69,8 +69,6 @@ decltype(auto) WrapDeprecatedImpl(py::str message,
 
 }  // namespace internal
 
-// TODO(eric.cousineau): Expose `dae
-
 /// Wraps any callable (function pointer, method pointer, lambda, etc.) to emit
 /// a deprecation message.
 template <typename Func>

--- a/bindings/pydrake/common/test/cpp_template_test.py
+++ b/bindings/pydrake/common/test/cpp_template_test.py
@@ -101,12 +101,12 @@ class TestCppTemplate(unittest.TestCase):
         template.add_instantiation(int, 1)
         template.add_instantiation(float, 2)
         instantiation, param = template.deprecate_instantiation(
-            int, "Example deprecation")
+            int, "Example deprecation", date="2038-01-19")
         self.assertEqual(instantiation, 1)
         self.assertEqual(param, (int,))
         with catch_drake_warnings(expected_count=1) as w:
             self.assertEqual(template[int], 1)
-        self.assertEqual(str(w[0].message), "Example deprecation")
+        self.assertIn("Example deprecation", str(w[0].message))
         # There should be no deprecations for other types.
         self.assertEqual(template[float], 2)
         # Double-deprecating should raise an error.

--- a/bindings/pydrake/common/test/deprecation_example/__init__.py
+++ b/bindings/pydrake/common/test/deprecation_example/__init__.py
@@ -21,11 +21,12 @@ class ExampleClass:
     message_prop = "`deprecated_prop` is also deprecated"
 
     # Deprecate method.
-    @deprecated(message_method)
+    @deprecated(message_method, date="2038-01-19")
     def deprecated_method(self):
         """Method Doc"""
         return 1
 
     # Deprecate public property.
     _deprecated_prop = property(lambda self: 2, doc=doc_prop)
-    deprecated_prop = deprecated(message_prop)(_deprecated_prop)
+    deprecated_prop = deprecated(message_prop, date="2038-01-19")(
+        _deprecated_prop)

--- a/bindings/pydrake/common/test/deprecation_example/cc_module_py.cc
+++ b/bindings/pydrake/common/test/deprecation_example/cc_module_py.cc
@@ -17,7 +17,7 @@ PYBIND11_MODULE(cc_module, m) {
 
   m.def("emit_deprecation", []() {
     // N.B. This is only for coverage. You generally do not need this.
-    WarnDeprecated("Example emitting of deprecation");
+    WarnDeprecated("Example emitting of deprecation", "2038-01-19");
   });
 
   {

--- a/bindings/pydrake/common/test/deprecation_test.py
+++ b/bindings/pydrake/common/test/deprecation_test.py
@@ -136,7 +136,11 @@ class TestDeprecation(unittest.TestCase):
     def _check_warning(self, item, message_expected, check_full=True):
         self.assertEqual(item.category, DrakeDeprecationWarning)
         if check_full:
-            self.assertEqual(message_expected, str(item.message))
+            full_message_expected = (
+                f"{message_expected} The deprecated code will be removed "
+                f"from Drake on or after 2038-01-19."
+            )
+            self.assertEqual(full_message_expected, str(item.message))
         else:
             self.assertIn(message_expected, str(item.message))
 
@@ -257,14 +261,13 @@ class TestDeprecation(unittest.TestCase):
         import deprecation_example.cc_module as m_new
         # Spoof module name.
         var_dict = dict(__name__="fake_module")
-        _forward_callables_as_deprecated(var_dict, m_new, "2050-01-01")
+        _forward_callables_as_deprecated(var_dict, m_new, date="2038-01-19")
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("once", DrakeDeprecationWarning)
             obj = var_dict["ExampleCppClass"]()
             self.assertIsInstance(obj, m_new.ExampleCppClass)
             message_expected = (
-                "``fake_module.ExampleCppClass`` is deprecated and will be "
-                "removed on or around 2050-01-01; please use "
-                "``deprecation_example.cc_module.ExampleCppClass`` instead.")
+                "Please use ``deprecation_example.cc_module.ExampleCppClass`` "
+                "instead of ``fake_module.ExampleCppClass``.")
             self.assertEqual(len(w), 1)
             self._check_warning(w[0], message_expected)

--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -119,31 +119,37 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.operator_mul.doc_1args_constEigenMatrixBase);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    // N.B. clang-format does weird stuff here.
+    // clang-format off
+    py::str linear_deprecation = FormatDeprecationMessage(py::str(R"""(
+The RigidTransform::linear() method was added for compatibility with
+Eigen::Isometry3, and is now deprecated. Use RigidTransform::GetAsMatrix4()
+instead.
+)""").attr("strip")(),
+        "2020-11-01");
+    py::str matrix_deprecation = FormatDeprecationMessage(py::str(R"""(
+The RigidTransform::matrix() method was added for compatibility with
+Eigen::Isometry3, and is now deprecated. Use RigidTransform::GetAsMatrix4()
+instead.
+)""").attr("strip")(),
+        "2020-11-01");
+    // clang-format on
+
     cls  // BR
         .def(
             "matrix",
-            [](RigidTransform<T>* self) {
-              WarnDeprecated(
-                  "The RigidTransform::matrix() method was added for "
-                  "compatibility with Eigen::Isometry3, and is now deprecated. "
-                  "Use RigidTransform::GetAsMatrix4() instead.");
+            [matrix_deprecation](RigidTransform<T>* self) {
+              WarnDeprecated(matrix_deprecation);
               return self->GetAsMatrix4();
             },
-            "The RigidTransform::matrix() method was added for "
-            "compatibility with Eigen::Isometry3, and is now deprecated. "
-            "Use RigidTransform::GetAsMatrix4() instead.")
+            std::string(matrix_deprecation).c_str())
         .def(
             "linear",
-            [](RigidTransform<T>* self) {
-              WarnDeprecated(
-                  "The RigidTransform::linear() method was added for "
-                  "compatibility with Eigen::Isometry3, and is now deprecated. "
-                  "Use RigidTransform::rotation().matrix() instead.");
+            [linear_deprecation](RigidTransform<T>* self) {
+              WarnDeprecated(linear_deprecation);
               return self->rotation().matrix();
             },
-            "The RigidTransform::linear() method was added for "
-            "compatibility with Eigen::Isometry3, and is now deprecated. "
-            "Use RigidTransform::rotation().matrix() instead.");
+            std::string(linear_deprecation).c_str());
 #pragma GCC diagnostic pop
     cls  // BR
         .def(py::pickle([](const Class& self) { return self.GetAsMatrix34(); },
@@ -289,21 +295,21 @@ void DoScalarDependentDefinitions(py::module m, T) {
   auto eigen_geometry_py = py::module::import("pydrake.common.eigen_geometry");
   // Install constructor to Isometry3 to permit `implicitly_convertible` to
   // work.
-  // TODO(eric.cousineau): Consider more elegant implicit conversion process.
-  // See pybind/pybind11#1735
+  // N.B. clang-format does weird stuff here.
+  // clang-format off
+  py::str isometry_deprecation = FormatDeprecationMessage(py::str(R"""(
+Implicit conversion from RigidTransform to Eigen::Isometry3 is deprecated. You
+may convert explicitly by calling GetAsIsometry3(), or try to avoid using
+Eigen::Isometry3 in the first place.
+)""").attr("strip")(),
+      "2020-11-01");
+  // clang-format on
   py::class_<Isometry3<T>>(eigen_geometry_py.attr("Isometry3"))
-      .def(py::init([](const RigidTransform<T>& X) {
-        WarnDeprecated(
-            "Implicit conversion from RigidTransform to Eigen::Isometry3 is "
-            "deprecated. You may convert explicitly by calling "
-            "GetAsIsometry3(), or try to avoid using Eigen::Isometry3 in the "
-            "first place.");
+      .def(py::init([isometry_deprecation](const RigidTransform<T>& X) {
+        WarnDeprecated(isometry_deprecation);
         return X.GetAsIsometry3();
       }),
-          "Implicit conversion from RigidTransform to Eigen::Isometry3 is "
-          "deprecated. You may convert explicitly by calling "
-          "GetAsIsometry3(), or try to avoid using Eigen::Isometry3 in the "
-          "first place.");
+          std::string(isometry_deprecation).c_str());
   py::implicitly_convertible<RigidTransform<T>, Isometry3<T>>();
 }
 

--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -121,12 +121,10 @@ void DoScalarDependentDefinitions(py::module m, T) {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
     cls  // BR
-        .def(
-            "matrix",
+        .def("matrix",
             WrapDeprecated(cls_doc.matrix.doc_deprecated, &Class::matrix),
             cls_doc.matrix.doc_deprecated)
-        .def(
-            "linear",
+        .def("linear",
             WrapDeprecated(cls_doc.linear.doc_deprecated, &Class::linear),
             cls_doc.linear.doc_deprecated);
 #pragma GCC diagnostic pop

--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -119,37 +119,16 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.operator_mul.doc_1args_constEigenMatrixBase);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    // N.B. clang-format does weird stuff here.
-    // clang-format off
-    py::str linear_deprecation = FormatDeprecationMessage(py::str(R"""(
-The RigidTransform::linear() method was added for compatibility with
-Eigen::Isometry3, and is now deprecated. Use RigidTransform::GetAsMatrix4()
-instead.
-)""").attr("strip")(),
-        "2020-11-01");
-    py::str matrix_deprecation = FormatDeprecationMessage(py::str(R"""(
-The RigidTransform::matrix() method was added for compatibility with
-Eigen::Isometry3, and is now deprecated. Use RigidTransform::GetAsMatrix4()
-instead.
-)""").attr("strip")(),
-        "2020-11-01");
-    // clang-format on
 
     cls  // BR
         .def(
             "matrix",
-            [matrix_deprecation](RigidTransform<T>* self) {
-              WarnDeprecated(matrix_deprecation);
-              return self->GetAsMatrix4();
-            },
-            std::string(matrix_deprecation).c_str())
+            WrapDeprecated(cls_doc.matrix.doc_deprecated, &Class::matrix),
+            cls_doc.matrix.doc_deprecated)
         .def(
             "linear",
-            [linear_deprecation](RigidTransform<T>* self) {
-              WarnDeprecated(linear_deprecation);
-              return self->rotation().matrix();
-            },
-            std::string(linear_deprecation).c_str());
+            WrapDeprecated(cls_doc.linear.doc_deprecated, &Class::linear),
+            cls_doc.linear.doc_deprecated);
 #pragma GCC diagnostic pop
     cls  // BR
         .def(py::pickle([](const Class& self) { return self.GetAsMatrix34(); },
@@ -295,21 +274,9 @@ instead.
   auto eigen_geometry_py = py::module::import("pydrake.common.eigen_geometry");
   // Install constructor to Isometry3 to permit `implicitly_convertible` to
   // work.
-  // N.B. clang-format does weird stuff here.
-  // clang-format off
-  py::str isometry_deprecation = FormatDeprecationMessage(py::str(R"""(
-Implicit conversion from RigidTransform to Eigen::Isometry3 is deprecated. You
-may convert explicitly by calling GetAsIsometry3(), or try to avoid using
-Eigen::Isometry3 in the first place.
-)""").attr("strip")(),
-      "2020-11-01");
-  // clang-format on
   py::class_<Isometry3<T>>(eigen_geometry_py.attr("Isometry3"))
-      .def(py::init([isometry_deprecation](const RigidTransform<T>& X) {
-        WarnDeprecated(isometry_deprecation);
-        return X.GetAsIsometry3();
-      }),
-          std::string(isometry_deprecation).c_str());
+      .def(py_init_deprecated<Isometry3<T>, const RigidTransform<T>&>(
+          doc.RigidTransform.operator_Transform.doc_deprecated));
   py::implicitly_convertible<RigidTransform<T>, Isometry3<T>>();
 }
 


### PR DESCRIPTION
Resolves #13729

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13730)
<!-- Reviewable:end -->
