### PR TITLE
autodiffxd tests: Establish heap use baselines

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -628,6 +628,14 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "autodiffxd_heap_test",
+    deps = [
+        ":autodiff",
+        "//common/test_utilities:limit_malloc",
+    ],
+)
+
+drake_cc_googletest(
     name = "autodiff_overloads_test",
     deps = [
         ":autodiff",

--- a/common/test/autodiffxd_heap_test.cc
+++ b/common/test/autodiffxd_heap_test.cc
@@ -1,0 +1,126 @@
+#include <gtest/gtest.h>
+
+#include "drake/common/autodiff.h"
+#include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/limit_malloc.h"
+
+using Eigen::VectorXd;
+
+namespace drake {
+namespace test {
+namespace {
+
+// Provide some autodiff variables that don't expire at scope end for test
+// cases.
+class AutoDiffXdHeapTest : public ::testing::Test {
+ protected:
+  AutoDiffXd x_{0.4, Eigen::VectorXd::Ones(3)};
+  AutoDiffXd y_{0.3, Eigen::VectorXd::Ones(3)};
+};
+
+// @note The test cases use a sum in function arguments to induce a temporary
+// that can potentially be consumed by pass-by-value optimizations. As of this
+// writing, none of the tested functions uses the optimization, so current heap
+// counts are a baseline for the existing implementations.
+
+// @note The tests cases use `volatile` variables to prevent optimizers from
+// removing the tested function calls entirely. As of this writing, there is no
+// evidence that the technique is strictly necessary. However, future
+// implementations may be vulnerable to dead-code elimination.
+
+TEST_F(AutoDiffXdHeapTest, Abs) {
+  LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+  volatile auto v = abs(x_ + y_);
+}
+
+TEST_F(AutoDiffXdHeapTest, Abs2) {
+  LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+  volatile auto v = abs2(x_ + y_);
+}
+
+TEST_F(AutoDiffXdHeapTest, Acos) {
+  LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+  volatile auto v = acos(x_ + y_);
+}
+
+TEST_F(AutoDiffXdHeapTest, Asin) {
+  LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+  volatile auto v = asin(x_ + y_);
+}
+
+TEST_F(AutoDiffXdHeapTest, Atan) {
+  LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+  volatile auto v = atan(x_ + y_);
+}
+
+TEST_F(AutoDiffXdHeapTest, Atan2) {
+  LimitMalloc guard({.max_num_allocations = 8, .min_num_allocations = 8});
+  volatile auto v = atan2(x_ + y_, y_);
+  volatile auto w = atan2(x_, x_ + y_);
+}
+
+TEST_F(AutoDiffXdHeapTest, Cos) {
+  LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+  volatile auto v = cos(x_ + y_);
+}
+
+TEST_F(AutoDiffXdHeapTest, Cosh) {
+  LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+  volatile auto v = cosh(x_ + y_);
+}
+
+TEST_F(AutoDiffXdHeapTest, Exp) {
+  LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+  volatile auto v = exp(x_ + y_);
+}
+
+TEST_F(AutoDiffXdHeapTest, Log) {
+  LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+  volatile auto v = log(x_ + y_);
+}
+
+TEST_F(AutoDiffXdHeapTest, Min) {
+  LimitMalloc guard({.max_num_allocations = 4, .min_num_allocations = 4});
+  volatile auto v = min(x_ + y_, y_);
+  volatile auto w = min(x_, x_ + y_);
+}
+
+TEST_F(AutoDiffXdHeapTest, Max) {
+  LimitMalloc guard({.max_num_allocations = 4, .min_num_allocations = 4});
+  volatile auto v = max(x_ + y_, y_);
+  volatile auto w = max(x_, x_ + y_);
+}
+
+TEST_F(AutoDiffXdHeapTest, Pow) {
+  LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+  volatile auto v = pow(x_ + y_, 2.0);
+}
+
+TEST_F(AutoDiffXdHeapTest, Sin) {
+  LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+  volatile auto v = sin(x_ + y_);
+}
+
+TEST_F(AutoDiffXdHeapTest, Sinh) {
+  LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+  volatile auto v = sinh(x_ + y_);
+}
+
+TEST_F(AutoDiffXdHeapTest, Sqrt) {
+  LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+  volatile auto v = sqrt(x_ + y_);
+}
+
+TEST_F(AutoDiffXdHeapTest, Tan) {
+  LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+  volatile auto v = tan(x_ + y_);
+}
+
+TEST_F(AutoDiffXdHeapTest, Tanh) {
+  LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+  volatile auto v = tanh(x_ + y_);
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace drake

--- a/common/test_utilities/limit_malloc.h
+++ b/common/test_utilities/limit_malloc.h
@@ -9,6 +9,10 @@ struct LimitMallocParams {
   /// When less than zero, there is no limit on the number of calls.
   int max_num_allocations{-1};
 
+  /// Minimum calls to malloc, calloc, or realloc (totaled as one).
+  /// When less than zero, there is no limit on the number of calls.
+  int min_num_allocations{-1};
+
   /// Whether a realloc() that leaves its `ptr` unchanged should be ignored.
   bool ignore_realloc_noops{false};
 };
@@ -17,6 +21,7 @@ struct LimitMallocParams {
 /// etc.) should be disallowed or curtailed.
 ///
 /// @note This class is currently a no-op on macOS.
+/// @note This class is currently a no-op in leak sanitizer runs.
 ///
 /// Example:
 /// @code
@@ -57,6 +62,9 @@ class LimitMalloc final {
 
   /// Returns the number of allocations observed so far.
   int num_allocations() const;
+
+  /// Returns the parameters structure used to construct this object.
+  const LimitMallocParams& params() const;
 
   // We write this out by hand, to avoid depending on Drake *at all*.
   /// @name Does not allow copy, move, or assignment

--- a/common/test_utilities/test/limit_malloc_test.cc
+++ b/common/test_utilities/test/limit_malloc_test.cc
@@ -52,29 +52,57 @@ class LimitMallocTest : public ::testing::TestWithParam<int> {
 
 // Use the same fixture for death tests, but with a different name.  Note that
 // Drake's styleguide forbids death tests, but our only choice here is to use
-// death tests because our implementation must use abort() because exceptions
-// cannot propagate through malloc() because it is a C ABI.
+// death tests because our implementations sense failure in contexts where
+// exceptions are forbidden. The implementation of max limits must use abort()
+// because exceptions cannot propagate through malloc() because it is a C
+// ABI. Similarly, the implementation of min limits must use abort() because it
+// senses failure within a destructor, which is a C++ `noexcept` context.
 using LimitMallocDeathTest = LimitMallocTest;
 
+// @note: The gtest EXPECT* macros can allocate, so cases take care to avoid
+// using them in LimitMalloc scopes under test. In particular, any checks on
+// LimitMalloc accessors must copy results and check them outside the guarded
+// scope.
+
 TEST_P(LimitMallocTest, UnlimitedTest) {
-  LimitMalloc guard(LimitMallocParams{ /* no limits specified */ });
-  EXPECT_EQ(guard.num_allocations(), 0);
-  Allocate();  // Malloc is OK.
-  Allocate();  // Malloc is OK.
-  Allocate();  // Malloc is OK.
+  // Choose spoiler values for testing.
+  int num_allocations = -1;
+  LimitMallocParams args{10, 20, true};
+  {
+    LimitMalloc guard(LimitMallocParams{ /* no limits specified */ });
+    num_allocations = guard.num_allocations();
+    args = guard.params();
+    Allocate();  // Malloc is OK.
+    Allocate();  // Malloc is OK.
+    Allocate();  // Malloc is OK.
+  }
+  EXPECT_EQ(num_allocations, 0);
+  EXPECT_EQ(args.max_num_allocations, -1);
+  EXPECT_EQ(args.min_num_allocations, -1);
+  EXPECT_EQ(args.ignore_realloc_noops, false);
 }
 
 TEST_P(LimitMallocTest, BasicTest) {
   Allocate();  // Malloc is OK.
+  LimitMallocParams args;
   {
     LimitMalloc guard;
+    args = guard.params();
     // The guarded code would go here; malloc is NOT ok.
   }
   Allocate();  // Malloc is OK again.
+  EXPECT_EQ(args.max_num_allocations, 0);
+  EXPECT_EQ(args.min_num_allocations, -1);
+  EXPECT_EQ(args.ignore_realloc_noops, false);
 }
 
-constexpr const char* const kDeathMessage =
-    "abort due to malloc #[0-9]+ while LimitMalloc\\([0-9]+\\) in effect";
+constexpr const char* const kMaxDeathMessage =
+    "abort due to malloc #[0-9]+ while"
+    " max_num_allocations = [0-9]+ in effect";
+
+constexpr const char* const kMinDeathMessage =
+    "abort due to scope end with [0-9]+ mallocs while"
+    " min_num_allocations = [0-9]+ in effect";
 
 TEST_P(LimitMallocDeathTest, BasicTest) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
@@ -82,10 +110,10 @@ TEST_P(LimitMallocDeathTest, BasicTest) {
   ASSERT_DEATH({
       LimitMalloc guard;
       Allocate();  // Malloc is NOT ok.
-    }, kDeathMessage);
+    }, kMaxDeathMessage);
 }
 
-TEST_P(LimitMallocTest, LimitTest) {
+TEST_P(LimitMallocTest, MaxLimitTest) {
   {
     LimitMalloc guard({.max_num_allocations = 1});
     Allocate();  // Once is okay.
@@ -94,21 +122,48 @@ TEST_P(LimitMallocTest, LimitTest) {
   Allocate();  // Malloc is OK again.
 }
 
-TEST_P(LimitMallocDeathTest, LimitTest) {
+TEST_P(LimitMallocTest, MinLimitTest) {
+  {
+    LimitMalloc guard({.max_num_allocations = 5, .min_num_allocations = 1});
+    Allocate();  // Once is necessary.
+    // Fewer calls here would fail.
+  }
+}
+
+TEST_P(LimitMallocDeathTest, MaxLimitTest) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   const auto expected_message =
-      std::string("Once was okay\n") + kDeathMessage;
+      std::string("Once was okay\n") + kMaxDeathMessage;
   ASSERT_DEATH({
       LimitMalloc guard({.max_num_allocations = 1});
       Allocate();
       std::cerr << "Once was okay\n";
-      // This is a convenient place to test that the getter returns a correct
-      // count.  We must check within a unit test that is known to be disabled
-      // via the BUILD file for platforms without a working implementation.
-      EXPECT_EQ(guard.num_allocations(), 1);
       // A second allocation will fail.
       Allocate();
     }, expected_message);
+}
+
+TEST_P(LimitMallocDeathTest, ObservationTest) {
+  // Though not actually a death test, this is is a convenient place to test
+  // that the getter returns a correct count.  We must check within a unit test
+  // that is known to be disabled via the BUILD file for platforms without a
+  // working implementation.
+  int num_allocations = -1;  // Choose spoiler value for testing.
+  {
+      LimitMalloc guard({.max_num_allocations = 1});
+      Allocate();
+      num_allocations = guard.num_allocations();
+  }
+  EXPECT_EQ(num_allocations, 1);
+}
+
+TEST_P(LimitMallocDeathTest, MinLimitTest) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  ASSERT_DEATH({
+      LimitMalloc guard({.max_num_allocations = 5, .min_num_allocations = 4});
+      Allocate();  // Some few allocations are not enough.
+      // The destructor will fail.
+    }, kMinDeathMessage);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -119,12 +174,13 @@ INSTANTIATE_TEST_SUITE_P(
 // When the user whitelists no-op reallocs, a call to realloc() that does not
 // change the size should not fail.
 GTEST_TEST(LimitReallocTest, ChangingSizeTest) {
-  void* dummy = malloc(16);;
+  void* dummy = malloc(16);
   g_dummy = dummy;
   ASSERT_TRUE(g_dummy != nullptr);
   {
     LimitMalloc guard({
         .max_num_allocations = 0,
+        .min_num_allocations = -1,
         .ignore_realloc_noops = true
     });
     dummy = realloc(dummy, 16);  // No change.
@@ -139,14 +195,15 @@ GTEST_TEST(LimitReallocTest, ChangingSizeTest) {
 // the size changed.
 GTEST_TEST(LimitReallocDeathTest, ChangingSizeTest) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-  void* dummy = malloc(16);;
+  void* dummy = malloc(16);
   g_dummy = dummy;
   ASSERT_TRUE(g_dummy != nullptr);
   const auto expected_message =
-      std::string("Once was okay\n") + kDeathMessage;
+      std::string("Once was okay\n") + kMaxDeathMessage;
   ASSERT_DEATH({
       LimitMalloc guard({
           .max_num_allocations = 0,
+          .min_num_allocations = -1,
           .ignore_realloc_noops = true
       });
       dummy = realloc(dummy, 16);  // No change.


### PR DESCRIPTION
Relevant to: #13985

Extend and use LimitMalloc to measure and enforce heap use of AutoDiffXd
math operators. These limits will help clarify the effect of subsequent
changes on the implementation of AutoDiffXd.

Summary of changes

* LimitMalloc:
  * Add params() accessor and .min_num_allocations parameter
  * Adjust error messages for clarity
  * Extend unit tests to cover new features
* autodifxd_*_test.cc:
  * Add LimitMalloc guards to enforce exact heap usage

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14018)
<!-- Reviewable:end -->
