### PR TITLE
simulator: Warn about time jumps

### DIFF
--- a/examples/rimless_wheel/test/rimless_wheel_test.cc
+++ b/examples/rimless_wheel/test/rimless_wheel_test.cc
@@ -87,6 +87,7 @@ GTEST_TEST(RimlessWheelTest, StepTest) {
   set_thetadot_to_achieve_energy(rw, steady_state_energy, &context);
   state.set_thetadot(state.thetadot() + 0.2);
   double initial_energy = rw.CalcTotalEnergy(context);
+  simulator.Initialize();
   simulator.AdvanceTo(.2);
   // Theta should now be on the other side of zero.
   EXPECT_LT(state.theta(), 0.0);
@@ -103,6 +104,7 @@ GTEST_TEST(RimlessWheelTest, StepTest) {
   set_thetadot_to_achieve_energy(rw, steady_state_energy, &context);
   state.set_thetadot(state.thetadot() - 0.2);
   initial_energy = rw.CalcTotalEnergy(context);
+  simulator.Initialize();
   simulator.AdvanceTo(.2);
   // Theta should now be on the other side of zero.
   EXPECT_LT(state.theta(), 0.);
@@ -118,6 +120,7 @@ GTEST_TEST(RimlessWheelTest, StepTest) {
   state.set_thetadot(-4.);
   toe = 0.0;
   double_support = false;
+  simulator.Initialize();
   initial_energy = rw.CalcTotalEnergy(context);
   simulator.AdvanceTo(.2);
   // Theta should now be on the other side of zero.
@@ -167,6 +170,7 @@ GTEST_TEST(RimlessWheelTest, FixedPointTest) {
   state.set_thetadot(0.0);
   toe = 0.0;
   double_support = false;
+  simulator.Initialize();
   simulator.AdvanceTo(0.2);
   EXPECT_TRUE(double_support);
   EXPECT_NEAR(std::abs(state.theta() - params.slope()), alpha, 1e-8);

--- a/multibody/plant/test/joint_limits_test.cc
+++ b/multibody/plant/test/joint_limits_test.cc
@@ -105,6 +105,7 @@ GTEST_TEST(JointLimitsTest, PrismaticJointConvergenceTest) {
     // Set the force to be positive and re-start the simulation.
     plant.get_actuation_input_port().FixValue(&context, 10.0);
     context.SetTime(0.0);
+    simulator.Initialize();
     simulator.AdvanceTo(simulation_time);
 
     // Verify we are at rest near the upper limit.
@@ -177,6 +178,7 @@ GTEST_TEST(JointLimitsTest, RevoluteJoint) {
     // Set the torque to be negative and re-start the simulation.
     plant.get_actuation_input_port().FixValue(&context, -1.5);
     context.SetTime(0.0);
+    simulator.Initialize();
     simulator.AdvanceTo(simulation_time);
 
     // Verify we are at rest near the lower limit.
@@ -278,6 +280,7 @@ GTEST_TEST(JointLimitsTest, KukaArm) {
       &context, VectorX<double>::Constant(nq, -0.4));
   plant.SetDefaultContext(&context);
   context.SetTime(0.0);
+  simulator.Initialize();
   simulator.AdvanceTo(simulation_time);
   for (int joint_number = 1; joint_number <= nq; ++joint_number) {
     const std::string joint_name = "iiwa_joint_" + std::to_string(joint_number);

--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -261,9 +261,13 @@ class Simulator {
   /// AdvanceTo() calls you should consider whether to call Initialize() before
   /// resuming; AdvanceTo() will not do that automatically for you. Whether to
   /// do so depends on whether you want the above initialization operations
-  /// performed. For example, if you changed the time you will likely want the
-  /// time-triggered events to be recalculated in case one is due at the new
-  /// starting time.
+  /// performed.
+  ///
+  /// @note In particular, if you changed the time you must call Initialize().
+  /// The time-triggered events must be recalculated in case one is due at the
+  /// new starting time. Currently, the AdvanceTo() call will print a warning
+  /// for the first violation; after 2020-12-01 the warning will become a hard
+  /// error.
   ///
   /// @warning Initialize() does not automatically attempt to satisfy System
   /// constraints -- it is up to you to make sure that constraints are
@@ -800,6 +804,10 @@ class Simulator {
   // Set by Initialize() and reset by various traumas.
   bool initialization_done_{false};
 
+  // Set by Initialize() and AdvanceTo(). Used to detect unexpected jumps in
+  // time.
+  double last_known_simtime_{nan()};
+
   // The vector of active witness functions.
   std::unique_ptr<std::vector<const WitnessFunction<T>*>> witness_functions_;
 
@@ -825,10 +833,6 @@ class Simulator {
   TimeOrWitnessTriggered time_or_witness_triggered_{
       TimeOrWitnessTriggered::kNothingTriggered
   };
-
-  // The time that the next timed event is to be handled. This value is set in
-  // both Initialize() and AdvanceTo().
-  T next_timed_event_time_{std::numeric_limits<double>::quiet_NaN()};
 
   // Pre-allocated temporaries for updated discrete states.
   std::unique_ptr<DiscreteValues<T>> discrete_updates_;

--- a/systems/analysis/test/simulator_test.cc
+++ b/systems/analysis/test/simulator_test.cc
@@ -423,6 +423,7 @@ GTEST_TEST(SimulatorTest, FixedStepIncreasingIsolationAccuracy) {
   while (accuracy > 1e-8) {
     // (Re)set the time and initial state.
     context.SetTime(0);
+    simulator.Initialize();
 
     // Simulate to h.
     simulator.AdvanceTo(h);

--- a/systems/controllers/dynamic_programming.cc
+++ b/systems/controllers/dynamic_programming.cc
@@ -94,6 +94,7 @@ FittedValueIteration(
     for (int state = 0; state < num_states; state++) {
       context.SetTime(0.0);
       sim_state.SetFromVector(state_mesh.get_mesh_point(state));
+      simulator->Initialize();
 
       cost[input](state) = timestep * cost_function(context);
 
@@ -224,6 +225,7 @@ Eigen::VectorXd LinearProgrammingApproximateDynamicProgramming(
       context.SetTime(0.0);
       state_vec = state_samples.col(state);
       sim_state.SetFromVector(state_vec);
+      simulator->Initialize();
 
       const double cost = timestep * cost_function(context);
 


### PR DESCRIPTION
Related to #13741.

 * remove a false member
 * add time jump check as one-time warning
 * adjust tests that use time jumps
 * adjust doc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13851)
<!-- Reviewable:end -->
