### PR TITLE
Add @drake prefix to bazel rules in tools

### DIFF
--- a/tools/skylark/BUILD.bazel
+++ b/tools/skylark/BUILD.bazel
@@ -1,8 +1,8 @@
 # -*- python -*-
 
-load("//tools/skylark:py.bzl", "py_binary")
-load("//tools/skylark:drake_py.bzl", "drake_py_unittest")
-load("//tools/lint:lint.bzl", "add_lint_tests")
+load("@drake//tools/skylark:py.bzl", "py_binary")
+load("@drake//tools/skylark:drake_py.bzl", "drake_py_unittest")
+load("@drake//tools/lint:lint.bzl", "add_lint_tests")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/tools/skylark/alias.bzl
+++ b/tools/skylark/alias.bzl
@@ -1,11 +1,11 @@
 # -*- python -*-
 
-load("//tools/skylark:py.bzl", "py_library")
+load("@drake//tools/skylark:py.bzl", "py_library")
 load(
     "@drake//tools/skylark:drake_cc.bzl",
     "drake_cc_library",
 )
-load("//tools/workspace:generate_file.bzl", "generate_file")
+load("@drake//tools/workspace:generate_file.bzl", "generate_file")
 
 def _combine_relative_labels(arg_list, arg_map):
     # Merge the relative_labels= and relative_labels_map= arguments as seen in

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -94,7 +94,7 @@ def _platform_copts(rule_copts, rule_gcc_copts, rule_clang_copts, cc_test = 0):
     if type(result) != "list":
         return result
     return select({
-        "//tools:drake_werror": result,
+        "@drake//tools:drake_werror": result,
         "//conditions:default": [
             x.replace("-Werror=", "-W")
             for x in result
@@ -104,7 +104,7 @@ def _platform_copts(rule_copts, rule_gcc_copts, rule_clang_copts, cc_test = 0):
 def _dsym_command(name):
     """Returns the command to produce .dSYM on macOS, or a no-op on Linux."""
     return select({
-        "//tools/cc_toolchain:apple_debug": (
+        "@drake//tools/cc_toolchain:apple_debug": (
             "dsymutil -f $(location :" + name + ") -o $@ 2> /dev/null"
         ),
         "//conditions:default": (
@@ -126,7 +126,7 @@ def _check_library_deps_blacklist(name, deps):
             continue
         if dep.endswith(":add_text_logging_gflags"):
             fail("The cc_library '" + name + "' must not depend on " +
-                 "//common:add_text_logging_gflags; only cc_binary targets " +
+                 "@drake//common:add_text_logging_gflags; only cc_binary targets " +
                  "are allowed to have gflags")
         if dep.endswith(":main"):
             fail("The cc_library '" + name + "' must not depend on a :main " +
@@ -649,7 +649,7 @@ def drake_cc_googletest(
     """
     if use_default_main:
         deps = deps + [
-            "//common/test_utilities:drake_cc_googletest_main",
+            "@drake//common/test_utilities:drake_cc_googletest_main",
         ]
     else:
         deps = deps + ["@gtest//:without_main"]
@@ -659,7 +659,7 @@ def drake_cc_googletest(
         # If we're in debug compilation mode, then skip all test cases so that
         # the test will trivially pass.
         new_args = args + select({
-            "//tools/cc_toolchain:debug": ["--gtest_filter=-*"],
+            "@drake//tools/cc_toolchain:debug": ["--gtest_filter=-*"],
             "//conditions:default": [],
         })
 

--- a/tools/skylark/drake_lcm.bzl
+++ b/tools/skylark/drake_lcm.bzl
@@ -1,7 +1,7 @@
 # -*- python -*-
 
 load(
-    "//tools/workspace/lcm:lcm.bzl",
+    "@drake//tools/workspace/lcm:lcm.bzl",
     "lcm_cc_library",
     "lcm_java_library",
     "lcm_py_library",

--- a/tools/skylark/drake_py.bzl
+++ b/tools/skylark/drake_py.bzl
@@ -1,6 +1,6 @@
 # -*- python -*-
 
-load("//tools/skylark:py.bzl", "py_binary", "py_library", "py_test")
+load("@drake//tools/skylark:py.bzl", "py_binary", "py_library", "py_test")
 
 def drake_py_library(
         name,
@@ -172,7 +172,7 @@ def drake_py_unittest(
     contain a __main__ handler nor a shebang line.  By default, sets test size
     to "small" to indicate a unit test.
     """
-    helper = "//common/test_utilities:drake_py_unittest_main.py"
+    helper = "@drake//common/test_utilities:drake_py_unittest_main.py"
     if kwargs.pop("srcs", None):
         fail("Changing srcs= is not allowed by drake_py_unittest." +
              " Use drake_py_test instead, if you need something weird.")
@@ -225,7 +225,7 @@ def drake_py_test(
     if "//:module_py" not in deps:
         deps += ["//:module_py"]
     if not allow_import_unittest:
-        deps = deps + ["//common/test_utilities:disable_python_unittest"]
+        deps = deps + ["@drake//common/test_utilities:disable_python_unittest"]
     if "py" not in tags:
         tags = tags + ["py"]
     _py_target_isolated(

--- a/tools/skylark/pybind.bzl
+++ b/tools/skylark/pybind.bzl
@@ -1,6 +1,6 @@
 # -*- python -*-
 
-load("//tools/skylark:py.bzl", "py_library")
+load("@drake//tools/skylark:py.bzl", "py_library")
 load("@cc//:compiler.bzl", "COMPILER_ID")
 
 # @see bazelbuild/bazel#3493 for needing `@drake//` when loading `install`.
@@ -401,7 +401,7 @@ generate_pybind_documentation_header = rule(
         ),
         "target_deps": attr.label_list(),
         "_mkdoc": attr.label(
-            default = Label("//tools/workspace/pybind11:mkdoc"),
+            default = Label("@drake//tools/workspace/pybind11:mkdoc"),
             allow_files = True,
             cfg = "host",
             executable = True,
@@ -476,7 +476,7 @@ generate_pybind_coverage = rule(
         "pybind_coverage_data": attr.label_list(allow_files = True),
         "_script": attr.label(
             default = Label(
-                "//tools/workspace/pybind11:generate_pybind_coverage",
+                "@drake//tools/workspace/pybind11:generate_pybind_coverage",
             ),
             allow_files = True,
             executable = True,


### PR DESCRIPTION
* By doing so we can use drake's awesome bazel toolchains in
  another repo that use drake as dependency. Currently the ambiguity
  in the dependencies defined in bazel rules make it unusable outside
  drake workspace

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14671)
<!-- Reviewable:end -->
