### PR TITLE
add a function to compute polynomial basis up to a given order.

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -210,6 +210,7 @@ drake_cc_library(
         "symbolic_monomial_util.h",
         "symbolic_polynomial.cc",
         "symbolic_polynomial.h",
+        "symbolic_polynomial_basis.h",
         "symbolic_polynomial_basis_element.cc",
         "symbolic_polynomial_basis_element.h",
         "symbolic_rational_function.cc",
@@ -1148,6 +1149,16 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "symbolic_polynomial_basis_element_test",
+    deps = [
+        ":essential",
+        ":symbolic",
+        "//common/test_utilities:expect_throws_message",
+        "//common/test_utilities:symbolic_test_util",
+    ],
+)
+
+drake_cc_googletest(
+    name = "symbolic_polynomial_basis_test",
     deps = [
         ":essential",
         ":symbolic",

--- a/common/symbolic.h
+++ b/common/symbolic.h
@@ -41,6 +41,7 @@
 #include "drake/common/symbolic_polynomial_basis_element.h"
 #include "drake/common/symbolic_chebyshev_basis_element.h"
 #include "drake/common/symbolic_chebyshev_polynomial.h"
+#include "drake/common/symbolic_polynomial_basis.h"
 #include "drake/common/symbolic_rational_function.h"
 #include "drake/common/symbolic_formula.h"
 #include "drake/common/symbolic_formula_visitor.h"

--- a/common/symbolic_monomial_util.h
+++ b/common/symbolic_monomial_util.h
@@ -100,6 +100,9 @@ namespace internal {
  * bin. Used as a helper function to implement MonomialBasis.
  *
  * @tparam MonomialOrder provides a monomial ordering.
+ * TODO(hongkai.dai): Remove this method and use
+ * AddPolynomialBasisElementsOfDegreeN in symbolic_polynomial_basis.h instead
+ * when we deprecate Monomial class.
  */
 template <typename MonomialOrder>
 void AddMonomialsOfDegreeN(const Variables& vars, int degree, const Monomial& b,

--- a/common/symbolic_polynomial_basis.h
+++ b/common/symbolic_polynomial_basis.h
@@ -1,0 +1,161 @@
+#pragma once
+
+#ifndef DRAKE_COMMON_SYMBOLIC_HEADER
+// TODO(soonho-tri): Change to #error, when #6613 merged.
+#warning Do not directly include this file. Include "drake/common/symbolic.h".
+#endif
+
+#include <functional>
+#include <map>
+#include <set>
+
+#include <Eigen/Core>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/symbolic.h"
+
+namespace drake {
+namespace symbolic {
+namespace internal {
+/* Adds the set {RaisePower(b, m) for m in Basis(vars, degree)} to `bin`.
+ `Basis` is the polynomial basis associated with `BasisElement` and
+ `Basis(vars, degree)` returns all BasisElement objects with variables `vars`
+ and total degree = `degree`. RaisePower(m, b) is the operation that "merges"
+ two `BasisElement`s such that the merged `BasisElement`:
+
+    - Is a product of all variables present in either m or b.
+    - The power of variable v is the sum of the degree of that variable in m and
+      b. If a variable is missing in a BasisElement, it has degree 0.
+
+ As a concrete example, assume that BasisElement is actually
+ MonomialBasisElement with
+ vars = {x, y}, degree = 2, and b = x²yz³. MonomialBasis({x, y}, 2) would
+ produce the set of MonomialBasisElements: x², xy, y². And applying
+ RaisePower(b, m) to each m would produce:
+
+  - RaisePower(x²yz³, x²) --> x⁴yz³
+  - RaisePower(x²yz³, xy) --> x³y²z³
+  - RaisePower(x²yz³, y²) --> x²y³z³
+
+ @tparam BasisElementOrder a total order of PolynomialBasisElement. An example
+         is BasisElementGradedReverseLexOrder.
+ @tparam BasisElement A derived class of PolynomialBasisElement.
+ @note A non-zero degree has no effect if vars is empty. If vars is empty
+ and degree is zero, then {RaisePower(b, m) for m in Basis(vars, degree)} = {b}.
+ */
+template <typename BasisElementOrder, typename BasisElement>
+void AddPolynomialBasisElementsOfDegreeN(
+    const Variables& vars, int degree, const BasisElement& b,
+    std::set<BasisElement, BasisElementOrder>* const bin) {
+  /* Iterating through Basis(vars, degree) is tricky due to the fact that the
+   number of variables is determined at runtime. For example, assume the
+   MonomialBasisElement with vars = {x, y, z} and degree = 3, then
+   Basis({x, y, z}, 3) would produce the basis elements: x³, x²y, xy², xyz, y³,
+   y²z, yz², z³. Conceptually, this matches well to nested for loops. Each
+   for loop "consumes" a portion of the target degree, leaving the remaining
+   part to the nested loops.
+
+   for (int p_x = degree; p_x >= 0; --p_x) {
+     for (int p_y = degree - p_x; p_y >= 0; --p_y) {
+       for (int p_z = degree - p_x - p_y; p_z >= 0; --p_z) {
+         Monomial m = x ** p_x * y ** p_y * z ** p_z;  // Ok, not real code.
+         bin->insert(RaisePower(m, b));
+       }
+     }
+   }
+
+   However, if we add another variable, we have to add another nested for loop.
+   We can't do that dynamically. So, we use recursion to create the *effect*
+   of a dynamically-determined number of nested for loops. Each level of the
+   recursion selects the "first" variable in the set and iteratively consumes
+   some portion of the target degree. The recursive call is made on the
+   remaining variables with the remaining available degree. The consumed portion
+   is preserved by pre-multiplying it with the `b` value and passing on this
+   accumulated b to the recursive call. RaisePower(m, b) is simply m * b. We
+   can refactor the product: RaisePower(m, b) = RaisePower(m/xⁱ, b * xⁱ) and
+   this relationship is the recursive call. */
+  static_assert(
+      std::is_base_of<PolynomialBasisElement, BasisElement>::value ||
+          std::is_same<BasisElement, Monomial>::value,
+      "BasisElement should be a derived class of PolynomialBasisElement");
+  if (degree == 0) {
+    bin->insert(b);
+    return;
+  }
+  if (vars.size() == 0) return;
+  const Variable& var{*vars.cbegin()};
+  for (int var_degree = degree; var_degree >= 0; --var_degree) {
+    std::map<Variable, int> new_var_to_degree_map = b.get_powers();
+    auto it = new_var_to_degree_map.find(var);
+    if (it != new_var_to_degree_map.end()) {
+      it->second += var_degree;
+    } else {
+      new_var_to_degree_map.emplace_hint(it, var, var_degree);
+    }
+    const BasisElement new_b(new_var_to_degree_map);
+    AddPolynomialBasisElementsOfDegreeN(vars - var, degree - var_degree, new_b,
+                                        bin);
+  }
+}
+}  // namespace internal
+
+/**
+ * Returns all polynomial basis elements up to a given degree under the graded
+ * reverse lexicographic order.
+ * @tparam rows Number of rows or Eigen::Dynamic.
+ * @tparam BasisElement A derived class of PolynomialBasisElement.
+ * @param vars The variables appearing in the polynomial basis.
+ * @param degree The highest total degree of the polynomial basis elements.
+ * @param degree_type If degree_type is kAny, then the polynomial basis
+ * elements' degrees are no larger than @p degree. If degree_type is kEven, then
+ * the elements' degrees are even numbers no larger than @p degree. If
+ * degree_type is kOdd, then the elements' degrees are odd numbers no larger
+ * than @p degree.
+ * TODO(hongkai.dai): this will replace ComputeMonomialBasis in
+ * symbolic_monomial_util.h
+ */
+template <int rows, typename BasisElement>
+Eigen::Matrix<BasisElement, rows, 1> ComputePolynomialBasisUpToDegree(
+    const Variables& vars, int degree, internal::DegreeType degree_type) {
+  DRAKE_DEMAND(vars.size() > 0);
+  DRAKE_DEMAND(degree >= 0);
+  // 1. Collect elements.
+  std::set<BasisElement,
+           BasisElementGradedReverseLexOrder<std::less<Variable>, BasisElement>>
+      basis_elements_set;
+  int start_degree = 0;
+  int degree_stride = 1;
+  switch (degree_type) {
+    case internal::DegreeType::kAny: {
+      start_degree = 0;
+      degree_stride = 1;
+      break;
+    }
+    case internal::DegreeType::kEven: {
+      start_degree = 0;
+      degree_stride = 2;
+      break;
+    }
+    case internal::DegreeType::kOdd: {
+      start_degree = 1;
+      degree_stride = 2;
+    }
+  }
+  for (int i = start_degree; i <= degree; i += degree_stride) {
+    internal::AddPolynomialBasisElementsOfDegreeN(vars, i, BasisElement{},
+                                                  &basis_elements_set);
+  }
+  // 2. Prepare the return value, basis.
+  DRAKE_DEMAND((rows == Eigen::Dynamic) ||
+               (static_cast<size_t>(rows) == basis_elements_set.size()));
+  Eigen::Matrix<BasisElement, rows, 1> basis(basis_elements_set.size());
+  int i{0};
+  for (const auto& m : basis_elements_set) {
+    basis[i] = m;
+    i++;
+  }
+  return basis;
+}
+
+}  // namespace symbolic
+}  // namespace drake

--- a/common/test/symbolic_polynomial_basis_test.cc
+++ b/common/test/symbolic_polynomial_basis_test.cc
@@ -1,0 +1,239 @@
+#include <gtest/gtest.h>
+
+#include "drake/common/symbolic.h"
+#include "drake/common/test_utilities/symbolic_test_util.h"
+
+namespace drake {
+namespace symbolic {
+class ComputePolynomialBasisUpToDegreeTest : public ::testing::Test {
+ protected:
+  const Variable x_{"x"};
+  const Variable y_{"y"};
+  const Variable z_{"z"};
+  const Variable w_{"w"};
+
+  void SetUp() override {
+    EXPECT_PRED2(test::VarLess, x_, y_);
+    EXPECT_PRED2(test::VarLess, y_, z_);
+    EXPECT_PRED2(test::VarLess, z_, w_);
+  }
+};
+
+TEST_F(ComputePolynomialBasisUpToDegreeTest, ChebyshevAnyParity) {
+  // Test ComputePolynomialBasisUpToDegree with degree_type=DegreeType::kAny.
+  // The chebyshev basis of x_ up to degree 0 is [1].
+  const Vector1<ChebyshevBasisElement> result0 =
+      ComputePolynomialBasisUpToDegree<1, ChebyshevBasisElement>(
+          Variables({x_}), 0, internal::DegreeType::kAny);
+  EXPECT_EQ(result0(0), ChebyshevBasisElement());
+
+  // The chebyshev basis of x_ up to degree 1 is [1, T1(x)].
+  const Vector2<ChebyshevBasisElement> result1 =
+      ComputePolynomialBasisUpToDegree<2, ChebyshevBasisElement>(
+          Variables({x_}), 1, internal::DegreeType::kAny);
+  EXPECT_EQ(result1(0), ChebyshevBasisElement());
+  EXPECT_EQ(result1(1), ChebyshevBasisElement(x_));
+
+  // The chebyshev basis of x_ up to degree 2 is [1, T1(x), T2(x)].
+  const Vector3<ChebyshevBasisElement> result2 =
+      ComputePolynomialBasisUpToDegree<3, ChebyshevBasisElement>(
+          Variables({x_}), 2, internal::DegreeType::kAny);
+  EXPECT_EQ(result2(0), ChebyshevBasisElement());
+  EXPECT_EQ(result2(1), ChebyshevBasisElement(x_, 1));
+  EXPECT_EQ(result2(2), ChebyshevBasisElement(x_, 2));
+
+  // The chebyshev basis of (x, y) up to degree 0 is [1]. Also instantitate the
+  // function with Eigen::Dynamic.
+  const VectorX<ChebyshevBasisElement> result3 =
+      ComputePolynomialBasisUpToDegree<Eigen::Dynamic, ChebyshevBasisElement>(
+          Variables({x_, y_}), 0, internal::DegreeType::kAny);
+  EXPECT_EQ(result3.rows(), 1);
+  EXPECT_EQ(result3(0), ChebyshevBasisElement());
+
+  // The chebyshev basis of (x, y) up to degree 1 is [1, T1(x), T1(y)].
+  const VectorX<ChebyshevBasisElement> result4 =
+      ComputePolynomialBasisUpToDegree<Eigen::Dynamic, ChebyshevBasisElement>(
+          Variables({x_, y_}), 1, internal::DegreeType::kAny);
+  EXPECT_EQ(result4.rows(), 3);
+  EXPECT_EQ(result4(0), ChebyshevBasisElement());
+  EXPECT_EQ(result4(1), ChebyshevBasisElement(x_));
+  EXPECT_EQ(result4(2), ChebyshevBasisElement(y_));
+
+  // The chebyshev basis of (x, y) up to degree 2 is [1, T1(x), T1(y), T2(x),
+  // T1(x)T1(y) T2(y)].
+  const VectorX<ChebyshevBasisElement> result5 =
+      ComputePolynomialBasisUpToDegree<Eigen::Dynamic, ChebyshevBasisElement>(
+          Variables({x_, y_}), 2, internal::DegreeType::kAny);
+  EXPECT_EQ(result5.rows(), 6);
+  EXPECT_EQ(result5(0), ChebyshevBasisElement());
+  EXPECT_EQ(result5(1), ChebyshevBasisElement(x_));
+  EXPECT_EQ(result5(2), ChebyshevBasisElement(y_));
+  EXPECT_EQ(result5(3), ChebyshevBasisElement(x_, 2));
+  EXPECT_EQ(result5(4), ChebyshevBasisElement({{x_, 1}, {y_, 1}}));
+  EXPECT_EQ(result5(5), ChebyshevBasisElement(y_, 2));
+
+  // The chebyshev basis of (x, y) up to degree 3 is [1, T1(x), T1(y), T2(x),
+  // T1(x)T1(y), T2(y), T3(x), T2(x)T1(y), T1(x)T2(y), T3(y)].
+  const VectorX<ChebyshevBasisElement> result6 =
+      ComputePolynomialBasisUpToDegree<Eigen::Dynamic, ChebyshevBasisElement>(
+          Variables({x_, y_}), 3, internal::DegreeType::kAny);
+  EXPECT_EQ(result6.rows(), 10);
+  EXPECT_EQ(result6(0), ChebyshevBasisElement());
+  EXPECT_EQ(result6(1), ChebyshevBasisElement(x_));
+  EXPECT_EQ(result6(2), ChebyshevBasisElement(y_));
+  EXPECT_EQ(result6(3), ChebyshevBasisElement(x_, 2));
+  EXPECT_EQ(result6(4), ChebyshevBasisElement({{x_, 1}, {y_, 1}}));
+  EXPECT_EQ(result6(5), ChebyshevBasisElement(y_, 2));
+  EXPECT_EQ(result6(6), ChebyshevBasisElement(x_, 3));
+  EXPECT_EQ(result6(7), ChebyshevBasisElement({{x_, 2}, {y_, 1}}));
+  EXPECT_EQ(result6(8), ChebyshevBasisElement({{x_, 1}, {y_, 2}}));
+  EXPECT_EQ(result6(9), ChebyshevBasisElement(y_, 3));
+
+  // The chebyshev basis of (x, y, z) up to degree 2 is [1, T1(x), T1(y),
+  // T1(z), T2(x), T1(x)T1(y), T1(x)T1(z), T2(y), T1(y)T1(z), T2(z)].
+  const VectorX<ChebyshevBasisElement> result7 =
+      ComputePolynomialBasisUpToDegree<Eigen::Dynamic, ChebyshevBasisElement>(
+          Variables({x_, y_, z_}), 2, internal::DegreeType::kAny);
+  EXPECT_EQ(result7.rows(), 10);
+  EXPECT_EQ(result7(0), ChebyshevBasisElement());
+  EXPECT_EQ(result7(1), ChebyshevBasisElement(x_));
+  EXPECT_EQ(result7(2), ChebyshevBasisElement(y_));
+  EXPECT_EQ(result7(3), ChebyshevBasisElement(z_));
+  EXPECT_EQ(result7(4), ChebyshevBasisElement(x_, 2));
+  EXPECT_EQ(result7(5), ChebyshevBasisElement({{x_, 1}, {y_, 1}}));
+  EXPECT_EQ(result7(6), ChebyshevBasisElement({{x_, 1}, {z_, 1}}));
+  EXPECT_EQ(result7(7), ChebyshevBasisElement(y_, 2));
+  EXPECT_EQ(result7(8), ChebyshevBasisElement({{y_, 1}, {z_, 1}}));
+  EXPECT_EQ(result7(9), ChebyshevBasisElement(z_, 2));
+
+  // The chebyshev basis of (x, y, z) up to degree 3 is [1, T1(x), T1(y),
+  // T1(z), T2(x) T1(x)T1(y), T1(x)T1(z), T2(y), T1(y)T1(z), T2(z), T3(x),
+  // T2(x)T1(y), T2(x)T1(z), T1(x)T2(y), T1(x)T1(y)T1(z), T1(x)T2(z), T3(y),
+  // T2(y)T1(z), T1(y)T2(z), T3(z)].
+  const VectorX<ChebyshevBasisElement> result8 =
+      ComputePolynomialBasisUpToDegree<Eigen::Dynamic, ChebyshevBasisElement>(
+          Variables({x_, y_, z_}), 3, internal::DegreeType::kAny);
+  EXPECT_EQ(result8.rows(), 20);
+  EXPECT_EQ(result8(0), ChebyshevBasisElement());
+  EXPECT_EQ(result8(1), ChebyshevBasisElement(x_));
+  EXPECT_EQ(result8(2), ChebyshevBasisElement(y_));
+  EXPECT_EQ(result8(3), ChebyshevBasisElement(z_));
+  EXPECT_EQ(result8(4), ChebyshevBasisElement(x_, 2));
+  EXPECT_EQ(result8(5), ChebyshevBasisElement({{x_, 1}, {y_, 1}}));
+  EXPECT_EQ(result8(6), ChebyshevBasisElement({{x_, 1}, {z_, 1}}));
+  EXPECT_EQ(result8(7), ChebyshevBasisElement(y_, 2));
+  EXPECT_EQ(result8(8), ChebyshevBasisElement({{y_, 1}, {z_, 1}}));
+  EXPECT_EQ(result8(9), ChebyshevBasisElement(z_, 2));
+  EXPECT_EQ(result8(10), ChebyshevBasisElement(x_, 3));
+  EXPECT_EQ(result8(11), ChebyshevBasisElement({{x_, 2}, {y_, 1}}));
+  EXPECT_EQ(result8(12), ChebyshevBasisElement({{x_, 2}, {z_, 1}}));
+  EXPECT_EQ(result8(13), ChebyshevBasisElement({{x_, 1}, {y_, 2}}));
+  EXPECT_EQ(result8(14), ChebyshevBasisElement({{x_, 1}, {y_, 1}, {z_, 1}}));
+  EXPECT_EQ(result8(15), ChebyshevBasisElement({{x_, 1}, {z_, 2}}));
+  EXPECT_EQ(result8(16), ChebyshevBasisElement(y_, 3));
+  EXPECT_EQ(result8(17), ChebyshevBasisElement({{y_, 2}, {z_, 1}}));
+  EXPECT_EQ(result8(18), ChebyshevBasisElement({{y_, 1}, {z_, 2}}));
+  EXPECT_EQ(result8(19), ChebyshevBasisElement(z_, 3));
+}
+
+TEST_F(ComputePolynomialBasisUpToDegreeTest, ChebyshevEvenParity) {
+  // Test ComputePolynomialBasisUpToDegree with degree_type=DegreeType::kEven.
+
+  // The chebyshev basis of x up to requested degree 0 or 1 (with even degrees)
+  // is [1].
+  for (int degree : {0, 1}) {
+    const auto result =
+        ComputePolynomialBasisUpToDegree<Eigen::Dynamic, ChebyshevBasisElement>(
+            Variables({x_}), degree, internal::DegreeType::kEven);
+    EXPECT_EQ(result.rows(), 1);
+    EXPECT_EQ(result(0), ChebyshevBasisElement());
+  }
+
+  // The chebyshev basis of x up to requested degree 2 or 3 (with even degrees)
+  // is [1, T2(x)].
+  for (int degree : {2, 3}) {
+    const auto result =
+        ComputePolynomialBasisUpToDegree<Eigen::Dynamic, ChebyshevBasisElement>(
+            Variables({x_}), degree, internal::DegreeType::kEven);
+    EXPECT_EQ(result.rows(), 2);
+    EXPECT_EQ(result(0), ChebyshevBasisElement());
+    EXPECT_EQ(result(1), ChebyshevBasisElement(x_, 2));
+  }
+
+  // The chebyshev basis of (x, y) up to requested degree 2 or 3 (with even
+  // degrees) is [1, T2(x), T1(x)T1(y) T2(y)].
+  for (int degree : {2, 3}) {
+    const auto result =
+        ComputePolynomialBasisUpToDegree<Eigen::Dynamic, ChebyshevBasisElement>(
+            Variables({x_, y_}), degree, internal::DegreeType::kEven);
+    EXPECT_EQ(result.rows(), 4);
+    EXPECT_EQ(result(0), ChebyshevBasisElement());
+    EXPECT_EQ(result(1), ChebyshevBasisElement(x_, 2));
+    EXPECT_EQ(result(2), ChebyshevBasisElement({{x_, 1}, {y_, 1}}));
+    EXPECT_EQ(result(3), ChebyshevBasisElement(y_, 2));
+  }
+}
+
+TEST_F(ComputePolynomialBasisUpToDegreeTest, ChebyshevOddParity) {
+  // Test ComputePolynomialBasisUpToDegree with degree_type=DegreeType::kOdd.
+  // The chebyshev basis of x up to degree 0 (with odd degrees) is [].
+  const auto result1 =
+      ComputePolynomialBasisUpToDegree<Eigen::Dynamic, ChebyshevBasisElement>(
+          Variables({x_}), 0, internal::DegreeType::kOdd);
+  EXPECT_EQ(result1.rows(), 0);
+
+  // The chebyshev basis of x up to requested degree 1 or 2 (with odd degrees)
+  // is [T1(x)].
+  for (int degree : {1, 2}) {
+    const auto result2 =
+        ComputePolynomialBasisUpToDegree<Eigen::Dynamic, ChebyshevBasisElement>(
+            Variables({x_}), degree, internal::DegreeType::kOdd);
+    EXPECT_EQ(result2.rows(), 1);
+    EXPECT_EQ(result2(0), ChebyshevBasisElement(x_));
+  }
+
+  // The chebyshev basis of x up to requestd degree 3 or 4 (with odd degrees) is
+  // [T1(x), T3(x)].
+  for (int degree : {3, 4}) {
+    const auto result4 =
+        ComputePolynomialBasisUpToDegree<Eigen::Dynamic, ChebyshevBasisElement>(
+            Variables({x_}), degree, internal::DegreeType::kOdd);
+    EXPECT_EQ(result4.rows(), 2);
+    EXPECT_EQ(result4(0), ChebyshevBasisElement(x_));
+    EXPECT_EQ(result4(1), ChebyshevBasisElement(x_, 3));
+  }
+
+  // The chebyshev basis of (x, y) up to requested degree 3 or 4 (with odd
+  // degrees) is [T1(x), T1(y), T3(x), T2(x)T1(y), T1(x)T2(y), T3(y)].
+  for (int degree : {3, 4}) {
+    const auto result5 =
+        ComputePolynomialBasisUpToDegree<Eigen::Dynamic, ChebyshevBasisElement>(
+            Variables({x_, y_}), degree, internal::DegreeType::kOdd);
+    EXPECT_EQ(result5.rows(), 6);
+    EXPECT_EQ(result5(0), ChebyshevBasisElement(x_));
+    EXPECT_EQ(result5(1), ChebyshevBasisElement(y_));
+    EXPECT_EQ(result5(2), ChebyshevBasisElement(x_, 3));
+    EXPECT_EQ(result5(3), ChebyshevBasisElement({{x_, 2}, {y_, 1}}));
+    EXPECT_EQ(result5(4), ChebyshevBasisElement({{x_, 1}, {y_, 2}}));
+    EXPECT_EQ(result5(5), ChebyshevBasisElement(y_, 3));
+  }
+}
+
+TEST_F(ComputePolynomialBasisUpToDegreeTest, MonomialAnyParity) {
+  // Test ComputePolynomialBasisUpToDegree with BasisElement = Monomial
+  // The monomial basis of (x, y) up to requested degree 2 is [1, x, y, x^2, xy,
+  // y^2]
+  const auto result1 =
+      ComputePolynomialBasisUpToDegree<Eigen::Dynamic, Monomial>(
+          Variables({x_, y_}), 2, internal::DegreeType::kAny);
+  EXPECT_EQ(result1.rows(), 6);
+  EXPECT_EQ(result1(0), Monomial());
+  EXPECT_EQ(result1(1), Monomial(x_));
+  EXPECT_EQ(result1(2), Monomial(y_));
+  EXPECT_EQ(result1(3), Monomial(x_, 2));
+  EXPECT_EQ(result1(4), Monomial({{x_, 1}, {y_, 1}}));
+  EXPECT_EQ(result1(5), Monomial(y_, 2));
+}
+
+}  // namespace symbolic
+}  // namespace drake


### PR DESCRIPTION
This function is the same as `ComputeMonomialBasis` function in https://github.com/RobotLocomotion/drake/blob/617396edf592997731604fa16030470e92548d20/common/symbolic_monomial_util.h#L138-L177, but it works for different PolynomialBasisElement class. Also this new function is in `drake::symbolic` namespace instead of `drake::symbolic::internal` namespace, as I plan to call this function directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13870)
<!-- Reviewable:end -->
