### PR TITLE
manipulation: remove redundant get_input_port() and get_output_port()

### DIFF
--- a/manipulation/kinova_jaco/jaco_command_receiver.cc
+++ b/manipulation/kinova_jaco/jaco_command_receiver.cc
@@ -46,15 +46,6 @@ JacoCommandReceiver::JacoCommandReceiver(int num_joints, int num_fingers)
       });
 }
 
-const systems::InputPort<double>& JacoCommandReceiver::get_input_port() const {
-  return LeafSystem<double>::get_input_port(0);
-}
-
-const systems::OutputPort<double>&
-JacoCommandReceiver::get_output_port() const {
-  return LeafSystem<double>::get_output_port(0);
-}
-
 void JacoCommandReceiver::set_initial_position(
     Context<double>* context, const Eigen::Ref<const VectorXd>& q) const {
   DRAKE_THROW_UNLESS(q.size() == num_joints_ + num_fingers_);

--- a/manipulation/kinova_jaco/jaco_command_receiver.h
+++ b/manipulation/kinova_jaco/jaco_command_receiver.h
@@ -50,12 +50,6 @@ class JacoCommandReceiver : public systems::LeafSystem<double> {
       systems::Context<double>* context,
       const Eigen::Ref<const Eigen::VectorXd>& q) const;
 
-  /// @name Named accessors for this System's input and output ports.
-  //@{
-  const systems::InputPort<double>& get_input_port() const;
-  const systems::OutputPort<double>& get_output_port() const;
-  //@}
-
  private:
   Eigen::VectorXd input_state(const systems::Context<double>&) const;
   void CalcInput(const systems::Context<double>&, lcmt_jaco_command*) const;

--- a/manipulation/kinova_jaco/jaco_command_sender.cc
+++ b/manipulation/kinova_jaco/jaco_command_sender.cc
@@ -13,13 +13,6 @@ JacoCommandSender::JacoCommandSender(int num_joints, int num_fingers)
       "lcmt_jaco_command", &JacoCommandSender::CalcOutput);
 }
 
-const systems::InputPort<double>& JacoCommandSender::get_input_port() const {
-  return LeafSystem<double>::get_input_port(0);
-}
-const systems::OutputPort<double>& JacoCommandSender::get_output_port() const {
-  return LeafSystem<double>::get_output_port(0);
-}
-
 void JacoCommandSender::CalcOutput(
     const systems::Context<double>& context, lcmt_jaco_command* output) const {
   const auto& state = get_input_port().Eval(context);

--- a/manipulation/kinova_jaco/jaco_command_sender.h
+++ b/manipulation/kinova_jaco/jaco_command_sender.h
@@ -41,12 +41,6 @@ class JacoCommandSender : public systems::LeafSystem<double> {
   JacoCommandSender(int num_joints = kJacoDefaultArmNumJoints,
                     int num_fingers = kJacoDefaultArmNumFingers);
 
-  /// @name Named accessors for this System's input and output ports.
-  //@{
-  const systems::InputPort<double>& get_input_port() const;
-  const systems::OutputPort<double>& get_output_port() const;
-  //@}
-
  private:
   void CalcOutput(const systems::Context<double>&, lcmt_jaco_command*) const;
 

--- a/manipulation/kinova_jaco/jaco_status_receiver.cc
+++ b/manipulation/kinova_jaco/jaco_status_receiver.cc
@@ -34,9 +34,6 @@ JacoStatusReceiver::JacoStatusReceiver(int num_joints, int num_fingers)
       &lcmt_jaco_status::finger_current>);
 }
 
