### PR TITLE
primitives: remove redundant get_input_port() and get_output_port()

### DIFF
--- a/systems/lcm/lcm_publisher_system.h
+++ b/systems/lcm/lcm_publisher_system.h
@@ -223,20 +223,6 @@ class LcmPublisherSystem : public LeafSystem<double> {
     return *lcm_;
   }
 
-  /**
-   * Returns the sole input port.
-   */
-  const InputPort<double>& get_input_port() const {
-    DRAKE_THROW_UNLESS(this->num_input_ports() == 1);
-    return LeafSystem<double>::get_input_port(0);
-  }
-
-  // Don't use the indexed overload; use the no-arg overload.
-  void get_input_port(int index) = delete;
-
-  // This system has no output ports.
-  void get_output_port(int) = delete;
-
  private:
   EventStatus PublishInputAsLcmMessage(const Context<double>& context) const;
 

--- a/systems/lcm/lcm_subscriber_system.h
+++ b/systems/lcm/lcm_subscriber_system.h
@@ -83,18 +83,6 @@ class LcmSubscriberSystem : public LeafSystem<double> {
 
   const std::string& get_channel_name() const;
 
-  /// Returns the sole output port.
-  const OutputPort<double>& get_output_port() const {
-    DRAKE_THROW_UNLESS(this->num_output_ports() == 1);
-    return LeafSystem<double>::get_output_port(0);
-  }
-
-  // Don't use the indexed overload; use the no-arg overload.
-  void get_output_port(int index) = delete;
-
-  // This system has no input ports.
-  void get_input_port(int) = delete;
-
   /**
    * Blocks the caller until its internal message count exceeds
    * `old_message_count` with an optional timeout.

--- a/systems/plants/spring_mass_system/spring_mass_system.cc
+++ b/systems/plants/spring_mass_system/spring_mass_system.cc
@@ -113,11 +113,6 @@ const InputPort<T>& SpringMassSystem<T>::get_force_port() const {
 }
 
 template <typename T>
-const OutputPort<T>& SpringMassSystem<T>::get_output_port() const {
-  return System<T>::get_output_port(0);
-}
-
-template <typename T>
 T SpringMassSystem<T>::EvalSpringForce(const Context<T>& context) const {
   const double k = spring_constant_N_per_m_;
   const T& x = get_position(context);

--- a/systems/plants/spring_mass_system/spring_mass_system.h
+++ b/systems/plants/spring_mass_system/spring_mass_system.h
@@ -82,9 +82,6 @@ class SpringMassSystem : public LeafSystem<T> {
   /// Returns the input port to the externally applied force.
   const InputPort<T>& get_force_port() const;
 
-  /// Returns the port to output state.
-  const OutputPort<T>& get_output_port() const;
-
   /// Returns the spring constant k that was provided at construction, in N/m.
   double get_spring_constant() const { return spring_constant_N_per_m_; }
 

--- a/systems/primitives/adder.h
+++ b/systems/primitives/adder.h
@@ -36,11 +36,6 @@ class Adder final : public LeafSystem<T> {
   template <typename U>
   explicit Adder(const Adder<U>&);
 
-  /// Returns the output port on which the sum is presented.
-  const OutputPort<T>& get_output_port() const {
-    return LeafSystem<T>::get_output_port(0);
-  }
-
  private:
   // Sums the input ports into a value suitable for the output port. If the
   // input ports are not the appropriate count or size, std::runtime_error will

--- a/systems/primitives/discrete_derivative.cc
+++ b/systems/primitives/discrete_derivative.cc
@@ -64,7 +64,8 @@ void DiscreteDerivative<T>::DoCalcDiscreteVariableUpdates(
     const std::vector<const drake::systems::DiscreteUpdateEvent<T>*>&,
     drake::systems::DiscreteValues<T>* state) const {
   // x₀[n+1] = u[n].
-  state->get_mutable_vector(0).SetFromVector(get_input_port().Eval(context));
+  state->get_mutable_vector(0).SetFromVector(
+      this->get_input_port().Eval(context));
 
   // x₁[n+1] = x₀[n].
   state->get_mutable_vector(1).SetFrom(context.get_discrete_state(0));

--- a/systems/primitives/discrete_derivative.h
+++ b/systems/primitives/discrete_derivative.h
@@ -98,14 +98,6 @@ class DiscreteDerivative final : public LeafSystem<T> {
     set_input_history(&context->get_mutable_state(), u, u);
   }
 
-  const systems::InputPort<T>& get_input_port() const {
-    return System<T>::get_input_port(0);
-  }
-
-  const systems::OutputPort<T>& get_output_port() const {
-    return System<T>::get_output_port(0);
-  }
-
   double time_step() const { return time_step_; }
 
   /// Returns the `suppress_initial_transient` passed to the constructor.
@@ -163,14 +155,6 @@ class StateInterpolatorWithDiscreteDerivative final : public Diagram<T> {
 
   /// Returns the `suppress_initial_transient` passed to the constructor.
   bool suppress_initial_transient() const;
-
-  const systems::InputPort<T>& get_input_port() const {
-    return System<T>::get_input_port(0);
-  }
-
-  const systems::OutputPort<T>& get_output_port() const {
-    return System<T>::get_output_port(0);
-  }
 
   /// Convenience method that sets the entire position history for the
   /// discrete-time derivative to a constant vector value (resulting in

--- a/systems/primitives/discrete_time_delay.cc
+++ b/systems/primitives/discrete_time_delay.cc
@@ -77,7 +77,7 @@ void DiscreteTimeDelay<T>::SaveInputVectorToBuffer(
   // value and adding the value on the input port to the end of the buffer.
   // TODO(mpetersen94): consider revising to avoid possibly expensive buffer
   // copy operation.
-  const auto& input = get_input_port().Eval(context);
+  const auto& input = this->get_input_port().Eval(context);
   Eigen::VectorBlock<VectorX<T>> updated_state_value =
       discrete_state->get_mutable_vector(0).get_mutable_value();
   Eigen::VectorBlock<const VectorX<T>> old_state_value =
@@ -102,7 +102,8 @@ template <typename T>
 void DiscreteTimeDelay<T>::SaveInputAbstractValueToBuffer(
     const Context<T>& context, State<T>* state) const {
   DRAKE_ASSERT(is_abstract());
-  const auto& input = get_input_port().template Eval<AbstractValue>(context);
+  const auto& input =
+      this->get_input_port().template Eval<AbstractValue>(context);
   int& oldest_index =
       state->template get_mutable_abstract_state<int>(delay_buffer_size_);
   AbstractValue& state_value =

--- a/systems/primitives/discrete_time_delay.h
+++ b/systems/primitives/discrete_time_delay.h
@@ -74,16 +74,6 @@ class DiscreteTimeDelay final : public LeafSystem<T> {
 
   ~DiscreteTimeDelay() final = default;
 
-  /// Returns the sole input port.
-  const InputPort<T>& get_input_port() const {
-    return LeafSystem<T>::get_input_port(0);
-  }
-
-  /// Returns the sole output port.
-  const OutputPort<T>& get_output_port() const {
-    return LeafSystem<T>::get_output_port(0);
-  }
-
   /// (Advanced) Manually samples the input port and updates the state of the
   /// block, sliding the delay buffer forward and placing the sampled input at
   /// the end. This emulates an update event and is mostly useful for testing.

--- a/systems/primitives/pass_through.cc
+++ b/systems/primitives/pass_through.cc
@@ -17,8 +17,8 @@ PassThrough<T>::PassThrough(
     DRAKE_DEMAND(vector_size != -1);
     BasicVector<T> model_value(vector_size);
     input_port_ = &this->DeclareVectorInputPort(model_value);
-    output_port_ = &this->DeclareVectorOutputPort(
-        model_value, &PassThrough::DoCalcVectorOutput);
+    this->DeclareVectorOutputPort(model_value,
+                                  &PassThrough::DoCalcVectorOutput);
   } else {
     DRAKE_DEMAND(vector_size == -1);
     // TODO(eric.cousineau): Remove value parameter from the constructor once
@@ -30,7 +30,7 @@ PassThrough<T>::PassThrough(
       return abstract_model_value_->Clone();
     };
     namespace sp = std::placeholders;
-    output_port_ = &this->DeclareAbstractOutputPort(
+    this->DeclareAbstractOutputPort(
         abstract_value_allocator,
         std::bind(&PassThrough::DoCalcAbstractOutput, this, sp::_1, sp::_2));
   }
@@ -48,7 +48,7 @@ void PassThrough<T>::DoCalcVectorOutput(
       const Context<T>& context,
       BasicVector<T>* output) const {
   DRAKE_ASSERT(!is_abstract());
-  const auto& input = get_input_port().Eval(context);
+  const auto& input = this->get_input_port().Eval(context);
   DRAKE_ASSERT(input.size() == output->size());
   output->get_mutable_value() = input;
 }

--- a/systems/primitives/pass_through.h
+++ b/systems/primitives/pass_through.h
@@ -57,18 +57,6 @@ class PassThrough final : public LeafSystem<T> {
     return *input_port_;
   }
 
-  // Don't use the indexed get_input_port when calling this system directly.
-  void get_input_port(int) = delete;
-
-  /// Returns the sole output port.
-  const OutputPort<T>& get_output_port() const {
-    DRAKE_ASSERT(output_port_ != nullptr);
-    return *output_port_;
-  }
-
-  // Don't use the indexed get_output_port when calling this system directly.
-  void get_output_port(int) = delete;
-
  private:
   // Allow different specializations to access each other's private data.
   template <typename U> friend class PassThrough;
@@ -91,10 +79,9 @@ class PassThrough final : public LeafSystem<T> {
 
   const std::unique_ptr<const AbstractValue> abstract_model_value_;
 
-  // We store our port pointers so that DoCalcVectorOutput's access to the
+  // We store our port pointer so that DoCalcVectorOutput's access to the
   // input_port_->Eval is inlined (without any port-count bounds checking).
   const InputPort<T>* input_port_{};
-  const OutputPort<T>* output_port_{};
 };
 
 }  // namespace systems

--- a/systems/primitives/port_switch.h
+++ b/systems/primitives/port_switch.h
@@ -79,10 +79,6 @@ class PortSwitch final : public LeafSystem<T> {
     return this->get_input_port(0);
   }
 
-  const OutputPort<T>& get_output_port() const {
-    return System<T>::get_output_port(0);
-  }
-
   /** Declares a new input port to the switch with port name `name`.  The
   type of this port is already defined by the type of the output port. This
   must be called before any Context is allocated. */

--- a/systems/primitives/saturation.cc
+++ b/systems/primitives/saturation.cc
@@ -26,10 +26,9 @@ Saturation<T>::Saturation(int input_size)
       this->DeclareInputPort(kVectorValued, input_size_).get_index();
   min_value_port_index_ =
       this->DeclareInputPort(kVectorValued, input_size_).get_index();
-  output_port_index_ =
-      this->DeclareVectorOutputPort(BasicVector<T>(input_size_),
-                                    &Saturation::CalcSaturatedOutput)
-          .get_index();
+  this->DeclareVectorOutputPort(BasicVector<T>(input_size_),
+                                &Saturation::CalcSaturatedOutput)
+      .get_index();
 }
 
 template <typename T>
