### PR TITLE
Separate out the unit test for the degenerate case

### DIFF
--- a/math/test/gray_code_test.cc
+++ b/math/test/gray_code_test.cc
@@ -7,8 +7,15 @@
 namespace drake {
 namespace math {
 namespace {
+
+GTEST_TEST(TestGrayCode, TestDegenerateCase) {
+  auto zero_code = CalculateReflectedGrayCodes(0);
+  EXPECT_EQ(zero_code.cols(), 0);
+  EXPECT_EQ(zero_code.rows(), 0);
+}
+
 GTEST_TEST(TestGrayCode, TestCalculateGrayCodes) {
-  for (int i = 0; i < 4; i++) {
+  for (int i = 1; i < 4; i++) {
     auto test_code = CalculateReflectedGrayCodes(i);
     // Asking for codes for 0 bits should generate 0 for 0 bits.
     // Asking for codes for i bits should generate 2^(i) codes for i bits.


### PR DESCRIPTION
 * This is a trivial disturbance to the test to correct
   a spurious kcov error; see
   https://github.com/SimonKagstrom/kcov/issues/339
 * Closes #14424

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14425)
<!-- Reviewable:end -->
