### PR TITLE
Add color images with textured objects

### DIFF
--- a/geometry/render/gl_renderer/BUILD.bazel
+++ b/geometry/render/gl_renderer/BUILD.bazel
@@ -45,6 +45,7 @@ drake_cc_package_library_gl_per_os(
         ":shader_program",
         ":shader_program_data",
         ":shape_meshes",
+        ":texture_library",
     ],
     visibility = ["//visibility:public"],
 )
@@ -100,6 +101,7 @@ drake_cc_library_gl_ubuntu_only(
         ":shader_program",
         ":shader_program_data",
         ":shape_meshes",
+        ":texture_library",
         "//common:essential",
         "//geometry/render:render_engine",
         "//geometry/render:render_label",
@@ -189,6 +191,17 @@ drake_cc_library_gl_ubuntu_only(
     ],
 )
 
+drake_cc_library_gl_ubuntu_only(
+    name = "texture_library",
+    srcs = ["texture_library.cc"],
+    hdrs = ["texture_library.h"],
+    deps = [
+        "//common:essential",
+        "//geometry/render/gl_renderer:opengl_context",
+        "@vtk//:vtkIOImage",
+    ],
+)
+
 drake_cc_googletest_gl_ubuntu_only(
     name = "buffer_dim_test",
     deps = [
@@ -226,6 +239,7 @@ drake_cc_googletest_gl_ubuntu_only(
         "//conditions:default": [],
     }),
     data = [
+        "//geometry/render:test_models",
         "//systems/sensors:test_models",
     ],
     tags = vtk_test_tags(),

--- a/geometry/render/gl_renderer/shader_program.cc
+++ b/geometry/render/gl_renderer/shader_program.cc
@@ -84,8 +84,8 @@ void ShaderProgram::LoadFromSources(const std::string& vertex_shader_source,
     throw std::runtime_error(error_prefix + info);
   }
 
-  projection_matrix_loc_ = GetUniformLocation("projection_matrix");
-  model_view_loc_ = GetUniformLocation("model_view_matrix");
+  projection_matrix_loc_ = GetUniformLocation("T_DC");
+  model_view_loc_ = GetUniformLocation("T_CM");
 }
 
 namespace {
@@ -105,8 +105,8 @@ void ShaderProgram::LoadFromFiles(const std::string& vertex_shader_file,
   LoadFromSources(LoadFile(vertex_shader_file), LoadFile(fragment_shader_file));
 }
 
-void ShaderProgram::SetProjectionMatrix(const Eigen::Matrix4f& X_DG) const {
-  glUniformMatrix4fv(projection_matrix_loc_, 1, GL_FALSE, X_DG.data());
+void ShaderProgram::SetProjectionMatrix(const Eigen::Matrix4f& T_DC) const {
+  glUniformMatrix4fv(projection_matrix_loc_, 1, GL_FALSE, T_DC.data());
 }
 
 void ShaderProgram::SetModelViewMatrix(const Eigen::Matrix4f& X_CM,
@@ -123,8 +123,8 @@ void ShaderProgram::SetModelViewMatrix(const Eigen::Matrix4f& X_CM,
           .finished();
   // clang-format on
   const Eigen::Matrix4f X_CglM = kX_CglC * X_CM;
-  Eigen::Matrix4f X_CglMscale = X_CglM * scale_mat;
-  glUniformMatrix4fv(model_view_loc_, 1, GL_FALSE, X_CglMscale.data());
+  Eigen::Matrix4f T_CglM = X_CglM * scale_mat;
+  glUniformMatrix4fv(model_view_loc_, 1, GL_FALSE, T_CglM.data());
   DoModelViewMatrix(X_CglM, scale);
 }
 

--- a/geometry/render/gl_renderer/shader_program.h
+++ b/geometry/render/gl_renderer/shader_program.h
@@ -48,12 +48,14 @@ namespace internal {
  shader code and any idiosyncratic details. To be compatible with *this*
  shader abstraction, a shader must meet some minimum requirements:
 
-   - It must specify a uniform mat4 called "model_view_matrix" - this transforms
-     vertices from the geometry's canonical frame G to the OpenGl camera frame
-     C.
-   - It must specify a uniform mat4 called "projection_matrix" - this transforms
-     vertices from the geometry's canonical frame G to the OpenGl device frame
-     D.  */
+   - It must specify a uniform mat4 called "T_CM" - this transforms
+     vertices from the geometry's canonical frame M to the OpenGl camera frame
+     C. This transform may include scale factors (meaning it is not necessarily
+     a RigidTransform).
+   - It must specify a uniform mat4 called "T_DC" - this transforms
+     vertices from the camera's frame C to the OpenGl normalized device frame
+     D. This is a projective transform, taking points in ℜ³ and mapping them
+     to ℜ². */
 class ShaderProgram {
  public:
   ShaderProgram() : id_(ShaderId::get_new_id()) {}
@@ -120,7 +122,7 @@ class ShaderProgram {
   /* Sets the OpenGl projection matrix state. The projection matrix transforms a
    vertex from the camera frame C to the OpenGl 2D device frame D -- it
    projects a point in 3D to a point on the image.  */
-  void SetProjectionMatrix(const Eigen::Matrix4f& X_DC) const;
+  void SetProjectionMatrix(const Eigen::Matrix4f& T_DC) const;
 
   /* Sets the OpenGl model view matrix (and allows the shader to do any other
    (instance, camera)-dependent configuration). The model view matrix X_CM

--- a/geometry/render/gl_renderer/test/shader_program_test.cc
+++ b/geometry/render/gl_renderer/test/shader_program_test.cc
@@ -87,12 +87,12 @@ class TestShader final : public ShaderProgram {
 
 constexpr char kVertexSource[] = R"""(
   #version 330
-  uniform mat4 model_view_matrix;
-  uniform mat4 projection_matrix;
+  uniform mat4 T_CM;
+  uniform mat4 T_DC;
   out vec4 p_CV;
   void main() {
-    gl_Position = projection_matrix * vec4(0.0, 0.0, 0.0, 1.0);
-    p_CV = model_view_matrix * vec4(0.0, 0.0, 0.0, 1.0);
+    gl_Position = T_DC * vec4(0.0, 0.0, 0.0, 1.0);
+    p_CV = T_CM * vec4(0.0, 0.0, 0.0, 1.0);
   }
 )""";
 
@@ -249,16 +249,16 @@ TEST_F(ShaderProgramTest, LoadShadersError) {
     DRAKE_EXPECT_THROWS_MESSAGE(
         program.LoadFromSources(R"""(
   #version 330
-  uniform mat4 model_view_matrix;
-  uniform mat4 projection_matrix;
+  uniform mat4 T_CM;
+  uniform mat4 T_DC;
   out vec4 p_CV;
   void main() {
     gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
-    p_CV = model_view_matrix * vec4(0.0, 0.0, 0.0, 1.0);
+    p_CV = T_CM * vec4(0.0, 0.0, 0.0, 1.0);
   }
 )""",
                                 kFragmentSource),
-        std::runtime_error, "Cannot get shader uniform 'projection_matrix'");
+        std::runtime_error, "Cannot get shader uniform 'T_DC'");
   }
 
   {
@@ -267,16 +267,16 @@ TEST_F(ShaderProgramTest, LoadShadersError) {
     DRAKE_EXPECT_THROWS_MESSAGE(
         program.LoadFromSources(R"""(
   #version 330
-  uniform mat4 model_view_matrix;
-  uniform mat4 projection_matrix;
+  uniform mat4 T_CM;
+  uniform mat4 T_DC;
   out vec4 p_CV;
   void main() {
-    gl_Position = projection_matrix * vec4(0.0, 0.0, 0.0, 1.0);
+    gl_Position = T_DC * vec4(0.0, 0.0, 0.0, 1.0);
     p_CV = vec4(0.0, 0.0, 0.0, 1.0);
   }
 )""",
                                 kFragmentSource),
-        std::runtime_error, "Cannot get shader uniform 'model_view_matrix'");
+        std::runtime_error, "Cannot get shader uniform 'T_CM'");
   }
 }
 

--- a/geometry/render/gl_renderer/texture_library.cc
+++ b/geometry/render/gl_renderer/texture_library.cc
@@ -1,0 +1,88 @@
+#include "drake/geometry/render/gl_renderer/texture_library.h"
+
+#include <algorithm>
+#include <cctype>
+
+#include <fmt/format.h>
+#include <vtkImageData.h>
+#include <vtkImageExport.h>
+#include <vtkNew.h>
+#include <vtkPNGReader.h>
+
+#include "drake/common/drake_assert.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace internal {
+
+TextureLibrary::TextureLibrary(const OpenGlContext* context)
+    : context_(context) {
+  DRAKE_DEMAND(context_ != nullptr);
+}
+
+std::optional<GLuint> TextureLibrary::GetTextureId(
+    const std::string& file_name) {
+  const auto iter = textures_.find(file_name);
+  if (iter != textures_.end()) return iter->second;
+  // If it's not a string from which we can even *consider* finding an
+  // extension, simply bail out.
+  if (file_name.size() < 4) return std::nullopt;
+
+  context_->MakeCurrent();
+  // Otherwise load the texture, register the texture.
+  std::string ext = file_name.substr(file_name.size() - 4, 4);
+  std::transform(ext.begin(), ext.end(), ext.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  // TODO(SeanCurtis-TRI) Support other image types.
+  if (ext != ".png") return std::nullopt;
+
+  vtkNew<vtkPNGReader> png_reader;
+  png_reader->SetFileName(file_name.c_str());
+  png_reader->Update();
+  vtkNew<vtkImageExport> exporter;
+  exporter->SetInputConnection(png_reader->GetOutputPort());
+  exporter->ImageLowerLeftOff();
+  exporter->Update();
+  vtkImageData* image = exporter->GetInput();
+  if (image == nullptr) return std::nullopt;
+
+  const int* dim = image->GetDimensions();
+  const int width = dim[0];
+  const int height = dim[1];
+  // We should have either rgb or rgba data.
+  const int num_channels = image->GetNumberOfScalarComponents();
+  const GLint internal_format =
+      num_channels == 4 ? GL_RGBA : (num_channels == 3 ? GL_RGB : 0);
+  if (internal_format == 0) {
+      return std::nullopt;
+  }
+  // Each channel should be an unsigned byte.
+  if (image->GetScalarType() != VTK_UNSIGNED_CHAR) {
+    return std::nullopt;
+  }
+
+  GLuint texture_id;
+  glGenTextures(1, &texture_id);
+  glBindTexture(GL_TEXTURE_2D, texture_id);
+
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  unsigned char* pixel =
+      static_cast<unsigned char*>(image->GetScalarPointer());
+  glTexImage2D(GL_TEXTURE_2D, 0, internal_format, width, height, 0,
+               internal_format, GL_UNSIGNED_BYTE, pixel);
+  glGenerateMipmap(GL_TEXTURE_2D);
+  glBindTexture(GL_TEXTURE_2D, 0);
+
+  textures_[file_name] = texture_id;
+
+  return texture_id;
+}
+
+}  // namespace internal
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/gl_renderer/texture_library.h
+++ b/geometry/render/gl_renderer/texture_library.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <map>
+#include <optional>
+#include <string>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/geometry/render/gl_renderer/opengl_context.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace internal {
+
+/* Stores a set of OpenGl textures objects, keyed by their in-filesystem name.
+ Its purpose is to guarantee that an image in the file system is only stored
+ once in an OpenGl context. As such, a %TextureLibrary instance is associated
+ with an instance of OpenGlContext.  */
+class TextureLibrary {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(TextureLibrary)
+
+  explicit TextureLibrary(const OpenGlContext* context);
+
+  /* Returns the unique OpenGl identifier for the texture with the given name.
+   Errors in loading the texture are processed *silently*. This will attempt
+   to load the image if a texture hasn't already been added with the given
+   `file_name`.
+
+   @param file_name  The absolute path to the file containing the texture data.
+   @returns A valid OpenGl identifier if the texture has been successfully
+            added to the library, std::nullopt if not.  */
+  std::optional<GLuint> GetTextureId(const std::string& file_name);
+
+ private:
+  const OpenGlContext* context_{};
+
+  /* The mapping from requested texture file name to its OpenGl id (as existing
+   in context_).  */
+  std::map<std::string, GLuint> textures_;
+};
+
+}  // namespace internal
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/multibody/multibody_doxygen.h
+++ b/multibody/multibody_doxygen.h
@@ -311,7 +311,8 @@ Quantity             |Symbol|     Typeset              | Monogram   | Meaning â€
 ---------------------|:----:|:------------------------:|:----------:|----------------------------
 Rotation matrix      |  R   |@f$^BR^C@f$               |`R_BC`      |Frame C's orientation in frame B
 Position vector      |  p   |@f$^Pp^Q@f$               |`p_PQ`      |Position from point P to point Q
-Transform/pose       |  X   |@f$^BX^C@f$               |`X_BC`      |Frame C's transform (pose) in frame B
+Transform/pose       |  X   |@f$^BX^C@f$               |`X_BC`      |Frame C's *rigid* transform (pose) in frame B
+General Transform    |  T   |@f$^BT^C@f$               |`T_BC`      |The relationship between two spaces -- it may be affine, projective, isometric, etc. Every X_AB can be written as T_AB, but not every T_AB can be written as X_AB.
 Angular velocity     |  w   |@f$^B\omega^C@f$          |`w_BC`      |Frame C's angular velocity in frame B â€ 
 Velocity             |  v   |@f$^Bv^Q@f$               |`v_BQ`      |%Point Q's translational velocity in frame B
 Spatial velocity     |  V   |@f$^BV^{C}@f$             |`V_BC`      |Frame C's spatial velocity in frame B


### PR DESCRIPTION
This introduces a shader to render textured objects (diffuse only).

 - New class: TextureLibrary
    - depends on the OpenGl context and owns all of the textures created in the OpenGl context.
 - RenderEngineGl
    - acquires an instance of TextureLibrary
    - Defines a new ShaderProgram -- diffuse textured.
    - Implements the VTK "default texture" logic (i.e., for an mesh.obj, look for mesh.png and apply it as texture -- unless one has already been defined.)
    - Adds texture vertices to the vertex array buffer.
    - Expand tests to include textures on various objects (not all, not yet). Further pushes the tests to conform to those for RenderEngineGl in anticipation of test refactoring.

Relates to #13617

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14260)
<!-- Reviewable:end -->
