### PR TITLE
MeshcatVisualizer: Tweaks to support caching mesh geometry on the zmqserver

### DIFF
--- a/bindings/pydrake/systems/test/meshcat_visualizer_test.py
+++ b/bindings/pydrake/systems/test/meshcat_visualizer_test.py
@@ -65,10 +65,12 @@ class TestMeshcat(unittest.TestCase):
 
         # Note: pass window=None argument to confirm kwargs are passed
         # through to meshcat.Visualizer.
-        visualizer = builder.AddSystem(MeshcatVisualizer(scene_graph,
-                                                         zmq_url=ZMQ_URL,
-                                                         open_browser=False,
-                                                         window=None))
+        visualizer = builder.AddSystem(MeshcatVisualizer(
+            scene_graph,
+            zmq_url=ZMQ_URL,
+            open_browser=False,
+            window=None,
+            delete_prefix_on_load=True))
         builder.Connect(scene_graph.get_pose_bundle_output_port(),
                         visualizer.get_input_port(0))
 
@@ -101,6 +103,7 @@ class TestMeshcat(unittest.TestCase):
         visualizer.publish_recording(play=True, repetitions=1)
         visualizer.reset_recording()
         self.assertEqual(len(visualizer._animation.clips), 0)
+        visualizer.delete_prefix()
 
     def test_kuka(self):
         """Kuka IIWA with mesh geometry."""

--- a/tools/workspace/meshcat_python/repository.bzl
+++ b/tools/workspace/meshcat_python/repository.bzl
@@ -44,9 +44,9 @@ def _impl(repository_ctx):
         "rdeits/meshcat-python",
         # Updating this commit requires local testing; see
         # drake/tools/workspace/meshcat/README.md for details.
-        "c1a0702787fe651b7abaf8c243da018c8728e2f9",
+        "bc620804eceae2691b63efc906f07c5ca754f4b3",
         repository_ctx.attr.mirrors,
-        sha256 = "00b1f131b2ffc08314b7624fb313f973b8853abe48e8a5175453a19fd27d6653",  # noqa
+        sha256 = "6149f79c6ba88d91bcb11d1911276406eccd5802ef8fa441004c153131ef0a56",  # noqa
     )
 
     repository_ctx.symlink(


### PR DESCRIPTION
Adds an argument to the constructor to avoid deleting the entire tree on every run.
Sets uuids deterministically based on the mesh file so that they can be recognized as identical on the server.
See https://github.com/rdeits/meshcat-python/pull/75

This makes a *dramatic* improvement in the workflow of using meshcat on colab (at least as we use it in drake), because we don't have to repeatedly download large meshfiles from repeated simulations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13971)
<!-- Reviewable:end -->
