### PR TITLE
[proximity] Increase ProximityEngine introspection for unit tests

### DIFF
--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -921,6 +921,20 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     return hydroelastic_geometries_;
   }
 
+  bool IsFclConvexType(GeometryId id) const {
+    auto iter = dynamic_objects_.find(id);
+    if (iter == dynamic_objects_.end()) {
+      iter = anchored_objects_.find(id);
+      if (iter == anchored_objects_.end()) {
+        throw std::logic_error(
+            fmt::format("ProximityEngine::IsFclConvexType() cannot be "
+                        "called for invalid geometry id {}.",
+                        id));
+      }
+    }
+    return iter->second->getNodeType() == fcl::GEOM_CONVEX;
+  }
+
  private:
   // Engine on one scalar can see the members of other engines.
   friend class ProximityEngineTester;
@@ -1227,6 +1241,11 @@ template <typename T>
 const hydroelastic::Geometries& ProximityEngine<T>::hydroelastic_geometries()
     const {
   return impl_->hydroelastic_geometries();
+}
+
+template <typename T>
+bool ProximityEngine<T>::IsFclConvexType(GeometryId id) const {
+  return impl_->IsFclConvexType(id);
 }
 
 }  // namespace internal

--- a/geometry/proximity_engine.h
+++ b/geometry/proximity_engine.h
@@ -336,6 +336,15 @@ class ProximityEngine {
 
   // Facilitate testing.
   friend class ProximityEngineTester;
+
+  // Reports if the geometry with the given id is represented by an fcl::Convex.
+  // This function exists solely for the purpose tracking the "represent Mesh
+  // as Convex" logic in other unit tests. When we represent meshes as
+  // non-convex entities in their own right, we can remove this method.
+  // This very specifically does *not* answer the question of whether the
+  // underlying shape is *mathematically* convex, just that it is implemented
+  // as fcl::Convex.
+  bool IsFclConvexType(GeometryId id) const;
 };
 
 #ifndef DRAKE_DOXYGEN_CXX

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -64,6 +64,12 @@ class ProximityEngineTester {
       GeometryId id, const ProximityEngine<T>& engine) {
     return engine.hydroelastic_geometries().hydroelastic_type(id);
   }
+
+  template <typename T>
+  static bool IsFclConvexType(const ProximityEngine<T>& engine,
+                                 GeometryId id) {
+    return engine.IsFclConvexType(id);
+  }
 };
 
 namespace {
@@ -343,6 +349,7 @@ GTEST_TEST(ProximityEngineTests, MeshSupportAsConvex) {
     const auto& [mesh_id, X_WM] =
         AddShape(&engine, mesh, true /* is_anchored */, false /* is_soft */,
                  Vector3d::Zero());
+    ASSERT_TRUE(ProximityEngineTester::IsFclConvexType(engine, mesh_id));
     const auto& [sphere_id, X_MS] =
         AddShape(&engine, Sphere(radius), false /* is_anchored */,
                  true /* is soft */, Vector3d::Zero());


### PR DESCRIPTION
We have other tests/functionality that rely on the fact that the Mesh shape is represented by an fcl::Convex under the hood. This gives those downstream tests the ability to query that this is still happening and condition the test outcomes accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14640)
<!-- Reviewable:end -->
