### PR TITLE
workspace: warn instead of error for macOS Big Sur

### DIFF
--- a/tools/workspace/os.bzl
+++ b/tools/workspace/os.bzl
@@ -109,7 +109,12 @@ def _determine_macos(repository_ctx):
     macos_release = ".".join(major_minor_versions)
 
     # Match supported macOS release(s).
-    if macos_release in ["10.15"]:
+    if macos_release in ["10.15", "11.0"]:
+        if macos_release == "11.0":
+            print(
+                "WARNING: macOS Big Sur 11.0 is NOT yet supported. " +
+                "Compilation, tests, and/or other functionality may fail.",
+            )
         return _make_result(macos_release = macos_release)
 
     # Nothing matched.


### PR DESCRIPTION
Relates #13648. I am not doing anything to fix the several errors anytime soon, unfortunately, but this at least does not put up an artificial block if someone wants to help me out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14391)
<!-- Reviewable:end -->
