### PR TITLE
framework: Deprecate kAutoSize

### DIFF
--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -51,8 +51,6 @@ void DefineFrameworkPySemantics(py::module m) {
   using namespace drake::systems;
   constexpr auto& doc = pydrake_doc.drake.systems;
 
-  m.attr("kAutoSize") = kAutoSize;
-
   py::class_<UseDefaultName> use_default_name_cls(
       m, "UseDefaultName", doc.UseDefaultName.doc);
   m.attr("kUseDefaultName") = kUseDefaultName;

--- a/systems/framework/framework_common.h
+++ b/systems/framework/framework_common.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/identifier.h"
 #include "drake/common/type_safe_index.h"
 #include "drake/common/value.h"
@@ -74,9 +75,10 @@ typedef enum {
   kAbstractValued = 1,
 } PortDataType;
 
-// TODO(sherm1) Implement this.
 /** Port type indicating a vector value whose size is not prespecified but
 rather depends on what it is connected to (not yet implemented). */
+DRAKE_DEPRECATED("2020-12-01",
+    "AutoSize was never implemented; the putative support is being removed.")
 constexpr int kAutoSize = -1;
 
 /** (Advanced.)  Tag type that indicates a system or port should use a default

--- a/systems/framework/input_port_base.h
+++ b/systems/framework/input_port_base.h
@@ -66,8 +66,8 @@ class InputPortBase : public PortBase {
   @param data_type
     Whether the port described is vector- or abstract-valued.
   @param size
-    If the port described is vector-valued, the number of elements, or kAutoSize
-    if determined by connections. Ignored for abstract-valued ports.
+    If the port described is vector-valued, the number of elements. Ignored for
+    abstract-valued ports.
   @param random_type
     Input ports may optionally be labeled as random, if the port is intended to
     model a random-source "noise" or "disturbance" input. */

--- a/systems/framework/output_port.cc
+++ b/systems/framework/output_port.cc
@@ -15,8 +15,6 @@ void OutputPort<T>::CheckValidAllocation(const AbstractValue& proposed) const {
                     proposed.GetNiceTypeName(), GetFullDescription()));
   }
 
-  if (this->size() == kAutoSize) return;  // Any size is acceptable.
-
   const int proposed_size = proposed_vec->get_value().size();
   if (proposed_size != this->size()) {
     throw std::logic_error(

--- a/systems/framework/port_base.cc
+++ b/systems/framework/port_base.cc
@@ -24,9 +24,13 @@ PortBase::PortBase(
   DRAKE_DEMAND(kind_string != nullptr);
   DRAKE_DEMAND(owning_system != nullptr);
   DRAKE_DEMAND(!name_.empty());
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   if (size_ == kAutoSize) {
-    throw std::domain_error("Auto-size ports are not yet implemented.");
+    throw std::domain_error(
+        "Auto-size ports are deprecated and unimplemented.");
   }
+#pragma GCC diagnostic pop
 }
 
 PortBase::~PortBase() = default;

--- a/systems/framework/port_base.h
+++ b/systems/framework/port_base.h
@@ -65,8 +65,8 @@ class PortBase {
   @param data_type
     Whether the port described is vector- or abstract-valued.
   @param size
-    If the port described is vector-valued, the number of elements, or kAutoSize
-    if determined by connections. Ignored for abstract-valued ports.
+    If the port described is vector-valued, the number of elements. Ignored for
+    abstract-valued ports.
   */
   PortBase(
       const char* kind_string, internal::SystemMessageInterface* owning_system,


### PR DESCRIPTION
The mention of an unimplemented feature is a distraction for users.

In pydrake, remove it immediately.  (As of Python 3.6, there is no official support for deprecating attributes; it's new as of 3.7.) This is a breaking change.

Closes #3109.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13981)
<!-- Reviewable:end -->
