### PR TITLE
yaml: Correctly emit variants with templated inner types

### DIFF
--- a/common/schema/BUILD.bazel
+++ b/common/schema/BUILD.bazel
@@ -77,6 +77,7 @@ drake_cc_googletest(
         "//common/test_utilities:expect_throws_message",
         "//common/test_utilities:symbolic_test_util",
         "//common/yaml:yaml_read_archive",
+        "//common/yaml:yaml_write_archive",
     ],
 )
 

--- a/common/yaml/test/yaml_read_archive_test.cc
+++ b/common/yaml/test/yaml_read_archive_test.cc
@@ -828,7 +828,7 @@ TEST_P(YamlReadArchiveTest, VisitVariantFoundUnknownTag) {
       "has unsupported type tag !UnknownTag "
       "while selecting a variant<> entry for "
       "std::variant<std::string,double,drake::yaml::test::DoubleStruct,"
-      "drake::yaml::test::StringStruct> value.");
+      "drake::yaml::test::EigenStruct<-1,1>> value.");
 }
 
 // This finds nothing when an Eigen::Vector or Eigen::Matrix was wanted.

--- a/common/yaml/test/yaml_write_archive_defaults_test.cc
+++ b/common/yaml/test/yaml_write_archive_defaults_test.cc
@@ -162,7 +162,7 @@ TEST_F(YamlWriteArchiveDefaultsTest, DifferentVariantTag) {
   data.value = DoubleStruct{1.0};
 
   VariantStruct defaults;
-  defaults.value = StringStruct{"1.0"};
+  defaults.value = EigenVecStruct();
 
   EXPECT_EQ(SaveDataWithoutDefaults(data, defaults), R"""(doc:
   value: !DoubleStruct

--- a/common/yaml/test/yaml_write_archive_test.cc
+++ b/common/yaml/test/yaml_write_archive_test.cc
@@ -184,13 +184,15 @@ TEST_F(YamlWriteArchiveTest, Variant) {
 
   test(Variant4(std::string("foo")), "foo");
   test(Variant4(DoubleStruct{1.0}), "!DoubleStruct\n    value: 1.0");
+  test(Variant4(EigenVecStruct{Eigen::Vector2d(1.0, 2.0)}),
+       "!EigenStruct\n    value: [1.0, 2.0]");
 
   // TODO(jwnimmer-tri) We'd like to see "!!float 1.0" here, but our writer
   // does not yet support that output syntax.
   DRAKE_EXPECT_THROWS_MESSAGE(
-    Save(VariantStruct{double{1.0}}),
-    std::exception,
-    "Cannot YamlWriteArchive the variant type double with a non-zero index");
+      Save(VariantStruct{double{1.0}}),
+      std::exception,
+      "Cannot YamlWriteArchive the variant type double with a non-zero index");
 }
 
 TEST_F(YamlWriteArchiveTest, EigenVector) {

--- a/common/yaml/yaml_write_archive.h
+++ b/common/yaml/yaml_write_archive.h
@@ -312,7 +312,13 @@ class YamlWriteArchive final {
           "Cannot YamlWriteArchive the variant type {} with a non-zero index",
           full_name));
     }
-    return NiceTypeName::RemoveNamespaces(full_name);
+    std::string short_name = NiceTypeName::RemoveNamespaces(full_name);
+    auto angle = short_name.find('<');
+    if (angle != std::string::npos) {
+      // Remove template arguments.
+      short_name.resize(angle);
+    }
+    return short_name;
   }
 
   template <typename T>


### PR DESCRIPTION
We need to discard the template arguments; they are not valid tag syntax.

Also add a stochastic acceptance test that would have caught this issue.

Closes #14322.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14327)
<!-- Reviewable:end -->
