### PR TITLE
Add FemElement and FemState.

### DIFF
--- a/multibody/fem/dev/BUILD.bazel
+++ b/multibody/fem/dev/BUILD.bazel
@@ -35,6 +35,67 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "elasticity_element_cache",
+    hdrs = [
+        "elasticity_element_cache.h",
+    ],
+    deps = [
+        ":deformation_gradient_cache",
+        ":element_cache",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "element_cache",
+    hdrs = [
+        "element_cache.h",
+    ],
+    deps = [
+        ":fem_indexes",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "fem_elasticity",
+    srcs = [
+        "fem_elasticity.cc",
+    ],
+    hdrs = [
+        "fem_elasticity.h",
+    ],
+    deps = [
+        ":constitutive_model",
+        ":elasticity_element_cache",
+        ":fem_element",
+        ":isoparametric_element",
+        ":linear_simplex_element",
+        ":quadrature",
+        "//common:default_scalars",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "fem_element",
+    srcs = [
+        "fem_element.cc",
+    ],
+    hdrs = [
+        "fem_element.h",
+    ],
+    deps = [
+        ":constitutive_model",
+        ":fem_state",
+        ":isoparametric_element",
+        ":quadrature",
+        "//common:default_scalars",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
     name = "fem_indexes",
     hdrs = [
         "fem_indexes.h",
@@ -42,6 +103,18 @@ drake_cc_library(
     deps = [
         "//common:essential",
         "//common:type_safe_index",
+    ],
+)
+
+drake_cc_library(
+    name = "fem_state",
+    hdrs = [
+        "fem_state.h",
+    ],
+    deps = [
+        ":element_cache",
+        "//common:copyable_unique_ptr",
+        "//common:essential",
     ],
 )
 
@@ -117,10 +190,24 @@ drake_cc_library(
 )
 
 drake_cc_googletest(
-    name = "linear_elasticity_model_cache_test",
+    name = "fem_elasticity_test",
     deps = [
-        ":linear_elasticity_model_cache",
+        ":fem_elasticity",
+        ":fem_state",
+        ":linear_elasticity_model",
+        ":linear_simplex_element",
+        ":quadrature",
+        "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
+        "//math:gradient",
+    ],
+)
+
+drake_cc_googletest(
+    name = "fem_state_test",
+    deps = [
+        ":element_cache",
+        ":fem_state",
     ],
 )
 
@@ -131,7 +218,14 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
         "//math:gradient",
-        "//math:jacobian",
+    ],
+)
+
+drake_cc_googletest(
+    name = "linear_elasticity_model_cache_test",
+    deps = [
+        ":linear_elasticity_model_cache",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/multibody/fem/dev/constitutive_model.h
+++ b/multibody/fem/dev/constitutive_model.h
@@ -35,47 +35,49 @@ class ConstitutiveModel {
    that match the derived %ConstitutiveModel. Make sure the `cache` that is
    passed in matches the %ConstitutiveModel. */
 
-  /** Calculates the energy density, in unit J/m³, given the model cache. */
-  std::vector<T> CalcPsi(const DeformationGradientCache<T>& cache) const {
+  /** Calculates the energy density per unit reference volume, in unit J/m³,
+   * given the model cache. */
+  std::vector<T> CalcElasticEnergyDensity(
+      const DeformationGradientCache<T>& cache) const {
     std::vector<T> Psi(cache.num_quads());
-    CalcPsi(cache, &Psi);
+    CalcElasticEnergyDensity(cache, &Psi);
     return Psi;
   }
 
-  /** Alternative signature for CalcPsi that writes the result in the output
-   argument. */
-  void CalcPsi(const DeformationGradientCache<T>& cache,
-               std::vector<T>* Psi) const {
+  /** Alternative signature for CalcElasticEnergyDensity that writes the result
+   in the output argument. */
+  void CalcElasticEnergyDensity(const DeformationGradientCache<T>& cache,
+                                std::vector<T>* Psi) const {
     DRAKE_DEMAND(Psi != nullptr);
     DRAKE_DEMAND(static_cast<int>(Psi->size()) == cache.num_quads());
-    DoCalcPsi(cache, Psi);
+    DoCalcElasticEnergyDensity(cache, Psi);
   }
 
   /** Calculates the First Piola stress, in unit Pa, given the model cache. */
-  std::vector<Matrix3<T>> CalcP(
+  std::vector<Matrix3<T>> CalcFirstPiolaStress(
       const DeformationGradientCache<T>& cache) const {
     std::vector<Matrix3<T>> P(cache.num_quads());
-    CalcP(cache, &P);
+    CalcFirstPiolaStress(cache, &P);
     return P;
   }
 
-  /** Alternative signature for CalcP that writes the result in the output
-   argument. */
-  void CalcP(const DeformationGradientCache<T>& cache,
-             std::vector<Matrix3<T>>* P) const {
+  /** Alternative signature for CalcFirstPiolaStress that writes the result in
+   the output argument. */
+  void CalcFirstPiolaStress(const DeformationGradientCache<T>& cache,
+                            std::vector<Matrix3<T>>* P) const {
     DRAKE_DEMAND(P != nullptr);
     DRAKE_DEMAND(static_cast<int>(P->size()) == cache.num_quads());
-    DoCalcP(cache, P);
+    DoCalcFirstPiolaStress(cache, P);
   }
 
  protected:
   /* Calculates the energy density, in unit J/m³, given the model cache. */
-  virtual void DoCalcPsi(const DeformationGradientCache<T>& cache,
-                         std::vector<T>* Psi) const = 0;
+  virtual void DoCalcElasticEnergyDensity(
+      const DeformationGradientCache<T>& cache, std::vector<T>* Psi) const = 0;
 
   /* Calculates the First Piola stress, in unit Pa, given the model cache. */
-  virtual void DoCalcP(const DeformationGradientCache<T>& cache,
-                       std::vector<Matrix3<T>>* P) const = 0;
+  virtual void DoCalcFirstPiolaStress(const DeformationGradientCache<T>& cache,
+                                      std::vector<Matrix3<T>>* P) const = 0;
 };
 }  // namespace fem
 }  // namespace multibody

--- a/multibody/fem/dev/elasticity_element_cache.h
+++ b/multibody/fem/dev/elasticity_element_cache.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "drake/common/copyable_unique_ptr.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fem/dev/deformation_gradient_cache.h"
+#include "drake/multibody/fem/dev/element_cache.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+/** Cached quantities per element that are used in the element routine
+ ElasticityElement. Implements the abstract interface ElementCache.
+
+ See ElasticityElement for the corresponding FemElement for
+ %ElasticityElementCache.
+ @tparam_nonsymbolic_scalar T. */
+template <typename T>
+class ElasticityElementCache : public ElementCache<T> {
+ public:
+  /** @name     Does not allow copy, move, or assignment. */
+  /** @{ */
+  /* Copy constructor is used only to facilitate implementation of Clone()
+   in derived classes. */
+  ElasticityElementCache(ElasticityElementCache&&) = delete;
+  ElasticityElementCache& operator=(ElasticityElementCache&&) = delete;
+  ElasticityElementCache& operator=(const ElasticityElementCache&) = delete;
+  /** @} */
+
+  /** Constructs a new %ElasticityElementCache.
+   @param element_index The index of the ElasticityElement associated with this
+   %ElasticityElementCache.
+   @param num_quads The number of quadrature locations at which cached
+   quantities need to be evaluated.
+   @param deformation_gradient_cache The DeformationGradientCache associated
+   with this element. Must be compatible with the ConstitutiveModel in the
+   ElasticityElement routine corresponding to this %ElasticityElementCache.
+   @pre `num_quads` must be positive.
+   @warning The input `deformation_gradient_cache` must be compatible with the
+   ConstitutiveModel in the ElasticityElement that shares the same element index
+   with this %ElasticityElementCache. More specifically, if the
+   ConstitutiveModel in the corresponding ElasticityElement is of type
+   "FooModel", then the input `deformation_gradient_cache` must be of type
+   "FooModelCache". */
+  ElasticityElementCache(
+      ElementIndex element_index, int num_quads,
+      std::unique_ptr<DeformationGradientCache<T>> deformation_gradient_cache)
+      : ElementCache<T>(element_index, num_quads),
+        deformation_gradient_cache_(std::move(deformation_gradient_cache)) {}
+
+  virtual ~ElasticityElementCache() = default;
+
+  /** @name Getter for the const cache entries.
+   @{ */
+  const DeformationGradientCache<T>& deformation_gradient_cache() const {
+    return *deformation_gradient_cache_;
+  }
+  /** @} */
+
+  /** @name Getter for the mutable cache entries.
+   @{ */
+  DeformationGradientCache<T>& mutable_deformation_gradient_cache() {
+    return *deformation_gradient_cache_;
+  }
+  /** @} */
+
+ protected:
+  /* Copy constructor to facilitate the `DoClone()` method. */
+  ElasticityElementCache(const ElasticityElementCache&) = default;
+
+  /* Creates an identical copy of the ElasticityElementCache object. */
+  std::unique_ptr<ElementCache<T>> DoClone() const final {
+    /* Can't use std::make_unique because the copy constructor is protected. */
+    return std::unique_ptr<ElementCache<T>>(
+        new ElasticityElementCache<T>(*this));
+  }
+
+ private:
+  copyable_unique_ptr<DeformationGradientCache<T>> deformation_gradient_cache_;
+};
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/dev/element_cache.h
+++ b/multibody/fem/dev/element_cache.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <memory>
+
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fem/dev/fem_indexes.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+/** %ElementCache stores the per element state-dependent quantities used in an
+ FEM simulation that are not states themselves. %ElementCache should be used in
+ tandem with FemElement. There should be a one-to-one correspondence between
+ each FemElement that performs the element routine and each %ElementCache that
+ stores the state-dependent quantities used in the routine. This correspondence
+ is maintained by the shared element index that is assigned to both the
+ FemElement and the %ElementCache in correspondence. Furthermore, the type of
+ FemElement and %ElementCache in correspondence must be compatible. More
+ specifically, if the FemElement is of concrete type `FooElement`, then the
+ %ElementCache that shares the same element index must be of concrete type
+ `FooElementCache`.
+ @tparam_nonsymbolic_scalar T. */
+template <typename T>
+class ElementCache {
+ public:
+  /** @name     Does not allow copy, move, or assignment. */
+  /** @{ */
+  /* Copy constructor is used only to facilitate implementation of Clone()
+   in derived classes. */
+  ElementCache(ElementCache&&) = delete;
+  ElementCache& operator=(ElementCache&&) = delete;
+  ElementCache& operator=(const ElementCache&) = delete;
+  /** @} */
+
+  virtual ~ElementCache() = default;
+
+  /** Creates an identical copy of the concrete ElementCache object.
+   */
+  std::unique_ptr<ElementCache<T>> Clone() const { return DoClone(); }
+
+  /** The index of the FemElement associated with this %ElementCache. */
+  ElementIndex element_index() const { return element_index_; }
+
+  /** The number of quadrature locations at which cached quantities need to be
+   evaluated. */
+  int num_quads() const { return num_quads_; }
+
+  // TODO(xuchenhan-tri): Add interface for marking cache entries stale when
+  // caching is in place.
+
+ protected:
+  /* Constructs a new ElementCache.
+   @param element_index The index of the FemElement associated with this
+   ElementCache.
+   @param num_quads The number of quadrature locations at which cached
+   quantities need to be evaluated.
+   @pre `num_quads` must be positive. */
+  ElementCache(ElementIndex element_index, int num_quads)
+      : element_index_(element_index), num_quads_(num_quads) {
+    DRAKE_ASSERT(element_index_.is_valid());
+    DRAKE_ASSERT(num_quads > 0);
+  }
+
+  /* Copy constructor for the base ElementCache class to facilitate
+   `DoClone()` in derived classes. */
+  ElementCache(const ElementCache&) = default;
+
+  /* Creates an identical copy of the concrete ElementCache object.
+   Derived classes must implement this so that it performs the complete
+   deep copy of the object, including all base class members. */
+  virtual std::unique_ptr<ElementCache<T>> DoClone() const = 0;
+
+ private:
+  ElementIndex element_index_;
+  int num_quads_{-1};
+};
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/dev/fem_elasticity.cc
+++ b/multibody/fem/dev/fem_elasticity.cc
@@ -1,0 +1,194 @@
+#include "drake/multibody/fem/dev/fem_elasticity.h"
+
+#include "drake/common/default_scalars.h"
+#include "drake/multibody/fem/dev/linear_simplex_element.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+template <typename T, class IsoparametricElementType, class QuadratureType>
+ElasticityElement<T, IsoparametricElementType, QuadratureType>::
+    ElasticityElement(ElementIndex element_index,
+                      const std::vector<NodeIndex>& node_indices,
+                      const T& density,
+                      std::unique_ptr<ConstitutiveModel<T>> constitutive_model,
+                      const Matrix3X<T>& reference_positions)
+    : FemElement<T>(element_index, node_indices),
+      density_(density),
+      constitutive_model_(std::move(constitutive_model)),
+      dxidX_(num_quads()),
+      reference_positions_(reference_positions),
+      reference_volume_(num_quads()) {
+  /* TODO(xuchenhan-tri): Consider removing the template NaturalDim from
+   IsoparametricElement and Quadrature (e.g. with CRTP). */
+  static_assert(std::is_base_of<IsoparametricElement<T, 1>,
+                                IsoparametricElementType>::value ||
+                    std::is_base_of<IsoparametricElement<T, 2>,
+                                    IsoparametricElementType>::value ||
+                    std::is_base_of<IsoparametricElement<T, 3>,
+                                    IsoparametricElementType>::value,
+                "IsoparametricElementType must be a derived class of "
+                "IsoparametricElement<T, NaturalDim>, where NaturalDim can "
+                "be 1, 2 or 3.");
+  static_assert(std::is_base_of<Quadrature<T, 1>, QuadratureType>::value ||
+                    std::is_base_of<Quadrature<T, 2>, QuadratureType>::value ||
+                    std::is_base_of<Quadrature<T, 3>, QuadratureType>::value,
+                "QuadratureType must be a derived class of "
+                "Quadrature<T, NaturalDim>, where NaturalDim can "
+                "be 1, 2 or 3.");
+  static_assert(
+      IsoparametricElementType::kNaturalDim == QuadratureType::kNaturalDim,
+      "The dimension of the parent domain for IsoparametricElement and "
+      "Quadrature must be the same.");
+  DRAKE_ASSERT(num_nodes() == reference_positions.cols());
+  DRAKE_ASSERT(num_nodes() == static_cast<int>(node_indices.size()));
+  // Record the quadrature point volumes for the new element.
+  const std::vector<MatrixX<T>> dXdxi =
+      shape_.CalcJacobian(reference_positions);
+  for (int q = 0; q < num_quads(); ++q) {
+    // The scale to transform quadrature weight in parent coordinates to
+    // reference coordinates.
+    T volume_scale;
+    if (kNaturalDim == 3) {
+      volume_scale = dXdxi[q].determinant();
+      // Degenerate tetrahedron in the initial configuration is not allowed.
+      DRAKE_ASSERT(volume_scale > 0);
+    } else if (kNaturalDim == 2) {
+      Eigen::ColPivHouseholderQR<MatrixX<T>> qr(dXdxi[q]);
+      volume_scale = abs(qr.matrixR()
+                             .topLeftCorner(kNaturalDim, kNaturalDim)
+                             .template triangularView<Eigen::Upper>()
+                             .determinant());
+    } else if (kNaturalDim == 1) {
+      volume_scale = dXdxi[q].norm();
+    } else {
+      DRAKE_UNREACHABLE();
+    }
+    reference_volume_[q] = volume_scale * quadrature_.get_weight(q);
+  }
+
+  // Record the inverse Jacobian at the reference configuration which is used in
+  // the calculation of deformation gradient.
+  const std::vector<MatrixX<T>> dxidX = shape_.CalcJacobianInverse(dXdxi);
+  for (int q = 0; q < num_quads(); ++q) {
+    dxidX_[q] = Eigen::Ref<const MatrixD3>(dxidX[q]);
+  }
+}
+
+template <typename T, class IsoparametricElementType, class QuadratureType>
+T ElasticityElement<T, IsoparametricElementType,
+                    QuadratureType>::CalcElasticEnergy(const FemState<T>& s)
+    const {
+  T elastic_energy = 0;
+  // TODO(xuchenhan-tri): Use the corresponding Eval method when cache is in
+  // place.
+  // TODO(xuchenhan-tri): Use fixed size array here.
+  std::vector<T> Psi(num_quads());
+  CalcElasticEnergyDensity(s, &Psi);
+  for (int q = 0; q < num_quads(); ++q) {
+    elastic_energy += reference_volume_[q] * Psi[q];
+  }
+  return elastic_energy;
+}
+
+template <typename T, class IsoparametricElementType, class QuadratureType>
+void ElasticityElement<T, IsoparametricElementType,
+                       QuadratureType>::DoCalcResidual(const FemState<T>& state,
+                                                       EigenPtr<VectorX<T>>
+                                                           residual) const {
+  // TODO(xuchenhan-tri): Add gravity and inertia terms when mass matrix is in
+  // place.
+  // TODO(xuchenhan-tri): Add damping force.
+  CalcNegativeElasticForce(state, residual);
+}
+
+template <typename T, class IsoparametricElementType, class QuadratureType>
+void ElasticityElement<T, IsoparametricElementType, QuadratureType>::
+    CalcNegativeElasticForce(const FemState<T>& state,
+                             EigenPtr<VectorX<T>> neg_force) const {
+  neg_force->setZero();
+  auto neg_force_matrix =
+      Eigen::Map<Matrix3X<T>>(neg_force->data(), 3, num_nodes());
+  // TODO(xuchenhan-tri): Use the corresponding Eval method when cache is in
+  // place.
+  std::vector<Matrix3<T>> P(num_quads());
+  CalcFirstPiolaStress(state, &P);
+  const std::vector<MatrixX<T>>& dSdxi =
+      shape_.CalcGradientInParentCoordinates();
+  for (int q = 0; q < num_quads(); ++q) {
+    /* Negative force is the gradient of energy.
+     -f = ∫dΨ/dx = ∫dΨ/dF : dF/dx dX.
+     Notice that Fᵢⱼ = xₐᵢdSₐ/dXⱼ, so dFᵢⱼ/dxᵦₖ = δₐᵦδᵢₖdSₐ/dXⱼ,
+     and dΨ/dFᵢⱼ = Pᵢⱼ, so the integrand becomes
+     PᵢⱼδₐᵦδᵢₖdSₐ/dXⱼ = PₖⱼdSᵦ/dXⱼ = P * dSdX.transpose() */
+    const auto& dSdX = dSdxi[q] * dxidX_[q];
+    neg_force_matrix += reference_volume_[q] * P[q] * dSdX.transpose();
+  }
+}
+
+template <typename T, class IsoparametricElementType, class QuadratureType>
+void ElasticityElement<T, IsoparametricElementType, QuadratureType>::
+    CalcDeformationGradient(const FemState<T>& state,
+                            std::vector<Matrix3<T>>* F) const {
+  F->resize(num_quads());
+  // TODO(xuchenhan-tri): Consider abstracting this potential common operation
+  // into FemElement.
+  Matrix3X<T> element_x(3, num_nodes());
+  const VectorX<T>& x_tmp = state.q();
+  const auto& x =
+      Eigen::Map<const Matrix3X<T>>(x_tmp.data(), 3, x_tmp.size() / 3);
+  for (int i = 0; i < num_nodes(); ++i) {
+    element_x.col(i) = x.col(this->node_indices()[i]);
+  }
+  const std::vector<MatrixX<T>> dxdxi = shape_.CalcJacobian(element_x);
+  for (int q = 0; q < num_quads(); ++q) {
+    (*F)[q] = dxdxi[q] * dxidX_[q];
+  }
+}
+
+template <typename T, class IsoparametricElementType, class QuadratureType>
+const DeformationGradientCache<T>&
+ElasticityElement<T, IsoparametricElementType, QuadratureType>::
+    EvalDeformationGradientCache(const FemState<T>& state) const {
+  ElasticityElementCache<T>& mutable_cache =
+      static_cast<ElasticityElementCache<T>&>(
+          state.mutable_element_cache(this->element_index()));
+  DeformationGradientCache<T>& deformation_gradient_cache =
+      mutable_cache.mutable_deformation_gradient_cache();
+  // TODO(xuchenhan-tri): Enable cahing when caching is in place.
+  std::vector<Matrix3<T>> F(num_quads());
+  CalcDeformationGradient(state, &F);
+  deformation_gradient_cache.UpdateCache(F);
+  return deformation_gradient_cache;
+}
+
+template <typename T, class IsoparametricElementType, class QuadratureType>
+void ElasticityElement<T, IsoparametricElementType, QuadratureType>::
+    CalcElasticEnergyDensity(const FemState<T>& state,
+                             std::vector<T>* Psi) const {
+  Psi->resize(num_quads());
+  const DeformationGradientCache<T>& deformation_gradient_cache =
+      EvalDeformationGradientCache(state);
+  constitutive_model_->CalcElasticEnergyDensity(deformation_gradient_cache,
+                                                Psi);
+}
+
+template <typename T, class IsoparametricElementType, class QuadratureType>
+void ElasticityElement<T, IsoparametricElementType, QuadratureType>::
+    CalcFirstPiolaStress(const FemState<T>& state,
+                         std::vector<Matrix3<T>>* P) const {
+  P->resize(num_quads());
+  // TODO(xuchenhan-tri): Use the corresponding Eval method when cache is in
+  // place.
+  const DeformationGradientCache<T>& deformation_gradient_cache =
+      EvalDeformationGradientCache(state);
+  constitutive_model_->CalcFirstPiolaStress(deformation_gradient_cache, P);
+}
+template class ElasticityElement<double, LinearSimplexElement<double, 3>,
+                                 SimplexGaussianQuadrature<double, 1, 3>>;
+template class ElasticityElement<AutoDiffXd,
+                                 LinearSimplexElement<AutoDiffXd, 3>,
+                                 SimplexGaussianQuadrature<AutoDiffXd, 1, 3>>;
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/dev/fem_elasticity.h
+++ b/multibody/fem/dev/fem_elasticity.h
@@ -1,0 +1,148 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fem/dev/constitutive_model.h"
+#include "drake/multibody/fem/dev/elasticity_element_cache.h"
+#include "drake/multibody/fem/dev/fem_element.h"
+#include "drake/multibody/fem/dev/fem_state.h"
+#include "drake/multibody/fem/dev/isoparametric_element.h"
+#include "drake/multibody/fem/dev/quadrature.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+/** The FEM element routine for static and dynamic 3D elasticity problems.
+ Implements the abstract interface of FemElement.
+
+ See ElasticityElementCache for the corresponding ElementCache for
+ %ElasticityElement.
+ @tparam_nonsymbolic_scalar T.
+ @tparam IsoparametricElementType The type of IsoparametricElement used in this
+ ElasticityElement. IsoparametricElementType must be a derived class from
+ IsoparametricElement.
+ @tparam QuadratureType The type of Quadrature used in this ElasticityElement.
+ QuadratureType must be a derived class from Quadrature.
+ */
+/* TODO(xuchenhan-tri): Consider making num_quads() and num_nodes() available at
+ compile time and thereby eliminating heap allocations. */
+/* TODO(xuchenhan-tri): Consider abstracting out the IsoparametricElement and
+ the Quadrature to a FixedSizeFemElement class, see issue #14302. */
+template <typename T, class IsoparametricElementType, class QuadratureType>
+class ElasticityElement : public FemElement<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ElasticityElement);
+
+  /** Constructs a new FEM elasticity element.
+   @param[in] element_index The global index of the new element.
+   @param[in] node_indices The global node indices of the nodes of this
+   element.
+   @param[in] density The mass density of the element in the reference
+   configuration, with unit kg/m³.
+   @param[in] constitutive_model The ConstitutiveModel to be used for this
+   element.
+   @param[in] reference_positions The positions of the nodes of this element in
+   the reference configuration.
+   @pre element_index must be valid.
+   @pre node_indices.size() must be equal to
+   IsoparametricElementType::num_nodes().
+   @pre node_indices.size() must be equal to reference_positions.cols().
+   @warning The input `constitutive_model` must be compatible with the
+   DeformationGradientCache in the ElasticityElementCache that shares the same
+   element index with this %ElasticityElement. More specifically, if the
+   DeformationGradientCache in the corresponding ElasticityElementCache is of
+   type "FooModelCache", then the input `constitutive_model` must be of type
+   "FooModel". */
+  ElasticityElement(ElementIndex element_index,
+                    const std::vector<NodeIndex>& node_indices,
+                    const T& density,
+                    std::unique_ptr<ConstitutiveModel<T>> constitutive_model,
+                    const Matrix3X<T>& reference_positions);
+
+  virtual ~ElasticityElement() = default;
+
+  /** The number of dimensions of the elasticity problem. */
+  int solution_dimension() const final { return 3; }
+
+  /** Number of quadrature points at which element-wise quantities are
+   evaluated. */
+  int num_quads() const { return quadrature_.num_points(); }
+
+  /** Number of nodes associated with this element. */
+  int num_nodes() const final { return shape_.num_nodes(); }
+
+  /** Returns the elastic potential energy stored in this element in unit J. */
+  T CalcElasticEnergy(const FemState<T>& state) const;
+
+ protected:
+  /* Calculates the element residual of this element evaluated at the input
+   state.
+   @param[in] state The FEM state at which to evaluate the residual.
+   @returns a vector of residual of size `3 * num_nodes()`. The vector is
+   ordered such that `3*i`-th to `3*i+2`-th entries of the vector stores the
+   residual corresponding to the i-th node in this element. */
+  void DoCalcResidual(const FemState<T>& state,
+                      EigenPtr<VectorX<T>> residual) const final;
+
+ private:
+  static constexpr int kNaturalDim = IsoparametricElementType::kNaturalDim;
+  using MatrixD3 =
+      Eigen::Matrix<T, kNaturalDim, 3>;
+
+  friend class ElasticityElementTest;
+
+  /* Calculates the elastic forces on the nodes in this element. Returns a
+   vector of elastic forces of size 3*num_nodes(). */
+  void CalcNegativeElasticForce(const FemState<T>& state,
+                                EigenPtr<VectorX<T>> force) const;
+
+  /* Calculates the deformation gradient at all quadrature points in the this
+   element. */
+  void CalcDeformationGradient(const FemState<T>& state,
+                               std::vector<Matrix3<T>>* F) const;
+
+  /* Evaluates the DeformationGradientCache for this element. */
+  /* TODO(xuchenhan-tri): This method unconditionally recomputes the
+   DeformationGradientCache. Enable caching when caching is in place. */
+  const DeformationGradientCache<T>& EvalDeformationGradientCache(
+      const FemState<T>& state) const;
+
+  /* Calculates the elastic energy density per unit reference volume, in unit
+   J/m³, at each quadrature point in this element. */
+  void CalcElasticEnergyDensity(const FemState<T>& state,
+                                std::vector<T>* Psi) const;
+
+  /* Calculates the first Piola stress, in unit Pa, at each quadrature point in
+   this element. */
+  void CalcFirstPiolaStress(const FemState<T>& state,
+                            std::vector<Matrix3<T>>* P) const;
+
+  /* The quadrature rule used for this element. */
+  QuadratureType quadrature_;
+  /* The isoparametric shape function used for this element. */
+  IsoparametricElementType shape_{quadrature_.get_points()};
+  /* The mass density of the element in the reference configuration with unit
+   kg/m³. */
+  T density_;
+  /* The constitutive model that describes the stress-strain relationship for
+   this element. */
+  std::unique_ptr<ConstitutiveModel<T>> constitutive_model_;
+  /* The inverse element Jacobian evaluated at reference configuration at the
+   quadrature points in this element. */
+  std::vector<MatrixD3> dxidX_;
+  /* The positions of the nodes of this element in the reference configuration.
+   */
+  Matrix3X<T> reference_positions_;
+  /* The volume evaluated at reference configuration occupied by the quadrature
+   points in this element. To integrate a function f over the reference domain,
+   sum f(q)*reference_volume_[q] over all the quadrature points q in the
+   element. */
+  std::vector<T> reference_volume_;
+};
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/dev/fem_element.cc
+++ b/multibody/fem/dev/fem_element.cc
@@ -1,0 +1,28 @@
+#include "drake/multibody/fem/dev/fem_element.h"
+
+#include <utility>
+
+#include "drake/common/default_scalars.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+template <typename T>
+void FemElement<T>::CalcResidual(const FemState<T>& state,
+                                 EigenPtr<VectorX<T>> residual) const {
+  DRAKE_ASSERT(residual != nullptr);
+  DRAKE_ASSERT(residual->size() == solution_dimension() * num_nodes());
+  DoCalcResidual(state, residual);
+}
+
+template <typename T>
+FemElement<T>::FemElement(ElementIndex element_index,
+                          const std::vector<NodeIndex>& node_indices)
+    : element_index_(element_index), node_indices_(node_indices) {
+  DRAKE_ASSERT(element_index_.is_valid());
+}
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fem::FemElement);

--- a/multibody/fem/dev/fem_element.h
+++ b/multibody/fem/dev/fem_element.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fem/dev/constitutive_model.h"
+#include "drake/multibody/fem/dev/fem_indexes.h"
+#include "drake/multibody/fem/dev/fem_state.h"
+#include "drake/multibody/fem/dev/isoparametric_element.h"
+#include "drake/multibody/fem/dev/quadrature.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+/** %FemElement is an abstract interface for the "element routines" used in FEM.
+ It computes quantities such as the residual and the stiffness matrix on a
+ single FEM element given the state of the FEM system. These quantities are
+ then assembled into their global counterparts by FemModel.
+
+ %FemElement should be used in tandem with ElementCache. There should be a
+ one-to-one correspondence between each %FemElement that performs the element
+ routine and each ElementCache that stores the state-dependent quantities used
+ in the routine. This correspondence is maintained by the shared element index
+ that is assigned to both the %FemElement and the ElementCache in
+ correspondence. Furthermore, the type of %FemElement and ElementCache in
+ correspondence must be compatible. More specifically, if the %FemElement is of
+ concrete type `FooElement`, then the ElementCache that shares the same element
+ index must be of concrete type `FooElementCache`.
+ @tparam_nonsymbolic_scalar T.  */
+template <typename T>
+class FemElement {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FemElement);
+
+  virtual ~FemElement() = default;
+
+  /** Global indices of the nodes of this element. */
+  const std::vector<NodeIndex>& node_indices() const { return node_indices_; }
+
+  /** Global ElementIndex of this element. */
+  ElementIndex element_index() const { return element_index_; }
+
+  /** The dimension of the codomain of the PDE's solution u. */
+  virtual int solution_dimension() const = 0;
+
+  /** Number of nodes associated with this element. */
+  virtual int num_nodes() const = 0;
+
+  /** Calculates the element residual of this element evaluated at the input
+   `state`. This method updates the cached quantities in the input `state` if
+   they are out of date.
+   @param[in] state The FemState at which to evaluate the residual.
+   @param[out] residual The residual vector of size `solution_dimension() *
+   num_nodes()`. The vector is ordered such that `i*solution_dimension()`-th to
+   `(i+1)*solution_dimension()-1`-th entries of the vector stores the residual
+   corresponding to the i-th node in this element.
+   @pre `residual` must not be the nullptr, and the vector it points to must
+   have size `num_nodes() * solution_dimension()` */
+  void CalcResidual(const FemState<T>& state,
+                    EigenPtr<VectorX<T>> residual) const;
+
+  // TODO(xuchenhan-tri): Add CalcMassMatrix and CalcStiffnessMatrix etc.
+
+ protected:
+  /* Constructs a new FEM element.
+    @param[in] element_index The global index of the new element.
+    @param[in] node_indices The global node indices of the nodes of this
+    element.
+    @pre element_index must be valid. */
+  FemElement(ElementIndex element_index,
+             const std::vector<NodeIndex>& node_indices);
+
+  /* Calculates the element residual of this element evaluated at the input
+   state.
+   @param[in] state The FemState at which to evaluate the residual.
+   @param[out] a vector of residual of size `solution_dimension()*num_nodes()`.
+   The vector is ordered such that `i*solution_dimension()`-th to
+   `(i+1)*solution_dimension()-1`-th entries of the vector stores the residual
+   corresponding to the i-th node in this element.
+   @pre residual must not be the nullptr, and the vector it points to must have
+   size `num_nodes() * solution_dimension()`. */
+  virtual void DoCalcResidual(const FemState<T>& s,
+                              EigenPtr<VectorX<T>> residual) const = 0;
+
+  // The global index of this element.
+  ElementIndex element_index_;
+  // The global node indices of this element.
+  std::vector<NodeIndex> node_indices_;
+};
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fem::FemElement);

--- a/multibody/fem/dev/fem_indexes.h
+++ b/multibody/fem/dev/fem_indexes.h
@@ -7,6 +7,9 @@ namespace multibody {
 namespace fem {
 /** Index used to identify element by index among FEM elements. */
 using ElementIndex = TypeSafeIndex<class ElementTag>;
+
+/** Index used to identify node by index among FEM nodes. */
+using NodeIndex = TypeSafeIndex<class NodeTag>;
 }  // namespace fem
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/fem/dev/fem_state.h
+++ b/multibody/fem/dev/fem_state.h
@@ -1,0 +1,140 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "drake/common/copyable_unique_ptr.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fem/dev/element_cache.h"
+#include "drake/multibody/fem/dev/fem_indexes.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+/** The states in the FEM simulation that are associated with the nodes and the
+ elements. The states include the generalized positions associated with each
+ node, `q`, and their time derivatives, `qdot`. %FemState also contains the
+ cached quantities that are associated with the elements whose values depend on
+ the states. See ElementCache for more on these state-dependent quantities.
+ @tparam_nonsymbolic_scalar T. */
+template <typename T>
+class FemState {
+ public:
+  /** Copy, move and assign are disabled. Copy constructors and assignment are
+   usually expensive for %FemState. If a copy is required, use Clone() if a deep
+   copy is required. Use SetFrom() if you want to set `this` %FemState from
+   another %FemState. */
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FemState);
+
+  FemState() = default;
+
+  /** Constructs an %FemState with prescribed number of states. */
+  explicit FemState(int num_generalized_positions)
+      : qdot_(num_generalized_positions), q_(num_generalized_positions) {}
+
+  /** Takes ownership of the input `element_cache` and set it as the element
+   cache that `this` %FemState owns. This method is usually called right after
+   the construction of the %FemState to set the element cache to the desired
+   quantity. */
+  void ResetElementCache(
+      std::vector<std::unique_ptr<ElementCache<T>>> element_cache) {
+    element_cache_.resize(element_cache.size());
+    for (int i = 0; i < static_cast<int>(element_cache.size()); ++i) {
+      element_cache_[i] = std::move(element_cache[i]);
+    }
+  }
+
+  /** Creates a deep identical copy of `this` %FemState with all its states and
+   cache. Returns a unique pointer to the copy. */
+  std::unique_ptr<FemState<T>> Clone() const {
+    auto clone = std::make_unique<FemState<T>>(num_generalized_positions());
+    clone->SetFrom(*this);
+    return clone;
+  }
+
+  /** Sets the states and cache of `this` %FemState from the input %FemState
+   `other`. After this method is called, the state and cache in `this`
+   %FemState will be an identical copy of those in the `other` %FemState. */
+  void SetFrom(const FemState<T>& other) {
+    Resize(other.num_generalized_positions());
+    set_q(other.q());
+    set_qdot(other.qdot());
+    element_cache_ = other.element_cache_;
+  }
+
+  /** Resize the number of states to the input `num_generalized_positions`. The
+   existing values are unchanged if `num_generalized_positions` is greater than
+   or equal to the number of existing generalized positions. */
+  void Resize(int num_generalized_positions) {
+    DRAKE_ASSERT(num_generalized_positions >= 0);
+    if (num_generalized_positions == this->num_generalized_positions()) return;
+    qdot_.conservativeResize(num_generalized_positions);
+    q_.conservativeResize(num_generalized_positions);
+  }
+
+  /** @name State getters.
+   @{ */
+  const VectorX<T>& qdot() const { return qdot_; }
+
+  const VectorX<T>& q() const { return q_; }
+  /** @} */
+
+  /** @name State setters.
+   The size of the values provided must match the current size
+   of the states.
+   @{ */
+  void set_qdot(const Eigen::Ref<const VectorX<T>>& value) {
+    DRAKE_ASSERT(value.size() == qdot_.size());
+    if (value == qdot_) return;
+    mutable_qdot() = value;
+  }
+
+  void set_q(const Eigen::Ref<const VectorX<T>>& value) {
+    DRAKE_ASSERT(value.size() == q_.size());
+    if (value == q_) return;
+    mutable_q() = value;
+  }
+  /** @} */
+
+  /** @name Mutable state getters.
+   The values of the states are mutable but the sizes
+   of the states are not allowed to change.
+   @{ */
+  Eigen::VectorBlock<VectorX<T>> mutable_qdot() {
+    return qdot_.head(qdot_.size());
+  }
+
+  Eigen::VectorBlock<VectorX<T>> mutable_q() { return q_.head(q_.size()); }
+  /** @} */
+
+  /** @name Getters and mutable getters for cached quantities.
+   @{ */
+  const ElementCache<T>& element_cache(ElementIndex e) const {
+    DRAKE_ASSERT(e.is_valid());
+    DRAKE_ASSERT(e < element_cache_.size());
+    DRAKE_ASSERT(element_cache_[e] != nullptr);
+    return *element_cache_[e];
+  }
+
+  ElementCache<T>& mutable_element_cache(ElementIndex e) const {
+    DRAKE_ASSERT(e.is_valid());
+    DRAKE_ASSERT(e < element_cache_.size());
+    DRAKE_ASSERT(element_cache_[e] != nullptr);
+    return *element_cache_[e];
+  }
+  /** @} */
+
+  int num_generalized_positions() const { return q_.size(); }
+
+ private:
+  // Time derivatives of generalized node positions.
+  VectorX<T> qdot_;
+  // Generalized node positions.
+  VectorX<T> q_;
+  // Owned element cache quantities.
+  std::vector<copyable_unique_ptr<ElementCache<T>>> element_cache_;
+};
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/dev/isoparametric_element.h
+++ b/multibody/fem/dev/isoparametric_element.h
@@ -29,12 +29,16 @@ namespace fem {
  IsoparametricElement and pass the new locations into the constructor.
  @tparam_nonsymbolic_scalar T.
  @tparam NaturalDim The dimension of the parent domain. */
+/* TODO(xuchenhan-tri): Consider templatize on spatial dimension as well. */
 template <typename T, int NaturalDim>
 class IsoparametricElement {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(IsoparametricElement);
 
   using VectorD = Eigen::Matrix<T, NaturalDim, 1>;
+
+  /** The dimension of the parent domain. */
+  static constexpr int kNaturalDim = NaturalDim;
 
   /** Constructs an isoparametric element that performs calculations at the
    locations specified by the input `locations`. */

--- a/multibody/fem/dev/linear_elasticity_model.cc
+++ b/multibody/fem/dev/linear_elasticity_model.cc
@@ -12,7 +12,7 @@ LinearElasticityModel<T>::LinearElasticityModel(const T& youngs_modulus,
 }
 
 template <typename T>
-void LinearElasticityModel<T>::DoCalcPsi(
+void LinearElasticityModel<T>::DoCalcElasticEnergyDensity(
     const DeformationGradientCache<T>& cache, std::vector<T>* Psi) const {
   const LinearElasticityModelCache<T>& linear_cache =
       static_cast<const LinearElasticityModelCache<T>&>(cache);
@@ -25,8 +25,9 @@ void LinearElasticityModel<T>::DoCalcPsi(
 }
 
 template <typename T>
-void LinearElasticityModel<T>::DoCalcP(const DeformationGradientCache<T>& cache,
-                                       std::vector<Matrix3<T>>* P) const {
+void LinearElasticityModel<T>::DoCalcFirstPiolaStress(
+    const DeformationGradientCache<T>& cache,
+    std::vector<Matrix3<T>>* P) const {
   const LinearElasticityModelCache<T>& linear_cache =
       static_cast<const LinearElasticityModelCache<T>&>(cache);
   for (int i = 0; i < linear_cache.num_quads(); ++i) {

--- a/multibody/fem/dev/linear_elasticity_model.h
+++ b/multibody/fem/dev/linear_elasticity_model.h
@@ -42,12 +42,12 @@ class LinearElasticityModel final : public ConstitutiveModel<T> {
 
  protected:
   /* Calculates the energy density, in unit J/m³, given the model cache. */
-  void DoCalcPsi(const DeformationGradientCache<T>& cache,
-                 std::vector<T>* Psi) const final;
+  void DoCalcElasticEnergyDensity(const DeformationGradientCache<T>& cache,
+                                  std::vector<T>* Psi) const final;
 
   /* Calculates the First Piola stress, in unit Pa, given the model cache. */
-  void DoCalcP(const DeformationGradientCache<T>& cache,
-               std::vector<Matrix3<T>>* P) const final;
+  void DoCalcFirstPiolaStress(const DeformationGradientCache<T>& cache,
+                              std::vector<Matrix3<T>>* P) const final;
 
  private:
   /* Set the Lamé parameters from Young's modulus and Poisson ratio. It's

--- a/multibody/fem/dev/linear_elasticity_model_cache.h
+++ b/multibody/fem/dev/linear_elasticity_model_cache.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include "drake/common/default_scalars.h"
@@ -18,7 +19,15 @@ namespace fem {
 template <typename T>
 class LinearElasticityModelCache : public DeformationGradientCache<T> {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(LinearElasticityModelCache);
+  /** @name     Does not allow copy, move, or assignment. */
+  /** @{ */
+  /* Copy constructor is used only to facilitate implementation of Clone()
+   in derived classes. */
+  LinearElasticityModelCache(LinearElasticityModelCache&&) = delete;
+  LinearElasticityModelCache& operator=(LinearElasticityModelCache&&) = delete;
+  LinearElasticityModelCache& operator=(const LinearElasticityModelCache&) =
+      delete;
+  /** @} */
 
   /** Constructs a %LinearElasticityModelCache with the given element index and
    number of quadrature locations.
@@ -41,11 +50,21 @@ class LinearElasticityModelCache : public DeformationGradientCache<T> {
   const std::vector<T>& trace_strain() const { return trace_strain_; }
 
  protected:
+  /* Copy constructor to facilitate the `DoClone()` method. */
+  LinearElasticityModelCache(const LinearElasticityModelCache&) = default;
+
   /* Updates the cached quantities with the given deformation gradients.
    @param F The up-to-date deformation gradients evaluated at the quadrature
    locations for the associated element.
    @pre The size of `F` must be the same as `num_quads()`. */
   void DoUpdateCache(const std::vector<Matrix3<T>>& F) final;
+
+  /* Creates an identical copy of the LinearElasticityModelCache object. */
+  std::unique_ptr<DeformationGradientCache<T>> DoClone() const final {
+    // Can't use std::make_unique because the copy constructor is protected.
+    return std::unique_ptr<DeformationGradientCache<T>>(
+        new LinearElasticityModelCache<T>(*this));
+  }
 
  private:
   // Infinitesimal strain = 0.5 * (F + Fᵀ) - I.

--- a/multibody/fem/dev/linear_simplex_element.h
+++ b/multibody/fem/dev/linear_simplex_element.h
@@ -21,6 +21,11 @@ template <typename T, int NaturalDim>
 class LinearSimplexElement : public IsoparametricElement<T, NaturalDim> {
  public:
   using typename IsoparametricElement<T, NaturalDim>::VectorD;
+
+  /** Number of nodes in this simplex element that is available at compile time.
+   */
+  enum : int { kNumNodes = NaturalDim + 1 };
+
   explicit LinearSimplexElement(std::vector<VectorD> locations)
       : IsoparametricElement<T, NaturalDim>(std::move(locations)) {
     S_ = CalcShapeFunctionsHelper();

--- a/multibody/fem/dev/quadrature.h
+++ b/multibody/fem/dev/quadrature.h
@@ -11,25 +11,33 @@
 namespace drake {
 namespace multibody {
 namespace fem {
-template <typename T, int NaturalDimension>
 /** A class for quadratures that facilitates numerical integrations in FEM. The
  specification of particular quadrature rules will be provided in the derived
  classes.
  @tparam T the scalar type of the function being integrated over.
  @tparam NaturalDimension dimension of the domain of integration.
  */
+template <typename T, int NaturalDimension>
 class Quadrature {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Quadrature);
 
   using VectorD = Eigen::Matrix<T, NaturalDimension, 1>;
 
+  /** The dimension of the parent domain. */
+  static constexpr int kNaturalDim = NaturalDimension;
+
   virtual ~Quadrature() = default;
 
   /// The number of quadrature points for the quadrature rule.
   int num_points() const { return points_.size(); }
 
-  /// The position in parent coordinate of the q-th quadrature point.
+  /// The position in parent coordinates of all quadrature points.
+  const std::vector<VectorD>& get_points() const {
+      return points_;
+  }
+
+  /// The position in parent coordinates of the q-th quadrature point.
   const VectorD& get_point(int q) const {
     DRAKE_DEMAND(q >= 0);
     DRAKE_DEMAND(q < num_points());

--- a/multibody/fem/dev/test/fem_elasticity_test.cc
+++ b/multibody/fem/dev/test/fem_elasticity_test.cc
@@ -1,0 +1,113 @@
+#include "drake/multibody/fem/dev/fem_elasticity.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/autodiff_gradient.h"
+#include "drake/multibody/fem/dev/fem_state.h"
+#include "drake/multibody/fem/dev/linear_elasticity_model.h"
+#include "drake/multibody/fem/dev/linear_simplex_element.h"
+#include "drake/multibody/fem/dev/quadrature.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+constexpr int kNaturalDim = 3;
+constexpr int kSpatialDim = 3;
+constexpr int kProblemDim = 3;
+constexpr int kQuadratureOrder = 1;
+constexpr int kNumQuads = 1;
+constexpr int kNumVertices = 4;
+constexpr int kDof = kSpatialDim * kNumVertices;
+const ElementIndex kDummyElementIndex(0);
+
+class ElasticityElementTest : public ::testing::Test {
+ protected:
+  using QuadratureType =
+      SimplexGaussianQuadrature<AutoDiffXd, kQuadratureOrder, kSpatialDim>;
+  using ShapeType = LinearSimplexElement<AutoDiffXd, kNaturalDim>;
+  void SetUp() override { SetupElement(); }
+
+  void SetupElement() {
+    std::vector<NodeIndex> node_indices = {NodeIndex(0), NodeIndex(1),
+                                           NodeIndex(2), NodeIndex(3)};
+    linear_elasticity_ =
+        std::make_unique<LinearElasticityModel<AutoDiffXd>>(1, 0.25);
+    MatrixX<AutoDiffXd> reference_positions = get_reference_positions();
+    const AutoDiffXd DummyDensity(1.23);
+    fem_elasticity_ = std::make_unique<
+        ElasticityElement<AutoDiffXd, ShapeType, QuadratureType>>(
+        kDummyElementIndex, node_indices, DummyDensity,
+        std::move(linear_elasticity_), reference_positions);
+  }
+
+  void SetupState() {
+    state_.Resize(kDof);
+    state_.set_qdot(VectorX<AutoDiffXd>::Zero(kDof));
+    // Set arbitrary node positions and the gradient.
+    Eigen::Matrix<double, kDof, 1> x;
+    x << 0.18, 0.63, 0.54, 0.13, 0.92, 0.17, 0.03, 0.86, 0.85, 0.25, 0.53, 0.67;
+    const Eigen::Matrix<double, kDof, Eigen::Dynamic> gradient =
+        MatrixX<double>::Identity(kDof, kDof);
+    const VectorX<AutoDiffXd> x_autodiff =
+        math::initializeAutoDiffGivenGradientMatrix(x, gradient);
+    state_.set_q(x_autodiff);
+    // Set up the element cache.
+    auto linear_elasticity_cache =
+        std::make_unique<LinearElasticityModelCache<AutoDiffXd>>(
+            kDummyElementIndex, kNumQuads);
+    std::vector<std::unique_ptr<ElementCache<AutoDiffXd>>> cache;
+    // TODO(xuchenhan-tri): Add a method to FemElement that creates a compatible
+    // ElementCache.
+    cache.emplace_back(std::make_unique<ElasticityElementCache<AutoDiffXd>>(
+        kDummyElementIndex, kNumQuads, std::move(linear_elasticity_cache)));
+    state_.ResetElementCache(std::move(cache));
+  }
+
+  // Set an arbitrary reference positions such that the tetrahedron is not
+  // inverted.
+  Matrix3X<AutoDiffXd> get_reference_positions() const {
+    Matrix3X<AutoDiffXd> Q(kSpatialDim, kNumVertices);
+    Q << -0.10, 0.90, 0.02, 0.10, 1.33, 0.23, 0.04, 0.01, 0.20, 0.03, 2.31,
+        -0.12;
+    return Q;
+  }
+
+  // Calculates the negative elastic force at state_.
+  VectorX<AutoDiffXd> CalcNegativeElasticForce() const {
+    VectorX<AutoDiffXd> neg_force(kDof);
+    fem_elasticity_->CalcNegativeElasticForce(state_, &neg_force);
+    return neg_force;
+  }
+
+  std::unique_ptr<ElasticityElement<AutoDiffXd, ShapeType, QuadratureType>>
+      fem_elasticity_;
+  std::unique_ptr<LinearElasticityModel<AutoDiffXd>> linear_elasticity_;
+  FemState<AutoDiffXd> state_;
+};
+
+namespace {
+TEST_F(ElasticityElementTest, Basic) {
+  EXPECT_EQ(fem_elasticity_->num_nodes(), kNumVertices);
+  EXPECT_EQ(fem_elasticity_->num_quads(), kNumQuads);
+  EXPECT_EQ(fem_elasticity_->solution_dimension(), kProblemDim);
+}
+
+TEST_F(ElasticityElementTest, ElasticForceIsNegativeEnergyDerivative) {
+  SetupState();
+  AutoDiffXd energy = fem_elasticity_->CalcElasticEnergy(state_);
+  VectorX<AutoDiffXd> neg_force = CalcNegativeElasticForce();
+  EXPECT_TRUE(CompareMatrices(energy.derivatives(), neg_force,
+                              std::numeric_limits<double>::epsilon()));
+  // TODO(xuchenhan-tri) Modify this to account for damping forces and inertia
+  // terms.
+  VectorX<AutoDiffXd> residual(kDof);
+  fem_elasticity_->CalcResidual(state_, &residual);
+  EXPECT_TRUE(CompareMatrices(residual, neg_force));
+}
+// TODO(xuchenhan-tri): Add TEST_F as needed for damping and inertia terms
+// separately.
+}  // namespace
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/dev/test/fem_state_test.cc
+++ b/multibody/fem/dev/test/fem_state_test.cc
@@ -1,0 +1,112 @@
+#include "drake/multibody/fem/dev/fem_state.h"
+
+#include <gtest/gtest.h>
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace {
+constexpr int kDof = 3;
+constexpr int kNumQuads = 1;
+constexpr int kNumCache = 2;
+// A toy element cache.
+class MyElementCache final : public ElementCache<double> {
+ public:
+  MyElementCache(ElementIndex element_index, int num_quads, int data)
+      : ElementCache(element_index, num_quads), data_(data) {}
+
+  int data() const { return data_; }
+
+ protected:
+  std::unique_ptr<ElementCache<double>> DoClone() const final {
+    return std::unique_ptr<ElementCache<double>>(new MyElementCache(*this));
+  }
+
+ private:
+  // Some fake data for testing.
+  int data_;
+};
+
+class FemStateTest : public ::testing::Test {
+ protected:
+  void SetUp() {
+    state_ = std::make_unique<FemState<double>>(kDof);
+    // Create a couple of cache entries.
+    state_->ResetElementCache(MakeElementCache());
+    // Set default states.
+    SetStates();
+  }
+
+  // Default values for the first kDof state entries.
+  VectorX<double> qdot() const { return Vector3<double>(0.3, 0.4, 0.5); }
+  VectorX<double> q() const { return Vector3<double>(0.7, 0.8, 0.9); }
+
+  // Set the states to default values.
+  void SetStates() {
+    // Set all states to their default values.
+    state_->set_qdot(qdot());
+    state_->set_q(q());
+  }
+
+  std::vector<std::unique_ptr<ElementCache<double>>> MakeElementCache() const {
+    std::vector<std::unique_ptr<ElementCache<double>>> cache;
+    std::vector<int> data = {3, 5};
+    for (int i = 0; i < kNumCache; ++i) {
+      cache.emplace_back(std::make_unique<MyElementCache>(ElementIndex(i),
+                                                          kNumQuads, data[i]));
+    }
+    return cache;
+  }
+
+  // FemState under test.
+  std::unique_ptr<FemState<double>> state_;
+};
+
+// Verify setters and getters are working properly.
+TEST_F(FemStateTest, SetAndGet) {
+  SetStates();
+  EXPECT_EQ(state_->qdot(), qdot());
+  EXPECT_EQ(state_->q(), q());
+}
+
+// Verify resizing does not thrash existing values.
+TEST_F(FemStateTest, ConservativeResize) {
+  SetStates();
+  state_->Resize(2 * kDof);
+  // The first kDof entres should remain unchanged.
+  EXPECT_EQ(state_->qdot().head(kDof), qdot());
+  EXPECT_EQ(state_->q().head(kDof), q());
+}
+
+TEST_F(FemStateTest, Clone) {
+  std::unique_ptr<FemState<double>> clone = state_->Clone();
+  EXPECT_EQ(clone->qdot(), qdot());
+  EXPECT_EQ(clone->q(), q());
+  for (ElementIndex i(0); i < kNumCache; ++i) {
+    const auto* cloned_cache =
+        dynamic_cast<const MyElementCache*>(&clone->element_cache(i));
+    const auto* original_cache =
+        dynamic_cast<const MyElementCache*>(&state_->element_cache(i));
+    ASSERT_TRUE(cloned_cache != nullptr);
+    ASSERT_TRUE(original_cache != nullptr);
+    EXPECT_EQ(cloned_cache->data(), original_cache->data());
+  }
+}
+
+TEST_F(FemStateTest, SetFrom) {
+  FemState<double> dest;
+  dest.SetFrom(*state_);
+  EXPECT_EQ(dest.qdot(), qdot());
+  EXPECT_EQ(dest.q(), q());
+  const auto cache = MakeElementCache();
+  for (ElementIndex i(0); i < kNumCache; ++i) {
+    const auto* dest_cache =
+        dynamic_cast<const MyElementCache*>(&dest.element_cache(i));
+    ASSERT_TRUE(dest_cache != nullptr);
+    EXPECT_EQ(dest_cache->data(),
+              static_cast<const MyElementCache*>(cache[i].get())->data());
+  }
+}
+}  // namespace
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/dev/test/linear_elasticity_model_cache_test.cc
+++ b/multibody/fem/dev/test/linear_elasticity_model_cache_test.cc
@@ -33,6 +33,26 @@ TEST_F(LinearElasticityCacheTest, UpdateCache) {
   EXPECT_EQ(linear_elasticity_cache_.strain()[0], strain);
   EXPECT_EQ(linear_elasticity_cache_.trace_strain()[0], trace_strain);
 }
+
+TEST_F(LinearElasticityCacheTest, Clone) {
+  const std::unique_ptr<DeformationGradientCache<double>> clone =
+      linear_elasticity_cache_.Clone();
+  // Test that the Clone() method returns the correct concrete type.
+  const auto* linear_elasticity_cache_clone =
+      dynamic_cast<const LinearElasticityModelCache<double>*>(clone.get());
+  EXPECT_TRUE(linear_elasticity_cache_clone != nullptr);
+  // Test that the Clone() method returns an identical copy.
+  EXPECT_EQ(linear_elasticity_cache_clone->deformation_gradient(),
+            linear_elasticity_cache_.deformation_gradient());
+  EXPECT_EQ(linear_elasticity_cache_clone->strain(),
+            linear_elasticity_cache_.strain());
+  EXPECT_EQ(linear_elasticity_cache_clone->trace_strain(),
+            linear_elasticity_cache_.trace_strain());
+  EXPECT_EQ(linear_elasticity_cache_clone->num_quads(),
+            linear_elasticity_cache_.num_quads());
+  EXPECT_EQ(linear_elasticity_cache_clone->element_index(),
+            linear_elasticity_cache_.element_index());
+}
 }  // namespace
 }  // namespace fem
 }  // namespace multibody

--- a/multibody/fem/dev/test/linear_elasticity_model_test.cc
+++ b/multibody/fem/dev/test/linear_elasticity_model_test.cc
@@ -5,7 +5,6 @@
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/math/autodiff_gradient.h"
-#include "drake/math/jacobian.h"
 
 namespace drake {
 namespace multibody {
@@ -64,8 +63,8 @@ GTEST_TEST(LinearElasticityTest, UndeformedState) {
   // In undeformaed state, the stress should be zero.
   const std::vector<Matrix3<double>> analytic_stress(kNumQuads,
                                                      Matrix3<double>::Zero());
-  EXPECT_EQ(model.CalcPsi(cache), analytic_energy_density);
-  EXPECT_EQ(model.CalcP(cache), analytic_stress);
+  EXPECT_EQ(model.CalcElasticEnergyDensity(cache), analytic_energy_density);
+  EXPECT_EQ(model.CalcFirstPiolaStress(cache), analytic_stress);
 }
 
 GTEST_TEST(LinearElasticityTest, PIsDerivativeOfPsi) {
@@ -90,8 +89,8 @@ GTEST_TEST(LinearElasticityTest, PIsDerivativeOfPsi) {
   }
   // P should be derivative of Psi.
   cache_autodiff.UpdateCache(Fs_autodiff);
-  const auto energy = model_autodiff.CalcPsi(cache_autodiff);
-  const auto P = model_autodiff.CalcP(cache_autodiff);
+  const auto energy = model_autodiff.CalcElasticEnergyDensity(cache_autodiff);
+  const auto P = model_autodiff.CalcFirstPiolaStress(cache_autodiff);
   for (int i = 0; i < kNumQuads; ++i) {
     EXPECT_TRUE(CompareMatrices(
         Eigen::Map<const Matrix3<double>>(energy[i].derivatives().data(), 3, 3),


### PR DESCRIPTION
FemState stores the node-wise states in a FEM simulation as well as
ElementCache that contains state-dependent quantities that are
associated with the FEM elements. FemElement consumes FemState and
performs the element routine in a FEM solver. Currently, the only
element routine we support is calculating the residual.

Concrete instance of ElementCache (ElasticityElementCache) and concrete
instance of FemElement (FemElasticity) are added to illustrate how
these two classes work together.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14263)
<!-- Reviewable:end -->
