### PR TITLE
Fix specialized QuadraticCost Eval with AutoDiff scalar.

### DIFF
--- a/solvers/cost.cc
+++ b/solvers/cost.cc
@@ -82,7 +82,8 @@ void QuadraticCost::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
 
   // If dx is the identity matrix (very common here), then skip the chain rule
   // multiplication dy * dx
-  if (dx == MatrixXd::Identity(x.size(), x.size())) {
+  if (dx.rows() == x.size() && dx.cols() == x.size() &&
+      dx == MatrixXd::Identity(x.size(), x.size())) {
     *y = math::initializeAutoDiffGivenGradientMatrix(result, dy);
   } else {
     *y = math::initializeAutoDiffGivenGradientMatrix(result, dy * dx);


### PR DESCRIPTION
Motivated by #13674

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13752)
<!-- Reviewable:end -->
