### PR TITLE
tools: No need for incompatible_restrict_string_escapes anymore

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -6,9 +6,6 @@ import %workspace%/tools/lint/bazel.rc
 # Disable native Python rules in Bazel versions before 4.0.
 build --incompatible_load_python_rules_from_bzl=yes
 
-# TODO(#14440) Remove this flag once our string escapes get fixed.
-build --incompatible_restrict_string_escapes=false
-
 # Default to an optimized build.
 build -c opt
 


### PR DESCRIPTION
This reverts commit fce3bdb591a6deb97e6414dcd82aa0eb4b67c7bb (#14441).

Closes  #14440.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14458)
<!-- Reviewable:end -->
