### PR TITLE
[geometry] Deprecate geometry data as State in SceneGraph

### DIFF
--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -82,7 +82,13 @@ class GeometryStateValue final : public Value<GeometryState<T>> {
 }  // namespace
 
 template <typename T>
-SceneGraph<T>::SceneGraph(bool data_as_state)
+SceneGraph<T>::SceneGraph() : SceneGraph(false, 0) {}
+
+template <typename T>
+SceneGraph<T>::SceneGraph(bool data_as_state) : SceneGraph(data_as_state, 0) {}
+
+template <typename T>
+SceneGraph<T>::SceneGraph(bool data_as_state, int)
     : LeafSystem<T>(SystemTypeTag<SceneGraph>{}),
       data_as_state_(data_as_state) {
   model_inspector_.set(&model_);
@@ -112,7 +118,7 @@ SceneGraph<T>::SceneGraph(bool data_as_state)
 template <typename T>
 template <typename U>
 SceneGraph<T>::SceneGraph(const SceneGraph<U>& other)
-    : SceneGraph(other.data_as_state_) {
+    : SceneGraph(other.data_as_state_, 0) {
   // TODO(SeanCurtis-TRI) This is very brittle; we are essentially assuming that
   //  T = AutoDiffXd. For now, that's true. If we ever support
   //  symbolic::Expression, this U --> T conversion will have to be more

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -5,6 +5,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/geometry/geometry_set.h"
 #include "drake/geometry/geometry_state.h"
 #include "drake/geometry/query_object.h"
@@ -226,34 +227,30 @@ class SceneGraph final : public systems::LeafSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SceneGraph)
 
-  /* TODO(SeanCurtis-TRI) Deprecate "data as state" behavior. Here's the
-   strategy:
+  /** Constructs a default (empty) scene graph. */
+  SceneGraph();
 
-     1. Addition of data-as-parameter as *alternative* goes in one PR.
-     2. Follow up PR reverses the semantics.
-        - Split single constructor into two:
-          - Default constructor has data-as-parameter behavior.
-          - Constructor with non-default-value bool parameter gets deprecation
-            tag warning people to prefer the default constructor.
-          - Only update Drake call sites where there is a proven need for
-            data as State.
-      3. After deprecation period, remove SceneGraph(bool) constructor.  */
   /** Constructs a default (empty) scene graph.
 
-   For historical reasons, the geometry data (aka geometry state) is stored as
-   State in the Context. As such, it can be modified via an unrestricted update
-   event. Alternatively, %SceneGraph can be configured to store its geometry
-   data as a Parameter. As such, it can only be modified outside the normal
-   simulation loop, but leaves SceneGraph completely stateless.
+   Historically, geometry data (aka GeometryState) has been stored as State in
+   the Context. This is no longer the default; now it is stored as a Parameter.
+   This deprecated constructor allows you to exercise the legacy behavior during
+   the deprecation period (by passing `true`).
 
-   @warning In the future, the "geometry-data-as-state" behavior will be
-   deprecated. There will be a transition period where the default configuration
-   is switched from State to Parameter, followed by the removal of the State
-   option.
+   The expectation is there are no current uses of SceneGraph that *require*
+   the data to be stored in State and, as such, this constructor should largely
+   go unused. If you *do* feel you require it, please post an issue so we can
+   resolve it prior to complete deprecation of this behavior.
 
    @param data_as_state  `true` stores the data as State; `false` stores it as a
                          Parameter.  */
-  explicit SceneGraph(bool data_as_state = true);
+  DRAKE_DEPRECATED(
+      "2021-02-01",
+      "The choice of storing geometry data as State has been deprecated. "
+      "Please use the default constructor which sets the geometry data as a "
+      "Parameter. If this doesn't work for you please submit an issue in Drake "
+      "describing your problem.")
+  explicit SceneGraph(bool data_as_state);
 
   /** Constructor used for scalar conversions. It should only be used to convert
    _from_ double _to_ other scalar types.  */
@@ -844,6 +841,13 @@ class SceneGraph final : public systems::LeafSystem<T> {
   // Give (at least temporarily) QueryObject access to the system API to
   // evaluate inputs on the context.
   friend class QueryObject<T>;
+
+  // Special constructor to help with constructor deprecation. The public API
+  // for declaring whether the geometry data should be stored as State or
+  // Parameter is deprecated. However, during the deprecation period, we need
+  // to maintain the functionality. This private constructor allows the copy
+  // constructor to propagate deprecated behavior without throwing warnings.
+  SceneGraph(bool data_as_state, int magic_key);
 
   // If SceneGraph has been configured to store the geometry data as state,
   // writes the current version of the geometry data to the context's abstract

--- a/geometry/test/geometry_visualization_test.cc
+++ b/geometry/test/geometry_visualization_test.cc
@@ -66,9 +66,10 @@ GTEST_TEST(GeometryVisualization, SimpleScene) {
   unique_ptr<Context<double>> context = scene_graph.CreateDefaultContext();
 
   // This exploits the knowledge that the GeometryState is the zero-indexed
-  // abstract state in the scene graph-allocated context.
+  // abstract Parameter in the scene graph-allocated context.
   const GeometryState<double>& geometry_state =
-      context->get_state().get_abstract_state<GeometryState<double>>(0);
+      context->get_parameters().get_abstract_parameter<GeometryState<double>>(
+          0);
 
   // Checks the load message for visual geometries.
   {

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -151,6 +151,10 @@ class SceneGraphTest : public ::testing::Test {
 // configurations. If this proves to be overly optimistic, we can parameterize
 // `SceneGraphTest` on that parameter and run those tests.
 TEST_F(SceneGraphTest, DataAsParameterVsState) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  // TODO(SeanCurtis-TRI) When deprecation is completed, remove this whole test.
+
   for (bool data_as_state : {true, false}) {
     SceneGraph<double> sg(data_as_state);
     auto context = sg.CreateDefaultContext();
@@ -163,6 +167,7 @@ TEST_F(SceneGraphTest, DataAsParameterVsState) {
     EXPECT_NO_THROW(
         SceneGraphTester::GetMutableGeometryState(sg, context.get()));
   }
+#pragma GCC diagnostic pop
 }
 
 // Test sources.
@@ -357,6 +362,10 @@ TEST_F(SceneGraphTest, TransmogrifyPorts) {
 // Tests that the work to "set" the context values for the transmogrified system
 // behaves correctly.
 TEST_F(SceneGraphTest, TransmogrifyContext) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  // TODO(SeanCurtis-TRI) When deprecation is completed, leave the test, but
+  // remove the outer loop.
   for (bool data_as_state : {true, false}) {
     SceneGraph<double> sg(data_as_state);
     SourceId s_id = sg.RegisterSource();
@@ -386,6 +395,7 @@ TEST_F(SceneGraphTest, TransmogrifyContext) {
     // vis the GeometryState.
     DRAKE_EXPECT_NO_THROW(context_ad->SetTimeStateAndParametersFrom(*context));
   }
+#pragma GCC diagnostic pop
 }
 
 // Tests that exercising the collision filtering logic *after* allocation is

--- a/systems/sensors/test/rgbd_sensor_test.cc
+++ b/systems/sensors/test/rgbd_sensor_test.cc
@@ -32,11 +32,11 @@ class GeometryStateTester {
   // the renderer with the given name *is* a DummyRenderEngine. (If no renderer
   // with that name exists, it will simply throw.)
   static const internal::DummyRenderEngine& GetDummyRenderEngine(
-      systems::Context<T>* context, const std::string& name) {
+      const systems::Context<T>& context, const std::string& name) {
     // Technically brittle, but relatively safe assumption that GeometryState
-    // is abstract state value 0.
-    auto& geo_state = context->get_mutable_state()
-        .template get_mutable_abstract_state<GeometryState<T>>(0);
+    // is abstract Parameter value 0.
+    auto& geo_state = context.get_parameters()
+                          .template get_abstract_parameter<GeometryState<T>>(0);
     const render::RenderEngine& engine = geo_state.GetRenderEngineOrThrow(name);
     return dynamic_cast<const internal::DummyRenderEngine&>(engine);
   }
@@ -227,7 +227,7 @@ class RgbdSensorTest : public ::testing::Test {
         &diagram_->GetMutableSubsystemContext(*sensor_, context_.get());
     // Must get the render engine instance from the context itself.
     render_engine_ = &GeometryStateTester<double>::GetDummyRenderEngine(
-        scene_graph_context_, kRendererName);
+        *scene_graph_context_, kRendererName);
   }
 
   // Confirms that the member sensor_ matches the expected properties.


### PR DESCRIPTION
This changes the default behavior in SceneGraph; a default-constructed SceneGraph stores its geometry data as a Parameter (previously it was State).

This leaves a stop-gap constructor in place (marked as deprecated) to explicitly request the data to be stored as State.

Related to #9501 and #14189.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14245)
<!-- Reviewable:end -->
