### PR TITLE
[hotfix] Fix render_benchmark build error under mac 

### DIFF
--- a/geometry/benchmarking/BUILD.bazel
+++ b/geometry/benchmarking/BUILD.bazel
@@ -20,6 +20,11 @@ drake_cc_binary(
 drake_cc_binary(
     name = "render_benchmark",
     srcs = ["render_benchmark.cc"],
+    defines = select({
+        "//tools/cc_toolchain:apple": [
+        ],
+        "//conditions:default": ["RENDER_ENGINE_GL_SUPPORTED"],
+    }),
     deps = [
         "//common:filesystem",
         "//geometry/render",


### PR DESCRIPTION
I was directly referencing the `render_engine_foo.h` headers. I did this
to template a function on RenderEngine subclass. However, there is no
render_engine_gl.h for mac os. There *is* a MakeRenderEngineGlFactory that
I use; it throws under mac.

Solution:
  1. Stop referencing the header file at all.
  2. Make the gl benchmarks conditional on a macro that says whether
     or not the gl renderer is supported.
  3. Put the macro in the benchmark's build configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14558)
<!-- Reviewable:end -->
