### PR TITLE
hotfix: typo in _warn_deprecated caused error outside of drake that was masked inside of drake

### DIFF
--- a/bindings/pydrake/systems/meshcat_visualizer.py
+++ b/bindings/pydrake/systems/meshcat_visualizer.py
@@ -559,7 +559,7 @@ class MeshcatContactVisualizer(LeafSystem):
             _warn_deprecated(
                 "The pose_bundle input port of MeshcatContactVisualizer is"
                 "deprecated; use the geometry_query inport port instead.",
-                date="2021-03-01.")
+                date="2021-03-01")
             self._warned_pose_bundle_input_port_connected = True
 
         contact_results = self.EvalAbstractInput(context, 1).get_value()


### PR DESCRIPTION
```
  File "/github/home/.cache/bazel/_bazel_root/2c6ecbd5334a25ecb6695496eb26484b/execroot/manipulation/bazel-out/k8-fastbuild/bin/clutter.runfiles/drake/.lib/python3.6/site-packages/pydrake/systems/meshcat_visualizer.py", line 562, in DoPublish
    date="2021-03-01.")
  File "/github/home/.cache/bazel/_bazel_root/2c6ecbd5334a25ecb6695496eb26484b/execroot/manipulation/bazel-out/k8-fastbuild/bin/clutter.runfiles/drake/.lib/python3.6/site-packages/pydrake/common/deprecation.py", line 142, in _warn_deprecated
    _format_deprecation_message(message, date=date),
  File "/github/home/.cache/bazel/_bazel_root/2c6ecbd5334a25ecb6695496eb26484b/execroot/manipulation/bazel-out/k8-fastbuild/bin/clutter.runfiles/drake/.lib/python3.6/site-packages/pydrake/common/deprecation.py", line 121, in _format_deprecation_message
    f"Date does not match YYYY-MM-DD pattern: {repr(date)}"
AssertionError: Date does not match YYYY-MM-DD pattern: '2021-03-01.'
```

Inside of drake, we force all examples that trigger this warning to catch the warning.  It must be that we have a hazard/loophole that swallows this particular error?  @EricCousineau-TRI 

At any rate, the hotfix is easy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14320)
<!-- Reviewable:end -->
