### PR TITLE
doc: Fix typo in v0.23 release notes

### DIFF
--- a/doc/release_notes/v0.23.0.rst
+++ b/doc/release_notes/v0.23.0.rst
@@ -17,13 +17,13 @@ These are breaking changes that did not undergo a deprecation period:
   final (`#13907`_).
 * Add [[nodiscard]] attributes to symbolic functions (`#14020`_, `#14021`_).
 * The drake/common/symbolic.h headers now ``#error`` when included incorrectly
+  (`#14003`_).
 * For drake::yaml::YamlReadArchive, it's now an error for yaml data to remain
   unparsed, unless the user opts in to allowing it; users who want a different
   behavior should change the Options at construction-time (`#13900`_).
 * The drake::examples::rod2d::Rod2D::pose_output() port has been removed, as
   the system no longer connects to the systems::rendering API (`#13890`_).
 * Remove pydrake.systems.framework.kAutoSize (`#13981`_).
-  (`#14003`_).
 * If you are using CMake to consume pydrake and you compile your own bindings
   using pybind11_add_module, you must now reset your target's default
   visibility to "default" (not "hidden") (`#14048`_).


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14061)
<!-- Reviewable:end -->
