### PR TITLE
[pydrake] Update RenderEngine python trampoline - omit soon-to-be-removed API

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -85,24 +85,6 @@ class PyRenderEngine : public py::wrapper<RenderEngine> {
     PYBIND11_OVERLOAD_PURE(void, Base, UpdateViewpoint, X_WR);
   }
 
-  void RenderColorImage(CameraProperties const& camera, bool show_window,
-      ImageRgba8U* color_image_out) const override {
-    PYBIND11_OVERLOAD_PURE(
-        void, Base, RenderColorImage, camera, show_window, color_image_out);
-  }
-
-  void RenderDepthImage(DepthCameraProperties const& camera,
-      ImageDepth32F* depth_image_out) const override {
-    PYBIND11_OVERLOAD_PURE(
-        void, Base, RenderDepthImage, camera, depth_image_out);
-  }
-
-  void RenderLabelImage(CameraProperties const& camera, bool show_window,
-      ImageLabel16I* label_image_out) const override {
-    PYBIND11_OVERLOAD_PURE(
-        void, Base, RenderLabelImage, camera, show_window, label_image_out);
-  }
-
   bool DoRegisterVisual(GeometryId id, Shape const& shape,
       PerceptionProperties const& properties,
       RigidTransformd const& X_WG) override {
@@ -124,17 +106,20 @@ class PyRenderEngine : public py::wrapper<RenderEngine> {
 
   void DoRenderColorImage(ColorRenderCamera const& camera,
       ImageRgba8U* color_image_out) const override {
-    PYBIND11_OVERLOAD(void, Base, DoRenderColorImage, camera, color_image_out);
+    PYBIND11_OVERLOAD_PURE(
+        void, Base, DoRenderColorImage, camera, color_image_out);
   }
 
   void DoRenderDepthImage(DepthRenderCamera const& camera,
       ImageDepth32F* depth_image_out) const override {
-    PYBIND11_OVERLOAD(void, Base, DoRenderDepthImage, camera, depth_image_out);
+    PYBIND11_OVERLOAD_PURE(
+        void, Base, DoRenderDepthImage, camera, depth_image_out);
   }
 
   void DoRenderLabelImage(ColorRenderCamera const& camera,
       ImageLabel16I* label_image_out) const override {
-    PYBIND11_OVERLOAD(void, Base, DoRenderLabelImage, camera, label_image_out);
+    PYBIND11_OVERLOAD_PURE(
+        void, Base, DoRenderLabelImage, camera, label_image_out);
   }
 
   void SetDefaultLightPosition(Vector3d const& X_DL) override {
@@ -154,6 +139,31 @@ class PyRenderEngine : public py::wrapper<RenderEngine> {
   static void ThrowIfInvalid(const systems::sensors::CameraInfo& intrinsics,
       const ImageType* image, const char* image_type) {
     return Base::ThrowIfInvalid<ImageType>(intrinsics, image, image_type);
+  }
+
+ private:
+  // TODO(SeanCurtis-TRI) We will be removing the Render*Image API when we
+  // deprecate CameraProperties. They must be implemented in order to build
+  // this class; so we'll make sure they clearly signal if they get invoked.
+  void RenderColorImage(
+      CameraProperties const&, bool, ImageRgba8U*) const override {
+    throw std::runtime_error(
+        "Python should not be able to invoke RenderColorImage with "
+        "CameraProperties");
+  }
+
+  void RenderDepthImage(
+      DepthCameraProperties const&, ImageDepth32F*) const override {
+    throw std::runtime_error(
+        "Python should not be able to invoke RenderDepthImage with "
+        "CameraProperties");
+  }
+
+  void RenderLabelImage(
+      CameraProperties const&, bool, ImageLabel16I*) const override {
+    throw std::runtime_error(
+        "Python should not be able to invoke RenderLabelImage with "
+        "CameraProperties");
   }
 };
 
@@ -300,17 +310,17 @@ void def_geometry_render(py::module m) {
             static_cast<void (Class::*)(ColorRenderCamera const&, ImageRgba8U*)
                     const>(&Class::RenderColorImage),
             py::arg("camera"), py::arg("color_image_out"),
-            cls_doc.RenderColorImage.doc_2args)
+            cls_doc.RenderColorImage.doc)
         .def("RenderDepthImage",
             static_cast<void (Class::*)(DepthRenderCamera const&,
                 ImageDepth32F*) const>(&Class::RenderDepthImage),
             py::arg("camera"), py::arg("depth_image_out"),
-            cls_doc.RenderDepthImage.doc_was_unable_to_choose_unambiguous_names)
+            cls_doc.RenderDepthImage.doc)
         .def("RenderLabelImage",
             static_cast<void (Class::*)(ColorRenderCamera const&,
                 ImageLabel16I*) const>(&Class::RenderLabelImage),
             py::arg("camera"), py::arg("label_image_out"),
-            cls_doc.RenderLabelImage.doc_2args)
+            cls_doc.RenderLabelImage.doc)
         .def("default_render_label",
             static_cast<RenderLabel (Class::*)() const>(
                 &Class::default_render_label),

--- a/geometry/render/render_engine.h
+++ b/geometry/render/render_engine.h
@@ -192,7 +192,8 @@ class RenderEngine : public ShapeReifier {
 
    @param camera                The intrinsic properties of the camera.
    @param show_window           If true, the render window will be displayed.
-   @param[out] color_image_out  The rendered color image.  */
+   @param[out] color_image_out  The rendered color image.
+   @pydrake_mkdoc_identifier{deprecated}  */
   virtual void RenderColorImage(
       const CameraProperties& camera, bool show_window,
       systems::sensors::ImageRgba8U* color_image_out) const = 0;
@@ -203,7 +204,8 @@ class RenderEngine : public ShapeReifier {
    depth images are not readily communicative to humans.
 
    @param camera                The intrinsic properties of the camera.
-   @param[out] depth_image_out  The rendered depth image.  */
+   @param[out] depth_image_out  The rendered depth image.
+   @pydrake_mkdoc_identifier{deprecated}  */
   virtual void RenderDepthImage(
       const DepthCameraProperties& camera,
       systems::sensors::ImageDepth32F* depth_image_out) const = 0;
@@ -213,7 +215,8 @@ class RenderEngine : public ShapeReifier {
 
    @param camera                The intrinsic properties of the camera.
    @param show_window           If true, the render window will be displayed.
-   @param[out] label_image_out  The rendered label image.  */
+   @param[out] label_image_out  The rendered label image.
+   @pydrake_mkdoc_identifier{deprecated}  */
   virtual void RenderLabelImage(
       const CameraProperties& camera,
       bool show_window,


### PR DESCRIPTION
The `RenderEngine` API has a `Render*Image(CameraProperties)` API. The `CameraProperties` classes are being supplanted by the `RenderCamera` API (which gives support for a fully specified pinhole camera intrinsic model). Rather than bind these soon-to-be-deprecated methods, we'll omit them to ease the pain of deprecation.

We're assuming that since these binding have only existed for about two weeks (as of the submission of this PR -- see #13835), a hard removal is acceptable. 

See [this conversation](https://github.com/RobotLocomotion/drake/pull/13835#issuecomment-723314350) from #13835.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14300)
<!-- Reviewable:end -->
