### PR TITLE
Implement external force in ElasticityElement/Model

### DIFF
--- a/multibody/fixed_fem/dev/elasticity_element.h
+++ b/multibody/fixed_fem/dev/elasticity_element.h
@@ -148,6 +148,33 @@ class ElasticityElement : public FemElement<DerivedElement, DerivedTraits> {
     return elastic_energy;
   }
 
+  /** Accumulates the total external force exerted on the %ElasticityElement at
+   the given `state` into the output parameter `external_force`.
+   @pre external_force != nullptr. */
+  void AddExternalForce(
+      const FemState<DerivedElement>& state,
+      EigenPtr<Vector<T, Traits::kNumDofs>> external_force) const {
+    DRAKE_ASSERT(external_force != nullptr);
+    /* So far, the only external force is gravity. */
+    *external_force += gravity_force_;
+  }
+
+  /** Computes the gravity force on each node in the element using the stored
+   mass and gravity vector. */
+  void PrecomputeGravityForce(
+      const Vector<T, Traits::kSpatialDimension>& gravity) {
+    constexpr int kDim = Traits::kSpatialDimension;
+    // TODO(xuchenhan-tri): Consider caching the lumped mass locally when it is
+    //  used for more than computing the gravity force.
+    const auto& lumped_mass = mass_matrix_.rowwise().sum();
+    for (int i = 0; i < Traits::kNumNodes; ++i) {
+      /* The following computation is equivalent to performing the matrix-vector
+       multiplication of the mass matrix and the stacked gravity vector. */
+      gravity_force_.template segment<kDim>(kDim * i) =
+          lumped_mass.template segment<kDim>(kDim * i).cwiseProduct(gravity);
+    }
+  }
+
  protected:
   /** Assignment and copy constructions are prohibited. Move constructor is
    allowed so that derived elasticity elements can likewise implement the move
@@ -157,25 +184,33 @@ class ElasticityElement : public FemElement<DerivedElement, DerivedTraits> {
   const ElasticityElement& operator=(const ElasticityElement&) = delete;
   ElasticityElement&& operator=(const ElasticityElement&&) = delete;
 
-  /** Constructs a new ElasticityElement. The constructor is made protected
-   because ElasticityElement should not be constructed directly. Use the
-   constructor of the derived classes instead.
+  /** Constructs a new ElasticityElement. In that process, precomputes the mass
+   matrix and the gravity force acting on the element. The constructor is made
+   protected because ElasticityElement should not be constructed directly. Use
+   the constructor of the derived classes instead.
    @param[in] element_index    The index of the new element.
    @param[in] node_indices    The node indices of the nodes of this element.
    @param[in] constitutive_model    The ConstitutiveModel to be used for this
    element.
    @param[in] reference_positions    The positions (in world frame) of the nodes
    of this element in the reference configuration.
-   @pre element_index must be valid. */
+   @param[in] denstiy    The mass density of the element with unit kg/m³.
+   @param[in] gravity    The gravitational accleration (in world frame) for the
+   new element with unit m/s².
+   @pre element_index must be valid.
+   @pre density > 0. */
   ElasticityElement(
       ElementIndex element_index,
       const std::array<NodeIndex, Traits::kNumNodes>& node_indices,
       const ConstitutiveModelType& constitutive_model,
       const Eigen::Ref<
           const Eigen::Matrix<T, Traits::kSpatialDimension, Traits::kNumNodes>>&
-          reference_positions)
+          reference_positions,
+      const T& density, const Vector<T, Traits::kSpatialDimension>& gravity)
       : FemElement<DerivedElement, DerivedTraits>(element_index, node_indices),
