### PR TITLE
[geometry] Geometry support for discrete hydroelastic contact

### DIFF
--- a/geometry/benchmarking/mesh_intersection_benchmark.cc
+++ b/geometry/benchmarking/mesh_intersection_benchmark.cc
@@ -278,9 +278,10 @@ BENCHMARK_DEFINE_F(MeshIntersectionBenchmark, WithoutBVH)
   SetupMeshes(state);
   std::unique_ptr<SurfaceMesh<double>> surface_SR;
   std::unique_ptr<SurfaceMeshFieldLinear<double, double>> e_SR;
+  std::vector<Vector3<double>> grad_eM_Ms;
   for (auto _ : state) {
     SurfaceVolumeIntersector<double>().SampleVolumeFieldOnSurface(
-        field_S_, mesh_R_, X_SR_, &surface_SR, &e_SR);
+        field_S_, mesh_R_, X_SR_, &surface_SR, &e_SR, &grad_eM_Ms);
   }
   RecordContactSurfaceResult(surface_SR.get(), "WithoutBVH", state);
 }
@@ -312,9 +313,11 @@ BENCHMARK_DEFINE_F(MeshIntersectionBenchmark, ___WithBVH)
   const auto bvh_R = BoundingVolumeHierarchy<SurfaceMesh<double>>(mesh_R_);
   std::unique_ptr<SurfaceMesh<double>> surface_SR;
   std::unique_ptr<SurfaceMeshFieldLinear<double, double>> e_SR;
+  std::vector<Vector3<double>> grad_eM_Ms;
   for (auto _ : state) {
     SurfaceVolumeIntersector<double>().SampleVolumeFieldOnSurface(
-        field_S_, bvh_S, mesh_R_, bvh_R, X_SR_, &surface_SR, &e_SR);
+        field_S_, bvh_S, mesh_R_, bvh_R, X_SR_, &surface_SR, &e_SR,
+        &grad_eM_Ms);
   }
   RecordContactSurfaceResult(surface_SR.get(), "___WithBVH", state);
 }

