### PR TITLE
WIP: Experiment. Further optimize Obb::HasOverlap() using array().abs() instead of `for` loop.

### DIFF
--- a/geometry/benchmarking/BUILD.bazel
+++ b/geometry/benchmarking/BUILD.bazel
@@ -1,6 +1,9 @@
 # -*- python -*-
 
-load("@drake//tools/skylark:drake_cc.bzl", "drake_cc_binary")
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_binary",
+)
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 drake_cc_binary(

--- a/geometry/benchmarking/obb_benchmark/BUILD.bazel
+++ b/geometry/benchmarking/obb_benchmark/BUILD.bazel
@@ -1,0 +1,33 @@
+# -*- python -*-
+
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_binary",
+    "drake_cc_library",
+    "drake_cc_test",
+)
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+drake_cc_test(
+    name = "obb_bench",
+    srcs = ["obb_bench.cc"],
+    linkstatic = True,
+    deps = [
+        "//common:essential",
+        "//geometry/proximity:obb",
+        "@googlebenchmark//:benchmark",
+    ],
+)
+
+sh_test(
+    name = "record_results",
+    size = "small",
+    srcs = ["record_results.sh"],
+    data = [
+        ":obb_bench",
+        "//tools/performance:record_results",
+    ],
+    tags = ["no_valgrind_tools"],
+)
+
+add_lint_tests()

--- a/geometry/benchmarking/obb_benchmark/README.md
+++ b/geometry/benchmarking/obb_benchmark/README.md
@@ -1,0 +1,69 @@
+Obb benchmark
+-------------
+
+Conduct benchmarking experiment under relatively controlled conditions to
+minimize runtime variations between repeated runs by controlling CPUs. 
+
+## Supported experiments
+
+General syntax:
+
+    $ geometry/benchmarking/obb_benchmark/conduct_experiment [DIRECTORY] [ARGS...]
+
+This is an example of how to run the benchmark:
+
+    $ geometry/benchmarking/obb_benchmark/conduct_experiment \
+      ~/project/ObbBench/record
+      
+You will get these files in ~/project/ObbBench/record directory.
+
+    $ ls ~/project/ObbBench/record/
+    compiler.txt  kernel.txt  os.txt  outputs.zip  results.json  summary.txt
+    
+The file summary.txt shows the statistics towards the end of the file.
+
+    $ tail -n12 ~/project/ObbBench/record/summary.txt
+    -------------------------------------------------------------------------------------
+    Benchmark                                           Time             CPU   Iterations
+    -------------------------------------------------------------------------------------
+    BM_ObbHasOverlap_31_Cases_mean                   3413 ns         3413 ns            9
+    BM_ObbHasOverlap_31_Cases_median                 3409 ns         3409 ns            9
+    BM_ObbHasOverlap_31_Cases_stddev                 7.96 ns         7.97 ns            9
+    BM_ObbHasOverlap_16_OverlapCases_mean            1920 ns         1920 ns            9
+    BM_ObbHasOverlap_16_OverlapCases_median          1911 ns         1911 ns            9
+    BM_ObbHasOverlap_16_OverlapCases_stddev          10.5 ns         10.5 ns            9
+    BM_ObbHasOverlap_15_NonOverlapCases_mean         1551 ns         1551 ns            9
+    BM_ObbHasOverlap_15_NonOverlapCases_median       1543 ns         1543 ns            9
+    BM_ObbHasOverlap_15_NonOverlapCases_stddev       9.67 ns         9.67 ns            9
+
+## Prepare for AVX Experiments
+
+The above data is from the default build flags on my puget-183882-03.
+Next I switched "*conduct_experiment*" to these build flags:
+
+    ./tools/performance/benchmark_tool conduct_experiment \
+        -b=--compilation_mode=opt \
+        -b=--copt=-g \
+        -b=--cxxopt=-march=broadwell \
+        $TARGET "$OUTPUT_DIR" -- "$@"
+
+Then, I got:
+
+    $ tail -n12 ~/project/ObbBench/2021-02-05_1400_broadwell/summary.txt 
+    -------------------------------------------------------------------------------------
+    Benchmark                                           Time             CPU   Iterations
+    -------------------------------------------------------------------------------------
+    BM_ObbHasOverlap_31_Cases_mean                   3498 ns         3498 ns            9
+    BM_ObbHasOverlap_31_Cases_median                 3490 ns         3490 ns            9
+    BM_ObbHasOverlap_31_Cases_stddev                 12.7 ns         12.7 ns            9
+    BM_ObbHasOverlap_16_OverlapCases_mean            1874 ns         1874 ns            9
+    BM_ObbHasOverlap_16_OverlapCases_median          1875 ns         1875 ns            9
+    BM_ObbHasOverlap_16_OverlapCases_stddev          9.21 ns         9.20 ns            9
+    BM_ObbHasOverlap_15_NonOverlapCases_mean         1512 ns         1512 ns            9
+    BM_ObbHasOverlap_15_NonOverlapCases_median       1504 ns         1504 ns            9
+    BM_ObbHasOverlap_15_NonOverlapCases_stddev       9.11 ns         9.11 ns            9
+
+## More info
+
+Google Benchmark Documentation
+https://github.com/google/benchmark#benchmark

