### PR TITLE
WIP: Umbrella experiment with AVX instructions in Obb::HasOverlap().

### DIFF
--- a/geometry/benchmarking/BUILD.bazel
+++ b/geometry/benchmarking/BUILD.bazel
@@ -1,6 +1,9 @@
 # -*- python -*-
 
-load("@drake//tools/skylark:drake_cc.bzl", "drake_cc_binary")
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_binary",
+)
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 drake_cc_binary(

--- a/geometry/benchmarking/obb_benchmark/BUILD.bazel
+++ b/geometry/benchmarking/obb_benchmark/BUILD.bazel
@@ -1,0 +1,33 @@
+# -*- python -*-
+
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_binary",
+    "drake_cc_library",
+    "drake_cc_test",
+)
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+drake_cc_test(
+    name = "obb_bench",
+    srcs = ["obb_bench.cc"],
+    linkstatic = True,
+    deps = [
+        "//common:essential",
+        "//geometry/proximity:obb",
+        "@googlebenchmark//:benchmark",
+    ],
+)
+
+sh_test(
+    name = "record_results",
+    size = "small",
+    srcs = ["record_results.sh"],
+    data = [
+        ":obb_bench",
+        "//tools/performance:record_results",
+    ],
+    tags = ["no_valgrind_tools"],
+)
+
+add_lint_tests()

--- a/geometry/benchmarking/obb_benchmark/README.md
+++ b/geometry/benchmarking/obb_benchmark/README.md
@@ -1,0 +1,65 @@
+Obb benchmark
+-------------
+
+Conduct benchmarking experiment under relatively controlled conditions to
+minimize runtime variations between repeated runs by controlling CPUs. 
+
+## Supported experiments
+
+General syntax:
+
+    $ geometry/benchmarking/obb_benchmark/conduct_experiment [DIRECTORY] [ARGS...]
+
+This is an example of how to run the benchmark:
+
+    $ geometry/benchmarking/obb_benchmark/conduct_experiment \
+      ~/project/ObbBench/record
+      
+You will get these files in ~/project/ObbBench/record directory.
+
+    $ ls ~/project/ObbBench/record/
+    compiler.txt  kernel.txt  os.txt  outputs.zip  results.json  summary.txt
+    
+The file summary.txt shows the statistics near the end of the file.
+
+    $ tail -n18 ~/project/ObbBench/record/summary.txt
+      ------------------------------------------------------------------------------------
+      Benchmark                                          Time             CPU   Iterations
+      ------------------------------------------------------------------------------------
+      ObbHasOverlapF/All_31_Cases_mean                3440 ns         3440 ns            9
+      ObbHasOverlapF/All_31_Cases_median              3439 ns         3439 ns            9
+      ObbHasOverlapF/All_31_Cases_stddev              2.84 ns         2.85 ns            9
+      ObbHasOverlapF/All_31_Cases_min                 3437 ns         3436 ns            9
+      ObbHasOverlapF/All_31_Cases_max                 3445 ns         3445 ns            9
+      ObbHasOverlapF/Overlap_16_Cases_mean            1920 ns         1920 ns            9
+      ObbHasOverlapF/Overlap_16_Cases_median          1920 ns         1920 ns            9
+      ObbHasOverlapF/Overlap_16_Cases_stddev         0.580 ns        0.596 ns            9
+      ObbHasOverlapF/Overlap_16_Cases_min             1919 ns         1919 ns            9
+      ObbHasOverlapF/Overlap_16_Cases_max             1921 ns         1921 ns            9
+      ObbHasOverlapF/NonOverlap_15_Cases_mean         1575 ns         1575 ns            9
+      ObbHasOverlapF/NonOverlap_15_Cases_median       1575 ns         1575 ns            9
+      ObbHasOverlapF/NonOverlap_15_Cases_stddev       3.05 ns         3.01 ns            9
+      ObbHasOverlapF/NonOverlap_15_Cases_min          1571 ns         1572 ns            9
+      ObbHasOverlapF/NonOverlap_15_Cases_max          1583 ns         1583 ns            9
+
+
+## Prepare for experiments on broadwell microarchitecture
+
+"*conduct_experiment*" use these build flags to experiment with broadwell
+ microarchitecture.
+
+    $ tail -n5 geometry/benchmarking/obb_benchmark/conduct_experiment 
+    ./tools/performance/benchmark_tool conduct_experiment \
+        -b=--compilation_mode=opt \
+        -b=--copt=-g \
+        -b=--cxxopt=-march=broadwell \
+        $TARGET "$OUTPUT_DIR" -- "$@"
+
+Notice that the argument `conduct_experiment` to the `benchmark_tool` refers
+to its subcommand. It is not a recursive call back to the script
+`obb_benchmark/conduct_experiment` in this directory.
+
+## More info
+
+Google Benchmark Documentation
+https://github.com/google/benchmark#benchmark

--- a/geometry/benchmarking/obb_benchmark/conduct_experiment
+++ b/geometry/benchmarking/obb_benchmark/conduct_experiment
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Execute the complete set of steps for a well-controlled benchmark experiment.
+
+set -e -u -o pipefail
+
+TARGET=//geometry/benchmarking/obb_benchmark:record_results
+ME=$(python3 -c 'import os; print(os.path.realpath("'"$0"'"))')
+HERE=$(dirname $ME)
+
+OUTPUT_DIR="$1"
+shift
+
+cd "$HERE"/../../..
+
+./tools/performance/benchmark_tool conduct_experiment \
+    -b=--compilation_mode=opt \
+    -b=--copt=-g \
+    -b=--cxxopt=-march=broadwell \
+    $TARGET "$OUTPUT_DIR" -- "$@"

