### PR TITLE
[render] Fully account for full camera intrinsics in RenderEngine ecosystem

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -813,10 +813,34 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("camera"), py::arg("parent_frame"), py::arg("X_PC"),
             py::arg("show_window") = false, cls_doc.RenderColorImage.doc)
         .def(
+            "RenderColorImage",
+            [](const Class* self, const render::ColorRenderCamera& camera,
+                FrameId parent_frame, const math::RigidTransformd& X_PC) {
+              systems::sensors::ImageRgba8U img(
+                  camera.core().intrinsics().width(),
+                  camera.core().intrinsics().height());
+              self->RenderColorImage(camera, parent_frame, X_PC, &img);
+              return img;
+            },
+            py::arg("camera"), py::arg("parent_frame"), py::arg("X_PC"),
+            cls_doc.RenderColorImage.doc)
+        .def(
             "RenderDepthImage",
             [](const Class* self, const render::DepthCameraProperties& camera,
                 FrameId parent_frame, const math::RigidTransformd& X_PC) {
               systems::sensors::ImageDepth32F img(camera.width, camera.height);
+              self->RenderDepthImage(camera, parent_frame, X_PC, &img);
+              return img;
+            },
+            py::arg("camera"), py::arg("parent_frame"), py::arg("X_PC"),
+            cls_doc.RenderDepthImage.doc)
+        .def(
+            "RenderDepthImage",
+            [](const Class* self, const render::DepthRenderCamera& camera,
+                FrameId parent_frame, const math::RigidTransformd& X_PC) {
+              systems::sensors::ImageDepth32F img(
+                  camera.core().intrinsics().width(),
+                  camera.core().intrinsics().height());
               self->RenderDepthImage(camera, parent_frame, X_PC, &img);
               return img;
             },
@@ -833,7 +857,19 @@ void DoScalarDependentDefinitions(py::module m, T) {
               return img;
             },
             py::arg("camera"), py::arg("parent_frame"), py::arg("X_PC"),
-            py::arg("show_window") = false, cls_doc.RenderLabelImage.doc);
+            py::arg("show_window") = false, cls_doc.RenderLabelImage.doc)
+        .def(
+            "RenderLabelImage",
+            [](const Class* self, const render::ColorRenderCamera& camera,
+                FrameId parent_frame, const math::RigidTransformd& X_PC) {
+              systems::sensors::ImageLabel16I img(
+                  camera.core().intrinsics().width(),
+                  camera.core().intrinsics().height());
+              self->RenderLabelImage(camera, parent_frame, X_PC, &img);
+              return img;
+            },
+            py::arg("camera"), py::arg("parent_frame"), py::arg("X_PC"),
+            cls_doc.RenderLabelImage.doc);
 
     AddValueInstantiation<QueryObject<T>>(m);
   }
@@ -940,7 +976,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("id_N", &Class::id_N, doc.ContactSurface.id_N.doc)
         .def("mesh_W", &Class::mesh_W, doc.ContactSurface.mesh_W.doc);
   }
