### PR TITLE
pydrake: Move {start,end}_time() to Trajectory

### DIFF
--- a/bindings/pydrake/test/trajectories_test.py
+++ b/bindings/pydrake/test/trajectories_test.py
@@ -7,11 +7,16 @@ from pydrake.common.test_utilities import numpy_compare
 from pydrake.math import RotationMatrix
 from pydrake.polynomial import Polynomial
 from pydrake.trajectories import (
-    PiecewisePolynomial, PiecewiseQuaternionSlerp
+    PiecewisePolynomial, PiecewiseQuaternionSlerp, Trajectory
 )
 
 
 class TestTrajectories(unittest.TestCase):
+    def test_trajectory_start_end_time(self):
+        # Acceptance check to ensure we have these base methods exposed.
+        Trajectory.start_time
+        Trajectory.end_time
+
     def test_piecewise_polynomial_empty_constructor(self):
         pp = PiecewisePolynomial()
 

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -31,6 +31,9 @@ PYBIND11_MODULE(trajectories, m) {
           py::arg("derivative_order") = 1, doc.Trajectory.EvalDerivative.doc)
       .def("MakeDerivative", &Trajectory<T>::MakeDerivative,
           py::arg("derivative_order") = 1, doc.Trajectory.MakeDerivative.doc)
+      .def("start_time", &Trajectory<T>::start_time,
+          doc.Trajectory.start_time.doc)
+      .def("end_time", &Trajectory<T>::end_time, doc.Trajectory.end_time.doc)
       .def("rows", &Trajectory<T>::rows, doc.Trajectory.rows.doc)
       .def("cols", &Trajectory<T>::cols, doc.Trajectory.cols.doc);
 
@@ -49,6 +52,8 @@ PYBIND11_MODULE(trajectories, m) {
           py::arg("segment_index"), doc.PiecewiseTrajectory.end_time.doc)
       .def("duration", &PiecewiseTrajectory<T>::duration,
           py::arg("segment_index"), doc.PiecewiseTrajectory.duration.doc)
+      // N.B. We must redefine these two overloads, as we cannot use the base
+      // classes' overloads. See: https://github.com/pybind/pybind11/issues/974
       .def("start_time",
           overload_cast_explicit<double>(&PiecewiseTrajectory<T>::start_time),
           doc.PiecewiseTrajectory.start_time.doc)


### PR DESCRIPTION
These methods were moved from `PiecewiseTrajectory` to its parent class a while ago in C++, but the bindings weren't updated. I'd like to have these as methods of `Trajectory` so that I don't need to repeat the bindings for other children that don't inherit from `PiecewiseTrajectory`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14049)
<!-- Reviewable:end -->
