### PR TITLE
Separate out dependencies related to documentation generation

### DIFF
--- a/setup/BUILD.bazel
+++ b/setup/BUILD.bazel
@@ -8,18 +8,24 @@ package(default_visibility = ["//visibility:public"])
 # Make our package requirements (but not manual scripts) available to
 # downstream projects.
 exports_files([
-    "ubuntu/source_distribution/packages-bionic-maintainer-only.txt",
-    "ubuntu/source_distribution/packages-bionic-test-only.txt",
-    "ubuntu/source_distribution/packages-bionic.txt",
-    "ubuntu/source_distribution/packages-focal-maintainer-only.txt",
-    "ubuntu/source_distribution/packages-focal-test-only.txt",
-    "ubuntu/source_distribution/packages-focal.txt",
+    "mac/binary_distribution/Brewfile",
+    "mac/binary_distribution/requirements.txt",
+    "mac/source_distribution/Brewfile",
+    "mac/source_distribution/Brewfile-doc-only",
+    "mac/source_distribution/Brewfile-maintainer-only",
+    "mac/source_distribution/requirements.txt",
+    "mac/source_distribution/requirements-maintainer-only.txt",
+    "mac/source_distribution/requirements-test-only.txt",
     "ubuntu/binary_distribution/packages-bionic.txt",
     "ubuntu/binary_distribution/packages-focal.txt",
-    "mac/source_distribution/requirements.txt",
-    "mac/source_distribution/Brewfile",
-    "mac/binary_distribution/requirements.txt",
-    "mac/binary_distribution/Brewfile",
+    "ubuntu/source_distribution/packages-bionic.txt",
+    "ubuntu/source_distribution/packages-bionic-doc-only.txt",
+    "ubuntu/source_distribution/packages-bionic-maintainer-only.txt",
+    "ubuntu/source_distribution/packages-bionic-test-only.txt",
+    "ubuntu/source_distribution/packages-focal.txt",
+    "ubuntu/source_distribution/packages-focal-doc-only.txt",
+    "ubuntu/source_distribution/packages-focal-maintainer-only.txt",
+    "ubuntu/source_distribution/packages-focal-test-only.txt",
 ])
 
 install_files(

--- a/setup/mac/install_prereqs.sh
+++ b/setup/mac/install_prereqs.sh
@@ -14,9 +14,15 @@ while [ "${1:-}" != "" ]; do
     --with-maintainer-only)
       source_distribution_args+=(--with-maintainer-only)
       ;;
+    # Do NOT install prerequisites that are only needed to build documentation,
+    # i.e., those prerequisites that are dependencies of bazel { build, run }
+    # { //doc:gen_sphinx, //bindings/pydrake/doc:gen_sphinx, //doc:doxygen }
+    --without-doc-only)
+      source_distribution_args+=(--without-doc-only)
+      ;;
     # Do NOT install prerequisites that are only needed to build and/or run
     # unit tests, i.e., those prerequisites that are not dependencies of
-    # bazel build //:install and/or bazel run //:install.
+    # bazel { build, run } //:install.
     --without-test-only)
       source_distribution_args+=(--without-test-only)
       ;;

--- a/setup/mac/source_distribution/Brewfile
+++ b/setup/mac/source_distribution/Brewfile
@@ -1,12 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-tap 'homebrew/cask-fonts' unless File.exist? '/Library/Fonts/DejaVuSans.ttf'
 tap 'robotlocomotion/director'
-
-cask 'font-dejavu' unless File.exist? '/Library/Fonts/DejaVuSans.ttf'
 
 brew 'bazel'
 brew 'robotlocomotion/director/clang-format@9'
-brew 'doxygen'
-brew 'robotlocomotion/director/sphinx-doc@1.8'

--- a/setup/mac/source_distribution/Brewfile-doc-only
+++ b/setup/mac/source_distribution/Brewfile-doc-only
@@ -1,0 +1,10 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+tap 'homebrew/cask-fonts' unless File.exist? '/Library/Fonts/DejaVuSans.ttf'
+tap 'robotlocomotion/director'
+
+cask 'font-dejavu' unless File.exist? '/Library/Fonts/DejaVuSans.ttf'
+
+brew 'doxygen'
+brew 'robotlocomotion/director/sphinx-doc@1.8'

--- a/setup/ubuntu/install_prereqs.sh
+++ b/setup/ubuntu/install_prereqs.sh
@@ -30,9 +30,15 @@ while [ "${1:-}" != "" ]; do
     --with-maintainer-only)
       source_distribution_args+=(--with-maintainer-only)
       ;;
+    # Do NOT install prerequisites that are only needed to build documentation,
+    # i.e., those prerequisites that are dependencies of bazel { build, run }
+    # { //doc:gen_sphinx, //bindings/pydrake/doc:gen_sphinx, //doc:doxygen }
+    --without-doc-only)
+      source_distribution_args+=(--without-doc-only)
+      ;;
     # Do NOT install prerequisites that are only needed to build and/or run
     # unit tests, i.e., those prerequisites that are not dependencies of
-    # bazel build //:install and/or bazel run //:install.
+    # bazel { build, run } //:install.
     --without-test-only)
       source_distribution_args+=(--without-test-only)
       ;;

