### PR TITLE
Make compatible with Eigen-3.3.8

### DIFF
--- a/systems/framework/system_constraint.h
+++ b/systems/framework/system_constraint.h
@@ -220,19 +220,19 @@ class SystemConstraint final {
     // elegant, and so that double evaluation is as fast as possible.
     if (type() == SystemConstraintType::kEquality) {
       if (tol == 0.0) {
-        return all(value.array() == 0.0);
+        return drake::all(value.array() == 0.0);
       } else {
-        return all(value.cwiseAbs().array() <= tol);
+        return drake::all(value.cwiseAbs().array() <= tol);
       }
     } else {
       DRAKE_ASSERT(type() == SystemConstraintType::kInequality);
       // TODO(hongkai.dai): ignore the bounds that are infinite.
       if (tol == 0.0) {
-        return all(value.array() >= lower_bound().array()) &&
-               all(value.array() <= upper_bound().array());
+        return drake::all(value.array() >= lower_bound().array()) &&
+               drake::all(value.array() <= upper_bound().array());
       } else {
-        return all((value - lower_bound()).array() >= -tol) &&
-               all((upper_bound() - value).array() >= -tol);
+        return drake::all((value - lower_bound()).array() >= -tol) &&
+               drake::all((upper_bound() - value).array() >= -tol);
       }
     }
   }


### PR DESCRIPTION
Eigen introduces [Eigen::all](http://eigen.tuxfamily.org/dox-devel/group__Core__Module.html#ga790ab6c4226ef5f678b9eb532a3eab14) and we need this patch to avoid name conflicts
with drake::all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14159)
<!-- Reviewable:end -->
