### PR TITLE
tools/performance: Start gathering sharable infrastructure

### DIFF
--- a/examples/multibody/cassie_benchmark/BUILD.bazel
+++ b/examples/multibody/cassie_benchmark/BUILD.bazel
@@ -29,15 +29,9 @@ sh_test(
     name = "record_results",
     size = "small",
     srcs = ["record_results.sh"],
-    # Debug-configured test runs are nice for coverage, but not very useful
-    # otherwise. Don't waste too much time on them.
-    args = select({
-        "//tools/cc_toolchain:debug": ["--benchmark_repetitions=1"],
-        "//conditions:default": [],
-    }),
     data = [
         ":cassie_bench",
-        "//tools/workspace/cc:identify_compiler",
+        "//tools/performance:record_results",
     ],
     tags = ["no_valgrind_tools"],
 )

--- a/examples/multibody/cassie_benchmark/conduct_experiment
+++ b/examples/multibody/cassie_benchmark/conduct_experiment
@@ -3,93 +3,14 @@
 
 set -e -u -o pipefail
 
-ME=$(readlink -f $0)
-HERE=$(dirname $ME)
 TARGET=//examples/multibody/cassie_benchmark:record_results
+ME=$(python3 -c 'import os; print(os.path.realpath("'"$0"'"))')
+HERE=$(dirname $ME)
 
-NO_TURBO_CONTROL_FILE=/sys/devices/system/cpu/intel_pstate/no_turbo
-
-CPU_GOVERNOR=
-NO_TURBO=
-
-die () {
-    echo $"$@"
-    exit 1
-}
-
-is_default_ubuntu () {
-    [[ $(uname) = "Linux" && $(echo $(lsb_release -irs)) = "Ubuntu 18.04" ]]
-}
-
-is_default_compiler () {
-    # Use deep bash magic to assert variables are unset.
-    [[ -z ${CC+x} && -z ${CXX+x} ]]
-}
-
-is_supported_cpu () {
-    [[ -e "$NO_TURBO_CONTROL_FILE" ]]
-}
-
-say () {
-    echo
-    echo === "$@" ===
-    echo
-}
-
-get_cpu_governor () {
-    cpupower frequency-info -p |sed -n 's%.*governor "\([^"]*\)".*%\1%pg'
-}
-
-set_cpu_governor () {
-    sudo cpupower frequency-set --governor "$1"
-}
-
-get_no_turbo () {
-    cat "$NO_TURBO_CONTROL_FILE"
-}
-
-set_no_turbo () {
-    sudo sh -c "echo $1 > $NO_TURBO_CONTROL_FILE"
-}
-
-clean () {
-    say Restore CPU speed settings.
-    [[ -n "$CPU_GOVERNOR" ]] && set_cpu_governor "$CPU_GOVERNOR"
-    [[ -n "$NO_TURBO" ]] && set_no_turbo "$NO_TURBO"
-}
-
-say Validate input.
-[[ "$#" -ge 1 ]] || die "missing argument: destination directory"
-DESTINATION="$1"
+OUTPUT_DIR="$1"
 shift
 
-say Validate environment.
-is_default_ubuntu || die "experiments only supported on default platform"
-is_default_compiler || die "experiments only supported with default compiler"
-is_supported_cpu || die "experiments only supported with Intel CPUs"
+cd "$HERE"/../../..
 
-say Validate sudo access, to avoid later interruptions.
-sudo -v
-
-say Install tools for CPU speed control.
-sudo apt install linux-tools-$(uname -r)
-
-say Build code.
-bazel build "$TARGET"
-
-say Wait for lingering activity to subside.
-sync
-sleep 10
-
-say Control CPU speed variation.
-trap clean EXIT
-CPU_GOVERNOR=$(get_cpu_governor)
-NO_TURBO=$(get_no_turbo)
-set_cpu_governor performance
-set_no_turbo 1
-
-say Run the experiment.
-bazel run "$TARGET" -- "$@"
-
-say Save data.
-"$HERE"/copy_results_to "$DESTINATION"
+./tools/performance/benchmark_tool conduct_experiment \
+    $TARGET "$OUTPUT_DIR" -- "$@"

