### PR TITLE
Add accessors to DiagramBuilder for exported ports

### DIFF
--- a/systems/framework/diagram_builder.cc
+++ b/systems/framework/diagram_builder.cc
@@ -119,6 +119,25 @@ InputPortIndex DiagramBuilder<T>::ExportInput(
 }
 
 template <typename T>
+bool DiagramBuilder<T>::HasExportedInputNamed(std::string name) {
+  return (std::find(input_port_names_.begin(), input_port_names_.end(), name)
+          != input_port_names_.end());
+}
+
+template <typename T>
+const InputPort<T>& DiagramBuilder<T>::GetExportedInputPort(std::string name) {
+  for (size_t i = 0; i < input_port_names_.size(); ++i) {
+    if (input_port_names_[i] == name) {
+      return input_port_ids_[i].first->get_input_port(
+          input_port_ids_[i].second);
+    }
+  }
+  throw std::logic_error(fmt::format(
+      "GetExportedInputPort(\"{}\"): No input port by that name was exported",
+      name));
+}
+
+template <typename T>
 OutputPortIndex DiagramBuilder<T>::ExportOutput(
     const OutputPort<T>& output,
     std::variant<std::string, UseDefaultName> name) {
@@ -137,6 +156,26 @@ OutputPortIndex DiagramBuilder<T>::ExportOutput(
   output_port_names_.emplace_back(std::move(port_name));
 
   return return_id;
+}
+
+template <typename T>
+bool DiagramBuilder<T>::HasExportedOutputNamed(std::string name) {
+  return (std::find(output_port_names_.begin(), output_port_names_.end(), name)
+          != output_port_names_.end());
+}
+
+template <typename T>
+const OutputPort<T>& DiagramBuilder<T>::GetExportedOutputPort(
+    std::string name) {
+  for (size_t i = 0; i < output_port_names_.size(); ++i) {
+    if (output_port_names_[i] == name) {
+      return output_port_ids_[i].first->get_output_port(
+          output_port_ids_[i].second);
+    }
+  }
+  throw std::logic_error(fmt::format(
+      "GetExportedOutputPort(\"{}\"): No output port by that name was exported",
+      name));
 }
 
 template <typename T>

--- a/systems/framework/diagram_builder.h
+++ b/systems/framework/diagram_builder.h
@@ -169,6 +169,12 @@ class DiagramBuilder {
       const InputPort<T>& input,
       std::variant<std::string, UseDefaultName> name = kUseDefaultName);
 
+  /// Return whether an input port has been exported with the given @p name.
+  bool HasExportedInputNamed(std::string name);
+
+  /// Return the exported input port named @p name.
+  const InputPort<T>& GetExportedInputPort(std::string name);
+
   /// Declares that the given @p output port of a constituent system is an
   /// output of the entire diagram.  @p name is an optional name for the output
   /// port; if it is unspecified, then a default name will be provided.
@@ -177,6 +183,12 @@ class DiagramBuilder {
   OutputPortIndex ExportOutput(
       const OutputPort<T>& output,
       std::variant<std::string, UseDefaultName> name = kUseDefaultName);
+
+  /// Return whether an output port has been exported with the given @p name.
+  bool HasExportedOutputNamed(std::string name);
+
+  /// Return the exported output port named @p name.
+  const OutputPort<T>& GetExportedOutputPort(std::string name);
 
   /// Builds the Diagram that has been described by the calls to Connect,
   /// ExportInput, and ExportOutput.

--- a/systems/framework/test/diagram_builder_test.cc
+++ b/systems/framework/test/diagram_builder_test.cc
@@ -434,6 +434,16 @@ GTEST_TEST(DiagramBuilderTest, SetPortNamesTest) {
   const auto source2_out =
       builder.ExportOutput(source2->get_output_port(0), "source2");
 
+  EXPECT_TRUE(builder.HasExportedInputNamed("sink1"));
+  EXPECT_EQ(&builder.GetExportedInputPort("sink1"),
+            &sink1->get_input_port(0));
+  EXPECT_FALSE(builder.HasExportedInputNamed("sink3"));
+
+  EXPECT_TRUE(builder.HasExportedOutputNamed("source1"));
+  EXPECT_EQ(&builder.GetExportedOutputPort("source1"),
+            &source1->get_output_port(0));
+  EXPECT_FALSE(builder.HasExportedOutputNamed("source3"));
+
   auto diagram = builder.Build();
 
   EXPECT_EQ(diagram->get_input_port(sink1_in).get_name(), "sink1");


### PR DESCRIPTION
* Downstream we have found passing builders around to be the most efficient
  and terse way to build up a complex diagram.
* Often different methods operating on the same diagram wish to connect without
  knowing each others' internal details.
* The export mechanism accomplishes this across the diagram boundary; with this
  change it is also usable within the diagram building process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14229)
<!-- Reviewable:end -->
