### PR TITLE
Allegro with reflected inertia

### DIFF
--- a/examples/allegro_hand/allegro_common.h
+++ b/examples/allegro_hand/allegro_common.h
@@ -16,7 +16,8 @@ namespace allegro_hand {
 constexpr int kAllegroNumJoints = 16;
 
 /// Set the feedback gains for the simulated position control
-void SetPositionControlledGains(Eigen::VectorXd* Kp, Eigen::VectorXd* Ki,
+void SetPositionControlledGains(double pid_frequency, double Ieff,
+                                Eigen::VectorXd* Kp, Eigen::VectorXd* Ki,
                                 Eigen::VectorXd* Kd);
 
 /// Creates selector matrices which extract state xₛ in a known order from the

--- a/examples/allegro_hand/joint_control/allegro_single_object_simulation.cc
+++ b/examples/allegro_hand/joint_control/allegro_single_object_simulation.cc
@@ -40,6 +40,8 @@ namespace {
 
 using math::RigidTransformd;
 using math::RollPitchYawd;
+using multibody::JointActuator;
+using multibody::JointActuatorIndex;
 using multibody::MultibodyPlant;
 
 DEFINE_double(simulation_time, std::numeric_limits<double>::infinity(),
@@ -49,10 +51,32 @@ DEFINE_bool(use_right_hand, true,
 DEFINE_bool(add_gravity, false,
             "Whether adding gravity (9.81 m/s^2) in the simulation");
 DEFINE_double(
-    mbp_discrete_update_period, 1.5e-4,
+    mbp_discrete_update_period, 1.0e-2,
     "The fixed-time step period (in seconds) of discrete updates for the "
     "multibody plant modeled as a discrete system. Strictly positive. "
     "Set to zero for a continuous plant model.");
+DEFINE_double(gear_ratio, 369.0,
+              "The gear ratio of each actuator, dimensionless.");
+DEFINE_double(
+    rotor_inertia, 1.0e-6,
+    "Estimated rotor inertia for the rotor of each actuator, in [kg⋅m²]. If "
+    "zero the effect of reflected inertia is not modeled.");
+DEFINE_double(
+    pid_frequency, 10.0,
+    "This frequency determines the time scale of the PID controller.");
+
+// Modeling the Allegro hand with and without reflected inertia.
+// The default command line parameters are set to model an Allegro hand that
+// includes the effect of reflected inertia due to the high gear ratio of the
+// actuators.
+// In these notes we provide recommended values of the parameters for when
+// reflected inertia is not modeled. Notice in particular that we need to reduce
+// the time step significantly.
+//
+// When reflected inertia is not modeled we recommend:
+//   rotor_inertia = 0.0.
+//   mbp_discrete_update_period = 1.5e-4 sec.
+//   pid_frequency = 30 Hz.
 
 void DoMain() {
   DRAKE_DEMAND(FLAGS_simulation_time > 0);
@@ -91,6 +115,67 @@ void DoMain() {
                                        std::nullopt,
                                        RigidTransformd::Identity());
 
+  // Model gear ratio and rotor inertia at each finger. In order to model the
+  // effect of reflected inertia, we need to have the gear ratio and rotor
+  // inertia of the actuators. We know from the Allegro hand's specs that the
+  // gear ratio is ρ = 369. More details in
+  // http://wiki.wonikrobotics.com/AllegroHandWiki/index.php/Allegro_Hand_Overview
+  // We do not know the exact motor used in the actuator.
+  // However we only need an approximate estimate of the rotor inertia. What we
+  // know from the Allegro hand's specs:
+  // 1. High gear ratio of ρ = 369.
+  // 2. maximum actuator torque: 0.7 Nm, i.e. 0.7/369 = 1.9 mN⋅m at the motor.
+  //    That is, the stall torque of the motor is in the order of 1.9 mN⋅m.
+  // 3. From drawings, we see the finger has a cross section of about 20 mm
+  //    wide. Therefore the diameter of the motor should be Ø ≲ 20 mm.
+  // 4. The hand's power requirement is 7.5 V and at 5 A (minimum). Therefore at
+  //    a minimum it runs at 37 Watts. For 16 actuators, we estimate motors of
+  //    about 2 Watts.
+  // 5. Max. joint speed of 0.11 sec/60° or 91 RPM. Thus the motor speed is
+  //    about 33500 RPM.
+  //
+  // We looked at brushed DC motors from Maxon at
+  // https://www.maxongroup.com/maxon/view/product/
+  // For motors in the range 14-16 mm in diameter, 2.5 W, we find that RPM and
+  // stall torque are in the right order of magnitude.
+  // We also find that most of them have a rotor inertia of about 1 g⋅cm².
+  //
+  // This information then lead us to the following actuator parameters:
+  //   - Gear ratio ρ = 369.
+  //   - Rotor inertia Iᵣ = 1×10⁻⁶ kg⋅m².
+  //
+  // This allow us to esimate the reflected inertia as:
+  //   - Irefl = ρ²⋅Iᵣ = 0.14 kg⋅m².
+  //
+  // As a reference, the mass of a finger is 0.17 kg. Each finger has phalanges
+  // of about 5 cm length. Therefore we estimate their rotational inertia as
+  // that for a rod about its end (1/3⋅m⋅ℓ²) at about 4.7×10⁻⁵ kg⋅m². That's
+  // 3000 times smaller than the reflected inertia!.
+  // That is, the effective inertia of the joint is 0.14 kg⋅m².
+  // We the estimate the time it'd take to move the joint a full revolution from
+  // zero velocity when applying the maximum torque of 0.7 Nm.
+  // We obtain t = sqrt(2θ/ẇ) = 1.6 secs, which seems consistent with
+  // experience.
+
+  // Rotor inertia in kg⋅m².
+  DRAKE_DEMAND(FLAGS_rotor_inertia >= 0.0);
+  DRAKE_DEMAND(FLAGS_gear_ratio >= 1.0);
+  const double rotor_inertia = FLAGS_rotor_inertia;
+  // Gear ratio, dimensionless.
+  const double gear_ratio = FLAGS_gear_ratio;
+  const double reflected_inertia = rotor_inertia * gear_ratio * gear_ratio;
+  // We expect all fingers to be actuated.
+  DRAKE_DEMAND(plant.num_actuators() == 16);
+  // N.B. This change MUST be performed before Finalize() in order to take
+  // effect.
+  for (JointActuatorIndex actuator_index(0);
+       actuator_index < plant.num_actuators(); ++actuator_index) {
+    JointActuator<double>& actuator =
+        plant.get_mutable_joint_actuator(actuator_index);
+    actuator.set_default_rotor_inertia(rotor_inertia);
+    actuator.set_default_gear_ratio(gear_ratio);
+  }
+
   if (!FLAGS_add_gravity) {
     plant.mutable_gravity_field().set_gravity_vector(
         Eigen::Vector3d::Zero());
@@ -111,11 +196,21 @@ void DoMain() {
   // Publish contact results for visualization.
   multibody::ConnectContactResultsToDrakeVisualizer(&builder, plant, lcm);
 
+  // Estimate rotational inertia for an average finger of mass 0.17/3 kg (0.17
+  // is the mass of one finger) and length 5 cm. We estimate it using the
+  // rotational inertia for a rod about its end, i.e. I = 1/3⋅m⋅ℓ².
+  const double mass_finger = 0.17 / 3.0;
+  const double length_finger = 0.05;
+  const double Ifinger = mass_finger / 3.0 * length_finger * length_finger;
+
+  // Approximate effective finger inertia.
+  const double Ieff = Ifinger + reflected_inertia;
+
   // PID controller for position control of the finger joints
   VectorX<double> kp, kd, ki;
   MatrixX<double> Sx, Sy;
   GetControlPortMapping(plant, &Sx, &Sy);
-  SetPositionControlledGains(&kp, &ki, &kd);
+  SetPositionControlledGains(FLAGS_pid_frequency, Ieff, &kp, &ki, &kd);
   auto& hand_controller = *builder.AddSystem<
       systems::controllers::PidController>(Sx, Sy, kp, ki, kd);
   builder.Connect(plant.get_state_output_port(),


### PR DESCRIPTION
Modeling reflected inertia for a real robotic system.
In this case, modeling reflected inertia allow us to use a time step 67 times larger, which leads to a sim running at about 20X.

~~Now dependent on #14167. Thus, right now pushed for discussion with a concrete use case.~~

cc'ing @joemasterjohn, @mitiguy, @sherm1, @alexalspach

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14204)
<!-- Reviewable:end -->
