### PR TITLE
[WIP] Some experimental hacks to AutoDiffScalar<VectorXd> specialization.

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -123,6 +123,7 @@ drake_cc_library(
 
 drake_cc_library(
     name = "autodiff",
+    srcs = ["autodiff.cc"],
     hdrs = [
         "autodiff.h",
         "autodiff_overloads.h",

--- a/common/autodiff.cc
+++ b/common/autodiff.cc
@@ -1,1 +1,4 @@
 #include "drake/common/autodiff.h"
+
+drake::internal::Pool& drake::internal::PoolVectorXd::pool_ =
+    drake::internal::PoolVectorXd::static_pool();

--- a/common/autodiff.cc
+++ b/common/autodiff.cc
@@ -1,3 +1,1 @@
 #include "drake/common/autodiff.h"
-
-drake::internal::Pool drake::internal::PoolVectorXd::pool_(128, 10);

--- a/common/autodiff.cc
+++ b/common/autodiff.cc
@@ -1,0 +1,3 @@
+#include "drake/common/autodiff.h"
+
+drake::internal::Pool drake::internal::PoolVectorXd::pool_(128, 10);

--- a/common/autodiffxd.h
+++ b/common/autodiffxd.h
@@ -530,7 +530,7 @@ class PoolVectorXd {
       __m256d* d = reinterpret_cast<__m256d*>(data);
 
       __m256d inn = _mm256_loadu_pd(in);  // May be unaligned.
-      *d = _mm256_sub_pd(*d, inn);  // d = d + inn
+      *d = _mm256_sub_pd(*d, inn);  // d = d - inn
 
       inn = _mm256_loadu_pd(in + 4);
       *(d + 1) = _mm256_sub_pd(*(d + 1), inn);
@@ -544,7 +544,7 @@ class PoolVectorXd {
       data += 16; in += 16;
     }
     while (data != this_end()) {
-      *data++ += *in++;
+      *data++ -= *in++;
     }
     return *this;
   }

--- a/common/test/autodiffxd_heap_test.cc
+++ b/common/test/autodiffxd_heap_test.cc
@@ -29,101 +29,101 @@ class AutoDiffXdHeapTest : public ::testing::Test {
 // implementations may be vulnerable to dead-code elimination.
 
 TEST_F(AutoDiffXdHeapTest, Abs) {
-  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 0});
   volatile auto v = abs(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Abs2) {
-  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 0});
   volatile auto v = abs2(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Acos) {
-  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 0});
   volatile auto v = acos(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Asin) {
-  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 0});
   volatile auto v = asin(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Atan) {
-  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 0});
   volatile auto v = atan(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Atan2) {
   {
-    LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+    LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 0});
     volatile auto v = atan2(x_ + y_, y_);
   }
   {
-    LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+    LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 0});
     // Right-hand parameter moves are blocked by code in Eigen; see #14039.
     volatile auto v = atan2(y_, x_ + y_);
   }
 }
 
 TEST_F(AutoDiffXdHeapTest, Cos) {
-  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 0});
   volatile auto v = cos(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Cosh) {
-  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 0});
   volatile auto v = cosh(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Exp) {
-  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 0});
   volatile auto v = exp(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Log) {
-  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 0});
   volatile auto v = log(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Min) {
-  LimitMalloc guard({.max_num_allocations = 4, .min_num_allocations = 4});
+  LimitMalloc guard({.max_num_allocations = 4, .min_num_allocations = 0});
   volatile auto v = min(x_ + y_, y_);
   volatile auto w = min(x_, x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Max) {
-  LimitMalloc guard({.max_num_allocations = 4, .min_num_allocations = 4});
+  LimitMalloc guard({.max_num_allocations = 4, .min_num_allocations = 0});
   volatile auto v = max(x_ + y_, y_);
   volatile auto w = max(x_, x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Pow) {
-  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 0});
   volatile auto v = pow(x_ + y_, 2.0);
 }
 
 TEST_F(AutoDiffXdHeapTest, Sin) {
-  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 0});
   volatile auto v = sin(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Sinh) {
-  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 0});
   volatile auto v = sinh(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Sqrt) {
-  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 0});
   volatile auto v = sqrt(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Tan) {
-  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 0});
   volatile auto v = tan(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Tanh) {
-  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 0});
   volatile auto v = tanh(x_ + y_);
 }
 

