### PR TITLE
pydrake/doc: Ensure any deps on sphinx have `tags = ["manual"]`

### DIFF
--- a/bindings/pydrake/doc/BUILD.bazel
+++ b/bindings/pydrake/doc/BUILD.bazel
@@ -13,6 +13,12 @@ load("//bindings/pydrake:pydrake.bzl", "add_lint_tests_pydrake")
 drake_py_library(
     name = "pydrake_sphinx_extension_py",
     srcs = ["pydrake_sphinx_extension.py"],
+    tags = [
+        # This target requires the appropriate prerequisites script for each
+        # platform to be run with the optional --with-doc-only command line
+        # option.
+        "manual",
+    ],
     deps = [
         "//bindings/pydrake/common:cpp_template_py",
         "//bindings/pydrake/common:deprecation_py",


### PR DESCRIPTION
Hotfix for #14500

As found by @jamiesnape  on Slack: https://drakedevelopers.slack.com/archives/C270MN28G/p1610478253294000

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14520)
<!-- Reviewable:end -->
