### PR TITLE
[render] Add texture coordinates for all RenderEngineGl shapes

### DIFF
--- a/geometry/render/gl_renderer/shape_meshes.cc
+++ b/geometry/render/gl_renderer/shape_meshes.cc
@@ -7,7 +7,7 @@
 #include <limits>
 #include <map>
 #include <string>
-#include <utility>
+#include <tuple>
 #include <vector>
 
 #include <fmt/format.h>
@@ -23,10 +23,10 @@ namespace internal {
 
 using Eigen::Vector2d;
 using Eigen::Vector3d;
-using std::make_pair;
+using std::make_tuple;
 using std::map;
-using std::pair;
 using std::string;
+using std::tuple;
 using std::vector;
 
 MeshData LoadMeshFromObj(std::istream* input_stream,
@@ -35,21 +35,21 @@ MeshData LoadMeshFromObj(std::istream* input_stream,
   vector<tinyobj::shape_t> shapes;
   vector<tinyobj::material_t> materials;
   string err;
-  // This renderer assumes everything is triangles -- we rely on tinyobj to
-  // triangulate for us.
+  /* This renderer assumes everything is triangles -- we rely on tinyobj to
+   triangulate for us. */
   const bool do_tinyobj_triangulation = true;
 
-  // Tinyobj doesn't infer the search directory from the directory containing
-  // the obj file. We have to provide that directory; of course, this assumes
-  // that the material library reference is relative to the obj directory.
-  // Ignore material-library file.
+  /* Tinyobj doesn't infer the search directory from the directory containing
+   the obj file. We have to provide that directory; of course, this assumes
+   that the material library reference is relative to the obj directory.
+   Ignore material-library file.  */
   tinyobj::MaterialReader* material_reader = nullptr;
   const bool ret =
       tinyobj::LoadObj(&attrib, &shapes, &materials, &err, input_stream,
                        material_reader, do_tinyobj_triangulation);
-  // As of tinyobj v1.0.6, we expect that `ret` will *always* be true. We are
-  // capturing it and asserting it so that if the version advances, and false is
-  // ever returned, CI will inform us so we can update the error messages.
+  /* As of tinyobj v1.0.6, we expect that `ret` will *always* be true. We are
+   capturing it and asserting it so that if the version advances, and false is
+   ever returned, CI will inform us so we can update the error messages.  */
   DRAKE_DEMAND(ret == true);
 
   if (shapes.empty()) {
@@ -59,45 +59,46 @@ MeshData LoadMeshFromObj(std::istream* input_stream,
         filename));
   }
 
-  // The parsed product needs to be further processed. The MeshData assumes
-  // that all vertex quantities (positions, normals, texture coordinates) are
-  // indexed with a common index; a face that references vertex i, will get its
-  // position from positions[i], its normal from normals[i], and its texture
-  // coordinate from uvs[i]. However, we _cannot_ assume that each vertex
-  // position is associated with a single per-vertex quantity (normal, uv) in
-  // the OBJ file. OBJ allows a vertex position to be associated with arbitrary
-  // per-vertex quantities in each face definition independently. So, we need to
-  // create the unique association here.
-  //
-  // To accomplish this:
-  //  1. Every vertex referenced by a face in the parsed OBJ is a "meta"
-  //     vertex consisting of a pair of indices: (p, n), the index in vertex
-  //     positions and normals. For example, imagine one face refers to meta
-  //     index (p, n₀) and another face refers to index (p, n₁). Although the
-  //     two faces appear to share a single vertex, those vertices have
-  //     different normals which require two different vertices in the mesh
-  //     data. We copy the vertex position and associate one copy with each
-  //     normal.
-  //  2. Given a mapping (p, n) --> i (a mapping from the meta vertex in the
-  //     parsed OBJ data to the unique index in the resultant mesh data), we
-  //     can build the faces in the final mesh data by mapping the (p, n)
-  //     pair in the OBJ face specification to the final mesh data vertex
-  //     index i.
-  //  3. When done, we should have an equal number of vertex positions as
-  //     we have normals. And all indices in the faces should be valid
-  //     indices into both vectors of data.
-  // NOTE: In the case of meta vertices (p, n₀) and (p, n₁) we are not actually
-  // confirming that normals[n₀] and normals[n₁] are actually different normals;
-  // we're assuming different indices implies different values.
-  //
-  // TODO(SeanCurtis-TRI) Extend this to include texture coordinates (and any
-  // other per-vertex quantity we eventually support).
+  /* The parsed product needs to be further processed. The MeshData assumes
+   that all vertex quantities (positions, normals, texture coordinates) are
+   indexed with a common index; a face that references vertex i, will get its
+   position from positions[i], its normal from normals[i], and its texture
+   coordinate from uvs[i]. However, we _cannot_ assume that each vertex
+   position is associated with a single per-vertex quantity (normal, uv) in
+   the OBJ file. OBJ allows a vertex position to be associated with arbitrary
+   per-vertex quantities in each face definition independently. So, we need to
+   create the unique association here.
 
-  // The map from (p, n) --> i.
-  map<pair<int, int>, int> obj_vertex_to_new_vertex;
-  // Accumulators for vertex positions, normals, and triangles.
+   To accomplish this:
+    1. Every vertex referenced by a face in the parsed OBJ is a "meta"
+       vertex consisting of a tuple of indices: (p, n, uv), the index in
+       vertex positions, normals, and texture coordinates. For example,
+       imagine one face refers to meta index (p, n₀, uv) and another face
+       refers to index (p, n₁, uv). Although the two faces appear to share a
+       single vertex (and a common texture coordinate), those vertices have
+       different normals which require two different vertices in the mesh
+       data. We copy the vertex position and texture coordinate and then
+       associate one copy with each normal. A similar operation would apply if
+       they only differed in texture coordinate (or in both).
+    2. Given a mapping (p, n, uv) --> i (a mapping from the meta vertex in the
+       parsed OBJ data to the unique index in the resultant mesh data), we
+       can build the faces in the final mesh data by mapping the (p, n, uv)
+       tuple in the OBJ face specification to the final mesh data vertex
+       index i.
+    3. When done, we should have an equal number of vertex positions as
+       normals and texture coordinates. And all indices in the faces should be
+       valid indices into all three vectors of data.
+   NOTE: In the case of meta vertices (p, n₀, uv) and (p, n₁, uv) we are not
+   confirming that normals[n₀] and normals[n₁] are actually different normals;
+   we're assuming different indices implies different values. Again, the same
+   applies to different texture coordinate indices.  */
+
+  /* The map from (p, n, uv) --> i.  */
+  map<tuple<int, int, int>, int> obj_vertex_to_new_vertex;
+  /* Accumulators for vertex positions, normals, and triangles.  */
   vector<Vector3d> positions;
   vector<Vector3d> normals;
+  vector<Vector2d> uvs;
   vector<Vector3<int>> triangles;
 
   // TODO(SeanCurtis-TRI) Revisit how we handle normals:
@@ -109,32 +110,49 @@ MeshData LoadMeshFromObj(std::istream* input_stream,
         filename));
   }
 
