### PR TITLE
Migrates volume mesh testing utilities

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -440,6 +440,9 @@ drake_cc_library(
     srcs = ["proximity_utilities.cc"],
     hdrs = ["proximity_utilities.h"],
     deps = [
+        ":sorted_triplet",
+        ":volume_mesh",
+        "//common:sorted_pair",
         "//geometry:geometry_ids",
         "//geometry:geometry_index",
         "//geometry:shape_specification",
@@ -637,7 +640,7 @@ drake_cc_googletest(
     size = "medium",
     deps = [
         ":make_cylinder_mesh",
-        ":sorted_triplet",
+        ":proximity_utilities",
     ],
 )
 

--- a/geometry/proximity/proximity_utilities.cc
+++ b/geometry/proximity/proximity_utilities.cc
@@ -1,5 +1,11 @@
 #include "drake/geometry/proximity/proximity_utilities.h"
 
+#include <set>
+#include <unordered_set>
+
+#include "drake/common/sorted_pair.h"
+#include "drake/geometry/proximity/sorted_triplet.h"
+
 namespace drake {
 namespace geometry {
 namespace internal {
@@ -42,6 +48,44 @@ std::string GetGeometryName(const fcl::CollisionObjectd& object) {
       return "Unsupported";
   }
   DRAKE_UNREACHABLE();
+}
+
+int CountEdges(const VolumeMesh<double>& mesh) {
+  std::unordered_set<SortedPair<VolumeVertexIndex>> edges;
+
+  for (auto& t : mesh.tetrahedra()) {
+    // 6 edges of a tetrahedron
+    edges.emplace(t.vertex(0), t.vertex(1));
+    edges.emplace(t.vertex(1), t.vertex(2));
+    edges.emplace(t.vertex(0), t.vertex(2));
+    edges.emplace(t.vertex(0), t.vertex(3));
+    edges.emplace(t.vertex(1), t.vertex(3));
+    edges.emplace(t.vertex(2), t.vertex(3));
+  }
+  return edges.size();
+}
+
+int CountFaces(const VolumeMesh<double>& mesh) {
+  std::set<SortedTriplet<VolumeVertexIndex>> faces;
+
+  for (const auto& t : mesh.tetrahedra()) {
+    // 4 faces of a tetrahedron, all facing in
+    faces.emplace(t.vertex(0), t.vertex(1), t.vertex(2));
+    faces.emplace(t.vertex(1), t.vertex(0), t.vertex(3));
+    faces.emplace(t.vertex(2), t.vertex(1), t.vertex(3));
+    faces.emplace(t.vertex(0), t.vertex(2), t.vertex(3));
+  }
+
+  return faces.size();
+}
+
+int ComputeEulerCharacteristic(const VolumeMesh<double>& mesh) {
+  const int k0 = mesh.vertices().size();
+  const int k1 = CountEdges(mesh);
+  const int k2 = CountFaces(mesh);
+  const int k3 = mesh.tetrahedra().size();
+
+  return k0 - k1 + k2 - k3;
 }
 
 }  // namespace internal

--- a/geometry/proximity/proximity_utilities.h
+++ b/geometry/proximity/proximity_utilities.h
@@ -9,6 +9,7 @@
 #include <fmt/format.h>
 
 #include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/proximity/volume_mesh.h"
 #include "drake/geometry/shape_specification.h"
 
 namespace drake {
@@ -125,6 +126,30 @@ class EncodedData {
 /* Returns the name of the geometry associated with the given collision
  `object`.  */
 std::string GetGeometryName(const fcl::CollisionObjectd& object);
+
+/* Counts the unique 1-simplices (edges) in `mesh`. */
+int CountEdges(const VolumeMesh<double>& mesh);
+
+/* Counts the unique 2-simplices (faces) in the `mesh` */
+int CountFaces(const VolumeMesh<double>& mesh);
+
+/*
+  Computes the generalized Euler characteristic:
+
+   χ = k₀ - k₁ + k₂ - k₃
+
+  Where kᵢ is the number of i-simplexes in the mesh.
+
+  We can use χ in a necessary condition for a _conforming_
+  tetrahedral mesh (any two tetrahedra intersect in their shared
+  face, or shared edge, or shared vertex, or not at all. There is
+  no partial overlapping of two tetrahedra.).
+
+  For example, every tetrahedral mesh of every geometric primitive
+  (Box , Cylinder, Ellipsoid, Sphere, etc.) must have χ = 1 because
+  it is topologically equivalent to a solid ball.
+*/
+int ComputeEulerCharacteristic(const VolumeMesh<double>& mesh);
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/test/proximity_utilities_test.cc
+++ b/geometry/proximity/test/proximity_utilities_test.cc
@@ -61,6 +61,61 @@ GTEST_TEST(EncodedData, ConstructionFromFclObject) {
   }
 }
 
+class VolumeMeshUtilities : public ::testing::Test {
+ public:
+  void SetUp() override {
+    // A  trivial volume mesh comprises of two tetrahedral elements with
+    // vertices on the coordinate axes and the origin like this:
+    //
+    //      +Z
+    //       |
+    //       v3
+    //       |
+    //       |
+    //     v0+------v2---+Y
+    //      /|
+    //     / |
+    //   v1  v4
+    //   /   |
+    // +X    |
+    //      -Z
+    //
+    const int element_data[2][4] = {{0, 1, 2, 3}, {0, 2, 1, 4}};
+    std::vector<VolumeElement> elements;
+    for (int e = 0; e < 2; ++e) elements.emplace_back(element_data[e]);
+    const Vector3<double> vertex_data[5] = {
+        Vector3<double>::Zero(), Vector3<double>::UnitX(),
+        Vector3<double>::UnitY(), Vector3<double>::UnitZ(),
+        -Vector3<double>::UnitZ()};
+    std::vector<VolumeVertex<double>> vertices;
+    for (int v = 0; v < 5; ++v) vertices.emplace_back(vertex_data[v]);
+    volume_mesh = std::make_unique<VolumeMesh<double>>(std::move(elements),
+                                                       std::move(vertices));
+  }
+
+ protected:
+  std::unique_ptr<VolumeMesh<double>> volume_mesh;
+};
+
+TEST_F(VolumeMeshUtilities, CountEdges) {
+  const int expected_edges = 9;
+  const int edges = CountEdges(*volume_mesh);
+  EXPECT_EQ(expected_edges, edges);
+}
+
+TEST_F(VolumeMeshUtilities, CountFaces) {
+  const int expected_faces = 7;
+  const int faces = CountFaces(*volume_mesh);
+  EXPECT_EQ(expected_faces, faces);
+}
+
+TEST_F(VolumeMeshUtilities, ComputeEulerCharacteristic) {
+  // For a convex mesh that is homeomorphic to a 3-dimensional ball, χ = 1.
+  const int expected_characteristic = 1;
+  const int characteristic = ComputeEulerCharacteristic(*volume_mesh);
+  EXPECT_EQ(expected_characteristic, characteristic);
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/test/volume_mesh_test.cc
+++ b/geometry/proximity/test/volume_mesh_test.cc
@@ -181,6 +181,26 @@ GTEST_TEST(VolumeMeshTest, TestCalcTetrahedronVolumeAutoDiffXd) {
   TestCalcTetrahedronVolume<AutoDiffXd>();
 }
 
+template <typename T>
+void TestCalcVolume() {
+  const RigidTransform<T> X_WM(
+      RollPitchYaw<T>(M_PI / 6.0, 2.0 * M_PI / 3.0, 7.0 * M_PI / 4.0),
+      Vector3<T>(1.0, 2.0, 3.0));
+  auto volume_mesh = TestVolumeMesh<T>(X_WM);
+  // Estimate 4 multiply+add, each introduces 2 epsilons.
+  const double kTolerance(8.0 * std::numeric_limits<double>::epsilon());
+
+  const double expected_volume(1. / 3.);
+  const double volume = ExtractDoubleOrThrow(volume_mesh->CalcVolume());
+  EXPECT_NEAR(expected_volume, volume, kTolerance);
+}
+
+GTEST_TEST(VolumeMeshTest, TestCalcVolumeDouble) { TestCalcVolume<double>(); }
+
+GTEST_TEST(VolumeMeshTest, TestCalcVolumeAutoDiffXd) {
+  TestCalcVolume<AutoDiffXd>();
+}
+
 template<typename T>
 void TestCalcBarycentric() {
   const RigidTransform<T> X_WM(

--- a/geometry/proximity/volume_mesh.h
+++ b/geometry/proximity/volume_mesh.h
@@ -223,6 +223,17 @@ class VolumeMesh {
     return volume;
   }
 
+  /** Calculates the volume of `this` mesh by taking the sum of the volume of
+   *  each tetrahedral element.
+   */
+  T CalcVolume() const {
+    T volume(0.0);
+    for (int e = 0; e < num_elements(); ++e) {
+      volume += CalcTetrahedronVolume(VolumeElementIndex(e));
+    }
+    return volume;
+  }
+
   /** Calculate barycentric coordinates with respect to the tetrahedron `e`
    of the point Q'. This operation is expensive compared with going from
    barycentric to Cartesian.


### PR DESCRIPTION
Solves #14205. 

-------------------------------------------------


Moves:
- ComputeEulerCharacteristic(const VolumeMesh<>&)
- CountEdges(const VolumeMesh<>&)
- CountFaces(const VolumeMesh<>&)

from `geometry/proximity/test/make_cylinder_mesh_test.cc`  to `geometry/proximity/proximity_utilities.cc`.

Creates unit tests for the migrated function in `geometry/proximity/test/proximity_utilities_test.cc`.

-------------------------------------------------

Moves:
- CalcTetrahedronMeshVolume(const VolumeMesh<double>& mesh)

from `geometry/proximity/test/make_cylinder_mesh_test.cc` to `VolumeMesh::CalcVolume()`.

Adds unit tests for `VolumeMesh::CalcVolume()` in `geometry/proximity/test/volume_mesh_test.cc`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14209)
<!-- Reviewable:end -->
