### PR TITLE
context: Add cross-reference to cache design docs

### DIFF
--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -244,6 +244,8 @@ class Context : public ContextBase {
   /// have changed. These methods _do not_ initiate such recomputation
   /// themselves.
   ///
+  /// @sa @ref cache_design_notes
+  ///
   /// <h3>Invalidation and "out of date" notification</h3>
   /// Each method in this group provides the ability to change a particular
   /// subset of the available quantities listed above. This triggers "out of


### PR DESCRIPTION
User Story:
- Went to doxygen for `Simulator` to review #13851 
- Clicked on `Context` to review caching
- Remember there was a design doc, saw no mention of it here
- Remembered that we have a Technical Notes (as an "expert" drake user)

This should make things more traceable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13852)
<!-- Reviewable:end -->
