### PR TITLE
[render] Deprecate CameraProperties and DepthCameraProperties

### DIFF
--- a/bindings/pydrake/examples/test/manipulation_station_test.py
+++ b/bindings/pydrake/examples/test/manipulation_station_test.py
@@ -205,9 +205,9 @@ class TestManipulationStation(unittest.TestCase):
         station = ManipulationStation(time_step=0.001)
         station.SetupManipulationClassStation()
         plant = station.get_multibody_plant()
-        properties = DepthCameraProperties(10, 10, np.pi / 4, "renderer",
-                                           0.01, 5.0)
-        with catch_drake_warnings(expected_count=1):
+        with catch_drake_warnings(expected_count=2):
+            properties = DepthCameraProperties(10, 10, np.pi / 4, "renderer",
+                                               0.01, 5.0)
             station.RegisterRgbdSensor("deprecated", plant.world_frame(), X_PC,
                                        properties)
         station.Finalize()

--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -141,6 +141,8 @@ class PyRenderEngine : public py::wrapper<RenderEngine> {
   }
 
  private:
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   // TODO(SeanCurtis-TRI) We will be removing the Render*Image API when we
   // deprecate CameraProperties. They must be implemented in order to build
   // this class; so we'll make sure they clearly signal if they get invoked.
@@ -164,6 +166,7 @@ class PyRenderEngine : public py::wrapper<RenderEngine> {
         "Python should not be able to invoke RenderLabelImage with "
         "CameraProperties");
   }
