### PR TITLE
[pybind] Correct bindings for DrakeVisualizer.AddToBuilder

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -1009,7 +1009,7 @@ void DoScalarIndependentDefinitions(py::module m) {
       py::arg("role") = geometry::Role::kIllustration,
       // Keep alive, ownership: `return` keeps `builder` alive.
       py::keep_alive<0, 1>(),
-      // Keep alive, ownership: `builder` keeps `lcm` alive.
+      // Keep alive, reference: `builder` keeps `lcm` alive.
       py::keep_alive<1, 3>(),
       // See #11531 for why `py_rvp::reference` is needed.
       py_rvp::reference, doc.ConnectDrakeVisualizer.doc_deprecated_4args);
@@ -1024,7 +1024,7 @@ void DoScalarIndependentDefinitions(py::module m) {
       py::arg("role") = geometry::Role::kIllustration,
       // Keep alive, ownership: `return` keeps `builder` alive.
       py::keep_alive<0, 1>(),
-      // Keep alive, ownership: `builder` keeps `lcm` alive.
+      // Keep alive, reference: `builder` keeps `lcm` alive.
       py::keep_alive<1, 3>(),
       // See #11531 for why `py_rvp::reference` is needed.
       py_rvp::reference, doc.ConnectDrakeVisualizer.doc_deprecated_5args);
@@ -1069,8 +1069,8 @@ void DoScalarIndependentDefinitions(py::module m) {
             py::arg("params") = DrakeVisualizerParams{},
             // Keep alive, ownership: `return` keeps `builder` alive.
             py::keep_alive<0, 1>(),
-            // Keep alive, reference: `return` keeps `lcm` alive.
-            py::keep_alive<0, 3>(), py_rvp::reference,
+            // Keep alive, reference: `builder` keeps `lcm` alive.
+            py::keep_alive<1, 3>(), py_rvp::reference,
             cls_doc.AddToBuilder.doc_4args_builder_scene_graph_lcm_params)
         .def_static("AddToBuilder",
             py::overload_cast<systems::DiagramBuilder<double>*,
@@ -1081,8 +1081,8 @@ void DoScalarIndependentDefinitions(py::module m) {
             py::arg("params") = DrakeVisualizerParams{},
             // Keep alive, ownership: `return` keeps `builder` alive.
             py::keep_alive<0, 1>(),
-            // Keep alive, reference: `return` keeps `lcm` alive.
-            py::keep_alive<0, 3>(), py_rvp::reference,
+            // Keep alive, reference: `builder` keeps `lcm` alive.
+            py::keep_alive<1, 3>(), py_rvp::reference,
             cls_doc.AddToBuilder.doc_4args_builder_query_object_port_lcm_params)
         .def_static("DispatchLoadMessage",
             &DrakeVisualizer::DispatchLoadMessage, py::arg("scene_graph"),


### PR DESCRIPTION
Previously, we had the return value keeping the provided lcm alive. If the return value isn't *captured* (e.g. vis = DrakeVis.AddToBuilder(....)) then that keep alive won't work and the lcm can be subsequently destroyed. This has been observed in the wild.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14314)
<!-- Reviewable:end -->
