### PR TITLE
autodiffxd: Optimize `operator*=` a bit more

### DIFF
--- a/common/autodiffxd.h
+++ b/common/autodiffxd.h
@@ -333,11 +333,15 @@ class AutoDiffScalar<VectorXd>
   inline AutoDiffScalar& operator*=(const AutoDiffScalar<OtherDerType>& other) {
     const bool has_this_der = m_derivatives.size() > 0;
     const bool has_both_der = has_this_der && (other.derivatives().size() > 0);
+    // Some of the math below may look tempting to rewrite using `*=`, but
+    // performance measurement and analysis show that this formulation is
+    // faster because it results in better expression tree optimization and
+    // inlining.
     if (has_both_der) {
-      m_derivatives *= other.value();
-      m_derivatives += other.derivatives() * m_value;
+      m_derivatives = m_derivatives * other.value() +
+                      other.derivatives() * m_value;
     } else if (has_this_der) {
-      m_derivatives *= other.value();
+      m_derivatives = m_derivatives * other.value();
     } else {
       m_derivatives = other.derivatives() * m_value;
     }


### PR DESCRIPTION
Relevant to: #10991, #13902

It turns out that relying on eigen's Matrix::operator*= too heavily results in
slower code. Rewrite AutoDiffXd::operator*= for autodiff inputs so that it gets
better optimization and inlining from Eigen.

Supporting benchmark measurements will be provided in #13902.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14171)
<!-- Reviewable:end -->
