### PR TITLE
cpplint: Disable whitespace/todo

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -20,6 +20,13 @@ filter=+build/pragma_once
 # Disable cpplint's include order.  We have our own via //tools:drakelint.
 filter=-build/include_order
 
+# We do not care about the whitespace details of a TODO comment.  It is not
+# relevant for easy grepping, and the GSG does not specify any particular
+# whitespace style.  (We *do* care what the "TODO(username)" itself looks like
+# because GSG forces a particular style there, but that formatting is covered
+# by the readability/todo rule, which we leave enabled.)
+filter=-whitespace/todo
+
 # TODO(#1805) Fix this.
 filter=-legal/copyright
 


### PR DESCRIPTION
In preparation for enabling C-style comment linting, we disable the whitespace rules for TODOs.  They go beyond what GSG demands, and it is unclear how to apply them to C-style comments.

Related to #13762 and RobotLocomotion/styleguide#31.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13763)
<!-- Reviewable:end -->
