### PR TITLE
Refactor the FEM constitutive model

### DIFF
--- a/multibody/fixed_fem/dev/BUILD.bazel
+++ b/multibody/fixed_fem/dev/BUILD.bazel
@@ -11,11 +11,69 @@ package(
 )
 
 drake_cc_library(
+    name = "constitutive_model",
+    hdrs = [
+        "constitutive_model.h",
+    ],
+    deps = [
+        ":deformation_gradient_cache_entry",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "deformation_gradient_cache_entry",
+    hdrs = [
+        "deformation_gradient_cache_entry.h",
+    ],
+    deps = [
+        ":fem_indexes",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "fem_indexes",
+    hdrs = [
+        "fem_indexes.h",
+    ],
+    deps = [
+        "//common:essential",
+        "//common:type_safe_index",
+    ],
+)
+
+drake_cc_library(
     name = "isoparametric_element",
     hdrs = [
         "isoparametric_element.h",
     ],
     deps = [
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "linear_constitutive_model",
+    hdrs = [
+        "linear_constitutive_model.h",
+    ],
+    deps = [
+        ":constitutive_model",
+        ":linear_constitutive_model_cache_entry",
+        "//common:default_scalars",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "linear_constitutive_model_cache_entry",
+    hdrs = [
+        "linear_constitutive_model_cache_entry.h",
+    ],
+    deps = [
+        ":deformation_gradient_cache_entry",
+        "//common:default_scalars",
         "//common:essential",
     ],
 )
@@ -27,7 +85,6 @@ drake_cc_library(
     ],
     deps = [
         ":isoparametric_element",
-        "//common:essential",
     ],
 )
 
@@ -58,6 +115,24 @@ drake_cc_googletest(
         ":isoparametric_element",
         ":linear_simplex_element",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_googletest(
+    name = "linear_constitutive_model_test",
+    deps = [
+        ":linear_constitutive_model",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+        "//math:gradient",
+    ],
+)
+
+drake_cc_googletest(
+    name = "linear_constitutive_model_cache_entry_test",
+    deps = [
+        ":linear_constitutive_model_cache_entry",
         "//common/test_utilities:expect_throws_message",
     ],
 )

--- a/multibody/fixed_fem/dev/constitutive_model.h
+++ b/multibody/fixed_fem/dev/constitutive_model.h
@@ -1,0 +1,108 @@
+#pragma once
+
+#include <array>
+
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fixed_fem/dev/deformation_gradient_cache_entry.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+/** A constitutive model relates the strain to the stress of the material and
+ governs the material response under deformation. This constitutive relationship
+ is defined through a hyperelastic potential energy, which increases with
+ non-rigid deformation from the initial state.
+
+ %ConstitutiveModel serves as the interface base class for all hyperelastic
+ constitutive models. Since constitutive models are usually evaluated in
+ computationally intensive inner loops of the simulation, the overhead caused by
+ virtual methods may be significant. Therefore, this class uses a CRTP pattern
+ to achieve compile-time polymorphism and avoids the overhead of virtual
+ methods and facilitates inlining instead. Derived constitutive models must
+ inherit from this base class and implement the interface this class provides.
+ The derived constitutive model must also be accompanied by a corresponding
+ traits class that declares the compile time quantities and type declarations
+ that this base class requires.
+ @tparam DerivedConstitutiveModel The concrete constitutive model that inherits
+ from %ConstitutiveModel through CRTP.
+ @tparam DerivedTraits The traits class associated with the
+ DerivedConstitutiveModel. */
+template <class DerivedConstitutiveModel, class DerivedTraits>
+class ConstitutiveModel {
+ public:
+  static_assert(
+      std::is_same_v<typename DerivedTraits::ModelType,
+                     DerivedConstitutiveModel>,
+      "The DerivedConstitutiveModel and the DerivedTraits must be compatible.");
+  using T = typename DerivedTraits::Scalar;
+
+  ~ConstitutiveModel() = default;
+
+  /** The number of locations at which the constitutive relationship is
+   evaluated. */
+  static constexpr int num_locations() { return DerivedTraits::kNumLocations; }
+
+  /** @name "Calc" Methods
+   Methods for calculating the energy density and its derivatives given the
+   cache entry required for these calculations. The constitutive model expects
+   that the input cache entries are up-to-date. FemElement is
+   responsible for updating these cache entries. ConstitutiveModel will
+   not and cannot verify the cache entries provided are up-to-date.
+   @{ */
+
+  /** Calculates the energy density in reference configuration, in unit J/m³,
+   given the model cache entry.
+   @pre `Psi != nullptr`. */
+  void CalcElasticEnergyDensity(
+      const typename DerivedTraits::DeformationGradientCacheEntryType&
+          cache_entry,
+      std::array<T, num_locations()>* Psi) const {
+    DRAKE_ASSERT(Psi != nullptr);
+    static_cast<const DerivedConstitutiveModel*>(this)
+        ->DoCalcElasticEnergyDensity(cache_entry, Psi);
+  }
+
+  /** Calculates the First Piola stress, in unit Pa, given the model cache
+   entry.
+   @pre `P != nullptr`. */
+  void CalcFirstPiolaStress(
+      const typename DerivedTraits::DeformationGradientCacheEntryType&
+          cache_entry,
+      std::array<Matrix3<T>, num_locations()>* P) const {
+    DRAKE_ASSERT(P != nullptr);
+    static_cast<const DerivedConstitutiveModel*>(this)->DoCalcFirstPiolaStress(
+        cache_entry, P);
+  }
+
+  /** Calculates the derivative of First Piola stress with respect to the
+   deformation gradient, given the model cache entry.
+   @pre `dPdF != nullptr`. */
+  void CalcFirstPiolaStressDerivative(
+      const typename DerivedTraits::DeformationGradientCacheEntryType&
+          cache_entry,
+      std::array<Eigen::Matrix<T, 9, 9>, num_locations()>* dPdF) const {
+    DRAKE_ASSERT(dPdF != nullptr);
+    static_cast<const DerivedConstitutiveModel*>(this)
+        ->DoCalcFirstPiolaStressDerivative(cache_entry, dPdF);
+  }
+  /** @} */
+
+  /** Creates a DeformationGradientCacheEntry that is compatible
+   with this %ConstitutiveModel. */
+  typename DerivedTraits::DeformationGradientCacheEntryType
+  MakeDeformationGradientCacheEntry(ElementIndex element_index) const {
+    return typename DerivedTraits::DeformationGradientCacheEntryType(
+        element_index);
+  }
+
+ protected:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ConstitutiveModel);
+
+  /** The base class constructor are made protected to prevent explicit
+   construction of a base class object. Concrete instances should be obtained
+   through the constructors of the derived constitutive models. */
+  ConstitutiveModel() = default;
+};
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/deformation_gradient_cache_entry.h
+++ b/multibody/fixed_fem/dev/deformation_gradient_cache_entry.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <array>
+
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fixed_fem/dev/fem_indexes.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+template <class>
+class DeformationGradientCacheEntry;
+/** %DeformationGradientCacheEntry stores per element cached quantities
+ that work in tandem with ConstitutiveModel. It is a static
+ interface that concrete constitutive model cache entries must inherit from to
+ store the set of specific quantities that need to be cached for the specific
+ model. There should be a one-to-one correspondence between the constitutive
+ model `Foo` that inherits from ConstitutiveModel and its cached quantities
+ `FooCacheEntry` that inherits from %DeformationGradientCacheEntry. These cached
+ quantities depend solely on deformation gradients, and they facilitate
+ calculations such as energy density, stress and stress derivative in the
+ constitutive model. ConstitutiveModel takes the corresponding cache entry as an
+ argument when performing various calculations. Similar to ConstitutiveModel,
+ this class also utilizes CRTP to eliminate the need for virtual methods and
+ facilitate inlining.
+ @tparam_nonsymbolic_scalar T.
+ @tparam num_locations Number of locations at which the cached quantities
+ are evaluated. */
+template <template <typename, int> class DerivedDeformationGradientCacheEntry,
+          typename T, int num_locations>
+class DeformationGradientCacheEntry<
+    DerivedDeformationGradientCacheEntry<T, num_locations>> {
+ public:
+  using Derived = DerivedDeformationGradientCacheEntry<T, num_locations>;
+
+  ~DeformationGradientCacheEntry() = default;
+
+  /** Updates the cache entry with the given deformation gradients.
+   @param F The up-to-date deformation gradients evaluated at the quadrature
+   locations for the associated element. */
+  void UpdateCacheEntry(const std::array<Matrix3<T>, num_locations>& F) {
+    deformation_gradient_ = F;
+    static_cast<Derived*>(this)->DoUpdateCacheEntry(F);
+  }
+
+  /** The index of the FemElement associated with this
+   %DeformationGradientCacheEntry. */
+  ElementIndex element_index() const { return element_index_; }
+
+  /** The number of quadrature locations at which the cache entry needs to be
+   evaluated. */
+  static constexpr int num_quadrature_points() { return num_locations; }
+
+  const std::array<Matrix3<T>, num_locations>& deformation_gradient() const {
+    return deformation_gradient_;
+  }
+
+ protected:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DeformationGradientCacheEntry);
+
+  /** Constructs a $DeformationGradientCacheEntry with the given element
+   index and. Users should not directly construct
+   %DeformationGradientCacheEntry. They should construct the specific
+   constitutive model cache entry (e.g.
+   LinearConstitutiveModelCacheEntry) that invokes the base
+   constructor.
+   @param element_index The index of the FemElement associated with this
+   %DeformationGradientCacheEntry. */
+  explicit DeformationGradientCacheEntry(ElementIndex element_index)
+      : element_index_(element_index) {
+    DRAKE_ASSERT(element_index.is_valid());
+    std::fill(deformation_gradient_.begin(), deformation_gradient_.end(),
+              Matrix3<T>::Identity());
+  }
+
+ private:
+  ElementIndex element_index_;
+  std::array<Matrix3<T>, num_locations> deformation_gradient_;
+};
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/fem_indexes.h
+++ b/multibody/fixed_fem/dev/fem_indexes.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "drake/common/type_safe_index.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+/** Index used to identify element by index among FEM elements. */
+using ElementIndex = TypeSafeIndex<class ElementTag>;
+
+/** Index used to identify node by index among FEM nodes. */
+using NodeIndex = TypeSafeIndex<class NodeTag>;
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/linear_constitutive_model.h
+++ b/multibody/fixed_fem/dev/linear_constitutive_model.h
@@ -1,0 +1,163 @@
+#pragma once
+
+#include <array>
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/unused.h"
+#include "drake/multibody/fixed_fem/dev/constitutive_model.h"
+#include "drake/multibody/fixed_fem/dev/linear_constitutive_model_cache_entry.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+/* Forward declare the model to be referred to in the traits class. */
+template <typename T, int num_locations>
+class LinearConstitutiveModel;
+
+/** Traits for LinearConstitutiveModel. */
+template <typename T, int num_locations>
+struct LinearConstitutiveModelTraits {
+  using Scalar = T;
+  using ModelType = LinearConstitutiveModel<T, num_locations>;
+  using DeformationGradientCacheEntryType =
+      LinearConstitutiveModelCacheEntry<T, num_locations>;
+  static constexpr int kNumLocations = num_locations;
+};
+
+/** Implements the infinitesimal-strain linear elasticity constitutive model as
+ described in Section 7.4 of [Gonzalez, 2008].
+ @tparam_nonsymbolic_scalar T.
+
+[Gonzalez, 2008] Gonzalez, Oscar, and Andrew M. Stuart. A first course in
+continuum mechanics. Cambridge University Press, 2008. */
+template <typename T, int num_locations>
+class LinearConstitutiveModel final
+    : public ConstitutiveModel<
+          LinearConstitutiveModel<T, num_locations>,
+          LinearConstitutiveModelTraits<T, num_locations>> {
+ public:
+  using Traits = LinearConstitutiveModelTraits<T, num_locations>;
+  using ModelType = typename Traits::ModelType;
+  using DeformationGradientCacheEntryType =
+      typename Traits::DeformationGradientCacheEntryType;
+  using Base = ConstitutiveModel<ModelType, Traits>;
+
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(LinearConstitutiveModel)
+
+  /** Constructs a %LinearConstitutiveModel constitutive model with the
+   prescribed Young's modulus and Poisson ratio.
+   @param youngs_modulus Young's modulus of the model, with unit N/m²
+   @param poisson_ratio Poisson ratio of the model, unitless.
+   @pre youngs_modulus must be non-negative.
+   @pre poisson_ratio must be strictly greater than -1 and strictly smaller than
+   0.5. */
+  LinearConstitutiveModel(const T& youngs_modulus, const T& poisson_ratio)
+      : E_(youngs_modulus), nu_(poisson_ratio) {
+    VerifyParameterValidity(E_, nu_);
+    SetLameParameters(E_, nu_);
+    /* Recall that
+          Pᵢⱼ = 2μ * εᵢⱼ + λ * εₐₐ * δᵢⱼ,
+      So,
+          ∂Pᵢⱼ/∂Fₖₗ = 2μ * ∂εᵢⱼ/∂Fₖₗ + λ * ∂εₐₐ/∂Fₖₗ * δᵢⱼ,
+      Since
+          ∂εᵢⱼ/∂Fₖₗ = 0.5 * δᵢₖ δⱼₗ  + 0.5 * δᵢₗ δₖⱼ.
+      Plugging in, we get:
+          ∂Pᵢⱼ/∂Fₖₗ = μ * (δᵢₖδⱼₗ + δᵢₗ δⱼₖ) +  λ * δₖₗ * δᵢⱼ.
+      Keep in mind that the indices are laid out such that the ik-th entry in
+      the jl-th block corresponds to the value dPᵢⱼ/dFₖₗ.  */
+    // First term.
+    dPdF_ = mu_ * Eigen::Matrix<T, 9, 9>::Identity();
+    for (int k = 0; k < 3; ++k) {
+      // Second term.
+      for (int l = 0; l < 3; ++l) {
+        const int i = l;
+        const int j = k;
+        dPdF_(3 * j + i, 3 * l + k) += mu_;
+      }
+      // Third term.
+      for (int i = 0; i < 3; ++i) {
+        const int l = k;
+        const int j = i;
+        dPdF_(3 * j + i, 3 * l + k) += lambda_;
+      }
+    }
+  }
+
+  ~LinearConstitutiveModel() = default;
+
+  T youngs_modulus() const { return E_; }
+
+  T poisson_ratio() const { return nu_; }
+
+  T shear_modulus() const { return mu_; }
+
+  T lame_first_parameter() const { return lambda_; }
+
+ private:
+  friend Base;
+
+  /* Implements the interface ConstitutiveModel::CalcElasticEnergyDensity() in
+   the CRTP base class. */
+  void DoCalcElasticEnergyDensity(
+      const LinearConstitutiveModelCacheEntry<T, num_locations>& cache_entry,
+      std::array<T, num_locations>* Psi) const {
+    for (int i = 0; i < num_locations; ++i) {
+      const auto& strain = cache_entry.strain()[i];
+      const auto& trace_strain = cache_entry.trace_strain()[i];
+      (*Psi)[i] = mu_ * strain.squaredNorm() +
+                  0.5 * lambda_ * trace_strain * trace_strain;
+    }
+  }
+
+  /* Implements the interface ConstitutiveModel::CalcFirstPiolaStress()
+   in the CRTP base class. */
+  void DoCalcFirstPiolaStress(
+      const DeformationGradientCacheEntryType& cache_entry,
+      std::array<Matrix3<T>, num_locations>* P) const {
+    for (int i = 0; i < num_locations; ++i) {
+      const auto& strain = cache_entry.strain()[i];
+      const auto& trace_strain = cache_entry.trace_strain()[i];
+      (*P)[i] =
+          2.0 * mu_ * strain + lambda_ * trace_strain * Matrix3<T>::Identity();
+    }
+  }
+
+  /* Implements the interface
+   ConstitutiveModel::CalcFirstPiolaStressDerivative() in the CRTP base class.
+  */
+  void DoCalcFirstPiolaStressDerivative(
+      const DeformationGradientCacheEntryType& cache_entry,
+      std::array<Eigen::Matrix<T, 9, 9>, num_locations>* dPdF) const {
+    unused(cache_entry);
+    std::fill(dPdF->begin(), dPdF->end(), dPdF_);
+  }
+
+  /* Set the Lamé parameters from Young's modulus and Poisson ratio. It's
+   important to keep the Lamé Parameters in sync with Young's modulus and
+   Poisson ratio as most computations use Lame parameters. */
+  void VerifyParameterValidity(const T& youngs_modulus,
+                               const T& poisson_ratio) const {
+    if (youngs_modulus < 0.0) {
+      throw std::logic_error("Young's modulus must be nonnegative.");
+    }
+    if (poisson_ratio >= 0.5 || poisson_ratio <= -1) {
+      throw std::logic_error("Poisson ratio must be in (-1, 0.5).");
+    }
+  }
+
+  void SetLameParameters(const T& youngs_modulus, const T& poisson_ratio) {
+    mu_ = youngs_modulus / (2.0 * (1.0 + poisson_ratio));
+    lambda_ = youngs_modulus * poisson_ratio /
+              ((1.0 + poisson_ratio) * (1.0 - 2.0 * poisson_ratio));
+  }
+
+  T E_;       // Young's modulus, N/m².
+  T nu_;      // Poisson ratio.
+  T mu_;      // Lamé's second parameter/Shear modulus, N/m².
+  T lambda_;  // Lamé's first parameter, N/m².
+  Eigen::Matrix<T, 9, 9>
+      dPdF_;  // The First Piola stress derivative is constant and precomputed.
+};
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/linear_constitutive_model_cache_entry.h
+++ b/multibody/fixed_fem/dev/linear_constitutive_model_cache_entry.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <array>
+
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fixed_fem/dev/deformation_gradient_cache_entry.h"
+#include "drake/multibody/fixed_fem/dev/fem_indexes.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+/** Cache entry for the LinearConstitutiveModel constitutive model.
+ See LinearConstitutiveModel for how the cache entry is used. See
+ DeformationGradientCacheEntry for more about cached quantities for
+ constitutive models.
+ @tparam_nonsymbolic_scalar T.
+ @tparam num_locations Number of locations at which the cached quantities are
+ evaluated. */
+template <typename T, int num_locations>
+class LinearConstitutiveModelCacheEntry
+    : public DeformationGradientCacheEntry<
+          LinearConstitutiveModelCacheEntry<T, num_locations>> {
+ public:
+  using Base = DeformationGradientCacheEntry<
+      LinearConstitutiveModelCacheEntry<T, num_locations>>;
+
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(
+      LinearConstitutiveModelCacheEntry);
+
+  ~LinearConstitutiveModelCacheEntry() = default;
+
+  /** Constructs a %LinearConstitutiveModelCacheEntry with the given
+   element index.
+   @param element_index The index of the FemElement associated with this
+   DeformationGradientCacheEntry. */
+  explicit LinearConstitutiveModelCacheEntry(ElementIndex element_index)
+      : DeformationGradientCacheEntry<
+            LinearConstitutiveModelCacheEntry<T, num_locations>>(
+            element_index) {
+    std::fill(strain_.begin(), strain_.end(), Matrix3<T>::Zero());
+    std::fill(trace_strain_.begin(), trace_strain_.end(), 0);
+  }
+
+  /** Returns the infinitesimal strains evaluated at the quadrature locations
+   for the associated element. */
+  const std::array<Matrix3<T>, num_locations>& strain() const {
+    return strain_;
+  }
+
+  /** Returns the traces of the infinitesimal strains evaluated at the
+   quadrature locations for the associated element. */
+  const std::array<T, num_locations>& trace_strain() const {
+    return trace_strain_;
+  }
+
+ private:
+  friend Base;
+
+  /* Implements the interface DeformationGradientCacheEntry::UpdateCacheEntry().
+   @param F The up-to-date deformation gradients evaluated at the quadrature
+   locations for the associated element. */
+  void DoUpdateCacheEntry(const std::array<Matrix3<T>, num_locations>& F) {
+    for (int i = 0; i < num_locations; ++i) {
+      strain_[i] = 0.5 * (F[i] + F[i].transpose()) - Matrix3<T>::Identity();
+      trace_strain_[i] = strain_[i].trace();
+    }
+  }
+  // Infinitesimal strain = 0.5 * (F + Fᵀ) - I.
+  std::array<Matrix3<T>, num_locations> strain_;
+  // Trace of `strain_`.
+  std::array<T, num_locations> trace_strain_;
+};
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/test/linear_constitutive_model_cache_entry_test.cc
+++ b/multibody/fixed_fem/dev/test/linear_constitutive_model_cache_entry_test.cc
@@ -1,0 +1,55 @@
+#include "drake/multibody/fixed_fem/dev/linear_constitutive_model_cache_entry.h"
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+namespace {
+const ElementIndex kElementIndex(3);
+constexpr int kNumQuads = 1;
+
+class LinearConstitutiveModelCacheEntryTest : public ::testing::Test {
+ protected:
+  void SetUp() {
+    linear_elasticity_cache_entry_.UpdateCacheEntry(
+        {MakeDeformationGradient()});
+  }
+
+  LinearConstitutiveModelCacheEntry<double, kNumQuads>
+      linear_elasticity_cache_entry_{kElementIndex};
+
+  // Make an arbitrary deformation gradient.
+  Matrix3<double> MakeDeformationGradient() {
+    Matrix3<double> F;
+    // clang-format off
+    F << 1.2, 2.3, 3.4,
+         4.5, 5.6, 6.7,
+         7.8, 8.9, 9.0;
+    // clang-format on
+    return F;
+  }
+};
+
+TEST_F(LinearConstitutiveModelCacheEntryTest,
+       LinearElasticityCacheEntryInitialization) {
+  EXPECT_EQ(linear_elasticity_cache_entry_.element_index(), kElementIndex);
+  EXPECT_EQ(linear_elasticity_cache_entry_.deformation_gradient().size(),
+            kNumQuads);
+  EXPECT_EQ(linear_elasticity_cache_entry_.strain().size(), kNumQuads);
+  EXPECT_EQ(linear_elasticity_cache_entry_.trace_strain().size(), kNumQuads);
+}
+
+TEST_F(LinearConstitutiveModelCacheEntryTest, UpdateCacheEntry) {
+  const Matrix3<double> F = MakeDeformationGradient();
+  const Matrix3<double> strain =
+      0.5 * (F + F.transpose()) - Matrix3<double>::Identity();
+  const double trace_strain = strain.trace();
+  EXPECT_EQ(linear_elasticity_cache_entry_.deformation_gradient()[0], F);
+  EXPECT_EQ(linear_elasticity_cache_entry_.strain()[0], strain);
+  EXPECT_EQ(linear_elasticity_cache_entry_.trace_strain()[0], trace_strain);
+}
+}  // namespace
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/test/linear_constitutive_model_test.cc
+++ b/multibody/fixed_fem/dev/test/linear_constitutive_model_test.cc
@@ -1,0 +1,149 @@
+#include "drake/multibody/fixed_fem/dev/linear_constitutive_model.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/math/autodiff_gradient.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+namespace {
+const ElementIndex kDummyElementIndex(0);
+constexpr int kNumQuads = 1;
+
+// Creates a vector of arbitrary deformation gradients.
+std::array<Matrix3<AutoDiffXd>, kNumQuads> MakeDeformationGradients() {
+  // Create random AutoDiffXd deformation.
+  Matrix3<double> F;
+  // clang-format off
+  F << 0.18, 0.63, 0.54,
+       0.13, 0.92, 0.17,
+       0.03, 0.86, 0.85;
+  // clang-format on
+  const std::array<Matrix3<double>, kNumQuads> deformation_gradients{F};
+  std::array<Matrix3<AutoDiffXd>, kNumQuads> deformation_gradients_autodiff;
+  const Eigen::Matrix<double, 9, Eigen::Dynamic> gradient(
+      Eigen::Matrix<double, 9, 9>::Identity());
+  for (int i = 0; i < kNumQuads; ++i) {
+    const auto F_autodiff_flat = math::initializeAutoDiffGivenGradientMatrix(
+        Eigen::Map<const Eigen::Matrix<double, 9, 1>>(
+            deformation_gradients[i].data(), 9),
+        gradient);
+    deformation_gradients_autodiff[i] =
+        Eigen::Map<const Matrix3<AutoDiffXd>>(F_autodiff_flat.data(), 3, 3);
+  }
+  return deformation_gradients_autodiff;
+}
+
+GTEST_TEST(LinearConstitutiveModelTest, Parameters) {
+  const LinearConstitutiveModel<double, kNumQuads> model(100.0, 0.25);
+  const double mu = 40.0;
+  const double lambda = 40.0;
+  EXPECT_EQ(model.youngs_modulus(), 100.0);
+  EXPECT_EQ(model.poisson_ratio(), 0.25);
+  EXPECT_EQ(model.shear_modulus(), mu);
+  EXPECT_EQ(model.lame_first_parameter(), lambda);
+}
+
+GTEST_TEST(LinearConstitutiveModelTest, InvalidYoungsModulus) {
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      (LinearConstitutiveModel<double, kNumQuads>(-1.0, 0.25)),
+      std::logic_error, "Young's modulus must be nonnegative.");
+}
+
+GTEST_TEST(LinearConstitutiveModelTest, InvalidPoissonRatioAtUpperLimit) {
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      (LinearConstitutiveModel<double, kNumQuads>(100.0, 0.5)),
+      std::logic_error, "Poisson ratio must be in \\(-1, 0.5\\).");
+}
+
+GTEST_TEST(LinearConstitutiveModelTest, InvalidPoissonRatioOverUpperLimit) {
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      (LinearConstitutiveModel<double, kNumQuads>(100.0, 0.6)),
+      std::logic_error, "Poisson ratio must be in \\(-1, 0.5\\).");
+}
+
+GTEST_TEST(LinearConstitutiveModelTest, InvalidPoissonRatioAtLower) {
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      (LinearConstitutiveModel<double, kNumQuads>(100.0, -1.0)),
+      std::logic_error, "Poisson ratio must be in \\(-1, 0.5\\).");
+}
+
+GTEST_TEST(LinearConstitutiveModelTest, InvalidPoissonRatioBelowLowerLimit) {
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      (LinearConstitutiveModel<double, kNumQuads>(100.0, -1.1)),
+      std::logic_error, "Poisson ratio must be in \\(-1, 0.5\\).");
+}
+
+GTEST_TEST(LinearConstitutiveModelTest, UndeformedState) {
+  const LinearConstitutiveModel<double, kNumQuads> model(100.0, 0.25);
+  LinearConstitutiveModelCacheEntry<double, kNumQuads> cache_entry(
+      kDummyElementIndex);
+  const std::array<Matrix3<double>, kNumQuads> F{Matrix3<double>::Identity()};
+  cache_entry.UpdateCacheEntry(F);
+  // In undeformed state, the energy density should be zero.
+  const std::array<double, kNumQuads> analytic_energy_density{0};
+  // In undeformaed state, the stress should be zero.
+  const std::array<Matrix3<double>, kNumQuads> analytic_stress{
+      Matrix3<double>::Zero()};
+  std::array<double, kNumQuads> energy_density;
+  model.CalcElasticEnergyDensity(cache_entry, &energy_density);
+  EXPECT_EQ(energy_density, analytic_energy_density);
+  std::array<Matrix3<double>, kNumQuads> stress;
+  model.CalcFirstPiolaStress(cache_entry, &stress);
+  EXPECT_EQ(stress, analytic_stress);
+}
+
+GTEST_TEST(LinearConstitutiveModelTest, PIsDerivativeOfPsi) {
+  const LinearConstitutiveModel<AutoDiffXd, kNumQuads> model(100.0, 0.3);
+  LinearConstitutiveModelCacheEntry<AutoDiffXd, kNumQuads> cache_entry(
+      kDummyElementIndex);
+  const std::array<Matrix3<AutoDiffXd>, kNumQuads> deformation_gradients =
+      MakeDeformationGradients();
+  // P should be derivative of Psi.
+  cache_entry.UpdateCacheEntry(deformation_gradients);
+  std::array<AutoDiffXd, kNumQuads> energy;
+  model.CalcElasticEnergyDensity(cache_entry, &energy);
+  std::array<Matrix3<AutoDiffXd>, kNumQuads> P;
+  model.CalcFirstPiolaStress(cache_entry, &P);
+  for (int i = 0; i < kNumQuads; ++i) {
+    EXPECT_TRUE(CompareMatrices(
+        Eigen::Map<const Matrix3<double>>(energy[i].derivatives().data(), 3, 3),
+        P[i]));
+  }
+}
+// TODO(xuchenhan-tri): This test applies to all ConstitutiveModels. Consider
+// moving it to ConstitutiveModelTest.
+GTEST_TEST(LinearConstitutiveModelTest, dPdFIsDerivativeOfP) {
+  const LinearConstitutiveModel<AutoDiffXd, kNumQuads> model(100.0, 0.3);
+  LinearConstitutiveModelCacheEntry<AutoDiffXd, kNumQuads> cache_entry(
+      kDummyElementIndex);
+  const std::array<Matrix3<AutoDiffXd>, kNumQuads> deformation_gradients =
+      MakeDeformationGradients();
+  cache_entry.UpdateCacheEntry(deformation_gradients);
+  std::array<Matrix3<AutoDiffXd>, kNumQuads> P;
+  model.CalcFirstPiolaStress(cache_entry, &P);
+  std::array<Eigen::Matrix<AutoDiffXd, 9, 9>, kNumQuads> dPdF;
+  model.CalcFirstPiolaStressDerivative(cache_entry, &dPdF);
+  for (int q = 0; q < kNumQuads; ++q) {
+    for (int i = 0; i < kSpaceDimension; ++i) {
+      for (int j = 0; j < kSpaceDimension; ++j) {
+        Matrix3<double> dPijdF;
+        for (int k = 0; k < kSpaceDimension; ++k) {
+          for (int l = 0; l < kSpaceDimension; ++l) {
+            dPijdF(k, l) = dPdF[q](3 * j + i, 3 * l + k).value();
+          }
+        }
+        EXPECT_TRUE(CompareMatrices(Eigen::Map<const Matrix3<double>>(
+                                        P[q](i, j).derivatives().data(), 3, 3),
+                                    dPijdF));
+      }
+    }
+  }
+}
+}  // namespace
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Refactor the FEM constitutive model implementation to eliminate heap
allocation and virtual methods. Change to a CRTP pattern for
compile-time polymorphism. The unit tests are the same as in the
previous implementation except for syntactic changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14473)
<!-- Reviewable:end -->
