### PR TITLE
Remove spdlog warning

### DIFF
--- a/bindings/pydrake/common/text_logging_pybind.cc
+++ b/bindings/pydrake/common/text_logging_pybind.cc
@@ -4,12 +4,17 @@
 #include <memory>
 #include <mutex>
 
+// clang-format off to disable clang-format-includes
+// N.B. text-logging.h must be included before spdlog headers
+// to avoid "SPDLOG_ACTIVE_LEVEL" redefined warning (#13771).
+#include "drake/common/text_logging.h"
+// clang-format on
+
 #include <spdlog/sinks/base_sink.h>
 #include <spdlog/sinks/dist_sink.h>
 
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/common/drake_assert.h"
-#include "drake/common/text_logging.h"
 #endif
 
 namespace drake {


### PR DESCRIPTION
Change the order of include statements to avoid the SPLOG_ACTIVE_LEVEL
redefined warning.

Resolves #13771

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13781)
<!-- Reviewable:end -->