--- a/geometry/benchmarking/obb_benchmark/copy_results_to
+++ b/geometry/benchmarking/obb_benchmark/copy_results_to
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Copy benchmark results to a user-chosen directory.
+
+set -e -u -o pipefail
+
+TARGET=//geometry/benchmarking/obb_benchmark:record_results
+ME=$(python3 -c 'import os; print(os.path.realpath("'"$0"'"))')
+HERE=$(dirname $ME)
+
+cd "$HERE"/../../..
+
+./tools/performance/benchmark_tool copy_results $TARGET "$1"

--- a/geometry/benchmarking/obb_benchmark/obb_bench.cc
+++ b/geometry/benchmarking/obb_benchmark/obb_bench.cc
@@ -1,0 +1,351 @@
+#include <benchmark/benchmark.h>
+
+#include "drake/common/drake_assert.h"
+#include "drake/geometry/proximity/obb.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+using Eigen::AngleAxisd;
+using Eigen::Matrix3d;
+using Eigen::Vector3d;
+using math::RigidTransformd;
+using math::RollPitchYawd;
+using math::RotationMatrixd;
+
+struct TestData {
+  TestData(const Obb& a_G_in, const Obb& b_H_in, const RigidTransformd& X_GH_in,
+           const bool& expect_overlap_in)
+      : a_G(a_G_in),
+        b_H(b_H_in),
+        X_GH(X_GH_in),
+        expect_overlap(expect_overlap_in) {}
+
+  Obb a_G;
+  Obb b_H;
+  RigidTransformd X_GH;
+  // I can use this field to separate the overlapping cases from the
+  // non-overlapping cases. The two set of inputs could have very different
+  // performance. In general, non-overlapping cases will return earlier than
+  // the overlapping cases.
+  bool expect_overlap;
+};
+
+void Obb_HasOverlap(const std::vector<TestData>& test_data) {
+  for (const TestData& t : test_data) {
+    DRAKE_DEMAND(t.expect_overlap == Obb::HasOverlap(t.a_G, t.b_H, t.X_GH));
+  }
+}
+
+// We want to compute X_AB such that B is posed relative to A as documented in
+// SetUp31Records. We can do so by generating the rotation component, R_AB, such
+// that Bq has a minimum value along the chosen axis, and we can solve for
+// the translation component, p_AoBo_A = p_AoAf_A + p_AfBq_A + p_BqBo_A.
+RigidTransformd CalcCornerTransform(const Obb& a, const Obb& b, const int axis,
+                                    const bool expect_overlap);
+
+// We want to compute X_AB such that B is posed relative to A as documented
+// in SetUp31Records. We can do so by generating the rotation component, R_AB,
+// such that Bq lies on the minimum edge along the chosen axis, and we can solve
+// for the translation component, p_AoBo_A = p_AoAf_A + p_AfBq_A + p_BqBo_A.
+RigidTransformd CalcEdgeTransform(const Obb& a, const Obb& b, const int a_axis,
+                                  const int b_axis, const bool expect_overlap);
+
+
+// Set up 31 cases of test data for OBBs overlap. We use 15 separating axes
+// between the two bounding boxes. The first 3 separating axes use the axes of
+// Frame A, the next 3 separating axes use the axes of Frame B, and the
+// remaining 9 separating axes use the axes defined by the cross product of
+// axes from Frame A and Frame B. For each of these 15 non-overlapping cases,
+// we also make the two boxes into contact to generate additional 15
+// overlapping cases. We also have one additional case of one box containing
+// a smaller parallel box.
+std::vector<TestData> SetUp31Records() {
+  std::vector<TestData> test_data;
+  // Frame strategy. For the canonical frame A of box `a` and the
+  // canonical frame B of box `b`, we want to control the pose X_AB between
+  // the two boxes. However, we need to give HasOverlap() the pose X_GH
+  // between the hierarchy frames G and H to which box `a` and box `b`
+  // belong. Our strategy is to control the tests through X_AB and then compose
+  // X_GH as:
+  //                 X_GH = X_GA * X_AB * X_BH.
+  // Frame A of box `a` is arbitrarily posed in the hierarchy frame G.
+  const RigidTransformd X_GA{
+      RotationMatrixd(RollPitchYawd(2. * M_PI / 3., M_PI_4, -M_PI / 3.)),
+      Vector3d(1, 2, 3)};
+  // Frame B of box `b` is arbitrarily posed in the hierarchy frame H.
+  const RigidTransformd X_HB{
+      RotationMatrixd(RollPitchYawd(M_PI_4, M_PI / 5., M_PI / 6.)),
+      Vector3d(2, 0.5, 4)};
+  const RigidTransformd X_BH = X_HB.inverse();
+  // One box is fully contained in the other and they are parallel. We make
+  // them parallel by setting X_AB to identity.
+  RigidTransformd X_AB = RigidTransformd::Identity();
+  Obb a(X_GA, Vector3d(1, 2, 1));
+  Obb b(X_HB, Vector3d(0.5, 1, 0.5));
+  test_data.emplace_back(a, b, X_GA * X_AB * X_BH /* X_GH */, true);
+  // To cover the cases of the axes of Frame A, we need to pose box B along
+  // each axis. For example, in the case of the Ax-axis, in a 2D view they would
+  // look like:
+  //           Ay
+  //           ^
+  //   --------|--------      ⋰ ⋱       ↗By
+  //   |       |       |   ⋰      ⋱  ↗
+  //   |       |       Af Bq       ↗⋱
+  //   |       |       |     ⋱   Bo   ⋱
+  //   |      Ao--------->Ax   ⋱    ↘   ⋱
+  //   |               |         ⋱    ↘⋰
+  //   |               |           ⋱⋰   ↘Bx
+  //   |               |
+  //   -----------------
+  //
+  //                                Hy
+  //                                ⇑
+  // Gy             Gx              ⇑
+  //   ⇖           ⇗                ⇑
+  //     ⇖       ⇗                  ⇑
+  //       ⇖   ⇗                    ⇑
+  //         Go                     Ho ⇒ ⇒ ⇒ ⇒ ⇒ Hx
+  //
+  //
+  // For this test, we define Point Bq as the minimum corner of the box B (i.e.,
+  // center - half width). We want to pose box B so Bq is the uniquely closest
+  // point to box A at a Point Af in the interior of +Ax face. The rest of
+  // the box B extends farther along the +Ax axis (as suggested in the above
+  // illustration). Point Bq will be a small epsilon away from the nearby face
+  // either outside (if expect_overlap is false) or inside (if true).
+  a = Obb(X_GA, Vector3d(2, 4, 3));
+  b = Obb(X_HB, Vector3d(3.5, 2, 1.5));
+  for (int axis = 0; axis < 3; ++axis) {
+    X_AB = CalcCornerTransform(a, b, axis, false /* expect_overlap */);
+    test_data.emplace_back(a, b, X_GA * X_AB * X_BH /* X_GH */, false);
+    X_AB = CalcCornerTransform(a, b, axis, true /* expect_overlap */);
+    test_data.emplace_back(a, b, X_GA * X_AB * X_BH /* X_GH */, true);
+  }
+  // To cover the local axes out of B, we can use the same method by swapping
+  // the order of the boxes and then using the inverse of the transform.
+  for (int axis = 0; axis < 3; ++axis) {
+    X_AB =
+        CalcCornerTransform(b, a, axis, false /* expect_overlap */).inverse();
+    test_data.emplace_back(a, b, X_GA * X_AB * X_BH /* X_GH */, false);
+    X_AB = CalcCornerTransform(b, a, axis, true /* expect_overlap */).inverse();
+    test_data.emplace_back(a, b, X_GA * X_AB * X_BH /* X_GH */, true);
+  }
+  // To cover the remaining 9 cases, we need to pose an edge from box B along
+  // an edge from box A. The axes that the edges are aligned with form the
+  // two inputs into the cross product for the separating axis. For example,
+  // in the following illustration, Af lies on the edge aligned with A's y-axis.
+  // Assuming that Bq lies on an edge aligned with B's x-axis, this would form
+  // the case testing the separating axis Ay × Bx.
+  //                       _________
+  //   +z                 /________/\              .
+  //    ^                 \        \ \             .
+  //    |   ______________ Bq       \ \            .
+  //    |  |\             Af \  Bo   \ \           .
+  //    |  | \ _____________\ \       \ \          .
+  // +y |  | |      Ao      |  \_______\/          .
+  //  \ |  \ |              |                      .
+  //   \|   \|______________|                      .
+  //    -----------------------------------> +x
+  //
+  // For this test, we define point Bq on the minimum edge of the box in its
+  // own frame (i.e., center - half width + an offset along the edge). We want
+  // to pose box B so Bq is the uniquely closest point to A at a Point Af on the
+  // edge between the +x and +z face of box A. The rest of box B extends
+  // farther along the +Ax and +Az axis (as suggested in the above
+  // illustration). Point Bq will be a small epsilon away from the nearby
+  // edge either outside (if expect_overlap is false) or inside (if true).
+  for (int a_axis = 0; a_axis < 3; ++a_axis) {
+    for (int b_axis = 0; b_axis < 3; ++b_axis) {
+      X_AB =
+          CalcEdgeTransform(a, b, a_axis, b_axis, false /* expect_overlap */);
+      // Separate along a's y-axis and b's x-axis.
+      test_data.emplace_back(a, b, X_GA * X_AB * X_BH  /* X_GH */, false);
+      X_AB =
+          CalcEdgeTransform(a, b, a_axis, b_axis, true /* expect_overlap */);
+      // Separate along a's y-axis and b's x-axis.
+      test_data.emplace_back(a, b, X_GA * X_AB * X_BH  /* X_GH */, true);
+    }
+  }
+
+  return test_data;
+}
+
+RigidTransformd CalcCornerTransform(const Obb& a, const Obb& b, const int axis,
+                                      const bool expect_overlap) {
+  const int axis1 = (axis + 1) % 3;
+  const int axis2 = (axis + 2) % 3;
+  // Construct the rotation matrix, R_AB, that has meaningful (non-zero)
+  // values everywhere for the remaining 2 axes and no symmetry.
+  const RotationMatrixd R_AB =
+      RotationMatrixd(AngleAxisd(M_PI / 5, Vector3d::Unit(axis1))) *
+          RotationMatrixd(AngleAxisd(-M_PI / 5, Vector3d::Unit(axis2)));
+
+  // We define p_BqBo in Frame A from box b's minimum corner Q to its center.
+  const Vector3d p_BqBo_A = R_AB * b.half_width();
+  // Reality check that the minimum corner and the center are strictly
+  // increasing along the given axis because we chose the rotation R_AB to
+  // support this property.
+  DRAKE_DEMAND(p_BqBo_A[axis] > 0.);
+
+  // We construct Bq to be a small relative offset either side of Af along the
+  // given A[axis], depending on whether we expect the boxes to overlap.
+  Vector3d p_AfBq_A{0, 0, 0};
+  p_AfBq_A[axis] = expect_overlap ? -0.01 : 0.01;
+
+  // We construct Af by taking the maximum corner and offsetting it along the
+  // remaining 2 axes, e.g. by a quarter across. This ensures we thoroughly
+  // exercise all bits instead of simply using any midpoints or corners.
+  //
+  //           A[axis1]
+  //           ^
+  //   --------|--------
+  //   |       |       |
+  //   |       |       Af
+  //   |       |       |
+  //   |      Ao------->A[axis]
+  //   |               |
+  //   |               |
+  //   |               |
+  //   -----------------
+  //
+  Vector3d p_AoAf_A = a.half_width();
+  p_AoAf_A[axis1] /= 2;
+  p_AoAf_A[axis2] /= 2;
+
+  const Vector3d p_AoBo_A = p_AoAf_A + p_AfBq_A + p_BqBo_A;
+  return RigidTransformd(R_AB, p_AoBo_A);
+}
+
+// We want to compute X_AB such that B is posed relative to A as documented
+// in TestObbOverlap. We can do so by generating the rotation component, R_AB,
+// such that Bq lies on the minimum edge along the chosen axis, and we can solve
+// for the translation component, p_AoBo_A = p_AoAf_A + p_AfBq_A + p_BqBo_A.
+RigidTransformd CalcEdgeTransform(const Obb& a, const Obb& b, const int a_axis,
+                                  const int b_axis, const bool expect_overlap) {
+  const int a_axis1 = (a_axis + 1) % 3;
+  const int a_axis2 = (a_axis + 2) % 3;
+  const int b_axis1 = (b_axis + 1) % 3;
+  const int b_axis2 = (b_axis + 2) % 3;
+  // Construct a rotation matrix that has meaningful (non-zero) values
+  // everywhere for the remaining 2 axes and no symmetry. Depending on the
+  // combination of axes, we need to rotate around different axes to ensure
+  // the edge remains as the minimum.
+  RotationMatrixd R_AB;
+  const double theta = M_PI / 5;
+  // For cases Ax × Bx, Ay × By, and Az × Bz.
+  if (a_axis == b_axis) {
+    R_AB = RotationMatrixd(AngleAxisd(theta, Vector3d::Unit(b_axis1))) *
+        RotationMatrixd(AngleAxisd(theta, Vector3d::Unit(b_axis2)));
+    // For cases Ax × By, Ay × Bz, and Az × Bx.
+  } else if (a_axis1 == b_axis) {
+    R_AB = RotationMatrixd(AngleAxisd(theta, Vector3d::Unit(b_axis1))) *
+        RotationMatrixd(AngleAxisd(-theta, Vector3d::Unit(b_axis2)));
+    // For cases Ax × Bz, Ay × Bx, and Az × By.
+  } else {
+    R_AB = RotationMatrixd(AngleAxisd(-theta, Vector3d::Unit(b_axis2))) *
+        RotationMatrixd(AngleAxisd(theta, Vector3d::Unit(b_axis1)));
+  }
+
+  // We define p_BqBo in Frame B taking a point on the minimum edge aligned
+  // with the given axis, offset it to be without symmetry, then convert it
+  // to Frame A by applying the rotation.
+  Vector3d p_BqBo_B = b.half_width();
+  p_BqBo_B[b_axis] -= b.half_width()[b_axis] / 2;
+  const Vector3d p_BqBo_A = R_AB * p_BqBo_B;
+  // Reality check that the point Bq and the center Bo are strictly
+  // increasing along the remaining 2 axes because we chose the rotation R_AB
+  // to support this property.
+  DRAKE_DEMAND(p_BqBo_A[a_axis1] > 0);
+  DRAKE_DEMAND(p_BqBo_A[a_axis2] > 0);
+
+  // We construct Bq to be a small relative offset either side of Af along the
+  // given axis, depending on whether we expect the boxes to overlap.
+  Vector3d p_AfBq_A{0, 0, 0};
+  const double offset = expect_overlap ? -0.01 : 0.01;
+  p_AfBq_A[a_axis1] = offset;
+  p_AfBq_A[a_axis2] = offset;
+
+  // We construct Af by taking the maximum corner and offsetting it along the
+  // given edge to thoroughly exercise all bits.
+  Vector3d p_AoAf_A = a.half_width();
+  p_AoAf_A[a_axis] -= a.half_width()[a_axis] / 2;
+
+  Vector3d p_AoBo_A = p_AoAf_A + p_AfBq_A + p_BqBo_A;
+  // Finally we combine the components to form the transform X_AB.
+  return RigidTransformd(R_AB, p_AoBo_A);
+}
+
+class ObbHasOverlapF : public benchmark::Fixture {
+ public:
+  ObbHasOverlapF() {
+    ComputeStatistics("min", [](const std::vector<double>& v) -> double {
+      return *(std::min_element(std::begin(v), std::end(v)));
+    });
+    ComputeStatistics("max", [](const std::vector<double>& v) -> double {
+      return *(std::max_element(std::begin(v), std::end(v)));
+    });
+  }
+
+  // This apparently futile using statement works around "overloaded virtual"
+  // errors in g++. All of this is a consequence of the weird deprecation of
+  // const-ref State versions of SetUp() and TearDown() in benchmark.h.
+  using benchmark::Fixture::SetUp;
+  void SetUp(benchmark::State&) override {
+    data_for_all_cases_ = SetUp31Records();
+  }
+
+ protected:
+  std::vector<TestData> data_for_all_cases_;
+};
+
+// Thirty-one cases of pairs of Obbs. The two Obbs in each pair may be
+// overlapping or non-overlapping.
+// NOLINTNEXTLINE(runtime/references) cpplint disapproves of gbench choices.
+BENCHMARK_F(ObbHasOverlapF, All_31_Cases)(benchmark::State& state) {
+  // Perform setup here
+  DRAKE_DEMAND(data_for_all_cases_.size() == 31);
+
+  for (auto _ : state) {
+    // This code gets timed
+    Obb_HasOverlap(data_for_all_cases_);
+  }
+}
+
+// Sixteen cases of pairs of overlapping Obbs.
+// NOLINTNEXTLINE(runtime/references) cpplint disapproves of gbench choices.
+BENCHMARK_F(ObbHasOverlapF, Overlap_16_Cases)(benchmark::State& state) {
+  // Perform setup here
+  std::vector<TestData> test_data;
+  for (const TestData& t : data_for_all_cases_)
+    if (t.expect_overlap) test_data.push_back(t);
+  DRAKE_DEMAND(test_data.size() == 16);
+
+  for (auto _ : state) {
+    // This code gets timed
+    Obb_HasOverlap(test_data);
+  }
+}
+
+// Fifteen cases of pairs of non-overlapping Obbs.
+// NOLINTNEXTLINE(runtime/references) cpplint disapproves of gbench choices.
+BENCHMARK_F(ObbHasOverlapF, NonOverlap_15_Cases)(benchmark::State& state) {
+  // Perform setup here
+  std::vector<TestData> test_data;
+  for (const TestData& t : data_for_all_cases_)
+    if (!t.expect_overlap) test_data.push_back(t);
+  DRAKE_DEMAND(test_data.size() == 15);
+
+  for (auto _ : state) {
+    // This code gets timed
+    Obb_HasOverlap(test_data);
+  }
+}
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake
+
+BENCHMARK_MAIN();
+

