### PR TITLE
[render] Add base-line color images to RenderEngineGl (no textured objects)

### DIFF
--- a/geometry/render/gl_renderer/BUILD.bazel
+++ b/geometry/render/gl_renderer/BUILD.bazel
@@ -40,6 +40,7 @@ drake_cc_package_library_gl_per_os(
         ":opengl_geometry",
         ":render_engine_gl",
         ":render_engine_gl_factory",
+        ":render_engine_gl_params",
         ":shader_program",
         ":shader_program_data",
         ":shape_meshes",
@@ -94,6 +95,7 @@ drake_cc_library_gl_ubuntu_only(
     deps = [
         ":opengl_context",
         ":opengl_geometry",
+        ":render_engine_gl_params",
         ":shader_program",
         ":shader_program_data",
         ":shape_meshes",
@@ -119,12 +121,21 @@ drake_cc_library(
     ],
     deps = select({
         "//tools/cc_toolchain:apple": [
+            ":render_engine_gl_params",
             "//geometry/render:render_engine",
         ],
         "//conditions:default": [
             ":render_engine_gl",
         ],
     }),
+)
+
+drake_cc_library(
+    name = "render_engine_gl_params",
+    hdrs = ["render_engine_gl_params.h"],
+    deps = [
+        "//geometry:rgba",
+    ],
 )
 
 drake_cc_library_gl_ubuntu_only(
@@ -204,6 +215,7 @@ drake_cc_googletest_gl_ubuntu_only(
     deps = [
         ":render_engine_gl",
         "//common:find_resource",
+        "//common/test_utilities:expect_no_throw",
         "//common/test_utilities:expect_throws_message",
         "//geometry/render:render_label",
         "//systems/sensors:color_palette",

--- a/geometry/render/gl_renderer/buffer_dim.h
+++ b/geometry/render/gl_renderer/buffer_dim.h
@@ -46,7 +46,7 @@ class BufferDim {
  The `frame_buffer` is configured with two additional objects:
 
    - the `value_texture` which stores the result of the rendering operations
-     (i.e., depth values, and, soon, color values and label values).
+     (i.e., depth, color, or label values).
    - A z-buffer that OpenGL uses to do hidden surface removal. The values in
      this buffer are strictly for internal OpenGL consumption.
 */

--- a/geometry/render/gl_renderer/gl_common.h
+++ b/geometry/render/gl_renderer/gl_common.h
@@ -13,7 +13,7 @@ namespace internal {
  structures. Because it serves as an index, we use kTypeCount to declare the
  *number* of index values available (relying on C++'s default behavior of
  assigning sequential values in enumerations).  */
-enum RenderType { kLabel = 0, kDepth, kTypeCount };
+enum RenderType { kColor = 0, kLabel, kDepth, kTypeCount };
 
 }  // namespace internal
 }  // namespace render

--- a/geometry/render/gl_renderer/no_render_engine_gl_factory.cc
+++ b/geometry/render/gl_renderer/no_render_engine_gl_factory.cc
@@ -1,10 +1,11 @@
 #include "drake/geometry/render/gl_renderer/render_engine_gl_factory.h"
+#include "drake/geometry/render/render_engine_gl_params.h"
 
 namespace drake {
 namespace geometry {
 namespace render {
 
-std::unique_ptr<RenderEngine> MakeRenderEngineGl() {
+std::unique_ptr<RenderEngine> MakeRenderEngineGl(RenderEngineGlParams = {}) {
   throw std::runtime_error(
       "RenderEngineGl was not compiled. You'll need to use a different render "
       "engine.");

--- a/geometry/render/gl_renderer/opengl_geometry.h
+++ b/geometry/render/gl_renderer/opengl_geometry.h
@@ -93,11 +93,13 @@ struct OpenGlInstance {
    @pre The shader program data has valid shader ids.  */
   OpenGlInstance(const OpenGlGeometry& g_in,
                  const math::RigidTransformd& pose_in,
-                 const Vector3<double>& scale_in, ShaderProgramData depth_data,
-                 ShaderProgramData label_data)
+                 const Vector3<double>& scale_in, ShaderProgramData color_data,
+                 ShaderProgramData depth_data, ShaderProgramData label_data)
       : geometry(g_in), X_WG(pose_in), scale(scale_in) {
+    DRAKE_DEMAND(color_data.shader_id().is_valid());
     DRAKE_DEMAND(depth_data.shader_id().is_valid());
     DRAKE_DEMAND(label_data.shader_id().is_valid());
+    shader_data[RenderType::kColor] = std::move(color_data);
     shader_data[RenderType::kDepth] = std::move(depth_data);
     shader_data[RenderType::kLabel] = std::move(label_data);
     DRAKE_DEMAND(geometry.is_defined());

--- a/geometry/render/gl_renderer/render_engine_gl.cc
+++ b/geometry/render/gl_renderer/render_engine_gl.cc
@@ -6,6 +6,8 @@
 
 #include <fmt/format.h>
 
+#include "drake/common/unused.h"
+
 namespace drake {
 namespace geometry {
 namespace render {
@@ -49,9 +51,110 @@ struct RegistrationData {
   const PerceptionProperties& properties;
 };
 
+/* The built-in shader for Rgba diffuse colored objects. This shader supports
+ all geometries because it provides a default diffuse color if none is given. */
+class DefaultRgbaColorShader final : public ShaderProgram {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DefaultRgbaColorShader)
+
+  explicit DefaultRgbaColorShader(const Rgba& default_diffuse)
+      : ShaderProgram(), default_diffuse_(default_diffuse) {
+    LoadFromSources(kVertexShader, kFragmentShader);
+    diffuse_color_loc_ = GetUniformLocation("diffuse_color");
+    normal_mat_loc_ = GetUniformLocation("normal_mat");
+  }
+
+  void SetInstanceParameters(const ShaderProgramData& data) const final {
+    glUniform4fv(diffuse_color_loc_, 1,
+                 data.value().get_value<Vector4<float>>().data());
+  }
+
+ private:
+  std::unique_ptr<ShaderProgram> DoClone() const final {
+    return make_unique<DefaultRgbaColorShader>(*this);
+  }
+
+  std::optional<ShaderProgramData> DoCreateProgramData(
+      const PerceptionProperties& properties) const final {
+    const Rgba rgba =
+        properties.GetPropertyOrDefault("phong", "diffuse", default_diffuse_);
+    Vector4<float> v4{
+        static_cast<float>(rgba.r()), static_cast<float>(rgba.g()),
+        static_cast<float>(rgba.b()), static_cast<float>(rgba.a())};
+    return ShaderProgramData{shader_id(), AbstractValue::Make(v4)};
+  }
+
+  void DoModelViewMatrix(const Eigen::Matrix4f& X_CglM,
+                         const Vector3d& scale) const override {
+    // When rendering *illuminated* objects, we have to account for the surface
+    // normals. In principle, we only need to *rotate* the normals from the
+    // model frame to the camera frame. However, if the geometry has undergone
+    // non-uniform scaling, we must *first* scale the normals by the inverse
+    // scale. So, the normal_mat below handles the scaling and the rotation. It
+    // relies on the shader to handle normalization of the scaled normals.
+    // This is the quantity historically referred to as gl_NormalMatrix
+    // (available to glsl in the "compatibility profile"). See
+    // https://www.cs.upc.edu/~robert/teaching/idi/GLSLangSpec.4.50.pdf.
+    const Eigen::DiagonalMatrix<float, 3, 3> inv_scale(
+        Vector3<float>(1.0 / scale(0), 1.0 / scale(1), 1.0 / scale(2)));
+    const Eigen::Matrix3f normal_mat = X_CglM.block<3, 3>(0, 0) * inv_scale;
+    glUniformMatrix3fv(normal_mat_loc_, 1, GL_FALSE, normal_mat.data());
+  }
+
+  // The default diffuse value to apply if missing the ("phong", "diffuse")
+  // property.
+  Rgba default_diffuse_;
+
+  // The location of the "diffuse_color" uniform in the shader.
+  GLint diffuse_color_loc_{};
+
+  // The location of the "normal_mat" uniform in the shader.
+  GLint normal_mat_loc_{};
+
+  // The vertex shader:
+  //   - Transforms the vertex into device *and* camera coordinates.
+  //   - Transforms the normal into camera coordinates to be interpolated
+  //     across the triangle.
+  static constexpr char kVertexShader[] = R"""(
+#version 330
+layout(location = 0) in vec3 p_MV;
+layout(location = 1) in vec3 n_M;
+uniform mat4 model_view_matrix;
+uniform mat4 projection_matrix;
+uniform mat3 normal_mat;
+varying vec3 n_C;
+void main() {
+  // p_DV; the vertex position in device coordinates.
+  gl_Position = projection_matrix * model_view_matrix * vec4(p_MV, 1);
+
+  // R_CM = normal_mat (although R may also include scaling).
+  n_C = normal_mat * n_M;
+})""";
+
+  // For each fragment from a geometry, compute the per-fragment, illuminated
+  // color.
+  static constexpr char kFragmentShader[] = R"""(
+#version 330
+uniform vec4 diffuse_color;
+varying vec3 n_C;
+out vec4 color;
+void main() {
+  // The light is "infinitely" far away in the (0, 0, 1) direction; so it is
+  // a fixed direction to *every* point.
+  vec3 light_dir_C = vec3(0, 0, 1);
+  // NOTE: Depending on triangle size and variance of normal direction over
+  // that triangle, n_C may not be unit length; to play it safe, we blindly
+  // normalize it. Consider *not* normalizing it if it improves performance
+  // without degrading visual quality.
+  vec3 nhat_C = normalize(n_C);
+  vec3 alt_diffuse = diffuse_color.rgb / 200 + vec3(0, 0, 1);
+  color = vec4(diffuse_color.rgb * max(dot(nhat_C, light_dir_C), 0.0),
+               diffuse_color.a);
+})""";
+};
 /* The built-in shader for objects in depth images. By default, the shader
  supports all geometries.  */
-class DefaultDepthShader final : public internal::ShaderProgram {
+class DefaultDepthShader final : public ShaderProgram {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DefaultDepthShader)
 
@@ -137,7 +240,7 @@ void main() {
  gives for geometry depends on the label encoder function. The shader program
  assumes the encoder will either provide a label or throw based on the given
  perception properties.  */
-class DefaultLabelShader final : public internal::ShaderProgram {
+class DefaultLabelShader final : public ShaderProgram {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DefaultLabelShader)
 
@@ -203,14 +306,28 @@ void main() {
 
 }  // namespace
 
-RenderEngineGl::RenderEngineGl()
-    : RenderEngine(),
-      opengl_context_(make_shared<OpenGlContext>()) {
+RenderEngineGl::RenderEngineGl(RenderEngineGlParams params)
+    : RenderEngine(params.default_label),
+      opengl_context_(make_shared<OpenGlContext>()),
+      parameters_(std::move(params)) {
   // Configuration of basic OpenGl state.
   opengl_context_->MakeCurrent();
   glClipControl(GL_UPPER_LEFT, GL_NEGATIVE_ONE_TO_ONE);
   glClearDepth(1.0);
   glEnable(GL_DEPTH_TEST);
+  // Generally, there should be no blending for depth and label images. We'll
+  // selectively enable blending for color images.
+  glDisable(GL_BLEND);
+  // We blend the rgb values (the first two parameters), but simply accumulate
+  // transparency (the last two parameters).
+  glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE);
+
+  // Color shaders. See documentation on GetShaderProgram. We want color from
+  // texture to be "more preferred" than color from rgba, so we add the
+  // texture color shader *after* the rgba color shader.
+  AddShader(make_unique<DefaultRgbaColorShader>(params.default_diffuse),
+            RenderType::kColor);
+
   // Depth shaders -- a single shader that accepts all geometry.
   AddShader(make_unique<DefaultDepthShader>(), RenderType::kDepth);
 
@@ -232,9 +349,58 @@ void RenderEngineGl::UpdateViewpoint(const RigidTransformd& X_WR) {
   X_CW_ = X_WR.inverse();
 }
 
-void RenderEngineGl::RenderColorImage(const CameraProperties&, bool,
-                                      ImageRgba8U*) const {
-  throw std::runtime_error("RenderEngineGl cannot render color images");
+void RenderEngineGl::RenderColorImage(const CameraProperties& camera,
+                                      bool show_window,
+                                      ImageRgba8U* color_image_out) const {
+  opengl_context_->MakeCurrent();
+
+  // TODO(SeanCurtis-TRI): For transparency to work properly, I need to
+  //  segregate objects with transparency from those without. The transparent
+  //  geometries then need to be sorted from farthest to nearest the camera and
+  //  rendered in that order. This may lead to shader thrashing. Without this
+  //  ordering, I may not necessarily see objects through transparent surfaces.
+  //  Confirm that VTK handles transparency correctly and do the same.
+
+  const RenderTarget render_target =
+      GetRenderTarget(camera, RenderType::kColor);
+  // TODO(SeanCurtis-TRI) Consider converting Rgba to float[4] as a method on
+  //  Rgba.
+  const Rgba& clear = parameters_.default_clear_color;
+  float clear_color[4] = {
+      static_cast<float>(clear.r()), static_cast<float>(clear.g()),
+      static_cast<float>(clear.b()), static_cast<float>(clear.a())};
+  glClearNamedFramebufferfv(render_target.frame_buffer, GL_COLOR, 0,
+                            &clear_color[0]);
+  glClear(GL_DEPTH_BUFFER_BIT);
+  // We only want blending for color; not for label or depth.
+  glEnable(GL_BLEND);
+
+  // Matrix mapping a geometry vertex from the camera frame C to the device
+  // frame D.
+  const Eigen::Matrix4f X_DC =
+      ComputeGlProjectionMatrix(camera, kGlZNear, kGlZFar);
+
+  for (const auto& [shader_id, shader_ptr] :
+       shader_programs_[RenderType::kColor]) {
+    unused(shader_id);
+    const ShaderProgram& shader_program = *shader_ptr;
+    shader_program.Use();
+
+    shader_program.SetProjectionMatrix(X_DC);
+
+    // Now I need to render the geometries.
+    RenderAt(shader_program, RenderType::kColor);
+    shader_program.Unuse();
+  }
+  glDisable(GL_BLEND);
+
+  // Note: SetWindowVisibility must be called *after* the rendering; setting the
+  // visibility is responsible for taking the target buffer and bringing it to
+  // the front buffer; reversing the order means the image we've just rendered
+  // wouldn't be visible.
+  SetWindowVisibility(camera, show_window, render_target);
+  glGetTextureImage(render_target.value_texture, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+                    color_image_out->size(), color_image_out->at(0, 0));
 }
 
 void RenderEngineGl::RenderDepthImage(const DepthCameraProperties& camera,
@@ -260,7 +426,8 @@ void RenderEngineGl::RenderDepthImage(const DepthCameraProperties& camera,
   //  which rendered outside the depth range.
   const double near_clip = std::max(0.01, camera.z_near - 0.1);
   const double far_clip = camera.z_far + 0.1;
-  // Matrix mapping a geometry vertex from its frame G to the device frame D.
+  // Matrix mapping a geometry vertex from the camera frame C to the device
+  // frame D.
   const Eigen::Matrix4f X_DC =
       ComputeGlProjectionMatrix(camera, near_clip, far_clip);
 
@@ -296,7 +463,8 @@ void RenderEngineGl::RenderLabelImage(const CameraProperties& camera,
   glClearNamedFramebufferfv(render_target.frame_buffer, GL_COLOR, 0,
                             &clear_color[0]);
   glClear(GL_DEPTH_BUFFER_BIT);
-  // Matrix mapping a geometry vertex from its frame G to the device frame D.
+  // Matrix mapping a geometry vertex from the camera frame C to the device
+  // frame D.
   const Eigen::Matrix4f X_DC =
       ComputeGlProjectionMatrix(camera, kGlZNear, kGlZFar);
 
@@ -409,6 +577,7 @@ bool RenderEngineGl::DoRemoveGeometry(GeometryId id) {
       DRAKE_UNREACHABLE();
     };
     const OpenGlInstance& instance = iter->second;
+    remove_from_family(id, instance.shader_data, RenderType::kColor);
     remove_from_family(id, instance.shader_data, RenderType::kDepth);
     remove_from_family(id, instance.shader_data, RenderType::kLabel);
     visuals_.erase(iter);
@@ -455,14 +624,21 @@ void RenderEngineGl::RenderAt(const ShaderProgram& shader_program,
 void RenderEngineGl::ImplementGeometry(const OpenGlGeometry& geometry,
                                        void* user_data, const Vector3d& scale) {
   const RegistrationData& data = *static_cast<RegistrationData*>(user_data);
+  std::optional<ShaderProgramData> color_data =
+      GetShaderProgram(data.properties, RenderType::kColor);
   std::optional<ShaderProgramData> depth_data =
       GetShaderProgram(data.properties, RenderType::kDepth);
   std::optional<ShaderProgramData> label_data =
       GetShaderProgram(data.properties, RenderType::kLabel);
-  DRAKE_DEMAND(depth_data.has_value() && label_data.has_value());
-  visuals_.emplace(data.id, OpenGlInstance(geometry, data.X_WG, scale,
-                                           *depth_data, *label_data));
+  DRAKE_DEMAND(color_data.has_value() && depth_data.has_value() &&
+               label_data.has_value());
 
+  visuals_.emplace(data.id,
+                   OpenGlInstance(geometry, data.X_WG, scale, *color_data,
+                                  *depth_data, *label_data));
+
+  shader_families_[RenderType::kColor][color_data->shader_id()].push_back(
+      data.id);
   shader_families_[RenderType::kDepth][depth_data->shader_id()].push_back(
       data.id);
   shader_families_[RenderType::kLabel][label_data->shader_id()].push_back(
@@ -548,6 +724,8 @@ OpenGlGeometry RenderEngineGl::GetMesh(const string& filename) {
 std::tuple<GLint, GLenum, GLenum> RenderEngineGl::get_texture_format(
     RenderType render_type) {
   switch (render_type) {
+    case RenderType::kColor:
+      return std::make_tuple(GL_RGBA8, GL_RGBA, GL_UNSIGNED_BYTE);
     case RenderType::kLabel:
       // TODO(SeanCurtis-TRI): Ultimately, this should be a 16-bit, signed int.
       return std::make_tuple(GL_RGBA8, GL_RGBA, GL_UNSIGNED_BYTE);
@@ -682,34 +860,49 @@ OpenGlGeometry RenderEngineGl::CreateGlGeometry(const MeshData& mesh_data) {
   // Create the vertex array object (VAO).
   glCreateVertexArrays(1, &geometry.vertex_array);
 
-  const auto& vertices = mesh_data.positions;
-  const auto& indices = mesh_data.indices;
 
   // Create the vertex buffer object (VBO).
   glCreateBuffers(1, &geometry.vertex_buffer);
-  glNamedBufferStorage(geometry.vertex_buffer,
-                       vertices.size() * sizeof(GLfloat), vertices.data(), 0);
-  // Bind the VBO with the VAO.
-  const int kBindingIndex = 0;  // The binding point.
-  glVertexArrayVertexBuffer(geometry.vertex_array, kBindingIndex,
-                            geometry.vertex_buffer, 0, 3 * sizeof(GLfloat));
 
-  // Bind the attribute in vertex shader to the VAO at the same binding point.
-  const int kLocP_ModelAttrib = 0;  // p_Model's location in vertex shader.
-  glVertexArrayAttribFormat(geometry.vertex_array, kLocP_ModelAttrib, 3,
-                            GL_FLOAT, GL_FALSE, 0);
-  glVertexArrayAttribBinding(geometry.vertex_array, kLocP_ModelAttrib,
-                             kBindingIndex);
-  glEnableVertexArrayAttrib(geometry.vertex_array, kLocP_ModelAttrib);
+  // We're representing the vertex data as a concatenation of positions and
+  // normals (i.e., (VVVNNN)). There should be an equal number of vertices and
+  // normals.
+  DRAKE_DEMAND(mesh_data.positions.rows() == mesh_data.normals.rows());
+  const int v_count = mesh_data.positions.rows();
+  vector<GLfloat> vertex_data;
+  // 3 floats each for position and normals.
+  vertex_data.reserve(v_count * (3 + 3));
+  vertex_data.insert(vertex_data.end(), mesh_data.positions.data(),
+                     mesh_data.positions.data() + v_count * 3);
+  vertex_data.insert(vertex_data.end(), mesh_data.normals.data(),
+                     mesh_data.normals.data() + v_count * 3);
+  glNamedBufferStorage(geometry.vertex_buffer,
+                       vertex_data.size() * sizeof(GLfloat),
+                       vertex_data.data(), 0);
+  const int position_attrib = 0;
+  glVertexArrayVertexBuffer(geometry.vertex_array, position_attrib,
+                            geometry.vertex_buffer, 0, 3 * sizeof(GLfloat));
+  glVertexArrayAttribFormat(geometry.vertex_array, position_attrib, 3, GL_FLOAT,
+                            GL_FALSE, 0);
+  glEnableVertexArrayAttrib(geometry.vertex_array, position_attrib);
+
+  const int normal_attrib = 1;
+  glVertexArrayVertexBuffer(
+      geometry.vertex_array, normal_attrib, geometry.vertex_buffer,
+      mesh_data.positions.size() * sizeof(GLfloat), 3 * sizeof(GLfloat));
+  glVertexArrayAttribFormat(geometry.vertex_array, normal_attrib, 3, GL_FLOAT,
+                            GL_FALSE, 0);
+  glEnableVertexArrayAttrib(geometry.vertex_array, normal_attrib);
 
   // Create the index buffer object (IBO).
   glCreateBuffers(1, &geometry.index_buffer);
-  glNamedBufferStorage(geometry.index_buffer, indices.size() * sizeof(GLuint),
-                       indices.data(), 0);
+  glNamedBufferStorage(geometry.index_buffer,
+                       mesh_data.indices.size() * sizeof(GLuint),
+                       mesh_data.indices.data(), 0);
   // Bind IBO with the VAO.
   glVertexArrayElementBuffer(geometry.vertex_array, geometry.index_buffer);
 
-  geometry.index_buffer_size = indices.size();
+  geometry.index_buffer_size = mesh_data.indices.size();
 
   // Note: We won't need to call the corresponding glDeleteVertexArrays or
   // glDeleteBuffers. The meshes we store are "canonical" meshes. Even if a

--- a/geometry/render/gl_renderer/render_engine_gl.h
+++ b/geometry/render/gl_renderer/render_engine_gl.h
@@ -15,6 +15,7 @@
 #include "drake/geometry/render/gl_renderer/gl_common.h"
 #include "drake/geometry/render/gl_renderer/opengl_context.h"
 #include "drake/geometry/render/gl_renderer/opengl_geometry.h"
+#include "drake/geometry/render/gl_renderer/render_engine_gl_params.h"
 #include "drake/geometry/render/gl_renderer/shader_program.h"
 #include "drake/geometry/render/gl_renderer/shape_meshes.h"
 #include "drake/geometry/render/render_engine.h"
@@ -40,7 +41,8 @@ class RenderEngineGl final : public RenderEngine {
   RenderEngineGl& operator=(RenderEngineGl&&) = delete;
   //@}}
 
-  RenderEngineGl();
+  /** Construct an instance of the render engine with the given `params`.  */
+  explicit RenderEngineGl(RenderEngineGlParams params = {});
 
   ~RenderEngineGl() final;
 
@@ -71,6 +73,8 @@ class RenderEngineGl final : public RenderEngine {
   void RenderLabelImage(
       const CameraProperties& camera, bool show_window,
       systems::sensors::ImageLabel16I* label_image_out) const final;
+
+  const RenderEngineGlParams& parameters() const { return parameters_; }
 
   /** @name    Shape reification  */
   //@{
@@ -206,6 +210,9 @@ class RenderEngineGl final : public RenderEngine {
   // So, all of these quantities are simple copy-safe POD (e.g., OpenGlGeometry)
   // or are stashed in a shared pointer.
   std::shared_ptr<internal::OpenGlContext> opengl_context_;
+
+  // The engine's configuration parameters.
+  RenderEngineGlParams parameters_;
 
   // A "shader family" is all of the shaders used to produce a particular image
   // type. Each unique shader is associated with the geometries to which it

--- a/geometry/render/gl_renderer/render_engine_gl_factory.cc
+++ b/geometry/render/gl_renderer/render_engine_gl_factory.cc
@@ -1,13 +1,15 @@
 #include "drake/geometry/render/gl_renderer/render_engine_gl_factory.h"
 
+#include <utility>
+
 #include "drake/geometry/render/gl_renderer/render_engine_gl.h"
 
 namespace drake {
 namespace geometry {
 namespace render {
 
-std::unique_ptr<RenderEngine> MakeRenderEngineGl() {
-  return std::make_unique<RenderEngineGl>();
+std::unique_ptr<RenderEngine> MakeRenderEngineGl(RenderEngineGlParams params) {
+  return std::make_unique<RenderEngineGl>(std::move(params));
 }
 
 }  // namespace render

--- a/geometry/render/gl_renderer/render_engine_gl_factory.h
+++ b/geometry/render/gl_renderer/render_engine_gl_factory.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <optional>
 
+#include "drake/geometry/render/gl_renderer/render_engine_gl_params.h"
 #include "drake/geometry/render/render_engine.h"
 
 namespace drake {
@@ -11,8 +12,22 @@ namespace render {
 
 /** Constructs a RenderEngine implementation which uses a purely OpenGL
  renderer. The engine only works under Ubuntu. If called on a Mac, it will
- produce a "dummy" implementation.  */
-std::unique_ptr<RenderEngine> MakeRenderEngineGl();
+ produce a "dummy" implementation.
+
+ @note %RenderEngineGl behaves a bit differently from other RenderEngine
+ implementations (e.g., RenderEngineVtk) with respect to displayed images.
+ First, %RenderEngineGl can only display a *single* image type at a time. So,
+ if a shown window has been requested for both label and color images, the
+ images will alternate in the same window. Second, the window display draws all
+ images *flipped vertically*. The image produced will be compatible with the
+ Drake ecosystem, only the visualization will be upside down. This has been
+ documented in https://github.com/RobotLocomotion/drake/issues/14254.
+
+ @warning %RenderEngineGl is not threadsafe. If a SceneGraph is instantiated
+ with a RenderEngineGl and there are multiple Context instances for that
+ SceneGraph, rendering in multiple threads may exhibit issues.  */
+std::unique_ptr<RenderEngine> MakeRenderEngineGl(
+    RenderEngineGlParams params = {});
 
 }  // namespace render
 }  // namespace geometry

--- a/geometry/render/gl_renderer/render_engine_gl_params.h
+++ b/geometry/render/gl_renderer/render_engine_gl_params.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "drake/geometry/render/render_label.h"
+#include "drake/geometry/rgba.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+
+/** Construction parameters for RenderEngineGl.  */
+struct RenderEngineGlParams {
+  /** Default render label to apply to a geometry when none is otherwise
+   specified.  */
+  RenderLabel default_label{RenderLabel::kUnspecified};
+
+  /** Default diffuse color to apply to a geometry when none is otherwise
+   specified in the (phong, diffuse) property.  */
+  Rgba default_diffuse{0.9, 0.7, 0.2, 1.0};
+
+  /** The default background color for color images.  */
+  Rgba default_clear_color{204 / 255., 229 / 255., 255 / 255., 1.0};
+};
+
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/gl_renderer/test/opengl_geometry_test.cc
+++ b/geometry/render/gl_renderer/test/opengl_geometry_test.cc
@@ -69,8 +69,11 @@ GTEST_TEST(OpenGlInstanceTest, Construction) {
                                      AbstractValue::Make(7.3)};
   const ShaderProgramData label_data{ShaderId::get_new_id(),
                                      AbstractValue::Make(RenderLabel(13))};
+  const ShaderProgramData color_data(
+      ShaderId::get_new_id(), AbstractValue::Make(33));
 
-  const OpenGlInstance instance{geometry, X_WG, scale, depth_data, label_data};
+  const OpenGlInstance instance{geometry,   X_WG,       scale,
+                                color_data, depth_data, label_data};
 
   EXPECT_EQ(instance.geometry.vertex_array, geometry.vertex_array);
   EXPECT_EQ(instance.geometry.vertex_buffer, geometry.vertex_buffer);
@@ -90,6 +93,11 @@ GTEST_TEST(OpenGlInstanceTest, Construction) {
       label_data.value().get_value<RenderLabel>());
   EXPECT_EQ(instance.shader_data[RenderType::kLabel].shader_id(),
             label_data.shader_id());
+  EXPECT_EQ(
+      instance.shader_data[RenderType::kColor].value().get_value<int>(),
+      color_data.value().get_value<int>());
+  EXPECT_EQ(instance.shader_data[RenderType::kColor].shader_id(),
+            color_data.shader_id());
 }
 
 }  // namespace

--- a/geometry/render/gl_renderer/test/render_engine_gl_test.cc
+++ b/geometry/render/gl_renderer/test/render_engine_gl_test.cc
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"
+#include "drake/common/test_utilities/expect_no_throw.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/geometry_roles.h"
@@ -53,6 +54,7 @@ using std::make_unique;
 using std::unique_ptr;
 using std::unordered_map;
 using systems::sensors::ColorI;
+using systems::sensors::ColorD;
 using systems::sensors::ImageDepth32F;
 using systems::sensors::ImageLabel16I;
 using systems::sensors::ImageRgba8U;
@@ -65,6 +67,10 @@ const double kZNear = 0.1;
 const double kZFar = 5.;
 const double kFovY = M_PI_4;
 const bool kShowWindow = false;
+
+// Each channel of the color image must be within the expected color +/- 1
+// (where each channel is in the range [0, 255]).
+const double kColorPixelTolerance = 1;
 
 // NOTE: The depth tolerance is this large mostly due to the combination of
 // several factors:
@@ -82,10 +88,15 @@ const bool kShowWindow = false;
 // larger (in area) than the default image size.
 const double kDepthTolerance = 1e-3;  // meters.
 
+// Background (sky) and terrain colors.
+const Rgba kBgColor{254 / 255.0, 127 / 255.0, 0.0, 1.0};
+const Rgba kTerrainColor{0, 0, 0, 1};
 // Provide a default visual color for this tests -- it is intended to be
 // different from the default color of the OpenGL render engine.
-const ColorI kDefaultVisualColor = {229u, 229u, 229u};
+const Rgba kDefaultVisualColor{229 / 255.0, 229 / 255.0, 229/ 255.0, 1.0};
 const float kDefaultDistance{3.f};
+
+const RenderLabel kDefaultLabel{13531};
 
 // Values to be used with the "centered shape" tests.
 // The amount inset from the edge of the images to *still* expect terrain
@@ -113,21 +124,55 @@ struct RgbaColor {
   RgbaColor(const ColorI& c, int alpha)
       : r(c.r), g(c.g), b(c.b), a(alpha) {}
   explicit RgbaColor(const uint8_t* p) : r(p[0]), g(p[1]), b(p[2]), a(p[3]) {}
-  explicit RgbaColor(const Vector4d& norm_color)
-      : r(static_cast<int>(norm_color(0) * 255)),
-        g(static_cast<int>(norm_color(1) * 255)),
-        b(static_cast<int>(norm_color(2) * 255)),
-        a(static_cast<int>(norm_color(3) * 255)) {}
+  // We'll allow *implicit* conversion from Rgba to RgbaColor to increase the
+  // utility of IsColorNear(), but only in the scope of this test.
+  // NOLINTNEXTLINE(runtime/explicit)
+  RgbaColor(const Rgba& rgba)
+      : r(static_cast<int>(rgba.r() * 255)),
+        g(static_cast<int>(rgba.g() * 255)),
+        b(static_cast<int>(rgba.b() * 255)),
+        a(static_cast<int>(rgba.a() * 255)) {}
   int r;
   int g;
   int b;
   int a;
 };
 
+std::ostream& operator<<(std::ostream& out, const RgbaColor& c) {
+  out << "(" << c.r << ", " << c.g << ", " << c.b << ", " << c.a << ")";
+  return out;
+}
+
+// Tests color within tolerance.
+bool IsColorNear(
+    const RgbaColor& expected, const RgbaColor& tested,
+    double tolerance = kColorPixelTolerance) {
+  using std::abs;
+  return (abs(expected.r - tested.r) <= tolerance &&
+      abs(expected.g - tested.g) <= tolerance &&
+      abs(expected.b - tested.b) <= tolerance &&
+      abs(expected.a - tested.a) <= tolerance);
+}
+
+// Tests that the color in the given `image` located at screen coordinate `p`
+// matches the `expected` color to within the given `tolerance`.
+::testing::AssertionResult CompareColor(
+    const RgbaColor& expected, const ImageRgba8U& image, const ScreenCoord& p,
+    double tolerance = kColorPixelTolerance) {
+  RgbaColor tested(image.at(p.x, p.y));
+  if (IsColorNear(expected, tested, tolerance)) {
+    return ::testing::AssertionSuccess();
+  }
+  return ::testing::AssertionFailure()
+         << "At pixel " << p << "\n  Expected: " << expected
+         << "\n  Found: " << tested << "\n  with tolerance: " << tolerance;
+}
+
 class RenderEngineGlTest : public ::testing::Test {
  public:
   RenderEngineGlTest()
-      : depth_(kWidth, kHeight),
+      : color_(kWidth, kHeight),
+        depth_(kWidth, kHeight),
         label_(kWidth, kHeight),
         // Looking straight down from 3m above the ground.
         X_WR_(RotationMatrixd{AngleAxisd(M_PI, Vector3d::UnitY()) *
@@ -142,14 +187,29 @@ class RenderEngineGlTest : public ::testing::Test {
   // test.
   void Render(RenderEngineGl* renderer = nullptr,
               const DepthCameraProperties* camera_in = nullptr,
+              ImageRgba8U* color_out = nullptr,
               ImageDepth32F* depth_in = nullptr,
               ImageLabel16I* label_in = nullptr) {
     if (!renderer) renderer = renderer_.get();
     const DepthCameraProperties& camera = camera_in ? *camera_in : camera_;
     ImageLabel16I* label = label_in ? label_in : &label_;
     ImageDepth32F* depth = depth_in ? depth_in : &depth_;
+    ImageRgba8U* color = color_out ? color_out : &color_;
     EXPECT_NO_THROW(renderer->RenderDepthImage(camera, depth));
     EXPECT_NO_THROW(renderer->RenderLabelImage(camera, kShowWindow, label));
+    EXPECT_NO_THROW(renderer->RenderColorImage(camera, kShowWindow, color));
+  }
+
+  // Confirms that all pixels in the member color image have the same value.
+  void VerifyUniformColor(const Rgba& rgba,
+                          const ImageRgba8U* color = nullptr) {
+    if (color == nullptr) color = &color_;
+    const RgbaColor test_color{rgba};
+    for (int y = 0; y < color->height(); ++y) {
+      for (int x = 0; x < color->width(); ++x) {
+        ASSERT_TRUE(CompareColor(test_color, *color, ScreenCoord{x, y}));
+      }
+    }
   }
 
   // Confirms that all pixels in the member label image have the same value.
@@ -231,12 +291,15 @@ class RenderEngineGlTest : public ::testing::Test {
   // member images will be tested.
   void VerifyOutliers(const RenderEngineGl& renderer,
                       const DepthCameraProperties& camera,
-                      ImageDepth32F* depth_in = nullptr,
-                      ImageLabel16I* label_in = nullptr) {
-    ImageDepth32F& depth = depth_in ? *depth_in : depth_;
-    ImageLabel16I& label = label_in ? *label_in : label_;
+                      const ImageRgba8U* color_in = nullptr,
+                      const ImageDepth32F* depth_in = nullptr,
+                      const ImageLabel16I* label_in = nullptr) const {
+    const ImageRgba8U& color = color_in ? *color_in : color_;
+    const ImageDepth32F& depth = depth_in ? *depth_in : depth_;
+    const ImageLabel16I& label = label_in ? *label_in : label_;
 
     for (const auto& screen_coord : GetOutliers(camera)) {
+      EXPECT_TRUE(CompareColor(expected_outlier_color_, color, screen_coord));
       EXPECT_TRUE(IsExpectedDepth(depth, screen_coord, expected_outlier_depth_,
                                   kDepthTolerance))
           << "Depth at: " << screen_coord;
@@ -246,42 +309,70 @@ class RenderEngineGlTest : public ::testing::Test {
     }
   }
 
-  void SetUp() override {}
+  void SetUp() override {
+    ResetExpectations();
+  }
 
   // All tests on this class must invoke this first.
   void SetUp(const RigidTransformd& X_WR, bool add_terrain = false) {
-    renderer_ = make_unique<RenderEngineGl>();
-    renderer_->UpdateViewpoint(X_WR);
+    // TODO(SeanCurtis-TRI): When GCC supports non-trivial designated
+    //  initialization turn this back into:
+    //  const RenderEngineGlParams params{.default_clear_color = kBgColor};
+    RenderEngineGlParams params;
+    params.default_clear_color = kBgColor;
+    renderer_ = make_unique<RenderEngineGl>(params);
+    InitializeRenderer(X_WR, add_terrain, renderer_.get());
+    // Ensure that we the test default visual color is different from the
+    // render engine's default color.
+    EXPECT_FALSE(IsColorNear(kDefaultVisualColor,
+                             renderer_->parameters().default_diffuse));
+  }
+
+  // Tests that instantiate their own renderers can initialize their renderers
+  // with this method.
+  void InitializeRenderer(const RigidTransformd& X_WR, bool add_terrain,
+                          RenderEngineGl* engine) {
+    engine->UpdateViewpoint(X_WR);
 
     if (add_terrain) {
-      const GeometryId ground_id = GeometryId::get_new_id();
       PerceptionProperties material;
       material.AddProperty("label", "id", RenderLabel::kDontCare);
-      renderer_->RegisterVisual(ground_id, HalfSpace(), material,
-                                RigidTransformd::Identity(),
-                                false /* needs update */);
+      material.AddProperty("phong", "diffuse", kTerrainColor);
+      engine->RegisterVisual(GeometryId::get_new_id(), HalfSpace(), material,
+                             RigidTransformd::Identity(),
+                             false /* needs update */);
     }
   }
 
   // Creates a simple perception properties set for fixed, known results.
   PerceptionProperties simple_material() const {
     PerceptionProperties material;
-    Vector4d color(kDefaultVisualColor.r / 255., kDefaultVisualColor.g / 255.,
-                   kDefaultVisualColor.b / 255., 1.);
-    material.AddProperty("phong", "diffuse", color);
+    material.AddProperty("phong", "diffuse", default_color_);
     material.AddProperty("label", "id", expected_label_);
     return material;
+  }
+
+  // Resets all expected values to the initial, default values.
+  void ResetExpectations() {
+    expected_color_ = RgbaColor{kDefaultVisualColor};
+    expected_outlier_color_ = RgbaColor{kTerrainColor};
+    expected_outlier_depth_ = 3.0f;
+    expected_object_depth_ = 2.0f;
+    // We expect each test to explicitly set this.
+    expected_label_ = RenderLabel();
+    expected_outlier_label_ = RenderLabel::kDontCare;
   }
 
   // Populates the given renderer with the sphere required for
   // PerformCenterShapeTest().
   void PopulateSphereTest(RenderEngineGl* renderer) {
-    Sphere sphere{0.5};
+    const double r = 0.5;
+    Sphere sphere{r};
     expected_label_ = RenderLabel(12345);  // an arbitrary value.
     renderer->RegisterVisual(geometry_id_, sphere, simple_material(),
                              RigidTransformd::Identity(),
                              true /* needs update */);
-    RigidTransformd X_WV{Vector3d{0, 0, 0.5}};
+    RigidTransformd X_WV{Vector3d{0, 0, r}};
     X_WV_.clear();
     X_WV_.insert({geometry_id_, X_WV});
     renderer->UpdatePoses(X_WV_);
@@ -295,15 +386,26 @@ class RenderEngineGlTest : public ::testing::Test {
     const DepthCameraProperties& cam = camera ? *camera : camera_;
     // Can't use the member images in case the camera has been configured to a
     // different size than the default camera_ configuration.
+    ImageRgba8U color(cam.width, cam.height);
     ImageDepth32F depth(cam.width, cam.height);
     ImageLabel16I label(cam.width, cam.height);
-    Render(renderer, &cam, &depth, &label);
+    Render(renderer, &cam, &color, &depth, &label);
 
-    VerifyOutliers(*renderer, cam, &depth, &label);
+    VerifyCenterShapeTest(*renderer, cam, color, depth, label);
+  }
+
+  void VerifyCenterShapeTest(const RenderEngineGl& renderer,
+                             const DepthCameraProperties& camera,
+                             const ImageRgba8U& color,
+                             const ImageDepth32F& depth,
+                             const ImageLabel16I& label) const {
+    VerifyOutliers(renderer, camera, &color, &depth, &label);
 
     // Verifies inside the sphere.
-    const ScreenCoord inlier = GetInlier(cam);
+    const ScreenCoord inlier = GetInlier(camera);
 
+    EXPECT_TRUE(CompareColor(expected_color_, color, inlier))
+              << "Color at: " << inlier;
     EXPECT_TRUE(
         IsExpectedDepth(depth, inlier, expected_object_depth_, kDepthTolerance))
         << "Depth at: " << inlier;
@@ -312,15 +414,18 @@ class RenderEngineGlTest : public ::testing::Test {
         << "Label at: " << inlier;
   }
 
-  float expected_outlier_depth_{3.f};
+  RgbaColor expected_color_{kDefaultVisualColor};
+  RgbaColor expected_outlier_color_{kTerrainColor};
+  float expected_outlier_depth_{kDefaultDistance};
   float expected_object_depth_{2.f};
   RenderLabel expected_label_;
   RenderLabel expected_outlier_label_{RenderLabel::kDontCare};
-  RgbaColor default_color_{kDefaultVisualColor, 255};
+  Rgba default_color_{kDefaultVisualColor};
 
   const DepthCameraProperties camera_ = {kWidth, kHeight, kFovY,
-                                         "n/a",  kZNear,  kZFar};
+                                         "unused",  kZNear,  kZFar};
 
+  ImageRgba8U color_;
   ImageDepth32F depth_;
   ImageLabel16I label_;
   RigidTransformd X_WR_;
@@ -339,8 +444,26 @@ TEST_F(RenderEngineGlTest, NoBodyTest) {
   Render();
 
   SCOPED_TRACE("NoBodyTest");
+  VerifyUniformColor(kBgColor);
   VerifyUniformLabel(RenderLabel::kEmpty);
   VerifyUniformDepth(std::numeric_limits<float>::infinity());
+}
+
+// Confirm that the color image clear color gets successfully configured.
+TEST_F(RenderEngineGlTest, ControlBackgroundColor) {
+  std::vector<Rgba> backgrounds{Rgba{0.1, 0.2, 0.3, 1.0},
+                                Rgba{0.5, 0.6, 0.7, 1.0},
+                                Rgba{1.0, 0.1, 0.4, 0.5}};
+  for (const auto& bg : backgrounds) {
+    // TODO(SeanCurtis-TRI): When GCC supports non-trivial designated
+    //  initialization turn this back into:
+    //  const RenderEngineGlParams params{.default_clear_color = bg};
+    RenderEngineGlParams params;
+    params.default_clear_color = bg;
+    RenderEngineGl engine(params);
+    Render(&engine);
+    VerifyUniformColor(bg, 0u);
+  }
 }
 
 // Tests an image with *only* terrain (perpendicular to the camera's forward
@@ -484,6 +607,8 @@ TEST_F(RenderEngineGlTest, CapsuleRotatedTest) {
   for (const int& offset : offsets) {
     const int y = inlier.y + offset;
     const ScreenCoord offset_inlier = {x, y};
+    EXPECT_TRUE(CompareColor(expected_color_, color_, offset_inlier))
+        << "Color at: " << offset_inlier;
     EXPECT_TRUE(IsExpectedDepth(depth_, offset_inlier, expected_object_depth_,
                                 kDepthTolerance))
         << "Depth at: " << offset_inlier;
@@ -672,6 +797,7 @@ TEST_F(RenderEngineGlTest, RemoveVisual) {
     RenderLabel label = RenderLabel(5);
     PerceptionProperties material;
     material.AddProperty("label", "id", label);
+    material.AddProperty("phong", "diffuse", kDefaultVisualColor);
     // This will accept all registered geometries and therefore, (bool)index
     // should always be true.
     renderer_->RegisterVisual(geometry_id, sphere, material,
@@ -899,6 +1025,69 @@ TEST_F(RenderEngineGlTest, DefaultProperties) {
   EXPECT_NO_THROW(Render());
 }
 
+// Tests the ability to configure the RenderEngineGl's default render label.
+TEST_F(RenderEngineGlTest, DefaultProperties_RenderLabel) {
+  // A variation of PopulateSphereTest(), but uses an empty set of properties.
+  // The result should be compatible with the running the sphere test.
+  auto populate_default_sphere = [](auto* engine) {
+    Sphere sphere{0.5};
+    const GeometryId id = GeometryId::get_new_id();
+    engine->RegisterVisual(id, sphere, PerceptionProperties(),
+                           RigidTransformd::Identity(),
+                           true /* needs update */);
+    RigidTransformd X_WV{Vector3d{0, 0, 0.5}};
+    engine->UpdatePoses(unordered_map<GeometryId, RigidTransformd>{{id, X_WV}});
+  };
+
+  // Case: No change to render engine's default must throw.
+  {
+    RenderEngineGl renderer;
+    InitializeRenderer(X_WR_, false /* no terrain */, &renderer);
+
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        populate_default_sphere(&renderer),
+        std::logic_error,
+        ".* geometry with the 'unspecified' or 'empty' render labels.*");
+  }
+
+  // Case: Change render engine's default to explicitly be unspecified; must
+  // throw.
+  {
+    RenderEngineGl renderer{{.default_label = RenderLabel::kUnspecified}};
+    InitializeRenderer(X_WR_, false /* no terrain */, &renderer);
+
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        populate_default_sphere(&renderer),
+        std::logic_error,
+        ".* geometry with the 'unspecified' or 'empty' render labels.*");
+  }
+
+  // Case: Change render engine's default to don't care. Label image should
+  // report don't care.
+  {
+    ResetExpectations();
+    RenderEngineGl renderer{{.default_label = RenderLabel::kDontCare}};
+    InitializeRenderer(X_WR_, true /* no terrain */, &renderer);
+
+    DRAKE_EXPECT_NO_THROW(populate_default_sphere(&renderer));
+    expected_label_ = RenderLabel::kDontCare;
+    expected_color_ = RgbaColor(renderer.parameters().default_diffuse);
+
+    SCOPED_TRACE("Default properties; don't care label");
+    PerformCenterShapeTest(&renderer);
+  }
+
+  // Case: Change render engine's default to invalid default value; must throw.
+  {
+    for (RenderLabel label :
+        {RenderLabel::kEmpty, RenderLabel(1), RenderLabel::kDoNotRender}) {
+      DRAKE_EXPECT_THROWS_MESSAGE(
+          RenderEngineGl({.default_label = label}), std::logic_error,
+          ".* default render label .* either 'kUnspecified' or 'kDontCare'.*");
+    }
+  }
+}
+
 // Tests to see if the two images are *exactly* equal - down to the last bit.
 ::testing::AssertionResult ImagesExactlyEqual(const ImageDepth32F& ref,
                                               const ImageDepth32F& test) {
@@ -972,15 +1161,6 @@ TEST_F(RenderEngineGlTest, RendererIndependence) {
   // the reference image.
   Render(&engine1);
   ASSERT_TRUE(ImagesExactlyEqual(reference_1, depth_));
-}
-
-TEST_F(RenderEngineGlTest, RenderColorImageThrows) {
-  RenderEngineGl engine;
-  CameraProperties camera{2, 2, M_PI, "junk"};
-  ImageRgba8U image{camera.width, camera.height};
-  DRAKE_EXPECT_THROWS_MESSAGE(engine.RenderColorImage(camera, false, &image),
-                              std::runtime_error,
-                              "RenderEngineGl cannot render color images");
 }
 
 // Confirms that passing in show_window = true "works". The test can't confirm


### PR DESCRIPTION
This adds basic color rendering to RenderEngineGl. It provides for phong-illuminated, Rgba-colored objects. (Textured objects will follow.)

 - RenderEngineGl
    - Introduces the color shader program, updates the RenderColorImage to use it.
    - Reformulate vertex buffer objects to account for normals.
    - Tests pick up color rendering infrastructure from RenderEngineVtk tests.
 - OpenGlGeometry constructor includes shader data for color shader.
 - Add RenderEngineGlParameters
    - contains: default label, default diffuse color, and clear color
    - integrated into RenderEngineGl, RenderEngineGlFactory, and tests.
 - Extend RenderType with kColor (gl_common.h)
 - Clean up
   - update comments in buffer_dim.h

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14226)
<!-- Reviewable:end -->
