### PR TITLE
py mbp: Make SpatialVector's default constructor initialize to NaN

### DIFF
--- a/bindings/pydrake/common/test_utilities/numpy_compare.py
+++ b/bindings/pydrake/common/test_utilities/numpy_compare.py
@@ -73,7 +73,14 @@ def to_float(x):
 
 
 def assert_equal(a, b):
-    """Compare scalars or arrays directly, requiring equality."""
+    """
+    Compare scalars or arrays directly, requiring equality.
+
+    For non-object dtypes, this has the same behavior as
+    ``np.testing.assert_equal``, namely that two NaNs being in the same
+    positions in an array implies equality, rather than NaN being compared as
+    numbers.
+    """
     a, b = map(np.asarray, (a, b))
     if a.size == 0 and b.size == 0:
         return
@@ -116,7 +123,10 @@ def assert_not_equal(a, b):
 
 def assert_float_equal(a, bf):
     """Checks equality of `a` (non-float) and `bf` (float) by converting `a` to
-    floats."""
+    floats.
+
+    See also: ``assert_equal``
+    """
     assert np.asarray(bf).dtype == float, np.asarray(bf).dtype
     af = to_float(a)
     assert_equal(af, bf)

--- a/bindings/pydrake/multibody/math_py.cc
+++ b/bindings/pydrake/multibody/math_py.cc
@@ -38,6 +38,21 @@ void BindSpatialVectorMixin(PyClass* pcls) {
   using Class = typename PyClass::type;
   auto& cls = *pcls;
   cls  // BR
+      .def(py::init([]() {
+        // See #14086 for more details.
+        Class out;
+        out.SetNaN();
+        return out;
+      }),
+          R"""(
+      Constructs to all NaNs.
+
+      Note:
+          This is different from C++, which in Release builds may leave memory
+          uninitialized. In pydrake, the function call overhead already trumps
+          any overhead from NAN-initialization, so we err on the side of
+          safety.
+      )""")
       .def(
           "rotational",
           [](const Class* self) -> const Vector3<T> {
@@ -100,7 +115,6 @@ void DoScalarDependentDefinitions(py::module m, T) {
         m, "SpatialVelocity", param, cls_doc.doc);
     BindSpatialVectorMixin<T>(&cls);
     cls  // BR
-        .def(py::init(), cls_doc.ctor.doc_0args)
         .def(py::init<const Eigen::Ref<const Vector3<T>>&,
                  const Eigen::Ref<const Vector3<T>>&>(),
             py::arg("w"), py::arg("v"), cls_doc.ctor.doc_2args)
@@ -130,7 +144,6 @@ void DoScalarDependentDefinitions(py::module m, T) {
         m, "SpatialMomentum", param, cls_doc.doc);
     BindSpatialVectorMixin<T>(&cls);
     cls  // BR
-        .def(py::init(), cls_doc.ctor.doc_0args)
         .def(py::init<const Eigen::Ref<const Vector3<T>>&,
                  const Eigen::Ref<const Vector3<T>>&>(),
             py::arg("h"), py::arg("l"), cls_doc.ctor.doc_2args)
@@ -147,7 +160,6 @@ void DoScalarDependentDefinitions(py::module m, T) {
         m, "SpatialAcceleration", param, cls_doc.doc);
     BindSpatialVectorMixin<T>(&cls);
     cls  // BR
-        .def(py::init(), cls_doc.ctor.doc_0args)
         .def(py::init<const Eigen::Ref<const Vector3<T>>&,
                  const Eigen::Ref<const Vector3<T>>&>(),
             py::arg("alpha"), py::arg("a"), cls_doc.ctor.doc_2args)
@@ -164,7 +176,6 @@ void DoScalarDependentDefinitions(py::module m, T) {
         m, "SpatialForce", param, cls_doc.doc);
     BindSpatialVectorMixin<T>(&cls);
     cls  // BR
-        .def(py::init(), cls_doc.ctor.doc_0args)
         .def(py::init<const Eigen::Ref<const Vector3<T>>&,
                  const Eigen::Ref<const Vector3<T>>&>(),
             py::arg("tau"), py::arg("f"), cls_doc.ctor.doc_2args)

--- a/bindings/pydrake/multibody/test/math_test.py
+++ b/bindings/pydrake/multibody/test/math_test.py
@@ -22,10 +22,16 @@ class TestMultibodyTreeMath(unittest.TestCase):
             self, T, cls, coeffs_name, rotation_name, translation_name):
         vec = cls()
         # - Accessors.
-        self.assertTrue(isinstance(vec.rotational(), np.ndarray))
-        self.assertTrue(isinstance(vec.translational(), np.ndarray))
-        self.assertEqual(vec.rotational().shape, (3,))
-        self.assertEqual(vec.translational().shape, (3,))
+        if T == Expression:
+            # TODO(eric.cousineau): Teach `numpy_compare` to handle NaN in
+            # symbolic expressions, without having to evaluate the expressions.
+            self.assertEqual(vec.rotational().shape, (3,))
+            self.assertEqual(vec.translational().shape, (3,))
+        else:
+            numpy_compare.assert_float_equal(
+                vec.rotational(), np.full(3, np.nan))
+            numpy_compare.assert_float_equal(
+                vec.translational(), np.full(3, np.nan))
         # - Fully-parameterized constructor.
         rotation_expected = [0.1, 0.3, 0.5]
         translation_expected = [0., 1., 2.]
@@ -84,7 +90,7 @@ class TestMultibodyTreeMath(unittest.TestCase):
         self.check_spatial_vector(T, SpatialVelocity_[T], "V", "w", "v")
         self.check_spatial_vector(T, SpatialMomentum_[T], "L", "h", "l")
         self.check_spatial_vector(
-                T, SpatialAcceleration_[T], "A", "alpha", "a")
+            T, SpatialAcceleration_[T], "A", "alpha", "a")
         self.check_spatial_vector(T, SpatialForce_[T], "F", "tau", "f")
 
     @numpy_compare.check_all_types


### PR DESCRIPTION
Towards #14086

Intermediate version of #14087

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14096)
<!-- Reviewable:end -->
