### PR TITLE
Add a build rule and a final newline for identify_compiler

### DIFF
--- a/tools/workspace/cc/BUILD.bazel
+++ b/tools/workspace/cc/BUILD.bazel
@@ -1,8 +1,16 @@
 # -*- python -*-
 
-# This file exists to make our directory into a Bazel package, so that our
-# neighboring *.bzl file can be loaded elsewhere.
-
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_binary",
+)
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
-add_lint_tests(cpplint_extra_srcs = ["identify_compiler.cc"])
+# Note that this program is compiled not only by this drake_cc_binary rule
+# but also separately by the repository.bzl file in this directory.
+drake_cc_binary(
+    name = "identify_compiler",
+    srcs = ["identify_compiler.cc"],
+)
+
+add_lint_tests()

--- a/tools/workspace/cc/identify_compiler.cc
+++ b/tools/workspace/cc/identify_compiler.cc
@@ -200,7 +200,7 @@ int main() {
   return 1;
 #endif
 
-  printf("%s %i %i", compiler_id, compiler_version_major,
+  printf("%s %i %i\n", compiler_id, compiler_version_major,
       compiler_version_minor);
   return 0;
 }


### PR DESCRIPTION
Add a build rule so identify_compiler gets built the same way as the rest of Drake. It was also missing a final newline.

See #13902.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13906)
<!-- Reviewable:end -->
