### PR TITLE
Fix pydrake's bindings coverage report

### DIFF
--- a/tools/skylark/pybind.bzl
+++ b/tools/skylark/pybind.bzl
@@ -428,8 +428,7 @@ def add_pybind_coverage_data(
     added to each package where coverage is desired."""
     native.filegroup(
         name = name,
-        srcs = native.glob(["*_py*.cc"]),
-        data = [
+        srcs = native.glob(["*_py*.cc"], allow_empty = False) + [
             subpackage + ":pybind_coverage_data"
             for subpackage in subpackages
         ],

--- a/tools/workspace/pybind11/BUILD.bazel
+++ b/tools/workspace/pybind11/BUILD.bazel
@@ -39,7 +39,6 @@ py_binary(
     name = "mkdoc",
     srcs = ["mkdoc.py"],
     data = [
-        "generate_pybind_coverage.py",
         "pybind_coverage_libclang_parser.py",
         "pybind_coverage_xml_parser.py",
     ],


### PR DESCRIPTION
The subpackages (e.g., multibody) were not being counted, because they were omitted from the coverage rule's filegroup's srcs.

Also remove a stray dependency that caused the bindings to be rebuilt unnecessarily when the coverage reporting tool changed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14187)
<!-- Reviewable:end -->
