### PR TITLE
plant: Add unit test for context cloning

### DIFF
--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -980,6 +980,16 @@ TEST_F(AcrobotPlantTests, SetRandomState) {
       random_context->get_mutable_continuous_state_vector().CopyToVector()));
 }
 
+// A basic sanity check for context cloning.
+TEST_F(AcrobotPlantTests, ContextClone) {
+  shoulder_->set_default_angle(0.05);
+  auto old_context = plant_->CreateDefaultContext();
+  auto new_context = old_context->Clone();
+  shoulder_->set_angle(old_context.get(), 0.01);
+  EXPECT_EQ(shoulder_->get_angle(*old_context), 0.01);
+  EXPECT_EQ(shoulder_->get_angle(*new_context), 0.05);
+}
+
 GTEST_TEST(MultibodyPlantTest, Graphviz) {
   MultibodyPlant<double> plant(0.0);
   const std::string acrobot_path =


### PR DESCRIPTION
Closes #9118.

Prior to #10581, MbP used a custom context subclass.  I suspect that was a necessary condition for the segfault, but in any case I've now added a regression test that MbP context cloning works as expected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14433)
<!-- Reviewable:end -->
