### PR TITLE
simulator: resolved mismatch of simulator integrator defaults

### DIFF
--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -409,6 +409,7 @@ drake_cc_library(
     deps = [
         ":runge_kutta2_integrator",
         ":runge_kutta3_integrator",
+        ":simulator_config",
         ":simulator_status",
         "//common:extract_double",
         "//systems/framework:context",

--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -14,6 +14,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/extract_double.h"
 #include "drake/systems/analysis/integrator_base.h"
+#include "drake/systems/analysis/simulator_config.h"
 #include "drake/systems/analysis/simulator_status.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/system.h"
@@ -21,18 +22,6 @@
 
 namespace drake {
 namespace systems {
-
-namespace internal {
-// Default value of target_realtime_rate_.
-const double kDefaultTargetRealtimeRate = 0.0;
-
-// Default integrator used by a Simulator.
-const char* const kDefaultIntegratorName = "runge_kutta3";
-
-// Default value of both publish_every_time_step_ and
-// publish_at_initialization_.
-const bool kDefaultPublishEveryTimeStep = false;
-}  // namespace internal
 
 /// @ingroup simulation
 /// Parameters for fine control of simulator initialization.
@@ -786,9 +775,6 @@ class Simulator {
     return std::numeric_limits<double>::quiet_NaN();
   }
 
-  static constexpr double kDefaultAccuracy = 1e-3;  // 1/10 of 1%.
-  static constexpr double kDefaultInitialStepSizeAttempt = 1e-3;
-
   // Do not use this.  This is valid iff the constructor is passed a
   // unique_ptr (allowing the Simulator to maintain ownership).  Use the
   // system_ variable instead, which is valid always.
@@ -802,11 +788,11 @@ class Simulator {
   VectorX<T> w0_, wf_;
 
   // Slow down to this rate if possible (user settable).
-  double target_realtime_rate_{internal::kDefaultTargetRealtimeRate};
+  double target_realtime_rate_{SimulatorConfig{}.target_realtime_rate};
 
-  bool publish_every_time_step_{internal::kDefaultPublishEveryTimeStep};
+  bool publish_every_time_step_{SimulatorConfig{}.publish_every_time_step};
 
-  bool publish_at_initialization_{internal::kDefaultPublishEveryTimeStep};
+  bool publish_at_initialization_{SimulatorConfig{}.publish_every_time_step};
 
   // These are recorded at initialization or statistics reset.
   double initial_simtime_{nan()};  // Simulated time at start of period.

--- a/systems/analysis/simulator_config.h
+++ b/systems/analysis/simulator_config.h
@@ -7,11 +7,6 @@
 namespace drake {
 namespace systems {
 
-// N.B. The default values here match simulator.h
-// and runge_kutta3_integrator.[h/cc]. For example
-// drake::systems::internal::kDefaultIntegratorName is "runge_kutta3".
-// TODO(dale.mcconachie) Ensure that the default SimulatorConfig remains
-// congruent with a default initialized Simulator.
 // TODO(dale.mcconachie) Update to include all configurable properties of
 // IntegratorBase. Currently, initial_step_size_target, minimum_step_size, and
 // throw_on_minimum_step_size_violation are missing.
@@ -28,8 +23,8 @@ struct SimulatorConfig {
   }
 
   std::string integration_scheme{"runge_kutta3"};
-  double max_step_size{1.0e-3};
-  double accuracy{1.0e-2};
+  double max_step_size{0.1};
+  double accuracy{1.0e-4};
   bool use_error_control{true};
   double target_realtime_rate{0.0};
   /// Sets Simulator::set_publish_at_initialization() in addition to

--- a/systems/analysis/simulator_gflags.cc
+++ b/systems/analysis/simulator_gflags.cc
@@ -5,17 +5,18 @@
 
 #include "drake/common/drake_throw.h"
 #include "drake/common/text_logging.h"
+#include "drake/systems/analysis/simulator.h"
 #include "drake/systems/analysis/simulator_config_functions.h"
 
 // === Simulator's parameters ===
 
 DEFINE_double(simulator_target_realtime_rate,
-              drake::systems::internal::kDefaultTargetRealtimeRate,
+              drake::systems::SimulatorConfig{}.target_realtime_rate,
               "[Simulator flag] Desired rate relative to real time.  See "
               "documentation for Simulator::set_target_realtime_rate() for "
               "details.");
 DEFINE_bool(simulator_publish_every_time_step,
-            drake::systems::internal::kDefaultPublishEveryTimeStep,
+            drake::systems::SimulatorConfig{}.publish_every_time_step,
             "[Simulator flag] Sets whether the simulation should trigger a "
             "forced-Publish event at the end of every trajectory-advancing "
             "step. This also includes the very first publish at t = 0 (see "
@@ -27,7 +28,7 @@ DEFINE_bool(simulator_publish_every_time_step,
 // N.B. The list here must be kept in sync with GetSupportedIntegrators() in
 // simulator_config_functions.cc.
 DEFINE_string(simulator_integration_scheme,
-              drake::systems::internal::kDefaultIntegratorName,
+              drake::systems::SimulatorConfig{}.integration_scheme,
               "[Integrator flag] Integration scheme to be used. Available "
               "options are: "
               "'bogacki_shampine3', "
@@ -41,20 +42,20 @@ DEFINE_string(simulator_integration_scheme,
               "'semi_explicit_euler', "
               "'velocity_implicit_euler'");
 
-DEFINE_double(simulator_max_time_step, 1.0E-3,
+DEFINE_double(simulator_max_time_step,
+              drake::systems::SimulatorConfig{}.max_step_size,
               "[Integrator flag] Maximum simulation time step used for "
               "integration. [s].");
 
-const double kDefaultSimulatorAccuracy = 1.0e-2;
-DEFINE_double(simulator_accuracy, kDefaultSimulatorAccuracy,
+DEFINE_double(simulator_accuracy, drake::systems::SimulatorConfig{}.accuracy,
               "[Integrator flag] Sets the simulation accuracy for variable "
               "step size integrators with error control.");
 
-DEFINE_bool(simulator_use_error_control, true,
+DEFINE_bool(simulator_use_error_control,
+            drake::systems::SimulatorConfig{}.use_error_control,
             "[Integrator flag] If 'true', the simulator's integrator will use "
             "error control if it supports it. Otherwise, the simulator "
             "attempts to use fixed steps.");
-
 
 namespace drake {
 namespace systems {
@@ -75,7 +76,7 @@ IntegratorBase<double>& ResetIntegratorFromGflags(
   } else {
     // Integrator is running in fixed step mode, therefore we warn the user if
     // the accuracy flag was changed from the command line.
-    if (FLAGS_simulator_accuracy != kDefaultSimulatorAccuracy)
+    if (FLAGS_simulator_accuracy != drake::systems::SimulatorConfig{}.accuracy)
       log()->warn(
           "Integrator accuracy provided, however the integrator is running in "
           "fixed step mode. The 'simulator_accuracy' flag will be ignored. "

--- a/systems/analysis/test/simulator_config_functions_test.cc
+++ b/systems/analysis/test/simulator_config_functions_test.cc
@@ -47,21 +47,26 @@ class DummySystem final : public drake::systems::LeafSystem<double> {
   DummySystem() {}
 };
 
-GTEST_TEST(SimulatorConfigFunctionsTest, ExtractDefaultsTest) {
+GTEST_TEST(SimulatorConfigFunctionsTest, SimulatorConfigCongruenceTest) {
+  // Ensure that a default constructed SimulatorConfig has the same values as a
+  // default constructed Simulator.
+  // N.B. Due to the RoundTripTest, we know that ExtractSimulatorConfig is doing
+  // actual work, not just returning a default constructed SimulatorConfig.
+
   const DummySystem dummy;
   Simulator<double> simulator(dummy);
 
-  // We can always extract the defaults.
-  const SimulatorConfig defaults = ExtractSimulatorConfig(simulator);
-  EXPECT_EQ(defaults.integration_scheme, "runge_kutta3");
-  // TODO(jeremy.nimmer) The integrators return incorrect defaults for
-  // max_step_size and accuracy.  Once Drake is fixed, we should EXPECT_EQ
-  // instead here.
-  EXPECT_GT(defaults.max_step_size, 0);
-  EXPECT_GT(defaults.accuracy, 0);
-  EXPECT_EQ(defaults.use_error_control, true);
-  EXPECT_EQ(defaults.target_realtime_rate, 0.0);
-  EXPECT_EQ(defaults.publish_every_time_step, false);
+  const SimulatorConfig config_defaults;
+  const SimulatorConfig sim_defaults = ExtractSimulatorConfig(simulator);
+  EXPECT_EQ(sim_defaults.integration_scheme,
+            config_defaults.integration_scheme);
+  EXPECT_EQ(sim_defaults.max_step_size, config_defaults.max_step_size);
+  EXPECT_EQ(sim_defaults.accuracy, config_defaults.accuracy);
+  EXPECT_EQ(sim_defaults.use_error_control, config_defaults.use_error_control);
+  EXPECT_EQ(sim_defaults.target_realtime_rate,
+            config_defaults.target_realtime_rate);
+  EXPECT_EQ(sim_defaults.publish_every_time_step,
+            config_defaults.publish_every_time_step);
 }
 
 GTEST_TEST(SimulatorConfigFunctionsTest, RoundTripTest) {


### PR DESCRIPTION
Towards #12903 

- Removed duplication of integrator defaults.
- Updated test to check if SimulatorConfig defaults are congruent with
integrator defaults.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14150)
<!-- Reviewable:end -->
