### PR TITLE
Mosek quadratic cost nonlinear constraint

### DIFF
--- a/solvers/mosek_solver_common.cc
+++ b/solvers/mosek_solver_common.cc
@@ -6,6 +6,7 @@
 #include <cstring>
 
 #include "drake/common/never_destroyed.h"
+#include "drake/common/text_logging.h"
 #include "drake/solvers/mathematical_program.h"
 
 namespace drake {
@@ -39,8 +40,33 @@ bool MosekSolver::ProgramAttributesSatisfied(const MathematicalProgram& prog) {
           ProgramAttribute::kExponentialConeConstraint,
           ProgramAttribute::kLinearCost, ProgramAttribute::kQuadraticCost,
           ProgramAttribute::kBinaryVariable});
-  return AreRequiredAttributesSupported(prog.required_capabilities(),
-                                        solver_capabilities.access());
+  const bool supported = AreRequiredAttributesSupported(
+      prog.required_capabilities(), solver_capabilities.access());
+  if (!supported) {
+    return false;
+  }
+  // When the program has quadratic cost and nonlinear constraints, the user
+  // should convert the quadratic cost to second order cone constraint using a
+  // slack variable.
+  if (prog.required_capabilities().count(ProgramAttribute::kQuadraticCost) >
+          0 &&
+      (prog.required_capabilities().count(
+           ProgramAttribute::kLorentzConeConstraint) > 0 ||
+       prog.required_capabilities().count(
+           ProgramAttribute::kRotatedLorentzConeConstraint) > 0 ||
+       prog.required_capabilities().count(
+           ProgramAttribute::kPositiveSemidefiniteConstraint) > 0 ||
+       prog.required_capabilities().count(
+           ProgramAttribute::kExponentialConeConstraint) > 0)) {
+    drake::log()->warn(
+        "The program contains quadratic cost and nonlinear convex conic "
+        "constraints. Consider to re-formulate the quadratic cost with a "
+        "slack variable and Lorentz cone constraint. Refer to "
+        "https://docs.mosek.com/modeling-cookbook/qcqo.html for more "
+        "details");
+    return false;
+  }
+  return true;
 }
 
 }  // namespace solvers

--- a/solvers/mosek_solver_common.cc
+++ b/solvers/mosek_solver_common.cc
@@ -6,7 +6,6 @@
 #include <cstring>
 
 #include "drake/common/never_destroyed.h"
