### PR TITLE
Don't run memcheck builds on optimizer_demo_smoke_test

### DIFF
--- a/examples/acrobot/dev/BUILD.bazel
+++ b/examples/acrobot/dev/BUILD.bazel
@@ -105,6 +105,7 @@ sh_test(
     name = "optimizer_demo_smoke_test",
     srcs = ["test/optimizer_demo_smoke_test.sh"],
     data = [":optimizer_demo"],
+    tags = ["no_memcheck"],  # This wraps python; python is memcheck-exempt.
 )
 
 drake_py_unittest(


### PR DESCRIPTION
 * This is an sh_test that invokes python.
 * Python is supposed to be memcheck-exempt for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14526)
<!-- Reviewable:end -->
