### PR TITLE
Allow tests to pass with both fmt < 7.1 and fmt >= 7.1

### DIFF
--- a/bindings/pydrake/systems/test/analysis_test.py
+++ b/bindings/pydrake/systems/test/analysis_test.py
@@ -75,9 +75,9 @@ class TestAnalysis(unittest.TestCase):
         system = ConstantVectorSource([1.])
         simulator = Simulator(system)
         status = simulator.AdvanceTo(1.)
-        self.assertEqual(
+        self.assertRegex(
             status.FormatMessage(),
-            "Simulator successfully reached the boundary time (1).")
+            "^Simulator successfully reached the boundary time")
         self.assertTrue(status.succeeded())
         self.assertEqual(status.boundary_time(), 1.)
         self.assertEqual(status.return_time(), 1.)

--- a/common/trajectories/test/discrete_time_trajectory_test.cc
+++ b/common/trajectories/test/discrete_time_trajectory_test.cc
@@ -49,12 +49,15 @@ GTEST_TEST(DiscreteTimeTrajectoryTest, ValueThrowsTest) {
 
   DiscreteTimeTrajectory<double> traj(times, values);
 
-  DRAKE_EXPECT_THROWS_MESSAGE(traj.value(-1), std::runtime_error,
-                              "Value requested at time -1 does not match .*");
-  DRAKE_EXPECT_THROWS_MESSAGE(traj.value(0.4), std::runtime_error,
-                              "Value requested at time 0.4 does not match .*");
-  DRAKE_EXPECT_THROWS_MESSAGE(traj.value(1), std::runtime_error,
-                              "Value requested at time 1 does not match .*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      traj.value(-1), std::runtime_error,
+      "Value requested at time -1(\\.0)? does not match .*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      traj.value(0.4), std::runtime_error,
+      "Value requested at time 0.4 does not match .*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      traj.value(1), std::runtime_error,
+      "Value requested at time 1(\\.0)? does not match .*");
 
   const double kLooseTolerance = 0.1;
   DiscreteTimeTrajectory<double> traj_w_loose_tol(times, values,

--- a/common/yaml/yaml_write_archive.h
+++ b/common/yaml/yaml_write_archive.h
@@ -251,6 +251,9 @@ class YamlWriteArchive final {
     using T = typename NVP::value_type;
     const T& value = *nvp.value();
     if constexpr (std::is_floating_point_v<T>) {
+      // Different versions of fmt disagree on whether to omit the trailing
+      // ".0" when formatting integer-valued floating-point numbers.  Force
+      // the ".0" in all cases by using the "#" option.
       root_[nvp.name()] = fmt::format("{:#}", value);
     } else {
       root_[nvp.name()] = fmt::format("{}", value);

--- a/multibody/parsing/test/detail_scene_graph_test.cc
+++ b/multibody/parsing/test/detail_scene_graph_test.cc
@@ -852,7 +852,7 @@ GTEST_TEST(SceneGraphParserDetail, ParseVisualMaterial) {
         MakeVisualPropertiesFromSdfVisual(*sdf_visual, NoopResolveFilename),
         std::runtime_error,
         "All values must be within the range \\[0, 1\\]. Values provided: "
-        "\\(r=0, g=1, b=255, a=1\\)");
+        "\\(r=0(\\.0)?, g=1(\\.0)?, b=255(\\.0)?, a=1(\\.0)?\\)");
   }
 }
 


### PR DESCRIPTION
The default string formatting of integer-valued floating-point values changed as of fmt 7.1.0.  In anticipation of Drake releases (or at least some Drake users) building against older revisions of fmt, we adjust magic string literals in tests to allow for either spelling.

Relates #14220.  Amends #14272.

\CC @hidmic FYI

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14379)
<!-- Reviewable:end -->
