### PR TITLE
parsing: Disable $HOME/.sdformat/sdformat.log

### DIFF
--- a/tools/workspace/sdformat/no-console-file.patch
+++ b/tools/workspace/sdformat/no-console-file.patch
@@ -1,0 +1,26 @@
+Disable logging to $HOME/.sdformat/sdformat.log
+
+Once https://github.com/osrf/sdformat/issues/334 is resolved, we can
+probably remove this patch from Drake.
+
+This patch was created by `diff -u` on a v9.2.0 checkout of sdformat
+after editing the source file locally.
+
+--- a/src/Console.cc	2020-04-02 14:55:20.000000000 -0400
++++ b/src/Console.cc	2020-08-10 10:39:40.290726763 -0400
+@@ -45,6 +45,7 @@
+ Console::Console()
+   : dataPtr(new ConsolePrivate)
+ {
++#if 0
+   // Set up the file that we'll log to.
+ #ifndef _WIN32
+   const char *home = std::getenv("HOME");
+@@ -72,6 +73,7 @@
+   }
+   std::string logFile = sdf::filesystem::append(logDir, "sdformat.log");
+   this->dataPtr->logFileStream.open(logFile.c_str(), std::ios::out);
++#endif
+ }
+ 
+ //////////////////////////////////////////////////

--- a/tools/workspace/sdformat/repository.bzl
+++ b/tools/workspace/sdformat/repository.bzl
@@ -16,6 +16,10 @@ def sdformat_repository(
             # should remove it once we reach a new enough version, probably for
             # sdformat10 or so.
             "@drake//tools/workspace/sdformat:3bbd303.patch",
+            # Disable logging to $HOME/.sdformat/sdformat.log
+            # Once https://github.com/osrf/sdformat/issues/334 is resolved, we
+            # can probably remove this patch from Drake.
+            "@drake//tools/workspace/sdformat:no-console-file.patch",
         ],
         patch_args = ["-p1"],
         mirrors = mirrors,


### PR DESCRIPTION
Log messages still appear on `std::cerr`, just not in a file anymore.

Libraries should not unconditionally open non-standard files nor create non-standard directories.

This removes the "No HOME defined in the environment. Will not log." message when running tests in bazel's hermetic sandbox.

Relates #9087 and https://github.com/osrf/sdformat/issues/334.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13850)
<!-- Reviewable:end -->
