### PR TITLE
framework: remove redundant get_input_port() and get_output_port()

### DIFF
--- a/systems/framework/vector_system.h
+++ b/systems/framework/vector_system.h
@@ -35,24 +35,6 @@ class VectorSystem : public LeafSystem<T> {
 
   ~VectorSystem() override = default;
 
-  /// Returns the sole input port.
-  const InputPort<T>& get_input_port() const {
-    DRAKE_DEMAND(this->num_input_ports() == 1);
-    return LeafSystem<T>::get_input_port(0);
-  }
-
-  // Don't use the indexed get_input_port when calling this system directly.
-  void get_input_port(int) = delete;
-
-  /// Returns the sole output port.
-  const OutputPort<T>& get_output_port() const {
-    DRAKE_DEMAND(this->num_output_ports() == 1);
-    return LeafSystem<T>::get_output_port(0);
-  }
-
-  // Don't use the indexed get_output_port when calling this system directly.
-  void get_output_port(int) = delete;
-
  protected:
   /// Creates a system with one input port and one output port of the given
   /// sizes, when the sizes are non-zero.  Either size can be zero, in which


### PR DESCRIPTION
PR #13883 provides these methods by default in the System base class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13896)
<!-- Reviewable:end -->
