### PR TITLE
Refactor FemState and FemElement

### DIFF
--- a/multibody/fixed_fem/dev/BUILD.bazel
+++ b/multibody/fixed_fem/dev/BUILD.bazel
@@ -33,6 +33,28 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "element_cache_entry",
+    hdrs = [
+        "element_cache_entry.h",
+    ],
+    deps = [
+        ":fem_indexes",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "fem_element",
+    hdrs = [
+        "fem_element.h",
+    ],
+    deps = [
+        ":fem_state",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
     name = "fem_indexes",
     hdrs = [
         "fem_indexes.h",
@@ -40,6 +62,16 @@ drake_cc_library(
     deps = [
         "//common:essential",
         "//common:type_safe_index",
+    ],
+)
+
+drake_cc_library(
+    name = "fem_state",
+    hdrs = [
+        "fem_state.h",
+    ],
+    deps = [
+        "//common:essential",
     ],
 )
 
@@ -106,6 +138,36 @@ drake_cc_library(
     ],
     deps = [
         ":quadrature",
+    ],
+)
+
+# === test/ ===
+
+drake_cc_library(
+    name = "dummy_element",
+    testonly = 1,
+    hdrs = ["test/dummy_element.h"],
+    deps = [
+        ":element_cache_entry",
+        ":fem_element",
+        ":fem_state",
+    ],
+)
+
+drake_cc_googletest(
+    name = "fem_element_test",
+    deps = [
+        ":dummy_element",
+    ],
+)
+
+drake_cc_googletest(
+    name = "fem_state_test",
+    deps = [
+        ":dummy_element",
+        ":element_cache_entry",
+        ":fem_state",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/multibody/fixed_fem/dev/element_cache_entry.h
+++ b/multibody/fixed_fem/dev/element_cache_entry.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "drake/multibody/fixed_fem/dev/fem_indexes.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+/** %ElementCacheEntry provides basic caching capabilities for the
+ per-element, state-dependent quantities used in an FEM simulation that are
+ not states themselves. These quantities are stored in `ElementData`.
+ @tparam ElementData    The state-dependent quantities of the element that are
+ stored. `ElementData` should be of type `FooElement::Traits::Data` where
+ `FooElement`, the element that this %ElementCacheEntry is holding data for,
+ is the same type as the template parameter `DerivedElement` in FemElement. */
+template <class ElementData>
+class ElementCacheEntry {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ElementCacheEntry);
+
+  static_assert(std::is_default_constructible_v<ElementData>,
+                "The template parameter 'ElementData' in ElementCacheEntry "
+                "must be default constructible. ");
+
+  /** Constructs a new %ElementCacheEntry with default initialized data. */
+  ElementCacheEntry() {}
+
+  ~ElementCacheEntry() = default;
+
+  ElementData& mutable_element_data() { return element_data_; }
+
+  const ElementData& element_data() const { return element_data_; }
+
+  // TODO(xuchenhan-tri): Add interface for marking cache entries stale when
+  //  caching is in place.
+
+ private:
+  ElementData element_data_;
+};
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/fem_element.h
+++ b/multibody/fixed_fem/dev/fem_element.h
@@ -1,0 +1,230 @@
+#pragma once
+
+#include <array>
+#include <string>
+
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fixed_fem/dev/fem_indexes.h"
+#include "drake/multibody/fixed_fem/dev/fem_state.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+// TODO(xuchenhan-tri) Document the definition of quantities like "natural
+// dimension". See issue #14475.
+/** %FemElement is the base class for spatially discretized FEM elements.
+ It computes quantities such as the residual and the stiffness matrix on a
+ single FEM element given the state of the FEM system. These quantities are then
+ assembled into their global counterparts by FemModel.
+
+ %FemElement serves as the base class for all FEM elements. Since FEM elements
+ are usually evaluated in computationally intensive inner loops of the
+ simulation, the overhead caused by virtual methods and heap allocations may be
+ significant. Therefore, this class uses CRTP to achieve compile-time
+ polymorphism and avoids the overhead of virtual methods and facilitates
+ inlining instead. The type information at compile time also helps eliminate all
+ heap allocations. Derived FEM elements must inherit from this base class and
+ implement the interface this class provides. The derived FEM elements must also
+ be accompanied by a corresponding traits class that declares the compile time
+ quantities and type declarations that this base class requires.
+
+ %FemElement also comes with per-element, state-dependent data. The data
+ specific to the `DerivedElement` should be declared in `DerivedTraits`, along
+ with the other responsibilities of `DerivedTraits` detailed below.
+ @tparam DerivedElement The concrete FEM element that inherits from %FemElement
+ through CRTP.
+ @tparam DerivedTraits The traits class associated with the DerivedElement. It
+ needs to provide a nested class `Data` for storing the per-element,
+ state-dependent data used by `DerivedElement`. In particular, the `Data` class
+ needs to provide a default constructor. It also needs to provide the following
+ compile time constants for the `DerivedElement`: `kNaturalDimension`,
+ `kSolutionDimension`, `kSpatialDimension`, the number of quadrature points in a
+ single `DerivedElement`, `kNumQuadraturePoints`, the number of nodes associated
+ with a single `DerivedElement`, `kNumNodes`, the number of degrees of freedom
+ that a single `DerivedElement` possesses, `kNumDofs`, and the order of the ODE
+ problem after FEM spatial discretization, `kOdeOrder`. */
+template <class DerivedElement, class DerivedTraits>
+class FemElement {
+ public:
+  using T = typename DerivedTraits::T;
+  using Traits = DerivedTraits;
+
+  /** Indices of the nodes of this element within the model. */
+  const std::array<NodeIndex, Traits::kNumNodes>& node_indices() const {
+    return node_indices_;
+  }
+
+  /** The ElementIndex of this element within the model. */
+  ElementIndex element_index() const { return element_index_; }
+
+  /** Computes the per-element, state-dependent data associated with this
+   `DerivedElement` given the `state`.
+   @pre data != nullptr. */
+  typename Traits::Data ComputeData(
+      const FemState<DerivedElement>& state) const {
+    return static_cast<const DerivedElement*>(this)->DoComputeData(state);
+  }
+
+  /** Calculates the element residual of this element evaluated at the input
+   state.
+   @param[in] state    The FEM state at which to evaluate the residual.
+   @param[out] residual    A vector of residual of size `Traits::kNumDofs`. All
+   values in `residual` will be overwritten.
+   @pre residual != nullptr */
+  void CalcResidual(const FemState<DerivedElement>& state,
+                    EigenPtr<Vector<T, Traits::kNumDofs>> residual) const {
+    DRAKE_ASSERT(residual != nullptr);
+    residual->setZero();
+    static_cast<const DerivedElement*>(this)->DoCalcResidual(state, residual);
+  }
+
+  /** Calculates the stiffness matrix (the derivative of the residual with
+  respect to the generalized positions) of this element given the state.
+  @param[in] state    The FEM state at which to evaluate the stiffness matrix.
+  @param[out] K    The stiffness matrix of size
+  `Traits::kNumDofs`-by-`Traits::kNumDofs`. All values of `K` will be
+  overwritten.
+  @pre K != nullptr */
+  void CalcStiffnessMatrix(
+      const FemState<DerivedElement>& state,
+      EigenPtr<Eigen::Matrix<T, Traits::kNumDofs, Traits::kNumDofs>> K) const {
+    DRAKE_ASSERT(K != nullptr);
+    K->setZero();
+    static_cast<const DerivedElement*>(this)->DoCalcStiffnessMatrix(state, K);
+  }
+
+  /** Calculates the damping matrix (the derivative of the residual with respect
+  to the time derivative of generalized positions) of this element given the
+  state.
+  @param[in] state    The FEM state at which to evaluate the damping matrix.
+  @param[out] D    The damping matrix of size
+  `Traits::kNumDofs`-by-`Traits::kNumDofs`. All values of `D` will be
+  overwritten.
+  @pre D != nullptr */
+  void CalcDampingMatrix(
+      const FemState<DerivedElement>& state,
+      EigenPtr<Eigen::Matrix<T, Traits::kNumDofs, Traits::kNumDofs>> D) const {
+    DRAKE_ASSERT(D != nullptr);
+    D->setZero();
+    static_cast<const DerivedElement*>(this)->DoCalcDampingMatrix(state, D);
+  }
+
+  /** Calculates the mass matrix (the derivative of the residual with respect to
+  the time second derivative of generalized positions) of this element given the
+  state.
+  @param[in] state    The FEM state at which to evaluate the mass matrix.
+  @param[out] M    The mass matrix of size
+  `Traits::kNumDofs`-by-`Traits::kNumDofs`. All values of `M` will be
+  overwritten.
+  @pre M != nullptr */
+  void CalcMassMatrix(
+      const FemState<DerivedElement>& state,
+      EigenPtr<Eigen::Matrix<T, Traits::kNumDofs, Traits::kNumDofs>> M) const {
+    DRAKE_ASSERT(M != nullptr);
+    static_cast<const DerivedElement*>(this)->DoCalcMassMatrix(state, M);
+  }
+
+ protected:
+  /** Assignment and copy constructions are prohibited.
+   Move constructor is allowed so that FemElement can be stored in
+   `std::vector`. */
+  FemElement(const FemElement&) = delete;
+  FemElement(FemElement&&) = default;
+  const FemElement& operator=(const FemElement&) = delete;
+  FemElement&& operator=(const FemElement&&) = delete;
+
+  /** Constructs a new FEM element. The constructor is made protected because
+   FemElement should not be constructed directly. Use the constructor of the
+   derived classes instead.
+   @param[in] element_index    The index of the new element within the model.
+   @param[in] node_indices    The node indices of the nodes of this element
+   within the model.
+   @pre element_index is valid.
+   @pre Entries in node_indices are valid. */
+  FemElement(ElementIndex element_index,
+             const std::array<NodeIndex, Traits::kNumNodes>& node_indices)
+      : element_index_(element_index), node_indices_(node_indices) {
+    DRAKE_ASSERT(element_index.is_valid());
+    for (int i = 0; i < Traits::kNumNodes; ++i) {
+      DRAKE_ASSERT(node_indices[i].is_valid());
+    }
+  }
+
+  /** `DerivedElement` must provide an implementation for `DoComputeData()`.
+   @throw std::exception if `DerivedElement` does not provide an implementation
+   for `DoComputeData()`. */
+  typename Traits::Data DoComputeData(
+      const FemState<DerivedElement>& state) const {
+    ThrowIfNotImplemented(__func__);
+  }
+
+  /** `DerivedElement` must provide an implementation for
+   `DoCalcResidual()` to provide the residual that is up to date given the
+   `state`. The caller guarantees that `residual` is non-null and contains all
+   zeros; the implementation in the derived class does not have to test for
+   this.
+   @throw std::exception if `DerivedElement` does not provide an implementation
+   for `DoCalcResidual()`. */
+  void DoCalcResidual(const FemState<DerivedElement>& state,
+                      EigenPtr<Vector<T, Traits::kNumDofs>> residual) const {
+    ThrowIfNotImplemented(__func__);
+  }
+
+  /** `DerivedElement` must provide an implementation for
+   `DoCalcStiffnessMatrix()` to provide the stiffness matrix that is up to date
+   given the `state`. The caller guarantees that `K` is non-null and contains
+   all zeros; the implementation in the derived class does not have to test for
+   this.
+   @throw std::exception if `DerivedElement` does not provide an implementation
+   for `DoCalcStiffnessMatrix()`. */
+  void DoCalcStiffnessMatrix(
+      const FemState<DerivedElement>& state,
+      EigenPtr<Eigen::Matrix<T, Traits::kNumDofs, Traits::kNumDofs>> K) const {
+    ThrowIfNotImplemented(__func__);
+  }
+
+  /** `DerivedElement` must provide an implementation for
+   `DoCalcDampingMatrix()` to provide the damping matrix that is up to date
+   given the `state` or to throw an exception indicating a damping matrix does
+   not exist. The caller guarantees that `D` is non-null and contains all
+   zeros; the implementation in the derived class does not have to test for
+   this.
+   @throw std::exception if `DerivedElement` does not provide an implementation
+   for `DoCalcDampingMatrix()`. */
+  void DoCalcDampingMatrix(
+      const FemState<DerivedElement>& state,
+      EigenPtr<Eigen::Matrix<T, Traits::kNumDofs, Traits::kNumDofs>> D) const {
+    ThrowIfNotImplemented(__func__);
+  }
+
+  /** `DerivedElement` must provide an implementation for `DoCalcMassMatrix()`
+   to provide the mass matrix that is up-to-date given the `state` or to throw
+   an exception indicating a mass matrix does not exist. The caller guarantees
+   that `M` is non-null (but it is uninitialized); the implementation in the
+   derived class does not have to test for this.
+   @throw std::exception if `DerivedElement` does not provide an implementation
+   for `DoCalcMassMatrix()`. */
+  void DoCalcMassMatrix(
+      const FemState<DerivedElement>& state,
+      EigenPtr<Eigen::Matrix<T, Traits::kNumDofs, Traits::kNumDofs>> M) const {
+    ThrowIfNotImplemented(__func__);
+  }
+
+ private:
+  /* Helper to throw a descriptive exception when a given function is not
+   implemented. */
+  void ThrowIfNotImplemented(const char* source_method) const {
+    throw std::runtime_error("The DerivedElement from " +
+                             NiceTypeName::Get(*this) +
+                             " must provide an implementation for " +
+                             std::string(source_method) + "().");
+  }
+
+  /* The index of this element within the model. */
+  ElementIndex element_index_;
+  /* The node indices of this element within the model. */
+  std::array<NodeIndex, Traits::kNumNodes> node_indices_;
+};
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/fem_state.h
+++ b/multibody/fixed_fem/dev/fem_state.h
@@ -1,0 +1,195 @@
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fixed_fem/dev/element_cache_entry.h"
+#include "drake/multibody/fixed_fem/dev/fem_indexes.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+/** Stores the fem model state and per-element state-dependent quantities.The
+ states include the generalized positions associated with each node, `q`, and
+ optionally, their first and second time derivatives, `qdot` and `qddot`.
+ %FemState also stores the per-element state-dependent quantities for its
+ corresponding elements (see ElementCacheEntry).
+ @tparam Element The type of FemElement that consumes this %FemState. This
+ template parameter provides the scalar type, the type of per-element data
+ this %FemState stores and the order of the ODE after FEM spatial
+ discretization. */
+template <typename Element>
+class FemState {
+ public:
+  using T = typename Element::T;
+
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(FemState);
+
+  /** The order of the ODE problem after FEM spatial discretization. */
+  static constexpr int ode_order() {
+    constexpr int order = Element::Traits::kOdeOrder;
+    static_assert(order == 0 || order == 1 || order == 2);
+    return order;
+  }
+
+  /** Constructs an %FemState of a zero-th order equation with prescribed
+   generalized positions.
+   @param[in] q    The prescribed generalized positions.
+   @pre ode_order() == 0. */
+  explicit FemState(const Eigen::Ref<const VectorX<T>>& q) : q_(q) {
+    DRAKE_THROW_UNLESS(ode_order() == 0);
+    DRAKE_ASSERT(qdot_.size() == 0);
+    DRAKE_ASSERT(qddot_.size() == 0);
+  }
+
+  /** Constructs an %FemState of a first order equation with prescribed
+   generalized positions and their time derivatives.
+   @param[in] q    The prescribed generalized positions.
+   @param[in] qdot    The prescribed time derivatives of generalized positions.
+   @pre ode_order() == 1.
+   @pre q.size() == qdot.size(). */
+  FemState(const Eigen::Ref<const VectorX<T>>& q,
+           const Eigen::Ref<const VectorX<T>>& qdot)
+      : q_(q), qdot_(qdot) {
+    DRAKE_THROW_UNLESS(ode_order() == 1);
+    DRAKE_THROW_UNLESS(q_.size() == qdot_.size());
+    DRAKE_ASSERT(qddot_.size() == 0);
+  }
+
+  /** Constructs an %FemState of a second order equation with prescribed
+   generalized positions and their first and second order time derivatives.
+   @param[in] q    The prescribed generalized positions.
+   @param[in] qdot    The prescribed time derivatives of generalized positions.
+   @param[in] qddot    The prescribed time second derivatives of generalized
+   positions.
+   @pre ode_order() == 2.
+   @pre q.size() == qdot.size().
+   @pre q.size() == qddot.size(). */
+  FemState(const Eigen::Ref<const VectorX<T>>& q,
+           const Eigen::Ref<const VectorX<T>>& qdot,
+           const Eigen::Ref<const VectorX<T>>& qddot)
+      : q_(q), qdot_(qdot), qddot_(qddot) {
+    DRAKE_THROW_UNLESS(ode_order() == 2);
+    DRAKE_THROW_UNLESS(q_.size() == qdot_.size());
+    DRAKE_THROW_UNLESS(q_.size() == qddot_.size());
+  }
+
+  /** Creates the per-element state-dependent data for the given `elements`. The
+  following invariant must be satisfied: `elements[i].element_index() == i` --
+  the i-th element reports an element index of `i`, as %FemState assumes this
+  invariant when the Element::Traits::Data are accessed via element_data().
+  @throw std::exception if elements[i].element_index() != i for some `i` = 0,
+  ..., `element.size()-1`. */
+  void MakeElementData(const std::vector<Element>& elements) {
+    element_cache_.clear();
+    for (int i = 0; i < static_cast<int>(elements.size()); ++i) {
+      if (elements[i].element_index() != ElementIndex(i)) {
+        throw std::runtime_error(
+            "Input element entry at " + std::to_string(i) + " has index " +
+            std::to_string(elements[i].element_index()) + " instead of " +
+            std::to_string(i) +
+            ". The entry with index i must be stored at position i.");
+      }
+    }
+    element_cache_.resize(elements.size());
+  }
+
+  int num_generalized_positions() const { return q_.size(); }
+
+  int element_cache_size() const { return element_cache_.size(); }
+  /** `q`, `qdot`, and `qddot` are resized (if they exist) with the semantics
+  outlined in <a
+  href="https://eigen.tuxfamily.org/dox/classEigen_1_1PlainObjectBase.html#a78a42a7c0be768374781f67f40c9ab0d">
+  Eigen::conservativeResize</a>. */
+  void Resize(int num_generalized_positions) {
+    DRAKE_ASSERT(num_generalized_positions >= 0);
+    q_.conservativeResize(num_generalized_positions);
+    if constexpr (ode_order() >= 1)
+      qdot_.conservativeResize(num_generalized_positions);
+    if constexpr (ode_order() == 2)
+      qddot_.conservativeResize(num_generalized_positions);
+  }
+
+  /** @name State getters.
+   @{ */
+  const VectorX<T>& q() const { return q_; }
+
+  const VectorX<T>& qdot() const {
+    DRAKE_THROW_UNLESS(ode_order() >= 1);
+    return qdot_;
+  }
+
+  const VectorX<T>& qddot() const {
+    DRAKE_THROW_UNLESS(ode_order() == 2);
+    return qddot_;
+  }
+  /** @} */
+
+  /** @name State setters.
+   The size of the values provided must match the current size of the states.
+   @{ */
+  void set_q(const Eigen::Ref<const VectorX<T>>& value) {
+    DRAKE_THROW_UNLESS(value.size() == q_.size());
+    mutable_q() = value;
+  }
+
+  void set_qdot(const Eigen::Ref<const VectorX<T>>& value) {
+    DRAKE_THROW_UNLESS(ode_order() >= 1);
+    DRAKE_THROW_UNLESS(value.size() == qdot_.size());
+    mutable_qdot() = value;
+  }
+
+  void set_qddot(const Eigen::Ref<const VectorX<T>>& value) {
+    DRAKE_THROW_UNLESS(ode_order() == 2);
+    DRAKE_THROW_UNLESS(value.size() == qddot_.size());
+    mutable_qddot() = value;
+  }
+  /** @} */
+
+  /** @name Mutable state getters.
+   The values of the states are mutable but the sizes of the states are not
+   allowed to change.
+   @{ */
+  Eigen::VectorBlock<VectorX<T>> mutable_q() { return q_.head(q_.size()); }
+
+  Eigen::VectorBlock<VectorX<T>> mutable_qdot() {
+    DRAKE_THROW_UNLESS(ode_order() >= 1);
+    return qdot_.head(qdot_.size());
+  }
+
+  Eigen::VectorBlock<VectorX<T>> mutable_qddot() {
+    DRAKE_THROW_UNLESS(ode_order() == 2);
+    return qddot_.head(qddot_.size());
+  }
+  /** @} */
+
+  /** Getter for element state-dependpent quantities. */
+  const typename Element::Traits::Data& element_data(
+      const Element& element) const {
+    ElementIndex id = element.element_index();
+    DRAKE_ASSERT(id.is_valid() && id < element_cache_size());
+    // TODO(xuchenhan-tri): Currently the data is always recomputed when this
+    //  method is invoked. Cache these data in the future.
+    typename Element::Traits::Data& data =
+        element_cache_[id].mutable_element_data();
+    data = element.ComputeData(*this);
+    return data;
+  }
+
+ private:
+  /* Generalized node positions. */
+  VectorX<T> q_{};
+  /* Time derivatives of generalized node positions. */
+  VectorX<T> qdot_{};
+  /* Time second derivatives of generalized node positions. */
+  VectorX<T> qddot_{};
+  /* Owned element cache entries. */
+  mutable std::vector<ElementCacheEntry<typename Element::Traits::Data>>
+      element_cache_{};
+};
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/test/dummy_element.h
+++ b/multibody/fixed_fem/dev/test/dummy_element.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include <array>
+
+#include "drake/multibody/fixed_fem/dev/element_cache_entry.h"
+#include "drake/multibody/fixed_fem/dev/fem_element.h"
+#include "drake/multibody/fixed_fem/dev/fem_state.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+namespace test {
+/* The traits for the DummyElement. In this case, all of the traits are unique
+ values so we can detect that each value is used in the expected context. */
+struct DummyElementTraits {
+  using T = double;
+  struct Data {
+    double value{0};
+  };
+  static constexpr int kNumNodes = 2;
+  static constexpr int kNumQuadraturePoints = 3;
+  static constexpr int kNaturalDimension = 4;
+  static constexpr int kSpatialDimension = 5;
+  static constexpr int kSolutionDimension = 6;
+  static constexpr int kNumDofs = 7;
+  static constexpr int kOdeOrder = 1;
+};
+/* A simple FemElement implementation. The calculation methods are implemented
+ as returning a fixed value (which can independently be accessed by calling
+ the corresponding dummy_* method -- e.g., CalcResidual() should return the
+ value in dummy_residual(). */
+class DummyElement final : public FemElement<DummyElement, DummyElementTraits> {
+ public:
+  using Base = FemElement<DummyElement, DummyElementTraits>;
+  using T = typename Base::T;
+
+  DummyElement(ElementIndex element_index,
+               const std::array<NodeIndex, Traits::kNumNodes>& node_indices)
+      : Base(element_index, node_indices) {}
+
+  /* Provides a fixed return value for CalcResidual(). */
+  static Vector<T, Traits::kNumDofs> dummy_residual() {
+    return Vector<T, Traits::kNumDofs>::Constant(1.23456);
+  }
+
+  /* Provides a fixed return value for CalcStiffnessMatrix(). */
+  static Eigen::Matrix<T, Traits::kNumDofs, Traits::kNumDofs>
+  dummy_stiffness_matrix() {
+    return Eigen::Matrix<T, Traits::kNumDofs, Traits::kNumDofs>::Constant(1.23);
+  }
+
+  /* Provides a fixed return value for CalcDampingMatrix(). */
+  static Eigen::Matrix<T, Traits::kNumDofs, Traits::kNumDofs>
+  dummy_damping_matrix() {
+    return Eigen::Matrix<T, Traits::kNumDofs, Traits::kNumDofs>::Constant(4.56);
+  }
+
+  /* Provides a fixed return value for CalcMassMatrix(). */
+  static Eigen::Matrix<T, Traits::kNumDofs, Traits::kNumDofs>
+  dummy_mass_matrix() {
+    return Eigen::Matrix<T, Traits::kNumDofs, Traits::kNumDofs>::Constant(7.89);
+  }
+
+  /* Provides a fixed value for the `Data` for `ComputeData()`. */
+  static Traits::Data dummy_data() { return {1.732}; }
+
+ private:
+  /* Friend the base class so that the interface in the CRTP base class can
+   access the private implementations of this class. */
+  friend Base;
+
+  /* Implements FemElement::ComputeData(). */
+  Traits::Data DoComputeData(const FemState<DummyElement>& state) const {
+    return dummy_data();
+  }
+
+  /* Implements FemElement::CalcResidual(). */
+  void DoCalcResidual(const FemState<DummyElement>& state,
+                      EigenPtr<Vector<T, Traits::kNumDofs>> residual) const {
+    *residual = dummy_residual();
+  }
+
+  /* Implements FemElement::CalcStiffnessMatrix(). */
+  void DoCalcStiffnessMatrix(
+      const FemState<DummyElement>& state,
+      EigenPtr<Eigen::Matrix<T, Traits::kNumDofs, Traits::kNumDofs>> K) const {
+    *K = dummy_stiffness_matrix();
+  }
+
+  /* Implements FemElement::CalcDampingMatrix(). */
+  void DoCalcDampingMatrix(
+      const FemState<DummyElement>& state,
+      EigenPtr<Eigen::Matrix<T, Traits::kNumDofs, Traits::kNumDofs>> D) const {
+    *D = dummy_damping_matrix();
+  }
+
+  /* Implements FemElement::CalcMassMatrix(). */
+  void DoCalcMassMatrix(
+      const FemState<DummyElement>& state,
+      EigenPtr<Eigen::Matrix<T, Traits::kNumDofs, Traits::kNumDofs>> M) const {
+    *M = dummy_mass_matrix();
+  }
+};
+}  // namespace test
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/test/fem_element_test.cc
+++ b/multibody/fixed_fem/dev/test/fem_element_test.cc
@@ -1,0 +1,137 @@
+#include "drake/multibody/fixed_fem/dev/fem_element.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/multibody/fixed_fem/dev/test/dummy_element.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+namespace test {
+namespace {
+const ElementIndex kZeroIndex = ElementIndex(0);
+const std::array<NodeIndex, DummyElementTraits::kNumNodes> kNodeIndices = {
+    {NodeIndex(0), NodeIndex(1)}};
+constexpr double dummy_value = 3.14;
+
+/* An minimal FemElement to test FemElement::CalcFoo() methods. */
+class CalcFooElement final
+    : public FemElement<CalcFooElement, DummyElementTraits> {
+ public:
+  using Base = FemElement<CalcFooElement, DummyElementTraits>;
+  CalcFooElement(ElementIndex element_index,
+                 const std::array<NodeIndex, Traits::kNumNodes>& node_indices,
+                 double value)
+      : Base(element_index, node_indices), value_(value) {}
+
+  Vector<T, Traits::kNumDofs> expected_residual() const {
+    return Vector<T, Traits::kNumDofs>::Constant(value_);
+  }
+
+  Eigen::Matrix<T, Traits::kNumDofs, Traits::kNumDofs> expected_matrix() const {
+    return Eigen::Matrix<T, Traits::kNumDofs, Traits::kNumDofs>::Constant(
+        value_);
+  }
+
+ private:
+  friend Base;
+
+  void DoCalcResidual(const FemState<CalcFooElement>& state,
+                      EigenPtr<Vector<T, Traits::kNumDofs>> residual) const {
+    for (int i = 0; i < Traits::kNumDofs; ++i) {
+      if ((*residual)(i) != 0) {
+        throw std::runtime_error("Input vector non-zero!");
+      }
+      (*residual)(i) = value_;
+    }
+  }
+
+  void DoCalcStiffnessMatrix(
+      const FemState<CalcFooElement>& state,
+      EigenPtr<Eigen::Matrix<T, Traits::kNumDofs, Traits::kNumDofs>> K) const {
+    VerifyInputIsZeroAndOverwriteWithConstant(K);
+  }
+
+  void DoCalcDampingMatrix(
+      const FemState<CalcFooElement>& state,
+      EigenPtr<Eigen::Matrix<T, Traits::kNumDofs, Traits::kNumDofs>> D) const {
+    VerifyInputIsZeroAndOverwriteWithConstant(D);
+  }
+
+  void DoCalcMassMatrix(
+      const FemState<CalcFooElement>& state,
+      EigenPtr<Eigen::Matrix<T, Traits::kNumDofs, Traits::kNumDofs>> M) const {
+    *M = expected_matrix();
+  }
+
+  void VerifyInputIsZeroAndOverwriteWithConstant(
+      EigenPtr<Eigen::Matrix<T, Traits::kNumDofs, Traits::kNumDofs>> matrix)
+      const {
+    for (int i = 0; i < Traits::kNumDofs; ++i) {
+      for (int j = 0; j < Traits::kNumDofs; ++j) {
+        if ((*matrix)(i, j) != 0) {
+          throw std::runtime_error("Input vector non-zero!");
+        }
+        (*matrix)(i, j) = value_;
+      }
+    }
+  }
+
+  double value_;
+};
+
+class FemElementTest : public ::testing::Test {
+ protected:
+  using T = DummyElementTraits::T;
+
+  /* Default values for the state. */
+  static VectorX<double> q() { return Vector3<double>(0.1, 0.2, 0.3); }
+  static VectorX<double> qdot() { return Vector3<double>(0.3, 0.4, 0.5); }
+
+  /* FemElement under test. */
+  CalcFooElement element_{kZeroIndex, kNodeIndices, dummy_value};
+  FemState<CalcFooElement> state_{q(), qdot()};
+};
+
+TEST_F(FemElementTest, Constructor) {
+  EXPECT_EQ(element_.node_indices(), kNodeIndices);
+  EXPECT_EQ(element_.element_index(), kZeroIndex);
+}
+
+/* The following tests confirm that CalcResidual(), CalcStiffnessMatrix,
+ CalcDampingMatrix(), correctly invoke their DoCalc counterparts with a
+ zeroed-out vector/matrix. We confirm this with a custom subclass of
+ FemElement that tests the input vector in DoCalc methods and returns a
+ specific value. */
+TEST_F(FemElementTest, Residual) {
+  Vector<T, DummyElementTraits::kNumDofs> residual;
+  element_.CalcResidual(state_, &residual);
+  EXPECT_EQ(residual, element_.expected_residual());
+}
+
+TEST_F(FemElementTest, StiffnessMatrix) {
+  Eigen::Matrix<T, DummyElementTraits::kNumDofs, DummyElementTraits::kNumDofs>
+      K;
+  element_.CalcStiffnessMatrix(state_, &K);
+  EXPECT_EQ(K, element_.expected_matrix());
+}
+
+TEST_F(FemElementTest, DampingMatrix) {
+  Eigen::Matrix<T, DummyElementTraits::kNumDofs, DummyElementTraits::kNumDofs>
+      D;
+  element_.CalcDampingMatrix(state_, &D);
+  EXPECT_EQ(D, element_.expected_matrix());
+}
+
+/* Test that CalcMassMatrix() is calling the expected DoCalcMassMatrix(). */
+TEST_F(FemElementTest, MassMatrix) {
+  Eigen::Matrix<T, DummyElementTraits::kNumDofs, DummyElementTraits::kNumDofs>
+      M;
+  element_.CalcMassMatrix(state_, &M);
+  EXPECT_EQ(M, element_.expected_matrix());
+}
+}  // namespace
+}  // namespace test
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/test/fem_state_test.cc
+++ b/multibody/fixed_fem/dev/test/fem_state_test.cc
@@ -1,0 +1,104 @@
+#include "drake/multibody/fixed_fem/dev/fem_state.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/multibody/fixed_fem/dev/element_cache_entry.h"
+#include "drake/multibody/fixed_fem/dev/test/dummy_element.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+namespace test {
+namespace {
+static constexpr int kNumDofs = 3;
+static constexpr int kNumElements = 2;
+const std::vector<ElementIndex> kElementIndices{ElementIndex(0),
+                                                ElementIndex(1)};
+const std::array<NodeIndex, DummyElementTraits::kNumNodes> kNodeIndices = {
+    {NodeIndex(0), NodeIndex(1)}};
+
+using Eigen::VectorXd;
+
+class FemStateTest : public ::testing::Test {
+ protected:
+  void SetUp() {
+    for (ElementIndex element_id : kElementIndices) {
+      elements_.emplace_back(element_id, kNodeIndices);
+    }
+    state_.MakeElementData(elements_);
+  }
+
+  /* Default values for the state. */
+  static VectorX<double> q() { return Vector3<double>(0.1, 0.2, 0.3); }
+  static VectorX<double> qdot() { return Vector3<double>(0.3, 0.4, 0.5); }
+
+  // TODO(xuchenhan-tri): Test the other constructors of FemState.
+  /* FemState under test. */
+  FemState<DummyElement> state_{q(), qdot()};
+  std::vector<DummyElement> elements_;
+};
+
+/* Verify setters and getters are working properly. */
+TEST_F(FemStateTest, GetStates) {
+  EXPECT_EQ(state_.num_generalized_positions(), kNumDofs);
+  EXPECT_EQ(state_.qdot(), qdot());
+  EXPECT_EQ(state_.q(), q());
+  /* The dummy element has order 1 and does not have second derivatives of the
+   generalized positions. */
+  // TODO(xuchenhan-tri): Add a test for successful invocation of the getter and
+  //  setter for `qddot()`.
+  EXPECT_THROW(state_.qddot(), std::exception);
+}
+
+TEST_F(FemStateTest, SetStates) {
+  state_.set_qdot(3.14 * qdot());
+  state_.set_q(-1.23 * q());
+  EXPECT_EQ(state_.qdot(), 3.14 * qdot());
+  EXPECT_EQ(state_.q(), -1.23 * q());
+  /* Setting values with incompatible sizes should throw. */
+  EXPECT_THROW(state_.set_qdot(VectorXd::Constant(1, 1.0)), std::exception);
+  EXPECT_THROW(state_.set_q(VectorXd::Constant(1, 1.0)), std::exception);
+  /* The dummy element has order 1 and does not have second derivatives of the
+   generalized positions. */
+  EXPECT_THROW(state_.set_qddot(VectorXd::Constant(3, 1.0)), std::exception);
+}
+
+/* Verify resizing does not thrash existing values. */
+TEST_F(FemStateTest, ConservativeResize) {
+  state_.Resize(2 * kNumDofs);
+  EXPECT_EQ(state_.num_generalized_positions(), 2 * kNumDofs);
+  /* The first kDof entries should remain unchanged. */
+  EXPECT_EQ(state_.qdot().head(kNumDofs), qdot());
+  EXPECT_EQ(state_.q().head(kNumDofs), q());
+  /* After downsizing, the first `smaller_size` entries should remain unchanged.
+   */
+  int smaller_size = kNumDofs / 2;
+  state_.Resize(smaller_size);
+  EXPECT_EQ(state_.num_generalized_positions(), smaller_size);
+  EXPECT_EQ(state_.qdot().head(smaller_size), qdot().head(smaller_size));
+  EXPECT_EQ(state_.q().head(smaller_size), q().head(smaller_size));
+}
+
+/* Test that element_data() retrieves the updated data. */
+TEST_F(FemStateTest, ElementData) {
+  EXPECT_EQ(state_.element_cache_size(), kNumElements);
+  for (int i = 0; i < kNumElements; ++i) {
+    EXPECT_EQ(DummyElement::dummy_data().value,
+              state_.element_data(elements_[i]).value);
+  }
+}
+
+TEST_F(FemStateTest, MakeElementData) {
+  std::vector<DummyElement> invalid_ordered_elements;
+  invalid_ordered_elements.emplace_back(ElementIndex(1), kNodeIndices);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      state_.MakeElementData(invalid_ordered_elements), std::exception,
+      "Input element entry at 0 has index 1 instead of 0. The entry with index "
+      "i must be stored at position i.");
+}
+}  // namespace
+}  // namespace test
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Refactor FemState and FemElement to eliminate heap allocation and
virtual methods. Change to a CRTP implemention for compile-time
polymorphism.

Change ElementCacheEntry class to fit it into the new design.

Add an additional attribute, ODE order, to FemElement so that PDEs that
are spatially discretized into ODEs of different orders get a unified
treatment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14491)
<!-- Reviewable:end -->
