### PR TITLE
pybind: Hard code -std=c++17 option spelling

### DIFF
--- a/tools/skylark/pybind.bzl
+++ b/tools/skylark/pybind.bzl
@@ -368,7 +368,7 @@ def _generate_pybind_documentation_header_impl(ctx):
              ",".join(ctx.attr.ignore_dirs_for_coverage))
     for p in ctx.attr.exclude_hdr_patterns:
         args.add("-exclude-hdr-patterns=" + p)
-    args.add_all(ctx.fragments.cpp.cxxopts, uniquify = True)
+    args.add("-std=c++17")
     args.add("-w")
 
     # N.B. This is for `targets` only.
@@ -415,7 +415,6 @@ generate_pybind_documentation_header = rule(
             default = [],
         ),
     },
-    fragments = ["cpp"],
     implementation = _generate_pybind_documentation_header_impl,
     output_to_genfiles = True,
 )


### PR DESCRIPTION
We know that our hard-coded libclang handles Drake's minimum C++ standard revision, so we can just hard-code that spelling for mkdoc.  This allows users to build object code using -std=c++20 mode without angering libclang.

I confirmed that on both Ubuntu and macOS, in a default configuration, the _only_ cxxopts coming in through the fragment was `-std=c++17`.

Closes #14654.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14669)
<!-- Reviewable:end -->
