### PR TITLE
Fix unit_quaternion_constraint_test failure on CI

### DIFF
--- a/multibody/inverse_kinematics/test/unit_quaternion_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/unit_quaternion_constraint_test.cc
@@ -48,8 +48,8 @@ TEST_F(TwoFreeBodiesConstraintTest, AddUnitQuaternionConstraintOnPlant) {
   auto q = prog.NewContinuousVariables(plant_->num_positions());
   AddUnitQuaternionConstraintOnPlant(*plant_, q, &prog);
   EXPECT_EQ(prog.generic_constraints().size(), 2);
-  Eigen::VectorXd q_val(14);
-  q_val.head<4>() << 0.5, -0.5, 0.5, -1.5;
+  Eigen::VectorXd q_val = Eigen::VectorXd::Zero(14);
+  q_val.head<4>() << 0.5, -0.5, 0.5, -1.;
   q_val.segment<4>(7) << 1.0 / 3, 2.0 / 3, 2.0 / 3, 0.5;
   EXPECT_EQ(prog.generic_constraints()[0].variables().rows(), 4);
   EXPECT_EQ(prog.generic_constraints()[1].variables().rows(), 4);


### PR DESCRIPTION
Trying to fix #14180 

The test fails on Mac. Unfortunately I can't reproduce it on my own machine. I just change the initial guess of the optimization and see if the CI will be happy

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14182)
<!-- Reviewable:end -->
