### PR TITLE
py common: Deprecate bad alises for Tolerance Type

### DIFF
--- a/bindings/pydrake/common/BUILD.bazel
+++ b/bindings/pydrake/common/BUILD.bazel
@@ -41,6 +41,7 @@ PACKAGE_INFO = get_pybind_package_info("//bindings")
 # dependency cycles with `pydrake:module_py`.
 # TODO(eric.cousineau): Decouple this module from the full-fledged
 # `libdrake.so`.
+# TODO(eric.cousineau): Remove this dependency cycle (#7912).
 drake_pybind_library(
     name = "_init_py",
     cc_deps = [
@@ -378,7 +379,10 @@ install(
 drake_py_unittest(
     name = "module_test",
     data = ["//examples/atlas:models"],
-    deps = [":module_py"],
+    deps = [
+        ":module_py",
+        "//bindings/pydrake/common/test_utilities:deprecation_py",
+    ],
 )
 
 drake_cc_googletest(

--- a/bindings/pydrake/common/deprecation.py
+++ b/bindings/pydrake/common/deprecation.py
@@ -151,7 +151,9 @@ class _DeprecatedDescriptor:
     """
 
     def __init__(self, original, message, *, date=None):
-        assert hasattr(original, '__get__'), "`original` must be a descriptor"
+        assert hasattr(original, '__get__'), (
+            f"`original` must be a descriptor: {original}"
+        )
         self._original = original
         self.__doc__ = self._original.__doc__
         self._message = message

--- a/bindings/pydrake/common/test/module_test.py
+++ b/bindings/pydrake/common/test/module_test.py
@@ -3,6 +3,7 @@ import unittest
 
 import pydrake.common as mut
 import pydrake.common._module_py._testing as mut_testing
+from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 
 
 class TestCommon(unittest.TestCase):
@@ -35,8 +36,17 @@ class TestCommon(unittest.TestCase):
 
     def test_tolerance_type(self):
         # Simply test the spelling
-        mut.ToleranceType.absolute
-        mut.ToleranceType.relative
+        mut.ToleranceType.kAbsolute
+        mut.ToleranceType.kRelative
+        with catch_drake_warnings(expected_count=2):
+            self.assertEqual(
+                mut.ToleranceType.absolute,
+                mut.ToleranceType.kAbsolute,
+            )
+            self.assertEqual(
+                mut.ToleranceType.relative,
+                mut.ToleranceType.kRelative,
+            )
 
     def test_random_distribution(self):
         # Simply test the spelling

--- a/bindings/pydrake/test/polynomial_test.py
+++ b/bindings/pydrake/test/polynomial_test.py
@@ -23,7 +23,7 @@ class TestPolynomial(unittest.TestCase):
         p_i = p.Integral(integration_constant=0)
         self.assertEqual(p_i.GetDegree(), 3)
         self.assertTrue(
-            p.CoefficientsAlmostEqual(p, 1e-14, ToleranceType.relative))
+            p.CoefficientsAlmostEqual(p, 1e-14, ToleranceType.kRelative))
 
     def test_arithmetic(self):
         p = Polynomial([0, 1])

--- a/bindings/pydrake/test/trajectories_test.py
+++ b/bindings/pydrake/test/trajectories_test.py
@@ -174,7 +174,7 @@ class TestTrajectories(unittest.TestCase):
         pp1 = PiecewisePolynomial.FirstOrderHold([0., 1., 2.], x)
         pp2 = PiecewisePolynomial.FirstOrderHold([2., 3., 4.], x)
         self.assertTrue(pp1.isApprox(
-            other=pp1, tol=1e-14, tol_type=ToleranceType.relative))
+            other=pp1, tol=1e-14, tol_type=ToleranceType.kRelative))
         pp1.ConcatenateInTime(other=pp2)
         self.assertEqual(pp1.end_time(), 4.)
 


### PR DESCRIPTION
Do dumb deferred deprecation gymnastics for pydrake.common._module_py
Make assertion error for descriptor deprecator more useful

Resolves #14591
Relates #7912 due to pulling hair out

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14592)
<!-- Reviewable:end -->
