### PR TITLE
autodiffxd: Remove global heap overhead (experimental)

### DIFF
--- a/common/test/autodiffxd_heap_test.cc
+++ b/common/test/autodiffxd_heap_test.cc
@@ -29,101 +29,101 @@ class AutoDiffXdHeapTest : public ::testing::Test {
 // implementations may be vulnerable to dead-code elimination.
 
 TEST_F(AutoDiffXdHeapTest, Abs) {
-  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+  LimitMalloc guard({.max_num_allocations = 0});
   volatile auto v = abs(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Abs2) {
-  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+  LimitMalloc guard({.max_num_allocations = 0});
   volatile auto v = abs2(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Acos) {
-  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+  LimitMalloc guard({.max_num_allocations = 0});
   volatile auto v = acos(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Asin) {
-  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+  LimitMalloc guard({.max_num_allocations = 0});
   volatile auto v = asin(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Atan) {
-  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+  LimitMalloc guard({.max_num_allocations = 0});
   volatile auto v = atan(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Atan2) {
   {
-    LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+    LimitMalloc guard({.max_num_allocations = 0});
     volatile auto v = atan2(x_ + y_, y_);
   }
   {
-    LimitMalloc guard({.max_num_allocations = 2, .min_num_allocations = 2});
+    LimitMalloc guard({.max_num_allocations = 0});
     // Right-hand parameter moves are blocked by code in Eigen; see #14039.
     volatile auto v = atan2(y_, x_ + y_);
   }
 }
 
 TEST_F(AutoDiffXdHeapTest, Cos) {
-  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+  LimitMalloc guard({.max_num_allocations = 0});
   volatile auto v = cos(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Cosh) {
-  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+  LimitMalloc guard({.max_num_allocations = 0});
   volatile auto v = cosh(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Exp) {
-  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+  LimitMalloc guard({.max_num_allocations = 0});
   volatile auto v = exp(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Log) {
-  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+  LimitMalloc guard({.max_num_allocations = 0});
   volatile auto v = log(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Min) {
-  LimitMalloc guard({.max_num_allocations = 4, .min_num_allocations = 4});
+  LimitMalloc guard({.max_num_allocations = 0});
   volatile auto v = min(x_ + y_, y_);
   volatile auto w = min(x_, x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Max) {
-  LimitMalloc guard({.max_num_allocations = 4, .min_num_allocations = 4});
+  LimitMalloc guard({.max_num_allocations = 0});
   volatile auto v = max(x_ + y_, y_);
   volatile auto w = max(x_, x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Pow) {
-  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+  LimitMalloc guard({.max_num_allocations = 0});
   volatile auto v = pow(x_ + y_, 2.0);
 }
 
 TEST_F(AutoDiffXdHeapTest, Sin) {
-  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+  LimitMalloc guard({.max_num_allocations = 0});
   volatile auto v = sin(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Sinh) {
-  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+  LimitMalloc guard({.max_num_allocations = 0});
   volatile auto v = sinh(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Sqrt) {
-  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+  LimitMalloc guard({.max_num_allocations = 0});
   volatile auto v = sqrt(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Tan) {
-  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+  LimitMalloc guard({.max_num_allocations = 0});
   volatile auto v = tan(x_ + y_);
 }
 
 TEST_F(AutoDiffXdHeapTest, Tanh) {
-  LimitMalloc guard({.max_num_allocations = 1, .min_num_allocations = 1});
+  LimitMalloc guard({.max_num_allocations = 0});
   volatile auto v = tanh(x_ + y_);
 }
 

--- a/common/yaml/yaml_read_archive.h
+++ b/common/yaml/yaml_read_archive.h
@@ -244,20 +244,21 @@ class YamlReadArchive final {
     this->VisitVariant(nvp);
   }
 
-  // For Eigen::Vector.
-  template <typename NVP, typename T, int Rows>
-  void DoVisit(const NVP& nvp, const Eigen::Matrix<T, Rows, 1>&, int32_t) {
-    if (Rows >= 0) {
-      this->VisitArray(nvp.name(), Rows, nvp.value()->data());
+  // For Eigen::Vector and Eigen::Matrix.
+  template <typename NVP, typename T, int Rows, int Cols,
+            int MaxRows, int MaxCols>
+  void DoVisit(const NVP& nvp,
+               const Eigen::Matrix<T, Rows, Cols, 0, MaxRows, MaxCols>&,
+               int32_t) {
+    if constexpr (Cols == 1) {
+      if constexpr (Rows >= 0 && Rows == MaxRows) {
+          this->VisitArray(nvp.name(), Rows, nvp.value()->data());
+      } else {
+        this->VisitVector(nvp);
+      }
     } else {
-      this->VisitVector(nvp);
+      this->VisitMatrix(nvp.name(), nvp.value());
     }
-  }
-
-  // For Eigen::Matrix.
-  template <typename NVP, typename T, int Rows, int Cols>
-  void DoVisit(const NVP& nvp, const Eigen::Matrix<T, Rows, Cols>&, int32_t) {
-    this->VisitMatrix(nvp.name(), nvp.value());
   }
 
   // If no other DoVisit matched, we'll treat the value as a scalar.

--- a/common/yaml/yaml_write_archive.h
+++ b/common/yaml/yaml_write_archive.h
@@ -208,19 +208,20 @@ class YamlWriteArchive final {
     this->VisitVariant(nvp);
   }
 
-  // For Eigen::Vector.
-  template <typename NVP, typename T, int Rows>
-  void DoVisit(const NVP& nvp, const Eigen::Matrix<T, Rows, 1>&, int32_t) {
-    Eigen::Matrix<T, Rows, 1>& value = *nvp.value();
-    const bool empty = value.size() == 0;
-    this->VisitArrayLike<T>(nvp.name(), value.size(),
-                            empty ? nullptr : &value.coeffRef(0));
-  }
-
-  // For Eigen::Matrix.
-  template <typename NVP, typename T, int Rows, int Cols>
-  void DoVisit(const NVP& nvp, const Eigen::Matrix<T, Rows, Cols>&, int32_t) {
-    this->VisitMatrix<T>(nvp.name(), nvp.value());
+  // For Eigen::Vector and Eigen::Matrix.
+  template <typename NVP, typename T, int Rows, int Cols,
+            int MaxRows, int MaxCols>
+  void DoVisit(const NVP& nvp,
+               const Eigen::Matrix<T, Rows, Cols, 0, MaxRows, MaxCols>&,
+               int32_t) {
+    if constexpr (Cols == 1) {
+        Eigen::Matrix<T, Rows, 1, 0, MaxRows, MaxCols>* value = nvp.value();
+        const bool empty = value->size() == 0;
+        this->VisitArrayLike<T>(nvp.name(), value->size(),
+                                empty ? nullptr : &value->coeffRef(0));
+    } else {
+      this->VisitMatrix<T>(nvp.name(), nvp.value());
+    }
   }
 
   // If no other DoVisit matched, we'll treat the value as a scalar.


### PR DESCRIPTION
Relevant to: #14215

Abuse the AutoDiffScalar<VectorXd> specialization to actually use a
different storage type for derivatives under the hood. Exploit the
change of storage to remove global heap overhead.

This implementation is noticeably faster than master, with the following
possible costs:

 * The capped-size derivatives storage likely wastes memory
 * The capped size may still be too small for some real problem
 * The storage type does leak to clients of the derivatives() accessor
 * Thread-local pools may be hostile to some obscure usage patterns

Some benefits of this scheme:

 * Avoids involvement with Eigen implementation details
 * Permits limited use of Eigen expression trees for speedups

Performance measurements will be posted in the issue.

Summary of changes:
 * autodiffxd.h:
   * naive pool class
   * change of derivatives storage type
   * thread-{safe,local} pool integration
 * autodiffxd_heap_test:
   * all cases show 0 allocations (pool seeded on init)
 * yaml_{read,write}_archive.h
   * more complete matching of Eigen types
   * necessitated by storage type leak via derivatives()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14242)
<!-- Reviewable:end -->
