### PR TITLE
Add Context::SetStateAndParametersFrom()

### DIFF
--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -401,17 +401,43 @@ class Context : public ContextBase {
     get_mutable_abstract_state<ValueType>(index) = value;
   }
 
-  // TODO(sherm1) Should treat fixed input port values same as parameters.
-  // TODO(sherm1) Change the name of this method to be more inclusive since it
-  //              also copies accuracy (now) and fixed input port values
-  //              (pending above TODO).
-  /// Sets this context's time, accuracy, state, and parameters from the
-  /// `double` values in @p source, regardless of this context's scalar type.
-  /// Sends out of date notifications for all dependent computations in this
+  // TODO(xuchenhan-tri) Should treat fixed input port values the same as
+  // parameters.
+  // TODO(xuchenhan-tri) Change the name of this method to be more inclusive
+  // since it also set fixed input port values (pending above TODO).
+  /// Copies all state and parameters in @p source, where numerical values are
+  /// of type `U`, to `this` context. Time and accuracy are unchanged in `this`
+  /// context, which means that this method can be called on a subcontext.
+  /// Sends out of date notifications for all dependent computations in `this`
   /// context.
-  /// @throws std::logic_error if this is not the root context.
   /// @note Currently does not copy fixed input port values from `source`.
   /// See System::FixInputPortsFrom() if you want to copy those.
