### PR TITLE
Parameterizes rigid bodies in MBP

### DIFF
--- a/multibody/benchmarks/acrobot/make_acrobot_plant.cc
+++ b/multibody/benchmarks/acrobot/make_acrobot_plant.cc
@@ -32,16 +32,16 @@ MakeAcrobotPlant(const AcrobotParameters& params, bool finalize,
 
   // Define each link's spatial inertia about their respective COM.
   UnitInertia<double> G1_Bcm =
-      UnitInertia<double>::StraightLine(params.Ic1(), Vector3d::UnitZ());
+      UnitInertia<double>::StraightLine(params.Gc1(), Vector3d::UnitZ());
   SpatialInertia<double> M1_L1o =
       SpatialInertia<double>::MakeFromCentralInertia(
-          params.m1(), p_L1L1cm, G1_Bcm);
+          params.m1(), p_L1L1cm, G1_Bcm * params.m1());
 
   UnitInertia<double> G2_Bcm =
-      UnitInertia<double>::StraightLine(params.Ic2(), Vector3d::UnitZ());
+      UnitInertia<double>::StraightLine(params.Gc2(), Vector3d::UnitZ());
   SpatialInertia<double> M2_L2o =
       SpatialInertia<double>::MakeFromCentralInertia(
-          params.m2(), p_L2L2cm, G2_Bcm);
+          params.m2(), p_L2L2cm, G2_Bcm * params.m2());
 
   // Add a rigid body to model each link.
   const RigidBody<double>& link1 = plant->AddRigidBody(

--- a/multibody/benchmarks/acrobot/make_acrobot_plant.h
+++ b/multibody/benchmarks/acrobot/make_acrobot_plant.h
@@ -78,7 +78,10 @@ class AcrobotParameters {
       Ic2_(Ic2),
       b1_(b1),
       b2_(b2),
-      g_(g) {}
+      g_(g) {
+        DRAKE_DEMAND(m1_ > 0);
+        DRAKE_DEMAND(m2_ > 0);
+      }
 
   // getters for robot parameters
   double m1() const { return m1_; }
@@ -89,6 +92,8 @@ class AcrobotParameters {
   double lc2() const { return lc2_; }
   double Ic1() const { return Ic1_; }
   double Ic2() const { return Ic2_; }
+  double Gc1() const { return Ic1_ / m1_; }
+  double Gc2() const { return Ic2_ / m2_; }
   double b1() const { return b1_; }
   double b2() const { return b2_; }
   double g() const { return g_; }

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -3102,6 +3102,265 @@ GTEST_TEST(MultibodyPlantTest, SceneGraphPorts) {
     EXPECT_NO_THROW(plant_finalized.get_geometry_poses_output_port());
 }
 
+GTEST_TEST(MultibodyPlantTest, RigidBodyParameters) {
+  // Add a plant with a few rigid bodies.
+  MultibodyPlant<double> plant(0.0);
+
+  const double sphere_radius = 1.0;
+  const double sphere_mass = 2.5;
+  const Vector3d sphere_com(0, 0, 0);
+  const UnitInertia<double> sphere_unit_inertia =
+      UnitInertia<double>::SolidSphere(sphere_radius);
+  const RigidBody<double>& sphere = plant.AddRigidBody(
+      "sphere",
+      SpatialInertia<double>(sphere_mass, sphere_com, sphere_unit_inertia));
+
+  const double cube_length = 2.0;
+  const double cube_mass = 5.0;
+  const Vector3d cube_com(0, 0, 0);
+  const UnitInertia<double> cube_unit_inertia =
+      UnitInertia<double>::SolidBox(cube_length, cube_length, cube_length);
+  const RigidBody<double>& cube = plant.AddRigidBody(
+      "cube", SpatialInertia<double>(cube_mass, cube_com, cube_unit_inertia));
+
+  plant.Finalize();
+
+  // Create a default context.
+  auto context = plant.CreateDefaultContext();
+
+  // Verify default parameters exist and are correct.
+  const double sphere_mass_in_context = sphere.get_mass(*context);
+  const Vector3<double> sphere_com_in_context =
+      sphere.CalcCenterOfMassInBodyFrame(*context);
+  const SpatialInertia<double> sphere_inertia_in_context =
+      sphere.CalcSpatialInertiaInBodyFrame(*context);
+
+  const double cube_mass_in_context = cube.get_mass(*context);
+  const Vector3<double> cube_com_in_context =
+      cube.CalcCenterOfMassInBodyFrame(*context);
+  const SpatialInertia<double> cube_inertia_in_context =
+      cube.CalcSpatialInertiaInBodyFrame(*context);
+
+  EXPECT_EQ(sphere_mass_in_context, sphere_mass);
+  EXPECT_EQ(sphere_inertia_in_context.get_mass(), sphere_mass);
+  EXPECT_TRUE(CompareMatrices(sphere_com_in_context, sphere_com));
+  EXPECT_TRUE(CompareMatrices(sphere_inertia_in_context.get_com(), sphere_com));
+  EXPECT_TRUE(CompareMatrices(
+      sphere_inertia_in_context.get_unit_inertia().get_moments(),
+      sphere_unit_inertia.get_moments()));
+  EXPECT_TRUE(CompareMatrices(
+      sphere_inertia_in_context.get_unit_inertia().get_products(),
+      sphere_unit_inertia.get_products()));
+
+  EXPECT_EQ(cube_mass_in_context, cube_mass);
+  EXPECT_EQ(cube_inertia_in_context.get_mass(), cube_mass);
+  EXPECT_TRUE(CompareMatrices(cube_com_in_context, cube_com));
+  EXPECT_TRUE(CompareMatrices(cube_inertia_in_context.get_com(), cube_com));
+  EXPECT_TRUE(
+      CompareMatrices(cube_inertia_in_context.get_unit_inertia().get_moments(),
+                      cube_unit_inertia.get_moments()));
+  EXPECT_TRUE(
+      CompareMatrices(cube_inertia_in_context.get_unit_inertia().get_products(),
+                      cube_unit_inertia.get_products()));
+
+  // Change parameters.
+  const double new_sphere_radius = 1.5;
+  const double new_sphere_mass = 3.9;
+  const Vector3d new_sphere_com(0, 0, 0);
+  const UnitInertia<double> new_sphere_unit_inertia =
+      UnitInertia<double>::SolidSphere(new_sphere_radius);
+
+  const double new_cube_length = 1.3;
+  const double new_cube_mass = 3.0;
+  const Vector3d new_cube_com(0, 0, 0);
+  const UnitInertia<double> new_cube_unit_inertia =
+      UnitInertia<double>::SolidBox(new_cube_length, new_cube_length,
+                                    new_cube_length);
+
+  SpatialInertia<double> new_sphere_params(new_sphere_mass, new_sphere_com,
+                                           new_sphere_unit_inertia);
+
+  SpatialInertia<double> new_cube_params(new_cube_mass, new_cube_com,
+                                         new_cube_unit_inertia);
+
+  sphere.SetSpatialInertiaInBodyFrame(context.get(), new_sphere_params);
+  cube.SetSpatialInertiaInBodyFrame(context.get(), new_cube_params);
+
+  // Verify parameters propagate.
+  const double new_sphere_mass_in_context = sphere.get_mass(*context);
+  const Vector3<double> new_sphere_com_in_context =
+      sphere.CalcCenterOfMassInBodyFrame(*context);
+  const SpatialInertia<double> new_sphere_inertia_in_context =
+      sphere.CalcSpatialInertiaInBodyFrame(*context);
+
+  const double new_cube_mass_in_context = cube.get_mass(*context);
+  const Vector3<double> new_cube_com_in_context =
+      cube.CalcCenterOfMassInBodyFrame(*context);
+  const SpatialInertia<double> new_cube_inertia_in_context =
+      cube.CalcSpatialInertiaInBodyFrame(*context);
+
+  EXPECT_EQ(new_sphere_mass_in_context, new_sphere_mass);
+  EXPECT_EQ(new_sphere_inertia_in_context.get_mass(), new_sphere_mass);
+  EXPECT_TRUE(
+      CompareMatrices(new_sphere_com_in_context, new_sphere_com));
+  EXPECT_TRUE(
+      CompareMatrices(new_sphere_inertia_in_context.get_com(), new_sphere_com));
+  EXPECT_TRUE(CompareMatrices(
+      new_sphere_inertia_in_context.get_unit_inertia().get_moments(),
+      new_sphere_unit_inertia.get_moments()));
+  EXPECT_TRUE(CompareMatrices(
+      new_sphere_inertia_in_context.get_unit_inertia().get_products(),
+      new_sphere_unit_inertia.get_products()));
+
+  EXPECT_EQ(new_cube_mass_in_context, new_cube_mass);
+  EXPECT_EQ(new_cube_inertia_in_context.get_mass(), new_cube_mass);
+  EXPECT_TRUE(
+      CompareMatrices(new_cube_com_in_context, new_cube_com));
+  EXPECT_TRUE(
+      CompareMatrices(new_cube_inertia_in_context.get_com(), new_cube_com));
+  EXPECT_TRUE(CompareMatrices(
+      new_cube_inertia_in_context.get_unit_inertia().get_moments(),
+      new_cube_unit_inertia.get_moments()));
+  EXPECT_TRUE(CompareMatrices(
+      new_cube_inertia_in_context.get_unit_inertia().get_products(),
+      new_cube_unit_inertia.get_products()));
+}
+
+GTEST_TEST(MultibodyPlantTest, AutoDiffAcrobotParameters) {
+  const double kTolerance = 5 * std::numeric_limits<double>::epsilon();
+
+  // Create an Acrobot plant with autodiff parameters for length and mass.
+  const double m1 = 2.0;
+  const double m2 = 4.0;
+  const double l1 = 1.0;
+  const double l2 = 2.0;
+  const double lc1 = 0.5 * l1;
+  const double lc2 = 0.5 * l2;
+  const double Gc1 = (1.0 / 12.0) * l1 * l1;
+  const double Gc2 = (1.0 / 12.0) * l2 * l2;
+  const double Ic1 = m1 * Gc1;
+  const double Ic2 = m2 * Gc2;
+
+  const AcrobotParameters params(m1, m2, l1, l2, lc1, lc2, Ic1, Ic2, 0.0, 0.0,
+                                 9.81);
+  unique_ptr<MultibodyPlant<double>> plant = MakeAcrobotPlant(params, true);
+
+  // Create a default context and set state.
+  unique_ptr<Context<double>> context = plant->CreateDefaultContext();
+
+  const RevoluteJoint<double>& shoulder_joint =
+      plant->GetJointByName<RevoluteJoint>(params.shoulder_joint_name());
+  const RevoluteJoint<double>& elbow_joint =
+      plant->GetJointByName<RevoluteJoint>(params.elbow_joint_name());
+  shoulder_joint.set_angle(context.get(), 0.0);
+  elbow_joint.set_angle(context.get(), 0.0);
+
+  // Scalar convert the plant to AutoDiffXd.
+  unique_ptr<MultibodyPlant<AutoDiffXd>> plant_autodiff =
+      systems::System<double>::ToAutoDiffXd(*plant);
+  unique_ptr<Context<AutoDiffXd>> context_autodiff =
+      plant_autodiff->CreateDefaultContext();
+  context_autodiff->SetTimeStateAndParametersFrom(*context);
+
+  // Set up our parameters as the independent variables.
+  // Differentiable parameters for the acrobot using only inertial parameters.
+  const AutoDiffXd m1_ad(m1, Vector3d(1, 0, 0));
+  const AutoDiffXd m2_ad(m2, Vector3d(0, 1, 0));
+  const AutoDiffXd l2_ad(l2, Vector3d(0, 0, 1));
+  const AutoDiffXd lc2_ad = 0.5 * l2_ad;
+  const AutoDiffXd Gc2_ad = (1.0 / 12.0) * l2_ad * l2_ad;
+
+  // Frame L1's origin is located at the shoulder outboard frame.
+  const Vector3<AutoDiffXd> p_L1L1cm = -lc1 * Vector3d::UnitZ();
+  // Frame L2's origin is located at the elbow outboard frame.
+  const Vector3<AutoDiffXd> p_L2L2cm = -lc2_ad * Vector3d::UnitZ();
+
+  // Define each link's spatial inertia about their respective COM.
+  UnitInertia<AutoDiffXd> Gc1_Bcm =
+      UnitInertia<AutoDiffXd>::StraightLine(Gc1, Vector3d::UnitZ());
+  SpatialInertia<AutoDiffXd> M1_L1o =
+      SpatialInertia<AutoDiffXd>::MakeFromCentralInertia(m1_ad, p_L1L1cm,
+                                                         Gc1_Bcm * m1_ad);
+
+  UnitInertia<AutoDiffXd> Gc2_Bcm =
+      UnitInertia<AutoDiffXd>::StraightLine(Gc2_ad, Vector3d::UnitZ());
+  SpatialInertia<AutoDiffXd> M2_L2o =
+      SpatialInertia<AutoDiffXd>::MakeFromCentralInertia(m2_ad, p_L2L2cm,
+                                                         Gc2_Bcm * m2_ad);
+
+  plant_autodiff->GetRigidBodyByName(params.link1_name())
+      .SetSpatialInertiaInBodyFrame(context_autodiff.get(), M1_L1o);
+
+  plant_autodiff->GetRigidBodyByName(params.link2_name())
+      .SetSpatialInertiaInBodyFrame(context_autodiff.get(), M2_L2o);
+
+  // Take the derivative of the mass matrix w.r.t. length.
+  Matrix2<AutoDiffXd> mass_matrix;
+  plant_autodiff->CalcMassMatrix(*context_autodiff, &mass_matrix);
+
+  const auto& mass_matrix_grad = math::autoDiffToGradientMatrix(mass_matrix);
+
+  // Verify numerical derivative matches analytic solution.
+  // In the starting configuration q = (0, 0).
+  //
+  //   c1 = cos(q[0]) = 1
+  //   s1 = sin(q[0]) = 0
+  //   c2 = cos(q[1]) = 1
+  //   s2 = sin(q[1]) = 0
+  //
+  //  Moments of Inertia, taken about the pivots:
+  //
+  //    I₁ = 4m₁Ic₁ = (1/3)m₁l₁²
+  //    I₂ = 4m₂Ic₂ = (1/3)m₂l₂²
+  //
+  // Moment of inertia at the shoulder joint origin.
+  const double I1 = 4 * Ic1;
+  // Moment of inertia at the elbow joint origin.
+  const double I2 = 4 * Ic2;
+
+  // Analytic Mass Matrix, M:
+  //
+  //  [ I₁ + I₂ + m₂l₁² + 2m₂l₁lc₂c₂   I₂ + m₂l₁lc₂c₂ ]
+  //  [      I₂ + m₂l₁lc₂c₂                 I₂        ]
+  Matrix2<double> analytic_mass_matrix;
+  analytic_mass_matrix << I1 + I2 + m2*l1*l1 + 2*m2*l1*lc2, I2 + m2*l1*lc2,
+                                            I2 + m2*l1*lc2,             I2;
+  EXPECT_TRUE(CompareMatrices(mass_matrix, analytic_mass_matrix, kTolerance,
+                              MatrixCompareType::relative));
+
+  // Analytic ∂M/∂m₁:
+  // [ (1/3)l₁²      0 ]
+  // [     0         0 ]
+  Vector4<double> analytic_mass_matrix_partial_m1;
+  analytic_mass_matrix_partial_m1 << (1.0/3.0)*l1*l1, 0.0,
+                                                 0.0, 0.0;
+  EXPECT_TRUE(CompareMatrices(mass_matrix_grad.col(0),
+                              analytic_mass_matrix_partial_m1, kTolerance,
+                              MatrixCompareType::relative));
+
+  // Analytic ∂M/∂m₂:
+  // [ (1/3)l₂² + l₁² + 2l₁lc₂c₂     (1/3)l₂² + l₁lc₂c₂ ]
+  // [    (1/3)l₂² + l₁lc₂c₂               (1/3)l₂²     ]
+  Vector4<double> analytic_mass_matrix_partial_m2;
+  analytic_mass_matrix_partial_m2 <<
+      (1.0/3.0)*l2*l2 + l1*l1 + 2*l1*lc2, (1.0/3.0)*l2*l2 + l1*lc2,
+                (1.0/3.0)*l2*l2 + l1*lc2,          (1.0/3.0)*l2*l2;
+  EXPECT_TRUE(CompareMatrices(mass_matrix_grad.col(1),
+                              analytic_mass_matrix_partial_m2, kTolerance,
+                              MatrixCompareType::relative));
+
+  // Analytic ∂M/∂l₂:
+  // [   (2/3)m₂l₂ + m₂l₁       (2/3)m₂l₂ + (1/2)m₂l₁ ]
+  // [ (2/3)m₂l₂ + (1/2)m₂l₁          (2/3)m₂l₂       ]
+  Vector4<double> analytic_mass_matrix_partial_l2;
+  analytic_mass_matrix_partial_l2 <<
+          (2.0/3.0)*m2*l2 + m2*l1, (2.0/3.0)*m2*l2 + 0.5*m2*l1,
+      (2.0/3.0)*m2*l2 + 0.5*m2*l1,             (2.0/3.0)*m2*l2;
+  EXPECT_TRUE(CompareMatrices(mass_matrix_grad.col(2),
+                              analytic_mass_matrix_partial_l2, kTolerance,
+                              MatrixCompareType::relative));
+}
+
 }  // namespace
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -141,6 +141,7 @@ drake_cc_library(
         "multibody_tree.h",
         "multibody_tree-inl.h",
         "multibody_tree_system.h",
+        "parameter_conversion.h",
         "planar_joint.h",
         "planar_mobilizer.h",
         "prismatic_joint.h",

--- a/multibody/tree/body.h
+++ b/multibody/tree/body.h
@@ -270,8 +270,8 @@ class Body : public MultibodyElement<Body, T, BodyIndex> {
   double get_default_mass() const { return default_mass_; }
 
   /// (Advanced) Returns the mass of this body stored in `context`.
-  virtual T get_mass(
-      const systems::Context<T> &context)const = 0;
+  virtual const T& get_mass(
+      const systems::Context<T> &context) const = 0;
 
   /// (Advanced) Computes the center of mass `p_BoBcm_B` (or `p_Bcm` for short)
   /// of this body measured from this body's frame origin `Bo` and expressed in

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -637,6 +637,11 @@ class MultibodyTree {
     return *owned_bodies_[body_index];
   }
 
+  Body<T>& get_mutable_body(BodyIndex body_index) {
+    DRAKE_THROW_UNLESS(body_index < num_bodies());
+    return *owned_bodies_[body_index];
+  }
+
   /// See MultibodyPlant method.
   const Joint<T>& get_joint(JointIndex joint_index) const {
     DRAKE_THROW_UNLESS(joint_index < num_joints());
@@ -658,6 +663,11 @@ class MultibodyTree {
 
   /// See MultibodyPlant method.
   const Frame<T>& get_frame(FrameIndex frame_index) const {
+    DRAKE_THROW_UNLESS(frame_index < num_frames());
+    return *frames_[frame_index];
+  }
+
+  Frame<T>& get_mutable_frame(FrameIndex frame_index) {
     DRAKE_THROW_UNLESS(frame_index < num_frames());
     return *frames_[frame_index];
   }
@@ -692,6 +702,12 @@ class MultibodyTree {
 
   const ForceElement<T>& get_force_element(
       ForceElementIndex force_element_index) const {
+    DRAKE_THROW_UNLESS(force_element_index < num_force_elements());
+    return *owned_force_elements_[force_element_index];
+  }
+
+  ForceElement<T>& get_mutable_force_element(
+      ForceElementIndex force_element_index) {
     DRAKE_THROW_UNLESS(force_element_index < num_force_elements());
     return *owned_force_elements_[force_element_index];
   }
@@ -2909,7 +2925,7 @@ class MultibodyTree {
   // List of all frames in the system ordered by their FrameIndex.
   // This vector contains a pointer to all frames in owned_frames_ as well as a
   // pointer to each BodyFrame, which are owned by their corresponding Body.
-  std::vector<const Frame<T>*> frames_;
+  std::vector<Frame<T>*> frames_;
 
   // The gravity field force element.
   UniformGravityFieldElement<T>* gravity_field_{nullptr};

--- a/multibody/tree/parameter_conversion.h
+++ b/multibody/tree/parameter_conversion.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include "drake/common/default_scalars.h"
+#include "drake/multibody/tree/spatial_inertia.h"
+#include "drake/systems/framework/basic_vector.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+namespace parameter_conversion {
+
+// Conversions for SpatialInertia<T>
+struct SpatialInertiaIndex {
+  /// The total number of rows (coordinates).
+  inline static const int k_num_coordinates = 10;
+
+  // The index of each individual coordinate.
+  inline static const int k_mass = 0;   // [0]: mass
+  inline static const int k_com_x = 1;  // [1]: center_of_mass_x
+  inline static const int k_com_y = 2;  // [2]: center_of_mass_y
+  inline static const int k_com_z = 3;  // [3]: center_of_masS_z
+  inline static const int k_Gxx = 4;    // [4]: unit_inertia_Gxx
+  inline static const int k_Gyy = 5;    // [5]: unit_inertia_Gyy
+  inline static const int k_Gzz = 6;    // [6]: unit_inertia_Gzz
+  inline static const int k_Gxy = 7;    // [7]: unit_inertia_Gxy
+  inline static const int k_Gxz = 8;    // [8]: unit_inertia_Gxz
+  inline static const int k_Gyz = 9;    // [9]: unit_inertia_Gyz
+};
+
+// Converts a SpatialInertia<T> to a BasicVector<T>
+template <typename T>
+systems::BasicVector<T> ToBasicVector(
+    const SpatialInertia<T>& spatial_inertia) {
+  const Vector3<T>& com = spatial_inertia.get_com();
+  const UnitInertia<T>& unit_inertia = spatial_inertia.get_unit_inertia();
+  return systems::BasicVector<T>(
+      {
+      // mass
+      spatial_inertia.get_mass(),
+      // center of mass
+      com(0), com(1), com(2),
+      // unit inertia
+      unit_inertia(0, 0), unit_inertia(1, 1), unit_inertia(2, 2),
+      unit_inertia(0, 1), unit_inertia(0, 2), unit_inertia(1, 2)});
+}
+
+// Extracts the mass from the BasicVector<T> representing a SpatialInertia<T> as
+// a const reference.
+template <typename T>
+const T& GetMass(const systems::BasicVector<T>& spatial_inertia_vector) {
+  DRAKE_DEMAND(spatial_inertia_vector.size() ==
+               SpatialInertiaIndex::k_num_coordinates);
+  return spatial_inertia_vector[SpatialInertiaIndex::k_mass];
+}
+
+// Extracts the center of mass from the BasicVector<T> representing a
+// SpatialInertia<T>.
+template <typename T>
+Vector3<T> GetCenterOfMass(
+    const systems::BasicVector<T>& spatial_inertia_vector) {
+  DRAKE_DEMAND(spatial_inertia_vector.size() ==
+               SpatialInertiaIndex::k_num_coordinates);
+  return Vector3<T>(
+      spatial_inertia_vector[SpatialInertiaIndex::k_com_x],
+      spatial_inertia_vector[SpatialInertiaIndex::k_com_y],
+      spatial_inertia_vector[SpatialInertiaIndex::k_com_z]);
+}
+
+// Converts a BasicVector<T> to a SpatialInertia<T>
+template <typename T>
+SpatialInertia<T> ToSpatialInertia(
+    const systems::BasicVector<T>& spatial_inertia_basic_vector) {
+  DRAKE_DEMAND(spatial_inertia_basic_vector.size() ==
+               SpatialInertiaIndex::k_num_coordinates);
+  const auto& spatial_inertia_vector = spatial_inertia_basic_vector.get_value();
+  return SpatialInertia<T>(
+      spatial_inertia_vector[SpatialInertiaIndex::k_mass],
+      Vector3<T>(spatial_inertia_vector[SpatialInertiaIndex::k_com_x],
+                 spatial_inertia_vector[SpatialInertiaIndex::k_com_y],
+                 spatial_inertia_vector[SpatialInertiaIndex::k_com_z]),
+      UnitInertia<T>(spatial_inertia_vector[SpatialInertiaIndex::k_Gxx],
+                     spatial_inertia_vector[SpatialInertiaIndex::k_Gyy],
+                     spatial_inertia_vector[SpatialInertiaIndex::k_Gzz],
+                     spatial_inertia_vector[SpatialInertiaIndex::k_Gxy],
+                     spatial_inertia_vector[SpatialInertiaIndex::k_Gxz],
+                     spatial_inertia_vector[SpatialInertiaIndex::k_Gyz]),
+      true);
+}
+}  // namespace parameter_conversion
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
- Make RigidBody declare/store a NumericParameter for SpatialInertia parameters
- Declare cache dependencies 
- Fleshed out `Body` methods to access parameters from context
  - `get_mass(const systems::Context<T> &)`
  - `CalcCenterOfMassInBodyFrame(const systems::Context<T>&)`
  - `CalcSpatialInertiaInBodyFrame(const systems::Context<T>&)`
- Creates an API in RigidBody for parameters:
  - `RigidBody::SetMass(Context<T>*, const T& mass)`
  - `RigidBody::SetCenterOfMassInBodyFrame(Context<T>*, const Vector3<T>& com)`
  - `RigidBody::SetSpatialInertiaInBodyFrame(Context<T>*, const SpatialInertia<T>& M_BBo_B)`
- Small bug fix in `multibody/benchmarks/acrobot/make_acrobot_plant`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13860)
<!-- Reviewable:end -->