--- a/geometry/benchmarking/obb_benchmark/record_results.sh
+++ b/geometry/benchmarking/obb_benchmark/record_results.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Collect context information for a benchmark experiment.
+
+${TEST_SRCDIR}/drake/tools/performance/record_results \
+    ${TEST_SRCDIR}/drake/geometry/benchmarking/obb_benchmark/obb_bench \
+    "$@"

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -44,6 +44,7 @@ drake_cc_package_library(
         ":plane",
         ":posed_half_space",
         ":proximity_utilities",
+        ":simd_avx",
         ":sorted_triplet",
         ":surface_mesh",
         ":tessellation_strategy",
@@ -424,6 +425,7 @@ drake_cc_library(
     hdrs = ["obb.h"],
     deps = [
         ":posed_half_space",
+        ":simd_avx",
         ":surface_mesh",
         ":volume_mesh",
         "//common",
@@ -497,6 +499,18 @@ drake_cc_library(
         "@fcl",
         "@fmt",
     ],
+)
+
+drake_cc_library(
+    name = "simd_avx",
+    srcs = ["simd_avx.cc"],
+    hdrs = ["simd_avx.h"],
+    copts = select({
+        "//tools/cc_toolchain:apple": [],
+        "//conditions:default": [
+            "-march=broadwell",
+        ],
+    }),
 )
 
 drake_cc_library(

--- a/geometry/proximity/simd_avx.cc
+++ b/geometry/proximity/simd_avx.cc
@@ -1,6 +1,7 @@
 #include "drake/geometry/proximity/simd_avx.h"
 
 #include <cstdint>
+
 #include <immintrin.h>
 
 // Warning: This is an experimental code to use AVX instructions. One

--- a/geometry/proximity/simd_avx.cc
+++ b/geometry/proximity/simd_avx.cc
@@ -1,0 +1,326 @@
+#include "drake/geometry/proximity/simd_avx.h"
+
+#include <cstdint>
+#include <immintrin.h>
+
+// Warning: This is an experimental code to use AVX instructions. One
+// limitation is that we cannot use Eigen in this file due to incompatible ABI.
+// That's the API uses double* instead of Vector3d or Matrix3d.
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+#if !(defined(__FMA__) && defined(__AVX2__))
+
+// Dot product of a row of l and a column of r, where both l and r are 3x3s in
+// column order.
+static double row_x_col_NoAVX(const double* l, const double* m) {
+  return l[0] * m[0] + l[3] * m[1] + l[6] * m[2];
+}
+
+// Straightforward 3x3 multiply: a = l*r. Matrices in column order.
+static inline void mult3x3_NoAVX(const double* l, const double* m, double* o) {
+  for (int i = 0; i < 3; ++i)
+    for (int j = 0; j < 3; ++j) {
+      const int c = 3 * j;  // Column start index.
+      o[c + i] = row_x_col_NoAVX(&l[i], &m[c]);
+    }
+}
+
+// Compose RigidTransforms stored as 3x3 RotationMatrix and separate position
+// vector. On return R_AC=R_AB*R_BC and p_AC = p_AB + p_BC_A where
+// p_BC_A=R_AB*p_BC.
+static inline void multX2_NoAVX(const double* R_AB, const double* p_AB,
+                                const double* R_BC, const double* p_BC,
+                                double* R_AC, double* p_AC) {
+  mult3x3_NoAVX(R_AB, R_BC, R_AC);
+  for (int i = 0; i < 3; ++i)
+    p_AC[i] = p_AB[i] + row_x_col_NoAVX(&R_AB[i], p_BC);
+}
+
+void multX2(const double* a /*R_AB*/, const double* x /*p_AB*/,
+            const double* A /*R_BC*/, const double* X /*p_BC*/,
+            double* r /*R_AC*/, double* xx /*p_AC*/) {
+  multX2_NoAVX(a, x, A, X, r, xx);
+}
+
+void multXX(const double* a /*X_AB*/, const double* A /*X_BC*/,
+            double* r /*X_AC*/) {
+  multX2_NoAVX(a, a + 9, A, A + 9, r, r + 9);
+}
+
+// Straightforward matrix-vector multiplication between 3x3-matrix M and
+// 3-vector V. The result is in 3-vector r.  The 3x3 matrix M is stored as
+// the array M[9] in column order. For example, the first column M(*,0) is:
+// M(0,0) = M[0],
+// M(1,0) = M[1],
+// M(2,0) = M[2],
+static inline void multMV_NoAVX(const double* M, const double* V,
+                                double* r) {
+  r[0] = row_x_col_NoAVX(M, V);
+  r[1] = row_x_col_NoAVX(M + 1, V);
+  r[2] = row_x_col_NoAVX(M + 2, V);
+}
+
+static inline void multXinvX_NoAVX(const double* X_BA, const double* X_BC,
+                                   double* r /*X_AC*/) {
+  // Calculate inverse rigid transform X_AB of X_BA.
+  double X_AB[12];
+  {
+    // Alias rotation R as the first 9 entries of rigid transform X.
+    const double* R_BA = X_BA;
+    double* R_AB = X_AB;
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        R_AB[i + 3 * j] = R_BA[j + 3 * i];
+      }
+    }
+    // Alias the translation vector as the last 3 entries of rigid transform.
+    const double* p_BoAo_B = X_BA + 9;
+    double* p_AB = X_AB + 9;
+    const double p_AoBo_B[3] = {-p_BoAo_B[0], -p_BoAo_B[1], -p_BoAo_B[2]};
+    multMV_NoAVX(R_AB, p_AoBo_B, p_AB);
+  }
+
+  multXX(X_AB, X_BC, r);
+}
+
+void multXinvX(const double* X_BA, const double* X_BC, double* r /*X_AC*/) {
+  multXinvX_NoAVX(X_BA, X_BC, r /*X_AC*/);
+}
+
+#else    // Use AVX instructions
+
+void multX2(const double* a /*R_AB*/, const double* x /*p_AB*/,
+            const double* A /*R_BC*/, const double* X /*p_BC*/,
+            double* r /*R_AC*/, double* xx /*p_AC*/) {
+  // constexpr uint64_t yes = 0x8000000000000000ULL;
+  constexpr uint64_t yes = uint64_t(1ull << 63);
+  constexpr uint64_t no  = uint64_t(0);
+  const __m256i mask = _mm256_setr_epi64x(yes, yes, yes, no);
+  const __m256d col0 = _mm256_loadu_pd(a);    // a b c (d)  d is unused
+  const __m256d col1 = _mm256_loadu_pd(a+3);  // d e f (g)  g is unused
+  const __m256d col2 = _mm256_maskload_pd(a+6, mask);  // g h i (0)
+  // Column rst
+  __m256d dup0 = _mm256_broadcast_sd(A);    // A A A A
+  __m256d dup1 = _mm256_broadcast_sd(A+1);  // B B B B
+  __m256d dup2 = _mm256_broadcast_sd(A+2);  // C C C C
+  __m256d res = _mm256_mul_pd(col0, dup0);  // aA bA cA (dA)
+  // aA+dB bA+eB cA+fB (dA+gB)
+  res = _mm256_fmadd_pd(col1, dup1, res);
+  // aA+dB+gC bA+eB+hC cA+fB+iC (dA+gB+0C)
+  res = _mm256_fmadd_pd(col2, dup2, res);
+  _mm256_storeu_pd(r, res);                // r s t (u)  will overwrite u
+  // Column uvw
+  dup0 = _mm256_broadcast_sd(A+3);         // D D D D
+  dup1 = _mm256_broadcast_sd(A+4);         // E E E E
+  dup2 = _mm256_broadcast_sd(A+5);         // F F F F
+  res = _mm256_mul_pd(col0, dup0);         // aD bD cD (dD)
+  res = _mm256_fmadd_pd(col1, dup1, res);  // aD+dE bD+eE cD+fE (dD+gE)
+  // aD+dE+gF bD+eE+hF cD+fE+iF (dD+gE+0F)
+  res = _mm256_fmadd_pd(col2, dup2, res);
+  _mm256_storeu_pd(r+3, res);              // u v w (x)  will overwrite
+  // Column xyz
+  dup0 = _mm256_broadcast_sd(A+6);         // G G G G
+  dup1 = _mm256_broadcast_sd(A+7);         // H H H H
+  dup2 = _mm256_broadcast_sd(A+8);         // I I I I
+  res = _mm256_mul_pd(col0, dup0);         // aG bG cG (dG)
+  res = _mm256_fmadd_pd(col1, dup1, res);  // aG+dH bG+eH cG+fH (dG+gH)
+  // aG+dH+gI bG+eH+hI cG+fH+iI (dG+gH+0I)
+  res = _mm256_fmadd_pd(col2, dup2, res);
+  _mm256_maskstore_pd(r+6, mask, res);      // x y z
+  // Column xx yy zz
+  dup0 = _mm256_broadcast_sd(X);            // X X X X
+  dup1 = _mm256_broadcast_sd(X+1);          // Y Y Y Y
+  dup2 = _mm256_broadcast_sd(X+2);          // Z Z Z Z
+  const __m256d col3 = _mm256_maskload_pd(x, mask);  // x y z (0)
+  res = _mm256_fmadd_pd(col0, dup0, col3);  // x+aX y+bX z+cX (0+dX)
+  // x+aX+dY    y+bX+eY    z+cX+fY    (0+dX+gY)
+  res = _mm256_fmadd_pd(col1, dup1, res);
+  // x+aX+dY+gZ y+bX+eY+hZ z+cX+fY+iZ (0+dX+gY+0Z)
+  res = _mm256_fmadd_pd(col2, dup2, res);
+  _mm256_maskstore_pd(xx, mask, res);       // xx yy zz
+}
+
+// Turn d into d d d d.
+static inline __m256d four(double d) {
+  return _mm256_set1_pd(d);
+}
+
+// Turn *d into *d *d *d *d.
+static inline __m256d four(const double* d) {
+  return _mm256_broadcast_sd(d);
+}
+
+/* Composition of transforms X_AC=X_AB*X_BC.
+Rotation matrix and position vector are adjacent in memory.
+
+We want to perform this 3x3 matrix multiply:
+
+     R_AC    R_AB    R_BC
+
+    r u x   a d g   A D G
+    s v y = b e h * B E H     All column ordered in memory.
+    t w z   c f i   C F I
+
+and    xx   x   a d g   X
+       yy = y + b e h * Y
+       zz   z   c f i   Z
+
+This is 63 flops altogether.
+
+Strategy: compute column rst in parallel, then uvw, then xyz.
+r = aA+dB+gC          xx = x + aX + dY + gZ
+s = bA+eB+hC  etc.    yy = y + bX + eY + hZ
+t = cA+fB+iC          zz = z + cX + fY + iZ
+
+Load columns from left matrix, duplicate elements from right.
+Peform 4 operations in parallel but ignore the 4th result.
+Be careful not to load or store past the last element.
+
+We end up doing 3*4 + 9*8 = 84 flops to get 63 useful ones.
+However, we do that in only 12 floating point instructions
+(three packed multiplies, nine packed fused-multiply-adds).
+*/
+
+// Try multiple accumulators.
+void multXX(const double* a /*X_AB*/, const double* A /*X_BC*/,
+            double* r /*X_AC*/) {
+  constexpr uint64_t yes  = uint64_t(1ull << 63);
+  constexpr uint64_t no  = uint64_t(0);
+  const __m256i mask = _mm256_setr_epi64x(yes, yes, yes, no);
+  __m256d acc0, acc1, acc2, acc3;  // Accumulators.
+
+  const __m256d abcd = _mm256_loadu_pd(a);            // a b c (d)  d is unused
+  const __m256d xyz0 = _mm256_maskload_pd(a+9, mask);  // x y z (0)
+
+  acc0 = _mm256_mul_pd(abcd, four(A));            // aA bA cA (dA)
+  acc1 = _mm256_mul_pd(abcd, four(A+3));          // aD bD cD (dD)
+  acc2 = _mm256_mul_pd(abcd, four(A+6));          // aG bG cG (dG)
+  acc3 = _mm256_fmadd_pd(abcd, four(A+9), xyz0);  // x+aX y+bX z+cX (0+dX)
+
+  const __m256d defg = _mm256_loadu_pd(a+3);      // d e f (g)  g is unused
+  acc0 = _mm256_fmadd_pd(defg, four(A+1), acc0);  // aA+dB bA+eB cA+fB (dA+gB)
+  acc1 = _mm256_fmadd_pd(defg, four(A+4), acc1);  // aD+dE bD+eE cD+fE (dD+gE)
+  acc2 = _mm256_fmadd_pd(defg, four(A+7), acc2);  // aG+dH bG+eH cG+fH (dG+gH)
+  // x+aX+dY    y+bX+eY    z+cX+fY    (0+dX+gY)
+  acc3 = _mm256_fmadd_pd(defg, four(A+10), acc3);
+
+  const __m256d ghix = _mm256_loadu_pd(a+6);      // g h i (x)
+  // aA+dB+gC bA+eB+hC cA+fB+iC (dA+gB+xC)
+  acc0 = _mm256_fmadd_pd(ghix, four(A+2), acc0);
+  // r s t (u)  we will overwrite u
+  _mm256_storeu_pd(r, acc0);
+
+  // aD+dE+gF bD+eE+hF cD+fE+iF (dD+gE+0F)
+  acc1 = _mm256_fmadd_pd(ghix, four(A+5), acc1);
+  _mm256_storeu_pd(r+3, acc1);  // u v w (x)  we will overwrite x
+
+  // aG+dH+gI bG+eH+hI cG+fH+iI (dG+gH+0I)
+  acc2 = _mm256_fmadd_pd(ghix, four(A+8), acc2);
+  _mm256_storeu_pd(r+6, acc2);  // x y z (xx)  we will overwrite xx
+
+  // x+aX+dY+gZ y+bX+eY+hZ z+cX+fY+iZ (0+dX+gY+xZ)
+  acc3 = _mm256_fmadd_pd(ghix, four(A+11), acc3);
+  _mm256_maskstore_pd(r+9, mask, acc3);  // xx yy zz
+
+  _mm256_zeroupper();
+}
+
+/* Composition of transforms X_AC=X_BA⁻¹*X_BC.
+Rotation matrix and position vector are adjacent in memory.
+
+We want to perform this 3x3 matrix multiply:
+
+     R_AC    R_BA⁻¹  R_BC
+
+    r u x   a b c   A D G
+    s v y = d e f * B E H     R_BA⁻¹ is row ordered; R_BC col ordered
+    t w z   g h i   C F I
+
+and    xx   a b c     X   x
+       yy = d e f * ( Y − y )
+       zz   g h i     Z   z
+
+This is 63 flops altogether.
+
+Strategy: compute column rst in parallel, then uvw, then xyz.
+Let PQR=XYZ-xyz.
+r = aA+bB+cC          xx = aP + bQ + cR
+s = dA+eB+fC  etc.    yy = dP + eQ + fR
+t = gA+hB+iC          zz = gP + hQ + iR
+
+Load columns from left matrix, duplicate elements from right.
+Peform 4 operations in parallel but ignore the 4th result.
+Be careful not to load or store past the last element.
+
+We end up doing 5*4 + 8*8 = 84 flops to get 63 useful ones.
+However, we do that in only 13 floating point instructions
+(4 packed multiplies, 1 packed subtract, 8 packed fused-multiply-adds).
+
+This method is about 2X slower than multXX when compiled with
+g++ 7.5, but is almost full speed with clang++ 6.
+*/
+void multXinvX(const double* a /*X_BA*/, const double* A /*X_BC*/,
+               double* r /*X_AC*/) {
+  constexpr uint64_t yes  = uint64_t(1ull << 63);
+  constexpr uint64_t no  = uint64_t(0);
+  const __m256i mask = _mm256_setr_epi64x(yes, yes, yes, no);
+
+  __m256d acc0, acc1, acc2, acc3;  // Accumulators.
+
+  const __m256d abcd = _mm256_loadu_pd(a);
+  const __m256d efgh = _mm256_loadu_pd(a+4);
+  const __m256d ebgh = _mm256_blend_pd(abcd, efgh, 0b1101);  // e b g h
+  const __m256d col1 = _mm256_permute_pd(ebgh, 0b0101);  // b e h (g)
+
+  const __m256d cdgh = _mm256_permute2f128_pd(abcd, efgh, 0b00110001);
+  const __m256d col0 = _mm256_blend_pd(abcd, cdgh, 0b1110);  // a d g (h) fast
+
+  const __m256d fghi = _mm256_loadu_pd(a+5);
+  const __m256d fcih = _mm256_shuffle_pd(fghi, cdgh, 0b1100);  // f c i h
+  const __m256d col2 = _mm256_permute_pd(fcih, 0b1001);  // c f i (h)
+
+  // Calculate PQR
+  const __m256d loadX = _mm256_maskload_pd(A+9, mask);  // X Y Z (0)
+  const __m256d loadx = _mm256_maskload_pd(a+9, mask);  // x y z (0)
+  const __m256d PQR = _mm256_sub_pd(loadX, loadx);  // PQR0 = XYZ0 − xyz0 (0)
+
+  acc0 = _mm256_mul_pd(col0, four(A));         // aA dA gA (bA)
+  acc1 = _mm256_mul_pd(col0, four(A+3));       // aD dD gD (bD)
+  acc2 = _mm256_mul_pd(col0, four(A+6));       // aG dG gG (bG)
+  acc3 = _mm256_mul_pd(col0, four(PQR[0]));    // aP dP gP (bP)
+
+  acc0 = _mm256_fmadd_pd(col1, four(A+1), acc0);   // aA+bB dA+eB gA+hB (bA+cB)
+  acc1 = _mm256_fmadd_pd(col1, four(A+4), acc1);   // aD+bE dD+eE gD+hE (bD+cE)
+  acc2 = _mm256_fmadd_pd(col1, four(A+7), acc2);   // aG+bH dG+eH gG+hH (bG+cH)
+  // aP+bQ dP+eQ gP+hQ (bP+cQ)
+  acc3 = _mm256_fmadd_pd(col1, four(PQR[1]), acc3);
+
+  // aA+bB+cC dA+eB+fC gA+hB+iC (bA+cB+0C)
+  acc0 = _mm256_fmadd_pd(col2, four(A+2), acc0);
+  // r s t (u)  we will overwrite u
+  _mm256_storeu_pd(r, acc0);
+
+  // aD+bE+cF dD+eE+fF gD+hE+iF (bD+cE+0F)
+  acc1 = _mm256_fmadd_pd(col2, four(A+5), acc1);
+  _mm256_storeu_pd(r+3, acc1);  // u v w (x)  we will overwrite x
+
+  // aG+bH+cI dG+eH+fI gG+hH+iI (bG+cH+0I)
+  acc2 = _mm256_fmadd_pd(col2, four(A+8), acc2);
+  _mm256_maskstore_pd(r+6, mask, acc2);  // x y z
+
+  // aP+bQ+cR dP+eQ+fR gP+hQ+iR (bP+cQ+0R)
+  acc3 = _mm256_fmadd_pd(col2, four(PQR[2]), acc3);
+  _mm256_maskstore_pd(r+9, mask, acc3);  // xx yy zz
+
+  _mm256_zeroupper();
+}
+
+#endif  // Use AVX instructions
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake
+

--- a/geometry/proximity/simd_avx.h
+++ b/geometry/proximity/simd_avx.h
@@ -1,0 +1,20 @@
+#pragma once
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+void multX2(const double* a /*R_AB*/, const double* x /*p_AB*/,
+            const double* A /*R_BC*/, const double* X /*p_BC*/,
+            double* r /*R_AC*/, double* xx /*p_AC*/);
+
+void multXX(const double* a /*X_AB*/, const double* A /*X_BC*/,
+            double* r /*X_AC*/);
+
+void multXinvX(const double* a /*X_BA*/, const double* A /*X_BC*/,
+               double* r /*X_AC*/);
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake
+


### PR DESCRIPTION
Experiment to speed up Obb::HasOverlap() using AVX instructions. This experimental PR contains all ideas that I have:

1. Use AVX in composing rigid transforms. (PR #14626)
2. Use `array() + kEpsilon` instead of `for{for{ +kEpsilon}}`. (PR #14628 do both 1 and 2)
3. Use matrix-vector multiplications in Ax,Ay,Az directions. (PR #14629 do 1,2, and 3)
4. Use matrix-vector multiplications in Bx,By,Bz directions.
5. Use matrix-vector multiplications in {Ax,Ay,Az}x{Bx,By,Bz} directions (x means cross product).

Right now using all the above ideas slows down HasOverlap() a lot.  I'll have smaller PRs for each or some of the ideas above. Each of the smaller PR together with #14621 (obb_benchmark) will tell us what to keep.

I intend to use these special build flags for AVX:

```
$ bazel test //geometry/proximity:obb_test \
 --compilation_mode=opt --copt=-g \
 --cxxopt=-march=broadwell
 
$ geometry/benchmarking/obb_benchmark/conduct_experiment ~/project/ObbBench/<record_data>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14623)
<!-- Reviewable:end -->
