### PR TITLE
Draft: Replace clang.cindex with pygccxml

### DIFF
--- a/tools/skylark/pybind.bzl
+++ b/tools/skylark/pybind.bzl
@@ -359,9 +359,13 @@ def _generate_pybind_documentation_header_impl(ctx):
     outputs = [ctx.outputs.out]
     args.add("-output=" + ctx.outputs.out.path)
     out_xml = getattr(ctx.outputs, "out_xml", None)
+
     if out_xml != None:
         outputs.append(out_xml)
         args.add("-output_xml=" + out_xml.path)
+    castxml = getattr(ctx.attr, "castxml", None)
+    if castxml != None:
+       args.add("-castxml=" + castxml)
     args.add("-quiet")
     args.add("-root-name=" + ctx.attr.root_name)
     args.add("-ignore-dirs-for-coverage=" +
@@ -407,6 +411,7 @@ generate_pybind_documentation_header = rule(
             executable = True,
         ),
         "out": attr.output(mandatory = True),
+        "castxml": attr.string(mandatory = True),
         "out_xml": attr.output(mandatory = False),
         "root_name": attr.string(default = "pydrake_doc"),
         "exclude_hdr_patterns": attr.string_list(),

--- a/tools/workspace/pybind11/BUILD.bazel
+++ b/tools/workspace/pybind11/BUILD.bazel
@@ -119,6 +119,7 @@ generate_pybind_documentation_header(
     testonly = 1,
     out = "test/sample_header_documentation.h",
     out_xml = "sample_header_documentation_test.xml",
+    castxml = "/usr/local/bin/castxml",
     root_name = "sample_header_doc",
     targets = [
         ":sample_header",


### PR DESCRIPTION
Begin to replace the clang.cindex usage with pygccxml.

Towards https://github.com/RobotLocomotion/drake/issues/13670

Assumes CastXML is in /usr/local/bin/castxml.
Known errors:
  pygccxml asserts that all include directories exist when run.
  Executing
    `bazel build -s --sandbox_debug //tools/workspace/pybind11:generate_sample_header`
  returns the following error:
    `RuntimeError: include directory("bazel-out/k8-opt/bin/common/_virtual_includes/common") does not exist!`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14239)
<!-- Reviewable:end -->
