### PR TITLE
Propagate joint default positions through scalar conversion

### DIFF
--- a/multibody/tree/ball_rpy_joint.cc
+++ b/multibody/tree/ball_rpy_joint.cc
@@ -27,6 +27,7 @@ std::unique_ptr<Joint<ToScalar>> BallRpyJoint<T>::TemplatedDoCloneToScalar(
                                    this->velocity_upper_limits());
   joint_clone->set_acceleration_limits(this->acceleration_lower_limits(),
                                        this->acceleration_upper_limits());
+  joint_clone->set_default_positions(this->default_positions());
 
   return joint_clone;
 }

--- a/multibody/tree/planar_joint.cc
+++ b/multibody/tree/planar_joint.cc
@@ -26,6 +26,7 @@ std::unique_ptr<Joint<ToScalar>> PlanarJoint<T>::TemplatedDoCloneToScalar(
                                    this->velocity_upper_limits());
   joint_clone->set_acceleration_limits(this->acceleration_lower_limits(),
                                        this->acceleration_upper_limits());
+  joint_clone->set_default_positions(this->default_positions());
 
   return joint_clone;
 }

--- a/multibody/tree/prismatic_joint.cc
+++ b/multibody/tree/prismatic_joint.cc
@@ -26,6 +26,7 @@ PrismaticJoint<T>::TemplatedDoCloneToScalar(
                                    this->velocity_upper_limits());
   joint_clone->set_acceleration_limits(this->acceleration_lower_limits(),
                                        this->acceleration_upper_limits());
+  joint_clone->set_default_positions(this->default_positions());
 
   return joint_clone;
 }

--- a/multibody/tree/revolute_joint.cc
+++ b/multibody/tree/revolute_joint.cc
@@ -26,6 +26,7 @@ std::unique_ptr<Joint<ToScalar>> RevoluteJoint<T>::TemplatedDoCloneToScalar(
                                    this->velocity_upper_limits());
   joint_clone->set_acceleration_limits(this->acceleration_lower_limits(),
                                        this->acceleration_upper_limits());
+  joint_clone->set_default_positions(this->default_positions());
 
   return joint_clone;
 }

--- a/multibody/tree/test/ball_rpy_joint_test.cc
+++ b/multibody/tree/test/ball_rpy_joint_test.cc
@@ -160,6 +160,7 @@ TEST_F(BallRpyJointTest, Clone) {
   EXPECT_EQ(joint_clone.acceleration_upper_limits(),
             joint_->acceleration_upper_limits());
   EXPECT_EQ(joint_clone.damping(), joint_->damping());
+  EXPECT_EQ(joint_clone.get_default_angles(), joint_->get_default_angles());
 }
 
 TEST_F(BallRpyJointTest, SetVelocityAndAccelerationLimits) {

--- a/multibody/tree/test/planar_joint_test.cc
+++ b/multibody/tree/test/planar_joint_test.cc
@@ -186,6 +186,9 @@ TEST_F(PlanarJointTest, Clone) {
   EXPECT_EQ(joint_clone.acceleration_upper_limits(),
             joint_->acceleration_upper_limits());
   EXPECT_EQ(joint_clone.damping(), joint_->damping());
+  EXPECT_EQ(joint_clone.get_default_rotation(), joint_->get_default_rotation());
+  EXPECT_EQ(joint_clone.get_default_translation(),
+            joint_->get_default_translation());
 }
 
 TEST_F(PlanarJointTest, DefaultState) {

--- a/multibody/tree/test/prismatic_joint_test.cc
+++ b/multibody/tree/test/prismatic_joint_test.cc
@@ -168,6 +168,8 @@ TEST_F(PrismaticJointTest, Clone) {
   EXPECT_EQ(joint1_clone.acceleration_upper_limits(),
             joint1_->acceleration_upper_limits());
   EXPECT_EQ(joint1_clone.damping(), joint1_->damping());
+  EXPECT_EQ(joint1_clone.get_default_translation(),
+            joint1_->get_default_translation());
 }
 
 TEST_F(PrismaticJointTest, RandomTranslationTest) {

--- a/multibody/tree/test/revolute_joint_test.cc
+++ b/multibody/tree/test/revolute_joint_test.cc
@@ -171,6 +171,7 @@ TEST_F(RevoluteJointTest, Clone) {
   EXPECT_EQ(joint1_clone.acceleration_upper_limits(),
             joint1_->acceleration_upper_limits());
   EXPECT_EQ(joint1_clone.damping(), joint1_->damping());
+  EXPECT_EQ(joint1_clone.get_default_angle(), joint1_->get_default_angle());
 }
 
 TEST_F(RevoluteJointTest, SetVelocityAndAccelerationLimits) {

--- a/multibody/tree/test/universal_joint_test.cc
+++ b/multibody/tree/test/universal_joint_test.cc
@@ -173,6 +173,7 @@ TEST_F(UniversalJointTest, Clone) {
   EXPECT_EQ(joint_clone.acceleration_upper_limits(),
             joint_->acceleration_upper_limits());
   EXPECT_EQ(joint_clone.damping(), joint_->damping());
+  EXPECT_EQ(joint_clone.get_default_angles(), joint_->get_default_angles());
 }
 
 TEST_F(UniversalJointTest, SetVelocityAndAccelerationLimits) {

--- a/multibody/tree/universal_joint.cc
+++ b/multibody/tree/universal_joint.cc
@@ -26,6 +26,7 @@ std::unique_ptr<Joint<ToScalar>> UniversalJoint<T>::TemplatedDoCloneToScalar(
                                    this->velocity_upper_limits());
   joint_clone->set_acceleration_limits(this->acceleration_lower_limits(),
                                        this->acceleration_upper_limits());
+  joint_clone->set_default_positions(this->default_positions());
 
   return joint_clone;
 }


### PR DESCRIPTION
Addresses #14344. This PR fixes a bug where joints' default positions were not being preserved upon scalar conversion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14347)
<!-- Reviewable:end -->
