### PR TITLE
Simplify SDFormat //pose elements

### DIFF
--- a/bindings/pydrake/multibody/test/two_bodies.sdf
+++ b/bindings/pydrake/multibody/test/two_bodies.sdf
@@ -6,9 +6,7 @@
   -->
   <model name="two_bodies">
     <link name="body1">
-      <pose> 0 0 0 0 0 0</pose>
       <inertial>
-        <pose> 0 0 0 0 0 0</pose>
         <mass>1</mass>
         <inertia>
           <ixx>0.001</ixx>
@@ -28,9 +26,7 @@
       </collision>
     </link>
     <link name="body2">
-      <pose> 0 0 0 0 0 0</pose>
       <inertial>
-        <pose> 0 0 0 0 0 0</pose>
         <mass>1</mass>
         <inertia>
           <ixx>0.001</ixx>

--- a/examples/acrobot/Acrobot.sdf
+++ b/examples/acrobot/Acrobot.sdf
@@ -3,7 +3,6 @@
   <model name="Acrobot">
     <link name="base_link">
       <collision name="base_link_collision">
-        <pose frame="">0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.2 0.2 0.2</size>
@@ -11,7 +10,6 @@
         </geometry>
       </collision>
       <visual name="base_link_visual">
-        <pose frame="">0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.2 0.2 0.2</size>
@@ -24,9 +22,9 @@
       <parent>world</parent>
     </joint>
     <link name="upper_link">
-      <pose frame="">0 0.15 0 0 0 0</pose>
+      <pose>0 0.15 0 0 0 0</pose>
       <inertial>
-        <pose frame="">0 0 -0.5 0 0 0</pose>
+        <pose>0 0 -0.5 0 0 0</pose>
         <mass>1</mass>
         <inertia>
           <ixx>1</ixx>
@@ -38,7 +36,7 @@
         </inertia>
       </inertial>
       <collision name="upper_link_collision">
-        <pose frame="">0 0 -0.5 0 0 0</pose>
+        <pose>0 0 -0.5 0 0 0</pose>
         <geometry>
           <cylinder>
             <length>1.1</length>
@@ -47,7 +45,7 @@
         </geometry>
       </collision>
       <visual name="upper_link_visual">
-        <pose frame="">0 0 -0.5 0 0 0</pose>
+        <pose>0 0 -0.5 0 0 0</pose>
         <geometry>
           <cylinder>
             <length>1.1</length>
@@ -74,9 +72,9 @@
       </axis>
     </joint>
     <link name="lower_link">
-      <pose frame="">0 0.25 -1 0 0 0</pose>
+      <pose>0 0.25 -1 0 0 0</pose>
       <inertial>
-        <pose frame="">0 0 -1 0 0 0</pose>
+        <pose>0 0 -1 0 0 0</pose>
         <mass>1</mass>
         <inertia>
           <ixx>1</ixx>
@@ -88,7 +86,7 @@
         </inertia>
       </inertial>
       <collision name="lower_link_collision">
-        <pose frame="">0 0 -1 0 0 0</pose>
+        <pose>0 0 -1 0 0 0</pose>
         <geometry>
           <cylinder>
             <length>2.1</length>
@@ -97,7 +95,7 @@
         </geometry>
       </collision>
       <visual name="lower_link_visual">
-        <pose frame="">0 0 -1 0 0 0</pose>
+        <pose>0 0 -1 0 0 0</pose>
         <geometry>
           <cylinder>
             <length>2.1</length>

--- a/examples/allegro_hand/joint_control/simple_mug.sdf
+++ b/examples/allegro_hand/joint_control/simple_mug.sdf
@@ -2,9 +2,8 @@
 <sdf version="1.6">
   <model name="simple_mug">
     <link name="main_body">
-      <pose frame="">0 0 0 0 -0 0</pose>
       <inertial>
-        <pose frame="">0.01 0 0.05 0 -0 0</pose>
+        <pose>0.01 0 0.05 0 0 0</pose>
         <mass>0.094</mass>
         <inertia>
           <ixx>0.000156</ixx>
@@ -16,7 +15,7 @@
         </inertia>
       </inertial>
       <collision name="main_body_collision">
-        <pose frame="">0 0 0.05 0 -0 0</pose>
+        <pose>0 0 0.05 0 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.13</length>
@@ -33,7 +32,7 @@
         </surface>
       </collision>
       <collision name="mug_handle_collision">
-        <pose frame="">0.055 0 0.05 0 -0 0</pose>
+        <pose>0.055 0 0.05 0 0 0</pose>
         <geometry>
           <box>
             <size>0.03 0.02 0.08</size>
@@ -41,7 +40,7 @@
         </geometry>
       </collision>
       <visual name="main_body_visual">
-        <pose frame="">0 0 0.05 0 -0 0</pose>
+        <pose>0 0 0.05 0 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.13</length>
@@ -50,7 +49,7 @@
         </geometry>
       </visual>
       <visual name="mug_handle_visual">
-        <pose frame="">0.055 0 0.05 0 -0 0</pose>
+        <pose>0.055 0 0.05 0 0 0</pose>
         <geometry>
           <box>
             <size>0.03 0.02 0.08</size>

--- a/examples/atlas/sdf/cinder_block_2/model.sdf
+++ b/examples/atlas/sdf/cinder_block_2/model.sdf
@@ -29,7 +29,6 @@
         </geometry>
       </visual>
       <collision name="collision_box">
-        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.396875 0.19368008 0.146</size>

--- a/examples/atlas/sdf/cinder_block_wide/model.sdf
+++ b/examples/atlas/sdf/cinder_block_wide/model.sdf
@@ -28,7 +28,6 @@
         </geometry>
       </visual>
       <collision name="block_collision">
-        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.387353556 0.387353556 0.146</size>

--- a/examples/atlas/sdf/drc_practice_task_2.world
+++ b/examples/atlas/sdf/drc_practice_task_2.world
@@ -27,7 +27,6 @@
     <!-- A ground plane -->
     <include>
       <uri>model://ground_plane</uri>
-      <pose>0 0 0 0 0 0</pose>
     </include>
     <model name="green_tape">
       <static>true</static>

--- a/examples/atlas/urdf/atlas_convex_hull.urdf
+++ b/examples/atlas/urdf/atlas_convex_hull.urdf
@@ -1183,7 +1183,6 @@
   </link>
   <gazebo reference="head_hokuyo_frame">
     <sensor name="head_hokuyo_sensor" type="ray">
-      <pose>0 0 0 0 0 0</pose>
       <visualize>false</visualize>
       <update_rate>40</update_rate>
       <ray>
@@ -1645,7 +1644,6 @@
     <sensor name="l_hand_camera_sensor" type="camera">
       <update_rate>10.0</update_rate>
       <camera name="l_hand_camera">
-        <pose>0 0 0 0 0 0</pose>
         <!-- m.antone estimate of 2.8mm tamron lense fov -->
         <horizontal_fov>1.7281</horizontal_fov>
         <image>
@@ -1714,7 +1712,6 @@
     <sensor name="r_hand_camera_sensor" type="camera">
       <update_rate>10.0</update_rate>
       <camera name="r_hand_camera">
-        <pose>0 0 0 0 0 0</pose>
         <!-- m.antone estimate of 2.8mm tamron lense fov -->
         <horizontal_fov>1.7281</horizontal_fov>
         <image>

--- a/examples/atlas/urdf/atlas_minimal_contact.urdf
+++ b/examples/atlas/urdf/atlas_minimal_contact.urdf
@@ -1016,7 +1016,6 @@
   </link>
   <gazebo reference="head_hokuyo_frame">
     <sensor name="head_hokuyo_sensor" type="ray">
-      <pose>0 0 0 0 0 0</pose>
       <visualize>false</visualize>
       <update_rate>40</update_rate>
       <ray>

--- a/examples/kuka_iiwa_arm/models/desk/transcendesk55inch.sdf
+++ b/examples/kuka_iiwa_arm/models/desk/transcendesk55inch.sdf
@@ -5,10 +5,9 @@
     To adjust the height of the table, see note below. Also recompute inertia.
     -->
     <link name="table_base">
-      <pose frame="">-0.243716 -0.625087 0 0 -0 0</pose>
+      <pose>-0.243716 -0.625087 0 0 0 0</pose>
       <inertial>
         <mass>30</mass>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <!--
         The spatial inertia values given below were derived based on the
         equation for a cuboid:
@@ -36,7 +35,7 @@
       <kinematic>0</kinematic>
       <gravity>1</gravity>
       <visual name="right_crossbar">
-        <pose frame="">0.65 0 0.01 0 -0 0</pose>
+        <pose>0.65 0 0.01 0 0 0</pose>
         <geometry>
           <box>
             <size>0.065 0.61 0.03</size>
@@ -59,7 +58,7 @@
         <transparency>0</transparency>
       </visual>
       <visual name="left_crossbar">
-        <pose frame="">-0.65 0 0.01 0 -0 0</pose>
+        <pose>-0.65 0 0.01 0 0 0</pose>
         <geometry>
           <box>
             <size>0.065 0.61 0.03</size>
@@ -82,7 +81,7 @@
         <transparency>0</transparency>
       </visual>
       <visual name="bottom_right_leg">
-        <pose frame="">0.65 0.2 0.31 0 -0 0</pose>
+        <pose>0.65 0.2 0.31 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.076 0.58</size>
@@ -105,7 +104,7 @@
         <transparency>0</transparency>
       </visual>
       <visual name="leg_brace">
-        <pose frame="">0 0.229 0.42 0 -0 0</pose>
+        <pose>0 0.229 0.42 0 0 0</pose>
         <geometry>
           <box>
             <size>1.25 0.02 0.25</size>
@@ -128,7 +127,7 @@
         <transparency>0</transparency>
       </visual>
       <visual name="bottom_left_leg">
-        <pose frame="">-0.65 0.2 0.31 0 -0 0</pose>
+        <pose>-0.65 0.2 0.31 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.076 0.58</size>
@@ -153,7 +152,7 @@
       <collision name="bottom_left_leg">
         <laser_retro>0</laser_retro>
         <max_contacts>10</max_contacts>
-        <pose frame="">-0.65 0.2 0.31 0 -0 0</pose>
+        <pose>-0.65 0.2 0.31 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.076 0.58</size>
@@ -208,7 +207,7 @@
       <collision name="left_crossbar">
         <laser_retro>0</laser_retro>
         <max_contacts>10</max_contacts>
-        <pose frame="">-0.65 0 0.01 0 -0 0</pose>
+        <pose>-0.65 0 0.01 0 0 0</pose>
         <geometry>
           <box>
             <size>0.065 0.61 0.03</size>
@@ -263,7 +262,7 @@
       <collision name="right_crossbar">
         <laser_retro>0</laser_retro>
         <max_contacts>10</max_contacts>
-        <pose frame="">0.65 0 0.01 0 -0 0</pose>
+        <pose>0.65 0 0.01 0 0 0</pose>
         <geometry>
           <box>
             <size>0.065 0.61 0.03</size>
@@ -318,7 +317,7 @@
       <collision name="bottom_right_leg">
         <laser_retro>0</laser_retro>
         <max_contacts>10</max_contacts>
-        <pose frame="">0.65 0.2 0.31 0 -0 0</pose>
+        <pose>0.65 0.2 0.31 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.076 0.58</size>
@@ -373,7 +372,7 @@
       <collision name="leg_brace">
         <laser_retro>0</laser_retro>
         <max_contacts>10</max_contacts>
-        <pose frame="">0 0.229 0.42 0 -0 0</pose>
+        <pose>0 0.229 0.42 0 0 0</pose>
         <geometry>
           <box>
             <size>1.25 0.02 0.25</size>
@@ -431,10 +430,9 @@
       To adjust the height of the table, adjust the value of the third 
       parameter in the pose frame, z. Also adjust inertia.
       -->
-      <pose frame="">-0.243716 -0.625087 0.48 0 -0 0</pose>
+      <pose>-0.243716 -0.625087 0.48 0 0 0</pose>
       <inertial>
         <mass>53.5</mass>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <inertia>
           <ixx>5.17741</ixx>
           <ixy>0</ixy>
@@ -447,7 +445,7 @@
       <self_collide>0</self_collide>
       <kinematic>0</kinematic>
       <visual name="upper_right_leg">
-        <pose frame="">0.65 0.2 0.375 0 -0 0</pose>
+        <pose>0.65 0.2 0.375 0 0 0</pose>
         <geometry>
           <box>
             <size>0.03 0.05 0.53</size>
@@ -470,7 +468,7 @@
         <transparency>0</transparency>
       </visual>
       <visual name="upper_left_leg">
-        <pose frame="">-0.65 0.2 0.375 0 -0 0</pose>
+        <pose>-0.65 0.2 0.375 0 0 0</pose>
         <geometry>
           <box>
             <size>0.03 0.05 0.53</size>
@@ -493,7 +491,7 @@
         <transparency>0</transparency>
       </visual>
       <visual name="tabletop">
-        <pose frame="">0 0 0.65 0 -0 0</pose>
+        <pose>0 0 0.65 0 0 0</pose>
         <geometry>
           <box>
             <size>1.4 0.6 0.03</size>
@@ -518,7 +516,7 @@
       <collision name="tabletop">
         <laser_retro>0</laser_retro>
         <max_contacts>10</max_contacts>
-        <pose frame="">0 0 0.65 0 -0 0</pose>
+        <pose>0 0 0.65 0 0 0</pose>
         <geometry>
           <box>
             <size>1.4 0.6 0.03</size>
@@ -578,7 +576,6 @@
     <joint name="table_height" type="prismatic">
       <parent>table_upper</parent>
       <child>table_base</child>
-      <pose frame="">0 0 0 0 -0 0</pose>
       <axis>
         <xyz>0 0 1</xyz>
         <use_parent_model_frame>0</use_parent_model_frame>

--- a/examples/kuka_iiwa_arm/models/table/extra_heavy_duty_table.sdf
+++ b/examples/kuka_iiwa_arm/models/table/extra_heavy_duty_table.sdf
@@ -2,10 +2,8 @@
 <sdf version="1.6">
   <model name="extra_heavy_duty_table">
     <link name="link">
-      <pose frame="">0 0 0 0 -0 0</pose>
       <inertial>
         <mass>53.5</mass>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <!--
         The spatial inertia values given below were derived based on the
         equation for a cuboid:
@@ -32,7 +30,7 @@
       <self_collide>0</self_collide>
       <kinematic>0</kinematic>
       <visual name="back_right_leg">
-        <pose frame="">-0.33 -0.35 0.381 0 -0 0</pose>
+        <pose>-0.33 -0.35 0.381 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.05 0.762</size>
@@ -55,7 +53,7 @@
         <transparency>0</transparency>
       </visual>
       <visual name="front_left_leg">
-        <pose frame="">0.33 0.35 0.381 0 -0 0</pose>
+        <pose>0.33 0.35 0.381 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.05 0.762</size>
@@ -78,7 +76,7 @@
         <transparency>0</transparency>
       </visual>
       <visual name="left_crossbar">
-        <pose frame="">0.33 0 0.13335 0 -0 0</pose>
+        <pose>0.33 0 0.13335 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.662 0.05</size>
@@ -101,7 +99,7 @@
         <transparency>0</transparency>
       </visual>
       <visual name="right_crossbar">
-        <pose frame="">-0.33 0 0.13335 0 -0 0</pose>
+        <pose>-0.33 0 0.13335 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.662 0.05</size>
@@ -124,7 +122,7 @@
         <transparency>0</transparency>
       </visual>
       <visual name="back_left_leg">
-        <pose frame="">-0.33 0.35 0.381 0 -0 0</pose>
+        <pose>-0.33 0.35 0.381 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.05 0.762</size>
@@ -147,7 +145,7 @@
         <transparency>0</transparency>
       </visual>
       <visual name="front_right_leg">
-        <pose frame="">0.33 -0.35 0.381 0 -0 0</pose>
+        <pose>0.33 -0.35 0.381 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.05 0.762</size>
@@ -170,7 +168,7 @@
         <transparency>0</transparency>
       </visual>
       <visual name="back_crossbar">
-        <pose frame="">0 0.35 0.13335 0 -0 0</pose>
+        <pose>0 0.35 0.13335 0 0 0</pose>
         <geometry>
           <box>
             <size>0.6112 0.05 0.05</size>
@@ -193,7 +191,7 @@
         <transparency>0</transparency>
       </visual>
       <visual name="front_crossbar">
