### PR TITLE
systems/rendering: remove redundant get_input_port() and get_output_port()

### DIFF
--- a/systems/rendering/multibody_position_to_geometry_pose.cc
+++ b/systems/rendering/multibody_position_to_geometry_pose.cc
@@ -78,7 +78,7 @@ void MultibodyPositionToGeometryPose<T>::CalcGeometryPose(
   // TODO(eric.cousineau): Place `plant_context_` in the cache of `context`,
   // and remove mutable member.
   plant_.GetMutablePositions(plant_context_.get()) =
-      get_input_port().Eval(context).head(plant_.num_positions());
+      this->get_input_port().Eval(context).head(plant_.num_positions());
 
   // Evaluate the plant's output port.
   plant_.get_geometry_poses_output_port().Calc(*plant_context_, output);

--- a/systems/rendering/multibody_position_to_geometry_pose.h
+++ b/systems/rendering/multibody_position_to_geometry_pose.h
@@ -73,16 +73,6 @@ class MultibodyPositionToGeometryPose final : public LeafSystem<T> {
   /** Returns true if this system owns its MultibodyPlant. */
   bool owns_plant() const { return owned_plant_ != nullptr; }
 
-  /** Returns the multibody position input port. */
-  const InputPort<T>& get_input_port() const {
-    return LeafSystem<T>::get_input_port(0);
-  }
-
-  /** Returns the geometry::FramePoseVector output port. */
-  const OutputPort<T>& get_output_port() const {
-    return LeafSystem<T>::get_output_port(0);
-  }
-
  private:
   // Configure the input/output ports and prepare for calculation.
   // @pre plant_ must reference a valid MBP.

--- a/systems/rendering/render_pose_to_geometry_pose.cc
+++ b/systems/rendering/render_pose_to_geometry_pose.cc
@@ -23,11 +23,10 @@ RenderPoseToGeometryPose<T>::RenderPoseToGeometryPose(
   using Output = geometry::FramePoseVector<T>;
   this->DeclareVectorInputPort(Input{});
   this->DeclareAbstractOutputPort(
-      []() {
-        return Value<Output>{}.Clone();
-      },
+      []() { return Value<Output>{}.Clone(); },
       [this, frame_id](const Context<T>& context, AbstractValue* calculated) {
-        const Input& input = get_input_port().template Eval<Input>(context);
+        const Input& input =
+            this->get_input_port().template Eval<Input>(context);
         calculated->get_mutable_value<Output>() =
             {{frame_id, input.get_transform()}};
       });

--- a/systems/rendering/render_pose_to_geometry_pose.h
+++ b/systems/rendering/render_pose_to_geometry_pose.h
@@ -24,16 +24,6 @@ class RenderPoseToGeometryPose final : public LeafSystem<T> {
 
   ~RenderPoseToGeometryPose() override;
 
-  /// Returns the rendering::PoseVector input port.
-  const InputPort<T>& get_input_port() const {
-    return LeafSystem<T>::get_input_port(0);
-  }
-
-  /// Returns the geometry::FramePoseVector output port.
-  const OutputPort<T>& get_output_port() const {
-    return LeafSystem<T>::get_output_port(0);
-  }
-
  private:
   // Allow different specializations to access each other's private data.
   template <typename> friend class RenderPoseToGeometryPose;


### PR DESCRIPTION
PR #13883 provides these methods by default in the System base class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13897)
<!-- Reviewable:end -->