@@ -49,10 +48,9 @@ Saturation<T>::Saturation(const VectorX<T>& min_value,
 
   input_port_index_ =
       this->DeclareInputPort(kVectorValued, input_size_).get_index();
-  output_port_index_ =
-      this->DeclareVectorOutputPort(BasicVector<T>(input_size_),
-                                    &Saturation::CalcSaturatedOutput)
-          .get_index();
+  this->DeclareVectorOutputPort(BasicVector<T>(input_size_),
+                                &Saturation::CalcSaturatedOutput)
+      .get_index();
 }
 
 template <typename T>

--- a/systems/primitives/saturation.h
+++ b/systems/primitives/saturation.h
@@ -62,12 +62,6 @@ class Saturation final : public LeafSystem<T> {
   /// @p u_min and @p u_max.
   Saturation(const VectorX<T>& min_value, const VectorX<T>& max_value);
 
-  // Don't use the indexed get_input_port when calling this system directly.
-  void get_input_port(int) = delete;
-
-  // Don't use the indexed get_output_port when calling this system directly.
-  void get_output_port(int) = delete;
-
   /// Returns the input port.
   const InputPort<T>& get_input_port() const {
     return System<T>::get_input_port(input_port_index_);
@@ -85,11 +79,6 @@ class Saturation final : public LeafSystem<T> {
     return System<T>::get_input_port(max_value_port_index_);
   }
 
-  /// Returns the output port.
-  const OutputPort<T>& get_output_port() const {
-    return System<T>::get_output_port(output_port_index_);
-  }
-
   /// Returns the size.
   int get_size() const { return input_size_; }
   // TODO(naveenoid) : Add a witness function for capturing events when
@@ -102,7 +91,6 @@ class Saturation final : public LeafSystem<T> {
   int input_port_index_{};
   int min_value_port_index_{};
   int max_value_port_index_{};
-  int output_port_index_{};
   const bool min_max_ports_enabled_{false};
   const int input_size_{};
   const VectorX<T> max_value_;

--- a/systems/primitives/signal_logger.cc
+++ b/systems/primitives/signal_logger.cc
@@ -83,13 +83,8 @@ void SignalLogger<T>::set_forced_publish_only() {
 
 template <typename T>
 EventStatus SignalLogger<T>::WriteToLog(const Context<T>& context) const {
-  log_.AddData(context.get_time(), get_input_port().Eval(context));
+  log_.AddData(context.get_time(), this->get_input_port().Eval(context));
   return EventStatus::Succeeded();
-}
-
-template <typename T>
-const InputPort<T>& SignalLogger<T>::get_input_port() const {
-  return System<T>::get_input_port(0);
 }
 
 }  // namespace systems

--- a/systems/primitives/signal_logger.h
+++ b/systems/primitives/signal_logger.h
@@ -108,10 +108,6 @@ class SignalLogger final : public LeafSystem<T> {
   /// Clears the logged data.
   void reset() { log_.reset(); }
 
-  /// Returns the only input port. The port's name is "data" so you can also
-  /// access this with GetInputPort("data").
-  const InputPort<T>& get_input_port() const;
-
  private:
   template <typename> friend class SignalLogger;
 

--- a/systems/primitives/symbolic_vector_system.cc
+++ b/systems/primitives/symbolic_vector_system.cc
@@ -34,7 +34,7 @@ Expression FirstOrderTaylorExpand(const Expression& f, const Substitution& a) {
 
 // Checks if @p v is in @p variables.
 bool Includes(const Ref<const VectorX<Variable>>& variables,
-              const Variable& v) {
+                     const Variable& v) {
   for (int i = 0; i < variables.size(); ++i) {
     if (variables[i].equal_to(v)) {
       return true;
@@ -198,7 +198,7 @@ void SymbolicVectorSystem<T>::PopulateFromContext(const Context<T>& context,
   // the Context (and not from input ports whose *unnecessary* evaluation can
   // lead to spurious algebraic loops).
   if (input_vars_.size() > 0 && needs_inputs) {
-    const auto& input = get_input_port().Eval(context);
+    const auto& input = this->get_input_port().Eval(context);
     for (int i = 0; i < input_vars_.size(); i++) {
       env[input_vars_[i]] = input[i];
     }

--- a/systems/primitives/symbolic_vector_system.h
+++ b/systems/primitives/symbolic_vector_system.h
@@ -131,18 +131,6 @@ class SymbolicVectorSystem final : public LeafSystem<T> {
 
   ~SymbolicVectorSystem() override = default;
 
-  /// Returns the sole input port.
-  const InputPort<T>& get_input_port() const {
-    DRAKE_DEMAND(this->num_input_ports() == 1);
-    return LeafSystem<T>::get_input_port(0);
-  }
-
-  /// Returns the sole output port.
-  const OutputPort<T>& get_output_port() const {
-    DRAKE_DEMAND(this->num_output_ports() == 1);
-    return LeafSystem<T>::get_output_port(0);
-  }
-
   /// @name Accessor methods.
   /// @{
   const std::optional<symbolic::Variable>& time_var() const {

--- a/systems/primitives/zero_order_hold.cc
+++ b/systems/primitives/zero_order_hold.cc
@@ -71,7 +71,7 @@ void ZeroOrderHold<T>::LatchInputVectorToState(
     const Context<T>& context,
     DiscreteValues<T>* discrete_state) const {
   DRAKE_ASSERT(!is_abstract());
-  const auto& input = get_input_port().Eval(context);
+  const auto& input = this->get_input_port().Eval(context);
   BasicVector<T>& state_value = discrete_state->get_mutable_vector(0);
   state_value.SetFromVector(input);
 }
@@ -89,7 +89,8 @@ void ZeroOrderHold<T>::LatchInputAbstractValueToState(
     const Context<T>& context,
     State<T>* state) const {
   DRAKE_ASSERT(is_abstract());
-  const auto& input = get_input_port().template Eval<AbstractValue>(context);
+  const auto& input =
+      this->get_input_port().template Eval<AbstractValue>(context);
   AbstractValue& state_value =
       state->get_mutable_abstract_state().get_mutable_value(0);
   state_value.SetFrom(input);

--- a/systems/primitives/zero_order_hold.h
+++ b/systems/primitives/zero_order_hold.h
@@ -71,16 +71,6 @@ class ZeroOrderHold final : public LeafSystem<T> {
 
   ~ZeroOrderHold() final = default;
 
-  /// Returns the sole input port.
-  const InputPort<T>& get_input_port() const {
-    return LeafSystem<T>::get_input_port(0);
-  }
-
-  /// Returns the sole output port.
-  const OutputPort<T>& get_output_port() const {
-    return LeafSystem<T>::get_output_port(0);
-  }
-
   /// Reports the period of this hold (in seconds).
   double period() const { return period_sec_; }
 


### PR DESCRIPTION
PR #13883 provides these methods by default in the System base class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13898)
<!-- Reviewable:end -->
