### PR TITLE
parsing: Add support for SDFormat 1.8 model composition

### DIFF
--- a/multibody/parsing/detail_scene_graph.cc
+++ b/multibody/parsing/detail_scene_graph.cc
@@ -87,6 +87,10 @@ std::unique_ptr<geometry::Shape> MakeShapeFromSdfGeometry(
 
   switch (sdf_geometry.Type()) {
     case sdf::GeometryType::EMPTY: {
+      // TODO(azeey): We should deprecate use of <drake:capsule> and
+      // <drake:ellipsoid> per
+      // https://github.com/RobotLocomotion/drake/issues/14837
+
       // Check for custom geometry tags, e.g. drake:capsule.
       if (sdf_geometry.Element()->HasElement("drake:capsule")) {
         const sdf::ElementPtr capsule_element =

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -42,6 +42,45 @@ using std::unique_ptr;
 
 // Unnamed namespace for free functions local to this file.
 namespace {
+
+// Given a @p relative_nested_name to an object, this function returns the model
+// instance that is an immediate parent of the object and the local name of the
+// object. The local name of the object does not have any scoping delimiters.
+//
+// @param[in] relative_nested_name
+//   The name of the object in the scope of the model associated with the given
+//   @p model_instance. The relative nested name can contain the scope delimiter
+//   to reference objects nested in child models.
+// @param[in] model_instance
+//   The model instance in whose scope @p relative_nested_name is defined.
+// @param[in] plant
+//   The MultibodyPlant object that contains the model instance identified by @p
+//   model_instance.
+// @returns A pair containing the resolved model instance and the local name of
+// the object referenced by @p relative_nested_name.
+std::pair<ModelInstanceIndex, std::string> GetResolvedModelInstanceAndLocalName(
+    const std::string& relative_nested_name, ModelInstanceIndex model_instance,
+    const MultibodyPlant<double>& plant) {
+  auto [parent_name, unscoped_local_name] =
+      sdf::SplitName(relative_nested_name);
+  ModelInstanceIndex resolved_model_instance = model_instance;
+
+  if (!parent_name.empty()) {
+    // If the parent is in the world_model_instance, the name can be looked up
+    // from the plant without creating an absolute name.
+    if (world_model_instance() == model_instance) {
+      resolved_model_instance = plant.GetModelInstanceByName(parent_name);
+    } else {
+      const std::string parent_model_absolute_name = sdf::JoinName(
+          plant.GetModelInstanceName(model_instance), parent_name);
+
+      resolved_model_instance =
+        plant.GetModelInstanceByName(parent_model_absolute_name);
+    }
+  }
+
+  return {resolved_model_instance, unscoped_local_name};
+}
 // Given an ignition::math::Inertial object, extract a RotationalInertia object
 // for the rotational inertia of body B, about its center of mass Bcm and,
 // expressed in the inertial frame Bi (as specified in <inertial> in the SDF
@@ -70,7 +109,7 @@ void ThrowIfPoseFrameSpecified(sdf::ElementPtr element) {
     if (!frame_name.empty()) {
       throw std::runtime_error(
           "<pose relative_to='{non-empty}'/> is presently not supported "
-          "in <inertial/> or <model/> tags.");
+          "in <inertial/> or top-level <model/> tags in model files.");
     }
   }
 }
@@ -100,6 +139,17 @@ Eigen::Vector3d ResolveAxisXyz(const sdf::JointAxis& axis) {
   ignition::math::Vector3d xyz;
   ThrowAnyErrors(axis.ResolveXyz(xyz));
   return ToVector3(xyz);
+}
+
+std::string ResolveJointParentLinkName(const sdf::Joint& joint) {
+  std::string link;
+  ThrowAnyErrors(joint.ResolveParentLink(link));
+  return link;
+}
+std::string ResolveJointChildLinkName(const sdf::Joint& joint) {
+  std::string link;
+  ThrowAnyErrors(joint.ResolveChildLink(link));
+  return link;
 }
 
 // Helper method to extract the SpatialInertia M_BBo_B of body B, about its body
@@ -145,7 +195,7 @@ SpatialInertia<double> ExtractSpatialInertiaAboutBoExpressedInB(
 
 // Helper method to retrieve a Body given the name of the link specification.
 const Body<double>& GetBodyByLinkSpecificationName(
-    const sdf::Model& model, const std::string& link_name,
+    const std::string& link_name,
     ModelInstanceIndex model_instance, const MultibodyPlant<double>& plant) {
   // SDF's convention to indicate a joint is connected to the world is to either
   // name the corresponding link "world" or just leave it unnamed.
@@ -153,13 +203,10 @@ const Body<double>& GetBodyByLinkSpecificationName(
   if (link_name.empty() || link_name == "world") {
     return plant.world_body();
   } else {
-    // TODO(amcastro-tri): Remove this when sdformat guarantees a model
-    // with basic structural checks.
-    if (!model.LinkNameExists(link_name)) {
-      throw std::logic_error("There is no parent link named '" +
-          link_name + "' in the model.");
-    }
-    return plant.GetBodyByName(link_name, model_instance);
+    const auto [parent_model_instance, local_name] =
+        GetResolvedModelInstanceAndLocalName(link_name, model_instance, plant);
+
+    return plant.GetBodyByName(local_name, parent_model_instance);
   }
 }
 
@@ -343,9 +390,9 @@ void AddJointFromSpecification(
     MultibodyPlant<double>* plant,
     std::set<sdf::JointType>* joint_types) {
   const Body<double>& parent_body = GetBodyByLinkSpecificationName(
-      model_spec, joint_spec.ParentLinkName(), model_instance, *plant);
+      ResolveJointParentLinkName(joint_spec), model_instance, *plant);
   const Body<double>& child_body = GetBodyByLinkSpecificationName(
-      model_spec, joint_spec.ChildLinkName(), model_instance, *plant);
+      ResolveJointChildLinkName(joint_spec), model_instance, *plant);
 
   // Get the pose of frame J in the frame of the child link C, as specified in
   // <joint> <pose> ... </pose></joint>. The default `relative_to` pose of a
@@ -579,15 +626,16 @@ const Frame<double>& AddFrameFromSpecification(
     const sdf::Frame& frame_spec, ModelInstanceIndex model_instance,
     const Frame<double>& default_frame, MultibodyPlant<double>* plant) {
   const Frame<double>* parent_frame{};
-  // TODO(eric.cousineau): Without supplying AttachedTo(), this ResolvePose
-  // call fails. Debug why.
   const RigidTransformd X_PF = ResolveRigidTransform(
       frame_spec.SemanticPose(), frame_spec.AttachedTo());
   if (frame_spec.AttachedTo().empty()) {
     parent_frame = &default_frame;
   } else {
+    const auto [parent_model_instance, local_name] =
+        GetResolvedModelInstanceAndLocalName(frame_spec.AttachedTo(),
+                                           model_instance, *plant);
     parent_frame = &plant->GetFrameByName(
-        frame_spec.AttachedTo(), model_instance);
+        local_name, parent_model_instance);
   }
   const Frame<double>& frame =
       plant->AddFrame(std::make_unique<FixedOffsetFrame<double>>(
@@ -699,45 +747,88 @@ bool AreWelded(
 
 // Helper method to add a model to a MultibodyPlant given an sdf::Model
 // specification object.
-ModelInstanceIndex AddModelFromSpecification(
+std::vector<ModelInstanceIndex> AddModelsFromSpecification(
     const sdf::Model& model,
     const std::string& model_name,
+    const RigidTransformd& X_WP,
     MultibodyPlant<double>* plant,
     const PackageMap& package_map,
-    const std::string& root_dir) {
+    const std::string& root_dir,
+    bool is_nested = false) {
   const ModelInstanceIndex model_instance =
     plant->AddModelInstance(model_name);
 
-  // TODO(eric.cousineau): Ensure this generalizes to cases when the parent
-  // frame is not the world. At present, we assume the parent frame is the
-  // world.
-  ThrowIfPoseFrameSpecified(model.Element());
-  const RigidTransformd X_WM = ToRigidTransform(model.RawPose());
+  std::vector <ModelInstanceIndex> added_model_instances{model_instance};
+
+  // "P" is the parent frame. If the model is in a child of //world or //sdf,
+  // this will be the world frame. Otherwise, this will be the parent model
+  // frame.
+  const RigidTransformd X_PM = ResolveRigidTransform(model.SemanticPose());
+  const RigidTransformd X_WM = X_WP * X_PM;
+
+  // Add nested models at root-level of <model>.
+  // Do this before the resolving canonical link because the link might be in a
+  // nested model.
+  drake::log()->trace("sdf_parser: Add nested models");
+  for (uint64_t model_index = 0; model_index < model.ModelCount();
+       ++model_index) {
+    const sdf::Model& nested_model = *model.ModelByIndex(model_index);
+    std::vector<ModelInstanceIndex> nested_model_instances =
+        AddModelsFromSpecification(
+            nested_model, sdf::JoinName(model_name, nested_model.Name()), X_WM,
+            plant, package_map, root_dir, true);
+
+    DRAKE_DEMAND(!nested_model_instances.empty());
+    const ModelInstanceIndex nested_model_instance =
+        nested_model_instances.front();
+
+    plant->AddFrame(std::make_unique<FixedOffsetFrame<double>>(
+        nested_model.Name(),
+        plant->GetFrameByName("__model__", nested_model_instance),
+        RigidTransformd::Identity(), model_instance));
+
+    added_model_instances.insert(added_model_instances.end(),
+                                 nested_model_instances.begin(),
+                                 nested_model_instances.end());
+  }
 
   drake::log()->trace("sdf_parser: Add links");
   std::vector<LinkInfo> added_link_infos = AddLinksFromSpecification(
       model_instance, model, X_WM, plant, package_map, root_dir);
 
-  drake::log()->trace("sdf_parser: Resolve canonical link");
-  std::string canonical_link_name = model.CanonicalLinkName();
-  if (canonical_link_name.empty()) {
-    // TODO(eric.cousineau): Should libsdformat auto-resolve this?
-    DRAKE_THROW_UNLESS(model.LinkCount() > 0);
-    canonical_link_name = model.LinkByIndex(0)->Name();
-  }
-  const Frame<double>& canonical_link_frame = plant->GetFrameByName(
-      canonical_link_name, model_instance);
-  const RigidTransformd X_MLc = ResolveRigidTransform(
-      model.LinkByName(canonical_link_name)->SemanticPose());
-
   // Add the SDF "model frame" given the model name so that way any frames added
   // to the plant are associated with this current model instance.
   // N.B. This follows SDFormat's convention.
   const std::string sdf_model_frame_name = "__model__";
-  const Frame<double>& model_frame =
-      plant->AddFrame(std::make_unique<FixedOffsetFrame<double>>(
-          sdf_model_frame_name, canonical_link_frame, X_MLc.inverse(),
-          model_instance));
+
+  drake::log()->trace("sdf_parser: Resolve canonical link");
+  const Frame<double>& model_frame = [&]() -> const Frame<double>& {
+    const auto [canonical_link, canonical_link_name] =
+        model.CanonicalLinkAndRelativeName();
+
+    if (canonical_link != nullptr) {
+      const auto [parent_model_instance, local_name] =
+          GetResolvedModelInstanceAndLocalName(canonical_link_name,
+                                             model_instance, *plant);
+      const Frame<double>& canonical_link_frame =
+          plant->GetFrameByName(local_name, parent_model_instance);
+      const RigidTransformd X_LcM = ResolveRigidTransform(
+          model.SemanticPose(),
+          sdf::JoinName(model.Name(), canonical_link_name));
+
+      return plant->AddFrame(std::make_unique<FixedOffsetFrame<double>>(
+          sdf_model_frame_name, canonical_link_frame, X_LcM, model_instance));
+    } else {
+      return plant->AddFrame(std::make_unique<FixedOffsetFrame<double>>(
+          sdf_model_frame_name, plant->world_frame(), X_WM, model_instance));
+    }
+  }();
+
+  if (!is_nested) {
+    plant->AddFrame(std::make_unique<FixedOffsetFrame<double>>(
+        model_name, model_frame, RigidTransformd::Identity(),
+        world_model_instance()));
+  }
 
   drake::log()->trace("sdf_parser: Add joints");
   // Add all the joints
@@ -805,7 +896,7 @@ ModelInstanceIndex AddModelFromSpecification(
     }
   }
 
-  return model_instance;
+  return added_model_instances;
 }
 
 }  // namespace
@@ -836,6 +927,10 @@ ModelInstanceIndex AddModelFromSdf(
   // Get the only model in the file.
   const sdf::Model& model = *root.Model();
 
+  // //sdf/model/pose/@relative_to is invalid. Note, libsdformat should emit an
+  // error during Load, but currently doesn't. See sdformat#567
+  ThrowIfPoseFrameSpecified(model.Element());
+
   if (scene_graph != nullptr && !plant->geometry_source_is_registered()) {
     plant->RegisterAsSourceForSceneGraph(scene_graph);
   }
@@ -843,8 +938,12 @@ ModelInstanceIndex AddModelFromSdf(
   const std::string model_name =
       model_name_in.empty() ? model.Name() : model_name_in;
 
-  return AddModelFromSpecification(
-      model, model_name, plant, package_map, root_dir);
+  std::vector<ModelInstanceIndex> added_model_instances =
+      AddModelsFromSpecification(model, model_name, {}, plant, package_map,
+                                 root_dir);
+
+  DRAKE_DEMAND(!added_model_instances.empty());
+  return added_model_instances.front();
 }
 
 std::vector<ModelInstanceIndex> AddModelsFromSdf(
@@ -906,8 +1005,16 @@ std::vector<ModelInstanceIndex> AddModelsFromSdf(
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
       const sdf::Model& model = *root.ModelByIndex(i);
 #pragma GCC diagnostic pop
-      model_instances.push_back(AddModelFromSpecification(
-            model, model.Name(), plant, package_map, root_dir));
+      // //sdf/model/pose/@relative_to is invalid. Note, libsdformat should emit
+      // an error during Load, but currently doesn't. See sdformat#567
+      ThrowIfPoseFrameSpecified(model.Element());
+
+      std::vector<ModelInstanceIndex> added_model_instances =
+          AddModelsFromSpecification(model, model.Name(), {}, plant,
+                                     package_map, root_dir);
+      model_instances.insert(model_instances.end(),
+                             added_model_instances.begin(),
+                             added_model_instances.end());
     }
   } else {
     // Load the world and all the models in the world.
@@ -916,19 +1023,23 @@ std::vector<ModelInstanceIndex> AddModelsFromSdf(
     // TODO(eric.cousineau): Either support or explicitly prevent adding joints
     // via `//world/joint`, per this Bitbucket comment: https://bit.ly/2udQxhp
 
+    for (uint64_t model_index = 0; model_index < world.ModelCount();
+        ++model_index) {
+      // Get the model.
+      const sdf::Model& model = *world.ModelByIndex(model_index);
+      std::vector<ModelInstanceIndex> added_model_instances =
+          AddModelsFromSpecification(model, model.Name(), {}, plant,
+                                     package_map, root_dir);
+      model_instances.insert(model_instances.end(),
+                             added_model_instances.begin(),
+                             added_model_instances.end());
+    }
+
     for (uint64_t frame_index = 0; frame_index < world.FrameCount();
         ++frame_index) {
       const sdf::Frame& frame = *world.FrameByIndex(frame_index);
       AddFrameFromSpecification(
           frame, world_model_instance(), plant->world_frame(), plant);
-    }
-
-    for (uint64_t model_index = 0; model_index < world.ModelCount();
-        ++model_index) {
-      // Get the model.
-      const sdf::Model& model = *world.ModelByIndex(model_index);
-      model_instances.push_back(AddModelFromSpecification(
-            model, model.Name(), plant, package_map, root_dir));
     }
   }
 

--- a/multibody/parsing/parser.h
+++ b/multibody/parsing/parser.h
@@ -36,37 +36,43 @@ class Parser final {
   /// Parses the SDF or URDF file named in @p file_name and adds all of its
   /// model(s) to @p plant.
   ///
-  /// SDF files may contain multiple `<model>` elements.  New model instances
-  /// will be added to @p plant for each `<model>` tag in the file.
+  /// SDFormat files may contain multiple `<model>` elements.  New model
+  /// instances will be added to @p plant for each `<model>` tag in the file.
+  ///
+  /// @note Adding multiple root-level models, i.e, `<model>`s direclty under
+  /// `<sdf>`, is deprecated. If you need multiple models in a single file,
+  /// please use an SDFormat world file.
   ///
   /// URDF files contain a single `<robot>` element.  Only a single model
   /// instance will be added to @p plant.
   ///
   /// @param file_name The name of the SDF or URDF file to be parsed.  The file
   ///   type will be inferred from the extension.
-  /// @returns The set of model instance indices for the newly added models.
+  /// @returns The set of model instance indices for the newly added models,
+  /// including nested models.
   /// @throws std::exception in case of errors.
   std::vector<ModelInstanceIndex> AddAllModelsFromFile(
       const std::string& file_name);
 
-  /// Parses the SDF or URDF file named in @p file_name and adds one model to
-  /// @p plant.  It is an error to call this using an SDF file with more than
-  /// one `<model>` element.
+  /// Parses the SDFormat or URDF file named in @p file_name and adds one
+  /// top-level model to @p plant. It is an error to call this using an SDFormat
+  /// file with more than one root-level `<model>` element.
   ///
-  /// @param file_name The name of the SDF or URDF file to be parsed.  The file
-  ///   type will be inferred from the extension.
-  /// @param model_name The name given to the newly created instance of this
-  ///   model.  If empty, the "name" attribute from the `<model>` or `<robot>`
-  ///   tag will be used.
-  /// @returns The instance index for the newly added model.
-  /// @throws std::exception in case of errors.
+  /// @note This function might create additional model instances corresponding
+  /// to nested models found in the top level SDFormat model. This means that
+  /// elements contained by the returned model instance may not comprise all of
+  /// the added elements due to how model instances are mutually exclusive and
+  /// not hierarchical (#14043).
+  ///
+  /// @sa http://sdformat.org/tutorials?tut=composition&ver=1.7 for details on
+  /// nesting in SDFormat.
   ModelInstanceIndex AddModelFromFile(
       const std::string& file_name,
       const std::string& model_name = {});
 
-  /// Parses the SDF or URDF XML data passed given in @p file_contents and adds
-  /// one model to @p plant.  It is an error to call this using an SDF with
-  /// more than one `<model>` element.
+  /// Provides same functionality as AddModelFromFile, but instead parses the
+  /// SDFormat or URDF XML data via @p file_contents with type dictated by
+  /// @p file_type.
   ///
   /// @param file_contents The XML data to be parsed.
   /// @param file_type The data format; must be either "sdf" or "urdf".

--- a/multibody/parsing/test/detail_scene_graph_test.cc
+++ b/multibody/parsing/test/detail_scene_graph_test.cc
@@ -185,6 +185,8 @@ GTEST_TEST(SceneGraphParserDetail, MakeBoxFromSdfGeometry) {
 
 // Verify MakeShapeFromSdfGeometry can make a Drake capsule from an
 // sdf::Geometry.
+// TODO(azeey): We should deprecate use of <drake:capsule> per
+// https://github.com/RobotLocomotion/drake/issues/14837
 GTEST_TEST(SceneGraphParserDetail, MakeDrakeCapsuleFromSdfGeometry) {
   unique_ptr<sdf::Geometry> sdf_geometry = MakeSdfGeometryFromString(
       "<drake:capsule>"
@@ -200,6 +202,8 @@ GTEST_TEST(SceneGraphParserDetail, MakeDrakeCapsuleFromSdfGeometry) {
 }
 
 // Verify MakeShapeFromSdfGeometry checks for invalid capsules.
+// TODO(azeey): We should deprecate use of <drake:capsule> per
+// https://github.com/RobotLocomotion/drake/issues/14837
 GTEST_TEST(SceneGraphParserDetail, CheckInvalidDrakeCapsules) {
   unique_ptr<sdf::Geometry> no_radius_geometry = MakeSdfGeometryFromString(
       "<drake:capsule>"
@@ -251,6 +255,8 @@ GTEST_TEST(SceneGraphParserDetail, MakeCylinderFromSdfGeometry) {
 
 // Verify MakeShapeFromSdfGeometry can make a Drake ellipsoid from an
 // sdf::Geometry.
+// TODO(azeey): We should deprecate use of <drake:ellipsoid> per
+// https://github.com/RobotLocomotion/drake/issues/14837
 GTEST_TEST(SceneGraphParserDetail, MakeDrakeEllipsoidFromSdfGeometry) {
   unique_ptr<sdf::Geometry> sdf_geometry = MakeSdfGeometryFromString(
       "<drake:ellipsoid>"
@@ -268,6 +274,8 @@ GTEST_TEST(SceneGraphParserDetail, MakeDrakeEllipsoidFromSdfGeometry) {
 }
 
 // Verify MakeShapeFromSdfGeometry checks for invalid ellispoids.
+// TODO(azeey): We should deprecate use of <drake:ellipsoid> per
+// https://github.com/RobotLocomotion/drake/issues/14837
 GTEST_TEST(SceneGraphParserDetail, CheckInvalidEllipsoids) {
   unique_ptr<sdf::Geometry> no_a_geometry = MakeSdfGeometryFromString(
       "<drake:ellipsoid>"

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -157,6 +157,11 @@ GTEST_TEST(MultibodyPlantSdfParserTest, ModelInstanceTest) {
   EXPECT_EQ(plant.GetModelInstanceByName("acrobot"), acrobot1);
   EXPECT_EQ(plant.GetModelInstanceByName("acrobot2"), acrobot2);
 
+  // Check that the model name override is reflected in the model frame.
+  EXPECT_TRUE(plant.HasFrameNamed("instance1"));
+  EXPECT_TRUE(plant.HasFrameNamed("acrobot"));
+  EXPECT_TRUE(plant.HasFrameNamed("acrobot2"));
+
   // Check a couple links from the first model without specifying the model
   // instance.
   EXPECT_TRUE(plant.HasBodyNamed("link3"));
@@ -259,10 +264,11 @@ struct PlantAndSceneGraph {
   std::unique_ptr<SceneGraph<double>> scene_graph;
 };
 
-PlantAndSceneGraph ParseTestString(const std::string& inner) {
+PlantAndSceneGraph ParseTestString(const std::string& inner,
+                                   const std::string& sdf_version = "1.6") {
   const std::string filename = temp_directory() + "/test_string.sdf";
   std::ofstream file(filename);
-  file << "<sdf version='1.6'>" << inner << "\n</sdf>\n";
+  file << "<sdf version='" << sdf_version << "'>" << inner << "\n</sdf>\n";
   file.close();
   PlantAndSceneGraph pair;
   pair.plant = std::make_unique<MultibodyPlant<double>>(0.0);
@@ -455,32 +461,128 @@ GTEST_TEST(SdfParser, FloatingBodyPose) {
 }
 
 GTEST_TEST(SdfParser, StaticModelSupported) {
-  // Test that static models are partially supported.
-  PlantAndSceneGraph pair = ParseTestString(R"""(
-<model name='good'>
-  <static>true</static>
-  <link name='a'>
-    <pose>1 2 3  0.1 0.2 0.3</pose>
-  </link>
-  <link name='b'>
-    <pose>4 5 6  0.4 0.5 0.6</pose>
-  </link>
-</model>)""");
-  pair.plant->Finalize();
-  EXPECT_EQ(pair.plant->num_positions(), 0);
-  auto context = pair.plant->CreateDefaultContext();
-  const RigidTransformd X_WA_expected(
-      RollPitchYawd(0.1, 0.2, 0.3), Vector3d(1, 2, 3));
-  const RigidTransformd X_WA =
+  {
+    SCOPED_TRACE("Test that static models are partially supported");
+    PlantAndSceneGraph pair = ParseTestString(R"""(
+  <model name='good'>
+    <static>true</static>
+    <link name='a'>
+      <pose>1 2 3  0.1 0.2 0.3</pose>
+    </link>
+    <link name='b'>
+      <pose>4 5 6  0.4 0.5 0.6</pose>
+    </link>
+  </model>)""");
+    pair.plant->Finalize();
+    EXPECT_EQ(pair.plant->num_positions(), 0);
+    auto context = pair.plant->CreateDefaultContext();
+    const RigidTransformd X_WA_expected(
+        RollPitchYawd(0.1, 0.2, 0.3), Vector3d(1, 2, 3));
+    const RigidTransformd X_WA =
       pair.plant->GetFrameByName("a").CalcPoseInWorld(*context);
-  EXPECT_TRUE(CompareMatrices(
-      X_WA_expected.GetAsMatrix4(), X_WA.GetAsMatrix4(), kEps));
-  const RigidTransformd X_WB_expected(
-      RollPitchYawd(0.4, 0.5, 0.6), Vector3d(4, 5, 6));
-  const RigidTransformd X_WB =
+    EXPECT_TRUE(CompareMatrices(
+          X_WA_expected.GetAsMatrix4(), X_WA.GetAsMatrix4(), kEps));
+    const RigidTransformd X_WB_expected(
+        RollPitchYawd(0.4, 0.5, 0.6), Vector3d(4, 5, 6));
+    const RigidTransformd X_WB =
       pair.plant->GetFrameByName("b").CalcPoseInWorld(*context);
-  EXPECT_TRUE(CompareMatrices(
-      X_WB_expected.GetAsMatrix4(), X_WB.GetAsMatrix4(), kEps));
+    EXPECT_TRUE(CompareMatrices(
+          X_WB_expected.GetAsMatrix4(), X_WB.GetAsMatrix4(), kEps));
+  }
+
+  {
+    SCOPED_TRACE(
+        "Verify that static models don't need to have a canonical link");
+    PlantAndSceneGraph pair;
+    DRAKE_ASSERT_NO_THROW(pair = ParseTestString(R"""(
+  <model name='a'>
+    <pose>1 2 3  0.1 0.2 0.3</pose>
+    <static>true</static>
+  </model>)""", "1.8"));
+    pair.plant->Finalize();
+    auto context = pair.plant->CreateDefaultContext();
+    const RigidTransformd X_WA_expected(
+        RollPitchYawd(0.1, 0.2, 0.3), Vector3d(1, 2, 3));
+
+    const auto &frame_A = pair.plant->GetFrameByName("a");
+    const RigidTransformd X_WA = frame_A.CalcPoseInWorld(*context);
+    EXPECT_TRUE(CompareMatrices(
+          X_WA_expected.GetAsMatrix4(), X_WA.GetAsMatrix4(), kEps));
+    EXPECT_EQ(frame_A.body().node_index(),
+              pair.plant->world_body().node_index());
+  }
+
+  {
+    // Verify that models that contain static models don't need a link
+    SCOPED_TRACE(
+        "Verify that models that contain static models don't need a link");
+    PlantAndSceneGraph pair;
+    DRAKE_EXPECT_NO_THROW(pair = ParseTestString(R"""(
+  <model name='a'>
+    <pose>1 2 3  0.0 0.0 0.3</pose>
+    <model name='b'>
+      <pose>0 0 0  0.1 0.2 0.0</pose>
+      <static>true</static>
+    </model>
+  </model>)""", "1.8"));
+    pair.plant->Finalize();
+    auto context = pair.plant->CreateDefaultContext();
+    const RigidTransformd X_WA_expected(
+        RollPitchYawd(0.0, 0.0, 0.3), Vector3d(1, 2, 3));
+
+    const auto &frame_A = pair.plant->GetFrameByName("a");
+    const RigidTransformd X_WA = frame_A.CalcPoseInWorld(*context);
+    EXPECT_TRUE(CompareMatrices(
+          X_WA_expected.GetAsMatrix4(), X_WA.GetAsMatrix4(), kEps));
+    EXPECT_EQ(frame_A.body().node_index(),
+              pair.plant->world_body().node_index());
+
+    const RigidTransformd X_WB_expected(
+        RollPitchYawd(0.1, 0.2, 0.3), Vector3d(1, 2, 3));
+
+    const auto &frame_B = pair.plant->GetFrameByName("b");
+    const RigidTransformd X_WB = frame_B.CalcPoseInWorld(*context);
+    EXPECT_TRUE(CompareMatrices(
+          X_WB_expected.GetAsMatrix4(), X_WB.GetAsMatrix4(), kEps));
+    EXPECT_EQ(frame_B.body().node_index(),
+              pair.plant->world_body().node_index());
+  }
+}
+
+GTEST_TEST(SdfParser, StaticFrameOnlyModelsSupported) {
+  // Verify that static models can contain just frames
+  PlantAndSceneGraph pair;
+  DRAKE_EXPECT_NO_THROW(pair = ParseTestString(R"""(
+  <model name='a'>
+    <static>true</static>
+    <pose>1 0 0  0 0 0</pose>
+    <frame name='b'>
+      <pose>0 2 0 0 0 0</pose>
+    </frame>
+    <frame name='c' attached_to='b'>
+      <pose>0 0 3 0 0 0</pose>
+    </frame>
+    <frame name='d'>
+      <pose relative_to='c'>0 0 0 0 0 0.3</pose>
+    </frame>
+  </model>)""", "1.8"));
+  pair.plant->Finalize();
+  auto context = pair.plant->CreateDefaultContext();
+
+  auto test_frame = [&](const std::string& frame_name,
+                       const RigidTransformd& X_WF_expected) {
+    const auto& frame = pair.plant->GetFrameByName(frame_name);
+    const RigidTransformd X_WF = frame.CalcPoseInWorld(*context);
+    EXPECT_TRUE(CompareMatrices(X_WF_expected.GetAsMatrix4(),
+                                X_WF.GetAsMatrix4(), kEps));
+    EXPECT_EQ(frame.body().node_index(),
+              pair.plant->world_body().node_index());
+  };
+
+  test_frame("a", {RollPitchYawd(0.0, 0.0, 0.0), Vector3d(1, 0, 0)});
+  test_frame("b", {RollPitchYawd(0.0, 0.0, 0.0), Vector3d(1, 2, 0)});
+  test_frame("c", {RollPitchYawd(0.0, 0.0, 0.0), Vector3d(1, 2, 3)});
+  test_frame("d", {RollPitchYawd(0.0, 0.0, 0.3), Vector3d(1, 2, 3)});
 }
 
 GTEST_TEST(SdfParser, StaticModelWithJoints) {
@@ -555,9 +657,7 @@ GTEST_TEST(SdfParserThrowsWhen, JointDampingIsNegative) {
           "Joint damping must be a non-negative number.");
 }
 
-// TODO(addisu, eric.cousineau): Update this unittest pending proper usage of
-// SDFormat 1.8, admitting some issues with SDFormat <=1.7 + libsdformat<=10.
-GTEST_TEST(SdfParser, DISABLED_IncludeTags) {
+GTEST_TEST(SdfParser, IncludeTags) {
   const std::string full_name = FindResourceOrThrow(
       "drake/multibody/parsing/test/sdf_parser_test/"
       "include_models.sdf");
@@ -574,15 +674,15 @@ GTEST_TEST(SdfParser, DISABLED_IncludeTags) {
   AddModelsFromSdfFile(full_name, package_map, &plant);
   plant.Finalize();
 
-  // We should have loaded 3 more models.
-  EXPECT_EQ(plant.num_model_instances(), 5);
+  // We should have loaded 5 more models.
+  EXPECT_EQ(plant.num_model_instances(), 7);
   // The models should have added 8 more bodies.
   EXPECT_EQ(plant.num_bodies(), 9);
   // The models should have added 5 more joints.
   EXPECT_EQ(plant.num_joints(), 5);
 
   // There should be a model instance with the name "robot1".
-  EXPECT_TRUE(plant.HasModelInstanceNamed("robot1"));
+  ASSERT_TRUE(plant.HasModelInstanceNamed("robot1"));
   ModelInstanceIndex robot1_model = plant.GetModelInstanceByName("robot1");
   // There should be a body with the name "base_link".
   EXPECT_TRUE(plant.HasBodyNamed("base_link", robot1_model));
@@ -592,7 +692,7 @@ GTEST_TEST(SdfParser, DISABLED_IncludeTags) {
   EXPECT_TRUE(plant.HasJointNamed("slider", robot1_model));
 
   // There should be a model instance with the name "robot2".
-  EXPECT_TRUE(plant.HasModelInstanceNamed("robot2"));
+  ASSERT_TRUE(plant.HasModelInstanceNamed("robot2"));
   ModelInstanceIndex robot2_model = plant.GetModelInstanceByName("robot2");
 
   // There should be a body with the name "base_link".
@@ -604,20 +704,28 @@ GTEST_TEST(SdfParser, DISABLED_IncludeTags) {
 
   // There should be a model instance with the name "weld_robots".
   EXPECT_TRUE(plant.HasModelInstanceNamed("weld_models"));
-  ModelInstanceIndex weld_model = plant.GetModelInstanceByName("weld_models");
+
+  ASSERT_TRUE(plant.HasModelInstanceNamed("weld_models::robot1"));
+  ModelInstanceIndex weld_model_robot1_model =
+      plant.GetModelInstanceByName("weld_models::robot1");
+
+  ASSERT_TRUE(plant.HasModelInstanceNamed("weld_models::robot2"));
+  ModelInstanceIndex weld_model_robot2_model =
+      plant.GetModelInstanceByName("weld_models::robot2");
 
   // There should be all the bodies and joints contained in "simple_robot1"
-  // prefixed with the model's name of "robot1".
-  EXPECT_TRUE(plant.HasBodyNamed("robot1::base_link", weld_model));
-  EXPECT_TRUE(plant.HasBodyNamed("robot1::moving_link", weld_model));
-  EXPECT_TRUE(plant.HasJointNamed("robot1::slider", weld_model));
+  // which is inside "weld_models"
+  EXPECT_TRUE(plant.HasBodyNamed("base_link", weld_model_robot1_model));
+  EXPECT_TRUE(plant.HasBodyNamed("moving_link", weld_model_robot1_model));
+  EXPECT_TRUE(plant.HasJointNamed("slider", weld_model_robot1_model));
   // There should be all the bodies and joints contained in "simple_robot2"
-  // prefixed with the model's name of "robot2".
-  EXPECT_TRUE(plant.HasBodyNamed("robot2::base_link", weld_model));
-  EXPECT_TRUE(plant.HasBodyNamed("robot2::moving_link", weld_model));
-  EXPECT_TRUE(plant.HasJointNamed("robot2::slider", weld_model));
-  // There should be a joint named "weld_robots"
-  EXPECT_TRUE(plant.HasJointNamed("weld_robots", weld_model));
+  // which is inside "weld_models"
+  EXPECT_TRUE(plant.HasBodyNamed("base_link", weld_model_robot2_model));
+  EXPECT_TRUE(plant.HasBodyNamed("moving_link", weld_model_robot2_model));
+  EXPECT_TRUE(plant.HasJointNamed("slider", weld_model_robot2_model));
+  // There should be a joint named "weld_robots". By convention, the joint
+  // will have the same model instance as the child frame.
+  EXPECT_TRUE(plant.HasJointNamed("weld_robots", weld_model_robot2_model));
 }
 
 GTEST_TEST(SdfParser, TestOptionalSceneGraph) {
@@ -905,7 +1013,7 @@ void FailWithUnsupportedRelativeTo(const std::string& inner) {
       ParseTestString(inner),
       std::runtime_error,
       R"(<pose relative_to='\{non-empty\}'/> is presently not supported )"
-      R"(in <inertial/> or <model/> tags.)");
+      R"(in <inertial/> or top-level <model/> tags in model files.)");
 }
 
 void FailWithInvalidWorld(const std::string& inner) {
@@ -1209,6 +1317,462 @@ GTEST_TEST(SdfParser, ReflectedInertiaParametersParsing) {
   }
 }
 
+// Verifies that the SDFormat loader can add directly nested models to a
+// multibody plant. For reference, the files test/integration/model_dom.cc and
+// test/integration/nested_model.cc in the libsdformat source code (tag
+// sdformat11_11.0.0) contain tests that show more detailed behavior of
+// SDFormat's nested model support.
+GTEST_TEST(SdfParser, LoadDirectlyNestedModelsInWorld) {
+  const std::string full_name = FindResourceOrThrow(
+      "drake/multibody/parsing/test/sdf_parser_test/"
+      "world_with_directly_nested_models.sdf");
+  MultibodyPlant<double> plant(0.0);
+
+  // We start with the world and default model instances.
+  ASSERT_EQ(plant.num_model_instances(), 2);
+  ASSERT_EQ(plant.num_bodies(), 1);
+  ASSERT_EQ(plant.num_joints(), 0);
+
+  PackageMap package_map;
+  package_map.PopulateUpstreamToDrake(full_name);
+  AddModelsFromSdfFile(full_name, package_map, &plant);
+  plant.Finalize();
+
+  // We should have loaded 3 more models.
+  EXPECT_EQ(plant.num_model_instances(), 5);
+  // The models should have added 4 more bodies.
+  EXPECT_EQ(plant.num_bodies(), 5);
+  // The models should have added 3 more joints.
+  EXPECT_EQ(plant.num_joints(), 3);
+
+  // There should be a model instance with the name "parent_model".
+  ASSERT_TRUE(plant.HasModelInstanceNamed("parent_model"));
+
+  // There should be a model instance with the name "parent_model::robot1".
+  // This is the model "robot1" nested inside "parent_model"
+  ASSERT_TRUE(plant.HasModelInstanceNamed("parent_model::robot1"));
+  ModelInstanceIndex robot1_model =
+    plant.GetModelInstanceByName("parent_model::robot1");
+
+  // There should be a body with the name "base_link".
+  EXPECT_TRUE(plant.HasBodyNamed("base_link", robot1_model));
+  // There should be another body with the name "moving_link".
+  EXPECT_TRUE(plant.HasBodyNamed("moving_link", robot1_model));
+  // There should be joint with the name "slider".
+  EXPECT_TRUE(plant.HasJointNamed("slider", robot1_model));
+
+  // There should be a model instance with the name "parent_model::robot2".
+  // This is the model "robot2" nested inside "parent_model"
+  ASSERT_TRUE(plant.HasModelInstanceNamed("parent_model::robot2"));
+  ModelInstanceIndex robot2_model =
+    plant.GetModelInstanceByName("parent_model::robot2");
+
+  // There should be a body with the name "base_link".
+  EXPECT_TRUE(plant.HasBodyNamed("base_link", robot2_model));
+  // There should be another body with the name "moving_link".
+  EXPECT_TRUE(plant.HasBodyNamed("moving_link", robot2_model));
+  // There should be joint with the name "slider".
+  EXPECT_TRUE(plant.HasJointNamed("slider", robot2_model));
+
+  // There should be a joint named "weld_robots". By convention, the joint
+  // will have the same model instance as the child frame.
+  EXPECT_TRUE(plant.HasJointNamed("weld_robots", robot2_model));
+}
+
+// Same test as LoadDirectlyNestedModelsInWorld, but where a model file contains
+// direclty nested models.
+GTEST_TEST(SdfParser, LoadDirectlyNestedModelsInModel) {
+  const std::string full_name = FindResourceOrThrow(
+      "drake/multibody/parsing/test/sdf_parser_test/"
+      "model_with_directly_nested_models.sdf");
+  MultibodyPlant<double> plant(0.0);
+
+  // We start with the world and default model instances.
+  ASSERT_EQ(plant.num_model_instances(), 2);
+  ASSERT_EQ(plant.num_bodies(), 1);
+  ASSERT_EQ(plant.num_joints(), 0);
+
+  PackageMap package_map;
+  package_map.PopulateUpstreamToDrake(full_name);
+  AddModelsFromSdfFile(full_name, package_map, &plant);
+  plant.Finalize();
+
+  // We should have loaded 4 more models.
+  EXPECT_EQ(plant.num_model_instances(), 6);
+  // The models should have added 4 more bodies.
+  EXPECT_EQ(plant.num_bodies(), 5);
+  // The models should have added 3 more joints.
+  EXPECT_EQ(plant.num_joints(), 3);
+
+  // There should be a model instance with the name "grand_parent_model" (top
+  // level model).
+  ASSERT_TRUE(plant.HasModelInstanceNamed("grand_parent_model"));
+
+  // There should be a model instance with the name
+  // "grand_parent_model::parent_model". This is the model "parent_model"
+  // nested inside "grand_parent_model"
+  ASSERT_TRUE(
+      plant.HasModelInstanceNamed("grand_parent_model::parent_model"));
+
+  // There should be a model instance with the name
+  // "grand_parent_model::parent_model::robot1". This is the model "robot1"
+  // nested inside "parent_model" which itself is nested inside
+  // grand_parent_model
+  ASSERT_TRUE(plant.HasModelInstanceNamed(
+        "grand_parent_model::parent_model::robot1"));
+  ModelInstanceIndex robot1_model = plant.GetModelInstanceByName(
+      "grand_parent_model::parent_model::robot1");
+
+  // There should be a body with the name "base_link".
+  EXPECT_TRUE(plant.HasBodyNamed("base_link", robot1_model));
+  // There should be another body with the name "moving_link".
+  EXPECT_TRUE(plant.HasBodyNamed("moving_link", robot1_model));
+  // There should be joint with the name "slider".
+  EXPECT_TRUE(plant.HasJointNamed("slider", robot1_model));
+
+  // There should be a model instance with the name
+  // "grand_parent_model::parent_model::robot2". This is the model "robot2"
+  // nested inside "parent_model" which itself is nested inside
+  // grand_parent_model
+  ASSERT_TRUE(plant.HasModelInstanceNamed(
+        "grand_parent_model::parent_model::robot2"));
+  ModelInstanceIndex robot2_model = plant.GetModelInstanceByName(
+      "grand_parent_model::parent_model::robot2");
+
+  // There should be a body with the name "base_link".
+  EXPECT_TRUE(plant.HasBodyNamed("base_link", robot2_model));
+  // There should be another body with the name "moving_link".
+  EXPECT_TRUE(plant.HasBodyNamed("moving_link", robot2_model));
+  // There should be joint with the name "slider".
+  EXPECT_TRUE(plant.HasJointNamed("slider", robot2_model));
+
+  // There should be a joint named "weld_robots". By convention, the joint
+  // will have the same model instance as the child frame.
+  EXPECT_TRUE(plant.HasJointNamed("weld_robots", robot2_model));
+}
+
+// Example model taken from
+// http://sdformat.org/tutorials?tut=composition_proposal&cat=pose_semantics_docs&#1-4-4-placement-frame-model-placement_frame-and-include-placement_frame
+GTEST_TEST(SdfParser, ModelPlacementFrame) {
+  const std::string model_string = R"""(
+<model name='table'> <!-- T -->
+  <pose>0 10 0  0 0 0</pose>
+  <link name='table_top'> <!-- S -->
+    <pose>0 0 1  0 0 0</pose>
+  </link>
+
+  <model name='mug' placement_frame='base'> <!-- M -->
+    <pose relative_to='table_top'/>
+    <link name='handle'> <!-- H -->
+      <pose>0.1 0 0  0 0 0</pose>
+    </link>
+    <link name='base'> <!-- B -->
+      <pose>0 0 -0.1  0 0 0</pose>
+    </link>
+  </model>
+
+</model>)""";
+  PlantAndSceneGraph pair = ParseTestString(model_string, "1.8");
+  ASSERT_NE(nullptr, pair.plant);
+  pair.plant->Finalize();
+  EXPECT_GT(pair.plant->num_positions(), 0);
+  auto context = pair.plant->CreateDefaultContext();
+
+  ASSERT_TRUE(pair.plant->HasModelInstanceNamed("table::mug"));
+  ModelInstanceIndex model_m = pair.plant->GetModelInstanceByName("table::mug");
+
+  ASSERT_TRUE(pair.plant->HasFrameNamed("mug"));
+  const Frame<double>& frame_M = pair.plant->GetFrameByName("mug");
+  ASSERT_TRUE(pair.plant->HasFrameNamed("__model__", model_m));
+  // frame M is equivalent to mug::__model__
+  EXPECT_TRUE(CompareMatrices(pair.plant->GetFrameByName("__model__", model_m)
+                                  .CalcPoseInWorld(*context)
+                                  .GetAsMatrix4(),
+                              pair.plant->GetFrameByName("mug")
+                                  .CalcPoseInWorld(*context)
+                                  .GetAsMatrix4(),
+                              kEps));
+
+  ASSERT_TRUE(pair.plant->HasFrameNamed("table_top"));
+  const Frame<double>& frame_S = pair.plant->GetFrameByName("table_top");
+
+  ASSERT_TRUE(pair.plant->HasFrameNamed("base", model_m));
+  const Frame<double>& frame_B = pair.plant->GetFrameByName("base", model_m);
+
+  ASSERT_TRUE(pair.plant->HasFrameNamed("handle", model_m));
+  const Frame<double>& frame_H = pair.plant->GetFrameByName("handle", model_m);
+
+  // X_SM = X_SB * X_MB^-1.
+  const RigidTransformd X_SM_expected(RollPitchYawd(0.0, 0.0, 0.0),
+                                      Vector3d(0.0, 0.0, 0.1));
+
+  const RigidTransformd X_SB_expected = RigidTransformd::Identity();
+  // X_SH = X_SB * X_HB^-1.
+  //      = X_SB * (X_MH^-1 * X_MB)^-1.
+  const RigidTransformd X_SH_expected(RollPitchYawd(0.0, 0.0, 0.0),
+                                      Vector3d(0.1, 0.0, 0.1));
+
+  const RigidTransformd X_SM = frame_M.CalcPose(*context, frame_S);
+  const RigidTransformd X_SH = frame_H.CalcPose(*context, frame_S);
+  const RigidTransformd X_SB = frame_B.CalcPose(*context, frame_S);
+
+  EXPECT_TRUE(CompareMatrices(
+      X_SM_expected.GetAsMatrix4(), X_SM.GetAsMatrix4(), kEps));
+  EXPECT_TRUE(CompareMatrices(
+      X_SB_expected.GetAsMatrix4(), X_SB.GetAsMatrix4(), kEps));
+  EXPECT_TRUE(CompareMatrices(
+      X_SH_expected.GetAsMatrix4(), X_SH.GetAsMatrix4(), kEps));
+
+  // X_WM = X_WT * X_TM
+  // X_TM = X_TS * X_MS^-1
+  // X_MS = X_MB * X_SB^-1
+  // The model frame M is 0.1m in the +z axis from frame B, but we know from the
+  // use of placement_frame that frame B and frame S are coincident. So X_WM is
+  // 0.1m in the +z axis from frame S.
+  const RigidTransformd X_WM_expected(RollPitchYawd(0.0, 0.0, 0.0),
+                                      Vector3d(0.0, 10.0, 1.1));
+
+  const RigidTransformd X_WB_expected(RollPitchYawd(0.0, 0.0, 0.0),
+                                      Vector3d(0.0, 10.0, 1.0));
+
+  const RigidTransformd X_WH_expected(RollPitchYawd(0.0, 0.0, 0.0),
+                                      Vector3d(0.1, 10.0, 1.1));
+
+  const RigidTransformd X_WM = frame_M.CalcPoseInWorld(*context);
+  const RigidTransformd X_WH = frame_H.CalcPoseInWorld(*context);
+  const RigidTransformd X_WB = frame_B.CalcPoseInWorld(*context);
+  EXPECT_TRUE(CompareMatrices(
+      X_WM_expected.GetAsMatrix4(), X_WM.GetAsMatrix4(), kEps));
+  EXPECT_TRUE(CompareMatrices(
+      X_WB_expected.GetAsMatrix4(), X_WB.GetAsMatrix4(), kEps));
+  EXPECT_TRUE(CompareMatrices(
+      X_WH_expected.GetAsMatrix4(), X_WH.GetAsMatrix4(), kEps));
+}
+
+// Verify that poses can be given relative to deeply nested frames.
+GTEST_TEST(SdfParser, PoseRelativeToMultiLevelNestedFrame) {
+  const std::string model_string = R"""(
+<model name='a'>
+  <pose>0.1 0 0  0 0 0</pose>
+  <model name='b'>
+    <pose>0 0.2 0.0  0 0 0</pose>
+    <model name='c'>
+      <pose>0 0.0 0.3  0 0 0</pose>
+      <link name='d'>
+        <pose>0 0.0 0.0  0 0.5 0.6</pose>
+      </link>
+    </model>
+  </model>
+  <link name='e'>
+    <pose relative_to="b::c::d">0 0 0  0.4 0 0.0</pose>
+  </link>
+</model>)""";
+  PlantAndSceneGraph pair;
+  DRAKE_ASSERT_NO_THROW(pair = ParseTestString(model_string, "1.8"));
+  ASSERT_NE(nullptr, pair.plant);
+  pair.plant->Finalize();
+  EXPECT_GT(pair.plant->num_positions(), 0);
+  auto context = pair.plant->CreateDefaultContext();
+
+  const RigidTransformd X_WE_expected(RollPitchYawd(0.4, 0.5, 0.6),
+                                      Vector3d(0.1, 0.2, 0.3));
+
+  const RigidTransformd X_WE =
+      pair.plant->GetFrameByName("e").CalcPoseInWorld(*context);
+  EXPECT_TRUE(CompareMatrices(
+      X_WE_expected.GetAsMatrix4(), X_WE.GetAsMatrix4(), kEps));
+}
+
+// Verify that joint axis can be expressed in deeply nested frames.
+GTEST_TEST(SdfParser, AxisXyzExperssedInMultiLevelNestedFrame) {
+  const std::string model_string = fmt::format(R"""(
+<model name='a'>
+  <pose>0.1 0 0  0 0 0</pose>
+  <model name='b'>
+    <pose>0 0.2 0.0  0 0 0</pose>
+    <model name='c'>
+      <pose>0 0.0 0.3  0 0 0</pose>
+      <link name='d'>
+        <pose>0 0.0 0.0  0 {} {}</pose>
+      </link>
+    </model>
+  </model>
+  <link name='e'/>
+  <link name='f'/>
+  <joint name="j" type="revolute">
+    <parent>e</parent>
+    <child>f</child>
+    <axis>
+      <xyz expressed_in="b::c::d">1 0 0</xyz>
+    </axis>
+  </joint>
+</model>)""", M_PI_2, M_PI_2);
+  PlantAndSceneGraph pair;
+  DRAKE_ASSERT_NO_THROW(pair = ParseTestString(model_string, "1.8"));
+  ASSERT_NE(nullptr, pair.plant);
+  pair.plant->Finalize();
+  EXPECT_GT(pair.plant->num_positions(), 0);
+  auto context = pair.plant->CreateDefaultContext();
+
+  const RollPitchYawd R_WD(0.0, M_PI_2, M_PI_2);
+
+  const Vector3d xyz_D(1, 0, 0);
+
+  const Vector3d xyz_W_expected = R_WD.ToRotationMatrix() * xyz_D;
+
+  DRAKE_EXPECT_NO_THROW(
+      pair.plant->GetJointByName<RevoluteJoint>("j"));
+  const RevoluteJoint<double>& joint_j =
+      pair.plant->GetJointByName<RevoluteJoint>("j");
+  EXPECT_TRUE(CompareMatrices(xyz_W_expected, joint_j.revolute_axis(), kEps));
+}
+
+// Verify frames can be attached to nested links or models
+GTEST_TEST(SdfParser, FrameAttachedToMultiLevelNestedFrame) {
+  const std::string model_string = R"""(
+<model name='a'>
+  <pose>0.1 0 0  0 0 0</pose>
+  <model name='b'>
+    <pose>0 0.2 0.0  0 0 0</pose>
+    <model name='c'>
+      <pose>0 0.0 0.3  0 0 0</pose>
+      <link name='d'>
+        <pose>0 0.0 0.0  0 0.5 0.6</pose>
+      </link>
+    </model>
+  </model>
+  <frame name='e' attached_to='b::c::d'> <!-- Frame attached to a link -->
+    <pose>0 0 0  0.4 0 0.0</pose>
+  </frame>
+  <frame name='f' attached_to='b::c'> <!-- Frame attached to a model -->
+    <pose>0 0 0  0.4 0.5 0.6</pose>
+  </frame>
+</model>)""";
+  PlantAndSceneGraph pair;
+  DRAKE_ASSERT_NO_THROW(pair = ParseTestString(model_string, "1.8"));
+  ASSERT_NE(nullptr, pair.plant);
+  pair.plant->Finalize();
+  EXPECT_GT(pair.plant->num_positions(), 0);
+  auto context = pair.plant->CreateDefaultContext();
+
+  const RigidTransformd X_WE_expected(RollPitchYawd(0.4, 0.5, 0.6),
+                                      Vector3d(0.1, 0.2, 0.3));
+  const RigidTransformd X_WF_expected(RollPitchYawd(0.4, 0.5, 0.6),
+                                      Vector3d(0.1, 0.2, 0.3));
+
+  const auto &frame_E = pair.plant->GetFrameByName("e");
+  const RigidTransformd X_WE = frame_E.CalcPoseInWorld(*context);
+  EXPECT_TRUE(CompareMatrices(
+      X_WE_expected.GetAsMatrix4(), X_WE.GetAsMatrix4(), kEps));
+
+  const auto &frame_F = pair.plant->GetFrameByName("f");
+  const RigidTransformd X_WF = frame_F.CalcPoseInWorld(*context);
+  EXPECT_TRUE(CompareMatrices(
+      X_WF_expected.GetAsMatrix4(), X_WF.GetAsMatrix4(), kEps));
+
+  // Also check that the frame is attached to the right body
+  ModelInstanceIndex model_c_instance =
+      pair.plant->GetModelInstanceByName("a::b::c");
+  EXPECT_EQ(frame_E.body().node_index(),
+            pair.plant->GetBodyByName("d", model_c_instance).node_index());
+
+  EXPECT_EQ(frame_F.body().node_index(),
+            pair.plant->GetBodyByName("d", model_c_instance).node_index());
+}
+
+// Verify frames and links can have the same local name without violating name
+// uniqueness requirements
+GTEST_TEST(SdfParser, RepeatedLinkName) {
+  const std::string model_string = R"""(
+<world name='a'>
+  <model name='b1'>
+    <link name='c'/>
+    <frame name='d'/>
+  </model>
+  <model name='b2'>
+    <link name='c'/>
+    <frame name='d'/>
+  </model>
+</world>)""";
+  PlantAndSceneGraph pair;
+  DRAKE_ASSERT_NO_THROW(pair = ParseTestString(model_string, "1.8"));
+}
+
+// Verify frames can be attached to models in a SDFormat world
+GTEST_TEST(SdfParser, FrameAttachedToModelFrameInWorld) {
+  const std::string model_string = R"""(
+<world name='a'>
+  <model name='b'>
+    <pose>0.1 0.2 0.0  0 0 0</pose>
+    <model name='c'>
+      <pose>0 0.0 0.3  0 0 0</pose>
+      <link name='d'/>
+    </model>
+  </model>
+  <frame name='e' attached_to='b'>
+    <pose>0 0 0.3  0.0 0.0 0.0</pose>
+  </frame>
+  <frame name='f' attached_to='b::c'>
+    <pose>0 0 0  0.0 0.0 0.6</pose>
+  </frame>
+</world>)""";
+  PlantAndSceneGraph pair;
+  DRAKE_ASSERT_NO_THROW(pair = ParseTestString(model_string, "1.8"));
+
+  ASSERT_NE(nullptr, pair.plant);
+  pair.plant->Finalize();
+  EXPECT_GT(pair.plant->num_positions(), 0);
+  auto context = pair.plant->CreateDefaultContext();
+
+  const RigidTransformd X_WE_expected(RollPitchYawd(0.0, 0.0, 0.0),
+                                      Vector3d(0.1, 0.2, 0.3));
+  const RigidTransformd X_WF_expected(RollPitchYawd(0.0, 0.0, 0.6),
+                                      Vector3d(0.1, 0.2, 0.3));
+
+  const auto &frame_E = pair.plant->GetFrameByName("e");
+  const RigidTransformd X_WE = frame_E.CalcPoseInWorld(*context);
+  EXPECT_TRUE(CompareMatrices(
+      X_WE_expected.GetAsMatrix4(), X_WE.GetAsMatrix4(), kEps));
+
+  const auto &frame_F = pair.plant->GetFrameByName("f");
+  const RigidTransformd X_WF = frame_F.CalcPoseInWorld(*context);
+  EXPECT_TRUE(CompareMatrices(
+      X_WF_expected.GetAsMatrix4(), X_WF.GetAsMatrix4(), kEps));
+
+  // Also check that the frame is attached to the right body
+  EXPECT_EQ(frame_E.body().node_index(),
+            pair.plant->GetBodyByName("d").node_index());
+
+  EXPECT_EQ(frame_F.body().node_index(),
+            pair.plant->GetBodyByName("d").node_index());
+}
+
+GTEST_TEST(SdfParser, SupportNonDefaultCanonicalLink) {
+  // Verify that non-default canonical links are handled properly. Here we have
+  // three different types of references used for the canonical link:
+  // * c::e - Nested link
+  // * f - Link that is not the first link in the model
+  const std::string model_string = R"""(
+  <model name='a' canonical_link='c::e'>
+    <link name='b'/>
+    <model name='c' canonical_link='f'>
+      <link name='d'/>
+      <link name='e'/>
+      <link name='f'/>
+    </model>
+  </model>)""";
+  PlantAndSceneGraph pair;
+  DRAKE_ASSERT_NO_THROW(pair = ParseTestString(model_string, "1.8"));
+
+  ASSERT_NE(nullptr, pair.plant);
+  pair.plant->Finalize();
+
+  EXPECT_EQ(pair.plant->GetFrameByName("a").body().index(),
+            pair.plant->GetBodyByName("e").index());
+
+  EXPECT_EQ(pair.plant->GetFrameByName("c").body().index(),
+            pair.plant->GetBodyByName("f").index());
+}
 }  // namespace
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/parsing/test/parser_test.cc
+++ b/multibody/parsing/test/parser_test.cc
@@ -120,6 +120,33 @@ GTEST_TEST(FileParserTest, MultiModelTest) {
   }
 }
 
+std::vector<std::string> GetModelInstanceNames(
+    const MultibodyPlant<double>& plant,
+    const std::vector<ModelInstanceIndex>& models) {
+  std::vector<std::string> names;
+  for (auto model : models) {
+    names.push_back(plant.GetModelInstanceName(model));
+  }
+  return names;
+}
+
+GTEST_TEST(FileParserTest, MultiModelViaWorldIncludesTest) {
+  const std::string sdf_name = FindResourceOrThrow(
+      "drake/multibody/parsing/test/sdf_parser_test/"
+      "world_with_directly_nested_models.sdf");
+  MultibodyPlant<double> plant(0.0);
+  const std::vector<ModelInstanceIndex> models =
+      Parser(&plant).AddAllModelsFromFile(sdf_name);
+  const std::vector<std::string> model_names_actual =
+      GetModelInstanceNames(plant, models);
+  const std::vector<std::string> model_names_expected = {
+      "parent_model",
+      "parent_model::robot1",
+      "parent_model::robot2",
+  };
+  EXPECT_EQ(model_names_actual, model_names_expected);
+}
+
 GTEST_TEST(FileParserTest, ExtensionMatchTest) {
   // An unknown extension is an error.
   // (Check both singular and plural overloads.)

--- a/multibody/parsing/test/sdf_parser_test/all_geometries_as_collision.sdf
+++ b/multibody/parsing/test/sdf_parser_test/all_geometries_as_collision.sdf
@@ -37,6 +37,8 @@
       </collision>
       <!-- This element is for testing the <drake:capsule> spelling. -->
       <!-- Immediately above, we tested the standard <capsule> spelling. -->
+      <!-- TODO(azeey): We should deprecate use of <drake:capsule>
+        per https://github.com/RobotLocomotion/drake/issues/14837 -->
       <collision name="DrakeCapsule">
         <geometry>
           <drake:capsule>
@@ -72,6 +74,8 @@
       </collision>
       <!-- This element is for testing the <drake:ellipsoid> spelling. -->
       <!-- Immediately above, we tested the standard <ellipsoid> spelling. -->
+      <!-- TODO(azeey): We should deprecate use of <drake:ellipsoid>
+        per https://github.com/RobotLocomotion/drake/issues/14837 -->
       <collision name="DrakeEllipsoid">
         <geometry>
           <drake:ellipsoid>

--- a/multibody/parsing/test/sdf_parser_test/all_geometries_as_visual.sdf
+++ b/multibody/parsing/test/sdf_parser_test/all_geometries_as_visual.sdf
@@ -37,12 +37,22 @@
       </visual>
       <!-- This element is for testing the <drake:capsule> spelling. -->
       <!-- Immediately above, we tested the standard <capsule> spelling. -->
+      <!-- TODO(azeey): We should deprecate use of <drake:capsule>
+        per https://github.com/RobotLocomotion/drake/issues/14837 -->
       <visual name="DrakeCapsule">
         <geometry>
           <drake:capsule>
             <length>1</length>
             <radius>0.1</radius>
           </drake:capsule>
+        </geometry>
+      </visual>
+      <visual name="CapsuleSdf">
+        <geometry>
+          <capsule>
+            <length>1</length>
+            <radius>0.1</radius>
+          </capsule>
         </geometry>
       </visual>
       <visual name="Convex">
@@ -72,6 +82,8 @@
       </visual>
       <!-- This element is for testing the <drake:ellipsoid> spelling. -->
       <!-- Immediately above, we tested the standard <ellipsoid> spelling. -->
+      <!-- TODO(azeey): We should deprecate use of <drake:ellipsoid>
+        per https://github.com/RobotLocomotion/drake/issues/14837 -->
       <visual name="DrakeEllipsoid">
         <geometry>
           <drake:ellipsoid>
@@ -79,6 +91,13 @@
             <b>2.0</b>
             <c>3.0</c>
           </drake:ellipsoid>
+        </geometry>
+      </visual>
+      <visual name="EllipsoidSdf">
+        <geometry>
+          <ellipsoid>
+            <radii>1.0 2.0 3.0</radii>
+          </ellipsoid>
         </geometry>
       </visual>
       <visual name="Mesh">

--- a/multibody/parsing/test/sdf_parser_test/include_models.sdf
+++ b/multibody/parsing/test/sdf_parser_test/include_models.sdf
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<sdf version="1.7">
+<sdf version="1.8">
   <world name="SimWorld">
     <include>
       <uri>model://simple_robot1</uri>

--- a/multibody/parsing/test/sdf_parser_test/model_with_directly_nested_models.sdf
+++ b/multibody/parsing/test/sdf_parser_test/model_with_directly_nested_models.sdf
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<sdf version="1.8">
+  <model name="grand_parent_model">
+    <model name="parent_model">
+      <model name="robot1">
+        <link name="base_link"/>
+        <link name="moving_link"/>
+        <joint name="slider" type="prismatic">
+          <parent>base_link</parent>
+          <child>moving_link</child>
+          <axis>
+            <xyz>0 0 1</xyz>
+          </axis>
+        </joint>
+      </model>
+      <model name="robot2">
+        <link name="base_link"/>
+        <link name="moving_link"/>
+        <joint name="slider" type="prismatic">
+          <parent>base_link</parent>
+          <child>moving_link</child>
+          <axis>
+            <xyz>0 0 1</xyz>
+          </axis>
+        </joint>
+      </model>
+      <joint name="weld_robots" type="revolute">
+        <parent>robot1::base_link</parent>
+        <child>robot2::base_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+        </axis>
+      </joint>
+    </model>
+  </model>
+</sdf>
+

--- a/multibody/parsing/test/sdf_parser_test/world_with_directly_nested_models.sdf
+++ b/multibody/parsing/test/sdf_parser_test/world_with_directly_nested_models.sdf
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<sdf version="1.8">
+  <world name="sim_world">
+    <model name="parent_model">
+      <model name="robot1">
+        <link name="base_link"/>
+        <link name="moving_link"/>
+        <joint name="slider" type="prismatic">
+          <parent>base_link</parent>
+          <child>moving_link</child>
+          <axis>
+            <xyz>0 0 1</xyz>
+          </axis>
+        </joint>
+      </model>
+      <model name="robot2">
+        <link name="base_link"/>
+        <link name="moving_link"/>
+        <joint name="slider" type="prismatic">
+          <parent>base_link</parent>
+          <child>moving_link</child>
+          <axis>
+            <xyz>0 0 1</xyz>
+          </axis>
+        </joint>
+      </model>
+      <joint name="weld_robots" type="revolute">
+        <parent>robot1::base_link</parent>
+        <child>robot2::base_link</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+        </axis>
+      </joint>
+    </model>
+  </world>
+</sdf>


### PR DESCRIPTION
Changes in behavior:
* Models nested via the `<include>` tag are no longer flattened, which means each included model will have its own model instance.
* `drake::multibody::Parser::AddAllModelsFromFile` now returns all added models including nested models

Note: This does not use a custom parser for URDFs via libsdformat's Interface API, and thus may incur unexpected behavior when including URDF files from SDFormat pending the full resolution of #14295.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14401)
<!-- Reviewable:end -->
