### PR TITLE
pydrake multibody: Add bindings for MultibodyPlant geometry accessors

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -656,6 +656,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("body"), py::arg("X_BG"), py::arg("shape"), py::arg("name"),
             py::arg("diffuse_color"), py::arg("scene_graph") = nullptr,
             doc_iso3_deprecation)
+        .def("GetVisualGeometriesForBody", &Class::GetVisualGeometriesForBody,
+            py::arg("body"), cls_doc.GetVisualGeometriesForBody.doc)
         .def("RegisterCollisionGeometry",
             py::overload_cast<const Body<T>&, const RigidTransform<double>&,
                 const geometry::Shape&, const std::string&,

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -189,6 +189,7 @@ class TestPlant(unittest.TestCase):
             plant.RegisterVisualGeometry(
                 body=body, X_BG=body_X_BG, shape=box, name="new_body_visual",
                 diffuse_color=[1., 0.64, 0.0, 0.5])
+            self.assertGreater(len(plant.GetVisualGeometriesForBody(body)), 0)
             plant.RegisterCollisionGeometry(
                 body=body, X_BG=body_X_BG, shape=box,
                 name="new_body_collision", coulomb_friction=body_friction)


### PR DESCRIPTION
Adds missing bindings to enable setting the transparency of bodies after parsing.

Closes #13970.