### PR TITLE
diagram/builder: Implement fan-out of diagram inputs

### DIFF
--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -500,6 +500,16 @@ void DefineFrameworkPySemantics(py::module m) {
         .def("ExportInput", &DiagramBuilder<T>::ExportInput, py::arg("input"),
             py::arg("name") = kUseDefaultName, py_rvp::reference_internal,
             doc.DiagramBuilder.ExportInput.doc)
+        .def("ConnectInput",
+            py::overload_cast<const std::string&, const InputPort<T>&>(
+                &DiagramBuilder<T>::ConnectInput),
+            py::arg("diagram_port_name"), py::arg("input"),
+            doc.DiagramBuilder.ConnectInput.doc_2args_diagram_port_name_input)
+        .def("ConnectInput",
+            py::overload_cast<InputPortIndex, const InputPort<T>&>(
+                &DiagramBuilder<T>::ConnectInput),
+            py::arg("diagram_port_index"), py::arg("input"),
+            doc.DiagramBuilder.ConnectInput.doc_2args_diagram_port_index_input)
         .def("ExportOutput", &DiagramBuilder<T>::ExportOutput,
             py::arg("output"), py::arg("name") = kUseDefaultName,
             py_rvp::reference_internal, doc.DiagramBuilder.ExportOutput.doc)

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -862,3 +862,32 @@ class TestGeneral(unittest.TestCase):
         system.set_name("zoh")
         html = GenerateHtml(system, initial_depth=2)
         self.assertRegex(html, r'key: "zoh"')
+
+    def test_diagram_fan_out(self):
+        builder = DiagramBuilder()
+        adder = builder.AddSystem(Adder(6, 1))
+        adder.set_name("adder")
+        builder.ExportOutput(adder.get_output_port())
+        in0_index = builder.ExportInput(adder.get_input_port(0), "in0")
+        in1_index = builder.ExportInput(adder.get_input_port(1), "in1")
+
+        # Exercise ConnectInput overload bindings, with and without argument
+        # names.
+        builder.ConnectInput(in0_index, adder.get_input_port(2))
+        builder.ConnectInput("in1", adder.get_input_port(3))
+        builder.ConnectInput(diagram_port_name="in0",
+                             input=adder.get_input_port(4))
+        builder.ConnectInput(diagram_port_index=in1_index,
+                             input=adder.get_input_port(5))
+
+        diagram = builder.Build()
+        diagram.set_name("fan_out_diagram")
+        graph = diagram.GetGraphvizString()
+
+        # Check the desired input topology is in the graph.
+        self.assertRegex(graph, "_u0 -> .*:u0")
+        self.assertRegex(graph, "_u1 -> .*:u1")
+        self.assertRegex(graph, "_u0 -> .*:u2")
+        self.assertRegex(graph, "_u1 -> .*:u3")
+        self.assertRegex(graph, "_u0 -> .*:u4")
+        self.assertRegex(graph, "_u1 -> .*:u5")

--- a/examples/kuka_iiwa_arm/kuka_torque_controller.h
+++ b/examples/kuka_iiwa_arm/kuka_torque_controller.h
@@ -57,10 +57,10 @@ class KukaTorqueController
 
  private:
   const multibody::MultibodyPlant<T>& plant_;
-  int input_port_index_estimated_state_{-1};
-  int input_port_index_desired_state_{-1};
-  int input_port_index_commanded_torque_{-1};
-  int output_port_index_control_{-1};
+  systems::InputPortIndex input_port_index_estimated_state_;
+  systems::InputPortIndex input_port_index_desired_state_;
+  systems::InputPortIndex input_port_index_commanded_torque_;
+  systems::OutputPortIndex output_port_index_control_;
 };
 
 }  // namespace kuka_iiwa_arm

