### PR TITLE
Adds parameters for FixedOffsetFrame

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -1451,6 +1451,16 @@ class TestPlant(unittest.TestCase):
             frame.GetFixedPoseInBodyFrame().GetAsMatrix4(),
             np.eye(4))
 
+        plant.Finalize()
+        context = plant.CreateDefaultContext()
+
+        X_PF = RigidTransform_[T](p=[1., 2., 3.])
+        frame.SetPoseInBodyFrame(context=context, X_PF=X_PF)
+
+        numpy_compare.assert_float_equal(
+            frame.CalcPoseInBodyFrame(context).GetAsMatrix34(),
+            numpy_compare.to_float(X_PF.GetAsMatrix34()))
+
     @numpy_compare.check_all_types
     def test_multibody_dynamics(self, T):
         MultibodyPlant = MultibodyPlant_[T]

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -165,7 +165,9 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("name", &Class::name, cls_doc.name.doc)
         .def("body", &Class::body, py_rvp::reference_internal, cls_doc.body.doc)
         .def("GetFixedPoseInBodyFrame", &Frame<T>::GetFixedPoseInBodyFrame,
-            cls_doc.GetFixedPoseInBodyFrame.doc);
+            cls_doc.GetFixedPoseInBodyFrame.doc)
+        .def("CalcPoseInBodyFrame", &Frame<T>::CalcPoseInBodyFrame,
+            py::arg("context"), cls_doc.CalcPoseInBodyFrame.doc);
   }
 
   {
@@ -195,7 +197,10 @@ void DoScalarDependentDefinitions(py::module m, T) {
               name, P, RigidTransform<double>(X_PF), model_instance);
         }),
             py::arg("name"), py::arg("P"), py::arg("X_PF"),
-            py::arg("model_instance") = std::nullopt, doc_iso3_deprecation);
+            py::arg("model_instance") = std::nullopt, doc_iso3_deprecation)
+        .def("SetPoseInBodyFrame", &Class::SetPoseInBodyFrame,
+            py::arg("context"), py::arg("X_PF"),
+            cls_doc.SetPoseInBodyFrame.doc);
   }
 
   // Bodies.


### PR DESCRIPTION
Towards [#13289](https://github.com/RobotLocomotion/drake/issues/13289).

Implements MultibodyElement Parameterization (started in [#13860](https://github.com/RobotLocomotion/drake/pull/13860)) for FixedOffsetFrame.

Introduces API for mutating FixedOffsetFrame given a context:
- `FixedOffsetFrame::SetPoseInBodyFrame`

Adds python binding for:
- `Frame::CalcPoseInBodyFrame()`
- `Frame::CalcRotationMatrixInBodyFrame()`
- `FixedOffsetFrame::SetPoseInBodyFrame()`

Relevant issues that this may partially/completely solve:
[#14084](https://github.com/RobotLocomotion/drake/issues/14084)
[#13520](https://github.com/RobotLocomotion/drake/issues/13520)
[#13517](https://github.com/RobotLocomotion/drake/issues/13517)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14137)
<!-- Reviewable:end -->
