### PR TITLE
Adds PackageMap Remove method

### DIFF
--- a/multibody/parsing/package_map.cc
+++ b/multibody/parsing/package_map.cc
@@ -38,6 +38,14 @@ bool PackageMap::Contains(const string& package_name) const {
   return map_.find(package_name) != map_.end();
 }
 
+void PackageMap::Remove(const string& package_name) {
+  if (map_.erase(package_name) == 0) {
+    throw std::runtime_error(
+        "Could not find and remove package://" + package_name + " from the "
+        "search path.");
+  }
+}
+
 int PackageMap::size() const {
   return map_.size();
 }

--- a/multibody/parsing/package_map.h
+++ b/multibody/parsing/package_map.h
@@ -26,6 +26,10 @@ class PackageMap {
   /// Returns true if and only if this PackageMap contains @p package_name.
   bool Contains(const std::string& package_name) const;
 
+  /// Removes package @p package_name and its previously added path.
+  /// Throws if @p package_name is not present in this PackageMap.
+  void Remove(const std::string& package_name);
+
   /// Returns the number of entries in this PackageMap.
   int size() const;
 

--- a/multibody/parsing/test/package_map_test.cc
+++ b/multibody/parsing/test/package_map_test.cc
@@ -59,7 +59,7 @@ void VerifyMatchWithTestDataRoot(const PackageMap& package_map) {
   VerifyMatch(package_map, expected_packages);
 }
 
-// Tests that the PackageMap can be manually populated.
+// Tests that the PackageMap can be manually populated and unpopulated.
 GTEST_TEST(PackageMapTest, TestManualPopulation) {
   filesystem::create_directory("package_foo");
   filesystem::create_directory("package_bar");
@@ -74,6 +74,17 @@ GTEST_TEST(PackageMapTest, TestManualPopulation) {
   }
 
   VerifyMatch(package_map, expected_packages);
+
+  map<string, string> expected_remaining_packages(expected_packages);
+  for (const auto& it : expected_packages) {
+    package_map.Remove(it.first);
+    expected_remaining_packages.erase(it.first);
+    VerifyMatch(package_map, expected_remaining_packages);
+  }
+
+  VerifyMatch(package_map, std::map<string, string>());
+
+  EXPECT_THROW(package_map.Remove("package_baz"), std::runtime_error);
 }
 
 // Tests that PackageMap can be populated by a package.xml.


### PR DESCRIPTION
As discussed in the comments of https://github.com/RobotLocomotion/drake/issues/10531#issuecomment-722501505, this PR creates a `PackageMap::Remove` method for removing package keys (and paths) that have been previously added to a `PackageMap`.

In terms of testing, I extended the `TestManualPopulation` to now test both `Add` and `Remove` methods of the `PackageMap`, including the error case of requesting a package that doesn't exist.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14301)
<!-- Reviewable:end -->
