### PR TITLE
framework: Mark subvector and supervector final

### DIFF
--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -77,11 +77,9 @@ drake_cc_library(
         "vector_base.h",
     ],
     deps = [
-        "//common:autodiff",
         "//common:default_scalars",
         "//common:dummy_value",
         "//common:essential",
-        "//common:symbolic",
     ],
 )
 

--- a/systems/framework/continuous_state.cc
+++ b/systems/framework/continuous_state.cc
@@ -5,6 +5,7 @@
 #include <unordered_set>
 #include <utility>
 
+#include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/subvector.h"
 
 namespace drake {
@@ -13,8 +14,8 @@ namespace systems {
 template <typename T>
 ContinuousState<T>::ContinuousState(std::unique_ptr<VectorBase<T>> state) {
   state_ = std::move(state);
-  generalized_position_.reset(new Subvector<T>(state_.get()));
-  generalized_velocity_.reset(new Subvector<T>(state_.get()));
+  generalized_position_.reset(new BasicVector<T>());
+  generalized_velocity_.reset(new BasicVector<T>());
   misc_continuous_state_.reset(
       new Subvector<T>(state_.get(), 0, state_->size()));
   DRAKE_ASSERT_VOID(DemandInvariants());

--- a/systems/framework/continuous_state.h
+++ b/systems/framework/continuous_state.h
@@ -6,7 +6,6 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_throw.h"
-#include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/framework_common.h"
 #include "drake/systems/framework/scalar_conversion_traits.h"
 #include "drake/systems/framework/vector_base.h"

--- a/systems/framework/subvector.h
+++ b/systems/framework/subvector.h
@@ -7,6 +7,7 @@
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/drake_throw.h"
 #include "drake/systems/framework/vector_base.h"
 
@@ -18,7 +19,7 @@ namespace systems {
 ///
 /// @tparam_default_scalar
 template <typename T>
-class Subvector : public VectorBase<T> {
+class Subvector final : public VectorBase<T> {
  public:
   // Subvector objects are neither copyable nor moveable.
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Subvector)
@@ -42,7 +43,10 @@ class Subvector : public VectorBase<T> {
   /// Constructs an empty subvector.
   /// @param vector The vector to slice.  Must not be nullptr. Must remain
   ///               valid for the lifetime of this object.
-  explicit Subvector(VectorBase<T>* vector) : Subvector(vector, 0, 0) {}
+  DRAKE_DEPRECATED("2020-12-01",
+      "Use BasicVector's default constructor, instead.")
+  explicit Subvector(VectorBase<T>* vector)
+      : Subvector(vector, 0, 0) {}
 
   int size() const override { return num_elements_; }
 

--- a/systems/framework/supervector.h
+++ b/systems/framework/supervector.h
@@ -21,7 +21,7 @@ namespace systems {
 ///
 /// @tparam_default_scalar
 template <typename T>
-class Supervector : public VectorBase<T> {
+class Supervector final : public VectorBase<T> {
  public:
   // Supervector objects are neither copyable nor moveable.
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Supervector)

--- a/systems/framework/test/subvector_test.cc
+++ b/systems/framework/test/subvector_test.cc
@@ -23,11 +23,14 @@ class SubvectorTest : public ::testing::Test {
 };
 
 TEST_F(SubvectorTest, NullptrVector) {
-  EXPECT_THROW(Subvector<double> subvec(nullptr), std::logic_error);
+  EXPECT_THROW(Subvector<double> subvec(nullptr, 0, 0), std::logic_error);
 }
 
-TEST_F(SubvectorTest, EmptySubvector) {
+TEST_F(SubvectorTest, EmptySubvectorDeprecated) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   Subvector<double> subvec(vector_.get());
+#pragma GCC diagnostic pop
   EXPECT_EQ(0, subvec.size());
   EXPECT_THROW(subvec.GetAtIndex(0), std::runtime_error);
 }

--- a/systems/framework/vector_base.h
+++ b/systems/framework/vector_base.h
@@ -10,7 +10,6 @@
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_deprecated.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 


### PR DESCRIPTION
This will make the h/cc split clearer in the future, as well as allow us to improve the implementations and inheritance tree of the VectorBase family.

This is a breaking change, in the unlikely event that anyone was inheriting from these classes.

Also deprecate a worthless constructor of Subvector.