### PR TITLE
setup: Fix typo in Ubuntu maintainer-only code

### DIFF
--- a/setup/ubuntu/binary_distribution/install_prereqs.sh
+++ b/setup/ubuntu/binary_distribution/install_prereqs.sh
@@ -31,4 +31,5 @@ pkg-config
 EOF
 )
 
-apt-get install --no-install-recommends $(cat "${BASH_SOURCE%/*}/packages-${codename}.txt")
+packages=$(cat "${BASH_SOURCE%/*}/packages-${codename}.txt")
+apt-get install --no-install-recommends ${packages}

--- a/setup/ubuntu/source_distribution/install_prereqs.sh
+++ b/setup/ubuntu/source_distribution/install_prereqs.sh
@@ -71,8 +71,8 @@ if [[ "${codename}" == 'bionic' ]] && [[ "${with_kcov}" -eq 1 ]]; then
 fi
 
 apt-get update
-apt-get install --no-install-recommends \
-  $(cat "${BASH_SOURCE%/*}/packages-${codename}.txt")
+packages=$(cat "${BASH_SOURCE%/*}/packages-${codename}.txt")
+apt-get install --no-install-recommends ${packages}
 
 # Ensure that we have available a locale that supports UTF-8 for generating a
 # C++ header containing Python API documentation during the build.
@@ -90,20 +90,20 @@ if [[ "${codename}" == 'focal' ]]; then
 fi
 
 if [[ "${with_doc_only}" -eq 1 ]]; then
-  apt-get install --no-install-recommends \
-    $(cat "${BASH_SOURCE%/*}/packages-${codename}-doc-only.txt")
+  packages=$(cat "${BASH_SOURCE%/*}/packages-${codename}-doc-only.txt")
+  apt-get install --no-install-recommends ${packages}
 fi
 
 if [[ "${with_test_only}" -eq 1 ]]; then
+  packages=$(cat "${BASH_SOURCE%/*}/packages-${codename}-test-only.txt")
   # Suppress Python 3.8 warnings when installing python3-pandas on Focal.
   PYTHONWARNINGS=ignore::SyntaxWarning \
-    apt-get install --no-install-recommends \
-      $(cat "${BASH_SOURCE%/*}/packages-${codename}-test-only.txt")
+    apt-get install --no-install-recommends ${packages}
 fi
 
 if [[ "${with_maintainer_only}" -eq 1 ]]; then
-  apt-get install --no-install-recommends \
-    $(cat "${BASH_SOURCE%/*}/packages-${codename}-maintainer.txt")
+  packages=$(cat "${BASH_SOURCE%/*}/packages-${codename}-maintainer-only.txt")
+  apt-get install --no-install-recommends ${packages}
 fi
 
 dpkg_install_from_wget() {


### PR DESCRIPTION
Rewrite the `apt-get` command lines to fail-fast if there is a filename typo in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14074)
<!-- Reviewable:end -->
