### PR TITLE
Fix limit_malloc_test on macOS

### DIFF
--- a/common/test_utilities/test/limit_malloc_test.cc
+++ b/common/test_utilities/test/limit_malloc_test.cc
@@ -13,6 +13,12 @@ namespace drake {
 namespace test {
 namespace {
 
+#ifdef __APPLE__
+constexpr bool kHasLimitMallocHooks = false;
+#else
+constexpr bool kHasLimitMallocHooks = true;
+#endif
+
 // Calls malloc (and then immediately frees).
 void CallMalloc() {
   void* dummy = malloc(16);
@@ -62,7 +68,7 @@ TEST_P(LimitMallocTest, UnlimitedTest) {
   Allocate();  // Malloc is OK.
   Allocate();  // Malloc is OK.
   // Allocations are counted.
-  EXPECT_EQ(3, guard.num_allocations());
+  EXPECT_EQ(guard.num_allocations(), kHasLimitMallocHooks ? 3 : 0);
 }
 
 TEST_P(LimitMallocTest, BasicTest) {


### PR DESCRIPTION
On macOS, the device under test is inoperative, so it can't track allocation counts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13932)
<!-- Reviewable:end -->
