### PR TITLE
Implement DynamicElasticityModel and NewmarkScheme

### DIFF
--- a/multibody/fixed_fem/dev/BUILD.bazel
+++ b/multibody/fixed_fem/dev/BUILD.bazel
@@ -63,6 +63,18 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "dynamic_elasticity_model",
+    hdrs = [
+        "dynamic_elasticity_model.h",
+    ],
+    deps = [
+        ":damping_model",
+        ":elasticity_model",
+        "//geometry/proximity:volume_mesh",
+    ],
+)
+
+drake_cc_library(
     name = "eigen_conjugate_gradient_solver",
     hdrs = [
         "eigen_conjugate_gradient_solver.h",
@@ -212,6 +224,16 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "newmark_scheme",
+    hdrs = [
+        "newmark_scheme.h",
+    ],
+    deps = [
+        ":state_updater",
+    ],
+)
+
+drake_cc_library(
     name = "quadrature",
     hdrs = [
         "quadrature.h",
@@ -309,6 +331,21 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "dynamic_elasticity_model_test",
+    deps = [
+        ":dynamic_elasticity_element",
+        ":dynamic_elasticity_model",
+        ":linear_constitutive_model",
+        ":linear_simplex_element",
+        ":newmark_scheme",
+        ":simplex_gaussian_quadrature",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//geometry/proximity:make_box_mesh",
+        "//math:gradient",
+    ],
+)
+
+drake_cc_googletest(
     name = "eigen_conjugate_gradient_solver_test",
     deps = [
         ":eigen_conjugate_gradient_solver",
@@ -385,6 +422,15 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "newmark_scheme_test",
+    deps = [
+        ":dummy_element",
+        ":newmark_scheme",
+        "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
     name = "simplex_gaussian_quadrature_test",
     deps = [
         ":simplex_gaussian_quadrature",
@@ -425,6 +471,7 @@ drake_cc_googletest(
         ":dummy_element",
         ":zeroth_order_state_updater",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/multibody/fixed_fem/dev/dynamic_elasticity_element.h
+++ b/multibody/fixed_fem/dev/dynamic_elasticity_element.h
@@ -83,7 +83,8 @@ class DynamicElasticityElement final
     /* residual = Ma-fₑ(x)-fᵥ(x, v)+fₑₓₜ, where M is the mass matrix, fₑ(x) is
      the elastic force, fᵥ(x, v) is the damping force and fₑₓₜ is the external
      force. */
-    *residual += this->mass_matrix() * state.qddot();
+    *residual += this->mass_matrix() *
+                 this->ExtractElementDofs(this->node_indices(), state.qddot());
     this->AddNegativeElasticForce(state, residual);
     AddNegativeDampingForce(state, residual);
     this->AddExternalForce(state, residual);
@@ -100,7 +101,9 @@ class DynamicElasticityElement final
     /* Note that the damping force fᵥ = -D * v, where D is the damping matrix.
      As we are accumulating the negative damping force here, the `+=` sign
      should be used. */
-    *negative_damping_force += damping_matrix * state.qdot();
+    *negative_damping_force +=
+        damping_matrix *
+        this->ExtractElementDofs(this->node_indices(), state.qdot());
   }
 
   /* Implements FemElement::CalcStiffnessMatrix().

--- a/multibody/fixed_fem/dev/dynamic_elasticity_model.h
+++ b/multibody/fixed_fem/dev/dynamic_elasticity_model.h
@@ -49,22 +49,26 @@ class DynamicElasticityModel : public ElasticityModel<Element> {
     /* Alias for more readability. */
     constexpr int kDim = Element::Traits::kSolutionDimension;
     constexpr int kNumNodes = Element::Traits::kNumNodes;
+    constexpr int kNumDofs = kDim * kNumNodes;
     DRAKE_THROW_UNLESS(kNumNodes == 4);
 
     using geometry::VolumeElementIndex;
-    /* Record the reference positions of the input mesh. */
-    const int node_offset = this->ParseTetMesh(mesh);
-    const NodeIndex node_index_offset(node_offset);
+    /* Record the reference positions of the input mesh. The returned offset is
+     from before the new tets are added. */
+    const NodeIndex node_index_offset(this->ParseTetMesh(mesh));
 
     /* Builds and adds new elements. */
     const VectorX<T>& X = this->reference_positions();
     std::array<NodeIndex, kNumNodes> element_node_indices;
     for (VolumeElementIndex i(0); i < mesh.num_elements(); ++i) {
       for (int j = 0; j < kNumNodes; ++j) {
+        /* To obtain the global node index, offset the local index of the nodes
+         in the mesh (starting from 0) by the existing number of nodes
+         before the current mesh is added. */
         const int node_id = mesh.element(i).vertex(j) + node_index_offset;
         element_node_indices[j] = NodeIndex(node_id);
       }
-      const Vector<T, kDim* kNumNodes> element_reference_positions =
+      const Vector<T, kNumDofs> element_reference_positions =
           Element::ExtractElementDofs(element_node_indices, X);
       const ElementIndex next_element_index =
           ElementIndex(this->num_elements());

--- a/multibody/fixed_fem/dev/elasticity_element.h
+++ b/multibody/fixed_fem/dev/elasticity_element.h
@@ -407,20 +407,15 @@ class ElasticityElement : public FemElement<DerivedElement, DerivedTraits> {
    element. */
   std::array<Matrix3<T>, Traits::kNumQuadraturePoints> CalcDeformationGradient(
       const FemState<DerivedElement>& state) const {
-    // TODO(xuchenhan-tri): Consider abstracting this potential common operation
-    //  into FemElement.
     std::array<Matrix3<T>, Traits::kNumQuadraturePoints> F;
-    Eigen::Matrix<T, Traits::kSolutionDimension, Traits::kNumNodes> element_x;
-    const VectorX<T>& x_tmp = state.q();
-    const auto& x = Eigen::Map<const Matrix3X<T>>(
-        x_tmp.data(), Traits::kSolutionDimension,
-        x_tmp.size() / Traits::kSolutionDimension);
-    for (int i = 0; i < Traits::kNumNodes; ++i) {
-      element_x.col(i) = x.col(this->node_indices()[i]);
-    }
+    const Vector<T, Traits::kSolutionDimension* Traits::kNumNodes> element_x =
+        this->ExtractElementDofs(this->node_indices(), state.q());
+    const auto& element_x_reshaped = Eigen::Map<
+        const Eigen::Matrix<T, Traits::kSolutionDimension, Traits::kNumNodes>>(
+        element_x.data(), Traits::kSolutionDimension, Traits::kNumNodes);
     const std::array<typename IsoparametricElementType::JacobianMatrix,
                      Traits::kNumQuadraturePoints>
-        dxdxi = isoparametric_element_.CalcJacobian(element_x);
+        dxdxi = isoparametric_element_.CalcJacobian(element_x_reshaped);
     for (int q = 0; q < Traits::kNumQuadraturePoints; ++q) {
       F[q] = dxdxi[q] * dxidX_[q];
     }

--- a/multibody/fixed_fem/dev/elasticity_element.h
+++ b/multibody/fixed_fem/dev/elasticity_element.h
@@ -408,7 +408,8 @@ class ElasticityElement : public FemElement<DerivedElement, DerivedTraits> {
   std::array<Matrix3<T>, Traits::kNumQuadraturePoints> CalcDeformationGradient(
       const FemState<DerivedElement>& state) const {
     std::array<Matrix3<T>, Traits::kNumQuadraturePoints> F;
-    const Vector<T, Traits::kSolutionDimension* Traits::kNumNodes> element_x =
+    constexpr int kNumDofs = Traits::kSolutionDimension * Traits::kNumNodes;
+    const Vector<T, kNumDofs> element_x =
         this->ExtractElementDofs(this->node_indices(), state.q());
     const auto& element_x_reshaped = Eigen::Map<
         const Eigen::Matrix<T, Traits::kSolutionDimension, Traits::kNumNodes>>(

--- a/multibody/fixed_fem/dev/elasticity_model.h
+++ b/multibody/fixed_fem/dev/elasticity_model.h
@@ -95,18 +95,13 @@ class ElasticityModel : public FemModel<Element> {
   ElasticityModel() = default;
   virtual ~ElasticityModel() = default;
 
-  /* Parse a tetrahedral volume mesh, store the positions of the vertices in
+  /** Parse a tetrahedral volume mesh, store the positions of the vertices in
    the mesh as the reference positions for the vertices, and increment the total
    number of vertices in the model. Returns the total number of vertices
    *before* the input `mesh` is parsed.
-
-   This function is only meant to be called by
-   DynamicElasticityModel::AddDynamicElasticityElementsFromTetMesh() and
-   StaticElasticityModel::AddStaticElasticityElementsFromTetMesh().
-
    @param mesh    The input tetrahedral mesh that describes the connectivity and
    the positions of the vertices. Each geometry::VolumeElement in the input
-   `mesh` will generate a ElasticityElement in this ElasticityModel.
+   `mesh` will generate an ElasticityElement in this ElasticityModel.
    @throw std::exception if Element::Traits::kNumNodes != 4. */
   int ParseTetMesh(const geometry::VolumeMesh<T>& mesh) {
     /* Alias for more readability. */

--- a/multibody/fixed_fem/dev/elasticity_model.h
+++ b/multibody/fixed_fem/dev/elasticity_model.h
@@ -95,8 +95,45 @@ class ElasticityModel : public FemModel<Element> {
   ElasticityModel() = default;
   virtual ~ElasticityModel() = default;
 
+  /* Parse a tetrahedral volume mesh, store the positions of the vertices in
+   the mesh as the reference positions for the vertices, and increment the total
+   number of vertices in the model. Returns the total number of vertices
+   *before* the input `mesh` is parsed.
+
+   This function is only meant to be called by
+   DynamicElasticityModel::AddDynamicElasticityElementsFromTetMesh() and
+   StaticElasticityModel::AddStaticElasticityElementsFromTetMesh().
+
+   @param mesh    The input tetrahedral mesh that describes the connectivity and
+   the positions of the vertices. Each geometry::VolumeElement in the input
+   `mesh` will generate a ElasticityElement in this ElasticityModel.
+   @throw std::exception if Element::Traits::kNumNodes != 4. */
+  int ParseTetMesh(const geometry::VolumeMesh<T>& mesh) {
+    /* Alias for more readability. */
+    constexpr int kDim = Element::Traits::kSolutionDimension;
+    constexpr int kNumNodes = Element::Traits::kNumNodes;
+    DRAKE_THROW_UNLESS(kNumNodes == 4);
+
+    using geometry::VolumeVertexIndex;
+    /* Record the reference positions of the input mesh. */
+    const int num_new_vertices = mesh.num_vertices();
+    reference_positions_.conservativeResize(reference_positions_.size() +
+                                            kDim * num_new_vertices);
+    const NodeIndex node_index_offset = NodeIndex(this->num_nodes());
+    for (VolumeVertexIndex i(0); i < num_new_vertices; ++i) {
+      reference_positions_.template segment<kDim>(
+          kDim * (i + node_index_offset)) = mesh.vertex(i).r_MV();
+    }
+    /* Record the number of vertices *before* the input mesh is parsed. */
+    const int num_vertices = this->num_nodes();
+    this->increment_num_nodes(num_new_vertices);
+    return num_vertices;
+  }
+
+  const VectorX<T>& reference_positions() const { return reference_positions_; }
+
  private:
-  /* The gravitational acceleration in the world frame. */
+  VectorX<T> reference_positions_{};
   Vector<T, Element::Traits::kSpatialDimension> gravity_{0, 0, -9.81};
 };
 }  // namespace fixed_fem

--- a/multibody/fixed_fem/dev/fem_element.h
+++ b/multibody/fixed_fem/dev/fem_element.h
@@ -125,6 +125,22 @@ class FemElement {
     static_cast<const DerivedElement*>(this)->DoCalcMassMatrix(state, M);
   }
 
+  /** Extract the dofs corresponding to the nodes given by `node_indices` from
+   the given `state_dofs`. */
+  static Vector<T, Traits::kSolutionDimension * Traits::kNumNodes>
+  ExtractElementDofs(
+      const std::array<NodeIndex, Traits::kNumNodes>& node_indices,
+      const VectorX<T>& state_dofs) {
+    constexpr int kDim = Traits::kSolutionDimension;
+    Vector<T, kDim * Traits::kNumNodes> element_dofs;
+    for (int i = 0; i < Traits::kNumNodes; ++i) {
+      DRAKE_ASSERT((node_indices[i] + 1) * kDim <= state_dofs.size());
+      element_dofs.template segment<kDim>(i * kDim) =
+          state_dofs.template segment<kDim>(node_indices[i] * kDim);
+    }
+    return element_dofs;
+  }
+
  protected:
   /** Assignment and copy constructions are prohibited.
    Move constructor is allowed so that FemElement can be stored in

--- a/multibody/fixed_fem/dev/newmark_scheme.h
+++ b/multibody/fixed_fem/dev/newmark_scheme.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include "drake/multibody/fixed_fem/dev/state_updater.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+/** Implements the interface StateUpdater with Newmark-beta time integration
+ scheme. The states are updated according to the following equation:
+
+      v = vₙ + dt ⋅ (γ ⋅ a + (1−γ) ⋅ aₙ)
+      x = xₙ + dt ⋅ vₙ + dt² ⋅ [β ⋅ a + (0.5−β) ⋅ aₙ].
+
+ See [Newmark, 1959] for the original reference for the method.
+
+ [Newmark, 1959] Newmark, Nathan M. "A method of computation for structural
+ dynamics." Journal of the engineering mechanics division 85.3 (1959): 67-94.
+
+ @tparam State    The type of FemState to be updated by the %NewmarkScheme. The
+ template parameter State must be an instantiation of FemState.
+ @pre State::ode_order() == 2. */
+template <class State>
+class NewmarkScheme final : public StateUpdater<State> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(NewmarkScheme);
+
+  static_assert(State::ode_order() == 2);
+  using T = typename State::T;
+
+  /** Construct a Newmark scheme with the provided timestep, `gamma` and `beta`.
+   @pre dt > 0.
+   @pre 0 <= gamma <= 1.
+   @pre 0 <= beta <= 0.5. */
+  NewmarkScheme(double dt, double gamma, double beta)
+      : dt_(dt), gamma_(gamma), beta_(beta) {
+    DRAKE_DEMAND(dt > 0);
+    DRAKE_DEMAND(0 <= gamma && gamma <= 1);
+    DRAKE_DEMAND(0 <= beta && beta <= 0.5);
+  }
+
+  ~NewmarkScheme() = default;
+
+  /** Implements StateUpdater::weights(). */
+  Vector3<T> weights() const final {
+    return {beta_ * dt_ * dt_, gamma_ * dt_, 1.0};
+  }
+
+ private:
+  /* Implements StateUpdater::DoUpdateState(). */
+  void DoUpdateState(const VectorX<T>& dz, State* state) const final {
+    const VectorX<T>& a = state->qddot();
+    const VectorX<T>& v = state->qdot();
+    const VectorX<T>& x = state->q();
+    state->set_qddot(a + dz);
+    state->set_qdot(v + dt_ * gamma_ * dz);
+    state->set_q(x + dt_ * dt_ * beta_ * dz);
+  }
+
+  /* Implements StateUpdater::DoIntegrateTime(). */
+  void DoIntegrateTime(const State& prev_state, State* state) const final {
+    const VectorX<T>& an = prev_state.qddot();
+    const VectorX<T>& vn = prev_state.qdot();
+    const VectorX<T>& xn = prev_state.q();
+    const VectorX<T>& a = state->qddot();
+    state->set_qdot(vn + dt_ * (gamma_ * a + (1.0 - gamma_) * an));
+    state->set_q(xn + dt_ * vn + dt_ * dt_ * (beta_ * a + (0.5 - beta_) * an));
+  }
+
+  double dt_{0};
+  double gamma_{0.5};
+  double beta_{0.25};
+};
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/state_updater.h
+++ b/multibody/fixed_fem/dev/state_updater.h
@@ -8,25 +8,39 @@ namespace fixed_fem {
 /** %StateUpdater provides the interface to update FemState in NewtonSolver.
  In each Newton-Raphson iteration of the FEM solver, we are solving for an
  equation in the form of
+
         G(q, q̇, q̈) = 0.
+
  For different FemModels, G takes different forms. For dynamic elasticity,
+
         G(q, q̇, q̈) = Mq̈ - fₑ(q) - fᵥ(q, q̇) - fₑₓₜ,
+
  where M is the mass matrix, fₑ(q) is the elastic force, fᵥ(q, q̇) is the
  damping force, and fₑₓₜ are the external forces. For static elasticity,
+
         G(q, q̇, q̈) = G(q) = -fₑ(q) + fₑₓₜ.
+
  For the Poisson equation,
+
         G(q, q̇, q̈) = G(q) = Kq − f.
+
  With time discretization, one can express `q`, `q̇,` `q̈` in terms of a
  single variable, which we dub the name "key variable" and denote it with `z`.
  For example, for dynamic elasticity with Newmark scheme,
+
         q̈ = z;
         q̇ = q̇ₙ + dt ⋅ (γ ⋅ z + (1−γ) ⋅ q̈ₙ)
         q = qₙ + dt ⋅ q̇ₙ + dt² ⋅ [β ⋅ z + (0.5−β) ⋅ q̈ₙ].
+
  Hence, we can write the system of equations as
+
         G(z) = 0,
+
  and in each Newton-Raphson iteration, we solve for a linear system of equation
  of the form
+
         ∇G(z) ⋅ dz = -G(z),
+
  where ∇G = ∂G/∂z. StateUpdater is responsible for updating the FemState given
  the solution of the linear solve, `dz`. In addition, %StateUpdater also
  provides the derivatives of the states with respect to the key variable `z`,
@@ -59,6 +73,25 @@ class StateUpdater {
     DoUpdateState(dz, state);
   }
 
+  // TODO(xuchenhan-tri): Consider passing in more than one previous state when
+  //  we implement multi-step methods. */
+  /** Advance the given `state` by one time step.
+   More specifically, if State::ode_order() > 0, then advance `state` in time
+   using the discrete time stepping scheme by a time step of size `dt` which is
+   stored in the time stepping scheme.
+   If State::ode_order() == 0, throw an exception.
+   @param[in] prev_state The state at the previous time step.
+   @param[in, out] state The state at the current time step. The highest order
+   state will be used as input (and will not be modified by this method). For
+   example, if State::ode_order() == 2, then `state->qddot()` will be used as
+   input (and will not be modified) and `state->q()` and `state->qdot()` will be
+   modified by numerically integrating in time.
+   @pre state != nullptr. */
+  void IntegrateTime(const State& prev_state, State* state) const {
+    DRAKE_DEMAND(state != nullptr);
+    DoIntegrateTime(prev_state, state);
+  }
+
  protected:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(StateUpdater);
   StateUpdater() = default;
@@ -68,6 +101,19 @@ class StateUpdater {
    class. The `dz` provided here has compatible size with the number of
    generalized positions in `state` and does not need to be checked again.  */
   virtual void DoUpdateState(const VectorX<T>& dz, State* state) const = 0;
+
+  /** Derived classes templated on FemState whose ode_order() is greater than 0
+   must override this method to integrate the state in time according to the
+   specific time stepping scheme. */
+  virtual void DoIntegrateTime(const State& prev_state, State* state) const {
+    if constexpr (State::ode_order() == 0) {
+      throw std::logic_error(
+          "There is no notion of time in a zeroth order ODE.");
+    }
+    throw std::runtime_error(
+        "IntegrateTime() should be implemented for this StateUpdater but is "
+        "not implemented.");
+  }
 };
 }  // namespace fixed_fem
 }  // namespace multibody

--- a/multibody/fixed_fem/dev/static_elasticity_model.h
+++ b/multibody/fixed_fem/dev/static_elasticity_model.h
@@ -47,15 +47,18 @@ class StaticElasticityModel : public ElasticityModel<Element> {
     DRAKE_THROW_UNLESS(kNumNodes == 4);
 
     using geometry::VolumeElementIndex;
-    /* Record the reference positions of the input mesh. */
-    const int node_offset = this->ParseTetMesh(mesh);
-    const NodeIndex node_index_offset(node_offset);
+    /* Record the reference positions of the input mesh. The returned offset is
+     from before the new tets are added. */
+    const NodeIndex node_index_offset(this->ParseTetMesh(mesh));
 
     /* Builds and adds new elements. */
     std::array<NodeIndex, kNumNodes> element_node_indices;
     const VectorX<T>& X = this->reference_positions();
     for (VolumeElementIndex i(0); i < mesh.num_elements(); ++i) {
       for (int j = 0; j < kNumNodes; ++j) {
+        /* To obtain the global node index, offset the local index of the nodes
+         in the mesh (starting from 0) by the existing number of nodes
+         before the current mesh is added. */
         const int node_id = mesh.element(i).vertex(j) + node_index_offset;
         element_node_indices[j] = NodeIndex(node_id);
       }

--- a/multibody/fixed_fem/dev/test/dynamic_elasticity_model_test.cc
+++ b/multibody/fixed_fem/dev/test/dynamic_elasticity_model_test.cc
@@ -1,0 +1,158 @@
+#include "drake/multibody/fixed_fem/dev/dynamic_elasticity_model.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/geometry/proximity/make_box_mesh.h"
+#include "drake/math/autodiff_gradient.h"
+#include "drake/multibody/fixed_fem/dev/dynamic_elasticity_element.h"
+#include "drake/multibody/fixed_fem/dev/fem_state.h"
+#include "drake/multibody/fixed_fem/dev/linear_constitutive_model.h"
+#include "drake/multibody/fixed_fem/dev/linear_simplex_element.h"
+#include "drake/multibody/fixed_fem/dev/newmark_scheme.h"
+#include "drake/multibody/fixed_fem/dev/simplex_gaussian_quadrature.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+namespace {
+constexpr int kNaturalDimension = 3;
+constexpr int kSpatialDimension = 3;
+constexpr int kSolutionDimension = 3;
+constexpr int kQuadratureOrder = 1;
+using T = AutoDiffXd;
+using QuadratureType =
+    SimplexGaussianQuadrature<kNaturalDimension, kQuadratureOrder>;
+constexpr int kNumQuads = QuadratureType::num_quadrature_points();
+using IsoparametricElementType =
+    LinearSimplexElement<T, kNaturalDimension, kSpatialDimension, kNumQuads>;
+using ConstitutiveModelType = LinearConstitutiveModel<T, kNumQuads>;
+using ElementType =
+    DynamicElasticityElement<IsoparametricElementType, QuadratureType,
+                             ConstitutiveModelType>;
+const double kYoungsModulus = 1.23;
+const double kPoissonRatio = 0.456;
+const double kDensity = 0.789;
+/* The geometry of the model under test is a cube and it has 8 vertices and 6
+ elements. */
+constexpr int kNumCubeVertices = 8;
+constexpr int kNumDofs = kNumCubeVertices * kSolutionDimension;
+constexpr int kNumElements = 6;
+/* Parameters for Newmark scheme. */
+const double kDt = 1e-3;
+const double kGamma = 0.2;
+const double kBeta = 0.3;
+/* Parameters for the damping model. */
+const double kMassDamping = 0.01;
+const double kStiffnessDamping = 0.02;
+
+class DynamicElasticityModelTest : public ::testing::Test {
+ protected:
+  /* Make a box and subdivide it into 6 tetrahedra. */
+  static geometry::VolumeMesh<T> MakeBoxTetMesh() {
+    const double length = 0.1;
+    geometry::Box box(length, length, length);
+    geometry::VolumeMesh mesh =
+        geometry::internal::MakeBoxVolumeMesh<T>(box, length);
+    return mesh;
+  }
+
+  void SetUp() override {
+    geometry::VolumeMesh<T> mesh = MakeBoxTetMesh();
+    const ConstitutiveModelType constitutive_model(kYoungsModulus,
+                                                   kPoissonRatio);
+    const DampingModel<T> damping_model(kMassDamping, kStiffnessDamping);
+    model_.AddDynamicElasticityElementsFromTetMesh(mesh, constitutive_model,
+                                                   kDensity, damping_model);
+  }
+
+  /* Returns an arbitrary perturbation to the reference configuration of the
+   cube geometry. */
+  static Vector<double, kNumDofs> perturbation() {
+    Vector<double, kNumDofs> delta;
+    delta << 0.18, 0.63, 0.54, 0.13, 0.92, 0.17, 0.03, 0.86, 0.85, 0.25, 0.53,
+        0.67, 0.81, 0.36, 0.45, 0.31, 0.29, 0.71, 0.30, 0.68, 0.58, 0.52, 0.35,
+        0.76;
+    return delta;
+  }
+
+  /* Returns an arbitrary FemState whose generalized positions are different
+   from reference positions and whose velocities and acclerations are nonzero.
+   In addition, set up AutoDiff derivatives for qddot. */
+  FemState<ElementType> MakeDeformedState() const {
+    const FemState<ElementType> reference_state = model_.MakeFemState();
+    FemState<ElementType> deformed_state = model_.MakeFemState();
+    /* Perturb qddot and set up derivatives. */
+    const Vector<double, kNumDofs> perturbed_qddot =
+        math::autoDiffToValueMatrix(deformed_state.qddot()) + perturbation();
+    Vector<T, kNumDofs> perturbed_qddot_autodiff;
+    math::initializeAutoDiff(perturbed_qddot, perturbed_qddot_autodiff);
+    deformed_state.set_qddot(perturbed_qddot_autodiff);
+    /* It's important to set up the `deformed_state` with `state_updater_` so
+     that the derivatives such as dq/dqddot are set up. */
+    state_updater_.IntegrateTime(reference_state, &deformed_state);
+    return deformed_state;
+  }
+
+  /* The model under test. */
+  DynamicElasticityModel<ElementType> model_;
+  const NewmarkScheme<FemState<ElementType>> state_updater_{kDt, kGamma, kBeta};
+};
+
+/* Tests the mesh has been successfully converted to elements. */
+TEST_F(DynamicElasticityModelTest, Geometry) {
+  EXPECT_EQ(model_.num_nodes(), kNumCubeVertices);
+  EXPECT_EQ(model_.num_elements(), kNumElements);
+}
+
+/* Tests that the tangent matrix of the model is the derivative of the residual
+ with respect to the change in qddot. */
+TEST_F(DynamicElasticityModelTest, TangentMatrixIsResidualDerivative) {
+  const FemState<ElementType> state = MakeDeformedState();
+
+  VectorX<T> residual(state.num_generalized_positions());
+  model_.CalcResidual(state, &residual);
+
+  Eigen::SparseMatrix<T> tangent_matrix;
+  model_.SetTangentMatrixSparsityPattern(&tangent_matrix);
+  model_.CalcTangentMatrix(state, state_updater_.weights(), &tangent_matrix);
+
+  /* In the discretization of the unit cube by 6 tetrahedra, there are 19 edges,
+   and 8 nodes, creating 19*2 + 8 blocks of 3-by-3 nonzero entries. Hence the
+   number of nonzero entries of the tangent matrix should be (19*2+8)*9. */
+  const int nnz = (19 * 2 + 8) * 9;
+  EXPECT_EQ(tangent_matrix.nonZeros(), nnz);
+
+  const MatrixX<T> dense_tangent_matrix(tangent_matrix);
+  for (int i = 0; i < state.num_generalized_positions(); ++i) {
+    EXPECT_TRUE(CompareMatrices(residual(i).derivatives(),
+                                dense_tangent_matrix.col(i),
+                                std::numeric_limits<double>::epsilon()));
+  }
+}
+
+/* Adds two copies of the same set of elements and tests that the residual for
+ the two copies are identical. */
+TEST_F(DynamicElasticityModelTest, MultipleMesh) {
+  geometry::VolumeMesh<T> mesh = MakeBoxTetMesh();
+  ConstitutiveModelType constitutive_model(kYoungsModulus, kPoissonRatio);
+  const DampingModel<T> damping_model(kMassDamping, kStiffnessDamping);
+  model_.AddDynamicElasticityElementsFromTetMesh(mesh, constitutive_model,
+                                                 kDensity, damping_model);
+
+  EXPECT_EQ(model_.num_nodes(), 2 * kNumCubeVertices);
+  /* Each cube is split into 6 tetrahedra. */
+  EXPECT_EQ(model_.num_elements(), 2 * kNumElements);
+
+  FemState<ElementType> state = model_.MakeFemState();
+  EXPECT_EQ(state.num_generalized_positions(), 2 * kNumDofs);
+
+  VectorX<T> residual(state.num_generalized_positions());
+  model_.CalcResidual(state, &residual);
+  EXPECT_TRUE(
+      CompareMatrices(residual.head(kNumDofs), residual.tail(kNumDofs), 0));
+}
+}  // namespace
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/test/newmark_scheme_test.cc
+++ b/multibody/fixed_fem/dev/test/newmark_scheme_test.cc
@@ -28,12 +28,12 @@ class NewmarkSchemeTest : public ::testing::Test {
     return Vector4<double>(0.1011, 0.1112, 0.1213, 0.1314);
   }
 
-  NewmarkScheme<FemState<DummyElement<2>>> newmark_scheme{kDt, kGamma, kBeta};
+  NewmarkScheme<FemState<DummyElement<2>>> newmark_scheme_{kDt, kGamma, kBeta};
 };
 
 TEST_F(NewmarkSchemeTest, Weights) {
   EXPECT_TRUE(CompareMatrices(
-      newmark_scheme.weights(),
+      newmark_scheme_.weights(),
       Vector3<double>(kBeta * kDt * kDt, kGamma * kDt, 1.0), 0));
 }
 
@@ -43,7 +43,7 @@ TEST_F(NewmarkSchemeTest, UpdateState) {
   const Vector4<double> qddot = MakeQddot();
   FemState<DummyElement<2>> state(q, qdot, qddot);
   const Vector4<double> dqddot(1.234, 4.567, 7.890, 0.123);
-  newmark_scheme.UpdateState(dqddot, &state);
+  newmark_scheme_.UpdateState(dqddot, &state);
   EXPECT_TRUE(CompareMatrices(state.qddot(), qddot + dqddot, 0));
   EXPECT_TRUE(
       CompareMatrices(state.qdot(), qdot + dqddot * kDt * kGamma, kTol));
@@ -51,7 +51,7 @@ TEST_F(NewmarkSchemeTest, UpdateState) {
 }
 
 /* Tests that Newmark scheme reproduces analytical solutions under qddot. */
-TEST_F(NewmarkSchemeTest, IntegrateTime) {
+TEST_F(NewmarkSchemeTest, AdvanceOneTimeStep) {
   const Vector4<double> q = MakeQ();
   const Vector4<double> qdot = MakeQdot();
   const Vector4<double> qddot = MakeQddot();
@@ -61,7 +61,7 @@ TEST_F(NewmarkSchemeTest, IntegrateTime) {
   const int kTimeSteps = 10;
   for (int i = 0; i < kTimeSteps; ++i) {
     state_np1.set_qddot(state_n.qddot());
-    newmark_scheme.IntegrateTime(state_n, &state_np1);
+    newmark_scheme_.AdvanceOneTimeStep(state_n, &state_np1);
     state_n = state_np1;
   }
   const double total_time = kDt * kTimeSteps;

--- a/multibody/fixed_fem/dev/test/newmark_scheme_test.cc
+++ b/multibody/fixed_fem/dev/test/newmark_scheme_test.cc
@@ -1,0 +1,82 @@
+#include "drake/multibody/fixed_fem/dev/newmark_scheme.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/multibody/fixed_fem/dev/test/dummy_element.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+namespace test {
+namespace {
+const double kDt = 1e-4;
+const double kGamma = 0.2;
+const double kBeta = 0.3;
+const double kTol = std::numeric_limits<double>::epsilon();
+class NewmarkSchemeTest : public ::testing::Test {
+ protected:
+  static Vector4<double> MakeQ() {
+    return Vector4<double>(1.23, 2.34, 3.45, 4.56);
+  }
+
+  static Vector4<double> MakeQdot() {
+    return Vector4<double>(5.67, 6.78, 7.89, 9.10);
+  }
+
+  static Vector4<double> MakeQddot() {
+    return Vector4<double>(0.1011, 0.1112, 0.1213, 0.1314);
+  }
+
+  NewmarkScheme<FemState<DummyElement<2>>> newmark_scheme{kDt, kGamma, kBeta};
+};
+
+TEST_F(NewmarkSchemeTest, Weights) {
+  EXPECT_TRUE(CompareMatrices(
+      newmark_scheme.weights(),
+      Vector3<double>(kBeta * kDt * kDt, kGamma * kDt, 1.0), 0));
+}
+
+TEST_F(NewmarkSchemeTest, UpdateState) {
+  const Vector4<double> q = MakeQ();
+  const Vector4<double> qdot = MakeQdot();
+  const Vector4<double> qddot = MakeQddot();
+  FemState<DummyElement<2>> state(q, qdot, qddot);
+  const Vector4<double> dqddot(1.234, 4.567, 7.890, 0.123);
+  newmark_scheme.UpdateState(dqddot, &state);
+  EXPECT_TRUE(CompareMatrices(state.qddot(), qddot + dqddot, 0));
+  EXPECT_TRUE(
+      CompareMatrices(state.qdot(), qdot + dqddot * kDt * kGamma, kTol));
+  EXPECT_TRUE(CompareMatrices(state.q(), q + dqddot * kDt * kDt * kBeta, kTol));
+}
+
+/* Tests that Newmark scheme reproduces analytical solutions under qddot. */
+TEST_F(NewmarkSchemeTest, IntegrateTime) {
+  const Vector4<double> q = MakeQ();
+  const Vector4<double> qdot = MakeQdot();
+  const Vector4<double> qddot = MakeQddot();
+  const FemState<DummyElement<2>> state_0(q, qdot, qddot);
+  FemState<DummyElement<2>> state_n(state_0);
+  FemState<DummyElement<2>> state_np1(state_0);
+  const int kTimeSteps = 10;
+  for (int i = 0; i < kTimeSteps; ++i) {
+    state_np1.set_qddot(state_n.qddot());
+    newmark_scheme.IntegrateTime(state_n, &state_np1);
+    state_n = state_np1;
+  }
+  const double total_time = kDt * kTimeSteps;
+  EXPECT_TRUE(CompareMatrices(state_n.qddot(), state_0.qddot()));
+  EXPECT_TRUE(CompareMatrices(state_n.qdot(),
+                              state_0.qdot() + total_time * state_0.qddot(),
+                              kTimeSteps * kTol));
+  EXPECT_TRUE(
+      CompareMatrices(state_n.q(),
+                      state_0.q() + total_time * state_0.qdot() +
+                          0.5 * total_time * total_time * state_0.qddot(),
+                      kTimeSteps * kTol));
+}
+}  // namespace
+}  // namespace test
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/test/zeroth_order_state_updater_test.cc
+++ b/multibody/fixed_fem/dev/test/zeroth_order_state_updater_test.cc
@@ -34,8 +34,8 @@ TEST_F(ZerothOrderStateUpdaterTest, IntegrateTime) {
   FemState<DummyElement<0>> prev_state(q);
   FemState<DummyElement<0>> new_state(prev_state);
   DRAKE_EXPECT_THROWS_MESSAGE(
-  state_updater.IntegrateTime(prev_state, &new_state), std::exception,
-          "There is no notion of time in a zeroth order ODE.");
+      state_updater.AdvanceOneTimeStep(prev_state, &new_state), std::exception,
+      "There is no notion of time in a zeroth order ODE.");
 }
 }  // namespace
 }  // namespace test

--- a/multibody/fixed_fem/dev/test/zeroth_order_state_updater_test.cc
+++ b/multibody/fixed_fem/dev/test/zeroth_order_state_updater_test.cc
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/multibody/fixed_fem/dev/test/dummy_element.h"
 
 namespace drake {
@@ -15,17 +16,26 @@ class ZerothOrderStateUpdaterTest : public ::testing::Test {
   ZerothOrderStateUpdater<FemState<DummyElement<0>>> state_updater;
 };
 
-TEST_F(ZerothOrderStateUpdaterTest, StateDerivative) {
+TEST_F(ZerothOrderStateUpdaterTest, Weights) {
   EXPECT_TRUE(
       CompareMatrices(state_updater.weights(), Vector3<double>(1, 0, 0), 0));
 }
 
 TEST_F(ZerothOrderStateUpdaterTest, UpdateState) {
-  VectorX<double> q = Vector4<double>(1.23, 2.34, 3.45, 4.56);
-  VectorX<double> dq = Vector4<double>(0.23, 0.34, 0.45, 0.56);
+  const VectorX<double> q = Vector4<double>(1.23, 2.34, 3.45, 4.56);
+  const VectorX<double> dq = Vector4<double>(0.23, 0.34, 0.45, 0.56);
   FemState<DummyElement<0>> state(q);
   state_updater.UpdateState(dq, &state);
   EXPECT_TRUE(CompareMatrices(state.q(), q + dq, 0));
+}
+
+TEST_F(ZerothOrderStateUpdaterTest, IntegrateTime) {
+  const VectorX<double> q = Vector4<double>(1.23, 2.34, 3.45, 4.56);
+  FemState<DummyElement<0>> prev_state(q);
+  FemState<DummyElement<0>> new_state(prev_state);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+  state_updater.IntegrateTime(prev_state, &new_state), std::exception,
+          "There is no notion of time in a zeroth order ODE.");
 }
 }  // namespace
 }  // namespace test

--- a/multibody/fixed_fem/dev/zeroth_order_state_updater.h
+++ b/multibody/fixed_fem/dev/zeroth_order_state_updater.h
@@ -21,10 +21,10 @@ class ZerothOrderStateUpdater final : public StateUpdater<State> {
   ZerothOrderStateUpdater() = default;
   ~ZerothOrderStateUpdater() = default;
 
-  /** Implements StateUpdater::weights(). */
-  Vector3<T> weights() const final { return {1, 0, 0}; }
-
  private:
+  /* Implements StateUpdater::weights(). */
+  Vector3<T> do_get_weights() const final { return {1, 0, 0}; }
+
   /* Implements StateUpdater::DoUpdateState(). */
   void DoUpdateState(const VectorX<T>& dz, State* state) const final {
     state->set_q(state->q() + dz);


### PR DESCRIPTION
- DynamicElasticityModel implements ElasticityModel.
- NewmarkScheme implements StateUpdater.
- Add a new method to StateUpdater, IntegrateTime.
- Add a new helper method to FemElement, ExtractElementDofs.
- Fix a bug in DynamicElasticityElement that the entire state (instead
of the state dofs corresponding to the element) multiplies the
mass/damping matrix when calculating the element residual.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14619)
<!-- Reviewable:end -->
