### PR TITLE
cassie_bench: Fix defect affecting affinity

### DIFF
--- a/examples/multibody/cassie_benchmark/record_results.sh
+++ b/examples/multibody/cassie_benchmark/record_results.sh
@@ -11,7 +11,6 @@ uname -a > ${TEST_UNDECLARED_OUTPUTS_DIR}/kernel.txt || true
 # if any.
 AFFINITY_COMMAND=""
 
-(
 case $(uname) in
     Linux)
         lsb_release -idrc
@@ -25,8 +24,7 @@ case $(uname) in
     *)
         echo unknown
         ;;
-esac
-) > ${TEST_UNDECLARED_OUTPUTS_DIR}/os.txt
+esac > ${TEST_UNDECLARED_OUTPUTS_DIR}/os.txt
 
 ${TEST_SRCDIR}/drake/tools/workspace/cc/identify_compiler \
  > ${TEST_UNDECLARED_OUTPUTS_DIR}/compiler.txt


### PR DESCRIPTION
Relevant to #13902.

Prior patches to enable CPU affinity were effectively no-op, since the
relevant assignment was done within a subshell (parentheses). However,
the only thing in the subshell was a case block, so the redirection
grouping happens for free anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13946)
<!-- Reviewable:end -->
