### PR TITLE
Better schunk models in manipulation station

### DIFF
--- a/bindings/pydrake/examples/manipulation_station_py.cc
+++ b/bindings/pydrake/examples/manipulation_station_py.cc
@@ -36,6 +36,15 @@ PYBIND11_MODULE(manipulation_station, m) {
           doc.IiwaCollisionModel.kBoxCollision.doc)
       .export_values();
 
+  py::enum_<SchunkCollisionModel>(
+      m, "SchunkCollisionModel", doc.SchunkCollisionModel.doc)
+      .value(
+          "kBox", SchunkCollisionModel::kBox, doc.SchunkCollisionModel.kBox.doc)
+      .value("kBoxPlusFingertipSpheres",
+          SchunkCollisionModel::kBoxPlusFingertipSpheres,
+          doc.SchunkCollisionModel.kBoxPlusFingertipSpheres.doc)
+      .export_values();
+
   py::class_<ManipulationStation<T>, Diagram<T>>(
       m, "ManipulationStation", doc.ManipulationStation.doc)
       .def(py::init<double>(), py::arg("time_step") = 0.002,
@@ -43,14 +52,17 @@ PYBIND11_MODULE(manipulation_station, m) {
       .def("SetupManipulationClassStation",
           &ManipulationStation<T>::SetupManipulationClassStation,
           py::arg("collision_model") = IiwaCollisionModel::kNoCollision,
+          py::arg("schunk_model") = SchunkCollisionModel::kBox,
           doc.ManipulationStation.SetupManipulationClassStation.doc)
       .def("SetupClutterClearingStation",
           &ManipulationStation<T>::SetupClutterClearingStation,
           py::arg("X_WCameraBody") = std::nullopt,
           py::arg("collision_model") = IiwaCollisionModel::kNoCollision,
+          py::arg("schunk_model") = SchunkCollisionModel::kBox,
           doc.ManipulationStation.SetupClutterClearingStation.doc)
       .def("SetupPlanarIiwaStation",
           &ManipulationStation<T>::SetupPlanarIiwaStation,
+          py::arg("schunk_model") = SchunkCollisionModel::kBox,
           doc.ManipulationStation.SetupPlanarIiwaStation.doc)
       .def("AddManipulandFromFile",
           &ManipulationStation<T>::AddManipulandFromFile, py::arg("model_file"),

--- a/examples/manipulation_station/end_effector_teleop_dualshock4.py
+++ b/examples/manipulation_station/end_effector_teleop_dualshock4.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from pydrake.examples.manipulation_station import (
     ManipulationStation, ManipulationStationHardwareInterface,
-    CreateClutterClearingYcbObjectList)
+    CreateClutterClearingYcbObjectList, SchunkCollisionModel)
 from pydrake.geometry import ConnectDrakeVisualizer
 from pydrake.multibody.plant import MultibodyPlant
 from pydrake.manipulation.planner import (
@@ -276,6 +276,10 @@ def main():
         '--setup', type=str, default='manipulation_class',
         help="The manipulation station setup to simulate. ",
         choices=['manipulation_class', 'clutter_clearing'])
+    parser.add_argument(
+        '--schunk_collision_model', type=str, default='box',
+        help="The Schunk collision model to use for simulation. ",
+        choices=['box', 'box_plus_fingertip_spheres'])
     MeshcatVisualizer.add_argparse_argument(parser)
     args = parser.parse_args()
 
@@ -292,15 +296,22 @@ def main():
     else:
         station = builder.AddSystem(ManipulationStation())
 
-        # Initializes the chosen station type.
+        if args.schunk_collision_model == "box":
+            schunk_model = SchunkCollisionModel.kBox
+        elif args.schunk_collision_model == "box_plus_fingertip_spheres":
+            schunk_model = SchunkCollisionModel.kBoxPlusFingertipSpheres
+
+    # Initializes the chosen station type.
         if args.setup == 'manipulation_class':
-            station.SetupManipulationClassStation()
+            station.SetupManipulationClassStation(
+                schunk_model=schunk_model)
             station.AddManipulandFromFile(
                 ("drake/examples/manipulation_station/models/"
                  "061_foam_brick.sdf"),
                 RigidTransform(RotationMatrix.Identity(), [0.6, 0, 0]))
         elif args.setup == 'clutter_clearing':
-            station.SetupClutterClearingStation()
+            station.SetupClutterClearingStation(
+                schunk_model=schunk_model)
             ycb_objects = CreateClutterClearingYcbObjectList()
             for model_file, X_WObject in ycb_objects:
                 station.AddManipulandFromFile(model_file, X_WObject)

--- a/examples/manipulation_station/end_effector_teleop_mouse.py
+++ b/examples/manipulation_station/end_effector_teleop_mouse.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from pydrake.examples.manipulation_station import (
     ManipulationStation, ManipulationStationHardwareInterface,
-    CreateClutterClearingYcbObjectList)
+    CreateClutterClearingYcbObjectList, SchunkCollisionModel)
 from pydrake.geometry import ConnectDrakeVisualizer
 from pydrake.multibody.plant import MultibodyPlant
 from pydrake.manipulation.planner import (
@@ -272,6 +272,11 @@ def main():
         '--setup', type=str, default='manipulation_class',
         help="The manipulation station setup to simulate. ",
         choices=['manipulation_class', 'clutter_clearing'])
+    parser.add_argument(
+        '--schunk_collision_model', type=str, default='box',
+        help="The Schunk collision model to use for simulation. ",
+        choices=['box', 'box_plus_fingertip_spheres'])
+
     MeshcatVisualizer.add_argparse_argument(parser)
     args = parser.parse_args()
 
@@ -291,15 +296,23 @@ def main():
     else:
         station = builder.AddSystem(ManipulationStation())
 
+        if args.schunk_collision_model == "box":
+            schunk_model = SchunkCollisionModel.kBox
+        elif args.schunk_collision_model == "box_plus_fingertip_spheres":
+            schunk_model = SchunkCollisionModel.kBoxPlusFingertipSpheres
+
         # Initializes the chosen station type.
         if args.setup == 'manipulation_class':
-            station.SetupManipulationClassStation()
+            station.SetupManipulationClassStation(
+                schunk_model=schunk_model)
             station.AddManipulandFromFile(
                 ("drake/examples/manipulation_station/models/"
                  "061_foam_brick.sdf"),
                 RigidTransform(RotationMatrix.Identity(), [0.6, 0, 0]))
         elif args.setup == 'clutter_clearing':
-            station.SetupClutterClearingStation()
+            station.SetupClutterClearingStation(
+                schunk_model=schunk_model)
+
             ycb_objects = CreateClutterClearingYcbObjectList()
             for model_file, X_WObject in ycb_objects:
                 station.AddManipulandFromFile(model_file, X_WObject)

--- a/examples/manipulation_station/manipulation_station.cc
+++ b/examples/manipulation_station/manipulation_station.cc
@@ -191,7 +191,7 @@ void ManipulationStation<T>::AddManipulandFromFile(
 template <typename T>
 void ManipulationStation<T>::SetupClutterClearingStation(
     const std::optional<const math::RigidTransform<double>>& X_WCameraBody,
-    IiwaCollisionModel collision_model) {
+    IiwaCollisionModel collision_model, SchunkCollisionModel schunk_model) {
   DRAKE_DEMAND(setup_ == Setup::kNone);
   setup_ = Setup::kClutterClearing;
 
@@ -237,12 +237,13 @@ void ManipulationStation<T>::SetupClutterClearingStation(
   }
 
   AddDefaultIiwa(collision_model);
-  AddDefaultWsg();
+  AddDefaultWsg(schunk_model);
 }
 
 template <typename T>
 void ManipulationStation<T>::SetupManipulationClassStation(
-    IiwaCollisionModel collision_model) {
+  IiwaCollisionModel collision_model,
+  SchunkCollisionModel schunk_model) {
   DRAKE_DEMAND(setup_ == Setup::kNone);
   setup_ = Setup::kManipulationClass;
 
@@ -282,7 +283,7 @@ void ManipulationStation<T>::SetupManipulationClassStation(
 
   // Add the default iiwa/wsg models.
   AddDefaultIiwa(collision_model);
-  AddDefaultWsg();
+  AddDefaultWsg(schunk_model);
 
   // Add default cameras.
   {
@@ -311,7 +312,8 @@ void ManipulationStation<T>::SetupManipulationClassStation(
 }
 
 template <typename T>
-void ManipulationStation<T>::SetupPlanarIiwaStation() {
+void ManipulationStation<T>::SetupPlanarIiwaStation(
+  SchunkCollisionModel schunk_model) {
   DRAKE_DEMAND(setup_ == Setup::kNone);
   setup_ = Setup::kPlanarIiwa;
 
@@ -344,7 +346,7 @@ void ManipulationStation<T>::SetupPlanarIiwaStation() {
   }
 
   // Add the default wsg model.
-  AddDefaultWsg();
+  AddDefaultWsg(schunk_model);
 }
 
 template <typename T>
@@ -914,8 +916,6 @@ void ManipulationStation<T>::AddDefaultIiwa(
           "drake/manipulation/models/iiwa_description/iiwa7/"
           "iiwa7_with_box_collision.sdf");
       break;
-    default:
-      throw std::domain_error("Unrecognized collision_model.");
   }
   const auto X_WI = RigidTransform<double>::Identity();
   auto iiwa_instance = internal::AddAndWeldModelFrom(
@@ -927,9 +927,21 @@ void ManipulationStation<T>::AddDefaultIiwa(
 
 // Add default wsg.
 template <typename T>
-void ManipulationStation<T>::AddDefaultWsg() {
-  const std::string sdf_path = FindResourceOrThrow(
-      "drake/manipulation/models/wsg_50_description/sdf/schunk_wsg_50.sdf");
+void ManipulationStation<T>::AddDefaultWsg(
+    const SchunkCollisionModel schunk_model) {
+  std::string sdf_path;
+  switch (schunk_model) {
+    case SchunkCollisionModel::kBox:
+      sdf_path = FindResourceOrThrow(
+          "drake/manipulation/models/wsg_50_description/sdf"
+          "/schunk_wsg_50_no_tip.sdf");
+      break;
+    case SchunkCollisionModel::kBoxPlusFingertipSpheres:
+      sdf_path = FindResourceOrThrow(
+          "drake/manipulation/models/wsg_50_description/sdf"
+          "/schunk_wsg_50_with_tip.sdf");
+      break;
+  }
   const multibody::Frame<T>& link7 =
       plant_->GetFrameByName("iiwa_link_7", iiwa_model_.model_instance);
   const RigidTransform<double> X_7G(RollPitchYaw<double>(M_PI_2, 0, M_PI_2),

--- a/examples/manipulation_station/manipulation_station.h
+++ b/examples/manipulation_station/manipulation_station.h
@@ -21,6 +21,14 @@ namespace manipulation_station {
 /// Determines which sdf is loaded for the IIWA in the ManipulationStation.
 enum class IiwaCollisionModel { kNoCollision, kBoxCollision };
 
+/// Determines which schunk model is used for the ManipulationStation.
+/// - kBox loads a model with a box collision geometry. This model is for those
+///   who want simplified collision behavior.
+/// - kBoxPlusFingertipSpheres loads a Schunk model with collision
+///   spheres that models the indentations at tip of the fingers, in addition
+///   to the box collision geometry on the fingers.
+enum class SchunkCollisionModel { kBox, kBoxPlusFingertipSpheres };
+
 /// Determines which manipulation station is simulated.
 enum class Setup { kNone, kManipulationClass, kClutterClearing, kPlanarIiwa };
 
@@ -145,9 +153,11 @@ class ManipulationStation : public systems::Diagram<T> {
   /// @note Only one of the `Setup___()` methods should be called.
   /// @param X_WCameraBody Transformation between the world and the camera body.
   /// @param collision_model Determines which sdf is loaded for the IIWA.
+  /// @param schunk_model Determines which sdf is loaded for the Schunk.
   void SetupClutterClearingStation(
       const std::optional<const math::RigidTransformd>& X_WCameraBody = {},
-      IiwaCollisionModel collision_model = IiwaCollisionModel::kNoCollision);
+      IiwaCollisionModel collision_model = IiwaCollisionModel::kNoCollision,
+      SchunkCollisionModel schunk_model = SchunkCollisionModel::kBox);
 
   /// Adds a default iiwa, wsg, cupboard, and 80/20 frame for the MIT
   /// Intelligent Robot Manipulation class, then calls
@@ -156,8 +166,10 @@ class ManipulationStation : public systems::Diagram<T> {
   /// @note Must be called before Finalize().
   /// @note Only one of the `Setup___()` methods should be called.
   /// @param collision_model Determines which sdf is loaded for the IIWA.
+  /// @param schunk_model Determines which sdf is loaded for the Schunk.
   void SetupManipulationClassStation(
-      IiwaCollisionModel collision_model = IiwaCollisionModel::kNoCollision);
+      IiwaCollisionModel collision_model = IiwaCollisionModel::kNoCollision,
+      SchunkCollisionModel schunk_model = SchunkCollisionModel::kBox);
 
   /// Adds a version of the iiwa with joints that would result in
   /// out-of-plane rotations welded in a fixed orientation, reducing the
@@ -167,7 +179,9 @@ class ManipulationStation : public systems::Diagram<T> {
   /// manipulands) will still potentially move in 3D.
   /// @note Must be called before Finalize().
   /// @note Only one of the `Setup___()` methods should be called.
-  void SetupPlanarIiwaStation();
+  /// @param schunk_model Determines which sdf is loaded for the Schunk.
+  void SetupPlanarIiwaStation(
+      SchunkCollisionModel schunk_model = SchunkCollisionModel::kBox);
 
   /// Sets the default State for the chosen setup.
   /// @param context A const reference to the ManipulationStation context.
@@ -460,7 +474,7 @@ class ManipulationStation : public systems::Diagram<T> {
   void MakeIiwaControllerModel();
 
   void AddDefaultIiwa(const IiwaCollisionModel collision_model);
-  void AddDefaultWsg();
+  void AddDefaultWsg(const SchunkCollisionModel schunk_model);
 
   // These are only valid until Finalize() is called.
   std::unique_ptr<multibody::MultibodyPlant<T>> owned_plant_;

--- a/manipulation/models/wsg_50_description/BUILD.bazel
+++ b/manipulation/models/wsg_50_description/BUILD.bazel
@@ -1,14 +1,28 @@
 # -*- python -*-
-
 load(
     "@drake//tools/skylark:drake_cc.bzl",
     "drake_cc_googletest",
 )
 load("//tools/install:install_data.bzl", "install_data")
 load("//tools/lint:lint.bzl", "add_lint_tests")
+load("@drake//tools/workspace:forward_files.bzl", "forward_files")
+load("//tools/workspace/models:files.bzl", "wsg_50_description_mesh_files")
 
 package(
     default_visibility = [":__subpackages__"],
+)
+
+_WSG_50_DESCRIPTION_MESHES = forward_files(
+    srcs = ["@models//:" + x for x in wsg_50_description_mesh_files()],
+    dest_prefix = "",
+    strip_prefix = "@models//:wsg_50_description/",
+    visibility = ["//visibility:private"],
+)
+
+install_data(
+    extra_prod_models = _WSG_50_DESCRIPTION_MESHES + [
+        "LICENSE.TXT",
+    ],
 )
 
 # === test/ ===
@@ -24,9 +38,14 @@ drake_cc_googletest(
     ],
 )
 
-install_data(
-    extra_prod_models = [
-        "LICENSE.TXT",
+drake_cc_googletest(
+    name = "wsg_50_sdf_test",
+    srcs = ["sdf/test/wsg_50_sdf_test.cc"],
+    data = [":models"],
+    deps = [
+        "//common:find_resource",
+        "//multibody/parsing",
+        "//multibody/plant",
     ],
 )
 

--- a/manipulation/models/wsg_50_description/README.md
+++ b/manipulation/models/wsg_50_description/README.md
@@ -1,5 +1,7 @@
 **WARNING** All of the *.urdf models and *.obj meshes in this package are
-deprecated and will be removed on 2020-11-01.
+deprecated and will be removed on 2020-11-01. The *.sdf files will not be
+deprecated, and the *.obj associated with the *.sdf files will be stored in
+the [models repo](https://github.com/RobotLocomotion/models/).
 
 Execute the following commands to regenerate the URDF files using `xacro`. Note
 that ROS Jade or newer must be used because the `xacro` scripts make use of more

--- a/manipulation/models/wsg_50_description/sdf/schunk_wsg_50_no_tip.sdf
+++ b/manipulation/models/wsg_50_description/sdf/schunk_wsg_50_no_tip.sdf
@@ -1,0 +1,322 @@
+<!-- This sdf file is based on schunk_wsg_50.sdf -->
+<?xml version="1.0"?>
+<sdf version="1.7">
+  <model name="Schunk_Gripper">
+    <link name="body">
+      <pose>0 -0.049133 0 0 0 0</pose>
+      <inertial>
+        <mass>0.988882</mass>
+        <inertia>
+          <ixx>0.162992</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.162992</iyy>
+          <iyz>0</iyz>
+          <izz>0.164814</izz>
+        </inertia>
+      </inertial>
+      <self_collide>0</self_collide>
+      <kinematic>0</kinematic>
+      <visual name="visual">
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>../meshes/wsg_body.obj</uri>
+          </mesh>
+        </geometry>
+        <material>
+          <diffuse>0.7 0.7 0.7 1</diffuse>
+        </material>
+      </visual>
+      <collision name="collision">
+        <laser_retro>0</laser_retro>
+        <max_contacts>10</max_contacts>
+        <geometry>
+          <box>
+            <size>0.146 0.0725 0.05</size>
+          </box>
+        </geometry>
+        <surface>
+          <friction>
+            <ode>
+              <mu>1</mu>
+              <mu2>1</mu2>
+              <fdir1>0 0 0</fdir1>
+              <slip1>0</slip1>
+              <slip2>0</slip2>
+            </ode>
+            <torsional>
+              <coefficient>1</coefficient>
+              <patch_radius>0</patch_radius>
+              <surface_radius>0</surface_radius>
+              <use_patch_radius>1</use_patch_radius>
+              <ode>
+                <slip>0</slip>
+              </ode>
+            </torsional>
+          </friction>
+          <bounce>
+            <restitution_coefficient>0</restitution_coefficient>
+            <threshold>1e+06</threshold>
+          </bounce>
+          <contact>
+            <collide_without_contact>0</collide_without_contact>
+            <collide_without_contact_bitmask>1</collide_without_contact_bitmask>
+            <collide_bitmask>1</collide_bitmask>
+            <ode>
+              <soft_cfm>0</soft_cfm>
+              <soft_erp>0.2</soft_erp>
+              <kp>1e+13</kp>
+              <kd>1</kd>
+              <max_vel>0.01</max_vel>
+              <min_depth>0</min_depth>
+            </ode>
+            <bullet>
+              <split_impulse>1</split_impulse>
+              <split_impulse_penetration_threshold>-0.01</split_impulse_penetration_threshold>
+              <soft_cfm>0</soft_cfm>
+              <soft_erp>0.2</soft_erp>
+              <kp>1e+13</kp>
+              <kd>1</kd>
+            </bullet>
+          </contact>
+        </surface>
+      </collision>
+    </link>
+    <frame name="body_frame">
+      <pose relative_to="body"/>
+    </frame>
+    <link name="left_finger">
+      <pose>-0.006 0.028 0 0 3.141592 0</pose>
+      <inertial>
+        <mass>0.05</mass>
+        <inertia>
+          <ixx>0.16</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.16</iyy>
+          <iyz>0</iyz>
+          <izz>0.16</izz>
+        </inertia>
+      </inertial>
+      <self_collide>0</self_collide>
+      <kinematic>0</kinematic>
+      <visual name="visual">
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>../meshes/finger_without_tip.obj</uri>
+          </mesh>
+        </geometry>
+        <material>
+          <diffuse>0.2 0.2 0.2 1</diffuse>
+        </material>
+      </visual>
+      <collision name="collision">
+        <laser_retro>0</laser_retro>
+        <max_contacts>10</max_contacts>
+        <geometry>
+          <box>
+            <size>0.012 0.082 0.02</size>
+          </box>
+        </geometry>
+        <surface>
+          <friction>
+            <ode>
+              <mu>1</mu>
+              <mu2>1</mu2>
+              <fdir1>0 0 0</fdir1>
+              <slip1>0</slip1>
+              <slip2>0</slip2>
+            </ode>
+            <torsional>
+              <coefficient>1</coefficient>
+              <patch_radius>0</patch_radius>
+              <surface_radius>0</surface_radius>
+              <use_patch_radius>1</use_patch_radius>
+              <ode>
+                <slip>0</slip>
+              </ode>
+            </torsional>
+          </friction>
+          <bounce>
+            <restitution_coefficient>0</restitution_coefficient>
+            <threshold>1e+06</threshold>
+          </bounce>
+          <contact>
+            <collide_without_contact>0</collide_without_contact>
+            <collide_without_contact_bitmask>1</collide_without_contact_bitmask>
+            <collide_bitmask>1</collide_bitmask>
+            <ode>
+              <soft_cfm>0</soft_cfm>
+              <soft_erp>0.2</soft_erp>
+              <kp>1e+13</kp>
+              <kd>1</kd>
+              <max_vel>0.01</max_vel>
+              <min_depth>0</min_depth>
+            </ode>
+            <bullet>
+              <split_impulse>1</split_impulse>
+              <split_impulse_penetration_threshold>-0.01</split_impulse_penetration_threshold>
+              <soft_cfm>0</soft_cfm>
+              <soft_erp>0.2</soft_erp>
+              <kp>1e+13</kp>
+              <kd>1</kd>
+            </bullet>
+          </contact>
+        </surface>
+      </collision>
+    </link>
+    <link name="right_finger">
+      <pose>0.006 0.028 0 0 0 0</pose>
+      <inertial>
+        <mass>0.05</mass>
+        <inertia>
+          <ixx>0.16</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.16</iyy>
+          <iyz>0</iyz>
+          <izz>0.16</izz>
+        </inertia>
+      </inertial>
+      <self_collide>0</self_collide>
+      <kinematic>0</kinematic>
+      <visual name="visual">
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>../meshes/finger_without_tip.obj</uri>
+          </mesh>
+        </geometry>
+        <material>
+          <diffuse>0.2 0.2 0.2 1</diffuse>
+        </material>
+      </visual>
+      <collision name="collision">
+        <laser_retro>0</laser_retro>
+        <max_contacts>10</max_contacts>
+        <geometry>
+          <box>
+            <size>0.012 0.082 0.02</size>
+          </box>
+        </geometry>
+        <surface>
+          <friction>
+            <ode>
+              <mu>1</mu>
+              <mu2>1</mu2>
+              <fdir1>0 0 0</fdir1>
+              <slip1>0</slip1>
+              <slip2>0</slip2>
+            </ode>
+            <torsional>
+              <coefficient>1</coefficient>
+              <patch_radius>0</patch_radius>
+              <surface_radius>0</surface_radius>
+              <use_patch_radius>1</use_patch_radius>
+              <ode>
+                <slip>0</slip>
+              </ode>
+            </torsional>
+          </friction>
+          <bounce>
+            <restitution_coefficient>0</restitution_coefficient>
+            <threshold>1e+06</threshold>
+          </bounce>
+          <contact>
+            <collide_without_contact>0</collide_without_contact>
+            <collide_without_contact_bitmask>1</collide_without_contact_bitmask>
+            <collide_bitmask>1</collide_bitmask>
+            <ode>
+              <soft_cfm>0</soft_cfm>
+              <soft_erp>0.2</soft_erp>
+              <kp>1e+13</kp>
+              <kd>1</kd>
+              <max_vel>0.01</max_vel>
+              <min_depth>0</min_depth>
+            </ode>
+            <bullet>
+              <split_impulse>1</split_impulse>
+              <split_impulse_penetration_threshold>-0.01</split_impulse_penetration_threshold>
+              <soft_cfm>0</soft_cfm>
+              <soft_erp>0.2</soft_erp>
+              <kp>1e+13</kp>
+              <kd>1</kd>
+            </bullet>
+          </contact>
+        </surface>
+      </collision>
+    </link>
+    <joint name="left_finger_sliding_joint" type="prismatic">
+      <parent>body</parent>
+      <child>left_finger</child>
+      <axis>
+        <xyz>-1 0 0</xyz>
+        <!-- Drake attaches an actuator to all and only joints with a nonzero
+             effort limit. -->
+        <limit>
+          <lower>-0.055</lower>
+          <upper>0</upper>
+          <effort>80</effort>
+          <stiffness>15000</stiffness>
+          <dissipation>50</dissipation>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+          <damping>0</damping>
+          <friction>0</friction>
+        </dynamics>
+      </axis>
+      <physics>
+        <ode>
+          <limit>
+            <cfm>0</cfm>
+            <erp>0.2</erp>
+          </limit>
+          <suspension>
+            <cfm>0</cfm>
+            <erp>0.2</erp>
+          </suspension>
+        </ode>
+      </physics>
+    </joint>
+    <joint name="right_finger_sliding_joint" type="prismatic">
+      <parent>body</parent>
+      <child>right_finger</child>
+      <axis>
+        <xyz>1 0 0</xyz>
+        <!-- Drake attaches an actuator to all and only joints with a nonzero
+             effort limit. -->
+        <limit>
+          <lower>0</lower>
+          <upper>0.055</upper>
+          <effort>80</effort>
+          <stiffness>15000</stiffness>
+          <dissipation>50</dissipation>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+          <damping>0</damping>
+          <friction>0</friction>
+        </dynamics>
+      </axis>
+      <physics>
+        <ode>
+          <limit>
+            <cfm>0</cfm>
+            <erp>0.2</erp>
+          </limit>
+          <suspension>
+            <cfm>0</cfm>
+            <erp>0.2</erp>
+          </suspension>
+        </ode>
+      </physics>
+    </joint>
+    <static>0</static>
+    <allow_auto_disable>1</allow_auto_disable>
+  </model>
+</sdf>

--- a/manipulation/models/wsg_50_description/sdf/schunk_wsg_50_with_tip.sdf
+++ b/manipulation/models/wsg_50_description/sdf/schunk_wsg_50_with_tip.sdf
@@ -1,0 +1,386 @@
+<!-- This sdf file is based on schunk_wsg_50.sdf -->
+<?xml version="1.0"?>
+<sdf version="1.7">
+  <model name="Schunk_Gripper">
+    <link name="body">
+      <pose>0 -0.049133 0 0 0 0</pose>
+      <inertial>
+        <mass>0.988882</mass>
+        <inertia>
+          <ixx>0.162992</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.162992</iyy>
+          <iyz>0</iyz>
+          <izz>0.164814</izz>
+        </inertia>
+      </inertial>
+      <self_collide>0</self_collide>
+      <kinematic>0</kinematic>
+      <visual name="visual">
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>../meshes/wsg_body.obj</uri>
+          </mesh>
+        </geometry>
+        <material>
+          <diffuse>0.7 0.7 0.7 1</diffuse>
+        </material>
+      </visual>
+      <collision name="collision">
+        <laser_retro>0</laser_retro>
+        <max_contacts>10</max_contacts>
+        <geometry>
+          <box>
+            <size>0.146 0.0725 0.05</size>
+          </box>
+        </geometry>
+        <surface>
+          <friction>
+            <ode>
+              <mu>1</mu>
+              <mu2>1</mu2>
+              <fdir1>0 0 0</fdir1>
+              <slip1>0</slip1>
+              <slip2>0</slip2>
+            </ode>
+            <torsional>
+              <coefficient>1</coefficient>
+              <patch_radius>0</patch_radius>
+              <surface_radius>0</surface_radius>
+              <use_patch_radius>1</use_patch_radius>
+              <ode>
+                <slip>0</slip>
+              </ode>
+            </torsional>
+          </friction>
+          <bounce>
+            <restitution_coefficient>0</restitution_coefficient>
+            <threshold>1e+06</threshold>
+          </bounce>
+          <contact>
+            <collide_without_contact>0</collide_without_contact>
+            <collide_without_contact_bitmask>1</collide_without_contact_bitmask>
+            <collide_bitmask>1</collide_bitmask>
+            <ode>
+              <soft_cfm>0</soft_cfm>
+              <soft_erp>0.2</soft_erp>
+              <kp>1e+13</kp>
+              <kd>1</kd>
+              <max_vel>0.01</max_vel>
+              <min_depth>0</min_depth>
+            </ode>
+            <bullet>
+              <split_impulse>1</split_impulse>
+              <split_impulse_penetration_threshold>-0.01</split_impulse_penetration_threshold>
+              <soft_cfm>0</soft_cfm>
+              <soft_erp>0.2</soft_erp>
+              <kp>1e+13</kp>
+              <kd>1</kd>
+            </bullet>
+          </contact>
+        </surface>
+      </collision>
+    </link>
+    <frame name="body_frame">
+      <pose relative_to="body"/>
+    </frame>
+    <link name="left_finger">
+      <pose>-0.0115 0.028 0 0 3.141592 0</pose>
+      <inertial>
+        <mass>0.05</mass>
+        <inertia>
+          <ixx>0.16</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.16</iyy>
+          <iyz>0</iyz>
+          <izz>0.16</izz>
+        </inertia>
+      </inertial>
+      <self_collide>0</self_collide>
+      <kinematic>0</kinematic>
+      <visual name="visual">
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>../meshes/finger_with_tip.obj</uri>
+          </mesh>
+        </geometry>
+        <material>
+          <diffuse>0.2 0.2 0.2 1</diffuse>
+        </material>
+      </visual>
+      <collision name="left_top">
+	<pose> -0.008 0.021 0 0 0 0 </pose>
+	<geometry>
+	  <sphere>
+            <radius> 0.001 </radius>
+          </sphere>
+        </geometry>
+      </collision>
+      <collision name="left_bottom">
+	<pose> -0.008 0.041 0 0 0 0 </pose>
+	<geometry>
+	  <sphere>
+            <radius> 0.001 </radius>
+          </sphere>
+        </geometry>
+      </collision>
+      <collision name="left_left">
+	<pose> -0.008 0.031 -0.01 0 0 0 </pose>
+	<geometry>
+	  <sphere>
+            <radius> 0.001 </radius>
+          </sphere>
+        </geometry>
+      </collision>
+      <collision name="left_right">
+	<pose> -0.008 0.031 0.01 0 0 0 </pose>
+	<geometry>
+	  <sphere>
+            <radius> 0.001 </radius>
+          </sphere>
+        </geometry>
+      </collision>                      
+      <collision name="collision">
+        <laser_retro>0</laser_retro>
+        <max_contacts>10</max_contacts>
+        <geometry>
+          <box>
+            <size>0.012 0.082 0.02</size>
+          </box>
+        </geometry>
+        <surface>
+          <friction>
+            <ode>
+              <mu>1</mu>
+              <mu2>1</mu2>
+              <fdir1>0 0 0</fdir1>
+              <slip1>0</slip1>
+              <slip2>0</slip2>
+            </ode>
+            <torsional>
+              <coefficient>1</coefficient>
+              <patch_radius>0</patch_radius>
+              <surface_radius>0</surface_radius>
+              <use_patch_radius>1</use_patch_radius>
+              <ode>
+                <slip>0</slip>
+              </ode>
+            </torsional>
+          </friction>
+          <bounce>
+            <restitution_coefficient>0</restitution_coefficient>
+            <threshold>1e+06</threshold>
+          </bounce>
+          <contact>
+            <collide_without_contact>0</collide_without_contact>
+            <collide_without_contact_bitmask>1</collide_without_contact_bitmask>
+            <collide_bitmask>1</collide_bitmask>
+            <ode>
+              <soft_cfm>0</soft_cfm>
+              <soft_erp>0.2</soft_erp>
+              <kp>1e+13</kp>
+              <kd>1</kd>
+              <max_vel>0.01</max_vel>
+              <min_depth>0</min_depth>
+            </ode>
+            <bullet>
+              <split_impulse>1</split_impulse>
+              <split_impulse_penetration_threshold>-0.01</split_impulse_penetration_threshold>
+              <soft_cfm>0</soft_cfm>
+              <soft_erp>0.2</soft_erp>
+              <kp>1e+13</kp>
+              <kd>1</kd>
+            </bullet>
+          </contact>
+        </surface>
+      </collision>
+    </link>
+    <link name="right_finger">
+      <pose>0.0115 0.028 0 0 0 0</pose>
+      <inertial>
+        <mass>0.05</mass>
+        <inertia>
+          <ixx>0.16</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.16</iyy>
+          <iyz>0</iyz>
+          <izz>0.16</izz>
+        </inertia>
+      </inertial>
+      <self_collide>0</self_collide>
+      <kinematic>0</kinematic>
+      <visual name="visual">
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>../meshes/finger_with_tip.obj</uri>
+          </mesh>
+        </geometry>
+        <material>
+          <diffuse>0.2 0.2 0.2 1</diffuse>
+        </material>
+      </visual>
+      <collision name="right_top">
+	<pose> -0.008 0.021 0 0 0 0 </pose>
+	<geometry>
+	  <sphere>
+            <radius> 0.001 </radius>
+          </sphere>
+        </geometry>
+      </collision>
+      <collision name="right_bottom">
+	<pose> -0.008 0.041 0 0 0 0 </pose>
+	<geometry>
+	  <sphere>
+            <radius> 0.001 </radius>
+          </sphere>
+        </geometry>
+      </collision>
+      <collision name="right_left">
+	<pose> -0.008 0.031 -0.01 0 0 0 </pose>
+	<geometry>
+	  <sphere>
+            <radius> 0.001 </radius>
+          </sphere>
+        </geometry>
+      </collision>
+      <collision name="right_right">
+	<pose> -0.008 0.031 0.01 0 0 0 </pose>
+	<geometry>
+	  <sphere>
+            <radius> 0.001 </radius>
+          </sphere>
+        </geometry>
+      </collision>                  
+      <collision name="collision">
+        <laser_retro>0</laser_retro>
+        <max_contacts>10</max_contacts>
+        <geometry>
+          <box>
+            <size>0.012 0.082 0.02</size>
+          </box>
+        </geometry>
+        <surface>
+          <friction>
+            <ode>
+              <mu>1</mu>
+              <mu2>1</mu2>
+              <fdir1>0 0 0</fdir1>
+              <slip1>0</slip1>
+              <slip2>0</slip2>
+            </ode>
+            <torsional>
+              <coefficient>1</coefficient>
+              <patch_radius>0</patch_radius>
+              <surface_radius>0</surface_radius>
+              <use_patch_radius>1</use_patch_radius>
+              <ode>
+                <slip>0</slip>
+              </ode>
+            </torsional>
+          </friction>
+          <bounce>
+            <restitution_coefficient>0</restitution_coefficient>
+            <threshold>1e+06</threshold>
+          </bounce>
+          <contact>
+            <collide_without_contact>0</collide_without_contact>
+            <collide_without_contact_bitmask>1</collide_without_contact_bitmask>
+            <collide_bitmask>1</collide_bitmask>
+            <ode>
+              <soft_cfm>0</soft_cfm>
+              <soft_erp>0.2</soft_erp>
+              <kp>1e+13</kp>
+              <kd>1</kd>
+              <max_vel>0.01</max_vel>
+              <min_depth>0</min_depth>
+            </ode>
+            <bullet>
+              <split_impulse>1</split_impulse>
+              <split_impulse_penetration_threshold>-0.01</split_impulse_penetration_threshold>
+              <soft_cfm>0</soft_cfm>
+              <soft_erp>0.2</soft_erp>
+              <kp>1e+13</kp>
+              <kd>1</kd>
+            </bullet>
+          </contact>
+        </surface>
+      </collision>
+    </link>
+    <joint name="left_finger_sliding_joint" type="prismatic">
+      <parent>body</parent>
+      <child>left_finger</child>
+      <axis>
+        <xyz>-1 0 0</xyz>
+        <!-- Drake attaches an actuator to all and only joints with a nonzero
+             effort limit. -->
+        <limit>
+          <lower>-0.055</lower>
+          <upper>0</upper>
+          <effort>80</effort>
+          <stiffness>15000</stiffness>
+          <dissipation>50</dissipation>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+          <damping>0</damping>
+          <friction>0</friction>
+        </dynamics>
+      </axis>
+      <physics>
+        <ode>
+          <limit>
+            <cfm>0</cfm>
+            <erp>0.2</erp>
+          </limit>
+          <suspension>
+            <cfm>0</cfm>
+            <erp>0.2</erp>
+          </suspension>
+        </ode>
+      </physics>
+    </joint>
+    <joint name="right_finger_sliding_joint" type="prismatic">
+      <parent>body</parent>
+      <child>right_finger</child>
+      <axis>
+        <xyz>1 0 0</xyz>
+        <!-- Drake attaches an actuator to all and only joints with a nonzero
+             effort limit. -->
+        <limit>
+          <lower>0</lower>
+          <upper>0.055</upper>
+          <effort>80</effort>
+          <stiffness>15000</stiffness>
+          <dissipation>50</dissipation>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+          <damping>0</damping>
+          <friction>0</friction>
+        </dynamics>
+      </axis>
+      <physics>
+        <ode>
+          <limit>
+            <cfm>0</cfm>
+            <erp>0.2</erp>
+          </limit>
+          <suspension>
+            <cfm>0</cfm>
+            <erp>0.2</erp>
+          </suspension>
+        </ode>
+      </physics>
+    </joint>
+    <static>0</static>
+    <allow_auto_disable>1</allow_auto_disable>
+  </model>
+</sdf>

--- a/manipulation/models/wsg_50_description/sdf/test/wsg_50_sdf_test.cc
+++ b/manipulation/models/wsg_50_description/sdf/test/wsg_50_sdf_test.cc
@@ -1,0 +1,59 @@
+#include <iostream>
+#include <string>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/plant/multibody_plant.h"
+
+namespace drake {
+namespace manipulation {
+namespace {
+
+// Tests that all the Sdf files can be parsed into a plant.
+GTEST_TEST(Wsg50DescriptionSdfTest, TestBoxSchunkSdf) {
+  const std::string prefix("drake/manipulation/models/wsg_50_description/sdf/");
+  const std::vector<std::string> file_names{
+    "schunk_wsg_50.sdf",
+    "schunk_wsg_50_ball_contact.sdf",
+    "schunk_wsg_50_no_tip.sdf",
+    "schunk_wsg_50_with_tip.sdf"};
+
+  for (size_t i = 0; i < file_names.size(); i++) {
+    const std::string kPath(FindResourceOrThrow(prefix + file_names[i]));
+
+    multibody::MultibodyPlant<double> plant(0.0);
+    multibody::Parser parser(&plant);
+    parser.AddModelFromFile(kPath);
+    plant.Finalize();
+
+    // Expect 3 model instances. One for the world, one default model instance
+    // for unspecified modeling elements, and the gripper model instance.
+    EXPECT_EQ(plant.num_model_instances(), 3);
+
+    // Expect 9 positions, 6 attached to the body, 2 to each joints of the
+    // gripper, and the first one reserved for multibody plant.
+    EXPECT_EQ(plant.num_positions(), 9);
+
+    // Expect 8 velocities, 6 attached to the body, 2 to each joints of the
+    // gripper.
+    EXPECT_EQ(plant.num_velocities(), 8);
+
+    ASSERT_EQ(plant.num_bodies(), 4);
+    const std::vector<std::string> expected_body_names{
+      "" /* Ignore the world body name */,
+        "body",
+        "left_finger",
+        "right_finger"};
+    for (multibody::BodyIndex j{1}; j < plant.num_bodies(); ++j) {
+      EXPECT_THAT(plant.get_body(j).name(),
+                  testing::EndsWith(expected_body_names.at(j)));
+    }
+  }
+}
+
+}  // namespace
+}  // namespace manipulation
+}  // namespace drake

--- a/tools/workspace/models/files.bzl
+++ b/tools/workspace/models/files.bzl
@@ -63,6 +63,13 @@ def skydio_2_mesh_files():
         "skydio_2/LICENSE",
     ]
 
+def wsg_50_description_mesh_files():
+    return [
+        "wsg_50_description/meshes/finger_without_tip.obj",
+        "wsg_50_description/meshes/finger_with_tip.obj",
+        "wsg_50_description/meshes/wsg_body.obj",
+    ]
+
 def ycb_mesh_files():
     """Manual enumeration of mesh files, to avoid needing to write extra Bazel
     logic.

--- a/tools/workspace/models/package.BUILD.bazel
+++ b/tools/workspace/models/package.BUILD.bazel
@@ -9,6 +9,7 @@ exports_files(
         "franka_description/**",
         "jaco_description/**",
         "skydio_2/**",
+        "wsg_50_description/**",
         "ycb/meshes/**",
     ], allow_empty = False),
     visibility = ["//visibility:public"],

--- a/tools/workspace/models/repository.bzl
+++ b/tools/workspace/models/repository.bzl
@@ -8,8 +8,8 @@ def models_repository(
     github_archive(
         name = name,
         repository = "RobotLocomotion/models",
-        commit = "70593dc411979f411d55360a28ea32f1242c37dd",
-        sha256 = "ec3db4d37948fdd72c7d6aa6797db3945441bfaf90d454c609afbc3710f24432",  # noqa
+        commit = "745547fbec8ec8cb10be6ef23f7f0cd5ba49d321",
+        sha256 = "a7ab36339c935a6e487f0275d8c5a38148658641e05207201cfd591d2ce60437",  # noqa
         build_file = "@drake//tools/workspace/models:package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
A fix to #13875 , adds two more realistic looking Schunk grippers for better visualization (+ perhaps some improvements to modeling collision geometry for the real schunk) 

The first model consists of real-looking schunk without the fingertip. 
![Screenshot from 2020-08-22 22-52-40](https://user-images.githubusercontent.com/22463195/90987807-b7673380-e55b-11ea-9084-ed6ab8d00831.png)

The second model includes fingertip with some collision spheres.
![Screenshot from 2020-08-22 23-09-06](https://user-images.githubusercontent.com/22463195/90987815-bfbf6e80-e55b-11ea-8ba1-fd1cfa2f3f25.png)

Includes changes to manipulation_station, its bindings, and end_effector_teleop codes so that different schunks can be called at runtime. 

`./bazel-bin/examples/manipulation_station/end_effector_teleop_mouse --schunk_model=box_schunk`
`./bazel-bin/examples/manipulation_station/end_effector_teleop_mouse --schunk_model=real_schunk_no_tip`
`./bazel-bin/examples/manipulation_station/end_effector_teleop_mouse --schunk_model=real_schunk_with_tip`

Same function is added to `end_effector_teleop_sliders.py` and `end_effector_teleop_dualshock4.py`
Available for manipulation class and clutter clearing setups, not available for planar iiwa. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13922)
<!-- Reviewable:end -->
