### PR TITLE
[geometry] Proposed implementation for streamlining of GeometryProperties API

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -200,20 +200,18 @@ class TestPlant(unittest.TestCase):
             self.assertGreater(plant.num_collision_geometries(), 0)
             body0_props = scene_graph.model_inspector().GetProximityProperties(
                 plant.GetCollisionGeometriesForBody(body)[0])
-            body0_friction = body0_props.GetProperty(
-                "material", "coulomb_friction")
+            friction_name = "material/coulomb_friction"
+            body0_friction = body0_props.Get(friction_name)
             self.assertEqual(body0_friction.static_friction(), 0.6)
             self.assertEqual(body0_friction.dynamic_friction(), 0.5)
             explicit_props = ProximityProperties()
-            explicit_props.AddProperty("material", "coulomb_friction",
-                                       CoulombFriction(1.1, 0.8))
+            explicit_props.Add(friction_name, CoulombFriction(1.1, 0.8))
             plant.RegisterCollisionGeometry(
                 body=body, X_BG=body_X_BG, shape=box,
                 name="new_body_collision2", properties=explicit_props)
             body1_props = scene_graph.model_inspector().GetProximityProperties(
                 plant.GetCollisionGeometriesForBody(body)[1])
-            body1_friction = body1_props.GetProperty(
-                "material", "coulomb_friction")
+            body1_friction = body1_props.Get(friction_name)
             self.assertGreater(plant.num_collision_geometries(), 1)
             self.assertEqual(body1_friction.static_friction(), 1.1)
             self.assertEqual(body1_friction.dynamic_friction(), 0.8)

--- a/bindings/pydrake/pydrake_doxygen.h
+++ b/bindings/pydrake/pydrake_doxygen.h
@@ -429,29 +429,30 @@ using Class = MultibodyPlant<T>;
 ...
 ```
 
+<!-- TODO(SeanCurtis-TRI): Once the new API (Add, Update, and Remove) has been
+ added, change these permalinks to refer to those functions.  ->
 As an example for parameter packs,
-`GeometryProperties::AddProperty<ValueType>`
+`GeometryProperties::Add<ValueType>`
 ([code permalink](https://git.io/JfqhL)) is a C++ sugar method that uses
 type erasure and ultimately passes the result to
-`GeometryProperties::AddPropertyAbstract`
-([code permalink](https://git.io/Jfqhm)), and only the `AddPropertyAbstract`
+`GeometryProperties::AddAbstract`
+([code permalink](https://git.io/Jfqhm)), and only the `AddAbstract`
 flavor is used in the bindings, but in such a way that it is similar to the C++
-API for `AddProperty` ([code permalink](https://git.io/JfqiT)):
+API for `Add` ([code permalink](https://git.io/JfqiT)):
 
 ```
 using Class = GeometryProperties;
 py::handle abstract_value_cls =
     py::module::import("pydrake.systems.framework").attr("AbstractValue");
 ...