-        <pose frame="">0 -0.35 0.13335 0 -0 0</pose>
+        <pose>0 -0.35 0.13335 0 0 0</pose>
         <geometry>
           <box>
             <size>0.6112 0.05 0.05</size>
@@ -216,7 +214,7 @@
         <transparency>0</transparency>
       </visual>
       <visual name="visual1">
-        <pose frame="">0 0 0.736 0 -0 0</pose>
+        <pose>0 0 0.736 0 0 0</pose>
         <geometry>
           <box>
             <size>0.7112 0.762 0.057</size>
@@ -241,7 +239,7 @@
       <collision name="front_crossbar">
         <laser_retro>0</laser_retro>
         <max_contacts>10</max_contacts>
-        <pose frame="">0 -0.35 0.13335 0 -0 0</pose>
+        <pose>0 -0.35 0.13335 0 0 0</pose>
         <geometry>
           <box>
             <size>0.6112 0.05 0.05</size>
@@ -296,7 +294,7 @@
       <collision name="back_crossbar">
         <laser_retro>0</laser_retro>
         <max_contacts>10</max_contacts>
-        <pose frame="">0 0.35 0.13335 0 -0 0</pose>
+        <pose>0 0.35 0.13335 0 0 0</pose>
         <geometry>
           <box>
             <size>0.6112 0.05 0.05</size>
@@ -351,7 +349,7 @@
       <collision name="left_crossbar">
         <laser_retro>0</laser_retro>
         <max_contacts>10</max_contacts>
-        <pose frame="">0.33 0 0.13335 0 -0 0</pose>
+        <pose>0.33 0 0.13335 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.662 0.05</size>
@@ -406,7 +404,7 @@
       <collision name="right_crossbar">
         <laser_retro>0</laser_retro>
         <max_contacts>10</max_contacts>
-        <pose frame="">-0.33 0 0.13335 0 -0 0</pose>
+        <pose>-0.33 0 0.13335 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.662 0.05</size>
@@ -461,7 +459,7 @@
       <collision name="back_right_leg">
         <laser_retro>0</laser_retro>
         <max_contacts>10</max_contacts>
-        <pose frame="">-0.33 -0.35 0.381 0 -0 0</pose>
+        <pose>-0.33 -0.35 0.381 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.05 0.762</size>
@@ -516,7 +514,7 @@
       <collision name="front_left_leg">
         <laser_retro>0</laser_retro>
         <max_contacts>10</max_contacts>
-        <pose frame="">0.33 0.35 0.381 0 -0 0</pose>
+        <pose>0.33 0.35 0.381 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.05 0.762</size>
@@ -571,7 +569,7 @@
       <collision name="back_left_leg">
         <laser_retro>0</laser_retro>
         <max_contacts>10</max_contacts>
-        <pose frame="">-0.33 0.35 0.381 0 -0 0</pose>
+        <pose>-0.33 0.35 0.381 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.05 0.762</size>
@@ -626,7 +624,7 @@
       <collision name="front_right_leg">
         <laser_retro>0</laser_retro>
         <max_contacts>10</max_contacts>
-        <pose frame="">0.33 -0.35 0.381 0 -0 0</pose>
+        <pose>0.33 -0.35 0.381 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.05 0.762</size>
@@ -681,7 +679,7 @@
       <collision name="surface">
         <laser_retro>0</laser_retro>
         <max_contacts>10</max_contacts>
-        <pose frame="">0 0 0.736 0 -0 0</pose>
+        <pose>0 0 0.736 0 0 0</pose>
         <geometry>
           <box>
             <size>0.7112 0.762 0.057</size>

--- a/examples/kuka_iiwa_arm/models/table/extra_heavy_duty_table_surface_only_collision.sdf
+++ b/examples/kuka_iiwa_arm/models/table/extra_heavy_duty_table_surface_only_collision.sdf
@@ -9,10 +9,8 @@
     checks needed.
     -->
     <link name="link">
-      <pose frame="">0 0 0 0 -0 0</pose>
       <inertial>
         <mass>53.5</mass>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <!--
         The spatial inertia values given below were derived based on the
         equation for a cuboid:
@@ -39,7 +37,7 @@
       <self_collide>0</self_collide>
       <kinematic>0</kinematic>
       <visual name="back_right_leg">
-        <pose frame="">-0.33 -0.35 0.381 0 -0 0</pose>
+        <pose>-0.33 -0.35 0.381 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.05 0.762</size>
@@ -62,7 +60,7 @@
         <transparency>0</transparency>
       </visual>
       <visual name="front_left_leg">
-        <pose frame="">0.33 0.35 0.381 0 -0 0</pose>
+        <pose>0.33 0.35 0.381 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.05 0.762</size>
@@ -85,7 +83,7 @@
         <transparency>0</transparency>
       </visual>
       <visual name="left_crossbar">
-        <pose frame="">0.33 0 0.13335 0 -0 0</pose>
+        <pose>0.33 0 0.13335 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.662 0.05</size>
@@ -108,7 +106,7 @@
         <transparency>0</transparency>
       </visual>
       <visual name="right_crossbar">
-        <pose frame="">-0.33 0 0.13335 0 -0 0</pose>
+        <pose>-0.33 0 0.13335 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.662 0.05</size>
@@ -131,7 +129,7 @@
         <transparency>0</transparency>
       </visual>
       <visual name="back_left_leg">
-        <pose frame="">-0.33 0.35 0.381 0 -0 0</pose>
+        <pose>-0.33 0.35 0.381 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.05 0.762</size>
@@ -154,7 +152,7 @@
         <transparency>0</transparency>
       </visual>
       <visual name="front_right_leg">
-        <pose frame="">0.33 -0.35 0.381 0 -0 0</pose>
+        <pose>0.33 -0.35 0.381 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.05 0.762</size>
@@ -177,7 +175,7 @@
         <transparency>0</transparency>
       </visual>
       <visual name="back_crossbar">
-        <pose frame="">0 0.35 0.13335 0 -0 0</pose>
+        <pose>0 0.35 0.13335 0 0 0</pose>
         <geometry>
           <box>
             <size>0.6112 0.05 0.05</size>
@@ -200,7 +198,7 @@
         <transparency>0</transparency>
       </visual>
       <visual name="front_crossbar">
-        <pose frame="">0 -0.35 0.13335 0 -0 0</pose>
+        <pose>0 -0.35 0.13335 0 0 0</pose>
         <geometry>
           <box>
             <size>0.6112 0.05 0.05</size>
@@ -223,7 +221,7 @@
         <transparency>0</transparency>
       </visual>
       <visual name="visual1">
-        <pose frame="">0 0 0.736 0 -0 0</pose>
+        <pose>0 0 0.736 0 0 0</pose>
         <geometry>
           <box>
             <size>0.7112 0.762 0.057</size>
@@ -248,7 +246,7 @@
       <collision name="surface">
         <laser_retro>0</laser_retro>
         <max_contacts>10</max_contacts>
-        <pose frame="">0 0 0.736 0 -0 0</pose>
+        <pose>0 0 0.736 0 0 0</pose>
         <geometry>
           <box>
             <size>0.7112 0.762 0.057</size>
@@ -307,7 +305,7 @@
       causes RBT SDFormat parsing code to segfault. Remove this once RBT is
       removed.
       -->
-      <pose frame="link">0 0 0.7645 0 -0 0</pose>
+      <pose frame="link">0 0 0.7645 0 0 0</pose>
     </frame>
     <!--
     N.B. This model used to have <static>true</static>, but this creates

--- a/examples/manipulation_station/models/061_foam_brick.sdf
+++ b/examples/manipulation_station/models/061_foam_brick.sdf
@@ -3,7 +3,7 @@
   <model name="foam_brick">
     <link name="base_link">
       <inertial>
-        <pose frame="">0 0 0.025 0 0 0 </pose>
+        <pose>0 0 0.025 0 0 0 </pose>
         <mass>0.028</mass>
         <inertia>
           <ixx>1.17e-5</ixx>
@@ -15,7 +15,7 @@
         </inertia>
       </inertial>
       <visual name="base_link">
-        <pose frame="">0 0 0.025 0 0 0</pose>
+        <pose>0 0 0.025 0 0 0</pose>
         <geometry>
           <box>
             <size>0.075 0.05 0.05</size>

--- a/examples/manipulation_station/models/amazon_table_simplified.sdf
+++ b/examples/manipulation_station/models/amazon_table_simplified.sdf
@@ -2,7 +2,6 @@
 <sdf version="1.6">
   <model name="amazon_table">
     <link name="amazon_table">
-      <pose>0 0 0 0 0 0 </pose>
       <inertial>
         <mass>1</mass>
         <inertia>

--- a/examples/manipulation_station/models/bin.sdf
+++ b/examples/manipulation_station/models/bin.sdf
@@ -10,9 +10,7 @@
       (0, 0, 0) at the center bottom of the bin
     -->
     <link name="bin_base">
-      <pose frame="">0 0 0 0 0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 0 0</pose>
         <mass>18.70</mass>
         <inertia>
           <ixx>0.79</ixx>
@@ -24,7 +22,7 @@
         </inertia>
       </inertial>
       <visual name="visual">
-        <pose frame="">0.22 0 0.105 0 0 0</pose>
+        <pose>0.22 0 0.105 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.63 0.21</size>
@@ -32,7 +30,7 @@
         </geometry>
       </visual>
       <collision name="front">
-        <pose frame="">0.22 0 0.105 0 0 0</pose>
+        <pose>0.22 0 0.105 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.63 0.21</size>
@@ -40,7 +38,7 @@
         </geometry>
       </collision>
       <visual name="slope">
-        <pose frame="">0.182 0 0.102 0 0.35 0</pose>
+        <pose>0.182 0 0.102 0 0.35 0</pose>
         <geometry>
           <box>
             <size>0.05 0.63 0.21</size>
@@ -48,7 +46,7 @@
         </geometry>
       </visual>
       <collision name="slope">
-        <pose frame="">0.182 0 0.102 0 0.35 0</pose>
+        <pose>0.182 0 0.102 0 0.35 0</pose>
         <geometry>
           <box>
             <size>0.05 0.63 0.21</size>
@@ -56,7 +54,7 @@
         </geometry>
       </collision>
       <visual name="back">
-        <pose frame="">-0.22 0 0.105 0 0 0</pose>
+        <pose>-0.22 0 0.105 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.63 0.21</size>
@@ -64,7 +62,7 @@
         </geometry>
       </visual>
       <collision name="back">
-        <pose frame="">-0.22 0 0.105 0 0 0</pose>
+        <pose>-0.22 0 0.105 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.63 0.21</size>
@@ -72,7 +70,7 @@
         </geometry>
       </collision>
       <visual name="left">
-        <pose frame="">0 0.29 0.105 0 0 0</pose>
+        <pose>0 0.29 0.105 0 0 0</pose>
         <geometry>
           <box>
             <size>0.49 0.05 0.21</size>
@@ -80,7 +78,7 @@
         </geometry>
       </visual>
       <collision name="left">
-        <pose frame="">0 0.29 0.105 0 0 0</pose>
+        <pose>0 0.29 0.105 0 0 0</pose>
         <geometry>
           <box>
             <size>0.49 0.05 0.21</size>
@@ -88,7 +86,7 @@
         </geometry>
       </collision>
       <visual name="right">
-        <pose frame="">0 -0.29 0.105 0 0 0</pose>
+        <pose>0 -0.29 0.105 0 0 0</pose>
         <geometry>
           <box>
             <size>0.49 0.05 0.21</size>
@@ -96,7 +94,7 @@
         </geometry>
       </visual>
       <collision name="right">
-        <pose frame="">0 -0.29 0.105 0 0 0</pose>
+        <pose>0 -0.29 0.105 0 0 0</pose>
         <geometry>
           <box>
             <size>0.49 0.05 0.21</size>
@@ -104,7 +102,7 @@
         </geometry>
       </collision>
       <visual name="bottom">
-        <pose frame="">0.0 0.0 0.0075 0 0 0</pose>
+        <pose>0.0 0.0 0.0075 0 0 0</pose>
         <geometry>
           <box>
             <size>0.49 0.63 0.015</size>
@@ -112,7 +110,7 @@
         </geometry>
       </visual>
       <collision name="bottom">
-        <pose frame="">0.0 0.0 0.0075 0 0 0</pose>
+        <pose>0.0 0.0 0.0075 0 0 0</pose>
         <geometry>
           <box>
             <size>0.49 0.63 0.015</size>

--- a/examples/manipulation_station/models/cupboard.sdf
+++ b/examples/manipulation_station/models/cupboard.sdf
@@ -2,7 +2,6 @@
 <sdf version="1.6">
   <model name="cupboard">
     <link name="cupboard_body">
-      <pose> 0 0 0 0 0 0</pose>
       <visual name="right_wall">
         <pose> 0 0.292 0 0 0 0</pose>
         <geometry>
@@ -37,7 +36,6 @@
       </collision>
     </link>
     <link name="top_and_bottom">
-      <pose> 0 0 0 0 0 0</pose>
       <visual name="bottom">
         <pose> 0 0 -0.3995 0 0 0</pose>
         <geometry>
@@ -107,7 +105,6 @@
     <joint name="top_and_bottom_cupboard_body" type="fixed">
       <child>top_and_bottom</child>
       <parent>cupboard_body</parent>
-      <pose>0 0 0 0 0 0 </pose>
     </joint>
     <!-- joint between cupboard_body and left_door -->
     <joint name="left_door_hinge" type="revolute">
@@ -147,7 +144,6 @@
         </geometry>
       </visual>
       <visual name="slab">
-        <pose> 0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.016 0.279 0.815</size>
@@ -167,7 +163,6 @@
         </geometry>
       </collision>
       <collision name="slab">
-        <pose> 0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.016 0.279 0.815</size>
@@ -213,7 +208,6 @@
         </geometry>
       </visual>
       <visual name="slab">
-        <pose> 0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.016 0.279 0.815</size>
@@ -233,7 +227,6 @@
         </geometry>
       </collision>
       <collision name="slab">
-        <pose> 0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.016 0.279 0.815</size>

--- a/examples/manipulation_station/models/cylinder.sdf
+++ b/examples/manipulation_station/models/cylinder.sdf
@@ -9,7 +9,6 @@
       (0, 0, 0) at the center (while ignoring the handle).
     -->
     <link name="base_link">
-      <pose>0 0 0 0 0 0</pose>
       <inertial>
         <pose>0.0042 0.00000 -0.0059 0 0 0</pose>
         <mass>0.321</mass>
@@ -23,7 +22,6 @@
         </inertia>
       </inertial>
       <visual name="visual_cylinder">
-        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <cylinder>
             <radius>0.043</radius>
@@ -46,7 +44,6 @@
         </material>
       </visual>
       <collision name="collision_cylinder">
-        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <cylinder>
             <radius>0.043</radius>

--- a/examples/manipulation_station/models/sphere.sdf
+++ b/examples/manipulation_station/models/sphere.sdf
@@ -3,7 +3,7 @@
   <model name="sphere">
     <link name="base_link">
       <inertial>
-        <pose frame="">0 0 0.025 0 0 0 </pose>
+        <pose>0 0 0.025 0 0 0 </pose>
         <mass>0.028</mass>
         <inertia>
           <ixx>1.17e-5</ixx>
@@ -15,7 +15,7 @@
         </inertia>
       </inertial>
       <visual name="sphere_visual">
-        <pose frame="">0 0 0.025 0 0 0</pose>
+        <pose>0 0 0.025 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.04</radius>

--- a/examples/manipulation_station/models/thin_box.sdf
+++ b/examples/manipulation_station/models/thin_box.sdf
@@ -2,10 +2,9 @@
 <sdf version="1.6">
   <model name="thin_box">
     <link name="base_link">
-      <pose frame="">0 0 0 0 0 0</pose>
       <inertial>
         <!-- The COM offset from the defined origin (m) -->
-        <pose frame="">7.9737e-03 6.8264e-03 5.1174e-03 0 0 0</pose>
+        <pose>7.9737e-03 6.8264e-03 5.1174e-03 0 0 0</pose>
         <mass>52.78e-3</mass>
         <inertia>
           <ixx>5.20e-06</ixx>
@@ -17,7 +16,7 @@
         </inertia>
       </inertial>
       <collision name="handle_collision">
-        <pose frame="">-0.031 0.007 0.005 0 -0.05 0</pose>
+        <pose>-0.031 0.007 0.005 0 -0.05 0</pose>
         <geometry>
           <box>
             <size>0.115 0.01 0.0025</size>
