### PR TITLE
setup: add double-conversion, sqlite3, and lzma for vtk

### DIFF
--- a/setup/mac/binary_distribution/Brewfile
+++ b/setup/mac/binary_distribution/Brewfile
@@ -7,6 +7,7 @@ tap 'robotlocomotion/director'
 cask 'adoptopenjdk' unless system '/usr/libexec/java_home --version 1.8+ --failfast &> /dev/null'
 
 brew 'cmake'
+brew 'double-conversion'
 brew 'dreal-deps/ibex/ibex@2.7.4'  # N.B. Matches drake/tools/workspace/ibex/version.bzl.
 brew 'eigen'
 brew 'gcc'
@@ -27,6 +28,7 @@ brew 'suite-sparse'
 brew 'tinyxml'
 brew 'tinyxml2'
 brew 'robotlocomotion/director/vtk@8.2'
+brew 'xz'
 brew 'yaml-cpp'
 brew 'zeromq'
 

--- a/setup/ubuntu/binary_distribution/packages-bionic.txt
+++ b/setup/ubuntu/binary_distribution/packages-bionic.txt
@@ -7,6 +7,7 @@ libamd2
 libblas3
 libboost-all-dev
 libbz2-1.0
+libdouble-conversion1
 libeigen3-dev
 libexpat1
 libfreetype6
@@ -21,6 +22,8 @@ libjpeg-turbo8
 libjsoncpp1
 liblapack3
 libldl2
+liblz4-1
+liblzma5
 libmumps-seq-5.1.2
 libnetcdf13
 libnlopt0
@@ -32,6 +35,7 @@ libqt5gui5
 libqt5printsupport5
 libqt5widgets5
 libquadmath0
+libsqlite3-0
 libtbb2
 libtheora0
 libtiff5

--- a/setup/ubuntu/binary_distribution/packages-focal.txt
+++ b/setup/ubuntu/binary_distribution/packages-focal.txt
@@ -6,6 +6,7 @@ jupyter-notebook
 libamd2
 libblas3
 libbz2-1.0
+libdouble-conversion3
 libeigen3-dev
 libexpat1
 libfreetype6
@@ -21,6 +22,7 @@ libjsoncpp1
 liblapack3
 libldl2
 liblz4-1
+liblzma5
 libmumps-seq-5.2.1
 libnetcdf15
 libnlopt-cxx0
@@ -32,6 +34,7 @@ libqt5gui5
 libqt5printsupport5
 libqt5widgets5
 libquadmath0
+libsqlite3-0
 libtbb2
 libtheora0
 libtiff5

--- a/setup/ubuntu/source_distribution/packages-bionic.txt
+++ b/setup/ubuntu/source_distribution/packages-bionic.txt
@@ -10,6 +10,7 @@ git
 libblas-dev
 libbz2-dev
 libclang-9-dev
+libdouble-conversion-dev
 libexpat1-dev
 libgflags-dev
 libgl1-mesa-dev
@@ -19,6 +20,7 @@ libjpeg-turbo8-dev
 libjsoncpp-dev
 liblapack-dev
 liblz4-dev
+liblzma-dev
 libmumps-seq-dev
 libnlopt-dev
 libpng-dev

--- a/setup/ubuntu/source_distribution/packages-focal.txt
+++ b/setup/ubuntu/source_distribution/packages-focal.txt
@@ -10,6 +10,7 @@ git
 libblas-dev
 libbz2-dev
 libclang-9-dev
+libdouble-conversion-dev
 libexpat1-dev
 libgflags-dev
 libgl-dev
@@ -20,6 +21,7 @@ libjpeg-turbo8-dev
 libjsoncpp-dev
 liblapack-dev
 liblz4-dev
+liblzma-dev
 libmumps-seq-dev
 libnlopt-cxx-dev
 libopengl-dev


### PR DESCRIPTION
Relates in part #14339 and in part continued Mac Python 3.8 support. Ultimately will resolve a few TODOs in the `vtk` `repository.bzl` and shift some of the compilation time onto Homebrew and Ubuntu. Note that `libtbb2` needs to be removed, but that would require the rebuild of `vtk` to be in this commit. Part 1 of either 2 or 3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14392)
<!-- Reviewable:end -->