--- a/geometry/benchmarking/obb_benchmark/conduct_experiment
+++ b/geometry/benchmarking/obb_benchmark/conduct_experiment
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Execute the complete set of steps for a well-controlled benchmark experiment.
+
+set -e -u -o pipefail
+
+TARGET=//geometry/benchmarking/obb_benchmark:record_results
+ME=$(python3 -c 'import os; print(os.path.realpath("'"$0"'"))')
+HERE=$(dirname $ME)
+
+OUTPUT_DIR="$1"
+shift
+
+cd "$HERE"/../../..
+
+./tools/performance/benchmark_tool conduct_experiment \
+    -b=--compilation_mode=opt \
+    -b=--copt=-g \
+    -b=--cxxopt=-march=broadwell \
+    $TARGET "$OUTPUT_DIR" -- "$@"

--- a/geometry/benchmarking/obb_benchmark/copy_results_to
+++ b/geometry/benchmarking/obb_benchmark/copy_results_to
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Copy benchmark results to a user-chosen directory.
+
+set -e -u -o pipefail
+
+TARGET=//geometry/benchmarking/obb_benchmark:record_results
+ME=$(python3 -c 'import os; print(os.path.realpath("'"$0"'"))')
+HERE=$(dirname $ME)
+
+cd "$HERE"/../../..
+
+./tools/performance/benchmark_tool copy_results $TARGET "$1"

