### PR TITLE
Remove underscores in Googletest test names

### DIFF
--- a/common/test/symbolic_chebyshev_basis_element_test.cc
+++ b/common/test/symbolic_chebyshev_basis_element_test.cc
@@ -14,7 +14,7 @@ class SymbolicChebyshevBasisElementTest : public ::testing::Test {
   const Variable z_{"z"};
 };
 
-TEST_F(SymbolicChebyshevBasisElementTest, less_than) {
+TEST_F(SymbolicChebyshevBasisElementTest, LessThan) {
   const ChebyshevBasisElement p1({{x_, 1}, {y_, 2}});
   const ChebyshevBasisElement p2({{y_, 3}});
   const ChebyshevBasisElement p3({{x_, 3}});

--- a/common/test/symbolic_expression_test.cc
+++ b/common/test/symbolic_expression_test.cc
@@ -1772,14 +1772,14 @@ TEST_F(SymbolicExpressionTest,
   EXPECT_PRED2(ExprEqual, arguments[1], the_arguments[1]);
 }
 
-TEST_F(SymbolicExpressionTest, UninterpretedFunction_Evaluate) {
+TEST_F(SymbolicExpressionTest, UninterpretedFunctionEvaluate) {
   const Expression uf1{uninterpreted_function("uf1", {})};
   const Expression uf2{uninterpreted_function("uf2", {var_x_, var_y_})};
   EXPECT_THROW(uf1.Evaluate(), std::runtime_error);
   EXPECT_THROW(uf2.Evaluate(), std::runtime_error);
 }
 
-TEST_F(SymbolicExpressionTest, UninterpretedFunction_Equal) {
+TEST_F(SymbolicExpressionTest, UninterpretedFunctionEqual) {
   const Expression uf1{uninterpreted_function("name1", {x_, y_ + z_})};
   const Expression uf2{uninterpreted_function("name1", {x_, y_ + z_})};
   EXPECT_TRUE(uf1.EqualTo(uf2));

--- a/common/test/symbolic_formula_test.cc
+++ b/common/test/symbolic_formula_test.cc
@@ -804,7 +804,7 @@ TEST_F(SymbolicFormulaTest, Forall2) {
   EXPECT_THROW(f1.Evaluate(), runtime_error);
 }
 
-TEST_F(SymbolicFormulaTest, PSD_Exception) {
+TEST_F(SymbolicFormulaTest, PsdException) {
   auto non_square = Eigen::Matrix<Expression, 2, 3>::Zero().eval();
   EXPECT_THROW(positive_semidefinite(non_square), runtime_error);
 
@@ -829,7 +829,7 @@ TEST_F(SymbolicFormulaTest, PSD_Exception) {
   EXPECT_THROW(positive_semidefinite(m, Eigen::Symmetric), runtime_error);
 }
 
-TEST_F(SymbolicFormulaTest, PSD_GetFreeVariables) {
+TEST_F(SymbolicFormulaTest, PsdGetFreeVariables) {
   const Variables vars1{f_psd_static_2x2_.GetFreeVariables()};
   EXPECT_EQ(vars1.size(), 2);
   EXPECT_TRUE(vars1.include(var_x_));
@@ -847,7 +847,7 @@ TEST_F(SymbolicFormulaTest, PSD_GetFreeVariables) {
   EXPECT_TRUE(vars3.include(var_z_));
 }
 
-TEST_F(SymbolicFormulaTest, PSD_EqualTo) {
+TEST_F(SymbolicFormulaTest, PsdEqualTo) {
   EXPECT_TRUE(f_psd_static_2x2_.EqualTo(f_psd_static_2x2_));
   EXPECT_FALSE(f_psd_static_2x2_.EqualTo(f_psd_dynamic_2x2_));
   EXPECT_FALSE(f_psd_static_2x2_.EqualTo(f_psd_static_3x3_));
@@ -862,7 +862,7 @@ TEST_F(SymbolicFormulaTest, PSD_EqualTo) {
   EXPECT_TRUE(f_psd_static_3x3_.EqualTo(f_psd_static_3x3_));
 }
 
-TEST_F(SymbolicFormulaTest, PSD_Evaluate) {
+TEST_F(SymbolicFormulaTest, PsdEvaluate) {
   EXPECT_THROW(f_psd_static_2x2_.Evaluate(), runtime_error);
   EXPECT_THROW(f_psd_dynamic_2x2_.Evaluate(), runtime_error);
   EXPECT_THROW(f_psd_static_3x3_.Evaluate(), runtime_error);
@@ -1107,7 +1107,7 @@ TEST_F(SymbolicFormulaTest, GetMatrixInPSD1) {
   EXPECT_FALSE(m3.IsRowMajor);  // m3 is column-major.
 }
 
-TEST_F(SymbolicFormulaTest, GetMatrixInPSD_NonSymmetric_Static) {
+TEST_F(SymbolicFormulaTest, GetMatrixInPsdNonSymmetricStatic) {
   MatrixX<Expression> m(3, 3);
   // clang-format off
   m << 1.0, 2.0, 3.0,
@@ -1150,7 +1150,7 @@ TEST_F(SymbolicFormulaTest, GetMatrixInPSD_NonSymmetric_Static) {
       sym_from_upper));
 }
 
-TEST_F(SymbolicFormulaTest, GetMatrixInPSD_NonSymmetric_Dynamic) {
+TEST_F(SymbolicFormulaTest, GetMatrixInPsdNonSymmetricDynamic) {
   Eigen::Matrix<Expression, 3, 3> m;
   // clang-format off
   m << 1.0, 2.0, 3.0,

--- a/common/test/symbolic_monomial_test.cc
+++ b/common/test/symbolic_monomial_test.cc
@@ -217,7 +217,7 @@ TEST_F(MonomialTest, MonomialWithZeroExponent) {
   EXPECT_EQ(m2.get_powers(), power_expected);
 }
 
-TEST_F(MonomialTest, MonomialBasis_x_0) {
+TEST_F(MonomialTest, MonomialBasisX0) {
   const drake::VectorX<Monomial> basis1{MonomialBasis({var_x_}, 0)};
   const auto basis2 = MonomialBasis<1, 0>({var_x_});
   EXPECT_EQ(decltype(basis2)::RowsAtCompileTime, 1);
@@ -230,7 +230,7 @@ TEST_F(MonomialTest, MonomialBasis_x_0) {
   EXPECT_EQ(basis2, expected);
 }
 
-TEST_F(MonomialTest, MonomialBasis_x_2) {
+TEST_F(MonomialTest, MonomialBasisX2) {
   const drake::VectorX<Monomial> basis1{MonomialBasis({var_x_}, 2)};
   const auto basis2 = MonomialBasis<1, 2>({var_x_});
   EXPECT_EQ(decltype(basis2)::RowsAtCompileTime, 3);
@@ -246,7 +246,7 @@ TEST_F(MonomialTest, MonomialBasis_x_2) {
   EXPECT_EQ(basis2, expected);
 }
 
-TEST_F(MonomialTest, MonomialBasis_x_y_0) {
+TEST_F(MonomialTest, MonomialBasisXY0) {
   const drake::VectorX<Monomial> basis1{MonomialBasis({var_x_, var_y_}, 0)};
   const auto basis2 = MonomialBasis<2, 0>({var_x_, var_y_});
   EXPECT_EQ(decltype(basis2)::RowsAtCompileTime, 1);
@@ -259,7 +259,7 @@ TEST_F(MonomialTest, MonomialBasis_x_y_0) {
   EXPECT_EQ(basis2, expected);
 }
 
-TEST_F(MonomialTest, MonomialBasis_x_y_1) {
+TEST_F(MonomialTest, MonomialBasisXY1) {
   const drake::VectorX<Monomial> basis1{MonomialBasis({var_x_, var_y_}, 1)};
   const auto basis2 = MonomialBasis<2, 1>({var_x_, var_y_});
   EXPECT_EQ(decltype(basis2)::RowsAtCompileTime, 3);
@@ -276,7 +276,7 @@ TEST_F(MonomialTest, MonomialBasis_x_y_1) {
   EXPECT_EQ(basis2, expected);
 }
 
-TEST_F(MonomialTest, MonomialBasis_x_y_2) {
+TEST_F(MonomialTest, MonomialBasisXY2) {
   const drake::VectorX<Monomial> basis1{MonomialBasis({var_x_, var_y_}, 2)};
   const auto basis2 = MonomialBasis<2, 2>({var_x_, var_y_});
   EXPECT_EQ(decltype(basis2)::RowsAtCompileTime, 6);
@@ -296,7 +296,7 @@ TEST_F(MonomialTest, MonomialBasis_x_y_2) {
   EXPECT_EQ(basis2, expected);
 }
 
-TEST_F(MonomialTest, MonomialBasis_x_y_3) {
+TEST_F(MonomialTest, MonomialBasisXY3) {
   const drake::VectorX<Monomial> basis1{MonomialBasis({var_x_, var_y_}, 3)};
   const auto basis2 = MonomialBasis<2, 3>({var_x_, var_y_});
   EXPECT_EQ(decltype(basis2)::RowsAtCompileTime, 10);
@@ -320,7 +320,7 @@ TEST_F(MonomialTest, MonomialBasis_x_y_3) {
   EXPECT_EQ(basis2, expected);
 }
 
-TEST_F(MonomialTest, MonomialBasis_x_y_z_2) {
+TEST_F(MonomialTest, MonomialBasisXYZ2) {
   const drake::VectorX<Monomial> basis1{
       MonomialBasis({var_x_, var_y_, var_z_}, 2)};
   const auto basis2 = MonomialBasis<3, 2>({var_x_, var_y_, var_z_});
@@ -346,7 +346,7 @@ TEST_F(MonomialTest, MonomialBasis_x_y_z_2) {
   EXPECT_EQ(basis2, expected);
 }
 
-TEST_F(MonomialTest, MonomialBasis_x_y_z_3) {
+TEST_F(MonomialTest, MonomialBasisXYZ3) {
   const drake::VectorX<Monomial> basis1{
       MonomialBasis({var_x_, var_y_, var_z_}, 3)};
   const auto basis2 = MonomialBasis<3, 3>({var_x_, var_y_, var_z_});
@@ -383,7 +383,7 @@ TEST_F(MonomialTest, MonomialBasis_x_y_z_3) {
   EXPECT_EQ(basis2, expected);
 }
 
-TEST_F(MonomialTest, MonomialBasis_x_y_z_w_3) {
+TEST_F(MonomialTest, MonomialBasisXYZW3) {
   const drake::VectorX<Monomial> basis1{
       MonomialBasis({var_x_, var_y_, var_z_, var_w_}, 3)};
   const auto basis2 = MonomialBasis<4, 3>({var_x_, var_y_, var_z_, var_w_});
@@ -433,7 +433,7 @@ TEST_F(MonomialTest, MonomialBasis_x_y_z_w_3) {
   EXPECT_EQ(basis2, expected);
 }
 
-TEST_F(MonomialTest, EvenDegreeMonomialBasis_x_2) {
+TEST_F(MonomialTest, EvenDegreeMonomialBasisX2) {
   const drake::VectorX<Monomial> basis1{EvenDegreeMonomialBasis({var_x_}, 2)};
   drake::Vector2<Monomial> expected;
 
@@ -445,7 +445,7 @@ TEST_F(MonomialTest, EvenDegreeMonomialBasis_x_2) {
   EXPECT_EQ(basis1, expected);
 }
 
-TEST_F(MonomialTest, EvenDegreeMonomialBasis_x_y_01) {
+TEST_F(MonomialTest, EvenDegreeMonomialBasisXY01) {
   const drake::VectorX<Monomial> basis1{
       EvenDegreeMonomialBasis({var_x_, var_y_}, 0)};
   const drake::VectorX<Monomial> basis2{
@@ -459,7 +459,7 @@ TEST_F(MonomialTest, EvenDegreeMonomialBasis_x_y_01) {
   EXPECT_EQ(basis2, expected);
 }
 
-TEST_F(MonomialTest, EvenDegreeMonomialBasis_x_y_23) {
+TEST_F(MonomialTest, EvenDegreeMonomialBasisXY23) {
   const drake::VectorX<Monomial> basis1{
       EvenDegreeMonomialBasis({var_x_, var_y_}, 2)};
   const drake::VectorX<Monomial> basis2{
@@ -478,7 +478,7 @@ TEST_F(MonomialTest, EvenDegreeMonomialBasis_x_y_23) {
   EXPECT_EQ(basis2, expected);
 }
 
-TEST_F(MonomialTest, EvenDegreeMonomialBasis_x_y_z_45) {
+TEST_F(MonomialTest, EvenDegreeMonomialBasisXYZ45) {
   const drake::VectorX<Monomial> basis1{
       EvenDegreeMonomialBasis({var_x_, var_y_, var_z_}, 4)};
   const drake::VectorX<Monomial> basis2{
@@ -516,7 +516,7 @@ TEST_F(MonomialTest, EvenDegreeMonomialBasis_x_y_z_45) {
   EXPECT_EQ(basis2, expected);
 }
 
-TEST_F(MonomialTest, OddDegreeMonomialBasis_x_3) {
+TEST_F(MonomialTest, OddDegreeMonomialBasisX3) {
   const drake::VectorX<Monomial> basis1{OddDegreeMonomialBasis({var_x_}, 3)};
   drake::Vector2<Monomial> expected;
 
@@ -528,7 +528,7 @@ TEST_F(MonomialTest, OddDegreeMonomialBasis_x_3) {
   EXPECT_EQ(basis1, expected);
 }
 
-TEST_F(MonomialTest, OddDegreeMonomialBasis_x_y_12) {
+TEST_F(MonomialTest, OddDegreeMonomialBasisXY12) {
   const drake::VectorX<Monomial> basis1{
       OddDegreeMonomialBasis({var_x_, var_y_}, 1)};
   const drake::VectorX<Monomial> basis2{
@@ -543,7 +543,7 @@ TEST_F(MonomialTest, OddDegreeMonomialBasis_x_y_12) {
   EXPECT_EQ(basis2, expected);
 }
 
-TEST_F(MonomialTest, OddDegreeMonomialBasis_x_y_34) {
+TEST_F(MonomialTest, OddDegreeMonomialBasisXY34) {
   const drake::VectorX<Monomial> basis1{
       OddDegreeMonomialBasis({var_x_, var_y_}, 3)};
   const drake::VectorX<Monomial> basis2{
@@ -564,7 +564,7 @@ TEST_F(MonomialTest, OddDegreeMonomialBasis_x_y_34) {
   EXPECT_EQ(basis2, expected);
 }
 
-TEST_F(MonomialTest, OddDegreeMonomialBasis_x_y_z_34) {
+TEST_F(MonomialTest, OddDegreeMonomialBasisXYZ34) {
   const drake::VectorX<Monomial> basis1{
       OddDegreeMonomialBasis({var_x_, var_y_, var_z_}, 3)};
   const drake::VectorX<Monomial> basis2{

--- a/common/test/symbolic_rational_function_test.cc
+++ b/common/test/symbolic_rational_function_test.cc
@@ -57,14 +57,14 @@ TEST_F(SymbolicRationalFunctionTest, Constructor) {
   EXPECT_PRED2(PolyEqual, f_p1_p2.denominator(), p2);
 }
 
-TEST_F(SymbolicRationalFunctionTest, Constructor_with_polynomial) {
+TEST_F(SymbolicRationalFunctionTest, ConstructorWithPolynomial) {
   // Constructor with numerator only.
   RationalFunction f1(p1_);
   EXPECT_PRED2(PolyEqual, f1.numerator(), p1_);
   EXPECT_PRED2(PolyEqual, f1.denominator(), polynomial_one_);
 }
 
-TEST_F(SymbolicRationalFunctionTest, Constructor_with_double) {
+TEST_F(SymbolicRationalFunctionTest, ConstructorWithDouble) {
   // Constructor with a double scalar.
   const double c = 5;
   RationalFunction f1(c);


### PR DESCRIPTION
See https://github.com/google/googletest/blob/master/googletest/docs/faq.md#why-should-test-suite-names-and-test-names-not-contain-underscore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14191)
<!-- Reviewable:end -->
