### PR TITLE
Fix throwing-Get methods missing Has counterparts

### DIFF
--- a/systems/framework/system.cc
+++ b/systems/framework/system.cc
@@ -634,6 +634,17 @@ const InputPort<T>& System<T>::GetInputPort(
 }
 
 template <typename T>
+bool System<T>::HasInputPort(
+    const std::string& port_name) const {
+  for (InputPortIndex i{0}; i < num_input_ports(); i++) {
+    if (port_name == get_input_port_base(i).get_name()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+template <typename T>
 const OutputPort<T>* System<T>::get_output_port_selection(
     std::variant<OutputPortSelection, OutputPortIndex> port_index) const {
   if (std::holds_alternative<OutputPortIndex>(port_index)) {
@@ -662,6 +673,17 @@ const OutputPort<T>& System<T>::GetOutputPort(
   throw std::logic_error("System " + GetSystemName() +
                          " does not have an output port named " +
                          port_name);
+}
+
+template <typename T>
+bool System<T>::HasOutputPort(
+    const std::string& port_name) const {
+  for (OutputPortIndex i{0}; i < num_output_ports(); i++) {
+    if (port_name == get_output_port_base(i).get_name()) {
+      return true;
+    }
+  }
+  return false;
 }
 
 template <typename T>

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -953,6 +953,10 @@ class System : public SystemBase {
   @throws std::logic_error if port_name is not found. */
   const InputPort<T>& GetInputPort(const std::string& port_name) const;
 
+  /** Returns true iff the system has an InputPort of the given @p
+   port_name. */
+  bool HasInputPort(const std::string& port_name) const;
+
   // TODO(sherm1) Make this an OutputPortIndex.
   /** Returns the typed output port at index @p port_index. */
   const OutputPort<T>& get_output_port(int port_index) const {
@@ -983,6 +987,11 @@ class System : public SystemBase {
   get_output_port() when performance is a concern.
   @throws std::logic_error if port_name is not found. */
   const OutputPort<T>& GetOutputPort(const std::string& port_name) const;
+
+  /** Returns true iff the system has an OutputPort of the given @p
+   port_name. */
+  bool HasOutputPort(const std::string& port_name) const;
+
 
   /** Returns the number of constraints specified for the system. */
   int num_constraints() const;

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -412,11 +412,15 @@ TEST_F(SystemTest, PortNameTest) {
   EXPECT_EQ(&system_.GetInputPort("u0"), &unnamed_input);
   EXPECT_EQ(&system_.GetInputPort("my_input"), &named_input);
   EXPECT_EQ(&system_.GetInputPort("abstract"), &named_abstract_input);
+  EXPECT_EQ(system_.HasInputPort("u0"), true);
+  EXPECT_EQ(system_.HasInputPort("fake_name"), false);
 
   // Test output port names.
   const auto& output_port = system_.AddAbstractOutputPort();
   EXPECT_EQ(output_port.get_name(), "y0");
   EXPECT_EQ(&system_.GetOutputPort("y0"), &output_port);
+  EXPECT_EQ(system_.HasOutputPort("y0"), true);
+  EXPECT_EQ(system_.HasOutputPort("fake_name"), false);
 
   // Requesting a non-existing port name should throw.
   DRAKE_EXPECT_THROWS_MESSAGE(


### PR DESCRIPTION
If a class exposes a `Foo& GetFoo(string)` method that throws if
there is no Foo of that name, then it must expose a corresponding
`HasFoo` method that allows a caller to know whether the getter
will throw.  Otherwise the no-catches standard makes safe use of
the getter impossible.

We've stomped most of these in the codebase but I just found these
two stragglers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14176)
<!-- Reviewable:end -->
