### PR TITLE
Add MeshcatVisualizer option to draw collision geometry

### DIFF
--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -482,8 +482,8 @@ drake_py_unittest(
         "//examples/kuka_iiwa_arm:models",
         "//examples/multibody/cart_pole:models",
         "//examples/quadrotor:models",
-        "//manipulation/models/iiwa_description:models",
         "//manipulation/models/allegro_hand_description:models",
+        "//manipulation/models/iiwa_description:models",
         "//systems/sensors:test_models",
     ],
     # Defects related to ZMQ when run under DRD or Helgrind.

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -483,6 +483,7 @@ drake_py_unittest(
         "//examples/multibody/cart_pole:models",
         "//examples/quadrotor:models",
         "//manipulation/models/iiwa_description:models",
+        "//manipulation/models/allegro_hand_description:models",
         "//systems/sensors:test_models",
     ],
     # Defects related to ZMQ when run under DRD or Helgrind.

--- a/bindings/pydrake/systems/meshcat_visualizer.py
+++ b/bindings/pydrake/systems/meshcat_visualizer.py
@@ -181,8 +181,8 @@ class MeshcatVisualizer(LeafSystem):
                 geometry from previous simulations to remain in the scene.  You
                 may call ``delete_prefix()`` manually to clear the scene.
             role: Renders geometry of the specified pydrake.geometry.Role
-            type -- defaults to Role.kIllustration to draw visual geometry,
-            and also supports Role.kProximity to draw collision geometry.
+                type -- defaults to Role.kIllustration to draw visual geometry,
+                and also supports Role.kProximity to draw collision geometry.
 
         Additional kwargs will be passed to the meshcat.Visualizer constructor.
         Note:

--- a/bindings/pydrake/systems/test/meshcat_visualizer_test.py
+++ b/bindings/pydrake/systems/test/meshcat_visualizer_test.py
@@ -236,19 +236,20 @@ class TestMeshcat(unittest.TestCase):
         simulator.set_publish_every_time_step(False)
         simulator.AdvanceTo(.1)
 
-    def test_kuka_proximity_geometry(self):
-        """Kuka IIWA with mesh geometry, drawn in proximity-geom mode."""
+    def test_allegro_proximity_geometry(self):
+        """Allegro hand with visual and collision geometry, drawn in
+           proximity-geom mode."""
         file_name = FindResourceOrThrow(
-            "drake/manipulation/models/iiwa_description/sdf/"
-            "iiwa14_no_collision.sdf")
+            "drake/manipulation/models/allegro_hand_description/sdf/"
+            "allegro_hand_description_left.sdf")
         builder = DiagramBuilder()
-        kuka, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.0)
-        Parser(plant=kuka).AddModelFromFile(file_name)
-        kuka.Finalize()
+        hand, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.0)
+        Parser(plant=hand).AddModelFromFile(file_name)
+        hand.Finalize()
 
         visualizer = builder.AddSystem(MeshcatVisualizer(
-            zmq_url="default",
-            open_browser=True,
+            zmq_url=ZMQ_URL,
+            open_browser=False,
             geometry_role_type="proximity"))
         builder.Connect(scene_graph.get_query_output_port(),
                         visualizer.get_geometry_query_input_port())
@@ -256,12 +257,12 @@ class TestMeshcat(unittest.TestCase):
         diagram = builder.Build()
 
         diagram_context = diagram.CreateDefaultContext()
-        kuka_context = diagram.GetMutableSubsystemContext(
-            kuka, diagram_context)
+        hand_context = diagram.GetMutableSubsystemContext(
+            hand, diagram_context)
 
-        kuka_actuation_port = kuka.get_actuation_input_port()
-        kuka_actuation_port.FixValue(kuka_context,
-                                     np.zeros(kuka_actuation_port.size()))
+        hand_actuation_port = hand.get_actuation_input_port()
+        hand_actuation_port.FixValue(hand_context,
+                                     np.zeros(hand_actuation_port.size()))
 
         simulator = Simulator(diagram, diagram_context)
         simulator.set_publish_every_time_step(False)

--- a/bindings/pydrake/systems/test/meshcat_visualizer_test.py
+++ b/bindings/pydrake/systems/test/meshcat_visualizer_test.py
@@ -27,6 +27,7 @@ from pydrake.geometry import (
     Box,
     GeometryInstance,
     IllustrationProperties,
+    Role,
     SceneGraph
 )
 from pydrake.multibody.plant import (
@@ -250,7 +251,7 @@ class TestMeshcat(unittest.TestCase):
         visualizer = builder.AddSystem(MeshcatVisualizer(
             zmq_url=ZMQ_URL,
             open_browser=False,
-            geometry_role_type="proximity"))
+            role=Role.kProximity))
         builder.Connect(scene_graph.get_query_output_port(),
                         visualizer.get_geometry_query_input_port())
 


### PR DESCRIPTION
Adds a flag to MeshcatVisualizer to toggle between the geometry role type that is illustrated. (Hope I didn't miss some obvious existing way to do this!)

Setting it to "illustration" draws the usual visual geometry, and shouldn't change functionality at all. This is the default arg.
![image](https://user-images.githubusercontent.com/3066703/102423502-2965fb80-3fd7-11eb-9fdb-d7e5a5af707e.png)

Setting it to "proximity" instead draws the collision geometry (i.e. proximity-role geometry), with random colors to make them easier to distinguish:
![image](https://user-images.githubusercontent.com/3066703/102423394-ea37aa80-3fd6-11eb-836b-8e42de45dc73.png)

(Since a fair amount of my collision geometry is `Convex`-type, I also enabled drawing of that type using the `Mesh` codepath.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14467)
<!-- Reviewable:end -->
