### PR TITLE
AutoDiffScalar: move-aware rewrites of more math

### DIFF
--- a/common/autodiffxd.h
+++ b/common/autodiffxd.h
@@ -377,103 +377,117 @@ class AutoDiffScalar<VectorXd>
 };
 
 #define DRAKE_EIGEN_AUTODIFFXD_DECLARE_GLOBAL_UNARY(FUNC, CODE) \
-  inline const AutoDiffScalar<VectorXd> FUNC(                   \
-      const AutoDiffScalar<VectorXd>& x) {                      \
+  inline AutoDiffScalar<VectorXd> FUNC(                         \
+      AutoDiffScalar<VectorXd> x) {                             \
     EIGEN_UNUSED typedef double Scalar;                         \
     CODE;                                                       \
+    return x;                                                   \
   }
 
 DRAKE_EIGEN_AUTODIFFXD_DECLARE_GLOBAL_UNARY(
-    abs, using std::abs; return Eigen::MakeAutoDiffScalar(
-        abs(x.value()), x.derivatives() * (x.value() < 0 ? -1 : 1));)
+    abs, using std::abs;
+    x.derivatives() *= (x.value() < 0 ? -1 : 1);
+    x.value() = abs(x.value());)
 
 DRAKE_EIGEN_AUTODIFFXD_DECLARE_GLOBAL_UNARY(
-    abs2, using numext::abs2; return Eigen::MakeAutoDiffScalar(
-        abs2(x.value()), x.derivatives() * (Scalar(2) * x.value()));)
+    abs2, using numext::abs2;
+    x.derivatives() *= (Scalar(2) * x.value());
+    x.value() = abs2(x.value());)
 
 DRAKE_EIGEN_AUTODIFFXD_DECLARE_GLOBAL_UNARY(
-    sqrt, using std::sqrt; Scalar sqrtx = sqrt(x.value());
-    return Eigen::MakeAutoDiffScalar(sqrtx,
-                                     x.derivatives() * (Scalar(0.5) / sqrtx));)
+    sqrt, using std::sqrt;
+    Scalar sqrtx = sqrt(x.value());
+    x.value() = sqrtx;
+    x.derivatives() *= (Scalar(0.5) / sqrtx);)
 
 DRAKE_EIGEN_AUTODIFFXD_DECLARE_GLOBAL_UNARY(
     cos, using std::cos; using std::sin;
-    return Eigen::MakeAutoDiffScalar(cos(x.value()),
-                                     x.derivatives() * (-sin(x.value())));)
+    x.derivatives() *= -sin(x.value());
+    x.value() = cos(x.value());)
 
 DRAKE_EIGEN_AUTODIFFXD_DECLARE_GLOBAL_UNARY(
     sin, using std::sin; using std::cos;
-    return Eigen::MakeAutoDiffScalar(sin(x.value()),
-                                     x.derivatives() * cos(x.value()));)
+    x.derivatives() *= cos(x.value());
+    x.value() = sin(x.value());)
 
 DRAKE_EIGEN_AUTODIFFXD_DECLARE_GLOBAL_UNARY(
-    exp, using std::exp; Scalar expx = exp(x.value());
-    return Eigen::MakeAutoDiffScalar(expx, x.derivatives() * expx);)
+    exp, using std::exp;
+    x.value() = exp(x.value());
+    x.derivatives() *= x.value();)
 
 DRAKE_EIGEN_AUTODIFFXD_DECLARE_GLOBAL_UNARY(
-    log, using std::log; return Eigen::MakeAutoDiffScalar(
-        log(x.value()), x.derivatives() * (Scalar(1) / x.value()));)
+    log, using std::log;
+    x.derivatives() *= Scalar(1) / x.value();
+    x.value() = log(x.value());)
 
 DRAKE_EIGEN_AUTODIFFXD_DECLARE_GLOBAL_UNARY(
-    tan, using std::tan; using std::cos; return Eigen::MakeAutoDiffScalar(
-        tan(x.value()),
-        x.derivatives() * (Scalar(1) / numext::abs2(cos(x.value()))));)
+    tan, using std::tan; using std::cos;
+    x.derivatives() *= Scalar(1) / numext::abs2(cos(x.value()));
+    x.value() = tan(x.value());)
 
 DRAKE_EIGEN_AUTODIFFXD_DECLARE_GLOBAL_UNARY(
-    asin, using std::sqrt; using std::asin; return Eigen::MakeAutoDiffScalar(
-        asin(x.value()),
-        x.derivatives() * (Scalar(1) / sqrt(1 - numext::abs2(x.value()))));)
+    asin, using std::sqrt; using std::asin;
+    x.derivatives() *= Scalar(1) / sqrt(1 - numext::abs2(x.value()));
+    x.value() = asin(x.value());)
 
 DRAKE_EIGEN_AUTODIFFXD_DECLARE_GLOBAL_UNARY(
-    acos, using std::sqrt; using std::acos; return Eigen::MakeAutoDiffScalar(
-        acos(x.value()),
-        x.derivatives() * (Scalar(-1) / sqrt(1 - numext::abs2(x.value()))));)
+    acos, using std::sqrt; using std::acos;
+    x.derivatives() *= Scalar(-1) / sqrt(1 - numext::abs2(x.value()));
+    x.value() = acos(x.value());)
 
 DRAKE_EIGEN_AUTODIFFXD_DECLARE_GLOBAL_UNARY(
-    atan, using std::atan; return Eigen::MakeAutoDiffScalar(
-        atan(x.value()),
-        x.derivatives() * (Scalar(1) / (1 + x.value() * x.value())));)
+    // TODO(rpoyner-tri): implementation seems fishy --see #14051.
+    atan, using std::atan;
+    x.derivatives() *= Scalar(1) / (1 + x.value() * x.value());
+    x.value() = atan(x.value());)
 
 DRAKE_EIGEN_AUTODIFFXD_DECLARE_GLOBAL_UNARY(
-    tanh, using std::cosh; using std::tanh; return Eigen::MakeAutoDiffScalar(
-        tanh(x.value()),
-        x.derivatives() * (Scalar(1) / numext::abs2(cosh(x.value()))));)
+    tanh, using std::cosh; using std::tanh;
+    x.derivatives() *= Scalar(1) / numext::abs2(cosh(x.value()));
+    x.value() = tanh(x.value());)
 
 DRAKE_EIGEN_AUTODIFFXD_DECLARE_GLOBAL_UNARY(
     sinh, using std::sinh; using std::cosh;
-    return Eigen::MakeAutoDiffScalar(sinh(x.value()),
-                                     x.derivatives() * cosh(x.value()));)
+    x.derivatives() *= cosh(x.value());
+    x.value() = sinh(x.value());)
 
 DRAKE_EIGEN_AUTODIFFXD_DECLARE_GLOBAL_UNARY(
     cosh, using std::sinh; using std::cosh;
-    return Eigen::MakeAutoDiffScalar(cosh(x.value()),
-                                     x.derivatives() * sinh(x.value()));)
+    x.derivatives() *= sinh(x.value());
+    x.value() = cosh(x.value());)
 
 #undef DRAKE_EIGEN_AUTODIFFXD_DECLARE_GLOBAL_UNARY
 
 // We have this specialization here because the Eigen-3.3.3's atan2
 // implementation for AutoDiffScalar does not make a return with properly sized
 // derivatives.
