### PR TITLE
Add FemModel and the concrete ElasticityModel.

### DIFF
--- a/multibody/fem/dev/BUILD.bazel
+++ b/multibody/fem/dev/BUILD.bazel
@@ -35,6 +35,37 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "elasticity_element",
+    srcs = [
+        "elasticity_element.cc",
+    ],
+    hdrs = [
+        "elasticity_element.h",
+    ],
+    deps = [
+        ":constitutive_model",
+        ":elasticity_element_base",
+        ":elasticity_element_cache",
+        ":linear_simplex_element",
+        ":quadrature",
+        "//common:default_scalars",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "elasticity_element_base",
+    hdrs = [
+        "elasticity_element_base.h",
+    ],
+    deps = [
+        ":fem_element",
+        ":fem_state",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
     name = "elasticity_element_cache",
     hdrs = [
         "elasticity_element_cache.h",
@@ -43,6 +74,26 @@ drake_cc_library(
         ":deformation_gradient_cache",
         ":element_cache",
         "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "elasticity_model",
+    srcs = [
+        "elasticity_model.cc",
+    ],
+    hdrs = [
+        "elasticity_model.h",
+    ],
+    deps = [
+        ":constitutive_model",
+        ":elasticity_element",
+        ":elasticity_element_base",
+        ":fem_model",
+        ":linear_simplex_element",
+        ":quadrature",
+        "//common:essential",
+        "//geometry/proximity:volume_mesh",
     ],
 )
 
@@ -58,26 +109,6 @@ drake_cc_library(
 )
 
 drake_cc_library(
-    name = "elasticity_element",
-    srcs = [
-        "elasticity_element.cc",
-    ],
-    hdrs = [
-        "elasticity_element.h",
-    ],
-    deps = [
-        ":constitutive_model",
-        ":elasticity_element_cache",
-        ":fem_element",
-        ":isoparametric_element",
-        ":linear_simplex_element",
-        ":quadrature",
-        "//common:default_scalars",
-        "//common:essential",
-    ],
-)
-
-drake_cc_library(
     name = "fem_element",
     srcs = [
         "fem_element.cc",
@@ -86,10 +117,7 @@ drake_cc_library(
         "fem_element.h",
     ],
     deps = [
-        ":constitutive_model",
         ":fem_state",
-        ":isoparametric_element",
-        ":quadrature",
         "//common:default_scalars",
         "//common:essential",
     ],
@@ -103,6 +131,22 @@ drake_cc_library(
     deps = [
         "//common:essential",
         "//common:type_safe_index",
+    ],
+)
+
+drake_cc_library(
+    name = "fem_model",
+    srcs = [
+        "fem_model.cc",
+    ],
+    hdrs = [
+        "fem_model.h",
+    ],
+    deps = [
+        ":fem_element",
+        ":fem_state",
+        "//common:default_scalars",
+        "//common:essential",
     ],
 )
 
@@ -186,6 +230,18 @@ drake_cc_library(
     deps = [
         "//common:essential",
         "//common:nice_type_name",
+    ],
+)
+
+drake_cc_googletest(
+    name = "elasticity_model_test",
+    deps = [
+        ":elasticity_model",
+        ":linear_elasticity_model",
+        ":linear_simplex_element",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//geometry/proximity:make_box_mesh",
+        "//math:gradient",
     ],
 )
 

--- a/multibody/fem/dev/constitutive_model.h
+++ b/multibody/fem/dev/constitutive_model.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
@@ -17,9 +18,20 @@ namespace fem {
 template <typename T>
 class ConstitutiveModel {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ConstitutiveModel);
+  /** @name     Does not allow copy, move, or assignment. */
+  /** @{ */
+  /* Copy constructor is made "protected" to facilitate Clone() and therefore it
+   is not publicly available. */
+  ConstitutiveModel(ConstitutiveModel&&) = delete;
+  ConstitutiveModel& operator=(ConstitutiveModel&&) = delete;
+  ConstitutiveModel& operator=(const ConstitutiveModel&) = delete;
+  /** @} */
 
   ConstitutiveModel() = default;
+
+  /** Creates an identical copy of the concrete ConstitutiveModel object.
+   */
+  std::unique_ptr<ConstitutiveModel<T>> Clone() const { return DoClone(); }
 
   virtual ~ConstitutiveModel() {}
 
@@ -36,10 +48,10 @@ class ConstitutiveModel {
    passed in matches the %ConstitutiveModel. */
 
   /** Calculates the energy density per unit reference volume, in unit J/m³,
-   * given the model cache. */
+   given the model cache. */
   std::vector<T> CalcElasticEnergyDensity(
       const DeformationGradientCache<T>& cache) const {
-    std::vector<T> Psi(cache.num_quads());
+    std::vector<T> Psi(cache.num_quadrature_points());
     CalcElasticEnergyDensity(cache, &Psi);
     return Psi;
   }
@@ -49,14 +61,15 @@ class ConstitutiveModel {
   void CalcElasticEnergyDensity(const DeformationGradientCache<T>& cache,
                                 std::vector<T>* Psi) const {
     DRAKE_DEMAND(Psi != nullptr);
-    DRAKE_DEMAND(static_cast<int>(Psi->size()) == cache.num_quads());
+    DRAKE_DEMAND(static_cast<int>(Psi->size()) ==
+                 cache.num_quadrature_points());
     DoCalcElasticEnergyDensity(cache, Psi);
   }
 
   /** Calculates the First Piola stress, in unit Pa, given the model cache. */
   std::vector<Matrix3<T>> CalcFirstPiolaStress(
       const DeformationGradientCache<T>& cache) const {
-    std::vector<Matrix3<T>> P(cache.num_quads());
+    std::vector<Matrix3<T>> P(cache.num_quadrature_points());
     CalcFirstPiolaStress(cache, &P);
     return P;
   }
@@ -66,18 +79,45 @@ class ConstitutiveModel {
   void CalcFirstPiolaStress(const DeformationGradientCache<T>& cache,
                             std::vector<Matrix3<T>>* P) const {
     DRAKE_DEMAND(P != nullptr);
-    DRAKE_DEMAND(static_cast<int>(P->size()) == cache.num_quads());
+    DRAKE_DEMAND(static_cast<int>(P->size()) == cache.num_quadrature_points());
     DoCalcFirstPiolaStress(cache, P);
   }
 
+  /** Creates a DeformationGradientCache that is compatible with this
+   %ConstitutiveModel. See ElasticityElement for more about the compatibility
+   requirement. */
+  std::unique_ptr<DeformationGradientCache<T>> MakeDeformationGradientCache(
+      ElementIndex element_index, int num_quadrature_points) const {
+    DRAKE_DEMAND(element_index.is_valid());
+    DRAKE_DEMAND(num_quadrature_points > 0);
+    return DoMakeDeformationGradientCache(element_index, num_quadrature_points);
+  }
+
  protected:
-  /* Calculates the energy density, in unit J/m³, given the model cache. */
+  /** Copy constructor for the base ConstitutiveModel class to facilitate
+   `DoClone()` in derived classes. */
+  ConstitutiveModel(const ConstitutiveModel&) = default;
+
+  /** Creates an identical copy of the concrete ConstitutiveModel object.
+   Derived classes must implement this so that it performs the complete
+   deep copy of the object, including all base class members. */
+  virtual std::unique_ptr<ConstitutiveModel<T>> DoClone() const = 0;
+
+  /** Derived class must calculate the energy density, in unit J/m³, given the
+   model cache. */
   virtual void DoCalcElasticEnergyDensity(
       const DeformationGradientCache<T>& cache, std::vector<T>* Psi) const = 0;
 
-  /* Calculates the First Piola stress, in unit Pa, given the model cache. */
+  /** Derived class must calculate the First Piola stress, in unit Pa, given the
+   model cache. */
   virtual void DoCalcFirstPiolaStress(const DeformationGradientCache<T>& cache,
                                       std::vector<Matrix3<T>>* P) const = 0;
+
+  /** Derived class must create a DeformationGradientCache that is compatible
+   with this ConstitutiveModel. */
+  virtual std::unique_ptr<DeformationGradientCache<T>>
+  DoMakeDeformationGradientCache(ElementIndex element_index,
+                                 int num_quadrature_points) const = 0;
 };
 }  // namespace fem
 }  // namespace multibody

--- a/multibody/fem/dev/deformation_gradient_cache.h
+++ b/multibody/fem/dev/deformation_gradient_cache.h
@@ -43,9 +43,9 @@ class DeformationGradientCache {
   /** Updates the cached quantities with the given deformation gradients.
    @param F The up-to-date deformation gradients evaluated at the quadrature
    locations for the associated element.
-   @pre The size of `F` must be the same as `num_quads()`. */
+   @pre The size of `F` must be the same as `num_quadrature_points()`. */
   void UpdateCache(const std::vector<Matrix3<T>>& F) {
-    DRAKE_ASSERT(static_cast<int>(F.size()) == num_quads_);
+    DRAKE_ASSERT(static_cast<int>(F.size()) == num_quadrature_points_);
     deformation_gradient_ = F;
     DoUpdateCache(F);
   }
@@ -56,7 +56,7 @@ class DeformationGradientCache {
 
   /** The number of quadrature locations at which cached quantities need to be
    evaluated. */
-  int num_quads() const { return num_quads_; }
+  int num_quadrature_points() const { return num_quadrature_points_; }
 
   const std::vector<Matrix3<T>>& deformation_gradient() const {
     return deformation_gradient_;
@@ -69,35 +69,36 @@ class DeformationGradientCache {
    caches (e.g. LinearElasticityModelCache) that invoke the base constructor.
    @param element_index The index of the FemElement associated with this
    DeformationGradientCache.
-   @param num_quads The number of quadrature locations at which cached
-   quantities need to be evaluated.
-   @pre `num_quads` must be positive. */
-  DeformationGradientCache(ElementIndex element_index, int num_quads)
+   @param num_quadrature_points The number of quadrature locations at which
+   cached quantities need to be evaluated.
+   @pre `num_quadrature_points` must be positive. */
+  DeformationGradientCache(ElementIndex element_index,
+                           int num_quadrature_points)
       : element_index_(element_index),
-        num_quads_(num_quads),
-        deformation_gradient_(num_quads, Matrix3<T>::Identity()) {
+        num_quadrature_points_(num_quadrature_points),
+        deformation_gradient_(num_quadrature_points, Matrix3<T>::Identity()) {
     DRAKE_ASSERT(element_index.is_valid());
-    DRAKE_ASSERT(num_quads > 0);
+    DRAKE_ASSERT(num_quadrature_points > 0);
   }
 
-  /* Copy constructor for the base DeformationGradientCache class to facilitate
+  /** Copy constructor for the base DeformationGradientCache class to facilitate
    `DoClone()` in derived classes. */
   DeformationGradientCache(const DeformationGradientCache&) = default;
 
-  /* Creates an identical copy of the concrete DeformationGradientCache object.
+  /** Creates an identical copy of the concrete DeformationGradientCache object.
    Derived classes must implement this so that it performs the complete
    deep copy of the object, including all base class members. */
   virtual std::unique_ptr<DeformationGradientCache<T>> DoClone() const = 0;
 
-  /* Updates the cached quantities with the given deformation gradients.
+  /** Updates the cached quantities with the given deformation gradients.
    @param F The up-to-date deformation gradients evaluated at the quadrature
    locations for the associated element.
-   @pre The size of `F` must be the same as `num_quads()`. */
+   @pre The size of `F` must be the same as `num_quadrature_points()`. */
   virtual void DoUpdateCache(const std::vector<Matrix3<T>>& F) = 0;
 
  private:
   ElementIndex element_index_;
-  int num_quads_{-1};
+  int num_quadrature_points_{-1};
   std::vector<Matrix3<T>> deformation_gradient_;
 };
 }  // namespace fem

--- a/multibody/fem/dev/elasticity_element.cc
+++ b/multibody/fem/dev/elasticity_element.cc
@@ -1,6 +1,7 @@
 #include "drake/multibody/fem/dev/elasticity_element.h"
 
 #include "drake/common/default_scalars.h"
+#include "drake/multibody/fem/dev/elasticity_element_cache.h"
 #include "drake/multibody/fem/dev/linear_simplex_element.h"
 
 namespace drake {
@@ -13,26 +14,19 @@ ElasticityElement<T, IsoparametricElementType, QuadratureType>::
                       const T& density,
                       std::unique_ptr<ConstitutiveModel<T>> constitutive_model,
                       const Matrix3X<T>& reference_positions)
-    : FemElement<T>(element_index, node_indices),
+    : ElasticityElementBase<T>(element_index, node_indices),
       density_(density),
       constitutive_model_(std::move(constitutive_model)),
-      dxidX_(num_quads()),
+      dxidX_(num_quadrature_points()),
       reference_positions_(reference_positions),
-      reference_volume_(num_quads()) {
+      reference_volume_(num_quadrature_points()) {
   /* TODO(xuchenhan-tri): Consider removing the template NaturalDim from
    IsoparametricElement and Quadrature (e.g. with CRTP). */
-  static_assert(std::is_base_of<IsoparametricElement<T, 1>,
-                                IsoparametricElementType>::value ||
-                    std::is_base_of<IsoparametricElement<T, 2>,
-                                    IsoparametricElementType>::value ||
-                    std::is_base_of<IsoparametricElement<T, 3>,
-                                    IsoparametricElementType>::value,
-                "IsoparametricElementType must be a derived class of "
-                "IsoparametricElement<T, NaturalDim>, where NaturalDim can "
-                "be 1, 2 or 3.");
-  static_assert(std::is_base_of<Quadrature<T, 1>, QuadratureType>::value ||
-                    std::is_base_of<Quadrature<T, 2>, QuadratureType>::value ||
-                    std::is_base_of<Quadrature<T, 3>, QuadratureType>::value,
+  static_assert(is_isoparametric_element<IsoparametricElementType>::value,
+      "IsoparametricElementType must be a derived class of "
+      "IsoparametricElement<T, NaturalDim>, where NaturalDim can "
+      "be 1, 2 or 3.");
+  static_assert(is_quadrature<QuadratureType>::value,
                 "QuadratureType must be a derived class of "
                 "Quadrature<T, NaturalDim>, where NaturalDim can "
                 "be 1, 2 or 3.");
@@ -45,7 +39,7 @@ ElasticityElement<T, IsoparametricElementType, QuadratureType>::
   // Record the quadrature point volumes for the new element.
   const std::vector<MatrixX<T>> dXdxi =
       shape_.CalcJacobian(reference_positions);
-  for (int q = 0; q < num_quads(); ++q) {
+  for (int q = 0; q < num_quadrature_points(); ++q) {
     // The scale to transform quadrature weight in parent coordinates to
     // reference coordinates.
     T volume_scale;
@@ -70,9 +64,20 @@ ElasticityElement<T, IsoparametricElementType, QuadratureType>::
   // Record the inverse Jacobian at the reference configuration which is used in
   // the calculation of deformation gradient.
   const std::vector<MatrixX<T>> dxidX = shape_.CalcJacobianInverse(dXdxi);
-  for (int q = 0; q < num_quads(); ++q) {
+  for (int q = 0; q < num_quadrature_points(); ++q) {
     dxidX_[q] = Eigen::Ref<const MatrixD3>(dxidX[q]);
   }
+}
+
+template <typename T, class IsoparametricElementType, class QuadratureType>
+std::unique_ptr<ElementCache<T>> ElasticityElement<
+    T, IsoparametricElementType, QuadratureType>::MakeElementCache() const {
+  std::unique_ptr<DeformationGradientCache<T>> deformation_gradient_cache =
+      constitutive_model_->MakeDeformationGradientCache(
+          this->element_index(), this->num_quadrature_points());
+  return std::make_unique<ElasticityElementCache<T>>(
+      this->element_index(), this->num_quadrature_points(),
+      std::move(deformation_gradient_cache));
 }
 
 template <typename T, class IsoparametricElementType, class QuadratureType>
@@ -83,9 +88,9 @@ T ElasticityElement<T, IsoparametricElementType,
   // TODO(xuchenhan-tri): Use the corresponding Eval method when cache is in
   // place.
   // TODO(xuchenhan-tri): Use fixed size array here.
-  std::vector<T> Psi(num_quads());
+  std::vector<T> Psi(num_quadrature_points());
   CalcElasticEnergyDensity(s, &Psi);
-  for (int q = 0; q < num_quads(); ++q) {
+  for (int q = 0; q < num_quadrature_points(); ++q) {
     elastic_energy += reference_volume_[q] * Psi[q];
   }
   return elastic_energy;
@@ -111,11 +116,11 @@ void ElasticityElement<T, IsoparametricElementType, QuadratureType>::
       Eigen::Map<Matrix3X<T>>(neg_force->data(), 3, num_nodes());
   // TODO(xuchenhan-tri): Use the corresponding Eval method when cache is in
   // place.
-  std::vector<Matrix3<T>> P(num_quads());
+  std::vector<Matrix3<T>> P(num_quadrature_points());
   CalcFirstPiolaStress(state, &P);
   const std::vector<MatrixX<T>>& dSdxi =
       shape_.CalcGradientInParentCoordinates();
-  for (int q = 0; q < num_quads(); ++q) {
+  for (int q = 0; q < num_quadrature_points(); ++q) {
     /* Negative force is the gradient of energy.
      -f = ∫dΨ/dx = ∫dΨ/dF : dF/dx dX.
      Notice that Fᵢⱼ = xₐᵢdSₐ/dXⱼ, so dFᵢⱼ/dxᵦₖ = δₐᵦδᵢₖdSₐ/dXⱼ,
@@ -130,7 +135,7 @@ template <typename T, class IsoparametricElementType, class QuadratureType>
 void ElasticityElement<T, IsoparametricElementType, QuadratureType>::
     CalcDeformationGradient(const FemState<T>& state,
                             std::vector<Matrix3<T>>* F) const {
-  F->resize(num_quads());
+  F->resize(num_quadrature_points());
   // TODO(xuchenhan-tri): Consider abstracting this potential common operation
   // into FemElement.
   Matrix3X<T> element_x(3, num_nodes());
@@ -141,7 +146,7 @@ void ElasticityElement<T, IsoparametricElementType, QuadratureType>::
     element_x.col(i) = x.col(this->node_indices()[i]);
   }
   const std::vector<MatrixX<T>> dxdxi = shape_.CalcJacobian(element_x);
-  for (int q = 0; q < num_quads(); ++q) {
+  for (int q = 0; q < num_quadrature_points(); ++q) {
     (*F)[q] = dxdxi[q] * dxidX_[q];
   }
 }
@@ -155,8 +160,8 @@ ElasticityElement<T, IsoparametricElementType, QuadratureType>::
           state.mutable_element_cache(this->element_index()));
   DeformationGradientCache<T>& deformation_gradient_cache =
       mutable_cache.mutable_deformation_gradient_cache();
-  // TODO(xuchenhan-tri): Enable cahing when caching is in place.
-  std::vector<Matrix3<T>> F(num_quads());
+  // TODO(xuchenhan-tri): Enable caching when caching is in place.
+  std::vector<Matrix3<T>> F(num_quadrature_points());
   CalcDeformationGradient(state, &F);
   deformation_gradient_cache.UpdateCache(F);
   return deformation_gradient_cache;
@@ -166,7 +171,7 @@ template <typename T, class IsoparametricElementType, class QuadratureType>
 void ElasticityElement<T, IsoparametricElementType, QuadratureType>::
     CalcElasticEnergyDensity(const FemState<T>& state,
                              std::vector<T>* Psi) const {
-  Psi->resize(num_quads());
+  Psi->resize(num_quadrature_points());
   const DeformationGradientCache<T>& deformation_gradient_cache =
       EvalDeformationGradientCache(state);
   constitutive_model_->CalcElasticEnergyDensity(deformation_gradient_cache,
@@ -177,9 +182,7 @@ template <typename T, class IsoparametricElementType, class QuadratureType>
 void ElasticityElement<T, IsoparametricElementType, QuadratureType>::
     CalcFirstPiolaStress(const FemState<T>& state,
                          std::vector<Matrix3<T>>* P) const {
-  P->resize(num_quads());
-  // TODO(xuchenhan-tri): Use the corresponding Eval method when cache is in
-  // place.
+  P->resize(num_quadrature_points());
   const DeformationGradientCache<T>& deformation_gradient_cache =
       EvalDeformationGradientCache(state);
   constitutive_model_->CalcFirstPiolaStress(deformation_gradient_cache, P);
@@ -189,6 +192,16 @@ template class ElasticityElement<double, LinearSimplexElement<double, 3>,
 template class ElasticityElement<AutoDiffXd,
                                  LinearSimplexElement<AutoDiffXd, 3>,
                                  SimplexGaussianQuadrature<AutoDiffXd, 1, 3>>;
+template class ElasticityElement<double, LinearSimplexElement<double, 3>,
+                                 SimplexGaussianQuadrature<double, 2, 3>>;
+template class ElasticityElement<AutoDiffXd,
+                                 LinearSimplexElement<AutoDiffXd, 3>,
+                                 SimplexGaussianQuadrature<AutoDiffXd, 2, 3>>;
+template class ElasticityElement<double, LinearSimplexElement<double, 3>,
+                                 SimplexGaussianQuadrature<double, 3, 3>>;
+template class ElasticityElement<AutoDiffXd,
+                                 LinearSimplexElement<AutoDiffXd, 3>,
+                                 SimplexGaussianQuadrature<AutoDiffXd, 3, 3>>;
 }  // namespace fem
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/fem/dev/elasticity_element_base.h
+++ b/multibody/fem/dev/elasticity_element_base.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/multibody/fem/dev/fem_element.h"
+#include "drake/multibody/fem/dev/fem_state.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+// TODO(xuchenhan-tri): Remove this class after issue #14302 is resolved.
+/** %ElasticityElementBase serves two purposes.
+ 1. It provides non-templatized ElasticityElement functionalities shared by the
+templatized derived classes.
+ 2. It provides non-templatized API's specific to ElasticityElement that do not
+exist in FemElement. */
+template <typename T>
+class ElasticityElementBase : public FemElement<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ElasticityElementBase);
+
+  virtual ~ElasticityElementBase() = default;
+
+  /** The number of dimensions of the elasticity problem. */
+  int solution_dimension() const final { return 3; }
+
+  /** Returns the elastic potential energy stored in this element in unit J. */
+  virtual T CalcElasticEnergy(const FemState<T>& state) const = 0;
+
+ protected:
+  ElasticityElementBase(ElementIndex element_index,
+                        const std::vector<NodeIndex>& node_indices)
+      : FemElement<T>(element_index, node_indices) {}
+};
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/dev/elasticity_element_cache.h
+++ b/multibody/fem/dev/elasticity_element_cache.h
@@ -12,8 +12,8 @@
 namespace drake {
 namespace multibody {
 namespace fem {
-/** Cached quantities per element that are used in the element routine
- ElasticityElement. Implements the abstract interface ElementCache.
+/** Cached quantities per element that are used in ElasticityElement. Implements
+ the abstract interface ElementCache.
 
  See ElasticityElement for the corresponding FemElement for
  %ElasticityElementCache.
@@ -23,8 +23,8 @@ class ElasticityElementCache : public ElementCache<T> {
  public:
   /** @name     Does not allow copy, move, or assignment. */
   /** @{ */
-  /* Copy constructor is used only to facilitate implementation of Clone()
-   in derived classes. */
+  /* Copy constructor is made "protected" to facilitate Clone() and therefore it
+   is not publicly available. */
   ElasticityElementCache(ElasticityElementCache&&) = delete;
   ElasticityElementCache& operator=(ElasticityElementCache&&) = delete;
   ElasticityElementCache& operator=(const ElasticityElementCache&) = delete;
@@ -33,12 +33,12 @@ class ElasticityElementCache : public ElementCache<T> {
   /** Constructs a new %ElasticityElementCache.
    @param element_index The index of the ElasticityElement associated with this
    %ElasticityElementCache.
-   @param num_quads The number of quadrature locations at which cached
-   quantities need to be evaluated.
+   @param num_quadrature_points The number of quadrature locations at which
+   cached quantities need to be evaluated.
    @param deformation_gradient_cache The DeformationGradientCache associated
    with this element. Must be compatible with the ConstitutiveModel in the
    ElasticityElement routine corresponding to this %ElasticityElementCache.
-   @pre `num_quads` must be positive.
+   @pre `num_quadrature_points` must be positive.
    @warning The input `deformation_gradient_cache` must be compatible with the
    ConstitutiveModel in the ElasticityElement that shares the same element index
    with this %ElasticityElementCache. More specifically, if the
@@ -46,9 +46,9 @@ class ElasticityElementCache : public ElementCache<T> {
    "FooModel", then the input `deformation_gradient_cache` must be of type
    "FooModelCache". */
   ElasticityElementCache(
-      ElementIndex element_index, int num_quads,
+      ElementIndex element_index, int num_quadrature_points,
       std::unique_ptr<DeformationGradientCache<T>> deformation_gradient_cache)
-      : ElementCache<T>(element_index, num_quads),
+      : ElementCache<T>(element_index, num_quadrature_points),
         deformation_gradient_cache_(std::move(deformation_gradient_cache)) {}
 
   virtual ~ElasticityElementCache() = default;
@@ -67,7 +67,7 @@ class ElasticityElementCache : public ElementCache<T> {
   }
   /** @} */
 
- protected:
+ private:
   /* Copy constructor to facilitate the `DoClone()` method. */
   ElasticityElementCache(const ElasticityElementCache&) = default;
 
@@ -78,7 +78,6 @@ class ElasticityElementCache : public ElementCache<T> {
         new ElasticityElementCache<T>(*this));
   }
 
- private:
   copyable_unique_ptr<DeformationGradientCache<T>> deformation_gradient_cache_;
 };
 }  // namespace fem

--- a/multibody/fem/dev/elasticity_model.cc
+++ b/multibody/fem/dev/elasticity_model.cc
@@ -1,0 +1,39 @@
+#include "drake/multibody/fem/dev/elasticity_model.h"
+
+#include "drake/multibody/fem/dev/linear_simplex_element.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+template <typename T>
+T ElasticityModel<T>::CalcElasticEnergy(const FemState<T>& state) const {
+  T energy(0);
+  for (ElementIndex element_index(0); element_index < this->num_elements();
+       ++element_index) {
+    const ElasticityElementBase<T>& e =
+        this->get_elasticity_element_base(element_index);
+    energy += e.CalcElasticEnergy(state);
+  }
+  return energy;
+}
+
+template <typename T>
+std::unique_ptr<FemState<T>> ElasticityModel<T>::DoMakeFemState() const {
+  const int num_nodes = this->num_nodes();
+  VectorX<T> q(this->num_dofs());
+  for (int i = 0; i < num_nodes; ++i) {
+    const Vector3<T>& q_WP = reference_positions_.at(NodeIndex(i));
+    q.template segment<3>(3 * i) = q_WP;
+  }
+  /* Velocity of the nodes are set to zero. If nonzero initial velocity is
+   desired, set it with SetInitialVelocity(). */
+  // TODO(xuchenhan-tri): Add SetInitialVelocity() to support configuring
+  // initial velocities.
+  const VectorX<T> qdot = VectorX<T>::Zero(this->num_dofs());
+  return std::make_unique<FemState<T>>(q, qdot);
+}
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fem::ElasticityModel);

--- a/multibody/fem/dev/elasticity_model.h
+++ b/multibody/fem/dev/elasticity_model.h
@@ -1,0 +1,195 @@
+#pragma once
+
+#include <memory>
+#include <set>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "drake/common/eigen_types.h"
+#include "drake/geometry/proximity/volume_mesh.h"
+#include "drake/multibody/fem/dev/elasticity_element.h"
+#include "drake/multibody/fem/dev/elasticity_element_base.h"
+#include "drake/multibody/fem/dev/elasticity_element_cache.h"
+#include "drake/multibody/fem/dev/fem_model.h"
+#include "drake/multibody/fem/dev/linear_simplex_element.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+/** The FEM model for static and dynamic 3D elasticity problems. Implements the
+ abstract interface of FemModel.
+ @tparam_nonsymbolic_scalar T. */
+template <typename T>
+class ElasticityModel : public FemModel<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ElasticityModel);
+
+  ElasticityModel() = default;
+
+  /** The number of dimensions of the elasticity problem. */
+  int solution_dimension() const final { return 3; }
+
+  /** Add ElasticityElement's to the %ElasticityModel from a mesh. The new
+   ElasticityElements created will be using LinearSimplexElement and
+   SimplexGaussianQuadrature.
+   @param mesh The input tetrahedral mesh that describes the connectivity and
+   the positions of the vertices. Each geometry::VolumeElement in the input
+   `mesh` will generate an ElasticityElement in this %ElasticityModel.
+   @param density The mass density of input object in the reference
+   configuration with unit kg/m³.
+   @param constitutive_model The ConstitutiveModel to be used for all the
+   ElasticityElements created.
+   @param QuadratureOrder The order of quadrature rule used for the
+   %ElasticityElement's added. Must be 1, 2 or 3.
+   @pre The vertices of the input `mesh` must be locally indexed, and the
+   indices must be consecutive. That is, the vertices in the `mesh` must be
+   indexed consecutively from 0 to mesh.num_vertices()-1.
+   @throws std::runtime_error if `quadrature_order` is not 1, 2 or 3. */
+  void AddElasticityElementsFromTetMesh(
+      const geometry::VolumeMesh<T>& mesh, T density,
+      const ConstitutiveModel<T>& constitutive_model, int quadrature_order) {
+    if (!(quadrature_order == 1 || quadrature_order == 2 ||
+          quadrature_order == 3)) {
+      throw std::runtime_error(
+          "Only linear, quadratic, and cubic quadrature rule is supported for "
+          "SimplexGaussianQuadrature");
+    }
+    DRAKE_DEMAND(density > 0);
+    // global index = local_index + node_index_offset.
+    const int num_nodes_in_mesh = mesh.num_vertices();
+    const int node_index_offset = this->num_nodes();
+    std::set<int> mesh_node_indices;
+    for (geometry::VolumeElementIndex element_index(0);
+         element_index < mesh.num_elements(); ++element_index) {
+      const geometry::VolumeElement& e = mesh.element(element_index);
+      std::vector<NodeIndex> element_node_indices(
+          geometry::VolumeMesh<T>::kVertexPerElement);
+      Eigen::Matrix<T, 3, geometry::VolumeMesh<T>::kVertexPerElement>
+          element_reference_positions;
+      for (int local_vertex_index = 0;
+           local_vertex_index < geometry::VolumeMesh<T>::kVertexPerElement;
+           ++local_vertex_index) {
+        const geometry::VolumeVertexIndex vid = e.vertex(local_vertex_index);
+        mesh_node_indices.insert(static_cast<int>(vid));
+        element_node_indices[local_vertex_index] =
+            NodeIndex(static_cast<int>(vid) + node_index_offset);
+        element_reference_positions.col(local_vertex_index) =
+            mesh.vertex(vid).r_MV();
+      }
+      std::unique_ptr<ConstitutiveModel<T>> constitutive_model_clone =
+          constitutive_model.Clone();
+      if (quadrature_order == 1) {
+        AddElasticityElement<LinearSimplexElement<T, 3>,
+                             SimplexGaussianQuadrature<T, 1, 3>>(
+            element_node_indices, density, std::move(constitutive_model_clone),
+            element_reference_positions);
+      } else if (quadrature_order == 2) {
+        AddElasticityElement<LinearSimplexElement<T, 3>,
+                             SimplexGaussianQuadrature<T, 2, 3>>(
+            element_node_indices, density, std::move(constitutive_model_clone),
+            element_reference_positions);
+      } else {
+        DRAKE_ASSERT(quadrature_order == 3);
+        AddElasticityElement<LinearSimplexElement<T, 3>,
+                             SimplexGaussianQuadrature<T, 3, 3>>(
+            element_node_indices, density, std::move(constitutive_model_clone),
+            element_reference_positions);
+      }
+    }
+    this->ThrowIfNodeIndicesAreInvalid(mesh_node_indices);
+    this->increment_num_nodes(num_nodes_in_mesh);
+  }
+
+  /** Calculates the total elastic potential energy, in unit J, in the
+   %ElasticityModel. */
+  T CalcElasticEnergy(const FemState<T>& state) const;
+
+ protected:
+  /** Creates a new FemState with no element cache. The generalized positions
+   are set to the reference positions and their derivatives are set to zero. */
+  std::unique_ptr<FemState<T>> DoMakeFemState() const final;
+
+ private:
+  /* Add a single new ElasticityElement to the ElasticityModel.
+   @param[in] node_indices The global node indices of the nodes of the new
+   ElasticityElement.
+   @param[in] density The mass density of the new ElasticityElement with unit
+   kg/m³.
+   @param[in] constitutive_model The ConstitutiveModel to be used for the new
+   ElasticityElement.
+   @param[in] reference_positions The reference positions of the nodes of the
+   new ElasticityElement.
+   @pre node_indices.size() must be the same as
+   IsoparametricElementType::num_nodes().
+   @pre reference_positions.cols() must be the same as
+   IsoparametricElementType::num_nodes().
+   @pre QuadratureType::kNaturalDim must be equal to
+   IsoparametricElementType::kNaturalDim.
+   @tparam IsoparametricElementType The type of IsoparametricElement used in
+   this ElasticityModel. IsoparametricElementType must be a derived class from
+   IsoparametricElement.
+   @tparam QuadratureType The type of Quadrature used in this ElasticityModel.
+   QuadratureType must be a derived class from Quadrature. */
+  template <class IsoparametricElementType, class QuadratureType>
+  void AddElasticityElement(
+      const std::vector<NodeIndex>& node_indices, const T& density,
+      std::unique_ptr<ConstitutiveModel<T>> constitutive_model,
+      const Matrix3X<T>& reference_positions) {
+    static_assert(is_isoparametric_element<IsoparametricElementType>::value,
+                  "IsoparametricElementType must be a derived class of "
+                  "IsoparametricElement<T, NaturalDim>, where NaturalDim can "
+                  "be 1, 2 or 3.");
+    static_assert(is_quadrature<QuadratureType>::value,
+                  "QuadratureType must be a derived class of "
+                  "Quadrature<T, NaturalDim>, where NaturalDim can "
+                  "be 1, 2 or 3.");
+    static_assert(
+        IsoparametricElementType::kNaturalDim == QuadratureType::kNaturalDim,
+        "The dimension of the parent domain for IsoparametricElement and "
+        "Quadrature must be the same.");
+    // TODO(xuchenhan-tri): This assumes that elements are never deleted which
+    // may not be true in the future (e.g. when we support fracture).
+    ElementIndex element_index(this->num_elements());
+    /* The number of reference positions should be the same as the number of
+     nodes in the element. */
+    DRAKE_DEMAND(reference_positions.cols() ==
+                 static_cast<int>(node_indices.size()));
+    for (int i = 0; i < static_cast<int>(node_indices.size()); ++i) {
+      /* Verify mesh consistency among elements. In other words, a single node
+       cannot be assigned with different reference positions in different
+       elements. */
+      if (reference_positions_.find(node_indices[i]) !=
+          reference_positions_.end()) {
+        DRAKE_DEMAND(reference_positions_[node_indices[i]] ==
+                     reference_positions.col(i));
+      } else {
+        reference_positions_[node_indices[i]] = reference_positions.col(i);
+      }
+    }
+    /* Create the element. */
+    this->AddElement(
+        std::make_unique<
+            ElasticityElement<T, IsoparametricElementType, QuadratureType>>(
+            element_index, node_indices, density, std::move(constitutive_model),
+            reference_positions));
+  }
+
+  /* Static cast the input `element` to be of type const
+   ElasticityElementBase<T>&. */
+  const ElasticityElementBase<T>& get_elasticity_element_base(
+      const ElementIndex& element_index) const {
+    return static_cast<const ElasticityElementBase<T>&>(
+        this->element(element_index));
+  }
+
+  /* 'reference_positions_' is used to verify mesh consistency. A single node
+   cannot be assigned with different reference positions in different
+   elements. */
+  std::unordered_map<NodeIndex, Vector3<T>> reference_positions_;
+};
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fem::ElasticityModel);

--- a/multibody/fem/dev/element_cache.h
+++ b/multibody/fem/dev/element_cache.h
@@ -25,8 +25,8 @@ class ElementCache {
  public:
   /** @name     Does not allow copy, move, or assignment. */
   /** @{ */
-  /* Copy constructor is used only to facilitate implementation of Clone()
-   in derived classes. */
+  /* Copy constructor is made "protected" to facilitate Clone() and therefore it
+   is not publicly available. */
   ElementCache(ElementCache&&) = delete;
   ElementCache& operator=(ElementCache&&) = delete;
   ElementCache& operator=(const ElementCache&) = delete;
@@ -43,36 +43,37 @@ class ElementCache {
 
   /** The number of quadrature locations at which cached quantities need to be
    evaluated. */
-  int num_quads() const { return num_quads_; }
+  int num_quadrature_points() const { return num_quadrature_points_; }
 
   // TODO(xuchenhan-tri): Add interface for marking cache entries stale when
   // caching is in place.
 
  protected:
-  /* Constructs a new ElementCache.
+  /** Constructs a new ElementCache.
    @param element_index The index of the FemElement associated with this
    ElementCache.
-   @param num_quads The number of quadrature locations at which cached
-   quantities need to be evaluated.
-   @pre `num_quads` must be positive. */
-  ElementCache(ElementIndex element_index, int num_quads)
-      : element_index_(element_index), num_quads_(num_quads) {
+   @param num_quadrature_points The number of quadrature locations at which
+   cached quantities need to be evaluated.
+   @pre `num_quadrature_points` must be positive. */
+  ElementCache(ElementIndex element_index, int num_quadrature_points)
+      : element_index_(element_index),
+        num_quadrature_points_(num_quadrature_points) {
     DRAKE_ASSERT(element_index_.is_valid());
-    DRAKE_ASSERT(num_quads > 0);
+    DRAKE_ASSERT(num_quadrature_points > 0);
   }
 
-  /* Copy constructor for the base ElementCache class to facilitate
+  /** Copy constructor for the base ElementCache class to facilitate
    `DoClone()` in derived classes. */
   ElementCache(const ElementCache&) = default;
 
-  /* Creates an identical copy of the concrete ElementCache object.
+  /** Creates an identical copy of the concrete ElementCache object.
    Derived classes must implement this so that it performs the complete
    deep copy of the object, including all base class members. */
   virtual std::unique_ptr<ElementCache<T>> DoClone() const = 0;
 
  private:
   ElementIndex element_index_;
-  int num_quads_{-1};
+  int num_quadrature_points_{-1};
 };
 }  // namespace fem
 }  // namespace multibody

--- a/multibody/fem/dev/fem_model.cc
+++ b/multibody/fem/dev/fem_model.cc
@@ -1,0 +1,75 @@
+#include "drake/multibody/fem/dev/fem_model.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+template <typename T>
+std::unique_ptr<FemState<T>> FemModel<T>::MakeFemState() const {
+  std::unique_ptr<FemState<T>> state = DoMakeFemState();
+  /* Set up the element cache that are compatible with the elements owned by
+   this model. */
+  std::vector<std::unique_ptr<ElementCache<T>>> cache;
+  for (int i = 0; i < num_elements(); ++i) {
+    cache.emplace_back(elements_[i]->MakeElementCache());
+  }
+  state->ResetElementCache(std::move(cache));
+  return state;
+}
+
+/* This method assembles the element residual computed in
+ FemElement::CalcResidual() into the global residual vector. */
+template <typename T>
+void FemModel<T>::CalcResidual(const FemState<T>& state,
+                               EigenPtr<VectorX<T>> residual) const {
+  DRAKE_DEMAND(residual->size() == num_dofs());
+  /* Verify the size of the cache in the input state is consistent with the
+   number of elements in the FemModel. */
+  DRAKE_DEMAND(state.element_cache_size() == num_elements());
+  /* The values are accumulated in the residual, so it is important to clear
+   the old data. */
+  residual->setZero();
+  /* The size of `element_residual` depends on the number of nodes in the
+   element and may change from one element to the next. */
+  VectorX<T> element_residual;
+  const int solution_dim = solution_dimension();
+  for (int e = 0; e < num_elements(); ++e) {
+    const int element_num_nodes = elements_[e]->num_nodes();
+    const int element_dofs = element_num_nodes * solution_dim;
+    element_residual.resize(element_dofs);
+    elements_[e]->CalcResidual(state, &element_residual);
+    // TODO(xuchenhan-tri): This may become a repeating pattern. Consider
+    // extracting it out into a method.
+    const std::vector<NodeIndex>& element_node_indices =
+        elements_[e]->node_indices();
+    for (int i = 0; i < element_num_nodes; ++i) {
+      for (int d = 0; d < solution_dim; ++d) {
+        const int ei = element_node_indices[i];
+        (*residual)[ei * solution_dim + d] +=
+            element_residual[i * solution_dim + d];
+      }
+    }
+  }
+}
+
+template <typename T>
+void FemModel<T>::ThrowIfNodeIndicesAreInvalid(
+    const std::set<int>& node_indices) const {
+  if (node_indices.size() == 0) return;
+  if (*node_indices.rbegin() != static_cast<int>(node_indices.size()) - 1 ||
+      *node_indices.begin() != 0) {
+    throw std::runtime_error(
+        "Node indices must be consecutive and start from zero and end with the "
+        "number of nodes minus one.");
+  }
+}
+
+template <typename T>
+void FemModel<T>::AddElement(std::unique_ptr<FemElement<T>> element) {
+  DRAKE_DEMAND(element != nullptr);
+  elements_.emplace_back(std::move(element));
+}
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fem::FemModel);

--- a/multibody/fem/dev/fem_model.h
+++ b/multibody/fem/dev/fem_model.h
@@ -1,0 +1,121 @@
+#pragma once
+
+#include <memory>
+#include <set>
+#include <utility>
+#include <vector>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fem/dev/fem_element.h"
+#include "drake/multibody/fem/dev/fem_indexes.h"
+#include "drake/multibody/fem/dev/fem_state.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+/** %FemModel calculates the components of the discretized FEM equations.
+ Suppose the PDE at hand is of the form
+
+     F(u, ∇u, ...) = 0.
+
+ where ... indicates possible higher derivatives that we aren't concerned with
+ here. In this PDE, u: Ω ⊂ Rᴰ → Rᵈ, is the unknown function being solved for.
+ Here, Ω is the domain, D is the dimension of the domain, and d is the solution
+ dimension. For instance, if you are solving for the temperature of a 3D object,
+ then the domain is three-dimensional (D = 3), while the solution, which is the
+ temperature at a point within the object, is one-dimensional (d = 1). After the
+ FEM discretization, the PDE is reduced to a system of linear or nonlinear
+ equations of the form:
+
+     G(u₁, u₂, ..., uₙ) = 0,
+
+ where n is the number of nodes in the discretization and G is a function from
+ Rⁿᵈ to Rⁿᵈ. The linear or nonlinear equation in the system associated with
+ the node `a` has the form
+
+     Gₐ(u₁, u₂, ..., uₙ) = 0,
+
+ where Gₐ is a function from Rⁿᵈ → Rᵈ and a = 1, ..., n. The nodal values u₁,
+ u₂, ..., uₙ are solved for with a linear or nonlinear solver, and the solution
+ u is interpolated from these nodal values.
+
+ %FemModel calculates various components of the system of linear or nonlinear
+ equations that supports solving the system. For example, CalcResidual()
+ calculates the value of G evaluated at the current state and
+ CalcTangentMatrix() calculates ∇G at the current state.
+ @tparam_nonsymbolic_scalar T. */
+template <typename T>
+class FemModel {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FemModel);
+
+  FemModel() = default;
+
+  virtual ~FemModel() = default;
+
+  /** Creates a new FemState. The new state's number of generalized positions is
+   equal to `num_dofs()`. The new state's element cache is
+   compatible with the FemElement's owned by this %FemModel. */
+  std::unique_ptr<FemState<T>> MakeFemState() const;
+
+  /** The dimension of the codomain of the PDE's solution u. */
+  virtual int solution_dimension() const = 0;
+
+  /** The number of degrees of freedom in the model. It is equal to
+   `solution_dimension()` * `num_nodes()`. */
+  int num_dofs() const { return solution_dimension() * num_nodes(); }
+
+  /** The number of FemElement's owned by `this` %FemModel. */
+  int num_elements() const { return elements_.size(); }
+
+  /** The number of nodes that are associated with `this` %FemModel. */
+  int num_nodes() const { return num_nodes_; }
+
+  /** Calculates the residual at the given FemState. Suppose the linear or
+   nonlinear system generated from the FEM discretization is
+        G(u₁, u₂, ..., uₙ) = 0,
+   then the output `residual` is equal to the function G evaluated at the
+   input `state`.
+   @param[in] state The FemState at which to evaluate the residual.
+   @param[out] residual The output residual evaluated at `state`.
+   @pre The size of `residual` must be equal to `num_dofs()`. */
+  void CalcResidual(const FemState<T>& state,
+                    EigenPtr<VectorX<T>> residual) const;
+
+  // TODO(xuchenhan-tri): Add missing methods such as CalcTangentMatrix and
+  // CalcMassMatrix etc.
+
+ protected:
+  /** Derived class should create a new FemState with no element cache and
+   initialize the per-node states. */
+  virtual std::unique_ptr<FemState<T>> DoMakeFemState() const = 0;
+
+  /** Throws if the `node_indices` are not consecutive from 0 to
+   the `node_indices.size()` - 1. */
+  void ThrowIfNodeIndicesAreInvalid(const std::set<int>& node_indices) const;
+
+  /** Takes ownership of the input `element` and adds it into `this` FemModel.
+   */
+  void AddElement(std::unique_ptr<FemElement<T>> element);
+
+  const FemElement<T>& element(ElementIndex i) const {
+    DRAKE_ASSERT(i.is_valid());
+    DRAKE_ASSERT(i < num_elements());
+    return *elements_[i];
+  }
+
+  /** Increment num_nodes by `num_new_nodes`. */
+  void increment_num_nodes(int num_new_nodes) { num_nodes_ += num_new_nodes; }
+
+ private:
+  /* FemElements owned by this model. */
+  std::vector<std::unique_ptr<FemElement<T>>> elements_;
+  /* The total number of nodes in the system. */
+  int num_nodes_{0};
+};
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fem::FemModel);

--- a/multibody/fem/dev/fem_state.h
+++ b/multibody/fem/dev/fem_state.h
@@ -129,6 +129,8 @@ class FemState {
 
   int num_generalized_positions() const { return q_.size(); }
 
+  int element_cache_size() const { return element_cache_.size(); }
+
  private:
   // Generalized node positions.
   VectorX<T> q_;

--- a/multibody/fem/dev/isoparametric_element.h
+++ b/multibody/fem/dev/isoparametric_element.h
@@ -137,6 +137,12 @@ class IsoparametricElement {
   // element.
   std::vector<VectorD> locations_;
 };
+
+template <class QuadratureType, typename T = void, int NaturalDimension = 0>
+struct is_isoparametric_element {
+  static constexpr bool value = false;
+};
+
 }  // namespace fem
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/fem/dev/linear_elasticity_model.cc
+++ b/multibody/fem/dev/linear_elasticity_model.cc
@@ -16,7 +16,7 @@ void LinearElasticityModel<T>::DoCalcElasticEnergyDensity(
     const DeformationGradientCache<T>& cache, std::vector<T>* Psi) const {
   const LinearElasticityModelCache<T>& linear_cache =
       static_cast<const LinearElasticityModelCache<T>&>(cache);
-  for (int i = 0; i < linear_cache.num_quads(); ++i) {
+  for (int i = 0; i < linear_cache.num_quadrature_points(); ++i) {
     const auto& strain = linear_cache.strain()[i];
     const auto& trace_strain = linear_cache.trace_strain()[i];
     (*Psi)[i] = mu_ * strain.squaredNorm() +
@@ -30,12 +30,20 @@ void LinearElasticityModel<T>::DoCalcFirstPiolaStress(
     std::vector<Matrix3<T>>* P) const {
   const LinearElasticityModelCache<T>& linear_cache =
       static_cast<const LinearElasticityModelCache<T>&>(cache);
-  for (int i = 0; i < linear_cache.num_quads(); ++i) {
+  for (int i = 0; i < linear_cache.num_quadrature_points(); ++i) {
     const auto& strain = linear_cache.strain()[i];
     const auto& trace_strain = linear_cache.trace_strain()[i];
     (*P)[i] =
         2.0 * mu_ * strain + lambda_ * trace_strain * Matrix3<T>::Identity();
   }
+}
+
+template <typename T>
+std::unique_ptr<DeformationGradientCache<T>>
+LinearElasticityModel<T>::DoMakeDeformationGradientCache(
+    ElementIndex element_index, int num_quadrature_points) const {
+  return std::make_unique<LinearElasticityModelCache<T>>(element_index,
+                                                         num_quadrature_points);
 }
 
 template <typename T>

--- a/multibody/fem/dev/linear_elasticity_model.h
+++ b/multibody/fem/dev/linear_elasticity_model.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include "drake/common/default_scalars.h"
@@ -19,7 +20,14 @@ continuum mechanics. Cambridge University Press, 2008. */
 template <typename T>
 class LinearElasticityModel final : public ConstitutiveModel<T> {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LinearElasticityModel);
+  /** @name     Does not allow copy, move, or assignment. */
+  /** @{ */
+  /* Copy constructor is made "protected" to facilitate Clone() and therefore it
+   is not publicly available. */
+  LinearElasticityModel(LinearElasticityModel&&) = delete;
+  LinearElasticityModel& operator=(LinearElasticityModel&&) = delete;
+  LinearElasticityModel& operator=(const LinearElasticityModel&) = delete;
+  /** @} */
 
   /** Constructs a %LinearElasticityModel constitutive model with the prescribed
    Young's modulus and Poisson ratio.
@@ -40,7 +48,17 @@ class LinearElasticityModel final : public ConstitutiveModel<T> {
 
   T lame_first_parameter() const { return lambda_; }
 
- protected:
+ private:
+  /* Copy constructor to facilitate the `DoClone()` method. */
+  LinearElasticityModel(const LinearElasticityModel&) = default;
+
+  /* Creates an identical copy of the LinearElasticityModel object. */
+  std::unique_ptr<ConstitutiveModel<T>> DoClone() const final {
+    // Can't use std::make_unique because the copy constructor is protected.
+    return std::unique_ptr<ConstitutiveModel<T>>(
+        new LinearElasticityModel<T>(*this));
+  }
+
   /* Calculates the energy density, in unit J/m³, given the model cache. */
   void DoCalcElasticEnergyDensity(const DeformationGradientCache<T>& cache,
                                   std::vector<T>* Psi) const final;
@@ -49,7 +67,11 @@ class LinearElasticityModel final : public ConstitutiveModel<T> {
   void DoCalcFirstPiolaStress(const DeformationGradientCache<T>& cache,
                               std::vector<Matrix3<T>>* P) const final;
 
- private:
+  /* Creates a LinearElasticityModelCache that is compatible with this
+   LinearElasticityModel. */
+  std::unique_ptr<DeformationGradientCache<T>> DoMakeDeformationGradientCache(
+      ElementIndex element_index, int num_quadrature_points) const final;
+
   /* Set the Lamé parameters from Young's modulus and Poisson ratio. It's
   important to keep the Lamé Parameters in sync with Young's modulus and
   Poisson ratio as most computations use Lame parameters. */

--- a/multibody/fem/dev/linear_elasticity_model_cache.cc
+++ b/multibody/fem/dev/linear_elasticity_model_cache.cc
@@ -8,7 +8,7 @@ namespace fem {
 template <typename T>
 void LinearElasticityModelCache<T>::DoUpdateCache(
     const std::vector<Matrix3<T>>& F) {
-  for (int i = 0; i < this->num_quads(); ++i) {
+  for (int i = 0; i < this->num_quadrature_points(); ++i) {
     strain_[i] = 0.5 * (F[i] + F[i].transpose()) - Matrix3<T>::Identity();
     trace_strain_[i] = strain_[i].trace();
   }

--- a/multibody/fem/dev/linear_elasticity_model_cache.h
+++ b/multibody/fem/dev/linear_elasticity_model_cache.h
@@ -21,8 +21,8 @@ class LinearElasticityModelCache : public DeformationGradientCache<T> {
  public:
   /** @name     Does not allow copy, move, or assignment. */
   /** @{ */
-  /* Copy constructor is used only to facilitate implementation of Clone()
-   in derived classes. */
+  /* Copy constructor is made "protected" to facilitate Clone() and therefore it
+   is not publicly available. */
   LinearElasticityModelCache(LinearElasticityModelCache&&) = delete;
   LinearElasticityModelCache& operator=(LinearElasticityModelCache&&) = delete;
   LinearElasticityModelCache& operator=(const LinearElasticityModelCache&) =
@@ -33,13 +33,14 @@ class LinearElasticityModelCache : public DeformationGradientCache<T> {
    number of quadrature locations.
    @param element_index The index of the FemElement associated with this
    DeformationGradientCache.
-   @param num_quads The number of quadrature locations at which cached
-   quantities need to be evaluated.
-   @pre `num_quads` must be positive. */
-  LinearElasticityModelCache(ElementIndex element_index, int num_quads)
-      : DeformationGradientCache<T>(element_index, num_quads),
-        strain_(num_quads, Matrix3<T>::Zero()),
-        trace_strain_(num_quads, 0) {}
+   @param num_quadrature_points The number of quadrature locations at which
+   cached quantities need to be evaluated.
+   @pre `num_quadrature_points` must be positive. */
+  LinearElasticityModelCache(ElementIndex element_index,
+                             int num_quadrature_points)
+      : DeformationGradientCache<T>(element_index, num_quadrature_points),
+        strain_(num_quadrature_points, Matrix3<T>::Zero()),
+        trace_strain_(num_quadrature_points, 0) {}
 
   /** Returns the infinitesimal strains evaluated at the quadrature locations
    for the associated element. */
@@ -49,14 +50,14 @@ class LinearElasticityModelCache : public DeformationGradientCache<T> {
    quadrature locations for the associated element. */
   const std::vector<T>& trace_strain() const { return trace_strain_; }
 
- protected:
+ private:
   /* Copy constructor to facilitate the `DoClone()` method. */
   LinearElasticityModelCache(const LinearElasticityModelCache&) = default;
 
   /* Updates the cached quantities with the given deformation gradients.
    @param F The up-to-date deformation gradients evaluated at the quadrature
    locations for the associated element.
-   @pre The size of `F` must be the same as `num_quads()`. */
+   @pre The size of `F` must be the same as `num_quadrature_points()`. */
   void DoUpdateCache(const std::vector<Matrix3<T>>& F) final;
 
   /* Creates an identical copy of the LinearElasticityModelCache object. */
@@ -66,7 +67,6 @@ class LinearElasticityModelCache : public DeformationGradientCache<T> {
         new LinearElasticityModelCache<T>(*this));
   }
 
- private:
   // Infinitesimal strain = 0.5 * (F + Fᵀ) - I.
   std::vector<Matrix3<T>> strain_;
   // Trace of `strain_`.

--- a/multibody/fem/dev/linear_simplex_element.h
+++ b/multibody/fem/dev/linear_simplex_element.h
@@ -20,11 +20,14 @@ namespace fem {
 template <typename T, int NaturalDim>
 class LinearSimplexElement : public IsoparametricElement<T, NaturalDim> {
  public:
+  static_assert(1 <= NaturalDim && NaturalDim <= 3,
+                "Only 1, 2 and 3 dimensional manifolds are supported.");
+
   using typename IsoparametricElement<T, NaturalDim>::VectorD;
 
   /** Number of nodes in this simplex element that is available at compile time.
    */
-  enum : int { kNumNodes = NaturalDim + 1 };
+  static constexpr int kNumNodes = NaturalDim + 1;
 
   explicit LinearSimplexElement(std::vector<VectorD> locations)
       : IsoparametricElement<T, NaturalDim>(std::move(locations)) {
@@ -49,6 +52,11 @@ class LinearSimplexElement : public IsoparametricElement<T, NaturalDim> {
   std::vector<VectorX<T>> S_;
   // Shape function derivatives evaluated at points specified at construction.
   std::vector<MatrixX<T>> dSdxi_;
+};
+
+template <typename T, int NaturalDimension>
+struct is_isoparametric_element<LinearSimplexElement<T, NaturalDimension>> {
+  static constexpr bool value = true;
 };
 }  // namespace fem
 }  // namespace multibody

--- a/multibody/fem/dev/quadrature.h
+++ b/multibody/fem/dev/quadrature.h
@@ -20,6 +20,9 @@ namespace fem {
 template <typename T, int NaturalDimension>
 class Quadrature {
  public:
+  static_assert(1 <= NaturalDimension && NaturalDimension <= 3,
+                  "Only 1, 2 and 3 dimensional spaces are supported.");
+
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Quadrature);
 
   using VectorD = Eigen::Matrix<T, NaturalDimension, 1>;
@@ -33,9 +36,7 @@ class Quadrature {
   int num_points() const { return points_.size(); }
 
   /// The position in parent coordinates of all quadrature points.
-  const std::vector<VectorD>& get_points() const {
-      return points_;
-  }
+  const std::vector<VectorD>& get_points() const { return points_; }
 
   /// The position in parent coordinates of the q-th quadrature point.
   const VectorD& get_point(int q) const {
@@ -186,6 +187,18 @@ class SimplexGaussianQuadrature : public Quadrature<T, NaturalDimension> {
       DRAKE_UNREACHABLE();
     }
   }
+};
+
+template <class QuadratureType, typename T = void, int QuadratureOrder = 0,
+          int NaturalDimension = 0>
+struct is_quadrature {
+  static constexpr bool value = false;
+};
+
+template <typename T, int QuadratureOrder, int NaturalDimension>
+struct is_quadrature<
+    SimplexGaussianQuadrature<T, QuadratureOrder, NaturalDimension>> {
+  static constexpr bool value = true;
 };
 }  // namespace fem
 }  // namespace multibody

--- a/multibody/fem/dev/test/elasticity_element_test.cc
+++ b/multibody/fem/dev/test/elasticity_element_test.cc
@@ -59,10 +59,7 @@ class ElasticityElementTest : public ::testing::Test {
         std::make_unique<LinearElasticityModelCache<AutoDiffXd>>(
             kDummyElementIndex, kNumQuads);
     std::vector<std::unique_ptr<ElementCache<AutoDiffXd>>> cache;
-    // TODO(xuchenhan-tri): Add a method to FemElement that creates a compatible
-    // ElementCache.
-    cache.emplace_back(std::make_unique<ElasticityElementCache<AutoDiffXd>>(
-        kDummyElementIndex, kNumQuads, std::move(linear_elasticity_cache)));
+    cache.emplace_back(elasticity_element_->MakeElementCache());
     state_->ResetElementCache(std::move(cache));
   }
 
@@ -91,7 +88,7 @@ class ElasticityElementTest : public ::testing::Test {
 namespace {
 TEST_F(ElasticityElementTest, Basic) {
   EXPECT_EQ(elasticity_element_->num_nodes(), kNumVertices);
-  EXPECT_EQ(elasticity_element_->num_quads(), kNumQuads);
+  EXPECT_EQ(elasticity_element_->num_quadrature_points(), kNumQuads);
   EXPECT_EQ(elasticity_element_->solution_dimension(), kProblemDim);
 }
 

--- a/multibody/fem/dev/test/elasticity_model_test.cc
+++ b/multibody/fem/dev/test/elasticity_model_test.cc
@@ -1,0 +1,125 @@
+#include "drake/multibody/fem/dev/elasticity_model.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/geometry/proximity/make_box_mesh.h"
+#include "drake/math/autodiff_gradient.h"
+#include "drake/multibody/fem/dev/fem_state.h"
+#include "drake/multibody/fem/dev/linear_elasticity_model.h"
+#include "drake/multibody/fem/dev/linear_simplex_element.h"
+#include "drake/multibody/fem/dev/quadrature.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace {
+constexpr int kNaturalDim = 3;
+constexpr int kSpatialDim = 3;
+constexpr int kQuadratureOrder = 1;
+constexpr int kNumQuads = 1;
+constexpr int kNumVertices = 8;
+constexpr int kDof = kSpatialDim * kNumVertices;
+constexpr double kMassDensity(10);
+constexpr double kYoungsModulus(2);
+constexpr double kPoissonRatio(0.25);
+
+class ElasticityModelTest : public ::testing::Test {
+ protected:
+  using Scalar = AutoDiffXd;
+  using IsoparametricElementType = LinearSimplexElement<Scalar, kNaturalDim>;
+  using QuadratureType =
+      SimplexGaussianQuadrature<Scalar, kQuadratureOrder, kNaturalDim>;
+
+  void SetUp() override {
+    /* Make a unit cube and subdivide it into tetrahedra. */
+    const double length = 1;
+    geometry::Box box(length, length, length);
+    mesh_ = std::make_unique<geometry::VolumeMesh<Scalar>>(
+        geometry::internal::MakeBoxVolumeMesh<Scalar>(box, 1));
+    LinearElasticityModel<Scalar> linear_elasticity_model(kYoungsModulus,
+                                                          kPoissonRatio);
+    Scalar density(kMassDensity);
+    elasticity_model_.AddElasticityElementsFromTetMesh(
+        *mesh_, density, linear_elasticity_model, kQuadratureOrder);
+  }
+
+  /* Creates arbitrary node positions along with derivatives 1. The position
+   could potentially cause elements to invert, but that should not affect the
+   result of the tests. */
+  VectorX<Scalar> MakePositions() {
+    VectorX<double> x(kDof);
+    x << 0.18, 0.63, 0.54, 0.13, 0.92, 0.17, 0.03, 0.86, 0.85, 0.25, 0.53, 0.67,
+        0.81, 0.36, 0.45, 0.31, 0.29, 0.71, 0.30, 0.68, 0.58, 0.52, 0.35, 0.76;
+    VectorX<AutoDiffXd> x_autodiff(kDof);
+    math::initializeAutoDiff(x, x_autodiff);
+    return x_autodiff;
+  }
+
+  /* The ElasticityModel under test. */
+  ElasticityModel<Scalar> elasticity_model_;
+  /* The geometry of the model. */
+  std::unique_ptr<geometry::VolumeMesh<Scalar>> mesh_;
+};
+
+TEST_F(ElasticityModelTest, Basic) {
+  EXPECT_EQ(elasticity_model_.num_nodes(), kNumVertices);
+  /* Each cube is split into 6 tetrahedra. */
+  EXPECT_EQ(elasticity_model_.num_elements(), 6);
+  EXPECT_EQ(elasticity_model_.solution_dimension(), 3);
+}
+
+TEST_F(ElasticityModelTest, MakeState) {
+  std::unique_ptr<FemState<Scalar>> state = elasticity_model_.MakeFemState();
+  ASSERT_TRUE(state != nullptr);
+  EXPECT_EQ(state->element_cache_size(), elasticity_model_.num_elements());
+  for (ElementIndex i(0); i < state->element_cache_size(); ++i) {
+    /* The element cache should be of type ElasticityElementCache. */
+    const auto* element_cache =
+        dynamic_cast<const ElasticityElementCache<Scalar>*>(
+            &state->element_cache(i));
+    ASSERT_TRUE(element_cache != nullptr);
+    /* The DeformationGradientCache should be of type
+     LinearElasticityModelCache. */
+    const auto* linear_elasticity_cache =
+        dynamic_cast<const LinearElasticityModelCache<Scalar>*>(
+            &element_cache->deformation_gradient_cache());
+    /* Verify that the cache is properly set up. */
+    ASSERT_TRUE(linear_elasticity_cache != nullptr);
+    EXPECT_EQ(linear_elasticity_cache->element_index(), i);
+    EXPECT_EQ(linear_elasticity_cache->num_quadrature_points(), kNumQuads);
+    EXPECT_EQ(linear_elasticity_cache->strain().size(), kNumQuads);
+    EXPECT_EQ(linear_elasticity_cache->trace_strain().size(), kNumQuads);
+    EXPECT_EQ(linear_elasticity_cache->deformation_gradient().size(),
+              kNumQuads);
+  }
+  EXPECT_EQ(state->num_generalized_positions(), kDof);
+  /* The default qdot should be zero. */
+  EXPECT_EQ(state->qdot(), VectorX<Scalar>::Zero(kDof));
+  /* The default q should be the reference position of the mesh. */
+  for (int i = 0; i < kNumVertices; ++i) {
+    EXPECT_EQ(state->q().segment<3>(3 * i),
+              mesh_->vertex(geometry::VolumeVertexIndex(i)).r_MV());
+  }
+  EXPECT_EQ(state->qdot(), VectorX<Scalar>::Zero(kDof));
+}
+
+TEST_F(ElasticityModelTest, ResidualIsEnergyDerivative) {
+  std::unique_ptr<FemState<Scalar>> state = elasticity_model_.MakeFemState();
+  /* Move to arbitrary positions. */
+  state->set_q(MakePositions());
+  Scalar energy = elasticity_model_.CalcElasticEnergy(*state);
+  VectorX<Scalar> residual(state->num_generalized_positions());
+  elasticity_model_.CalcResidual(*state, &residual);
+  /* TODO(xuchenhan-tri): Damping and inertia terms need to be added to this
+   test when they are in place. */
+  EXPECT_TRUE(CompareMatrices(energy.derivatives(), residual,
+                              std::numeric_limits<double>::epsilon()));
+}
+
+}  // namespace
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fem/dev/test/fem_state_test.cc
+++ b/multibody/fem/dev/test/fem_state_test.cc
@@ -11,8 +11,9 @@ constexpr int kNumCache = 2;
 // A toy element cache.
 class MyElementCache final : public ElementCache<double> {
  public:
-  MyElementCache(ElementIndex element_index, int num_quads, int data)
-      : ElementCache(element_index, num_quads), data_(data) {}
+  MyElementCache(ElementIndex element_index, int num_quadrature_points,
+                 int data)
+      : ElementCache(element_index, num_quadrature_points), data_(data) {}
 
   int data() const { return data_; }
 

--- a/multibody/fem/dev/test/linear_elasticity_model_cache_test.cc
+++ b/multibody/fem/dev/test/linear_elasticity_model_cache_test.cc
@@ -27,7 +27,7 @@ class LinearElasticityCacheTest : public ::testing::Test {
 
 TEST_F(LinearElasticityCacheTest, LinearElasticityCacheInitialization) {
   EXPECT_EQ(linear_elasticity_cache_.element_index(), kElementIndex);
-  EXPECT_EQ(linear_elasticity_cache_.num_quads(), kNumQuads);
+  EXPECT_EQ(linear_elasticity_cache_.num_quadrature_points(), kNumQuads);
   EXPECT_EQ(linear_elasticity_cache_.deformation_gradient().size(), kNumQuads);
   EXPECT_EQ(linear_elasticity_cache_.strain().size(), kNumQuads);
   EXPECT_EQ(linear_elasticity_cache_.trace_strain().size(), kNumQuads);
@@ -57,8 +57,8 @@ TEST_F(LinearElasticityCacheTest, Clone) {
             linear_elasticity_cache_.strain());
   EXPECT_EQ(linear_elasticity_cache_clone->trace_strain(),
             linear_elasticity_cache_.trace_strain());
-  EXPECT_EQ(linear_elasticity_cache_clone->num_quads(),
-            linear_elasticity_cache_.num_quads());
+  EXPECT_EQ(linear_elasticity_cache_clone->num_quadrature_points(),
+            linear_elasticity_cache_.num_quadrature_points());
   EXPECT_EQ(linear_elasticity_cache_clone->element_index(),
             linear_elasticity_cache_.element_index());
 }


### PR DESCRIPTION
FemModel helps calculate quantities used in solving the FEM discretized system of equations. It

1. owns FemElements and assembles residual and tangent matrix using their element counterparts, and 
2. builds FemState.

See [this google doc](https://docs.google.com/document/d/1RqeR-K2_TKaxEp9e7_qSykL6QWN6bI2tHxZ1BL7v5ao/) for the design for FemModel and its dependent classes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14317)
<!-- Reviewable:end -->
