### PR TITLE
Ignore geometry with invalid sizes in meshcat and pyplot visualizers.

### DIFF
--- a/bindings/pydrake/systems/meshcat_visualizer.py
+++ b/bindings/pydrake/systems/meshcat_visualizer.py
@@ -62,6 +62,13 @@ def _convert_mesh(geom):
         RotationMatrix(Quaternion(geom.quaternion)),
         geom.position).GetAsMatrix4()
 
+    # Short-circuit if the geometry scale is invalid.
+    # (All uses of float data should be strictly positive:
+    # edge lengths for boxes, radius and length for
+    # spheres and cylinders, and scaling for meshes.)
+    if not all([x > 0 for x in geom.float_data]):
+        return meshcat_geom, material, element_local_tf
+
     if geom.type == geom.BOX:
         assert geom.num_float_data == 3
         meshcat_geom = meshcat.geometry.Box(geom.float_data)

--- a/bindings/pydrake/systems/planar_scenegraph_visualizer.py
+++ b/bindings/pydrake/systems/planar_scenegraph_visualizer.py
@@ -201,6 +201,13 @@ class PlanarSceneGraphVisualizer(PyPlotVisualizer):
                 if geom.color[3] == 0:
                     continue
 
+                # Short-circuit if the geometry scale is invalid.
+                # (All uses of float data should be strictly positive:
+                # edge lengths for boxes, radius and length for
+                # spheres and cylinders, and scaling for meshes.)
+                if not all([x > 0 for x in geom.float_data]):
+                    continue
+
                 X_BG = RigidTransform(
                     RotationMatrix(Quaternion(geom.quaternion)),
                     geom.position)


### PR DESCRIPTION
Fixes #13846 by modifying the meshcat and planar scenegraph visualizers to ignore visual geometry with non-positive `geom.float_data` entries.

See #13846 for a picture of `drake/manipulation/models/jaco_description/urdf/j2s7s300.urdf` as visualized in meshcat before this change. After this change, all seems well:
![image](https://user-images.githubusercontent.com/3066703/92151349-f9f7fe00-edee-11ea-9a3f-bed7f8364d21.png)

And the planar visualizer is happy as well (before this change, it threw an error at a convex hull computation during init):
![image](https://user-images.githubusercontent.com/3066703/92151437-1a27bd00-edef-11ea-9369-b6519946766f.png)

And the manipulation station looks good too, which I believe stresses all of the other geometry types:
![image](https://user-images.githubusercontent.com/3066703/92151318-ee0c3c00-edee-11ea-94de-1cf02cc971da.png).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14013)
<!-- Reviewable:end -->
