### PR TITLE
cassie_bench: Separate autodiff malloc counts from benchmark timing

### DIFF
--- a/examples/multibody/cassie_benchmark/test/cassie_bench.cc
+++ b/examples/multibody/cassie_benchmark/test/cassie_bench.cc
@@ -214,13 +214,17 @@ BENCHMARK_F(CassieAutodiffFixture, AutodiffMassMatrix)
   // The first iteration allocates more memory than subsequent runs.
   compute();
 
-  for (auto _ : state) {
+  for (int k = 0; k < 3; k++) {
     // @see LimitMalloc note above.
     LimitMalloc guard(LimitReleaseOnly(31426));
 
     compute();
 
     tracker.Update(guard.num_allocations());
+  }
+
+  for (auto _ : state) {
+    compute();
   }
 }
 
@@ -247,13 +251,17 @@ BENCHMARK_F(CassieAutodiffFixture, AutodiffInverseDynamics)
   // The first iteration allocates more memory than subsequent runs.
   compute();
 
-  for (auto _ : state) {
+  for (int k = 0; k < 3; k++) {
     // @see LimitMalloc note above.
     LimitMalloc guard(LimitReleaseOnly(38027));
 
     compute();
 
     tracker.Update(guard.num_allocations());
+  }
+
+  for (auto _ : state) {
+    compute();
   }
 }
 
@@ -279,13 +287,17 @@ BENCHMARK_F(CassieAutodiffFixture, AutodiffForwardDynamics)
   // The first iteration allocates more memory than subsequent runs.
   compute();
 
-  for (auto _ : state) {
+  for (int k = 0; k < 3; k++) {
     // @see LimitMalloc note above.
     LimitMalloc guard(LimitReleaseOnly(57693));
 
     compute();
 
     tracker.Update(guard.num_allocations());
+  }
+
+  for (auto _ : state) {
+    compute();
   }
 }
 


### PR DESCRIPTION
Relevant to: #10991, #13902

I finally realized that LimitMalloc counting was contributing significant
overhead to autodiff benchmark timings, owing to necessary synchronization
primitives in that module. This patch separates the two measurements, to
clarify the things we want to focus on.

Notice that this change of measurement will require some revision of our
timings for older versions, to keep comparisons sensible. Reviewers should look
for updates to the tracking issue #13902.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14146)
<!-- Reviewable:end -->
