### PR TITLE
Add Jekyll framework

### DIFF
--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -72,6 +72,61 @@ drake_py_binary(
 )
 
 drake_py_library(
+    name = "jekyll_base",
+    srcs = ["jekyll_base.py"],
+    tags = [
+        # This target requires the appropriate prerequisites script for each
+        # platform to be run with the optional --with-doc-only command line
+        # option.
+        "manual",
+    ],
+)
+
+filegroup(
+    name = "jekyll_data",
+    srcs = [
+        "_config.yml",
+        "_js/drake.js",
+        "_layouts/default.html",
+        "index.md",
+    ],
+)
+
+drake_py_binary(
+    name = "gen_jekyll",
+    srcs = ["gen_jekyll.py"],
+    add_test_rule = 1,
+    data = [":jekyll_data"],
+    tags = [
+        # This target requires the appropriate prerequisites script for each
+        # platform to be run with the optional --with-doc-only command line
+        # option.
+        "manual",
+    ],
+    test_rule_args = [
+        "--out_dir=<test>",
+    ],
+    deps = [
+        ":jekyll_base",
+    ],
+)
+
+drake_py_binary(
+    name = "serve_jekyll",
+    srcs = ["serve_jekyll.py"],
+    data = [":jekyll_data"],
+    tags = [
+        # This target requires the appropriate prerequisites script for each
+        # platform to be run with the optional --with-doc-only command line
+        # option.
+        "manual",
+    ],
+    deps = [
+        ":jekyll_base",
+    ],
+)
+
+drake_py_library(
     name = "system_doxygen",
     srcs = ["system_doxygen.py"],
     visibility = ["//visibility:public"],

--- a/doc/_config.yml
+++ b/doc/_config.yml
@@ -1,0 +1,13 @@
+# Jekyll config file
+
+title: drake
+
+exclude:
+  - gen_jekyll
+  - gen_jekyll.py
+  - jekyll_base.py
+  - serve_jekyll
+  - serve_jekyll.py
+
+keep_files:
+  - js

--- a/doc/_js/drake.js
+++ b/doc/_js/drake.js
@@ -1,0 +1,1 @@
+// TODO(betsy.mcphail): Add Jekyll js code here

--- a/doc/_layouts/default.html
+++ b/doc/_layouts/default.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
+  </head>
+  <body>
+    {{ content }}
+  </body>
+<!-- Javascript Assets -->
+<script src="{{ '/js/plugins-min.js' | relative_url }}"></script>
+</html>
+

--- a/doc/documentation_instructions.rst
+++ b/doc/documentation_instructions.rst
@@ -7,6 +7,14 @@ Documentation Generation Instructions
 Documentation generation and preview as described in this document are
 supported on Ubuntu only.
 
+Before getting started, install the appropriate prerequisites with the
+``--with-doc-only`` command line option, e.g., ::
+
+    $ ./setup/ubuntu/install_prereqs.sh --with-doc-only
+
+Sphinx and Doxygen
+==================
+
 *Note: Before proceeding, please*
 :ref:`build Drake from source <build_from_source>`. This is necessary because
 otherwise the various build targets mentioned below will not exist.
@@ -20,17 +28,7 @@ This includes API documentation
 `Python <https://drake.mit.edu/pydrake/index.html>`_) and
 `Drake's website <https://drake.mit.edu>`_.
 
-.. _documentation-generation-instructions-bazel:
-
-When using Bazel
-================
-
-First, install the appropriate prerequisites with the ``--with-doc-only`` command
-line option, e.g., ::
-
-    $ ./setup/ubuntu/install_prereqs.sh --with-doc-only
-
-Then, to generate the website and serve it locally with
+To generate the website and serve it locally with
 `webbrowser <https://docs.python.org/2/library/webbrowser.html>`_::
 
     $ bazel run //doc:serve_sphinx [-- --browser=false]
@@ -52,3 +50,23 @@ To generate the Python API documentation::
 
 The contents of the Python API documentation are also available via
 ``bazel build //bindings/pydrake/doc:sphinx.zip``.
+
+Jekyll
+======
+
+*Note: Jekyll documentation is a work in progress and is not published live
+yet.* Currently, this process will generate or serve an empty page (index.html).
+
+It is *not* necessary to build Drake prior to running either command below.
+
+To serve page locally at http://127.0.0.1:<n>::
+
+    $ bazel run //doc:serve_jekyll [-- --default_port <n>]
+
+If not specified, the default port is 8000.
+
+To create output in the specified out_dir::
+
+    $ bazel run //doc:gen_jekyll -- --out_dir
+
+The output directory must not already exist.

