### PR TITLE
Convert #warnings to errors

### DIFF
--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -49,7 +49,7 @@ drake_cc_library(
     name = "simulator_flags",
     srcs = ["simulator_flags.cc"],
     hdrs = ["simulator_flags.h"],
-    copts = ["-w"],
+    copts = ["-Wno-cpp"],
     deps = [
         ":simulator_config_functions",
     ],

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -6,6 +6,7 @@ load("@cc//:compiler.bzl", "COMPILER_ID", "COMPILER_VERSION_MAJOR")
 # building with any compiler.
 CXX_FLAGS = [
     "-Werror=all",
+    "-Werror=cpp",
     "-Werror=deprecated",
     "-Werror=deprecated-declarations",
     "-Werror=ignored-qualifiers",


### PR DESCRIPTION
Addresses #14151 and #14163, converting `#warnings` to errors and keeping both `gcc` and `clang` happy on both Mojave and Bionic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14174)
<!-- Reviewable:end -->
