### PR TITLE
workspace: Update pybind11 fork with cherry-pick from upstream

### DIFF
--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -218,6 +218,20 @@ class TestCustom(unittest.TestCase):
                 ]:
             self.assertIsInstance(func(arg), DependencyTicket, func)
 
+    def test_leaf_system_issue13792(self):
+        """
+        Ensures that users get a better error when forgetting to explicitly
+        call the C++ superclass's __init__.
+        """
+
+        class Oops(LeafSystem):
+            def __init__(self):
+                pass
+
+        with self.assertRaises(TypeError) as cm:
+            Oops()
+        self.assertIn("LeafSystem_[float].__init__", str(cm.exception))
+
     def test_all_leaf_system_overrides(self):
         test = self
 

--- a/tools/workspace/pybind11/repository.bzl
+++ b/tools/workspace/pybind11/repository.bzl
@@ -6,9 +6,9 @@ load("@drake//tools/workspace:github.bzl", "github_archive")
 # Using the `drake` branch of this repository.
 _REPOSITORY = "RobotLocomotion/pybind11"
 
-_COMMIT = "5dfa2b35b7e8fd2c2c01c8f7f6d87faf808e8cbd"
+_COMMIT = "18dfca681391c0d1b1d4302106c82e97a9806f46"
 
-_SHA256 = "4319080bb8566c7ff52072111f10a57d86867b5ee29e441553905ae6f89aeab6"
+_SHA256 = "38b608a3cc61745c4cccbd118f9034838bb5bc1c72a0e7e978245e318af7c085"
 
 def pybind11_repository(
         name,


### PR DESCRIPTION
Add test checking for missing `LeafSystem.__init__`

Resolves #13792

FYI @RussTedrake

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13801)
<!-- Reviewable:end -->
