### PR TITLE
[visualization] Allow force publish calls on DrakeVisualizer

### DIFF
--- a/geometry/drake_visualizer.cc
+++ b/geometry/drake_visualizer.cc
@@ -22,6 +22,7 @@ using math::RigidTransformd;
 using std::make_unique;
 using std::vector;
 using systems::Context;
+using systems::EventStatus;
 
 namespace {
 
@@ -166,6 +167,7 @@ DrakeVisualizer::DrakeVisualizer(lcm::DrakeLcmInterface* lcm,
 
   DeclarePeriodicPublishEvent(params_.publish_period, 0.0,
                               &DrakeVisualizer::SendGeometryMessage);
+  DeclareForcedPublishEvent(&DrakeVisualizer::SendGeometryMessage);
 
   query_object_input_port_ =
       this->DeclareAbstractInputPort("query_object",
@@ -208,7 +210,7 @@ void DrakeVisualizer::DispatchLoadMessage(const SceneGraph<double>& scene_graph,
                   lcm);
 }
 
-void DrakeVisualizer::SendGeometryMessage(
+EventStatus DrakeVisualizer::SendGeometryMessage(
     const Context<double>& context) const {
   const auto& query_object =
       query_object_input_port().Eval<QueryObject<double>>(context);
@@ -230,6 +232,8 @@ void DrakeVisualizer::SendGeometryMessage(
 
   SendDrawMessage(query_object, EvalDynamicFrameData(context),
                   context.get_time(), lcm_);
+
+  return EventStatus::Succeeded();
 }
 
 void DrakeVisualizer::SendLoadMessage(

--- a/geometry/drake_visualizer.h
+++ b/geometry/drake_visualizer.h
@@ -11,6 +11,7 @@
 #include "drake/geometry/query_object.h"
 #include "drake/lcm/drake_lcm_interface.h"
 #include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/framework/event_status.h"
 #include "drake/systems/framework/input_port.h"
 #include "drake/systems/framework/leaf_system.h"
 #include "drake/systems/framework/output_port.h"
@@ -178,7 +179,8 @@ class DrakeVisualizer : public systems::LeafSystem<double> {
 
   /* The periodic event handler. It tests to see if the last scene description
    is valid (if not, updates it) and then broadcasts poses.  */
-  void SendGeometryMessage(const systems::Context<double>& context) const;
+  systems::EventStatus SendGeometryMessage(
+      const systems::Context<double>& context) const;
 
   /* Data stored in the cache; populated when we transmit a load message and
    read from for a pose message.  */

--- a/geometry/test/drake_visualizer_test.cc
+++ b/geometry/test/drake_visualizer_test.cc
@@ -525,6 +525,20 @@ TEST_F(DrakeVisualizerTest, TargetRole) {
   }
 }
 
+/* Confirms that a force publish is sufficient.  */
+TEST_F(DrakeVisualizerTest, ForcePublish) {
+  ConfigureDiagram(kPublishPeriod, Role::kIllustration);
+  PopulateScene();
+  auto context = diagram_->CreateDefaultContext();
+  const auto& vis_context = visualizer_->GetMyContextFromRoot(*context);
+  visualizer_->Publish(vis_context);
+
+  /* Confirm that messages were sent.  */
+  MessageResults results = ProcessMessages();
+  ASSERT_EQ(results.num_load, 1);
+  ASSERT_EQ(results.num_draw, 1);
+}
+
 /* When targeting a non-illustration role, if that same geometry *has* an
  illustration role with color, that value is used instead of the default.  */
 TEST_F(DrakeVisualizerTest, GeometryWithIllustrationFallback) {


### PR DESCRIPTION
This enables calls to DrakeVisualizer::Publish(context) to broadcast the draw message (with a load message as necessary). This enables the workflow where users can publish arbitrary configurations as defined in contexts (independent of the simulator).

relates to #13597, #14282

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14304)
<!-- Reviewable:end -->
