### PR TITLE
tools: Distinguish test_rule_tags vs tags

### DIFF
--- a/bindings/pydrake/doc/BUILD.bazel
+++ b/bindings/pydrake/doc/BUILD.bazel
@@ -40,6 +40,14 @@ drake_py_binary(
     imports = ["."],
     main = "gen_sphinx.py",
     tags = [
+        # This target requires the appropriate prerequisites script for each
+        # platform to be run with the optional --with-doc-only command line
+        # option.
+        "manual",
+    ],
+    test_rule_args = ["--out_dir=<test>"],
+    test_rule_size = "medium",
+    test_rule_tags = [
         # Some (currently disabled) Sphinx extensions try to reach out to the
         # network; we should fail-fast if someone tries to turn them on.
         "block-network",
@@ -50,8 +58,6 @@ drake_py_binary(
         # Test exceeds timeout when run under Valgrind tools.
         "no_valgrind_tools",
     ],
-    test_rule_args = ["--out_dir=<test>"],
-    test_rule_size = "medium",
     deps = [
         ":pydrake_sphinx_extension_py",
         "//bindings/pydrake",  # We must import `pydrake` to document it.

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -40,6 +40,15 @@ drake_py_binary(
         "sample_vimrc",
     ],
     tags = [
+        # This target requires the appropriate prerequisites script for each
+        # platform to be run with the optional --with-doc-only command line
+        # option.
+        "manual",
+    ],
+    test_rule_args = [
+        "--out_dir=<test>",
+    ],
+    test_rule_tags = [
         # Some (currently disabled) Sphinx extensions try to reach out to the
         # network; we should fail-fast if someone tries to turn them on.
         "block-network",
@@ -49,9 +58,6 @@ drake_py_binary(
         "manual",
         # Test exceeds timeout when run under Valgrind tools.
         "no_valgrind_tools",
-    ],
-    test_rule_args = [
-        "--out_dir=<test>",
     ],
     deps = [
         ":sphinx_base",
@@ -105,6 +111,12 @@ drake_py_binary(
     ],
     test_rule_args = [
         "--out_dir=<test>",
+    ],
+    test_rule_tags = [
+        # This target requires the appropriate prerequisites script for each
+        # platform to be run with the optional --with-doc-only command line
+        # option.
+        "manual",
     ],
     deps = [
         ":jekyll_base",

--- a/examples/cubic_polynomial/BUILD.bazel
+++ b/examples/cubic_polynomial/BUILD.bazel
@@ -8,7 +8,7 @@ drake_cc_binary(
     name = "region_of_attraction",
     srcs = ["region_of_attraction.cc"],
     add_test_rule = 1,
-    tags = mosek_test_tags(),
+    test_rule_tags = mosek_test_tags(),
     deps = [
         "//solvers:mathematical_program",
         "//solvers:solve",
@@ -20,7 +20,7 @@ drake_cc_binary(
     name = "backward_reachability",
     srcs = ["backward_reachability.cc"],
     add_test_rule = 1,
-    tags = mosek_test_tags(),
+    test_rule_tags = mosek_test_tags(),
     deps = [
         "//common/proto:call_python",
         "//solvers:mathematical_program",

--- a/examples/kuka_iiwa_arm/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/BUILD.bazel
@@ -100,10 +100,10 @@ drake_cc_binary(
         ":models",
         "//manipulation/models/iiwa_description:models",
     ],
+    test_rule_args = ["--simulation_sec=0.1 --target_realtime_rate=0.0"],
     # TODO(kyle.edwards@kitware.com): Re-enable this test when it no longer
     # causes timeouts in kcov.
-    tags = ["no_kcov"],
-    test_rule_args = ["--simulation_sec=0.1 --target_realtime_rate=0.0"],
+    test_rule_tags = ["no_kcov"],
     deps = [
         ":iiwa_common",
         ":iiwa_lcm",

--- a/examples/manipulation_station/BUILD.bazel
+++ b/examples/manipulation_station/BUILD.bazel
@@ -82,11 +82,11 @@ drake_cc_binary(
         "mock_station_simulation.cc",
     ],
     add_test_rule = 1,
-    tags = vtk_test_tags(),
     test_rule_args = [
         "--target_realtime_rate=0.0",
         "--duration=0.1",
     ],
+    test_rule_tags = vtk_test_tags(),
     deps = [
         ":manipulation_station",
         "//geometry:drake_visualizer",
@@ -106,12 +106,12 @@ drake_cc_binary(
         "proof_of_life.cc",
     ],
     add_test_rule = 1,
-    tags = vtk_test_tags(),
     test_rule_args = [
         "--target_realtime_rate=0.0",
         "--duration=0.1",
         "--test",
     ],
+    test_rule_tags = vtk_test_tags(),
     test_rule_timeout = "moderate",
     deps = [
         ":manipulation_station",
@@ -162,12 +162,12 @@ drake_py_binary(
     name = "joint_teleop",
     srcs = ["joint_teleop.py"],
     add_test_rule = 1,
-    tags = vtk_test_tags(),
     test_rule_args = [
         "--target_realtime_rate=0.0",
         "--duration=0.1",
         "--test",
     ],
+    test_rule_tags = vtk_test_tags(),
     test_rule_timeout = "moderate",  # Frequently exceeds short timeout in dbg.
     deps = [
         "//bindings/pydrake",
@@ -178,14 +178,14 @@ drake_py_binary(
     name = "end_effector_teleop_dualshock4",
     srcs = ["end_effector_teleop_dualshock4.py"],
     add_test_rule = 1,
-    # Disable testing for this module since it will fail on CI
-    # because it assumes that dualshock4 controller is connected.
-    tags = vtk_test_tags() + ["manual"],
     test_rule_args = [
         "--target_realtime_rate=0.0",
         "--duration=0.1",
         "--test",
     ],
+    # Disable testing for this module since it will fail on CI
+    # because it assumes that dualshock4 controller is connected.
+    test_rule_tags = vtk_test_tags() + ["manual"],
     test_rule_timeout = "moderate",  # Frequently exceeds short timeout in dbg.
     deps = [
         ":differential_ik",
@@ -198,12 +198,12 @@ drake_py_binary(
     name = "end_effector_teleop_mouse",
     srcs = ["end_effector_teleop_mouse.py"],
     add_test_rule = 1,
-    tags = vtk_test_tags(),
     test_rule_args = [
         "--target_realtime_rate=0.0",
         "--duration=0.1",
         "--test",
     ],
+    test_rule_tags = vtk_test_tags(),
     test_rule_timeout = "moderate",  # Frequently exceeds short timeout in dbg.
     deps = [
         ":differential_ik",
@@ -216,12 +216,12 @@ drake_py_binary(
     name = "end_effector_teleop_sliders",
     srcs = ["end_effector_teleop_sliders.py"],
     add_test_rule = 1,
-    tags = vtk_test_tags(),
     test_rule_args = [
         "--target_realtime_rate=0.0",
         "--duration=0.1",
         "--test",
     ],
+    test_rule_tags = vtk_test_tags(),
     test_rule_timeout = "moderate",  # Frequently exceeds short timeout in dbg.
     deps = [
         ":differential_ik",

--- a/examples/scene_graph/BUILD.bazel
+++ b/examples/scene_graph/BUILD.bazel
@@ -34,10 +34,10 @@ drake_cc_binary(
     name = "bouncing_ball_run_dynamics",
     srcs = ["bouncing_ball_run_dynamics.cc"],
     add_test_rule = 1,
-    tags = vtk_test_tags(),
     test_rule_args = [
         "--simulation_time=0.1",
     ],
+    test_rule_tags = vtk_test_tags(),
     deps = [
         ":bouncing_ball_plant",
         "//geometry:drake_visualizer",

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -502,6 +502,7 @@ def drake_cc_binary(
         add_test_rule = 0,
         test_rule_args = [],
         test_rule_data = [],
+        test_rule_tags = None,
         test_rule_size = None,
         test_rule_timeout = None,
         test_rule_flaky = 0,
@@ -569,7 +570,7 @@ def drake_cc_binary(
             flaky = test_rule_flaky,
             linkstatic = linkstatic,
             args = test_rule_args,
-            tags = tags + ["nolint"],
+            tags = (test_rule_tags or []) + ["nolint"],
             **kwargs
         )
 

--- a/tools/skylark/drake_py.bzl
+++ b/tools/skylark/drake_py.bzl
@@ -112,6 +112,7 @@ def drake_py_binary(
         add_test_rule = 0,
         test_rule_args = [],
         test_rule_data = [],
+        test_rule_tags = None,
         test_rule_size = None,
         test_rule_timeout = None,
         test_rule_flaky = 0,
@@ -153,7 +154,7 @@ def drake_py_binary(
             size = test_rule_size,
             timeout = test_rule_timeout,
             flaky = test_rule_flaky,
-            tags = tags + ["nolint"],
+            tags = (test_rule_tags or []) + ["nolint"],
             # N.B. Same as the warning in `drake_pybind_cc_googletest`: numpy
             # imports unittest unconditionally.
             allow_import_unittest = True,


### PR DESCRIPTION
Adding test-specific tags to non-test programs is misleading.

(This is a prerequisite for housecleaning our doc tests.)

This PR temporarily increases the `tags = ["manual"]` copy-pasta in our doc folders.  That will evaporate in the next PR #14583.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14581)
<!-- Reviewable:end -->