--- a/geometry/proximity/mesh_half_space_intersection.cc
+++ b/geometry/proximity/mesh_half_space_intersection.cc
@@ -345,9 +345,9 @@ ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
   auto bvh_callback = [&tri_indices, &mesh_R, &R_WS = X_WS.rotation(),
                        &R_WR](SurfaceFaceIndex tri_index) {
     // The gradient of the half space pressure field lies in the _opposite_
-    // direction as its normal. Its normal is Sz. So, grad_p_W = - Sz_W.
-    const Eigen::Vector3d& grad_p_W = -R_WS.col(2);
-    if (IsFaceNormalInNormalDirection(grad_p_W, mesh_R, tri_index, R_WR)) {
+    // direction as its normal. Its normal is Sz. So, unit_grad_p_W = -Sz_W.
+    const Eigen::Vector3d& unit_grad_p_W = -R_WS.col(2);
+    if (IsFaceNormalInNormalDirection(unit_grad_p_W, mesh_R, tri_index, R_WR)) {
       tri_indices.push_back(tri_index);
     }
     return BvttCallbackResult::Continue;
@@ -400,10 +400,18 @@ ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
       "pressure", std::move(vertex_pressures), mesh_W.get(),
       false /* calc_gradient */);
 
+  // TODO(SeanCurtis-TRI) In this case, the gradient across the contact surface
+  //  is a constant. It would be good if we could exploit this and *not* copy
+  //  the same vector value once per triangle.
+  const Eigen::Vector3d& unit_grad_p_W = X_WS.rotation().col(2);
+  auto grad_eS_W = std::make_unique<std::vector<Vector3<T>>>(
+      mesh_W->num_elements(), -pressure_scale * unit_grad_p_W);
+
   // ConstructSurfaceMeshFromMeshHalfspaceIntersection() promises to make the
   // face normals point out of the rigid surface and into the soft half space.
   return std::make_unique<ContactSurface<T>>(id_S, id_R, std::move(mesh_W),
-                                             std::move(field_W));
+                                             std::move(field_W),
+                                             std::move(grad_eS_W), nullptr);
 }
 
 template void ConstructTriangleHalfspaceIntersectionPolygon(
@@ -429,18 +437,18 @@ template void ConstructTriangleHalfspaceIntersectionPolygon(
         edges_to_newly_created_vertices);
 
 template std::unique_ptr<SurfaceMesh<double>>
-    ConstructSurfaceMeshFromMeshHalfspaceIntersection(
-        const SurfaceMesh<double>& input_mesh_F,
-        const PosedHalfSpace<double>& half_space_F,
-        const std::vector<SurfaceFaceIndex>& tri_indices,
-        const math::RigidTransform<double>& X_WF);
+ConstructSurfaceMeshFromMeshHalfspaceIntersection(
+    const SurfaceMesh<double>& input_mesh_F,
+    const PosedHalfSpace<double>& half_space_F,
+    const std::vector<SurfaceFaceIndex>& tri_indices,
+    const math::RigidTransform<double>& X_WF);
 
 template std::unique_ptr<SurfaceMesh<AutoDiffXd>>
-    ConstructSurfaceMeshFromMeshHalfspaceIntersection(
-        const SurfaceMesh<double>& input_mesh_F,
-        const PosedHalfSpace<AutoDiffXd>& half_space_F,
-        const std::vector<SurfaceFaceIndex>& tri_indices,
-        const math::RigidTransform<AutoDiffXd>& X_WF);
+ConstructSurfaceMeshFromMeshHalfspaceIntersection(
+    const SurfaceMesh<double>& input_mesh_F,
+    const PosedHalfSpace<AutoDiffXd>& half_space_F,
+    const std::vector<SurfaceFaceIndex>& tri_indices,
+    const math::RigidTransform<AutoDiffXd>& X_WF);
 
 template std::unique_ptr<ContactSurface<double>>
 ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(

--- a/geometry/proximity/mesh_intersection.h
+++ b/geometry/proximity/mesh_intersection.h
@@ -67,15 +67,18 @@ class SurfaceVolumeIntersector {
        The sampled field values on the intersecting surface (samples to support
        a linear mesh field -- i.e., one per vertex). If no intersection exists,
        this will not change.
+   @param[out] grad_eM_Ms
+       The sampled gradient of the soft mesh pressure field (one sample per
+       triangle in `surface_MN_M`).
    @note
        The output surface mesh may have duplicate vertices.
    */
   void SampleVolumeFieldOnSurface(
       const VolumeMeshField<T, T>& volume_field_M,
-      const SurfaceMesh<T>& surface_N,
-      const math::RigidTransform<T>& X_MN,
+      const SurfaceMesh<T>& surface_N, const math::RigidTransform<T>& X_MN,
       std::unique_ptr<SurfaceMesh<T>>* surface_MN_M,
-      std::unique_ptr<SurfaceMeshFieldLinear<T, T>>* e_MN);
+      std::unique_ptr<SurfaceMeshFieldLinear<T, T>>* e_MN,
+      std::vector<Vector3<T>>* grad_eM_Ms);
 
   /* A variant of SampleVolumeFieldOnSurface but with broad-phase culling to
    reduce the number of element-pairs evaluated.  */
@@ -86,7 +89,8 @@ class SurfaceVolumeIntersector {
       const BoundingVolumeHierarchy<SurfaceMesh<T>>& bvh_N,
       const math::RigidTransform<T>& X_MN,
       std::unique_ptr<SurfaceMesh<T>>* surface_MN_M,
-      std::unique_ptr<SurfaceMeshFieldLinear<T, T>>* e_MN);
+      std::unique_ptr<SurfaceMeshFieldLinear<T, T>>* e_MN,
+      std::vector<Vector3<T>>* grad_eM_Ms);
 
  private:
   /* Calculates the intersection point between an infinite straight line

--- a/geometry/proximity/test/mesh_half_space_intersection_test.cc
+++ b/geometry/proximity/test/mesh_half_space_intersection_test.cc
@@ -755,6 +755,8 @@ REGISTER_TYPED_TEST_SUITE_P(MeshHalfspaceIntersectionTest, NoIntersection,
 //    - Compute pressure field on mesh.
 //    - Return contact surface with mesh and pressure; field must have pointer
 //      to the mesh.
+//    - Report the gradients of soft half space's pressure field across all
+//      triangles.
 //
 // It is impossible to test correct BVH use (it's all fully contained within
 // the implementation). So, we'll focus on intersecting and non-intersecting
@@ -790,21 +792,23 @@ GTEST_TEST(ComputeContactSurfaceFromSoftHalfSpaceRigidMeshTest, DoubleValued) {
     EXPECT_EQ(contact_surface, nullptr);
   }
 
-  {
-    // Case: intersecting.
+  // Define an intersecting configuration.
+  // The half space is defined in Frame H. The box is defined in Frame B.
+  // Have the half space's boundary plane lie _near_ the box's origin and its
+  // normal not quite aligned with Bz -- the goal is to get a contact surface
+  // that has the same general _topology_ as the
+  // (MeshHalfSpaceIntersectionTest, BoxMesh) test (see above), but not
+  // actually have the half space perfectly aligned with the mesh.
+  // We pick a rotation roughly 5 degrees away from Bz and a small offset
+  // from the origin.
+  const RigidTransform<double> X_BH{
+      AngleAxis<double>{M_PI * 0.027, Vector3d{1, 1, 0}.normalized()},
+      Vector3<double>{0.1, -0.05, 0.075}};
+  const RigidTransform<double> X_WH = X_WF * X_FB * X_BH;
 
-    // The half space is defined in Frame H. The box is defined in Frame B.
-    // Have the half space's boundary plane lie _near_ the box's origin and its
-    // normal not quite aligned with Bz -- the goal is to get a contact surface
-    // that has the same general _topology_ as the
-    // (MeshHalfSpaceIntersectionTest, BoxMesh) test (see above), but not
-    // actually have the half space perfectly aligned with the mesh.
-    // We pick a rotation roughly 5 degrees away from Bz and a small offset
-    // from the origin.
-    const RigidTransform<double> X_BH{
-        AngleAxis<double>{M_PI * 0.027, Vector3d{1, 1, 0}.normalized()},
-        Vector3<double>{0.1, -0.05, 0.075}};
-    const RigidTransform<double> X_WH = X_WF * X_FB * X_BH;
+  {
+    // Case: intersecting configuration (ignoring the gradients of the
+    // constituent pressure fields).
     const std::unique_ptr<ContactSurface<double>> contact_surface =
         ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
             hs_id, X_WH, pressure_scale, mesh_id, mesh_F, bvh_F, X_WF);
@@ -832,8 +836,49 @@ GTEST_TEST(ComputeContactSurfaceFromSoftHalfSpaceRigidMeshTest, DoubleValued) {
       EXPECT_NEAR(pressure, expected_pressure, 1e-15);
     }
   }
-}
 
+  {
+    // Case:  A repeat of the previous test, this time, we simply test for the
+    // existence (and correctness) of the pressure field gradient associated
+    // with the half space; it should be the negative scaled half space normal.
+    // We'll repeat the test twice, swapping ids to make sure the pressure field
+    // moves from M to N.
+    const Vector3d grad_eH_W_expected =
+        -pressure_scale * X_WH.rotation().col(2);
+    {
+      const std::unique_ptr<ContactSurface<double>> contact_surface =
+          ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
+              hs_id, X_WH, pressure_scale, mesh_id, mesh_F, bvh_F, X_WF);
+      ASSERT_NE(contact_surface, nullptr);
+      ASSERT_LT(mesh_id, hs_id);
+      EXPECT_FALSE(contact_surface->HasGradE_M());
+      EXPECT_TRUE(contact_surface->HasGradE_N());
+
+      EXPECT_GT(contact_surface->mesh_W().num_faces(), 0);
+      for (SurfaceFaceIndex f(0); f < contact_surface->mesh_W().num_faces();
+           ++f) {
+        ASSERT_TRUE(CompareMatrices(contact_surface->EvaluateGradE_N_W(f),
+                                    grad_eH_W_expected));
+      }
+    }
+
+    {
+      const std::unique_ptr<ContactSurface<double>> contact_surface =
+          ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
+              mesh_id, X_WH, pressure_scale, hs_id, mesh_F, bvh_F, X_WF);
+      ASSERT_NE(contact_surface, nullptr);
+      EXPECT_TRUE(contact_surface->HasGradE_M());
+      EXPECT_FALSE(contact_surface->HasGradE_N());
+
+      EXPECT_GT(contact_surface->mesh_W().num_faces(), 0);
+      for (SurfaceFaceIndex f(0); f < contact_surface->mesh_W().num_faces();
+           ++f) {
+        ASSERT_TRUE(CompareMatrices(contact_surface->EvaluateGradE_M_W(f),
+                                    grad_eH_W_expected));
+      }
+    }
+  }
+}
 
 // Confirm that the rigid-soft intersection correctly culls backface geometry.
 GTEST_TEST(CompupteContactSurfaceFromSoftHalfSpaceRigidMeshTest, BackfaceCull) {

--- a/geometry/proximity/test/mesh_plane_intersection_test.cc
+++ b/geometry/proximity/test/mesh_plane_intersection_test.cc
@@ -885,6 +885,7 @@ TEST_F(SliceTetWithPlaneTest, NoDoubleCounting) {
   4. Confirm that the surface mesh field references the surface mesh in the
      resultant ContactSurface.
   5. Mesh normals point out of plane and into soft mesh.
+  6. Report the pressure gradient of the soft mesh on the contact surface.
  These tests are done in a single, non-trivial frame F. The robustness of the
  numerics is covered in the SliceTetWithPlaneTest and this just needs to
  account for data tracking. */
@@ -1136,6 +1137,67 @@ TEST_F(ComputeContactSurfaceTest, NormalsInPlaneDirection) {
   }
 }
 
