### PR TITLE
workspace: Change how fmt and spdlog dependencies are obtained

### DIFF
--- a/common/text_logging.h
+++ b/common/text_logging.h
@@ -23,9 +23,11 @@ not be compiled if debugging is turned off (-DNDEBUG is set):
   DRAKE_LOGGER_DEBUG("message: {}", something_conditionally_compiled);
 </pre>
 
-The format string syntax is fmtlib; see https://fmt.dev/7.1.0/syntax.html.
+The format string syntax is fmtlib; see https://fmt.dev/latest/syntax.html.
 In particular, any class that overloads `operator<<` for `ostream` can be
-printed without any special handling.
+printed without any special handling.  (Note that the documentation link
+provides syntax for the latest version of fmtlib; the version of fmtlib
+used by Drake might be older.)
 */
 
 #include <string>

--- a/tools/install/libdrake/drake.cps
+++ b/tools/install/libdrake/drake.cps
@@ -39,7 +39,7 @@
       "X-CMake-Find-Args": ["CONFIG"]
     },
     "spdlog": {
-      "Version": "1.3",
+      "Version": "1.5",
       "Hints": ["@prefix@/lib/cmake/spdlog"],
       "X-CMake-Find-Args": ["CONFIG"]
     },

--- a/tools/workspace/fmt/package-create-cps.py
+++ b/tools/workspace/fmt/package-create-cps.py
@@ -1,3 +1,7 @@
+# This file is only used in cases when we need to build and/or install fmt from
+# source, i.e., when we are not using pkg-config.  See repository.bzl for the
+# logic to select when that occurs.
+
 from drake.tools.install.cpsutils import read_version_defs
 
 defs = read_version_defs("#define FMT_VERSION ([0-9]{1,2})([0-9]{2})([0-9]{2})$")

--- a/tools/workspace/fmt/package.BUILD.bazel
+++ b/tools/workspace/fmt/package.BUILD.bazel
@@ -1,5 +1,9 @@
 # -*- python -*-
 
