### PR TITLE
Versatile error message for gimbal-lock singularity (helps debug bushings).

### DIFF
--- a/math/roll_pitch_yaw.cc
+++ b/math/roll_pitch_yaw.cc
@@ -180,7 +180,7 @@ void RollPitchYaw<T>::SetFromQuaternionAndRotationMatrix(
         " formed by the Quaternion passed to this method.  To avoid this"
         " inconsistency, ensure the orientation of R and Quaternion align."
         " ({}:{}).", __func__, tolerance, __FILE__, __LINE__);
-    throw std::logic_error(message);
+    throw std::runtime_error(message);
   }
 
   // This algorithm converts a quaternion and %RotationMatrix to %RollPitchYaw.
@@ -226,7 +226,7 @@ void RollPitchYaw<T>::ThrowPitchAngleViolatesGimbalLockTolerance(
         " orientation singularity, use a quaternion -- not RollPitchYaw."
         " ({}:{}).", function_name, pitch_radians * 180 / M_PI,
                      tolerance_degrees, file_name, line_number);
-    throw std::logic_error(message);
+    throw std::runtime_error(message);
 }
 
 }  // namespace math

--- a/math/roll_pitch_yaw.h
+++ b/math/roll_pitch_yaw.h
@@ -60,14 +60,14 @@ class RollPitchYaw {
 
   /// Constructs a %RollPitchYaw from a 3x1 array of angles.
   /// @param[in] rpy 3x1 array with roll, pitch, yaw angles (units of radians).
-  /// @throws std::logic_error in debug builds if !IsValid(rpy).
+  /// @throws std::exception in debug builds if !IsValid(rpy).
   explicit RollPitchYaw(const Vector3<T>& rpy) { set(rpy); }
 
   /// Constructs a %RollPitchYaw from roll, pitch, yaw angles (radian units).
   /// @param[in] roll x-directed angle in SpaceXYZ rotation sequence.
   /// @param[in] pitch y-directed angle in SpaceXYZ rotation sequence.
   /// @param[in] yaw z-directed angle in SpaceXYZ rotation sequence.
-  /// @throws std::logic_error in debug builds if
+  /// @throws std::exception in debug builds if
   /// !IsValid(Vector3<T>(roll, pitch, yaw)).
   RollPitchYaw(const T& roll, const T& pitch, const T& yaw) {
     set(roll, pitch, yaw);
@@ -89,14 +89,14 @@ class RollPitchYaw {
   /// @param[in] quaternion unit %Quaternion.
   /// @note This new high-accuracy algorithm avoids numerical round-off issues
   /// encountered by some algorithms when pitch is within 1E-6 of π/2 or -π/2.
-  /// @throws std::logic_error in debug builds if !IsValid(rpy).
+  /// @throws std::exception in debug builds if !IsValid(rpy).
   explicit RollPitchYaw(const Eigen::Quaternion<T>& quaternion) {
     SetFromQuaternion(quaternion);
   }
 
   /// Sets `this` %RollPitchYaw from a 3x1 array of angles.
   /// @param[in] rpy 3x1 array with roll, pitch, yaw angles (units of radians).
-  /// @throws std::logic_error in debug builds if !IsValid(rpy).
+  /// @throws std::exception in debug builds if !IsValid(rpy).
   RollPitchYaw<T>& set(const Vector3<T>& rpy) {
     return SetOrThrowIfNotValidInDebugBuild(rpy);
   }
@@ -105,7 +105,7 @@ class RollPitchYaw {
   /// @param[in] roll x-directed angle in SpaceXYZ rotation sequence.
   /// @param[in] pitch y-directed angle in SpaceXYZ rotation sequence.
   /// @param[in] yaw z-directed angle in SpaceXYZ rotation sequence.
-  /// @throws std::logic_error in debug builds if
+  /// @throws std::exception in debug builds if
   /// !IsValid(Vector3<T>(roll, pitch, yaw)).
   RollPitchYaw<T>& set(const T& roll, const T& pitch, const T& yaw) {
     return set(Vector3<T>(roll, pitch, yaw));
@@ -117,7 +117,7 @@ class RollPitchYaw {
   /// @param[in] quaternion unit %Quaternion.
   /// @note This new high-accuracy algorithm avoids numerical round-off issues
   /// encountered by some algorithms when pitch is within 1E-6 of π/2 or -π/2.
-  /// @throws std::logic_error in debug builds if !IsValid(rpy).
+  /// @throws std::exception in debug builds if !IsValid(rpy).
   void SetFromQuaternion(const Eigen::Quaternion<T>& quaternion);
 
   /// Uses a high-accuracy efficient algorithm to set the roll-pitch-yaw
@@ -306,7 +306,7 @@ class RollPitchYaw {
   /// %RollPitchYaw whose angles `[r; p; y]` orient two generic frames A and D.
   /// @param[in] w_AD_A, frame D's angular velocity in frame A, expressed in A.
   /// @returns `[ṙ; ṗ; ẏ]`, the 1ˢᵗ time-derivative of `this` %RollPitchYaw.
-  /// @throws std::logic_error if `cos(p) ≈ 0` (`p` is near gimbal-lock).
+  /// @throws std::exception if `cos(p) ≈ 0` (`p` is near gimbal-lock).
   /// @note This method has a divide-by-zero error (singularity) when the cosine
   /// of the pitch angle `p` is zero [i.e., `cos(p) = 0`].  This problem (called
   /// "gimbal lock") occurs when `p = n π  + π / 2`, where n is any integer.
@@ -330,7 +330,7 @@ class RollPitchYaw {
   /// to `[wx; wy; wz]ₐ` (which is w_AD_A expressed in A).
   /// In other words, `rpyDt = M * w_AD_A`.
   /// @param[in] function_name name of the calling function/method.
-  /// @throws std::logic_error if `cos(p) ≈ 0` (`p` is near gimbal-lock).
+  /// @throws std::exception if `cos(p) ≈ 0` (`p` is near gimbal-lock).
   /// @note This method has a divide-by-zero error (singularity) when the cosine
   /// of the pitch angle `p` is zero [i.e., `cos(p) = 0`].  This problem (called
   /// "gimbal lock") occurs when `p = n π  + π / 2`, where n is any integer.
@@ -348,7 +348,7 @@ class RollPitchYaw {
   /// @param[in] alpha_AD_A, frame D's angular acceleration in frame A,
   /// expressed in frame A.
   /// @returns `[r̈, p̈, ÿ]`, the 2ⁿᵈ time-derivative of `this` %RollPitchYaw.
-  /// @throws std::logic_error if `cos(p) ≈ 0` (`p` is near gimbal-lock).
+  /// @throws std::exception if `cos(p) ≈ 0` (`p` is near gimbal-lock).
   /// @note This method has a divide-by-zero error (singularity) when the cosine
   /// of the pitch angle `p` is zero [i.e., `cos(p) = 0`].  This problem (called
   /// "gimbal lock") occurs when `p = n π  + π / 2`, where n is any integer.
@@ -372,7 +372,7 @@ class RollPitchYaw {
   /// @param[in] alpha_AD_D, frame D's angular acceleration in frame A,
   /// expressed in frame D.
   /// @returns `[r̈, p̈, ÿ]`, the 2ⁿᵈ time-derivative of `this` %RollPitchYaw.
-  /// @throws std::logic_error if `cos(p) ≈ 0` (`p` is near gimbal-lock).
+  /// @throws std::exception if `cos(p) ≈ 0` (`p` is near gimbal-lock).
   /// @note This method has a divide-by-zero error (singularity) when the cosine
   /// of the pitch angle `p` is zero [i.e., `cos(p) = 0`].  This problem (called
   /// "gimbal lock") occurs when `p = n π  + π / 2`, where n is any integer.
@@ -440,11 +440,10 @@ class RollPitchYaw {
   // @param[in] file_name name of the file with the calling function/method.
   // @param[in] line_number the line number in file_name that made the call.
   // @param[in] pitch_angle pitch angle `p` (in radians).
-  // @throws std::logic_error with a message that `p` is too near gimbal-lock.
+  // @throws std::exception with a message that `p` is too near gimbal-lock.
   static void ThrowPitchAngleViolatesGimbalLockTolerance(
     const char* function_name, const char* file_name, const int line_number,
     const T& pitch_angle);
-
 
   // Uses a quaternion and its associated rotation matrix `R` to accurately
   // and efficiently set the roll-pitch-yaw angles (SpaceXYZ Euler angles)
@@ -454,7 +453,7 @@ class RollPitchYaw {
   // range `-π <= r <= π`, `-π/2 <= p <= π/2`, `-π <= y <= π`.
   // @param[in] quaternion unit quaternion with elements `[e0, e1, e2, e3]`.
   // @param[in] R The %RotationMatrix corresponding to `quaternion`.
-  // @throws std::logic_error in debug builds if rpy fails IsValid(rpy).
+  // @throws std::exception in debug builds if rpy fails IsValid(rpy).
   // @note Aborts in debug builds if `quaternion` does not correspond to `R`.
   void SetFromQuaternionAndRotationMatrix(
       const Eigen::Quaternion<T>& quaternion, const RotationMatrix<T>& R);
@@ -566,7 +565,7 @@ class RollPitchYaw {
   // @param[in] function_name name of the calling function/method.
   // @param[in] file_name name of the file with the calling function/method.
   // @param[in] line_number the line number in file_name that made the call.
-  // @throws std::logic_error if `cos(p) ≈ 0` (`p` is near gimbal-lock).
+  // @throws std::exception if `cos(p) ≈ 0` (`p` is near gimbal-lock).
   // @note This method has a divide-by-zero error (singularity) when the cosine
   // of the pitch angle `p` is zero [i.e., `cos(p) = 0`].  This problem (called
   // "gimbal lock") occurs when `p = n π  + π / 2`, where n is any integer.
@@ -604,7 +603,7 @@ class RollPitchYaw {
 
   // Sets `this` %RollPitchYaw from a Vector3.
   // @param[in] rpy allegedly valid roll-pitch-yaw angles.
-  // @throws std::logic_error in debug builds if rpy fails IsValid(rpy).
+  // @throws std::exception in debug builds if rpy fails IsValid(rpy).
   RollPitchYaw<T>& SetOrThrowIfNotValidInDebugBuild(const Vector3<T>& rpy) {
     DRAKE_ASSERT_VOID(ThrowIfNotValid(rpy));
     roll_pitch_yaw_ = rpy;

--- a/math/test/roll_pitch_yaw_test.cc
+++ b/math/test/roll_pitch_yaw_test.cc
@@ -220,7 +220,7 @@ GTEST_TEST(RollPitchYaw, CalcAngularVelocityFromRpyDtAndViceVersa) {
   const RollPitchYaw<double> rpyA(0.2, M_PI / 2, 0.4);
   DRAKE_EXPECT_THROWS_MESSAGE(
       rpyA.CalcMatrixRelatingRpyDtToAngularVelocityInParent(),
-      std::logic_error, expected_messageA);
+      std::runtime_error, expected_messageA);
 
   // Now test the inverse relationship.
   const Vector3d rpyDt_calculated =
@@ -234,27 +234,27 @@ GTEST_TEST(RollPitchYaw, CalcAngularVelocityFromRpyDtAndViceVersa) {
       ".*gimbal-lock.*"
       "roll_pitch_yaw.h.*";
   DRAKE_EXPECT_THROWS_MESSAGE(rpyA.CalcRpyDtFromAngularVelocityInParent(w_AD_A),
-                              std::logic_error, expected_messageB);
+                              std::runtime_error, expected_messageB);
 
   const RollPitchYaw<double> rpyB(0.2, -M_PI / 2, 0.4);
   DRAKE_EXPECT_THROWS_MESSAGE(rpyB.CalcRpyDtFromAngularVelocityInParent(w_AD_A),
-                              std::logic_error, expected_messageB);
+                              std::runtime_error, expected_messageB);
 
   const RollPitchYaw<double> rpyC(0.2, 3 * M_PI / 2, 0.4);
   DRAKE_EXPECT_THROWS_MESSAGE(rpyC.CalcRpyDtFromAngularVelocityInParent(w_AD_A),
-                              std::logic_error, expected_messageB);
+                              std::runtime_error, expected_messageB);
 
   const RollPitchYaw<double> rpyD(0.2, -3 * M_PI / 2, 0.4);
   DRAKE_EXPECT_THROWS_MESSAGE(rpyD.CalcRpyDtFromAngularVelocityInParent(w_AD_A),
-                              std::logic_error, expected_messageB);
+                              std::runtime_error, expected_messageB);
 
   const RollPitchYaw<double> rpyE(0.2, 3 * M_PI / 2 + 1E-8, 0.4);
   DRAKE_EXPECT_THROWS_MESSAGE(rpyE.CalcRpyDtFromAngularVelocityInParent(w_AD_A),
-                              std::logic_error, expected_messageB);
+                              std::runtime_error, expected_messageB);
 
   const RollPitchYaw<double> rpyF(0.2, -3 * M_PI / 2 + 1E-8, 0.4);
   DRAKE_EXPECT_THROWS_MESSAGE(rpyF.CalcRpyDtFromAngularVelocityInParent(w_AD_A),
-                              std::logic_error, expected_messageB);
+                              std::runtime_error, expected_messageB);
 }
 
 // Test accuracy of back-and-forth conversion from angular velocity to rpyDt
@@ -278,16 +278,17 @@ GTEST_TEST(RollPitchYaw, PrecisionOfAngularVelocityFromRpyDtAndViceVersa) {
     if (is_imprecise) {
       ++number_of_imprecise_cases;
       const char* expected_message =
-          "RollPitchYaw::CalcRpyDtFromAngularVelocityInParent().*gimbal-lock.*";
+          "RollPitchYaw::CalcRpyDtFromAngularVelocityInParent()"
+          ".*gimbal-lock.*";
       DRAKE_EXPECT_THROWS_MESSAGE(
           rpyDt = rpy.CalcRpyDtFromAngularVelocityInParent(wA),
-          std::logic_error, expected_message);
+          std::runtime_error, expected_message);
       expected_message =
-          "RollPitchYaw::CalcRpyDDtFromRpyDtAndAngularAccelInParent().*gimbal-"
-          "lock.*";
+          "RollPitchYaw::CalcRpyDDtFromRpyDtAndAngularAccelInParent()"
+          ".*gimbal-lock.*";
       DRAKE_EXPECT_THROWS_MESSAGE(rpyDDt =
         rpy.CalcRpyDDtFromRpyDtAndAngularAccelInParent(rpyDt, alphaA),
-        std::logic_error, expected_message);
+        std::runtime_error, expected_message);
     } else {
       ++number_of_precise_cases;
       rpyDt = rpy.CalcRpyDtFromAngularVelocityInParent(wA);
@@ -379,17 +380,16 @@ GTEST_TEST(RollPitchYaw, CalcRpyDDtFromAngularAccel) {
         Vector3d rpyDDt, rpyDDt_verify;
         if (rpy.DoesPitchAngleViolateGimbalLockTolerance()) {
           const char* expected_message =
-              "RollPitchYaw::CalcRpyDDtFromRpyDtAndAngularAccelInParent().*"
-              "gimbal-lock.*";
+              "RollPitchYaw::CalcRpyDDtFromRpyDtAndAngularAccelInParent()"
+              ".*gimbal-lock.*";
           DRAKE_EXPECT_THROWS_MESSAGE(rpyDDt =
              rpy.CalcRpyDDtFromRpyDtAndAngularAccelInParent(rpyDt, alpha_AD_A),
-             std::logic_error, expected_message);
-          expected_message =
-              "RollPitchYaw::CalcRpyDDtFromAngularAccelInChild().*"
-                  "gimbal-lock.*";
+             std::runtime_error, expected_message);
+          expected_message = "RollPitchYaw::CalcRpyDDtFromAngularAccelInChild()"
+                             ".*gimbal-lock.*";
           DRAKE_EXPECT_THROWS_MESSAGE(rpyDDt_verify =
              rpy.CalcRpyDDtFromAngularAccelInChild(rpyDt, alpha_AD_D),
-             std::logic_error, expected_message);
+             std::runtime_error, expected_message);
           continue;
         }
 

--- a/multibody/tree/linear_bushing_roll_pitch_yaw.cc
+++ b/multibody/tree/linear_bushing_roll_pitch_yaw.cc
@@ -284,16 +284,18 @@ template <typename T>
 void LinearBushingRollPitchYaw<T>::ThrowPitchAngleViolatesGimbalLockTolerance(
     const T& pitch_angle, const char* function_name) {
     const double pitch_radians = ExtractDoubleOrThrow(pitch_angle);
+    const double pitch_tolerance =
+        math::RollPitchYaw<double>::GimbalLockPitchAngleTolerance();
     std::string message = fmt::format("LinearBushingRollPitchYaw::{}():"
-        " Pitch angle p = {:G} degrees is close to gimbal-lock which means"
-        " p ≈ (n*π ± π/2) where n = 0, 1, 2, ..."
-        " There is a divide-by-zero error (singularity) at gimbal-lock.  Pitch"
-        " angles near gimbal-lock cause numerical inaccuracies.  To avoid this"
-        " orientation singularity, use a reasonable default alignment of the"
-        " frames associated with this LinearBushingRollPitchYaw"
-        " and/or choose stiffness and damping properties"
-        " that help avoid pitch angles near gimbal lock.",
-        function_name, pitch_radians * 180 / M_PI);
+        " Pitch angle p = {:G} degrees is within {:G} degrees of gimbal-lock"
+        " which means p ≈ (n*π ± π/2) where n = 0, 1, 2, ..."
+        " There is a divide-by-zero error (singularity) at gimbal-lock due to"
+        " this bushing's mathematical dependence on roll-pitch-yaw angles."
+        " A pitch angle near gimbal-lock cause numerical inaccuracies.  To"
+        " avoid this pitch angle problem, use a reasonable default alignment of"
+        " the frames associated with this bushing and/or choose stiffness and"
+        " damping properties that help avoid pitch angles near gimbal lock.",
+        function_name, pitch_radians * 180 / M_PI, pitch_tolerance);
     throw std::runtime_error(message);
 }
 

--- a/multibody/tree/linear_bushing_roll_pitch_yaw.cc
+++ b/multibody/tree/linear_bushing_roll_pitch_yaw.cc
@@ -1,6 +1,7 @@
 #include "drake/multibody/tree/linear_bushing_roll_pitch_yaw.h"
 
 #include <limits>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -277,6 +278,23 @@ Vector3<T> LinearBushingRollPitchYaw<T>::CalcBushingTorqueOnCExpressedInA(
   // bushing forces on C have their resultant force 𝐟 applied at Cp (not Co).
   const Vector3<T> t_Cp_A = N.transpose() * tau;
   return t_Cp_A;  // [tx ty tz]ᴀ
+}
+
+template <typename T>
+void LinearBushingRollPitchYaw<T>::ThrowPitchAngleViolatesGimbalLockTolerance(
+    const T& pitch_angle, const char* function_name) {
+    const double pitch_radians = ExtractDoubleOrThrow(pitch_angle);
+    std::string message = fmt::format("LinearBushingRollPitchYaw::{}():"
+        " Pitch angle p = {:G} degrees is close to gimbal-lock which means"
+        " p ≈ (n*π ± π/2) where n = 0, 1, 2, ..."
+        " There is a divide-by-zero error (singularity) at gimbal-lock.  Pitch"
+        " angles near gimbal-lock cause numerical inaccuracies.  To avoid this"
+        " orientation singularity, use a reasonable default alignment of the"
+        " frames associated with this LinearBushingRollPitchYaw"
+        " and/or choose stiffness and damping properties"
+        " that help avoid pitch angles near gimbal lock.",
+        function_name, pitch_radians * 180 / M_PI);
+    throw std::runtime_error(message);
 }
 
 template <typename T>


### PR DESCRIPTION
Resolves #14114 which requested a better error message when users encounter gimbal lock during use of class LinearBushingRollPitchYaw.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14126)
<!-- Reviewable:end -->