+  /// @see SetTimeStateAndParametersFrom() if you want to copy time and accuracy
+  /// along with state and parameters to a root context.
+  template <typename U>
+  void SetStateAndParametersFrom(const Context<U>& source) {
+    // A single change event for all these changes is faster than doing
+    // each separately.
+    const int64_t change_event = this->start_new_change_event();
+
+    SetStateAndParametersFromHelper(source, change_event);
+  }
+
+  // TODO(xuchenhan-tri) Should treat fixed input port values the same as
+  // parameters.
+  // TODO(xuchenhan-tri) Change the name of this method to be more inclusive
+  // since it also copies accuracy (now) and fixed input port values
+  // (pending above TODO).
+  /// Copies time, accuracy, all state and all parameters in @p source, where
+  /// numerical values are of type `U`, to `this` context. This method can only
+  /// be called on root contexts because time and accuracy are copied.
+  /// Sends out of date notifications for all dependent computations in this
+  /// context.
+  /// @throws std::exception if this is not the root context.
+  /// @note Currently does not copy fixed input port values from `source`.
+  /// See System::FixInputPortsFrom() if you want to copy those.
+  /// @see SetStateAndParametersFrom() if you want to copy state and parameters
+  /// to a non-root context.
   template <typename U>
   void SetTimeStateAndParametersFrom(const Context<U>& source) {
     ThrowIfNotRootContext(__func__, "Time");
@@ -424,14 +450,9 @@ class Context : public ContextBase {
     PropagateTimeChange(this, converter(source.get_time()), {}, change_event);
     PropagateAccuracyChange(this, source.get_accuracy(), change_event);
 
-    // Notification is separate from the actual value change for bulk changes.
-    PropagateBulkChange(change_event, &Context<T>::NoteAllStateChanged);
-    do_access_mutable_state().SetFrom(source.get_state());
-
-    PropagateBulkChange(change_event, &Context<T>::NoteAllParametersChanged);
-    parameters_->SetFrom(source.get_parameters());
-
-    // TODO(sherm1) Fixed input copying goes here.
+    // Set state and parameters (and fixed input port values pending TODO) from
+    // the source.
+    SetStateAndParametersFromHelper(source, change_event);
   }
 
   // Allow access to the base class method (takes an AbstractValue).
@@ -830,6 +851,25 @@ class Context : public ContextBase {
   // Call with arguments like (__func__, "Time"), capitalized as shown.
   void ThrowIfNotRootContext(const char* func_name,
                              const char* quantity) const;
+
+  // TODO(xuchenhan-tri) Should treat fixed input port values the same as
+  // parameters.
+  // TODO(xuchenhan-tri) Change the name of this method to be more inclusive
+  // since it also fixed input port values (pending above TODO).
+  // This helper allow us to reuse this code in several APIs with a single
+  // change_event.
+  template <typename U>
+  void SetStateAndParametersFromHelper(const Context<U>& source,
+                                       int64_t change_event) {
+    // Notification is separate from the actual value change for bulk changes.
+    PropagateBulkChange(change_event, &Context<T>::NoteAllStateChanged);
+    do_access_mutable_state().SetFrom(source.get_state());
+
+    PropagateBulkChange(change_event, &Context<T>::NoteAllParametersChanged);
+    parameters_->SetFrom(source.get_parameters());
+
+    // TODO(xuchenhan-tri) Fixed input copying goes here.
+  }
 
   // These helpers allow us to reuse this code in several APIs while the
   // error message contains the actual API name.

--- a/systems/framework/test/diagram_context_test.cc
+++ b/systems/framework/test/diagram_context_test.cc
@@ -775,6 +775,64 @@ TEST_F(DiagramContextTest, SubcontextCloneIsError) {
       "this Context was created by 'adder0'.");
 }
 
+TEST_F(DiagramContextTest, SubcontextSetTimeStateAndParametersFromIsError) {
+  auto clone = dynamic_pointer_cast<DiagramContext<double>>(context_->Clone());
+  ASSERT_TRUE(clone != nullptr);
+  const auto& source_subcontext =
+      context_->GetSubsystemContext(SubsystemIndex{0});
+  auto& dest_subcontext = clone->GetMutableSubsystemContext(SubsystemIndex{0});
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dest_subcontext.SetTimeStateAndParametersFrom(source_subcontext),
+      std::exception,
+      "SetTimeStateAndParametersFrom\\(\\): Time change allowed only in the "
+      "root Context.");
+}
+
+TEST_F(DiagramContextTest, SubcontextSetStateAndParametersFrom) {
+  auto clone = dynamic_pointer_cast<DiagramContext<double>>(context_->Clone());
+  ASSERT_TRUE(clone != nullptr);
+  // Set arbitrary time, accuracy, state and parameters to the cloned
+  // context so that they are different from the original context.
+  const double new_time = context_->get_time() + 1.;
+  const double new_accuracy = 3e-12;
+  const Eigen::Vector2d new_xc(0.125, 7.5);
+  const double new_xd = -1.;
+  const int new_xa = 12345;
+  const double new_pn = -2;
+  const int new_pa = 101;
+
+  clone->SetTime(new_time);
+  clone->SetAccuracy(new_accuracy);
+  clone->SetContinuousState(new_xc);
+  clone->get_mutable_discrete_state(0)[0] = new_xd;
+  clone->get_mutable_abstract_state<int>(0) = new_xa;
+  clone->get_mutable_numeric_parameter(0).SetAtIndex(0, new_pn);
+  clone->get_mutable_abstract_parameter(0).set_value<int>(new_pa);
+
+  // Call the method under test for the subcontexts of context_.
+  for (int i = 0; i < kNumSystems; ++i) {
+    const auto& source_subcontext =
+        context_->GetSubsystemContext(SubsystemIndex{i});
+    auto& dest_subcontext =
+        clone->GetMutableSubsystemContext(SubsystemIndex{i});
+    dest_subcontext.SetStateAndParametersFrom(source_subcontext);
+  }
+
+  // The state and the parameters should have been set to be the same
+  // as the source context.
+  VerifyClonedParameters(clone->get_parameters());
+  VerifyClonedState(clone->get_state());
+
+  // Verify time and accuracy did not change for this context and its
+  // subcontexts.
+  EXPECT_EQ(clone->get_time(), new_time);
+  EXPECT_EQ(clone->get_accuracy(), new_accuracy);
+  for (SubsystemIndex i(0); i < kNumSystems; ++i) {
+    const auto& subcontext = clone->GetSubsystemContext(i);
+    EXPECT_EQ(subcontext.get_time(), new_time);
+    EXPECT_EQ(subcontext.get_accuracy(), new_accuracy);
+  }
+}
 }  // namespace
 }  // namespace systems
 }  // namespace drake


### PR DESCRIPTION
Resolves #14138.

Add the method Context::SetStateAndParametersFrom() to allow
copying state and parameters from another context to a non-root
context.

Change the documentation for
Context::SetTimeStateAndParametersFrom() to reflect what it does.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14156)
<!-- Reviewable:end -->
