### PR TITLE
Adds missing import for jupyter widgets

### DIFF
--- a/bindings/pydrake/systems/jupyter_widgets.py
+++ b/bindings/pydrake/systems/jupyter_widgets.py
@@ -10,6 +10,7 @@ import numpy as np
 from collections import namedtuple
 from functools import partial
 
+from IPython.display import display
 from ipywidgets import FloatSlider, Layout, Widget
 
 from pydrake.common.jupyter import process_ipywidget_events


### PR DESCRIPTION
clearly it should have been there.  it was somehow not needed in most cases, but mac nbconvert seemed to miss it.  (go figure)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13941)
<!-- Reviewable:end -->
