### PR TITLE
pydrake: Make explicit / orthogonal unittest for `catch_drake_warnings`

### DIFF
--- a/bindings/pydrake/common/BUILD.bazel
+++ b/bindings/pydrake/common/BUILD.bazel
@@ -403,6 +403,7 @@ drake_cc_googletest(
 drake_cc_library(
     name = "deprecation_example_class",
     testonly = 1,
+    srcs = ["test/deprecation_example/example_class.cc"],
     hdrs = ["test/deprecation_example/example_class.h"],
     deps = [
         "//:drake_shared_library",
@@ -438,6 +439,9 @@ drake_pybind_library(
         "test/deprecation_example/cc_module_py.cc",
     ],
     package_info = PACKAGE_INFO,
+    py_deps = [
+        "//bindings/pydrake:module_py",
+    ],
     visibility = ["//visibility:private"],
 )
 
@@ -453,12 +457,24 @@ drake_py_library(
     ],
 )
 
+# Note: This target tests the low-level deprecation API.
+# Please see `deprecation_utility_test` for a unittest on higher-level
+# deprecation API.
 drake_py_unittest(
     name = "deprecation_test",
     deps = [
         # N.B. We include this here due to awkward setup for `pydrake.common`.
         ":module_py",
         ":deprecation_example",
+    ],
+)
+
+# Provides a unittest for high-level deprecation API.
+drake_py_unittest(
+    name = "deprecation_utility_test",
+    deps = [
+        ":deprecation_example",
+        "//bindings/pydrake/common/test_utilities:deprecation_py",
     ],
 )
 

--- a/bindings/pydrake/common/test/deprecation_example/README.md
+++ b/bindings/pydrake/common/test/deprecation_example/README.md
@@ -1,6 +1,7 @@
 # `pydrake` Deprecation Example
 
-This package is used by `../deprecation_test.py` and shows the following:
+This package is used by `../deprecation_utility_test.py` and shows the
+following:
 
 * How to use `pydrake.common.deprecation` in a module, leveraging `ModuleShim`
     * `__init__.py` shows using `ModuleShim`

--- a/bindings/pydrake/common/test/deprecation_example/example_class.cc
+++ b/bindings/pydrake/common/test/deprecation_example/example_class.cc
@@ -1,0 +1,1 @@
+#include "drake/bindings/pydrake/common/test/deprecation_example/example_class.h"  // NOLINT

--- a/bindings/pydrake/common/test/deprecation_example/example_class.h
+++ b/bindings/pydrake/common/test/deprecation_example/example_class.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "drake/common/drake_deprecated.h"
+#include "drake/common/unused.h"
 
 namespace drake {
 namespace example_class {
@@ -15,28 +16,53 @@ class ExampleCppClass {
   // up the following deprecation below.
 
   DRAKE_DEPRECATED("2038-01-19", "Do not use ExampleCppClass(int).")
-  explicit ExampleCppClass(int) {}
+  explicit ExampleCppClass(int x) {
+    // This toy function does no actual work where a real function would do
+    // work with the parameters. Using unused minimally satisfies the
+    // compiler's need that all named parameters be "used". We can't simply
+    // omit the parameter name because python doc extraction depends on those
+    // names.
+    unused(x);
+  }
 
   DRAKE_DEPRECATED("2038-01-19", "Do not use ExampleCppClass(double).")
-  explicit ExampleCppClass(double) {}
+  explicit ExampleCppClass(double y) {
+    // This toy function does no actual work where a real function would do
+    // work with the parameters. Using unused minimally satisfies the
+    // compiler's need that all named parameters be "used". We can't simply
+    // omit the parameter name because python doc extraction depends on those
+    // names.
+    unused(y);
+  }
 
-  DRAKE_DEPRECATED("2038-01-19", "Do not use DeprecatedMethod().")
+  DRAKE_DEPRECATED("2038-01-19", "Do not use DeprecatedMethod.")
   void DeprecatedMethod() {}
 
-  /// Good property.
-  int prop{};
+  DRAKE_DEPRECATED("2038-01-19", "Do not use DeprecatedMethod.")
+  void DeprecatedMethod(int) {}
 
   /// Good overload.
   void overload() {}
 
   DRAKE_DEPRECATED("2038-01-19", "Do not use overload(int).")
-  void overload(int) {}
+  void overload(int x) {
+    // This toy function does no actual work where a real function would do
+    // work with the parameters. Using unused minimally satisfies the
+    // compiler's need that all named parameters be "used". We can't simply
+    // omit the parameter name because python doc extraction depends on those
+    // names.
+    unused(x);
+  }
+
+  /// Good property.
+  int prop{};
 };
 
 /// Serves as an example for binding (and deprecating) a simple struct. This
 /// allows the struct to be constructed with ParamInit and deprecated using
 /// the corresponding DeprecatedParamInit.
-struct ExampleCppStruct {
+struct DRAKE_DEPRECATED(
+    "2038-01-19", "Do not use ExampleCppStruct") ExampleCppStruct {
   int i{};
   int j{};
 };

--- a/bindings/pydrake/common/test/deprecation_test.py
+++ b/bindings/pydrake/common/test/deprecation_test.py
@@ -1,3 +1,9 @@
+"""
+Tests low-level deprecation API.
+
+Please see `deprecation_utility_test.py` for a unittest on higher-level API.
+"""
+
 import rlcompleter
 import sys
 from types import ModuleType
@@ -145,6 +151,12 @@ class TestDeprecation(unittest.TestCase):
             self.assertIn(message_expected, str(item.message))
 
     def test_member_deprecation(self):
+        """
+        Tests low-level deprecation API for members.
+
+        Please see `deprecation_utility_test.py` for a unittest on
+        higher-level API.
+        """
         from deprecation_example import ExampleClass
 
         def base_deprecation():
@@ -221,52 +233,13 @@ class TestDeprecation(unittest.TestCase):
             warnings.simplefilter("ignore", DeprecationWarning)
             warnings.simplefilter("once", DrakeDeprecationWarning)
 
-    def test_deprecation_pybind(self):
-        """Test C++ usage in `deprecation_pybind.h`, as is used in
-        `cc_module_py.cc`."""
-        from deprecation_example.cc_module import (
-            ExampleCppClass,
-            ExampleCppStruct,
-            emit_deprecation,
-        )
-        # TODO(eric.cousineau): Break these apart.
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("once", DrakeDeprecationWarning)
-            # This is a descriptor, so it will trigger on class access.
-            ExampleCppClass.DeprecatedMethod
-            self.assertEqual(len(w), 1)
-            self._check_warning(w[0], "Do not use DeprecatedMethod()", False)
-            # Same for a property.
-            ExampleCppClass.deprecated_prop
-            self.assertEqual(len(w), 2)
-            self._check_warning(w[1], "Do not use deprecated_prop", False)
-            # Call good overload; no new warnings.
-            obj = ExampleCppClass()
-            obj.overload()
-            self.assertEqual(len(w), 2)
-            # Call bad overload.
-            obj.overload(10)
-            self.assertEqual(len(w), 3)
-            self._check_warning(w[2], "Do not use overload(int)", False)
-            # Call bad constructors.
-            ExampleCppClass(1)
-            self.assertEqual(len(w), 4)
-            self._check_warning(w[3], "Do not use ExampleCppClass(int)", False)
-            # - Factory.
-            ExampleCppClass(2.0)
-            self.assertEqual(len(w), 5)
-            self._check_warning(
-                w[4], "Do not use ExampleCppClass(double)", False)
-            # Explicit call.
-            emit_deprecation()
-            self.assertEqual(len(w), 6)
-            self._check_warning(w[5], "Example emitting of deprecation", False)
-            # Param init (regardless of arguments).
-            ExampleCppStruct()
-            self.assertEqual(len(w), 7)
-            self._check_warning(w[6], "Deprecated as of 2038-01-19", False)
-
     def test_deprecated_callable(self):
+        """
+        Tests low-level deprecation API for callables.
+
+        Please see `deprecation_utility_test.py` for a unittest on
+        higher-level API.
+        """
         import deprecation_example.cc_module as m_new
         # Spoof module name.
         var_dict = dict(__name__="fake_module")

--- a/bindings/pydrake/common/test/deprecation_utility_test.py
+++ b/bindings/pydrake/common/test/deprecation_utility_test.py
@@ -1,0 +1,57 @@
+"""
+Provides a unittest for high-level deprecation testing API
+(``catch_drake_warnings``), relevant to deprecations in pybind11 bindings of
+C++ API.
+
+For more details, please review the following documentation:
+
+- https://drake.mit.edu/code_review_checklist.html
+- https://drake.mit.edu/doxygen_cxx/group__python__bindings.html#PydrakeDeprecation
+- https://drake.mit.edu/doxygen_cxx/group__python__bindings.html#PydrakeDoc
+"""  # noqa
+
+import unittest
+
+from pydrake.common.test_utilities.deprecation import catch_drake_warnings
+
+import deprecation_example.cc_module as mut_cc
+
+
+class TestDeprecationExample(unittest.TestCase):
+    def test_cc_deprecated_param_init(self):
+        with catch_drake_warnings(expected_count=1) as w:
+            obj = mut_cc.ExampleCppStruct()
+            self.assertIn("Do not use ExampleCppStruct", str(w[0].message))
+
+        self.assertEqual(obj.i, 0)
+        self.assertEqual(obj.j, 0)
+
+    def test_cc_py_init_deprecated(self):
+        mut_cc.ExampleCppClass()
+
+        with catch_drake_warnings(expected_count=1) as w:
+            mut_cc.ExampleCppClass(0)
+            self.assertIn("Do not use ExampleCppClass(int)", str(w[0].message))
+        with catch_drake_warnings(expected_count=1) as w:
+            mut_cc.ExampleCppClass(0.0)
+            self.assertIn(
+                "Do not use ExampleCppClass(double)", str(w[0].message))
+
+    def test_cc_deprecate_attribute(self):
+        obj = mut_cc.ExampleCppClass()
+
+        with catch_drake_warnings(expected_count=2) as w:
+            obj.DeprecatedMethod()
+            self.assertIn("Do not use DeprecatedMethod", str(w[0].message))
+            obj.DeprecatedMethod(int())
+            self.assertEqual(str(w[0].message), str(w[1].message))
+
+    def test_cc_wrap_deprecated_for_overload(self):
+        obj = mut_cc.ExampleCppClass()
+
+        # Not deprecated.
+        obj.overload()
+
+        with catch_drake_warnings(expected_count=1) as w:
+            obj.overload(0)
+            self.assertIn("Do not use overload(int)", str(w[0].message))

--- a/bindings/pydrake/pydrake_doxygen.h
+++ b/bindings/pydrake/pydrake_doxygen.h
@@ -330,7 +330,7 @@ For examples of how to use the deprecations and what side effects they will
 have, please see:
 
 - [`drake/bindings/.../deprecation_example/`](https://github.com/RobotLocomotion/drake/tree/master/bindings/pydrake/common/test/deprecation_example)
-- [`drake/bindings/.../deprecation_test.py`](https://github.com/RobotLocomotion/drake/blob/master/bindings/pydrake/common/test/deprecation_test.py)
+- [`drake/bindings/.../deprecation_utility_test.py`](https://github.com/RobotLocomotion/drake/blob/master/bindings/pydrake/common/test/deprecation_utility_test.py)
 
 @note All deprecations in Drake should ultimately use the
 [Python `warnings` module](https://docs.python.org/3.6/library/warnings.html),


### PR DESCRIPTION
Show `catch_drake_warnings` be used next to non-deprecated API
Adds arguments names to methods
Make the goal of ExampleCppStruct deprecation more clear in code (not
just comments)

~To partially address @mitiguy's pain points here:~
A very scoped-down change motivated by:
https://githu1.com/robotlocomotion/drake/pull/14538#pullrequestreview-571747122

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14546)
<!-- Reviewable:end -->
