### PR TITLE
[rendering] Give RenderEngineGl access to full camera intrinsics

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -172,7 +172,7 @@ void def_geometry_render(py::module m) {
     const auto& cls_doc = doc.ClippingRange;
     py::class_<Class>(m, "ClippingRange", cls_doc.doc)
         .def(py::init<Class const&>(), cls_doc.ctor.doc)
-        .def(py::init<double, double>(), cls_doc.near.doc, cls_doc.far.doc)
+        .def(py::init<double, double>(), cls_doc.ctor.doc, cls_doc.far.doc)
         .def("far", static_cast<double (Class::*)() const>(&Class::far),
             cls_doc.far.doc)
         .def("near", static_cast<double (Class::*)() const>(&Class::near),
@@ -183,9 +183,9 @@ void def_geometry_render(py::module m) {
     const auto& cls_doc = doc.ColorRenderCamera;
     py::class_<Class> cls(m, "ColorRenderCamera", cls_doc.doc);
     cls  // BR
-        .def(py::init<Class const&>(), cls_doc.ctor.doc)
-        .def(py::init<RenderCameraCore, bool>(), cls_doc.core.doc,
-            cls_doc.show_window.doc)
+        .def(py::init<Class const&>())
+        .def(py::init<RenderCameraCore, bool>(),
+            cls_doc.ctor.doc_2args_core_show_window)
         .def("core", static_cast<RenderCameraCore const& (Class::*)() const>(
                          &Class::core))
         .def("show_window",

--- a/geometry/render/BUILD.bazel
+++ b/geometry/render/BUILD.bazel
@@ -15,6 +15,7 @@ drake_cc_package_library(
     name = "render",
     visibility = ["//visibility:public"],
     deps = [
+        ":camera_properties",
         ":render_camera",
         ":render_engine",
         ":render_engine_ospray",
@@ -26,10 +27,16 @@ drake_cc_package_library(
 )
 
 drake_cc_library(
+    name = "camera_properties",
+    hdrs = ["camera_properties.h"],
+)
+
+drake_cc_library(
     name = "render_camera",
     srcs = ["render_camera.cc"],
     hdrs = ["render_camera.h"],
     deps = [
+        ":camera_properties",
         "//common:essential",
         "//math:geometric_transform",
         "//systems/sensors:camera_info",
@@ -41,11 +48,9 @@ drake_cc_library(
 drake_cc_library(
     name = "render_engine",
     srcs = ["render_engine.cc"],
-    hdrs = [
-        "camera_properties.h",
-        "render_engine.h",
-    ],
+    hdrs = ["render_engine.h"],
     deps = [
+        ":camera_properties",
         ":render_camera",
         ":render_label",
         "//common:essential",

--- a/geometry/render/gl_renderer/render_engine_gl.h
+++ b/geometry/render/gl_renderer/render_engine_gl.h
@@ -50,6 +50,10 @@ class RenderEngineGl final : public RenderEngine {
   /** @see RenderEngine::UpdateViewpoint().  */
   void UpdateViewpoint(const math::RigidTransformd& X_WR) final;
 
+  using RenderEngine::RenderColorImage;
+  using RenderEngine::RenderDepthImage;
+  using RenderEngine::RenderLabelImage;
+
   /** @see RenderEngine::RenderColorImage(). Currently unimplemented. Calling
    this will throw an exception.
 
@@ -116,6 +120,21 @@ class RenderEngineGl final : public RenderEngine {
   // @see RenderEngine::DoClone().
   std::unique_ptr<RenderEngine> DoClone() const final;
 
+  // @see RenderEngine::DoRenderColorImage().
+  void DoRenderColorImage(
+      const ColorRenderCamera& camera,
+      systems::sensors::ImageRgba8U* color_image_out) const final;
+
+  // @see RenderEngine::DoRenderDepthImage().
+  void DoRenderDepthImage(
+      const DepthRenderCamera& render_camera,
+      systems::sensors::ImageDepth32F* depth_image_out) const final;
+
+  // @see RenderEngine::DoRenderLabelImage().
+  void DoRenderLabelImage(
+      const ColorRenderCamera& camera,
+      systems::sensors::ImageLabel16I* label_image_out) const final;
+
   // Copy constructor used for cloning.
   RenderEngineGl(const RenderEngineGl& other) = default;
 
@@ -154,14 +173,7 @@ class RenderEngineGl final : public RenderEngine {
   // called if there is not already a cached render target for the camera's
   // reported image size (w, h) in render_targets_.
   static internal::RenderTarget CreateRenderTarget(
-      const CameraProperties& camera, internal::RenderType render_type);
-
-  // Computes the projection matrix based on the given camera. This is the
-  // matrix that projects a point from the camera frame C to the 2D image device
-  // frame D: T_DC.
-  Eigen::Matrix4f ComputeGlProjectionMatrix(const CameraProperties& camera,
-                                            double clip_near,
-                                            double clip_far) const;
+      const RenderCameraCore& camera, internal::RenderType render_type);
 
   // Obtains the label image rendered from a specific object pose. This is
   // slower than it has to be because it does per-pixel processing on the CPU.
@@ -173,7 +185,7 @@ class RenderEngineGl final : public RenderEngine {
   // target guarantees that the target will be ready for receiving OpenGL
   // draw commands.
   internal::RenderTarget GetRenderTarget(
-      const CameraProperties& camera, internal::RenderType render_type) const;
+      const RenderCameraCore& camera, internal::RenderType render_type) const;
 
   // Creates an OpenGlGeometry from the mesh defined by the given `mesh_data`.
   static internal::OpenGlGeometry CreateGlGeometry(
@@ -188,7 +200,7 @@ class RenderEngineGl final : public RenderEngine {
   //  - the window is made hidden (or remains hidden).
   // @pre RenderTarget's frame buffer has the same dimensions as reported by the
   // camera.
-  void SetWindowVisibility(const CameraProperties& camera, bool show_window,
+  void SetWindowVisibility(const RenderCameraCore& camera, bool show_window,
                            const internal::RenderTarget& target) const;
 
   // Adds a shader program to the set of candidate shaders for the given render

--- a/geometry/render/gl_renderer/shader_program.h
+++ b/geometry/render/gl_renderer/shader_program.h
@@ -7,9 +7,9 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/geometry_roles.h"
-#include "drake/geometry/render/camera_properties.h"
 #include "drake/geometry/render/gl_renderer/opengl_includes.h"
 #include "drake/geometry/render/gl_renderer/shader_program_data.h"
+#include "drake/geometry/render/render_camera.h"
 #include "drake/geometry/rgba.h"
 
 namespace drake {
@@ -117,7 +117,7 @@ class ShaderProgram {
    properties. This should *not* include model -> camera -> device transforms.
    they are handled elsewhere.  */
   virtual void SetDepthCameraParameters(
-      const DepthCameraProperties& /* camera */) const {}
+      const DepthRenderCamera& /* camera */) const {}
 
   /* Sets the OpenGl projection matrix state. The projection matrix transforms a
    vertex from the camera frame C to the OpenGl 2D device frame D -- it

--- a/geometry/render/gl_renderer/test/shader_program_test.cc
+++ b/geometry/render/gl_renderer/test/shader_program_test.cc
@@ -52,7 +52,7 @@ class TestShader final : public ShaderProgram {
   }
 
   void SetDepthCameraParameters(
-      const DepthCameraProperties& /* camera */) const override {
+      const DepthRenderCamera& /* camera */) const override {
     set_depth_camera_called_ = true;
   }
 
@@ -361,7 +361,10 @@ TEST_F(ShaderProgramTest, SetDepthCameraParameters) {
   TestShader shader;
   const ShaderProgram* shader_ptr = &shader;
 
-  DepthCameraProperties camera{10, 10, M_PI, "", 0.1, 10.0};
+  DepthRenderCamera camera{
+      RenderCameraCore{"n/a", {10, 10, M_PI}, {0.1, 10.1}, {}},
+      DepthRange{0.1, 10}};
+
   ASSERT_FALSE(shader.CalledSetDepthCameraParameters());
   shader_ptr->SetDepthCameraParameters(camera);
   ASSERT_TRUE(shader.CalledSetDepthCameraParameters());

--- a/geometry/render/render_camera.cc
+++ b/geometry/render/render_camera.cc
@@ -8,6 +8,9 @@ namespace drake {
 namespace geometry {
 namespace render {
 
+using math::RigidTransformd;
+using systems::sensors::CameraInfo;
+
 ClippingRange::ClippingRange(double near, double far) : near_(near), far_(far) {
   if (near <= 0 || far <= 0 || far <= near) {
     throw std::runtime_error(fmt::format(
@@ -15,6 +18,46 @@ ClippingRange::ClippingRange(double near, double far) : near_(near), far_(far) {
         "greater than near. Instantiated with near = {} and far = {}",
         near, far));
   }
+}
+
+RenderCameraCore::RenderCameraCore(const CameraProperties& camera,
+                                   double clipping_far)
+    : RenderCameraCore(camera.renderer_name,
+                       CameraInfo{camera.width, camera.height, camera.fov_y},
+                       ClippingRange{kClippingNear, clipping_far},
+                       RigidTransformd{}) {}
+
+Eigen::Matrix4d RenderCameraCore::CalcProjectionMatrix() const {
+  /* Given the camera properties we compute the projection matrix as follows:
+   (See https://strawlab.org/2011/11/05/augmented-reality-with-OpenGL/)
+
+            │ 2*fx/w     0      (w - 2*cx) / w       0    │
+            │ 0        2*fy/h  -(h - 2*cy) / h       0    │
+            │ 0          0        -(f+n) / d   -2*f*n / d │
+            │ 0          0             -1            0    │
+
+   The symbols in the matrix are predominantly aliases for the input parameter
+   values (see below for details).
+   */
+  const double fx = intrinsics_.focal_x();
+  const double fy = intrinsics_.focal_y();
+  const double n = clipping().near();
+  const double f = clipping().far();
+  const int w = intrinsics_.width();
+  const int h = intrinsics_.height();
+  const double cx = intrinsics_.center_x();
+  const double cy = intrinsics_.center_y();
+  const double d = f - n;
+
+  Eigen::Matrix4d T_DC = Eigen::Matrix4d::Zero();
+  T_DC(0, 0) =  2 * fx / w;
+  T_DC(0, 2) =  (w - 2 * cx) / w;
+  T_DC(1, 1) =  2 * fy / h;
+  T_DC(1, 2) =  -(h - 2 * cy) / h;
+  T_DC(2, 2) =  -(f + n) / d;
+  T_DC(2, 3) =  -2 * f * n / d;
+  T_DC(3, 2) =  -1;
+  return T_DC;
 }
 
 DepthRange::DepthRange(double min_in, double max_in)

--- a/geometry/render/test/render_camera_test.cc
+++ b/geometry/render/test/render_camera_test.cc
@@ -13,6 +13,7 @@ namespace geometry {
 namespace render {
 namespace {
 
+using Eigen::Matrix4d;
 using Eigen::Vector3d;
 using math::RigidTransformd;
 using systems::sensors::CameraInfo;
@@ -55,6 +56,161 @@ GTEST_TEST(RenderCameraCoreTest, Constructor) {
                               X_BS.GetAsMatrix4()));
 }
 
+/* Test the converstion constructor. This will be removed when CameraProperties
+ is removed.  */
+GTEST_TEST(RenderCameraCoreTest, CameraPropertiesConversion) {
+  CameraProperties props{640, 480, M_PI / 3, "some_name"};
+  for (const double clipping_far : {15.0, 22.5}) {
+    const CameraInfo expected_intrinsics(props.width, props.height,
+                                         props.fov_y);
+    const RenderCameraCore cam{props, clipping_far};
+    EXPECT_EQ(cam.intrinsics().width(), expected_intrinsics.width());
+    EXPECT_EQ(cam.intrinsics().height(), expected_intrinsics.height());
+    EXPECT_EQ(cam.intrinsics().fov_y(), expected_intrinsics.fov_y());
+    EXPECT_EQ(cam.intrinsics().fov_x(), expected_intrinsics.fov_x());
+    EXPECT_EQ(cam.intrinsics().center_x(), expected_intrinsics.center_x());
+    EXPECT_EQ(cam.intrinsics().center_y(), expected_intrinsics.center_y());
+    EXPECT_EQ(cam.renderer_name(), props.renderer_name);
+    EXPECT_EQ(cam.clipping().far(), clipping_far);
+    // We're not putting a strict value on the near clipping plane; just that
+    // it's strictly positive and less than the far value.
+    EXPECT_GT(cam.clipping().near(), 0);
+    EXPECT_LT(cam.clipping().near(), cam.clipping().far());
+    EXPECT_TRUE(cam.sensor_pose_in_camera_body().IsExactlyIdentity());
+  }
+}
+
+/* Confirm that the correct projection matrix is created. Note: this doesn't
+test that the matrix as defined as below is correct; for that, we appeal to
+authority (the provided link). We merely show that the matrix is implemented
+correctly.  */
+GTEST_TEST(RenderCameraCoreTest, CalcProjectionMatrix) {
+  /* Given this definition of the projection matrix:
+   (See https://strawlab.org/2011/11/05/augmented-reality-with-OpenGL/)
+
+            │ 2*fx/w     0      (w - 2*cx) / w       0    │
+            │ 0        2*fy/h  -(h - 2*cy) / h       0    │
+            │ 0          0        -(f+n) / d   -2*f*n / d │
+            │ 0          0             -1            0    │
+
+   To test this, we'll create a camera and have it compute a reference
+   projection matrix. Then, by perturbing each camera parameter, we can predict
+   the relationship between the reference matrix and the new matrix. The
+   differences should be limited. By accounting for the known differences, we
+   should be able to compare the test matrix with the reference matrix and
+   show equivalency.
+
+   We've picked arbitrary values for the intrinsics that would be atypical for
+   rendering applications to prevent the possibility that the test parameters
+   shadow otherwise hard-coded, default values. (e.g., a 640x480 image). */
+  constexpr double kEps = std::numeric_limits<double>::epsilon();
+  const int w{384};
+  const int h{175};
+  const double fx{378};
+  const double fy{410};
+  const double cx{w * 0.5 + 15};
+  const double cy{h * 0.5 - 11};
+  const double n{0.45};
+  const double f{11.75};
+  const RenderCameraCore base_cam{"", {w, h, fx, fy, cx, cy}, {n, f}, {}};
+  Matrix4d X_DC_base = base_cam.CalcProjectionMatrix();
+
+  {
+    /* Confirm zeros in all the right places.  */
+    Matrix4d X_DC_alt(X_DC_base);
+    X_DC_alt(0, 1) = 0;
+    X_DC_alt(0, 3) = 0;
+    X_DC_alt(1, 0) = 0;
+    X_DC_alt(1, 3) = 0;
+    X_DC_alt(2, 0) = 0;
+    X_DC_alt(2, 1) = 0;
+    X_DC_alt(3, 0) = 0;
+    X_DC_alt(3, 1) = 0;
+    X_DC_alt(3, 3) = 0;
+    EXPECT_TRUE(CompareMatrices(X_DC_base, X_DC_alt));
+  }
+
+  {
+    /* Case: width. Doubling width should make:
+         - X_DC(0, 0) * 2 = X_DC_base(0, 0) and
+         - X_DC(0, 2) - cx / w = X_DC_base(0, 2).  */
+    const RenderCameraCore cam{"", {2 * w, h, fx, fy, cx, cy}, {n, f}, {}};
+    Eigen::Matrix4d X_DC = cam.CalcProjectionMatrix();
+    X_DC(0, 0) *= 2;
+    X_DC(0, 2) -= cx / w;
+    EXPECT_TRUE(CompareMatrices(X_DC, X_DC_base));
+  }
+
+  {
+    /* Case: height. Doubling height should make:
+         - X_DC(1, 1) * 2 = X_DC_base(1, 1) and
+         - X_DC(1, 2) + cy / h = X_DC_base(1, 2).  */
+    const RenderCameraCore cam{"", {w, 2 * h, fx, fy, cx, cy}, {n, f}, {}};
+    Eigen::Matrix4d X_DC = cam.CalcProjectionMatrix();
+    X_DC(1, 1) *= 2;
+    X_DC(1, 2) += cy / h;
+    EXPECT_TRUE(CompareMatrices(X_DC, X_DC_base, kEps));
+  }
+
+  {
+    /* Case: fx. Doubling fx should make X_DC(0, 0) / 2 = X_DC_base(0, 0).  */
+    const RenderCameraCore cam{"", {w, h, 2 * fx, fy, cx, cy}, {n, f}, {}};
+    Eigen::Matrix4d X_DC = cam.CalcProjectionMatrix();
+    X_DC(0, 0) /= 2;
+    EXPECT_TRUE(CompareMatrices(X_DC, X_DC_base, kEps));
+  }
+
+  {
+    /* Case: fy. Doubling fy should make X_DC(1, 1) / 2 = X_DC_base(1, 1).  */
+    const RenderCameraCore cam{"", {w, h, fx, 2 * fy, cx, cy}, {n, f}, {}};
+    Eigen::Matrix4d X_DC = cam.CalcProjectionMatrix();
+    X_DC(1, 1) /= 2;
+    EXPECT_TRUE(CompareMatrices(X_DC, X_DC_base, kEps));
+  }
+
+  {
+    /* Case: cx. Changing cx by +13 should make
+        - X_DC(0, 2) + 2 * 13 / w = X_DC_base(0, 2).  */
+    const RenderCameraCore cam{"", {w, h, fx, fy, cx + 13, cy}, {n, f}, {}};
+    Eigen::Matrix4d X_DC = cam.CalcProjectionMatrix();
+    X_DC(0, 2) += 2 * 13.0 / w;
+    EXPECT_TRUE(CompareMatrices(X_DC, X_DC_base, kEps));
+  }
+
+  {
+    /* Case: cy. Doubling cy +13 should make
+        - X_DC(1, 2) - 2 * 13 / h = X_DC_base(1, 2).  */
+    const RenderCameraCore cam{"", {w, h, fx, fy, cx, cy + 13}, {n, f}, {}};
+    Eigen::Matrix4d X_DC = cam.CalcProjectionMatrix();
+    X_DC(1, 2) -= 2 * 13.0 / h;
+    EXPECT_TRUE(CompareMatrices(X_DC, X_DC_base, kEps));
+  }
+
+  {
+    /* Case: n. The relationship between f and n is ugly enough that we
+     can't really define the relationship between X_DC and X_DC_base. Instead,
+     we'll calculate the expected value directly.  */
+    const RenderCameraCore cam{"", {w, h, fx, fy, cx, cy}, {2 * n, f}, {}};
+    Eigen::Matrix4d X_DC = cam.CalcProjectionMatrix();
+    Matrix4d X_DC_expected = X_DC_base;
+    X_DC_expected(2, 2) = -(f + 2 * n) / (f - 2 * n);
+    X_DC_expected(2, 3) = -2 * f * 2 * n / (f - 2 * n);
+    EXPECT_TRUE(CompareMatrices(X_DC, X_DC_expected, kEps));
+  }
+
+  {
+    /* Case: f. The relationship between f and n is ugly enough that we
+     can't really define the relationship between X_DC and X_DC_base. Instead,
+     we'll calculate the expected value directly.  */
+    const RenderCameraCore cam{"", {w, h, fx, fy, cx, cy}, {n, 2 * f}, {}};
+    Eigen::Matrix4d X_DC = cam.CalcProjectionMatrix();
+    Matrix4d X_DC_expected = X_DC_base;
+    X_DC_expected(2, 2) = -(2 * f + n) / (2 * f - n);
+    X_DC_expected(2, 3) = -2 * 2 * f * n / (2 * f - n);
+    EXPECT_TRUE(CompareMatrices(X_DC, X_DC_expected, kEps));
+  }
+}
+
 GTEST_TEST(ColorRenderCameraTest, Constructor) {
   const std::string renderer_name = "some_renderer";
   const CameraInfo intrinsics{320, 240, M_PI};
@@ -74,6 +230,23 @@ GTEST_TEST(ColorRenderCameraTest, Constructor) {
       CompareMatrices(camera.core().sensor_pose_in_camera_body().GetAsMatrix4(),
                       X_BS.GetAsMatrix4()));
   EXPECT_EQ(camera.show_window(), show_window);
+}
+
+/* Test the converstion constructor. This will be removed when CameraProperties
+ is removed.  */
+GTEST_TEST(ColorRenderCameraTest, CameraPropertiesConversion) {
+  CameraProperties props{640, 480, M_PI / 3, "some_name"};
+  for (const bool show_window : {true, false}) {
+    const ColorRenderCamera cam{props, show_window};
+    // We'll test a single feature of the core camera data, assuming that its
+    // success implies that the core data was correctly converted.
+    EXPECT_EQ(cam.core().intrinsics().width(), props.width);
+    // We *will* confirm that the conversion sets up valid clipping planes:
+    // strictly positive with near < far.
+    EXPECT_GT(cam.core().clipping().near(), 0);
+    EXPECT_LT(cam.core().clipping().near(), cam.core().clipping().far());
+    EXPECT_EQ(cam.show_window(), show_window);
+  }
 }
 
 GTEST_TEST(DepthRangeTest, Constructor) {
@@ -138,6 +311,25 @@ GTEST_TEST(DepthRenderCameraTest, Constructor) {
       std::runtime_error,
       "Depth camera's depth range extends beyond the clipping planes; near = "
       ".+, far = .+, min. depth = .+, max. depth = .+");
+}
+
+/* Test the converstion constructor. This will be removed when
+ DepthCameraProperties is removed.  */
+GTEST_TEST(DepthRenderCameraTest, CameraPropertiesConversion) {
+  DepthCameraProperties props{640, 480, M_PI / 3, "some_name", 0.25, 7.5};
+    const DepthRenderCamera cam{props};
+    // We'll test a single feature of the core camera data, assuming that its
+    // success implies that the core data was correctly converted.
+    EXPECT_EQ(cam.core().intrinsics().width(), props.width);
+    // We *will* confirm that the conversion sets up valid clipping planes:
+    // strictly positive, near < far, and the depth range is "enclosed" in the
+    // clipping range.
+    EXPECT_GT(cam.core().clipping().near(), 0);
+    EXPECT_LE(cam.core().clipping().near(), cam.depth_range().min_depth());
+    EXPECT_LT(cam.core().clipping().near(), cam.core().clipping().far());
+    EXPECT_GE(cam.core().clipping().far(), cam.depth_range().max_depth());
+    EXPECT_EQ(cam.depth_range().min_depth(), props.z_near);
+    EXPECT_EQ(cam.depth_range().max_depth(), props.z_far);
 }
 
 }  // namespace

--- a/geometry/render/test/render_engine_vtk_test.cc
+++ b/geometry/render/test/render_engine_vtk_test.cc
@@ -1426,6 +1426,12 @@ Vector4<int> FindBoxEdges(const ImageType& image) {
 // configuration and we'll predict the contents of the image relative to a
 // baseline image, based on the change in rendering properties.
 TEST_F(RenderEngineVtkTest, IntrinsicsAndRenderProperties) {
+  // TODO(11965) Now that the creation of the projection matrix is part
+  //  of RenderCameraCore (and tested there), this could be simplified. We rely
+  //  on the *correctness* of the projection matrix and merely confirm that
+  //  it is being computed at all. That would eliminate the many tweaks and
+  //  comparisons. Consider simplifying this when the render engine test
+  //  infrastructure is refactored.
   Init(X_WC_, true /* add_terrain */);
   PopulateSimpleBoxTest(renderer_.get());
 


### PR DESCRIPTION
 - Refactor the mapping from `RenderCamera` --> OpenGl Projection matrix previously defined in `RenderEngineVtk` into `RenderCameraCore`.
 - Add convenience constructors for `*RenderCamera` instances from `CameraProperties` instances.
 - Add `RenderCamera`-based rendering to `RenderEngineGl`
   - Implement `DoRender*Image(*RenderCamera)` API from `RenderEngine`
   - Express `Render*Image(*CameraProperties)` in terms of the `DoRender*Image` API. This is about 95% cut-and-paste and 5% changing `CameraProperties` declarations to `RenderCamera` declarations.
   - tweak `ShaderProgram` to consume new camera type.
 - Copy-and-paste `render_engine_vtk_test.cc` code for testing intrinsics into `render_engine_gl_test.cc`.

resolves #13617

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14289)
<!-- Reviewable:end -->
