### PR TITLE
Revise Debug-mode cache value validation to avoid heap allocation.

### DIFF
--- a/common/test_utilities/limit_malloc.cc
+++ b/common/test_utilities/limit_malloc.cc
@@ -155,7 +155,8 @@ void Monitor::ObserveAllocation() {
 
   // Report an error (but re-enable malloc before doing so!).
   ActiveMonitor::reset();
-  std::cerr << "abort due to malloc while LimitMalloc is in effect";
+  std::cerr << "abort due to malloc #" << observed << " while LimitMalloc("
+            << args_.max_num_allocations << ") in effect";
   std::cerr << std::endl;
   // TODO(jwnimmer-tri) It would be nice to print a backtrace here.
   std::abort();

--- a/common/test_utilities/test/limit_malloc_test.cc
+++ b/common/test_utilities/test/limit_malloc_test.cc
@@ -74,7 +74,7 @@ TEST_P(LimitMallocTest, BasicTest) {
 }
 
 constexpr const char* const kDeathMessage =
-    "abort due to malloc while LimitMalloc is in effect";
+    "abort due to malloc #[0-9]+ while LimitMalloc\\([0-9]+\\) in effect";
 
 TEST_P(LimitMallocDeathTest, BasicTest) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";

--- a/systems/framework/cache_entry.cc
+++ b/systems/framework/cache_entry.cc
@@ -47,24 +47,19 @@ void CacheEntry::Calc(const ContextBase& context,
                       AbstractValue* value) const {
   DRAKE_DEMAND(value != nullptr);
   DRAKE_ASSERT_VOID(owning_system_->ValidateContext(context));
-  DRAKE_ASSERT_VOID(CheckValidAbstractValue(*value));
+  DRAKE_ASSERT_VOID(CheckValidAbstractValue(context, *value));
 
   calc_function_(context, value);
 }
 
-// See OutputPort::CheckValidOutputType; treat both methods similarly.
-void CacheEntry::CheckValidAbstractValue(const AbstractValue& proposed) const {
-  // TODO(sherm1) Consider whether we can depend on there already being an
-  //              object of this type in the context's CacheEntryValue so we
-  //              wouldn't have to allocate one here. If so could also store
-  //              a precomputed type_index there for further savings. Would
-  //              need to pass in a ContextBase.
-  auto good_ptr = Allocate();  // Very expensive!
-  const AbstractValue& good = *good_ptr;
-  if (proposed.type_info() != good.type_info()) {
+void CacheEntry::CheckValidAbstractValue(const ContextBase& context,
+                                         const AbstractValue& proposed) const {
+  const CacheEntryValue& cache_value = get_cache_entry_value(context);
+  const AbstractValue& value = cache_value.PeekAbstractValueOrThrow();
+  if (proposed.type_info() != value.type_info()) {
     throw std::logic_error(FormatName("Calc") +
                            "expected AbstractValue output type " +
-                           good.GetNiceTypeName() + " but got " +
+                           value.GetNiceTypeName() + " but got " +
                            proposed.GetNiceTypeName() + ".");
   }
 }

--- a/systems/framework/cache_entry.h
+++ b/systems/framework/cache_entry.h
@@ -343,8 +343,9 @@ class CacheEntry {
   }
 
   // Check that an AbstractValue provided to Calc() is suitable for this cache
-  // entry. (Very expensive; use in Debug only.)
-  void CheckValidAbstractValue(const AbstractValue& proposed) const;
+  // entry.
+  void CheckValidAbstractValue(const ContextBase& context,
+                               const AbstractValue& proposed) const;
 
   // Provides an identifying prefix for error messages.
   std::string FormatName(const char* api) const;

--- a/systems/framework/diagram_output_port.h
+++ b/systems/framework/diagram_output_port.h
@@ -112,6 +112,15 @@ class DiagramOutputPort final : public OutputPort<T> {
     return {source_subsystem_index_, source_output_port_->ticket()};
   };
 
+  // Check that an AbstractValue provided to Calc() is suitable for this port
+  // by asking the source port to do it.
+  void ThrowIfInvalidPortValueType(
+      const Context<T>& context,
+      const AbstractValue& proposed_value) const final {
+    OutputPort<T>::ThrowIfInvalidPortValueType(
+        *source_output_port_, get_subcontext(context), proposed_value);
+  }
+
   // Digs out the right subcontext for delegation.
   const Context<T>& get_subcontext(const Context<T>& diagram_context) const {
     const DiagramContext<T>* diagram_context_downcast =

--- a/systems/framework/leaf_output_port.cc
+++ b/systems/framework/leaf_output_port.cc
@@ -1,4 +1,24 @@
 #include "drake/systems/framework/leaf_output_port.h"
 
+namespace drake::systems {
+
+template <typename T>
+void LeafOutputPort<T>::ThrowIfInvalidPortValueType(
+    const Context<T>& context, const AbstractValue& proposed) const {
+  const CacheEntryValue& cache_value =
+      cache_entry().get_cache_entry_value(context);
+  const AbstractValue& value = cache_value.PeekAbstractValueOrThrow();
+
+  if (proposed.type_info() != value.type_info()) {
+    throw std::logic_error(
+        fmt::format("OutputPort::Calc(): expected output type {} "
+                    "but got {} for {}.",
+                    value.GetNiceTypeName(), proposed.GetNiceTypeName(),
+                    PortBase::GetFullDescription()));
+  }
+}
+
+}  // namespace drake::systems
+
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::LeafOutputPort)

--- a/systems/framework/leaf_output_port.h
+++ b/systems/framework/leaf_output_port.h
@@ -102,6 +102,12 @@ class LeafOutputPort final : public OutputPort<T> {
     return {std::nullopt, cache_entry().ticket()};
   };
 
+  // Check that an AbstractValue provided to Calc() is suitable for this port
+  // by comparing it with the port's cache entry value type.
+  void ThrowIfInvalidPortValueType(
+      const Context<T>& context,
+      const AbstractValue& proposed_value) const final;
+
   CacheEntry* const cache_entry_;
 };
 

--- a/systems/framework/output_port.cc
+++ b/systems/framework/output_port.cc
@@ -1,4 +1,32 @@
 #include "drake/systems/framework/output_port.h"
 
+namespace drake::systems {
+
+template<typename T>
+void OutputPort<T>::CheckValidAllocation(const AbstractValue& proposed) const {
+  if (this->get_data_type() != kVectorValued)
+    return;  // Nothing we can check for an abstract port.
+
+  auto proposed_vec = dynamic_cast<const Value<BasicVector<T>>*>(&proposed);
+  if (proposed_vec == nullptr) {
+    throw std::logic_error(
+        fmt::format("OutputPort::Allocate(): expected BasicVector output type "
+                    "but got {} for {}.",
+                    proposed.GetNiceTypeName(), GetFullDescription()));
+  }
+
+  if (this->size() == kAutoSize) return;  // Any size is acceptable.
+
+  const int proposed_size = proposed_vec->get_value().size();
+  if (proposed_size != this->size()) {
+    throw std::logic_error(
+        fmt::format("OutputPort::Allocate(): expected vector output type of "
+                    "size {} but got a vector of size {} for {}.",
+                    this->size(), proposed_size, GetFullDescription()));
+  }
+}
+
+}  // namespace drake::systems
+
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::OutputPort)

--- a/systems/framework/test/output_port_test.cc
+++ b/systems/framework/test/output_port_test.cc
@@ -73,7 +73,22 @@ class MyOutputPort : public OutputPort<double> {
   internal::OutputPortPrerequisite DoGetPrerequisite() const override {
     ADD_FAILURE() << "We won't call this.";
     return {};
-  };
+  }
+
+  void ThrowIfInvalidPortValueType(
+      const Context<double>& context,
+      const AbstractValue& proposed_value) const final {
+    // Note: this is a very expensive way to check -- fine for this test
+    // case (which has no alternative) but don't copy into real code!
+    auto good_value = Allocate();
+    if (proposed_value.type_info() != good_value->type_info()) {
+      throw std::logic_error(fmt::format(
+          "OutputPort::Calc(): expected output type {} "
+          "but got {} for {}.",
+          good_value->GetNiceTypeName(), proposed_value.GetNiceTypeName(),
+          PortBase::GetFullDescription()));
+    }
+  }
 };
 
 class MyStringAllocatorPort : public MyOutputPort {


### PR DESCRIPTION
Reworks two Debug-mode validations that were done using heap-allocated value objects for cache entries to avoid heap use.
The difference in heap allocations between Debug and Release builds made it hard to track down spurious use of the heap in MultibodyPlant, which is best done in Debug builds; this makes the Debug and Release heap use the same (and also makes the validations less expensive).

Also:
- Moves one method definition from the output_port.h header to the .cc file to follow our updated style guidelines.
- Updates cassie_bench to unconditionally limit heap allocation to zero.
- Enforces heap limits in both Release and Debug for the non-AutoDiff tests; AutoDiff allocations are still greater in Debug.
- Added counts to the LimitMalloc error message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13951)
<!-- Reviewable:end -->
