### PR TITLE
workspace: Upgrade fmt to latest release 7.1.0

### DIFF
--- a/bindings/pydrake/systems/test/analysis_test.py
+++ b/bindings/pydrake/systems/test/analysis_test.py
@@ -77,7 +77,7 @@ class TestAnalysis(unittest.TestCase):
         status = simulator.AdvanceTo(1.)
         self.assertEqual(
             status.FormatMessage(),
-            "Simulator successfully reached the boundary time (1.0).")
+            "Simulator successfully reached the boundary time (1).")
         self.assertTrue(status.succeeded())
         self.assertEqual(status.boundary_time(), 1.)
         self.assertEqual(status.return_time(), 1.)

--- a/common/test/text_logging_test.cc
+++ b/common/test/text_logging_test.cc
@@ -60,7 +60,7 @@ GTEST_TEST(TextLoggingTest, SmokeTest) {
 // Check that floating point values format sensibly.  We'll just test fmt
 // directly, since we know that spdlog uses it internally.
 GTEST_TEST(TextLoggingTest, FloatingPoint) {
-  EXPECT_EQ(fmt::format("{}", 1.0), "1.0");
+  EXPECT_EQ(fmt::format("{:#}", 1.0), "1.0");
   // This number is particularly challenging.
   EXPECT_EQ(fmt::format("{}", 0.009), "0.009");
 }

--- a/common/text_logging.h
+++ b/common/text_logging.h
@@ -23,7 +23,7 @@ not be compiled if debugging is turned off (-DNDEBUG is set):
   DRAKE_LOGGER_DEBUG("message: {}", something_conditionally_compiled);
 </pre>
 
-The format string syntax is fmtlib; see https://fmt.dev/7.0.3/syntax.html.
+The format string syntax is fmtlib; see https://fmt.dev/7.1.0/syntax.html.
 In particular, any class that overloads `operator<<` for `ostream` can be
 printed without any special handling.
 */

--- a/common/trajectories/test/discrete_time_trajectory_test.cc
+++ b/common/trajectories/test/discrete_time_trajectory_test.cc
@@ -50,11 +50,11 @@ GTEST_TEST(DiscreteTimeTrajectoryTest, ValueThrowsTest) {
   DiscreteTimeTrajectory<double> traj(times, values);
 
   DRAKE_EXPECT_THROWS_MESSAGE(traj.value(-1), std::runtime_error,
-                              "Value requested at time -1.0 does not match .*");
+                              "Value requested at time -1 does not match .*");
   DRAKE_EXPECT_THROWS_MESSAGE(traj.value(0.4), std::runtime_error,
                               "Value requested at time 0.4 does not match .*");
   DRAKE_EXPECT_THROWS_MESSAGE(traj.value(1), std::runtime_error,
-                              "Value requested at time 1.0 does not match .*");
+                              "Value requested at time 1 does not match .*");
 
   const double kLooseTolerance = 0.1;
   DiscreteTimeTrajectory<double> traj_w_loose_tol(times, values,

--- a/common/yaml/yaml_write_archive.h
+++ b/common/yaml/yaml_write_archive.h
@@ -5,6 +5,7 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
 #include <variant>
@@ -249,7 +250,11 @@ class YamlWriteArchive final {
   void VisitScalar(const NVP& nvp) {
     using T = typename NVP::value_type;
     const T& value = *nvp.value();
-    root_[nvp.name()] = fmt::format("{}", value);
+    if constexpr (std::is_floating_point_v<T>) {
+      root_[nvp.name()] = fmt::format("{:#}", value);
+    } else {
+      root_[nvp.name()] = fmt::format("{}", value);
+    }
   }
 
   template <typename NVP>

--- a/multibody/parsing/test/detail_scene_graph_test.cc
+++ b/multibody/parsing/test/detail_scene_graph_test.cc
@@ -852,7 +852,7 @@ GTEST_TEST(SceneGraphParserDetail, ParseVisualMaterial) {
         MakeVisualPropertiesFromSdfVisual(*sdf_visual, NoopResolveFilename),
         std::runtime_error,
         "All values must be within the range \\[0, 1\\]. Values provided: "
-        "\\(r=0.0, g=1.0, b=255.0, a=1.0\\)");
+        "\\(r=0, g=1, b=255, a=1\\)");
   }
 }
 

--- a/tools/workspace/fmt/repository.bzl
+++ b/tools/workspace/fmt/repository.bzl
@@ -10,8 +10,8 @@ def fmt_repository(
         repository = "fmtlib/fmt",
         # When changing the fmt version, also update the URL in the file
         # overview docstring of drake/common/text_logging.h.
-        commit = "7.0.3",
-        sha256 = "b4b51bc16288e2281cddc59c28f0b4f84fed58d016fb038273a09f05f8473297",  # noqa
+        commit = "7.1.0",
+        sha256 = "a53bce7e3b7ee8c7374723262a43356afff176b1684b86061748409e6f8b56c5",  # noqa
         build_file = "@drake//tools/workspace/fmt:package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
> Changed the default floating point format to not include .0 for consistency with std::format and std::to_chars. It is possible to get the decimal point and trailing zero with the # specifier.

-- https://github.com/fmtlib/fmt/releases/tag/7.1.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14272)
<!-- Reviewable:end -->
