### PR TITLE
pydrake: Fix type bug in BasicVector::set_value for non-float types

### DIFF
--- a/bindings/pydrake/systems/framework_py_values.cc
+++ b/bindings/pydrake/systems/framework_py_values.cc
@@ -134,7 +134,7 @@ void DefineFrameworkPyValues(py::module m) {
         .def(
             "set_value",
             [](Value<BasicVector<T>>* self,
-                const Eigen::Ref<const Eigen::VectorXd>& value) {
+                const Eigen::Ref<const VectorX<T>>& value) {
               self->set_value(BasicVector<T>(value));
             },
             py::arg("value"));


### PR DESCRIPTION
Resolves #14341

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14343)
<!-- Reviewable:end -->