+#pragma GCC diagnostic pop
 };
 
 void def_geometry_render(py::module m) {
@@ -244,14 +247,18 @@ void def_geometry_render(py::module m) {
     DefCopyAndDeepCopy(&cls);
   }
 
-  // TODO(eric.cousineau): Deprecate these.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   {
     using Class = CameraProperties;
-    py::class_<Class> cls(m, "CameraProperties", doc.CameraProperties.doc);
+    py::class_<Class> cls(
+        m, "CameraProperties", doc.CameraProperties.doc_deprecated);
     cls  // BR
-        .def(py::init<int, int, double, std::string>(), py::arg("width"),
-            py::arg("height"), py::arg("fov_y"), py::arg("renderer_name"),
-            doc.CameraProperties.ctor.doc)
+        .def(py_init_deprecated<Class, int, int, double, std::string>(
+                 "Deprecated; due to be removed after 2021-03-01. Please use "
+                 "ColorRenderCamera instead"),
+            py::arg("width"), py::arg("height"), py::arg("fov_y"),
+            py::arg("renderer_name"), doc.CameraProperties.ctor.doc)
         .def_readwrite("width", &Class::width, doc.CameraProperties.width.doc)
         .def_readwrite(
             "height", &Class::height, doc.CameraProperties.height.doc)
@@ -264,9 +271,12 @@ void def_geometry_render(py::module m) {
   {
     using Class = DepthCameraProperties;
     py::class_<Class, CameraProperties> cls(
-        m, "DepthCameraProperties", doc.DepthCameraProperties.doc);
+        m, "DepthCameraProperties", doc.DepthCameraProperties.doc_deprecated);
     cls  // BR
-        .def(py::init<int, int, double, std::string, double, double>(),
+        .def(py_init_deprecated<Class, int, int, double, std::string, double,
+                 double>(
+                 "Deprecated; due to be removed after 2021-03-01. Please use "
+                 "DepthRenderCamera instead"),
             py::arg("width"), py::arg("height"), py::arg("fov_y"),
             py::arg("renderer_name"), py::arg("z_near"), py::arg("z_far"),
             doc.DepthCameraProperties.ctor.doc)
@@ -276,6 +286,7 @@ void def_geometry_render(py::module m) {
             "z_far", &Class::z_far, doc.DepthCameraProperties.z_far.doc);
     DefCopyAndDeepCopy(&cls);
   }
+#pragma GCC diagnostic pop
 
   {
     using Class = RenderEngine;

--- a/bindings/pydrake/systems/test/sensors_test.py
+++ b/bindings/pydrake/systems/test/sensors_test.py
@@ -273,7 +273,7 @@ class TestSensors(unittest.TestCase):
 
         def construct_deprecated(parent_id, X_PB):
             # One deprecation warning for CameraPoses and one for RgbdSensor.
-            with catch_drake_warnings(expected_count=2):
+            with catch_drake_warnings(expected_count=4):
                 color_properties = CameraProperties(
                     width=width, height=height, fov_y=np.pi/6,
                     renderer_name="renderer")
@@ -303,7 +303,7 @@ class TestSensors(unittest.TestCase):
                                   depth_camera=depth_camera)
 
         def construct_single_deprecated(parent_id, X_PB):
-            with catch_drake_warnings(expected_count=2):
+            with catch_drake_warnings(expected_count=3):
                 depth_properties = DepthCameraProperties(
                         width=width, height=height, fov_y=np.pi/6,
                         renderer_name="renderer", z_near=0.1, z_far=5.5)

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -599,11 +599,11 @@ class TestGeometry(unittest.TestCase):
         self.assertEqual(params.default_label, label)
         self.assertTrue((params.default_diffuse == diffuse).all())
 
-    def test_render_depth_camera_properties(self):
-        obj = mut.render.DepthCameraProperties(width=320, height=240,
-                                               fov_y=pi/6,
-                                               renderer_name="test_renderer",
-                                               z_near=0.1, z_far=5.0)
+    def test_render_depth_camera_properties_deprecated(self):
+        with catch_drake_warnings(expected_count=1):
+            obj = mut.render.DepthCameraProperties(
+                width=320, height=240, fov_y=pi/6,
+                renderer_name="test_renderer", z_near=0.1, z_far=5.0)
         self.assertEqual(obj.width, 320)
         self.assertEqual(obj.height, 240)
         self.assertEqual(obj.fov_y, pi/6)
@@ -737,7 +737,9 @@ class TestGeometry(unittest.TestCase):
             X_PC=RigidTransform())
         self.assertIsInstance(image, ImageLabel16I)
 
-        with catch_drake_warnings(expected_count=3):
+        with catch_drake_warnings(expected_count=4):
+            # One deprecation warning for constructing DepthCameraProperties
+            # and one for each invocation of Render*Image.
             depth_camera = mut.render.DepthCameraProperties(
                 width=320, height=240, fov_y=pi/6, renderer_name=renderer_name,
                 z_near=0.1, z_far=5.0)
@@ -983,7 +985,10 @@ class TestGeometry(unittest.TestCase):
         self.assertEqual(current_engine.label_count, 1)
 
         # Confirm that the CameraProperties APIs are *not* available.
-        cam = mut.render.CameraProperties(10, 10, np.pi / 4, "")
+        with catch_drake_warnings(expected_count=2):
+            cam = mut.render.CameraProperties(10, 10, np.pi / 4, "")
+            depth_cam = mut.render.DepthCameraProperties(10, 10, np.pi / 4, "",
+                                                         0.1, 5)
         with self.assertRaises(TypeError):
             engine.RenderColorImage(
                 cam, True, ImageRgba8U(cam.width, cam.height))
@@ -991,8 +996,6 @@ class TestGeometry(unittest.TestCase):
             engine.RenderLabelImage(
                 cam, True, ImageLabel16I(cam.width, cam.height))
 
-        depth_cam = mut.render.DepthCameraProperties(10, 10, np.pi / 4, "",
-                                                     0.1, 5)
         with self.assertRaises(TypeError):
             engine.RenderDepthImage(
                 depth_cam, True,

--- a/examples/manipulation_station/test/manipulation_station_test.cc
+++ b/examples/manipulation_station/test/manipulation_station_test.cc
@@ -393,6 +393,8 @@ GTEST_TEST(ManipulationStationTest, RegisterRgbdCameraTest) {
     multibody::MultibodyPlant<double>& plant =
         dut.get_mutable_multibody_plant();
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     geometry::render::DepthCameraProperties camera_properties(
         640, 480, M_PI_4, dut.default_renderer_name(), 0.1, 2.0);
 
@@ -401,8 +403,6 @@ GTEST_TEST(ManipulationStationTest, RegisterRgbdCameraTest) {
     const auto& frame0 =
         plant.AddFrame(std::make_unique<multibody::FixedOffsetFrame<double>>(
             "frame0", plant.world_frame(), X_WF0));
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     dut.RegisterRgbdSensor("camera0", frame0, X_F0C0, camera_properties);
 
     const Eigen::Translation3d X_F0F1(0, -0.1, 0.2);

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -991,6 +991,8 @@ std::vector<std::string> GeometryState<T>::RegisteredRendererNames() const {
   return names;
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 template <typename T>
 void GeometryState<T>::RenderColorImage(const render::CameraProperties& camera,
                                         FrameId parent_frame,
@@ -1003,10 +1005,7 @@ void GeometryState<T>::RenderColorImage(const render::CameraProperties& camera,
   // TODO(SeanCurtis-TRI): Invoke UpdateViewpoint() as part of a calc cache
   //  entry. Challenge: how to do that with a parameter passed here?
   const_cast<render::RenderEngine&>(engine).UpdateViewpoint(X_WC);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   engine.RenderColorImage(camera, show_window, color_image_out);
-#pragma GCC diagnostic pop
 }
 
 template <typename T>
@@ -1018,10 +1017,7 @@ void GeometryState<T>::RenderDepthImage(
       GetRenderEngineOrThrow(camera.renderer_name);
   // See note in RenderColorImage() about this const cast.
   const_cast<render::RenderEngine&>(engine).UpdateViewpoint(X_WC);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   engine.RenderDepthImage(camera, depth_image_out);
-#pragma GCC diagnostic pop
 }
 
 template <typename T>
@@ -1035,11 +1031,9 @@ void GeometryState<T>::RenderLabelImage(const render::CameraProperties& camera,
       GetRenderEngineOrThrow(camera.renderer_name);
   // See note in RenderColorImage() about this const cast.
   const_cast<render::RenderEngine&>(engine).UpdateViewpoint(X_WC);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   engine.RenderLabelImage(camera, show_window, label_image_out);
-#pragma GCC diagnostic pop
 }
+#pragma GCC diagnostic pop
 
 template <typename T>
 void GeometryState<T>::RenderColorImage(const ColorRenderCamera& camera,

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -498,6 +498,8 @@ class GeometryState {
   /** Implementation of SceneGraph::RegisteredRendererNames().  */
   std::vector<std::string> RegisteredRendererNames() const;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   /** Implementation of QueryObject::RenderColorImage().
    @pre All poses have already been updated.  */
   DRAKE_DEPRECATED("2021-03-01",
@@ -526,6 +528,8 @@ class GeometryState {
                         FrameId parent_frame, const math::RigidTransformd& X_PC,
                         bool show_window,
                         systems::sensors::ImageLabel16I* label_image_out) const;
+
+#pragma GCC diagnostic pop
 
   /** Implementation of QueryObject::RenderColorImage().
    @pre All poses have already been updated.  */

--- a/geometry/query_object.cc
+++ b/geometry/query_object.cc
@@ -190,6 +190,8 @@ QueryObject<T>::ComputeSignedDistanceToPoint(
   return state.ComputeSignedDistanceToPoint(p_WQ, threshold);
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 template <typename T>
 void QueryObject<T>::RenderColorImage(const CameraProperties& camera,
                                       FrameId parent_frame,
@@ -200,12 +202,10 @@ void QueryObject<T>::RenderColorImage(const CameraProperties& camera,
 
   FullPoseUpdate();
   const GeometryState<T>& state = geometry_state();
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   return state.RenderColorImage(camera, parent_frame, X_PC, show_window,
                                 color_image_out);
-#pragma GCC diagnostic pop
 }
+#pragma GCC diagnostic pop
 
 template <typename T>
 void QueryObject<T>::RenderColorImage(const ColorRenderCamera& camera,
@@ -219,6 +219,8 @@ void QueryObject<T>::RenderColorImage(const ColorRenderCamera& camera,
   return state.RenderColorImage(camera, parent_frame, X_PC, color_image_out);
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 template <typename T>
 void QueryObject<T>::RenderDepthImage(const DepthCameraProperties& camera,
                                       FrameId parent_frame,
@@ -228,11 +230,9 @@ void QueryObject<T>::RenderDepthImage(const DepthCameraProperties& camera,
 
   FullPoseUpdate();
   const GeometryState<T>& state = geometry_state();
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   return state.RenderDepthImage(camera, parent_frame, X_PC, depth_image_out);
-#pragma GCC diagnostic pop
 }
+#pragma GCC diagnostic pop
 
 template <typename T>
 void QueryObject<T>::RenderDepthImage(const DepthRenderCamera& camera,
@@ -246,6 +246,8 @@ void QueryObject<T>::RenderDepthImage(const DepthRenderCamera& camera,
   return state.RenderDepthImage(camera, parent_frame, X_PC, depth_image_out);
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 template <typename T>
 void QueryObject<T>::RenderLabelImage(const CameraProperties& camera,
                                       FrameId parent_frame,
@@ -256,12 +258,10 @@ void QueryObject<T>::RenderLabelImage(const CameraProperties& camera,
 
   FullPoseUpdate();
   const GeometryState<T>& state = geometry_state();
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   return state.RenderLabelImage(camera, parent_frame, X_PC, show_window,
                                 label_image_out);
-#pragma GCC diagnostic pop
 }
+#pragma GCC diagnostic pop
 
 template <typename T>
 void QueryObject<T>::RenderLabelImage(const ColorRenderCamera& camera,

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -484,6 +484,8 @@ class QueryObject {
    */
   //@{
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   /** Renders an RGB image for the given `camera` posed with respect to the
    indicated parent frame P.
 
@@ -500,6 +502,7 @@ class QueryObject {
                         const math::RigidTransformd& X_PC,
                         bool show_window,
                         systems::sensors::ImageRgba8U* color_image_out) const;
+#pragma GCC diagnostic pop
 
   /** Renders an RGB image for the given `camera` posed with respect to the
    indicated parent frame P.
@@ -512,6 +515,8 @@ class QueryObject {
                         FrameId parent_frame, const math::RigidTransformd& X_PC,
                         systems::sensors::ImageRgba8U* color_image_out) const;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   /** Renders a depth image for the given `camera` posed with respect to the
    indicated parent frame P.
 
@@ -530,6 +535,7 @@ class QueryObject {
                         FrameId parent_frame,
                         const math::RigidTransformd& X_PC,
                         systems::sensors::ImageDepth32F* depth_image_out) const;
+#pragma GCC diagnostic pop
 
   /** Renders a depth image for the given `camera` posed with respect to the
    indicated parent frame P.
@@ -546,6 +552,8 @@ class QueryObject {
                         FrameId parent_frame, const math::RigidTransformd& X_PC,
                         systems::sensors::ImageDepth32F* depth_image_out) const;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   /** Renders a label image for the given `camera` posed with respect to the
    indicated parent frame P.
 
@@ -562,6 +570,7 @@ class QueryObject {
                         const math::RigidTransformd& X_PC,
                         bool show_window,
                         systems::sensors::ImageLabel16I* label_image_out) const;
+#pragma GCC diagnostic pop
 
   /** Renders a label image for the given `camera` posed with respect to the
    indicated parent frame P.

--- a/geometry/render/camera_properties.h
+++ b/geometry/render/camera_properties.h
@@ -4,6 +4,8 @@
 #include <string>
 #include <utility>
 
+#include "drake/common/drake_deprecated.h"
+
 namespace drake {
 namespace geometry {
 namespace render {
@@ -23,7 +25,9 @@ namespace render {
 
  The focal length is inferred by the sensor format (width and height) and the
  field of view along the y-axis. */
-struct CameraProperties {
+struct DRAKE_DEPRECATED("2021-03-01",
+                        "CameraProperties are being deprecated. Please use "
+                        "ColorRenderCamera.") CameraProperties {
   CameraProperties(int width_in, int height_in, double fov_y_in,
                    std::string renderer_name_in)
       : width(width_in),
@@ -41,7 +45,10 @@ struct CameraProperties {
  intrinsic properties of the render camera but extended with additional
  depth-specific parameters.
  @see CameraProperties */
-struct DepthCameraProperties : public CameraProperties {
+struct DRAKE_DEPRECATED("2021-03-01",
+                        "DepthCameraProperties are being deprecated. Please "
+                        "use DepthRenderCamera.")
+DepthCameraProperties : public CameraProperties {
   DepthCameraProperties(int width_in, int height_in, double fov_y_in,
                         std::string renderer_name_in, double z_near_in,
                         double z_far_in)

--- a/geometry/render/render_camera.cc
+++ b/geometry/render/render_camera.cc
@@ -20,12 +20,15 @@ ClippingRange::ClippingRange(double near, double far) : near_(near), far_(far) {
   }
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 RenderCameraCore::RenderCameraCore(const CameraProperties& camera,
                                    double clipping_far, RigidTransformd X_BS)
     : RenderCameraCore(camera.renderer_name,
                        CameraInfo{camera.width, camera.height, camera.fov_y},
                        ClippingRange{kClippingNear, clipping_far},
                        std::move(X_BS)) {}
+#pragma GCC diagnostic pop
 
 Eigen::Matrix4d RenderCameraCore::CalcProjectionMatrix() const {
   /* Given the camera properties we compute the projection matrix as follows:

--- a/geometry/render/render_camera.h
+++ b/geometry/render/render_camera.h
@@ -44,11 +44,14 @@ class RenderCameraCore {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(RenderCameraCore);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   /** (Advanced) Constructs a %RenderCameraCore from the old, symmetric camera
    representation. This constructor should only be used internally; it serves
    as a stop gap measure until CameraProperties is fully deprecated.  */
   RenderCameraCore(const CameraProperties& camera, double clipping_far,
                    math::RigidTransformd X_BS = {});
+#pragma GCC diagnostic pop
 
   /** Fully-specified constructor. See the documentation on the member getter
    methods for documentation of parameters.  */
@@ -107,6 +110,8 @@ class ColorRenderCamera {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ColorRenderCamera);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   /** Constructs a %ColorRenderCamera from the old, symmetric camera
    representation. This constructor should only be used internally; it serves
    as a stop gap measure until CameraProperties is fully deprecated.  */
@@ -116,6 +121,7 @@ class ColorRenderCamera {
       : ColorRenderCamera(
             RenderCameraCore(camera, kClippingFar, std::move(X_BC)),
             show_window) {}
+#pragma GCC diagnostic pop
 
   /** Fully-specified constructor. See the documentation on the member getter
    methods for documentation of parameters.  */
@@ -176,6 +182,8 @@ class DepthRenderCamera {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DepthRenderCamera);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   /** Constructs a %DepthRenderCamera from the old, symmetric camera
    representation. This constructor should only be used internally; it serves
    as a stop gap measure until CameraProperties is fully deprecated.  */
@@ -184,6 +192,7 @@ class DepthRenderCamera {
       : DepthRenderCamera(
             RenderCameraCore(camera, camera.z_far * 1.1, std::move(X_BD)),
             DepthRange(camera.z_near, camera.z_far)) {}
+#pragma GCC diagnostic pop
 
   /** Fully-specified constructor. See the documentation on the member getter
    methods for documentation of parameters.

--- a/geometry/render/render_engine.cc
+++ b/geometry/render/render_engine.cc
@@ -104,11 +104,11 @@ void RenderEngine::DoRenderColorImage(const ColorRenderCamera& camera,
       NiceTypeName::Get(*this));
 
   const CameraInfo& intrinsics = camera.core().intrinsics();
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   CameraProperties simple_props{intrinsics.width(), intrinsics.height(),
                                 intrinsics.fov_y(),
                                 camera.core().renderer_name()};
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   RenderColorImage(simple_props, camera.show_window(), color_image_out);
 #pragma GCC diagnostic pop
 }
@@ -132,14 +132,14 @@ void RenderEngine::DoRenderDepthImage(const DepthRenderCamera& camera,
       NiceTypeName::Get(*this));
 
   const CameraInfo& intrinsics = camera.core().intrinsics();
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   DepthCameraProperties simple_props{intrinsics.width(),
                                      intrinsics.height(),
                                      intrinsics.fov_y(),
                                      camera.core().renderer_name(),
                                      camera.depth_range().min_depth(),
                                      camera.depth_range().max_depth()};
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   RenderDepthImage(simple_props, depth_image_out);
 #pragma GCC diagnostic pop
 }
@@ -163,11 +163,11 @@ void RenderEngine::DoRenderLabelImage(const ColorRenderCamera& camera,
       NiceTypeName::Get(*this));
 
   const CameraInfo& intrinsics = camera.core().intrinsics();
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   CameraProperties simple_props{intrinsics.width(), intrinsics.height(),
                                 intrinsics.fov_y(),
                                 camera.core().renderer_name()};
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   RenderLabelImage(simple_props, camera.show_window(), label_image_out);
 #pragma GCC diagnostic pop
 }

--- a/geometry/render/render_engine.h
+++ b/geometry/render/render_engine.h
@@ -224,8 +224,8 @@ class RenderEngine : public ShapeReifier {
    */
   //@{
 
-  // TODO(SeanCurtis-TRI): Deprecate these (Depth)CameraProperties variants
-  //  of the render functions.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   /** Renders the registered geometry into the given color (rgb) image based on
    a simplified camera model.
 
@@ -283,6 +283,7 @@ class RenderEngine : public ShapeReifier {
     DoRenderLabelImage(cam, label_image_out);
   }
 
+#pragma GCC diagnostic pop
   //@}
 
   /** @name Rendering using fully-specified camera models

--- a/geometry/render/test/render_camera_test.cc
+++ b/geometry/render/test/render_camera_test.cc
@@ -56,33 +56,6 @@ GTEST_TEST(RenderCameraCoreTest, Constructor) {
                               X_BS.GetAsMatrix4()));
 }
 
-/* Test the converstion constructor. This will be removed when CameraProperties
- is removed.  */
-GTEST_TEST(RenderCameraCoreTest, CameraPropertiesConversion) {
-  const CameraProperties props{640, 480, M_PI / 3, "some_name"};
-  const RigidTransformd X_BS(Vector3d{1, 2, 3});
-  for (const double clipping_far : {15.0, 22.5}) {
-    const CameraInfo expected_intrinsics(props.width, props.height,
-                                         props.fov_y);
-    const RenderCameraCore cam{props, clipping_far, X_BS};
-    EXPECT_EQ(cam.intrinsics().width(), expected_intrinsics.width());
-    EXPECT_EQ(cam.intrinsics().height(), expected_intrinsics.height());
-    EXPECT_EQ(cam.intrinsics().fov_y(), expected_intrinsics.fov_y());
-    EXPECT_EQ(cam.intrinsics().fov_x(), expected_intrinsics.fov_x());
-    EXPECT_EQ(cam.intrinsics().center_x(), expected_intrinsics.center_x());
-    EXPECT_EQ(cam.intrinsics().center_y(), expected_intrinsics.center_y());
-    EXPECT_EQ(cam.renderer_name(), props.renderer_name);
-    EXPECT_EQ(cam.clipping().far(), clipping_far);
-    // We're not putting a strict value on the near clipping plane; just that
-    // it's strictly positive and less than the far value.
-    EXPECT_GT(cam.clipping().near(), 0);
-    EXPECT_LT(cam.clipping().near(), cam.clipping().far());
-    EXPECT_TRUE(
-        CompareMatrices(cam.sensor_pose_in_camera_body().GetAsMatrix34(),
-                        X_BS.GetAsMatrix34()));
-  }
-}
-
 /* Confirm that the correct projection matrix is created. Note: this doesn't
 test that the matrix as defined as below is correct; for that, we appeal to
 authority (the provided link). We merely show that the matrix is implemented
@@ -235,28 +208,6 @@ GTEST_TEST(ColorRenderCameraTest, Constructor) {
   EXPECT_EQ(camera.show_window(), show_window);
 }
 
-/* Test the converstion constructor. This will be removed when CameraProperties
- is removed.  */
-GTEST_TEST(ColorRenderCameraTest, CameraPropertiesConversion) {
-  const CameraProperties props{640, 480, M_PI / 3, "some_name"};
-  const RigidTransformd X_BS(Vector3d{1, 2, 3});
-  for (const bool show_window : {true, false}) {
-    const ColorRenderCamera cam{props, show_window, X_BS};
-    // We'll test a single feature of the core camera data, assuming that its
-    // success implies that the core data was correctly converted.
-    EXPECT_EQ(cam.core().intrinsics().width(), props.width);
-    // We *will* confirm that the conversion sets up valid clipping planes:
-    // strictly positive with near < far.
-    EXPECT_GT(cam.core().clipping().near(), 0);
-    EXPECT_LT(cam.core().clipping().near(), cam.core().clipping().far());
-    EXPECT_EQ(cam.show_window(), show_window);
-    // Confirm that the pose gets passed along.
-    EXPECT_TRUE(
-        CompareMatrices(cam.core().sensor_pose_in_camera_body().GetAsMatrix34(),
-                        X_BS.GetAsMatrix34()));
-  }
-}
-
 GTEST_TEST(DepthRangeTest, Constructor) {
   {
     // Case: Valid values.
@@ -321,7 +272,59 @@ GTEST_TEST(DepthRenderCameraTest, Constructor) {
       ".+, far = .+, min. depth = .+, max. depth = .+");
 }
 
-/* Test the converstion constructor. This will be removed when
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+/* Test the conversion constructor. This will be removed when CameraProperties
+ is removed.  */
+GTEST_TEST(RenderCameraCoreTest, CameraPropertiesConversion) {
+  const CameraProperties props{640, 480, M_PI / 3, "some_name"};
+  const RigidTransformd X_BS(Vector3d{1, 2, 3});
+  for (const double clipping_far : {15.0, 22.5}) {
+    const CameraInfo expected_intrinsics(props.width, props.height,
+                                         props.fov_y);
+    const RenderCameraCore cam{props, clipping_far, X_BS};
+    EXPECT_EQ(cam.intrinsics().width(), expected_intrinsics.width());
+    EXPECT_EQ(cam.intrinsics().height(), expected_intrinsics.height());
+    EXPECT_EQ(cam.intrinsics().fov_y(), expected_intrinsics.fov_y());
+    EXPECT_EQ(cam.intrinsics().fov_x(), expected_intrinsics.fov_x());
+    EXPECT_EQ(cam.intrinsics().center_x(), expected_intrinsics.center_x());
+    EXPECT_EQ(cam.intrinsics().center_y(), expected_intrinsics.center_y());
+    EXPECT_EQ(cam.renderer_name(), props.renderer_name);
+    EXPECT_EQ(cam.clipping().far(), clipping_far);
+    // We're not putting a strict value on the near clipping plane; just that
+    // it's strictly positive and less than the far value.
+    EXPECT_GT(cam.clipping().near(), 0);
+    EXPECT_LT(cam.clipping().near(), cam.clipping().far());
+    EXPECT_TRUE(
+        CompareMatrices(cam.sensor_pose_in_camera_body().GetAsMatrix34(),
+                        X_BS.GetAsMatrix34()));
+  }
+}
+
+/* Test the conversion constructor. This will be removed when CameraProperties
+ is removed.  */
+GTEST_TEST(ColorRenderCameraTest, CameraPropertiesConversion) {
+  const CameraProperties props{640, 480, M_PI / 3, "some_name"};
+  const RigidTransformd X_BS(Vector3d{1, 2, 3});
+  for (const bool show_window : {true, false}) {
+    const ColorRenderCamera cam{props, show_window, X_BS};
+    // We'll test a single feature of the core camera data, assuming that its
+    // success implies that the core data was correctly converted.
+    EXPECT_EQ(cam.core().intrinsics().width(), props.width);
+    // We *will* confirm that the conversion sets up valid clipping planes:
+    // strictly positive with near < far.
+    EXPECT_GT(cam.core().clipping().near(), 0);
+    EXPECT_LT(cam.core().clipping().near(), cam.core().clipping().far());
+    EXPECT_EQ(cam.show_window(), show_window);
+    // Confirm that the pose gets passed along.
+    EXPECT_TRUE(
+        CompareMatrices(cam.core().sensor_pose_in_camera_body().GetAsMatrix34(),
+                        X_BS.GetAsMatrix34()));
+  }
+}
+
+/* Test the conversion constructor. This will be removed when
  DepthCameraProperties is removed.  */
 GTEST_TEST(DepthRenderCameraTest, CameraPropertiesConversion) {
   const DepthCameraProperties props{640, 480, M_PI / 3, "some_name", 0.25, 7.5};
@@ -344,6 +347,7 @@ GTEST_TEST(DepthRenderCameraTest, CameraPropertiesConversion) {
         CompareMatrices(cam.core().sensor_pose_in_camera_body().GetAsMatrix34(),
                         X_BS.GetAsMatrix34()));
 }
+#pragma GCC diagnostic pop
 
 }  // namespace
 }  // namespace render

--- a/geometry/render/test/render_engine_test.cc
+++ b/geometry/render/test/render_engine_test.cc
@@ -446,10 +446,9 @@ GTEST_TEST(RenderEngine, OldApiDelegatesToNewApi) {
            cores_equal(test.core(), expected.core());
   };
 
-  const DepthCameraProperties properties{w, h, M_PI / 3, "n/a", 0.25, 11.5};
-
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  const DepthCameraProperties properties{w, h, M_PI / 3, "n/a", 0.25, 11.5};
 
   engine.RenderColorImage(properties, true, &color);
   EXPECT_EQ(engine.num_color_renders(), 1);
@@ -482,10 +481,13 @@ GTEST_TEST(RenderEngine, OldApiDelegatesToNewApi) {
 // detected.
 GTEST_TEST(RenderEngine, DetectUnimplementedRender) {
   // Set up cameras and images.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   const CameraProperties cam_props(10, 10, M_PI / 4, "n/a");
   const DepthCameraProperties depth_props(cam_props.width, cam_props.height,
                                           cam_props.fov_y,
                                           cam_props.renderer_name, 0.2, 8.0);
+#pragma GCC diagnostic pop
   const ColorRenderCamera color_cam(cam_props);
   const DepthRenderCamera depth_cam(depth_props);
   ImageRgba8U color_image(cam_props.width, cam_props.height);
@@ -518,6 +520,10 @@ GTEST_TEST(RenderEngine, DetectUnimplementedRender) {
       engine.RenderLabelImage(color_cam, &label_image), std::exception,
       ".+render a label image.+RenderLabelImage.+DoRenderLabelImage.+");
 }
+
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
 // This class implements *only* the legacy API to validate forwarding of APIs.
 // Calls on the old API are counted, and the camera properties are cached for
@@ -623,6 +629,7 @@ GTEST_TEST(RenderEngine, NewApiDelegatesToOldApi) {
   EXPECT_TRUE(cameras_match(engine.last_label_camera_properties(),
                             color_camera.core()));
 }
+#pragma GCC diagnostic pop
 
 }  // namespace
 }  // namespace render

--- a/geometry/test/query_object_test.cc
+++ b/geometry/test/query_object_test.cc
@@ -206,10 +206,10 @@ TEST_F(QueryObjectTest, DefaultQueryThrows) {
   EXPECT_DEFAULT_ERROR(default_object.RenderLabelImage(
       color_camera, FrameId::get_new_id(), X_WC, &label));
 
-  const DepthCameraProperties properties(2, 2, M_PI, "dummy_renderer", 0.1,
-                                         5.0);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  const DepthCameraProperties properties(2, 2, M_PI, "dummy_renderer", 0.1,
+                                         5.0);
   EXPECT_DEFAULT_ERROR(default_object.RenderColorImage(
       properties, FrameId::get_new_id(), X_WC, false, &color));
   EXPECT_DEFAULT_ERROR(default_object.RenderDepthImage(

--- a/systems/sensors/rgbd_sensor.h
+++ b/systems/sensors/rgbd_sensor.h
@@ -116,8 +116,8 @@ class RgbdSensor final : public LeafSystem<double> {
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  // These deprecated methods make use of the deprecated struct CameraPoses.
-  // So, we disable the warnings.
+  // These deprecated methods make use of the deprecated structs
+  // *CameraProperties and CameraPoses. So, we disable the warnings.
 
   /** Constructs an %RgbdSensor whose frame `B` is rigidly affixed to the frame
    P, indicated by `parent_id`, and with the given "simple" camera properties.


### PR DESCRIPTION
This deprecates the old camera properties classes themselves. As part of that endeavor:

  - bindings deprecate the constructors.
  - A slew of deprecation warning suppressions everywhere.
    - In some cases, test cases were moved around to facilitate deprecation
      suppression en masse (see render_camera_test.cc)
  - Updated python tests to expect deprecation warnings.

Towards resolving checklist in #11880.

Closes #11880

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14376)
<!-- Reviewable:end -->
