### PR TITLE
doxygen: add @ingroup tags to schunk wsg systems

### DIFF
--- a/manipulation/schunk_wsg/schunk_wsg_constants.h
+++ b/manipulation/schunk_wsg/schunk_wsg_constants.h
@@ -48,6 +48,7 @@ VectorX<T> GetSchunkWsgOpenPosition() {
 
 /// Extract the distance between the fingers (and its time derivative) out
 /// of the plant model which pretends the two fingers are independent.
+/// @ingroup manipulation_systems
 template <typename T>
 std::unique_ptr<systems::MatrixGain<T>>
 MakeMultibodyStateToWsgStateSystem() {
@@ -59,6 +60,9 @@ MakeMultibodyStateToWsgStateSystem() {
   return std::make_unique<systems::MatrixGain<T>>(D);
 }
 
+/// Extract the gripper measured force from the generalized forces on the two
+/// fingers.
+/// @ingroup manipulation_systems
 template <typename T>
 class MultibodyForceToWsgForceSystem : public systems::VectorSystem<T> {
  public:
@@ -84,8 +88,8 @@ class MultibodyForceToWsgForceSystem : public systems::VectorSystem<T> {
   }
 };
 
-/// Extract the gripper measured force from the generalized forces on the two
-/// fingers.
+/// Helper method to create a MultibodyForceToWsgForceSystem.
+/// @ingroup manipulation_systems
 template <typename T>
 std::unique_ptr<systems::VectorSystem<T>>
 MakeMultibodyForceToWsgForceSystem() {

--- a/manipulation/schunk_wsg/schunk_wsg_lcm.h
+++ b/manipulation/schunk_wsg/schunk_wsg_lcm.h
@@ -33,6 +33,7 @@ namespace schunk_wsg {
 /// - force_limit
 /// @endsystem
 ///
+/// @ingroup manipulation_systems
 class SchunkWsgCommandReceiver : public systems::LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SchunkWsgCommandReceiver)
@@ -80,6 +81,7 @@ class SchunkWsgCommandReceiver : public systems::LeafSystem<double> {
 /// - lcmt_schunk_wsg_command
 /// @endsystem
 ///
+/// @ingroup manipulation_systems
 class SchunkWsgCommandSender : public systems::LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SchunkWsgCommandSender)
@@ -126,6 +128,7 @@ class SchunkWsgCommandSender : public systems::LeafSystem<double> {
 /// - force
 /// @endsystem
 ///
+/// @ingroup manipulation_systems
 class SchunkWsgStatusReceiver : public systems::LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SchunkWsgStatusReceiver)

--- a/manipulation/schunk_wsg/schunk_wsg_position_controller.h
+++ b/manipulation/schunk_wsg/schunk_wsg_position_controller.h
@@ -55,6 +55,7 @@ namespace schunk_wsg {
 /// is a scalar surrogate for the force measurement from the driver, f =
 /// abs(f₀-f₁) which, like the gripper itself, only reports a positive force.
 ///
+/// @ingroup manipulation_systems
 class SchunkWsgPdController : public systems::LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SchunkWsgPdController)
@@ -131,6 +132,7 @@ class SchunkWsgPdController : public systems::LeafSystem<double> {
 /// @endsystem
 ///
 /// @see SchunkWsgPdController
+/// @ingroup manipulation_systems
 class SchunkWsgPositionController : public systems::Diagram<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SchunkWsgPositionController)

--- a/systems/systems.h
+++ b/systems/systems.h
@@ -79,8 +79,8 @@
 
 /// @addtogroup manipulation_systems
 /// @{
-/// @brief Systems implementations that specifically support dexterous
-/// manipulation capabilities in robotics.
+/// @brief Systems implementations and related functions that specifically 
+/// support dexterous manipulation capabilities in robotics.
 /// @}
 
 /// @addtogroup message_passing


### PR DESCRIPTION
This at least makes sure that all of our schunk wsg variants appear in the same places in doxygen.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14412)
<!-- Reviewable:end -->
