### PR TITLE
Refactor other symbolic classes

### DIFF
--- a/common/symbolic_chebyshev_basis_element.h
+++ b/common/symbolic_chebyshev_basis_element.h
@@ -44,7 +44,7 @@ class ChebyshevBasisElement : public PolynomialBasisElement {
   ChebyshevBasisElement(const Eigen::Ref<const VectorX<Variable>>& vars,
                         const Eigen::Ref<const Eigen::VectorXi>& degrees);
 
-  ~ChebyshevBasisElement() = default;
+  ~ChebyshevBasisElement() override = default;
 
   /**
    * Compares two ChebyshevBasisElement in lexicographic order.
@@ -65,7 +65,7 @@ class ChebyshevBasisElement : public PolynomialBasisElement {
    * variable in `this`, then we return an empty map.
    * @param var A variable to differentiate with.
    */
-  std::map<ChebyshevBasisElement, double> Differentiate(
+  [[nodiscard]] std::map<ChebyshevBasisElement, double> Differentiate(
       const Variable& var) const;
 
   /**
@@ -79,7 +79,8 @@ class ChebyshevBasisElement : public PolynomialBasisElement {
    * example, ∫ T₂(x)T₃(y)dx = 1/6*T₃(x)T₃(y) − 1/2 * T₁(x)T₃(y), then the
    * result is the map containing {T₃(x)T₃(y), 1/6} and {T₁(x)T₃(y), -1/2}.
    */
-  std::map<ChebyshevBasisElement, double> Integrate(const Variable& var) const;
+  [[nodiscard]] std::map<ChebyshevBasisElement, double> Integrate(
+      const Variable& var) const;
 
   /** Partially evaluates using a given environment @p env. The evaluation
    * result is of type pair<double, ChebyshevBasisElement>. The first component
@@ -91,7 +92,7 @@ class ChebyshevBasisElement : public PolynomialBasisElement {
    * is T₂(3)*T₃(2)*T₁(z) = 17 * 26 * T₁(z) = 442*T₁(z), then we return the pair
    * (442, T₁(z)).
    */
-  std::pair<double, ChebyshevBasisElement> EvaluatePartial(
+  [[nodiscard]] std::pair<double, ChebyshevBasisElement> EvaluatePartial(
       const Environment& env) const;
 
   /** Implements the @ref hash_append concept. */
@@ -106,8 +107,9 @@ class ChebyshevBasisElement : public PolynomialBasisElement {
   }
 
  private:
-  double DoEvaluate(double variable_val, int degree) const override;
-  Expression DoToExpression() const override;
+  [[nodiscard]] double DoEvaluate(double variable_val,
+                                  int degree) const override;
+  [[nodiscard]] Expression DoToExpression() const override;
 };
 
 /**

--- a/common/symbolic_chebyshev_polynomial.h
+++ b/common/symbolic_chebyshev_polynomial.h
@@ -39,20 +39,20 @@ class ChebyshevPolynomial {
   ChebyshevPolynomial(Variable var, int degree);
 
   /** Getter for the variable. */
-  const Variable& var() const { return var_; }
+  [[nodiscard]] const Variable& var() const { return var_; }
 
   /** Getter for the degree of the Chebyshev polynomial. */
-  int degree() const { return degree_; }
+  [[nodiscard]] int degree() const { return degree_; }
 
   /**
    * Converts this Chebyshev polynomial to a polynomial with monomial basis.
    */
-  Polynomial ToPolynomial() const;
+  [[nodiscard]] Polynomial ToPolynomial() const;
 
   /**
    * Evaluates this Chebyshev polynomial at @p var_val.
    */
-  double Evaluate(double var_val) const;
+  [[nodiscard]] double Evaluate(double var_val) const;
 
   /**
    * Checks if this and @p other represent the same Chebyshev polynomial. Two
@@ -97,7 +97,8 @@ class ChebyshevPolynomial {
    * chebyshev_coeff_pairs[0] = (T₀(x), n).
    * For the special case when degree() == 0, we return an empty vector.
    */
-  std::vector<std::pair<ChebyshevPolynomial, double>> Differentiate() const;
+  [[nodiscard]] std::vector<std::pair<ChebyshevPolynomial, double>>
+  Differentiate() const;
 
   /** Implements the @ref hash_append concept. */
   template <class HashAlgorithm>
@@ -119,10 +120,10 @@ std::ostream& operator<<(std::ostream& out, const ChebyshevPolynomial& p);
 
 /**
  * Evaluates a Chebyshev polynomial at a given value.
- * @param variable_val The value of the variable.
+ * @param var_val The value of the variable.
  * @param degree The degree of the Chebyshev polynomial.
  */
-double EvaluateChebyshevPolynomial(double variable_val, int degree);
+double EvaluateChebyshevPolynomial(double var_val, int degree);
 }  // namespace symbolic
 }  // namespace drake
 

