### PR TITLE
[geometry] Add new geometry::DrakeVisualizer system

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -12,6 +12,7 @@
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/geometry/drake_visualizer.h"
 #include "drake/geometry/geometry_frame.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/geometry_instance.h"
@@ -439,6 +440,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
     cls  // BR
         .def("num_sources", &Class::num_sources, cls_doc.num_sources.doc)
         .def("num_frames", &Class::num_frames, cls_doc.num_frames.doc)
+        .def("world_frame_id", &Class::world_frame_id,
+            cls_doc.world_frame_id.doc)
         .def("num_geometries", &Class::num_geometries,
             cls_doc.num_geometries.doc)
         .def("GetAllGeometryIds", &Class::GetAllGeometryIds,
@@ -478,6 +481,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("GetPoseInFrame", &Class::GetPoseInFrame,
             py_rvp::reference_internal, py::arg("geometry_id"),
             cls_doc.GetPoseInFrame.doc)
+        .def("GetProperties", &Class::GetProperties, py_rvp::reference_internal,
+            py::arg("geometry_id"), py::arg("role"), cls_doc.GetProperties.doc)
         .def("GetProximityProperties", &Class::GetProximityProperties,
             py_rvp::reference_internal, py::arg("geometry_id"),
             cls_doc.GetProximityProperties.doc)
@@ -920,6 +925,32 @@ void DoScalarIndependentDefinitions(py::module m) {
       py::arg("lcm"), py::arg("role") = geometry::Role::kIllustration,
       doc.DispatchLoadMessage.doc);
 
+  {
+    using Class = DrakeVisualizerParams;
+    constexpr auto& cls_doc = doc.DrakeVisualizerParams;
+    py::class_<Class>(m, "DrakeVisualizerParams", cls_doc.doc)
+        .def(ParamInit<Class>())
+        .def_readwrite("publish_period", &DrakeVisualizerParams::publish_period,
+            cls_doc.publish_period.doc)
+        .def_readwrite("role", &DrakeVisualizerParams::role, cls_doc.role.doc)
+        .def_readwrite("default_color", &DrakeVisualizerParams::default_color,
+            cls_doc.default_color.doc);
+  }
+
+  {
+    using Class = DrakeVisualizer;
+    constexpr auto& cls_doc = doc.DrakeVisualizer;
+    py::class_<Class, LeafSystem<double>>(m, "DrakeVisualizer", cls_doc.doc)
+        .def(py::init<lcm::DrakeLcmInterface*, DrakeVisualizerParams>(),
+            py::arg("lcm") = nullptr,
+            py::arg("params") = DrakeVisualizerParams{},
+            // Keep alive, reference: `self` keeps `lcm` alive.
+            py::keep_alive<1, 2>(),  // BR
+            cls_doc.ctor.doc)
+        .def("query_object_input_port", &Class::query_object_input_port,
+            py_rvp::reference_internal, cls_doc.query_object_input_port.doc);
+  }
+
   // Shape constructors
   {
     py::class_<Shape> shape_cls(m, "Shape", doc.Shape.doc);
@@ -1120,8 +1151,9 @@ void DoScalarIndependentDefinitions(py::module m) {
     using Class = GeometryVersion;
     constexpr auto& cls_doc = doc.GeometryVersion;
     py::class_<Class> cls(m, "GeometryVersion", cls_doc.doc);
-    cls.def(py::init<const GeometryVersion&>(), py::arg("other"),
-           "Creates a copy of the GeometryVersion.")
+    cls.def(py::init(), cls_doc.ctor.doc)
+        .def(py::init<const GeometryVersion&>(), py::arg("other"),
+            "Creates a copy of the GeometryVersion.")
         .def("IsSameAs", &Class::IsSameAs, py::arg("other"), py::arg("role"),
             cls_doc.IsSameAs.doc);
     DefCopyAndDeepCopy(&cls);

--- a/examples/scene_graph/BUILD.bazel
+++ b/examples/scene_graph/BUILD.bazel
@@ -40,7 +40,7 @@ drake_cc_binary(
     ],
     deps = [
         ":bouncing_ball_plant",
-        "//geometry:geometry_visualization",
+        "//geometry:drake_visualizer",
         "//geometry:scene_graph",
         "//geometry/render:render_engine_vtk",
         "//systems/analysis:simulator",
@@ -61,7 +61,7 @@ drake_cc_binary(
         "--simulation_time=0.01",
     ],
     deps = [
-        "//geometry:geometry_visualization",
+        "//geometry:drake_visualizer",
         "//geometry:scene_graph",
         "//lcmtypes:contact_results_for_viz",
         "//systems/analysis:simulator",
@@ -106,7 +106,7 @@ drake_cc_binary(
     ],
     deps = [
         ":solar_system",
-        "//geometry:geometry_visualization",
+        "//geometry:drake_visualizer",
         "//geometry:scene_graph",
         "//systems/analysis:simulator",
         "//systems/framework:diagram",

--- a/examples/scene_graph/bouncing_ball_run_dynamics.cc
+++ b/examples/scene_graph/bouncing_ball_run_dynamics.cc
@@ -4,8 +4,8 @@
 #include <gflags/gflags.h>
 
 #include "drake/examples/scene_graph/bouncing_ball_plant.h"
+#include "drake/geometry/drake_visualizer.h"
 #include "drake/geometry/geometry_instance.h"
-#include "drake/geometry/geometry_visualization.h"
 #include "drake/geometry/render/render_engine_vtk_factory.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/geometry/shape_specification.h"
@@ -36,7 +36,7 @@ namespace {
 
 using Eigen::Vector3d;
 using Eigen::Vector4d;
-using geometry::ConnectDrakeVisualizer;
+using geometry::DrakeVisualizer;
 using geometry::GeometryInstance;
 using geometry::SceneGraph;
 using geometry::GeometryId;
@@ -102,7 +102,9 @@ int do_main() {
                   bouncing_ball2->get_geometry_query_input_port());
 
   DrakeLcm lcm;
-  ConnectDrakeVisualizer(&builder, *scene_graph, &lcm);
+  auto visualizer = builder.AddSystem<DrakeVisualizer>(&lcm);
+  builder.Connect(scene_graph->get_query_output_port(),
+                  visualizer->query_object_input_port());
 
   if (FLAGS_render_on) {
     PerceptionProperties properties;

--- a/examples/scene_graph/simple_contact_surface_vis.cc
+++ b/examples/scene_graph/simple_contact_surface_vis.cc
@@ -12,12 +12,12 @@
 #include <gflags/gflags.h>
 
 #include "drake/common/value.h"
+#include "drake/geometry/drake_visualizer.h"
 #include "drake/geometry/frame_kinematics_vector.h"
 #include "drake/geometry/geometry_frame.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/geometry_roles.h"
-#include "drake/geometry/geometry_visualization.h"
 #include "drake/geometry/proximity_properties.h"
 #include "drake/geometry/query_object.h"
 #include "drake/geometry/query_results/contact_surface.h"
@@ -41,9 +41,9 @@ namespace contact_surface {
 using Eigen::Vector3d;
 using Eigen::Vector4d;
 using geometry::Box;
-using geometry::ConnectDrakeVisualizer;
 using geometry::ContactSurface;
 using geometry::Cylinder;
+using geometry::DrakeVisualizer;
 using geometry::FrameId;
 using geometry::FramePoseVector;
 using geometry::GeometryFrame;
@@ -321,7 +321,9 @@ int do_main() {
   DrakeLcm lcm;
 
   // Visualize geometry.
-  ConnectDrakeVisualizer(&builder, scene_graph, &lcm);
+  auto& visualizer = *builder.AddSystem<DrakeVisualizer>(&lcm);
+  builder.Connect(scene_graph.get_query_output_port(),
+                  visualizer.query_object_input_port());
 
   // Visualize contacts.
   auto& contact_to_lcm =

--- a/examples/scene_graph/solar_system_run_dynamics.cc
+++ b/examples/scene_graph/solar_system_run_dynamics.cc
@@ -1,7 +1,7 @@
 #include <gflags/gflags.h>
 
 #include "drake/examples/scene_graph/solar_system.h"
-#include "drake/geometry/geometry_visualization.h"
+#include "drake/geometry/drake_visualizer.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/lcm/drake_lcm.h"
 #include "drake/systems/analysis/simulator.h"
@@ -31,7 +31,10 @@ int do_main() {
   builder.Connect(solar_system->get_geometry_pose_output_port(),
                   scene_graph->get_source_pose_port(solar_system->source_id()));
 
-  geometry::ConnectDrakeVisualizer(&builder, *scene_graph);
+  auto visualizer = builder.AddSystem<geometry::DrakeVisualizer>();
+  builder.Connect(scene_graph->get_query_output_port(),
+                  visualizer->query_object_input_port());
+
   auto diagram = builder.Build();
 
   systems::Simulator<double> simulator(*diagram);

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -14,6 +14,7 @@ drake_cc_package_library(
     name = "geometry",
     visibility = ["//visibility:public"],
     deps = [
+        ":drake_visualizer",
         ":frame_kinematics",
         ":geometry_frame",
         ":geometry_ids",
@@ -61,6 +62,22 @@ drake_cc_library(
         "@fcl",
         "@fmt",
         "@tinyobjloader",
+    ],
+)
+
+drake_cc_library(
+    name = "drake_visualizer",
+    srcs = ["drake_visualizer.cc"],
+    hdrs = ["drake_visualizer.h"],
+    deps = [
+        ":geometry_roles",
+        ":geometry_version",
+        ":scene_graph",
+        "//common:essential",
+        "//lcm:drake_lcm",
+        "//lcmtypes:viewer",
+        "//systems/framework:context",
+        "//systems/framework:leaf_system",
     ],
 )
 
@@ -310,6 +327,15 @@ filegroup(
         "test/non_convex_mesh.obj",
         "test/quad_cube.mtl",
         "test/quad_cube.obj",
+    ],
+)
+
+drake_cc_googletest(
+    name = "drake_visualizer_test",
+    deps = [
+        ":drake_visualizer",
+        "//lcm:mock",
+        "//systems/analysis:simulator",
     ],
 )
 

--- a/geometry/drake_visualizer.cc
+++ b/geometry/drake_visualizer.cc
@@ -1,0 +1,348 @@
+#include "drake/geometry/drake_visualizer.h"
+
+#include <utility>
+#include <vector>
+
+#include "drake/common/value.h"
+#include "drake/geometry/query_object.h"
+#include "drake/geometry/shape_specification.h"
+#include "drake/lcm/drake_lcm.h"
+#include "drake/lcmt_viewer_draw.hpp"
+#include "drake/lcmt_viewer_geometry_data.hpp"
+#include "drake/lcmt_viewer_load_robot.hpp"
+#include "drake/math/rigid_transform.h"
+#include "drake/math/rotation_matrix.h"
+
+namespace drake {
+namespace geometry {
+
+using Eigen::Quaterniond;
+using lcm::DrakeLcm;
+using math::RigidTransformd;
+using std::make_unique;
+using std::vector;
+using systems::Context;
+
+namespace {
+
+// Simple class for converting shape specifications into LCM-compatible shapes.
+class ShapeToLcm : public ShapeReifier {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ShapeToLcm)
+
+  ShapeToLcm() = default;
+  ~ShapeToLcm() override = default;
+
+  lcmt_viewer_geometry_data Convert(const Shape& shape,
+                                    const RigidTransformd& X_PG,
+                                    const Rgba& in_color) {
+    X_PG_ = X_PG;
+    // NOTE: Reify *may* change X_PG_ based on the shape. For example, the
+    // half-space requires an additional offset to shift the box representing
+    // the plane *to* the plane.
+    shape.Reify(this);
+
+    // Saves the location and orientation of the visualization geometry in the
+    // `lcmt_viewer_geometry_data` object. The location and orientation are
+    // specified in the body's frame.
+    Eigen::Map<Eigen::Vector3f> position(geometry_data_.position);
+    position = X_PG_.translation().cast<float>();
+    // LCM quaternion must be w, x, y, z.
+    Quaterniond q(X_PG_.rotation().ToQuaternion());
+    geometry_data_.quaternion[0] = q.w();
+    geometry_data_.quaternion[1] = q.x();
+    geometry_data_.quaternion[2] = q.y();
+    geometry_data_.quaternion[3] = q.z();
+
+    Eigen::Map<Eigen::Vector4f> color(geometry_data_.color);
+    Eigen::Vector4d color_vec(in_color.r(), in_color.g(), in_color.b(),
+                              in_color.a());
+    color = color_vec.cast<float>();
+    return geometry_data_;
+  }
+
+  using ShapeReifier::ImplementGeometry;
+
+  void ImplementGeometry(const Sphere& sphere, void*) override {
+    geometry_data_.type = geometry_data_.SPHERE;
+    geometry_data_.num_float_data = 1;
+    geometry_data_.float_data.push_back(static_cast<float>(sphere.radius()));
+  }
+
+  void ImplementGeometry(const Ellipsoid& ellipsoid, void*) override {
+    geometry_data_.type = geometry_data_.ELLIPSOID;
+    geometry_data_.num_float_data = 3;
+    geometry_data_.float_data.push_back(static_cast<float>(ellipsoid.a()));
+    geometry_data_.float_data.push_back(static_cast<float>(ellipsoid.b()));
+    geometry_data_.float_data.push_back(static_cast<float>(ellipsoid.c()));
+  }
+
+  void ImplementGeometry(const Cylinder& cylinder, void*) override {
+    geometry_data_.type = geometry_data_.CYLINDER;
+    geometry_data_.num_float_data = 2;
+    geometry_data_.float_data.push_back(static_cast<float>(cylinder.radius()));
+    geometry_data_.float_data.push_back(static_cast<float>(cylinder.length()));
+  }
+
+  void ImplementGeometry(const HalfSpace&, void*) override {
+    // Currently representing a half space as a big box. This assumes that the
+    // underlying box representation is centered on the origin.
+    geometry_data_.type = geometry_data_.BOX;
+    geometry_data_.num_float_data = 3;
+    // Box width, height, and thickness.
+    geometry_data_.float_data.push_back(50);
+    geometry_data_.float_data.push_back(50);
+    const float thickness = 1;
+    geometry_data_.float_data.push_back(thickness);
+
+    // The final pose of the box is the half-space's pose pre-multiplied by
+    // an offset sufficient to move the box down so it's top face lies on the
+    // z = 0 plane.
+    // Shift it down so that the origin lies on the top surface.
+    RigidTransformd box_xform{Eigen::Vector3d{0, 0, -thickness / 2}};
+    X_PG_ = X_PG_ * box_xform;
+  }
+
+  void ImplementGeometry(const Box& box, void*) override {
+    geometry_data_.type = geometry_data_.BOX;
+    geometry_data_.num_float_data = 3;
+    // Box width, depth, and height.
+    geometry_data_.float_data.push_back(static_cast<float>(box.width()));
+    geometry_data_.float_data.push_back(static_cast<float>(box.depth()));
+    geometry_data_.float_data.push_back(static_cast<float>(box.height()));
+  }
+
+  void ImplementGeometry(const Capsule& capsule, void*) override {
+    geometry_data_.type = geometry_data_.CAPSULE;
+    geometry_data_.num_float_data = 2;
+    geometry_data_.float_data.push_back(static_cast<float>(capsule.radius()));
+    geometry_data_.float_data.push_back(static_cast<float>(capsule.length()));
+  }
+
+  void ImplementGeometry(const Mesh& mesh, void*) override {
+    geometry_data_.type = geometry_data_.MESH;
+    geometry_data_.num_float_data = 3;
+    geometry_data_.float_data.push_back(static_cast<float>(mesh.scale()));
+    geometry_data_.float_data.push_back(static_cast<float>(mesh.scale()));
+    geometry_data_.float_data.push_back(static_cast<float>(mesh.scale()));
+    geometry_data_.string_data = mesh.filename();
+  }
+
+  // For visualization, Convex is the same as Mesh.
+  void ImplementGeometry(const Convex& mesh, void*) override {
+    geometry_data_.type = geometry_data_.MESH;
+    geometry_data_.num_float_data = 3;
+    geometry_data_.float_data.push_back(static_cast<float>(mesh.scale()));
+    geometry_data_.float_data.push_back(static_cast<float>(mesh.scale()));
+    geometry_data_.float_data.push_back(static_cast<float>(mesh.scale()));
+    geometry_data_.string_data = mesh.filename();
+  }
+
+ private:
+  lcmt_viewer_geometry_data geometry_data_{};
+  // The transform from the geometry frame to its parent frame.
+  RigidTransformd X_PG_;
+};
+
+}  // namespace
+
+DrakeVisualizer::DrakeVisualizer(lcm::DrakeLcmInterface* lcm,
+                                 DrakeVisualizerParams params)
+    : LeafSystem<double>(),
+      owned_lcm_(lcm ? nullptr : new DrakeLcm()),
+      lcm_(lcm ? lcm : owned_lcm_.get()),
+      params_(std::move(params)) {
+  if (params_.publish_period <= 0) {
+    throw std::runtime_error(fmt::format(
+        "DrakeVisualizer requires a positive publish period; {} was given",
+        params_.publish_period));
+  }
+  if (params_.role == Role::kUnassigned) {
+    throw std::runtime_error(
+        "DrakeVisualizer cannot be be used for geometries with the "
+        "Role::kUnassigned value. Please choose proximity, perception, or "
+        "illustration");
+  }
+
+  DeclarePeriodicPublishEvent(params_.publish_period, 0.0,
+                              &DrakeVisualizer::SendGeometryMessage);
+
+  query_object_input_port_ =
+      this->DeclareAbstractInputPort("query_object",
+                                     Value<QueryObject<double>>())
+          .get_index();
+
+  // This cache entry depends on *nothing*.
+  dynamic_data_cache_index_ =
+      DeclareCacheEntry("dynamic_frames", vector<DynamicFrameData>(),
+                        &DrakeVisualizer::CalcDynamicFrameData,
+                        {nothing_ticket()})
+          .cache_index();
+}
+
+void DrakeVisualizer::SendGeometryMessage(
+    const Context<double>& context) const {
+  const auto& query_object =
+      query_object_input_port().Eval<QueryObject<double>>(context);
+  const GeometryVersion& current_version =
+      query_object.inspector().geometry_version();
+
+  bool send_load_message = false;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!version_.IsSameAs(current_version, params_.role)) {
+      send_load_message = true;
+      version_ = current_version;
+    }
+  }
+  if (send_load_message) {
+    SendLoadMessage(context);
+  }
+  SendPoseMessage(context);
+}
+
+void DrakeVisualizer::SendLoadMessage(const Context<double>& context) const {
+  const auto& query_object =
+      query_object_input_port().Eval<QueryObject<double>>(context);
+  const SceneGraphInspector<double>& inspector = query_object.inspector();
+
+  lcmt_viewer_load_robot message{};
+
+  // We'll need to make sure our knowledge of dynamic frames can get updated.
+  get_cache_entry(dynamic_data_cache_index_)
+      .get_mutable_cache_entry_value(context)
+      .mark_out_of_date();
+  const vector<DynamicFrameData>& dynamic_frames =
+      get_cache_entry(dynamic_data_cache_index_)
+          .Eval<vector<DynamicFrameData>>(context);
+  // Add the world frame if it has geometries with the specified role.
+  const int anchored_count = inspector.NumGeometriesForFrameWithRole(
+      inspector.world_frame_id(), params_.role);
+  const int frame_count =
+      static_cast<int>(dynamic_frames.size()) + (anchored_count > 0 ? 1 : 0);
+
+  message.num_links = frame_count;
+  message.link.resize(frame_count);
+
+  // Helper utility to create lcm geometry description from geometry id.
+  auto make_geometry = [this, &inspector](GeometryId g_id) {
+    const GeometryProperties* props =
+        inspector.GetProperties(g_id, params_.role);
+    // We assume that the g_id was obtained by asking for geometries with the
+    // indicated role. So, by definition, the properties should be non-null.
+    DRAKE_ASSERT(props != nullptr);
+    const Shape& shape = inspector.GetShape(g_id);
+    Rgba default_color = params_.default_color;
+    if (params_.role != Role::kIllustration) {
+      const GeometryProperties* illus_props =
+          inspector.GetIllustrationProperties(g_id);
+      if (illus_props) {
+        default_color = illus_props->GetPropertyOrDefault("phong", "diffuse",
+                                                          default_color);
+      }
+    }
+    const Rgba& color =
+        props->GetPropertyOrDefault("phong", "diffuse", default_color);
+    return ShapeToLcm().Convert(shape, inspector.GetPoseInFrame(g_id), color);
+  };
+
+  int link_index = 0;
+  // Load anchored geometry into the world frame.
+  if (anchored_count) {
+    message.link[0].name = "world";
+    message.link[0].robot_num = 0;
+    message.link[0].num_geom = anchored_count;
+    message.link[0].geom.resize(anchored_count);
+    int geom_index = -1;  // We'll pre-increment before using.
+    for (const GeometryId& g_id :
+         inspector.GetGeometries(inspector.world_frame_id(), params_.role)) {
+      message.link[0].geom[++geom_index] = make_geometry(g_id);
+    }
+    link_index = 1;
+  }
+
+  // Load dynamic geometry into their own frames.
+  for (const auto& [frame_id, geometry_count, name] : dynamic_frames) {
+    message.link[link_index].name = name;
+    message.link[link_index].robot_num = inspector.GetFrameGroup(frame_id);
+    message.link[link_index].num_geom = geometry_count;
+    message.link[link_index].geom.resize(geometry_count);
+    int geom_index = -1;  // We'll pre-increment before using.
+    for (const GeometryId& g_id :
+         inspector.GetGeometries(frame_id, params_.role)) {
+      message.link[link_index].geom[++geom_index] = make_geometry(g_id);
+    }
+    ++link_index;
+  }
+
+  lcm::Publish(lcm_, "DRAKE_VIEWER_LOAD_ROBOT", message, context.get_time());
+}
+
+void DrakeVisualizer::SendPoseMessage(const Context<double>& context) const {
+  const auto& query_object =
+      query_object_input_port().Eval<QueryObject<double>>(context);
+  const SceneGraphInspector<double>& inspector = query_object.inspector();
+
+  lcmt_viewer_draw message{};
+
+  const vector<DynamicFrameData>& dynamic_frames =
+      get_cache_entry(dynamic_data_cache_index_)
+          .Eval<vector<DynamicFrameData>>(context);
+  const int frame_count = static_cast<int>(dynamic_frames.size());
+
+  message.timestamp = static_cast<int64_t>(context.get_time() * 1000.0);
+  message.num_links = frame_count;
+  message.link_name.resize(frame_count);
+  message.robot_num.resize(frame_count);
+  message.position.resize(frame_count);
+  message.quaternion.resize(frame_count);
+
+  for (int i = 0; i < frame_count; ++i) {
+    const FrameId id = dynamic_frames[i].frame_id;
+    message.robot_num[i] = inspector.GetFrameGroup(id);
+    message.link_name[i] = dynamic_frames[i].name;
+
+    const RigidTransformd& X_WF = query_object.X_WF(id);
+    message.position[i].resize(3);
+    message.position[i][0] = X_WF.translation()[0];
+    message.position[i][1] = X_WF.translation()[1];
+    message.position[i][2] = X_WF.translation()[2];
+
+    const Eigen::Quaternion<double> q = X_WF.rotation().ToQuaternion();
+    message.quaternion[i].resize(4);
+    message.quaternion[i][0] = q.w();
+    message.quaternion[i][1] = q.x();
+    message.quaternion[i][2] = q.y();
+    message.quaternion[i][3] = q.z();
+  }
+
+  lcm::Publish(lcm_, "DRAKE_VIEWER_DRAW", message, context.get_time());
+}
+
+void DrakeVisualizer::CalcDynamicFrameData(
+    const Context<double>& context,
+    vector<DynamicFrameData>* frame_data) const {
+  const auto& query_object =
+      query_object_input_port().Eval<QueryObject<double>>(context);
+  const SceneGraphInspector<double>& inspector = query_object.inspector();
+  // Collect the dynamic frames that actually have geometries of the
+  // specified role. These are the frames broadcast in a draw message and are
+  // also part of the load message (plus possibly the world frame).
+  vector<DynamicFrameData>& dynamic_frames = *frame_data;
+  dynamic_frames.clear();
+
+  for (const FrameId& frame_id : inspector.all_frame_ids()) {
+    // We'll handle the world frame special.
+    if (frame_id == inspector.world_frame_id()) continue;
+    const int count =
+        inspector.NumGeometriesForFrameWithRole(frame_id, params_.role);
+    if (count > 0) {
+      dynamic_frames.push_back({frame_id, count,
+                                inspector.GetOwningSourceName(frame_id) +
+                                    "::" + inspector.GetName(frame_id)});
+    }
+  }
+}
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/drake_visualizer.h
+++ b/geometry/drake_visualizer.h
@@ -1,0 +1,200 @@
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/geometry/geometry_roles.h"
+#include "drake/geometry/geometry_version.h"
+#include "drake/geometry/query_object.h"
+#include "drake/lcm/drake_lcm_interface.h"
+#include "drake/systems/framework/input_port.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace geometry {
+
+/* TODO(SeanCurtis-TRI): Here's the stuff that needs to happen:
+
+  - Static method that adds this to a diagram (including connections) so that
+    it can be done in a single call.
+*/
+
+/** The set of parameters for configuring DrakeVisualizer.  */
+struct DrakeVisualizerParams {
+  /** The duration (in seconds) between published LCM messages that update the
+   poses of the scene's geometry.  */
+  double publish_period{1 / 60.0};
+
+  /* The role of the geometries to be sent to the visualizer.  */
+  Role role{Role::kIllustration};
+
+  /** The color to apply to any geometry that hasn't defined one.  */
+  Rgba default_color{0.9, 0.9, 0.9, 1.0};
+};
+
+/** A system that publishes LCM messages compatible with the `drake_visualizer`
+ application representing the current state of a SceneGraph instance (whose
+ QueryObject-valued output port is connected to this system's input port).
+
+ @system
+ name: DrakeVisualizer
+ input_ports:
+ - query_object
+ @endsystem
+
+ The %DrakeVisualizer system broadcasts two kinds of LCM messages:
+
+   - a message that defines the geometry in the world on the lcm channel named
+     "DRAKE_VIEWER_DRAW",
+   - a message that updates the poses of those geometries on the lcm channel
+     named "DRAKE_VIEWER_LOAD_ROBOT"
+
+ The system uses the versioning mechanism provided by SceneGraph to detect
+ changes to the geometry so that a change in SceneGraph's data will propagate
+ to `drake_visualizer`.
+
+ @anchor drake_visualizer_role_consumer
+ <h3>Visualization by Role</h3>
+
+ By default, %DrakeVisualizer visualizes geometries with the illustration role
+ (see @ref geometry_roles for more details). It can be configured to visualize
+ geometries with other roles (see DrakeVisualizerParams). Only one role can be
+ specified.
+
+ The appearance of the geometry in the visualizer is typically defined by the
+ the geometry's properties for the visualized role.
+
+   - For the visualized role, if a geometry has the ("phong", "diffuse")
+     property described in the table below, that value is used.
+   - Otherwise, if the geometry *also* has the illustration properties, those
+     properties are likewise tested for the ("phong", "diffuse") property. This
+     rule only has significance is the visualized role is *not* the illustration
+     role.
+   - Otherwise, the configured default color will be applied (see
+     DrakeVisualizerParams).
+
+ | Group name | Required | Property Name |  Property Type  | Property Description |
+ | :--------: | :------: | :-----------: | :-------------: | :------------------- |
+ |    phong   | no       | diffuse       |     Rgba        | The rgba value of the object surface. |
+
+ <h4>Appearance of OBJ files</h4>
+
+ Meshes represented by OBJ are special. The OBJ file can reference a material
+ file (.mtl). If found by `drake_visualizer`, the values in the .mtl will take
+ precedence over the ("phong", "diffuse") geometry property.
+
+ It's worth emphasizing that these rules permits control over the appearance of
+ collision geometry on a per-geometry basis by assigning an explicit Rgba value
+ to the ("phong", "diffuse") property in the geometry's ProximityProperties.
+
+ @note If collision geometries are added to SceneGraph by parsing URDF/SDF
+ files, they will not have diffuse values. Even if elements were added to the
+ specification files, they would not be parsed. They must be added to the
+ geometries after parsing.
+
+ <h3>Effective visualization</h3>
+
+ The best visualization is when draw messages have been preceded by a compatible
+ load message (i.e., a "coherent" message sequence). While LCM doesn't guarantee
+ that messages will be received/processed in the same order as they are
+ broadcast, your results will be best if %DrakeVisualizer is allowed to
+ broadcast coherent messages. Practices that interfere with that will likely
+ produce undesirable results. E.g.,
+
+   - Evaluating a single instance of %DrakeVisualizer across several threads,
+     such that the data in the per-thread systems::Context varies.
+   - Evaluating multiple instances of %DrakeVisualizer in a single thread that
+     share the same lcm::DrakeLcmInterface.
+*/
+class DrakeVisualizer : public systems::LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DrakeVisualizer)
+
+  /** Creates an instance of %DrakeVisualizer.
+
+   @param lcm     An optional LCM interface. If none is provided, this system
+                  will allocate its own instance. If one is provided it must
+                  remain valid for the lifetime of this object.
+   @param params  The set of parameters to control this system's behavior.
+   @throws std::exception if `params.publish_period <= 0`.
+   @throws std::exception if `params.role == Role::kUnassigned`.
+   */
+  DrakeVisualizer(lcm::DrakeLcmInterface* lcm = nullptr,
+                  DrakeVisualizerParams params = {});
+
+  /** Returns the QueryObject-valued input port. It should be connected to
+   SceneGraph's QueryObject-valued output port. Failure to do so will cause a
+   runtime error when attempting to broadcast messages.  */
+  const systems::InputPort<double>& query_object_input_port() const {
+    return this->get_input_port(query_object_input_port_);
+  }
+
+ private:
+  friend class DrakeVisualizerTest;
+
+  /* The periodic event handler. It tests to see if the last scene description
+   is valid (if not, updates it) and then broadcasts poses.  */
+  void SendGeometryMessage(const systems::Context<double>& context) const;
+
+  /* Dispatches a "load geometry" message; replacing the whole scene with the
+   current scene.  */
+  void SendLoadMessage(const systems::Context<double>& context) const;
+
+  /* Dispatches a "update pose" message for geometry that is known to have been
+   loaded.  */
+  void SendPoseMessage(const systems::Context<double>& context) const;
+
+  /* Data stored in the cache; populated when we transmit a load message and
+   read from for a pose message.  */
+  struct DynamicFrameData {
+    FrameId frame_id;
+    int num_geometry{};
+    std::string name;
+  };
+
+  /* Identifies all of the frames with dynamic data and stores them (with
+   additional data) in the given vector `frame_data`. */
+  void CalcDynamicFrameData(const systems::Context<double>& context,
+                            std::vector<DynamicFrameData>* frame_data) const;
+
+  /* DrakeVisualizer stores a "model" of what it thinks is registered in the
+   drake_visualizer application. Because drake_visualizer is not part of the
+   Drake state, this model is likewise not part of the Drake state. It is a
+   property of the system. This allows arbitrary changes to the context but
+   DrakeVisualizer can still make its *best effort* to ensure that
+   drake_visualizer state is consistent with the messages it is about to send.
+   Because of the nature of lcm messages, it cannot make guarantees; lcm
+   messages can arrive in a different order than they were broadcast.
+
+   To this end, DrakeVisualizer has the model (GeometryVersion) and a
+   mutex that will allow updating that model safely. Beyond that, there are
+   no guarantees about order of operations when the publish callback is
+   invoked across multiple threads.  */
+
+  /* The version of the geometry that was last loaded (i.e., had a load message
+   sent). If the version found on the input port differs from this value, a
+   new load message will be sent prior to the "draw" message.  */
+  mutable GeometryVersion version_;
+  mutable std::mutex mutex_;
+
+  /* The index of this System's QueryObject-valued input port.  */
+  int query_object_input_port_{};
+
+  /* The LCM interface: the owned (if such exists) and the active interface
+   (whether owned or not). The active interface is mutable because we non-const
+   access to the LCM interface in const System methods.  */
+  std::unique_ptr<lcm::DrakeLcmInterface> owned_lcm_{};
+  mutable lcm::DrakeLcmInterface* lcm_{};
+
+  /* The index of the cache entry that stores the dynamic frame data.  */
+  systems::CacheIndex dynamic_data_cache_index_{};
+
+  /* The parameters for the visualizer.  */
+  DrakeVisualizerParams params_;
+};
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/geometry_roles.h
+++ b/geometry/geometry_roles.h
@@ -174,6 +174,7 @@ class PerceptionProperties final : public GeometryProperties{
 /** The set of properties for geometry used in an "illustration" role.
 
  Examples of functionality that depends on the illustration role:
+   - @ref drake_visualizer_role_consumer "drake::geometry::DrakeVisualizer"
    - @ref geometry_visualization_role_dependency
      "drake::geometry::ConnectDrakeVisualizer()"
  */

--- a/geometry/geometry_version.cc
+++ b/geometry/geometry_version.cc
@@ -2,6 +2,12 @@
 
 namespace drake {
 namespace geometry {
+
+GeometryVersion::GeometryVersion()
+    : proximity_version_id_(RoleVersionId::get_new_id()),
+      perception_version_id_(RoleVersionId::get_new_id()),
+      illustration_version_id_(RoleVersionId::get_new_id()) {}
+
 bool GeometryVersion::IsSameAs(const GeometryVersion& other, Role role) const {
   switch (role) {
     case Role::kUnassigned:
@@ -16,11 +22,6 @@ bool GeometryVersion::IsSameAs(const GeometryVersion& other, Role role) const {
   }
   DRAKE_UNREACHABLE();
 }
-
-GeometryVersion::GeometryVersion()
-    : proximity_version_id_(RoleVersionId::get_new_id()),
-      perception_version_id_(RoleVersionId::get_new_id()),
-      illustration_version_id_(RoleVersionId::get_new_id()) {}
 
 void GeometryVersion::modify_proximity() {
   proximity_version_id_ = RoleVersionId::get_new_id();

--- a/geometry/geometry_version.h
+++ b/geometry/geometry_version.h
@@ -32,6 +32,10 @@ class GeometryVersion {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(GeometryVersion);
 
+  /** Constructs a default-initialized instance; guaranteed to be different
+   from every other instance. */
+  GeometryVersion();
+
   /** Returns true if `this` GeometryVersion has the same `role`
    version as the `other` GeometryVersion. */
   bool IsSameAs(const GeometryVersion& other, Role role) const;
@@ -47,10 +51,6 @@ class GeometryVersion {
 
   /* Facilitates testing. */
   friend class GeometryVersionTest;
-
-  /* Create unique version id for all roles so that the new geometry version
-   unique. */
-  GeometryVersion();
 
   void modify_proximity();
 

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -11,6 +11,7 @@
 #include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/geometry_state.h"
+#include "drake/geometry/internal_frame.h"
 #include "drake/geometry/shape_specification.h"
 
 namespace drake {
@@ -96,6 +97,12 @@ class SceneGraphInspector {
   typename GeometryState<T>::FrameIdRange all_frame_ids() const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->get_frame_ids();
+  }
+
+  /** Reports the id for the world frame.  */
+  FrameId world_frame_id() const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return internal::InternalFrame::world_frame_id();
   }
 
   /** Reports the _total_ number of geometries in the scene graph.  */
@@ -347,40 +354,67 @@ class SceneGraphInspector {
     return state_->GetPoseInFrame(id);
   }
 
-  /** Returns a pointer to the const proximity properties of the geometry with
-   the given `id`.
-   @param id   The identifier for the queried geometry.
-   @return A pointer to the properties (or nullptr if there are no such
+  /** Return a pointer to the const properties indicated by `role` of the
+   geometry with the given `geometry_id`.
+   @param geometry_id    The identifier for the queried geometry.
+   @param role           The role whose properties are acquired.
+   @return A pointer to the properties (or `nullptr` if there are no such
            properties).
-   @throws std::logic_error if `id` does not map to a registered geometry.  */
-  const ProximityProperties* GetProximityProperties(
-      GeometryId id) const {
+   @throws std::exception if `geometry_id` does not map to a registered
+           geometry.  */
+  const GeometryProperties* GetProperties(GeometryId geometry_id,
+                                          Role role) const {
     DRAKE_DEMAND(state_ != nullptr);
-    return state_->GetProximityProperties(id);
+    switch (role) {
+      case Role::kProximity:
+        return state_->GetProximityProperties(geometry_id);
+      case Role::kIllustration:
+        return state_->GetIllustrationProperties(geometry_id);
+      case Role::kPerception:
+        return state_->GetPerceptionProperties(geometry_id);
+      case Role::kUnassigned:
+        return nullptr;
+    }
+    return nullptr;
+  }
+
+  /** Returns a pointer to the const proximity properties of the geometry with
+   the given `geometry_id`.
+   @param geometry_id   The identifier for the queried geometry.
+   @return A pointer to the properties (or `nullptr` if there are no such
+           properties).
+   @throws std::exception if `geometry_id` does not map to a registered
+           geometry.  */
+  const ProximityProperties* GetProximityProperties(
+      GeometryId geometry_id) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->GetProximityProperties(geometry_id);
   }
 
   /** Returns a pointer to the const illustration properties of the geometry
-   with the given `id`.
-   @param id   The identifier for the queried geometry.
-   @return A pointer to the properties (or nullptr if there are no such
+   with the given `geometry_id`.
+   @param geometry_id   The identifier for the queried geometry.
+   @return A pointer to the properties (or `nullptr` if there are no such
            properties).
-   @throws std::logic_error if `id` does not map to a registered geometry.  */
+   @throws std::exception if `geometry_id` does not map to a registered
+           geometry.  */
   const IllustrationProperties* GetIllustrationProperties(
-      GeometryId id) const {
+      GeometryId geometry_id) const {
     DRAKE_DEMAND(state_ != nullptr);
-    return state_->GetIllustrationProperties(id);
+    return state_->GetIllustrationProperties(geometry_id);
   }
 
   /** Returns a pointer to the const perception properties of the geometry
-   with the given `id`.
-   @param id   The identifier for the queried geometry.
-   @return A pointer to the properties (or nullptr if there are no such
+   with the given `geometry_id`.
+   @param geometry_id   The identifier for the queried geometry.
+   @return A pointer to the properties (or `nullptr` if there are no such
            properties).
-   @throws std::logic_error if `id` does not map to a registered geometry.  */
+   @throws std::exception if `geometry_id` does not map to a registered
+           geometry.  */
   const PerceptionProperties* GetPerceptionProperties(
-      GeometryId id) const {
+      GeometryId geometry_id) const {
     DRAKE_DEMAND(state_ != nullptr);
-    return state_->GetPerceptionProperties(id);
+    return state_->GetPerceptionProperties(geometry_id);
   }
 
   /** Reports true if the two geometries with given ids `id1` and `id2`, define

--- a/geometry/test/drake_visualizer_test.cc
+++ b/geometry/test/drake_visualizer_test.cc
@@ -1,0 +1,563 @@
+#include "drake/geometry/drake_visualizer.h"
+
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include "drake/geometry/frame_kinematics_vector.h"
+#include "drake/geometry/geometry_frame.h"
+#include "drake/geometry/geometry_instance.h"
+#include "drake/geometry/rgba.h"
+#include "drake/geometry/scene_graph.h"
+#include "drake/geometry/shape_specification.h"
+#include "drake/lcm/drake_mock_lcm.h"
+#include "drake/lcm/lcm_messages.h"
+#include "drake/lcmt_viewer_draw.hpp"
+#include "drake/lcmt_viewer_geometry_data.hpp"
+#include "drake/lcmt_viewer_load_robot.hpp"
+#include "drake/math/rigid_transform.h"
+#include "drake/systems/analysis/simulator.h"
+#include "drake/systems/framework/context.h"
+#include "drake/systems/framework/diagram_builder.h"
+
+namespace drake {
+namespace geometry {
+
+using Eigen::Vector3d;
+using math::RigidTransformd;
+using std::make_unique;
+using std::map;
+using std::move;
+using std::string;
+using std::unique_ptr;
+using std::vector;
+using systems::Context;
+using systems::Diagram;
+using systems::DiagramBuilder;
+using systems::Simulator;
+
+namespace {
+
+/* Serves as a source of pose values for SceneGraph input ports. */
+class PoseSource : public systems::LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PoseSource)
+  PoseSource() {
+    this->DeclareAbstractOutputPort(FramePoseVector<double>(),
+                                    &PoseSource::ReadPoses);
+  }
+
+  void SetPoses(FramePoseVector<double> poses) { poses_ = move(poses); }
+
+ private:
+  void ReadPoses(const Context<double>&, FramePoseVector<double>* poses) const {
+    *poses = poses_;
+  }
+
+  FramePoseVector<double> poses_;
+};
+
+}  // namespace
+
+// TODO(SeanCurtis-TRI): These unit tests aren't complete. Much of the DUT has
+//  code from the old `geometry_visualizer.{h|cc}. That code wasn't particularly
+//  tested either, but has been run thousands of times. That code lives on in
+//  DrakeVisualizer and the tests still leave out the following aspects:
+//
+//    1. Mapping from shape specification to LCM equivalent (i.e., spheres are
+//       visualized as spheres, boxes as boxes, etc.)
+//    2. The poses of geometries (both relative to their parent frame and the
+//       frame in the world).
+//
+// The assumption is that if these were wrong, it would immediately apparent to
+// every user. If this ever changes, it might be worthwhile to test these
+// things.
+
+
+/* Note: We're not using an anonymous namespace so the DrakeVisualizerTest
+ satisfies the friend declaration in DrakeVisualizer.  */
+
+/* Infrastructure for testing the DrakeVisualizer. */
+class DrakeVisualizerTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    ASSERT_EQ(lcm_.get_lcm_url(), "memq://");
+  }
+
+  /* Returns the pointer to the `visualizer`'s owned lcm interface (may be
+   nullptr). */
+  static const lcm::DrakeLcmInterface* get_owned_interface(
+      const DrakeVisualizer& visualizer) {
+    return visualizer.owned_lcm_.get();
+  }
+
+  /* Returns the pointer to the `visualizer`'s active lcm interface -- the one
+   being invoked to do work (can't be nullptr). */
+  static const lcm::DrakeLcmInterface* get_active_interface(
+      const DrakeVisualizer& visualizer) {
+    return visualizer.lcm_;
+  }
+
+  /* Configures the diagram (and raw pointers) with a DrakeVisualizer configured
+   by the given parameters.  */
+  void ConfigureDiagram(double period = kPublishPeriod,
+                        Role role = Role::kIllustration,
+                        const Rgba& default_color = Rgba{0.1, 0.2, 0.3, 0.4}) {
+    DrakeVisualizerParams params{period, role, default_color};
+    DiagramBuilder<double> builder;
+    scene_graph_ = builder.AddSystem<SceneGraph<double>>();
+    visualizer_ = builder.AddSystem<DrakeVisualizer>(&lcm_, move(params));
+    builder.Connect(scene_graph_->get_query_output_port(),
+                    visualizer_->query_object_input_port());
+    source_id_ = scene_graph_->RegisterSource(kSourceName);
+    pose_source_ = builder.AddSystem<PoseSource>();
+    builder.Connect(pose_source_->get_output_port(0),
+                    scene_graph_->get_source_pose_port(source_id_));
+    diagram_ = builder.Build();
+  }
+
+  /* Populates SceneGraph with various objects. This function's defining
+   characteristic is that there are three different geometries, each with a
+   different role, such that there will always be one geometry included,
+   regardless of role.  */
+  void PopulateScene() {
+    // A box has perception properties with a green color.
+    const FrameId f0_id =
+        scene_graph_->RegisterFrame(source_id_, GeometryFrame("perception", 0));
+    const GeometryId g0_id = scene_graph_->RegisterGeometry(
+        source_id_, f0_id,
+        make_unique<GeometryInstance>(RigidTransformd{},
+                                      make_unique<Box>(1, 1, 1), "perception"));
+    PerceptionProperties percep_prop;
+    percep_prop.AddProperty("phong", "diffuse", Rgba(0, 1, 0, 1));
+    scene_graph_->AssignRole(source_id_, g0_id, percep_prop);
+
+    // A cylinder has illustration properties with a blue color.
+    const FrameId f1_id = scene_graph_->RegisterFrame(
+        source_id_, GeometryFrame("illustration", 1));
+    const GeometryId g1_id = scene_graph_->RegisterGeometry(
+        source_id_, f1_id,
+        make_unique<GeometryInstance>(
+            RigidTransformd{}, make_unique<Cylinder>(1, 1), "illustration"));
+    IllustrationProperties illus_prop;
+    illus_prop.AddProperty("phong", "diffuse", Rgba(0, 1, 0, 1));
+    scene_graph_->AssignRole(source_id_, g1_id, illus_prop);
+
+    // A sphere has proximity properties with no color.
+    const FrameId f2_id =
+        scene_graph_->RegisterFrame(source_id_, GeometryFrame("proximity", 2));
+    const GeometryId g2_id = scene_graph_->RegisterGeometry(
+        source_id_, f2_id,
+        make_unique<GeometryInstance>(RigidTransformd{}, make_unique<Sphere>(1),
+                                      "proximity"));
+    scene_graph_->AssignRole(source_id_, g2_id, ProximityProperties());
+
+    pose_source_->SetPoses({{f0_id, RigidTransformd{}},
+                            {f1_id, RigidTransformd{}},
+                            {f2_id, RigidTransformd{}}});
+  }
+
+  /* Collection of data for reporting what is waiting in the LCM queue.  */
+  struct MessageResults {
+    int num_load{};
+    // Zeroed out unless num_load > 0.
+    lcmt_viewer_load_robot load_message{};
+    int num_draw{};
+    // Zeroed out unless num_draw > 0.
+    lcmt_viewer_draw draw_message{};
+  };
+
+  /* Processes the message queue, reporting the number of load and draw messges
+   and, if that number is non-zero, the last message of each type received.  */
+  MessageResults ProcessMessages() {
+    lcm_.HandleSubscriptions(0);
+    const int num_draw = draw_subscriber_.count();
+    lcmt_viewer_draw draw_message = draw_subscriber_.message();
+    const int num_load = load_subscriber_.count();
+    lcmt_viewer_load_robot load_message = load_subscriber_.message();
+    draw_subscriber_.clear();
+    load_subscriber_.clear();
+    return {num_load, load_message, num_draw, draw_message};
+  }
+
+  /* Handles all subscribers and confirms the number of load and draw messages
+   are as expected. Clears the subscribers after looking. */
+  ::testing::AssertionResult ExpectedMessageCount(int num_load, int num_draw) {
+    MessageResults results = ProcessMessages();
+    if (results.num_draw != num_draw || results.num_load != num_load) {
+      ::testing::AssertionFailure()
+          << "Expected " << num_load << " load messages and " << num_draw
+          << " draw messages"
+          << "\nFound   " << results.num_load << " load messages and "
+          << results.num_draw << " draw messages";
+    }
+    return ::testing::AssertionSuccess();
+  }
+
+  static constexpr double kPublishPeriod = 1 / 60.0;
+  /* The LCM channel names. We are implicitly confirming that DrakeVisualizer
+   broadcasts on the right channels via the subscribers. The reception of
+   expected messages on those subscribers is proof.  */
+  static constexpr char kLoadChannel[] = "DRAKE_VIEWER_LOAD_ROBOT";
+  static constexpr char kDrawChannel[] = "DRAKE_VIEWER_DRAW";
+
+  /* The name of the source registered with the SceneGraph.  */
+  static constexpr char kSourceName[] = "DrakeVisualizerTest";
+
+  /* The LCM visualizer broadcasts messages on.  */
+  lcm::DrakeMockLcm lcm_;
+  /* The subscribers for draw and load messages.  */
+  lcm::Subscriber<lcmt_viewer_draw> draw_subscriber_{&lcm_, kDrawChannel};
+  lcm::Subscriber<lcmt_viewer_load_robot> load_subscriber_{&lcm_, kLoadChannel};
+
+  /* Raw pointer into the diagram's scene graph.  */
+  SceneGraph<double>* scene_graph_{};
+  /* Raw pointer into the diagram's visualizer.  */
+  DrakeVisualizer* visualizer_{};
+  /* Raw pointer to the pose data.  */
+  PoseSource* pose_source_{};
+  SourceId source_id_;
+  /* A diagram containing scene graph and connected visualizer.  */
+  unique_ptr<Diagram<double>> diagram_;
+};
+
+/* Confirms that the visualizer publishes at the specified period.  */
+TEST_F(DrakeVisualizerTest, PublishPeriod) {
+  for (double period : {1 / 30.0, 1 / 10.0}) {
+    ConfigureDiagram(period);
+    Simulator<double> simulator(*diagram_);
+    ASSERT_EQ(simulator.get_context().get_time(), 0.0);
+
+    SCOPED_TRACE(fmt::format("Period = {:.4}", period));
+
+    // When we start up, we should get a load and a draw at time 0.
+    simulator.AdvanceTo(0.0);
+    EXPECT_TRUE(ExpectedMessageCount(1, 1));
+
+    // Advancing past five period boundaries --> five draw messages.
+    simulator.AdvanceTo(period * 5.1);
+    EXPECT_TRUE(ExpectedMessageCount(0, 5));
+  }
+}
+
+/* Confirms messages are sent, even if there is nothing. This matters because
+ a no-op would *not* clear drake_visualizer leading to confusing results (if
+ the visualizer already contained geometry from a previous session).  */
+TEST_F(DrakeVisualizerTest, EmptyScene) {
+  ConfigureDiagram();
+  Simulator<double> simulator(*diagram_);
+  simulator.AdvanceTo(0.0);
+  MessageResults results = ProcessMessages();
+  ASSERT_EQ(results.num_load, 1);
+  EXPECT_EQ(results.load_message.num_links, 0);
+
+  ASSERT_EQ(results.num_draw, 1);
+  EXPECT_EQ(results.draw_message.num_links, 0);
+  EXPECT_EQ(results.draw_message.timestamp, 0);
+}
+
+/* DrakeVisualizer can accept an lcm interface from the user or instantiate its
+ own. This tests that logic. However, it does *not* do any work on the owned
+ lcm interface because we don't want this unit test to spew network traffic.  */
+TEST_F(DrakeVisualizerTest, OwnedLcm) {
+  DrakeVisualizer visualizer_external(&lcm_);
+  EXPECT_EQ(get_owned_interface(visualizer_external), nullptr);
+  EXPECT_EQ(get_active_interface(visualizer_external), &lcm_);
+
+  /* Note: do not do any work with this instance that would cause LCM messages
+   to be spewed!  */
+  DrakeVisualizer visualizer_owning;
+  EXPECT_NE(get_owned_interface(visualizer_owning), nullptr);
+  EXPECT_NE(get_owned_interface(visualizer_owning), &lcm_);
+  EXPECT_EQ(get_active_interface(visualizer_owning),
+            get_owned_interface(visualizer_owning));
+}
+
+/* DrakeVisualizer uses the cache to facilitate coordination between what got
+ broadcast in the load message and what needs to be broadcast in the draw
+ message. This confirms we get the same results with cache enabled and disabled.
+ In this case, we use the number and names of the dynamic frames and the draw
+ messages as evidence. */
+TEST_F(DrakeVisualizerTest, CacheInsensitive) {
+  lcmt_viewer_draw messages[2];
+
+  for (bool cache_enabled : {true, false}) {
+    ConfigureDiagram();
+    PopulateScene();
+
+    Simulator<double> simulator(*diagram_);
+    if (cache_enabled) {
+      simulator.get_mutable_context().EnableCaching();
+    } else {
+      simulator.get_mutable_context().DisableCaching();
+    }
+    simulator.AdvanceTo(0.0);
+    MessageResults results = ProcessMessages();
+    /* Confirm that messages were sent.  */
+    ASSERT_EQ(results.num_load, 1);
+    ASSERT_EQ(results.num_draw, 1);
+
+    /* Stash the draw message for comparison.  */
+    messages[cache_enabled ? 0 : 1] = results.draw_message;
+  }
+  /* Confirm that *something* was visualized.  */
+  ASSERT_GT(messages[0].num_links, 0);
+
+  /* Confirm the two draw messages are identical.  */
+  const vector<uint8_t> encoding0 = lcm::EncodeLcmMessage(messages[0]);
+  const vector<uint8_t> encoding1 = lcm::EncodeLcmMessage(messages[1]);
+  EXPECT_EQ(encoding0, encoding1);
+}
+
+/* Confirm that configuring the default diffuse color affects the resulting
+ color for geometries with no specified diffuse values.  */
+TEST_F(DrakeVisualizerTest, ConfigureDefaultDiffuse) {
+  /* Apply to arbitrary default diffuse and confirm the geometry (with no)
+   diffuse color defined, inherits it.  */
+  for (const auto& expected_rgba :
+       {Rgba{0.75, 0.25, 0.125, 1.0}, Rgba{0.5, 0.75, 0.875, 0.5}}) {
+    ConfigureDiagram(kPublishPeriod, Role::kProximity, expected_rgba);
+    const FrameId f_id =
+        scene_graph_->RegisterFrame(source_id_, GeometryFrame("frame", 0));
+    const GeometryId g_id = scene_graph_->RegisterGeometry(
+        source_id_, f_id,
+        make_unique<GeometryInstance>(RigidTransformd{}, make_unique<Sphere>(1),
+                                      "proximity_sphere"));
+    // ProximityProperties will make use of the default diffuse value.
+    scene_graph_->AssignRole(source_id_, g_id, ProximityProperties());
+    pose_source_->SetPoses({{f_id, RigidTransformd{}}});
+    Simulator<double> simulator(*diagram_);
+    simulator.AdvanceTo(0.0);
+    MessageResults results = ProcessMessages();
+    ASSERT_EQ(results.num_load, 1);
+    ASSERT_EQ(results.load_message.num_links, 1);
+    ASSERT_EQ(results.load_message.link[0].num_geom, 1);
+    const auto& color = results.load_message.link[0].geom[0].color;
+    const Rgba rgba{color[0], color[1], color[2], color[3]};
+    EXPECT_EQ(rgba, expected_rgba);
+  }
+}
+
+/* Confirm that the anchored and dynamic geometries are handled correctly. All
+ geometries are loaded (with the "world" frame holding the anchored geometries
+ and all dynamic geometries on other frames). The draw message should only
+ provide data for the dynamic frames (i.e., "world" will not be included).  */
+TEST_F(DrakeVisualizerTest, AnchoredAndDynamicGeometry) {
+  ConfigureDiagram(kPublishPeriod, Role::kProximity);
+  const FrameId f_id =
+      scene_graph_->RegisterFrame(source_id_, GeometryFrame("frame", 0));
+  const GeometryId g0_id = scene_graph_->RegisterGeometry(
+      source_id_, f_id,
+      make_unique<GeometryInstance>(RigidTransformd{}, make_unique<Sphere>(1),
+                                    "sphere0"));
+  scene_graph_->AssignRole(source_id_, g0_id, ProximityProperties());
+  const GeometryId g1_id = scene_graph_->RegisterGeometry(
+      source_id_, f_id,
+      make_unique<GeometryInstance>(RigidTransformd{Vector3d{10, 0, 0}},
+                                    make_unique<Sphere>(1), "sphere1"));
+  scene_graph_->AssignRole(source_id_, g1_id, ProximityProperties());
+
+  const GeometryId g2_id = scene_graph_->RegisterAnchoredGeometry(
+      source_id_,
+      make_unique<GeometryInstance>(RigidTransformd{Vector3d{5, 0, 0}},
+                                    make_unique<Sphere>(1), "sphere3"));
+  scene_graph_->AssignRole(source_id_, g2_id, ProximityProperties());
+
+  pose_source_->SetPoses({{f_id, RigidTransformd{}}});
+
+  Simulator<double> simulator(*diagram_);
+  simulator.AdvanceTo(0.0);
+  MessageResults results = ProcessMessages();
+
+  // Confirm load message; three geometries on two links.
+  ASSERT_EQ(results.num_load, 1);
+  ASSERT_EQ(results.load_message.num_links, 2);
+  // We exploit the fact that we always know the world is first.
+  ASSERT_EQ(results.load_message.link[0].name, "world");
+  ASSERT_EQ(results.load_message.link[0].num_geom, 1);
+
+  // Now test for the dynamic frame (with its two geometries).
+  ASSERT_EQ(results.load_message.link[1].name, string(kSourceName) + "::frame");
+  ASSERT_EQ(results.load_message.link[1].num_geom, 2);
+
+  // Confirm draw message; a single link.
+  ASSERT_EQ(results.num_draw, 1);
+  ASSERT_EQ(results.draw_message.num_links, 1);
+  ASSERT_EQ(results.draw_message.link_name[0], string(kSourceName) + "::frame");
+}
+
+/* Confirms that the role parameter leads to the correct geometry being
+ selected.  */
+TEST_F(DrakeVisualizerTest, TargetRole) {
+  const string source_name(kSourceName);
+  /* For a given role, the name of the *unique* frame we expect to load. The
+   frame should have a single geometry affixed to it.  */
+  const map<Role, string> expected{
+      {Role::kIllustration, source_name + "::illustration"},
+      {Role::kPerception, source_name + "::perception"},
+      {Role::kProximity, source_name + "::proximity"}};
+  for (const auto& [role, name] : expected) {
+    ConfigureDiagram(kPublishPeriod, role);
+    PopulateScene();
+    Simulator<double> simulator(*diagram_);
+    simulator.AdvanceTo(0.0);
+    MessageResults results = ProcessMessages();
+
+    /* Confirm that messages were sent.  */
+    ASSERT_EQ(results.num_load, 1);
+    ASSERT_EQ(results.load_message.num_links, 1);
+    EXPECT_EQ(results.load_message.link[0].name, name);
+    EXPECT_EQ(results.load_message.link[0].num_geom, 1);
+
+    ASSERT_EQ(results.num_draw, 1);
+    ASSERT_EQ(results.draw_message.num_links, 1);
+    EXPECT_EQ(results.draw_message.link_name[0], name);
+  }
+}
+
+/* When targeting a non-illustration role, if that same geometry *has* an
+ illustration role with color, that value is used instead of the default.  */
+TEST_F(DrakeVisualizerTest, GeometryWithIllustrationFallback) {
+  ConfigureDiagram(kPublishPeriod, Role::kProximity);
+  const GeometryId g_id = scene_graph_->RegisterAnchoredGeometry(
+      source_id_, make_unique<GeometryInstance>(
+                      RigidTransformd{}, make_unique<Sphere>(1), "sphere0"));
+  const Rgba expected_rgba{0.25, 0.125, 0.75, 0.5};
+  ASSERT_NE(expected_rgba, DrakeVisualizerParams().default_color);
+  IllustrationProperties illus_props;
+  illus_props.AddProperty("phong", "diffuse", expected_rgba);
+  scene_graph_->AssignRole(source_id_, g_id, ProximityProperties());
+  scene_graph_->AssignRole(source_id_, g_id, illus_props);
+
+  Simulator<double> simulator(*diagram_);
+  simulator.AdvanceTo(0.0);
+
+  // We're just checking the load message for the right color.
+  MessageResults results = ProcessMessages();
+  ASSERT_EQ(results.num_load, 1);
+  ASSERT_EQ(results.load_message.num_links, 1);
+  ASSERT_EQ(results.load_message.link[0].num_geom, 1);
+  const auto& color = results.load_message.link[0].geom[0].color;
+  const Rgba rgba(color[0], color[1], color[2], color[3]);
+  EXPECT_EQ(rgba, expected_rgba);
+}
+
+/* For *any* role type, if the properties include ("phong", "diffuse"), *that*
+ color will be used.  */
+TEST_F(DrakeVisualizerTest, AllRolesCanDefineDiffuse) {
+  for (const Role role : {Role::kProximity, Role::kPerception}) {
+    ConfigureDiagram(kPublishPeriod, role);
+    const GeometryId g_id = scene_graph_->RegisterAnchoredGeometry(
+        source_id_, make_unique<GeometryInstance>(
+                        RigidTransformd{}, make_unique<Sphere>(1), "sphere0"));
+    const Rgba expected_rgba{0.25, 0.125, 0.75, 0.5};
+    ASSERT_NE(expected_rgba, DrakeVisualizerParams().default_color);
+    if (role == Role::kProximity) {
+      ProximityProperties props;
+      props.AddProperty("phong", "diffuse", expected_rgba);
+      scene_graph_->AssignRole(source_id_, g_id, props);
+    } else if (role == Role::kPerception) {
+      PerceptionProperties props;
+      props.AddProperty("phong", "diffuse", expected_rgba);
+      scene_graph_->AssignRole(source_id_, g_id, props);
+    }
+
+    Simulator<double> simulator(*diagram_);
+    simulator.AdvanceTo(0.0);
+
+    // We're just checking the load message for the right color.
+    MessageResults results = ProcessMessages();
+    ASSERT_EQ(results.num_load, 1);
+    ASSERT_EQ(results.load_message.num_links, 1);
+    ASSERT_EQ(results.load_message.link[0].num_geom, 1);
+    const auto& color = results.load_message.link[0].geom[0].color;
+    const Rgba rgba(color[0], color[1], color[2], color[3]);
+    EXPECT_EQ(rgba, expected_rgba);
+  }
+}
+
+/* Confirms that the documented prerequisites do bad things.  */
+TEST_F(DrakeVisualizerTest, BadParameters) {
+  // Zero publish period.
+  EXPECT_THROW(
+      DrakeVisualizer(&lcm_, DrakeVisualizerParams{0, Role::kIllustration,
+                                                   Rgba{1, 1, 1, 1}}),
+      std::exception);
+
+  // Negative publish period.
+  EXPECT_THROW(
+      DrakeVisualizer(&lcm_, DrakeVisualizerParams{-0.1, Role::kIllustration,
+                                                   Rgba{1, 1, 1, 1}}),
+      std::exception);
+
+  // Unassigned role.
+  EXPECT_THROW(
+      DrakeVisualizer(&lcm_, DrakeVisualizerParams{0.1, Role::kUnassigned,
+                                                   Rgba{1, 1, 1, 1}}),
+      std::exception);
+}
+
+/* This confirms that DrakeVisualizer will dispatch a new load message when it
+ recognizes a change in the visualized role's version. We'll confirm both the
+ positive case (change to expected role triggers load) and the negative case
+ (change to other roles does *not* trigger load).  */
+TEST_F(DrakeVisualizerTest, ChangesInVersion) {
+  for (const Role role :
+       {Role::kProximity, Role::kPerception, Role::kIllustration}) {
+    ConfigureDiagram(kPublishPeriod, role);
+    const GeometryId g_id = scene_graph_->RegisterAnchoredGeometry(
+        source_id_, make_unique<GeometryInstance>(
+                        RigidTransformd{}, make_unique<Sphere>(1), "sphere0"));
+
+    Simulator<double> simulator(*diagram_);
+    Context<double>& diagram_context = simulator.get_mutable_context();
+    Context<double>& sg_context =
+        diagram_->GetMutableSubsystemContext(*scene_graph_, &diagram_context);
+    double t = 0.0;
+    simulator.AdvanceTo(t);
+    // Confirm the initial load/draw message pair.
+    MessageResults results = ProcessMessages();
+    ASSERT_EQ(results.num_load, 1);
+    ASSERT_EQ(results.num_draw, 1);
+
+    t += kPublishPeriod;
+    simulator.AdvanceTo(t);
+    // Confirm draw only.
+    results = ProcessMessages();
+    ASSERT_EQ(results.num_load, 0);
+    ASSERT_EQ(results.num_draw, 1);
+
+    // Confirm that modifying a role has the expected outcome. If the modified
+    // role matches the visualized `role`, we expect a load message. Otherwise
+    // expect no load message.
+    // We don't exhaustively compare all three roles. The only way to get
+    // perception version changes is to have an actual render engine that
+    // accepts geometry. We'll avoid the overhead and assume that successful
+    // interactions of other role-role matchups suggest that it's likewise true
+    // for a modified perception role.
+    for (const Role modified_role : {Role::kProximity, Role::kIllustration}) {
+      if (modified_role == Role::kProximity) {
+        scene_graph_->AssignRole(&sg_context, source_id_, g_id,
+                                 ProximityProperties());
+      } else if (modified_role == Role::kIllustration) {
+        scene_graph_->AssignRole(&sg_context, source_id_, g_id,
+                                 IllustrationProperties());
+      }
+      t += kPublishPeriod;
+      simulator.AdvanceTo(t);
+      results = ProcessMessages();
+      EXPECT_EQ(results.num_load, modified_role == role ? 1 : 0)
+          << "For visualized role '" << role << "' and modified role '" << role
+          << "'\n";
+      EXPECT_EQ(results.num_draw, 1);
+    }
+  }
+}
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/test/geometry_version_test.cc
+++ b/geometry/test/geometry_version_test.cc
@@ -15,13 +15,10 @@ namespace geometry {
 class GeometryVersionTest : public ::testing::Test {
  protected:
   void SetUp() {}
-  GeometryVersion version_;
 
   void modify_proximity(GeometryVersion* v) { v->modify_proximity(); }
   void modify_perception(GeometryVersion* v) { v->modify_perception(); }
   void modify_illustration(GeometryVersion* v) { v->modify_illustration(); }
-
-  GeometryVersion CreateGeometryVersion() const { return GeometryVersion(); }
 
   void VerifySameRole(const GeometryVersion& v1, const GeometryVersion& v2,
                       Role role) const {
@@ -50,6 +47,8 @@ class GeometryVersionTest : public ::testing::Test {
     VerifyDistinctRole(v1, v2, Role::kPerception);
     VerifyDistinctRole(v1, v2, Role::kIllustration);
   }
+
+  GeometryVersion version_;
 };
 
 namespace {
@@ -133,7 +132,7 @@ TEST_F(GeometryVersionTest, Transitivity) {
 // Tests property 5.
 TEST_F(GeometryVersionTest, DefaultConstruct) {
   // Each default constructed version is unique.
-  GeometryVersion new_version = CreateGeometryVersion();
+  GeometryVersion new_version;
   VerifyDistinctVersions(new_version, version_);
 }
 }  // namespace


### PR DESCRIPTION
A new leaf system that supplants the old `geometry::ConnectDrakeVisualizer` functionality. The introduction of this `System` improves Drake in several ways.

1. It provides a visualizer example that make use of the `QueryObject` and `SceneGraphInspector` public API (the old version exercised internal code).
2. It has the ability to update the visualization based on changes to the geometry.
3. It is a single system (rather than an entire diagram).
4. It frees `SceneGraph` to remove the out-dated `PoseBundle` output port that is currently used to visualize to `drake_visualizer`.

This
  - Includes the C++ and python versions of the new `System`.
  - Updates `examples/scene_graph` to make use `DrakeVisualizer`.
  - Adds upgraded unit tests over those for the old interface.
  - It also tweaks `GeometryVersion` to allow for default construction of versions so that objects can default construct a `GeometryVersion` member.
  - Extends the API for `SceneGraphInspector` with some helpful methods.

relates #13597
relates #14258

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14247)
<!-- Reviewable:end -->
