### PR TITLE
setup: explicitly add six for cpplint

### DIFF
--- a/setup/mac/source_distribution/requirements-test-only.txt
+++ b/setup/mac/source_distribution/requirements-test-only.txt
@@ -1,2 +1,3 @@
 jupyter
 pandas
+six

--- a/setup/ubuntu/source_distribution/packages-bionic-test-only.txt
+++ b/setup/ubuntu/source_distribution/packages-bionic-test-only.txt
@@ -8,6 +8,7 @@ python3-nbformat
 python3-numpy-dbg
 python3-pandas
 python3-scipy-dbg
+python3-six
 python3-tk-dbg
 python3-yaml-dbg
 python3-zmq-dbg

--- a/setup/ubuntu/source_distribution/packages-focal-test-only.txt
+++ b/setup/ubuntu/source_distribution/packages-focal-test-only.txt
@@ -9,6 +9,7 @@ python3-nbformat
 python3-numpy-dbg
 python3-pandas
 python3-scipy-dbg
+python3-six
 python3-tk-dbg
 python3-yaml-dbg
 python3-zmq-dbg


### PR DESCRIPTION
At least on Mac we are no longer getting `six` transitively. We may still be fine on Linux, but does not hurt to be explicit. Looks like it would be easy to exorcise `six` from the tool without causing additional conflicts of any substance., but I don't have time for that at present.

(see https://github.com/RobotLocomotion/styleguide/blob/4b76baf0fdf78154c3b72cdd713c2247d2a43e3a/cpplint/cpplint.py#L56-L58)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14390)
<!-- Reviewable:end -->