-        constitutive_model_(constitutive_model) {
+        constitutive_model_(constitutive_model),
+        density_(density) {
+    DRAKE_DEMAND(density_ > 0);
     /* Find the Jacobian of the change of variable function X(ξ). */
     const std::array<
         Eigen::Matrix<T, Traits::kSpatialDimension, Traits::kNaturalDimension>,
@@ -228,6 +263,11 @@ class ElasticityElement : public FemElement<DerivedElement, DerivedTraits> {
     for (int q = 0; q < Traits::kNumQuadraturePoints; ++q) {
       dSdX_transpose_[q] = (dSdxi[q] * dxidX_[q]).transpose();
     }
+    /* Gravity force depends on mass, which depends on volume. Therefore we must
+     compute volume, mass, gravity in that order. */
+    mass_matrix_ = PrecomputeMassMatrix();
+
+    PrecomputeGravityForce(gravity);
   }
 
   /** Adds the negative elastic force on the nodes of this element into the
@@ -331,6 +371,15 @@ class ElasticityElement : public FemElement<DerivedElement, DerivedTraits> {
     return reference_volume_;
   }
 
+  const Eigen::Matrix<T, Traits::kNumDofs, Traits::kNumDofs>& mass_matrix()
+      const {
+    return mass_matrix_;
+  }
+
+  const Vector<T, Traits::kNumDofs>& gravity_force() const {
+    return gravity_force_;
+  }
+
  private:
   /* Friend the base class so that FemElement::ComputeData() can reach its
    implementation. */
@@ -427,6 +476,40 @@ class ElasticityElement : public FemElement<DerivedElement, DerivedTraits> {
     return static_cast<const DerivedElement&>(*this);
   }
 
+  Eigen::Matrix<T, Traits::kNumDofs, Traits::kNumDofs> PrecomputeMassMatrix()
+      const {
+    Eigen::Matrix<T, Traits::kNumDofs, Traits::kNumDofs> mass =
+        Eigen::Matrix<T, Traits::kNumDofs, Traits::kNumDofs>::Zero();
+    const std::array<Vector<T, Traits::kNumNodes>,
+                     Traits::kNumQuadraturePoints>& S =
+        isoparametric_element().GetShapeFunctions();
+    /* S_mat is the matrix representation of S. */
+    Eigen::Matrix<T, Traits::kNumNodes, Traits::kNumQuadraturePoints> S_mat;
+    for (int q = 0; q < Traits::kNumQuadraturePoints; ++q) {
+      S_mat.col(q) = S[q];
+    }
+    /* weighted_S stores the shape function weighted by the reference
+     volume of the quadrature point. */
+    Eigen::Matrix<T, Traits::kNumNodes, Traits::kNumQuadraturePoints>
+        weighted_S(S_mat);
+    for (int q = 0; q < Traits::kNumQuadraturePoints; ++q) {
+      weighted_S.col(q) *= reference_volume_[q];
+    }
+    /* weighted_SST = weighted_S * Sᵀ. The ij-th entry approximates the integral
+     ∫SᵢSⱼ dX */
+    Eigen::Matrix<T, Traits::kNumNodes, Traits::kNumNodes> weighted_SST =
+        weighted_S * S_mat.transpose();
+    constexpr int kDim = Traits::kSolutionDimension;
+    for (int i = 0; i < Traits::kNumNodes; ++i) {
+      for (int j = 0; j < Traits::kNumNodes; ++j) {
+        mass.template block<kDim, kDim>(kDim * i, kDim * j) =
+            Eigen::Matrix<T, kDim, kDim>::Identity() * weighted_SST(i, j) *
+            density_;
+      }
+    }
+    return mass;
+  }
+
   // TODO(xuchenhan-tri): Consider bumping this up into FemElement when new
   //  FemElement types are added.
   /* The quadrature rule used for this element. */
@@ -452,6 +535,13 @@ class ElasticityElement : public FemElement<DerivedElement, DerivedTraits> {
    reference domain, sum f(q)*reference_volume_[q] over all the quadrature
    points q in the element. */
   std::array<T, Traits::kNumQuadraturePoints> reference_volume_;
+  /* The mass density of the element in the reference configuration with
+   unit kg/m³. */
+  T density_;
+  /* Precomputed mass matrix. */
+  Eigen::Matrix<T, Traits::kNumDofs, Traits::kNumDofs> mass_matrix_;
+  /* Gravity force on the element. */
+  Vector<T, Traits::kNumDofs> gravity_force_;
 };
 }  // namespace fixed_fem
 }  // namespace multibody

--- a/multibody/fixed_fem/dev/fem_model.h
+++ b/multibody/fixed_fem/dev/fem_model.h
@@ -214,6 +214,12 @@ class FemModel {
     return elements_[i];
   }
 
