### PR TITLE
Geometry world pose as up to date as possible after Registration

### DIFF
--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -21,6 +21,7 @@
 namespace drake {
 namespace geometry {
 
+using internal::convert_to_double;
 using internal::GeometryStateCollisionFilterAttorney;
 using internal::InternalFrame;
 using internal::InternalGeometry;
@@ -558,7 +559,7 @@ GeometryId GeometryState<T>::RegisterGeometry(
 
   // pose() is always RigidTransform<double>. To account for
   // GeometryState<AutoDiff>, we need to cast it to the common type T.
-  X_WGs_[geometry_id] = geometry->pose().cast<T>();
+  X_WGs_[geometry_id] = X_WF_[frame.index()] * geometry->pose().cast<T>();
 
   geometries_.emplace(
       geometry_id,
@@ -672,7 +673,9 @@ void GeometryState<T>::AssignRole(SourceId source_id, GeometryId geometry_id,
       geometry.SetRole(std::move(properties));
       if (geometry.is_dynamic()) {
         // Pass the geometry to the engine.
-        geometry_engine_->AddDynamicGeometry(geometry.shape(), geometry_id,
+        const RigidTransformd& X_WG = convert_to_double(X_WGs_.at(geometry_id));
+        geometry_engine_->AddDynamicGeometry(geometry.shape(), X_WG,
+                                             geometry_id,
                                              *geometry.proximity_properties());
 
         InternalFrame& frame = frames_[geometry.frame_id()];
@@ -758,13 +761,14 @@ void GeometryState<T>::AssignRole(SourceId source_id, GeometryId geometry_id,
 
   geometry.SetRole(std::move(properties));
 
+  const RigidTransformd& X_WG = convert_to_double(X_WGs_.at(geometry_id));
   bool added_to_renderer{false};
   for (auto& [name, engine] : render_engines_) {
     if (accepting_renderers.empty() || accepting_renderers.count(name) > 0) {
       added_to_renderer =
           engine->RegisterVisual(
               geometry_id, geometry.shape(), *geometry.perception_properties(),
-              RigidTransformd(geometry.X_FG()), geometry.is_dynamic()) ||
+              X_WG, geometry.is_dynamic()) ||
           added_to_renderer;
     }
   }

--- a/geometry/proximity_engine.h
+++ b/geometry/proximity_engine.h
@@ -90,11 +90,12 @@ class ProximityEngine {
 
   /* Adds the given `shape` to the engine's _dynamic_ geometry.
    @param shape   The shape to add.
+   @param X_WG    The pose of the shape in the world frame.
    @param id      The id of the geometry in SceneGraph to which this shape
                   belongs.
    @param props   The proximity properties for the shape.  */
-  void AddDynamicGeometry(const Shape& shape, GeometryId id,
-                          const ProximityProperties& props = {});
+  void AddDynamicGeometry(const Shape& shape, const math::RigidTransformd& X_WG,
+                          GeometryId id, const ProximityProperties& props = {});
 
   /* Adds the given `shape` to the engine's _anchored_ geometry.
    @param shape   The shape to add.


### PR DESCRIPTION
Geometry world pose as up to date as possible after Registration

Prior to this, the world pose of the geometry was ignored upon registration. It was assumed that any query that depended on geometry world pose would be preceded by a call that updates the frames' poses.

However, it is possible to
  - Update frame poses
  - Add a geometry
  - perform a query

In that case, the added geometry will not have the correct world pose.

This change stores a value for X_WG based on the assumption that X_WF is meaningful. If the assumption is correct, X_WG will likewise be meaningful. If the assumption is wrong, we are not harmed.

Furthermore, for the queries (e.g., illustration, perception, and proximity) to work, those values need to propagate downwards. Work for proximity and perception has been done. The illustration role has no further copies of the pose beyond that in `GeometryState`.

Resolves #13989

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13990)
<!-- Reviewable:end -->
