### PR TITLE
upgrade mosek to mosek 9.2

### DIFF
--- a/doc/bazel.rst
+++ b/doc/bazel.rst
@@ -161,7 +161,7 @@ Proprietary Solvers
 The Drake Bazel build currently supports the following proprietary solvers:
 
  * Gurobi 9.0.2
- * MOSEK 9.0
+ * MOSEK 9.2
  * SNOPT 7.4
 
 .. When upgrading SNOPT to a newer revision, re-enable TestPrintFile in
@@ -201,7 +201,7 @@ See https://docs.bazel.build/versions/master/user-manual.html#bazelrc.
 MOSEK
 -----
 
-The Drake Bazel build system downloads MOSEK 9.0.96 automatically.  No manual
+The Drake Bazel build system downloads MOSEK 9.2.33 automatically.  No manual
 installation is required.  Set the location of your license file as follows:
 
 ``export MOSEKLM_LICENSE_FILE=/path/to/mosek.lic``

--- a/solvers/mosek_solver.cc
+++ b/solvers/mosek_solver.cc
@@ -26,10 +26,10 @@ namespace drake {
 namespace solvers {
 namespace {
 // Mosek treats psd matrix variables in a special manner.
-// Check https://docs.mosek.com/9.0/capi/tutorial-sdo-shared.html for more
+// Check https://docs.mosek.com/9.2/capi/tutorial-sdo-shared.html for more
 // details. To summarize, Mosek stores a positive semidefinite (psd) matrix
 // variable as a "bar var" (as called in Mosek's API, for example
-// https://docs.mosek.com/9.0/capi/tutorial-sdo-shared.html). Inside Mosek, it
+// https://docs.mosek.com/9.2/capi/tutorial-sdo-shared.html). Inside Mosek, it
 // accesses each of the psd matrix variable with a unique ID. Moreover, the
 // Mosek user cannot access the entries of the psd matrix variable individually;
 // instead, the user can only access the matrix X̅ as a whole. To impose
@@ -89,7 +89,7 @@ class MatrixVariableEntry {
 
 // Mosek stores dual variable in different categories, called slc, suc, slx, sux
 // and snx. Refer to
-// https://docs.mosek.com/9.0/capi/alphabetic-functionalities.html#mosek.task.getsolution
+// https://docs.mosek.com/9.2/capi/alphabetic-functionalities.html#mosek.task.getsolution
 // for more information.
 enum class DualVarType {
   kLinearConstraint,  ///< Corresponds to Mosek's slc and suc.
@@ -109,8 +109,8 @@ using ConstraintDualIndices = std::vector<ConstraintDualIndex>;
 
 // This function is used to print information for each iteration to the console,
 // it will show PRSTATUS, PFEAS, DFEAS, etc. For more information, check out
-// https://docs.mosek.com/9.0/capi/solver-io.html. This printstr is copied
-// directly from https://docs.mosek.com/9.0/capi/solver-io.html#stream-logging.
+// https://docs.mosek.com/9.2/capi/solver-io.html. This printstr is copied
+// directly from https://docs.mosek.com/9.2/capi/solver-io.html#stream-logging.
 void MSKAPI printstr(void*, const char str[]) { printf("%s", str); }
 
 enum class LinearConstraintBoundType {
@@ -1391,13 +1391,13 @@ MSKrescodee AddEqualityConstraintBetweenMatrixVariablesForSameDecisionVariable(
 }
 
 // @param slx Mosek dual variables for variable lower bound. See
-// https://docs.mosek.com/9.0/capi/alphabetic-functionalities.html#mosek.task.getslx
+// https://docs.mosek.com/9.2/capi/alphabetic-functionalities.html#mosek.task.getslx
 // @param sux Mosek dual variables for variable upper bound. See
-// https://docs.mosek.com/9.0/capi/alphabetic-functionalities.html#mosek.task.getsux
+// https://docs.mosek.com/9.2/capi/alphabetic-functionalities.html#mosek.task.getsux
 // @param slc Mosek dual variables for linear constraint lower bound. See
-// https://docs.mosek.com/9.0/capi/alphabetic-functionalities.html#mosek.task.getslc
+// https://docs.mosek.com/9.2/capi/alphabetic-functionalities.html#mosek.task.getslc
 // @param suc Mosek dual variables for linear constraint upper bound. See
-// https://docs.mosek.com/9.0/capi/alphabetic-functionalities.html#mosek.task.getsuc
+// https://docs.mosek.com/9.2/capi/alphabetic-functionalities.html#mosek.task.getsuc
 void SetBoundingBoxDualSolution(
     const std::vector<Binding<BoundingBoxConstraint>>& constraints,
     const std::vector<MSKrealt>& slx, const std::vector<MSKrealt>& sux,
@@ -1502,7 +1502,7 @@ MSKrescodee SetDualSolution(
   if (which_sol != MSK_SOL_ITG) {
     // Mosek cannot return dual solution if the solution type is MSK_SOL_ITG
     // (which stands for mixed integer optimizer), see
-    // https://docs.mosek.com/9.0/capi/accessing-solution.html#available-solutions
+    // https://docs.mosek.com/9.2/capi/accessing-solution.html#available-solutions
     int num_mosek_vars{0};
     rescode = MSK_getnumvar(task, &num_mosek_vars);
     if (rescode != MSK_RES_OK) {
@@ -1510,7 +1510,7 @@ MSKrescodee SetDualSolution(
     }
     // Mosek dual variables for variable lower bounds (slx) and upper bounds
     // (sux). Refer to
-    // https://docs.mosek.com/9.0/capi/alphabetic-functionalities.html#mosek.task.getsolution
+    // https://docs.mosek.com/9.2/capi/alphabetic-functionalities.html#mosek.task.getsolution
     // for more explaination.
     std::vector<MSKrealt> slx(num_mosek_vars);
     std::vector<MSKrealt> sux(num_mosek_vars);
@@ -1529,7 +1529,7 @@ MSKrescodee SetDualSolution(
     }
     // Mosek dual variables for linear constraints lower bounds (slc) and upper
     // bounds (suc). Refer to
-    // https://docs.mosek.com/9.0/capi/alphabetic-functionalities.html#mosek.task.getsolution
+    // https://docs.mosek.com/9.2/capi/alphabetic-functionalities.html#mosek.task.getsolution
     // for more explaination.
     std::vector<MSKrealt> slc(num_linear_constraints);
     std::vector<MSKrealt> suc(num_linear_constraints);
@@ -1605,7 +1605,7 @@ class MosekSolver::License {
 std::shared_ptr<MosekSolver::License> MosekSolver::AcquireLicense() {
   // According to
   // https://docs.mosek.com/8.1/cxxfusion/solving-parallel.html sharing
-  // an env used between threads is safe (not mentioned in 9.0 documentation),
+  // an env used between threads is safe (not mentioned in 9.2 documentation),
   // but nothing mentions thread-safety when allocating the environment. We can
   // safeguard against this ambiguity by using GetScopedSingleton for basic
   // thread-safety when acquiring / releasing the license.

--- a/solvers/mosek_solver.h
+++ b/solvers/mosek_solver.h
@@ -18,15 +18,15 @@ namespace solvers {
  */
 struct MosekSolverDetails {
   /// The mosek optimization time. Please refer to MSK_DINF_OPTIMIZER_TIME in
-  /// https://docs.mosek.com/9.0/capi/constants.html?highlight=msk_dinf_optimizer_time
+  /// https://docs.mosek.com/9.2/capi/constants.html?highlight=msk_dinf_optimizer_time
   double optimizer_time{};
   /// The response code returned from mosek solver. Check
-  /// https://docs.mosek.com/9.0/capi/response-codes.html for the meaning on the
+  /// https://docs.mosek.com/9.2/capi/response-codes.html for the meaning on the
   /// response code.
   int rescode{};
   /// The solution status after solving the problem. Check
-  /// https://docs.mosek.com/9.0/capi/accessing-solution.html and
-  /// https://docs.mosek.com/9.0/capi/constants.html#mosek.solsta for the
+  /// https://docs.mosek.com/9.2/capi/accessing-solution.html and
+  /// https://docs.mosek.com/9.2/capi/constants.html#mosek.solsta for the
   /// meaning on the solution status.
   int solution_status{};
 };
@@ -39,7 +39,7 @@ struct MosekSolverDetails {
  * (Mosek might change the values of the integer/binary variables in the
  * subsequent iterations.) If the specified integer solution is infeasible or
  * incomplete, MOSEK will simply ignore it. For more details, check
- * https://docs.mosek.com/9.0/capi/tutorial-mio-shared.html?highlight=initial
+ * https://docs.mosek.com/9.2/capi/tutorial-mio-shared.html?highlight=initial
  */
 class MosekSolver final : public SolverBase {
  public:
@@ -53,7 +53,7 @@ class MosekSolver final : public SolverBase {
 
   /**
    * Control stream logging. Refer to
-   * https://docs.mosek.com/9.0/capi/solver-io.html for more details.
+   * https://docs.mosek.com/9.2/capi/solver-io.html for more details.
    * @param flag Set to true if the user want to turn on stream logging.
    * @param log_file If the user wants to output the logging to a file, then
    * set @p log_file to the name of that file. If the user wants to output the
@@ -108,7 +108,7 @@ class MosekSolver final : public SolverBase {
   mutable std::shared_ptr<License> license_;
   // Set to true if the user wants the solver to produce output to the console
   // or a log file. Default to false, such that the solver runs silently.
-  // Check out https://docs.mosek.com/9.0/capi/solver-io.html for more info.
+  // Check out https://docs.mosek.com/9.2/capi/solver-io.html for more info.
   bool stream_logging_{false};
   // set @p log_file to the name of that file. If the user wants to output the
   // logging to the console, then set log_file to empty string. Default to an

--- a/solvers/solver_options.h
+++ b/solvers/solver_options.h
@@ -42,7 +42,7 @@ namespace solvers {
  * version used in Drake.
  *
  * "MOSEK" -- Parameter name and values as specified in Mosek Reference
- * https://docs.mosek.com/9.0/capi/parameters.html
+ * https://docs.mosek.com/9.2/capi/parameters.html
  */
 class SolverOptions {
  public:

--- a/solvers/test/linear_program_examples.h
+++ b/solvers/test/linear_program_examples.h
@@ -76,7 +76,7 @@ class LinearProgram1 : public OptimizationProgram {
 };
 
 // Test a simple linear programming problem
-// Adapted from https://docs.mosek.com/9.0/capi/tutorial-lo-shared.html
+// Adapted from https://docs.mosek.com/9.2/capi/tutorial-lo-shared.html
 // min -3x0 - x1 - 5x2 - x3
 // s.t     3x0 +  x1 + 2x2        = 30
 //   15 <= 2x0 +  x1 + 3x2 +  x3 <= inf

--- a/solvers/test/mosek_solver_test.cc
+++ b/solvers/test/mosek_solver_test.cc
@@ -40,7 +40,7 @@ TEST_F(UnboundedLinearProgramTest0, Test) {
         result.get_solver_details<MosekSolver>();
     EXPECT_EQ(mosek_solver_details.rescode, 0);
     // This problem status is defined in
-    // https://docs.mosek.com/9.0/capi/constants.html#mosek.prosta
+    // https://docs.mosek.com/9.2/capi/constants.html#mosek.prosta
     const int MSK_SOL_STA_DUAL_INFEAS_CER = 6;
     EXPECT_EQ(mosek_solver_details.solution_status,
               MSK_SOL_STA_DUAL_INFEAS_CER);
@@ -241,7 +241,7 @@ GTEST_TEST(MosekTest, SolverOptionsTest) {
   mosek_solver.Solve(prog, {}, solver_options, &result);
   EXPECT_FALSE(result.is_success());
   // This response code is defined in
-  // https://docs.mosek.com/9.0/capi/response-codes.html#mosek.rescode
+  // https://docs.mosek.com/9.2/capi/response-codes.html#mosek.rescode
   const int MSK_RES_ERR_HUGE_C{1375};
   EXPECT_EQ(result.get_solver_details<MosekSolver>().rescode,
             MSK_RES_ERR_HUGE_C);
@@ -263,11 +263,11 @@ GTEST_TEST(MosekSolver, SolverOptionsErrorTest) {
   mosek_solver.Solve(prog, {}, solver_options, &result);
   const auto& solver_details = result.get_solver_details<MosekSolver>();
   // This response code is defined in
-  // https://docs.mosek.com/9.0/capi/response-codes.html#mosek.rescode
+  // https://docs.mosek.com/9.2/capi/response-codes.html#mosek.rescode
   const int MSK_RES_ERR_PARAM_NAME_INT = 1207;
   EXPECT_EQ(solver_details.rescode, MSK_RES_ERR_PARAM_NAME_INT);
   // This problem status is defined in
-  // https://docs.mosek.com/9.0/capi/constants.html#mosek.prosta
+  // https://docs.mosek.com/9.2/capi/constants.html#mosek.prosta
   const int MSK_PRO_STA_UNKNOWN = 0;
   EXPECT_EQ(solver_details.solution_status, MSK_PRO_STA_UNKNOWN);
 

--- a/solvers/test/quadratic_program_examples.cc
+++ b/solvers/test/quadratic_program_examples.cc
@@ -432,7 +432,7 @@ void TestQPonUnitBallExample(const SolverInterface& solver) {
         SolverTypeConverter::IdToType(result.get_solver_id()).value();
     double tol = 1E-4;
     if (solver_type == SolverType::kMosek) {
-      // Regression from MOSEK 8.1 to MOSEK 9.0.
+      // Regression from MOSEK 8.1 to MOSEK 9.2.
       tol = 2E-4;
     }
     EXPECT_TRUE(CompareMatrices(x_value, x_expected, tol,

--- a/solvers/test/semidefinite_program_examples.h
+++ b/solvers/test/semidefinite_program_examples.h
@@ -65,7 +65,7 @@ void SolveEigenvalueProblem(const SolverInterface& solver,
                             double tol);
 
 /// Solve an SDP with a second order cone constraint. This example is taken from
-/// https://docs.mosek.com/9.0/capi/tutorial-sdo-shared.html
+/// https://docs.mosek.com/9.2/capi/tutorial-sdo-shared.html
 void SolveSDPwithSecondOrderConeExample1(const SolverInterface& solver,
                                          double tol);
 

--- a/tools/dynamic_analysis/tsan.supp
+++ b/tools/dynamic_analysis/tsan.supp
@@ -23,8 +23,8 @@ thread:__kmp_create_worker
 # thread leak (libiomp5.*) in __kmp_create_monitor
 thread:__kmp_create_monitor
 
-# data race libmosek64.so.9.0.  MOSEK has not been instrumented with TSan.
-called_from_lib:libmosek64.so.9.0
+# data race libmosek64.so.9.2.  MOSEK has not been instrumented with TSan.
+called_from_lib:libmosek64.so.9.2
 
 # data race (libglib-2.0.*) in g_static_rec_mutex_lock
 race:g_static_rec_mutex_lock

--- a/tools/workspace/mosek/repository.bzl
+++ b/tools/workspace/mosek/repository.bzl
@@ -28,15 +28,15 @@ def _impl(repository_ctx):
     # When these values are updated, tools/dynamic_analysis/tsan.supp may also
     # need updating.
     mosek_major_version = 9
-    mosek_minor_version = 0
-    mosek_patch_version = 96
+    mosek_minor_version = 2
+    mosek_patch_version = 33
 
     if repository_ctx.os.name == "mac os x":
         mosek_platform = "osx64x86"
-        sha256 = "04bc5e6edf89439931ba2a2090309a5cbecd2d939f7c1cce8f0b304922ed28ed"  # noqa
+        sha256 = "72e3b46f1df67376f4a854db65841773fb4558bf8625395607bd1fa9ecf44879"  # noqa
     elif repository_ctx.os.name == "linux":
         mosek_platform = "linux64x86"
-        sha256 = "ef0c7a74e4a51db028f9cf9d0a0f3c31f9866fb2f7e7434e2356c474f73234bf"  # noqa
+        sha256 = "e223389b9517fc636b75bb3cee817847df4bc9ca987ba279f40a9fbe5fa276d6"  # noqa
     else:
         fail(
             "Operating system is NOT supported",
@@ -70,7 +70,7 @@ def _impl(repository_ctx):
         install_name_tool = which(repository_ctx, "install_name_tool")
 
         # Note that libmosek64.dylib is (erroneously) a copy of
-        # libmosek64.9.0.dylib instead of a symlink. Otherwise, the list of
+        # libmosek64.9.2.dylib instead of a symlink. Otherwise, the list of
         # files should include the following in place of bin/libmosek64.dylib:
         #
         # "bin/libmosek64.{}.{}.dylib".format(mosek_major_version,


### PR DESCRIPTION
Drake currently supports mosek 9.0, which has a bug in pre-solve the problem to get the dual variable solutions (as shown in our PR #14383. I contacted with Mosek developer and confirmed that Mosek 9.2 resolves this bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14484)
<!-- Reviewable:end -->
