### PR TITLE
py eigen_geometry: Bind Quaternion.slerp

### DIFF
--- a/bindings/pydrake/common/eigen_geometry_py.cc
+++ b/bindings/pydrake/common/eigen_geometry_py.cc
@@ -275,7 +275,15 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def(
             "multiply",
             [](const Class& self, const Class& other) { return self * other; },
-            "Quaternion multiplication");
+            "Quaternion multiplication")
+        .def(
+            "slerp",
+            [](const Class& self, double t, const Class& other) {
+              return self.slerp(t, other);
+            },
+            py::arg("t"), py::arg("other"),
+            "The spherical linear interpolation between the two quaternions "
+            "(self and other) at the parameter t in [0;1].");
     auto multiply_vector = [](const Class& self, const Vector3<T>& vector) {
       return self * vector;
     };

--- a/bindings/pydrake/common/test/eigen_geometry_test.py
+++ b/bindings/pydrake/common/test/eigen_geometry_test.py
@@ -119,6 +119,9 @@ class TestEigenGeometry(unittest.TestCase):
         numpy_compare.assert_float_equal(
                 q_AB_conj.wxyz(), [0.5, -0.5, -0.5, -0.5])
 
+        numpy_compare.assert_float_equal(
+            q_I.slerp(t=0, other=q_I).wxyz(), [1., 0, 0, 0])
+
         # Test `type_caster`s.
         if T == float:
             value = test_util.create_quaternion()

--- a/math/quaternion.h
+++ b/math/quaternion.h
@@ -17,6 +17,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_bool.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/is_approx_equal_abstol.h"
 #include "drake/math/rotation_matrix.h"
@@ -125,6 +126,7 @@ typename Derived1::Scalar quatDiffAxisInvar(
  * doi: 10.1109/ROBOT.2004.1308895
  */
 template <typename Derived1, typename Derived2, typename Scalar>
+DRAKE_DEPRECATED("2020-12-01", "Use Eigen::Quaternion<T>::slerp() instead")
 Vector4<Scalar> Slerp(const Eigen::MatrixBase<Derived1>& q1,
                       const Eigen::MatrixBase<Derived2>& q2,
                       const Scalar& interpolation_parameter) {


### PR DESCRIPTION
Resolves #13809

quaternion: Deprecate drake::math::Slerp in lieu of Eigen's

The motivation here is that I'm lazy, and I want access to Slerp in Python.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13810)
<!-- Reviewable:end -->
