### PR TITLE
[geometry] Deprecate kDim in SurfaceMesh and VolumeMesh.

### DIFF
--- a/geometry/proximity/bvh.h
+++ b/geometry/proximity/bvh.h
@@ -337,7 +337,7 @@ class Bvh {
   // (see Obb::Equal()).
   static bool EqualTrees(const BvNode<MeshType>& a, const BvNode<MeshType>& b);
 
-  static constexpr int kElementVertexCount = MeshType::kDim + 1;
+  static constexpr int kElementVertexCount = MeshType::kVertexPerElement;
 
   std::unique_ptr<BvNode<MeshType>> root_node_;
 };

--- a/geometry/proximity/mesh_field_linear.h
+++ b/geometry/proximity/mesh_field_linear.h
@@ -137,7 +137,7 @@ class MeshFieldLinear final : public MeshField<T, MeshType> {
              const typename MeshType::Barycentric& b) const final {
     const auto& element = this->mesh().element(e);
     T value = b[0] * values_[element.vertex(0)];
-    for (int i = 1; i < MeshType::kDim + 1; ++i) {
+    for (int i = 1; i < MeshType::kVertexPerElement; ++i) {
       value += b[i] * values_[element.vertex(i)];
     }
     return value;

--- a/geometry/proximity/mesh_to_vtk.cc
+++ b/geometry/proximity/mesh_to_vtk.cc
@@ -42,7 +42,7 @@ void WriteVtkUnstructuredGrid(std::ofstream& out, const Mesh& mesh) {
   const int num_elements = mesh.num_elements();
   // For a triangular mesh, we use 4 integers per triangle.
   // For a tetrahedral mesh, we use 5 integers per tetrahedron.
-  const int num_vertices_per_element = Mesh::kDim + 1;
+  const int num_vertices_per_element = Mesh::kVertexPerElement;
   const int num_integers = num_elements * (num_vertices_per_element + 1);
   out << "CELLS " << num_elements << " " << num_integers << std::endl;
   for (typename Mesh::ElementIndex i(0); i < num_elements; ++i) {
@@ -57,8 +57,9 @@ void WriteVtkUnstructuredGrid(std::ofstream& out, const Mesh& mesh) {
 
   const int kVtkCellTypeTriangle = 5;
   const int kVtkCellTypeTetrahedron = 10;
-  const int cell_type =
-      (Mesh::kDim == 2) ? kVtkCellTypeTriangle : kVtkCellTypeTetrahedron;
+  const int cell_type = (Mesh::kVertexPerElement == 3)
+                            ? kVtkCellTypeTriangle
+                            : kVtkCellTypeTetrahedron;
   out << "CELL_TYPES " << num_elements << std::endl;
   for (int i = 0; i < num_elements; ++i) {
     out << fmt::format("{}\n", cell_type);

--- a/geometry/proximity/surface_mesh.h
+++ b/geometry/proximity/surface_mesh.h
@@ -8,6 +8,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/type_safe_index.h"
 #include "drake/math/rigid_transform.h"
@@ -129,13 +130,14 @@ class SurfaceMesh {
 
   using ScalarType = T;
 
-  // TODO(DamrongGuoy): Remove kDim and replace its usage like (kDim + 1) by
-  //  kVertexPerElement in mesh_to_vtk, mesh_field_linear, and
-  //  bounding_volume_hierarchy. Issue #12756.
-
   /**
    A surface mesh has the intrinsic dimension 2.  It is embedded in 3-d space.
    */
+  DRAKE_DEPRECATED(
+      "2021-04-01",
+      "kDim has been deemed redundant, and its usage is being dropped in "
+      "favor of using kVertexPerElement. The relationship between kDim and "
+      "kVertexPerElement is: kVertexPerElement = kDim + 1.")
   static constexpr int kDim = 2;
 
   /**
@@ -165,7 +167,7 @@ class SurfaceMesh {
 
    The barycentric coordinates for a point Q are notated a b_Q.
    */
-  using Barycentric = Vector<T, kDim + 1>;
+  using Barycentric = Vector<T, kVertexPerElement>;
 
   /** Type of Cartesian coordinates. Mesh consumers can use it in conversion
    from Cartesian coordinates to barycentric coordinates.

--- a/geometry/proximity/volume_mesh.h
+++ b/geometry/proximity/volume_mesh.h
@@ -10,6 +10,7 @@
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/type_safe_index.h"
 
@@ -129,10 +130,11 @@ class VolumeMesh {
 
   using ScalarType = T;
 
-  // TODO(DamrongGuoy): Remove kDim and replace its usage like (kDim + 1) by
-  //  kVertexPerElement in mesh_to_vtk, mesh_field_linear, and
-  //  bounding_volume_hierarchy. Issue #12756.
-
+  DRAKE_DEPRECATED(
+      "2021-04-01",
+      "kDim has been deemed redundant, and its usage is being dropped in "
+      "favor of using kVertexPerElement. The relationship between kDim and "
+      "kVertexPerElement is: kVertexPerElement = kDim + 1.")
   static constexpr int kDim = 3;
 
   /**
@@ -156,7 +158,7 @@ class VolumeMesh {
    could calculate one of the bᵢ from the others; however, there is no
    standard way to omit one of the coordinates.
   */
-  using Barycentric = Vector<T, kDim + 1>;
+  using Barycentric = Vector<T, kVertexPerElement>;
 
   /** Type of Cartesian coordinates. Mesh consumers can use it in conversion
    from Cartesian coordinates to barycentric coordinates.


### PR DESCRIPTION
Deprecate kDim in SurfaceMesh and VolumeMesh.
Use kVertexPerElement for kDim+1 instead. Fixes #12756.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14420)
<!-- Reviewable:end -->