--- a/common/test/autodiffxd_make_coherent_test.cc
+++ b/common/test/autodiffxd_make_coherent_test.cc
@@ -17,7 +17,7 @@ GTEST_TEST(AutoDiffXdMakeCoherentTest, AutoDiffEmptyDerivatives) {
   autodiffxd_make_coherent(donor, &recipient);
   EXPECT_EQ(4., recipient.value());
   EXPECT_TRUE(
-      CompareMatrices(recipient.derivatives(), Eigen::Vector2d::Zero()));
+      CompareMatrices(recipient.const_derivatives(), Eigen::Vector2d::Zero()));
 }
 
 GTEST_TEST(AutoDiffXdMakeCoherentTest, AutoDiffNonemptyDerivatives) {

--- a/common/test/autodiffxd_test.h
+++ b/common/test/autodiffxd_test.h
@@ -58,7 +58,7 @@ class AutoDiffXdTest : public ::testing::Test {
 
     return CompareMatrices(
         value_and_der_x, value_and_der_3,
-        2.0 * std::numeric_limits<double>::epsilon(),
+        8 * std::numeric_limits<double>::epsilon(),
         MatrixCompareType::relative)
       << "\n(where xd.size() = " << e_xd.derivatives().size() << ")";
   }

--- a/geometry/proximity/test/distance_to_point_callback_test.cc
+++ b/geometry/proximity/test/distance_to_point_callback_test.cc
@@ -99,7 +99,7 @@ class PointShapeAutoDiffSignedDistanceTester {
       error = true;
       failure << "Test distance has no derivatives";
     }
-    const Vector3d ddistance_dp_WQ = result.distance.derivatives();
+    const Vector3d ddistance_dp_WQ = result.distance.const_derivatives();
     const Vector3d grad_W_val = math::autoDiffToValueMatrix(result.grad_W);
     if (grad_W_val.array().isNaN().any()) {
       if (error) failure << "\n";

--- a/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/minimum_distance_constraint_test.cc
@@ -55,7 +55,7 @@ class TwoFreeSpheresMinimumDistanceTest : public TwoFreeSpheresTest {
     EXPECT_TRUE(constraint.CheckSatisfied(q_autodiff));
     EXPECT_EQ(y_double(0), 0);
     EXPECT_TRUE(CompareMatrices(
-        y_autodiff(0).derivatives(),
+        y_autodiff(0).const_derivatives(),
         Eigen::Matrix<double, kNumPositionsForTwoFreeBodies, 1>::Zero()));
     CheckConstraintEvalNonsymbolic(constraint, q_autodiff, 1E-12);
   }

--- a/multibody/tree/multibody_forces.h
+++ b/multibody/tree/multibody_forces.h
@@ -35,7 +35,11 @@ class MultibodyForces {
   explicit MultibodyForces(const internal::MultibodyTree<T>& model);
 
   /// Number of bodies and number of generalized velocities overload. This
-  /// constructor is useful for constructing the MultibodyForces structure
+  /// constructor is us
+  ///
+  ///
+  ///
+  /// --eful for constructing the MultibodyForces structure
   /// before a MultibodyPlant has been consructed.
   MultibodyForces(int nb, int nv);
 

--- a/tools/cc_toolchain/bazel.rc
+++ b/tools/cc_toolchain/bazel.rc
@@ -1,9 +1,13 @@
 # Disable ccache due to incompatibility with Bazel.
 build --action_env=CCACHE_DISABLE=1
 
-# Add C++17 compiler flags.
-build --cxxopt=-std=c++17
-build --host_cxxopt=-std=c++17
+# Add C++17 compiler flags and enable use of 256-bit AVX2 a FMA instructions.
+# The tune=haswell setting encourages the optimizer to choose 256-bit
+# instructions rather than pairs of 128-bit ones.
+build --cxxopt=-std=c++17 --cxxopt=-mavx2 --cxxopt=-mfma \
+      --cxxopt=-mtune=haswell
+build --host_cxxopt=-std=c++17 --host_cxxopt=-mavx2 --host_cxxopt=-mfma \
+      --host_cxxopt=-mtune=haswell
 
 # When compiling with Drake as the main WORKSPACE (i.e., if and only if this
 # rcfile is loaded), we enable -Werror by default for Drake's *own* targets,
@@ -13,7 +17,7 @@ build --host_cxxopt=-std=c++17
 # command line, or promote *any* warnings even from externals to errors via
 # --copt=-Werror.
 #
-# When compiilng Drake as an external package, this rcfile is not loaded and we
+# When compiling Drake as an external package, this rcfile is not loaded and we
 # won't promote warnings to errors by default.
 build --define=DRAKE_WERROR=ON
 


### PR DESCRIPTION
(Please ignore for now)
I'm playing with our specialization of AutoDiffScalar<VectorXd> to see if we can get rid of all the heap allocation but keep the move optimizations. Just seeing if I can get it through CI. Larded down with instrumentation and bugcatchers at the moment -- don't draw any performance conclusions yet.

cc @rpoyner-tri

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14214)
<!-- Reviewable:end -->
