### PR TITLE
pydrake: Remove the recently-added ShiftInPlace bindings

### DIFF
--- a/bindings/pydrake/multibody/math_py.cc
+++ b/bindings/pydrake/multibody/math_py.cc
@@ -115,8 +115,6 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("w"), py::arg("v"), cls_doc.ctor.doc_2args)
         .def(
             py::init<const Vector6<T>&>(), py::arg("V"), cls_doc.ctor.doc_1args)
-        .def("ShiftInPlace", &Class::ShiftInPlace, py::arg("p_BpBq_E"),
-            py_rvp::reference, cls_doc.ShiftInPlace.doc)
         .def("Shift", &Class::Shift, py::arg("p_BpBq_E"), cls_doc.Shift.doc)
         .def("ComposeWithMovingFrameVelocity",
             &Class::ComposeWithMovingFrameVelocity, py::arg("p_PoBo_E"),
@@ -176,11 +174,6 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("tau"), py::arg("f"), cls_doc.ctor.doc_2args)
         .def(
             py::init<const Vector6<T>&>(), py::arg("F"), cls_doc.ctor.doc_1args)
-        .def("ShiftInPlace",
-            overload_cast_explicit<Class&, const Vector3<T>&>(
-                &Class::ShiftInPlace),
-            py::arg("p_BpBq_E"), py_rvp::reference,
-            cls_doc.ShiftInPlace.doc_1args)
         .def("Shift",
             overload_cast_explicit<Class, const Vector3<T>&>(&Class::Shift),
             py::arg("p_BpBq_E"), cls_doc.Shift.doc_1args)

--- a/bindings/pydrake/multibody/test/math_test.py
+++ b/bindings/pydrake/multibody/test/math_test.py
@@ -115,7 +115,6 @@ class TestMultibodyTreeMath(unittest.TestCase):
         V = SpatialVelocity_[T].Zero()
         to_T = np.vectorize(T)
         p = to_T(np.zeros(3))
-        self.assertIs(V.ShiftInPlace(p_BpBq_E=p), V)
         self.assertIsInstance(V.Shift(p_BpBq_E=p), SpatialVelocity_[T])
         self.assertIsInstance(
             V.ComposeWithMovingFrameVelocity(p_PoBo_E=p, V_PB_E=V),
@@ -136,7 +135,6 @@ class TestMultibodyTreeMath(unittest.TestCase):
         F = SpatialForce_[T].Zero()
         to_T = np.vectorize(T)
         p = to_T(np.zeros(3))
-        self.assertIs(F.ShiftInPlace(p_BpBq_E=p), F)
         self.assertIsInstance(F.Shift(p_BpBq_E=p), SpatialForce_[T])
         V = SpatialVelocity_[T].Zero()
         self.assertIsInstance(F.dot(V_IBp_E=V), T)

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -3,7 +3,6 @@
 import unittest
 
 import numpy as np
-import warnings
 
 from pydrake.autodiffutils import AutoDiffXd
 from pydrake.symbolic import Expression, Variable
@@ -405,10 +404,6 @@ class TestPlant(unittest.TestCase):
         self.assertIsInstance(joint_actuator.name(), str)
         self.assertIsInstance(joint_actuator.joint(), Joint)
         self.assertIsInstance(joint_actuator.effort_limit(), float)
-
-    def check_old_spelling_exists(self, value):
-        # Just to make it obvious when this is being tested.
-        self.assertIsNot(value, None)
 
     @numpy_compare.check_all_types
     def test_inertia_api(self, T):


### PR DESCRIPTION
We choose not to bind these on `SpatialVelocity` and `SpatialForce` because their performance micro-optimization makes no sense in Python.

Also remove some dead `plant_test` code while we're here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14194)
<!-- Reviewable:end -->
