### PR TITLE
[examples] Connect rod 2d to SceneGraph for visualization

### DIFF
--- a/examples/rod2d/BUILD.bazel
+++ b/examples/rod2d/BUILD.bazel
@@ -26,16 +26,11 @@ drake_cc_binary(
     test_rule_args = [" --sim_duration=0.01"],
     deps = [
         ":rod2d",
-        "//attic/systems/rendering:drake_visualizer_client",
-        "//common:add_text_logging_gflags",
+        ":rod2d_geometry",
         "//common:essential",
-        "//lcm",
-        "//lcmtypes:viewer",
+        "//geometry:geometry_visualization",
         "//systems/analysis",
         "//systems/framework",
-        "//systems/lcm:lcm_pubsub_system",
-        "//systems/rendering:pose_aggregator",
-        "//systems/rendering:pose_bundle_to_draw_message",
         "@gflags",
     ],
 )
@@ -53,6 +48,26 @@ drake_cc_library(
         "//solvers:mathematical_program",
         "//systems/framework:leaf_system",
         "//systems/rendering:pose_vector",
+    ],
+)
+
+drake_cc_library(
+    name = "rod2d_geometry",
+    srcs = ["rod2d_geometry.cc"],
+    hdrs = [
+        "rod2d_geometry.h",
+    ],
+    deps = [
+        "//geometry:frame_kinematics",
+        "//geometry:geometry_frame",
+        "//geometry:geometry_ids",
+        "//geometry:geometry_instance",
+        "//geometry:geometry_roles",
+        "//geometry:rgba",
+        "//geometry:scene_graph",
+        "//math:geometric_transform",
+        "//systems/framework:diagram_builder",
+        "//systems/framework:leaf_system",
     ],
 )
 

--- a/examples/rod2d/rod2d.cc
+++ b/examples/rod2d/rod2d.cc
@@ -47,8 +47,7 @@ Rod2D<T>::Rod2D(SystemType system_type, double dt)
 
   this->DeclareInputPort(systems::kVectorValued, 3);
   state_output_port_ = &this->DeclareVectorOutputPort(
-      systems::BasicVector<T>(6), &Rod2D::CopyStateOut);
-  pose_output_port_ = &this->DeclareVectorOutputPort(&Rod2D::CopyPoseOut);
+      "state_output", systems::BasicVector<T>(6), &Rod2D::CopyStateOut);
 }
 
 // Computes the external forces on the rod.
@@ -484,16 +483,6 @@ void Rod2D<T>::CopyStateOut(const systems::Context<T>& context,
                                ? context.get_discrete_state(0).CopyToVector()
                                : context.get_continuous_state().CopyToVector();
   state_port_value->SetFromVector(state);
-}
-
-template <typename T>
-void Rod2D<T>::CopyPoseOut(
-    const systems::Context<T>& context,
-    systems::rendering::PoseVector<T>* pose_port_value) const {
-  const VectorX<T> state = (system_type_ == SystemType::kDiscretized)
-                               ? context.get_discrete_state(0).CopyToVector()
-                               : context.get_continuous_state().CopyToVector();
-  ConvertStateToPose(state, pose_port_value);
 }
 
 /// Integrates the Rod 2D example forward in time using a
@@ -1063,20 +1052,6 @@ void Rod2D<T>::SetDefaultState(const systems::Context<T>&,
       // TODO(edrumwri): Determine and set the point of contact.
     }
   }
-}
-
-// Converts a state vector to a rendering PoseVector.
-template <class T>
-void Rod2D<T>::ConvertStateToPose(const VectorX<T>& state,
-                                  systems::rendering::PoseVector<T>* pose) {
-  // Converts the configuration of the rod to a pose, accounting for both
-  // the change to a y+ up coordinate system and the fact that Drake's cylinder
-  // up-direction defaults to +z.
-  const T theta = state[2] + M_PI_2;
-  pose->set_translation(Eigen::Translation<T, 3>(state[0], 0, state[1]));
-  const Vector3<T> y_axis{0, 1, 0};
-  const Eigen::AngleAxis<T> rotation(theta, y_axis);
-  pose->set_rotation(Eigen::Quaternion<T>(rotation));
 }
 
 template class Rod2D<double>;

