### PR TITLE
framework: Regularize VectorBase bounds checking

### DIFF
--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -80,6 +80,8 @@ drake_cc_library(
         "//common:default_scalars",
         "//common:dummy_value",
         "//common:essential",
+        "//common:nice_type_name",
+        "//common:unused",
     ],
 )
 
@@ -678,6 +680,7 @@ drake_cc_googletest(
         "//common:essential",
         "//common:symbolic",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
         "//systems/framework/test_utilities:my_vector",
     ],
 )

--- a/systems/framework/supervector.h
+++ b/systems/framework/supervector.h
@@ -1,12 +1,8 @@
 #pragma once
 
 #include <algorithm>
-#include <cstdint>
-#include <stdexcept>
 #include <utility>
 #include <vector>
-
-#include <Eigen/Dense>
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
@@ -41,22 +37,34 @@ class Supervector final : public VectorBase<T> {
     return lookup_table_.empty() ? 0 : lookup_table_.back();
   }
 
- protected:
-  const T& DoGetAtIndex(int index) const final {
-    const auto target = GetSubvectorAndOffset(index);
-    return (*target.first)[target.second];
-  }
-
-  T& DoGetAtIndex(int index) final {
-    const auto target = GetSubvectorAndOffset(index);
-    return (*target.first)[target.second];
-  }
-
  private:
+  const T& DoGetAtIndexUnchecked(int index) const final {
+    DRAKE_ASSERT(index < size());
+    const auto& [subvector, offset] = GetSubvectorAndOffset(index);
+    return (*subvector)[offset];
+  }
+
+  T& DoGetAtIndexUnchecked(int index) final {
+    DRAKE_ASSERT(index < size());
+    const auto& [subvector, offset] = GetSubvectorAndOffset(index);
+    return (*subvector)[offset];
+  }
+
+  const T& DoGetAtIndexChecked(int index) const final {
+    if (index >= size()) { this->ThrowOutOfRange(index); }
+    const auto& [subvector, offset] = GetSubvectorAndOffset(index);
+    return (*subvector)[offset];
+  }
+
+  T& DoGetAtIndexChecked(int index) final {
+    if (index >= size()) { this->ThrowOutOfRange(index); }
+    const auto& [subvector, offset] = GetSubvectorAndOffset(index);
+    return (*subvector)[offset];
+  }
+
   // Given an index into the supervector, returns the subvector that
   // contains that index, and its offset within the subvector. This operation
-  // is O(log(N)) in the number of subvectors. Throws std::out_of_range for
-  // invalid indices.
+  // is O(log(N)) in the number of subvectors.
   //
   // Example: if the lookup table is [1, 4, 9], and @p index is 5, this
   // function returns a pointer to the third of three subvectors, with offset
