### PR TITLE
Add doxygen group for multibody systems

### DIFF
--- a/multibody/plant/propeller.h
+++ b/multibody/plant/propeller.h
@@ -76,7 +76,7 @@ stabilizable linearization around a hovering fixed point in 3D without them).
 which applies only a force (no moment) in the Propeller coordinates.
 
 @tparam_default_scalar
-@ingroup multibody
+@ingroup multibody_systems
 */
 template <typename T>
 class Propeller final : public systems::LeafSystem<T> {

--- a/systems/systems.h
+++ b/systems/systems.h
@@ -13,11 +13,10 @@
 /// drake::systems::Diagram class permits modeling complex systems from
 /// libraries of parts.
 ///
-/// For a "Hello, World!" example of writing a dynamical system, see
-/// simple_continuous_time_system.cc and/or simple_discrete_time_system.cc.
-/// For an example of a system that uses some of the more advanced
-/// features, such as typed input, output, state, and parameter vectors,
-/// see simple_car.h .
+/// For an introduction to using systems in python, see the dynamical_systems
+/// tutorial.  For a "Hello, World!" example of writing a dynamical system in
+/// C++, see simple_continuous_time_system.cc and/or
+/// simple_discrete_time_system.cc.
 ///
 /// @}
 
@@ -30,6 +29,7 @@
 ///   @defgroup sensor_systems Sensors
 ///   @defgroup manipulation_systems Manipulation
 ///   @defgroup message_passing Message Passing
+///   @defgroup multibody_systems Multibody Systems
 ///   @defgroup perception_systems Perception
 ///   @defgroup discrete_systems Discrete Systems
 ///   @defgroup stochastic_systems Stochastic Systems
@@ -91,6 +91,11 @@
 /// @}
 // TODO(russt): Add pointers to / recommendations for connecting to ROS.
 // TODO(russt): Add ZMQ.
+
+/// @addtogroup multibody_systems
+/// @{
+/// @brief Systems that relate to, or add functionality to, MultibodyPlant.
+/// @}
 
 /// @addtogroup perception_systems
 /// @{


### PR DESCRIPTION
I noticed that the Propeller system was sitting in a very odd place in the doxygen hierarchy.  This cleans that up.
Also resolves a stale reference to simple_car.h

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13929)
<!-- Reviewable:end -->
