### PR TITLE
Make set_default_positions an NVI

### DIFF
--- a/multibody/tree/ball_rpy_joint.h
+++ b/multibody/tree/ball_rpy_joint.h
@@ -178,15 +178,10 @@ class BallRpyJoint final : public Joint<T> {
   }
 
   /// Sets the default angles of this joint.
-  /// If the parent tree has been finalized and the underlying mobilizer is
-  /// valid, this method sets the default positions of that mobilizer.
   /// @param[in] angles
   ///   The desired default angles of the joint
   void set_default_angles(const Vector3<double>& angles) {
     this->set_default_positions(angles);
-    if (this->has_implementation()) {
-      get_mutable_mobilizer()->set_default_position(this->default_positions());
-    }
   }
 
  protected:
@@ -225,6 +220,13 @@ class BallRpyJoint final : public Joint<T> {
   }
 
   int do_get_num_positions() const override { return 3; }
+
+  void do_set_default_positions(
+      const VectorX<double>& default_positions) override {
+    if (this->has_implementation()) {
+      get_mutable_mobilizer()->set_default_position(default_positions);
+    }
+  }
 
   // Joint<T> overrides:
   std::unique_ptr<typename Joint<T>::BluePrint> MakeImplementationBlueprint()

--- a/multibody/tree/joint.h
+++ b/multibody/tree/joint.h
@@ -361,7 +361,8 @@ class Joint : public MultibodyElement<Joint, T, JointIndex> {
     acc_upper_limits_ = upper_limits;
   }
 
-  /// Sets the default positions to @p default_positions.
+  /// Sets the default positions to @p default_positions. Joint subclasses are
+  /// expected to implement the do_set_default_positions().
   /// @throws std::exception if the dimension of @p default_positions does not
   /// match num_positions().
   /// @note The values in @p default_positions are NOT constrained to be within
