### PR TITLE
py sensors: Ensure keep_alive for Image[].data is honored

### DIFF
--- a/bindings/pydrake/systems/sensors_py.cc
+++ b/bindings/pydrake/systems/sensors_py.cc
@@ -124,10 +124,16 @@ PYBIND11_MODULE(sensors, m) {
             self->height(), self->width(), int{ImageTraitsT::kNumChannels});
       };
       auto get_data = [=](const ImageT* self) {
-        return ToArray(self->at(0, 0), self->size(), get_shape(self));
+        py::object array =
+            ToArray(self->at(0, 0), self->size(), get_shape(self));
+        py_keep_alive(array, py::cast(self));
+        return array;
       };
       auto get_mutable_data = [=](ImageT* self) {
-        return ToArray(self->at(0, 0), self->size(), get_shape(self));
+        py::object array =
+            ToArray(self->at(0, 0), self->size(), get_shape(self));
+        py_keep_alive(array, py::cast(self));
+        return array;
       };
 
       py::class_<ImageT> image(m, TemporaryClassName<ImageT>().c_str());
@@ -145,9 +151,8 @@ PYBIND11_MODULE(sensors, m) {
               doc.Image.at.doc_2args_x_y_nonconst)
           // Non-C++ properties. Make them Pythonic.
           .def_property_readonly("shape", get_shape)
-          .def_property_readonly("data", get_data, py_rvp::reference_internal)
-          .def_property_readonly(
-              "mutable_data", get_mutable_data, py_rvp::reference_internal);
+          .def_property_readonly("data", get_data)
+          .def_property_readonly("mutable_data", get_mutable_data);
       // Constants.
       image.attr("Traits") = traits;
       // - Do not duplicate aliases (e.g. `kNumChannels`) for now.

--- a/bindings/pydrake/systems/test/sensors_test.py
+++ b/bindings/pydrake/systems/test/sensors_test.py
@@ -1,5 +1,6 @@
 import pydrake.systems.sensors as mut
 
+import gc
 import unittest
 
 import numpy as np
@@ -153,6 +154,17 @@ class TestSensors(unittest.TestCase):
                 for ih in range(h):
                     self.assertTrue(
                         np.allclose(data[ih, iw, :], image.at(iw, ih)))
+
+            # Ensure that keep alive works by using temporary objects.
+
+            def check_keep_alive():
+                image = ImageT(w, h, channel_default)
+                return (image.data, image.mutable_data)
+
+            data, mutable_data = check_keep_alive()
+            gc.collect()
+            np.testing.assert_array_equal(data, channel_default)
+            np.testing.assert_array_equal(mutable_data, channel_default)
 
     def test_constants(self):
         # Simply ensure we can access the constants.


### PR DESCRIPTION
Resolves #8919

Test does not indicate a difference in Drake, but fixes a segfault in Anzu PR 5371

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14015)
<!-- Reviewable:end -->