--- a/geometry/benchmarking/obb_benchmark/obb_bench.cc
+++ b/geometry/benchmarking/obb_benchmark/obb_bench.cc
@@ -1,0 +1,338 @@
+#include <benchmark/benchmark.h>
+
+#include "drake/common/drake_assert.h"
+#include "drake/geometry/proximity/obb.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+using Eigen::AngleAxisd;
+using Eigen::Matrix3d;
+using Eigen::Vector3d;
+using math::RigidTransformd;
+using math::RollPitchYawd;
+using math::RotationMatrixd;
+
+struct TestData {
+  TestData(const Obb& a_G_in, const Obb& b_H_in, const RigidTransformd& X_GH_in,
+           const bool& expect_overlap_in)
+      : a_G(a_G_in),
+        b_H(b_H_in),
+        X_GH(X_GH_in),
+        expect_overlap(expect_overlap_in) {}
+
+  Obb a_G;
+  Obb b_H;
+  RigidTransformd X_GH;
+  // I can use this field to separate the overlapping cases from the
+  // non-overlapping cases. The two set of inputs could have very different
+  // performance. In general, non-overlapping cases will return earlier than
+  // the overlapping cases.
+  bool expect_overlap;
+};
+
+void Obb_HasOverlap(const std::vector<TestData>& test_data) {
+  for (const TestData& t : test_data) {
+    DRAKE_DEMAND(t.expect_overlap == Obb::HasOverlap(t.a_G, t.b_H, t.X_GH));
+  }
+}
+
+// We want to compute X_AB such that B is posed relative to A as documented in
+// TestObbOverlap. We can do so by generating the rotation component, R_AB, such
+// that Bq has a minimum value along the chosen axis, and we can solve for
+// the translation component, p_AoBo_A = p_AoAf_A + p_AfBq_A + p_BqBo_A.
+RigidTransformd CalcCornerTransform(const Obb& a, const Obb& b, const int axis,
+                                    const bool expect_overlap);
+
+// We want to compute X_AB such that B is posed relative to A as documented
+// in TestObbOverlap. We can do so by generating the rotation component, R_AB,
+// such that Bq lies on the minimum edge along the chosen axis, and we can solve
+// for the translation component, p_AoBo_A = p_AoAf_A + p_AfBq_A + p_BqBo_A.
+RigidTransformd CalcEdgeTransform(const Obb& a, const Obb& b, const int a_axis,
+                                  const int b_axis, const bool expect_overlap);
+
+
+// TODO(DamrongGuoy): Explain why the return vector has 31 records.
+//  It is 2 * 15 + 1.  The number 2 is true or false (overlap or not).
+//  The number 15 is directions <=> Ax,Ay,Az, Bx,By,Bz, {Ax,Ay,Az}x{Bx,By,Bz}.
+//  The number 1 is the single parallel case.
+
+// Set up data for OBBs overlap. There are 15 cases to test, each covering a
+// separating axis between the two bounding boxes. The first 3 cases use the
+// axes of Frame A, the next 3 cases use the axes of Frame B, and the remaining
+// 9 cases use the axes defined by the cross product of axes from Frame A and
+// Frame B. We also test that it is robust for the case of parallel boxes.
+std::vector<TestData> SetUp31Records() {
+  std::vector<TestData> test_data;
+  // Frame strategy. For the canonical frame A of box `a` and the
+  // canonical frame B of box `b`, we want to control the pose X_AB between
+  // the two boxes. However, we need to give HasOverlap() the pose X_GH
+  // between the hierarchy frames G and H to which box `a` and box `b`
+  // belong. Our strategy is to control the tests through X_AB and then compose
+  // X_GH as:
+  //                 X_GH = X_GA * X_AB * X_BH.
+  // Frame A of box `a` is arbitrarily posed in the hierarchy frame G.
+  const RigidTransformd X_GA{
+      RotationMatrixd(RollPitchYawd(2. * M_PI / 3., M_PI_4, -M_PI / 3.)),
+      Vector3d(1, 2, 3)};
+  // Frame B of box `b` is arbitrarily posed in the hierarchy frame H.
+  const RigidTransformd X_HB{
+      RotationMatrixd(RollPitchYawd(M_PI_4, M_PI / 5., M_PI / 6.)),
+      Vector3d(2, 0.5, 4)};
+  const RigidTransformd X_BH = X_HB.inverse();
+  // One box is fully contained in the other and they are parallel. We make
+  // them parallel by setting X_AB to identity.
+  RigidTransformd X_AB = RigidTransformd::Identity();
+  Obb a(X_GA, Vector3d(1, 2, 1));
+  Obb b(X_HB, Vector3d(0.5, 1, 0.5));
+  test_data.emplace_back(a, b, X_GA * X_AB * X_BH /* X_GH */, true);
+  // To cover the cases of the axes of Frame A, we need to pose box B along
+  // each axis. For example, in the case of the Ax-axis, in a 2D view they would
+  // look like:
+  //           Ay
+  //           ^
+  //   --------|--------      ⋰ ⋱       ↗By
+  //   |       |       |   ⋰      ⋱  ↗
+  //   |       |       Af Bq       ↗⋱
+  //   |       |       |     ⋱   Bo   ⋱
+  //   |      Ao--------->Ax   ⋱    ↘   ⋱
+  //   |               |         ⋱    ↘⋰
+  //   |               |           ⋱⋰   ↘Bx
+  //   |               |
+  //   -----------------
+  //
+  //                                Hy
+  //                                ⇑
+  // Gy             Gx              ⇑
+  //   ⇖           ⇗                ⇑
+  //     ⇖       ⇗                  ⇑
+  //       ⇖   ⇗                    ⇑
+  //         Go                     Ho ⇒ ⇒ ⇒ ⇒ ⇒ Hx
+  //
+  //
+  // For this test, we define Point Bq as the minimum corner of the box B (i.e.,
+  // center - half width). We want to pose box B so Bq is the uniquely closest
+  // point to box A at a Point Af in the interior of +Ax face. The rest of
+  // the box B extends farther along the +Ax axis (as suggested in the above
+  // illustration). Point Bq will be a small epsilon away from the nearby face
+  // either outside (if expect_overlap is false) or inside (if true).
+  a = Obb(X_GA, Vector3d(2, 4, 3));
+  b = Obb(X_HB, Vector3d(3.5, 2, 1.5));
+  for (int axis = 0; axis < 3; ++axis) {
+    X_AB = CalcCornerTransform(a, b, axis, false /* expect_overlap */);
+    test_data.emplace_back(a, b, X_GA * X_AB * X_BH /* X_GH */, false);
+    X_AB = CalcCornerTransform(a, b, axis, true /* expect_overlap */);
+    test_data.emplace_back(a, b, X_GA * X_AB * X_BH /* X_GH */, true);
+  }
+  // To cover the local axes out of B, we can use the same method by swapping
+  // the order of the boxes and then using the inverse of the transform.
+  for (int axis = 0; axis < 3; ++axis) {
+    X_AB =
+        CalcCornerTransform(b, a, axis, false /* expect_overlap */).inverse();
+    test_data.emplace_back(a, b, X_GA * X_AB * X_BH /* X_GH */, false);
+    X_AB = CalcCornerTransform(b, a, axis, true /* expect_overlap */).inverse();
+    test_data.emplace_back(a, b, X_GA * X_AB * X_BH /* X_GH */, true);
+  }
+  // To cover the remaining 9 cases, we need to pose an edge from box B along
+  // an edge from box A. The axes that the edges are aligned with form the
+  // two inputs into the cross product for the separating axis. For example,
+  // in the following illustration, Af lies on the edge aligned with A's y-axis.
+  // Assuming that Bq lies on an edge aligned with B's x-axis, this would form
+  // the case testing the separating axis Ay × Bx.
+  //                       _________
+  //   +z                 /________/\              .
+  //    ^                 \        \ \             .
+  //    |   ______________ Bq       \ \            .
+  //    |  |\             Af \  Bo   \ \           .
+  //    |  | \ _____________\ \       \ \          .
+  // +y |  | |      Ao      |  \_______\/          .
+  //  \ |  \ |              |                      .
+  //   \|   \|______________|                      .
+  //    -----------------------------------> +x
+  //
+  // For this test, we define point Bq on the minimum edge of the box in its
+  // own frame (i.e., center - half width + an offset along the edge). We want
+  // to pose box B so Bq is the uniquely closest point to A at a Point Af on the
+  // edge between the +x and +z face of box A. The rest of box B extends
+  // farther along the +Ax and +Az axis (as suggested in the above
+  // illustration). Point Bq will be a small epsilon away from the nearby
+  // edge either outside (if expect_overlap is false) or inside (if true).
+  for (int a_axis = 0; a_axis < 3; ++a_axis) {
+    for (int b_axis = 0; b_axis < 3; ++b_axis) {
+      X_AB =
+          CalcEdgeTransform(a, b, a_axis, b_axis, false /* expect_overlap */);
+      // Separate along a's y-axis and b's x-axis.
+      test_data.emplace_back(a, b, X_GA * X_AB * X_BH  /* X_GH */, false);
+      X_AB =
+          CalcEdgeTransform(a, b, a_axis, b_axis, true /* expect_overlap */);
+      // Separate along a's y-axis and b's x-axis.
+      test_data.emplace_back(a, b, X_GA * X_AB * X_BH  /* X_GH */, true);
+    }
+  }
+
+  return test_data;
+}
+
+RigidTransformd CalcCornerTransform(const Obb& a, const Obb& b, const int axis,
+                                      const bool expect_overlap) {
+  const int axis1 = (axis + 1) % 3;
+  const int axis2 = (axis + 2) % 3;
+  // Construct the rotation matrix, R_AB, that has meaningful (non-zero)
+  // values everywhere for the remaining 2 axes and no symmetry.
+  const RotationMatrixd R_AB =
+      RotationMatrixd(AngleAxisd(M_PI / 5, Vector3d::Unit(axis1))) *
+          RotationMatrixd(AngleAxisd(-M_PI / 5, Vector3d::Unit(axis2)));
+
+  // We define p_BqBo in Frame A from box b's minimum corner Q to its center.
+  const Vector3d p_BqBo_A = R_AB * b.half_width();
+  // Reality check that the minimum corner and the center are strictly
+  // increasing along the given axis because we chose the rotation R_AB to
+  // support this property.
+  DRAKE_DEMAND(p_BqBo_A[axis] > 0.);
+
+  // We construct Bq to be a small relative offset either side of Af along the
+  // given A[axis], depending on whether we expect the boxes to overlap.
+  Vector3d p_AfBq_A{0, 0, 0};
+  p_AfBq_A[axis] = expect_overlap ? -0.01 : 0.01;
+
+  // We construct Af by taking the maximum corner and offsetting it along the
+  // remaining 2 axes, e.g. by a quarter across. This ensures we thoroughly
+  // exercise all bits instead of simply using any midpoints or corners.
+  //
+  //           A[axis1]
+  //           ^
+  //   --------|--------
+  //   |       |       |
+  //   |       |       Af
+  //   |       |       |
+  //   |      Ao------->A[axis]
+  //   |               |
+  //   |               |
+  //   |               |
+  //   -----------------
+  //
+  Vector3d p_AoAf_A = a.half_width();
+  p_AoAf_A[axis1] /= 2;
+  p_AoAf_A[axis2] /= 2;
+
+  const Vector3d p_AoBo_A = p_AoAf_A + p_AfBq_A + p_BqBo_A;
+  return RigidTransformd(R_AB, p_AoBo_A);
+}
+
+// We want to compute X_AB such that B is posed relative to A as documented
+// in TestObbOverlap. We can do so by generating the rotation component, R_AB,
+// such that Bq lies on the minimum edge along the chosen axis, and we can solve
+// for the translation component, p_AoBo_A = p_AoAf_A + p_AfBq_A + p_BqBo_A.
+RigidTransformd CalcEdgeTransform(const Obb& a, const Obb& b, const int a_axis,
+                                  const int b_axis, const bool expect_overlap) {
+  const int a_axis1 = (a_axis + 1) % 3;
+  const int a_axis2 = (a_axis + 2) % 3;
+  const int b_axis1 = (b_axis + 1) % 3;
+  const int b_axis2 = (b_axis + 2) % 3;
+  // Construct a rotation matrix that has meaningful (non-zero) values
+  // everywhere for the remaining 2 axes and no symmetry. Depending on the
+  // combination of axes, we need to rotate around different axes to ensure
+  // the edge remains as the minimum.
+  RotationMatrixd R_AB;
+  const double theta = M_PI / 5;
+  // For cases Ax × Bx, Ay × By, and Az × Bz.
+  if (a_axis == b_axis) {
+    R_AB = RotationMatrixd(AngleAxisd(theta, Vector3d::Unit(b_axis1))) *
+        RotationMatrixd(AngleAxisd(theta, Vector3d::Unit(b_axis2)));
+    // For cases Ax × By, Ay × Bz, and Az × Bx.
+  } else if (a_axis1 == b_axis) {
+    R_AB = RotationMatrixd(AngleAxisd(theta, Vector3d::Unit(b_axis1))) *
+        RotationMatrixd(AngleAxisd(-theta, Vector3d::Unit(b_axis2)));
+    // For cases Ax × Bz, Ay × Bx, and Az × By.
+  } else {
+    R_AB = RotationMatrixd(AngleAxisd(-theta, Vector3d::Unit(b_axis2))) *
+        RotationMatrixd(AngleAxisd(theta, Vector3d::Unit(b_axis1)));
+  }
+
+  // We define p_BqBo in Frame B taking a point on the minimum edge aligned
+  // with the given axis, offset it to be without symmetry, then convert it
+  // to Frame A by applying the rotation.
+  Vector3d p_BqBo_B = b.half_width();
+  p_BqBo_B[b_axis] -= b.half_width()[b_axis] / 2;
+  const Vector3d p_BqBo_A = R_AB * p_BqBo_B;
+  // Reality check that the point Bq and the center Bo are strictly
+  // increasing along the remaining 2 axes because we chose the rotation R_AB
+  // to support this property.
+  DRAKE_DEMAND(p_BqBo_A[a_axis1] > 0);
+  DRAKE_DEMAND(p_BqBo_A[a_axis2] > 0);
+
+  // We construct Bq to be a small relative offset either side of Af along the
+  // given axis, depending on whether we expect the boxes to overlap.
+  Vector3d p_AfBq_A{0, 0, 0};
+  const double offset = expect_overlap ? -0.01 : 0.01;
+  p_AfBq_A[a_axis1] = offset;
+  p_AfBq_A[a_axis2] = offset;
+
+  // We construct Af by taking the maximum corner and offsetting it along the
+  // given edge to thoroughly exercise all bits.
+  Vector3d p_AoAf_A = a.half_width();
+  p_AoAf_A[a_axis] -= a.half_width()[a_axis] / 2;
+
+  Vector3d p_AoBo_A = p_AoAf_A + p_AfBq_A + p_BqBo_A;
+  // Finally we combine the components to form the transform X_AB.
+  return RigidTransformd(R_AB, p_AoBo_A);
+}
+
+// NOLINTNEXTLINE(runtime/references) cpplint disapproves of gbench choices.
+static void BM_ObbHasOverlap_31_Cases(benchmark::State& state) {
+  // Perform setup here
+  std::vector<TestData> test_data = SetUp31Records();
+  int num_data = test_data.size();
+  DRAKE_DEMAND(num_data == 31);
+
+  for (auto _ : state) {
+    // This code gets timed
+    Obb_HasOverlap(test_data);
+  }
+}
+// Register the function as a benchmark
+BENCHMARK(BM_ObbHasOverlap_31_Cases);
+
+// NOLINTNEXTLINE(runtime/references) cpplint disapproves of gbench choices.
+static void BM_ObbHasOverlap_16_OverlapCases(benchmark::State& state) {
+  // Perform setup here
+  std::vector<TestData> superset = SetUp31Records();
+  std::vector<TestData> test_data;
+  for (const TestData& t : superset)
+    if (t.expect_overlap) test_data.push_back(t);
+  int num_data = test_data.size();
+  DRAKE_DEMAND(num_data == 16);
+
+  for (auto _ : state) {
+    // This code gets timed
+    Obb_HasOverlap(test_data);
+  }
+}
+// Register the function as a benchmark
+BENCHMARK(BM_ObbHasOverlap_16_OverlapCases);
+
+// NOLINTNEXTLINE(runtime/references) cpplint disapproves of gbench choices.
+static void BM_ObbHasOverlap_15_NonOverlapCases(benchmark::State& state) {
+  // Perform setup here
+  std::vector<TestData> superset = SetUp31Records();
+  std::vector<TestData> test_data;
+  for (const TestData& t : superset)
+    if (!t.expect_overlap) test_data.push_back(t);
+  int num_data = test_data.size();
+  DRAKE_DEMAND(num_data == 15);
+
+  for (auto _ : state) {
+    // This code gets timed
+    Obb_HasOverlap(test_data);
+  }
+}
+// Register the function as a benchmark
+BENCHMARK(BM_ObbHasOverlap_15_NonOverlapCases);
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake
+
+BENCHMARK_MAIN();
+

