### PR TITLE
trajectories: Refactor PiecewiseCartesianTrajectory to PiecewisePoseTrajectory

### DIFF
--- a/common/trajectories/BUILD.bazel
+++ b/common/trajectories/BUILD.bazel
@@ -17,6 +17,7 @@ drake_cc_package_library(
         ":bspline_trajectory",
         ":discrete_time_trajectory",
         ":piecewise_polynomial",
+        ":piecewise_pose",
         ":piecewise_quaternion",
         ":piecewise_trajectory",
         ":trajectory",
@@ -73,6 +74,19 @@ drake_cc_library(
         "//common:essential",
         "//common:polynomial",
         "@fmt",
+    ],
+)
+
+drake_cc_library(
+    name = "piecewise_pose",
+    srcs = ["piecewise_pose.cc"],
+    hdrs = ["piecewise_pose.h"],
+    deps = [
+        ":piecewise_polynomial",
+        ":piecewise_quaternion",
+        "//common:essential",
+        "//common:pointer_cast",
+        "//math:geometric_transform",
     ],
 )
 
@@ -166,6 +180,14 @@ drake_cc_googletest(
     deps = [
         ":piecewise_polynomial",
         ":random_piecewise_polynomial",
+        "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "piecewise_pose_test",
+    deps = [
+        ":piecewise_pose",
         "//common/test_utilities:eigen_matrix_compare",
     ],
 )

--- a/common/trajectories/piecewise_pose.cc
+++ b/common/trajectories/piecewise_pose.cc
@@ -1,0 +1,136 @@
+#include "drake/common/trajectories/piecewise_pose.h"
+
+#include "drake/common/pointer_cast.h"
+#include "drake/common/polynomial.h"
+#include "drake/math/rotation_matrix.h"
+
+namespace drake {
+namespace trajectories {
+
+template <typename T>
+PiecewisePose<T>::PiecewisePose(const PiecewisePolynomial<T>& pos_traj,
+                                const PiecewiseQuaternionSlerp<T>& rot_traj) {
+  DRAKE_DEMAND(pos_traj.rows() == 3);
+  DRAKE_DEMAND(pos_traj.cols() == 1);
+  position_ = pos_traj;
+  velocity_ = position_.derivative();
+  acceleration_ = velocity_.derivative();
+  orientation_ = rot_traj;
+}
+
+template <typename T>
+PiecewisePose<T> PiecewisePose<T>::MakeCubicLinearWithEndLinearVelocity(
+    const std::vector<T>& times,
+    const std::vector<math::RigidTransform<T>>& poses,
+    const Vector3<T>& start_vel, const Vector3<T>& end_vel) {
+  std::vector<MatrixX<T>> pos_knots(poses.size());
+  std::vector<math::RotationMatrix<T>> rot_knots(poses.size());
+  for (size_t i = 0; i < poses.size(); ++i) {
+    pos_knots[i] = poses[i].translation();
+    rot_knots[i] = poses[i].rotation();
+  }
+
+  return PiecewisePose<T>(
+      PiecewisePolynomial<T>::CubicWithContinuousSecondDerivatives(
+          times, pos_knots, start_vel, end_vel),
+      PiecewiseQuaternionSlerp<T>(times, rot_knots));
+}
+
+template <typename T>
+std::unique_ptr<Trajectory<T>> PiecewisePose<T>::Clone() const {
+  return std::make_unique<PiecewisePose>(*this);
+}
+
+template <typename T>
+math::RigidTransform<T> PiecewisePose<T>::get_pose(const T& time) const {
+  return math::RigidTransform<T>(orientation_.orientation(time),
+                                 position_.value(time));
+}
+
+template <typename T>
+Vector6<T> PiecewisePose<T>::get_velocity(const T& time) const {
+  Vector6<T> velocity;
+  if (orientation_.is_time_in_range(time)) {
+    velocity.template head<3>() = orientation_.angular_velocity(time);
+  } else {
+    velocity.template head<3>().setZero();
+  }
+  if (position_.is_time_in_range(time)) {
+    velocity.template tail<3>() = velocity_.value(time);
+  } else {
+    velocity.template tail<3>().setZero();
+  }
+  return velocity;
+}
+
+template <typename T>
+Vector6<T> PiecewisePose<T>::get_acceleration(const T& time) const {
+  Vector6<T> acceleration;
+  if (orientation_.is_time_in_range(time)) {
+    acceleration.template head<3>() = orientation_.angular_acceleration(time);
+  } else {
+    acceleration.template head<3>().setZero();
+  }
+  if (position_.is_time_in_range(time)) {
+    acceleration.template tail<3>() = acceleration_.value(time);
+  } else {
+    acceleration.template tail<3>().setZero();
+  }
+  return acceleration;
+}
+
+template <typename T>
+bool PiecewisePose<T>::is_approx(const PiecewisePose<T>& other,
+                                 double tol) const {
+  bool ret = position_.isApprox(other.position_, tol);
+  ret &= orientation_.is_approx(other.orientation_, tol);
+  return ret;
+}
+
+template <typename T>
+bool PiecewisePose<T>::do_has_derivative() const {
+  return true;
+}
+
+template <typename T>
+MatrixX<T> PiecewisePose<T>::DoEvalDerivative(const T& t,
+                                              int derivative_order) const {
+  if (derivative_order == 0) {
+    return value(t);
+  }
+  Vector6<T> derivative;
+  derivative.template head<3>() =
+      orientation_.EvalDerivative(t, derivative_order);
+  derivative.template tail<3>() = position_.EvalDerivative(t, derivative_order);
+  return derivative;
+}
+
+template <typename T>
+std::unique_ptr<Trajectory<T>> PiecewisePose<T>::DoMakeDerivative(
+    int derivative_order) const {
+  if (derivative_order == 0) {
+    return this->Clone();
+  }
+  std::unique_ptr<PiecewisePolynomial<T>> orientation_deriv =
+      dynamic_pointer_cast<PiecewisePolynomial<T>>(
+          orientation_.MakeDerivative(derivative_order));
+  PiecewisePolynomial<T> position_deriv =
+      position_.derivative(derivative_order);
+  const std::vector<T>& breaks = position_deriv.get_segment_times();
+  std::vector<MatrixX<Polynomial<T>>> derivative;
+  for (size_t ii = 0; ii < breaks.size() - 1; ii++) {
+    MatrixX<Polynomial<T>> segment_derivative(6, 1);
+    segment_derivative.template topRows<3>() =
+        orientation_deriv->getPolynomialMatrix(ii);
+    segment_derivative.template bottomRows<3>() =
+        position_deriv.getPolynomialMatrix(ii);
+    derivative.push_back(segment_derivative);
+  }
+  return std::make_unique<PiecewisePolynomial<T>>(derivative, breaks);
+}
+
+}  // namespace trajectories
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class drake::trajectories::PiecewisePose)

--- a/common/trajectories/piecewise_pose.h
+++ b/common/trajectories/piecewise_pose.h
@@ -1,0 +1,121 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/common/trajectories/piecewise_polynomial.h"
+#include "drake/common/trajectories/piecewise_quaternion.h"
+#include "drake/common/trajectories/piecewise_trajectory.h"
+#include "drake/math/rigid_transform.h"
+
+namespace drake {
+namespace trajectories {
+
+/**
+ * A wrapper class that represents a pose trajectory, whose rotation part is a
+ * PiecewiseQuaternionSlerp and the translation part is a PiecewisePolynomial.
+ *
+ * @tparam_default_scalars
+ */
+template <typename T>
+class PiecewisePose final : public PiecewiseTrajectory<T> {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PiecewisePose)
+
+  /**
+   *  Constructs an empty piecewise pose trajectory.
+   */
+  PiecewisePose() {}
+
+  /**
+   * Constructor.
+   * @param pos_traj Position trajectory.
+   * @param rot_traj Orientation trajectory.
+   */
+  PiecewisePose(const PiecewisePolynomial<T>& pos_traj,
+                const PiecewiseQuaternionSlerp<T>& rot_traj);
+
+  /**
+   * Constructs a PiecewisePose from given @p time and @p poses.
+   * A cubic polynomial with given end velocities is used to construct the
+   * position part. The rotational part is represented by a piecewise quaterion
+   * trajectory.  There must be at least two elements in @p times and @p poses.
+   * @param times     Breaks used to build the splines.
+   * @param poses     Knots used to build the splines.
+   * @param start_vel Start linear velocity.
+   * @param end_vel   End linear velocity.
+   */
+  static PiecewisePose<T> MakeCubicLinearWithEndLinearVelocity(
+      const std::vector<T>& times,
+      const std::vector<math::RigidTransform<T>>& poses,
+      const Vector3<T>& start_vel = Vector3<T>::Zero(),
+      const Vector3<T>& end_vel = Vector3<T>::Zero());
+
+  std::unique_ptr<Trajectory<T>> Clone() const override;
+
+  Eigen::Index rows() const override { return 4; }
+
+  Eigen::Index cols() const override { return 4; }
+
+  /**
+   * Returns the interpolated pose at @p time.
+   */
+  math::RigidTransform<T> get_pose(const T& time) const;
+
+  MatrixX<T> value(const T& t) const override {
+    return get_pose(t).GetAsMatrix4();
+  }
+
+  /**
+   * Returns the interpolated velocity at @p time or zero if @p time is before
+   * this trajectory's start time or after its end time.
+   */
+  Vector6<T> get_velocity(const T& time) const;
+
+  /**
+   * Returns the interpolated acceleration at @p time or zero if @p time is
+   * before this trajectory's start time or after its end time.
+   */
+  Vector6<T> get_acceleration(const T& time) const;
+
+  /**
+   * Returns true if the position and orientation trajectories are both
+   * within @p tol from the other's.
+   */
+  bool is_approx(const PiecewisePose<T>& other, double tol) const;
+
+  /**
+   * Returns the position trajectory.
+   */
+  const PiecewisePolynomial<T>& get_position_trajectory() const {
+    return position_;
+  }
+
+  /**
+   * Returns the orientation trajectory.
+   */
+  const PiecewiseQuaternionSlerp<T>& get_orientation_trajectory() const {
+    return orientation_;
+  }
+
+ private:
+  bool do_has_derivative() const override;
+
+  MatrixX<T> DoEvalDerivative(const T& t, int derivative_order) const override;
+
+  std::unique_ptr<Trajectory<T>> DoMakeDerivative(
+      int derivative_order) const override;
+
+  PiecewisePolynomial<T> position_;
+  PiecewisePolynomial<T> velocity_;
+  PiecewisePolynomial<T> acceleration_;
+  PiecewiseQuaternionSlerp<T> orientation_;
+};
+
+}  // namespace trajectories
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class drake::trajectories::PiecewisePose)