+  Element& mutable_element(ElementIndex i) {
+    DRAKE_ASSERT(i.is_valid());
+    DRAKE_ASSERT(i < num_elements());
+    return elements_[i];
+  }
+
   /** Moves the input `element` into the vector of elements held by `this`
    %FemModel. */
   void AddElement(Element&& element) {

--- a/multibody/fixed_fem/dev/static_elasticity_model.h
+++ b/multibody/fixed_fem/dev/static_elasticity_model.h
@@ -29,7 +29,8 @@ class StaticElasticityModel : public ElasticityModel<Element> {
   /** Add tetrahedral StaticElasticityElements to the %StaticElasticityModel
    from a mesh. The positions of the vertices in the mesh are used as reference
    positions for the volume as well as the generalized positions for the model
-   in MakeFemState().
+   in MakeFemState(). The gravity constant for the newly added elements is given
+   by ElasticityModel::gravity().
    @param mesh    The input tetrahedral mesh that describes the connectivity and
    the positions of the vertices. Each geometry::VolumeElement in the input
    `mesh` will generate a StaticElasticityElement in this
@@ -39,7 +40,7 @@ class StaticElasticityModel : public ElasticityModel<Element> {
    @throw std::exception if Element::Traits::kNumNodes != 4. */
   void AddStaticElasticityElementsFromTetMesh(
       const geometry::VolumeMesh<T>& mesh,
-      const ConstitutiveModel& constitutive_model) {
+      const ConstitutiveModel& constitutive_model, const T& density) {
     /* Alias for more readability. */
     constexpr int kDim = Element::Traits::kSolutionDimension;
     constexpr int kNumNodes = Element::Traits::kNumNodes;
@@ -67,7 +68,8 @@ class StaticElasticityModel : public ElasticityModel<Element> {
       }
       ElementIndex next_element_index = ElementIndex(this->num_elements());
       this->AddElement(next_element_index, element_node_indices,
-                       constitutive_model, element_reference_positions);
+                       constitutive_model, element_reference_positions, density,
+                       this->gravity());
     }
 
     this->increment_num_nodes(num_new_vertices);

--- a/multibody/fixed_fem/dev/test/static_elasticity_element_test.cc
+++ b/multibody/fixed_fem/dev/test/static_elasticity_element_test.cc
@@ -33,6 +33,8 @@ class StaticElasticityElementTest : public ::testing::Test {
   static constexpr int kNumNodes = ElementType::Traits::kNumNodes;
   const std::array<NodeIndex, kNumNodes> dummy_node_indices = {
       {NodeIndex(0), NodeIndex(1), NodeIndex(2), NodeIndex(3)}};
+  const T kDensity{0.123};
+  const Vector3<T> kGravity_W{0, 0, -9.8};
 
   void SetUp() override {
     SetupElement();
@@ -44,7 +46,7 @@ class StaticElasticityElementTest : public ::testing::Test {
         get_reference_positions();
     ConstitutiveModelType model(1, 0.25);
     elements_.emplace_back(kZeroIndex, dummy_node_indices, model,
-                           reference_positions);
+                           reference_positions, kDensity, kGravity_W);
   }
 
   /* Set up a state with arbitrary positions. */
@@ -110,12 +112,14 @@ TEST_F(StaticElasticityElementTest, Constructor) {
 
 /* Tests that the calculation of the residual calls the calculation of the
  negative elastic force and the external force. */
-TEST_F(StaticElasticityElementTest, ResidualIsNegativeElasticForce) {
+TEST_F(StaticElasticityElementTest,
+       ResidualIsNegativeElasticForcePlusExternalForce) {
   Vector<T, kNumDofs> residual;
   element().CalcResidual(*state_, &residual);
-  // TODO(xuchenhan-tri): Modify this test to account for external forces when
-  //  external forces are added. */
-  EXPECT_TRUE(CompareMatrices(CalcNegativeElasticForce(), residual, 0));
+  Vector<T, kNumDofs> external_force = Vector<T, kNumDofs>::Zero();
+  element().AddExternalForce(*state_, &external_force);
+  EXPECT_TRUE(CompareMatrices(CalcNegativeElasticForce() + external_force,
+                              residual, 0));
 }
 
 /* Tests that the calculation of the stiffness matrix calls the calculation of

--- a/multibody/fixed_fem/dev/test/static_elasticity_model_test.cc
+++ b/multibody/fixed_fem/dev/test/static_elasticity_model_test.cc
@@ -37,6 +37,7 @@ const double kPoissonRatio = 0.456;
 constexpr int kNumCubeVertices = 8;
 constexpr int kNumDofs = kNumCubeVertices * kSolutionDimension;
 constexpr int kNumElements = 6;
+const T kDensity{0.123};
 
 class StaticElasticityModelTest : public ::testing::Test {
  protected:
@@ -52,7 +53,8 @@ class StaticElasticityModelTest : public ::testing::Test {
   void SetUp() override {
     geometry::VolumeMesh<T> mesh = MakeBoxTetMesh();
     ConstitutiveModelType constitutive_model(kYoungsModulus, kPoissonRatio);
-    model_.AddStaticElasticityElementsFromTetMesh(mesh, constitutive_model);
+    model_.AddStaticElasticityElementsFromTetMesh(mesh, constitutive_model,
+                                                  kDensity);
   }
 
   /* Returns an arbitrary perturbation to the reference configuration of the
@@ -88,13 +90,15 @@ TEST_F(StaticElasticityModelTest, Geometry) {
 }
 
 /* Tests that the residual of the model is the derivative of the elastic energy
- with respect to the generalized positions when there is no external force. */
-TEST_F(StaticElasticityModelTest, ResidualIsEnergyDerivative) {
+ with respect to the generalized positions plus external force. */
+TEST_F(StaticElasticityModelTest, ResidualIsEnergyDerivativePlusExternalForce) {
   FemState<ElementType> state = MakeDeformedState();
   T energy = model_.CalcElasticEnergy(state);
   VectorX<T> residual(state.num_generalized_positions());
   model_.CalcResidual(state, &residual);
-  EXPECT_TRUE(CompareMatrices(energy.derivatives(), residual,
+  VectorX<T> external_force(state.num_generalized_positions());
+  model_.CalcExternalForce(state, &external_force);
+  EXPECT_TRUE(CompareMatrices(energy.derivatives() + external_force, residual,
                               std::numeric_limits<double>::epsilon()));
 }
 
@@ -130,7 +134,8 @@ TEST_F(StaticElasticityModelTest, TangentMatrixIsResidualDerivative) {
 TEST_F(StaticElasticityModelTest, MultipleMesh) {
   geometry::VolumeMesh<T> mesh = MakeBoxTetMesh();
   ConstitutiveModelType constitutive_model(kYoungsModulus, kPoissonRatio);
-  model_.AddStaticElasticityElementsFromTetMesh(mesh, constitutive_model);
+  model_.AddStaticElasticityElementsFromTetMesh(mesh, constitutive_model,
+                                                kDensity);
 
   EXPECT_EQ(model_.num_nodes(), 2 * kNumCubeVertices);
   /* Each cube is split into 6 tetrahedra. */
@@ -143,6 +148,26 @@ TEST_F(StaticElasticityModelTest, MultipleMesh) {
   model_.CalcResidual(state, &residual);
   EXPECT_TRUE(
       CompareMatrices(residual.head(kNumDofs), residual.tail(kNumDofs), 0));
+}
+
+/* Tests that the total external force exerted on a model matches the expected
+ value. */
+TEST_F(StaticElasticityModelTest, ExternalForce) {
+  FemState<ElementType> state = MakeDeformedState();
+  const Vector3<T> gravity{1, 0, 0};
+  model_.SetGravity(gravity);
+  VectorX<T> external_force(state.num_generalized_positions());
+  model_.CalcExternalForce(state, &external_force);
+  Vector3<T> total_external_force = Vector3<T>::Zero();
+  for (int i = 0; i < model_.num_nodes(); ++i) {
+    total_external_force += external_force.template segment<3>(i * 3);
+  }
+  T volume = MakeBoxTetMesh().CalcVolume();
+  // TODO(xuchenhan-tri) We are assuming that the only external force is gravity
+  //  now. This might change in the future. Change this test accordingly.
+  Vector3<T> expected_external_force = gravity * kDensity * volume;
+  EXPECT_TRUE(CompareMatrices(total_external_force, expected_external_force,
+                              std::numeric_limits<double>::epsilon()));
 }
 }  // namespace
 }  // namespace fixed_fem


### PR DESCRIPTION
- Move mass matrix calculation from DynamicElasticityElement to the base
class, ElasticityElement.

- Provide methods set gravity vector.

- Provide methods to precompute the gravity force on the element.

- Modify existing tests to accomodate for the new term that appears in
residual calculation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14595)
<!-- Reviewable:end -->
