### PR TITLE
Eliminate remaining heap use from CalcMassMatrix()

### DIFF
--- a/examples/multibody/cassie_benchmark/test/cassie_bench.cc
+++ b/examples/multibody/cassie_benchmark/test/cassie_bench.cc
@@ -136,7 +136,7 @@ BENCHMARK_F(CassieDoubleFixture, DoubleMassMatrix)(benchmark::State& state) {
   MatrixXd M(nv_, nv_);
   for (auto _ : state) {
     // @see LimitMalloc note above.
-    LimitMalloc guard(LimitReleaseOnly(174));
+    LimitMalloc guard(LimitReleaseOnly(0));
     InvalidateState();
     plant_->CalcMassMatrix(*context_, &M);
     tracker.Update(guard.num_allocations());
@@ -216,7 +216,7 @@ BENCHMARK_F(CassieAutodiffFixture, AutodiffMassMatrix)
 
   for (auto _ : state) {
     // @see LimitMalloc note above.
-    LimitMalloc guard(LimitReleaseOnly(61197));
+    LimitMalloc guard(LimitReleaseOnly(53652));
 
     compute();
 

--- a/multibody/math/BUILD.bazel
+++ b/multibody/math/BUILD.bazel
@@ -101,6 +101,7 @@ drake_cc_googletest(
         ":spatial_algebra",
         "//common:autodiff",
         "//common:symbolic",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/multibody/math/spatial_force.h
+++ b/multibody/math/spatial_force.h
@@ -121,6 +121,37 @@ class SpatialForce : public SpatialVector<SpatialForce, T> {
     return *this;
   }
 
+  /// Performs a rigid in-place shift of each column of 6 x n matrix
+  /// `F_Bp_E_all` as if each column were a %SpatialForce. The spatial forces
+  /// are assumed to be applied at point P of a body B, and we shift them to
+  /// point Q of that body by modifying the moment appropriately (translational
+  /// forces are unchanged). Hence on output the matrix should be renamed
+  /// F_Bq_E_all (conceptually). The first three elements of each column must
+  /// store the torque (rotational) component while the last three elements
+  /// store the force (translational) component. All quantities are expressed
+  /// in the same common frame E.
+  ///
+  /// @param[in,out] F_Bp_E_all
+  ///   A 6 x n matrix of spatial forces at point Bp on input, shifted to point
+  ///   Bq on output.
+  /// @param[in] p_BpBq_E
+  ///   The vector from point Bp to point Bq.
+  ///
+  /// @pre Columns are spatial forces with torque first, then force.
+  /// @see ShiftInPlace(const Vector3<T>&) for details.
+  static void ShiftInPlace(EigenPtr<Matrix6X<T>> F_Bp_E_all,
+                           const Vector3<T>& p_BpBq_E) {
+    const int ncol = F_Bp_E_all->cols();
+    for (int j = 0; j < ncol; ++j) {
+      // These are Eigen intermediate types; better not to look!
+      auto F_Bp_E = F_Bp_E_all->col(j);
+      auto torque = F_Bp_E.template head<3>();
+      const auto force = F_Bp_E.template tail<3>();
+      torque -= p_BpBq_E.cross(force);
+    }
+    // F_Bp_E_all should now be called F_Bq_E_all.
+  }
+
   /// Shift of a %SpatialForce from one application point to another.
   /// This is an alternate signature for shifting a spatial force's
   /// application point that does not change the original object. See
@@ -142,25 +173,37 @@ class SpatialForce : public SpatialVector<SpatialForce, T> {
     return SpatialForce<T>(*this).ShiftInPlace(p_BpBq_E);
   }
 
-  /// Performs a rigid shift of each column of `F_P_E` as if they contained the
-  /// 6 components of a spatial force. It is assumed the first three elements of
-  /// each column store the rotational component while the last three elements
-  /// store the translational component.
-  /// Given the position of Q in P, each spatial force `F_P_E` about P is
-  /// rigidly shifted to point Q, see Shift(). All quantities are expressed in a
-  /// same common frame E.
-  /// F_Q_E must be non-null and point to a matrix of 6 rows and as many columns
-  /// as input F_P_E, otherwise an assertion failure is triggered.
-  /// @note Aliasing is allowed. That is, F_Q_E can point to the same memory
-  /// referenced by F_P_E, resulting in an in-place operation.
-  static void Shift(const Eigen::Ref<const Matrix6X<T>>& F_P_E,
-                    const Vector3<T>& p_PQ_E, EigenPtr<Matrix6X<T>> F_Q_E) {
-    DRAKE_DEMAND(F_Q_E != nullptr);
-    DRAKE_DEMAND(F_Q_E->cols() == F_P_E.cols());
-    F_Q_E->template topRows<3>() =
-        F_P_E.template topRows<3>() +
-        F_P_E.template bottomRows<3>().colwise().cross(p_PQ_E);
-    F_Q_E->template bottomRows<3>() = F_P_E.template bottomRows<3>();
+  /// Performs a rigid shift of each column of 6 x n matrix `F_Bp_E_all` into
+  /// `F_Bq_E_all` as if each column were a %SpatialForce. The spatial forces
+  /// are assumed to be applied at point P of a body B, and we shift them to
+  /// point Q of that body by modifying the moment appropriately (translational
+  /// forces are unchanged). The first three elements of each column must store
+  /// the torque (rotational) component while the last three elements store the
+  /// force (translational) component. All quantities are expressed in the same
+  /// common frame E.
+  ///
+  /// @param[in] F_Bp_E_all
+  ///   A 6 x n matrix of spatial forces at point Bp on input, shifted to point
+  ///   Bq on output.
+  /// @param[in] p_BpBq_E
+  ///   The vector from point Bp to point Bq.
+  /// @param[out] F_Bq_E_all
+  ///   A 6 x n matrix of spatial forces shifted from Bp to Bq.
+  ///
+  /// @pre Columns are spatial forces with torque first, then force.
+  /// @pre F_Bq_E_all must be non-null and point to a 6 x n matrix (same size
+  ///   as the input matrix).
+  /// @note Although this method will function if the input and output are
+  ///   the same matrix, it is faster to use ShiftInPlace() in that case since
+  ///   the translational components don't need to be copied.
+  /// @see ShiftInPlace(const Vector3<T>&) for details.
+  static void Shift(const Eigen::Ref<const Matrix6X<T>>& F_Bp_E_all,
+                    const Vector3<T>& p_BpBq_E,
+                    EigenPtr<Matrix6X<T>> F_Bq_E_all) {
+    DRAKE_DEMAND(F_Bq_E_all != nullptr);
+    DRAKE_DEMAND(F_Bq_E_all->cols() == F_Bp_E_all.cols());
+    *F_Bq_E_all = F_Bp_E_all;
+    ShiftInPlace(F_Bq_E_all, p_BpBq_E);
   }
 
   /// Given `this` spatial force `F_Bp_E` applied at point P of body B and

--- a/multibody/math/test/spatial_algebra_test.cc
+++ b/multibody/math/test/spatial_algebra_test.cc
@@ -10,6 +10,7 @@
 #include "drake/common/eigen_types.h"
 #include "drake/common/extract_double.h"
 #include "drake/common/symbolic.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
 
 namespace drake {
 namespace multibody {
@@ -586,7 +587,7 @@ TYPED_TEST(ElementsInF6Test, ShiftOperation) {
   EXPECT_TRUE(F_Bo_E.IsApprox(expected_F_Bo_E));
 
   // We perform the shift operation on a Matrix storing a spatial force in each
-  // column.
+  // column. First we'll use the not-in-place Shift() method.
   constexpr int num_forces = 3;
   const Matrix6X<T> Fmatrix_Ao_E =
       F_Ao_E.get_coeffs().rowwise().replicate(num_forces);
@@ -597,6 +598,12 @@ TYPED_TEST(ElementsInF6Test, ShiftOperation) {
     SpatialQuantity Fj_Bo_E(Fmatrix_Bo_E.col(j));
     EXPECT_TRUE(Fj_Bo_E.IsApprox(expected_F_Bo_E));
   }
+
+  // Now shift it back using the ShiftInPlace() method. We're expecting
+  // near-perfect results.
+  const double kTolerance = 10 * std::numeric_limits<double>::epsilon();
+  SpatialForce<T>::ShiftInPlace(&Fmatrix_Bo_E, -p_AB_E);
+  EXPECT_TRUE(CompareMatrices(Fmatrix_Bo_E, Fmatrix_Ao_E, kTolerance));
 }
 
 // Tests operator+().

--- a/multibody/tree/spatial_inertia.h
+++ b/multibody/tree/spatial_inertia.h
@@ -447,8 +447,9 @@ class SpatialInertia {
   /// stores the spatial vector in F⁶ result of multiplying `this` spatial
   /// inertia with the j-th column of `Mmatrix`.
   template <typename Derived>
-  Eigen::Matrix<T, 6, Derived::ColsAtCompileTime> operator*(
-      const Eigen::MatrixBase<Derived>& Mmatrix) const {
+  Eigen::Matrix<T, 6, Derived::ColsAtCompileTime, 0, 6,
+                Derived::MaxColsAtCompileTime>
+  operator*(const Eigen::MatrixBase<Derived>& Mmatrix) const {
     static_assert(is_eigen_scalar_same<Derived, T>::value,
                   "Derived must be templated on the same scalar type as this "
                   "spatial inertia.");
@@ -460,7 +461,9 @@ class SpatialInertia {
     const Vector3<T>& mp_BoBcm_E = CalcComMoment();  // = m * p_BoBcm
     const Matrix3<T> I_SP_E = CalcRotationalInertia().CopyToFullMatrix3();
 
-    Eigen::Matrix<T, 6, Derived::ColsAtCompileTime> F_Bo_E(6, Mmatrix.cols());
+    Eigen::Matrix<T, 6, Derived::ColsAtCompileTime, 0, 6,
+                  Derived::MaxColsAtCompileTime>
+        F_Bo_E(6, Mmatrix.cols());
 
     // Rotational component.
     F_Bo_E.template topRows<3>() =


### PR DESCRIPTION
This is a follow-up from #13928 that gets rid of the rest of the heap allocation for CalcMassMatrix().
Also:
- Eliminates unnecessary work done for weld (fixed) joints.
- Adds a SpatialForce::ShiftInPlace() method and uses it in place of SpatialForce::Shift(). In-place is more efficient since translational forces don't change, and the method uses no heap space. 
- Reimplemented SpatialForce::Shift() in terms of ShiftInPlace() to eliminate its heap use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13933)
<!-- Reviewable:end -->
