### PR TITLE
py common: Add (internal) mechanism to trigger a segfault

### DIFF
--- a/bindings/pydrake/common/module_py.cc
+++ b/bindings/pydrake/common/module_py.cc
@@ -84,6 +84,12 @@ void def_testing(py::module m) {
   m.def("make_cc_unregistered_derived_type", []() {
     return std::unique_ptr<RegisteredType>(new UnregisteredDerivedType());
   });
+
+  m.def("trigger_segfault", []() {
+    py::print("This is going to segfault.", py::arg("flush") = true);
+    int* value{};
+    *value = 0xbadf00d;
+  });
 }
 }  // namespace testing
 


### PR DESCRIPTION
@sloretz is running into an issue where he can't seem to see symbols for `pydrake`.

This is just a thing (namely for me) to try something like the following; it is *not* public API:
```sh
cd drake
bazel run -c dbg //:install -- ${PWD}/build
python_path=$(ls -d ~+/build/lib/python*/site-packages)
env -i PYTHONPATH=${python_path} /usr/bin/python3 -c 'import pydrake.common._module_py._testing as m; m.trigger_segfault()'
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14380)
<!-- Reviewable:end -->
