### PR TITLE
yaml: Factor out example_structs for unit tests

### DIFF
--- a/common/yaml/BUILD.bazel
+++ b/common/yaml/BUILD.bazel
@@ -47,6 +47,16 @@ drake_cc_library(
 
 # === test/ ===
 
+drake_cc_library(
+    name = "example_structs",
+    testonly = True,
+    hdrs = ["test/example_structs.h"],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//common:name_value",
+    ],
+)
+
 drake_cc_googletest(
     name = "yaml_performance_test",
     deps = [
@@ -61,6 +71,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "yaml_read_archive_test",
     deps = [
+        ":example_structs",
         ":yaml_read_archive",
         "//common:name_value",
         "//common/test_utilities:eigen_matrix_compare",
@@ -71,6 +82,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "yaml_write_archive_test",
     deps = [
+        ":example_structs",
         ":yaml_write_archive",
         "//common:name_value",
         "//common/test_utilities:expect_throws_message",

--- a/common/yaml/test/example_structs.h
+++ b/common/yaml/test/example_structs.h
@@ -1,0 +1,261 @@
+#pragma once
+
+#include <array>
+#include <map>
+#include <optional>
+#include <ostream>
+#include <string>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+#include <Eigen/Core>
+
+#include "drake/common/name_value.h"
+
+namespace drake {
+namespace yaml {
+namespace test {
+
+// A value used in the test data below to include a default (placeholder) value
+// when initializing struct data members.
+constexpr double kNominalDouble = 1.2345;
+
+// These unit tests use a variety of sample Serializable structs, showing what
+// a user may write for their own schemas.
+
+struct DoubleStruct {
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(value));
+  }
+
+  double value = kNominalDouble;
+};
+
+bool operator==(const DoubleStruct& a, const DoubleStruct& b) {
+  return a.value == b.value;
+}
+
+struct StringStruct {
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(value));
+  }
+
+  std::string value = "kNominalDouble";
+};
+
+struct ArrayStruct {
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(value));
+  }
+
+  ArrayStruct() {
+    value.fill(kNominalDouble);
+  }
+
+  explicit ArrayStruct(const std::array<double, 3>& value_in)
+      : value(value_in) {}
+
+  std::array<double, 3> value;
+};
+
+struct VectorStruct {
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(value));
+  }
+
+  VectorStruct() {
+    value.resize(1, kNominalDouble);
+  }
+
+  explicit VectorStruct(const std::vector<double>& value_in)
+      : value(value_in) {}
+
+  std::vector<double> value;
+};
+
+struct NonPodVectorStruct {
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(value));
+  }
+
+  NonPodVectorStruct() {
+    value.resize(1, {"kNominalDouble"});
+  }
+
+  std::vector<StringStruct> value;
+};
+
+struct MapStruct {
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(value));
+  }
+
+  MapStruct() {
+    value["kNominalDouble"] = kNominalDouble;
+  }
+
+  explicit MapStruct(const std::map<std::string, double>& value_in)
+      : value(value_in) {}
+
+  std::map<std::string, double> value;
+};
+
+struct UnorderedMapStruct {
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(value));
+  }
+
+  UnorderedMapStruct() {
+    value["kNominalDouble"] = kNominalDouble;
+  }
+
+  explicit UnorderedMapStruct(
+      const std::unordered_map<std::string, double>& value_in)
+      : value(value_in) {}
+
+  std::unordered_map<std::string, double> value;
+};
+
+struct OptionalStruct {
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(value));
+  }
+
+  OptionalStruct() {
+    value = kNominalDouble;
+  }
+
+  explicit OptionalStruct(const double value_in)
+      : OptionalStruct(std::optional<double>(value_in)) {}
+
+  explicit OptionalStruct(const std::optional<double>& value_in)
+      : value(value_in) {}
+
+  std::optional<double> value;
+};
+
+using Variant3 = std::variant<std::string, double, DoubleStruct>;
+
+std::ostream& operator<<(std::ostream& os, const Variant3& value) {
+  if (value.index() == 0) {
+    os << "std::string{" << std::get<0>(value) << "}";
+  } else if (value.index() == 1) {
+    os << "double{" << std::get<1>(value) << "}";
+  } else {
+    os << "DoubleStruct{" << std::get<2>(value).value << "}";
+  }
+  return os;
+}
+
+struct VariantStruct {
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(value));
+  }
+
+  VariantStruct() {
+    value = kNominalDouble;
+  }
+
+  explicit VariantStruct(const Variant3& value_in)
+      : value(value_in) {}
+
+  Variant3 value;
+};
+
+struct VariantWrappingStruct {
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(inner));
+  }
+
+  VariantStruct inner;
+};
+
+template <int Rows, int Cols>
+struct EigenStruct {
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(value));
+  }
+
+  EigenStruct() {
+    if (value.size() == 0) {
+      value.resize(1, 1);
+    }
+    value.setConstant(kNominalDouble);
+  }
+
+  explicit EigenStruct(const Eigen::Matrix<double, Rows, Cols>& value_in)
+      : value(value_in) {}
+
+  Eigen::Matrix<double, Rows, Cols> value;
+};
+
+using EigenVecStruct = EigenStruct<Eigen::Dynamic, 1>;
+using EigenVec3Struct = EigenStruct<3, 1>;
+using EigenMatrixStruct = EigenStruct<Eigen::Dynamic, Eigen::Dynamic>;
+using EigenMatrix34Struct = EigenStruct<3, 4>;
+
+struct OuterStruct {
+  struct InnerStruct {
+    template <typename Archive>
+    void Serialize(Archive* a) {
+      a->Visit(DRAKE_NVP(inner_value));
+    }
+
+    double inner_value = kNominalDouble;
+  };
+
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(outer_value));
+    a->Visit(DRAKE_NVP(inner_struct));
+  }
+
+  double outer_value = kNominalDouble;
+  InnerStruct inner_struct;
+};
+
+struct OuterWithBlankInner {
+  struct Blank {
+    template <typename Archive>
+    void Serialize(Archive* a) {}
+  };
+
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(outer_value));
+    a->Visit(DRAKE_NVP(inner_struct));
+  }
+
+  double outer_value = kNominalDouble;
+  Blank inner_struct;
+};
+
+struct BigMapStruct {
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(value));
+  }
+
+  BigMapStruct() {
+    value["foo"].outer_value = 1.0;
+    value["foo"].inner_struct.inner_value = 2.0;
+  }
+
+  std::map<std::string, OuterStruct> value;
+};
+
+}  // namespace test
+}  // namespace yaml
+}  // namespace drake

