### PR TITLE
[render] Adds Capsule and Ellipse to RenderEngineGl

### DIFF
--- a/geometry/render/gl_renderer/render_engine_gl.cc
+++ b/geometry/render/gl_renderer/render_engine_gl.cc
@@ -223,6 +223,25 @@ void RenderEngineGl::ImplementGeometry(const Box& box, void* user_data) {
                     Vector3d(box.width(), box.depth(), box.height()));
 }
 
+void RenderEngineGl::ImplementGeometry(const Capsule& capsule,
+                                       void* user_data) {
+  const int resolution = 50;
+  auto [vertices, indices] =
+      internal::MakeCapsule(resolution, capsule.radius(), capsule.length());
+
+  OpenGlGeometry geometry = CreateGlGeometry(vertices, indices);
+  capsules_.push_back(geometry);
+
+  ImplementGeometry(geometry, user_data, Vector3d::Ones());
+}
+
+void RenderEngineGl::ImplementGeometry(const Ellipsoid& ellipsoid,
+                                       void* user_data) {
+  OpenGlGeometry geometry = GetSphere();
+  ImplementGeometry(geometry, user_data,
+                    Vector3d(ellipsoid.a(), ellipsoid.b(), ellipsoid.c()));
+}
+
 void RenderEngineGl::ImplementGeometry(const Mesh& mesh, void* user_data) {
   OpenGlGeometry geometry = GetMesh(mesh.filename());
   ImplementGeometry(geometry, user_data, Vector3d(1, 1, 1) * mesh.scale());

--- a/geometry/render/gl_renderer/render_engine_gl.h
+++ b/geometry/render/gl_renderer/render_engine_gl.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <tuple>
 #include <unordered_map>
+#include <vector>
 
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/geometry_roles.h"
@@ -76,6 +77,8 @@ class RenderEngineGl final : public RenderEngine {
   void ImplementGeometry(const Cylinder& cylinder, void* user_data) final;
   void ImplementGeometry(const HalfSpace& half_space, void* user_data) final;
   void ImplementGeometry(const Box& box, void* user_data) final;
+  void ImplementGeometry(const Capsule& capsule, void* user_data) final;
+  void ImplementGeometry(const Ellipsoid& ellipsoid, void* user_data) final;
   void ImplementGeometry(const Mesh& mesh, void* user_data) final;
   void ImplementGeometry(const Convex& convex, void* user_data) final;
   //@}
@@ -213,6 +216,12 @@ class RenderEngineGl final : public RenderEngine {
   internal::OpenGlGeometry cylinder_;
   internal::OpenGlGeometry half_space_;
   internal::OpenGlGeometry box_;
+  // TODO(SeanCurtis-TRI): Figure out how to re-use capsules - if two capsules
+  // have the same dimensions (or are related by a *uniform* scale*), we can
+  // re-use the same geometry.
+  // Each capsule is unique; they cannot generally be related by a linear
+  // transform (i.e., translation, rotation, and non-uniform scale).
+  std::vector<internal::OpenGlGeometry> capsules_;
 
   // Mapping from obj filename to the mesh loaded into an OpenGlGeometry.
   std::unordered_map<std::string, internal::OpenGlGeometry> meshes_;

--- a/geometry/render/gl_renderer/shape_meshes.h
+++ b/geometry/render/gl_renderer/shape_meshes.h
@@ -78,7 +78,7 @@ std::pair<VertexBuffer, IndexBuffer> MakeLongLatUnitSphere(
 
  @param num_strips  The number of strips the barrel's curvature is divided into.
  @param num_bands   The number of equal-width bands spanning the height of the
-                    clinder.
+                    cylinder.
  @pre `num_strips` >= 3 (otherwise the cylinder will have no volume).
  @pre `num_bands` >= 1.  */
 std::pair<VertexBuffer, IndexBuffer> MakeUnitCylinder(int num_strips = 50,
@@ -87,7 +87,7 @@ std::pair<VertexBuffer, IndexBuffer> MakeUnitCylinder(int num_strips = 50,
 /* Creates an OpenGL-compaptible mesh reprepsenting a square patch. The patch
  has edge length `measure` units long. The square patch is defined lying on the
  z = 0 plane in its canonical frame C, centered on the origin Co. The faces are
- wound such that the right-handed face normal points in the dirction of the
+ wound such that the right-handed face normal points in the direction of the
  positive z-axis of Frame C.
 
  The domain of the patch is divided into square sub regions based on the given
@@ -98,7 +98,7 @@ std::pair<VertexBuffer, IndexBuffer> MakeUnitCylinder(int num_strips = 50,
 std::pair<VertexBuffer, IndexBuffer> MakeSquarePatch(GLfloat measure = 200,
                                                      int resolution = 1);
 
-/* Creates an OpenGL_compatible mesh representation of the unit box - all edges
+/* Creates an OpenGL-compatible mesh representation of the unit box - all edges
  are length 1. The box is centered on the origin of its canonical frame C with
  its edges aligned to the frame's basis. Each face of the box is divided into a
  single pair of triangles.
@@ -107,7 +107,29 @@ std::pair<VertexBuffer, IndexBuffer> MakeSquarePatch(GLfloat measure = 200,
     properties yield undesirable artifacts for large boxes.  --> */
 std::pair<VertexBuffer, IndexBuffer> MakeUnitBox();
 
-// TODO(SeanCurtis): capsule, ellipsoid.
+/* Creates an OpenGL-compatible mesh representation of a capsule with the given
+ `radius` and `length`. The capsule is centered on the origin of its canonical
+ frame C with its length aligned with C's z axis: Cz. The capsule is,
+ conceptually, a cylinder capped with two hemispheres. The `length` is the
+ measure of the cylinder's length. So, the *total* length of the capsule would
+ be `length + 2 * radius`.
+
+ The capsule is tessellated according to `samples`. The circular cross section
+ of the cylindrical region of the capsule will have `samples` number of
+ vertices. The two hemispherical caps will be tesselated such that triangles
+ near the spherical equators have good aspect ratios. There is only a single
+ band of quadrilaterals (split into pairs of triangles) in the cylindrical
+ region.
+
+ @param samples   The number of vertices to place around the barrel of the
+                  capsule.
+ @param radius    The radius of the hemispherical end-caps and cylindrical
+                  barrel.
+ @param length    The length of the cylindrical barrel.
+ @pre `samples` >= 3 (otherwise the capsule will have no volume).
+ @pre radius > 0 and length > 0.  */
+std::pair<VertexBuffer, IndexBuffer> MakeCapsule(int samples, double radius,
+                                                 double length);
 
 }  // namespace internal
 }  // namespace render


### PR DESCRIPTION
 - mesh generation (shape_meshes.*)
   - Generate an arbitrary capsule.
   - incidental typos corrected in header file.
   - unit tests to confirm capsule geometry satisfies certain invariants.
   - unit tests slightly refactored to re-use code; an invariant for all convex shapes centered on the origin placed into its own function. (This function will expand in the future.)
 - mesh rendering
   - RenderEngineGl models an Ellipse with a Sphere and non-uniform scale.
   - Treats every Capsule as unique.
   - unit tests are copied verbatim from render_engine_vtk_test.cc for capsule and ellipse.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14001)
<!-- Reviewable:end -->
