### PR TITLE
yaml: Change allow_yaml_with_no_cpp's default to false

### DIFF
--- a/common/yaml/yaml_read_archive.cc
+++ b/common/yaml/yaml_read_archive.cc
@@ -9,6 +9,22 @@
 
 namespace drake {
 namespace yaml {
+
+YamlReadArchive::YamlReadArchive(const YAML::Node& root)
+    : YamlReadArchive(root, Options{}) {}
+
+YamlReadArchive::YamlReadArchive(const YAML::Node& root, const Options& options)
+    : owned_root_(root),
+      root_(&owned_root_),
+      mapish_item_key_(nullptr),
+      mapish_item_value_(nullptr),
+      options_(options),
+      parent_(nullptr) {
+  // Reprocess the owned_root for merge keys only after all member fields are
+  // initialized; otherwise, the method might access invalid member data.
+  RewriteMergeKeys(const_cast<YAML::Node*>(&owned_root_));
+}
+
 namespace {
 
 // The source and destination are both of type Map.  Copy the key-value pairs

--- a/common/yaml/yaml_read_archive.h
+++ b/common/yaml/yaml_read_archive.h
@@ -94,26 +94,12 @@ class YamlReadArchive final {
 
   /// Creates an archive that reads from @p root.  See the %YamlReadArchive
   /// class overview for details.
-  ///
-  /// When the `options` are not provided by the caller, this currently sets
-  /// `allow_yaml_with_no_cpp = true` for backwards compatibility reasons.
-  /// This default will change in a future Drake release to be `false`,
-  /// instead.  Callers that wish to avoid disruption should set the options
-  /// explicitly.
-  explicit YamlReadArchive(const YAML::Node& root, const Options& options = {
-                             .allow_yaml_with_no_cpp = true,
-                             .allow_cpp_with_no_yaml = false,
-                             .retain_map_defaults = false})
-      : owned_root_(root),
-        root_(&owned_root_),
-        mapish_item_key_(nullptr),
-        mapish_item_value_(nullptr),
-        options_(options),
-        parent_(nullptr) {
-    // Reprocess the owned_root for merge keys only after all member fields are
-    // initialized; otherwise, the method might access invalid member data.
-    RewriteMergeKeys(const_cast<YAML::Node*>(&owned_root_));
-  }
+  explicit YamlReadArchive(const YAML::Node& root);
+
+  /// Creates an archive that reads from @p root, with @p options that allow
+  /// for less restrictive parsing.  See the %YamlReadArchive class overview
+  /// for details.
+  YamlReadArchive(const YAML::Node& root, const Options& options);
 
   /// Sets the contents `serializable` based on the YAML file associated with
   /// this archive.  See the %YamlReadArchive class overview for details.


### PR DESCRIPTION
It's now an error for yaml data to remain unparsed, unless the user opts-in to allowing it.

The syntax to opt-in was added in Drake v0.19.0 released on 2020-06-15.  Now that v0.22.0 release 2020-08-17 is available, it seems safe enough to flip the default on master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13900)
<!-- Reviewable:end -->
