### PR TITLE
[render] Refactor RenderEngineGl shader logic

### DIFF
--- a/geometry/render/gl_renderer/BUILD.bazel
+++ b/geometry/render/gl_renderer/BUILD.bazel
@@ -35,14 +35,23 @@ drake_cc_package_library_gl_per_os(
         ":render_engine_gl_factory",
     ],
     ubuntu_deps = [
+        ":gl_common",
         ":opengl_context",
         ":opengl_geometry",
         ":render_engine_gl",
         ":render_engine_gl_factory",
         ":shader_program",
+        ":shader_program_data",
         ":shape_meshes",
     ],
     visibility = ["//visibility:public"],
+)
+
+drake_cc_library_gl_ubuntu_only(
+    name = "gl_common",
+    hdrs = [
+        "gl_common.h",
+    ],
 )
 
 drake_cc_library_gl_ubuntu_only(
@@ -65,7 +74,9 @@ drake_cc_library_gl_ubuntu_only(
     name = "opengl_geometry",
     hdrs = ["opengl_geometry.h"],
     deps = [
+        ":gl_common",
         ":opengl_context",
+        ":shader_program_data",
         "//geometry/render:render_label",
         "//math:geometric_transform",
     ],
@@ -84,6 +95,7 @@ drake_cc_library_gl_ubuntu_only(
         ":opengl_context",
         ":opengl_geometry",
         ":shader_program",
+        ":shader_program_data",
         ":shape_meshes",
         "//common:essential",
         "//geometry/render:render_engine",
@@ -120,8 +132,21 @@ drake_cc_library_gl_ubuntu_only(
     srcs = ["shader_program.cc"],
     hdrs = ["shader_program.h"],
     deps = [
+        ":shader_program_data",
         "//common:essential",
+        "//geometry:geometry_roles",
+        "//geometry/render:render_engine",
         "//geometry/render/gl_renderer:opengl_context",
+    ],
+)
+
+drake_cc_library_gl_ubuntu_only(
+    name = "shader_program_data",
+    hdrs = ["shader_program_data.h"],
+    deps = [
+        "//common:copyable_unique_ptr",
+        "//common:identifier",
+        "//common:value",
     ],
 )
 
@@ -218,6 +243,7 @@ drake_cc_googletest_gl_ubuntu_only(
         ":opengl_context",
         ":shader_program",
         "//common:temp_directory",
+        "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
     ],
 )

--- a/geometry/render/gl_renderer/gl_common.h
+++ b/geometry/render/gl_renderer/gl_common.h
@@ -1,0 +1,21 @@
+#pragma once
+
+// TODO(SeanCurtis-TRI): Come up with a better name for this file.
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace internal {
+
+// TODO(SeanCurtis-TRI): Consider moving this up to RenderEngine; it's useful
+//  for multiple RenderEngine types.
+/* Rendering types available. Used to index into render-type-dependent data
+ structures. Because it serves as an index, we use kTypeCount to declare the
+ *number* of index values available (relying on C++'s default behavior of
+ assigning sequential values in enumerations).  */
+enum RenderType { kLabel = 0, kDepth, kTypeCount };
+
+}  // namespace internal
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/gl_renderer/opengl_context.cc
+++ b/geometry/render/gl_renderer/opengl_context.cc
@@ -181,7 +181,7 @@ class OpenGlContext::Impl {
     XDestroyWindow(display(), window_);
   }
 
-  void MakeCurrent() {
+  void MakeCurrent() const {
     if (glXGetCurrentContext() != context_ &&
         !glXMakeCurrent(display(), window_, context_)) {
       throw std::runtime_error("Error making an OpenGL context current");
@@ -289,7 +289,7 @@ OpenGlContext::OpenGlContext(bool debug)
 
 OpenGlContext::~OpenGlContext() = default;
 
-void OpenGlContext::MakeCurrent() { impl_->MakeCurrent(); }
+void OpenGlContext::MakeCurrent() const { impl_->MakeCurrent(); }
 
 void OpenGlContext::DisplayWindow(const int width, const int height) {
   impl_->DisplayWindow(width, height);

--- a/geometry/render/gl_renderer/opengl_context.h
+++ b/geometry/render/gl_renderer/opengl_context.h
@@ -27,7 +27,7 @@ class OpenGlContext {
 
   /* Makes this context current.
    @throw std::runtime_error if not successful.  */
-  void MakeCurrent();
+  void MakeCurrent() const;
 
   /* Displays the window at the given dimensions. Calling this redundantly (on
    an already visible window of the given size) has no effect.  */

--- a/geometry/render/gl_renderer/shader_program.cc
+++ b/geometry/render/gl_renderer/shader_program.cc
@@ -13,33 +13,36 @@ namespace geometry {
 namespace render {
 namespace internal {
 
+using Eigen::Vector3d;
+
 namespace {
 
 GLuint CompileShader(GLuint shader_type, const std::string& shader_code) {
-  GLuint shader_id = glCreateShader(shader_type);
+  GLuint shader_gl_id = glCreateShader(shader_type);
   char const* source_ptr = shader_code.c_str();
-  glShaderSource(shader_id, 1, &source_ptr, NULL);
-  glCompileShader(shader_id);
+  glShaderSource(shader_gl_id, 1, &source_ptr, NULL);
+  glCompileShader(shader_gl_id);
 
   // Check compilation result.
   GLint result{0};
-  glGetShaderiv(shader_id, GL_COMPILE_STATUS, &result);
+  glGetShaderiv(shader_gl_id, GL_COMPILE_STATUS, &result);
   if (!result) {
     const std::string error_prefix =
         fmt::format("Error compiling {} shader: ",
                     shader_type == GL_VERTEX_SHADER ? "vertex" : "fragment");
     std::string info("No further information available");
     int info_log_length;
-    glGetShaderiv(shader_id, GL_INFO_LOG_LENGTH, &info_log_length);
+    glGetShaderiv(shader_gl_id, GL_INFO_LOG_LENGTH, &info_log_length);
     if (info_log_length > 0) {
       std::vector<char> error_message(info_log_length + 1);
-      glGetShaderInfoLog(shader_id, info_log_length, NULL, &error_message[0]);
+      glGetShaderInfoLog(shader_gl_id, info_log_length, NULL,
+                         &error_message[0]);
       info = &error_message[0];
     }
     throw std::runtime_error(error_prefix + info);
   }
 
-  return shader_id;
+  return shader_gl_id;
 }
 
 }  // namespace
@@ -53,33 +56,36 @@ void ShaderProgram::LoadFromSources(const std::string& vertex_shader_source,
       CompileShader(GL_FRAGMENT_SHADER, fragment_shader_source);
 
   // Link.
-  program_id_ = glCreateProgram();
-  glAttachShader(program_id_, vertex_shader_id);
-  glAttachShader(program_id_, fragment_shader_id);
-  glLinkProgram(program_id_);
+  gl_id_ = glCreateProgram();
+  glAttachShader(gl_id_, vertex_shader_id);
+  glAttachShader(gl_id_, fragment_shader_id);
+  glLinkProgram(gl_id_);
 
   // Clean up.
-  glDetachShader(program_id_, vertex_shader_id);
-  glDetachShader(program_id_, fragment_shader_id);
+  glDetachShader(gl_id_, vertex_shader_id);
+  glDetachShader(gl_id_, fragment_shader_id);
   glDeleteShader(vertex_shader_id);
   glDeleteShader(fragment_shader_id);
 
   // Check.
   GLint result{0};
-  glGetProgramiv(program_id_, GL_LINK_STATUS, &result);
+  glGetProgramiv(gl_id_, GL_LINK_STATUS, &result);
   if (!result) {
     const std::string error_prefix = "Error linking shaders: ";
     std::string info("No further information available");
     int info_log_length;
-    glGetProgramiv(program_id_, GL_INFO_LOG_LENGTH, &info_log_length);
+    glGetProgramiv(gl_id_, GL_INFO_LOG_LENGTH, &info_log_length);
     if (info_log_length > 0) {
       std::vector<char> error_message(info_log_length + 1);
-      glGetProgramInfoLog(program_id_, info_log_length, NULL,
+      glGetProgramInfoLog(gl_id_, info_log_length, NULL,
                           &error_message[0]);
       info = &error_message[0];
     }
     throw std::runtime_error(error_prefix + info);
   }
+
+  projection_matrix_loc_ = GetUniformLocation("projection_matrix");
+  model_view_loc_ = GetUniformLocation("model_view_matrix");
 }
 
 namespace {
@@ -99,30 +105,44 @@ void ShaderProgram::LoadFromFiles(const std::string& vertex_shader_file,
   LoadFromSources(LoadFile(vertex_shader_file), LoadFile(fragment_shader_file));
 }
 
+void ShaderProgram::SetProjectionMatrix(const Eigen::Matrix4f& X_DG) const {
+  glUniformMatrix4fv(projection_matrix_loc_, 1, GL_FALSE, X_DG.data());
+}
+
+void ShaderProgram::SetModelViewMatrix(const Eigen::Matrix4f& X_CM,
+                                       const Vector3d& scale) const {
+  const Eigen::DiagonalMatrix<float, 4, 4> scale_mat(
+      Vector4<float>(scale(0), scale(1), scale(2), 1.0));
+  // Our camera frame C wrt the OpenGL's camera frame Cgl.
+  // clang-format off
+  static const Eigen::Matrix4f kX_CglC =
+      (Eigen::Matrix4f() << 1,  0,  0, 0,
+                            0, -1,  0, 0,
+                            0,  0, -1, 0,
+                            0,  0,  0, 1)
+          .finished();
+  // clang-format on
+  const Eigen::Matrix4f X_CglM = kX_CglC * X_CM;
+  Eigen::Matrix4f X_CglMscale = X_CglM * scale_mat;
+  glUniformMatrix4fv(model_view_loc_, 1, GL_FALSE, X_CglMscale.data());
+  DoModelViewMatrix(X_CglM, scale);
+}
+
 GLint ShaderProgram::GetUniformLocation(const std::string& uniform_name) const {
-  GLint id = glGetUniformLocation(program_id_, uniform_name.c_str());
+  GLint id = glGetUniformLocation(gl_id_, uniform_name.c_str());
   if (id < 0) {
-    throw std::runtime_error("Cannot get shader uniform " + uniform_name);
+    throw std::runtime_error(
+        fmt::format("Cannot get shader uniform '{}'", uniform_name));
   }
   return id;
 }
 
-void ShaderProgram::SetUniformValue(const std::string& uniform_name,
-                                    float value) const {
-  glUniform1f(GetUniformLocation(uniform_name), value);
-}
-
-void ShaderProgram::SetUniformValue(const std::string& uniform_name,
-                                    const Vector4<float>& value) const {
-  glUniform4fv(GetUniformLocation(uniform_name), 1, value.data());
-}
-
-void ShaderProgram::Use() const { glUseProgram(program_id_); }
+void ShaderProgram::Use() const { glUseProgram(gl_id_); }
 
 void ShaderProgram::Unuse() const {
   GLint curr_program;
   glGetIntegerv(GL_CURRENT_PROGRAM, &curr_program);
-  if (curr_program == static_cast<GLint>(program_id_)) {
+  if (curr_program == static_cast<GLint>(gl_id_)) {
     glUseProgram(0);
   }
 }

--- a/geometry/render/gl_renderer/shader_program.h
+++ b/geometry/render/gl_renderer/shader_program.h
@@ -1,32 +1,71 @@
 #pragma once
 
+#include <memory>
+#include <optional>
 #include <string>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/geometry/geometry_roles.h"
+#include "drake/geometry/render/camera_properties.h"
 #include "drake/geometry/render/gl_renderer/opengl_includes.h"
+#include "drake/geometry/render/gl_renderer/shader_program_data.h"
+#include "drake/geometry/rgba.h"
 
 namespace drake {
 namespace geometry {
 namespace render {
 namespace internal {
 
+/* TODO(SeanCurtis-TRI) This implies a compile-time shader definition. It may
+ be preferred to move away from this architecture. To do runtime shader
+ configuration requires careful coordination between the runtime configurable
+ properties and the compile-time mechanisms. Plenty of guidance and
+ documentation on what constitutes valid declarations. (I.e., you have to assume
+ that vertex position is at location 0, etc.)
+
+ Furthermore, the definition of the shader must be accompanied by consistent
+ shader *meta data* which will inform the ShaderProgram class of what uniforms,
+ pixel attributes, etc., are required, their types, and where they come from.
+ This last -- where they come from -- is going to be compile-time constrained.
+ There should be an enumerated number of quantities (of known types) that
+ ShaderProgram can bind.
+
+ Alternatively, we could ape the VTK architecture with the exception being
+ that we require *declaration* of shaders (or provide automatic clustering of
+ identical shaders) such that we don't have a ridiculous proliferation of
+ shaders, leading to a thrashing OpenGL context. This last option has the
+ benefit of providing cross-RenderEngine shader compatibility. All we need is
+ the ability to manufacture a shader and can pass that into any pipeline that
+ consumes glsl (and knows how to set properties/uniforms). */
+
 /* Definition of a GLSL shader program including a vertex and fragment shader.
  All operations on this shader program require an active OpenGL context. In
  fact, they require the same context which was active when the program was
- "loaded".  */
+ "loaded".
+
+ Explicit functionality is given in derived classes. They specify the actual
+ shader code and any idiosyncratic details. To be compatible with *this*
+ shader abstraction, a shader must meet some minimum requirements:
+
+   - It must specify a uniform mat4 called "model_view_matrix" - this transforms
+     vertices from the geometry's canonical frame G to the OpenGl camera frame
+     C.
+   - It must specify a uniform mat4 called "projection_matrix" - this transforms
+     vertices from the geometry's canonical frame G to the OpenGl device frame
+     D.  */
 class ShaderProgram {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ShaderProgram)
-
-  ShaderProgram() = default;
+  ShaderProgram() : id_(ShaderId::get_new_id()) {}
 
   /* Note: we're using the default destructor and explicitly *not* cleaning up
    the OpenGl context. This is consistent with how we treat all OpenGl objects:
    RenderTarget, OpenGlGeometry, etc. We assume that destruction of the OpenGL
    context will clean it up and the RenderEngineGl's footprint is sufficiently
    small that no actual object management will be required.  */
-  ~ShaderProgram() = default;
+  virtual ~ShaderProgram() = default;
+
+  std::unique_ptr<ShaderProgram> Clone() const { return DoClone(); }
 
   /* Loads a %ShaderProgram from GLSL code contained in the provided strings.
 
@@ -53,28 +92,109 @@ class ShaderProgram {
   void LoadFromFiles(const std::string& vertex_shader_file,
                      const std::string& fragment_shader_file);
 
+  /* Each %ShaderProgram can examine a set of properties and determine if it
+   the properties are sufficient to apply this shader to the geometry with the
+   given `properties`. This data will be used by the shader at render time to
+   configure the per-instance shader parameters.
+
+   The derived classes define the details in DoCreateProgramData.
+
+   @returns The validated and packaged shader program properties, `nullopt` if
+            `this` shader program cannot be applied for the given properties. */
+  std::optional<ShaderProgramData> CreateProgramData(
+      const PerceptionProperties& properties) const {
+    return DoCreateProgramData(properties);
+  }
+
+  /* Allows derived shaders to extract data from the given instance to populate
+   *per-instance* shader parameters. */
+  virtual void SetInstanceParameters(
+      const ShaderProgramData& /* data */) const {}
+
+  /* Allows derived shaders to manipulate OpenGl state based on camera
+   properties. This should *not* include model -> camera -> device transforms.
+   they are handled elsewhere.  */
+  virtual void SetDepthCameraParameters(
+      const DepthCameraProperties& /* camera */) const {}
+
+  /* Sets the OpenGl projection matrix state. The projection matrix transforms a
+   vertex from the camera frame C to the OpenGl 2D device frame D -- it
+   projects a point in 3D to a point on the image.  */
+  void SetProjectionMatrix(const Eigen::Matrix4f& X_DC) const;
+
+  /* Sets the OpenGl model view matrix (and allows the shader to do any other
+   (instance, camera)-dependent configuration). The model view matrix X_CM
+   transforms a vertex from the model frame M to the camera frame C. This will
+   call DoModelViewMatrix().
+
+   Note: there is a subtle difference between the geometry frame G and the model
+   frame M. Geometries are typically defined in a canonical frame in which they
+   have unit dimensions. This canonical geometry is scaled to create the model.
+   Therefore, the geometry frame G and model frame M are related by the scale
+   matrix S_MG (such that it is zero off the diagonal and has the x-, y-, and
+   z-scale values along the diagonal).
+
+   @param X_CM   The pose of the *model* frame relative to the camera frame.
+   @param scale  The per-axis scale of the geometry.  */
+  void SetModelViewMatrix(const Eigen::Matrix4f& X_CM,
+                          const Eigen::Vector3d& scale) const;
+
   /* Provides the location of the named shader uniform parameter.
    @throws std::runtime_error if the named uniform isn't part of the program. */
   GLint GetUniformLocation(const std::string& uniform_name) const;
 
-  /* Sets the scalar uniform value to the given value.
-   @throws std::runtime_error if the named uniform isn't part of the program. */
-  void SetUniformValue(const std::string& uniform_name, float value) const;
-
-  /* Sets the vector4 uniform value to the given value.  */
-  void SetUniformValue(const std::string& uniform_name,
-                       const Vector4<float>& value) const;
-
   /* Binds the program for usage.  */
   void Use() const;
 
-  /* Unbinds the program (if this is the current program).  */
+  /* Unbinds the program (if this is the current program). Derived classes are
+   not obliged to call this. RenderEngineGl promises to only call operations
+   on a particular ShaderProgram after calling its Use() method.  */
   void Unuse() const;
+
+  /* Reports the Drake identifier for this shader; this is not the OpenGl
+   identifier used in OpenGl APIs.  */
+  ShaderId shader_id() const { return id_; }
+
+ protected:
+  /* The copy and move semantics are only made available for sub-classes so
+   they can easily implement DoClone.  */
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ShaderProgram)
+
+  /* Derived classes should clone themselves.  */
+  virtual std::unique_ptr<ShaderProgram> DoClone() const = 0;
+
+  /* Derived classes define if the properties support the use of this shader.
+   Not supported is communicated with a nullopt. Support is given by a defined
+   ShaderProgramData (even if it's data *value* is nullptr).  */
+  virtual std::optional<ShaderProgramData> DoCreateProgramData(
+      const PerceptionProperties& /* properties */) const {
+    return std::nullopt;
+  }
+
+  /* Derived classes can set additional state based on a camera-instance pair.
+   See SetModelViewMatrix() docs for the explanation of the difference between
+   geometry frame G, model frame M, and input parameter `scale`.
+
+   @param X_CglM   The pose of the model in the OpenGl camera frame; this frame
+                   is different than the physical camera, accounting for frame
+                   conventions in OpenGl.
+   @param scale    The per-axis scale of the geometry.  */
+  virtual void DoModelViewMatrix(const Eigen::Matrix4f& /* X_CglM */,
+                                 const Eigen::Vector3d& /* scale */) const {}
 
  private:
   friend class ShaderProgramTest;
 
-  GLuint program_id_{0};
+  // The Drake identifier for this shader. It exists whether the shader has been
+  // correctly compiled or not.
+  ShaderId id_;
+
+  GLuint gl_id_{0};
+
+  // Locations of the projection matrix and the model view matrix in the
+  // *supported* shader.
+  GLint projection_matrix_loc_{};
+  GLint model_view_loc_{};
 };
 
 }  // namespace internal

--- a/geometry/render/gl_renderer/shader_program_data.h
+++ b/geometry/render/gl_renderer/shader_program_data.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include "drake/common/copyable_unique_ptr.h"
+#include "drake/common/identifier.h"
+#include "drake/common/value.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace internal {
+
+/* Type used to identify unique shader programs in RenderEngineGl. */
+using ShaderId = drake::Identifier<class ShaderTag>;
+
+/* When a geometry instance is to be rendered into an image, it is associated
+  with a shader. The instance will store the shader it uses and the per-instance
+  data that that shader requires. See OpenGlInstance for more details.  */
+class ShaderProgramData {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ShaderProgramData)
+
+  ShaderProgramData() = default;
+
+  /* Constructs the data for the shader with the given `shader_id` and the given
+   data (the data may be `nullptr`, but if the corresponding ShaderProgram
+   was expecting actual data, this will lead to a run-time error).  */
+  ShaderProgramData(ShaderId shader_id, std::unique_ptr<AbstractValue> value)
+      : shader_id_(shader_id), value_(std::move(value)) {}
+
+  ShaderId shader_id() const { return shader_id_; }
+  const AbstractValue& value() const { return *value_; }
+
+ private:
+  /* The id of the shader to which this data belongs. */
+  ShaderId shader_id_{};
+
+  /* The type-erased data for the shader.  */
+  copyable_unique_ptr<AbstractValue> value_{};
+};
+}  // namespace internal
+
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/gl_renderer/test/opengl_geometry_test.cc
+++ b/geometry/render/gl_renderer/test/opengl_geometry_test.cc
@@ -63,8 +63,14 @@ GTEST_TEST(OpenGlInstanceTest, Construction) {
   const OpenGlGeometry geometry(1, 2, 3, 4);
   const RigidTransformd X_WG{Vector3d{-1, -2, 3}};
   const Vector3d scale{0.25, 0.5, 0.75};
-  const RenderLabel label(17);
-  const OpenGlInstance instance{geometry, X_WG, scale, label};
+  // We'll create a pretend block of depth data; simply a double value with no
+  // real meaning.
+  const ShaderProgramData depth_data{ShaderId::get_new_id(),
+                                     AbstractValue::Make(7.3)};
+  const ShaderProgramData label_data{ShaderId::get_new_id(),
+                                     AbstractValue::Make(RenderLabel(13))};
+
+  const OpenGlInstance instance{geometry, X_WG, scale, depth_data, label_data};
 
   EXPECT_EQ(instance.geometry.vertex_array, geometry.vertex_array);
   EXPECT_EQ(instance.geometry.vertex_buffer, geometry.vertex_buffer);
@@ -73,7 +79,17 @@ GTEST_TEST(OpenGlInstanceTest, Construction) {
   EXPECT_TRUE(
       CompareMatrices(instance.X_WG.GetAsMatrix34(), X_WG.GetAsMatrix34()));
   EXPECT_TRUE(CompareMatrices(instance.scale, scale));
-  EXPECT_EQ(instance.label, label);
+
+  EXPECT_EQ(
+      instance.shader_data[RenderType::kDepth].value().get_value<double>(),
+      depth_data.value().get_value<double>());
+  EXPECT_EQ(instance.shader_data[RenderType::kDepth].shader_id(),
+            depth_data.shader_id());
+  EXPECT_EQ(
+      instance.shader_data[RenderType::kLabel].value().get_value<RenderLabel>(),
+      label_data.value().get_value<RenderLabel>());
+  EXPECT_EQ(instance.shader_data[RenderType::kLabel].shader_id(),
+            label_data.shader_id());
 }
 
 }  // namespace

--- a/geometry/render/gl_renderer/test/render_engine_gl_test.cc
+++ b/geometry/render/gl_renderer/test/render_engine_gl_test.cc
@@ -61,7 +61,7 @@ using systems::sensors::InvalidDepth;
 // Default camera properties.
 const int kWidth = 640;
 const int kHeight = 480;
-const double kZNear = 0.5;
+const double kZNear = 0.1;
 const double kZFar = 5.;
 const double kFovY = M_PI_4;
 const bool kShowWindow = false;
@@ -130,9 +130,9 @@ class RenderEngineGlTest : public ::testing::Test {
       : depth_(kWidth, kHeight),
         label_(kWidth, kHeight),
         // Looking straight down from 3m above the ground.
-        X_WR_(Translation3d(0, 0, kDefaultDistance) *
-              Eigen::AngleAxisd(M_PI, Vector3d::UnitY()) *
-              Eigen::AngleAxisd(-M_PI_2, Vector3d::UnitZ())),
+        X_WR_(RotationMatrixd{AngleAxisd(M_PI, Vector3d::UnitY()) *
+                              AngleAxisd(-M_PI_2, Vector3d::UnitZ())},
+              {0, 0, kDefaultDistance}),
         geometry_id_(GeometryId::get_new_id()) {}
 
  protected:

--- a/geometry/render/gl_renderer/test/shader_program_test.cc
+++ b/geometry/render/gl_renderer/test/shader_program_test.cc
@@ -6,34 +6,109 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/pointer_cast.h"
 #include "drake/common/temp_directory.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/render/gl_renderer/opengl_context.h"
+#include "drake/geometry/render/gl_renderer/shader_program_data.h"
 
 namespace drake {
 namespace geometry {
 namespace render {
 namespace internal {
+class ShaderProgramTest;
 namespace {
+
+/* A simple shader implementation that exercises all of the virtual API and
+ reports if it has been called.  */
+class TestShader final : public ShaderProgram {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(TestShader)
+
+  struct Data {
+    int i_value{-1};
+    double d_value{-1.0};
+  };
+
+  explicit TestShader(int magic_number = 0)
+      : ShaderProgram(), magic_number_(magic_number) {}
+
+  // Collection of flags which report if certain virtual methods have been
+  // invoked.
+  bool DoModelViewMatrixCalled() const { return do_mv_matrix_called_; }
+
+  bool CalledSetInstanceParameters() const {
+    return set_instance_params_called_;
+  }
+
+  bool CalledSetDepthCameraParameters() const {
+    return set_depth_camera_called_;
+  }
+
+  // Overrides of virtual methods.
+  void SetInstanceParameters(const ShaderProgramData&) const override {
+    set_instance_params_called_ = true;
+  }
+
+  void SetDepthCameraParameters(
+      const DepthCameraProperties& /* camera */) const override {
+    set_depth_camera_called_ = true;
+  }
+
+ private:
+  friend class drake::geometry::render::internal::ShaderProgramTest;
+
+  std::unique_ptr<ShaderProgram> DoClone() const final {
+    return std::make_unique<TestShader>(*this);
+  }
+
+  // We extract ("test", "i_value") and ("test", "d_value") properties and
+  // stash them in
+  std::optional<ShaderProgramData> DoCreateProgramData(
+      const PerceptionProperties& properties) const override {
+    Data data;
+    data.i_value = properties.GetProperty<int>("test", "i_value");
+    data.d_value = properties.GetProperty<double>("test", "d_value");
+    return ShaderProgramData{shader_id(), AbstractValue::Make(data)};
+  }
+
+  void DoModelViewMatrix(const Eigen::Matrix4f&,
+                         const Eigen::Vector3d&) const override {
+    do_mv_matrix_called_ = true;
+  }
+
+  mutable bool do_mv_matrix_called_{false};
+  mutable bool set_instance_params_called_{false};
+  mutable bool set_depth_camera_called_{false};
+
+  int magic_number_{};
+};
 
 constexpr char kVertexSource[] = R"""(
   #version 330
+  uniform mat4 model_view_matrix;
+  uniform mat4 projection_matrix;
+  out vec4 p_CV;
   void main() {
-    gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+    gl_Position = projection_matrix * vec4(0.0, 0.0, 0.0, 1.0);
+    p_CV = model_view_matrix * vec4(0.0, 0.0, 0.0, 1.0);
   }
 )""";
 
 constexpr char kFragmentSource[] = R"""(
   #version 330
   uniform float test_uniform;
-  uniform vec4 test_uniform4;
+  in vec4 p_CV;
   void main() {
-    gl_FragColor = vec4(0.18, 0.54, 0.34, test_uniform) + test_uniform4;
+    gl_FragColor = vec4(0.18, 0.54, 0.34, test_uniform) + p_CV;
   }
 )""";
 
 }  // namespace
 
+using Eigen::Matrix4f;
+using Eigen::Vector3d;
 using std::string;
 
 // Test class is *not* in the anonymous namespace so it can exploit the
@@ -46,8 +121,39 @@ class ShaderProgramTest : public ::testing::Test {
   }
 
   // Reports the program id of the given program.
-  static GLuint program_id(const ShaderProgram& program) {
-    return program.program_id_;
+  static GLuint gl_id(const ShaderProgram& program) { return program.gl_id_; }
+
+  static GLint proj_mat_loc(const ShaderProgram& program) {
+    return program.projection_matrix_loc_;
+  }
+
+  static GLint model_view_loc(const ShaderProgram& program) {
+    return program.model_view_loc_;
+  }
+
+  static ::testing::AssertionResult Equals(const TestShader& p1,
+                                           const TestShader& p2) {
+    if (p1.id_ != p2.id_ || p1.gl_id_ != p2.gl_id_ ||
+        p1.projection_matrix_loc_ != p2.projection_matrix_loc_ ||
+        p1.model_view_loc_ != p2.model_view_loc_ ||
+        p1.magic_number_ != p2.magic_number_) {
+      return ::testing::AssertionFailure()
+             << "Shader programs didn't match"
+             << "\n  p1:"
+             << "\n    shader id: " << p1.id_
+             << "\n    OpenGl id: " << p1.gl_id_
+             << "\n    projection matrix location: "
+             << p1.projection_matrix_loc_
+             << "\n    model view matrix location: " << p1.model_view_loc_
+             << "\n    magic number: " << p1.magic_number_ << "\n  p2:"
+             << "\n    shader id: " << p2.id_
+             << "\n    OpenGl id: " << p2.gl_id_
+             << "\n    projection matrix location: "
+             << p2.projection_matrix_loc_
+             << "\n    model view matrix location: " << p2.model_view_loc_
+             << "\n    magic number: " << p1.magic_number_;
+    }
+    return ::testing::AssertionSuccess();
   }
 
  private:
@@ -60,11 +166,10 @@ class ShaderProgramTest : public ::testing::Test {
 TEST_F(ShaderProgramTest, LoadShaders) {
   {
     // Case: Load from in-memory vertex and fragment shaders.
-    ShaderProgram program;
-    EXPECT_EQ(program_id(program), 0);
-    EXPECT_NO_THROW(
-        program.LoadFromSources(kVertexSource, kFragmentSource));
-    EXPECT_NE(program_id(program), 0);
+    TestShader program;
+    EXPECT_EQ(gl_id(program), 0);
+    EXPECT_NO_THROW(program.LoadFromSources(kVertexSource, kFragmentSource));
+    EXPECT_NE(gl_id(program), 0);
   }
 
   {
@@ -82,9 +187,9 @@ TEST_F(ShaderProgramTest, LoadShaders) {
     write_shader(vertex_shader, kVertexSource);
     write_shader(fragment_shader, kFragmentSource);
 
-    ShaderProgram program;
+    TestShader program;
     EXPECT_NO_THROW(program.LoadFromFiles(vertex_shader, fragment_shader));
-    EXPECT_NE(program_id(program), 0);
+    EXPECT_NE(gl_id(program), 0);
   }
 }
 
@@ -96,39 +201,39 @@ TEST_F(ShaderProgramTest, LoadShadersError) {
   // details of the compilation error reported by the OpenGL driver. The
   // error regular expression uses "[^]+" instead of ".+" because the error
   // may include line breaks and ".+" does *not* include line breaks.
-    ShaderProgram program;
+  TestShader program;
   {
     // Case: Bad vertex shader.
     DRAKE_EXPECT_THROWS_MESSAGE(
         program.LoadFromSources("This is garbage", kFragmentSource),
-        std::runtime_error,
-        "Error compiling vertex shader[^]+");
+        std::runtime_error, "Error compiling vertex shader[^]+");
   }
+
   {
     // Case: Bad fragment shader.
     DRAKE_EXPECT_THROWS_MESSAGE(
         program.LoadFromSources(kVertexSource, "This is garbage"),
-        std::runtime_error,
-        "Error compiling fragment shader[^]+");
+        std::runtime_error, "Error compiling fragment shader[^]+");
   }
+
   {
     // Case: Both shaders are bad. This stops at reporting the vertex error.
     DRAKE_EXPECT_THROWS_MESSAGE(
         program.LoadFromSources("This is garbage", "also garbage"),
-        std::runtime_error,
-        "Error compiling vertex shader[^]+");
+        std::runtime_error, "Error compiling vertex shader[^]+");
   }
+
   {
     // Case: linker error. To trigger the linker error, we omit the main
     // function from the fragment shader as documented here:
     // https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glLinkProgram.xhtml
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        program.LoadFromSources(kVertexSource, R"""(
+    DRAKE_EXPECT_THROWS_MESSAGE(program.LoadFromSources(kVertexSource, R"""(
             #version 100
             void foo() {
               gl_FragColor = vec4(0.1, 0.2, 0.3, 1.0);
             })"""),
-        std::runtime_error, "Error linking shaders[^]+");
+                                std::runtime_error,
+                                "Error linking shaders[^]+");
   }
 
   {
@@ -137,31 +242,57 @@ TEST_F(ShaderProgramTest, LoadShadersError) {
         program.LoadFromFiles("invalid.vert", "invalid.frag"),
         std::runtime_error, "Error opening shader file: .+");
   }
+
+  {
+    // Case: Missing projection matrix uniform. In this case, one is *listed*
+    // in the shader, but because it isn't used, it gets compiled out.
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        program.LoadFromSources(R"""(
+  #version 330
+  uniform mat4 model_view_matrix;
+  uniform mat4 projection_matrix;
+  out vec4 p_CV;
+  void main() {
+    gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+    p_CV = model_view_matrix * vec4(0.0, 0.0, 0.0, 1.0);
+  }
+)""",
+                                kFragmentSource),
+        std::runtime_error, "Cannot get shader uniform 'projection_matrix'");
+  }
+
+  {
+    // Case: Missing modelview matrix uniform. In this case, one is *listed*
+    // in the shader, but because it isn't used, it gets compiled out.
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        program.LoadFromSources(R"""(
+  #version 330
+  uniform mat4 model_view_matrix;
+  uniform mat4 projection_matrix;
+  out vec4 p_CV;
+  void main() {
+    gl_Position = projection_matrix * vec4(0.0, 0.0, 0.0, 1.0);
+    p_CV = vec4(0.0, 0.0, 0.0, 1.0);
+  }
+)""",
+                                kFragmentSource),
+        std::runtime_error, "Cannot get shader uniform 'model_view_matrix'");
+  }
 }
 
 TEST_F(ShaderProgramTest, UniformAccess) {
-  ShaderProgram program;
+  TestShader program;
   program.LoadFromSources(kVertexSource, kFragmentSource);
   EXPECT_NO_THROW(program.GetUniformLocation("test_uniform"));
   DRAKE_EXPECT_THROWS_MESSAGE(program.GetUniformLocation("invalid"),
                               std::runtime_error,
-                              "Cannot get shader uniform invalid");
-  EXPECT_NO_THROW(program.SetUniformValue("test_uniform", 1.5f));
-  DRAKE_EXPECT_THROWS_MESSAGE(program.SetUniformValue("invalid", 1.75f),
-                              std::runtime_error,
-                              "Cannot get shader uniform invalid");
-
-  EXPECT_NO_THROW(program.SetUniformValue("test_uniform4",
-                                          Vector4<float>(0.2, 0.1, 0.1, 0.3)));
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      program.SetUniformValue("invalid", Vector4<float>(0.2, 0.1, 0.1, 0.3)),
-      std::runtime_error, "Cannot get shader uniform invalid");
+                              "Cannot get shader uniform 'invalid'");
 }
 
 TEST_F(ShaderProgramTest, Binding) {
-  ShaderProgram program1;
+  TestShader program1;
   program1.LoadFromSources(kVertexSource, kFragmentSource);
-  ShaderProgram program2;
+  TestShader program2;
   program2.LoadFromSources(kVertexSource, kFragmentSource);
 
   // Report the id of the currently bound program.
@@ -177,19 +308,123 @@ TEST_F(ShaderProgramTest, Binding) {
 
   // Bind one of the programs.
   ASSERT_NO_THROW(program1.Use());
-  ASSERT_EQ(current_program(), program_id(program1));
+  ASSERT_EQ(current_program(), gl_id(program1));
 
   // Binding another causes the current program to switch.
   ASSERT_NO_THROW(program2.Use());
-  ASSERT_EQ(current_program(), program_id(program2));
+  ASSERT_EQ(current_program(), gl_id(program2));
 
   // Attempting to unbind with the wrong program has no effect.
   ASSERT_NO_THROW(program1.Unuse());
-  ASSERT_EQ(current_program(), program_id(program2));
+  ASSERT_EQ(current_program(), gl_id(program2));
 
   // Unbinding the current program clears it.
   ASSERT_NO_THROW(program2.Unuse());
   ASSERT_EQ(current_program(), 0);
+}
+
+// Confirms the virtual nature of CreateProgramData() and its respect for the
+// override.
+TEST_F(ShaderProgramTest, CreateProgramData) {
+  TestShader shader;
+  ShaderProgram* shader_ptr = &shader;
+  shader_ptr->LoadFromSources(kVertexSource, kFragmentSource);
+
+  PerceptionProperties props;
+  const int i_value{17};
+  const double d_value{18.5};
+  props.AddProperty("test", "i_value", i_value);
+  props.AddProperty("test", "d_value", d_value);
+
+  std::optional<ShaderProgramData> data = shader_ptr->CreateProgramData(props);
+  ASSERT_NE(data, std::nullopt);
+  const auto& data_value = data->value().get_value<TestShader::Data>();
+  EXPECT_EQ(data_value.i_value, i_value);
+  EXPECT_EQ(data_value.d_value, d_value);
+  EXPECT_EQ(data->shader_id(), shader.shader_id());
+}
+
+// Confirms that the SetInstanceParameters virtual API is respected in derived
+// classes.
+TEST_F(ShaderProgramTest, SetInstanceParameters) {
+  TestShader shader;
+  const ShaderProgram* shader_ptr = &shader;
+
+  ShaderProgramData data{ShaderId::get_new_id(), nullptr};
+  ASSERT_FALSE(shader.CalledSetInstanceParameters());
+  shader_ptr->SetInstanceParameters(data);
+  ASSERT_TRUE(shader.CalledSetInstanceParameters());
+}
+
+// Confirms the virtual nature of SetDepthCameraParameters().
+TEST_F(ShaderProgramTest, SetDepthCameraParameters) {
+  TestShader shader;
+  const ShaderProgram* shader_ptr = &shader;
+
+  DepthCameraProperties camera{10, 10, M_PI, "", 0.1, 10.0};
+  ASSERT_FALSE(shader.CalledSetDepthCameraParameters());
+  shader_ptr->SetDepthCameraParameters(camera);
+  ASSERT_TRUE(shader.CalledSetDepthCameraParameters());
+}
+
+// Confirms that given matrix propagates into the OpenGl state.
+TEST_F(ShaderProgramTest, SetProjectionMatrix) {
+  TestShader shader;
+  shader.LoadFromSources(kVertexSource, kFragmentSource);
+
+  // Note: this is a weird, invalid projection matrix that we shouldn't expect
+  // should ever happen by accident.
+  const Matrix4f proj_mat = -Matrix4f::Ones();
+  shader.Use();
+  shader.SetProjectionMatrix(proj_mat);
+  shader.Unuse();
+  float proj_mat_data[16];
+  glGetUniformfv(gl_id(shader), proj_mat_loc(shader), &proj_mat_data[0]);
+  const Matrix4f gl_proj_mat(proj_mat_data);
+  EXPECT_TRUE(CompareMatrices(proj_mat, gl_proj_mat));
+}
+
+// Confirms that given matrix propagates into the OpenGl state and that the
+// virtual API gets exercised.
+TEST_F(ShaderProgramTest, SetModelViewMatrix) {
+  TestShader shader;
+  shader.LoadFromSources(kVertexSource, kFragmentSource);
+  const ShaderProgram* shader_ptr = &shader;
+
+  // Note: this is a weird, invalid projection matrix that we shouldn't expect
+  // should ever happen by accident.
+  Matrix4f X_CM = Matrix4f::Identity();
+  X_CM.col(3) << 1, 2, 3, 1;  // Simple translation.
+  const Vector3d scale(0.5, 2, 4);
+  ASSERT_FALSE(shader.DoModelViewMatrixCalled());
+  shader_ptr->Use();
+  shader_ptr->SetModelViewMatrix(X_CM, scale);
+  shader_ptr->Unuse();
+  ASSERT_TRUE(shader.DoModelViewMatrixCalled());
+
+  float mv_mat_data[16];
+  glGetUniformfv(gl_id(shader), model_view_loc(shader), &mv_mat_data[0]);
+  const Matrix4f gl_mv_mat(mv_mat_data);
+
+  // Construct the OpenGl model view matrix by hand.
+  const Matrix4f X_CglC =
+      (Matrix4f() << 1, 0, 0, 0, 0, -1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1)
+          .finished();
+  const Eigen::DiagonalMatrix<float, 4, 4> scale_mat(
+      Vector4<float>(scale(0), scale(1), scale(2), 1.0));
+  const Matrix4f expected_mv_mat = X_CglC * X_CM * scale_mat;
+  EXPECT_TRUE(CompareMatrices(expected_mv_mat, gl_mv_mat));
+}
+
+// Confirms that the clone contains the same data (including any derived data).
+// This implicitly confirms that ShaderProgram::Clone calls DoClone().
+TEST_F(ShaderProgramTest, Cloning) {
+  TestShader shader{13};
+  shader.LoadFromSources(kVertexSource, kFragmentSource);
+  ShaderProgram* shader_ptr = &shader;
+  auto shader_clone = dynamic_pointer_cast<TestShader>(shader_ptr->Clone());
+  ASSERT_NE(shader_clone, nullptr);
+  EXPECT_TRUE(Equals(*shader_clone, shader));
 }
 
 }  // namespace internal


### PR DESCRIPTION
This refactors how RenderEngineGl works with OpenGl Shaders and Programs. The `ShaderProgram` class is given more intelligence and takes a greater burden of the work than previously, This is in preparation for adding shaders to do color rendering (and color with textures).

- ShaderProgram is now an abstract class; it provides interfaces for shader program implementations to interact with the RenderEngine but mask many of the details.
    - Geometries are grouped by the shader they use so that we can reduce changes in the OpenGl context during rendering.
    - Each shader knows what properties of an instance are important and can extract them and provide them in a type-erased container to be associated with that instance.
- Change the depth and label to be derived classes of ShaderProgram
- Refactor the nested enum ImageType to RenderType and make it available to multiple uses (e.g., RenderEngine and OpenGlInstance)
- Clean up
    - OpenGlContext::MakeCurrent() corrected to being a const method.
    - Make render_engine_gl_test better match render_engine_vtk_test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14177)
<!-- Reviewable:end -->
