### PR TITLE
Consolidate code for both bias and regular (unbias) spatial accelerations.

### DIFF
--- a/multibody/tree/frame.h
+++ b/multibody/tree/frame.h
@@ -50,6 +50,11 @@ class Frame : public FrameBase<T> {
     return body_;
   }
 
+  /// Returns true if `this` is the world frame.
+  bool is_world_frame() const {
+    return this->index() == FrameIndex(0);
+  }
+
   /// Returns the name of this frame. It may be empty if unnamed.
   const std::string& name() const {
     return name_;

--- a/multibody/tree/frame.h
+++ b/multibody/tree/frame.h
@@ -55,6 +55,12 @@ class Frame : public FrameBase<T> {
     return this->index() == FrameIndex(0);
   }
 
+  /// Returns true if `this` is the body frame.
+  bool is_body_frame() const {
+    return this->index() == body_.body_frame().index();
+  }
+
+
   /// Returns the name of this frame. It may be empty if unnamed.
   const std::string& name() const {
     return name_;

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -1331,7 +1331,7 @@ SpatialAcceleration<T> MultibodyTree<T>::CalcBiasSpatialAcceleration(
   // TODO(mitiguy) Allow with_respect_to be JacobianWrtVariable::kQDot.
   DRAKE_THROW_UNLESS(with_respect_to == JacobianWrtVariable::kV);
 
-  // Reserve room to store all the bodies spatial acceleration bias in world W.
+  // Reserve room to store all the bodies' spatial acceleration bias in world W.
   // TODO(Mitiguy) Inefficient use of heap. Per issue #13560, implement caching.
   std::vector<SpatialAcceleration<T>> AsBias_WB_all(num_bodies());
   CalcAllBodyBiasSpatialAccelerationsInWorld(context, with_respect_to,
@@ -1346,8 +1346,8 @@ SpatialAcceleration<T> MultibodyTree<T>::CalcBiasSpatialAcceleration(
   // Frame_A is regarded as fixed/welded to a body herein named body_A.
   // Extract body_A's spatial acceleration bias in W from AsBias_WB_all.
   const Body<T>& body_A = frame_A.body();
-  const SpatialAcceleration<T> AsBias_WBodyA_W = frame_A.is_world_frame() ?
-      SpatialAcceleration<T>::Zero() : AsBias_WB_all[body_A.node_index()];
+  const SpatialAcceleration<T> AsBias_WBodyA_W =
+      AsBias_WB_all[body_A.node_index()];
 
   // Calculate Bp's spatial acceleration bias in body_A, expressed in frame_E.
   return CalcSpatialAccelerationHelper(context, frame_B, p_BoBp_B, body_A,

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -2521,7 +2521,7 @@ class MultibodyTree {
   // mobilizer, even after Finalize().
   void AddQuaternionFreeMobilizerToAllBodiesWithNoMobilizer();
 
-  // For a frame Fp that is fixed/welded to a frame_F, this method helps form
+  // For a frame Fp that is fixed/welded to a frame_F, this method computes
   // A_AFp_E, Fp's spatial acceleration in a body_A, expressed in a frame_E.
   // @param[in] context Contains the state of the multibody system.
   // @param[in] frame_F Frame Fp is fixed/welded to frame_F and frame_F is
@@ -2534,7 +2534,7 @@ class MultibodyTree {
   //   expressed in W (body_B is the body to which frame_F is fixed/welded).
   // @param[in] A_WA_W The spatial acceleration of body_A in world frame W,
   //   expressed in W.
-  // @return A_AFp_E Fp's spatial acceleration in body_A, expressed in frame_E.
+  // @returns A_AFp_E Fp's spatial acceleration in body_A, expressed in frame_E.
   // @note To use this method for a bias spatial acceleration in world frame W,
   // expressed in W with respect to speeds 𝑠 (𝑠 = q̇ or 𝑠 = v), instead pass
   // A𝑠Bias_WB_W (body_B's bias spatial acceleration in W expressed in W) and
@@ -2550,10 +2550,10 @@ class MultibodyTree {
       const SpatialAcceleration<T>& A_WB_W,
       const SpatialAcceleration<T>& A_WA_W) const;
 
-  // For a frame Bp that is fixed to both a frame_B and a body_A, this method
+  // For a frame Bp fixed/welded to both a frame_B and a body_A, this method
   // shifts spatial acceleration in the world frame W from body_A to frame_Bp.
   // @param[in] frame_B A frame that is fixed/welded to body_A.
-  //            frame_Bp is regarded as fixed/welded to frame_B.
+  //            frame_Bp is fixed to frame_B, shifted by p_BoBp_B.
   // @param[in] p_BoBp_B Position vector from Bo (frame_B's origin) to the
   //            origin of frame_Bp, expressed in frame_B.
   // @param[in] A_WA_W body_A's spatial acceleration in W, expressed in W.

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -2521,23 +2521,54 @@ class MultibodyTree {
   // mobilizer, even after Finalize().
   void AddQuaternionFreeMobilizerToAllBodiesWithNoMobilizer();
 
-  // Shift bias spatial acceleration from the origin Ao of body A to a
-  // point Bp of (fixed to) a frame B, where frame B is fixed/welded to body A.
+  // For a point Bp fixed/welded to a frame_B, this helper method helps form
+  // A_ABp_E, Bp's spatial acceleration in a frame A, expressed in a frame_E.
+  // @param[in] context The state of the multibody system.
+  // @param[in] frame_B The frame on which point Bp is fixed/welded.
+  // @param[in] p_BoBp_B Position vector from Bo (frame_B's origin) to point Bp,
+  //   expressed in frame_B.
+  // @param[in] frame_A The frame that measures A_ABp_E.
+  // @param[in] frame_E The frame in which A_ABp_E is expressed on output.
+  // @param[in] A_WbodyB_W The spatial acceleration of body_B in world frame W,
+  //   expressed in W (bodyB is the body to which frame_B is fixed/welded).
+  // @param[in] A_WbodyA_W The spatial acceleration of body_A in world frame W,
+  //   expressed in W (bodyA is the body to which frame_A is fixed/welded).
+  // @return A_ABp_E Bp's spatial acceleration in frame_A, expressed in frame_E.
+  // @note To use this method for a bias spatial acceleration in world frame W,
+  // expressed in W with respect to speeds 𝑠 (𝑠 = q̇ or 𝑠 = v), instead pass
+  // A𝑠Bias_WbodyB_W (bodyB's bias spatial acceleration in W expressed in W) and
+  // A𝑠Bias_WbodyA_W (bodyA's bias spatial acceleration in W expressed in W),
+  // in which case the method returns A𝑠Bias_ABp_E (Bp's bias spatial
+  // acceleration in frame_A, expressed in frame_E, with respect to speeds 𝑠.
+  SpatialAcceleration<T> CalcSpatialAccelerationHelper(
+      const systems::Context<T>& context,
+      const Frame<T>& frame_B,
+      const Eigen::Ref<const Vector3<T>>& p_BoBp_B,
+      const Frame<T>& frame_A,
+      const Frame<T>& frame_E,
+      const SpatialAcceleration<T>& A_WbodyB_W,
+      const SpatialAcceleration<T>& A_WbodyA_W) const;
+
+  // For a frame_B that is fixed/welded to a body A, shift spatial acceleration
+  // in the world frame W from point Ao (body A's origin) to a point Bp of B.
   // @param[in] context The state of the multibody system.
   // @param[in] frame_B The frame on which point Bp is fixed/welded.
   // @param[in] p_BoBp_B Position vector from Bo (frame_B's origin) to a point
-  // Bp (regarded as fixed to B), expressed in frame_B.
-  // @param[in] body_A The body on which frame_B is fixed/welded.
-  // @param[in] A𝑠Bias_WA_W Point Ao's spatial acceleration bias in frame W
-  // with respect to speeds 𝑠 (𝑠 = q̇ or 𝑠 = v), expressed in the world frame W.
-  // @returns  A𝑠Bias_WBp_W Point Bp's spatial acceleration bias in frame W
-  // with respect to speeds 𝑠 (𝑠 = q̇ or 𝑠 = v), expressed in the world frame W.
-  SpatialAcceleration<T> ShiftSpatialAccelerationBiasInWorld(
+  //            Bp (regarded as fixed to both A and B), expressed in frame_B.
+  // @param[in] A_WAo_W Point Ao's spatial acceleration in the world frame W,
+  //            expressed in W.
+  // @returns A_WBp_W Point Bp's spatial acceleration in the world frame W,
+  //            expressed in W.
+  // @note To use this method for a bias spatial acceleration, instead pass
+  // A𝑠Bias_WAo_W (point Ao's bias spatial acceleration in the world frame W,
+  // expressed in W with respect to speeds 𝑠 (𝑠 = q̇ or 𝑠 = v)). It then returns
+  // A𝑠Bias_WBp_W (point Bp's bias spatial acceleration in W, expressed in W
+  // with respect to speeds 𝑠).
+  SpatialAcceleration<T> ShiftSpatialAccelerationInWorld(
       const systems::Context<T>& context,
-      const Body<T>& body_A,
       const Frame<T>& frame_B,
       const Eigen::Ref<const Vector3<T>>& p_BoBp_B,
-      const SpatialAcceleration<T>& AsBias_WA_W) const;
+      const SpatialAcceleration<T>& A_WAo_W) const;
 
   // For all bodies, calculate bias spatial acceleration in the world frame W.
   // @param[in] context The state of the multibody system.

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -2521,54 +2521,55 @@ class MultibodyTree {
   // mobilizer, even after Finalize().
   void AddQuaternionFreeMobilizerToAllBodiesWithNoMobilizer();
 
-  // For a point Bp fixed/welded to a frame_B, this helper method helps form
-  // A_ABp_E, Bp's spatial acceleration in a frame A, expressed in a frame_E.
-  // @param[in] context The state of the multibody system.
-  // @param[in] frame_B The frame on which point Bp is fixed/welded.
-  // @param[in] p_BoBp_B Position vector from Bo (frame_B's origin) to point Bp,
-  //   expressed in frame_B.
-  // @param[in] frame_A The frame that measures A_ABp_E.
-  // @param[in] frame_E The frame in which A_ABp_E is expressed on output.
-  // @param[in] A_WbodyB_W The spatial acceleration of body_B in world frame W,
-  //   expressed in W (bodyB is the body to which frame_B is fixed/welded).
-  // @param[in] A_WbodyA_W The spatial acceleration of body_A in world frame W,
-  //   expressed in W (bodyA is the body to which frame_A is fixed/welded).
-  // @return A_ABp_E Bp's spatial acceleration in frame_A, expressed in frame_E.
+  // For a frame Fp that is fixed/welded to a frame_F, this method helps form
+  // A_AFp_E, Fp's spatial acceleration in a body_A, expressed in a frame_E.
+  // @param[in] context Contains the state of the multibody system.
+  // @param[in] frame_F Frame Fp is fixed/welded to frame_F and frame_F is
+  //  fixed/welded to a body_B.
+  // @param[in] p_FoFp_F Position vector from Fo (frame_F's origin) to the
+  //   the origin of frame_Fp, expressed in frame_F.
+  // @param[in] body_A The rigid body whose body-frame measures A_AFp_E.
+  // @param[in] frame_E The frame in which A_AFp_E is expressed on output.
+  // @param[in] A_WB_W The spatial acceleration of body_B in world frame W,
+  //   expressed in W (body_B is the body to which frame_F is fixed/welded).
+  // @param[in] A_WA_W The spatial acceleration of body_A in world frame W,
+  //   expressed in W.
+  // @return A_AFp_E Fp's spatial acceleration in body_A, expressed in frame_E.
   // @note To use this method for a bias spatial acceleration in world frame W,
   // expressed in W with respect to speeds 𝑠 (𝑠 = q̇ or 𝑠 = v), instead pass
-  // A𝑠Bias_WbodyB_W (bodyB's bias spatial acceleration in W expressed in W) and
-  // A𝑠Bias_WbodyA_W (bodyA's bias spatial acceleration in W expressed in W),
-  // in which case the method returns A𝑠Bias_ABp_E (Bp's bias spatial
-  // acceleration in frame_A, expressed in frame_E, with respect to speeds 𝑠.
+  // A𝑠Bias_WB_W (body_B's bias spatial acceleration in W expressed in W) and
+  // A𝑠Bias_WA_W (body_A's bias spatial acceleration in W expressed in W),
+  // in which case the method returns A𝑠Bias_AFp_E (Fp's bias spatial
+  // acceleration in body_A, expressed in frame_E, with respect to speeds 𝑠.
   SpatialAcceleration<T> CalcSpatialAccelerationHelper(
       const systems::Context<T>& context,
-      const Frame<T>& frame_B,
-      const Eigen::Ref<const Vector3<T>>& p_BoBp_B,
-      const Frame<T>& frame_A,
+      const Frame<T>& frame_F,
+      const Eigen::Ref<const Vector3<T>>& p_FoFp_F,
+      const Body<T>& body_A,
       const Frame<T>& frame_E,
-      const SpatialAcceleration<T>& A_WbodyB_W,
-      const SpatialAcceleration<T>& A_WbodyA_W) const;
+      const SpatialAcceleration<T>& A_WB_W,
+      const SpatialAcceleration<T>& A_WA_W) const;
 
-  // For a frame_B that is fixed/welded to a body A, shift spatial acceleration
-  // in the world frame W from point Ao (body A's origin) to a point Bp of B.
-  // @param[in] context The state of the multibody system.
-  // @param[in] frame_B The frame on which point Bp is fixed/welded.
-  // @param[in] p_BoBp_B Position vector from Bo (frame_B's origin) to a point
-  //            Bp (regarded as fixed to both A and B), expressed in frame_B.
-  // @param[in] A_WAo_W Point Ao's spatial acceleration in the world frame W,
-  //            expressed in W.
-  // @returns A_WBp_W Point Bp's spatial acceleration in the world frame W,
-  //            expressed in W.
+  // For a frame Bp that is fixed to both a frame_B and a body_A, this method
+  // shifts spatial acceleration in the world frame W from body_A to frame_Bp.
+  // @param[in] frame_B A frame that is fixed/welded to body_A.
+  //            frame_Bp is regarded as fixed/welded to frame_B.
+  // @param[in] p_BoBp_B Position vector from Bo (frame_B's origin) to the
+  //            origin of frame_Bp, expressed in frame_B.
+  // @param[in] A_WA_W body_A's spatial acceleration in W, expressed in W.
+  // @param[in] pc Contains the position kinematics for this multibody system.
+  // @param[in] pc Contains the velocity kinematics for this multibody system.
+  // @returns A_WBp_W Frame Bp's spatial acceleration in W, expressed in W.
   // @note To use this method for a bias spatial acceleration, instead pass
-  // A𝑠Bias_WAo_W (point Ao's bias spatial acceleration in the world frame W,
-  // expressed in W with respect to speeds 𝑠 (𝑠 = q̇ or 𝑠 = v)). It then returns
-  // A𝑠Bias_WBp_W (point Bp's bias spatial acceleration in W, expressed in W
-  // with respect to speeds 𝑠).
+  // A𝑠Bias_WAo_W (body_A's bias spatial acceleration in W expressed in W with
+  // respect to speeds 𝑠 (𝑠 = q̇ or 𝑠 = v)). It then returns A𝑠Bias_WBp_W (point
+  // Bp's bias spatial acceleration in W, expressed in W with respect to 𝑠).
   SpatialAcceleration<T> ShiftSpatialAccelerationInWorld(
-      const systems::Context<T>& context,
       const Frame<T>& frame_B,
       const Eigen::Ref<const Vector3<T>>& p_BoBp_B,
-      const SpatialAcceleration<T>& A_WAo_W) const;
+      const SpatialAcceleration<T>& A_WA_W,
+      const PositionKinematicsCache<T>& pc,
+      const VelocityKinematicsCache<T>& vc) const;
 
   // For all bodies, calculate bias spatial acceleration in the world frame W.
   // @param[in] context The state of the multibody system.

--- a/multibody/tree/test/frames_test.cc
+++ b/multibody/tree/test/frames_test.cc
@@ -143,6 +143,19 @@ TEST_F(FrameTests, IsWorldFrameMethod) {
   EXPECT_TRUE(frame_W.is_world_frame());
 }
 
+TEST_F(FrameTests, IsBodyFrameMethod) {
+  EXPECT_TRUE(frameB_->is_body_frame());
+  EXPECT_FALSE(frameP_->is_body_frame());
+  EXPECT_FALSE(frameQ_->is_body_frame());
+  EXPECT_FALSE(frameR_->is_body_frame());
+  EXPECT_FALSE(frameS_->is_body_frame());
+  EXPECT_FALSE(frameSChild_->is_body_frame());
+  const Frame<double>& frame_W = tree().world_frame();
+  EXPECT_TRUE(frame_W.is_body_frame());
+  const Frame<double>& bodyB_frame = bodyB_->body_frame();
+  EXPECT_TRUE(bodyB_frame.is_body_frame());
+}
+
 // Verifies the BodyFrame methods to compute poses in different frames.
 TEST_F(FrameTests, BodyFrameCalcPoseMethods) {
   // Verify this method computes the pose X_BF of this frame F in the body

--- a/multibody/tree/test/frames_test.cc
+++ b/multibody/tree/test/frames_test.cc
@@ -132,6 +132,17 @@ class FrameTests : public ::testing::Test {
   math::RigidTransformd X_QG_;
 };
 
+TEST_F(FrameTests, IsWorldFrameMethod) {
+  EXPECT_FALSE(frameB_->is_world_frame());
+  EXPECT_FALSE(frameP_->is_world_frame());
+  EXPECT_FALSE(frameQ_->is_world_frame());
+  EXPECT_FALSE(frameR_->is_world_frame());
+  EXPECT_FALSE(frameS_->is_world_frame());
+  EXPECT_FALSE(frameSChild_->is_world_frame());
+  const Frame<double>& frame_W = tree().world_frame();
+  EXPECT_TRUE(frame_W.is_world_frame());
+}
+
 // Verifies the BodyFrame methods to compute poses in different frames.
 TEST_F(FrameTests, BodyFrameCalcPoseMethods) {
   // Verify this method computes the pose X_BF of this frame F in the body


### PR DESCRIPTION
This PR helps progress on issue #13754.
Much of the code created for CalcBiasSpatialAcceleration() is also useful for CalcSpatialAcceleration().  
I started by creating a large PR that implements both what is done in this PR (splitting generally useful spatial acceleration code from bias-only spatial acceleration code) as well as implementing new functionality for CalcSpatialAcceleration().  However, it was unnecessarily large and complex.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13838)
<!-- Reviewable:end -->