--- a/doc/gen_jekyll.py
+++ b/doc/gen_jekyll.py
@@ -1,0 +1,11 @@
+"""
+Generates documentation for `drake.mit.edu`.
+"""
+
+from os.path import abspath, dirname
+
+from drake.doc.jekyll_base import gen_main
+
+if __name__ == "__main__":
+    input_dir = dirname(abspath(__file__))
+    gen_main(input_dir=input_dir)

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,0 +1,3 @@
+---
+layout: default
+---

--- a/doc/jekyll_base.py
+++ b/doc/jekyll_base.py
@@ -1,0 +1,97 @@
+import argparse
+import os
+from os.path import abspath, exists, isabs, isdir, join
+from shutil import rmtree
+from subprocess import check_call
+import sys
+import tempfile
+
+
+def _die(s):
+    print(s, file=sys.stderr)
+    sys.exit(1)
+
+
+def _minify(input_dir, out_dir):
+    # TODO(betsymcphail): Once implemented for production, the Jekyll site may
+    #  require third party .js plugins in addition to drake.js.
+    # Add the full path to any plugins here.
+    drake_js = join(input_dir, "_js", "drake.js")
+    plugins = [drake_js]
+    plugin_dir = join(out_dir, "js")
+    if not exists(plugin_dir):
+        os.mkdir(plugin_dir)
+    plugins_min_js = join(plugin_dir, "plugins-min.js")
+    check_call(
+        [
+            "uglifyjs",
+            " ".join(plugins),
+            "-o", plugins_min_js,
+            "-c", "-m",
+        ]
+    )
+
+
+def gen_main(input_dir):
+    """Main entry point for generation.
+
+    Args:
+        input_dir: Directory which contains initial input files.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--out_dir", type=str, required=True,
+        help="Output directory. Must be an absolute path and must not exist.")
+    args = parser.parse_args()
+    out_dir = args.out_dir
+    if out_dir == "<test>":
+        out_dir = join(os.environ["TEST_TMPDIR"], "jekyll")
+    if not isabs(out_dir):
+        _die("--out_dir must be absolute path: {}".format(out_dir))
+    # Jekyll will remove all of the contents of the output directory without
+    # warning. Require an empty directory to avoid accidental deletion.
+    if exists(out_dir):
+        _die("--out_dir must not exist: {}".format(out_dir))
+
+    # Create output directory.
+    os.makedirs(out_dir)
+
+    # Minify files directly to output location.
+    _minify(input_dir, out_dir)
+
+    # Generate.
+    check_call(
+        [
+            "jekyll", "build",
+            "-s", input_dir,
+            "-d", out_dir,
+        ]
+    )
+
+
+def preview_main(input_dir, default_port):
+    """Main entry point for preview
+
+     Args:
+        default_port: Default port for local server.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--port", type=int, default=default_port, metavar='PORT',
+        help="Port for serving doc pages on a local server.")
+    args = parser.parse_args()
+
+    # Choose an arbitrary, temporary location for generating documentation.
+    with tempfile.TemporaryDirectory() as out_dir:
+        # Minify files directly to output location.
+        _minify(input_dir, out_dir)
+
+        # Generate.
+        check_call(
+            [
+                "jekyll", "serve",
+                "-s", input_dir,
+                "-d", out_dir,
+                "--port", str(args.port),
+            ]
+        )

--- a/doc/serve_jekyll.py
+++ b/doc/serve_jekyll.py
@@ -1,0 +1,11 @@
+"""
+Serves documentation for `drake.mit.edu`.
+"""
+
+from os.path import abspath, dirname
+
+from drake.doc.jekyll_base import preview_main
+
+if __name__ == "__main__":
+    input_dir = dirname(abspath(__file__))
+    preview_main(input_dir=input_dir, default_port=8000)


### PR DESCRIPTION
Working toward #13832 (bullet 4)

Generates or serves an empty page (index.html)

``bazel run //doc:serve_jekyll`` will serve page locally at http://127.0.0.1:8000

``bazel run //doc:gen_jekyll -- --out_dir <output directory>`` will create output in specified <output directory>

Note: It is not necessary to build drake prior to running either command above.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14531)
<!-- Reviewable:end -->
