### PR TITLE
Implement Frame::CalcSpatialAccelerationInWorld()

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -479,6 +479,7 @@ drake_cc_googletest(
         "//common:autodiff",
         "//common/test_utilities:eigen_matrix_compare",
         "//math:geometric_transform",
+        "//math:gradient",
         "//multibody/test_utilities:add_fixed_objects_to_plant",
     ],
 )

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -2917,7 +2917,7 @@ void MultibodyPlant<T>::CalcBodySpatialAccelerationsOutput(
 template <typename T>
 const SpatialAcceleration<T>&
 MultibodyPlant<T>::EvalBodySpatialAccelerationInWorld(
-    const systems::Context<T>& context,
+    const Context<T>& context,
     const Body<T>& body_B) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
   const AccelerationKinematicsCache<T>& ac = EvalForwardDynamics(context);

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -2919,7 +2919,7 @@ const SpatialAcceleration<T>&
 MultibodyPlant<T>::EvalBodySpatialAccelerationInWorld(
     const Context<T>& context,
     const Body<T>& body_B) const {
-  DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+  internal_tree().IsFinalizedAndHasThisParentTreeOrThrow(body_B);
   const AccelerationKinematicsCache<T>& ac = EvalForwardDynamics(context);
   return ac.get_A_WB(body_B.node_index());
 }

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -2919,7 +2919,8 @@ const SpatialAcceleration<T>&
 MultibodyPlant<T>::EvalBodySpatialAccelerationInWorld(
     const Context<T>& context,
     const Body<T>& body_B) const {
-  internal_tree().IsFinalizedAndHasThisParentTreeOrThrow(body_B);
+  DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+  DRAKE_DEMAND(this == &body_B.GetParentPlant());;
   const AccelerationKinematicsCache<T>& ac = EvalForwardDynamics(context);
   return ac.get_A_WB(body_B.node_index());
 }

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -2915,6 +2915,16 @@ void MultibodyPlant<T>::CalcBodySpatialAccelerationsOutput(
 }
 
 template <typename T>
+const SpatialAcceleration<T>&
+MultibodyPlant<T>::EvalBodySpatialAccelerationInWorld(
+    const systems::Context<T>& context,
+    const Body<T>& body_B) const {
+  DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+  const AccelerationKinematicsCache<T>& ac = EvalForwardDynamics(context);
+  return ac.get_A_WB(body_B.node_index());
+}
+
+template <typename T>
 void MultibodyPlant<T>::CalcFramePoseOutput(
     const Context<T>& context, FramePoseVector<T>* poses) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -2136,8 +2136,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   ///   The body B for which the pose is requested.
   /// @retval X_WB
   ///   The pose of body frame B in the world frame W.
-  /// @throws std::exception if Finalize() was not called on `this` model or if
-  /// `body_B` does not belong to this model.
+  /// @throws std::logic_error if Finalize() was not called on `this` model or
+  ///   if `body_B` does not belong to this model.
   const math::RigidTransform<T>& EvalBodyPoseInWorld(
       const systems::Context<T>& context,
       const Body<T>& body_B) const {
@@ -2151,8 +2151,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   ///   The body B for which the spatial velocity is requested.
   /// @returns V_WB
   ///   The spatial velocity of body frame B in the world frame W.
-  /// @throws std::exception if Finalize() was not called on `this` model or if
-  /// `body_B` does not belong to this model.
+  /// @throws std::logic_error if Finalize() was not called on `this` model or
+  ///   if `body_B` does not belong to this model.
   const SpatialVelocity<T>& EvalBodySpatialVelocityInWorld(
       const systems::Context<T>& context,
       const Body<T>& body_B) const {
@@ -2167,8 +2167,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   ///   The body B for which the spatial acceleration is requested.
   /// @returns A_WB_W
   ///   The spatial acceleration of body B in the world frame W, expressed in W.
-  /// @throws std::exception if Finalize() was not called on `this` model or if
-  /// `body_B` does not belong to this model.
+  /// @throws std::logic_error if Finalize() was not called on `this` model or
+  ///   if `body_B` does not belong to this model.
   /// @note When cached values are out of sync with the state stored in context,
   /// this method performs an expensive forward dynamics computation, whereas
   /// once evaluated, successive calls to this method are inexpensive.

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -2169,8 +2169,9 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   ///   The spatial acceleration of body B in the world frame W, expressed in W.
   /// @throws std::exception if Finalize() was not called on `this` model or if
   /// `body_B` does not belong to this model.
-  /// @note This method calls MultibodyPlant::EvalForwardDynamics() which can
-  /// be computational intensive.
+  /// @note When cached values are out of sync with the state stored in context,
+  /// this method performs an expensive forward dynamics computation, whereas
+  /// once evaluated, successive calls to this method are inexpensive.
   const SpatialAcceleration<T>& EvalBodySpatialAccelerationInWorld(
       const systems::Context<T>& context,
       const Body<T>& body_B) const;

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -2159,6 +2159,19 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     return internal_tree().EvalBodySpatialVelocityInWorld(context, body_B);
   }
 
+  /// Evaluate the spatial acceleration A_WB_W of a body B in the world frame W.
+  /// @param[in] context
+  ///   The context storing the state of the model.
+  /// @param[in] body_B
+  ///   The body B for which the spatial acceleration is requested.
+  /// @returns A_WB_W
+  ///   The spatial acceleration of body B in the world frame W.
+  /// @throws std::exception if Finalize() was not called on `this` model or if
+  /// `body_B` does not belong to this model.
+  const SpatialAcceleration<T>& EvalBodySpatialAccelerationInWorld(
+      const systems::Context<T>& context,
+      const Body<T>& body_B) const;
+
   /// Evaluates all point pairs of contact for a given state of the model stored
   /// in `context`.
   /// Each entry in the returned vector corresponds to a single point pair

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -2159,15 +2159,18 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     return internal_tree().EvalBodySpatialVelocityInWorld(context, body_B);
   }
 
-  /// Evaluate the spatial acceleration A_WB_W of a body B in the world frame W.
+  /// Evaluates A_WB_W, the spatial acceleration of a body B in the world
+  /// world frame W, expressed in the world frame W.
   /// @param[in] context
   ///   The context storing the state of the model.
   /// @param[in] body_B
   ///   The body B for which the spatial acceleration is requested.
   /// @returns A_WB_W
-  ///   The spatial acceleration of body B in the world frame W.
+  ///   The spatial acceleration of body B in the world frame W, expressed in W.
   /// @throws std::exception if Finalize() was not called on `this` model or if
   /// `body_B` does not belong to this model.
+  /// @note This method calls MultibodyPlant::EvalForwardDynamics() which can
+  /// be computational intensive.
   const SpatialAcceleration<T>& EvalBodySpatialAccelerationInWorld(
       const systems::Context<T>& context,
       const Body<T>& body_B) const;

--- a/multibody/plant/test/frame_kinematics_test.cc
+++ b/multibody/plant/test/frame_kinematics_test.cc
@@ -134,7 +134,8 @@ TEST_F(KukaIiwaModelTests, FramesKinematics) {
   // Reverify A_WH_W by differentiating the spatial velocity V_WH_W.
   // Spatial acceleration is a function of the generalized accelerations vdot.
   // Use forward dynamics to calculate values for vdot (for the given q, v).
-  const auto& derivs = plant_->EvalTimeDerivatives(*context_);
+  const systems::ContinuousState<double>& derivs =
+      plant_->EvalTimeDerivatives(*context_);
   const VectorX<double> vdot(derivs.get_generalized_velocity().CopyToVector());
   EXPECT_EQ(vdot.size(), plant_->num_velocities());
 
@@ -165,10 +166,8 @@ TEST_F(KukaIiwaModelTests, FramesKinematics) {
       frame_H_autodiff.CalcSpatialVelocityInWorld(*context_autodiff_);
 
   // Form the expected spatial acceleration via AutoDiffXd results.
-  const Vector6<AutoDiffXd> A_WH_W_alternate =
+  const Vector6<double> A_WH_W_expected_double =
       math::autoDiffToGradientMatrix(V_WH_W_autodiff.get_coeffs());
-  const Vector6<double> A_WH_W_expected_double(
-      math::autoDiffToValueMatrix(A_WH_W_alternate));
 
   // Verify computed spatial acceleration numerical values.
   EXPECT_TRUE(CompareMatrices(A_WH_W.get_coeffs(), A_WH_W_expected_double,

--- a/multibody/plant/test/frame_kinematics_test.cc
+++ b/multibody/plant/test/frame_kinematics_test.cc
@@ -97,25 +97,38 @@ TEST_F(KukaIiwaModelTests, FramesKinematics) {
       V_WB_all[end_effector_link_->index()];
   EXPECT_EQ(V_WE.get_coeffs(), V_WE_from_port.get_coeffs());
 
-  // Verify frame_H's spatial acceleration in world W, expressed in W.
-  const SpatialAcceleration<double> A_WE =
+  // Verify a short-cut return from Frame::CalcSpatialAccelerationInWorld()
+  // when dealing with a body_frame (as opposed to a generic frame).
+  // Compare results with the A_WE_W from an associated plant method.
+  const Frame<double>& frame_E = end_effector_link_->body_frame();
+  const SpatialAcceleration<double> A_WE_W =
+      frame_E.CalcSpatialAccelerationInWorld(*context_);
+  const SpatialAcceleration<double> A_WE_W_alternate1 =
+     plant_->EvalBodySpatialAccelerationInWorld(*context_, *end_effector_link_);
+  EXPECT_EQ(A_WE_W.get_coeffs(), A_WE_W_alternate1.get_coeffs());
+
+  // Also verify A_WE_W against Body::EvalSpatialAccelerationInWorld().
+  const SpatialAcceleration<double> A_WE_W_alternate2 =
     end_effector_link_->EvalSpatialAccelerationInWorld(*context_);
-  const SpatialAcceleration<double> A_WH =
+  EXPECT_EQ(A_WE_W.get_coeffs(), A_WE_W_alternate2.get_coeffs());
+
+  // Also verify A_WE_W from the plant's output port for spatial acceleration.
+  const auto& A_WB_all =
+    plant_->get_body_spatial_accelerations_output_port()
+        .Eval<std::vector<SpatialAcceleration<double>>>(*context_);
+  ASSERT_EQ(A_WB_all.size(), plant_->num_bodies());
+  const SpatialAcceleration<double>& A_WE_W_from_port =
+      A_WB_all[end_effector_link_->index()];
+  EXPECT_EQ(A_WE_W.get_coeffs(), A_WE_W_from_port.get_coeffs());
+
+  // Verify frame_H's spatial acceleration in world W, expressed in W.
+  const SpatialAcceleration<double> A_WH_W =
     frame_H_->CalcSpatialAccelerationInWorld(*context_);
   const Vector3<double> w_WE_W = V_WH.rotational();
-  const SpatialAcceleration<double> A_WH_expected = A_WE.Shift(p_EH_W, w_WE_W);
-  EXPECT_TRUE(CompareMatrices(A_WH.get_coeffs(), A_WH_expected.get_coeffs(),
+  const SpatialAcceleration<double> A_WH_W_expected =
+      A_WE_W.Shift(p_EH_W, w_WE_W);
+  EXPECT_TRUE(CompareMatrices(A_WH_W.get_coeffs(), A_WH_W_expected.get_coeffs(),
                               kTolerance, MatrixCompareType::relative));
-
-  // Alternatively, get the spatial acceleration A_WE using the plant's
-  // output port for spatial accelerations.
-  const auto& A_WB_all =
-      plant_->get_body_spatial_accelerations_output_port()
-          .Eval<std::vector<SpatialAcceleration<double>>>(*context_);
-  ASSERT_EQ(A_WB_all.size(), plant_->num_bodies());
-  const SpatialAcceleration<double>& A_WE_from_port =
-      A_WB_all[end_effector_link_->index()];
-  EXPECT_EQ(A_WE.get_coeffs(), A_WE_from_port.get_coeffs());
 
   // Spatial velocity of link 3 measured in the H frame and expressed in the
   // end-effector frame E.

--- a/multibody/plant/test/frame_kinematics_test.cc
+++ b/multibody/plant/test/frame_kinematics_test.cc
@@ -206,7 +206,6 @@ TEST_F(KukaIiwaModelTests, FramesKinematics) {
                               kTolerance, MatrixCompareType::relative));
 }
 
-
 TEST_F(KukaIiwaModelTests, CalcSpatialAcceleration) {
   // Numerical tolerance used to verify numerical results.
   const double kTolerance = 10 * std::numeric_limits<double>::epsilon();

--- a/multibody/plant/test/frame_kinematics_test.cc
+++ b/multibody/plant/test/frame_kinematics_test.cc
@@ -166,11 +166,11 @@ TEST_F(KukaIiwaModelTests, FramesKinematics) {
       frame_H_autodiff.CalcSpatialVelocityInWorld(*context_autodiff_);
 
   // Form the expected spatial acceleration via AutoDiffXd results.
-  const Vector6<double> A_WH_W_expected_double =
+  const Vector6<double> A_WH_W_expected_alternate =
       math::autoDiffToGradientMatrix(V_WH_W_autodiff.get_coeffs());
 
   // Verify computed spatial acceleration numerical values.
-  EXPECT_TRUE(CompareMatrices(A_WH_W.get_coeffs(), A_WH_W_expected_double,
+  EXPECT_TRUE(CompareMatrices(A_WH_W.get_coeffs(), A_WH_W_expected_alternate,
                                kTolerance, MatrixCompareType::relative));
 
   // Spatial velocity of link 3 measured in the H frame and expressed in the

--- a/multibody/plant/test/frame_kinematics_test.cc
+++ b/multibody/plant/test/frame_kinematics_test.cc
@@ -69,29 +69,29 @@ SpatialAcceleration<double> CalcSpatialAccelerationViaSpatialVelocityDerivative(
   plant_autodiff->GetMutablePositionsAndVelocities(context_autodiff.get()) =
       x_autodiff;
 
-  // Using AutoDiff, compute V_ABp_A (point Bp's spatial velocity in frame_A,
-  // expressed in frame_A), and its time derivative which is A_ABp_A
-  // (point Bp's spatial acceleration in frame_A, expressed in frame_A).
+  // Using AutoDiff, compute V_AB_A (frame B's spatial velocity in frame_A,
+  // expressed in frame_A), and its time derivative which is A_AB_A
+  // (frame B's spatial acceleration in frame_A, expressed in frame_A).
   const Frame<AutoDiffXd>& frame_A_autodiff =
       plant_autodiff->get_frame(frame_A.index());
   const Frame<AutoDiffXd>& frame_B_autodiff =
       plant_autodiff->get_frame(frame_B.index());
-  const SpatialVelocity<AutoDiffXd> V_ABo_A_autodiff =
+  const SpatialVelocity<AutoDiffXd> V_AB_A_autodiff =
       frame_B_autodiff.CalcSpatialVelocity(*context_autodiff, frame_A_autodiff,
                                            frame_A_autodiff);
 
   // Form spatial acceleration via AutoDiffXd results.
-  const Vector6<double> A_ABo_A_double(
-      math::autoDiffToGradientMatrix(V_ABo_A_autodiff.get_coeffs()));
-  const SpatialAcceleration<double> A_ABo_A(A_ABo_A_double);
+  const SpatialAcceleration<double> A_AB_A(
+      math::autoDiffToGradientMatrix(V_AB_A_autodiff.get_coeffs()));
 
   // Shortcut return if frame_A == frame_E.
-  if (frame_E.index() == frame_A.index()) return A_ABo_A;
+  if (frame_E.index() == frame_A.index()) return A_AB_A;
+
   // Otherwise, express the result in frame_E.
   const RotationMatrix<double> R_EA =
       frame_A.CalcRotationMatrix(context, frame_E);
-  const SpatialAcceleration<double> A_ABo_E = R_EA * A_ABo_A;
-  return A_ABo_E;
+  const SpatialAcceleration<double> A_AB_E = R_EA * A_AB_A;
+  return A_AB_E;
 }
 
 TEST_F(KukaIiwaModelTests, FramesKinematics) {

--- a/multibody/plant/test/frame_kinematics_test.cc
+++ b/multibody/plant/test/frame_kinematics_test.cc
@@ -172,48 +172,6 @@ TEST_F(KukaIiwaModelTests, FramesKinematics) {
       V_WB_all[end_effector_link_->index()];
   EXPECT_EQ(V_WE.get_coeffs(), V_WE_from_port.get_coeffs());
 
-  // Verify a short-cut return from Frame::CalcSpatialAccelerationInWorld()
-  // when dealing with a body_frame (as opposed to a generic frame).
-  // Compare results with the A_WE_W from an associated plant method.
-  const Frame<double>& frame_E = end_effector_link_->body_frame();
-  const SpatialAcceleration<double> A_WE_W =
-      frame_E.CalcSpatialAccelerationInWorld(*context_);
-  const SpatialAcceleration<double> A_WE_W_alternate1 =
-     plant_->EvalBodySpatialAccelerationInWorld(*context_, *end_effector_link_);
-  EXPECT_EQ(A_WE_W.get_coeffs(), A_WE_W_alternate1.get_coeffs());
-
-  // Also verify A_WE_W against Body::EvalSpatialAccelerationInWorld().
-  const SpatialAcceleration<double> A_WE_W_alternate2 =
-    end_effector_link_->EvalSpatialAccelerationInWorld(*context_);
-  EXPECT_EQ(A_WE_W.get_coeffs(), A_WE_W_alternate2.get_coeffs());
-
-  // Also verify A_WE_W from the plant's output port for spatial acceleration.
-  const auto& A_WB_all =
-    plant_->get_body_spatial_accelerations_output_port()
-        .Eval<std::vector<SpatialAcceleration<double>>>(*context_);
-  ASSERT_EQ(A_WB_all.size(), plant_->num_bodies());
-  const SpatialAcceleration<double>& A_WE_W_from_port =
-      A_WB_all[end_effector_link_->index()];
-  EXPECT_EQ(A_WE_W.get_coeffs(), A_WE_W_from_port.get_coeffs());
-
-  // Verify A_WH_W, frame_H's spatial acceleration in world W, expressed in W.
-  const SpatialAcceleration<double> A_WH_W =
-    frame_H_->CalcSpatialAccelerationInWorld(*context_);
-  const Vector3<double> w_WE_W = V_WH.rotational();
-  const SpatialAcceleration<double> A_WH_W_expected =
-      A_WE_W.Shift(p_EH_W, w_WE_W);
-  EXPECT_TRUE(CompareMatrices(A_WH_W.get_coeffs(), A_WH_W_expected.get_coeffs(),
-                              kTolerance, MatrixCompareType::relative));
-
-  // Reverify A_WH_W by differentiating the spatial velocity V_WH_W.
-  const Frame<double>& frame_W = plant_->world_frame();
-  const SpatialAcceleration<double> A_WE_W_alternate3 =
-      CalcSpatialAccelerationViaSpatialVelocityDerivative(
-          *plant_, *context_, *frame_H_, frame_W, frame_W);
-  EXPECT_TRUE(CompareMatrices(A_WH_W.get_coeffs(),
-                              A_WE_W_alternate3.get_coeffs(),
-                              kTolerance, MatrixCompareType::relative));
-
   // Spatial velocity of link 3 measured in the H frame and expressed in the
   // end-effector frame E.
   const SpatialVelocity<double> V_HL3_E =
@@ -245,6 +203,49 @@ TEST_F(KukaIiwaModelTests, FramesKinematics) {
   const RotationMatrixd R_HH =
       plant_->CalcRelativeRotationMatrix(*context_, *frame_H_, *frame_H_);
   EXPECT_TRUE(CompareMatrices(R_HH.matrix(), Matrix3<double>::Identity(),
+                              kTolerance, MatrixCompareType::relative));
+}
+
+
+TEST_F(KukaIiwaModelTests, CalcSpatialAcceleration) {
+  // Numerical tolerance used to verify numerical results.
+  const double kTolerance = 10 * std::numeric_limits<double>::epsilon();
+  SetArbitraryConfiguration();
+
+  // Verify a short-cut return from Frame::CalcSpatialAccelerationInWorld()
+  // when dealing with a body_frame (as opposed to a generic frame).
+  // Compare results with the A_WE_W from an associated plant method.
+  const Frame<double>& frame_E = end_effector_link_->body_frame();
+  const SpatialAcceleration<double> A_WE_W =
+      frame_E.CalcSpatialAccelerationInWorld(*context_);
+  const SpatialAcceleration<double> A_WE_W_expected1 =
+     plant_->EvalBodySpatialAccelerationInWorld(*context_, *end_effector_link_);
+  EXPECT_EQ(A_WE_W.get_coeffs(), A_WE_W_expected1.get_coeffs());
+
+  // Also verify A_WE_W against Body::EvalSpatialAccelerationInWorld().
+  const SpatialAcceleration<double> A_WE_W_expected2 =
+      end_effector_link_->EvalSpatialAccelerationInWorld(*context_);
+  EXPECT_EQ(A_WE_W.get_coeffs(),  A_WE_W_expected2.get_coeffs());
+
+  // Also verify A_WE_W from the plant's output port for spatial acceleration.
+  const auto& A_WB_all =
+      plant_->get_body_spatial_accelerations_output_port()
+          .Eval<std::vector<SpatialAcceleration<double>>>(*context_);
+  ASSERT_EQ(A_WB_all.size(), plant_->num_bodies());
+  const SpatialAcceleration<double>& A_WE_W_expected3 =
+      A_WB_all[end_effector_link_->index()];
+  EXPECT_EQ(A_WE_W.get_coeffs(), A_WE_W_expected3.get_coeffs());
+
+  // Verify A_WH_W, frame_H's spatial acceleration in world W, expressed in W.
+  // Do this by differentiating the spatial velocity V_WH_W.
+  const SpatialAcceleration<double> A_WH_W =
+      frame_H_->CalcSpatialAccelerationInWorld(*context_);
+  const Frame<double>& frame_W = plant_->world_frame();
+  const SpatialAcceleration<double> A_WH_W_expected =
+      CalcSpatialAccelerationViaSpatialVelocityDerivative(
+          *plant_, *context_, *frame_H_, frame_W, frame_W);
+  EXPECT_TRUE(CompareMatrices(A_WH_W.get_coeffs(),
+                              A_WH_W_expected.get_coeffs(),
                               kTolerance, MatrixCompareType::relative));
 }
 

--- a/multibody/tree/body.h
+++ b/multibody/tree/body.h
@@ -306,7 +306,9 @@ class Body : public MultibodyElement<Body, T, BodyIndex> {
   }
 
   /// Returns A_WB_W, the spatial acceleration of `this` body B in the world
-  /// frame W as a function of the state of the model stored in `context`.
+  /// frame W expressed in frame W as a function of the state stored in context.
+  /// @note Indirectly, this method calls MultibodyPlant::EvalForwardDynamics()
+  /// which can be computational intensive.
   const SpatialAcceleration<T>& EvalSpatialAccelerationInWorld(
       const systems::Context<T>& context) const {
     const MultibodyPlant<T>& parent_plant = this->GetParentPlant();

--- a/multibody/tree/body.h
+++ b/multibody/tree/body.h
@@ -307,8 +307,9 @@ class Body : public MultibodyElement<Body, T, BodyIndex> {
 
   /// Returns A_WB_W, the spatial acceleration of `this` body B in the world
   /// frame W expressed in frame W as a function of the state stored in context.
-  /// @note Indirectly, this method calls MultibodyPlant::EvalForwardDynamics()
-  /// which can be computational intensive.
+  /// @note When cached values are out of sync with the state stored in context,
+  /// this method performs an expensive forward dynamics computation, whereas
+  /// once evaluated, successive calls to this method are inexpensive.
   const SpatialAcceleration<T>& EvalSpatialAccelerationInWorld(
       const systems::Context<T>& context) const {
     const MultibodyPlant<T>& parent_plant = this->GetParentPlant();

--- a/multibody/tree/body.h
+++ b/multibody/tree/body.h
@@ -305,6 +305,14 @@ class Body : public MultibodyElement<Body, T, BodyIndex> {
         context, *this);
   }
 
+  /// Returns A_WB_W, the spatial acceleration of `this` body B in the world
+  /// frame W as a function of the state of the model stored in `context`.
+  const SpatialAcceleration<T>& EvalSpatialAccelerationInWorld(
+      const systems::Context<T>& context) const {
+    const MultibodyPlant<T>& parent_plant = this->GetParentPlant();
+    return parent_plant.EvalBodySpatialAccelerationInWorld(context, *this);
+  }
+
   /// Gets the sptatial force on `this` body B from `forces` as F_BBo_W:
   /// applied at body B's origin Bo and expressed in world world frame W.
   const SpatialForce<T>& GetForceInWorld(

--- a/multibody/tree/frame.h
+++ b/multibody/tree/frame.h
@@ -223,8 +223,9 @@ class Frame : public FrameBase<T> {
   /// world frame W expressed in W as a function of the state stored in context.
   /// @note Body::EvalSpatialAccelerationInWorld() provides a more efficient way
   /// to obtain the spatial acceleration for a body frame.
-  /// @note Indirectly, this method calls MultibodyPlant::EvalForwardDynamics()
-  /// which can be computational intensive.
+  /// @note When cached values are out of sync with the state stored in context,
+  /// this method performs an expensive forward dynamics computation, whereas
+  /// once evaluated, successive calls to this method are inexpensive.
   SpatialAcceleration<T> CalcSpatialAccelerationInWorld(
       const systems::Context<T>& context) const {
     // `this` frame_F is fixed to a body B.  Calculate A_WB_W, body B's spatial

--- a/multibody/tree/frame.h
+++ b/multibody/tree/frame.h
@@ -219,6 +219,24 @@ class Frame : public FrameBase<T> {
     return R_WE.inverse() * V_MF_W;
   }
 
+  /// Computes and returns the spatial acceleration A_WF_W of `this` frame F in
+  /// the world frame W as a function of the state stored in context.
+  /// @note Body::EvalSpatialAccelerationInWorld() provides a more efficient way
+  /// to obtain the spatial acceleration for a body frame.
+  SpatialAcceleration<T> CalcSpatialAccelerationInWorld(
+      const systems::Context<T>& context) const {
+    const math::RotationMatrix<T>& R_WB =
+        body().EvalPoseInWorld(context).rotation();
+    const Vector3<T> p_BoFo_B = CalcPoseInBodyFrame(context).translation();
+    const Vector3<T> p_BoFo_W = R_WB * p_BoFo_B;
+    const SpatialAcceleration<T>& A_WB_W =
+        body().EvalSpatialAccelerationInWorld(context);
+    const Vector3<T>& w_WB_W =
+        body().EvalSpatialVelocityInWorld(context).rotational();
+    const SpatialAcceleration<T> A_WF_W = A_WB_W.Shift(p_BoFo_W, w_WB_W);
+    return A_WF_W;
+  }
+
   /// (Advanced) NVI to DoCloneToScalar() templated on the scalar type of the
   /// new clone to be created. This method is mostly intended to be called by
   /// MultibodyTree::CloneToScalar(). Most users should not call this clone

--- a/multibody/tree/frame.h
+++ b/multibody/tree/frame.h
@@ -221,10 +221,10 @@ class Frame : public FrameBase<T> {
 
   /// Computes and returns the spatial acceleration A_WF_W of `this` frame F in
   /// world frame W expressed in W as a function of the state stored in context.
-  /// @note Indirectly, this method calls MultibodyPlant::EvalForwardDynamics()
-  /// which can be computational intensive.
   /// @note Body::EvalSpatialAccelerationInWorld() provides a more efficient way
   /// to obtain the spatial acceleration for a body frame.
+  /// @note Indirectly, this method calls MultibodyPlant::EvalForwardDynamics()
+  /// which can be computational intensive.
   SpatialAcceleration<T> CalcSpatialAccelerationInWorld(
       const systems::Context<T>& context) const {
     // `this` frame_F is fixed to a body B.  Calculate A_WB_W, body B's spatial

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -2479,6 +2479,13 @@ class MultibodyTree {
       const PositionKinematicsCache<T>& pc,
       std::vector<Vector6<T>>* H_PB_W_cache) const;
 
+  /// (Internal) Method that throws std::logic_error if the multibody tree is
+  /// not finalized or `body_B` does not belong to `this` multibody tree.
+  void IsFinalizedAndHasThisParentTreeOrThrow(const Body<T>& body_B) const {
+    DRAKE_MBT_THROW_IF_NOT_FINALIZED();
+    body_B.HasThisParentTreeOrThrow(this);
+  }
+
  private:
   // Make MultibodyTree templated on every other scalar type a friend of
   // MultibodyTree<T> so that CloneToScalar<ToAnyOtherScalar>() can access

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -2479,13 +2479,6 @@ class MultibodyTree {
       const PositionKinematicsCache<T>& pc,
       std::vector<Vector6<T>>* H_PB_W_cache) const;
 
-  /// (Internal) Method that throws std::logic_error if the multibody tree is
-  /// not finalized or `body_B` does not belong to `this` multibody tree.
-  void IsFinalizedAndHasThisParentTreeOrThrow(const Body<T>& body_B) const {
-    DRAKE_MBT_THROW_IF_NOT_FINALIZED();
-    body_B.HasThisParentTreeOrThrow(this);
-  }
-
  private:
   // Make MultibodyTree templated on every other scalar type a friend of
   // MultibodyTree<T> so that CloneToScalar<ToAnyOtherScalar>() can access


### PR DESCRIPTION
Per issue #13754, the Frame and Body classes currently have methods to calculate Pose and SpatialVelocity such as Frame::CalcSpatialVelocityInWorld().  It is natural that these classes have corresponding methods for SpatialAcceleration, e.g., Frame::CalcSpatialAccelerationInWorld().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13773)
<!-- Reviewable:end -->
