### PR TITLE
[geometry] New tetrahedral mesh of Box conforms to its medial axis.

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -255,6 +255,7 @@ drake_cc_library(
     srcs = ["make_box_mesh.cc"],
     hdrs = ["make_box_mesh.h"],
     deps = [
+        ":proximity_utilities",
         ":surface_mesh",
         ":volume_mesh",
         ":volume_to_surface_mesh",
@@ -659,6 +660,7 @@ drake_cc_googletest(
     name = "make_box_mesh_test",
     deps = [
         ":make_box_mesh",
+        ":proximity_utilities",
         "//common/test_utilities:eigen_matrix_compare",
     ],
 )

--- a/geometry/proximity/make_box_mesh.cc
+++ b/geometry/proximity/make_box_mesh.cc
@@ -1,8 +1,335 @@
 #include "drake/geometry/proximity/make_box_mesh.h"
 
+#include <algorithm>
+#include <array>
+#include <unordered_set>
+
+#include "drake/geometry/proximity/proximity_utilities.h"
+
 namespace drake {
 namespace geometry {
 namespace internal {
+
+using Eigen::Vector3d;
+using std::unordered_set;
+
+/* Subdivides a virtual cube to have up to six tetrahedra such that they
+ share the diagonal v0v6 (see ordering below). We allow repeated vertices in
+ the virtual cube and will skip tetrahedra with repeated vertices.
+
+ We assume the input vertex indices (represented as VolumeVertexIndex) are in
+ this ordering:
+   1. Four vertices v0,v1,v2,v3 of the "bottom" face in counterclockwise
+      order when look from "above" the cube.
+   2. Four vertices v4,v5,v6,v7 of the "top" face matching v0,v1,v2,v3,
+      respectively.
+
+                       v4-----------v7
+                      /|           /|
+                     / |          / |
+                    /  |         /  |
+                   /   |        /   |
+                  /    v0------/----v3
+                 /    /       /    /
+                v5-----------v6   /
+                |   /        |   /
+                |  /         |  /
+                | /          | /
+                |/           |/
+                v1-----------v2
+
+ Examples of cases with repeated vertices.
+ - If v0 == v3 and v1 == v2, we will have a prism instead of a cube and will
+   get 3 tetrahedra instead of 6 tetrahedra.
+ - If v0 == v1 == v2 == v3, we will have a pyramid instead of a cube and will
+   get 2 tetrahedra instead of 6 tetrahedra.
+
+ @note   This function is purely topological because it takes only
+ VolumeVertexIndex into account without attempting to access coordinates of
+ the vertices.
+ */
+std::vector<VolumeElement> SplitToTetrahedra(
+    VolumeVertexIndex v0, VolumeVertexIndex v1, VolumeVertexIndex v2,
+    VolumeVertexIndex v3, VolumeVertexIndex v4, VolumeVertexIndex v5,
+    VolumeVertexIndex v6, VolumeVertexIndex v7) {
+  std::vector<VolumeElement> elements;
+  elements.reserve(6);
+  VolumeVertexIndex previous = v1;
+  for (const VolumeVertexIndex& next : {v2, v3, v7, v4, v5, v1}) {
+    // Allow distinct vertex indices only.
+    if (unordered_set<VolumeVertexIndex>({previous, next, v0, v6}).size() ==
+        4) {
+      elements.emplace_back(previous, next, v0, v6);
+    }
+    previous = next;
+  }
+  return elements;
+}
+
+template <typename T>
+VolumeMesh<T> MakeBoxVolumeMeshWithMa(const Box& box) {
+  // Begin: Notes For Developers.
+  //
+  // <h1> Illustration in two dimensions </h1>
+  //
+  // To illustrate the idea of the algorithm, first we describe an analogy in
+  // two dimensions. Given a rectangle V₀V₁V₂V₃ in ℝ², we can imagine the
+  // process of growing four trapezoids, each of which is from an edge of the
+  // rectangle, as shown in these three pictures:
+  //
+  //     V₀                         V₁     V₀                         V₁
+  //     +--------------------------+      +--------------------------+
+  //     | ↘----------------------↙ |      | ↘                      ↙ |
+  //     | |M₀                  M₁| |      |   ↘------------------↙   |
+  //     | |                      | |      |   |                  |   |
+  //     | |M₂                  M₃| |      |   ↗------------------↖   |
+  //     | ↗----------------------↖ |      | ↗                      ↖ |
+  //     +--------------------------+      +--------------------------+
+  //     V₂                         V₃     V₂                         V₃
+  //
+  //     V₀                         V₁
+  //     +--------------------------+
+  //     | ↘                      ↙ |
+  //     |   ↘                  ↙   |      ↙↘↖↗ border medial lines
+  //     |    M₀==============M₁    |      ==== central medial lines
+  //     |   ↗                  ↖   |
+  //     | ↗                      ↖ |
+  //     +--------------------------+
+  //     V₂                         V₃
+  //
+  // Notice that:
+  //
+  // 1. For each vertex Vᵢ of the rectangle, its virtual copy (vertex Mᵢ in the
+  //    pictures) moves along an MA's line from Vᵢ towards an MA's vertex. We
+  //    call this line a border medial line (drawn with arrows in the picture).
+  // 2. For each edge VᵢVⱼ, its virtual copy (edge MᵢMⱼ in the pictures)
+  //    shrinks and moves towards the MA's line connecting two MA's vertices
+  //    in the middle of the rectangle. We call this line the central medial
+  //    line (drawn with "==" in the picture). In some cases (e.g., edges M₀M₁
+  //    or M₂M₃ in the above picture), MᵢMⱼ ends up to coincide with the
+  //    central medial line. In other cases (e.g., edges M₀M₂ or M₁M₃ in the
+  //    above picture), MᵢMⱼ shrink to a single point, which is an MA's vertex
+  //    on the central medial line.
+  // 3. For each trapezoid VᵢVⱼMᵢMⱼ, it grows until its edge MᵢMⱼ reaches the
+  //    central medial line (either by becoming the central medial line or by
+  //    shrinking to a vertex of the central medial line). Notice that two of
+  //    the four trapezoids degenerate to triangles. The four (possibly
+  //    degenerated) trapezoids partition the rectangle V₀V₁V₂V₃.
+  //
+  // In two dimensions, the algorithm would partition the rectangle into four
+  // blocks, each of which is a (possibly degenerated) trapezoid. Then, we
+  // can subdivide each block into triangles for the output mesh.
+  //
+  // To handle both the normal trapezoids and the degenerated trapezoids
+  // seamlessly, we can use two duplicated vertices of a trapezoid to
+  // represent a triangle. In other words, the MA-partitioning algorithm
+  // always gives virtual trapezoids VᵢVⱼMᵢMⱼ, and the triangle-subdivision
+  // subroutine generates triangles VᵢVⱼMᵢ and VⱼMᵢMⱼ, and filters out the
+  // triangle VⱼMᵢMⱼ when Mᵢ=Mⱼ.
+  //
+  // In summary, this is the algorithm in two dimensions:
+  //
+  //   For each edge VᵢVⱼ of the rectangle {
+  //     Create a virtual trapezoid VᵢVⱼMᵢMⱼ, where Mᵢ and Mⱼ are the
+  //     matching MA's vertices of Vᵢ and Vⱼ, respectively.
+  //     Subdivide the virtual trapezoid VᵢVⱼMᵢMⱼ into one or two triangles.
+  //   }
+  //
+  // Notice that if we are given a square instead of a rectangle, all the
+  // virtual trapezoids would degenerate to triangles. Therefore, the
+  // triangle-subdivision subroutine will generate one triangle for each
+  // virtual trapezoid.
+  //
+  // This algorithm in two dimensions generate four and six triangles
+  // in the output meshes for the input square and rectangle, respectively.
+  //
+  //
+  // <h1> Algorithm in three dimensions </h1>
+  //
+  // This is the main idea of our implementation in three dimensions analogous
+  // to the example in two dimensions above.
+  //
+  //   For each face VᵢVⱼVₖVₗ of the input box {
+  //     Create a virtual frustum VᵢVⱼVₖVₗMᵢMⱼMₖMₗ, where Mᵢ, Mⱼ, Mₖ, Mₗ
+  //     are the matching MA's vertices of Vᵢ, Vⱼ, Vₖ, Vₗ, respectively.
+  //     Subdivide each virtual frustum (topological cube) into six
+  //     tetrahedra and filter out tetrahedra with duplicated vertices.
+  //   }
+  //
+  // In this discussion, a frustum is a three-dimensional polytope with two
+  // parallel rectangular faces (one face is smaller than the other) and four
+  // trapezoidal faces connecting the two rectangular faces. The following
+  // pictures show the top views of a 6-face frustum, a frustum that
+  // degenerates to a 5-face (topological) "triangular prism", and a frustum
+  // that degenerates to a 5-face right square pyramid.
+  //
+  //     Vᵢ                         Vⱼ     Vᵢ                         Vⱼ
+  //     +--------------------------+      +--------------------------+
+  //     | ↘  Mᵢ               Mⱼ ↙ |      | ↘                      ↙ |
+  //     |   ↘------------------↙   |      |   ↘                  ↙   |
+  //     |   |                  |   |      |     x--------------x     |
+  //     |   ↗------------------↖   |      |   ↗                  ↖   |
+  //     | ↗  Mₖ               Mₗ ↖ |      | ↗                      ↖ |
+  //     +--------------------------+      +--------------------------+
+  //     Vₖ                         Vₗ     Vₖ                         Vₗ
+  //
+  //             Vᵢ          Vⱼ
+  //             +-----------+          These pictures are intended to be
+  //             | ↘       ↙ |          three dimensional with the axis of
+  //             |   ↘   ↙   |          the third dimension perpendicular
+  //             |     x     |          to the screen. The arrows go from
+  //             |   ↗   ↖   |          lower altitude to higher altitude.
+  //             | ↗       ↖ |          All arrows have the same slope 1.
+  //             +-----------+
+  //             Vₖ          Vₗ
+  //
+  // In all cases, we allow the virtual frustum to have duplicated vertices
+  // in order to represent the degenerated ones (prisms and pyramids)
+  // seamlessly. (A prism is a virtual frustum with Mᵢ = Mₖ and Mⱼ = Mₗ. A
+  // pyramid is a virtual frustum with  Mᵢ = Mⱼ = Mₖ = Mₗ.)
+  //
+  // End: Notes for Developers.
+
+  // The mesh vertices comprise the eight box vertices and up to four unique
+  // MA's vertices inside the box. Later each virtual frustum will comprise
+  // eight (possibly with duplication) indices into mesh_vertices.
+  std::vector<VolumeVertex<T>> mesh_vertices;
+  mesh_vertices.reserve(12);
+
+  // The eight mesh vertices of the box are indexed by the 2x2x2 array `v`,
+  // where the i,j,k indices for v[i][j][k] correspond to the x,y,z
+  // directions of the box's frame, respectively.
+  //
+  //         v001------v011
+  //        /|        /|           Z
+  //       / |       / |           |
+  //      /  v000---/--v010        |
+  //     /  /      /  /            o------Y  The box's frame's origin is
+  //    /  /      /  /            /          actually at the center of the box.
+  //   v101------v111            /
+  //   | /       | /            X
+  //   |/        |/
+  //   v100------v110
+  //
+  VolumeVertexIndex v[2][2][2];
+  const Vector3d half_box = box.size() / 2.;
+  for (const int i : {0, 1}) {
+    const double x(i == 0 ? -half_box.x() : half_box.x());
+    for (const int j : {0, 1}) {
+      const double y(j == 0 ? -half_box.y() : half_box.y());
+      for (const int k : {0, 1}) {
+        const double z(k == 0 ? -half_box.z() : half_box.z());
+        v[i][j][k] = VolumeVertexIndex(mesh_vertices.size());
+        mesh_vertices.emplace_back(x, y, z);
+      }
+    }
+  }
+  // Virtually we pretend that there are 8 MA's vertices--corresponding
+  // to the 8 box vertices--even though actually there are at most 4 unique
+  // MA's vertices (and could be as low as only 1) inside the box. The 8
+  // virtual MA's vertices are represented by the 2x2x2 array `m`, where the
+  // virtual MA's vertex m[i][j][k] corresponds to the box's vertex
+  // v[i][j][k]. Some of the m[i][j][k]'s are duplicated by design.
+  VolumeVertexIndex m[2][2][2];
+  const double min_half_box = half_box.minCoeff();
+  // Similar to half_box describing the half dimensions of the box,
+  // half_central_Ma describes the half dimensions of the central piece of MA.
+  // Unlike half_box having all three non-zero components, half_central_Ma
+  // always has at least one zero-valued component by design. It has one,
+  // two, or three zero-valued components when the central piece of MA is a
+  // rectangle, a line segment, or a point, respectively. We will use the
+  // zero-valued components of half_central_Ma as indicators of duplicated
+  // m[i][j][k].
+  const Vector3d half_central_Ma_before_tolerancing =
+      half_box - Vector3d::Constant(min_half_box);
+  const Vector3d half_central_Ma =
+      (half_central_Ma_before_tolerancing.array() >
+       DistanceToPointRelativeTolerance(min_half_box))
+          .select(half_central_Ma_before_tolerancing, 0.);
+  for (const int i : {0, 1}) {
+    const double x = i == 0 ? -half_central_Ma.x() : half_central_Ma.x();
+    for (const int j : {0, 1}) {
+      const double y = j == 0 ? -half_central_Ma.y() : half_central_Ma.y();
+      for (const int k : {0, 1}) {
+        const double z = k == 0 ? -half_central_Ma.z() : half_central_Ma.z();
+        // Zero-valued components of half_central_Ma indicate duplication of
+        // the virtual MA's vertices m[i][j][k].
+        const bool duplicate_in_i = i == 1 && half_central_Ma.x() == 0;
+        const bool duplicate_in_j = j == 1 && half_central_Ma.y() == 0;
+        const bool duplicate_in_k = k == 1 && half_central_Ma.z() == 0;
+        // Since the loops are executed in lexicographic order of (i,j,k),
+        // we know that the assignment of a potential duplicated entry
+        // m[1][j][k], m[i][1][k], or m[i][j][1] must be preceded already by
+        // the assignment of m[0][j][k], m[i][0][k], or m[i][j][0],
+        // respectively. There is no uninitialized-memory read of m[][][].
+        m[i][j][k] = duplicate_in_i
+                         ? m[0][j][k]
+                         : duplicate_in_j
+                               ? m[i][0][k]
+                               : duplicate_in_k
+                                     ? m[i][j][0]
+                                     : VolumeVertexIndex(mesh_vertices.size());
+        if (!duplicate_in_i && !duplicate_in_j && !duplicate_in_k) {
+          mesh_vertices.emplace_back(x, y, z);
+        }
+      }
+    }
+  }
+  // 8 box vertices + at most 4 MA's vertices.
+  DRAKE_DEMAND(mesh_vertices.size() <= 12);
+
+  std::vector<VolumeElement> mesh_elements;
+  mesh_elements.reserve(24);
+  auto append =
+      [&mesh_elements](const std::vector<VolumeElement>& new_elements) {
+        mesh_elements.insert(mesh_elements.end(), new_elements.begin(),
+                             new_elements.end());
+      };
+
+  // We design the ordering of the 8 vertices of each virtual frustum, so
+  // that all SplitToTetrahedra() of all virtual frusta are conforming.
+  // Here conforming means a tetrahedron of one virtual frustum and another
+  // tetrahedron of another virtual frustum intersect in their shared face,
+  // or shared edge, or shared vertex, i.e., there is no partial overlap.
+  //
+  // This picture is useful for visualizing construction of the six virtual
+  // frustra. The virtual vertices m[i][j][k] are supposed to be inside the
+  // box, but we draw them outside the box for clarity. Here we draw the
+  // m[i][j][k] as 8 separated vertices, even though some of them are
+  // actually duplicated.
+  //
+  //         v001------v011
+  //        /|        /|                m001--m011           Z
+  //       / |       / |               /|    /|              |
+  //      /  v000---/--v010           / m000/-m010           |
+  //     /  /      /  /              / /   / /               o------Y
+  //    /  /      /  /              m101--m111              /
+  //   v101------v111               |/    |/               /
+  //   | /       | /                m100--m110            X
+  //   |/        |/
+  //   v100------v110
+  //
+
+  // front face (+X)
+  append(SplitToTetrahedra(m[1][0][0], m[1][1][0], m[1][1][1], m[1][0][1],
+                           v[1][0][0], v[1][1][0], v[1][1][1], v[1][0][1]));
+  // back face (-X)
+  append(SplitToTetrahedra(m[0][0][0], m[0][0][1], m[0][1][1], m[0][1][0],
+                           v[0][0][0], v[0][0][1], v[0][1][1], v[0][1][0]));
+  // right face (+Y)
+  append(SplitToTetrahedra(m[0][1][0], m[0][1][1], m[1][1][1], m[1][1][0],
+                           v[0][1][0], v[0][1][1], v[1][1][1], v[1][1][0]));
+  // left face (-Y)
+  append(SplitToTetrahedra(m[0][0][0], m[1][0][0], m[1][0][1], m[0][0][1],
+                           v[0][0][0], v[1][0][0], v[1][0][1], v[0][0][1]));
+  // top face (+Z)
+  append(SplitToTetrahedra(m[0][0][1], m[1][0][1], m[1][1][1], m[0][1][1],
+                           v[0][0][1], v[1][0][1], v[1][1][1], v[0][1][1]));
+  // bottom face (-Z)
+  append(SplitToTetrahedra(m[0][0][0], m[0][1][0], m[1][1][0], m[1][0][0],
+                           v[0][0][0], v[0][1][0], v[1][1][0], v[1][0][0]));
+  return {std::move(mesh_elements), std::move(mesh_vertices)};
+}
 
 int CalcSequentialIndex(int i, int j, int k, const Vector3<int>& num_vertices) {
   DRAKE_DEMAND(0 <= i && i < num_vertices.x());
@@ -125,6 +452,9 @@ VolumeMesh<T> MakeBoxVolumeMesh(const Box& box, double resolution_hint) {
 
   return VolumeMesh<T>(std::move(elements), std::move(vertices));
 }
+
+template VolumeMesh<double> MakeBoxVolumeMeshWithMa(const Box&);
+template VolumeMesh<AutoDiffXd> MakeBoxVolumeMeshWithMa(const Box&);
 
 // Explicit instantiations for double and AutoDiffXd to support the
 // documentation.

--- a/geometry/proximity/make_box_mesh.h
+++ b/geometry/proximity/make_box_mesh.h
@@ -14,6 +14,148 @@ namespace drake {
 namespace geometry {
 namespace internal {
 
+/* Generates a tetrahedral volume mesh of a given box by medial axis (MA)
+ subdivision. The box is subdivided into blocks using its MA, and then the
+ blocks are subdivided into tetrahedra. Using this mesh with MeshFieldLinear,
+ we can represent the distance-to-boundary function φ of the box accurately and
+ economically. The same thing is true for a hydroelastic pressure field that
+ is a constant scaling of φ.
+
+ The box's MA is the set of all points having more than one closest point on
+ the box's boundary. (See https://en.wikipedia.org/wiki/Medial_axis for more
+ about the medial axis.)
+
+ The following picture schematically shows the analogy of MA in two dimensions.
+ MA of the rectangle (drawn with "--", "|", and "+") consists of the (open)
+ line segments (drawn with arrows) from each of the rectangle's vertices to a
+ medial vertex (drawn with "o") and the (closed) line segment (drawn with "==")
+ connecting the two medial vertices.
+
+      U                          V                    U           V
+      +--------------------------+                    +-----------+
+      | ↘                      ↙ |                    | ↘       ↙ |
+      |   ↘                  ↙   |                    |   ↘   ↙   |
+      |  M₀ o==============o M₁  |                    |  M₀ o     |
+      |   ↗                  ↖   |                    |   ↗   ↖   |
+      | ↗                      ↖ |                    | ↗       ↖ |
+      +--------------------------+                    +-----------+
+  In 2D, a rectangle's MA has 2 vertices.   In 2D, a square's MA has 1 vertex.
+
+ In three dimensions, a box B's MA has one, two, or four vertices Mᵢ at
+ the points having four or more closest points on the box's boundary.
+ The MA comprises (L for set of lines, P for set of polygons):
+
+ L1. the eight (open) line segments from B's vertex to MA's vertex,
+ L2. zero, one, or four line segments (aligned to B's frame) connecting MA's
+     vertices Mᵢ and Mⱼ together,
+ P3. the twelve polygons that are isosceles trapezoids or isosceles triangles
+     (Each polygon is bounded by an edge VᵢVⱼ of the box B, two lines VᵢMₖ and
+     VⱼMₗ in L1, and, for trapezoids, the line MₖMₗ in L2, i.e., Mₖ ≠ Mₗ),
+ P4. possibly one rectangle or square of four MA's vertices bounded by the
+     four lines in L2 (The rectangle degenerates to one MA's vertex for a
+     cube and the line in L2 for a long box with two small square faces).
+
+ The following examples describe MAs of boxes with various shapes.
+
+ Example 1. MA of a box with three distinct dimensions bz < bx < by comprises
+   four isosceles triangles (not shown), eight isosceles trapezoids (not shown),
+   and one rectangle M₀M₁M₂M₃, as shown in this picture:
+
+          V₇----------------------------------------------V₆
+         /|                                              /|
+        / |                                             / |
+       /  |                                            /  |      z
+      /   |    M₃---------------------------------M₂  /   |      |
+     /    V₃--/----------------------------------/---/----V₂     |
+    /    /   /                                  /   /    /       o-------y
+   V₄----------------------------------------------V₅   /       /
+   |   /   /                                  /    |   /       /
+   |  /   M₀---------------------------------M₁    |  /       x
+   | /                                             | /
+   |/                                              |/
+   V₀----------------------------------------------V₁
+
+   In this example, the MA's faces are:
+     - the triangular faces (Vᵢ, Mⱼ, Vₖ):
+       (V₀, M₀, V₄), (V₁, M₁, V₅), (V₂, M₂, V₆), (V₃, M₃, V₇),
+     - the trapezoidal faces (Vᵢ, Mⱼ, Mₖ, Vₗ):
+       (V₀, M₀, M₃, V₃), (V₄, M₀, M₃, V₇), (V₁, M₁, M₀, V₀), (V₅, M₁, M₀, V₄),
+       (V₂, M₂, M₁, V₁), (V₆, M₂, M₁, V₅), (V₃, M₃, M₂, V₂), (V₇, M₃, M₂, V₆),
+     - and the rectangular face: (M₀, M₁, M₂, M₃).
+
+ Example 2. MA of a long box with two small square faces (the box dimensions
+   are bz = bx < by) comprises eight isosceles triangles (not shown) and four
+   isosceles trapezoids (not shown) that share the medial edge M₀M₁, as shown
+   in this picture:
+
+        V₇----------------------------------------V₆
+       / |                                       / |
+      /  |                                      /  |      z
+     /   |                                     /   |      |
+   V₄----------------------------------------V₅    |      |
+   |     |   M₀------------------------M₁    |     |      o-------y
+   |    V₃-----------------------------------|----V₂     /
+   |   /                                     |   /      /
+   |  /                                      |  /      x
+   | /                                       | /
+   V₀----------------------------------------V₁
+
+   In this example, the MA's faces are:
+     - the triangular faces (Vᵢ, Mⱼ, Vₖ):
+       (V₀, M₀, V₄), (V₁, M₁, V₅), (V₂, M₁, V₆), (V₃, M₀, V₇),
+       (V₀, M₀, V₃), (V₄, M₀, V₇), (V₂, M₁, V₁), (V₆, M₁, V₅),
+     - and the trapezoidal faces (Vᵢ, Mⱼ, Mₖ, Vₗ):
+       (V₁, M₁, M₀, V₀), (V₅, M₁, M₀, V₄), (V₃, M₀, M₁, V₂), (V₇, M₀, M₁, V₆).
+
+ Example 3. MA of a cube comprises twelve isosceles triangles (not shown)
+   sharing the medial vertex M₀, as shown in this picture:
+
+        V₇--------------V₆
+       / |             / |
+      /  |            /  |      z
+     /   |           /   |      |
+   V₄--------------V₅    |      |
+   |     |   M₀    |     |      o-------y
+   |    V₃---------|----V₂     /
+   |   /           |   /      /
+   |  /            |  /      x
+   | /             | /
+   V₀--------------V₁
+
+  In this example, the MA's faces are the triangular faces (Vᵢ, M₀, Vₖ):
+       (V₀, M₀, V₄), (V₁, M₀, V₅), (V₂, M₀, V₆), (V₃, M₀, V₇),
+       (V₀, M₀, V₃), (V₄, M₀, V₇), (V₂, M₀, V₁), (V₆, M₀, V₅),
+       (V₁, M₀, V₀), (V₅, M₀, V₄), (V₃, M₀, V₂), (V₇, M₀, V₆).
+
+ The output mesh will have these properties:
+
+   1. The generated vertices are unique. There are no repeating vertices in
+      the list of vertex coordinates.
+   2. The generated tetrahedra are _conforming_. Two tetrahedra intersect in
+      their shared face, or shared edge, or shared vertex, or not at all.
+      There is no partial overlapping of two tetrahedra.
+   3. Depending on the shape of the box, the mesh has 12, 16, or 24
+      tetrahedra and 9, 10, or 12 vertices, respectively.
+      3.1 The mesh of a cube has 12 tetrahedra. (MA has only one vertex
+          in the cube's interior.)
+      3.2 The mesh of a long box with two small square faces has 16
+          tetrahedra. (MA has only two vertices in the box's interior
+          forming a line segment.)
+      3.3 The mesh of a shallow box with two big square faces has 24
+          tetrahedra. (MA has four vertices in the box's interior forming a
+          square.)
+      3.4 The mesh of a box with three distinct dimensions also has 24
+          tetrahedra. (MA has four vertices in the box's interior forming a
+          rectangle.)
+
+ @param[in] box
+     The box shape specification (see drake::geometry::Box).
+ @retval volume_mesh
+ @tparam_nonsymbolic_scalar
+ */
+template <typename T>
+VolumeMesh<T> MakeBoxVolumeMeshWithMa(const Box& box);
+
 /*
  Generates a tetrahedral volume mesh of a given box by subdividing the box
  into _rectangular cells_ (volume bounded by six axis-aligned faces) and

--- a/geometry/proximity/test/make_box_field_test.cc
+++ b/geometry/proximity/test/make_box_field_test.cc
@@ -1,5 +1,6 @@
 #include "drake/geometry/proximity/make_box_field.h"
 
+#include <cmath>
 #include <limits>
 
 #include <gtest/gtest.h>
@@ -47,6 +48,59 @@ GTEST_TEST(MakeBoxFieldTest, MakeBoxPressureField) {
   for (const VolumeVertexIndex& v : boundary_vertex_indices) {
     double pressure = pressure_field.EvaluateAtVertex(v);
     EXPECT_EQ(pressure, 0.0);
+  }
+}
+
+GTEST_TEST(MakeBoxFieldTest, MakeBoxPressureFieldInMeshWithMedialAxis) {
+  // Box dimensions are set to avoid symmetry.
+  const Box box(1.0, 2.0, 3.0);
+  const VolumeMesh<double> mesh = MakeBoxVolumeMeshWithMa<double>(box);
+
+  // A reasonable positive value for testing the maximum pressure value.
+  const double kElasticModulus = 1.0e5;
+  VolumeMeshFieldLinear<double, double> pressure_field =
+      MakeBoxPressureField<double>(box, &mesh, kElasticModulus);
+
+  // Check that all vertices have their pressure values within the range of
+  // zero to kElasticModulus, and their minimum and maximum values are indeed
+  // zero and kElasticModulus respectively.
+  double max_pressure = std::numeric_limits<double>::lowest();
+  double min_pressure = std::numeric_limits<double>::max();
+  for (VolumeVertexIndex v(0); v < mesh.num_vertices(); ++v) {
+    double pressure = pressure_field.EvaluateAtVertex(v);
+    EXPECT_LE(pressure, kElasticModulus);
+    EXPECT_GE(pressure, 0.0);
+    if (pressure > max_pressure) {
+      max_pressure = pressure;
+    }
+    if (pressure < min_pressure) {
+      min_pressure = pressure;
+    }
+  }
+  EXPECT_EQ(min_pressure, 0.0);
+  EXPECT_EQ(max_pressure, kElasticModulus);
+
+  // Check that all boundary vertices have zero pressure.
+  std::vector<VolumeVertexIndex> boundary_vertex_indices =
+      CollectUniqueVertices(IdentifyBoundaryFaces(mesh.tetrahedra()));
+  for (const VolumeVertexIndex& v : boundary_vertex_indices) {
+    double pressure = pressure_field.EvaluateAtVertex(v);
+    EXPECT_EQ(pressure, 0.0);
+  }
+
+  // Check that there is no constant-pressure tetrahedron.
+  const double kPressureTolerance =
+      kElasticModulus * std::numeric_limits<double>::epsilon();
+  for (VolumeElementIndex e(0); e < mesh.num_elements(); ++e) {
+    const double pressure_v0 =
+        pressure_field.EvaluateAtVertex(mesh.element(e).vertex(0));
+    bool same_pressure = true;
+    for (int i = 1; i < mesh.kVertexPerElement && same_pressure; ++i) {
+      const double pressure_vi =
+          pressure_field.EvaluateAtVertex(mesh.element(e).vertex(i));
+      same_pressure = kPressureTolerance >= std::abs(pressure_v0 - pressure_vi);
+    }
+    EXPECT_FALSE(same_pressure);
   }
 }
 

--- a/geometry/proximity/test/make_box_mesh_test.cc
+++ b/geometry/proximity/test/make_box_mesh_test.cc
@@ -1,13 +1,340 @@
 #include "drake/geometry/proximity/make_box_mesh.h"
 
+#include <algorithm>
+#include <cmath>
+
 #include <gtest/gtest.h>
 
+#include "drake/common/eigen_types.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/geometry/proximity/proximity_utilities.h"
 
 namespace drake {
 namespace geometry {
 namespace internal {
+
 namespace {
+
+using Eigen::Vector3d;
+using std::abs;
+using std::find;
+using std::find_if;
+using std::for_each;
+
+// TODO(#14235): Move IsTetrahedronRespectingMa() to possibly
+//  proximity_utilities and extend it to other shape primitives.
+
+// Returns true if `tetrahedron` in `mesh` has its four vertices belonging to
+// the same block of the medial-axis subdivision of `box`, i.e., there is a
+// box's face to which all four vertices are _closest_. Here a vertex is
+// _closest_ to a box's face when there is no other closer face. Notice that
+// a vertex may have multiple closest faces, i.e., it is on the medial axis.
+//
+// We use the given `tolerance` for comparing distances.
+//
+// @pre No vertex of the tetrahedron is outside the box.
+//
+// Here we omit the frame notations because everything is expressed in the
+// frame of the box. It might change in the future.
+bool IsTetrahedronRespectingMa(const VolumeElement& tetrahedron,
+                               const VolumeMesh<double>& mesh, const Box& box,
+                               const double tolerance) {
+  const Vector3d half_size = box.size() / 2.;
+  auto distance_to_boundary = [&half_size](const Vector3d& point_in_box) {
+    Vector3d abs_point = point_in_box.array().abs();
+    // Verify that the point is in the box.
+    DRAKE_DEMAND((half_size.array() >= abs_point.array()).all());
+    return (half_size - abs_point).minCoeff();
+  };
+  // The six faces of the box are the ±X, ±Y, ±Z faces.
+  for (int axis = 0; axis < 3; ++axis) {
+    for (const double face_bound : {-half_size[axis], half_size[axis]}) {
+      bool closest_to_this_face = true;
+      for (int i = 0; i < mesh.kVertexPerElement && closest_to_this_face; ++i) {
+        const Vector3d vertex = mesh.vertex(tetrahedron.vertex(i)).r_MV();
+        const double distance_to_this_face = abs(vertex[axis] - face_bound);
+        closest_to_this_face =
+            tolerance >= distance_to_this_face - distance_to_boundary(vertex);
+      }
+      if (closest_to_this_face) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+// Verifies that a tetrahedral mesh of a box from MakeBoxVolumeMeshWithMa()
+// satisfies all these properties:
+//
+//   A. The mesh is conforming.
+//   B. The mesh conforms to the box.
+//   C. The mesh conforms to the box's medial axis.
+//
+// We will use this function in all unit tests of MakeBoxVolumeMeshWithMa().
+//
+// @retval true when all conditions passed.
+//
+// Here we omit the frame notations because everything is expressed in the
+// frame of the box. It might change in the future.
+bool VerifyBoxMeshWithMa(const VolumeMesh<double>& mesh, const Box& box) {
+  // A. The mesh is conforming.
+  // A1. The mesh has unique vertices.
+  const int num_vertices = mesh.num_vertices();
+  for (VolumeVertexIndex i(0); i < num_vertices; ++i) {
+    for (VolumeVertexIndex j(i + 1); j < num_vertices; ++j) {
+      const bool vertex_is_unique =
+          mesh.vertex(i).r_MV() != mesh.vertex(j).r_MV();
+      EXPECT_TRUE(vertex_is_unique) << "The mesh has duplicated vertices.";
+      if (!vertex_is_unique) {
+        return false;
+      }
+    }
+  }
+  // A2. Euler characteristic = 1. This is a necessary condition (but may not
+  //     be sufficient) for conforming tetrahedra (two tetrahedra intersect in
+  //     their shared face, or shared edge, or shared vertex, or not at all.
+  //     There is no partial overlapping of two tetrahedra.).
+  const int euler_characteristic = ComputeEulerCharacteristic(mesh);
+  EXPECT_EQ(1, euler_characteristic)
+      << "The mesh's tetrahedra are not conforming because the mesh's Euler "
+         "characteristic is "
+      << euler_characteristic << " instead of 1.";
+  if (euler_characteristic != 1) {
+    return false;
+  }
+
+  // B. The mesh conforms to the box.
+  // B1. The mesh has a vertex at each of the 8 corner points of the box.
+  const Vector3d half_size = box.size() / 2.;
+  for (const double x : {-half_size.x(), half_size.x()}) {
+    for (const double y : {-half_size.y(), half_size.y()}) {
+      for (const double z : {-half_size.z(), half_size.z()}) {
+        const VolumeVertex<double> corner(x, y, z);
+        const bool corner_is_a_mesh_vertex =
+            mesh.vertices().end() !=
+            find_if(mesh.vertices().begin(), mesh.vertices().end(),
+                    [&corner](const VolumeVertex<double>& v) -> bool {
+                      return v.r_MV() == corner.r_MV();
+                    });
+        EXPECT_TRUE(corner_is_a_mesh_vertex)
+            << "A corner point of the box is missing from the mesh vertices.";
+        if (!corner_is_a_mesh_vertex) {
+          return false;
+        }
+      }
+    }
+  }
+  // B2. No mesh's vertex is outside the box.
+  for (VolumeVertexIndex i(0); i < num_vertices; ++i) {
+    const bool vertex_is_inside_or_on_boundary =
+        (mesh.vertex(i).r_MV().array().abs() <= half_size.array()).all();
+    EXPECT_TRUE(vertex_is_inside_or_on_boundary)
+        << "A mesh vertex is outside the box.";
+    if (!vertex_is_inside_or_on_boundary) {
+      return false;
+    }
+  }
+  // B3. The volume of the mesh equals the volume of the box.
+  const double mesh_volume = mesh.CalcVolume();
+  const double box_volume = box.width() * box.depth() * box.height();
+  // We estimate the tolerance from:
+  // 1. There are about 4 multiply+add in calculating a tetrahedron's volume,
+  //    so we have 8 epsilons.
+  // 2. The rounding errors accumulate over the number of tetrahedra.
+  const double volume_tolerance(mesh.num_elements() * 8.0 *
+                                std::numeric_limits<double>::epsilon());
+  EXPECT_NEAR(mesh_volume, box_volume, volume_tolerance)
+      << "The mesh's volume does not equal the box's volume.";
+  if (abs(mesh_volume - box_volume) > volume_tolerance) {
+    return false;
+  }
+
+  // C. The mesh conforms to the box's medial axis.
+  // C1. No tetrahedron has all four vertices on the box's boundary, i.e.,
+  //     each tetrahedron has at least one interior vertex.
+  std::vector<VolumeVertexIndex> boundary_vertices =
+      CollectUniqueVertices(IdentifyBoundaryFaces(mesh.tetrahedra()));
+  for (const VolumeElement tetrahedron : mesh.tetrahedra()) {
+    bool tetrahedron_has_an_interior_vertex = false;
+    for (int i = 0;
+         i < mesh.kVertexPerElement && !tetrahedron_has_an_interior_vertex;
+         ++i) {
+      tetrahedron_has_an_interior_vertex =
+          boundary_vertices.end() == find(boundary_vertices.begin(),
+                                          boundary_vertices.end(),
+                                          tetrahedron.vertex(i));
+    }
+    EXPECT_TRUE(tetrahedron_has_an_interior_vertex)
+        << "A tetrahedron has all its vertices on the box's boundary.";
+    if (!tetrahedron_has_an_interior_vertex) {
+      return false;
+    }
+  }
+  // C2. No tetrahedron has all four vertices at the same distance to the
+  //     box's boundary.
+  // Assume the mesh already passes B2 (no mesh's vertex is outside the box).
+  auto distance_to_boundary = [&half_size](const Vector3d& point_in_box) {
+    Vector3d abs_point = point_in_box.array().abs();
+    // Verify that the point is in the box.
+    DRAKE_DEMAND((half_size.array() >= abs_point.array()).all());
+    return (half_size - abs_point).minCoeff();
+  };
+  const double distance_tolerance =
+      DistanceToPointRelativeTolerance(half_size.maxCoeff());
+  for (const VolumeElement tetrahedron : mesh.tetrahedra()) {
+    const double distance_v0 =
+        distance_to_boundary(mesh.vertex(tetrahedron.vertex(0)).r_MV());
+    bool different_distance_from_v0 = false;
+    for (int i = 1; i < mesh.kVertexPerElement && !different_distance_from_v0;
+         ++i) {
+      different_distance_from_v0 =
+          distance_tolerance <
+          abs(distance_v0 -
+              distance_to_boundary(mesh.vertex(tetrahedron.vertex(i)).r_MV()));
+    }
+    EXPECT_TRUE(different_distance_from_v0)
+        << "A tetrahedron has all vertices at the same distances to"
+           " the box's boundary.";
+    if (!different_distance_from_v0) {
+      return false;
+    }
+  }
+  // C3. Each tetrahedron conforms to MA.
+  // Assume the mesh already passes B2 (no mesh's vertex is outside the box).
+  for (const VolumeElement tetrahedron : mesh.tetrahedra()) {
+    bool tetrahedron_conform_to_MA =
+        IsTetrahedronRespectingMa(tetrahedron, mesh, box, distance_tolerance);
+    EXPECT_TRUE(tetrahedron_conform_to_MA)
+        << "A tetrahedron does not conform to the medial axis of the box.";
+    if (!tetrahedron_conform_to_MA) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+// This test should cover every program statement in MakeBoxVolumeMeshWithMa()
+// and its subroutine SplitToTetrahedra(). You can use kcov to verify.
+GTEST_TEST(MakeBoxVolumeMeshWithMaTest, StatementCoverage) {
+  // A cube allows degeneracy of MA in all three directions, so we can
+  // exercise every line of code. Testing with a non-cube box (for
+  // example, a box of size 2x4x6) will miss some lines of code.
+  const Box box(Box::MakeCube(1.3));
+  const VolumeMesh<double> mesh = MakeBoxVolumeMeshWithMa<double>(box);
+  EXPECT_EQ(mesh.num_elements(), 12);
+  EXPECT_EQ(mesh.num_vertices(), 9);
+  EXPECT_TRUE(VerifyBoxMeshWithMa(mesh, box));
+}
+
+// This test should cover all boolean conditions of MakeBoxVolumeMeshWithMa().
+// We want to test all boolean terms (also known as conditions) in a
+// statement like this:
+//
+//     if (!duplicate_in_i && !duplicate_in_j && !duplicate_in_k) {
+//        ...
+//     }
+//
+// We can use this table (T=true, F=false):
+// +---------- -- -+---------- -- -+---------------+-----------------+
+// |duplicate_in_i |duplicate_in_j |duplicate_in_k | test parameter  |
+// +---------- -- -+---------- -- -+---------------+-----------------+
+// |       T       |       T       |       T       | Box(2, 2, 2)    |
+// |       F       |       F       |       T       | Box(6, 4, 2)    |
+// |       T       |       F       |       F       | Box(2, 6, 4)    |
+// +---------- -- -+---------- -- -+---------------+-----------------+
+//
+// We do not test all 2³ = 8 combinations. We only pick enough test parameters
+// to cover each boolean term with the values of true and false at least once.
+// Notice that the two combinations {(F,F,F),(T,T,T)} would have done the
+// job; however, (F,F,F) is infeasible because at least in one of the index
+// i,j, or k, we must have duplicated vertices by design.
+GTEST_TEST(MakeBoxVolumeMeshWithMaTest, ConditionCoverage) {
+  // +---------- -- -+---------- -- -+---------------+-----------------+
+  // |duplicate_in_i |duplicate_in_j |duplicate_in_k | test parameter  |
+  // +---------- -- -+---------- -- -+---------------+-----------------+
+  // |       T       |       T       |       T       | Box(2, 2, 2)    |
+  // +---------- -- -+---------- -- -+---------------+-----------------+
+  {
+    const Box box(2., 2., 2.);
+    const VolumeMesh<double> mesh = MakeBoxVolumeMeshWithMa<double>(box);
+    EXPECT_EQ(mesh.num_elements(), 12);
+    EXPECT_EQ(mesh.num_vertices(), 9);
+    EXPECT_TRUE(VerifyBoxMeshWithMa(mesh, box));
+  }
+  // +---------- -- -+---------- -- -+---------------+-----------------+
+  // |duplicate_in_i |duplicate_in_j |duplicate_in_k | test parameter  |
+  // +---------- -- -+---------- -- -+---------------+-----------------+
+  // |       F       |       F       |       T       | Box(6, 4, 2)    |
+  // +---------- -- -+---------- -- -+---------------+-----------------+
+  {
+    const Box box(6., 4., 2.);
+    const VolumeMesh<double> mesh = MakeBoxVolumeMeshWithMa<double>(box);
+    EXPECT_EQ(mesh.num_elements(), 24);
+    EXPECT_EQ(mesh.num_vertices(), 12);
+    EXPECT_TRUE(VerifyBoxMeshWithMa(mesh, box));
+  }
+  // +---------- -- -+---------- -- -+---------------+-----------------+
+  // |duplicate_in_i |duplicate_in_j |duplicate_in_k | test parameter  |
+  // +---------- -- -+---------- -- -+---------------+-----------------+
+  // |       T       |       F       |       F       | Box(2, 6, 4)    |
+  // +---------- -- -+---------- -- -+---------------+-----------------+
+  {
+    const Box box(2., 6., 4.);
+    const VolumeMesh<double> mesh = MakeBoxVolumeMeshWithMa<double>(box);
+    EXPECT_EQ(mesh.num_elements(), 24);
+    EXPECT_EQ(mesh.num_vertices(), 12);
+    EXPECT_TRUE(VerifyBoxMeshWithMa(mesh, box));
+  }
+}
+
+// This test should cover all representative parameters, i.e., all equivalent
+// classes of input boxes for MakeBoxVolumeMeshWithMa(). Here we define the
+// equivalent classes of Box(a,b,c) by the repeated box dimensions and their
+// relative length to the remaining dimension like this:
+//
+// a = b = c  a cube
+// a = b < c  a long box with two small square faces
+// a = b > c  a shallow box with two big square faces
+// a < b < c  a box with three distinct dimensions
+//
+// We do not distinguish a permutation of a,b,c from another, i.e., Box(2,4,6)
+// and Box(6,4,2) are considered in the same equivalent class.
+GTEST_TEST(MakeBoxVolumeMeshWithMaTest, ParameterValueCoverage) {
+  // A box with same three dimensions.
+  {
+    const Box box(2., 2., 2.);
+    const VolumeMesh<double> mesh = MakeBoxVolumeMeshWithMa<double>(box);
+    EXPECT_EQ(mesh.num_elements(), 12);
+    EXPECT_EQ(mesh.num_vertices(), 9);
+    EXPECT_TRUE(VerifyBoxMeshWithMa(mesh, box));
+  }
+  // A box with two same short dimensions.
+  {
+    const Box box(2., 4., 2.);
+    const VolumeMesh<double> mesh = MakeBoxVolumeMeshWithMa<double>(box);
+    EXPECT_EQ(mesh.num_elements(), 16);
+    EXPECT_EQ(mesh.num_vertices(), 10);
+    EXPECT_TRUE(VerifyBoxMeshWithMa(mesh, box));
+  }
+  // A box with two same long dimensions.
+  {
+    const Box box(4., 4., 2.);
+    const VolumeMesh<double> mesh = MakeBoxVolumeMeshWithMa<double>(box);
+    EXPECT_EQ(mesh.num_elements(), 24);
+    EXPECT_EQ(mesh.num_vertices(), 12);
+    EXPECT_TRUE(VerifyBoxMeshWithMa(mesh, box));
+  }
+  // A box with three distinct dimensions.
+  {
+    const Box box(2., 4., 6.);
+    const VolumeMesh<double> mesh = MakeBoxVolumeMeshWithMa<double>(box);
+    EXPECT_EQ(mesh.num_elements(), 24);
+    EXPECT_EQ(mesh.num_vertices(), 12);
+    EXPECT_TRUE(VerifyBoxMeshWithMa(mesh, box));
+  }
+}
 
 GTEST_TEST(MakeBoxVolumeMeshTest, CalcSequentialIndex) {
   const Vector3<int> num_vertices(3, 2, 5);


### PR DESCRIPTION
Solve #11906. Partially solve #12128.

The following picture shows examples of this kind of meshes. Some tetrahedra are hidden to show how the meshes look inside.

![image](https://user-images.githubusercontent.com/42557859/96898309-6cc34400-1444-11eb-9a95-1ba4ad5b0ee2.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14216)
<!-- Reviewable:end -->
