### PR TITLE
Add parsing for reflected inertia parameters

### DIFF
--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -236,7 +236,22 @@ void AddJointActuatorFromSpecification(
   // as a way to specify un-actuated joints. Thus, the user would say
   // <effort>0</effort> for un-actuated joints.
   if (effort_limit != 0) {
-    plant->AddJointActuator(joint_spec.Name(), joint, effort_limit);
+    const JointActuator<double>& actuator =
+        plant->AddJointActuator(joint_spec.Name(), joint, effort_limit);
+
+    // Parse and add the optional drake:rotor_inertia parameter.
+    if (joint_spec.Element()->HasElement("drake:rotor_inertia")) {
+      plant->get_mutable_joint_actuator(actuator.index())
+          .set_default_rotor_inertia(
+              joint_spec.Element()->Get<double>("drake:rotor_inertia"));
+    }
+
+    // Parse and add the optional drake:gear_ratio parameter.
+    if (joint_spec.Element()->HasElement("drake:gear_ratio")) {
+      plant->get_mutable_joint_actuator(actuator.index())
+          .set_default_gear_ratio(
+              joint_spec.Element()->Get<double>("drake:gear_ratio"));
+    }
   }
 }
 

--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -561,7 +561,36 @@ void ParseTransmission(
     return;
   }
 
-  plant->AddJointActuator(actuator_name, joint, effort_iter->second);
+  const JointActuator<double>& actuator =
+      plant->AddJointActuator(actuator_name, joint, effort_iter->second);
+
+  // Parse and add the optional drake:rotor_inertia parameter.
+  XMLElement* rotor_inertia_node =
+      actuator_node->FirstChildElement("drake:rotor_inertia");
+  if (rotor_inertia_node) {
+    double rotor_inertia;
+    if (!ParseScalarAttribute(rotor_inertia_node, "value", &rotor_inertia)) {
+      throw std::runtime_error(
+          "ERROR: joint actuator " + actuator_name +
+          "'s drake:rotor_inertia does not have a \"value\" attribute!");
+    }
+    plant->get_mutable_joint_actuator(actuator.index())
+        .set_default_rotor_inertia(rotor_inertia);
+  }
+
+  // Parse and add the optional drake:gear_ratio parameter.
+  XMLElement* gear_ratio_node =
+      actuator_node->FirstChildElement("drake:gear_ratio");
+  if (gear_ratio_node) {
+    double gear_ratio;
+    if (!ParseScalarAttribute(gear_ratio_node, "value", &gear_ratio)) {
+      throw std::runtime_error(
+          "ERROR: joint actuator " + actuator_name +
+          "'s drake:gear_ratio does not have a \"value\" attribute!");
+    }
+    plant->get_mutable_joint_actuator(actuator.index())
+        .set_default_gear_ratio(gear_ratio);
+  }
 }
 
 void ParseFrame(ModelInstanceIndex model_instance,


### PR DESCRIPTION
Modifies the SDF and URDF parser to take two custom tags:
- `drake:rotor_inertia`
- `drake:gear_ratio`
Used to set `JointActuator::default_rotor_inertia_` and `JointActuator::default_gear_ratio_`.

In SDF, these custom tags are expected to appear within the `<joint>` tag, e.g.:
```
<model>
  ...
  <joint name="joint" type="revolute">
  ...
    <drake:rotor_inertia>1.5</drake:rotor_inertia>
    <drake:gear_ratio>300</drake:gear_ratio>
  ...
```

In URDF, these custom tags are expected to appear within the `<actuator>` tag within a `<transmission>` tag, e.g.:
```
<robot>
  ...
  <transmission>
    ...
    <actuator>
      ...
      <drake:rotor_inertia value="1.5" />
      <drake:gear_ratio value="300" />
      ...
```

Related to #12335

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14323)
<!-- Reviewable:end -->
