### PR TITLE
systems/lcm: Add LcmScopeSystem

### DIFF
--- a/lcmtypes/BUILD.bazel
+++ b/lcmtypes/BUILD.bazel
@@ -235,6 +235,12 @@ drake_lcm_cc_library(
 )
 
 drake_lcm_cc_library(
+    name = "scope",
+    lcm_package = "drake",
+    lcm_srcs = ["lcmt_scope.lcm"],
+)
+
+drake_lcm_cc_library(
     name = "support_data",
     lcm_package = "drake",
     lcm_srcs = ["lcmt_support_data.lcm"],
@@ -384,6 +390,7 @@ LCMTYPES_CC = [
     ":qp_input",
     ":resolved_contact",
     ":schunk",
+    ":scope",
     ":support_data",
     ":viewer",
     ":viewer2_comms",

--- a/lcmtypes/lcmt_scope.lcm
+++ b/lcmtypes/lcmt_scope.lcm
@@ -1,0 +1,11 @@
+package drake;
+
+// The message type for LcmScopeSystem.
+struct lcmt_scope {
+  // The timestamp in microseconds.
+  int64_t utime;
+
+  // The scoped value.
+  int32_t size;
+  double value[size];
+}

--- a/systems/lcm/BUILD.bazel
+++ b/systems/lcm/BUILD.bazel
@@ -19,6 +19,7 @@ drake_cc_package_library(
         ":lcm_log_playback_system",
         ":lcm_publisher_system",
         ":lcm_pubsub_system",
+        ":lcm_scope_system",
         ":lcm_subscriber_system",
         ":serializer",
     ],
@@ -57,6 +58,19 @@ drake_cc_library(
     deps = [
         ":serializer",
         "//lcm:drake_lcm",
+        "//systems/framework:leaf_system",
+    ],
+)
+
+drake_cc_library(
+    name = "lcm_scope_system",
+    srcs = ["lcm_scope_system.cc"],
+    hdrs = ["lcm_scope_system.h"],
+    deps = [
+        ":lcm_publisher_system",
+        "//lcm:interface",
+        "//lcmtypes:scope",
+        "//systems/framework:diagram_builder",
         "//systems/framework:leaf_system",
     ],
 )
@@ -140,6 +154,19 @@ drake_cc_googletest(
         "//lcmtypes:drake_signal",
         "//systems/analysis:simulator",
         "//systems/framework:diagram_builder",
+    ],
+)
+
+drake_cc_googletest(
+    name = "lcm_scope_system_test",
+    deps = [
+        ":lcm_interface_system",
+        ":lcm_scope_system",
+        "//lcmtypes:scope",
+        "//systems/analysis:simulator",
+        "//systems/framework:diagram",
+        "//systems/framework:diagram_builder",
+        "//systems/primitives:sine",
     ],
 )
 

--- a/systems/lcm/connect_lcm_scope.h
+++ b/systems/lcm/connect_lcm_scope.h
@@ -9,7 +9,12 @@ namespace drake {
 namespace systems {
 namespace lcm {
 
+// TODO(jwnimmer-tri) Add DRAKE_DEPRECATED onto here as of 2021-01-01 or so,
+// with the removal date the usual +3 months after the marker gets added.
 /**
+ (To be deprecated.) Prefer to use LcmScopeSystem::AddToBuilder instead of
+ this function; the LcmScopeSystem provides more detailed timestamps.
+
  Provides the ability to publish any vector-valued output port to the LCM
  @p channel, using the drake::lcmt_drake_signal LCM message type, by adding
  an appropriate LcmPublisherSystem to the @p builder.  If @p lcm is

--- a/systems/lcm/lcm_scope_system.cc
+++ b/systems/lcm/lcm_scope_system.cc
@@ -1,0 +1,58 @@
+#include "drake/systems/lcm/lcm_scope_system.h"
+
+#include <memory>
+
+#include "drake/common/drake_throw.h"
+#include "drake/lcmt_scope.hpp"
+
+namespace drake {
+namespace systems {
+namespace lcm {
+namespace {
+
+void Convert(
+    const double time,
+    const Eigen::VectorBlock<const VectorX<double>>& input,
+    lcmt_scope* output) {
+  output->utime = static_cast<int64_t>(time * 1e6);
+  output->size = input.size();
+  output->value.resize(output->size);
+  for (int i = 0; i < output->size; ++i) {
+    output->value[i] = input[i];
+  }
+}
+
+}  // namespace
+
+LcmScopeSystem::LcmScopeSystem(int size) {
+  const InputPort<double>& input_port = this->DeclareVectorInputPort(
+      "input", BasicVector<double>(size));
+  this->DeclareAbstractOutputPort(
+      "output",
+      []() { return std::make_unique<Value<lcmt_scope>>(lcmt_scope{}); },
+      [&input_port](const Context<double>& context, AbstractValue* output) {
+        const auto& input = input_port.Eval(context);
+        auto& message = output->get_mutable_value<lcmt_scope>();
+        Convert(context.get_time(), input, &message);
+      });
+}
+
+std::tuple<LcmScopeSystem*, LcmPublisherSystem*> LcmScopeSystem::AddToBuilder(
+    systems::DiagramBuilder<double>* builder,
+    drake::lcm::DrakeLcmInterface* lcm,
+    const OutputPort<double>& signal,
+    const std::string& channel,
+    double publish_period) {
+  DRAKE_THROW_UNLESS(builder != nullptr);
+  DRAKE_THROW_UNLESS(lcm != nullptr);
+  auto* scope = builder->AddSystem<LcmScopeSystem>(signal.size());
+  builder->Connect(signal, scope->get_input_port());
+  auto* publisher = builder->AddSystem(LcmPublisherSystem::Make<lcmt_scope>(
+      channel, lcm, publish_period));
+  builder->Connect(*scope, *publisher);
+  return {scope, publisher};
+}
+
+}  // namespace lcm
+}  // namespace systems
+}  // namespace drake

--- a/systems/lcm/lcm_scope_system.h
+++ b/systems/lcm/lcm_scope_system.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <string>
+#include <tuple>
+
+#include "drake/lcm/drake_lcm_interface.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/framework/leaf_system.h"
+#include "drake/systems/lcm/lcm_publisher_system.h"
+
+namespace drake {
+namespace systems {
+namespace lcm {
+
+/** %LcmScopeSystem provides the ability to convert any vector output port to a
+simple LCM message and publish that message periodically. The intention is to
+instrument complex diagrams using external tools like `lcm-spy`.
+
+@ingroup message_passing */
+class LcmScopeSystem final : public LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LcmScopeSystem)
+
+  /** (Advanced.) Most users will use AddToBuilder instead of this constructor.
+  On its own, this constructor does not publish anything.
+
+  Creates a system with one input port and one output port. The input accepts
+  a vector of the given `size`. The output produces an lcmt_scope message. */
+  explicit LcmScopeSystem(int size);
+
+  /** Adds an LcmScopeSystem and LcmPublisherSystem to the given `builder`.
+
+  @param[in] lcm A pointer to the LCM subsystem to use, which must remain valid
+  for the lifetime of `builder`. This will typically be an instance of an
+  LcmInterfaceSystem that's already been added to the `builder`.
+
+  @param[in] signal The output port to be scoped.  Must be an OutputPort of a
+  system that's already been added to the `builder`.
+
+  @param[in] channel The LCM channel on which to publish.
+
+  @param[in] publish_period Specifies how often messages will be published.
+  If the period is zero, the LcmPublisherSystem will publish every step. */
+  static std::tuple<LcmScopeSystem*, LcmPublisherSystem*> AddToBuilder(
+      systems::DiagramBuilder<double>* builder,
+      drake::lcm::DrakeLcmInterface* lcm,
+      const OutputPort<double>& signal,
+      const std::string& channel,
+      double publish_period);
+};
+
+}  // namespace lcm
+}  // namespace systems
+}  // namespace drake

