### PR TITLE
Add GeometryRevision.

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -229,7 +229,9 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py_rvp::reference_internal, py::arg("geometry_id"),
             cls_doc.GetPerceptionProperties.doc)
         .def("CloneGeometryInstance", &Class::CloneGeometryInstance,
-            py::arg("geometry_id"), cls_doc.CloneGeometryInstance.doc);
+            py::arg("geometry_id"), cls_doc.CloneGeometryInstance.doc)
+        .def("geometry_version", &Class::geometry_version,
+            py_rvp::reference_internal, cls_doc.geometry_version.doc);
   }
 
   //  SceneGraph
@@ -846,6 +848,18 @@ void DoScalarIndependentDefinitions(py::module m) {
     constexpr auto& cls_doc = doc.GeometrySet;
     py::class_<Class>(m, "GeometrySet", cls_doc.doc)
         .def(py::init(), doc.GeometrySet.ctor.doc);
+  }
+
+  // GeometryVersion
+  {
+    using Class = GeometryVersion;
+    constexpr auto& cls_doc = doc.GeometryVersion;
+    py::class_<Class> cls(m, "GeometryVersion", cls_doc.doc);
+    cls.def(py::init<const GeometryVersion&>(), py::arg("other"),
+           "Creates a copy of the GeometryVersion.")
+        .def("IsSameAs", &Class::IsSameAs, py::arg("other"), py::arg("role"),
+            cls_doc.IsSameAs.doc);
+    DefCopyAndDeepCopy(&cls);
   }
 
   // ProximityProperties

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -112,6 +112,8 @@ class TestGeometry(unittest.TestCase):
         self.assertIsInstance(
             inspector.GetPoseInFrame(geometry_id=global_geometry),
             RigidTransform_[float])
+        self.assertIsInstance(inspector.geometry_version(),
+                              mut.GeometryVersion)
 
         # Check AssignRole bits.
         proximity = mut.ProximityProperties()
@@ -363,6 +365,26 @@ class TestGeometry(unittest.TestCase):
                               mut.PerceptionProperties)
         self.assertIsInstance(geometry.perception_properties(),
                               mut.PerceptionProperties)
