### PR TITLE
Add FemElement and FemState.

### DIFF
--- a/multibody/fem/dev/BUILD.bazel
+++ b/multibody/fem/dev/BUILD.bazel
@@ -35,6 +35,66 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "elasticity_element_cache",
+    hdrs = [
+        "elasticity_element_cache.h",
+    ],
+    deps = [
+        ":deformation_gradient_cache",
+        ":element_cache",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "element_cache",
+    hdrs = [
+        "element_cache.h",
+    ],
+    deps = [
+        ":fem_indexes",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "fem_elasticity",
+    srcs = [
+        "fem_elasticity.cc",
+    ],
+    hdrs = [
+        "fem_elasticity.h",
+    ],
+    deps = [
+        ":constitutive_model",
+        ":elasticity_element_cache",
+        ":fem_element",
+        ":isoparametric_element",
+        ":quadrature",
+        "//common:default_scalars",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "fem_element",
+    srcs = [
+        "fem_element.cc",
+    ],
+    hdrs = [
+        "fem_element.h",
+    ],
+    deps = [
+        ":constitutive_model",
+        ":fem_state",
+        ":isoparametric_element",
+        ":quadrature",
+        "//common:default_scalars",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
     name = "fem_indexes",
     hdrs = [
         "fem_indexes.h",
@@ -42,6 +102,17 @@ drake_cc_library(
     deps = [
         "//common:essential",
         "//common:type_safe_index",
+    ],
+)
+
+drake_cc_library(
+    name = "fem_state",
+    hdrs = [
+        "fem_state.h",
+    ],
+    deps = [
+        ":element_cache",
+        "//common:essential",
     ],
 )
 
@@ -117,10 +188,24 @@ drake_cc_library(
 )
 
 drake_cc_googletest(
-    name = "linear_elasticity_model_cache_test",
+    name = "fem_elasticity_test",
     deps = [
-        ":linear_elasticity_model_cache",
+        ":fem_elasticity",
+        ":fem_state",
+        ":linear_elasticity_model",
+        ":linear_simplex_element",
+        ":quadrature",
+        "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
+        "//math:gradient",
+    ],
+)
+
+drake_cc_googletest(
+    name = "fem_state_test",
+    deps = [
+        ":element_cache",
+        ":fem_state",
     ],
 )
 
@@ -131,7 +216,14 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
         "//math:gradient",
-        "//math:jacobian",
+    ],
+)
+
+drake_cc_googletest(
+    name = "linear_elasticity_model_cache_test",
+    deps = [
+        ":linear_elasticity_model_cache",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/multibody/fem/dev/elasticity_element_cache.h
+++ b/multibody/fem/dev/elasticity_element_cache.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fem/dev/deformation_gradient_cache.h"
+#include "drake/multibody/fem/dev/element_cache.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+/** Cached quantities per element that are used in the element routine
+ FemElasticity. Implements the abstract interface ElementCache.
+
+ See FemElasticity for the corresponding FemElement for %ElasticityElementCache.
+ @tparam_nonsymbolic_scalar T. */
+template <typename T>
+class ElasticityElementCache : public ElementCache<T> {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ElasticityElementCache);
+
+  /** Constructs a new %ElasticityElementCache.
+   @param element_index The index of the FemElasticity associated with this
+   %ElasticityElementCache.
+   @param num_quads The number of quadrature locations at which cached
+   quantities need to be evaluated.
+   @param deformation_gradient_cache The DeformationGradientCache associated
+   with this element. Must be compatible with the ConstitutiveModel in the
+   FemElasticity routine corresponding to this %ElasticityElementCache.
+   @pre `num_quads` must be positive.
+   @warning The input `deformation_gradient_cache` must be compatible with the
+   ConstitutiveModel in the FemElasticity that shares the same element index
+   with this %ElasticityElementCache. More specifically, if the
+   ConstitutiveModel in the corresponding FemElasticity is of type "FooModel",
+   then the input `deformation_gradient_cache` must be of type "FooModelCache".
+  */
+  ElasticityElementCache(
+      ElementIndex element_index, int num_quads,
+      std::unique_ptr<DeformationGradientCache<T>> deformation_gradient_cache)
+      : ElementCache<T>(element_index, num_quads),
+        deformation_gradient_cache_(std::move(deformation_gradient_cache)) {}
+
+  virtual ~ElasticityElementCache() = default;
+
+  /// Getter for the const cache entries.
+  /// @{
+  const std::unique_ptr<DeformationGradientCache<T>>&
+  deformation_gradient_cache() const {
+    return deformation_gradient_cache_;
+  }
+  /// @}
+
+  /// Getter for the mutable cache entries.
+  /// @{
+  std::unique_ptr<DeformationGradientCache<T>>&
+  mutable_deformation_gradient_cache() {
+    return deformation_gradient_cache_;
+  }
+  /// @}
+
+ private:
+  std::unique_ptr<DeformationGradientCache<T>> deformation_gradient_cache_;
+};
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/dev/element_cache.h
+++ b/multibody/fem/dev/element_cache.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fem/dev/fem_indexes.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+/** %ElementCache stores the per element state-dependent quantities used in an
+ FEM simulation that are not states themselves. %ElementCache should be used in
+ tandem with FemElement. There should be a one-to-one correspondence between
+ each FemElement that performs the element routine and each %ElementCache that
+ stores the state-dependent quantities used in the routine. This correspondence
+ is maintained by the same element index that is assigned to the FemElement
+ and the %ElementCache in correspondence. Furthermore, the type of FemElement
+ and %ElementCache in correspondence must be compatible. More specifically, if
+ the FemElement is of concrete type `FemFoo`, then the %ElementCache that shares
+ the same element index must be of concrete type `FooElementCache`.
+ @tparam_nonsymbolic_scalar T. */
+template <typename T>
+class ElementCache {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ElementCache);
+
+  virtual ~ElementCache() = default;
+
+  /** The index of the FemElement associated with this %ElementCache. */
+  ElementIndex element_index() const { return element_index_; }
+
+  /** The number of quadrature locations at which cached quantities need to be
+   evaluated. */
+  int num_quads() const { return num_quads_; }
+
+  // TODO(xuchenhan-tri): Add interface for marking cache entries stale when
+  // caching is in place.
+
+ protected:
+  /* Constructs a new ElementCache.
+   @param element_index The index of the FemElement associated with this
+   ElementCache.
+   @param num_quads The number of quadrature locations at which cached
+   quantities need to be evaluated.
+   @pre `num_quads` must be positive. */
+  ElementCache(ElementIndex element_index, int num_quads)
+      : element_index_(element_index), num_quads_(num_quads) {
+    DRAKE_DEMAND(element_index_.is_valid());
+    DRAKE_DEMAND(num_quads > 0);
+  }
+
+ private:
+  ElementIndex element_index_;
+  int num_quads_{-1};
+};
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/dev/fem_elasticity.cc
+++ b/multibody/fem/dev/fem_elasticity.cc
@@ -1,0 +1,133 @@
+#include "drake/multibody/fem/dev/fem_elasticity.h"
+
+#include "drake/common/default_scalars.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+
+template <typename T, int NaturalDim>
+FemElasticity<T, NaturalDim>::FemElasticity(
+    ElementIndex element_index,
+    const IsoparametricElement<T, NaturalDim>& shape,
+    const Quadrature<T, NaturalDim>& quadrature,
+    const std::vector<NodeIndex>& node_indices,
+    const Eigen::Ref<const Matrix3X<T>>& reference_positions,
+    const ConstitutiveModel<T>& constitutive_model)
+    : FemElement<T, NaturalDim>(element_index, shape, quadrature, node_indices),
+      constitutive_model_(constitutive_model),
+      dxidX_(num_quads()),
+      volume_(num_quads()) {
+  DRAKE_DEMAND(num_nodes() == reference_positions.cols());
+  // Record the quadrature point volumes for the new element.
+  std::vector<MatrixX<T>> dXdxi = shape.CalcJacobian(reference_positions);
+  for (int q = 0; q < num_quads(); ++q) {
+    // Degenerate tetrahedron in the initial configuration is not allowed.
+    T det = dXdxi[q].determinant();
+    DRAKE_DEMAND(det > 0);
+    volume_[q] = det * quadrature.get_weight(q);
+  }
+
+  // Record the inverse Jacobian at the reference configuration which is used in
+  // the calculation of deformation gradient.
+  auto dxidX = shape.CalcJacobianInverse(dXdxi);
+  for (int q = 0; q < num_quads(); ++q) {
+    dxidX_[q] = Eigen::Ref<MatrixD3>(dxidX[q]);
+  }
+}
+
+template <typename T, int NaturalDim>
+T FemElasticity<T, NaturalDim>::CalcElasticEnergy(const FemState<T>& s) const {
+  T elastic_energy = 0;
+  // TODO(xuchenhan-tri): Use the corresponding Eval method with cache is in
+  // place.
+  std::vector<T> Psi(num_quads());
+  CalcPsi(s, &Psi);
+  for (int q = 0; q < num_quads(); ++q) {
+    elastic_energy += volume_[q] * Psi[q];
+  }
+  return elastic_energy;
+}
+
+template <typename T, int NaturalDim>
+void FemElasticity<T, NaturalDim>::DoCalcResidual(
+    const FemState<T>& state, EigenPtr<VectorX<T>> residual) const {
+  CalcElasticForce(state, residual);
+}
+
+template <typename T, int NaturalDim>
+void FemElasticity<T, NaturalDim>::CalcElasticForce(
+    const FemState<T>& state, EigenPtr<VectorX<T>> force) const {
+  force->setZero();
+  auto force_matrix = Eigen::Map<Matrix3X<T>>(force->data(), 3, num_nodes());
+  // TODO(xuchenhan-tri): Use the corresponding Eval method with cache is in
+  // place.
+  std::vector<Matrix3<T>> P(num_quads());
+  CalcP(state, &P);
+  const auto dSdxi = shape_.CalcGradientInParentCoordinates();
+  for (int q = 0; q < num_quads(); ++q) {
+    force_matrix -=
+        volume_[q] * P[q] * dxidX_[q].transpose() * dSdxi[q].transpose();
+  }
+}
+
+template <typename T, int NaturalDim>
+void FemElasticity<T, NaturalDim>::CalcF(const FemState<T>& state,
+                                         std::vector<Matrix3<T>>* F) const {
+  F->resize(num_quads());
+  Matrix3X<T> element_x(3, num_nodes());
+  const auto& x_tmp = state.x();
+  const auto& x =
+      Eigen::Map<const Matrix3X<T>>(x_tmp.data(), 3, x_tmp.size() / 3);
+  for (int i = 0; i < num_nodes(); ++i) {
+    element_x.col(i) = x.col(node_indices_[i]);
+  }
+  auto dxdxi = shape_.CalcJacobian(element_x);
+  for (int q = 0; q < num_quads(); ++q) {
+    (*F)[q] = dxdxi[q] * dxidX_[q];
+  }
+}
+
+template <typename T, int NaturalDim>
+const std::unique_ptr<DeformationGradientCache<T>>&
+FemElasticity<T, NaturalDim>::CalcDeformationGradientCache(
+    const FemState<T>& state) const {
+  ElasticityElementCache<T>& mutable_cache =
+      static_cast<ElasticityElementCache<T>&>(
+          state.mutable_cache_at(element_index_));
+  auto& deformation_gradient_cache =
+      mutable_cache.mutable_deformation_gradient_cache();
+  // TODO(xuchenhan-tri): Use the corresponding Eval method with cache is in
+  // place.
+  std::vector<Matrix3<T>> F(num_quads());
+  CalcF(state, &F);
+  deformation_gradient_cache->UpdateCache(F);
+  return deformation_gradient_cache;
+}
+
+template <typename T, int NaturalDim>
+void FemElasticity<T, NaturalDim>::CalcPsi(const FemState<T>& state,
+                                           std::vector<T>* Psi) const {
+  Psi->resize(num_quads());
+  // TODO(xuchenhan-tri): Use the corresponding Eval method with cache is in
+  // place.
+  const auto& deformation_gradient_cache = CalcDeformationGradientCache(state);
+  constitutive_model_.CalcPsi(*deformation_gradient_cache, Psi);
+}
+
+template <typename T, int NaturalDim>
+void FemElasticity<T, NaturalDim>::CalcP(const FemState<T>& state,
+                                         std::vector<Matrix3<T>>* P) const {
+  P->resize(num_quads());
+  // TODO(xuchenhan-tri): Use the corresponding Eval method with cache is in
+  // place.
+  const auto& deformation_gradient_cache = CalcDeformationGradientCache(state);
+  constitutive_model_.CalcP(*deformation_gradient_cache, P);
+}
+template class FemElasticity<double, 2>;
+template class FemElasticity<double, 3>;
+template class FemElasticity<AutoDiffXd, 2>;
+template class FemElasticity<AutoDiffXd, 3>;
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/dev/fem_elasticity.h
+++ b/multibody/fem/dev/fem_elasticity.h
@@ -1,0 +1,124 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fem/dev/constitutive_model.h"
+#include "drake/multibody/fem/dev/elasticity_element_cache.h"
+#include "drake/multibody/fem/dev/fem_element.h"
+#include "drake/multibody/fem/dev/fem_state.h"
+#include "drake/multibody/fem/dev/isoparametric_element.h"
+#include "drake/multibody/fem/dev/quadrature.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+/** The FEM element routine for static and dynamic 3D elasticity problems.
+ Implements the abstract interface of FemElement.
+
+ See ElasticityElementCache for the corresponding ElementCache for
+ %FemElasticity.
+ @tparam_nonsymbolic_scalar T.
+ @tparam NaturalDim The dimension of the parent domain of the FEM elements,
+ e.g. 2 for triangles and 3 for tetrahedrons.  */
+template <typename T, int NaturalDim>
+class FemElasticity : public FemElement<T, NaturalDim> {
+ public:
+  using MatrixD3 = Eigen::Matrix<T, NaturalDim, 3>;
+  /* Make base class methods visible. */
+  using FemElement<T, NaturalDim>::num_nodes;
+  using FemElement<T, NaturalDim>::num_quads;
+
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FemElasticity);
+
+  /** Constructs a new FEM elasticity element.
+   @param[in] element_index The global index of the new element.
+   @param[in] shape The shape function to used for this element.
+   @param[in] quadrature The quadrature rule to be used for this element.
+   @param[in] node_indices The global node indices of the nodes of this
+   element.
+   @param[in] reference_positions The reference positions of the nodes of
+   this element.
+   @param[in] constitutive_model The constitutive model to be used for this
+   element.
+   @pre element_index must be valid.
+   @pre @p shape.num_nodes() must be the same as size of @p node_indices.
+   @pre @p shape.num_nodes() must be the same as the number of columns of @p
+   reference_positions.
+   @warning The input `constitutive_model` must be compatible with the
+   DeformationGradientCache in the ElasticityElementCache that shares the same
+   element index with this %FemElasticity. More specifically, if the
+   DeformationGradientCache in the corresponding ElasticityElementCache is of
+   type "FooModelCache", then the input `constitutive_model` must be of type
+   "FooModel". */
+  FemElasticity(ElementIndex element_index,
+                const IsoparametricElement<T, NaturalDim>& shape,
+                const Quadrature<T, NaturalDim>& quadrature,
+                const std::vector<NodeIndex>& node_indices,
+                const Eigen::Ref<const Matrix3X<T>>& reference_positions,
+                const ConstitutiveModel<T>& constitutive_model);
+
+  virtual ~FemElasticity() = default;
+
+  /** The number of spatial dimensions that this element sits in. */
+  int num_spatial_dim() const final { return 3; }
+
+  /** Returns the elastic potential energy stored in this element. */
+  T CalcElasticEnergy(const FemState<T>& s) const;
+
+ protected:
+  /* Calculates the element residual of this element evaluated at the input
+   state.
+   @param[in] state The FEM state at which to evaluate the residual.
+   @returns a vector of residual of size `3 * num_nodes()`. The vector is
+   ordered such that `3*i`-th to `3*i+2`-th entries of the vector stores the
+   residual corresponding to the i-th node in this element. */
+  void DoCalcResidual(const FemState<T>& state,
+                      EigenPtr<VectorX<T>> residual) const final;
+
+ private:
+  /* Make base class protected members visible. */
+  using FemElement<T, NaturalDim>::node_indices_;
+  using FemElement<T, NaturalDim>::element_index_;
+  using FemElement<T, NaturalDim>::shape_;
+
+  friend class FemElasticityTest;
+
+  /* Calculates the elastic force on the nodes in this element. Returns a vector
+   of elastic force of size 3*num_nodes(). */
+  void CalcElasticForce(const FemState<T>& state,
+                        EigenPtr<VectorX<T>> force) const;
+
+  /* Calculates the deformation gradient at all quadrature points in the this
+   element. */
+  void CalcF(const FemState<T>& state, std::vector<Matrix3<T>>* F) const;
+
+  const std::unique_ptr<DeformationGradientCache<T>>&
+  CalcDeformationGradientCache(const FemState<T>& state) const;
+
+  /* Calculates the elastic energy density at each quadrature point in this
+   * element. */
+  void CalcPsi(const FemState<T>& state, std::vector<T>* Psi) const;
+
+  /* Calculates the first Piola stress at each quadrature point in this element.
+   */
+  void CalcP(const FemState<T>& state, std::vector<Matrix3<T>>* P) const;
+
+  /* The constitutive model that describes the stress-strain relationship for
+   this element. */
+  const ConstitutiveModel<T>& constitutive_model_;
+  /* The inverse element Jacobian evaluated at reference configuration at the
+   quadrature points in this element. */
+  std::vector<MatrixD3> dxidX_;
+  /* The volume evaluated at reference configuration occupied by the quadrature
+   points in this element. To integrate a function f over an element, sum
+   f(q)*volume_[q] over all the quadrature points in the element. */
+  std::vector<T> volume_;
+};
+
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/dev/fem_element.cc
+++ b/multibody/fem/dev/fem_element.cc
@@ -1,0 +1,43 @@
+#include "drake/multibody/fem/dev/fem_element.h"
+
+#include "drake/common/default_scalars.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+template <typename T, int NaturalDim>
+VectorX<T> FemElement<T, NaturalDim>::CalcResidual(const FemState<T>& s) const {
+  VectorX<T> residual(num_nodes() * num_spatial_dim());
+  CalcResidual(s, &residual);
+  return residual;
+}
+
+template <typename T, int NaturalDim>
+void FemElement<T, NaturalDim>::CalcResidual(
+    const FemState<T>& s, EigenPtr<VectorX<T>> residual) const {
+  DRAKE_DEMAND(residual != nullptr);
+  DRAKE_DEMAND(residual->size() == num_spatial_dim() * num_nodes());
+  DoCalcResidual(s, residual);
+}
+
+template <typename T, int NaturalDim>
+FemElement<T, NaturalDim>::FemElement(
+    ElementIndex element_index,
+    const IsoparametricElement<T, NaturalDim>& shape,
+    const Quadrature<T, NaturalDim>& quadrature,
+    const std::vector<NodeIndex>& node_indices)
+    : element_index_(element_index),
+      shape_(shape),
+      quadrature_(quadrature),
+      node_indices_(node_indices) {
+  DRAKE_DEMAND(element_index_.is_valid());
+  DRAKE_DEMAND(shape_.num_nodes() == static_cast<int>(node_indices_.size()));
+}
+
+template class FemElement<double, 2>;
+template class FemElement<double, 3>;
+template class FemElement<AutoDiffXd, 2>;
+template class FemElement<AutoDiffXd, 3>;
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/dev/fem_element.h
+++ b/multibody/fem/dev/fem_element.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fem/dev/constitutive_model.h"
+#include "drake/multibody/fem/dev/fem_indexes.h"
+#include "drake/multibody/fem/dev/fem_state.h"
+#include "drake/multibody/fem/dev/isoparametric_element.h"
+#include "drake/multibody/fem/dev/quadrature.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+/** %FemElement is an abstract interface for the "element routines" used in FEM.
+ It computes quantities such as the residual and the stiffness matrix on a
+ single FEM element given the state of the FEM system. These quantities are
+ then assembled into their global counterparts by FemModel.
+
+ %FemElement should be used in tandem with ElementCache. There should be a
+ one-to-one correspondence between each %FemElement that performs the element
+ routine and each ElementCache that stores the state-dependent quantities used
+ in the routine. This correspondence is maintained by the same element index
+ that is assigned to the %FemElement and the ElementCache in correspondence.
+ Furthermore, the type of %FemElement and ElementCache in correspondence must be
+ compatible. More specifically, if the %FemElement is of concrete type `FemFoo`,
+ then the ElementCache that shares the same element index must be of concrete
+ type `FooElementCache`.
+ @tparam_nonsymbolic_scalar T.
+ @tparam NaturalDim The dimension of the parent domain of the FEM elements,
+ e.g. 2 for triangles and 3 for tetrahedrons.  */
+template <typename T, int NaturalDim>
+class FemElement {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FemElement);
+
+  virtual ~FemElement() = default;
+
+  const std::vector<NodeIndex>& node_indices() const { return node_indices_; }
+
+  /** Number of quadrature points at which element-wise quantities are
+   evaluated. */
+  int num_quads() const { return quadrature_.num_points(); }
+
+  /** Number of nodes associated with this element. */
+  int num_nodes() const { return shape_.num_nodes(); }
+
+  /** The number of spatial dimensions that this element sits in. */
+  virtual int num_spatial_dim() const = 0;
+
+  /** Calculates the element residual of this element evaluated at the input
+   state. This method updates the cached quantities in the input FemState if
+   they are out of date.
+   @param[in] state The FEM state at which to evaluate the residual.
+   @returns a vector of residual of size `num_spatial_dim() * num_nodes()`. The
+   vector is ordered such that `{i * num_spatial_dim()}`-th to
+   `{(i+1) * num_spatial_dim() - 1}`-th entries of the vector stores the
+   residual corresponding to the i-th node in this element. */
+  VectorX<T> CalcResidual(const FemState<T>& s) const;
+
+  /** Alternative signature that writes the residual in the output argument.
+   @pre residual must not be the nullptr, and the vector it points to must have
+   size `num_nodes() * num_spatial_dim()`. */
+  void CalcResidual(const FemState<T>& s, EigenPtr<VectorX<T>> residual) const;
+
+  // TODO(xuchenhan-tri): Add CalcMassMatrix and CalcStiffnessMatrix etc.
+
+ protected:
+  /* Constructs a new FEM element.
+    @param[in] element_index The global index of the new element.
+    @param[in] shape The shape function to used for this element.
+    @param[in] quadrature The quadrature rule to be used for this element.
+    @param[in] node_indices The global node indices of the nodes of this
+    element.
+    @pre element_index must be valid.
+    @pre shape.num_nodes() must be the same as size of node_indices. */
+  FemElement(ElementIndex element_index,
+             const IsoparametricElement<T, NaturalDim>& shape,
+             const Quadrature<T, NaturalDim>& quadrature,
+             const std::vector<NodeIndex>& node_indices);
+
+  /* Calculates the element residual of this element evaluated at the input
+   state.
+   @param[in] state The FEM state at which to evaluate the residual.
+   @param[out] a vector of residual of size `num_spatial_dim()*num_nodes()`.
+   The vector is ordered such that `i*num_spatial_dim()`-th to
+   `(i+1)*num_spatial_dim()-1`-th entries of the vector stores the residual
+   corresponding to the i-th node in this element.
+   @pre residual must not be the nullptr, and the vector it points to must have
+   size `num_nodes() * num_spatial_dim()`. */
+  virtual void DoCalcResidual(const FemState<T>& s,
+                              EigenPtr<VectorX<T>> residual) const = 0;
+
+  // The global index of this element.
+  ElementIndex element_index_;
+  // The isoparametric shape function used for this element.
+  const IsoparametricElement<T, NaturalDim>& shape_;
+  // The quadrature rule used for this element.
+  const Quadrature<T, NaturalDim>& quadrature_;
+  // The global node indices of this element.
+  std::vector<NodeIndex> node_indices_;
+};
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/dev/fem_indexes.h
+++ b/multibody/fem/dev/fem_indexes.h
@@ -7,6 +7,9 @@ namespace multibody {
 namespace fem {
 /** Index used to identify element by index among FEM elements. */
 using ElementIndex = TypeSafeIndex<class ElementTag>;
+
+/** Index used to identify node by index among FEM nodes. */
+using NodeIndex = TypeSafeIndex<class NodeTag>;
 }  // namespace fem
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/fem/dev/fem_state.h
+++ b/multibody/fem/dev/fem_state.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fem/dev/element_cache.h"
+#include "drake/multibody/fem/dev/fem_indexes.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+/** The states in the FEM simulation that are associated with the nodes and the
+ elements. The states include the positions of the nodes, `x`, and their time
+ derivatives, `v`. FemState also contains the cached quantities that are
+ associated with the elements whose values depend on the states. See
+ ElementCache.
+ @tparam_nonsymbolic_scalar T. */
+template <typename T>
+class FemState {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(FemState);
+
+  FemState() = default;
+
+  /** Resize the position and velocity states to the input `size`. The existing
+   values are unchanged if `size` is greater than or equal to the size of the
+   existing states. */
+  void Resize(int size) {
+    DRAKE_DEMAND(size >= 0);
+    v_.conservativeResize(size);
+    x_.conservativeResize(size);
+  }
+
+  /// State getters.
+  /// @{
+  const VectorX<T>& v() const { return v_; }
+
+  const VectorX<T>& x() const { return x_; }
+  /// @}
+
+  /// State setters. The value provided must match the current size of the
+  /// states.
+  /// @{
+  void set_v(const Eigen::Ref<const VectorX<T>>& value) {
+    DRAKE_DEMAND(value.size() == v_.size());
+    if (value == v_) return;
+    v_ = value;
+  }
+
+  void set_x(const Eigen::Ref<const VectorX<T>>& value) {
+    DRAKE_DEMAND(value.size() == x_.size());
+    if (value == x_) return;
+    x_ = value;
+  }
+  /// @}
+
+  /// Mutable state getters. The value of the states is mutable but the sizes of
+  /// the states are not allowed to change.
+  /// @{
+  Eigen::VectorBlock<VectorX<T>> mutable_v() { return v_.head(v_.size()); }
+
+  Eigen::VectorBlock<VectorX<T>> mutable_x() { return x_.head(x_.size()); }
+  /// @}
+
+  /// Getters and mutable getters for cached quantities.
+  /// @{
+  const std::vector<std::unique_ptr<ElementCache<T>>>& cache() const {
+    return cache_;
+  }
+
+  std::vector<std::unique_ptr<ElementCache<T>>>& mutable_cache() const {
+    return cache_;
+  }
+
+  const ElementCache<T>& cache_at(ElementIndex e) const { return *cache_[e]; }
+
+  ElementCache<T>& mutable_cache_at(ElementIndex e) const { return *cache_[e]; }
+  /// @}
+
+ private:
+  // Node velocities.
+  VectorX<T> v_;
+  // Node positions.
+  VectorX<T> x_;
+  // Owned cached quantities.
+  mutable std::vector<std::unique_ptr<ElementCache<T>>> cache_;
+};
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/dev/quadrature.h
+++ b/multibody/fem/dev/quadrature.h
@@ -29,6 +29,11 @@ class Quadrature {
   /// The number of quadrature points for the quadrature rule.
   int num_points() const { return points_.size(); }
 
+  /// The position in parent coordinate of all quadrature points.
+  const std::vector<VectorD>& get_points() const {
+      return points_;
+  }
+
   /// The position in parent coordinate of the q-th quadrature point.
   const VectorD& get_point(int q) const {
     DRAKE_DEMAND(q >= 0);

--- a/multibody/fem/dev/test/fem_elasticity_test.cc
+++ b/multibody/fem/dev/test/fem_elasticity_test.cc
@@ -1,0 +1,103 @@
+#include "drake/multibody/fem/dev/fem_elasticity.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/autodiff_gradient.h"
+#include "drake/multibody/fem/dev/fem_state.h"
+#include "drake/multibody/fem/dev/linear_elasticity_model.h"
+#include "drake/multibody/fem/dev/linear_simplex_element.h"
+#include "drake/multibody/fem/dev/quadrature.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+constexpr int kNaturalDim = 3;
+constexpr int kSpatialDim = 3;
+constexpr int kQuadratureOrder = 1;
+constexpr int kNumVertices = 4;
+constexpr int kDof = kSpatialDim * kNumVertices;
+const ElementIndex kDummyElementIndex(0);
+
+class FemElasticityTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    SetupElement();
+    SetupState();
+  }
+
+  void SetupElement() {
+    quadrature_ = std::make_unique<
+        SimplexGaussianQuadrature<AutoDiffXd, kQuadratureOrder, kSpatialDim>>();
+    shape_ = std::make_unique<LinearSimplexElement<AutoDiffXd, kNaturalDim>>(
+        quadrature_->get_points());
+    std::vector<NodeIndex> node_indices = {NodeIndex(0), NodeIndex(1),
+                                           NodeIndex(2), NodeIndex(3)};
+    Matrix3X<AutoDiffXd> reference_positions = get_reference_positions();
+    linear_elasticity_ =
+        std::make_unique<LinearElasticityModel<AutoDiffXd>>(100, 0.25);
+    fem_elasticity_ = std::make_unique<FemElasticity<AutoDiffXd, kNaturalDim>>(
+        kDummyElementIndex, *shape_, *quadrature_, node_indices,
+        reference_positions, *linear_elasticity_);
+  }
+
+  void SetupState() {
+    state_.Resize(kDof);
+    state_.mutable_v() = VectorX<AutoDiffXd>::Zero(kDof);
+    // Set arbitrary node positions and the gradient.
+    Eigen::Matrix<double, kDof, 1> x;
+    x << 0.18, 0.63, 0.54, 0.13, 0.92, 0.17, 0.03, 0.86, 0.85, 0.25, 0.53, 0.67;
+    const Eigen::Matrix<double, kDof, Eigen::Dynamic> gradient =
+        MatrixX<double>::Identity(kDof, kDof);
+    const VectorX<AutoDiffXd> x_autodiff =
+        math::initializeAutoDiffGivenGradientMatrix(x, gradient);
+    state_.mutable_x() = x_autodiff;
+    // Set up the element cache.
+    auto& cache = state_.mutable_cache();
+    auto linear_elasticity_cache =
+        std::make_unique<LinearElasticityModelCache<AutoDiffXd>>(
+            kDummyElementIndex, quadrature_->num_points());
+    cache.emplace_back(std::make_unique<ElasticityElementCache<AutoDiffXd>>(
+        kDummyElementIndex, quadrature_->num_points(),
+        std::move(linear_elasticity_cache)));
+  }
+
+  // Set an arbitrary reference position such that the tetrahedron is not
+  // inverted.
+  Matrix3X<AutoDiffXd> get_reference_positions() const {
+    Matrix3X<AutoDiffXd> Q(kSpatialDim, kNumVertices);
+    Q << -0.10, 0.90, 0.02, 0.10, 1.33, 0.23, 0.04, 0.01, 0.20, 0.03, 2.31,
+        -0.12;
+    return Q;
+  }
+
+  // Calculates the elastic force at state_.
+  VectorX<AutoDiffXd> CalcElasticForce() const {
+      VectorX<AutoDiffXd> force(kDof);
+      fem_elasticity_->CalcElasticForce(state_, &force);
+      return force;
+  }
+
+  std::unique_ptr<FemElasticity<AutoDiffXd, kNaturalDim>> fem_elasticity_;
+  std::unique_ptr<IsoparametricElement<AutoDiffXd, kNaturalDim>> shape_;
+  std::unique_ptr<Quadrature<AutoDiffXd, kNaturalDim>> quadrature_;
+  std::unique_ptr<LinearElasticityModel<AutoDiffXd>> linear_elasticity_;
+  FemState<AutoDiffXd> state_;
+};
+
+namespace {
+TEST_F(FemElasticityTest, Basic) {
+  EXPECT_EQ(fem_elasticity_->num_nodes(), kNumVertices);
+  EXPECT_EQ(fem_elasticity_->num_quads(), quadrature_->num_points());
+  EXPECT_EQ(fem_elasticity_->num_spatial_dim(), kSpatialDim);
+}
+
+TEST_F(FemElasticityTest, ElasticForceIsNegativeEnergyDerivative) {
+  AutoDiffXd energy = fem_elasticity_->CalcElasticEnergy(state_);
+  VectorX<AutoDiffXd> residual = CalcElasticForce();
+  EXPECT_TRUE(CompareMatrices(energy.derivatives(), -residual, 1e-13));
+}
+}  // namespace
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/dev/test/fem_state_test.cc
+++ b/multibody/fem/dev/test/fem_state_test.cc
@@ -1,0 +1,64 @@
+#include "drake/multibody/fem/dev/fem_state.h"
+
+#include <gtest/gtest.h>
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace {
+constexpr int kDof = 3;
+constexpr int kNumQuads = 1;
+// A toy element cache to test the `mark_foo_cache_stale` methods.
+struct MyElementCache : public ElementCache<double> {
+  MyElementCache(ElementIndex element_index, int num_quads)
+      : ElementCache(element_index, num_quads) {}
+};
+
+class FemStateTest : public ::testing::Test {
+ protected:
+  void SetUp() {
+    // Create a couple of cache entries.
+    auto& mutable_cache = state_.mutable_cache();
+    auto cache_0 = std::make_unique<MyElementCache>(ElementIndex(0), kNumQuads);
+    auto cache_1 = std::make_unique<MyElementCache>(ElementIndex(1), kNumQuads);
+    mutable_cache.emplace_back(std::move(cache_0));
+    mutable_cache.emplace_back(std::move(cache_1));
+    // Set default states.
+    SetStates();
+  }
+  // Default value for the state of the single vertex.
+  VectorX<double> v() const { return Vector3<double>(0.3, 0.4, 0.5); }
+  VectorX<double> x() const { return Vector3<double>(0.7, 0.8, 0.9); }
+
+  // Resize so that there only exists a single vertex and then set the states to
+  // default values.
+  void SetStates() {
+    // Allocate space for states.
+    state_.Resize(kDof);
+    // Set all states for the single vertex to their default values.
+    state_.set_v(v());
+    state_.set_x(x());
+  }
+
+  // FemState under test.
+  FemState<double> state_;
+};
+
+// Verify setters and getters are working properly.
+TEST_F(FemStateTest, SetAndGet) {
+  SetStates();
+  EXPECT_EQ(state_.v(), v());
+  EXPECT_EQ(state_.x(), x());
+}
+
+// Verify resizing does not thrash existing values.
+TEST_F(FemStateTest, ConservativeResize) {
+  SetStates();
+  state_.Resize(2 * kDof);
+  // The first entry should remain unchanged.
+  EXPECT_EQ(state_.v().head(kDof), v());
+  EXPECT_EQ(state_.x().head(kDof), x());
+}
+}  // namespace
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/dev/test/linear_elasticity_model_test.cc
+++ b/multibody/fem/dev/test/linear_elasticity_model_test.cc
@@ -5,7 +5,6 @@
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/math/autodiff_gradient.h"
-#include "drake/math/jacobian.h"
 
 namespace drake {
 namespace multibody {


### PR DESCRIPTION
FemState stores the node-wise states in a FEM simulation as well as
ElementCache that contains state-dependent quantities that are
associated with the FEM elements. FemElement consumes FemState and
performs the element routine in a FEM solver. Currently, the only
element routine we support is calculating the residual.

Concrete instance of ElementCache (ElasticityElementCache) and concrete
instance of FemElement (FemElasticity) are added to illustrate how
these two classes work together.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14261)
<!-- Reviewable:end -->