--- a/common/symbolic_codegen.h
+++ b/common/symbolic_codegen.h
@@ -29,39 +29,42 @@ class CodeGenVisitor {
   explicit CodeGenVisitor(const std::vector<Variable>& parameters);
 
   /// Generates C expression for the expression @p e.
-  std::string CodeGen(const Expression& e) const;
+  [[nodiscard]] std::string CodeGen(const Expression& e) const;
 
  private:
-  std::string VisitVariable(const Expression& e) const;
-  std::string VisitConstant(const Expression& e) const;
-  std::string VisitAddition(const Expression& e) const;
-  std::string VisitMultiplication(const Expression& e) const;
+  [[nodiscard]] std::string VisitVariable(const Expression& e) const;
+  [[nodiscard]] std::string VisitConstant(const Expression& e) const;
+  [[nodiscard]] std::string VisitAddition(const Expression& e) const;
+  [[nodiscard]] std::string VisitMultiplication(const Expression& e) const;
   // Helper method to handle unary cases.
-  std::string VisitUnary(const std::string& f, const Expression& e) const;
+  [[nodiscard]] std::string VisitUnary(const std::string& f,
+                                       const Expression& e) const;
   // Helper method to handle binary cases.
-  std::string VisitBinary(const std::string& f, const Expression& e) const;
-  std::string VisitPow(const Expression& e) const;
-  std::string VisitDivision(const Expression& e) const;
-  std::string VisitAbs(const Expression& e) const;
-  std::string VisitLog(const Expression& e) const;
-  std::string VisitExp(const Expression& e) const;
-  std::string VisitSqrt(const Expression& e) const;
-  std::string VisitSin(const Expression& e) const;
-  std::string VisitCos(const Expression& e) const;
-  std::string VisitTan(const Expression& e) const;
-  std::string VisitAsin(const Expression& e) const;
-  std::string VisitAcos(const Expression& e) const;
-  std::string VisitAtan(const Expression& e) const;
-  std::string VisitAtan2(const Expression& e) const;
-  std::string VisitSinh(const Expression& e) const;
-  std::string VisitCosh(const Expression& e) const;
-  std::string VisitTanh(const Expression& e) const;
-  std::string VisitMin(const Expression& e) const;
-  std::string VisitMax(const Expression& e) const;
-  std::string VisitCeil(const Expression& e) const;
-  std::string VisitFloor(const Expression& e) const;
-  std::string VisitIfThenElse(const Expression& e) const;
-  std::string VisitUninterpretedFunction(const Expression& e) const;
+  [[nodiscard]] std::string VisitBinary(const std::string& f,
+                                        const Expression& e) const;
+  [[nodiscard]] std::string VisitPow(const Expression& e) const;
+  [[nodiscard]] std::string VisitDivision(const Expression& e) const;
+  [[nodiscard]] std::string VisitAbs(const Expression& e) const;
+  [[nodiscard]] std::string VisitLog(const Expression& e) const;
+  [[nodiscard]] std::string VisitExp(const Expression& e) const;
+  [[nodiscard]] std::string VisitSqrt(const Expression& e) const;
+  [[nodiscard]] std::string VisitSin(const Expression& e) const;
+  [[nodiscard]] std::string VisitCos(const Expression& e) const;
+  [[nodiscard]] std::string VisitTan(const Expression& e) const;
+  [[nodiscard]] std::string VisitAsin(const Expression& e) const;
+  [[nodiscard]] std::string VisitAcos(const Expression& e) const;
+  [[nodiscard]] std::string VisitAtan(const Expression& e) const;
+  [[nodiscard]] std::string VisitAtan2(const Expression& e) const;
+  [[nodiscard]] std::string VisitSinh(const Expression& e) const;
+  [[nodiscard]] std::string VisitCosh(const Expression& e) const;
+  [[nodiscard]] std::string VisitTanh(const Expression& e) const;
+  [[nodiscard]] std::string VisitMin(const Expression& e) const;
+  [[nodiscard]] std::string VisitMax(const Expression& e) const;
+  [[nodiscard]] std::string VisitCeil(const Expression& e) const;
+  [[nodiscard]] std::string VisitFloor(const Expression& e) const;
+  [[nodiscard]] std::string VisitIfThenElse(const Expression& e) const;
+  [[nodiscard]] std::string VisitUninterpretedFunction(
+      const Expression& e) const;
   // Makes VisitExpression a friend of this class so that it can use private
   // methods.
   friend std::string VisitExpression<std::string>(const CodeGenVisitor*,

--- a/common/symbolic_environment.cc
+++ b/common/symbolic_environment.cc
@@ -119,7 +119,7 @@ const Environment::mapped_type& Environment::operator[](
     oss << "Environment::operator[] is called with a dummy variable.";
     throw runtime_error(oss.str());
   }
-  if (!map_.count(key)) {
+  if (map_.count(key) == 0) {
     ostringstream oss;
     oss << "Environment::operator[] was called on a const Environment "
         << "with a missing key \"" << key << "\".";

--- a/common/symbolic_environment.h
+++ b/common/symbolic_environment.h
@@ -97,13 +97,13 @@ class Environment {
   /** Returns an iterator to the end. */
   iterator end() { return map_.end(); }
   /** Returns a const iterator to the beginning. */
-  const_iterator begin() const { return map_.cbegin(); }
+  [[nodiscard]] const_iterator begin() const { return map_.cbegin(); }
   /** Returns a const iterator to the end. */
-  const_iterator end() const { return map_.cend(); }
+  [[nodiscard]] const_iterator end() const { return map_.cend(); }
   /** Returns a const iterator to the beginning. */
-  const_iterator cbegin() const { return map_.cbegin(); }
+  [[nodiscard]] const_iterator cbegin() const { return map_.cbegin(); }
   /** Returns a const iterator to the end. */
-  const_iterator cend() const { return map_.cend(); }
+  [[nodiscard]] const_iterator cend() const { return map_.cend(); }
 
   /** Inserts a pair (@p key, @p elem). */
   void insert(const key_type& key, const mapped_type& elem);
@@ -119,20 +119,22 @@ class Environment {
               const Eigen::Ref<const MatrixX<mapped_type>>& elements);
 
   /** Checks whether the container is empty.  */
-  bool empty() const { return map_.empty(); }
+  [[nodiscard]] bool empty() const { return map_.empty(); }
   /** Returns the number of elements. */
-  size_t size() const { return map_.size(); }
+  [[nodiscard]] size_t size() const { return map_.size(); }
 
   /** Finds element with specific key. */
   iterator find(const key_type& key) { return map_.find(key); }
   /** Finds element with specific key. */
-  const_iterator find(const key_type& key) const { return map_.find(key); }
+  [[nodiscard]] const_iterator find(const key_type& key) const {
+    return map_.find(key);
+  }
 
   /** Returns the domain of this environment. */
-  Variables domain() const;
+  [[nodiscard]] Variables domain() const;
 
   /** Returns string representation. */
-  std::string to_string() const;
+  [[nodiscard]] std::string to_string() const;
 
   /** Returns a reference to the value that is mapped to a key equivalent to
    *  @p key, performing an insertion if such key does not already exist.

--- a/common/symbolic_generic_polynomial.cc
+++ b/common/symbolic_generic_polynomial.cc
@@ -272,8 +272,8 @@ bool GenericPolynomialEqual(const GenericPolynomial<BasisElement>& p1,
 
 template <typename BasisElement>
 bool GenericPolynomial<BasisElement>::EqualTo(
-    const GenericPolynomial<BasisElement>& other) const {
-  return GenericPolynomialEqual<BasisElement>(*this, other, false);
+    const GenericPolynomial<BasisElement>& p) const {
+  return GenericPolynomialEqual<BasisElement>(*this, p, false);
 }
 
 template class GenericPolynomial<MonomialBasisElement>;

--- a/common/symbolic_generic_polynomial.h
+++ b/common/symbolic_generic_polynomial.h
@@ -68,29 +68,34 @@ class GenericPolynomial {
   GenericPolynomial(const BasisElement& m);
 
   /** Returns the indeterminates of this generic polynomial. */
-  const Variables& indeterminates() const { return indeterminates_; }
+  [[nodiscard]] const Variables& indeterminates() const {
+    return indeterminates_;
+  }
 
   /** Returns the decision variables of this generic polynomial. */
-  const Variables& decision_variables() const { return decision_variables_; }
+  [[nodiscard]] const Variables& decision_variables() const {
+    return decision_variables_;
+  }
 
   /** Returns the map from each basis element to its coefficient. */
-  const MapType& basis_element_to_coefficient_map() const {
+  [[nodiscard]] const MapType& basis_element_to_coefficient_map() const {
     return basis_element_to_coefficient_map_;
   }
 
   /** Returns the highest degree of this generic polynomial in an indeterminate
    * @p v. */
-  int Degree(const Variable& v) const;
+  [[nodiscard]] int Degree(const Variable& v) const;
 
   /** Returns the total degree of this generic polynomial. */
-  int TotalDegree() const;
+  [[nodiscard]] int TotalDegree() const;
 
   /**
    * Differentiates this generic polynomial with respect to the variable @p x.
    * Note that a variable @p x can be either a decision variable or an
    * indeterminate.
    */
-  GenericPolynomial<BasisElement> Differentiate(const Variable& x) const;
+  [[nodiscard]] GenericPolynomial<BasisElement> Differentiate(
+      const Variable& x) const;
 
   /** Computes the Jacobian matrix J of the generic polynomial with respect to
    * @p vars. J(0,i) contains ∂f/∂vars(i). @p vars should be an Eigen column
@@ -120,13 +125,14 @@ class GenericPolynomial {
    * @throws std::invalid_argument if there is a variable in this generic
    * polynomial whose assignment is not provided by @p env.
    */
-  double Evaluate(const Environment& env) const;
+  [[nodiscard]] double Evaluate(const Environment& env) const;
 
   /** Partially evaluates this generic polynomial using an environment @p env.
 
    * @throws std::runtime_error if NaN is detected during evaluation.
    */
-  GenericPolynomial<BasisElement> EvaluatePartial(const Environment& env) const;
+  [[nodiscard]] GenericPolynomial<BasisElement> EvaluatePartial(
+      const Environment& env) const;
 
   /** Partially evaluates this generic polynomial by substituting @p var with @p
    * c.
@@ -134,8 +140,8 @@ class GenericPolynomial {
    * @throws std::runtime_error if NaN is detected at any point during
    * evaluation.
    */
-  GenericPolynomial<BasisElement> EvaluatePartial(const Variable& var,
-                                                  double c) const;
+  [[nodiscard]] GenericPolynomial<BasisElement> EvaluatePartial(
+      const Variable& var, double c) const;
 
   /** Adds @p coeff * @p m to this generic polynomial. */
   GenericPolynomial<BasisElement> AddProduct(const Expression& coeff,
@@ -150,12 +156,12 @@ class GenericPolynomial {
    * @retval polynomial_cleaned A generic polynomial whose terms with small
    * coefficients are removed.
    */
-  GenericPolynomial<BasisElement> RemoveTermsWithSmallCoefficients(
-      double coefficient_tol) const;
+  [[nodiscard]] GenericPolynomial<BasisElement>
+  RemoveTermsWithSmallCoefficients(double coefficient_tol) const;
 
   /** Returns true if this generic polynomial and @p p are structurally equal.
    */
-  bool EqualTo(const GenericPolynomial<BasisElement>& p) const;
+  [[nodiscard]] bool EqualTo(const GenericPolynomial<BasisElement>& p) const;
 
  private:
   // Throws std::runtime_error if there is a variable appeared in both of

--- a/common/symbolic_monomial_basis_element.h
+++ b/common/symbolic_monomial_basis_element.h
@@ -88,7 +88,7 @@ class MonomialBasisElement : public PolynomialBasisElement {
    *     (x³*y²).EvaluatePartial({{x, 2}})
    *   = (2³ = 8, y²).
    */
-  std::pair<double, MonomialBasisElement> EvaluatePartial(
+  [[nodiscard]] std::pair<double, MonomialBasisElement> EvaluatePartial(
       const Environment& env) const;
 
   /** Returns this monomial raised to @p p.
@@ -109,7 +109,7 @@ class MonomialBasisElement : public PolynomialBasisElement {
    * If @p var is not a variable in MonomialBasisElement, then returns an empty
    * map.
    */
-  std::map<MonomialBasisElement, double> Differentiate(
+  [[nodiscard]] std::map<MonomialBasisElement, double> Differentiate(
       const Variable& var) const;
 
   /**
@@ -120,7 +120,8 @@ class MonomialBasisElement : public PolynomialBasisElement {
    * = 1/4 x⁴y². If @p var is not a variable in this MonomialBasisElement, for
    * example ∫ x³y²dz = x³y²z, then we return (x³y²z → 1)
    */
-  std::map<MonomialBasisElement, double> Integrate(const Variable& var) const;
+  [[nodiscard]] std::map<MonomialBasisElement, double> Integrate(
+      const Variable& var) const;
 
   /** Implements the @ref hash_append concept. */
   template <class HashAlgorithm>
@@ -145,11 +146,13 @@ class MonomialBasisElement : public PolynomialBasisElement {
    * When this = x²y³, it returns {[T₂(x)T₃(y)⇒1/8], [T₂(x)T₁(y)⇒3/8],
    * [T₀(x)T₃(y)⇒1/8], [T₀(x)T₁(y)⇒3/8]}.
    */
-  std::map<ChebyshevBasisElement, double> ToChebyshevBasis() const;
+  [[nodiscard]] std::map<ChebyshevBasisElement, double> ToChebyshevBasis()
+      const;
 
  private:
-  double DoEvaluate(double variable_val, int degree) const override;
-  Expression DoToExpression() const override;
+  [[nodiscard]] double DoEvaluate(double variable_val,
+                                  int degree) const override;
+  [[nodiscard]] Expression DoToExpression() const override;
 };
 
 std::ostream& operator<<(std::ostream& out, const MonomialBasisElement& m);

--- a/common/symbolic_monomial_util.h
+++ b/common/symbolic_monomial_util.h
@@ -107,7 +107,7 @@ namespace internal {
 template <typename MonomialOrder>
 void AddMonomialsOfDegreeN(const Variables& vars, int degree, const Monomial& b,
                            std::set<Monomial, MonomialOrder>* const bin) {
-  DRAKE_ASSERT(vars.size() > 0);
+  DRAKE_ASSERT(!vars.empty());
   if (degree == 0) {
     bin->insert(b);
     return;
@@ -120,7 +120,6 @@ void AddMonomialsOfDegreeN(const Variables& vars, int degree, const Monomial& b,
   for (int i{degree - 1}; i >= 0; --i) {
     AddMonomialsOfDegreeN(vars - var, degree - i, b * Monomial{var, i}, bin);
   }
-  return;
 }
 
 enum class DegreeType {
@@ -142,7 +141,7 @@ template <int rows>
 Eigen::Matrix<Monomial, rows, 1> ComputeMonomialBasis(
     const Variables& vars, int degree,
     DegreeType degree_type = DegreeType::kAny) {
-  DRAKE_DEMAND(vars.size() > 0);
+  DRAKE_DEMAND(!vars.empty());
   DRAKE_DEMAND(degree >= 0);
   // 1. Collect monomials.
   std::set<Monomial, GradedReverseLexOrder<std::less<Variable>>> monomials;

--- a/common/symbolic_polynomial_basis.h
+++ b/common/symbolic_polynomial_basis.h
@@ -82,7 +82,9 @@ void AddPolynomialBasisElementsOfDegreeN(
     bin->insert(b);
     return;
   }
-  if (vars.size() == 0) return;
+  if (vars.empty()) {
+    return;
+  }
   const Variable& var{*vars.cbegin()};
   for (int var_degree = degree; var_degree >= 0; --var_degree) {
     std::map<Variable, int> new_var_to_degree_map = b.get_powers();
@@ -117,7 +119,7 @@ void AddPolynomialBasisElementsOfDegreeN(
 template <int rows, typename BasisElement>
 Eigen::Matrix<BasisElement, rows, 1> ComputePolynomialBasisUpToDegree(
     const Variables& vars, int degree, internal::DegreeType degree_type) {
-  DRAKE_DEMAND(vars.size() > 0);
+  DRAKE_DEMAND(!vars.empty());
   DRAKE_DEMAND(degree >= 0);
   // 1. Collect elements.
   std::set<BasisElement,

--- a/common/symbolic_polynomial_basis_element.cc
+++ b/common/symbolic_polynomial_basis_element.cc
@@ -33,9 +33,6 @@ std::map<Variable, int> ToVarToDegreeMap(
 }
 }  // namespace
 
-PolynomialBasisElement::PolynomialBasisElement()
-    : var_to_degree_map_{}, total_degree_{0} {}
-
 PolynomialBasisElement::PolynomialBasisElement(
     const std::map<Variable, int>& var_to_degree_map) {
   total_degree_ = std::accumulate(

--- a/common/symbolic_polynomial_basis_element.h
+++ b/common/symbolic_polynomial_basis_element.h
@@ -51,7 +51,7 @@ class PolynomialBasisElement {
    * Constructs a polynomial basis with empty var_to_degree map. This element
    * should be interpreted as 1.
    */
-  PolynomialBasisElement();
+  PolynomialBasisElement() = default;
 
   /**
    * Constructs a polynomial basis given the variable and the degree of that
@@ -73,7 +73,7 @@ class PolynomialBasisElement {
 
   virtual ~PolynomialBasisElement() = default;
 
-  const std::map<Variable, int>& var_to_degree_map() const {
+  [[nodiscard]] const std::map<Variable, int>& var_to_degree_map() const {
     return var_to_degree_map_;
   }
 
@@ -83,32 +83,32 @@ class PolynomialBasisElement {
    * get_powers() function. We will remove this get_powers() function when
    * Monomial class is deprecated.
    */
-  const std::map<Variable, int>& get_powers() const {
+  [[nodiscard]] const std::map<Variable, int>& get_powers() const {
     return var_to_degree_map_;
   }
 
   /** Returns the total degree of a polynomial basis. This is the summation of
    * the degree for each variable. */
-  int total_degree() const { return total_degree_; }
+  [[nodiscard]] int total_degree() const { return total_degree_; }
 
   /** Returns the degree of this PolynomialBasisElement in a variable @p v. If
    * @p v is not a variable in this PolynomialBasisElement, then returns 0.*/
-  int degree(const Variable& v) const;
+  [[nodiscard]] int degree(const Variable& v) const;
 
-  Variables GetVariables() const;
+  [[nodiscard]] Variables GetVariables() const;
 
   /** Evaluates under a given environment @p env.
    *
    * @throws std::invalid_argument exception if there is a variable in this
    * monomial whose assignment is not provided by @p env.
    */
-  double Evaluate(const Environment& env) const;
+  [[nodiscard]] double Evaluate(const Environment& env) const;
 
   bool operator==(const PolynomialBasisElement& other) const;
 
   bool operator!=(const PolynomialBasisElement& other) const;
 
-  symbolic::Expression ToExpression() const;
+  [[nodiscard]] Expression ToExpression() const;
 
  protected:
   /**
@@ -116,9 +116,10 @@ class PolynomialBasisElement {
    * function is meant to be called by the derived class, to compare two
    * polynomial basis of the same derived class.
    */
-  bool lexicographical_compare(const PolynomialBasisElement& other) const;
+  [[nodiscard]] bool lexicographical_compare(
+      const PolynomialBasisElement& other) const;
 
-  virtual bool EqualTo(const PolynomialBasisElement& other) const;
+  [[nodiscard]] virtual bool EqualTo(const PolynomialBasisElement& other) const;
 
   // Partially evaluate a polynomial basis element, where @p e does not
   // necessarily contain all the variables in this basis element. The
@@ -137,9 +138,10 @@ class PolynomialBasisElement {
   // a given degree. For example, for a monomial basis, this evaluates xⁿ where
   // x is the variable value and n is the degree; for a Chebyshev basis, this
   // evaluats the Chebyshev polynomial Tₙ(x).
-  virtual double DoEvaluate(double variable_val, int degree) const = 0;
+  [[nodiscard]] virtual double DoEvaluate(double variable_val,
+                                          int degree) const = 0;
 
-  virtual Expression DoToExpression() const = 0;
+  [[nodiscard]] virtual Expression DoToExpression() const = 0;
 
   // Internally, the polynomial basis is represented as a mapping from a
   // variable to its degree.

--- a/common/symbolic_rational_function.cc
+++ b/common/symbolic_rational_function.cc
@@ -7,9 +7,8 @@ namespace symbolic {
 RationalFunction::RationalFunction()
     : numerator_{} /* zero polynomial */, denominator_{1} {}
 
-RationalFunction::RationalFunction(const Polynomial& numerator,
-                                   const Polynomial& denominator)
-    : numerator_{numerator}, denominator_{denominator} {
+RationalFunction::RationalFunction(Polynomial numerator, Polynomial denominator)
+    : numerator_{std::move(numerator)}, denominator_{std::move(denominator)} {
   if (denominator_.EqualTo(Polynomial() /* zero polynomial */)) {
     throw std::invalid_argument(
         "RationalFunction: the denominator should not be 0.");
@@ -139,7 +138,8 @@ RationalFunction& RationalFunction::operator/=(double c) {
 }
 
 RationalFunction operator-(RationalFunction f) {
-  return RationalFunction(-f.numerator(), f.denominator());
+  f.numerator_ *= -1;
+  return f;
 }
 
 RationalFunction operator+(RationalFunction f1, const RationalFunction& f2) {
@@ -166,8 +166,8 @@ RationalFunction operator-(RationalFunction f, const Polynomial& p) {
   return f -= p;
 }
 
-RationalFunction operator-(const Polynomial& p, RationalFunction f) {
-  return f = -f + p;
+RationalFunction operator-(const Polynomial& p, const RationalFunction& f) {
+  return -f + p;
 }
 
 RationalFunction operator-(RationalFunction f, double c) { return f -= c; }

--- a/common/symbolic_rational_function.h
+++ b/common/symbolic_rational_function.h
@@ -44,7 +44,7 @@ class RationalFunction {
    * can be decision variables in the numerator.
    * @throws std::logic_error if the precondition is not satisfied.
    */
-  RationalFunction(const Polynomial& numerator, const Polynomial& denominator);
+  RationalFunction(Polynomial numerator, Polynomial denominator);
 
   /**
    * Constructs the rational function: p / 1. Note that we use 1 as the
@@ -63,10 +63,10 @@ class RationalFunction {
   ~RationalFunction() = default;
 
   /// Getter for the numerator.
-  const Polynomial& numerator() const { return numerator_; }
+  [[nodiscard]] const Polynomial& numerator() const { return numerator_; }
 
   /// Getter for the denominator.
-  const Polynomial& denominator() const { return denominator_; }
+  [[nodiscard]] const Polynomial& denominator() const { return denominator_; }
 
   RationalFunction& operator+=(const RationalFunction& f);
   RationalFunction& operator+=(const Polynomial& p);
@@ -85,9 +85,15 @@ class RationalFunction {
   RationalFunction& operator/=(double c);
 
   /**
+   * Unary minus operation for rational function.
+   * if f(x) = p(x) / q(x), then -f(x) = (-p(x)) / q(x)
+   */
+  friend RationalFunction operator-(RationalFunction f);
+
+  /**
    * Returns true if this rational function and f are structurally equal.
    */
-  bool EqualTo(const RationalFunction& f) const;
+  [[nodiscard]] bool EqualTo(const RationalFunction& f) const;
 
   /**
    * Returns a symbolic formula representing the condition where this rational
@@ -112,12 +118,6 @@ class RationalFunction {
   Polynomial denominator_;
 };
 
-/**
- * Unary minus operation for rational function.
- * if f(x) = p(x) / q(x), then -f(x) = (-p(x)) / q(x)
- */
-RationalFunction operator-(RationalFunction f);
-
 RationalFunction operator+(RationalFunction f1, const RationalFunction& f2);
 RationalFunction operator+(RationalFunction f, const Polynomial& p);
 RationalFunction operator+(const Polynomial& p, RationalFunction f);
@@ -126,7 +126,7 @@ RationalFunction operator+(double c, RationalFunction f);
 
 RationalFunction operator-(RationalFunction f1, const RationalFunction& f2);
 RationalFunction operator-(RationalFunction f, const Polynomial& p);
-RationalFunction operator-(const Polynomial& p, RationalFunction f);
+RationalFunction operator-(const Polynomial& p, const RationalFunction& f);
 RationalFunction operator-(RationalFunction f, double c);
 RationalFunction operator-(double c, RationalFunction f);
 

--- a/common/symbolic_simplification.cc
+++ b/common/symbolic_simplification.cc
@@ -45,8 +45,8 @@ class UnificationVisitor {
   //
   // In this case, there is no way to match `e` with `p` because `a + b` is not
   // matched with `x * y`.  Therefore, `Unify(p, e)` returns `nullopt`.
-  std::optional<Substitution> Unify(const Pattern& p,
-                                    const Expression& e) const {
+  [[nodiscard]] std::optional<Substitution> Unify(const Pattern& p,
+                                                  const Expression& e) const {
     Substitution subst;
     if (Unify(p, e, &subst)) {
       return subst;

--- a/common/symbolic_variable.h
+++ b/common/symbolic_variable.h
@@ -60,10 +60,7 @@ class Variable {
    *  It is allowed to construct a dummy variable but it should not be used to
    *  construct a symbolic expression.
    */
-  Variable()
-      : id_{0},
-        type_{Type::CONTINUOUS},
-        name_{std::make_shared<std::string>()} {}
+  Variable() : name_{std::make_shared<std::string>()} {}
 
   /** Constructs a default value.  This overload is used by Eigen when
    * EIGEN_INITIALIZE_MATRICES_BY_ZERO is enabled.
@@ -76,17 +73,21 @@ class Variable {
 
   /** Checks if this is a dummy variable (ID = 0) which is created by
    *  the default constructor. */
-  bool is_dummy() const { return get_id() == 0; }
-  Id get_id() const;
-  Type get_type() const;
-  std::string get_name() const;
-  std::string to_string() const;
+  [[nodiscard]] bool is_dummy() const { return get_id() == 0; }
+  [[nodiscard]] Id get_id() const;
+  [[nodiscard]] Type get_type() const;
+  [[nodiscard]] std::string get_name() const;
+  [[nodiscard]] std::string to_string() const;
 
   /// Checks the equality of two variables based on their ID values.
-  bool equal_to(const Variable& v) const { return get_id() == v.get_id(); }
+  [[nodiscard]] bool equal_to(const Variable& v) const {
+    return get_id() == v.get_id();
+  }
 
   /// Compares two variables based on their ID values.
-  bool less(const Variable& v) const { return get_id() < v.get_id(); }
+  [[nodiscard]] bool less(const Variable& v) const {
+    return get_id() < v.get_id();
+  }
 
   /** Implements the @ref hash_append concept. */
   template <class HashAlgorithm>

--- a/common/symbolic_variables.cc
+++ b/common/symbolic_variables.cc
@@ -11,7 +11,6 @@
 #include "drake/common/hash.h"
 #include "drake/common/symbolic.h"
 
-using std::accumulate;
 using std::includes;
 using std::initializer_list;
 using std::inserter;

--- a/common/symbolic_variables.h
+++ b/common/symbolic_variables.h
@@ -48,18 +48,18 @@ class Variables {
   explicit Variables(const Eigen::Ref<const VectorX<Variable>>& vec);
 
   /** Returns the number of elements. */
-  size_type size() const { return vars_.size(); }
+  [[nodiscard]] size_type size() const { return vars_.size(); }
 
   /** Checks if this set is empty or not. */
-  bool empty() const { return vars_.empty(); }
+  [[nodiscard]] bool empty() const { return vars_.empty(); }
 
   /** Returns string representation of Variables. */
-  std::string to_string() const;
+  [[nodiscard]] std::string to_string() const;
 
   /** Implements the @ref hash_append concept. */
   template <class HashAlgorithm>
-  friend void hash_append(
-      HashAlgorithm& hasher, const Variables& item) noexcept {
+  friend void hash_append(HashAlgorithm& hasher,
+                          const Variables& item) noexcept {
     using drake::hash_append;
     hash_append(hasher, item.vars_);
   }
@@ -69,25 +69,29 @@ class Variables {
   /** Returns an iterator to the end. */
   iterator end() { return vars_.end(); }
   /** Returns an iterator to the beginning. */
-  const_iterator begin() const { return vars_.cbegin(); }
+  [[nodiscard]] const_iterator begin() const { return vars_.cbegin(); }
   /** Returns an iterator to the end. */
-  const_iterator end() const { return vars_.cend(); }
+  [[nodiscard]] const_iterator end() const { return vars_.cend(); }
   /** Returns a const iterator to the beginning. */
-  const_iterator cbegin() const { return vars_.cbegin(); }
+  [[nodiscard]] const_iterator cbegin() const { return vars_.cbegin(); }
   /** Returns a const iterator to the end. */
-  const_iterator cend() const { return vars_.cend(); }
+  [[nodiscard]] const_iterator cend() const { return vars_.cend(); }
   /** Returns a reverse iterator to the beginning. */
   reverse_iterator rbegin() { return vars_.rbegin(); }
   /** Returns a reverse iterator to the end. */
   reverse_iterator rend() { return vars_.rend(); }
   /** Returns a reverse iterator to the beginning. */
-  const_reverse_iterator rbegin() const { return vars_.crbegin(); }
+  [[nodiscard]] const_reverse_iterator rbegin() const {
+    return vars_.crbegin();
+  }
   /** Returns a reverse iterator to the end. */
-  const_reverse_iterator rend() const { return vars_.crend(); }
+  [[nodiscard]] const_reverse_iterator rend() const { return vars_.crend(); }
   /** Returns a const reverse-iterator to the beginning. */
-  const_reverse_iterator crbegin() const { return vars_.crbegin(); }
+  [[nodiscard]] const_reverse_iterator crbegin() const {
+    return vars_.crbegin();
+  }
   /** Returns a const reverse-iterator to the end. */
-  const_reverse_iterator crend() const { return vars_.crend(); }
+  [[nodiscard]] const_reverse_iterator crend() const { return vars_.crend(); }
 
   /** Inserts a variable @p var into a set. */
   void insert(const Variable& var) { vars_.insert(var); }
@@ -108,19 +112,23 @@ class Variables {
 
   /** Finds element with specific key. */
   iterator find(const Variable& key) { return vars_.find(key); }
-  const_iterator find(const Variable& key) const { return vars_.find(key); }
+  [[nodiscard]] const_iterator find(const Variable& key) const {
+    return vars_.find(key);
+  }
 
   /** Return true if @p key is included in the Variables. */
-  bool include(const Variable& key) const { return find(key) != end(); }
+  [[nodiscard]] bool include(const Variable& key) const {
+    return find(key) != end();
+  }
 
   /** Return true if @p vars is a subset of the Variables. */
-  bool IsSubsetOf(const Variables& vars) const;
+  [[nodiscard]] bool IsSubsetOf(const Variables& vars) const;
   /** Return true if @p vars is a superset of the Variables. */
-  bool IsSupersetOf(const Variables& vars) const;
+  [[nodiscard]] bool IsSupersetOf(const Variables& vars) const;
   /** Return true if @p vars is a strict subset of the Variables. */
-  bool IsStrictSubsetOf(const Variables& vars) const;
+  [[nodiscard]] bool IsStrictSubsetOf(const Variables& vars) const;
   /** Return true if @p vars is a strict superset of the Variables. */
-  bool IsStrictSupersetOf(const Variables& vars) const;
+  [[nodiscard]] bool IsStrictSupersetOf(const Variables& vars) const;
 
   friend bool operator==(const Variables& vars1, const Variables& vars2);
 
@@ -173,6 +181,6 @@ Variables intersect(const Variables& vars1, const Variables& vars2);
 
 namespace std {
 /* Provides std::hash<drake::symbolic::Variables>. */
-template <> struct hash<drake::symbolic::Variables>
-    : public drake::DefaultHash {};
+template <>
+struct hash<drake::symbolic::Variables> : public drake::DefaultHash {};
 }  // namespace std

--- a/common/test/symbolic_generic_polynomial_test.cc
+++ b/common/test/symbolic_generic_polynomial_test.cc
@@ -4,6 +4,7 @@
 #include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/common/test_utilities/symbolic_test_util.h"
+#include "drake/common/unused.h"
 
 namespace drake {
 namespace symbolic {
@@ -266,7 +267,9 @@ TEST_F(SymbolicGenericPolynomialTest, Evaluate) {
       {var_x_, -7.0},
       {var_z_, -2.0},
   }};
-  EXPECT_THROW(p.Evaluate(partial_env), std::invalid_argument);
+  double dummy{};
+  EXPECT_THROW(dummy = p.Evaluate(partial_env), std::invalid_argument);
+  unused(dummy);
 }
 
 TEST_F(SymbolicGenericPolynomialTest, PartialEvaluate1) {
@@ -326,7 +329,8 @@ TEST_F(SymbolicGenericPolynomialTest, PartialEvaluate4) {
        {MonomialBasisElement(var_x_), b_},
        {MonomialBasisElement(), c_}}};
   const Environment env{{{var_a_, 0.0}, {var_b_, 0.0}, {var_c_, 0.0}}};
-  EXPECT_THROW(p.EvaluatePartial(env), runtime_error);
+  GenericPolynomial<MonomialBasisElement> dummy;
+  EXPECT_THROW(dummy = p.EvaluatePartial(env), runtime_error);
 }
 
 TEST_F(SymbolicGenericPolynomialTest, EqualTo) {

--- a/common/test/symbolic_monomial_basis_element_test.cc
+++ b/common/test/symbolic_monomial_basis_element_test.cc
@@ -4,6 +4,7 @@
 #include "drake/common/symbolic.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/common/test_utilities/symbolic_test_util.h"
+#include "drake/common/unused.h"
 
 using std::pair;
 using std::runtime_error;
@@ -463,7 +464,9 @@ TEST_F(MonomialBasisElementTest, Evaluate) {
 TEST_F(MonomialBasisElementTest, EvaluateException) {
   const MonomialBasisElement m{{{var_x_, 1}, {var_y_, 2}}};  // xy^2
   const Environment env{{{var_x_, 1.0}}};
-  EXPECT_THROW(m.Evaluate(env), std::invalid_argument);
+  double dummy{};
+  EXPECT_THROW(dummy = m.Evaluate(env), std::invalid_argument);
+  unused(dummy);
 }
 
 TEST_F(MonomialBasisElementTest, EvaluatePartial) {

--- a/common/test/symbolic_polynomial_basis_element_test.cc
+++ b/common/test/symbolic_polynomial_basis_element_test.cc
@@ -4,6 +4,7 @@
 #include "drake/common/symbolic.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/common/test_utilities/symbolic_test_util.h"
+#include "drake/common/unused.h"
 #define DRAKE_COMMON_SYMBOLIC_DETAIL_HEADER
 #include "drake/common/symbolic_expression_cell.h"
 #undef DRAKE_COMMON_SYMBOLIC_DETAIL_HEADER
@@ -155,8 +156,10 @@ TEST_F(SymbolicPolynomialBasisElementTest, Evaluate) {
   // p1=y²
   EXPECT_EQ(p1.Evaluate(env2), 9);
   // p2=xy², but env2 does not contain value for x.
-  DRAKE_EXPECT_THROWS_MESSAGE(p2.Evaluate(env2), std::invalid_argument,
+  double dummy{};
+  DRAKE_EXPECT_THROWS_MESSAGE(dummy = p2.Evaluate(env2), std::invalid_argument,
                               ".* x is not in env");
+  unused(dummy);
 }
 
 TEST_F(SymbolicPolynomialBasisElementTest, LessThan) {


### PR DESCRIPTION
 - Add `[[nodiscard]]` attribute. Update the affected test cases.
 - [modernize-pass-by-value](https://clang.llvm.org/extra/clang-tidy/checks/modernize-pass-by-value.html)
 - Remove implicit Boolean conversion for readability
 - `RationalFunction::operator-`: change parameter types

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14021)
<!-- Reviewable:end -->
