### PR TITLE
Add MonomialBasisElement.

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -206,6 +206,8 @@ drake_cc_library(
         "symbolic_ldlt.h",
         "symbolic_monomial.cc",
         "symbolic_monomial.h",
+        "symbolic_monomial_basis_element.cc",
+        "symbolic_monomial_basis_element.h",
         "symbolic_monomial_util.cc",
         "symbolic_monomial_util.h",
         "symbolic_polynomial.cc",
@@ -974,6 +976,16 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "symbolic_chebyshev_basis_element_test",
+    deps = [
+        ":essential",
+        ":symbolic",
+        "//common/test_utilities:expect_throws_message",
+        "//common/test_utilities:symbolic_test_util",
+    ],
+)
+
+drake_cc_googletest(
+    name = "symbolic_monomial_basis_element_test",
     deps = [
         ":essential",
         ":symbolic",

--- a/common/symbolic.h
+++ b/common/symbolic.h
@@ -40,6 +40,7 @@
 #include "drake/common/symbolic_polynomial.h"
 #include "drake/common/symbolic_polynomial_basis_element.h"
 #include "drake/common/symbolic_chebyshev_basis_element.h"
+#include "drake/common/symbolic_monomial_basis_element.h"
 #include "drake/common/symbolic_chebyshev_polynomial.h"
 #include "drake/common/symbolic_rational_function.h"
 #include "drake/common/symbolic_formula.h"

--- a/common/symbolic_chebyshev_basis_element.cc
+++ b/common/symbolic_chebyshev_basis_element.cc
@@ -59,7 +59,7 @@ std::map<ChebyshevBasisElement, double> ChebyshevBasisElement::Differentiate(
   return result;
 }
 
-std::map<ChebyshevBasisElement, double> ChebyshevBasisElement::Integration(
+std::map<ChebyshevBasisElement, double> ChebyshevBasisElement::Integrate(
     const Variable& var) const {
   auto var_to_degree_map = this->var_to_degree_map();
   auto it = var_to_degree_map.find(var);

--- a/common/symbolic_chebyshev_basis_element.h
+++ b/common/symbolic_chebyshev_basis_element.h
@@ -79,8 +79,7 @@ class ChebyshevBasisElement : public PolynomialBasisElement {
    * example, ∫ T₂(x)T₃(y)dx = 1/6*T₃(x)T₃(y) − 1/2 * T₁(x)T₃(y), then the
    * result is the map containing {T₃(x)T₃(y), 1/6} and {T₁(x)T₃(y), -1/2}.
    */
-  std::map<ChebyshevBasisElement, double> Integration(
-      const Variable& var) const;
+  std::map<ChebyshevBasisElement, double> Integrate(const Variable& var) const;
 
   /** Partially evaluates using a given environment @p env. The evaluation
    * result is of type pair<double, ChebyshevBasisElement>. The first component

--- a/common/symbolic_monomial_basis_element.cc
+++ b/common/symbolic_monomial_basis_element.cc
@@ -1,0 +1,204 @@
+// NOLINTNEXTLINE(build/include): Its header file is included in symbolic.h.
+#include <map>
+#include <numeric>
+#include <stdexcept>
+#include <utility>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/symbolic.h"
+#define DRAKE_COMMON_SYMBOLIC_DETAIL_HEADER
+#include "drake/common/symbolic_expression_cell.h"
+#undef DRAKE_COMMON_SYMBOLIC_DETAIL_HEADER
+
+namespace drake {
+namespace symbolic {
+
+namespace {
+// Converts a symbolic expression @p e into an internal representation of
+// Monomial class, a mapping from a base (Variable) to its exponent (int). This
+// function is called inside of the constructor Monomial(const
+// symbolic::Expression&).
+std::map<Variable, int> ToMonomialPower(const Expression& e) {
+  // TODO(soonho): Re-implement this function by using a Polynomial visitor.
+  DRAKE_DEMAND(e.is_polynomial());
+  std::map<Variable, int> powers;
+  if (is_one(e)) {  // This block is deliberately left empty.
+  } else if (is_constant(e)) {
+    throw std::runtime_error(
+        "A constant not equal to 1, this is not a monomial.");
+  } else if (is_variable(e)) {
+    powers.emplace(get_variable(e), 1);
+  } else if (is_pow(e)) {
+    const Expression& base{get_first_argument(e)};
+    const Expression& exponent{get_second_argument(e)};
+    // The following holds because `e` is polynomial.
+    DRAKE_DEMAND(is_constant(exponent));
+    // The following static_cast (double -> int) does not lose information
+    // because of the precondition `e.is_polynomial()`.
+    const int n{static_cast<int>(get_constant_value(exponent))};
+    powers = ToMonomialPower(base);
+    // pow(base, n) => (∏ᵢ xᵢ)^ⁿ => ∏ᵢ (xᵢ^ⁿ)
+    for (auto& p : powers) {
+      p.second *= n;
+    }
+  } else if (is_multiplication(e)) {
+    if (!is_one(get_constant_in_multiplication(e))) {
+      throw std::runtime_error("The constant in the multiplication is not 1.");
+    }
+    // e = ∏ᵢ pow(baseᵢ, exponentᵢ).
+    for (const auto& p : get_base_to_exponent_map_in_multiplication(e)) {
+      for (const auto& q : ToMonomialPower(pow(p.first, p.second))) {
+        auto it = powers.find(q.first);
+        if (it == powers.end()) {
+          powers.emplace(q.first, q.second);
+        } else {
+          it->second += q.second;
+        }
+      }
+    }
+  } else {
+    throw std::runtime_error(
+        "This expression cannot be converted to a monomial.");
+  }
+  return powers;
+}
+// Converts a pair of variables and their integer exponents into an internal
+// representation of Monomial class, a mapping from a base (Variable) to its
+// exponent (int). This function is called in the constructor taking the same
+// types of arguments.
+}  // namespace
+MonomialBasisElement::MonomialBasisElement(
+    const std::map<Variable, int>& var_to_degree_map)
+    : PolynomialBasisElement(var_to_degree_map) {}
+
+MonomialBasisElement::MonomialBasisElement(
+    const Eigen::Ref<const VectorX<Variable>>& vars,
+    const Eigen::Ref<const Eigen::VectorXi>& degrees)
+    : PolynomialBasisElement(vars, degrees) {}
+
+MonomialBasisElement::MonomialBasisElement(const Variable& var)
+    : MonomialBasisElement({{var, 1}}) {}
+
+MonomialBasisElement::MonomialBasisElement(const Variable& var, int degree)
+    : MonomialBasisElement({{var, degree}}) {}
+
+MonomialBasisElement::MonomialBasisElement() : PolynomialBasisElement() {}
+
+MonomialBasisElement::MonomialBasisElement(const Expression& e)
+    : MonomialBasisElement(ToMonomialPower(e.Expand())) {}
+
+bool MonomialBasisElement::operator<(const MonomialBasisElement& other) const {
+  return this->lexicographical_compare(other);
+}
+
+std::pair<double, MonomialBasisElement> MonomialBasisElement::EvaluatePartial(
+    const Environment& env) const {
+  double coeff{};
+  std::map<Variable, int> new_basis_element;
+  DoEvaluatePartial(env, &coeff, &new_basis_element);
+  return std::make_pair(coeff, MonomialBasisElement(new_basis_element));
+}
+
+double MonomialBasisElement::DoEvaluate(double variable_val, int degree) const {
+  return std::pow(variable_val, degree);
+}
+
+Expression MonomialBasisElement::DoToExpression() const {
+  // It builds this base_to_exponent_map and uses ExpressionMulFactory to build
+  // a multiplication expression.
+  std::map<Expression, Expression> base_to_exponent_map;
+  for (const auto& [var, degree] : var_to_degree_map()) {
+    base_to_exponent_map.emplace(Expression{var}, degree);
+  }
+  return ExpressionMulFactory{1.0, base_to_exponent_map}.GetExpression();
+}
+
+std::ostream& operator<<(std::ostream& out, const MonomialBasisElement& m) {
+  if (m.var_to_degree_map().empty()) {
+    return out << 1;
+  }
+  auto it = m.var_to_degree_map().begin();
+  out << it->first;
+  if (it->second > 1) {
+    out << "^" << it->second;
+  }
+  for (++it; it != m.var_to_degree_map().end(); ++it) {
+    out << " * ";
+    out << it->first;
+    if (it->second > 1) {
+      out << "^" << it->second;
+    }
+  }
+  return out;
+}
+
+MonomialBasisElement& MonomialBasisElement::pow_in_place(const int p) {
+  if (p < 0) {
+    std::ostringstream oss;
+    oss << "MonomialBasisElement::pow(int p) is called with a negative p = "
+        << p;
+    throw std::runtime_error(oss.str());
+  }
+  if (p == 0) {
+    int* total_degree = get_mutable_total_degree();
+    *total_degree = 0;
+    get_mutable_var_to_degree_map()->clear();
+  } else if (p > 1) {
+    for (auto& item : *get_mutable_var_to_degree_map()) {
+      int& exponent{item.second};
+      exponent *= p;
+    }
+    int* total_degree = get_mutable_total_degree();
+    *total_degree *= p;
+  }  // If p == 1, NO OP.
+  return *this;
+}
+
+std::map<MonomialBasisElement, double> MonomialBasisElement::Differentiate(
+    const Variable& var) const {
+  std::map<Variable, int> new_var_to_degree_map = var_to_degree_map();
+  auto it = new_var_to_degree_map.find(var);
+  if (it == new_var_to_degree_map.end()) {
+    return {};
+  }
+  const int degree = it->second;
+  it->second--;
+  return {{MonomialBasisElement(new_var_to_degree_map), degree}};
+}
+
+std::map<MonomialBasisElement, double> MonomialBasisElement::Integrate(
+    const Variable& var) const {
+  auto new_var_to_degree_map = var_to_degree_map();
+  auto it = new_var_to_degree_map.find(var);
+  if (it == new_var_to_degree_map.end()) {
+    // var is not a variable in var_to_degree_map. Append it to
+    // new_var_to_degree_map.
+    new_var_to_degree_map.emplace_hint(it, var, 1);
+    return {{MonomialBasisElement(new_var_to_degree_map), 1.}};
+  }
+  const int degree = it->second;
+  it->second++;
+  return {{MonomialBasisElement(new_var_to_degree_map), 1. / (degree + 1)}};
+}
+
+std::map<MonomialBasisElement, double> operator*(
+    const MonomialBasisElement& m1, const MonomialBasisElement& m2) {
+  std::map<Variable, int> var_to_degree_map_product = m1.var_to_degree_map();
+  for (const auto& [var, degree] : m2.var_to_degree_map()) {
+    auto it = var_to_degree_map_product.find(var);
+    if (it == var_to_degree_map_product.end()) {
+      var_to_degree_map_product.emplace(var, degree);
+    } else {
+      it->second += degree;
+    }
+  }
+  MonomialBasisElement product(var_to_degree_map_product);
+  return std::map<MonomialBasisElement, double>{{{product, 1.}}};
+}
+
+std::map<MonomialBasisElement, double> pow(MonomialBasisElement m, int p) {
+  return std::map<MonomialBasisElement, double>{{{m.pow_in_place(p), 1.}}};
+}
+
+}  // namespace symbolic
+}  // namespace drake

--- a/common/symbolic_monomial_basis_element.h
+++ b/common/symbolic_monomial_basis_element.h
@@ -1,0 +1,195 @@
+#pragma once
+
+#ifndef DRAKE_COMMON_SYMBOLIC_HEADER
+// TODO(soonho-tri): Change to #error, when #6613 merged.
+#warning Do not directly include this file. Include "drake/common/symbolic.h".
+#endif
+
+#include <map>
+#include <utility>
+
+#include <Eigen/Core>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/hash.h"
+#include "drake/common/symbolic.h"
+
+namespace drake {
+namespace symbolic {
+/**
+ * MonomialBasisElement represents a monomial, a product of powers of variables
+ * with non-negative integer exponents. Note that it doesn't not include the
+ * coefficient part of a monomial. So x, x³y, xy²z are all valid
+ * MonomialBasisElement instances, but 1+x or 2xy²z are not.
+ * TODO(hongkai.dai): deprecate Monomial class and replace Monomial class with
+ * MonomialBasisElement class.
+ * For more information regarding the motivation of this class, please see
+ * Drake github issue #13602 and #13803.
+ */
+class MonomialBasisElement : public PolynomialBasisElement {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(MonomialBasisElement)
+
+  /** Constructs a monomial equal to 1. Namely the toal degree is zero. */
+  MonomialBasisElement();
+
+  /** Constructs a default value.  This overload is used by Eigen when
+   * EIGEN_INITIALIZE_MATRICES_BY_ZERO is enabled.
+   */
+  explicit MonomialBasisElement(std::nullptr_t) : MonomialBasisElement() {}
+
+  /**
+   * Constructs a MonomialBasisElement from variable to degree map.
+   */
+  explicit MonomialBasisElement(
+      const std::map<Variable, int>& var_to_degree_map);
+
+  /**
+   * Converts an expression to a monomial if the expression is written as
+   * ∏ᵢpow(xᵢ, kᵢ), otherwise throws a runtime error.
+   * @pre is_polynomial(e) should be true.
+   */
+  explicit MonomialBasisElement(const Expression& e);
+
+  /** Constructs a Monomial from a vector of variables `vars` and their
+   * corresponding integer degrees `degrees`.
+   * For example, `MonomialBasisElement([x, y, z], [2, 0, 1])` constructs a
+   * MonomialBasisElement `x²z`.
+   *
+   * @pre The size of `vars` should be the same as the size of `degrees`.
+   * @throws std::logic_error if `degrees` includes a negative integer.
+   */
+  MonomialBasisElement(const Eigen::Ref<const VectorX<Variable>>& vars,
+                       const Eigen::Ref<const Eigen::VectorXi>& degrees);
+
+  /**
+   * Constructs a monomial basis element with only one variable, and the degree
+   * is 1.
+   */
+  explicit MonomialBasisElement(const Variable& var);
+
+  /**
+   * Constructs a monomial basis element with only one variable, and the degree
+   * of that variable is given by @p degree.
+   */
+  MonomialBasisElement(const Variable& var, int degree);
+
+  /** Partially evaluates using a given environment @p env. The evaluation
+   * result is of type pair<double, MonomialBasisElement>. The first component
+   * (: double) represents the coefficient part while the second component
+   * represents the remaining parts of the MonomialBasisElement which was not
+   * evaluated.
+   *
+   * Example 1. Evaluate with a fully-specified environment
+   *     (x³*y²).EvaluatePartial({{x, 2}, {y, 3}})
+   *   = (2³ * 3² = 8 * 9 = 72, MonomialBasisElement{} = 1).
+   *
+   * Example 2. Evaluate with a partial environment
+   *     (x³*y²).EvaluatePartial({{x, 2}})
+   *   = (2³ = 8, y²).
+   */
+  std::pair<double, MonomialBasisElement> EvaluatePartial(
+      const Environment& env) const;
+
+  /** Returns this monomial raised to @p p.
+   * @throws std::runtime_error if @p p is negative.
+   */
+  MonomialBasisElement& pow_in_place(int p);
+
+  /**
+   * Compares two MonomialBasisElement in lexicographic order.
+   */
+  bool operator<(const MonomialBasisElement& other) const;
+
+  /**
+   * Differentiates this MonomialBasisElement.
+   * Since dxⁿ/dx = nxⁿ⁻¹, we return the map from the MonomialBasisElement to
+   * its coefficient. So if this MonomialBasisElement is x³y², then
+   * differentiate with x will return (x²y² → 3) as dx³y²/dx = 3x²y²
+   * If @p var is not a variable in MonomialBasisElement, then returns an empty
+   * map.
+   */
+  std::map<MonomialBasisElement, double> Differentiate(
+      const Variable& var) const;
+
+  /**
+   * Integrates this MonomialBasisElement on a variable.
+   * Since ∫ xⁿ dx = 1 / (n+1) xⁿ⁺¹, we return the map from the
+   * MonomialBasisElement to its coefficient in the integration result. So if
+   * this MonomialBasisElement is x³y², then we return (x⁴y² → 1/4) as ∫ x³y²dx
+   * = 1/4 x⁴y². If @p var is not a variable in this MonomialBasisElement, for
+   * example ∫ x³y²dz = x³y²z, then we return (x³y²z → 1)
+   */
+  std::map<MonomialBasisElement, double> Integrate(const Variable& var) const;
+
+  /** Implements the @ref hash_append concept. */
+  template <class HashAlgorithm>
+  friend void hash_append(HashAlgorithm& hasher,
+                          const MonomialBasisElement& item) noexcept {
+    using drake::hash_append;
+    // We do not send total_degree_ to the hasher, because it is already fully
+    // represented by var_to_degree_map_ -- it is just a cached tally of the
+    // exponents.
+    hash_append(hasher, item.var_to_degree_map());
+  }
+
+ private:
+  double DoEvaluate(double variable_val, int degree) const override;
+  Expression DoToExpression() const override;
+};
+
+std::ostream& operator<<(std::ostream& out, const MonomialBasisElement& m);
+
+/** Returns a multiplication of two monomials, @p m1 and @p m2.
+ * @note that we return a map from the monomial product to its coefficient. This
+ * map has size 1, and the coefficient is also 1. We return a map instead of the
+ * MonomialBasisElement directly, because we want operator* to have the same
+ * return signature as other PolynomialBasisElement. For example, the product
+ * between two ChebyshevBasisElement objects is a weighted sum of
+ * ChebyshevBasisElement objects.
+ * @note we do not provide operator*= function for this class, since operator*=
+ * would return MonomialBasisElement, which is different from operator*.
+ */
+std::map<MonomialBasisElement, double> operator*(
+    const MonomialBasisElement& m1, const MonomialBasisElement& m2);
+
+/** Returns @p m raised to @p p.
+ * @note that we return a map from the monomial power to its coefficient. This
+ * map has size 1, and the coefficient is also 1. We return a map instead of the
+ * MonomialBasisElement directly, because we want pow() to have the same
+ * return signature as other PolynomialBasisElement. For example, the power
+ * of a ChebyshevBasisElement object is a weighted sum of ChebyshevBasisElement
+ * objects.
+ * @throws std::runtime_error if @p p is negative.
+ */
+std::map<MonomialBasisElement, double> pow(MonomialBasisElement m, int p);
+}  // namespace symbolic
+}  // namespace drake
+
+namespace std {
+/* Provides std::hash<drake::symbolic::MonomialBasisElement>. */
+template <>
+struct hash<drake::symbolic::MonomialBasisElement> : public drake::DefaultHash {
+};
+}  // namespace std
+
+#if !defined(DRAKE_DOXYGEN_CXX)
+namespace Eigen {
+// Eigen scalar type traits for Matrix<drake::symbolic::MonomialBasisElement>.
+template <>
+struct NumTraits<drake::symbolic::MonomialBasisElement>
+    : GenericNumTraits<drake::symbolic::MonomialBasisElement> {
+  static inline int digits10() { return 0; }
+};
+
+namespace internal {
+// Informs Eigen how to cast drake::symbolic::MonomialBasisElement to
+// drake::symbolic::Expression.
+template <>
+EIGEN_DEVICE_FUNC inline drake::symbolic::Expression cast(
+    const drake::symbolic::MonomialBasisElement& m) {
+  return m.ToExpression();
+}
+}  // namespace internal
+}  // namespace Eigen
+#endif  // !defined(DRAKE_DOXYGEN_CXX)

--- a/common/symbolic_polynomial_basis_element.h
+++ b/common/symbolic_polynomial_basis_element.h
@@ -36,6 +36,7 @@ namespace symbolic {
  * - std::map<Derived, double> operator*(const Derived& A, const Derived&B)
  * - std::map<Derived, double> Derived::Differentiate(const Variable& var)
  * const;
+ * - std::map<Derived, double> Derived::Integrate(const Variable& var) const;
  * - bool Derived::operator<(const Derived& other) const;
  * - std::pair<double, Derived> EvaluatePartial(const Environment& e) const;
  *

--- a/common/test/symbolic_chebyshev_basis_element_test.cc
+++ b/common/test/symbolic_chebyshev_basis_element_test.cc
@@ -189,26 +189,25 @@ TEST_F(SymbolicChebyshevBasisElementTest, Differentiate) {
   EXPECT_EQ(result8.at(ChebyshevBasisElement({{x_, 1}, {y_, 3}})), 8);
 }
 
-TEST_F(SymbolicChebyshevBasisElementTest, Integration) {
+TEST_F(SymbolicChebyshevBasisElementTest, Integrate) {
   // ∫1dx = T1(x)
-  const auto result1 = ChebyshevBasisElement().Integration(x_);
+  const auto result1 = ChebyshevBasisElement().Integrate(x_);
   EXPECT_EQ(result1.size(), 1);
   EXPECT_EQ(result1.at(ChebyshevBasisElement({{x_, 1}})), 1);
 
   // ∫T2(x)dy = T2(x)T1(y)
-  const auto result2 = ChebyshevBasisElement({{x_, 2}}).Integration(y_);
+  const auto result2 = ChebyshevBasisElement({{x_, 2}}).Integrate(y_);
   EXPECT_EQ(result2.size(), 1);
   EXPECT_EQ(result2.at(ChebyshevBasisElement({{x_, 2}, {y_, 1}})), 1);
 
   // ∫T2(x)dx = 1/6*T3(x) - 1/2*T1(x)
-  const auto result3 = ChebyshevBasisElement({{x_, 2}}).Integration(x_);
+  const auto result3 = ChebyshevBasisElement({{x_, 2}}).Integrate(x_);
   EXPECT_EQ(result3.size(), 2);
   EXPECT_EQ(result3.at(ChebyshevBasisElement({{x_, 3}})), 1. / 6);
   EXPECT_EQ(result3.at(ChebyshevBasisElement({{x_, 1}})), -1. / 2);
 
   // ∫T3(x)T2(y)dx = 1/8*T4(x)T2(y) - 1/4*T2(x)T2(y)
-  const auto result4 =
-      ChebyshevBasisElement({{x_, 3}, {y_, 2}}).Integration(x_);
+  const auto result4 = ChebyshevBasisElement({{x_, 3}, {y_, 2}}).Integrate(x_);
   EXPECT_EQ(result4.size(), 2);
   EXPECT_EQ(result4.at(ChebyshevBasisElement({{x_, 4}, {y_, 2}})), 1. / 8);
   EXPECT_EQ(result4.at(ChebyshevBasisElement({{x_, 2}, {y_, 2}})), -1. / 4);

--- a/common/test/symbolic_monomial_basis_element_test.cc
+++ b/common/test/symbolic_monomial_basis_element_test.cc
@@ -1,0 +1,584 @@
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/symbolic.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/common/test_utilities/symbolic_test_util.h"
+
+using std::pair;
+using std::runtime_error;
+
+namespace drake {
+namespace symbolic {
+
+using test::ExprEqual;
+using test::VarLess;
+
+class MonomialBasisElementTest : public ::testing::Test {
+ protected:
+  const symbolic::Variable var_w_{"w"};
+  const symbolic::Variable var_z_{"z"};
+  const symbolic::Variable var_y_{"y"};
+  const symbolic::Variable var_x_{"x"};
+
+  const Expression w_{var_w_};
+  const Expression z_{var_z_};
+  const Expression y_{var_y_};
+  const Expression x_{var_x_};
+
+  std::vector<MonomialBasisElement> monomials_;
+
+  void SetUp() override {
+    monomials_ = {
+        MonomialBasisElement{},                            // 1.0
+        MonomialBasisElement{var_x_, 1},                   // x^1
+        MonomialBasisElement{var_y_, 1},                   // y^1
+        MonomialBasisElement{var_z_, 1},                   // z^1
+        MonomialBasisElement{var_x_, 2},                   // x^2
+        MonomialBasisElement{var_y_, 3},                   // y^3
+        MonomialBasisElement{var_z_, 4},                   // z^4
+        MonomialBasisElement{{{var_x_, 1}, {var_y_, 2}}},  // xy^2
+        MonomialBasisElement{{{var_y_, 2}, {var_z_, 5}}},  // y^2z^5
+        MonomialBasisElement{
+            {{var_x_, 1}, {var_y_, 2}, {var_z_, 3}}},  // xy^2z^3
+        MonomialBasisElement{
+            {{var_x_, 2}, {var_y_, 4}, {var_z_, 3}}},  // x^2y^4z^3
+    };
+
+    EXPECT_PRED2(VarLess, var_y_, var_x_);
+    EXPECT_PRED2(VarLess, var_z_, var_y_);
+    EXPECT_PRED2(VarLess, var_w_, var_z_);
+  }
+
+  // Helper function to extract Substitution (Variable -> Expression) from a
+  // symbolic environment.
+  Substitution ExtractSubst(const Environment& env) {
+    Substitution subst;
+    subst.reserve(env.size());
+    for (const pair<const Variable, double>& p : env) {
+      subst.emplace(p.first, p.second);
+    }
+    return subst;
+  }
+
+  // Checks if MonomialBasisElement::Evaluate corresponds to
+  // Expression::Evaluate.
+  //
+  //                            ToExpression
+  //                     MonomialBasisElement ----> Expression
+  //                                ||                ||
+  // MonomialBasisElement::Evaluate ||                || Expression::Evaluate
+  //                                ||                ||
+  //                                \/                \/
+  //                          double (result2) == double (result1)
+  //
+  // In one direction (left-to-right), we convert a Monomial to an Expression
+  // and evaluate it to a double value (result1). In another direction
+  // (top-to-bottom), we directly evaluate a Monomial to double (result2). The
+  // two result1 and result2 should be the same.
+  bool CheckEvaluate(const MonomialBasisElement& m, const Environment& env) {
+    const double result1{m.ToExpression().Evaluate(env)};
+    const double result2{m.Evaluate(env)};
+    return result1 == result2;
+  }
+
+  // Checks if MonomialBasisElement::EvaluatePartial corresponds to Expression's
+  // EvaluatePartial.
+  //
+  //                            ToExpression
+  //           MonomialBasisElement ---------> Expression
+  //                      ||                      ||
+  //      EvaluatePartial ||                      || EvaluatePartial
+  //                      ||                      ||
+  //                      \/                      \/
+  //   double * MonomialBasisElement (e2) ==  Expression (e1)
+  //
+  // In one direction (left-to-right), first we convert a MonomialBasisElement
+  // to an Expression using MonomialBasisElement::ToExpression and call
+  // Expression::EvaluatePartial to have an Expression (e1). In another
+  // direction (top-to-bottom), we call MonomialBasisElement::EvaluatePartial
+  // which returns a pair of double (coefficient part) and Monomial. We obtain
+  // e2 by multiplying the two. Then, we check if e1 and e2 are structurally
+  // equal.
+  bool CheckEvaluatePartial(const MonomialBasisElement& m,
+                            const Environment& env) {
+    const Expression e1{m.ToExpression().EvaluatePartial(env)};
+    const pair<double, MonomialBasisElement> subst_result{
+        m.EvaluatePartial(env)};
+    const Expression e2{subst_result.first *
+                        subst_result.second.ToExpression()};
+
+    return e1.EqualTo(e2);
+  }
+};
+
+TEST_F(MonomialBasisElementTest, Constructor) {
+  const MonomialBasisElement m1{};
+  EXPECT_TRUE(m1.var_to_degree_map().empty());
+  EXPECT_EQ(m1.total_degree(), 0);
+
+  const MonomialBasisElement m2{var_x_};
+  EXPECT_EQ(m2.var_to_degree_map().size(), 1);
+  EXPECT_EQ(m2.var_to_degree_map().at(var_x_), 1);
+  EXPECT_EQ(m2.total_degree(), 1);
+
+  const MonomialBasisElement m3{pow(var_x_, 2) * pow(var_y_, 3)};
+  EXPECT_EQ(m3.var_to_degree_map().size(), 2);
+  EXPECT_EQ(m3.var_to_degree_map().at(var_x_), 2);
+  EXPECT_EQ(m3.var_to_degree_map().at(var_y_), 3);
+  EXPECT_EQ(m3.total_degree(), 5);
+
+  const MonomialBasisElement m4{{{var_x_, 3}, {var_y_, 2}}};
+  EXPECT_EQ(m4.var_to_degree_map().size(), 2);
+  EXPECT_EQ(m4.var_to_degree_map().at(var_x_), 3);
+  EXPECT_EQ(m4.var_to_degree_map().at(var_y_), 2);
+  EXPECT_EQ(m4.total_degree(), 5);
+
+  const MonomialBasisElement m5{{{var_x_, 3}, {var_y_, 0}}};
+  EXPECT_EQ(m5.var_to_degree_map().size(), 1);
+  EXPECT_EQ(m5.var_to_degree_map().at(var_x_), 3);
+  EXPECT_EQ(m5.total_degree(), 3);
+
+  const MonomialBasisElement m6{Vector2<Variable>(var_x_, var_y_),
+                                Eigen::Vector2i(1, 3)};
+  EXPECT_EQ(m6.var_to_degree_map().size(), 2);
+  EXPECT_EQ(m6.var_to_degree_map().at(var_x_), 1);
+  EXPECT_EQ(m6.var_to_degree_map().at(var_y_), 3);
+  EXPECT_EQ(m6.total_degree(), 4);
+
+  const MonomialBasisElement m7{var_x_, 3};
+  EXPECT_EQ(m7.var_to_degree_map().size(), 1);
+  EXPECT_EQ(m7.var_to_degree_map().at(var_x_), 3);
+  EXPECT_EQ(m7.total_degree(), 3);
+}
+
+// Tests that default constructor and EIGEN_INITIALIZE_MATRICES_BY_ZERO
+// constructor both create the same value.
+TEST_F(MonomialBasisElementTest, DefaultConstructors) {
+  const MonomialBasisElement m_default;
+  const MonomialBasisElement m_zero(0);
+  EXPECT_EQ(m_default.total_degree(), 0);
+  EXPECT_EQ(m_zero.total_degree(), 0);
+}
+
+TEST_F(MonomialBasisElementTest, ConstructFromVariable) {
+  const MonomialBasisElement m1{var_x_};
+  const std::map<Variable, int> powers{m1.var_to_degree_map()};
+
+  // Checks that powers = {x ↦ 1}.
+  ASSERT_EQ(powers.size(), 1u);
+  EXPECT_EQ(powers.begin()->first, var_x_);
+  EXPECT_EQ(powers.begin()->second, 1);
+}
+
+TEST_F(MonomialBasisElementTest, ConstructFromVariablesAndExponents) {
+  // [] * [] => 1.
+  const VectorX<Variable> vars(0);
+  const VectorX<int> exponents(0);
+  const MonomialBasisElement one{MonomialBasisElement{Expression::One()}};
+  EXPECT_EQ(MonomialBasisElement(vars, exponents), one);
+
+  const Vector3<Variable> vars_xyz{var_x_, var_y_, var_z_};
+  // [x, y, z] * [0, 0, 0] => 1.
+  const MonomialBasisElement m1{vars_xyz, Eigen::Vector3i{0, 0, 0}};
+  EXPECT_EQ(m1, one);
+
+  // [x, y, z] * [1, 1, 1] => xyz.
+  const MonomialBasisElement m2{vars_xyz, Eigen::Vector3i{1, 1, 1}};
+  const MonomialBasisElement m2_expected{x_ * y_ * z_};
+  EXPECT_EQ(m2, m2_expected);
+
+  // [x, y, z] * [2, 0, 3] => x²z³.
+  const MonomialBasisElement m3{vars_xyz, Eigen::Vector3i{2, 0, 3}};
+  const MonomialBasisElement m3_expected{pow(x_, 2) * pow(z_, 3)};
+  EXPECT_EQ(m3, m3_expected);
+
+  // [x, y, z] * [2, 0, -1] => Exception!
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      MonomialBasisElement(vars_xyz, Eigen::Vector3i(2, 0, -1)),
+      std::logic_error, "The exponent is negative.");
+}
+
+TEST_F(MonomialBasisElementTest, GetVariables) {
+  const MonomialBasisElement m0{};
+  EXPECT_EQ(m0.GetVariables(), Variables{});
+
+  const MonomialBasisElement m1{var_z_, 4};
+  EXPECT_EQ(m1.GetVariables(), Variables({var_z_}));
+
+  const MonomialBasisElement m2{{{var_x_, 1}, {var_y_, 2}}};
+  EXPECT_EQ(m2.GetVariables(), Variables({var_x_, var_y_}));
+
+  const MonomialBasisElement m3{{{var_x_, 1}, {var_y_, 2}, {var_z_, 3}}};
+  EXPECT_EQ(m3.GetVariables(), Variables({var_x_, var_y_, var_z_}));
+}
+
+// Checks we can have an Eigen matrix of Monomials without compilation
+// errors. No assertions in the test.
+TEST_F(MonomialBasisElementTest, EigenMatrixOfMonomials) {
+  Eigen::Matrix<MonomialBasisElement, 2, 2> M;
+  // M = | 1   x    |
+  //     | y²  x²z³ |
+  M << MonomialBasisElement{}, MonomialBasisElement{var_x_},
+      MonomialBasisElement{{{var_y_, 2}}},
+      MonomialBasisElement{{{var_x_, 2}, {var_z_, 3}}};
+
+  // The following fails if we do not provide
+  // `Eigen::NumTraits<drake::symbolic::MonomialBasisElement>`.
+  std::ostringstream oss;
+  oss << M;
+}
+
+TEST_F(MonomialBasisElementTest, MonomialOne) {
+  // Compares monomials all equal to 1, but with different variables.
+  MonomialBasisElement m1{};
+  MonomialBasisElement m2({{var_x_, 0}});
+  MonomialBasisElement m3({{var_x_, 0}, {var_y_, 0}});
+  EXPECT_EQ(m1, m2);
+  EXPECT_EQ(m1, m3);
+  EXPECT_EQ(m2, m3);
+}
+
+TEST_F(MonomialBasisElementTest, MonomialWithZeroExponent) {
+  // Compares monomials containing zero exponent, such as x^0 * y^2
+  MonomialBasisElement m1({{var_y_, 2}});
+  MonomialBasisElement m2({{var_x_, 0}, {var_y_, 2}});
+  EXPECT_EQ(m1, m2);
+  EXPECT_EQ(m2.var_to_degree_map().size(), 1);
+  std::map<Variable, int> power_expected;
+  power_expected.emplace(var_y_, 2);
+  EXPECT_EQ(m2.var_to_degree_map(), power_expected);
+}
+
+// This test shows that we can have a std::unordered_map whose key is of
+// MonomialBasisElement.
+TEST_F(MonomialBasisElementTest, UnorderedMapOfMonomial) {
+  std::unordered_map<MonomialBasisElement, double> monomial_to_coeff_map;
+  MonomialBasisElement x_3{var_x_, 3};
+  MonomialBasisElement y_5{var_y_, 5};
+  // Add 2 * x^3
+  monomial_to_coeff_map.emplace(x_3, 2);
+  // Add -7 * y^5
+  monomial_to_coeff_map.emplace(y_5, -7);
+
+  const auto it1 = monomial_to_coeff_map.find(x_3);
+  ASSERT_TRUE(it1 != monomial_to_coeff_map.end());
+  EXPECT_EQ(it1->second, 2);
+
+  const auto it2 = monomial_to_coeff_map.find(y_5);
+  ASSERT_TRUE(it2 != monomial_to_coeff_map.end());
+  EXPECT_EQ(it2->second, -7);
+}
+
+// Converts a constant to monomial.
+TEST_F(MonomialBasisElementTest, ToMonomial0) {
+  MonomialBasisElement expected;
+  EXPECT_EQ(MonomialBasisElement(1), expected);
+  EXPECT_EQ(MonomialBasisElement(pow(x_, 0)), expected);
+  EXPECT_THROW(MonomialBasisElement(2), std::exception);
+}
+
+// Converts expression x to monomial.
+TEST_F(MonomialBasisElementTest, ToMonomial1) {
+  MonomialBasisElement expected(var_x_, 1);
+  EXPECT_EQ(MonomialBasisElement(x_), expected);
+}
+
+// Converts expression x * y to monomial.
+TEST_F(MonomialBasisElementTest, ToMonomial2) {
+  std::map<Variable, int> powers;
+  powers.emplace(var_x_, 1);
+  powers.emplace(var_y_, 1);
+  MonomialBasisElement expected(powers);
+  EXPECT_EQ(MonomialBasisElement(x_ * y_), expected);
+}
+
+// Converts expression x^3 to monomial.
+TEST_F(MonomialBasisElementTest, ToMonomial3) {
+  MonomialBasisElement expected(var_x_, 3);
+  EXPECT_EQ(MonomialBasisElement(pow(x_, 3)), expected);
+  EXPECT_EQ(MonomialBasisElement(pow(x_, 2) * x_), expected);
+}
+
+// Converts expression x^3 * y to monomial.
+TEST_F(MonomialBasisElementTest, ToMonomial4) {
+  std::map<Variable, int> powers;
+  powers.emplace(var_x_, 3);
+  powers.emplace(var_y_, 1);
+  MonomialBasisElement expected(powers);
+  EXPECT_EQ(MonomialBasisElement(pow(x_, 3) * y_), expected);
+  EXPECT_EQ(MonomialBasisElement(pow(x_, 2) * y_ * x_), expected);
+}
+
+// Converts expression x*(y+z) - x*y to monomial
+TEST_F(MonomialBasisElementTest, ToMonomial5) {
+  std::map<Variable, int> powers({{var_x_, 1}, {var_z_, 1}});
+  MonomialBasisElement expected(powers);
+  EXPECT_EQ(MonomialBasisElement(x_ * z_), expected);
+  EXPECT_EQ(MonomialBasisElement(x_ * (y_ + z_) - x_ * y_), expected);
+}
+
+// `pow(x * y, 2) * pow(x^2 * y^2, 3)` is a monomial (x^8 * y^8).
+TEST_F(MonomialBasisElementTest, ToMonomial6) {
+  const MonomialBasisElement m1{pow(x_ * y_, 2) * pow(x_ * x_ * y_ * y_, 3)};
+  const MonomialBasisElement m2{{{var_x_, 8}, {var_y_, 8}}};
+  EXPECT_EQ(m1, m2);
+}
+
+// x^0 is a monomial (1).
+TEST_F(MonomialBasisElementTest, ToMonomial7) {
+  const MonomialBasisElement m1(var_x_, 0);
+  const MonomialBasisElement m2{Expression{1.0}};
+  const MonomialBasisElement m3{pow(x_, 0.0)};
+  EXPECT_EQ(m1, m2);
+  EXPECT_EQ(m1, m3);
+  EXPECT_EQ(m2, m3);
+}
+
+// `2 * x` is not a monomial because of its coefficient `2`.
+TEST_F(MonomialBasisElementTest, ToMonomialException1) {
+  EXPECT_THROW(MonomialBasisElement{2 * x_}, runtime_error);
+}
+
+// `x + y` is not a monomial.
+TEST_F(MonomialBasisElementTest, ToMonomialException2) {
+  EXPECT_THROW(MonomialBasisElement{x_ + y_}, runtime_error);
+}
+
+// `x / 2.0` is not a monomial.
+TEST_F(MonomialBasisElementTest, ToMonomialException3) {
+  EXPECT_THROW(MonomialBasisElement{x_ / 2.0}, runtime_error);
+}
+
+// `x ^ -1` is not a monomial.
+TEST_F(MonomialBasisElementTest, ToMonomialException4) {
+  // Note: Parentheses are required around macro argument containing braced
+  // initializer list.
+  DRAKE_EXPECT_THROWS_MESSAGE((MonomialBasisElement{{{var_x_, -1}}}),
+                              std::logic_error,
+                              "The degree for x is negative.");
+}
+
+TEST_F(MonomialBasisElementTest, Multiplication) {
+  // m₁ = xy²
+  const MonomialBasisElement m1{{{var_x_, 1}, {var_y_, 2}}};
+  // m₂ = y²z⁵
+  const MonomialBasisElement m2{{{var_y_, 2}, {var_z_, 5}}};
+  // m₃ = m₁ * m₂ = xy⁴z⁵
+  const MonomialBasisElement m3{{{var_x_, 1}, {var_y_, 4}, {var_z_, 5}}};
+  const std::map<MonomialBasisElement, double> result1 = m1 * m2;
+  EXPECT_EQ(result1.size(), 1);
+  EXPECT_EQ(result1.at(m3), 1);
+
+  // m₄=z³
+  const MonomialBasisElement m4(var_z_, 3);
+  const auto result2 = m1 * m4;
+  EXPECT_EQ(result2.size(), 1);
+  EXPECT_EQ(
+      result2.at(MonomialBasisElement({{var_x_, 1}, {var_y_, 2}, {var_z_, 3}})),
+      1);
+
+  const auto result3 = m2 * m4;
+  EXPECT_EQ(result3.size(), 1);
+  EXPECT_EQ(result3.at(MonomialBasisElement({{var_y_, 2}, {var_z_, 8}})), 1);
+}
+
+TEST_F(MonomialBasisElementTest, Pow) {
+  // m₁ = xy²
+  const MonomialBasisElement m1{{{var_x_, 1}, {var_y_, 2}}};
+  // m₂ = y²z⁵
+  const MonomialBasisElement m2{{{var_y_, 2}, {var_z_, 5}}};
+
+  // pow(m₁, 0) = 1.0
+  const std::map<MonomialBasisElement, double> result1 = pow(m1, 0);
+  EXPECT_EQ(result1.size(), 1);
+  EXPECT_EQ(result1.at(MonomialBasisElement()), 1);
+  // pow(m₂, 0) = 1.0
+  const std::map<MonomialBasisElement, double> result2 = pow(m2, 0);
+  EXPECT_EQ(result2.size(), 1);
+  EXPECT_EQ(result2.at(MonomialBasisElement()), 1);
+
+  // pow(m₁, 1) = m₁
+  const auto result3 = pow(m1, 1);
+  EXPECT_EQ(result3.size(), 1);
+  EXPECT_EQ(result3.at(m1), 1);
+  // pow(m₂, 1) = m₂
+  const auto result4 = pow(m2, 1);
+  EXPECT_EQ(result4.size(), 1);
+  EXPECT_EQ(result4.at(m2), 1);
+
+  // pow(m₁, 3) = x³y⁶
+  const auto result5 = pow(m1, 3);
+  EXPECT_EQ(result5.size(), 1);
+  EXPECT_EQ(result5.at(MonomialBasisElement({{var_x_, 3}, {var_y_, 6}})), 1);
+  EXPECT_EQ(result5.begin()->first.total_degree(), 9);
+  // pow(m₂, 4) = y⁸z²⁰
+  const auto result6 = pow(m2, 4);
+  EXPECT_EQ(result6.size(), 1);
+  EXPECT_EQ(result6.at(MonomialBasisElement({{var_y_, 8}, {var_z_, 20}})), 1);
+  EXPECT_EQ(result6.begin()->first.total_degree(), 28);
+
+  // pow(m₁, -1) throws an exception.
+  EXPECT_THROW(pow(m1, -1), runtime_error);
+  // pow(m₂, -5) throws an exception.
+  EXPECT_THROW(pow(m2, -5), runtime_error);
+}
+
+TEST_F(MonomialBasisElementTest, PowInPlace) {
+  // m₁ = xy²
+  MonomialBasisElement m1{{{var_x_, 1}, {var_y_, 2}}};
+  const MonomialBasisElement m1_copy{m1};
+  EXPECT_EQ(m1, m1_copy);
+
+  // m₁.pow_in_place modifies m₁.
+  m1.pow_in_place(2);
+  EXPECT_NE(m1, m1_copy);
+  EXPECT_EQ(m1, MonomialBasisElement({{var_x_, 2}, {var_y_, 4}}));
+  EXPECT_EQ(m1.total_degree(), 6);
+
+  // m₁ gets m₁⁰, which is 1.
+  m1.pow_in_place(0);
+  EXPECT_EQ(m1, MonomialBasisElement());
+  EXPECT_EQ(m1.total_degree(), 0);
+}
+
+TEST_F(MonomialBasisElementTest, Evaluate) {
+  const std::vector<Environment> environments{
+      {{var_x_, 1.0}, {var_y_, 2.0}, {var_z_, 3.0}},     // + + +
+      {{var_x_, -1.0}, {var_y_, 2.0}, {var_z_, 3.0}},    // - + +
+      {{var_x_, 1.0}, {var_y_, -2.0}, {var_z_, 3.0}},    // + - +
+      {{var_x_, 1.0}, {var_y_, 2.0}, {var_z_, -3.0}},    // + + -
+      {{var_x_, -1.0}, {var_y_, -2.0}, {var_z_, 3.0}},   // - - +
+      {{var_x_, 1.0}, {var_y_, -2.0}, {var_z_, -3.0}},   // + - -
+      {{var_x_, -1.0}, {var_y_, 2.0}, {var_z_, -3.0}},   // - + -
+      {{var_x_, -1.0}, {var_y_, -2.0}, {var_z_, -3.0}},  // - - -
+  };
+  for (const MonomialBasisElement& m : monomials_) {
+    for (const Environment& env : environments) {
+      EXPECT_TRUE(CheckEvaluate(m, env));
+    }
+  }
+}
+
+TEST_F(MonomialBasisElementTest, EvaluateException) {
+  const MonomialBasisElement m{{{var_x_, 1}, {var_y_, 2}}};  // xy^2
+  const Environment env{{{var_x_, 1.0}}};
+  EXPECT_THROW(m.Evaluate(env), std::invalid_argument);
+}
+
+TEST_F(MonomialBasisElementTest, EvaluatePartial) {
+  const std::vector<Environment> environments{
+      {{var_x_, 2.0}},
+      {{var_y_, 3.0}},
+      {{var_z_, 4.0}},
+      {{var_x_, 2.0}, {var_y_, -2.0}},
+      {{var_y_, -4.0}, {var_z_, 2.5}},
+      {{var_x_, -2.3}, {var_z_, 2.6}},
+      {{var_x_, -1.0}, {var_y_, 2.0}, {var_z_, 3.0}},
+  };
+  for (const MonomialBasisElement& m : monomials_) {
+    for (const Environment& env : environments) {
+      EXPECT_TRUE(CheckEvaluatePartial(m, env));
+    }
+  }
+}
+
+TEST_F(MonomialBasisElementTest, DegreeVariable) {
+  EXPECT_EQ(MonomialBasisElement().degree(var_x_), 0);
+  EXPECT_EQ(MonomialBasisElement().degree(var_y_), 0);
+
+  EXPECT_EQ(MonomialBasisElement(var_x_).degree(var_x_), 1);
+  EXPECT_EQ(MonomialBasisElement(var_x_).degree(var_y_), 0);
+
+  EXPECT_EQ(MonomialBasisElement(var_x_, 4).degree(var_x_), 4);
+  EXPECT_EQ(MonomialBasisElement(var_x_, 4).degree(var_y_), 0);
+
+  EXPECT_EQ(MonomialBasisElement({{var_x_, 1}, {var_y_, 2}}).degree(var_x_), 1);
+  EXPECT_EQ(MonomialBasisElement({{var_x_, 1}, {var_y_, 2}}).degree(var_y_), 2);
+}
+
+TEST_F(MonomialBasisElementTest, TotalDegree) {
+  EXPECT_EQ(MonomialBasisElement().total_degree(), 0);
+  EXPECT_EQ(MonomialBasisElement(var_x_).total_degree(), 1);
+  EXPECT_EQ(MonomialBasisElement(var_x_, 1).total_degree(), 1);
+  EXPECT_EQ(MonomialBasisElement(var_x_, 4).total_degree(), 4);
+  EXPECT_EQ(MonomialBasisElement({{var_x_, 1}, {var_y_, 2}}).total_degree(), 3);
+}
+
+TEST_F(MonomialBasisElementTest, Differentiate) {
+  // d1/dx = 0
+  const std::map<MonomialBasisElement, double> result1 =
+      MonomialBasisElement().Differentiate(var_x_);
+  EXPECT_TRUE(result1.empty());
+
+  // dxy / dz = 0
+  const std::map<MonomialBasisElement, double> result2 =
+      MonomialBasisElement{{{var_x_, 1}, {var_y_, 1}}}.Differentiate(var_z_);
+  EXPECT_TRUE(result2.empty());
+
+  // dx / dx = 1
+  const auto result3 = MonomialBasisElement(var_x_).Differentiate(var_x_);
+  EXPECT_EQ(result3.size(), 1);
+  EXPECT_EQ(result3.at(MonomialBasisElement()), 1);
+
+  // dxy / dy = x
+  const auto result4 =
+      MonomialBasisElement({{var_x_, 1}, {var_y_, 1}}).Differentiate(var_y_);
+  EXPECT_EQ(result4.size(), 1);
+  EXPECT_EQ(result4.at(MonomialBasisElement(var_x_)), 1);
+
+  // dx²y²z / dx = 2xy²z
+  const auto result5 =
+      MonomialBasisElement({{var_x_, 2}, {var_y_, 2}, {var_z_, 1}})
+          .Differentiate(var_x_);
+  EXPECT_EQ(result5.size(), 1);
+  EXPECT_EQ(
+      result5.at(MonomialBasisElement({{var_x_, 1}, {var_y_, 2}, {var_z_, 1}})),
+      2);
+  // x³y⁴z² / dy = 4x³y³z²
+  const auto result6 =
+      MonomialBasisElement({{var_x_, 3}, {var_y_, 4}, {var_z_, 2}})
+          .Differentiate(var_y_);
+  EXPECT_EQ(result6.size(), 1);
+  EXPECT_EQ(
+      result6.at(MonomialBasisElement({{var_x_, 3}, {var_y_, 3}, {var_z_, 2}})),
+      4);
+}
+
+TEST_F(MonomialBasisElementTest, Integrate) {
+  // ∫1 dx = x
+  const std::map<MonomialBasisElement, double> result1 =
+      MonomialBasisElement().Integrate(var_x_);
+  EXPECT_EQ(result1.size(), 1);
+  EXPECT_EQ(result1.at(MonomialBasisElement(var_x_)), 1);
+
+  // ∫ x dy = xy
+  const std::map<MonomialBasisElement, double> result2 =
+      MonomialBasisElement(var_x_).Integrate(var_y_);
+  EXPECT_EQ(result2.size(), 1);
+  EXPECT_EQ(result2.at(MonomialBasisElement({{var_x_, 1}, {var_y_, 1}})), 1);
+
+  // ∫x dx = x²/2
+  const auto result3 = MonomialBasisElement(var_x_).Integrate(var_x_);
+  EXPECT_EQ(result3.size(), 1);
+  EXPECT_EQ(result3.at(MonomialBasisElement(var_x_, 2)), 0.5);
+
+  // ∫ xy² dy = 1/3 xy³
+  const auto result4 =
+      MonomialBasisElement({{var_x_, 1}, {var_y_, 2}}).Integrate(var_y_);
+  EXPECT_EQ(result4.size(), 1);
+  EXPECT_EQ(result4.at(MonomialBasisElement({{var_x_, 1}, {var_y_, 3}})),
+            1. / 3);
+
+  // ∫ x²y³z dy = 1/4 x²y⁴z
+  const auto result5 =
+      MonomialBasisElement({{var_x_, 2}, {var_y_, 3}, {var_z_, 1}})
+          .Integrate(var_y_);
+  EXPECT_EQ(result5.size(), 1);
+  EXPECT_EQ(
+      result5.at(MonomialBasisElement({{var_x_, 2}, {var_y_, 4}, {var_z_, 1}})),
+      1. / 4);
+}
+
+}  // namespace symbolic
+}  // namespace drake


### PR DESCRIPTION
This PR is a step to #13803. 

This PR is large, but most of the code is just copy from `symbolic_monomial.h, symbolic_monomial.cc` and `symbolic_monomial_test.cc`.

The major change is
1. The return type of `operator*` is different in `MonomialBasisElement` vs `Monomial`. To keep the API consistent with `ChebyshevBasisElement`, the return type is `std::map<MonomialBasisElement, double>` instead of a single `Monomial`.
2. I added `Differentiate` and `Integration` to `MonomialBasisElement`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13867)
<!-- Reviewable:end -->
