### PR TITLE
common:  Add std::optional support to DRAKE_DEMAND.

### DIFF
--- a/bindings/pydrake/common/module_py.cc
+++ b/bindings/pydrake/common/module_py.cc
@@ -39,7 +39,7 @@ py::handle ResolvePyObject(const type_erased_ptr& ptr) {
 
 // Gets a class's fully-qualified name.
 std::string GetPyClassName(py::handle obj) {
-  DRAKE_DEMAND(!!obj);
+  DRAKE_DEMAND(obj);
   py::handle cls = obj.get_type();
   return py::str("{}.{}").format(
       cls.attr("__module__"), cls.attr("__qualname__"));

--- a/common/drake_assert.h
+++ b/common/drake_assert.h
@@ -98,9 +98,10 @@ namespace assert {
 // require special handling.
 template <typename Condition>
 struct ConditionTraits {
-  static constexpr bool is_valid = std::is_convertible<Condition, bool>::value;
+  static constexpr bool is_valid =
+      std::is_constructible<bool, Condition>::value;
   static bool Evaluate(const Condition& value) {
-    return value;
+    return static_cast<bool>(value);
   }
 };
 }  // namespace assert

--- a/common/nice_type_name_override.cc
+++ b/common/nice_type_name_override.cc
@@ -14,7 +14,7 @@ NiceTypeNamePtrOverride& ptr_override() {
 }  // namespace
 
 void SetNiceTypeNamePtrOverride(NiceTypeNamePtrOverride new_ptr_override) {
-  DRAKE_DEMAND(!!new_ptr_override);
+  DRAKE_DEMAND(new_ptr_override);
   DRAKE_DEMAND(!ptr_override());
   ptr_override() = new_ptr_override;
 }

--- a/common/test/drake_assert_test.cc
+++ b/common/test/drake_assert_test.cc
@@ -1,5 +1,6 @@
 #include "drake/common/drake_assert.h"
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -36,10 +37,15 @@ GTEST_TEST(DrakeAssertDeathTest, DemandTest) {
 }
 
 struct BoolConvertible { operator bool() const { return true; } };
+struct BoolExplicitConvertible {
+  explicit operator bool() const { return true; }
+};
 GTEST_TEST(DrakeAssertDeathTest, AssertSyntaxTest) {
   // These should compile.
   DRAKE_ASSERT((2 + 2) == 4);
   DRAKE_ASSERT(BoolConvertible());
+  DRAKE_ASSERT(BoolExplicitConvertible());
+  DRAKE_ASSERT(std::optional<int>{3});
 }
 
 GTEST_TEST(DrakeAssertDeathTest, AssertFalseTest) {

--- a/examples/allegro_hand/joint_control/allegro_single_object_simulation.cc
+++ b/examples/allegro_hand/joint_control/allegro_single_object_simulation.cc
@@ -101,7 +101,7 @@ void DoMain() {
 
   // Visualization
   geometry::ConnectDrakeVisualizer(&builder, scene_graph);
-  DRAKE_DEMAND(!!plant.get_source_id());
+  DRAKE_DEMAND(plant.get_source_id());
   builder.Connect(
       plant.get_geometry_poses_output_port(),
       scene_graph.get_source_pose_port(plant.get_source_id().value()));

--- a/examples/allegro_hand/run_allegro_constant_load_demo.cc
+++ b/examples/allegro_hand/run_allegro_constant_load_demo.cc
@@ -97,7 +97,7 @@ void DoMain() {
   builder.Connect(constant_source->get_output_port(),
                   plant.get_actuation_input_port());
 
-  DRAKE_DEMAND(!!plant.get_source_id());
+  DRAKE_DEMAND(plant.get_source_id());
   builder.Connect(
       plant.get_geometry_poses_output_port(),
       scene_graph.get_source_pose_port(plant.get_source_id().value()));

--- a/examples/multibody/acrobot/passive_simulation.cc
+++ b/examples/multibody/acrobot/passive_simulation.cc
@@ -79,7 +79,7 @@ int do_main() {
                   acrobot.get_actuation_input_port());
 
   // Sanity check on the availability of the optional source id before using it.
-  DRAKE_DEMAND(!!acrobot.get_source_id());
+  DRAKE_DEMAND(acrobot.get_source_id());
 
   builder.Connect(
       acrobot.get_geometry_poses_output_port(),

--- a/examples/multibody/acrobot/run_lqr.cc
+++ b/examples/multibody/acrobot/run_lqr.cc
@@ -139,7 +139,7 @@ int do_main() {
                   acrobot.get_actuation_input_port());
 
   // Sanity check on the availability of the optional source id before using it.
-  DRAKE_DEMAND(!!acrobot.get_source_id());
+  DRAKE_DEMAND(acrobot.get_source_id());
 
   builder.Connect(
       acrobot.get_geometry_poses_output_port(),

--- a/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
+++ b/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
@@ -86,7 +86,7 @@ int do_main() {
   DRAKE_DEMAND(plant.num_positions() == 7);
 
   // Sanity check on the availability of the optional source id before using it.
-  DRAKE_DEMAND(!!plant.get_source_id());
+  DRAKE_DEMAND(plant.get_source_id());
 
   builder.Connect(scene_graph.get_query_output_port(),
                   plant.get_geometry_query_input_port());

--- a/examples/multibody/pendulum/passive_simulation.cc
+++ b/examples/multibody/pendulum/passive_simulation.cc
@@ -81,7 +81,7 @@ int do_main() {
                   pendulum.get_actuation_input_port());
 
   // Sanity check on the availability of the optional source id before using it.
-  DRAKE_DEMAND(!!pendulum.get_source_id());
+  DRAKE_DEMAND(pendulum.get_source_id());
 
   builder.Connect(
       pendulum.get_geometry_poses_output_port(),

--- a/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
+++ b/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
@@ -146,7 +146,7 @@ int do_main() {
   DRAKE_DEMAND(plant.num_positions() == 7);
 
   // Sanity check on the availability of the optional source id before using it.
-  DRAKE_DEMAND(!!plant.get_source_id());
+  DRAKE_DEMAND(plant.get_source_id());
 
   builder.Connect(scene_graph.get_query_output_port(),
                   plant.get_geometry_query_input_port());

--- a/examples/simple_gripper/simple_gripper.cc
+++ b/examples/simple_gripper/simple_gripper.cc
@@ -238,7 +238,7 @@ int do_main() {
   DRAKE_DEMAND(plant.num_actuated_dofs() == 2);
 
   // Sanity check on the availability of the optional source id before using it.
-  DRAKE_DEMAND(!!plant.get_source_id());
+  DRAKE_DEMAND(plant.get_source_id());
 
   builder.Connect(scene_graph.get_query_output_port(),
                   plant.get_geometry_query_input_port());

--- a/multibody/plant/test/multibody_plant_hydroelastic_contact_results_output_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_contact_results_output_test.cc
@@ -56,7 +56,7 @@ class HydroelasticContactResultsOutputTester : public ::testing::Test {
 
     // Sanity check on the availability of the optional source id before using
     // it.
-    DRAKE_DEMAND(!!plant_->get_source_id());
+    DRAKE_DEMAND(plant_->get_source_id());
 
     builder.Connect(scene_graph.get_query_output_port(),
                     plant_->get_geometry_query_input_port());

--- a/systems/lcm/lcm_publisher_system.cc
+++ b/systems/lcm/lcm_publisher_system.cc
@@ -84,7 +84,7 @@ LcmPublisherSystem::~LcmPublisherSystem() {}
 
 void LcmPublisherSystem::AddInitializationMessage(
     InitializationPublisher initialization_publisher) {
-  DRAKE_DEMAND(!!initialization_publisher);
+  DRAKE_DEMAND(initialization_publisher);
 
   initialization_publisher_ = std::move(initialization_publisher);
 


### PR DESCRIPTION
 * `std::optional`s (and `std::function`s and a few others) are
   contextually bool-convertible; this is
   why they can be used as an `if` predicate.
 * However its `operator bool` is `explicit`, so it is not
   `std::is_convertible<bool...>`.
 * By switching from `is_convertible` to `is_constructible` we
   allow `DRAKE_DEMAND(optional_thing)` to work in the same
   way as `if(optional-thing)`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14172)
<!-- Reviewable:end -->
