### PR TITLE
doc: Escape 'templated' URL with port number for Jekyll instructions

### DIFF
--- a/doc/documentation_instructions.rst
+++ b/doc/documentation_instructions.rst
@@ -59,7 +59,7 @@ yet.* Currently, this process will generate or serve an empty page (index.html).
 
 It is *not* necessary to build Drake prior to running either command below.
 
-To serve page locally at http://127.0.0.1:<n>::
+To serve page locally at ``http://127.0.0.1:<n>``::
 
     $ bazel run //doc:serve_jekyll [-- --default_port <n>]
 


### PR DESCRIPTION
Came across while reviewing #13832

Before:
> ![image](https://user-images.githubusercontent.com/26719449/105904149-c95b6f80-5fee-11eb-988c-d7df3f7cd3e8.png)

After:
> ![image](https://user-images.githubusercontent.com/26719449/105904253-e728d480-5fee-11eb-9a11-381211aba81d.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14572)
<!-- Reviewable:end -->
