### PR TITLE
PlanarSceneGraphVisualizer: Store convex hulls of meshes

### DIFF
--- a/bindings/pydrake/systems/planar_scenegraph_visualizer.py
+++ b/bindings/pydrake/systems/planar_scenegraph_visualizer.py
@@ -270,7 +270,14 @@ class PlanarSceneGraphVisualizer(PyPlotVisualizer):
                     # Get mesh scaling.
                     scale = geom.float_data[0]
                     mesh = ReadObjToSurfaceMesh(filename, scale)
-                    patch_G = np.vstack([v.r_MV() for v in mesh.vertices()]).T
+                    patch_G = np.vstack([v.r_MV() for v in mesh.vertices()])
+                    # Only store the vertices of the (3D) convex hull of the
+                    # mesh, as any interior vertices will still be interior
+                    # vertices after projection, and will therefore be removed
+                    # in _update_body_fill_verts().
+                    hull = spatial.ConvexHull(patch_G)
+                    patch_G = np.vstack(
+                        [patch_G[v, :] for v in hull.vertices]).T
 
                 else:
                     print("UNSUPPORTED GEOMETRY TYPE {} IGNORED".format(


### PR DESCRIPTION
Prior to this commit, we stored all of the vertices of each mesh and then took
their convex hull after projecting them to the visualization plane every dt. Now
we only store the vertices of the 3D convex hull of each mesh. The 2D convex
hull must still be computed at each dt, but, for meshes with lots of interior
vertices, it will now be over a much smaller set of points.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13857)
<!-- Reviewable:end -->
