### PR TITLE
Revert "workspace: Update pybind11 fork to latest commit"

### DIFF
--- a/tools/workspace/pybind11/repository.bzl
+++ b/tools/workspace/pybind11/repository.bzl
@@ -6,9 +6,9 @@ load("@drake//tools/workspace:github.bzl", "github_archive")
 # Using the `drake` branch of this repository.
 _REPOSITORY = "RobotLocomotion/pybind11"
 
-_COMMIT = "58a368ea8e89638e01a7385cad9ce4345d70003d"
+_COMMIT = "18dfca681391c0d1b1d4302106c82e97a9806f46"
 
-_SHA256 = "0b10cc70112f3de67c6c732bfa35e7c0bb92244a811b55574f99edbe170150a9"
+_SHA256 = "38b608a3cc61745c4cccbd118f9034838bb5bc1c72a0e7e978245e318af7c085"
 
 def pybind11_repository(
         name,


### PR DESCRIPTION
Reverts RobotLocomotion/drake#14028

Dear @EricCousineau-TRI ,

The on-call build cop, @DamrongGuoy , believes that your PR #14028 may have
broken one or more of Drake's continuous integration builds [1]. It is
possible to break a build even if your PR passed continuous integration
pre-merge because additional platforms are tested post-merge.

The specific build failures under investigation are:
[RobotLocomotion » drake-external-examples » macos catalina 10.15:](https://github.com/RobotLocomotion/drake-external-examples/runs/1098871545?check_suite_focus=true)

Therefore, the build cop has created this revert PR and started a complete
post-merge build to determine whether your PR was in fact the cause of the
problem. If that build passes, this revert PR will be merged 60 minutes from
now. You can then fix the problem at your leisure, and send a new PR to
reinstate your change.

If you believe your original PR did not actually break the build, please
explain on this thread.

If you believe you can fix the break promptly in lieu of a revert, please
explain on this thread, and send a PR to the build cop for review ASAP.

If you believe your original PR definitely did break the build and should be
reverted, please review and LGTM this PR. This allows the build cop to merge
without waiting for CI results.

For advice on how to handle a build cop revert, see [2].

Thanks!
Your Friendly On-call Build Cop

[1] CI Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Production/
[2] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14046)
<!-- Reviewable:end -->
