### PR TITLE
meshcat: tweak contact visualization

### DIFF
--- a/bindings/pydrake/systems/test/meshcat_visualizer_test.py
+++ b/bindings/pydrake/systems/test/meshcat_visualizer_test.py
@@ -231,7 +231,7 @@ class TestMeshcat(unittest.TestCase):
         plant.WeldFrames(
             A=plant.world_frame(),
             B=plant.GetFrameByName("link", table_model),
-            X_AB=RigidTransform(RotationMatrix.MakeXRotation(0.1)))
+            X_AB=RigidTransform(RotationMatrix.MakeXRotation(0.2)))
 
         plant.Finalize()
 
@@ -284,7 +284,7 @@ class TestMeshcat(unittest.TestCase):
             contact_input_port.get_index()).get_value()
 
         self.assertGreater(contact_results.num_point_pair_contacts(), 0)
-        self.assertEqual(len(contact_viz._contacts), 4)
+        self.assertEqual(len(contact_viz._published_contacts), 4)
 
     def test_texture_override(self):
         """Draws a textured box to test the texture override pathway."""


### PR DESCRIPTION
don't call set_object unless a new contact pair appears in the contact results
draw both contact forces (equal and opposite)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14218)
<!-- Reviewable:end -->
