### PR TITLE
setup: Export all of the package list txt files

### DIFF
--- a/setup/BUILD.bazel
+++ b/setup/BUILD.bazel
@@ -8,7 +8,11 @@ package(default_visibility = ["//visibility:public"])
 # Make our package requirements (but not manual scripts) available to
 # downstream projects.
 exports_files([
+    "ubuntu/source_distribution/packages-bionic-maintainer_only.txt",
+    "ubuntu/source_distribution/packages-bionic-test-only.txt",
     "ubuntu/source_distribution/packages-bionic.txt",
+    "ubuntu/source_distribution/packages-focal-maintainer-only.txt",
+    "ubuntu/source_distribution/packages-focal-test-only.txt",
     "ubuntu/source_distribution/packages-focal.txt",
     "ubuntu/binary_distribution/packages-bionic.txt",
     "ubuntu/binary_distribution/packages-focal.txt",


### PR DESCRIPTION
We missed this in 06604c29e3c9c276646b0a5a7fbfd651d8e7049b (#13753).

TRI's Anzu needs the full lists to slurp it into our setup procedures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13827)
<!-- Reviewable:end -->
