### PR TITLE
examples: Deprecate IRB140 and big_robot_toy models

### DIFF
--- a/examples/irb140/README.md
+++ b/examples/irb140/README.md
@@ -1,3 +1,5 @@
+**WARNING** All of the files (*.urdf models and *.obj meshes) in this package
+are deprecated and will be removed on 2020-11-01.
 
 This directory contains model files for the IRB140.
 

--- a/examples/kuka_iiwa_arm/models/objects/README.md
+++ b/examples/kuka_iiwa_arm/models/objects/README.md
@@ -1,0 +1,2 @@
+**WARNING** The `big_robot_toy` (*.urdf model and *.obj mesh) is deprecated and
+will be removed on 2020-11-01.


### PR DESCRIPTION
These are unused, untested, and have large meshes that do not follow the `RobotLocomotion/models` policy (#11913).  Git remembers.

Drake is not a clearinghouse for models, it's a repository of software.  All model files on master should be actively used by some demo or test case.

This is short-changing the 3-months-round-up rule of thumb by one week, but given that it's only removing some data files that are easy to copy for any users who still need these, I'd rather keep the more aggressive timeline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13831)
<!-- Reviewable:end -->
