### PR TITLE
bindings: Fix ConnectDrakeVisualizer keep_alive behavior

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -627,6 +627,8 @@ void DoScalarIndependentDefinitions(py::module m) {
       py::arg("role") = geometry::Role::kIllustration,
       // Keep alive, ownership: `return` keeps `builder` alive.
       py::keep_alive<0, 1>(),
+      // Keep alive, ownership: `builder` keeps `lcm` alive.
+      py::keep_alive<1, 3>(),
       // See #11531 for why `py_rvp::reference` is needed.
       py_rvp::reference, doc.ConnectDrakeVisualizer.doc_4args);
   m.def("ConnectDrakeVisualizer",
@@ -638,6 +640,8 @@ void DoScalarIndependentDefinitions(py::module m) {
       py::arg("role") = geometry::Role::kIllustration,
       // Keep alive, ownership: `return` keeps `builder` alive.
       py::keep_alive<0, 1>(),
+      // Keep alive, ownership: `builder` keeps `lcm` alive.
+      py::keep_alive<1, 3>(),
       // See #11531 for why `py_rvp::reference` is needed.
       py_rvp::reference, doc.ConnectDrakeVisualizer.doc_5args);
   m.def("DispatchLoadMessage", &DispatchLoadMessage, py::arg("scene_graph"),


### PR DESCRIPTION
When a DrakeLcm object is constructed in Python, within the call to ConnectDrakeVisualizer, nothing was keeping it alive which lead to a seg fault when the diagram was initialized ([see minimal reproduction](https://github.com/mpetersen94/drake/commit/d8b97d5b0f7c7cd6cf564cc97d779a74ecb69cf9)).  This ensures that the DrakeLcm object is kept alive so long as the diagram it is apart of is alive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13868)
<!-- Reviewable:end -->