-inline const AutoDiffScalar<VectorXd> atan2(const AutoDiffScalar<VectorXd>& a,
-                                            const AutoDiffScalar<VectorXd>& b) {
+inline AutoDiffScalar<VectorXd> atan2(AutoDiffScalar<VectorXd> a,
+                                      const AutoDiffScalar<VectorXd>& b) {
   const bool has_a_der = a.derivatives().size() > 0;
   const bool has_both_der = has_a_der && (b.derivatives().size() > 0);
   const double squared_hypot = a.value() * a.value() + b.value() * b.value();
-  return MakeAutoDiffScalar(
-      std::atan2(a.value(), b.value()),
-      VectorXd((has_both_der
-                    ? VectorXd(a.derivatives() * b.value() -
-                               a.value() * b.derivatives())
-                    : has_a_der ? VectorXd(a.derivatives() * b.value())
-                                : VectorXd(-a.value() * b.derivatives())) /
-               squared_hypot));
+  if (has_both_der) {
+    a.derivatives() *= b.value();
+    a.derivatives() -= a.value() * b.derivatives();
+  } else if (has_a_der) {
+    a.derivatives() *= b.value();
+  } else {
+    a.derivatives() = -a.value() * b.derivatives();
+  }
+  a.derivatives() /= squared_hypot;
+  a.value() = std::atan2(a.value(), b.value());
+  return a;
 }
 
-inline const AutoDiffScalar<VectorXd> pow(const AutoDiffScalar<VectorXd>& a,
-                                          double b) {
+// Right-hand pass-by-value optimizations for atan2() are blocked by code in
+// Eigen; see #14039.
+
+inline AutoDiffScalar<VectorXd> pow(AutoDiffScalar<VectorXd> a, double b) {
+  // TODO(rpoyner-tri): implementation seems fishy --see #14052.
   using std::pow;
-  return MakeAutoDiffScalar(pow(a.value(), b),
-                            a.derivatives() * (b * pow(a.value(), b - 1)));
+  a.derivatives() *= b * pow(a.value(), b - 1);
+  a.value() = pow(a.value(), b);
+  return a;
 }
 
 // We have these implementations here because Eigen's implementations do not

--- a/common/test/autodiffxd_heap_test.cc
+++ b/common/test/autodiffxd_heap_test.cc
@@ -29,53 +29,59 @@ class AutoDiffXdHeapTest : public ::testing::Test {
 // implementations may be vulnerable to dead-code elimination.
 
 TEST_F(AutoDiffXdHeapTest, Abs) {
-  LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
   volatile auto v = abs(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Abs2) {
-  LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
   volatile auto v = abs2(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Acos) {
-  LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
   volatile auto v = acos(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Asin) {
-  LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
   volatile auto v = asin(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Atan) {
-  LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
   volatile auto v = atan(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Atan2) {
-  LimitMalloc guard({.max_num_allocations = 8, .min_num_allocations = 8});
-  volatile auto v = atan2(x_ + y_, y_);
-  volatile auto w = atan2(x_, x_ + y_);
+  {
+    LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+    volatile auto v = atan2(x_ + y_, y_);
+  }
+  {
+    LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+    // Right-hand parameter moves are blocked by code in Eigen; see #14039.
+    volatile auto v = atan2(y_, x_ + y_);
+  }
 }
 
 TEST_F(AutoDiffXdHeapTest, Cos) {
-  LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
   volatile auto v = cos(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Cosh) {
-  LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
   volatile auto v = cosh(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Exp) {
-  LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
   volatile auto v = exp(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Log) {
-  LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
   volatile auto v = log(x_ + y_);
 }
 
@@ -92,32 +98,32 @@ TEST_F(AutoDiffXdHeapTest, Max) {
 }
 
 TEST_F(AutoDiffXdHeapTest, Pow) {
-  LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
   volatile auto v = pow(x_ + y_, 2.0);
 }
 
 TEST_F(AutoDiffXdHeapTest, Sin) {
-  LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
   volatile auto v = sin(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Sinh) {
-  LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
   volatile auto v = sinh(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Sqrt) {
-  LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
   volatile auto v = sqrt(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Tan) {
-  LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
   volatile auto v = tan(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Tanh) {
-  LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
   volatile auto v = tanh(x_ + y_);
 }
 


### PR DESCRIPTION
Relevant to: #13985, #14039

Rewrite various global-scope math functions on AutoDiffScalars to
exploit pass-by-value optimizations; demonstrate resulting improvements
via lowered allocation counts in the heap test. The issues noted above
give more context.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14045)
<!-- Reviewable:end -->
