### PR TITLE
[pydrake] Enable GeometryProperty copy construction in pydrake

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -867,15 +867,36 @@ void DoScalarIndependentDefinitions(py::module m) {
         .def(py::init(), doc.GeometrySet.ctor.doc);
   }
 
-  py::class_<ProximityProperties, GeometryProperties>(
-      m, "ProximityProperties", doc.ProximityProperties.doc)
-      .def(py::init(), doc.ProximityProperties.ctor.doc);
-  py::class_<IllustrationProperties, GeometryProperties>(
-      m, "IllustrationProperties", doc.IllustrationProperties.doc)
-      .def(py::init(), doc.IllustrationProperties.ctor.doc);
-  py::class_<PerceptionProperties, GeometryProperties>(
-      m, "PerceptionProperties", doc.PerceptionProperties.doc)
-      .def(py::init(), doc.PerceptionProperties.ctor.doc);
+  // ProximityProperties
+  {
+    py::class_<ProximityProperties, GeometryProperties> cls(
+        m, "ProximityProperties", doc.ProximityProperties.doc);
+    cls.def(py::init(), doc.ProximityProperties.ctor.doc)
+        .def(py::init<const ProximityProperties&>(), py::arg("other"),
+            "Creates a copy of the properties");
+    DefCopyAndDeepCopy(&cls);
+  }
+
+  // IllustrationProperties
+  {
+    py::class_<IllustrationProperties, GeometryProperties> cls(
+        m, "IllustrationProperties", doc.IllustrationProperties.doc);
+    cls.def(py::init(), doc.IllustrationProperties.ctor.doc)
+        .def(py::init<const IllustrationProperties&>(), py::arg("other"),
+            "Creates a copy of the properties");
+    DefCopyAndDeepCopy(&cls);
+  }
+
+  // PerceptionProperties
+  {
+    py::class_<PerceptionProperties, GeometryProperties> cls(
+        m, "PerceptionProperties", doc.PerceptionProperties.doc);
+    cls.def(py::init(), doc.PerceptionProperties.ctor.doc)
+        .def(py::init<const PerceptionProperties&>(), py::arg("other"),
+            "Creates a copy of the properties");
+    DefCopyAndDeepCopy(&cls);
+  }
+
   m.def("MakePhongIllustrationProperties", &MakePhongIllustrationProperties,
       py_rvp::reference_internal, py::arg("diffuse"),
       doc.MakePhongIllustrationProperties.doc);

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -1,6 +1,7 @@
 import pydrake.geometry as mut
 import pydrake.geometry._testing as mut_testing
 
+import copy
 import sys
 import unittest
 import warnings
@@ -421,6 +422,20 @@ class TestGeometry(unittest.TestCase):
         self.assertEqual(
             prop.GetProperty(group_name=default_group, name="to_update"),
             20)
+
+        # Property copying.
+        for PropertyType in [mut.ProximityProperties,
+                             mut.IllustrationProperties,
+                             mut.PerceptionProperties]:
+            props = PropertyType()
+            props.AddProperty("g", "p", 10)
+            self.assertTrue(props.HasProperty("g", "p"))
+            props_copy = PropertyType(other=props)
+            self.assertTrue(props_copy.HasProperty("g", "p"))
+            props_copy2 = copy.copy(props)
+            self.assertTrue(props_copy2.HasProperty("g", "p"))
+            props_copy3 = copy.deepcopy(props)
+            self.assertTrue(props_copy3.HasProperty("g", "p"))
 
     def test_render_engine_vtk_params(self):
         # Confirm default construction of params.


### PR DESCRIPTION
The {Proximity|Illustration|Perception}Properties now have a copy constructor in pydrake. This facilitates the ability to update/replace properties.

This is the second piece necessary to meaningfully enable #13970.

resolves #13970.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14010)
<!-- Reviewable:end -->
