### PR TITLE
geometry/proximity_engine: add better error when shape size == 0

### DIFF
--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -155,9 +155,16 @@ namespace {
                                "' : " + err);
     }
 
-    if (shapes.size() != 1) {
+    if (shapes.size() == 0) {
       throw std::runtime_error(
-          fmt::format("The OBJ contains multiple objects; only OBJs with a "
+          fmt::format("The OBJ file contains no objects; only OBJs with a "
+                      "single object are supported: '{}'. Potentially the "
+		      "file is corrupt, or not an OBJ file.",
+                      filename));
+    }
+    if (shapes.size() > 1) {
+      throw std::runtime_error(
+          fmt::format("The OBJ file contains multiple objects; only OBJs with a "
                       "single object are supported: '{}'",
                       filename));
     }

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -158,14 +158,14 @@ namespace {
     if (shapes.size() == 0) {
       throw std::runtime_error(
           fmt::format("The OBJ file contains no objects; only OBJs with a "
-                      "single object are supported: '{}'. Potentially the "
-                      "file is corrupt, or not an OBJ file.",
+                      "single object are supported. Potentially, the "
+                      "file is corrupt, or not an OBJ file. File name: '{}'",
                       filename));
     }
     if (shapes.size() > 1) {
       throw std::runtime_error(
           fmt::format("The OBJ file contains multiple objects; only OBJs"
-                      "with a single object are supported: '{}'",
+                      "with a single object are supported. File name: '{}'",
                       filename));
     }
 

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -159,13 +159,13 @@ namespace {
       throw std::runtime_error(
           fmt::format("The OBJ file contains no objects; only OBJs with a "
                       "single object are supported: '{}'. Potentially the "
-		      "file is corrupt, or not an OBJ file.",
+                      "file is corrupt, or not an OBJ file.",
                       filename));
     }
     if (shapes.size() > 1) {
       throw std::runtime_error(
-          fmt::format("The OBJ file contains multiple objects; only OBJs with a "
-                      "single object are supported: '{}'",
+          fmt::format("The OBJ file contains multiple objects; only OBJs"
+                      "with a single object are supported: '{}'",
                       filename));
     }
 

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -586,7 +586,7 @@ GTEST_TEST(ProximityEngineTests, ExceptionTwoObjectsInObjFileForConvex) {
       1.0};
   DRAKE_EXPECT_THROWS_MESSAGE(
       engine.AddDynamicGeometry(convex, {}, GeometryId::get_new_id()),
-      std::runtime_error, ".*only OBJs with a single object.*");
+      std::runtime_error, ".*Potentially, the file is corrupt,.*");
 }
 
 // Tests for copy/move semantics.  ---------------------------------------------


### PR DESCRIPTION
Added a better error message for when the `tinyOBJ` loader does not manage to load the object for whatever reason.

I was dealing with this for several hours before realizing that I was trying to load an STL in one of my links and didn't realize that Drake doesn't support STL without adding the converter.

Hopefully, this should avoid similar issues in the fureu

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14480)
<!-- Reviewable:end -->
