### PR TITLE
Clean up and deprecation of SceneGraphInspector/QueryObject bindings

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -129,6 +129,7 @@ drake_pybind_library(
         "//bindings/pydrake:documentation_pybind",
         "//bindings/pydrake/common:cpp_template_pybind",
         "//bindings/pydrake/common:default_scalars_pybind",
+        "//bindings/pydrake/common:deprecation_pybind",
         "//bindings/pydrake/common:type_pack",
         "//bindings/pydrake/common:value_pybind",
         "//lcmtypes:viewer",

--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -8,6 +8,7 @@
 
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
+#include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/type_pack.h"
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
@@ -456,10 +457,29 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("GetCollisionCandidates", &Class::GetCollisionCandidates,
             cls_doc.GetCollisionCandidates.doc)
         // Sources and source-related data.
-        .def("SourceIsRegistered", &Class::SourceIsRegistered, py::arg("id"),
-            cls_doc.SourceIsRegistered.doc)
-        .def("GetSourceName", &Class::GetSourceName, py::arg("source_id"),
-            cls_doc.GetSourceName.doc)
+        .def("SourceIsRegistered", &Class::SourceIsRegistered,
+            py::arg("source_id"), cls_doc.SourceIsRegistered.doc)
+        .def("SourceIsRegistered",
+            WrapDeprecated(
+                "Please use SceneGraphInspector.SourceIsRegistered("
+                "source_id=value) instead. This variant will be removed after"
+                " after 2021-03-01",
+                &Class::SourceIsRegistered),
+            py::arg("id"), cls_doc.SourceIsRegistered.doc)
+        .def("GetName",
+            overload_cast_explicit<const std::string&, SourceId>(
+                &Class::GetName),
+            py_rvp::reference_internal, py::arg("source_id"),
+            cls_doc.GetName.doc_1args_source_id);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
+        .def("GetSourceName",
+            WrapDeprecated(
+                cls_doc.GetSourceName.doc_deprecated, &Class::GetSourceName),
+            py::arg("source_id"), cls_doc.GetSourceName.doc_deprecated);
+#pragma GCC diagnostic pop
+    cls  // BR
         .def("NumFramesForSource", &Class::NumFramesForSource,
             py::arg("source_id"), cls_doc.NumFramesForSource.doc)
         .def("FramesForSource", &Class::FramesForSource, py::arg("source_id"),
@@ -723,38 +743,70 @@ void DoScalarDependentDefinitions(py::module m, T) {
   //  QueryObject
   {
     using Class = QueryObject<T>;
+    constexpr auto& cls_doc = doc.QueryObject;
     auto cls = DefineTemplateClassWithDefault<Class>(
-        m, "QueryObject", param, doc.QueryObject.doc);
+        m, "QueryObject", param, cls_doc.doc);
     cls  // BR
-        .def(py::init(), doc.QueryObject.ctor.doc)
+        .def(py::init(), cls_doc.ctor.doc)
         .def("inspector", &QueryObject<T>::inspector,
-            py_rvp::reference_internal, doc.QueryObject.inspector.doc)
-        .def("X_WF", &QueryObject<T>::X_WF, py::arg("id"),
-            py_rvp::reference_internal, doc.QueryObject.X_WF.doc)
-        .def("X_PF", &QueryObject<T>::X_PF, py::arg("id"),
-            py_rvp::reference_internal, doc.QueryObject.X_PF.doc)
-        .def("X_WG", &QueryObject<T>::X_WG, py::arg("id"),
-            py_rvp::reference_internal, doc.QueryObject.X_WG.doc)
+            py_rvp::reference_internal, cls_doc.inspector.doc)
+        .def("GetPoseInWorld",
+            overload_cast_explicit<const math::RigidTransform<T>&, FrameId>(
+                &Class::GetPoseInWorld),
+            py::arg("frame_id"), py_rvp::reference_internal,
+            cls_doc.GetPoseInWorld.doc_1args_frame_id)
+        .def("GetPoseInParent", &Class::GetPoseInParent, py::arg("frame_id"),
+            py_rvp::reference_internal, cls_doc.GetPoseInParent.doc)
+        .def("GetPoseInWorld",
+            overload_cast_explicit<const math::RigidTransform<T>&, GeometryId>(
+                &Class::GetPoseInWorld),
+            py::arg("geometry_id"), py_rvp::reference_internal,
+            cls_doc.GetPoseInWorld.doc_1args_geometry_id);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
+        .def("X_WF",
+            WrapDeprecated(cls_doc.X_WF.doc_deprecated, &QueryObject<T>::X_WF),
+            py::arg("id"), py_rvp::reference_internal,
+            cls_doc.X_WF.doc_deprecated)
+        .def("X_PF",
+            WrapDeprecated(cls_doc.X_PF.doc_deprecated, &QueryObject<T>::X_PF),
+            py::arg("id"), py_rvp::reference_internal,
+            cls_doc.X_PF.doc_deprecated)
+        .def("X_WG",
+            WrapDeprecated(cls_doc.X_WG.doc_deprecated, &QueryObject<T>::X_WG),
+            py::arg("id"), py_rvp::reference_internal,
+            cls_doc.X_WG.doc_deprecated);
+#pragma GCC diagnostic pop
+    cls  // BR
         .def("ComputeSignedDistancePairwiseClosestPoints",
             &QueryObject<T>::ComputeSignedDistancePairwiseClosestPoints,
             py::arg("max_distance") = std::numeric_limits<double>::infinity(),
-            doc.QueryObject.ComputeSignedDistancePairwiseClosestPoints.doc)
+            cls_doc.ComputeSignedDistancePairwiseClosestPoints.doc)
         .def("ComputeSignedDistancePairClosestPoints",
             &QueryObject<T>::ComputeSignedDistancePairClosestPoints,
+            py::arg("geometry_id_A"), py::arg("geometry_id_B"),
+            cls_doc.ComputeSignedDistancePairClosestPoints.doc)
+        .def("ComputeSignedDistancePairClosestPoints",
+            WrapDeprecated("Please use "
+                           "QueryObject.ComputeSignedDistancePairClosestPoints("
+                           "geometry_id_A=value1, geometry_id_B=value2). This "
+                           "variant will be removed on or after 2021-03-01.",
+                &QueryObject<T>::ComputeSignedDistancePairClosestPoints),
             py::arg("id_A"), py::arg("id_B"),
-            doc.QueryObject.ComputeSignedDistancePairClosestPoints.doc)
+            cls_doc.ComputeSignedDistancePairClosestPoints.doc)
         .def("ComputePointPairPenetration",
             &QueryObject<T>::ComputePointPairPenetration,
-            doc.QueryObject.ComputePointPairPenetration.doc)
+            cls_doc.ComputePointPairPenetration.doc)
         .def("ComputeSignedDistanceToPoint",
             &QueryObject<T>::ComputeSignedDistanceToPoint, py::arg("p_WQ"),
             py::arg("threshold") = std::numeric_limits<double>::infinity(),
-            doc.QueryObject.ComputeSignedDistanceToPoint.doc)
+            cls_doc.ComputeSignedDistanceToPoint.doc)
         .def("FindCollisionCandidates",
             &QueryObject<T>::FindCollisionCandidates,
-            doc.QueryObject.FindCollisionCandidates.doc)
+            cls_doc.FindCollisionCandidates.doc)
         .def("HasCollisions", &QueryObject<T>::HasCollisions,
-            doc.QueryObject.HasCollisions.doc)
+            cls_doc.HasCollisions.doc)
         .def(
             "RenderColorImage",
             [](const Class* self, const render::CameraProperties& camera,
@@ -766,8 +818,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
               return img;
             },
             py::arg("camera"), py::arg("parent_frame"), py::arg("X_PC"),
-            py::arg("show_window") = false,
-            doc.QueryObject.RenderColorImage.doc)
+            py::arg("show_window") = false, cls_doc.RenderColorImage.doc)
         .def(
             "RenderDepthImage",
             [](const Class* self, const render::DepthCameraProperties& camera,
@@ -777,7 +828,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
               return img;
             },
             py::arg("camera"), py::arg("parent_frame"), py::arg("X_PC"),
-            doc.QueryObject.RenderDepthImage.doc)
+            cls_doc.RenderDepthImage.doc)
         .def(
             "RenderLabelImage",
             [](const Class* self, const render::CameraProperties& camera,
@@ -789,8 +840,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
               return img;
             },
             py::arg("camera"), py::arg("parent_frame"), py::arg("X_PC"),
-            py::arg("show_window") = false,
-            doc.QueryObject.RenderLabelImage.doc);
+            py::arg("show_window") = false, cls_doc.RenderLabelImage.doc);
 
     AddValueInstantiation<QueryObject<T>>(m);
   }

