### PR TITLE
Explicitly set encoding when opening files in system_doxygen.py

### DIFF
--- a/doc/system_doxygen.py
+++ b/doc/system_doxygen.py
@@ -134,7 +134,7 @@ if __name__ == "__main__":
         raise RuntimeError(f"Wrong number of arguments.\n{__doc__}")
 
     # Load the file in batch into a string.
-    with open(sys.argv[1], 'r') as f:
+    with open(sys.argv[1], 'r', encoding='utf-8') as f:
         s = f.read()
 
     s = process_doxygen_system_tags(s)


### PR DESCRIPTION
Default behavior changed between 3.6 and 3.8 so this ensures behavior is the same. For whatever reason is this causing issues for the Bionic apt build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14536)
<!-- Reviewable:end -->
