### PR TITLE
Bind LeafSystem::DeclarePeriodicPublishEvent

### DIFF
--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -553,6 +553,25 @@ Note: The above is for the C++ documentation. For Python, use
             &LeafSystemPublic::DeclarePeriodicPublish, py::arg("period_sec"),
             py::arg("offset_sec") = 0.,
             doc.LeafSystem.DeclarePeriodicPublish.doc)
+        .def("DeclarePeriodicPublishEvent",
+            WrapCallbacks(
+                [](PyLeafSystem* self, double period_sec, double offset_sec,
+                    std::function<EventStatus(const Context<T>&)> publish) {
+                  self->DeclarePeriodicEvent(period_sec, offset_sec,
+                      PublishEvent<T>(TriggerType::kPeriodic,
+                          [publish](const Context<T>& context,
+                              const PublishEvent<T>&) {
+                            return publish(context);
+                          }));
+                }),
+            py_rvp::reference_internal, py::arg("period_sec"),
+            py::arg("offset_sec"), py::arg("publish"), R"""(
+            Declares that a Publish event should occur periodically and that it
+            should invoke the given event handler method.  Your publish method
+            *must* return an EventStatus; you will obtain unfortunately obscure
+            error messages (about incompatible function arguments to DoPublish)
+            if it does not.
+            )""")
         .def("DeclarePeriodicDiscreteUpdate",
             &LeafSystemPublic::DeclarePeriodicDiscreteUpdate,
             py::arg("period_sec"), py::arg("offset_sec") = 0.,


### PR DESCRIPTION
Adds one of the missing bindings.

Note 1: I elected for this solution instead of adding yet another overload to LeafSystem proper.  I don't believe we have any examples yet of using the `MySystem::calc` style function pointers; I would have needed to declare the `std::function<EventStatus(Context)>` variant on `LeafSystem`. 

Note 2: (or perhaps "Whine 1") We have an unfortunate pattern of us having python documentation that says "Advanced -- do not use" or "Deprecated", but where we do not actually offer the bindings (yet) for the user to do anything else.  I guess we'll just whack-a-mole them down.

FTR -- the documentation looks like this:

![Screenshot from 2020-08-02 10-30-41](https://user-images.githubusercontent.com/6442292/89125329-aae74200-d4ab-11ea-86c4-be558fff2fcf.png)

I originally tried ammending the c++ doxygen, but it was just misleading and wrong when used as a python doc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13793)
<!-- Reviewable:end -->
