### PR TITLE
Update references to binder release URL

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -48,10 +48,10 @@ Core Library
         </tr>
         <tr>
             <td style="text-align:center">
-                <a target="_doc" href="https://drake.mit.edu/doxygen_cxx/group__systems.html">doc</a> | <a target="_tutorial" href="https://mybinder.org/v2/gh/RobotLocomotion/drake/nightly-release?filepath=tutorials/dynamical_systems.ipynb">tutorial</a>
+                <a target="_doc" href="https://drake.mit.edu/doxygen_cxx/group__systems.html">doc</a> | <a target="_tutorial" href="https://mybinder.org/v2/gh/RobotLocomotion/drake/nightly-release-binder?filepath=tutorials/dynamical_systems.ipynb">tutorial</a>
             </td>
             <td style="text-align:center">
-                <a target="_doc" href="https://drake.mit.edu/doxygen_cxx/group__solvers.html">doc</a> | <a target="_tutorial" href="https://mybinder.org/v2/gh/RobotLocomotion/drake/nightly-release?filepath=tutorials/mathematical_program.ipynb">tutorial</a>
+                <a target="_doc" href="https://drake.mit.edu/doxygen_cxx/group__solvers.html">doc</a> | <a target="_tutorial" href="https://mybinder.org/v2/gh/RobotLocomotion/drake/nightly-release-binder?filepath=tutorials/mathematical_program.ipynb">tutorial</a>
             </td>
             <td style="text-align:center">
                 <a target="_doc" href="https://drake.mit.edu/doxygen_cxx/group__multibody.html">doc</a>
@@ -76,7 +76,7 @@ use nbviewer to only preview the notebook (where startup time is fast):
 
 .. raw:: html
 
-    <a target="_doc" href="https://mybinder.org/v2/gh/RobotLocomotion/drake/nightly-release?filepath=tutorials">
+    <a target="_doc" href="https://mybinder.org/v2/gh/RobotLocomotion/drake/nightly-release-binder?filepath=tutorials">
       <img src="https://mybinder.org/badge_logo.svg"/>
     </a>
     <a target="_doc" href="https://nbviewer.jupyter.org/github/RobotLocomotion/drake/blob/nightly-release/tutorials/">

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -14,7 +14,7 @@ Binder:
 
 .. raw:: html
 
-    <a target="_doc" href="https://mybinder.org/v2/gh/RobotLocomotion/drake/nightly-release?filepath=tutorials">
+    <a target="_doc" href="https://mybinder.org/v2/gh/RobotLocomotion/drake/nightly-release-binder?filepath=tutorials">
       <img src="https://mybinder.org/badge_logo.svg"/>
     </a>
 

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -20,16 +20,16 @@ bazel run //tutorials:mathematical_program
 The notebooks in this folder can be run and quickly viewed online using
 [Binder](https://mybinder.org) and [nbviewer](https://nbviewer.jupyter.org/).
 
-To run or quickly view them from the Drake `nightly-release` branch on GitHub:
+To run or quickly view them from the Drake `nightly-release-binder` branch on GitHub:
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/RobotLocomotion/drake/nightly-release?filepath=tutorials)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/RobotLocomotion/drake/nightly-release-binder?filepath=tutorials)
 [![nbviewer](https://img.shields.io/badge/view%20on-nbviewer-brightgreen.svg)](https://nbviewer.jupyter.org/github/RobotLocomotion/drake/blob/nightly-release/tutorials/)
 
 Since Binder uses the `robotlocomotion/drake:latest` image on
 [Docker Hub](https://hub.docker.com/r/robotlocomotion/drake) that is published
-once a day from the `nightly-release` branch, it may be missing features used by
-notebooks on `master`. These will be available the next day when the
-`nightly-release` branch is automatically updated.
+once a day from the `nightly-release-binder` branch, it may be missing features
+used by notebooks on `master`. These will be available the next day when the
+`nightly-release-binder` branch is automatically updated.
 
 If you are looking to browse among the notebooks with minimal wait time,
 nbviewer is highly recommended, as you can also launch Binder directly from
@@ -59,6 +59,6 @@ For the pull request that adds the notebook(s), please include a `nbviewer`
 link to the directory on your fork and branch, e.g.,
 `https://nbviewer.jupyter.org/github/{user}/drake/blob/{branch}/tutorials/`
 
-If appropriate, add a Binder link to the notebook (in the `nightly-release`
+If appropriate, add a Binder link to the notebook (in the `nightly-release-binder`
 branch) in the relevant documentation in `/doc`, e.g.,
-`https://mybinder.org/v2/gh/RobotLocomotion/drake/nightly-release?filepath=tutorials/{notebook}.ipynb`
+`https://mybinder.org/v2/gh/RobotLocomotion/drake/nightly-release-binder?filepath=tutorials/{notebook}.ipynb`


### PR DESCRIPTION
Update URLs in drake from
`https://mybinder.org/v2/gh/RobotLocomotion/drake/nightly-release` to
`https://mybinder.org/v2/gh/RobotLocomotion/drake/nightly-release-binder`.

Drake-ci pull request [#115](https://github.com/RobotLocomotion/drake-ci/pull/115)

Resolves #13209

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13979)
<!-- Reviewable:end -->