@@ -33,7 +32,7 @@
         </surface>
       </collision>
       <collision name="base_collision">
-        <pose frame="">0.067 0.007 0.0115 0 -0.45 0</pose>
+        <pose>0.067 0.007 0.0115 0 -0.45 0</pose>
         <geometry>
           <box>
             <size>0.047 0.042 0.0025</size>
@@ -41,7 +40,7 @@
         </geometry>
       </collision>
       <visual name="visual_1">
-        <pose frame="">-0.031 0.007 0.005 0 -0.05 0</pose>
+        <pose>-0.031 0.007 0.005 0 -0.05 0</pose>
         <geometry>
           <box>
             <size>0.115 0.01 0.0025</size>
@@ -52,7 +51,7 @@
         </material>
       </visual>
       <visual name="visual_2">
-        <pose frame="">0.067 0.007 0.0115 0 -0.45 0</pose>
+        <pose>0.067 0.007 0.0115 0 -0.45 0</pose>
         <geometry>
           <box>
             <size>0.047 0.042 0.0025</size>
@@ -65,7 +64,7 @@
       <!-- Add spheres to the corners of the collision boxes, to avoid
       bouncing. -->
       <collision name="handle_corner_col_0">
-        <pose frame="">-0.0885 0.002 0.00225 0 0 0</pose>
+        <pose>-0.0885 0.002 0.00225 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>2e-3</radius>
@@ -73,7 +72,7 @@
         </geometry>
       </collision>
       <collision name="handle_corner_col_1">
-        <pose frame="">-0.0885 0.012 0.00225 0 0 0</pose>
+        <pose>-0.0885 0.012 0.00225 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>2e-3</radius>
@@ -81,7 +80,7 @@
         </geometry>
       </collision>
       <collision name="base_corner_col_0">
-        <pose frame="">0.088 0.028 0.022 0 0 0</pose>
+        <pose>0.088 0.028 0.022 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>2e-3</radius>
@@ -89,7 +88,7 @@
         </geometry>
       </collision>
       <collision name="base_corner_col_1">
-        <pose frame="">0.088 -0.0145 0.022 0 0 0</pose>
+        <pose>0.088 -0.0145 0.022 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>2e-3</radius>
@@ -97,7 +96,7 @@
         </geometry>
       </collision>
       <collision name="base_corner_col_2">
-        <pose frame="">0.046 -0.014 0.001 0 0 0</pose>
+        <pose>0.046 -0.014 0.001 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>2e-3</radius>
@@ -105,7 +104,7 @@
         </geometry>
       </collision>
       <collision name="base_corner_col_3">
-        <pose frame="">0.046 0.028 0.001 0 0 0</pose>
+        <pose>0.046 0.028 0.001 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>2e-3</radius>
@@ -114,7 +113,7 @@
       </collision>
       <!-- Add collision spheres along the handle-->
       <collision name="handle_sphere_col_0">
-        <pose frame="">-0.080 0.007 0.005 0 0 0</pose>
+        <pose>-0.080 0.007 0.005 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>2e-3</radius>
@@ -122,7 +121,7 @@
         </geometry>
       </collision>
       <collision name="handle_sphere_col_1">
-        <pose frame="">-0.070 0.007 0.005 0 0 0</pose>
+        <pose>-0.070 0.007 0.005 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>2e-3</radius>
@@ -130,7 +129,7 @@
         </geometry>
       </collision>
       <collision name="handle_sphere_col_2">
-        <pose frame="">-0.060 0.007 0.005 0 0 0</pose>
+        <pose>-0.060 0.007 0.005 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>2e-3</radius>
@@ -138,7 +137,7 @@
         </geometry>
       </collision>
       <collision name="handle_sphere_col_3">
-        <pose frame="">-0.050 0.007 0.005 0 0 0</pose>
+        <pose>-0.050 0.007 0.005 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>2e-3</radius>
@@ -146,7 +145,7 @@
         </geometry>
       </collision>
       <collision name="handle_sphere_col_4">
-        <pose frame="">-0.040 0.007 0.005 0 0 0</pose>
+        <pose>-0.040 0.007 0.005 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>2e-3</radius>
@@ -154,7 +153,7 @@
         </geometry>
       </collision>
       <collision name="handle_sphere_col_5">
-        <pose frame="">-0.030 0.007 0.005 0 0 0</pose>
+        <pose>-0.030 0.007 0.005 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>2e-3</radius>
@@ -162,7 +161,7 @@
         </geometry>
       </collision>
       <collision name="handle_sphere_col_6">
-        <pose frame="">-0.020 0.007 0.005 0 0 0</pose>
+        <pose>-0.020 0.007 0.005 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>2e-3</radius>
@@ -170,7 +169,7 @@
         </geometry>
       </collision>
       <collision name="handle_sphere_col_7">
-        <pose frame="">-0.010 0.007 0.005 0 0 0</pose>
+        <pose>-0.010 0.007 0.005 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>2e-3</radius>
@@ -178,7 +177,7 @@
         </geometry>
       </collision>
       <collision name="handle_sphere_col_8">
-        <pose frame="">-0 0.007 0.005 0 0 0</pose>
+        <pose>-0 0.007 0.005 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>2e-3</radius>
@@ -186,7 +185,7 @@
         </geometry>
       </collision>
       <collision name="handle_sphere_col_9">
-        <pose frame="">0.010 0.007 0.005 0 0 0</pose>
+        <pose>0.010 0.007 0.005 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>2e-3</radius>
@@ -194,7 +193,7 @@
         </geometry>
       </collision>
       <collision name="handle_sphere_col_10">
-        <pose frame="">0.020 0.007 0.005 0 0 0</pose>
+        <pose>0.020 0.007 0.005 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>2e-3</radius>

--- a/examples/manipulation_station/models/thin_cylinder.sdf
+++ b/examples/manipulation_station/models/thin_cylinder.sdf
@@ -2,7 +2,6 @@
 <sdf version="1.6">
   <model name="thin_cylinder">
     <link name="base_link">
-      <pose>0 0 0 0 0 0</pose>
       <inertial>
         <pose>0 0 0.00915 0 0 0</pose>
         <mass>0.375</mass>

--- a/examples/multibody/cart_pole/cart_pole.sdf
+++ b/examples/multibody/cart_pole/cart_pole.sdf
@@ -5,7 +5,6 @@
          documented in cart_pole_params_named_vector.yaml.
          They MUST be kept in sync. -->
     <link name="Cart">
-      <pose>0 0 0 0 0 0</pose>
       <inertial>
         <mass>10.0</mass>
         <!-- For this model case, with the cart not having any rotational
@@ -23,7 +22,6 @@
         </inertia>
       </inertial>
       <visual name="cart_visual">
-        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.24 0.12 0.12</size>
@@ -50,7 +48,6 @@
         </inertia>
       </inertial>
       <visual name="pole_point_mass">
-        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.05</radius>

--- a/examples/multibody/four_bar/four_bar.sdf
+++ b/examples/multibody/four_bar/four_bar.sdf
@@ -76,7 +76,6 @@
     <link name="A">
       <!-- The frame A measured in the world frame, X_WA is the identity. This 
       link is also called 'Crank' in the diagram in README.md -->
