### PR TITLE
[sensors] Deprecate the old `foo_sensor.h` to become `foo.h`

### DIFF
--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -45,7 +45,9 @@ drake_cc_package_library(
 drake_cc_library(
     name = "accelerometer",
     srcs = ["accelerometer.cc"],
-    hdrs = ["accelerometer_sensor.h"],
+    hdrs = [
+        "accelerometer.h",
+    ],
     deps = [
         "//math:geometric_transform",
         "//multibody/math",
@@ -87,7 +89,9 @@ drake_cc_library(
 drake_cc_library(
     name = "gyroscope",
     srcs = ["gyroscope.cc"],
-    hdrs = ["gyroscope_sensor.h"],
+    hdrs = [
+        "gyroscope.h",
+    ],
     deps = [
         "//math:geometric_transform",
         "//multibody/math",

--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -47,6 +47,7 @@ drake_cc_library(
     srcs = ["accelerometer.cc"],
     hdrs = [
         "accelerometer.h",
+        "accelerometer_sensor.h",
     ],
     deps = [
         "//math:geometric_transform",
@@ -91,6 +92,7 @@ drake_cc_library(
     srcs = ["gyroscope.cc"],
     hdrs = [
         "gyroscope.h",
+        "gyroscope_sensor.h",
     ],
     deps = [
         "//math:geometric_transform",

--- a/systems/sensors/accelerometer.cc
+++ b/systems/sensors/accelerometer.cc
@@ -1,6 +1,4 @@
-/* clang-format off to disable clang-format-includes */
-#include "drake/systems/sensors/accelerometer_sensor.h"
-/* clang-format on */
+#include "drake/systems/sensors/accelerometer.h"
 
 #include "drake/multibody/math/spatial_algebra.h"
 

--- a/systems/sensors/accelerometer.h
+++ b/systems/sensors/accelerometer.h
@@ -1,5 +1,5 @@
 #pragma once
-// TODO(Posa): Rename header to accelerometer.h to match the class name.
+
 #include <memory>
 #include <vector>
 

--- a/systems/sensors/accelerometer_sensor.h
+++ b/systems/sensors/accelerometer_sensor.h
@@ -1,0 +1,6 @@
+#pragma once
+
+// NOLINTNEXTLINE(whitespace/line_length)
+#warning DRAKE DEPRECATED: Please use accelerometer.h instead. The deprecated code will be removed from Drake on or after 2021-02-01.
+
+#include "drake/systems/sensors/accelerometer.h"

--- a/systems/sensors/gyroscope.cc
+++ b/systems/sensors/gyroscope.cc
@@ -1,6 +1,4 @@
-/* clang-format off to disable clang-format-includes */
-#include "drake/systems/sensors/gyroscope_sensor.h"
-/* clang-format on */
+#include "drake/systems/sensors/gyroscope.h"
 
 #include "drake/multibody/math/spatial_algebra.h"
 

--- a/systems/sensors/gyroscope.h
+++ b/systems/sensors/gyroscope.h
@@ -1,5 +1,5 @@
 #pragma once
-// TODO(Posa): Rename header to gyroscope.h to match the class name.
+
 #include <memory>
 #include <vector>
 

--- a/systems/sensors/gyroscope_sensor.h
+++ b/systems/sensors/gyroscope_sensor.h
@@ -1,0 +1,6 @@
+#pragma once
+
+// NOLINTNEXTLINE(whitespace/line_length)
+#warning DRAKE DEPRECATED: Please use gyroscope.h instead. The deprecated code will be removed from Drake on or after 2021-02-01.
+
+#include "drake/systems/sensors/gyroscope.h"

--- a/systems/sensors/test/accelerometer_test.cc
+++ b/systems/sensors/test/accelerometer_test.cc
@@ -1,3 +1,5 @@
+#include "drake/systems/sensors/accelerometer.h"
+
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"
@@ -7,7 +9,6 @@
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/test_utilities/scalar_conversion.h"
-#include "drake/systems/sensors/accelerometer_sensor.h"
 
 namespace drake {
 namespace {

--- a/systems/sensors/test/gyroscope_test.cc
+++ b/systems/sensors/test/gyroscope_test.cc
@@ -1,3 +1,5 @@
+#include "drake/systems/sensors/gyroscope.h"
+
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"
@@ -7,7 +9,6 @@
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/test_utilities/scalar_conversion.h"
-#include "drake/systems/sensors/gyroscope_sensor.h"
 
 namespace drake {
 namespace {


### PR DESCRIPTION
While attic was alive, we had `attic/systems/sensors/foo.h`. To create versions that were compatible with MBP, we created `attic/systems/sensors/foo_sensor.h` to distinguish them via build systems (although they included classes of the same name).

Now that attic is gone, we can remove the `_sensor` suffix.

This has two curated commits. The first renames the header files and changes all Drake references to be consistent; this preserves the blame/history on the files. The second commit adds back the `foo_sensor.h` files. The restored files emit a deprecation warning and include the renamed header.

resolves #14123

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14185)
<!-- Reviewable:end -->