@@ -66,15 +74,11 @@ class Supervector final : public VectorBase<T> {
   // 0 | 1 2 3 | 4 5 6 7 8
   //               ^ index 5
   std::pair<VectorBase<T>*, int> GetSubvectorAndOffset(int index) const {
-    if (index >= size() || index < 0) {
-      throw std::out_of_range("Index " + std::to_string(index) +
-                              " out of bounds for supervector of size " +
-                              std::to_string(size()));
-    }
     // Binary-search the lookup_table_ for the first element that is larger
     // than the specified index.
     const auto it =
         std::upper_bound(lookup_table_.begin(), lookup_table_.end(), index);
+    DRAKE_DEMAND(it != lookup_table_.end());
 
     // Use the lookup result to identify the subvector that contains the index.
     const int subvector_id =

--- a/systems/framework/test/continuous_state_test.cc
+++ b/systems/framework/test/continuous_state_test.cc
@@ -101,10 +101,10 @@ TEST_F(ContinuousStateTest, ArrayOperator) {
 
 TEST_F(ContinuousStateTest, OutOfBoundsAccess) {
   EXPECT_THROW(continuous_state_->get_generalized_position().GetAtIndex(2),
-               std::runtime_error);
+               std::exception);
   EXPECT_THROW(
       continuous_state_->get_mutable_generalized_velocity().SetAtIndex(1, 42),
-      std::runtime_error);
+      std::exception);
 }
 
 // Tests that std::out_of_range is thrown if the component dimensions do not

--- a/systems/framework/test/supervector_test.cc
+++ b/systems/framework/test/supervector_test.cc
@@ -31,9 +31,11 @@ class SupervectorTest : public ::testing::Test {
 };
 
 TEST_F(SupervectorTest, GetAtIndex) {
+  const auto& const_supervector = *supervector_;
   ASSERT_EQ(kLength, supervector_->size());
   for (int i = 0; i < kLength; ++i) {
     EXPECT_EQ(i, supervector_->GetAtIndex(i));
+    EXPECT_EQ(i, const_supervector.GetAtIndex(i));
   }
 }
 
@@ -57,17 +59,44 @@ TEST_F(SupervectorTest, SetAtIndex) {
   EXPECT_EQ(16, vec4_->GetAtIndex(2));
 }
 
-
 // Tests that the Supervector can be addressed as an array.
 TEST_F(SupervectorTest, ArrayOperator) {
   (*supervector_)[5] = 42;
   EXPECT_EQ(42, (*vec2_)[1]);
-  EXPECT_EQ(8, (*supervector_)[8]);
+
+  const auto& const_supervector = *supervector_;
+  EXPECT_EQ(8, const_supervector[8]);
 }
 
 TEST_F(SupervectorTest, OutOfRange) {
-  EXPECT_THROW(supervector_->GetAtIndex(-1), std::out_of_range);
-  EXPECT_THROW(supervector_->GetAtIndex(10), std::out_of_range);
+  EXPECT_THROW(supervector_->GetAtIndex(-1), std::exception);
+  EXPECT_THROW(supervector_->GetAtIndex(10), std::exception);
+  EXPECT_THROW(supervector_->SetAtIndex(-1, 0.0), std::exception);
+  EXPECT_THROW(supervector_->SetAtIndex(10, 0.0), std::exception);
+}
+
+// Tests that a supervector can be SetFrom another vector.
+TEST_F(SupervectorTest, SetFromVector) {
+  auto next_value = BasicVector<double>::Make({
+      10, 11, 12, 13, 14, 15, 16, 17, 18});
+  supervector_->SetFromVector(next_value->CopyToVector());
+  EXPECT_EQ(10, supervector_->GetAtIndex(0));
+  EXPECT_EQ(11, supervector_->GetAtIndex(1));
+
+  EXPECT_THROW(supervector_->SetFromVector(Eigen::Vector3d::Zero()),
+               std::exception);
+}
+
+// Tests that a supervector can be SetFrom another VectorBase.
+TEST_F(SupervectorTest, SetFrom) {
+  auto next_value = BasicVector<double>::Make({
+      10, 11, 12, 13, 14, 15, 16, 17, 18});
+  supervector_->SetFrom(*next_value);
+  EXPECT_EQ(10, supervector_->GetAtIndex(0));
+  EXPECT_EQ(11, supervector_->GetAtIndex(1));
+
+  auto bad_value = BasicVector<double>::Make(3);
+  EXPECT_THROW(supervector_->SetFrom(*bad_value), std::exception);
 }
 
 TEST_F(SupervectorTest, Empty) {

--- a/systems/framework/vector_base.h
+++ b/systems/framework/vector_base.h
@@ -1,17 +1,19 @@
 #pragma once
 
-#include <algorithm>
 #include <initializer_list>
-#include <memory>
+#include <ostream>
 #include <stdexcept>
 #include <utility>
 
-#include <Eigen/Dense>
+#include <fmt/format.h>
 
 #include "drake/common/default_scalars.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/nice_type_name.h"
+#include "drake/common/unused.h"
 
 namespace drake {
 namespace systems {
@@ -42,63 +44,73 @@ class VectorBase {
 
   /// Returns the element at the given index in the vector.
   /// @pre 0 <= `index` < size()
-  T& operator[](int index) { return DoGetAtIndex(index); }
+  T& operator[](int index) {
+    DRAKE_ASSERT(index >= 0);
+    return DoGetAtIndexUnchecked(index);
+  }
 
   /// Returns the element at the given index in the vector.
   /// @pre 0 <= `index` < size()
-  const T& operator[](int index) const { return DoGetAtIndex(index); }
-
-  /// Returns the element at the given index in the vector.
-  /// @throws std::runtime_error if the index is >= size() or negative.
-  /// Consider operator[]() instead if bounds-checking is unwanted.
-  const T& GetAtIndex(int index) const {
-    if (index < 0) { throw std::out_of_range("VectorBase index < 0"); }
-    return DoGetAtIndex(index);
+  const T& operator[](int index) const {
+    DRAKE_ASSERT(index >= 0);
+    return DoGetAtIndexUnchecked(index);
   }
 
   /// Returns the element at the given index in the vector.
-  /// @throws std::runtime_error if the index is >= size() or negative.
+  /// @throws std::exception if the index is >= size() or negative.
+  /// Consider operator[]() instead if bounds-checking is unwanted.
+  const T& GetAtIndex(int index) const {
+    if (index < 0) { this->ThrowOutOfRange(index); }
+    return DoGetAtIndexChecked(index);
+  }
+
+  /// Returns the element at the given index in the vector.
+  /// @throws std::exception if the index is >= size() or negative.
   /// Consider operator[]() instead if bounds-checking is unwanted.
   T& GetAtIndex(int index) {
-    if (index < 0) { throw std::out_of_range("VectorBase index < 0"); }
-    return DoGetAtIndex(index);
+    if (index < 0) { this->ThrowOutOfRange(index); }
+    return DoGetAtIndexChecked(index);
   }
 
   /// Replaces the state at the given index with the value.
-  /// @throws std::runtime_error if the index is >= size().
+  /// @throws std::exception if the index is >= size().
   /// Consider operator[]() instead if bounds-checking is unwanted.
   void SetAtIndex(int index, const T& value) {
     GetAtIndex(index) = value;
   }
 
   /// Replaces the entire vector with the contents of @p value.
-  /// @throws std::runtime_error if @p value is not a column vector with size()
+  /// @throws std::exception if @p value is not a column vector with size()
   /// rows.
   ///
   /// Implementations should ensure this operation is O(N) in the size of the
   /// value and allocates no memory.
   virtual void SetFrom(const VectorBase<T>& value) {
-    DRAKE_THROW_UNLESS(value.size() == size());
-    for (int i = 0; i < value.size(); ++i) {
+    const int n = value.size();
+    if (n != size()) { this->ThrowMismatchedSize(n); }
+    for (int i = 0; i < n; ++i) {
       (*this)[i] = value[i];
     }
   }
 
-  /// Replaces the entire vector with the contents of @p value. Throws
-  /// std::runtime_error if @p value is not a column vector with size() rows.
+  /// Replaces the entire vector with the contents of @p value.
+  /// @throws std::exception if @p value is not a column vector with size()
+  /// rows.
   ///
   /// Implementations should ensure this operation is O(N) in the size of the
   /// value and allocates no memory.
   virtual void SetFromVector(const Eigen::Ref<const VectorX<T>>& value) {
-    DRAKE_THROW_UNLESS(value.rows() == size());
-    for (int i = 0; i < value.rows(); ++i) {
+    const int n = value.rows();
+    if (n != size()) { this->ThrowMismatchedSize(n); }
+    for (int i = 0; i < n; ++i) {
       (*this)[i] = value[i];
     }
   }
 
+  /// Sets all elements of this vector to zero.
   virtual void SetZero() {
-    const int sz = size();
-    for (int i = 0; i < sz; ++i) {
+    const int n = size();
+    for (int i = 0; i < n; ++i) {
       (*this)[i] = T(0.0);
     }
   }
@@ -122,56 +134,56 @@ class VectorBase {
   /// @throws std::exception if `vec` is the wrong size.
   virtual void CopyToPreSizedVector(EigenPtr<VectorX<T>> vec) const {
     DRAKE_THROW_UNLESS(vec != nullptr);
-    DRAKE_THROW_UNLESS(vec->rows() == size());
-    for (int i = 0; i < size(); ++i) {
+    const int n = vec->rows();
+    if (n != size()) { this->ThrowMismatchedSize(n); }
+    for (int i = 0; i < n; ++i) {
       (*vec)[i] = (*this)[i];
     }
   }
 
-  /// Adds a scaled version of this vector to Eigen vector @p vec, which
-  /// must be the same size.
+  /// Adds a scaled version of this vector to Eigen vector @p vec.
+  /// @throws std::exception if `vec` is the wrong size.
   ///
-  /// Implementations may override this default implementation with a more
-  /// efficient approach, for instance if this vector is contiguous.
   /// Implementations should ensure this operation remains O(N) in the size of
   /// the value and allocates no memory.
   virtual void ScaleAndAddToVector(const T& scale,
                                    EigenPtr<VectorX<T>> vec) const {
     DRAKE_THROW_UNLESS(vec != nullptr);
-    if (vec->rows() != size()) {
-      throw std::out_of_range("Addends must be the same size.");
-    }
-    for (int i = 0; i < size(); ++i) {
+    const int n = vec->rows();
+    if (n != size()) { this->ThrowMismatchedSize(n); }
+    for (int i = 0; i < n; ++i) {
       (*vec)[i] += scale * (*this)[i];
     }
   }
 
-  /// Add in scaled vector @p rhs to this vector. Both vectors must
-  /// be the same size.
+  /// Add in scaled vector @p rhs to this vector.
+  /// @throws std::exception if @p rhs is a different size than this.
   VectorBase& PlusEqScaled(const T& scale, const VectorBase<T>& rhs) {
     return PlusEqScaled({{scale, rhs}});
   }
 
-  /// Add in multiple scaled vectors to this vector. All vectors
-  /// must be the same size.
+  /// Add in multiple scaled vectors to this vector.
+  /// @throws std::exception if any rhs are a different size than this.
   VectorBase& PlusEqScaled(const std::initializer_list<
                            std::pair<T, const VectorBase<T>&>>& rhs_scale) {
-    for (const auto& operand : rhs_scale) {
-      if (operand.second.size() != size())
-        throw std::out_of_range("Addends must be the same size.");
+    const int n = size();
+    for (const auto& [scale, rhs] : rhs_scale) {
+      unused(scale);
+      const int rhs_n = rhs.size();
+      if (rhs_n != n) { this->ThrowMismatchedSize(rhs_n); }
     }
-
     DoPlusEqScaled(rhs_scale);
-
     return *this;
   }
 
   /// Add in vector @p rhs to this vector.
+  /// @throws std::exception if @p rhs is a different size than this.
   VectorBase& operator+=(const VectorBase<T>& rhs) {
     return PlusEqScaled(T(1), rhs);
   }
 
   /// Subtract in vector @p rhs to this vector.
+  /// @throws std::exception if @p rhs is a different size than this.
   VectorBase& operator-=(const VectorBase<T>& rhs) {
     return PlusEqScaled(T(-1), rhs);
   }
@@ -190,12 +202,22 @@ class VectorBase {
   VectorBase() {}
 
   /// Implementations should ensure this operation is O(1) and allocates no
-  /// memory.  The index has already been checked for negative, but not size.
-  virtual const T& DoGetAtIndex(int index) const = 0;
+  /// memory.  The index need not be validated when in release mode.
+  virtual const T& DoGetAtIndexUnchecked(int index) const = 0;
+
+  /// Implementations should ensure this operation is O(1) and allocates no
+  /// memory.  The index need not be validated when in release mode.
+  virtual T& DoGetAtIndexUnchecked(int index) = 0;
 
   /// Implementations should ensure this operation is O(1) and allocates no
   /// memory.  The index has already been checked for negative, but not size.
-  virtual T& DoGetAtIndex(int index) = 0;
+  /// Implementations must throw an exception when index >= size().
+  virtual const T& DoGetAtIndexChecked(int index) const = 0;
+
+  /// Implementations should ensure this operation is O(1) and allocates no
+  /// memory.  The index has already been checked for negative, but not size.
+  /// Implementations must throw an exception when index >= size().
+  virtual T& DoGetAtIndexChecked(int index) = 0;
 
   /// Adds in multiple scaled vectors to this vector. All vectors
   /// are guaranteed to be the same size.
@@ -210,17 +232,26 @@ class VectorBase {
   /// the value and allocates no memory.
   virtual void DoPlusEqScaled(const std::initializer_list<
                               std::pair<T, const VectorBase<T>&>>& rhs_scale) {
-    const int sz = size();
-    for (const auto& operand : rhs_scale) {
-      DRAKE_THROW_UNLESS(operand.second.size() == sz);
-    }
-    for (int i = 0; i < sz; ++i) {
+    const int n = size();
+    for (int i = 0; i < n; ++i) {
       T value(0);
-      for (const auto& operand : rhs_scale) {
-        value += operand.second[i] * operand.first;
+      for (const auto& [scale, rhs] : rhs_scale) {
+        value += rhs[i] * scale;
       }
       (*this)[i] += value;
     }
+  }
+
+  [[noreturn]] void ThrowOutOfRange(int index) const {
+    throw std::out_of_range(fmt::format(
+        "Index {} is not within [0, {}) while accessing {}.",
+        index, size(), NiceTypeName::Get(*this)));
+  }
+
+  [[noreturn]] void ThrowMismatchedSize(int other_size) const {
+    throw std::out_of_range(fmt::format(
+        "Operand vector size {} does not match this {} size {}",
+        other_size, NiceTypeName::Get(*this), size()));
   }
 };
 


### PR DESCRIPTION
In preparing to move some methods into cc files (#12814), it became clear that a good code split between h and cc would be difficult given the current idioms for bounds checking.

This commit adjusts `operator[]` access to not check bounds (it was already documented not to check, but was doing so anyway) and unifies the exception formatting into the `VectorBase` class.

This is a breaking change in the sense that the exception subclass being thrown may be different now; the API promises are weakened to only promise to throw a `std::exception`, not any specific kind of exception.  The unit tests are weakened to reflect this.

This is breaking change in demoting `BasicVector::DoGetAtIndex` from protected to private.

Also add a Doxygen comment to specify `SetZero`.

Also adjust `#include` statements to remove unused inclusions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14101)
<!-- Reviewable:end -->
