### PR TITLE
pydrake: Bind TrajectoryAffineSystem

### DIFF
--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -26,6 +26,7 @@
 #include "drake/systems/primitives/signal_logger.h"
 #include "drake/systems/primitives/sine.h"
 #include "drake/systems/primitives/symbolic_vector_system.h"
+#include "drake/systems/primitives/trajectory_affine_system.h"
 #include "drake/systems/primitives/trajectory_source.h"
 #include "drake/systems/primitives/wrap_to_system.h"
 #include "drake/systems/primitives/zero_order_hold.h"
@@ -314,6 +315,61 @@ PYBIND11_MODULE(primitives, m) {
             doc.ZeroOrderHold.ctor.doc_2args_period_sec_abstract_model_value);
   };
   type_visit(bind_common_scalar_types, CommonScalarPack{});
+
+  // N.B. Capturing `&doc` should not be required; workaround per #9600.
+  auto bind_non_symbolic_scalar_types = [m, &doc](auto dummy) {
+    using T = decltype(dummy);
+
+    DefineTemplateClassWithDefault<TrajectoryAffineSystem<T>, LeafSystem<T>>(m,
+        "TrajectoryAffineSystem", GetPyParam<T>(),
+        doc.TrajectoryAffineSystem.doc)
+        .def(py::init<const trajectories::Trajectory<double>&,
+                 const trajectories::Trajectory<double>&,
+                 const trajectories::Trajectory<double>&,
+                 const trajectories::Trajectory<double>&,
+                 const trajectories::Trajectory<double>&,
+                 const trajectories::Trajectory<double>&, double>(),
+            py::arg("A"), py::arg("B"), py::arg("f0"), py::arg("C"),
+            py::arg("D"), py::arg("y0"), py::arg("time_period") = 0.0,
+            doc.TrajectoryAffineSystem.ctor.doc)
+        .def("A",
+            overload_cast_explicit<MatrixX<T>, const T&>(
+                &TrajectoryAffineSystem<T>::A),
+            doc.TrajectoryAffineSystem.A.doc)
+        .def("B",
+            overload_cast_explicit<MatrixX<T>, const T&>(
+                &TrajectoryAffineSystem<T>::B),
+            doc.TrajectoryAffineSystem.B.doc)
+        .def("f0",
+            overload_cast_explicit<VectorX<T>, const T&>(
+                &TrajectoryAffineSystem<T>::f0),
+            doc.TrajectoryAffineSystem.f0.doc)
+        .def("C",
+            overload_cast_explicit<MatrixX<T>, const T&>(
+                &TrajectoryAffineSystem<T>::C),
+            doc.TrajectoryAffineSystem.C.doc)
+        .def("D",
+            overload_cast_explicit<MatrixX<T>, const T&>(
+                &TrajectoryAffineSystem<T>::D),
+            doc.TrajectoryAffineSystem.D.doc)
+        .def("y0",
+            overload_cast_explicit<VectorX<T>, const T&>(
+                &TrajectoryAffineSystem<T>::y0),
+            doc.TrajectoryAffineSystem.y0.doc)
+        // Wrap a few methods from the TimeVaryingAffineSystem parent class.
+        // TODO(russt): Move to TimeVaryingAffineSystem if/when that class is
+        // wrapped.
+        .def("time_period", &TrajectoryAffineSystem<T>::time_period,
+            doc.TimeVaryingAffineSystem.time_period.doc)
+        .def("configure_default_state",
+            &TimeVaryingAffineSystem<T>::configure_default_state, py::arg("x0"),
+            doc.TimeVaryingAffineSystem.configure_default_state.doc)
+        .def("configure_random_state",
+            &TimeVaryingAffineSystem<T>::configure_random_state,
+            py::arg("covariance"),
+            doc.TimeVaryingAffineSystem.configure_random_state.doc);
+  };
+  type_visit(bind_non_symbolic_scalar_types, NonSymbolicScalarPack{});
 
   py::class_<BarycentricMeshSystem<double>, LeafSystem<double>>(
       m, "BarycentricMeshSystem", doc.BarycentricMeshSystem.doc)

