### PR TITLE
primitives: Promote some ASSERT to DEMAND

### DIFF
--- a/systems/primitives/affine_system.cc
+++ b/systems/primitives/affine_system.cc
@@ -281,7 +281,7 @@ unique_ptr<AffineSystem<T>> AffineSystem<T>::MakeAffineSystem(
   //
   // where x = state_vars and u = input_vars.
   const int num_states = state_vars.size();
-  DRAKE_ASSERT(num_states == dynamics.size());
+  DRAKE_DEMAND(num_states == dynamics.size());
   const int num_inputs = input_vars.size();
   const int num_outputs = output.size();
 

--- a/systems/primitives/first_order_low_pass_filter.cc
+++ b/systems/primitives/first_order_low_pass_filter.cc
@@ -22,8 +22,8 @@ FirstOrderLowPassFilter<T>::FirstOrderLowPassFilter(
           SystemTypeTag<FirstOrderLowPassFilter>{},
           time_constants.size(), time_constants.size()),
       time_constants_(time_constants) {
-  DRAKE_ASSERT(time_constants.size() > 0);
-  DRAKE_ASSERT((time_constants.array() > 0).all());
+  DRAKE_DEMAND(time_constants.size() > 0);
+  DRAKE_DEMAND((time_constants.array() > 0).all());
   this->DeclareContinuousState(time_constants.size());
 }
 
@@ -56,7 +56,7 @@ void FirstOrderLowPassFilter<T>::set_initial_output_value(
     Context<T>* context, const Eigen::Ref<const VectorX<T>>& z0) const {
   VectorBase<T>& state_vector = context->get_mutable_continuous_state_vector();
   // Asserts that the input value is a column vector of the appropriate size.
-  DRAKE_ASSERT(z0.rows() == state_vector.size() && z0.cols() == 1);
+  DRAKE_DEMAND(z0.rows() == state_vector.size() && z0.cols() == 1);
   state_vector.SetFromVector(z0);
 }
 

--- a/systems/primitives/integrator.cc
+++ b/systems/primitives/integrator.cc
@@ -26,7 +26,7 @@ void Integrator<T>::set_integral_value(
     Context<T>* context, const Eigen::Ref<const VectorX<T>>& value) const {
   VectorBase<T>& state_vector = context->get_mutable_continuous_state_vector();
   // Asserts that the input value is a column vector of the appropriate size.
-  DRAKE_ASSERT(value.rows() == state_vector.size() && value.cols() == 1);
+  DRAKE_DEMAND(value.rows() == state_vector.size() && value.cols() == 1);
   state_vector.SetFromVector(value);
 }
 

--- a/systems/primitives/linear_system.cc
+++ b/systems/primitives/linear_system.cc
@@ -63,7 +63,7 @@ unique_ptr<LinearSystem<T>> LinearSystem<T>::MakeLinearSystem(
   //
   // where x = state_vars and u = input_vars.
   const int num_states = state_vars.size();
-  DRAKE_ASSERT(num_states == dynamics.size());
+  DRAKE_DEMAND(num_states == dynamics.size());
   const int num_inputs = input_vars.size();
   const int num_outputs = output.size();
 


### PR DESCRIPTION
These checks are not performance-critical, and are checking user input (not internal invariants), so we should always leave them armed.

Having these off by default let a bug slip through into Anzu.

(Of course, we could work to improve the error messages & etc; this is just the minimum delta from the current state of affairs.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14615)
<!-- Reviewable:end -->
