### PR TITLE
[WIP] Modify bazel.rc to permit use of AVX2 and FMA instructions

### DIFF
--- a/common/schema/test/transform_test.cc
+++ b/common/schema/test/transform_test.cc
@@ -20,6 +20,7 @@ rotation: !Rpy { deg: [10, 20, 30] }
 )""";
 
 GTEST_TEST(DeterministicTest, TransformTest) {
+  constexpr double kEps = std::numeric_limits<double>::epsilon();
   Transform transform;
   YamlReadArchive(YAML::Load(deterministic)).Accept(&transform);
 
@@ -31,10 +32,10 @@ GTEST_TEST(DeterministicTest, TransformTest) {
       Eigen::Vector3d(1., 2., 3.));
   EXPECT_TRUE(drake::CompareMatrices(
       transform.GetDeterministicValue().GetAsMatrix34(),
-      expected.GetAsMatrix34()));
+      expected.GetAsMatrix34(), 2*kEps));
   EXPECT_TRUE(drake::CompareMatrices(
       transform.Mean().GetAsMatrix34(),
-      expected.GetAsMatrix34()));
+      expected.GetAsMatrix34(), 2*kEps));
 }
 
 const char* random = R"""(

--- a/common/test/autodiffxd_test.h
+++ b/common/test/autodiffxd_test.h
@@ -58,7 +58,7 @@ class AutoDiffXdTest : public ::testing::Test {
 
     return CompareMatrices(
         value_and_der_x, value_and_der_3,
-        2.0 * std::numeric_limits<double>::epsilon(),
+        4.0 * std::numeric_limits<double>::epsilon(),
         MatrixCompareType::relative)
       << "\n(where xd.size() = " << e_xd.derivatives().size() << ")";
   }

--- a/examples/compass_gait/test/compass_gait_test.cc
+++ b/examples/compass_gait/test/compass_gait_test.cc
@@ -205,7 +205,10 @@ GTEST_TEST(CompassGaitTest, TestCollisionDynamics) {
 
   const double angular_momentum_after =
       CalcAngularMomentum(cg, *next_context, true);
-  EXPECT_NEAR(angular_momentum_before, angular_momentum_after, 5e-15);
+  const double kEps = std::numeric_limits<double>::epsilon();
+  // Use a relative tolerance here if angular momentum is large.
+  const double tol = 8*kEps*std::max(std::abs(angular_momentum_before), 1.);
+  EXPECT_NEAR(angular_momentum_before, angular_momentum_after, tol);
 
   // Ensure that the toe moved forward.
   EXPECT_GT(cg.get_toe_position(*next_context), cg.get_toe_position(*context));

--- a/geometry/proximity/test/distance_to_point_callback_test.cc
+++ b/geometry/proximity/test/distance_to_point_callback_test.cc
@@ -120,9 +120,10 @@ class PointShapeAutoDiffSignedDistanceTester {
     EXPECT_NEAR(grad_W_squared_norm.value(), 1, tolerance_);
     // The gradient of grad_W_squared_norm should be 0.
     if (grad_W_squared_norm.derivatives().size() > 0) {
+      // Looser tolerance required to pass when AVX instructions enabled.
       auto grad_W_unit_length_derivative_compare =
           CompareMatrices(grad_W_squared_norm.derivatives(),
-                          Eigen::VectorXd::Zero(grad_size), tolerance_);
+                          Eigen::VectorXd::Zero(grad_size), 2*tolerance_);
       if (!grad_W_unit_length_derivative_compare) {
         if (error) failure << "\n";
         error = true;

--- a/geometry/proximity/test/mesh_half_space_intersection_test.cc
+++ b/geometry/proximity/test/mesh_half_space_intersection_test.cc
@@ -168,7 +168,8 @@ class MeshHalfspaceIntersectionTest : public ::testing::Test {
   bool AreFacesEquivalent(const SurfaceFace& fa,
                           const SurfaceMesh<double>& mesh_a,
                           const SurfaceFace& fb, const SurfaceMesh<T>& mesh_b) {
-    constexpr double kEps = 10 * std::numeric_limits<double>::epsilon();
+    // Tolerance loosened from 10ε to 16ε to pass with AVX instructions enabled.
+    constexpr double kEps = 16 * std::numeric_limits<double>::epsilon();
     // Get the three vertices from each.
     std::array<Vector3d, 3> vertices_a = {mesh_a.vertex(fa.vertex(0)).r_MV(),
                                           mesh_a.vertex(fa.vertex(1)).r_MV(),

--- a/geometry/proximity/test/mesh_plane_intersection_test.cc
+++ b/geometry/proximity/test/mesh_plane_intersection_test.cc
@@ -299,11 +299,13 @@ class SliceTetWithPlaneTest : public ::testing::Test {
           // product indicates that S *cannot* lie between V0 and V1 (colinear
           // or not) and a positive value equal to |V0S| * |V0V1| indicates
           // colinearity.
-          if (std::abs(p_V0V1_F.dot(p_V0S_F) - d_V0V1 * d_V0S) > kEps) continue;
+          // Tolerance loosened to 2ε to pass when AVX instructions enabled.
+          if (std::abs(p_V0V1_F.dot(p_V0S_F) - d_V0V1 * d_V0S) > 2*kEps)
+            continue;
           // Define weight w such that: S = w * V0 + (1 - w) * V1.
           double w = 1.0 - d_V0S / d_V0V1;
           // The previous test already confirmed colinearity and w >= 0.
-          if (w > 1 + kEps) {
+          if (w > 1 + 2*kEps) {
             return {{},
                     ::testing::AssertionFailure()
                         << "Vertex " << v << " is co-linear with edge " << e

--- a/geometry/proximity/test/obb_test.cc
+++ b/geometry/proximity/test/obb_test.cc
@@ -613,15 +613,12 @@ TEST_F(ObbMakerTestOctahedron, ObbMakerCompute) {
 
   const Obb obb_F = ObbMaker(mesh_F, test_vertices_).Compute();
   EXPECT_TRUE(Contain(obb_F, mesh_F, test_vertices_));
-  // The threshold was set empirically. It is much smaller than the
-  // previous test before vertex transform.
-  EXPECT_NEAR(obb_F.CalcVolume(), 9.741, 0.001);
-
-  // Empirical tolerance for comparing unit vectors from characteristic
-  // equation AX = λX and rigid transform.
-  double kEps = 100. * std::numeric_limits<double>::epsilon();
-  EXPECT_FALSE(CompareMatrices(obb_F.pose().GetAsMatrix4(),
-                               (X_MF * obb_M.pose()).GetAsMatrix4(), kEps));
+  // Show that OBB of the rigid-tranformed octahedron has less than half the
+  // volume of OBB of the original octahedron. Therefore, our algorithm is not
+  // always optimal. This example is an Achilles heel of our method because
+  // the regular octahedron has no preferred direction in the sense of
+  // Principal Component Analysis.
+  EXPECT_LT(obb_F.CalcVolume() / obb_M.CalcVolume(), 0.5);
 }
 
 // TODO(DamrongGuoy): Update or remove this test if we improve the algorithm.

--- a/geometry/proximity/test/penetration_as_point_pair_callback_test.cc
+++ b/geometry/proximity/test/penetration_as_point_pair_callback_test.cc
@@ -244,8 +244,8 @@ class PenetrationAsPointPairCallbackTest : public ::testing::Test {
           &collision_filter_, &X_WGs_double, &point_pairs_double);
       EXPECT_FALSE(Callback<double>(&sphere_A_, &shape, &callback_data_double));
       ASSERT_EQ(point_pairs_double.size(), 1u);
-      EXPECT_EQ(ExtractDoubleOrThrow(first_result.depth),
-                point_pairs_double[0].depth);
+      EXPECT_NEAR(ExtractDoubleOrThrow(first_result.depth),
+                  point_pairs_double[0].depth, kEps);
       EXPECT_TRUE(
           CompareMatrices(math::autoDiffToValueMatrix(first_result.p_WCa),
                           point_pairs_double[0].p_WCa));

--- a/geometry/render/gl_renderer/test/shape_meshes_test.cc
+++ b/geometry/render/gl_renderer/test/shape_meshes_test.cc
@@ -737,7 +737,12 @@ GTEST_TEST(PrimitiveMeshTests, MakeSquarePatch) {
     }
     const Vector3f corner = Vector3f(0.5f, 0.5f, 0.0) * kMeasure;
     EXPECT_TRUE(CompareMatrices(min_pt, -corner, kEps));
-    EXPECT_TRUE(CompareMatrices(max_pt, corner, kEps));
+    // We are using single-precision floating-point numbers. When we use AVX2
+    // + FMA with GCC on Ubuntu 18.04, it failed for the absolute tolerance
+    // kEps = 1.2e-7 with delta = -9.5e-7. That's why we increase that
+    // tolerance ten times here. Interestingly CLang was fine with the
+    // tolerance kEps.
+    EXPECT_TRUE(CompareMatrices(max_pt, corner, 10 * kEps));
 
     const auto expected_n = Vector3f::UnitZ().transpose();
     for (int v = 0; v < mesh_data.positions.rows(); ++v) {

--- a/manipulation/planner/test/robot_plan_interpolator_test.cc
+++ b/manipulation/planner/test/robot_plan_interpolator_test.cc
@@ -172,8 +172,8 @@ void DoTrajectoryTest(InterpolatorType interp_type) {
               << "Failed at interpolator type: " << interp_str;
   }
 
-  // Check that the final knot point has zero acceleration and
-  // velocity.
+  // Check that the final knot point has zero acceleration and velocity.
+  const double kEps = std::numeric_limits<double>::epsilon();
   if (interp_type == InterpolatorType::Cubic ||
       interp_type == InterpolatorType::ZeroOrderHold ||
       interp_type == InterpolatorType::Pchip) {
@@ -186,9 +186,9 @@ void DoTrajectoryTest(InterpolatorType interp_type) {
     const double accel =
         output->get_vector_data(dut.get_acceleration_output_port().get_index())
             ->GetAtIndex(0);
-    EXPECT_FLOAT_EQ(velocity, 0)
+    EXPECT_NEAR(velocity, 0, 8*kEps)
               << "Failed at interpolator type: " << interp_str;
-    EXPECT_FLOAT_EQ(accel, 0)
+    EXPECT_NEAR(accel, 0, 8*kEps)
               << "Failed at interpolator type: " << interp_str;
   }
 
@@ -200,7 +200,7 @@ void DoTrajectoryTest(InterpolatorType interp_type) {
   double position =
       output->get_vector_data(dut.get_state_output_port().get_index())
           ->GetAtIndex(0);
-  EXPECT_DOUBLE_EQ(1, position)
+  EXPECT_NEAR(1, position, 8*kEps)
             << "Failed at interpolator type: " << interp_str;
 
   plan.num_states = 0;
@@ -210,7 +210,7 @@ void DoTrajectoryTest(InterpolatorType interp_type) {
   dut.CalcOutput(*context, output.get());
   position = output->get_vector_data(
       dut.get_state_output_port().get_index())->GetAtIndex(0);
-  EXPECT_DOUBLE_EQ(1, position)
+  EXPECT_NEAR(1, position, 8*kEps)
             << "Failed at interpolator type: " << interp_str;
 }
 

--- a/math/test/rotation_matrix_test.cc
+++ b/math/test/rotation_matrix_test.cc
@@ -310,13 +310,13 @@ GTEST_TEST(RotationMatrix, ConstructorWithRollPitchYaw) {
                     * Eigen::AngleAxisd(r, Vector3d::UnitX())).matrix();
   const RotationMatrix<double> R_eigen(m);
   const RotationMatrix<double> R_rpy(rpy);
-  EXPECT_TRUE(R_rpy.IsNearlyEqualTo(R_eigen, kEpsilon));
+  EXPECT_TRUE(R_rpy.IsNearlyEqualTo(R_eigen, 4*kEpsilon));
 
   RotationMatrixd R1 = RotationMatrix<double>::MakeZRotation(y);
   RotationMatrixd R2 = RotationMatrix<double>::MakeYRotation(p);
   RotationMatrixd R3 = RotationMatrix<double>::MakeXRotation(r);
   RotationMatrixd R_expected = R1 * R2 * R3;
-  EXPECT_TRUE(R_rpy.IsExactlyEqualTo(R_expected));
+  EXPECT_TRUE(R_rpy.IsNearlyEqualTo(R_expected, 4*kEpsilon));
 }
 
 // Test calculating the inverse and transpose of a RotationMatrix.

--- a/multibody/benchmarks/chaotic_babyboot/MG/test/MG_chaotic_babyboot_test.cc
+++ b/multibody/benchmarks/chaotic_babyboot/MG/test/MG_chaotic_babyboot_test.cc
@@ -58,16 +58,17 @@ void CompareExpectedSolutionVsActualSolution(
   // Note: After passing pre-merge CI (continuous integration) and merging this
   // test to master, the test failed post-merge CI on a Macintosh build (for
   // qBDt), so the qADt and qBDt multipliers were made less strict.
+  // Some further tweaks were required to pass with AVX enabled.
   // TODO(@mitiguy) Remove macintosh_scale_factor if Macintosh passes this
   // test without scaling.
   const double absError = MG_chaotic_babyboot.absError;
   const double macintosh_scale_factor = 15;
-  EXPECT_LE(std::abs(qA_difference), 1E2 * absError);
-  EXPECT_LE(std::abs(qB_difference), 1E2 * absError);
+  EXPECT_LE(std::abs(qA_difference), 5E2 * absError);
+  EXPECT_LE(std::abs(qB_difference), 5E2 * absError);
   EXPECT_LE(std::abs(qADt_difference), 5E2 * absError * macintosh_scale_factor);
   EXPECT_LE(std::abs(qBDt_difference), 5E2 * absError * macintosh_scale_factor);
-  EXPECT_LE(std::abs(qADDt_difference), 1E3 * absError);
-  EXPECT_LE(std::abs(qBDDt_difference), 1E3 * absError);
+  EXPECT_LE(std::abs(qADDt_difference), 5E3 * absError);
+  EXPECT_LE(std::abs(qBDDt_difference), 5E3 * absError);
   EXPECT_LE(std::abs(energy_difference), 0.5 * absError);
 }
 

--- a/multibody/benchmarks/free_body/test/multibody_plant_free_body_test.cc
+++ b/multibody/benchmarks/free_body/test/multibody_plant_free_body_test.cc
@@ -442,11 +442,11 @@ void TestKaneExactSolution(FreeBody torque_free_cylinder_kane,
 
   // Ensure Kane's quaternion time-derivative matches expected angular velocity.
   EXPECT_TRUE(math::IsQuaternionAndQuaternionDtEqualAngularVelocityExpressedInB(
-    quat_kane, quatDt_kane, w_expected, 8 * kEpsilon));
+    quat_kane, quatDt_kane, w_expected, 16 * kEpsilon));
 
   // Ensure expected quaternion time-derivative matches Kane's angular velocity.
   EXPECT_TRUE(math::IsQuaternionAndQuaternionDtEqualAngularVelocityExpressedInB(
-      quat_expected, quatDt_expected, w_kane, 8 * kEpsilon));
+      quat_expected, quatDt_expected, w_kane, 16 * kEpsilon));
 }
 
 

--- a/multibody/fixed_fem/dev/test/isoparametric_element_test.cc
+++ b/multibody/fixed_fem/dev/test/isoparametric_element_test.cc
@@ -194,13 +194,13 @@ TEST_F(IsoparametricElementTest, JacobianInverse3DTriangle) {
      dξ/dx should be the pseudoinverse of the Jacobian. */
     EXPECT_TRUE(CompareMatrices(dxidx[i] * dxdxi[i],
                                 MatrixX<double>::Identity(2, 2),
-                                std::numeric_limits<double>::epsilon()));
+                                4.0 * std::numeric_limits<double>::epsilon()));
     // dx/dξ * dξ/dx should be symmetric.
     auto A = dxdxi[i] * dxidx[i];
     EXPECT_TRUE(CompareMatrices(A, A.transpose(),
-                                std::numeric_limits<double>::epsilon()));
+                                4.0 * std::numeric_limits<double>::epsilon()));
     EXPECT_TRUE(CompareMatrices(VectorX<double>::Zero(2), dxidx[i] * n,
-                                std::numeric_limits<double>::epsilon()));
+                                4.0 * std::numeric_limits<double>::epsilon()));
   }
 }
 

--- a/multibody/math/test/spatial_algebra_test.cc
+++ b/multibody/math/test/spatial_algebra_test.cc
@@ -717,7 +717,8 @@ TYPED_TEST(SpatialAccelerationTest, CoriolisAcceleration) {
       the z direction, this contribution points in the positive y direction.*/
       2.0 * w_AP.norm() * V_PQ.translational().norm() * Vector3<T>::UnitY();
 
-  EXPECT_TRUE(A_AQ.IsApprox(A_AQ_expected));
+  constexpr double kEps = std::numeric_limits<double>::epsilon();
+  EXPECT_TRUE(A_AQ.IsApprox(A_AQ_expected, 4*kEps));
 }
 
 // Unit test for the method SpatialAcceleration::Shift().

--- a/multibody/plant/test/multibody_plant_reaction_forces_test.cc
+++ b/multibody/plant/test/multibody_plant_reaction_forces_test.cc
@@ -353,7 +353,10 @@ class SpinningRodTest : public ::testing::Test {
   }
 
   void VerifyJointReactionForces() {
-    const double kTolerance = 20 * std::numeric_limits<double>::epsilon();
+    // Tolerance appears loose here because the absolute tolerance tests below
+    // should really be relative tolerance in some cases since the reaction
+    // forces can be large.
+    const double kTolerance = 32 * std::numeric_limits<double>::epsilon();
 
     // Evaluate the spatial acceleration of the rod.
     const auto& A_WB_all =

--- a/multibody/tree/test/rotational_inertia_test.cc
+++ b/multibody/tree/test/rotational_inertia_test.cc
@@ -303,7 +303,8 @@ GTEST_TEST(RotationalInertia, ShiftToCenterOfMass) {
   const double Iyz = I_BP_Byz + mass * yBcm*zBcm;
   const RotationalInertia<double> expected_I_BBcm_B(
       Ixx, Iyy, Izz, Ixy, Ixz, Iyz);
-  EXPECT_TRUE(I_BBcm_B.IsNearlyEqualTo(expected_I_BBcm_B, 2*kEpsilon));
+  // Tolerance loosened from 2ε to 4ε to pass with AVX instructions enabled.
+  EXPECT_TRUE(I_BBcm_B.IsNearlyEqualTo(expected_I_BBcm_B, 4*kEpsilon));
 }
 
 // Test the method ShiftToThenAwayFromCenterOfMass for a body B's

--- a/solvers/create_constraint.h
+++ b/solvers/create_constraint.h
@@ -248,7 +248,8 @@ Binding<LorentzConeConstraint> ParseLorentzConeConstraint(
  */
 Binding<LorentzConeConstraint> ParseLorentzConeConstraint(
     const symbolic::Expression& linear_expr,
-    const symbolic::Expression& quadratic_expr, double tol = 0);
+    const symbolic::Expression& quadratic_expr,
+    double tol = 4*std::numeric_limits<double>::epsilon());
 
 /*
  * Assist MathematicalProgram::AddRotatedLorentzConeConstraint(...)
@@ -262,7 +263,8 @@ Binding<RotatedLorentzConeConstraint> ParseRotatedLorentzConeConstraint(
 Binding<RotatedLorentzConeConstraint> ParseRotatedLorentzConeConstraint(
     const symbolic::Expression& linear_expr1,
     const symbolic::Expression& linear_expr2,
-    const symbolic::Expression& quadratic_expr, double tol = 0);
+    const symbolic::Expression& quadratic_expr,
+    double tol = 4*std::numeric_limits<double>::epsilon());
 
 // TODO(eric.cousineau): Implement this if variable creation is separated.
 // Format would be (tuple(linear_binding, psd_binding), new_vars)

--- a/solvers/test/constraint_test.cc
+++ b/solvers/test/constraint_test.cc
@@ -595,7 +595,7 @@ GTEST_TEST(testConstraint, testExponentialConeConstraint) {
   Eigen::Vector2d y_expected;
   y_expected(0) = z(0) - z(1) * std::exp(z(2) / z(1));
   y_expected(1) = z(1);
-  const double tol = 5 * std::numeric_limits<double>::epsilon();
+  const double tol = 8 * std::numeric_limits<double>::epsilon();
   EXPECT_TRUE(CompareMatrices(y, y_expected, tol));
 
   // Check autodiff evaluation.

--- a/solvers/test/system_identification_test.cc
+++ b/solvers/test/system_identification_test.cc
@@ -168,10 +168,12 @@ GTEST_TEST(SystemIdentificationTest, BasicEstimateParameters) {
 
     EXPECT_LT(error, 1e-5);
     EXPECT_EQ(estimated_params.size(), 3u);
+    const double kEps = std::numeric_limits<double>::epsilon();
     for (const auto& var : {a_var, b_var, c_var}) {
       // `9 * error` here in case all of the RMS error was in a single term.
+      // We also need an absolute tolerance here in case error is very near 0.
       EXPECT_NEAR(estimated_params[var], expected_params.at(var),
-                  9 * error);
+                  std::max(9 * error, 64 * kEps));
     }
   }
 

--- a/systems/primitives/test/symbolic_vector_system_test.cc
+++ b/systems/primitives/test/symbolic_vector_system_test.cc
@@ -683,6 +683,7 @@ class SymbolicVectorSystemAutoDiffXdTest : public SymbolicVectorSystemTest {
 };
 
 TEST_F(SymbolicVectorSystemAutoDiffXdTest, AutodiffXdFullGradient) {
+  constexpr double kEps = std::numeric_limits<double>::epsilon();
   const VectorX<AutoDiffXd> txup = math::initializeAutoDiff(txupval_);
   SetContext(txup);
 
@@ -690,17 +691,20 @@ TEST_F(SymbolicVectorSystemAutoDiffXdTest, AutodiffXdFullGradient) {
       autodiff_system_->EvalTimeDerivatives(*context_).CopyToVector();
   EXPECT_TRUE(
       CompareMatrices(math::autoDiffToValueMatrix(xdotval),
-                      Vector1d{-xval_ * pval_[0] + xval_ * xval_ * xval_}));
+                      Vector1d{-xval_ * pval_[0] + xval_ * xval_ * xval_},
+                      2*kEps));
   EXPECT_TRUE(
-      CompareMatrices(xdotval[0].derivatives(), expected_xdotval0_deriv_));
+      CompareMatrices(xdotval[0].derivatives(), expected_xdotval0_deriv_,
+                      2*kEps));
 
   const auto& yval = autodiff_system_->get_output_port(0)
                          .template Eval<BasicVector<AutoDiffXd>>(*context_)
                          .get_value();
   EXPECT_TRUE(CompareMatrices(
       math::autoDiffToValueMatrix(yval),
-      Vector1d{tval_ + 2 * uval_[0] + 3 * uval_[1] + pval_[1]}));
-  EXPECT_TRUE(CompareMatrices(yval[0].derivatives(), expected_yval0_deriv_));
+      Vector1d{tval_ + 2 * uval_[0] + 3 * uval_[1] + pval_[1]}, 2*kEps));
+  EXPECT_TRUE(CompareMatrices(yval[0].derivatives(), expected_yval0_deriv_,
+                              2*kEps));
 }
 
 TEST_F(SymbolicVectorSystemAutoDiffXdTest, AutodiffXdGradientRelativeToInput) {
@@ -726,6 +730,7 @@ TEST_F(SymbolicVectorSystemAutoDiffXdTest, AutodiffXdGradientRelativeToInput) {
 // Similar to AutodiffXdGradientRelativeToInput, but this time with some empty
 // derivatives.
 TEST_F(SymbolicVectorSystemAutoDiffXdTest, AutodiffXdGradientRelativeToState) {
+  constexpr double kEps = std::numeric_limits<double>::epsilon();
   VectorX<AutoDiffXd> txup = txupval_;
   txup.head<2>() = math::initializeAutoDiff(txupval_.head<2>());
   SetContext(txup);
@@ -733,13 +738,13 @@ TEST_F(SymbolicVectorSystemAutoDiffXdTest, AutodiffXdGradientRelativeToState) {
   const auto xdotval =
       autodiff_system_->EvalTimeDerivatives(*context_).CopyToVector();
   EXPECT_TRUE(CompareMatrices(xdotval[0].derivatives(),
-                              expected_xdotval0_deriv_.head<2>()));
+                              expected_xdotval0_deriv_.head<2>(), kEps));
 
   const auto& yval = autodiff_system_->get_output_port(0)
                          .template Eval<BasicVector<AutoDiffXd>>(*context_)
                          .get_value();
   EXPECT_TRUE(CompareMatrices(yval[0].derivatives(),
-                              expected_yval0_deriv_.head<2>()));
+                              expected_yval0_deriv_.head<2>(), kEps));
 }
 
 TEST_F(SymbolicVectorSystemAutoDiffXdTest,

--- a/tools/cc_toolchain/bazel.rc
+++ b/tools/cc_toolchain/bazel.rc
@@ -1,9 +1,13 @@
 # Disable ccache due to incompatibility with Bazel.
 build --action_env=CCACHE_DISABLE=1
 
-# Add C++17 compiler flags.
-build --cxxopt=-std=c++17
-build --host_cxxopt=-std=c++17
+# Add C++17 compiler flags and enable use of 256-bit AVX2 a FMA instructions.
+# The tune=haswell setting encourages the optimizer to choose 256-bit
+# instructions rather than pairs of 128-bit ones.
+build --cxxopt=-std=c++17 --cxxopt=-mavx2 --cxxopt=-mfma \
+      --cxxopt=-mtune=haswell
+build --host_cxxopt=-std=c++17 --host_cxxopt=-mavx2 --host_cxxopt=-mfma \
+      --host_cxxopt=-mtune=haswell
 
 # When compiling with Drake as the main WORKSPACE (i.e., if and only if this
 # rcfile is loaded), we enable -Werror by default for Drake's *own* targets,


### PR DESCRIPTION
We have been exploring speedups for Drake exploiting SIMD parallelism. To deploy these speedups would require that Drake be compiled with SIMD instructions. This PR does nothing but add the compiler flags to allow that for the AVX2 and FMA (fused multiply-add) instructions that were introduced with Haswell in 2013. 

I believe these 8-year old instructions will be available on all the Intel hardware Drake users are likely to run on (though I'm not certain yet about AMD support for FMA).  We'll have to use different flags when we support ARM.

@jamiesnape @jwnimmer-tri thoughts on this change?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14594)
<!-- Reviewable:end -->
