### PR TITLE
workspace: Avoid using whitespace in pkg-config rpaths

### DIFF
--- a/tools/workspace/pkg_config.bzl
+++ b/tools/workspace/pkg_config.bzl
@@ -112,10 +112,10 @@ def setup_pkg_config_repository(repository_ctx):
                         linkopts[i] = linkopt
                         break
 
-        # Add `-Wl,-rpath <path>` for `-L<path>`.
+        # Add `-Wl,-rpath,<path>` for `-L<path>`.
         # See https://github.com/RobotLocomotion/drake/issues/7387#issuecomment-359952616  # noqa
         if linkopt.startswith("-L"):
-            linkopts.insert(i, "-Wl,-rpath " + linkopt[2:])
+            linkopts.insert(i, "-Wl,-rpath," + linkopt[2:])
             continue
 
         # Switches stay put.


### PR DESCRIPTION
As of bazel 4.0, the user_link_flags changes from a list to a depset.

Therefore, when we used -Wl,-rpath /foo/bar as our spelling, the first instance survived but a second instance would skips the -Wl,-rpath part but keep the /quux/bar part, leaving a stray directory on the link line

By consolidating each rpath addition as a single list element even after whitespace tokenization, it will remain intact.

This was biting us when fetching ipopt.pc, which has several junk compiler paths thrown into it on Ubuntu 18.04.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14439)
<!-- Reviewable:end -->
