### PR TITLE
multibody: add ValidateContext() to methods that take a context

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -218,6 +218,14 @@ class TestPlant(unittest.TestCase):
             self.assertEqual(body1_friction.static_friction(), 1.1)
             self.assertEqual(body1_friction.dynamic_friction(), 0.8)
 
+        # Confirm that passing the diagram context into the plant (a common
+        # user error) throws a RuntimeError instead of crashing.
+        plant.Finalize()
+        diagram = builder.Build()
+        context = diagram.CreateDefaultContext()
+        with self.assertRaises(RuntimeError):
+            plant.EvalBodyPoseInWorld(context, body)
+
     @numpy_compare.check_all_types
     def test_multibody_plant_api_via_parsing(self, T):
         MultibodyPlant = MultibodyPlant_[T]

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -574,6 +574,7 @@ void MultibodyPlant<T>::SetFreeBodyPoseInWorldFrame(
     systems::Context<T>* context,
     const Body<T>& body, const math::RigidTransform<T>& X_WB) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+  this->ValidateContext(context);
   internal_tree().SetFreeBodyPoseOrThrow(body, X_WB, context);
 }
 
@@ -583,6 +584,7 @@ void MultibodyPlant<T>::SetFreeBodyPoseInAnchoredFrame(
     const Frame<T>& frame_F, const Body<T>& body,
     const math::RigidTransform<T>& X_FB) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+  this->ValidateContext(context);
 
   if (!internal_tree().get_topology().IsBodyAnchored(frame_F.body().index())) {
     throw std::logic_error(
@@ -603,6 +605,7 @@ void MultibodyPlant<T>::CalcSpatialAccelerationsFromVdot(
     const systems::Context<T>& context,
     const VectorX<T>& known_vdot,
     std::vector<SpatialAcceleration<T>>* A_WB_array) const {
+  this->ValidateContext(context);
   DRAKE_THROW_UNLESS(A_WB_array != nullptr);
   DRAKE_THROW_UNLESS(static_cast<int>(A_WB_array->size()) == num_bodies());
   internal_tree().CalcSpatialAccelerationsFromVdot(
@@ -626,6 +629,7 @@ template<typename T>
 void MultibodyPlant<T>::CalcForceElementsContribution(
       const systems::Context<T>& context,
       MultibodyForces<T>* forces) const {
+  this->ValidateContext(context);
   DRAKE_THROW_UNLESS(forces != nullptr);
   DRAKE_THROW_UNLESS(forces->CheckHasRightSizeForModel(internal_tree()));
   internal_tree().CalcForceElementsContribution(
@@ -900,6 +904,7 @@ void MultibodyPlant<T>::CalcNormalAndTangentContactJacobians(
     const std::vector<internal::DiscreteContactPair<T>>& contact_pairs,
     MatrixX<T>* Jn_ptr, MatrixX<T>* Jt_ptr,
     std::vector<RotationMatrix<T>>* R_WC_set) const {
+  this->ValidateContext(context);
   DRAKE_DEMAND(Jn_ptr != nullptr);
   DRAKE_DEMAND(Jt_ptr != nullptr);
 
@@ -1099,6 +1104,7 @@ template <typename T>
 std::vector<PenetrationAsPointPair<T>>
 MultibodyPlant<T>::CalcPointPairPenetrations(
     const systems::Context<T>& context) const {
+  this->ValidateContext(context);
   if (num_collision_geometries() > 0) {
     const auto& query_object = EvalGeometryQueryInput(context);
     return query_object.ComputePointPairPenetration();
@@ -1130,6 +1136,7 @@ std::vector<CoulombFriction<double>>
 MultibodyPlant<T>::CalcCombinedFrictionCoefficients(
     const drake::systems::Context<T>& context,
     const std::vector<internal::DiscreteContactPair<T>>& contact_pairs) const {
+  this->ValidateContext(context);
   std::vector<CoulombFriction<double>> combined_frictions;
   combined_frictions.reserve(contact_pairs.size());
 
@@ -1159,6 +1166,7 @@ template<typename T>
 void MultibodyPlant<T>::CopyContactResultsOutput(
     const systems::Context<T>& context,
     ContactResults<T>* contact_results) const {
+  this->ValidateContext(context);
   DRAKE_DEMAND(contact_results != nullptr);
   *contact_results = EvalContactResults(context);
 }
@@ -1167,6 +1175,7 @@ template <typename T>
 void MultibodyPlant<T>::CalcContactResultsContinuous(
     const systems::Context<T>& context,
     ContactResults<T>* contact_results) const {
+  this->ValidateContext(context);
   DRAKE_DEMAND(contact_results != nullptr);
   contact_results->Clear();
   if (num_collision_geometries() == 0) return;
@@ -1210,6 +1219,7 @@ template <typename T>
 void MultibodyPlant<T>::CalcContactResultsContinuousHydroelastic(
     const systems::Context<T>& context,
     ContactResults<T>* contact_results) const {
+  this->ValidateContext(context);
   const internal::HydroelasticContactInfoAndBodySpatialForces<T>&
       contact_info_and_spatial_body_forces =
           EvalHydroelasticContactForces(context);
@@ -1240,6 +1250,7 @@ template <typename T>
 void MultibodyPlant<T>::CalcContactResultsContinuousPointPair(
     const systems::Context<T>& context,
     ContactResults<T>* contact_results) const {
+  this->ValidateContext(context);
 
   const std::vector<PenetrationAsPointPair<T>>& point_pairs =
       EvalPointPairPenetrations(context);
@@ -1353,6 +1364,7 @@ template <typename T>
 void MultibodyPlant<T>::CalcContactResultsDiscrete(
     const systems::Context<T>& context,
     ContactResults<T>* contact_results) const {
+  this->ValidateContext(context);
   DRAKE_DEMAND(contact_results != nullptr);
   if (num_collision_geometries() == 0) return;
 
@@ -1408,6 +1420,7 @@ template <typename T>
 void MultibodyPlant<T>::CalcAndAddContactForcesByPenaltyMethod(
     const systems::Context<T>& context,
     std::vector<SpatialForce<T>>* F_BBo_W_array) const {
+  this->ValidateContext(context);
   DRAKE_DEMAND(F_BBo_W_array != nullptr);
   DRAKE_DEMAND(static_cast<int>(F_BBo_W_array->size()) == num_bodies());
   if (num_collision_geometries() == 0) return;
@@ -1476,6 +1489,7 @@ void MultibodyPlant<T>::CalcHydroelasticContactForces(
     const Context<T>& context,
     internal::HydroelasticContactInfoAndBodySpatialForces<T>*
         contact_info_and_body_forces) const {
+  this->ValidateContext(context);
   DRAKE_DEMAND(contact_info_and_body_forces != nullptr);
 
   std::vector<SpatialForce<T>>& F_BBo_W_array =
@@ -1579,6 +1593,7 @@ template <typename T>
 void MultibodyPlant<T>::AddInForcesFromInputPorts(
     const drake::systems::Context<T>& context,
     MultibodyForces<T>* forces) const {
+  this->ValidateContext(context);
   AddAppliedExternalGeneralizedForces(context, forces);
   AddAppliedExternalSpatialForces(context, forces);
   AddJointActuationForces(context, forces);
@@ -1587,6 +1602,7 @@ void MultibodyPlant<T>::AddInForcesFromInputPorts(
 template<typename T>
 void MultibodyPlant<T>::AddAppliedExternalGeneralizedForces(
     const systems::Context<T>& context, MultibodyForces<T>* forces) const {
+  this->ValidateContext(context);
   // If there are applied generalized forces, add them in.
   const InputPort<T>& applied_generalized_force_input =
       this->get_input_port(applied_generalized_force_input_port_);
@@ -1601,6 +1617,7 @@ void MultibodyPlant<T>::AddAppliedExternalSpatialForces(
     const systems::Context<T>& context, MultibodyForces<T>* forces) const {
   // Get the mutable applied external spatial forces vector
   // (a.k.a., body force vector).
+  this->ValidateContext(context);
   std::vector<SpatialForce<T>>& F_BBo_W_array = forces->mutable_body_forces();
 
   // Evaluate the input port; if it's not connected, return now.
@@ -1631,6 +1648,7 @@ void MultibodyPlant<T>::AddAppliedExternalSpatialForces(
 template<typename T>
 void MultibodyPlant<T>::AddJointActuationForces(
     const systems::Context<T>& context, MultibodyForces<T>* forces) const {
+  this->ValidateContext(context);
   DRAKE_DEMAND(forces != nullptr);
   if (num_actuators() > 0) {
     const VectorX<T> u = AssembleActuationInput(context);
@@ -1651,6 +1669,7 @@ void MultibodyPlant<T>::AddJointActuationForces(
 template<typename T>
 void MultibodyPlant<T>::AddJointLimitsPenaltyForces(
     const systems::Context<T>& context, MultibodyForces<T>* forces) const {
+  this->ValidateContext(context);
   DRAKE_THROW_UNLESS(is_discrete());
   DRAKE_DEMAND(forces != nullptr);
 
@@ -1698,6 +1717,7 @@ void MultibodyPlant<T>::AddJointLimitsPenaltyForces(
 template<typename T>
 VectorX<T> MultibodyPlant<T>::AssembleActuationInput(
     const systems::Context<T>& context) const {
+  this->ValidateContext(context);
   // Assemble the vector from the model instance input ports.
   VectorX<T> actuation_input(num_actuated_dofs());
   int u_offset = 0;
@@ -1782,6 +1802,7 @@ template <typename T>
 void MultibodyPlant<T>::CalcContactSurfaces(
     const drake::systems::Context<T>& context,
     std::vector<ContactSurface<T>>* contact_surfaces) const {
+  this->ValidateContext(context);
   DRAKE_DEMAND(contact_surfaces);
 
   const auto& query_object = EvalGeometryQueryInput(context);
@@ -1801,6 +1822,7 @@ template <typename T>
 void MultibodyPlant<T>::CalcHydroelasticWithFallback(
     const drake::systems::Context<T>& context,
     internal::HydroelasticFallbackCacheData<T>* data) const {
+  this->ValidateContext(context);
   DRAKE_DEMAND(data != nullptr);
 
   if (num_collision_geometries() > 0) {
@@ -1828,6 +1850,8 @@ template <typename T>
 std::vector<internal::DiscreteContactPair<T>>
 MultibodyPlant<T>::CalcDiscreteContactPairs(
     const systems::Context<T>& context) const {
+  this->ValidateContext(context);
+
   if (num_collision_geometries() == 0) return {};
 
   // Only numeric values are supported. We detect that T is a Drake numeric type
@@ -1898,6 +1922,7 @@ void MultibodyPlant<T>::CalcTamsiResults(
     const drake::systems::Context<T>& context0,
     contact_solvers::internal::ContactSolverResults<T>* results) const {
   // Assert this method was called on a context storing discrete state.
+  this->ValidateContext(context0);
   DRAKE_ASSERT(context0.num_discrete_state_groups() == 1);
   DRAKE_ASSERT(context0.num_continuous_states() == 0);
 
@@ -2140,6 +2165,7 @@ void MultibodyPlant<T>::CallContactSolver(
 template <typename T>
 void MultibodyPlant<T>::CalcGeneralizedContactForcesContinuous(
     const Context<T>& context, VectorX<T>* tau_contact) const {
+  this->ValidateContext(context);
   DRAKE_DEMAND(tau_contact);
   DRAKE_DEMAND(tau_contact->size() == num_velocities());
   DRAKE_DEMAND(!is_discrete());
@@ -2180,6 +2206,7 @@ template <typename T>
 void MultibodyPlant<T>::CalcSpatialContactForcesContinuous(
       const drake::systems::Context<T>& context,
       std::vector<SpatialForce<T>>* F_BBo_W_array) const {
+  this->ValidateContext(context);
   DRAKE_DEMAND(F_BBo_W_array);
   DRAKE_DEMAND(static_cast<int>(F_BBo_W_array->size()) == num_bodies());
   DRAKE_DEMAND(!is_discrete());
@@ -2229,6 +2256,7 @@ void MultibodyPlant<T>::CalcNonContactForces(
     const drake::systems::Context<T>& context,
     bool discrete,
     MultibodyForces<T>* forces) const {
+  this->ValidateContext(context);
   DRAKE_DEMAND(forces != nullptr);
   DRAKE_DEMAND(forces->CheckHasRightSizeForModel(*this));
 
@@ -2245,6 +2273,8 @@ void MultibodyPlant<T>::CalcNonContactForces(
 template <typename T>
 void MultibodyPlant<T>::AddInForcesContinuous(
     const systems::Context<T>& context, MultibodyForces<T>* forces) const {
+  this->ValidateContext(context);
+
   // Forces from MultibodyTree elements are handled in MultibodyTreeSystem;
   // we need only handle MultibodyPlant-specific forces here.
   AddInForcesFromInputPorts(context, forces);
@@ -2262,6 +2292,7 @@ template <typename T>
 void MultibodyPlant<T>::DoCalcForwardDynamicsDiscrete(
     const drake::systems::Context<T>& context0,
     AccelerationKinematicsCache<T>* ac) const {
+  this->ValidateContext(context0);
   DRAKE_DEMAND(ac != nullptr);
   DRAKE_DEMAND(is_discrete());
 
@@ -2289,6 +2320,8 @@ void MultibodyPlant<T>::DoCalcDiscreteVariableUpdates(
     const drake::systems::Context<T>& context0,
     const std::vector<const drake::systems::DiscreteUpdateEvent<T>*>&,
     drake::systems::DiscreteValues<T>* updates) const {
+  this->ValidateContext(context0);
+
   // Get the system state as raw Eigen vectors
   // (solution at the previous time step).
   auto x0 = context0.get_discrete_state(0).get_value();
@@ -2735,6 +2768,7 @@ template <typename T>
 void MultibodyPlant<T>::CopyMultibodyStateOut(
     const Context<T>& context, BasicVector<T>* state_vector) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+  this->ValidateContext(context);
   state_vector->SetFromVector(GetPositionsAndVelocities(context));
 }
 
@@ -2743,6 +2777,7 @@ void MultibodyPlant<T>::CopyMultibodyStateOut(
     ModelInstanceIndex model_instance,
     const Context<T>& context, BasicVector<T>* state_vector) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+  this->ValidateContext(context);
   state_vector->SetFromVector(
       GetPositionsAndVelocities(context, model_instance));
 }
@@ -2883,6 +2918,7 @@ void MultibodyPlant<T>::CalcBodyPosesOutput(
     const Context<T>& context,
     std::vector<math::RigidTransform<T>>* X_WB_all) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+  this->ValidateContext(context);
   X_WB_all->resize(num_bodies());
   for (BodyIndex body_index(0); body_index < this->num_bodies(); ++body_index) {
     const Body<T>& body = get_body(body_index);
@@ -2895,6 +2931,7 @@ void MultibodyPlant<T>::CalcBodySpatialVelocitiesOutput(
     const Context<T>& context,
     std::vector<SpatialVelocity<T>>* V_WB_all) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+  this->ValidateContext(context);
   V_WB_all->resize(num_bodies());
   for (BodyIndex body_index(0); body_index < this->num_bodies(); ++body_index) {
     const Body<T>& body = get_body(body_index);
@@ -2907,6 +2944,7 @@ void MultibodyPlant<T>::CalcBodySpatialAccelerationsOutput(
     const Context<T>& context,
     std::vector<SpatialAcceleration<T>>* A_WB_all) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+  this->ValidateContext(context);
   A_WB_all->resize(num_bodies());
   const AccelerationKinematicsCache<T>& ac = this->EvalForwardDynamics(context);
   for (BodyIndex body_index(0); body_index < this->num_bodies(); ++body_index) {
@@ -2921,7 +2959,9 @@ MultibodyPlant<T>::EvalBodySpatialAccelerationInWorld(
     const Context<T>& context,
     const Body<T>& body_B) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+  this->ValidateContext(context);
   DRAKE_DEMAND(this == &body_B.GetParentPlant());
+  this->ValidateContext(context);
   const AccelerationKinematicsCache<T>& ac = this->EvalForwardDynamics(context);
   return ac.get_A_WB(body_B.node_index());
 }
@@ -2930,6 +2970,7 @@ template <typename T>
 void MultibodyPlant<T>::CalcFramePoseOutput(
     const Context<T>& context, FramePoseVector<T>* poses) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+  this->ValidateContext(context);
   const internal::PositionKinematicsCache<T>& pc =
       EvalPositionKinematics(context);
 
@@ -2955,6 +2996,7 @@ template <typename T>
 void MultibodyPlant<T>::CalcReactionForces(
     const systems::Context<T>& context,
     std::vector<SpatialForce<T>>* F_CJc_Jc_array) const {
+  this->ValidateContext(context);
   DRAKE_DEMAND(F_CJc_Jc_array != nullptr);
   DRAKE_DEMAND(static_cast<int>(F_CJc_Jc_array->size()) == num_joints());
 

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1677,6 +1677,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// correspond to the context for a multibody model.
   Eigen::VectorBlock<const VectorX<T>> GetPositionsAndVelocities(
       const systems::Context<T>& context) const {
+    this->ValidateContext(context);
     return internal_tree().GetPositionsAndVelocities(context);
   }
 
@@ -1690,6 +1691,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   VectorX<T> GetPositionsAndVelocities(
       const systems::Context<T>& context,
       ModelInstanceIndex model_instance) const {
+    this->ValidateContext(context);
     return internal_tree().GetPositionsAndVelocities(context, model_instance);
   }
 
@@ -1703,6 +1705,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// correspond to the context for a multibody model.
   Eigen::VectorBlock<VectorX<T>> GetMutablePositionsAndVelocities(
       systems::Context<T>* context) const {
+    this->ValidateContext(context);
     return internal_tree().GetMutablePositionsAndVelocities(context);
   }
 
@@ -1713,6 +1716,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// `q_v` is not equal to `num_positions() + num_velocities()`.
   void SetPositionsAndVelocities(
       systems::Context<T>* context, const VectorX<T>& q_v) const {
+    this->ValidateContext(context);
     DRAKE_THROW_UNLESS(q_v.size() == (num_positions() + num_velocities()));
     internal_tree().GetMutablePositionsAndVelocities(context) = q_v;
   }
@@ -1726,6 +1730,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   void SetPositionsAndVelocities(
       systems::Context<T>* context, ModelInstanceIndex model_instance,
       const VectorX<T>& q_v) const {
+    this->ValidateContext(context);
     DRAKE_THROW_UNLESS(
         q_v.size() ==
         (num_positions(model_instance) + num_velocities(model_instance)));
@@ -1743,6 +1748,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     // Note: the nestedExpression() is necessary to treat the VectorBlock<T>
     // returned from GetPositionsAndVelocities() as a VectorX<T> so that we can
     // call head() on it.
+    this->ValidateContext(context);
     return GetPositionsAndVelocities(context).nestedExpression().head(
         num_positions());
   }
@@ -1756,6 +1762,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   VectorX<T> GetPositions(
       const systems::Context<T>& context,
       ModelInstanceIndex model_instance) const {
+    this->ValidateContext(context);
     return internal_tree().GetPositionsFromArray(
         model_instance, GetPositions(context));
   }
@@ -1774,6 +1781,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     // Note: the nestedExpression() is necessary to treat the VectorBlock<T>
     // returned from GetMutablePositionsAndVelocities() as a VectorX<T> so that
     // we can call head() on it.
+    this->ValidateContext(context);
     return internal_tree().GetMutablePositionsAndVelocities(context)
         .nestedExpression().head(num_positions());
   }
@@ -1790,6 +1798,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @pre `state` comes from this MultibodyPlant.
   Eigen::VectorBlock<VectorX<T>> GetMutablePositions(
       const systems::Context<T>& context, systems::State<T>* state) const {
+    this->ValidateContext(context);
     DRAKE_ASSERT_VOID(CheckValidState(state));
     // Note: the nestedExpression() is necessary to treat the VectorBlock<T>
     // returned from GetMutablePositionsAndVelocities() as a VectorX<T> so that
@@ -1805,6 +1814,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// not correspond to the context for a multibody model, or if the length of
   /// `q` is not equal to `num_positions()`.
   void SetPositions(systems::Context<T>* context, const VectorX<T>& q) const {
+    this->ValidateContext(context);
     DRAKE_THROW_UNLESS(q.size() == num_positions());
     GetMutablePositions(context) = q;
   }
@@ -1817,6 +1827,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   void SetPositions(
       systems::Context<T>* context,
       ModelInstanceIndex model_instance, const VectorX<T>& q_instance) const {
+    this->ValidateContext(context);
     DRAKE_THROW_UNLESS(q_instance.size() == num_positions(model_instance));
     Eigen::VectorBlock<VectorX<T>> q = GetMutablePositions(context);
     internal_tree().SetPositionsInArray(model_instance, q_instance, &q);
@@ -1831,6 +1842,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   void SetPositions(const systems::Context<T>& context,
                     systems::State<T>* state, ModelInstanceIndex model_instance,
                     const VectorX<T>& q_instance) const {
+    this->ValidateContext(context);
     DRAKE_THROW_UNLESS(q_instance.size() == num_positions(model_instance));
     CheckValidState(state);
     Eigen::VectorBlock<VectorX<T>> q = GetMutablePositions(context, state);
@@ -1845,6 +1857,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     // Note: the nestedExpression() is necessary to treat the VectorBlock<T>
     // returned from GetPositionsAndVelocities() as a VectorX<T> so that we can
     // call tail() on it.
+    this->ValidateContext(context);
     return GetPositionsAndVelocities(context).nestedExpression().tail(
         num_velocities());
   }
@@ -1858,6 +1871,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   VectorX<T> GetVelocities(
       const systems::Context<T>& context,
       ModelInstanceIndex model_instance) const {
+    this->ValidateContext(context);
     return internal_tree().GetVelocitiesFromArray(
         model_instance, GetVelocities(context));
   }
@@ -1874,6 +1888,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @pre `state` comes from this MultibodyPlant.
   Eigen::VectorBlock<VectorX<T>> GetMutableVelocities(
       const systems::Context<T>& context, systems::State<T>* state) const {
+    this->ValidateContext(context);
     DRAKE_ASSERT_VOID(CheckValidState(state));
     // Note: the nestedExpression() is necessary to treat the VectorBlock<T>
     // returned from GetMutablePositionsAndVelocities() as a VectorX<T> so that
@@ -1887,6 +1902,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// See GetMutableVelocities() method above.
   Eigen::VectorBlock<VectorX<T>> GetMutableVelocities(
       systems::Context<T>* context) const {
+    this->ValidateContext(context);
     return GetMutableVelocities(*context, &context->get_mutable_state());
   }
 
@@ -1895,6 +1911,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// not correspond to the context for a multibody model, or if the length of
   /// `v` is not equal to `num_velocities()`.
   void SetVelocities(systems::Context<T>* context, const VectorX<T>& v) const {
+    this->ValidateContext(context);
     DRAKE_THROW_UNLESS(v.size() == num_velocities());
     GetMutableVelocities(context) = v;
   }
@@ -1909,6 +1926,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   void SetVelocities(
       const systems::Context<T>& context, systems::State<T>* state,
       ModelInstanceIndex model_instance, const VectorX<T>& v_instance) const {
+    this->ValidateContext(context);
     DRAKE_THROW_UNLESS(v_instance.size() == num_velocities(model_instance));
     CheckValidState(state);
     Eigen::VectorBlock<VectorX<T>> v = GetMutableVelocities(context, state);
@@ -1924,6 +1942,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   void SetVelocities(
       systems::Context<T>* context,
       ModelInstanceIndex model_instance, const VectorX<T>& v_instance) const {
+    this->ValidateContext(context);
     DRAKE_THROW_UNLESS(v_instance.size() == num_velocities(model_instance));
     Eigen::VectorBlock<VectorX<T>> v = GetMutableVelocities(context);
     internal_tree().SetVelocitiesInArray(model_instance, v_instance, &v);
@@ -1937,6 +1956,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   void SetDefaultState(const systems::Context<T>& context,
                        systems::State<T>* state) const override {
     DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+    this->ValidateContext(context);
     CheckValidState(state);
     internal_tree().SetDefaultState(context, state);
     for (const BodyIndex& index : GetFloatingBaseBodies()) {
@@ -1956,6 +1976,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
                       systems::State<T>* state,
                       RandomGenerator* generator) const override {
     DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+    this->ValidateContext(context);
     CheckValidState(state);
     internal_tree().SetRandomState(context, state, generator);
   }
@@ -2069,6 +2090,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception if called pre-finalize.
   math::RigidTransform<T> GetFreeBodyPose(const systems::Context<T>& context,
                                           const Body<T>& body) const {
+    this->ValidateContext(context);
     return internal_tree().GetFreeBodyPoseOrThrow(context, body);
   }
 
@@ -2081,6 +2103,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception if called pre-finalize.
   void SetFreeBodyPose(systems::Context<T>* context, const Body<T>& body,
                        const math::RigidTransform<T>& X_WB) const {
+    this->ValidateContext(context);
     internal_tree().SetFreeBodyPoseOrThrow(body, X_WB, context);
   }
 
@@ -2095,6 +2118,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   void SetFreeBodyPose(
       const systems::Context<T>& context, systems::State<T>* state,
       const Body<T>& body, const math::RigidTransform<T>& X_WB) const {
+    this->ValidateContext(context);
     CheckValidState(state);
     internal_tree().SetFreeBodyPoseOrThrow(body, X_WB, context, state);
   }
@@ -2129,6 +2153,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   void SetFreeBodySpatialVelocity(
       systems::Context<T>* context, const Body<T>& body,
       const SpatialVelocity<T>& V_WB) const {
+    this->ValidateContext(context);
     internal_tree().SetFreeBodySpatialVelocityOrThrow(body, V_WB, context);
   }
 
@@ -2143,6 +2168,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   void SetFreeBodySpatialVelocity(
       const systems::Context<T>& context, systems::State<T>* state,
       const Body<T>& body, const SpatialVelocity<T>& V_WB) const {
+    this->ValidateContext(context);
     CheckValidState(state);
     internal_tree().SetFreeBodySpatialVelocityOrThrow(
         body, V_WB, context, state);
@@ -2228,6 +2254,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   const math::RigidTransform<T>& EvalBodyPoseInWorld(
       const systems::Context<T>& context,
       const Body<T>& body_B) const {
+    this->ValidateContext(context);
     return internal_tree().EvalBodyPoseInWorld(context, body_B);
   }
 
@@ -2243,6 +2270,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   const SpatialVelocity<T>& EvalBodySpatialVelocityInWorld(
       const systems::Context<T>& context,
       const Body<T>& body_B) const {
+    this->ValidateContext(context);
     return internal_tree().EvalBodySpatialVelocityInWorld(context, body_B);
   }
 
@@ -2275,6 +2303,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   const std::vector<geometry::PenetrationAsPointPair<T>>&
   EvalPointPairPenetrations(const systems::Context<T>& context) const {
     DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+    this->ValidateContext(context);
     switch (contact_model_) {
       case ContactModel::kPointContactOnly:
         return this->get_cache_entry(cache_indexes_.point_pairs)
@@ -2308,6 +2337,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const systems::Context<T>& context,
       const Frame<T>& frame_F,
       const Frame<T>& frame_G) const {
+    this->ValidateContext(context);
     return internal_tree().CalcRelativeTransform(context, frame_F, frame_G);
   }
 
@@ -2325,6 +2355,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const systems::Context<T>& context,
       const Frame<T>& frame_F,
       const Frame<T>& frame_G) const {
+    this->ValidateContext(context);
     return internal_tree().CalcRelativeRotationMatrix(context,
                                                       frame_F, frame_G);
   }
@@ -2364,6 +2395,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const Eigen::Ref<const MatrixX<T>>& p_BQi,
       const Frame<T>& frame_A,
       EigenPtr<MatrixX<T>> p_AQi) const {
+    this->ValidateContext(context);
     DRAKE_DEMAND(p_AQi != nullptr);
     return internal_tree().CalcPointsPositions(
         context, frame_B, p_BQi, frame_A, p_AQi);
@@ -2385,6 +2417,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception if `composite_mass <= 0`.
   Vector3<T> CalcCenterOfMassPosition(
       const systems::Context<T>& context) const {
+    this->ValidateContext(context);
     return internal_tree().CalcCenterOfMassPosition(context);
   }
 
@@ -2410,6 +2443,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   Vector3<T> CalcCenterOfMassPosition(
       const systems::Context<T>& context,
       const std::vector<ModelInstanceIndex>& model_instances) const {
+    this->ValidateContext(context);
     return internal_tree().CalcCenterOfMassPosition(context, model_instances);
   }
 
@@ -2431,6 +2465,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   SpatialMomentum<T> CalcSpatialMomentumInWorldAboutPoint(
       const systems::Context<T>& context,
       const Vector3<T>& p_WoP_W) const {
+    this->ValidateContext(context);
     return internal_tree().CalcSpatialMomentumInWorldAboutPoint(context,
                                                                 p_WoP_W);
   }
@@ -2465,6 +2500,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const systems::Context<T>& context,
       const std::vector<ModelInstanceIndex>& model_instances,
       const Vector3<T>& p_WoP_W) const {
+    this->ValidateContext(context);
     return internal_tree().CalcSpatialMomentumInWorldAboutPoint(context,
         model_instances, p_WoP_W);
   }
@@ -2532,6 +2568,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const systems::Context<T>& context,
       const VectorX<T>& known_vdot,
       const MultibodyForces<T>& external_forces) const {
+    this->ValidateContext(context);
     return internal_tree().CalcInverseDynamics(
         context, known_vdot, external_forces);
   }
@@ -2579,6 +2616,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   ///   therefore to a decrease of the gravitational potential energy.
   VectorX<T> CalcGravityGeneralizedForces(
       const systems::Context<T>& context) const {
+    this->ValidateContext(context);
     return internal_tree().CalcGravityGeneralizedForces(context);
   }
 
@@ -2608,6 +2646,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const systems::Context<T>& context,
       const Eigen::Ref<const VectorX<T>>& v,
       EigenPtr<VectorX<T>> qdot) const {
+    this->ValidateContext(context);
     DRAKE_DEMAND(qdot != nullptr);
     return internal_tree().MapVelocityToQDot(context, v, qdot);
   }
@@ -2641,6 +2680,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const systems::Context<T>& context,
       const Eigen::Ref<const VectorX<T>>& qdot,
       EigenPtr<VectorX<T>> v) const {
+    this->ValidateContext(context);
     DRAKE_DEMAND(v != nullptr);
     internal_tree().MapQDotToVelocity(context, qdot, v);
   }
@@ -2693,6 +2733,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// mass matrix whenever possible.
   void CalcMassMatrixViaInverseDynamics(
       const systems::Context<T>& context, EigenPtr<MatrixX<T>> M) const {
+    this->ValidateContext(context);
     DRAKE_DEMAND(M != nullptr);
     internal_tree().CalcMassMatrixViaInverseDynamics(context, M);
   }
@@ -2714,6 +2755,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// mass matrix whenever possible.
   void CalcMassMatrix(const systems::Context<T>& context,
                       EigenPtr<MatrixX<T>> M) const {
+    this->ValidateContext(context);
     DRAKE_DEMAND(M != nullptr);
     internal_tree().CalcMassMatrix(context, M);
   }
@@ -2740,6 +2782,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   ///   proper size.
   void CalcBiasTerm(
       const systems::Context<T>& context, EigenPtr<VectorX<T>> Cv) const {
+    this->ValidateContext(context);
     DRAKE_DEMAND(Cv != nullptr);
     internal_tree().CalcBiasTerm(context, Cv);
   }
@@ -2788,6 +2831,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const Frame<T>& frame_A,
       const Frame<T>& frame_E) const {
     // TODO(Mitiguy) Allow with_respect_to to be JacobianWrtVariable::kQDot.
+    this->ValidateContext(context);
     return internal_tree().CalcBiasTranslationalAcceleration(
         context, with_respect_to, frame_B, p_BoBi_B, frame_A, frame_E);
   }
@@ -2832,6 +2876,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const Frame<T>& frame_A,
       const Frame<T>& frame_E) const {
     // TODO(Mitiguy) Allow with_respect_to to be JacobianWrtVariable::kQDot.
+    this->ValidateContext(context);
     return internal_tree().CalcBiasSpatialAcceleration(
         context, with_respect_to, frame_B, p_BoBp_B, frame_A, frame_E);
   }
@@ -2883,6 +2928,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
                                    const Frame<T>& frame_A,
                                    const Frame<T>& frame_E,
                                    EigenPtr<MatrixX<T>> Js_V_ABp_E) const {
+    this->ValidateContext(context);
     DRAKE_DEMAND(Js_V_ABp_E != nullptr);
     internal_tree().CalcJacobianSpatialVelocity(context, with_respect_to,
                                                 frame_B, p_BoBp_B, frame_A,
@@ -2920,6 +2966,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
                                    const Frame<T>& frame_A,
                                    const Frame<T>& frame_E,
                                    EigenPtr<Matrix3X<T>> Js_w_AB_E) const {
+    this->ValidateContext(context);
     DRAKE_DEMAND(Js_w_AB_E != nullptr);
     return internal_tree().CalcJacobianAngularVelocity(
         context, with_respect_to, frame_B, frame_A, frame_E, Js_w_AB_E);
@@ -2970,6 +3017,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       EigenPtr<MatrixX<T>> Js_v_ABi_E) const {
     // TODO(amcastro-tri): provide the Jacobian-times-vector operation.  For
     // some applications it is all we need and it is more efficient to compute.
+    this->ValidateContext(context);
     DRAKE_DEMAND(Js_v_ABi_E != nullptr);
     internal_tree().CalcJacobianTranslationalVelocity(
         context, with_respect_to, frame_B, frame_B, p_BoBi_B, frame_A, frame_E,
@@ -3005,6 +3053,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       EigenPtr<Matrix3X<T>> Js_v_ACcm_E) const {
     // TODO(yangwill): Add an optional parameter to calculate this for a
     // subset of bodies instead of the full system
+    this->ValidateContext(context);
     DRAKE_DEMAND(Js_v_ACcm_E != nullptr);
     internal_tree().CalcJacobianCenterOfMassTranslationalVelocity(
         context, with_respect_to, frame_A, frame_E, Js_v_ACcm_E);
@@ -3037,6 +3086,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const Frame<T>& frame_A, const Frame<T>& frame_E) const {
     // TODO(yangwill): Add an optional parameter to calculate this for a
     // subset of bodies instead of the full system
+    this->ValidateContext(context);
     return internal_tree().CalcBiasCenterOfMassTranslationalAcceleration(
         context, with_respect_to, frame_A, frame_E);
   }
@@ -3761,6 +3811,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // geometry_query_input_port is not connected, but is expected to be.
   const geometry::QueryObject<T>& EvalGeometryQueryInput(
       const systems::Context<T>& context) const {
+    this->ValidateContext(context);
     if (!get_geometry_query_input_port().HasValue(context)) {
       throw std::logic_error(
           "The geometry query input port (see "
@@ -3952,6 +4003,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // Eval version of the method CalcContactSurfaces().
   const std::vector<geometry::ContactSurface<T>>& EvalContactSurfaces(
       const systems::Context<T>& context) const {
+    this->ValidateContext(context);
     switch (contact_model_) {
       case ContactModel::kHydroelasticWithFallback: {
         const auto& data =
@@ -4267,6 +4319,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   const internal::ContactJacobians<T>& EvalContactJacobians(
       const systems::Context<T>& context) const {
     DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+    this->ValidateContext(context);
     return this->get_cache_entry(cache_indexes_.contact_jacobians)
         .template Eval<internal::ContactJacobians<T>>(context);
   }

--- a/multibody/plant/test/multibody_plant_reflected_inertia_test.cc
+++ b/multibody/plant/test/multibody_plant_reflected_inertia_test.cc
@@ -272,7 +272,7 @@ TEST_F(MultibodyPlantReflectedInertiaTests, CalcKineticEnergyAndMomentum) {
   const SpatialMomentum<double> L_W =
       plant_.CalcSpatialMomentumInWorldAboutPoint(*context_, p_WoWo_W);
   const SpatialMomentum<double> L_W_ri =
-      plant_ri_.CalcSpatialMomentumInWorldAboutPoint(*context_, p_WoWo_W);
+      plant_ri_.CalcSpatialMomentumInWorldAboutPoint(*context_ri_, p_WoWo_W);
   EXPECT_TRUE(
       CompareMatrices(L_W.get_coeffs(), L_W_ri.get_coeffs(), kTolerance));
 }


### PR DESCRIPTION
We have a very common recurring hazard in student workflows -- they pass a diagram context into a multibodyplant method (via pydrake) and the python kernel crashes.  This PR aims to address it.

(I caught one recent failure in a test on master, too).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14389)
<!-- Reviewable:end -->
