### PR TITLE
Tidy up nits on schema classes

### DIFF
--- a/common/name_value.h
+++ b/common/name_value.h
@@ -3,6 +3,50 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 
+/** @addtogroup technical_notes
+@{
+@defgroup serialize_tips Writing a Serialize method
+
+Structured data sometimes provides a Serialize method to be compatible with a
+variety of readers, writers, or any other code that needs to visit the data
+generically.
+
+Here is an example of implementing a Serialize method:
+@code
+struct DoubleStruct {
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(value));
+  }
+
+  double value{0.0};
+};
+@endcode
+
+By convention, we place the Serialize method prior to the data members per
+<a href="https://drake.mit.edu/styleguide/cppguide.html#Declaration_Order">the
+styleguide rule</a>.  Each data member has a matching `Visit` line in the
+Serialize method, in the same order as the member fields appear.
+
+By convention, we declare all of the member fields as public, since they are
+effectively so anyway (because anything that calls the Serialize method
+receives a mutable pointer to them).  The typical way to do this is to declare
+the data as a `struct`, instead of a `class`.
+
+However, if
+<a href="https://drake.mit.edu/styleguide/cppguide.html#Structs_vs._Classes">the
+styleguide rule</a> for struct vs class points towards using a `class` instead,
+then we follow that advice and make it a `class`, but we explicitly label the
+member fields as `public`.  We also omit the trailing underscore from the field
+names, so that the Serialize API presented to the caller of the class is
+indifferent to whether it is phrased as a `struct` or a `class`.
+
+For how Serialize and Archive interact, see the drake::yaml::YamlReadArchive
+class overview.
+
+@}
+*/
+
 namespace drake {
 
 /// A basic implementation of the Name-Value Pair concept as used in the

--- a/common/schema/rotation.h
+++ b/common/schema/rotation.h
@@ -19,6 +19,9 @@ namespace schema {
 ///
 /// For an overview of configuring stochastic transforms, see
 /// @ref schema_transform and @ref schema_stochastic.
+///
+/// See @ref serialize_tips for implementation details, especially the
+/// unusually public member fields.
 class Rotation {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Rotation)
@@ -100,10 +103,6 @@ class Rotation {
   void Serialize(Archive* a) {
     a->Visit(DRAKE_NVP(value));
   }
-
-  // N.B. As is standard for classes implementing Serialize(), we declare all
-  // of our members fields as public since they are effectively so anyway, and
-  // we omit the trailing underscore from the field names.
 
   using Variant = std::variant<Identity, Rpy, AngleAxis, Uniform>;
   Variant value;

--- a/common/schema/stochastic.h
+++ b/common/schema/stochastic.h
@@ -195,12 +195,11 @@ rotations, translations, and transforms using stochastic schemas.
 
 @} */
 
-// N.B. As is standard for classes implementing Serialize(), below we always
-// declare all of our members fields as public since they are effectively so
-// anyway, and we omit the trailing underscore from the field names.
-
 /// Base class for a single distribution, to be used with YAML archives.
 /// (See class DistributionVector for vector-valued distributions.)
+///
+/// See @ref serialize_tips for implementation details, especially the
+/// unusually public member fields in our subclasses.
 class Distribution {
  public:
   virtual ~Distribution();
@@ -346,6 +345,9 @@ double GetDeterministicValue(const DistributionVariant& var);
 
 /// Base class for a vector of distributions, to be used with YAML archives.
 /// (See class Distribution for scalar-valued distributions.)
+///
+/// See @ref serialize_tips for implementation details, especially the
+/// unusually public member fields in our subclasses.
 class DistributionVector {
  public:
   virtual ~DistributionVector();

--- a/common/schema/test/rotation_test.cc
+++ b/common/schema/test/rotation_test.cc
@@ -15,10 +15,6 @@ using drake::math::RollPitchYawd;
 using drake::yaml::YamlReadArchive;
 using drake::yaml::YamlWriteArchive;
 
-// TODO(jeremy.nimmer) We can remove this argument from the call sites below
-// once Drake's YamlReadArchive constructor default changes to be strict.
-constexpr YamlReadArchive::Options kStrict;
-
 GTEST_TEST(RotationTest, ConstructorDefault) {
   Rotation rotation;
   EXPECT_TRUE(std::holds_alternative<Rotation::Identity>(rotation.value));
@@ -45,11 +41,11 @@ GTEST_TEST(RotationTest, ConstructorRpy) {
 }
 
 GTEST_TEST(RotationTest, Rpy) {
-  constexpr const char* const yaml_data = R"R(
+  constexpr const char* const yaml_data = R"""(
   value: !Rpy { deg: [10., 20., 30.] }
-  )R";
+  )""";
   Rotation rotation;
-  YamlReadArchive(YAML::Load(yaml_data), kStrict).Accept(&rotation);
+  YamlReadArchive(YAML::Load(yaml_data)).Accept(&rotation);
   ASSERT_TRUE(rotation.IsDeterministic());
   const RollPitchYawd rpy(rotation.GetDeterministicValue());
   const Vector3d actual = rpy.vector() * 180 / M_PI;
@@ -58,11 +54,11 @@ GTEST_TEST(RotationTest, Rpy) {
 }
 
 GTEST_TEST(RotationTest, AngleAxis) {
-  constexpr const char* const yaml_data = R"R(
+  constexpr const char* const yaml_data = R"""(
   value: !AngleAxis { angle_deg: 10.0, axis: [0, 1, 0] }
-  )R";
+  )""";
   Rotation rotation;
-  YamlReadArchive(YAML::Load(yaml_data), kStrict).Accept(&rotation);
+  YamlReadArchive(YAML::Load(yaml_data)).Accept(&rotation);
   ASSERT_TRUE(rotation.IsDeterministic());
   const Eigen::AngleAxis<double> actual =
       rotation.GetDeterministicValue().ToAngleAxis();
@@ -72,21 +68,21 @@ GTEST_TEST(RotationTest, AngleAxis) {
 }
 
 GTEST_TEST(RotationTest, Uniform) {
-  constexpr const char* const yaml_data = R"R(
+  constexpr const char* const yaml_data = R"""(
   value: !Uniform {}
-  )R";
+  )""";
   Rotation rotation;
-  YamlReadArchive(YAML::Load(yaml_data), kStrict).Accept(&rotation);
+  YamlReadArchive(YAML::Load(yaml_data)).Accept(&rotation);
   EXPECT_FALSE(rotation.IsDeterministic());
   EXPECT_NO_THROW(rotation.ToSymbolic());
 }
 
 GTEST_TEST(RotationTest, RpyUniform) {
-  constexpr const char* const yaml_data = R"R(
+  constexpr const char* const yaml_data = R"""(
   value: !Rpy { deg: !UniformVector { min: [0, 10, 20], max: [30, 40, 50] } }
-  )R";
+  )""";
   Rotation rotation;
-  YamlReadArchive(YAML::Load(yaml_data), kStrict).Accept(&rotation);
+  YamlReadArchive(YAML::Load(yaml_data)).Accept(&rotation);
   EXPECT_FALSE(rotation.IsDeterministic());
   // We trust stochastic_test.cc to check that stochastic.h parsed the ranges
   // correctly, and so do not verify them further here.

--- a/common/schema/test/stochastic_test.cc
+++ b/common/schema/test/stochastic_test.cc
@@ -20,10 +20,6 @@ namespace drake {
 namespace schema {
 namespace {
 
-// TODO(jeremy.nimmer) We can remove this argument from the call sites below
-// once Drake's YamlReadArchive constructor default changes to be strict.
-constexpr YamlReadArchive::Options kStrict;
-
 struct DistributionStruct {
   std::vector<DistributionVariant> vec;
 
@@ -71,7 +67,7 @@ void CheckUniformDiscreteSymbolic(
 
 GTEST_TEST(StochasticTest, ScalarTest) {
   DistributionStruct variants;
-  YamlReadArchive(YAML::Load(all_variants), kStrict).Accept(&variants);
+  YamlReadArchive(YAML::Load(all_variants)).Accept(&variants);
 
   RandomGenerator generator;
 
@@ -151,7 +147,7 @@ GTEST_TEST(StochasticTest, ScalarTest) {
   EXPECT_PRED2(ExprEqual, symbolic_vec(4), 3.2);
 
   // Try loading a value which looks like an ordinary vector.
-  YamlReadArchive(YAML::Load(floats), kStrict).Accept(&variants);
+  YamlReadArchive(YAML::Load(floats)).Accept(&variants);
   vec = Sample(variants.vec, &generator);
   ASSERT_EQ(vec.size(), 3);
   EXPECT_TRUE(CompareMatrices(vec, Eigen::Vector3d(5.0, 6.1, 7.2)));
@@ -193,7 +189,7 @@ uniform_scalar: !Uniform { min: 1, max: 2 }
 
 GTEST_TEST(StochasticTest, VectorTest) {
   DistributionVectorStruct variants;
-  YamlReadArchive(YAML::Load(vector_variants), kStrict).Accept(&variants);
+  YamlReadArchive(YAML::Load(vector_variants)).Accept(&variants);
 
   RandomGenerator generator;
 
@@ -364,7 +360,7 @@ value: !Deterministic { value: 2.0 }
 )""";
   FixedSize2 parsed;
   DRAKE_EXPECT_THROWS_MESSAGE(
-      YamlReadArchive(YAML::Load(input), kStrict).Accept(&parsed),
+      YamlReadArchive(YAML::Load(input)).Accept(&parsed),
       std::exception,
       ".*unsupported type tag !Deterministic while selecting a variant<> entry"
       " for std::variant<.*> value.*");

--- a/common/schema/test/transform_test.cc
+++ b/common/schema/test/transform_test.cc
@@ -13,20 +13,15 @@ namespace drake {
 namespace schema {
 namespace {
 
-// TODO(jeremy.nimmer) We can remove this argument from the call sites below
-// once Drake's YamlReadArchive constructor default changes to be strict.
-constexpr YamlReadArchive::Options kStrict;
-
-// TODO(jwnimmer-tri) Change use R""" per Drake GSG, throughout this file.
-const char* deterministic = R"R(
+const char* deterministic = R"""(
 base_frame: foo
 translation: [1., 2., 3.]
 rotation: !Rpy { deg: [10, 20, 30] }
-)R";
+)""";
 
 GTEST_TEST(DeterministicTest, TransformTest) {
   Transform transform;
-  YamlReadArchive(YAML::Load(deterministic), kStrict).Accept(&transform);
+  YamlReadArchive(YAML::Load(deterministic)).Accept(&transform);
 
   EXPECT_EQ(*transform.base_frame, "foo");
 
@@ -42,14 +37,14 @@ GTEST_TEST(DeterministicTest, TransformTest) {
       expected.GetAsMatrix34()));
 }
 
-const char* deprecated_rpy = R"R(
+const char* deprecated_rpy = R"""(
 translation: [1., 2., 3.]
 rotation_rpy_deg: [10., 20., 30.]
-)R";
+)""";
 
 GTEST_TEST(DeprecatedDeterministicTest, TransformTest) {
   Transform transform;
-  YamlReadArchive(YAML::Load(deprecated_rpy), kStrict).Accept(&transform);
+  YamlReadArchive(YAML::Load(deprecated_rpy)).Accept(&transform);
 
   drake::math::RigidTransformd expected(
       drake::math::RollPitchYawd(
@@ -63,15 +58,15 @@ GTEST_TEST(DeprecatedDeterministicTest, TransformTest) {
       expected.GetAsMatrix34()));
 }
 
-const char* random = R"R(
+const char* random = R"""(
 base_frame: bar
 translation: !UniformVector { min: [1., 2., 3.], max: [4., 5., 6.] }
 rotation: !Uniform {}
-)R";
+)""";
 
 GTEST_TEST(StochasticTest, TransformTest) {
   Transform transform;
-  YamlReadArchive(YAML::Load(random), kStrict).Accept(&transform);
+  YamlReadArchive(YAML::Load(random)).Accept(&transform);
 
   EXPECT_EQ(*transform.base_frame, "bar");
   EXPECT_FALSE(IsDeterministic(transform.translation));
@@ -82,18 +77,18 @@ GTEST_TEST(StochasticTest, TransformTest) {
       Eigen::Vector3d(2.5, 3.5, 4.5)));
 }
 
-const char* random_bounded = R"R(
+const char* random_bounded = R"""(
 base_frame: baz
 translation: !UniformVector { min: [1., 2., 3.], max: [4., 5., 6.] }
 rotation: !Rpy
   deg: !UniformVector
     min: [380, -0.25, -1.]
     max: [400,  0.25,  1.]
-)R";
+)""";
 
 GTEST_TEST(StochasticSampleTest, TransformTest) {
   Transform transform;
-  YamlReadArchive(YAML::Load(random_bounded), kStrict).Accept(&transform);
+  YamlReadArchive(YAML::Load(random_bounded)).Accept(&transform);
   drake::RandomGenerator generator(0);
   drake::math::RigidTransformd sampled_transform = transform.Sample(&generator);
 

--- a/common/schema/transform.h
+++ b/common/schema/transform.h
@@ -146,6 +146,9 @@ For an explanation of `!Uniform`, `!UniformVector`, and other available options
 ///
 /// For an overview of configuring stochastic transforms, see
 /// @ref schema_transform and @ref schema_stochastic.
+///
+/// See @ref serialize_tips for implementation details, especially the
+/// unusually public member fields.
 class Transform {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Transform)
@@ -209,10 +212,6 @@ class Transform {
       this->set_rotation_rpy_deg(*maybe_rpy);
     }
   }
-
-  // N.B. As is standard for classes implementing Serialize(), we declare all
-  // of our members fields as public since they are effectively so anyway, and
-  // we omit the trailing underscore from the field names.
 
   /// An optional base frame name for this transform.  When left unspecified,
   /// the default depends on the semantics of the enclosing struct.


### PR DESCRIPTION
In #13943 and #13949 there were some clean-ups suggested.  This realizes those requests.

Commits are separate for review, but will be squashed before merging.

Closes #13251.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13991)
<!-- Reviewable:end -->
