### PR TITLE
Add FemState and ElementCache.

### DIFF
--- a/multibody/fem/dev/BUILD.bazel
+++ b/multibody/fem/dev/BUILD.bazel
@@ -13,6 +13,49 @@ package(
 )
 
 drake_cc_library(
+    name = "constitutive_model_cache",
+    hdrs = [
+        "constitutive_model_cache.h",
+    ],
+    deps = [
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "element_cache",
+    hdrs = [
+        "element_cache.h",
+    ],
+    deps = [
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "elasticity_element_cache",
+    hdrs = [
+        "elasticity_element_cache.h",
+    ],
+    deps = [
+        ":constitutive_model_cache",
+        ":element_cache",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "fem_state",
+    hdrs = [
+        "fem_state.h",
+    ],
+    deps = [
+        ":element_cache",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
     name = "isoparametric_element",
     srcs = [
         "isoparametric_element.cc",
@@ -49,6 +92,29 @@ drake_cc_library(
     deps = [
         "//common:essential",
         "//common:nice_type_name",
+    ],
+)
+
+drake_cc_googletest(
+    name = "constitutive_model_cache_test",
+    deps = [
+        ":constitutive_model_cache",
+    ],
+)
+
+drake_cc_googletest(
+    name = "fem_state_test",
+    deps = [
+        ":element_cache",
+        ":fem_state",
+    ],
+)
+
+drake_cc_googletest(
+    name = "elasticity_element_cache_test",
+    deps = [
+        ":constitutive_model_cache",
+        ":elasticity_element_cache",
     ],
 )
 

--- a/multibody/fem/dev/constitutive_model_cache.h
+++ b/multibody/fem/dev/constitutive_model_cache.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+
+/** Cached quantities that facilitates calculation such as energy density,
+ stress and stress derivative in the constitutive model. There should be a
+ one-to-one correspondence between constitutive model `Foo` and its cached
+ quantities `FooCache`. The constitutive model takes its cache as an argument
+ when performing various calculations.
+ @tparam_nonsymbolic_scalar T.
+ @tparam SpatialDim The spatial dimension of the domain. */
+// TODO(xuchenhan-tri) link this doc to ConstitutiveModel when it is checked in.
+template <typename T, int SpatialDim>
+struct ConstitutiveModelCache {
+  ConstitutiveModelCache(int element_index_in, int num_quads_in)
+      : element_index(element_index_in), num_quads(num_quads_in) {}
+
+  using MatrixD = Eigen::Matrix<T, SpatialDim, SpatialDim>;
+
+  int element_index{-1};
+  int num_quads{-1};
+};
+
+/** Cached quantities for the LinearElasticity constitutive model.
+ @tparam_nonsymbolic_scalar T.
+ @tparam SpatialDim The spatial dimension of the domain. */
+template <typename T, int SpatialDim>
+struct LinearElasticityCache : ConstitutiveModelCache<T, SpatialDim> {
+  LinearElasticityCache(int element_index_in, int num_quads_in)
+      : ConstitutiveModelCache<T, SpatialDim>(element_index_in, num_quads_in),
+        F(num_quads_in),
+        strain(num_quads_in),
+        trace_strain(num_quads_in) {}
+  using typename ConstitutiveModelCache<T, SpatialDim>::MatrixD;
+  std::vector<MatrixD> F;       // Deformation gradient.
+  std::vector<MatrixD> strain;  // Infinitesimal strain = 0.5 * (F + Fᵀ) - I.
+  std::vector<T> trace_strain;  // Trace of `strain`.
+};
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/dev/elasticity_element_cache.h
+++ b/multibody/fem/dev/elasticity_element_cache.h
@@ -1,0 +1,191 @@
+#pragma once
+
+#include <type_traits>
+#include <vector>
+
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fem/dev/constitutive_model_cache.h"
+#include "drake/multibody/fem/dev/element_cache.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+/** Cached quantities per element that are used in the element routine for
+ elasticity.
+ @tparam_nonsymbolic_scalar T.
+ @tparam SpatialDim The spatial dimension of the domain.
+ @tparam ModelCacheType The type for constitutive model cache, must be
+ derived from ConstitutiveModelCache<T, SpatialDim>. */
+// TODO(xuchenhan-tri) link the doc of this class to FemElasticity when
+// FemElasticity is checked in.
+template <typename T, int SpatialDim, class ModelCacheType>
+class ElasticityElementCache : public ElementCache<T, SpatialDim> {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ElasticityElementCache);
+
+  // The ModelType must be derived from ConstitutiveModelCache<T, SpatialDim>.
+  // This also asserts that the scalar type for the ModelType must agree with
+  // the scalar type of this cache and that their spatial dimensions must also
+  // agree.
+  static_assert(
+      std::is_convertible<ModelCacheType*,
+                          ConstitutiveModelCache<T, SpatialDim>*>::value);
+  ElasticityElementCache(int element_index, int num_quads)
+      : ElementCache<T, SpatialDim>(element_index, num_quads),
+        F_(num_quads),
+        F0_(num_quads),
+        constitutive_model_cache_(element_index, num_quads),
+        Psi_(num_quads),
+        P_(num_quads),
+        dPdF_(num_quads) {}
+
+  using MatrixD = Eigen::Matrix<T, SpatialDim, SpatialDim>;
+
+  virtual ~ElasticityElementCache() = default;
+
+  void mark_v0_cache_stale() final {}
+
+  void mark_v_cache_stale() final {}
+
+  void mark_x0_cache_stale() final {
+    mark_F0_stale(true);
+    mark_Psi_stale(true);
+    mark_P_stale(true);
+    mark_dPdF_stale(true);
+    mark_constitutive_model_x0_cache_stale(true);
+  }
+
+  void mark_x_cache_stale() final {
+    mark_F_stale(true);
+    mark_Psi_stale(true);
+    mark_P_stale(true);
+    mark_dPdF_stale(true);
+    mark_constitutive_model_x_cache_stale(true);
+  };
+
+  /// Getters for the const cache entries.
+  /// @{
+  const std::vector<MatrixD>& get_F() const { return F_; }
+
+  const std::vector<MatrixD>& get_F0() const { return F0_; }
+
+  const ModelCacheType& get_constitutive_model_cache() const {
+    return constitutive_model_cache_;
+  }
+
+  const std::vector<T>& get_Psi() const { return Psi_; }
+
+  const std::vector<MatrixD>& get_P() const { return P_; }
+
+  const std::vector<
+      Eigen::Matrix<T, SpatialDim * SpatialDim, SpatialDim * SpatialDim>>&
+  get_dPdF() const {
+    return dPdF_;
+  }
+  /// @}
+
+  /// Getters for the mutable cache entries.
+  /// @{
+  std::vector<MatrixD>& get_mutable_F() {
+    mark_F_stale(true);
+    return F_;
+  }
+
+  std::vector<MatrixD>& get_mutable_F0() {
+    mark_F0_stale(true);
+    return F0_;
+  }
+
+  ModelCacheType& get_mutable_constitutive_model_cache() {
+    mark_constitutive_model_cache_stale(true);
+    return constitutive_model_cache_;
+  }
+
+  std::vector<T>& get_mutable_Psi() {
+    mark_Psi_stale(true);
+    return Psi_;
+  }
+
+  std::vector<MatrixD>& get_mutable_P() {
+    mark_P_stale(true);
+    return P_;
+  }
+
+  std::vector<
+      Eigen::Matrix<T, SpatialDim * SpatialDim, SpatialDim * SpatialDim>>&
+  get_mutable_dPdF() {
+    mark_dPdF_stale(true);
+    return dPdF_;
+  }
+  /// @}
+
+  /// Getters for the status of the cache entries.
+  /// @{
+  bool F_stale() const { return F_stale_; }
+  bool F0_stale() const { return F0_stale_; }
+  bool constitutive_model_cache_stale() const {
+    return constitutive_model_x_cache_stale_ ||
+           constitutive_model_x0_cache_stale_;
+  }
+  bool constitutive_model_x_cache_stale() const {
+    return constitutive_model_x_cache_stale_;
+  }
+  bool constitutive_model_x0_cache_stale() const {
+    return constitutive_model_x0_cache_stale_;
+  }
+  bool Psi_stale() const { return Psi_stale_; }
+  bool P_stale() const { return P_stale_; }
+  bool dPdF_stale() const { return dPdF_stale_; }
+  /// @}
+
+ private:
+  // Facilitates testing.
+  friend class ElasticityElementCacheTest;
+  // TODO(xuchenhan-tri): Add FemElasticity as a friend.
+
+  // Setters for the status of the cache entries.
+  // @{
+  void mark_F_stale(bool flag) { F_stale_ = flag; }
+  void mark_F0_stale(bool flag) { F0_stale_ = flag; }
+  void mark_constitutive_model_cache_stale(bool flag) {
+    mark_constitutive_model_x_cache_stale(flag);
+    mark_constitutive_model_x0_cache_stale(flag);
+  }
+  void mark_constitutive_model_x_cache_stale(bool flag) {
+    constitutive_model_x_cache_stale_ = flag;
+  }
+  void mark_constitutive_model_x0_cache_stale(bool flag) {
+    constitutive_model_x0_cache_stale_ = flag;
+  }
+  void mark_Psi_stale(bool flag) { Psi_stale_ = flag; }
+  void mark_P_stale(bool flag) { P_stale_ = flag; }
+  void mark_dPdF_stale(bool flag) { dPdF_stale_ = flag; }
+  // @}
+
+  // Deformation gradient. Depends on x.
+  std::vector<MatrixD> F_;
+  bool F_stale_{true};
+  // Deformation gradient of the previous time step. Depends on x0.
+  std::vector<MatrixD> F0_;
+  bool F0_stale_{true};
+  // Scratch for computing energy/stress/stress-derivatives. Depends on x0 and
+  // x. We separate the cache values depending on x and x0 respectively so that
+  // a change in x does not thrash cache depending solely on x0 and vice versa.
+  ModelCacheType constitutive_model_cache_;
+  bool constitutive_model_x_cache_stale_{true};
+  bool constitutive_model_x0_cache_stale_{true};
+  // Elastic energy density. Depends on x0 and x.
+  std::vector<T> Psi_;
+  bool Psi_stale_{true};
+  // First Piola stress. Depends on x0 and x.
+  std::vector<MatrixD> P_;
+  bool P_stale_{true};
+  // First Piola stress derivative. Depends on x0 and x.
+  std::vector<
+      Eigen::Matrix<T, SpatialDim * SpatialDim, SpatialDim * SpatialDim>>
+      dPdF_;
+  bool dPdF_stale_{true};
+};
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/dev/element_cache.h
+++ b/multibody/fem/dev/element_cache.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+/** This class stores the per element cached quantities that depend on FemState
+ to save computation time when we know that these quantities have not changed
+ since the last time we computed them. When the `Foo` state in FemState
+ changes, the method `mark_Foo_cache_stale` needs to be called to to invalid
+ the cache entries that depend on `Foo`.
+ @tparam_nonsymbolic_scalar T.
+ @tparam SpatialDim The spatial dimension of the domain. */
+template <typename T, int SpatialDim>
+class ElementCache {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ElementCache);
+
+  ElementCache(int element_index, int num_quads)
+      : element_index_(element_index), num_quads_(num_quads) {}
+
+  virtual ~ElementCache() = default;
+
+  /// Marks all cached quantities that depend on v0 as stale.
+  virtual void mark_v0_cache_stale() = 0;
+
+  /// Marks all cached quantities that depend on v as stale.
+  virtual void mark_v_cache_stale() = 0;
+
+  /// Marks all cached quantities that depend on x0 as stale.
+  virtual void mark_x0_cache_stale() = 0;
+
+  /// Marks all cached quantities that depend on x as stale.
+  virtual void mark_x_cache_stale() = 0;
+
+  int element_index() const { return element_index_; }
+  int num_quads() const { return num_quads_; }
+
+ private:
+  // The global index of the element whose quantities `this` element cache
+  // caches.
+  int element_index_{-1};
+  // Number of quadrature points used on this element.
+  int num_quads_{-1};
+};
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/dev/fem_state.h
+++ b/multibody/fem/dev/fem_state.h
@@ -1,0 +1,243 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fem/dev/element_cache.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+/** The states in the FEM simulation that live on element vertices. The states
+ include the position of the vertices `x` and its time derivative `v` as well
+ as the same quantities evaluated at the previous time step. FemState also
+ contains the cached quantities that live on the element and whose values
+ depend on the states.
+ @tparam_nonsymbolic_scalar T.
+ @tparam SpatialDim The spatial dimension of the domain. */
+template <typename T, int SpatialDim>
+class FemState {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(FemState);
+
+  FemState() = default;
+
+  using VectorD = Eigen::Matrix<T, SpatialDim, 1>;
+  using ConstVectorBlockD = Eigen::VectorBlock<const VectorX<T>, SpatialDim>;
+
+  int num_verts() const { return num_verts_; }
+
+  /// Resize the FemState to hold the states for `v` vertices. The existing
+  /// values are unchanged if `v` is greater than or equal to `num_verts()`.
+  void resize(int num_verts) {
+    DRAKE_DEMAND(num_verts >= 0);
+    num_verts_ = num_verts;
+    v0_.conservativeResize(num_verts * SpatialDim);
+    v_.conservativeResize(num_verts * SpatialDim);
+    x0_.conservativeResize(num_verts * SpatialDim);
+    x_.conservativeResize(num_verts * SpatialDim);
+  }
+
+  /// Getters.
+  /// @{
+  const VectorX<T>& get_v0() const { return v0_; }
+
+  const VectorX<T>& get_v() const { return v_; }
+
+  const VectorX<T>& get_x0() const { return x0_; }
+
+  const VectorX<T>& get_x() const { return x_; }
+  /// @}
+
+  /// Setters. The value provided must match the current size of the states.
+  /// @{
+  void set_v0(const Eigen::Ref<const VectorX<T>>& value) {
+    DRAKE_DEMAND(value.size() == num_verts_ * SpatialDim);
+    if (value == v0_) return;
+    mark_v0_cache_stale();
+    v0_ = value;
+  }
+
+  void set_v(const Eigen::Ref<const VectorX<T>>& value) {
+    DRAKE_DEMAND(value.size() == num_verts_ * SpatialDim);
+    if (value == v_) return;
+    mark_v_cache_stale();
+    v_ = value;
+  }
+
+  void set_x0(const Eigen::Ref<const VectorX<T>>& value) {
+    DRAKE_DEMAND(value.size() == num_verts_ * SpatialDim);
+    if (value == x0_) return;
+    mark_x0_cache_stale();
+    x0_ = value;
+  }
+
+  void set_x(const Eigen::Ref<const VectorX<T>>& value) {
+    DRAKE_DEMAND(value.size() == num_verts_ * SpatialDim);
+    if (value == x_) return;
+    mark_x_cache_stale();
+    x_ = value;
+  }
+  /// @}
+
+  /// Convenient getters for when the index of the vertex is known.
+  /// These methods take the index of the vertex `i` as an argument.
+  /// @{
+  ConstVectorBlockD get_v0_at(int i) const {
+    DRAKE_DEMAND(0 <= i);
+    DRAKE_DEMAND(i < num_verts_);
+    return v0_.template segment<SpatialDim>(SpatialDim * i);
+  }
+
+  ConstVectorBlockD get_v_at(int i) const {
+    DRAKE_DEMAND(0 <= i);
+    DRAKE_DEMAND(i < num_verts_);
+    return v_.template segment<SpatialDim>(SpatialDim * i);
+  }
+
+  ConstVectorBlockD get_x0_at(int i) const {
+    DRAKE_DEMAND(0 <= i);
+    DRAKE_DEMAND(i < num_verts_);
+    return x0_.template segment<SpatialDim>(SpatialDim * i);
+  }
+
+  ConstVectorBlockD get_x_at(int i) const {
+    DRAKE_DEMAND(0 <= i);
+    DRAKE_DEMAND(i < num_verts_);
+    return x_.template segment<SpatialDim>(SpatialDim * i);
+  }
+  /// @}
+
+  /// Convenient setters for when the index of the vertex is known.
+  /// These methods take the index of the vertex `v` as an argument.
+  void set_v0_at(int i, const Eigen::Ref<const VectorD>& value) {
+    DRAKE_DEMAND(0 <= i);
+    DRAKE_DEMAND(i < num_verts_);
+    if (value == get_v0_at(i)) return;
+    mark_v0_cache_stale();
+    v0_.template segment<SpatialDim>(SpatialDim * i) = value;
+  }
+
+  void set_v_at(int i, const Eigen::Ref<const VectorD>& value) {
+    DRAKE_DEMAND(0 <= i);
+    DRAKE_DEMAND(i < num_verts_);
+    if (value == get_v_at(i)) return;
+    mark_v_cache_stale();
+    v_.template segment<SpatialDim>(SpatialDim * i) = value;
+  }
+
+  void set_x0_at(int i, const Eigen::Ref<const VectorD>& value) {
+    DRAKE_DEMAND(0 <= i);
+    DRAKE_DEMAND(i < num_verts_);
+    if (value == get_x0_at(i)) return;
+    mark_x0_cache_stale();
+    x0_.template segment<SpatialDim>(SpatialDim * i) = value;
+  }
+
+  void set_x_at(int i, const Eigen::Ref<const VectorD>& value) {
+    DRAKE_DEMAND(0 <= i);
+    DRAKE_DEMAND(i < num_verts_);
+    if (value == get_x_at(i)) return;
+    mark_x_cache_stale();
+    x_.template segment<SpatialDim>(SpatialDim * i) = value;
+  }
+  /// @}
+
+  /// Mutable Getters. The value of the states is mutable but the size of the
+  /// states is not allowed to change.
+  /// @{
+  Eigen::VectorBlock<VectorX<T>> get_mutable_v0() {
+    mark_v0_cache_stale();
+    return v0_.head(v0_.rows());
+  }
+
+  Eigen::VectorBlock<VectorX<T>> get_mutable_v() {
+    mark_v_cache_stale();
+    return v_.head(v_.rows());
+  }
+
+  Eigen::VectorBlock<VectorX<T>> get_mutable_x0() {
+    mark_x0_cache_stale();
+    return x0_.head(x0_.rows());
+  }
+
+  Eigen::VectorBlock<VectorX<T>> get_mutable_x() {
+    mark_x_cache_stale();
+    return x_.head(x_.rows());
+  }
+  /// @}
+
+  /// Getters and mutable getters for cached quantities.
+  /// @{
+  const std::vector<std::unique_ptr<ElementCache<T, SpatialDim>>>& get_cache()
+      const {
+    return cache_;
+  }
+
+  /// (Advanced) The caller is responsible for correctly setting the staleness
+  /// flag for the cached quantities.
+  std::vector<std::unique_ptr<ElementCache<T, SpatialDim>>>& get_mutable_cache()
+      const {
+    return cache_;
+  }
+
+  const std::unique_ptr<ElementCache<T, SpatialDim>>& get_cache_at(
+      int e) const {
+    DRAKE_DEMAND(e < static_cast<int>(cache_.size()));
+    DRAKE_DEMAND(0 <= e);
+    return cache_[e];
+  }
+
+  /// (Advanced) The caller is responsible for correctly setting the staleness
+  /// flag for the cached quantities.
+  std::unique_ptr<ElementCache<T, SpatialDim>>& get_mutable_cache_at(
+      int e) const {
+    DRAKE_DEMAND(e < static_cast<int>(cache_.size()));
+    DRAKE_DEMAND(0 <= e);
+    return cache_[e];
+  }
+  /// @}
+
+ private:
+  void mark_v0_cache_stale() {
+    for (int e = 0; e < static_cast<int>(cache_.size()); ++e) {
+      cache_[e]->mark_v0_cache_stale();
+    }
+  }
+
+  void mark_v_cache_stale() {
+    for (int e = 0; e < static_cast<int>(cache_.size()); ++e) {
+      cache_[e]->mark_v_cache_stale();
+    }
+  }
+
+  void mark_x0_cache_stale() {
+    for (int e = 0; e < static_cast<int>(cache_.size()); ++e) {
+      cache_[e]->mark_x0_cache_stale();
+    }
+  }
+
+  void mark_x_cache_stale() {
+    for (int e = 0; e < static_cast<int>(cache_.size()); ++e) {
+      cache_[e]->mark_x_cache_stale();
+    }
+  }
+
+  // Number of vertices.
+  int num_verts_{0};
+  // Vertex velocity from previous time step.
+  VectorX<T> v0_;
+  // Vertex velocities.
+  VectorX<T> v_;
+  // Vertex position from previous time step.
+  VectorX<T> x0_;
+  // Vertex positions.
+  VectorX<T> x_;
+  // Owned cached quantities.
+  mutable std::vector<std::unique_ptr<ElementCache<T, SpatialDim>>> cache_;
+};
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/dev/test/constitutive_model_cache_test.cc
+++ b/multibody/fem/dev/test/constitutive_model_cache_test.cc
@@ -1,0 +1,31 @@
+#include "drake/multibody/fem/dev/constitutive_model_cache.h"
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace {
+constexpr int kElementIndex = 3;
+constexpr int kNumQuads = 5;
+constexpr int kDim = 3;
+
+
+class ConstitutiveModelCacheTest : public ::testing::Test {
+ protected:
+  void SetUp() {}
+  LinearElasticityCache<double, kDim> linear_elasticity_cache_{kElementIndex,
+                                                         kNumQuads};
+};
+
+TEST_F(ConstitutiveModelCacheTest, LinearElasticityCacheInitialization) {
+  EXPECT_EQ(linear_elasticity_cache_.element_index, kElementIndex);
+  EXPECT_EQ(linear_elasticity_cache_.num_quads, kNumQuads);
+  EXPECT_EQ(linear_elasticity_cache_.F.size(), kNumQuads);
+  EXPECT_EQ(linear_elasticity_cache_.strain.size(), kNumQuads);
+  EXPECT_EQ(linear_elasticity_cache_.trace_strain.size(), kNumQuads);
+}
+}  // namespace
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/dev/test/elasticity_element_cache_test.cc
+++ b/multibody/fem/dev/test/elasticity_element_cache_test.cc
@@ -1,0 +1,199 @@
+#include "drake/multibody/fem/dev/elasticity_element_cache.h"
+
+#include <limits>
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/multibody/fem/dev/constitutive_model_cache.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+
+class ElasticityElementCacheTest : public ::testing::Test {
+ protected:
+  static constexpr int kElementIndex = 3;
+  static constexpr int kNumQuads = 5;
+  static constexpr int kDim = 3;
+  void SetUp() {}
+  ElasticityElementCache<double, kDim, LinearElasticityCache<double, kDim>>
+      elasticity_cache_{kElementIndex, kNumQuads};
+
+  void VerifyAllCacheStale() const {
+    EXPECT_TRUE(elasticity_cache_.F_stale());
+    EXPECT_TRUE(elasticity_cache_.F0_stale());
+    EXPECT_TRUE(elasticity_cache_.constitutive_model_cache_stale());
+    EXPECT_TRUE(elasticity_cache_.constitutive_model_x_cache_stale());
+    EXPECT_TRUE(elasticity_cache_.constitutive_model_x0_cache_stale());
+    EXPECT_TRUE(elasticity_cache_.Psi_stale());
+    EXPECT_TRUE(elasticity_cache_.P_stale());
+    EXPECT_TRUE(elasticity_cache_.dPdF_stale());
+  }
+
+  void VerifyAllCacheFresh() const {
+    EXPECT_FALSE(elasticity_cache_.F_stale());
+    EXPECT_FALSE(elasticity_cache_.F0_stale());
+    EXPECT_FALSE(elasticity_cache_.constitutive_model_cache_stale());
+    EXPECT_FALSE(elasticity_cache_.constitutive_model_x_cache_stale());
+    EXPECT_FALSE(elasticity_cache_.constitutive_model_x0_cache_stale());
+    EXPECT_FALSE(elasticity_cache_.Psi_stale());
+    EXPECT_FALSE(elasticity_cache_.P_stale());
+    EXPECT_FALSE(elasticity_cache_.dPdF_stale());
+  }
+
+  void MarkAllCacheFresh() {
+    elasticity_cache_.mark_F_stale(false);
+    elasticity_cache_.mark_F0_stale(false);
+    elasticity_cache_.mark_constitutive_model_cache_stale(false);
+    elasticity_cache_.mark_Psi_stale(false);
+    elasticity_cache_.mark_P_stale(false);
+    elasticity_cache_.mark_dPdF_stale(false);
+  }
+
+  // Create fake values for F.
+  std::vector<Matrix3<double>> CreateF() const {
+    Matrix3<double> F = Matrix3<double>::Identity();
+    return std::vector<Matrix3<double>>(kNumQuads, F);
+  }
+
+  // Create fake values for F0.
+  std::vector<Matrix3<double>> CreateF0() const {
+    Matrix3<double> F0 = 2.0 * Matrix3<double>::Identity();
+    return std::vector<Matrix3<double>>(kNumQuads, F0);
+  }
+
+  // Create fake value for model cache.
+  LinearElasticityCache<double, kDim> CreateModelCache() const {
+    LinearElasticityCache<double, kDim> linear_elasticity_cache(kElementIndex,
+                                                          kNumQuads);
+    linear_elasticity_cache.F = CreateF();
+    linear_elasticity_cache.strain = CreateP();
+    linear_elasticity_cache.trace_strain = CreatePsi();
+    return linear_elasticity_cache;
+  }
+
+  // Create fake values for Psi.
+  std::vector<double> CreatePsi() const {
+    return std::vector<double>(kNumQuads, 0.123);
+  }
+
+  // Create fake values for P.
+  std::vector<Matrix3<double>> CreateP() const {
+    Matrix3<double> P = 3.0 * Matrix3<double>::Identity();
+    return std::vector<Matrix3<double>>(kNumQuads, P);
+  }
+
+  // Create fake values for dPdF.
+  std::vector<Eigen::Matrix<double, 9, 9>> CreatedPdF() const {
+    Eigen::Matrix<double, 9, 9> dPdF =
+        4.0 * Eigen::Matrix<double, 9, 9>::Identity();
+    return std::vector<Eigen::Matrix<double, 9, 9>>(kNumQuads, dPdF);
+  }
+};
+
+namespace {
+
+TEST_F(ElasticityElementCacheTest, Initialization) {
+  // Verify that the element index and the number of quadrature points
+  // percolates.
+  EXPECT_EQ(elasticity_cache_.element_index(), kElementIndex);
+  EXPECT_EQ(elasticity_cache_.num_quads(), kNumQuads);
+  EXPECT_EQ(elasticity_cache_.get_F().size(), kNumQuads);
+  EXPECT_EQ(elasticity_cache_.get_F0().size(), kNumQuads);
+  EXPECT_EQ(elasticity_cache_.get_constitutive_model_cache().element_index,
+            kElementIndex);
+  EXPECT_EQ(elasticity_cache_.get_constitutive_model_cache().num_quads,
+            kNumQuads);
+  EXPECT_EQ(elasticity_cache_.get_Psi().size(), kNumQuads);
+  EXPECT_EQ(elasticity_cache_.get_P().size(), kNumQuads);
+  EXPECT_EQ(elasticity_cache_.get_dPdF().size(), kNumQuads);
+  // Verify that all `stale flags` are initialized to true.
+  VerifyAllCacheStale();
+}
+
+TEST_F(ElasticityElementCacheTest, MarkAsStale) {
+  MarkAllCacheFresh();
+  VerifyAllCacheFresh();
+}
+
+TEST_F(ElasticityElementCacheTest, Getters) {
+  MarkAllCacheFresh();
+  auto& F = elasticity_cache_.get_mutable_F();
+  auto& F0 = elasticity_cache_.get_mutable_F0();
+  auto& model_cache = elasticity_cache_.get_mutable_constitutive_model_cache();
+  auto& Psi = elasticity_cache_.get_mutable_Psi();
+  auto& P = elasticity_cache_.get_mutable_P();
+  auto& dPdF = elasticity_cache_.get_mutable_dPdF();
+  // Non-const getters should mark the corresponding cache stale.
+  VerifyAllCacheStale();
+  // Give the cache some fake values.
+  F = CreateF();
+  F0 = CreateF0();
+  model_cache = CreateModelCache();
+  Psi = CreatePsi();
+  P = CreateP();
+  dPdF = CreatedPdF();
+
+  // Test const getters.
+  EXPECT_EQ(elasticity_cache_.get_F(), CreateF());
+  EXPECT_EQ(elasticity_cache_.get_F0(), CreateF0());
+  EXPECT_EQ(elasticity_cache_.get_Psi(), CreatePsi());
+  EXPECT_EQ(elasticity_cache_.get_P(), CreateP());
+  EXPECT_EQ(elasticity_cache_.get_dPdF(), CreatedPdF());
+
+  const auto& linear_elasticity_cache =
+      elasticity_cache_.get_constitutive_model_cache();
+  const auto& created_cache = CreateModelCache();
+  EXPECT_EQ(linear_elasticity_cache.element_index, created_cache.element_index);
+  EXPECT_EQ(linear_elasticity_cache.num_quads, created_cache.num_quads);
+  EXPECT_EQ(linear_elasticity_cache.F, created_cache.F);
+  EXPECT_EQ(linear_elasticity_cache.strain, created_cache.strain);
+  EXPECT_EQ(linear_elasticity_cache.trace_strain, created_cache.trace_strain);
+}
+
+TEST_F(ElasticityElementCacheTest, xCache) {
+  MarkAllCacheFresh();
+  elasticity_cache_.mark_x_cache_stale();
+  // F, constitutive_model_x_cache, Psi, P, dPdF depend on x.
+  EXPECT_TRUE(elasticity_cache_.F_stale());
+  EXPECT_FALSE(elasticity_cache_.F0_stale());
+  EXPECT_TRUE(elasticity_cache_.constitutive_model_cache_stale());
+  EXPECT_TRUE(elasticity_cache_.constitutive_model_x_cache_stale());
+  EXPECT_FALSE(elasticity_cache_.constitutive_model_x0_cache_stale());
+  EXPECT_TRUE(elasticity_cache_.Psi_stale());
+  EXPECT_TRUE(elasticity_cache_.P_stale());
+  EXPECT_TRUE(elasticity_cache_.dPdF_stale());
+}
+
+TEST_F(ElasticityElementCacheTest, x0Cache) {
+  MarkAllCacheFresh();
+  elasticity_cache_.mark_x0_cache_stale();
+  // F0, constitutive_model_x0_cache, Psi, P, dPdF depend on x0.
+  EXPECT_FALSE(elasticity_cache_.F_stale());
+  EXPECT_TRUE(elasticity_cache_.F0_stale());
+  EXPECT_TRUE(elasticity_cache_.constitutive_model_cache_stale());
+  EXPECT_FALSE(elasticity_cache_.constitutive_model_x_cache_stale());
+  EXPECT_TRUE(elasticity_cache_.constitutive_model_x0_cache_stale());
+  EXPECT_TRUE(elasticity_cache_.Psi_stale());
+  EXPECT_TRUE(elasticity_cache_.P_stale());
+  EXPECT_TRUE(elasticity_cache_.dPdF_stale());
+}
+
+TEST_F(ElasticityElementCacheTest, vCache) {
+  // No cache entry depends on v currently.
+  MarkAllCacheFresh();
+  elasticity_cache_.mark_v_cache_stale();
+  VerifyAllCacheFresh();
+}
+
+TEST_F(ElasticityElementCacheTest, v0Cache) {
+  // No cache entry depends on v0 currently.
+  MarkAllCacheFresh();
+  elasticity_cache_.mark_v0_cache_stale();
+  VerifyAllCacheFresh();
+}
+}  // namespace
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/dev/test/fem_state_test.cc
+++ b/multibody/fem/dev/test/fem_state_test.cc
@@ -1,0 +1,280 @@
+#include "drake/multibody/fem/dev/fem_state.h"
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace {
+constexpr int kDim = 3;
+
+// A toy element cache to test the `mark_foo_cache_stale` methods.
+struct MyElementCache : public ElementCache<double, kDim> {
+  MyElementCache(int element_index, int num_quads)
+      : ElementCache(element_index, num_quads) {}
+
+  bool c0_stale{false};  // Depends on v0, v.
+  bool c1_stale{false};  // Depends on x0, x.
+  bool c2_stale{false};  // Depends on v, x.
+  bool c3_stale{false};  // Depends on v0, v, x0, x.
+
+  void mark_v0_cache_stale() final {
+    c0_stale = true;
+    c3_stale = true;
+  }
+
+  void mark_v_cache_stale() final {
+    c0_stale = true;
+    c2_stale = true;
+    c3_stale = true;
+  }
+
+  void mark_x0_cache_stale() final {
+    c1_stale = true;
+    c3_stale = true;
+  }
+
+  void mark_x_cache_stale() final {
+    c1_stale = true;
+    c2_stale = true;
+    c3_stale = true;
+  }
+};
+
+class FemStateTest : public ::testing::Test {
+ protected:
+  using VectorD = Eigen::Matrix<double, kDim, 1>;
+
+  void SetUp() {
+    // Create a couple of cache entries.
+    auto& mutable_cache = state_.get_mutable_cache();
+    auto cache_0 = std::make_unique<MyElementCache>(0, 1);
+    auto cache_1 = std::make_unique<MyElementCache>(1, 1);
+    mutable_cache.emplace_back(std::move(cache_0));
+    mutable_cache.emplace_back(std::move(cache_1));
+    // Set default states.
+    SetStates();
+    // Update all cache entries so that all cache are fresh at the start of each
+    // test.
+    for (int i = 0; i < static_cast<int>(mutable_cache.size()); ++i) {
+      auto& my_cache = static_cast<MyElementCache&>(*mutable_cache[i]);
+      RefreshCache(&my_cache);
+    }
+  }
+
+  // Default value for the state of the single vertex.
+  VectorD v0() const { return VectorD(0.1, 0.2, 0.3); }
+  VectorD v() const { return VectorD(0.3, 0.4, 0.5); }
+  VectorD x0() const { return VectorD(0.5, 0.6, 0.7); }
+  VectorD x() const { return VectorD(0.7, 0.8, 0.9); }
+
+  // Resize so that there only exists a single vertex and then set the states to
+  // default values.
+  void SetStates() {
+    // Allocate space for states for one vertex.
+    state_.resize(1);
+    // Set all states for the single vertex to their default values.
+    state_.set_v0(v0());
+    state_.set_v(v());
+    state_.set_x0(x0());
+    state_.set_x(x());
+  }
+
+  // Reset all stale flags in `my_cache` to false.
+  void RefreshCache(MyElementCache* my_cache) const {
+    my_cache->c0_stale = false;
+    my_cache->c1_stale = false;
+    my_cache->c2_stale = false;
+    my_cache->c3_stale = false;
+  }
+
+  // Verify that all cache entries depending on the state `v0` is marked as
+  // stale, and all other cache entries remain fresh. Then, refresh all the
+  // cache entries.
+  void VerifyV0CacheStale() {
+    auto& mutable_cache = state_.get_mutable_cache();
+    for (int i = 0; i < static_cast<int>(mutable_cache.size()); ++i) {
+      auto& my_cache = static_cast<MyElementCache&>(*mutable_cache[i]);
+      EXPECT_TRUE(my_cache.c0_stale);
+      EXPECT_TRUE(my_cache.c3_stale);
+      EXPECT_FALSE(my_cache.c1_stale);
+      EXPECT_FALSE(my_cache.c2_stale);
+      RefreshCache(&my_cache);
+    }
+  }
+
+  // Verify that all cache entries depending on the state `v` is marked as
+  // stale, and all other cache entries remain fresh. Then, refresh all the
+  // cache entries
+  void VerifyVCacheStale() {
+    auto& mutable_cache = state_.get_mutable_cache();
+    for (int i = 0; i < static_cast<int>(mutable_cache.size()); ++i) {
+      auto& my_cache = static_cast<MyElementCache&>(*mutable_cache[i]);
+      EXPECT_TRUE(my_cache.c0_stale);
+      EXPECT_TRUE(my_cache.c2_stale);
+      EXPECT_TRUE(my_cache.c3_stale);
+      EXPECT_FALSE(my_cache.c1_stale);
+      RefreshCache(&my_cache);
+    }
+  }
+
+  // Verify that all cache entries depending on the state `x0` is marked as
+  // stale, and all other cache entries remain fresh. Then, refresh all the
+  // cache entries.
+  void VerifyX0CacheStale() {
+    auto& mutable_cache = state_.get_mutable_cache();
+    for (int i = 0; i < static_cast<int>(mutable_cache.size()); ++i) {
+      auto& my_cache = static_cast<MyElementCache&>(*mutable_cache[i]);
+      EXPECT_TRUE(my_cache.c1_stale);
+      EXPECT_TRUE(my_cache.c3_stale);
+      EXPECT_FALSE(my_cache.c0_stale);
+      EXPECT_FALSE(my_cache.c2_stale);
+      RefreshCache(&my_cache);
+    }
+  }
+
+  // Verify that all cache entries depending on the state `x` is marked as
+  // stale, and all other cache entries remain fresh. Then, refresh all the
+  // cache entries
+  void VerifyXCacheStale() {
+    auto& mutable_cache = state_.get_mutable_cache();
+    for (int i = 0; i < static_cast<int>(mutable_cache.size()); ++i) {
+      auto& my_cache = static_cast<MyElementCache&>(*mutable_cache[i]);
+      EXPECT_TRUE(my_cache.c1_stale);
+      EXPECT_TRUE(my_cache.c2_stale);
+      EXPECT_TRUE(my_cache.c3_stale);
+      EXPECT_FALSE(my_cache.c0_stale);
+      RefreshCache(&my_cache);
+    }
+  }
+
+  // Verify that all cache entries all fresh.
+  void VerifyAllCacheFresh() const {
+    auto& cache = state_.get_cache();
+    for (int i = 0; i < static_cast<int>(cache.size()); ++i) {
+      auto& my_cache = static_cast<MyElementCache&>(*cache[i]);
+      EXPECT_FALSE(my_cache.c0_stale);
+      EXPECT_FALSE(my_cache.c3_stale);
+      EXPECT_FALSE(my_cache.c1_stale);
+      EXPECT_FALSE(my_cache.c2_stale);
+    }
+  }
+
+  // FemState under test.
+  FemState<double, kDim> state_;
+};
+
+// Verify setters and getters are working properly.
+TEST_F(FemStateTest, SetAndGet) {
+  SetStates();
+  EXPECT_EQ(state_.num_verts(), 1);
+  EXPECT_EQ(state_.get_v0(), v0());
+  EXPECT_EQ(state_.get_v(), v());
+  EXPECT_EQ(state_.get_x0(), x0());
+  EXPECT_EQ(state_.get_x(), x());
+}
+
+// Verify resizing does not thrash existing values.
+TEST_F(FemStateTest, ConservativeResize) {
+  SetStates();
+  state_.resize(2);
+  // The first entry should remain unchanged.
+  EXPECT_EQ(state_.get_v0_at(0), v0());
+  EXPECT_EQ(state_.get_v_at(0), v());
+  EXPECT_EQ(state_.get_x0_at(0), x0());
+  EXPECT_EQ(state_.get_x_at(0), x());
+}
+
+// Verify convenient setters and getters at a given vertex are working properly.
+TEST_F(FemStateTest, SetAndGetAt) {
+  state_.set_v0_at(0, 2 * v0());
+  state_.set_v_at(0, 2 * v());
+  state_.set_x0_at(0, 2 * x0());
+  state_.set_x_at(0, 2 * x());
+  EXPECT_EQ(state_.get_v0_at(0), 2 * v0());
+  EXPECT_EQ(state_.get_v_at(0), 2 * v());
+  EXPECT_EQ(state_.get_x0_at(0), 2 * x0());
+  EXPECT_EQ(state_.get_x_at(0), 2 * x());
+}
+
+// Verify setting states to different values marks cache entries stale.
+TEST_F(FemStateTest, SetStatesMarkCacheStale) {
+  state_.set_v(2 * v());
+  VerifyVCacheStale();
+  state_.set_v0(2 * v0());
+  VerifyV0CacheStale();
+  state_.set_x(2 * x());
+  VerifyXCacheStale();
+  state_.set_x0(2 * x0());
+  VerifyX0CacheStale();
+}
+
+// Verify setting states at a vertex to different values marks cache entries
+// stale.
+TEST_F(FemStateTest, SetStatesAtMarkCacheStale) {
+  state_.set_v_at(0, 2 * v());
+  VerifyVCacheStale();
+  state_.set_v0_at(0, 2 * v0());
+  VerifyV0CacheStale();
+  state_.set_x_at(0, 2 * x());
+  VerifyXCacheStale();
+  state_.set_x0_at(0, 2 * x0());
+  VerifyX0CacheStale();
+}
+
+// Verify getting the mutable states marks cache entries stale.
+TEST_F(FemStateTest, GetMutableStateMarkStale) {
+  auto v0 = state_.get_mutable_v0();
+  const VectorX<double> new_v0 = Vector3<double>(1, 2, 3);
+  v0 = new_v0;
+  EXPECT_EQ(state_.get_v0(), new_v0);
+  VerifyV0CacheStale();
+
+  auto v = state_.get_mutable_v();
+  const VectorX<double> new_v = Vector3<double>(3, 4, 5);
+  v = new_v;
+  EXPECT_EQ(state_.get_v(), new_v);
+  VerifyVCacheStale();
+
+  auto x0 = state_.get_mutable_x0();
+  const VectorX<double> new_x0 = Vector3<double>(5, 6, 7);
+  x0 = new_x0;
+  EXPECT_EQ(state_.get_x0(), new_x0);
+  VerifyX0CacheStale();
+
+  auto x = state_.get_mutable_x();
+  const VectorX<double> new_x = Vector3<double>(7, 8, 9);
+  x = new_x;
+  EXPECT_EQ(state_.get_x(), new_x);
+  VerifyXCacheStale();
+}
+
+// Verify setting states to the same values as existing states does not mark
+// cache entries stale.
+TEST_F(FemStateTest, SetSameStatesPreserveCache) {
+  state_.set_v(v());
+  VerifyAllCacheFresh();
+  state_.set_v0(v0());
+  VerifyAllCacheFresh();
+  state_.set_x(x());
+  VerifyAllCacheFresh();
+  state_.set_x0(x0());
+  VerifyAllCacheFresh();
+}
+
+// Verify setting states at a vertex to the same values as existing states does
+// not mark cache entries stale.
+TEST_F(FemStateTest, SetSameStatesAtPreserveCache) {
+  state_.set_v_at(0, v());
+  VerifyAllCacheFresh();
+  state_.set_v0_at(0, v0());
+  VerifyAllCacheFresh();
+  state_.set_x_at(0, x());
+  VerifyAllCacheFresh();
+  state_.set_x0_at(0, x0());
+  VerifyAllCacheFresh();
+}
+}  // namespace
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Add the API for FemState and ElementCache.
Flesh out simple caching mechanism for element cache quantities.
Create ElasticityElementCache that implements the API of ElementCache as well as
ConstitutiveModelCache required in ElasticityElementCache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14228)
<!-- Reviewable:end -->
