### PR TITLE
examples: remove redundant get_input_port() and get_output_port()

### DIFF
--- a/examples/pendulum/pendulum_plant.cc
+++ b/examples/pendulum/pendulum_plant.cc
@@ -27,12 +27,6 @@ template <typename T>
 PendulumPlant<T>::~PendulumPlant() = default;
 
 template <typename T>
-const systems::InputPort<T>& PendulumPlant<T>::get_input_port() const {
-  DRAKE_DEMAND(systems::LeafSystem<T>::num_input_ports() == 1);
-  return systems::LeafSystem<T>::get_input_port(0);
-}
-
-template <typename T>
 const systems::OutputPort<T>& PendulumPlant<T>::get_state_output_port() const {
   DRAKE_DEMAND(systems::LeafSystem<T>::num_output_ports() == 1);
   return systems::LeafSystem<T>::get_output_port(0);

--- a/examples/pendulum/pendulum_plant.h
+++ b/examples/pendulum/pendulum_plant.h
@@ -35,9 +35,6 @@ class PendulumPlant final : public systems::LeafSystem<T> {
 
   ~PendulumPlant() final;
 
-  /// Returns the input port to the externally applied force.
-  const systems::InputPort<T>& get_input_port() const;
-
   /// Returns the port to output state.
   const systems::OutputPort<T>& get_state_output_port() const;
 


### PR DESCRIPTION
PR #13883 provides these methods by default in the System base class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13894)
<!-- Reviewable:end -->