--- a/setup/ubuntu/source_distribution/install_prereqs.sh
+++ b/setup/ubuntu/source_distribution/install_prereqs.sh
@@ -8,6 +8,7 @@
 
 set -euo pipefail
 
+with_doc_only=1
 with_kcov=0
 with_maintainer_only=0
 with_test_only=1
@@ -26,9 +27,15 @@ while [ "${1:-}" != "" ]; do
     --with-maintainer-only)
       with_maintainer_only=1
       ;;
+    # Do NOT install prerequisites that are only needed to build documentation,
+    # i.e., those prerequisites that are dependencies of bazel { build, run }
+    # { //doc:gen_sphinx, //bindings/pydrake/doc:gen_sphinx, //doc:doxygen }
+    --without-doc-only)
+      with_doc_only=0
+      ;;
     # Do NOT install prerequisites that are only needed to build and/or run
     # unit tests, i.e., those prerequisites that are not dependencies of
-    # bazel build //:install and/or bazel run //:install.
+    # bazel { build, run } //:install.
     --without-test-only)
       with_test_only=0
       ;;
@@ -67,6 +74,9 @@ apt-get update
 apt-get install --no-install-recommends \
   $(cat "${BASH_SOURCE%/*}/packages-${codename}.txt")
 
+# Ensure that we have available a locale that supports UTF-8 for generating a
+# C++ header containing Python API documentation during the build.
+apt-get install --no-install-recommends locales
 locale-gen en_US.UTF-8
 
 if [[ "${codename}" == 'focal' ]]; then
@@ -77,6 +87,11 @@ if [[ "${codename}" == 'focal' ]]; then
   else
     echo "/usr/bin/python is already installed"
   fi
+fi
+
+if [[ "${with_doc_only}" -eq 1 ]]; then
+  apt-get install --no-install-recommends \
+    $(cat "${BASH_SOURCE%/*}/packages-${codename}-doc-only.txt")
 fi
 
 if [[ "${with_test_only}" -eq 1 ]]; then

--- a/setup/ubuntu/source_distribution/install_prereqs.sh
+++ b/setup/ubuntu/source_distribution/install_prereqs.sh
@@ -145,7 +145,15 @@ dpkg_install_from_wget() {
   rm "${tmpdeb}"
 }
 
-# Depends: g++, unzip, zlib1g-dev
+# Install bazel package dependencies (these may duplicate dependencies of
+# drake).
+apt-get install --no-install-recommends $(cat <<EOF
+g++
+unzip
+zlib1g-dev
+EOF
+)
+
 dpkg_install_from_wget \
   bazel 3.4.1 \
   https://releases.bazel.build/3.4.1/release/bazel_3.4.1-linux-x86_64.deb \

--- a/setup/ubuntu/source_distribution/packages-bionic-doc-only.txt
+++ b/setup/ubuntu/source_distribution/packages-bionic-doc-only.txt
@@ -1,0 +1,6 @@
+fonts-dejavu-core
+fonts-dejavu-extra
+graphviz
+python3-docutils
+python3-sphinx
+python3-sphinx-rtd-theme

--- a/setup/ubuntu/source_distribution/packages-bionic.txt
+++ b/setup/ubuntu/source_distribution/packages-bionic.txt
@@ -5,11 +5,8 @@ coinor-libcoinutils-dev
 coinor-libipopt-dev
 default-jdk
 file
-fonts-dejavu-core
-fonts-dejavu-extra
 gfortran
 git
-graphviz
 libblas-dev
 libbz2-dev
 libclang-9-dev
@@ -30,14 +27,9 @@ libtiff5-dev
 libtinyxml-dev
 libtool
 libx11-dev
-locales
 openssh-client
 patch
 patchelf
 pkg-config
 python3-all-dev
-python3-docutils
-python3-sphinx
-python3-sphinx-rtd-theme
-unzip
 zlib1g-dev

--- a/setup/ubuntu/source_distribution/packages-focal-doc-only.txt
+++ b/setup/ubuntu/source_distribution/packages-focal-doc-only.txt
@@ -1,0 +1,6 @@
+fonts-dejavu-core
+fonts-dejavu-extra
+graphviz
+python3-docutils
+python3-sphinx
+python3-sphinx-rtd-theme

--- a/setup/ubuntu/source_distribution/packages-focal.txt
+++ b/setup/ubuntu/source_distribution/packages-focal.txt
@@ -5,11 +5,8 @@ coinor-libcoinutils-dev
 coinor-libipopt-dev
 default-jdk
 file
-fonts-dejavu-core
-fonts-dejavu-extra
 gfortran
 git
-graphviz
 libblas-dev
 libbz2-dev
 libclang-9-dev
@@ -32,14 +29,9 @@ libtiff-dev
 libtinyxml-dev
 libtool
 libx11-dev
-locales
 openssh-client
 patch
 patchelf
 pkg-config
 python3-all-dev
-python3-docutils
-python3-sphinx
-python3-sphinx-rtd-theme
-unzip
 zlib1g-dev


### PR DESCRIPTION
Relates #12783 and #13168. In two minds about whether to add the `--without-doc-only` flag, but it is here in this PR will can be tested during the CMake and/or packaging builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13984)
<!-- Reviewable:end -->
