### PR TITLE
Revert "Pass the time limit to OSQP settings"

### DIFF
--- a/solvers/osqp_solver.cc
+++ b/solvers/osqp_solver.cc
@@ -230,7 +230,6 @@ void SetOsqpSolverSettings(const SolverOptions& solver_options,
   // Default polish to true, to get an accurate solution.
   SetOsqpSolverSettingWithDefaultValue(options_int, "polish",
                                        &(settings->polish), 1);
-  SetOsqpSolverSetting(options_double, "time_limit", &(settings->time_limit));
 }
 
 template <typename C>

--- a/solvers/test/osqp_solver_test.cc
+++ b/solvers/test/osqp_solver_test.cc
@@ -176,49 +176,6 @@ GTEST_TEST(OsqpSolverTest, SolverOptionsTest) {
     EXPECT_NE(result.get_solver_details<OsqpSolver>().status_val, OSQP_SOLVED);
   }
 }
-
-GTEST_TEST(OsqpSolverTest, TimeLimitTest) {
-  // Intentionally create a slightly big problem to get a longer solve time.
-  int n_x = 200;
-
-  MathematicalProgram prog;
-  auto x = prog.NewContinuousVariables(n_x);
-  Eigen::MatrixXd A = Eigen::MatrixXd::Identity(n_x, n_x);
-  Eigen::VectorXd b = Eigen::VectorXd::Ones(n_x);
-  prog.AddLinearConstraint(A, -b, b, x);
-  prog.AddQuadraticErrorCost(A, -1.1 * b, x);
-
-  MathematicalProgramResult result;
-  OsqpSolver osqp_solver;
-  if (osqp_solver.available()) {
-    osqp_solver.Solve(prog, {}, {}, &result);
-    const int OSQP_SOLVED = 1;
-    EXPECT_EQ(result.get_solver_details<OsqpSolver>().status_val, OSQP_SOLVED);
-    // OSQP is not very accurate, use a loose tolerance.
-    EXPECT_TRUE(CompareMatrices(result.GetSolution(x), -b, 1E-5));
-
-    // Now only allow one tenth of the solve time in the OSQP solver. The solver
-    // should not be able to solve the problem in time.
-    const double one_tenth_solve_time =
-        result.get_solver_details<OsqpSolver>().solve_time / 10;
-    SolverOptions solver_options;
-    solver_options.SetOption(osqp_solver.solver_id(), "time_limit",
-                             one_tenth_solve_time);
-    osqp_solver.Solve(prog, {}, solver_options, &result);
-    EXPECT_NE(result.get_solver_details<OsqpSolver>().status_val, OSQP_SOLVED);
-    EXPECT_TRUE(result.get_solver_details<OsqpSolver>().solve_time <
-                one_tenth_solve_time * 2);
-
-    // Now set the options in prog.
-    prog.SetSolverOption(osqp_solver.solver_id(), "time_limit",
-                         one_tenth_solve_time);
-    osqp_solver.Solve(prog, {}, {}, &result);
-    EXPECT_NE(result.get_solver_details<OsqpSolver>().status_val, OSQP_SOLVED);
-    EXPECT_TRUE(result.get_solver_details<OsqpSolver>().solve_time <
-                one_tenth_solve_time * 2);
-  }
-}
-
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake


### PR DESCRIPTION
Dear @yminchen,

The on-call build cop, @avalenzu, believes that your PR #14625  may have
broken one or more of Drake's continuous integration builds [1]. It is
possible to break a build even if your PR passed continuous integration
pre-merge because additional platforms are tested post-merge.

The specific build failures under investigation are:
- https://drake-jenkins.csail.mit.edu/view/Production/job/linux-bionic-clang-bazel-nightly-everything-coverage/842/
- https://drake-jenkins.csail.mit.edu/view/Production/job/linux-focal-clang-bazel-nightly-everything-coverage/250/

Therefore, the build cop has created this revert PR and started a complete
post-merge build to determine whether your PR was in fact the cause of the
problem. If that build passes, this revert PR will be merged 60 minutes from
now. You can then fix the problem at your leisure, and send a new PR to
reinstate your change.

If you believe your original PR did not actually break the build, please
explain on this thread.

If you believe you can fix the break promptly in lieu of a revert, please
explain on this thread, and send a PR to the build cop for review ASAP.

If you believe your original PR definitely did break the build and should be
reverted, please review and LGTM this PR. This allows the build cop to merge
without waiting for CI results.

For advice on how to handle a build cop revert, see [2].

Thanks!
Your Friendly On-call Build Cop

[1] CI Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Production/
[2] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14636)
<!-- Reviewable:end -->
