### PR TITLE
Add ConstitutiveModel and DeformationGradientCache.

### DIFF
--- a/multibody/fem/dev/BUILD.bazel
+++ b/multibody/fem/dev/BUILD.bazel
@@ -13,6 +13,39 @@ package(
 )
 
 drake_cc_library(
+    name = "constitutive_model",
+    hdrs = [
+        "constitutive_model.h",
+    ],
+    deps = [
+        ":deformation_gradient_cache",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "deformation_gradient_cache",
+    hdrs = [
+        "deformation_gradient_cache.h",
+    ],
+    deps = [
+        ":fem_indexes",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "fem_indexes",
+    hdrs = [
+        "fem_indexes.h",
+    ],
+    deps = [
+        "//common:essential",
+        "//common:type_safe_index",
+    ],
+)
+
+drake_cc_library(
     name = "isoparametric_element",
     srcs = [
         "isoparametric_element.cc",
@@ -21,6 +54,37 @@ drake_cc_library(
         "isoparametric_element.h",
     ],
     deps = [
+        "//common:default_scalars",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "linear_elasticity_model",
+    srcs = [
+        "linear_elasticity_model.cc",
+    ],
+    hdrs = [
+        "linear_elasticity_model.h",
+    ],
+    deps = [
+        ":constitutive_model",
+        ":linear_elasticity_model_cache",
+        "//common:default_scalars",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "linear_elasticity_model_cache",
+    srcs = [
+        "linear_elasticity_model_cache.cc",
+    ],
+    hdrs = [
+        "linear_elasticity_model_cache.h",
+    ],
+    deps = [
+        ":deformation_gradient_cache",
         "//common:default_scalars",
         "//common:essential",
     ],
@@ -49,6 +113,25 @@ drake_cc_library(
     deps = [
         "//common:essential",
         "//common:nice_type_name",
+    ],
+)
+
+drake_cc_googletest(
+    name = "linear_elasticity_model_cache_test",
+    deps = [
+        ":linear_elasticity_model_cache",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "linear_elasticity_model_test",
+    deps = [
+        ":linear_elasticity_model",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+        "//math:gradient",
+        "//math:jacobian",
     ],
 )
 

--- a/multibody/fem/dev/constitutive_model.h
+++ b/multibody/fem/dev/constitutive_model.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fem/dev/deformation_gradient_cache.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+/** A constitutive model relates the strain to the stress of the material. It
+ governs the material response under deformation. This constitutive relationship
+ is defined through the potential energy, which increases with non-rigid
+ deformation from the initial state.
+ @tparam_nonsymbolic_scalar T. */
+template <typename T>
+class ConstitutiveModel {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ConstitutiveModel);
+
+  ConstitutiveModel() = default;
+
+  virtual ~ConstitutiveModel() {}
+
+  // TODO(xuchenhan-tri) Update the list of methods here as more methods are
+  // introduced.
+  // TODO(xuchenhan-tri) Clarify that FemElement is responsible for updating
+  // the cached quantities once FemElement is introduced.
+  /** @name "Calc" Methods
+   "Calc" methods that calculate the energy density and stress given the cached
+   quantities required for these calculations. The constitutive model expects
+   that the input cached quantities are up-to-date.
+   @warning Derived classes will static cast `cache` into derived cache classes
+   that match the derived %ConstitutiveModel. Make sure the `cache` that is
+   passed in matches the %ConstitutiveModel. */
+
+  /** Calculates the energy density, in unit J/m³, given the model cache. */
+  std::vector<T> CalcPsi(const DeformationGradientCache<T>& cache) const {
+    std::vector<T> Psi(cache.num_quads());
+    CalcPsi(cache, &Psi);
+    return Psi;
+  }
+
+  /** Alternative signature for CalcPsi that writes the result in the output
+   argument. */
+  void CalcPsi(const DeformationGradientCache<T>& cache,
+               std::vector<T>* Psi) const {
+    DRAKE_DEMAND(Psi != nullptr);
+    DRAKE_DEMAND(static_cast<int>(Psi->size()) == cache.num_quads());
+    DoCalcPsi(cache, Psi);
+  }
+
+  /** Calculates the First Piola stress, in unit Pa, given the model cache. */
+  std::vector<Matrix3<T>> CalcP(
+      const DeformationGradientCache<T>& cache) const {
+    std::vector<Matrix3<T>> P(cache.num_quads());
+    CalcP(cache, &P);
+    return P;
+  }
+
+  /** Alternative signature for CalcP that writes the result in the output
+   argument. */
+  void CalcP(const DeformationGradientCache<T>& cache,
+             std::vector<Matrix3<T>>* P) const {
+    DRAKE_DEMAND(P != nullptr);
+    DRAKE_DEMAND(static_cast<int>(P->size()) == cache.num_quads());
+    DoCalcP(cache, P);
+  }
+
+ protected:
+  /* Calculates the energy density, in unit J/m³, given the model cache. */
+  virtual void DoCalcPsi(const DeformationGradientCache<T>& cache,
+                         std::vector<T>* Psi) const = 0;
+
+  /* Calculates the First Piola stress, in unit Pa, given the model cache. */
+  virtual void DoCalcP(const DeformationGradientCache<T>& cache,
+                       std::vector<Matrix3<T>>* P) const = 0;
+};
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/dev/deformation_gradient_cache.h
+++ b/multibody/fem/dev/deformation_gradient_cache.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fem/dev/fem_indexes.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+/** %DeformationGradientCache stores per element cached quantities that work in
+ tandem with ConstitutiveModel. It is an abstract interface that actual concrete
+ constitutive models must inherit from to store the set of specific quantities
+ that need to be cached for the specific model. There should be a one-to-one
+ correspondence between the constitutive model `Foo` that inherits from
+ ConstitutiveModel and its cached quantities `FooCache` that inherits from
+ %DeformationGradientCache. These cached quantities depend solely on deformation
+ gradients, and they facilitate calculations such as energy density, stress and
+ stress derivative in the constitutive model. ConstitutiveModel takes
+ the corresponding cache as an argument when performing various calculations.
+ @tparam_nonsymbolic_scalar T. */
+template <typename T>
+class DeformationGradientCache {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DeformationGradientCache);
+
+  virtual ~DeformationGradientCache() = default;
+
+  /** Updates the cached quantities with the given deformation gradients.
+   @param F The up-to-date deformation gradients evaluated at the quadrature
+   locations for the associated element.
+   @pre The size of `F` must be the same as `num_quads()`. */
+  void UpdateCache(const std::vector<Matrix3<T>>& F) {
+    DRAKE_DEMAND(static_cast<int>(F.size()) == num_quads_);
+    deformation_gradient_ = F;
+    DoUpdateCache(F);
+  }
+
+  /** The index of the FemElement associated with this
+   %DeformationGradientCache. */
+  ElementIndex element_index() const { return element_index_; }
+
+  /** The number of quadrature locations at which cached quantities need to be
+   evaluated. */
+  int num_quads() const { return num_quads_; }
+
+  const std::vector<Matrix3<T>>& deformation_gradient() const {
+    return deformation_gradient_;
+  }
+
+ protected:
+  /* Constructs a DeformationGradientCache with the given element index and
+   number of quadrature locations. Users should not directly construct
+   DeformationGradientCache. They should construct specific constitutive model
+   caches (e.g. LinearElasticityModelCache) that invoke the base constructor.
+   @param element_index The index of the FemElement associated with this
+   DeformationGradientCache.
+   @param num_quads The number of quadrature locations at which cached
+   quantities need to be evaluated.
+   @pre `num_quads` must be positive. */
+  DeformationGradientCache(ElementIndex element_index, int num_quads)
+      : element_index_(element_index),
+        num_quads_(num_quads),
+        deformation_gradient_(num_quads) {
+    DRAKE_DEMAND(element_index.is_valid());
+    DRAKE_DEMAND(num_quads > 0);
+  }
+
+  /* Updates the cached quantities with the given deformation gradients.
+   @param F The up-to-date deformation gradients evaluated at the quadrature
+   locations for the associated element.
+   @pre The size of `F` must be the same as `num_quads()`. */
+  virtual void DoUpdateCache(const std::vector<Matrix3<T>>& F) = 0;
+
+ private:
+  ElementIndex element_index_;
+  int num_quads_{-1};
+  std::vector<Matrix3<T>> deformation_gradient_;
+};
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/dev/fem_indexes.h
+++ b/multibody/fem/dev/fem_indexes.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "drake/common/type_safe_index.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+/** Index used to identify element by index among FEM elements. */
+using ElementIndex = TypeSafeIndex<class ElementTag>;
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/dev/linear_elasticity_model.cc
+++ b/multibody/fem/dev/linear_elasticity_model.cc
@@ -1,0 +1,62 @@
+#include "drake/multibody/fem/dev/linear_elasticity_model.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+template <typename T>
+LinearElasticityModel<T>::LinearElasticityModel(const T& youngs_modulus,
+                                                const T& poisson_ratio)
+    : E_(youngs_modulus), nu_(poisson_ratio) {
+  VerifyParameterValidity(E_, nu_);
+  SetLameParameters(E_, nu_);
+}
+
+template <typename T>
+void LinearElasticityModel<T>::DoCalcPsi(
+    const DeformationGradientCache<T>& cache, std::vector<T>* Psi) const {
+  const LinearElasticityModelCache<T>& linear_cache =
+      static_cast<const LinearElasticityModelCache<T>&>(cache);
+  for (int i = 0; i < linear_cache.num_quads(); ++i) {
+    const auto& strain = linear_cache.strain()[i];
+    const auto& trace_strain = linear_cache.trace_strain()[i];
+    (*Psi)[i] = mu_ * strain.squaredNorm() +
+                0.5 * lambda_ * trace_strain * trace_strain;
+  }
+}
+
+template <typename T>
+void LinearElasticityModel<T>::DoCalcP(const DeformationGradientCache<T>& cache,
+                                       std::vector<Matrix3<T>>* P) const {
+  const LinearElasticityModelCache<T>& linear_cache =
+      static_cast<const LinearElasticityModelCache<T>&>(cache);
+  for (int i = 0; i < linear_cache.num_quads(); ++i) {
+    const auto& strain = linear_cache.strain()[i];
+    const auto& trace_strain = linear_cache.trace_strain()[i];
+    (*P)[i] =
+        2.0 * mu_ * strain + lambda_ * trace_strain * Matrix3<T>::Identity();
+  }
+}
+
+template <typename T>
+void LinearElasticityModel<T>::VerifyParameterValidity(
+    const T& youngs_modulus, const T& poisson_ratio) const {
+  if (youngs_modulus < 0.0) {
+    throw std::logic_error("Young's modulus must be nonnegative.");
+  }
+  if (poisson_ratio >= 0.5 || poisson_ratio <= -1) {
+    throw std::logic_error("Poisson ratio must be in (-1, 0.5).");
+  }
+}
+
+template <typename T>
+void LinearElasticityModel<T>::SetLameParameters(const T& youngs_modulus,
+                                                 const T& poisson_ratio) {
+  mu_ = youngs_modulus / (2.0 * (1.0 + poisson_ratio));
+  lambda_ = youngs_modulus * poisson_ratio /
+            ((1.0 + poisson_ratio) * (1.0 - 2.0 * poisson_ratio));
+}
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fem::LinearElasticityModel);

--- a/multibody/fem/dev/linear_elasticity_model.h
+++ b/multibody/fem/dev/linear_elasticity_model.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fem/dev/constitutive_model.h"
+#include "drake/multibody/fem/dev/linear_elasticity_model_cache.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+/** Implements the infinitesimal-strain linear elasticity constitutive model as
+ described in Section 7.4 of [Gonzalez, 2008].
+ @tparam_nonsymbolic_scalar T.
+
+[Gonzalez, 2008] Gonzalez, Oscar, and Andrew M. Stuart. A first course in
+continuum mechanics. Cambridge University Press, 2008. */
+template <typename T>
+class LinearElasticityModel final : public ConstitutiveModel<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LinearElasticityModel);
+
+  /** Constructs a %LinearElasticityModel constitutive model with the prescribed
+   Young's modulus and Poisson ratio.
+   @param youngs_modulus Young's modulus of the model, with unit N/m²
+   @param poisson_ratio Poisson ratio of the model, unitless.
+   @pre youngs_modulus must be non-negative.
+   @pre poisson_ratio must be strictly greater than -1 and strictly smaller than
+   0.5. */
+  LinearElasticityModel(const T& youngs_modulus, const T& poisson_ratio);
+
+  ~LinearElasticityModel() = default;
+
+  T youngs_modulus() const { return E_; }
+
+  T poisson_ratio() const { return nu_; }
+
+  T shear_modulus() const { return mu_; }
+
+  T lame_first_parameter() const { return lambda_; }
+
+ protected:
+  /* Calculates the energy density, in unit J/m³, given the model cache. */
+  void DoCalcPsi(const DeformationGradientCache<T>& cache,
+                 std::vector<T>* Psi) const final;
+
+  /* Calculates the First Piola stress, in unit Pa, given the model cache. */
+  void DoCalcP(const DeformationGradientCache<T>& cache,
+               std::vector<Matrix3<T>>* P) const final;
+
+ private:
+  /* Set the Lamé parameters from Young's modulus and Poisson ratio. It's
+  important to keep the Lamé Parameters in sync with Young's modulus and
+  Poisson ratio as most computations use Lame parameters. */
+  void VerifyParameterValidity(const T& youngs_modulus,
+                               const T& poisson_ratio) const;
+
+  void SetLameParameters(const T& youngs_modulus, const T& poisson_ratio);
+
+  T E_;       // Young's modulus, N/m².
+  T nu_;      // Poisson ratio.
+  T mu_;      // Lamé's second parameter/Shear modulus, N/m².
+  T lambda_;  // Lamé's first parameter, N/m².
+};
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fem::LinearElasticityModel);

--- a/multibody/fem/dev/linear_elasticity_model_cache.cc
+++ b/multibody/fem/dev/linear_elasticity_model_cache.cc
@@ -1,0 +1,20 @@
+#include "drake/multibody/fem/dev/linear_elasticity_model_cache.h"
+
+#include <vector>
+
+namespace drake {
+namespace multibody {
+namespace fem {
+template <typename T>
+void LinearElasticityModelCache<T>::DoUpdateCache(
+    const std::vector<Matrix3<T>>& F) {
+  for (int i = 0; i < this->num_quads(); ++i) {
+    strain_[i] = 0.5 * (F[i] + F[i].transpose()) - Matrix3<T>::Identity();
+    trace_strain_[i] = strain_[i].trace();
+  }
+}
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fem::LinearElasticityModelCache);

--- a/multibody/fem/dev/linear_elasticity_model_cache.h
+++ b/multibody/fem/dev/linear_elasticity_model_cache.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fem/dev/deformation_gradient_cache.h"
+#include "drake/multibody/fem/dev/fem_indexes.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+/** Cached quantities for the LinearElasticityModel constitutive model.
+ See LinearElasticityModel for how the cache is used. See
+ DeformationGradientCache for more about cached quantities for constitutive
+ models.
+ @tparam_nonsymbolic_scalar T. */
+template <typename T>
+class LinearElasticityModelCache : public DeformationGradientCache<T> {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(LinearElasticityModelCache);
+
+  /** Constructs a %LinearElasticityModelCache with the given element index and
+   number of quadrature locations.
+   @param element_index The index of the FemElement associated with this
+   DeformationGradientCache.
+   @param num_quads The number of quadrature locations at which cached
+   quantities need to be evaluated.
+   @pre `num_quads` must be positive. */
+  LinearElasticityModelCache(ElementIndex element_index, int num_quads)
+      : DeformationGradientCache<T>(element_index, num_quads),
+        strain_(num_quads),
+        trace_strain_(num_quads) {}
+
+  /** Returns the infinitesimal strains evaluated at the quadrature locations
+   for the associated element. */
+  const std::vector<Matrix3<T>>& strain() const { return strain_; }
+
+  /** Returns the traces of the infinitesimal strains evaluated at the
+   quadrature locations for the associated element. */
+  const std::vector<T>& trace_strain() const { return trace_strain_; }
+
+ protected:
+  /* Updates the cached quantities with the given deformation gradients.
+   @param F The up-to-date deformation gradients evaluated at the quadrature
+   locations for the associated element.
+   @pre The size of `F` must be the same as `num_quads()`. */
+  void DoUpdateCache(const std::vector<Matrix3<T>>& F) final;
+
+ private:
+  // Infinitesimal strain = 0.5 * (F + Fᵀ) - I.
+  std::vector<Matrix3<T>> strain_;
+  // Trace of `strain_`.
+  std::vector<T> trace_strain_;
+};
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fem::LinearElasticityModelCache);

--- a/multibody/fem/dev/test/linear_elasticity_model_cache_test.cc
+++ b/multibody/fem/dev/test/linear_elasticity_model_cache_test.cc
@@ -1,0 +1,39 @@
+#include "drake/multibody/fem/dev/linear_elasticity_model_cache.h"
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace {
+const ElementIndex kElementIndex(3);
+constexpr int kNumQuads = 1;
+
+class LinearElasticityCacheTest : public ::testing::Test {
+ protected:
+  LinearElasticityModelCache<double> linear_elasticity_cache_{kElementIndex,
+                                                              kNumQuads};
+};
+
+TEST_F(LinearElasticityCacheTest, LinearElasticityCacheInitialization) {
+  EXPECT_EQ(linear_elasticity_cache_.element_index(), kElementIndex);
+  EXPECT_EQ(linear_elasticity_cache_.num_quads(), kNumQuads);
+  EXPECT_EQ(linear_elasticity_cache_.deformation_gradient().size(), kNumQuads);
+  EXPECT_EQ(linear_elasticity_cache_.strain().size(), kNumQuads);
+  EXPECT_EQ(linear_elasticity_cache_.trace_strain().size(), kNumQuads);
+}
+
+TEST_F(LinearElasticityCacheTest, UpdateCache) {
+  const Matrix3<double> F = Matrix3<double>::Random();
+  linear_elasticity_cache_.UpdateCache({F});
+  const Matrix3<double> strain =
+      0.5 * (F + F.transpose()) - Matrix3<double>::Identity();
+  const double trace_strain = strain.trace();
+  EXPECT_EQ(linear_elasticity_cache_.deformation_gradient()[0], F);
+  EXPECT_EQ(linear_elasticity_cache_.strain()[0], strain);
+  EXPECT_EQ(linear_elasticity_cache_.trace_strain()[0], trace_strain);
+}
+}  // namespace
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/dev/test/linear_elasticity_model_test.cc
+++ b/multibody/fem/dev/test/linear_elasticity_model_test.cc
@@ -1,0 +1,104 @@
+#include "drake/multibody/fem/dev/linear_elasticity_model.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/math/autodiff_gradient.h"
+#include "drake/math/jacobian.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace {
+const ElementIndex kDummyElementIndex(0);
+constexpr int kNumQuads = 2;
+
+GTEST_TEST(LinearElasticityTest, Parameters) {
+  const LinearElasticityModel<double> model(100.0, 0.25);
+  const double mu = 40.0;
+  const double lambda = 40.0;
+  EXPECT_EQ(model.youngs_modulus(), 100.0);
+  EXPECT_EQ(model.poisson_ratio(), 0.25);
+  EXPECT_EQ(model.shear_modulus(), mu);
+  EXPECT_EQ(model.lame_first_parameter(), lambda);
+}
+
+GTEST_TEST(LinearElasticityTest, InvalidYoungsModulus) {
+  DRAKE_EXPECT_THROWS_MESSAGE(LinearElasticityModel<double>(-1.0, 0.25),
+                              std::logic_error,
+                              "Young's modulus must be nonnegative.");
+}
+
+GTEST_TEST(LinearElasticityTest, InvalidPoissonRatioAtUpperLimit) {
+  DRAKE_EXPECT_THROWS_MESSAGE(LinearElasticityModel<double>(100.0, 0.5),
+                              std::logic_error,
+                              "Poisson ratio must be in \\(-1, 0.5\\).");
+}
+
+GTEST_TEST(LinearElasticityTest, InvalidPoissonRatioOverUpperLimit) {
+  DRAKE_EXPECT_THROWS_MESSAGE(LinearElasticityModel<double>(100.0, 0.6),
+                              std::logic_error,
+                              "Poisson ratio must be in \\(-1, 0.5\\).");
+}
+
+GTEST_TEST(LinearElasticityTest, InvalidPoissonRatioAtLower) {
+  DRAKE_EXPECT_THROWS_MESSAGE(LinearElasticityModel<double>(100.0, -1.0),
+                              std::logic_error,
+                              "Poisson ratio must be in \\(-1, 0.5\\).");
+}
+
+GTEST_TEST(LinearElasticityTest, InvalidPoissonRatioBelowLowerLimit) {
+  DRAKE_EXPECT_THROWS_MESSAGE(LinearElasticityModel<double>(100.0, -1.1),
+                              std::logic_error,
+                              "Poisson ratio must be in \\(-1, 0.5\\).");
+}
+
+GTEST_TEST(LinearElasticityTest, UndeformedState) {
+  const LinearElasticityModel<double> model(100.0, 0.25);
+  LinearElasticityModelCache<double> cache(kDummyElementIndex, kNumQuads);
+  const std::vector<Matrix3<double>> F(kNumQuads, Matrix3<double>::Identity());
+  cache.UpdateCache(F);
+  // In undeformed state, the energy density should be zero.
+  const std::vector<double> analytic_energy_density(kNumQuads, 0);
+  // In undeformaed state, the stress should be zero.
+  const std::vector<Matrix3<double>> analytic_stress(kNumQuads,
+                                                     Matrix3<double>::Zero());
+  EXPECT_EQ(model.CalcPsi(cache), analytic_energy_density);
+  EXPECT_EQ(model.CalcP(cache), analytic_stress);
+}
+
+GTEST_TEST(LinearElasticityTest, PIsDerivativeOfPsi) {
+  const LinearElasticityModel<AutoDiffXd> model_autodiff(100.0, 0.25);
+  LinearElasticityModelCache<AutoDiffXd> cache_autodiff(kDummyElementIndex,
+                                                        kNumQuads);
+  // Create random AutoDiffXd deformation.
+  Matrix3<double> F;
+  F << 0.18, 0.63, 0.54,
+       0.13, 0.92, 0.17,
+       0.03, 0.86, 0.85;
+  const std::vector<Matrix3<double>> Fs(kNumQuads, F);
+  std::vector<Matrix3<AutoDiffXd>> Fs_autodiff(kNumQuads);
+  const Eigen::Matrix<double, 9, Eigen::Dynamic> gradient =
+      MatrixX<double>::Identity(9, 9);
+  for (int i = 0; i < kNumQuads; ++i) {
+    const auto F_autodiff_flat = math::initializeAutoDiffGivenGradientMatrix(
+        Eigen::Map<const Eigen::Matrix<double, 9, 1>>(Fs[i].data(), 9),
+        gradient);
+    Fs_autodiff[i] =
+        Eigen::Map<const Matrix3<AutoDiffXd>>(F_autodiff_flat.data(), 3, 3);
+  }
+  // P should be derivative of Psi.
+  cache_autodiff.UpdateCache(Fs_autodiff);
+  const auto energy = model_autodiff.CalcPsi(cache_autodiff);
+  const auto P = model_autodiff.CalcP(cache_autodiff);
+  for (int i = 0; i < kNumQuads; ++i) {
+    EXPECT_TRUE(CompareMatrices(
+        Eigen::Map<const Matrix3<double>>(energy[i].derivatives().data(), 3, 3),
+        P[i]));
+  }
+}
+}  // namespace
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
The ConstitutiveModel class takes in a DeformationGradientCache and
calculates energy and stress using the material's constitutive
relationship. ConstitutiveModel is the "const method" and
DeformationGradientCache is the "data".

This concept is illustrated with the concrete instance pair
LinearElasticityModel and LinearElasticityModelCache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14236)
<!-- Reviewable:end -->
