### PR TITLE
parsing: Don't warn when re-discovering the same package.xml

### DIFF
--- a/multibody/parsing/package_map.cc
+++ b/multibody/parsing/package_map.cc
@@ -128,8 +128,13 @@ void PackageMap::AddPackageIfNew(const string& package_name,
   if (!Contains(package_name)) {
     Add(package_name, path);
   } else {
-    drake::log()->warn("Package \"{}\" was found more than once in the "
-                       "search space.", package_name);
+    const string existing_path = GetPath(package_name);
+    if (path != existing_path) {
+      drake::log()->warn(
+          "PackageMap is ignoring newly-found path \"{}\" for package \"{}\""
+          " and will continue using the previously-known path at \"{}\".",
+          path, package_name, existing_path);
+    }
   }
 }
 

--- a/multibody/parsing/package_map.h
+++ b/multibody/parsing/package_map.h
@@ -77,8 +77,9 @@ class PackageMap {
   void CrawlForPackages(const std::string& path);
 
   // This method is the same as Add() except it first checks to ensure that
-  // package_name is not already in this PackageMap. If it is not, this
-  // method prints a warning and returns.
+  // package_name is not already in this PackageMap. If it was already present
+  // with a different path, then this method prints a warning and returns
+  // without adding the new path.
   void AddPackageIfNew(const std::string& package_name,
       const std::string& path);
 

--- a/multibody/parsing/test/package_map_test.cc
+++ b/multibody/parsing/test/package_map_test.cc
@@ -123,6 +123,10 @@ GTEST_TEST(PackageMapTest, TestPopulateUpstreamToDrake) {
   };
 
   VerifyMatch(package_map, expected_packages);
+
+  // Call it again to exercise the "don't add things twice" code.
+  package_map.PopulateUpstreamToDrake(sdf_file_name);
+  VerifyMatch(package_map, expected_packages);
 }
 
 // Tests that PackageMap can be populated from an env var.


### PR DESCRIPTION
As best I can tell, this bug has been around ~forever.

Closes #14032.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14089)
<!-- Reviewable:end -->
