### PR TITLE
Bump meshcat_python SHA to get generalized "start server" methods.

### DIFF
--- a/bindings/pydrake/test/all_test.py
+++ b/bindings/pydrake/test/all_test.py
@@ -19,6 +19,9 @@ class TestAll(unittest.TestCase):
             warnings.filterwarnings(
                 "ignore", message="Matplotlib is building the font cache",
                 category=UserWarning)
+            warnings.filterwarnings(
+                "ignore", message=".* from 'collections.abc' is deprecated",
+                category=DeprecationWarning)
             import pydrake.all
             self.assertEqual(len(w), 0, [x.message for x in w])
 

--- a/tools/workspace/meshcat_python/repository.bzl
+++ b/tools/workspace/meshcat_python/repository.bzl
@@ -44,9 +44,9 @@ def _impl(repository_ctx):
         "rdeits/meshcat-python",
         # Updating this commit requires local testing; see
         # drake/tools/workspace/meshcat/README.md for details.
-        "ba573b1fc9e11d149b5a608946acb226e5328a28",
+        "c1a0702787fe651b7abaf8c243da018c8728e2f9",
         repository_ctx.attr.mirrors,
-        sha256 = "9a671d4096d7a195ea3d93d4e332ff9774217e35db4e0b2b25becf1c875d900e",  # noqa
+        sha256 = "00b1f131b2ffc08314b7624fb313f973b8853abe48e8a5175453a19fd27d6653",  # noqa
     )
 
     repository_ctx.symlink(


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13806)
<!-- Reviewable:end -->
