### PR TITLE
Tests to ensure RigidTransform<double> can work with optimization instructions.

### DIFF
--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -432,9 +432,6 @@ class RigidTransform {
   /// @returns `this` %RigidTransform which has been multiplied by `other`.
   /// On return, `this = X_AC`, where `X_AC = X_AB * X_BC`.
   RigidTransform<T>& operator*=(const RigidTransform<T>& other) {
-    static_assert(!std::is_same<double, T>() ||
-            sizeof(RigidTransform<double>) == optimal_sizeof_RigidTransformd_,
-        "Optimized instructions depend on sizeof(RigidTransform<double>).");
     p_AoBo_A_ = *this * other.translation();
     R_AB_ *= other.rotation();
     return *this;
@@ -597,22 +594,6 @@ class RigidTransform {
     }
   }
 
-  // For optimization, preserve the order of this class's two non-static data
-  // members, namely its rotation matrix R_AB_ and position vector p_AoBo_A_.
-  // Optimization (e.g., AVX instructions for multiplying rigid transforms) can
-  // leverage a continuous memory layout of RigidTransform<double> as 12
-  // sequential doubles starting with a 3x3 RotationMatrix<double> (9 doubles)
-  // immediately followed by a 3x1 position vector (3 doubles).
-  // A unit test verifies the order is always R_AB_followed by  p_AoBo_A_.
-  // Note: The C++ standard guarantees that the members of a class appear in
-  // memory in the same order as they are declared.  Nonstatic data members of a
-  // (non-union) class are allocated so that later members have higher addresses
-  // within a class object. Implementation alignment requirements might cause
-  // two adjacent members not to be allocated immediately after each other.
-  // Related: https://github.com/RobotLocomotion/drake/pull/14626
-  // Related: https://github.com/RobotLocomotion/drake/pull/14623
-  static constexpr double optimal_sizeof_RigidTransformd_ = 12 * sizeof(double);
-
   // Rotation matrix relating two frames, e.g. frame A and frame B.
   // The default constructor for R_AB_ is an identity matrix.
   RotationMatrix<T> R_AB_;
@@ -620,6 +601,19 @@ class RigidTransform {
   // Position vector from A's origin Ao to B's origin Bo, expressed in A.
   Vector3<T> p_AoBo_A_;
 };
+
+// To enable low-level optimizations we insist that RigidTransform<double> is
+// packed into 12 consecutive doubles, with a 3x3 RotationMatrix<double> in
+// the first 9 doubles and the translation vector in the last 3 doubles.
+// A unit test verifies this memory layout for a RigidTransform<double>.
+// Note: The C++ standard guarantees that the members of a class appear in
+// memory in the same order as they are declared.  Nonstatic data members of a
+// (non-union) class are allocated so that later members have higher addresses
+// within a class object. Implementation alignment requirements might cause
+// two adjacent members not to be allocated immediately after each other.
+static_assert(sizeof(RigidTransform<double>) == 12 * sizeof(double),
+    "Low-level optimizations depend on RigidTransform<double> being "
+    "stored as 12 sequential doubles in memory.");
 
 /// Abbreviation (alias/typedef) for a RigidTransform double scalar type.
 /// @relates RigidTransform

--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -604,11 +604,11 @@ class RigidTransform {
 
 // To enable low-level optimizations we insist that RigidTransform<double> is
 // packed into 12 consecutive doubles, with a 3x3 RotationMatrix<double> in
-// the first 9 doubles and the translation vector in the last 3 doubles.
+// the first 9 doubles and a translation vector in the last 3 doubles.
 // A unit test verifies this memory layout for a RigidTransform<double>.
-// Note: The C++ standard guarantees that the non-static members of a class
-// appear in memory in the same order as they are declared.  Implementation
-// alignment requirements might cause a gap in memory between adjacent members.
+// Note: The C++ standard guarantees that non-static members of a class appear
+// in memory in the same order as they are declared.  Implementation alignment
+// requirements can cause an alignment gap in memory between adjacent members.
 static_assert(sizeof(RigidTransform<double>) == 12 * sizeof(double),
     "Low-level optimizations depend on RigidTransform<double> being "
     "stored as 12 sequential doubles in memory.");

--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -597,13 +597,13 @@ class RigidTransform {
     }
   }
 
-  // For oprimization, perserve the order of this class's two non-static data
+  // For optimization, preserve the order of this class's two non-static data
   // members, namely its rotation matrix R_AB_ and position vector p_AoBo_A_.
   // Optimization (e.g., AVX instructions for multiplying rigid transforms) can
   // leverage a continuous memory layout of RigidTransform<double> as 12
   // sequential doubles starting with a 3x3 RotationMatrix<double> (9 doubles)
-  // immediately followed by a 3x1 position vector (3 doubles).  A unit test
-  // verifies the ordering remains as first R_AB_followed by  p_AoBo_A_.
+  // immediately followed by a 3x1 position vector (3 doubles).
+  // A unit test verifies the order is always R_AB_followed by  p_AoBo_A_.
   // Note: The C++ standard guarantees that the members of a class appear in
   // memory in the same order as they are declared.  Nonstatic data members of a
   // (non-union) class are allocated so that later members have higher addresses

--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -606,11 +606,9 @@ class RigidTransform {
 // packed into 12 consecutive doubles, with a 3x3 RotationMatrix<double> in
 // the first 9 doubles and the translation vector in the last 3 doubles.
 // A unit test verifies this memory layout for a RigidTransform<double>.
-// Note: The C++ standard guarantees that the members of a class appear in
-// memory in the same order as they are declared.  Nonstatic data members of a
-// (non-union) class are allocated so that later members have higher addresses
-// within a class object. Implementation alignment requirements might cause
-// two adjacent members not to be allocated immediately after each other.
+// Note: The C++ standard guarantees that the non-static members of a class
+// appear in memory in the same order as they are declared.  Implementation
+// alignment requirements might cause a gap in memory between adjacent members.
 static_assert(sizeof(RigidTransform<double>) == 12 * sizeof(double),
     "Low-level optimizations depend on RigidTransform<double> being "
     "stored as 12 sequential doubles in memory.");

--- a/math/test/rigid_transform_test.cc
+++ b/math/test/rigid_transform_test.cc
@@ -716,7 +716,7 @@ GTEST_TEST(RigidTransform, OperatorMultiplyByMatrix3X) {
 }
 
 GTEST_TEST(RigidTransform, TestMemoryLayoutOfRigidTransformDouble) {
-  // For oprimization, verify the order of this class's two non-static data
+  // For optimization, verify the order of this class's two non-static data
   // members, namely rotation matrix R_AB_ and position vector p_AoBo_A_.
   // Optimization (e.g., AVX instructions for multiplying rigid transforms) can
   // leverage a continuous memory layout of RigidTransform<double> as 12

--- a/math/test/rigid_transform_test.cc
+++ b/math/test/rigid_transform_test.cc
@@ -716,13 +716,9 @@ GTEST_TEST(RigidTransform, OperatorMultiplyByMatrix3X) {
 }
 
 GTEST_TEST(RigidTransform, TestMemoryLayoutOfRigidTransformDouble) {
-  // For optimization, verify the order of this class's two non-static data
-  // members, namely rotation matrix R_AB_ and position vector p_AoBo_A_.
-  // Optimization (e.g., AVX instructions for multiplying rigid transforms) can
-  // leverage a continuous memory layout of RigidTransform<double> as 12
-  // sequential doubles starting with a 3x3 RotationMatrix<double> (9 doubles)
-  // immediately followed by a 3x1 position vector (3 doubles).  This unit test
-  // verifies the ordering remains as first R_AB_followed by  p_AoBo_A_.
+  // For optimization (e.g., AVX instructions), verify RigidTransform<double>
+  // is packed into 12 consecutive doubles, first with a 3x3 rotation matrix
+  // (9 doubles) followed by a 3x1  position vector (3 doubles).
   RigidTransform<double> X;
   const double* X_address = reinterpret_cast<const double*>(&X);
   const double* R_address = reinterpret_cast<const double*>(&X.rotation());
@@ -730,7 +726,7 @@ GTEST_TEST(RigidTransform, TestMemoryLayoutOfRigidTransformDouble) {
   EXPECT_EQ(X_address, R_address);
   EXPECT_EQ(X_address + 9, p_address);
 
-  // Test that the entire class is only 12 doubles long.
+  // Test that the entire class occupies memory equal to 12 doubles.
   EXPECT_EQ(sizeof(X), 12 * sizeof(double));
 }
 


### PR DESCRIPTION
Optimization (e.g., AVX instructions for multiplying rigid transforms) can leverage a continuous memory layout of RigidTransform<double> as 12 sequential doubles starting with a 3x3 RotationMatrix<double> (9 doubles) immediately followed by a 3x1 position vector (3 doubles).

A unit test verifies the order is always R_AB_followed by  p_AoBo_A_.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14643)
<!-- Reviewable:end -->
