### PR TITLE
lcmtypes: Remove stray deprecation notice

### DIFF
--- a/lcmtypes/README.md
+++ b/lcmtypes/README.md
@@ -30,7 +30,6 @@ also unused within Drake and therefore are being removed:
 - lcmt_foot_flag
 - lcmt_quadrotor_input_t
 - lcmt_quadrotor_output_t
-- lcmt_robot_state
 - lcmt_scope_data
 - lcmt_simulation_command
 

--- a/lcmtypes/lcmt_robot_state.lcm
+++ b/lcmtypes/lcmt_robot_state.lcm
@@ -1,8 +1,5 @@
 package drake;
 
-// DRAKE DEPRECATED: This message is unused within Drake and therefore will be
-// removed on or after 2021-04-01.
-
 struct lcmt_robot_state
 {
   int64_t utime;


### PR DESCRIPTION
This snuck in during #14372 after it was rebased over #14377.  Previously the plan was to deprecate this message, but after the rewrite we decided to keep it.  The BUILD.bazel file was correct (no deprecation) but the stale comments were overlooked.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14539)
<!-- Reviewable:end -->
