### PR TITLE
[geometry] Make Cylinder's tetrahedral mesh with embedded medial axis.

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -38,6 +38,7 @@ drake_cc_package_library(
         ":mesh_intersection",
         ":mesh_plane_intersection",
         ":mesh_to_vtk",
+        ":meshing_utilities",
         ":obb",
         ":obj_to_surface_mesh",
         ":penetration_as_point_pair_callback",
@@ -255,6 +256,7 @@ drake_cc_library(
     srcs = ["make_box_mesh.cc"],
     hdrs = ["make_box_mesh.h"],
     deps = [
+        ":meshing_utilities",
         ":proximity_utilities",
         ":surface_mesh",
         ":volume_mesh",
@@ -277,8 +279,10 @@ drake_cc_library(
 
 drake_cc_library(
     name = "make_cylinder_mesh",
+    srcs = ["make_cylinder_mesh.cc"],
     hdrs = ["make_cylinder_mesh.h"],
     deps = [
+        ":meshing_utilities",
         ":surface_mesh",
         ":volume_mesh",
         ":volume_to_surface_mesh",
@@ -409,6 +413,15 @@ drake_cc_library(
         ":surface_mesh",
         ":volume_mesh",
         "@fmt",
+    ],
+)
+
+drake_cc_library(
+    name = "meshing_utilities",
+    srcs = ["meshing_utilities.cc"],
+    hdrs = ["meshing_utilities.h"],
+    deps = [
+        ":volume_mesh",
     ],
 )
 
@@ -670,6 +683,7 @@ drake_cc_googletest(
     deps = [
         ":make_cylinder_field",
         ":make_cylinder_mesh",
+        ":mesh_to_vtk",
         ":volume_to_surface_mesh",
     ],
 )

--- a/geometry/proximity/make_box_mesh.cc
+++ b/geometry/proximity/make_box_mesh.cc
@@ -1,9 +1,8 @@
 #include "drake/geometry/proximity/make_box_mesh.h"
 
 #include <algorithm>
-#include <array>
-#include <unordered_set>
 
+#include "drake/geometry/proximity/meshing_utilities.h"
 #include "drake/geometry/proximity/proximity_utilities.h"
 
 namespace drake {
@@ -11,60 +10,6 @@ namespace geometry {
 namespace internal {
 
 using Eigen::Vector3d;
-using std::unordered_set;
-
-/* Subdivides a virtual cube to have up to six tetrahedra such that they
- share the diagonal v0v6 (see ordering below). We allow repeated vertices in
- the virtual cube and will skip tetrahedra with repeated vertices.
-
- We assume the input vertex indices (represented as VolumeVertexIndex) are in
- this ordering:
-   1. Four vertices v0,v1,v2,v3 of the "bottom" face in counterclockwise
-      order when look from "above" the cube.
-   2. Four vertices v4,v5,v6,v7 of the "top" face matching v0,v1,v2,v3,
-      respectively.
-
-                       v4-----------v7
-                      /|           /|
-                     / |          / |
-                    /  |         /  |
-                   /   |        /   |
-                  /    v0------/----v3
-                 /    /       /    /
-                v5-----------v6   /
-                |   /        |   /
-                |  /         |  /
-                | /          | /
-                |/           |/
-                v1-----------v2
-
- Examples of cases with repeated vertices.
- - If v0 == v3 and v1 == v2, we will have a prism instead of a cube and will
-   get 3 tetrahedra instead of 6 tetrahedra.
- - If v0 == v1 == v2 == v3, we will have a pyramid instead of a cube and will
-   get 2 tetrahedra instead of 6 tetrahedra.
-
- @note   This function is purely topological because it takes only
- VolumeVertexIndex into account without attempting to access coordinates of
- the vertices.
- */
-std::vector<VolumeElement> SplitToTetrahedra(
-    VolumeVertexIndex v0, VolumeVertexIndex v1, VolumeVertexIndex v2,
-    VolumeVertexIndex v3, VolumeVertexIndex v4, VolumeVertexIndex v5,
-    VolumeVertexIndex v6, VolumeVertexIndex v7) {
-  std::vector<VolumeElement> elements;
-  elements.reserve(6);
-  VolumeVertexIndex previous = v1;
-  for (const VolumeVertexIndex& next : {v2, v3, v7, v4, v5, v1}) {
-    // Allow distinct vertex indices only.
-    if (unordered_set<VolumeVertexIndex>({previous, next, v0, v6}).size() ==
-        4) {
-      elements.emplace_back(previous, next, v0, v6);
-    }
-    previous = next;
-  }
-  return elements;
-}
 
 template <typename T>
 VolumeMesh<T> MakeBoxVolumeMeshWithMa(const Box& box) {

--- a/geometry/proximity/make_cylinder_mesh.cc
+++ b/geometry/proximity/make_cylinder_mesh.cc
@@ -1,0 +1,142 @@
+#include "drake/geometry/proximity/make_cylinder_mesh.h"
+
+#include <cmath>
+
+#include "drake/common/eigen_types.h"
+#include "drake/geometry/proximity/meshing_utilities.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+template <typename T>
+VolumeMesh<T> MakeCylinderVolumeMeshWithMa(const Cylinder& cylinder,
+                                           const double resolution_hint) {
+  const int num_vertices_per_circle =
+      static_cast<int>(ceil(2. * M_PI * cylinder.radius() / resolution_hint));
+
+  std::vector<VolumeVertex<T>> mesh_vertices;
+  // TODO(DamrongGuoy): Tighten the bound.
+  mesh_vertices.reserve(3 * num_vertices_per_circle + 2);
+
+  // For convenience, we add vertices at the centers of the top and bottom
+  // caps.
+  VolumeVertexIndex cv[2];
+  const double top_z = cylinder.length() / 2.;
+  const double bottom_z = -top_z;
+  cv[0] = VolumeVertexIndex(mesh_vertices.size());
+  mesh_vertices.emplace_back(0, 0, bottom_z);
+  cv[1] = VolumeVertexIndex(mesh_vertices.size());
+  mesh_vertices.emplace_back(0, 0, top_z);
+
+  // Vertices on the two circular rims.
+  // v[0][i] is on the bottom -Z circular rim.
+  // v[1][i] is on the top +Z circular rim.
+  VolumeVertexIndex v[2][num_vertices_per_circle];
+  const double angle_step = 2. * M_PI / num_vertices_per_circle;
+  for (int i=0; i < num_vertices_per_circle; ++i) {
+    const double x = cylinder.radius() * cos(angle_step * i);
+    const double y = cylinder.radius() * sin(angle_step * i);
+    v[0][i] = VolumeVertexIndex(mesh_vertices.size());
+    mesh_vertices.emplace_back(x, y, bottom_z);
+    v[1][i] = VolumeVertexIndex(mesh_vertices.size());
+    mesh_vertices.emplace_back(x, y, top_z);
+  }
+
+  // For a long cylinder, these two vertices are at the two end points of the
+  // central medial line segment. For a short cylinder, these two virtual
+  // vertices point to the same mesh vertex at the center of the central
+  // medial circular disk for convenience. For a medium cylinder, both virtual
+  // vertices point to the same mesh vertex at the origin of the frame of
+  // the cylinder.
+  VolumeVertexIndex cm[2];
+  const double shorter_half = std::min(top_z, cylinder.radius());
+  const double offset_distance = shorter_half;
+  const double offset_top_z = top_z - offset_distance;
+  const double offset_bottom_z = -offset_top_z;
+  cm[0] = VolumeVertexIndex(mesh_vertices.size());
+  mesh_vertices.emplace_back(0, 0, offset_bottom_z);
+  if (top_z > cylinder.radius()) {
+    // Long cylinder.
+    cm[1] = VolumeVertexIndex(mesh_vertices.size());
+    mesh_vertices.emplace_back(0, 0, offset_top_z);
+  } else {
+    // Medium cylinder or short cylinder.
+    cm[1] = cm[0];
+  }
+
+  // For a long cylinder, all virtual vertices m[0][i] point to the same mesh
+  // vertex as cm[0], and all virtual vertices m[1][i] point to the same mesh
+  // vertex as cm[1]. For a short cylinder, all virtual vertices m[0][i] and
+  // m[1][i] are at the same boundary circle of the central medial disk.
+  // For a medium cylinder, all m[0][i] and m[1][i] point to the same vertex
+  // as cm[0] = cm[1].
+  VolumeVertexIndex m[2][num_vertices_per_circle];
+  const double offset_radius = cylinder.radius() - offset_distance;
+  const double scale_cylinder_radius_to_offset_surface =
+  offset_radius / cylinder.radius();
+  for (int i = 0; i < num_vertices_per_circle; ++i) {
+    if (top_z >= cylinder.radius()) {
+      // Long cylinder or medium cylinder.
+      m[0][i] = cm[0];
+      m[1][i] = cm[1];
+    } else {
+      // Short cylinder.
+      const double x = ExtractDoubleOrThrow(mesh_vertices[v[0][i]].r_MV().x()) *
+          scale_cylinder_radius_to_offset_surface;
+      const double y = ExtractDoubleOrThrow(mesh_vertices[v[0][i]].r_MV().y()) *
+          scale_cylinder_radius_to_offset_surface;
+      m[0][i] = VolumeVertexIndex(mesh_vertices.size());
+      mesh_vertices.emplace_back(x, y, offset_bottom_z);
+      m[1][i] = m[0][i];
+    }
+  }
+
+  std::vector<VolumeElement> mesh_elements;
+  auto append =
+      [&mesh_elements](const std::vector<VolumeElement>& new_elements) {
+        mesh_elements.insert(mesh_elements.end(), new_elements.begin(),
+                             new_elements.end());
+      };
+
+  // TODO(DamrongGuoy): Tighten the bound.
+  mesh_elements.reserve(6 * num_vertices_per_circle +
+                        6 * num_vertices_per_circle +
+                        6 * num_vertices_per_circle);
+  // Virtual rectangular boxes.
+  // i = (n-1) 0 1 2 ... (n-2)
+  // j =   0   1 2 3 ... (n-1)
+  int i = num_vertices_per_circle - 1;
+  for (int j = 0; j < num_vertices_per_circle; ++j) {
+    append(SplitToTetrahedra(m[0][j], m[1][j], m[1][i], m[0][i],    // medial
+                             v[0][j], v[1][j], v[1][i], v[0][i]));  // cylinder
+    i = j;
+  }
+
+  // Bottom virtual triangular prisms.
+  i = num_vertices_per_circle - 1;
+  for (int j = 0; j < num_vertices_per_circle; ++j) {
+    append(SplitToTetrahedra(m[0][j], v[0][j], v[0][i], m[0][i], cm[0], cv[0],
+                             cv[0], cm[0]));
+    i = j;
+  }
+
+  // Top virtual triangular prisms.
+  i = num_vertices_per_circle - 1;
+  for (int j = 0; j < num_vertices_per_circle; ++j) {
+    append(SplitToTetrahedra(m[1][j], m[1][i], v[1][i], v[1][j], cm[1], cm[1],
+                             cv[1], cv[1]));
+    i = j;
+  }
+
+  return {std::move(mesh_elements), std::move(mesh_vertices)};
+}
+
+template VolumeMesh<double> MakeCylinderVolumeMeshWithMa(
+    const Cylinder&, double resolution_hint);
+template VolumeMesh<AutoDiffXd> MakeCylinderVolumeMeshWithMa(
+    const Cylinder&, double resolution_hint);
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/make_cylinder_mesh.h
+++ b/geometry/proximity/make_cylinder_mesh.h
@@ -18,6 +18,10 @@ namespace drake {
 namespace geometry {
 namespace internal {
 
+template <typename T>
+VolumeMesh<T> MakeCylinderVolumeMeshWithMa(const Cylinder& cylinder,
+                                           double resolution_hint);
+
 // Helper methods for MakeCylinderVolumeMesh().
 #ifndef DRAKE_DOXYGEN_CXX
 

--- a/geometry/proximity/meshing_utilities.cc
+++ b/geometry/proximity/meshing_utilities.cc
@@ -1,0 +1,32 @@
+#include "drake/geometry/proximity/meshing_utilities.h"
+
+#include <unordered_set>
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+using std::unordered_set;
+
+std::vector<VolumeElement> SplitToTetrahedra(
+    VolumeVertexIndex v0, VolumeVertexIndex v1, VolumeVertexIndex v2,
+    VolumeVertexIndex v3, VolumeVertexIndex v4, VolumeVertexIndex v5,
+    VolumeVertexIndex v6, VolumeVertexIndex v7) {
+  std::vector<VolumeElement> elements;
+  elements.reserve(6);
+  VolumeVertexIndex previous = v1;
+  for (const VolumeVertexIndex& next : {v2, v3, v7, v4, v5, v1}) {
+    // Allow distinct vertex indices only.
+    if (unordered_set<VolumeVertexIndex>({previous, next, v0, v6}).size() ==
+        4) {
+      elements.emplace_back(previous, next, v0, v6);
+    }
+    previous = next;
+  }
+  return elements;
+}
+
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/meshing_utilities.h
+++ b/geometry/proximity/meshing_utilities.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/geometry/proximity/volume_mesh.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+/* Subdivides a virtual cube to have up to six tetrahedra such that they
+ share the diagonal v0v6 (see ordering below). We allow repeated vertices in
+ the virtual cube and will skip tetrahedra with repeated vertices.
+
+ We assume the input vertex indices (represented as VolumeVertexIndex) are in
+ this ordering:
+   1. Four vertices v0,v1,v2,v3 of the "bottom" face in counterclockwise
+      order when look from "above" the cube.
+   2. Four vertices v4,v5,v6,v7 of the "top" face matching v0,v1,v2,v3,
+      respectively.
+
+                       v4-----------v7
+                      /|           /|
+                     / |          / |
+                    /  |         /  |
+                   /   |        /   |
+                  /    v0------/----v3
+                 /    /       /    /
+                v5-----------v6   /
+                |   /        |   /
+                |  /         |  /
+                | /          | /
+                |/           |/
+                v1-----------v2
+
+ Examples of cases with repeated vertices.
+ - If v0 == v3 and v1 == v2, we will have a prism instead of a cube and will
+   get 3 tetrahedra instead of 6 tetrahedra.
+ - If v0 == v1 == v2 == v3, we will have a pyramid instead of a cube and will
+   get 2 tetrahedra instead of 6 tetrahedra.
+
+ @note   This function is purely topological because it takes only
+ VolumeVertexIndex into account without attempting to access coordinates of
+ the vertices.
+ */
+std::vector<VolumeElement> SplitToTetrahedra(
+    VolumeVertexIndex v0, VolumeVertexIndex v1, VolumeVertexIndex v2,
+    VolumeVertexIndex v3, VolumeVertexIndex v4, VolumeVertexIndex v5,
+    VolumeVertexIndex v6, VolumeVertexIndex v7);
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/make_cylinder_mesh_test.cc
+++ b/geometry/proximity/test/make_cylinder_mesh_test.cc
@@ -11,6 +11,34 @@ namespace geometry {
 namespace internal {
 namespace {
 
+GTEST_TEST(MakeCylinderVolumeMeshWithMaTest, Long) {
+  const double radius = 1.0;
+  const double length = 3.0;
+  const double resolution_hint = radius/2;
+  VolumeMesh<double> mesh = MakeCylinderVolumeMeshWithMa<double>(
+      Cylinder(radius, length), resolution_hint);
+  EXPECT_EQ(1, ComputeEulerCharacteristic(mesh));
+}
+
+GTEST_TEST(MakeCylinderVolumeMeshWithMaTest, Medium) {
+  const double radius = 1.0;
+  const double length = 2.0;
+  const double resolution_hint = radius / 2;
+  VolumeMesh<double> mesh = MakeCylinderVolumeMeshWithMa<double>(
+      Cylinder(radius, length), resolution_hint);
+  EXPECT_EQ(1, ComputeEulerCharacteristic(mesh));
+}
+
+GTEST_TEST(MakeCylinderVolumeMeshWithMaTest, Short) {
+  const double radius = 1.0;
+  const double length = 1.0;
+  const double resolution_hint = radius/2;
+  VolumeMesh<double> mesh = MakeCylinderVolumeMeshWithMa<double>(
+      Cylinder(radius, length), resolution_hint);
+  EXPECT_EQ(1, ComputeEulerCharacteristic(mesh));
+}
+
+
 GTEST_TEST(MakeCylinderVolumeMesh, CoarsestMesh) {
   const double radius = 1.0;
   const double length = 2.0;


### PR DESCRIPTION
Still a draft PR. Fix issue #12128.

Cc: @joemasterjohn You might find this draft useful.  I also factored out SplitToTetrahedra(), which might be useful for the Capsule mesh too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14334)
<!-- Reviewable:end -->
