### PR TITLE
Remove redundant generalized_acceleration cache from MultibodyPlant

### DIFF
--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3671,7 +3671,6 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     systems::CacheIndex contact_jacobians;
     systems::CacheIndex contact_results;
     systems::CacheIndex contact_surfaces;
-    systems::CacheIndex generalized_accelerations;
     systems::CacheIndex generalized_contact_forces_continuous;
     systems::CacheIndex hydro_fallback;
     systems::CacheIndex point_pairs;
@@ -3997,18 +3996,6 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const systems::Context<T>& context) const {
     return this->get_cache_entry(cache_indexes_.contact_results)
         .template Eval<ContactResults<T>>(context);
-  }
-
-  // Given the state x and input u in `context`, this method computes the
-  // generalized acceleration into vdot.
-  void CalcGeneralizedAccelerations(const drake::systems::Context<T>& context,
-                                    VectorX<T>* vdot) const;
-
-  // Eval() version of the method CalcGeneralizedAccelerations().
-  const VectorX<T>& EvalGeneralizedAccelerations(
-      const systems::Context<T>& context) const {
-    return this->get_cache_entry(cache_indexes_.generalized_accelerations)
-        .template Eval<VectorX<T>>(context);
   }
 
   // Calc method for the reaction forces output port.

--- a/multibody/tree/multibody_tree_system.h
+++ b/multibody/tree/multibody_tree_system.h
@@ -169,8 +169,6 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
         .template Eval<std::vector<Vector6<T>>>(context);
   }
 
-  // TODO(sherm1) Add ArticulatedBodyInertiaCache.
-
  protected:
   /** @name        Alternate API for derived classes
   Derived classes may use these methods to create a MultibodyTreeSystem


### PR DESCRIPTION
MBP's generalized acceleration (vdot) cache is unneeded since vdot is also cached in the AccelerationKinematicsCache. All uses of the vdot cache simply evaluated the AccelerationKinematicsCache and then copied vdot out of it. This PR gets rid of that and instead makes use of the AccelerationKinematicsCache directly.

This is a lemma PR toward #13854.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13855)
<!-- Reviewable:end -->
