### PR TITLE
multibody: Remove add_package_path from model directives

### DIFF
--- a/multibody/parsing/model_directives.h
+++ b/multibody/parsing/model_directives.h
@@ -95,34 +95,6 @@ struct AddModelInstance {
   std::string name;
 };
 
-/// Directive to add a path in the filesystem to the resolution of
-/// `package://` URIs during the processing of model directives and the
-/// models they load.
-/// @warning:  This is expected to be deprecated soon.
-struct AddPackagePath {
-  bool IsValid() const {
-    if (name.empty()) {
-      drake::log()->error("add_package_path: `name` must be non-empty.");
-      return false;
-    } else if (path.empty()) {
-      drake::log()->error("add_package_path: `path` must be non-empty.");
-      return false;
-    }
-    return true;
-  }
-
-  template <typename Archive>
-  void Serialize(Archive* a) {
-    a->Visit(DRAKE_NVP(name));
-    a->Visit(DRAKE_NVP(path));
-  }
-
-  /// The model instance name.
-  std::string name;
-  /// The filesystem path to the package root.
-  std::string path;
-};
-
 /// Directive to add a Frame to the scene.  The added frame must have a name
 /// and a transform with a base frame and offset.
 struct AddFrame {
@@ -194,11 +166,11 @@ struct ModelDirective {
     const bool unique =
         (add_model.has_value() + add_model_instance.has_value() +
          add_frame.has_value() + add_weld.has_value() +
-         add_package_path.has_value() + add_directives.has_value()) == 1;
+         add_directives.has_value()) == 1;
     if (!unique) {
       drake::log()->error(
           "directive: Specify one of `add_model`, `add_model_instance`, "
-          "`add_frame`, `add_package_path`, or `add_directives`");
+          "`add_frame`, or `add_directives`");
       return false;
     } else if (add_model) {
       return add_model->IsValid();
@@ -208,8 +180,6 @@ struct ModelDirective {
       return add_frame->IsValid();
     } else if (add_weld) {
       return add_weld->IsValid();
-    } else if (add_package_path) {
-      return add_package_path->IsValid();
     } else {
       return add_directives->IsValid();
     }
@@ -221,7 +191,6 @@ struct ModelDirective {
     a->Visit(DRAKE_NVP(add_model_instance));
     a->Visit(DRAKE_NVP(add_frame));
     a->Visit(DRAKE_NVP(add_weld));
-    a->Visit(DRAKE_NVP(add_package_path));
     a->Visit(DRAKE_NVP(add_directives));
   }
 
@@ -229,7 +198,6 @@ struct ModelDirective {
   std::optional<AddModelInstance> add_model_instance;
   std::optional<AddFrame> add_frame;
   std::optional<AddWeld> add_weld;
-  std::optional<AddPackagePath> add_package_path;
   std::optional<AddDirectives> add_directives;
 };
 

--- a/multibody/parsing/process_model_directives.cc
+++ b/multibody/parsing/process_model_directives.cc
@@ -170,24 +170,6 @@ void ProcessModelDirectivesImpl(
           get_scoped_frame(directive.add_weld->child),
           error_func, plant, added_models);
 
-    } else if (directive.add_package_path) {
-      auto& package_path = *directive.add_package_path;
-      drake::log()->debug("  add_package_path: {}", package_path.name);
-      const fs::path abspath_xml =
-          drake::FindResourceOrThrow(package_path.path + "/package.xml");
-      std::string path = abspath_xml.parent_path().string();
-
-      // It is possible to get the same `add_package_path` directive twice,
-      // e.g. by including the same directives yaml twice.  That's fine so
-      // long as they agree.
-      if (parser->package_map().Contains(package_path.name)) {
-        std::string old_path = parser->package_map().GetPath(package_path.name);
-        if (old_path.back() == '/') old_path.pop_back();
-        if (path.back() == '/') path.pop_back();
-        DRAKE_DEMAND(path == old_path);
-      } else {
-        parser->package_map().Add(package_path.name, path);
-      }
     } else {
       // Recurse.
       auto& sub = *directive.add_directives;


### PR DESCRIPTION
Package URIs are controlled by PackageMap, not in-band directives.

This is a breaking change.

Closes Anzu 4989.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14529)
<!-- Reviewable:end -->
