### PR TITLE
framework: Split diagram_state files out of diagram_context

### DIFF
--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -30,6 +30,7 @@ drake_cc_package_library(
         ":diagram_continuous_state",
         ":diagram_discrete_values",
         ":diagram_output_port",
+        ":diagram_state",
         ":discrete_values",
         ":event_collection",
         ":framework_common",
@@ -552,13 +553,31 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "diagram_state",
+    srcs = ["diagram_state.cc"],
+    hdrs = ["diagram_state.h"],
+    deps = [
+        ":abstract_values",
+        ":continuous_state",
+        ":diagram_continuous_state",
+        ":diagram_discrete_values",
+        ":discrete_values",
+        ":state",
+        "//common:default_scalars",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
     name = "diagram_context",
     srcs = ["diagram_context.cc"],
     hdrs = ["diagram_context.h"],
     deps = [
         ":context",
-        ":diagram_continuous_state",
-        ":diagram_discrete_values",
+        ":diagram_state",
+        ":framework_common",
+        ":parameters",
+        ":state",
         ":vector",
         "//common:default_scalars",
         "//common:essential",

--- a/systems/framework/diagram_context.cc
+++ b/systems/framework/diagram_context.cc
@@ -1,7 +1,4 @@
 #include "drake/systems/framework/diagram_context.h"
 
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
-    class ::drake::systems::DiagramState)
-
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::DiagramContext)

--- a/systems/framework/diagram_context.h
+++ b/systems/framework/diagram_context.h
@@ -1,10 +1,7 @@
 #pragma once
 
-#include <map>
 #include <memory>
 #include <optional>
-#include <set>
-#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -13,99 +10,13 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/context.h"
-#include "drake/systems/framework/diagram_continuous_state.h"
-#include "drake/systems/framework/diagram_discrete_values.h"
-#include "drake/systems/framework/fixed_input_port_value.h"
+#include "drake/systems/framework/diagram_state.h"
 #include "drake/systems/framework/framework_common.h"
 #include "drake/systems/framework/parameters.h"
 #include "drake/systems/framework/state.h"
-#include "drake/systems/framework/supervector.h"
 
 namespace drake {
 namespace systems {
-
-// TODO(sherm1) This should be in its own file.
-/// DiagramState is a State, annotated with pointers to all the mutable
-/// substates that it spans.
-template <typename T>
-class DiagramState : public State<T> {
- public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiagramState)
-
-  /// Constructs a DiagramState consisting of @p size substates.
-  explicit DiagramState<T>(int size) :
-      State<T>(),
-      substates_(size),
-      owned_substates_(size) {}
-
-  /// Sets the substate at @p index to @p substate, or aborts if @p index is
-  /// out of bounds. Does not take ownership of @p substate, which must live
-  /// as long as this object.
-  void set_substate(int index, State<T>* substate) {
-    DRAKE_DEMAND(index >= 0 && index < num_substates());
-    substates_[index] = substate;
-  }
-
-  /// Sets the substate at @p index to @p substate, or aborts if @p index is
-  /// out of bounds.
-  void set_and_own_substate(int index, std::unique_ptr<State<T>> substate) {
-    set_substate(index, substate.get());
-    owned_substates_[index] = std::move(substate);
-  }
-
-  /// Returns the substate at @p index.
-  const State<T>& get_substate(int index) const {
-    DRAKE_DEMAND(index >= 0 && index < num_substates());
-    return *substates_[index];
-  }
-
-  /// Returns the substate at @p index.
-  State<T>& get_mutable_substate(int index) {
-    DRAKE_DEMAND(index >= 0 && index < num_substates());
-    return *substates_[index];
-  }
-
-  /// Finalizes this state as a span of all the constituent substates.
-  void Finalize() {
-    DRAKE_DEMAND(!finalized_);
-    finalized_ = true;
-    std::vector<ContinuousState<T>*> sub_xcs;
-    sub_xcs.reserve(num_substates());
-    std::vector<DiscreteValues<T>*> sub_xds;
-    std::vector<AbstractValue*> sub_xas;
-    for (State<T>* substate : substates_) {
-      // Continuous
-      sub_xcs.push_back(&substate->get_mutable_continuous_state());
-      // Discrete
-      sub_xds.push_back(&substate->get_mutable_discrete_state());
-      // Abstract (no substructure)
-      AbstractValues& xa = substate->get_mutable_abstract_state();
-      for (int i_xa = 0; i_xa < xa.size(); ++i_xa) {
-        sub_xas.push_back(&xa.get_mutable_value(i_xa));
-      }
-    }
-
-    // This State consists of a continuous, discrete, and abstract state, each
-    // of which is a spanning vector over the continuous, discrete, and abstract
-    // parts of the constituent states.  The spanning vectors do not own any
-    // of the actual memory that contains state variables. They just hold
-    // pointers to that memory.
-    this->set_continuous_state(
-        std::make_unique<DiagramContinuousState<T>>(sub_xcs));
-    this->set_discrete_state(
-        std::make_unique<DiagramDiscreteValues<T>>(sub_xds));
-    this->set_abstract_state(std::make_unique<AbstractValues>(sub_xas));
-  }
-
- private:
-  int num_substates() const {
-    return static_cast<int>(substates_.size());
-  }
-
-  bool finalized_{false};
-  std::vector<State<T>*> substates_;
-  std::vector<std::unique_ptr<State<T>>> owned_substates_;
-};
 
 /// The DiagramContext is a container for all of the data necessary to uniquely
 /// determine the computations performed by a Diagram. Specifically, a
@@ -533,9 +444,6 @@ class DiagramContext final : public Context<T> {
 
 }  // namespace systems
 }  // namespace drake
-
-DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
-    class ::drake::systems::DiagramState)
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::DiagramContext)