+# This file is only used in cases when we need to build and/or install fmt from
+# source, i.e., when we are not using pkg-config.  See repository.bzl for the
+# logic to select when that occurs.
+
 load(
     "@drake//tools/install:install.bzl",
     "cmake_config",

--- a/tools/workspace/fmt/repository.bzl
+++ b/tools/workspace/fmt/repository.bzl
@@ -1,17 +1,77 @@
 # -*- python -*-
 
-load("@drake//tools/workspace:github.bzl", "github_archive")
+load("@drake//tools/workspace:os.bzl", "determine_os")
+load(
+    "@drake//tools/workspace:github.bzl",
+    "setup_github_repository",
+)
+load(
+    "@drake//tools/workspace:pkg_config.bzl",
+    "setup_pkg_config_repository",
+)
 
-def fmt_repository(
-        name,
-        mirrors = None):
-    github_archive(
-        name = name,
-        repository = "fmtlib/fmt",
-        # When changing the fmt version, also update the URL in the file
-        # overview docstring of drake/common/text_logging.h.
-        commit = "7.1.3",
-        sha256 = "5cae7072042b3043e12d53d50ef404bbb76949dad1de368d7f993a15c8c05ecc",  # noqa
-        build_file = "@drake//tools/workspace/fmt:package.BUILD.bazel",
-        mirrors = mirrors,
-    )
+def _impl(repo_ctx):
+    os_result = determine_os(repo_ctx)
+    if os_result.error != None:
+        fail(os_result.error)
+    if os_result.is_macos:
+        # On macOS, we use fmt from homebrew via pkg-config.
+        error = setup_pkg_config_repository(repo_ctx).error
+    elif os_result.ubuntu_release == "18.04":
+        # On Ubuntu 18.04, the host-provided spdlog is way too old so we can't
+        # use its bundled fmt, and there is no other fmt package available, so
+        # we'll recompile it from downloaded github sources.
+        error = setup_github_repository(repo_ctx).error
+    elif os_result.ubuntu_release == "20.04":
+        # On Ubuntu 20.04 we're using the host-provided spdlog which uses a
+        # bundled fmt, so we'll have to reuse that same bundle for ourselves.
+        repo_ctx.symlink("/usr/include/spdlog/fmt/bundled", "include/fmt")
+        repo_ctx.symlink("include/fmt/LICENSE.rst", "LICENSE.rst")
+        repo_ctx.symlink(
+            Label("@drake//tools/workspace/fmt:package.BUILD.bazel"),
+            "BUILD.bazel",
+        )
+        error = None
+    else:
+        fail("Unsupported OS")
+    if error != None:
+        fail(error)
+
+fmt_repository = repository_rule(
+    attrs = {
+        # The next two attributes are used only when we take the branch for
+        # setup_pkg_config_repository in the above logic.
+        "modname": attr.string(
+            default = "fmt",
+        ),
+        "build_epilog": attr.string(
+            # When using fmt from pkg-config, there is nothing to install.
+            default = """
+load("@drake//tools/install:install.bzl", "install")
+install(name = "install")
+            """,
+        ),
+        # The remaining attributes are used only when we take the branch for
+        # setup_github_repository in the above logic.
+        "repository": attr.string(
+            default = "fmtlib/fmt",
+        ),
+        "commit": attr.string(
+            # Per https://github.com/gabime/spdlog/releases/tag/v1.5.0 this is
+            # the bundled version we should pin, in cases where we're building
+            # from source instead of using the host version.
+            default = "6.1.2",
+        ),
+        "sha256": attr.string(
+            default = "1cafc80701b746085dddf41bd9193e6d35089e1c6ec1940e037fcb9c98f62365",  # noqa
+        ),
+        "build_file": attr.label(
+            default = "@drake//tools/workspace/fmt:package.BUILD.bazel",
+        ),
+        "extra_strip_prefix": attr.string(),
+        "mirrors": attr.string_list_dict(),
+    },
+    local = True,
+    configure = True,
+    implementation = _impl,
+)

--- a/tools/workspace/new_release.py
+++ b/tools/workspace/new_release.py
@@ -42,12 +42,16 @@ _IGNORED_REPOSITORIES = [
     # We don't know how to check non-default branches yet.
     "clang_cindex_python3",
     "pybind11",
+    # We've purposely pinned these to older revisions, as noted by comments in
+    # their repository.bzl files.
+    "fmt",
+    "spdlog",
 ]
 
 # For these repositories, we only look at tags, not releases.  For the dict
 # value, use a blank value to match the latest tag or a regex to only select
 # tags that share the match with the tag currently in use.  (This can be used
-# to ping to a given major or major.minor release series.)
+# to pin to a given major or major.minor release series.)
 _OVERLOOK_RELEASE_REPOSITORIES = {
     "github3_py": r"^(\d+.)",
     "pycodestyle": "",

--- a/tools/workspace/spdlog/package-create-cps.py
+++ b/tools/workspace/spdlog/package-create-cps.py
@@ -1,3 +1,6 @@
+# This file is only used in cases when we need to rebuild spdlog from source.
+# See repository.bzl for the logic to select when that occurs.
+
 from drake.tools.install.cpsutils import read_defs, read_requires
 
 def_re = "#define\s+(\S+)\s+(\S+)"

--- a/tools/workspace/spdlog/package.BUILD.bazel
+++ b/tools/workspace/spdlog/package.BUILD.bazel
@@ -1,5 +1,8 @@
 # -*- python -*-
 
+# This file is only used in cases when we need to rebuild spdlog from source.
+# See repository.bzl for the logic to select when that occurs.
+
 load(
     "@drake//tools/install:install.bzl",
     "cmake_config",
@@ -15,8 +18,8 @@ config_setting(
     visibility = ["//visibility:private"],
 )
 
-# The public headers are all of the non-inl include files.
-# We use Drake's @fmt external, not the bundled version inside spdlog.
+# The public headers are all of the non-inl include files.  When we're building
+# our own spdlog, we'll use Drake's @fmt external, not the bundled version.
 _HDRS = glob(
     [
         "include/spdlog/**",

--- a/tools/workspace/spdlog/repository.bzl
+++ b/tools/workspace/spdlog/repository.bzl
@@ -1,15 +1,73 @@
 # -*- python -*-
 
-load("@drake//tools/workspace:github.bzl", "github_archive")
+load("@drake//tools/workspace:os.bzl", "determine_os")
+load(
+    "@drake//tools/workspace:github.bzl",
+    "setup_github_repository",
+)
+load(
+    "@drake//tools/workspace:pkg_config.bzl",
+    "setup_pkg_config_repository",
+)
 
-def spdlog_repository(
-        name,
-        mirrors = None):
-    github_archive(
-        name = name,
-        repository = "gabime/spdlog",
-        commit = "v1.8.1",
-        sha256 = "5197b3147cfcfaa67dd564db7b878e4a4b3d9f3443801722b3915cdeced656cb",  # noqa
-        build_file = "@drake//tools/workspace/spdlog:package.BUILD.bazel",
-        mirrors = mirrors,
-    )
+def _impl(repo_ctx):
+    os_result = determine_os(repo_ctx)
+    if os_result.error != None:
+        fail(os_result.error)
+    if os_result.is_macos:
+        # On macOS, we use spdlog from homebrew via pkg-config.
+        error = setup_pkg_config_repository(repo_ctx).error
+    elif os_result.ubuntu_release == "18.04":
+        # On Ubuntu 18.04, the host-provided spdlog is way too old.  Instead,
+        # we'll recompile it from downloaded github sources.
+        error = setup_github_repository(repo_ctx).error
+    else:
+        # On Ubuntu 20.04, we use the host-provided spdlog via pkg-config.
+        error = setup_pkg_config_repository(repo_ctx).error
+    if error != None:
+        fail(error)
+
+spdlog_repository = repository_rule(
+    attrs = {
+        # The next two attributes are used only when we take the branch for
+        # setup_pkg_config_repository in the above logic.
+        "modname": attr.string(
+            default = "spdlog",
+        ),
+        "extra_defines": attr.string_list(
+            default = ["HAVE_SPDLOG"],
+        ),
+        "extra_deps": attr.string_list(
+            default = ["@fmt"],
+        ),
+        "build_epilog": attr.string(
+            # When using spdlog from pkg-config, there is nothing to install.
+            default = """
+load("@drake//tools/install:install.bzl", "install")
+install(name = "install")
+            """,
+        ),
+        # The remaining attributes are used only when we take the branch for
+        # setup_github_repository in the above logic.
+        "repository": attr.string(
+            default = "gabime/spdlog",
+        ),
+        "commit": attr.string(
+            # Here, we elect to use the same version as Ubuntu 20.04, even
+            # though it is not the newest revision.  Sticking with a single,
+            # older revision helps reduce spurious CI failures.
+            default = "v1.5.0",
+        ),
+        "sha256": attr.string(
+            default = "b38e0bbef7faac2b82fed550a0c19b0d4e7f6737d5321d4fd8f216b80f8aee8a",  # noqa
+        ),
+        "build_file": attr.label(
+            default = "@drake//tools/workspace/spdlog:package.BUILD.bazel",
+        ),
+        "extra_strip_prefix": attr.string(),
+        "mirrors": attr.string_list_dict(),
+    },
+    local = True,
+    configure = True,
+    implementation = _impl,
+)


### PR DESCRIPTION
On Ubuntu 18.04, we downgrade to spdlog 5.1.0 and fmt 6.1.2, but we still compile them from github source releases.

On Ubuntu 20.04, fmt and spdlog are obtained from the host now.  (The host copy of fmt is also installed by Drake, because Ubuntu's packaging is deficient.) The versions are spdlog 5.1.0 with bundled fmt 6.1.2.

On macOS, fmt and spdlog are obtained from homebrew now.  The versions are the latest available, per the usual homebrew policy.

Closes #14220.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14427)
<!-- Reviewable:end -->
