### PR TITLE
pydrake: Respect mesh scaling in PlanarSceneGraphVisualizer

### DIFF
--- a/bindings/pydrake/systems/planar_scenegraph_visualizer.py
+++ b/bindings/pydrake/systems/planar_scenegraph_visualizer.py
@@ -267,7 +267,9 @@ class PlanarSceneGraphVisualizer(PyPlotVisualizer):
                     if not os.path.exists(filename):
                         raise FileNotFoundError(errno.ENOENT, os.strerror(
                             errno.ENOENT), filename)
-                    mesh = ReadObjToSurfaceMesh(filename)
+                    # Get mesh scaling.
+                    scale = geom.float_data[0]
+                    mesh = ReadObjToSurfaceMesh(filename, scale)
                     patch_G = np.vstack([v.r_MV() for v in mesh.vertices()]).T
 
                 else:

--- a/bindings/pydrake/systems/test/planar_scenegraph_visualizer_test.py
+++ b/bindings/pydrake/systems/test/planar_scenegraph_visualizer_test.py
@@ -139,12 +139,12 @@ class TestPlanarSceneGraphVisualizer(unittest.TestCase):
         This test ensures we can load obj files or provide a reasonable error
         message.
         """
-        def scene_graph_with_mesh(filename):
+        def scene_graph_with_mesh(filename, scale=1.0):
             builder = DiagramBuilder()
             mbp, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.0)
             world_body = mbp.world_body()
 
-            mesh_shape = Mesh(filename)
+            mesh_shape = Mesh(filename, scale=scale)
             mesh_body = mbp.AddRigidBody("mesh", SpatialInertia(
                 mass=1.0, p_PScm_E=np.array([0., 0., 0.]),
                 G_SP_E=UnitInertia(1.0, 1.0, 1.0)))
@@ -184,6 +184,13 @@ class TestPlanarSceneGraphVisualizer(unittest.TestCase):
         scene_graph = scene_graph_with_mesh("garbage.STL")
         with self.assertRaises(RuntimeError):
             PlanarSceneGraphVisualizer(scene_graph)
+
+        # This should load correctly and yield a very large patch.
+        scene_graph = scene_graph_with_mesh(mesh_name, 1e3)
+        visualizer = PlanarSceneGraphVisualizer(scene_graph)
+        _, _, width, height = visualizer.ax.dataLim.bounds
+        self.assertTrue(width > 10.0)
+        self.assertTrue(height > 10.0)
 
     def testConnectPlanarSceneGraphVisualizer(self):
         """Cart-Pole with simple geometry."""


### PR DESCRIPTION
Now meshes that are in mm shouldn't show up as enormous geometries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13836)
<!-- Reviewable:end -->