+  // TODO(SeanCurtis-TRI) Loosen this restriction; allow missing texture
+  //  coordinates as long as no texture is applied.
+  if (attrib.texcoords.size() == 0) {
+    throw std::runtime_error(fmt::format(
+        "OBJ has no texture coordinates; RenderEngineGl requires OBJs with "
+        "texture coordinates: {}",
+        filename));
+  }
+
   for (const auto& shape : shapes) {
-    // The faces are encoded in a series of index values [i0, i1, ..., iN]
-    // Each face is a block (e.g., [(i0, i1, i2), (i2, i3, i4), ... ]). We
-    // know that the block size must be three. So, we'll march through the
-    // faces and maintain an index into the vector of indices so we can always
-    // pull out the next index.
+    /* Each face is a sequence of indices. All of the face indices are
+     concatenated together in one long sequence: [i1, i2, ..., iN]. Because
+     we have nothing but triangles, that sequence can be partitioned into
+     triples, each representing one triangle:
+       [(i1, i2, i3), (i4, i5, i6), ..., (iN-2, iN-1, iN)].
+     We maintain an index into that long sequence (v_index) and simply
+     increment it knowing that every three increments takes us to a new face. */
     int v_index = 0;
     const auto& shape_mesh = shape.mesh;
     const int num_faces = static_cast<int>(shape_mesh.num_face_vertices.size());
     for (int f = 0; f < num_faces; ++f) {
       DRAKE_DEMAND(shape_mesh.num_face_vertices[f] == 3);
-      // Captures the [i0, i1, i2] new index values for the face.
+      /* Captures the [i0, i1, i2] new index values for the face.  */
       int face_vertices[3] = {-1, -1, -1};
       for (int i = 0; i < 3; ++i) {
         const int position_index = shape_mesh.indices[v_index].vertex_index;
         const int norm_index = shape_mesh.indices[v_index].normal_index;
+        const int uv_index = shape_mesh.indices[v_index].texcoord_index;
         if (norm_index < 0) {
           throw std::runtime_error(
               fmt::format("Not all faces reference normals: {}", filename));
         }
-        const auto obj_indices = make_pair(position_index, norm_index);
+        if (uv_index < 0) {
+          throw std::runtime_error(fmt::format(
+              "Not all faces reference texture coordinates: {}", filename));
+        }
+        const auto obj_indices =
+            make_tuple(position_index, norm_index, uv_index);
         if (obj_vertex_to_new_vertex.count(obj_indices) == 0) {
           obj_vertex_to_new_vertex[obj_indices] =
               static_cast<int>(positions.size());
-          // Guarantee that the positions.size() == normals.size() by always
-          // growing them in lock step.
+          /* Guarantee that the positions.size() == normals.size() == uvs.size()
+           by always growing them in lock step.  */
           positions.emplace_back(
               Vector3d{attrib.vertices[3 * position_index],
                        attrib.vertices[3 * position_index + 1],
@@ -142,6 +160,8 @@ MeshData LoadMeshFromObj(std::istream* input_stream,
           normals.emplace_back(attrib.normals[3 * norm_index],
                                attrib.normals[3 * norm_index + 1],
                                attrib.normals[3 * norm_index + 2]);
+          uvs.emplace_back(attrib.texcoords[2 * uv_index],
+                           attrib.texcoords[2 * uv_index + 1]);
         }
         face_vertices[i] = obj_vertex_to_new_vertex[obj_indices];
         ++v_index;
@@ -149,6 +169,9 @@ MeshData LoadMeshFromObj(std::istream* input_stream,
       triangles.emplace_back(&face_vertices[0]);
     }
   }
+
+  DRAKE_DEMAND(positions.size() == normals.size());
+  DRAKE_DEMAND(positions.size() == uvs.size());
 
   MeshData mesh_data;
   mesh_data.indices.resize(triangles.size(), 3);
@@ -162,6 +185,10 @@ MeshData LoadMeshFromObj(std::istream* input_stream,
   mesh_data.normals.resize(normals.size(), 3);
   for (int n = 0; n < mesh_data.normals.rows(); ++n) {
     mesh_data.normals.row(n) = normals[n].cast<GLfloat>();
+  }
+  mesh_data.uvs.resize(uvs.size(), 2);
+  for (int uv = 0; uv < mesh_data.uvs.rows(); ++uv) {
+    mesh_data.uvs.row(uv) = uvs[uv].cast<GLfloat>();
   }
 
   return mesh_data;
@@ -181,26 +208,35 @@ namespace {
  that is revolved around the z-axis. The revolute surface is discrete, so the
  curve is evaluted at fixed angular samples (determined by the
  `rotate_sample_count`). The curve is defined implicitly and is sampled along
- its length a fixed number of times (determined by the `curve_samle_count`).
+ its length a fixed number of times (determined by the `curve_sample_count`).
 
- This assumes that the two end points of the curve *lie* on the Cz axes. So, the
+ This assumes that the two end points of the curve *lie on* the Cz axes. So, the
  top and bottom of the revolute mesh are single vertices (with a triangle fan
  radiating outward).
 
  Another way to consider this is that we're lofting circles to symmetrically fit
  the curve path (i.e., every circle's center lies on the z axis). The total
  number of circles is `curve_sample_count` with the expectation that the first
- and last circles have radius zero. They are enumerated c_1, c_2, c_N, where
- `N = curve_sample_count`. For a given circle index, we need to know the
- circle's radius and its position on the z-axis.
+ and last circles have radius zero. They are enumerated c_0, c_2, ..., c_C,
+ where `C = curve_sample_count - 1`. For a given circle index, we need to know
+ the circle's radius and its position on the z-axis.
 
- @param rotate_sample_count  The total number of radial samples in the
-                             revolution.
+ To accommodate texture coordinates, each circle has overlapping vertices at
+ the beginning/end. In other words, if `R = rotate_sample_count` each circle
+ will have R + 1 vertices where the first and last vertices are coincident.
+ This will allow for the first vertex to have the texture coordinate (0, v) and
+ the last to have texture coordinate (1, v).
+
+ @param rotate_sample_count  The total number of radial samples in each circle.
  @param curve_sample_count   The total number of circles lofting.
  @param calc_radius_i        A function that reports the radius of the ith
-                             circle.
+                             circle. The first and last circles (with zero
+                             radius) should have indices 0 and
+                             `curve_sample_count - 1`, respectively.
  @param calc_z_i             A function that reports the position of the ith
-                             circle center along the z axis.
+                             circle center along the z axis. Circle indices for
+                             this function should have the same semantics as for
+                             `calc_radius_i`.
  @pre `calc_radius_i(0)` and `calc_radius_i(curve_sample_count - 1) = 0`.
  */
 MeshData MakeRevoluteShape(int rotate_sample_count, int curve_sample_count,
@@ -209,11 +245,12 @@ MeshData MakeRevoluteShape(int rotate_sample_count, int curve_sample_count,
   const GLfloat delta_theta =
       static_cast<GLfloat>(2 * M_PI / rotate_sample_count);
 
-  /* We have R revolute samples and C curve samples.
+  /* We have R rotation samples and C curve samples.
 
    Vertex count:
    The first and last curve samples are single vertices. Every other curve
-   sample forms a ring with R vertices. So, total vertices = (C - 2) * R + 2.
+   sample forms a ring with R + 1 vertices. So,
+   total vertices = (C - 2) * (R + 1) + 2.
 
    Triangle count:
    We create triangles by spanning between rings. Because rings 0 and C-1 are
@@ -225,7 +262,8 @@ MeshData MakeRevoluteShape(int rotate_sample_count, int curve_sample_count,
      = 2R + (C - 3) * 2R
      = 2R(1 + (C - 3))
      = 2R(C - 2). */
-  const int vert_count = (curve_sample_count - 2) * rotate_sample_count + 2;
+  const int vert_count =
+      (curve_sample_count - 2) * (rotate_sample_count + 1) + 2;
   const int tri_count = (curve_sample_count - 2) * 2 * rotate_sample_count;
 
   MeshData mesh_data;
@@ -234,96 +272,94 @@ MeshData MakeRevoluteShape(int rotate_sample_count, int curve_sample_count,
   auto& indices = mesh_data.indices;
   indices.resize(tri_count, 3);
 
-  // Insertion points into vertices and indices for each new vertex and tri.
+  /* Insertion points into vertices and indices for each new vertex and tri.  */
   int v_index = 0;
   int t_index = 0;
+  /* The index of the ring we're operating on; this the ring for which vertices
+   are being generated and added. */
+  int ring_i = 0;
 
-  // Ring 0 is a single point; add that "ring".
-  vertices.row(v_index) << 0, 0, calc_z_i(0);
+  /* Ring 0 is a single point; add that "ring". */
+  vertices.row(v_index) << 0, 0, calc_z_i(ring_i);
   ++v_index;
 
-  // Index of the ring whose vertices are being added, the ring's position on
-  // the z axis, and its radius.
-  int ring_i = 1;
+  /* Computes the vertex position for the index `v` of the vertex in the ring,
+   v ∈ [0, R] (inclusive), with the given z-value and ring radius r.  */
+  auto make_vertex = [delta_theta](int v, GLfloat v_z, GLfloat r)  {
+    const GLfloat theta = v * delta_theta;
+    const GLfloat v_x = r * ::cosf(theta);
+    const GLfloat v_y = r * ::sinf(theta);
+    return Vector3<GLfloat>{v_x, v_y, v_z};
+  };
+
+  /* Now start with the rings that have non-zero radius.  */
+  ++ring_i;
   GLfloat z_i = calc_z_i(ring_i);
   GLfloat r_i = calc_radius_i(ring_i);
 
-  // Triangles spanning ring 0 to ring 1 is simply a triangle fan around vertex
-  // 0.
-  /* Each iteration of the for loop adds vertex v_j = [0, R-1] in the *current*
-   ring. Its global index in vertices is tracked by v_index. p is the global
-   index of the vertex that topologically precedes v in its ring. For example,
-   in a given for loop, v_index would take the values of the ring's vertices
-   in sequence: e.g., [11, 12, 13, 14, ... 20]. p would then iterate through
-   the values [20, 11, 12, ..., 19]. While p "precedes" v_j in some sense,
-   p < v_index is not always true; the vertex that "precedes" the first vertex
-   in the ring is the last vertex in the ring added to vertices. This same
-   pattern gets repeated as we iterate through ring (see below). */
-  int p = v_index + rotate_sample_count - 1;
-  for (int v_j = 0; v_j < rotate_sample_count; ++v_j) {
-    const GLfloat theta = v_j * delta_theta;
-    const GLfloat v_x = r_i * ::cosf(theta);
-    const GLfloat v_y = r_i * ::sinf(theta);
-    vertices.row(v_index) << v_x, v_y, z_i;
-    indices.row(t_index++) << 0, p, v_index;
-    p = v_index++;
+  /* Triangles spanning ring 0 to ring 1 are simply a triangle fan around vertex
+   0.  */
+  /* We add R + 1 vertices, but R triangles. To do that, we add the first R
+   vertices and build triangles referencing the about-to-be-added *next* vertex.
+   Finally, we copy the first vertex in the set so we know they are *perfectly*
+   coincident. We use this same strategy in populating all the interior rings
+   and bands and again at the triangle fan spanning the last two rings.  */
+  for (int v_j = 0; v_j < rotate_sample_count; ++v_j, ++v_index) {
+    vertices.row(v_index) = make_vertex(v_j, z_i, r_i);
+    indices.row(t_index++) << 0, v_index, v_index + 1;
   }
+  vertices.row(v_index) << vertices.row(v_index - rotate_sample_count);
+  ++v_index;
 
-  // All of the rings from the curve samples with non-zero radius (i.e., rings
-  // [1, N-1]).
-  /*
-     We add all the vertices for ring_i and build triangles between ring_i and
-     ring_i-1. The triangles are formed with the following vertices:
+  /* All of the remaining rings from the curve samples with non-zero radius
+   (i.e., rings 2 to N-1, inclusive).  */
+  /* We add all the vertices for ring_i and build triangles between ring_i and
+   ring_i-1. The triangles are formed with the following vertices:
 
-         │ c    │ b
+         │ b    │ c
      ────•──────•────                      <-- ring i-1
          │ ╲    │
          │   ╲  │
-         │ p   ╲│ v
+         │ v   ╲│ v+1
      ────•──────•────                      <-- ring i
          │      │
 
-     The vertices are labeled by their *global* _indices_ v, p, b, and c.
-      v: the jth vertex for ring i -- added in this iteration of the for loop.
-      p: the topologically previous vertex to v in the same ring (with periodic
-         conditions).
-      b = v - R
-      c = p - R
+   The vertices are labeled by their *global indices* v, v+1, b, and c.
+      v:   the jth vertex for ring i -- added in this iteration of the for loop.
+      v+1: the subsequent vertex to v in the same ring
+      b = v - (R + 1) = v - R - 1 = c - 1
+      c = v + 1 - (R + 1) = v - R
     */
   for (ring_i = 2; ring_i < curve_sample_count - 1; ++ring_i) {
     z_i = calc_z_i(ring_i);
     r_i = calc_radius_i(ring_i);
 
-    p = v_index + rotate_sample_count - 1;
-    for (int v_j = 0; v_j < rotate_sample_count; ++v_j) {
-      const GLfloat theta = v_j * delta_theta;
-      const GLfloat v_x = r_i * ::cosf(theta);
-      const GLfloat v_y = r_i * ::sinf(theta);
-      vertices.row(v_index) << v_x, v_y, z_i;
-      const int b = v_index - rotate_sample_count;
-      const int c = p - rotate_sample_count;
-      indices.row(t_index++) << v_index, c, p;
-      indices.row(t_index++) << v_index, b, c;
-      p = v_index++;
+    for (int v_j = 0; v_j < rotate_sample_count; ++v_j, ++v_index) {
+      vertices.row(v_index) = make_vertex(v_j, z_i, r_i);
+      const int c = v_index - rotate_sample_count;
+      const int b = c - 1;
+      indices.row(t_index++) << v_index, v_index + 1, b;
+      indices.row(t_index++) << v_index + 1, c, b;
     }
+    vertices.row(v_index) << vertices.row(v_index - rotate_sample_count);
+    ++v_index;
   }
 
-  // Triangles spanning ring C-2 to ring C-1; a triangle fan around the last
-  // vertex.
+  /* Triangles spanning ring C-2 to ring C-1; a triangle fan around the last
+   vertex. We're only missing the last vertex, all other vertices exist.  */
   vertices.row(v_index) << 0.f, 0.f, calc_z_i(ring_i);
-  const int prev_ring_start = v_index - rotate_sample_count;
-  // Post-increment v_index so its value represents the total number of
-  // vertices added.
+  const int prev_ring_start = v_index - rotate_sample_count - 1;
+  /* Post-increment v_index so its value represents the total number of
+   vertices added.  */
   const int ring_C_vertex = v_index++;
-  p = ring_C_vertex - 1;
-  // We have all the vertices, we just need to create the spanning triangles.
+  /* We *now* have all the vertices, we just need to create the spanning
+   triangles. */
   for (int v_j = 0; v_j < rotate_sample_count; ++v_j) {
     const int v = prev_ring_start + v_j;
-    indices.row(t_index++) << v, p, ring_C_vertex;
-    p = v;
+    indices.row(t_index++) << v, ring_C_vertex, v + 1;
   }
 
-  // The process of building should match our predicted counts.
+  /* The process of building should match our predicted counts.  */
   DRAKE_DEMAND(v_index == vert_count);
   DRAKE_DEMAND(t_index == tri_count);
 
@@ -353,7 +389,9 @@ MeshData MakeLongLatUnitSphere(int longitude_bands, int latitude_bands) {
   Vertex count:
   For T latitude bands, there are T + 1 "rings" of vertices. Two rings have
   radius 0 and a single vertex (the north and south pole). The other rings
-  all have G vertices. Total number of vertices = (T - 1) * G + 2.
+  all have G + 1 vertices (due to the fact that MakeRevoluteShape() introduces
+  a "seam" on each ring to allow for texture coordinates).
+  Total number of vertices = (T - 1) * (G + 1) + 2.
 
   Triangle count:
   Every medial latitudinal band produces G quads or 2G triangles. There are
@@ -367,7 +405,7 @@ MeshData MakeLongLatUnitSphere(int longitude_bands, int latitude_bands) {
   uniformly spaced along the Cz axis (this would lead to ill-aspected
   triangles). Instead, we define z_i (the height of the ith ring center) so that
   the _longitudinal_ circle is uniformly sampled. Every interior latitude ring
-  t_i has radius r_i = sqrt(R² - z_i * z_i), R = 1 for the unit sphere.
+  t_i has radius r_i = sqrt(R² - z_i²), R = 1 for the unit sphere.
 
   The algorithm starts at the north pole and works to the south pole, tracking
   which longitude ring we're on. For 0 < t_i < T, we also generate the triangles
@@ -377,17 +415,17 @@ MeshData MakeLongLatUnitSphere(int longitude_bands, int latitude_bands) {
   rotation samples. The "curve" we're revolving is a half circle. We are
   sampling it from pole to pole forming `latitude_bands` number of bands; which
   means, from the revolute surface function's perspective, we are sampling the
-  half circle `latitute_bands + 1` times.
+  half circle `latitude_bands + 1` times.
   */
-  // Minimum values that create a sphere approximation with volume.
+  /* Minimum values that create a sphere approximation with volume.  */
   DRAKE_DEMAND(longitude_bands >= 3);
   DRAKE_DEMAND(latitude_bands >= 2);
 
-  const int vert_count = (latitude_bands - 1) * longitude_bands + 2;
+  const int vert_count = (latitude_bands - 1) * (longitude_bands + 1) + 2;
   const int tri_count = (2 * latitude_bands - 2) * longitude_bands;
 
-  // Angle separating latitudinal rings measured in the longitudinal direction
-  // (defines the height of rings).
+  /* Angle separating latitudinal rings measured in the longitudinal direction
+   (defines the height of rings).  */
   const GLfloat delta_phi = static_cast<GLfloat>(M_PI / latitude_bands);
   auto calc_z_i = [delta_phi, latitude_bands](int ring_i) {
     DRAKE_DEMAND(ring_i >= 0 && ring_i <= latitude_bands);
@@ -402,16 +440,40 @@ MeshData MakeLongLatUnitSphere(int longitude_bands, int latitude_bands) {
   MeshData mesh_data = MakeRevoluteShape(longitude_bands, latitude_bands + 1,
                                          calc_radius_i, calc_z_i);
 
-  // The process of building should match our predicted counts.
+  /* The process of building should match our predicted counts.  */
   DRAKE_DEMAND(mesh_data.positions.rows() == vert_count);
   DRAKE_DEMAND(mesh_data.indices.rows() == tri_count);
 
-  // We can add the normals in a post-hoc manner.
-  mesh_data.normals.resize(mesh_data.positions.rows(), 3);
-  for (int v = 0; v < mesh_data.positions.rows(); ++v) {
+  /* We can add the normals in a post-hoc manner; every vertex normal is simply
+   the normalized position vector (given this is the unit sphere, the two
+   quantities should be the same).  */
+  mesh_data.normals.resize(vert_count, 3);
+  for (int v = 0; v < vert_count; ++v) {
     const auto p_MV = mesh_data.positions.row(v);
     mesh_data.normals.row(v) = p_MV.normalized();
   }
+
+  /* Post hoc addition of texture coordinates. Note: the values at the north
+   and south poles, (<0, 1> and <0, 0>, respectively) will lead to visual
+   artifacts. There is no known good solution for polar texture coordinates
+   without those artifacts.  */
+  mesh_data.uvs.resize(vert_count, 2);
+  /* North pole.  */
+  mesh_data.uvs.row(0) << 0, 1;
+  /* All lines of latitude.  */
+  int v_index = 1;
+  const double delta_u = 1.0 / longitude_bands;
+  const double delta_v = 1.0 / latitude_bands;
+  for (int ring = 1; ring < latitude_bands; ++ring) {
+    const double v = 1.0 - ring * delta_v;
+    for (int vertex = 0; vertex <= longitude_bands; ++vertex, ++v_index) {
+      const double u = vertex * delta_u;
+      mesh_data.uvs.row(v_index) << u, v;
+    }
+  }
+  /* South pole.  */
+  mesh_data.uvs.row(v_index) << 0, 0;
+  DRAKE_DEMAND(++v_index == vert_count);
 
   return mesh_data;
 }
@@ -447,13 +509,14 @@ MeshData MakeUnitCylinder(int num_strips, int num_bands) {
    We create the cylinder by creating a single revolute surface and then
    subsequently breaking it apart to introduce normal discontinuities. In the
    revolute, connected cylinder mesh, there are B + 1 rings of vertices
-   plus two more vertices in the centers of the caps. Each ring has S vertices
-   for a total vertex count of:
-      (B + 1) * S + 2.
+   plus two more vertices in the centers of the caps. Each ring has S + 1
+   vertices (due to the fact that MakeRevoluteShape() introduces a "seam" on
+   each ring to allow for texture coordinates), for a total vertex count of:
+      (B + 1) * (S + 1) + 2.
 
    The final mesh duplicates Ring 1 and Ring B + 2 (see the notes below on
    creating normals). This leads to a final vertex count of:
-      (B + 1) * S + 2 + S * 2 = (B + 3) * S + 2.
+      (B + 1) * (S + 1) + 2 + (S + 1) * 2 = (B + 3) * (S + 1) + 2.
 
    Triange count
    Each band on the barrel creates 2S triangles. Each cap produces S triangles
@@ -488,25 +551,25 @@ MeshData MakeUnitCylinder(int num_strips, int num_bands) {
   DRAKE_DEMAND(num_strips >= 3);
   DRAKE_DEMAND(num_bands >= 1);
 
-  const int rev_vert_count = (num_bands + 1) * num_strips + 2;
+  const int rev_vert_count = (num_bands + 1) * (num_strips + 1) + 2;
   const int tri_count = 2 * (num_bands + 1) * num_strips;
 
-  // The height of each band along the length of the barrel.
+  /* The height of each band along the length of the barrel.  */
   const GLfloat band_height = 1.f / num_bands;
 
-  // As illustrated above, circle 0 & 1 have a z-value of 0.5, circles
-  // C-2 and C-1 are at -0.5, and all other circles are distributed between.
-  // Because C = B + 3, C-2 = B + 1 and C-1 = B + 2.
+  /* As illustrated above, circle 0 & 1 have a z-value of 0.5, circles
+   C-2 and C-1 are at -0.5, and all other circles are distributed between.
+   Because C = B + 3, C-2 = B + 1 and C-1 = B + 2.  */
   auto calc_z_i = [band_height, num_bands](int ring_i) {
     DRAKE_DEMAND(ring_i >= 0 && ring_i <= num_bands + 2);
     if (ring_i < 2) return 0.5f;
     if (ring_i > num_bands) return -0.5f;
-    // Circles 2, 3, ... C - 3 should have a displacement of 1, 2, ..., C-4
-    // band_height below the top cap.
+    /* Circles 2, 3, ... C - 3 should have a displacement of 1, 2, ..., C-4
+     band_height below the top cap.  */
     return 0.5f - (ring_i - 1) * band_height;
   };
   auto calc_radius_i = [num_bands](int ring_i) {
-    // Circles 0 and C-1 are zero-radius circles. C-1 = (B + 3) -1 = B + 2.
+    /* Circles 0 and C-1 are zero-radius circles. C-1 = (B + 3) -1 = B + 2.  */
     DRAKE_DEMAND(ring_i >= 0 && ring_i <= num_bands + 2);
     if (ring_i == 0 || ring_i == num_bands + 2) return 0.f;
     return 1.f;
@@ -514,39 +577,41 @@ MeshData MakeUnitCylinder(int num_strips, int num_bands) {
   MeshData mesh_data =
       MakeRevoluteShape(num_strips, num_bands + 3, calc_radius_i, calc_z_i);
 
-  // The process of building should match our predicted counts.
+  /* The process of building should match our predicted counts.  */
   DRAKE_DEMAND(mesh_data.positions.rows() == rev_vert_count);
   DRAKE_DEMAND(mesh_data.indices.rows() == tri_count);
 
-  /* To have a hard-edge on the cylinder cap, we need to have 2 * num_strips
-   more vertices; the vertices on the top and bottom rings (those that run
-   along the perimeter of the caps) need to be duplicated. The vertices returned
-   by MakeRevoluteShape are as follows:
+  /* To have a hard-edge on the cylinder cap, we need to have
+   2 * (num_strips + 1) more vertices; the vertices on the top and bottom rings
+   (those that run along the perimeter of the caps) need to be duplicated. The
+   vertices returned by MakeRevoluteShape are as follows:
 
     |__|___|___|...|___|___|___|...|___|___|...|___|__|
-     c₀ r₁₁ r₁₂ ... r₁ₙ r₂₁ r₂₂ ... rₘ₁ rₘ₂ ... rₘₙ c₁
+     c₀ r₁₀ r₁₁ ... r₁ₙ r₂₀ r₂₁ ... rₘ₀ rₘ₁ ... rₘₙ c₁
 
    The first and last vertices (c₀ and c₁) are the centers of the top and
-   bottom caps. There are M = num_bands + 1 blocks of N = num_strips vertices
-   representing a single "ring" of vertices. Each vertex is denoted as rⱼᵢ for
-   the iᵗʰ vertex in ring j. The first and last rings (r₁ and rₘ₋₁) will
+   bottom caps. There are M = num_bands + 1 blocks of N + 1 = num_strips + 1
+   vertices representing a single "ring" of vertices. Each vertex is denoted as
+   rⱼᵢ for the iᵗʰ vertex in ring j. The first and last rings (r₁ and rₘ₋₁) will
    be duplicated. The first ring will be duplicated immediately after c₀ and
    the last ring directly before c₁. All triangle indices will be modified
    to reflect the shift.  */
 
   const int old_v_count = mesh_data.positions.rows();
-  DRAKE_DEMAND(old_v_count > 0);
-  const int new_v_count = old_v_count + 2 * num_strips;
+  const int new_v_count = old_v_count + 2 * (num_strips + 1);
   MeshData full_mesh_data;
   full_mesh_data.positions.resize(new_v_count, 3);
   full_mesh_data.normals.resize(new_v_count, 3);
+  full_mesh_data.uvs.resize(new_v_count, 2);
   const int t_count = mesh_data.indices.rows();
   full_mesh_data.indices.resize(t_count, 3);
 
-  const int cap_v_count = num_strips + 1;
+  /* The first and last k = S + 2 vertices are referenced by cap triangles.  */
+  const int cap_v_count = num_strips + 2;
+  /* Total number of vertices referenced by barrel triangles.  */
   const int barrel_v_count = old_v_count - 2;
-  // Copy vertex positions; the first N + 1 vertices are the bottom cap and the
-  // last N + 1 are the top cap.
+  /* Copy vertex positions; the first N + 1 vertices are the bottom cap and the
+   last N + 1 are the top cap.  */
   full_mesh_data.positions.block(0, 0, cap_v_count, 3) =
       mesh_data.positions.block(0, 0, cap_v_count, 3);
   full_mesh_data.positions.block(cap_v_count, 0, barrel_v_count, 3) =
@@ -554,28 +619,28 @@ MeshData MakeUnitCylinder(int num_strips, int num_bands) {
   full_mesh_data.positions.block(new_v_count - cap_v_count, 0, cap_v_count, 3) =
       mesh_data.positions.block(old_v_count - cap_v_count, 0, cap_v_count, 3);
 
-  // Write all the normal data.
-  // Top cap.
+  /* Write all the normal data.  */
+  /* Top cap.  */
   int v = 0;
   for (; v < cap_v_count; ++v) {
     full_mesh_data.normals.row(v) << 0, 0, 1;
   }
-  // All barrel vertices.
+  /* All barrel vertices.  */
   for (; v < barrel_v_count + cap_v_count; ++v) {
     const auto p_MV = full_mesh_data.positions.row(v);
     const Vector2d p_MV_xy(p_MV(0, 0), p_MV(0, 1));
     const Vector2d n_MV_xy = p_MV_xy.normalized();
     full_mesh_data.normals.row(v) << n_MV_xy(0), n_MV_xy(1), 0;
   }
-  // Bottom cap.
+  /* Bottom cap.  */
   for (; v < new_v_count; ++v) {
     full_mesh_data.normals.row(v) << 0, 0, -1;
   }
 
-  // Transform indices in the triangles.
-  // Top cap remains unchanged; so we'll skip the first num_strips triangles.
+  /* Transform indices in the triangles. */
+  /* Top cap remains unchanged; so we'll skip the first num_strips triangles. */
   full_mesh_data.indices = mesh_data.indices;
-  const auto offset = Vector3<GLuint>::Constant(num_strips).transpose();
+  const auto offset = Vector3<GLuint>::Constant(num_strips + 1).transpose();
   int t = num_strips;
   for (; t < t_count - num_strips; ++t) {
     full_mesh_data.indices.row(t) += offset;
@@ -583,6 +648,63 @@ MeshData MakeUnitCylinder(int num_strips, int num_bands) {
   for (; t < t_count; ++t) {
     full_mesh_data.indices.row(t) += 2 * offset;
   }
+
+  /* TODO(SeanCurtis-TRI) Consider treating cylinders like capsules; rather
+    than scaling a single unit cylinder (which will lead to funny texture
+    artifacts), consider creating unique cylinders so their texture coordinates
+    stretch over non-unit cylinders well.  */
+
+  /* Texture coordinates. The u-direction goes from zero to 1, radially, joining
+   at the seam created by the revolute mesh. The v-direction, like the sphere,
+   spans from the north pole (1) to the south pole (0) and is scaled according
+   to the geodesic distance. The radius and heights of this cylinder are both
+   1. So, the top 1/3 of the cylinder's texture will *always* apply to the
+   top face, the next third to the barrel, and the last third to the bottom
+   face. Even if the cylinder is scaled to arbitrary radius/length this
+   mapping will still be true.  */
+  const int ring_size = num_strips + 1;
+  const GLfloat arc_length = 3;  /* Two radii + length.  */
+  int uv_index = 0;
+  /* North pole.  */
+  full_mesh_data.uvs.row(uv_index) << 0, 1;
+  ++uv_index;
+  /* Now handle the rings of vertices. Each ring has a constant v-coordinate
+   and a set of u-values that span [0, 1]. So, we'll create the u- and
+   v-values that we'll write into the data as blocks.  */
+  VectorX<GLfloat> u_values(ring_size);
+  u_values.setLinSpaced(0.f, 1.f);
+  VectorX<GLfloat> v_values(ring_size);
+  v_values.setConstant(2.f / arc_length);
+
+  /* First two rings are duplicates with matching uv coordinates.  */
+  full_mesh_data.uvs.block(uv_index, 0, ring_size, 1) = u_values;
+  full_mesh_data.uvs.block(uv_index, 1, ring_size, 1) = v_values;
+  uv_index += ring_size;
+  full_mesh_data.uvs.block(uv_index, 0, ring_size, 1) = u_values;
+  full_mesh_data.uvs.block(uv_index, 1, ring_size, 1) = v_values;
+  uv_index += ring_size;
+
+  /* For B bands, there are B - 1 rings located *strictly* on the barrel.  */
+  const GLfloat v_delta = 1 / arc_length / num_bands;
+  for (int barrel_ring = 0; barrel_ring < num_bands - 1; ++barrel_ring) {
+    v_values.setConstant(v_values(0) - v_delta);
+    full_mesh_data.uvs.block(uv_index, 0, ring_size, 1) = u_values;
+    full_mesh_data.uvs.block(uv_index, 1, ring_size, 1) = v_values;
+    uv_index += ring_size;
+  }
+
+  /* Last two rings are duplicates with matching uv coordinates.  */
+  v_values.setConstant(1.f / arc_length);
+  full_mesh_data.uvs.block(uv_index, 0, ring_size, 1) = u_values;
+  full_mesh_data.uvs.block(uv_index, 1, ring_size, 1) = v_values;
+  uv_index += ring_size;
+  full_mesh_data.uvs.block(uv_index, 0, ring_size, 1) = u_values;
+  full_mesh_data.uvs.block(uv_index, 1, ring_size, 1) = v_values;
+  uv_index += ring_size;
+
+  /* South pole.  */
+  full_mesh_data.uvs.row(uv_index) << 0, 0;
+  DRAKE_DEMAND(++uv_index == new_v_count);
 
   return full_mesh_data;
 }
@@ -597,10 +719,13 @@ MeshData MakeSquarePatch(GLfloat measure, int resolution) {
   MeshData mesh_data;
   mesh_data.positions.resize(vert_count, 3);
   mesh_data.normals.resize(vert_count, 3);
+  mesh_data.uvs.resize(vert_count, 2);
   mesh_data.indices.resize(tri_count, 3);
 
-  // The size of each square sub-patch.
-  const GLfloat delta = measure / resolution;
+  /* The size of each square sub-patch.  */
+  const GLfloat delta_pos = measure / resolution;
+  /* The size of each square sub-patch in *texture coordinates*.  */
+  const GLfloat delta_uv = 1.f / resolution;
 
   /* Build the following grid. Where N = resolution.
 
@@ -626,17 +751,20 @@ MeshData MakeSquarePatch(GLfloat measure, int resolution) {
                      (x0, y0)         ↓
   */
 
-  // First add the vertices.
+  /* First add the vertices.  */
   int v_index = 0;
 
   GLfloat x0 = -measure / 2;
   GLfloat y0 = -measure / 2;
   for (int i = 0; i <= resolution; ++i) {
-    const GLfloat y = y0 + i * delta;
+    const GLfloat y = y0 + i * delta_pos;
+    const GLfloat v = i * delta_uv;
     for (int j = 0; j <= resolution; ++j) {
       mesh_data.normals.row(v_index) << 0, 0, 1;
-      const GLfloat x = x0 + j * delta;
-      mesh_data.positions.row(v_index++) << x, y, 0;
+      const GLfloat x = x0 + j * delta_pos;
+      mesh_data.positions.row(v_index) << x, y, 0;
+      const GLfloat u = j * delta_uv;
+      mesh_data.uvs.row(v_index++) << u, v;
     }
   }
 
@@ -689,29 +817,30 @@ MeshData MakeUnitBox() {
   MeshData mesh_data;
   mesh_data.positions.resize(24, 3);
   mesh_data.normals.resize(24, 3);
+  mesh_data.uvs.resize(24, 2);
   mesh_data.indices.resize(12, 3);
   /* clang-format off */
-  mesh_data.positions << -0.5f, -0.5f, -0.5f,  // -y face: a b c d.
+  mesh_data.positions << -0.5f, -0.5f, -0.5f,  /* -y face: a b c d.  */
                           0.5f, -0.5f, -0.5f,
                           0.5f, -0.5f,  0.5f,
                          -0.5f, -0.5f,  0.5f,
-                          0.5f, -0.5f, -0.5f,  // +x face: b f g c.
+                          0.5f, -0.5f, -0.5f,  /* +x face: b f g c.  */
                           0.5f,  0.5f, -0.5f,
                           0.5f,  0.5f,  0.5f,
                           0.5f, -0.5f,  0.5f,
-                         -0.5f, -0.5f,  0.5f,  // +z face: d c g h
+                         -0.5f, -0.5f,  0.5f,  /* +z face: d c g h  */
                           0.5f, -0.5f,  0.5f,
                           0.5f,  0.5f,  0.5f,
                          -0.5f,  0.5f,  0.5f,
-                         -0.5f, -0.5f, -0.5f,  // -x face: a d h e
+                         -0.5f,  0.5f, -0.5f,  /* -x face: e a d h  */
+                         -0.5f, -0.5f, -0.5f,
                          -0.5f, -0.5f,  0.5f,
                          -0.5f,  0.5f,  0.5f,
-                         -0.5f,  0.5f, -0.5f,
-                         -0.5f, -0.5f, -0.5f,  // -z face: a e f b
-                         -0.5f,  0.5f, -0.5f,
+                         -0.5f,  0.5f, -0.5f,  /* -z face: e f b a  */
                           0.5f,  0.5f, -0.5f,
                           0.5f, -0.5f, -0.5f,
-                          0.5f,  0.5f, -0.5f,  //  +y face: f e h g
+                         -0.5f, -0.5f, -0.5f,
+                          0.5f,  0.5f, -0.5f,  /*  +y face: f e h g  */
                          -0.5f,  0.5f, -0.5f,
                          -0.5f,  0.5f,  0.5f,
                           0.5f,  0.5f,  0.5f;
@@ -740,6 +869,33 @@ MeshData MakeUnitBox() {
                         0,  1,  0,
                         0,  1,  0,
                         0,  1,  0;
+  /* The ordering of the face vertex indices have been defined such that we can
+   specify each face's vertex coordinates with the same clockwise pattern:
+   (0, 0) -> (1, 0) -> (1, 1) -> (0, 1).  */
+  mesh_data.uvs << 0, 0,
+                   1, 0,
+                   1, 1,
+                   0, 1,
+                   0, 0,
+                   1, 0,
+                   1, 1,
+                   0, 1,
+                   0, 0,
+                   1, 0,
+                   1, 1,
+                   0, 1,
+                   0, 0,
+                   1, 0,
+                   1, 1,
+                   0, 1,
+                   0, 0,
+                   1, 0,
+                   1, 1,
+                   0, 1,
+                   0, 0,
+                   1, 0,
+                   1, 1,
+                   0, 1;
 
   mesh_data.indices << 0, 1, 2,
                        0, 2, 3,
@@ -774,81 +930,142 @@ MeshData MakeCapsule(int samples, double radius, double length) {
   const int lat_bands = half_samples + (half_samples % 2);
   const MeshData sphere_data = MakeLongLatUnitSphere(samples, lat_bands);
 
-  /* There should be `2H + samples` vertices in the sphere, where H is the
+  /* The number of vertices in a "ring" is samples + 1 because the revolute
+   surface duplicates the first vertex on each ring to accommodate texture
+   coordinates.  */
+  const int ring_size = samples + 1;
+  /* There should be `2H + ring_size` vertices in the sphere, where H is the
    number of vertices in a hemisphere *excluding* the vertices on the equator.
 
-   The resulting capsule will have `2H + 2 * samples` vertices and normals and
-   `T + 2 * samples` triangles, where T is the number of triangles in the
-   sphere.  */
-  const int H = (sphere_data.positions.rows() - samples) / 2;
-  DRAKE_DEMAND(2 * H + samples == sphere_data.positions.rows());
+   The resulting capsule will have `2H + 2 * ring_size` vertices, normals, and
+   uvs and `T + 2 * samples` triangles, where T is the number of triangles in
+   the sphere.  */
+  const int H = (sphere_data.positions.rows() - ring_size) / 2;
+  DRAKE_DEMAND(2 * H + ring_size == sphere_data.positions.rows());
 
   MeshData data;
-  const int vert_count = 2 * (H + samples);
+  const int vert_count = 2 * (H + ring_size);
   data.positions.resize(vert_count, 3);
   data.normals.resize(vert_count, 3);
+  data.uvs.resize(vert_count, 2);
   const int tri_count = sphere_data.indices.rows() + (2 * samples);
   data.indices.resize(tri_count, 3);
 
   /* Process vertices and normals. Vertices get scaled by radius and offset
-   half the length, normals get copied. */
+   half the length, normals and uvs get copied. (The copied uv values will be
+   modified later to account for the difference between spheres and capsules. */
   int sphere_v = -1;
   int capsule_v = -1;
-  // Northern hemisphere plus the equator.
+  /* Northern hemisphere plus the equator.  */
   const Vector3<GLfloat> offset(0, 0, length / 2);
-  for (int i = 0; i < H + samples; ++i) {
+  for (int i = 0; i < H + ring_size; ++i) {
     const Vector3<GLfloat> p_SV = sphere_data.positions.row(++sphere_v);
     data.positions.row(++capsule_v) = p_SV * radius + offset;
     data.normals.row(capsule_v) = sphere_data.normals.row(sphere_v);
+    data.uvs.row(capsule_v) = sphere_data.uvs.row(sphere_v);
   }
-  sphere_v -= samples;
-  for (int i = 0; i < H + samples; ++i) {
+  /* Back up our *reading* index so that we get a copy of the equator.  */
+  sphere_v -= ring_size;
+  for (int i = 0; i < H + ring_size; ++i) {
     const Vector3<GLfloat> p_SV = sphere_data.positions.row(++sphere_v);
     data.positions.row(++capsule_v) = p_SV * radius - offset;
     data.normals.row(capsule_v) = sphere_data.normals.row(sphere_v);
+    data.uvs.row(capsule_v) = sphere_data.uvs.row(sphere_v);
   }
 
   /* Process the faces. The first half can be taken verbatim. Then we inject
    the barrel vertices (connecting the two equators), the southern hemisphere
-   needs all indices offset by `samples`.  */
+   needs all indices offset by `ring_size`.  */
 
   const int hemisphere_tri_count = sphere_data.indices.rows() / 2;
   data.indices.block(0, 0, hemisphere_tri_count, 3) =
       sphere_data.indices.block(0, 0, hemisphere_tri_count, 3);
   /* We add all the triangles for the barrel spanning the two equators. Given
-   a moving pair of indices lying on the southern equator (p, v) we walk around
-   the equator building triangle pairs as shown:
+   a vertex index lying on the southern equator v, we walk around the equator
+   building triangle pairs as shown:
 
-       │ c    │ b
-   ────•──────•────                      <-- northern equator
-       │ ╲    │
-       │   ╲  │
-       │ p   ╲│ v
-   ────•──────•────                      <-- southern equator
-       │      │
+         │ b    │ c
+     ────•──────•────                      <-- northern equator
+         │ ╲    │
+         │   ╲  │
+         │ v   ╲│ v+1
+     ────•──────•────                      <-- southern equator
+         │      │
 
-   The vertices are labeled by their *global* _indices_ v, p, b, and c.
-   v: the jth vertex for the southern equator.
-   p: the topologically previous vertex to v on the equator (subject to periodic
-      conditions).
-   b = v - samples
-   c = p - samples  */
+     The vertices are labeled by their *global* _indices_ v, v+1, b, and c and
+     R = ring_size.
+
+      v:   the jth vertex for the southern equator.
+      v+1: the subsequent vertex to v.
+      b = v - R
+      c = v + 1 - R
+    */
   int capsule_t = hemisphere_tri_count;
-  int v = H + samples;      // the "first" vertex of the southern equator.
-  int p = v + samples - 1;  // the "last" vertex on the southern equator.
+  int v = H + ring_size;      /* the "first" vertex of the southern equator.  */
   for (int i = 0; i < samples; ++i, ++v, capsule_t += 2) {
-    data.indices.row(capsule_t) << p, v, p - samples;
-    data.indices.row(capsule_t + 1) << v, v - samples, p - samples;
-    p = v;
+    data.indices.row(capsule_t) << v, v + 1, v - ring_size;
+    data.indices.row(capsule_t + 1) << v + 1, v + 1 - ring_size, v - ring_size;
   }
   /* Now the southern hemisphere gets its indices offset to account for the
-   injection of `samples` new vertices.  */
-  const Vector3<GLuint> i_offset(samples, samples, samples);
+   injection of `ring_size` new vertices.  */
+  const Vector3<GLuint> i_offset(ring_size, ring_size, ring_size);
   for (int sphere_t = hemisphere_tri_count;
        sphere_t < sphere_data.indices.rows(); ++sphere_t, ++capsule_t) {
     auto tri = sphere_data.indices.row(sphere_t);
     data.indices.row(capsule_t) = tri + i_offset.transpose();
   }
+
+  /* Texture coordinates.
+   We've copied the *sphere's* texture coordinates along with positions and
+   normals. The u-values in the texture coordinates are all properly inherited
+   from the sphere. However, the v-values are not correct. They need to be
+   redistributed to account for the length of the cylindrical barrel and
+   arbitrary radius. The geodesic distance between the sphere's poles is 1/2 the
+   circumference: πR (R = 1 for the unit sphere). The distance for the capsule
+   is `L = πR + length`. This will lead to a re-parameterization of the
+   v-values.
+
+   The geodesic distance (or arc length) from pole to equator is πR / 2. Its
+   fraction of the full geodesic distance is
+
+      πR / 2 / L = πR / 2L.
+
+   Therefore, over the span from pole to equator, the v-values change by
+   πR / 2L. The v-value at the north pole starts at 1 and decreases
+   by πR / 2L and the south pole starts at 0 and increases by the same amount.
+   In each hemisphere, the v-value should change an *equal* amount from one
+   latitude ring to the next. We constructed the sphere with B = lat_bands
+   number of bands (an even number). So, that means there are B/2 bands in each
+   hemisphere to span πR / 2L values of v, so:
+
+     delta_v = πR / 2L / (B/2) = πR / BL
+   */
+  const GLfloat arc_length = length + M_PI * radius;
+  const GLfloat delta_v = M_PI * radius / (lat_bands * arc_length);
+  int uv_index = 0;
+
+  /* Skipping north and south pole; they are the same as with the sphere.  */
+
+  /* The latitude rings on the northern hemisphere.  */
+  for (int r = 1; r <= lat_bands / 2; ++r) {
+    /* The v-value for this ring.  */
+    const GLfloat v_value = 1.f - r * delta_v;
+    for (int i = 0; i < ring_size; ++i) {
+      data.uvs(++uv_index, 1) = v_value;
+    }
+  }
+  /* The latitude rings for the southern hemisphere.  */
+  for (int r = 0; r < lat_bands / 2; ++r) {
+    /* The v-value for this ring.  */
+    const GLfloat v_value = (lat_bands - r) * delta_v;
+    for (int i = 0; i < ring_size; ++i) {
+      data.uvs(++uv_index, 1) = v_value;
+    }
+  }
+
+  /* The index is of the second-to-last texture coordinate. Increment one for
+   the last, and one more for the total count.  */
+  DRAKE_DEMAND(uv_index + 2 == vert_count);
 
   return data;
 }

--- a/geometry/render/render_engine_vtk_base.cc
+++ b/geometry/render/render_engine_vtk_base.cc
@@ -32,6 +32,13 @@ using Eigen::Vector3d;
 //  explained *somewhere* in the documentation. The layout of the texture on the
 //  box and (eventually) its ability to be transformed. But also for all shapes.
 
+// TODO(SeanCurtis-TRI): The vtkCylinderSource has a similar artifact as the
+//  cube source. The top and bottom faces tile the texture across those faces.
+//  The corner of the texture is located at the center of the face and then
+//  tiles once per each unit the face spans. This is a horrible behavior.
+//  Create a DrakeCylinderSource that matches the Cylinder used in the
+//  RenderEngineGl geometry for consistency.
+
 /* A custom poly data algorithm for creating a Box for Drake. This differs from
  (and is preferred over) the vtkCubeSource for the following reasons.
 


### PR DESCRIPTION
 - Meshes: texture coordinates, like normals, are required for all objs.
   - In the future, relax this requirement so that it's only an error if a texture map is applied to an obj without texture coordinates.
 - Primitives
   - Texture coordinates are generated for all primitives.
   - MakeRevoluteShape now introduces a seam in vertex positions around the revolute axis. On each ring, the first and last vertex positions are identical. This allows for discontinuities in texture coordinates when going around that axis.
 - Testing is nominal
   - Almost impossible to create real tests without duplicating the code under the test. Instead, we have some token smoke tests and will rely on *obvious* visual artifacts to reveal if texture coordinates are broken.
 - Special note:
   - The texture coordinates on the cylinder are *different* than in VTK. The cylinder, essentially, gets spherical coordinates projected onto it. The vtkCylinderSource treats the cap faces like the vtkCubeSource treated the faces.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14175)
<!-- Reviewable:end -->
