### PR TITLE
cassie_bench: Improve allocation tracking

### DIFF
--- a/common/test_utilities/limit_malloc.cc
+++ b/common/test_utilities/limit_malloc.cc
@@ -44,6 +44,8 @@ class Monitor {
     }
   }
 
+  int num_allocations() const { return observed_num_allocations_.load(); }
+
  private:
   void ObserveAllocation();
 
@@ -172,6 +174,10 @@ LimitMalloc::LimitMalloc(LimitMallocParams args) {
   if (prior) {
     throw std::logic_error("Cannot nest LimitMalloc guards");
   }
+}
+
+int LimitMalloc::num_allocations() const {
+  return ActiveMonitor::load()->num_allocations();
 }
 
 LimitMalloc::~LimitMalloc() {

--- a/common/test_utilities/limit_malloc.h
+++ b/common/test_utilities/limit_malloc.h
@@ -55,6 +55,9 @@ class LimitMalloc final {
   /// Undoes this object's malloc limits.
   ~LimitMalloc();
 
+  /// Returns the number of allocations observed so far.
+  int num_allocations() const;
+
   // We write this out by hand, to avoid depending on Drake *at all*.
   /// @name Does not allow copy, move, or assignment
   //@{

--- a/common/test_utilities/test/limit_malloc_test.cc
+++ b/common/test_utilities/test/limit_malloc_test.cc
@@ -61,6 +61,8 @@ TEST_P(LimitMallocTest, UnlimitedTest) {
   Allocate();  // Malloc is OK.
   Allocate();  // Malloc is OK.
   Allocate();  // Malloc is OK.
+  // Allocations are counted.
+  EXPECT_EQ(3, guard.num_allocations());
 }
 
 TEST_P(LimitMallocTest, BasicTest) {


### PR DESCRIPTION
 * expose allocation count from LimitMalloc
 * track allocations with some simple stats
 * separate first run to expose steady state allocation
 * lower some Limitmalloc ceilings from observations

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13930)
<!-- Reviewable:end -->
