### PR TITLE
simulator: Optionally suppress initialization events

### DIFF
--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -57,6 +57,16 @@ PYBIND11_MODULE(analysis, m) {
             cls_doc.IsIdenticalStatus.doc);
   }
 
+  {
+    constexpr auto& cls_doc = pydrake_doc.drake.systems.InitializeParams;
+    using Class = InitializeParams;
+    py::class_<Class>(m, "InitializeParams", cls_doc.doc)
+        .def(ParamInit<Class>())
+        .def_readwrite("suppress_initialization_events",
+            &Class::suppress_initialization_events,
+            cls_doc.suppress_initialization_events.doc);
+  }
+
   auto bind_scalar_types = [m](auto dummy) {
     constexpr auto& doc = pydrake_doc.drake.systems;
     using T = decltype(dummy);
@@ -130,7 +140,8 @@ PYBIND11_MODULE(analysis, m) {
             // Keep alive, ownership: `context` keeps `self` alive.
             py::keep_alive<3, 1>(), doc.Simulator.ctor.doc)
         .def("Initialize", &Simulator<T>::Initialize,
-            doc.Simulator.Initialize.doc)
+            doc.Simulator.Initialize.doc,
+            py::arg("params") = InitializeParams{})
         .def("AdvanceTo", &Simulator<T>::AdvanceTo, py::arg("boundary_time"),
             doc.Simulator.AdvanceTo.doc)
         .def("AdvancePendingEvents", &Simulator<T>::AdvancePendingEvents,

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -17,6 +17,7 @@ from pydrake.examples.rimless_wheel import RimlessWheel
 from pydrake.symbolic import Expression
 from pydrake.systems.analysis import (
     GetIntegrationSchemes,
+    InitializeParams,
     IntegratorBase, IntegratorBase_,
     PrintSimulatorStatistics,
     ResetIntegratorFromFlags,
@@ -371,6 +372,7 @@ class TestGeneral(unittest.TestCase):
             self.assertTrue(simulator.get_context() is
                             simulator.get_mutable_context())
             check_output(simulator.get_context())
+            simulator.Initialize()
             simulator.AdvanceTo(1)
             simulator.ResetStatistics()
             simulator.AdvanceTo(2)
@@ -391,6 +393,13 @@ class TestGeneral(unittest.TestCase):
             check_output(context)
             simulator.AdvanceTo(1)
             simulator.AdvancePendingEvents()
+
+            # Reuse simulator over the same time interval, without
+            # initialization events.
+            context.SetTime(0.)
+            simulator.Initialize(InitializeParams(
+                suppress_initialization_events=True))
+            simulator.AdvanceTo(1)
 
     def test_copy(self):
         # Copy a context using `deepcopy` or `clone`.

--- a/systems/analysis/simulator.cc
+++ b/systems/analysis/simulator.cc
@@ -58,7 +58,7 @@ Simulator<T>::Simulator(const System<T>* system,
 }
 
 template <typename T>
-SimulatorStatus Simulator<T>::Initialize() {
+SimulatorStatus Simulator<T>::Initialize(const InitializeParams& params) {
   // TODO(sherm1) Modify Context to satisfy constraints.
   // TODO(sherm1) Invoke System's initial conditions computation.
   if (!context_)
@@ -79,7 +79,9 @@ SimulatorStatus Simulator<T>::Initialize() {
 
   // Process all the initialization events.
   auto init_events = system_.AllocateCompositeEventCollection();
-  system_.GetInitializationEvents(*context_, init_events.get());
+  if (!params.suppress_initialization_events) {
+    system_.GetInitializationEvents(*context_, init_events.get());
+  }
 
   // Do unrestricted updates first.
   HandleUnrestrictedUpdate(init_events->get_unrestricted_update_events());

--- a/systems/analysis/test/simulator_test.cc
+++ b/systems/analysis/test/simulator_test.cc
@@ -2124,6 +2124,11 @@ GTEST_TEST(SimulatorTest, Initialization) {
     bool get_pub_init() const { return pub_init_; }
     bool get_dis_update_init() const { return dis_update_init_; }
     bool get_unres_update_init() const { return unres_update_init_; }
+    void reset() const {
+      pub_init_ = false;
+      dis_update_init_ = false;
+      unres_update_init_ = false;
+    }
 
    private:
     void InitPublish(const Context<double>& context,
@@ -2143,8 +2148,6 @@ GTEST_TEST(SimulatorTest, Initialization) {
           TriggerType::kInitialization) {
         EXPECT_EQ(context.get_time(), 0);
         dis_update_init_ = true;
-      } else {
-        EXPECT_TRUE(dis_update_init_);
       }
     }
 
@@ -2157,8 +2160,6 @@ GTEST_TEST(SimulatorTest, Initialization) {
           TriggerType::kInitialization) {
         EXPECT_EQ(context.get_time(), 0);
         unres_update_init_ = true;
-      } else {
-        EXPECT_TRUE(unres_update_init_);
       }
     }
 
@@ -2174,6 +2175,15 @@ GTEST_TEST(SimulatorTest, Initialization) {
   EXPECT_TRUE(sys.get_pub_init());
   EXPECT_TRUE(sys.get_dis_update_init());
   EXPECT_TRUE(sys.get_unres_update_init());
+
+  sys.reset();
+  simulator.get_mutable_context().SetTime(0);
+  simulator.Initialize({.suppress_initialization_events = true});
+  simulator.AdvanceTo(1);
+
+  EXPECT_FALSE(sys.get_pub_init());
+  EXPECT_FALSE(sys.get_dis_update_init());
+  EXPECT_FALSE(sys.get_unres_update_init());
 }
 
 GTEST_TEST(SimulatorTest, OwnedSystemTest) {


### PR DESCRIPTION
Closes #13858.

 * Add defaulted parameter struct arg to Initialize(). This yields legible call
   sites and leaves room for adding further parameters.
 * Adjust existing test to cover a no-init simulator reuse.
 * Add python bindings, and extend existing tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13872)
<!-- Reviewable:end -->
