### PR TITLE
jupyter: more robust fail fast when running as non-interactive kernel

### DIFF
--- a/bindings/pydrake/common/jupyter.py
+++ b/bindings/pydrake/common/jupyter.py
@@ -30,7 +30,7 @@ def process_ipywidget_events(num_events_to_process=1):
 
     shell = get_ipython()
     # Ok to do nothing if running from console.
-    if shell is None:
+    if shell is None or not hasattr(shell, 'kernel'):
         return
     kernel = shell.kernel
     events = []


### PR DESCRIPTION
my bazel test script on travis ubuntu has been failing because get_ipython() returns an object, but not one that has a usable kernel.
https://github.com/RussTedrake/manipulation/runs/1077702318?check_suite_focus=true

This makes it more robust.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14025)
<!-- Reviewable:end -->
