### PR TITLE
Add jekyll and ruby as docs-only dependency

### DIFF
--- a/setup/ubuntu/source_distribution/packages-bionic-doc-only.txt
+++ b/setup/ubuntu/source_distribution/packages-bionic-doc-only.txt
@@ -1,6 +1,9 @@
 fonts-dejavu-core
 fonts-dejavu-extra
 graphviz
+jekyll
 python3-docutils
 python3-sphinx
 python3-sphinx-rtd-theme
+ruby-jekyll-paginate
+ruby

--- a/setup/ubuntu/source_distribution/packages-focal-doc-only.txt
+++ b/setup/ubuntu/source_distribution/packages-focal-doc-only.txt
@@ -1,6 +1,9 @@
 fonts-dejavu-core
 fonts-dejavu-extra
 graphviz
+jekyll
 python3-docutils
 python3-sphinx
 python3-sphinx-rtd-theme
+ruby-jekyll-paginate
+ruby


### PR DESCRIPTION
Working towards #13832

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14349)
<!-- Reviewable:end -->
