### PR TITLE
math: Declare explicit class instantiations for SO(3) and SE(3)

### DIFF
--- a/math/rigid_transform.cc
+++ b/math/rigid_transform.cc
@@ -1,6 +1,4 @@
 #include "drake/math/rigid_transform.h"
 
-#include "drake/common/default_scalars.h"
-
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::math::RigidTransform)

--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -2,6 +2,7 @@
 
 #include <limits>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_bool.h"
 #include "drake/common/drake_copyable.h"
@@ -633,3 +634,6 @@ using RigidTransformd = RigidTransform<double>;
 
 }  // namespace math
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::math::RigidTransform)

--- a/math/roll_pitch_yaw.h
+++ b/math/roll_pitch_yaw.h
@@ -657,3 +657,6 @@ using RollPitchYawd = RollPitchYaw<double>;
 
 }  // namespace math
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::math::RollPitchYaw)

--- a/math/rotation_matrix.cc
+++ b/math/rotation_matrix.cc
@@ -1,6 +1,4 @@
 #include "drake/math/rotation_matrix.h"
 
-#include "drake/common/default_scalars.h"
-
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::math::RotationMatrix)

--- a/math/rotation_matrix.h
+++ b/math/rotation_matrix.h
@@ -7,6 +7,7 @@
 #include <Eigen/Dense>
 #include <fmt/format.h>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_bool.h"
 #include "drake/common/drake_copyable.h"
@@ -1082,3 +1083,6 @@ RotationMatrix<T>::ThrowIfNotValid(const Matrix3<S>& R) {
 
 }  // namespace math
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::math::RotationMatrix)


### PR DESCRIPTION
Motivations:

1. Just for speed, 'cause why not?
2. As part of #7889, one way to know to bind an instantiation is to use it in actual C++ code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13798)
<!-- Reviewable:end -->