-      <pose>0 0 0 0 0 0</pose>
       <inertial>
         <!-- Acm (A's center of mass) is located at the midpoint of the 4 meter long link. -->
         <pose>2 0 0 0 0 0</pose>

--- a/examples/planar_gripper/planar_brick.sdf
+++ b/examples/planar_gripper/planar_brick.sdf
@@ -5,7 +5,6 @@
   </link>
     <link name="brick_dummy_link1">
       <inertial>
-        <pose frame="">0 0 0 0 0 0 </pose>
         <mass>1e-10</mass>
         <inertia>
           <ixx>1e-10</ixx>
@@ -30,7 +29,6 @@
     </joint>
     <link name="brick_dummy_link2">
       <inertial>
-        <pose frame="">0 0 0 0 0 0 </pose>
         <mass>1e-10</mass>
         <inertia>
           <ixx>1e-10</ixx>
@@ -55,7 +53,6 @@
     </joint>
     <link name="brick_link">
       <inertial>
-        <pose frame="">0 0 0 0 0 0 </pose>
         <mass>0.028</mass>
         <inertia>
           <ixx>1.17e-5</ixx>
@@ -67,7 +64,7 @@
         </inertia>
       </inertial>
       <visual name="brick_visual_1">
-        <pose frame="">0 0 0.025 0 0 0</pose>
+        <pose>0 0 0.025 0 0 0</pose>
         <geometry>
           <box>
             <size>0.07 0.1 0.05</size>
@@ -78,7 +75,7 @@
         </material>
       </visual>
       <visual name="brick_visual_2">
-        <pose frame="">0 0 -0.025 0 0 0</pose>
+        <pose>0 0 -0.025 0 0 0</pose>
         <geometry>
           <box>
             <size>0.07 0.1 0.05</size>
@@ -89,7 +86,6 @@
         </material>
       </visual>
       <collision name="box_collision">
-        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.07 0.1 0.1</size>

--- a/examples/planar_gripper/planar_gripper.sdf
+++ b/examples/planar_gripper/planar_gripper.sdf
@@ -7,7 +7,6 @@
   <model name="planar_gripper">
     <link name="finger1_base">
       <visual name="base_visual">
-        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.08 0.08 0.008</size>
@@ -19,7 +18,6 @@
       </visual>
     </link>
     <link name="finger1_link1">
-      <pose>0 0 0 0 0 0</pose>
       <inertial>
         <pose>0 0 -0.0425 0 0 0</pose>
         <mass>0.1</mass>
@@ -129,7 +127,6 @@
       <parent>finger1_link1</parent>
       <child>finger1_link2</child>
       <!-- Pose X_CJ of the joint frame J in the frame C of the child link -->
-      <pose>0 0 0 0 0 0</pose>
       <axis>
         <xyz>1 0 0</xyz>
         <limit>
@@ -212,11 +209,9 @@
     <joint name="finger1_sensor_weldjoint" type="fixed">
       <parent>finger1_link2</parent>
       <child>finger1_tip_link</child>
-      <pose>0 0 0 0 0 0</pose>
     </joint>
     <link name="finger2_base">
       <visual name="base_visual">
-        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.08 0.08 0.008</size>
@@ -228,7 +223,6 @@
       </visual>
     </link>
     <link name="finger2_link1">
-      <pose>0 0 0 0 0 0</pose>
       <inertial>
         <pose>0 0 -0.0425 0 0 0</pose>
         <mass>0.1</mass>
@@ -338,7 +332,6 @@
       <parent>finger2_link1</parent>
       <child>finger2_link2</child>
       <!-- Pose X_CJ of the joint frame J in the frame C of the child link -->
-      <pose>0 0 0 0 0 0</pose>
       <axis>
         <xyz>1 0 0</xyz>
         <limit>
@@ -421,11 +414,9 @@
     <joint name="finger2_sensor_weldjoint" type="fixed">
       <parent>finger2_link2</parent>
       <child>finger2_tip_link</child>
-      <pose>0 0 0 0 0 0</pose>
     </joint>
     <link name="finger3_base">
       <visual name="base_visual">
-        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.08 0.08 0.008</size>
@@ -437,7 +428,6 @@
       </visual>
     </link>
     <link name="finger3_link1">
-      <pose>0 0 0 0 0 0</pose>
       <inertial>
         <pose>0 0 -0.0425 0 0 0</pose>
         <mass>0.1</mass>
@@ -547,7 +537,6 @@
       <parent>finger3_link1</parent>
       <child>finger3_link2</child>
       <!-- Pose X_CJ of the joint frame J in the frame C of the child link -->
-      <pose>0 0 0 0 0 0</pose>
       <axis>
         <xyz>1 0 0</xyz>
         <limit>
@@ -630,7 +619,6 @@
     <joint name="finger3_sensor_weldjoint" type="fixed">
       <parent>finger3_link2</parent>
       <child>finger3_tip_link</child>
-      <pose>0 0 0 0 0 0</pose>
     </joint>
   </model>
 </sdf>

--- a/examples/planar_gripper/planar_gripper.xacro
+++ b/examples/planar_gripper/planar_gripper.xacro
@@ -22,7 +22,6 @@
     <xacro:macro name="finger" params="fnum">
       <link name="finger${fnum}_base">
         <visual name="base_visual">
-          <pose>0 0 0 0 0 0</pose>
           <geometry>
             <box>
               <size>${base_dim} ${base_dim} ${base_dim/10}</size>
@@ -34,7 +33,6 @@
         </visual>
       </link>
       <link name="finger${fnum}_link1">
-        <pose>0 0 0 0 0 0</pose>
         <inertial>
           <pose>0 0 -${l1_length/2} 0 0 0</pose>
           <mass>${l1_mass}</mass>
@@ -144,7 +142,6 @@
         <parent>finger${fnum}_link1</parent>
         <child>finger${fnum}_link2</child>
         <!-- Pose X_CJ of the joint frame J in the frame C of the child link -->
-        <pose>0 0 0 0 0 0</pose>
         <axis>
           <xyz>1 0 0</xyz>
           <limit>
@@ -227,7 +224,6 @@
       <joint name="finger${fnum}_sensor_weldjoint" type="fixed">
         <parent>finger${fnum}_link2</parent>
         <child>finger${fnum}_tip_link</child>
-        <pose>0 0 0 0 0 0</pose>
       </joint>
     </xacro:macro>
     <xacro:finger fnum="1"/>

--- a/examples/quadrotor/warehouse.sdf
+++ b/examples/quadrotor/warehouse.sdf
@@ -3,7 +3,7 @@
   <model name="room_w_lidar">
     <static>true</static>
     <link name="bottom_wall">
-      <pose frame="">3.5 -0.25 -1.6 0 0 0</pose>
+      <pose>3.5 -0.25 -1.6 0 0 0</pose>
       <visual name="wall">
         <geometry>
           <box>
@@ -20,7 +20,7 @@
       </collision>
     </link>
     <link name="left_wall">
-      <pose frame="">3.5 1.75 0 0 0 0</pose>
+      <pose>3.5 1.75 0 0 0 0</pose>
       <visual name="wall">
         <geometry>
           <box>
@@ -37,7 +37,7 @@
       </collision>
     </link>
     <link name="right_wall">
-      <pose frame="">3.5 -2.25 0 0 0 0</pose>
+      <pose>3.5 -2.25 0 0 0 0</pose>
       <visual name="wall">
         <geometry>
           <box>
@@ -54,7 +54,7 @@
       </collision>
     </link>
     <link name="back_wall">
-      <pose frame="">-1.25 -0.25 0 0 0 0</pose>
+      <pose>-1.25 -0.25 0 0 0 0</pose>
       <visual name="wall">
         <geometry>
           <box>
@@ -71,7 +71,7 @@
       </collision>
     </link>
     <link name="front_wall">
-      <pose frame="">8.25 -0.25 0 0 0 0</pose>
+      <pose>8.25 -0.25 0 0 0 0</pose>
       <visual name="wall">
         <geometry>
           <box>
@@ -88,7 +88,7 @@
       </collision>
     </link>
     <link name="slalom_1">
-      <pose frame="">1.75 0.5 0 0 0 0</pose>
+      <pose>1.75 0.5 0 0 0 0</pose>
       <visual name="wall">
         <geometry>
           <box>
@@ -105,7 +105,7 @@
       </collision>
     </link>
     <link name="slalom_2">
-      <pose frame="">3.75 -1 0 0 0 0</pose>
+      <pose>3.75 -1 0 0 0 0</pose>
       <visual name="wall">
         <geometry>
           <box>
@@ -122,7 +122,7 @@
       </collision>
     </link>
     <link name="slalom_3">
-      <pose frame="">5.75 0.5 0 0 0 0</pose>
+      <pose>5.75 0.5 0 0 0 0</pose>
       <visual name="wall">
         <geometry>
           <box>

--- a/examples/simple_four_bar/FourBar.sdf
+++ b/examples/simple_four_bar/FourBar.sdf
@@ -14,7 +14,6 @@
         </inertia>
       </inertial>
       <visual name="base">
-        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <cylinder>
             <length>4</length>
@@ -141,7 +140,6 @@
     <joint name="joint_3" type="revolute">
       <parent>base_link</parent>
       <child>link_3</child>
-      <pose>0 0 0 0 0 0</pose>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>

--- a/examples/simple_gripper/simple_gripper.sdf
+++ b/examples/simple_gripper/simple_gripper.sdf
@@ -19,10 +19,8 @@
     <joint name="weld_base" type="fixed">
       <parent>world</parent>
       <child>y_translate_link</child>
-      <pose>0 0 0 0 0 0</pose>
     </joint>
     <link name="y_translate_link">
-      <pose frame="">0 0 0 0 -0 0</pose>
       <inertial>
         <mass>0.0001</mass>
         <inertia>
@@ -33,13 +31,11 @@
           <iyz>0</iyz>
           <izz>0.0001</izz>
         </inertia>
-        <pose frame="">0 0 0 0 -0 0</pose>
       </inertial>
     </link>
     <joint name="translate_joint" type="prismatic">
       <parent>y_translate_link</parent>
       <child>body</child>
-      <pose frame="">0 0 0 0 -0 0</pose>
       <axis>
         <xyz>0 0 1</xyz>
         <use_parent_model_frame>1</use_parent_model_frame>
@@ -51,7 +47,7 @@
       </axis>
     </joint>
     <link name="body">
-      <pose frame="">0 -0.049133 0 0 -0 0</pose>
+      <pose>0 -0.049133 0 0 0 0</pose>
       <inertial>
         <mass>0.988882</mass>
         <inertia>
@@ -62,10 +58,8 @@
           <iyz>0</iyz>
           <izz>0.164814</izz>
         </inertia>
-        <pose frame="">0 0 0 0 -0 0</pose>
       </inertial>
       <visual name="visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <box>
             <size>0.146 0.0725 0.049521</size>
@@ -74,7 +68,7 @@
       </visual>
     </link>
     <link name="left_finger">
-      <pose frame="">0.040 0.029 0 0 -0 0</pose>
+      <pose>0.040 0.029 0 0 0 0</pose>
       <inertial>
         <mass>0.05</mass>
         <inertia>
@@ -85,10 +79,8 @@
           <iyz>0</iyz>
           <izz>0.16</izz>
         </inertia>
-        <pose frame="">0 0 0 0 -0 0</pose>
       </inertial>
       <visual name="visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <box>
             <size>0.007 0.081 0.028</size>
@@ -97,7 +89,7 @@
       </visual>
     </link>
     <link name="right_finger">
-      <pose frame="">0.047 0.029 0 0 0 0</pose>
+      <pose>0.047 0.029 0 0 0 0</pose>
       <inertial>
         <mass>0.05</mass>
         <inertia>
@@ -108,10 +100,8 @@
           <iyz>0</iyz>
           <izz>0.16</izz>
         </inertia>
-        <pose frame="">0 0 0 0 -0 0</pose>
       </inertial>
       <visual name="visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <box>
             <size>0.007 0.081 0.028</size>
@@ -122,12 +112,10 @@
     <joint name="weld_right_finger" type="fixed">
       <parent>body</parent>
       <child>right_finger</child>
-      <pose>0 0 0 0 0 0</pose>
     </joint>
     <joint name="finger_sliding_joint" type="prismatic">
       <parent>right_finger</parent>
       <child>left_finger</child>
-      <pose frame="">0 0 0 0 -0 0</pose>
       <axis>
         <xyz>1 0 0</xyz>
         <use_parent_model_frame>0</use_parent_model_frame>

--- a/examples/simple_gripper/simple_mug.sdf
+++ b/examples/simple_gripper/simple_mug.sdf
@@ -2,9 +2,8 @@
 <sdf version="1.6">
   <model name="simple_mug">
     <link name="main_body">
-      <pose frame="">0 0 0 0 -0 0</pose>
       <inertial>
-        <pose frame="">0.01 0 0.05 0 -0 0</pose>
+        <pose>0.01 0 0.05 0 0 0</pose>
         <mass>0.094</mass>
         <inertia>
           <ixx>0.000156</ixx>
@@ -16,7 +15,7 @@
         </inertia>
       </inertial>
       <collision name="main_body_collision">
-        <pose frame="">0 0 0.05 0 -0 0</pose>
+        <pose>0 0 0.05 0 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.1</length>
@@ -33,7 +32,7 @@
         </surface>
       </collision>
       <visual name="main_body_visual">
-        <pose frame="">0 0 0.05 0 -0 0</pose>
+        <pose>0 0 0.05 0 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.1</length>
@@ -42,7 +41,7 @@
         </geometry>
       </visual>
       <visual name="mug_handle_visual">
-        <pose frame="">0.055 0 0.05 0 -0 0</pose>
+        <pose>0.055 0 0.05 0 0 0</pose>
         <geometry>
           <box>
             <size>0.03 0.02 0.08</size>

--- a/manipulation/models/allegro_hand_description/sdf/allegro_hand_description_left.sdf
+++ b/manipulation/models/allegro_hand_description/sdf/allegro_hand_description_left.sdf
@@ -28,9 +28,7 @@
 <sdf version="1.6">
   <model name="allegro_hand_left">
     <link name="hand_root">
-      <pose frame="">0 0 0 0 -0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.4154</mass>
         <inertia>
           <ixx>    2.089e-03</ixx>
@@ -42,7 +40,7 @@
         </inertia>
       </inertial>
       <collision name="hand_root_fixed_joint_lump__palm_link_collision">
-        <pose frame="">-0.0093 0 0.0475 0 -0 0</pose>
+        <pose>-0.0093 0 0.0475 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0408 0.113 0.095</size>
@@ -50,7 +48,7 @@
         </geometry>
       </collision>
       <visual name="hand_root_fixed_joint_lump__palm_link_visual">
-        <pose frame="">0 0 0.095 -1.5708 0 0</pose>
+        <pose>0 0 0.095 -1.5708 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -60,9 +58,8 @@
       </visual>
     </link>
     <link name="link_8">
-      <pose frame="">0 0.0435 0.093458 -0.087267 0 0</pose>
+      <pose>0 0.0435 0.093458 -0.087267 0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.0119</mass>
         <inertia>
           <ixx>   1.954e-06</ixx>
@@ -74,7 +71,7 @@
         </inertia>
       </inertial>
       <collision name="link_8_collision">
-        <pose frame="">0 0 0.0082 0 -0 0</pose>
+        <pose>0 0 0.0082 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0196 0.0275 0.0164</size>
@@ -82,7 +79,6 @@
         </geometry>
       </collision>
       <visual name="link_8_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -108,9 +104,8 @@
       </axis>
     </joint>
     <link name="link_9">
-      <pose frame="">0 0.044929 0.109796 -0.087267 0 0</pose>
+      <pose>0 0.044929 0.109796 -0.087267 0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.065</mass>
         <inertia>
           <ixx>  7.192e-05</ixx>
@@ -122,7 +117,7 @@
         </inertia>
       </inertial>
       <collision name="link_9_collision">
-        <pose frame="">0 0 0.027 0 -0 0</pose>
+        <pose>0 0 0.027 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0196 0.0275 0.054</size>
@@ -130,7 +125,6 @@
         </geometry>
       </collision>
       <visual name="link_9_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -156,9 +150,8 @@
       </axis>
     </joint>
     <link name="link_10">
-      <pose frame="">0 0.049636 0.16359 -0.087267 0 0</pose>
+      <pose>0 0.049636 0.16359 -0.087267 0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.0355</mass>
         <inertia>
           <ixx>     3.169e-05</ixx>
@@ -170,7 +163,7 @@
         </inertia>
       </inertial>
       <collision name="link_10_collision">
-        <pose frame="">0 0 0.0192 0 -0 0</pose>
+        <pose>0 0 0.0192 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0196 0.0275 0.0384</size>
@@ -178,7 +171,6 @@
         </geometry>
       </collision>
       <visual name="link_10_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -204,9 +196,8 @@
       </axis>
     </joint>
     <link name="link_11">
-      <pose frame="">0 0.052983 0.201844 -0.087267 0 0</pose>
+      <pose>0 0.052983 0.201844 -0.087267 0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.0264</mass>
         <inertia>
           <ixx>   1.263e-05</ixx>
@@ -218,7 +209,7 @@
         </inertia>
       </inertial>
       <collision name="link_11_collision">
-        <pose frame="">0 0 0.01335 0 -0 0</pose>
+        <pose>0 0 0.01335 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0196 0.0275 0.0267</size>
@@ -226,7 +217,7 @@
         </geometry>
       </collision>
       <collision name="link_11_tip_collision_1">
-        <pose frame="">0 0 0.0267 0 -0 0</pose>
+        <pose>0 0 0.0267 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.012</radius>
@@ -234,7 +225,6 @@
         </geometry>
       </collision>
       <visual name="link_11_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -243,7 +233,7 @@
         </geometry>
       </visual>
       <visual name="link_11_tip_visual_1">
-        <pose frame="">0 0 0.0267 0 -0 0</pose>
+        <pose>0 0 0.0267 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -269,9 +259,8 @@
       </axis>
     </joint>
     <link name="link_12">
-      <pose frame="">-0.0182 -0.019333 0.049013 -3.14159 -1.48353 -1.5708</pose>
+      <pose>-0.0182 -0.019333 0.049013 -3.14159 -1.48353 -1.5708</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.0176</mass>
         <inertia>
           <ixx> 0.8139e-05</ixx>
@@ -283,7 +272,7 @@
         </inertia>
       </inertial>
       <collision name="link_12_collision">
-        <pose frame="">-0.0179 0.009 0.0145 0 -0 0</pose>
+        <pose>-0.0179 0.009 0.0145 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0358 0.034 0.0455</size>
@@ -291,7 +280,7 @@
         </geometry>
       </collision>
       <visual name="link_12_visual">
-        <pose frame="">0 0 0 3.14159 -0 0</pose>
+        <pose>0 0 0 3.14159 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -317,9 +306,8 @@
       </axis>
     </joint>
     <link name="link_13">
-      <pose frame="">-0.0132 -0.056728 0.018638 -3.14159 -1.48353 -1.5708</pose>
+      <pose>-0.0132 -0.056728 0.018638 -3.14159 -1.48353 -1.5708</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.0119</mass>
         <inertia>
           <ixx>   1.926e-06</ixx>
@@ -332,7 +320,7 @@
       </inertial>
       <!--
       <collision name='link_13_collision'>
-        <pose frame=''>0 0 0.00885 0 -0 0</pose>
+        <pose>0 0 0.00885 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0196 0.0275 0.0177</size>
@@ -341,7 +329,6 @@
       </collision>
     -->
       <visual name="link_13_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -367,9 +354,8 @@
       </axis>
     </joint>
     <link name="link_14">
-      <pose frame="">-0.0132 -0.074361 0.017096 -3.14159 -1.48353 -1.5708</pose>
+      <pose>-0.0132 -0.074361 0.017096 -3.14159 -1.48353 -1.5708</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.038</mass>
         <inertia>
           <ixx>  3.670e-05</ixx>
@@ -381,7 +367,7 @@
         </inertia>
       </inertial>
       <collision name="link_14_collision">
-        <pose frame="">0 0 0.0257 0 -0 0</pose>
+        <pose>0 0 0.0257 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0196 0.0275 0.0514</size>
@@ -389,7 +375,6 @@
         </geometry>
       </collision>
       <visual name="link_14_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -415,9 +400,9 @@
       </axis>
     </joint>
     <link name="link_15">
-      <pose frame="">-0.0132 -0.125565 0.012616 -3.14159 -1.48353 -1.5708</pose>
+      <pose>-0.0132 -0.125565 0.012616 -3.14159 -1.48353 -1.5708</pose>
       <inertial>
-        <pose frame="">0 0 0.012781 0 -0 0</pose>
+        <pose>0 0 0.012781 0 0 0</pose>
         <mass>0.0556</mass>
         <inertia>
           <ixx>  7.054e-05</ixx>
@@ -429,7 +414,7 @@
         </inertia>
       </inertial>
       <collision name="link_15_collision">
-        <pose frame="">0 0 0.02115 0 -0 0</pose>
+        <pose>0 0 0.02115 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0196 0.0275 0.0423</size>
@@ -437,7 +422,7 @@
         </geometry>
       </collision>
       <collision name="link_15_tip_collision_1">
-        <pose frame="">0 0 0.0423 0 -0 0</pose>
+        <pose>0 0 0.0423 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.012</radius>
@@ -445,7 +430,6 @@
         </geometry>
       </collision>
       <visual name="link_15_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -454,7 +438,7 @@
         </geometry>
       </visual>
       <visual name="link_15_tip_visual_1">
-        <pose frame="">0 0 0.0423 0 -0 0</pose>
+        <pose>0 0 0.0423 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -480,9 +464,8 @@
       </axis>
     </joint>
     <link name="link_4">
-      <pose frame="">0 0 0.0957 0 -0 0</pose>
+      <pose>0 0 0.0957 0 0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.0119</mass>
         <inertia>
           <ixx>   1.954e-06</ixx>
@@ -494,7 +477,7 @@
         </inertia>
       </inertial>
       <collision name="link_4_collision">
-        <pose frame="">0 0 0.0082 0 -0 0</pose>
+        <pose>0 0 0.0082 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0196 0.0275 0.0164</size>
@@ -502,7 +485,6 @@
         </geometry>
       </collision>
       <visual name="link_4_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -528,9 +510,8 @@
       </axis>
     </joint>
     <link name="link_5">
-      <pose frame="">0 0 0.1121 0 -0 0</pose>
+      <pose>0 0 0.1121 0 0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.065</mass>
         <inertia>
           <ixx>  7.192e-05</ixx>
@@ -542,7 +523,7 @@
         </inertia>
       </inertial>
       <collision name="link_5_collision">
-        <pose frame="">0 0 0.027 0 -0 0</pose>
+        <pose>0 0 0.027 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0196 0.0275 0.054</size>
@@ -550,7 +531,6 @@
         </geometry>
       </collision>
       <visual name="link_5_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -576,9 +556,8 @@
       </axis>
     </joint>
     <link name="link_6">
-      <pose frame="">0 0 0.1661 0 -0 0</pose>
+      <pose>0 0 0.1661 0 0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.0355</mass>
         <inertia>
           <ixx>     3.169e-05</ixx>
@@ -590,7 +569,7 @@
         </inertia>
       </inertial>
       <collision name="link_6_collision">
-        <pose frame="">0 0 0.0192 0 -0 0</pose>
+        <pose>0 0 0.0192 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0196 0.0275 0.0384</size>
@@ -598,7 +577,6 @@
         </geometry>
       </collision>
       <visual name="link_6_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -624,9 +602,8 @@
       </axis>
     </joint>
     <link name="link_7">
-      <pose frame="">0 0 0.2045 0 -0 0</pose>
+      <pose>0 0 0.2045 0 0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.0264</mass>
         <inertia>
           <ixx>   1.263e-05</ixx>
@@ -638,7 +615,7 @@
         </inertia>
       </inertial>
       <collision name="link_7_collision">
-        <pose frame="">0 0 0.01335 0 -0 0</pose>
+        <pose>0 0 0.01335 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0196 0.0275 0.0267</size>
@@ -646,7 +623,7 @@
         </geometry>
       </collision>
       <collision name="link_7_tip_collision_1">
-        <pose frame="">0 0 0.0267 0 -0 0</pose>
+        <pose>0 0 0.0267 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.012</radius>
@@ -654,7 +631,6 @@
         </geometry>
       </collision>
       <visual name="link_7_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -663,7 +639,7 @@
         </geometry>
       </visual>
       <visual name="link_7_tip_visual_1">
-        <pose frame="">0 0 0.0267 0 -0 0</pose>
+        <pose>0 0 0.0267 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -689,9 +665,8 @@
       </axis>
     </joint>
     <link name="link_0">
-      <pose frame="">0 -0.0435 0.093458 0.087267 -0 0</pose>
+      <pose>0 -0.0435 0.093458 0.087267 0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.0119</mass>
         <inertia>
           <ixx>   1.954e-06</ixx>
@@ -703,7 +678,7 @@
         </inertia>
       </inertial>
       <collision name="link_0_collision">
-        <pose frame="">0 0 0.0082 0 -0 0</pose>
+        <pose>0 0 0.0082 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0196 0.0275 0.0164</size>
@@ -711,7 +686,6 @@
         </geometry>
       </collision>
       <visual name="link_0_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -737,9 +711,8 @@
       </axis>
     </joint>
     <link name="link_1">
-      <pose frame="">0 -0.044929 0.109796 0.087267 -0 0</pose>
+      <pose>0 -0.044929 0.109796 0.087267 0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.065</mass>
         <inertia>
           <ixx>  7.192e-05</ixx>
@@ -751,7 +724,7 @@
         </inertia>
       </inertial>
       <collision name="link_1_collision">
-        <pose frame="">0 0 0.027 0 -0 0</pose>
+        <pose>0 0 0.027 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0196 0.0275 0.054</size>
@@ -759,7 +732,6 @@
         </geometry>
       </collision>
       <visual name="link_1_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -785,9 +757,8 @@
       </axis>
     </joint>
     <link name="link_2">
-      <pose frame="">0 -0.049636 0.16359 0.087267 -0 0</pose>
+      <pose>0 -0.049636 0.16359 0.087267 0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.0355</mass>
         <inertia>
           <ixx>     3.169e-05</ixx>
@@ -799,7 +770,7 @@
         </inertia>
       </inertial>
       <collision name="link_2_collision">
-        <pose frame="">0 0 0.0192 0 -0 0</pose>
+        <pose>0 0 0.0192 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0196 0.0275 0.0384</size>
@@ -807,7 +778,6 @@
         </geometry>
       </collision>
       <visual name="link_2_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -833,9 +803,8 @@
       </axis>
     </joint>
     <link name="link_3">
-      <pose frame="">0 -0.052983 0.201844 0.087267 -0 0</pose>
+      <pose>0 -0.052983 0.201844 0.087267 0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.0264</mass>
         <inertia>
           <ixx>   1.263e-05</ixx>
@@ -847,7 +816,7 @@
         </inertia>
       </inertial>
       <collision name="link_3_collision">
-        <pose frame="">0 0 0.01335 0 -0 0</pose>
+        <pose>0 0 0.01335 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0196 0.0275 0.0267</size>
@@ -855,7 +824,7 @@
         </geometry>
       </collision>
       <collision name="link_3_tip_collision_1">
-        <pose frame="">0 0 0.0267 0 -0 0</pose>
+        <pose>0 0 0.0267 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.012</radius>
@@ -863,7 +832,6 @@
         </geometry>
       </collision>
       <visual name="link_3_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -872,7 +840,7 @@
         </geometry>
       </visual>
       <visual name="link_3_tip_visual_1">
-        <pose frame="">0 0 0.0267 0 -0 0</pose>
+        <pose>0 0 0.0267 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>

--- a/manipulation/models/allegro_hand_description/sdf/allegro_hand_description_right.sdf
+++ b/manipulation/models/allegro_hand_description/sdf/allegro_hand_description_right.sdf
@@ -28,9 +28,7 @@
 <sdf version="1.6">
   <model name="allegro_hand_right">
     <link name="hand_root">
-      <pose frame="">0 0 0 0 -0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.4154</mass>
         <inertia>
           <ixx>    2.089e-03</ixx>
@@ -42,7 +40,7 @@
         </inertia>
       </inertial>
       <collision name="hand_root_fixed_joint_lump__palm_link_collision">
-        <pose frame="">-0.0093 0 0.0475 0 -0 0</pose>
+        <pose>-0.0093 0 0.0475 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0408 0.113 0.095</size>
@@ -50,7 +48,7 @@
         </geometry>
       </collision>
       <visual name="hand_root_fixed_joint_lump__palm_link_visual">
-        <pose frame="">0 0 0.095 0 -0 0</pose>
+        <pose>0 0 0.095 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -60,9 +58,8 @@
       </visual>
     </link>
     <link name="link_0">
-      <pose frame="">0 0.0435 0.093458 -0.087267 0 0</pose>
+      <pose>0 0.0435 0.093458 -0.087267 0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.0119</mass>
         <inertia>
           <ixx>   1.954e-06</ixx>
@@ -74,7 +71,7 @@
         </inertia>
       </inertial>
       <collision name="link_0_collision">
-        <pose frame="">0 0 0.0082 0 -0 0</pose>
+        <pose>0 0 0.0082 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0196 0.0275 0.0164</size>
@@ -82,7 +79,6 @@
         </geometry>
       </collision>
       <visual name="link_0_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -108,9 +104,8 @@
       </axis>
     </joint>
     <link name="link_1">
-      <pose frame="">0 0.044929 0.109796 -0.087267 0 0</pose>
+      <pose>0 0.044929 0.109796 -0.087267 0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.065</mass>
         <inertia>
           <ixx>  7.192e-05</ixx>
@@ -122,7 +117,7 @@
         </inertia>
       </inertial>
       <collision name="link_1_collision">
-        <pose frame="">0 0 0.027 0 -0 0</pose>
+        <pose>0 0 0.027 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0196 0.0275 0.054</size>
@@ -130,7 +125,6 @@
         </geometry>
       </collision>
       <visual name="link_1_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -156,9 +150,8 @@
       </axis>
     </joint>
     <link name="link_2">
-      <pose frame="">0 0.049636 0.16359 -0.087267 0 0</pose>
+      <pose>0 0.049636 0.16359 -0.087267 0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.0355</mass>
         <inertia>
           <ixx>     3.169e-05</ixx>
@@ -170,7 +163,7 @@
         </inertia>
       </inertial>
       <collision name="link_2_collision">
-        <pose frame="">0 0 0.0192 0 -0 0</pose>
+        <pose>0 0 0.0192 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0196 0.0275 0.0384</size>
@@ -178,7 +171,6 @@
         </geometry>
       </collision>
       <visual name="link_2_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -204,9 +196,8 @@
       </axis>
     </joint>
     <link name="link_3">
-      <pose frame="">0 0.052983 0.201844 -0.087267 0 0</pose>
+      <pose>0 0.052983 0.201844 -0.087267 0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.0264</mass>
         <inertia>
           <ixx>   1.263e-05</ixx>
@@ -218,7 +209,7 @@
         </inertia>
       </inertial>
       <collision name="link_3_collision">
-        <pose frame="">0 0 0.01335 0 -0 0</pose>
+        <pose>0 0 0.01335 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0196 0.0275 0.0267</size>
@@ -226,7 +217,7 @@
         </geometry>
       </collision>
       <collision name="link_3_tip_collision_1">
-        <pose frame="">0 0 0.0267 0 -0 0</pose>
+        <pose>0 0 0.0267 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.012</radius>
@@ -234,7 +225,6 @@
         </geometry>
       </collision>
       <visual name="link_3_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -243,7 +233,7 @@
         </geometry>
       </visual>
       <visual name="link_3_tip_visual_1">
-        <pose frame="">0 0 0.0267 0 -0 0</pose>
+        <pose>0 0 0.0267 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -269,9 +259,8 @@
       </axis>
     </joint>
     <link name="link_12">
-      <pose frame="">-0.0182 0.019333 0.049013 3.14159 -1.48353 1.5708</pose>
+      <pose>-0.0182 0.019333 0.049013 3.14159 -1.48353 1.5708</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.0176</mass>
         <inertia>
           <ixx> 0.8139e-05</ixx>
@@ -283,7 +272,7 @@
         </inertia>
       </inertial>
       <collision name="link_12_collision">
-        <pose frame="">-0.0179 0.009 0.0145 0 -0 0</pose>
+        <pose>-0.0179 0.009 0.0145 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0358 0.034 0.0455</size>
@@ -291,7 +280,6 @@
         </geometry>
       </collision>
       <visual name="link_12_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -317,9 +305,8 @@
       </axis>
     </joint>
     <link name="link_13">
-      <pose frame="">-0.0132 0.056728 0.018638 3.14159 -1.48353 1.5708</pose>
+      <pose>-0.0132 0.056728 0.018638 3.14159 -1.48353 1.5708</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.0119</mass>
         <inertia>
           <ixx>   1.926e-06</ixx>
@@ -332,7 +319,7 @@
       </inertial>
       <!--
       <collision name='link_13_collision'>
-        <pose frame=''>0 0 0.00885 0 -0 0</pose>
+        <pose>0 0 0.00885 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0196 0.0275 0.0177</size>
@@ -341,7 +328,6 @@
       </collision>  
     -->
       <visual name="link_13_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -367,9 +353,8 @@
       </axis>
     </joint>
     <link name="link_14">
-      <pose frame="">-0.0132 0.074361 0.017096 3.14159 -1.48353 1.5708</pose>
+      <pose>-0.0132 0.074361 0.017096 3.14159 -1.48353 1.5708</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.038</mass>
         <inertia>
           <ixx>  3.670e-05</ixx>
@@ -381,7 +366,7 @@
         </inertia>
       </inertial>
       <collision name="link_14_collision">
-        <pose frame="">0 0 0.0257 0 -0 0</pose>
+        <pose>0 0 0.0257 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0196 0.0275 0.0514</size>
@@ -389,7 +374,6 @@
         </geometry>
       </collision>
       <visual name="link_14_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -415,9 +399,9 @@
       </axis>
     </joint>
     <link name="link_15">
-      <pose frame="">-0.0132 0.125565 0.012616 3.14159 -1.48353 1.5708</pose>
+      <pose>-0.0132 0.125565 0.012616 3.14159 -1.48353 1.5708</pose>
       <inertial>
-        <pose frame="">0 0 0.012781 0 -0 0</pose>
+        <pose>0 0 0.012781 0 0 0</pose>
         <mass>0.0556</mass>
         <inertia>
           <ixx>  7.054e-05</ixx>
@@ -429,7 +413,7 @@
         </inertia>
       </inertial>
       <collision name="link_15_collision">
-        <pose frame="">0 0 0.02115 0 -0 0</pose>
+        <pose>0 0 0.02115 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0196 0.0275 0.0423</size>
@@ -437,7 +421,7 @@
         </geometry>
       </collision>
       <collision name="link_15_tip_collision_1">
-        <pose frame="">0 0 0.0423 0 -0 0</pose>
+        <pose>0 0 0.0423 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.012</radius>
@@ -445,7 +429,6 @@
         </geometry>
       </collision>
       <visual name="link_15_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -454,7 +437,7 @@
         </geometry>
       </visual>
       <visual name="link_15_tip_visual_1">
-        <pose frame="">0 0 0.0423 0 -0 0</pose>
+        <pose>0 0 0.0423 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -480,9 +463,8 @@
       </axis>
     </joint>
     <link name="link_4">
-      <pose frame="">0 0 0.0957 0 -0 0</pose>
+      <pose>0 0 0.0957 0 0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.0119</mass>
         <inertia>
           <ixx>   1.954e-06</ixx>
@@ -494,7 +476,7 @@
         </inertia>
       </inertial>
       <collision name="link_4_collision">
-        <pose frame="">0 0 0.0082 0 -0 0</pose>
+        <pose>0 0 0.0082 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0196 0.0275 0.0164</size>
@@ -502,7 +484,6 @@
         </geometry>
       </collision>
       <visual name="link_4_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -528,9 +509,8 @@
       </axis>
     </joint>
     <link name="link_5">
-      <pose frame="">0 0 0.1121 0 -0 0</pose>
+      <pose>0 0 0.1121 0 0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.065</mass>
         <inertia>
           <ixx>  7.192e-05</ixx>
@@ -542,7 +522,7 @@
         </inertia>
       </inertial>
       <collision name="link_5_collision">
-        <pose frame="">0 0 0.027 0 -0 0</pose>
+        <pose>0 0 0.027 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0196 0.0275 0.054</size>
@@ -550,7 +530,6 @@
         </geometry>
       </collision>
       <visual name="link_5_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -576,9 +555,8 @@
       </axis>
     </joint>
     <link name="link_6">
-      <pose frame="">0 0 0.1661 0 -0 0</pose>
+      <pose>0 0 0.1661 0 0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.0355</mass>
         <inertia>
           <ixx>     3.169e-05</ixx>
@@ -590,7 +568,7 @@
         </inertia>
       </inertial>
       <collision name="link_6_collision">
-        <pose frame="">0 0 0.0192 0 -0 0</pose>
+        <pose>0 0 0.0192 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0196 0.0275 0.0384</size>
@@ -598,7 +576,6 @@
         </geometry>
       </collision>
       <visual name="link_6_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -624,9 +601,8 @@
       </axis>
     </joint>
     <link name="link_7">
-      <pose frame="">0 0 0.2045 0 -0 0</pose>
+      <pose>0 0 0.2045 0 0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.0264</mass>
         <inertia>
           <ixx>   1.263e-05</ixx>
@@ -638,7 +614,7 @@
         </inertia>
       </inertial>
       <collision name="link_7_collision">
-        <pose frame="">0 0 0.01335 0 -0 0</pose>
+        <pose>0 0 0.01335 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0196 0.0275 0.0267</size>
@@ -646,7 +622,7 @@
         </geometry>
       </collision>
       <collision name="link_7_tip_collision_1">
-        <pose frame="">0 0 0.0267 0 -0 0</pose>
+        <pose>0 0 0.0267 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.012</radius>
@@ -654,7 +630,6 @@
         </geometry>
       </collision>
       <visual name="link_7_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -663,7 +638,7 @@
         </geometry>
       </visual>
       <visual name="link_7_tip_visual_1">
-        <pose frame="">0 0 0.0267 0 -0 0</pose>
+        <pose>0 0 0.0267 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -689,9 +664,8 @@
       </axis>
     </joint>
     <link name="link_8">
-      <pose frame="">0 -0.0435 0.093458 0.087267 -0 0</pose>
+      <pose>0 -0.0435 0.093458 0.087267 0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.0119</mass>
         <inertia>
           <ixx>   1.954e-06</ixx>
@@ -703,7 +677,7 @@
         </inertia>
       </inertial>
       <collision name="link_8_collision">
-        <pose frame="">0 0 0.0082 0 -0 0</pose>
+        <pose>0 0 0.0082 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0196 0.0275 0.0164</size>
@@ -711,7 +685,6 @@
         </geometry>
       </collision>
       <visual name="link_8_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -737,9 +710,8 @@
       </axis>
     </joint>
     <link name="link_9">
-      <pose frame="">0 -0.044929 0.109796 0.087267 -0 0</pose>
+      <pose>0 -0.044929 0.109796 0.087267 0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.065</mass>
         <inertia>
           <ixx>  7.192e-05</ixx>
@@ -751,7 +723,7 @@
         </inertia>
       </inertial>
       <collision name="link_9_collision">
-        <pose frame="">0 0 0.027 0 -0 0</pose>
+        <pose>0 0 0.027 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0196 0.0275 0.054</size>
@@ -759,7 +731,6 @@
         </geometry>
       </collision>
       <visual name="link_9_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -785,9 +756,8 @@
       </axis>
     </joint>
     <link name="link_10">
-      <pose frame="">0 -0.049636 0.16359 0.087267 -0 0</pose>
+      <pose>0 -0.049636 0.16359 0.087267 0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.0355</mass>
         <inertia>
           <ixx>     3.169e-05</ixx>
@@ -799,7 +769,7 @@
         </inertia>
       </inertial>
       <collision name="link_10_collision">
-        <pose frame="">0 0 0.0192 0 -0 0</pose>
+        <pose>0 0 0.0192 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0196 0.0275 0.0384</size>
@@ -807,7 +777,6 @@
         </geometry>
       </collision>
       <visual name="link_10_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -833,9 +802,8 @@
       </axis>
     </joint>
     <link name="link_11">
-      <pose frame="">0 -0.052983 0.201844 0.087267 -0 0</pose>
+      <pose>0 -0.052983 0.201844 0.087267 0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>0.0264</mass>
         <inertia>
           <ixx>   1.263e-05</ixx>
@@ -847,7 +815,7 @@
         </inertia>
       </inertial>
       <collision name="link_11_collision">
-        <pose frame="">0 0 0.01335 0 -0 0</pose>
+        <pose>0 0 0.01335 0 0 0</pose>
         <geometry>
           <box>
             <size>0.0196 0.0275 0.0267</size>
@@ -855,7 +823,7 @@
         </geometry>
       </collision>
       <collision name="link_11_tip_collision_1">
-        <pose frame="">0 0 0.0267 0 -0 0</pose>
+        <pose>0 0 0.0267 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.012</radius>
@@ -863,7 +831,6 @@
         </geometry>
       </collision>
       <visual name="link_11_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -872,7 +839,7 @@
         </geometry>
       </visual>
       <visual name="link_11_tip_visual_1">
-        <pose frame="">0 0 0.0267 0 -0 0</pose>
+        <pose>0 0 0.0267 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>

--- a/manipulation/models/iiwa_description/iiwa7/iiwa7_no_collision.sdf
+++ b/manipulation/models/iiwa_description/iiwa7/iiwa7_no_collision.sdf
@@ -2,9 +2,8 @@
 <sdf version="1.6">
   <model name="iiwa7">
     <link name="iiwa_link_0">
-      <pose frame="">0 0 0 0 -0 0</pose>
       <inertial>
-        <pose frame="">-0.013 0 0.07 0 -0 0</pose>
+        <pose>-0.013 0 0.07 0 0 0</pose>
         <mass>3.863</mass>
         <inertia>
           <ixx>0.0141</ixx>
@@ -16,7 +15,6 @@
         </inertia>
       </inertial>
       <visual name="iiwa_link_0_visual">
-        <pose frame="">0 0 0 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -32,9 +30,9 @@
       <self_collide>0</self_collide>
     </link>
     <link name="iiwa_link_1">
-      <pose frame="">0 0 0.1575 0 -0 0</pose>
+      <pose>0 0 0.1575 0 0 0</pose>
       <inertial>
-        <pose frame="">0 -0.0347 0.113 0 -0 0</pose>
+        <pose>0 -0.0347 0.113 0 0 0</pose>
         <mass>2.7025</mass>
         <inertia>
           <ixx>0.0171</ixx>
@@ -46,7 +44,6 @@
         </inertia>
       </inertial>
       <visual name="iiwa_link_1_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -82,9 +79,9 @@
       </axis>
     </joint>
     <link name="iiwa_link_2">
-      <pose frame="">0 0 0.3405 1.5708 -0 -3.14159</pose>
+      <pose>0 0 0.3405 1.5708 0 -3.14159</pose>
       <inertial>
-        <pose frame="">0.000 0.0668 0.0344 0 -0 0</pose>
+        <pose>0.000 0.0668 0.0344 0 0 0</pose>
         <mass>2.7258</mass>
         <inertia>
           <ixx>0.0170</ixx>
@@ -96,7 +93,6 @@
         </inertia>
       </inertial>
       <visual name="iiwa_link_2_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -132,9 +128,9 @@
       </axis>
     </joint>
     <link name="iiwa_link_3">
-      <pose frame="">0 -0 0.5245 0 0 0</pose>
+      <pose>0 0 0.5245 0 0 0</pose>
       <inertial>
-        <pose frame="">0 0.0296 0.1265 0 -0 0</pose>
+        <pose>0 0.0296 0.1265 0 0 0</pose>
         <mass>3.175</mass>
         <inertia>
           <ixx>0.025</ixx>
@@ -146,7 +142,6 @@
         </inertia>
       </inertial>
       <visual name="iiwa_link_3_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -182,9 +177,9 @@
       </axis>
     </joint>
     <link name="iiwa_link_4">
-      <pose frame="">0 -0 0.74 1.5708 0 0</pose>
+      <pose>0 0 0.74 1.5708 0 0</pose>
       <inertial>
-        <pose frame="">0 0.067 0.034 0 -0 0</pose>
+        <pose>0 0.067 0.034 0 0 0</pose>
         <mass>2.73</mass>
         <inertia>
           <ixx>0.017</ixx>
@@ -196,7 +191,6 @@
         </inertia>
       </inertial>
       <visual name="iiwa_link_4_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -232,9 +226,9 @@
       </axis>
     </joint>
     <link name="iiwa_link_5">
-      <pose frame="">0 -0 0.924 0 -0 -3.14159</pose>
+      <pose>0 0 0.924 0 0 -3.14159</pose>
       <inertial>
-        <pose frame="">0.0001 0.021 0.076 0 -0 0</pose>
+        <pose>0.0001 0.021 0.076 0 0 0</pose>
         <mass>1.69</mass>
         <inertia>
           <ixx>0.01</ixx>
@@ -246,7 +240,6 @@
         </inertia>
       </inertial>
       <visual name="iiwa_link_5_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -282,9 +275,9 @@
       </axis>
     </joint>
     <link name="iiwa_link_6">
-      <pose frame="">0 0 1.1395 1.5708 -0 -3.14159</pose>
+      <pose>0 0 1.1395 1.5708 0 -3.14159</pose>
       <inertial>
-        <pose frame="">0 0.0026 0.0005 0 -0 0</pose>
+        <pose>0 0.0026 0.0005 0 0 0</pose>
         <mass>1.8</mass>
         <inertia>
           <ixx>0.0051</ixx>
@@ -296,7 +289,7 @@
         </inertia>
       </inertial>
       <visual name="iiwa_link_6_visual">
-        <pose frame="">0 0 -0.060700 0 -0 0</pose>
+        <pose>0 0 -0.060700 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -332,9 +325,9 @@
       </axis>
     </joint>
     <link name="iiwa_link_7">
-      <pose frame="">0 0 1.22 0 0 0</pose>
+      <pose>0 0 1.22 0 0 0</pose>
       <inertial>
-        <pose frame="">0 0 0.0294 0 -0 0</pose>
+        <pose>0 0 0.0294 0 0 0</pose>
         <mass>.4</mass>
         <inertia>
           <ixx>0.0004</ixx>
@@ -346,7 +339,6 @@
         </inertia>
       </inertial>
       <visual name="iiwa_link_7_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>

--- a/manipulation/models/iiwa_description/iiwa7/iiwa7_with_box_collision.sdf
+++ b/manipulation/models/iiwa_description/iiwa7/iiwa7_with_box_collision.sdf
@@ -2,9 +2,8 @@
 <sdf version="1.6">
   <model name="iiwa7">
     <link name="iiwa_link_0">
-      <pose frame="">0 0 0 0 -0 0</pose>
       <inertial>
-        <pose frame="">-0.013 0 0.07 0 -0 0</pose>
+        <pose>-0.013 0 0.07 0 0 0</pose>
         <mass>3.863</mass>
         <inertia>
           <ixx>0.0141</ixx>
@@ -16,7 +15,6 @@
         </inertia>
       </inertial>
       <visual name="iiwa_link_0_visual">
-        <pose frame="">0 0 0 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -28,7 +26,7 @@
         </material>
       </visual>
       <collision name="iiwa_link_0_collision">
-        <pose>-0.004563 0 0.07875 0 -0 0</pose>
+        <pose>-0.004563 0 0.07875 0 0 0</pose>
         <geometry>
           <box>
             <size>0.216874 0.207874 0.1575</size>
@@ -40,9 +38,9 @@
       <self_collide>0</self_collide>
     </link>
     <link name="iiwa_link_1">
-      <pose frame="">0 0 0.1575 0 -0 0</pose>
+      <pose>0 0 0.1575 0 0 0</pose>
       <inertial>
-        <pose frame="">0 -0.0347 0.113 0 -0 0</pose>
+        <pose>0 -0.0347 0.113 0 0 0</pose>
         <mass>2.7025</mass>
         <inertia>
           <ixx>0.0171</ixx>
@@ -54,7 +52,6 @@
         </inertia>
       </inertial>
       <visual name="iiwa_link_1_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -66,7 +63,7 @@
         </material>
       </visual>
       <collision name="iiwa_link_1_collision">
-        <pose>0 -0.023301 0.127997 0 -0 0</pose>
+        <pose>0 -0.023301 0.127997 0 0 0</pose>
         <geometry>
           <box>
             <size>0.13596 0.182584 0.260995</size>
@@ -98,9 +95,9 @@
       </axis>
     </joint>
     <link name="iiwa_link_2">
-      <pose frame="">0 0 0.3405 1.5708 -0 -3.14159</pose>
+      <pose>0 0 0.3405 1.5708 0 -3.14159</pose>
       <inertial>
-        <pose frame="">0.000 0.0668 0.0344 0 -0 0</pose>
+        <pose>0.000 0.0668 0.0344 0 0 0</pose>
         <mass>2.7258</mass>
         <inertia>
           <ixx>0.0170</ixx>
@@ -112,7 +109,6 @@
         </inertia>
       </inertial>
       <visual name="iiwa_link_2_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -124,7 +120,7 @@
         </material>
       </visual>
       <collision name="iiwa_link_2_collision">
-        <pose>0 0.0580045 0.0173035 0 -0 0</pose>
+        <pose>0 0.0580045 0.0173035 0 0 0</pose>
         <geometry>
           <box>
             <size>0.135988 0.251991 0.182605</size>
@@ -156,9 +152,9 @@
       </axis>
     </joint>
     <link name="iiwa_link_3">
-      <pose frame="">0 -0 0.5245 0 0 0</pose>
+      <pose>0 0 0.5245 0 0 0</pose>
       <inertial>
-        <pose frame="">0 0.0296 0.1265 0 -0 0</pose>
+        <pose>0 0.0296 0.1265 0 0 0</pose>
         <mass>3.175</mass>
         <inertia>
           <ixx>0.025</ixx>
@@ -170,7 +166,6 @@
         </inertia>
       </inertial>
       <visual name="iiwa_link_3_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -182,7 +177,7 @@
         </material>
       </visual>
       <collision name="iiwa_link_3_collision">
-        <pose>0 0.0182965 0.11073 0 -0 0</pose>
+        <pose>0 0.0182965 0.11073 0 0 0</pose>
         <geometry>
           <box>
             <size>0.135987 0.182593 0.29346</size>
@@ -214,9 +209,9 @@
       </axis>
     </joint>
     <link name="iiwa_link_4">
-      <pose frame="">0 -0 0.74 1.5708 0 0</pose>
+      <pose>0 0 0.74 1.5708 0 0</pose>
       <inertial>
-        <pose frame="">0 0.067 0.034 0 -0 0</pose>
+        <pose>0 0.067 0.034 0 0 0</pose>
         <mass>2.73</mass>
         <inertia>
           <ixx>0.017</ixx>
@@ -228,7 +223,6 @@
         </inertia>
       </inertial>
       <visual name="iiwa_link_4_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -240,7 +234,7 @@
         </material>
       </visual>
       <collision name="iiwa_link_4_collision">
-        <pose>0 0.0580045 0.0233035 0 -0 0</pose>
+        <pose>0 0.0580045 0.0233035 0 0 0</pose>
         <geometry>
           <box>
             <size>0.135988 0.251991 0.182605</size>
@@ -272,9 +266,9 @@
       </axis>
     </joint>
     <link name="iiwa_link_5">
-      <pose frame="">0 -0 0.924 0 -0 -3.14159</pose>
+      <pose>0 0 0.924 0 0 -3.14159</pose>
       <inertial>
-        <pose frame="">0.0001 0.021 0.076 0 -0 0</pose>
+        <pose>0.0001 0.021 0.076 0 0 0</pose>
         <mass>1.69</mass>
         <inertia>
           <ixx>0.01</ixx>
@@ -286,7 +280,6 @@
         </inertia>
       </inertial>
       <visual name="iiwa_link_5_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -298,7 +291,7 @@
         </material>
       </visual>
       <collision name="iiwa_link_5_collision">
-        <pose>0 0.015546 0.102458 0 -0 0</pose>
+        <pose>0 0.015546 0.102458 0 0 0</pose>
         <geometry>
           <box>
             <size>0.135999 0.167092 0.276916</size>
@@ -330,9 +323,9 @@
       </axis>
     </joint>
     <link name="iiwa_link_6">
-      <pose frame="">0 0 1.1395 1.5708 -0 -3.14159</pose>
+      <pose>0 0 1.1395 1.5708 0 -3.14159</pose>
       <inertial>
-        <pose frame="">0 0.0026 0.0005 0 -0 0</pose>
+        <pose>0 0.0026 0.0005 0 0 0</pose>
         <mass>1.8</mass>
         <inertia>
           <ixx>0.0051</ixx>
@@ -344,7 +337,7 @@
         </inertia>
       </inertial>
       <visual name="iiwa_link_6_visual">
-        <pose frame="">0 0 -0.060700 0 -0 0</pose>
+        <pose>0 0 -0.060700 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -356,7 +349,6 @@
         </material>
       </visual>
       <collision name="iiwa_link_6_collision">
-        <pose>0 0 0 0 -0 0</pose>
         <geometry>
           <box>
             <size>0.132334 0.177387 0.137409</size>
@@ -388,9 +380,9 @@
       </axis>
     </joint>
     <link name="iiwa_link_7">
-      <pose frame="">0 0 1.22 0 0 0</pose>
+      <pose>0 0 1.22 0 0 0</pose>
       <inertial>
-        <pose frame="">0 0 0.0294 0 -0 0</pose>
+        <pose>0 0 0.0294 0 0 0</pose>
         <mass>.4</mass>
         <inertia>
           <ixx>0.0004</ixx>
@@ -402,7 +394,6 @@
         </inertia>
       </inertial>
       <visual name="iiwa_link_7_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -414,7 +405,7 @@
         </material>
       </visual>
       <collision name="iiwa_link_7_collision">
-        <pose>0 0 0.021997 0 -0 0</pose>
+        <pose>0 0 0.021997 0 0 0</pose>
         <geometry>
           <box>
             <size>0.10385 0.103885 0.045</size>

--- a/manipulation/models/iiwa_description/sdf/iiwa14_no_collision.sdf
+++ b/manipulation/models/iiwa_description/sdf/iiwa14_no_collision.sdf
@@ -10,9 +10,8 @@ Later edited by hand to:
 <sdf version="1.7">
   <model name="iiwa14">
     <link name="iiwa_link_0">
-      <pose>0 0 0 0 -0 0</pose>
       <inertial>
-        <pose>-0.1 0 0.07 0 -0 0</pose>
+        <pose>-0.1 0 0.07 0 0 0</pose>
         <mass>5</mass>
         <inertia>
           <ixx>0.05</ixx>
@@ -24,7 +23,6 @@ Later edited by hand to:
         </inertia>
       </inertial>
       <visual name="iiwa_link_0_fixed_joint_lump__iiwa_link_0_visual">
-        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -40,9 +38,9 @@ Later edited by hand to:
       <self_collide>0</self_collide>
     </link>
     <link name="iiwa_link_1">
-      <pose relative_to="iiwa_joint_1">0 0 0 0 0 0</pose>
+      <pose relative_to="iiwa_joint_1"/>
       <inertial>
-        <pose>0 -0.03 0.12 0 -0 0</pose>
+        <pose>0 -0.03 0.12 0 0 0</pose>
         <mass>5.76</mass>
         <inertia>
           <ixx>0.033</ixx>
@@ -54,7 +52,6 @@ Later edited by hand to:
         </inertia>
       </inertial>
       <visual name="iiwa_link_1_visual">
-        <pose>0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -91,9 +88,9 @@ Later edited by hand to:
     </joint>
     <!-- SDFormat 1.7 -->
     <link name="iiwa_link_2">
-      <pose relative_to="iiwa_joint_2">0 0 0 0 0 0</pose>
+      <pose relative_to="iiwa_joint_2"/>
       <inertial>
-        <pose>0.0003 0.059 0.042 0 -0 0</pose>
+        <pose>0.0003 0.059 0.042 0 0 0</pose>
         <mass>6.35</mass>
         <inertia>
           <ixx>0.0305</ixx>
@@ -105,7 +102,6 @@ Later edited by hand to:
         </inertia>
       </inertial>
       <visual name="iiwa_link_2_visual_grey">
-        <pose>0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -117,7 +113,6 @@ Later edited by hand to:
         </material>
       </visual>
       <visual name="iiwa_link_2_visual_orange">
-        <pose>0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -155,9 +150,9 @@ Later edited by hand to:
       </axis>
     </joint>
     <link name="iiwa_link_3">
-      <pose relative_to="iiwa_joint_3">0 0 0 0 0 0</pose>
+      <pose relative_to="iiwa_joint_3"/>
       <inertial>
-        <pose>0 0.03 0.13 0 -0 0</pose>
+        <pose>0 0.03 0.13 0 0 0</pose>
         <mass>3.5</mass>
         <inertia>
           <ixx>0.025</ixx>
@@ -169,7 +164,6 @@ Later edited by hand to:
         </inertia>
       </inertial>
       <visual name="iiwa_link_3_visual">
-        <pose>0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -181,7 +175,6 @@ Later edited by hand to:
         </material>
       </visual>
       <visual name="iiwa_link_3_visual_band">
-        <pose>0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -193,7 +186,6 @@ Later edited by hand to:
         </material>
       </visual>
       <visual name="iiwa_link_3_visual_kuka">
-        <pose>0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -229,9 +221,9 @@ Later edited by hand to:
       </axis>
     </joint>
     <link name="iiwa_link_4">
-      <pose relative_to="iiwa_joint_4">0 0 0 0 0 0</pose>
+      <pose relative_to="iiwa_joint_4"/>
       <inertial>
-        <pose>0 0.067 0.034 0 -0 0</pose>
+        <pose>0 0.067 0.034 0 0 0</pose>
         <mass>3.5</mass>
         <inertia>
           <ixx>0.017</ixx>
@@ -243,7 +235,6 @@ Later edited by hand to:
         </inertia>
       </inertial>
       <visual name="iiwa_link_4_visual_grey">
-        <pose>0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -255,7 +246,6 @@ Later edited by hand to:
         </material>
       </visual>
       <visual name="iiwa_link_4_visual_orange">
-        <pose>0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -291,9 +281,9 @@ Later edited by hand to:
       </axis>
     </joint>
     <link name="iiwa_link_5">
-      <pose relative_to="iiwa_joint_5">0 0 0 0 0 0</pose>
+      <pose relative_to="iiwa_joint_5"/>
       <inertial>
-        <pose>0.0001 0.021 0.076 0 -0 0</pose>
+        <pose>0.0001 0.021 0.076 0 0 0</pose>
         <mass>3.5</mass>
         <inertia>
           <ixx>0.01</ixx>
@@ -305,7 +295,6 @@ Later edited by hand to:
         </inertia>
       </inertial>
       <visual name="iiwa_link_5_visual">
-        <pose>0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -317,7 +306,6 @@ Later edited by hand to:
         </material>
       </visual>
       <visual name="iiwa_link_5_visual_band">
-        <pose>0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -329,7 +317,6 @@ Later edited by hand to:
         </material>
       </visual>
       <visual name="iiwa_link_5_visual_kuka">
-        <pose>0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -365,9 +352,9 @@ Later edited by hand to:
       </axis>
     </joint>
     <link name="iiwa_link_6">
-      <pose relative_to="iiwa_joint_6">0 0 0 0 0 0</pose>
+      <pose relative_to="iiwa_joint_6"/>
       <inertial>
-        <pose>0 0.0006 0.0004 0 -0 0</pose>
+        <pose>0 0.0006 0.0004 0 0 0</pose>
         <mass>1.8</mass>
         <inertia>
           <ixx>0.0049</ixx>
@@ -379,7 +366,6 @@ Later edited by hand to:
         </inertia>
       </inertial>
       <visual name="iiwa_link_6_visual_grey">
-        <pose>0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -391,7 +377,6 @@ Later edited by hand to:
         </material>
       </visual>
       <visual name="iiwa_link_6_visual_orange">
-        <pose>0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -427,9 +412,9 @@ Later edited by hand to:
       </axis>
     </joint>
     <link name="iiwa_link_7">
-      <pose relative_to="iiwa_joint_7">0 0 0 0 0 0</pose>
+      <pose relative_to="iiwa_joint_7"/>
       <inertial>
-        <pose>0 0 0.02 0 -0 0</pose>
+        <pose>0 0 0.02 0 0 0</pose>
         <mass>1.2</mass>
         <inertia>
           <ixx>0.001</ixx>
@@ -441,7 +426,6 @@ Later edited by hand to:
         </inertia>
       </inertial>
       <visual name="iiwa_link_7_visual">
-        <pose>0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>

--- a/manipulation/models/iiwa_description/sdf/iiwa14_polytope_collision.sdf
+++ b/manipulation/models/iiwa_description/sdf/iiwa14_polytope_collision.sdf
@@ -7,9 +7,8 @@ Later edited by hand to rename the base link and remove damping from the joints.
 <sdf version="1.6">
   <model name="iiwa14">
     <link name="iiwa_link_0">
-      <pose frame="">0 0 0 0 -0 0</pose>
       <inertial>
-        <pose frame="">-0.1 0 0.07 0 -0 0</pose>
+        <pose>-0.1 0 0.07 0 0 0</pose>
         <mass>5</mass>
         <inertia>
           <ixx>0.05</ixx>
@@ -21,7 +20,6 @@ Later edited by hand to rename the base link and remove damping from the joints.
         </inertia>
       </inertial>
       <visual name="iiwa_link_0_fixed_joint_lump__iiwa_link_0_visual">
-        <pose frame="">0 0 0 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -37,9 +35,9 @@ Later edited by hand to rename the base link and remove damping from the joints.
       <self_collide>0</self_collide>
     </link>
     <link name="iiwa_link_1">
-      <pose frame="">0 0 0.1575 0 -0 0</pose>
+      <pose>0 0 0.1575 0 0 0</pose>
       <inertial>
-        <pose frame="">0 -0.03 0.12 0 -0 0</pose>
+        <pose>0 -0.03 0.12 0 0 0</pose>
         <mass>5.76</mass>
         <inertia>
           <ixx>0.033</ixx>
@@ -51,7 +49,6 @@ Later edited by hand to rename the base link and remove damping from the joints.
         </inertia>
       </inertial>
       <visual name="iiwa_link_1_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -87,9 +84,9 @@ Later edited by hand to rename the base link and remove damping from the joints.
       </axis>
     </joint>
     <link name="iiwa_link_2">
-      <pose frame="">0 0 0.36 1.5708 -0 -3.14159</pose>
+      <pose>0 0 0.36 1.5708 0 -3.14159</pose>
       <inertial>
-        <pose frame="">0.0003 0.059 0.042 0 -0 0</pose>
+        <pose>0.0003 0.059 0.042 0 0 0</pose>
         <mass>6.35</mass>
         <inertia>
           <ixx>0.0305</ixx>
@@ -101,7 +98,6 @@ Later edited by hand to rename the base link and remove damping from the joints.
         </inertia>
       </inertial>
       <visual name="iiwa_link_2_visual_grey">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -113,7 +109,6 @@ Later edited by hand to rename the base link and remove damping from the joints.
         </material>
       </visual>
       <visual name="iiwa_link_2_visual_orange">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -149,9 +144,9 @@ Later edited by hand to rename the base link and remove damping from the joints.
       </axis>
     </joint>
     <link name="iiwa_link_3">
-      <pose frame="">0 -0 0.5645 0 0 0</pose>
+      <pose>0 0 0.5645 0 0 0</pose>
       <inertial>
-        <pose frame="">0 0.03 0.13 0 -0 0</pose>
+        <pose>0 0.03 0.13 0 0 0</pose>
         <mass>3.5</mass>
         <inertia>
           <ixx>0.025</ixx>
@@ -163,7 +158,6 @@ Later edited by hand to rename the base link and remove damping from the joints.
         </inertia>
       </inertial>
       <visual name="iiwa_link_3_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -175,7 +169,6 @@ Later edited by hand to rename the base link and remove damping from the joints.
         </material>
       </visual>
       <visual name="iiwa_link_3_visual_band">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -187,7 +180,6 @@ Later edited by hand to rename the base link and remove damping from the joints.
         </material>
       </visual>
       <visual name="iiwa_link_3_visual_kuka">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -223,9 +215,9 @@ Later edited by hand to rename the base link and remove damping from the joints.
       </axis>
     </joint>
     <link name="iiwa_link_4">
-      <pose frame="">0 -0 0.78 1.5708 0 0</pose>
+      <pose>0 0 0.78 1.5708 0 0</pose>
       <inertial>
-        <pose frame="">0 0.067 0.034 0 -0 0</pose>
+        <pose>0 0.067 0.034 0 0 0</pose>
         <mass>3.5</mass>
         <inertia>
           <ixx>0.017</ixx>
@@ -237,7 +229,6 @@ Later edited by hand to rename the base link and remove damping from the joints.
         </inertia>
       </inertial>
       <visual name="iiwa_link_4_visual_grey">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -249,7 +240,6 @@ Later edited by hand to rename the base link and remove damping from the joints.
         </material>
       </visual>
       <visual name="iiwa_link_4_visual_orange">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -285,9 +275,9 @@ Later edited by hand to rename the base link and remove damping from the joints.
       </axis>
     </joint>
     <link name="iiwa_link_5">
-      <pose frame="">0 -0 0.9645 0 -0 -3.14159</pose>
+      <pose>0 0 0.9645 0 0 -3.14159</pose>
       <inertial>
-        <pose frame="">0.0001 0.021 0.076 0 -0 0</pose>
+        <pose>0.0001 0.021 0.076 0 0 0</pose>
         <mass>3.5</mass>
         <inertia>
           <ixx>0.01</ixx>
@@ -299,7 +289,6 @@ Later edited by hand to rename the base link and remove damping from the joints.
         </inertia>
       </inertial>
       <visual name="iiwa_link_5_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -311,7 +300,6 @@ Later edited by hand to rename the base link and remove damping from the joints.
         </material>
       </visual>
       <visual name="iiwa_link_5_visual_band">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -323,7 +311,6 @@ Later edited by hand to rename the base link and remove damping from the joints.
         </material>
       </visual>
       <visual name="iiwa_link_5_visual_kuka">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -359,9 +346,9 @@ Later edited by hand to rename the base link and remove damping from the joints.
       </axis>
     </joint>
     <link name="iiwa_link_6">
-      <pose frame="">0 0 1.18 1.5708 -0 -3.14159</pose>
+      <pose>0 0 1.18 1.5708 0 -3.14159</pose>
       <inertial>
-        <pose frame="">0 0.0006 0.0004 0 -0 0</pose>
+        <pose>0 0.0006 0.0004 0 0 0</pose>
         <mass>1.8</mass>
         <inertia>
           <ixx>0.0049</ixx>
@@ -373,7 +360,6 @@ Later edited by hand to rename the base link and remove damping from the joints.
         </inertia>
       </inertial>
       <visual name="iiwa_link_6_visual_grey">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -385,7 +371,6 @@ Later edited by hand to rename the base link and remove damping from the joints.
         </material>
       </visual>
       <visual name="iiwa_link_6_visual_orange">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -421,9 +406,9 @@ Later edited by hand to rename the base link and remove damping from the joints.
       </axis>
     </joint>
     <link name="iiwa_link_7">
-      <pose frame="">0 0 1.261 0 0 0</pose>
+      <pose>0 0 1.261 0 0 0</pose>
       <inertial>
-        <pose frame="">0 0 0.02 0 -0 0</pose>
+        <pose>0 0 0.02 0 0 0</pose>
         <mass>1.2</mass>
         <inertia>
           <ixx>0.001</ixx>
@@ -435,7 +420,6 @@ Later edited by hand to rename the base link and remove damping from the joints.
         </inertia>
       </inertial>
       <collision name="iiwa_link_7_collision">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -455,7 +439,6 @@ Later edited by hand to rename the base link and remove damping from the joints.
         </surface>
       </collision>
       <visual name="iiwa_link_7_visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>

--- a/manipulation/models/wsg_50_description/sdf/schunk_wsg_50.sdf
+++ b/manipulation/models/wsg_50_description/sdf/schunk_wsg_50.sdf
@@ -2,7 +2,7 @@
 <sdf version="1.6">
   <model name="Schunk_Gripper">
     <link name="body">
-      <pose frame="">0 -0.049133 0 0 -0 0</pose>
+      <pose>0 -0.049133 0 0 0 0</pose>
       <inertial>
         <mass>0.988882</mass>
         <inertia>
@@ -13,12 +13,10 @@
           <iyz>0</iyz>
           <izz>0.164814</izz>
         </inertia>
-        <pose frame="">0 0 0 0 -0 0</pose>
       </inertial>
       <self_collide>0</self_collide>
       <kinematic>0</kinematic>
       <visual name="visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <box>
             <size>0.146 0.0725 0.049521</size>
@@ -44,7 +42,6 @@
       <collision name="collision">
         <laser_retro>0</laser_retro>
         <max_contacts>10</max_contacts>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <box>
             <size>0.146 0.0725 0.049521</size>
@@ -98,10 +95,10 @@
       </collision>
     </link>
     <frame name="body_frame">
-      <pose frame="body">0 0 0 0 0 0</pose>
+      <pose frame="body"/>
     </frame>
     <link name="left_finger">
-      <pose frame="">-0.008 0.025 0 0 -0 0</pose>
+      <pose>-0.008 0.025 0 0 0 0</pose>
       <inertial>
         <mass>0.05</mass>
         <inertia>
@@ -112,12 +109,10 @@
           <iyz>0</iyz>
           <izz>0.16</izz>
         </inertia>
-        <pose frame="">0 0 0 0 -0 0</pose>
       </inertial>
       <self_collide>0</self_collide>
       <kinematic>0</kinematic>
       <visual name="visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <box>
             <size>0.016 0.075 0.02</size>
@@ -143,7 +138,6 @@
       <collision name="collision">
         <laser_retro>0</laser_retro>
         <max_contacts>10</max_contacts>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <box>
             <size>0.016 0.075 0.02</size>
@@ -197,7 +191,7 @@
       </collision>
     </link>
     <link name="right_finger">
-      <pose frame="">0.008 0.025 0 0 -0 0</pose>
+      <pose>0.008 0.025 0 0 0 0</pose>
       <inertial>
         <mass>0.05</mass>
         <inertia>
@@ -208,12 +202,10 @@
           <iyz>0</iyz>
           <izz>0.16</izz>
         </inertia>
-        <pose frame="">0 0 0 0 -0 0</pose>
       </inertial>
       <self_collide>0</self_collide>
       <kinematic>0</kinematic>
       <visual name="visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <box>
             <size>0.016 0.075 0.02</size>
@@ -239,7 +231,6 @@
       <collision name="collision">
         <laser_retro>0</laser_retro>
         <max_contacts>10</max_contacts>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <box>
             <size>0.016 0.075 0.02</size>
@@ -295,7 +286,6 @@
     <joint name="left_finger_sliding_joint" type="prismatic">
       <parent>body</parent>
       <child>left_finger</child>
-      <pose frame="">0 0 0 0 -0 0</pose>
       <axis>
         <xyz>1 0 0</xyz>
         <use_parent_model_frame>0</use_parent_model_frame>
@@ -331,7 +321,6 @@
     <joint name="right_finger_sliding_joint" type="prismatic">
       <parent>body</parent>
       <child>right_finger</child>
-      <pose frame="">0 0 0 0 -0 0</pose>
       <axis>
         <xyz>1 0 0</xyz>
         <use_parent_model_frame>0</use_parent_model_frame>

--- a/manipulation/models/wsg_50_description/sdf/schunk_wsg_50_ball_contact.sdf
+++ b/manipulation/models/wsg_50_description/sdf/schunk_wsg_50_ball_contact.sdf
@@ -6,7 +6,7 @@
          finger, with two additional spheres forming a triangle at each finger
          tip.-->
     <link name="body">
-      <pose frame="">0 -0.049133 0 0 -0 0</pose>
+      <pose>0 -0.049133 0 0 0 0</pose>
       <inertial>
         <mass>0.988882</mass>
         <inertia>
@@ -17,12 +17,10 @@
           <iyz>0</iyz>
           <izz>0.164814</izz>
         </inertia>
-        <pose frame="">0 0 0 0 -0 0</pose>
       </inertial>
       <self_collide>0</self_collide>
       <kinematic>0</kinematic>
       <visual name="visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <box>
             <size>0.146 0.0725 0.049521</size>
@@ -48,7 +46,6 @@
       <collision name="collision">
         <laser_retro>0</laser_retro>
         <max_contacts>10</max_contacts>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <box>
             <size>0.146 0.0725 0.049521</size>
@@ -102,10 +99,10 @@
       </collision>
     </link>
     <frame name="body_frame">
-      <pose frame="body">0 0 0 0 0 0</pose>
+      <pose frame="body"/>
     </frame>
     <link name="left_finger">
-      <pose frame="">-0.008 0.029 0 0 -0 0</pose>
+      <pose>-0.008 0.029 0 0 0 0</pose>
       <inertial>
         <mass>0.05</mass>
         <inertia>
@@ -116,12 +113,10 @@
           <iyz>0</iyz>
           <izz>0.16</izz>
         </inertia>
-        <pose frame="">0 0 0 0 -0 0</pose>
       </inertial>
       <self_collide>0</self_collide>
       <kinematic>0</kinematic>
       <visual name="visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <box>
             <size>0.016 0.083 0.02</size>
@@ -147,7 +142,7 @@
       <!-- A sequence of spaced spheres the *width* of the finger from the tip
       towards the base. -->
       <collision name="collision_0">
-        <pose frame="">0 -0.0209 0 0 0 0</pose>
+        <pose>0 -0.0209 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.008</radius>
@@ -155,7 +150,7 @@
         </geometry>
       </collision>
       <collision name="collision_1">
-        <pose frame="">0 -0.0049 0 0 0 0</pose>
+        <pose>0 -0.0049 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.008</radius>
@@ -163,7 +158,7 @@
         </geometry>
       </collision>
       <collision name="collision_2">
-        <pose frame="">0 0.0112 0 0 0 0</pose>
+        <pose>0 0.0112 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.008</radius>
@@ -171,7 +166,7 @@
         </geometry>
       </collision>
       <collision name="collision_3">
-        <pose frame="">0 0.0271 0 0 0 0</pose>
+        <pose>0 0.0271 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.008</radius>
@@ -181,7 +176,7 @@
       <!-- Two more spheres that form a triangle with the tip-most sphere
            above. -->
       <collision name="collision_4">
-        <pose frame="">0.0040 0.0375 0.0060 0 0 0</pose>
+        <pose>0.0040 0.0375 0.0060 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.004</radius>
@@ -189,7 +184,7 @@
         </geometry>
       </collision>
       <collision name="collision_5">
-        <pose frame="">0.0040 0.0375 -0.0060 0 0 0</pose>
+        <pose>0.0040 0.0375 -0.0060 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.004</radius>
@@ -198,7 +193,7 @@
       </collision>
     </link>
     <link name="right_finger">
-      <pose frame="">0.008 0.029 0 0 -0 0</pose>
+      <pose>0.008 0.029 0 0 0 0</pose>
       <inertial>
         <mass>0.05</mass>
         <inertia>
@@ -209,12 +204,10 @@
           <iyz>0</iyz>
           <izz>0.16</izz>
         </inertia>
-        <pose frame="">0 0 0 0 -0 0</pose>
       </inertial>
       <self_collide>0</self_collide>
       <kinematic>0</kinematic>
       <visual name="visual">
-        <pose frame="">0 0 0 0 -0 0</pose>
         <geometry>
           <box>
             <size>0.016 0.083 0.02</size>
@@ -240,7 +233,7 @@
       <!-- A sequence of spaced spheres the *width* of the finger from the tip
       towards the base. -->
       <collision name="collision_0">
-        <pose frame="">0 -0.0209 0 0 0 0</pose>
+        <pose>0 -0.0209 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.008</radius>
@@ -248,7 +241,7 @@
         </geometry>
       </collision>
       <collision name="collision_1">
-        <pose frame="">0 -0.0049 0 0 0 0</pose>
+        <pose>0 -0.0049 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.008</radius>
@@ -256,7 +249,7 @@
         </geometry>
       </collision>
       <collision name="collision_2">
-        <pose frame="">0 0.0112 0 0 0 0</pose>
+        <pose>0 0.0112 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.008</radius>
@@ -264,7 +257,7 @@
         </geometry>
       </collision>
       <collision name="collision_3">
-        <pose frame="">0 0.0271 0 0 0 0</pose>
+        <pose>0 0.0271 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.008</radius>
@@ -274,7 +267,7 @@
       <!-- Two more spheres that form a triangle with the tip-most sphere
            above. -->
       <collision name="collision_4">
-        <pose frame="">-0.004 0.0375 0.0060 0 0 0</pose>
+        <pose>-0.004 0.0375 0.0060 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.004</radius>
@@ -282,7 +275,7 @@
         </geometry>
       </collision>
       <collision name="collision_5">
-        <pose frame="">-0.004 0.0375 -0.0060 0 0 0</pose>
+        <pose>-0.004 0.0375 -0.0060 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.004</radius>
@@ -293,7 +286,6 @@
     <joint name="left_finger_sliding_joint" type="prismatic">
       <parent>body</parent>
       <child>left_finger</child>
-      <pose frame="">0 0 0 0 -0 0</pose>
       <axis>
         <xyz>1 0 0</xyz>
         <use_parent_model_frame>0</use_parent_model_frame>
@@ -329,7 +321,6 @@
     <joint name="right_finger_sliding_joint" type="prismatic">
       <parent>body</parent>
       <child>right_finger</child>
-      <pose frame="">0 0 0 0 -0 0</pose>
       <axis>
         <xyz>1 0 0</xyz>
         <use_parent_model_frame>0</use_parent_model_frame>

--- a/manipulation/models/ycb/sdf/003_cracker_box.sdf
+++ b/manipulation/models/ycb/sdf/003_cracker_box.sdf
@@ -27,7 +27,7 @@
         </inertia>
       </inertial>
       <visual name="base_link_cracker">
-        <pose frame="">-0.014 0.103 0.013 1.57 -1.57 0</pose>
+        <pose>-0.014 0.103 0.013 1.57 -1.57 0</pose>
         <geometry>
           <mesh>
             <uri>../meshes/003_cracker_box_textured.obj</uri>
@@ -46,7 +46,6 @@
       case a deviation of 0.0005 m from the visual surface).
      -->
       <collision name="box_collision">
