### PR TITLE
Revert "[render] Deprecate CameraProperties and DepthCameraProperties"

### DIFF
--- a/bindings/pydrake/examples/test/manipulation_station_test.py
+++ b/bindings/pydrake/examples/test/manipulation_station_test.py
@@ -205,9 +205,9 @@ class TestManipulationStation(unittest.TestCase):
         station = ManipulationStation(time_step=0.001)
         station.SetupManipulationClassStation()
         plant = station.get_multibody_plant()
-        with catch_drake_warnings(expected_count=2):
-            properties = DepthCameraProperties(10, 10, np.pi / 4, "renderer",
-                                               0.01, 5.0)
+        properties = DepthCameraProperties(10, 10, np.pi / 4, "renderer",
+                                           0.01, 5.0)
+        with catch_drake_warnings(expected_count=1):
             station.RegisterRgbdSensor("deprecated", plant.world_frame(), X_PC,
                                        properties)
         station.Finalize()

--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -141,8 +141,6 @@ class PyRenderEngine : public py::wrapper<RenderEngine> {
   }
 
  private:
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   // TODO(SeanCurtis-TRI) We will be removing the Render*Image API when we
   // deprecate CameraProperties. They must be implemented in order to build
   // this class; so we'll make sure they clearly signal if they get invoked.
@@ -166,7 +164,6 @@ class PyRenderEngine : public py::wrapper<RenderEngine> {
         "Python should not be able to invoke RenderLabelImage with "
         "CameraProperties");
   }
