### PR TITLE
cassie_benchmark: Fix nightly build break

### DIFF
--- a/examples/multibody/cassie_benchmark/BUILD.bazel
+++ b/examples/multibody/cassie_benchmark/BUILD.bazel
@@ -29,6 +29,7 @@ sh_test(
     size = "small",
     srcs = ["record_results.sh"],
     data = [":cassie_bench"],
+    tags = ["no_valgrind_tools"],
 )
 
 add_lint_tests()


### PR DESCRIPTION
Valgrind runs were detecting that lsb_release is written in Python, and
complaining about all the usual things.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13865)
<!-- Reviewable:end -->
