### PR TITLE
unit_inertia: Change ReExpress to use frame A instead of frame F

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -426,7 +426,7 @@ class TestPlant(unittest.TestCase):
         self.assertIsInstance(unit_inertia, RotationalInertia)
         self.assertIsInstance(unit_inertia.CopyToFullMatrix3(), np.ndarray)
         self.assertIsInstance(
-            unit_inertia.ReExpress(R_FE=RotationMatrix()), UnitInertia)
+            unit_inertia.ReExpress(R_AE=RotationMatrix()), UnitInertia)
         # Test spatial inertia construction.
         SpatialInertia()
         spatial_inertia = SpatialInertia(

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -651,7 +651,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def(py::init(), cls_doc.ctor.doc_0args)
         .def(py::init<const T&, const T&, const T&>(), py::arg("Ixx"),
             py::arg("Iyy"), py::arg("Izz"), cls_doc.ctor.doc_3args)
-        .def("ReExpress", &Class::ReExpress, py::arg("R_FE"),
+        .def("ReExpress", &Class::ReExpress, py::arg("R_AE"),
             cls_doc.ReExpress.doc);
   }
 

--- a/multibody/tree/unit_inertia.h
+++ b/multibody/tree/unit_inertia.h
@@ -98,19 +98,19 @@ class UnitInertia : public RotationalInertia<T> {
 
   /// Re-express a unit inertia in a different frame, performing the operation
   /// in place and modifying the original object. @see ReExpress() for details.
-  UnitInertia<T>& ReExpressInPlace(const math::RotationMatrix<T>& R_FE) {
-    RotationalInertia<T>::ReExpressInPlace(R_FE);
+  UnitInertia<T>& ReExpressInPlace(const math::RotationMatrix<T>& R_AE) {
+    RotationalInertia<T>::ReExpressInPlace(R_AE);
     return *this;
   }
 
   /// Given `this` unit inertia `G_BP_E` of a body B about a point P and
   /// expressed in frame E, this method computes the same unit inertia
-  /// re-expressed in another frame F as `G_BP_F = R_FE * G_BP_E * (R_FE)ᵀ`.
-  /// @param[in] R_FE RotationMatrix relating frames F and E.
-  /// @retval G_BP_F The same unit inertia for body B about point P but now
-  ///                re-expressed in frame F.
-  UnitInertia<T> ReExpress(const math::RotationMatrix<T>& R_FE) const {
-    return UnitInertia<T>(RotationalInertia<T>::ReExpress(R_FE));
+  /// re-expressed in another frame A as `G_BP_A = R_AE * G_BP_E * (R_AE)ᵀ`.
+  /// @param[in] R_AE RotationMatrix relating frames A and E.
+  /// @retval G_BP_A The same unit inertia for body B about point P but now
+  ///                re-expressed in frame A.
+  UnitInertia<T> ReExpress(const math::RotationMatrix<T>& R_AE) const {
+    return UnitInertia<T>(RotationalInertia<T>::ReExpress(R_AE));
   }
 
   /// For a central unit inertia `G_Bcm_E` computed about a body's center of


### PR DESCRIPTION
For consistency with rotational_inertia and spatial_inertia

Follow-up to #14111

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14112)
<!-- Reviewable:end -->