-#pragma GCC diagnostic pop
 };
 
 void def_geometry_render(py::module m) {
@@ -247,18 +244,14 @@ void def_geometry_render(py::module m) {
     DefCopyAndDeepCopy(&cls);
   }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  // TODO(eric.cousineau): Deprecate these.
   {
     using Class = CameraProperties;
-    py::class_<Class> cls(
-        m, "CameraProperties", doc.CameraProperties.doc_deprecated);
+    py::class_<Class> cls(m, "CameraProperties", doc.CameraProperties.doc);
     cls  // BR
-        .def(py_init_deprecated<Class, int, int, double, std::string>(
-                 "Deprecated; due to be removed after 2021-03-01. Please use "
-                 "ColorRenderCamera instead"),
-            py::arg("width"), py::arg("height"), py::arg("fov_y"),
-            py::arg("renderer_name"), doc.CameraProperties.ctor.doc)
+        .def(py::init<int, int, double, std::string>(), py::arg("width"),
+            py::arg("height"), py::arg("fov_y"), py::arg("renderer_name"),
+            doc.CameraProperties.ctor.doc)
         .def_readwrite("width", &Class::width, doc.CameraProperties.width.doc)
         .def_readwrite(
             "height", &Class::height, doc.CameraProperties.height.doc)
@@ -271,12 +264,9 @@ void def_geometry_render(py::module m) {
   {
     using Class = DepthCameraProperties;
     py::class_<Class, CameraProperties> cls(
-        m, "DepthCameraProperties", doc.DepthCameraProperties.doc_deprecated);
+        m, "DepthCameraProperties", doc.DepthCameraProperties.doc);
     cls  // BR
-        .def(py_init_deprecated<Class, int, int, double, std::string, double,
-                 double>(
-                 "Deprecated; due to be removed after 2021-03-01. Please use "
-                 "DepthRenderCamera instead"),
+        .def(py::init<int, int, double, std::string, double, double>(),
             py::arg("width"), py::arg("height"), py::arg("fov_y"),
             py::arg("renderer_name"), py::arg("z_near"), py::arg("z_far"),
             doc.DepthCameraProperties.ctor.doc)
@@ -286,7 +276,6 @@ void def_geometry_render(py::module m) {
             "z_far", &Class::z_far, doc.DepthCameraProperties.z_far.doc);
     DefCopyAndDeepCopy(&cls);
   }
-#pragma GCC diagnostic pop
 
   {
     using Class = RenderEngine;

--- a/bindings/pydrake/systems/test/sensors_test.py
+++ b/bindings/pydrake/systems/test/sensors_test.py
@@ -273,7 +273,7 @@ class TestSensors(unittest.TestCase):
 
         def construct_deprecated(parent_id, X_PB):
             # One deprecation warning for CameraPoses and one for RgbdSensor.
-            with catch_drake_warnings(expected_count=4):
+            with catch_drake_warnings(expected_count=2):
                 color_properties = CameraProperties(
                     width=width, height=height, fov_y=np.pi/6,
                     renderer_name="renderer")
@@ -303,7 +303,7 @@ class TestSensors(unittest.TestCase):
                                   depth_camera=depth_camera)
 
         def construct_single_deprecated(parent_id, X_PB):
-            with catch_drake_warnings(expected_count=3):
+            with catch_drake_warnings(expected_count=2):
                 depth_properties = DepthCameraProperties(
                         width=width, height=height, fov_y=np.pi/6,
                         renderer_name="renderer", z_near=0.1, z_far=5.5)

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -599,11 +599,11 @@ class TestGeometry(unittest.TestCase):
         self.assertEqual(params.default_label, label)
         self.assertTrue((params.default_diffuse == diffuse).all())
 
-    def test_render_depth_camera_properties_deprecated(self):
-        with catch_drake_warnings(expected_count=1):
-            obj = mut.render.DepthCameraProperties(
-                width=320, height=240, fov_y=pi/6,
-                renderer_name="test_renderer", z_near=0.1, z_far=5.0)
+    def test_render_depth_camera_properties(self):
+        obj = mut.render.DepthCameraProperties(width=320, height=240,
+                                               fov_y=pi/6,
+                                               renderer_name="test_renderer",
+                                               z_near=0.1, z_far=5.0)
         self.assertEqual(obj.width, 320)
         self.assertEqual(obj.height, 240)
         self.assertEqual(obj.fov_y, pi/6)
@@ -737,9 +737,7 @@ class TestGeometry(unittest.TestCase):
             X_PC=RigidTransform())
         self.assertIsInstance(image, ImageLabel16I)
 
-        with catch_drake_warnings(expected_count=4):
-            # One deprecation warning for constructing DepthCameraProperties
-            # and one for each invocation of Render*Image.
+        with catch_drake_warnings(expected_count=3):
             depth_camera = mut.render.DepthCameraProperties(
                 width=320, height=240, fov_y=pi/6, renderer_name=renderer_name,
                 z_near=0.1, z_far=5.0)
@@ -985,10 +983,7 @@ class TestGeometry(unittest.TestCase):
         self.assertEqual(current_engine.label_count, 1)
 
         # Confirm that the CameraProperties APIs are *not* available.
-        with catch_drake_warnings(expected_count=2):
-            cam = mut.render.CameraProperties(10, 10, np.pi / 4, "")
-            depth_cam = mut.render.DepthCameraProperties(10, 10, np.pi / 4, "",
-                                                         0.1, 5)
+        cam = mut.render.CameraProperties(10, 10, np.pi / 4, "")
         with self.assertRaises(TypeError):
             engine.RenderColorImage(
                 cam, True, ImageRgba8U(cam.width, cam.height))
@@ -996,6 +991,8 @@ class TestGeometry(unittest.TestCase):
             engine.RenderLabelImage(
                 cam, True, ImageLabel16I(cam.width, cam.height))
 
+        depth_cam = mut.render.DepthCameraProperties(10, 10, np.pi / 4, "",
+                                                     0.1, 5)
         with self.assertRaises(TypeError):
             engine.RenderDepthImage(
                 depth_cam, True,

--- a/examples/manipulation_station/test/manipulation_station_test.cc
+++ b/examples/manipulation_station/test/manipulation_station_test.cc
@@ -393,8 +393,6 @@ GTEST_TEST(ManipulationStationTest, RegisterRgbdCameraTest) {
     multibody::MultibodyPlant<double>& plant =
         dut.get_mutable_multibody_plant();
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     geometry::render::DepthCameraProperties camera_properties(
         640, 480, M_PI_4, dut.default_renderer_name(), 0.1, 2.0);
 
@@ -403,6 +401,8 @@ GTEST_TEST(ManipulationStationTest, RegisterRgbdCameraTest) {
     const auto& frame0 =
         plant.AddFrame(std::make_unique<multibody::FixedOffsetFrame<double>>(
             "frame0", plant.world_frame(), X_WF0));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     dut.RegisterRgbdSensor("camera0", frame0, X_F0C0, camera_properties);
 
     const Eigen::Translation3d X_F0F1(0, -0.1, 0.2);

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -991,8 +991,6 @@ std::vector<std::string> GeometryState<T>::RegisteredRendererNames() const {
   return names;
 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 template <typename T>
 void GeometryState<T>::RenderColorImage(const render::CameraProperties& camera,
                                         FrameId parent_frame,
@@ -1005,7 +1003,10 @@ void GeometryState<T>::RenderColorImage(const render::CameraProperties& camera,
   // TODO(SeanCurtis-TRI): Invoke UpdateViewpoint() as part of a calc cache
   //  entry. Challenge: how to do that with a parameter passed here?
   const_cast<render::RenderEngine&>(engine).UpdateViewpoint(X_WC);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   engine.RenderColorImage(camera, show_window, color_image_out);
+#pragma GCC diagnostic pop
 }
 
 template <typename T>
@@ -1017,7 +1018,10 @@ void GeometryState<T>::RenderDepthImage(
       GetRenderEngineOrThrow(camera.renderer_name);
   // See note in RenderColorImage() about this const cast.
   const_cast<render::RenderEngine&>(engine).UpdateViewpoint(X_WC);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   engine.RenderDepthImage(camera, depth_image_out);
+#pragma GCC diagnostic pop
 }
 
 template <typename T>
@@ -1031,9 +1035,11 @@ void GeometryState<T>::RenderLabelImage(const render::CameraProperties& camera,
       GetRenderEngineOrThrow(camera.renderer_name);
   // See note in RenderColorImage() about this const cast.
   const_cast<render::RenderEngine&>(engine).UpdateViewpoint(X_WC);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   engine.RenderLabelImage(camera, show_window, label_image_out);
-}
 #pragma GCC diagnostic pop
+}
 
 template <typename T>
 void GeometryState<T>::RenderColorImage(const ColorRenderCamera& camera,

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -498,8 +498,6 @@ class GeometryState {
   /** Implementation of SceneGraph::RegisteredRendererNames().  */
   std::vector<std::string> RegisteredRendererNames() const;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   /** Implementation of QueryObject::RenderColorImage().
    @pre All poses have already been updated.  */
   DRAKE_DEPRECATED("2021-03-01",
@@ -528,8 +526,6 @@ class GeometryState {
                         FrameId parent_frame, const math::RigidTransformd& X_PC,
                         bool show_window,
                         systems::sensors::ImageLabel16I* label_image_out) const;
-
-#pragma GCC diagnostic pop
 
   /** Implementation of QueryObject::RenderColorImage().
    @pre All poses have already been updated.  */

--- a/geometry/query_object.cc
+++ b/geometry/query_object.cc
@@ -190,8 +190,6 @@ QueryObject<T>::ComputeSignedDistanceToPoint(
   return state.ComputeSignedDistanceToPoint(p_WQ, threshold);
 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 template <typename T>
 void QueryObject<T>::RenderColorImage(const CameraProperties& camera,
                                       FrameId parent_frame,
@@ -202,10 +200,12 @@ void QueryObject<T>::RenderColorImage(const CameraProperties& camera,
 
   FullPoseUpdate();
   const GeometryState<T>& state = geometry_state();
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   return state.RenderColorImage(camera, parent_frame, X_PC, show_window,
                                 color_image_out);
-}
 #pragma GCC diagnostic pop
+}
 
 template <typename T>
 void QueryObject<T>::RenderColorImage(const ColorRenderCamera& camera,
@@ -219,8 +219,6 @@ void QueryObject<T>::RenderColorImage(const ColorRenderCamera& camera,
   return state.RenderColorImage(camera, parent_frame, X_PC, color_image_out);
 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 template <typename T>
 void QueryObject<T>::RenderDepthImage(const DepthCameraProperties& camera,
                                       FrameId parent_frame,
@@ -230,9 +228,11 @@ void QueryObject<T>::RenderDepthImage(const DepthCameraProperties& camera,
 
   FullPoseUpdate();
   const GeometryState<T>& state = geometry_state();
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   return state.RenderDepthImage(camera, parent_frame, X_PC, depth_image_out);
-}
 #pragma GCC diagnostic pop
+}
 
 template <typename T>
 void QueryObject<T>::RenderDepthImage(const DepthRenderCamera& camera,
@@ -246,8 +246,6 @@ void QueryObject<T>::RenderDepthImage(const DepthRenderCamera& camera,
   return state.RenderDepthImage(camera, parent_frame, X_PC, depth_image_out);
 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 template <typename T>
 void QueryObject<T>::RenderLabelImage(const CameraProperties& camera,
                                       FrameId parent_frame,
@@ -258,10 +256,12 @@ void QueryObject<T>::RenderLabelImage(const CameraProperties& camera,
 
   FullPoseUpdate();
   const GeometryState<T>& state = geometry_state();
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   return state.RenderLabelImage(camera, parent_frame, X_PC, show_window,
                                 label_image_out);
-}
 #pragma GCC diagnostic pop
+}
 
 template <typename T>
 void QueryObject<T>::RenderLabelImage(const ColorRenderCamera& camera,

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -486,8 +486,6 @@ class QueryObject {
    */
   //@{
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   /** Renders an RGB image for the given `camera` posed with respect to the
    indicated parent frame P.
 
@@ -504,7 +502,6 @@ class QueryObject {
                         const math::RigidTransformd& X_PC,
                         bool show_window,
                         systems::sensors::ImageRgba8U* color_image_out) const;
-#pragma GCC diagnostic pop
 
   /** Renders an RGB image for the given `camera` posed with respect to the
    indicated parent frame P.
@@ -517,8 +514,6 @@ class QueryObject {
                         FrameId parent_frame, const math::RigidTransformd& X_PC,
                         systems::sensors::ImageRgba8U* color_image_out) const;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   /** Renders a depth image for the given `camera` posed with respect to the
    indicated parent frame P.
 
@@ -537,7 +532,6 @@ class QueryObject {
                         FrameId parent_frame,
                         const math::RigidTransformd& X_PC,
                         systems::sensors::ImageDepth32F* depth_image_out) const;
-#pragma GCC diagnostic pop
 
   /** Renders a depth image for the given `camera` posed with respect to the
    indicated parent frame P.
@@ -554,8 +548,6 @@ class QueryObject {
                         FrameId parent_frame, const math::RigidTransformd& X_PC,
                         systems::sensors::ImageDepth32F* depth_image_out) const;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   /** Renders a label image for the given `camera` posed with respect to the
    indicated parent frame P.
 
@@ -572,7 +564,6 @@ class QueryObject {
                         const math::RigidTransformd& X_PC,
                         bool show_window,
                         systems::sensors::ImageLabel16I* label_image_out) const;
-#pragma GCC diagnostic pop
 
   /** Renders a label image for the given `camera` posed with respect to the
    indicated parent frame P.

--- a/geometry/render/camera_properties.h
+++ b/geometry/render/camera_properties.h
@@ -4,8 +4,6 @@
 #include <string>
 #include <utility>
 
-#include "drake/common/drake_deprecated.h"
-
 namespace drake {
 namespace geometry {
 namespace render {
@@ -25,9 +23,7 @@ namespace render {
 
  The focal length is inferred by the sensor format (width and height) and the
  field of view along the y-axis. */
-struct DRAKE_DEPRECATED("2021-03-01",
-                        "CameraProperties are being deprecated. Please use "
-                        "ColorRenderCamera.") CameraProperties {
+struct CameraProperties {
   CameraProperties(int width_in, int height_in, double fov_y_in,
                    std::string renderer_name_in)
       : width(width_in),
@@ -45,10 +41,7 @@ struct DRAKE_DEPRECATED("2021-03-01",
  intrinsic properties of the render camera but extended with additional
  depth-specific parameters.
  @see CameraProperties */
-struct DRAKE_DEPRECATED("2021-03-01",
-                        "DepthCameraProperties are being deprecated. Please "
-                        "use DepthRenderCamera.")
-DepthCameraProperties : public CameraProperties {
+struct DepthCameraProperties : public CameraProperties {
   DepthCameraProperties(int width_in, int height_in, double fov_y_in,
                         std::string renderer_name_in, double z_near_in,
                         double z_far_in)

--- a/geometry/render/render_camera.cc
+++ b/geometry/render/render_camera.cc
@@ -20,15 +20,12 @@ ClippingRange::ClippingRange(double near, double far) : near_(near), far_(far) {
   }
 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 RenderCameraCore::RenderCameraCore(const CameraProperties& camera,
                                    double clipping_far, RigidTransformd X_BS)
     : RenderCameraCore(camera.renderer_name,
                        CameraInfo{camera.width, camera.height, camera.fov_y},
                        ClippingRange{kClippingNear, clipping_far},
                        std::move(X_BS)) {}
-#pragma GCC diagnostic pop
 
 Eigen::Matrix4d RenderCameraCore::CalcProjectionMatrix() const {
   /* Given the camera properties we compute the projection matrix as follows:

--- a/geometry/render/render_camera.h
+++ b/geometry/render/render_camera.h
@@ -44,14 +44,11 @@ class RenderCameraCore {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(RenderCameraCore);
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   /** (Advanced) Constructs a %RenderCameraCore from the old, symmetric camera
    representation. This constructor should only be used internally; it serves
    as a stop gap measure until CameraProperties is fully deprecated.  */
   RenderCameraCore(const CameraProperties& camera, double clipping_far,
                    math::RigidTransformd X_BS = {});
-#pragma GCC diagnostic pop
 
   /** Fully-specified constructor. See the documentation on the member getter
    methods for documentation of parameters.  */
@@ -110,8 +107,6 @@ class ColorRenderCamera {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ColorRenderCamera);
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   /** Constructs a %ColorRenderCamera from the old, symmetric camera
    representation. This constructor should only be used internally; it serves
    as a stop gap measure until CameraProperties is fully deprecated.  */
@@ -121,7 +116,6 @@ class ColorRenderCamera {
       : ColorRenderCamera(
             RenderCameraCore(camera, kClippingFar, std::move(X_BC)),
             show_window) {}
-#pragma GCC diagnostic pop
 
   /** Fully-specified constructor. See the documentation on the member getter
    methods for documentation of parameters.  */
@@ -182,8 +176,6 @@ class DepthRenderCamera {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DepthRenderCamera);
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   /** Constructs a %DepthRenderCamera from the old, symmetric camera
    representation. This constructor should only be used internally; it serves
    as a stop gap measure until CameraProperties is fully deprecated.  */
@@ -192,7 +184,6 @@ class DepthRenderCamera {
       : DepthRenderCamera(
             RenderCameraCore(camera, camera.z_far * 1.1, std::move(X_BD)),
             DepthRange(camera.z_near, camera.z_far)) {}
-#pragma GCC diagnostic pop
 
   /** Fully-specified constructor. See the documentation on the member getter
    methods for documentation of parameters.

--- a/geometry/render/render_engine.cc
+++ b/geometry/render/render_engine.cc
@@ -104,11 +104,11 @@ void RenderEngine::DoRenderColorImage(const ColorRenderCamera& camera,
       NiceTypeName::Get(*this));
 
   const CameraInfo& intrinsics = camera.core().intrinsics();
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   CameraProperties simple_props{intrinsics.width(), intrinsics.height(),
                                 intrinsics.fov_y(),
                                 camera.core().renderer_name()};
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   RenderColorImage(simple_props, camera.show_window(), color_image_out);
 #pragma GCC diagnostic pop
 }
@@ -132,14 +132,14 @@ void RenderEngine::DoRenderDepthImage(const DepthRenderCamera& camera,
       NiceTypeName::Get(*this));
 
   const CameraInfo& intrinsics = camera.core().intrinsics();
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   DepthCameraProperties simple_props{intrinsics.width(),
                                      intrinsics.height(),
                                      intrinsics.fov_y(),
                                      camera.core().renderer_name(),
                                      camera.depth_range().min_depth(),
                                      camera.depth_range().max_depth()};
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   RenderDepthImage(simple_props, depth_image_out);
 #pragma GCC diagnostic pop
 }
@@ -163,11 +163,11 @@ void RenderEngine::DoRenderLabelImage(const ColorRenderCamera& camera,
       NiceTypeName::Get(*this));
 
   const CameraInfo& intrinsics = camera.core().intrinsics();
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   CameraProperties simple_props{intrinsics.width(), intrinsics.height(),
                                 intrinsics.fov_y(),
                                 camera.core().renderer_name()};
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   RenderLabelImage(simple_props, camera.show_window(), label_image_out);
 #pragma GCC diagnostic pop
 }

--- a/geometry/render/render_engine.h
+++ b/geometry/render/render_engine.h
@@ -224,8 +224,8 @@ class RenderEngine : public ShapeReifier {
    */
   //@{
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  // TODO(SeanCurtis-TRI): Deprecate these (Depth)CameraProperties variants
+  //  of the render functions.
   /** Renders the registered geometry into the given color (rgb) image based on
    a simplified camera model.
 
@@ -283,7 +283,6 @@ class RenderEngine : public ShapeReifier {
     DoRenderLabelImage(cam, label_image_out);
   }
 
-#pragma GCC diagnostic pop
   //@}
 
   /** @name Rendering using fully-specified camera models

--- a/geometry/render/test/render_camera_test.cc
+++ b/geometry/render/test/render_camera_test.cc
@@ -56,6 +56,33 @@ GTEST_TEST(RenderCameraCoreTest, Constructor) {
                               X_BS.GetAsMatrix4()));
 }
 
+/* Test the converstion constructor. This will be removed when CameraProperties
+ is removed.  */
+GTEST_TEST(RenderCameraCoreTest, CameraPropertiesConversion) {
+  const CameraProperties props{640, 480, M_PI / 3, "some_name"};
+  const RigidTransformd X_BS(Vector3d{1, 2, 3});
+  for (const double clipping_far : {15.0, 22.5}) {
+    const CameraInfo expected_intrinsics(props.width, props.height,
+                                         props.fov_y);
+    const RenderCameraCore cam{props, clipping_far, X_BS};
+    EXPECT_EQ(cam.intrinsics().width(), expected_intrinsics.width());
+    EXPECT_EQ(cam.intrinsics().height(), expected_intrinsics.height());
+    EXPECT_EQ(cam.intrinsics().fov_y(), expected_intrinsics.fov_y());
+    EXPECT_EQ(cam.intrinsics().fov_x(), expected_intrinsics.fov_x());
+    EXPECT_EQ(cam.intrinsics().center_x(), expected_intrinsics.center_x());
+    EXPECT_EQ(cam.intrinsics().center_y(), expected_intrinsics.center_y());
+    EXPECT_EQ(cam.renderer_name(), props.renderer_name);
+    EXPECT_EQ(cam.clipping().far(), clipping_far);
+    // We're not putting a strict value on the near clipping plane; just that
+    // it's strictly positive and less than the far value.
+    EXPECT_GT(cam.clipping().near(), 0);
+    EXPECT_LT(cam.clipping().near(), cam.clipping().far());
+    EXPECT_TRUE(
+        CompareMatrices(cam.sensor_pose_in_camera_body().GetAsMatrix34(),
+                        X_BS.GetAsMatrix34()));
+  }
+}
+
 /* Confirm that the correct projection matrix is created. Note: this doesn't
 test that the matrix as defined as below is correct; for that, we appeal to
 authority (the provided link). We merely show that the matrix is implemented
@@ -208,6 +235,28 @@ GTEST_TEST(ColorRenderCameraTest, Constructor) {
   EXPECT_EQ(camera.show_window(), show_window);
 }
 
+/* Test the converstion constructor. This will be removed when CameraProperties
+ is removed.  */
+GTEST_TEST(ColorRenderCameraTest, CameraPropertiesConversion) {
+  const CameraProperties props{640, 480, M_PI / 3, "some_name"};
+  const RigidTransformd X_BS(Vector3d{1, 2, 3});
+  for (const bool show_window : {true, false}) {
+    const ColorRenderCamera cam{props, show_window, X_BS};
+    // We'll test a single feature of the core camera data, assuming that its
+    // success implies that the core data was correctly converted.
+    EXPECT_EQ(cam.core().intrinsics().width(), props.width);
+    // We *will* confirm that the conversion sets up valid clipping planes:
+    // strictly positive with near < far.
+    EXPECT_GT(cam.core().clipping().near(), 0);
+    EXPECT_LT(cam.core().clipping().near(), cam.core().clipping().far());
+    EXPECT_EQ(cam.show_window(), show_window);
+    // Confirm that the pose gets passed along.
+    EXPECT_TRUE(
+        CompareMatrices(cam.core().sensor_pose_in_camera_body().GetAsMatrix34(),
+                        X_BS.GetAsMatrix34()));
+  }
+}
+
 GTEST_TEST(DepthRangeTest, Constructor) {
   {
     // Case: Valid values.
@@ -272,59 +321,7 @@ GTEST_TEST(DepthRenderCameraTest, Constructor) {
       ".+, far = .+, min. depth = .+, max. depth = .+");
 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
-/* Test the conversion constructor. This will be removed when CameraProperties
- is removed.  */
-GTEST_TEST(RenderCameraCoreTest, CameraPropertiesConversion) {
-  const CameraProperties props{640, 480, M_PI / 3, "some_name"};
-  const RigidTransformd X_BS(Vector3d{1, 2, 3});
-  for (const double clipping_far : {15.0, 22.5}) {
-    const CameraInfo expected_intrinsics(props.width, props.height,
-                                         props.fov_y);
-    const RenderCameraCore cam{props, clipping_far, X_BS};
-    EXPECT_EQ(cam.intrinsics().width(), expected_intrinsics.width());
-    EXPECT_EQ(cam.intrinsics().height(), expected_intrinsics.height());
-    EXPECT_EQ(cam.intrinsics().fov_y(), expected_intrinsics.fov_y());
-    EXPECT_EQ(cam.intrinsics().fov_x(), expected_intrinsics.fov_x());
-    EXPECT_EQ(cam.intrinsics().center_x(), expected_intrinsics.center_x());
-    EXPECT_EQ(cam.intrinsics().center_y(), expected_intrinsics.center_y());
-    EXPECT_EQ(cam.renderer_name(), props.renderer_name);
-    EXPECT_EQ(cam.clipping().far(), clipping_far);
-    // We're not putting a strict value on the near clipping plane; just that
-    // it's strictly positive and less than the far value.
-    EXPECT_GT(cam.clipping().near(), 0);
-    EXPECT_LT(cam.clipping().near(), cam.clipping().far());
-    EXPECT_TRUE(
-        CompareMatrices(cam.sensor_pose_in_camera_body().GetAsMatrix34(),
-                        X_BS.GetAsMatrix34()));
-  }
-}
-
-/* Test the conversion constructor. This will be removed when CameraProperties
- is removed.  */
-GTEST_TEST(ColorRenderCameraTest, CameraPropertiesConversion) {
-  const CameraProperties props{640, 480, M_PI / 3, "some_name"};
-  const RigidTransformd X_BS(Vector3d{1, 2, 3});
-  for (const bool show_window : {true, false}) {
-    const ColorRenderCamera cam{props, show_window, X_BS};
-    // We'll test a single feature of the core camera data, assuming that its
-    // success implies that the core data was correctly converted.
-    EXPECT_EQ(cam.core().intrinsics().width(), props.width);
-    // We *will* confirm that the conversion sets up valid clipping planes:
-    // strictly positive with near < far.
-    EXPECT_GT(cam.core().clipping().near(), 0);
-    EXPECT_LT(cam.core().clipping().near(), cam.core().clipping().far());
-    EXPECT_EQ(cam.show_window(), show_window);
-    // Confirm that the pose gets passed along.
-    EXPECT_TRUE(
-        CompareMatrices(cam.core().sensor_pose_in_camera_body().GetAsMatrix34(),
-                        X_BS.GetAsMatrix34()));
-  }
-}
-
-/* Test the conversion constructor. This will be removed when
+/* Test the converstion constructor. This will be removed when
  DepthCameraProperties is removed.  */
 GTEST_TEST(DepthRenderCameraTest, CameraPropertiesConversion) {
   const DepthCameraProperties props{640, 480, M_PI / 3, "some_name", 0.25, 7.5};
@@ -347,7 +344,6 @@ GTEST_TEST(DepthRenderCameraTest, CameraPropertiesConversion) {
         CompareMatrices(cam.core().sensor_pose_in_camera_body().GetAsMatrix34(),
                         X_BS.GetAsMatrix34()));
 }
-#pragma GCC diagnostic pop
 
 }  // namespace
 }  // namespace render

--- a/geometry/render/test/render_engine_test.cc
+++ b/geometry/render/test/render_engine_test.cc
@@ -446,9 +446,10 @@ GTEST_TEST(RenderEngine, OldApiDelegatesToNewApi) {
            cores_equal(test.core(), expected.core());
   };
 
+  const DepthCameraProperties properties{w, h, M_PI / 3, "n/a", 0.25, 11.5};
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  const DepthCameraProperties properties{w, h, M_PI / 3, "n/a", 0.25, 11.5};
 
   engine.RenderColorImage(properties, true, &color);
   EXPECT_EQ(engine.num_color_renders(), 1);
@@ -481,13 +482,10 @@ GTEST_TEST(RenderEngine, OldApiDelegatesToNewApi) {
 // detected.
 GTEST_TEST(RenderEngine, DetectUnimplementedRender) {
   // Set up cameras and images.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   const CameraProperties cam_props(10, 10, M_PI / 4, "n/a");
   const DepthCameraProperties depth_props(cam_props.width, cam_props.height,
                                           cam_props.fov_y,
                                           cam_props.renderer_name, 0.2, 8.0);
-#pragma GCC diagnostic pop
   const ColorRenderCamera color_cam(cam_props);
   const DepthRenderCamera depth_cam(depth_props);
   ImageRgba8U color_image(cam_props.width, cam_props.height);
@@ -520,10 +518,6 @@ GTEST_TEST(RenderEngine, DetectUnimplementedRender) {
       engine.RenderLabelImage(color_cam, &label_image), std::exception,
       ".+render a label image.+RenderLabelImage.+DoRenderLabelImage.+");
 }
-
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
 // This class implements *only* the legacy API to validate forwarding of APIs.
 // Calls on the old API are counted, and the camera properties are cached for
@@ -629,7 +623,6 @@ GTEST_TEST(RenderEngine, NewApiDelegatesToOldApi) {
   EXPECT_TRUE(cameras_match(engine.last_label_camera_properties(),
                             color_camera.core()));
 }
-#pragma GCC diagnostic pop
 
 }  // namespace
 }  // namespace render

--- a/geometry/test/query_object_test.cc
+++ b/geometry/test/query_object_test.cc
@@ -206,10 +206,10 @@ TEST_F(QueryObjectTest, DefaultQueryThrows) {
   EXPECT_DEFAULT_ERROR(default_object.RenderLabelImage(
       color_camera, FrameId::get_new_id(), X_WC, &label));
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   const DepthCameraProperties properties(2, 2, M_PI, "dummy_renderer", 0.1,
                                          5.0);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   EXPECT_DEFAULT_ERROR(default_object.RenderColorImage(
       properties, FrameId::get_new_id(), X_WC, false, &color));
   EXPECT_DEFAULT_ERROR(default_object.RenderDepthImage(

--- a/systems/sensors/rgbd_sensor.h
+++ b/systems/sensors/rgbd_sensor.h
@@ -116,8 +116,8 @@ class RgbdSensor final : public LeafSystem<double> {
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  // These deprecated methods make use of the deprecated structs
-  // *CameraProperties and CameraPoses. So, we disable the warnings.
+  // These deprecated methods make use of the deprecated struct CameraPoses.
+  // So, we disable the warnings.
 
   /** Constructs an %RgbdSensor whose frame `B` is rigidly affixed to the frame
    P, indicated by `parent_id`, and with the given "simple" camera properties.

--- a/systems/sensors/test/rgbd_sensor_test.cc
+++ b/systems/sensors/test/rgbd_sensor_test.cc
@@ -198,10 +198,18 @@ class RgbdSensorTest : public ::testing::Test {
       : ::testing::Test(),
         // N.B. This is using arbitrary yet different intrinsics for color vs.
         // depth.
+        color_properties_(640, 480, M_PI / 4, kRendererName),
+        depth_properties_(320, 240, M_PI / 6, kRendererName, 0.1, 10),
+        color_camera_(color_properties_, false),
+        depth_camera_(depth_properties_) {}
+/* TODO(SeanCurtis-TRI) When we finish deprecating the CameraProperties APIs
+ the instantiation of the two RenderCameras will become the text below (to
+ maintain test equivalence).
         color_camera_({kRendererName, {640, 480, M_PI / 4}, {0.1, 10.0}, {}},
                       false),
         depth_camera_({kRendererName, {320, 240, M_PI / 6}, {0.1, 10.0}, {}},
                       {0.1, 10}) {}
+*/
 
  protected:
   // Creates a Diagram with a SceneGraph and RgbdSensor connected appropriately.
@@ -277,6 +285,8 @@ class RgbdSensorTest : public ::testing::Test {
     return result;
   }
 
+  CameraProperties color_properties_;
+  DepthCameraProperties depth_properties_;
   ColorRenderCamera color_camera_;
   DepthRenderCamera depth_camera_;
   unique_ptr<Diagram<double>> diagram_;
@@ -309,26 +319,31 @@ TEST_F(RgbdSensorTest, PortNames) {
   EXPECT_EQ(sensor.X_WB_output_port().get_name(), "X_WB");
 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-TEST_F(RgbdSensorTest, ConstructDeprecatedCameraProperties) {
-  const CameraProperties color_props(2, 2, M_PI, "name");
-  const DepthCameraProperties depth_props(4, 4, M_PI / 4, "name", 1.0, 10.0);
+// Confirms that simple intrinsics (CameraProperties) gets translated to full
+// intrinsics (CameraInfo) correctly.
+TEST_F(RgbdSensorTest, ConstructFullySpecifiedCameraIntrinsics) {
+  const CameraInfo color_intrinsics{2, 2, M_PI};
+  const ColorRenderCamera color_camera(
+      {"name", color_intrinsics, {0.1, 10.0}, RigidTransformd{}}, true);
+  const CameraInfo depth_intrinsics{3, 3, M_PI * 0.9};
+  const DepthRenderCamera depth_camera(
+      {"name", depth_intrinsics, {0.1, 10.0}, RigidTransformd{}}, {1, 10});
 
   const FrameId parent_id = FrameId::get_new_id();
   const RigidTransformd X_PB;
 
   {
     // Case: Declare color and depth intrinsics separately.
-    RgbdSensor sensor{parent_id, X_PB, color_props, depth_props};
+    RgbdSensor sensor{parent_id, X_PB, color_camera, depth_camera};
 
     EXPECT_TRUE(
-        CompareCameraInfo(sensor.color_camera_info(), CameraInfo(2, 2, M_PI)));
-    EXPECT_TRUE(CompareCameraInfo(sensor.depth_camera_info(),
-                                  CameraInfo(4, 4, M_PI / 4)));
+        CompareCameraInfo(sensor.color_camera_info(), color_intrinsics));
+    EXPECT_TRUE(
+        CompareCameraInfo(sensor.depth_camera_info(), depth_intrinsics));
+    EXPECT_TRUE(Compare(sensor.color_render_camera(), color_camera));
+    EXPECT_TRUE(Compare(sensor.depth_render_camera(), depth_camera));
   }
 }
-#pragma GCC diagnostic pop
 
 // Tests that the anchored camera reports the correct parent frame and has the
 // right pose passed to the renderer.
@@ -339,7 +354,7 @@ TEST_F(RgbdSensorTest, ConstructAnchoredCamera) {
 
   auto make_sensor = [this, &X_WB](SceneGraph<double>*) {
     return make_unique<RgbdSensor>(SceneGraph<double>::world_frame_id(), X_WB,
-                                   color_camera_, depth_camera_);
+                                   color_properties_, depth_properties_);
   };
   MakeCameraDiagram(make_sensor);
 
@@ -366,8 +381,8 @@ TEST_F(RgbdSensorTest, ConstructFrameFixedCamera) {
                       &X_PB](SceneGraph<double>* graph) {
     source_id = graph->RegisterSource("source");
     graph->RegisterFrame(source_id, frame);
-    return make_unique<RgbdSensor>(frame.id(), X_PB, color_camera_,
-                                   depth_camera_);
+    return make_unique<RgbdSensor>(frame.id(), X_PB, color_properties_,
+                                   depth_properties_);
   };
   MakeCameraDiagram(make_sensor);
 
@@ -420,24 +435,12 @@ TEST_F(RgbdSensorTest, ConstructCameraWithNonTrivialOffsetsDeprecated) {
   // For uniqueness, simply invert X_BC.
   const RigidTransformd X_BD{X_BC.inverse()};
   const RigidTransformd X_WB;
-  const ColorRenderCamera color_camera(
-      {color_camera_.core().renderer_name(),
-       {color_camera_.core().intrinsics().width(),
-        color_camera_.core().intrinsics().height(),
-        color_camera_.core().intrinsics().fov_y()},
-       color_camera_.core().clipping(),
-       X_BC},
-      false);
-  const DepthRenderCamera depth_camera(
-      {depth_camera_.core().renderer_name(),
-       {depth_camera_.core().intrinsics().width(),
-        depth_camera_.core().intrinsics().height(),
-        depth_camera_.core().intrinsics().fov_y()},
-       depth_camera_.core().clipping(),
-       X_BD},
-      depth_camera_.depth_range());
-  const RgbdSensor sensor(scene_graph_->world_frame_id(), X_WB, color_camera,
-                          depth_camera);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  const RgbdSensor sensor(
+      scene_graph_->world_frame_id(), X_WB, color_properties_,
+      depth_properties_, RgbdSensor::CameraPoses{X_BC, X_BD});
+#pragma GCC diagnostic pop
   EXPECT_TRUE(CompareMatrices(
       sensor.X_BC().GetAsMatrix4(), X_BC.GetAsMatrix4()));
   EXPECT_TRUE(CompareMatrices(
@@ -483,8 +486,7 @@ TEST_F(RgbdSensorTest, DepthImage32FTo16U) {
 
 // Tests that the discrete sensor is properly constructed.
 GTEST_TEST(RgbdSensorDiscrete, Construction) {
-  const DepthRenderCamera depth_camera(
-      {"render", {640, 480, M_PI / 4}, {0.1, 10.0}, {}}, {0.1, 10});
+  DepthCameraProperties properties(640, 480, M_PI / 4, "render", 0.1, 10);
   const double kPeriod = 0.1;
 
   const bool include_render_port = true;
@@ -492,7 +494,7 @@ GTEST_TEST(RgbdSensorDiscrete, Construction) {
   // the `RgbdSensor` constructor which takes only `DepthCameraProperties`.
   RgbdSensorDiscrete sensor(
       make_unique<RgbdSensor>(SceneGraph<double>::world_frame_id(),
-                              RigidTransformd::Identity(), depth_camera),
+                              RigidTransformd::Identity(), properties),
       kPeriod, include_render_port);
   EXPECT_EQ(sensor.query_object_input_port().get_name(), "geometry_query");
   EXPECT_EQ(sensor.color_image_output_port().get_name(), "color_image");
@@ -509,13 +511,12 @@ GTEST_TEST(RgbdSensorDiscrete, Construction) {
 // Test that the diagram's internal architecture is correct and, likewise,
 // wired correctly.
 GTEST_TEST(RgbdSensorDiscrete, ImageHold) {
-  const DepthRenderCamera depth_camera(
-      {"render", {640, 480, M_PI / 4}, {0.1, 10.0}, {}}, {0.1, 10});
+  DepthCameraProperties properties(640, 480, M_PI / 4, "render", 0.1, 10);
   // N.B. In addition to testing a discrete sensor, this also tests
   // the `RgbdSensor` constructor which takes only `DepthCameraProperties`.
   auto sensor =
       make_unique<RgbdSensor>(SceneGraph<double>::world_frame_id(),
-                              RigidTransformd::Identity(), depth_camera);
+                              RigidTransformd::Identity(), properties);
   RgbdSensor* sensor_raw = sensor.get();
   const double kPeriod = 0.1;
   const bool include_render_port = true;


### PR DESCRIPTION
Dear @SeanCurtis-TRI,

The on-call build cop, $BUILD_COP, believes that your PR #14376 may have
broken one or more of Drake's continuous integration builds [1]. It is
possible to break a build even if your PR passed continuous integration
pre-merge because additional platforms are tested post-merge.

The specific build failures under investigation are:
https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/mac-catalina-clang-bazel-continuous-release/81/

Therefore, the build cop has created this revert PR and started a complete
post-merge build to determine whether your PR was in fact the cause of the
problem. If that build passes, this revert PR will be merged 60 minutes from
now. You can then fix the problem at your leisure, and send a new PR to
reinstate your change.

If you believe your original PR did not actually break the build, please
explain on this thread.

If you believe you can fix the break promptly in lieu of a revert, please
explain on this thread, and send a PR to the build cop for review ASAP.

If you believe your original PR definitely did break the build and should be
reverted, please review and LGTM this PR. This allows the build cop to merge
without waiting for CI results.

For advice on how to handle a build cop revert, see [2].

Thanks!
Your Friendly On-call Build Cop

[1] CI Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Production/
[2] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14384)
<!-- Reviewable:end -->
