### PR TITLE
Remove usage of unintialized values.

### DIFF
--- a/multibody/fem/dev/BUILD.bazel
+++ b/multibody/fem/dev/BUILD.bazel
@@ -191,7 +191,6 @@ drake_cc_library(
 
 drake_cc_googletest(
     name = "fem_elasticity_test",
-    tags = ["manual"],  # Currently fails valgrind.
     deps = [
         ":fem_elasticity",
         ":fem_state",
@@ -206,7 +205,6 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "fem_state_test",
-    tags = ["manual"],  # Currently fails valgrind.
     deps = [
         ":element_cache",
         ":fem_state",
@@ -225,7 +223,6 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "linear_elasticity_model_cache_test",
-    tags = ["manual"],  # Currently fails valgrind.
     deps = [
         ":linear_elasticity_model_cache",
         "//common/test_utilities:expect_throws_message",

--- a/multibody/fem/dev/deformation_gradient_cache.h
+++ b/multibody/fem/dev/deformation_gradient_cache.h
@@ -75,7 +75,7 @@ class DeformationGradientCache {
   DeformationGradientCache(ElementIndex element_index, int num_quads)
       : element_index_(element_index),
         num_quads_(num_quads),
-        deformation_gradient_(num_quads) {
+        deformation_gradient_(num_quads, Matrix3<T>::Identity()) {
     DRAKE_ASSERT(element_index.is_valid());
     DRAKE_ASSERT(num_quads > 0);
   }

--- a/multibody/fem/dev/linear_elasticity_model_cache.h
+++ b/multibody/fem/dev/linear_elasticity_model_cache.h
@@ -38,8 +38,8 @@ class LinearElasticityModelCache : public DeformationGradientCache<T> {
    @pre `num_quads` must be positive. */
   LinearElasticityModelCache(ElementIndex element_index, int num_quads)
       : DeformationGradientCache<T>(element_index, num_quads),
-        strain_(num_quads),
-        trace_strain_(num_quads) {}
+        strain_(num_quads, Matrix3<T>::Zero()),
+        trace_strain_(num_quads, 0) {}
 
   /** Returns the infinitesimal strains evaluated at the quadrature locations
    for the associated element. */

--- a/multibody/fem/dev/test/fem_state_test.cc
+++ b/multibody/fem/dev/test/fem_state_test.cc
@@ -29,23 +29,14 @@ class MyElementCache final : public ElementCache<double> {
 class FemStateTest : public ::testing::Test {
  protected:
   void SetUp() {
-    state_ = std::make_unique<FemState<double>>(kDof);
+    state_ = std::make_unique<FemState<double>>(q(), qdot());
     // Create a couple of cache entries.
     state_->ResetElementCache(MakeElementCache());
-    // Set default states.
-    SetStates();
   }
 
   // Default values for the first kDof state entries.
   VectorX<double> qdot() const { return Vector3<double>(0.3, 0.4, 0.5); }
   VectorX<double> q() const { return Vector3<double>(0.7, 0.8, 0.9); }
-
-  // Set the states to default values.
-  void SetStates() {
-    // Set all states to their default values.
-    state_->set_qdot(qdot());
-    state_->set_q(q());
-  }
 
   std::vector<std::unique_ptr<ElementCache<double>>> MakeElementCache() const {
     std::vector<std::unique_ptr<ElementCache<double>>> cache;
@@ -62,15 +53,13 @@ class FemStateTest : public ::testing::Test {
 };
 
 // Verify setters and getters are working properly.
-TEST_F(FemStateTest, SetAndGet) {
-  SetStates();
+TEST_F(FemStateTest, GetStates) {
   EXPECT_EQ(state_->qdot(), qdot());
   EXPECT_EQ(state_->q(), q());
 }
 
 // Verify resizing does not thrash existing values.
 TEST_F(FemStateTest, ConservativeResize) {
-  SetStates();
   state_->Resize(2 * kDof);
   // The first kDof entres should remain unchanged.
   EXPECT_EQ(state_->qdot().head(kDof), qdot());
@@ -93,7 +82,8 @@ TEST_F(FemStateTest, Clone) {
 }
 
 TEST_F(FemStateTest, SetFrom) {
-  FemState<double> dest;
+  // Set up an arbitrary state.
+  FemState<double> dest(VectorX<double>::Zero(1), VectorX<double>::Zero(1));
   dest.SetFrom(*state_);
   EXPECT_EQ(dest.qdot(), qdot());
   EXPECT_EQ(dest.q(), q());

--- a/multibody/fem/dev/test/linear_elasticity_model_cache_test.cc
+++ b/multibody/fem/dev/test/linear_elasticity_model_cache_test.cc
@@ -11,8 +11,18 @@ constexpr int kNumQuads = 1;
 
 class LinearElasticityCacheTest : public ::testing::Test {
  protected:
+  void SetUp() {
+    linear_elasticity_cache_.UpdateCache({MakeDeformationGradient()});
+  }
   LinearElasticityModelCache<double> linear_elasticity_cache_{kElementIndex,
                                                               kNumQuads};
+
+  // Make an arbitrary deformation gradient.
+  Matrix3<double> MakeDeformationGradient() {
+    Matrix3<double> F;
+    F << 1.2, 2.3, 3.4, 4.5, 5.6, 6.7, 7.8, 8.9, 9.0;
+    return F;
+  }
 };
 
 TEST_F(LinearElasticityCacheTest, LinearElasticityCacheInitialization) {
@@ -24,8 +34,7 @@ TEST_F(LinearElasticityCacheTest, LinearElasticityCacheInitialization) {
 }
 
 TEST_F(LinearElasticityCacheTest, UpdateCache) {
-  const Matrix3<double> F = Matrix3<double>::Random();
-  linear_elasticity_cache_.UpdateCache({F});
+  const Matrix3<double> F = MakeDeformationGradient();
   const Matrix3<double> strain =
       0.5 * (F + F.transpose()) - Matrix3<double>::Identity();
   const double trace_strain = strain.trace();


### PR DESCRIPTION
Remove usage of uninitialized values in FemState and
LinearElasticityModelCacheTest. Fixes issue #14312.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14313)
<!-- Reviewable:end -->
