### PR TITLE
Add (unused) attribute to snopt rule

### DIFF
--- a/tools/workspace/snopt/repository.bzl
+++ b/tools/workspace/snopt/repository.bzl
@@ -220,6 +220,7 @@ _attrs = {
         allow_single_file = True,
         default = "@drake//tools/workspace/snopt:package.BUILD.bazel",
     ),
+    "recursive_init_submodules": attr.bool(),
 }
 
 _snopt_repository = repository_rule(


### PR DESCRIPTION
The argument 'recursive_init_submodules' was added in Bazel 3.6

This fixes CI failing jobs:
https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/mac-mojave-unprovisioned-clang-bazel-continuous-snopt-packaging/1589/
https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-catalina-unprovisioned-clang-bazel-nightly-release/303/
https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-mojave-unprovisioned-clang-bazel-nightly-release/452/
https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-mojave-unprovisioned-clang-bazel-nightly-snopt-packaging/546/

Example error:
```
[4:35:12 AM]  Repository rule _snopt_repository defined at:
[4:35:12 AM]    /Users/mojave/workspace/mac-mojave-unprovisioned-clang-bazel-nightly-release/src/tools/workspace/snopt/repository.bzl:225:36: in <toplevel>
[4:35:12 AM]  ERROR: An error occurred during the fetch of repository 'snopt':
[4:35:12 AM]     Traceback (most recent call last):
[4:35:12 AM]  	File "/Users/mojave/workspace/mac-mojave-unprovisioned-clang-bazel-nightly-release/src/tools/workspace/snopt/repository.bzl", line 190, column 35, in _impl
[4:35:12 AM]  		updated_attrs = _setup_git(repo_ctx)
[4:35:12 AM]  	File "/Users/mojave/workspace/mac-mojave-unprovisioned-clang-bazel-nightly-release/src/tools/workspace/snopt/repository.bzl", line 81, column 29, in _setup_git
[4:35:12 AM]  		git_repo_info = git_repo(repo_ctx, str(repo_ctx.path(".")))
[4:35:12 AM]  	File "/Users/mojave/workspace/mac-mojave-unprovisioned-clang-bazel-nightly-release/_bazel_mojave/ecbf095c1b3d19ae2df89ad79b121524/external/bazel_tools/tools/build_defs/repo/git_worker.bzl", line 82, column 45, in git_repo
[4:35:12 AM]  		recursive_init_submodules = ctx.attr.recursive_init_submodules,
[4:35:12 AM]  Error: No such attribute 'recursive_init_submodules'
[4:35:12 AM]  Available attributes: _action_listener, _config_dependencies, _configure, _environ, applicable_licenses, branch, build_file, commit, compatible_with, deprecation, expect_failure, features, generator_function, generator_location, generator_name, init_submodules, name, patch_args, patch_cmds, patch_tool, patches, remote, restricted_to, shallow_since, tag, tags, testonly, transitive_configs, verbose, visibility
[4:35:12 AM]  ERROR: /Users/mojave/workspace/mac-mojave-unprovisioned-clang-bazel-nightly-release/src/solvers/BUILD.bazel:794:17: no such package '@snopt//': No such attribute 'recursive_init_submodules'
[4:35:12 AM]  Available attributes: _action_listener, _config_dependencies, _configure, _environ, applicable_licenses, branch, build_file, commit, compatible_with, deprecation, expect_failure, features, generator_function, generator_location, generator_name, init_submodules, name, patch_args, patch_cmds, patch_tool, patches, remote, restricted_to, shallow_since, tag, tags, testonly, transitive_configs, verbose, visibility and referenced by '//solvers:snopt_solver'
```


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14179)
<!-- Reviewable:end -->
