### PR TITLE
[FEM] FemSolver and static elasticity test

### DIFF
--- a/multibody/fixed_fem/dev/BUILD.bazel
+++ b/multibody/fixed_fem/dev/BUILD.bazel
@@ -192,6 +192,22 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "fem_solver",
+    hdrs = [
+        "fem_solver.h",
+    ],
+    deps = [
+        ":dirichlet_boundary_condition",
+        ":eigen_conjugate_gradient_solver",
+        ":fem_model",
+        ":linear_system_solver",
+        ":state_updater",
+        "//common:essential",
+        "//multibody/contact_solvers:sparse_linear_operator",
+    ],
+)
+
+drake_cc_library(
     name = "fem_state",
     hdrs = [
         "fem_state.h",
@@ -427,6 +443,23 @@ drake_cc_googletest(
     name = "fem_element_test",
     deps = [
         ":dummy_element",
+    ],
+)
+
+drake_cc_googletest(
+    name = "fem_solver_test",
+    deps = [
+        ":eigen_conjugate_gradient_solver",
+        ":fem_solver",
+        ":linear_constitutive_model",
+        ":linear_simplex_element",
+        ":simplex_gaussian_quadrature",
+        ":static_elasticity_element",
+        ":static_elasticity_model",
+        ":zeroth_order_state_updater",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//geometry/proximity:make_box_mesh",
+        "//math:gradient",
     ],
 )
 

--- a/multibody/fixed_fem/dev/dirichlet_boundary_condition.h
+++ b/multibody/fixed_fem/dev/dirichlet_boundary_condition.h
@@ -13,6 +13,8 @@
 namespace drake {
 namespace multibody {
 namespace fixed_fem {
+// TODO(xuchenhan-tri): Have FemModel own DirichletBoundaryCondition. See issue
+// #14668.
 /** %DirichletBoundaryCondition provides functionalities related to Dirichlet
  boundary conditions (BC) to the FEM solver. In particular, it provides the
  following functionalities:
@@ -26,7 +28,7 @@ namespace fixed_fem {
  like:
  ```
  // First, apply the boundary condition to the state.
- bc.ApplyBoundaryCondition(&state).
+ bc.ApplyBoundaryCondition(&state);
  // Then find the residual for the system without BC using FemModel.
  model.CalcResidual(state, &residual);
  // Modify the residual to account for the BC.

--- a/multibody/fixed_fem/dev/dynamic_elasticity_element.h
+++ b/multibody/fixed_fem/dev/dynamic_elasticity_element.h
@@ -80,14 +80,14 @@ class DynamicElasticityElement final
   /* Implements FemElement::CalcResidual(). */
   void DoCalcResidual(const FemState<ElementType>& state,
                       EigenPtr<Vector<T, Traits::kNumDofs>> residual) const {
-    /* residual = Ma-fₑ(x)-fᵥ(x, v)+fₑₓₜ, where M is the mass matrix, fₑ(x) is
+    /* residual = Ma-fₑ(x)-fᵥ(x, v)-fₑₓₜ, where M is the mass matrix, fₑ(x) is
      the elastic force, fᵥ(x, v) is the damping force and fₑₓₜ is the external
      force. */
     *residual += this->mass_matrix() *
                  this->ExtractElementDofs(this->node_indices(), state.qddot());
     this->AddNegativeElasticForce(state, residual);
     AddNegativeDampingForce(state, residual);
-    this->AddExternalForce(state, residual);
+    this->AddScaledExternalForce(state, -1.0, residual);
   }
 
   /* Adds the negative damping force on the nodes of this element into the given

--- a/multibody/fixed_fem/dev/eigen_conjugate_gradient_solver.h
+++ b/multibody/fixed_fem/dev/eigen_conjugate_gradient_solver.h
@@ -30,12 +30,12 @@ class EigenMatrixProxy : public Eigen::EigenBase<EigenMatrixProxy<T>> {
   };
 
   StorageIndex rows() const {
-    DRAKE_ASSERT(linear_operator_ != nullptr);
+    DRAKE_THROW_UNLESS(linear_operator_ != nullptr);
     return linear_operator_->rows();
   }
 
   StorageIndex cols() const {
-    DRAKE_ASSERT(linear_operator_ != nullptr);
+    DRAKE_THROW_UNLESS(linear_operator_ != nullptr);
     return linear_operator_->cols();
   }
 
@@ -56,9 +56,11 @@ class EigenMatrixProxy : public Eigen::EigenBase<EigenMatrixProxy<T>> {
    This class keeps a reference to the input `linear_operator` and therefore it
    is required that `linear_operator` outlives this object. */
   EigenMatrixProxy(
-      const contact_solvers::internal::LinearOperator<T>& linear_operator)
-      : linear_operator_(&linear_operator),
-        scratch_vector_(linear_operator.rows()) {}
+      const contact_solvers::internal::LinearOperator<T>* linear_operator)
+      : linear_operator_(linear_operator) {}
+
+  /* Resize the scratch vector to match the size of the linear operator. */
+  void Resize() { scratch_vector_.resize(linear_operator_->rows()); }
 
   ~EigenMatrixProxy() = default;
 
@@ -152,11 +154,8 @@ class EigenConjugateGradientSolver : public LinearSystemSolver<T> {
   ||Ax-b||/||b|| is smaller than the set tolerance or when the max number of
   iterations is reached.  */
   EigenConjugateGradientSolver(
-      const contact_solvers::internal::LinearOperator<T>& A, double tol = 1e-4)
-      : LinearSystemSolver<T>(A), matrix_proxy_(A) {
-    cg_.compute(matrix_proxy_);
-    cg_.setTolerance(tol);
-  }
+      const contact_solvers::internal::LinearOperator<T>* A, double tol = 1e-4)
+      : LinearSystemSolver<T>(A), matrix_proxy_(A) {}
 
   ~EigenConjugateGradientSolver() {}
 
@@ -178,9 +177,14 @@ class EigenConjugateGradientSolver : public LinearSystemSolver<T> {
   double tolerance() const { return cg_.tolerance(); }
 
   /* Forwards to Eigen::ConjugateGradient::setTolerance(). */
-  void set_tolerance(double tol) { cg_.setTolerance(tol); }
+  void set_tolerance(const T& tol) final { cg_.setTolerance(tol); }
 
  private:
+  void DoCompute() final {
+    matrix_proxy_.Resize();
+    cg_.compute(matrix_proxy_);
+  }
+
   EigenMatrixProxy<T> matrix_proxy_;
   /* TODO(xuchenhan-tri): Allow for custom preconditioner if needed in the
    future. */

--- a/multibody/fixed_fem/dev/elasticity_element.h
+++ b/multibody/fixed_fem/dev/elasticity_element.h
@@ -149,14 +149,15 @@ class ElasticityElement : public FemElement<DerivedElement, DerivedTraits> {
   }
 
   /** Accumulates the total external force exerted on the %ElasticityElement at
-   the given `state` into the output parameter `external_force`.
+   the given `state` scaled by `scale` into the output parameter
+   `external_force`.
    @pre external_force != nullptr. */
-  void AddExternalForce(
-      const FemState<DerivedElement>& state,
+  void AddScaledExternalForce(
+      const FemState<DerivedElement>& state, const T& scale,
       EigenPtr<Vector<T, Traits::kNumDofs>> external_force) const {
     DRAKE_ASSERT(external_force != nullptr);
     /* So far, the only external force is gravity. */
-    *external_force += gravity_force_;
+    *external_force += scale * gravity_force_;
   }
 
   /** Computes the gravity force on each node in the element using the stored

--- a/multibody/fixed_fem/dev/elasticity_model.h
+++ b/multibody/fixed_fem/dev/elasticity_model.h
@@ -56,8 +56,29 @@ class ElasticityModel : public FemModel<Element> {
     return gravity_;
   }
 
-  /** Calculates the total external force exerted on the %ElasticityModel at
-   the given `state`.
+  /** Sets explicitly specified external forces (with units of N) on the dofs in
+   the model. These explicit forces show up in the CalcResidual() and
+   CalcExternalForce(). To turn off explicit external forces, pass in an empty
+   vector.
+   @throw std::exception if the size of `forces` is greater than zero but not
+   equal to num_dofs().
+   @note If the size of the model is changed after SetExplicitExternalForce() is
+   called, an exception will be thrown when the model is evaluated unless
+   another SetExplicitExternalForce() is called with an external force of the
+   correct size. */
+  void SetExplicitExternalForce(const VectorX<T>& forces) {
+    if (forces.size() == 0 || forces.size() == this->num_dofs()) {
+      explicit_external_forces_ = forces;
+      return;
+    }
+    throw std::runtime_error(
+        "The input force has size " + std::to_string(forces.size()) +
+        ", and it doesn't match the size of the model, which has " +
+        std::to_string(this->num_dofs()) + " dofs.");
+  }
+
+  /** Calculates the total external force exerted on the vertices of
+   %ElasticityModel at the given `state`. The forces have units N.
    @param[in] state The FemState at which to evaluate the external force.
    @param[out] external_force The external force evaluated at `state`.
    @pre external_force != nullptr.
@@ -79,7 +100,7 @@ class ElasticityModel : public FemModel<Element> {
     Vector<T, kNumDofs> element_force;
     for (ElementIndex e(0); e < this->num_elements(); ++e) {
       element_force.setZero();
-      this->element(e).AddExternalForce(state, &element_force);
+      this->element(e).AddScaledExternalForce(state, 1, &element_force);
       const std::array<NodeIndex, kNumNodes>& element_node_indices =
           this->element(e).node_indices();
       for (int i = 0; i < kNumNodes; ++i) {
@@ -88,6 +109,8 @@ class ElasticityModel : public FemModel<Element> {
             element_force.template segment<kDim>(i * kDim);
       }
     }
+    /* Add in the contribution from explicitly set external force. */
+    AddScaledExplicitExternalForces(1, external_force);
   }
 
  protected:
@@ -128,8 +151,34 @@ class ElasticityModel : public FemModel<Element> {
   const VectorX<T>& reference_positions() const { return reference_positions_; }
 
  private:
+  /* Adds per-vertex residuals that are explicitly specified at each vertex. */
+  void AddExplicitResidual(EigenPtr<VectorX<T>> residual) const final {
+    /* Note that external forces enter the residual with a negative sign. */
+    AddScaledExplicitExternalForces(-1, residual);
+  }
+
+  /* Adds the stored `explicit_external_forces_` scaled by `scale` to the given
+   `f`. Throw an exception if their sizes don't match. */
+  void AddScaledExplicitExternalForces(const T& scale,
+                                       EigenPtr<VectorX<T>> f) const {
+    if (explicit_external_forces_.size() == f->size()) {
+      *f += scale * explicit_external_forces_;
+      return;
+    }
+    if (explicit_external_forces_.size() != 0) {
+      throw std::runtime_error(
+          "The input force has size " + std::to_string(f->size()) +
+          ", and it doesn't match the size of the stored explicit external "
+          "force which has size " +
+          std::to_string(explicit_external_forces_.size()));
+    }
+  }
+
   VectorX<T> reference_positions_{};
   Vector<T, Element::Traits::kSpatialDimension> gravity_{0, 0, -9.81};
+  /* Explicit external force set by SetExplicitExternalForce. Default is empty.
+   */
+  VectorX<T> explicit_external_forces_{};
 };
 }  // namespace fixed_fem
 }  // namespace multibody

--- a/multibody/fixed_fem/dev/fem_solver.h
+++ b/multibody/fixed_fem/dev/fem_solver.h
@@ -1,0 +1,200 @@
+#pragma once
+
+#include <algorithm>
+#include <memory>
+#include <utility>
+
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/contact_solvers/sparse_linear_operator.h"
+#include "drake/multibody/fixed_fem/dev/dirichlet_boundary_condition.h"
+#include "drake/multibody/fixed_fem/dev/eigen_conjugate_gradient_solver.h"
+#include "drake/multibody/fixed_fem/dev/fem_model.h"
+#include "drake/multibody/fixed_fem/dev/linear_system_solver.h"
+#include "drake/multibody/fixed_fem/dev/state_updater.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+// TODO(xuchenhan-tri): Remove the template by making the model and the state
+// abstract. See issue #14667.
+/** %FemSolver solves for the state of a given FemModel at which residual of the
+ FemModel is sufficiently close to zero. %FemSolver uses a simple Newton-Raphson
+ solver to solve for the zero residual state. A common workflow looks like:
+ ```
+ // Creates a solver for a given FemModel and sets the LinearSystemSolver used
+ // in the Newton-Raphson iterations.
+ FemSolver<Model> solver(std::move(fem_model), std::move(linear_solver);
+ // Optionally, sets the tolerance under which we deem the residual is
+ // effectively zero.
+ solver.set_tolerance(kTolereance);
+ // Optionally, sets the desired boundary condition.
+ solver.SetDirichletBoundaryCondition(std::move(bc));
+ // Finally, provide an initial guess and solve for the zero residual state.
+ solver.SolveWithInitialGuess(state_updater, &state);
+ // Now the residual at `state` has 2-norm smaller than `kTolerance` if the
+ // solver has converged.
+ ```
+ @tparam Model    The type of model that `this` %FemSolver solves for. Must be
+ derived from FemModel. */
+template <class Model>
+class FemSolver {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FemSolver);
+  static_assert(
+      std::is_base_of_v<FemModel<typename Model::ElementType>, Model>,
+      "The template parameter Model should be derived from FemModel. ");
+  using T = typename Model::T;
+  using State = FemState<typename Model::ElementType>;
+
+  // TODO(xuchenhan-tri): Consider moving LinearSystemSolver out of internal
+  // namespace and allow users to configure the linear solver.
+  /** Constructs a new FemSolver with the given FemModel and an Eigen Conjugate
+   Gradient solver as the linear solver. */
+  explicit FemSolver(std::unique_ptr<Model> model) : model_(std::move(model)) {
+    Resize();
+    linear_solver_ =
+        std::make_unique<internal::EigenConjugateGradientSolver<T>>(&A_op_);
+  }
+
+  /** Uses a Newton-Raphson solver to solve for the solution state at which the
+   residual of the FemModel is below the set tolerance (see set_tolerance()).
+   @param[in] state_updater    The StateUpdater used to update `state` in each
+   Newton-Raphson iteration.
+   @param[in, out] state    As input, `state` provides an initial guess of the
+   solution. As output, `state` reports the solution state at which the residual
+   of the FemModel is deemed sufficiently close to zero.
+   @pre state != nullptr. */
+  int SolveWithInitialGuess(const StateUpdater<State>& state_updater,
+                            State* state) const {
+    DRAKE_DEMAND(state != nullptr);
+    DRAKE_DEMAND(model_ != nullptr);
+    DRAKE_DEMAND(linear_solver_ != nullptr);
+    /* Make sure the scratch quantities are of the correct size and apply BC if
+     one is specified. */
+    Resize();
+    if (dirichlet_bc_ != nullptr) {
+      dirichlet_bc_->ApplyBoundaryConditions(state);
+    }
+
+    model_->CalcResidual(*state, &b_);
+    if (dirichlet_bc_ != nullptr) {
+      dirichlet_bc_->ApplyBcToResidual(&b_);
+    }
+    int iter = 0;
+    /* Newton-Raphson iterations. We iterate until any of the following is true:
+     1. The max number of allowed iterations is reached;
+     2. The norm of the change in the state in a single iteration is smaller
+        than the absolute tolerance.
+     3. The relative error (the norm of the change in the state divided by the
+        norm of the state) is smaller than the unitless relative tolerance. */
+    do {
+      model_->CalcTangentMatrix(*state, state_updater.weights(), &A_);
+      if (dirichlet_bc_ != nullptr) {
+        dirichlet_bc_->ApplyBcToTangentMatrix(&A_);
+      }
+      linear_solver_->Compute();
+      /* Solving for A * dz = -b. */
+      linear_solver_->Solve(-b_, &dz_);
+      state_updater.UpdateState(dz_, state);
+      model_->CalcResidual(*state, &b_);
+      if (dirichlet_bc_ != nullptr) {
+        dirichlet_bc_->ApplyBcToResidual(&b_);
+      }
+      ++iter;
+    } while (dz_.norm() >
+                 std::max(relative_tolerance_ * state->HighestOrderStateNorm(),
+                          absolute_tolerance_) &&
+             iter < kMaxIterations_);
+    if (iter == kMaxIterations_) {
+      // TODO(xuchenhan-tri): Provide some advice on how to get a "better
+      //  initial guess". Or instead, return a status indicating the solver
+      //  did not converge and let users decide what to do.
+      throw std::runtime_error(
+          "The solver did not converge " + std::to_string(kMaxIterations_) +
+          " iterations. Please provide a better initial guess.");
+    }
+    return iter;
+  }
+
+  /** Returns the FemModel that this solver owns. */
+  const Model& model() const {
+    DRAKE_THROW_UNLESS(model_ != nullptr);
+    return *model_;
+  }
+
+  /** Returns the mutable FemModel that this solver owns. */
+  Model& mutable_model() {
+    DRAKE_THROW_UNLESS(model_ != nullptr);
+    return *model_;
+  }
+
+  /** Takes ownership of the given Dirichlet boundary condition and applies it
+   to the FemModel this solver owns. */
+  void SetDirichletBoundaryCondition(
+      std::unique_ptr<DirichletBoundaryCondition<State>> dirichlet_bc) {
+    dirichlet_bc_ = std::move(dirichlet_bc);
+  }
+
+  /** Sets the relative tolerance, unitless. The Newton-Raphson iterations are
+   considered as converged if the norm of the change in the state in one
+   iteration is smaller than the norm of the current state times the relative
+   tolerace. The default value is 1e-6. */
+  void set_relative_tolerance(const T& tolerance) {
+    relative_tolerance_ = tolerance;
+  }
+
+  /** Sets the absolute tolerance which has the same unit as the state with the
+   highest order of the model. For example, for dynamic elasticity, it has the
+   unit of m/s², and for static elasticity, it has the unit of m. The
+   Newton-Raphson iterations are considered as converged if the change in the
+   state is smaller than the absolute tolerance. The default value is 1e-6. */
+  void set_absolute_tolerance(const T& tolerance) {
+    absolute_tolerance_ = tolerance;
+  }
+
+  /** Sets the relative tolerance for the linear solver used in `this`
+   FemSolver if the linear solver is iterative. No-op if the linear solver is
+   direct. */
+  void set_linear_solve_tolerance(const T& tolerance) {
+    linear_solver_->set_tolerance(tolerance);
+  }
+
+ private:
+  /* Resize the scratch quantities to the size of the model. */
+  void Resize() const {
+    if (b_.size() != model_->num_dofs()) {
+      b_.resize(model_->num_dofs());
+      dz_.resize(model_->num_dofs());
+      A_.resize(model_->num_dofs(), model_->num_dofs());
+      model_->SetTangentMatrixSparsityPattern(&A_);
+    }
+  }
+
+  /* The FEM model being solved by `this` solver. */
+  std::unique_ptr<Model> model_;
+  /* The linear solver used to solve the FEM model. */
+  std::unique_ptr<internal::LinearSystemSolver<T>> linear_solver_;
+  /* The Dirichlet boundary condition imposed on the model. */
+  std::unique_ptr<DirichletBoundaryCondition<State>> dirichlet_bc_;
+  /* A scratch sparse matrix to store the tangent matrix of the model. */
+  mutable Eigen::SparseMatrix<T> A_;
+  /* The operator form of A_. */
+  const contact_solvers::internal::SparseLinearOperator<T> A_op_{"A", &A_};
+  /* A scratch vector to store the residual of the model. */
+  mutable VectorX<T> b_;
+  /* A scratch vector to store the solution to A * dz = -b. */
+  mutable VectorX<T> dz_;
+  /* The relative tolerance for determining the convergence of the Newton
+   solver, unitless. */
+  T relative_tolerance_{1e-6};
+  /* The absolute tolerance for determining the convergence of the Newton
+   solver. It has the same unit as the highest order state. */
+  T absolute_tolerance_{1e-6};
+  // TODO(xuchenhan-tri): Consider making `kMaxIterations_` configurable.
+  /* Any reasonable Newton solve should converge within 20 iterations. If it
+   doesn't converge in 20 iterations, chances are it will never converge. */
+  int kMaxIterations_{20};
+};
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/fem_state.h
+++ b/multibody/fixed_fem/dev/fem_state.h
@@ -178,6 +178,14 @@ class FemState {
     return data;
   }
 
+  /** Calculates the norm of the state with the highest order. */
+  T HighestOrderStateNorm() const {
+    if constexpr (ode_order() == 0) return q_.norm();
+    if constexpr (ode_order() == 1) return qdot_.norm();
+    if constexpr (ode_order() == 2) return qddot_.norm();
+    DRAKE_UNREACHABLE();
+  }
+
  private:
   /* Generalized node positions. */
   VectorX<T> q_{};

--- a/multibody/fixed_fem/dev/linear_system_solver.h
+++ b/multibody/fixed_fem/dev/linear_system_solver.h
@@ -15,7 +15,7 @@ namespace internal {
 template <typename T>
 class LinearSystemSolver {
  public:
-  virtual ~LinearSystemSolver() {}
+  virtual ~LinearSystemSolver() = default;
 
   /* Performs the linear solve to get x = A⁻¹b. */
   virtual void Solve(const Eigen::Ref<const VectorX<T>>& b,
@@ -24,33 +24,55 @@ class LinearSystemSolver {
   /* Returns the size of the linear system, which is equal to the number of rows
    and columns of the matrix A. */
   int size() const {
-    DRAKE_ASSERT(A_ != nullptr);
+    DRAKE_THROW_UNLESS(A_ != nullptr);
     return A_->rows();
   }
 
-  /* Returns the underlying linear operator. Useful for debugging purposes. */
+  /* Perform precomputes on A such as factorize the matrix. This method only
+   needs to be called every time A changes. A common workflow looks like:
+   ```
+   // Precompute (e.g. factorize) A.
+   linear_solver.Compute();
+   // Solve for Ax₁ = b₁.
+   linear_solver.Solve(b1, &x1);
+   // Solve for Ax₂ = b₂ without factorizing A again.
+   linear_solver.Solve(b2, &x2);
+   ...
+   ``` */
+  void Compute() {
+    DRAKE_THROW_UNLESS(A_ != nullptr);
+    DRAKE_THROW_UNLESS(A_->rows() == A_->cols());
+    DoCompute();
+  }
+
+  /* Returns the underlying linear operator. Useful for debugging purposes.
+   */
   const contact_solvers::internal::LinearOperator<T>& A() {
-    DRAKE_ASSERT(A_ != nullptr);
+    DRAKE_THROW_UNLESS(A_ != nullptr);
     return *A_;
   }
 
+  /* Sets the tolerance for iterative solvers. No-op for direct solvers. */
+  virtual void set_tolerance(const T& tolerance) {}
+
  protected:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LinearSystemSolver);
-
   /* Constructs a new linear solver with the prescribed linear operator A.
-   This class keeps a reference to input linear operator `A` and therefore it is
-   required that `A` outlives this object.
-   @param[in] A    The linear operator that describes the linear system. The
-   number of rows and columns must be the same for A.
-   @throw std::exception if A.rows() != A.cols(). */
+   This class keeps a reference to input linear operator `A` and therefore it
+   is required that `A` outlives this object.
+   @param[in] A    The linear operator that describes the linear system. */
   explicit LinearSystemSolver(
-      const contact_solvers::internal::LinearOperator<T>& A)
-      : A_(&A) {
-    DRAKE_THROW_UNLESS(A.rows() == A.cols());
+      const contact_solvers::internal::LinearOperator<T>* A)
+      : A_(A) {
+    DRAKE_DEMAND(A_ != nullptr);
   }
 
+  /* Derived classes should override this method to perform percomputes (e.g.
+   factorize) on A, the left hand side of the system, if necessary. */
+  virtual void DoCompute() {}
+
  private:
-  const contact_solvers::internal::LinearOperator<T>* A_;
+  const contact_solvers::internal::LinearOperator<T>* A_{nullptr};
 };
 }  // namespace internal
 }  // namespace fixed_fem

--- a/multibody/fixed_fem/dev/static_elasticity_element.h
+++ b/multibody/fixed_fem/dev/static_elasticity_element.h
@@ -80,10 +80,10 @@ class StaticElasticityElement final
   /* Implements FemElement::CalcResidual(). */
   void DoCalcResidual(const FemState<ElementType>& state,
                       EigenPtr<Vector<T, Traits::kNumDofs>> residual) const {
-    /* residual = -fₑ(x) + fₑₓₜ, where fₑ(x) is the elastic force and fₑₓₜ is
+    /* residual = -fₑ(x) - fₑₓₜ, where fₑ(x) is the elastic force and fₑₓₜ is
      the external force. */
     this->AddNegativeElasticForce(state, residual);
-    this->AddExternalForce(state, residual);
+    this->AddScaledExternalForce(state, -1, residual);
   }
 
   /* Implements FemElement::CalcStiffnessMatrix(). */

--- a/multibody/fixed_fem/dev/test/dynamic_elasticity_element_test.cc
+++ b/multibody/fixed_fem/dev/test/dynamic_elasticity_element_test.cc
@@ -145,9 +145,9 @@ TEST_F(DynamicElasticityElementTest, Residual) {
   Vector<T, kNumDofs> negative_fe = negative_elastic_force();
   Vector<T, kNumDofs> negative_fv = negative_damping_force();
   Vector<T, kNumDofs> external_force = Vector<T, kNumDofs>::Zero();
-  element().AddExternalForce(*state_, &external_force);
+  element().AddScaledExternalForce(*state_, 1.0, &external_force);
   EXPECT_TRUE(CompareMatrices(
-      residual, momentum_change + negative_fe + negative_fv + external_force,
+      residual, momentum_change + negative_fe + negative_fv - external_force,
       0));
 }
 

--- a/multibody/fixed_fem/dev/test/eigen_conjugate_gradient_solver_test.cc
+++ b/multibody/fixed_fem/dev/test/eigen_conjugate_gradient_solver_test.cc
@@ -53,7 +53,8 @@ GTEST_TEST(EigenConjugateGradientSolverTest, DoubleDenseSolverTest) {
   const Eigen::SparseMatrix<double> A = MakeSpdMatrix().sparseView();
   contact_solvers::internal::SparseLinearOperator<double> A_op("A", &A);
   const Vector<double, kD> b = MakeRhs();
-  const EigenConjugateGradientSolver<double> solver(A_op, kTol);
+  EigenConjugateGradientSolver<double> solver(&A_op, kTol);
+  solver.Compute();
   Eigen::Matrix<double, kD, 1> x;
   solver.Solve(b, &x);
 
@@ -71,7 +72,8 @@ GTEST_TEST(EigenConjugateGradientSolverTest, DoubleSparseSolverTest) {
 
   contact_solvers::internal::SparseLinearOperator<double> A_op("A", &A);
   const Vector<double, kD> b = MakeRhs();
-  const EigenConjugateGradientSolver<double> solver(A_op, kTol);
+  EigenConjugateGradientSolver<double> solver(&A_op, kTol);
+  solver.Compute();
   Eigen::Matrix<double, kD, 1> x;
   solver.Solve(b, &x);
 
@@ -91,7 +93,8 @@ GTEST_TEST(EigenConjugateGradientSolverTest, AutoDiffSolverTestRhs) {
   Vector<T, kD> b_autodiff;
   math::initializeAutoDiff(b, b_autodiff);
   /* Build the solve and solve for x. */
-  const EigenConjugateGradientSolver<T> solver(A_op, kTol);
+  EigenConjugateGradientSolver<T> solver(&A_op, kTol);
+  solver.Compute();
   Eigen::Matrix<T, kD, 1> x;
   solver.Solve(b_autodiff, &x);
   /* Use LU decomposition to invert the matrix A. */
@@ -131,7 +134,8 @@ GTEST_TEST(EigenConjugateGradientSolverTest, AutoDiffSolverTestLhs) {
   /* Set up solver and rhs and solve for the solution, x_cg. */
   const Eigen::SparseMatrix<T> A_sparse = A_autodiff.sparseView();
   contact_solvers::internal::SparseLinearOperator<T> A_op("A", &A_sparse);
-  const EigenConjugateGradientSolver<T> solver(A_op, kTol);
+  EigenConjugateGradientSolver<T> solver(&A_op, kTol);
+  solver.Compute();
   const Vector<double, kD> b = MakeRhs();
   Vector<T, kD> x_cg;
   solver.Solve(b.cast<T>(), &x_cg);

--- a/multibody/fixed_fem/dev/test/fem_solver_test.cc
+++ b/multibody/fixed_fem/dev/test/fem_solver_test.cc
@@ -1,0 +1,162 @@
+#include "drake/multibody/fixed_fem/dev/fem_solver.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/geometry/proximity/make_box_mesh.h"
+#include "drake/math/autodiff_gradient.h"
+#include "drake/multibody/fixed_fem/dev/eigen_conjugate_gradient_solver.h"
+#include "drake/multibody/fixed_fem/dev/fem_state.h"
+#include "drake/multibody/fixed_fem/dev/linear_constitutive_model.h"
+#include "drake/multibody/fixed_fem/dev/linear_simplex_element.h"
+#include "drake/multibody/fixed_fem/dev/simplex_gaussian_quadrature.h"
+#include "drake/multibody/fixed_fem/dev/static_elasticity_element.h"
+#include "drake/multibody/fixed_fem/dev/static_elasticity_model.h"
+#include "drake/multibody/fixed_fem/dev/zeroth_order_state_updater.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+constexpr int kNaturalDimension = 3;
+constexpr int kSpatialDimension = 3;
+constexpr int kSolutionDimension = 3;
+constexpr int kQuadratureOrder = 1;
+/* Number of nodes subject to Dirichlet BC. */
+constexpr int kNumDirichlet = 4;
+constexpr int kNumNodes = 8;
+constexpr int kNumDofs = kNumNodes * kSolutionDimension;
+constexpr double kTol = 1e-14;
+using T = double;
+using QuadratureType =
+    SimplexGaussianQuadrature<kNaturalDimension, kQuadratureOrder>;
+constexpr int kNumQuads = QuadratureType::num_quadrature_points();
+using IsoparametricElementType =
+    LinearSimplexElement<T, kNaturalDimension, kSpatialDimension, kNumQuads>;
+using ConstitutiveModelType = LinearConstitutiveModel<T, kNumQuads>;
+using ElementType =
+    StaticElasticityElement<IsoparametricElementType, QuadratureType,
+                            ConstitutiveModelType>;
+using ModelType = StaticElasticityModel<ElementType>;
+using SolverType = FemSolver<ModelType>;
+using State = FemState<ElementType>;
+const double kYoungsModulus = 1.234;
+const double kPoissonRatio = 0.4567;
+const double kDensity = 8.90;
+/* Set a non-default gravity to check gravity's set correctly. */
+const Vector3<T> kGravity{1.23, -4.56, 7.89};
+
+class FemSolverTest : public ::testing::Test {
+ protected:
+  /* Make a box and subdivide it into 6 tetrahedra. */
+  static geometry::VolumeMesh<T> MakeBoxTetMesh() {
+    const double kLength = 0.1;
+    const geometry::Box box(kLength, kLength, kLength);
+    const geometry::VolumeMesh<T> mesh =
+        geometry::internal::MakeBoxVolumeMesh<T>(box, kLength);
+    EXPECT_EQ(mesh.num_elements(), 6);
+    EXPECT_EQ(mesh.num_vertices(), 8);
+    return mesh;
+  }
+
+  void SetUp() override {
+    /* Builds the FemModel. */
+    std::unique_ptr<ModelType> model = MakeBoxModel();
+    model->SetGravity(kGravity);
+
+    /* Builds the FemSolver. */
+    solver_ = std::make_unique<SolverType>(std::move(model));
+    solver_->set_linear_solve_tolerance(kTol);
+    solver_->set_relative_tolerance(kTol);
+    solver_->set_absolute_tolerance(kTol);
+
+    /* Set up the Dirichlet BC. */
+    std::unique_ptr<DirichletBoundaryCondition<State>> bc = MakeCeilingBc();
+    solver_->SetDirichletBoundaryCondition(std::move(bc));
+  }
+
+  static std::unique_ptr<ModelType> MakeBoxModel() {
+    const geometry::VolumeMesh<T> mesh = MakeBoxTetMesh();
+    const ConstitutiveModelType constitutive_model(kYoungsModulus,
+                                                   kPoissonRatio);
+    auto model = std::make_unique<ModelType>();
+    model->AddStaticElasticityElementsFromTetMesh(mesh, constitutive_model,
+                                                  kDensity);
+    return model;
+  }
+
+  /* Creates the undeformed state of the model under test. */
+  static State MakeReferenceState() {
+    std::unique_ptr<ModelType> model = MakeBoxModel();
+    return model->MakeFemState();
+  }
+
+  /* Creates a Dirichlet boundary condition that constrains the first
+   `kNumDirichlet` vertices. */
+  static std::unique_ptr<DirichletBoundaryCondition<State>> MakeCeilingBc() {
+    auto bc = std::make_unique<DirichletBoundaryCondition<State>>();
+    const State state = MakeReferenceState();
+    const VectorX<T>& q = state.q();
+    for (int node = 0; node < kNumDirichlet; ++node) {
+      const DofIndex starting_dof_index(kSolutionDimension * node);
+      /* Dirichlet BC for all dofs associated with the node. */
+      for (int d = 0; d < kSolutionDimension; ++d) {
+        bc->AddBoundaryCondition(DofIndex(starting_dof_index + d),
+                                 Vector1<T>(q(starting_dof_index + d)));
+      }
+    }
+    return bc;
+  }
+
+  /* Creates an arbitrary state that respects the Dirichlet BC created above. */
+  static State MakeArbitraryState() {
+    State state = MakeReferenceState();
+    const VectorX<T> q = MakeArbitraryPositions();
+    state.set_q(q);
+    std::unique_ptr<DirichletBoundaryCondition<State>> bc = MakeCeilingBc();
+    bc->ApplyBoundaryConditions(&state);
+    return state;
+  }
+
+  /* Creates an arbitrary position vector with dofs compatible with the box
+   mesh. The positions for this test are indeed arbitrarily chosen and do not
+   necessarily lead to a valid physical configuration. Whether the configuration
+   is physical is not relevant because the static linear elasticity test below
+   should pass *regardless* of the geometry state. */
+  static Vector<double, kNumDofs> MakeArbitraryPositions() {
+    Vector<double, kNumDofs> q;
+    q << 0.18, 0.63, 0.54, 0.13, 0.92, 0.17, 0.03, 0.86, 0.85, 0.25, 0.53, 0.67,
+        0.81, 0.36, 0.45, 0.31, 0.29, 0.71, 0.30, 0.68, 0.58, 0.52, 0.35, 0.76;
+    return q;
+  }
+
+  /* The solver under test. */
+  std::unique_ptr<SolverType> solver_;
+};
+
+namespace {
+/* We move the vertices of the mesh to arbitrary locations q and record the net
+force f exerted on the vertices. Then if we apply f on the vertices in the
+reference state, we should recover the positions q for static equilibrium. */
+TEST_F(FemSolverTest, StaticForceEquilibrium) {
+  /* Create an arbitrary state and find the nodel force exerted on the vertices
+   of the mesh (in unit N). */
+  const State prescribed_state = MakeArbitraryState();
+  const ModelType& model = solver_->model();
+  VectorX<T> nodal_force(kNumDofs);
+  model.CalcResidual(prescribed_state, &nodal_force);
+
+  /* If we exert the same force on the reference state, we should expect to
+   recover the same positions as above. */
+  const T initial_error = nodal_force.norm();
+  ModelType& mutable_model = solver_->mutable_model();
+  mutable_model.SetExplicitExternalForce(nodal_force);
+  State state = MakeReferenceState();
+  const ZerothOrderStateUpdater<State> state_updater;
+  solver_->SolveWithInitialGuess(state_updater, &state);
+  EXPECT_TRUE(CompareMatrices(state.q(), prescribed_state.q(),
+                              std::max(kTol, kTol * initial_error)));
+}
+}  // namespace
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/test/static_elasticity_element_test.cc
+++ b/multibody/fixed_fem/dev/test/static_elasticity_element_test.cc
@@ -113,12 +113,12 @@ TEST_F(StaticElasticityElementTest, Constructor) {
 /* Tests that the calculation of the residual calls the calculation of the
  negative elastic force and the external force. */
 TEST_F(StaticElasticityElementTest,
-       ResidualIsNegativeElasticForcePlusExternalForce) {
+       ResidualIsNegativeElasticForceMinusExternalForce) {
   Vector<T, kNumDofs> residual;
   element().CalcResidual(*state_, &residual);
   Vector<T, kNumDofs> external_force = Vector<T, kNumDofs>::Zero();
-  element().AddExternalForce(*state_, &external_force);
-  EXPECT_TRUE(CompareMatrices(CalcNegativeElasticForce() + external_force,
+  element().AddScaledExternalForce(*state_, 1.0, &external_force);
+  EXPECT_TRUE(CompareMatrices(CalcNegativeElasticForce() - external_force,
                               residual, 0));
 }
 

--- a/multibody/fixed_fem/dev/test/static_elasticity_model_test.cc
+++ b/multibody/fixed_fem/dev/test/static_elasticity_model_test.cc
@@ -91,14 +91,15 @@ TEST_F(StaticElasticityModelTest, Geometry) {
 
 /* Tests that the residual of the model is the derivative of the elastic energy
  with respect to the generalized positions plus external force. */
-TEST_F(StaticElasticityModelTest, ResidualIsEnergyDerivativePlusExternalForce) {
+TEST_F(StaticElasticityModelTest,
+       ResidualIsEnergyDerivativeMinusExternalForce) {
   FemState<ElementType> state = MakeDeformedState();
   T energy = model_.CalcElasticEnergy(state);
   VectorX<T> residual(state.num_generalized_positions());
   model_.CalcResidual(state, &residual);
   VectorX<T> external_force(state.num_generalized_positions());
   model_.CalcExternalForce(state, &external_force);
-  EXPECT_TRUE(CompareMatrices(energy.derivatives() + external_force, residual,
+  EXPECT_TRUE(CompareMatrices(energy.derivatives() - external_force, residual,
                               std::numeric_limits<double>::epsilon()));
 }
 


### PR DESCRIPTION
FemSolver provides the minimum functionalities needed to solve the
system of equations that arise from FEM space discretization by
integrating components such as FemModel, LinearSystemSolver and
DirichletBoundaryCondition.

FemSolverTest serves as an integration test for FEM. It generates
an arbitrary set of forces on the vertices of a model by setting
arbitrary displacements for the vertices of the model. It then verifies
that under those forces, the solution provided the solver matches the
prescribed displacements.

To enable the test mentioned above, the capability to set an explicit
external force directly on the vertices of the model has been added.
Furthermore, the API for LinearSystemSolver has been slightly changed
to allow LHS of the system to be modified.

Bug fix: fix the sign of the external forces that appear in the residual
for ElasticityElement/Model.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14649)
<!-- Reviewable:end -->