-        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.158000 0.207400 0.065800</size>

--- a/manipulation/models/ycb/sdf/004_sugar_box.sdf
+++ b/manipulation/models/ycb/sdf/004_sugar_box.sdf
@@ -27,7 +27,7 @@
         </inertia>
       </inertial>
       <visual name="base_link_sugar">
-        <pose frame="">-0.018  0.088  0.0039 -0.77 -1.52 2.36</pose>
+        <pose>-0.018  0.088  0.0039 -0.77 -1.52 2.36</pose>
         <geometry>
           <mesh>
             <uri>../meshes/004_sugar_box_textured.obj</uri>
@@ -46,7 +46,6 @@
       case a deviation of 0.0005 m from the visual surface).
      -->
       <collision name="box_collision">
-        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.086700 0.170300 0.039100</size>

--- a/manipulation/models/ycb/sdf/005_tomato_soup_can.sdf
+++ b/manipulation/models/ycb/sdf/005_tomato_soup_can.sdf
@@ -27,7 +27,7 @@
         </inertia>
       </inertial>
       <visual name="base_link_soup">
-        <pose frame="">-0.0018  0.051 -0.084 1.57 0.13 0.0</pose>
+        <pose>-0.0018  0.051 -0.084 1.57 0.13 0.0</pose>
         <geometry>
           <mesh>
             <uri>../meshes/005_tomato_soup_can_textured.obj</uri>

