### PR TITLE
setup: Upgrade recommended Bazel version to 3.7

### DIFF
--- a/doc/developers.rst
+++ b/doc/developers.rst
@@ -79,7 +79,7 @@ Drake requires a compiler running in C++17 mode.
 | Operating System                 | Bazel | CMake | C/C++ Compiler      | Java              | Python |
 +==================================+=======+=======+=====================+===================+========+
 +----------------------------------+-------+-------+---------------------+-------------------+--------+
-| Ubuntu 18.04 LTS (Bionic Beaver) | 3.5   | 3.10  | | GCC 7.5 (default) | OpenJDK 11        | 3.6    |
+| Ubuntu 18.04 LTS (Bionic Beaver) | 3.7   | 3.10  | | GCC 7.5 (default) | OpenJDK 11        | 3.6    |
 |                                  |       |       | | Clang 9           |                   |        |
 +----------------------------------+       +-------+---------------------+                   +--------+
 | Ubuntu 20.04 LTS (Focal Fossa)   |       | 3.16  | | GCC 9.3 (default) |                   | 3.8    |

--- a/setup/ubuntu/source_distribution/install_prereqs.sh
+++ b/setup/ubuntu/source_distribution/install_prereqs.sh
@@ -155,6 +155,6 @@ EOF
 )
 
 dpkg_install_from_wget \
-  bazel 3.5.0 \
-  https://releases.bazel.build/3.5.0/release/bazel_3.5.0-linux-x86_64.deb \
-  08b71237eccc3c313e62976894fc260d9e1c1ecdfa5b14fc7477fce1c36c618c
+  bazel 3.7.0 \
+  https://releases.bazel.build/3.7.0/release/bazel_3.7.0-linux-x86_64.deb \
+  2fc8dfb85328112a9d67f614e33026be74c2ac95645ed8e88896366eaa3d8fc3


### PR DESCRIPTION
At the moment, claiming 3.7 on macOS is a small lie but will soon become true, because we need to refresh the CI images there to fix python and director.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14246)
<!-- Reviewable:end -->
