### PR TITLE
Revert "Expose piecewise quat slerp's orientation getters."

### DIFF
--- a/bindings/pydrake/test/trajectories_test.py
+++ b/bindings/pydrake/test/trajectories_test.py
@@ -226,28 +226,3 @@ class TestTrajectories(unittest.TestCase):
         pq.Append(time=3., quaternion=q)
         pq.Append(time=4., rotation_matrix=R)
         pq.Append(time=5., angle_axis=a)
-
-        # Test getters.
-        pq = PiecewiseQuaternionSlerp(
-            breaks=[0, 1], angle_axes=[a, AngleAxis(np.pi/2, [0, 0, 1])]
-        )
-        np.testing.assert_equal(
-            np.array([1, 0, 0, 0]), pq.orientation(time=0).wxyz()
-        )
-        np.testing.assert_equal(
-            np.array([0, 0, np.pi/2]), pq.angular_velocity(time=0)
-        )
-        np.testing.assert_equal(
-            np.zeros(3), pq.angular_acceleration(time=0)
-        )
-
-        np.testing.assert_equal(
-            np.array([np.cos(np.pi/4), 0, 0, np.sin(np.pi/4)]),
-            pq.orientation(time=1).wxyz(),
-        )
-        np.testing.assert_equal(
-            np.array([0, 0, np.pi/2]), pq.angular_velocity(time=1)
-        )
-        np.testing.assert_equal(
-            np.zeros(3), pq.angular_acceleration(time=1)
-        )

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -234,14 +234,7 @@ PYBIND11_MODULE(trajectories, m) {
           py::overload_cast<const T&, const AngleAxis<T>&>(
               &PiecewiseQuaternionSlerp<T>::Append),
           py::arg("time"), py::arg("angle_axis"),
-          doc.PiecewiseQuaternionSlerp.Append.doc_2args_time_angle_axis)
-      .def("orientation", &PiecewiseQuaternionSlerp<T>::orientation,
-          py::arg("time"), doc.PiecewiseQuaternionSlerp.orientation.doc)
-      .def("angular_velocity", &PiecewiseQuaternionSlerp<T>::angular_velocity,
-          py::arg("time"), doc.PiecewiseQuaternionSlerp.angular_velocity.doc)
-      .def("angular_acceleration",
-          &PiecewiseQuaternionSlerp<T>::angular_acceleration, py::arg("time"),
-          doc.PiecewiseQuaternionSlerp.angular_acceleration.doc);
+          doc.PiecewiseQuaternionSlerp.Append.doc_2args_time_angle_axis);
 }
 
 }  // namespace pydrake

--- a/common/trajectories/piecewise_quaternion.h
+++ b/common/trajectories/piecewise_quaternion.h
@@ -85,30 +85,30 @@ class PiecewiseQuaternionSlerp final : public PiecewiseTrajectory<T> {
 
   /**
    * Interpolates orientation.
-   * @param time Time for interpolation.
-   * @return The interpolated quaternion at `time`.
+   * @param t Time for interpolation.
+   * @return The interpolated quaternion at `t`.
    */
-  Quaternion<T> orientation(const T& time) const;
+  Quaternion<T> orientation(const T& t) const;
 
-  MatrixX<T> value(const T& time) const override {
-    return orientation(time).matrix();
+  MatrixX<T> value(const T& t) const override {
+    return orientation(t).matrix();
   }
 
   /**
    * Interpolates angular velocity.
-   * @param time Time for interpolation.
-   * @return The interpolated angular velocity at `time`,
+   * @param t Time for interpolation.
+   * @return The interpolated angular velocity at `t`,
    * which is constant per segment.
    */
-  Vector3<T> angular_velocity(const T& time) const;
+  Vector3<T> angular_velocity(const T& t) const;
 
   /**
    * Interpolates angular acceleration.
-   * @param time Time for interpolation.
-   * @return The interpolated angular acceleration at `time`,
+   * @param t Time for interpolation.
+   * @return The interpolated angular acceleration at `t`,
    * which is always zero for slerp.
    */
-  Vector3<T> angular_acceleration(const T& time) const;
+  Vector3<T> angular_acceleration(const T& t) const;
 
   /**
    * Getter for the internal quaternion samples.


### PR DESCRIPTION
Dear @siyuanfeng-tri,

The on-call build cop, @avalenzu, believes that your PR #14585 may have
broken one or more of Drake's continuous integration builds [1]. It is
possible to break a build even if your PR passed continuous integration
pre-merge because additional platforms are tested post-merge.

The specific build failures under investigation are:
https://drake-jenkins.csail.mit.edu/view/Production/job/mac-catalina-clang-bazel-continuous-release/175/

Therefore, the build cop has created this revert PR and started a complete
post-merge build to determine whether your PR was in fact the cause of the
problem. If that build passes, this revert PR will be merged 60 minutes from
now. You can then fix the problem at your leisure, and send a new PR to
reinstate your change.

If you believe your original PR did not actually break the build, please
explain on this thread.

If you believe you can fix the break promptly in lieu of a revert, please
explain on this thread, and send a PR to the build cop for review ASAP.

If you believe your original PR definitely did break the build and should be
reverted, please review and LGTM this PR. This allows the build cop to merge
without waiting for CI results.

For advice on how to handle a build cop revert, see [2].

Thanks!
Your Friendly On-call Build Cop

[1] CI Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Production/
[2] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14588)
<!-- Reviewable:end -->
