### PR TITLE
[geometry] API to get a frame's geometries

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -201,6 +201,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.GetSourceName.doc)
         .def("GetFrameId", &Class::GetFrameId, py::arg("geometry_id"),
             cls_doc.GetFrameId.doc)
+        .def("GetGeometries", &Class::GetGeometries, py::arg("frame_id"),
+            py::arg("role") = std::nullopt, cls_doc.GetGeometries.doc)
         .def("GetGeometryIdByName", &Class::GetGeometryIdByName,
             py::arg("frame_id"), py::arg("role"), py::arg("name"),
             cls_doc.GetGeometryIdByName.doc)

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -49,15 +49,18 @@ class TestGeometry(unittest.TestCase):
         global_geometry = scene_graph.RegisterGeometry(
             source_id=global_source, frame_id=global_frame,
             geometry=mut.GeometryInstance(X_PG=RigidTransform_[float](),
-                                          shape=mut.Sphere(1.), name="sphere"))
+                                          shape=mut.Sphere(1.),
+                                          name="sphere1"))
         global_geometry_2 = scene_graph.RegisterGeometry(
             source_id=global_source, geometry_id=global_geometry,
             geometry=mut.GeometryInstance(X_PG=RigidTransform_[float](),
-                                          shape=mut.Sphere(1.), name="sphere"))
+                                          shape=mut.Sphere(1.),
+                                          name="sphere2"))
         anchored_geometry = scene_graph.RegisterAnchoredGeometry(
             source_id=global_source,
             geometry=mut.GeometryInstance(X_PG=RigidTransform_[float](),
-                                          shape=mut.Sphere(1.), name="sphere"))
+                                          shape=mut.Sphere(1.),
+                                          name="sphere3"))
         self.assertIsInstance(
             scene_graph.get_source_pose_port(global_source), InputPort)
         self.assertIsInstance(
@@ -74,19 +77,34 @@ class TestGeometry(unittest.TestCase):
 
         # Test SceneGraphInspector API
         inspector = scene_graph.model_inspector()
-        self.assertEqual(inspector.num_frames(), 3)
         self.assertEqual(inspector.num_sources(), 2)
+        self.assertEqual(inspector.num_frames(), 3)
         self.assertEqual(inspector.num_geometries(), 3)
+        self.assertEqual(len(inspector.GetAllGeometryIds()), 3)
         self.assertEqual(
             inspector.NumGeometriesWithRole(role=mut.Role.kUnassigned), 3)
         self.assertEqual(inspector.NumDynamicGeometries(), 2)
         self.assertEqual(inspector.NumAnchoredGeometries(), 1)
         self.assertTrue(inspector.SourceIsRegistered(id=global_source))
         self.assertEqual(inspector.GetSourceName(id=global_source), "anchored")
+        self.assertEqual(inspector.GetFrameId(global_geometry), global_frame)
+        self.assertEqual(len(inspector.GetGeometries(frame_id=global_frame)),
+                         2)
+        self.assertTrue(
+            global_geometry in inspector.GetGeometries(frame_id=global_frame))
+        self.assertEqual(
+            len(inspector.GetGeometries(frame_id=global_frame,
+                                        role=mut.Role.kProximity)),
+            0)
+        self.assertEqual(
+            inspector.GetGeometryIdByName(frame_id=global_frame,
+                                          role=mut.Role.kUnassigned,
+                                          name="sphere1"),
+            global_geometry)
         self.assertEqual(
             inspector.GetName(frame_id=global_frame), "anchored_frame")
         self.assertEqual(
-            inspector.GetName(geometry_id=global_geometry), "sphere")
+            inspector.GetName(geometry_id=global_geometry), "sphere1")
 
         with catch_drake_warnings(expected_count=2):
             self.assertEqual(
@@ -94,7 +112,7 @@ class TestGeometry(unittest.TestCase):
                 "anchored_frame")
             self.assertEqual(
                 inspector.GetNameByGeometryId(geometry_id=global_geometry),
-                "sphere")
+                "sphere1")
 
         self.assertIsInstance(
             inspector.GetPoseInParent(geometry_id=global_geometry),

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -271,6 +271,28 @@ int GeometryState<T>::NumGeometriesWithRole(FrameId frame_id, Role role) const {
 }
 
 template <typename T>
+std::vector<GeometryId> GeometryState<T>::GetGeometries(
+    FrameId frame_id, std::optional<Role> role) const {
+  FindOrThrow(frame_id, frames_, [frame_id]() {
+    return fmt::format(
+        "Cannot report geometries associated with invalid frame id: {}",
+        frame_id);
+  });
+  const InternalFrame& frame = frames_.at(frame_id);
+
+  std::vector<GeometryId> ids;
+  ids.reserve(frame.child_geometries().size());
+  for (GeometryId g_id : frame.child_geometries()) {
+    if (role.has_value()) {
+      if (!geometries_.at(g_id).has_role(*role)) continue;
+    }
+    ids.push_back(g_id);
+  }
+  std::sort(ids.begin(), ids.end());
+  return ids;
+}
+
+template <typename T>
 GeometryId GeometryState<T>::GetGeometryIdByName(
     FrameId frame_id, Role role, const std::string& name) const {
   const std::string canonical_name = internal::CanonicalizeStringName(name);

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -173,6 +173,10 @@ class GeometryState {
    */
   int NumGeometriesForFrameWithRole(FrameId frame_id, Role role) const;
 
+  /** Implementation of SceneGraphInspector::GetGeometries.  */
+  std::vector<GeometryId> GetGeometries(FrameId frame_id,
+                                        std::optional<Role> role) const;
+
   // TODO(SeanCurtis-TRI): Redundant w.r.t. NumGeometriesForFrameWithRole().
   /** Reports the number of child geometries for this frame that have the
    indicated role assigned. This only includes the immediate child geometries of

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <set>
 #include <string>
 #include <unordered_set>
@@ -238,6 +239,20 @@ class SceneGraphInspector {
   int NumGeometriesForFrameWithRole(FrameId id, Role role) const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->NumGeometriesForFrameWithRole(id, role);
+  }
+
+  /** Returns geometry ids that have been registered directly to the frame
+   indicated by `frame_id`. If a `role` is provided, only geometries with that
+   role assigned will be returned, otherwise all geometries will be returned.
+   @param frame_id    The id of the frame in question.
+   @param role  The requested role; if omitted, all geometries registered to the
+                frame are returned.
+   @returns The requested unique geometry ids in a consistent order.
+   @throws std::logic_error if `id` does not map to a registered frame.  */
+  std::vector<GeometryId> GetGeometries(
+      FrameId frame_id, const std::optional<Role>& role = std::nullopt) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->GetGeometries(frame_id, role);
   }
 
   /** Reports the id of the geometry with the given `name` and `role`, attached

--- a/geometry/test/scene_graph_inspector_test.cc
+++ b/geometry/test/scene_graph_inspector_test.cc
@@ -70,6 +70,7 @@ GTEST_TEST(SceneGraphInspector, ExerciseEverything) {
   inspector.GetFrameGroup(frame_id);
   inspector.NumGeometriesForFrame(frame_id);
   inspector.NumGeometriesForFrameWithRole(frame_id, Role::kUnassigned);
+  inspector.GetGeometries(frame_id, Role::kUnassigned);
   // Register a geometry to prevent an exception being thrown.
   const GeometryId geometry_id =
       tester.mutable_state().RegisterGeometry(


### PR DESCRIPTION
This introduces a new API. Given a frame id, the ids of the frame's geometries can be returned. It can be filtered on a particular role.

This includes the C++ and python interface.

(In the process of adding tests to the new pydrake bindings, I noticed that there were tests missing for previously existing python APIs. They were added and the *order* of the existing tests were changed to match the order of the bindings to ease future reading.)

This is the alternate solution to issue #13970.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/13999)
<!-- Reviewable:end -->
