### PR TITLE
Improve inlining for EigenPtr and RotationalInertia::ReExpress

### DIFF
--- a/common/symbolic_decompose.cc
+++ b/common/symbolic_decompose.cc
@@ -47,6 +47,7 @@ void DecomposeLinearExpressions(
     const Eigen::Ref<const VectorX<Expression>>& expressions,
     const Eigen::Ref<const VectorX<symbolic::Variable>>& vars,
     EigenPtr<Eigen::MatrixXd> M) {
+  DRAKE_DEMAND(M != nullptr);
   DRAKE_DEMAND(M->rows() == expressions.rows() && M->cols() == vars.rows());
   for (int i = 0; i < expressions.size(); ++i) {
     const Expression& e{expressions(i)};
@@ -73,6 +74,7 @@ void DecomposeAffineExpressions(
     const Eigen::Ref<const VectorX<Expression>>& expressions,
     const Eigen::Ref<const VectorX<symbolic::Variable>>& vars,
     EigenPtr<Eigen::MatrixXd> M, EigenPtr<Eigen::VectorXd> v) {
+  DRAKE_DEMAND(M != nullptr && v != nullptr);
   DRAKE_DEMAND(M->rows() == expressions.rows() && M->cols() == vars.rows());
   DRAKE_DEMAND(v->rows() == expressions.rows());
   for (int i = 0; i < expressions.size(); ++i) {

--- a/common/test/eigen_types_test.cc
+++ b/common/test/eigen_types_test.cc
@@ -93,7 +93,6 @@ GTEST_TEST(EigenTypesTest, EigenPtr_Null) {
   EXPECT_FALSE(null_ptr != nullptr);
   EXPECT_TRUE(!null_ptr);
   EXPECT_TRUE(null_ptr == nullptr);
-  EXPECT_THROW(*null_ptr, std::runtime_error);
 
   Matrix3d X;
   X.setConstant(0);
@@ -132,12 +131,10 @@ GTEST_TEST(EigenTypesTest, EigenPtr) {
   // Tests set.
   set(&M1, 0, 0, 1);       // Sets M1(0,0) = 1
   EXPECT_EQ(M1(0, 0), 1);  // Checks M1(0, 0) = 1
-  EXPECT_THROW(set(nullptr, 0, 0, 1), std::runtime_error);
 
   // Tests get.
   EXPECT_EQ(get(&M1, 0, 0), 1);  // Checks M1(0, 0) = 1
   EXPECT_EQ(get(&M2, 0, 0), 0);  // Checks M2(0, 0) = 1
-  EXPECT_THROW(get(nullptr, 0, 0), std::runtime_error);
 
   // Shows how to use EigenPtr with .block(). Here we introduce `tmp` to avoid
   // taking the address of temporary object.

--- a/examples/acrobot/acrobot_plant.cc
+++ b/examples/acrobot/acrobot_plant.cc
@@ -129,6 +129,7 @@ void AcrobotPlant<T>::DoCalcImplicitTimeDerivativesResidual(
     const systems::Context<T>& context,
     const systems::ContinuousState<T>& proposed_derivatives,
     EigenPtr<VectorX<T>> residual) const {
+  DRAKE_DEMAND(residual != nullptr);
   const AcrobotState<T>& state = get_state(context);
   const T& tau = get_tau(context);
 

--- a/examples/mass_spring_cloth/cloth_spring_model.cc
+++ b/examples/mass_spring_cloth/cloth_spring_model.cc
@@ -253,6 +253,7 @@ void ClothSpringModel<T>::UpdateDiscreteState(
 template <typename T>
 void ClothSpringModel<T>::AccumulateContinuousSpringForce(
     const systems::Context<T>& context, EigenPtr<VectorX<T>> forces) const {
+  DRAKE_DEMAND(forces != nullptr);
   const VectorX<T> continuous_states =
       context.get_continuous_state().CopyToVector();
   const auto& q = continuous_states.head(num_positions());
@@ -267,6 +268,7 @@ void ClothSpringModel<T>::AccumulateElasticForce(
     const ClothSpringModelParams<T>& param,
     const Eigen::Ref<const VectorX<T>>& q,
     EigenPtr<VectorX<T>> elastic_force) const {
+  DRAKE_DEMAND(elastic_force != nullptr);
   for (const Spring& s : springs_) {
     // Get the positions of the two particles connected by the spring.
     const int p0 = s.particle0;
@@ -291,6 +293,7 @@ void ClothSpringModel<T>::AccumulateDampingForce(
     const Eigen::Ref<const VectorX<T>>& q,
     const Eigen::Ref<const VectorX<T>>& v,
     EigenPtr<VectorX<T>> damping_force) const {
+  DRAKE_DEMAND(damping_force != nullptr);
   for (const Spring& s : springs_) {
     // Get the positions and velocities of the two particles connected by
     // the spring.

--- a/examples/mass_spring_cloth/cloth_spring_model.h
+++ b/examples/mass_spring_cloth/cloth_spring_model.h
@@ -141,6 +141,7 @@ class ClothSpringModel final : public systems::LeafSystem<T> {
    the quantity vectors.*/
   static void set_particle_state(int particle_index, const Vector3<T>& state,
                                  EigenPtr<VectorX<T>> vec) {
+    DRAKE_ASSERT(vec != nullptr);
     const int p_index = particle_index * 3;
     (*vec)[p_index] = state(0);
     (*vec)[p_index + 1] = state(1);
@@ -154,6 +155,7 @@ class ClothSpringModel final : public systems::LeafSystem<T> {
   static void accumulate_particle_state(int particle_index,
                                         const Vector3<T>& state,
                                         EigenPtr<VectorX<T>> vec) {
+    DRAKE_ASSERT(vec != nullptr);
     const int p_index = particle_index * 3;
     (*vec)[p_index] += state(0);
     (*vec)[p_index + 1] += state(1);

--- a/math/barycentric.cc
+++ b/math/barycentric.cc
@@ -34,6 +34,7 @@ template <typename T>
 void BarycentricMesh<T>::get_mesh_point(int index,
                                         EigenPtr<Eigen::VectorXd> point) const {
   DRAKE_DEMAND(index >= 0);
+  DRAKE_DEMAND(point != nullptr);
   point->resize(get_input_size());
   // Iterate through the input dimensions, assigning the value and reducing
   // the index to be relevant only to the remaining dimensions.
@@ -72,6 +73,7 @@ void BarycentricMesh<T>::EvalBarycentricWeights(
     EigenPtr<Eigen::VectorXi> mesh_indices,
     EigenPtr<VectorX<T>> weights) const {
   DRAKE_DEMAND(input.size() == static_cast<int>(input_grid_.size()));
+  DRAKE_DEMAND(mesh_indices != nullptr && weights != nullptr);
 
   // std::pair of fractional position [0,1] and dimension index (position first,
   // so that std::pair's default operator< works for us).

--- a/math/barycentric.h
+++ b/math/barycentric.h
@@ -130,6 +130,7 @@ class BarycentricMesh {
       const Eigen::Ref<const MatrixX<ValueT>>& mesh_values,
       const Eigen::Ref<const VectorX<T>>& input,
       EigenPtr<VectorX<ValueT>> output) const {
+    DRAKE_DEMAND(output != nullptr);
     DRAKE_DEMAND(input.size() == get_input_size());
     DRAKE_DEMAND(mesh_values.cols() == get_num_mesh_points());
 

--- a/multibody/math/spatial_force.h
+++ b/multibody/math/spatial_force.h
@@ -141,6 +141,7 @@ class SpatialForce : public SpatialVector<SpatialForce, T> {
   /// @see ShiftInPlace(const Vector3<T>&) for details.
   static void ShiftInPlace(EigenPtr<Matrix6X<T>> F_Bp_E_all,
                            const Vector3<T>& p_BpBq_E) {
+    DRAKE_ASSERT(F_Bp_E_all != nullptr);  // ASSERT because inner loop method.
     const int ncol = F_Bp_E_all->cols();
     for (int j = 0; j < ncol; ++j) {
       // These are Eigen intermediate types; better not to look!

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1983,6 +1983,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       ModelInstanceIndex model_instance,
       const Eigen::Ref<const VectorX<T>>& u_instance,
       EigenPtr<VectorX<T>> u) const {
+    DRAKE_DEMAND(u != nullptr);
     internal_tree().SetActuationInArray(model_instance, u_instance, u);
   }
 
@@ -2005,6 +2006,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       ModelInstanceIndex model_instance,
       const Eigen::Ref<const VectorX<T>>& q_instance,
       EigenPtr<VectorX<T>> q) const {
+    DRAKE_DEMAND(q != nullptr);
     internal_tree().SetPositionsInArray(model_instance, q_instance, q);
   }
 
@@ -2027,6 +2029,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       ModelInstanceIndex model_instance,
       const Eigen::Ref<const VectorX<T>>& v_instance,
       EigenPtr<VectorX<T>> v) const {
+    DRAKE_DEMAND(v != nullptr);
     internal_tree().SetVelocitiesInArray(model_instance, v_instance, v);
   }
   /// @} <!-- State accessors and mutators -->
@@ -2361,6 +2364,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const Eigen::Ref<const MatrixX<T>>& p_BQi,
       const Frame<T>& frame_A,
       EigenPtr<MatrixX<T>> p_AQi) const {
+    DRAKE_DEMAND(p_AQi != nullptr);
     return internal_tree().CalcPointsPositions(
         context, frame_B, p_BQi, frame_A, p_AQi);
   }
@@ -2548,6 +2552,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const systems::Context<T>& context,
       const Eigen::Ref<const VectorX<T>>& v,
       EigenPtr<VectorX<T>> qdot) const {
+    DRAKE_DEMAND(qdot != nullptr);
     return internal_tree().MapVelocityToQDot(context, v, qdot);
   }
 
@@ -2580,6 +2585,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const systems::Context<T>& context,
       const Eigen::Ref<const VectorX<T>>& qdot,
       EigenPtr<VectorX<T>> v) const {
+    DRAKE_DEMAND(v != nullptr);
     internal_tree().MapQDotToVelocity(context, qdot, v);
   }
   /// @} <!-- Kinematic and dynamic computations -->
@@ -2631,6 +2637,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// mass matrix whenever possible.
   void CalcMassMatrixViaInverseDynamics(
       const systems::Context<T>& context, EigenPtr<MatrixX<T>> M) const {
+    DRAKE_DEMAND(M != nullptr);
     internal_tree().CalcMassMatrixViaInverseDynamics(context, M);
   }
 
@@ -2651,6 +2658,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// mass matrix whenever possible.
   void CalcMassMatrix(const systems::Context<T>& context,
                       EigenPtr<MatrixX<T>> M) const {
+    DRAKE_DEMAND(M != nullptr);
     internal_tree().CalcMassMatrix(context, M);
   }
 
@@ -2676,6 +2684,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   ///   proper size.
   void CalcBiasTerm(
       const systems::Context<T>& context, EigenPtr<VectorX<T>> Cv) const {
+    DRAKE_DEMAND(Cv != nullptr);
     internal_tree().CalcBiasTerm(context, Cv);
   }
 
@@ -2818,6 +2827,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
                                    const Frame<T>& frame_A,
                                    const Frame<T>& frame_E,
                                    EigenPtr<MatrixX<T>> Js_V_ABp_E) const {
+    DRAKE_DEMAND(Js_V_ABp_E != nullptr);
     internal_tree().CalcJacobianSpatialVelocity(context, with_respect_to,
                                                 frame_B, p_BoBp_B, frame_A,
                                                 frame_E, Js_V_ABp_E);
@@ -2854,6 +2864,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
                                    const Frame<T>& frame_A,
                                    const Frame<T>& frame_E,
                                    EigenPtr<Matrix3X<T>> Js_w_AB_E) const {
+    DRAKE_DEMAND(Js_w_AB_E != nullptr);
     return internal_tree().CalcJacobianAngularVelocity(
         context, with_respect_to, frame_B, frame_A, frame_E, Js_w_AB_E);
   }
@@ -2903,6 +2914,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       EigenPtr<MatrixX<T>> Js_v_ABi_E) const {
     // TODO(amcastro-tri): provide the Jacobian-times-vector operation.  For
     // some applications it is all we need and it is more efficient to compute.
+    DRAKE_DEMAND(Js_v_ABi_E != nullptr);
     internal_tree().CalcJacobianTranslationalVelocity(
         context, with_respect_to, frame_B, frame_B, p_BoBi_B, frame_A, frame_E,
         Js_v_ABi_E);
@@ -2937,6 +2949,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       EigenPtr<Matrix3X<T>> Js_v_ACcm_E) const {
     // TODO(yangwill): Add an optional parameter to calculate this for a
     // subset of bodies instead of the full system
+    DRAKE_DEMAND(Js_v_ACcm_E != nullptr);
     internal_tree().CalcJacobianCenterOfMassTranslationalVelocity(
         context, with_respect_to, frame_A, frame_E, Js_v_ACcm_E);
   }

--- a/multibody/plant/tamsi_solver.cc
+++ b/multibody/plant/tamsi_solver.cc
@@ -263,6 +263,7 @@ void TamsiSolver<T>::SetOneWayCoupledProblemData(
     EigenPtr<const MatrixX<T>> Jn, EigenPtr<const MatrixX<T>> Jt,
     EigenPtr<const VectorX<T>> p_star,
     EigenPtr<const VectorX<T>> fn, EigenPtr<const VectorX<T>> mu) {
+  DRAKE_DEMAND(M && Jn && Jt && p_star && fn && mu);
   nc_ = fn->size();
   DRAKE_THROW_UNLESS(p_star->size() == nv_);
   DRAKE_THROW_UNLESS(M->rows() == nv_ && M->cols() == nv_);
@@ -280,6 +281,8 @@ void TamsiSolver<T>::SetTwoWayCoupledProblemData(
     EigenPtr<const MatrixX<T>> Jt, EigenPtr<const VectorX<T>> p_star,
     EigenPtr<const VectorX<T>> fn0, EigenPtr<const VectorX<T>> stiffness,
     EigenPtr<const VectorX<T>> dissipation, EigenPtr<const VectorX<T>> mu) {
+  DRAKE_DEMAND(M && Jn && Jt && p_star && fn0 && stiffness && dissipation
+                   && mu);
   nc_ = fn0->size();
   DRAKE_THROW_UNLESS(p_star->size() == nv_);
   DRAKE_THROW_UNLESS(M->rows() == nv_ && M->cols() == nv_);

--- a/multibody/plant/test/multibody_plant_forward_dynamics_test.cc
+++ b/multibody/plant/test/multibody_plant_forward_dynamics_test.cc
@@ -41,6 +41,7 @@ class KukaIiwaModelForwardDynamicsTests : public test::KukaIiwaModelTests {
       const Eigen::Ref<const VectorX<double>>& q,
       const Eigen::Ref<const VectorX<double>>& v,
       EigenPtr<VectorX<double>> vdot) {
+    DRAKE_DEMAND(vdot != nullptr);
     // Update joint positions and velocities.
     VectorX<double> x(q.size() + v.size());
     x << q, v;
@@ -59,6 +60,7 @@ class KukaIiwaModelForwardDynamicsTests : public test::KukaIiwaModelTests {
       const Eigen::Ref<const VectorX<double>>& q,
       const Eigen::Ref<const VectorX<double>>& v,
       EigenPtr<VectorX<double>> vdot) {
+    DRAKE_DEMAND(vdot != nullptr);
     // Update joint positions and velocities.
     VectorX<double> x(q.size() + v.size());
     x << q, v;

--- a/multibody/tree/model_instance.cc
+++ b/multibody/tree/model_instance.cc
@@ -66,7 +66,7 @@ template <class T>
 void ModelInstance<T>::SetPositionsInArray(
     const Eigen::Ref<const VectorX<T>>& model_q,
     EigenPtr<VectorX<T>> q_array) const {
-  DRAKE_DEMAND(q_array);
+  DRAKE_DEMAND(q_array != nullptr);
   if (q_array->size() != this->get_parent_tree().num_positions() ||
       model_q.size() != num_positions()) {
     throw std::logic_error("Passed in array(s) is not properly sized.");
@@ -102,6 +102,7 @@ template <class T>
 void ModelInstance<T>::SetVelocitiesInArray(
     const Eigen::Ref<const VectorX<T>>& model_v,
     EigenPtr<VectorX<T>> v_array) const {
+  DRAKE_DEMAND(v_array != nullptr);
   DRAKE_DEMAND(v_array->size() == this->get_parent_tree().num_velocities());
   DRAKE_DEMAND(model_v.size() == num_velocities());
   int velocity_offset = 0;


### PR DESCRIPTION
This is a small installment along the long path to improving MultibodyPlant performance as tracked in #13902. My ultimate goal is to have all inner-loop computations in MBPlant inlined. To achieve that requires that the very lowest-level tiny methods (e.g. accessors, dot products) inline successfully, otherwise they prevent their callers from inlining.

Studying the timings and generated assembly code in kcachegrind for the InverseDynamics subtest, I discovered some unexpected failures-to-inline for some low-level methods:
- EigenPtr operator* and operator-> (implemented via private get_reference())
- Eigen's comma initializer operator as used in RotationalInertia::ReExpressInPlace (see #13962).

EigenPtr had a release-mode error check that I've replaced with a prerequisite checked only in Debug. I eliminated the comma operators from ReExpressInPlace() in favor of direct element assignment. Looking again in kcachegrind, ReExpressInPlace()'s internals are now entirely inline and get_reference() no longer appears at all.

The overall effect of these tiny changes is a 1% speedup for mass matrix, inverse, and forward dynamics computations as measured by cassie_benchmark. (About 0.75% for ReExpressInPlace() and 0.25% for EigenPtr.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14088)
<!-- Reviewable:end -->
