### PR TITLE
cassie bench: Fix blunder in benchmark configuration

### DIFF
--- a/examples/multibody/cassie_benchmark/record_results.sh
+++ b/examples/multibody/cassie_benchmark/record_results.sh
@@ -25,7 +25,7 @@ ${TEST_SRCDIR}/drake/tools/workspace/cc/identify_compiler \
  > ${TEST_UNDECLARED_OUTPUTS_DIR}/compiler.txt
 
 ${TEST_SRCDIR}/drake/examples/multibody/cassie_benchmark/cassie_bench \
-    --benchmark_report_aggregates_only=true \
+    --benchmark_display_aggregates_only=true \
     --benchmark_repetitions=9 \
     --benchmark_out_format=json \
     --benchmark_out=${TEST_UNDECLARED_OUTPUTS_DIR}/results.json \


### PR DESCRIPTION
Prior options were stripping raw data out of the json file, which is
worth keeping for statistical comparisons.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13914)
<!-- Reviewable:end -->
