### PR TITLE
[geometry] Fix-forward for CI failures on `make_capsule_mesh_test`.

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -711,9 +711,12 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "make_capsule_mesh_test",
+    # This test includes generating the finest mesh allowed for a particular
+    # cylinder. The test size is increased to "medium" so that debug builds
+    # are successful in CI.
+    size = "medium",
     deps = [
         ":make_capsule_mesh",
-        ":mesh_to_vtk",
         ":proximity_utilities",
     ],
 )

--- a/geometry/proximity/test/make_capsule_mesh_test.cc
+++ b/geometry/proximity/test/make_capsule_mesh_test.cc
@@ -143,7 +143,7 @@ void VerifyCapsuleMeshWithMa(const VolumeMesh<double>& mesh,
 GTEST_TEST(MakeCapsuleVolumeMesTest, Long) {
   const double radius = 1.0;
   const double length = 3.0;
-  const double resolution_hint = 0.05;
+  const double resolution_hint = 0.5;
   const Capsule capsule(radius, length);
   const VolumeMesh<double> mesh =
       MakeCapsuleVolumeMesh<double>(capsule, resolution_hint);


### PR DESCRIPTION
Closes #14673.

- Adds size="medium" to `make_capsule_mesh_test`
- Removes one unused dependency from `make_capsule_mesh_test`
- Fixes typo with wrong resolution hint in `make_capsule_mesh_test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14674)
<!-- Reviewable:end -->
