### PR TITLE
jekyll: Do not use strict mode

### DIFF
--- a/doc/_config.yml
+++ b/doc/_config.yml
@@ -100,6 +100,7 @@ kramdown:
   show_warnings: true
 
 liquid:
-  error_mode: strict
-  strict_variables: true
-  strict_filters: true
+  # TODO(eric.cousineau): Make these stricter at some point.
+  error_mode: warn
+  strict_variables: false
+  strict_filters: false

--- a/doc/_includes/header.html
+++ b/doc/_includes/header.html
@@ -12,7 +12,7 @@
         <li class="site-menu-item">
           {% if item.url %}<a href="{{ item.url | relative_url }}" class="site-menu-item">{% endif %}{{ item.title }}{% if item.url %}</a>{% endif %}
 
-          {% if item.subfolderitems[0] %}
+          {% if item contains "subfolderitems" %}
             <div class="sub">
             {% for entry in item.subfolderitems %}
               <a href="{{ entry.url | relative_url }}" class="site-menu-item">{{ entry.page }}</a>


### PR DESCRIPTION
Use `contains` for explicit nested config check for one missing var
See: https://github.com/Shopify/liquid/issues/1034#issuecomment-590121750

From failure: https://drake-cdash.csail.mit.edu/test/129053560
```
  Liquid Exception: Liquid error ({runfiles}/drake/doc/_includes/header.html line 15): undefined variable subfolderitems included in /_layouts/default.html
jekyll 3.8.6 | Error:  Liquid error ({runfiles}/drake/doc/_includes/header.html line 15): undefined variable subfolderitems included 
/usr/lib/ruby/vendor_ruby/liquid/variable_lookup.rb:62:in `block in evaluate': Liquid error ({runfiles}/drake/doc/_includes/header.html line 15): undefined variable subfolderitems included  (Liquid::UndefinedVariable)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14672)
<!-- Reviewable:end -->
