### PR TITLE
Replace drake-visualizer with warning script on prebuilt Docker images

### DIFF
--- a/tools/install/dockerhub/bionic/Dockerfile
+++ b/tools/install/dockerhub/bionic/Dockerfile
@@ -7,7 +7,13 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get update -qq \
   && apt-get install --no-install-recommends -o Dpkg::Use-Pty=0 -qy \
     $(cat /opt/drake/share/drake/setup/packages-bionic.txt) \
-  && rm -rf /opt/drake/share/drake/setup /var/lib/apt/lists/*
+  && rm -rf /opt/drake/share/drake/setup /var/lib/apt/lists/* \
+  && mv /opt/drake/bin/drake-visualizer /opt/drake/bin/drake-visualizer.image
+RUN printf '#!/bin/bash\n \
+echo "drake-visualizer is not supported on Docker containers.\n\
+Although not guaranteed to run, the executable is available to try as-is:\n\
+/opt/drake/bin/drake-visualizer.image"' > /opt/drake/bin/drake-visualizer\
+  && chmod a+x /opt/drake/bin/drake-visualizer
 ENV LD_LIBRARY_PATH="/opt/drake/lib:${LD_LIBRARY_PATH}" \
   PATH="/opt/drake/bin:${PATH}" \
   PYTHONPATH="/opt/drake/lib/python3.6/site-packages:${PYTHONPATH}"

--- a/tools/install/dockerhub/focal/Dockerfile
+++ b/tools/install/dockerhub/focal/Dockerfile
@@ -7,7 +7,13 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get update -qq \
   && apt-get install --no-install-recommends -o Dpkg::Use-Pty=0 -qy \
     $(cat /opt/drake/share/drake/setup/packages-focal.txt) \
-  && rm -rf /opt/drake/share/drake/setup /var/lib/apt/lists/*
+  && rm -rf /opt/drake/share/drake/setup /var/lib/apt/lists/* \
+  && mv /opt/drake/bin/drake-visualizer /opt/drake/bin/drake-visualizer.image
+RUN printf '#!/bin/bash\n \
+echo "drake-visualizer is not supported on Docker containers.\n\
+Although not guaranteed to run, the executable is available to try as-is:\n\
+/opt/drake/bin/drake-visualizer.image"' > /opt/drake/bin/drake-visualizer\
+  && chmod a+x /opt/drake/bin/drake-visualizer
 ENV LD_LIBRARY_PATH="/opt/drake/lib:${LD_LIBRARY_PATH}" \
   PATH="/opt/drake/bin:${PATH}" \
   PYTHONPATH="/opt/drake/lib/python3.8/site-packages:${PYTHONPATH}"


### PR DESCRIPTION
On prebuilt Docker images, rename `drake-visualizer` to
`drake-visualizer.image`. Create a `drake-visualizer` script that prints a
warning message with a pointer to the renamed file.

Resolves #12483 and #13639

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13764)
<!-- Reviewable:end -->
