### PR TITLE
doc/developers: Mention leaving review unassigned for feature review

### DIFF
--- a/doc/developers.rst
+++ b/doc/developers.rst
@@ -204,6 +204,12 @@ alignment with the team's goals. During this review, you and your reviewer
 should also strive to minimize the number of changes that will be necessary
 in platform review.
 
+If you are still not sure whom to assign for code review, simply do not assign
+a reviewer. As part of a
+:ref:`platform reviewer's responsibilities <platform_reviewer_checklists>`,
+they will come across the unassigned PR and find an appropriate feature
+reviewer.
+
 **Platform Review.** After your feature reviewer has signed off on your change,
 reassign it to a Drake owner for platform review. The owner will inspect for
 architectural compatibility, stability, performance, test coverage, and style.


### PR DESCRIPTION
Per @zachfang's DM question regarding review for #14494

In the case that the author does not know who the most appropriate
feature reviewer may be.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14495)
<!-- Reviewable:end -->
