### PR TITLE
Prefer triple-quote for C++ multi-line string literals

### DIFF
--- a/common/schema/dev/test/stochastic_test.cc
+++ b/common/schema/dev/test/stochastic_test.cc
@@ -27,13 +27,13 @@ struct DistributionStruct {
   }
 };
 
-const char* all_variants = R"R(
+const char* all_variants = R"""(
 vec: [ !Deterministic { value: 5.0 },
        !Gaussian { mean: 2.0, std: 4.0 },
        !Uniform { min: 1.0, max: 5.0 },
        !UniformDiscrete { values: [1, 1.5, 2] },
        3.2 ]
-)R";
+)""";
 
 const char* floats = "vec: [5.0, 6.1, 7.2]";
 
@@ -171,7 +171,7 @@ struct DistributionVectorStruct {
   }
 };
 
-const char* vector_variants = R"R(
+const char* vector_variants = R"""(
 vector: [1., 2., 3.]
 deterministic: !DeterministicVector { value: [3., 4., 5.] }
 gaussian1: !GaussianVector { mean: [1.1, 1.2, 1.3], std: [0.1, 0.2, 0.3] }
@@ -180,7 +180,7 @@ uniform: !UniformVector { min: [10, 20], max: [11, 22] }
 deterministic_scalar: !Deterministic { value: 19.5 }
 gaussian_scalar: !Gaussian { mean: 5, std: 1 }
 uniform_scalar: !Uniform { min: 1, max: 2 }
-)R";
+)""";
 
 GTEST_TEST(StochasticTest, VectorTest) {
   DistributionVectorStruct variants;

--- a/common/yaml/test/yaml_read_archive_test.cc
+++ b/common/yaml/test/yaml_read_archive_test.cc
@@ -192,14 +192,14 @@ TEST_P(YamlReadArchiveTest, BigStdMapAppend) {
     // The parser would raise an uninteresting exception in this case.
     return;
   }
-  std::string doc = R"R(
+  std::string doc = R"""(
 doc:
   value:
     bar:
       outer_value: 3.0
       inner_struct:
         inner_value: 4.0
-)R";
+)""";
   const auto& x = AcceptNoThrow<BigMapStruct>(Load(doc));
   if (GetParam().retain_map_defaults) {
     EXPECT_EQ(x.value.size(), 2);
@@ -217,12 +217,12 @@ TEST_P(YamlReadArchiveTest, BigStdMapMergeNewOuterValue) {
     // The parser would raise an uninteresting exception in this case.
     return;
   }
-  std::string doc = R"R(
+  std::string doc = R"""(
 doc:
   value:
     foo:
       outer_value: 3.0
-)R";
+)""";
   const auto& x = AcceptNoThrow<BigMapStruct>(Load(doc));
   EXPECT_EQ(x.value.size(), 1);
   EXPECT_EQ(x.value.at("foo").outer_value, 3.0);
@@ -238,13 +238,13 @@ TEST_P(YamlReadArchiveTest, BigStdMapMergeNewInnerValue) {
     // The parser would raise an uninteresting exception in this case.
     return;
   }
-  std::string doc = R"R(
+  std::string doc = R"""(
 doc:
   value:
     foo:
       inner_struct:
         inner_value: 4.0
-)R";
+)""";
   const auto& x = AcceptNoThrow<BigMapStruct>(Load(doc));
   EXPECT_EQ(x.value.size(), 1);
   if (GetParam().retain_map_defaults) {
@@ -260,11 +260,11 @@ TEST_P(YamlReadArchiveTest, BigStdMapMergeEmpty) {
     // The parser would raise an uninteresting exception in this case.
     return;
   }
-  std::string doc = R"R(
+  std::string doc = R"""(
 doc:
   value:
     foo: {}
-)R";
+)""";
   const auto& x = AcceptNoThrow<BigMapStruct>(Load(doc));
   EXPECT_EQ(x.value.size(), 1);
   if (GetParam().retain_map_defaults) {
@@ -294,7 +294,7 @@ TEST_P(YamlReadArchiveTest, StdMapWithMergeKeys) {
   };
 
   // Use merge keys to populate some keys.
-  test(R"R(
+  test(R"""(
 _template: &template
   foo: 1.0
 
@@ -302,10 +302,10 @@ doc:
   value:
     << : *template
     bar: 2.0
-)R", {{"foo", 1.0}, {"bar", 2.0}});
+)""", {{"foo", 1.0}, {"bar", 2.0}});
 
   // A pre-existing value should win, though.
-  test(R"R(
+  test(R"""(
 _template: &template
   foo: 3.0
 
@@ -314,10 +314,10 @@ doc:
     << : *template
     foo: 1.0
     bar: 2.0
-)R", {{"foo", 1.0}, {"bar", 2.0}});
+)""", {{"foo", 1.0}, {"bar", 2.0}});
 
   // A list of merges should also work.
-  test(R"R(
+  test(R"""(
 _template: &template
   - foo: 1.0
   - baz: 3.0
@@ -326,33 +326,33 @@ doc:
   value:
     << : *template
     bar: 2.0
-)R", {{"foo", 1.0}, {"bar", 2.0}, {"baz", 3.0}});
+)""", {{"foo", 1.0}, {"bar", 2.0}, {"baz", 3.0}});
 }
 
 TEST_P(YamlReadArchiveTest, StdMapWithBadMergeKey) {
   DRAKE_EXPECT_THROWS_MESSAGE(
-      AcceptIntoDummy<MapStruct>(Load(R"R(
+      AcceptIntoDummy<MapStruct>(Load(R"""(
 _template: &template 99.0
 
 doc:
   value:
     << : *template
     bar: 2.0
-)R")),
+)""")),
       std::runtime_error,
       "YAML node of type Map \\(with size 1 and keys \\{value\\}\\)"
       " has invalid merge key type \\(Scalar\\) within entry"
       " for std::map<[^ ]*> value\\.");
 
   DRAKE_EXPECT_THROWS_MESSAGE(
-      AcceptIntoDummy<MapStruct>(Load(R"R(
+      AcceptIntoDummy<MapStruct>(Load(R"""(
 _template: &template
 
 doc:
   value:
     << : *template
     bar: 2.0
-)R")),
+)""")),
       std::runtime_error,
       "YAML node of type Map \\(with size 1 and keys \\{value\\}\\)"
       " has invalid merge key type \\(Null\\) within entry"
@@ -429,13 +429,13 @@ TEST_P(YamlReadArchiveTest, EigenMatrix) {
     EXPECT_TRUE(drake::CompareMatrices(mat34.value, expected));
   };
 
-  test(R"R(
+  test(R"""(
 doc:
   value:
   - [0.0, 1.0, 2.0, 3.0]
   - [4.0, 5.0, 6.0, 7.0]
   - [8.0, 9.0, 10.0, 11.0]
-)R", (Matrix34d{} << 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11).finished());
+)""", (Matrix34d{} << 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11).finished());
 }
 
 TEST_P(YamlReadArchiveTest, EigenMissing) {
@@ -452,12 +452,12 @@ TEST_P(YamlReadArchiveTest, EigenMissing) {
 }
 
 TEST_P(YamlReadArchiveTest, Nested) {
-  const auto& x = AcceptNoThrow<OuterStruct>(Load(R"R(
+  const auto& x = AcceptNoThrow<OuterStruct>(Load(R"""(
 doc:
   outer_value: 1.0
   inner_struct:
     inner_value: 2.0
-)R"));
+)"""));
   EXPECT_EQ(x.outer_value, 1.0);
   EXPECT_EQ(x.inner_struct.inner_value, 2.0);
 }
@@ -476,7 +476,7 @@ TEST_P(YamlReadArchiveTest, NestedWithMergeKeys) {
   };
 
   // Use merge keys to populate InnerStruct.
-  test(R"R(
+  test(R"""(
 _template: &template
   inner_value: 2.0
   ignored_key: ignored_value
@@ -485,11 +485,11 @@ doc:
   inner_struct:
     << : *template
   outer_value: 1.0
-)R");
+)""");
 
   // Use merge keys to populate InnerStruct, though to no effect because the
   // existing value wins.
-  test(R"R(
+  test(R"""(
 _template: &template
   inner_value: 3.0
   ignored_key: ignored_value
@@ -499,10 +499,10 @@ doc:
     << : *template
     inner_value: 2.0
   outer_value: 1.0
-)R");
+)""");
 
   // Use merge keys to populate OuterStruct.
-  test(R"R(
+  test(R"""(
 _template: &template
   inner_struct:
     inner_value: 2.0
@@ -511,11 +511,11 @@ _template: &template
 doc:
   << : *template
   outer_value: 1.0
-)R");
+)""");
 
   // Use array of merge keys to populate OuterStruct.
   // First array with a value wins.
-  test(R"R(
+  test(R"""(
 _template: &template
   - inner_struct:
       inner_value: 2.0
@@ -526,19 +526,19 @@ _template: &template
 doc:
   << : *template
   outer_value: 1.0
-)R");
+)""");
 }
 
 TEST_P(YamlReadArchiveTest, NestedWithBadMergeKey) {
   DRAKE_EXPECT_THROWS_MESSAGE(
-      AcceptIntoDummy<OuterStruct>(Load(R"R(
+      AcceptIntoDummy<OuterStruct>(Load(R"""(
 _template: &template 99.0
 
 doc:
   inner_struct:
     << : *template
   outer_value: 1.0
-)R")),
+)""")),
       std::runtime_error,
       "YAML node of type Map"
       " \\(with size 2 and keys \\{inner_struct, outer_value\\}\\)"
@@ -546,14 +546,14 @@ doc:
       " for .*::OuterStruct::InnerStruct inner_struct\\.");
 
   DRAKE_EXPECT_THROWS_MESSAGE(
-      AcceptIntoDummy<OuterStruct>(Load(R"R(
+      AcceptIntoDummy<OuterStruct>(Load(R"""(
 _template: &template
 
 doc:
   inner_struct:
     << : *template
   outer_value: 1.0
-)R")),
+)""")),
       std::runtime_error,
       "YAML node of type Map"
       " \\(with size 2 and keys \\{inner_struct, outer_value\\}\\)"
@@ -561,7 +561,7 @@ doc:
       " for .*::OuterStruct::InnerStruct inner_struct\\.");
 
   DRAKE_EXPECT_THROWS_MESSAGE(
-      AcceptIntoDummy<OuterStruct>(Load(R"R(
+      AcceptIntoDummy<OuterStruct>(Load(R"""(
 _template: &template
   - inner_value
   - 2.0
@@ -569,7 +569,7 @@ _template: &template
 doc:
   << : *template
   outer_value: 1.0
-)R")),
+)""")),
       std::runtime_error,
       "YAML node of type Map \\(with size 1 and keys \\{outer_value\\}\\)"
       " has invalid merge key type \\(Sequence-of-non-Map\\) within entry"
@@ -579,12 +579,12 @@ doc:
 // This finds nothing when a scalar was wanted, because the name had a typo.
 TEST_P(YamlReadArchiveTest, VisitScalarFoundNothing) {
   // This has a "_TYPO" in a field name.
-  const YAML::Node node = Load(R"R(
+  const YAML::Node node = Load(R"""(
 doc:
   outer_value: 1.0
   inner_struct:
     inner_value_TYPO: 2.0
-)R");
+)""");
   if (GetParam().allow_cpp_with_no_yaml &&
       GetParam().allow_yaml_with_no_cpp) {
     const auto& x = AcceptNoThrow<OuterStruct>(node);
@@ -616,12 +616,12 @@ doc:
 // This finds an array when a scalar was wanted.
 TEST_P(YamlReadArchiveTest, VisitScalarFoundArray) {
   DRAKE_EXPECT_THROWS_MESSAGE(
-      AcceptIntoDummy<OuterStruct>(Load(R"R(
+      AcceptIntoDummy<OuterStruct>(Load(R"""(
 doc:
   outer_value: 1.0
   inner_struct:
     inner_value: [2.0, 3.0]
-)R")),
+)""")),
       std::runtime_error,
       "YAML node of type Map \\(with size 1 and keys \\{inner_value\\}\\)"
       " has non-Scalar \\(Sequence\\) entry for double inner_value"
@@ -633,13 +633,13 @@ doc:
 // This finds a struct when a scalar was wanted.
 TEST_P(YamlReadArchiveTest, VisitScalarFoundStruct) {
   DRAKE_EXPECT_THROWS_MESSAGE(
-      AcceptIntoDummy<OuterStruct>(Load(R"R(
+      AcceptIntoDummy<OuterStruct>(Load(R"""(
 doc:
   outer_value: 1.0
   inner_struct:
     inner_value:
        key: 2.0
-)R")),
+)""")),
       std::runtime_error,
       "YAML node of type Map \\(with size 1 and keys \\{inner_value\\}\\)"
       " has non-Scalar \\(Map\\) entry for double inner_value"
@@ -669,11 +669,11 @@ TEST_P(YamlReadArchiveTest, VisitArrayFoundScalar) {
 // This finds a sub-structure when a std::array was wanted.
 TEST_P(YamlReadArchiveTest, VisitArrayFoundStruct) {
   DRAKE_EXPECT_THROWS_MESSAGE(
-      AcceptIntoDummy<ArrayStruct>(Load(R"R(
+      AcceptIntoDummy<ArrayStruct>(Load(R"""(
 doc:
   value:
     inner_value: 1.0
-)R")),
+)""")),
       std::runtime_error,
       "YAML node of type Map \\(with size 1 and keys \\{value\\}\\)"
       " has non-Sequence \\(Map\\) entry for std::array<.*> value\\.");
@@ -700,11 +700,11 @@ TEST_P(YamlReadArchiveTest, VisitVectorFoundScalar) {
 // This finds a sub-structure when a std::vector was wanted.
 TEST_P(YamlReadArchiveTest, VisitVectorFoundStruct) {
   DRAKE_EXPECT_THROWS_MESSAGE(
-      AcceptIntoDummy<VectorStruct>(Load(R"R(
+      AcceptIntoDummy<VectorStruct>(Load(R"""(
 doc:
   value:
     inner_value: 1.0
-)R")),
+)""")),
       std::runtime_error,
       "YAML node of type Map \\(with size 1 and keys \\{value\\}\\)"
       " has non-Sequence \\(Map\\) entry for std::vector<.*> value\\.");
@@ -836,13 +836,13 @@ TEST_P(YamlReadArchiveTest, VisitEigenMatrixFoundOneDimensional) {
 
 // This finds a non-square (4+4+3) matrix, when an Eigen::Matrix was wanted.
 TEST_P(YamlReadArchiveTest, VisitEigenMatrixFoundNonSquare) {
-  const std::string doc(R"R(
+  const std::string doc(R"""(
 doc:
   value:
   - [0.0, 1.0, 2.0, 3.0]
   - [4.0, 5.0, 6.0, 7.0]
   - [8.0, 9.0, 0.0]
-)R");
+)""");
   DRAKE_EXPECT_THROWS_MESSAGE(
       AcceptIntoDummy<EigenMatrixStruct>(Load(doc)),
       std::runtime_error,
@@ -857,10 +857,10 @@ doc:
 
 // This finds nothing when a sub-structure was wanted.
 TEST_P(YamlReadArchiveTest, VisitStructFoundNothing) {
-  const YAML::Node node = Load(R"R(
+  const YAML::Node node = Load(R"""(
   doc:
     outer_value: 1.0
-  )R");
+  )""");
   if (GetParam().allow_cpp_with_no_yaml) {
     const auto& x = AcceptNoThrow<OuterStruct>(node);
     EXPECT_EQ(x.outer_value, 1.0);
@@ -877,11 +877,11 @@ TEST_P(YamlReadArchiveTest, VisitStructFoundNothing) {
 // This finds a scalar when a sub-structure was wanted.
 TEST_P(YamlReadArchiveTest, VisitStructFoundScalar) {
   DRAKE_EXPECT_THROWS_MESSAGE(
-      AcceptIntoDummy<OuterStruct>(Load(R"R(
+      AcceptIntoDummy<OuterStruct>(Load(R"""(
 doc:
   outer_value: 1.0
   inner_struct: 2.0
-)R")),
+)""")),
       std::runtime_error,
       "YAML node of type Map"
       " \\(with size 2 and keys \\{inner_struct, outer_value\\}\\)"
@@ -891,11 +891,11 @@ doc:
 // This finds an array when a sub-structure was wanted.
 TEST_P(YamlReadArchiveTest, VisitStructFoundArray) {
   DRAKE_EXPECT_THROWS_MESSAGE(
-      AcceptIntoDummy<OuterStruct>(Load(R"R(
+      AcceptIntoDummy<OuterStruct>(Load(R"""(
 doc:
   outer_value: 1.0
   inner_struct: [2.0, 3.0]
-)R")),
+)""")),
       std::runtime_error,
       "YAML node of type Map"
       " \\(with size 2 and keys \\{inner_struct, outer_value\\}\\)"

--- a/common/yaml/test/yaml_write_archive_defaults_test.cc
+++ b/common/yaml/test/yaml_write_archive_defaults_test.cc
@@ -41,9 +41,9 @@ TEST_F(YamlWriteArchiveDefaultsTest, BasicExample1) {
   OuterStruct data = defaults;
   data.outer_value = 3.0;
 
-  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"R(doc:
+  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"""(doc:
   outer_value: 3.0
-)R");
+)""");
 }
 
 // Shows the typical use -- that only the novel data is output.
@@ -56,10 +56,10 @@ TEST_F(YamlWriteArchiveDefaultsTest, BasicExample2) {
   OuterStruct data = defaults;
   data.inner_struct.inner_value = 3.0;
 
-  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"R(doc:
+  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"""(doc:
   inner_struct:
     inner_value: 3.0
-)R");
+)""");
 }
 
 // Same as the BasicExample1 from above, except that the map order of the
@@ -73,9 +73,9 @@ TEST_F(YamlWriteArchiveDefaultsTest, DifferentMapOrder1) {
   data.outer_value = 3.0;
   data.inner_struct.inner_value = defaults.inner_struct.inner_value;
 
-  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"R(doc:
+  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"""(doc:
   outer_value: 3.0
-)R");
+)""");
 }
 
 // Same as the BasicExample2 from above, except that the map order of the
@@ -89,10 +89,10 @@ TEST_F(YamlWriteArchiveDefaultsTest, DifferentMapOrder2) {
   data.outer_value = defaults.outer_value;
   data.inner_struct.inner_value = 3.0;
 
-  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"R(doc:
+  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"""(doc:
   inner_struct:
     inner_value: 3.0
-)R");
+)""");
 }
 
 // YAML nulls are handled reasonably, without throwing.
@@ -102,8 +102,8 @@ TEST_F(YamlWriteArchiveDefaultsTest, Nulls) {
 
   OptionalStruct defaults = data;
 
-  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"R(doc:
-)R");
+  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"""(doc:
+)""");
 }
 
 // Arrays differing in their values are not erased.
@@ -114,9 +114,9 @@ TEST_F(YamlWriteArchiveDefaultsTest, DifferentArrays) {
   ArrayStruct defaults;
   defaults.value = { 0.0, 0.0, 0.0 };
 
-  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"R(doc:
+  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"""(doc:
   value: [1.0, 2.0, 3.0]
-)R");
+)""");
 }
 
 // Vectors differing in size (but sharing a prefix) are not erased.
@@ -127,9 +127,9 @@ TEST_F(YamlWriteArchiveDefaultsTest, DifferentSizeVectors) {
   VectorStruct defaults;
   defaults.value = { 1.0, 2.0 };
 
-  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"R(doc:
+  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"""(doc:
   value: [1.0, 2.0, 3.0]
-)R");
+)""");
 }
 
 // Variants differing by tag are not erased.
@@ -140,10 +140,10 @@ TEST_F(YamlWriteArchiveDefaultsTest, DifferentVariantTag) {
   VariantStruct defaults;
   defaults.value = StringStruct{"1.0"};
 
-  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"R(doc:
+  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"""(doc:
   value: !DoubleStruct
     value: 1.0
-)R");
+)""");
 }
 
 // Maps differing in key only (same value) are not erased.
@@ -154,10 +154,10 @@ TEST_F(YamlWriteArchiveDefaultsTest, DifferentMapKeys) {
   MapStruct defaults;
   defaults.value["b"] = 1.0;
 
-  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"R(doc:
+  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"""(doc:
   value:
     a: 1.0
-)R");
+)""");
 }
 
 // Maps differing in value only (same key) are not erased.
@@ -168,10 +168,10 @@ TEST_F(YamlWriteArchiveDefaultsTest, DifferentMapValues) {
   MapStruct defaults;
   defaults.value["a"] = 2.0;
 
-  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"R(doc:
+  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"""(doc:
   value:
     a: 1.0
-)R");
+)""");
 }
 
 // In the ununsual case that the user provided two different schemas to
@@ -185,9 +185,9 @@ TEST_F(YamlWriteArchiveDefaultsTest, DifferentSchemas) {
 
   ArrayStruct defaults;
 
-  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"R(doc:
+  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"""(doc:
   value: 1.0
-)R");
+)""");
 }
 
 // In the ununsual case that the user provided two different (but similar)
@@ -202,11 +202,11 @@ TEST_F(YamlWriteArchiveDefaultsTest, DifferentInnerSchemas) {
 
   OuterWithBlankInner defaults;
 
-  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"R(doc:
+  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"""(doc:
   outer_value: 1.0
   inner_struct:
     inner_value: 2.0
-)R");
+)""");
 }
 
 }  // namespace

--- a/common/yaml/test/yaml_write_archive_test.cc
+++ b/common/yaml/test/yaml_write_archive_test.cc
@@ -67,9 +67,9 @@ TEST_F(YamlWriteArchiveTest, StdArray) {
     EXPECT_EQ(Save(x), expected);
   };
 
-  test({1.0, 2.0, 3.0}, R"R(doc:
+  test({1.0, 2.0, 3.0}, R"""(doc:
   value: [1.0, 2.0, 3.0]
-)R");
+)""");
 }
 
 TEST_F(YamlWriteArchiveTest, StdVector) {
@@ -81,13 +81,13 @@ TEST_F(YamlWriteArchiveTest, StdVector) {
 
   // When the vector items are simple YAML scalars, we should use
   // "flow" style, where they all appear on a single line.
-  test({}, R"R(doc:
+  test({}, R"""(doc:
   value: []
-)R");
+)""");
 
-  test({1.0, 2.0, 3.0}, R"R(doc:
+  test({1.0, 2.0, 3.0}, R"""(doc:
   value: [1.0, 2.0, 3.0]
-)R");
+)""");
 
   // When the vector items are not simple scalars, we should use
   // "block" style, where each gets its own line(s).
@@ -96,11 +96,11 @@ TEST_F(YamlWriteArchiveTest, StdVector) {
     {.value = "foo"},
     {.value = "bar"},
   };
-  EXPECT_EQ(Save(x), R"R(doc:
+  EXPECT_EQ(Save(x), R"""(doc:
   value:
     - value: foo
     - value: bar
-)R");
+)""");
 }
 
 TEST_F(YamlWriteArchiveTest, StdMap) {
@@ -110,20 +110,20 @@ TEST_F(YamlWriteArchiveTest, StdMap) {
     EXPECT_EQ(Save(x), expected);
   };
 
-  test({}, R"R(doc:
+  test({}, R"""(doc:
   value: {}
-)R");
+)""");
 
-  test({{"foo", 0.0}}, R"R(doc:
+  test({{"foo", 0.0}}, R"""(doc:
   value:
     foo: 0.0
-)R");
+)""");
 
-  test({{"foo", 0.0}, {"bar", 1.0}}, R"R(doc:
+  test({{"foo", 0.0}, {"bar", 1.0}}, R"""(doc:
   value:
     bar: 1.0
     foo: 0.0
-)R");
+)""");
 }
 
 
@@ -147,7 +147,7 @@ TEST_F(YamlWriteArchiveTest, StdUnorderedMap) {
     {"charlie", 2.0},
     {"bravo", 1.0},
     {"alpha", 0.0},
-  }, R"R(doc:
+  }, R"""(doc:
   value:
     alpha: 0.0
     bravo: 1.0
@@ -156,7 +156,7 @@ TEST_F(YamlWriteArchiveTest, StdUnorderedMap) {
     echo: 4.0
     fox: 5.0
     gulf: 6.0
-)R");
+)""");
 }
 
 TEST_F(YamlWriteArchiveTest, Optional) {
@@ -196,9 +196,9 @@ TEST_F(YamlWriteArchiveTest, EigenVector) {
     EXPECT_EQ(Save(x3), expected);
   };
 
-  test(Eigen::Vector3d(1.0, 2.0, 3.0), R"R(doc:
+  test(Eigen::Vector3d(1.0, 2.0, 3.0), R"""(doc:
   value: [1.0, 2.0, 3.0]
-)R");
+)""");
 }
 
 TEST_F(YamlWriteArchiveTest, EigenVectorX) {
@@ -208,12 +208,12 @@ TEST_F(YamlWriteArchiveTest, EigenVectorX) {
     EXPECT_EQ(Save(x), expected);
   };
 
-  test(Eigen::VectorXd(), R"R(doc:
+  test(Eigen::VectorXd(), R"""(doc:
   value: []
-)R");
-  test(Eigen::Matrix<double, 1, 1>(1.0), R"R(doc:
+)""");
+  test(Eigen::Matrix<double, 1, 1>(1.0), R"""(doc:
   value: [1.0]
-)R");
+)""");
 }
 
 TEST_F(YamlWriteArchiveTest, EigenMatrix) {
@@ -226,12 +226,12 @@ TEST_F(YamlWriteArchiveTest, EigenMatrix) {
   };
 
   test((Matrix34d{} << 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11).finished(),
-       R"R(doc:
+       R"""(doc:
   value:
     - [0.0, 1.0, 2.0, 3.0]
     - [4.0, 5.0, 6.0, 7.0]
     - [8.0, 9.0, 10.0, 11.0]
-)R");
+)""");
 }
 
 TEST_F(YamlWriteArchiveTest, Nested) {
@@ -240,11 +240,11 @@ TEST_F(YamlWriteArchiveTest, Nested) {
   x.outer_value = 1.0;
 
   const std::string saved = Save(x);
-  const std::string expected = R"R(doc:
+  const std::string expected = R"""(doc:
   outer_value: 1.0
   inner_struct:
     inner_value: 2.0
-)R";
+)""";
   EXPECT_EQ(saved, expected);
 }
 
@@ -253,10 +253,10 @@ TEST_F(YamlWriteArchiveTest, BlankInner) {
   x.outer_value = 1.0;
 
   const std::string saved = Save(x);
-  const std::string expected = R"R(doc:
+  const std::string expected = R"""(doc:
   outer_value: 1.0
   inner_struct: {}
-)R";
+)""";
   EXPECT_EQ(saved, expected);
 }
 

--- a/geometry/render/gl_renderer/render_engine_gl.cc
+++ b/geometry/render/gl_renderer/render_engine_gl.cc
@@ -48,7 +48,7 @@ RenderEngineGl::RenderEngineGl()
   // The vertex shader computes two pieces of information per vertex: its
   // transformed position and its depth. Both get linearly interpolated across
   // the rasterized triangle's fragments.
-  const string kDepthVertexShader = R"__(
+  const string kDepthVertexShader = R"""(
 #version 330
 
 layout(location = 0) in vec3 p_Model;
@@ -60,13 +60,13 @@ void main() {
   vec4 p_Camera = model_view_matrix * vec4(p_Model, 1);
   depth = -p_Camera.z;
   gl_Position = projection_matrix * p_Camera;
-})__";
+})""";
 
   // The fragment shader "clamps" the depth of the fragment to the specified
   // sensor range. Values closer than depth_z_near are set to zero, values
   // farther than depth_z_far are pushed to infinity. This "clamped" depth value
   // gets written to the frame buffer.
-  const string kDepthFragmentShader = R"__(
+  const string kDepthFragmentShader = R"""(
 #version 330
 
 in float depth;
@@ -93,13 +93,13 @@ void main() {
     encoded_depth = pos_infinity;
   else
     encoded_depth = depth;
-})__";
+})""";
 
   // The vertex shader simply transforms the vertices. Strictly speaking, we
   // could combine modelview and projection matrices into a single transform,
   // but there's no real value in doing so. Leaving it as is maintains
   // compatibility with the depth shader.
-  const std::string kLabelVertexShader = R"__(
+  const std::string kLabelVertexShader = R"""(
 #version 330
 layout(location = 0) in vec3 p_Model;
 uniform mat4 model_view_matrix;
@@ -107,17 +107,17 @@ uniform mat4 projection_matrix;
 void main() {
   vec4 p_Camera = model_view_matrix * vec4(p_Model, 1);
   gl_Position = projection_matrix * p_Camera;
-})__";
+})""";
 
   // For each fragment from a geometry, it simply colors the fragment with the
   // provided label encoded as an RGBA color.
-  const std::string kLabelFragmentShader = R"__(
+  const std::string kLabelFragmentShader = R"""(
 #version 330
 out vec4 color;
 uniform vec4 encoded_label;
 void main() {
   color = encoded_label;
-})__";
+})""";
 
   shader_programs_[kLabel].LoadFromSources(kLabelVertexShader,
                                            kLabelFragmentShader);

--- a/geometry/render/gl_renderer/test/shader_program_test.cc
+++ b/geometry/render/gl_renderer/test/shader_program_test.cc
@@ -16,21 +16,21 @@ namespace render {
 namespace internal {
 namespace {
 
-constexpr char kVertexSource[] = R"_(
+constexpr char kVertexSource[] = R"""(
   #version 330
   void main() {
     gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
   }
-)_";
+)""";
 
-constexpr char kFragmentSource[] = R"_(
+constexpr char kFragmentSource[] = R"""(
   #version 330
   uniform float test_uniform;
   uniform vec4 test_uniform4;
   void main() {
     gl_FragColor = vec4(0.18, 0.54, 0.34, test_uniform) + test_uniform4;
   }
-)_";
+)""";
 
 }  // namespace
 
@@ -123,11 +123,11 @@ TEST_F(ShaderProgramTest, LoadShadersError) {
     // function from the fragment shader as documented here:
     // https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glLinkProgram.xhtml
     DRAKE_EXPECT_THROWS_MESSAGE(
-        program.LoadFromSources(kVertexSource, R"_(
+        program.LoadFromSources(kVertexSource, R"""(
             #version 100
             void foo() {
               gl_FragColor = vec4(0.1, 0.2, 0.3, 1.0);
-            })_"),
+            })"""),
         std::runtime_error, "Error linking shaders[^]+");
   }
 

--- a/geometry/render/gl_renderer/test/shape_meshes_test.cc
+++ b/geometry/render/gl_renderer/test/shape_meshes_test.cc
@@ -67,7 +67,7 @@ GTEST_TEST(LoadMeshFromObjTest, TriangulatePolygons) {
           o──────o
           6      7
   */
-  std::stringstream in_stream(R"_(
+  std::stringstream in_stream(R"""(
   v -1 -1 0
   v 1 -1 0
   v 2 1 0
@@ -77,7 +77,7 @@ GTEST_TEST(LoadMeshFromObjTest, TriangulatePolygons) {
   v 1 -2 0
   f 1 2 3 4 5
   f 6 7 2 1
-  )_");
+  )""");
   auto [vertices, indices] = LoadMeshFromObj(&in_stream);
   EXPECT_EQ(vertices.rows(), 7);
   EXPECT_EQ(indices.rows(), 5);
@@ -100,7 +100,7 @@ GTEST_TEST(LoadMeshFromObjTest, PreserveTriangulation) {
           o──────o
           6      7
   */
-  std::stringstream in_stream(R"_(
+  std::stringstream in_stream(R"""(
   v -1 -1 0
   v 1 -1 0
   v 2 1 0
@@ -113,7 +113,7 @@ GTEST_TEST(LoadMeshFromObjTest, PreserveTriangulation) {
   f 3 4 5
   f 1 6 7
   f 1 7 2
-  )_");
+  )""");
   auto [vertices, indices] = LoadMeshFromObj(&in_stream);
   EXPECT_EQ(vertices.rows(), 7);
   EXPECT_EQ(indices.rows(), 5);
@@ -131,7 +131,7 @@ GTEST_TEST(LoadMeshFromObjTest, NoMeshOptimization) {
     1, 6  o───────o 2
 
   */
-  std::stringstream in_stream(R"_(
+  std::stringstream in_stream(R"""(
   v -1 -1 0  # First four corners form a box around the origin.
   v 1 -1 0
   v 1 1 0
@@ -140,7 +140,7 @@ GTEST_TEST(LoadMeshFromObjTest, NoMeshOptimization) {
   v -1 -1 0  # Duplpicate of vertex 1
   f 1 2 3
   f 6 3 4
-  )_");
+  )""");
   auto [vertices, indices] = LoadMeshFromObj(&in_stream);
   EXPECT_EQ(vertices.rows(), 6);
   EXPECT_EQ(indices.rows(), 2);

--- a/geometry/render/shaders/depth_shaders.h
+++ b/geometry/render/shaders/depth_shaders.h
@@ -10,7 +10,7 @@ namespace shaders {
 //   //VTK::System::Dec
 /** A vertex shader program for rendering depth images, which computes vertices
  and normals for the fragment shader program coming after. */
-constexpr char kDepthVS[] = R"__(
+constexpr char kDepthVS[] = R"""(
     //VTK::System::Dec
     attribute vec4 vertexMC;
     uniform mat4 MCDCMatrix;
@@ -20,7 +20,7 @@ constexpr char kDepthVS[] = R"__(
       vertexVCVSOutput = MCVCMatrix * vertexMC;
       gl_Position = MCDCMatrix * vertexMC;
     }
-)__";
+)""";
 
 // TODO(SeanCurtis-TRI): Investigate rendering directly to a one-channel,
 //  32-bit float image so that the encoding isn't necessary.
@@ -43,7 +43,7 @@ constexpr char kDepthVS[] = R"__(
  The reason is that we need to set one to alpha channel so that the rendered
  "image" will be opaque. Otherwise, we will have different colors from what
  we output here, thus expect, in the end.  */
-constexpr char kDepthFS[] = R"__(
+constexpr char kDepthFS[] = R"""(
     //VTK::System::Dec
     //VTK::Output::Dec
     varying vec4 vertexVCVSOutput;
@@ -109,7 +109,7 @@ constexpr char kDepthFS[] = R"__(
       }
       color_out = vec4(res, 1.);
     }
-)__";
+)""";
 
 }  // namespace shaders
 }  // namespace render

--- a/multibody/parsing/test/detail_scene_graph_test.cc
+++ b/multibody/parsing/test/detail_scene_graph_test.cc
@@ -1018,7 +1018,7 @@ GTEST_TEST(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
   // It contains a `{}` place holder such that child tags of <collision> can be
   // injected to test various expressions of collision properties --
   // substitution via fmt::format.
-  const std::string collision_xml = R"_(
+  const std::string collision_xml = R"""(
 <collision name="some_geo">
   <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
   <geometry>
@@ -1027,7 +1027,7 @@ GTEST_TEST(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
     </plane>
   </geometry>{}
 </collision>
-)_";
+)""";
 
   auto make_sdf_collision = [&collision_xml](const char* material_string) {
     return MakeSdfCollisionFromString(
@@ -1057,14 +1057,14 @@ GTEST_TEST(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
   // confirm that all of the basic tags get parsed and focus on the logic that
   // is unique to `MakeProximityPropertiesForCollision()`.
   {
-    unique_ptr<sdf::Collision> sdf_collision = make_sdf_collision(R"_(
+    unique_ptr<sdf::Collision> sdf_collision = make_sdf_collision(R"""(
   <drake:proximity_properties>
     <drake:mesh_resolution_hint>2.5</drake:mesh_resolution_hint>
     <drake:elastic_modulus>3.5</drake:elastic_modulus>
     <drake:hunt_crossley_dissipation>4.5</drake:hunt_crossley_dissipation>
     <drake:mu_dynamic>4.5</drake:mu_dynamic>
     <drake:mu_static>4.75</drake:mu_static>
-  </drake:proximity_properties>)_");
+  </drake:proximity_properties>)""");
     ProximityProperties properties =
         MakeProximityPropertiesForCollision(*sdf_collision);
     assert_single_property(properties, geometry::internal::kHydroGroup,
@@ -1078,10 +1078,10 @@ GTEST_TEST(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
 
   // Case: specifies rigid hydroelastic.
   {
-    unique_ptr<sdf::Collision> sdf_collision = make_sdf_collision(R"_(
+    unique_ptr<sdf::Collision> sdf_collision = make_sdf_collision(R"""(
   <drake:proximity_properties>
     <drake:rigid_hydroelastic/>
-  </drake:proximity_properties>)_");
+  </drake:proximity_properties>)""");
     ProximityProperties properties =
         MakeProximityPropertiesForCollision(*sdf_collision);
     ASSERT_TRUE(properties.HasProperty(geometry::internal::kHydroGroup,
@@ -1093,10 +1093,10 @@ GTEST_TEST(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
 
   // Case: specifies soft hydroelastic.
   {
-    unique_ptr<sdf::Collision> sdf_collision = make_sdf_collision(R"_(
+    unique_ptr<sdf::Collision> sdf_collision = make_sdf_collision(R"""(
   <drake:proximity_properties>
     <drake:soft_hydroelastic/>
-  </drake:proximity_properties>)_");
+  </drake:proximity_properties>)""");
     ProximityProperties properties =
         MakeProximityPropertiesForCollision(*sdf_collision);
     ASSERT_TRUE(properties.HasProperty(geometry::internal::kHydroGroup,
@@ -1108,11 +1108,11 @@ GTEST_TEST(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
 
   // Case: specifies both -- should be an error.
   {
-    unique_ptr<sdf::Collision> sdf_collision = make_sdf_collision(R"_(
+    unique_ptr<sdf::Collision> sdf_collision = make_sdf_collision(R"""(
   <drake:proximity_properties>
     <drake:rigid_hydroelastic/>
     <drake:soft_hydroelastic/>
-  </drake:proximity_properties>)_");
+  </drake:proximity_properties>)""");
     DRAKE_EXPECT_THROWS_MESSAGE(
         MakeProximityPropertiesForCollision(*sdf_collision),
         std::runtime_error,
@@ -1123,7 +1123,7 @@ GTEST_TEST(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
   // Case: has no drake coefficients, only mu & m2 in ode: contains mu, mu2
   // friction.
   {
-    unique_ptr<sdf::Collision> sdf_collision = make_sdf_collision(R"_(
+    unique_ptr<sdf::Collision> sdf_collision = make_sdf_collision(R"""(
   <surface>
     <friction>
       <ode>
@@ -1131,7 +1131,7 @@ GTEST_TEST(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
         <mu2>0.3</mu2>
       </ode>
     </friction>
-  </surface>)_");
+  </surface>)""");
     ProximityProperties properties =
         MakeProximityPropertiesForCollision(*sdf_collision);
     assert_friction(properties, {0.8, 0.3});
@@ -1140,7 +1140,7 @@ GTEST_TEST(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
   // Case: has both ode (mu, mu2) and drake (dynamic): contains
   // drake::mu_dynamic wins.
   {
-    unique_ptr<sdf::Collision> sdf_collision = make_sdf_collision(R"_(
+    unique_ptr<sdf::Collision> sdf_collision = make_sdf_collision(R"""(
   <drake:proximity_properties>
     <drake:mu_dynamic>0.3</drake:mu_dynamic>
   </drake:proximity_properties>
@@ -1151,7 +1151,7 @@ GTEST_TEST(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
         <mu2>1.3</mu2>
       </ode>
     </friction>
-  </surface>)_");
+  </surface>)""");
     ProximityProperties properties =
         MakeProximityPropertiesForCollision(*sdf_collision);
     assert_friction(properties, {0.3, 0.3});

--- a/multibody/parsing/test/detail_urdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_urdf_geometry_test.cc
@@ -206,13 +206,13 @@ GTEST_TEST(DetailUrdfGeometryTest, AddMaterialToMaterialMap) {
 // <collision> tag.
 unique_ptr<XMLDocument> MakeCollisionDocFromString(
     const std::string& collision_spec) {
-  const std::string urdf_harness = R"_(
+  const std::string urdf_harness = R"""(
 <?xml version="1.0"?>
   <collision>
     <geometry>
       <box size=".1 .2 .3"/>
     </geometry>{}
-  </collision>)_";
+  </collision>)""";
   const std::string urdf = fmt::format(urdf_harness, collision_spec);
   auto doc = make_unique<XMLDocument>();
   doc->Parse(urdf.c_str());
@@ -555,14 +555,14 @@ TEST_F(UrdfGeometryTests, CollisionProperties) {
   // confirm that all of the basic tags get parsed and focus on the logic that
   // is unique to `ParseCollision()`.
   {
-    unique_ptr<XMLDocument> doc = MakeCollisionDocFromString(R"_(
+    unique_ptr<XMLDocument> doc = MakeCollisionDocFromString(R"""(
   <drake:proximity_properties>
     <drake:mesh_resolution_hint value="2.5"/>
     <drake:elastic_modulus value="3.5" />
     <drake:hunt_crossley_dissipation value="3.5" />
     <drake:mu_dynamic value="3.25" />
     <drake:mu_static value="3.5" />
-  </drake:proximity_properties>)_");
+  </drake:proximity_properties>)""");
     const XMLElement* collision_node = doc->FirstChildElement("collision");
     ASSERT_NE(collision_node, nullptr);
     GeometryInstance instance =
@@ -580,10 +580,10 @@ TEST_F(UrdfGeometryTests, CollisionProperties) {
 
   // Case: specifies rigid hydroelastic.
   {
-    unique_ptr<XMLDocument> doc = MakeCollisionDocFromString(R"_(
+    unique_ptr<XMLDocument> doc = MakeCollisionDocFromString(R"""(
   <drake:proximity_properties>
     <drake:rigid_hydroelastic/>
-  </drake:proximity_properties>)_");
+  </drake:proximity_properties>)""");
     const XMLElement* collision_node = doc->FirstChildElement("collision");
     ASSERT_NE(collision_node, nullptr);
     GeometryInstance instance =
@@ -599,10 +599,10 @@ TEST_F(UrdfGeometryTests, CollisionProperties) {
 
   // Case: specifies soft hydroelastic.
   {
-    unique_ptr<XMLDocument> doc = MakeCollisionDocFromString(R"_(
+    unique_ptr<XMLDocument> doc = MakeCollisionDocFromString(R"""(
   <drake:proximity_properties>
     <drake:soft_hydroelastic/>
-  </drake:proximity_properties>)_");
+  </drake:proximity_properties>)""");
     const XMLElement* collision_node = doc->FirstChildElement("collision");
     ASSERT_NE(collision_node, nullptr);
     GeometryInstance instance =
@@ -618,11 +618,11 @@ TEST_F(UrdfGeometryTests, CollisionProperties) {
 
   // Case: specifies both -- should be an error.
   {
-    unique_ptr<XMLDocument> doc = MakeCollisionDocFromString(R"_(
+    unique_ptr<XMLDocument> doc = MakeCollisionDocFromString(R"""(
   <drake:proximity_properties>
     <drake:soft_hydroelastic/>
     <drake:rigid_hydroelastic/>
-  </drake:proximity_properties>)_");
+  </drake:proximity_properties>)""");
     const XMLElement* collision_node = doc->FirstChildElement("collision");
     ASSERT_NE(collision_node, nullptr);
     DRAKE_EXPECT_THROWS_MESSAGE(
@@ -637,11 +637,11 @@ TEST_F(UrdfGeometryTests, CollisionProperties) {
   // Case: has no drake:proximity_properties coefficients, only drake_compliance
   // coeffs.
   {
-    unique_ptr<XMLDocument> doc = MakeCollisionDocFromString(R"_(
+    unique_ptr<XMLDocument> doc = MakeCollisionDocFromString(R"""(
   <drake_compliance>
     <static_friction>3.5</static_friction>
     <dynamic_friction>2.5</dynamic_friction>
-  </drake_compliance>)_");
+  </drake_compliance>)""");
     const XMLElement* collision_node = doc->FirstChildElement("collision");
     ASSERT_NE(collision_node, nullptr);
     GeometryInstance instance =
@@ -653,14 +653,14 @@ TEST_F(UrdfGeometryTests, CollisionProperties) {
 
   // Case: has both drake_compliance and drake:proximity_properties;
   // drake:proximity_properties wins.
-  unique_ptr<XMLDocument> doc = MakeCollisionDocFromString(R"_(
+  unique_ptr<XMLDocument> doc = MakeCollisionDocFromString(R"""(
   <drake_compliance>
     <static_friction>3.5</static_friction>
     <dynamic_friction>2.5</dynamic_friction>
   </drake_compliance>
   <drake:proximity_properties>
     <drake:mu_dynamic value="4.5" />
-  </drake:proximity_properties>)_");
+  </drake:proximity_properties>)""");
   const XMLElement* collision_node = doc->FirstChildElement("collision");
   ASSERT_NE(collision_node, nullptr);
   GeometryInstance instance =

--- a/systems/framework/system_html.cc
+++ b/systems/framework/system_html.cc
@@ -200,7 +200,7 @@ class LinkWriter : public SystemVisitor<double> {
 
 std::string GenerateHtml(const System<double>& system, int initial_depth) {
   std::stringstream html;
-  html << R"!(
+  html << R"""(
 <div style='height:400px;' id='myDiagramDiv'>
 The implementation of GenerateHtml has been temporarily removed from Drake due
 to licensing restrictions.
@@ -346,24 +346,24 @@ to licensing restrictions.
     linkFromPortIdProperty: "fromPort", // required information:
     linkToPortIdProperty: "toPort", // identifies data property names
     nodeDataArray: [
-)!";
+)""";
 
   NodeWriter node_writer("", &html, initial_depth);
   system.Accept(&node_writer);
 
-  html << R"!(
+  html << R"""(
     ],
     linkDataArray: [
-)!";
+)""";
 
   LinkWriter link_writer(&html);
   system.Accept(&link_writer);
 
-  html << R"!(
+  html << R"""(
     ]
   });
 </script>
-)!";
+)""";
   return html.str();
 }
 

--- a/tools/vector_gen/test/sample_test.cc
+++ b/tools/vector_gen/test/sample_test.cc
@@ -212,13 +212,13 @@ GTEST_TEST(SampleTest, SymbolicIsValid) {
 
 // Cover Serialize and its relationship to YAML.
 GTEST_TEST(SampleTest, YamlTest) {
-  const std::string yaml_text = R"R(
+  const std::string yaml_text = R"""(
 values:
   x: 0
   two_word: -1
   absone: 0.25
   unset: 99e9
-)R";
+)""";
   const YAML::Node yaml_node = YAML::Load(yaml_text);
   Sample<double> dut;
   drake::yaml::YamlReadArchive(yaml_node["values"]).Accept(&dut);


### PR DESCRIPTION
To help naive readers better understand this unusual construction, we'll use a marker similar to Python's multi-line literal and apply the style uniformly across the codebase.

Relates #13699.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13811)
<!-- Reviewable:end -->