--- a/manipulation/models/ycb/sdf/006_mustard_bottle.sdf
+++ b/manipulation/models/ycb/sdf/006_mustard_bottle.sdf
@@ -28,7 +28,7 @@
         </inertia>
       </inertial>
       <visual name="base_link_mustard">
-        <pose frame="">0.0049 0.092 0.027 1.57 -0.40 0.0</pose>
+        <pose>0.0049 0.092 0.027 1.57 -0.40 0.0</pose>
         <geometry>
           <mesh>
             <uri>../meshes/006_mustard_bottle_textured.obj</uri>

--- a/manipulation/models/ycb/sdf/009_gelatin_box.sdf
+++ b/manipulation/models/ycb/sdf/009_gelatin_box.sdf
@@ -27,7 +27,7 @@
         </inertia>
       </inertial>
       <visual name="base_link_gelatin">
-        <pose frame="">-0.0029 0.024 -0.015 -0.0085 -0.002 1.34</pose>
+        <pose>-0.0029 0.024 -0.015 -0.0085 -0.002 1.34</pose>
         <geometry>
           <mesh>
             <uri>../meshes/009_gelatin_box_textured.obj</uri>
@@ -46,7 +46,6 @@
       case a deviation of 0.0005 m from the visual surface).
      -->
       <collision name="box_collision">
