### PR TITLE
common: Don't defect use of TypeSafeIndex or Identifier references

### DIFF
--- a/common/identifier.h
+++ b/common/identifier.h
@@ -68,8 +68,9 @@ namespace drake {
  prefer the practice of returning std::optional<Identifier> instead.
 
  It is the designed intent of this class, that ids derived from this class can
- be passed and returned by value. Passing ids by const reference should be
- considered a misuse.
+ be passed and returned by value. (Drake's typical calling convention requires
+ passing input arguments by const reference, or by value when moved from. That
+ convention does not apply to this class.)
 
  The following alias will create a unique identifier type for class `Foo`:
  @code{.cpp}

--- a/common/type_safe_index.h
+++ b/common/type_safe_index.h
@@ -62,8 +62,9 @@ namespace drake {
 /// `std::optional<Index>` instead.
 ///
 /// It is the designed intent of this class, that indices derived from this
-/// class can be passed and returned by value. Passing indices by const
-/// reference should be considered a misuse.
+/// class can be passed and returned by value. (Drake's typical calling
+/// convention requires passing input arguments by const reference, or by value
+/// when moved from. That convention does not apply to this class.)
 ///
 /// This is the recommended method to create a unique index type associated with
 /// class `Foo`:


### PR DESCRIPTION
Asking reviewers to defect (and so authors to obey) a special-cased style rule is a maintenance burden.

Co-requisite of #14094.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14105)
<!-- Reviewable:end -->
