### PR TITLE
pydrake doc: Add missing manual tag to sphinx library

### DIFF
--- a/bindings/pydrake/doc/BUILD.bazel
+++ b/bindings/pydrake/doc/BUILD.bazel
@@ -13,6 +13,12 @@ load("//bindings/pydrake:pydrake.bzl", "add_lint_tests_pydrake")
 drake_py_library(
     name = "pydrake_sphinx_extension_py",
     srcs = ["pydrake_sphinx_extension.py"],
+    tags = [
+        # This target requires the appropriate prerequisites script for each
+        # platform to be run with the optional --with-doc-only command line
+        # option.
+        "manual",
+    ],
     deps = [
         "//bindings/pydrake/common:cpp_template_py",
         "//bindings/pydrake/common:deprecation_py",


### PR DESCRIPTION
Hotfix for 9868cf0b25c58912023d2dc941f3408faf960936.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14521)
<!-- Reviewable:end -->
