### PR TITLE
Adds support for "planar visualization" in meshcat

### DIFF
--- a/bindings/pydrake/systems/test/meshcat_visualizer_test.py
+++ b/bindings/pydrake/systems/test/meshcat_visualizer_test.py
@@ -84,6 +84,9 @@ class TestMeshcat(unittest.TestCase):
 
         simulator = Simulator(diagram, diagram_context)
         simulator.set_publish_every_time_step(False)
+        visualizer.set_planar_viewpoint(
+            camera_position=[0, -1, 0], camera_focus=[0, 0, 0],
+            xmin=-2, xmax=2, ymin=-1, ymax=2)
         visualizer.start_recording()
         simulator.AdvanceTo(.1)
         visualizer.stop_recording()

--- a/examples/manipulation_station/end_effector_teleop_dualshock4.py
+++ b/examples/manipulation_station/end_effector_teleop_dualshock4.py
@@ -313,6 +313,8 @@ def main():
                 station.get_scene_graph(), zmq_url=args.meshcat))
             builder.Connect(station.GetOutputPort("pose_bundle"),
                             meshcat.get_input_port(0))
+            if args.setup == 'planar':
+                meshcat.set_planar_viewpoint()
 
     robot = station.get_controller_plant()
     params = DifferentialInverseKinematicsParameters(robot.num_positions(),

--- a/examples/manipulation_station/end_effector_teleop_mouse.py
+++ b/examples/manipulation_station/end_effector_teleop_mouse.py
@@ -312,6 +312,8 @@ def main():
                 station.get_scene_graph(), zmq_url=args.meshcat))
             builder.Connect(station.GetOutputPort("pose_bundle"),
                             meshcat.get_input_port(0))
+            if args.setup == 'planar':
+                meshcat.set_planar_viewpoint()
 
     robot = station.get_controller_plant()
     params = DifferentialInverseKinematicsParameters(robot.num_positions(),

--- a/examples/manipulation_station/end_effector_teleop_sliders.py
+++ b/examples/manipulation_station/end_effector_teleop_sliders.py
@@ -242,6 +242,9 @@ def main():
                 open_browser=args.open_browser))
             builder.Connect(station.GetOutputPort("pose_bundle"),
                             meshcat.get_input_port(0))
+            if args.setup == 'planar':
+                meshcat.set_planar_viewpoint()
+
         elif args.setup == 'planar':
             pyplot_visualizer = builder.AddSystem(PlanarSceneGraphVisualizer(
                 station.get_scene_graph()))

--- a/examples/manipulation_station/joint_teleop.py
+++ b/examples/manipulation_station/joint_teleop.py
@@ -86,6 +86,8 @@ def main():
                     open_browser=args.open_browser))
             builder.Connect(station.GetOutputPort("pose_bundle"),
                             meshcat.get_input_port(0))
+            if args.setup == 'planar':
+                meshcat.set_planar_viewpoint()
         if args.setup == 'planar':
             pyplot_visualizer = builder.AddSystem(PlanarSceneGraphVisualizer(
                 station.get_scene_graph()))

--- a/tools/workspace/meshcat/repository.bzl
+++ b/tools/workspace/meshcat/repository.bzl
@@ -11,8 +11,8 @@ def meshcat_repository(
         repository = "rdeits/meshcat",
         # Updating this commit requires local testing; see
         # drake/tools/workspace/meshcat/README.md for details.
-        commit = "02b605b6def67f198d7a86ae60c8bb977ba7ef13",
-        sha256 = "0e818ade5ef037f4db735aef1f67baf146ace0f458324da76367a66a72faf729",  # noqa
+        commit = "85fd641e8897ffe453502e0ec152225562999b0b",
+        sha256 = "6571f294a712216059ce60e22f28db7f37de6b4c45cbb3ccbae6af9a06b63899",  # noqa
         build_file = "@drake//tools/workspace/meshcat:package.BUILD.bazel",  # noqa
         mirrors = mirrors,
     )

--- a/tools/workspace/meshcat_python/repository.bzl
+++ b/tools/workspace/meshcat_python/repository.bzl
@@ -44,9 +44,9 @@ def _impl(repository_ctx):
         "rdeits/meshcat-python",
         # Updating this commit requires local testing; see
         # drake/tools/workspace/meshcat/README.md for details.
-        "c4ef22c84336d6a8eaab682f73bb47cfca5d5779",
+        "ba573b1fc9e11d149b5a608946acb226e5328a28",
         repository_ctx.attr.mirrors,
-        sha256 = "0815ef569dd5728fe0d1880a0fe0fc26800bed2e2467e930df480b6ed34b61f4",  # noqa
+        sha256 = "9a671d4096d7a195ea3d93d4e332ff9774217e35db4e0b2b25becf1c875d900e",  # noqa
     )
 
     repository_ctx.symlink(


### PR DESCRIPTION
And uses it in the ManipulationStation planar demos
Also sets a different background color for meshcat (now that I finally can!) to match drake-visualizer.

See http://people.csail.mit.edu/russt/uploads/planar_iiwa_teleop.html for a preview.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13755)
<!-- Reviewable:end -->