+/* Tests responsibility 6: the gradient of the mesh's pressure field is supplied
+ in the resulting contact surface. We make sure there's contact across multiple
+ tetrahedra so that we can confirm that unique gradients are reported.  */
+TEST_F(ComputeContactSurfaceTest, GradientConstituentPressure) {
+  ASSERT_LT(mesh_id_, plane_id_);
+
+  const Vector3d& Mx_F = X_FM_.rotation().col(0);
+  // The plane's normal aligns with Mx; slices through both tets.
+  const Vector3d p_FB = X_FM_.translation() + 0.5 * Mx_F;
+  const Plane<double> plane_F{Mx_F, p_FB};
+
+  const Vector3d& grad_eMesh_W_expected0 =
+      X_WF_.rotation() * field_F_->EvaluateGradient(VolumeElementIndex(0));
+  const Vector3d& grad_eMesh_W_expected1 =
+      X_WF_.rotation() * field_F_->EvaluateGradient(VolumeElementIndex(1));
+
+  {
+    // Case: plane slices through both tets. The resulting surface should have
+    // six triangles. The gradient for pressure field on M should be defined, N
+    // is not. The gradient reported on the first three triangles is that of tet
+    // 0, and for the last three should be tet 1.
+    unique_ptr<ContactSurface<double>> contact_surface =
+        ComputeContactSurface<double>(mesh_id_, *field_F_, plane_id_, plane_F,
+                                      both_tets_, X_WF_);
+    ASSERT_NE(contact_surface, nullptr);
+    EXPECT_EQ(contact_surface->mesh_W().num_elements(), 6);
+    EXPECT_EQ(contact_surface->mesh_W().num_vertices(), 6);
+    EXPECT_TRUE(contact_surface->HasGradE_M());
+    EXPECT_FALSE(contact_surface->HasGradE_N());
+    for (SurfaceFaceIndex f(0); f < 3; ++f) {
+      EXPECT_TRUE(CompareMatrices(contact_surface->EvaluateGradE_M_W(f),
+                                  grad_eMesh_W_expected0));
+    }
+    for (SurfaceFaceIndex f(3); f < 6; ++f) {
+      EXPECT_TRUE(CompareMatrices(contact_surface->EvaluateGradE_M_W(f),
+                                  grad_eMesh_W_expected1));
+    }
+  }
+
+  {
+    // Case: Reversing the ids will swap M and N. Otherwise all results should
+    // be the same.
+     unique_ptr<ContactSurface<double>> contact_surface =
+        ComputeContactSurface<double>(plane_id_, *field_F_, mesh_id_, plane_F,
+                                      both_tets_, X_WF_);
+    ASSERT_NE(contact_surface, nullptr);
+    EXPECT_EQ(contact_surface->mesh_W().num_elements(), 6);
+    EXPECT_EQ(contact_surface->mesh_W().num_vertices(), 6);
+    EXPECT_FALSE(contact_surface->HasGradE_M());
+    EXPECT_TRUE(contact_surface->HasGradE_N());
+    for (SurfaceFaceIndex f(0); f < 3; ++f) {
+      EXPECT_TRUE(CompareMatrices(contact_surface->EvaluateGradE_N_W(f),
+                                  grad_eMesh_W_expected0));
+    }
+    for (SurfaceFaceIndex f(3); f < 6; ++f) {
+      EXPECT_TRUE(CompareMatrices(contact_surface->EvaluateGradE_N_W(f),
+                                  grad_eMesh_W_expected1));
+    }
+  }
+}
+
 /* Test of ComputeContactSurfaceFromSoftVolumeRigidHalfSpace(). This function
  has the following unique responsibilities:
 
@@ -1174,6 +1236,8 @@ GTEST_TEST(MeshPlaneIntersectionTest, SoftVolumeRigidHalfSpace) {
     // indicators.
     auto contact_surface = ComputeContactSurfaceFromSoftVolumeRigidHalfSpace(
         id_A, field_F, bvh_F, X_WS, id_B, X_WR);
+    EXPECT_TRUE(contact_surface->HasGradE_M());
+    EXPECT_FALSE(contact_surface->HasGradE_N());
     ASSERT_NE(contact_surface, nullptr);
     // We exploit the knowledge that id_M < id_N and id_A < id_B.
     ASSERT_LT(id_A, id_B);

--- a/geometry/test/query_object_test.cc
+++ b/geometry/test/query_object_test.cc
@@ -142,7 +142,10 @@ TEST_F(QueryObjectTest, CopySemantics) {
 // the class (SceneGraph) that actually *performs* those queries. The
 // correctness of those queries is handled in geometry_state_test.cc. The
 // wrapper merely confirms that the state is correct and that wrapper
-// functionality is tested in DefaultQueryThrows.
+// functionality is tested in DefaultQueryThrows. Arguably, the question of
+// "do the parameters and return values" get mapped correctly could be under
+// test. But, for now, we assume the parameters and return values are propagated
+// correctly.
 TEST_F(QueryObjectTest, DefaultQueryThrows) {
   QueryObject<double> default_object;
   EXPECT_TRUE(is_default(default_object));
@@ -160,10 +163,13 @@ TEST_F(QueryObjectTest, DefaultQueryThrows) {
   EXPECT_DEFAULT_ERROR(default_object.X_PF(FrameId::get_new_id()));
   EXPECT_DEFAULT_ERROR(default_object.X_WG(GeometryId::get_new_id()));
 
-
   // Penetration queries.
   EXPECT_DEFAULT_ERROR(default_object.ComputePointPairPenetration());
   EXPECT_DEFAULT_ERROR(default_object.ComputeContactSurfaces());
+  std::vector<ContactSurface<double>> surfaces;
+  std::vector<PenetrationAsPointPair<double>> point_pairs;
+  EXPECT_DEFAULT_ERROR(default_object.ComputeContactSurfacesWithFallback(
+      &surfaces, &point_pairs));
 
   // Signed distance queries.
   EXPECT_DEFAULT_ERROR(


### PR DESCRIPTION
1. Introduce new (optional) data for ContactSurface.
   - The gradients of the constituent fields sampled once per *triangle*.
2. Extend API to allow for addition of new data in results.
   - QueryObject
   - GeometryState
   - ProximityEngine
   - HydroelasticCallback
   - Soft-rigid mesh intersection
   - rigid half space-soft mesh intersection
   - soft half space-rigid mesh intersection

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13864)
<!-- Reviewable:end -->