-        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.083200 0.067100 0.024000</size>

--- a/manipulation/models/ycb/sdf/010_potted_meat_can.sdf
+++ b/manipulation/models/ycb/sdf/010_potted_meat_can.sdf
@@ -27,7 +27,7 @@
         </inertia>
       </inertial>
       <visual name="base_link_meat">
-        <pose frame="">0.034 0.039 0.025 1.57 0.052 0.0</pose>
+        <pose>0.034 0.039 0.025 1.57 0.052 0.0</pose>
         <geometry>
           <mesh>
             <uri>../meshes/010_potted_meat_can_textured.obj</uri>
@@ -46,7 +46,6 @@
       case a deviation of 0.0005 m from the visual surface).
      -->
       <collision name="box_collision">
-        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.095600 0.077500 0.051600</size>

--- a/multibody/benchmarks/acrobot/acrobot.sdf
+++ b/multibody/benchmarks/acrobot/acrobot.sdf
@@ -39,7 +39,6 @@
       <!-- A visual to show the link's pivot point -->
       <visual name="Link1_pivot_visual">
         <!-- Pose of the sphere used for visual in Link1's frame -->
-        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.125</radius>
@@ -102,7 +101,6 @@
       <parent>Link1</parent>
       <child>Link2</child>
       <!-- Pose X_CJ of the joint frame J in the frame C of the child link -->
