### PR TITLE
schema: Use 'class' not 'struct' for more complex types

### DIFF
--- a/common/schema/dev/rotation.h
+++ b/common/schema/dev/rotation.h
@@ -19,7 +19,8 @@ namespace schema {
 ///
 /// For an overview of configuring stochastic transforms, see
 /// @ref schema_transform and @ref schema_stochastic.
-struct Rotation {
+class Rotation {
+ public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Rotation)
 
   /// Constructs the Identity rotation.
@@ -99,6 +100,10 @@ struct Rotation {
   void Serialize(Archive* a) {
     a->Visit(DRAKE_NVP(value));
   }
+
+  // N.B. As is standard for classes implementing Serialize(), we declare all
+  // of our members fields as public since they are effectively so anyway, and
+  // we omit the trailing underscore from the field names.
 
   using Variant = std::variant<Identity, Rpy, AngleAxis, Uniform>;
   Variant value;

--- a/common/schema/dev/stochastic.cc
+++ b/common/schema/dev/stochastic.cc
@@ -443,9 +443,9 @@ Eigen::VectorXd GetDeterministicValue(
   template Clazz<5>; \
   template Clazz<6>;
 
-DRAKE_INSTANTIATE_ALL_SIZES(struct DeterministicVector)
-DRAKE_INSTANTIATE_ALL_SIZES(struct GaussianVector)
-DRAKE_INSTANTIATE_ALL_SIZES(struct UniformVector)
+DRAKE_INSTANTIATE_ALL_SIZES(class DeterministicVector)
+DRAKE_INSTANTIATE_ALL_SIZES(class GaussianVector)
+DRAKE_INSTANTIATE_ALL_SIZES(class UniformVector)
 
 #undef DRAKE_INSTANTIATE_ALL_SIZES
 

--- a/common/schema/dev/stochastic.h
+++ b/common/schema/dev/stochastic.h
@@ -195,9 +195,14 @@ rotations, translations, and transforms using stochastic schemas.
 
 @} */
 
+// N.B. As is standard for classes implementing Serialize(), below we always
+// declare all of our members fields as public since they are effectively so
+// anyway, and we omit the trailing underscore from the field names.
+
 /// Base class for a single distribution, to be used with YAML archives.
-/// (See struct DistributionVector for vector-valued distributions.)
-struct Distribution {
+/// (See class DistributionVector for vector-valued distributions.)
+class Distribution {
+ public:
   virtual ~Distribution();
 
   virtual double Sample(drake::RandomGenerator* generator) const = 0;
@@ -210,7 +215,8 @@ struct Distribution {
 };
 
 /// A single deterministic `value`.
-struct Deterministic final : public Distribution {
+class Deterministic final : public Distribution {
+ public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Deterministic)
 
   Deterministic();
@@ -231,7 +237,8 @@ struct Deterministic final : public Distribution {
 };
 
 /// A gaussian distribution with `mean` and `stddev`.
-struct Gaussian final : public Distribution {
+class Gaussian final : public Distribution {
+ public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Gaussian)
 
   Gaussian();
@@ -253,7 +260,8 @@ struct Gaussian final : public Distribution {
 };
 
 /// A uniform distribution with `min` inclusive and `max` exclusive.
-struct Uniform final : public Distribution {
+class Uniform final : public Distribution {
+ public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Uniform)
 
   Uniform();
@@ -275,7 +283,8 @@ struct Uniform final : public Distribution {
 };
 
 /// Chooses from among discrete `values` with equal probability.
-struct UniformDiscrete final : public Distribution {
+class UniformDiscrete final : public Distribution {
+ public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(UniformDiscrete)
 
   UniformDiscrete();
@@ -336,8 +345,9 @@ double GetDeterministicValue(const DistributionVariant& var);
 // ---------------------------------------------------------------------------
 
 /// Base class for a vector of distributions, to be used with YAML archives.
-/// (See struct Distribution for single distributions.)
-struct DistributionVector {
+/// (See class Distribution for single distributions.)
+class DistributionVector {
+ public:
   virtual ~DistributionVector();
 
   virtual Eigen::VectorXd Sample(drake::RandomGenerator* generator) const = 0;
@@ -352,7 +362,8 @@ struct DistributionVector {
 /// A single deterministic vector `value`.
 /// @tparam Size rows at compile time (max 6) or else Eigen::Dynamic.
 template <int Size>
-struct DeterministicVector final : public DistributionVector {
+class DeterministicVector final : public DistributionVector {
+ public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DeterministicVector)
 
   DeterministicVector();
@@ -374,7 +385,8 @@ struct DeterministicVector final : public DistributionVector {
 /// A gaussian distribution with vector `mean` and vector or scalar `stddev`.
 /// @tparam Size rows at compile time (max 6) or else Eigen::Dynamic.
 template <int Size>
-struct GaussianVector final : public DistributionVector {
+class GaussianVector final : public DistributionVector {
+ public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(GaussianVector)
 
   GaussianVector();
@@ -400,7 +412,8 @@ struct GaussianVector final : public DistributionVector {
 /// exclusive.
 /// @tparam Size rows at compile time (max 6) or else Eigen::Dynamic.
 template <int Size>
-struct UniformVector final : public DistributionVector {
+class UniformVector final : public DistributionVector {
+ public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(UniformVector)
 
   UniformVector();

--- a/common/schema/dev/transform.h
+++ b/common/schema/dev/transform.h
@@ -146,7 +146,8 @@ For an explanation of `!Uniform`, `!UniformVector`, and other available options
 ///
 /// For an overview of configuring stochastic transforms, see
 /// @ref schema_transform and @ref schema_stochastic.
-struct Transform {
+class Transform {
+ public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Transform)
 
   /// Constructs the Identity transform.
@@ -208,6 +209,10 @@ struct Transform {
       this->set_rotation_rpy_deg(*maybe_rpy);
     }
   }
+
+  // N.B. As is standard for classes implementing Serialize(), we declare all
+  // of our members fields as public since they are effectively so anyway, and
+  // we omit the trailing underscore from the field names.
 
   /// An optional base frame name for this transform.  When left unspecified,
   /// the default depends on the semantics of the enclosing struct.


### PR DESCRIPTION
Per discussion in #13943 for GSG.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13947)
<!-- Reviewable:end -->
