### PR TITLE
setup: Add libspdlog-dev on Ubuntu 20.04 Focal

### DIFF
--- a/setup/ubuntu/binary_distribution/packages-focal.txt
+++ b/setup/ubuntu/binary_distribution/packages-focal.txt
@@ -34,6 +34,7 @@ libqt5gui5
 libqt5printsupport5
 libqt5widgets5
 libquadmath0
+libspdlog-dev
 libsqlite3-0
 libtheora0
 libtiff5


### PR DESCRIPTION
Adding in anticipation of compiling against the host library, instead of our own separate copy, in #14427.

Towards #14220.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14429)
<!-- Reviewable:end -->
