### PR TITLE
manipulation_station: change controller plant to discrete time

### DIFF
--- a/examples/manipulation_station/manipulation_station.cc
+++ b/examples/manipulation_station/manipulation_station.cc
@@ -54,7 +54,8 @@ namespace internal {
 SpatialInertia<double> MakeCompositeGripperInertia(
     const std::string& wsg_sdf_path,
     const std::string& gripper_body_frame_name) {
-  MultibodyPlant<double> plant(0.0);
+  // Set timestep to 1.0 since it is arbitrary, to quiet joint limit warnings.
+  MultibodyPlant<double> plant(1.0);
   multibody::Parser parser(&plant);
   parser.AddModelFromFile(wsg_sdf_path);
   plant.Finalize();
@@ -157,9 +158,9 @@ ManipulationStation<T>::ManipulationStation(double time_step)
     : owned_plant_(std::make_unique<MultibodyPlant<T>>(time_step)),
       owned_scene_graph_(std::make_unique<SceneGraph<T>>()),
       // Given the controller does not compute accelerations, it is irrelevant
-      // whether the plant is continuous or discrete. We arbitrarily make it
-      // continuous.
-      owned_controller_plant_(std::make_unique<MultibodyPlant<T>>(0.0)) {
+      // whether the plant is continuous or discrete. We make it
+      // discrete to avoid warnings about joint limits.
+      owned_controller_plant_(std::make_unique<MultibodyPlant<T>>(1.0)) {
   // This class holds the unique_ptrs explicitly for plant and scene_graph
   // until Finalize() is called (when they are moved into the Diagram). Grab
   // the raw pointers, which should stay valid for the lifetime of the Diagram.


### PR DESCRIPTION
It has no impact on the manipulation station behavior, but avoids the noisy warnings about unsupported joint limits for continuous time models.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14079)
<!-- Reviewable:end -->
