### PR TITLE
Minor fixes for flake8's F821 (undefined name) error

### DIFF
--- a/bindings/pydrake/examples/multibody/pendulum_lqr_monte_carlo_analysis.py
+++ b/bindings/pydrake/examples/multibody/pendulum_lqr_monte_carlo_analysis.py
@@ -50,7 +50,7 @@ def main():
         help="Torque limit of the pendulum.")
     args = parser.parse_args()
     if args.torque_limit < 0:
-        raise InvalidArgumentError("Please supply a nonnegative torque limit.")
+        raise ValueError("Please supply a nonnegative torque limit.")
 
     # Assemble the Pendulum plant.
     builder = DiagramBuilder()

--- a/bindings/pydrake/manipulation/simple_ui.py
+++ b/bindings/pydrake/manipulation/simple_ui.py
@@ -183,7 +183,7 @@ class SchunkWsgButtons(LeafSystem):
 
         if window is None:
             self.window = tk.Tk()
-            self.window.title(title)
+            self.window.title("Schunk WSG Buttons")
         else:
             self.window = window
 

--- a/examples/manipulation_station/differential_ik.py
+++ b/examples/manipulation_station/differential_ik.py
@@ -1,3 +1,6 @@
+import numpy as np
+
+from pydrake.common.eigen_geometry import AngleAxis
 from pydrake.manipulation.planner import DoDifferentialInverseKinematics
 from pydrake.math import RigidTransform, RollPitchYaw
 from pydrake.systems.framework import BasicVector, LeafSystem, PortDataType


### PR DESCRIPTION
Command-line:
```
$ flake8 --select=F821 **/*.py \
    | grep -v _extra.py | grep -v drake_visualizer | grep -v schunk_buttons.py
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14293)
<!-- Reviewable:end -->