--- a/common/yaml/test/yaml_write_archive_test.cc
+++ b/common/yaml/test/yaml_write_archive_test.cc
@@ -1,209 +1,17 @@
 #include "drake/common/yaml/yaml_write_archive.h"
 
-#include <cmath>
 #include <vector>
 
-#include <Eigen/Core>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/name_value.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
-
-using drake::yaml::YamlWriteArchive;
-
-namespace {
-
-// These unit tests use a variety of sample Serializable structs, showing what
-// a user may write for their own schemas.
-
-struct DoubleStruct {
-  double value = NAN;
-
-  template <typename Archive>
-  void Serialize(Archive* a) {
-    a->Visit(DRAKE_NVP(value));
-  }
-};
-
-struct StringStruct {
-  std::string value = "NAN";
-
-  template <typename Archive>
-  void Serialize(Archive* a) {
-    a->Visit(DRAKE_NVP(value));
-  }
-};
-
-struct ArrayStruct {
-  std::array<double, 3> value;
-
-  template <typename Archive>
-  void Serialize(Archive* a) {
-    a->Visit(DRAKE_NVP(value));
-  }
-
-  ArrayStruct() {
-    value.fill(NAN);
-  }
-
-  explicit ArrayStruct(const std::array<double, 3>& value_in)
-      : value(value_in) {}
-};
-
-struct VectorStruct {
-  std::vector<double> value;
-
-  template <typename Archive>
-  void Serialize(Archive* a) {
-    a->Visit(DRAKE_NVP(value));
-  }
-
-  VectorStruct() {
-    value.resize(1, NAN);
-  }
-
-  explicit VectorStruct(const std::vector<double>& value_in)
-      : value(value_in) {}
-};
-
-struct NonPodVectorStruct {
-  std::vector<StringStruct> value;
-
-  template <typename Archive>
-  void Serialize(Archive* a) {
-    a->Visit(DRAKE_NVP(value));
-  }
-
-  NonPodVectorStruct() {
-    value.resize(1, {"NAN"});
-  }
-};
-
-struct MapStruct {
-  template <typename Archive>
-  void Serialize(Archive* a) {
-    a->Visit(DRAKE_NVP(value));
-  }
-
-  std::map<std::string, double> value;
-};
-
-struct UnorderedMapStruct {
-  template <typename Archive>
-  void Serialize(Archive* a) {
-    a->Visit(DRAKE_NVP(value));
-  }
-
-  std::unordered_map<std::string, double> value;
-};
-
-struct OptionalStruct {
-  std::optional<double> value;
-
-  template <typename Archive>
-  void Serialize(Archive* a) {
-    a->Visit(DRAKE_NVP(value));
-  }
-
-  OptionalStruct()
-      : OptionalStruct(NAN) {}
-
-  explicit OptionalStruct(const double value_in)
-      : OptionalStruct(std::optional<double>(value_in)) {}
-
-  explicit OptionalStruct(const std::optional<double>& value_in)
-      : value(value_in) {}
-};
-
-using Variant3 = std::variant<std::string, double, DoubleStruct>;
-
-struct VariantStruct {
-  Variant3 value;
-
-  template <typename Archive>
-  void Serialize(Archive* a) {
-    a->Visit(DRAKE_NVP(value));
-  }
-
-  VariantStruct()
-      : VariantStruct(NAN) {}
-
-  explicit VariantStruct(const Variant3& value_in)
-      : value(value_in) {}
-};
-
-struct VariantWrappingStruct {
-  VariantStruct inner;
-
-  template <typename Archive>
-  void Serialize(Archive* a) {
-    a->Visit(DRAKE_NVP(inner));
-  }
-};
-
-template <int Rows, int Cols>
-struct EigenStruct {
-  Eigen::Matrix<double, Rows, Cols> value;
-
-  template <typename Archive>
-  void Serialize(Archive* a) {
-    a->Visit(DRAKE_NVP(value));
-  }
-
-  EigenStruct() {
-    value.setConstant(NAN);
-  }
-
-  explicit EigenStruct(const Eigen::Matrix<double, Rows, Cols>& value_in)
-      : value(value_in) {}
-};
-
-using EigenVecStruct = EigenStruct<Eigen::Dynamic, 1>;
-using EigenVec3Struct = EigenStruct<3, 1>;
-using EigenMatrixStruct = EigenStruct<Eigen::Dynamic, Eigen::Dynamic>;
-using EigenMatrix34Struct = EigenStruct<3, 4>;
-
-struct OuterStruct {
-  struct InnerStruct {
-    double inner_value = NAN;
-
-    template <typename Archive>
-    void Serialize(Archive* a) {
-      a->Visit(DRAKE_NVP(inner_value));
-    }
-  };
-
-  double outer_value = NAN;
-  InnerStruct inner_struct;
-
-  template <typename Archive>
-  void Serialize(Archive* a) {
-    a->Visit(DRAKE_NVP(outer_value));
-    a->Visit(DRAKE_NVP(inner_struct));
-  }
-};
-
-struct OuterWithBlankInner {
-  struct Blank {
-    template <typename Archive>
-    void Serialize(Archive* a) {}
-  };
-
-  double outer_value = NAN;
-  Blank inner_struct;
-
-  template <typename Archive>
-  void Serialize(Archive* a) {
-    a->Visit(DRAKE_NVP(outer_value));
-    a->Visit(DRAKE_NVP(inner_struct));
-  }
-};
-
-}  // namespace
+#include "drake/common/yaml/test/example_structs.h"
 
 namespace drake {
 namespace yaml {
+namespace test {
 namespace {
 
 // A test fixture with common helpers.
@@ -453,5 +261,6 @@ TEST_F(YamlWriteArchiveTest, BlankInner) {
 }
 
 }  // namespace
+}  // namespace test
 }  // namespace yaml
 }  // namespace drake


### PR DESCRIPTION
Tidy up the struct a little bit to resolve differences between the two copies: Serialize as first thing in struct, use kNominalDouble not NAN, always have a non-zero, non-empty default value, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13733)
<!-- Reviewable:end -->