--- a/geometry/drake_visualizer.cc
+++ b/geometry/drake_visualizer.cc
@@ -298,11 +298,11 @@ void DrakeVisualizer::SendPoseMessage(const Context<double>& context) const {
   message.quaternion.resize(frame_count);
 
   for (int i = 0; i < frame_count; ++i) {
-    const FrameId id = dynamic_frames[i].frame_id;
-    message.robot_num[i] = inspector.GetFrameGroup(id);
+    const FrameId frame_id = dynamic_frames[i].frame_id;
+    message.robot_num[i] = inspector.GetFrameGroup(frame_id);
     message.link_name[i] = dynamic_frames[i].name;
 
-    const RigidTransformd& X_WF = query_object.X_WF(id);
+    const RigidTransformd& X_WF = query_object.GetPoseInWorld(frame_id);
     message.position[i].resize(3);
     message.position[i][0] = X_WF.translation()[0];
     message.position[i][1] = X_WF.translation()[1];

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -143,7 +143,7 @@ class GeometryState {
   /** Implementation of SceneGraphInspector::SourceIsRegistered().  */
   bool SourceIsRegistered(SourceId source_id) const;
 
-  /** Implementation of SceneGraphInspector::GetSourceName().  */
+  /** Implementation of SceneGraphInspector::GetName().  */
   const std::string& GetName(SourceId id) const;
 
   /** Implementation of SceneGraphInspector::NumFramesForSource().  */
@@ -243,14 +243,14 @@ class GeometryState {
    registered frames.  */
   //@{
 
-  /** Implementation of QueryObject::X_WF().  */
+  /** Implementation of QueryObject::GetPoseInWorld(FrameId).  */
   const math::RigidTransform<T>& get_pose_in_world(FrameId frame_id) const;
 
-  /** Implementation of QueryObject::X_WG().  */
+  /** Implementation of QueryObject::GetPoseInWorld(GeometryId).  */
   const math::RigidTransform<T>& get_pose_in_world(
       GeometryId geometry_id) const;
 
-  /** Implementation of QueryObject::X_PF().  */
+  /** Implementation of QueryObject::GetPoseInParent().  */
   const math::RigidTransform<T>& get_pose_in_parent(FrameId frame_id) const;
 
   //@}

--- a/geometry/query_object.cc
+++ b/geometry/query_object.cc
@@ -47,6 +47,16 @@ QueryObject<T>& QueryObject<T>::operator=(const QueryObject<T>& query_object) {
 }
 
 template <typename T>
+const RigidTransform<T>& QueryObject<T>::GetPoseInWorld(
+    FrameId frame_id) const {
+  ThrowIfNotCallable();
+
+  FullPoseUpdate();
+  const GeometryState<T>& state = geometry_state();
+  return state.get_pose_in_world(frame_id);
+}
+
+template <typename T>
 const RigidTransform<T>& QueryObject<T>::X_WF(FrameId id) const {
   ThrowIfNotCallable();
 
@@ -56,12 +66,32 @@ const RigidTransform<T>& QueryObject<T>::X_WF(FrameId id) const {
 }
 
 template <typename T>
+const RigidTransform<T>& QueryObject<T>::GetPoseInParent(
+    FrameId frame_id) const {
+  ThrowIfNotCallable();
+
+  FullPoseUpdate();
+  const GeometryState<T>& state = geometry_state();
+  return state.get_pose_in_parent(frame_id);
+}
+
+template <typename T>
 const RigidTransform<T>& QueryObject<T>::X_PF(FrameId id) const {
   ThrowIfNotCallable();
 
   FullPoseUpdate();
   const GeometryState<T>& state = geometry_state();
   return state.get_pose_in_parent(id);
+}
+
+template <typename T>
+const RigidTransform<T>& QueryObject<T>::GetPoseInWorld(
+    GeometryId geometry_id) const {
+  ThrowIfNotCallable();
+
+  FullPoseUpdate();
+  const GeometryState<T>& state = geometry_state();
+  return state.get_pose_in_world(geometry_id);
 }
 
 template <typename T>
@@ -139,12 +169,13 @@ QueryObject<T>::ComputeSignedDistancePairwiseClosestPoints(
 
 template <typename T>
 SignedDistancePair<T> QueryObject<T>::ComputeSignedDistancePairClosestPoints(
-    GeometryId id_A, GeometryId id_B) const {
+    GeometryId geometry_id_A, GeometryId geometry_id_B) const {
   ThrowIfNotCallable();
 
   FullPoseUpdate();
   const GeometryState<T>& state = geometry_state();
-  return state.ComputeSignedDistancePairClosestPoints(id_A, id_B);
+  return state.ComputeSignedDistancePairClosestPoints(geometry_id_A,
+                                                      geometry_id_B);
 }
 
 template <typename T>

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/geometry/query_results/contact_surface.h"
 #include "drake/geometry/query_results/penetration_as_point_pair.h"
 #include "drake/geometry/query_results/signed_distance_pair.h"
@@ -104,24 +105,36 @@ class QueryObject {
    inspector() to access the SceneGraphInspector.  */
   //@{
 
-  // TODO(SeanCurtis-TRI): When I have RigidTransform internally, make these
-  // const references.
-  /** Reports the position of the frame indicated by `id` relative to the world
-   frame.
-   @throws std::logic_error if the frame `id` is not valid.  */
+  /** Reports the position of the frame indicated by `frame_id` relative to the
+   world frame.
+   @throws std::exception if the frame `frame_id` is not valid.  */
+  const math::RigidTransform<T>& GetPoseInWorld(FrameId frame_id) const;
+
+  /** Deprecated variant of GetPoseInWorld(FrameId).  */
+  DRAKE_DEPRECATED("2021-03-01", "Please use GetPoseInWorld(FrameId) instead.")
   const math::RigidTransform<T>& X_WF(FrameId id) const;
 
-  /** Reports the position of the frame indicated by `id` relative to its parent
-   frame. If the frame was registered with the world frame as its parent frame,
-   this value will be identical to that returned by X_WF().
-   @note This is analogous to but distinct from SceneGraphInspector::X_PG().
-   In this case, the pose will *always* be relative to another frame.
-   @throws std::logic_error if the frame `id` is not valid.  */
+  /** Reports the position of the frame indicated by `frame_id` relative to its
+   parent frame. If the frame was registered with the world frame as its parent
+   frame, this value will be identical to that returned by GetPoseInWorld().
+   @note This is analogous to but distinct from
+   SceneGraphInspector::GetPoseInParent(). In this case, the pose will *always*
+   be relative to another frame.
+   @throws std::exception if the frame `frame_id` is not valid.  */
+  const math::RigidTransform<T>& GetPoseInParent(FrameId frame_id) const;
+
+  /** Deprecated variant of GetPoseInParent().  */
+  DRAKE_DEPRECATED("2021-03-01", "Please use GetPoseInParent(FrameId) instead.")
   const math::RigidTransform<T>& X_PF(FrameId id) const;
 
-  /** Reports the position of the geometry indicated by `id` relative to the
-   world frame.
-   @throws std::logic_error if the geometry `id` is not valid.  */
+  /** Reports the position of the geometry indicated by `geometry_id` relative
+   to the world frame.
+   @throws std::exception if the geometry `geometry_id` is not valid.  */
+  const math::RigidTransform<T>& GetPoseInWorld(GeometryId geometry_id) const;
+
+  /** Deprecated variant of GetPoseInWorld(GeometryId).  */
+  DRAKE_DEPRECATED("2021-03-01",
+                   "Please use GetPoseInWorld(GeometryId) instead.")
   const math::RigidTransform<T>& X_WG(GeometryId id) const;
 
   //@}
@@ -372,10 +385,10 @@ class QueryObject {
    indicated by id. This function has the same restrictions on scalar report
    as ComputeSignedDistancePairwiseClosestPoints().
 
-   @throws if either geometry id is invalid, or if the pair (id_A, id_B) has
-           been marked as filtered.  */
+   @throws std::exception if either geometry id is invalid, or if the pair
+                          (A, B) has been marked as filtered.  */
   SignedDistancePair<T> ComputeSignedDistancePairClosestPoints(
-      GeometryId id_A, GeometryId id_B) const;
+      GeometryId geometry_id_A, GeometryId geometry_id_B) const;
 
   // TODO(DamrongGuoy): Improve and refactor documentation of
   // ComputeSignedDistanceToPoint(). Move the common sections into Signed

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -8,6 +8,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/geometry_state.h"
@@ -159,14 +160,22 @@ class SceneGraphInspector {
   /** @name                Sources and source-related data  */
   //@{
 
-  /** Reports `true` if the given `id` maps to a registered source.  */
-  bool SourceIsRegistered(SourceId id) const {
+  /** Reports `true` if the given `source_id` maps to a registered source.  */
+  bool SourceIsRegistered(SourceId source_id) const {
     DRAKE_DEMAND(state_ != nullptr);
-    return state_->SourceIsRegistered(id);
+    return state_->SourceIsRegistered(source_id);
+  }
+
+  /** Reports the name for the source with the given `source_id`.
+   @throws std::exception if `source_id` does not map to a registered source. */
+  const std::string& GetName(SourceId source_id) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->GetName(source_id);
   }
 
   /** Reports the name for the source with the given `id`.
    @throws std::logic_error if `id` does not map to a registered source. */
+  DRAKE_DEPRECATED("2021-03-01", "Please use GetName(SourceId) instead.")
   const std::string& GetSourceName(SourceId id) const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->GetName(id);

--- a/geometry/test/query_object_test.cc
+++ b/geometry/test/query_object_test.cc
@@ -160,9 +160,15 @@ TEST_F(QueryObjectTest, DefaultQueryThrows) {
   // Enumerate *all* queries to confirm they throw the proper exception.
 
   // Scalar-dependent state queries.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   EXPECT_DEFAULT_ERROR(default_object.X_WF(FrameId::get_new_id()));
   EXPECT_DEFAULT_ERROR(default_object.X_PF(FrameId::get_new_id()));
   EXPECT_DEFAULT_ERROR(default_object.X_WG(GeometryId::get_new_id()));
+#pragma GCC diagnostic pop
+  EXPECT_DEFAULT_ERROR(default_object.GetPoseInWorld(FrameId::get_new_id()));
+  EXPECT_DEFAULT_ERROR(default_object.GetPoseInParent(FrameId::get_new_id()));
+  EXPECT_DEFAULT_ERROR(default_object.GetPoseInWorld(GeometryId::get_new_id()));
 
   // Penetration queries.
   EXPECT_DEFAULT_ERROR(default_object.ComputePointPairPenetration());
@@ -182,9 +188,6 @@ TEST_F(QueryObjectTest, DefaultQueryThrows) {
 
   EXPECT_DEFAULT_ERROR(default_object.FindCollisionCandidates());
   EXPECT_DEFAULT_ERROR(default_object.HasCollisions());
-  EXPECT_DEFAULT_ERROR(default_object.X_WF(FrameId::get_new_id()));
-  EXPECT_DEFAULT_ERROR(default_object.X_PF(FrameId::get_new_id()));
-  EXPECT_DEFAULT_ERROR(default_object.X_WG(GeometryId::get_new_id()));
 
   // Render queries.
   const ColorRenderCamera color_camera{

--- a/geometry/test/scene_graph_inspector_test.cc
+++ b/geometry/test/scene_graph_inspector_test.cc
@@ -56,7 +56,11 @@ GTEST_TEST(SceneGraphInspector, ExerciseEverything) {
   // Register a source to prevent exceptions being thrown.
   const SourceId source_id = tester.mutable_state().RegisterNewSource("name");
   inspector.SourceIsRegistered(source_id);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   inspector.GetSourceName(source_id);
+#pragma GCC diagnostic pop
+  inspector.GetName(source_id);
   inspector.NumFramesForSource(source_id);
   inspector.FramesForSource(source_id);
 

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -185,10 +185,10 @@ TEST_F(SceneGraphTest, RegisterSourceDefaultName) {
 // registered and that the name is available.
 TEST_F(SceneGraphTest, RegisterSourceSpecifiedName) {
   std::string name = "some_unique_name";
-  SourceId id = scene_graph_.RegisterSource(name);
-  EXPECT_TRUE(id.is_valid());
-  EXPECT_TRUE(scene_graph_.SourceIsRegistered(id));
-  EXPECT_EQ(scene_graph_.model_inspector().GetSourceName(id), name);
+  SourceId source_id = scene_graph_.RegisterSource(name);
+  EXPECT_TRUE(source_id.is_valid());
+  EXPECT_TRUE(scene_graph_.SourceIsRegistered(source_id));
+  EXPECT_EQ(scene_graph_.model_inspector().GetName(source_id), name);
 }
 
 // Tests that sources can be registered after context allocation; it should be
@@ -201,11 +201,11 @@ TEST_F(SceneGraphTest, RegisterSourcePostContext) {
   SourceId new_source = scene_graph_.RegisterSource(new_source_name);
   EXPECT_TRUE(scene_graph_.SourceIsRegistered(new_source));
   // Contained in scene graph.
-  EXPECT_EQ(scene_graph_.model_inspector().GetSourceName(new_source),
+  EXPECT_EQ(scene_graph_.model_inspector().GetName(new_source),
             new_source_name);
   // Not found in allocated context.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      query_object().inspector().GetSourceName(new_source),
+      query_object().inspector().GetName(new_source),
       std::logic_error, "Querying source name for an invalid source id.*");
 }
 

--- a/systems/sensors/rgbd_sensor.cc
+++ b/systems/sensors/rgbd_sensor.cc
@@ -196,7 +196,7 @@ void RgbdSensor::CalcX_WB(const Context<double>& context,
     X_WB = X_PB_;
   } else {
     const QueryObject<double>& query_object = get_query_object(context);
-    X_WB = query_object.X_WF(parent_frame_id_) * X_PB_;
+    X_WB = query_object.GetPoseInWorld(parent_frame_id_) * X_PB_;
   }
 
   Translation3d trans{X_WB.translation()};


### PR DESCRIPTION
As per issue 14258, we want all public APIs that take Identifiers as parameters to have names representing their id type (source_id and not simply id). This handles what is termed "Category 3" APIs in that issue. This includes deprecations of some APIs that have been renamed and some deprecations on only the bindings.

resolves #14258

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14280)
<!-- Reviewable:end -->
