### PR TITLE
Revert "build: Wcpp warnings to errors"

### DIFF
--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -6,7 +6,6 @@ load("@cc//:compiler.bzl", "COMPILER_ID", "COMPILER_VERSION_MAJOR")
 # building with any compiler.
 CXX_FLAGS = [
     "-Werror=all",
-    "-Werror=cpp",
     "-Werror=deprecated",
     "-Werror=deprecated-declarations",
     "-Werror=ignored-qualifiers",


### PR DESCRIPTION
Dear @dmcconachie-tri,

The on-call build cop, @BetsyMcPhail , believes that your PR #14155 may have
broken one or more of Drake's continuous integration builds [1]. It is
possible to break a build even if your PR passed continuous integration
pre-merge because additional platforms are tested post-merge.

The specific build failures under investigation are:
https://drake-jenkins.csail.mit.edu/job/mac-mojave-clang-cmake-continuous-release/1471/

Therefore, the build cop has created this revert PR and started a complete
post-merge build to determine whether your PR was in fact the cause of the
problem. If that build passes, this revert PR will be merged 60 minutes from
now. You can then fix the problem at your leisure, and send a new PR to
reinstate your change.

If you believe your original PR did not actually break the build, please
explain on this thread.

If you believe you can fix the break promptly in lieu of a revert, please
explain on this thread, and send a PR to the build cop for review ASAP.

If you believe your original PR definitely did break the build and should be
reverted, please review and LGTM this PR. This allows the build cop to merge
without waiting for CI results.

For advice on how to handle a build cop revert, see [2].

Thanks!
Your Friendly On-call Build Cop

[1] CI Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Production/
[2] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14163)
<!-- Reviewable:end -->
