### PR TITLE
Introduce discrete contact pairs for agnostic treatment of discrete contact models

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -21,6 +21,7 @@ drake_cc_package_library(
         ":contact_jacobians",
         ":contact_results",
         ":coulomb_friction",
+        ":discrete_contact_pair",
         ":externally_applied_spatial_force",
         ":hydroelastic_contact_info",
         ":hydroelastic_quadrature_point_data",
@@ -30,6 +31,16 @@ drake_cc_package_library(
         ":propeller",
         ":tamsi_solver",
         ":tamsi_solver_results",
+    ],
+)
+
+drake_cc_library(
+    name = "discrete_contact_pair",
+    srcs = [],
+    hdrs = ["discrete_contact_pair.h"],
+    deps = [
+        "//common:essential",
+        "//geometry:geometry_ids",
     ],
 )
 
@@ -56,6 +67,7 @@ drake_cc_library(
         ":contact_jacobians",
         ":contact_results",
         ":coulomb_friction",
+        ":discrete_contact_pair",
         ":externally_applied_spatial_force",
         ":hydroelastic_traction",
         ":tamsi_solver",

--- a/multibody/plant/discrete_contact_pair.h
+++ b/multibody/plant/discrete_contact_pair.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/geometry/geometry_ids.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+/* A characterization of intersection of two penetrating geometries with the
+ discrete information a discrete solver cares about. Encapsulated in this
+ manner, the solver is agnostic to whether these pairs are penetration pairs for
+ a point contact model or quadrature point pairs for a compliant surface model
+ such a hydroelastics.
+
+ @tparam T The underlying scalar type. Must be a valid Eigen scalar. */
+template <typename T>
+struct DiscreteContactPair {
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DiscreteContactPair)
+  DiscreteContactPair() = default;
+
+  /* The id of the first geometry in the contact. */
+  geometry::GeometryId id_A;
+  /* The id of the second geometry in the contact. */
+  geometry::GeometryId id_B;
+  /* Position of contact point C in world frame W. Contact forces will be
+   applied at this point. */
+  Vector3<T> p_WC;
+  /* The unit-length normal which defines the penetration direction, pointing
+   from geometry B into geometry A, measured and expressed in the world frame.
+   It _approximates_ the normal to the plane on which the contact patch lies. */
+  Vector3<T> nhat_BA_W;
+  /* The (undamped) normal contact force at the current configuration before
+   a discrete update is made. With "undamped" we mean this force only contains
+   the compliant component of the model, without the Hunt & Crossley term. */
+  T fn0{0.0};
+  /* The effective discrete stiffness of the contact pair. */
+  T stiffness{0.0};
+  /* The effective damping of the contact pair. */
+  T damping{0.0};
+};
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
This essentially is a refactor on how MBP collects data to be passed to our discrete solver. Nothing changes in terms of functionality. This prepares the internal infrastructure so that in a following PR, enabling discrete hydro only requires a very localized change within `MBP::CalcDiscreteContactPairs()` (introduced in this PR). This localized change is possible due to the fact that we made TAMSI agnostic to the discrete model in, #13696.

### Edit
The Jacobian computation fixes an old TODO and therefore contact results are expected to change so slightly (in the right direction). Not a breaking change, but probably users should be notified in the next release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13734)
<!-- Reviewable:end -->
