### PR TITLE
CSDP on mac should have a different numerical tolerance.

### DIFF
--- a/solvers/test/csdp_solver_test.cc
+++ b/solvers/test/csdp_solver_test.cc
@@ -335,7 +335,7 @@ GTEST_TEST(TestSOS, MotzkinPolynomial) {
     CsdpSolver solver(method);
     if (solver.available()) {
       const auto result = solver.Solve(dut.prog());
-      dut.CheckResult(result, 6E-9);
+      dut.CheckResult(result, 1.5E-8);
     }
   }
 }


### PR DESCRIPTION
One possible explanation is that they use different BLAS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13759)
<!-- Reviewable:end -->
