### PR TITLE
Implement MBP::GetUniqueBaseBody()

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -439,6 +439,11 @@ void DoScalarDependentDefinitions(py::module m, T) {
             },
             py::arg("body"), py::arg("V_WB"), py::arg("context"),
             cls_doc.SetFreeBodySpatialVelocity.doc_3args)
+        .def("HasUniqueFreeBaseBody", &Class::HasUniqueFreeBaseBody,
+            py::arg("model_instance"), cls_doc.HasUniqueFreeBaseBody.doc)
+        .def("GetUniqueFreeBaseBodyOrThrow",
+            &Class::GetUniqueFreeBaseBodyOrThrow, py::arg("model_instance"),
+            cls_doc.GetUniqueFreeBaseBodyOrThrow.doc)
         .def(
             "EvalBodyPoseInWorld",
             [](const Class* self, const Context<T>& context,

--- a/examples/allegro_hand/joint_control/allegro_single_object_simulation.cc
+++ b/examples/allegro_hand/joint_control/allegro_single_object_simulation.cc
@@ -42,6 +42,7 @@ using math::RigidTransformd;
 using math::RollPitchYawd;
 using multibody::JointActuator;
 using multibody::JointActuatorIndex;
+using multibody::ModelInstanceIndex;
 using multibody::MultibodyPlant;
 
 DEFINE_double(simulation_time, std::numeric_limits<double>::infinity(),
@@ -105,7 +106,7 @@ void DoMain() {
       "drake/examples/allegro_hand/joint_control/simple_mug.sdf");
   multibody::Parser parser(&plant);
   parser.AddModelFromFile(hand_model_path);
-  parser.AddModelFromFile(object_model_path);
+  ModelInstanceIndex mug_model = parser.AddModelFromFile(object_model_path);
 
   // Weld the hand to the world frame
   const auto& joint_hand_root = plant.GetBodyByName("hand_root");
@@ -268,7 +269,6 @@ void DoMain() {
   diagram->SetDefaultContext(diagram_context.get());
 
   // Set the position of object
-  const multibody::Body<double>& mug = plant.GetBodyByName("main_body");
   const multibody::Body<double>& hand = plant.GetBodyByName("hand_root");
   systems::Context<double>& plant_context =
       diagram->GetMutableSubsystemContext(plant, diagram_context.get());
@@ -279,7 +279,8 @@ void DoMain() {
   RigidTransformd X_WM(
       RollPitchYawd(M_PI / 2, 0, 0),
       p_WHand + Eigen::Vector3d(0.095, 0.062, 0.095));
-  plant.SetFreeBodyPose(&plant_context, mug, X_WM);
+  plant.SetFreeBodyPose(&plant_context,
+                        plant.GetUniqueFreeBaseBodyOrThrow(mug_model), X_WM);
 
   // set the initial command for the hand
   hand_command_receiver.set_initial_position(

--- a/examples/simple_gripper/simple_gripper.cc
+++ b/examples/simple_gripper/simple_gripper.cc
@@ -36,6 +36,7 @@ using math::RollPitchYawd;
 using multibody::Body;
 using multibody::ConnectContactResultsToDrakeVisualizer;
 using multibody::CoulombFriction;
+using multibody::ModelInstanceIndex;
 using multibody::MultibodyPlant;
 using multibody::Parser;
 using multibody::PrismaticJoint;
@@ -166,7 +167,7 @@ int do_main() {
 
   full_name =
       FindResourceOrThrow("drake/examples/simple_gripper/simple_mug.sdf");
-  parser.AddModelFromFile(full_name);
+  ModelInstanceIndex mug_model = parser.AddModelFromFile(full_name);
 
   // Obtain the "translate_joint" axis so that we know the direction of the
   // forced motions. We do not apply gravity if motions are forced in the
@@ -302,9 +303,6 @@ int do_main() {
   // Set initial position of the left finger.
   finger_slider.set_translation(&plant_context, -FLAGS_grip_width);
 
-  // Get mug body so we can set its initial pose.
-  const Body<double>& mug = plant.GetBodyByName("main_body");
-
   // Initialize the mug pose to be right in the middle between the fingers.
   const Vector3d& p_WBr =
       plant.EvalBodyPoseInWorld(plant_context, right_finger).translation();
@@ -316,7 +314,8 @@ int do_main() {
       RollPitchYawd(FLAGS_rx * M_PI / 180, FLAGS_ry * M_PI / 180,
                     (FLAGS_rz * M_PI / 180) + M_PI),
       Vector3d(0.0, mug_y_W, 0.0));
-  plant.SetFreeBodyPose(&plant_context, mug, X_WM);
+  plant.SetFreeBodyPose(&plant_context,
+                        plant.GetUniqueFreeBaseBodyOrThrow(mug_model), X_WM);
 
   // Set the initial height of the gripper and its initial velocity so that with
   // the applied harmonic forces it continues to move in a harmonic oscillation

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -2238,6 +2238,29 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       systems::Context<T>* context,
       const Frame<T>& frame_F, const Body<T>& body,
       const math::RigidTransform<T>& X_FB) const;
+
+  /// If there exists a unique base body that belongs to the model given by
+  /// `model_instance` and that unique base body is free
+  /// (see HasUniqueBaseBody()), return that free body. Throw an exception
+  /// otherwise.
+  /// @throws std::exception if called pre-finalize.
+  /// @throws std::exception if `model_instance` is not valid.
+  /// @throws std::exception if HasUniqueFreeBaseBody(model_instance) == false.
+  const Body<T>& GetUniqueFreeBaseBodyOrThrow(
+      ModelInstanceIndex model_instance) const {
+    DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+    return internal_tree().GetUniqueFreeBaseBodyOrThrowImpl(model_instance);
+  }
+
+  /// Return true if there exists a unique base body in the model given by
+  /// `model_instance` and that unique base body is free.
+  /// @throws std::exception if called pre-finalize.
+  /// @throws std::exception if `model_instance` is not valid.
+  bool HasUniqueFreeBaseBody(ModelInstanceIndex model_instance) const {
+    DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+    return internal_tree().HasUniqueFreeBaseBodyImpl(model_instance);
+  }
+
   /// @} <!-- Working with free bodies -->
 
   /// @anchor mbp_kinematic_and_dynamic_computations

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -745,6 +745,13 @@ class MultibodyTree {
     return it->second;
   }
 
+  // Implements MultibodyPlant::HasUniqueFreeBaseBody.
+  bool HasUniqueFreeBaseBodyImpl(ModelInstanceIndex model_instance) const;
+
+  // Implements MultibodyPlant::GetUniqueFreeBaseBodyOrThrow.
+  const Body<T>& GetUniqueFreeBaseBodyOrThrowImpl(
+      ModelInstanceIndex model_instance) const;
+
   // @name Querying for multibody elements by name
   // These methods allow a user to query whether a given multibody element is
   // part of `this` model. These queries can be performed at any time during
@@ -2982,6 +2989,14 @@ class MultibodyTree {
     }
     return range.first->second;
   }
+
+  // If there exists a unique base body (a body whose parent is the world body)
+  // in the model given by `model_instance`, return the index of that body.
+  // Otherwise return std::nullopt. In particular, if the given `model_instance`
+  // is the world model instance, return `std::nullopt`.
+  // @throws std::exception if `model_instance` is not valid.
+  std::optional<BodyIndex> MaybeGetUniqueBaseBodyIndex(
+      ModelInstanceIndex model_instance) const;
 
   // TODO(amcastro-tri): In future PR's adding MBT computational methods, write
   // a method that verifies the state of the topology with a signature similar


### PR DESCRIPTION
In addition, implement MBP::SetFreeBodyPose(Context*,
ModelInstanceIndex, const RigidTransform&).

Fix #9747. Resolve the third item in #10736.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14450)
<!-- Reviewable:end -->
