### PR TITLE
cassie bench: Add processor affinity control for Linux

### DIFF
--- a/examples/multibody/cassie_benchmark/README.md
+++ b/examples/multibody/cassie_benchmark/README.md
@@ -24,6 +24,9 @@ controlled conditions.
 
     $ examples/multibody/cassie_benchmark/conduct_experiment [DIRECTORY]
 
+The conduct_experiment script will attempt to reduce result variance by
+controlling cpu throttling and by setting a cpu affinity mask.
+
 It is still up to the user to make sure the machine is appropriate (not
 a virtual machine, for example), and relatively unloaded. Close as many
 running programs as is practical.
@@ -45,7 +48,9 @@ discussion of methods are being tracked in Github issue #13902.
 ## Experiment details
 
 The following command will perform a benchmark experiment (with
-environment controls) and collect context information.
+environment controls) and collect context information. It is not
+confined to a specific platform, like :conduct_experiment, and it
+controls fewer environment conditions.
 
     $ bazel run //examples/multibody/cassie_benchmark:record_results
 
@@ -55,6 +60,16 @@ controlled. These include:
 * load average -- close as many other programs as practical
 * cpu throttling -- varies with platform
   * Linux: https://github.com/google/benchmark#disabling-cpu-frequency-scaling
+
+The :record_results target does try to mitigate costs of rescheduling to
+a different processor (Linux only), by setting a processor
+affinity. However, it does not do full-featured processor isolation, so
+it is still important to limit the number of running programs. As of
+this writing, the benchmark is assigned to processor #0; it may be worth
+monitoring the system to ensure that processor will be fully available
+to the experiment.
+
+## Results data files
 
 Bazel buries the results deep in its output tree. To copy them
 somewhere more convenient, use this command outside of Bazel:

--- a/examples/multibody/cassie_benchmark/record_results.sh
+++ b/examples/multibody/cassie_benchmark/record_results.sh
@@ -7,10 +7,17 @@ set -e -u -o pipefail
 
 uname -a > ${TEST_UNDECLARED_OUTPUTS_DIR}/kernel.txt || true
 
+# Fill this in with a platform-specific command to control processor affinity,
+# if any.
+AFFINITY_COMMAND=""
+
 (
 case $(uname) in
     Linux)
         lsb_release -idrc
+        # Choosing processor #0 is arbitrary. It is up to experimenters
+        # to ensure it is reliably idle during experiments.
+        AFFINITY_COMMAND="taskset 0x1"
         ;;
     Darwin)
         sw_vers
@@ -24,6 +31,7 @@ esac
 ${TEST_SRCDIR}/drake/tools/workspace/cc/identify_compiler \
  > ${TEST_UNDECLARED_OUTPUTS_DIR}/compiler.txt
 
+${AFFINITY_COMMAND} \
 ${TEST_SRCDIR}/drake/examples/multibody/cassie_benchmark/cassie_bench \
     --benchmark_display_aggregates_only=true \
     --benchmark_repetitions=9 \


### PR DESCRIPTION
Relevant to #13902.

On linux only, invoke the benchmark under the `taskset` command. Add a
bit of documentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13936)
<!-- Reviewable:end -->
