### PR TITLE
Adds drake package for model URI resolution

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,6 +16,7 @@ exports_files([
     ".bazelproject",
     ".clang-format",
     ".drake-find_resource-sentinel",
+    "package.xml",
 ])
 
 # Drake's top-level module; all drake_py_stuff rules add this to deps.

--- a/bindings/pydrake/multibody/parsing_py.cc
+++ b/bindings/pydrake/multibody/parsing_py.cc
@@ -33,6 +33,8 @@ PYBIND11_MODULE(parsing, m) {
             py::arg("package_path"), cls_doc.Add.doc)
         .def("Contains", &Class::Contains, py::arg("package_name"),
             cls_doc.Contains.doc)
+        .def("Remove", &Class::Remove, py::arg("package_name"),
+            cls_doc.Remove.doc)
         .def("size", &Class::size, cls_doc.size.doc)
         .def("GetPath", &Class::GetPath, py::arg("package_name"),
             cls_doc.GetPath.doc)

--- a/bindings/pydrake/multibody/test/parsing_test.py
+++ b/bindings/pydrake/multibody/test/parsing_test.py
@@ -31,7 +31,10 @@ class TestParsing(unittest.TestCase):
         model = FindResourceOrThrow(
             "drake/examples/atlas/urdf/atlas_minimal_contact.urdf")
 
-        # Simple coverage test for Add, Contains, size, GetPath, AddPackageXml.
+        # Simple coverage test for Remove, Add, Contains, size, GetPath,
+        # AddPackageXml.
+        dut.Remove('drake')
+        self.assertEqual(dut.size(), 0)
         dut.Add(package_name="root", package_path=tmpdir)
         self.assertEqual(dut.size(), 1)
         self.assertTrue(dut.Contains(package_name="root"))