--- a/geometry/benchmarking/obb_benchmark/record_results.sh
+++ b/geometry/benchmarking/obb_benchmark/record_results.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Collect context information for a benchmark experiment.
+
+${TEST_SRCDIR}/drake/tools/performance/record_results \
+    ${TEST_SRCDIR}/drake/geometry/benchmarking/obb_benchmark/obb_bench \
+    "$@"

--- a/geometry/proximity/obb.cc
+++ b/geometry/proximity/obb.cc
@@ -3,6 +3,8 @@
 #include <algorithm>
 #include <limits>
 
+#include <immintrin.h>
+
 #include "drake/geometry/proximity/surface_mesh.h"
 #include "drake/geometry/proximity/volume_mesh.h"
 
@@ -16,30 +18,52 @@ using math::RigidTransformd;
 using math::RollPitchYawd;
 using math::RotationMatrixd;
 
+void multX2(const double* a /*R_AB*/, const double* x /*p_AB*/,
+            const double* A /*R_BC*/, const double* X /*p_BC*/,
+            double* r /*R_AC*/, double* xx /*p_AC*/);
+
 bool Obb::HasOverlap(const Obb& a, const Obb& b,
                      const math::RigidTransformd& X_GH) {
   // The canonical frame A of box `a` is posed in the hierarchy frame G, and
   // the canonical frame B of box `b` is posed in the hierarchy frame H.
   const RigidTransformd& X_GA = a.pose();
   const RigidTransformd& X_HB = b.pose();
-  const RigidTransformd X_AB = X_GA.inverse() * X_GH * X_HB;
 
-  // We need to split the transform into the position and rotation components,
-  // `p_AB` and `R_AB`. For the purposes of streamlining the math below, they
-  // will henceforth be named `t` and `r` respectively.
-  const Vector3d& t = X_AB.translation();
-  const Matrix3d& r = X_AB.rotation().matrix();
+  // Previously we composed the rigid transforms like this:
+  //
+  // const RigidTransformd X_AB = X_GA.inverse() * X_GH * X_HB;
+  //
+  // Now we will use AVX instructions and do composition in two steps.
+  // Step 1. Get R_AH and p_AH from X_GA.inverse() and X_GH.
+  const RigidTransformd& X_AG = X_GA.inverse();
+  const double* R_AG = &X_AG.rotation().matrix().coeff(0, 0);
+  const double* p_AG = &X_AG.translation().coeff(0);
+  const double* R_GH = &X_GH.rotation().matrix().coeff(0, 0);
+  const double* p_GH = &X_GH.translation().coeff(0);
+  double R_AH[9];
+  double p_AH[3];
+  multX2(R_AG, p_AG, R_GH, p_GH, R_AH, p_AH);
+  // Step 2. Get R_AB and p_AB from (R_AH, p_AH) and X_HB.
+  const double* R_HB = &X_HB.rotation().matrix().coeff(0, 0);
+  const double* p_HB = &X_HB.translation().coeff(0);
+  double R_AB_double[9];
+  double p_AB_double[3];
+  multX2(R_AH, p_AH, R_HB, p_HB, R_AB_double, p_AB_double);
+
+  const Vector3d p_AB(p_AB_double);
+  const Matrix3d R_AB(R_AB_double);
+
+  // We need to split the transform into the position and rotation
+  // components, `p_AB` and `R_AB`. For the purposes of streamlining the
+  // math below, they will henceforth be named `t` and `r` respectively.
+  const Vector3d t(p_AB_double);
+  const Matrix3d r(R_AB_double);
 
   // Compute some common subexpressions and add epsilon to counteract
   // arithmetic error, e.g. when two edges are parallel. We use the value as
   // specified from Gottschalk's OBB robustness tests.
   const double kEpsilon = 0.000001;
-  Matrix3d abs_r = r;
-  for (int i = 0; i < 3; ++i) {
-    for (int j = 0; j < 3; ++j) {
-      abs_r(i, j) = abs(abs_r(i, j)) + kEpsilon;
-    }
-  }
+  Matrix3d abs_r = r.array().abs() + kEpsilon;
 
   // First category of cases separating along a's axes.
   for (int i = 0; i < 3; ++i) {
@@ -79,6 +103,51 @@ bool Obb::HasOverlap(const Obb& a, const Obb& b,
   }
 
   return true;
+}
+
+void multX2(const double* a /*R_AB*/, const double* x /*p_AB*/,
+            const double* A /*R_BC*/, const double* X /*p_BC*/,
+            double* r /*R_AC*/, double* xx /*p_AC*/) {
+  //constexpr uint64_t yes = 0x8000000000000000ULL;    //NOLINT(*)
+  constexpr uint64_t yes  = uint64_t(1ull << 63);    //NOLINT(*)
+  constexpr uint64_t no  = uint64_t(0);    //NOLINT(*)
+  const __m256i mask = _mm256_setr_epi64x(yes, yes, yes, no);    //NOLINT(*)
+  const __m256d col0 = _mm256_loadu_pd(a);            // a b c (d)  d is unused    //NOLINT(*)
+  const __m256d col1 = _mm256_loadu_pd(a+3);          // d e f (g)  g is unused    //NOLINT(*)
+  const __m256d col2 = _mm256_maskload_pd(a+6, mask); // g h i (0)    //NOLINT(*)
+  // Column rst    //NOLINT(*)
+  __m256d dup0 = _mm256_broadcast_sd(A);  // A A A A    //NOLINT(*)
+  __m256d dup1 = _mm256_broadcast_sd(A+1);// B B B B    //NOLINT(*)
+  __m256d dup2 = _mm256_broadcast_sd(A+2);// C C C C    //NOLINT(*)
+  __m256d res = _mm256_mul_pd(col0, dup0);        // aA bA cA (dA)    //NOLINT(*)
+  res = _mm256_fmadd_pd(col1, dup1, res); // aA+dB bA+eB cA+fB (dA+gB)    //NOLINT(*)
+  res = _mm256_fmadd_pd(col2, dup2, res); // aA+dB+gC bA+eB+hC cA+fB+iC (dA+gB+0C)    //NOLINT(*)
+  _mm256_storeu_pd(r, res);               // r s t (u)  will overwrite u    //NOLINT(*)
+  // Column uvw    //NOLINT(*)
+  dup0 = _mm256_broadcast_sd(A+3);        // D D D D    //NOLINT(*)
+  dup1 = _mm256_broadcast_sd(A+4);        // E E E E    //NOLINT(*)
+  dup2 = _mm256_broadcast_sd(A+5);        // F F F F    //NOLINT(*)
+  res = _mm256_mul_pd(col0, dup0);        // aD bD cD (dD)    //NOLINT(*)
+  res = _mm256_fmadd_pd(col1, dup1, res); // aD+dE bD+eE cD+fE (dD+gE)    //NOLINT(*)
+  res = _mm256_fmadd_pd(col2, dup2, res); // aD+dE+gF bD+eE+hF cD+fE+iF (dD+gE+0F)    //NOLINT(*)
+  _mm256_storeu_pd(r+3, res);             // u v w (x)  will overwrite x    //NOLINT(*)
+  // Column xyz    //NOLINT(*)
+  dup0 = _mm256_broadcast_sd(A+6);        // G G G G    //NOLINT(*)
+  dup1 = _mm256_broadcast_sd(A+7);        // H H H H    //NOLINT(*)
+  dup2 = _mm256_broadcast_sd(A+8);        // I I I I    //NOLINT(*)
+  res = _mm256_mul_pd(col0, dup0);        // aG bG cG (dG)    //NOLINT(*)
+  res = _mm256_fmadd_pd(col1, dup1, res); // aG+dH bG+eH cG+fH (dG+gH)    //NOLINT(*)
+  res = _mm256_fmadd_pd(col2, dup2, res); // aG+dH+gI bG+eH+hI cG+fH+iI (dG+gH+0I)    //NOLINT(*)
+  _mm256_maskstore_pd(r+6, mask, res);    // x y z    //NOLINT(*)
+  // Column xx yy zz    //NOLINT(*)
+  dup0 = _mm256_broadcast_sd(X);            // X X X X    //NOLINT(*)
+  dup1 = _mm256_broadcast_sd(X+1);          // Y Y Y Y    //NOLINT(*)
+  dup2 = _mm256_broadcast_sd(X+2);          // Z Z Z Z    //NOLINT(*)
+  const __m256d col3 = _mm256_maskload_pd(x, mask); // x y z (0)    //NOLINT(*)
+  res = _mm256_fmadd_pd(col0, dup0, col3);// x+aX y+bX z+cX (0+dX)    //NOLINT(*)
+  res = _mm256_fmadd_pd(col1, dup1, res); // x+aX+dY    y+bX+eY    z+cX+fY    (0+dX+gY)    //NOLINT(*)
+  res = _mm256_fmadd_pd(col2, dup2, res); // x+aX+dY+gZ y+bX+eY+hZ z+cX+fY+iZ (0+dX+gY+0Z)    //NOLINT(*)
+  _mm256_maskstore_pd(xx, mask, res);     // xx yy zz    //NOLINT(*)
 }
 
 bool Obb::HasOverlap(const Obb& bv, const Plane<double>& plane_P,

--- a/tools/performance/benchmark_tool
+++ b/tools/performance/benchmark_tool
@@ -132,7 +132,7 @@ def conduct_experiment(args):
     sudo('apt', 'install', f'linux-tools-{kernel_name}', 'linux-tools-common')
 
     say("Build code.")
-    run('bazel', 'build', args.target)
+    run('bazel', 'build', *args.extra_build_args, args.target)
 
     sleep_seconds = 10
     say(f"Wait {sleep_seconds} seconds for lingering activity to subside.")
@@ -140,7 +140,8 @@ def conduct_experiment(args):
 
     with CpuSpeedSettings().scope(governor="performance", no_turbo="1"):
         say("Run the experiment.")
-        run('bazel', 'run', args.target, '--', *args.extra_args)
+        run('bazel', 'run',
+            *args.extra_build_args, args.target, '--', *args.extra_args)
 
     say(f"Save data to {args.output_dir}/.")
     copy_results(args)
@@ -180,6 +181,9 @@ def main():
         description='run controlled experiment for TARGET,'
         ' copying benchmark data to OUTPUT-DIR')
     add_common_args(parser_conduct_experiment)
+    parser_conduct_experiment.add_argument(
+        '-b', '--extra-build-args', action='append', default=[],
+        help='extra arguments passed to bazel build and run')
     parser_conduct_experiment.add_argument(
         'extra_args', nargs='*',
         help='extra arguments passed to the underlying executable')


### PR DESCRIPTION
(Rebase on ObbHasOverlapBenchMark #14621)
(Branch out of ObbHasOverlapAVXTransformOnly #14626)

Use array().abs() + kEpsilon instead of for{for{abs() + kEpsilon}}.

It can improve obb_benchmark slightly to:
```
$ tail -n12 ~/project/ObbBench/2021-02-05_1510_ObbAVXTransformArray/summary.txt 
-------------------------------------------------------------------------------------
Benchmark                                           Time             CPU   Iterations
-------------------------------------------------------------------------------------
BM_ObbHasOverlap_31_Cases_mean                   2922 ns         2922 ns            9
BM_ObbHasOverlap_31_Cases_median                 2919 ns         2919 ns            9
BM_ObbHasOverlap_31_Cases_stddev                 5.26 ns         5.25 ns            9
BM_ObbHasOverlap_16_OverlapCases_mean            1598 ns         1598 ns            9
BM_ObbHasOverlap_16_OverlapCases_median          1598 ns         1598 ns            9
BM_ObbHasOverlap_16_OverlapCases_stddev          1.19 ns         1.20 ns            9
BM_ObbHasOverlap_15_NonOverlapCases_mean         1263 ns         1263 ns            9
BM_ObbHasOverlap_15_NonOverlapCases_median       1264 ns         1263 ns            9
BM_ObbHasOverlap_15_NonOverlapCases_stddev       1.90 ns         1.90 ns            9
```
