### PR TITLE
framework: Un-deprecate FixInputPort taking an const ref

### DIFF
--- a/systems/framework/context_base.h
+++ b/systems/framework/context_base.h
@@ -218,7 +218,8 @@ class ContextBase : public internal::ContextMessageInterface {
   FixedInputPortValue& FixInputPort(
       int index, std::unique_ptr<AbstractValue> value);
 
-  /** Same as above method but the value is passed by const reference instead
+  /** (Advanced)
+  Same as above method but the value is passed by const reference instead
   of by unique_ptr. The port will contain a copy of the `value` (not retain a
   pointer to the `value`).
 
@@ -230,8 +231,6 @@ class ContextBase : public internal::ContextMessageInterface {
   @exclude_from_pydrake_mkdoc{The prior overload's docstring is better, and we
   only need one of the two -- overloading on ownership doesn't make sense for
   pydrake.} */
-  DRAKE_DEPRECATED("2021-01-01",
-      "Use input_port.FixValue() instead of context.FixInputPort().")
   FixedInputPortValue& FixInputPort(int index, const AbstractValue& value) {
     return FixInputPort(index, value.Clone());
   }


### PR DESCRIPTION
User-facing APIs should prefer const-ref (not unique_ptr) when the user provides new values for the framework to use (per #8904).  We will adjust the advice in the class further in the future (#14453), but for now with a release in flight, this is the minimal change to allow users to keep using the forward-looking API.

This reverts one of the deprecations from #14093.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14454)
<!-- Reviewable:end -->
