### PR TITLE
DifferentialIKSystem: Add (optional) discrete state to "warn once"

### DIFF
--- a/bindings/pydrake/manipulation/planner_py.cc
+++ b/bindings/pydrake/manipulation/planner_py.cc
@@ -151,11 +151,13 @@ PYBIND11_MODULE(planner, m) {
                  const multibody::Frame<double>&, double,
                  const manipulation::planner::
                      DifferentialInverseKinematicsParameters&,
-                 const systems::Context<double>*>(),
+                 const systems::Context<double>*, bool>(),
             // Keep alive, reference: `self` keeps `robot` alive.
             py::keep_alive<1, 2>(), py::arg("robot"), py::arg("frame_E"),
             py::arg("time_step"), py::arg("parameters"),
-            py::arg("robot_context") = nullptr, cls_doc.ctor.doc)
+            py::arg("robot_context") = nullptr,
+            py::arg("log_only_when_result_state_changes") = true,
+            cls_doc.ctor.doc)
         .def("SetPositions", &Class::SetPositions, py::arg("context"),
             py::arg("positions"), cls_doc.SetPositions.doc)
         .def("ForwardKinematics", &Class::ForwardKinematics, py::arg("context"),

--- a/bindings/pydrake/manipulation/test/planner_test.py
+++ b/bindings/pydrake/manipulation/test/planner_test.py
@@ -96,7 +96,8 @@ class TestPlanner(unittest.TestCase):
             frame_E=frame,
             time_step=time_step,
             parameters=parameters,
-            robot_context=context)
+            robot_context=context,
+            log_only_when_result_state_changes=True)
 
         integrator.get_mutable_parameters().set_timestep(0.2)
         self.assertEqual(integrator.get_parameters().get_timestep(), 0.2)

--- a/manipulation/planner/differential_inverse_kinematics_integrator.cc
+++ b/manipulation/planner/differential_inverse_kinematics_integrator.cc
@@ -15,7 +15,7 @@ DifferentialInverseKinematicsIntegrator::
         const multibody::MultibodyPlant<double>& robot,
         const multibody::Frame<double>& frame_E, double time_step,
         const DifferentialInverseKinematicsParameters& parameters,
-        const Context<double>* context)
+        const Context<double>* context, bool log_only_when_result_state_changes)
     : robot_(robot),
       frame_E_(frame_E),
       parameters_(parameters),
@@ -27,6 +27,10 @@ DifferentialInverseKinematicsIntegrator::
 
   this->DeclarePeriodicDiscreteUpdate(time_step);
   this->DeclareDiscreteState(robot.num_positions());
