### PR TITLE
Expose piecewise quat slerp's orientation getters.

### DIFF
--- a/bindings/pydrake/test/trajectories_test.py
+++ b/bindings/pydrake/test/trajectories_test.py
@@ -226,3 +226,28 @@ class TestTrajectories(unittest.TestCase):
         pq.Append(time=3., quaternion=q)
         pq.Append(time=4., rotation_matrix=R)
         pq.Append(time=5., angle_axis=a)
+
+        # Test getters.
+        pq = PiecewiseQuaternionSlerp(
+            breaks=[0, 1], angle_axes=[a, AngleAxis(np.pi/2, [0, 0, 1])]
+        )
+        np.testing.assert_equal(
+            np.array([1, 0, 0, 0]), pq.orientation(time=0).wxyz()
+        )
+        np.testing.assert_equal(
+            np.array([0, 0, np.pi/2]), pq.angular_velocity(time=0)
+        )
+        np.testing.assert_equal(
+            np.zeros(3), pq.angular_acceleration(time=0)
+        )
+
+        np.testing.assert_equal(
+            np.array([np.cos(np.pi/4), 0, 0, np.sin(np.pi/4)]),
+            pq.orientation(time=1).wxyz(),
+        )
+        np.testing.assert_equal(
+            np.array([0, 0, np.pi/2]), pq.angular_velocity(time=1)
+        )
+        np.testing.assert_equal(
+            np.zeros(3), pq.angular_acceleration(time=1)
+        )

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -234,7 +234,14 @@ PYBIND11_MODULE(trajectories, m) {
           py::overload_cast<const T&, const AngleAxis<T>&>(
               &PiecewiseQuaternionSlerp<T>::Append),
           py::arg("time"), py::arg("angle_axis"),
-          doc.PiecewiseQuaternionSlerp.Append.doc_2args_time_angle_axis);
+          doc.PiecewiseQuaternionSlerp.Append.doc_2args_time_angle_axis)
+      .def("orientation", &PiecewiseQuaternionSlerp<T>::orientation,
+          py::arg("time"), doc.PiecewiseQuaternionSlerp.orientation.doc)
+      .def("angular_velocity", &PiecewiseQuaternionSlerp<T>::angular_velocity,
+          py::arg("time"), doc.PiecewiseQuaternionSlerp.angular_velocity.doc)
+      .def("angular_acceleration",
+          &PiecewiseQuaternionSlerp<T>::angular_acceleration, py::arg("time"),
+          doc.PiecewiseQuaternionSlerp.angular_acceleration.doc);
 }
 
 }  // namespace pydrake

--- a/common/trajectories/piecewise_quaternion.h
+++ b/common/trajectories/piecewise_quaternion.h
@@ -85,30 +85,30 @@ class PiecewiseQuaternionSlerp final : public PiecewiseTrajectory<T> {
 
   /**
    * Interpolates orientation.
-   * @param t Time for interpolation.
-   * @return The interpolated quaternion at `t`.
+   * @param time Time for interpolation.
+   * @return The interpolated quaternion at `time`.
    */
-  Quaternion<T> orientation(const T& t) const;
+  Quaternion<T> orientation(const T& time) const;
 
-  MatrixX<T> value(const T& t) const override {
-    return orientation(t).matrix();
+  MatrixX<T> value(const T& time) const override {
+    return orientation(time).matrix();
   }
 
   /**
    * Interpolates angular velocity.
-   * @param t Time for interpolation.
-   * @return The interpolated angular velocity at `t`,
+   * @param time Time for interpolation.
+   * @return The interpolated angular velocity at `time`,
    * which is constant per segment.
    */
-  Vector3<T> angular_velocity(const T& t) const;
+  Vector3<T> angular_velocity(const T& time) const;
 
   /**
    * Interpolates angular acceleration.
-   * @param t Time for interpolation.
-   * @return The interpolated angular acceleration at `t`,
+   * @param time Time for interpolation.
+   * @return The interpolated angular acceleration at `time`,
    * which is always zero for slerp.
    */
-  Vector3<T> angular_acceleration(const T& t) const;
+  Vector3<T> angular_acceleration(const T& time) const;
 
   /**
    * Getter for the internal quaternion samples.


### PR DESCRIPTION
Relates to #14561

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14585)
<!-- Reviewable:end -->