+
+    def test_geometry_version_api(self):
+        SceneGraph = mut.SceneGraph_[float]
+        scene_graph = SceneGraph()
+        inspector = scene_graph.model_inspector()
+        version0 = inspector.geometry_version()
+        version1 = copy.deepcopy(version0)
+        self.assertTrue(version0.IsSameAs(other=version1,
+                                          role=mut.Role.kProximity))
+        self.assertTrue(version0.IsSameAs(other=version1,
+                                          role=mut.Role.kPerception))
+        self.assertTrue(version0.IsSameAs(other=version1,
+                                          role=mut.Role.kIllustration))
+        version2 = mut.GeometryVersion(other=version0)
+        self.assertTrue(version0.IsSameAs(other=version2,
+                                          role=mut.Role.kProximity))
+        self.assertTrue(version0.IsSameAs(other=version2,
+                                          role=mut.Role.kPerception))
+        self.assertTrue(version0.IsSameAs(other=version2,
+                                          role=mut.Role.kIllustration))
 
     def test_rgba_api(self):
         r, g, b, a = 0.75, 0.5, 0.25, 1.

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -23,6 +23,7 @@ drake_cc_package_library(
         ":geometry_roles",
         ":geometry_set",
         ":geometry_state",
+        ":geometry_version",
         ":geometry_visualization",
         ":internal_frame",
         ":internal_geometry",
@@ -131,6 +132,17 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "geometry_version",
+    srcs = ["geometry_version.cc"],
+    hdrs = ["geometry_version.h"],
+    deps = [
+        ":geometry_roles",
+        "//common:essential",
+        "//common:identifier",
+    ],
+)
+
+drake_cc_library(
     name = "geometry_roles",
     srcs = ["geometry_roles.cc"],
     hdrs = ["geometry_roles.h"],
@@ -157,6 +169,7 @@ drake_cc_library(
         ":geometry_index",
         ":geometry_instance",
         ":geometry_set",
+        ":geometry_version",
         ":internal_frame",
         ":internal_geometry",
         ":proximity_engine",
@@ -345,6 +358,13 @@ drake_cc_googletest(
     deps = [
         ":geometry_properties",
         "//common/test_utilities",
+    ],
+)
+
+drake_cc_googletest(
+    name = "geometry_version_test",
+    deps = [
+        ":geometry_version",
     ],
 )
 

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -690,6 +690,7 @@ void GeometryState<T>::AssignRole(SourceId source_id, GeometryId geometry_id,
   InternalGeometry& geometry =
       ValidateRoleAssign(source_id, geometry_id, Role::kProximity, assign);
 
+  geometry_version_.modify_proximity();
   switch (assign) {
     case RoleAssign::kNew:
       geometry.SetRole(std::move(properties));
@@ -800,6 +801,11 @@ void GeometryState<T>::AssignRole(SourceId source_id, GeometryId geometry_id,
         "Perception role assigned to geometry {}, but no renderer accepted it",
         geometry_id);
   }
+  if (added_to_renderer) {
+    // Increment version number only if some renderer picks up the role
+    // assignment.
+    geometry_version_.modify_perception();
+  }
 }
 
 template <typename T>
@@ -832,6 +838,8 @@ void GeometryState<T>::AssignRole(SourceId source_id, GeometryId geometry_id,
 
   InternalGeometry& geometry =
       ValidateRoleAssign(source_id, geometry_id, Role::kIllustration, assign);
+
+  geometry_version_.modify_illustration();
 
   geometry.SetRole(std::move(properties));
 }
@@ -924,6 +932,8 @@ void GeometryState<T>::ExcludeCollisionsWithin(const GeometrySet& set) {
   std::unordered_set<GeometryId> anchored;
   CollectIds(set, &dynamic, &anchored);
 
+  geometry_version_.modify_proximity();
+
   geometry_engine_->ExcludeCollisionsWithin(dynamic, anchored);
 }
 
@@ -936,6 +946,9 @@ void GeometryState<T>::ExcludeCollisionsBetween(const GeometrySet& setA,
   std::unordered_set<GeometryId> dynamic2;
   std::unordered_set<GeometryId> anchored2;
   CollectIds(setB, &dynamic2, &anchored2);
+
+  geometry_version_.modify_proximity();
+
   geometry_engine_->ExcludeCollisionsBetween(dynamic1, anchored1, dynamic2,
                                              anchored2);
 }
@@ -949,16 +962,22 @@ void GeometryState<T>::AddRenderer(
   }
   render::RenderEngine* render_engine = renderer.get();
   render_engines_[name] = move(renderer);
+  bool accepted = false;
   for (auto& id_geo_pair : geometries_) {
     InternalGeometry& geometry = id_geo_pair.second;
     if (geometry.has_perception_role()) {
       const GeometryId id = id_geo_pair.first;
       const PerceptionProperties* properties = geometry.perception_properties();
       DRAKE_DEMAND(properties != nullptr);
-      render_engine->RegisterVisual(id, geometry.shape(), *properties,
-                                    RigidTransformd(geometry.X_FG()),
-                                    geometry.is_dynamic());
+      accepted |= render_engine->RegisterVisual(
+                     id, geometry.shape(), *properties,
+                     RigidTransformd(geometry.X_FG()), geometry.is_dynamic());
     }
+  }
+  // Increment version number if any geometry is registered to the new
+  // renderer.
+  if (accepted) {
+    geometry_version_.modify_perception();
   }
 }
 
@@ -1332,6 +1351,7 @@ bool GeometryState<T>::RemoveFromRendererUnchecked(
     // The engine has reported the belief that it has geometry `id`. Therefore,
     // removal should report true.
     DRAKE_DEMAND(engine->RemoveGeometry(id) == true);
+    geometry_version_.modify_perception();
     return true;
   }
   return false;
@@ -1348,6 +1368,7 @@ bool GeometryState<T>::RemoveProximityRole(GeometryId geometry_id) {
   // Geometry *is* registered; do the work to remove it.
   geometry_engine_->RemoveGeometry(geometry_id, geometry->is_dynamic());
   geometry->RemoveProximityRole();
+  geometry_version_.modify_proximity();
   return true;
 }
 
@@ -1360,6 +1381,7 @@ bool GeometryState<T>::RemoveIllustrationRole(GeometryId geometry_id) {
   if (!geometry->has_illustration_role()) return false;
 
   geometry->RemoveIllustrationRole();
+  geometry_version_.modify_illustration();
   return true;
 }
 

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -16,6 +16,7 @@
 #include "drake/geometry/geometry_index.h"
 #include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/geometry_set.h"
+#include "drake/geometry/geometry_version.h"
 #include "drake/geometry/internal_frame.h"
 #include "drake/geometry/internal_geometry.h"
 #include "drake/geometry/proximity_engine.h"
@@ -66,7 +67,7 @@ using FrameIdSet = std::unordered_set<FrameId>;
 template <typename T>
 class GeometryState {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(GeometryState)
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(GeometryState);
 
   /** An object that represents the range of FrameId values in the state. It
    is used in range-based for loops to iterate through registered frames.  */
@@ -130,6 +131,10 @@ class GeometryState {
   /** Implementation of SceneGraphInspector::GetCollisionCandidates().  */
   std::set<std::pair<GeometryId, GeometryId>> GetCollisionCandidates() const;
 
+  /** Implementation of SceneGraphInspector::GetGeometryVersion().  */
+  const GeometryVersion& geometry_version() const {
+      return geometry_version_;
+  }
   //@}
 
   /** @name          Sources and source-related data  */
@@ -371,7 +376,6 @@ class GeometryState {
                             d) the context has already been allocated.  */
   int RemoveFromRenderer(const std::string& renderer_name, SourceId source_id,
                          GeometryId geometry_id);
-
   //@}
 
   //----------------------------------------------------------------------------
@@ -567,7 +571,8 @@ class GeometryState {
         geometries_(source.geometries_),
         frame_index_to_id_map_(source.frame_index_to_id_map_),
         geometry_engine_(std::move(source.geometry_engine_->ToAutoDiffXd())),
-        render_engines_(source.render_engines_) {
+        render_engines_(source.render_engines_),
+        geometry_version_(source.geometry_version_) {
     auto convert_pose_vector = [](const std::vector<math::RigidTransform<U>>& s,
                                   std::vector<math::RigidTransform<T>>* d) {
       std::vector<math::RigidTransform<T>>& dest = *d;
@@ -851,6 +856,9 @@ class GeometryState {
   // The collection of all registered renderers.
   std::unordered_map<std::string, copyable_unique_ptr<render::RenderEngine>>
       render_engines_;
+
+  // The version for this geometry data.
+  GeometryVersion geometry_version_;
 };
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/geometry_version.cc
+++ b/geometry/geometry_version.cc
@@ -1,0 +1,37 @@
+#include "drake/geometry/geometry_version.h"
+
+namespace drake {
+namespace geometry {
+bool GeometryVersion::IsSameAs(const GeometryVersion& other, Role role) const {
+  switch (role) {
+    case Role::kUnassigned:
+      throw std::logic_error(
+          "Trying to compare the version of unassigned roles.");
+    case Role::kProximity:
+      return proximity_version_id_ == other.proximity_version_id_;
+    case Role::kIllustration:
+      return illustration_version_id_ == other.illustration_version_id_;
+    case Role::kPerception:
+      return perception_version_id_ == other.perception_version_id_;
+  }
+  DRAKE_UNREACHABLE();
+}
+
+GeometryVersion::GeometryVersion()
+    : proximity_version_id_(RoleVersionId::get_new_id()),
+      perception_version_id_(RoleVersionId::get_new_id()),
+      illustration_version_id_(RoleVersionId::get_new_id()) {}
+
+void GeometryVersion::modify_proximity() {
+  proximity_version_id_ = RoleVersionId::get_new_id();
+}
+
+void GeometryVersion::modify_perception() {
+  perception_version_id_ = RoleVersionId::get_new_id();
+}
+
+void GeometryVersion::modify_illustration() {
+  illustration_version_id_ = RoleVersionId::get_new_id();
+}
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/geometry_version.h
+++ b/geometry/geometry_version.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/identifier.h"
+#include "drake/geometry/geometry_roles.h"
+
+namespace drake {
+namespace geometry {
+/**
+A version numbering class that reports revisions of SceneGraph's geometric data.
+
+Other Systems can use this version number to perform updates when they detect
+changes to the geometric data they consume. The version of the geometry data is
+made available through SceneGraphInspector.
+
+The geometry data is partitioned by geometric role and have independent role
+version values. Some of SceneGraph's API (as variously documented) will cause
+one or more role versions to change. This class provides the API `IsSameAs`
+that takes another GeometryVersion as well as a Role to help detect whether the
+provided role of the geometries may have changed. For example:
+
+@code
+// Downstream system holds an instance of GeometryVersion `old_version` as a
+// reference to compare against.
+// Get the version under test from SceneGraphInspector.
+const GeometryVersion& test_version = scene_graph_inspector.geometry_version();
+// Determine if two versions have the same proximity data.
+bool same_proximity = old_version.IsSameAs(test_version, Role::kProximity);
+@endcode
+*/
+class GeometryVersion {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(GeometryVersion);
+
+  /** Returns true if `this` GeometryVersion has the same `role`
+   version as the `other` GeometryVersion. */
+  bool IsSameAs(const GeometryVersion& other, Role role) const;
+
+ private:
+  using RoleVersionId = Identifier<class RoleVersionTag>;
+  /* Only GeometryState can update the role versions and construct
+   GeometryVersion from scratch. Downstream systems should obtain a reference
+   through the API provided by SceneGraphInspector if they want the version.
+   They then may choose to retain a copy if needed. */
+  template <typename T>
+  friend class GeometryState;
+
+  /* Facilitates testing. */
+  friend class GeometryVersionTest;
+
+  /* Create unique version id for all roles so that the new geometry version
+   unique. */
+  GeometryVersion();
+
+  void modify_proximity();
+
+  void modify_perception();
+
+  void modify_illustration();
+
+  RoleVersionId proximity_version_id_;
+  RoleVersionId perception_version_id_;
+  RoleVersionId illustration_version_id_;
+};
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -412,6 +412,12 @@ class SceneGraphInspector {
   std::unique_ptr<GeometryInstance>
   CloneGeometryInstance(GeometryId id) const;
 
+  /** Returns the geometry version that can be used to detect changes
+   to the geometry data associated with geometry roles. The reference returned
+   should not be persisted. If it needs to be persisted, it should be copied. */
+  const GeometryVersion& geometry_version() const {
+    return state_->geometry_version();
+  }
   //@}
 
  private:

--- a/geometry/test/geometry_version_test.cc
+++ b/geometry/test/geometry_version_test.cc
@@ -1,0 +1,141 @@
+#include "drake/geometry/geometry_version.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/geometry/geometry_roles.h"
+
+namespace drake {
+namespace geometry {
+/* GeometryVersionTest tests the following properties of GeometryVersion:
+  1. Role versions within a GeometryVersion are independent from each other.
+  2. Copies of GeometryVersion are equivalent immediately after the copy.
+  3. The equivalence in the second property is transitive upon copying.
+  4. Copies of GeometryVersion then are modified independently after the copy.
+  5. Each GeometryVersion created from scratch is unique. */
+class GeometryVersionTest : public ::testing::Test {
+ protected:
+  void SetUp() {}
+  GeometryVersion version_;
+
+  void modify_proximity(GeometryVersion* v) { v->modify_proximity(); }
+  void modify_perception(GeometryVersion* v) { v->modify_perception(); }
+  void modify_illustration(GeometryVersion* v) { v->modify_illustration(); }
+
+  GeometryVersion CreateGeometryVersion() const { return GeometryVersion(); }
+
+  void VerifySameRole(const GeometryVersion& v1, const GeometryVersion& v2,
+                      Role role) const {
+    EXPECT_TRUE(v1.IsSameAs(v2, role));
+    // Verify commutativity.
+    EXPECT_TRUE(v2.IsSameAs(v1, role));
+  }
+
+  void VerifyDistinctRole(const GeometryVersion& v1, const GeometryVersion& v2,
+                          Role role) const {
+    EXPECT_FALSE(v1.IsSameAs(v2, role));
+    // Verify commutativity.
+    EXPECT_FALSE(v2.IsSameAs(v1, role));
+  }
+
+  void VerifyIdenticalVersions(const GeometryVersion& v1,
+                               const GeometryVersion& v2) const {
+    VerifySameRole(v1, v2, Role::kProximity);
+    VerifySameRole(v1, v2, Role::kPerception);
+    VerifySameRole(v1, v2, Role::kIllustration);
+  }
+
+  void VerifyDistinctVersions(const GeometryVersion& v1,
+                              const GeometryVersion& v2) const {
+    VerifyDistinctRole(v1, v2, Role::kProximity);
+    VerifyDistinctRole(v1, v2, Role::kPerception);
+    VerifyDistinctRole(v1, v2, Role::kIllustration);
+  }
+};
+
+namespace {
+// Tests property 1.
+TEST_F(GeometryVersionTest, Proximity) {
+  GeometryVersion old_version = version_;
+  modify_proximity(&version_);
+  const auto& new_version = version_;
+  VerifyDistinctRole(old_version, new_version, Role::kProximity);
+  VerifySameRole(old_version, new_version, Role::kPerception);
+  VerifySameRole(old_version, new_version, Role::kIllustration);
+}
+
+// Tests property 1.
+TEST_F(GeometryVersionTest, Perception) {
+  GeometryVersion old_version = version_;
+  modify_perception(&version_);
+  const auto& new_version = version_;
+  VerifySameRole(old_version, new_version, Role::kProximity);
+  VerifyDistinctRole(old_version, new_version, Role::kPerception);
+  VerifySameRole(old_version, new_version, Role::kIllustration);
+}
+
+// Tests property 1.
+TEST_F(GeometryVersionTest, Illustration) {
+  GeometryVersion old_version = version_;
+  modify_illustration(&version_);
+  const auto& new_version = version_;
+  VerifySameRole(old_version, new_version, Role::kProximity);
+  VerifySameRole(old_version, new_version, Role::kPerception);
+  VerifyDistinctRole(old_version, new_version, Role::kIllustration);
+}
+
+// Test for unsupported role.
+TEST_F(GeometryVersionTest, Unassigned) {
+  GeometryVersion old_version = version_;
+  const auto& new_version = version_;
+  EXPECT_THROW(old_version.IsSameAs(new_version, Role::kUnassigned),
+               std::logic_error);
+}
+
+// Tests properties 2 and 4 for assignment.
+TEST_F(GeometryVersionTest, Assignment) {
+  GeometryVersion copied_version = version_;
+  VerifyIdenticalVersions(copied_version, version_);
+  modify_illustration(&version_);
+  // The role versions in the copy move independently of the original ones.
+  VerifySameRole(version_, copied_version, Role::kProximity);
+  VerifySameRole(version_, copied_version, Role::kPerception);
+  VerifyDistinctRole(version_, copied_version, Role::kIllustration);
+}
+
+// Tests properties 2 and 4 for copy constructor.
+TEST_F(GeometryVersionTest, CopyConstruct) {
+  // Copy constructed version should be equivalent to the original version.
+  GeometryVersion copied_version(version_);
+  VerifyIdenticalVersions(copied_version, version_);
+  modify_illustration(&version_);
+  // The role versions in the copy move independently of the original ones.
+  VerifySameRole(version_, copied_version, Role::kProximity);
+  VerifySameRole(version_, copied_version, Role::kPerception);
+  VerifyDistinctRole(version_, copied_version, Role::kIllustration);
+}
+
+// Tests properties 3 and 4.
+TEST_F(GeometryVersionTest, Transitivity) {
+  GeometryVersion v1(version_);
+  GeometryVersion v2(version_);
+  // The equivalence is transitive at the time of the copy.
+  VerifyIdenticalVersions(v1, v2);
+  // The copies then evolve independently for each role.
+  modify_perception(&v1);
+  modify_proximity(&v2);
+  VerifyDistinctRole(v1, v2, Role::kProximity);
+  VerifyDistinctRole(v1, v2, Role::kPerception);
+  // The illustration role version remains unmodified since the two
+  // versions were copied from the parent.
+  VerifySameRole(v1, v2, Role::kIllustration);
+}
+
+// Tests property 5.
+TEST_F(GeometryVersionTest, DefaultConstruct) {
+  // Each default constructed version is unique.
+  GeometryVersion new_version = CreateGeometryVersion();
+  VerifyDistinctVersions(new_version, version_);
+}
+}  // namespace
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/test/scene_graph_inspector_test.cc
+++ b/geometry/test/scene_graph_inspector_test.cc
@@ -114,6 +114,7 @@ GTEST_TEST(SceneGraphInspector, ExerciseEverything) {
   EXPECT_NE(geometry_instance_clone->proximity_properties(), nullptr);
   EXPECT_EQ(geometry_instance_clone->perception_properties(), nullptr);
   EXPECT_EQ(geometry_instance_clone->illustration_properties(), nullptr);
+  inspector.geometry_version();
 }
 
 }  // namespace


### PR DESCRIPTION
Resolves #13176. 

GeometryState owns a GeometryRevision that enables a easy query when the underlying geometries change.
Downstream systems may query the revision numbers through SceneGraphInspector.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14196)
<!-- Reviewable:end -->
