### PR TITLE
Rewrite of MeshcatContactVisualizer

### DIFF
--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -627,6 +627,8 @@ void DefineFrameworkPySemantics(py::module m) {
             py::arg("context"), py::arg("value"), py_rvp::reference,
             // Keep alive, ownership: `return` keeps `context` alive.
             py::keep_alive<0, 2>(), doc.InputPort.FixValue.doc)
+        .def("HasValue", &InputPort<T>::HasValue, py::arg("context"),
+            doc.InputPort.HasValue.doc)
         .def("get_system", &InputPort<T>::get_system, py_rvp::reference,
             doc.InputPort.get_system.doc);
 

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -639,6 +639,7 @@ class TestGeneral(unittest.TestCase):
         self.assertIsInstance(fixed.GetMutableData(), AbstractValue)
         input_port = system.get_input_port(0)
 
+        self.assertTrue(input_port.HasValue(context))
         value = input_port.Eval(context)
         self.assertEqual(type(value), type(model_value.get_value()))
         self.assertEqual(value, model_value.get_value())
@@ -655,6 +656,7 @@ class TestGeneral(unittest.TestCase):
         system.get_input_port(0).FixValue(context, np_value)
         input_port = system.get_input_port(0)
 
+        self.assertTrue(input_port.HasValue(context))
         value = input_port.Eval(context)
         self.assertEqual(type(value), np.ndarray)
         np.testing.assert_equal(value, np_value)


### PR DESCRIPTION
I looked more closely at the code because I hit a bug where the contact force IDs were incrementing unstably even though my scene was in steady state.  It caused flickering contact forces, and ground the performance in meshcat to a halt.

I found the current implementation to be unnecessarily complex and inefficient.  This PR cleans it up.

As a bonus, I've also added arrow heads to the cylinders, and changed the colors to match the contact forces in drake visualizer.  The overall result improves the visualization quite a bit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14210)
<!-- Reviewable:end -->
