### PR TITLE
yaml: Bugfix in std::optional handling

### DIFF
--- a/common/yaml/test/example_structs.h
+++ b/common/yaml/test/example_structs.h
@@ -149,6 +149,24 @@ struct OptionalStruct {
   std::optional<double> value;
 };
 
+struct OptionalStructNoDefault {
+  template <typename Archive>
+  void Serialize(Archive* a) {
+    a->Visit(DRAKE_NVP(value));
+  }
+
+  OptionalStructNoDefault()
+      : value(std::nullopt) {}
+
+  explicit OptionalStructNoDefault(const double value_in)
+      : OptionalStructNoDefault(std::optional<double>(value_in)) {}
+
+  explicit OptionalStructNoDefault(const std::optional<double>& value_in)
+      : value(value_in) {}
+
+  std::optional<double> value;
+};
+
 using Variant4 = std::variant<std::string, double, DoubleStruct, StringStruct>;
 
 std::ostream& operator<<(std::ostream& os, const Variant4& value) {

--- a/common/yaml/test/yaml_read_archive_test.cc
+++ b/common/yaml/test/yaml_read_archive_test.cc
@@ -371,9 +371,19 @@ TEST_P(YamlReadArchiveTest, Optional) {
     }
   };
 
-  test("doc: {}", std::nullopt);
+  if (GetParam().allow_cpp_with_no_yaml) {
+    test("doc: {}", kNominalDouble);
+  } else {
+    test("doc: {}", std::nullopt);
+  }
   if (GetParam().allow_yaml_with_no_cpp) {
-    test("doc:\n  foo: bar", std::nullopt);
+    test("doc:\n  foo: bar\n  value: 1.0", 1.0);
+    test("doc:\n  foo: bar\n  value:", std::nullopt);
+    if (GetParam().allow_cpp_with_no_yaml) {
+      test("doc:\n  foo: bar", kNominalDouble);
+    } else {
+      test("doc:\n  foo: bar", std::nullopt);
+    }
   }
   test("doc:\n  value:", std::nullopt);
   test("doc:\n  value: 1.0", 1.0);

--- a/common/yaml/yaml_read_archive.h
+++ b/common/yaml/yaml_read_archive.h
@@ -293,15 +293,24 @@ class YamlReadArchive final {
     // or has an empty value.  In yaml-cpp, presence is denoted by IsDefined(),
     // and empty is denoted by IsNull().
     const auto& sub_node = MaybeGetSubNode(nvp.name());
-    if (!sub_node.IsDefined() || sub_node.IsNull()) {
+
+    if ((!sub_node.IsDefined() && !options_.allow_cpp_with_no_yaml) ||
+        (sub_node.IsDefined() && sub_node.IsNull())) {
       *nvp.value() = std::nullopt;
       return;
     }
 
-    // Visit the unpacked optional as if it weren't wrapped in optional<>.
+    // Ensure we have a fully constructed object because either the YAML has a
+    // non-NULL entry, or the value is allowed to be defaulted by setting
+    // options_.allow_cpp_with_no_yaml to true
     using T = typename NVP::value_type::value_type;
     std::optional<T>& storage = *nvp.value();
     if (!storage) { storage = T{}; }
+
+    if (!sub_node.IsDefined() && options_.allow_cpp_with_no_yaml) {
+      return;
+    }
+    // Visit the unpacked optional as if it weren't wrapped in optional<>.
     this->Visit(drake::MakeNameValue(nvp.name(), &storage.value()),
                 VisitShouldMemorizeType::kNo);
   }

--- a/common/yaml/yaml_read_archive.h
+++ b/common/yaml/yaml_read_archive.h
@@ -303,7 +303,7 @@ class YamlReadArchive final {
       return;
     }
 
-    if (sub_node.IsDefined() && sub_node.IsNull()) {
+    if (sub_node.IsNull()) {
       *nvp.value() = std::nullopt;
       return;
     }


### PR DESCRIPTION
This change allows the `allow_cpp_with_no_yaml = true` option to correctly return `std::optional` objects that are valid, even when the yaml string does have have the given field.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14076)
<!-- Reviewable:end -->