--- a/common/trajectories/piecewise_quaternion.cc
+++ b/common/trajectories/piecewise_quaternion.cc
@@ -11,7 +11,7 @@ namespace trajectories {
 
 template <typename T>
 bool PiecewiseQuaternionSlerp<T>::is_approx(
-    const PiecewiseQuaternionSlerp<T>& other, const T& tol) const {
+    const PiecewiseQuaternionSlerp<T>& other, double tol) const {
   // Velocities are derived from the quaternions, and I don't want to
   // overload units for tol, so I am skipping the checks on velocities.
   if (!this->SegmentTimesEqual(other, tol))
@@ -24,7 +24,8 @@ bool PiecewiseQuaternionSlerp<T>::is_approx(
     // A quick reference:
     // Page "Metric on sphere of unit quaternions" from
     // http://www.cs.cmu.edu/afs/cs/academic/class/16741-s07/www/Lecture8.pdf
-    T dot = std::abs(quaternions_[i].dot(other.quaternions_[i]));
+    double dot = std::abs(
+        ExtractDoubleOrThrow(quaternions_[i].dot(other.quaternions_[i])));
     if (dot < std::cos(tol / 2)) {
       return false;
     }
@@ -36,7 +37,7 @@ bool PiecewiseQuaternionSlerp<T>::is_approx(
 namespace internal {
 
 template <typename T>
-Vector3<T> ComputeAngularVelocity(double duration, const Quaternion<T>& q,
+Vector3<T> ComputeAngularVelocity(const T& duration, const Quaternion<T>& q,
                                   const Quaternion<T>& qnext) {
   // Computes qnext = q_delta * q first, turn q_delta into an axis, which
   // turns into an angular velocity.
@@ -48,7 +49,7 @@ Vector3<T> ComputeAngularVelocity(double duration, const Quaternion<T>& q,
 
 template <typename T>
 void PiecewiseQuaternionSlerp<T>::Initialize(
-    const std::vector<double>& breaks,
+    const std::vector<T>& breaks,
     const std::vector<Quaternion<T>>& quaternions) {
   if (quaternions.size() != breaks.size()) {
     throw std::logic_error("Quaternions and breaks length mismatch.");
@@ -74,7 +75,7 @@ void PiecewiseQuaternionSlerp<T>::Initialize(
 
 template <typename T>
 PiecewiseQuaternionSlerp<T>::PiecewiseQuaternionSlerp(
-    const std::vector<double>& breaks,
+    const std::vector<T>& breaks,
     const std::vector<Quaternion<T>>& quaternions)
     : PiecewiseTrajectory<T>(breaks) {
   Initialize(breaks, quaternions);
@@ -82,7 +83,7 @@ PiecewiseQuaternionSlerp<T>::PiecewiseQuaternionSlerp(
 
 template <typename T>
 PiecewiseQuaternionSlerp<T>::PiecewiseQuaternionSlerp(
-    const std::vector<double>& breaks,
+    const std::vector<T>& breaks,
     const std::vector<Matrix3<T>>& rot_matrices)
     : PiecewiseTrajectory<T>(breaks) {
   std::vector<Quaternion<T>> quaternions(rot_matrices.size());
@@ -94,7 +95,7 @@ PiecewiseQuaternionSlerp<T>::PiecewiseQuaternionSlerp(
 
 template <typename T>
 PiecewiseQuaternionSlerp<T>::PiecewiseQuaternionSlerp(
-    const std::vector<double>& breaks,
+    const std::vector<T>& breaks,
     const std::vector<math::RotationMatrix<T>>& rot_matrices)
     : PiecewiseTrajectory<T>(breaks) {
   std::vector<Quaternion<T>> quaternions(rot_matrices.size());
@@ -106,7 +107,7 @@ PiecewiseQuaternionSlerp<T>::PiecewiseQuaternionSlerp(
 
 template <typename T>
 PiecewiseQuaternionSlerp<T>::PiecewiseQuaternionSlerp(
-    const std::vector<double>& breaks,
+    const std::vector<T>& breaks,
     const std::vector<AngleAxis<T>>& ang_axes)
     : PiecewiseTrajectory<T>(breaks) {
   std::vector<Quaternion<T>> quaternions(ang_axes.size());
@@ -122,22 +123,22 @@ std::unique_ptr<Trajectory<T>> PiecewiseQuaternionSlerp<T>::Clone() const {
 }
 
 template <typename T>
-double PiecewiseQuaternionSlerp<T>::ComputeInterpTime(int segment_index,
-                                                           double time) const {
-  time =
+T PiecewiseQuaternionSlerp<T>::ComputeInterpTime(int segment_index,
+                                                  const T& time) const {
+  T interp_time =
       (time - this->start_time(segment_index)) / this->duration(segment_index);
-  time = std::max(time, 0.0);
-  time = std::min(time, 1.0);
-  return time;
+  interp_time = std::max(interp_time, T(0.0));
+  interp_time = std::min(interp_time, T(1.0));
+  return interp_time;
 }
 
 template <typename T>
-Quaternion<T> PiecewiseQuaternionSlerp<T>::orientation(double t) const {
+Quaternion<T> PiecewiseQuaternionSlerp<T>::orientation(const T& t) const {
   int segment_index = this->get_segment_index(t);
-  t = ComputeInterpTime(segment_index, t);
+  T interp_t = ComputeInterpTime(segment_index, t);
 
   Quaternion<T> q1 = quaternions_.at(segment_index)
-                              .slerp(t, quaternions_.at(segment_index + 1));
+                         .slerp(interp_t, quaternions_.at(segment_index + 1));
 
   q1.normalize();
 
@@ -145,14 +146,14 @@ Quaternion<T> PiecewiseQuaternionSlerp<T>::orientation(double t) const {
 }
 
 template <typename T>
-Vector3<T> PiecewiseQuaternionSlerp<T>::angular_velocity(double t) const {
+Vector3<T> PiecewiseQuaternionSlerp<T>::angular_velocity(const T& t) const {
   int segment_index = this->get_segment_index(t);
 
   return angular_velocities_.at(segment_index);
 }
 
 template <typename T>
-Vector3<T> PiecewiseQuaternionSlerp<T>::angular_acceleration(double) const {
+Vector3<T> PiecewiseQuaternionSlerp<T>::angular_acceleration(const T&) const {
   return Vector3<T>::Zero();
 }
 
@@ -216,7 +217,8 @@ std::unique_ptr<Trajectory<T>> PiecewiseQuaternionSlerp<T>::DoMakeDerivative(
   return std::make_unique<PiecewisePolynomial<T>>(Vector3<T>::Zero());
 }
 
-template class PiecewiseQuaternionSlerp<double>;
-
 }  // namespace trajectories
 }  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class drake::trajectories::PiecewiseQuaternionSlerp)

--- a/common/trajectories/piecewise_quaternion.h
+++ b/common/trajectories/piecewise_quaternion.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <vector>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/trajectories/piecewise_trajectory.h"
@@ -11,7 +12,6 @@
 namespace drake {
 namespace trajectories {
 
-// TODO(siyuan.feng): check if this works for AutoDiffScalar.
 /**
  * A class representing a trajectory for quaternions that are interpolated
  * using piecewise slerp (spherical linear interpolation).
@@ -27,7 +27,7 @@ namespace trajectories {
  * Another intuitive way to think about this is that consecutive quaternions
  * have the shortest geodesic distance on the unit sphere.
  *
- * @tparam_double_only
+ * @tparam_default_scalars
  */
 template<typename T>
 class PiecewiseQuaternionSlerp final : public PiecewiseTrajectory<T> {
@@ -45,7 +45,7 @@ class PiecewiseQuaternionSlerp final : public PiecewiseTrajectory<T> {
    * or breaks have length < 2.
    */
   PiecewiseQuaternionSlerp(
-      const std::vector<double>& breaks,
+      const std::vector<T>& breaks,
       const std::vector<Quaternion<T>>& quaternions);
 
   /**
@@ -54,7 +54,7 @@ class PiecewiseQuaternionSlerp final : public PiecewiseTrajectory<T> {
    * or breaks have length < 2.
    */
   PiecewiseQuaternionSlerp(
-      const std::vector<double>& breaks,
+      const std::vector<T>& breaks,
       const std::vector<Matrix3<T>>& rotation_matrices);
 
   /**
@@ -63,7 +63,7 @@ class PiecewiseQuaternionSlerp final : public PiecewiseTrajectory<T> {
    * or breaks have length < 2.
    */
   PiecewiseQuaternionSlerp(
-      const std::vector<double>& breaks,
+      const std::vector<T>& breaks,
       const std::vector<math::RotationMatrix<T>>& rotation_matrices);
 
   /**
@@ -72,7 +72,7 @@ class PiecewiseQuaternionSlerp final : public PiecewiseTrajectory<T> {
    * or breaks have length < 2.
    */
   PiecewiseQuaternionSlerp(
-      const std::vector<double>& breaks,
+      const std::vector<T>& breaks,
       const std::vector<AngleAxis<T>>& angle_axes);
 
   ~PiecewiseQuaternionSlerp() override = default;
@@ -88,7 +88,7 @@ class PiecewiseQuaternionSlerp final : public PiecewiseTrajectory<T> {
    * @param t Time for interpolation.
    * @return The interpolated quaternion at `t`.
    */
-  Quaternion<T> orientation(double t) const;
+  Quaternion<T> orientation(const T& t) const;
 
   MatrixX<T> value(const T& t) const override {
     return orientation(t).matrix();
@@ -100,7 +100,7 @@ class PiecewiseQuaternionSlerp final : public PiecewiseTrajectory<T> {
    * @return The interpolated angular velocity at `t`,
    * which is constant per segment.
    */
-  Vector3<T> angular_velocity(double t) const;
+  Vector3<T> angular_velocity(const T& t) const;
 
   /**
    * Interpolates angular acceleration.
@@ -108,7 +108,7 @@ class PiecewiseQuaternionSlerp final : public PiecewiseTrajectory<T> {
    * @return The interpolated angular acceleration at `t`,
    * which is always zero for slerp.
    */
-  Vector3<T> angular_acceleration(double t) const;
+  Vector3<T> angular_acceleration(const T& t) const;
 
   /**
    * Getter for the internal quaternion samples.
@@ -126,10 +126,10 @@ class PiecewiseQuaternionSlerp final : public PiecewiseTrajectory<T> {
   /**
    * Returns true if all the corresponding segment times are within
    * @p tol seconds, and the angle difference between the corresponding
-   * quaternion sample points are within @p tol.
+   * quaternion sample points are within @p tol (using `ExtractDoubleOrThrow`).
    */
   bool is_approx(const PiecewiseQuaternionSlerp<T>& other,
-                 const T& tol) const;
+                 double tol) const;
 
   /**
    * Given a new Quaternion, this method adds one segment to the end of `this`.
@@ -150,11 +150,11 @@ class PiecewiseQuaternionSlerp final : public PiecewiseTrajectory<T> {
  private:
   // Initialize quaternions_ and computes angular velocity for each segment.
   void Initialize(
-      const std::vector<double>& breaks,
+      const std::vector<T>& breaks,
       const std::vector<Quaternion<T>>& quaternions);
 
   // Computes the interpolation time within each segment. Result is in [0, 1].
-  double ComputeInterpTime(int segment_index, double time) const;
+  T ComputeInterpTime(int segment_index, const T& time) const;
 
   bool do_has_derivative() const override;
 
@@ -169,3 +169,6 @@ class PiecewiseQuaternionSlerp final : public PiecewiseTrajectory<T> {
 
 }  // namespace trajectories
 }  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class drake::trajectories::PiecewiseQuaternionSlerp)

--- a/common/trajectories/test/piecewise_pose_test.cc
+++ b/common/trajectories/test/piecewise_pose_test.cc
@@ -1,0 +1,221 @@
+#include "drake/common/trajectories/piecewise_pose.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/rigid_transform.h"
+
+namespace drake {
+namespace trajectories {
+
+using math::RigidTransform;
+using trajectories::PiecewisePolynomial;
+using trajectories::PiecewiseQuaternionSlerp;
+
+class PiecewisePoseTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    std::vector<double> times = {1, 2};
+    std::vector<AngleAxis<double>> rot_samples(times.size());
+    std::vector<MatrixX<double>> pos_samples(times.size(),
+                                             MatrixX<double>(3, 1));
+
+    rot_samples[0] = AngleAxis<double>(0.3, Vector3<double>::UnitX());
+    rot_samples[1] = AngleAxis<double>(-1, Vector3<double>::UnitY());
+
+    pos_samples[0] << 0.3, 0, -0.5;
+    pos_samples[1] << 1, -1, 3;
+
+    std::vector<RigidTransform<double>> samples(times.size());
+    for (size_t i = 0; i < times.size(); ++i) {
+      samples[i] = RigidTransform<double>(rot_samples[i], pos_samples[i]);
+    }
+
+    Vector3<double> start_vel(Vector3<double>::Zero());
+    Vector3<double> end_vel(Vector3<double>::Zero());
+
+    dut_ = PiecewisePose<double>::MakeCubicLinearWithEndLinearVelocity(
+        times, samples, start_vel, end_vel);
+
+    test_times_ = {times.front() - 0.2, times.front(),
+                   (times.front() + times.back()) / 2., times.back(),
+                   times.back() + 0.3};
+
+    position_ =
+        PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(
+            times, pos_samples, start_vel, end_vel);
+    orientation_ = PiecewiseQuaternionSlerp<double>(times, rot_samples);
+  }
+
+  PiecewisePose<double> dut_;
+  std::vector<double> test_times_;
+
+  PiecewisePolynomial<double> position_;
+  PiecewiseQuaternionSlerp<double> orientation_;
+};
+
+// Tests linear velocity starts and ends at zero.
+TEST_F(PiecewisePoseTest, TestEndLinearVelocity) {
+  double t0 = dut_.get_position_trajectory().start_time();
+  double t1 = dut_.get_position_trajectory().end_time();
+
+  EXPECT_TRUE(drake::CompareMatrices(dut_.get_velocity(t0).tail<3>(),
+                                     Vector3<double>::Zero(), 1e-12,
+                                     drake::MatrixCompareType::absolute));
+
+  EXPECT_TRUE(drake::CompareMatrices(dut_.get_velocity(t1).tail<3>(),
+                                     Vector3<double>::Zero(), 1e-12,
+                                     drake::MatrixCompareType::absolute));
+}
+
+// Tests pose matches that directly interpolated from PiecewiseQuaternionSlerp
+// and PiecewisePolynomial.
+TEST_F(PiecewisePoseTest, TestPose) {
+  for (double time : test_times_) {
+    math::RigidTransform<double> expected(orientation_.orientation(time),
+                                          position_.value(time));
+    EXPECT_TRUE(drake::CompareMatrices(dut_.get_pose(time).GetAsMatrix4(),
+                                       expected.GetAsMatrix4(), 1e-12,
+                                       drake::MatrixCompareType::absolute));
+    EXPECT_TRUE(drake::CompareMatrices(dut_.value(time),
+                                       expected.GetAsMatrix4(), 1e-12,
+                                       drake::MatrixCompareType::absolute));
+  }
+}
+
+// Tests velocity matches that directly interpolated from
+// PiecewiseQuaternionSlerp and PiecewisePolynomial.
+TEST_F(PiecewisePoseTest, TestVelocity) {
+  for (double time : test_times_) {
+    Vector6<double> expected;
+    expected.head<3>() = orientation_.angular_velocity(time);
+    expected.tail<3>() = position_.derivative().value(time);
+
+    if (!orientation_.is_time_in_range(time)) expected.head<3>().setZero();
+    if (!position_.is_time_in_range(time)) expected.tail<3>().setZero();
+
+    EXPECT_TRUE(drake::CompareMatrices(dut_.get_velocity(time), expected, 1e-12,
+                                       drake::MatrixCompareType::absolute));
+  }
+}
+
+// Tests angular acceleration is always zero because of linear interpolation,
+// and linear acceleration matches that interpolated from
+// PiecewisePolynomial.
+TEST_F(PiecewisePoseTest, TestAccelertaion) {
+  for (double time : test_times_) {
+    Vector6<double> expected;
+    expected.head<3>() = Vector3<double>::Zero();
+    expected.tail<3>() = position_.derivative(2).value(time);
+
+    if (!position_.is_time_in_range(time)) expected.tail<3>().setZero();
+
+    EXPECT_TRUE(drake::CompareMatrices(dut_.get_acceleration(time), expected,
+                                       1e-12,
+                                       drake::MatrixCompareType::absolute));
+  }
+}
+
+// Tests getters.
+TEST_F(PiecewisePoseTest, TestGetTrajectory) {
+  EXPECT_TRUE(dut_.get_position_trajectory().isApprox(position_, 1e-12));
+  EXPECT_TRUE(dut_.get_orientation_trajectory().is_approx(orientation_, 1e-12));
+}
+
+// Tests is_approx().
+TEST_F(PiecewisePoseTest, TestIsApprox) {
+  std::vector<double> times = {1, 2, 3};
+  std::vector<AngleAxis<double>> rot_samples(times.size());
+  std::vector<MatrixX<double>> pos_samples(times.size(), MatrixX<double>(3, 1));
+  pos_samples[0] << -3, 1, 0;
+  pos_samples[1] << -2, -1, 5;
+  pos_samples[2] << -2, -1, 5;
+
+  rot_samples[0] = AngleAxis<double>(0.3, Vector3<double>::UnitX());
+  rot_samples[1] = AngleAxis<double>(-1, Vector3<double>::UnitY());
+  rot_samples[2] = AngleAxis<double>(-0.44, Vector3<double>::UnitZ());
+
+  PiecewisePolynomial<double> new_pos_traj =
+      PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(
+          times, pos_samples);
+  PiecewiseQuaternionSlerp<double> new_rot_traj(times, rot_samples);
+
+  {
+    PiecewisePose<double> diff_position(new_pos_traj, orientation_);
+    EXPECT_TRUE(!diff_position.is_approx(dut_, 1e-12));
+  }
+
+  {
+    PiecewisePose<double> diff_orientation(position_, new_rot_traj);
+    EXPECT_TRUE(!diff_orientation.is_approx(dut_, 1e-12));
+  }
+}
+
+// Tests getters.
+TEST_F(PiecewisePoseTest, TestTrajectoryOverrides) {
+  EXPECT_EQ(dut_.rows(), 4);
+  EXPECT_EQ(dut_.cols(), 4);
+  EXPECT_TRUE(dut_.has_derivative());
+
+  std::vector<double> truncated_test_times_ =
+      std::vector<double>(test_times_.begin() + 1, test_times_.end() - 1);
+
+  const auto zeroth_derivative = dut_.MakeDerivative(0);
+  const auto first_derivative = dut_.MakeDerivative(1);
+  const auto second_derivative = dut_.MakeDerivative(2);
+
+  for (double time : truncated_test_times_) {
+    EXPECT_TRUE(drake::CompareMatrices(dut_.value(time),
+                                       zeroth_derivative->value(time), 1e-12,
+                                       drake::MatrixCompareType::absolute));
+    EXPECT_TRUE(drake::CompareMatrices(dut_.value(time),
+                                       dut_.EvalDerivative(time, 0), 1e-12,
+                                       drake::MatrixCompareType::absolute));
+
+    EXPECT_TRUE(drake::CompareMatrices(dut_.get_velocity(time),
+                                       first_derivative->value(time), 1e-12,
+                                       drake::MatrixCompareType::absolute));
+    EXPECT_TRUE(drake::CompareMatrices(dut_.get_velocity(time),
+                                       dut_.EvalDerivative(time, 1), 1e-12,
+                                       drake::MatrixCompareType::absolute));
+
+    EXPECT_TRUE(drake::CompareMatrices(dut_.get_acceleration(time),
+                                       second_derivative->value(time), 1e-12,
+                                       drake::MatrixCompareType::absolute));
+    EXPECT_TRUE(drake::CompareMatrices(dut_.get_acceleration(time),
+                                       dut_.EvalDerivative(time, 2), 1e-12,
+                                       drake::MatrixCompareType::absolute));
+  }
+}
+
+template <typename T>
+void TestScalarType() {
+  std::vector<T> times = {1, 2};
+  std::vector<AngleAxis<T>> rot_samples(times.size());
+  std::vector<MatrixX<T>> pos_samples(times.size(), MatrixX<T>(3, 1));
+
+  rot_samples[0] = AngleAxis<T>(0.3, Vector3<T>::UnitX());
+  rot_samples[1] = AngleAxis<T>(-1, Vector3<T>::UnitY());
+
+  pos_samples[0] << 0.3, 0, -0.5;
+  pos_samples[1] << 1, -1, 3;
+
+  Vector3<T> start_vel(Vector3<T>::Zero());
+  Vector3<T> end_vel(Vector3<T>::Zero());
+
+  PiecewisePolynomial<T> position_traj =
+      PiecewisePolynomial<T>::CubicWithContinuousSecondDerivatives(
+          times, pos_samples, start_vel, end_vel);
+  PiecewiseQuaternionSlerp<T> orientation_traj(times, rot_samples);
+
+  PiecewisePose<T> pose_traj(position_traj, orientation_traj);
+}
+
+GTEST_TEST(PiecewisePoseScalarTest, ScalarTypes) {
+  TestScalarType<double>();
+  TestScalarType<AutoDiffXd>();
+  TestScalarType<symbolic::Expression>();
+}
+
+}  // namespace trajectories
+}  // namespace drake

--- a/common/trajectories/test/piecewise_quaternion_test.cc
+++ b/common/trajectories/test/piecewise_quaternion_test.cc
@@ -261,6 +261,22 @@ GTEST_TEST(TestPiecewiseQuaternionSlerp, TestDerivatives) {
   }
 }
 
+template <typename T>
+void TestScalarType() {
+  std::vector<T> times = {1, 2};
+  std::vector<AngleAxis<T>> rot_samples(times.size());
+  rot_samples[0] = AngleAxis<T>(0.3, Vector3<T>::UnitX());
+  rot_samples[1] = AngleAxis<T>(-1, Vector3<T>::UnitY());
+
+  PiecewiseQuaternionSlerp<T> quat_traj(times, rot_samples);
+}
+
+GTEST_TEST(TestPiecewiseQuaternionSlerp, ScalarTypes) {
+  TestScalarType<double>();
+  TestScalarType<AutoDiffXd>();
+  TestScalarType<symbolic::Expression>();
+}
+
 }  // namespace
 }  // namespace trajectories
 }  // namespace drake

--- a/manipulation/util/BUILD.bazel
+++ b/manipulation/util/BUILD.bazel
@@ -93,6 +93,7 @@ drake_cc_library(
     hdrs = [
         "trajectory_utils.h",
     ],
+    copts = ["-Wno-deprecated-declarations"],
     deps = [
         "//common/trajectories:piecewise_polynomial",
         "//common/trajectories:piecewise_quaternion",
@@ -160,6 +161,7 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "trajectory_utils_test",
+    copts = ["-Wno-deprecated-declarations"],
     deps = [
         ":trajectory_utils",
         "//common/test_utilities:eigen_matrix_compare",

--- a/manipulation/util/trajectory_utils.h
+++ b/manipulation/util/trajectory_utils.h
@@ -3,6 +3,7 @@
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/trajectories/piecewise_polynomial.h"
 #include "drake/common/trajectories/piecewise_quaternion.h"
@@ -19,7 +20,8 @@ namespace manipulation {
  * assumed to be independent of each other.
  */
 template <typename T>
-class PiecewiseCubicTrajectory {
+class DRAKE_DEPRECATED("2021-05-01", "Use PiecewisePolynomial instead.")
+PiecewiseCubicTrajectory {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PiecewiseCubicTrajectory)
 
@@ -117,7 +119,8 @@ class PiecewiseCubicTrajectory {
  * PiecewiseQuaternionSlerp.
  */
 template <typename T>
-class PiecewiseCartesianTrajectory {
+class DRAKE_DEPRECATED("2021-05-01", "Use PiecewisePoseTrajectory instead.")
+PiecewiseCartesianTrajectory {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PiecewiseCartesianTrajectory)
 


### PR DESCRIPTION
Also deprecates `PiecewiseCartesianTrajectory` and `PiecewiseCubicTrajectory`

Closes #13973

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14337)
<!-- Reviewable:end -->
