### PR TITLE
Remove spurious uses of the inline keyword

### DIFF
--- a/common/autodiff_overloads.h
+++ b/common/autodiff_overloads.h
@@ -177,7 +177,7 @@ struct dummy_value<Eigen::AutoDiffScalar<DerType>> {
 /// implementation of min/max function for AutoDiffScalar type
 /// (https://bitbucket.org/eigen/eigen/src/10a1de58614569c9250df88bdfc6402024687bc6/unsupported/Eigen/src/AutoDiff/AutoDiffScalar.h?at=default&fileviewer=file-view-default#AutoDiffScalar.h-546).
 template <typename DerType1, typename DerType2>
-inline Eigen::AutoDiffScalar<
+Eigen::AutoDiffScalar<
     typename Eigen::internal::remove_all<DerType1>::type::PlainObject>
 if_then_else(bool f_cond, const Eigen::AutoDiffScalar<DerType1>& x,
              const Eigen::AutoDiffScalar<DerType2>& y) {

--- a/common/copyable_unique_ptr.h
+++ b/common/copyable_unique_ptr.h
@@ -380,7 +380,7 @@ class copyable_unique_ptr : public std::unique_ptr<T> {
  in a copyable_unique_ptr object. This is equivalent to `os << p.get();`.
  @relates copyable_unique_ptr */
 template <class charT, class traits, class T>
-inline std::basic_ostream<charT, traits>& operator<<(
+std::basic_ostream<charT, traits>& operator<<(
     std::basic_ostream<charT, traits>& os,
     const copyable_unique_ptr<T>& cu_ptr) {
   os << cu_ptr.get();

--- a/common/identifier.h
+++ b/common/identifier.h
@@ -213,8 +213,7 @@ class Identifier {
  @relates Identifier
  */
 template <typename Tag>
-inline std::ostream& operator<<(std::ostream& out,
-                                const Identifier<Tag>& id) {
+std::ostream& operator<<(std::ostream& out, const Identifier<Tag>& id) {
   out << id.get_value();
   return out;
 }
@@ -222,7 +221,7 @@ inline std::ostream& operator<<(std::ostream& out,
 /** Enables use of identifiers with to_string. It requires ADL to work. So,
  it should be invoked as: `to_string(id);` and should be preceded by
  `using std::to_string`.*/
-template <typename Tag> inline
+template <typename Tag>
 std::string to_string(const drake::Identifier<Tag>& id) {
   return std::to_string(id.get_value());
 }

--- a/multibody/math/spatial_vector.h
+++ b/multibody/math/spatial_vector.h
@@ -288,7 +288,7 @@ class SpatialVector {
 /// Stream insertion operator to write SpatialVector objects into a
 /// `std::ostream`. Especially useful for debugging.
 /// @relates SpatialVector.
-template <template <typename> class SpatialQuantity, typename T> inline
+template <template <typename> class SpatialQuantity, typename T>
 std::ostream& operator<<(std::ostream& o,
                          const SpatialVector<SpatialQuantity, T>& V) {
   o << "[" << V[0];

--- a/multibody/tree/rotational_inertia.h
+++ b/multibody/tree/rotational_inertia.h
@@ -1034,7 +1034,7 @@ class RotationalInertia {
 /// Insertion operator to write %RotationalInertia's into a `std::ostream`.
 /// Especially useful for debugging.
 /// @relates RotationalInertia
-template <typename T> inline
+template <typename T>
 std::ostream& operator<<(std::ostream& o,
                          const RotationalInertia<T>& I) {
   int width = 0;

--- a/multibody/tree/spatial_inertia.h
+++ b/multibody/tree/spatial_inertia.h
@@ -514,7 +514,7 @@ class SpatialInertia {
 /// Insertion operator to write SpatialInertia objects into a `std::ostream`.
 /// Especially useful for debugging.
 /// @relates SpatialInertia
-template <typename T> inline
+template <typename T>
 std::ostream& operator<<(std::ostream& o,
                          const SpatialInertia<T>& M) {
   return o << std::endl

--- a/perception/point_cloud.h
+++ b/perception/point_cloud.h
@@ -79,8 +79,8 @@ class PointCloud final {
   /// Represents an invalid or uninitialized value.
   static constexpr T kDefaultValue = std::numeric_limits<T>::quiet_NaN();
   static constexpr C kDefaultColor{};
-  static inline bool IsDefaultValue(T value) { return std::isnan(value); }
-  static inline bool IsInvalidValue(T value) { return !std::isfinite(value); }
+  static bool IsDefaultValue(T value) { return std::isnan(value); }
+  static bool IsInvalidValue(T value) { return !std::isfinite(value); }
 
   /// Constructs a point cloud of a given `new_size`, with the prescribed
   /// `fields`. If `kDescriptors` is one of the fields, then

--- a/perception/point_cloud_flags.h
+++ b/perception/point_cloud_flags.h
@@ -51,12 +51,12 @@ class DescriptorType final {
       : size_(size),
         name_(name) {}
 
-  inline int size() const { return size_; }
-  inline std::string name() const { return name_; }
-  inline bool operator==(const DescriptorType& other) const {
+  int size() const { return size_; }
+  std::string name() const { return name_; }
+  bool operator==(const DescriptorType& other) const {
     return size_ == other.size_ && name() == other.name();
   }
-  inline bool operator!=(const DescriptorType& other) const {
+  bool operator!=(const DescriptorType& other) const {
     return !(*this == other);
   }
 

--- a/systems/controllers/setpoint.h
+++ b/systems/controllers/setpoint.h
@@ -115,22 +115,22 @@ class CartesianSetpoint {
   }
 
   // Getters
-  inline const math::RigidTransform<Scalar>& desired_pose() const {
+  const math::RigidTransform<Scalar>& desired_pose() const {
     return pose_d_;
   }
-  inline const Vector6<Scalar>& desired_velocity() const { return vel_d_; }
-  inline const Vector6<Scalar>& desired_acceleration() const { return acc_d_; }
-  inline const Vector6<Scalar>& Kp() const { return Kp_; }
-  inline const Vector6<Scalar>& Kd() const { return Kd_; }
+  const Vector6<Scalar>& desired_velocity() const { return vel_d_; }
+  const Vector6<Scalar>& desired_acceleration() const { return acc_d_; }
+  const Vector6<Scalar>& Kp() const { return Kp_; }
+  const Vector6<Scalar>& Kd() const { return Kd_; }
 
   // Setters
-  inline math::RigidTransform<Scalar>& mutable_desired_pose() {
+  math::RigidTransform<Scalar>& mutable_desired_pose() {
     return pose_d_;
   }
-  inline Vector6<Scalar>& mutable_desired_velocity() { return vel_d_; }
-  inline Vector6<Scalar>& mutable_desired_acceleration() { return acc_d_; }
-  inline Vector6<Scalar>& mutable_Kp() { return Kp_; }
-  inline Vector6<Scalar>& mutable_Kd() { return Kd_; }
+  Vector6<Scalar>& mutable_desired_velocity() { return vel_d_; }
+  Vector6<Scalar>& mutable_desired_acceleration() { return acc_d_; }
+  Vector6<Scalar>& mutable_Kp() { return Kp_; }
+  Vector6<Scalar>& mutable_Kd() { return Kd_; }
 
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
@@ -149,8 +149,8 @@ class CartesianSetpoint {
 };
 
 template <typename Scalar>
-inline std::ostream& operator<<(std::ostream& out,
-                                const CartesianSetpoint<Scalar>& setpoint) {
+std::ostream& operator<<(std::ostream& out,
+                         const CartesianSetpoint<Scalar>& setpoint) {
   const math::RigidTransform<Scalar> X(setpoint.desired_pose());
   const math::RollPitchYaw<Scalar> rpy(X.rotation());
   out << "pose: (" << X.translation().transpose()
@@ -249,19 +249,19 @@ class VectorSetpoint {
   }
 
   // Getters
-  inline const VectorX<Scalar>& desired_position() const { return pos_d_; }
-  inline const VectorX<Scalar>& desired_velocity() const { return vel_d_; }
-  inline const VectorX<Scalar>& desired_acceleration() const { return acc_d_; }
-  inline const VectorX<Scalar>& Kp() const { return Kp_; }
-  inline const VectorX<Scalar>& Kd() const { return Kd_; }
-  inline int size() const { return pos_d_.size(); }
+  const VectorX<Scalar>& desired_position() const { return pos_d_; }
+  const VectorX<Scalar>& desired_velocity() const { return vel_d_; }
+  const VectorX<Scalar>& desired_acceleration() const { return acc_d_; }
+  const VectorX<Scalar>& Kp() const { return Kp_; }
+  const VectorX<Scalar>& Kd() const { return Kd_; }
+  int size() const { return pos_d_.size(); }
 
   // Setters
-  inline VectorX<Scalar>& mutable_desired_position() { return pos_d_; }
-  inline VectorX<Scalar>& mutable_desired_velocity() { return vel_d_; }
-  inline VectorX<Scalar>& mutable_desired_acceleration() { return acc_d_; }
-  inline VectorX<Scalar>& mutable_Kp() { return Kp_; }
-  inline VectorX<Scalar>& mutable_Kd() { return Kd_; }
+  VectorX<Scalar>& mutable_desired_position() { return pos_d_; }
+  VectorX<Scalar>& mutable_desired_velocity() { return vel_d_; }
+  VectorX<Scalar>& mutable_desired_acceleration() { return acc_d_; }
+  VectorX<Scalar>& mutable_Kp() { return Kp_; }
+  VectorX<Scalar>& mutable_Kd() { return Kd_; }
 
  private:
   // Desired position

--- a/systems/primitives/symbolic_vector_system.cc
+++ b/systems/primitives/symbolic_vector_system.cc
@@ -33,8 +33,8 @@ Expression FirstOrderTaylorExpand(const Expression& f, const Substitution& a) {
 }
 
 // Checks if @p v is in @p variables.
-inline bool Includes(const Ref<const VectorX<Variable>>& variables,
-                     const Variable& v) {
+bool Includes(const Ref<const VectorX<Variable>>& variables,
+              const Variable& v) {
   for (int i = 0; i < variables.size(); ++i) {
     if (variables[i].equal_to(v)) {
       return true;


### PR DESCRIPTION
- The only time we _should_ use `inline` is for non-templated functions defined at namespace scope in a header file, so that they link correctly (ala ODR).
- Methods defined within a class definition are automatically inline, no need for the keyword.
- Templated methods are automatically inline, no need for the keyword.

As inspired by https://github.com/RobotLocomotion/styleguide/pull/33.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13887)
<!-- Reviewable:end -->
