### PR TITLE
tools: Use incompatible_restrict_string_escapes for now

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -6,6 +6,9 @@ import %workspace%/tools/lint/bazel.rc
 # Disable native Python rules in Bazel versions before 4.0.
 build --incompatible_load_python_rules_from_bzl=yes
 
+# TODO(#14440) Remove this flag once our string escapes get fixed.
+build --incompatible_restrict_string_escapes=false
+
 # Default to an optimized build.
 build -c opt
 


### PR DESCRIPTION
As of bazel 4.0, we get a hard error without this nerf.
Once we've fixed our code to comply, we should remove the nerf.

Relates #14440.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14441)
<!-- Reviewable:end -->
