### PR TITLE
[WIP] For API consistency, create method Frame::CalcSpatialAcceleration() to mimic Frame::CalcSpatialVelocity().

### DIFF
--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -2962,7 +2962,7 @@ void MultibodyPlant<T>::CalcFramePoseOutput(
   // TODO(amcastro-tri): Make use of Body::EvalPoseInWorld(context) once caching
   // lands.
   poses->clear();
-  for (const auto& it : body_index_to_frame_id_) {
+  for (const auto it : body_index_to_frame_id_) {
     const BodyIndex body_index = it.first;
     if (body_index == world_index()) continue;
     const Body<T>& body = get_body(body_index);

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -2755,7 +2755,6 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @param[in] p_BoBp_B Position vector from Bo (frame_B's origin) to point Bp
   /// (regarded as affixed/welded to B), expressed in frame_B.
   /// @param[in] frame_A The frame that measures A𝑠Bias_ABp.
-  /// Currently, an exception is thrown if frame_A is not the World frame.
   /// @param[in] frame_E The frame in which A𝑠Bias_ABp is expressed on output.
   /// @returns A𝑠Bias_ABp_E Point Bp's spatial acceleration bias in frame A
   /// with respect to speeds 𝑠 (𝑠 = q̇ or 𝑠 = v), expressed in frame E.
@@ -2767,7 +2766,6 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @see CalcJacobianSpatialVelocity() to compute J𝑠_V_ABp, point Bp's
   /// translational velocity Jacobian in frame A with respect to 𝑠.
   /// @throws std::exception if with_respect_to is not JacobianWrtVariable::kV
-  /// @throws std::exception if frame_A is not the world frame.
   SpatialAcceleration<T> CalcBiasSpatialAcceleration(
       const systems::Context<T>& context,
       JacobianWrtVariable with_respect_to,

--- a/multibody/tree/body.cc
+++ b/multibody/tree/body.cc
@@ -8,6 +8,15 @@ namespace drake {
 namespace multibody {
 
 template <typename T>
+const SpatialAcceleration<T>& Body<T>::EvalSpatialAccelerationInWorld(
+    const systems::Context<T>& context) const {
+  const MultibodyPlant<T>& parent_plant = this->GetParentPlant();
+  const SpatialAcceleration<T>& A_WB_W =
+      parent_plant.EvalBodySpatialAccelerationInWorld(context, *this);
+  return A_WB_W;
+}
+
+template <typename T>
 template <typename ToScalar>
 std::unique_ptr<Frame<ToScalar>> BodyFrame<T>::TemplatedDoCloneToScalar(
     const internal::MultibodyTree<ToScalar>& tree_clone) const {

--- a/multibody/tree/body.h
+++ b/multibody/tree/body.h
@@ -311,10 +311,7 @@ class Body : public MultibodyElement<Body, T, BodyIndex> {
   /// this method performs an expensive forward dynamics computation, whereas
   /// once evaluated, successive calls to this method are inexpensive.
   const SpatialAcceleration<T>& EvalSpatialAccelerationInWorld(
-      const systems::Context<T>& context) const {
-    const MultibodyPlant<T>& parent_plant = this->GetParentPlant();
-    return parent_plant.EvalBodySpatialAccelerationInWorld(context, *this);
-  }
+      const systems::Context<T>& context) const;
 
   /// Gets the sptatial force on `this` body B from `forces` as F_BBo_W:
   /// applied at body B's origin Bo and expressed in world world frame W.

--- a/multibody/tree/frame.h
+++ b/multibody/tree/frame.h
@@ -252,8 +252,6 @@ class Frame : public FrameBase<T> {
         body().EvalPoseInWorld(context).rotation();
     const Vector3<T> p_BoFo_B = CalcPoseInBodyFrame(context).translation();
     const Vector3<T> p_BoFo_W = R_WB * p_BoFo_B;
-    const SpatialAcceleration<T>& A_WB_W =
-        body().EvalSpatialAccelerationInWorld(context);
     const Vector3<T>& w_WB_W =
         body().EvalSpatialVelocityInWorld(context).rotational();
     const SpatialAcceleration<T> A_WF_W = A_WB_W.Shift(p_BoFo_W, w_WB_W);

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1574,6 +1574,22 @@ class MultibodyTree {
       const VectorX<T>& known_vdot,
       AccelerationKinematicsCache<T>* ac) const;
 
+  // For one point Bp fixed/welded to a frame B, calculates A_ABp_E, Bp's
+  // spatial acceleration in frame A, expressed in frame_E.
+  // @param[in] context The state of the multibody system.
+  // @param[in] frame_B The frame on which point Bp is affixed/welded.
+  // @param[in] p_BoBp_B Position vector from Bo (frame_B's origin) to point Bp,
+  //            expressed in frame_B.
+  // @param[in] frame_A The frame that measures A_ABp_E.
+  // @param[in] frame_E The frame in which A_ABp_E is expressed on output.
+  // @returns A_ABp_E Bp's spatial acceleration in frame A expressed in frame_E.
+  SpatialAcceleration<T> CalcSpatialAcceleration(
+      const systems::Context<T>& context,
+      const Frame<T>& frame_B,
+      const Eigen::Ref<const Vector3<T>>& p_BoBp_B,
+      const Frame<T>& frame_A,
+      const Frame<T>& frame_E) const;
+
   /// See MultibodyPlant method.
   /// @warning The output parameter `A_WB_array` is indexed by BodyNodeIndex,
   /// while MultibodyPlant's method returns accelerations indexed by BodyIndex.


### PR DESCRIPTION
Per issue #13773, the Frame and Body classes currently have methods to calculate Pose and SpatialVelocity such as Frame::CalcSpatialVelocity().  It is natural that these classes have corresponding methods for SpatialAcceleration, e.g., Frame::CalcSpatialAcceleration().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13783)
<!-- Reviewable:end -->
