### PR TITLE
Allow yaml write to dump the node without a keyname

### DIFF
--- a/common/yaml/test/yaml_write_archive_defaults_test.cc
+++ b/common/yaml/test/yaml_write_archive_defaults_test.cc
@@ -20,14 +20,14 @@ class YamlWriteArchiveDefaultsTest : public ::testing::Test {
  public:
   template <typename DataSerializable, typename DefaultsSerializable>
   static std::string SaveDataWithoutDefaults(
-        const DataSerializable& data,
-        const DefaultsSerializable& defaults) {
+      const DataSerializable& data, const DefaultsSerializable& defaults,
+      const std::string& key_name = "doc") {
     YamlWriteArchive defaults_archive;
     defaults_archive.Accept(defaults);
     YamlWriteArchive archive;
     archive.Accept(data);
     archive.EraseMatchingMaps(defaults_archive);
-    return archive.EmitString("doc");
+    return archive.EmitString(key_name);
   }
 };
 
@@ -59,6 +59,30 @@ TEST_F(YamlWriteArchiveDefaultsTest, BasicExample2) {
   EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"""(doc:
   inner_struct:
     inner_value: 3.0
+)""");
+}
+
+// Shows the typical use -- emit the content with or without providing a
+// root_name.
+TEST_F(YamlWriteArchiveDefaultsTest, BasicExample3) {
+  OuterStruct defaults;
+  defaults.outer_value = 1.0;
+
+  OuterStruct data;
+  data.outer_value = 3.0;
+  data.inner_struct.inner_value = defaults.inner_struct.inner_value;
+
+  // Emit using the default "doc" root name.
+  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"""(doc:
+  outer_value: 3.0
+)""");
+
+  // Emit using an empty root name.
+  EXPECT_EQ(SaveDataWithoutDefaults(data, defaults, ""), R"""(outer_value: 3.0
+)""");
+
+  // Emit with an empty root name without defaults.
+  EXPECT_EQ(SaveDataWithoutDefaults(defaults, defaults, ""), R"""({}
 )""");
 }
 

--- a/common/yaml/yaml_write_archive.cc
+++ b/common/yaml/yaml_write_archive.cc
@@ -103,11 +103,19 @@ std::string YamlWriteArchive::YamlDumpWithSortedMaps(
 std::string YamlWriteArchive::EmitString(const std::string& root_name) const {
   std::string result;
   if (root_.IsNull()) {
-    result = root_name + ":\n";
+    if (root_name.empty()) {
+      result = "{}\n";
+    } else {
+      result = root_name + ":\n";
+    }
   } else {
-    YAML::Node document;
-    document[root_name] = root_;
-    result = YamlDumpWithSortedMaps(document) + "\n";
+    if (root_name.empty()) {
+      result = YamlDumpWithSortedMaps(root_) + "\n";
+    } else {
+      YAML::Node document;
+      document[root_name] = root_;
+      result = YamlDumpWithSortedMaps(document) + "\n";
+    }
   }
   return result;
 }

--- a/common/yaml/yaml_write_archive.h
+++ b/common/yaml/yaml_write_archive.h
@@ -93,9 +93,18 @@ class YamlWriteArchive final {
   }
 
   /// Returns the YAML string for whatever Serializable was most recently
-  /// passed into Accept.  The returned document will be a single Map node
-  /// named using `root_name` with the Serializable's visited fields as
-  /// key-value entries within it.
+  /// passed into Accept.
+  ///
+  /// If the `root_name` is empty, the returned document will be the
+  /// Serializable's visited content (which itself is already a Map node)
+  /// directly. If the visited serializable content is null (in cases
+  /// `Accpet()` has not been called or the entries are erased after calling
+  /// `EraseMatchingMaps()`), then an empty map `{}` will be emitted.
+  ///
+  /// If the `root_name` is not empty, the returned document will be a
+  /// single Map node named using `root_name` with the Serializable's visited
+  /// content as key-value entries within it. The visited content could be
+  /// null and the nullness is defined as above.
   std::string EmitString(const std::string& root_name = "root") const;
 
   /// (Advanced.)  Remove from this archive any map entries that are identical


### PR DESCRIPTION
This PR allows the Emitter to dump the internal root node directly. This is useful if the user only wants to dump an accepted schema as it is rather than assigning it to a key name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13915)
<!-- Reviewable:end -->
