### PR TITLE
[geometry] SceneGraph can store geometry data as State or Parameter

### DIFF
--- a/geometry/geometry_visualization.cc
+++ b/geometry/geometry_visualization.cc
@@ -281,7 +281,7 @@ void DispatchLoadMessage(const SceneGraph<double>& scene_graph,
                          lcm::DrakeLcmInterface* lcm, Role role) {
   lcmt_viewer_load_robot message =
       internal::GeometryVisualizationImpl::BuildLoadMessage(
-          *scene_graph.initial_state_, role);
+          scene_graph.model_, role);
   // Send a load message.
   Publish(lcm, "DRAKE_VIEWER_LOAD_ROBOT", message);
 }

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -16,15 +16,29 @@ namespace drake {
 namespace geometry {
 
 using render::RenderLabel;
+using std::make_unique;
+using std::vector;
 using systems::Context;
 using systems::InputPort;
 using systems::LeafSystem;
-using systems::rendering::PoseBundle;
+using systems::Parameters;
+using systems::State;
 using systems::SystemTypeTag;
-using std::make_unique;
-using std::vector;
+using systems::rendering::PoseBundle;
 
 namespace {
+
+/* We're creating a T-valued abstract value (stored either as State or
+ Parameter). AbstractValues aren't really supposed to do that. They should be
+ the same type *regardless* the scalar type for the Context. However, this
+ breaks that paradigm. I need to be able to assign (i.e., call
+ Context::SetTimeStateAndParametersFrom()) on an AutoDiff-valued Context with
+ a double-valued context. The Value type would die in that attempt (because the
+ two types will be different). This implementation of the AbstractValue
+ interface has special logic to catch and handle this case. It will *still*
+ fail trying to set a double-valued Context from an autodiff-valued one; but
+ that is generally a global failure and not an artifact of this abstract state.
+ */
 template <typename T>
 class GeometryStateValue final : public Value<GeometryState<T>> {
  public:
@@ -40,15 +54,22 @@ class GeometryStateValue final : public Value<GeometryState<T>> {
 
   void SetFrom(const AbstractValue& other) override {
     if (!do_double_assign(other)) {
+      // `other` doesn't contain GeometryState<double>, fall back to
+      // Value::SetFrom() to see if assignment is otherwise valid.
       Value<GeometryState<T>>::SetFrom(other);
     }
   }
 
  private:
+  /* Assigns to the GeometryState<T> stored in *this* Value iff other contains
+   GeometryState<double>. Returns true if that assignment is successful.  */
   bool do_double_assign(const AbstractValue& other) {
     const GeometryStateValue<double>* double_value =
         dynamic_cast<const GeometryStateValue<double>*>(&other);
     if (double_value) {
+      // This relies on the GeometryState::operator= conversion operation
+      // assuming that *this* value's instance can be assigned to by a
+      // double-valued instance.
       this->get_mutable_value() = double_value->get_value();
       return true;
     }
@@ -61,12 +82,17 @@ class GeometryStateValue final : public Value<GeometryState<T>> {
 }  // namespace
 
 template <typename T>
-SceneGraph<T>::SceneGraph()
-    : LeafSystem<T>(SystemTypeTag<SceneGraph>{}) {
-  auto state_value = make_unique<GeometryStateValue<T>>();
-  initial_state_ = &state_value->get_mutable_value();
-  model_inspector_.set(initial_state_);
-  geometry_state_index_ = this->DeclareAbstractState(std::move(state_value));
+SceneGraph<T>::SceneGraph(bool data_as_state)
+    : LeafSystem<T>(SystemTypeTag<SceneGraph>{}),
+      data_as_state_(data_as_state) {
+  model_inspector_.set(&model_);
+  if (data_as_state_) {
+    geometry_state_index_ = this->DeclareAbstractState(
+        make_unique<GeometryStateValue<T>>());
+  } else {
+    geometry_state_index_ =
+        this->DeclareAbstractParameter(GeometryStateValue<T>());
+  }
 
   bundle_port_index_ = this->DeclareAbstractOutputPort(
                                "lcm_visualization", &SceneGraph::MakePoseBundle,
@@ -85,14 +111,13 @@ SceneGraph<T>::SceneGraph()
 
 template <typename T>
 template <typename U>
-SceneGraph<T>::SceneGraph(const SceneGraph<U>& other) : SceneGraph() {
-  // NOTE: If other.initial_state_ is not null, it means we're converting a
-  // system that hasn't had its context allocated yet. We want the converted
-  // system to persist the same state.
-  if (other.initial_state_ != nullptr) {
-    *initial_state_ = *(other.initial_state_->ToAutoDiffXd());
-    model_inspector_.set(initial_state_);
-  }
+SceneGraph<T>::SceneGraph(const SceneGraph<U>& other)
+    : SceneGraph(other.data_as_state_) {
+  // TODO(SeanCurtis-TRI) This is very brittle; we are essentially assuming that
+  //  T = AutoDiffXd. For now, that's true. If we ever support
+  //  symbolic::Expression, this U --> T conversion will have to be more
+  //  generic.
+  model_ = *(other.model_.ToAutoDiffXd());
 
   // We need to guarantee that the same source ids map to the same port indices.
   // We'll do this by processing the source ids in monotonically increasing
@@ -122,7 +147,7 @@ SceneGraph<T>::SceneGraph(const SceneGraph<U>& other) : SceneGraph() {
 
 template <typename T>
 SourceId SceneGraph<T>::RegisterSource(const std::string& name) {
-  SourceId source_id = initial_state_->RegisterNewSource(name);
+  SourceId source_id = model_.RegisterNewSource(name);
   MakeSourcePorts(source_id);
   return source_id;
 }
@@ -142,21 +167,20 @@ const InputPort<T>& SceneGraph<T>::get_source_pose_port(
 template <typename T>
 FrameId SceneGraph<T>::RegisterFrame(SourceId source_id,
                                      const GeometryFrame& frame) {
-  return initial_state_->RegisterFrame(source_id, frame);
+  return model_.RegisterFrame(source_id, frame);
 }
 
 template <typename T>
 FrameId SceneGraph<T>::RegisterFrame(SourceId source_id, FrameId parent_id,
                                      const GeometryFrame& frame) {
-  return initial_state_->RegisterFrame(source_id, parent_id, frame);
+  return model_.RegisterFrame(source_id, parent_id, frame);
 }
 
 template <typename T>
 GeometryId SceneGraph<T>::RegisterGeometry(
     SourceId source_id, FrameId frame_id,
     std::unique_ptr<GeometryInstance> geometry) {
-  return initial_state_->RegisterGeometry(source_id, frame_id,
-                                          std::move(geometry));
+  return model_.RegisterGeometry(source_id, frame_id, std::move(geometry));
 }
 
 template <typename T>
@@ -171,8 +195,8 @@ template <typename T>
 GeometryId SceneGraph<T>::RegisterGeometry(
     SourceId source_id, GeometryId geometry_id,
     std::unique_ptr<GeometryInstance> geometry) {
-  return initial_state_->RegisterGeometryWithParent(source_id, geometry_id,
-                                                    std::move(geometry));
+  return model_.RegisterGeometryWithParent(source_id, geometry_id,
+                                           std::move(geometry));
 }
 
 template <typename T>
@@ -187,13 +211,12 @@ GeometryId SceneGraph<T>::RegisterGeometry(
 template <typename T>
 GeometryId SceneGraph<T>::RegisterAnchoredGeometry(
     SourceId source_id, std::unique_ptr<GeometryInstance> geometry) {
-  return initial_state_->RegisterAnchoredGeometry(source_id,
-                                                  std::move(geometry));
+  return model_.RegisterAnchoredGeometry(source_id, std::move(geometry));
 }
 
 template <typename T>
 void SceneGraph<T>::RemoveGeometry(SourceId source_id, GeometryId geometry_id) {
-  initial_state_->RemoveGeometry(source_id, geometry_id);
+  model_.RemoveGeometry(source_id, geometry_id);
 }
 
 template <typename T>
@@ -206,30 +229,29 @@ void SceneGraph<T>::RemoveGeometry(Context<T>* context, SourceId source_id,
 template <typename T>
 void SceneGraph<T>::AddRenderer(
     std::string name, std::unique_ptr<render::RenderEngine> renderer) {
-  return initial_state_->AddRenderer(std::move(name), std::move(renderer));
+  return model_.AddRenderer(std::move(name), std::move(renderer));
 }
 
 template <typename T>
 bool SceneGraph<T>::HasRenderer(const std::string& name) const {
-  return initial_state_->HasRenderer(name);
+  return model_.HasRenderer(name);
 }
 
 template <typename T>
 int SceneGraph<T>::RendererCount() const {
-  return initial_state_->RendererCount();
+  return model_.RendererCount();
 }
 
 template <typename T>
 vector<std::string> SceneGraph<T>::RegisteredRendererNames() const {
-  return initial_state_->RegisteredRendererNames();
+  return model_.RegisteredRendererNames();
 }
 
 template <typename T>
 void SceneGraph<T>::AssignRole(SourceId source_id, GeometryId geometry_id,
                                ProximityProperties properties,
                                RoleAssign assign) {
-  initial_state_->AssignRole(source_id, geometry_id, std::move(properties),
-                             assign);
+  model_.AssignRole(source_id, geometry_id, std::move(properties), assign);
 }
 
 template <typename T>
@@ -245,8 +267,7 @@ template <typename T>
 void SceneGraph<T>::AssignRole(SourceId source_id, GeometryId geometry_id,
                                PerceptionProperties properties,
                                RoleAssign assign) {
-  initial_state_->AssignRole(source_id, geometry_id, std::move(properties),
-                             assign);
+  model_.AssignRole(source_id, geometry_id, std::move(properties), assign);
 }
 
 template <typename T>
@@ -262,8 +283,7 @@ template <typename T>
 void SceneGraph<T>::AssignRole(SourceId source_id, GeometryId geometry_id,
                                IllustrationProperties properties,
                                RoleAssign assign) {
-  initial_state_->AssignRole(source_id, geometry_id, std::move(properties),
-                             assign);
+  model_.AssignRole(source_id, geometry_id, std::move(properties), assign);
 }
 
 template <typename T>
@@ -282,7 +302,7 @@ void SceneGraph<T>::AssignRole(Context<T>* context, SourceId source_id,
 
 template <typename T>
 int SceneGraph<T>::RemoveRole(SourceId source_id, FrameId frame_id, Role role) {
-  return initial_state_->RemoveRole(source_id, frame_id, role);
+  return model_.RemoveRole(source_id, frame_id, role);
 }
 
 template <typename T>
@@ -295,7 +315,7 @@ int SceneGraph<T>::RemoveRole(Context<T>* context, SourceId source_id,
 template <typename T>
 int SceneGraph<T>::RemoveRole(SourceId source_id, GeometryId geometry_id,
                               Role role) {
-  return initial_state_->RemoveRole(source_id, geometry_id, role);
+  return model_.RemoveRole(source_id, geometry_id, role);
 }
 
 template <typename T>
@@ -312,7 +332,7 @@ const SceneGraphInspector<T>& SceneGraph<T>::model_inspector() const {
 
 template <typename T>
 void SceneGraph<T>::ExcludeCollisionsWithin(const GeometrySet& geometry_set) {
-  initial_state_->ExcludeCollisionsWithin(geometry_set);
+  model_.ExcludeCollisionsWithin(geometry_set);
 }
 
 template <typename T>
@@ -325,7 +345,7 @@ void SceneGraph<T>::ExcludeCollisionsWithin(
 template <typename T>
 void SceneGraph<T>::ExcludeCollisionsBetween(const GeometrySet& setA,
                                              const GeometrySet& setB) {
-  initial_state_->ExcludeCollisionsBetween(setA, setB);
+  model_.ExcludeCollisionsBetween(setA, setB);
 }
 
 template <typename T>
@@ -337,15 +357,35 @@ void SceneGraph<T>::ExcludeCollisionsBetween(Context<T>* context,
 }
 
 template <typename T>
+void SceneGraph<T>::SetDefaultState(const Context<T>& context,
+                                    State<T>* state) const {
+  LeafSystem<T>::SetDefaultState(context, state);
+  if (data_as_state_) {
+    state->template get_mutable_abstract_state<GeometryState<T>>(
+        geometry_state_index_) = model_;
+  }
+}
+
+template <typename T>
+void SceneGraph<T>::SetDefaultParameters(const Context<T>& context,
+                                         Parameters<T>* parameters) const {
+  LeafSystem<T>::SetDefaultParameters(context, parameters);
+  if (!data_as_state_) {
+    parameters->template get_mutable_abstract_parameter<GeometryState<T>>(
+        geometry_state_index_) = model_;
+  }
+}
+
+template <typename T>
 void SceneGraph<T>::MakeSourcePorts(SourceId source_id) {
   // This will fail only if the source generator starts recycling source ids.
   DRAKE_ASSERT(input_source_ids_.count(source_id) == 0);
   // Create and store the input ports for this source id.
   SourcePorts& source_ports = input_source_ids_[source_id];
-  source_ports.pose_port = this->DeclareAbstractInputPort(
-                                   initial_state_->GetName(source_id) + "_pose",
-                                   Value<FramePoseVector<T>>())
-                               .get_index();
+  source_ports.pose_port =
+      this->DeclareAbstractInputPort(model_.GetName(source_id) + "_pose",
+                                     Value<FramePoseVector<T>>())
+          .get_index();
 }
 
 template <typename T>
@@ -367,9 +407,8 @@ void SceneGraph<T>::CalcQueryObject(const Context<T>& context,
 
 template <typename T>
 PoseBundle<T> SceneGraph<T>::MakePoseBundle() const {
-  const auto& g_state = *initial_state_;
   vector<FrameId> dynamic_frames =
-      GetDynamicFrames(g_state, Role::kIllustration);
+      GetDynamicFrames(model_, Role::kIllustration);
   return PoseBundle<T>(static_cast<int>(dynamic_frames.size()));
 }
 
@@ -474,16 +513,28 @@ void SceneGraph<T>::ThrowUnlessRegistered(SourceId source_id,
 template <typename T>
 GeometryState<T>& SceneGraph<T>::mutable_geometry_state(
     Context<T>* context) const {
-  return context->get_mutable_state()
-      .template get_mutable_abstract_state<GeometryState<T>>(
-          geometry_state_index_);
+  if (data_as_state_) {
+    return context->get_mutable_state()
+        .template get_mutable_abstract_state<GeometryState<T>>(
+            geometry_state_index_);
+  } else {
+    return context->get_mutable_parameters()
+        .template get_mutable_abstract_parameter<GeometryState<T>>(
+            geometry_state_index_);
+  }
 }
 
 template <typename T>
 const GeometryState<T>& SceneGraph<T>::geometry_state(
     const Context<T>& context) const {
-  return context.get_state().template get_abstract_state<GeometryState<T>>(
-      geometry_state_index_);
+  if (data_as_state_) {
+    return context.get_state().template get_abstract_state<GeometryState<T>>(
+        geometry_state_index_);
+  } else {
+    return context.get_parameters()
+        .template get_abstract_parameter<GeometryState<T>>(
+            geometry_state_index_);
+  }
 }
 
 // Explicitly instantiates on the most common scalar types.

--- a/geometry/test/geometry_visualization_test.cc
+++ b/geometry/test/geometry_visualization_test.cc
@@ -63,7 +63,7 @@ GTEST_TEST(GeometryVisualization, SimpleScene) {
       make_unique<Sphere>(radius), "sphere_collision"));
   scene_graph.AssignRole(source_id, collision_id, ProximityProperties());
 
-  unique_ptr<Context<double>> context = scene_graph.AllocateContext();
+  unique_ptr<Context<double>> context = scene_graph.CreateDefaultContext();
 
   // This exploits the knowledge that the GeometryState is the zero-indexed
   // abstract state in the scene graph-allocated context.

--- a/geometry/test/query_object_test.cc
+++ b/geometry/test/query_object_test.cc
@@ -120,7 +120,8 @@ TEST_F(QueryObjectTest, CopySemantics) {
   QueryObject<double> from_default{default_object};
   EXPECT_TRUE(is_default(from_default));
 
-  unique_ptr<Context<double>> live_context = scene_graph_.AllocateContext();
+  unique_ptr<Context<double>> live_context =
+      scene_graph_.CreateDefaultContext();
   unique_ptr<QueryObject<double>> live_query_object =
       MakeQueryObject(live_context.get(), &scene_graph_);
   EXPECT_TRUE(is_live(*live_query_object));
@@ -226,7 +227,7 @@ TEST_F(QueryObjectTest, CreateValidInspector) {
   GeometryId geometry_id = scene_graph_.RegisterGeometry(
       source_id, frame_id, make_unique<GeometryInstance>(
                                identity, make_unique<Sphere>(1.0), "sphere"));
-  unique_ptr<Context<double>> context = scene_graph_.AllocateContext();
+  unique_ptr<Context<double>> context = scene_graph_.CreateDefaultContext();
   unique_ptr<QueryObject<double>> query_object =
       MakeQueryObject(context.get(), &scene_graph_);
 
@@ -244,7 +245,7 @@ TEST_F(QueryObjectTest, CreateValidInspector) {
 TEST_F(QueryObjectTest, BakedCopyHasFullUpdate) {
   SourceId s_id = scene_graph_.RegisterSource("BakeTest");
   FrameId frame_id = scene_graph_.RegisterFrame(s_id, GeometryFrame("frame"));
-  unique_ptr<Context<double>> context = scene_graph_.AllocateContext();
+  unique_ptr<Context<double>> context = scene_graph_.CreateDefaultContext();
   RigidTransformd X_WF{Vector3d{1, 2, 3}};
   FramePoseVector<double> poses{{frame_id, X_WF}};
   scene_graph_.get_source_pose_port(s_id).FixValue(context.get(), poses);

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -84,6 +84,18 @@ class SceneGraphTester {
                              PoseBundle<T>* bundle) {
     return scene_graph.CalcPoseBundle(context, bundle);
   }
+
+  template <typename T>
+  static const GeometryState<T>& GetGeometryState(
+      const SceneGraph<T>& scene_graph, const systems::Context<T>& context) {
+    return scene_graph.geometry_state(context);
+  }
+
+  template <typename T>
+  static GeometryState<T>& GetMutableGeometryState(
+      const SceneGraph<T>& scene_graph, systems::Context<T>* context) {
+    return scene_graph.mutable_geometry_state(context);
+  }
 };
 
 namespace {
@@ -96,7 +108,7 @@ std::unique_ptr<GeometryInstance> make_sphere_instance(
 }
 
 // Testing harness to facilitate working with/testing the SceneGraph. Before
-// performing *any* queries in tests, `AllocateContext` must be explicitly
+// performing *any* queries in tests, `CreateDefaultContext` must be explicitly
 // invoked in the test.
 
 class SceneGraphTest : public ::testing::Test {
@@ -106,19 +118,19 @@ class SceneGraphTest : public ::testing::Test {
         query_object_(QueryObjectTest::MakeNullQueryObject<double>()) {}
 
  protected:
-  void AllocateContext() {
+  void CreateDefaultContext() {
     // TODO(SeanCurtis-TRI): This will probably have to be moved into an
     // explicit call so it can be run *after* topology has been set.
-    context_ = scene_graph_.AllocateContext();
+    context_ = scene_graph_.CreateDefaultContext();
     QueryObjectTest::set_query_object(&query_object_, &scene_graph_,
                                       context_.get());
   }
 
   const QueryObject<double>& query_object() const {
-    // The `AllocateContext()` method must have been called *prior* to this
+    // The `CreateDefaultContext()` method must have been called *prior* to this
     // method.
     if (!context_)
-      throw std::runtime_error("Must call AllocateContext() first.");
+      throw std::runtime_error("Must call CreateDefaultContext() first.");
     return query_object_;
   }
 
@@ -128,9 +140,30 @@ class SceneGraphTest : public ::testing::Test {
 
  private:
   // Keep this private so tests must access it through the getter so we can
-  // determine if AllocateContext() has been invoked.
+  // determine if CreateDefaultContext() has been invoked.
   QueryObject<double> query_object_;
 };
+
+// Confirms that the SceneGraph can be instantiated with the geometry data
+// stored as state or parameter (abstract either way). Because this
+// architectural choice is nicely embedded in SceneGraph's geometry_state() and
+// mutable_geometry_state() methods, we don't run *every* unit test in both
+// configurations. If this proves to be overly optimistic, we can parameterize
+// `SceneGraphTest` on that parameter and run those tests.
+TEST_F(SceneGraphTest, DataAsParameterVsState) {
+  for (bool data_as_state : {true, false}) {
+    SceneGraph<double> sg(data_as_state);
+    auto context = sg.CreateDefaultContext();
+    EXPECT_EQ(context->get_state().get_abstract_state().size(),
+              data_as_state ? 1 : 0);
+    EXPECT_EQ(context->get_parameters().num_abstract_parameters(),
+              data_as_state ? 0 : 1);
+    // A smoke test to confirm that we can acquire the geometry state.
+    EXPECT_NO_THROW(SceneGraphTester::GetGeometryState(sg, *context));
+    EXPECT_NO_THROW(
+        SceneGraphTester::GetMutableGeometryState(sg, context.get()));
+  }
+}
 
 // Test sources.
 
@@ -158,7 +191,7 @@ TEST_F(SceneGraphTest, RegisterSourceSpecifiedName) {
 // allocated context.. It also implicitly tests that the model inspector is
 // available _after_ allocation.
 TEST_F(SceneGraphTest, RegisterSourcePostContext) {
-  AllocateContext();
+  CreateDefaultContext();
   const std::string new_source_name = "register_source_post_context";
   SourceId new_source = scene_graph_.RegisterSource(new_source_name);
   EXPECT_TRUE(scene_graph_.SourceIsRegistered(new_source));
@@ -174,7 +207,7 @@ TEST_F(SceneGraphTest, RegisterSourcePostContext) {
 // Tests ability to report if a source is registered or not.
 TEST_F(SceneGraphTest, SourceIsRegistered) {
   SourceId id = scene_graph_.RegisterSource();
-  AllocateContext();
+  CreateDefaultContext();
   EXPECT_TRUE(scene_graph_.SourceIsRegistered(id));
   EXPECT_FALSE(scene_graph_.SourceIsRegistered(SourceId::get_new_id()));
 }
@@ -195,7 +228,7 @@ TEST_F(SceneGraphTest, InputPortsForInvalidSource) {
 TEST_F(SceneGraphTest, AcquireInputPortsAfterAllocation) {
   SourceId id = scene_graph_.RegisterSource();
   DRAKE_EXPECT_NO_THROW(scene_graph_.get_source_pose_port(id));
-  AllocateContext();
+  CreateDefaultContext();
   // Port which *hadn't* been accessed is still accessible.
   DRAKE_EXPECT_NO_THROW(scene_graph_.get_source_pose_port(id));
 }
@@ -213,7 +246,7 @@ TEST_F(SceneGraphTest, TopologyAfterAllocation) {
   GeometryId old_geometry_id = scene_graph_.RegisterGeometry(id, old_frame_id,
       make_sphere_instance());
 
-  AllocateContext();
+  CreateDefaultContext();
 
   FrameId parent_frame_id =
       scene_graph_.RegisterFrame(id, GeometryFrame("frame"));
@@ -270,7 +303,7 @@ TEST_F(SceneGraphTest, DirectFeedThrough) {
 // Simple, toy case: there are no geometry sources; evaluate of pose update
 // should be, essentially a no op.
 TEST_F(SceneGraphTest, FullPoseUpdateEmpty) {
-  AllocateContext();
+  CreateDefaultContext();
   DRAKE_EXPECT_NO_THROW(
       SceneGraphTester::FullPoseUpdate(scene_graph_, *context_));
 }
@@ -280,7 +313,7 @@ TEST_F(SceneGraphTest, FullPoseUpdateEmpty) {
 TEST_F(SceneGraphTest, FullPoseUpdateAnchoredOnly) {
   SourceId s_id = scene_graph_.RegisterSource();
   scene_graph_.RegisterAnchoredGeometry(s_id, make_sphere_instance());
-  AllocateContext();
+  CreateDefaultContext();
   DRAKE_EXPECT_NO_THROW(
       SceneGraphTester::FullPoseUpdate(scene_graph_, *context_));
 }
@@ -298,7 +331,7 @@ TEST_F(SceneGraphTest, TransmogrifyWithoutAllocation) {
       scene_graph_ad.RegisterAnchoredGeometry(s_id, make_sphere_instance()));
 
   // After allocation, registration should _still_ be valid.
-  AllocateContext();
+  CreateDefaultContext();
   system_ad = scene_graph_.ToAutoDiffXd();
   SceneGraph<AutoDiffXd>& scene_graph_ad2 =
       *dynamic_cast<SceneGraph<AutoDiffXd>*>(system_ad.get());
@@ -309,7 +342,7 @@ TEST_F(SceneGraphTest, TransmogrifyWithoutAllocation) {
 // Tests that the ports are correctly mapped.
 TEST_F(SceneGraphTest, TransmogrifyPorts) {
   SourceId s_id = scene_graph_.RegisterSource();
-  AllocateContext();
+  CreateDefaultContext();
   std::unique_ptr<systems::System<AutoDiffXd>> system_ad =
       scene_graph_.ToAutoDiffXd();
   SceneGraph<AutoDiffXd>& scene_graph_ad =
@@ -318,33 +351,41 @@ TEST_F(SceneGraphTest, TransmogrifyPorts) {
             scene_graph_.num_input_ports());
   EXPECT_EQ(scene_graph_ad.get_source_pose_port(s_id).get_index(),
             scene_graph_.get_source_pose_port(s_id).get_index());
-  std::unique_ptr<systems::Context<AutoDiffXd>> context_ad =
-      scene_graph_ad.AllocateContext();
+  EXPECT_NO_THROW(scene_graph_ad.CreateDefaultContext());
 }
 
 // Tests that the work to "set" the context values for the transmogrified system
 // behaves correctly.
 TEST_F(SceneGraphTest, TransmogrifyContext) {
-  SourceId s_id = scene_graph_.RegisterSource();
-  // Register geometry that should be successfully transmogrified.
-  GeometryId g_id =
-      scene_graph_.RegisterAnchoredGeometry(s_id, make_sphere_instance());
-  AllocateContext();
-  std::unique_ptr<System<AutoDiffXd>> system_ad = scene_graph_.ToAutoDiffXd();
-  SceneGraph<AutoDiffXd>& scene_graph_ad =
-      *dynamic_cast<SceneGraph<AutoDiffXd>*>(system_ad.get());
-  std::unique_ptr<Context<AutoDiffXd>> context_ad =
-      scene_graph_ad.AllocateContext();
-  context_ad->SetTimeStateAndParametersFrom(*context_);
-  // Pull out GeometryState from context by exploiting knowledge that it is
-  // zero-indexed.
-  const GeometryState<AutoDiffXd>& geo_state_ad =
-      context_ad->get_state().get_abstract_state<GeometryState<AutoDiffXd>>(0);
-  // If the anchored geometry were not ported over, this would throw an
-  // exception.
-  EXPECT_TRUE(geo_state_ad.BelongsToSource(g_id, s_id));
-  EXPECT_THROW(geo_state_ad.BelongsToSource(GeometryId::get_new_id(), s_id),
-               std::logic_error);
+  for (bool data_as_state : {true, false}) {
+    SceneGraph<double> sg(data_as_state);
+    SourceId s_id = sg.RegisterSource();
+    // Register geometry that should be successfully transmogrified.
+    GeometryId g_id =
+        sg.RegisterAnchoredGeometry(s_id, make_sphere_instance());
+    std::unique_ptr<Context<double>> context = sg.CreateDefaultContext();
+    // This should transmogrify the internal *model*, so when I allocate the
+    // transmogrified context, I should get the "same" values (considering type
+    // change).
+    std::unique_ptr<System<AutoDiffXd>> system_ad = sg.ToAutoDiffXd();
+    SceneGraph<AutoDiffXd>& scene_graph_ad =
+        *dynamic_cast<SceneGraph<AutoDiffXd>*>(system_ad.get());
+    std::unique_ptr<Context<AutoDiffXd>> context_ad =
+        scene_graph_ad.CreateDefaultContext();
+
+    // Extract the GeometryState and query some invariants on it directly.
+    const GeometryState<AutoDiffXd>& geo_state_ad =
+        SceneGraphTester::GetGeometryState(scene_graph_ad, *context_ad);
+    // If the anchored geometry were not ported over, this would throw an
+    // exception.
+    EXPECT_TRUE(geo_state_ad.BelongsToSource(g_id, s_id));
+    EXPECT_THROW(geo_state_ad.BelongsToSource(GeometryId::get_new_id(), s_id),
+                 std::logic_error);
+
+    // Quick reality check that this is still valid although unnecessary vis a
+    // vis the GeometryState.
+    DRAKE_EXPECT_NO_THROW(context_ad->SetTimeStateAndParametersFrom(*context));
+  }
 }
 
 // Tests that exercising the collision filtering logic *after* allocation is
@@ -353,7 +394,7 @@ TEST_F(SceneGraphTest, PostAllocationCollisionFiltering) {
   SourceId source_id = scene_graph_.RegisterSource("filter_after_allocation");
   FrameId frame_id =
       scene_graph_.RegisterFrame(source_id, GeometryFrame("dummy"));
-  AllocateContext();
+  CreateDefaultContext();
 
   GeometrySet geometry_set{frame_id};
   DRAKE_EXPECT_NO_THROW(scene_graph_.ExcludeCollisionsWithin(geometry_set));
@@ -511,7 +552,7 @@ GTEST_TEST(SceneGraphConnectionTest, FullPoseUpdateConnected) {
                   scene_graph->get_source_pose_port(source_id));
   auto diagram = builder.Build();
 
-  auto diagram_context = diagram->AllocateContext();
+  auto diagram_context = diagram->CreateDefaultContext();
   diagram->SetDefaultContext(diagram_context.get());
   const auto& sg_context =
       diagram->GetMutableSubsystemContext(*scene_graph, diagram_context.get());
@@ -528,7 +569,7 @@ GTEST_TEST(SceneGraphConnectionTest, FullPoseUpdateDisconnected) {
   auto source_system = builder.AddSystem<GeometrySourceSystem>(scene_graph);
   source_system->set_name("source_system");
   auto diagram = builder.Build();
-  auto diagram_context = diagram->AllocateContext();
+  auto diagram_context = diagram->CreateDefaultContext();
   diagram->SetDefaultContext(diagram_context.get());
   const auto& sg_context =
       diagram->GetMutableSubsystemContext(*scene_graph, diagram_context.get());
@@ -548,7 +589,7 @@ GTEST_TEST(SceneGraphConnectionTest, FullPoseUpdateNoConnections) {
   auto source_system = builder.AddSystem<GeometrySourceSystem>(scene_graph);
   source_system->set_name("source_system");
   auto diagram = builder.Build();
-  auto diagram_context = diagram->AllocateContext();
+  auto diagram_context = diagram->CreateDefaultContext();
   diagram->SetDefaultContext(diagram_context.get());
   const auto& sg_context =
       diagram->GetMutableSubsystemContext(*scene_graph, diagram_context.get());
@@ -563,7 +604,7 @@ GTEST_TEST(SceneGraphConnectionTest, FullPoseUpdateNoConnections) {
 GTEST_TEST(SceneGraphAutoDiffTest, InstantiateAutoDiff) {
   SceneGraph<AutoDiffXd> scene_graph;
   scene_graph.RegisterSource("dummy_source");
-  auto context = scene_graph.AllocateContext();
+  auto context = scene_graph.CreateDefaultContext();
 
   QueryObject<AutoDiffXd> handle =
       QueryObjectTest::MakeNullQueryObject<AutoDiffXd>();
@@ -578,7 +619,7 @@ GTEST_TEST(SceneGraphVisualizationTest, NoWorldInPoseVector) {
     SceneGraph<double> scene_graph;
     PoseBundle<double> poses = SceneGraphTester::MakePoseBundle(scene_graph);
     EXPECT_EQ(0, poses.get_num_poses());
-    auto context = scene_graph.AllocateContext();
+    auto context = scene_graph.CreateDefaultContext();
     DRAKE_EXPECT_NO_THROW(
         SceneGraphTester::CalcPoseBundle(scene_graph, *context, &poses));
   }
@@ -588,7 +629,7 @@ GTEST_TEST(SceneGraphVisualizationTest, NoWorldInPoseVector) {
     SceneGraph<double> scene_graph;
     PoseBundle<double> poses(1);
     EXPECT_EQ(poses.get_num_poses(), 1);
-    auto context = scene_graph.AllocateContext();
+    auto context = scene_graph.CreateDefaultContext();
     DRAKE_EXPECT_NO_THROW(
         SceneGraphTester::CalcPoseBundle(scene_graph, *context, &poses));
     EXPECT_EQ(poses.get_num_poses(), 0);
@@ -600,7 +641,7 @@ GTEST_TEST(SceneGraphVisualizationTest, NoWorldInPoseVector) {
     scene_graph.RegisterSource("dummy");
     PoseBundle<double> poses = SceneGraphTester::MakePoseBundle(scene_graph);
     EXPECT_EQ(0, poses.get_num_poses());
-    auto context = scene_graph.AllocateContext();
+    auto context = scene_graph.CreateDefaultContext();
     DRAKE_EXPECT_NO_THROW(
         SceneGraphTester::CalcPoseBundle(scene_graph, *context, &poses));
   }
@@ -616,7 +657,7 @@ GTEST_TEST(SceneGraphVisualizationTest, NoWorldInPoseVector) {
                                       make_unique<Sphere>(1.0), "sphere"));
     PoseBundle<double> poses = SceneGraphTester::MakePoseBundle(scene_graph);
     EXPECT_EQ(0, poses.get_num_poses());
-    auto context = scene_graph.AllocateContext();
+    auto context = scene_graph.CreateDefaultContext();
     DRAKE_EXPECT_NO_THROW(
         SceneGraphTester::CalcPoseBundle(scene_graph, *context, &poses));
   }
@@ -636,7 +677,7 @@ GTEST_TEST(SceneGraphVisualizationTest, NoWorldInPoseVector) {
     // The frame has no illustration geometry, so it is not part of the pose
     // bundle.
     EXPECT_EQ(0, poses.get_num_poses());
-    auto context = scene_graph.AllocateContext();
+    auto context = scene_graph.CreateDefaultContext();
     const FramePoseVector<double> pose_vector{
         {f_id, RigidTransformd::Identity()}};
     scene_graph.get_source_pose_port(s_id).FixValue(context.get(), pose_vector);
@@ -662,7 +703,7 @@ GTEST_TEST(SceneGraphVisualizationTest, NoWorldInPoseVector) {
     // The dynamic geometry has no illustration role, so it doesn't lead the
     // frame to be included in the bundle.
     EXPECT_EQ(0, poses.get_num_poses());
-    auto context = scene_graph.AllocateContext();
+    auto context = scene_graph.CreateDefaultContext();
     const FramePoseVector<double> pose_vector{
         {f_id, RigidTransformd::Identity()}};
     scene_graph.get_source_pose_port(s_id).FixValue(context.get(), pose_vector);
@@ -680,11 +721,11 @@ GTEST_TEST(SceneGraphContextModifier, RegisterGeometry) {
   SourceId source_id = scene_graph.RegisterSource("source");
   FrameId frame_id =
       scene_graph.RegisterFrame(source_id, GeometryFrame("frame"));
-  auto context = scene_graph.AllocateContext();
+  auto context = scene_graph.CreateDefaultContext();
 
   // Confirms the state. NOTE: All subsequent actions modify `context` in place.
   // This allows us to use this same query_object and inspector throughout the
-  // test without requiring any updates or changes to them..
+  // test without requiring any updates or changes to them.
   QueryObject<double> query_object;
   SceneGraphTester::GetQueryObjectPortValue(scene_graph, *context,
                                             &query_object);
@@ -741,7 +782,7 @@ GTEST_TEST(SceneGraphContextModifier, CollisionFilters) {
   EXPECT_FALSE(scene_graph.model_inspector().CollisionFiltered(g_id1, g_id3));
   EXPECT_FALSE(scene_graph.model_inspector().CollisionFiltered(g_id2, g_id3));
 
-  auto context = scene_graph.AllocateContext();
+  auto context = scene_graph.CreateDefaultContext();
 
   // Confirms the state. NOTE: Because we're not copying the query object or
   // changing context, this query object and inspector are valid for querying

--- a/systems/sensors/test/rgbd_sensor_test.cc
+++ b/systems/sensors/test/rgbd_sensor_test.cc
@@ -219,7 +219,7 @@ class RgbdSensorTest : public ::testing::Test {
     builder.Connect(scene_graph_->get_query_output_port(),
                     sensor_->query_object_input_port());
     diagram_ = builder.Build();
-    context_ = diagram_->AllocateContext();
+    context_ = diagram_->CreateDefaultContext();
     context_->DisableCaching();
     scene_graph_context_ =
         &diagram_->GetMutableSubsystemContext(*scene_graph_, context_.get());


### PR DESCRIPTION
While this provides the ability to choose whether the giant geometry data blob for SceneGraph is stored as Parameter or State, the default behavior remains State to maintain backwards compatibility.

In support of this endeavor, the LeafSystem interface is extended to declare an abstract Parameter by passing ownership of a pre-instantiated object. This enables SceneGraph to hang on to a pointer and mutate it post declaration.

Tests are extended accordingly.

Resolves #9501

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14189)
<!-- Reviewable:end -->
