### PR TITLE
limit_malloc: Disarm under valgrind

### DIFF
--- a/common/test_utilities/limit_malloc.h
+++ b/common/test_utilities/limit_malloc.h
@@ -20,8 +20,10 @@ struct LimitMallocParams {
 /// Instantiate this class in a unit test scope where malloc (and realloc,
 /// etc.) should be disallowed or curtailed.
 ///
-/// @note This class is currently a no-op on macOS.
-/// @note This class is currently a no-op in leak sanitizer runs.
+/// @note This class is currently a no-op in some build configurations:
+///       - macOS
+///       - leak sanitizer
+///       - valgrind tools
 ///
 /// Example:
 /// @code

--- a/tools/dynamic_analysis/drd.sh
+++ b/tools/dynamic_analysis/drd.sh
@@ -15,6 +15,9 @@ export G_SLICE=always-malloc
 # tests.
 export GTEST_DEATH_TEST_USE_FORK=1
 
+# If unset, set to empty string.
+export VALGRIND_OPTS="$VALGRIND_OPTS"
+
 valgrind \
     --error-exitcode=1 \
     --gen-suppressions=all \

--- a/tools/dynamic_analysis/helgrind.sh
+++ b/tools/dynamic_analysis/helgrind.sh
@@ -15,6 +15,9 @@ export G_SLICE=always-malloc
 # tests.
 export GTEST_DEATH_TEST_USE_FORK=1
 
+# If unset, set to empty string.
+export VALGRIND_OPTS="$VALGRIND_OPTS"
+
 valgrind \
     --error-exitcode=1 \
     --gen-suppressions=all \

--- a/tools/dynamic_analysis/valgrind.sh
+++ b/tools/dynamic_analysis/valgrind.sh
@@ -15,6 +15,9 @@ export G_SLICE=always-malloc
 # tests.
 export GTEST_DEATH_TEST_USE_FORK=1
 
+# If unset, set to empty string.
+export VALGRIND_OPTS="$VALGRIND_OPTS"
+
 valgrind \
     --error-exitcode=1 \
     --gen-suppressions=all \


### PR DESCRIPTION
Fixes a nightly build failure seen here:
https://drake-cdash.csail.mit.edu/viewTest.php?onlydelta&buildid=1336134

This solution may seem like overkill, when I could have just set tags in
bazel rules. Here are some reasons why I didn't do that:

 * bazel tags don't (yet^) propagate up dependency chains, so any
   library module that induces the need for tags just sets off an
   endless game of whack-a-mole.
   ^yet: see https://github.com/bazelbuild/bazel/issues/8830
* solving LSAN at the source but not similar valgrind problems seems
   inconsistent.

Another alternative not taken: checking RUNNING_ON_VALGRIND from
valgrind.h. This solution would have required a bunch of apple-aware
build hacks and/or fighting with Homebrew to ensure that valgrind.h was
installed and available.

Summary of changes:

 * LimitMalloc:
   * Rewrite IsLeakSanitizerBuild() as IsSupportedConfguration()
     * opposite sign, but more general
     * add valgrind non-support via VALGRIND_OPTS env var check
   * Update doc
   * for sherm1: convert a static global function to namespace{}
 * valgrind shell scripts:
   * Ensure the VALGRIND_OPTS variable is always set and exported

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14040)
<!-- Reviewable:end -->
