### PR TITLE
Remove all dependencies on bot_core messages

### DIFF
--- a/lcmtypes/BUILD.bazel
+++ b/lcmtypes/BUILD.bazel
@@ -212,17 +212,13 @@ drake_lcm_py_library(
 drake_py_library(
     name = "lcmtypes_drake_py",
     srcs = ["__init__.py"],
-    deps = [
-        ":_generated_lcmtypes_drake_py",
-        "@lcmtypes_bot2_core//:lcmtypes_bot2_core_py",
-    ],
+    deps = [":_generated_lcmtypes_drake_py"],
 )
 
 drake_lcm_java_library(
     name = "lcmtypes_drake_java",
     lcm_package = "drake",
     lcm_srcs = glob(["*.lcm"]),
-    deps = ["@lcmtypes_bot2_core//:lcmtypes_bot2_core_java"],
 )
 
 # This should list every LCM type that is known to Drake.
@@ -254,7 +250,6 @@ drake_java_binary(
     visibility = ["//visibility:private"],
     runtime_deps = [
         ":lcmtypes_drake_java",
-        "@lcmtypes_bot2_core//:lcmtypes_bot2_core_java",
         "@lcmtypes_robotlocomotion//:lcmtypes_robotlocomotion_java",
         "@optitrack_driver//lcmtypes:lcmtypes_optitrack",
     ],

--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -253,7 +253,6 @@ cc_library(
         "//lcmtypes:lcmtypes_drake_cc",
         "@eigen",
         "@fmt",
-        "@lcmtypes_bot2_core",
         "@lcmtypes_robotlocomotion",
         "@optitrack_driver//lcmtypes:optitrack_lcmtypes",
     ],

--- a/tools/workspace/lcmtypes_robotlocomotion/package.BUILD.bazel
+++ b/tools/workspace/lcmtypes_robotlocomotion/package.BUILD.bazel
@@ -17,21 +17,24 @@ load(
     "lcm_py_library",
 )
 
-LCM_SRCS = glob(["lcmtypes/*.lcm"])
+LCM_SRCS = glob(["lcmtypes/*.lcm"], exclude = [
+    "lcmtypes/grasp_transition_state_t.lcm",
+    "lcmtypes/robot_plan_t.lcm",
+    "lcmtypes/robot_plan_w_keyframes_t.lcm",
+    "lcmtypes/robot_plan_with_supports_t.lcm",
+])
 
 lcm_cc_library(
     name = "lcmtypes_robotlocomotion",
     includes = ["lcmtypes"],
     lcm_package = "robotlocomotion",
     lcm_srcs = LCM_SRCS,
-    deps = ["@lcmtypes_bot2_core"],
 )
 
 lcm_java_library(
     name = "lcmtypes_robotlocomotion_java",
     lcm_package = "robotlocomotion",
     lcm_srcs = LCM_SRCS,
-    deps = ["@lcmtypes_bot2_core//:lcmtypes_bot2_core_java"],
 )
 
 lcm_py_library(
@@ -39,7 +42,6 @@ lcm_py_library(
     imports = ["lcmtypes"],
     lcm_package = "robotlocomotion",
     lcm_srcs = LCM_SRCS,
-    deps = ["@lcmtypes_bot2_core//:lcmtypes_bot2_core_py"],
 )
 
 CMAKE_PACKAGE = "robotlocomotion-lcmtypes"


### PR DESCRIPTION
Exorcise use of all bot_core messages within Drake, with the sole exception of the python definitions for drake_visualizer.

Towards #14362.

We do not have a license to use the openhumanids code, so we must stop doing so (https://github.com/openhumanoids/bot_core_lcmtypes/issues/33).  Furthermore, there is no longer any real inter-operability reason to try to share these message structures across collaborating projects, so the dependency is adding no value for the cost of maintaining and redistributing it.

The lcmtypes_bot2_core external and installed message definitions are deprecated and will be removed on 2020-03-01.

List of breaking changes:

Remove message definitions for:
- drake.lcmt_manipulator_plan_move_end_effector
- robotlocomotion.grasp_transition_state_t
- robotlocomotion.robot_plan_t
- robotlocomotion.robot_plan_w_keyframes_t
- robotlocomotion.robot_plan_with_supports_t

These messages depend on bot_core.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14319)
<!-- Reviewable:end -->
