### PR TITLE
release notes: Remove `attic` from template

### DIFF
--- a/doc/release_notes/template.txt
+++ b/doc/release_notes/template.txt
@@ -94,7 +94,7 @@ Newly bound
 Build system and dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. <relnotes for attic,cmake,doc,setup,third_party,tools go here>
+.. <relnotes for cmake,doc,setup,third_party,tools go here>
 
 * TBD
 


### PR DESCRIPTION
Came across during #14646

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14647)
<!-- Reviewable:end -->
