### PR TITLE
[geometry] Making contact results deterministic

### DIFF
--- a/geometry/proximity/hydroelastic_callback.h
+++ b/geometry/proximity/hydroelastic_callback.h
@@ -222,6 +222,10 @@ bool Callback(fcl::CollisionObjectd* object_A_ptr,
             type_A, GetGeometryName(*object_A_ptr), encoding_a.id(), type_B,
             GetGeometryName(*object_B_ptr), encoding_b.id()));
       case CalcContactSurfaceResult::kSameCompliance:
+        // TODO(SeanCurtis-TRI): When we introduce soft-soft compliance, make
+        //  sure we always dispatch the two soft objects in a fixed order based
+        //  on their corresponding geometry ids. See penetration_as_point_pair
+        //  Callback for an example.
         throw std::logic_error(fmt::format(
             "Requested contact between two {} objects ({} with id "
             "{}, {} with id {}); only rigid-soft pairs are currently supported",

--- a/geometry/proximity/penetration_as_point_pair_callback.h
+++ b/geometry/proximity/penetration_as_point_pair_callback.h
@@ -51,8 +51,10 @@ struct CallbackData {
   std::vector<PenetrationAsPointPair<double>>& point_pairs;
 };
 
-// Callback function for FCL's collide() function for retrieving a *single*
-// contact.
+/* Callback function for FCL's collide() function for retrieving a *single*
+ contact. As documented by QueryObject::ComputePointPairPenetration(), the
+ result added to the output data is the same, regardless of the order of
+ the two fcl objects.  */
 bool Callback(fcl::CollisionObjectd* fcl_object_A_ptr,
               fcl::CollisionObjectd* fcl_object_B_ptr, void* callback_data);
 

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -174,7 +174,9 @@ class QueryObject {
    -->
 
    @returns A vector populated with all detected penetrations characterized as
-            point pairs.
+            point pairs. The ordering of the results is guaranteed to be
+            consistent -- for fixed geometry poses, the results will remain
+            the same.
    @warning This silently ignores Mesh geometries (but Convex mesh geometries
             are included). */
   std::vector<PenetrationAsPointPair<double>> ComputePointPairPenetration()
@@ -222,7 +224,9 @@ class QueryObject {
    geometry pairs that couldn't be culled.
 
    @returns A vector populated with all detected intersections characterized as
-            contact surfaces.  */
+            contact surfaces. The ordering of the results is guaranteed to be
+            consistent -- for fixed geometry poses, the results will remain
+            the same.  */
   std::vector<ContactSurface<T>> ComputeContactSurfaces() const;
 
   /** Reports pair-wise intersections and characterizes each non-empty
@@ -243,6 +247,9 @@ class QueryObject {
    Because point pairs can only be computed for double-valued systems, this can
    also only support double-valued ContactSurface instances.
 
+   The ordering of the _added_ results is guaranteed to be consistent -- for
+   fixed geometry poses, the results will remain the same.
+
    @param[out] surfaces     The vector that contact surfaces will be added to.
                             The vector will _not_ be cleared.
    @param[out] point_pairs  The vector that fall back point pair data will be
@@ -258,7 +265,9 @@ class QueryObject {
    b) *known* to be separated. The caller is responsible for confirming that
    the remaining, unculled geometry pairs are *actually* in collision.
 
-   @returns A vector populated with collision pair candidates.
+   @returns A vector populated with collision pair candidates (the order will
+            remain constant for a fixed population but can change as geometry
+            ids are added/removed).
    @warning This silently ignores Mesh geometries (but Convex mesh geometries
             are included). */
   std::vector<SortedPair<GeometryId>> FindCollisionCandidates() const;


### PR DESCRIPTION
This encompasses two things:
  1. Guarantees that if objects A and B make contact, that the result is identical regardless of which is "first" or "second".
  2. For multiple contacts, the results will be ordered in a reliable ordering (for a fixed set of poses).

This impacts the following queries documented in QueryObject:
  - ComputePointPairPenetration()
  - ComputeContactSurfaces()
  - ComputeContactSurfacesWithFallback()
  - FindCollisionCandidates()

resolves #13736

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13737)
<!-- Reviewable:end -->