--- a/systems/lcm/test/lcm_scope_system_test.cc
+++ b/systems/lcm/test/lcm_scope_system_test.cc
@@ -1,0 +1,64 @@
+#include "drake/systems/lcm/lcm_scope_system.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/lcmt_scope.hpp"
+#include "drake/systems/analysis/simulator.h"
+#include "drake/systems/framework/diagram.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/lcm/lcm_interface_system.h"
+#include "drake/systems/primitives/sine.h"
+
+namespace drake {
+namespace systems {
+namespace lcm {
+namespace {
+
+// Scope a Sine and check the output.
+GTEST_TEST(ScopeTest, Acceptance) {
+  // Set up the diagram.
+  const std::string channel = "CHANNEL";
+  const double publish_period = 0.25;
+  DiagramBuilder<double> builder;
+  auto lcm = builder.AddSystem<LcmInterfaceSystem>();
+  auto source = builder.AddSystem<Sine>(
+      Eigen::Vector2d(1.0,        2.0),          // amplitudes
+      Eigen::Vector2d(2.0 * M_PI, 2 * M_PI),     // frequencies = 1 rev / sec
+      Eigen::Vector2d(0.0,        0.5 * M_PI));  // phases
+  auto [scope, publisher] = LcmScopeSystem::AddToBuilder(
+      &builder, lcm, source->get_output_port(0), channel, publish_period);
+  ASSERT_NE(scope, nullptr);
+  ASSERT_NE(publisher, nullptr);
+
+  // Simulate and listen for received messages.
+  drake::lcm::Subscriber<lcmt_scope> subscriber(lcm, channel);
+  Simulator<double> simulator(builder.Build());
+
+  // When time == 0.0.
+  simulator.AdvanceTo(0.0);
+  lcm->HandleSubscriptions(0);
+  ASSERT_EQ(subscriber.count(), 1);
+  ASSERT_EQ(subscriber.message().size, 2);
+  EXPECT_NEAR(subscriber.message().value[0], 0.0, 1e-10);
+  EXPECT_NEAR(subscriber.message().value[1], 2.0, 1e-10);
+  subscriber.clear();
+
+  // When we approach time == publish_period (but don't cross it yet).
+  simulator.AdvanceTo(0.99 * publish_period);
+  lcm->HandleSubscriptions(0);
+  ASSERT_EQ(subscriber.count(), 0);
+
+  // When we reach time == publish_period exactly.
+  simulator.AdvanceTo(publish_period);
+  lcm->HandleSubscriptions(0);
+  ASSERT_EQ(subscriber.count(), 1);
+  ASSERT_EQ(subscriber.message().size, 2);
+  EXPECT_NEAR(subscriber.message().value[0], 1.0, 1e-10);
+  EXPECT_NEAR(subscriber.message().value[1], 0.0, 1e-10);
+  subscriber.clear();
+}
+
+}  // namespace
+}  // namespace lcm
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
This provides a rewrite of LCM scoping using a new message type, so that we can get microsecond timestamps instead of milliseconds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14308)
<!-- Reviewable:end -->
