### PR TITLE
Fix output port index for kuka_simulation example

### DIFF
--- a/examples/kuka_iiwa_arm/kuka_simulation.cc
+++ b/examples/kuka_iiwa_arm/kuka_simulation.cc
@@ -137,7 +137,7 @@ int DoMain() {
                   plant_state_demux->get_input_port(0));
   builder.Connect(plant_state_demux->get_output_port(0),
                   status_sender->get_position_measured_input_port());
-  builder.Connect(plant_state_demux->get_output_port(0),
+  builder.Connect(plant_state_demux->get_output_port(1),
                   status_sender->get_velocity_estimated_input_port());
   builder.Connect(command_receiver->get_commanded_position_output_port(),
                   status_sender->get_position_commanded_input_port());


### PR DESCRIPTION
Noticed this while trying out the demo. This demultiplexer output port should be 1 for velocity (0 for position).

Signed-off-by: Stephen Brawner <brawner@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14631)
<!-- Reviewable:end -->