@@ -369,6 +370,7 @@ class Joint : public MultibodyElement<Joint, T, JointIndex> {
   void set_default_positions(const VectorX<double>& default_positions) {
     DRAKE_THROW_UNLESS(default_positions.size() == num_positions());
     default_positions_ = default_positions;
+    do_set_default_positions(default_positions);
   }
   /// @}
 
@@ -455,19 +457,36 @@ class Joint : public MultibodyElement<Joint, T, JointIndex> {
 
   /// Implementation to the NVI velocity_start(), see velocity_start() for
   /// details.
+  /// @note Implementations must meet the styleguide requirements for snake_case
+  /// accessor methods.
   virtual int do_get_velocity_start() const = 0;
 
   /// Implementation to the NVI num_velocities(), see num_velocities() for
   /// details.
+  /// @note Implementations must meet the styleguide requirements for snake_case
+  /// accessor methods.
   virtual int do_get_num_velocities() const = 0;
 
   /// Implementation to the NVI position_start(), see position_start() for
   /// details.
+  /// @note Implementations must meet the styleguide requirements for snake_case
+  /// accessor methods.
   virtual int do_get_position_start() const = 0;
 
   /// Implementation to the NVI num_positions(), see num_positions() for
   /// details.
+  /// @note Implementations must meet the styleguide requirements for
+  /// snake_case accessor methods.
   virtual int do_get_num_positions() const = 0;
+
+  /// Implementation to the NVI set_default_positions(), see
+  /// set_default_positions() for details. It is the responsibility of the
+  /// subclass to ensure that their joint implementation, should they have one,
+  /// is updated with @p default_positions.
+  /// @note Implementations must meet the styleguide requirements for snake_case
+  /// accessor methods.
+  virtual void do_set_default_positions(
+      const VectorX<double>& default_positions) = 0;
 
   /// Implementation to the NVI GetOnePosition() that must only be implemented
   /// by those joint subclasses that have a single degree of freedom.

--- a/multibody/tree/prismatic_joint.h
+++ b/multibody/tree/prismatic_joint.h
@@ -196,15 +196,10 @@ class PrismaticJoint final : public Joint<T> {
 
   /// Sets the `default_positions` of this joint (in this case a single
   /// translation)
-  /// If the parent tree has been finalized and the underlying mobilizer is
-  /// valid, this method sets the default position of that mobilizer.
   /// @param[in] translation
   ///   The desired default translation of the joint
   void set_default_translation(double translation) {
     this->set_default_positions(Vector1d{translation});
-    if (this->has_implementation()) {
-      get_mutable_mobilizer()->set_default_position(this->default_positions());
-    }
   }
 
   void set_random_translation_distribution(
@@ -265,16 +260,19 @@ class PrismaticJoint final : public Joint<T> {
     return get_mobilizer()->velocity_start_in_v();
   }
 
-  int do_get_num_velocities() const override {
-    return 1;
-  }
+  int do_get_num_velocities() const override { return 1; }
 
   int do_get_position_start() const override {
     return get_mobilizer()->position_start_in_q();
   }
 
-  int do_get_num_positions() const override {
-    return 1;
+  int do_get_num_positions() const override { return 1; }
+
+  void do_set_default_positions(
+      const VectorX<double>& default_positions) override {
+    if (this->has_implementation()) {
+      get_mutable_mobilizer()->set_default_position(default_positions);
+    }
   }
 
   const T& DoGetOnePosition(const systems::Context<T>& context) const override {

--- a/multibody/tree/revolute_joint.h
+++ b/multibody/tree/revolute_joint.h
@@ -229,15 +229,10 @@ class RevoluteJoint final : public Joint<T> {
   double get_default_angle() const { return this->default_positions()[0]; }
 
   /// Sets the `default_positions` of this joint (in this case a single angle).
-  /// If the parent tree has been finalized and the underlying mobilizer is
-  /// valid, this method sets the default position of that mobilizer.
   /// @param[in] angle
   ///   The desired default angle of the joint
   void set_default_angle(double angle) {
     this->set_default_positions(Vector1d{angle});
-    if (this->has_implementation()) {
-      get_mutable_mobilizer()->set_default_position(this->default_positions());
-    }
   }
 
   /// Adds into `forces` a given `torque` for `this` joint that is to be applied
@@ -308,6 +303,13 @@ class RevoluteJoint final : public Joint<T> {
 
   int do_get_num_positions() const override {
     return 1;
+  }
+
+  void do_set_default_positions(
+      const VectorX<double>& default_positions) override {
+    if (this->has_implementation()) {
+      get_mutable_mobilizer()->set_default_position(default_positions);
+    }
   }
 
   const T& DoGetOnePosition(const systems::Context<T>& context) const override {

--- a/multibody/tree/universal_joint.h
+++ b/multibody/tree/universal_joint.h
@@ -160,9 +160,6 @@ class UniversalJoint final : public Joint<T> {
   /// @param[in] angles The desired default angles of the joint
   void set_default_angles(const Vector2<double>& angles) {
     this->set_default_positions(angles);
-    if (this->has_implementation()) {
-      get_mutable_mobilizer()->set_default_position(this->default_positions());
-    }
   }
 
   /// Sets the random distribution that angles of this joint will be randomly
@@ -223,6 +220,13 @@ class UniversalJoint final : public Joint<T> {
   }
 
   int do_get_num_positions() const override { return 2; }
+
+  void do_set_default_positions(
+      const VectorX<double>& default_positions) override {
+    if (this->has_implementation()) {
+      get_mutable_mobilizer()->set_default_position(default_positions);
+    }
+  }
 
   // Joint<T> overrides:
   std::unique_ptr<typename Joint<T>::BluePrint> MakeImplementationBlueprint()

--- a/multibody/tree/weld_joint.h
+++ b/multibody/tree/weld_joint.h
@@ -87,6 +87,8 @@ class WeldJoint final : public Joint<T> {
     return 0;
   }
 
+  void do_set_default_positions(const VectorX<double>&) override { return; }
+
   // Joint<T> overrides:
   std::unique_ptr<typename Joint<T>::BluePrint>
   MakeImplementationBlueprint() const override;


### PR DESCRIPTION
Solution to #13756.
Turns `set_default_positions()` into an NVI and adds the pure virtual `do_set_default_positions()` to the `Joint` class.
Adds implementations of `do_set_default_positions()` to all current `Joint` subclasses.


cc'ing @mpetersen94. I, @amcastro-tri,  found out this bug when reviewing your PR, so thanks for that!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13757)
<!-- Reviewable:end -->
