### PR TITLE
Disable range-loop-analysis warnings for Clang 10 and Apple Clang 12

### DIFF
--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -1,6 +1,6 @@
 # -*- python -*-
 
-load("@cc//:compiler.bzl", "COMPILER_ID")
+load("@cc//:compiler.bzl", "COMPILER_ID", "COMPILER_VERSION_MAJOR")
 
 # The CXX_FLAGS will be enabled for all C++ rules in the project
 # building with any compiler.
@@ -16,7 +16,8 @@ CXX_FLAGS = [
 ]
 
 # The CLANG_FLAGS will be enabled for all C++ rules in the project when
-# building with clang (including the Apple LLVM compiler).
+# building with clang (excluding the Apple LLVM compiler see APPLECLANG_FLAGS
+# below).
 CLANG_FLAGS = CXX_FLAGS + [
     "-Werror=absolute-value",
     "-Werror=inconsistent-missing-override",
@@ -24,6 +25,29 @@ CLANG_FLAGS = CXX_FLAGS + [
     "-Werror=return-stack-address",
     "-Werror=sign-compare",
 ]
+
+# The CLANG_VERSION_SPECIFIC_FLAGS will be enabled for all C++ rules in the
+# project when building with a Clang compiler of the specified major
+# version (excluding the Apple LLVM compiler, see
+# APPLECLANG_VERSION_SPECIFIC_FLAGS below).
+CLANG_VERSION_SPECIFIC_FLAGS = {
+    10: [
+        # TODO(jamiesnape): Fix these warnings and remove this suppression when
+        # Clang 10 is a supported compiler on Ubuntu.
+        "-Wno-range-loop-analysis",
+    ],
+}
+
+# The APPLECLANG_FLAGS will be enabled for all C++ rules in the project when
+# building with the Apple LLVM compiler.
+APPLECLANG_FLAGS = CLANG_FLAGS
+
+# The APPLECLANG_VERSION_SPECIFIC_FLAGS will be enabled for all C++ rules in
+# the project when building with an Apple LLVM compiler of the specified major
+# version.
+APPLECLANG_VERSION_SPECIFIC_FLAGS = {
+    12: CLANG_VERSION_SPECIFIC_FLAGS[10],
+}
 
 # The GCC_FLAGS will be enabled for all C++ rules in the project when
 # building with gcc.
@@ -50,8 +74,14 @@ def _platform_copts(rule_copts, rule_gcc_copts, rule_clang_copts, cc_test = 0):
     When cc_test=1, the GCC_CC_TEST_FLAGS will be added.  It should only be set
     to 1 from cc_test rules or rules that are boil down to cc_test rules.
     """
-    if COMPILER_ID.endswith("Clang"):
+    if COMPILER_ID == "AppleClang":
+        result = APPLECLANG_FLAGS + rule_copts + rule_clang_copts
+        if COMPILER_VERSION_MAJOR in APPLECLANG_VERSION_SPECIFIC_FLAGS:
+            result += APPLECLANG_VERSION_SPECIFIC_FLAGS[COMPILER_VERSION_MAJOR]
+    elif COMPILER_ID == "Clang":
         result = CLANG_FLAGS + rule_copts + rule_clang_copts
+        if COMPILER_VERSION_MAJOR in CLANG_VERSION_SPECIFIC_FLAGS:
+            result += CLANG_VERSION_SPECIFIC_FLAGS[COMPILER_VERSION_MAJOR]
     elif COMPILER_ID == "GNU":
         extra_gcc_flags = GCC_CC_TEST_FLAGS if cc_test else []
         result = GCC_FLAGS + extra_gcc_flags + rule_copts + rule_gcc_copts

--- a/tools/workspace/cc/repository.bzl
+++ b/tools/workspace/cc/repository.bzl
@@ -147,7 +147,10 @@ def _impl(repository_ctx):
 
 COMPILER_ID = "{}"
 
-""".format(compiler_id)
+COMPILER_VERSION_MAJOR = {}
+COMPILER_VERSION_MINOR = {}
+
+""".format(compiler_id, compiler_version_major, compiler_version_minor)
 
     repository_ctx.file(
         "compiler.bzl",


### PR DESCRIPTION
Relates #14085. This is the minimal solution to make Xcode 12 users happy again. I will follow up fixing the warnings since they are trivial to fix, but this will stay in place until Ubuntu users can reproduce the same set of compiler warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14091)
<!-- Reviewable:end -->