-}
+}  // NOLINT(readability/fn_size)
 
 void DoScalarIndependentDefinitions(py::module m) {
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.

--- a/geometry/render/gl_renderer/render_engine_gl.cc
+++ b/geometry/render/gl_renderer/render_engine_gl.cc
@@ -483,29 +483,6 @@ void RenderEngineGl::UpdateViewpoint(const RigidTransformd& X_WR) {
   X_CW_ = X_WR.inverse();
 }
 
-void RenderEngineGl::RenderColorImage(const CameraProperties& camera,
-                                      bool show_window,
-                                      ImageRgba8U* color_image_out) const {
-  const ColorRenderCamera cam(camera, show_window);
-  ThrowIfInvalid(cam.core().intrinsics(), color_image_out, "color");
-  DoRenderColorImage(ColorRenderCamera(camera, show_window), color_image_out);
-}
-
-void RenderEngineGl::RenderDepthImage(const DepthCameraProperties& camera,
-                                      ImageDepth32F* depth_image_out) const {
-  DepthRenderCamera cam(camera);
-  ThrowIfInvalid(cam.core().intrinsics(), depth_image_out, "depth");
-  DoRenderDepthImage(cam, depth_image_out);
-}
-
-void RenderEngineGl::RenderLabelImage(const CameraProperties& camera,
-                                      bool show_window,
-                                      ImageLabel16I* label_image_out) const {
-  const ColorRenderCamera cam(camera, show_window);
-  ThrowIfInvalid(cam.core().intrinsics(), label_image_out, "label");
-  DoRenderLabelImage(ColorRenderCamera(camera, show_window), label_image_out);
-}
-
 void RenderEngineGl::ImplementGeometry(const Sphere& sphere, void* user_data) {
   OpenGlGeometry geometry = GetSphere();
   const double r = sphere.radius();

--- a/geometry/render/gl_renderer/render_engine_gl.h
+++ b/geometry/render/gl_renderer/render_engine_gl.h
@@ -50,35 +50,6 @@ class RenderEngineGl final : public RenderEngine {
   /** @see RenderEngine::UpdateViewpoint().  */
   void UpdateViewpoint(const math::RigidTransformd& X_WR) final;
 
-  using RenderEngine::RenderColorImage;
-  using RenderEngine::RenderDepthImage;
-  using RenderEngine::RenderLabelImage;
-
-  /** @see RenderEngine::RenderColorImage(). Currently unimplemented. Calling
-   this will throw an exception.
-
-   Note that the display window triggered by `show_window` is shared with
-   RenderLabelImage(), and only the last color or label image rendered will be
-   visible in the window (once these methods are implemented).  */
-  void RenderColorImage(
-      const CameraProperties& camera, bool show_window,
-      systems::sensors::ImageRgba8U* color_image_out) const final;
-
-  /** @see RenderEngine::RenderDepthImage().  */
-  void RenderDepthImage(
-      const DepthCameraProperties& camera,
-      systems::sensors::ImageDepth32F* depth_image_out) const final;
-
-  /** @see RenderEngine::RenderLabelImage(). Currently unimplemented. Calling
-   this will throw an exception.
-
-   Note that the display window triggered by `show_window` is shared with
-   RenderColorImage(), and only the last color or label image rendered will be
-   visible in the window (once these methods are implemented).  */
-  void RenderLabelImage(
-      const CameraProperties& camera, bool show_window,
-      systems::sensors::ImageLabel16I* label_image_out) const final;
-
   const RenderEngineGlParams& parameters() const { return parameters_; }
 
   /** @name    Shape reification  */

--- a/geometry/render/gl_renderer/test/render_engine_gl_test.cc
+++ b/geometry/render/gl_renderer/test/render_engine_gl_test.cc
@@ -1482,47 +1482,6 @@ TEST_F(RenderEngineGlTest, MeshGeometryReuse) {
             second_geometry.index_buffer_size);
 }
 
-// A reality check that confirms that the conversion from CameraProperties
-// to intrinsics is as expected -- they produce equivalent images.
-TEST_F(RenderEngineGlTest, CameraPropertiesVsCameraIntrinsics) {
-  Init(X_WR_, true /* add_terrain */);
-  PopulateSimpleBoxTest(renderer_.get());
-
-  // We're going to render some baseline images using the CameraProperties.
-  ImageRgba8U ref_color(camera_.width, camera_.height);
-  ImageDepth32F ref_depth(camera_.width, camera_.height);
-  ImageLabel16I ref_label(camera_.width, camera_.height);
-  Render(renderer_.get(), &camera_, &ref_color, &ref_depth, &ref_label);
-
-  // Instantiating camear models with the same data as in DepthCameraProperties
-  // should produce the *same* images.
-  const CameraInfo intrinsics{camera_.width, camera_.height, camera_.fov_y};
-  const ColorRenderCamera color_camera{camera_, kShowWindow};
-  const DepthRenderCamera depth_camera{camera_};
-
-  ImageRgba8U equiv_color(camera_.width, camera_.height);
-  ImageDepth32F equiv_depth(camera_.width, camera_.height);
-  ImageLabel16I equiv_label(camera_.width, camera_.height);
-  renderer_->RenderColorImage(color_camera, &equiv_color);
-  renderer_->RenderDepthImage(depth_camera, &equiv_depth);
-  renderer_->RenderLabelImage(color_camera, &equiv_label);
-
-  // The color and label images should be *bit* identical.
-  EXPECT_EQ(memcmp(ref_color.at(0, 0), equiv_color.at(0, 0), ref_color.size()),
-            0);
-
-  EXPECT_EQ(memcmp(ref_label.at(0, 0), equiv_label.at(0, 0), ref_label.size()),
-            0);
-  // The depth values take a slightly more numerically complex path and can
-  // lead to small rounding errors that the color channels are less
-  // susceptible to. To show the images are equal, we need to compare with
-  // tolerance.
-  for (int d = 0; d < ref_depth.size(); ++d) {
-    ASSERT_NEAR(ref_depth.at(0, 0)[d], equiv_depth.at(0, 0)[d],
-                4 * std::numeric_limits<float>::epsilon());
-  }
-}
-
 namespace {
 
 // Defines the relationship between two adjacent pixels in a rendering of a box.

--- a/geometry/render/render_engine.cc
+++ b/geometry/render/render_engine.cc
@@ -5,6 +5,7 @@
 #include <fmt/format.h>
 
 #include "drake/common/nice_type_name.h"
+#include "drake/common/scope_exit.h"
 #include "drake/common/text_logging.h"
 
 namespace drake {
@@ -83,13 +84,23 @@ RenderLabel RenderEngine::GetRenderLabelOrThrow(
 
 void RenderEngine::DoRenderColorImage(const ColorRenderCamera& camera,
                                       ImageRgba8U* color_image_out) const {
+  if (visited_color_) {
+    throw std::runtime_error(fmt::format(
+        "{}: attempting to render a color image without implementing "
+        "RenderColorImage (deprecated) or DoRenderColorImage (preferred).",
+        NiceTypeName::Get(*this)));
+  }
+  visited_color_ = true;
+  ScopeExit guard([this]() { visited_color_ = false; });
+
   // TODO(SeanCurtis-TRI): Consider modifying this warning (and those for the
   //  other image types) so that it only gets broadcast if the intrinsics *have*
   //  properties that would lose information.
   static const logging::Warn log_once(
-      "{}::DoRenderColorImage has not been implemented; using simple camera "
-      "model variant; if the camera intrinsics have anisotropic focal lengths "
-      "or a non-centered principal point, those details will be lost.",
+      "{}::DoRenderColorImage has not been implemented; attempting to use the "
+      "simple camera model variant; if the camera intrinsics have anisotropic "
+      "focal lengths or a non-centered principal point, those details will be "
+      "lost.",
       NiceTypeName::Get(*this));
 
   const CameraInfo& intrinsics = camera.core().intrinsics();
@@ -101,10 +112,20 @@ void RenderEngine::DoRenderColorImage(const ColorRenderCamera& camera,
 
 void RenderEngine::DoRenderDepthImage(const DepthRenderCamera& camera,
                                       ImageDepth32F* depth_image_out) const {
+  if (visited_depth_) {
+    throw std::runtime_error(fmt::format(
+        "{}: attempting to render a depth image without implementing "
+        "RenderDepthImage (deprecated) or DoRenderDepthImage (preferred).",
+        NiceTypeName::Get(*this)));
+  }
+  visited_depth_ = true;
+  ScopeExit guard([this]() { visited_depth_ = false; });
+
   static const logging::Warn log_once(
-      "{}::DoRenderDepthImage has not been implemented; using simple camera "
-      "model variant; if the camera intrinsics have anisotropic focal lengths "
-      "or a non-centered principal point, those details will be lost.",
+      "{}::DoRenderDepthImage has not been implemented; attempting to use the "
+      "simple camera model variant; if the camera intrinsics have anisotropic "
+      "focal lengths or a non-centered principal point, those details will be "
+      "lost.",
       NiceTypeName::Get(*this));
 
   const CameraInfo& intrinsics = camera.core().intrinsics();
@@ -119,10 +140,20 @@ void RenderEngine::DoRenderDepthImage(const DepthRenderCamera& camera,
 
 void RenderEngine::DoRenderLabelImage(const ColorRenderCamera& camera,
                                       ImageLabel16I* label_image_out) const {
+  if (visited_label_) {
+    throw std::runtime_error(fmt::format(
+        "{}: attempting to render a label image without implementing "
+        "RenderLabelImage (deprecated) or DoRenderLabelImage (preferred).",
+        NiceTypeName::Get(*this)));
+  }
+  visited_label_ = true;
+  ScopeExit guard([this]() { visited_label_ = false; });
+
   static const logging::Warn log_once(
-      "{}::DoRenderLabelImage has not been implemented; using simple camera "
-      "model variant; if the camera intrinsics have anisotropic focal lengths "
-      "or a non-centered principal point, those details will be lost.",
+      "{}::DoRenderLabelImage has not been implemented; attempting to use the "
+      "simple camera model variant; if the camera intrinsics have anisotropic "
+      "focal lengths or a non-centered principal point, those details will be "
+      "lost.",
       NiceTypeName::Get(*this));
 
   const CameraInfo& intrinsics = camera.core().intrinsics();

--- a/geometry/render/render_engine.h
+++ b/geometry/render/render_engine.h
@@ -169,19 +169,57 @@ class RenderEngine : public ShapeReifier {
                 system.  */
   virtual void UpdateViewpoint(const math::RigidTransformd& X_WR) = 0;
 
+  /* Note to developers on deprecation strategy
+
+   https://github.com/RobotLocomotion/drake/issues/11880
+
+   Deprecation is rendered a bit tricky because full camera intrinsics was
+   introduced to make it backwards compatible. But now we have to "forward" it.
+   The strategy works as follows:
+
+   1. We want the Render*Image(CameraProperties) to delegate to the full
+      intrinsics. However, the backwards compatible implementation of the
+      DoRender*Image(RenderCamera) API delegates it right back.
+      - First, we document that people shouldn't do that!
+      - We put in a mechanism where we can recognize the unimplemented loop and
+        throw an appropriate message.
+      - We *can't* recognize if someone overrides the implementation and makes
+        their own delegation loop.  :-/
+    2. When we remove these methods:
+       - DoRender*Image implementations will simply throw a not-implemented
+         error.
+       - remove the mutable visited_foo_ tags.
+       - Update the documentation on DoRender*Image.
+       - Deprecate the CameraProperties and DepthCameraProperties structs
+         - They cannot be deprecated simultaneously.
+
+   There is an inherent challenge in this deprecation. Although we're
+   deprecating the virtual methods in RenderEngine, deprecation warnings do not
+   get emitted by implementing those methods in a derived class. Nor do they
+   get emitted if those methods are exercised by the derived class (as opposed
+   to the base class). So, downstream users who are directly accessing derived
+   RenderEngine implementations could still have usages that will suddenly
+   break when the deprecated methods here get deleted.
+   */
   /** @name Rendering using simple camera models
 
-   These methods use a simplified camera model. They allow specification of the
-   camera image size and the the focal length in the y-direction (via the
-   given field-of-view value). However, it assumes that the focal length in the
-   x direction is the same and further assumes that camera's principal point
-   projects onto the _center_ of the image.
+   These *legacy* methods use a simplified camera model. They allow
+   specification of the camera image size and the focal length in the
+   y-direction (via the given field-of-view value). However, it assumes that the
+   focal length in the x direction is the same and further assumes that camera's
+   principal point projects onto the _center_ of the image.
 
    For %RenderEngine implementations that also depend on near and far clipping
    planes, those planes are set arbitrarily by the implementation.
 
-   For full control over the camera model (and related rendering properties),
-   use the fully-specified variants defined below.
+   @warning These APIs (and the corresponding CameraProperties and
+   DepthCameraProperties) are all being deprecated. For existing %RenderEngine
+   implementations that have already overridden these methods, the
+   implementations should move to the `DoRender*Image()` variants (with
+   appropriate *minor* transformations from CameraProperties to RenderCamera
+   APIs). New %RenderEngine implementations should *not* override these methods
+   and simply implement the DoRender*Image() methods.
+   See https://github.com/RobotLocomotion/drake/issues/11880.
    */
   //@{
 
@@ -196,7 +234,11 @@ class RenderEngine : public ShapeReifier {
    @pydrake_mkdoc_identifier{deprecated}  */
   virtual void RenderColorImage(
       const CameraProperties& camera, bool show_window,
-      systems::sensors::ImageRgba8U* color_image_out) const = 0;
+      systems::sensors::ImageRgba8U* color_image_out) const {
+    const ColorRenderCamera cam(camera, show_window);
+    ThrowIfInvalid(cam.core().intrinsics(), color_image_out, "color");
+    DoRenderColorImage(cam, color_image_out);
+  }
 
   /** Renders the registered geometry into the given depth image based on
    a simplified camera model. In contrast to the other rendering operations,
@@ -208,7 +250,11 @@ class RenderEngine : public ShapeReifier {
    @pydrake_mkdoc_identifier{deprecated}  */
   virtual void RenderDepthImage(
       const DepthCameraProperties& camera,
-      systems::sensors::ImageDepth32F* depth_image_out) const = 0;
+      systems::sensors::ImageDepth32F* depth_image_out) const {
+    const DepthRenderCamera cam(camera);
+    ThrowIfInvalid(cam.core().intrinsics(), depth_image_out, "depth");
+    DoRenderDepthImage(cam, depth_image_out);
+  }
 
   /** Renders the registered geometry into the given label image based on
    a simplified camera model.
@@ -218,9 +264,12 @@ class RenderEngine : public ShapeReifier {
    @param[out] label_image_out  The rendered label image.
    @pydrake_mkdoc_identifier{deprecated}  */
   virtual void RenderLabelImage(
-      const CameraProperties& camera,
-      bool show_window,
-      systems::sensors::ImageLabel16I* label_image_out) const = 0;
+      const CameraProperties& camera, bool show_window,
+      systems::sensors::ImageLabel16I* label_image_out) const {
+    const ColorRenderCamera cam(camera, show_window);
+    ThrowIfInvalid(cam.core().intrinsics(), label_image_out, "label");
+    DoRenderLabelImage(cam, label_image_out);
+  }
 
   //@}
 
@@ -456,6 +505,14 @@ class RenderEngine : public ShapeReifier {
   // provide one. Default constructor is RenderLabel::kUnspecified via the
   // RenderLabel default constructor.
   RenderLabel default_render_label_{};
+
+  // Guard bits during the deprecation period for CameraProperties. These allow
+  // us to detect if an implementation of RenderEngine has failed to implement
+  // appropriate code. It prevents a stack overflow/infinite recursion between
+  // the default implementations.
+  mutable bool visited_color_{};
+  mutable bool visited_depth_{};
+  mutable bool visited_label_{};
 };
 
 }  // namespace render

--- a/geometry/render/render_engine_vtk.h
+++ b/geometry/render/render_engine_vtk.h
@@ -107,25 +107,6 @@ class RenderEngineVtk : public RenderEngine,
   /** @see RenderEngine::UpdateViewpoint().  */
   void UpdateViewpoint(const math::RigidTransformd& X_WR) override;
 
-  using RenderEngine::RenderColorImage;
-  using RenderEngine::RenderDepthImage;
-  using RenderEngine::RenderLabelImage;
-
-  /** @see RenderEngine::RenderColorImage().  */
-  void RenderColorImage(
-      const CameraProperties& camera, bool show_window,
-      systems::sensors::ImageRgba8U* color_image_out) const override;
-
-  /** @see RenderEngine::RenderDepthImage().  */
-  void RenderDepthImage(
-      const DepthCameraProperties& camera,
-      systems::sensors::ImageDepth32F* depth_image_out) const override;
-
-  /** @see RenderEngine::RenderLabelImage().  */
-  void RenderLabelImage(
-      const CameraProperties& camera, bool show_window,
-      systems::sensors::ImageLabel16I* label_image_out) const override;
-
   /** @name    Shape reification  */
   //@{
   using RenderEngine::ImplementGeometry;
@@ -217,15 +198,6 @@ class RenderEngineVtk : public RenderEngine,
   // vtkWindowToImageFilter and vtkImageExporter, so that VTK reflects
   // vtkActors' pose update for rendering.
   static void PerformVtkUpdate(const RenderingPipeline& p);
-
-  // This actually modifies internal state; the pointer to a const pipeline
-  // allows mutation via the contained vtkNew pointers.
-  void UpdateWindow(const CameraProperties& camera, bool show_window,
-                    const RenderingPipeline* p, const char* name) const;
-
-  // Modifies the camera for the special case of the depth camera.
-  void UpdateWindow(const DepthCameraProperties& camera,
-                    const RenderingPipeline* p) const;
 
   // Configures the VTK model to reflect the given `camera`, this includes
   // render size camera intrinsics, visible windows, etc.

--- a/geometry/render/test/render_engine_test.cc
+++ b/geometry/render/test/render_engine_test.cc
@@ -47,6 +47,29 @@ using systems::sensors::ImageDepth32F;
 using systems::sensors::ImageLabel16I;
 using systems::sensors::ImageRgba8U;
 
+// This is the absolutely minimum code to make an instantiable RenderEngine.
+// It is *not* an example appropriate implementation of RenderEngine, it is
+// merely a class of convenience for these tests so that individual aspects
+// can be implemented in a targeted manner without worrying about this baseline
+// functionality.
+// This mainline implementation:
+//    - UpdateViewpoint and DoUpdateVisualPose are no-ops.
+//    - DoRegisterVisual and DoRemoveGeometry do nothing and report such.
+//    - DoClone simply returns nullptr.
+//    - Implements no rendering interfaces (which means invoking rendering from
+//      any API should throw an exception).
+class MinimumEngine : public RenderEngine {
+ public:
+  void UpdateViewpoint(const math::RigidTransformd&) override {}
+  bool DoRegisterVisual(GeometryId, const Shape&, const PerceptionProperties&,
+                        const RigidTransformd&) override {
+    return false;
+  }
+  void DoUpdateVisualPose(GeometryId, const math::RigidTransformd&) override {}
+  bool DoRemoveGeometry(GeometryId) override { return false; }
+  std::unique_ptr<RenderEngine> DoClone() const override { return nullptr; }
+};
+
 // Tests the RenderEngine-specific functionality for managing registration of
 // geometry and its corresponding update behavior. The former should configure
 // each geometry correctly on whether it gets updated or not, and the latter
@@ -320,115 +343,9 @@ GTEST_TEST(RenderEngine, ValidateIntrinsicsAndImage) {
   });
 }
 
-/* A sub-class of DummyRenderEngine that *does* implement the full-intrinsics
- camera API. Exercising that API on this instance should use the full API and
- not the fallback, simple API.  */
-class FullSpecRenderEngine : public DummyRenderEngine {
- public:
-  int num_full_color_renders() const { return full_color_count_; }
-  int num_full_depth_renders() const { return full_depth_count_; }
-  int num_full_label_renders() const { return full_label_count_; }
-
- private:
-  void DoRenderColorImage(const ColorRenderCamera&,
-                          ImageRgba8U*) const override {
-    ++full_color_count_;
-  }
-
-  void DoRenderDepthImage(const DepthRenderCamera&,
-                          ImageDepth32F*) const override {
-    ++full_depth_count_;
-  }
-
-  void DoRenderLabelImage(const ColorRenderCamera&,
-                          ImageLabel16I*) const override {
-    ++full_label_count_;
-  }
-
-  mutable int full_color_count_{};
-  mutable int full_depth_count_{};
-  mutable int full_label_count_{};
-};
-
-// Confirms expected behavior of the full-camera-intrinsics API.
-// For engines that *haven't* implemented the API, it defaults to simple API.
-// For engines that *have* implemented the API, confirm it is exercised.
-GTEST_TEST(RenderEngine, FullIntrinsicsRendering) {
-  const CameraInfo intrinsics{2, 2, M_PI};
-  const ColorRenderCamera color_camera{
-      {"n/a", intrinsics, {0.1, 10}, RigidTransformd{}}, false};
-  const DepthRenderCamera depth_camera{
-      {"n/a", intrinsics, {0.1, 10}, RigidTransformd{}}, {1.0, 5.0}};
-
-  ImageRgba8U color(2, 2);
-  ImageDepth32F depth(2, 2);
-  ImageLabel16I label(2, 2);
-  {
-    // Case: RenderEngine has *not* implemented the full-intrinsics API. It
-    // defaults to the simple intrinsics API. We also need to confirm that
-    // the properties are properly "converted".
-    DummyRenderEngine default_engine;
-
-    // Confirm all counters are as expected before starting.
-    ASSERT_EQ(default_engine.num_simple_color_renders(), 0);
-    ASSERT_EQ(default_engine.num_simple_depth_renders(), 0);
-    ASSERT_EQ(default_engine.num_simple_label_renders(), 0);
-
-    auto cameras_match = [](const CameraProperties& test,
-                            const CameraInfo& expected) {
-      return test.width == expected.width() &&
-             test.height == expected.height() && test.fov_y == expected.fov_y();
-    };
-
-    auto depths_match = [](const DepthCameraProperties& test,
-                           const DepthRenderCamera& expected) {
-      return test.z_near == expected.depth_range().min_depth() &&
-             test.z_far == expected.depth_range().max_depth();
-    };
-
-    default_engine.RenderColorImage(color_camera, &color);
-    EXPECT_EQ(default_engine.num_simple_color_renders(), 1);
-    EXPECT_TRUE(cameras_match(default_engine.last_color_camera_properties(),
-                              intrinsics));
-    default_engine.RenderDepthImage(depth_camera, &depth);
-    EXPECT_EQ(default_engine.num_simple_depth_renders(), 1);
-    EXPECT_TRUE(cameras_match(default_engine.last_depth_camera_properties(),
-                              intrinsics));
-    EXPECT_TRUE(depths_match(default_engine.last_depth_camera_properties(),
-                             depth_camera));
-    default_engine.RenderLabelImage(color_camera, &label);
-    EXPECT_EQ(default_engine.num_simple_label_renders(), 1);
-    EXPECT_TRUE(cameras_match(default_engine.last_label_camera_properties(),
-                              intrinsics));
-  }
-
-  {
-    // Case: RenderEngine *has* implemented the full-intrinsics API. The simple
-    // API does *not* get called.
-    FullSpecRenderEngine full_engine;
-
-    // Confirm all counters are as expected before starting.
-    ASSERT_EQ(full_engine.num_simple_color_renders(), 0);
-    ASSERT_EQ(full_engine.num_simple_depth_renders(), 0);
-    ASSERT_EQ(full_engine.num_simple_label_renders(), 0);
-    ASSERT_EQ(full_engine.num_full_color_renders(), 0);
-    ASSERT_EQ(full_engine.num_full_depth_renders(), 0);
-    ASSERT_EQ(full_engine.num_full_label_renders(), 0);
-
-    full_engine.RenderColorImage(color_camera, &color);
-    EXPECT_EQ(full_engine.num_simple_color_renders(), 0);
-    EXPECT_EQ(full_engine.num_full_color_renders(), 1);
-    full_engine.RenderDepthImage(depth_camera, &depth);
-    EXPECT_EQ(full_engine.num_simple_depth_renders(), 0);
-    EXPECT_EQ(full_engine.num_full_depth_renders(), 1);
-    full_engine.RenderLabelImage(color_camera, &label);
-    EXPECT_EQ(full_engine.num_simple_label_renders(), 0);
-    EXPECT_EQ(full_engine.num_full_label_renders(), 1);
-  }
-}
-
-// An absolute barebones RenderEngine implementation; however it is cloneable.
-class CloneableEngine : public render::RenderEngine {
+// An absolute barebones RenderEngine implementation; however it is cloneable
+// with both a copy constructor *and* a valid DoClone() implementation.
+class CloneableEngine : public MinimumEngine {
  public:
   CloneableEngine(const CloneableEngine&) = default;
   CloneableEngine& operator=(const CloneableEngine&) = delete;
@@ -436,24 +353,8 @@ class CloneableEngine : public render::RenderEngine {
   CloneableEngine& operator=(CloneableEngine&&) = delete;
 
   CloneableEngine() = default;
-  void UpdateViewpoint(const math::RigidTransformd&) override {}
-  void RenderColorImage(const render::CameraProperties&, bool,
-                        systems::sensors::ImageRgba8U*) const override {}
-  void RenderDepthImage(const render::DepthCameraProperties&,
-                        systems::sensors::ImageDepth32F*) const override {}
-  void RenderLabelImage(const render::CameraProperties&, bool,
-                        systems::sensors::ImageLabel16I*) const override {}
-  using ShapeReifier::ImplementGeometry;
 
- protected:
-  bool DoRegisterVisual(GeometryId id, const Shape&,
-                        const PerceptionProperties&,
-                        const math::RigidTransformd&) override {
-    return false;
-  }
-  void DoUpdateVisualPose(GeometryId, const math::RigidTransformd&) override {}
-  bool DoRemoveGeometry(GeometryId) override { return false; }
-  std::unique_ptr<render::RenderEngine> DoClone() const override {
+  std::unique_ptr<RenderEngine> DoClone() const override {
     return std::make_unique<CloneableEngine>(*this);
   }
 };
@@ -477,6 +378,243 @@ GTEST_TEST(RenderEngine, DetectDoCloneFailure) {
       "Error in cloning RenderEngine class of type .+NoDoCloneEngine; the "
       "clone returns type .+CloneableEngine. .+NoDoCloneEngine::DoClone.. was "
       "probably not implemented");
+}
+
+// Test infrastructure to support deprecation efforts. After completing the
+// deprecation, all of this test infrastructure can/should simply go away.
+// In the deprecation period there are three possible configurations of a child
+// RenderEngine class:
+//
+//   - Failed to implement either the old or new APIs.
+//     - This should be detected and an error thrown. See
+//       the test DetectUnimplementedRender below.
+//   - Implementation of new API (invocation of old delegates to new).
+//     - The DummyRenderEngine satisfies this case and allows detection of
+//       delegation. See the test OldApiDelegatesToNewApi
+//       below.
+//   - Implementaiton of old API (invocation of new delegates to old).
+//     - See the test NewApiDelegatesToOldApi.
+//
+// There is *technically* a fourth option, implementation of both old and new
+// APIs. If a subclass does that, then the RenderEngine API doesn't participate
+// at all and that scenario is outside the scope of the tests for RenderEngine.
+//
+// https://github.com/RobotLocomotion/drake/issues/11880
+
+// The desired behavior in the deprecation period is for the user to implement
+// DoRender*Image and calls to RenderImage(CamProperties) get automatically
+// forwarded. DummyRenderEngine has this expected implementation. Confirm
+// the forwarding. To that end, we'll confirm two things: that the DoRender*
+// function got called and that the camera provided is what we expect.
+GTEST_TEST(RenderEngine, OldApiDelegatesToNewApi) {
+  // Arbitrary image sizes that are unlikely to be hard-coded anywhere.
+  const int w = 35;
+  const int h = 45;
+
+  ImageRgba8U color(w, h);
+  ImageDepth32F depth(w, h);
+  ImageLabel16I label(w, h);
+
+  // DummyRenderEngine implements the new DoRender*Image API and *not* the old
+  // CameraProperties-based API.
+  DummyRenderEngine engine;
+
+  auto cores_equal = [](const RenderCameraCore& test,
+                        const RenderCameraCore& expected) {
+    return test.renderer_name() == expected.renderer_name() &&
+           test.clipping().near() == expected.clipping().near() &&
+           test.clipping().far() == expected.clipping().far() &&
+           CompareMatrices(
+               test.sensor_pose_in_camera_body().GetAsMatrix34(),
+               expected.sensor_pose_in_camera_body().GetAsMatrix34()) &&
+           CompareMatrices(test.intrinsics().intrinsic_matrix(),
+                           expected.intrinsics().intrinsic_matrix());
+  };
+
+  auto color_cameras_equal = [&cores_equal](const ColorRenderCamera& test,
+                                            const ColorRenderCamera& expected) {
+    return test.show_window() == expected.show_window() &&
+           cores_equal(test.core(), expected.core());
+  };
+
+  auto depth_cameras_equal = [&cores_equal](const DepthRenderCamera& test,
+                                            const DepthRenderCamera& expected) {
+    return test.depth_range().min_depth() ==
+               expected.depth_range().min_depth() &&
+           test.depth_range().max_depth() ==
+               expected.depth_range().max_depth() &&
+           cores_equal(test.core(), expected.core());
+  };
+
+  const DepthCameraProperties properties{w, h, M_PI / 3, "n/a", 0.25, 11.5};
+
+  engine.RenderColorImage(properties, true, &color);
+  EXPECT_EQ(engine.num_color_renders(), 1);
+  EXPECT_TRUE(color_cameras_equal(engine.last_color_camera(),
+                                  ColorRenderCamera(properties, true)));
+
+  engine.RenderColorImage(properties, false, &color);
+  EXPECT_EQ(engine.num_color_renders(), 2);
+  EXPECT_TRUE(color_cameras_equal(engine.last_color_camera(),
+                                  ColorRenderCamera(properties, false)));
+
+  engine.RenderDepthImage(properties, &depth);
+  EXPECT_EQ(engine.num_depth_renders(), 1);
+  EXPECT_TRUE(depth_cameras_equal(engine.last_depth_camera(),
+                                  DepthRenderCamera(properties)));
+
+  engine.RenderLabelImage(properties, true, &label);
+  EXPECT_EQ(engine.num_label_renders(), 1);
+  EXPECT_TRUE(color_cameras_equal(engine.last_label_camera(),
+                                  ColorRenderCamera(properties, true)));
+
+  engine.RenderLabelImage(properties, false, &label);
+  EXPECT_EQ(engine.num_label_renders(), 2);
+  EXPECT_TRUE(color_cameras_equal(engine.last_label_camera(),
+                                  ColorRenderCamera(properties, false)));
+}
+
+// Confirms that a RenderEngine that doesn't implement any rendering API is
+// detected.
+GTEST_TEST(RenderEngine, DetectUnimplementedRender) {
+  // Set up cameras and images.
+  const CameraProperties cam_props(10, 10, M_PI / 4, "n/a");
+  const DepthCameraProperties depth_props(cam_props.width, cam_props.height,
+                                          cam_props.fov_y,
+                                          cam_props.renderer_name, 0.2, 8.0);
+  const ColorRenderCamera color_cam(cam_props);
+  const DepthRenderCamera depth_cam(depth_props);
+  ImageRgba8U color_image(cam_props.width, cam_props.height);
+  ImageDepth32F depth_image(depth_props.width, depth_props.height);
+  ImageLabel16I label_image(cam_props.width, cam_props.height);
+
+  // Remember, MinimumEngine has implemented no rendering logic.
+  MinimumEngine engine;
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      engine.RenderColorImage(cam_props, false, &color_image), std::exception,
+      ".+render a color image.+RenderColorImage.+DoRenderColorImage.+");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      engine.RenderDepthImage(depth_props, &depth_image), std::exception,
+      ".+render a depth image.+RenderDepthImage.+DoRenderDepthImage.+");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      engine.RenderLabelImage(cam_props, false, &label_image), std::exception,
+      ".+render a label image.+RenderLabelImage.+DoRenderLabelImage.+");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      engine.RenderColorImage(color_cam, &color_image), std::exception,
+      ".+render a color image.+RenderColorImage.+DoRenderColorImage.+");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      engine.RenderDepthImage(depth_cam, &depth_image), std::exception,
+      ".+render a depth image.+RenderDepthImage.+DoRenderDepthImage.+");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      engine.RenderLabelImage(color_cam, &label_image), std::exception,
+      ".+render a label image.+RenderLabelImage.+DoRenderLabelImage.+");
+}
+
+// This class implements *only* the legacy API to validate forwarding of APIs.
+// Calls on the old API are counted, and the camera properties are cached for
+// later examination.
+class LegacyEngine final : public MinimumEngine {
+ public:
+  LegacyEngine()
+      : color_props_{0, 0, 0, ""},
+        depth_props_{0, 0, 0, "", 0, 0},
+        label_props_{0, 0, 0, ""} {}
+
+  // Make sure the new API is available (even though we're not implementing it).
+  using MinimumEngine::RenderColorImage;
+  using MinimumEngine::RenderDepthImage;
+  using MinimumEngine::RenderLabelImage;
+
+  void RenderColorImage(const CameraProperties& camera, bool,
+                        ImageRgba8U*) const final {
+    ++color_count_;
+    color_props_ = camera;
+  }
+  void RenderDepthImage(const DepthCameraProperties& camera,
+                        ImageDepth32F*) const final {
+    ++depth_count_;
+    depth_props_ = camera;
+  }
+  void RenderLabelImage(const CameraProperties& camera, bool,
+                        ImageLabel16I*) const final {
+    ++label_count_;
+    label_props_ = camera;
+  }
+
+  int num_color_renders() const { return color_count_; }
+  int num_depth_renders() const { return depth_count_; }
+  int num_label_renders() const { return label_count_; }
+
+  const CameraProperties& last_color_camera_properties() const {
+    return color_props_;
+  }
+  const DepthCameraProperties& last_depth_camera_properties() const {
+    return depth_props_;
+  }
+  const CameraProperties& last_label_camera_properties() const {
+    return label_props_;
+  }
+
+ private:
+  mutable int color_count_{};
+  mutable int depth_count_{};
+  mutable int label_count_{};
+  mutable CameraProperties color_props_;
+  mutable DepthCameraProperties depth_props_;
+  mutable CameraProperties label_props_;
+};
+
+// Tests the case where a RenderEngine implements the old API, but not the new
+// API. Confirms that the delegation occurs and the camera is converted as
+// expected.
+GTEST_TEST(RenderEngine, NewApiDelegatesToOldApi) {
+  const CameraInfo intrinsics{2, 2, M_PI};
+  const ColorRenderCamera color_camera{
+      {"n/a", intrinsics, {0.1, 10}, RigidTransformd{}}, false};
+  const DepthRenderCamera depth_camera{
+      {"n/a", intrinsics, {0.1, 10}, RigidTransformd{}}, {1.0, 5.0}};
+
+  ImageRgba8U color(2, 2);
+  ImageDepth32F depth(2, 2);
+  ImageLabel16I label(2, 2);
+
+  LegacyEngine engine;
+
+  // Confirm all counters are as expected before starting.
+  ASSERT_EQ(engine.num_color_renders(), 0);
+  ASSERT_EQ(engine.num_depth_renders(), 0);
+  ASSERT_EQ(engine.num_label_renders(), 0);
+
+  auto cameras_match = [](const CameraProperties& test,
+                          const RenderCameraCore& expected) {
+    return test.width == expected.intrinsics().width() &&
+           test.height == expected.intrinsics().height() &&
+           test.fov_y == expected.intrinsics().fov_y() &&
+           test.renderer_name == expected.renderer_name();
+  };
+
+  auto depths_match = [](const DepthCameraProperties& test,
+                         const DepthRenderCamera& expected) {
+    return test.z_near == expected.depth_range().min_depth() &&
+           test.z_far == expected.depth_range().max_depth();
+  };
+
+  engine.RenderColorImage(color_camera, &color);
+  EXPECT_EQ(engine.num_color_renders(), 1);
+  EXPECT_TRUE(cameras_match(engine.last_color_camera_properties(),
+                            color_camera.core()));
+  engine.RenderDepthImage(depth_camera, &depth);
+  EXPECT_EQ(engine.num_depth_renders(), 1);
+  EXPECT_TRUE(cameras_match(engine.last_depth_camera_properties(),
+                            depth_camera.core()));
+  EXPECT_TRUE(
+      depths_match(engine.last_depth_camera_properties(), depth_camera));
+  engine.RenderLabelImage(color_camera, &label);
+  EXPECT_EQ(engine.num_label_renders(), 1);
+  EXPECT_TRUE(cameras_match(engine.last_label_camera_properties(),
+                            color_camera.core()));
 }
 
 }  // namespace

--- a/geometry/render/test/render_engine_vtk_test.cc
+++ b/geometry/render/test/render_engine_vtk_test.cc
@@ -1285,49 +1285,6 @@ TEST_F(RenderEngineVtkTest, PreservePropertyTexturesOverClone) {
   ASSERT_TRUE(clone->GeometryHasColorTexture(id, texture_name));
 }
 
-// A reality check that confirms that the conversion from CameraProperties
-// to intrinsics is as expected -- they produce equivalent images.
-TEST_F(RenderEngineVtkTest, CameraPropertiesVsCameraIntrinsics) {
-  Init(X_WC_, true /* add_terrain */);
-  PopulateSimpleBoxTest(renderer_.get());
-
-  // We're going to render some baseline images using the CameraProperties.
-  ImageRgba8U ref_color(camera_.width, camera_.height);
-  ImageDepth32F ref_depth(camera_.width, camera_.height);
-  ImageLabel16I ref_label(camera_.width, camera_.height);
-  Render(renderer_.get(), &camera_, &ref_color, &ref_depth, &ref_label);
-
-  // Instantiating camear models with the same data as in DepthCameraProperties
-  // should produce the *same* images.
-  const CameraInfo intrinsics{camera_.width, camera_.height, camera_.fov_y};
-  const ColorRenderCamera color_camera{{"n/a", intrinsics, {0.1, 100.0}, {}},
-                                       kShowWindow};
-  const DepthRenderCamera depth_camera{{"n/a", intrinsics, {0.1, 100.0}, {}},
-                                       {camera_.z_near, camera_.z_far}};
-
-  ImageRgba8U equiv_color(camera_.width, camera_.height);
-  ImageDepth32F equiv_depth(camera_.width, camera_.height);
-  ImageLabel16I equiv_label(camera_.width, camera_.height);
-  renderer_->RenderColorImage(color_camera, &equiv_color);
-  renderer_->RenderDepthImage(depth_camera, &equiv_depth);
-  renderer_->RenderLabelImage(color_camera, &equiv_label);
-
-  // The color and label images should be *bit* identical.
-  EXPECT_EQ(memcmp(ref_color.at(0, 0), equiv_color.at(0, 0), ref_color.size()),
-            0);
-
-  EXPECT_EQ(memcmp(ref_label.at(0, 0), equiv_label.at(0, 0), ref_label.size()),
-            0);
-  // The depth values take a slightly more numerically complex path and can
-  // lead to small rounding errors that the color channels are less
-  // susceptible to. To show the images are equal, we need to compare with
-  // tolerance.
-  for (int d = 0; d < ref_depth.size(); ++d) {
-    ASSERT_NEAR(ref_depth.at(0, 0)[d], equiv_depth.at(0, 0)[d],
-                4 * std::numeric_limits<float>::epsilon());
-  }
-}
-
 namespace {
 
 // Defines the relationship between two adjacent pixels in a rendering of a box.


### PR DESCRIPTION
This revisits the implementation of `RenderEngine` in preparation for deprecating the old `CameraProperties` and `DepthCameraProperties` in favor of the new `ColorRenderCamera` and `DepthRenderCamera`.

 - We implement the `CameraProperties` `RenderEngine` API by delegating to the `RenderCamera` API (it was previously purely abstract).
    - This introduces circular delegation in the default behavior and we add a *temporary* mechanism for catching the defective case where the circle gets entered.
    - A collection of tests have been added to validate all transitional delegation logic.
 - `RenderEngineGl`, `RenderEngineVtk`, `DummyRenderEngine` remove their `CameraProperties`-related APIs in favor of inheriting `RenderEngine`'s.
   - Tests that compare equivalency between images created by the two APIs on the derived classes are no longer necessary.
 - Bind `QueryObject::Render*Image(*RenderCamera)` API
 - the python version of `DummyRenderEngine` (in `geometry_test.py`) is updated to match the C++ version.

This is the first of a sequence of PRs that will end in deprecation of `CameraProperties` and `DepthCameraProperties`.

Towards resolving checklist in #11880.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14357)
<!-- Reviewable:end -->
