### PR TITLE
model_directives: Use normalized path when comparing old vs. new paths

### DIFF
--- a/common/find_runfiles.cc
+++ b/common/find_runfiles.cc
@@ -76,7 +76,13 @@ RunfilesSingleton Create() {
   if (result.runfiles) {
     for (const auto& key_value : result.runfiles->EnvVars()) {
       if (key_value.first == "RUNFILES_DIR") {
-        result.runfiles_dir = key_value.second;
+        // N.B. We must normalize the path; otherwise the path may include
+        // `parent/./path` if the binary was run using `./bazel-bin/target` vs
+        // `bazel-bin/target`.
+        // TODO(eric.cousineau): Show this in Drake itself. This behavior was
+        // encountered in Anzu issue 5653, in a Python binary.
+        result.runfiles_dir =
+            filesystem::path(key_value.second).lexically_normal().string();
         break;
       }
     }

--- a/common/test/find_runfiles_test.cc
+++ b/common/test/find_runfiles_test.cc
@@ -6,6 +6,7 @@
 #include "drake/common/filesystem.h"
 #include "drake/common/temp_directory.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/common/text_logging.h"
 
 namespace drake {
 namespace {
@@ -14,6 +15,7 @@ GTEST_TEST(FindRunfilesTest, AcceptanceTest) {
   EXPECT_TRUE(HasRunfiles());
   const auto result = FindRunfile(
       "drake/common/test/find_resource_test_data.txt");
+  drake::log()->debug("result.abspath: {}", result.abspath);
   EXPECT_GT(result.abspath.size(), 0);
   EXPECT_TRUE(filesystem::is_regular_file({result.abspath}));
   EXPECT_EQ(result.error, "");


### PR DESCRIPTION
Otherwise, we can get different runfiles paths if you run a binary
via `./bazel-bin/target` vs. `bazel-bin/target`

See Anzu issue 5653 for concrete motivation.

\cc @siyuanfeng-tri 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14211)
<!-- Reviewable:end -->
