### PR TITLE
Add retry to brew and apt-get update calls and add flag to skip update altogether

### DIFF
--- a/setup/mac/binary_distribution/install_prereqs.sh
+++ b/setup/mac/binary_distribution/install_prereqs.sh
@@ -5,6 +5,21 @@
 
 set -euxo pipefail
 
+with_update=1
+
+while [ "${1:-}" != "" ]; do
+  case "$1" in
+    # Do NOT call brew update during execution of this script.
+    --without-update)
+      with_update=0
+      ;;
+    *)
+      echo 'Invalid command line argument' >&2
+      exit 5
+  esac
+  shift
+done
+
 if [[ "${EUID}" -eq 0 ]]; then
   echo 'ERROR: This script must NOT be run as root' >&2
   exit 1
@@ -19,6 +34,10 @@ if ! command -v brew &>/dev/null; then
     "$(/usr/bin/curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 fi
 
+# Pass --retry 2 when invoking the curl command line tool during execution of
+# this script to retry twice the download of a bottle.
+[[ -z "${HOMEBREW_CURL_RETRIES:-}" ]] || export HOMEBREW_CURL_RETRIES=2
+
 # Do not automatically update before running brew install, brew upgrade, or brew
 # tap during execution of this script. We manually update where necessary and
 # retry if the update fails.
@@ -26,10 +45,20 @@ export HOMEBREW_NO_AUTO_UPDATE=1
 
 # Do not automatically cleanup installed, upgraded, and/or reinstalled formulae
 # during execution of this script. Manually run brew cleanup after the script
-# completes or wait for the next automatic cleanup if necessary
+# completes or wait for the next automatic cleanup if necessary.
 export HOMEBREW_NO_INSTALL_CLEANUP=1
 
-brew update
+binary_distribution_called_update=0
+
+if [[ "${with_update}" -eq 1 ]]; then
+  # Note that brew update uses git, so HOMEBREW_CURL_RETRIES does not take
+  # effect.
+  brew update || (sleep 30; brew update)
+
+  # Do NOT call brew update again when installing prerequisites for source
+  # distributions.
+  binary_distribution_called_update=1
+fi
 
 # TODO(jamiesnape): Remove lines tapping robotlocomotion/director and
 # uninstalling ipopt@3.11, vtk@8.2, ospray@1.8, and embree@3.5 on or after

--- a/setup/mac/install_prereqs.sh
+++ b/setup/mac/install_prereqs.sh
@@ -5,6 +5,7 @@
 
 set -euxo pipefail
 
+binary_distribution_args=()
 source_distribution_args=()
 
 while [ "${1:-}" != "" ]; do
@@ -26,6 +27,11 @@ while [ "${1:-}" != "" ]; do
     --without-test-only)
       source_distribution_args+=(--without-test-only)
       ;;
+    # Do NOT call brew update during execution of this script.
+    --without-update)
+      binary_distribution_args+=(--without-update)
+      source_distribution_args+=(--without-update)
+      ;;
     *)
       echo 'Invalid command line argument' >&2
       exit 1
@@ -37,7 +43,8 @@ done
 # needed when developing with binary distributions are also needed when
 # developing with source distributions.
 
-source "${BASH_SOURCE%/*}/binary_distribution/install_prereqs.sh"
+source "${BASH_SOURCE%/*}/binary_distribution/install_prereqs.sh" \
+  "${binary_distribution_args[@]:-}"
 
 # The following additional dependencies are only needed when developing with
 # source distributions.

--- a/setup/mac/source_distribution/install_prereqs.sh
+++ b/setup/mac/source_distribution/install_prereqs.sh
@@ -9,6 +9,7 @@ set -euxo pipefail
 
 with_maintainer_only=0
 with_test_only=1
+with_update=1
 
 while [ "${1:-}" != "" ]; do
   case "$1" in
@@ -22,6 +23,10 @@ while [ "${1:-}" != "" ]; do
     # bazel { build, run } //:install.
     --without-test-only)
       with_test_only=0
+      ;;
+    # Do NOT call brew update during execution of this script.
+    --without-update)
+      with_update=0
       ;;
     *)
       echo 'Invalid command line argument' >&2
@@ -40,7 +45,10 @@ if ! command -v brew &>/dev/null; then
   exit 4
 fi
 
-brew update
+if [[ "${with_update}" -eq 1 && "${binary_distribution_called_update:-0}" -ne 1 ]]; then
+  brew update || (sleep 30; brew update)
+fi
+
 brew bundle --file="${BASH_SOURCE%/*}/Brewfile" --no-lock
 
 if [[ "${with_maintainer_only}" -eq 1 ]]; then

--- a/setup/ubuntu/binary_distribution/install_prereqs.sh
+++ b/setup/ubuntu/binary_distribution/install_prereqs.sh
@@ -5,6 +5,21 @@
 
 set -euo pipefail
 
+with_update=1
+
+while [ "${1:-}" != "" ]; do
+  case "$1" in
+    # Do NOT call apt-get update during execution of this script.
+    --without-update)
+      with_update=0
+      ;;
+    *)
+      echo 'Invalid command line argument' >&2
+      exit 3
+  esac
+  shift
+done
+
 if [[ "${EUID}" -ne 0 ]]; then
   echo 'ERROR: This script must be run as root' >&2
   exit 1
@@ -14,7 +29,16 @@ if command -v conda &>/dev/null; then
   echo 'WARNING: Anaconda is NOT supported for building and using the Drake Python bindings' >&2
 fi
 
-apt-get update
+binary_distribution_called_update=0
+
+if [[ "${with_update}" -eq 1 ]]; then
+  apt-get update || (sleep 30; apt-get update)
+
+  # Do NOT call apt-get update again when installing prerequisites for source
+  # distributions.
+  binary_distribution_called_update=1
+fi
+
 apt-get install --no-install-recommends lsb-release
 
 codename=$(lsb_release -sc)

--- a/setup/ubuntu/install_prereqs.sh
+++ b/setup/ubuntu/install_prereqs.sh
@@ -14,6 +14,7 @@ me='The Drake source distribution prerequisite setup script'
 
 trap at_exit EXIT
 
+binary_distribution_args=()
 source_distribution_args=()
 
 while [ "${1:-}" != "" ]; do
@@ -48,6 +49,11 @@ while [ "${1:-}" != "" ]; do
     --without-test-only)
       source_distribution_args+=(--without-test-only)
       ;;
+    # Do NOT call apt-get update during execution of this script.
+    --without-update)
+      binary_distribution_args+=(--without-update)
+      source_distribution_args+=(--without-update)
+      ;;
     *)
       echo 'Invalid command line argument' >&2
       exit 1
@@ -63,7 +69,8 @@ done
 # generate the dependencies of the drake .deb package, so does not include
 # development dependencies such as build-essential and cmake.
 
-source "${BASH_SOURCE%/*}/binary_distribution/install_prereqs.sh"
+source "${BASH_SOURCE%/*}/binary_distribution/install_prereqs.sh" \
+  "${binary_distribution_args[@]:-}"
 
 # The following additional dependencies are only needed when developing with
 # source distributions.


### PR DESCRIPTION
Things I could do:

1. Remove the retries and assume that If you are bothered that you do your one and only update beforehand (modulo `kcov`) you will pass `--without-update`.
2. Add some logic (not difficult, but verbose) to check that the `kcov`-related update really is needed.

I don't mind doing (1.) , just a couple of `sed` calls to fixup. Probably not worth doing (2.).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14492)
<!-- Reviewable:end -->
