### PR TITLE
Refactor IsoparametricElement to remove heap allocation

### DIFF
--- a/multibody/fixed_fem/dev/BUILD.bazel
+++ b/multibody/fixed_fem/dev/BUILD.bazel
@@ -11,6 +11,27 @@ package(
 )
 
 drake_cc_library(
+    name = "isoparametric_element",
+    hdrs = [
+        "isoparametric_element.h",
+    ],
+    deps = [
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "linear_simplex_element",
+    hdrs = [
+        "linear_simplex_element.h",
+    ],
+    deps = [
+        ":isoparametric_element",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
     name = "quadrature",
     hdrs = [
         "quadrature.h",
@@ -28,6 +49,23 @@ drake_cc_library(
     ],
     deps = [
         ":quadrature",
+    ],
+)
+
+drake_cc_googletest(
+    name = "isoparametric_element_test",
+    deps = [
+        ":isoparametric_element",
+        ":linear_simplex_element",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "linear_simplex_element_test",
+    deps = [
+        ":linear_simplex_element",
     ],
 )
 

--- a/multibody/fixed_fem/dev/isoparametric_element.h
+++ b/multibody/fixed_fem/dev/isoparametric_element.h
@@ -1,0 +1,230 @@
+#pragma once
+#include <array>
+#include <utility>
+
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+/** IsoparametricElement is a class that evaluates shape functions
+ and their derivatives at prescribed locations. The shape function
+ `S` located at a vertex `a` maps the parent domain to a scalar. The reference
+ position `X` as well as `u(X)`, an arbitrary function on the reference domain,
+ can be interpolated from nodal values `Xₐ` and `uₐ` to any location in the
+ parent domain using the shape function, i.e.:
+
+ <pre>
+     X(ξ) = Sₐ(ξ)Xₐ, and
+     u(X(ξ)) = Sₐ(ξ)uₐ,
+ </pre>
+
+ where ξ ∈ ℝᵈ is in the parent domain and d is its dimension (and we call it the
+ natural dimension), which may be different from the dimension of X, which we
+ call the spatial dimension (e.g. 2D membrane or shell element in 3D dynamics
+ simulation has natural dimension 2 and spatial dimension 3). The constructor
+ for this class takes in an array of locations at which we may evaluate and/or
+ interpolate various quantities. If you need to evaluate and/or interpolate at
+ other locations, construct another instance of %IsoparametricElement and pass
+ the new locations into the constructor.
+
+ %IsoparametricElement serves as the interface base class. Since shape
+ functions are usually evaluated in computationally intensive inner loops of the
+ simulation, the overhead caused by virtual methods may be significant.
+ Therefore, this class uses CRTP to achieve compile-time polymorphism
+ and avoids the overhead of virtual methods, and permits inlining instead.
+ Concrete isoparametric elements must inherit from this base class and implement
+ the interface this class provides. The derived isoparametric element must also
+ be accompanied by a corresponding traits class that declares the compile time
+ quantities and type declarations that this base class requires. One cannot
+ combine the derived class and the traits class because the derived class is
+ incomplete at the time when the traits is needed.
+ @tparam DerivedElement The concrete isoparametric element that inherits
+ from %IsoparametricElement through CRTP.
+ @tparam DerivedTraits The traits class associated with the DerivedElement. */
+template <class DerivedElement, class DerivedTraits>
+class IsoparametricElement {
+ public:
+  /** The number of locations to evaluate various quantities in the
+   element. */
+  static constexpr int num_sample_locations() {
+    return DerivedTraits::kNumSampleLocations;
+  }
+
+  /** The dimension of the parent domain. */
+  static constexpr int natural_dimension() {
+    return DerivedTraits::kNaturalDimension;
+  }
+
+  /** The dimension of the spatial domain. */
+  static constexpr int spatial_dimension() {
+    return DerivedTraits::kSpatialDimension;
+  }
+
+  /** The number of nodes in the element. E.g. 3 for linear triangles, 9 for
+   quadratic quadrilaterals and 4 for linear tetrahedrons. */
+  static constexpr int num_nodes() { return DerivedTraits::kNumNodes; }
+
+  /** std::array of size `num_sample_locations()`. */
+  template <typename U>
+  using ArrayType = std::array<U, num_sample_locations()>;
+
+  using T = typename DerivedTraits::Scalar;
+
+  /** Type of locations at which to evaluate and/or interpolate numerical
+   quantities from nodes. */
+  using LocationsType = ArrayType<Vector<T, natural_dimension()>>;
+
+  /** Fixed size matrix type to store the Jacobian matrix. */
+  using JacobianMatrix =
+      Eigen::Matrix<T, spatial_dimension(), natural_dimension()>;
+
+  /** Fixed size matrix type to store the pseudoinverse Jacobian matrix. */
+  using PseudoinverseJacobianMatrix =
+      Eigen::Matrix<T, natural_dimension(), spatial_dimension()>;
+
+  /** Returns the array of sample locations in the parent domain at which the
+   isoparametric element evaluates elemental quantities, as provided at
+   construction. */
+  const LocationsType& locations() const { return locations_; }
+
+  /** Obtains the shape function array
+     <pre>
+          S(ξ) = [S₀(ξ); S₁(ξ); ... Sₐ(ξ); ...; Sₙ₋₁(ξ)]
+     </pre>
+   at each location in the parent domain provided at construction.
+   @returns an array of size equal to `num_sample_locations()`. The q-th entry
+   contains the vector S(ξ), of size num_nodes(), evaluated at the
+   q-th sample location in the parent domain provided at construction.
+   The a-th component of S(ξ) corresponds to the shape function Sₐ(ξ) for node
+   a. */
+  const ArrayType<Vector<T, num_nodes()>>& GetShapeFunctions() const {
+    const DerivedElement& derived = static_cast<const DerivedElement&>(*this);
+    return derived.GetShapeFunctions();
+  }
+
+  /** Obtains the gradient of the shape functions in parent coordinates, dS/dξ,
+   evaluated at each location in the parent domain provided at construction.
+   @returns an array of size `num_sample_locations()`. The q-th entry contains
+   the matrix dS/dξ, of size `num_nodes()`-by-`natural_dimension()`, evaluated
+   at the q-th sample location in the parent domain provided at construction.
+   The a-th row of the matrix gives the derivatives dSₐ/dξ for node a. */
+  const ArrayType<Eigen::Matrix<T, num_nodes(), natural_dimension()>>&
+  GetGradientInParentCoordinates() const {
+    const DerivedElement& derived = static_cast<const DerivedElement&>(*this);
+    return derived.GetGradientInParentCoordinates();
+  }
+
+  // TODO(xuchenhan-tri): Implement CalcGradientInSpatialCoordinates().
+
+  /** Computes the Jacobian matrix, dx/dξ, at each location in the parent domain
+   provided at construction.
+   @param xa Spatial coordinates for each element node stored column-wise.
+   @returns an array of size 'num_sample_locations()`. The q-th entry contains
+   the Jacobian matrix dx/dξ, of size
+   `spatial_dimension()`-by-`natural_dimension()`, evaluated at the q-th sample
+   location in the parent domain provided at construction. */
+  ArrayType<JacobianMatrix> CalcJacobian(
+      const Eigen::Ref<
+          const Eigen::Matrix<T, spatial_dimension(), num_nodes()>>& xa) const {
+    ArrayType<JacobianMatrix> dxdxi;
+    const ArrayType<Eigen::Matrix<T, num_nodes(), natural_dimension()>>& dSdxi =
+        GetGradientInParentCoordinates();
+    for (int q = 0; q < num_sample_locations(); ++q) {
+      dxdxi[q] = xa * dSdxi[q];
+    }
+    return dxdxi;
+  }
+
+  /** Computes dξ/dx, the pseudoinverse Jacobian matrix, at each sample location
+   in the parent domain provided at construction.
+   @param xa Spatial coordinates for each element node stored column-wise.
+   @returns an array of size `num_sample_locations()`. The q-th entry contains
+   the pseudoinverse Jacobian dξ/dx, of size
+   `natural_dimension()`-by-`spatial_dimension()`, evaluated at the q-th sample
+   location in the parent domain provided at construction.
+   @pre the element with node positions `xa` must not be degenerate.
+   @see CalcJacobian().  */
+  ArrayType<PseudoinverseJacobianMatrix> CalcJacobianPseudoinverse(
+      const Eigen::Ref<
+          const Eigen::Matrix<T, spatial_dimension(), num_nodes()>>& xa) const {
+    ArrayType<JacobianMatrix> dxdxi = CalcJacobian(xa);
+    return CalcJacobianPseudoinverse(dxdxi);
+  }
+
+  /** Preferred signature for computing dξ/dx when the Jacobian matrices are
+   available so as to avoid recomputing the Jacobian matrices.
+   @param jacobian An array of size `num_sample_locations()`. The q-th entry
+   contains the Jacobian matrix dx/dξ, of size
+   `spatial_dimension()`-by-`natural_dimension()`, evaluated at the q-th sample
+   location in the parent domain provided at construction.
+   @pre Each entry in `jacobian` must be full rank.
+   @see CalcJacobian(). */
+  /* Suppose the Jacobian matrix J = dx/dξ is m×n where m >= n. We are looking
+   for a n×m matrix A = dξ/dx. By the chain rule, AJ = I. In fact A is the
+   pseudoinverse of J. To see that, observe that AJA = A, JAJ = J, (AJ)ᵀ = AJ.
+   The only nontrivial fact is that (JA)ᵀ = JA. To see that, QR decompose J so
+   that J = QR where Q is orthogonal and R is upper triangular, and define B =
+   AQ. Here R and B are the dx/dξ and dξ/dx in the Q bases, and thus the m-n
+   right-most columns of B are zero. Restricting B and R to their top-left n×n
+   corners (call them B̂ and R̂̂), we get R̂B̂ = B̂ᵀR̂̂ᵀ = Iₙₓₙ. Padding zeros in the
+   correct places, we see that BᵀRᵀ = RB. Therefore, QBᵀRᵀQᵀ = QRBQᵀ which
+   implies AᵀJᵀ = JA. */
+  // TODO(xuchenhan-tri): The rank revealing Eigen::JacobiSVD is used instead of
+  //  Eigen::HouseholderQR to guard against rank-deficiency. This is fine for
+  //  now as this function is only invoked in precomputes at the moment.
+  //  Consider the more performant alternative when we need this in an inner
+  //  loop.
+  ArrayType<PseudoinverseJacobianMatrix> CalcJacobianPseudoinverse(
+      const ArrayType<JacobianMatrix>& jacobian) const {
+    ArrayType<PseudoinverseJacobianMatrix> dxidx;
+    for (int q = 0; q < num_sample_locations(); ++q) {
+      /* Thin unitaries are enough but Eigen does not allow them for fixed size
+       matrix. */
+      Eigen::JacobiSVD<JacobianMatrix> svd(
+          jacobian[q], Eigen::ComputeFullU | Eigen::ComputeFullV);
+      if (svd.rank() != natural_dimension()) {
+        throw std::runtime_error(
+            "The element is degenerate and does not have a valid Jacobian "
+            "pseudoinverse (the pseudoinverse is not the left inverse).");
+      }
+      /* Use SVD to solve for the least square system which gives the
+       pseudoinverse. */
+      dxidx[q] = svd.solve(Eigen::Matrix<T, spatial_dimension(),
+                                         spatial_dimension()>::Identity());
+    }
+    return dxidx;
+  }
+
+  /** Interpolates nodal values `ua` into u(ξ) at each sample location
+   in the parent domain provided at construction.
+   @param ua The value of function u at each element node stored column-wise.
+   @returns an array of size `num_sample_locations()` of the interpolated
+   values of u.
+   @tparam dim The dimension of the value of u. */
+  template <int dim>
+  ArrayType<Vector<T, dim>> InterpolateNodalValues(
+      const Eigen::Ref<const Eigen::Matrix<T, dim, num_nodes()>>& ua) const {
+    const ArrayType<Vector<T, num_nodes()>>& S = GetShapeFunctions();
+    ArrayType<Vector<T, dim>> interpolated_value;
+    for (int q = 0; q < num_sample_locations(); ++q) {
+      interpolated_value[q] = ua * S[q];
+    }
+    return interpolated_value;
+  }
+
+ protected:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(IsoparametricElement);
+
+  /** Constructs an isoparametric element that performs calculations at the
+   locations specified by the input `locations`. */
+  explicit IsoparametricElement(LocationsType locations)
+      : locations_(std::move(locations)) {}
+
+ private:
+  /* The locations at which to evaluate various quantities of this element. */
+  LocationsType locations_;
+};
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/linear_simplex_element.h
+++ b/multibody/fixed_fem/dev/linear_simplex_element.h
@@ -1,0 +1,133 @@
+#pragma once
+
+#include <array>
+#include <utility>
+
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fixed_fem/dev/isoparametric_element.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+/** The number of nodes of 1D simplices (segments) is 2. The number of nodes of
+ 2D simplices (triangles) is 3. The number of nodes of 3D simplices
+ (tetrahedron) is 4. */
+template <int NaturalDimension>
+constexpr int num_linear_simplex_element_nodes() {
+  return NaturalDimension + 1;
+}
+
+/** Traits for LinearSimplexElement. */
+template <typename T, int NaturalDimension, int SpatialDimension,
+          int NumSampleLocations>
+struct LinearSimplexElementTraits {
+  using Scalar = T;
+  static constexpr int kNaturalDimension = NaturalDimension;
+  static constexpr int kSpatialDimension = SpatialDimension;
+  static constexpr int kNumSampleLocations = NumSampleLocations;
+  static constexpr int kNumNodes =
+      num_linear_simplex_element_nodes<NaturalDimension>();
+};
+
+/** A concrete IsoparametricElement for linear simplex elements
+ (segments, triangles and tetrahedrons). In parent domain, the simplex's node
+ are laid out in the following way: the 0-th node is placed at the origin and
+ the i-th node for 1 <= i <= NaturalDimension is placed at the point whose i-th
+ coordinate is 1 and all other coordinates are 0.
+ @tparam NaturalDimension The dimension of the parent domain.
+ @tparam SpatialDimension The dimension of the spatial domain.
+ @tparam NumSampleLocations The number of locations to evaluate interpolations
+ and other calculations are performed. */
+template <typename T, int NaturalDimension, int SpatialDimension,
+          int NumSampleLocations>
+class LinearSimplexElement
+    : public IsoparametricElement<
+          LinearSimplexElement<T, NaturalDimension, SpatialDimension,
+                               NumSampleLocations>,
+          LinearSimplexElementTraits<T, NaturalDimension, SpatialDimension,
+                                     NumSampleLocations>> {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(LinearSimplexElement);
+
+  static_assert(1 <= NaturalDimension && NaturalDimension <= 3,
+                "Only 1, 2 and 3 dimensional manifolds are supported.");
+  static_assert(1 <= SpatialDimension && SpatialDimension <= 3,
+                "Only 1, 2 and 3 spatial dimensions are supported.");
+  static_assert(NaturalDimension <= SpatialDimension,
+                "NaturalDimension must be smaller than or equal to the "
+                "SpatialDimension.");
+  using ElementType =
+      LinearSimplexElement<T, NaturalDimension, SpatialDimension,
+                           NumSampleLocations>;
+  using Traits =
+      LinearSimplexElementTraits<T, NaturalDimension, SpatialDimension,
+                                 NumSampleLocations>;
+  using Base = IsoparametricElement<ElementType, Traits>;
+  using Base::natural_dimension;
+  using Base::num_nodes;
+  using LocationsType = typename Base::LocationsType;
+
+  template <typename U>
+  using ArrayType = typename Base::template ArrayType<U>;
+
+  using JacobianMatrix = typename Base::JacobianMatrix;
+
+  /** Constructs a linear simplex isoparametric element and precomputes the
+   shape functions as well as their gradients. */
+  explicit LinearSimplexElement(LocationsType locations)
+      : Base(std::move(locations)),
+        S_(GetShapeFunctionsHelper()),
+        dSdxi_(GetGradientInParentCoordinatesHelper()) {}
+
+  /** Implements Base::GetShapeFunctions(). */
+  const ArrayType<Vector<T, num_nodes()>>& GetShapeFunctions() const {
+    return S_;
+  }
+
+  /** Implements Base::GetGradientInParentCoordinates(). */
+  const ArrayType<Eigen::Matrix<T, num_nodes(), natural_dimension()>>&
+  GetGradientInParentCoordinates() const {
+    return dSdxi_;
+  }
+
+ private:
+  /* Precomputes the shape functions. */
+  ArrayType<Vector<T, num_nodes()>> GetShapeFunctionsHelper() const {
+    ArrayType<Vector<T, num_nodes()>> S;
+    const LocationsType& locations = this->locations();
+    for (int q = 0; q < this->num_sample_locations(); ++q) {
+      Vector<T, num_nodes()> Sq;
+      // Sₐ = ξₐ₋₁ for a = 1, ..., NumNodes - 1
+      for (int a = 1; a < num_nodes(); ++a) {
+        Sq(a) = locations[q](a - 1);
+      }
+      // S₀ = 1−ξ₀ − ... − ξₙ₋₂
+      Sq(0) = 0;
+      Sq(0) = 1 - Sq.sum();
+      S[q] = Sq;
+    }
+    return S;
+  }
+
+  /* Precomputes the shape function gradients in parent coordinates. */
+  static const ArrayType<Eigen::Matrix<T, num_nodes(), natural_dimension()>>
+  GetGradientInParentCoordinatesHelper() {
+    Eigen::Matrix<T, num_nodes(), natural_dimension()> dSdxi_q;
+    dSdxi_q.template topRows<1>() =
+        -1.0 * Vector<T, natural_dimension()>::Ones();
+    dSdxi_q.template bottomRows<natural_dimension()>() =
+        Eigen::Matrix<T, natural_dimension(), natural_dimension()>::Identity();
+    ArrayType<Eigen::Matrix<T, num_nodes(), natural_dimension()>> dSdxi;
+    dSdxi.fill(dSdxi_q);
+    return dSdxi;
+  }
+
+  /* Shape functions evaluated at points specified at construction. */
+  ArrayType<Vector<T, num_nodes()>> S_;
+  /* Shape function derivatives evaluated at points specified at construction.
+   */
+  ArrayType<Eigen::Matrix<T, num_nodes(), natural_dimension()>> dSdxi_;
+};
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/quadrature.h
+++ b/multibody/fixed_fem/dev/quadrature.h
@@ -8,7 +8,7 @@
 
 namespace drake {
 namespace multibody {
-namespace fem {
+namespace fixed_fem {
 // TODO(xuchenhan-tri): Consider allowing AutoDiffScalar if it simplifies the
 // syntax in the AutoDiff case.
 /** A base class for quadratures that facilitates numerical integrations in FEM.
@@ -24,8 +24,6 @@ class Quadrature {
                 "Only 1, 2 and 3 dimensional shapes are supported.");
   static_assert(1 <= NumLocations,
                 "There has to be at least one quadrature point.");
-
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Quadrature);
 
   using VectorD = Eigen::Matrix<double, NaturalDimension, 1>;
   using LocationsType = std::array<VectorD, NumLocations>;
@@ -56,6 +54,8 @@ class Quadrature {
   }
 
  protected:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Quadrature);
+
   /** Construct a Quadrature object given the quadrature locations and the
    weights of the quadrature points. */
   explicit Quadrature(
@@ -67,6 +67,6 @@ class Quadrature {
   LocationsType points_;
   WeightsType weights_;
 };
-}  // namespace fem
+}  // namespace fixed_fem
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/fixed_fem/dev/simplex_gaussian_quadrature.h
+++ b/multibody/fixed_fem/dev/simplex_gaussian_quadrature.h
@@ -7,12 +7,12 @@
 
 namespace drake {
 namespace multibody {
-namespace fem {
+namespace fixed_fem {
 /** Calculates the number of quadrature points used for simplices given the
  natural dimension and the order of the quadrature rule as template
  parameters. */
 template <int NaturalDim, int Order>
-constexpr int SimplexQuadratureNumLocations() {
+constexpr int num_simplex_quadrature_locations() {
   static_assert(
       1 <= Order && Order <= 3,
       "Only linear, quadratic and cubic quadrature rules are supported.");
@@ -42,10 +42,10 @@ constexpr int SimplexQuadratureNumLocations() {
 template <int NaturalDimension, int Order>
 class SimplexGaussianQuadrature
     : public Quadrature<NaturalDimension,
-          SimplexQuadratureNumLocations<NaturalDimension, Order>()> {
+          num_simplex_quadrature_locations<NaturalDimension, Order>()> {
  public:
   using Base = Quadrature<NaturalDimension,
-      SimplexQuadratureNumLocations<NaturalDimension, Order>()>;
+      num_simplex_quadrature_locations<NaturalDimension, Order>()>;
   using VectorD = typename Base::VectorD;
   using LocationsType = typename Base::LocationsType;
   using WeightsType = typename Base::WeightsType;
@@ -156,6 +156,6 @@ class SimplexGaussianQuadrature
     }
   }
 };
-}  // namespace fem
+}  // namespace fixed_fem
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/fixed_fem/dev/test/isoparametric_element_test.cc
+++ b/multibody/fixed_fem/dev/test/isoparametric_element_test.cc
@@ -1,0 +1,296 @@
+#include "drake/multibody/fixed_fem/dev/isoparametric_element.h"
+
+#include <limits>
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/multibody/fixed_fem/dev/linear_simplex_element.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+namespace {
+
+constexpr int kNumSamplesTri = 4;
+constexpr int kNumSamplesTet = 5;
+
+// Test scalar value 2D function.
+double LinearScalarFunction2D(const Vector2<double>& x) {
+  const Vector2<double> a{1.2, 3.4};
+  return 5.6 + a.dot(x);
+}
+
+// Test vector value 2D function.
+Vector3<double> LinearVectorFunction2D(const Vector2<double>& x) {
+  Eigen::Matrix<double, 3, 2> a;
+  // clang-format off
+  a << 0.1, 1.2, 2.3,
+       3.4, 4.5, 5.6;
+  // clang-format on
+  return Vector3<double>{6.7, 7.8, 8.9} + a * x;
+}
+
+// Test scalar value 3D function.
+double LinearScalarFunction3D(const Vector3<double>& x) {
+  const Vector3<double> a{1.2, 3.4, 7.8};
+  return 9.0 + a.dot(x);
+}
+
+// Test vector value 3D function.
+Vector3<double> LinearVectorFunction3D(const Vector3<double>& x) {
+  Eigen::Matrix<double, 3, 3> a;
+  // clang-format off
+  a << 0.1, 1.2, 2.3,
+       3.4, 4.5, 5.6,
+       6.7, 7.8, 8.9;
+  // clang-format on
+  return Vector3<double>{6.7, 7.8, 8.9} + a * x;
+}
+
+class IsoparametricElementTest : public ::testing::Test {
+ protected:
+  void SetUp() override {}
+
+  // Sample locations for triangle elements.
+  std::array<Vector2<double>, kNumSamplesTri> tri_locations() const {
+    return {{{0.0, 0.0}, {0.1, 0.2}, {1, 0}, {0, 1}}};
+  }
+
+  // Sample locations for tetrahedral elements.
+  std::array<Vector3<double>, kNumSamplesTet> tet_locations() const {
+    return {
+        {{0.0, 0.0, 0.0}, {1, 0, 0}, {0, 1, 0}, {0, 0, 1}, {0.1, 0.2, 0.3}}};
+  }
+
+  // Triangle element in 2d.
+  LinearSimplexElement<double, 2, 2, kNumSamplesTri> tri_2d_{tri_locations()};
+  // Triangle element in 3d.
+  LinearSimplexElement<double, 2, 3, kNumSamplesTri> tri_3d_{tri_locations()};
+  // Tetrahedral element in 3d.
+  LinearSimplexElement<double, 3, 3, kNumSamplesTet> tet_{tet_locations()};
+};
+
+TEST_F(IsoparametricElementTest, NumNodes) {
+  EXPECT_EQ(tri_2d_.num_nodes(), 3);
+  EXPECT_EQ(tri_3d_.num_nodes(), 3);
+  EXPECT_EQ(tet_.num_nodes(), 4);
+}
+
+TEST_F(IsoparametricElementTest, NumPoints) {
+  EXPECT_EQ(tri_2d_.num_sample_locations(), kNumSamplesTri);
+  EXPECT_EQ(tri_3d_.num_sample_locations(), kNumSamplesTri);
+  EXPECT_EQ(tet_.num_sample_locations(), kNumSamplesTet);
+}
+
+TEST_F(IsoparametricElementTest, GetLocation) {
+  const auto& tri_2d_samples = tri_2d_.locations();
+  const auto& tri_3d_samples = tri_3d_.locations();
+  const auto& tet_samples = tet_.locations();
+  EXPECT_EQ(tri_2d_samples, tri_locations());
+  EXPECT_EQ(tri_3d_samples, tri_locations());
+  EXPECT_EQ(tet_samples, tet_locations());
+}
+
+TEST_F(IsoparametricElementTest, Jacobian2DTriangle) {
+  /* Scale the unit triangle by a factor of two to get the reference triangle.
+   */
+  Eigen::Matrix<double, 2, 3> xa;
+  // clang-format off
+  xa << 0, 2, 0,
+        0, 0, 2;
+  // clang-format on
+  const auto dxdxi = tri_2d_.CalcJacobian(xa);
+  EXPECT_EQ(dxdxi.size(), kNumSamplesTri);
+  for (int i = 0; i < kNumSamplesTri; ++i) {
+    EXPECT_TRUE(
+        CompareMatrices(dxdxi[i], 2.0 * MatrixX<double>::Identity(2, 2)));
+  }
+}
+
+TEST_F(IsoparametricElementTest, Jacobian3DTriangle) {
+  /* Put the vertices of the reference triangle at (0,0,0), (0,1,0) and
+  (0,0,2). */
+  Matrix3<double> xa;
+  // clang-format off
+  xa << 0, 0, 0,
+        0, 1, 0,
+        0, 0, 2;
+  // clang-format on
+  const auto dxdxi = tri_3d_.CalcJacobian(xa);
+  EXPECT_EQ(dxdxi.size(), kNumSamplesTri);
+  Eigen::Matrix<double, 3, 2> analytic_dxdxi;
+  // clang-format off
+  analytic_dxdxi << 0, 0,  // The x-coordinate of reference is independent of
+                           // the parent coordinate.
+                    1, 0,  // dy/dxi_0 = 1.  dy/dxi_1 = 0.
+                    0, 2;  // dz/dxi_0 = 0.  dz/dxi_1 = 2.
+  // clang-format on
+  for (int i = 0; i < kNumSamplesTri; ++i) {
+    EXPECT_TRUE(CompareMatrices(dxdxi[i], analytic_dxdxi));
+  }
+}
+
+TEST_F(IsoparametricElementTest, JacobianTetrahedron) {
+  /* Put the vertices of the reference triangle at (0,0,0), (0,1,0) and
+  (0, 0, 2), and (3,0,0). */
+  Eigen::Matrix<double, 3, 4> xa;
+  // clang-format off
+  xa << 0, 0, 0, 3,
+        0, 1, 0, 0,
+        0, 0, 2, 0;
+  // clang-format on
+  const auto dxdxi = tet_.CalcJacobian(xa);
+  EXPECT_EQ(dxdxi.size(), kNumSamplesTet);
+  Matrix3<double> analytic_dxdxi;
+  // clang-format off
+  analytic_dxdxi << 0, 0, 3,  // dx/dxi_0 = 0. dx/dxi_1 = 0. dx/dxi_2 = 3.
+                    1, 0, 0,  // dy/dxi_0 = 1. dy/dxi_1 = 0. dy/dxi_2 = 0.
+                    0, 2, 0;  // dz/dxi_0 = 0. dz/dxi_1 = 2. dz/dxi_2 = 0.
+  // clang-format on
+  for (int i = 0; i < kNumSamplesTet; ++i) {
+    EXPECT_TRUE(CompareMatrices(dxdxi[i], analytic_dxdxi));
+  }
+}
+
+TEST_F(IsoparametricElementTest, JacobianInverse2DTriangle) {
+  /* Initialize a random triangle in 2D that is not degenerate (can be
+   inverted). */
+  Eigen::Matrix<double, 2, 3> xa;
+  // clang-format off
+  xa << 0.65, 0.18, 0.79,
+        0.52, 0.34, 0.34;
+  // clang-format on
+  const auto dxdxi = tri_2d_.CalcJacobian(xa);
+  const auto dxidx = tri_2d_.CalcJacobianPseudoinverse(xa);
+  EXPECT_EQ(dxidx.size(), kNumSamplesTri);
+  for (int i = 0; i < kNumSamplesTri; ++i) {
+    EXPECT_TRUE(CompareMatrices(dxdxi[i] * dxidx[i],
+                                MatrixX<double>::Identity(2, 2),
+                                4.0 * std::numeric_limits<double>::epsilon()));
+    EXPECT_TRUE(
+        CompareMatrices(dxidx[i], tri_2d_.CalcJacobianPseudoinverse(dxdxi)[i]));
+  }
+}
+
+TEST_F(IsoparametricElementTest, JacobianInverse3DTriangle) {
+  /* Initialize a random triangle in 3D that is not degenerate (can be
+   inverted). */
+  Matrix3<double> xa;
+  // clang-format off
+  xa << 0.65, 0.18, 0.79,
+        0.52, 0.34, 0.34,
+        0.58, 0.43, 0.19;
+  // clang-format on
+  const auto dxdxi = tri_3d_.CalcJacobian(xa);
+  const auto dxidx = tri_3d_.CalcJacobianPseudoinverse(xa);
+  EXPECT_EQ(dxidx.size(), kNumSamplesTri);
+  // The normal of the triangle should live in the null space of dξ/dx.
+  auto n = (xa.col(1) - xa.col(0)).cross(xa.col(2) - xa.col(0)).normalized();
+  for (int i = 0; i < kNumSamplesTri; ++i) {
+    /* The Jacobian dx/dξ is of dimension 3 x 2 and has full column rank (2).
+     dξ/dx should be the pseudoinverse of the Jacobian. */
+    EXPECT_TRUE(CompareMatrices(dxidx[i] * dxdxi[i],
+                                MatrixX<double>::Identity(2, 2),
+                                std::numeric_limits<double>::epsilon()));
+    // dx/dξ * dξ/dx should be symmetric.
+    auto A = dxdxi[i] * dxidx[i];
+    EXPECT_TRUE(CompareMatrices(A, A.transpose(),
+                                std::numeric_limits<double>::epsilon()));
+    EXPECT_TRUE(CompareMatrices(VectorX<double>::Zero(2), dxidx[i] * n,
+                                std::numeric_limits<double>::epsilon()));
+  }
+}
+
+TEST_F(IsoparametricElementTest, JacobianInverseTetrahedon) {
+  // Initialize a random tetrahedron in 3D that is not degenerate (can be
+  // inverted).
+  // clang-format off
+  Eigen::Matrix<double, 3, 4> xa;
+  xa << 0.65, 0.18, 0.79, -2.12,
+        0.52, 0.34, 0.34, 0.12,
+        0.58, 0.43, 0.19, -1.34;
+  // clang-format on
+  const auto dxdxi = tet_.CalcJacobian(xa);
+  const auto dxidx = tet_.CalcJacobianPseudoinverse(xa);
+  EXPECT_EQ(dxidx.size(), kNumSamplesTet);
+  for (int i = 0; i < kNumSamplesTet; ++i) {
+    EXPECT_TRUE(CompareMatrices(dxidx[i] * dxdxi[i],
+                                MatrixX<double>::Identity(3, 3),
+                                16.0 * std::numeric_limits<double>::epsilon()));
+  }
+}
+
+TEST_F(IsoparametricElementTest, DegenerateElementPseudoinverseJacobian) {
+  /* Initialize a triangle in 3D that is degenerate. */
+  Matrix3<double> xa;
+  // clang-format off
+    xa << 1, 0, 0.5,
+          0, 1, 0.5,
+          0, 0, 0;
+  // clang-format on
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      tri_3d_.CalcJacobianPseudoinverse(xa), std::exception,
+      "The element is degenerate and does not have a valid Jacobian "
+      "pseudoinverse \\(the pseudoinverse is not the left inverse\\).");
+}
+
+TEST_F(IsoparametricElementTest, InterpolateScalar2D) {
+  const double u0 = LinearScalarFunction2D({0, 0});
+  const double u1 = LinearScalarFunction2D({1, 0});
+  const double u2 = LinearScalarFunction2D({0, 1});
+  const Vector3<double> u(u0, u1, u2);
+  // Linear simplex element should interpolate linear functions perfectly.
+  for (int i = 0; i < kNumSamplesTri; ++i) {
+    EXPECT_DOUBLE_EQ(LinearScalarFunction2D(tri_2d_.locations()[i]),
+                     tri_2d_.InterpolateNodalValues<1>(u.transpose())[i](0));
+  }
+}
+
+TEST_F(IsoparametricElementTest, InterpolateScalar3D) {
+  const double u0 = LinearScalarFunction3D({0, 0, 0});
+  const double u1 = LinearScalarFunction3D({1, 0, 0});
+  const double u2 = LinearScalarFunction3D({0, 1, 0});
+  const double u3 = LinearScalarFunction3D({0, 0, 1});
+  const Vector4<double> u(u0, u1, u2, u3);
+  // Linear simplex element should interpolate linear functions perfectly.
+  for (int i = 0; i < kNumSamplesTet; ++i) {
+    EXPECT_EQ(LinearScalarFunction3D(tet_.locations()[i]),
+              tet_.InterpolateNodalValues<1>(u.transpose())[i](0));
+  }
+}
+
+TEST_F(IsoparametricElementTest, InterpolateVector2D) {
+  const Vector3<double> u0(LinearVectorFunction2D({0, 0}));
+  const Vector3<double> u1(LinearVectorFunction2D({1, 0}));
+  const Vector3<double> u2(LinearVectorFunction2D({0, 1}));
+  Matrix3<double> u;
+  u << u0, u1, u2;
+  // Linear simplex element should interpolate linear functions perfectly.
+  for (int i = 0; i < kNumSamplesTri; ++i) {
+    EXPECT_TRUE(CompareMatrices(LinearVectorFunction2D(tri_2d_.locations()[i]),
+                                tri_2d_.InterpolateNodalValues<3>(u)[i],
+                                8.0 * std::numeric_limits<double>::epsilon()));
+  }
+}
+
+TEST_F(IsoparametricElementTest, InterpolateVector3D) {
+  const Vector3<double> u0(LinearVectorFunction3D({0, 0, 0}));
+  const Vector3<double> u1(LinearVectorFunction3D({1, 0, 0}));
+  const Vector3<double> u2(LinearVectorFunction3D({0, 1, 0}));
+  const Vector3<double> u3(LinearVectorFunction3D({0, 0, 1}));
+  Eigen::Matrix<double, 3, 4> u;
+  u << u0, u1, u2, u3;
+  // Linear simplex element should interpolate linear functions perfectly.
+  for (int i = 0; i < kNumSamplesTet; ++i) {
+    EXPECT_TRUE(CompareMatrices(LinearVectorFunction3D(tet_.locations()[i]),
+                                tet_.InterpolateNodalValues<3>(u)[i],
+                                8.0 * std::numeric_limits<double>::epsilon()));
+  }
+}
+}  // namespace
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/test/linear_simplex_element_test.cc
+++ b/multibody/fixed_fem/dev/test/linear_simplex_element_test.cc
@@ -1,0 +1,105 @@
+#include "drake/multibody/fixed_fem/dev/linear_simplex_element.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+namespace {
+
+constexpr int kNumQuads = 2;
+const std::array<Vector2<double>, kNumQuads> tri_locations{
+    {{0.0, 0.0}, {1.0 / 3.0, 1.0 / 3.0}}};
+const std::array<Vector3<double>, kNumQuads> tet_locations{
+    {{0.0, 0.0, 0.0}, {0.25, 0.25, 0.25}}};
+
+class LinearSimplexElementTest : public ::testing::Test {
+ protected:
+  void SetUp() override {}
+  LinearSimplexElement<double, 2, 2, kNumQuads> tri_{tri_locations};
+  LinearSimplexElement<double, 3, 3, kNumQuads> tet_{tet_locations};
+};
+
+TEST_F(LinearSimplexElementTest, ShapeFunction2D) {
+  const auto& S = tri_.GetShapeFunctions();
+  EXPECT_EQ(S.size(), kNumQuads);
+  // There are three vertices in a triangle.
+  EXPECT_EQ(S[0].size(), 3);
+  EXPECT_EQ(S[1].size(), 3);
+  // The shape function for the 3 nodes of the triangle are 1-x-y, x and y.
+  // The first location to evaluate is at (0, 0).
+  EXPECT_EQ(S[0](0), 1);
+  EXPECT_EQ(S[0](1), 0);
+  EXPECT_EQ(S[0](2), 0);
+
+  // The second location to evaluate is at (1/3, 1/3).
+  for (int i = 0; i < 3; ++i) {
+    EXPECT_DOUBLE_EQ(S[1](i), 1.0 / 3.0);
+  }
+}
+
+TEST_F(LinearSimplexElementTest, ShapeFunction3D) {
+  const auto& S = tet_.GetShapeFunctions();
+  EXPECT_EQ(S.size(), kNumQuads);
+  // There are four vertices in a tetrahedron.
+  for (int q = 0; q < kNumQuads; ++q) {
+    EXPECT_EQ(S[q].size(), 4);
+  }
+  // The shape function for the 4 nodes of the tetrahedron are
+  // 1-x-y-z, x, y and z.
+  // The point to evaluate is at (0, 0, 0).
+  EXPECT_EQ(S[0](0), 1);
+  EXPECT_EQ(S[0](1), 0);
+  EXPECT_EQ(S[0](2), 0);
+  EXPECT_EQ(S[0](3), 0);
+  // The second point to evaluate is at (1/4, 1/4, 1/4).
+  for (int i = 0; i < 4; ++i) {
+    EXPECT_DOUBLE_EQ(S[1](i), 0.25);
+  }
+}
+
+TEST_F(LinearSimplexElementTest, ShapeFunctionDerivative2D) {
+  const auto& dSdxi = tri_.GetGradientInParentCoordinates();
+  EXPECT_EQ(dSdxi.size(), kNumQuads);
+  // The shape function for the 3 nodes of the triangle are 1-x-y, x and y. So
+  // the derivatives with respect to x is [-1, 1, 0], and
+  // the derivatives with respect to y is [-1, 0, 1].
+  Vector3<double> x_deriv(-1, 1, 0);
+  Vector3<double> y_deriv(-1, 0, 1);
+  for (int q = 0; q < kNumQuads; ++q) {
+    // There are three vertices in a triangle.
+    EXPECT_EQ(dSdxi[q].rows(), 3);
+    // The dimension of the parent domain is two.
+    EXPECT_EQ(dSdxi[q].cols(), 2);
+    EXPECT_EQ(dSdxi[q].col(0), x_deriv);
+    EXPECT_EQ(dSdxi[q].col(1), y_deriv);
+  }
+}
+
+TEST_F(LinearSimplexElementTest, ShapeFunctionDerivative3D) {
+  const auto& dSdxi = tet_.GetGradientInParentCoordinates();
+  EXPECT_EQ(dSdxi.size(), kNumQuads);
+  // The shape function for the 3 nodes of the triangle are 1-x-y-z, x, y and z.
+  // So the derivatives with respect to x is [-1, 1, 0, 0],
+  // the derivative with respect to y is [-1, 0, 1, 0],
+  // and the derivative with respect to z is [-1, 0, 0, 1].
+  const Vector4<double> x_deriv(-1, 1, 0, 0);
+  const Vector4<double> y_deriv(-1, 0, 1, 0);
+  const Vector4<double> z_deriv(-1, 0, 0, 1);
+  for (int q = 0; q < kNumQuads; ++q) {
+    // There are four vertices in a tetrahedron.
+    EXPECT_EQ(dSdxi[q].rows(), 4);
+    // The dimension of the parent domain is three.
+    EXPECT_EQ(dSdxi[q].cols(), 3);
+    EXPECT_EQ(dSdxi[q].col(0), x_deriv);
+    EXPECT_EQ(dSdxi[q].col(1), y_deriv);
+    EXPECT_EQ(dSdxi[q].col(2), z_deriv);
+  }
+}
+
+}  // namespace
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/test/simplex_gaussian_quadrature_test.cc
+++ b/multibody/fixed_fem/dev/test/simplex_gaussian_quadrature_test.cc
@@ -6,7 +6,7 @@
 
 namespace drake {
 namespace multibody {
-namespace fem {
+namespace fixed_fem {
 namespace {
 using Eigen::Vector2d;
 using Eigen::Vector3d;
@@ -332,6 +332,6 @@ TEST_F(SimplexGaussianQuadratureTest, Cubic3D) {
               numerical_integral, std::numeric_limits<double>::epsilon());
 }
 }  // namespace
-}  // namespace fem
+}  // namespace fixed_fem
 }  // namespace multibody
 }  // namespace drake


### PR DESCRIPTION
Refactor the FEM isoparametric element implementation to eliminate heap
allocation and virtual methods. Change to a CRTP pattern for
compile-time polymorphism. The unit tests are the same as in the
previous implementation except for syntactic changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14452)
<!-- Reviewable:end -->
