### PR TITLE
[render] Deprecate RenderEngine::Render*Image(CameraProperties) API

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -802,18 +802,6 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.HasCollisions.doc)
         .def(
             "RenderColorImage",
-            [](const Class* self, const render::CameraProperties& camera,
-                FrameId parent_frame, const math::RigidTransformd& X_PC,
-                bool show_window) {
-              systems::sensors::ImageRgba8U img(camera.width, camera.height);
-              self->RenderColorImage(
-                  camera, parent_frame, X_PC, show_window, &img);
-              return img;
-            },
-            py::arg("camera"), py::arg("parent_frame"), py::arg("X_PC"),
-            py::arg("show_window") = false, cls_doc.RenderColorImage.doc)
-        .def(
-            "RenderColorImage",
             [](const Class* self, const render::ColorRenderCamera& camera,
                 FrameId parent_frame, const math::RigidTransformd& X_PC) {
               systems::sensors::ImageRgba8U img(
@@ -824,16 +812,6 @@ void DoScalarDependentDefinitions(py::module m, T) {
             },
             py::arg("camera"), py::arg("parent_frame"), py::arg("X_PC"),
             cls_doc.RenderColorImage.doc)
-        .def(
-            "RenderDepthImage",
-            [](const Class* self, const render::DepthCameraProperties& camera,
-                FrameId parent_frame, const math::RigidTransformd& X_PC) {
-              systems::sensors::ImageDepth32F img(camera.width, camera.height);
-              self->RenderDepthImage(camera, parent_frame, X_PC, &img);
-              return img;
-            },
-            py::arg("camera"), py::arg("parent_frame"), py::arg("X_PC"),
-            cls_doc.RenderDepthImage.doc)
         .def(
             "RenderDepthImage",
             [](const Class* self, const render::DepthRenderCamera& camera,
@@ -848,18 +826,6 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.RenderDepthImage.doc)
         .def(
             "RenderLabelImage",
-            [](const Class* self, const render::CameraProperties& camera,
-                FrameId parent_frame, const math::RigidTransformd& X_PC,
-                bool show_window = false) {
-              systems::sensors::ImageLabel16I img(camera.width, camera.height);
-              self->RenderLabelImage(
-                  camera, parent_frame, X_PC, show_window, &img);
-              return img;
-            },
-            py::arg("camera"), py::arg("parent_frame"), py::arg("X_PC"),
-            py::arg("show_window") = false, cls_doc.RenderLabelImage.doc)
-        .def(
-            "RenderLabelImage",
             [](const Class* self, const render::ColorRenderCamera& camera,
                 FrameId parent_frame, const math::RigidTransformd& X_PC) {
               systems::sensors::ImageLabel16I img(
@@ -870,6 +836,50 @@ void DoScalarDependentDefinitions(py::module m, T) {
             },
             py::arg("camera"), py::arg("parent_frame"), py::arg("X_PC"),
             cls_doc.RenderLabelImage.doc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
+        .def("RenderColorImage",
+            WrapDeprecated(cls_doc.RenderColorImage.doc_deprecated,
+                [](const Class* self, const render::CameraProperties& camera,
+                    FrameId parent_frame, const math::RigidTransformd& X_PC,
+                    bool show_window) {
+                  systems::sensors::ImageRgba8U img(
+                      camera.width, camera.height);
+                  self->RenderColorImage(
+                      camera, parent_frame, X_PC, show_window, &img);
+                  return img;
+                }),
+            py::arg("camera"), py::arg("parent_frame"), py::arg("X_PC"),
+            py::arg("show_window") = false,
+            cls_doc.RenderColorImage.doc_deprecated)
+        .def("RenderDepthImage",
+            WrapDeprecated(cls_doc.RenderDepthImage.doc_deprecated,
+                [](const Class* self,
+                    const render::DepthCameraProperties& camera,
+                    FrameId parent_frame, const math::RigidTransformd& X_PC) {
+                  systems::sensors::ImageDepth32F img(
+                      camera.width, camera.height);
+                  self->RenderDepthImage(camera, parent_frame, X_PC, &img);
+                  return img;
+                }),
+            py::arg("camera"), py::arg("parent_frame"), py::arg("X_PC"),
+            cls_doc.RenderDepthImage.doc_deprecated)
+        .def("RenderLabelImage",
+            WrapDeprecated(cls_doc.RenderLabelImage.doc_deprecated,
+                [](const Class* self, const render::CameraProperties& camera,
+                    FrameId parent_frame, const math::RigidTransformd& X_PC,
+                    bool show_window = false) {
+                  systems::sensors::ImageLabel16I img(
+                      camera.width, camera.height);
+                  self->RenderLabelImage(
+                      camera, parent_frame, X_PC, show_window, &img);
+                  return img;
+                }),
+            py::arg("camera"), py::arg("parent_frame"), py::arg("X_PC"),
+            py::arg("show_window") = false,
+            cls_doc.RenderLabelImage.doc_deprecated);
+#pragma GCC diagnostic pop
 
     AddValueInstantiation<QueryObject<T>>(m);
   }

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -737,21 +737,22 @@ class TestGeometry(unittest.TestCase):
             X_PC=RigidTransform())
         self.assertIsInstance(image, ImageLabel16I)
 
-        depth_camera = mut.render.DepthCameraProperties(
-            width=320, height=240, fov_y=pi/6, renderer_name=renderer_name,
-            z_near=0.1, z_far=5.0)
-        image = query_object.RenderColorImage(
-            camera=depth_camera, parent_frame=SceneGraph.world_frame_id(),
-            X_PC=RigidTransform())
-        self.assertIsInstance(image, ImageRgba8U)
-        image = query_object.RenderDepthImage(
-            camera=depth_camera, parent_frame=SceneGraph.world_frame_id(),
-            X_PC=RigidTransform())
-        self.assertIsInstance(image, ImageDepth32F)
-        image = query_object.RenderLabelImage(
-            camera=depth_camera, parent_frame=SceneGraph.world_frame_id(),
-            X_PC=RigidTransform())
-        self.assertIsInstance(image, ImageLabel16I)
+        with catch_drake_warnings(expected_count=3):
+            depth_camera = mut.render.DepthCameraProperties(
+                width=320, height=240, fov_y=pi/6, renderer_name=renderer_name,
+                z_near=0.1, z_far=5.0)
+            image = query_object.RenderColorImage(
+                camera=depth_camera, parent_frame=SceneGraph.world_frame_id(),
+                X_PC=RigidTransform())
+            self.assertIsInstance(image, ImageRgba8U)
+            image = query_object.RenderDepthImage(
+                camera=depth_camera, parent_frame=SceneGraph.world_frame_id(),
+                X_PC=RigidTransform())
+            self.assertIsInstance(image, ImageDepth32F)
+            image = query_object.RenderLabelImage(
+                camera=depth_camera, parent_frame=SceneGraph.world_frame_id(),
+                X_PC=RigidTransform())
+            self.assertIsInstance(image, ImageLabel16I)
 
     def test_read_obj_to_surface_mesh(self):
         mesh_path = FindResourceOrThrow("drake/geometry/test/quad_cube.obj")

--- a/examples/scene_graph/bouncing_ball_run_dynamics.cc
+++ b/examples/scene_graph/bouncing_ball_run_dynamics.cc
@@ -44,7 +44,8 @@ using geometry::HalfSpace;
 using geometry::IllustrationProperties;
 using geometry::PerceptionProperties;
 using geometry::ProximityProperties;
-using geometry::render::DepthCameraProperties;
+using geometry::render::ColorRenderCamera;
+using geometry::render::DepthRenderCamera;
 using geometry::render::RenderEngineVtkParams;
 using geometry::render::RenderLabel;
 using geometry::SceneGraph;
@@ -111,8 +112,9 @@ int do_main() {
     scene_graph->AssignRole(global_source, ground_id, properties);
 
     // Create the camera.
-    DepthCameraProperties camera_properties(640, 480, M_PI_4, render_name, 0.1,
-                                            2.0);
+    const ColorRenderCamera color_camera{
+        {render_name, {640, 480, M_PI_4}, {0.1, 2.0}, {}}, false};
+    const DepthRenderCamera depth_camera{color_camera.core(), {0.1, 2.0}};
     // We need to position and orient the camera. We have the camera body frame
     // B (see rgbd_sensor.h) and the camera frame C (see camera_info.h).
     // By default X_BC = I in the RgbdSensor. So, to aim the camera, Cz = Bz
@@ -130,7 +132,7 @@ int do_main() {
     const RigidTransformd X_WB(R_WB, p_WB);
 
     auto camera = builder.AddSystem<RgbdSensor>(
-        scene_graph->world_frame_id(), X_WB, camera_properties);
+        scene_graph->world_frame_id(), X_WB, color_camera, depth_camera);
     builder.Connect(scene_graph->get_query_output_port(),
                     camera->query_object_input_port());
 

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -1003,7 +1003,10 @@ void GeometryState<T>::RenderColorImage(const render::CameraProperties& camera,
   // TODO(SeanCurtis-TRI): Invoke UpdateViewpoint() as part of a calc cache
   //  entry. Challenge: how to do that with a parameter passed here?
   const_cast<render::RenderEngine&>(engine).UpdateViewpoint(X_WC);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   engine.RenderColorImage(camera, show_window, color_image_out);
+#pragma GCC diagnostic pop
 }
 
 template <typename T>
@@ -1015,7 +1018,10 @@ void GeometryState<T>::RenderDepthImage(
       GetRenderEngineOrThrow(camera.renderer_name);
   // See note in RenderColorImage() about this const cast.
   const_cast<render::RenderEngine&>(engine).UpdateViewpoint(X_WC);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   engine.RenderDepthImage(camera, depth_image_out);
+#pragma GCC diagnostic pop
 }
 
 template <typename T>
@@ -1029,7 +1035,10 @@ void GeometryState<T>::RenderLabelImage(const render::CameraProperties& camera,
       GetRenderEngineOrThrow(camera.renderer_name);
   // See note in RenderColorImage() about this const cast.
   const_cast<render::RenderEngine&>(engine).UpdateViewpoint(X_WC);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   engine.RenderLabelImage(camera, show_window, label_image_out);
+#pragma GCC diagnostic pop
 }
 
 template <typename T>

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -501,6 +501,9 @@ class GeometryState {
 
   /** Implementation of QueryObject::RenderColorImage().
    @pre All poses have already been updated.  */
+  DRAKE_DEPRECATED("2021-03-01",
+                   "CameraProperties are being deprecated. Please use the "
+                   "ColorRenderCamera variant.")
   void RenderColorImage(const render::CameraProperties& camera,
                         FrameId parent_frame, const math::RigidTransformd& X_PC,
                         bool show_window,
@@ -508,12 +511,18 @@ class GeometryState {
 
   /** Implementation of QueryObject::RenderDepthImage().
    @pre All poses have already been updated.  */
+  DRAKE_DEPRECATED("2021-03-01",
+                   "CameraProperties are being deprecated. Please use the "
+                   "DepthRenderCamera variant.")
   void RenderDepthImage(const render::DepthCameraProperties& camera,
                         FrameId parent_frame, const math::RigidTransformd& X_PC,
                         systems::sensors::ImageDepth32F* depth_image_out) const;
 
   /** Implementation of QueryObject::RenderLabelImage().
    @pre All poses have already been updated.  */
+  DRAKE_DEPRECATED("2021-03-01",
+                   "CameraProperties are being deprecated. Please use the "
+                   "ColorRenderCamera variant.")
   void RenderLabelImage(const render::CameraProperties& camera,
                         FrameId parent_frame, const math::RigidTransformd& X_PC,
                         bool show_window,

--- a/geometry/query_object.cc
+++ b/geometry/query_object.cc
@@ -200,8 +200,11 @@ void QueryObject<T>::RenderColorImage(const CameraProperties& camera,
 
   FullPoseUpdate();
   const GeometryState<T>& state = geometry_state();
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   return state.RenderColorImage(camera, parent_frame, X_PC, show_window,
                                 color_image_out);
+#pragma GCC diagnostic pop
 }
 
 template <typename T>
@@ -225,7 +228,10 @@ void QueryObject<T>::RenderDepthImage(const DepthCameraProperties& camera,
 
   FullPoseUpdate();
   const GeometryState<T>& state = geometry_state();
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   return state.RenderDepthImage(camera, parent_frame, X_PC, depth_image_out);
+#pragma GCC diagnostic pop
 }
 
 template <typename T>
@@ -250,8 +256,11 @@ void QueryObject<T>::RenderLabelImage(const CameraProperties& camera,
 
   FullPoseUpdate();
   const GeometryState<T>& state = geometry_state();
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   return state.RenderLabelImage(camera, parent_frame, X_PC, show_window,
                                 label_image_out);
+#pragma GCC diagnostic pop
 }
 
 template <typename T>

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -498,12 +498,22 @@ class QueryObject {
    @param X_PC                  The pose of the camera body in the parent frame.
    @param show_window           If true, the render window will be displayed.
    @param[out] color_image_out  The rendered color image. */
+  DRAKE_DEPRECATED("2021-03-01",
+                   "CameraProperties are being deprecated. Please use the "
+                   "ColorRenderCamera variant.")
   void RenderColorImage(const render::CameraProperties& camera,
                         FrameId parent_frame,
                         const math::RigidTransformd& X_PC,
                         bool show_window,
                         systems::sensors::ImageRgba8U* color_image_out) const;
 
+  /** Renders an RGB image for the given `camera` posed with respect to the
+   indicated parent frame P.
+
+   @param camera                The camera to render from.
+   @param parent_frame          The id for the camera's parent frame.
+   @param X_PC                  The pose of the camera body in the parent frame.
+   @param[out] color_image_out  The rendered color image. */
   void RenderColorImage(const render::ColorRenderCamera& camera,
                         FrameId parent_frame, const math::RigidTransformd& X_PC,
                         systems::sensors::ImageRgba8U* color_image_out) const;
@@ -519,11 +529,25 @@ class QueryObject {
    @param parent_frame          The id for the camera's parent frame.
    @param X_PC                  The pose of the camera body in the parent frame.
    @param[out] depth_image_out  The rendered depth image. */
+  DRAKE_DEPRECATED("2021-03-01",
+                   "CameraProperties are being deprecated. Please use the "
+                   "DepthRenderCamera variant.")
   void RenderDepthImage(const render::DepthCameraProperties& camera,
                         FrameId parent_frame,
                         const math::RigidTransformd& X_PC,
                         systems::sensors::ImageDepth32F* depth_image_out) const;
 
+  /** Renders a depth image for the given `camera` posed with respect to the
+   indicated parent frame P.
+
+   In contrast to the other rendering methods, rendering depth images doesn't
+   provide the option to display the window; generally, basic depth images are
+   not readily communicative to humans.
+
+   @param camera                The camera to render from.
+   @param parent_frame          The id for the camera's parent frame.
+   @param X_PC                  The pose of the camera body in the parent frame.
+   @param[out] depth_image_out  The rendered depth image. */
   void RenderDepthImage(const render::DepthRenderCamera& camera,
                         FrameId parent_frame, const math::RigidTransformd& X_PC,
                         systems::sensors::ImageDepth32F* depth_image_out) const;
@@ -536,12 +560,22 @@ class QueryObject {
    @param X_PC                  The pose of the camera body in the parent frame.
    @param show_window           If true, the render window will be displayed.
    @param[out] label_image_out  The rendered label image. */
+  DRAKE_DEPRECATED("2021-03-01",
+                   "CameraProperties are being deprecated. Please use the "
+                   "ColorRenderCamera variant.")
   void RenderLabelImage(const render::CameraProperties& camera,
                         FrameId parent_frame,
                         const math::RigidTransformd& X_PC,
                         bool show_window,
                         systems::sensors::ImageLabel16I* label_image_out) const;
 
+  /** Renders a label image for the given `camera` posed with respect to the
+   indicated parent frame P.
+
+   @param camera                The camera to render from.
+   @param parent_frame          The id for the camera's parent frame.
+   @param X_PC                  The pose of the camera body in the parent frame.
+   @param[out] label_image_out  The rendered label image. */
   void RenderLabelImage(const render::ColorRenderCamera& camera,
                         FrameId parent_frame, const math::RigidTransformd& X_PC,
                         systems::sensors::ImageLabel16I* label_image_out) const;

--- a/geometry/render/render_engine.cc
+++ b/geometry/render/render_engine.cc
@@ -107,7 +107,10 @@ void RenderEngine::DoRenderColorImage(const ColorRenderCamera& camera,
   CameraProperties simple_props{intrinsics.width(), intrinsics.height(),
                                 intrinsics.fov_y(),
                                 camera.core().renderer_name()};
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   RenderColorImage(simple_props, camera.show_window(), color_image_out);
+#pragma GCC diagnostic pop
 }
 
 void RenderEngine::DoRenderDepthImage(const DepthRenderCamera& camera,
@@ -135,7 +138,10 @@ void RenderEngine::DoRenderDepthImage(const DepthRenderCamera& camera,
                                      camera.core().renderer_name(),
                                      camera.depth_range().min_depth(),
                                      camera.depth_range().max_depth()};
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   RenderDepthImage(simple_props, depth_image_out);
+#pragma GCC diagnostic pop
 }
 
 void RenderEngine::DoRenderLabelImage(const ColorRenderCamera& camera,
@@ -160,7 +166,10 @@ void RenderEngine::DoRenderLabelImage(const ColorRenderCamera& camera,
   CameraProperties simple_props{intrinsics.width(), intrinsics.height(),
                                 intrinsics.fov_y(),
                                 camera.core().renderer_name()};
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   RenderLabelImage(simple_props, camera.show_window(), label_image_out);
+#pragma GCC diagnostic pop
 }
 
 void RenderEngine::SetDefaultLightPosition(const Vector3<double>&) {}

--- a/geometry/render/render_engine.h
+++ b/geometry/render/render_engine.h
@@ -10,6 +10,7 @@
 #include <Eigen/Dense>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/render/camera_properties.h"
@@ -232,6 +233,10 @@ class RenderEngine : public ShapeReifier {
    @param show_window           If true, the render window will be displayed.
    @param[out] color_image_out  The rendered color image.
    @pydrake_mkdoc_identifier{deprecated}  */
+  DRAKE_DEPRECATED("2021-03-01",
+                   "CameraProperties are being deprecated. Prefer the "
+                   "ColorRenderCamera variant; implement the protected "
+                   "DoRenderColorImage() method.")
   virtual void RenderColorImage(
       const CameraProperties& camera, bool show_window,
       systems::sensors::ImageRgba8U* color_image_out) const {
@@ -246,8 +251,11 @@ class RenderEngine : public ShapeReifier {
    depth images are not readily communicative to humans.
 
    @param camera                The intrinsic properties of the camera.
-   @param[out] depth_image_out  The rendered depth image.
-   @pydrake_mkdoc_identifier{deprecated}  */
+   @param[out] depth_image_out  The rendered depth image.  */
+  DRAKE_DEPRECATED("2021-03-01",
+                   "DepthCameraProperties are being deprecated. Prefer the "
+                   "DepthRenderCamera variant; implement the protected "
+                   "DoRenderDepthImage() method.")
   virtual void RenderDepthImage(
       const DepthCameraProperties& camera,
       systems::sensors::ImageDepth32F* depth_image_out) const {
@@ -263,6 +271,10 @@ class RenderEngine : public ShapeReifier {
    @param show_window           If true, the render window will be displayed.
    @param[out] label_image_out  The rendered label image.
    @pydrake_mkdoc_identifier{deprecated}  */
+  DRAKE_DEPRECATED("2021-03-01",
+                   "CameraProperties are being deprecated. Prefer the "
+                   "ColorRenderCamera variant; implement the protected "
+                   "DoRenderLabelImage() method.")
   virtual void RenderLabelImage(
       const CameraProperties& camera, bool show_window,
       systems::sensors::ImageLabel16I* label_image_out) const {
@@ -382,8 +394,11 @@ class RenderEngine : public ShapeReifier {
    `color_image_out` is not `nullptr` and its size is consistent with the
    camera intrinsics.
 
-   The default implementation strips out intrinsics unsupported by the simple
-   render API and prints a warning. */
+   During the deprecation period, the default implementation strips out
+   intrinsics unsupported by the simple render API, prints a warning, and
+   attempts to delegate to the simple-camera RenderColorImage. After
+   the deprecation period, it will throw a "not implemented"-style exception.
+   */
   virtual void DoRenderColorImage(
       const ColorRenderCamera& camera,
       systems::sensors::ImageRgba8U* color_image_out) const;
@@ -393,8 +408,11 @@ class RenderEngine : public ShapeReifier {
    `depth_image_out` is not `nullptr` and its size is consistent with the
    camera intrinsics.
 
-   The default implementation strips out intrinsics unsupported by the simple
-   render API and prints a warning. */
+   During the deprecation period, the default implementation strips out
+   intrinsics unsupported by the simple render API, prints a warning, and
+   attempts to delegate to the simple-camera RenderDepthImage. After
+   the deprecation period, it will throw a "not implemented"-style exception.
+   */
   virtual void DoRenderDepthImage(
       const DepthRenderCamera& camera,
       systems::sensors::ImageDepth32F* depth_image_out) const;
@@ -404,8 +422,11 @@ class RenderEngine : public ShapeReifier {
    `label_image_out` is not `nullptr` and its size is consistent with the
    camera intrinsics.
 
-   The default implementation strips out intrinsics unsupported by the simple
-   render API and prints a warning. */
+   During the deprecation period, the default implementation strips out
+   intrinsics unsupported by the simple render API, prints a warning, and
+   attempts to delegate to the simple-camera RenderLabelImage. After
+   the deprecation period, it will throw a "not implemented"-style exception.
+   */
   virtual void DoRenderLabelImage(
       const ColorRenderCamera& camera,
       systems::sensors::ImageLabel16I* label_image_out) const;

--- a/geometry/render/render_engine_vtk.cc
+++ b/geometry/render/render_engine_vtk.cc
@@ -45,18 +45,6 @@ using systems::sensors::vtk_util::MakeVtkPointerArray;
 
 namespace {
 
-// A note on OpenGL clipping planes and DepthCameraProperties near and far.
-// The z near and far planes reported in DepthCameraProperties are properties of
-// the modeled sensor. They cannot produce reliable depths closer than z_near
-// or farther than z_far.
-// We *could* set the OpenGl clipping planes to [z_near, z_far], however, that
-// will lead to undesirable artifacts. Any geometry that lies at a distance
-// in the range [0, z_near) would be clipped away with *no* occluding effects.
-// So, instead, we render the depth image in the range [epsilon, z_far] and
-// then detect the occluding pixels that lie closer than the camera's supported
-// range and mark them as too close. Clipping all geometry beyond z_far is not
-// a problem because they can unambiguously be marked as too far.
-const double kClippingPlaneNear = 0.01;
 const double kTerrainSize = 100.;
 
 void SetModelTransformMatrixToVtkCamera(
@@ -112,8 +100,9 @@ std::string RemoveFileExtension(const std::string& filepath) {
 namespace internal {
 
 ShaderCallback::ShaderCallback() :
-    z_near_(kClippingPlaneNear),
-    // This value will be overwritten by the camera's z_far value.
+    // These values are arbitrary "reasonable" values, but we expect them to
+    // *both* be overwritten upon every usage.
+    z_near_(0.01),
     z_far_(100.0) {}
 
 }  // namespace internal

--- a/geometry/render/test/render_engine_vtk_test.cc
+++ b/geometry/render/test/render_engine_vtk_test.cc
@@ -54,6 +54,8 @@ using systems::sensors::InvalidDepth;
 // Default camera properties.
 const int kWidth = 640;
 const int kHeight = 480;
+const double kClipNear = 0.1;
+const double kClipFar = 100.0;
 const double kZNear = 0.5;
 const double kZFar = 5.;
 const double kFovY = M_PI_4;
@@ -195,18 +197,20 @@ class RenderEngineVtkTest : public ::testing::Test {
   // This interface allows that to be completely reconfigured by the calling
   // test.
   void Render(RenderEngineVtk* renderer = nullptr,
-              const DepthCameraProperties* camera_in = nullptr,
+              const DepthRenderCamera* camera_in = nullptr,
               ImageRgba8U* color_out = nullptr,
               ImageDepth32F* depth_out = nullptr,
               ImageLabel16I* label_out = nullptr) {
     if (!renderer) renderer = renderer_.get();
-    const DepthCameraProperties& camera = camera_in ? *camera_in : camera_;
+    const DepthRenderCamera& depth_camera =
+        camera_in ? *camera_in : depth_camera_;
+    const ColorRenderCamera color_camera(depth_camera.core(), kShowWindow);
     ImageRgba8U* color = color_out ? color_out : &color_;
     ImageDepth32F* depth = depth_out ? depth_out : &depth_;
     ImageLabel16I* label = label_out ? label_out : &label_;
-    renderer->RenderColorImage(camera, kShowWindow, color);
-    renderer->RenderDepthImage(camera, depth);
-    renderer->RenderLabelImage(camera, kShowWindow, label);
+    EXPECT_NO_THROW(renderer->RenderDepthImage(depth_camera, depth));
+    EXPECT_NO_THROW(renderer->RenderLabelImage(color_camera, label));
+    EXPECT_NO_THROW(renderer->RenderColorImage(color_camera, color));
   }
 
   // Confirms that all pixels in the member color image have the same value.
@@ -251,17 +255,17 @@ class RenderEngineVtkTest : public ::testing::Test {
   }
 
   // Compute the set of outliers for a given set of camera properties.
-  static vector<ScreenCoord> GetOutliers(const CameraProperties& camera) {
-    return vector<ScreenCoord>{
+  static std::vector<ScreenCoord> GetOutliers(const CameraInfo& intrinsics) {
+    return std::vector<ScreenCoord>{
         {kInset, kInset},
-        {kInset, camera.height - kInset - 1},
-        {camera.width - kInset - 1, camera.height - kInset - 1},
-        {camera.width - kInset - 1, kInset}};
+        {kInset, intrinsics.height() - kInset - 1},
+        {intrinsics.width() - kInset - 1, intrinsics.height() - kInset - 1},
+        {intrinsics.width() - kInset - 1, kInset}};
   }
 
   // Compute the inlier for the given set of camera properties.
-  static ScreenCoord GetInlier(const CameraProperties& camera) {
-    return ScreenCoord{camera.width / 2, camera.height / 2};
+  static ScreenCoord GetInlier(const CameraInfo& intrinsics) {
+    return {intrinsics.width() / 2, intrinsics.height() / 2};
   }
 
   // Tests that the depth value in the given `image` at the given `coord` is
@@ -297,7 +301,7 @@ class RenderEngineVtkTest : public ::testing::Test {
   // plane. If images are provided, the given images will be tested, otherwise
   // the member images will be tested.
   void VerifyOutliers(const RenderEngineVtk& renderer,
-                      const DepthCameraProperties& camera,
+                      const DepthRenderCamera& camera,
                       const char* name,
                       const ImageRgba8U* color_in = nullptr,
                       const ImageDepth32F* depth_in = nullptr,
@@ -306,7 +310,7 @@ class RenderEngineVtkTest : public ::testing::Test {
     const ImageDepth32F& depth = depth_in ? *depth_in : depth_;
     const ImageLabel16I& label = label_in ? *label_in : label_;
 
-    for (const auto& screen_coord : GetOutliers(camera)) {
+    for (const auto& screen_coord : GetOutliers(camera.core().intrinsics())) {
       const int x = screen_coord.x;
       const int y = screen_coord.y;
       EXPECT_TRUE(CompareColor(expected_outlier_color_, color, screen_coord))
@@ -422,13 +426,15 @@ class RenderEngineVtkTest : public ::testing::Test {
   // compatible shape and camera configuration (e.g., PopulateSphereTest()).
   void PerformCenterShapeTest(RenderEngineVtk* renderer,
                               const char* name,
-                              const DepthCameraProperties* camera = nullptr) {
-    const DepthCameraProperties& cam = camera ? *camera : camera_;
+                              const DepthRenderCamera* camera = nullptr) {
+    const DepthRenderCamera& cam = camera ? *camera : depth_camera_;
+    const int w = cam.core().intrinsics().width();
+    const int h = cam.core().intrinsics().height();
     // Can't use the member images in case the camera has been configured to a
     // different size than the default camera_ configuration.
-    ImageRgba8U color(cam.width, cam.height);
-    ImageDepth32F depth(cam.width, cam.height);
-    ImageLabel16I label(cam.width, cam.height);
+    ImageRgba8U color(w, h);
+    ImageDepth32F depth(w, h);
+    ImageLabel16I label(w, h);
     Render(renderer, &cam, &color, &depth, &label);
 
     VerifyCenterShapeTest(*renderer, name, cam, color, depth, label);
@@ -436,14 +442,14 @@ class RenderEngineVtkTest : public ::testing::Test {
 
   void VerifyCenterShapeTest(const RenderEngineVtk& renderer,
                               const char* name,
-                              const DepthCameraProperties& camera,
+                              const DepthRenderCamera& camera,
                               const ImageRgba8U& color,
                               const ImageDepth32F& depth,
                               const ImageLabel16I& label) const {
     VerifyOutliers(renderer, camera, name, &color, &depth, &label);
 
     // Verifies inside the sphere.
-    const ScreenCoord inlier = GetInlier(camera);
+    const ScreenCoord inlier = GetInlier(camera.core().intrinsics());
     const int x = inlier.x;
     const int y = inlier.y;
     EXPECT_TRUE(CompareColor(expected_color_, color, inlier))
@@ -463,8 +469,11 @@ class RenderEngineVtkTest : public ::testing::Test {
   RenderLabel expected_outlier_label_{RenderLabel::kDontCare};
   RgbaColor default_color_{kDefaultVisualColor, 255};
 
-  const DepthCameraProperties camera_ = {kWidth, kHeight, kFovY, "unused",
-                                         kZNear, kZFar};
+  // We store a reference depth camera; we can always derive a color camera
+  // from it; they have the same intrinsics and we grab the global kShowWindow.
+  const DepthRenderCamera depth_camera_{
+      {"unused", {kWidth, kHeight, kFovY}, {kClipNear, kClipFar}, {}},
+      {kZNear, kZFar}};
 
   ImageRgba8U color_;
   ImageDepth32F depth_;
@@ -545,8 +554,8 @@ TEST_F(RenderEngineVtkTest, HorizonTest) {
       AngleAxisd(M_PI_2, Vector3d::UnitY())}};
   Init(X_WR, true);
 
-  CameraProperties camera{camera_.width, camera_.height, camera_.fov_y,
-                          "ignored"};
+  const ColorRenderCamera camera(depth_camera_.core(), kShowWindow);
+  const auto& intrinsics = camera.core().intrinsics();
   // Returns y in [0, camera.height), index of horizon location in image
   // coordinate system under several assumptions:
   //   - the ground plane is not clipped by kClippingPlaneFar,
@@ -554,15 +563,15 @@ TEST_F(RenderEngineVtkTest, HorizonTest) {
   //   - the ground is a square 100m on a side, centered on world origin.
   //   - camera is located above world origin with a view direction parallel to
   //     the ground (such that the horizon is a horizontal line).
-  auto CalcHorizon = [&camera](double z) {
-    const double kTerrainSize = 50.;
+  auto CalcHorizon = [intrinsics](double z) {
+    const double kTerrainHalfSize = 50.;
     const double kFocalLength =
-        camera.height * 0.5 / std::tan(0.5 * camera.fov_y);
+        intrinsics.height() * 0.5 / std::tan(0.5 * intrinsics.fov_y());
     // We assume the horizon is *below* the middle of the screen. So, we compute
     // the number of pixels below the screen center the horizon must lie, and
     // then add half screen height to that value to get the number of rows
     // from the top row of the image.
-    return 0.5 * camera.height + z / kTerrainSize * kFocalLength;
+    return 0.5 * intrinsics.height() + z / kTerrainHalfSize * kFocalLength;
   };
 
   // Verifies v index of horizon at three different camera heights.
@@ -570,14 +579,14 @@ TEST_F(RenderEngineVtkTest, HorizonTest) {
   for (const double z : {2., 1., 0.5}) {
     X_WR.set_translation({p_WR(0), p_WR(1), z});
     renderer_->UpdateViewpoint(X_WR);
-    ImageRgba8U color(camera.width, camera.height);
-    renderer_->RenderColorImage(camera, kShowWindow, &color);
+    ImageRgba8U color(intrinsics.width(), intrinsics.height());
+    renderer_->RenderColorImage(camera, &color);
 
     int actual_horizon{0};
     // This test is looking for the *first* row that isn't exactly sky color.
     // That implies it's starting its search *in the sky*. That implies that the
     // top row is zero and the bottom row is height - 1.
-    for (int y = 0; y < camera.height; ++y) {
+    for (int y = 0; y < intrinsics.height(); ++y) {
       if ((static_cast<uint8_t>(kBgColor.r != color.at(0, y)[0])) ||
           (static_cast<uint8_t>(kBgColor.g != color.at(0, y)[1])) ||
           (static_cast<uint8_t>(kBgColor.b != color.at(0, y)[2]))) {
@@ -595,6 +604,7 @@ TEST_F(RenderEngineVtkTest, HorizonTest) {
 
 // Performs the shape-centered-in-the-image test with a box.
 TEST_F(RenderEngineVtkTest, BoxTest) {
+  const auto& intrinsics = depth_camera_.core().intrinsics();
   for (const bool use_texture : {false, true}) {
     for (const double texture_scale : {1.0, 0.5}) {
       const bool texture_scaled = texture_scale != 1;
@@ -638,7 +648,8 @@ TEST_F(RenderEngineVtkTest, BoxTest) {
       // Because we have a radially symmetric lens, px = py and we can compute
       // that measure by with simple trigonometry.
       const double pixel_size = 4 * expected_object_depth_ *
-                                tan(camera_.fov_y / 2.0) / camera_.height;
+                                tan(intrinsics.fov_y() / 2.0) /
+                                intrinsics.height();
       RigidTransformd X_WV{RotationMatrixd{AngleAxisd(M_PI, Vector3d::UnitX())},
                            Vector3d{(-box.width() + pixel_size) * 0.5,
                                     (-box.depth() + pixel_size) * 0.5, 0.625}};
@@ -697,8 +708,10 @@ TEST_F(RenderEngineVtkTest, TransparentSphereTest) {
   const int int_alpha = 128;
   default_color_ = RgbaColor(kDefaultVisualColor, int_alpha);
   PopulateSphereTest(&renderer);
-  ImageRgba8U color(camera_.width, camera_.height);
-  renderer.RenderColorImage(camera_, kShowWindow, &color);
+  const ColorRenderCamera camera(depth_camera_.core(), kShowWindow);
+  const auto& intrinsics = camera.core().intrinsics();
+  ImageRgba8U color(intrinsics.width(), intrinsics.height());
+  renderer.RenderColorImage(camera, &color);
 
   // Note: under CI this test runs with Xvfb - a virtual frame buffer. This does
   // *not* use the OpenGL drivers and, empirically, it has shown a different
@@ -723,7 +736,7 @@ TEST_F(RenderEngineVtkTest, TransparentSphereTest) {
   const RgbaColor expect_quad{
       blend(kDefaultVisualColor, kTerrainColorI, quad_factor), 255};
 
-  const ScreenCoord inlier = GetInlier(camera_);
+  const ScreenCoord inlier = GetInlier(intrinsics);
   EXPECT_TRUE(CompareColor(expect_linear, color, inlier) ||
               CompareColor(expect_quad, color, inlier));
 }
@@ -789,12 +802,12 @@ TEST_F(RenderEngineVtkTest, CapsuleRotatedTest) {
   Render(renderer_.get());
 
   const char* name = "Capsule rotated test";
-  VerifyOutliers(*renderer_, camera_, name);
+  VerifyOutliers(*renderer_, depth_camera_, name);
 
   // Verifies the inliers towards the ends of the capsule and ensures its
   // length attribute is respected as opposed to just its radius. This
   // distinguishes it from other shape tests, such as a sphere.
-  const ScreenCoord inlier = GetInlier(camera_);
+  const ScreenCoord inlier = GetInlier(depth_camera_.core().intrinsics());
   const int offsets[2] = {kHeight / 4, -kHeight / 4};
   const int x = inlier.x;
   for (const int& offset : offsets) {
@@ -1111,44 +1124,58 @@ TEST_F(RenderEngineVtkTest, DifferentCameras) {
   Init(X_WC_, true);
   PopulateSphereTest(renderer_.get());
 
+  const auto& ref_core = depth_camera_.core();
+  const std::string& ref_name = ref_core.renderer_name();
+  const RigidTransformd ref_X_BS = ref_core.sensor_pose_in_camera_body();
+  const ClippingRange& ref_clipping = ref_core.clipping();
+  const auto& ref_intrinsics = ref_core.intrinsics();
+  const int ref_w = ref_intrinsics.width();
+  const int ref_h = ref_intrinsics.height();
+  const double ref_fov_y = ref_intrinsics.fov_y();
+
   // Baseline -- confirm that all of the defaults in this test still produce
   // the expected outcome.
-  PerformCenterShapeTest(renderer_.get(), "Camera change - baseline", &camera_);
+  PerformCenterShapeTest(renderer_.get(), "Camera change - baseline",
+                         &depth_camera_);
 
   // Test changes in sensor sizes.
   {
     // Now run it again with a camera with a smaller sensor (quarter area).
-    DepthCameraProperties small_camera{camera_};
-    small_camera.width /= 2;
-    small_camera.height /= 2;
+    const DepthRenderCamera small_camera{
+        {ref_name, {ref_w / 2, ref_h / 2, ref_fov_y}, ref_clipping, ref_X_BS},
+        depth_camera_.depth_range()};
     PerformCenterShapeTest(renderer_.get(), "Camera change - small camera",
                            &small_camera);
 
     // Now run it again with a camera with a bigger sensor (4X area).
-    DepthCameraProperties big_camera{camera_};
-    big_camera.width *= 2;
-    big_camera.height *= 2;
+    const DepthRenderCamera big_camera{
+        {ref_name, {ref_w * 2, ref_h * 2, ref_fov_y}, ref_clipping, ref_X_BS},
+        depth_camera_.depth_range()};
     PerformCenterShapeTest(renderer_.get(), "Camera change - big camera",
                            &big_camera);
   }
 
   // Test changes in fov (larger and smaller).
   {
-    DepthCameraProperties narrow_fov(camera_);
-    narrow_fov.fov_y /= 2;
+    const DepthRenderCamera narrow_fov{
+        {ref_name, {ref_w, ref_h, ref_fov_y / 2}, ref_clipping, ref_X_BS},
+        depth_camera_.depth_range()};
     PerformCenterShapeTest(renderer_.get(), "Camera change - narrow fov",
                            &narrow_fov);
 
-    DepthCameraProperties wide_fov(camera_);
-    wide_fov.fov_y *= 2;
+    const DepthRenderCamera wide_fov{
+        {ref_name, {ref_w, ref_h, ref_fov_y * 2}, ref_clipping, ref_X_BS},
+        depth_camera_.depth_range()};
     PerformCenterShapeTest(renderer_.get(), "Camera change - wide fov",
                            &wide_fov);
   }
 
   // Test changes to depth range.
   {
-    DepthCameraProperties clipping_far_plane(camera_);
-    clipping_far_plane.z_far = expected_outlier_depth_ - 0.1;
+    const auto& depth_range = depth_camera_.depth_range();
+    const DepthRenderCamera clipping_far_plane{
+        depth_camera_.core(),
+        {depth_range.min_depth(), expected_outlier_depth_ - 0.1}};
     const float old_outlier_depth = expected_outlier_depth_;
     expected_outlier_depth_ = std::numeric_limits<float>::infinity();
     PerformCenterShapeTest(renderer_.get(),
@@ -1157,8 +1184,9 @@ TEST_F(RenderEngineVtkTest, DifferentCameras) {
     // NOTE: Need to restored expected outlier depth for next test.
     expected_outlier_depth_ = old_outlier_depth;
 
-    DepthCameraProperties clipping_near_plane(camera_);
-    clipping_near_plane.z_near = expected_object_depth_ + 0.1;
+      const DepthRenderCamera clipping_near_plane{
+        depth_camera_.core(),
+        {expected_object_depth_ + 0.1, depth_range.max_depth()}};
     expected_object_depth_ = 0;
     PerformCenterShapeTest(renderer_.get(),
                            "Camera change - z near clips mesh",

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -564,7 +564,8 @@ class SceneGraph final : public systems::LeafSystem<T> {
 
   /** Adds a new render engine to this %SceneGraph. The %SceneGraph owns the
    render engine. The render engine's name should be referenced in the
-   @ref render::CameraProperties "CameraProperties" provided in the render
+   @ref render::ColorRenderCamera "ColorRenderCamera" or
+   @ref render::DepthRenderCamera "DepthRenderCamera" provided in the render
    queries (see QueryObject::RenderColorImage() as an example).
 
    There is no restriction on when a renderer is added relative to geometry

--- a/geometry/test/query_object_test.cc
+++ b/geometry/test/query_object_test.cc
@@ -194,26 +194,29 @@ TEST_F(QueryObjectTest, DefaultQueryThrows) {
       {"n/a", {2, 2, M_PI}, {0.1, 10}, RigidTransformd{}}, false};
   const DepthRenderCamera depth_camera{
       {"n/a", {2, 2, M_PI}, {0.1, 10}, RigidTransformd{}}, {0.2, 0.9}};
-  const DepthCameraProperties properties(2, 2, M_PI, "dummy_renderer", 0.1,
-                                         5.0);
   const RigidTransformd X_WC = RigidTransformd::Identity();
+
   ImageRgba8U color;
   EXPECT_DEFAULT_ERROR(default_object.RenderColorImage(
-      properties, FrameId::get_new_id(), X_WC, false, &color));
-  EXPECT_DEFAULT_ERROR(default_object.RenderColorImage(
       color_camera, FrameId::get_new_id(), X_WC, &color));
-
   ImageDepth32F depth;
   EXPECT_DEFAULT_ERROR(default_object.RenderDepthImage(
-      properties, FrameId::get_new_id(), X_WC, &depth));
-  EXPECT_DEFAULT_ERROR(default_object.RenderDepthImage(
       depth_camera, FrameId::get_new_id(), X_WC, &depth));
-
   ImageLabel16I label;
   EXPECT_DEFAULT_ERROR(default_object.RenderLabelImage(
-      properties, FrameId::get_new_id(), X_WC, false, &label));
-  EXPECT_DEFAULT_ERROR(default_object.RenderLabelImage(
       color_camera, FrameId::get_new_id(), X_WC, &label));
+
+  const DepthCameraProperties properties(2, 2, M_PI, "dummy_renderer", 0.1,
+                                         5.0);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  EXPECT_DEFAULT_ERROR(default_object.RenderColorImage(
+      properties, FrameId::get_new_id(), X_WC, false, &color));
+  EXPECT_DEFAULT_ERROR(default_object.RenderDepthImage(
+      properties, FrameId::get_new_id(), X_WC, &depth));
+  EXPECT_DEFAULT_ERROR(default_object.RenderLabelImage(
+      properties, FrameId::get_new_id(), X_WC, false, &label));
+#pragma GCC diagnostic pop
 
   EXPECT_DEFAULT_ERROR(default_object.GetRenderEngineByName("dummy"));
 


### PR DESCRIPTION
- RenderEngine
  - Deprecate the api.
  - Modify documentation on DoRender*Image API to reflect deprecation implications.
  - Guard tests from deprecation warnings.
- QueryObject
  - Deprecate corresponding API
  - Add documentation for the new API.
  - deprecate bindings
- GeometryState
  - Deprecate corresponding API (functionally internal, but not technically internal, so I'm simply deprecating it and allowing it to evaporate with all the rest of in the spring).
- Clean up numerous call sites to upgrade from CameraProperties to RenderCamera
  - benchmarks, examples, documentation, and tests.

Towards resolving checklist in #11880.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14359)
<!-- Reviewable:end -->
