### PR TITLE
Fix doc string in show_model.py

### DIFF
--- a/manipulation/util/show_model.py
+++ b/manipulation/util/show_model.py
@@ -30,7 +30,7 @@ remove the need for `--find_resource`:
 
     ./bazel-bin/manipulation/util/show_model \
         --meshcat default \
-        ${PWD}/manipulation/models/iiwa_description/sdf/iiwa7_no_collision.sdf
+        ${PWD}/manipulation/models/iiwa_description/sdf/iiwa14_no_collision.sdf
 
 Note:
     If `--meshcat` is not specified, no meshcat visualization will take


### PR DESCRIPTION
It was referring to a urdf file that does not exist

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13847)
<!-- Reviewable:end -->