--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -50,6 +50,9 @@ drake_cc_library(
     hdrs = [
         "package_map.h",
     ],
+    data = [
+        "//:package.xml",
+    ],
     visibility = [
         "//visibility:public",
     ],

--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -380,6 +380,21 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "drake_pkg_uri_test",
+    data = [
+        ":test_models",
+    ],
+    deps = [
+        "//common:find_resource",
+        "//geometry:drake_visualizer",
+        "//geometry:scene_graph",
+        "//multibody/parsing",
+        "//systems/analysis:simulator",
+        "//systems/framework:diagram_builder",
+    ],
+)
+
+drake_cc_googletest(
     name = "detail_path_utils_test",
     data = [
         ":test_models",

--- a/multibody/parsing/package_map.cc
+++ b/multibody/parsing/package_map.cc
@@ -12,6 +12,7 @@
 #include "drake/common/drake_path.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/filesystem.h"
+#include "drake/common/find_resource.h"
 #include "drake/common/text_logging.h"
 
 namespace drake {
@@ -23,13 +24,8 @@ using tinyxml2::XMLDocument;
 using tinyxml2::XMLElement;
 
 PackageMap::PackageMap() {
-  const std::optional<string> maybe_drake_path = MaybeGetDrakePath();
-  if (!maybe_drake_path) {
-    drake::log()->warn("Could not determine Drake's path.");
-  } else {
-    Add("drake", *maybe_drake_path);
-    // drake::log()->warn("Found Drake's path: {}", *maybe_drake_path);
-  }
+  std::string drake_pkg = FindResourceOrThrow("drake/package.xml");
+  AddPackageXml(drake_pkg);
 }
 
 void PackageMap::Add(const string& package_name, const string& package_path) {

--- a/multibody/parsing/package_map.cc
+++ b/multibody/parsing/package_map.cc
@@ -22,7 +22,15 @@ using std::string;
 using tinyxml2::XMLDocument;
 using tinyxml2::XMLElement;
 
-PackageMap::PackageMap() {}
+PackageMap::PackageMap() {
+  const std::optional<string> maybe_drake_path = MaybeGetDrakePath();
+  if (!maybe_drake_path) {
+    drake::log()->warn("Could not determine Drake's path.");
+  } else {
+    Add("drake", *maybe_drake_path);
+    // drake::log()->warn("Found Drake's path: {}", *maybe_drake_path);
+  }
+}
 
 void PackageMap::Add(const string& package_name, const string& package_path) {
   DRAKE_THROW_UNLESS(map_.count(package_name) == 0);

--- a/multibody/parsing/test/drake_pkg_uri_test.cc
+++ b/multibody/parsing/test/drake_pkg_uri_test.cc
@@ -1,0 +1,92 @@
+/*
+@file
+Parses and visualizes sdf/urdf.
+
+If you wish to visualize this mesh, in its own terminal run:
+
+ $ bazel-bin/tools/drake_visualizer
+
+In a new terminal, run example to visualize model:
+
+ $ bazel run \
+   //multibody/parsing/test:drake_pkg_uri_test -- \
+   --visualize=true --visualize_sec=1
+
+*/
+
+#include <chrono>
+#include <string>
+#include <thread>
+
+#include <fmt/format.h>
+#include <gflags/gflags.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/geometry/drake_visualizer.h"
+#include "drake/geometry/scene_graph.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/systems/analysis/simulator.h"
+#include "drake/systems/framework/diagram_builder.h"
+
+DEFINE_bool(
+    visualize, false, "Publish model to Drake Visualizer.");
+DEFINE_double(
+    visualize_sec, 0., "Amount of time to pause between each model to "
+    "visualize in Drake Visualizer.");
+
+namespace drake {
+namespace multibody {
+namespace {
+
+using geometry::DrakeVisualizer;
+using geometry::SceneGraph;
+using multibody::AddMultibodyPlantSceneGraph;
+using multibody::Parser;
+using systems::DiagramBuilder;
+using systems::Simulator;
+
+class ParseTest : public testing::TestWithParam<std::string> {};
+
+TEST_P(ParseTest, ParsesSdfAndVisualizes) {
+  const std::string object_name = GetParam();
+  const std::string filename = FindResourceOrThrow(fmt::format(
+      "drake/multibody/parsing/test/drake_pkg_uri_test/{}",
+      object_name));
+
+  DiagramBuilder<double> builder;
+  auto [plant, scene_graph] = AddMultibodyPlantSceneGraph(&builder, 0.0);
+  // Record the default number of models before a new model is added.
+  const int default_num_models = plant.num_model_instances();
+
+  // Check to ensure model is parsable.
+  EXPECT_NO_THROW(Parser(&plant).AddModelFromFile(filename));
+
+  // Ensure there was exactly one model instance added for the new model.
+  EXPECT_EQ(plant.num_model_instances() - default_num_models, 1);
+
+  // Visualize via publishing, if requested.
+  if (FLAGS_visualize || FLAGS_visualize_sec > 0.0) {
+    DrakeVisualizer::AddToBuilder(&builder, scene_graph);
+    plant.Finalize();
+    auto diagram = builder.Build();
+    drake::log()->info("Visualize: {}", object_name);
+    Simulator<double> simulator(*diagram);
+    simulator.Initialize();
+    diagram->Publish(simulator.get_context());
+    if (FLAGS_visualize_sec > 0.0) {
+      drake::log()->info("Pausing for {} sec...", FLAGS_visualize_sec);
+      std::this_thread::sleep_for(
+          std::chrono::milliseconds(
+              static_cast<int>(1000 * FLAGS_visualize_sec)));
+    }
+  }
+}
+
+
+INSTANTIATE_TEST_SUITE_P(DRAKE_URI_MODEL, ParseTest,
+  testing::Values("cube_visual.sdf", "cube_visual.urdf"));
+
+}  // namespace
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/parsing/test/drake_pkg_uri_test/cube_visual.sdf
+++ b/multibody/parsing/test/drake_pkg_uri_test/cube_visual.sdf
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<sdf version="1.9">
+  <model name="cube_robot">
+    <link name="link0">
+      <visual name="cube">
+        <geometry>
+          <mesh>
+            <uri>package://drake/multibody/parsing/test/tri_cube.obj</uri>
+          </mesh>
+        </geometry>
+      </visual>
+    </link>
+    <joint name="weld_link0" type="fixed">
+      <parent>world</parent>
+      <child>link0</child>
+    </joint>
+  </model>
+</sdf>

--- a/multibody/parsing/test/drake_pkg_uri_test/cube_visual.urdf
+++ b/multibody/parsing/test/drake_pkg_uri_test/cube_visual.urdf
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<robot name="cube_robot">
+  <link name="link0">
+    <inertial>
+      <mass value="1"/>
+    </inertial>
+    <visual name="cube">
+      <geometry>
+        <mesh filename="package://drake/multibody/parsing/test/tri_cube.obj"/>
+      </geometry>
+    </visual>
+  </link>
+</robot>

--- a/multibody/parsing/test/package_map_test.cc
+++ b/multibody/parsing/test/package_map_test.cc
@@ -10,6 +10,9 @@
 using std::map;
 using std::string;
 
+// FIXME(imcmahon): add constant for expected minumum package path
+// and then use it to check for the correct PackgeMap size
+
 namespace drake {
 namespace multibody {
 namespace {
@@ -27,7 +30,7 @@ string GetTestDataRoot() {
 
 void VerifyMatch(const PackageMap& package_map,
     const map<string, string>& expected_packages) {
-  EXPECT_EQ(package_map.size(), static_cast<int>(expected_packages.size()));
+  EXPECT_EQ(package_map.size()-1, static_cast<int>(expected_packages.size()));
   for (const auto& path_entry : expected_packages) {
     const std::string& package_name = path_entry.first;
     const std::string& package_path = path_entry.second;
@@ -147,14 +150,14 @@ GTEST_TEST(PackageMapTest, TestPopulateUpstreamToDrake) {
 GTEST_TEST(PackageMapTest, TestPopulateFromEnvironment) {
   PackageMap package_map;
 
-  // Test a null environment.
+  // Test a null environment with only the Drake package.
   package_map.PopulateFromEnvironment("FOOBAR");
-  EXPECT_EQ(package_map.size(), 0);
+  EXPECT_EQ(package_map.size(), 1);
 
-  // Test an empty environment.
+  // Test an empty environment with only the Drake package.
   ::setenv("FOOBAR", "", 1);
   package_map.PopulateFromEnvironment("FOOBAR");
-  EXPECT_EQ(package_map.size(), 0);
+  EXPECT_EQ(package_map.size(), 1);
 
   // Test three environment entries, concatenated:
   // - one bad path
@@ -194,7 +197,7 @@ GTEST_TEST(PackageMapTest, TestStreamingToString) {
 
   // Verifies that there are three lines in the resulting string.
   EXPECT_EQ(std::count(resulting_string.begin(), resulting_string.end(), '\n'),
-            3);
+            4);
 }
 
 }  // namespace

--- a/multibody/parsing/test/package_map_test.cc
+++ b/multibody/parsing/test/package_map_test.cc
@@ -10,9 +10,6 @@
 using std::map;
 using std::string;
 
-// FIXME(imcmahon): add constant for expected minumum package path
-// and then use it to check for the correct PackgeMap size
-
 namespace drake {
 namespace multibody {
 namespace {
@@ -30,7 +27,7 @@ string GetTestDataRoot() {
 
 void VerifyMatch(const PackageMap& package_map,
     const map<string, string>& expected_packages) {
-  EXPECT_EQ(package_map.size()-1, static_cast<int>(expected_packages.size()));
+  EXPECT_EQ(package_map.size(), static_cast<int>(expected_packages.size()));
   for (const auto& path_entry : expected_packages) {
     const std::string& package_name = path_entry.first;
     const std::string& package_path = path_entry.second;
@@ -72,6 +69,8 @@ GTEST_TEST(PackageMapTest, TestManualPopulation) {
   };
 
   PackageMap package_map;
+  package_map.Remove("drake");
+
   for (const auto& it : expected_packages) {
     package_map.Add(it.first, it.second);
   }
@@ -98,6 +97,7 @@ GTEST_TEST(PackageMapTest, TestPopulateFromXml) {
   const string xml_dirname =
       filesystem::path(xml_filename).parent_path().string();
   PackageMap package_map;
+  package_map.Remove("drake");
   package_map.AddPackageXml(xml_filename);
 
   map<string, string> expected_packages = {
@@ -110,6 +110,7 @@ GTEST_TEST(PackageMapTest, TestPopulateFromXml) {
 GTEST_TEST(PackageMapTest, TestPopulateMapFromFolder) {
   const string root_path = GetTestDataRoot();
   PackageMap package_map;
+  package_map.Remove("drake");
   package_map.PopulateFromFolder(root_path);
   VerifyMatchWithTestDataRoot(package_map);
 }
@@ -119,6 +120,7 @@ GTEST_TEST(PackageMapTest, TestPopulateMapFromFolder) {
 GTEST_TEST(PackageMapTest, TestPopulateMapFromFolderExtraTrailingSlashes) {
   const string root_path = GetTestDataRoot();
   PackageMap package_map;
+  package_map.Remove("drake");
   package_map.PopulateFromFolder(root_path + "///////");
   VerifyMatchWithTestDataRoot(package_map);
 }
@@ -132,6 +134,7 @@ GTEST_TEST(PackageMapTest, TestPopulateUpstreamToDrake) {
       "sdf/test_model.sdf");
 
   PackageMap package_map;
+  package_map.Remove("drake");
   package_map.PopulateUpstreamToDrake(sdf_file_name);
 
   map<string, string> expected_packages = {
@@ -149,15 +152,16 @@ GTEST_TEST(PackageMapTest, TestPopulateUpstreamToDrake) {
 // Tests that PackageMap can be populated from an env var.
 GTEST_TEST(PackageMapTest, TestPopulateFromEnvironment) {
   PackageMap package_map;
+  package_map.Remove("drake");
 
-  // Test a null environment with only the Drake package.
+  // Test a null environment.
   package_map.PopulateFromEnvironment("FOOBAR");
-  EXPECT_EQ(package_map.size(), 1);
+  EXPECT_EQ(package_map.size(), 0);
 
-  // Test an empty environment with only the Drake package.
+  // Test an empty environment.
   ::setenv("FOOBAR", "", 1);
   package_map.PopulateFromEnvironment("FOOBAR");
-  EXPECT_EQ(package_map.size(), 1);
+  EXPECT_EQ(package_map.size(), 0);
 
   // Test three environment entries, concatenated:
   // - one bad path
@@ -179,6 +183,7 @@ GTEST_TEST(PackageMapTest, TestStreamingToString) {
   };
 
   PackageMap package_map;
+  package_map.Remove("drake");
   for (const auto& it : expected_packages) {
     package_map.Add(it.first, it.second);
   }
@@ -197,7 +202,7 @@ GTEST_TEST(PackageMapTest, TestStreamingToString) {
 
   // Verifies that there are three lines in the resulting string.
   EXPECT_EQ(std::count(resulting_string.begin(), resulting_string.end(), '\n'),
-            4);
+            3);
 }
 
 }  // namespace

--- a/multibody/parsing/test/parser_test.cc
+++ b/multibody/parsing/test/parser_test.cc
@@ -186,14 +186,14 @@ GTEST_TEST(FileParserTest, FindDrakePackageWhenAdding) {
       MultibodyPlant<double> plant(0.0);
       geometry::SceneGraph<double> scene_graph;
       Parser parser(&plant, &scene_graph);
-      EXPECT_EQ(parser.package_map().size(), 1);
+      const int orig_package_size = parser.package_map().size();
 
       // Because the box.sdf references an obj via a package: URI, this would
       // throw if the package were not found.
       EXPECT_NO_THROW(add_func(FindResourceOrThrow(file_name), &parser));
 
       // Now we explicitly confirm the package map has been modified.
-      EXPECT_EQ(parser.package_map().size(), 2);
+      EXPECT_EQ(parser.package_map().size(), orig_package_size+1);
       EXPECT_TRUE(parser.package_map().Contains("box_model"));
     }
   }

--- a/multibody/parsing/test/parser_test.cc
+++ b/multibody/parsing/test/parser_test.cc
@@ -186,14 +186,14 @@ GTEST_TEST(FileParserTest, FindDrakePackageWhenAdding) {
       MultibodyPlant<double> plant(0.0);
       geometry::SceneGraph<double> scene_graph;
       Parser parser(&plant, &scene_graph);
-      EXPECT_EQ(parser.package_map().size(), 0);
+      EXPECT_EQ(parser.package_map().size(), 1);
 
       // Because the box.sdf references an obj via a package: URI, this would
       // throw if the package were not found.
       EXPECT_NO_THROW(add_func(FindResourceOrThrow(file_name), &parser));
 
       // Now we explicitly confirm the package map has been modified.
-      EXPECT_EQ(parser.package_map().size(), 1);
+      EXPECT_EQ(parser.package_map().size(), 2);
       EXPECT_TRUE(parser.package_map().Contains("box_model"));
     }
   }

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,5 @@
 <package format="2">
   <name>drake</name>
-  <version>0.24.0</version>
   <description>
   Model-Based Design and Verification for Robotics.
   </description>

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,9 @@
+<package format="2">
+  <name>drake</name>
+  <version>0.24.0</version>
+  <description>
+  Model-Based Design and Verification for Robotics.
+  </description>
+  <maintainer>Drake Developers</maintainer>
+  <license>BSD-3-Clause</license>
+</package>


### PR DESCRIPTION
This is an initial proof of concept toward https://github.com/RobotLocomotion/drake/issues/10531, specifically the minimal subset of items listed in https://github.com/RobotLocomotion/drake/issues/10531#issuecomment-724324215 to prove that a drake package uri could be used in a model format to refer to a mesh.

The idea is to add a `drake/package.xml`, to allow resources inside SDFormat and URDF files to be able to resolve meshes inside of Drake. In the constructor of `PackageMap`, I prepopulated the map with the Drake package as we discussed in the issue linked above.

I started down a few different paths to ensure `Scenegraph` and `DrakeVisualizer` could resolve package URI's inside these model format files, but at least in my initial testing, it appears the functionality is already there once the Drake package is added to the `PackgeMap`. I repurposed a basic parse & visualize test to show the cube mesh could be loaded into `DrakeVisualizer`.

At this point, I'm interested in feedback on the design direction keeping in mind I intend to do cleanup on things like the unittests before turning this into a proper PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14363)
<!-- Reviewable:end -->
