### PR TITLE
Doc Setup: Remove js packages

### DIFF
--- a/setup/ubuntu/source_distribution/packages-bionic-doc-only.txt
+++ b/setup/ubuntu/source_distribution/packages-bionic-doc-only.txt
@@ -2,8 +2,6 @@ fonts-dejavu-core
 fonts-dejavu-extra
 graphviz
 jekyll
-libjs-imagesloaded
-libjs-jquery-throttle-debounce
 node-uglify
 python3-docutils
 python3-sphinx

--- a/setup/ubuntu/source_distribution/packages-focal-doc-only.txt
+++ b/setup/ubuntu/source_distribution/packages-focal-doc-only.txt
@@ -2,8 +2,6 @@ fonts-dejavu-core
 fonts-dejavu-extra
 graphviz
 jekyll
-libjs-imagesloaded
-libjs-jquery-throttle-debounce
 node-uglify
 python3-docutils
 python3-sphinx


### PR DESCRIPTION
'libjs-imagesloaded' is not available on Focal.

Remove both javascript packages from setup script.  The Jekyll website source is still under construction and can be modified to work around or use different packages.

Fixes  PR #14507, in place of revert PR #14510.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14512)
<!-- Reviewable:end -->
