### PR TITLE
perception: Split unit test cases

### DIFF
--- a/perception/test/point_cloud_flags_test.cc
+++ b/perception/test/point_cloud_flags_test.cc
@@ -24,7 +24,7 @@ GTEST_TEST(PointCloudFlagsTest, ConstExpr) {
   EXPECT_TRUE(std::is_literal_type<pcf::DescriptorType>::value);
 }
 
-GTEST_TEST(PointCloudFlagsTest, Basic) {
+GTEST_TEST(PointCloudFlagsTest, Formatting) {
   // Check human-friendly formatting.
   {
     std::ostringstream os;
@@ -37,7 +37,9 @@ GTEST_TEST(PointCloudFlagsTest, Basic) {
     os << (pcf::kXYZs | pcf::kRGBs | pcf::kDescriptorCurvature);
     EXPECT_EQ("(kXYZs | kRGBs | kDescriptorCurvature)", os.str());
   }
+}
 
+GTEST_TEST(PointCloudFlagsTest, Basic) {
   // Check basics.
   pcf::Fields lhs = pcf::kXYZs;
   pcf::Fields rhs = pcf::kXYZs;


### PR DESCRIPTION
This avoids an obscure kcov bug when using GCC and Ubuntu 20.04.

Filed upstream as https://github.com/SimonKagstrom/kcov/issues/339.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14283)
<!-- Reviewable:end -->
