### PR TITLE
tools: Move cc macros for per_os support to common skylark

### DIFF
--- a/geometry/render/gl_renderer/BUILD.bazel
+++ b/geometry/render/gl_renderer/BUILD.bazel
@@ -4,15 +4,14 @@ load(
     "@drake//tools/skylark:drake_cc.bzl",
     "drake_cc_googletest",
     "drake_cc_library",
-    "drake_cc_package_library",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load("//tools/skylark:test_tags.bzl", "vtk_test_tags")
 load(
-    "defs.bzl",
-    "drake_cc_googletest_gl_ubuntu_only",
-    "drake_cc_library_gl_ubuntu_only",
-    "drake_cc_package_library_gl_per_os",
+    "//tools/skylark:drake_cc_per_os.bzl",
+    "drake_cc_googletest_ubuntu_only",
+    "drake_cc_library_ubuntu_only",
+    "drake_cc_package_library_per_os",
 )
 
 # This gl_renderer package is only implemented on Ubuntu.  For macOS, only the
@@ -29,7 +28,7 @@ load(
 
 package(default_visibility = ["//visibility:private"])
 
-drake_cc_package_library_gl_per_os(
+drake_cc_package_library_per_os(
     name = "gl_renderer",
     macos_deps = [
         ":render_engine_gl_factory",
@@ -50,14 +49,14 @@ drake_cc_package_library_gl_per_os(
     visibility = ["//visibility:public"],
 )
 
-drake_cc_library_gl_ubuntu_only(
+drake_cc_library_ubuntu_only(
     name = "gl_common",
     hdrs = [
         "gl_common.h",
     ],
 )
 
-drake_cc_library_gl_ubuntu_only(
+drake_cc_library_ubuntu_only(
     name = "opengl_context",
     srcs = ["opengl_context.cc"],
     hdrs = [
@@ -73,7 +72,7 @@ drake_cc_library_gl_ubuntu_only(
     ],
 )
 
-drake_cc_library_gl_ubuntu_only(
+drake_cc_library_ubuntu_only(
     name = "opengl_geometry",
     hdrs = ["opengl_geometry.h"],
     deps = [
@@ -85,7 +84,7 @@ drake_cc_library_gl_ubuntu_only(
     ],
 )
 
-drake_cc_library_gl_ubuntu_only(
+drake_cc_library_ubuntu_only(
     name = "render_engine_gl",
     srcs = [
         "render_engine_gl.cc",
@@ -157,7 +156,7 @@ drake_cc_library(
     ],
 )
 
-drake_cc_library_gl_ubuntu_only(
+drake_cc_library_ubuntu_only(
     name = "shader_program",
     srcs = ["shader_program.cc"],
     hdrs = ["shader_program.h"],
@@ -170,7 +169,7 @@ drake_cc_library_gl_ubuntu_only(
     ],
 )
 
-drake_cc_library_gl_ubuntu_only(
+drake_cc_library_ubuntu_only(
     name = "shader_program_data",
     hdrs = ["shader_program_data.h"],
     deps = [
@@ -180,7 +179,7 @@ drake_cc_library_gl_ubuntu_only(
     ],
 )
 
-drake_cc_library_gl_ubuntu_only(
+drake_cc_library_ubuntu_only(
     name = "shape_meshes",
     srcs = ["shape_meshes.cc"],
     hdrs = ["shape_meshes.h"],
@@ -191,7 +190,7 @@ drake_cc_library_gl_ubuntu_only(
     ],
 )
 
-drake_cc_library_gl_ubuntu_only(
+drake_cc_library_ubuntu_only(
     name = "texture_library",
     srcs = ["texture_library.cc"],
     hdrs = ["texture_library.h"],
@@ -203,14 +202,14 @@ drake_cc_library_gl_ubuntu_only(
     ],
 )
 
-drake_cc_googletest_gl_ubuntu_only(
+drake_cc_googletest_ubuntu_only(
     name = "buffer_dim_test",
     deps = [
         ":render_engine_gl",
     ],
 )
 
-drake_cc_googletest_gl_ubuntu_only(
+drake_cc_googletest_ubuntu_only(
     name = "opengl_context_test",
     tags = [
         # GLX functions show up with bad reads, bad writes, possibly lost, and
@@ -224,7 +223,7 @@ drake_cc_googletest_gl_ubuntu_only(
     ],
 )
 
-drake_cc_googletest_gl_ubuntu_only(
+drake_cc_googletest_ubuntu_only(
     name = "opengl_geometry_test",
     deps = [
         ":opengl_geometry",
@@ -233,12 +232,8 @@ drake_cc_googletest_gl_ubuntu_only(
     ],
 )
 
-drake_cc_googletest_gl_ubuntu_only(
+drake_cc_googletest_ubuntu_only(
     name = "render_engine_gl_test",
-    args = select({
-        "//tools/cc_toolchain:apple": ["--gtest_filter=-*"],
-        "//conditions:default": [],
-    }),
     data = [
         "//geometry/render:test_models",
         "//systems/sensors:test_models",
@@ -266,7 +261,7 @@ drake_cc_googletest(
     ],
 )
 
-drake_cc_googletest_gl_ubuntu_only(
+drake_cc_googletest_ubuntu_only(
     name = "shape_meshes_test",
     data = [
         "//systems/sensors:test_models",
@@ -280,7 +275,7 @@ drake_cc_googletest_gl_ubuntu_only(
     ],
 )
 
-drake_cc_googletest_gl_ubuntu_only(
+drake_cc_googletest_ubuntu_only(
     name = "shader_program_test",
     tags = vtk_test_tags(),
     deps = [

--- a/tools/skylark/drake_cc_per_os.bzl
+++ b/tools/skylark/drake_cc_per_os.bzl
@@ -1,3 +1,9 @@
+# -*- python -*-
+
+# This is a separate file from drake_cc.bzl because the dependency on
+# @drake_detected_os is somewhat brittle and might present challenges
+# for users exploring novel platforms.
+
 load(
     "@drake//tools/skylark:drake_cc.bzl",
     "drake_cc_googletest",
@@ -9,29 +15,44 @@ load(
     "DISTRIBUTION",
 )
 
-def drake_cc_googletest_gl_ubuntu_only(**kwargs):
+def drake_cc_googletest_ubuntu_only(
+        name,
+        visibility = ["//visibility:private"],
+        **kwargs):
     """Declares a drake_cc_googletest iff we are building on Ubuntu.
     Otherwise, does nothing.
-    """
-    if DISTRIBUTION == "ubuntu":
-        drake_cc_googletest(**kwargs)
 
-def drake_cc_library_gl_ubuntu_only(name, hdrs = [], **kwargs):
-    """Declares a drake_cc_library iff we are building on Ubuntu.
-    Otherwise, does nothing.
+    Because this test is not cross-platform, the visibility defaults to
+    private.
     """
     if DISTRIBUTION == "ubuntu":
-        # Because this library is not cross-platform, we must use default
-        # visibility (i.e., private) and not install its private headers.
-        drake_cc_library(
+        drake_cc_googletest(
             name = name,
-            hdrs = hdrs,
-            install_hdrs_exclude = hdrs,
-            visibility = None,
+            visibility = visibility,
             **kwargs
         )
 
-def drake_cc_package_library_gl_per_os(
+def drake_cc_library_ubuntu_only(
+        name,
+        hdrs = [],
+        visibility = ["//visibility:private"],
+        **kwargs):
+    """Declares a drake_cc_library iff we are building on Ubuntu.
+    Otherwise, does nothing.
+
+    Because this library is not cross-platform, the visibility defaults to
+    private and the headers are excluded from the installation.
+    """
+    if DISTRIBUTION == "ubuntu":
+        drake_cc_library(
+            name = name,
+            hdrs = hdrs,
+            visibility = visibility,
+            install_hdrs_exclude = hdrs,
+            **kwargs
+        )
+
+def drake_cc_package_library_per_os(
         macos_deps = [],
         ubuntu_deps = [],
         **kwargs):


### PR DESCRIPTION
This keeps us aligned the the pattern in #14470.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14471)
<!-- Reviewable:end -->
