### PR TITLE
[proximity] Fixes bug in HalfSpace-HalfSpace support for point-pair penetration

### DIFF
--- a/geometry/proximity/penetration_as_point_pair_callback.cc
+++ b/geometry/proximity/penetration_as_point_pair_callback.cc
@@ -331,10 +331,12 @@ struct ScalarSupport {
 /* Primitive support for double-valued query.  */
 template <>
 struct ScalarSupport<double> {
-  static bool is_supported(fcl::NODE_TYPE, fcl::NODE_TYPE) {
-    // Doubles (via its fallback) can support anything. (Including halfspace-X
-    // which is not supported in signed distance queries).
-    return true;
+  static bool is_supported(fcl::NODE_TYPE node1, fcl::NODE_TYPE node2) {
+    // Doubles (via its fallback) can support *almost* anything. Here, we
+    // enumerate the *very* limited unsupported cases. We can't meaningfully
+    // collide two half spaces, but fcl doesn't have an intelligent response.
+    // So, we simply short circuit at this point.
+    return !(node1 == fcl::GEOM_HALFSPACE && node2 == fcl::GEOM_HALFSPACE);
   }
 };
 

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -175,8 +175,15 @@ class QueryObject {
    For two penetrating geometries g_A and g_B, it is guaranteed that they will
    map to `id_A` and `id_B` in a fixed, repeatable manner.
 
-   <h3>Scalar support</h3>
-   This method only provides double-valued penetration results.
+   <h3>Scalar and Shape Support</h3>
+    - For scalar type `double`, we support all Shape-Shape pairs *except* for
+      HalfSpace-HalfSpace. In that case, half spaces are either non-colliding or
+      have an infinite amount of penetration.
+    - For scalar type AutoDiffXd, we only support query pairs Sphere-Box,
+      Sphere-Capsule, Sphere-Cylinder, Sphere-HalfSpace, and Sphere-Sphere.
+
+   For a Shape-Shape pair in collision that is *not* supported for a given
+   scalar type, an exception is thrown.
 
    @returns A vector populated with all detected penetrations characterized as
             point pairs. The ordering of the results is guaranteed to be
@@ -184,10 +191,8 @@ class QueryObject {
             the same.
    @warning For Mesh shapes, their convex hulls are used in this query. It is
             *not* computationally efficient or particularly accurate.
-   @throws if T = AutoDiffXd and an unsupported pair of geometries are in
-   collision. Currently for T = AutoDiffXd, we support the collision between a
-   sphere with another simple geometry including box, cylinder, capsule and
-   halfspace.*/
+   @throws std::exception if unsupported pairs are in contact (see "Scalar
+   and Shape Support" for description of "unsupported pairs").*/
   std::vector<PenetrationAsPointPair<T>> ComputePointPairPenetration() const;
 
   /**


### PR DESCRIPTION
The very special case of `HalfSpace`-`HalfSpace` was not considered. This should throw an error as being a meaningless query. Before this patch, the fcl query would be dispatched and we were at the mercy of how fcl handled it -- it handles it poorly. Now, we officially report a problem.

This also cleans up the documentation in `QueryObject` to reflect the current state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14639)
<!-- Reviewable:end -->
