### PR TITLE
pydrake: Improve unit test error message

### DIFF
--- a/bindings/pydrake/test/all_test.py
+++ b/bindings/pydrake/test/all_test.py
@@ -20,7 +20,7 @@ class TestAll(unittest.TestCase):
                 "ignore", message="Matplotlib is building the font cache",
                 category=UserWarning)
             import pydrake.all
-            self.assertEqual(len(w), 0, w)
+            self.assertEqual(len(w), 0, [x.message for x in w])
 
     def test_usage_no_all(self):
         from pydrake.common import FindResourceOrThrow


### PR DESCRIPTION
When a warning does occur, its str does not explain it; instead, we should print the message to improve debugging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13761)
<!-- Reviewable:end -->
