### PR TITLE
rules_cc: Adapt whole_archive for bazel 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ endif()
 
 # The version passed to find_package(Bazel) should match the
 # minimum_bazel_version value in the call to versions.check() in WORKSPACE.
-set(MINIMUM_BAZEL_VERSION 2.0)
+set(MINIMUM_BAZEL_VERSION 3.0)
 find_package(Bazel ${MINIMUM_BAZEL_VERSION} MODULE REQUIRED)
 
 get_filename_component(C_COMPILER_REALPATH "${CMAKE_C_COMPILER}" REALPATH)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,4 +25,4 @@ load("@bazel_skylib//lib:versions.bzl", "versions")
 # This needs to be in WORKSPACE or a repository rule for native.bazel_version
 # to actually be defined. The minimum_bazel_version value should match the
 # version passed to the find_package(Bazel) call in the root CMakeLists.txt.
-versions.check(minimum_bazel_version = "2.0")
+versions.check(minimum_bazel_version = "3.0")


### PR DESCRIPTION
Several cc_info data structures got reorganized.  This function supports bazel 3.x and 4.0 now, but no longer support 2.x.

Drake's new minimum bazel version is 3.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14442)
<!-- Reviewable:end -->