-      <pose>0 0 0 0 0 0</pose>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>

--- a/multibody/parsing/test/links_with_visuals_and_collisions.urdf
+++ b/multibody/parsing/test/links_with_visuals_and_collisions.urdf
@@ -22,7 +22,6 @@
       </geometry>
     </visual>
     <collision name="link1_collision1">
-      <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
       <geometry>
         <cylinder radius="0.5" length="2.0"/>
       </geometry>

--- a/multibody/parsing/test/package_map_test_packages/package_map_test_package_a/sdf/test_model.sdf
+++ b/multibody/parsing/test/package_map_test_packages/package_map_test_package_a/sdf/test_model.sdf
@@ -2,9 +2,7 @@
 <sdf version="1.6">
   <model name="test_model">
     <link name="test_link">
-      <pose frame="">0 0 0 0 0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 0 0</pose>
         <mass>1</mass>
         <inertia>
           <ixx>0</ixx>

--- a/multibody/parsing/test/sdf_parser_test/joint_parsing_test.sdf
+++ b/multibody/parsing/test/sdf_parser_test/joint_parsing_test.sdf
@@ -5,9 +5,7 @@ Defines an SDF model with various types of joints used for testing the parser.
 <sdf version="1.6">
   <model name="joint_parsing_test">
     <link name="link1">
-      <pose frame="">0 0 0 0 -0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>1</mass>
         <inertia>
           <ixx>0.1</ixx>
@@ -20,9 +18,7 @@ Defines an SDF model with various types of joints used for testing the parser.
       </inertial>
     </link>
     <link name="link2">
-      <pose frame="">0 0 0 0 -0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>1</mass>
         <inertia>
           <ixx>0.1</ixx>
@@ -54,9 +50,7 @@ Defines an SDF model with various types of joints used for testing the parser.
       </axis>
     </joint>
     <link name="link3">
-      <pose frame="">0 0 0 0 -0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>1</mass>
         <inertia>
           <ixx>0.1</ixx>
@@ -88,9 +82,7 @@ Defines an SDF model with various types of joints used for testing the parser.
       </axis>
     </joint>
     <link name="link4">
-      <pose frame="">0 0 0 0 -0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>1</mass>
         <inertia>
           <ixx>0.1</ixx>
@@ -115,9 +107,7 @@ Defines an SDF model with various types of joints used for testing the parser.
       </axis>
     </joint>
     <link name="link5">
-      <pose frame="">0 0 0 0 -0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>1</mass>
         <inertia>
           <ixx>0.1</ixx>
@@ -130,7 +120,6 @@ Defines an SDF model with various types of joints used for testing the parser.
       </inertial>
     </link>
     <joint name="ball_joint" type="ball">
-      <pose>0 0 0 0 0 0</pose>
       <child>link5</child>
       <parent>link4</parent>
       <axis>
@@ -141,9 +130,7 @@ Defines an SDF model with various types of joints used for testing the parser.
       </axis>
     </joint>
     <link name="link6">
-      <pose frame="">0 0 0 0 -0 0</pose>
       <inertial>
-        <pose frame="">0 0 0 0 -0 0</pose>
         <mass>1</mass>
         <inertia>
           <ixx>0.1</ixx>
@@ -156,7 +143,6 @@ Defines an SDF model with various types of joints used for testing the parser.
       </inertial>
     </link>
     <joint name="universal_joint" type="universal">
-      <pose>0 0 0 0 0 0</pose>
       <child>link6</child>
       <parent>link5</parent>
       <axis>

--- a/multibody/plant/test/box.sdf
+++ b/multibody/plant/test/box.sdf
@@ -58,7 +58,7 @@
     </joint>
     <!-- Ghost body of negligible mass. -->
     <link name="ghost_body">
-      <pose frame="">0 0 0.5 0 0 0</pose>
+      <pose>0 0 0.5 0 0 0</pose>
       <inertial>
         <mass>1.0e-6</mass>
         <inertia>
@@ -77,7 +77,6 @@
     <joint name="x_slider" type="prismatic">
       <parent>world</parent>
       <child>ghost_body</child>
-      <pose>0 0 0 0 0 0</pose>
       <axis>
         <xyz>1 0 0</xyz>
         <!-- Drake attaches an actuator to all joints with a non-zero effort
@@ -92,7 +91,6 @@
     <joint name="z_slider" type="prismatic">
       <parent>ghost_body</parent>
       <child>box</child>
-      <pose>0 0 0 0 0 0</pose>
       <axis>
         <xyz>0 0 1</xyz>
         <!-- Drake attaches an actuator to all joints with a non-zero effort

--- a/systems/sensors/models/box.sdf
+++ b/systems/sensors/models/box.sdf
@@ -3,7 +3,6 @@
   <model name="box">
     <pose>0 0 0.3 0 0 0</pose>
     <link name="box">
-      <pose>0 0 0 0 0 0</pose>
       <inertial>
         <mass>5.</mass>
         <inertia>
@@ -16,7 +15,6 @@
         </inertia>
       </inertial>
       <visual name="box">
-        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.05 0.05 0.05</size>

--- a/systems/sensors/models/sphere.sdf
+++ b/systems/sensors/models/sphere.sdf
@@ -1,14 +1,11 @@
 <?xml version="1.0"?>
 <sdf version="1.4">
   <model name="sphere">
-    <pose>0 0 0 0 0 0</pose>
     <link name="sphere">
-      <pose>0 0 0 0 0 0</pose>
       <inertial>
         <mass>1.</mass>
       </inertial>
       <visual name="sphere">
-        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.1</radius>

--- a/systems/sensors/test/models/box.sdf
+++ b/systems/sensors/test/models/box.sdf
@@ -3,7 +3,6 @@
   <model name="box">
     <pose>0 0 0.5 0 0 0</pose>
     <link name="box">
-      <pose>0 0 0 0 0 0</pose>
       <inertial>
         <mass>1.</mass>
         <inertia>
@@ -16,7 +15,6 @@
         </inertia>
       </inertial>
       <visual name="box">
-        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>10. 10. 1.</size>

--- a/systems/sensors/test/models/box_with_mesh.sdf
+++ b/systems/sensors/test/models/box_with_mesh.sdf
@@ -9,7 +9,6 @@
   <model name="box">
     <pose>0 0 0.5 0 0 0</pose>
     <link name="box">
-      <pose>0 0 0 0 0 0</pose>
       <inertial>
         <mass>1.</mass>
         <inertia>
@@ -22,7 +21,6 @@
         </inertia>
       </inertial>
       <visual name="box">
-        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <mesh>
             <uri>meshes/box.obj</uri>

--- a/systems/sensors/test/models/nothing.sdf
+++ b/systems/sensors/test/models/nothing.sdf
@@ -1,9 +1,7 @@
 <?xml version="1.0"?>
 <sdf version="1.4">
   <model name="foo">
-    <pose>0 0 0 0 0 0</pose>
     <link name="link">
-      <pose>0 0 0 0 0 0</pose>
       <inertial>
         <mass>1.</mass>
       </inertial>

--- a/systems/sensors/test/models/sphere.sdf
+++ b/systems/sensors/test/models/sphere.sdf
@@ -3,12 +3,10 @@
   <model name="sphere">
     <pose>0 0.02 0.5 0 0 0</pose>
     <link name="sphere">
-      <pose>0 0 0 0 0 0</pose>
       <inertial>
         <mass>1.</mass>
       </inertial>
       <visual name="sphere">
-        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.5</radius>


### PR DESCRIPTION
Towards #13758

- Remove `//pose/@frame` when empty
- Collapse identity transforms (all zeros)
- Remove purely identity transforms ("<pose/>")

Script used:
https://git.io/JJ2OQ

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13774)
<!-- Reviewable:end -->