--- a/examples/multibody/cassie_benchmark/copy_results_to
+++ b/examples/multibody/cassie_benchmark/copy_results_to
@@ -3,19 +3,10 @@
 
 set -e -u -o pipefail
 
-die () {
-    echo $"$@"
-    exit 1
-}
+TARGET=//examples/multibody/cassie_benchmark:record_results
+ME=$(python3 -c 'import os; print(os.path.realpath("'"$0"'"))')
+HERE=$(dirname $ME)
 
+cd "$HERE"/../../..
 
-[[ "$#" -ge 1 ]] || die "missing argument: destination directory"
-
-DST="$1"
-
-TESTLOGS=$(bazel info bazel-testlogs)
-TARGET="examples/multibody/cassie_benchmark/record_results"
-SRC="${TESTLOGS}/${TARGET}/test.outputs"
-
-mkdir -p "$DST"
-cp -av "$SRC"/* "$DST"
+./tools/performance/benchmark_tool copy_results $TARGET "$1"

--- a/examples/multibody/cassie_benchmark/record_results.sh
+++ b/examples/multibody/cassie_benchmark/record_results.sh
@@ -1,42 +1,6 @@
 #!/bin/bash
 # Collect context information for a benchmark experiment.
-# TODO(rpoyner-tri) find a robust way of recording source code version
-# information.
 
-set -e -u -o pipefail
-
-uname -a > ${TEST_UNDECLARED_OUTPUTS_DIR}/kernel.txt || true
-
-# Fill this in with a platform-specific command to control processor affinity,
-# if any.
-AFFINITY_COMMAND=""
-
-case $(uname) in
-    Linux)
-        lsb_release -idrc
-        # Choosing processor #0 is arbitrary. It is up to experimenters
-        # to ensure it is reliably idle during experiments.
-        AFFINITY_COMMAND="taskset 0x1"
-        ;;
-    Darwin)
-        sw_vers
-        ;;
-    *)
-        echo unknown
-        ;;
-esac > ${TEST_UNDECLARED_OUTPUTS_DIR}/os.txt
-
-${TEST_SRCDIR}/drake/tools/workspace/cc/identify_compiler \
- > ${TEST_UNDECLARED_OUTPUTS_DIR}/compiler.txt
-
-${AFFINITY_COMMAND} \
-${TEST_SRCDIR}/drake/examples/multibody/cassie_benchmark/cassie_bench \
-    --benchmark_display_aggregates_only=true \
-    --benchmark_repetitions=9 \
-    --benchmark_out_format=json \
-    --benchmark_out=${TEST_UNDECLARED_OUTPUTS_DIR}/results.json \
-    "$@" \
-    >& ${TEST_UNDECLARED_OUTPUTS_DIR}/summary.txt
-
-echo Full results are in:
-echo ${TEST_UNDECLARED_OUTPUTS_DIR}/
+${TEST_SRCDIR}/drake/tools/performance/record_results \
+    ${TEST_SRCDIR}/drake/examples/multibody/cassie_benchmark/cassie_bench \
+    "$@"

--- a/tools/performance/BUILD.bazel
+++ b/tools/performance/BUILD.bazel
@@ -1,0 +1,16 @@
+# -*- python -*-
+
+load("//tools/lint:lint.bzl", "add_lint_tests")
+load("//tools/skylark:py.bzl", "py_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+py_binary(
+    name = "record_results",
+    srcs = ["record_results.py"],
+    data = [
+        "//tools/workspace/cc:identify_compiler",
+    ],
+)
+
+add_lint_tests(python_lint_extra_srcs = ["benchmark_tool"])

--- a/tools/performance/README.md
+++ b/tools/performance/README.md
@@ -1,0 +1,18 @@
+# Tools support for performance analysis
+
+This directory contains tools to help with careful performance measurement and
+analysis of Drake programs.
+
+## Benchmarking tools
+
+Included here are two tools to help with well-controlled benchmark experiments:
+
+ * `record_results.py` -- run benchmark under bazel, record context and results
+ * `benchmark_tool` -- outside-bazel tool for experiments and data handling
+
+A fully worked example that integrates these two tools is available at
+`drake/examples/multibody/cassie_benchmark`. Some of the history of attempts to
+drive variance out of benchmark results is captured in #13902.
+
+TODO(rpoyner-tri): explain how to use compare.py from the googlebenchmark
+package to compare stored results from different experiments.

--- a/tools/performance/benchmark_tool
+++ b/tools/performance/benchmark_tool
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Tool to help with controlled benchmark experiments.
+
+Subcommands:
+
+conduct_experiment:
+  If necessary, install software for CPU speed adjustment. Run a bazel target,
+  with CPU speed control disabled. Copy result data to a user selected output
+  directory. Only supported on Ubuntu 18.04.
+
+  The purpose of CPU speed control for benchmarking is to disable automatic CPU
+  speed scaling, so that results of similar experiments will be more
+  repeatable, and comparable across experiments. Performance "in the wild" with
+  scaling enabled may be faster or slower, with higher variance.
+
+  This operation uses `sudo` commands to install tools for CPU scaling control
+  and to actually change the CPU configuration.
+
+copy_results:
+  Copy results of a prior run of a designated target to a user selected output
+  directory.
+"""
+
+import argparse
+import contextlib
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import time
+
+WORKSPACE = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+
+
+def is_default_ubuntu():
+    """Return True iff platform is Ubuntu 18.04."""
+    if os.uname().sysname != "Linux":
+        return False
+    release_info = subprocess.check_output(
+                ["lsb_release", "-irs"], encoding='utf-8')
+    return ("Ubuntu\n18.04" in release_info)
+
+
+def say(*args):
+    """Print all the args, formatted for visibility."""
+    print(f"\n=== {' '.join(args)} ===\n")
+
+
+def run(*args, echo=False):
+    """Run a subprocess, checking for failure. Optionally echo the command."""
+    if echo:
+        print('Running: ', ' '.join([shlex.quote(x) for x in args]))
+    subprocess.run(list(args), check=True)
+
+
+def sudo(*args):
+    """Run sudo, passing all args to it."""
+    run('sudo', *args, echo=True)
+
+
+class CpuSpeedSettings:
+    """Routines for controlling CPU speed."""
+
+    # This is the Linux kernel configuration file for Intel's "turbo boost".
+    # https://www.kernel.org/doc/html/v4.12/admin-guide/pm/intel_pstate.html#no-turbo-attr
+    NO_TURBO_CONTROL_FILE = "/sys/devices/system/cpu/intel_pstate/no_turbo"
+
+    def is_supported_cpu(self):
+        """Returns True if the current CPU is supported for speed control."""
+        return os.path.exists(self.NO_TURBO_CONTROL_FILE)
+
+    def get_cpu_governor(self):
+        """Return the current CPU governor name string."""
+        text = subprocess.check_output(
+            ["cpupower", "frequency-info", "-p"], encoding='utf-8')
+        m = re.search(r'\bgovernor "([^"]*)" ', text)
+        return m.group(1)
+
+    def set_cpu_governor(self, governor):
+        """Set the CPU governor to the given name string."""
+        sudo('cpupower', 'frequency-set', '--governor', governor)
+
+    def get_no_turbo(self):
+        """Return the current no-turbo state as string, either '1' or '0'."""
+        with open(self.NO_TURBO_CONTROL_FILE, 'r', encoding='utf-8') as fo:
+            return fo.read().strip()
+
+    def set_no_turbo(self, no_turbo):
+        """Set the no-turbo state to the given no_turbo string."""
+        sudo('sh', '-c', f"echo {no_turbo} > {self.NO_TURBO_CONTROL_FILE}")
+
+    @contextlib.contextmanager
+    def scope(self, governor, no_turbo):
+        """Context manager that sets governor and no_turbo states and
+        restores the old state afterward.
+        """
+        say("Control CPU speed variation. [Note: sudo!]")
+        old_gov = self.get_cpu_governor()
+        old_nt = self.get_no_turbo()
+        try:
+            self.set_cpu_governor(governor)
+            self.set_no_turbo(no_turbo)
+            yield
+        finally:
+            say("Restore CPU speed settings. [Note: sudo!]")
+            self.set_no_turbo(old_nt)
+            self.set_cpu_governor(old_gov)
+
+
+def target_to_path_fragment(target):
+    """Convert a bazel target to a path fragment."""
+    target_fragment = target
+    if target_fragment.startswith('//'):
+        target_fragment = target_fragment[2:]
+    return os.path.join(*target_fragment.split(':'))
+
+
+def conduct_experiment(args):
+    """Implement the conduct_experiment sub-command."""
+    say("Validate environment.")
+    assert is_default_ubuntu(), (
+        "experiments only supported on default platform")
+    assert CpuSpeedSettings().is_supported_cpu(), (
+        "experiments only supported with Intel CPUs")
+
+    say("Install tools for CPU speed control. [Note: sudo!]")
+    kernel_name = subprocess.check_output(
+        ['uname', '-r'], encoding='utf-8').strip()
+    sudo('apt', 'install', f'linux-tools-{kernel_name}', 'linux-tools-common')
+
+    say("Build code.")
+    run('bazel', 'build', args.target)
+
+    sleep_seconds = 10
+    say(f"Wait {sleep_seconds} seconds for lingering activity to subside.")
+    time.sleep(sleep_seconds)
+
+    with CpuSpeedSettings().scope(governor="performance", no_turbo="1"):
+        say("Run the experiment.")
+        run('bazel', 'run', args.target, '--', *args.extra_args)
+
+    say(f"Save data to {args.output_dir}/.")
+    copy_results(args)
+
+
+def copy_results(args):
+    """Implement the copy_results sub-command."""
+    src = os.path.join(WORKSPACE, 'bazel-testlogs',
+                       target_to_path_fragment(args.target),
+                       'test.outputs')
+    shutil.rmtree(args.output_dir, ignore_errors=True)
+    shutil.copytree(src, args.output_dir)
+
+
+def main():
+    # Don't run under bazel; this program issues bazel commands.
+    assert "runfiles" not in ':'.join(sys.path), "Don't run under bazel!"
+
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    subparsers = parser.add_subparsers(
+        help='subcommand to run', dest='subcommand')
+    subparsers.required = True
+
+    def add_common_args(parser):
+        parser.add_argument(
+            'target', metavar='TARGET',
+            help='bazel target of benchmark program')
+        parser.add_argument(
+            'output_dir', metavar='OUTPUT-DIR',
+            help='output directory for benchmark data;'
+            ' any existing contents will be erased.')
+
+    parser_conduct_experiment = subparsers.add_parser(
+        'conduct_experiment',
+        description='run controlled experiment for TARGET,'
+        ' copying benchmark data to OUTPUT-DIR')
+    add_common_args(parser_conduct_experiment)
+    parser_conduct_experiment.add_argument(
+        'extra_args', nargs='*',
+        help='extra arguments passed to the underlying executable')
+    parser_conduct_experiment.set_defaults(func=conduct_experiment)
+
+    parser_copy_results = subparsers.add_parser(
+        'copy_results',
+        description='copy benchmark data for TARGET'
+        ' from the bazel-testlogs tree to OUTPUT-DIR')
+    add_common_args(parser_copy_results)
+    parser_copy_results.set_defaults(func=copy_results)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/performance/record_results.py
+++ b/tools/performance/record_results.py
@@ -1,0 +1,88 @@
+"""Run a google benchmark program, with restricted processor affinity to
+mitigate variance of measurements. Collect environment information and store it
+alongside the the benchmark results.
+"""
+
+# TODO(rpoyner-tri) find a robust way of recording source code version
+# information.
+
+# TODO(rpoyner-tri) make affinity configurable if some new use case needs to
+# run on multiple cores.
+
+import os
+import subprocess
+import sys
+
+
+def main():
+    benchmark = sys.argv[1]
+    command_tail = sys.argv[2:]
+
+    results_dir = os.environ['TEST_UNDECLARED_OUTPUTS_DIR']
+    src_dir = os.environ['TEST_SRCDIR']
+
+    # Debug-configured test runs are nice for coverage, but not very useful
+    # otherwise. Don't waste too much time on them.
+    if '-dbg/' in results_dir:
+        command_tail.append("--benchmark_repetitions=1")
+
+    os_data = os.uname()
+
+    # Record kernel.
+    kernel_results = os.path.join(results_dir, "kernel.txt")
+    with open(kernel_results, 'w', encoding='utf-8') as kernel_file:
+        print(' '.join(list(os_data)), file=kernel_file)
+
+    # Record OS.
+    os_results = os.path.join(results_dir, "os.txt")
+    if os_data.sysname == 'Linux':
+        os_txt = subprocess.run(
+            ["lsb_release", "-idrc"],
+            check=True, stdout=subprocess.PIPE, encoding='utf-8').stdout
+    elif os_data.sysname == 'Darwin':
+        os_txt = subprocess.run(
+            ["sw_vers"],
+            check=True, stdout=subprocess.PIPE, encoding='utf-8').stdout
+    else:
+        os_txt = "unknown"
+    with open(os_results, 'w', encoding='utf-8') as os_file:
+        print(os_txt, file=os_file)
+
+    # Record compiler.
+    id_compiler = os.path.join(
+        src_dir, 'drake/tools/workspace/cc/identify_compiler')
+    compiler_results = os.path.join(results_dir, "compiler.txt")
+    with open(compiler_results, 'w', encoding='utf-8') as compiler_file:
+        os_txt = subprocess.run(
+            [id_compiler], check=True, stdout=compiler_file)
+
+    # Set affinity command, based on platform.
+    affinity_command = []
+    if os_data.sysname == 'Linux':
+        # Choosing processor #0 is arbitrary. It is up to experimenters
+        # to ensure it is reliably idle during experiments.
+        affinity_command = ["taskset", "0x1"]
+
+    # Run benchmark.
+    benchmark_results = os.path.join(results_dir, "summary.txt")
+    benchmark_json_results = os.path.join(results_dir, "results.json")
+    benchmark_exe = os.path.join(src_dir, benchmark)
+    benchmark_command = [
+        benchmark_exe,
+        '--benchmark_display_aggregates_only=true',
+        '--benchmark_repetitions=9',
+        '--benchmark_out_format=json',
+        f'--benchmark_out={benchmark_json_results}',
+    ]
+    with open(benchmark_results, 'w', encoding='utf-8') as benchmark_file:
+        os_txt = subprocess.run(
+            affinity_command + benchmark_command + command_tail,
+            check=True, stdout=benchmark_file, stderr=subprocess.STDOUT)
+
+    # Announce.
+    print("Full results are in:")
+    print(results_dir + "/")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Relevant to: #14464

Gather the sharable bits of experiment execution scripting and port the cassie
benchmark to use it.

This is a WIP branch, exploring the idea of factoring some experiment-execution
machinery out of the cassie_benchmark example.  I'm not greatly sold on how it
looks so far, though I think it is potentially useful enough and solves enough
distracting subproblems to be worth some sort of better expression.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14505)
<!-- Reviewable:end -->
