### PR TITLE
Provide System::get_input_port() and get_output_port().  Stop deleting `get_*_port(int)`.

### DIFF
--- a/attic/systems/sensors/gyroscope.h
+++ b/attic/systems/sensors/gyroscope.h
@@ -87,18 +87,6 @@ class Gyroscope : public systems::LeafSystem<double> {
   /// @see get_tree()
   const RigidBodyFrame<double>& get_frame() const { return frame_; }
 
-  /// Returns the input port that should contain the generalized (i.e., linear
-  /// and rotational) position and velocity state of the RigidBodyTree DOFs.
-  const InputPort<double>& get_input_port() const {
-    return System<double>::get_input_port(input_port_index_);
-  }
-
-  /// Returns a the state output port, which contains the sensor's
-  /// sensed values.
-  const OutputPort<double>& get_output_port() const {
-    return System<double>::get_output_port(output_port_index_);
-  }
-
  private:
   // Computes the angular velocity as sensed by this sensor.
   void CalcAngularVelocity(const Context<double>& context,

--- a/bindings/pydrake/examples/pendulum_py.cc
+++ b/bindings/pydrake/examples/pendulum_py.cc
@@ -35,11 +35,6 @@ PYBIND11_MODULE(pendulum, m) {
   py::class_<PendulumPlant<T>, LeafSystem<T>>(
       m, "PendulumPlant", doc.PendulumPlant.doc)
       .def(py::init<>(), doc.PendulumPlant.ctor.doc)
-      .def("get_input_port", &System<T>::get_input_port,
-          py_rvp::reference_internal, py::arg("port_index"),
-          pydrake_doc.drake.systems.System.get_input_port.doc)
-      .def("get_input_port", &PendulumPlant<T>::get_input_port,
-          py_rvp::reference_internal, doc.PendulumPlant.get_input_port.doc)
       .def("get_state_output_port", &PendulumPlant<T>::get_state_output_port,
           py_rvp::reference_internal,
           doc.PendulumPlant.get_state_output_port.doc)

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -274,15 +274,27 @@ struct Impl {
         DefineTemplateClassWithDefault<System<T>, SystemBase, PySystem>(
             m, "System", GetPyParam<T>(), doc.System.doc);
     system_cls  // BR
-        .def("get_input_port", &System<T>::get_input_port,
+        .def("get_input_port",
+            overload_cast_explicit<const InputPort<T>&, int>(
+                &System<T>::get_input_port),
             py_rvp::reference_internal, py::arg("port_index"),
-            doc.System.get_input_port.doc)
+            doc.System.get_input_port.doc_1args)
+        .def("get_input_port",
+            overload_cast_explicit<const InputPort<T>&>(
+                &System<T>::get_input_port),
+            py_rvp::reference_internal, doc.System.get_input_port.doc_0args)
         .def("GetInputPort", &System<T>::GetInputPort,
             py_rvp::reference_internal, py::arg("port_name"),
             doc.System.GetInputPort.doc)
-        .def("get_output_port", &System<T>::get_output_port,
+        .def("get_output_port",
+            overload_cast_explicit<const OutputPort<T>&, int>(
+                &System<T>::get_output_port),
             py_rvp::reference_internal, py::arg("port_index"),
-            doc.System.get_output_port.doc)
+            doc.System.get_output_port.doc_1args)
+        .def("get_output_port",
+            overload_cast_explicit<const OutputPort<T>&>(
+                &System<T>::get_output_port),
+            py_rvp::reference_internal, doc.System.get_output_port.doc_0args)
         .def("GetOutputPort", &System<T>::GetOutputPort,
             py_rvp::reference_internal, py::arg("port_name"),
             doc.System.GetOutputPort.doc)

--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -86,12 +86,6 @@ PYBIND11_MODULE(primitives, m) {
         // Wrap a few methods from the TimeVaryingAffineSystem parent class.
         // TODO(russt): Move to TimeVaryingAffineSystem if/when that class is
         // wrapped.
-        .def("get_input_port", &TimeVaryingAffineSystem<T>::get_input_port,
-            py_rvp::reference_internal,
-            doc.TimeVaryingAffineSystem.get_input_port.doc)
-        .def("get_output_port", &TimeVaryingAffineSystem<T>::get_output_port,
-            py_rvp::reference_internal,
-            doc.TimeVaryingAffineSystem.get_output_port.doc)
         .def("time_period", &AffineSystem<T>::time_period,
             doc.TimeVaryingAffineSystem.time_period.doc)
         .def("configure_default_state",
@@ -100,15 +94,7 @@ PYBIND11_MODULE(primitives, m) {
         .def("configure_random_state",
             &TimeVaryingAffineSystem<T>::configure_random_state,
             py::arg("covariance"),
-            doc.TimeVaryingAffineSystem.configure_random_state.doc)
-        // Need to specifically redeclare the System to have both overloads
-        // available.
-        .def("get_input_port", &System<T>::get_input_port,
-            py_rvp::reference_internal, py::arg("port_index"),
-            pydrake_doc.drake.systems.System.get_input_port.doc)
-        .def("get_output_port", &System<T>::get_output_port,
-            py_rvp::reference_internal, py::arg("port_index"),
-            pydrake_doc.drake.systems.System.get_output_port.doc);
+            doc.TimeVaryingAffineSystem.configure_random_state.doc);
 
     DefineTemplateClassWithDefault<ConstantValueSource<T>, LeafSystem<T>>(
         m, "ConstantValueSource", GetPyParam<T>(), doc.ConstantValueSource.doc)

--- a/bindings/pydrake/systems/rendering_py.cc
+++ b/bindings/pydrake/systems/rendering_py.cc
@@ -143,15 +143,7 @@ PYBIND11_MODULE(rendering, m) {
           // Keep alive, reference: `self` keeps `plant` alive.
           py::keep_alive<1, 2>(),
           doc.MultibodyPositionToGeometryPose.ctor
-              .doc_2args_plant_input_multibody_state)
-      .def("get_input_port",
-          &MultibodyPositionToGeometryPose<T>::get_input_port,
-          py_rvp::reference_internal,
-          doc.MultibodyPositionToGeometryPose.get_input_port.doc)
-      .def("get_output_port",
-          &MultibodyPositionToGeometryPose<T>::get_output_port,
-          py_rvp::reference_internal,
-          doc.MultibodyPositionToGeometryPose.get_output_port.doc);
+              .doc_2args_plant_input_multibody_state);
 
   // TODO(eric.cousineau): Add more systems as needed.
 }

--- a/examples/pendulum/pendulum_plant.cc
+++ b/examples/pendulum/pendulum_plant.cc
@@ -27,12 +27,6 @@ template <typename T>
 PendulumPlant<T>::~PendulumPlant() = default;
 
 template <typename T>
-const systems::InputPort<T>& PendulumPlant<T>::get_input_port() const {
-  DRAKE_DEMAND(systems::LeafSystem<T>::num_input_ports() == 1);
-  return systems::LeafSystem<T>::get_input_port(0);
-}
-
-template <typename T>
 const systems::OutputPort<T>& PendulumPlant<T>::get_state_output_port() const {
   DRAKE_DEMAND(systems::LeafSystem<T>::num_output_ports() == 1);
   return systems::LeafSystem<T>::get_output_port(0);

--- a/examples/pendulum/pendulum_plant.h
+++ b/examples/pendulum/pendulum_plant.h
@@ -35,9 +35,6 @@ class PendulumPlant final : public systems::LeafSystem<T> {
 
   ~PendulumPlant() final;
 
-  /// Returns the input port to the externally applied force.
-  const systems::InputPort<T>& get_input_port() const;
-
   /// Returns the port to output state.
   const systems::OutputPort<T>& get_state_output_port() const;
 

--- a/manipulation/kinova_jaco/jaco_command_receiver.cc
+++ b/manipulation/kinova_jaco/jaco_command_receiver.cc
@@ -46,15 +46,6 @@ JacoCommandReceiver::JacoCommandReceiver(int num_joints, int num_fingers)
       });
 }
 
-const systems::InputPort<double>& JacoCommandReceiver::get_input_port() const {
-  return LeafSystem<double>::get_input_port(0);
-}
-
-const systems::OutputPort<double>&
-JacoCommandReceiver::get_output_port() const {
-  return LeafSystem<double>::get_output_port(0);
-}
-
 void JacoCommandReceiver::set_initial_position(
     Context<double>* context, const Eigen::Ref<const VectorXd>& q) const {
   DRAKE_THROW_UNLESS(q.size() == num_joints_ + num_fingers_);

--- a/manipulation/kinova_jaco/jaco_command_receiver.h
+++ b/manipulation/kinova_jaco/jaco_command_receiver.h
@@ -50,12 +50,6 @@ class JacoCommandReceiver : public systems::LeafSystem<double> {
       systems::Context<double>* context,
       const Eigen::Ref<const Eigen::VectorXd>& q) const;
 
-  /// @name Named accessors for this System's input and output ports.
-  //@{
-  const systems::InputPort<double>& get_input_port() const;
-  const systems::OutputPort<double>& get_output_port() const;
-  //@}
-
  private:
   Eigen::VectorXd input_state(const systems::Context<double>&) const;
   void CalcInput(const systems::Context<double>&, lcmt_jaco_command*) const;

--- a/manipulation/kinova_jaco/jaco_command_sender.cc
+++ b/manipulation/kinova_jaco/jaco_command_sender.cc
@@ -13,13 +13,6 @@ JacoCommandSender::JacoCommandSender(int num_joints, int num_fingers)
       "lcmt_jaco_command", &JacoCommandSender::CalcOutput);
 }
 
-const systems::InputPort<double>& JacoCommandSender::get_input_port() const {
-  return LeafSystem<double>::get_input_port(0);
-}
-const systems::OutputPort<double>& JacoCommandSender::get_output_port() const {
-  return LeafSystem<double>::get_output_port(0);
-}
-
 void JacoCommandSender::CalcOutput(
     const systems::Context<double>& context, lcmt_jaco_command* output) const {
   const auto& state = get_input_port().Eval(context);

--- a/manipulation/kinova_jaco/jaco_command_sender.h
+++ b/manipulation/kinova_jaco/jaco_command_sender.h
@@ -41,12 +41,6 @@ class JacoCommandSender : public systems::LeafSystem<double> {
   JacoCommandSender(int num_joints = kJacoDefaultArmNumJoints,
                     int num_fingers = kJacoDefaultArmNumFingers);
 
-  /// @name Named accessors for this System's input and output ports.
-  //@{
-  const systems::InputPort<double>& get_input_port() const;
-  const systems::OutputPort<double>& get_output_port() const;
-  //@}
-
  private:
   void CalcOutput(const systems::Context<double>&, lcmt_jaco_command*) const;
 

--- a/manipulation/kinova_jaco/jaco_status_receiver.cc
+++ b/manipulation/kinova_jaco/jaco_status_receiver.cc
@@ -34,9 +34,6 @@ JacoStatusReceiver::JacoStatusReceiver(int num_joints, int num_fingers)
       &lcmt_jaco_status::finger_current>);
 }
 
-const systems::InputPort<double>& JacoStatusReceiver::get_input_port() const {
-  return LeafSystem<double>::get_input_port(0);
-}
 using OutPort = systems::OutputPort<double>;
 const OutPort& JacoStatusReceiver::get_state_output_port() const {
   return LeafSystem<double>::get_output_port(0);

--- a/manipulation/kinova_jaco/jaco_status_receiver.h
+++ b/manipulation/kinova_jaco/jaco_status_receiver.h
@@ -48,7 +48,6 @@ class JacoStatusReceiver : public systems::LeafSystem<double> {
 
   /// @name Named accessors for this System's input and output ports.
   //@{
-  const systems::InputPort<double>& get_input_port() const;
   const systems::OutputPort<double>& get_state_output_port() const;
   const systems::OutputPort<double>& get_torque_output_port() const;
   const systems::OutputPort<double>& get_torque_external_output_port() const;

--- a/manipulation/kinova_jaco/jaco_status_sender.cc
+++ b/manipulation/kinova_jaco/jaco_status_sender.cc
@@ -32,9 +32,6 @@ const InPort& JacoStatusSender::get_torque_external_input_port() const {
 const InPort& JacoStatusSender::get_current_input_port() const {
   return LeafSystem<double>::get_input_port(3);
 }
-const systems::OutputPort<double>& JacoStatusSender::get_output_port() const {
-  return LeafSystem<double>::get_output_port(0);
-}
 
 void JacoStatusSender::CalcOutput(
     const systems::Context<double>& context, lcmt_jaco_status* output) const {

--- a/manipulation/kinova_jaco/jaco_status_sender.h
+++ b/manipulation/kinova_jaco/jaco_status_sender.h
@@ -53,7 +53,6 @@ class JacoStatusSender : public systems::LeafSystem<double> {
   const systems::InputPort<double>& get_torque_input_port() const;
   const systems::InputPort<double>& get_torque_external_input_port() const;
   const systems::InputPort<double>& get_current_input_port() const;
-  const systems::OutputPort<double>& get_output_port() const;
   //@}
 
  private:

--- a/manipulation/kuka_iiwa/iiwa_command_sender.cc
+++ b/manipulation/kuka_iiwa/iiwa_command_sender.cc
@@ -21,9 +21,6 @@ const InPort& IiwaCommandSender::get_position_input_port() const {
 const InPort& IiwaCommandSender::get_torque_input_port() const {
   return LeafSystem<double>::get_input_port(1);
 }
-const systems::OutputPort<double>& IiwaCommandSender::get_output_port() const {
-  return LeafSystem<double>::get_output_port(0);
-}
 
 void IiwaCommandSender::CalcOutput(
     const systems::Context<double>& context, lcmt_iiwa_command* output) const {

--- a/manipulation/kuka_iiwa/iiwa_command_sender.h
+++ b/manipulation/kuka_iiwa/iiwa_command_sender.h
@@ -43,7 +43,6 @@ class IiwaCommandSender : public systems::LeafSystem<double> {
   //@{
   const systems::InputPort<double>& get_position_input_port() const;
   const systems::InputPort<double>& get_torque_input_port() const;
-  const systems::OutputPort<double>& get_output_port() const;
   //@}
 
  private:

--- a/manipulation/kuka_iiwa/iiwa_status_receiver.cc
+++ b/manipulation/kuka_iiwa/iiwa_status_receiver.cc
@@ -39,9 +39,6 @@ IiwaStatusReceiver::IiwaStatusReceiver(int num_joints)
         &lcmt_iiwa_status::joint_torque_external>);
 }
 
-const systems::InputPort<double>& IiwaStatusReceiver::get_input_port() const {
-  return LeafSystem<double>::get_input_port(0);
-}
 using OutPort = systems::OutputPort<double>;
 const OutPort& IiwaStatusReceiver::get_position_commanded_output_port() const {
   return LeafSystem<double>::get_output_port(0);

--- a/manipulation/kuka_iiwa/iiwa_status_receiver.h
+++ b/manipulation/kuka_iiwa/iiwa_status_receiver.h
@@ -46,7 +46,6 @@ class IiwaStatusReceiver : public systems::LeafSystem<double> {
 
   /// @name Named accessors for this System's input and output ports.
   //@{
-  const systems::InputPort<double>& get_input_port() const;
   const systems::OutputPort<double>& get_position_commanded_output_port() const;
   const systems::OutputPort<double>& get_position_measured_output_port() const;
   const systems::OutputPort<double>& get_velocity_estimated_output_port() const;

--- a/manipulation/kuka_iiwa/iiwa_status_sender.cc
+++ b/manipulation/kuka_iiwa/iiwa_status_sender.cc
@@ -42,9 +42,6 @@ const InPort& IiwaStatusSender::get_torque_measured_input_port() const {
 const InPort& IiwaStatusSender::get_torque_external_input_port() const {
   return LeafSystem<double>::get_input_port(5);
 }
-const systems::OutputPort<double>& IiwaStatusSender::get_output_port() const {
-  return LeafSystem<double>::get_output_port(0);
-}
 
 namespace {
 // Returns the first one of port1.Eval or port2.Eval that has a value.

--- a/manipulation/kuka_iiwa/iiwa_status_sender.h
+++ b/manipulation/kuka_iiwa/iiwa_status_sender.h
@@ -64,7 +64,6 @@ class IiwaStatusSender : public systems::LeafSystem<double> {
   const systems::InputPort<double>& get_torque_commanded_input_port() const;
   const systems::InputPort<double>& get_torque_measured_input_port() const;
   const systems::InputPort<double>& get_torque_external_input_port() const;
-  const systems::OutputPort<double>& get_output_port() const;
   //@}
 
  private:

--- a/manipulation/schunk_wsg/schunk_wsg_plain_controller.h
+++ b/manipulation/schunk_wsg/schunk_wsg_plain_controller.h
@@ -148,8 +148,6 @@ class SchunkWsgPlainController
     return systems::Diagram<double>::get_output_port(0);
   }
 
-  const systems::OutputPort<double>& get_output_port(int) const = delete;
-
  private:
   int desired_grip_state_input_port_{-1};
   int feed_forward_force_input_port_{-1};

--- a/systems/framework/single_output_vector_source.h
+++ b/systems/framework/single_output_vector_source.h
@@ -33,14 +33,6 @@ class SingleOutputVectorSource : public LeafSystem<T> {
 
   ~SingleOutputVectorSource() override = default;
 
-  /// Returns the sole output port.
-  const OutputPort<T>& get_output_port() const {
-    return LeafSystem<T>::get_output_port(0);
-  }
-
-  // Don't use the indexed get_output_port when calling this system directly.
-  void get_output_port(int) = delete;
-
  protected:
   /// Creates a source with the given sole output port configuration.
   ///

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -929,6 +929,17 @@ class System : public SystemBase {
         this->GetInputPortBaseOrThrow(__func__, port_index));
   }
 
+  /** Convenience method for the case of exactly one input port. */
+  const InputPort<T>& get_input_port() const {
+    static constexpr char message[] =
+        "Cannot use the get_input_port() convenience method unless there is"
+        " exactly one input port. num_input_ports() = {}";
+    if (num_input_ports() != 1) {
+      throw std::logic_error(fmt::format(message, num_input_ports()));
+    }
+    return get_input_port(0);
+  }
+
   /** Returns the typed input port specified by the InputPortSelection or by
   the InputPortIndex.  Returns nullptr if no port is selected.  This is
   provided as a convenience method since many algorithms provide the same
@@ -947,6 +958,17 @@ class System : public SystemBase {
   const OutputPort<T>& get_output_port(int port_index) const {
     return dynamic_cast<const OutputPort<T>&>(
         this->GetOutputPortBaseOrThrow(__func__, port_index));
+  }
+
+  /** Convenience method for the case of exactly one output port. */
+  const OutputPort<T>& get_output_port() const {
+    static constexpr char message[] =
+        "Cannot use the get_output_port() convenience method unless there is"
+        " exactly one output port. num_output_ports() = {}";
+    if (num_output_ports() != 1) {
+      throw std::logic_error(fmt::format(message, num_output_ports()));
+    }
+    return get_output_port(0);
   }
 
   /** Returns the typed output port specified by the OutputPortSelection or by

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -368,6 +368,30 @@ TEST_F(SystemTest, PortReferencesAreStable) {
   EXPECT_EQ(kAbstractValued, first_output.get_data_type());
 }
 
+// Tests the convenience methods for the case when we have exactly one input or
+// output port.
+TEST_F(SystemTest, ExactlyOnePortConvenience) {
+  DRAKE_EXPECT_THROWS_MESSAGE(system_.get_input_port(), std::logic_error,
+                              ".*num_input_ports\\(\\) = 0");
+
+  system_.DeclareInputPort("one", kVectorValued, 2);
+  EXPECT_EQ(&system_.get_input_port(), &system_.get_input_port(0));
+
+  system_.DeclareInputPort("two", kVectorValued, 2);
+  DRAKE_EXPECT_THROWS_MESSAGE(system_.get_input_port(), std::logic_error,
+                              ".*num_input_ports\\(\\) = 2");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(system_.get_output_port(), std::logic_error,
+                              ".*num_output_ports\\(\\) = 0");
+
+  system_.AddAbstractOutputPort();
+  EXPECT_EQ(&system_.get_output_port(), &system_.get_output_port(0));
+
+  system_.AddAbstractOutputPort();
+  DRAKE_EXPECT_THROWS_MESSAGE(system_.get_output_port(), std::logic_error,
+                              ".*num_output_ports\\(\\) = 2");
+}
+
 TEST_F(SystemTest, PortNameTest) {
   const auto& unnamed_input = system_.DeclareInputPort(kVectorValued, 2);
   const auto& named_input =

--- a/systems/framework/vector_system.h
+++ b/systems/framework/vector_system.h
@@ -35,24 +35,6 @@ class VectorSystem : public LeafSystem<T> {
 
   ~VectorSystem() override = default;
 
-  /// Returns the sole input port.
-  const InputPort<T>& get_input_port() const {
-    DRAKE_DEMAND(this->num_input_ports() == 1);
-    return LeafSystem<T>::get_input_port(0);
-  }
-
-  // Don't use the indexed get_input_port when calling this system directly.
-  void get_input_port(int) = delete;
-
-  /// Returns the sole output port.
-  const OutputPort<T>& get_output_port() const {
-    DRAKE_DEMAND(this->num_output_ports() == 1);
-    return LeafSystem<T>::get_output_port(0);
-  }
-
-  // Don't use the indexed get_output_port when calling this system directly.
-  void get_output_port(int) = delete;
-
  protected:
   /// Creates a system with one input port and one output port of the given
   /// sizes, when the sizes are non-zero.  Either size can be zero, in which

--- a/systems/lcm/lcm_publisher_system.h
+++ b/systems/lcm/lcm_publisher_system.h
@@ -223,20 +223,6 @@ class LcmPublisherSystem : public LeafSystem<double> {
     return *lcm_;
   }
 
-  /**
-   * Returns the sole input port.
-   */
-  const InputPort<double>& get_input_port() const {
-    DRAKE_THROW_UNLESS(this->num_input_ports() == 1);
-    return LeafSystem<double>::get_input_port(0);
-  }
-
-  // Don't use the indexed overload; use the no-arg overload.
-  void get_input_port(int index) = delete;
-
-  // This system has no output ports.
-  void get_output_port(int) = delete;
-
  private:
   EventStatus PublishInputAsLcmMessage(const Context<double>& context) const;
 

--- a/systems/lcm/lcm_subscriber_system.h
+++ b/systems/lcm/lcm_subscriber_system.h
@@ -83,18 +83,6 @@ class LcmSubscriberSystem : public LeafSystem<double> {
 
   const std::string& get_channel_name() const;
 
-  /// Returns the sole output port.
-  const OutputPort<double>& get_output_port() const {
-    DRAKE_THROW_UNLESS(this->num_output_ports() == 1);
-    return LeafSystem<double>::get_output_port(0);
-  }
-
-  // Don't use the indexed overload; use the no-arg overload.
-  void get_output_port(int index) = delete;
-
-  // This system has no input ports.
-  void get_input_port(int) = delete;
-
   /**
    * Blocks the caller until its internal message count exceeds
    * `old_message_count` with an optional timeout.

--- a/systems/plants/spring_mass_system/spring_mass_system.cc
+++ b/systems/plants/spring_mass_system/spring_mass_system.cc
@@ -113,11 +113,6 @@ const InputPort<T>& SpringMassSystem<T>::get_force_port() const {
 }
 
 template <typename T>
-const OutputPort<T>& SpringMassSystem<T>::get_output_port() const {
-  return System<T>::get_output_port(0);
-}
-
-template <typename T>
 T SpringMassSystem<T>::EvalSpringForce(const Context<T>& context) const {
   const double k = spring_constant_N_per_m_;
   const T& x = get_position(context);

--- a/systems/plants/spring_mass_system/spring_mass_system.h
+++ b/systems/plants/spring_mass_system/spring_mass_system.h
@@ -82,9 +82,6 @@ class SpringMassSystem : public LeafSystem<T> {
   /// Returns the input port to the externally applied force.
   const InputPort<T>& get_force_port() const;
 
-  /// Returns the port to output state.
-  const OutputPort<T>& get_output_port() const;
-
   /// Returns the spring constant k that was provided at construction, in N/m.
   double get_spring_constant() const { return spring_constant_N_per_m_; }
 

--- a/systems/primitives/adder.h
+++ b/systems/primitives/adder.h
@@ -36,11 +36,6 @@ class Adder final : public LeafSystem<T> {
   template <typename U>
   explicit Adder(const Adder<U>&);
 
-  /// Returns the output port on which the sum is presented.
-  const OutputPort<T>& get_output_port() const {
-    return LeafSystem<T>::get_output_port(0);
-  }
-
  private:
   // Sums the input ports into a value suitable for the output port. If the
   // input ports are not the appropriate count or size, std::runtime_error will

--- a/systems/primitives/affine_system.cc
+++ b/systems/primitives/affine_system.cc
@@ -55,20 +55,6 @@ TimeVaryingAffineSystem<T>::TimeVaryingAffineSystem(
 }
 
 template <typename T>
-const InputPort<T>& TimeVaryingAffineSystem<T>::get_input_port()
-    const {
-  DRAKE_DEMAND(num_inputs_ > 0);
-  return System<T>::get_input_port(0);
-}
-
-template <typename T>
-const OutputPort<T>& TimeVaryingAffineSystem<T>::get_output_port()
-    const {
-  DRAKE_DEMAND(num_outputs_ > 0);
-  return System<T>::get_output_port(0);
-}
-
-template <typename T>
 void TimeVaryingAffineSystem<T>::configure_default_state(
     const Eigen::Ref<const VectorX<T>>& x0) {
   DRAKE_DEMAND(x0.rows() == num_states_);
@@ -106,7 +92,7 @@ void TimeVaryingAffineSystem<T>::CalcOutputY(
   }
 
   if (num_inputs_ > 0) {
-    const auto& u = get_input_port().Eval(context);
+    const auto& u = this->get_input_port().Eval(context);
     const MatrixX<T> Dt = D(t);
     DRAKE_DEMAND(Dt.rows() == num_outputs_ && Dt.cols() == num_inputs_);
     y += Dt * u;
@@ -133,7 +119,7 @@ void TimeVaryingAffineSystem<T>::DoCalcTimeDerivatives(
   xdot += At * x;
 
   if (num_inputs_ > 0) {
-    const auto& u = get_input_port().Eval(context);
+    const auto& u = this->get_input_port(0).Eval(context);
 
     const MatrixX<T> Bt = B(t);
     DRAKE_THROW_UNLESS(Bt.rows() == num_states_ && Bt.cols() == num_inputs_);
@@ -164,7 +150,7 @@ void TimeVaryingAffineSystem<T>::DoCalcDiscreteVariableUpdates(
   xn += At * x;
 
   if (num_inputs_ > 0) {
-    const auto& u = get_input_port().Eval(context);
+    const auto& u = this->get_input_port().Eval(context);
 
     const MatrixX<T> Bt = B(t);
     DRAKE_DEMAND(Bt.rows() == num_states_ && Bt.cols() == num_inputs_);
@@ -331,7 +317,7 @@ void AffineSystem<T>::DoCalcTimeDerivatives(
   VectorX<T> xdot = A_ * x + f0_;
 
   if (this->num_inputs() > 0) {
-    const auto& u = this->get_input_port().Eval(context);
+    const auto& u = this->get_input_port(0).Eval(context);
 
     xdot += B_ * u;
   }

--- a/systems/primitives/affine_system.h
+++ b/systems/primitives/affine_system.h
@@ -44,12 +44,6 @@ class TimeVaryingAffineSystem : public LeafSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(TimeVaryingAffineSystem)
 
-  /// Returns the input port containing the externally applied input.
-  const InputPort<T>& get_input_port() const;
-
-  /// Returns the output port containing the output state.
-  const OutputPort<T>& get_output_port() const;
-
   /// @name Methods To Be Implemented by Subclasses
   ///
   /// Implementations must define these, and the returned matrices must

--- a/systems/primitives/discrete_derivative.cc
+++ b/systems/primitives/discrete_derivative.cc
@@ -64,7 +64,8 @@ void DiscreteDerivative<T>::DoCalcDiscreteVariableUpdates(
     const std::vector<const drake::systems::DiscreteUpdateEvent<T>*>&,
     drake::systems::DiscreteValues<T>* state) const {
   // x₀[n+1] = u[n].
-  state->get_mutable_vector(0).SetFromVector(get_input_port().Eval(context));
+  state->get_mutable_vector(0).SetFromVector(
+      this->get_input_port().Eval(context));
 
   // x₁[n+1] = x₀[n].
   state->get_mutable_vector(1).SetFrom(context.get_discrete_state(0));

--- a/systems/primitives/discrete_derivative.h
+++ b/systems/primitives/discrete_derivative.h
@@ -98,14 +98,6 @@ class DiscreteDerivative final : public LeafSystem<T> {
     set_input_history(&context->get_mutable_state(), u, u);
   }
 
-  const systems::InputPort<T>& get_input_port() const {
-    return System<T>::get_input_port(0);
-  }
-
-  const systems::OutputPort<T>& get_output_port() const {
-    return System<T>::get_output_port(0);
-  }
-
   double time_step() const { return time_step_; }
 
   /// Returns the `suppress_initial_transient` passed to the constructor.
@@ -163,14 +155,6 @@ class StateInterpolatorWithDiscreteDerivative final : public Diagram<T> {
 
   /// Returns the `suppress_initial_transient` passed to the constructor.
   bool suppress_initial_transient() const;
-
-  const systems::InputPort<T>& get_input_port() const {
-    return System<T>::get_input_port(0);
-  }
-
-  const systems::OutputPort<T>& get_output_port() const {
-    return System<T>::get_output_port(0);
-  }
 
   /// Convenience method that sets the entire position history for the
   /// discrete-time derivative to a constant vector value (resulting in

--- a/systems/primitives/discrete_time_delay.cc
+++ b/systems/primitives/discrete_time_delay.cc
@@ -77,7 +77,7 @@ void DiscreteTimeDelay<T>::SaveInputVectorToBuffer(
   // value and adding the value on the input port to the end of the buffer.
   // TODO(mpetersen94): consider revising to avoid possibly expensive buffer
   // copy operation.
-  const auto& input = get_input_port().Eval(context);
+  const auto& input = this->get_input_port().Eval(context);
   Eigen::VectorBlock<VectorX<T>> updated_state_value =
       discrete_state->get_mutable_vector(0).get_mutable_value();
   Eigen::VectorBlock<const VectorX<T>> old_state_value =
@@ -102,7 +102,8 @@ template <typename T>
 void DiscreteTimeDelay<T>::SaveInputAbstractValueToBuffer(
     const Context<T>& context, State<T>* state) const {
   DRAKE_ASSERT(is_abstract());
-  const auto& input = get_input_port().template Eval<AbstractValue>(context);
+  const auto& input =
+      this->get_input_port().template Eval<AbstractValue>(context);
   int& oldest_index =
       state->template get_mutable_abstract_state<int>(delay_buffer_size_);
   AbstractValue& state_value =

--- a/systems/primitives/discrete_time_delay.h
+++ b/systems/primitives/discrete_time_delay.h
@@ -74,16 +74,6 @@ class DiscreteTimeDelay final : public LeafSystem<T> {
 
   ~DiscreteTimeDelay() final = default;
 
-  /// Returns the sole input port.
-  const InputPort<T>& get_input_port() const {
-    return LeafSystem<T>::get_input_port(0);
-  }
-
-  /// Returns the sole output port.
-  const OutputPort<T>& get_output_port() const {
-    return LeafSystem<T>::get_output_port(0);
-  }
-
   /// (Advanced) Manually samples the input port and updates the state of the
   /// block, sliding the delay buffer forward and placing the sampled input at
   /// the end. This emulates an update event and is mostly useful for testing.

--- a/systems/primitives/pass_through.cc
+++ b/systems/primitives/pass_through.cc
@@ -48,7 +48,7 @@ void PassThrough<T>::DoCalcVectorOutput(
       const Context<T>& context,
       BasicVector<T>* output) const {
   DRAKE_ASSERT(!is_abstract());
-  const auto& input = get_input_port().Eval(context);
+  const auto& input = this->get_input_port().Eval(context);
   DRAKE_ASSERT(input.size() == output->size());
   output->get_mutable_value() = input;
 }

--- a/systems/primitives/pass_through.h
+++ b/systems/primitives/pass_through.h
@@ -51,24 +51,6 @@ class PassThrough final : public LeafSystem<T> {
   // TODO(eric.cousineau): Possibly share single port interface with
   // ZeroOrderHold (#6490).
 
-  /// Returns the sole input port.
-  const InputPort<T>& get_input_port() const {
-    DRAKE_ASSERT(input_port_ != nullptr);
-    return *input_port_;
-  }
-
-  // Don't use the indexed get_input_port when calling this system directly.
-  void get_input_port(int) = delete;
-
-  /// Returns the sole output port.
-  const OutputPort<T>& get_output_port() const {
-    DRAKE_ASSERT(output_port_ != nullptr);
-    return *output_port_;
-  }
-
-  // Don't use the indexed get_output_port when calling this system directly.
-  void get_output_port(int) = delete;
-
  private:
   // Allow different specializations to access each other's private data.
   template <typename U> friend class PassThrough;

--- a/systems/primitives/port_switch.h
+++ b/systems/primitives/port_switch.h
@@ -79,10 +79,6 @@ class PortSwitch final : public LeafSystem<T> {
     return this->get_input_port(0);
   }
 
-  const OutputPort<T>& get_output_port() const {
-    return System<T>::get_output_port(0);
-  }
-
   /** Declares a new input port to the switch with port name `name`.  The
   type of this port is already defined by the type of the output port. This
   must be called before any Context is allocated. */

--- a/systems/primitives/saturation.h
+++ b/systems/primitives/saturation.h
@@ -62,12 +62,6 @@ class Saturation final : public LeafSystem<T> {
   /// @p u_min and @p u_max.
   Saturation(const VectorX<T>& min_value, const VectorX<T>& max_value);
 
-  // Don't use the indexed get_input_port when calling this system directly.
-  void get_input_port(int) = delete;
-
-  // Don't use the indexed get_output_port when calling this system directly.
-  void get_output_port(int) = delete;
-
   /// Returns the input port.
   const InputPort<T>& get_input_port() const {
     return System<T>::get_input_port(input_port_index_);
@@ -83,11 +77,6 @@ class Saturation final : public LeafSystem<T> {
   const InputPort<T>& get_max_value_port() const {
     DRAKE_THROW_UNLESS(min_max_ports_enabled_);
     return System<T>::get_input_port(max_value_port_index_);
-  }
-
-  /// Returns the output port.
-  const OutputPort<T>& get_output_port() const {
-    return System<T>::get_output_port(output_port_index_);
   }
 
   /// Returns the size.

--- a/systems/primitives/signal_logger.cc
+++ b/systems/primitives/signal_logger.cc
@@ -83,13 +83,8 @@ void SignalLogger<T>::set_forced_publish_only() {
 
 template <typename T>
 EventStatus SignalLogger<T>::WriteToLog(const Context<T>& context) const {
-  log_.AddData(context.get_time(), get_input_port().Eval(context));
+  log_.AddData(context.get_time(), this->get_input_port().Eval(context));
   return EventStatus::Succeeded();
-}
-
-template <typename T>
-const InputPort<T>& SignalLogger<T>::get_input_port() const {
-  return System<T>::get_input_port(0);
 }
 
 }  // namespace systems

--- a/systems/primitives/signal_logger.h
+++ b/systems/primitives/signal_logger.h
@@ -108,10 +108,6 @@ class SignalLogger final : public LeafSystem<T> {
   /// Clears the logged data.
   void reset() { log_.reset(); }
 
-  /// Returns the only input port. The port's name is "data" so you can also
-  /// access this with GetInputPort("data").
-  const InputPort<T>& get_input_port() const;
-
  private:
   template <typename> friend class SignalLogger;
 

--- a/systems/primitives/symbolic_vector_system.cc
+++ b/systems/primitives/symbolic_vector_system.cc
@@ -198,7 +198,7 @@ void SymbolicVectorSystem<T>::PopulateFromContext(const Context<T>& context,
   // the Context (and not from input ports whose *unnecessary* evaluation can
   // lead to spurious algebraic loops).
   if (input_vars_.size() > 0 && needs_inputs) {
-    const auto& input = get_input_port().Eval(context);
+    const auto& input = this->get_input_port().Eval(context);
     for (int i = 0; i < input_vars_.size(); i++) {
       env[input_vars_[i]] = input[i];
     }

--- a/systems/primitives/symbolic_vector_system.h
+++ b/systems/primitives/symbolic_vector_system.h
@@ -131,18 +131,6 @@ class SymbolicVectorSystem final : public LeafSystem<T> {
 
   ~SymbolicVectorSystem() override = default;
 
-  /// Returns the sole input port.
-  const InputPort<T>& get_input_port() const {
-    DRAKE_DEMAND(this->num_input_ports() == 1);
-    return LeafSystem<T>::get_input_port(0);
-  }
-
-  /// Returns the sole output port.
-  const OutputPort<T>& get_output_port() const {
-    DRAKE_DEMAND(this->num_output_ports() == 1);
-    return LeafSystem<T>::get_output_port(0);
-  }
-
   /// @name Accessor methods.
   /// @{
   const std::optional<symbolic::Variable>& time_var() const {

--- a/systems/primitives/test/linear_system_test.cc
+++ b/systems/primitives/test/linear_system_test.cc
@@ -59,7 +59,7 @@ GTEST_TEST(LinearSystemTestWithEmptyPort, EmptyPort) {
   // when the empty vector port is unconnected.
   auto context = dut.CreateDefaultContext();
   auto derivatives = dut.AllocateTimeDerivatives();
-  dut.get_input_port().FixValue(context.get(), 0.);
+  dut.get_input_port(0).FixValue(context.get(), 0.);
   DRAKE_EXPECT_NO_THROW(dut.CalcTimeDerivatives(*context, derivatives.get()));
 }
 

--- a/systems/primitives/zero_order_hold.cc
+++ b/systems/primitives/zero_order_hold.cc
@@ -71,7 +71,7 @@ void ZeroOrderHold<T>::LatchInputVectorToState(
     const Context<T>& context,
     DiscreteValues<T>* discrete_state) const {
   DRAKE_ASSERT(!is_abstract());
-  const auto& input = get_input_port().Eval(context);
+  const auto& input = this->get_input_port().Eval(context);
   BasicVector<T>& state_value = discrete_state->get_mutable_vector(0);
   state_value.SetFromVector(input);
 }
@@ -89,7 +89,8 @@ void ZeroOrderHold<T>::LatchInputAbstractValueToState(
     const Context<T>& context,
     State<T>* state) const {
   DRAKE_ASSERT(is_abstract());
-  const auto& input = get_input_port().template Eval<AbstractValue>(context);
+  const auto& input =
+      this->get_input_port().template Eval<AbstractValue>(context);
   AbstractValue& state_value =
       state->get_mutable_abstract_state().get_mutable_value(0);
   state_value.SetFrom(input);

--- a/systems/primitives/zero_order_hold.h
+++ b/systems/primitives/zero_order_hold.h
@@ -71,16 +71,6 @@ class ZeroOrderHold final : public LeafSystem<T> {
 
   ~ZeroOrderHold() final = default;
 
-  /// Returns the sole input port.
-  const InputPort<T>& get_input_port() const {
-    return LeafSystem<T>::get_input_port(0);
-  }
-
-  /// Returns the sole output port.
-  const OutputPort<T>& get_output_port() const {
-    return LeafSystem<T>::get_output_port(0);
-  }
-
   /// Reports the period of this hold (in seconds).
   double period() const { return period_sec_; }
 

--- a/systems/rendering/multibody_position_to_geometry_pose.cc
+++ b/systems/rendering/multibody_position_to_geometry_pose.cc
@@ -78,7 +78,7 @@ void MultibodyPositionToGeometryPose<T>::CalcGeometryPose(
   // TODO(eric.cousineau): Place `plant_context_` in the cache of `context`,
   // and remove mutable member.
   plant_.GetMutablePositions(plant_context_.get()) =
-      get_input_port().Eval(context).head(plant_.num_positions());
+      this->get_input_port().Eval(context).head(plant_.num_positions());
 
   // Evaluate the plant's output port.
   plant_.get_geometry_poses_output_port().Calc(*plant_context_, output);

--- a/systems/rendering/multibody_position_to_geometry_pose.h
+++ b/systems/rendering/multibody_position_to_geometry_pose.h
@@ -73,16 +73,6 @@ class MultibodyPositionToGeometryPose final : public LeafSystem<T> {
   /** Returns true if this system owns its MultibodyPlant. */
   bool owns_plant() const { return owned_plant_ != nullptr; }
 
-  /** Returns the multibody position input port. */
-  const InputPort<T>& get_input_port() const {
-    return LeafSystem<T>::get_input_port(0);
-  }
-
-  /** Returns the geometry::FramePoseVector output port. */
-  const OutputPort<T>& get_output_port() const {
-    return LeafSystem<T>::get_output_port(0);
-  }
-
  private:
   // Configure the input/output ports and prepare for calculation.
   // @pre plant_ must reference a valid MBP.

--- a/systems/rendering/render_pose_to_geometry_pose.cc
+++ b/systems/rendering/render_pose_to_geometry_pose.cc
@@ -23,11 +23,10 @@ RenderPoseToGeometryPose<T>::RenderPoseToGeometryPose(
   using Output = geometry::FramePoseVector<T>;
   this->DeclareVectorInputPort(Input{});
   this->DeclareAbstractOutputPort(
-      []() {
-        return Value<Output>{}.Clone();
-      },
+      []() { return Value<Output>{}.Clone(); },
       [this, frame_id](const Context<T>& context, AbstractValue* calculated) {
-        const Input& input = get_input_port().template Eval<Input>(context);
+        const Input& input =
+            this->get_input_port().template Eval<Input>(context);
         calculated->get_mutable_value<Output>() =
             {{frame_id, input.get_transform()}};
       });

--- a/systems/rendering/render_pose_to_geometry_pose.h
+++ b/systems/rendering/render_pose_to_geometry_pose.h
@@ -24,16 +24,6 @@ class RenderPoseToGeometryPose final : public LeafSystem<T> {
 
   ~RenderPoseToGeometryPose() override;
 
-  /// Returns the rendering::PoseVector input port.
-  const InputPort<T>& get_input_port() const {
-    return LeafSystem<T>::get_input_port(0);
-  }
-
-  /// Returns the geometry::FramePoseVector output port.
-  const OutputPort<T>& get_output_port() const {
-    return LeafSystem<T>::get_output_port(0);
-  }
-
  private:
   // Allow different specializations to access each other's private data.
   template <typename> friend class RenderPoseToGeometryPose;


### PR DESCRIPTION
The cost of authoring a new system is still too high.  I was about to implement the default (no argument) `get_input_port()` and `get_output_port()` methods for my new system, but realized that the amount of trivial code throughout the codebase was immense.  (Rule of >>three?).

Not having these default also complicates the python bindings.  Users that wanted both methods had to provide overloads of the base system class for the derived class.  And if I had a nickel for every time a student/novice user asked about why `get_input_port(0)` worked for some systems, but not all systems that have >0 input ports...

This PR also proposes that we STOP the practice of deleting the default `get_input_port(int)` and `get_output_port(int)` methods when we offer the `get_input_port()`, etc method alternatives.  In this case, I will happily trade the compile-time check for the runtime check in order to imho considerably improve the consistency of the API and the user experience.  (I was going to defer this change to a second PR, but it turns out they are coupled, since the deletions as written were deleting both base class overloads and causing compilation errors.)

Reviewers: The key change is the two new additional methods in `system.h`.