+  if (log_only_when_result_state_changes) {
+    this->DeclareDiscreteState(Vector1d(static_cast<double>(
+        DifferentialInverseKinematicsStatus::kSolutionFound)));
+  }
 
   this->DeclareVectorOutputPort(
       "joint_positions", systems::BasicVector<double>(robot.num_positions()),
@@ -50,7 +54,7 @@ void DifferentialInverseKinematicsIntegrator::SetPositions(
     Context<double>* context,
     const Eigen::Ref<const Eigen::VectorXd>& positions) const {
   DRAKE_DEMAND(positions.size() == robot_.num_positions());
-  context->get_mutable_discrete_state_vector().SetFromVector(positions);
+  context->get_mutable_discrete_state(0).SetFromVector(positions);
 }
 
 math::RigidTransformd
@@ -77,7 +81,7 @@ void DifferentialInverseKinematicsIntegrator::UpdateRobotContext(
     const Context<double>& context,
     Context<double>* robot_context) const {
   robot_.SetPositions(robot_context,
-                      context.get_discrete_state_vector().get_value());
+                      context.get_discrete_state(0).get_value());
 }
 
 void DifferentialInverseKinematicsIntegrator::DoCalcDiscreteVariableUpdates(
@@ -101,21 +105,58 @@ void DifferentialInverseKinematicsIntegrator::DoCalcDiscreteVariableUpdates(
   DifferentialInverseKinematicsResult result = DoDifferentialInverseKinematics(
       robot_, robot_context, V_WE_desired, frame_E_, parameters_);
 
-  const auto& positions = context.get_discrete_state_vector().get_value();
+  const auto& positions = context.get_discrete_state(0).get_value();
   if (result.status != DifferentialInverseKinematicsStatus::kSolutionFound) {
-    drake::log()->warn("Differential IK could not find a solution at time {}.",
-                       context.get_time());
-    discrete_state->get_mutable_vector().SetFromVector(positions);
+    if (this->num_discrete_state_groups() == 1) {
+      drake::log()->warn(
+          "Differential IK could not find a solution at time {}.",
+          context.get_time());
+    }
+    discrete_state->get_mutable_vector(0).SetFromVector(positions);
   } else {
-    discrete_state->get_mutable_vector().SetFromVector(
+    discrete_state->get_mutable_vector(0).SetFromVector(
         positions + time_step_ * result.joint_velocities.value());
+  }
+
+  if (this->num_discrete_state_groups() > 1) {
+    // Note: Casting to double here is ugly, but it avoids significant
+    // additional complexity (of declaring abstract state, and a CacheEntry to
+    // share the update from the diff IK solution across multiple components of
+    // the Context, etc).  We only cast from the enum to double, and avoid the
+    // other direction.
+    const double status_quo = discrete_state->get_vector(1).GetAtIndex(0);
+    discrete_state->get_mutable_vector(1).SetAtIndex(
+        0, static_cast<double>(result.status));
+
+    // We only assume that the equality of two enums can be tested on the
+    // converted double; we make no assumption about the value of the cast.
+    if (static_cast<double>(result.status) != status_quo) {
+      switch (result.status) {
+        case DifferentialInverseKinematicsStatus::kSolutionFound:
+          drake::log()->warn(
+              "Differential IK started finding solutions again at time {}.",
+              context.get_time());
+          break;
+        case DifferentialInverseKinematicsStatus::kNoSolutionFound:
+          drake::log()->warn(
+              "Differential IK started returning status:\"no solution\" at "
+              "time {}.",
+              context.get_time());
+          break;
+        case DifferentialInverseKinematicsStatus::kStuck:
+          drake::log()->warn(
+              "Differential IK started returning status:\"stuck\" at time {}.",
+              context.get_time());
+          break;
+      }
+    }
   }
 }
 
 void DifferentialInverseKinematicsIntegrator::CopyPositionsOut(
     const Context<double>& context,
     systems::BasicVector<double>* output) const {
-  output->SetFrom(context.get_discrete_state_vector());
+  output->SetFrom(context.get_discrete_state(0));
 }
 
 }  // namespace planner

--- a/manipulation/planner/differential_inverse_kinematics_integrator.h
+++ b/manipulation/planner/differential_inverse_kinematics_integrator.h
@@ -48,6 +48,12 @@ class DifferentialInverseKinematicsIntegrator
   values of this context will be overwritten during integration; you only need
   to pass this in if the robot has any non-default parameters.  @default
   `robot.CreateDefaultContext()`.
+  @param log_only_when_result_state_changes is a boolean that determines whether
+  the system will log on every differential IK failure, or only when the failure
+  state changes.  When the value is `true`, it will cause the system to have an
+  additional discrete state variable to store the most recent
+  DifferentialInverseKinematicsStatus.  Set this to `false` if you want
+  IsDifferenceEquationSystem() to return `true`.
 
   Note: All references must remain valid for the lifetime of this system.
   */
@@ -56,7 +62,8 @@ class DifferentialInverseKinematicsIntegrator
       const multibody::Frame<double>& frame_E, double time_step,
       // Note: parameters last so they could be optional in the future.
       const DifferentialInverseKinematicsParameters& parameters,
-      const systems::Context<double>* robot_context = nullptr);
+      const systems::Context<double>* robot_context = nullptr,
+      bool log_only_when_result_state_changes = true);
 
   /** Sets the joint positions, which are stored as state in the context. It is
   recommended that the user calls this method to initialize the position

--- a/manipulation/planner/test/differential_inverse_kinematics_integrator_test.cc
+++ b/manipulation/planner/test/differential_inverse_kinematics_integrator_test.cc
@@ -43,6 +43,11 @@ GTEST_TEST(DifferentialInverseKinematicsIntegatorTest, BasicTest) {
       *robot, frame_E, time_step, params);
   auto diff_ik_context = diff_ik.CreateDefaultContext();
 
+  // Set the results status state to a failure state.
+  diff_ik_context->get_mutable_discrete_state(1).SetAtIndex(
+      0, static_cast<double>(
+             DifferentialInverseKinematicsStatus::kNoSolutionFound));
+
   Eigen::VectorXd q(7);
   q << 0.1, 0.2, -.15, 0.43, -0.32, -0.21, 0.11;
 
@@ -60,6 +65,11 @@ GTEST_TEST(DifferentialInverseKinematicsIntegatorTest, BasicTest) {
   auto discrete_state = diff_ik.AllocateDiscreteVariables();
   diff_ik.CalcDiscreteVariableUpdates(*diff_ik_context, discrete_state.get());
 
+  // Confirm that the result status state was updated properly.
+  EXPECT_EQ(
+      discrete_state->get_vector(1).GetAtIndex(0),
+      static_cast<double>(DifferentialInverseKinematicsStatus::kSolutionFound));
+
   params.set_timestep(time_step);  // intentionally set this after diff_ik call
   DifferentialInverseKinematicsResult result = DoDifferentialInverseKinematics(
       *robot, *robot_context, X_WE_desired.GetAsIsometry3(), frame_E, params);
@@ -67,6 +77,20 @@ GTEST_TEST(DifferentialInverseKinematicsIntegatorTest, BasicTest) {
   EXPECT_EQ(result.status, DifferentialInverseKinematicsStatus::kSolutionFound);
   EXPECT_TRUE(CompareMatrices(q + time_step * result.joint_velocities.value(),
                               discrete_state->get_vector(0).get_value()));
+
+  // Add infeasible constraints, and confirm the result state.
+  // clang-format off
+  const auto A = (MatrixX<double>(2, 7) <<
+      1, -1,  0, 0, 0, 0, 0,
+      0,  1, -1, 0, 0, 0, 0).finished();
+  // clang-format on
+  const auto b = Eigen::VectorXd::Zero(A.rows());
+  diff_ik.get_mutable_parameters().AddLinearVelocityConstraint(
+      std::make_shared<solvers::LinearConstraint>(A, b, b));
+  diff_ik.CalcDiscreteVariableUpdates(*diff_ik_context, discrete_state.get());
+  EXPECT_EQ(discrete_state->get_vector(1).GetAtIndex(0),
+            static_cast<double>(
+                DifferentialInverseKinematicsStatus::kStuck));
 }
 
 GTEST_TEST(DifferentialInverseKinematicsIntegatorTest, ParametersTest) {
@@ -84,6 +108,29 @@ GTEST_TEST(DifferentialInverseKinematicsIntegatorTest, ParametersTest) {
   EXPECT_EQ(diff_ik.get_parameters().get_timestep(), time_step);
   diff_ik.get_mutable_parameters().set_timestep(0.2);
   EXPECT_EQ(diff_ik.get_parameters().get_timestep(), 0.2);
+}
+
+// Confirm that we can act like a difference equation system when the warning
+// logic is disabled.
+GTEST_TEST(DifferentialInverseKinematicsIntegatorTest,
+           DifferenceEquationSystemTest) {
+  auto robot = MakeIiwa();
+  auto robot_context = robot->CreateDefaultContext();
+  const multibody::Frame<double>& frame_E =
+      robot->GetFrameByName("iiwa_link_7");
+
+  DifferentialInverseKinematicsParameters params(robot->num_positions(),
+                                                 robot->num_velocities());
+  const double time_step = 0.1;
+
+  DifferentialInverseKinematicsIntegrator diff_ik_with_status_state(
+      *robot, frame_E, time_step, params);
+  EXPECT_EQ(diff_ik_with_status_state.num_discrete_state_groups(), 2);
+
+  DifferentialInverseKinematicsIntegrator diff_ik_without_status_state(
+      *robot, frame_E, time_step, params, nullptr, false);
+  EXPECT_EQ(diff_ik_without_status_state.num_discrete_state_groups(), 1);
+  EXPECT_TRUE(diff_ik_without_status_state.IsDifferenceEquationSystem());
 }
 
 }  // namespace


### PR DESCRIPTION
This significantly improves the robustness of the teleoperation demo on colab.  Currently, if a user drives the robot into singularity (and it is relatively common mistake), then the diff IK spews so many warnings that the sliders disappear (and so does the "stop simulation" button).  This allows users to recover from it without closing/crashing their kernel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14004)
<!-- Reviewable:end -->
