### PR TITLE
cassie_bench: Force static linking

### DIFF
--- a/examples/multibody/cassie_benchmark/BUILD.bazel
+++ b/examples/multibody/cassie_benchmark/BUILD.bazel
@@ -14,6 +14,7 @@ drake_cc_test(
     name = "cassie_bench",
     srcs = ["test/cassie_bench.cc"],
     data = ["cassie_v2.urdf"],
+    linkstatic = True,
     deps = [
         "//common:essential",
         "//common:find_resource",


### PR DESCRIPTION
Closes #13910.

This makes the benchmark program more structurally similar to most Drake
executables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13913)
<!-- Reviewable:end -->