-const systems::InputPort<double>& JacoStatusReceiver::get_input_port() const {
-  return LeafSystem<double>::get_input_port(0);
-}
 using OutPort = systems::OutputPort<double>;
 const OutPort& JacoStatusReceiver::get_state_output_port() const {
   return LeafSystem<double>::get_output_port(0);

--- a/manipulation/kinova_jaco/jaco_status_receiver.h
+++ b/manipulation/kinova_jaco/jaco_status_receiver.h
@@ -48,7 +48,6 @@ class JacoStatusReceiver : public systems::LeafSystem<double> {
 
   /// @name Named accessors for this System's input and output ports.
   //@{
-  const systems::InputPort<double>& get_input_port() const;
   const systems::OutputPort<double>& get_state_output_port() const;
   const systems::OutputPort<double>& get_torque_output_port() const;
   const systems::OutputPort<double>& get_torque_external_output_port() const;

--- a/manipulation/kinova_jaco/jaco_status_sender.cc
+++ b/manipulation/kinova_jaco/jaco_status_sender.cc
@@ -32,9 +32,6 @@ const InPort& JacoStatusSender::get_torque_external_input_port() const {
 const InPort& JacoStatusSender::get_current_input_port() const {
   return LeafSystem<double>::get_input_port(3);
 }
-const systems::OutputPort<double>& JacoStatusSender::get_output_port() const {
-  return LeafSystem<double>::get_output_port(0);
-}
 
 void JacoStatusSender::CalcOutput(
     const systems::Context<double>& context, lcmt_jaco_status* output) const {

--- a/manipulation/kinova_jaco/jaco_status_sender.h
+++ b/manipulation/kinova_jaco/jaco_status_sender.h
@@ -53,7 +53,6 @@ class JacoStatusSender : public systems::LeafSystem<double> {
   const systems::InputPort<double>& get_torque_input_port() const;
   const systems::InputPort<double>& get_torque_external_input_port() const;
   const systems::InputPort<double>& get_current_input_port() const;
-  const systems::OutputPort<double>& get_output_port() const;
   //@}
 
  private:

--- a/manipulation/kuka_iiwa/iiwa_command_sender.cc
+++ b/manipulation/kuka_iiwa/iiwa_command_sender.cc
@@ -21,9 +21,6 @@ const InPort& IiwaCommandSender::get_position_input_port() const {
 const InPort& IiwaCommandSender::get_torque_input_port() const {
   return LeafSystem<double>::get_input_port(1);
 }
-const systems::OutputPort<double>& IiwaCommandSender::get_output_port() const {
-  return LeafSystem<double>::get_output_port(0);
-}
 
 void IiwaCommandSender::CalcOutput(
     const systems::Context<double>& context, lcmt_iiwa_command* output) const {

--- a/manipulation/kuka_iiwa/iiwa_command_sender.h
+++ b/manipulation/kuka_iiwa/iiwa_command_sender.h
@@ -43,7 +43,6 @@ class IiwaCommandSender : public systems::LeafSystem<double> {
   //@{
   const systems::InputPort<double>& get_position_input_port() const;
   const systems::InputPort<double>& get_torque_input_port() const;
-  const systems::OutputPort<double>& get_output_port() const;
   //@}
 
  private:

--- a/manipulation/kuka_iiwa/iiwa_status_receiver.cc
+++ b/manipulation/kuka_iiwa/iiwa_status_receiver.cc
@@ -39,9 +39,6 @@ IiwaStatusReceiver::IiwaStatusReceiver(int num_joints)
         &lcmt_iiwa_status::joint_torque_external>);
 }
 
-const systems::InputPort<double>& IiwaStatusReceiver::get_input_port() const {
-  return LeafSystem<double>::get_input_port(0);
-}
 using OutPort = systems::OutputPort<double>;
 const OutPort& IiwaStatusReceiver::get_position_commanded_output_port() const {
   return LeafSystem<double>::get_output_port(0);

--- a/manipulation/kuka_iiwa/iiwa_status_receiver.h
+++ b/manipulation/kuka_iiwa/iiwa_status_receiver.h
@@ -46,7 +46,6 @@ class IiwaStatusReceiver : public systems::LeafSystem<double> {
 
   /// @name Named accessors for this System's input and output ports.
   //@{
-  const systems::InputPort<double>& get_input_port() const;
   const systems::OutputPort<double>& get_position_commanded_output_port() const;
   const systems::OutputPort<double>& get_position_measured_output_port() const;
   const systems::OutputPort<double>& get_velocity_estimated_output_port() const;

--- a/manipulation/kuka_iiwa/iiwa_status_sender.cc
+++ b/manipulation/kuka_iiwa/iiwa_status_sender.cc
@@ -42,9 +42,6 @@ const InPort& IiwaStatusSender::get_torque_measured_input_port() const {
 const InPort& IiwaStatusSender::get_torque_external_input_port() const {
   return LeafSystem<double>::get_input_port(5);
 }
-const systems::OutputPort<double>& IiwaStatusSender::get_output_port() const {
-  return LeafSystem<double>::get_output_port(0);
-}
 
 namespace {
 // Returns the first one of port1.Eval or port2.Eval that has a value.

--- a/manipulation/kuka_iiwa/iiwa_status_sender.h
+++ b/manipulation/kuka_iiwa/iiwa_status_sender.h
@@ -64,7 +64,6 @@ class IiwaStatusSender : public systems::LeafSystem<double> {
   const systems::InputPort<double>& get_torque_commanded_input_port() const;
   const systems::InputPort<double>& get_torque_measured_input_port() const;
   const systems::InputPort<double>& get_torque_external_input_port() const;
-  const systems::OutputPort<double>& get_output_port() const;
   //@}
 
  private:

--- a/manipulation/schunk_wsg/schunk_wsg_plain_controller.h
+++ b/manipulation/schunk_wsg/schunk_wsg_plain_controller.h
@@ -148,8 +148,6 @@ class SchunkWsgPlainController
     return systems::Diagram<double>::get_output_port(0);
   }
 
-  const systems::OutputPort<double>& get_output_port(int) const = delete;
-
  private:
   int desired_grip_state_input_port_{-1};
   int feed_forward_force_input_port_{-1};


### PR DESCRIPTION
PR #13883 provides these methods by default in the System base class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13895)
<!-- Reviewable:end -->
