### PR TITLE
schema: Incorporate some Anzu nit fixes

### DIFF
--- a/common/schema/dev/stochastic.cc
+++ b/common/schema/dev/stochastic.cc
@@ -1,7 +1,7 @@
 #include "drake/common/schema/dev/stochastic.h"
 
 #include <stdexcept>
-#include <type_traits>
+#include <utility>
 
 #include <fmt/format.h>
 

--- a/common/schema/dev/stochastic.h
+++ b/common/schema/dev/stochastic.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <memory>
-#include <utility>
+#include <type_traits>
 #include <variant>
 #include <vector>
 

--- a/common/schema/dev/test/stochastic_test.cc
+++ b/common/schema/dev/test/stochastic_test.cc
@@ -18,6 +18,10 @@ namespace drake {
 namespace schema {
 namespace {
 
+// TODO(jeremy.nimmer) We can remove this argument from the call sites below
+// once Drake's YamlReadArchive constructor default changes to be strict.
+constexpr YamlReadArchive::Options kStrict;
+
 struct DistributionStruct {
   std::vector<DistributionVariant> vec;
 
@@ -65,7 +69,7 @@ void CheckUniformDiscreteSymbolic(
 
 GTEST_TEST(StochasticTest, ScalarTest) {
   DistributionStruct variants;
-  YamlReadArchive(YAML::Load(all_variants)).Accept(&variants);
+  YamlReadArchive(YAML::Load(all_variants), kStrict).Accept(&variants);
 
   RandomGenerator generator;
 
@@ -142,7 +146,7 @@ GTEST_TEST(StochasticTest, ScalarTest) {
   EXPECT_PRED2(ExprEqual, symbolic_vec(4), 3.2);
 
   // Try loading a value which looks like an ordinary vector.
-  YamlReadArchive(YAML::Load(floats)).Accept(&variants);
+  YamlReadArchive(YAML::Load(floats), kStrict).Accept(&variants);
   vec = Sample(variants.vec, &generator);
   ASSERT_EQ(vec.size(), 3);
   EXPECT_TRUE(CompareMatrices(vec, Eigen::Vector3d(5.0, 6.1, 7.2)));
@@ -184,7 +188,7 @@ uniform_scalar: !Uniform { min: 1, max: 2 }
 
 GTEST_TEST(StochasticTest, VectorTest) {
   DistributionVectorStruct variants;
-  YamlReadArchive(YAML::Load(vector_variants)).Accept(&variants);
+  YamlReadArchive(YAML::Load(vector_variants), kStrict).Accept(&variants);
 
   RandomGenerator generator;
 


### PR DESCRIPTION
This copies into Drake some small fixups that have been applied in Anzu since these files were originally forked.

Relates #13251.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13822)
<!-- Reviewable:end -->
