### PR TITLE
Reduce heap allocation in CalcMassMatrix()

### DIFF
--- a/examples/multibody/cassie_benchmark/test/cassie_bench.cc
+++ b/examples/multibody/cassie_benchmark/test/cassie_bench.cc
@@ -136,7 +136,7 @@ BENCHMARK_F(CassieDoubleFixture, DoubleMassMatrix)(benchmark::State& state) {
   MatrixXd M(nv_, nv_);
   for (auto _ : state) {
     // @see LimitMalloc note above.
-    LimitMalloc guard(LimitReleaseOnly(175));
+    LimitMalloc guard(LimitReleaseOnly(174));
     InvalidateState();
     plant_->CalcMassMatrix(*context_, &M);
     tracker.Update(guard.num_allocations());
@@ -216,7 +216,7 @@ BENCHMARK_F(CassieAutodiffFixture, AutodiffMassMatrix)
 
   for (auto _ : state) {
     // @see LimitMalloc note above.
-    LimitMalloc guard(LimitReleaseOnly(61405));
+    LimitMalloc guard(LimitReleaseOnly(61197));
 
     compute();
 

--- a/multibody/tree/body_node.h
+++ b/multibody/tree/body_node.h
@@ -1266,10 +1266,10 @@ class BodyNode : public MultibodyElement<BodyNode, T, BodyNodeIndex> {
   /// @param[in] M_B_W Spatial inertia for the body B associated with this node.
   /// About B's origin Bo and expressed in the world frame W.
   /// @param[in] pc Position kinematics cache.
-  /// @param[in] R_B_W_all Vector storing the composite body inertia for all
+  /// @param[in] Mc_B_W_all Vector storing the composite body inertia for all
   /// bodies in the multibody system. It must contain already up-to-date
   /// composite body inertias for all the children of `this` node.
-  /// @param[out] R_B_W The composite body inertia for `this` node. It must be
+  /// @param[out] Mc_B_W The composite body inertia for `this` node. It must be
   /// non-nullptr.
   /// @pre CalcCompositeBodyInertia_TipToBase() must have already been called
   /// for the children nodes (and, by recursive precondition, all outboard nodes
@@ -1277,15 +1277,15 @@ class BodyNode : public MultibodyElement<BodyNode, T, BodyNodeIndex> {
   void CalcCompositeBodyInertia_TipToBase(
       const SpatialInertia<T>& M_B_W,
       const PositionKinematicsCache<T>& pc,
-      const std::vector<SpatialInertia<T>>& R_B_W_all,
-      SpatialInertia<T>* R_B_W) const {
+      const std::vector<SpatialInertia<T>>& Mc_B_W_all,
+      SpatialInertia<T>* Mc_B_W) const {
     DRAKE_THROW_UNLESS(topology_.body != world_index());
-    DRAKE_THROW_UNLESS(R_B_W != nullptr);
+    DRAKE_THROW_UNLESS(Mc_B_W != nullptr);
 
     // Composite body inertia R_B_W for this node B, about its frame's origin
     // Bo, and expressed in the world frame W. Here we adopt the notation used
     // in Jain's book.
-    *R_B_W = M_B_W;
+    *Mc_B_W = M_B_W;
     // Add composite body inertia contributions from all children.
     for (const BodyNode<T>* child : children_) {
       // Shift vector p_CoBo_W.
@@ -1294,10 +1294,10 @@ class BodyNode : public MultibodyElement<BodyNode, T, BodyNodeIndex> {
 
       // Composite body inertia for outboard child body C, about Co, expressed
       // in W.
-      const SpatialInertia<T>& R_CCo_W = R_B_W_all[child->index()];
+      const SpatialInertia<T>& Mc_CCo_W = Mc_B_W_all[child->index()];
 
       // Shift to Bo and add it to the composite body inertia of B.
-      *R_B_W += R_CCo_W.Shift(p_CoBo_W);
+      *Mc_B_W += Mc_CCo_W.Shift(p_CoBo_W);
     }
   }
 


### PR DESCRIPTION
This is the first in a long series of changes to eliminate heap allocations and other performance issues in MBPlant. 

Changes here:
- Adds a cache entry for composite body inertias so CalcMassMatrix() doesn't have to heap allocate them. That removes just one heap allocation from each CalcMassMatrix() call.
- Updated the heap limit in cassie_benchmark accordingly (from 175 to 174; I verified it fails at 173).
- Modernized the MBTreeSystem cache allocation code to make it more readable. That requires having some inline methods defined in MBTreeSystem that can be provided as the cache entries' Calc() methods. Made some (internal) name changes for consistency.
- Changed terminology for composite body inertias from "R" to "Mc" since R means rotation matrix and "M" is used for spatial inertias (and these are just spatial inertias of composite bodies). Featherstone uses "I" for spatial inertias and "Iᶜ" for composite body inertias so this is similar in spirit to that notation.

I reran cassie_benchmark to verify that this has no discernable effect on runtimes (as expected).

Relates #13186, #13902

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13928)
<!-- Reviewable:end -->
