### PR TITLE
Restore "workspace: Update pybind11 fork to latest commit"

### DIFF
--- a/tools/workspace/pybind11/repository.bzl
+++ b/tools/workspace/pybind11/repository.bzl
@@ -6,9 +6,9 @@ load("@drake//tools/workspace:github.bzl", "github_archive")
 # Using the `drake` branch of this repository.
 _REPOSITORY = "RobotLocomotion/pybind11"
 
-_COMMIT = "18dfca681391c0d1b1d4302106c82e97a9806f46"
+_COMMIT = "58a368ea8e89638e01a7385cad9ce4345d70003d"
 
-_SHA256 = "38b608a3cc61745c4cccbd118f9034838bb5bc1c72a0e7e978245e318af7c085"
+_SHA256 = "0b10cc70112f3de67c6c732bfa35e7c0bb92244a811b55574f99edbe170150a9"
 
 def pybind11_repository(
         name,


### PR DESCRIPTION
**Downstream Warning**:
If you are using CMake to consume `pydrake` and you compile your own bindings using `pybind11_add_module`, you must now reset your target's default visibility to "default" (not "hidden").
See [drake_cmake_installed](https://github.com/RobotLocomotion/drake-external-examples/blob/9a70157/drake_cmake_installed/src/simple_bindings/CMakeLists.txt#L45) for an example of doing so.

This reverts commit 690a7eacd136c842d2a7aeda7a5228cfa9d7af95.

Resolves #14047

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14048)
<!-- Reviewable:end -->