-#include "drake/common/text_logging.h"
 #include "drake/solvers/mathematical_program.h"
 
 namespace drake {
@@ -48,22 +47,8 @@ bool MosekSolver::ProgramAttributesSatisfied(const MathematicalProgram& prog) {
   // When the program has quadratic cost and nonlinear constraints, the user
   // should convert the quadratic cost to second order cone constraint using a
   // slack variable.
-  if (prog.required_capabilities().count(ProgramAttribute::kQuadraticCost) >
-          0 &&
-      (prog.required_capabilities().count(
-           ProgramAttribute::kLorentzConeConstraint) > 0 ||
-       prog.required_capabilities().count(
-           ProgramAttribute::kRotatedLorentzConeConstraint) > 0 ||
-       prog.required_capabilities().count(
-           ProgramAttribute::kPositiveSemidefiniteConstraint) > 0 ||
-       prog.required_capabilities().count(
-           ProgramAttribute::kExponentialConeConstraint) > 0)) {
-    drake::log()->warn(
-        "The program contains quadratic cost and nonlinear convex conic "
-        "constraints. Consider to re-formulate the quadratic cost with a "
-        "slack variable and Lorentz cone constraint. Refer to "
-        "https://docs.mosek.com/modeling-cookbook/qcqo.html for more "
-        "details");
+  if (HasQuadraticCostAndNonlinearConicConstraint(
+          prog.required_capabilities())) {
     return false;
   }
   return true;

--- a/solvers/program_attribute.cc
+++ b/solvers/program_attribute.cc
@@ -82,5 +82,17 @@ std::ostream& operator<<(std::ostream& os, const ProgramAttributes& attrs) {
   return os;
 }
 
+bool HasQuadraticCostAndNonlinearConicConstraint(
+    const ProgramAttributes& required) {
+  if (required.count(ProgramAttribute::kQuadraticCost) > 0 &&
+      (required.count(ProgramAttribute::kLorentzConeConstraint) > 0 ||
+       required.count(ProgramAttribute::kRotatedLorentzConeConstraint) > 0 ||
+       required.count(ProgramAttribute::kPositiveSemidefiniteConstraint) > 0 ||
+       required.count(ProgramAttribute::kExponentialConeConstraint) > 0)) {
+    return true;
+  }
+  return false;
+}
+
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/program_attribute.h
+++ b/solvers/program_attribute.h
@@ -49,5 +49,20 @@ std::ostream& operator<<(std::ostream&, const ProgramAttribute&);
 std::string to_string(const ProgramAttributes&);
 std::ostream& operator<<(std::ostream&, const ProgramAttributes&);
 
+/**
+ * When the program has a convex quadratic cost and convex nonlinear conic
+ * constraints (like Lorentz cone, PSD cone, exponential cone, etc), although
+ * the program is still convex, it is not conic (with a quadratic cost). It is
+ * better to reformulate the quadratic cost to a linear cost with slack variable
+ * and a Lorentz cone constraint. For example, for the quadratic cost min xᵀQx
+ * we can reformulate it as
+ * min s
+ * s.t s >= |L'x|
+ * where s is a slack variable, L*L' = Q. s >= |L'x| is a Lorentz cone
+ * constraint.
+ */
+bool HasQuadraticCostAndNonlinearConicConstraint(
+    const ProgramAttributes& required);
+
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/gurobi_solver_test.cc
+++ b/solvers/test/gurobi_solver_test.cc
@@ -487,6 +487,23 @@ GTEST_TEST(GurobiTest, SOCPDualSolution2) {
   }
 }
 
+GTEST_TEST(GurobiTest, QuadraticCostNonlinearConicConstraint) {
+  // Gurobi can solve problem with quadratic cost and nonlinear conic
+  // constraint.
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<3>();
+  prog.AddQuadraticCost(x[0] * x[0]);
+  prog.AddLorentzConeConstraint(x);
+
+  GurobiSolver solver;
+  if (solver.available()) {
+    auto result = solver.Solve(prog);
+    EXPECT_TRUE(result.is_success());
+    EXPECT_TRUE(
+        CompareMatrices(result.GetSolution(x), Eigen::Vector3d::Zero(), 1E-6));
+  }
+}
+
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/mosek_solver_test.cc
+++ b/solvers/test/mosek_solver_test.cc
@@ -362,6 +362,20 @@ GTEST_TEST(MosekTest, UnivariateNonnegative1) {
     dut.CheckResult(result, 1E-9);
   }
 }
+
+GTEST_TEST(MosekTest, QuadraticCostNonlinearConstraint) {
+  // Mosek can't solve a problem with quadratic cost and Lorentz cone
+  // constraint.
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<3>();
+  prog.AddQuadraticCost(x[0] * x[0]);
+  prog.AddLorentzConeConstraint(x);
+
+  MosekSolver solver;
+  if (solver.available()) {
+    EXPECT_FALSE(MosekSolver::ProgramAttributesSatisfied(prog));
+  }
+}
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/program_attribute_test.cc
+++ b/solvers/test/program_attribute_test.cc
@@ -24,6 +24,28 @@ GTEST_TEST(ProgramAttributeTest, ToString) {
   EXPECT_EQ(os.str(), "{ProgramAttributes: GenericCost, GenericConstraint}");
 }
 
+GTEST_TEST(HasQuadraticCostAndNonlinearConicConstraintTest, Test) {
+  EXPECT_TRUE(HasQuadraticCostAndNonlinearConicConstraint(
+      ProgramAttributes{ProgramAttribute::kQuadraticCost,
+                        ProgramAttribute::kLorentzConeConstraint}));
+  EXPECT_TRUE(HasQuadraticCostAndNonlinearConicConstraint(
+      ProgramAttributes{ProgramAttribute::kQuadraticCost,
+                        ProgramAttribute::kRotatedLorentzConeConstraint}));
+  EXPECT_TRUE(HasQuadraticCostAndNonlinearConicConstraint(
+      ProgramAttributes{ProgramAttribute::kQuadraticCost,
+                        ProgramAttribute::kPositiveSemidefiniteConstraint}));
+  EXPECT_TRUE(HasQuadraticCostAndNonlinearConicConstraint(
+      ProgramAttributes{ProgramAttribute::kQuadraticCost,
+                        ProgramAttribute::kExponentialConeConstraint}));
+  EXPECT_FALSE(HasQuadraticCostAndNonlinearConicConstraint(
+      ProgramAttributes{ProgramAttribute::kQuadraticCost,
+                        ProgramAttribute::kQuadraticConstraint}));
+  EXPECT_FALSE(HasQuadraticCostAndNonlinearConicConstraint(ProgramAttributes{
+      ProgramAttribute::kQuadraticCost, ProgramAttribute::kLinearConstraint}));
+  EXPECT_FALSE(HasQuadraticCostAndNonlinearConicConstraint(
+      ProgramAttributes{ProgramAttribute::kQuadraticCost,
+                        ProgramAttribute::kLinearEqualityConstraint}));
+}
 }  // namespace
 }  // namespace test
 }  // namespace solvers


### PR DESCRIPTION
Some users encountered this https://stackoverflow.com/questions/61360928/sos-polynomial-with-drake-and-mosek-yields-error-code-1501.

It is kind of hard for the users to find out the cause for this failure. So we check it explicitly, that mosek doesn't support quadratic cost with nonlinear constraint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14129)
<!-- Reviewable:end -->
