### PR TITLE
Refactor quadrature to remove heap allocations

### DIFF
--- a/multibody/fem/dev/README.md
+++ b/multibody/fem/dev/README.md
@@ -1,0 +1,7 @@
+Finite Element Method (FEM)
+================================================================================
+
+The first iteration of the FEM solver. The contents will gradually be moved to
+the fixed size counter part per
+[issue #14330](https://github.com/RobotLocomotion/drake/issues/14330). See the
+fixed size version [here](../../fixed_fem/dev/README.md).

--- a/multibody/fixed_fem/dev/BUILD.bazel
+++ b/multibody/fixed_fem/dev/BUILD.bazel
@@ -1,0 +1,41 @@
+#- * - python - * -
+load("//tools/lint:lint.bzl", "add_lint_tests")
+load(
+    "//tools/skylark:drake_cc.bzl",
+    "drake_cc_googletest",
+    "drake_cc_library",
+)
+
+package(
+    default_visibility = ["//visibility:private"],
+)
+
+drake_cc_library(
+    name = "quadrature",
+    hdrs = [
+        "quadrature.h",
+    ],
+    deps = [
+        "//common:default_scalars",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "simplex_gaussian_quadrature",
+    hdrs = [
+        "simplex_gaussian_quadrature.h",
+    ],
+    deps = [
+        ":quadrature",
+    ],
+)
+
+drake_cc_googletest(
+    name = "simplex_gaussian_quadrature_test",
+    deps = [
+        ":simplex_gaussian_quadrature",
+    ],
+)
+
+add_lint_tests()

--- a/multibody/fixed_fem/dev/README.md
+++ b/multibody/fixed_fem/dev/README.md
@@ -1,0 +1,7 @@
+Fixed size Finite Element Method (FEM)
+================================================================================
+
+The second iteration of the FEM solver. The contents are meant to replace the
+solver in the [first iteration](../../fem/dev/README.md) per the
+plan of actions in
+[issue #14330](https://github.com/RobotLocomotion/drake/issues/14330).

--- a/multibody/fixed_fem/dev/quadrature.h
+++ b/multibody/fixed_fem/dev/quadrature.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <array>
+#include <string>
+#include <utility>
+
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+// TODO(xuchenhan-tri): Consider allowing AutoDiffScalar if it simplifies the
+// syntax in the AutoDiff case.
+/** A base class for quadratures that facilitates numerical integrations in FEM.
+ This class provides the common interface and the data for all the quadrature
+ rules with no heap allocation or virtual methods. The specification of
+ particular quadrature rules will be provided in the derived classes.
+ @tparam NaturalDimension dimension of the domain of integration.
+ @tparam NumLocations number of quadrature locations. */
+template <int NaturalDimension, int NumLocations>
+class Quadrature {
+ public:
+  static_assert(1 <= NaturalDimension && NaturalDimension <= 3,
+                "Only 1, 2 and 3 dimensional shapes are supported.");
+  static_assert(1 <= NumLocations,
+                "There has to be at least one quadrature point.");
+
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Quadrature);
+
+  using VectorD = Eigen::Matrix<double, NaturalDimension, 1>;
+  using LocationsType = std::array<VectorD, NumLocations>;
+  using WeightsType = std::array<double, NumLocations>;
+
+  /** The dimension of the parent domain. */
+  static constexpr int natural_dimension() { return NaturalDimension; }
+
+  /** The number of quadrature locations. */
+  static constexpr int num_quadrature_points() { return NumLocations; }
+
+  /** The position in parent coordinates of all quadrature points. */
+  const LocationsType& get_points() const { return points_; }
+
+  /** The weight of all quadrature points. */
+  const WeightsType& get_weights() const { return weights_; }
+
+  /** The position in parent coordinates of the q-th quadrature point. */
+  const VectorD& get_point(int q) const {
+    DRAKE_ASSERT(0 <= q && q < NumLocations);
+    return points_[q];
+  }
+
+  /** The weight of the q-th quadrature point. */
+  double get_weight(int q) const {
+    DRAKE_ASSERT(0 <= q && q < NumLocations);
+    return weights_[q];
+  }
+
+ protected:
+  /** Construct a Quadrature object given the quadrature locations and the
+   weights of the quadrature points. */
+  explicit Quadrature(
+      std::pair<LocationsType, WeightsType>&& points_and_weights)
+      : points_(std::move(points_and_weights.first)),
+        weights_(std::move(points_and_weights.second)) {}
+
+ private:
+  LocationsType points_;
+  WeightsType weights_;
+};
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/simplex_gaussian_quadrature.h
+++ b/multibody/fixed_fem/dev/simplex_gaussian_quadrature.h
@@ -1,0 +1,161 @@
+#pragma once
+
+#include <utility>
+
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fixed_fem/dev/quadrature.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+/** Calculates the number of quadrature points used for simplices given the
+ natural dimension and the order of the quadrature rule as template
+ parameters. */
+template <int NaturalDim, int Order>
+constexpr int SimplexQuadratureNumLocations() {
+  static_assert(
+      1 <= Order && Order <= 3,
+      "Only linear, quadratic and cubic quadrature rules are supported.");
+  if constexpr (Order == 1) {
+    return 1;
+  } else if constexpr (Order == 2) {
+    return NaturalDim + 1;
+  } else if constexpr (Order == 3) {
+    return NaturalDim + 2;
+  }
+}
+
+/** Calculates the Gaussian quadrature rule for 2D and 3D unit simplices
+ (triangles and tetrahedrons up to cubic order as described section 3 in
+ [Hammer, 1956] as well as section 9.10 of [Zienkiewics, 2005]. The 2D unit
+ triangle has vertices located at (0,0), (1,0) and (0,1). The 3D unit
+ tetrahedron has vertices located at (0,0,0), (1,0,0), (0,1,0) and (0,0,1).
+ @tparam Order order of the quadrature rule. Must be 1, 2, or 3. The
+ quadrature rule will be exact for polynomials of degree less than or equal to
+ Order.
+ @tparam NaturalDimension dimension of the unit simplex. Must be 2, or 3.
+
+ [Hammer, 1956] P.C. Hammer, O.P. Marlowe, and A.H. Stroud. Numerical
+ integration over simplexes and cones. Math. Tables Aids Comp. 10, 130-7, 1956.
+ [Zienkiewicz, 2005] Zienkiewicz, Olek C., Robert L. Taylor, and Jian Z. Zhu.
+ The finite element method: its basis and fundamentals. Elsevier, 2005. */
+template <int NaturalDimension, int Order>
+class SimplexGaussianQuadrature
+    : public Quadrature<NaturalDimension,
+          SimplexQuadratureNumLocations<NaturalDimension, Order>()> {
+ public:
+  using Base = Quadrature<NaturalDimension,
+      SimplexQuadratureNumLocations<NaturalDimension, Order>()>;
+  using VectorD = typename Base::VectorD;
+  using LocationsType = typename Base::LocationsType;
+  using WeightsType = typename Base::WeightsType;
+
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SimplexGaussianQuadrature);
+
+  SimplexGaussianQuadrature() : Base(ComputePointsAndWeights()) {}
+
+ private:
+  /* Helper function to initialize quadrature locations and weights. */
+  std::pair<LocationsType, WeightsType> ComputePointsAndWeights() const {
+    if constexpr (NaturalDimension == 2) {
+      // For a unit triangle, area = 0.5.
+      if constexpr (Order == 1) {
+        // quadrature point location,  weight/area
+        //  (1/3, 1/3)                     1.0
+        LocationsType points = {{{1.0 / 3.0, 1.0 / 3.0}}};
+        WeightsType weights = {{0.5}};
+        return make_pair(move(points), move(weights));
+        // TODO(xuchenhan-tri): fix the bug in cpplint as described in
+        // https://github.com/google/styleguide/issues/541. A solution has been
+        // proposed at https://github.com/cpplint/cpplint/pull/136.
+        // NOLINTNEXTLINE(readability/braces)
+      } else if constexpr (Order == 2) {
+        // quadrature point location,  weight/area
+        //  (1/6, 1/6)                     1/3
+        //  (2/3, 1/6)                     1/3
+        //  (1/6, 2/3)                     1/3
+        // Note: Here we choose r=1/2 in section 3 of [Hammer, 1956]. They also
+        // mentioned the other choice with r=-1/2. We do not use r=-1/2 as it
+        // lies out side of the element.
+        LocationsType points;
+        points[0] = {1.0 / 6.0, 1.0 / 6.0};
+        points[1] = {2.0 / 3.0, 1.0 / 6.0};
+        points[2] = {1.0 / 6.0, 2.0 / 3.0};
+        WeightsType weights = {{1.0 / 6.0, 1.0 / 6.0, 1.0 / 6.0}};
+        return make_pair(move(points), move(weights));
+        // NOLINTNEXTLINE(readability/braces)
+      } else if constexpr (Order == 3) {
+        // quadrature point location,  weight/area
+        //  (1/3, 1/3)                     -9/16
+        //  (3/5, 1/5)                     25/48
+        //  (1/5, 3/5)                     25/48
+        //  (1/5, 1/5)                     25/48
+        LocationsType points;
+        points[0] = {1.0 / 3.0, 1.0 / 3.0};
+        points[1] = {0.6, 0.2};
+        points[2] = {0.2, 0.6};
+        points[3] = {0.2, 0.2};
+        WeightsType weights = {
+            {-9.0 / 32.0, 25.0 / 96.0, 25.0 / 96.0, 25.0 / 96.0}};
+        return make_pair(move(points), move(weights));
+      } else {
+        DRAKE_UNREACHABLE();
+      }
+      // NOLINTNEXTLINE(readability/braces)
+    } else if constexpr (NaturalDimension == 3) {
+      // For a unit tetrahedron, area = 1/6.
+      if constexpr (Order == 1) {
+        // quadrature point location,  weight/area
+        //  (1/4, 1/4, 1/4)                1.0
+        LocationsType points = {{{0.25, 0.25, 0.25}}};
+        WeightsType weights = {{1.0 / 6.0}};
+        return make_pair(move(points), move(weights));
+        // NOLINTNEXTLINE(readability/braces)
+      } else if constexpr (Order == 2) {
+        // quadrature point location,  weight/area
+        //  (a, b, b)                      1/4
+        //  (b, a, b)                      1/4
+        //  (b, b, a)                      1/4
+        //  (b, b, b)                      1/4
+        // where a = (1+3*sqrt(1/5))/4, b = (1-1/sqrt(1/5))/4.
+        LocationsType points;
+        double a = (1.0 + 3.0 * sqrt(0.2)) / 4.0;
+        double b = (1.0 - sqrt(0.2)) / 4.0;
+        points[0] = {a, b, b};
+        points[1] = {b, a, b};
+        points[2] = {b, b, a};
+        points[3] = {b, b, b};
+        WeightsType weights = {
+            {1.0 / 24.0, 1.0 / 24.0, 1.0 / 24.0, 1.0 / 24.0}};
+        return make_pair(move(points), move(weights));
+        // NOLINTNEXTLINE(readability/braces)
+      } else if constexpr (Order == 3) {
+        // quadrature point location,  weight/area
+        //  (1/4, 1/4, 1/4)               -4/5
+        //  (a, b, b)                      9/20
+        //  (b, a, b)                      9/20
+        //  (b, b, a)                      9/20
+        //  (b, b, b)                      9/20
+        // where a = 1/2, b = 1/6.
+        LocationsType points;
+        double a = 0.5;
+        double b = 1.0 / 6.0;
+        points[0] = {0.25, 0.25, 0.25};
+        points[1] = {a, b, b};
+        points[2] = {b, a, b};
+        points[3] = {b, b, a};
+        points[4] = {b, b, b};
+        WeightsType weights = {
+            {-2.0 / 15.0, 3.0 / 40.0, 3.0 / 40.0, 3.0 / 40.0, 3.0 / 40.0}};
+        return make_pair(move(points), move(weights));
+      } else {
+        DRAKE_UNREACHABLE();
+      }
+    } else {
+      DRAKE_UNREACHABLE();
+    }
+  }
+};
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/test/simplex_gaussian_quadrature_test.cc
+++ b/multibody/fixed_fem/dev/test/simplex_gaussian_quadrature_test.cc
@@ -1,0 +1,337 @@
+#include "drake/multibody/fixed_fem/dev/simplex_gaussian_quadrature.h"
+
+#include <limits>
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace {
+using Eigen::Vector2d;
+using Eigen::Vector3d;
+struct LinearTestFunction2D {
+  static constexpr double a0 = 1.0;
+  static constexpr double a1 = 3.0;
+  static constexpr double a2 = -2.0;
+
+  // Returns the value of function
+  //     y(x₀, x₁) = a₀ + a₁ * x₀+ a₂ * x₁
+  // evaluated at input x.
+  static double Eval(const Vector2d& x) { return a0 + a1 * x(0) + a2 * x(1); }
+
+  static double EvalAnalyticalIntegralOverUnitTriangle() {
+    // The integral of the monomial 1 and x over the unit triangle with end
+    // points at (0,0), (1,0) and (0,1) is
+    //     ∫₀¹∫₀¹⁻ˣ 1 dydx =  1/2.
+    //     ∫₀¹∫₀¹⁻ʸ x dxdy =  1/6.
+    // So the integral of f(x) = a₀ + a₁ * x₀ + a₂ * x₁ is equal to
+    //     1/2 * a₀ + 1/6 * a₁ + 1/6 * a₂.
+    return 0.5 * a0 + 1.0 / 6.0 * a1 + 1.0 / 6.0 * a2;
+  }
+};
+
+struct QuadraticTestFunction2D {
+  static constexpr double a0 = 1.0;
+  static constexpr double a1 = 3.0;
+  static constexpr double a2 = -2.0;
+  static constexpr double a3 = 7.2;
+  static constexpr double a4 = -3.15;
+  static constexpr double a5 = -0.82;
+  // Returns the value of function
+  //     y(x₀, x₁) = a₀ + a₁*x₀ + a₂*x₁ + a₃*x₀*x₁ + a₄*x₀² + a₅*x₁²
+  // evaluated at input x.
+  static double Eval(const Vector2d& x) {
+    return a0 + a1 * x(0) + a2 * x(1) + a3 * x(0) * x(1) + a4 * x(0) * x(0) +
+           a5 * x(1) * x(1);
+  }
+
+  static double EvalAnalyticalIntegralOverUnitTriangle() {
+    // The integral of the monomial 1, x, xy and x² over the unit triangle with
+    // end points at (0,0), (1,0) and (0,1) are
+    //     ∫₀¹∫₀¹⁻ˣ 1 dydx =  1/2.
+    //     ∫₀¹∫₀¹⁻ˣ x dydx =  1/6.
+    //     ∫₀¹∫₀¹⁻ʸ xy dxdy =  1/24.
+    //     ∫₀¹∫₀¹⁻ʸ x² dxdy =  1/12.
+    // So the integral of  f(x₀, x₁) = a₀ + a₁*x₀ + a₂*x₁ + a₃*x₀*x₁ + a₄*x₀² +
+    // a₅*x₁² is equal to
+    //     1/2 * a₀ + 1/6 * a₁ + 1/6 * a₂ + 1/24 * a₃ + 1/12 * a₄ + 1/12 * a₅.
+    return 0.5 * a0 + 1.0 / 6.0 * a1 + 1.0 / 6.0 * a2 + 1.0 / 24.0 * a3 +
+           1.0 / 12.0 * a4 + 1.0 / 12.0 * a5;
+  }
+};
+
+struct CubicTestFunction2D {
+  static constexpr double a0 = 1.0;
+  static constexpr double a1 = 3.0;
+  static constexpr double a2 = -2.0;
+  static constexpr double a3 = 7.2;
+  static constexpr double a4 = -3.15;
+  static constexpr double a5 = -0.82;
+  static constexpr double a6 = 9.22;
+  static constexpr double a7 = -1.84;
+  static constexpr double a8 = -3.32;
+  static constexpr double a9 = 8.31;
+  // Returns the value of function
+  //     y(x₀, x₁) = a₀ + a₁*x₀ + a₂*x₁ + a₃*x₀*x₁ + a₄*x₀² + a₅*x₁² + a₆*x₀³ +
+  //     a₇*x₀²x₁ + a₈x₀x₁² + a₉*x₁³
+  // evaluated at input x.
+  static double Eval(const Vector2d& x) {
+    double x0 = x(0);
+    double x0_sqr = x0 * x0;
+    double x0_cube = x0_sqr * x0;
+    double x1 = x(1);
+    double x1_sqr = x1 * x1;
+    double x1_cube = x1_sqr * x1;
+    return a0 + a1 * x0 + a2 * x1 + a3 * x0 * x1 + a4 * x0_sqr + a5 * x1_sqr +
+           a6 * x0_cube + a7 * x0_sqr * x1 + a8 * x1_sqr * x0 + a9 * x1_cube;
+  }
+
+  static double EvalAnalyticalIntegralOverUnitTriangle() {
+    // The integral of the monomial 1, x, xy and x² over the unit triangle with
+    // end points at (0,0), (1,0) and (0,1) are
+    //     ∫₀¹∫₀¹⁻ˣ 1 dydx =  1/2.
+    //     ∫₀¹∫₀¹⁻ˣ x dydx =  1/6.
+    //     ∫₀¹∫₀¹⁻ʸ xy dxdy =  1/24.
+    //     ∫₀¹∫₀¹⁻ʸ x² dxdy =  1/12.
+    //     ∫₀¹∫₀¹⁻ʸ x²y dxdy =  1/60.
+    //     ∫₀¹∫₀¹⁻ʸ x³ dxdy =  1/20.
+    // So the integral of
+    //     f(x₀, x₁) = a₀ + a₁*x₀ + a₂*x₁ + a₃*x₀*x₁ + a₄*x₀² + a₅*x₁² + a₆*x₀³
+    //     + a₇*x₀x₁² + a₈x₀²x₁ + a₉*x₁³
+    //  is equal to
+    //     1/2 * a₀ + 1/6 * a₁ + 1/6 * a₂ + 1/24 * a₃ + 1/12 * a₄ + 1/12 * a₅ +
+    //     1/20 * a6 + 1/60 * a7 + 1/60 * a8 + 1/20 * a9.
+    return 0.5 * a0 + 1.0 / 6.0 * a1 + 1.0 / 6.0 * a2 + 1.0 / 24.0 * a3 +
+           1.0 / 12.0 * a4 + 1.0 / 12.0 * a5 + 1.0 / 20.0 * a6 +
+           1.0 / 60.0 * a7 + 1.0 / 60 * a8 + 1.0 / 20.0 * a9;
+  }
+};
+
+struct LinearTestFunction3D {
+  static constexpr double a0 = 1.0;
+  static constexpr double a1 = 3.0;
+  static constexpr double a2 = -2.0;
+  static constexpr double a3 = -4.0;
+
+  // Returns the value of function
+  //     y(x₀, x₁, x₂) = a₀ + a₁ * x₀+ a₂ * x₁+ a₃ * x₂
+  // evaluated at input x.
+  static double Eval(const Vector3d& x) {
+    return a0 + a1 * x(0) + a2 * x(1) + a3 * x(2);
+  }
+
+  static double EvalAnalyticalIntegralOverUnitTet() {
+    // The integral of the monomial 1 and x over the unit tetrahedron with end
+    // points at (0,0,0), (1,0,0), (0,1,0) and (0,0,1) is
+    //     ∫₀¹∫₀¹⁻ˣ∫₀¹⁻ˣ⁻ʸ 1 dzdydx =  1/6.
+    //     ∫₀¹∫₀¹⁻ˣ∫₀¹⁻ˣ⁻ʸ x dzdydx =  1/24.
+    // So the integral of f(x) = a₀ + a₁*x₀ + a₂*x₁ + a₃*x₂ is equal to
+    //     1/6 * a₀ + 1/24 * a₁ + 1/24 * a₂ + 1/24 * a₃.
+    return 1.0 / 6.0 * a0 + 1.0 / 24.0 * a1 + 1.0 / 24.0 * a2 + 1.0 / 24.0 * a3;
+  }
+};
+
+struct QuadraticTestFunction3D {
+  static constexpr double a0 = 1.0;
+  static constexpr double a1 = 3.0;
+  static constexpr double a2 = -2.0;
+  static constexpr double a3 = -4.0;
+  static constexpr double a4 = -2.7;
+  static constexpr double a5 = -1.3;
+  static constexpr double a6 = 7.0;
+  static constexpr double a7 = -3.6;
+  static constexpr double a8 = -2.1;
+  static constexpr double a9 = 5.3;
+
+  // Returns the value of function
+  //     y(x₀, x₁, x₂) = a₀ + a₁ * x₀+ a₂ * x₁+ a₃ * x₂ + a₄ * x₀*x₁ + a₅ *
+  //     x₀*x₂ + a₆ * x₁*x₂ + a₇*x₀²  + a₈*x₁² + a₉*x₂².
+  // evaluated at input x.
+  static double Eval(const Vector3d& x) {
+    return a0 + a1 * x(0) + a2 * x(1) + a3 * x(2) + a4 * x(0) * x(1) +
+           a5 * x(0) * x(2) + a6 * x(1) * x(2) + a7 * x(0) * x(0) +
+           a8 * x(1) * x(1) + a9 * x(2) * x(2);
+  }
+
+  static double EvalAnalyticalIntegralOverUnitTet() {
+    // The integral of the monomial 1, x, xy, and  x² over the unit tetrahedron
+    // with end points at (0,0,0), (1,0,0), (0,1,0) and (0,0,1) is
+    //     ∫₀¹∫₀¹⁻ˣ∫₀¹⁻ˣ⁻ʸ 1 dzdydx =  1/6.
+    //     ∫₀¹∫₀¹⁻ˣ∫₀¹⁻ˣ⁻ʸ x dzdydx =  1/24.
+    //     ∫₀¹∫₀¹⁻ˣ∫₀¹⁻ˣ⁻ʸ xy dzdydx =  1/120.
+    //     ∫₀¹∫₀¹⁻ˣ∫₀¹⁻ˣ⁻ʸ x² dzdydx =  1/60.
+    // So the integral of  f(x) = a₀ + a₁ * x₀+ a₂ * x₁+ a₃ * x₂  + a₄ * x₀*x₁ +
+    // a₅ * x₀*x₂ + a₆ * x₁*x₂ + a₇*x₀²  + a₈*x₁² + a₉*x₂² is equal to
+    //     1/6 * a₀ + 1/24 * a₁ + 1/24 * a₂ + 1/24 * a₃ + 1/120 * a₄ + 1/120 *
+    //     a₅ + 1/120 * a₆ + 1/60 * a₇ + 1/60 * a₈ + 1/60 * a₉
+    return 1.0 / 6.0 * a0 + 1.0 / 24.0 * a1 + 1.0 / 24.0 * a2 +
+           1.0 / 24.0 * a3 + 1.0 / 120.0 * a4 + 1.0 / 120.0 * a5 +
+           1.0 / 120.0 * a6 + 1.0 / 60.0 * a7 + 1.0 / 60.0 * a8 +
+           1.0 / 60.0 * a9;
+  }
+};
+
+struct CubicTestFunction3D {
+  static constexpr double a0 = 1.0;
+  static constexpr double a1 = 3.0;
+  static constexpr double a2 = -2.0;
+  static constexpr double a3 = -4.0;
+  static constexpr double a4 = -2.7;
+  static constexpr double a5 = -1.3;
+  static constexpr double a6 = 7.0;
+  static constexpr double a7 = -3.6;
+  static constexpr double a8 = -2.1;
+  static constexpr double a9 = 5.3;
+  static constexpr double a10 = 1.2;
+  static constexpr double a11 = 2.3;
+  static constexpr double a12 = 3.4;
+  static constexpr double a13 = 4.5;
+  static constexpr double a14 = 5.6;
+  static constexpr double a15 = 6.7;
+  static constexpr double a16 = 7.8;
+  static constexpr double a17 = 8.9;
+  static constexpr double a18 = 9.0;
+  static constexpr double a19 = 1.2;
+
+  // Returns the value of function
+  //     y(x₀, x₁, x₂) = a₀ + a₁x₀ + a₂x₁ + a₃x₂ + a₄x₀x₁ + a₅x₀x₂ + a₆x₁x₂ +
+  //     a₇x₀²  + a₈x₁² + a₉x₂² + a₁₀x₀³ + a₁₁x₁³ + a₁₂x₂³ +  a₁₃x₀²x₁ +
+  //     a₁₄x₀x₁² + a₁₅x₀²x₂ + a₁₆x₀x₂² + a₁₇x₁²x₂ + a₁₈x₁x₂² + a₁₉x₁x₂x₃.
+  // evaluated at input x.
+  static double Eval(const Vector3d& x) {
+    double x0 = x(0);
+    double x0_sqr = x0 * x0;
+    double x0_cube = x0_sqr * x0;
+    double x1 = x(1);
+    double x1_sqr = x1 * x1;
+    double x1_cube = x1_sqr * x1;
+    double x2 = x(2);
+    double x2_sqr = x2 * x2;
+    double x2_cube = x2_sqr * x2;
+    return a0 + a1 * x0 + a2 * x1 + a3 * x2 + a4 * x0 * x1 + a5 * x0 * x2 +
+           a6 * x1 * x2 + a7 * x0_sqr + a8 * x1_sqr + a9 * x2_sqr +
+           a10 * x0_cube + a11 * x1_cube + a12 * x2_cube + a13 * x0_sqr * x1 +
+           a14 * x0 * x1_sqr + a15 * x0_sqr * x2 + a16 * x0 * x2_sqr +
+           a17 * x1_sqr * x2 + a18 * x1 * x2_sqr + a19 * x0 * x1 * x2;
+  }
+
+  static double EvalAnalyticalIntegralOverUnitTet() {
+    // The integral of the monomial 1, x, xy, and  x² over the unit tetrahedron
+    // with end points at (0,0,0), (1,0,0), (0,1,0) and (0,0,1) is
+    //     ∫₀¹∫₀¹⁻ˣ∫₀¹⁻ˣ⁻ʸ 1 dzdydx =  1/6.
+    //     ∫₀¹∫₀¹⁻ˣ∫₀¹⁻ˣ⁻ʸ x dzdydx =  1/24.
+    //     ∫₀¹∫₀¹⁻ˣ∫₀¹⁻ˣ⁻ʸ xy dzdydx =  1/120.
+    //     ∫₀¹∫₀¹⁻ˣ∫₀¹⁻ˣ⁻ʸ x² dzdydx =  1/60.
+    //     ∫₀¹∫₀¹⁻ˣ∫₀¹⁻ˣ⁻ʸ xyz dzdydx =  1/720.
+    //     ∫₀¹∫₀¹⁻ˣ∫₀¹⁻ˣ⁻ʸ x²y dzdydx =  1/360.
+    //     ∫₀¹∫₀¹⁻ˣ∫₀¹⁻ˣ⁻ʸ x³ dzdydx =  1/120.
+    // So the integral of
+    //     f(x₀, x₁, x₂) = a₀ + a₁x₀ + a₂x₁ + a₃x₂ + a₄x₀x₁ + a₅x₀x₂ + a₆x₁x₂ +
+    //     a₇x₀² + a₈x₁² + a₉x₂² + a₁₀x₀³ + a₁₁x₁³ + a₁₂x₂³ +  a₁₃x₀²x₁ +
+    //     a₁₄x₀x₁² + a₁₅x₀²x₂ + a₁₆x₀x₂² + a₁₇x₁²x₂ + a₁₈x₁x₂² + a₁₉x₁x₂x₃
+    // is equal to
+    //     1/6 * a₀ + 1/24 * (a₁ + a₂ + a₃) + 1/120 * (a₄ + a₅ + a₆) +
+    //     1/60 * (a₇ + a₈ + a₉) + 1/120 * (a₁₀ + a₁₁ + a₁₂) + 1/360 * (a₁₃ +
+    //     a₁₄ + a₁₅ + a₁₆ + a₁₇ + a₁₈) + 1/720 * a₁₉.
+    return 1.0 / 6.0 * a0 + 1.0 / 24.0 * (a1 + a2 + a3) +
+           1.0 / 120.0 * (a4 + a5 + a6) + 1.0 / 60.0 * (a7 + a8 + a9) +
+           1.0 / 120.0 * (a10 + a11 + a12) +
+           1.0 / 360.0 * (a13 + a14 + a15 + a16 + a17 + a18) +
+           1.0 / 720.0 * a19;
+  }
+};
+
+class SimplexGaussianQuadratureTest : public ::testing::Test {
+  void SetUp() override {}
+
+ protected:
+  template <int NaturalDim, int NumQuadratureLocations>
+  double Integrate(const Quadrature<
+                       NaturalDim, NumQuadratureLocations>& quadrature,
+                   double (*f)(const Eigen::Matrix<double, NaturalDim, 1>&)) {
+    double numerical_integral = 0;
+    for (int i = 0; i < NumQuadratureLocations; ++i) {
+      numerical_integral +=
+          quadrature.get_weight(i) * f(quadrature.get_point(i));
+    }
+    return numerical_integral;
+  }
+
+  SimplexGaussianQuadrature<2, 1> linear_2d_quadrature_;
+  SimplexGaussianQuadrature<2, 2> quadratic_2d_quadrature_;
+  SimplexGaussianQuadrature<2, 3> cubic_2d_quadrature_;
+  SimplexGaussianQuadrature<3, 1> linear_3d_quadrature_;
+  SimplexGaussianQuadrature<3, 2> quadratic_3d_quadrature_;
+  SimplexGaussianQuadrature<3, 3> cubic_3d_quadrature_;
+};
+
+TEST_F(SimplexGaussianQuadratureTest, Linear2D) {
+  // Linear Gaussian quadrature only needs 1 quadrature point.
+  EXPECT_EQ(linear_2d_quadrature_.num_quadrature_points(), 1);
+  // Numerical integral of f = ∑ᵢ wᵢ f(xᵢ) where wᵢ is the weight of the i-th
+  // quadrature point and xᵢ is the location of the i-th quadrature point.
+  double numerical_integral =
+      Integrate(linear_2d_quadrature_, LinearTestFunction2D::Eval);
+  EXPECT_NEAR(LinearTestFunction2D::EvalAnalyticalIntegralOverUnitTriangle(),
+              numerical_integral, std::numeric_limits<double>::epsilon());
+}
+
+TEST_F(SimplexGaussianQuadratureTest, Linear3D) {
+  // Linear Gaussian quadrature only needs 1 quadrature point.
+  EXPECT_EQ(linear_3d_quadrature_.num_quadrature_points(), 1);
+  // Numerical integral of f = ∑ᵢ wᵢ f(xᵢ) where wᵢ is the weight of the i-th
+  // quadrature point and xᵢ is the location of the i-th quadrature point.
+  double numerical_integral =
+      Integrate(linear_3d_quadrature_, LinearTestFunction3D::Eval);
+  EXPECT_NEAR(LinearTestFunction3D::EvalAnalyticalIntegralOverUnitTet(),
+              numerical_integral, std::numeric_limits<double>::epsilon());
+}
+
+TEST_F(SimplexGaussianQuadratureTest, Quadratic2D) {
+  // Quadratic Gaussian quadrature needs 3 quadrature point.
+  EXPECT_EQ(quadratic_2d_quadrature_.num_quadrature_points(), 3);
+  // Numerical integral of f = ∑ᵢ wᵢ f(xᵢ) where wᵢ is the weight of the i-th
+  // quadrature point and xᵢ is the location of the i-th quadrature point.
+  double numerical_integral =
+      Integrate(quadratic_2d_quadrature_, QuadraticTestFunction2D::Eval);
+  EXPECT_NEAR(QuadraticTestFunction2D::EvalAnalyticalIntegralOverUnitTriangle(),
+              numerical_integral, std::numeric_limits<double>::epsilon());
+}
+
+TEST_F(SimplexGaussianQuadratureTest, Quadratic3D) {
+  // Quadratic Gaussian quadrature needs 3 quadrature point.
+  EXPECT_EQ(quadratic_3d_quadrature_.num_quadrature_points(), 4);
+  // Numerical integral of f = ∑ᵢ wᵢ f(xᵢ) where wᵢ is the weight of the i-th
+  // quadrature point and xᵢ is the location of the i-th quadrature point.
+  double numerical_integral =
+      Integrate(quadratic_3d_quadrature_, QuadraticTestFunction3D::Eval);
+  EXPECT_NEAR(QuadraticTestFunction3D::EvalAnalyticalIntegralOverUnitTet(),
+              numerical_integral, std::numeric_limits<double>::epsilon());
+}
+
+TEST_F(SimplexGaussianQuadratureTest, Cubic2D) {
+  // Cubic Gaussian quadrature needs 4 quadrature point.
+  EXPECT_EQ(cubic_2d_quadrature_.num_quadrature_points(), 4);
+  // Numerical integral of f = ∑ᵢ wᵢ f(xᵢ) where wᵢ is the weight of the i-th
+  // quadrature point and xᵢ is the location of the i-th quadrature point.
+  double numerical_integral =
+      Integrate(cubic_2d_quadrature_, CubicTestFunction2D::Eval);
+  EXPECT_NEAR(CubicTestFunction2D::EvalAnalyticalIntegralOverUnitTriangle(),
+              numerical_integral, std::numeric_limits<double>::epsilon());
+}
+
+TEST_F(SimplexGaussianQuadratureTest, Cubic3D) {
+  // Cubic Gaussian quadrature needs 5 quadrature point.
+  EXPECT_EQ(cubic_3d_quadrature_.num_quadrature_points(), 5);
+  // Numerical integral of f = ∑ᵢ wᵢ f(xᵢ) where wᵢ is the weight of the i-th
+  // quadrature point and xᵢ is the location of the i-th quadrature point.
+  double numerical_integral =
+      Integrate(cubic_3d_quadrature_, CubicTestFunction3D::Eval);
+  EXPECT_NEAR(CubicTestFunction3D::EvalAnalyticalIntegralOverUnitTet(),
+              numerical_integral, std::numeric_limits<double>::epsilon());
+}
+}  // namespace
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Refactor the FEM quadrature implementation in Drake. Add additional
template parameter so that the size of the quadrature points and the
weights are available at compile time. The unit tests are the same as
in the previous implementation except for syntactic changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14448)
<!-- Reviewable:end -->
