### PR TITLE
Update VGT external for new device voxelizer interface

### DIFF
--- a/tools/workspace/voxelized_geometry_tools/package.BUILD.bazel
+++ b/tools/workspace/voxelized_geometry_tools/package.BUILD.bazel
@@ -33,6 +33,7 @@ cc_library(
     ],
     hdrs = [
         "include/voxelized_geometry_tools/cuda_voxelization_helpers.h",
+        "include/voxelized_geometry_tools/device_voxelization_interface.hpp",
     ],
     includes = ["include"],
     deps = [
@@ -47,6 +48,7 @@ cc_library(
         "src/voxelized_geometry_tools/dummy_opencl_voxelization_helpers.cc",
     ],
     hdrs = [
+        "include/voxelized_geometry_tools/device_voxelization_interface.hpp",
         "include/voxelized_geometry_tools/opencl_voxelization_helpers.h",
     ],
     includes = ["include"],
@@ -60,15 +62,14 @@ cc_library(
     name = "pointcloud_voxelization",
     srcs = [
         "src/voxelized_geometry_tools/cpu_pointcloud_voxelization.cpp",
-        "src/voxelized_geometry_tools/cuda_pointcloud_voxelization.cpp",
-        "src/voxelized_geometry_tools/opencl_pointcloud_voxelization.cpp",
+        "src/voxelized_geometry_tools/device_pointcloud_voxelization.cpp",
         "src/voxelized_geometry_tools/pointcloud_voxelization.cpp",
     ],
     hdrs = [
         "include/voxelized_geometry_tools/cpu_pointcloud_voxelization.hpp",
-        "include/voxelized_geometry_tools/cuda_pointcloud_voxelization.hpp",
         "include/voxelized_geometry_tools/cuda_voxelization_helpers.h",
-        "include/voxelized_geometry_tools/opencl_pointcloud_voxelization.hpp",
+        "include/voxelized_geometry_tools/device_pointcloud_voxelization.hpp",
+        "include/voxelized_geometry_tools/device_voxelization_interface.hpp",
         "include/voxelized_geometry_tools/opencl_voxelization_helpers.h",
         "include/voxelized_geometry_tools/pointcloud_voxelization.hpp",
         "include/voxelized_geometry_tools/pointcloud_voxelization_interface.hpp",  # noqa

--- a/tools/workspace/voxelized_geometry_tools/repository.bzl
+++ b/tools/workspace/voxelized_geometry_tools/repository.bzl
@@ -14,8 +14,8 @@ def voxelized_geometry_tools_repository(
         repository = "ToyotaResearchInstitute/voxelized_geometry_tools",
         # When updating, ensure that any new unit tests are reflected in
         # package.BUILD.bazel and BUILD.bazel in drake.
-        commit = "02aa5773c0cfd33aaa7e54cf606beaffd78e250f",
-        sha256 = "d0a19668e7c578bd4c0b41b836d462dc03b2f66cfe7d4a78ec96386ea8c44132",  # noqa
+        commit = "ce62e93546f6468e0689fa8bdce21d05f816f935",
+        sha256 = "f5b4b0a942cfab0c0e205c9aca090855fce5a54e0dfa7bd4b75a93385b498f1b",  # noqa
         build_file = "//tools/workspace/voxelized_geometry_tools:package.BUILD.bazel",  # noqa
         mirrors = mirrors,
     )


### PR DESCRIPTION
Updates `voxelized_geometry_tools` external to new device pointcloud voxelizer interface that reduces duplication between CUDA and OpenCL voxelizers (and simplifies stubbing them out).

+@ggould-tri for feature review, thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14600)
<!-- Reviewable:end -->
