### PR TITLE
[render] Deprecate ManipulationStation CameraProperties API

### DIFF
--- a/bindings/pydrake/examples/BUILD.bazel
+++ b/bindings/pydrake/examples/BUILD.bazel
@@ -62,6 +62,7 @@ drake_pybind_library(
     name = "manipulation_station_py",
     cc_deps = [
         "//bindings/pydrake:documentation_pybind",
+        "//bindings/pydrake/common:deprecation_pybind",
     ],
     cc_srcs = ["manipulation_station_py.cc"],
     package_info = PACKAGE_INFO,
@@ -174,6 +175,7 @@ drake_py_unittest(
     name = "manipulation_station_test",
     deps = [
         ":manipulation_station_py",
+        "//bindings/pydrake/common/test_utilities",
         "//bindings/pydrake/multibody:parsing_py",
         "//bindings/pydrake/multibody:plant_py",
     ],

--- a/bindings/pydrake/examples/manipulation_station_py.cc
+++ b/bindings/pydrake/examples/manipulation_station_py.cc
@@ -2,6 +2,7 @@
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 
+#include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/examples/manipulation_station/manipulation_station.h"
@@ -47,106 +48,113 @@ PYBIND11_MODULE(manipulation_station, m) {
           doc.SchunkCollisionModel.kBoxPlusFingertipSpheres.doc)
       .export_values();
 
-  py::class_<ManipulationStation<T>, Diagram<T>>(
-      m, "ManipulationStation", doc.ManipulationStation.doc)
-      .def(py::init<double>(), py::arg("time_step") = 0.002,
-          doc.ManipulationStation.ctor.doc)
-      .def("SetupManipulationClassStation",
-          &ManipulationStation<T>::SetupManipulationClassStation,
-          py::arg("collision_model") = IiwaCollisionModel::kNoCollision,
-          py::arg("schunk_model") = SchunkCollisionModel::kBox,
-          doc.ManipulationStation.SetupManipulationClassStation.doc)
-      .def("SetupClutterClearingStation",
-          &ManipulationStation<T>::SetupClutterClearingStation,
-          py::arg("X_WCameraBody") = std::nullopt,
-          py::arg("collision_model") = IiwaCollisionModel::kNoCollision,
-          py::arg("schunk_model") = SchunkCollisionModel::kBox,
-          doc.ManipulationStation.SetupClutterClearingStation.doc)
-      .def("SetupPlanarIiwaStation",
-          &ManipulationStation<T>::SetupPlanarIiwaStation,
-          py::arg("schunk_model") = SchunkCollisionModel::kBox,
-          doc.ManipulationStation.SetupPlanarIiwaStation.doc)
-      .def("AddManipulandFromFile",
-          &ManipulationStation<T>::AddManipulandFromFile, py::arg("model_file"),
-          py::arg("X_WObject"),
-          doc.ManipulationStation.AddManipulandFromFile.doc)
-      .def("RegisterIiwaControllerModel",
-          &ManipulationStation<T>::RegisterIiwaControllerModel,
-          doc.ManipulationStation.RegisterIiwaControllerModel.doc)
-      .def("RegisterRgbdSensor", &ManipulationStation<T>::RegisterRgbdSensor,
-          doc.ManipulationStation.RegisterRgbdSensor.doc)
-      .def("RegisterWsgControllerModel",
-          &ManipulationStation<T>::RegisterWsgControllerModel,
-          doc.ManipulationStation.RegisterWsgControllerModel.doc)
-      .def("Finalize", py::overload_cast<>(&ManipulationStation<T>::Finalize),
-          doc.ManipulationStation.Finalize.doc_0args)
-      .def("num_iiwa_joints", &ManipulationStation<T>::num_iiwa_joints,
-          doc.ManipulationStation.num_iiwa_joints.doc)
-      .def("get_multibody_plant", &ManipulationStation<T>::get_multibody_plant,
-          py_rvp::reference_internal,
-          doc.ManipulationStation.get_multibody_plant.doc)
-      .def("get_mutable_multibody_plant",
-          &ManipulationStation<T>::get_mutable_multibody_plant,
-          py_rvp::reference_internal,
-          doc.ManipulationStation.get_mutable_multibody_plant.doc)
-      .def("get_scene_graph", &ManipulationStation<T>::get_scene_graph,
-          py_rvp::reference_internal,
-          doc.ManipulationStation.get_scene_graph.doc)
-      .def("get_mutable_scene_graph",
-          &ManipulationStation<T>::get_mutable_scene_graph,
-          py_rvp::reference_internal,
-          doc.ManipulationStation.get_mutable_scene_graph.doc)
-      .def("get_controller_plant",
-          &ManipulationStation<T>::get_controller_plant,
-          py_rvp::reference_internal,
-          doc.ManipulationStation.get_controller_plant.doc)
-      .def("GetIiwaPosition", &ManipulationStation<T>::GetIiwaPosition,
-          doc.ManipulationStation.GetIiwaPosition.doc)
-      .def("SetIiwaPosition",
-          overload_cast_explicit<void, systems::Context<T>*,
-              const Eigen::Ref<const VectorX<T>>&>(
-              &ManipulationStation<T>::SetIiwaPosition),
-          py::arg("station_context"), py::arg("q"),
-          doc.ManipulationStation.SetIiwaPosition.doc_2args)
-      .def("GetIiwaVelocity", &ManipulationStation<T>::GetIiwaVelocity,
-          doc.ManipulationStation.GetIiwaVelocity.doc)
-      .def("SetIiwaVelocity",
-          overload_cast_explicit<void, systems::Context<T>*,
-              const Eigen::Ref<const VectorX<T>>&>(
-              &ManipulationStation<T>::SetIiwaVelocity),
-          py::arg("station_context"), py::arg("v"),
-          doc.ManipulationStation.SetIiwaVelocity.doc_2args)
-      .def("GetWsgPosition", &ManipulationStation<T>::GetWsgPosition,
-          doc.ManipulationStation.GetWsgPosition.doc)
-      .def("SetWsgPosition",
-          overload_cast_explicit<void, systems::Context<T>*, const T&>(
-              &ManipulationStation<T>::SetWsgPosition),
-          py::arg("station_context"), py::arg("q"),
-          doc.ManipulationStation.SetWsgPosition.doc_2args)
-      .def("GetWsgVelocity", &ManipulationStation<T>::GetWsgVelocity,
-          doc.ManipulationStation.GetWsgVelocity.doc)
-      .def("SetWsgVelocity",
-          overload_cast_explicit<void, systems::Context<T>*, const T&>(
-              &ManipulationStation<T>::SetWsgVelocity),
-          py::arg("station_context"), py::arg("v"),
-          doc.ManipulationStation.SetWsgVelocity.doc_2args)
-      .def("GetStaticCameraPosesInWorld",
-          &ManipulationStation<T>::GetStaticCameraPosesInWorld,
-          py_rvp::reference_internal,
-          doc.ManipulationStation.GetStaticCameraPosesInWorld.doc)
-      .def("get_camera_names", &ManipulationStation<T>::get_camera_names,
-          doc.ManipulationStation.get_camera_names.doc)
-      .def("SetWsgGains", &ManipulationStation<T>::SetWsgGains,
-          doc.ManipulationStation.SetWsgGains.doc)
-      .def("SetIiwaPositionGains",
-          &ManipulationStation<T>::SetIiwaPositionGains,
-          doc.ManipulationStation.SetIiwaPositionGains.doc)
-      .def("SetIiwaVelocityGains",
-          &ManipulationStation<T>::SetIiwaVelocityGains,
-          doc.ManipulationStation.SetIiwaVelocityGains.doc)
-      .def("SetIiwaIntegralGains",
-          &ManipulationStation<T>::SetIiwaIntegralGains,
-          doc.ManipulationStation.SetIiwaIntegralGains.doc);
+  {
+    using Class = ManipulationStation<T>;
+    const auto& cls_doc = doc.ManipulationStation;
+
+    py::class_<Class, Diagram<T>> cls(m, "ManipulationStation", cls_doc.doc);
+    cls  // BR
+        .def(py::init<double>(), py::arg("time_step") = 0.002, cls_doc.ctor.doc)
+        .def("SetupManipulationClassStation",
+            &Class::SetupManipulationClassStation,
+            py::arg("collision_model") = IiwaCollisionModel::kNoCollision,
+            py::arg("schunk_model") = SchunkCollisionModel::kBox,
+            cls_doc.SetupManipulationClassStation.doc)
+        .def("SetupClutterClearingStation", &Class::SetupClutterClearingStation,
+            py::arg("X_WCameraBody") = std::nullopt,
+            py::arg("collision_model") = IiwaCollisionModel::kNoCollision,
+            py::arg("schunk_model") = SchunkCollisionModel::kBox,
+            cls_doc.SetupClutterClearingStation.doc)
+        .def("SetupPlanarIiwaStation", &Class::SetupPlanarIiwaStation,
+            py::arg("schunk_model") = SchunkCollisionModel::kBox,
+            cls_doc.SetupPlanarIiwaStation.doc)
+        .def("AddManipulandFromFile", &Class::AddManipulandFromFile,
+            py::arg("model_file"), py::arg("X_WObject"),
+            cls_doc.AddManipulandFromFile.doc)
+        .def("RegisterIiwaControllerModel", &Class::RegisterIiwaControllerModel,
+            cls_doc.RegisterIiwaControllerModel.doc);
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls.def("RegisterRgbdSensor",
+        WrapDeprecated(cls_doc.RegisterRgbdSensor.doc_single_properties,
+            py::overload_cast<const std::string&, const multibody::Frame<T>&,
+                const math::RigidTransform<double>&,
+                const geometry::render::DepthCameraProperties&>(
+                &Class::RegisterRgbdSensor)),
+        cls_doc.RegisterRgbdSensor.doc_single_properties);
+#pragma GCC diagnostic pop
+
+    cls  // BR
+        .def("RegisterRgbdSensor",
+            py::overload_cast<const std::string&, const multibody::Frame<T>&,
+                const math::RigidTransform<double>&,
+                const geometry::render::DepthRenderCamera&>(
+                &Class::RegisterRgbdSensor),
+            cls_doc.RegisterRgbdSensor.doc_single_camera)
+        .def("RegisterRgbdSensor",
+            py::overload_cast<const std::string&, const multibody::Frame<T>&,
+                const math::RigidTransform<double>&,
+                const geometry::render::ColorRenderCamera&,
+                const geometry::render::DepthRenderCamera&>(
+                &Class::RegisterRgbdSensor),
+            cls_doc.RegisterRgbdSensor.doc_dual_camera)
+        .def("RegisterWsgControllerModel", &Class::RegisterWsgControllerModel,
+            cls_doc.RegisterWsgControllerModel.doc)
+        .def("Finalize", py::overload_cast<>(&Class::Finalize),
+            cls_doc.Finalize.doc_0args)
+        .def("num_iiwa_joints", &Class::num_iiwa_joints,
+            cls_doc.num_iiwa_joints.doc)
+        .def("get_multibody_plant", &Class::get_multibody_plant,
+            py_rvp::reference_internal, cls_doc.get_multibody_plant.doc)
+        .def("get_mutable_multibody_plant", &Class::get_mutable_multibody_plant,
+            py_rvp::reference_internal, cls_doc.get_mutable_multibody_plant.doc)
+        .def("get_scene_graph", &Class::get_scene_graph,
+            py_rvp::reference_internal, cls_doc.get_scene_graph.doc)
+        .def("get_mutable_scene_graph", &Class::get_mutable_scene_graph,
+            py_rvp::reference_internal, cls_doc.get_mutable_scene_graph.doc)
+        .def("get_controller_plant", &Class::get_controller_plant,
+            py_rvp::reference_internal, cls_doc.get_controller_plant.doc)
+        .def("GetIiwaPosition", &Class::GetIiwaPosition,
+            cls_doc.GetIiwaPosition.doc)
+        .def("SetIiwaPosition",
+            overload_cast_explicit<void, systems::Context<T>*,
+                const Eigen::Ref<const VectorX<T>>&>(&Class::SetIiwaPosition),
+            py::arg("station_context"), py::arg("q"),
+            cls_doc.SetIiwaPosition.doc_2args)
+        .def("GetIiwaVelocity", &Class::GetIiwaVelocity,
+            cls_doc.GetIiwaVelocity.doc)
+        .def("SetIiwaVelocity",
+            overload_cast_explicit<void, systems::Context<T>*,
+                const Eigen::Ref<const VectorX<T>>&>(&Class::SetIiwaVelocity),
+            py::arg("station_context"), py::arg("v"),
+            cls_doc.SetIiwaVelocity.doc_2args)
+        .def("GetWsgPosition", &Class::GetWsgPosition,
+            cls_doc.GetWsgPosition.doc)
+        .def("SetWsgPosition",
+            overload_cast_explicit<void, systems::Context<T>*, const T&>(
+                &Class::SetWsgPosition),
+            py::arg("station_context"), py::arg("q"),
+            cls_doc.SetWsgPosition.doc_2args)
+        .def("GetWsgVelocity", &Class::GetWsgVelocity,
+            cls_doc.GetWsgVelocity.doc)
+        .def("SetWsgVelocity",
+            overload_cast_explicit<void, systems::Context<T>*, const T&>(
+                &Class::SetWsgVelocity),
+            py::arg("station_context"), py::arg("v"),
+            cls_doc.SetWsgVelocity.doc_2args)
+        .def("GetStaticCameraPosesInWorld", &Class::GetStaticCameraPosesInWorld,
+            py_rvp::reference_internal, cls_doc.GetStaticCameraPosesInWorld.doc)
+        .def("get_camera_names", &Class::get_camera_names,
+            cls_doc.get_camera_names.doc)
+        .def("SetWsgGains", &Class::SetWsgGains, cls_doc.SetWsgGains.doc)
+        .def("SetIiwaPositionGains", &Class::SetIiwaPositionGains,
+            cls_doc.SetIiwaPositionGains.doc)
+        .def("SetIiwaVelocityGains", &Class::SetIiwaVelocityGains,
+            cls_doc.SetIiwaVelocityGains.doc)
+        .def("SetIiwaIntegralGains", &Class::SetIiwaIntegralGains,
+            cls_doc.SetIiwaIntegralGains.doc);
+  }
 
   py::class_<ManipulationStationHardwareInterface, Diagram<double>>(m,
       "ManipulationStationHardwareInterface",

--- a/bindings/pydrake/examples/test/manipulation_station_test.py
+++ b/bindings/pydrake/examples/test/manipulation_station_test.py
@@ -2,6 +2,7 @@ import unittest
 import numpy as np
 
 from pydrake.common import FindResourceOrThrow
+from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 from pydrake.examples.manipulation_station import (
     CreateClutterClearingYcbObjectList,
     CreateManipulationClassYcbObjectList,
@@ -9,10 +10,19 @@ from pydrake.examples.manipulation_station import (
     ManipulationStation,
     ManipulationStationHardwareInterface
 )
+from pydrake.geometry.render import (
+    ClippingRange,
+    ColorRenderCamera,
+    DepthCameraProperties,
+    DepthRange,
+    DepthRenderCamera,
+    RenderCameraCore,
+)
 from pydrake.math import RigidTransform, RollPitchYaw
 from pydrake.multibody.plant import MultibodyPlant
 from pydrake.multibody.tree import ModelInstanceIndex
 from pydrake.multibody.parsing import Parser
+from pydrake.systems.sensors import CameraInfo
 
 
 class TestManipulationStation(unittest.TestCase):
@@ -167,3 +177,41 @@ class TestManipulationStation(unittest.TestCase):
 
         ycb_objects = CreateManipulationClassYcbObjectList()
         self.assertEqual(len(ycb_objects), 5)
+
+    def test_rgbd_sensor_registration(self):
+        X_PC = RigidTransform(p=[1, 2, 3])
+        station = ManipulationStation(time_step=0.001)
+        station.SetupManipulationClassStation()
+        plant = station.get_multibody_plant()
+        color_camera = ColorRenderCamera(
+            RenderCameraCore("renderer", CameraInfo(10, 10, np.pi/4),
+                             ClippingRange(0.1, 10.0), RigidTransform()),
+            False)
+        depth_camera = DepthRenderCamera(color_camera.core(),
+                                         DepthRange(0.1, 9.5))
+        station.RegisterRgbdSensor("single_sensor", plant.world_frame(), X_PC,
+                                   depth_camera)
+        station.RegisterRgbdSensor("dual_sensor", plant.world_frame(), X_PC,
+                                   color_camera, depth_camera)
+        station.Finalize()
+        camera_poses = station.GetStaticCameraPosesInWorld()
+        # The three default cameras plus the two just added.
+        self.assertEqual(len(camera_poses), 5)
+        self.assertTrue("single_sensor" in camera_poses)
+        self.assertTrue("dual_sensor" in camera_poses)
+
+    def test_rgbd_sensor_registration_deprecated(self):
+        X_PC = RigidTransform(p=[1, 2, 3])
+        station = ManipulationStation(time_step=0.001)
+        station.SetupManipulationClassStation()
+        plant = station.get_multibody_plant()
+        properties = DepthCameraProperties(10, 10, np.pi / 4, "renderer",
+                                           0.01, 5.0)
+        with catch_drake_warnings(expected_count=1):
+            station.RegisterRgbdSensor("deprecated", plant.world_frame(), X_PC,
+                                       properties)
+        station.Finalize()
+        camera_poses = station.GetStaticCameraPosesInWorld()
+        # The three default cameras plus the one just added.
+        self.assertEqual(len(camera_poses), 4)
+        self.assertTrue("deprecated" in camera_poses)

--- a/examples/manipulation_station/test/manipulation_station_test.cc
+++ b/examples/manipulation_station/test/manipulation_station_test.cc
@@ -360,6 +360,39 @@ GTEST_TEST(ManipulationStationTest, RegisterRgbdCameraTest) {
     multibody::MultibodyPlant<double>& plant =
         dut.get_mutable_multibody_plant();
 
+    geometry::render::DepthRenderCamera depth_camera{
+        {dut.default_renderer_name(), {640, 480, M_PI_4}, {0.05, 3.0}, {}},
+        {0.1, 2.0}};
+
+    const Eigen::Translation3d X_WF0(0, 0, 0.2);
+    const Eigen::Translation3d X_F0C0(0.3, 0.2, 0.0);
+    const auto& frame0 =
+        plant.AddFrame(std::make_unique<multibody::FixedOffsetFrame<double>>(
+            "frame0", plant.world_frame(), X_WF0));
+    dut.RegisterRgbdSensor("camera0", frame0, X_F0C0, depth_camera);
+
+    const Eigen::Translation3d X_F0F1(0, -0.1, 0.2);
+    const Eigen::Translation3d X_F1C1(-0.2, 0.2, 0.33);
+    const auto& frame1 =
+        plant.AddFrame(std::make_unique<multibody::FixedOffsetFrame<double>>(
+            "frame1", frame0, X_F0F1));
+    dut.RegisterRgbdSensor("camera1", frame1, X_F1C1, depth_camera);
+
+    std::map<std::string, math::RigidTransform<double>> camera_poses =
+        dut.GetStaticCameraPosesInWorld();
+
+    EXPECT_EQ(camera_poses.size(), 2);
+    EXPECT_TRUE(camera_poses.at("camera0").IsExactlyEqualTo(X_WF0 * X_F0C0));
+    EXPECT_TRUE(
+        camera_poses.at("camera1").IsExactlyEqualTo(X_WF0 * X_F0F1 * X_F1C1));
+  }
+
+  {
+    // Repeat the above test for the deprecated API.
+    ManipulationStation<double> dut;
+    multibody::MultibodyPlant<double>& plant =
+        dut.get_mutable_multibody_plant();
+
     geometry::render::DepthCameraProperties camera_properties(
         640, 480, M_PI_4, dut.default_renderer_name(), 0.1, 2.0);
 
@@ -368,6 +401,8 @@ GTEST_TEST(ManipulationStationTest, RegisterRgbdCameraTest) {
     const auto& frame0 =
         plant.AddFrame(std::make_unique<multibody::FixedOffsetFrame<double>>(
             "frame0", plant.world_frame(), X_WF0));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     dut.RegisterRgbdSensor("camera0", frame0, X_F0C0, camera_properties);
 
     const Eigen::Translation3d X_F0F1(0, -0.1, 0.2);
@@ -376,6 +411,7 @@ GTEST_TEST(ManipulationStationTest, RegisterRgbdCameraTest) {
         plant.AddFrame(std::make_unique<multibody::FixedOffsetFrame<double>>(
             "frame1", frame0, X_F0F1));
     dut.RegisterRgbdSensor("camera1", frame1, X_F1C1, camera_properties);
+#pragma GCC diagnostic pop
 
     std::map<std::string, math::RigidTransform<double>> camera_poses =
         dut.GetStaticCameraPosesInWorld();


### PR DESCRIPTION
  - Deprecate the old RegisterRgbdSensor (update tests)
  - Add RegisterRgbdSensor that is compatible with RenderCamera.
    - add tests.
  - Refactor the default D415 camera (and actually *include* the full, documented intrinsics, differentiating between color and depth).
  - Update bindings
    - use the Class, cls_doc style to make it more compact
    - bind new methods, deprecate old.
    - update tests

Towards resolving checklist in #11880.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14375)
<!-- Reviewable:end -->
