### PR TITLE
multibody: Implement PlanarJoint

### DIFF
--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -103,6 +103,7 @@ drake_cc_library(
         "multibody_forces.cc",
         "multibody_tree.cc",
         "multibody_tree_system.cc",
+        "planar_joint.cc",
         "planar_mobilizer.cc",
         "prismatic_joint.cc",
         "prismatic_mobilizer.cc",
@@ -140,6 +141,7 @@ drake_cc_library(
         "multibody_tree.h",
         "multibody_tree-inl.h",
         "multibody_tree_system.h",
+        "planar_joint.h",
         "planar_mobilizer.h",
         "prismatic_joint.h",
         "prismatic_mobilizer.h",
@@ -507,6 +509,14 @@ drake_cc_googletest(
     name = "ball_rpy_joint_test",
     deps = [
         ":tree",
+    ],
+)
+
+drake_cc_googletest(
+    name = "planar_joint_test",
+    deps = [
+        ":tree",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/multibody/tree/planar_joint.cc
+++ b/multibody/tree/planar_joint.cc
@@ -1,0 +1,69 @@
+#include "drake/multibody/tree/planar_joint.h"
+
+#include <memory>
+
+#include "drake/multibody/tree/multibody_tree.h"
+
+namespace drake {
+namespace multibody {
+
+template <typename T>
+template <typename ToScalar>
+std::unique_ptr<Joint<ToScalar>> PlanarJoint<T>::TemplatedDoCloneToScalar(
+    const internal::MultibodyTree<ToScalar>& tree_clone) const {
+  const Frame<ToScalar>& frame_on_parent_body_clone =
+      tree_clone.get_variant(this->frame_on_parent());
+  const Frame<ToScalar>& frame_on_child_body_clone =
+      tree_clone.get_variant(this->frame_on_child());
+
+  // Make the Joint<T> clone.
+  auto joint_clone = std::make_unique<PlanarJoint<ToScalar>>(
+      this->name(), frame_on_parent_body_clone, frame_on_child_body_clone,
+      this->damping());
+  joint_clone->set_position_limits(this->position_lower_limits(),
+                                   this->position_upper_limits());
+  joint_clone->set_velocity_limits(this->velocity_lower_limits(),
+                                   this->velocity_upper_limits());
+  joint_clone->set_acceleration_limits(this->acceleration_lower_limits(),
+                                       this->acceleration_upper_limits());
+
+  return joint_clone;
+}
+
+template <typename T>
+std::unique_ptr<Joint<double>> PlanarJoint<T>::DoCloneToScalar(
+    const internal::MultibodyTree<double>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
+template <typename T>
+std::unique_ptr<Joint<AutoDiffXd>> PlanarJoint<T>::DoCloneToScalar(
+    const internal::MultibodyTree<AutoDiffXd>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
+template <typename T>
+std::unique_ptr<Joint<symbolic::Expression>> PlanarJoint<T>::DoCloneToScalar(
+    const internal::MultibodyTree<symbolic::Expression>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
+// N.B. Due to esoteric linking errors on Mac (see #9345) involving
+// `MobilizerImpl`, we must place this implementation in the source file, not
+// in the header file.
+template <typename T>
+std::unique_ptr<typename Joint<T>::BluePrint>
+PlanarJoint<T>::MakeImplementationBlueprint() const {
+  auto blue_print = std::make_unique<typename Joint<T>::BluePrint>();
+  auto planar_mobilizer = std::make_unique<internal::PlanarMobilizer<T>>(
+      this->frame_on_parent(), this->frame_on_child());
+  planar_mobilizer->set_default_position(this->default_positions());
+  blue_print->mobilizers_.push_back(std::move(planar_mobilizer));
+  return blue_print;
+}
+
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::PlanarJoint)

--- a/multibody/tree/planar_joint.h
+++ b/multibody/tree/planar_joint.h
@@ -1,0 +1,367 @@
+#pragma once
+
+#include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/multibody/tree/joint.h"
+#include "drake/multibody/tree/multibody_forces.h"
+#include "drake/multibody/tree/planar_mobilizer.h"
+
+namespace drake {
+namespace multibody {
+
+/// This joint models a planar joint allowing two bodies to translate and rotate
+/// relative to one another in a plane with three degrees of freedom.
+/// That is, given a frame F attached to the parent body P and a frame M
+/// attached to the child body B (see the Joint class's documentation), this
+/// joint allows frame M to translate within the x-y plane of frame F and to
+/// rotate about the z-axis, with M's z-axis Mz and F's z-axis Fz coincident at
+/// all times. The translations along the x- and y-axes of F, the rotation about
+/// the z-axis and their rates specify the state of the joint.
+/// Zero (x, y, θ) corresponds to frames F and M being coincident and aligned.
+/// Translation (x, y) is defined to be positive in the direction of the
+/// respective axes and the rotation θ is defined to be positive according to
+/// the right-hand-rule with the thumb aligned in the direction of frame F's
+/// z-axis.
+///
+/// @tparam_default_scalar
+template <typename T>
+class PlanarJoint final : public Joint<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PlanarJoint)
+
+  template <typename Scalar>
+  using Context = systems::Context<Scalar>;
+
+  /// The name for this Joint type.
+  static constexpr char kTypeName[] = "planar";
+
+  /// Constructor to create a planar joint between two bodies so that frame F
+  /// attached to the parent body P and frame M attached to the child body B
+  /// translate and rotate as described in the class's documentation.
+  /// This constructor signature creates a joint with no joint limits, i.e. the
+  /// joint position, velocity and acceleration limits are the pair `(-∞, ∞)`.
+  /// These can be set using the Joint methods set_position_limits(),
+  /// set_velocity_limits() and set_acceleration_limits().
+  /// The first three arguments to this constructor are those of the Joint class
+  /// constructor. See the Joint class's documentation for details.
+  /// The additional parameters are:
+  /// @param[in] damping
+  ///   Viscous damping coefficient, in N⋅s/m for translation and N⋅m⋅s for
+  ///   rotation, used to model losses within the joint. See documentation of
+  ///   damping() for details on modelling of the damping force and torque.
+  /// @throws std::exception if any element of damping is negative.
+  PlanarJoint(const std::string& name, const Frame<T>& frame_on_parent,
+              const Frame<T>& frame_on_child, Vector3<double> damping)
+      : Joint<T>(name, frame_on_parent, frame_on_child,
+                 VectorX<double>::Constant(
+                     3, -std::numeric_limits<double>::infinity()),
+                 VectorX<double>::Constant(
+                     3, std::numeric_limits<double>::infinity()),
+                 VectorX<double>::Constant(
+                     3, -std::numeric_limits<double>::infinity()),
+                 VectorX<double>::Constant(
+                     3, std::numeric_limits<double>::infinity()),
+                 VectorX<double>::Constant(
+                     3, -std::numeric_limits<double>::infinity()),
+                 VectorX<double>::Constant(
+                     3, std::numeric_limits<double>::infinity())) {
+    DRAKE_THROW_UNLESS((damping.array() >= 0).all());
+    damping_ = damping;
+  }
+
+  const std::string& type_name() const final {
+    static const never_destroyed<std::string> name{kTypeName};
+    return name.access();
+  }
+
+  /// Returns `this` joint's damping constant in N⋅s/m for the translational
+  /// degrees and N⋅m⋅s for the rotational degree. The damping force (in N) is
+  /// modeled as `fᵢ = -dampingᵢ⋅vᵢ, i = 1, 2` i.e. opposing motion, with vᵢ
+  /// the translation rates along the i-th axis for `this` joint (see
+  /// get_translational_velocity()) and fᵢ the force on child body B at Mo and
+  /// expressed in F. That is, f_BMo_F = (f₁, f₂). The damping torque (in N⋅m)
+  /// is modeled as `τ = -damping₃⋅ω` i.e. opposing motion, with ω the angular
+  /// rate for `this` joint (see get_angular_velocity()) and τ the torque on
+  /// child body B expressed in frame F as t_B_F = τ⋅Fz_F.
+  Vector3<double> damping() const { return damping_; }
+
+  /// @name Context-dependent value access
+  /// @{
+
+  /// Gets the position of `this` joint from `context`.
+  ///
+  /// @param[in] context The context of the model this joint belongs to.
+  /// @retval p_FoMo_F The position of `this` joint stored in the `context`
+  ///                  ordered as (x, y). See class documentation for details.
+  Vector2<T> get_translation(const Context<T>& context) const {
+    return get_mobilizer()->get_translations(context);
+  }
+
+  /// Sets the `context` so that the position of `this` joint equals `p_FoMo_F`.
+  ///
+  /// @param[in] context The context of the model this joint belongs to.
+  /// @param[in] p_FoMo_F The desired position in meters to be stored in
+  ///                     `context` ordered as (x, y). See class documentation
+  ///                     for details.
+  /// @returns a constant reference to `this` joint.
+  const PlanarJoint<T>& set_translation(Context<T>* context,
+                                        const Vector2<T>& p_FoMo_F) const {
+    get_mobilizer()->set_translations(context, p_FoMo_F);
+    return *this;
+  }
+
+  /// Gets the angle θ of `this` joint from `context`.
+  ///
+  /// @param[in] context The context of the model this joint belongs to.
+  /// @retval theta The angle of `this` joint stored in the `context`. See class
+  ///               documentation for details.
+  const T& get_rotation(const systems::Context<T>& context) const {
+    return get_mobilizer()->get_angle(context);
+  }
+
+  /// Sets the `context` so that the angle θ of `this` joint equals `theta`.
+  ///
+  /// @param[in] context The context of the model this joint belongs to.
+  /// @param[in] theta The desired angle in radians to be stored in `context`.
+  ///                  See class documentation for details.
+  /// @returns a constant reference to `this` joint.
+  const PlanarJoint<T>& set_rotation(systems::Context<T>* context,
+                                     const T& theta) const {
+    get_mobilizer()->set_angle(context, theta);
+    return *this;
+  }
+
+  /// Sets the `context` so that the position of `this` joint equals `p_FoMo_F`
+  /// and its angle equals `theta`.
+  ///
+  /// @param[in] context The context of the model this joint belongs to.
+  /// @param[in] p_FoMo_F The desired position in meters to be stored in
+  ///                     `context` ordered as (x, y). See class documentation
+  ///                     for details.
+  /// @param[in] theta The desired angle in radians to be stored in `context`.
+  ///                  See class documentation for details.
+  /// @returns a constant reference to `this` joint.
+  const PlanarJoint<T>& set_pose(systems::Context<T>* context,
+                                 const Vector2<T>& p_FoMo_F,
+                                 const T& theta) const {
+    get_mobilizer()->set_translations(context, p_FoMo_F);
+    get_mobilizer()->set_angle(context, theta);
+    return *this;
+  }
+
+  /// Gets the translational velocity v_FoMo_F, in meters per second, of `this`
+  /// joint's Mo measured and expressed in frame F from `context`.
+  /// @param[in] context The context of the model this joint belongs to.
+  /// @retval v_FoMo_F The translational velocity of `this` joint as stored in
+  ///                  the `context`.
+  Vector2<T> get_translational_velocity(
+      const systems::Context<T>& context) const {
+    return get_mobilizer()->get_translation_rates(context);
+  }
+
+  /// Sets the translational velocity, in meters per second, of this `this`
+  /// joint's Mo measured and expressed in frame F  to `v_FoMo_F`. The new
+  /// translational velocity gets stored in `context`.
+  /// @param[in] context The context of the model this joint belongs to.
+  /// @param[in] v_FoMo_F The desired translational velocity of `this` joint in
+  ///                     meters per second.
+  /// @returns a constant reference to `this` joint.
+  const PlanarJoint<T>& set_translational_velocity(
+      systems::Context<T>* context, const Vector2<T>& v_FoMo_F) const {
+    get_mobilizer()->set_translation_rates(context, v_FoMo_F);
+    return *this;
+  }
+
+  /// Gets the rate of change, in radians per second, of `this` joint's angle
+  /// θ from `context`.  See class documentation for the definition of this
+  /// angle.
+  ///
+  /// @param[in] context The context of the model this joint belongs to.
+  /// @retval theta_dot The rate of change of `this` joint's angle θ as
+  ///                   stored in the `context`.
+  const T& get_angular_velocity(const systems::Context<T>& context) const {
+    return get_mobilizer()->get_angular_rate(context);
+  }
+
+  /// Sets the rate of change, in radians per second, of `this` joint's angle
+  /// θ (see class documentation) to `theta_dot`. The new rate of change gets
+  /// stored in `context`.
+  ///
+  /// @param[in] context The context of the model this joint belongs to.
+  /// @param[in] theta_dot The desired rates of change of `this` joint's
+  ///                      angle in radians per second.
+  /// @returns a constant reference to `this` joint.
+  const PlanarJoint<T>& set_angular_velocity(systems::Context<T>* context,
+                                             const T& theta_dot) const {
+    get_mobilizer()->set_angular_rate(context, theta_dot);
+    return *this;
+  }
+
+  /// @}
+
+  /// Gets the default position for `this` joint.
+  /// @retval p_FoMo_F The default position of `this` joint.
+  Vector2<double> get_default_translation() const {
+    return this->default_positions().head(2);
+  }
+
+  /// Sets the default position of this joint.
+  /// @param[in] p_FoMo_F The desired default position of the joint
+  void set_default_translation(const Vector2<double>& p_FoMo_F) {
+    Vector3<double> state(p_FoMo_F[0], p_FoMo_F[1],
+                          this->default_positions()[2]);
+    this->set_default_positions(state);
+  }
+
+  /// Gets the default angle for `this` joint.
+  /// @retval theta The default angle of `this` joint.
+  double get_default_rotation() const { return this->default_positions()[2]; }
+
+  /// Sets the default angle of this joint.
+  /// @param[in] theta The desired default angle of the joint
+  void set_default_rotation(const double& theta) {
+    Vector3<double> state = this->default_positions();
+    state[2] = theta;
+    this->set_default_positions(state);
+  }
+
+  /// Sets the default position and angle of this joint.
+  /// @param[in] p_FoMo_F The desired default position of the joint
+  /// @param[in] theta The desired default angle of the joint
+  void set_default_pose(const Vector2<double>& p_FoMo_F, const double& theta) {
+    Vector3<double> state(p_FoMo_F[0], p_FoMo_F[1], theta);
+    this->set_default_positions(state);
+  }
+
+  /// Sets the random distribution that the position and angle of this
+  /// joint will be randomly sampled from. See class documentation for details
+  /// on the definition of the position and angle.
+  void set_random_pose_distribution(
+      const Vector2<symbolic::Expression>& p_FoMo_F,
+      const symbolic::Expression& theta) {
+    Vector3<symbolic::Expression> state(p_FoMo_F[0], p_FoMo_F[1], theta);
+    get_mutable_mobilizer()->set_random_position_distribution(state);
+  }
+
+ private:
+  /// Joint<T> override called through public NVI, Joint::AddInForce().
+  /// Therefore arguments were already checked to be valid.
+  /// For a PlanarJoint, we must always have `joint_dof < 3` since there are
+  /// three degrees of freedom (num_velocities() == 3). `joint_tau` is the force
+  /// applied along the x-axis of the parent  frame F if `joint_dof = 0`, the
+  /// force applied along the y-axis of the parent frame F if `joint_dof = 1`,
+  /// or the torque about the z-axis of the parent frame F if `joint_dof = 2`.
+  /// The force is applied to the body declared as child (according to the
+  /// planar joint's constructor) at the origin of the child frame M. The force
+  /// is defined to be positive in the direction of the selected axis and the
+  /// torque is defined to be positive according to the right hand rule about
+  /// the selected axis. That is, a positive force causes a positive
+  /// translational acceleration and a positive torque causes a positive angular
+  /// acceleration (of the child body frame).
+  void DoAddInOneForce(const systems::Context<T>&, int joint_dof,
+                       const T& joint_tau,
+                       MultibodyForces<T>* forces) const final {
+    DRAKE_DEMAND(joint_dof < 3);
+    Eigen::VectorBlock<Eigen::Ref<VectorX<T>>> tau_mob =
+        get_mobilizer()->get_mutable_generalized_forces_from_array(
+            &forces->mutable_generalized_forces());
+    tau_mob(joint_dof) += joint_tau;
+  }
+
+  /// Joint<T> override called through public NVI, Joint::AddInDamping().
+  /// Therefore arguments were already checked to be valid.
+  /// This method adds into `forces` a dissipative force according to the
+  /// viscous law `f = -d⋅v`, with d the damping coefficient (see damping()).
+  void DoAddInDamping(const systems::Context<T>& context,
+                      MultibodyForces<T>* forces) const final {
+    Eigen::VectorBlock<Eigen::Ref<VectorX<T>>> tau =
+        get_mobilizer()->get_mutable_generalized_forces_from_array(
+            &forces->mutable_generalized_forces());
+    const Vector2<T>& v_translation = get_translational_velocity(context);
+    const T& v_angular = get_angular_velocity(context);
+    const Vector3<double> damping_coeff = damping();
+    tau[0] -= damping_coeff[0] * v_translation[0];
+    tau[1] -= damping_coeff[1] * v_translation[1];
+    tau[2] -= damping_coeff[2] * v_angular;
+  }
+
+  int do_get_velocity_start() const final {
+    return get_mobilizer()->velocity_start_in_v();
+  }
+
+  int do_get_num_velocities() const final { return 3; }
+
+  int do_get_position_start() const final {
+    return get_mobilizer()->position_start_in_q();
+  }
+
+  int do_get_num_positions() const final { return 3; }
+
+  void do_set_default_positions(
+      const VectorX<double>& default_positions) final {
+    if (this->has_implementation()) {
+      get_mutable_mobilizer()->set_default_position(default_positions);
+    }
+  }
+
+  // Joint<T> overrides:
+  std::unique_ptr<typename Joint<T>::BluePrint> MakeImplementationBlueprint()
+      const final;
+
+  std::unique_ptr<Joint<double>> DoCloneToScalar(
+      const internal::MultibodyTree<double>& tree_clone) const final;
+
+  std::unique_ptr<Joint<AutoDiffXd>> DoCloneToScalar(
+      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const final;
+
+  std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
+      const internal::MultibodyTree<symbolic::Expression>&) const final;
+
+  // Make PlanarJoint templated on every other scalar type a friend of
+  // PlanarJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access
+  // private members of PlanarJoint<T>.
+  template <typename>
+  friend class PlanarJoint;
+
+  // Returns the mobilizer implementing this joint.
+  // The internal implementation of this joint could change in a future version.
+  // However its public API should remain intact.
+  const internal::PlanarMobilizer<T>* get_mobilizer() const {
+    // This implementation should only have one mobilizer.
+    DRAKE_DEMAND(this->get_implementation().num_mobilizers() == 1);
+    const internal::PlanarMobilizer<T>* mobilizer =
+        dynamic_cast<const internal::PlanarMobilizer<T>*>(
+            this->get_implementation().mobilizers_[0]);
+    DRAKE_DEMAND(mobilizer != nullptr);
+    return mobilizer;
+  }
+
+  internal::PlanarMobilizer<T>* get_mutable_mobilizer() {
+    // This implementation should only have one mobilizer.
+    DRAKE_DEMAND(this->get_implementation().num_mobilizers() == 1);
+    auto* mobilizer = dynamic_cast<internal::PlanarMobilizer<T>*>(
+        this->get_implementation().mobilizers_[0]);
+    DRAKE_DEMAND(mobilizer != nullptr);
+    return mobilizer;
+  }
+
+  // Helper method to make a clone templated on ToScalar.
+  template <typename ToScalar>
+  std::unique_ptr<Joint<ToScalar>> TemplatedDoCloneToScalar(
+      const internal::MultibodyTree<ToScalar>& tree_clone) const;
+
+  // This joint's damping constant in N⋅s/m for translation and N⋅m⋅s for
+  // rotation.
+  Vector3<double> damping_;
+};
+
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::PlanarJoint)

--- a/multibody/tree/test/planar_joint_test.cc
+++ b/multibody/tree/test/planar_joint_test.cc
@@ -1,0 +1,268 @@
+// clang-format: off
+#include "drake/multibody/tree/multibody_tree-inl.h"
+// clang-format: on
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/multibody/tree/planar_joint.h"
+#include "drake/multibody/tree/rigid_body.h"
+#include "drake/systems/framework/context.h"
+
+namespace drake {
+namespace multibody {
+namespace {
+
+using Eigen::Vector2d;
+using Eigen::Vector3d;
+using systems::Context;
+
+constexpr double kPositionLowerLimit = -1.0;
+constexpr double kPositionUpperLimit = 1.5;
+constexpr double kVelocityLowerLimit = -1.1;
+constexpr double kVelocityUpperLimit = 1.6;
+constexpr double kAccelerationLowerLimit = -1.2;
+constexpr double kAccelerationUpperLimit = 1.7;
+constexpr double kDamping = 3;
+constexpr double kPositionNonZeroDefault = 0.25;
+
+class PlanarJointTest : public ::testing::Test {
+ public:
+  // Creates a MultibodyTree model with a body attached to the world via a
+  // planar joint.
+  void SetUp() override {
+    // Spatial inertia for adding bodies. The actual value is not important for
+    // these tests and therefore we do not initialize it.
+    const SpatialInertia<double> M_B;  // Default construction is ok for this.
+
+    // Create an empty model.
+    auto model = std::make_unique<internal::MultibodyTree<double>>();
+
+    // Add a body so we can add a joint between it and the world:
+    body_ = &model->AddBody<RigidBody>(M_B);
+
+    // Add a planar joint between the world and body1:
+    joint_ = &model->AddJoint<PlanarJoint>("Joint", model->world_body(),
+                                           std::nullopt, *body_, std::nullopt,
+                                           Vector3d::Constant(kDamping));
+    mutable_joint_ = dynamic_cast<PlanarJoint<double>*>(
+        &model->get_mutable_joint(joint_->index()));
+    DRAKE_DEMAND(mutable_joint_);
+    mutable_joint_->set_position_limits(
+        Vector3d::Constant(kPositionLowerLimit),
+        Vector3d::Constant(kPositionUpperLimit));
+    mutable_joint_->set_velocity_limits(
+        Vector3d::Constant(kVelocityLowerLimit),
+        Vector3d::Constant(kVelocityUpperLimit));
+    mutable_joint_->set_acceleration_limits(
+        Vector3d::Constant(kAccelerationLowerLimit),
+        Vector3d::Constant(kAccelerationUpperLimit));
+
+    // We are done adding modeling elements. Transfer tree to system and get
+    // a Context.
+    system_ = std::make_unique<internal::MultibodyTreeSystem<double>>(
+        std::move(model));
+    context_ = system_->CreateDefaultContext();
+  }
+
+  const internal::MultibodyTree<double>& tree() const {
+    return internal::GetInternalTree(*system_);
+  }
+
+ protected:
+  std::unique_ptr<internal::MultibodyTreeSystem<double>> system_;
+  std::unique_ptr<Context<double>> context_;
+
+  const RigidBody<double>* body_{nullptr};
+  const PlanarJoint<double>* joint_{nullptr};
+  PlanarJoint<double>* mutable_joint_{nullptr};
+};
+
+TEST_F(PlanarJointTest, Type) {
+  const Joint<double>& base = *joint_;
+  EXPECT_EQ(base.type_name(), "planar");
+}
+
+// Verify the expected number of dofs.
+TEST_F(PlanarJointTest, NumDOFs) {
+  EXPECT_EQ(tree().num_positions(), 3);
+  EXPECT_EQ(tree().num_velocities(), 3);
+  EXPECT_EQ(joint_->num_positions(), 3);
+  EXPECT_EQ(joint_->num_velocities(), 3);
+  EXPECT_EQ(joint_->position_start(), 0);
+  EXPECT_EQ(joint_->velocity_start(), 0);
+}
+
+TEST_F(PlanarJointTest, GetJointLimits) {
+  EXPECT_EQ(joint_->position_lower_limits().size(), 3);
+  EXPECT_EQ(joint_->position_upper_limits().size(), 3);
+  EXPECT_EQ(joint_->velocity_lower_limits().size(), 3);
+  EXPECT_EQ(joint_->velocity_upper_limits().size(), 3);
+  EXPECT_EQ(joint_->acceleration_lower_limits().size(), 3);
+  EXPECT_EQ(joint_->acceleration_upper_limits().size(), 3);
+
+  EXPECT_EQ(joint_->position_lower_limits(),
+            Vector3d::Constant(kPositionLowerLimit));
+  EXPECT_EQ(joint_->position_upper_limits(),
+            Vector3d::Constant(kPositionUpperLimit));
+  EXPECT_EQ(joint_->velocity_lower_limits(),
+            Vector3d::Constant(kVelocityLowerLimit));
+  EXPECT_EQ(joint_->velocity_upper_limits(),
+            Vector3d::Constant(kVelocityUpperLimit));
+  EXPECT_EQ(joint_->acceleration_lower_limits(),
+            Vector3d::Constant(kAccelerationLowerLimit));
+  EXPECT_EQ(joint_->acceleration_upper_limits(),
+            Vector3d::Constant(kAccelerationUpperLimit));
+  EXPECT_EQ(joint_->damping(), Vector3d::Constant(kDamping));
+}
+
+// Context-dependent value access.
+TEST_F(PlanarJointTest, ContextDependentAccess) {
+  const Vector2d translation1(1, 0.3);
+  const double angle1 = 1.5;
+  const Vector2d translation2(2, 2.3);
+  const double angle2 = 3;
+  // Position access:
+  joint_->set_translation(context_.get(), translation1);
+  EXPECT_EQ(joint_->get_translation(*context_), translation1);
+  joint_->set_rotation(context_.get(), angle1);
+  EXPECT_EQ(joint_->get_rotation(*context_), angle1);
+  joint_->set_pose(context_.get(), translation2, angle2);
+  EXPECT_EQ(joint_->get_translation(*context_), translation2);
+  EXPECT_EQ(joint_->get_rotation(*context_), angle2);
+
+  // Velocity access:
+  joint_->set_translational_velocity(context_.get(), translation1);
+  EXPECT_EQ(joint_->get_translational_velocity(*context_), translation1);
+  joint_->set_angular_velocity(context_.get(), angle1);
+  EXPECT_EQ(joint_->get_angular_velocity(*context_), angle1);
+}
+
+// Tests API to apply torques to individual dof of joint. Ensures that adding
+// forces individually is equivalent to adding forces collectively.
+TEST_F(PlanarJointTest, AddInOneForce) {
+  const double force_value = M_PI_2;
+  const double kEpsilon = std::numeric_limits<double>::epsilon();
+  MultibodyForces<double> forces1(tree());
+  MultibodyForces<double> forces2(tree());
+
+  for (int ii = 0; ii < joint_->num_positions(); ii++) {
+    // Add value twice:
+    joint_->AddInOneForce(*context_, ii, force_value, &forces1);
+    joint_->AddInOneForce(*context_, ii, force_value, &forces1);
+    // Add value only once:
+    joint_->AddInOneForce(*context_, ii, force_value, &forces2);
+  }
+  // Add forces2 into itself (same as adding torque twice):
+  forces2.AddInForces(forces2);
+
+  // forces1 and forces2 should be equal:
+  EXPECT_EQ(forces1.generalized_forces(), forces2.generalized_forces());
+  auto F2 = forces2.body_forces().cbegin();
+  for (auto& F1 : forces1.body_forces())
+    EXPECT_TRUE(F1.IsApprox(*F2++, kEpsilon));
+}
+
+TEST_F(PlanarJointTest, Clone) {
+  auto model_clone = tree().CloneToScalar<AutoDiffXd>();
+  const auto& joint_clone = model_clone->get_variant(*joint_);
+
+  EXPECT_EQ(joint_clone.name(), joint_->name());
+  EXPECT_EQ(joint_clone.frame_on_parent().index(),
+            joint_->frame_on_parent().index());
+  EXPECT_EQ(joint_clone.frame_on_child().index(),
+            joint_->frame_on_child().index());
+  EXPECT_EQ(joint_clone.position_lower_limits(),
+            joint_->position_lower_limits());
+  EXPECT_EQ(joint_clone.position_upper_limits(),
+            joint_->position_upper_limits());
+  EXPECT_EQ(joint_clone.velocity_lower_limits(),
+            joint_->velocity_lower_limits());
+  EXPECT_EQ(joint_clone.velocity_upper_limits(),
+            joint_->velocity_upper_limits());
+  EXPECT_EQ(joint_clone.acceleration_lower_limits(),
+            joint_->acceleration_lower_limits());
+  EXPECT_EQ(joint_clone.acceleration_upper_limits(),
+            joint_->acceleration_upper_limits());
+  EXPECT_EQ(joint_clone.damping(), joint_->damping());
+}
+
+TEST_F(PlanarJointTest, DefaultState) {
+  const Vector2d new_default_translation =
+      Vector2d::Constant(kPositionNonZeroDefault);
+  const Vector2d out_of_bounds_low_translation =
+      Vector2d::Constant(kPositionLowerLimit - 1);
+  const Vector2d out_of_bounds_high_translation =
+      Vector2d::Constant(kPositionUpperLimit + 1);
+
+  const double new_default_rotation = kPositionNonZeroDefault;
+  const double out_of_bounds_low_rotation = kPositionLowerLimit - 1;
+  const double out_of_bounds_high_rotation = kPositionUpperLimit + 1;
+
+  // Constructor should set the default translation to Vector2d::Zero() and
+  // rotation to zero.
+  EXPECT_EQ(joint_->get_default_translation(), Vector2d::Zero());
+  EXPECT_EQ(joint_->get_default_rotation(), 0);
+
+  // Setting a new default translation should propagate so that
+  // `get_default_translation()` remains correct.
+  mutable_joint_->set_default_translation(new_default_translation);
+  EXPECT_EQ(joint_->get_default_translation(), new_default_translation);
+
+  // Setting a new default rotation should propagate so that
+  // `get_default_rotation()` remains correct.
+  mutable_joint_->set_default_rotation(new_default_rotation);
+  EXPECT_EQ(joint_->get_default_rotation(), new_default_rotation);
+
+  // Setting the default translation or rotation out of the bounds of the limits
+  // should NOT throw an exception.
+  EXPECT_NO_THROW(
+      mutable_joint_->set_default_translation(out_of_bounds_low_translation));
+  EXPECT_NO_THROW(
+      mutable_joint_->set_default_translation(out_of_bounds_high_translation));
+  EXPECT_NO_THROW(
+      mutable_joint_->set_default_rotation(out_of_bounds_low_rotation));
+  EXPECT_NO_THROW(
+      mutable_joint_->set_default_rotation(out_of_bounds_high_rotation));
+
+  // Setting a new default pose should propagate so that
+  // `get_default_translation()` and `get_default_rotation()` remain correct.
+  mutable_joint_->set_default_pose(new_default_translation,
+                                   new_default_rotation);
+  EXPECT_EQ(joint_->get_default_translation(), new_default_translation);
+  EXPECT_EQ(joint_->get_default_rotation(), new_default_rotation);
+}
+
+TEST_F(PlanarJointTest, RandomState) {
+  RandomGenerator generator;
+  std::uniform_real_distribution<symbolic::Expression> uniform;
+
+  tree().SetRandomState(*context_, &context_->get_mutable_state(), &generator);
+
+  EXPECT_EQ(joint_->get_translation(*context_), Vector2d::Zero());
+  EXPECT_EQ(joint_->get_rotation(*context_), 0);
+
+  mutable_joint_->set_random_pose_distribution(
+      Vector2<symbolic::Expression>(uniform(generator) + 1.0,
+                                    uniform(generator) + 2.0),
+      uniform(generator) + 3.0);
+  tree().SetRandomState(*context_, &context_->get_mutable_state(), &generator);
+  EXPECT_GE(mutable_joint_->get_translation(*context_)[0], 1.0);
+  EXPECT_LE(mutable_joint_->get_translation(*context_)[0], 2.0);
+  EXPECT_GE(mutable_joint_->get_translation(*context_)[1], 2.0);
+  EXPECT_LE(mutable_joint_->get_translation(*context_)[1], 3.0);
+  EXPECT_GE(mutable_joint_->get_rotation(*context_), 3.0);
+  EXPECT_LE(mutable_joint_->get_rotation(*context_), 4.0);
+
+  // Check that they change on a second draw from the distribution.
+  const Vector2d last_translation = mutable_joint_->get_translation(*context_);
+  const double last_rotation = mutable_joint_->get_rotation(*context_);
+  tree().SetRandomState(*context_, &context_->get_mutable_state(), &generator);
+  EXPECT_NE(mutable_joint_->get_translation(*context_), last_translation);
+  EXPECT_NE(mutable_joint_->get_rotation(*context_), last_rotation);
+}
+
+}  // namespace
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Adds a 3 dof planar joint that allows motion in the xy plane and rotation about the z-axis of the parent frame.

- [x] Requires #13711 

Towards #12404
Relates #12401

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13747)
<!-- Reviewable:end -->