--- a/systems/framework/diagram_state.cc
+++ b/systems/framework/diagram_state.cc
@@ -1,0 +1,55 @@
+#include "drake/systems/framework/diagram_state.h"
+
+#include "drake/common/value.h"
+#include "drake/systems/framework/abstract_values.h"
+#include "drake/systems/framework/continuous_state.h"
+#include "drake/systems/framework/diagram_continuous_state.h"
+#include "drake/systems/framework/diagram_discrete_values.h"
+#include "drake/systems/framework/discrete_values.h"
+
+namespace drake {
+namespace systems {
+
+template <typename T>
+DiagramState<T>::DiagramState(int size)
+    : State<T>(),
+      substates_(size),
+      owned_substates_(size) {}
+
+template <typename T>
+void DiagramState<T>::Finalize() {
+  DRAKE_DEMAND(!finalized_);
+  finalized_ = true;
+  std::vector<ContinuousState<T>*> sub_xcs;
+  sub_xcs.reserve(num_substates());
+  std::vector<DiscreteValues<T>*> sub_xds;
+  std::vector<AbstractValue*> sub_xas;
+  for (State<T>* substate : substates_) {
+    // Continuous
+    sub_xcs.push_back(&substate->get_mutable_continuous_state());
+    // Discrete
+    sub_xds.push_back(&substate->get_mutable_discrete_state());
+    // Abstract (no substructure)
+    AbstractValues& xa = substate->get_mutable_abstract_state();
+    for (int i_xa = 0; i_xa < xa.size(); ++i_xa) {
+      sub_xas.push_back(&xa.get_mutable_value(i_xa));
+    }
+  }
+
+  // This State consists of a continuous, discrete, and abstract state, each
+  // of which is a spanning vector over the continuous, discrete, and abstract
+  // parts of the constituent states.  The spanning vectors do not own any
+  // of the actual memory that contains state variables. They just hold
+  // pointers to that memory.
+  this->set_continuous_state(
+      std::make_unique<DiagramContinuousState<T>>(sub_xcs));
+  this->set_discrete_state(
+      std::make_unique<DiagramDiscreteValues<T>>(sub_xds));
+  this->set_abstract_state(std::make_unique<AbstractValues>(sub_xas));
+}
+
+}  // namespace systems
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::DiagramState)

--- a/systems/framework/diagram_state.h
+++ b/systems/framework/diagram_state.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/systems/framework/state.h"
+
+namespace drake {
+namespace systems {
+
+/// DiagramState is a State, annotated with pointers to all the mutable
+/// substates that it spans.
+template <typename T>
+class DiagramState : public State<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiagramState)
+
+  /// Constructs a DiagramState consisting of @p size substates.
+  explicit DiagramState<T>(int size);
+
+  /// Sets the substate at @p index to @p substate, or aborts if @p index is
+  /// out of bounds. Does not take ownership of @p substate, which must live
+  /// as long as this object.
+  void set_substate(int index, State<T>* substate) {
+    DRAKE_DEMAND(index >= 0 && index < num_substates());
+    substates_[index] = substate;
+  }
+
+  /// Sets the substate at @p index to @p substate, or aborts if @p index is
+  /// out of bounds.
+  void set_and_own_substate(int index, std::unique_ptr<State<T>> substate) {
+    set_substate(index, substate.get());
+    owned_substates_[index] = std::move(substate);
+  }
+
+  /// Returns the substate at @p index.
+  const State<T>& get_substate(int index) const {
+    DRAKE_DEMAND(index >= 0 && index < num_substates());
+    return *substates_[index];
+  }
+
+  /// Returns the substate at @p index.
+  State<T>& get_mutable_substate(int index) {
+    DRAKE_DEMAND(index >= 0 && index < num_substates());
+    return *substates_[index];
+  }
+
+  /// Finalizes this state as a span of all the constituent substates.
+  void Finalize();
+
+ private:
+  int num_substates() const {
+    return static_cast<int>(substates_.size());
+  }
+
+  bool finalized_{false};
+  std::vector<State<T>*> substates_;
+  std::vector<std::unique_ptr<State<T>>> owned_substates_;
+};
+
+}  // namespace systems
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::DiagramState)


### PR DESCRIPTION
Toward #12814, and per the TODO in `diagram_context.h`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13749)
<!-- Reviewable:end -->