-    .def("AddProperty",
-        [abstract_value_cls](Class* self, const std::string& group_name,
-            const std::string& name, py::object value) {
+    .def("Add",
+        [abstract_value_cls](
+            Class* self, const std::string& name, py::object value) {
           py::object abstract = abstract_value_cls.attr("Make")(value);
-          self->AddPropertyAbstract(
-              group_name, name, abstract.cast<const AbstractValue&>());
+          self->AddAbstract(name, abstract.cast<const AbstractValue&>());
         },
-        py::arg("group_name"), py::arg("name"), py::arg("value"),
-        cls_doc.AddProperty.doc)
+        py::arg("name"), py::arg("value"),
+        cls_doc.Add.doc)
 ...
 ```
 

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -146,7 +146,7 @@ class TestGeometry(unittest.TestCase):
         # Check AssignRole bits.
         proximity = mut.ProximityProperties()
         perception = mut.PerceptionProperties()
-        perception.AddProperty("label", "id", mut.render.RenderLabel(0))
+        perception.Add("label/id"), mut.render.RenderLabel(0))
         illustration = mut.IllustrationProperties()
         props = [
             proximity,
@@ -554,59 +554,61 @@ class TestGeometry(unittest.TestCase):
         self.assertEqual(prop.Get(name=default_to_update), 20)
 
     def test_geometry_properties_old_api(self):
-        # TODO(SeanCurtis-TRI): This whole test should be deprecated when the
-        #  old API gets deprecated.
-        # Test perception/ illustration properties (specifically Rgba).
-        test_vector = [0., 0., 1., 1.]
-        test_color = mut.Rgba(0., 0., 1., 1.)
-        phong_props = mut.MakePhongIllustrationProperties(test_vector)
-        self.assertIsInstance(phong_props, mut.IllustrationProperties)
-        actual_color = phong_props.GetProperty("phong", "diffuse")
-        self.assertEqual(actual_color, test_color)
-        # Ensure that we can create it manually.
-        phong_props = mut.IllustrationProperties()
-        phong_props.AddProperty("phong", "diffuse", test_color)
-        actual_color = phong_props.GetProperty("phong", "diffuse")
-        self.assertEqual(actual_color, test_color)
-        # Test proximity properties.
-        prop = mut.ProximityProperties()
-        self.assertEqual(str(prop), "drake::geometry::ProximityProperties")
-        default_group = prop.default_group_name()
-        self.assertTrue(prop.HasGroup(group_name=default_group))
-        self.assertEqual(prop.num_groups(), 1)
-        self.assertTrue(default_group in prop.GetGroupNames())
-        prop.AddProperty(group_name=default_group, name="test", value=3)
-        self.assertTrue(prop.HasProperty(group_name=default_group,
-                                         name="test"))
-        self.assertEqual(
-            prop.GetProperty(group_name=default_group, name="test"), 3)
-        self.assertEqual(
-            prop.GetPropertyOrDefault(
-                group_name=default_group, name="empty", default_value=5),
-            5)
-        group_values = prop.GetPropertiesInGroup(group_name=default_group)
-        for name, value in group_values.items():
-            self.assertIsInstance(name, str)
-            self.assertIsInstance(value, AbstractValue)
-        # Remove the property.
-        self.assertTrue(prop.RemoveProperty(group_name=default_group,
-                                            name="test"))
-        self.assertFalse(prop.HasProperty(group_name=default_group,
-                                          name="test"))
-        # Update a property.
-        prop.AddProperty(group_name=default_group, name="to_update", value=17)
-        self.assertTrue(prop.HasProperty(group_name=default_group,
-                                         name="to_update"))
-        self.assertEqual(
-            prop.GetProperty(group_name=default_group, name="to_update"), 17)
+        # We're simply going to catch *all* the deprecation warnings en masse.
+        with catch_drake_warnings(expected_count=15):
+            # Test perception/ illustration properties (specifically Rgba).
+            test_vector = [0., 0., 1., 1.]
+            test_color = mut.Rgba(0., 0., 1., 1.)
+            phong_props = mut.MakePhongIllustrationProperties(test_vector)
+            self.assertIsInstance(phong_props, mut.IllustrationProperties)
+            actual_color = phong_props.GetProperty("phong", "diffuse")
+            self.assertEqual(actual_color, test_color)
+            # Ensure that we can create it manually.
+            phong_props = mut.IllustrationProperties()
+            phong_props.AddProperty("phong", "diffuse", test_color)
+            actual_color = phong_props.GetProperty("phong", "diffuse")
+            self.assertEqual(actual_color, test_color)
+            # Test proximity properties.
+            prop = mut.ProximityProperties()
+            self.assertEqual(str(prop), "drake::geometry::ProximityProperties")
+            default_group = prop.default_group_name()
+            self.assertTrue(prop.HasGroup(group_name=default_group))
+            self.assertEqual(prop.num_groups(), 1)
+            self.assertTrue(default_group in prop.GetGroupNames())
+            prop.AddProperty(group_name=default_group, name="test", value=3)
+            self.assertTrue(prop.HasProperty(group_name=default_group,
+                                             name="test"))
+            self.assertEqual(
+                prop.GetProperty(group_name=default_group, name="test"), 3)
+            self.assertEqual(
+                prop.GetPropertyOrDefault(
+                    group_name=default_group, name="empty", default_value=5),
+                5)
+            group_values = prop.GetPropertiesInGroup(group_name=default_group)
+            for name, value in group_values.items():
+                self.assertIsInstance(name, str)
+                self.assertIsInstance(value, AbstractValue)
+            # Remove the property.
+            self.assertTrue(prop.RemoveProperty(group_name=default_group,
+                                                name="test"))
+            self.assertFalse(prop.HasProperty(group_name=default_group,
+                                              name="test"))
+            # Update a property.
+            prop.AddProperty(group_name=default_group, name="to_update",
+                             value=17)
+            self.assertTrue(prop.HasProperty(group_name=default_group,
+                                             name="to_update"))
+            self.assertEqual(
+                prop.GetProperty(group_name=default_group, name="to_update"),
+                17)
 
-        prop.UpdateProperty(group_name=default_group, name="to_update",
-                            value=20)
-        self.assertTrue(prop.HasProperty(group_name=default_group,
-                                         name="to_update"))
-        self.assertEqual(
-            prop.GetProperty(group_name=default_group, name="to_update"),
-            20)
+            prop.UpdateProperty(group_name=default_group, name="to_update",
+                                value=20)
+            self.assertTrue(prop.HasProperty(group_name=default_group,
+                                             name="to_update"))
+            self.assertEqual(
+                prop.GetProperty(group_name=default_group, name="to_update"),
+                20)
 
         # Property copying.
         for PropertyType in [mut.ProximityProperties,

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -520,6 +520,47 @@ class TestGeometry(unittest.TestCase):
         test_color = mut.Rgba(0., 0., 1., 1.)
         phong_props = mut.MakePhongIllustrationProperties(test_vector)
         self.assertIsInstance(phong_props, mut.IllustrationProperties)
+        phong_diffuse = "phong/diffuse"
+        actual_color = phong_props.Get(phong_diffuse)
+        self.assertEqual(actual_color, test_color)
+        # Ensure that we can create it manually.
+        phong_props = mut.IllustrationProperties()
+        phong_props.Add(phong_diffuse, test_color)
+        actual_color = phong_props.Get(phong_diffuse)
+        self.assertEqual(actual_color, test_color)
+        # Test proximity properties.
+        prop = mut.ProximityProperties()
+        self.assertEqual(str(prop), "drake::geometry::ProximityProperties")
+        default_test = "test"
+        prop.Add(name=default_test, value=3)
+        self.assertTrue(prop.HasProperty(default_test))
+        self.assertEqual(prop.Get(name=default_test), 3)
+        self.assertEqual(
+            prop.GetPropertyOrDefault(
+                name="invalid",
+                default_value=5),
+            5)
+        # Remove the property.
+        self.assertTrue(prop.Remove(name=default_test))
+        self.assertFalse(prop.HasProperty(name=default_test))
+        # Update a property.
+        default_to_update = "to_update"
+        prop.Add(name=default_to_update, value=17)
+        self.assertTrue(prop.HasProperty(name=default_to_update))
+        self.assertEqual(prop.Get(name=default_to_update), 17)
+
+        prop.Update(name=default_to_update, value=20)
+        self.assertTrue(prop.HasProperty(name=default_to_update))
+        self.assertEqual(prop.Get(name=default_to_update), 20)
+
+    def test_geometry_properties_old_api(self):
+        # TODO(SeanCurtis-TRI): This whole test should be deprecated when the
+        #  old API gets deprecated.
+        # Test perception/ illustration properties (specifically Rgba).
+        test_vector = [0., 0., 1., 1.]
+        test_color = mut.Rgba(0., 0., 1., 1.)
+        phong_props = mut.MakePhongIllustrationProperties(test_vector)
+        self.assertIsInstance(phong_props, mut.IllustrationProperties)
         actual_color = phong_props.GetProperty("phong", "diffuse")
         self.assertEqual(actual_color, test_color)
         # Ensure that we can create it manually.
@@ -529,7 +570,7 @@ class TestGeometry(unittest.TestCase):
         self.assertEqual(actual_color, test_color)
         # Test proximity properties.
         prop = mut.ProximityProperties()
-        self.assertEqual(str(prop), "[__default__]")
+        self.assertEqual(str(prop), "drake::geometry::ProximityProperties")
         default_group = prop.default_group_name()
         self.assertTrue(prop.HasGroup(group_name=default_group))
         self.assertEqual(prop.num_groups(), 1)

--- a/doc/python_bindings.rst
+++ b/doc/python_bindings.rst
@@ -382,14 +382,14 @@ Similarly, type-erasure C++ APIs that look like:
 .. code-block:: cpp
 
     InputPort<T>::Eval<ValueType>(context)
-    GeometryProperties::AddProperty<ValueType>(group_name, name, value)
+    GeometryProperties::Add<ValueType>(name, value)
 
 will become the following in Python:
 
 .. code-block:: pycon
 
     InputPort_[T].Eval(context)
-    GeometryProperties.AddProperty(group_name, name, value)
+    GeometryProperties.Add(name, value)
 
 Debugging with the Python Bindings
 ----------------------------------

--- a/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
+++ b/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
@@ -119,7 +119,7 @@ int do_main() {
                                     "wall_collision", std::move(prox_prop));
 
     geometry::IllustrationProperties illus_prop;
-    illus_prop.AddProperty("phong", "diffuse", Vector4d(0.7, 0.5, 0.4, 0.5));
+    illus_prop.Add("phong/diffuse", Vector4d(0.7, 0.5, 0.4, 0.5));
     plant.RegisterVisualGeometry(plant.world_body(), X_WB, wall, "wall_visual",
                                  std::move(illus_prop));
   }

--- a/examples/planar_gripper/gripper_brick.cc
+++ b/examples/planar_gripper/gripper_brick.cc
@@ -208,12 +208,12 @@ GripperBrickHelper<T>::GetFingerTipBrickCoulombFriction(Finger finger) const {
           finger_tip_sphere_geometry_id(finger));
 
   const multibody::CoulombFriction<T>& brick_friction =
-      brick_props.GetProperty<multibody::CoulombFriction<T>>(
-          "material", "coulomb_friction");
+      brick_props.Get<multibody::CoulombFriction<T>>(
+          {"material", "coulomb_friction"});
 
   const multibody::CoulombFriction<T>& finger_tip_friction =
-      finger_props.GetProperty<multibody::CoulombFriction<T>>(
-          "material", "coulomb_friction");
+      finger_props.Get<multibody::CoulombFriction<T>>(
+          {"material", "coulomb_friction"});
 
   return multibody::CalcContactFrictionFromSurfaceProperties(
       brick_friction, finger_tip_friction);

--- a/examples/scene_graph/bouncing_ball_plant.cc
+++ b/examples/scene_graph/bouncing_ball_plant.cc
@@ -64,10 +64,8 @@ BouncingBallPlant<T>::BouncingBallPlant(SourceId source_id,
   scene_graph->AssignRole(source_id, ball_id_, IllustrationProperties());
   scene_graph->AssignRole(source_id, ball_id_, ProximityProperties());
   PerceptionProperties perception_properties;
-  perception_properties.AddProperty("phong", "diffuse",
-                                    Vector4d{0.8, 0.8, 0.8, 1.0});
-  perception_properties.AddProperty("label", "id",
-                                    RenderLabel(ball_id_.get_value()));
+  perception_properties.Add("phong/diffuse", Vector4d{0.8, 0.8, 0.8, 1.0})
+      .Add("label/id", RenderLabel(ball_id_.get_value()));
   scene_graph->AssignRole(source_id, ball_id_, perception_properties);
 
   // Allocate the output port now that the frame has been registered.

--- a/examples/scene_graph/bouncing_ball_run_dynamics.cc
+++ b/examples/scene_graph/bouncing_ball_run_dynamics.cc
@@ -106,8 +106,8 @@ int do_main() {
 
   if (FLAGS_render_on) {
     PerceptionProperties properties;
-    properties.AddProperty("phong", "diffuse", Vector4d{0.8, 0.8, 0.8, 1.0});
-    properties.AddProperty("label", "id", RenderLabel(ground_id.get_value()));
+    properties.Add("phong/diffuse", Vector4d{0.8, 0.8, 0.8, 1.0})
+        .Add("label/id", RenderLabel(ground_id.get_value()));
     scene_graph->AssignRole(global_source, ground_id, properties);
 
     // Create the camera.

--- a/examples/scene_graph/simple_contact_surface_vis.cc
+++ b/examples/scene_graph/simple_contact_surface_vis.cc
@@ -114,7 +114,7 @@ class MovingBall final : public LeafSystem<double> {
     scene_graph->AssignRole(source_id_, geometry_id_, prox_props);
 
     IllustrationProperties illus_props;
-    illus_props.AddProperty("phong", "diffuse", Vector4d(0.8, 0.1, 0.1, 0.25));
+    illus_props.Add("phong/diffuse", Vector4d(0.8, 0.1, 0.1, 0.25));
     scene_graph->AssignRole(source_id_, geometry_id_, illus_props);
 
     geometry_pose_port_ =
@@ -292,8 +292,7 @@ int do_main() {
   AddRigidHydroelasticProperties(edge_len, &rigid_props);
   scene_graph.AssignRole(source_id, ground_id, rigid_props);
   IllustrationProperties illustration_box;
-  illustration_box.AddProperty("phong", "diffuse",
-                               Vector4d{0.5, 0.5, 0.45, 1.0});
+  illustration_box.Add("phong/diffuse", Vector4d{0.5, 0.5, 0.45, 1.0});
   scene_graph.AssignRole(source_id, ground_id, illustration_box);
 
   // Add arbitrary cylinder to bang into -- this should crash in strict
@@ -308,8 +307,8 @@ int do_main() {
   }
   scene_graph.AssignRole(source_id, can_id, std::move(proximity_cylinder));
   IllustrationProperties illustration_cylinder;
-  illustration_cylinder.AddProperty("phong", "diffuse",
-                                    Vector4d{0.5, 0.5, 0.45, 0.5});
+  illustration_cylinder.Add("phong/diffuse",
+                            Vector4d{0.5, 0.5, 0.45, 0.5});
   scene_graph.AssignRole(source_id, can_id, illustration_cylinder);
 
   // Make and visualize contacts.

--- a/examples/scene_graph/solar_system.cc
+++ b/examples/scene_graph/solar_system.cc
@@ -51,7 +51,7 @@ unique_ptr<GeometryInstance> MakeShape(const RigidTransformd& pose,
   auto instance = make_unique<GeometryInstance>(
       pose, make_unique<Shape>(std::forward<ShapeArgs>(args)...), name);
   IllustrationProperties properties;
-  properties.AddProperty("phong", "diffuse", diffuse);
+  properties.Add("phong/diffuse", diffuse);
   instance->set_illustration_properties(properties);
   return instance;
 }

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -166,6 +166,9 @@ drake_cc_library(
     deps = [
         ":geometry_properties",
         "//common:essential",
+        "//geometry/proximity:hydroelastic_type",
+        "//geometry/proximity:tessellation_strategy",
+        "//multibody/plant:coulomb_friction",
     ],
 )
 
@@ -201,6 +204,7 @@ drake_cc_library(
     hdrs = ["proximity_properties.h"],
     deps = [
         ":geometry_roles",
+        "//geometry/proximity:hydroelastic_type",
         "//multibody/plant:coulomb_friction",
     ],
 )
@@ -388,9 +392,10 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
-    name = "geometry_version_test",
+    name = "geometry_roles_test",
     deps = [
-        ":geometry_version",
+        ":geometry_roles",
+        "//common/test_utilities",
     ],
 )
 
@@ -410,6 +415,13 @@ drake_cc_googletest(
         ":geometry_state",
         "//common/test_utilities",
         "//geometry/test_utilities:dummy_render_engine",
+    ],
+)
+
+drake_cc_googletest(
+    name = "geometry_version_test",
+    deps = [
+        ":geometry_version",
     ],
 )
 

--- a/geometry/benchmarking/render_benchmark.cc
+++ b/geometry/benchmarking/render_benchmark.cc
@@ -185,8 +185,8 @@ const double kFovY = M_PI_4;
 class RenderEngineBenchmark : public benchmark::Fixture {
  public:
   RenderEngineBenchmark() {
-    material_.AddProperty("phong", "diffuse", sphere_rgba_);
-    material_.AddProperty("label", "id", RenderLabel::kDontCare);
+    material_.Add("phong/diffuse", sphere_rgba_)
+        .Add("label/id", RenderLabel::kDontCare);
   }
 
   using benchmark::Fixture::SetUp;

--- a/geometry/drake_visualizer.cc
+++ b/geometry/drake_visualizer.cc
@@ -261,12 +261,12 @@ void DrakeVisualizer::SendLoadMessage(
       const GeometryProperties* illus_props =
           inspector.GetIllustrationProperties(g_id);
       if (illus_props) {
-        default_color = illus_props->GetPropertyOrDefault("phong", "diffuse",
+        default_color = illus_props->GetPropertyOrDefault("phong/diffuse",
                                                           default_color);
       }
     }
     const Rgba& color =
-        props->GetPropertyOrDefault("phong", "diffuse", default_color);
+        props->GetPropertyOrDefault("phong/diffuse", default_color);
     return ShapeToLcm().Convert(shape, inspector.GetPoseInFrame(g_id), color);
   };
 

--- a/geometry/geometry_properties.cc
+++ b/geometry/geometry_properties.cc
@@ -56,11 +56,17 @@ bool GeometryProperties::Remove(const string& name) {
 }
 
 bool GeometryProperties::HasGroup(const string& group_name) const {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   return GetGroupNames().count(group_name) > 0;
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
 }
 
 int GeometryProperties::num_groups() const {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   return static_cast<int>(GetGroupNames().size());
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
 }
 
 GeometryProperties::Group GeometryProperties::GetPropertiesInGroup(

--- a/geometry/geometry_properties.h
+++ b/geometry/geometry_properties.h
@@ -10,6 +10,7 @@
 #include <Eigen/Dense>
 
 #include "drake/common/copyable_unique_ptr.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/never_destroyed.h"
 #include "drake/common/value.h"
 #include "drake/geometry/rgba.h"
@@ -366,22 +367,27 @@ class GeometryProperties {
 
   /** Returns `true` if any property starts with the string `group_name + "/"`.
    */
+  DRAKE_DEPRECATED("2020-11-01", "Groups will no longer be used")
   bool HasGroup(const std::string& group_name) const;
 
   /** Reports the number of "groups" (see HasGroup() for definition of a group).
    */
+  DRAKE_DEPRECATED("2020-11-01", "Groups will no longer be used")
   int num_groups() const;
 
   /** Returns a *copy* of all of the properties whose names begin with the
    substring `group_name + "/"`.  */
+  DRAKE_DEPRECATED("2020-11-01", "Groups will no longer be used")
   Group GetPropertiesInGroup(const std::string& group_name) const;
 
   /** Returns all the unique group names (see HasGroup() for the definition of
    a group).  */
+  DRAKE_DEPRECATED("2020-11-01", "Groups will no longer be used")
   std::set<std::string> GetGroupNames() const;
 
   /** Variant of Add() on the property "group_name/name".  */
   template <typename ValueType>
+  DRAKE_DEPRECATED("2020-11-01", "Please use Add instead of AddProperty")
   void AddProperty(const std::string& group_name, const std::string& name,
                    const ValueType& value) {
     Add(encode_group(group_name, name), value);
@@ -389,12 +395,15 @@ class GeometryProperties {
 
   /** Variant of Update() on the property "group_name/name".  */
   template <typename ValueType>
+  DRAKE_DEPRECATED("2020-11-01", "Please use Update instead of UpdateProperty")
   void UpdateProperty(const std::string& group_name, const std::string& name,
                       const ValueType& value) {
     Update(encode_group(group_name, name), value);
   }
 
   /** Variant of AddAbstract() on the property "group_name/name".  */
+  DRAKE_DEPRECATED("2020-11-01", "Please use AddAbstract instead of "
+                                 "AddPropertyAbstract")
   void AddPropertyAbstract(const std::string& group_name,
                            const std::string& name,
                            const AbstractValue& value) {
@@ -402,6 +411,8 @@ class GeometryProperties {
   }
 
   /** Variant of UpdateAbstract() on the property "group_name/name".  */
+  DRAKE_DEPRECATED("2020-11-01", "Please use UpdateAbstract instead of "
+                                 "UpdatePropertyAbstract")
   void UpdatePropertyAbstract(const std::string& group_name,
                               const std::string& name,
                               const AbstractValue& value) {
@@ -409,6 +420,8 @@ class GeometryProperties {
   }
 
   /** Variant of HasProperty() on the property "group_name/name".  */
+  DRAKE_DEPRECATED("2020-11-01", "Please use HasProperty(string) "
+                                 "instead of HasProperty(string, string)")
   bool HasProperty(const std::string& group_name,
                    const std::string& name) const {
     return HasProperty(encode_group(group_name, name));
@@ -416,12 +429,15 @@ class GeometryProperties {
 
   /** Variant of Get() on the property "group_name/name".  */
   template <typename ValueType>
+  DRAKE_DEPRECATED("2020-11-01", "Please use Get instead of GetProperty")
   decltype(auto) GetProperty(const std::string& group_name,
                              const std::string& name) const {
     return Get<ValueType>(encode_group(group_name, name));
   }
 
   /** Variant of GetAbstract() on the property "group_name/name".  */
+  DRAKE_DEPRECATED("2020-11-01", "Please use GetAbstract instead of "
+                                 "GetPropertyAbstract")
   const AbstractValue& GetPropertyAbstract(const std::string& group_name,
                                            const std::string& name) const {
     return GetAbstract(encode_group(group_name, name));
@@ -429,6 +445,9 @@ class GeometryProperties {
 
   /** Variant of GetPropertyOrDefault() on the property "group_name/name".  */
   template <typename ValueType>
+  DRAKE_DEPRECATED("2020-11-01",
+                   "Please use GetPropertyOrDefault(string, value) "
+                   "instead of GetPropertyOrDefault(string, string, value)")
   ValueType GetPropertyOrDefault(const std::string& group_name,
                                  const std::string& name,
                                  ValueType default_value) const {
@@ -438,12 +457,15 @@ class GeometryProperties {
   /** Returns the default group name. There is no guarantee as to _what_ string
    corresponds to the default group. Therefore it should always be accessed via
    this method.  */
+  DRAKE_DEPRECATED("2020-11-01", "Groups will no longer be used")
   static const std::string& default_group_name() {
     static const never_destroyed<std::string> kDefaultGroup("");
     return kDefaultGroup.access();
   }
 
   /** Variant of Remove() where ('group_name', 'name') are given explicitly.  */
+  DRAKE_DEPRECATED("2020-11-01",
+                   "Please use Remove instead of RemoveProperty")
   bool RemoveProperty(const std::string& group_name, const std::string& name) {
     return Remove(encode_group(group_name, name));
   }
@@ -452,22 +474,27 @@ class GeometryProperties {
 
 #ifndef DRAKE_DOXYGEN_CXX
   // Note: these overloads of the property access methods exist to enable
-  // calls like `properties.Add({"group", "property"}, "string literal");
+  // calls like `properties.Add("group/property", "string literal");
   // Template matching would deduce that the `ValueType` in this case is a const
   // char* (which is not copyable). By explicitly declaring this API, we can
   // implicitly convert the string literals to copyable std::strings. We assume
   // that the user is never actually trying to store const char*. We omit
   // these from the doxygen because they provide no value there.
+  DRAKE_DEPRECATED("2020-11-01", "Please use Add instead of AddProperty")
   void AddProperty(const std::string& group_name, const std::string& name,
                    const char* value) {
     Add<std::string>(encode_group(group_name, name), value);
   }
 
+  DRAKE_DEPRECATED("2020-11-01", "Please use Uppdate instead of UpdateProperty")
   void UpdateProperty(const std::string& group_name, const std::string& name,
                       const char* value) {
     Update<std::string>(encode_group(group_name, name), value);
   }
 
+  DRAKE_DEPRECATED("2020-11-01",
+                   "Please use GetPropertyOrDefault(string, value) "
+                   "instead of GetPropertyOrDefault(string, string, value)")
   std::string GetPropertyOrDefault(const std::string& group_name,
                                    const std::string& name,
                                    const char* default_value) const {

--- a/geometry/geometry_roles.cc
+++ b/geometry/geometry_roles.cc
@@ -27,7 +27,7 @@ std::ostream& operator<<(std::ostream& out, const Role& role) {
 IllustrationProperties MakePhongIllustrationProperties(
     const Vector4<double>& diffuse) {
   IllustrationProperties props;
-  props.AddProperty("phong", "diffuse", diffuse);
+  props.Add("phong/diffuse", diffuse);
   return props;
 }
 

--- a/geometry/geometry_roles.cc
+++ b/geometry/geometry_roles.cc
@@ -2,6 +2,10 @@
 
 #include <string>
 
+#include "drake/geometry/proximity/hydroelastic_type.h"
+#include "drake/geometry/proximity/tessellation_strategy.h"
+#include "drake/multibody/plant/coulomb_friction.h"
+
 namespace drake {
 namespace geometry {
 
@@ -29,6 +33,56 @@ IllustrationProperties MakePhongIllustrationProperties(
   IllustrationProperties props;
   props.Add("phong/diffuse", diffuse);
   return props;
+}
+
+namespace {
+
+// Various functions to use with DoThrowIfInvalid.
+bool is_positive_double(const double& value) { return value > 0.0; }
+
+bool is_nonnegative_double(const double& value) { return value >= 0.0; }
+
+template <typename ValueType>
+bool always_true(const ValueType&) {
+  return true;
+}
+
+bool has_defined_compliance(const internal::HydroelasticType& value) {
+  return value != internal::HydroelasticType::kUndefined;
+}
+
+}  // namespace
+
+void ProximityProperties::DoThrowIfInvalid(const PropertyName& property,
+                                           const AbstractValue& value) const {
+  if (property == material_elastic_modulus()) {
+    ValidateOrThrow<double>(property, value, &is_positive_double,
+                            "value must be > 0");
+  } else if (property == material_coulomb_friction()) {
+    ValidateOrThrow<multibody::CoulombFriction<double>>(
+        property, value, always_true<multibody::CoulombFriction<double>>,
+        "any valid friction");
+  } else if (property == material_hunt_crossley_dissipation()) {
+    ValidateOrThrow<double>(property, value, is_nonnegative_double,
+                            "value must be >= 0");
+  } else if (property == material_point_contact_stiffness()) {
+    ValidateOrThrow<double>(property, value, is_positive_double,
+                    "value must be > 0");
+  } else if (property == hydroelastic_resolution_hint()) {
+    ValidateOrThrow<double>(property, value, is_positive_double,
+                            "value must be > 0");
+  } else if (property == hydroelastic_slab_thickness()) {
+    ValidateOrThrow<double>(property, value, is_positive_double,
+                            "value must be > 0");
+  } else if (property == hydroelastic_compliance_type()) {
+    ValidateOrThrow<internal::HydroelasticType>(
+        property, value, has_defined_compliance,
+        "compliance can't be undefined");
+  } else if (property == hydrolastic_tessellation_strategy()) {
+    ValidateOrThrow<internal::TessellationStrategy>(
+        property, value, always_true<internal::TessellationStrategy>,
+        "any valid strategy");
+  }
 }
 
 }  // namespace geometry

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -780,7 +780,7 @@ void GeometryState<T>::AssignRole(SourceId source_id, GeometryId geometry_id,
   //  need to handle these changes.
 
   auto accepting_renderers =
-      properties.GetPropertyOrDefault("renderer", "accepting", set<string>{});
+      properties.GetPropertyOrDefault("renderer/accepting", set<string>{});
 
   geometry.SetRole(std::move(properties));
 
@@ -812,7 +812,7 @@ template <typename T>
 void GeometryState<T>::AssignRole(SourceId source_id, GeometryId geometry_id,
                                   IllustrationProperties properties,
                                   RoleAssign assign) {
-  if (properties.HasProperty("phong", "diffuse_map")) {
+  if (properties.HasProperty("phong/diffuse_map")) {
     static logging::Warn log_once(
         "Explicitly defined values for the phong/diffuse_map property "
         "are not currently used in illustration roles -- only perception "

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -814,7 +814,7 @@ void GeometryState<T>::AssignRole(SourceId source_id, GeometryId geometry_id,
                                   RoleAssign assign) {
   if (properties.HasProperty("phong", "diffuse_map")) {
     static logging::Warn log_once(
-        "Explicitly defined values for the ('phong', 'diffuse_map') property "
+        "Explicitly defined values for the phong/diffuse_map property "
         "are not currently used in illustration roles -- only perception "
         "roles");
   }

--- a/geometry/geometry_visualization.cc
+++ b/geometry/geometry_visualization.cc
@@ -229,7 +229,7 @@ lcmt_viewer_load_robot GeometryVisualizationImpl::BuildLoadMessage(
       if (props != nullptr) {
         const Shape& shape = geometry.shape();
         const Vector4d& color = props->GetPropertyOrDefault(
-            "phong", "diffuse", default_color);
+            "phong/diffuse", default_color);
         message.link[0].geom[geom_index] = MakeGeometryData(
             shape, geometry.X_FG(), color);
         ++geom_index;
@@ -259,7 +259,7 @@ lcmt_viewer_load_robot GeometryVisualizationImpl::BuildLoadMessage(
       if (props != nullptr) {
         const Shape& shape = geometry.shape();
         const Vector4d& color = props->GetPropertyOrDefault(
-            "phong", "diffuse", default_color);
+            "phong/diffuse", default_color);
         message.link[link_index].geom[geom_index] =
             MakeGeometryData(shape, geometry.X_FG(), color);
         ++geom_index;

--- a/geometry/profiling/contact_surface_rigid_bowl_soft_ball.cc
+++ b/geometry/profiling/contact_surface_rigid_bowl_soft_ball.cc
@@ -173,7 +173,7 @@ class MovingSoftGeometry final : public LeafSystem<double> {
     scene_graph->AssignRole(source_id_, geometry_id_, prox_props);
 
     IllustrationProperties illus_props;
-    illus_props.AddProperty("phong", "diffuse", Vector4d(0.8, 0.1, 0.1, 0.25));
+    illus_props.Add("phong/diffuse", Vector4d(0.8, 0.1, 0.1, 0.25));
     scene_graph->AssignRole(source_id_, geometry_id_, illus_props);
 
     geometry_pose_port_ =
@@ -338,7 +338,7 @@ int do_main() {
   AddRigidHydroelasticProperties(FLAGS_resolution_hint, &rigid_props);
   scene_graph.AssignRole(source_id, rigid_geometry_id, rigid_props);
   IllustrationProperties illus_props;
-  illus_props.AddProperty("phong", "diffuse", Vector4d{0.5, 0.5, 0.45, 0.25});
+  illus_props.Add("phong/diffuse", Vector4d{0.5, 0.5, 0.45, 0.25});
   scene_graph.AssignRole(source_id, rigid_geometry_id, illus_props);
 
   // Make and visualize contacts.

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -25,6 +25,7 @@ drake_cc_package_library(
         ":find_collision_candidates_callback",
         ":hydroelastic_callback",
         ":hydroelastic_internal",
+        ":hydroelastic_type",
         ":make_box_field",
         ":make_box_mesh",
         ":make_cylinder_field",
@@ -236,6 +237,13 @@ drake_cc_library(
         "//geometry:shape_specification",
         "@fmt",
     ],
+)
+
+drake_cc_library(
+    name = "hydroelastic_type",
+    srcs = ["hydroelastic_type.cc"],
+    hdrs = ["hydroelastic_type.h"],
+    deps = ["//common:essential"],
 )
 
 drake_cc_library(

--- a/geometry/proximity/hydroelastic_internal.cc
+++ b/geometry/proximity/hydroelastic_internal.cc
@@ -122,12 +122,12 @@ void Geometries::AddGeometry(GeometryId id, RigidGeometry geometry) {
 }
 
 // Validator interface for use with extracting valid properties. It is
-// instantiated with shape (e.g., "Sphere", "Box", etc.) and compliance (i.e.,
-// "rigid" or "soft") strings (to help give intelligible error messages) and
-// then attempts to extract a typed value from a set of proximity properties --
-// spewing meaningful error messages based on absence, type mismatch, and
-// invalid values.
-template <typename ValueType>
+// instantiated with shape name (e.g., "Sphere", "Box", etc.) and compliance
+// (i.e., "rigid" or "soft") strings (to help give intelligible error messages)
+// and then attempts to extract a typed value from a set of proximity properties
+// -- spewing meaningful error messages if missing. When using _canonical_
+// proximity properties, we assume that type and value has been validated prior
+// to being stored in the properties.
 class Validator {
  public:
   // Parameters `shape_name` and `compliance` are only for error messages.
@@ -139,47 +139,20 @@ class Validator {
   // Extract an arbitrary property from the proximity properties. Throws a
   // consistent error message in the case of missing or mis-typed properties.
   // Relies on the ValidateValue() method to validate the value.
+  template <typename ValueType>
   const ValueType& Extract(const ProximityProperties& props,
-                           const std::string& PropName) {
-    if (!props.HasProperty(PropName)) {
+                           const std::string& property) {
+    if (!props.HasProperty(property)) {
       throw std::logic_error(
           fmt::format("Cannot create {} {}; missing the {} property",
-                      compliance(), shape_name(), PropName));
+                      compliance(), shape_name(), property));
     }
-    const auto& value = props.Get<ValueType>(PropName);
-    ValidateValue(value, PropName);
-    return value;
+    return props.Get<ValueType>(property);
   }
-
- protected:
-  const char* shape_name() const { return shape_name_; }
-  const char* compliance() const { return compliance_; }
-
-  // Does the work of validating the given value. Sub-classes should throw if
-  // the provided value is not valid. The first parameter is the value to
-  // validate; the second is the name of the property in question.
-  virtual void ValidateValue(const ValueType&, const std::string&) const {}
 
  private:
   const char* shape_name_{};
   const char* compliance_{};
-};
-
-// Validator that extracts *positive doubles*.
-class PositiveDouble : public Validator<double> {
- public:
-  // Inherit the constructor from the base class.
-  using Validator<double>::Validator;
-
- protected:
-  void ValidateValue(const double& value,
-                     const std::string& PropName) const override {
-    if (value <= 0) {
-      throw std::logic_error(
-          fmt::format("Cannot create {} {}; the {} property must be positive",
-                      compliance(), shape_name(), PropName));
-    }
-  }
 };
 
 std::optional<RigidGeometry> MakeRigidRepresentation(
@@ -189,9 +162,9 @@ std::optional<RigidGeometry> MakeRigidRepresentation(
 
 std::optional<RigidGeometry> MakeRigidRepresentation(
     const Sphere& sphere, const ProximityProperties& props) {
-  PositiveDouble validator("Sphere", "rigid");
+  Validator validator("Sphere", "rigid");
   const double edge_length =
-      validator.Extract(props, PropName(kHydroGroup, kRezHint));
+      validator.Extract<double>(props, props.hydroelastic_resolution_hint());
   auto mesh = make_unique<SurfaceMesh<double>>(
       MakeSphereSurfaceMesh<double>(sphere, edge_length));
 
@@ -212,9 +185,9 @@ std::optional<RigidGeometry> MakeRigidRepresentation(
 
 std::optional<RigidGeometry> MakeRigidRepresentation(
     const Cylinder& cylinder, const ProximityProperties& props) {
-  PositiveDouble validator("Cylinder", "rigid");
+  Validator validator("Cylinder", "rigid");
   const double edge_length =
-      validator.Extract(props, PropName(kHydroGroup, kRezHint));
+      validator.Extract<double>(props, props.hydroelastic_resolution_hint());
   auto mesh = make_unique<SurfaceMesh<double>>(
       MakeCylinderSurfaceMesh<double>(cylinder, edge_length));
 
@@ -223,9 +196,9 @@ std::optional<RigidGeometry> MakeRigidRepresentation(
 
 std::optional<RigidGeometry> MakeRigidRepresentation(
     const Ellipsoid& ellipsoid, const ProximityProperties& props) {
-  PositiveDouble validator("Ellipsoid", "rigid");
+  Validator validator("Ellipsoid", "rigid");
   const double edge_length =
-      validator.Extract(props, PropName(kHydroGroup, kRezHint));
+      validator.Extract<double>(props, props.hydroelastic_resolution_hint());
   auto mesh = make_unique<SurfaceMesh<double>>(
       MakeEllipsoidSurfaceMesh<double>(ellipsoid, edge_length));
 
@@ -252,19 +225,19 @@ std::optional<RigidGeometry> MakeRigidRepresentation(
 
 std::optional<SoftGeometry> MakeSoftRepresentation(
     const Sphere& sphere, const ProximityProperties& props) {
-  PositiveDouble validator("Sphere", "soft");
+  Validator validator("Sphere", "soft");
   // First, create the mesh.
   const double edge_length =
-      validator.Extract(props, PropName(kHydroGroup, kRezHint));
+      validator.Extract<double>(props, props.hydroelastic_resolution_hint());
   // If nothing is said, let's go for the *cheap* tessellation strategy.
   const TessellationStrategy strategy =
-      props.GetPropertyOrDefault(PropName(kHydroGroup, "tessellation_strategy"),
+      props.GetPropertyOrDefault(props.hydrolastic_tessellation_strategy(),
                                  TessellationStrategy::kSingleInteriorVertex);
   auto mesh = make_unique<VolumeMesh<double>>(
       MakeSphereVolumeMesh<double>(sphere, edge_length, strategy));
 
   const double elastic_modulus =
-      validator.Extract(props, PropName(kMaterialGroup, kElastic));
+      validator.Extract<double>(props, props.material_elastic_modulus());
 
   auto pressure = make_unique<VolumeMeshFieldLinear<double, double>>(
       MakeSpherePressureField(sphere, mesh.get(), elastic_modulus));
@@ -274,13 +247,13 @@ std::optional<SoftGeometry> MakeSoftRepresentation(
 
 std::optional<SoftGeometry> MakeSoftRepresentation(
     const Box& box, const ProximityProperties& props) {
-  PositiveDouble validator("Box", "soft");
+  Validator validator("Box", "soft");
   // First, create the mesh.
   auto mesh =
       make_unique<VolumeMesh<double>>(MakeBoxVolumeMeshWithMa<double>(box));
 
   const double elastic_modulus =
-      validator.Extract(props, PropName(kMaterialGroup, kElastic));
+      validator.Extract<double>(props, props.material_elastic_modulus());
 
   auto pressure = make_unique<VolumeMeshFieldLinear<double, double>>(
       MakeBoxPressureField(box, mesh.get(), elastic_modulus));
@@ -290,15 +263,15 @@ std::optional<SoftGeometry> MakeSoftRepresentation(
 
 std::optional<SoftGeometry> MakeSoftRepresentation(
     const Cylinder& cylinder, const ProximityProperties& props) {
-  PositiveDouble validator("Cylinder", "soft");
+  Validator validator("Cylinder", "soft");
   // First, create the mesh.
   const double edge_length =
-      validator.Extract(props, PropName(kHydroGroup, kRezHint));
+      validator.Extract<double>(props, props.hydroelastic_resolution_hint());
   auto mesh = make_unique<VolumeMesh<double>>(
       MakeCylinderVolumeMesh<double>(cylinder, edge_length));
 
   const double elastic_modulus =
-      validator.Extract(props, PropName(kMaterialGroup, kElastic));
+      validator.Extract<double>(props, props.material_elastic_modulus());
 
   auto pressure = make_unique<VolumeMeshFieldLinear<double, double>>(
       MakeCylinderPressureField(cylinder, mesh.get(), elastic_modulus));
@@ -308,19 +281,19 @@ std::optional<SoftGeometry> MakeSoftRepresentation(
 
 std::optional<SoftGeometry> MakeSoftRepresentation(
     const Ellipsoid& ellipsoid, const ProximityProperties& props) {
-  PositiveDouble validator("Ellipsoid", "soft");
+  Validator validator("Ellipsoid", "soft");
   // First, create the mesh.
   const double edge_length =
-      validator.Extract(props, PropName(kHydroGroup, kRezHint));
+      validator.Extract<double>(props, props.hydroelastic_resolution_hint());
   // If nothing is said, let's go for the *cheap* tessellation strategy.
   const TessellationStrategy strategy =
-      props.GetPropertyOrDefault(PropName(kHydroGroup, "tessellation_strategy"),
+      props.GetPropertyOrDefault(props.hydrolastic_tessellation_strategy(),
                                  TessellationStrategy::kSingleInteriorVertex);
   auto mesh = make_unique<VolumeMesh<double>>(
       MakeEllipsoidVolumeMesh<double>(ellipsoid, edge_length, strategy));
 
   const double elastic_modulus =
-      validator.Extract(props, PropName(kMaterialGroup, kElastic));
+      validator.Extract<double>(props, props.material_elastic_modulus());
 
   auto pressure = make_unique<VolumeMeshFieldLinear<double, double>>(
       MakeEllipsoidPressureField(ellipsoid, mesh.get(), elastic_modulus));
@@ -330,13 +303,13 @@ std::optional<SoftGeometry> MakeSoftRepresentation(
 
 std::optional<SoftGeometry> MakeSoftRepresentation(
     const HalfSpace&, const ProximityProperties& props) {
-  PositiveDouble validator("HalfSpace", "soft");
+  Validator validator("HalfSpace", "soft");
 
   const double thickness =
-      validator.Extract(props, PropName(kHydroGroup, kSlabThickness));
+      validator.Extract<double>(props, props.hydroelastic_slab_thickness());
 
   const double elastic_modulus =
-      validator.Extract(props, PropName(kMaterialGroup, kElastic));
+      validator.Extract<double>(props, props.material_elastic_modulus());
 
   return SoftGeometry(SoftHalfSpace{elastic_modulus / thickness});
 }

--- a/geometry/proximity/hydroelastic_internal.cc
+++ b/geometry/proximity/hydroelastic_internal.cc
@@ -51,7 +51,7 @@ void Geometries::RemoveGeometry(GeometryId id) {
 void Geometries::MaybeAddGeometry(const Shape& shape, GeometryId id,
                                   const ProximityProperties& properties) {
   const HydroelasticType type = properties.GetPropertyOrDefault(
-      PropName(kHydroGroup, kComplianceType), HydroelasticType::kUndefined);
+      properties.hydroelastic_compliance_type(), HydroelasticType::kUndefined);
   if (type != HydroelasticType::kUndefined) {
     ReifyData data{type, id, properties};
     shape.Reify(this, &data);

--- a/geometry/proximity/hydroelastic_internal.cc
+++ b/geometry/proximity/hydroelastic_internal.cc
@@ -142,7 +142,7 @@ class Validator {
   const ValueType& Extract(const ProximityProperties& props,
                            const char* group_name, const char* property_name) {
     const std::string full_property_name =
-        fmt::format("('{}', '{}')", group_name, property_name);
+        fmt::format("{}/{}", group_name, property_name);
     if (!props.HasProperty(group_name, property_name)) {
       throw std::logic_error(
           fmt::format("Cannot create {} {}; missing the {} property",

--- a/geometry/proximity/hydroelastic_internal.h
+++ b/geometry/proximity/hydroelastic_internal.h
@@ -378,8 +378,7 @@ std::optional<RigidGeometry> MakeRigidRepresentation(
   return {};
 }
 
-/* Rigid sphere support. Requires the ('hydroelastic', 'resolution_hint')
- property.  */
+/* Rigid sphere support. Requires the hydroelastic/resolution_hint property.  */
 std::optional<RigidGeometry> MakeRigidRepresentation(
     const Sphere& sphere, const ProximityProperties& props);
 
@@ -387,13 +386,13 @@ std::optional<RigidGeometry> MakeRigidRepresentation(
 std::optional<RigidGeometry> MakeRigidRepresentation(
     const Box& box, const ProximityProperties& props);
 
-/* Rigid cylinder support. Requires the ('hydroelastic', 'resolution_hint')
- property.  */
+/* Rigid cylinder support. Requires the hydroelastic/resolution_hint property.
+ */
 std::optional<RigidGeometry> MakeRigidRepresentation(
     const Cylinder& cylinder, const ProximityProperties& props);
 
-/* Rigid ellipsoid support. Requires the ('hydroelastic', 'resolution_hint')
- property.  */
+/* Rigid ellipsoid support. Requires the hydroelastic/resolution_hint property.
+ */
 std::optional<RigidGeometry> MakeRigidRepresentation(
     const Ellipsoid& ellipsoid, const ProximityProperties& props);
 
@@ -426,31 +425,31 @@ std::optional<SoftGeometry> MakeSoftRepresentation(const Shape& shape,
 }
 
 /* Creates a soft sphere (assuming the proximity properties have sufficient
- information). Requires the ('hydroelastic', 'resolution_hint') and
- ('material', 'elastic_modulus') properties.  */
+ information). Requires the hydroelastic/resolution_hint and
+ material/elastic_modulus properties.  */
 std::optional<SoftGeometry> MakeSoftRepresentation(
     const Sphere& sphere, const ProximityProperties& props);
 
 /* Creates a soft box (assuming the proximity properties have sufficient
- information). Requires the ('material', 'elastic_modulus') properties.  */
+ information). Requires the material/elastic_modulus property.  */
 std::optional<SoftGeometry> MakeSoftRepresentation(
     const Box& box, const ProximityProperties& props);
 
 /* Creates a soft cylinder (assuming the proximity properties have sufficient
- information). Requires the ('hydroelastic', 'resolution_hint') and
- ('material', 'elastic_modulus') properties.  */
+ information). Requires the hydroelastic/resolution_hint and
+ material/elastic_modulus properties.  */
 std::optional<SoftGeometry> MakeSoftRepresentation(
     const Cylinder& cylinder, const ProximityProperties& props);
 
 /* Creates a soft ellipsoid (assuming the proximity properties have sufficient
- information). Requires the ('hydroelastic', 'resolution_hint') and
- ('material', 'elastic_modulus') properties.  */
+ information). Requires the hydroelastic/resolution_hint and
+ material/elastic_modulus properties.  */
 std::optional<SoftGeometry> MakeSoftRepresentation(
     const Ellipsoid& ellipsoid, const ProximityProperties& props);
 
 /* Creates a compliant half space (assuming the proximity properties have
- sufficient information). Requires the ('hydroelastic', 'slab_thickness') and
- ('material', 'elastic_modulus') properties.  */
+ sufficient information). Requires the hydroelastic/slab_thickness and
+ material/elastic_modulus properties.  */
 std::optional<SoftGeometry> MakeSoftRepresentation(
     const HalfSpace& half_space, const ProximityProperties& props);
 

--- a/geometry/proximity/hydroelastic_type.cc
+++ b/geometry/proximity/hydroelastic_type.cc
@@ -1,0 +1,28 @@
+#include "drake/geometry/proximity/hydroelastic_type.h"
+
+#include "drake/common/drake_assert.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+std::ostream& operator<<(std::ostream& out, const HydroelasticType& type) {
+  switch (type) {
+    case HydroelasticType::kUndefined:
+      out << "undefined";
+      break;
+    case HydroelasticType::kRigid:
+      out << "rigid";
+      break;
+    case HydroelasticType::kSoft:
+      out << "soft";
+      break;
+    default:
+      DRAKE_UNREACHABLE();
+  }
+  return out;
+}
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/hydroelastic_type.h
+++ b/geometry/proximity/hydroelastic_type.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <iostream>
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+// TODO(SeanCurtis-TRI): Update this to have an additional classification: kBoth
+//  when we have the need from the algorithm. For example: when we have two
+//  very stiff objects, we'd want to process them as soft. But when one
+//  very stiff and one very soft object interact, it might make sense to
+//  consider the stiff object as effectively rigid and simplify the computation.
+//  In this case, the object would get two representations.
+/* Classification of the type of representation a shape has for the
+ hydroelastic contact model: rigid or soft.  */
+enum class HydroelasticType { kUndefined, kRigid, kSoft };
+
+/* Streaming operator for writing hydroelastic type to output stream.  */
+std::ostream& operator<<(std::ostream& out, const HydroelasticType& type);
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/hydroelastic_callback_test.cc
+++ b/geometry/proximity/test/hydroelastic_callback_test.cc
@@ -47,7 +47,7 @@ ProximityProperties soft_properties() {
   AddSoftHydroelasticProperties(resolution_hint, &props);
   // Redundantly add slab thickness so it can be used with compliant mesh or
   // compliant half space.
-  props.Add(PropName(kHydroGroup, kSlabThickness), 0.25);
+  props.Add(props.hydroelastic_slab_thickness(), 0.25);
   return props;
 }
 

--- a/geometry/proximity/test/hydroelastic_callback_test.cc
+++ b/geometry/proximity/test/hydroelastic_callback_test.cc
@@ -47,7 +47,7 @@ ProximityProperties soft_properties() {
   AddSoftHydroelasticProperties(resolution_hint, &props);
   // Redundantly add slab thickness so it can be used with compliant mesh or
   // compliant half space.
-  props.AddProperty(kHydroGroup, kSlabThickness, 0.25);
+  props.Add(PropName(kHydroGroup, kSlabThickness), 0.25);
   return props;
 }
 

--- a/geometry/proximity/test/hydroelastic_internal_test.cc
+++ b/geometry/proximity/test/hydroelastic_internal_test.cc
@@ -704,8 +704,8 @@ void TestPropertyErrors(
     // This error message comes from GeometryProperties::GetProperty().
     DRAKE_EXPECT_THROWS_MESSAGE(
         maker(shape_spec, wrong_value), std::logic_error,
-        fmt::format(".*The property \\('{}', '{}'\\) exists, but is of a "
-                    "different type.+string'",
+        fmt::format(".*The property '{}/{}' exists, but is of a different "
+                    "type.+string'",
                     group_name, property_name));
   }
 

--- a/geometry/proximity/test/hydroelastic_internal_test.cc
+++ b/geometry/proximity/test/hydroelastic_internal_test.cc
@@ -693,7 +693,7 @@ void TestPropertyErrors(
   {
     DRAKE_EXPECT_THROWS_MESSAGE(
         maker(shape_spec, props), std::logic_error,
-        fmt::format("Cannot create {} {}.+'{}'\\) property", compliance,
+        fmt::format("Cannot create {} {}.+{} property", compliance,
                     shape_name, property_name));
   }
 
@@ -715,7 +715,7 @@ void TestPropertyErrors(
     negative_value.AddProperty(group_name, property_name, *bad_value);
     DRAKE_EXPECT_THROWS_MESSAGE(
         maker(shape_spec, negative_value), std::logic_error,
-        fmt::format("Cannot create {} {}.+'{}'.+ positive", compliance,
+        fmt::format("Cannot create {} {}.+{}.+ positive", compliance,
                     shape_name, property_name));
   }
 }

--- a/geometry/proximity_properties.cc
+++ b/geometry/proximity_properties.cc
@@ -15,23 +15,6 @@ const char* const kRezHint = "resolution_hint";
 const char* const kComplianceType = "compliance_type";
 const char* const kSlabThickness = "slab_thickness";
 
-std::ostream& operator<<(std::ostream& out, const HydroelasticType& type) {
-  switch (type) {
-    case HydroelasticType::kUndefined:
-      out << "undefined";
-      break;
-    case HydroelasticType::kRigid:
-      out << "rigid";
-      break;
-    case HydroelasticType::kSoft:
-      out << "soft";
-      break;
-    default:
-      DRAKE_UNREACHABLE();
-  }
-  return out;
-}
-
 std::string PropName(const std::string& group, const std::string& prop) {
   return group + "/" + prop;
 }

--- a/geometry/proximity_properties.cc
+++ b/geometry/proximity_properties.cc
@@ -4,21 +4,6 @@ namespace drake {
 namespace geometry {
 namespace internal {
 
-const char* const kMaterialGroup = "material";
-const char* const kElastic = "elastic_modulus";
-const char* const kFriction = "coulomb_friction";
-const char* const kHcDissipation = "hunt_crossley_dissipation";
-const char* const kPointStiffness = "point_contact_stiffness";
-
-const char* const kHydroGroup = "hydroelastic";
-const char* const kRezHint = "resolution_hint";
-const char* const kComplianceType = "compliance_type";
-const char* const kSlabThickness = "slab_thickness";
-
-std::string PropName(const std::string& group, const std::string& prop) {
-  return group + "/" + prop;
-}
-
 }  // namespace internal
 
 using internal::PropName;
@@ -43,17 +28,15 @@ void AddContactMaterial(
       throw std::logic_error(fmt::format(
           "The elastic modulus must be positive; given {}", *elastic_modulus));
     }
-    properties->Add(PropName(internal::kMaterialGroup, internal::kElastic),
-                    *elastic_modulus);
+    properties->Add(properties->material_elastic_modulus(), *elastic_modulus);
   }
   if (dissipation.has_value()) {
     if (*dissipation < 0) {
       throw std::logic_error(fmt::format(
           "The dissipation can't be negative; given {}", *dissipation));
     }
-    properties->Add(
-        PropName(internal::kMaterialGroup, internal::kHcDissipation),
-        *dissipation);
+    properties->Add(properties->material_hunt_crossley_dissipation(),
+                    *dissipation);
   }
 
   if (point_stiffness.has_value()) {
@@ -62,14 +45,12 @@ void AddContactMaterial(
           "The point_contact_stiffness must be strictly positive; given {}",
           *point_stiffness));
     }
-    properties->Add(
-        PropName(internal::kMaterialGroup, internal::kPointStiffness),
-        *point_stiffness);
+    properties->Add(properties->material_point_contact_stiffness(),
+                    *point_stiffness);
   }
 
   if (friction.has_value()) {
-    properties->Add(PropName(internal::kMaterialGroup, internal::kFriction),
-                    *friction);
+    properties->Add(properties->material_coulomb_friction(), *friction);
   }
 }
 
@@ -79,8 +60,7 @@ void AddContactMaterial(
 void AddRigidHydroelasticProperties(double resolution_hint,
                                     ProximityProperties* properties) {
   DRAKE_DEMAND(properties);
-  properties->Add(PropName(internal::kHydroGroup, internal::kRezHint),
-                  resolution_hint);
+  properties->Add(properties->hydroelastic_resolution_hint(), resolution_hint);
   AddRigidHydroelasticProperties(properties);
 }
 
@@ -89,15 +69,14 @@ void AddRigidHydroelasticProperties(ProximityProperties* properties) {
   // The bare minimum of defining a rigid geometry is to declare its compliance
   // type. Downstream consumers (ProximityEngine) will determine if this is
   // sufficient.
-  properties->Add(PropName(internal::kHydroGroup, internal::kComplianceType),
+  properties->Add(properties->hydroelastic_compliance_type(),
                   internal::HydroelasticType::kRigid);
 }
 
 void AddSoftHydroelasticProperties(double resolution_hint,
                                    ProximityProperties* properties) {
   DRAKE_DEMAND(properties);
-  properties->Add(PropName(internal::kHydroGroup, internal::kRezHint),
-                  resolution_hint);
+  properties->Add(properties->hydroelastic_resolution_hint(), resolution_hint);
   AddSoftHydroelasticProperties(properties);
 }
 
@@ -106,15 +85,14 @@ void AddSoftHydroelasticProperties(ProximityProperties* properties) {
   // The bare minimum of defining a soft geometry is to declare its compliance
   // type. Downstream consumers (ProximityEngine) will determine if this is
   // sufficient.
-  properties->Add(PropName(internal::kHydroGroup, internal::kComplianceType),
+  properties->Add(properties->hydroelastic_compliance_type(),
                   internal::HydroelasticType::kSoft);
 }
 
 void AddSoftHydroelasticPropertiesForHalfSpace(
     double slab_thickness, ProximityProperties* properties) {
   DRAKE_DEMAND(properties);
-  properties->Add(PropName(internal::kHydroGroup, internal::kSlabThickness),
-                  slab_thickness);
+  properties->Add(properties->hydroelastic_slab_thickness(), slab_thickness);
   AddSoftHydroelasticProperties(properties);
 }
 

--- a/geometry/proximity_properties.cc
+++ b/geometry/proximity_properties.cc
@@ -13,7 +13,7 @@ const char* const kPointStiffness = "point_contact_stiffness";
 const char* const kHydroGroup = "hydroelastic";
 const char* const kRezHint = "resolution_hint";
 const char* const kComplianceType = "compliance_type";
-const char* const  kSlabThickness = "slab_thickness";
+const char* const kSlabThickness = "slab_thickness";
 
 std::ostream& operator<<(std::ostream& out, const HydroelasticType& type) {
   switch (type) {
@@ -32,7 +32,13 @@ std::ostream& operator<<(std::ostream& out, const HydroelasticType& type) {
   return out;
 }
 
+std::string PropName(const std::string& group, const std::string& prop) {
+  return group + "/" + prop;
+}
+
 }  // namespace internal
+
+using internal::PropName;
 
 void AddContactMaterial(
     const std::optional<double>& elastic_modulus,
@@ -48,21 +54,23 @@ void AddContactMaterial(
     const std::optional<double>& point_stiffness,
     const std::optional<multibody::CoulombFriction<double>>& friction,
     ProximityProperties* properties) {
+
   if (elastic_modulus.has_value()) {
     if (*elastic_modulus <= 0) {
       throw std::logic_error(fmt::format(
           "The elastic modulus must be positive; given {}", *elastic_modulus));
     }
-    properties->AddProperty(internal::kMaterialGroup, internal::kElastic,
-                            *elastic_modulus);
+    properties->Add(PropName(internal::kMaterialGroup, internal::kElastic),
+                    *elastic_modulus);
   }
   if (dissipation.has_value()) {
     if (*dissipation < 0) {
       throw std::logic_error(fmt::format(
           "The dissipation can't be negative; given {}", *dissipation));
     }
-    properties->AddProperty(internal::kMaterialGroup, internal::kHcDissipation,
-                            *dissipation);
+    properties->Add(
+        PropName(internal::kMaterialGroup, internal::kHcDissipation),
+        *dissipation);
   }
 
   if (point_stiffness.has_value()) {
@@ -71,13 +79,14 @@ void AddContactMaterial(
           "The point_contact_stiffness must be strictly positive; given {}",
           *point_stiffness));
     }
-    properties->AddProperty(internal::kMaterialGroup, internal::kPointStiffness,
-                            *point_stiffness);
+    properties->Add(
+        PropName(internal::kMaterialGroup, internal::kPointStiffness),
+        *point_stiffness);
   }
 
   if (friction.has_value()) {
-    properties->AddProperty(internal::kMaterialGroup, internal::kFriction,
-                            *friction);
+    properties->Add(PropName(internal::kMaterialGroup, internal::kFriction),
+                    *friction);
   }
 }
 
@@ -87,8 +96,8 @@ void AddContactMaterial(
 void AddRigidHydroelasticProperties(double resolution_hint,
                                     ProximityProperties* properties) {
   DRAKE_DEMAND(properties);
-  properties->AddProperty(internal::kHydroGroup, internal::kRezHint,
-                          resolution_hint);
+  properties->Add(PropName(internal::kHydroGroup, internal::kRezHint),
+                  resolution_hint);
   AddRigidHydroelasticProperties(properties);
 }
 
@@ -97,15 +106,15 @@ void AddRigidHydroelasticProperties(ProximityProperties* properties) {
   // The bare minimum of defining a rigid geometry is to declare its compliance
   // type. Downstream consumers (ProximityEngine) will determine if this is
   // sufficient.
-  properties->AddProperty(internal::kHydroGroup, internal::kComplianceType,
-                          internal::HydroelasticType::kRigid);
+  properties->Add(PropName(internal::kHydroGroup, internal::kComplianceType),
+                  internal::HydroelasticType::kRigid);
 }
 
 void AddSoftHydroelasticProperties(double resolution_hint,
                                    ProximityProperties* properties) {
   DRAKE_DEMAND(properties);
-  properties->AddProperty(internal::kHydroGroup, internal::kRezHint,
-                          resolution_hint);
+  properties->Add(PropName(internal::kHydroGroup, internal::kRezHint),
+                  resolution_hint);
   AddSoftHydroelasticProperties(properties);
 }
 
@@ -114,15 +123,15 @@ void AddSoftHydroelasticProperties(ProximityProperties* properties) {
   // The bare minimum of defining a soft geometry is to declare its compliance
   // type. Downstream consumers (ProximityEngine) will determine if this is
   // sufficient.
-  properties->AddProperty(internal::kHydroGroup, internal::kComplianceType,
-                          internal::HydroelasticType::kSoft);
+  properties->Add(PropName(internal::kHydroGroup, internal::kComplianceType),
+                  internal::HydroelasticType::kSoft);
 }
 
 void AddSoftHydroelasticPropertiesForHalfSpace(
     double slab_thickness, ProximityProperties* properties) {
   DRAKE_DEMAND(properties);
-  properties->AddProperty(internal::kHydroGroup, internal::kSlabThickness,
-                          slab_thickness);
+  properties->Add(PropName(internal::kHydroGroup, internal::kSlabThickness),
+                  slab_thickness);
   AddSoftHydroelasticProperties(properties);
 }
 

--- a/geometry/proximity_properties.h
+++ b/geometry/proximity_properties.h
@@ -17,66 +17,6 @@
 
 namespace drake {
 namespace geometry {
-namespace internal {
-
-/* @name  Declaring general contact material properties
-
- String constants used to access the contact material properties that
- SceneGraph depends on. These are not the exhaustive set of contact material
- properties that downstream consumers (e.g., MultibodyPlant) may require.
-
- As the namespace indicates, these are for internal use only, so Drake entities
- can implicitly coordinate the values they use to define proximity properties.
- These strings don't suggest what constitutes a valid property *value*. For
- those definitions, one should refer to the consumer of the properties (as
- called out in the documentation of the ProximityProperties class).  */
-//@{
-
-extern const char* const kMaterialGroup;   ///< The contact material group name.
-extern const char* const kElastic;         ///< Elastic modulus property name.
-extern const char* const kFriction;        ///< Friction coefficients property
-                                           ///< name.
-extern const char* const kHcDissipation;   ///< Hunt-Crossley dissipation
-                                           ///< property name.
-extern const char* const kPointStiffness;  ///< Point stiffness property
-                                           ///< name.
-
-//@}
-
-/* @name  Declaring geometry for hydroelastic contact.
-
- In order for a geometry to be used in hydroelastic contact, it must be declared
- as such. The declaration consists of setting a number of properties in the
- geometry's associated ProximityProperties.
-
- These utilities include:
-
-   - string constants to read and write the indicated properties, and
-   - utility functions for declaring consistent hydroelastic properties
-     including
-       - differentiating between a rigid and soft geometry
-       - accounting for differences between tessellated meshes and half spaces.
-
- @todo Add reference to discussion of hydroelastic proximity properties along
- the lines of "For the full discussion of preparing geometry for use in the
- hydroelastic contact model, see `@ref MODULE_NOT_WRITTEN_YET`.
- */
-//@{
-
-extern const char* const kHydroGroup;       ///< Hydroelastic group name.
-extern const char* const kRezHint;          ///< Resolution hint property name.
-extern const char* const kComplianceType;   ///< Compliance type property name.
-extern const char* const kSlabThickness;    ///< Slab thickness property name
-                                            ///< (for half spaces).
-
-//@}
-
-// TODO(SeanCurtis-TRI) This is a short-term hack to convert call sites that
-//  look like {group, prop} into the single string format. Remove this when
-//  I kill off all of the above char*.
-std::string PropName(const std::string& group, const std::string& prop);
-
-}  // namespace internal
 
 /**
  * @anchor contact_material_utility_functions

--- a/geometry/proximity_properties.h
+++ b/geometry/proximity_properties.h
@@ -12,6 +12,7 @@
 #include <string>
 
 #include "drake/geometry/geometry_roles.h"
+#include "drake/geometry/proximity/hydroelastic_type.h"
 #include "drake/multibody/plant/coulomb_friction.h"
 
 namespace drake {
@@ -74,23 +75,6 @@ extern const char* const kSlabThickness;    ///< Slab thickness property name
 //  look like {group, prop} into the single string format. Remove this when
 //  I kill off all of the above char*.
 std::string PropName(const std::string& group, const std::string& prop);
-
-// TODO(SeanCurtis-TRI): Update this to have an additional classification: kBoth
-//  when we have the need from the algorithm. For example: when we have two
-//  very stiff objects, we'd want to process them as soft. But when one
-//  very stiff and one very soft object interact, it might make sense to
-//  consider the stiff object as effectively rigid and simplify the computation.
-//  In this case, the object would get two representations.
-/* Classification of the type of representation a shape has for the
- hydroelastic contact model: rigid or soft.  */
-enum class HydroelasticType {
-  kUndefined,
-  kRigid,
-  kSoft
-};
-
-/* Streaming operator for writing hydroelastic type to output stream.  */
-std::ostream& operator<<(std::ostream& out, const HydroelasticType& type);
 
 }  // namespace internal
 

--- a/geometry/proximity_properties.h
+++ b/geometry/proximity_properties.h
@@ -9,6 +9,7 @@
 
 #include <optional>
 #include <ostream>
+#include <string>
 
 #include "drake/geometry/geometry_roles.h"
 #include "drake/multibody/plant/coulomb_friction.h"
@@ -68,6 +69,11 @@ extern const char* const kSlabThickness;    ///< Slab thickness property name
                                             ///< (for half spaces).
 
 //@}
+
+// TODO(SeanCurtis-TRI) This is a short-term hack to convert call sites that
+//  look like {group, prop} into the single string format. Remove this when
+//  I kill off all of the above char*.
+std::string PropName(const std::string& group, const std::string& prop);
 
 // TODO(SeanCurtis-TRI): Update this to have an additional classification: kBoth
 //  when we have the need from the algorithm. For example: when we have two

--- a/geometry/render/gl_renderer/render_engine_gl.cc
+++ b/geometry/render/gl_renderer/render_engine_gl.cc
@@ -80,7 +80,7 @@ class DefaultRgbaColorShader final : public ShaderProgram {
   std::optional<ShaderProgramData> DoCreateProgramData(
       const PerceptionProperties& properties) const final {
     const Rgba rgba =
-        properties.GetPropertyOrDefault("phong", "diffuse", default_diffuse_);
+        properties.GetPropertyOrDefault("phong/diffuse", default_diffuse_);
     Vector4<float> v4{
         static_cast<float>(rgba.r()), static_cast<float>(rgba.g()),
         static_cast<float>(rgba.b()), static_cast<float>(rgba.a())};
@@ -193,16 +193,15 @@ class DefaultTextureColorShader final : public internal::ShaderProgram {
 
   std::optional<ShaderProgramData>
   DoCreateProgramData(const PerceptionProperties& properties) const final {
-    if (!properties.HasProperty("phong", "diffuse_map")) return std::nullopt;
+    if (!properties.HasProperty("phong/diffuse_map")) return std::nullopt;
 
-    const string& file_name =
-        properties.GetProperty<string>("phong", "diffuse_map");
+    const string& file_name = properties.Get<string>("phong/diffuse_map");
     std::optional<GLuint> texture_id = library_->GetTextureId(file_name);
 
     if (!texture_id.has_value()) return std::nullopt;
 
     const auto& scale = properties.GetPropertyOrDefault(
-        "phong", "diffuse_scale", Vector2d(1, 1));
+        "phong/diffuse_scale", Vector2d(1, 1));
     return ShaderProgramData{shader_id(), AbstractValue::Make(
       InstanceData{*texture_id, scale.cast<float>()})};
   }
@@ -689,7 +688,7 @@ void RenderEngineGl::ImplementMesh(const internal::OpenGlGeometry& geometry,
                                    const Vector3<double>& scale,
                                    const std::string& file_name) {
   const RegistrationData& data = *static_cast<RegistrationData*>(user_data);
-  if (data.properties.HasProperty("phong", "diffuse_map")) {
+  if (data.properties.HasProperty("phong/diffuse_map")) {
     ImplementGeometry(geometry, user_data, scale);
     return;
   }
@@ -704,7 +703,7 @@ void RenderEngineGl::ImplementMesh(const internal::OpenGlGeometry& geometry,
   PerceptionProperties temp_props(data.properties);
   filesystem::path file_path(file_name);
   const string png_name = file_path.replace_extension(".png").string();
-  temp_props.AddProperty("phong", "diffuse_map", png_name);
+  temp_props.Add("phong/diffuse_map", png_name);
   RegistrationData temp_data{data.id, data.X_WG, temp_props};
   ImplementGeometry(geometry, &temp_data, scale);
 }

--- a/geometry/render/gl_renderer/test/render_engine_gl_test.cc
+++ b/geometry/render/gl_renderer/test/render_engine_gl_test.cc
@@ -343,11 +343,11 @@ class RenderEngineGlTest : public ::testing::Test {
 
     if (add_terrain) {
       PerceptionProperties material;
-      material.AddProperty("label", "id", RenderLabel::kDontCare);
-      material.AddProperty("phong", "diffuse", kTerrainColor);
-      engine->RegisterVisual(GeometryId::get_new_id(), HalfSpace(), material,
-                             RigidTransformd::Identity(),
-                             false /* needs update */);
+      material.Add("label/id", RenderLabel::kDontCare);
+      material.Add("phong/diffuse", kTerrainColor);
+      renderer_->RegisterVisual(GeometryId::get_new_id(), HalfSpace(), material,
+                                RigidTransformd::Identity(),
+                                false /* needs update */);
     }
   }
 
@@ -356,13 +356,12 @@ class RenderEngineGlTest : public ::testing::Test {
   // this method.
   PerceptionProperties simple_material(bool use_texture = false) const {
     PerceptionProperties material;
-    material.AddProperty("phong", "diffuse", default_color_);
-    material.AddProperty("label", "id", expected_label_);
+    material.Add("phong/diffuse", default_color_);
+    material.Add("label/id", expected_label_);
     if (use_texture) {
-      material.AddProperty(
-          "phong", "diffuse_map",
-          FindResourceOrThrow(
-              "drake/systems/sensors/test/models/meshes/box.png"));
+      material.Add("phong/diffuse_map",
+                   FindResourceOrThrow(
+                       "drake/systems/sensors/test/models/meshes/box.png"));
     }
     return material;
   }
@@ -622,13 +621,13 @@ TEST_F(RenderEngineGlTest, BoxTest) {
       // the un-tiled default behavior and the ability to scale the texture.
       PerceptionProperties props = simple_material(false);
       if (use_texture) {
-        props.AddProperty(
-            "phong", "diffuse_map",
+        props.Add(
+            "phong/diffuse_map",
             FindResourceOrThrow(
                 "drake/geometry/render/test/diag_gradient.png"));
         if (texture_scaled) {
-          props.AddProperty(
-              "phong", "diffuse_scale", Vector2d{texture_scale, texture_scale});
+          props.Add(
+              "phong/diffuse_scale", Vector2d{texture_scale, texture_scale});
         }
       }
       renderer_->RegisterVisual(id, box, props,
@@ -925,7 +924,7 @@ TEST_F(RenderEngineGlTest, MeshTest) {
   // NOTE: Specifying a diffuse map with a known bad path, will force the box
   // to get the diffuse RGBA value (otherwise it would pick up the `box.png`
   // texture).
-  material.AddProperty("phong", "diffuse_map", "bad_path");
+  material.Add("phong/diffuse_map", "bad_path");
   const GeometryId id = GeometryId::get_new_id();
   renderer_->RegisterVisual(id, mesh, material, RigidTransformd::Identity(),
                             true /* needs update */);
@@ -946,8 +945,8 @@ TEST_F(RenderEngineGlTest, TextureMeshTest) {
   Mesh mesh(filename);
   expected_label_ = RenderLabel(4);
   PerceptionProperties material = simple_material();
-  material.AddProperty(
-      "phong", "diffuse_map",
+  material.Add(
+      "phong/diffuse_map",
       FindResourceOrThrow("drake/systems/sensors/test/models/meshes/box.png"));
   const GeometryId id = GeometryId::get_new_id();
   renderer_->RegisterVisual(id, mesh, material, RigidTransformd::Identity(),
@@ -1012,7 +1011,7 @@ TEST_F(RenderEngineGlTest, ConvexTest) {
   // NOTE: Specifying a diffuse map with a known bad path, will force the box
   // to get the diffuse RGBA value (otherwise it would pick up the `box.png`
   // texture.
-  material.AddProperty("phong", "diffuse_map", "bad_path");
+  material.Add("phong/diffuse_map", "bad_path");
   const GeometryId id = GeometryId::get_new_id();
   renderer_->RegisterVisual(id, convex, material, RigidTransformd::Identity(),
                             true /* needs update */);
@@ -1074,8 +1073,8 @@ TEST_F(RenderEngineGlTest, RemoveVisual) {
     const float depth = kDefaultDistance - kRadius - z;
     RenderLabel label = RenderLabel(5);
     PerceptionProperties material;
-    material.AddProperty("label", "id", label);
-    material.AddProperty("phong", "diffuse", kDefaultVisualColor);
+    material.Add("label/id", label);
+    material.Add("phong/diffuse", kDefaultVisualColor);
     // This will accept all registered geometries and therefore, (bool)index
     // should always be true.
     renderer_->RegisterVisual(geometry_id, sphere, material,
@@ -1293,7 +1292,7 @@ TEST_F(RenderEngineGlTest, DefaultProperties) {
       std::logic_error,
       ".* geometry with the 'unspecified' or 'empty' render labels.*");
   PerceptionProperties material;
-  material.AddProperty("label", "id", RenderLabel::kDontCare);
+  material.Add("label/id", RenderLabel::kDontCare);
   renderer_->RegisterVisual(id, box, material, RigidTransformd::Identity(),
                             true);
   RigidTransformd X_WV{Translation3d(0, 0, 0.5)};
@@ -1394,7 +1393,7 @@ TEST_F(RenderEngineGlTest, RendererIndependence) {
 
   auto add_terrain = [ground](auto* renderer) {
     PerceptionProperties material;
-    material.AddProperty("label", "id", RenderLabel::kDontCare);
+    material.Add("label/id", RenderLabel::kDontCare);
     renderer->RegisterVisual(ground, HalfSpace(), material,
                              RigidTransformd::Identity(),
                              false /* needs update */);

--- a/geometry/render/gl_renderer/test/shader_program_test.cc
+++ b/geometry/render/gl_renderer/test/shader_program_test.cc
@@ -68,8 +68,8 @@ class TestShader final : public ShaderProgram {
   std::optional<ShaderProgramData> DoCreateProgramData(
       const PerceptionProperties& properties) const override {
     Data data;
-    data.i_value = properties.GetProperty<int>("test", "i_value");
-    data.d_value = properties.GetProperty<double>("test", "d_value");
+    data.i_value = properties.Get<int>("test/i_value");
+    data.d_value = properties.Get<double>("test/d_value");
     return ShaderProgramData{shader_id(), AbstractValue::Make(data)};
   }
 
@@ -333,8 +333,7 @@ TEST_F(ShaderProgramTest, CreateProgramData) {
   PerceptionProperties props;
   const int i_value{17};
   const double d_value{18.5};
-  props.AddProperty("test", "i_value", i_value);
-  props.AddProperty("test", "d_value", d_value);
+  props.Add("test/i_value", i_value).Add("test/d_value", d_value);
 
   std::optional<ShaderProgramData> data = shader_ptr->CreateProgramData(props);
   ASSERT_NE(data, std::nullopt);

--- a/geometry/render/render_engine.cc
+++ b/geometry/render/render_engine.cc
@@ -70,7 +70,7 @@ bool RenderEngine::has_geometry(GeometryId id) const {
 RenderLabel RenderEngine::GetRenderLabelOrThrow(
     const PerceptionProperties& properties) const {
   RenderLabel label =
-      properties.GetPropertyOrDefault("label", "id", default_render_label_);
+      properties.GetPropertyOrDefault("label/id", default_render_label_);
   if (label == RenderLabel::kUnspecified || label == RenderLabel::kEmpty) {
     throw std::logic_error(
         "Cannot register a geometry with the 'unspecified' or 'empty' render "

--- a/geometry/render/render_engine_ospray.cc
+++ b/geometry/render/render_engine_ospray.cc
@@ -473,8 +473,7 @@ void RenderEngineOspray::ImplementGeometry(vtkPolyDataAlgorithm* source,
   // TODO(SeanCurtis-TRI): Modify this once OSPRay-specific materials are
   //  supported.
   const std::string& diffuse_map_name =
-      data.properties.GetPropertyOrDefault<std::string>("phong", "diffuse_map",
-                                                        "");
+      data.properties.GetPropertyOrDefault("phong/diffuse_map", "");
   // Legacy support for *implied* texture maps. If we have mesh.obj, we look for
   // mesh.png (unless one has been specifically called out in the properties).
   // TODO(SeanCurtis-TRI): Remove this legacy texture when objects and materials
@@ -506,7 +505,7 @@ void RenderEngineOspray::ImplementGeometry(vtkPolyDataAlgorithm* source,
     color_actor->SetTexture(texture.Get());
   } else {
     const Vector4d& diffuse =
-        data.properties.GetPropertyOrDefault("phong", "diffuse",
+        data.properties.GetPropertyOrDefault({"phong", "diffuse"},
                                              default_diffuse_);
     color_actor->GetProperty()->SetColor(diffuse(0), diffuse(1), diffuse(2));
     color_actor->GetProperty()->SetOpacity(diffuse(3));

--- a/geometry/render/render_engine_vtk.cc
+++ b/geometry/render/render_engine_vtk.cc
@@ -595,8 +595,7 @@ void RenderEngineVtk::ImplementGeometry(vtkPolyDataAlgorithm* source,
   // Color actor.
   auto& color_actor = actors[ImageType::kColor];
   const std::string& diffuse_map_name =
-      data.properties.GetPropertyOrDefault<std::string>("phong", "diffuse_map",
-                                                        "");
+      data.properties.GetPropertyOrDefault("phong/diffuse_map", "");
   // Legacy support for *implied* texture maps. If we have mesh.obj, we look for
   // mesh.png (unless one has been specifically called out in the properties).
   // TODO(SeanCurtis-TRI): Remove this legacy texture when objects and materials
@@ -620,7 +619,7 @@ void RenderEngineVtk::ImplementGeometry(vtkPolyDataAlgorithm* source,
   }
   if (!texture_name.empty()) {
     const Vector2d& uv_scale = data.properties.GetPropertyOrDefault(
-        "phong", "diffuse_scale", Vector2d{1, 1});
+        "phong/diffuse_scale", Vector2d{1, 1});
     vtkNew<vtkPNGReader> texture_reader;
     texture_reader->SetFileName(texture_name.c_str());
     texture_reader->Update();
@@ -632,7 +631,7 @@ void RenderEngineVtk::ImplementGeometry(vtkPolyDataAlgorithm* source,
     color_actor->SetTexture(texture.Get());
   } else {
     const Vector4d& diffuse =
-        data.properties.GetPropertyOrDefault("phong", "diffuse",
+        data.properties.GetPropertyOrDefault("phong/diffuse",
                                              default_diffuse_);
     color_actor->GetProperty()->SetColor(diffuse(0), diffuse(1), diffuse(2));
     color_actor->GetProperty()->SetOpacity(diffuse(3));

--- a/geometry/render/render_engine_vtk_base.cc
+++ b/geometry/render/render_engine_vtk_base.cc
@@ -262,7 +262,7 @@ vtkSmartPointer<vtkPolyDataAlgorithm> CreateVtkBox(
       vtkSmartPointer<DrakeCubeSource>::New();
   vtk_box->set_size({box.width(), box.depth(), box.height()});
   const Vector2d& uv_scale = properties.GetPropertyOrDefault(
-      "phong", "diffuse_scale", Vector2d{1, 1});
+      {"phong", "diffuse_scale"}, Vector2d{1, 1});
   vtk_box->set_uv_scale(uv_scale);
   return vtk_box;
 }

--- a/geometry/render/test/render_engine_ospray_test.cc
+++ b/geometry/render/test/render_engine_ospray_test.cc
@@ -237,10 +237,10 @@ class RenderEngineOsprayTest : public ::testing::Test {
 
     if (add_terrain) {
       PerceptionProperties material;
-      material.AddProperty("label", "id", RenderLabel::kDontCare);
-      material.AddProperty(
-          "phong", "diffuse",
-          Vector4d{kTerrainColorD.r, kTerrainColorD.g, kTerrainColorD.b, 1.0});
+      material.Add("label/id", RenderLabel::kDontCare)
+          .Add("phong/diffuse",
+               Vector4d{kTerrainColorD.r, kTerrainColorD.g, kTerrainColorD.b,
+                        1.0});
       engine->RegisterVisual(GeometryId::get_new_id(), HalfSpace(), material,
                              RigidTransformd::Identity(),
                              false /* needs update */);
@@ -252,12 +252,11 @@ class RenderEngineOsprayTest : public ::testing::Test {
     PerceptionProperties material;
     Vector4d color_n(default_color_.r / 255., default_color_.g / 255.,
                      default_color_.b / 255., default_color_.a / 255.);
-    material.AddProperty("phong", "diffuse", color_n);
+    material.Add("phong/diffuse", color_n);
     if (use_texture) {
-      material.AddProperty(
-          "phong", "diffuse_map",
-          FindResourceOrThrow(
-              "drake/systems/sensors/test/models/meshes/box.png"));
+      material.Add("phong/diffuse_map",
+                   FindResourceOrThrow(
+                       "drake/systems/sensors/test/models/meshes/box.png"));
     }
     return material;
   }
@@ -435,13 +434,12 @@ TEST_F(RenderEngineOsprayTest, BoxTest) {
       // the untiled default behavior and the ability to scale the texture.
       PerceptionProperties props = simple_material(false);
       if (use_texture) {
-        props.AddProperty(
-            "phong", "diffuse_map",
-            FindResourceOrThrow(
-                "drake/geometry/render/test/diag_gradient.png"));
+        props.Add("phong/diffuse_map",
+                  FindResourceOrThrow(
+                      "drake/geometry/render/test/diag_gradient.png"));
         if (texture_scaled) {
-          props.AddProperty(
-              "phong", "diffuse_scale", Vector2d{texture_scale, texture_scale});
+          props.Add("phong/diffuse_scale",
+                    Vector2d{texture_scale, texture_scale});
         }
       }
       renderer_->RegisterVisual(id, box, props,
@@ -690,7 +688,7 @@ TEST_F(RenderEngineOsprayTest, MeshTest) {
       FindResourceOrThrow("drake/systems/sensors/test/models/meshes/box.obj");
   Mesh mesh(filename);
   PerceptionProperties material = simple_material();
-  material.AddProperty("phong", "diffuse_map", "bad_path");
+  material.Add("phong/diffuse_map", "bad_path");
   const GeometryId id = GeometryId::get_new_id();
   renderer_->RegisterVisual(id, mesh, material, RigidTransformd::Identity(),
                             true /* needs update */);
@@ -709,8 +707,8 @@ TEST_F(RenderEngineOsprayTest, TextureMeshTest) {
       FindResourceOrThrow("drake/systems/sensors/test/models/meshes/box.obj");
   Mesh mesh(filename);
   PerceptionProperties material = simple_material();
-  material.AddProperty(
-      "phong", "diffuse_map",
+  material.Add(
+      {"phong", "diffuse_map"},
       FindResourceOrThrow("drake/systems/sensors/test/models/meshes/box.png"));
   const GeometryId id = GeometryId::get_new_id();
   renderer_->RegisterVisual(id, mesh, material, RigidTransformd::Identity(),
@@ -800,7 +798,7 @@ TEST_F(RenderEngineOsprayTest, RemoveVisual) {
     Vector4d norm_diffuse{diffuse.r / 255., diffuse.g / 255., diffuse.b / 255.,
                           diffuse.a / 255.};
     PerceptionProperties material;
-    material.AddProperty("phong", "diffuse", norm_diffuse);
+    material.Add("phong/diffuse", norm_diffuse);
 
     renderer_->RegisterVisual(geometry_id, sphere, material,
                               RigidTransformd::Identity());

--- a/geometry/render/test/render_engine_test.cc
+++ b/geometry/render/test/render_engine_test.cc
@@ -79,7 +79,7 @@ GTEST_TEST(RenderEngine, RegistrationAndUpdate) {
   // failure when providing an invalid render label. (See Case 1.)
   auto make_properties = [](RenderLabel label) {
     PerceptionProperties properties;
-    properties.AddProperty("label", "id", label);
+    properties.Add("label/id", label);
     return properties;
   };
 

--- a/geometry/render/test/render_engine_vtk_test.cc
+++ b/geometry/render/test/render_engine_vtk_test.cc
@@ -344,9 +344,9 @@ class RenderEngineVtkTest : public ::testing::Test {
 
     if (add_terrain) {
       PerceptionProperties material;
-      material.AddProperty("label", "id", RenderLabel::kDontCare);
-      material.AddProperty(
-          "phong", "diffuse",
+      material.Add("label/id", RenderLabel::kDontCare);
+      material.Add(
+          "phong/diffuse",
           Vector4d{kTerrainColorD.r, kTerrainColorD.g, kTerrainColorD.b, 1.0});
       engine->RegisterVisual(GeometryId::get_new_id(), HalfSpace(), material,
                              RigidTransformd::Identity(),
@@ -361,13 +361,12 @@ class RenderEngineVtkTest : public ::testing::Test {
     PerceptionProperties material;
     Vector4d color_n(default_color_.r / 255., default_color_.g / 255.,
                      default_color_.b / 255., default_color_.a / 255.);
-    material.AddProperty("phong", "diffuse", color_n);
-    material.AddProperty("label", "id", expected_label_);
+    material.Add("phong/diffuse", color_n)
+        .Add("label/id", expected_label_);
     if (use_texture) {
-      material.AddProperty(
-          "phong", "diffuse_map",
-          FindResourceOrThrow(
-              "drake/systems/sensors/test/models/meshes/box.png"));
+      material.Add("phong/diffuse_map",
+                   FindResourceOrThrow(
+                       "drake/systems/sensors/test/models/meshes/box.png"));
     }
     return material;
   }
@@ -616,13 +615,12 @@ TEST_F(RenderEngineVtkTest, BoxTest) {
       // the untiled default behavior and the ability to scale the texture.
       PerceptionProperties props = simple_material(false);
       if (use_texture) {
-        props.AddProperty(
-            "phong", "diffuse_map",
-            FindResourceOrThrow(
-                "drake/geometry/render/test/diag_gradient.png"));
+        props.Add("phong/diffuse_map",
+                  FindResourceOrThrow(
+                      "drake/geometry/render/test/diag_gradient.png"));
         if (texture_scaled) {
-          props.AddProperty(
-              "phong", "diffuse_scale", Vector2d{texture_scale, texture_scale});
+          props.Add("phong/diffuse_scale",
+                    Vector2d{texture_scale, texture_scale});
         }
       }
       renderer_->RegisterVisual(id, box, props,
@@ -891,7 +889,7 @@ TEST_F(RenderEngineVtkTest, MeshTest) {
   Mesh mesh(filename);
   expected_label_ = RenderLabel(3);
   PerceptionProperties material = simple_material();
-  material.AddProperty("phong", "diffuse_map", "bad_path");
+  material.Add("phong/diffuse_map", "bad_path");
   const GeometryId id = GeometryId::get_new_id();
   renderer_->RegisterVisual(id, mesh, material, RigidTransformd::Identity(),
                             true /* needs update */);
@@ -911,8 +909,8 @@ TEST_F(RenderEngineVtkTest, TextureMeshTest) {
   Mesh mesh(filename);
   expected_label_ = RenderLabel(4);
   PerceptionProperties material = simple_material();
-  material.AddProperty(
-      "phong", "diffuse_map",
+  material.Add(
+      "phong/diffuse_map",
       FindResourceOrThrow("drake/systems/sensors/test/models/meshes/box.png"));
   const GeometryId id = GeometryId::get_new_id();
   renderer_->RegisterVisual(id, mesh, material, RigidTransformd::Identity(),
@@ -1007,8 +1005,8 @@ TEST_F(RenderEngineVtkTest, RemoveVisual) {
                           diffuse.a / 255.};
     RenderLabel label = RenderLabel(5);
     PerceptionProperties material;
-    material.AddProperty("phong", "diffuse", norm_diffuse);
-    material.AddProperty("label", "id", label);
+    material.Add("phong/diffuse", norm_diffuse)
+        .Add("label/id", label);
     // This will accept all registered geometries and therefore, (bool)index
     // should always be true.
     renderer_->RegisterVisual(geometry_id, sphere, material,
@@ -1272,8 +1270,8 @@ TEST_F(RenderEngineVtkTest, PreservePropertyTexturesOverClone) {
   const GeometryId id = GeometryId::get_new_id();
   const RenderLabel label(12345);  // an arbitrary value.
   PerceptionProperties material;
-  material.AddProperty("phong", "diffuse", Vector4d{1.0, 1.0, 1.0, 1.0});
-  material.AddProperty("label", "id", label);
+  material.Add("phong/diffuse", Vector4d{1.0, 1.0, 1.0, 1.0})
+      .Add("label/id", label);
   engine.RegisterVisual(id, sphere, material, RigidTransformd(),
                         true /* needs update */);
   engine.ApplyColorTextureToGeometry(id, texture_name);

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -705,7 +705,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
 
    By default, a geometry with a perception role will be reified by all
    render::RenderEngine instances. This behavior can be changed. Renderers can
-   be explicitly whitelisted via the ('renderer', 'accepting') perception
+   be explicitly whitelisted via the `renderer/accepting` perception
    property. Its type is std::set<std::string> and it contains the names of
    all the renderers that _may_ reify it. If no property is defined (or an
    empty set is given), then the default behavior of all renderers attempting

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -633,7 +633,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
 
    @code
    ProximityProperties props;
-   props.AddProperty(....);  // Populate the properties.
+   props.Add(....);  // Populate the properties.
    scene_graph.AssignRole(source_id, geometry_id, props, RoleAssign::kReplace);
    @endcode
 
@@ -649,11 +649,11 @@ class SceneGraph final : public systems::LeafSystem<T> {
    DRAKE_DEMAND(old_props);
    ProximityProperties new_props(*old_props);
    // Add a new property.
-   new_props.AddProperty("group", "new_prop_name", some_value);
+   new_props.Add("new_prop_name", some_value);
    // Remove a property previously assigned.
-   new_props.RemoveProperty("old_group", "old_name_1");
+   new_props.Remove({"old_prop_name");
    // Update the *value* of an existing property (but enforce same type).
-   new_props.UpdateProperty("old_group", "old_name_2", new_value);
+   new_props.Update("old_prop_name_2", new_value);
    scene_graph.AssignRole(source_id, geometry_id, new_props,
                           RoleAssign::kReplace);
    @endcode

--- a/geometry/test/drake_visualizer_test.cc
+++ b/geometry/test/drake_visualizer_test.cc
@@ -141,7 +141,7 @@ class DrakeVisualizerTest : public ::testing::Test {
         make_unique<GeometryInstance>(RigidTransformd{},
                                       make_unique<Box>(1, 1, 1), "perception"));
     PerceptionProperties percep_prop;
-    percep_prop.AddProperty("phong", "diffuse", Rgba(0, 1, 0, 1));
+    percep_prop.Add("phong/diffuse", Rgba(0, 1, 0, 1));
     scene_graph_->AssignRole(source_id_, g0_id, percep_prop);
 
     // A cylinder has illustration properties with a blue color.
@@ -152,7 +152,7 @@ class DrakeVisualizerTest : public ::testing::Test {
         make_unique<GeometryInstance>(
             RigidTransformd{}, make_unique<Cylinder>(1, 1), "illustration"));
     IllustrationProperties illus_prop;
-    illus_prop.AddProperty("phong", "diffuse", Rgba(0, 1, 0, 1));
+    illus_prop.Add("phong/diffuse", Rgba(0, 1, 0, 1));
     scene_graph_->AssignRole(source_id_, g1_id, illus_prop);
 
     // A sphere has proximity properties with no color.
@@ -535,7 +535,7 @@ TEST_F(DrakeVisualizerTest, GeometryWithIllustrationFallback) {
   const Rgba expected_rgba{0.25, 0.125, 0.75, 0.5};
   ASSERT_NE(expected_rgba, DrakeVisualizerParams().default_color);
   IllustrationProperties illus_props;
-  illus_props.AddProperty("phong", "diffuse", expected_rgba);
+  illus_props.Add("phong/diffuse", expected_rgba);
   scene_graph_->AssignRole(source_id_, g_id, ProximityProperties());
   scene_graph_->AssignRole(source_id_, g_id, illus_props);
 
@@ -564,11 +564,11 @@ TEST_F(DrakeVisualizerTest, AllRolesCanDefineDiffuse) {
     ASSERT_NE(expected_rgba, DrakeVisualizerParams().default_color);
     if (role == Role::kProximity) {
       ProximityProperties props;
-      props.AddProperty("phong", "diffuse", expected_rgba);
+      props.Add("phong/diffuse", expected_rgba);
       scene_graph_->AssignRole(source_id_, g_id, props);
     } else if (role == Role::kPerception) {
       PerceptionProperties props;
-      props.AddProperty("phong", "diffuse", expected_rgba);
+      props.Add("phong/diffuse", expected_rgba);
       scene_graph_->AssignRole(source_id_, g_id, props);
     }
 

--- a/geometry/test/geometry_properties_test.cc
+++ b/geometry/test/geometry_properties_test.cc
@@ -415,6 +415,9 @@ GTEST_TEST(GeometryProperties, ChainingWrites) {
 //  that API is removed, remove all tests from the test fixture:
 //  GeometryPropertiesOld.
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 GTEST_TEST(GeometryPropertiesOld, ManagingGroups) {
   TestProperties properties;
   const string& group_name{"some_group"};
@@ -784,6 +787,7 @@ GTEST_TEST(GeometryPropertiesOld, RgbaAndVector4) {
   // - Get<Vector4d>.
   EXPECT_EQ(vector, properties.GetProperty<Vector4d>(group_name, vector_name));
 }
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
 
 }  // namespace
 }  // namespace geometry

--- a/geometry/test/geometry_properties_test.cc
+++ b/geometry/test/geometry_properties_test.cc
@@ -24,123 +24,79 @@ class TestProperties : public GeometryProperties {
   TestProperties() = default;
 };
 
-GTEST_TEST(GeometryProperties, ManagingGroups) {
-  TestProperties properties;
-  const string& group_name{"some_group"};
-  // Only contains the default group.
-  ASSERT_EQ(1, properties.num_groups());
-  ASSERT_FALSE(properties.HasGroup(group_name));
-  ASSERT_TRUE(properties.HasGroup(TestProperties::default_group_name()));
-
-  // Add the group for the first time by adding a property.
-  properties.AddProperty(group_name, "junk_value", 1);
-  ASSERT_TRUE(properties.HasGroup(group_name));
-  ASSERT_EQ(2, properties.num_groups());
-
-  // Retrieve the group.
-  using PropertyGroup = GeometryProperties::Group;
-  const PropertyGroup& group = properties.GetPropertiesInGroup(group_name);
-  EXPECT_EQ(1u, group.size());
-
-  DRAKE_EXPECT_THROWS_MESSAGE(properties.GetPropertiesInGroup("invalid_name"),
-                              std::logic_error,
-                              ".*Can't retrieve properties for a group that "
-                              "doesn't exist: 'invalid_name'");
-}
-
 // Tests adding properties (successfully and otherwise). Uses a call to
-// GetProperty() to confirm successful add.
+// Get() to confirm successful add.
 GTEST_TEST(GeometryProperties, AddProperty) {
   TestProperties properties;
-  const string& group_name{"some_group"};
 
   // Confirm property doesn't exist.
   const string prop_name("some_property");
-  ASSERT_FALSE(properties.HasProperty(group_name, prop_name));
+  ASSERT_FALSE(properties.HasProperty(prop_name));
 
   // Add the property.
   const int int_value{7};
-  DRAKE_EXPECT_NO_THROW(
-      properties.AddProperty(group_name, prop_name, int_value));
+  DRAKE_EXPECT_NO_THROW(properties.Add(prop_name, int_value));
 
   // Confirm existence.
-  ASSERT_TRUE(properties.HasProperty(group_name, prop_name));
-  ASSERT_EQ(properties.GetProperty<int>(group_name, prop_name), int_value);
+  ASSERT_TRUE(properties.HasProperty(prop_name));
+  ASSERT_EQ(properties.Get<int>(prop_name), int_value);
 
   // Redundant add fails.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      properties.AddProperty(group_name, prop_name, int_value),
-      std::logic_error,
-      fmt::format(
-          ".*Trying to add property \\('{}', '{}'\\).+ name already exists",
-          group_name, prop_name));
-  ASSERT_TRUE(properties.HasProperty(group_name, prop_name));
+      properties.Add(prop_name, int_value), std::logic_error,
+      fmt::format(".*Trying to add property '{}'.+ name already exists",
+                  prop_name));
+  ASSERT_TRUE(properties.HasProperty(prop_name));
 }
 
 // Tests updating properties (successfully and otherwise). Uses a call to
-// GetProperty() to confirm successful add.
+// Get() to confirm successful add.
 GTEST_TEST(GeometryProperties, UpdateProperty) {
   TestProperties properties;
 
   // Initialize with a single property.
-  const string group_name{"some_group"};
   const string prop_name("some_property");
   const int int_value{7};
-  DRAKE_EXPECT_NO_THROW(
-      properties.AddProperty(group_name, prop_name, int_value));
-  EXPECT_EQ(properties.GetProperty<int>(group_name, prop_name), int_value);
+  DRAKE_EXPECT_NO_THROW(properties.Add(prop_name, int_value));
+  EXPECT_EQ(properties.Get<int>(prop_name), int_value);
 
-  // UpdateProperty adds new property.
+  // Update adds new property.
   const string& prop_name2("other_property");
-  EXPECT_FALSE(properties.HasProperty(group_name, prop_name2));
-  EXPECT_NO_THROW(
-      properties.UpdateProperty(group_name, prop_name2, "from_update"));
-  EXPECT_EQ(properties.GetProperty<string>(group_name, prop_name2),
-            "from_update");
+  EXPECT_FALSE(properties.HasProperty(prop_name2));
+  EXPECT_NO_THROW(properties.Update(prop_name2, "from_update"));
+  EXPECT_EQ(properties.Get<string>(prop_name2), "from_update");
 
-  // UpdateProperty alias works for changing value (with same type).
-  EXPECT_NO_THROW(
-      properties.UpdateProperty(group_name, prop_name, int_value + 10));
-  EXPECT_EQ(properties.GetProperty<int>(group_name, prop_name), int_value + 10);
+  // Update alias works for changing value (with same type).
+  EXPECT_NO_THROW(properties.Update(prop_name, int_value + 10));
+  EXPECT_EQ(properties.Get<int>(prop_name), int_value + 10);
 
-  // UpdateProperty alias fails for changing type.
+  // Update alias fails for changing type.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      properties.UpdateProperty(group_name, prop_name, 17.0), std::logic_error,
-      fmt::format(".*Trying to update property \\('{}', '{}'\\).+ is of "
-                  "different type.+",
-                  group_name, prop_name));
+      properties.Update(prop_name, 17.0), std::logic_error,
+      fmt::format(".*Trying to update property '{}'.+ is of different type.+",
+                  prop_name));
 }
 
 GTEST_TEST(GeometryProperties, RemoveProperty) {
   TestProperties properties;
-  const string group1{"group1"};
-  const string group2{"group2"};
   const string prop1{"prop1"};
   const string prop2{"prop2"};
 
-  // Add two groups with two properties each.
-  properties.AddProperty(group1, prop1, 1);
-  properties.AddProperty(group1, prop2, 2);
-  properties.AddProperty(group2, prop1, 3);
-  properties.AddProperty(group2, prop2, 4);
-  ASSERT_TRUE(properties.HasProperty(group1, prop1));
-  ASSERT_TRUE(properties.HasProperty(group1, prop2));
-  ASSERT_TRUE(properties.HasProperty(group2, prop1));
-  ASSERT_TRUE(properties.HasProperty(group2, prop2));
+  // Simply add a couple of properties.
+  properties.Add(prop1, 1);
+  properties.Add(prop2, 2);
+  ASSERT_TRUE(properties.HasProperty(prop1));
+  ASSERT_TRUE(properties.HasProperty(prop2));
 
   // Remove property, make sure all others are still intact.
-  EXPECT_TRUE(properties.RemoveProperty(group1, prop1));
-  ASSERT_FALSE(properties.HasProperty(group1, prop1));
-  ASSERT_TRUE(properties.HasProperty(group1, prop2));
-  ASSERT_TRUE(properties.HasProperty(group2, prop1));
-  ASSERT_TRUE(properties.HasProperty(group2, prop2));
+  EXPECT_TRUE(properties.Remove(prop1));
+  ASSERT_FALSE(properties.HasProperty(prop1));
+  ASSERT_TRUE(properties.HasProperty(prop2));
 
   // Trying to remove it again has no effect.
-  EXPECT_FALSE(properties.RemoveProperty(group1, prop1));
-  EXPECT_FALSE(properties.HasProperty(group1, prop1));
-  EXPECT_TRUE(properties.HasProperty(group1, prop2));
-  EXPECT_TRUE(properties.HasProperty(group2, prop1));
-  EXPECT_TRUE(properties.HasProperty(group2, prop2));
+  EXPECT_FALSE(properties.Remove(prop1));
+  ASSERT_FALSE(properties.HasProperty(prop1));
+  ASSERT_TRUE(properties.HasProperty(prop2));
 }
 
 // Struct for the AddPropertyStruct test.
@@ -156,11 +112,9 @@ GTEST_TEST(GeometryProperties, AddPropertyStruct) {
 
   const string prop_name("test data");
   TestData data{1, 2., "3"};
-  DRAKE_EXPECT_NO_THROW(properties.AddProperty(
-      TestProperties::default_group_name(), prop_name, data));
+  DRAKE_EXPECT_NO_THROW(properties.Add(prop_name, data));
 
-  const TestData& read = properties.GetProperty<TestData>(
-      TestProperties::default_group_name(), prop_name);
+  const TestData& read = properties.Get<TestData>(prop_name);
   EXPECT_EQ(data.i, read.i);
   EXPECT_EQ(data.d, read.d);
   EXPECT_EQ(data.s, read.s);
@@ -170,55 +124,42 @@ GTEST_TEST(GeometryProperties, AddPropertyStruct) {
 GTEST_TEST(GeometryProperties, GetPropertyOrDefault) {
   // Create one group with a single property.
   TestProperties properties;
-  const string group_name{"some_group"};
   const double double_value{7};
   const double default_value = double_value - 1;
   const string prop_name("some_property");
-  DRAKE_EXPECT_NO_THROW(
-      properties.AddProperty(group_name, prop_name, double_value));
+  DRAKE_EXPECT_NO_THROW(properties.Add(prop_name, double_value));
 
   // Case: default value that can be *implicitly* converted to the desired
   // type requires explicit template declaration.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      properties.GetPropertyOrDefault(group_name, prop_name, 3),
-      std::logic_error,
-      fmt::format(
-          ".*The property \\('{}', '{}'\\) exists, but is of a different type. "
-          "Requested 'int', but found 'double'",
-          group_name, prop_name));
-  DRAKE_EXPECT_NO_THROW(
-      properties.GetPropertyOrDefault<double>(group_name, prop_name, 3));
+      properties.GetPropertyOrDefault(prop_name, 3), std::logic_error,
+      fmt::format(".*The property '{}' exists, but is of a different type. "
+                  "Requested 'int', but found 'double'",
+                  prop_name));
+  DRAKE_EXPECT_NO_THROW(properties.GetPropertyOrDefault<double>(prop_name, 3));
 
   // Case: read an existing property.
-  int read_value =
-      properties.GetPropertyOrDefault(group_name, prop_name, default_value);
+  int read_value = properties.GetPropertyOrDefault(prop_name, default_value);
   EXPECT_EQ(double_value, read_value);
 
-  // Case: read from valid group, but invalid property.
-  read_value = properties.GetPropertyOrDefault(group_name, "invalid_prop",
-                                               default_value);
-  EXPECT_EQ(default_value, read_value);
-
-  // Case: read from invalid group.
-  read_value = properties.GetPropertyOrDefault("invalid_group", "invalid_prop",
-                                               default_value);
+  // Case: read invalid property.
+  read_value = properties.GetPropertyOrDefault("invalid_prop", default_value);
   EXPECT_EQ(default_value, read_value);
 
   // Case: Property exists of different type.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      properties.GetPropertyOrDefault(group_name, prop_name, "test"),
-      std::logic_error,
-      fmt::format(".*The property \\('{}', '{}'\\) exists, but is of a "
-                  "different type. Requested 'std::string', but found 'double'",
-                  group_name, prop_name));
+      properties.GetPropertyOrDefault(prop_name, "test"), std::logic_error,
+      fmt::format(".*The property '{}' exists, but is of a different type. "
+                  "Requested 'std::string', but found 'double'",
+                  prop_name));
 
   // Using r-values as defaults; this tests both compatibility and correctness.
-  properties.AddProperty("strings", "valid_string", "valid_string");
-  string valid_value =
-      properties.GetPropertyOrDefault("strings", "valid_string", "missing");
+  properties.Add("valid_string", "valid_string");
+  const string valid_value =
+      properties.GetPropertyOrDefault("valid_string", "missing");
   EXPECT_EQ("valid_string", valid_value);
-  string default_value_return = properties.GetPropertyOrDefault(
-      "strings", "invalid_string", "rvalue_string");
+  const string default_value_return =
+      properties.GetPropertyOrDefault("invalid_string", "rvalue_string");
   EXPECT_EQ("rvalue_string", default_value_return);
 }
 
@@ -226,57 +167,35 @@ GTEST_TEST(GeometryProperties, GetPropertyOrDefault) {
 // implicitly tested in the functions that added/set properties).
 GTEST_TEST(GeometryProperties, GetPropertyFailure) {
   TestProperties properties;
-  const string& group_name{"some_group"};
   const string prop_name("some_property");
 
   // Getter errors
-  // Case: Asking for property from non-existent group.
+  // Case: Asking for non-existent property.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      properties.GetProperty<int>(group_name, prop_name), std::logic_error,
-      fmt::format(
-          ".*Trying to read property \\('{}', '{}'\\), but the group does not "
-          "exist.",
-          group_name, prop_name));
+      properties.Get<int>(prop_name), std::logic_error,
+      fmt::format(".*There is no property '{}'.", prop_name));
 
-  // Case: Group exists, property does not.
-  properties.AddProperty(group_name, prop_name + "_alt", 1);
+  // Case: Property exists, but property is of different type.
+  DRAKE_EXPECT_NO_THROW(properties.Add(prop_name, 7.0));
   DRAKE_EXPECT_THROWS_MESSAGE(
-      properties.GetProperty<int>(group_name, prop_name), std::logic_error,
-      fmt::format(".*There is no property \\('{}', '{}'\\)", group_name,
+      properties.Get<int>(prop_name), std::logic_error,
+      fmt::format(".*The property '{}' exists, but is of a different type. "
+                  "Requested 'int', but found 'double'",
                   prop_name));
-
-  // Case: Group and property exists, but property is of different type.
-  DRAKE_EXPECT_NO_THROW(properties.AddProperty(group_name, prop_name, 7.0));
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      properties.GetProperty<int>(group_name, prop_name), std::logic_error,
-      fmt::format(
-          ".*The property \\('{}', '{}'\\) exists, but is of a different type. "
-          "Requested 'int', but found 'double'",
-          group_name, prop_name));
 }
 
 // Tests iteration through a group's properties.
 GTEST_TEST(GeometryProperties, PropertyIteration) {
   TestProperties properties;
-  const string& default_group = TestProperties::default_group_name();
   std::unordered_map<string, int> reference{{"prop1", 10}, {"prop2", 20}};
-  for (const auto& pair : reference) {
-    properties.AddProperty(default_group, pair.first, pair.second);
+  for (const auto& [name, value] : reference) {
+    properties.Add(name, value);
   }
 
-  // Get exception for non-existent group.
-  DRAKE_EXPECT_THROWS_MESSAGE(properties.GetPropertiesInGroup("bad_group"),
-                              std::logic_error,
-                              ".*Can't retrieve properties for a group that "
-                              "doesn't exist: 'bad_group'");
-
-  // Confirm that all properties have the right value and get visited.
   std::set<string> visited_properties;
-  for (const auto& pair : properties.GetPropertiesInGroup(default_group)) {
-    const string& name = pair.first;
+  for (const auto& [name, abstract_value] : properties.GetAllProperties()) {
     EXPECT_GT(reference.count(name), 0);
-    EXPECT_EQ(reference[name],
-              properties.GetProperty<int>(default_group, name));
+    EXPECT_EQ(reference[name], abstract_value->get_value<int>());
     visited_properties.insert(name);
   }
   EXPECT_EQ(reference.size(), visited_properties.size());
@@ -288,18 +207,8 @@ GTEST_TEST(GeometryProperties, CopyMoveSemantics) {
   // they are all int-valued to facilitate comparison between property sets.
   auto make_properties = []() {
     TestProperties props;
-    const string& default_group = TestProperties::default_group_name();
-    props.AddProperty(default_group, "prop1", 1);
-    props.AddProperty(default_group, "prop2", 2);
-
-    const string group1("group1");
-    // NOTE: Duplicate property name differentiated by different group.
-    props.AddProperty(group1, "prop1", 3);
-    props.AddProperty(group1, "prop3", 4);
-    props.AddProperty(group1, "prop4", 5);
-
-    const string group2("group2");
-    props.AddProperty(group2, "prop5", 6);
+    props.Add("prop1", 1);
+    props.Add("prop2", 2);
     return props;
   };
 
@@ -307,37 +216,29 @@ GTEST_TEST(GeometryProperties, CopyMoveSemantics) {
   auto properties_equal =
       [](const TestProperties& reference,
          const TestProperties& test) -> ::testing::AssertionResult {
-    if (reference.num_groups() != test.num_groups()) {
+    if (reference.GetAllProperties().size() != test.GetAllProperties().size()) {
       return ::testing::AssertionFailure()
-             << "Different number of groups. Expected "
-             << reference.num_groups() << " found " << test.num_groups();
+             << "Different number of properties.\n  Expected "
+             << reference.GetAllProperties().size() << "\n  Found "
+             << test.GetAllProperties().size();
     }
-
-    for (const auto& group_name : reference.GetGroupNames()) {
-      if (test.HasGroup(group_name)) {
-        for (const auto& pair : reference.GetPropertiesInGroup(group_name)) {
-          const string& name = pair.first;
-          int expected_value = pair.second->get_value<int>();
-          if (test.HasProperty(group_name, name)) {
-            int test_value = test.GetProperty<int>(group_name, name);
-            if (expected_value != test_value) {
-              return ::testing::AssertionFailure()
-                     << "Expected value for '" << group_name << "':'" << name
-                     << "' to be " << expected_value << ". Found "
-                     << test_value;
-            }
-          } else {
-            return ::testing::AssertionFailure()
-                   << "Expected group '" << group_name << "' to have property '"
-                   << name << "'. It does not exist.";
-          }
-        }
-      } else {
+    for (const auto& [name, abstract_value] : reference.GetAllProperties()) {
+      if (!test.HasProperty(name)) {
         return ::testing::AssertionFailure()
-               << "Expected group '" << group_name
-               << "' is missing from test properties";
+               << "Missing expected property: " << name;
+      }
+      const int expected_value = abstract_value->get_value<int>();
+      const int test_value = test.Get<int>(name);
+      if (expected_value != test_value) {
+        return ::testing::AssertionFailure()
+               << "Mismatch on property '" << name << "'.\n  Expected "
+               << expected_value << "\n  Found " << test_value;
       }
     }
+    // Note: We're not explicitly testing to see what properties may exist in
+    // test that *aren't* in reference. There's no point; we know they're the
+    // same size. If test has properties absent from reference, that means
+    // reference has properties absent in test (which are caught above).
     return ::testing::AssertionSuccess();
   };
 
@@ -456,6 +357,388 @@ GTEST_TEST(GeometryProperties, GloballyCounted) {
 // Confirms the amount of copying that occurs.
 GTEST_TEST(GeometryProperties, CopyCountCheck) {
   TestProperties properties;
+  const string name_1("name_1");
+  const string name_2("name_2");
+
+  // When adding a property, 2 copies should occur: once when constructing a
+  // value, then another when cloning it.
+  const GloballyCounted value;
+  properties.AddAbstract(name_1, Value(value));
+  EXPECT_TRUE(GloballyCounted::get_stats_and_reset().Equal({2, 0}));
+
+  // Same as above.
+  properties.Add(name_2, value);
+  EXPECT_TRUE(GloballyCounted::get_stats_and_reset().Equal({2, 0}));
+
+  // No copies upon retrieving the type.
+  properties.Get<GloballyCounted>(name_1);
+  EXPECT_TRUE(GloballyCounted::get_stats_and_reset().Equal({0, 0}));
+}
+
+GTEST_TEST(GeometryProperties, RgbaAndVector4) {
+  const Rgba color(0.75, 0.5, 0.25, 1.);
+  const Vector4d vector(0.75, 0.5, 0.25, 1.);
+
+  TestProperties properties;
+  const string color_name("color_name");
+  const string fake_name("fake_name");
+
+  // Adding an Rgba should be accessible as both Rgba and Vector4d.
+  properties.Add(color_name, color);
+  EXPECT_EQ(color, properties.Get<Rgba>(color_name));
+  EXPECT_EQ(vector, properties.Get<Vector4d>(color_name));
+  EXPECT_EQ(vector,
+            properties.GetPropertyOrDefault<Vector4d>(fake_name, vector));
+
+  // Adding a Vector4d should be accessible as both Rgba and Vector4d.
+  const string vector_name("vector_name");
+  properties.Add(vector_name, vector);
+  EXPECT_EQ(color, properties.Get<Rgba>(vector_name));
+  EXPECT_EQ(vector, properties.Get<Vector4d>(vector_name));
+}
+
+// Confirms that properties can be written in a chained sequence.
+GTEST_TEST(GeometryProperties, ChainingWrites) {
+  TestProperties props;
+  props.Add("p0", 0)
+      .Update("p1", 1)
+      .AddAbstract("p2", Value(2))
+      .UpdateAbstract("p3", Value(3));
+  for (int i = 0; i < 4; ++i) {
+    EXPECT_EQ(props.Get<int>(fmt::format("p{}", i)), i);
+  }
+}
+
+// TODO(SeanCurtis-TRI) The tests below relate to the old group-based API. Some
+//  of the tests are unique to group-specific behavior. Some are simply repeats
+//  of the previous tests while exercising the group, property variants. When
+//  that API is removed, remove all tests from the test fixture:
+//  GeometryPropertiesOld.
+
+GTEST_TEST(GeometryPropertiesOld, ManagingGroups) {
+  TestProperties properties;
+  const string& group_name{"some_group"};
+  // Only contains the default group.
+  ASSERT_EQ(1, properties.num_groups());
+  ASSERT_FALSE(properties.HasGroup(group_name));
+  ASSERT_TRUE(properties.HasGroup(TestProperties::default_group_name()));
+
+  // Add the group for the first time by adding a property.
+  properties.AddProperty(group_name, "junk_value", 1);
+  ASSERT_TRUE(properties.HasGroup(group_name));
+  ASSERT_EQ(2, properties.num_groups());
+
+  // Retrieve the group.
+  using PropertyGroup = GeometryProperties::Group;
+  const PropertyGroup& group = properties.GetPropertiesInGroup(group_name);
+  EXPECT_EQ(1u, group.size());
+
+  EXPECT_EQ(properties.GetPropertiesInGroup("invalid_name").size(), 0);
+}
+
+// Tests adding properties (successfully and otherwise). Uses a call to
+// GetProperty() to confirm successful add.
+GTEST_TEST(GeometryPropertiesOld, AddProperty) {
+  TestProperties properties;
+  const string& group_name{"some_group"};
+
+  // Confirm property doesn't exist.
+  const string prop_name("some_property");
+  ASSERT_FALSE(properties.HasProperty(group_name, prop_name));
+
+  // Add the property.
+  const int int_value{7};
+  DRAKE_EXPECT_NO_THROW(
+      properties.AddProperty(group_name, prop_name, int_value));
+
+  // Confirm existence.
+  ASSERT_TRUE(properties.HasProperty(group_name, prop_name));
+  ASSERT_EQ(properties.GetProperty<int>(group_name, prop_name), int_value);
+
+  // Redundant add fails.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      properties.AddProperty(group_name, prop_name, int_value),
+      std::logic_error,
+      fmt::format(".*Trying to add property '{}/{}'.+ name already exists",
+                  group_name, prop_name));
+  ASSERT_TRUE(properties.HasProperty(group_name, prop_name));
+}
+
+// Tests updating properties (successfully and otherwise). Uses a call to
+// GetProperty() to confirm successful add.
+GTEST_TEST(GeometryPropertiesOld, UpdateProperty) {
+  TestProperties properties;
+
+  // Initialize with a single property.
+  const string group_name{"some_group"};
+  const string prop_name("some_property");
+  const int int_value{7};
+  DRAKE_EXPECT_NO_THROW(
+      properties.AddProperty(group_name, prop_name, int_value));
+  EXPECT_EQ(properties.GetProperty<int>(group_name, prop_name), int_value);
+
+  // UpdateProperty adds new property.
+  const string& prop_name2("other_property");
+  EXPECT_FALSE(properties.HasProperty(group_name, prop_name2));
+  EXPECT_NO_THROW(
+      properties.UpdateProperty(group_name, prop_name2, "from_update"));
+  EXPECT_EQ(properties.GetProperty<string>(group_name, prop_name2),
+            "from_update");
+
+  // UpdateProperty alias works for changing value (with same type).
+  EXPECT_NO_THROW(
+      properties.UpdateProperty(group_name, prop_name, int_value + 10));
+  EXPECT_EQ(properties.GetProperty<int>(group_name, prop_name), int_value + 10);
+
+  // UpdateProperty alias fails for changing type.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      properties.UpdateProperty(group_name, prop_name, 17.0), std::logic_error,
+      fmt::format(
+          ".*Trying to update property '{}/{}'.+ is of different type.+",
+          group_name, prop_name));
+}
+
+GTEST_TEST(GeometryPropertiesOld, RemoveProperty) {
+  TestProperties properties;
+  const string group1{"group1"};
+  const string group2{"group2"};
+  const string prop1{"prop1"};
+  const string prop2{"prop2"};
+
+  // Add two groups with two properties each.
+  properties.AddProperty(group1, prop1, 1);
+  properties.AddProperty(group1, prop2, 2);
+  properties.AddProperty(group2, prop1, 3);
+  properties.AddProperty(group2, prop2, 4);
+  ASSERT_TRUE(properties.HasProperty(group1, prop1));
+  ASSERT_TRUE(properties.HasProperty(group1, prop2));
+  ASSERT_TRUE(properties.HasProperty(group2, prop1));
+  ASSERT_TRUE(properties.HasProperty(group2, prop2));
+
+  // Remove property, make sure all others are still intact.
+  EXPECT_TRUE(properties.RemoveProperty(group1, prop1));
+  ASSERT_FALSE(properties.HasProperty(group1, prop1));
+  ASSERT_TRUE(properties.HasProperty(group1, prop2));
+  ASSERT_TRUE(properties.HasProperty(group2, prop1));
+  ASSERT_TRUE(properties.HasProperty(group2, prop2));
+
+  // Trying to remove it again has no effect.
+  EXPECT_FALSE(properties.RemoveProperty(group1, prop1));
+  EXPECT_FALSE(properties.HasProperty(group1, prop1));
+  EXPECT_TRUE(properties.HasProperty(group1, prop2));
+  EXPECT_TRUE(properties.HasProperty(group2, prop1));
+  EXPECT_TRUE(properties.HasProperty(group2, prop2));
+}
+
+// Tests the case where the property value is a struct.
+GTEST_TEST(GeometryPropertiesOld, AddPropertyStruct) {
+  TestProperties properties;
+
+  const string prop_name("test data");
+  TestData data{1, 2., "3"};
+  DRAKE_EXPECT_NO_THROW(properties.AddProperty(
+      TestProperties::default_group_name(), prop_name, data));
+
+  const TestData& read = properties.GetProperty<TestData>(
+      TestProperties::default_group_name(), prop_name);
+  EXPECT_EQ(data.i, read.i);
+  EXPECT_EQ(data.d, read.d);
+  EXPECT_EQ(data.s, read.s);
+}
+
+// Tests property access with default.
+GTEST_TEST(GeometryPropertiesOld, GetPropertyOrDefault) {
+  // Create one group with a single property.
+  TestProperties properties;
+  const string group_name{"some_group"};
+  const double double_value{7};
+  const double default_value = double_value - 1;
+  const string prop_name("some_property");
+  DRAKE_EXPECT_NO_THROW(
+      properties.AddProperty(group_name, prop_name, double_value));
+
+  // Case: default value that can be *implicitly* converted to the desired
+  // type requires explicit template declaration.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      properties.GetPropertyOrDefault(group_name, prop_name, 3),
+      std::logic_error,
+      fmt::format(".*The property '{}/{}' exists, but is of a different type. "
+                  "Requested 'int', but found 'double'",
+                  group_name, prop_name));
+  DRAKE_EXPECT_NO_THROW(
+      properties.GetPropertyOrDefault<double>(group_name, prop_name, 3));
+
+  // Case: read an existing property.
+  int read_value =
+      properties.GetPropertyOrDefault(group_name, prop_name, default_value);
+  EXPECT_EQ(double_value, read_value);
+
+  // Case: read from valid group, but invalid property.
+  read_value = properties.GetPropertyOrDefault(group_name, "invalid_prop",
+                                               default_value);
+  EXPECT_EQ(default_value, read_value);
+
+  // Case: read from invalid group.
+  read_value = properties.GetPropertyOrDefault("invalid_group", "invalid_prop",
+                                               default_value);
+  EXPECT_EQ(default_value, read_value);
+
+  // Case: Property exists of different type.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      properties.GetPropertyOrDefault(group_name, prop_name, "test"),
+      std::logic_error,
+      fmt::format(".*The property '{}/{}' exists, but is of a different type. "
+                  "Requested 'std::string', but found 'double'",
+                  group_name, prop_name));
+
+  // Using r-values as defaults; this tests both compatibility and correctness.
+  properties.AddProperty("strings", "valid_string", "valid_string");
+  string valid_value =
+      properties.GetPropertyOrDefault("strings", "valid_string", "missing");
+  EXPECT_EQ("valid_string", valid_value);
+  string default_value_return = properties.GetPropertyOrDefault(
+      "strings", "invalid_string", "rvalue_string");
+  EXPECT_EQ("rvalue_string", default_value_return);
+}
+
+// Tests the unsuccessful access to properties (successful access has been
+// implicitly tested in the functions that added/set properties).
+GTEST_TEST(GeometryPropertiesOld, GetPropertyFailure) {
+  TestProperties properties;
+  const string& group_name{"some_group"};
+  const string prop_name("some_property");
+
+  // Getter errors
+
+  // Case: Group exists, property does not.
+  properties.AddProperty(group_name, prop_name + "_alt", 1);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      properties.GetProperty<int>(group_name, prop_name), std::logic_error,
+      fmt::format(".*There is no property '{}/{}'.", group_name, prop_name));
+
+  // Case: Group and property exists, but property is of different type.
+  DRAKE_EXPECT_NO_THROW(properties.AddProperty(group_name, prop_name, 7.0));
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      properties.GetProperty<int>(group_name, prop_name), std::logic_error,
+      fmt::format(".*The property '{}/{}' exists, but is of a different type. "
+                  "Requested 'int', but found 'double'",
+                  group_name, prop_name));
+}
+
+// Tests iteration through a group's properties.
+GTEST_TEST(GeometryPropertiesOld, PropertyIteration) {
+  TestProperties properties;
+  const string& default_group = TestProperties::default_group_name();
+  std::unordered_map<string, int> reference{{"prop1", 10}, {"prop2", 20}};
+  for (const auto& pair : reference) {
+    properties.AddProperty(default_group, pair.first, pair.second);
+  }
+
+  // Confirm that all properties have the right value and get visited.
+  std::set<string> visited_properties;
+  for (const auto& pair : properties.GetPropertiesInGroup(default_group)) {
+    const string& name = pair.first;
+    EXPECT_GT(reference.count(name), 0);
+    EXPECT_EQ(reference[name],
+              properties.GetProperty<int>(default_group, name));
+    visited_properties.insert(name);
+  }
+  EXPECT_EQ(reference.size(), visited_properties.size());
+}
+
+// Confirms that derived classes *can* be copied/moved.
+GTEST_TEST(GeometryPropertiesOld, CopyMoveSemantics) {
+  // Populate a property set with an arbitrary set of properties. In this case,
+  // they are all int-valued to facilitate comparison between property sets.
+  auto make_properties = []() {
+    TestProperties props;
+    const string& default_group = TestProperties::default_group_name();
+    props.AddProperty(default_group, "prop1", 1);
+    props.AddProperty(default_group, "prop2", 2);
+
+    const string group1("group1");
+    // NOTE: Duplicate property name differentiated by different group.
+    props.AddProperty(group1, "prop1", 3);
+    props.AddProperty(group1, "prop3", 4);
+    props.AddProperty(group1, "prop4", 5);
+
+    const string group2("group2");
+    props.AddProperty(group2, "prop5", 6);
+    return props;
+  };
+
+  // Only works for int-valued properties.
+  auto properties_equal =
+      [](const TestProperties& reference,
+         const TestProperties& test) -> ::testing::AssertionResult {
+    if (reference.num_groups() != test.num_groups()) {
+      return ::testing::AssertionFailure()
+             << "Different number of groups. Expected "
+             << reference.num_groups() << " found " << test.num_groups();
+    }
+
+    for (const auto& group_name : reference.GetGroupNames()) {
+      if (test.HasGroup(group_name)) {
+        for (const auto& pair : reference.GetPropertiesInGroup(group_name)) {
+          const string& name = pair.first;
+          int expected_value = pair.second->get_value<int>();
+          if (test.HasProperty(group_name, name)) {
+            int test_value = test.GetProperty<int>(group_name, name);
+            if (expected_value != test_value) {
+              return ::testing::AssertionFailure()
+                     << "Expected value for '" << group_name << "':'" << name
+                     << "' to be " << expected_value << ". Found "
+                     << test_value;
+            }
+          } else {
+            return ::testing::AssertionFailure()
+                   << "Expected group '" << group_name << "' to have property '"
+                   << name << "'. It does not exist.";
+          }
+        }
+      } else {
+        return ::testing::AssertionFailure()
+               << "Expected group '" << group_name
+               << "' is missing from test properties";
+      }
+    }
+    return ::testing::AssertionSuccess();
+  };
+
+  TestProperties source = make_properties();
+  TestProperties reference = make_properties();
+
+  // Copy construction.
+  TestProperties copy_construct(source);
+  EXPECT_TRUE(properties_equal(reference, copy_construct));
+
+  // Copy assignment.
+  TestProperties copy_assign;
+  EXPECT_FALSE(properties_equal(reference, copy_assign));
+  copy_assign = source;
+  EXPECT_TRUE(properties_equal(reference, copy_assign));
+
+  // Strictly speaking, confirming that the move *source* has changed isn't
+  // necessary. The move semantics aren't documented. However, given that this
+  // is using default move semantics on unordered_map, we can assume that the
+  // source is modified by the move. So, we'll go ahead and test that.
+
+  // Move construction.
+  TestProperties move_construct(std::move(source));
+  EXPECT_FALSE(properties_equal(reference, source));
+  EXPECT_TRUE(properties_equal(reference, move_construct));
+
+  // Move assignment.
+  TestProperties move_assign;
+  EXPECT_FALSE(properties_equal(reference, move_assign));
+  move_assign = std::move(move_construct);
+  EXPECT_FALSE(properties_equal(reference, move_construct));
+  EXPECT_TRUE(properties_equal(reference, move_assign));
+}
+
+// Confirms the amount of copying that occurs.
+GTEST_TEST(GeometryPropertiesOld, CopyCountCheck) {
+  TestProperties properties;
   const string& group_name{"some_group"};
   const string name_1("name_1");
   const string name_2("name_2");
@@ -475,7 +758,7 @@ GTEST_TEST(GeometryProperties, CopyCountCheck) {
   EXPECT_TRUE(GloballyCounted::get_stats_and_reset().Equal({0, 0}));
 }
 
-GTEST_TEST(GeometryProperties, RgbaAndVector4) {
+GTEST_TEST(GeometryPropertiesOld, RgbaAndVector4) {
   const Rgba color(0.75, 0.5, 0.25, 1.);
   const Vector4d vector(0.75, 0.5, 0.25, 1.);
 

--- a/geometry/test/geometry_roles_test.cc
+++ b/geometry/test/geometry_roles_test.cc
@@ -1,0 +1,160 @@
+#include "drake/geometry/geometry_roles.h"
+
+#include <set>
+#include <vector>
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/proximity/hydroelastic_type.h"
+#include "drake/geometry/proximity/tessellation_strategy.h"
+#include "drake/multibody/plant/coulomb_friction.h"
+
+namespace drake {
+namespace geometry {
+namespace {
+
+using geometry::internal::HydroelasticType;
+using geometry::internal::TessellationStrategy;
+using multibody::CoulombFriction;
+
+/* Confirms that all of the canonical properties listed in the
+ ProximityPropperties documentation return the expected value. This should be
+ kept in sync with the documentation *and* the implemented static methods. */
+GTEST_TEST(ProximityPropertiesTest, CanonicalProperties) {
+  EXPECT_EQ(ProximityProperties::material_elastic_modulus(),
+            PropertyName("material", "elastic_modulus"));
+  EXPECT_EQ(ProximityProperties::material_coulomb_friction(),
+            PropertyName("material", "coulomb_friction"));
+  EXPECT_EQ(ProximityProperties::material_hunt_crossley_dissipation(),
+            PropertyName("material", "hunt_crossley_dissipation"));
+  EXPECT_EQ(ProximityProperties::material_point_contact_stiffness(),
+            PropertyName("material", "point_contact_stiffness"));
+  EXPECT_EQ(ProximityProperties::hydroelastic_resolution_hint(),
+            PropertyName("hydroelastic", "resolution_hint"));
+  EXPECT_EQ(ProximityProperties::hydroelastic_slab_thickness(),
+            PropertyName("hydroelastic", "slab_thickness"));
+  EXPECT_EQ(ProximityProperties::hydroelastic_compliance_type(),
+            PropertyName("hydroelastic", "compliance_type"));
+  EXPECT_EQ(ProximityProperties::hydrolastic_tessellation_strategy(),
+            PropertyName("hydroelastic", "tessellation_strategy"));
+}
+
+/* Tests the named _canonical_ property for validation. All canonical properties
+ should validate for *type*. Some also validate for values of the correct type.
+
+ @param property        The name of the property to test.
+ @param valid_values    One or more values that should pass validation.
+ @param wrong_value     An example of a value of the wrong type.
+ @param bad_values      A collection of values that would *not* pass validation.
+                        If the property doesn't validate value, leave this
+                        empty.
+*/
+template <typename ValidType, typename WrongType>
+void TestCanonicalProperty(const PropertyName& property,
+                           const std::vector<ValidType>& valid_values,
+                           const WrongType& wrong_value,
+                           const std::vector<ValidType>& bad_values = {}) {
+  static_assert(!std::is_same<ValidType, WrongType>::value,
+                "The test requires ValidType and WrongType to be different");
+  DRAKE_DEMAND(valid_values.size() > 0);
+
+  ProximityProperties props;
+
+  EXPECT_FALSE(props.HasProperty(property));
+  // The wrong type should throw.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      props.Add(property, wrong_value), std::logic_error,
+      fmt::format("Failed to validate property {}; expected type.+", property));
+  // Invalid values of the right type should throw.
+  for (const auto& bad_value : bad_values) {
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        props.Add(property, bad_value), std::logic_error,
+        fmt::format("Failed to validate property {}; value.+", property));
+  }
+  // Valid values should be content.
+  for (const auto& valid_value : valid_values) {
+    EXPECT_NO_THROW(props.Add(property, valid_value));
+    EXPECT_TRUE(props.HasProperty(property));
+    EXPECT_EQ(props.Get<ValidType>(property), valid_value);
+    // Clean it up so that the next good value can be added without error.
+    props.Remove(property);
+  }
+}
+
+GTEST_TEST(ProximityPropertiesTest, MaterialElasticModulus) {
+  SCOPED_TRACE("ProximityProperty::material_elastic_modulus");
+  // Elastic modulus must be strictly positive; so we'll test zero and a
+  // negative value as bad.
+  TestCanonicalProperty<double>(ProximityProperties::material_elastic_modulus(),
+                                {3.5}, "wrong_value", {0.0, -1.5});
+}
+
+GTEST_TEST(ProximityPropertiesTest, MaterialCoulombFriction) {
+  SCOPED_TRACE("ProximityProperty::material_coulomb_friction");
+  // Coulomb friction doesn't validate values (the CoulombFriction struct has
+  // already done that.))
+  const CoulombFriction<double> expected{0.2, 0.1};
+  TestCanonicalProperty<CoulombFriction<double>>(
+      ProximityProperties::material_coulomb_friction(), {expected},
+      "wrong_value");
+}
+
+GTEST_TEST(ProximityPropertiesTest, MaterialHuntCrossleyDissipation) {
+  SCOPED_TRACE("ProximityProperty::material_hunt_crossley_dissipation");
+  // Dissippation can't be negative; so we'll test zero and a a positive value
+  // as good values.
+  TestCanonicalProperty<double>(
+      ProximityProperties::material_hunt_crossley_dissipation(), {0, 1.75},
+      "wrong_value", {-1.5});
+}
+
+GTEST_TEST(ProximityPropertiesTest, MaterialPointContactStiffness) {
+  SCOPED_TRACE("ProximityProperty::material_point_contact_stiffness");
+  // Point stiffness must be strictly positive; so we'll test zero and a
+  // negative value as bad.
+  TestCanonicalProperty<double>(
+      ProximityProperties::material_point_contact_stiffness(), {3.5},
+      "wrong_value", {0.0, -1.5});
+}
+
+GTEST_TEST(ProximityPropertiesTest, HydroelasticResolutionHint) {
+  SCOPED_TRACE("ProximityProperty::hydroelastic_resolution_hint");
+  // The resolution hint must be strictly positive; so we'll test zero and a
+  // negative value as bad.
+  TestCanonicalProperty<double>(
+      ProximityProperties::hydroelastic_resolution_hint(), {3.5},
+      "wrong_value", {0.0, -1.5});
+}
+
+GTEST_TEST(ProximityPropertiesTest, HydroelasticSlabThickness) {
+  SCOPED_TRACE("ProximityProperty::hydroelastic_slab_thickness");
+  // The slab thickness must be strictly positive; so we'll test zero and a
+  // negative value as bad.
+  TestCanonicalProperty<double>(
+      ProximityProperties::hydroelastic_slab_thickness(), {3.5},
+      "wrong_value", {0.0, -1.5});
+}
+
+GTEST_TEST(ProximityPropertiesTest, HydroelasticComplianceType) {
+  SCOPED_TRACE("ProximityProperty::hydroelastic_compliance_type");
+  // The compliance type is valid for soft and rigid, and not for undefined.
+  TestCanonicalProperty<HydroelasticType>(
+      ProximityProperties::hydroelastic_compliance_type(),
+      {HydroelasticType::kRigid, HydroelasticType::kSoft}, "wrong_value",
+      {HydroelasticType::kUndefined});
+}
+
+GTEST_TEST(ProximityPropertiesTest, HydroelasticTessellationStrategy) {
+  SCOPED_TRACE("ProximityProperty::hydrolastic_tessellation_strategy");
+  // The tessellation strategy is valid for all enumerations. We'll just pick
+  // one.
+  TestCanonicalProperty<TessellationStrategy>(
+      ProximityProperties::hydrolastic_tessellation_strategy(),
+      {TessellationStrategy::kSingleInteriorVertex}, "wrong_value");
+}
+
+}  // namespace
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/test/geometry_visualization_test.cc
+++ b/geometry/test/geometry_visualization_test.cc
@@ -40,14 +40,15 @@ GTEST_TEST(GeometryVisualization, SimpleScene) {
 
   // Floats because the lcm messages store floats.
   const float radius = 1.25f;
-  const float r = 1.0;
-  const float g = 0.5f;
-  const float b = 0.25f;
-  const float a = 0.125f;
   GeometryId sphere_id = scene_graph.RegisterGeometry(
       source_id, frame_id,
       make_unique<GeometryInstance>(RigidTransformd::Identity(),
                                     make_unique<Sphere>(radius), "sphere"));
+
+  const float r = 1.0;
+  const float g = 0.5f;
+  const float b = 0.25f;
+  const float a = 0.125f;
   Vector4<double> color{r, g, b, a};
   scene_graph.AssignRole(source_id, sphere_id,
                          MakePhongIllustrationProperties(color));

--- a/geometry/test/internal_geometry_test.cc
+++ b/geometry/test/internal_geometry_test.cc
@@ -17,9 +17,9 @@ namespace {
 template <typename Properties>
 std::pair<Properties, Properties> MakePropertyPair() {
   Properties p1;
-  p1.AddProperty("group1", "value", 1);
+  p1.Add("value1", 1);
   Properties p2;
-  p2.AddProperty("group2", "value", 2);
+  p2.Add("value2", 2);
   return std::make_pair(p1, p2);
 }
 
@@ -34,15 +34,15 @@ GTEST_TEST(InternalGeometryTest, PropertyAssignment) {
     DRAKE_EXPECT_NO_THROW(geometry.SetRole(p1));
     EXPECT_TRUE(geometry.has_proximity_role());
     EXPECT_TRUE(
-        geometry.proximity_properties()->HasProperty("group1", "value"));
+        geometry.proximity_properties()->HasProperty("value1"));
     EXPECT_FALSE(
-        geometry.proximity_properties()->HasProperty("group2", "value"));
+        geometry.proximity_properties()->HasProperty("value2"));
     // Resetting proximity properties is not an error.
     DRAKE_EXPECT_NO_THROW(geometry.SetRole(p2));
     EXPECT_FALSE(
-        geometry.proximity_properties()->HasProperty("group1", "value"));
+        geometry.proximity_properties()->HasProperty("value1"));
     EXPECT_TRUE(
-        geometry.proximity_properties()->HasProperty("group2", "value"));
+        geometry.proximity_properties()->HasProperty("value2"));
   }
 
   {
@@ -52,15 +52,15 @@ GTEST_TEST(InternalGeometryTest, PropertyAssignment) {
     DRAKE_EXPECT_NO_THROW(geometry.SetRole(p1));
     EXPECT_TRUE(geometry.has_illustration_role());
     EXPECT_TRUE(
-        geometry.illustration_properties()->HasProperty("group1", "value"));
+        geometry.illustration_properties()->HasProperty("value1"));
     EXPECT_FALSE(
-        geometry.illustration_properties()->HasProperty("group2", "value"));
+        geometry.illustration_properties()->HasProperty("value2"));
     // Resetting illustration properties is not an error.
     DRAKE_EXPECT_NO_THROW(geometry.SetRole(p2));
     EXPECT_FALSE(
-        geometry.illustration_properties()->HasProperty("group1", "value"));
+        geometry.illustration_properties()->HasProperty("value1"));
     EXPECT_TRUE(
-        geometry.illustration_properties()->HasProperty("group2", "value"));
+        geometry.illustration_properties()->HasProperty("value2"));
   }
 
   {

--- a/geometry/test/internal_geometry_test.cc
+++ b/geometry/test/internal_geometry_test.cc
@@ -13,7 +13,7 @@ namespace internal {
 namespace {
 
 // Create two instances of the given Properties type with different properties:
-// ('group1', 'value') in the first, ('group2', 'value') in the second.
+// group1/value in the first, group2/value in the second.
 template <typename Properties>
 std::pair<Properties, Properties> MakePropertyPair() {
   Properties p1;

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -603,7 +603,7 @@ GTEST_TEST(ProximityEngineTests, ReplaceProperties) {
   // it mindlessly attempts to update the hydroelastic representation.
   {
     ProximityProperties props;
-    props.AddProperty("foo", "bar", 1.0);
+    props.Add("foo/bar", 1.0);
     engine.AddDynamicGeometry(sphere.shape(), {}, sphere.id(), props);
     EXPECT_EQ(PET::hydroelastic_type(sphere.id(), engine), kUndefined);
     DRAKE_EXPECT_NO_THROW(
@@ -618,8 +618,8 @@ GTEST_TEST(ProximityEngineTests, ReplaceProperties) {
     // Pick a characteristic length sufficiently large that we create the
     // coarsest, cheapest mesh possible.
     EXPECT_EQ(PET::hydroelastic_type(sphere.id(), engine), kUndefined);
-    props.AddProperty(kMaterialGroup, kElastic,
-                      std::numeric_limits<double>::infinity());
+    props.Add({kMaterialGroup, kElastic},
+              std::numeric_limits<double>::infinity());
     AddRigidHydroelasticProperties(3 * radius, &props);
     DRAKE_EXPECT_NO_THROW(
         engine.UpdateRepresentationForNewProperties(sphere, props));
@@ -638,21 +638,20 @@ GTEST_TEST(ProximityEngineTests, ReplaceProperties) {
   // Create a baseline property set that requests a soft hydroelastic
   // representation, but is not necessarily sufficient to define one.
   ProximityProperties hydro_trigger;
-  hydro_trigger.AddProperty(kHydroGroup, kComplianceType,
-                            HydroelasticType::kSoft);
+  hydro_trigger.Add({kHydroGroup, kComplianceType}, HydroelasticType::kSoft);
 
   // Case: New properties request hydroelastic, but they are incomplete and
   // efforts to assign those properties throw.
   {
     ProximityProperties bad_props_no_elasticity(hydro_trigger);
-    bad_props_no_elasticity.AddProperty(kHydroGroup, kRezHint, 1.25);
+    bad_props_no_elasticity.Add({kHydroGroup, kRezHint}, 1.25);
     DRAKE_EXPECT_THROWS_MESSAGE(
         engine.UpdateRepresentationForNewProperties(sphere,
                                                     bad_props_no_elasticity),
         std::logic_error, "Cannot create soft Sphere; missing the .+ property");
 
     ProximityProperties bad_props_no_length(hydro_trigger);
-    bad_props_no_length.AddProperty(kMaterialGroup, kElastic, 5e8);
+    bad_props_no_length.Add({kMaterialGroup, kElastic}, 5e8);
     DRAKE_EXPECT_THROWS_MESSAGE(
         engine.UpdateRepresentationForNewProperties(sphere,
                                                     bad_props_no_length),

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -618,7 +618,7 @@ GTEST_TEST(ProximityEngineTests, ReplaceProperties) {
     // Pick a characteristic length sufficiently large that we create the
     // coarsest, cheapest mesh possible.
     EXPECT_EQ(PET::hydroelastic_type(sphere.id(), engine), kUndefined);
-    props.Add({kMaterialGroup, kElastic},
+    props.Add(props.material_elastic_modulus(),
               std::numeric_limits<double>::infinity());
     AddRigidHydroelasticProperties(3 * radius, &props);
     DRAKE_EXPECT_NO_THROW(
@@ -638,20 +638,23 @@ GTEST_TEST(ProximityEngineTests, ReplaceProperties) {
   // Create a baseline property set that requests a soft hydroelastic
   // representation, but is not necessarily sufficient to define one.
   ProximityProperties hydro_trigger;
-  hydro_trigger.Add({kHydroGroup, kComplianceType}, HydroelasticType::kSoft);
+  hydro_trigger.Add(hydro_trigger.hydroelastic_compliance_type(),
+                    HydroelasticType::kSoft);
 
   // Case: New properties request hydroelastic, but they are incomplete and
   // efforts to assign those properties throw.
   {
     ProximityProperties bad_props_no_elasticity(hydro_trigger);
-    bad_props_no_elasticity.Add({kHydroGroup, kRezHint}, 1.25);
+    bad_props_no_elasticity.Add(
+        bad_props_no_elasticity.hydroelastic_resolution_hint(), 1.25);
     DRAKE_EXPECT_THROWS_MESSAGE(
         engine.UpdateRepresentationForNewProperties(sphere,
                                                     bad_props_no_elasticity),
         std::logic_error, "Cannot create soft Sphere; missing the .+ property");
 
     ProximityProperties bad_props_no_length(hydro_trigger);
-    bad_props_no_length.Add({kMaterialGroup, kElastic}, 5e8);
+    bad_props_no_length.Add(bad_props_no_length.material_elastic_modulus(),
+                            5e8);
     DRAKE_EXPECT_THROWS_MESSAGE(
         engine.UpdateRepresentationForNewProperties(sphere,
                                                     bad_props_no_length),

--- a/geometry/test/proximity_properties_test.cc
+++ b/geometry/test/proximity_properties_test.cc
@@ -15,10 +15,12 @@ using internal::kComplianceType;
 using internal::kElastic;
 using internal::kFriction;
 using internal::kHcDissipation;
-using internal::kPointStiffness;
 using internal::kHydroGroup;
 using internal::kMaterialGroup;
+using internal::kPointStiffness;
 using internal::kRezHint;
+using internal::kSlabThickness;
+using internal::PropName;
 using CoulombFrictiond = multibody::CoulombFriction<double>;
 
 GTEST_TEST(ProximityPropertiesTest, AddContactMaterial) {
@@ -31,11 +33,11 @@ GTEST_TEST(ProximityPropertiesTest, AddContactMaterial) {
   {
     ProximityProperties p;
     EXPECT_NO_THROW(AddContactMaterial(E, d, ps, mu, &p));
-    EXPECT_EQ(p.GetProperty<double>(kMaterialGroup, kElastic), E);
-    EXPECT_EQ(p.GetProperty<double>(kMaterialGroup, kHcDissipation), d);
-    EXPECT_EQ(p.GetProperty<double>(kMaterialGroup, kPointStiffness), ps);
+    EXPECT_EQ(p.Get<double>(PropName(kMaterialGroup, kElastic)), E);
+    EXPECT_EQ(p.Get<double>(PropName(kMaterialGroup, kHcDissipation)), d);
+    EXPECT_EQ(p.Get<double>(PropName(kMaterialGroup, kPointStiffness)), ps);
     const CoulombFrictiond& mu_stored =
-        p.GetProperty<CoulombFrictiond>(kMaterialGroup, kFriction);
+        p.Get<CoulombFrictiond>(PropName(kMaterialGroup, kFriction));
     EXPECT_EQ(mu_stored.static_friction(), mu.static_friction());
     EXPECT_EQ(mu_stored.dynamic_friction(), mu.dynamic_friction());
   }
@@ -43,7 +45,7 @@ GTEST_TEST(ProximityPropertiesTest, AddContactMaterial) {
   // Error case: Already has elastic_modulus.
   {
     ProximityProperties p;
-    p.AddProperty(kMaterialGroup, kElastic, E);
+    p.Add(PropName(kMaterialGroup, kElastic), E);
     DRAKE_EXPECT_THROWS_MESSAGE(
         AddContactMaterial(E, d, ps, mu, &p), std::logic_error,
         ".+ Trying to add property .+ name already exists");
@@ -52,7 +54,7 @@ GTEST_TEST(ProximityPropertiesTest, AddContactMaterial) {
   // Error case: Already has dissipation.
   {
     ProximityProperties p;
-    p.AddProperty(kMaterialGroup, kHcDissipation, d);
+    p.Add(PropName(kMaterialGroup, kHcDissipation), d);
     DRAKE_EXPECT_THROWS_MESSAGE(
         AddContactMaterial(E, d, ps, mu, &p), std::logic_error,
         ".+ Trying to add property .+ name already exists");
@@ -61,7 +63,7 @@ GTEST_TEST(ProximityPropertiesTest, AddContactMaterial) {
   // Error case: Already has stiffness.
   {
     ProximityProperties p;
-    p.AddProperty(kMaterialGroup, kPointStiffness, ps);
+    p.Add(PropName(kMaterialGroup, kPointStiffness), ps);
     DRAKE_EXPECT_THROWS_MESSAGE(
         AddContactMaterial(E, d, ps, mu, &p), std::logic_error,
         ".+ Trying to add property .+ name already exists");
@@ -70,7 +72,7 @@ GTEST_TEST(ProximityPropertiesTest, AddContactMaterial) {
   // Error case: Already has friction.
   {
     ProximityProperties p;
-    p.AddProperty(kMaterialGroup, kFriction, mu);
+    p.Add(PropName(kMaterialGroup, kFriction), mu);
     DRAKE_EXPECT_THROWS_MESSAGE(
         AddContactMaterial(E, d, ps, mu, &p), std::logic_error,
         ".+ Trying to add property .+ name already exists");
@@ -121,17 +123,18 @@ GTEST_TEST(ProximityPropertiesTest, AddRigidProperties) {
   for (double length : {1e-5, 1.25, 1e7}) {
     ProximityProperties props;
     AddRigidHydroelasticProperties(length, &props);
-    EXPECT_TRUE(props.HasProperty(kHydroGroup, kComplianceType));
-    EXPECT_EQ(props.GetProperty<HydroelasticType>(kHydroGroup, kComplianceType),
-              HydroelasticType::kRigid);
-    EXPECT_TRUE(props.HasProperty(kHydroGroup, kRezHint));
-    EXPECT_EQ(props.GetProperty<double>(kHydroGroup, kRezHint), length);
+    EXPECT_TRUE(props.HasProperty(PropName(kHydroGroup, kComplianceType)));
+    EXPECT_EQ(
+        props.Get<HydroelasticType>(PropName(kHydroGroup, kComplianceType)),
+        HydroelasticType::kRigid);
+    EXPECT_TRUE(props.HasProperty(PropName(kHydroGroup, kRezHint)));
+    EXPECT_EQ(props.Get<double>(PropName(kHydroGroup, kRezHint)), length);
   }
 
   ProximityProperties props;
   AddRigidHydroelasticProperties(&props);
-  EXPECT_TRUE(props.HasProperty(kHydroGroup, kComplianceType));
-  EXPECT_EQ(props.GetProperty<HydroelasticType>(kHydroGroup, kComplianceType),
+  EXPECT_TRUE(props.HasProperty(PropName(kHydroGroup, kComplianceType)));
+  EXPECT_EQ(props.Get<HydroelasticType>(PropName(kHydroGroup, kComplianceType)),
             HydroelasticType::kRigid);
 }
 
@@ -143,17 +146,18 @@ GTEST_TEST(ProximityPropertiesTest, AddSoftProperties) {
   for (double length : {1e-5, 1.25, 1e7}) {
     ProximityProperties props;
     AddSoftHydroelasticProperties(length, &props);
-    EXPECT_TRUE(props.HasProperty(kHydroGroup, kComplianceType));
-    EXPECT_EQ(props.GetProperty<HydroelasticType>(kHydroGroup, kComplianceType),
-              HydroelasticType::kSoft);
-    EXPECT_TRUE(props.HasProperty(kHydroGroup, kRezHint));
-    EXPECT_EQ(props.GetProperty<double>(kHydroGroup, kRezHint), length);
+    EXPECT_TRUE(props.HasProperty(PropName(kHydroGroup, kComplianceType)));
+    EXPECT_EQ(
+        props.Get<HydroelasticType>(PropName(kHydroGroup, kComplianceType)),
+        HydroelasticType::kSoft);
+    EXPECT_TRUE(props.HasProperty(PropName(kHydroGroup, kRezHint)));
+    EXPECT_EQ(props.Get<double>(PropName(kHydroGroup, kRezHint)), length);
   }
 
   ProximityProperties props;
   AddSoftHydroelasticProperties(&props);
-  EXPECT_TRUE(props.HasProperty(kHydroGroup, kComplianceType));
-  EXPECT_EQ(props.GetProperty<HydroelasticType>(kHydroGroup, kComplianceType),
+  EXPECT_TRUE(props.HasProperty(PropName(kHydroGroup, kComplianceType)));
+  EXPECT_EQ(props.Get<HydroelasticType>(PropName(kHydroGroup, kComplianceType)),
             HydroelasticType::kSoft);
 }
 
@@ -163,15 +167,15 @@ GTEST_TEST(ProximityPropertiesTest, AddHalfSpaceSoftProperties) {
   const double E = 1.5e8;
   for (double thickness : {1e-5, 1.25, 1e7}) {
     ProximityProperties props;
-    props.AddProperty(internal::kMaterialGroup, internal::kElastic, E);
+    props.Add(PropName(kMaterialGroup, kElastic), E);
     AddSoftHydroelasticPropertiesForHalfSpace(thickness, &props);
-    EXPECT_TRUE(
-        props.HasProperty(internal::kHydroGroup, internal::kSlabThickness));
-    EXPECT_EQ(props.GetProperty<double>(internal::kHydroGroup,
-                                        internal::kSlabThickness),
+    EXPECT_TRUE(props.HasProperty(PropName(kHydroGroup, kSlabThickness)));
+    EXPECT_EQ(props.Get<double>(
+                  PropName(internal::kHydroGroup, internal::kSlabThickness)),
               thickness);
-    EXPECT_EQ(props.GetProperty<HydroelasticType>(kHydroGroup, kComplianceType),
-              HydroelasticType::kSoft);
+    EXPECT_EQ(
+        props.Get<HydroelasticType>(PropName(kHydroGroup, kComplianceType)),
+        HydroelasticType::kSoft);
   }
 }
 

--- a/geometry/test/proximity_properties_test.cc
+++ b/geometry/test/proximity_properties_test.cc
@@ -11,16 +11,6 @@ namespace geometry {
 namespace {
 
 using internal::HydroelasticType;
-using internal::kComplianceType;
-using internal::kElastic;
-using internal::kFriction;
-using internal::kHcDissipation;
-using internal::kHydroGroup;
-using internal::kMaterialGroup;
-using internal::kPointStiffness;
-using internal::kRezHint;
-using internal::kSlabThickness;
-using internal::PropName;
 using CoulombFrictiond = multibody::CoulombFriction<double>;
 
 GTEST_TEST(ProximityPropertiesTest, AddContactMaterial) {
@@ -33,11 +23,11 @@ GTEST_TEST(ProximityPropertiesTest, AddContactMaterial) {
   {
     ProximityProperties p;
     EXPECT_NO_THROW(AddContactMaterial(E, d, ps, mu, &p));
-    EXPECT_EQ(p.Get<double>(PropName(kMaterialGroup, kElastic)), E);
-    EXPECT_EQ(p.Get<double>(PropName(kMaterialGroup, kHcDissipation)), d);
-    EXPECT_EQ(p.Get<double>(PropName(kMaterialGroup, kPointStiffness)), ps);
+    EXPECT_EQ(p.Get<double>(p.material_elastic_modulus()), E);
+    EXPECT_EQ(p.Get<double>(p.material_hunt_crossley_dissipation()), d);
+    EXPECT_EQ(p.Get<double>(p.material_point_contact_stiffness()), ps);
     const CoulombFrictiond& mu_stored =
-        p.Get<CoulombFrictiond>(PropName(kMaterialGroup, kFriction));
+        p.Get<CoulombFrictiond>(p.material_coulomb_friction());
     EXPECT_EQ(mu_stored.static_friction(), mu.static_friction());
     EXPECT_EQ(mu_stored.dynamic_friction(), mu.dynamic_friction());
   }
@@ -45,7 +35,7 @@ GTEST_TEST(ProximityPropertiesTest, AddContactMaterial) {
   // Error case: Already has elastic_modulus.
   {
     ProximityProperties p;
-    p.Add(PropName(kMaterialGroup, kElastic), E);
+    p.Add(p.material_elastic_modulus(), E);
     DRAKE_EXPECT_THROWS_MESSAGE(
         AddContactMaterial(E, d, ps, mu, &p), std::logic_error,
         ".+ Trying to add property .+ name already exists");
@@ -54,7 +44,7 @@ GTEST_TEST(ProximityPropertiesTest, AddContactMaterial) {
   // Error case: Already has dissipation.
   {
     ProximityProperties p;
-    p.Add(PropName(kMaterialGroup, kHcDissipation), d);
+    p.Add(p.material_hunt_crossley_dissipation(), d);
     DRAKE_EXPECT_THROWS_MESSAGE(
         AddContactMaterial(E, d, ps, mu, &p), std::logic_error,
         ".+ Trying to add property .+ name already exists");
@@ -63,7 +53,7 @@ GTEST_TEST(ProximityPropertiesTest, AddContactMaterial) {
   // Error case: Already has stiffness.
   {
     ProximityProperties p;
-    p.Add(PropName(kMaterialGroup, kPointStiffness), ps);
+    p.Add(p.material_point_contact_stiffness(), ps);
     DRAKE_EXPECT_THROWS_MESSAGE(
         AddContactMaterial(E, d, ps, mu, &p), std::logic_error,
         ".+ Trying to add property .+ name already exists");
@@ -72,7 +62,7 @@ GTEST_TEST(ProximityPropertiesTest, AddContactMaterial) {
   // Error case: Already has friction.
   {
     ProximityProperties p;
-    p.Add(PropName(kMaterialGroup, kFriction), mu);
+    p.Add(p.material_coulomb_friction(), mu);
     DRAKE_EXPECT_THROWS_MESSAGE(
         AddContactMaterial(E, d, ps, mu, &p), std::logic_error,
         ".+ Trying to add property .+ name already exists");
@@ -123,18 +113,17 @@ GTEST_TEST(ProximityPropertiesTest, AddRigidProperties) {
   for (double length : {1e-5, 1.25, 1e7}) {
     ProximityProperties props;
     AddRigidHydroelasticProperties(length, &props);
-    EXPECT_TRUE(props.HasProperty(PropName(kHydroGroup, kComplianceType)));
-    EXPECT_EQ(
-        props.Get<HydroelasticType>(PropName(kHydroGroup, kComplianceType)),
-        HydroelasticType::kRigid);
-    EXPECT_TRUE(props.HasProperty(PropName(kHydroGroup, kRezHint)));
-    EXPECT_EQ(props.Get<double>(PropName(kHydroGroup, kRezHint)), length);
+    EXPECT_TRUE(props.HasProperty(props.hydroelastic_compliance_type()));
+    EXPECT_EQ(props.Get<HydroelasticType>(props.hydroelastic_compliance_type()),
+              HydroelasticType::kRigid);
+    EXPECT_TRUE(props.HasProperty(props.hydroelastic_resolution_hint()));
+    EXPECT_EQ(props.Get<double>(props.hydroelastic_resolution_hint()), length);
   }
 
   ProximityProperties props;
   AddRigidHydroelasticProperties(&props);
-  EXPECT_TRUE(props.HasProperty(PropName(kHydroGroup, kComplianceType)));
-  EXPECT_EQ(props.Get<HydroelasticType>(PropName(kHydroGroup, kComplianceType)),
+  EXPECT_TRUE(props.HasProperty(props.hydroelastic_compliance_type()));
+  EXPECT_EQ(props.Get<HydroelasticType>(props.hydroelastic_compliance_type()),
             HydroelasticType::kRigid);
 }
 
@@ -146,18 +135,17 @@ GTEST_TEST(ProximityPropertiesTest, AddSoftProperties) {
   for (double length : {1e-5, 1.25, 1e7}) {
     ProximityProperties props;
     AddSoftHydroelasticProperties(length, &props);
-    EXPECT_TRUE(props.HasProperty(PropName(kHydroGroup, kComplianceType)));
-    EXPECT_EQ(
-        props.Get<HydroelasticType>(PropName(kHydroGroup, kComplianceType)),
-        HydroelasticType::kSoft);
-    EXPECT_TRUE(props.HasProperty(PropName(kHydroGroup, kRezHint)));
-    EXPECT_EQ(props.Get<double>(PropName(kHydroGroup, kRezHint)), length);
+    EXPECT_TRUE(props.HasProperty(props.hydroelastic_compliance_type()));
+    EXPECT_EQ(props.Get<HydroelasticType>(props.hydroelastic_compliance_type()),
+              HydroelasticType::kSoft);
+    EXPECT_TRUE(props.HasProperty(props.hydroelastic_resolution_hint()));
+    EXPECT_EQ(props.Get<double>(props.hydroelastic_resolution_hint()), length);
   }
 
   ProximityProperties props;
   AddSoftHydroelasticProperties(&props);
-  EXPECT_TRUE(props.HasProperty(PropName(kHydroGroup, kComplianceType)));
-  EXPECT_EQ(props.Get<HydroelasticType>(PropName(kHydroGroup, kComplianceType)),
+  EXPECT_TRUE(props.HasProperty(props.hydroelastic_compliance_type()));
+  EXPECT_EQ(props.Get<HydroelasticType>(props.hydroelastic_compliance_type()),
             HydroelasticType::kSoft);
 }
 
@@ -167,15 +155,13 @@ GTEST_TEST(ProximityPropertiesTest, AddHalfSpaceSoftProperties) {
   const double E = 1.5e8;
   for (double thickness : {1e-5, 1.25, 1e7}) {
     ProximityProperties props;
-    props.Add(PropName(kMaterialGroup, kElastic), E);
+    props.Add(props.material_elastic_modulus(), E);
     AddSoftHydroelasticPropertiesForHalfSpace(thickness, &props);
-    EXPECT_TRUE(props.HasProperty(PropName(kHydroGroup, kSlabThickness)));
-    EXPECT_EQ(props.Get<double>(
-                  PropName(internal::kHydroGroup, internal::kSlabThickness)),
+    EXPECT_TRUE(props.HasProperty(props.hydroelastic_slab_thickness()));
+    EXPECT_EQ(props.Get<double>(props.hydroelastic_slab_thickness()),
               thickness);
-    EXPECT_EQ(
-        props.Get<HydroelasticType>(PropName(kHydroGroup, kComplianceType)),
-        HydroelasticType::kSoft);
+    EXPECT_EQ(props.Get<HydroelasticType>(props.hydroelastic_compliance_type()),
+              HydroelasticType::kSoft);
   }
 }
 

--- a/geometry/test/proximity_properties_test.cc
+++ b/geometry/test/proximity_properties_test.cc
@@ -46,7 +46,7 @@ GTEST_TEST(ProximityPropertiesTest, AddContactMaterial) {
     p.AddProperty(kMaterialGroup, kElastic, E);
     DRAKE_EXPECT_THROWS_MESSAGE(
         AddContactMaterial(E, d, ps, mu, &p), std::logic_error,
-        ".+ Trying to add property \\('.+', '.+'\\).+ name already exists");
+        ".+ Trying to add property .+ name already exists");
   }
 
   // Error case: Already has dissipation.
@@ -55,7 +55,7 @@ GTEST_TEST(ProximityPropertiesTest, AddContactMaterial) {
     p.AddProperty(kMaterialGroup, kHcDissipation, d);
     DRAKE_EXPECT_THROWS_MESSAGE(
         AddContactMaterial(E, d, ps, mu, &p), std::logic_error,
-        ".+ Trying to add property \\('.+', '.+'\\).+ name already exists");
+        ".+ Trying to add property .+ name already exists");
   }
 
   // Error case: Already has stiffness.
@@ -64,7 +64,7 @@ GTEST_TEST(ProximityPropertiesTest, AddContactMaterial) {
     p.AddProperty(kMaterialGroup, kPointStiffness, ps);
     DRAKE_EXPECT_THROWS_MESSAGE(
         AddContactMaterial(E, d, ps, mu, &p), std::logic_error,
-        ".+ Trying to add property \\('.+', '.+'\\).+ name already exists");
+        ".+ Trying to add property .+ name already exists");
   }
 
   // Error case: Already has friction.
@@ -73,7 +73,7 @@ GTEST_TEST(ProximityPropertiesTest, AddContactMaterial) {
     p.AddProperty(kMaterialGroup, kFriction, mu);
     DRAKE_EXPECT_THROWS_MESSAGE(
         AddContactMaterial(E, d, ps, mu, &p), std::logic_error,
-        ".+ Trying to add property \\('.+', '.+'\\).+ name already exists");
+        ".+ Trying to add property .+ name already exists");
   }
 
   // Error case: 0 elasticity.

--- a/geometry/test_utilities/dummy_render_engine.h
+++ b/geometry/test_utilities/dummy_render_engine.h
@@ -91,7 +91,7 @@ class DummyRenderEngine : public render::RenderEngine {
    to _accept_ geometry during registration.  */
   PerceptionProperties accepting_properties() const {
     PerceptionProperties properties;
-    properties.AddProperty(include_group_name_, "ignored", 0);
+    properties.Add(include_name_, 0);
     return properties;
   }
 
@@ -172,7 +172,7 @@ class DummyRenderEngine : public render::RenderEngine {
                         const math::RigidTransformd& X_WG) override {
     X_WGs_[id] = X_WG;
     GetRenderLabelOrThrow(properties);
-    if (force_accept_ || properties.HasGroup(include_group_name_)) {
+    if (force_accept_ || properties.HasProperty(include_name_)) {
       registered_geometries_.insert(id);
       return true;
     }
@@ -212,9 +212,9 @@ class DummyRenderEngine : public render::RenderEngine {
   // Track each id that gets updated and what it has been updated to.
   std::map<GeometryId, math::RigidTransformd> updated_ids_;
 
-  // The group name whose presence will lead to a shape being added to the
+  // The property name whose presence will lead to a shape being added to the
   // engine.
-  std::string include_group_name_{"in_test"};
+  std::string include_name_{"dummy_renderer_accepts_if_present"};
 
   // The last updated camera pose (defaults to identity).
   math::RigidTransformd X_WC_;

--- a/multibody/hydroelastics/hydroelastic_engine.cc
+++ b/multibody/hydroelastics/hydroelastic_engine.cc
@@ -32,9 +32,9 @@ MaterialProperties GetMaterials(GeometryId id,
   if (const ProximityProperties* properties =
           inspector.GetProximityProperties(id)) {
     material.elastic_modulus =
-        properties->GetPropertyOrDefault("material", "elastic_modulus", kInf);
+        properties->GetPropertyOrDefault({"material", "elastic_modulus"}, kInf);
     material.dissipation = properties->GetPropertyOrDefault(
-        "material", "hunt_crossley_dissipation", 0.0);
+        {"material", "hunt_crossley_dissipation"}, 0.0);
     DRAKE_DEMAND(material.elastic_modulus > 0);
     DRAKE_DEMAND(material.dissipation >= 0);
   } else {

--- a/multibody/hydroelastics/test/hydroelastic_engine_test.cc
+++ b/multibody/hydroelastics/test/hydroelastic_engine_test.cc
@@ -52,8 +52,8 @@ class HydroelasticEngineTest : public ::testing::Test {
                              double dissipation) {
     GeometryId id = AddGeometry(name);
     ProximityProperties props;
-    props.AddProperty("material", "elastic_modulus", elastic_modulus);
-    props.AddProperty("material", "hunt_crossley_dissipation", dissipation);
+    props.Add("material/elastic_modulus", elastic_modulus)
+        .Add("material/hunt_crossley_dissipation", dissipation);
     scene_graph_.AssignRole(source_id_, id, props);
     return id;
   }

--- a/multibody/optimization/sliding_friction_complementarity_constraint.cc
+++ b/multibody/optimization/sliding_friction_complementarity_constraint.cc
@@ -186,11 +186,11 @@ void SlidingFrictionComplementarityNonlinearConstraint::DoEval(
           *inspector.GetProximityProperties(signed_distance_pair.id_B);
 
       const CoulombFriction<double>& geometryA_friction =
-          geometryA_props.GetProperty<CoulombFriction<double>>(
-              "material", "coulomb_friction");
+          geometryA_props.Get<CoulombFriction<double>>(
+              {"material", "coulomb_friction"});
       const CoulombFriction<double>& geometryB_friction =
-          geometryB_props.GetProperty<CoulombFriction<double>>(
-              "material", "coulomb_friction");
+          geometryB_props.Get<CoulombFriction<double>>(
+              {"material", "coulomb_friction"});
 
       CoulombFriction<double> combined_friction =
           CalcContactFrictionFromSurfaceProperties(geometryA_friction,

--- a/multibody/optimization/static_friction_cone_complementarity_constraint.cc
+++ b/multibody/optimization/static_friction_cone_complementarity_constraint.cc
@@ -109,11 +109,9 @@ void StaticFrictionConeComplementarityNonlinearConstraint::DoEval(
           signed_distance_pair.id_B);
 
   const CoulombFriction<double>& geometryA_friction =
-      geometryA_props.GetProperty<CoulombFriction<double>>("material",
-                                                           "coulomb_friction");
+      geometryA_props.Get<CoulombFriction<double>>("material/coulomb_friction");
   const CoulombFriction<double>& geometryB_friction =
-      geometryB_props.GetProperty<CoulombFriction<double>>("material",
-                                                           "coulomb_friction");
+      geometryB_props.Get<CoulombFriction<double>>("material/coulomb_friction");
 
   CoulombFriction<double> combined_friction =
       CalcContactFrictionFromSurfaceProperties(geometryA_friction,

--- a/multibody/optimization/static_friction_cone_constraint.cc
+++ b/multibody/optimization/static_friction_cone_constraint.cc
@@ -82,11 +82,11 @@ void StaticFrictionConeConstraint::DoEval(
               signed_distance_pair.id_B);
 
       const CoulombFriction<double>& geometryA_friction =
-          geometryA_props.GetProperty<CoulombFriction<double>>(
-              "material", "coulomb_friction");
+          geometryA_props.Get<CoulombFriction<double>>(
+              {"material", "coulomb_friction"});
       const CoulombFriction<double>& geometryB_friction =
-          geometryB_props.GetProperty<CoulombFriction<double>>(
-              "material", "coulomb_friction");
+          geometryB_props.Get<CoulombFriction<double>>(
+              {"material", "coulomb_friction"});
 
       CoulombFriction<double> combined_friction =
           CalcContactFrictionFromSurfaceProperties(geometryA_friction,

--- a/multibody/parsing/detail_common.cc
+++ b/multibody/parsing/detail_common.cc
@@ -23,8 +23,9 @@ geometry::ProximityProperties ParseProximityProperties(
     } else if (is_soft) {
       geometry::AddSoftHydroelasticProperties(*rez_hint, &properties);
     } else {
-      properties.AddProperty(geometry::internal::kHydroGroup,
-                             geometry::internal::kRezHint, *rez_hint);
+      properties.Add(
+          {geometry::internal::kHydroGroup, geometry::internal::kRezHint},
+          *rez_hint);
     }
   } else {
     if (is_rigid) {

--- a/multibody/parsing/detail_common.cc
+++ b/multibody/parsing/detail_common.cc
@@ -23,9 +23,7 @@ geometry::ProximityProperties ParseProximityProperties(
     } else if (is_soft) {
       geometry::AddSoftHydroelasticProperties(*rez_hint, &properties);
     } else {
-      properties.Add(
-          {geometry::internal::kHydroGroup, geometry::internal::kRezHint},
-          *rez_hint);
+      properties.Add(properties.hydroelastic_resolution_hint(), *rez_hint);
     }
   } else {
     if (is_rigid) {

--- a/multibody/parsing/detail_scene_graph.cc
+++ b/multibody/parsing/detail_scene_graph.cc
@@ -406,11 +406,9 @@ ProximityProperties MakeProximityPropertiesForCollision(
 
   // TODO(SeanCurtis-TRI): Remove all of this legacy parsing code based on
   //  issue #12598.
-  if (!properties.HasProperty({geometry::internal::kMaterialGroup,
-                               geometry::internal::kFriction})) {
-    properties.Add(
-        {geometry::internal::kMaterialGroup, geometry::internal::kFriction},
-        MakeCoulombFrictionFromSdfCollisionOde(sdf_collision));
+  if (!properties.HasProperty(properties.material_coulomb_friction())) {
+    properties.Add(properties.material_coulomb_friction(),
+                   MakeCoulombFrictionFromSdfCollisionOde(sdf_collision));
   } else {
     // We parsed friction from <drake:proximity_properties>; test for the
     // existence of the legacy mechanism and warn we're not using it.

--- a/multibody/parsing/detail_scene_graph.cc
+++ b/multibody/parsing/detail_scene_graph.cc
@@ -271,7 +271,7 @@ IllustrationProperties MakeVisualPropertiesFromSdfVisual(
           throw std::runtime_error(fmt::format(
               "Unable to locate the texture file: {}", texture_name));
         }
-        properties.AddProperty("phong", "diffuse_map", resolved_path);
+        properties.Add("phong/diffuse_map", resolved_path);
       }
     }
 
@@ -286,7 +286,7 @@ IllustrationProperties MakeVisualPropertiesFromSdfVisual(
 
       Vector4<double> color{sdf_color.R(), sdf_color.G(), sdf_color.B(),
                             sdf_color.A()};
-      props->AddProperty("phong", property, color);
+      props->Add({"phong", property}, color);
     };
 
     add_property("diffuse", &properties);
@@ -314,7 +314,7 @@ IllustrationProperties MakeVisualPropertiesFromSdfVisual(
       accepting = accepting->GetNextElement(kAcceptingTag);
     }
     DRAKE_DEMAND(accepting_names.size() > 0);
-    properties.AddProperty("renderer", "accepting", move(accepting_names));
+    properties.Add("renderer/accepting", move(accepting_names));
   }
 
   return properties;
@@ -406,10 +406,10 @@ ProximityProperties MakeProximityPropertiesForCollision(
 
   // TODO(SeanCurtis-TRI): Remove all of this legacy parsing code based on
   //  issue #12598.
-  if (!properties.HasProperty(geometry::internal::kMaterialGroup,
-                              geometry::internal::kFriction)) {
-    properties.AddProperty(
-        geometry::internal::kMaterialGroup, geometry::internal::kFriction,
+  if (!properties.HasProperty({geometry::internal::kMaterialGroup,
+                               geometry::internal::kFriction})) {
+    properties.Add(
+        {geometry::internal::kMaterialGroup, geometry::internal::kFriction},
         MakeCoulombFrictionFromSdfCollisionOde(sdf_collision));
   } else {
     // We parsed friction from <drake:proximity_properties>; test for the

--- a/multibody/parsing/detail_scene_graph.h
+++ b/multibody/parsing/detail_scene_graph.h
@@ -170,7 +170,7 @@ math::RigidTransformd MakeGeometryPoseFromSdfCollision(
    4. If no meaningful friction coefficients are found, a default value will be
       created (see default_friction()).
  As long as no exception is thrown, the resulting ProximityProperties will have
- the ('material', 'coulomb_friction') property.  */
+ the material/coulomb_friction property.  */
 geometry::ProximityProperties MakeProximityPropertiesForCollision(
         const sdf::Collision& sdf_collision);
 

--- a/multibody/parsing/detail_urdf_geometry.cc
+++ b/multibody/parsing/detail_urdf_geometry.cc
@@ -373,7 +373,7 @@ geometry::GeometryInstance ParseVisual(const std::string& parent_element_name,
       properties = geometry::MakePhongIllustrationProperties(*(material.rgba));
     }
     if (material.diffuse_map) {
-      properties.AddProperty("phong", "diffuse_map", *(material.diffuse_map));
+      properties.Add("phong/diffuse_map", *(material.diffuse_map));
     }
   }
 
@@ -397,7 +397,7 @@ geometry::GeometryInstance ParseVisual(const std::string& parent_element_name,
       accepting_node = accepting_node->NextSiblingElement(kAcceptingTag);
     }
     DRAKE_DEMAND(accepting_names.size() > 0);
-    properties.AddProperty("renderer", "accepting", std::move(accepting_names));
+    properties.Add("renderer/accepting", std::move(accepting_names));
   }
 
   std::string geometry_name;
@@ -559,14 +559,15 @@ geometry::GeometryInstance ParseCollision(
   // TODO(SeanCurtis-TRI): Remove all of this legacy parsing code based on
   //  issue #12598.
   // Now test to see how we should handle a potential <drake_compliance> tag.
-  if (!props.HasProperty(geometry::internal::kMaterialGroup,
-                         geometry::internal::kFriction)) {
+  if (!props.HasProperty({geometry::internal::kMaterialGroup,
+                          geometry::internal::kFriction})) {
     // We have no friction from <drake:proximity_properties> so we need the old
     // tag.
     CoulombFriction<double> friction =
         ParseCoulombFrictionFromDrakeCompliance(parent_element_name, node);
-    props.AddProperty(geometry::internal::kMaterialGroup,
-                      geometry::internal::kFriction, friction);
+    props.Add(
+        {geometry::internal::kMaterialGroup, geometry::internal::kFriction},
+        friction);
   } else {
     // We parsed friction from <drake:proximity_properties>; test for the
     // existence of <drake_compliance> and warn that it won't be used.

--- a/multibody/parsing/detail_urdf_geometry.cc
+++ b/multibody/parsing/detail_urdf_geometry.cc
@@ -559,15 +559,12 @@ geometry::GeometryInstance ParseCollision(
   // TODO(SeanCurtis-TRI): Remove all of this legacy parsing code based on
   //  issue #12598.
   // Now test to see how we should handle a potential <drake_compliance> tag.
-  if (!props.HasProperty({geometry::internal::kMaterialGroup,
-                          geometry::internal::kFriction})) {
+  if (!props.HasProperty(props.material_coulomb_friction())) {
     // We have no friction from <drake:proximity_properties> so we need the old
     // tag.
     CoulombFriction<double> friction =
         ParseCoulombFrictionFromDrakeCompliance(parent_element_name, node);
-    props.Add(
-        {geometry::internal::kMaterialGroup, geometry::internal::kFriction},
-        friction);
+    props.Add(props.material_coulomb_friction(), friction);
   } else {
     // We parsed friction from <drake:proximity_properties>; test for the
     // existence of <drake_compliance> and warn that it won't be used.

--- a/multibody/parsing/detail_urdf_geometry.h
+++ b/multibody/parsing/detail_urdf_geometry.h
@@ -188,7 +188,7 @@ geometry::GeometryInstance ParseVisual(
       created (see default_friction()).
  As long as no exception is thrown, the returned geometry::GeometryInstance
  will contain a valid instance of geometry::ProximityProperties with (at least)
- the ('material', 'coulomb_friction') property.
+ the material/coulomb_friction property.
 
  @param[in] parent_element_name The name of the parent link element, used
  to construct default geometry names and for error reporting.

--- a/multibody/parsing/test/common_parser_test.cc
+++ b/multibody/parsing/test/common_parser_test.cc
@@ -123,16 +123,16 @@ TEST_P(MultibodyPlantLinkTests, LinksWithCollisions) {
       plant_.GetCollisionGeometriesForBody(plant_.GetBodyByName("link1"));
   ASSERT_EQ(link1_collision_geometry_ids.size(), 2);
 
-  EXPECT_TRUE(scene_graph_.model_inspector()
-                  .GetProximityProperties(link1_collision_geometry_ids[0])
-                  ->GetProperty<CoulombFriction<double>>("material",
-                                                         "coulomb_friction") ==
-              CoulombFriction<double>(0.8, 0.3));
-  EXPECT_TRUE(scene_graph_.model_inspector()
-                  .GetProximityProperties(link1_collision_geometry_ids[1])
-                  ->GetProperty<CoulombFriction<double>>("material",
-                                                         "coulomb_friction") ==
-              CoulombFriction<double>(1.5, 0.6));
+  EXPECT_EQ(
+      scene_graph_.model_inspector()
+          .GetProximityProperties(link1_collision_geometry_ids[0])
+          ->Get<CoulombFriction<double>>({"material", "coulomb_friction"}),
+      CoulombFriction<double>(0.8, 0.3));
+  EXPECT_EQ(
+      scene_graph_.model_inspector()
+          .GetProximityProperties(link1_collision_geometry_ids[1])
+          ->Get<CoulombFriction<double>>({"material", "coulomb_friction"}),
+      CoulombFriction<double>(1.5, 0.6));
 
   const std::vector<GeometryId>& link2_collision_geometry_ids =
       plant_.GetCollisionGeometriesForBody(plant_.GetBodyByName("link2"));
@@ -143,11 +143,11 @@ TEST_P(MultibodyPlantLinkTests, LinksWithCollisions) {
   ASSERT_EQ(link3_collision_geometry_ids.size(), 1);
   // Verifies the default value of the friction coefficients when the user does
   // not specify them in the SDF file.
-  EXPECT_EQ(scene_graph_.model_inspector()
-                .GetProximityProperties(link3_collision_geometry_ids[0])
-                ->GetProperty<CoulombFriction<double>>("material",
-                                                       "coulomb_friction"),
-            default_friction());
+  EXPECT_EQ(
+      scene_graph_.model_inspector()
+          .GetProximityProperties(link3_collision_geometry_ids[0])
+          ->Get<CoulombFriction<double>>({"material", "coulomb_friction"}),
+      default_friction());
 }
 
 

--- a/multibody/parsing/test/detail_scene_graph_test.cc
+++ b/multibody/parsing/test/detail_scene_graph_test.cc
@@ -1032,10 +1032,9 @@ GTEST_TEST(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
 
   auto assert_friction = [](const ProximityProperties& properties,
                             const CoulombFriction<double>& expected_friction) {
-    ASSERT_TRUE(properties.HasProperty({geometry::internal::kMaterialGroup,
-                                        geometry::internal::kFriction}));
-    const auto& friction = properties.Get<CoulombFriction<double>>(
-        {geometry::internal::kMaterialGroup, geometry::internal::kFriction});
+    const PropertyName& property = properties.material_coulomb_friction();
+    ASSERT_TRUE(properties.HasProperty(property));
+    const auto& friction = properties.Get<CoulombFriction<double>>(property);
     EXPECT_EQ(friction.static_friction(), expected_friction.static_friction());
     EXPECT_EQ(friction.dynamic_friction(),
               expected_friction.dynamic_friction());
@@ -1063,12 +1062,12 @@ GTEST_TEST(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
   </drake:proximity_properties>)""");
     ProximityProperties properties =
         MakeProximityPropertiesForCollision(*sdf_collision);
-    assert_single_property(properties, {geometry::internal::kHydroGroup,
-                           geometry::internal::kRezHint}, 2.5);
-    assert_single_property(properties, {geometry::internal::kMaterialGroup,
-                           geometry::internal::kElastic}, 3.5);
-    assert_single_property(properties, {geometry::internal::kMaterialGroup,
-                           geometry::internal::kHcDissipation}, 4.5);
+    assert_single_property(properties,
+                           properties.hydroelastic_resolution_hint(), 2.5);
+    assert_single_property(properties, properties.material_elastic_modulus(),
+                           3.5);
+    assert_single_property(
+        properties, properties.material_hunt_crossley_dissipation(), 4.5);
     assert_friction(properties, {4.75, 4.5});
   }
 
@@ -1080,10 +1079,10 @@ GTEST_TEST(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
   </drake:proximity_properties>)""");
     ProximityProperties properties =
         MakeProximityPropertiesForCollision(*sdf_collision);
-    ASSERT_TRUE(properties.HasProperty({geometry::internal::kHydroGroup,
-                                        geometry::internal::kComplianceType}));
+    ASSERT_TRUE(
+        properties.HasProperty(properties.hydroelastic_compliance_type()));
     EXPECT_EQ(properties.Get<geometry::internal::HydroelasticType>(
-        {geometry::internal::kHydroGroup, geometry::internal::kComplianceType}),
+                  properties.hydroelastic_compliance_type()),
               geometry::internal::HydroelasticType::kRigid);
   }
 
@@ -1095,10 +1094,10 @@ GTEST_TEST(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
   </drake:proximity_properties>)""");
     ProximityProperties properties =
         MakeProximityPropertiesForCollision(*sdf_collision);
-    ASSERT_TRUE(properties.HasProperty({geometry::internal::kHydroGroup,
-                                        geometry::internal::kComplianceType}));
+    ASSERT_TRUE(
+        properties.HasProperty(properties.hydroelastic_compliance_type()));
     EXPECT_EQ(properties.Get<geometry::internal::HydroelasticType>(
-        {geometry::internal::kHydroGroup, geometry::internal::kComplianceType}),
+                  properties.hydroelastic_compliance_type()),
               geometry::internal::HydroelasticType::kSoft);
   }
 

--- a/multibody/parsing/test/detail_urdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_urdf_geometry_test.cc
@@ -568,12 +568,12 @@ TEST_F(UrdfGeometryTests, CollisionProperties) {
         ParseCollision("link_name", package_map, root_dir, collision_node);
     ASSERT_NE(instance.proximity_properties(), nullptr);
     const ProximityProperties& properties = *instance.proximity_properties();
-    verify_single_property(properties, {geometry::internal::kHydroGroup,
-                           geometry::internal::kRezHint}, 2.5);
-    verify_single_property(properties, {geometry::internal::kMaterialGroup,
-                           geometry::internal::kElastic}, 3.5);
-    verify_single_property(properties, {geometry::internal::kMaterialGroup,
-                           geometry::internal::kHcDissipation}, 3.5);
+    verify_single_property(properties,
+                           properties.hydroelastic_resolution_hint(), 2.5);
+    verify_single_property(properties, properties.material_elastic_modulus(),
+                           3.5);
+    verify_single_property(
+        properties, properties.material_hunt_crossley_dissipation(), 3.5);
     verify_friction(properties, {3.5, 3.25});
   }
 
@@ -589,11 +589,11 @@ TEST_F(UrdfGeometryTests, CollisionProperties) {
         ParseCollision("link_name", package_map, root_dir, collision_node);
     ASSERT_NE(instance.proximity_properties(), nullptr);
     const ProximityProperties& properties = *instance.proximity_properties();
-    ASSERT_TRUE(properties.HasProperty({geometry::internal::kHydroGroup,
-                                        geometry::internal::kComplianceType}));
+    ASSERT_TRUE(
+        properties.HasProperty(properties.hydroelastic_compliance_type()));
     EXPECT_EQ(properties.Get<geometry::internal::HydroelasticType>(
-        {geometry::internal::kHydroGroup, geometry::internal::kComplianceType}),
-            geometry::internal::HydroelasticType::kRigid);
+                  properties.hydroelastic_compliance_type()),
+              geometry::internal::HydroelasticType::kRigid);
   }
 
   // Case: specifies soft hydroelastic.
@@ -608,10 +608,10 @@ TEST_F(UrdfGeometryTests, CollisionProperties) {
         ParseCollision("link_name", package_map, root_dir, collision_node);
     ASSERT_NE(instance.proximity_properties(), nullptr);
     const ProximityProperties& properties = *instance.proximity_properties();
-    ASSERT_TRUE(properties.HasProperty({geometry::internal::kHydroGroup,
-                                        geometry::internal::kComplianceType}));
+    ASSERT_TRUE(
+        properties.HasProperty(properties.hydroelastic_compliance_type()));
     EXPECT_EQ(properties.Get<geometry::internal::HydroelasticType>(
-        {geometry::internal::kHydroGroup, geometry::internal::kComplianceType}),
+                  properties.hydroelastic_compliance_type()),
               geometry::internal::HydroelasticType::kSoft);
   }
 

--- a/multibody/parsing/test/detail_urdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_urdf_geometry_test.cc
@@ -532,7 +532,7 @@ TEST_F(UrdfGeometryTests, CollisionProperties) {
                                    const char* group, const char* property,
                                    double value) {
     ASSERT_TRUE(properties.HasProperty(group, property))
-        << fmt::format("  for property: ('{}', '{}')", group, property);
+        << fmt::format("  for property: {}/{}", group, property);
     EXPECT_EQ(properties.GetProperty<double>(group, property), value);
   };
 

--- a/multibody/plant/coulomb_friction.h
+++ b/multibody/plant/coulomb_friction.h
@@ -95,6 +95,14 @@ class CoulombFriction {
   T dynamic_friction_{0.0};
 };
 
+template <typename T>
+std::ostream& operator<<(std::ostream& out,
+                         const CoulombFriction<T>& friction) {
+  out << "CoulombFriction(static: " << friction.static_friction()
+      << ", dynamic: " << friction.dynamic_friction() << ")";
+  return out;
+}
+
 /// Given the surface properties of two different surfaces, this method computes
 /// the Coulomb's law coefficients of friction characterizing the interaction by
 /// friction of the given surface pair.

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -400,20 +400,19 @@ geometry::GeometryId MultibodyPlant<T>::RegisterVisualGeometry(
   // TODO(SeanCurtis-TRI): Eliminate the automatic assignment of perception
   //  and illustration in favor of a protocol that allows definition.
   geometry::PerceptionProperties perception_props;
-  perception_props.AddProperty("label", "id", RenderLabel(body.index()));
-  perception_props.AddProperty(
-      "phong", "diffuse",
-      properties.GetPropertyOrDefault(
-          "phong", "diffuse", Vector4<double>(0.9, 0.9, 0.9, 1.0)));
-  if (properties.HasProperty("phong", "diffuse_map")) {
-    perception_props.AddProperty(
-        "phong", "diffuse_map",
-        properties.GetProperty<std::string>("phong", "diffuse_map"));
+  perception_props.Add("label/id", RenderLabel(body.index()))
+      .Add("phong/diffuse",
+           properties.GetPropertyOrDefault(
+               {"phong", "diffuse"}, Vector4<double>(0.9, 0.9, 0.9, 1.0)));
+  if (properties.HasProperty({"phong", "diffuse_map"})) {
+    perception_props.Add(
+        {"phong", "diffuse_map"},
+        properties.Get<std::string>({"phong", "diffuse_map"}));
   }
-  if (properties.HasProperty("renderer", "accepting")) {
-    perception_props.AddProperty(
-      "renderer", "accepting",
-      properties.GetProperty<std::set<std::string>>("renderer", "accepting"));
+  if (properties.HasProperty({"renderer", "accepting"})) {
+    perception_props.Add(
+        {"renderer", "accepting"},
+        properties.Get<std::set<std::string>>({"renderer", "accepting"}));
   }
   member_scene_graph().AssignRole(*source_id_, id, perception_props);
 
@@ -437,12 +436,12 @@ geometry::GeometryId MultibodyPlant<T>::RegisterCollisionGeometry(
     geometry::ProximityProperties properties) {
   DRAKE_MBP_THROW_IF_FINALIZED();
   DRAKE_THROW_UNLESS(geometry_source_is_registered());
-  DRAKE_THROW_UNLESS(properties.HasProperty(geometry::internal::kMaterialGroup,
-                                            geometry::internal::kFriction));
+  DRAKE_THROW_UNLESS(properties.HasProperty({geometry::internal::kMaterialGroup,
+                                             geometry::internal::kFriction}));
 
   const CoulombFriction<double> coulomb_friction =
-      properties.GetProperty<CoulombFriction<double>>(
-          geometry::internal::kMaterialGroup, geometry::internal::kFriction);
+      properties.Get<CoulombFriction<double>>(
+          {geometry::internal::kMaterialGroup, geometry::internal::kFriction});
 
   // TODO(amcastro-tri): Consider doing this after finalize so that we can
   // register geometry that has a fixed path to world to the world body (i.e.,
@@ -469,8 +468,8 @@ geometry::GeometryId MultibodyPlant<T>::RegisterCollisionGeometry(
     const geometry::Shape& shape, const std::string& name,
     const CoulombFriction<double>& coulomb_friction) {
   geometry::ProximityProperties props;
-  props.AddProperty(geometry::internal::kMaterialGroup,
-                    geometry::internal::kFriction, coulomb_friction);
+  props.Add({geometry::internal::kMaterialGroup, geometry::internal::kFriction},
+            coulomb_friction);
   return RegisterCollisionGeometry(body, X_BG, shape, name, std::move(props));
 }
 
@@ -1536,17 +1535,17 @@ void MultibodyPlant<T>::CalcHydroelasticContactForces(
         inspector.GetProximityProperties(geometryM_id);
     DRAKE_DEMAND(propM != nullptr);
     DRAKE_DEMAND(propN != nullptr);
-    DRAKE_THROW_UNLESS(propM->HasProperty(geometry::internal::kMaterialGroup,
-                                          geometry::internal::kFriction));
-    DRAKE_THROW_UNLESS(propN->HasProperty(geometry::internal::kMaterialGroup,
-                                          geometry::internal::kFriction));
+    DRAKE_THROW_UNLESS(propM->HasProperty({geometry::internal::kMaterialGroup,
+                                           geometry::internal::kFriction}));
+    DRAKE_THROW_UNLESS(propN->HasProperty({geometry::internal::kMaterialGroup,
+                                           geometry::internal::kFriction}));
 
     const CoulombFriction<double>& geometryM_friction =
-        propM->GetProperty<CoulombFriction<double>>(
-            geometry::internal::kMaterialGroup, geometry::internal::kFriction);
+        propM->Get<CoulombFriction<double>>({geometry::internal::kMaterialGroup,
+                                             geometry::internal::kFriction});
     const CoulombFriction<double>& geometryN_friction =
-        propN->GetProperty<CoulombFriction<double>>(
-            geometry::internal::kMaterialGroup, geometry::internal::kFriction);
+        propN->Get<CoulombFriction<double>>({geometry::internal::kMaterialGroup,
+                                             geometry::internal::kFriction});
 
     // Compute combined friction coefficient.
     const CoulombFriction<double> combined_friction =

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3780,14 +3780,13 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     DRAKE_DEMAND(prop != nullptr);
     // Note: Invocation of GetPropertyOrDefault<T> requires implicit conversion
     // from the stored propeprty type (double) to T.
-    return std::pair(prop->template GetPropertyOrDefault<T>(
-                         {geometry::internal::kMaterialGroup,
-                          geometry::internal::kPointStiffness},
-                         penalty_method_contact_parameters_.geometry_stiffness),
-                     prop->template GetPropertyOrDefault<T>(
-                         {geometry::internal::kMaterialGroup,
-                          geometry::internal::kHcDissipation},
-                         penalty_method_contact_parameters_.dissipation));
+    return std::pair(
+        prop->template GetPropertyOrDefault<T>(
+            prop->material_point_contact_stiffness(),
+            penalty_method_contact_parameters_.geometry_stiffness),
+        prop->template GetPropertyOrDefault<T>(
+            prop->material_hunt_crossley_dissipation(),
+            penalty_method_contact_parameters_.dissipation));
   }
 
   // Helper to acquire per-geometry Coulomb friction coefficients from
@@ -3802,10 +3801,9 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     const geometry::ProximityProperties* prop =
         inspector.GetProximityProperties(id);
     DRAKE_DEMAND(prop != nullptr);
-    DRAKE_THROW_UNLESS(prop->HasProperty({geometry::internal::kMaterialGroup,
-                                         geometry::internal::kFriction}));
+    DRAKE_THROW_UNLESS(prop->HasProperty(prop->material_coulomb_friction()));
     return prop->GetProperty<CoulombFriction<double>>(
-        {geometry::internal::kMaterialGroup, geometry::internal::kFriction});
+        prop->material_coulomb_friction());
   }
 
   // Checks that the provided State is consistent with this plant.

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -398,8 +398,7 @@ enum class ContactModel {
  const geometry::ProximityProperties* props =
      inspector.GetProximityProperties(geometry_id);
  const CoulombFriction<T>& geometry_friction =
-     props->GetProperty<CoulombFriction<T>>("material",
-                                            "coulomb_friction");
+     props->Get<CoulombFriction<T>>({"material", "coulomb_friction"});
  @endcode
 */
 /// @anchor mbp_parameters
@@ -3779,13 +3778,15 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     const geometry::ProximityProperties* prop =
         inspector.GetProximityProperties(id);
     DRAKE_DEMAND(prop != nullptr);
+    // Note: Invocation of GetPropertyOrDefault<T> requires implicit conversion
+    // from the stored propeprty type (double) to T.
     return std::pair(prop->template GetPropertyOrDefault<T>(
-                         geometry::internal::kMaterialGroup,
-                         geometry::internal::kPointStiffness,
+                         {geometry::internal::kMaterialGroup,
+                          geometry::internal::kPointStiffness},
                          penalty_method_contact_parameters_.geometry_stiffness),
                      prop->template GetPropertyOrDefault<T>(
-                         geometry::internal::kMaterialGroup,
-                         geometry::internal::kHcDissipation,
+                         {geometry::internal::kMaterialGroup,
+                          geometry::internal::kHcDissipation},
                          penalty_method_contact_parameters_.dissipation));
   }
 
@@ -3801,10 +3802,10 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     const geometry::ProximityProperties* prop =
         inspector.GetProximityProperties(id);
     DRAKE_DEMAND(prop != nullptr);
-    DRAKE_THROW_UNLESS(prop->HasProperty(geometry::internal::kMaterialGroup,
-                                         geometry::internal::kFriction));
+    DRAKE_THROW_UNLESS(prop->HasProperty({geometry::internal::kMaterialGroup,
+                                         geometry::internal::kFriction}));
     return prop->GetProperty<CoulombFriction<double>>(
-        geometry::internal::kMaterialGroup, geometry::internal::kFriction);
+        {geometry::internal::kMaterialGroup, geometry::internal::kFriction});
   }
 
   // Checks that the provided State is consistent with this plant.

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -1442,35 +1442,35 @@ GTEST_TEST(MultibodyPlantTest, CollisionGeometryRegistration) {
   const double sphere1_stiffness = 980;    // N/m
   const double sphere1_dissipation = 3.2;  // s/m
   geometry::ProximityProperties sphere1_properties;
-  sphere1_properties.AddProperty(geometry::internal::kMaterialGroup,
-                                 geometry::internal::kFriction,
-                                 sphere1_friction);
-  sphere1_properties.AddProperty(geometry::internal::kMaterialGroup,
-                                 geometry::internal::kPointStiffness,
-                                 sphere1_stiffness);
-  sphere1_properties.AddProperty(geometry::internal::kMaterialGroup,
-                                 geometry::internal::kHcDissipation,
-                                 sphere1_dissipation);
+  sphere1_properties
+      .Add({geometry::internal::kMaterialGroup, geometry::internal::kFriction},
+           sphere1_friction)
+      .Add({geometry::internal::kMaterialGroup,
+            geometry::internal::kPointStiffness},
+           sphere1_stiffness)
+      .Add({geometry::internal::kMaterialGroup,
+            geometry::internal::kHcDissipation},
+           sphere1_dissipation);
   GeometryId sphere1_id = plant.RegisterCollisionGeometry(
       sphere1, RigidTransformd::Identity(), geometry::Sphere(radius),
       "collision", std::move(sphere1_properties));
 
   geometry::ProximityProperties sphere2_properties;
-  sphere2_properties.AddProperty("test", "dummy", 7);
+  sphere2_properties.Add("test/dummy", 7);
   CoulombFriction<double> sphere2_friction(0.7, 0.6);
   // estimated parameters for mass=1kg, penetration_tolerance=0.05m
   // and gravity g=9.8 m/s^2.
   const double sphere2_stiffness = 196;    // N/m
   const double sphere2_dissipation = 1.4;  // s/m
-  sphere2_properties.AddProperty(geometry::internal::kMaterialGroup,
-                                 geometry::internal::kFriction,
-                                 sphere2_friction);
-  sphere2_properties.AddProperty(geometry::internal::kMaterialGroup,
-                                 geometry::internal::kPointStiffness,
-                                 sphere2_stiffness);
-  sphere2_properties.AddProperty(geometry::internal::kMaterialGroup,
-                                 geometry::internal::kHcDissipation,
-                                 sphere2_dissipation);
+  sphere2_properties
+      .Add({geometry::internal::kMaterialGroup, geometry::internal::kFriction},
+           sphere2_friction)
+      .Add({geometry::internal::kMaterialGroup,
+            geometry::internal::kPointStiffness},
+           sphere2_stiffness)
+      .Add({geometry::internal::kMaterialGroup,
+            geometry::internal::kHcDissipation},
+           sphere2_dissipation);
   const RigidBody<double>& sphere2 =
       plant.AddRigidBody("Sphere2", SpatialInertia<double>());
   GeometryId sphere2_id = plant.RegisterCollisionGeometry(
@@ -1483,8 +1483,8 @@ GTEST_TEST(MultibodyPlantTest, CollisionGeometryRegistration) {
               nullptr);
     const geometry::ProximityProperties& props =
         *scene_graph.model_inspector().GetProximityProperties(sphere2_id);
-    EXPECT_TRUE(props.HasProperty("test", "dummy"));
-    EXPECT_EQ(props.GetProperty<int>("test", "dummy"), 7);
+    EXPECT_TRUE(props.HasProperty({"test", "dummy"}));
+    EXPECT_EQ(props.Get<int>({"test", "dummy"}), 7);
   }
 
   // We are done defining the model.
@@ -1542,29 +1542,32 @@ GTEST_TEST(MultibodyPlantTest, CollisionGeometryRegistration) {
   const geometry::ProximityProperties& sphere2_props =
       *scene_graph.model_inspector().GetProximityProperties(sphere2_id);
 
-  EXPECT_TRUE(ground_props.GetProperty<CoulombFriction<double>>(
-                  geometry::internal::kMaterialGroup,
-                  geometry::internal::kFriction) == ground_friction);
-  EXPECT_TRUE(sphere1_props.GetProperty<CoulombFriction<double>>(
-                  geometry::internal::kMaterialGroup,
-                  geometry::internal::kFriction) == sphere1_friction);
-  EXPECT_TRUE(sphere2_props.GetProperty<CoulombFriction<double>>(
-                  geometry::internal::kMaterialGroup,
-                  geometry::internal::kFriction) == sphere2_friction);
+  EXPECT_EQ(
+      ground_props.Get<CoulombFriction<double>>(
+          {geometry::internal::kMaterialGroup, geometry::internal::kFriction}),
+      ground_friction);
+  EXPECT_EQ(
+      sphere1_props.Get<CoulombFriction<double>>(
+          {geometry::internal::kMaterialGroup, geometry::internal::kFriction}),
+      sphere1_friction);
+  EXPECT_EQ(
+      sphere2_props.Get<CoulombFriction<double>>(
+          {geometry::internal::kMaterialGroup, geometry::internal::kFriction}),
+      sphere2_friction);
 
-  EXPECT_TRUE(sphere1_props.GetProperty<double>(
-                  geometry::internal::kMaterialGroup,
-                  geometry::internal::kPointStiffness) == sphere1_stiffness);
-  EXPECT_TRUE(sphere2_props.GetProperty<double>(
-                  geometry::internal::kMaterialGroup,
-                  geometry::internal::kPointStiffness) == sphere2_stiffness);
+  EXPECT_EQ(sphere1_props.Get<double>({geometry::internal::kMaterialGroup,
+                                       geometry::internal::kPointStiffness}),
+            sphere1_stiffness);
+  EXPECT_EQ(sphere2_props.Get<double>({geometry::internal::kMaterialGroup,
+                                       geometry::internal::kPointStiffness}),
+            sphere2_stiffness);
 
-  EXPECT_TRUE(sphere1_props.GetProperty<double>(
-                  geometry::internal::kMaterialGroup,
-                  geometry::internal::kHcDissipation) == sphere1_dissipation);
-  EXPECT_TRUE(sphere2_props.GetProperty<double>(
-                  geometry::internal::kMaterialGroup,
-                  geometry::internal::kHcDissipation) == sphere2_dissipation);
+  EXPECT_EQ(sphere1_props.Get<double>({geometry::internal::kMaterialGroup,
+                                       geometry::internal::kHcDissipation}),
+            sphere1_dissipation);
+  EXPECT_EQ(sphere2_props.Get<double>({geometry::internal::kMaterialGroup,
+                                       geometry::internal::kHcDissipation}),
+            sphere2_dissipation);
 }
 
 // Verifies the process of visual geometry registration with a SceneGraph.
@@ -1611,10 +1614,9 @@ GTEST_TEST(MultibodyPlantTest, VisualGeometryRegistration) {
       plant.AddRigidBody("Sphere2", SpatialInertia<double>());
   IllustrationProperties sphere2_props;
   const Vector4<double> sphere2_diffuse{0.1, 0.9, 0.1, 0.5};
-  sphere2_props.AddProperty("phong", "diffuse", sphere2_diffuse);
-  sphere2_props.AddProperty("phong", "diffuse_map", "empty.png");
-  sphere2_props.AddProperty("renderer", "accepting",
-                            std::set<std::string>{"not_dummy"});
+  sphere2_props.Add("phong/diffuse", sphere2_diffuse)
+      .Add("phong/diffuse_map", "empty.png")
+      .Add("renderer/accepting"}, std::set<std::string>{"not_dummy");
   GeometryId sphere2_id = plant.RegisterVisualGeometry(
       sphere2, RigidTransformd::Identity(), geometry::Sphere(radius), "visual",
       sphere2_props);
@@ -1644,7 +1646,7 @@ GTEST_TEST(MultibodyPlantTest, VisualGeometryRegistration) {
         inspector.GetIllustrationProperties(ground_id);
     ASSERT_NE(material, nullptr);
     // Undefined property value indicates use of default value.
-    EXPECT_FALSE(material->HasProperty("phong", "diffuse"));
+    EXPECT_FALSE(material->HasProperty({"phong", "diffuse"}));
   }
 
   // This implicitly assumes that there *is* a "phong"|"diffuse" material. An
@@ -1653,7 +1655,7 @@ GTEST_TEST(MultibodyPlantTest, VisualGeometryRegistration) {
     const IllustrationProperties* material =
         inspector.GetIllustrationProperties(id);
     return
-        material->GetProperty<Vector4<double>>("phong", "diffuse");
+        material->Get<Vector4<double>>({"phong", "diffuse"});
   };
   {
     const Vector4<double>& test_diffuse = get_diffuse_color(sphere1_id);
@@ -1667,8 +1669,8 @@ GTEST_TEST(MultibodyPlantTest, VisualGeometryRegistration) {
                                 MatrixCompareType::absolute));
     const IllustrationProperties* material =
         inspector.GetIllustrationProperties(sphere2_id);
-    ASSERT_TRUE(material->HasProperty("phong", "diffuse_map"));
-    EXPECT_EQ(material->GetProperty<std::string>("phong", "diffuse_map"),
+    ASSERT_TRUE(material->HasProperty({"phong", "diffuse_map"}));
+    EXPECT_EQ(material->Get<std::string>({"phong", "diffuse_map"}),
         "empty.png");
   }
 }

--- a/tutorials/rendering_multibody_plant.ipynb
+++ b/tutorials/rendering_multibody_plant.ipynb
@@ -392,7 +392,7 @@
     "for geometry_id in inspector.GetAllGeometryIds():\n",
     "    body = plant.GetBodyFromFrameId(inspector.GetFrameId(geometry_id))\n",
     "    geometry_label = inspector.GetPerceptionProperties(\n",
-    "        geometry_id).GetProperty(\"label\", \"id\")\n",
+    "        geometry_id).Get(\"label/id\"))\n",
     "    # WARNING: If you do not cast the `geometry_label` to `int`, this\n",
     "    # comparison will take a long time since NumPy will do\n",
     "    # element-by-element comparison using `RenderLabel.__eq__`.\n",


### PR DESCRIPTION
This is an exploration of the issues discussed in issue #13688. There are two *key* additions and then some incidental issues:

  1. Adds new `PropertyName` class for "naming" a property. 
    - Much of the `GeometryProperties` api uses `(const std::string& group, const std::string& property) in the parameter lists to identify a property. The API has now been extended to offer a preferred `(const PropertyName& property)` API instead. This reduces the brittleness of asking the caller to always keep those two strings coordinated at the all site.
  2. Gives the notion of "canonical" properties to a `GeometryProperties` child class. This entails convenience methods for getting `PropertyName` values for those canonical  properties as well as the opportunity to validate them when they are added to the set (without limiting the ability to add arbitrary properties above and beyond the canonical properties).

Incidentally:
  - Historically, a property would be written as `('group', 'property')` in documentation and error messages. This is both tedious to write and a pain to use in regular expressions (e.g., in tests). We're changing this convention to be `group/property` (more like a XML-style path). None of the funtional API actually relied on how we would denote a property in text, so the change is benign.
  - We deprecate the old (group, property) geometry properties API
  - Begin deprecating the old mechanism for coordinating the previous code used for coordinating canonical properties in Drake.

The purpose of this draft PR is to solicit feedback on a possible resolution of #13688.

To that end, each revision offers a different piece of functionality. Find the changes that interest you most and give feedback:

Revision 1: Add `PropertyName` and the API for `GeometryProperties` to use it.
Revision 2: Change string representation from `('group', 'property')` to `group/property`
Revision 3: Add python bindings to the `PropertyName` based API.
Revision 4: Deprecate the old (string, string) API of `GeometryProperties` in favor of the `PropertyName`-based API.
Revision 5: Modify `GeometryProperties` so derived classes have a mechanism for validating properties upon registration.
Revision 6: `ProximityProperties` documents and implements its "canonical properties"
Revision 7: All uses of `geometry::internal::kMaterialGroup`, etc., for working with canonical proximity properties have been replaced with calls to the `ProximityProperties` API and the internal strings have been removed.

Any subsequent revision reflects tweaks to the branch based on comment or CI failure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13742)
<!-- Reviewable:end -->
