### PR TITLE
Update externals CRU and VGT for bugfix to voxel grid lookup functions

### DIFF
--- a/tools/workspace/common_robotics_utilities/repository.bzl
+++ b/tools/workspace/common_robotics_utilities/repository.bzl
@@ -14,8 +14,8 @@ def common_robotics_utilities_repository(
         repository = "ToyotaResearchInstitute/common_robotics_utilities",
         # When updating, ensure that any new unit tests are reflected in
         # package.BUILD.bazel and BUILD.bazel in drake.
-        commit = "1fa04edddca020249e2ca90d6fa44ffcf59c76f3",
-        sha256 = "7c5258e1fc34b6e3e6615d3e8f792d7e3d568cc5c1af379d51803dff64a1eb35",  # noqa
+        commit = "9148b7699b0ddbdbe8710b566bf8a017cd99f257",
+        sha256 = "e55579d22ddae444fbaa8167d0c5524e1938bdb0a9b4fe7731cf3b201aeabae3",  # noqa
         build_file = "//tools/workspace/common_robotics_utilities:package.BUILD.bazel",  # noqa
         mirrors = mirrors,
     )

--- a/tools/workspace/voxelized_geometry_tools/repository.bzl
+++ b/tools/workspace/voxelized_geometry_tools/repository.bzl
@@ -14,8 +14,8 @@ def voxelized_geometry_tools_repository(
         repository = "ToyotaResearchInstitute/voxelized_geometry_tools",
         # When updating, ensure that any new unit tests are reflected in
         # package.BUILD.bazel and BUILD.bazel in drake.
-        commit = "a039f7f5f19e461747f7b1fa3f11023d324881ea",
-        sha256 = "3bde6b3376151655535aabb3d06fb453459c15046869a8c6ef678c6912299233",  # noqa
+        commit = "02aa5773c0cfd33aaa7e54cf606beaffd78e250f",
+        sha256 = "d0a19668e7c578bd4c0b41b836d462dc03b2f66cfe7d4a78ec96386ea8c44132",  # noqa
         build_file = "//tools/workspace/voxelized_geometry_tools:package.BUILD.bazel",  # noqa
         mirrors = mirrors,
     )


### PR DESCRIPTION
Updates versions of externals `common_robotics_utilities` and `voxelized_geometry_tools` with fixes in voxel grid lookups. Changes are purely bugfixes and do not change API.

Changes in externals:
- `common_robotics_utilities` - fixes in dense voxel grid and spatial hashed voxel grid lookups
- `voxelized_geometry_tools` fixes in OpenCL and CUDA implementations of dense voxel grid lookups

+@ggould-tri for feature review, thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14530)
<!-- Reviewable:end -->