--- a/bindings/pydrake/systems/test/primitives_test.py
+++ b/bindings/pydrake/systems/test/primitives_test.py
@@ -47,6 +47,7 @@ from pydrake.systems.primitives import (
     StateInterpolatorWithDiscreteDerivative,
     StateInterpolatorWithDiscreteDerivative_,
     SymbolicVectorSystem, SymbolicVectorSystem_,
+    TrajectoryAffineSystem, TrajectoryAffineSystem_,
     TrajectorySource,
     WrapToSystem, WrapToSystem_,
     ZeroOrderHold, ZeroOrderHold_,
@@ -91,6 +92,8 @@ class TestGeneral(unittest.TestCase):
         self._check_instantiations(Sine_)
         self._check_instantiations(StateInterpolatorWithDiscreteDerivative_)
         self._check_instantiations(SymbolicVectorSystem_)
+        self._check_instantiations(TrajectoryAffineSystem_,
+                                   supports_symbolic=False)
         self._check_instantiations(WrapToSystem_)
         self._check_instantiations(ZeroOrderHold_)
 
@@ -222,6 +225,42 @@ class TestGeneral(unittest.TestCase):
 
         system = MatrixGain(D=A)
         self.assertTrue((system.D() == A).all())
+
+        system = TrajectoryAffineSystem(
+            PiecewisePolynomial(A),
+            PiecewisePolynomial(B),
+            PiecewisePolynomial(f0),
+            PiecewisePolynomial(C),
+            PiecewisePolynomial(D),
+            PiecewisePolynomial(y0),
+            .1)
+        self.assertEqual(system.get_input_port(0), system.get_input_port())
+        self.assertEqual(system.get_output_port(0), system.get_output_port())
+        context = system.CreateDefaultContext()
+        self.assertEqual(system.get_input_port(0).size(), 1)
+        self.assertEqual(context.get_discrete_state_vector().size(), 2)
+        self.assertEqual(system.get_output_port(0).size(), 1)
+        for t in np.linspace(0., 1., 5):
+            self.assertTrue((system.A(t) == A).all())
+            self.assertTrue((system.B(t) == B).all())
+            self.assertTrue((system.f0(t) == f0).all())
+            self.assertTrue((system.C(t) == C).all())
+            self.assertEqual(system.D(t), D)
+            self.assertEqual(system.y0(t), y0)
+        self.assertEqual(system.time_period(), .1)
+        x0 = np.array([1, 2])
+        system.configure_default_state(x0=x0)
+        system.SetDefaultContext(context)
+        np.testing.assert_equal(
+            context.get_discrete_state_vector().CopyToVector(), x0)
+        generator = RandomGenerator()
+        system.SetRandomContext(context, generator)
+        np.testing.assert_equal(
+            context.get_discrete_state_vector().CopyToVector(), x0)
+        system.configure_random_state(covariance=np.eye(2))
+        system.SetRandomContext(context, generator)
+        self.assertNotEqual(
+            context.get_discrete_state_vector().CopyToVector()[1], x0[1])
 
     def test_linear_system_zero_size(self):
         # Explicitly test #12633.

--- a/bindings/pydrake/test/trajectories_test.py
+++ b/bindings/pydrake/test/trajectories_test.py
@@ -143,6 +143,11 @@ class TestTrajectories(unittest.TestCase):
         v = pp.vector_values([0, 4])
         self.assertEqual(v.shape, (3, 2))
 
+    def test_addition(self):
+        pp1 = PiecewisePolynomial([1, 2, 3])
+        pp2 = pp1 + pp1
+        self.assertTrue((pp2.value(0) == 2 * pp1.value(0)).all())
+
     def test_quaternion_slerp(self):
         # Test empty constructor.
         pq = PiecewiseQuaternionSlerp()

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -158,6 +158,7 @@ PYBIND11_MODULE(trajectories, m) {
           doc.PiecewisePolynomial.slice.doc)
       .def("shiftRight", &PiecewisePolynomial<T>::shiftRight, py::arg("offset"),
           doc.PiecewisePolynomial.shiftRight.doc)
+      .def(py::self + py::self)
       .def("setPolynomialMatrixBlock",
           &PiecewisePolynomial<T>::setPolynomialMatrixBlock,
           py::arg("replacement"), py::arg("segment_index"),


### PR DESCRIPTION
This is all pattern-matched off of the bindings for `AffineSystem()`. This also adds a binding for `PiecewisePolynomial` addition, which is useful when preparing the trajectories to be passed to `TrajectoryAffineSystem`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14009)
<!-- Reviewable:end -->
