### PR TITLE
py systems: Add keep_alive cycle to DiagramBuilder.AddSystem

### DIFF
--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -457,6 +457,11 @@ void DefineFrameworkPySemantics(py::module m) {
               return self->AddSystem(std::move(system));
             },
             py::arg("system"),
+            // TODO(eric.cousineau): These two keep_alive's purposely form a
+            // reference cycle as a workaround for #14355. We should find a
+            // better way?
+            // Keep alive, reference: `self` keeps `return` alive.
+            py::keep_alive<1, 0>(),
             // Keep alive, ownership: `system` keeps `self` alive.
             py::keep_alive<2, 1>(), doc.DiagramBuilder.AddSystem.doc)
         .def("empty", &DiagramBuilder<T>::empty, doc.DiagramBuilder.empty.doc)

--- a/bindings/pydrake/systems/test/lifetime_test.py
+++ b/bindings/pydrake/systems/test/lifetime_test.py
@@ -64,8 +64,10 @@ class TestLifetime(unittest.TestCase):
         self.assertFalse(info.deleted)
         self.assertTrue(system is not None)
         del system
-        # Upon removing this reference, everything should be cleared up.
-        self.assertTrue(info.deleted)
+        # Upon removing this reference, everything should have been cleared up.
+        # However, since we work around #14355 by inducing a keep_alive cycle,
+        # it will not be deleted.
+        self.assertFalse(info.deleted)
 
     def test_ownership_multiple_containers(self):
         info = Info()


### PR DESCRIPTION
This is a workaround to ensure we propagate keep_alive relationships

Resolves #14355

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14356)
<!-- Reviewable:end -->
