### PR TITLE
Add jupyter widget version of JointSliders

### DIFF
--- a/bindings/pydrake/manipulation/simple_ui.py
+++ b/bindings/pydrake/manipulation/simple_ui.py
@@ -111,8 +111,11 @@ class JointSliders(VectorSystem):
     def set_position(self, q):
         """
         Set all robot positions (corresponding to joint positions and
-        potentially positions not associated with any joint) to the
-        values in q.
+        potentially positions not associated with any joint) to the values in
+        q.  Note that most models have a floating-base mobilizer by default
+        (unless the MultibodyPlant explicitly welds the base to the world), and
+        so have 7 positions corresponding to the quaternion representation of
+        that floating-base position, but not to any joint.
 
         Args:
             q: a vector whose length is robot.num_positions().
@@ -123,13 +126,16 @@ class JointSliders(VectorSystem):
 
     def set_joint_position(self, q):
         """
-        Set the slider positions to the values in q.
+        Set the slider positions to the values in q.  A list of positions which
+        must be the same length as the number of positions ASSOCIATED WITH
+        JOINTS in the MultibodyPlant.  This does not include, e.g.,
+        floating-base coordinates, which will be assigned a default value.
 
         Args:
             q: a vector whose length is the same as the number of joint
             positions (also the number of sliders) for the robot.
         """
-        assert(len(q) == len(self._default_position))
+        assert(len(q) == len(self._slider))
         for i in range(len(self._slider)):
             self._slider[i].set(q[i])
 

--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -48,6 +48,17 @@ drake_pybind_library(
     ],
 )
 
+drake_py_library(
+    name = "jupyter_widgets_py",
+    srcs = ["jupyter_widgets.py"],
+    imports = PACKAGE_INFO.py_imports,
+    deps = [
+        ":module_py",
+        "//bindings/pydrake/common:jupyter_py",
+        "//bindings/pydrake/systems:framework_py",
+    ],
+)
+
 drake_pybind_library(
     name = "math_py",
     cc_deps = [
@@ -155,6 +166,7 @@ PY_LIBRARIES_WITH_INSTALL = [
 ]
 
 PY_LIBRARIES = [
+    ":jupyter_widgets_py",
     ":module_py",
 ]
 
@@ -183,6 +195,23 @@ filegroup(
     srcs = glob([
         "**/*.sdf",
     ]),
+)
+
+drake_jupyter_py_binary(
+    name = "examples/jupyter_widgets_examples",
+    add_test_rule = 1,
+    data = [
+        "//manipulation/models/iiwa_description:models",
+    ],
+    deps = [
+        ":jupyter_widgets_py",
+        ":parsing_py",
+        ":plant_py",
+        "//bindings/pydrake:geometry_py",
+        "//bindings/pydrake/systems:analysis_py",
+        "//bindings/pydrake/systems:framework_py",
+        "//bindings/pydrake/systems:rendering_py",
+    ],
 )
 
 drake_py_unittest(

--- a/bindings/pydrake/multibody/examples/jupyter_widgets_examples.ipynb
+++ b/bindings/pydrake/multibody/examples/jupyter_widgets_examples.ipynb
@@ -1,0 +1,104 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "running_as_notebook = False  # Manually set this to True if you are a human (see #13862)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# JointSliders\n",
+    "\n",
+    "Running this cell should allow you to control the joints of the IIWA in drake visualizer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "from IPython.display import display\n",
+    "from ipywidgets import ToggleButton\n",
+    "\n",
+    "from pydrake.common import FindResourceOrThrow\n",
+    "from pydrake.geometry import ConnectDrakeVisualizer, SceneGraph\n",
+    "from pydrake.multibody.plant import MultibodyPlant\n",
+    "from pydrake.multibody.parsing import Parser\n",
+    "from pydrake.systems.analysis import Simulator                                      \n",
+    "from pydrake.systems.framework import DiagramBuilder\n",
+    "from pydrake.systems.rendering import MultibodyPositionToGeometryPose\n",
+    "\n",
+    "from pydrake.multibody.jupyter_widgets import JointSliders\n",
+    "\n",
+    "builder = DiagramBuilder()\n",
+    "scene_graph = builder.AddSystem(SceneGraph())\n",
+    "plant = MultibodyPlant(time_step=0.0)\n",
+    "plant.RegisterAsSourceForSceneGraph(scene_graph)\n",
+    "Parser(plant, scene_graph).AddModelFromFile(FindResourceOrThrow(\n",
+    "    \"drake/manipulation/models/iiwa_description/iiwa7/iiwa7_no_collision.sdf\"))\n",
+    "plant.Finalize()\n",
+    "\n",
+    "# Add sliders to set positions of the joints.\n",
+    "sliders = builder.AddSystem(JointSliders(robot=plant))\n",
+    "to_pose = builder.AddSystem(MultibodyPositionToGeometryPose(plant))\n",
+    "builder.Connect(sliders.get_output_port(0), to_pose.get_input_port())\n",
+    "builder.Connect(\n",
+    "    to_pose.get_output_port(),\n",
+    "    scene_graph.get_source_pose_port(plant.get_source_id()))\n",
+    "\n",
+    "ConnectDrakeVisualizer(builder, scene_graph)\n",
+    "\n",
+    "# Make the diagram and run it.\n",
+    "diagram = builder.Build()\n",
+    "simulator = Simulator(diagram)\n",
+    "\n",
+    "if running_as_notebook:  \n",
+    "    simulator.set_target_realtime_rate(1.0)\n",
+    "    stop_button = ToggleButton(value=False, description='Stop Simulation')\n",
+    "    display(stop_button)\n",
+    "    while not stop_button.value:\n",
+    "        simulator.AdvanceTo(simulator.get_context().get_time() + 5.0)\n",
+    "    stop_button.value = False\n",
+    "else:  # running as a test.\n",
+    "    simulator.AdvanceTo(0.1)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/bindings/pydrake/multibody/jupyter_widgets.py
+++ b/bindings/pydrake/multibody/jupyter_widgets.py
@@ -1,0 +1,130 @@
+"""
+Provides some useful systems using ipywidgets and MultibodyPlant.
+
+This is gui code; to test changes, please manually run
+//bindings/pydrake/multibody/jupyter_widgets_examples.ipynb.
+"""
+
+import numpy as np
+
+from ipywidgets import FloatSlider, Layout
+
+from pydrake.common.jupyter import process_ipywidget_events
+from pydrake.multibody.tree import JointIndex
+from pydrake.systems.framework import BasicVector, VectorSystem
+
+
+class JointSliders(VectorSystem):
+    """
+    Provides a simple ipywidgets gui with one slider per joint of the
+    MultibodyPlant.  Any positions that are not associated with joints (e.g.
+    floating-base "mobilizers") are held constant at the default value
+    obtained from robot.CreateDefaultContext().
+
+    System YAML
+        name: JointSliders
+        output_ports:
+        - positions
+    """
+
+    def __init__(self, robot, lower_limit=-10., upper_limit=10.,
+                 resolution=0.01, length=200, update_period_sec=0.005):
+        """"
+        Args:
+            robot:       A MultibodyPlant.
+            lower_limit: A scalar or vector of length robot.num_positions().
+                         The lower limit of the slider will be the maximum
+                         value of this number and any limit specified in the
+                         Joint.
+            upper_limit: A scalar or vector of length robot.num_positions().
+                         The upper limit of the slider will be the minimum
+                         value of this number and any limit specified in the
+                         Joint.
+            resolution:  A scalar or vector of length robot.num_positions()
+                         that specifies the discretization of the slider.
+            length:      The length of the sliders.
+            update_period_sec: Specifies how often the window update() method
+                         gets called.
+        """
+        VectorSystem.__init__(self, 0, robot.num_positions())
+
+        # The widgets themselves have undeclared state.  For now, we accept it,
+        # and simply disable caching on the output port.
+        self.get_output_port(0).disable_caching_by_default()
+
+        def _reshape(x, num):
+            x = np.array(x)
+            assert len(x.shape) <= 1
+            return np.array(x) * np.ones(num)
+
+        lower_limit = _reshape(lower_limit, robot.num_positions())
+        upper_limit = _reshape(upper_limit, robot.num_positions())
+        resolution = _reshape(resolution, robot.num_positions())
+
+        # Schedule window updates in either case (new or existing window):
+        self.DeclarePeriodicPublish(update_period_sec, 0.0)
+
+        self._slider = []
+        self._slider_position_start = []
+        context = robot.CreateDefaultContext()
+        self._default_position = robot.GetPositions(context)
+
+        k = 0
+        for i in range(0, robot.num_joints()):
+            joint = robot.get_joint(JointIndex(i))
+            low = joint.position_lower_limits()
+            upp = joint.position_upper_limits()
+            for j in range(0, joint.num_positions()):
+                index = joint.position_start() + j
+                self._slider_position_start.append(index)
+                self._slider.append(
+                    FloatSlider(value=self._default_position[index],
+                                min=max(low[j], lower_limit[k]),
+                                max=min(upp[j], upper_limit[k]),
+                                step=resolution[k],
+                                continuous_update=True,
+                                description=joint.name(),
+                                style={'description_width': 'initial'},
+                                layout=Layout(width=f"'{length}'")))
+                display(self._slider[k])
+                k += 1
+
+    def set_positions(self, q):
+        """
+        Set all robot positions; comparable to MultibodyPlant.SetPositions.
+        Note that we only have sliders for joint positions, but the
+        MultibodyPlant positions many include non-joint positions.  For
+        example, models have a floating-base mobilizer by default (unless the
+        MultibodyPlant explicitly welds the base to the world), and so have 7
+        positions corresponding to the quaternion representation of that
+        floating-base position, but not to any joint.
+
+        Args:
+            q: a vector whose length is robot.num_positions().
+        """
+        self._default_position[:] = q
+        for i in range(len(self._slider)):
+            self._slider[i].value = q[self._slider_position_start[i]]
+
+    def set_joint_positions(self, q):
+        """
+        Set the slider positions to the values in q.  A list of positions which
+        must be the same length as the number of positions ASSOCIATED WITH
+        JOINTS in the MultibodyPlant.  This does not include, e.g.,
+        floating-base coordinates, which will be assigned a default value.
+
+        Args:
+            q: a vector whose length is the same as the number of joint
+            positions (also the number of sliders) for the robot.
+        """
+        assert(len(q) == len(self._slider))
+        for i in range(len(self._slider)):
+            self._slider[i].value = q[i]
+
+    def DoPublish(self, context, event):
+        process_ipywidget_events()
+
+    def DoCalcVectorOutput(self, context, unused, unused2, output):
+        output[:] = self._default_position
+        for i in range(0, len(self._slider)):
+            output[self._slider_position_start[i]] = self._slider[i].value


### PR DESCRIPTION
Restores #13884

With one modification: the Jupyter notebook is moved to the  ``examples`` subdirectory. It seems that the Jupyter infrastructure includes the current directory in the path. When the notebook is in the ``pydrake/multibody`` directory, this causes ``import math`` to use ``pydrake.multibody.math`` rather than the Python standard library.

Follow-up to: #13901
Resolves #13918

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14017)
<!-- Reviewable:end -->
