### PR TITLE
Add pydrake bindings for model directives.

### DIFF
--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -220,6 +220,7 @@ drake_py_unittest(
     data = [
         "//examples/atlas:models",
         "//multibody/benchmarks/acrobot:models",
+        "//multibody/parsing:process_model_directives_test_models",
     ],
     deps = [
         ":parsing_py",

--- a/bindings/pydrake/multibody/parsing_py.cc
+++ b/bindings/pydrake/multibody/parsing_py.cc
@@ -5,6 +5,7 @@
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/multibody/parsing/package_map.h"
 #include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/parsing/process_model_directives.h"
 
 using drake::geometry::SceneGraph;
 using drake::multibody::MultibodyPlant;
@@ -57,6 +58,49 @@ PYBIND11_MODULE(parsing, m) {
             py::arg("file_contents"), py::arg("file_type"),
             py::arg("model_name") = "", cls_doc.AddModelFromString.doc);
   }
+
+  // Model Directives
+  {
+    using Class = parsing::ModelDirectives;
+    py::class_<Class>(m, "ModelDirectives", doc.parsing.ModelDirectives.doc);
+  }
+
+  m.def("LoadModelDirectives", &parsing::LoadModelDirectives,
+      py::arg("filename"), doc.parsing.LoadModelDirectives.doc);
+
+  // ModelInstanceInfo
+  {
+    using Class = parsing::ModelInstanceInfo;
+    constexpr auto& cls_doc = doc.parsing.ModelInstanceInfo;
+    py::class_<Class>(m, "ModelInstanceInfo", cls_doc.doc)
+        .def_readonly("model_name", &Class::model_name, cls_doc.model_name.doc)
+        .def_readonly("model_path", &Class::model_path, cls_doc.model_path.doc)
+        .def_readonly("parent_frame_name", &Class::parent_frame_name,
+            cls_doc.parent_frame_name.doc)
+        .def_readonly("child_frame_name", &Class::child_frame_name,
+            cls_doc.child_frame_name.doc)
+        .def_readonly("X_PC", &Class::X_PC, cls_doc.X_PC.doc)
+        .def_readonly("model_instance", &Class::model_instance,
+            cls_doc.model_instance.doc);
+  }
+
+  constexpr char kWeldErrorDisclaimer[] = R"""(
+    Note:
+        pydrake does not currently support `ModelWeldErrorFunction`.
+    )""";
+  m.def(
+      "ProcessModelDirectives",
+      [](const parsing::ModelDirectives& directives,
+          MultibodyPlant<double>* plant, Parser* parser = nullptr) {
+        std::vector<parsing::ModelInstanceInfo> added_models;
+        parsing::ProcessModelDirectives(
+            directives, plant, &added_models, parser);
+        return added_models;
+      },
+      py::arg("directives"), py::arg("plant"), py::arg("parser"),
+      (std::string(doc.parsing.ProcessModelDirectives.doc) +
+          kWeldErrorDisclaimer)
+          .c_str());
 }
 
 }  // namespace pydrake

--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -268,6 +268,9 @@ filegroup(
     name = "process_model_directives_test_models",
     testonly = True,
     data = glob(["test/process_model_directives_test/**"]),
+    visibility = [
+        "//bindings/pydrake/multibody:__pkg__",
+    ],
 )
 
 drake_cc_googletest(


### PR DESCRIPTION
* Weld error support omitted for simplicity.
* Follow-up to #14038
* Completes #13282

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14144)
<!-- Reviewable:end -->
