### PR TITLE
yaml: Move method definition to cc file

### DIFF
--- a/common/yaml/yaml_write_archive.cc
+++ b/common/yaml/yaml_write_archive.cc
@@ -96,5 +96,17 @@ std::string YamlWriteArchive::YamlDumpWithSortedMaps(
   return emitter.c_str();
 }
 
+std::string YamlWriteArchive::EmitString(const std::string& root_name) const {
+  std::string result;
+  if (root_.IsNull()) {
+    result = root_name + ":\n";
+  } else {
+    YAML::Node document;
+    document[root_name] = root_;
+    result = YamlDumpWithSortedMaps(document) + "\n";
+  }
+  return result;
+}
+
 }  // namespace yaml
 }  // namespace drake

--- a/common/yaml/yaml_write_archive.h
+++ b/common/yaml/yaml_write_archive.h
@@ -96,17 +96,7 @@ class YamlWriteArchive final {
   /// passed into Accept.  The returned document will be a single Map node
   /// named using `root_name` with the Serializable's visited fields as
   /// key-value entries within it.
-  std::string EmitString(const std::string& root_name = "root") const {
-    std::string result;
-    if (root_.IsNull()) {
-      result = root_name + ":\n";
-    } else {
-      YAML::Node document;
-      document[root_name] = root_;
-      result = YamlDumpWithSortedMaps(document) + "\n";
-    }
-    return result;
-  }
+  std::string EmitString(const std::string& root_name = "root") const;
 
   /// (Advanced.)  Copies the value pointed to by `nvp.value()` into the YAML
   /// object.  Most users should should call Accept, not Visit.


### PR DESCRIPTION
Generally we should prefer cc file for compilation speed, but it was overlooked during the initial implementation.

Prep for #13699.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13732)
<!-- Reviewable:end -->