--- a/manipulation/schunk_wsg/schunk_wsg_controller.cc
+++ b/manipulation/schunk_wsg/schunk_wsg_controller.cc
@@ -5,7 +5,6 @@
 #include "drake/manipulation/schunk_wsg/schunk_wsg_plain_controller.h"
 #include "drake/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.h"
 #include "drake/systems/framework/diagram_builder.h"
-#include "drake/systems/primitives/pass_through.h"
 
 namespace drake {
 namespace manipulation {
@@ -14,21 +13,17 @@ namespace schunk_wsg {
 SchunkWsgController::SchunkWsgController(double kp, double ki, double kd) {
   systems::DiagramBuilder<double> builder;
 
-  auto state_pass_through = builder.AddSystem<systems::PassThrough<double>>(
-      kSchunkWsgNumPositions + kSchunkWsgNumVelocities);
-
-  builder.ExportInput(state_pass_through->get_input_port(), "state");
+  auto wsg_trajectory_generator =
+      builder.AddSystem<SchunkWsgTrajectoryGenerator>(
+          kSchunkWsgNumPositions + kSchunkWsgNumVelocities,
+          kSchunkWsgPositionIndex);
+  const auto state_port_index = builder.ExportInput(
+      wsg_trajectory_generator->get_state_input_port(), "state");
 
   auto command_receiver = builder.AddSystem<SchunkWsgCommandReceiver>();
   builder.ExportInput(command_receiver->GetInputPort("command_message"),
                       "command_message");
 
-  auto wsg_trajectory_generator =
-      builder.AddSystem<SchunkWsgTrajectoryGenerator>(
-          kSchunkWsgNumPositions + kSchunkWsgNumVelocities,
-          kSchunkWsgPositionIndex);
-  builder.Connect(state_pass_through->get_output_port(),
-                  wsg_trajectory_generator->get_state_input_port());
   builder.Connect(command_receiver->get_position_output_port(),
                   wsg_trajectory_generator->get_desired_position_input_port());
   builder.Connect(command_receiver->get_force_limit_output_port(),
@@ -36,8 +31,8 @@ SchunkWsgController::SchunkWsgController(double kp, double ki, double kd) {
 
   auto wsg_controller = builder.AddSystem<SchunkWsgPlainController>(
       ControlMode::kPosition, kp, ki, kd);
-  builder.Connect(state_pass_through->get_output_port(),
-                  wsg_controller->get_input_port_estimated_state());
+  builder.ConnectInput(state_port_index,
+                       wsg_controller->get_input_port_estimated_state());
   builder.Connect(wsg_trajectory_generator->get_target_output_port(),
                   wsg_controller->get_input_port_desired_state());
   builder.Connect(wsg_trajectory_generator->get_max_force_output_port(),

--- a/manipulation/schunk_wsg/schunk_wsg_plain_controller.h
+++ b/manipulation/schunk_wsg/schunk_wsg_plain_controller.h
@@ -149,10 +149,10 @@ class SchunkWsgPlainController
   }
 
  private:
-  int desired_grip_state_input_port_{-1};
-  int feed_forward_force_input_port_{-1};
-  int state_input_port_{-1};
-  int max_force_input_port_{-1};
+  systems::InputPortIndex desired_grip_state_input_port_;
+  systems::InputPortIndex feed_forward_force_input_port_;
+  systems::InputPortIndex state_input_port_;
+  systems::InputPortIndex max_force_input_port_;
 };
 
 }  // namespace schunk_wsg

--- a/systems/controllers/inverse_dynamics_controller.h
+++ b/systems/controllers/inverse_dynamics_controller.h
@@ -159,10 +159,10 @@ class InverseDynamicsController : public Diagram<T>,
   const multibody::MultibodyPlant<T>* multibody_plant_for_control_{nullptr};
   PidController<T>* pid_{nullptr};
   const bool has_reference_acceleration_{false};
-  int input_port_index_estimated_state_{-1};
-  int input_port_index_desired_state_{-1};
-  int input_port_index_desired_acceleration_{-1};
-  int output_port_index_control_{-1};
+  InputPortIndex input_port_index_estimated_state_;
+  InputPortIndex input_port_index_desired_state_;
+  InputPortIndex input_port_index_desired_acceleration_;
+  OutputPortIndex output_port_index_control_;
 };
 
 }  // namespace controllers

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -91,10 +91,16 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
   /// Returns a reference to the map of connections between Systems.
   const std::map<InputPortLocator, OutputPortLocator>& connection_map() const;
 
-  /// Returns the "locator" for the subsystem input port that was exported as
-  /// the @p port_index input port for the Diagram.
-  const InputPortLocator& get_input_port_locator(
+  /// Returns the collection of "locators" for the subsystem input ports that
+  /// were exported or connected to the @p port_index input port for the
+  /// Diagram.
+  std::vector<InputPortLocator> GetInputPortLocators(
       InputPortIndex port_index) const;
+
+  /// Returns an arbitrary "locator" for one of the subsystem input ports that
+  /// were exported to the @p port_index input port for the Diagram.
+  DRAKE_DEPRECATED("2021-03-01", "Use GetInputPortLocators() instead.")
+  InputPortLocator get_input_port_locator(InputPortIndex port_index) const;
 
   /// Returns the "locator" for the subsystem output port that was exported as
   /// the @p port_index output port for the Diagram.
@@ -471,11 +477,17 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
   // Validates the given @p blueprint and sets up the Diagram accordingly.
   void Initialize(std::unique_ptr<Blueprint> blueprint);
 
-  // Exposes the given port as an input of the Diagram.
-  void ExportInput(const InputPortLocator& port, std::string name);
+  // Connects the given port to an input of the Diagram indicated by @p name.
+  // If the named Diagram input does not exist, it is declared.
+  void ExportOrConnectInput(const InputPortLocator& port, std::string name);
 
   // Exposes the given subsystem output port as an output of the Diagram.
   void ExportOutput(const OutputPortLocator& port, std::string name);
+
+  // Returns an arbitrary "locator" for one of the subsystem input ports that
+  // were exported to the @p port_index input port for the Diagram.
+  InputPortLocator GetArbitraryInputPortLocator(
+      InputPortIndex port_index) const;
 
   // Returns a reference to the value in the given context, of the specified
   // output port of one of this Diagram's immediate subsystems, recalculating
@@ -516,10 +528,11 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
   // Map to quickly satisfy "What is the subsystem index of the child system?"
   std::map<const System<T>*, SubsystemIndex> system_index_map_;
 
-  // The ordered inputs and outputs of this Diagram. Index by InputPortIndex
-  // and OutputPortIndex.
-  std::vector<InputPortLocator> input_port_ids_;
+  // The ordered outputs of this Diagram. Index by OutputPortIndex.
   std::vector<OutputPortLocator> output_port_ids_;
+
+  // The map of subsystem inputs to inputs of this Diagram.
+  std::map<InputPortLocator, InputPortIndex> input_port_map_;
 
   // For all T, Diagram<T> considers DiagramBuilder<T> a friend, so that the
   // builder can set the internal state correctly.

--- a/systems/framework/system_html.cc
+++ b/systems/framework/system_html.cc
@@ -163,14 +163,15 @@ class LinkWriter : public SystemVisitor<double> {
     // Add edges from the input port nodes to the subsystems that
     // actually service that port.
     for (InputPortIndex i(0); i < diagram.num_input_ports(); ++i) {
-      const Diagram<double>::InputPortLocator& dest =
-          diagram.get_input_port_locator(i);
-      const System<double>* dest_sys = dest.first;
-      *html_ << "{ ";
-      *html_ << "from: \"" << diagram.get_name() << "_u" << i << "\", ";
-      ToPortTokenWriter output_writer(dest.second, html_);
-      dest_sys->Accept(&output_writer);
-      *html_ << "},\n";
+      const auto& dests = diagram.GetInputPortLocators(i);
+      for (const auto& dest : dests) {
+        const System<double>* dest_sys = dest.first;
+        *html_ << "{ ";
+        *html_ << "from: \"" << diagram.get_name() << "_u" << i << "\", ";
+        ToPortTokenWriter output_writer(dest.second, html_);
+        dest_sys->Accept(&output_writer);
+        *html_ << "},\n";
+      }
     }
 
     // Add edges to the output ports.

--- a/systems/framework/test/system_html_test.cc
+++ b/systems/framework/test/system_html_test.cc
@@ -10,6 +10,7 @@
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/system.h"
 #include "drake/systems/primitives/adder.h"
+#include "drake/systems/primitives/discrete_derivative.h"
 #include "drake/systems/primitives/pass_through.h"
 
 namespace drake {
@@ -77,6 +78,17 @@ output_ports: [ { name: "y", id: "y0" }, ],
 { from: "subdiagram_u0", to: "adder", toPort: "u1", },
 { from: "subdiagram_u1", to: "pass", toPort: "u0", },
 { from: "adder", fromPort: "y0", to: "subdiagram_y0", },)"));
+}
+
+// Test a diagram that uses exported input fan-out.
+GTEST_TEST(SystemHtmlTest, SystemWithFanout) {
+  StateInterpolatorWithDiscreteDerivative<double> system(3, 0.05);
+  system.set_name("terp");
+  const std::string html = GenerateHtml(system);
+
+  // Proof of life test for fanout.
+  EXPECT_THAT(html, HasSubstr(R"(from: "terp_u0", to: "drake/systems/Multiplexer)"));
+  EXPECT_THAT(html, HasSubstr(R"(from: "terp_u0", to: "drake/systems/DiscreteDerivative)"));
 }
 
 GTEST_TEST(SystemHtmlTest, ManipulationStation) {

--- a/systems/primitives/discrete_derivative.cc
+++ b/systems/primitives/discrete_derivative.cc
@@ -6,7 +6,6 @@
 #include "drake/common/default_scalars.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/primitives/multiplexer.h"
-#include "drake/systems/primitives/pass_through.h"
 
 namespace drake {
 namespace systems {
@@ -115,16 +114,14 @@ StateInterpolatorWithDiscreteDerivative<
     int num_positions, double time_step, bool suppress_initial_transient) {
   DiagramBuilder<T> builder;
 
-  auto pass_through = builder.template AddSystem<PassThrough>(num_positions);
   derivative_ = builder.template AddSystem<DiscreteDerivative>(
       num_positions, time_step, suppress_initial_transient);
   auto mux = builder.template AddSystem<Multiplexer>(
       std::vector<int>{num_positions, num_positions});
 
-  builder.ExportInput(pass_through->get_input_port(), "position");
-  builder.Connect(pass_through->get_output_port(),
-                  derivative_->get_input_port());
-  builder.Connect(pass_through->get_output_port(), mux->get_input_port(0));
+  const auto port_index = builder.ExportInput(derivative_->get_input_port(),
+                                              "position");
+  builder.ConnectInput(port_index, mux->get_input_port(0));
   builder.Connect(derivative_->get_output_port(), mux->get_input_port(1));
   builder.ExportOutput(mux->get_output_port(0), "state");
 


### PR DESCRIPTION
Closes #3555.

Expands diagram and builder to support implicit fan-out of diagram input ports,
replacing the old work-around of using a pass-through system.

Summary of changes:
 * Allow repeated ExportInput calls to implement implicit fan-out
   * requires more bookkeeping in diagram and builder
 * Deprecate diagram.get_input_port_locator() API
   * replaced with fan-out-aware GetInputPortLocators()
   * port clients of deprecated API; all within systems/framework
 * Add necessary test coverage
 * Port various diagrams to use fan-out instead of pass-throughs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14361)
<!-- Reviewable:end -->
