### PR TITLE
examples: Fully port monte carlo acrobot and add a demo program

### DIFF
--- a/examples/acrobot/dev/BUILD.bazel
+++ b/examples/acrobot/dev/BUILD.bazel
@@ -14,9 +14,40 @@ load(
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
+# Now we have our non-test modules in alphabetical order...
+
 drake_py_library(
     name = "acrobot_io",
     srcs = ["acrobot_io.py"],
+    deps = [
+        "//bindings/pydrake",
+    ],
+)
+
+drake_py_library(
+    name = "metrics",
+    srcs = ["metrics.py"],
+)
+
+drake_py_library(
+    # This is the library form of spong_sim.py.
+    name = "spong_sim_lib_py",
+    srcs = ["spong_sim.py"],
+    deps = [
+        ":acrobot_io",
+        "//bindings/pydrake",
+    ],
+)
+
+drake_py_binary(
+    # This is the directly-runnable form of spong_sim.py.
+    name = "spong_sim_main_py",
+    srcs = ["spong_sim.py"],
+    main = "spong_sim.py",
+    deps = [
+        ":acrobot_io",
+        "//bindings/pydrake",
+    ],
 )
 
 drake_cc_binary(
@@ -38,11 +69,41 @@ drake_cc_binary(
 )
 
 # === test/ ===
+
 drake_py_unittest(
     name = "acrobot_io_test",
     data = [
         ":test/example_scenario.yaml",
     ],
+    deps = [
+        ":acrobot_io",
+        "//bindings/pydrake",
+    ],
+)
+
+drake_py_unittest(
+    name = "metrics_test",
+    deps = [
+        ":metrics",
+    ],
+)
+
+drake_py_unittest(
+    name = "spong_sim_lib_py_test",
+    deps = [
+        ":spong_sim_lib_py",
+    ],
+)
+
+drake_py_test(
+    name = "spong_sim_main_py_test",
+    srcs = ["test/spong_sim_main_test.py"],
+    allow_import_unittest = True,
+    data = [
+        ":spong_sim_main_py",
+        ":test/example_scenario.yaml",
+    ],
+    main = "test/spong_sim_main_test.py",
     deps = [
         ":acrobot_io",
         "//bindings/pydrake",

--- a/examples/acrobot/dev/acrobot_io.py
+++ b/examples/acrobot/dev/acrobot_io.py
@@ -1,12 +1,7 @@
+import numpy as np
 import yaml
 
-import numpy as np
-
-# This is a magic tribool value described at
-#   https://github.com/yaml/pyyaml/pull/256
-# and must be set this way for post- and pre- pyyaml#256 yaml dumpers to give
-# the same output.
-_FLOW_STYLE = None
+from pydrake.common.yaml import yaml_load, yaml_dump
 
 
 def load_scenario(*, filename=None, data=None, scenario_name=None):
@@ -14,15 +9,7 @@ def load_scenario(*, filename=None, data=None, scenario_name=None):
     loads and returns one acrobot scenario from the file.  The `scenario_name`
     may only be omitted when the file contains a single scenario.
     """
-    # TODO(ggould-tri) This originally used a schema parser that was aware of
-    # the stochastic schema types (eg "!Gaussian" object tags).  That is not
-    # currently ported here as the python version of spong_sim does not
-    # support stochastic schemas.
-    if data:
-        scenarios = yaml.safe_load(data)
-    else:
-        with open(filename, "r") as data_file:
-            scenarios = yaml.safe_load(data_file)
+    scenarios = yaml_load(filename=filename, data=data)
     if scenario_name:
         result = scenarios[scenario_name]
     else:
@@ -37,29 +24,26 @@ def load_scenario(*, filename=None, data=None, scenario_name=None):
 def save_scenario(*, scenario, scenario_name):
     """Given a scenario and its name, returns a yaml-formatted str for it.
     """
-    # For a whitelist of scenario-specific items, convert numpy arrays into
+    # For a known list of scenario-specific items, convert numpy arrays into
     # lists for serialization purposes.
     scrubbed = dict(scenario)
     for key in ["controller_params", "initial_state"]:
-        if "min" in scenario[key]:
+        if isinstance(scenario[key], dict):
             for subkey in ["min", "max"]:
                 scrubbed[key][subkey] = [
                     float(x) for x in scenario[key][subkey]
                 ]
         else:
             scrubbed[key] = [float(x) for x in scenario[key]]
-    return yaml.dump({scenario_name: scrubbed},
-                     Dumper=yaml.CDumper,
-                     default_flow_style=_FLOW_STYLE)
+    return yaml_dump({scenario_name: scrubbed})
 
 
 def load_output(*, filename=None, data=None):
     """Given an acrobot output `filename` xor `data`, loads and returns the
-    np.ndarray.
-
-    NOTE: We re-implement this here (rather than using `yaml_load`) in order
-    to use `yaml.CLoader`, which greatly improves performance, but cannot be
-    used for all the cases supported by yaml_load.
+    np.ndarray. NOTE: We re-implement this here (rather than using
+    `yaml_load`) in order to use `yaml.CLoader`, which greatly improves
+    performance, but cannot be used for all the cases supported by
+    yaml_load.
     """
     if sum(bool(x) for x in [data, filename]) != 1:
         raise RuntimeError("Must specify exactly one of data= and filename=")
@@ -76,5 +60,4 @@ def load_output(*, filename=None, data=None):
 def save_output(*, x_tape):
     """Given an acrobot output `x_tape`, returns a yaml-formatter str for it.
     """
-    return yaml.dump({"x_tape": x_tape.tolist()},
-                     default_flow_style=_FLOW_STYLE)
+    return yaml_dump({"x_tape": x_tape.tolist()})

--- a/examples/acrobot/dev/metrics.py
+++ b/examples/acrobot/dev/metrics.py
@@ -1,0 +1,50 @@
+import numpy as np
+
+
+def _wrap_to(value, low, high):
+    assert low < high
+    return ((value - low) % (high - low)) + low
+
+
+def deviation_from_upright_equilibrium(x):
+    return np.array([
+        _wrap_to(x[0], 0, 2 * np.pi) - np.pi,
+        _wrap_to(x[1], -np.pi, np.pi),
+        x[2],
+        x[3],
+    ])
+
+
+def final_state_cost(x_tape):
+    """
+    Returns the L2-norm of the deviation from the upright equilibrium at the
+    final state in `x_tape`
+    """
+    return np.linalg.norm(deviation_from_upright_equilibrium(x_tape[:, -1]))
+
+
+def ensemble_cost(x_tapes):
+    """
+    Returns the total cost for the trajectories in `x_tapes`.
+    """
+    per_trajectory_costs = [final_state_cost(x_tape) for x_tape in x_tapes]
+    # Return the L1-norm of the per-trajectory-costs, scaled by the number of
+    # trajectories.
+    return np.linalg.norm(per_trajectory_costs, 1) / len(x_tapes)
+
+
+def is_success(x_tape):
+    """
+    Returns true if the final state in `x_tape` is close to the upright
+    equilibrium.
+    """
+    return np.linalg.norm(deviation_from_upright_equilibrium(
+        x_tape[:, -1])) < 1e-3
+
+
+def success_rate(x_tapes):
+    """
+    Given a list of x-tapes, returns the fraction of the total for which
+    `is_success()` returns True.
+    """
+    return np.sum([is_success(x_tape) for x_tape in x_tapes]) / len(x_tapes)

--- a/examples/acrobot/dev/spong_sim.py
+++ b/examples/acrobot/dev/spong_sim.py
@@ -14,7 +14,7 @@ from pydrake.systems.analysis import Simulator
 from pydrake.systems.framework import DiagramBuilder
 from pydrake.systems.primitives import LogOutput
 
-from anzu.sim.acrobot.acrobot_io import load_scenario, save_output
+from drake.examples.acrobot.dev.acrobot_io import load_scenario, save_output
 
 
 def simulate(*, initial_state, controller_params, t_final, tape_period):

--- a/examples/acrobot/dev/spong_sim.py
+++ b/examples/acrobot/dev/spong_sim.py
@@ -1,0 +1,73 @@
+"""A main() program (plus an reusable standalone function) that simulates a
+spong-controlled acrobot.
+"""
+
+import argparse
+import sys
+
+from pydrake.examples.acrobot import (
+    AcrobotPlant,
+    AcrobotSpongController,
+    AcrobotState,
+)
+from pydrake.systems.analysis import Simulator
+from pydrake.systems.framework import DiagramBuilder
+from pydrake.systems.primitives import LogOutput
+
+from anzu.sim.acrobot.acrobot_io import load_scenario, save_output
+
+
+def simulate(*, initial_state, controller_params, t_final, tape_period):
+    """Simulates an Acrobot + Spong controller from the given initial state and
+    parameters until the given final time.  Returns the state sampled at the
+    given tape_period.
+    """
+    builder = DiagramBuilder()
+    plant = builder.AddSystem(AcrobotPlant())
+    controller = builder.AddSystem(AcrobotSpongController())
+
+    builder.Connect(plant.get_output_port(0), controller.get_input_port(0))
+    builder.Connect(controller.get_output_port(0), plant.get_input_port(0))
+    state_logger = LogOutput(plant.get_output_port(0), builder)
+    state_logger.set_publish_period(tape_period)
+
+    diagram = builder.Build()
+    simulator = Simulator(diagram)
+    context = simulator.get_mutable_context()
+    plant_context = diagram.GetMutableSubsystemContext(plant, context)
+    controller_context = diagram.GetMutableSubsystemContext(
+        controller, context)
+
+    plant_context.SetContinuousState(initial_state)
+    controller_context.get_mutable_numeric_parameter(0).SetFromVector(
+        controller_params)
+
+    simulator.AdvanceTo(t_final)
+
+    x_tape = state_logger.data()
+    return x_tape
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--scenario", metavar="*.yaml",
+        help="Scenario file to load (required).")
+    parser.add_argument(
+        "--output", metavar="*.yaml",
+        help="Output file to save (required).")
+    args = parser.parse_args()
+    if not args.scenario:
+        parser.error("A --scenario file is required.")
+    if not args.output:
+        parser.error("An --output file is required.")
+    scenario = load_scenario(filename=args.scenario)
+    x_tape = simulate(**scenario)
+    text = save_output(x_tape=x_tape)
+    with open(args.output, 'w') as handle:
+        handle.write(text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/acrobot/dev/test/metrics_test.py
+++ b/examples/acrobot/dev/test/metrics_test.py
@@ -1,0 +1,74 @@
+import unittest
+
+import numpy as np
+
+from anzu.sim.acrobot.metrics import (
+    deviation_from_upright_equilibrium,
+    final_state_cost,
+    is_success,
+    success_rate,
+)
+
+
+class TestMetrics(unittest.TestCase):
+    def setUp(self):
+        self.x_equilibrium = [np.pi, 0, 0, 0]
+        self.x_wrapped_equilibrium = [-np.pi, 2 * np.pi, 0, 0]
+
+        self.equilibrium_tapes = 2 * [np.zeros([4, 10])]
+        self.equilibrium_tapes[0][:, -1] = self.x_equilibrium
+        self.equilibrium_tapes[1][:, -1] = self.x_wrapped_equilibrium
+
+        self.nonequilibrium_tapes = 4 * [np.zeros([4, 10])]
+        self.nonequilibrium_tapes[0][:, -1] = [0, 0, 0, 0]
+        self.nonequilibrium_tapes[1][:, -1] = [np.pi, np.pi / 2, 0, 0]
+        self.nonequilibrium_tapes[2][:, -1] = [np.pi, 0, 1, 0]
+        self.nonequilibrium_tapes[3][:, -1] = [np.pi, 0, 0, 1]
+
+    def test_deviation_from_upright_equilibrium(self):
+        # Verify that the deviation is 0 at the upright equilibrium.
+        self.assertTrue(
+            np.linalg.norm(
+                deviation_from_upright_equilibrium(self.x_equilibrium)) == 0)
+        # Verify that the deviation is 0 if we add or subtract 2 * pi
+        self.assertTrue(
+            np.linalg.norm(
+                deviation_from_upright_equilibrium(self.x_wrapped_equilibrium))
+            == 0)
+        # Verify a few other values.
+        self.assertTrue((deviation_from_upright_equilibrium(
+            [0, 0, 0, 0]) == np.array([-np.pi, 0, 0, 0])).all())
+        self.assertTrue((deviation_from_upright_equilibrium(
+            [np.pi, np.pi / 2, 0, 0]) == np.array([0, np.pi / 2, 0, 0])).all())
+        self.assertTrue((deviation_from_upright_equilibrium(
+            [np.pi, 0, 1, 0]) == np.array([0, 0, 1, 0])).all())
+        self.assertTrue((deviation_from_upright_equilibrium(
+            [np.pi, 0, 0, 1]) == np.array([0, 0, 0, 1])).all())
+
+    def test_final_state_cost(self):
+        # Verify that tapes ending at equilibrium have zero cost.
+        for x_tape in self.equilibrium_tapes:
+            self.assertTrue(final_state_cost(x_tape) == 0)
+        # Verify that tapes ending at non-equilibrium points have positive
+        # cost.
+        for x_tape in self.nonequilibrium_tapes:
+            self.assertGreater(final_state_cost(x_tape), 0)
+
+    def test_is_success(self):
+        # Verify that ending at the upright equilibrium yields true.
+        for x_tape in self.equilibrium_tapes:
+            self.assertTrue(is_success(x_tape))
+        # Verify that ending at non-equilibrium points yields false.
+        for x_tape in self.nonequilibrium_tapes:
+            self.assertFalse(is_success(x_tape))
+
+    def test_success_rate(self):
+        self.assertEqual(success_rate(self.nonequilibrium_tapes), 0.)
+        self.assertEqual(
+            success_rate(self.nonequilibrium_tapes + self.equilibrium_tapes +
+                         self.equilibrium_tapes), 0.5)
+        self.assertEqual(success_rate(self.equilibrium_tapes), 1.)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/acrobot/dev/test/metrics_test.py
+++ b/examples/acrobot/dev/test/metrics_test.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-from anzu.sim.acrobot.metrics import (
+from drake.examples.acrobot.dev.metrics import (
     deviation_from_upright_equilibrium,
     final_state_cost,
     is_success,
@@ -65,10 +65,6 @@ class TestMetrics(unittest.TestCase):
     def test_success_rate(self):
         self.assertEqual(success_rate(self.nonequilibrium_tapes), 0.)
         self.assertEqual(
-            success_rate(self.nonequilibrium_tapes + self.equilibrium_tapes +
-                         self.equilibrium_tapes), 0.5)
+            success_rate(self.nonequilibrium_tapes + self.equilibrium_tapes
+                         + self.equilibrium_tapes), 0.5)
         self.assertEqual(success_rate(self.equilibrium_tapes), 1.)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/examples/acrobot/dev/test/spong_sim_lib_py_test.py
+++ b/examples/acrobot/dev/test/spong_sim_lib_py_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-from anzu.sim.acrobot.spong_sim import simulate
+from drake.examples.acrobot.dev.spong_sim import simulate
 
 
 class TestSpongControlledAcrobot(unittest.TestCase):
@@ -12,7 +12,3 @@ class TestSpongControlledAcrobot(unittest.TestCase):
             t_final=30.0, tape_period=0.05)
         # 4 states x 30 seconds of samples at 20 Hz per sample_scenario.
         self.assertEqual(x_tape.shape, (4, 601))
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/examples/acrobot/dev/test/spong_sim_lib_py_test.py
+++ b/examples/acrobot/dev/test/spong_sim_lib_py_test.py
@@ -1,0 +1,18 @@
+import unittest
+
+from anzu.sim.acrobot.spong_sim import simulate
+
+
+class TestSpongControlledAcrobot(unittest.TestCase):
+
+    def test_simulate(self):
+        x_tape = simulate(
+            initial_state=[0.01, 0.02, 0.03, 0.04],
+            controller_params=[0.001, 0.002, 0.003, 0.004],
+            t_final=30.0, tape_period=0.05)
+        # 4 states x 30 seconds of samples at 20 Hz per sample_scenario.
+        self.assertEqual(x_tape.shape, (4, 601))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/acrobot/dev/test/spong_sim_main_test.py
+++ b/examples/acrobot/dev/test/spong_sim_main_test.py
@@ -69,6 +69,4 @@ if __name__ == "__main__":
     if "--cc" in sys.argv:
         sys.argv.remove("--cc")
         _backend = "cc"
-
-    assert _backend == "cc"  # TODO(#13494) Python backend temporarily missing.
     unittest.main()


### PR DESCRIPTION
This PR brings the full acrobot monte carlo example from downstream into Drake.
In addition it adds a simple demonstration program, since the downstream code that uses this example is not ported.

Co-authored-by: Jeremy Nimmer <jeremy.nimmer@tri.global>
Co-authored-by: Andrés K. Valenzuela <andres.valenzuela@tri.global>
Co-authored-by: Eric Cousineau <eric.cousineau@tri.global>
Co-authored-by: Sam Creasey <sam.creasey@tri.global>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14478)
<!-- Reviewable:end -->
