### PR TITLE
Add LinearSystemSolver and EigenConjugateGradientSolver

### DIFF
--- a/multibody/fixed_fem/dev/BUILD.bazel
+++ b/multibody/fixed_fem/dev/BUILD.bazel
@@ -51,6 +51,17 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "eigen_conjugate_gradient_solver",
+    hdrs = [
+        "eigen_conjugate_gradient_solver.h",
+    ],
+    deps = [
+        ":linear_system_solver",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
     name = "elasticity_element",
     hdrs = [
         "elasticity_element.h",
@@ -154,6 +165,17 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "linear_system_solver",
+    hdrs = [
+        "linear_system_solver.h",
+    ],
+    deps = [
+        "//common:essential",
+        "//multibody/contact_solvers:linear_operator",
+    ],
+)
+
+drake_cc_library(
     name = "quadrature",
     hdrs = [
         "quadrature.h",
@@ -206,6 +228,16 @@ drake_cc_googletest(
         ":simplex_gaussian_quadrature",
         "//common/test_utilities:eigen_matrix_compare",
         "//math:gradient",
+    ],
+)
+
+drake_cc_googletest(
+    name = "eigen_conjugate_gradient_solver_test",
+    deps = [
+        ":eigen_conjugate_gradient_solver",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//math:gradient",
+        "//multibody/contact_solvers:sparse_linear_operator",
     ],
 )
 

--- a/multibody/fixed_fem/dev/eigen_conjugate_gradient_solver.h
+++ b/multibody/fixed_fem/dev/eigen_conjugate_gradient_solver.h
@@ -1,0 +1,194 @@
+#pragma once
+
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/contact_solvers/linear_operator.h"
+#include "drake/multibody/fixed_fem/dev/linear_system_solver.h"
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+namespace internal {
+/* In order to implement the linear solver for contact_solvers::LinearOperator,
+ we implement the matrix-free concept in
+ https://eigen.tuxfamily.org/dox/group__MatrixfreeSolverExample.html through the
+ EigenMatrixProxy class. It wraps around the linear operator and turns it into
+ an Eigen object. It provides the methods rows(), cols(), and a bespoke
+ multiplication operator. */
+template <typename T>
+class EigenMatrixProxy : public Eigen::EigenBase<EigenMatrixProxy<T>> {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(EigenMatrixProxy);
+  /* Required typedefs, constants, and methods for EigenMatrixProxy to be used
+    in Eigen::ConjugateGradient. */
+  using Traits = Eigen::internal::traits<EigenMatrixProxy<T>>;
+  using Scalar = typename Traits::Scalar;
+  using RealScalar = typename Traits::Scalar;
+  using StorageIndex = typename Traits::StorageIndex;
+  enum {
+    ColsAtCompileTime = Traits::ColsAtCompileTime,
+    MaxColsAtCompileTime = Traits::MaxColsAtCompileTime,
+    IsRowMajor = false
+  };
+
+  StorageIndex rows() const {
+    DRAKE_ASSERT(linear_operator_ != nullptr);
+    return linear_operator_->rows();
+  }
+
+  StorageIndex cols() const {
+    DRAKE_ASSERT(linear_operator_ != nullptr);
+    return linear_operator_->cols();
+  }
+
+  /* Implements multiplication for EigenMatrixProxy by returning an
+   Eigen::Product.
+   @tparam Rhs    The type of the Eigen vector multiplying `this` matrix on the
+   right. */
+  template <typename Rhs>
+  Eigen::Product<EigenMatrixProxy<T>, Rhs, Eigen::AliasFreeProduct> operator*(
+      const Eigen::MatrixBase<Rhs>& x) const {
+    DRAKE_ASSERT(linear_operator_ != nullptr);
+    return Eigen::Product<EigenMatrixProxy<T>, Rhs, Eigen::AliasFreeProduct>(
+        *this, x.derived());
+  }
+
+  /* Custom APIs */
+  /* Constructs an EigenMatrixProxy wrapping around the input "linear_operator".
+   This class keeps a reference to the input `linear_operator` and therefore it
+   is required that `linear_operator` outlives this object. */
+  EigenMatrixProxy(
+      const contact_solvers::internal::LinearOperator<T>& linear_operator)
+      : linear_operator_(&linear_operator),
+        scratch_vector_(linear_operator.rows()) {}
+
+  ~EigenMatrixProxy() = default;
+
+  /* Scales the product of `this` EigenMatrixProxy and `rhs` by `scale` and adds
+   the result to `dest`. */
+  void ScaleProductAndAdd(const T& scale,
+                          const Eigen::Ref<const VectorX<T>>& rhs,
+                          EigenPtr<VectorX<T>> dest) const {
+    DRAKE_ASSERT(linear_operator_ != nullptr);
+    linear_operator_->Multiply(rhs, &scratch_vector_);
+    *dest += scale * scratch_vector_;
+  }
+
+ private:
+  const contact_solvers::internal::LinearOperator<T>* linear_operator_;
+  /* A scratch space to store the result of A*x to avoid repeated allocation. */
+  mutable VectorX<T> scratch_vector_;
+};
+}  // namespace internal
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake
+
+namespace Eigen {
+namespace internal {
+/* Minimal required traits for a custom linear operator to be used in a Eigen
+  sparse iterative solver. */
+template <typename T>
+struct traits<drake::multibody::fixed_fem::internal::EigenMatrixProxy<T>> {
+  using Scalar = T;
+  using StorageIndex = int;
+  /* It doesn't matter whether StorageKind is Sparse or Dense as long as it
+   matches the "Shape" of the matrix in generic_product_impl below so that the
+   correct template specialization takes place. */
+  using StorageKind = Sparse;
+  enum {
+    RowsAtCompileTime = Dynamic,
+    ColsAtCompileTime = Dynamic,
+    MaxRowsAtCompileTime = Dynamic,
+    MaxColsAtCompileTime = Dynamic,
+    /* Compile time properties of the matrix. See
+       https://eigen.tuxfamily.org/dox-devel/group__flags.html. */
+    Flags = 0x0
+  };
+};
+
+/* Implements multiplications between EigenMatrixProxy and Eigen dense vectors
+ by specializing the template Eigen::generic_product_impl. */
+template <typename Rhs, typename T>
+struct generic_product_impl<
+    drake::multibody::fixed_fem::internal::EigenMatrixProxy<T>, Rhs,
+    SparseShape, DenseShape,
+    GemvProduct>  // GEMV stands for matrix-vector
+    : generic_product_impl_base<
+          drake::multibody::fixed_fem::internal::EigenMatrixProxy<T>, Rhs,
+          generic_product_impl<
+              drake::multibody::fixed_fem::internal::EigenMatrixProxy<T>,
+              Rhs>> {
+  template <typename Dest>
+  static void scaleAndAddTo(
+      // NOLINTNEXTLINE(runtime/references) Eigen internal signature.
+      Dest& dst,
+      const drake::multibody::fixed_fem::internal::EigenMatrixProxy<T>& lhs,
+      const Rhs& rhs, const T& alpha) {
+    /* This method implements "dst += alpha * lhs * rhs" inplace. */
+    lhs.ScaleProductAndAdd(alpha, rhs, &dst);
+  }
+};
+}  // namespace internal
+}  // namespace Eigen
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+namespace internal {
+/* Implements LinearSystemSolver with an underlying Eigen::ConjugateGradient
+ solver. The linear operator A in the system Ax = b must be symmetric positive
+ definite (SPD). This solver, however, will not verify that A is SPD as the
+ verification process is usually expensive. The user of this class therefore has
+ to be careful in passing in a SPD operator. Failure to do so may lead to
+ incorrect solutions.
+ @tparam_nonsymbolic_scalar T */
+template <typename T>
+class EigenConjugateGradientSolver : public LinearSystemSolver<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(EigenConjugateGradientSolver)
+
+  /* Constructs an EigenConjugateGradientSolver and set the tolerance of the
+  iterative solver to the given `tol`. Being an iterative solver, the underlying
+  Eigen::ConjudateGradient solver will iterate until the relative error
+  ||Ax-b||/||b|| is smaller than the set tolerance or when the max number of
+  iterations is reached.  */
+  EigenConjugateGradientSolver(
+      const contact_solvers::internal::LinearOperator<T>& A, double tol = 1e-4)
+      : LinearSystemSolver<T>(A), matrix_proxy_(A) {
+    cg_.compute(matrix_proxy_);
+    cg_.setTolerance(tol);
+  }
+
+  ~EigenConjugateGradientSolver() {}
+
+  /* Implements LinearSystemSolver::Solve(). */
+  void Solve(const Eigen::Ref<const VectorX<T>>& b,
+             EigenPtr<VectorX<T>> x) const final {
+    *x = cg_.solve(b);
+  }
+
+  /* Returns Eigen::ConjugateGradient::maxIterations(). */
+  void max_iterations() const { cg_.maxIterations(); }
+
+  /* Forwards to Eigen::ConjugateGradient::setMaxIterations(). */
+  void set_max_iterations(int max_iterations) {
+    cg_.setMaxIterations(max_iterations);
+  }
+
+  /* Returns Eigen::ConjugateGradient::tolerance(). */
+  double tolerance() const { return cg_.tolerance(); }
+
+  /* Forwards to Eigen::ConjugateGradient::setTolerance(). */
+  void set_tolerance(double tol) { cg_.setTolerance(tol); }
+
+ private:
+  EigenMatrixProxy<T> matrix_proxy_;
+  /* TODO(xuchenhan-tri): Allow for custom preconditioner if needed in the
+   future. */
+  Eigen::ConjugateGradient<EigenMatrixProxy<T>, Eigen::Lower | Eigen::Upper,
+                           Eigen::IdentityPreconditioner>
+      cg_;
+};
+}  // namespace internal
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/linear_system_solver.h
+++ b/multibody/fixed_fem/dev/linear_system_solver.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "drake/multibody/contact_solvers/linear_operator.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+namespace internal {
+/* A generic interface to solve a linear system of equations of the form
+ Ax = b, where A ∈ ℝⁿˣⁿ and b ∈ ℝⁿ are given and x ∈ ℝⁿ is the unknown to be
+ solved for. The unknown x and the right hand side b are dense. The linear
+ operator A is represented by contact_solvers::internal::LinearOperator and may
+ be dense or sparse.
+ @tparam_nonsymbolic_scalar T */
+template <typename T>
+class LinearSystemSolver {
+ public:
+  virtual ~LinearSystemSolver() {}
+
+  /* Performs the linear solve to get x = A⁻¹b. */
+  virtual void Solve(const Eigen::Ref<const VectorX<T>>& b,
+                     EigenPtr<VectorX<T>> x) const = 0;
+
+  /* Returns the size of the linear system, which is equal to the number of rows
+   and columns of the matrix A. */
+  int size() const {
+    DRAKE_ASSERT(A_ != nullptr);
+    return A_->rows();
+  }
+
+  /* Returns the underlying linear operator. Useful for debugging purposes. */
+  const contact_solvers::internal::LinearOperator<T>& A() {
+    DRAKE_ASSERT(A_ != nullptr);
+    return *A_;
+  }
+
+ protected:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LinearSystemSolver);
+
+  /* Constructs a new linear solver with the prescribed linear operator A.
+   This class keeps a reference to input linear operator `A` and therefore it is
+   required that `A` outlives this object.
+   @param[in] A    The linear operator that describes the linear system. The
+   number of rows and columns must be the same for A.
+   @throw std::exception if A.rows() != A.cols(). */
+  explicit LinearSystemSolver(
+      const contact_solvers::internal::LinearOperator<T>& A)
+      : A_(&A) {
+    DRAKE_THROW_UNLESS(A.rows() == A.cols());
+  }
+
+ private:
+  const contact_solvers::internal::LinearOperator<T>* A_;
+};
+}  // namespace internal
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/test/eigen_conjugate_gradient_solver_test.cc
+++ b/multibody/fixed_fem/dev/test/eigen_conjugate_gradient_solver_test.cc
@@ -1,0 +1,174 @@
+#include "drake/multibody/fixed_fem/dev/eigen_conjugate_gradient_solver.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/autodiff_gradient.h"
+#include "drake/multibody/contact_solvers/sparse_linear_operator.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+namespace internal {
+namespace {
+/* Dimension of the system. */
+constexpr int kD = 4;
+/* Tolerance for the CG solver. */
+const double kTol = 1e-14;
+
+/* Generate an arbitrary kD-by-kD matrix. */
+Eigen::Matrix<double, kD, kD> MakeMatrix() {
+  Eigen::Matrix<double, kD, kD> B;
+  // clang-format off
+  B << 31.705908, 62.927869, 93.446683, 65.319711,
+       12.200296, 32.078717, 13.422328, 25.142288,
+       53.688842, 12.454311, 33.192683, 85.237341,
+       14.656643, 42.836689, 13.362649, 85.326259;
+  // clang-format on
+  return B;
+}
+
+/* Generate an arbitrary symmetric positive definite (SPD) matrix. */
+Eigen::Matrix<double, kD, kD> MakeSpdMatrix() {
+  Eigen::Matrix<double, kD, kD> B = MakeMatrix();
+  /* A = Bᵀ * B + ε * I₄ is guaranteed to be symmetric positive definite. */
+  return B.transpose() * B + 0.1 * Eigen::Matrix<double, kD, kD>::Identity();
+}
+
+/* Generate an arbitrary right hand side vector b. */
+Vector<double, kD> MakeRhs() {
+  Vector<double, kD> b;
+  b << 56.134, 43.548, 23.545, 12.374;
+  return b;
+}
+
+/* Tests the solution of the linear solve is correct as measure by
+ reconstruction errors. */
+GTEST_TEST(EigenConjugateGradientSolverTest, DoubleDenseSolverTest) {
+  /* TODO(xuchenhan-tri) The only reason that we are testing with a
+   SparseLinearOperator here is because that is the only linear operator
+   available at the moment. Change to a more appropriate dense linear
+   operator when something like that lands. */
+  const Eigen::SparseMatrix<double> A = MakeSpdMatrix().sparseView();
+  contact_solvers::internal::SparseLinearOperator<double> A_op("A", &A);
+  const Vector<double, kD> b = MakeRhs();
+  const EigenConjugateGradientSolver<double> solver(A_op, kTol);
+  Eigen::Matrix<double, kD, 1> x;
+  solver.Solve(b, &x);
+
+  EXPECT_LE((A * x - b).norm(), b.norm() * kTol);
+}
+
+GTEST_TEST(EigenConjugateGradientSolverTest, DoubleSparseSolverTest) {
+  Eigen::SparseMatrix<double> A =
+      Eigen::Matrix<double, kD, kD>(Vector4<double>(1, 2, 3, 4).asDiagonal())
+          .sparseView();
+  /* Add a few off-diagonal entries to make A not completely trivial to solve
+   while still maintaining the SPD-ness of A. */
+  A.coeffRef(0, 1) = 0.1;
+  A.coeffRef(1, 0) = 0.1;
+
+  contact_solvers::internal::SparseLinearOperator<double> A_op("A", &A);
+  const Vector<double, kD> b = MakeRhs();
+  const EigenConjugateGradientSolver<double> solver(A_op, kTol);
+  Eigen::Matrix<double, kD, 1> x;
+  solver.Solve(b, &x);
+
+  EXPECT_LE((A * x - b).norm(), b.norm() * kTol);
+}
+
+/* Tests the derivatives of the solution with respect to the right hand side
+ matches the expected values. */
+GTEST_TEST(EigenConjugateGradientSolverTest, AutoDiffSolverTestRhs) {
+  using T = AutoDiffXd;
+  /* Build the operator A. */
+  const Eigen::Matrix<double, kD, kD> A = MakeSpdMatrix();
+  const Eigen::SparseMatrix<T> A_sparse = A.cast<T>().sparseView();
+  contact_solvers::internal::SparseLinearOperator<T> A_op("A", &A_sparse);
+  /* Build the right hand side b. */
+  const Vector<double, kD> b = MakeRhs();
+  Vector<T, kD> b_autodiff;
+  math::initializeAutoDiff(b, b_autodiff);
+  /* Build the solve and solve for x. */
+  const EigenConjugateGradientSolver<T> solver(A_op, kTol);
+  Eigen::Matrix<T, kD, 1> x;
+  solver.Solve(b_autodiff, &x);
+  /* Use LU decomposition to invert the matrix A. */
+  const Eigen::FullPivLU<Eigen::Matrix<double, kD, kD>> lu(A);
+  for (int i = 0; i < kD; ++i) {
+    Vector<double, kD> unit_derivative = Vector<double, kD>::Zero();
+    unit_derivative(i) = 1.0;
+    /* We are checking the gradient of x = f(b) = A\b w.r.t b, namely, grad =
+     df/db. We know that this gradient is such that grad.row(i) = A \ eᵢ, hence
+     the check below. */
+    const Vector<double, kD> expected_derivatives = lu.solve(unit_derivative);
+    EXPECT_TRUE(CompareMatrices(x(i).derivatives(), expected_derivatives,
+                                std::numeric_limits<double>::epsilon()));
+  }
+}
+
+/* Tests the derivatives of the solution with respect to the left hand side
+ matches the expected values. */
+GTEST_TEST(EigenConjugateGradientSolverTest, AutoDiffSolverTestLhs) {
+  /* We take care to make sure the derivatives of A is compatible with the fact
+  that A remains SPD. In particular, we cannot initialize the derivatives with
+  following code block:
+  ```
+  const Eigen::Matrix<double, kD, kD> A = MakeSpdMatrix();
+  Eigen::Matrix<T, kD, kD> A_autodiff;
+  math::initializeAutoDiff(A, A_autodiff);
+  ```
+  because then dA is not guaranteed to be symmetric. */
+  using T = AutoDiffXd;
+  const Eigen::Matrix<double, kD, kD> B = MakeMatrix();
+  Eigen::Matrix<T, kD, kD> B_autodiff;
+  math::initializeAutoDiff(B, B_autodiff);
+  /* A = Bᵀ * B + ε * I₄ is guaranteed to be symmetric positive definite. */
+  Eigen::Matrix<T, kD, kD> A_autodiff =
+      B_autodiff.transpose() * B_autodiff +
+      Eigen::Matrix<T, kD, kD>::Identity() * 0.1;
+  /* Set up solver and rhs and solve for the solution, x_cg. */
+  const Eigen::SparseMatrix<T> A_sparse = A_autodiff.sparseView();
+  contact_solvers::internal::SparseLinearOperator<T> A_op("A", &A_sparse);
+  const EigenConjugateGradientSolver<T> solver(A_op, kTol);
+  const Vector<double, kD> b = MakeRhs();
+  Vector<T, kD> x_cg;
+  solver.Solve(b.cast<T>(), &x_cg);
+
+  /* Use LU decomposition to get expected values for A⁻¹, A⁻¹Bᵀ and x. */
+  const Eigen::FullPivLU<Eigen::Matrix<T, kD, kD>> lu(A_autodiff);
+  const Eigen::Matrix<T, kD, kD> A_inverse =
+      lu.solve(Eigen::Matrix<T, kD, kD>::Identity());
+  const Eigen::Matrix<T, kD, kD> A_inverse_BT =
+      lu.solve(B_autodiff.transpose());
+  Vector<T, kD> x = lu.solve(b.cast<T>());
+  const Vector<T, kD> Bx = B_autodiff * x;
+  EXPECT_TRUE(CompareMatrices(x, x_cg, kTol));
+
+  for (int i = 0; i < kD; ++i) {
+    const Eigen::Matrix<double, kD, kD> xi_derivatives_cg =
+        Eigen::Map<const Eigen::Matrix<double, kD, kD>>(
+            x_cg(i).derivatives().data(), kD, kD);
+    /* Build the expected derivatives of x(i) w.r.t. B:
+     x = f(B) = A⁻¹b.
+     ∂xᵢ/∂Bⱼₖ = ∂A⁻¹ᵢₗ/∂Bⱼₖbₗ = −A⁻¹ᵢₚ * ∂Aₚₛ/∂Bⱼₖ  * A⁻¹ₛₗbₗ (1).
+     Note that A = Bᵀ * B + ε * I₄ and thus  ∂Aₚₛ/∂Bⱼₖ = δₖₚBⱼₛ+δₖₛBⱼₚ.
+     Plugging it into (1) and after some algebra we get
+     ∂xᵢ/∂Bⱼₖ = -A⁻¹ᵢₖ(Bx)ⱼ - (A⁻¹B)ᵢⱼxₖ. */
+    Eigen::Matrix<double, kD, kD> expected_derivatives;
+    for (int j = 0; j < kD; ++j) {
+      for (int k = 0; k < kD; ++k) {
+        expected_derivatives(j, k) =
+            -(A_inverse(i, k) * Bx(j) + A_inverse_BT(i, j) * x(k)).value();
+      }
+    }
+    /* The derivatives matches expected value. */
+    EXPECT_TRUE(CompareMatrices(xi_derivatives_cg, expected_derivatives, kTol));
+  }
+}
+}  // namespace
+}  // namespace internal
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
- Creates the LinearSystemSolver class that provides minimal API
required to solve the linear systems that arise from FEM solver.

- Creates an concrete implementation of LinearSystemSolver,
EigenConjugateGradientSolver that wraps around the
Eigen::ConjugateGradient solver.

- Implements EigenMatrixProxy which turns
multibody::contact_solvers::internal::LinearOperator into Eigen objects
and facilitates implementation of EigenConjugateGradientSolver.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14548)
<!-- Reviewable:end -->
