### PR TITLE
MosekSolver supports quadratic cost with nonlinear conic constraints.

### DIFF
--- a/math/quadratic_form.h
+++ b/math/quadratic_form.h
@@ -20,6 +20,7 @@ namespace math {
  * @pre 1. Y is positive semidefinite.
  *      2. zero_tol is non-negative.
  * @throws std::runtime_error when the pre-conditions are not satisfied.
+ * @note We only use the lower triangular part of Y.
  */
 Eigen::MatrixXd DecomposePSDmatrixIntoXtransposeTimesX(
     const Eigen::Ref<const Eigen::MatrixXd>& Y, double zero_tol);

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -785,10 +785,12 @@ drake_cc_library(
     hdrs = ["mosek_solver.h"],
     deps = select({
         "//tools:with_mosek": [
+            ":aggregate_costs_constraints",
             ":mathematical_program",
             ":mathematical_program_result",
             ":solver_base",
             "//common:scoped_singleton",
+            "//math:quadratic_form",
             "@mosek",
         ],
         "//conditions:default": [

--- a/solvers/test/mosek_solver_test.cc
+++ b/solvers/test/mosek_solver_test.cc
@@ -362,6 +362,38 @@ GTEST_TEST(MosekTest, UnivariateNonnegative1) {
     dut.CheckResult(result, 1E-9);
   }
 }
+
+GTEST_TEST(MosekTest, MinimalDistanceFromSphereProblem) {
+  for (bool with_linear_cost : {true, false}) {
+    MinimalDistanceFromSphereProblem<3> dut1(Eigen::Vector3d(0, 0, 0),
+                                             Eigen::Vector3d(0, 0, 0), 1,
+                                             with_linear_cost);
+    MinimalDistanceFromSphereProblem<3> dut2(Eigen::Vector3d(0, 0, 1),
+                                             Eigen::Vector3d(0, 0, 0), 1,
+                                             with_linear_cost);
+    MinimalDistanceFromSphereProblem<3> dut3(Eigen::Vector3d(0, 1, 1),
+                                             Eigen::Vector3d(0, 0, 0), 1,
+                                             with_linear_cost);
+    MinimalDistanceFromSphereProblem<3> dut4(Eigen::Vector3d(0, 1, 1),
+                                             Eigen::Vector3d(-1, -1, 0), 1,
+                                             with_linear_cost);
+    MosekSolver solver;
+    if (solver.available()) {
+      const double tol = 1E-4;
+      dut1.SolveAndCheckSolution(solver, tol);
+      dut2.SolveAndCheckSolution(solver, tol);
+      dut3.SolveAndCheckSolution(solver, tol);
+      dut4.SolveAndCheckSolution(solver, tol);
+    }
+  }
+}
+
+GTEST_TEST(MosekTest, SolveSDPwithQuadraticCosts) {
+  MosekSolver solver;
+  if (solver.available()) {
+    SolveSDPwithQuadraticCosts(solver, 1E-8);
+  }
+}
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/semidefinite_program_examples.h
+++ b/solvers/test/semidefinite_program_examples.h
@@ -93,6 +93,20 @@ void SolveSDPwithSecondOrderConeExample2(const SolverInterface& solver,
  */
 void SolveSDPwithOverlappingVariables(const SolverInterface& solver,
                                       double tol);
+
+/** Solve an SDP with quadratic cost and two PSD constraints, where each PSD
+ * constraint has duplicate entries and the two PSD matrix share a common
+ * variables.
+ * min x0² + 2*x0 + x2
+ * s.t ⎡x0 x1⎤ is psd
+ *     ⎣x1 x0⎦
+ *     ⎡x0 x1⎤ is psd
+ *     ⎣x1 x0⎦
+ *     x1 == 1
+ *
+ * The optimal solution will be x = (1, 1, -1).
+ */
+void SolveSDPwithQuadraticCosts(const SolverInterface& solver, double tol);
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake


### PR DESCRIPTION
Convert the quadratic cost to a linear cost with rotated Lorentz cone
constraint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14237)
<!-- Reviewable:end -->
