### PR TITLE
[geometry] Use the new box mesh in hydroelastic contact model.

### DIFF
--- a/geometry/profiling/BUILD.bazel
+++ b/geometry/profiling/BUILD.bazel
@@ -24,7 +24,7 @@ drake_cc_binary(
     ],
     deps = [
         "//common",
-        "//geometry:geometry_visualization",
+        "//geometry:drake_visualizer",
         "//geometry:scene_graph",
         "//lcmtypes:contact_results_for_viz",
         "//systems/analysis:explicit_euler_integrator",

--- a/geometry/profiling/README.md
+++ b/geometry/profiling/README.md
@@ -23,7 +23,47 @@ kcachegrind callgrind.out.19482
 
 # Available Examples.
 
-* contact_surface_rigid_bowl_soft_ball.cc:
-Compute contact surface between an anchored rigid bowl and a dynamic soft
+## contact_surface_rigid_bowl_soft_ball.cc:
+Compute contact surface between an anchored rigid bowl and a moving soft
 ball. The rigid bowl is a realistic non-convex object, and the soft ball uses
 a coarse tetrahedral mesh, which is typical in hydroelastic contact model.
+
+To visualize the contact surface and pressure, run drake_visualizer and
+configure Hydroelastic Contact Visualization plugin as follows:
+1. From the top menu, click on: Plugins > Contacts > Configure Hydroelastic
+ Contact
+ Visualization.
+2. Change "Maximum pressure" to a reasonably large number (for example, 4e7).
+3. Check or uncheck "Render contact surface with pressure" as you prefer.
+4. Check or uncheck "Renter contact surface wireframe" as you prefer.
+5. Click "OK".
+6. Run this profiling example.
+
+Instead of the default rigid bowl, it can optionally use a rigid ball or a
+rigid box. Instead of the default soft ball, it can use a soft box.
+Totally there are six possible combinations: 
+
+- default rigid bowl and default soft ball,
+```
+bazel-bin/geometry/profiling/contact_surface_rigid_bowl_soft_ball
+```
+- default rigid bowl and soft box option,
+```
+bazel-bin/geometry/profiling/contact_surface_rigid_bowl_soft_ball --soft=box
+```
+- rigid ball option and default soft ball,
+```
+bazel-bin/geometry/profiling/contact_surface_rigid_bowl_soft_ball --rigid=ball
+```
+- rigid ball option and soft box option,
+```
+bazel-bin/geometry/profiling/contact_surface_rigid_bowl_soft_ball --rigid=ball --soft=box
+```
+- rigid box option and default soft ball,
+```
+bazel-bin/geometry/profiling/contact_surface_rigid_bowl_soft_ball --rigid=box
+```
+- rigid box option and soft box option.
+```
+bazel-bin/geometry/profiling/contact_surface_rigid_bowl_soft_ball --rigid=box --soft=box
+```

--- a/geometry/proximity/hydroelastic_internal.h
+++ b/geometry/proximity/hydroelastic_internal.h
@@ -383,8 +383,7 @@ std::optional<RigidGeometry> MakeRigidRepresentation(
 std::optional<RigidGeometry> MakeRigidRepresentation(
     const Sphere& sphere, const ProximityProperties& props);
 
-/* Rigid box support. Requires the ('hydroelastic', 'resolution_hint')
- property.  */
+/* Rigid box support. It doesn't depend on any of the proximity properties. */
 std::optional<RigidGeometry> MakeRigidRepresentation(
     const Box& box, const ProximityProperties& props);
 
@@ -433,8 +432,7 @@ std::optional<SoftGeometry> MakeSoftRepresentation(
     const Sphere& sphere, const ProximityProperties& props);
 
 /* Creates a soft box (assuming the proximity properties have sufficient
- information). Requires the ('hydroelastic', 'resolution_hint') and
- ('material', 'elastic_modulus') properties.  */
+ information). Requires the ('material', 'elastic_modulus') properties.  */
 std::optional<SoftGeometry> MakeSoftRepresentation(
     const Box& box, const ProximityProperties& props);
 


### PR DESCRIPTION
Complete the solution for issue #11906 by using the new mesh from PR #14216 in the hydroelastic contact model.

The compliant box will use the new volume mesh conforming to its medial axis, and the rigid box will use the coarsest surface mesh.

I also added a rigid box and a soft box to the contact-surface profiling example to visually verify that the newer coarser meshes still give good quality pressure distribution on the contact surface.  The first picture below shows the contact surface between the coarsest rigid box's mesh (grey) against the new medial-axis mesh of a soft box (pink).  The second picture below shows the contact surface between the coarsest rigid box's mesh (grey) and a soft ball's  mesh (pink).

![image](https://user-images.githubusercontent.com/42557859/97240142-b7c5ba00-17aa-11eb-8490-bcc62a365495.png)

![image](https://user-images.githubusercontent.com/42557859/97240073-80570d80-17aa-11eb-9d28-497336460e48.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14251)
<!-- Reviewable:end -->
