### PR TITLE
benchmark_tool: pass extra build args

### DIFF
--- a/tools/performance/benchmark_tool
+++ b/tools/performance/benchmark_tool
@@ -16,6 +16,14 @@ conduct_experiment:
   This operation uses `sudo` commands to install tools for CPU scaling control
   and to actually change the CPU configuration.
 
+  It is possible to customize the bazel build and run steps by using
+  "--extra-build-args=" (a.k.a. "-b=") options:
+
+    benchmark_tool conduct_experiment \\
+      -b=--copt=-mtune=haswell \\
+      -b=--copt=-g \\
+      [TARGET] [OUTPUT-DIR]
+
 copy_results:
   Copy results of a prior run of a designated target to a user selected output
   directory.
@@ -132,7 +140,7 @@ def conduct_experiment(args):
     sudo('apt', 'install', f'linux-tools-{kernel_name}', 'linux-tools-common')
 
     say("Build code.")
-    run('bazel', 'build', args.target)
+    run('bazel', 'build', *args.extra_build_args, args.target)
 
     sleep_seconds = 10
     say(f"Wait {sleep_seconds} seconds for lingering activity to subside.")
@@ -140,7 +148,8 @@ def conduct_experiment(args):
 
     with CpuSpeedSettings().scope(governor="performance", no_turbo="1"):
         say("Run the experiment.")
-        run('bazel', 'run', args.target, '--', *args.extra_args)
+        run('bazel', 'run',
+            *args.extra_build_args, args.target, '--', *args.extra_args)
 
     say(f"Save data to {args.output_dir}/.")
     copy_results(args)
@@ -180,6 +189,9 @@ def main():
         description='run controlled experiment for TARGET,'
         ' copying benchmark data to OUTPUT-DIR')
     add_common_args(parser_conduct_experiment)
+    parser_conduct_experiment.add_argument(
+        '-b', '--extra-build-args', action='append', default=[],
+        help='extra arguments passed to bazel build and run')
     parser_conduct_experiment.add_argument(
         'extra_args', nargs='*',
         help='extra arguments passed to the underlying executable')


### PR DESCRIPTION
There is great interest in experimenting with various modifications to
default build options. One example is to enable modern instruction set
extensions. This patch to benchmark_tool permits callers to pass
arbitrary bazel options to the build and run steps, to allow such
experiments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14624)
<!-- Reviewable:end -->