--- a/examples/rod2d/rod2d.h
+++ b/examples/rod2d/rod2d.h
@@ -9,7 +9,6 @@
 #include "drake/multibody/constraint/constraint_solver.h"
 #include "drake/solvers/moby_lcp_solver.h"
 #include "drake/systems/framework/leaf_system.h"
-#include "drake/systems/rendering/pose_vector.h"
 
 namespace drake {
 namespace examples {
@@ -139,9 +138,7 @@ States: planar position (state indices 0 and 1) and orientation (state
         m/s, and rad/s, respectively. Orientation is measured counter-
         clockwise with respect to the x-axis.
 
-Outputs: Output Port 0 corresponds to the state vector; Output Port 1
-         corresponds to a PoseVector giving the 3D pose of the rod in the world
-         frame.
+Outputs: Output Port 0 corresponds to the state vector.
 
 - [Stewart, 2000]  D. Stewart, "Rigid-Body Dynamics with Friction and
                    Impact". SIAM Rev., 42(1), 3-39, 2000.
@@ -398,9 +395,9 @@ class Rod2D : public systems::LeafSystem<T> {
   /// for a given state (using @p context).
   int DetermineNumWitnessFunctions(const systems::Context<T>& context) const;
 
-  /// Returns the 3D pose of this rod.
-  const systems::OutputPort<T>& pose_output() const {
-    return *pose_output_port_;
+  /// Returns the state of this rod.
+  const systems::OutputPort<T>& state_output() const {
+    return *state_output_port_;
   }
 
   /// Utility method for determining the World frame location of one of three
@@ -498,8 +495,6 @@ class Rod2D : public systems::LeafSystem<T> {
   int get_k(const systems::Context<T>& context) const;
   void CopyStateOut(const systems::Context<T>& context,
                     systems::BasicVector<T>* output) const;
-  void CopyPoseOut(const systems::Context<T>& context,
-                   systems::rendering::PoseVector<T>* output) const;
   void DoCalcTimeDerivatives(const systems::Context<T>& context,
                              systems::ContinuousState<T>* derivatives)
                                const override;
@@ -510,8 +505,6 @@ class Rod2D : public systems::LeafSystem<T> {
   void SetDefaultState(const systems::Context<T>& context,
                        systems::State<T>* state) const override;
 
-  static void ConvertStateToPose(const VectorX<T>& state,
-                                 systems::rendering::PoseVector<T>* pose);
   Vector3<T> ComputeExternalForces(const systems::Context<T>& context) const;
   Matrix3<T> GetInverseInertiaMatrix() const;
   void CalcTwoContactNoSlidingForces(const systems::Context<T>& context,
@@ -573,7 +566,6 @@ class Rod2D : public systems::LeafSystem<T> {
   double kCharacteristicDeformation{1e-3};
 
   // Output ports.
-  const systems::OutputPort<T>* pose_output_port_{nullptr};
   const systems::OutputPort<T>* state_output_port_{nullptr};
 };
 

--- a/examples/rod2d/rod2d_geometry.cc
+++ b/examples/rod2d/rod2d_geometry.cc
@@ -1,0 +1,81 @@
+#include "drake/examples/rod2d/rod2d_geometry.h"
+
+#include <memory>
+
+#include "drake/geometry/frame_kinematics_vector.h"
+#include "drake/geometry/geometry_frame.h"
+#include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/geometry_instance.h"
+#include "drake/geometry/geometry_roles.h"
+#include "drake/geometry/rgba.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/math/rotation_matrix.h"
+
+namespace drake {
+namespace examples {
+namespace rod2d {
+
+using Eigen::Vector3d;
+using math::RigidTransformd;
+using math::RotationMatrixd;
+
+const Rod2dGeometry* Rod2dGeometry::AddToBuilder(
+    double radius, double length, systems::DiagramBuilder<double>* builder,
+    const systems::OutputPort<double>& rod2d_state_port,
+    geometry::SceneGraph<double>* scene_graph) {
+  DRAKE_THROW_UNLESS(builder != nullptr);
+  DRAKE_THROW_UNLESS(scene_graph != nullptr);
+
+  auto rod2d_geometry = builder->AddSystem(std::unique_ptr<Rod2dGeometry>(
+      new Rod2dGeometry(radius, length, scene_graph)));
+  builder->Connect(rod2d_state_port, rod2d_geometry->get_input_port());
+  builder->Connect(
+      rod2d_geometry->get_output_port(),
+      scene_graph->get_source_pose_port(rod2d_geometry->source_id_));
+
+  return rod2d_geometry;
+}
+
+Rod2dGeometry::Rod2dGeometry(double radius, double length,
+                             geometry::SceneGraph<double>* scene_graph) {
+  DRAKE_THROW_UNLESS(scene_graph != nullptr);
+
+  source_id_ = scene_graph->RegisterSource("rod2d");
+  frame_id_ =
+      scene_graph->RegisterFrame(source_id_, geometry::GeometryFrame("rod2d"));
+  geometry::GeometryId geometry = scene_graph->RegisterGeometry(
+      source_id_, frame_id_,
+      std::make_unique<geometry::GeometryInstance>(
+          RigidTransformd{},
+          std::make_unique<geometry::Cylinder>(radius, length), "rod2d"));
+  geometry::IllustrationProperties illus_props;
+  illus_props.AddProperty("phong", "diffuse", geometry::Rgba(0.7, 0.7, 0.7, 1));
+  scene_graph->AssignRole(source_id_, geometry, illus_props);
+
+  // Only uses the qs of the state (x, y, θ).
+  this->DeclareVectorInputPort("state", systems::BasicVector<double>(6));
+  this->DeclareAbstractOutputPort("geometry_pose",
+                                  &Rod2dGeometry::OutputGeometryPose);
+}
+
+Rod2dGeometry::~Rod2dGeometry() = default;
+
+void Rod2dGeometry::OutputGeometryPose(
+    const systems::Context<double>& context,
+    geometry::FramePoseVector<double>* poses) const {
+  DRAKE_DEMAND(frame_id_.is_valid());
+
+  const auto& state = get_input_port().Eval(context);
+  // Converts the configuration of the rod to a pose in ℜ³. The 2D system lies
+  // on the x-y plane with +y up. In 3D, we place it on the y = 0 plane with +z
+  // up. This is compatible with the fact that a drake cylinder has its axis
+  // aligned with the z-axis.
+  math::RigidTransformd pose(RotationMatrixd::MakeYRotation(state(2) + M_PI_2),
+                             Vector3d(state(0), 0, state(1)));
+
+  *poses = {{frame_id_, pose}};
+}
+
+}  // namespace rod2d
+}  // namespace examples
+}  // namespace drake

--- a/examples/rod2d/rod2d_geometry.h
+++ b/examples/rod2d/rod2d_geometry.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "drake/geometry/scene_graph.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace examples {
+namespace rod2d {
+
+// Expresses the Rod2D's geometry to a SceneGraph.
+///
+/// @system
+/// name: Rod2dGeometry
+/// input_ports:
+/// - state
+/// output_ports:
+/// - geometry_pose
+/// @endsystem
+///
+/// This class has no public constructor; instead use the AddToBuilder() static
+/// method to create and add it to a DiagramBuilder directly.
+class Rod2dGeometry final : public systems::LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Rod2dGeometry);
+  ~Rod2dGeometry() final;
+
+  /// Creates, adds, and connects a Rod2dGeometry system into the given
+  /// `builder`. Both the `rod2d_state_port.get_system()` and `scene_graph`
+  /// systems must have been added to the given `builder` already.
+  ///
+  /// The `scene_graph` pointer is not retained by the %Rod2dGeometry
+  /// system. The return value pointer is an alias of the new %Rod2dGeometry
+  /// system that is owned by the `builder`.
+  ///
+  /// The rod is visualized with a cylinder with the given `radius`, and
+  /// `length` displayed with the a default grey color.
+  static const Rod2dGeometry* AddToBuilder(
+      double radius, double length, systems::DiagramBuilder<double>* builder,
+      const systems::OutputPort<double>& rod2d_state_port,
+      geometry::SceneGraph<double>* scene_graph);
+
+ private:
+  Rod2dGeometry(double radius, double length, geometry::SceneGraph<double>*);
+  void OutputGeometryPose(const systems::Context<double>&,
+                          geometry::FramePoseVector<double>*) const;
+
+  // Geometry source identifier for this system to interact with SceneGraph.
+  geometry::SourceId source_id_{};
+  // The id for the rod's body.
+  geometry::FrameId frame_id_{};
+};
+
+}  // namespace rod2d
+}  // namespace examples
+}  // namespace drake

--- a/examples/rod2d/rod2d_sim.cc
+++ b/examples/rod2d/rod2d_sim.cc
@@ -5,42 +5,24 @@
 
 #include <gflags/gflags.h>
 
-#include "drake/common/text_logging.h"
 #include "drake/examples/rod2d/rod2d.h"
-#include "drake/lcm/drake_lcm.h"
-#include "drake/lcmt_viewer_draw.hpp"
-#include "drake/lcmt_viewer_load_robot.hpp"
+#include "drake/examples/rod2d/rod2d_geometry.h"
+#include "drake/geometry/geometry_visualization.h"
 #include "drake/systems/analysis/implicit_euler_integrator.h"
 #include "drake/systems/analysis/runge_kutta3_integrator.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/diagram_builder.h"
-#include "drake/systems/lcm/lcm_publisher_system.h"
-#include "drake/systems/lcm/lcm_subscriber_system.h"
-#include "drake/systems/lcm/serializer.h"
-#include "drake/systems/rendering/pose_aggregator.h"
-#include "drake/systems/rendering/pose_bundle_to_draw_message.h"
-
-// TODO(jwnimmer-tri) Port this demo to use SceneGraph.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#include "drake/systems/rendering/drake_visualizer_client.h"
-#pragma GCC diagnostic pop
 
 using Rod2D = drake::examples::rod2d::Rod2D<double>;
-using drake::lcm::DrakeLcm;
-using drake::systems::BasicVector;
+using drake::examples::rod2d::Rod2dGeometry;
+using drake::geometry::ConnectDrakeVisualizer;
+using drake::geometry::SceneGraph;
 using drake::systems::Context;
-using drake::systems::lcm::LcmPublisherSystem;
-using drake::systems::lcm::LcmSubscriberSystem;
-using drake::systems::lcm::Serializer;
 using drake::systems::DiagramBuilder;
-using drake::systems::rendering::MakeGeometryData;
-using drake::systems::rendering::PoseAggregator;
-using drake::systems::rendering::PoseBundleToDrawMessage;
-using drake::systems::Simulator;
 using drake::systems::ImplicitEulerIntegrator;
 using drake::systems::RungeKutta3Integrator;
+using drake::systems::Simulator;
 
 // Simulation parameters.
 DEFINE_string(system_type, "discretized",
@@ -56,25 +38,7 @@ int main(int argc, char* argv[]) {
   // Parse any flags.
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
-  // Emit a one-time load message.
-  Serializer<drake::lcmt_viewer_load_robot> load_serializer;
-
-  // TODO(edrumwri): Remove the DRAKE_VIEWER_DRAW, DRAKE_VIEWER_LOAD_ROBOT
-  //                 magic strings as soon as they are a named constant within
-  //                 Drake (or, even better, remove as much of this
-  //                 copy/pasted visualization code when possible).
-  // Build the simulation diagram.
-  DrakeLcm lcm;
   DiagramBuilder<double> builder;
-  PoseAggregator<double>* aggregator =
-      builder.template AddSystem<PoseAggregator>();
-  PoseBundleToDrawMessage* converter =
-      builder.template AddSystem<PoseBundleToDrawMessage>();
-  LcmPublisherSystem* publisher =
-      builder.template AddSystem<LcmPublisherSystem>(
-          "DRAKE_VIEWER_DRAW",
-          std::make_unique<Serializer<drake::lcmt_viewer_draw>>(), &lcm,
-          0.01 /* publish period */);
 
   // Create the rod and add it to the diagram.
   Rod2D* rod;
@@ -90,32 +54,14 @@ int main(int argc, char* argv[]) {
     return -1;
   }
 
-  // Create the rod visualization.
-  DrakeShapes::VisualElement rod_vis(
-      DrakeShapes::Cylinder(FLAGS_rod_radius, rod->get_rod_half_length() * 2),
-      Eigen::Isometry3d::Identity(), Eigen::Vector4d(0.7, 0.7, 0.7, 1));
-
-  // Create the load message.
-  drake::lcmt_viewer_load_robot message{};
-  message.num_links = 1;
-  message.link.resize(1);
-  message.link.back().name = "rod";
-  message.link.back().robot_num = 0;
-  message.link.back().num_geom = 1;
-  message.link.back().geom.resize(1);
-  message.link.back().geom[0] = MakeGeometryData(rod_vis);
-
-  // Send a load message.
-  Publish(&lcm, "DRAKE_VIEWER_LOAD_ROBOT", message);
+  auto& scene_graph = *builder.AddSystem<SceneGraph<double>>();
+  Rod2dGeometry::AddToBuilder(FLAGS_rod_radius, rod->get_rod_half_length() * 2,
+                              &builder, rod->state_output(), &scene_graph);
+  ConnectDrakeVisualizer(&builder, scene_graph);
 
   // Set the names of the systems.
   rod->set_name("rod");
-  aggregator->set_name("aggregator");
-  converter->set_name("converter");
 
-  builder.Connect(rod->pose_output(), aggregator->AddSingleInput("rod", 0));
-  builder.Connect(*aggregator, *converter);
-  builder.Connect(*converter, *publisher);
   auto diagram = builder.Build();
 
   // Make no external forces act on the rod.

--- a/examples/rod2d/test/rod2d_test.cc
+++ b/examples/rod2d/test/rod2d_test.cc
@@ -20,7 +20,6 @@ using drake::systems::SystemOutput;
 using drake::systems::AbstractValues;
 using drake::systems::Simulator;
 using drake::systems::Context;
-using drake::systems::rendering::PoseVector;
 
 using Eigen::Vector2d;
 using Eigen::Vector3d;
@@ -1132,7 +1131,6 @@ GTEST_TEST(Rod2DCrossValidationTest, Outputs) {
 
   // Set port indices.
   const int state_port = 0;
-  const int pose_port = 1;
 
   // Verify that state outputs are identical.
   const double eq_tol = 10 * std::numeric_limits<double>::epsilon();
@@ -1146,16 +1144,6 @@ GTEST_TEST(Rod2DCrossValidationTest, Outputs) {
   x_pdae[2] = M_PI_2;
   context_pdae->get_mutable_continuous_state().SetFromVector(x_pdae);
   pdae.CalcOutput(*context_pdae, output_pdae.get());
-
-  // Rotation by theta is converted to rotation around +y by theta + π/2.
-  const PoseVector<double>* const pose = dynamic_cast<
-      PoseVector<double>*>(output_pdae->GetMutableVectorData(pose_port));
-  const Eigen::Quaterniond quat = pose->get_rotation();
-  EXPECT_NEAR(quat.y(), 1, eq_tol);
-
-  // -- Translation along +y is converted to translation along +z.
-  const auto translation = pose->get_translation();
-  EXPECT_NEAR(translation.z(), pdae.get_rod_half_length(), eq_tol);
 }
 
 }  // namespace rod2d


### PR DESCRIPTION
Supplant the old visualization mechanism with the standard used in examples. examples/rod2d is no longer dependent on attic code.

resolves #13316

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13890)
<!-- Reviewable:end -->
