### PR TITLE
Remove invalid geometry from the jaco model

### DIFF
--- a/manipulation/models/jaco_description/urdf/j2n6s300.urdf
+++ b/manipulation/models/jaco_description/urdf/j2n6s300.urdf
@@ -41,21 +41,7 @@
 -->
   <!-- Director seems to really want a link named "base", so this is
        renamed from "root" -->
-  <link name="base">
-    <visual>
-      <origin rpy="0 0 0" xyz="0 0 0"/>
-      <geometry>
-        <box size="0 0 0"/>
-      </geometry>
-      <!--<material name="Black" /> -->
-    </visual>
-    <collision>
-      <origin rpy="0 0 0" xyz="0 0 0"/>
-      <geometry>
-        <box size="0 0 0"/>
-      </geometry>
-    </collision>
-  </link>
+  <link name="base"/>
   <gazebo>
     <plugin filename="libgazebo_ros_control.so" name="gazebo_ros_control">
       <robotNamespace>j2n6s300</robotNamespace>
@@ -354,16 +340,6 @@
     </actuator>
   </transmission>
   <link name="j2n6s300_end_effector">
-    <visual>
-      <geometry>
-        <box size="0 0 0"/>
-      </geometry>
-    </visual>
-    <collision>
-      <geometry>
-        <box size="0 0 0"/>
-      </geometry>
-    </collision>
   </link>
   <joint name="j2n6s300_joint_end_effector" type="fixed">
     <parent link="j2n6s300_link_6"/>

--- a/manipulation/models/jaco_description/urdf/j2n6s300_col.urdf
+++ b/manipulation/models/jaco_description/urdf/j2n6s300_col.urdf
@@ -40,19 +40,6 @@
    finger_distal      58
 -->
   <link name="root">
-    <visual>
-      <origin rpy="0 0 0" xyz="0 0 0"/>
-      <geometry>
-        <box size="0 0 0"/>
-      </geometry>
-      <!--<material name="Black" /> -->
-    </visual>
-    <collision>
-      <origin rpy="0 0 0" xyz="0 0 0"/>
-      <geometry>
-        <box size="0 0 0"/>
-      </geometry>
-    </collision>
   </link>
   <!-- for gazebo -->
   <link name="world"/>
@@ -335,16 +322,6 @@
     </actuator>
   </transmission>
   <link name="j2n6s300_end_effector">
-    <visual>
-      <geometry>
-        <box size="0 0 0"/>
-      </geometry>
-    </visual>
-    <collision>
-      <geometry>
-        <box size="0 0 0"/>
-      </geometry>
-    </collision>
   </link>
   <joint name="j2n6s300_joint_end_effector" type="fixed">
     <parent link="j2n6s300_link_6"/>


### PR DESCRIPTION
An upcoming PR will mention this model in a `data=` line, which will
cause it to be validity checked.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14042)
<!-- Reviewable:end -->
