### PR TITLE
simulator: Squelch deprecation warning when building.

### DIFF
--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -49,6 +49,7 @@ drake_cc_library(
     name = "simulator_flags",
     srcs = ["simulator_flags.cc"],
     hdrs = ["simulator_flags.h"],
+    copts = ["-w"],
     deps = [
         ":simulator_config_functions",
     ],


### PR DESCRIPTION
Removes a warning when building introduced by #14135.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14149)
<!-- Reviewable:end -->
