### PR TITLE
setup: do not error when robotlocomotion/director is not tapped

### DIFF
--- a/setup/mac/binary_distribution/install_prereqs.sh
+++ b/setup/mac/binary_distribution/install_prereqs.sh
@@ -18,8 +18,9 @@ if ! command -v /usr/local/bin/brew &>/dev/null; then
   /usr/bin/ruby -e "$(/usr/bin/curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 fi
 
-# TODO(jamiesnape): Remove lines uninstalling vtk@8.2, ospray@1.8, and
-# embree@3.5 on or after 2021-02-01.
+# TODO(jamiesnape): Remove lines tapping robotlocomotion/director and
+# uninstalling vtk@8.2, ospray@1.8, and embree@3.5 on or after 2021-02-01.
+/usr/local/bin/brew tap robotlocomotion/director
 /usr/local/bin/brew uninstall --force $(cat <<EOF
 robotlocomotion/director/vtk@8.2
 robotlocomotion/director/ospray@1.8


### PR DESCRIPTION
Fixes an issue seen in https://github.com/RobotLocomotion/drake-external-examples/runs/1519981618?check_suite_focus=true:
```
+ /usr/local/bin/brew uninstall --force robotlocomotion/director/vtk@8.2 robotlocomotion/director/ospray@1.8 robotlocomotion/director/embree@3.5
Error: No available formula with the name "robotlocomotion/director/vtk@8.2".
Please tap it and then try again: brew tap robotlocomotion/director
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14428)
<!-- Reviewable:end -->
