### PR TITLE
systems: Fix #14006

### DIFF
--- a/systems/primitives/affine_system.cc
+++ b/systems/primitives/affine_system.cc
@@ -118,7 +118,7 @@ void TimeVaryingAffineSystem<T>::CalcOutputY(
 template <typename T>
 void TimeVaryingAffineSystem<T>::DoCalcTimeDerivatives(
     const Context<T>& context, ContinuousState<T>* derivatives) const {
-  if (num_states_ == 0) return;
+  if (num_states_ == 0 || time_period_ > 0) return;
 
   const T t = context.get_time();
 

--- a/systems/primitives/test/affine_system_test.cc
+++ b/systems/primitives/test/affine_system_test.cc
@@ -325,6 +325,19 @@ GTEST_TEST(SimpleTimeVaryingAffineSystemTest, EvalTest) {
                               sys.get_output_port().Eval(*context)));
 }
 
+GTEST_TEST(SimpleTimeVaryingAffineSystemTest,
+           ContinuousDiscreteVariableUpdatesTest) {
+  // Verify that we can call `DiscreteVariablesUpdate()` on a continuous-time
+  // system without dying.
+  SimpleTimeVaryingAffineSystem sys(0.0);  // A continuous-time system.
+
+  auto context = sys.CreateDefaultContext();
+  sys.get_input_port().FixValue(context.get(), 42.0);
+
+  auto updates = sys.AllocateDiscreteVariables();
+  EXPECT_NO_THROW(sys.CalcDiscreteVariableUpdates(*context, updates.get()));
+}
+
 GTEST_TEST(SimpleTimeVaryingAffineSystemTest, DiscreteEvalTest) {
   SimpleTimeVaryingAffineSystem sys(1.0);  // A discrete-time system.
   const double t = 2.5;
@@ -342,6 +355,18 @@ GTEST_TEST(SimpleTimeVaryingAffineSystemTest, DiscreteEvalTest) {
 
   EXPECT_TRUE(CompareMatrices(x + sys.y0(t) + 42.0 * sys.D(t),
                               sys.get_output_port().Eval(*context)));
+}
+
+GTEST_TEST(SimpleTimeVaryingAffineSystemTest, DiscreteCalcTimeDerivativesTest) {
+  // Verify that we can call `CalcTimeDerivatives()` on a discrete-time system
+  // without dying.
+  SimpleTimeVaryingAffineSystem sys(1.0);  // A discrete-time system.
+
+  auto context = sys.CreateDefaultContext();
+  sys.get_input_port().FixValue(context.get(), 42.0);
+
+  auto derivs = sys.AllocateTimeDerivatives();
+  EXPECT_NO_THROW(sys.CalcTimeDerivatives(*context, derivs.get()));
 }
 
 // Checks that a time-varying affine system will fail if the matrices do not


### PR DESCRIPTION
Return early from `TimeVaryingAffineSystem::DoCalcTimeDerivatives()` if `this` is a discrete-time system.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14008)
<!-- Reviewable:end -->
