### PR TITLE
Replace markdown index blocks with a _homeblocks collection

### DIFF
--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -103,6 +103,7 @@ filegroup(
     ] + glob([
         "_includes/*.html",
         "_includes/*.md",
+        "_homeblocks/*.md",
         "_layouts/*.html",
         "_pages/*.md",
         "_release-notes/*.md",

--- a/doc/_config.yml
+++ b/doc/_config.yml
@@ -68,6 +68,9 @@ collections:
   release-notes:
     output: true
     permalink: /release_notes/:path
+  # Home-page elements
+  homeblocks:
+    output: true
 
 defaults:
   - scope:

--- a/doc/_homeblocks/1-about-video.md
+++ b/doc/_homeblocks/1-about-video.md
@@ -1,0 +1,8 @@
+---
+title: About Video
+display-title: dont
+---
+
+{% include video-autoplay.html
+  url = "https://user-images.githubusercontent.com/26719449/108152577-4d14f300-70a7-11eb-88c5-5da0c39b1e24.mp4"
+%}

--- a/doc/_homeblocks/1-about.md
+++ b/doc/_homeblocks/1-about.md
@@ -1,0 +1,12 @@
+---
+title: Overview
+---
+
+**Drake ("dragon" in Middle English) is a C++ toolbox started by the
+[Robot Locomotion Group](http://groups.csail.mit.edu/locomotion/) at the MIT Computer Science and Artificial Intelligence Lab (CSAIL). The [development team has now
+grown significantly](/credits.html), with core development led by the [Toyota Research Institute](https://www.tri.global/).
+It is a collection of tools for analyzing the dynamics of our robots and building control systems for them, with a heavy emphasis on optimization-based design/analysis.**
+
+While there are an increasing number of simulation tools available for robotics, most of them function like a black box: commands go in, sensors come out. Drake aims to simulate even very complex dynamics of robots (e.g. including friction, contact, aerodynamics, …), but always with an emphasis on exposing the structure in the governing equations (sparsity, analytical gradients, polynomial structure, uncertainty quantification, …) and making this information available for advanced planning, control, and analysis algorithms. Drake provides an interface to Python to enable rapid-prototyping of new algorithms, and also aims to provide solid open-source implementations for many state-of-the-art algorithms. Finally, we hope Drake provides many compelling examples that can help people get started and provide much needed benchmarks. We are excited to accept user contributions to improve the coverage.
+
+We hope you find this tool useful. Please see [Getting Help](/getting_help.html) if you wish to share your comments, questions, success stories, or frustrations. And please contribute your best bug fixes, features, and examples!

--- a/doc/_homeblocks/2-tutorials.md
+++ b/doc/_homeblocks/2-tutorials.md
@@ -1,0 +1,24 @@
+---
+title: Tutorials
+---
+
+We have Python tutorials that can be previewed and executed as Jupyter
+notebooks online with no need for local installation. You can use Binder to
+preview and execute the notebooks (but startup time may be long), or you can
+use nbviewer to only preview the notebook (where startup time is fast):
+
+<div class="aside">
+    <a target="_doc" href="https://mybinder.org/v2/gh/RobotLocomotion/drake/nightly-release-binder?filepath=tutorials">
+      <img src="https://mybinder.org/badge_logo.svg"/>
+    </a>
+    <a target="_doc" href="https://nbviewer.jupyter.org/github/RobotLocomotion/drake/blob/nightly-release/tutorials/">
+      <img src="https://img.shields.io/badge/view%20on-nbviewer-brightgreen.svg"/>
+    </a>
+</div>
+
+If you are browsing on nbviewer, you may click on the Binder button
+at the top-right of the page.
+
+You may find more information about how to run these locally with Jupyter,
+the branch the tutorials use, how they are published to Binder, etc., in
+[drake/tutorials/README.md.](https://github.com/RobotLocomotion/drake/blob/master/tutorials/README.md)

--- a/doc/_homeblocks/3-citing-drake.md
+++ b/doc/_homeblocks/3-citing-drake.md
@@ -1,0 +1,14 @@
+---
+title: Citing Drake
+---
+
+If you would like to cite Drake in your academic publications, we suggest the following BibTeX citation:
+
+```
+@misc{drake,
+ author = “Russ Tedrake and the Drake Development Team”,
+ title = “Drake: Model-based design and verification for robotics”,
+ year = 2019,
+ url = “https://drake.mit.edu”
+}
+```

--- a/doc/_homeblocks/4-examples.md
+++ b/doc/_homeblocks/4-examples.md
@@ -1,0 +1,15 @@
+---
+title: Examples
+---
+
+{% comment %}
+TODO(russt): make this a table with different algorithms, too.
+{% endcomment %}
+
+We have a number of use cases demonstrated under drake/examples in the
+[source tree](https://github.com/RobotLocomotion/drake/tree/master/examples), and
+more available through our [Drake Gallery](/gallery.html) (contributions welcome!).
+
+We also have a number of [examples of using Drake as a external library](https://github.com/RobotLocomotion/drake-external-examples)
+in your own projects, including examples with various build systems and
+examples of how you might set up continuous integration.

--- a/doc/_homeblocks/5-acknowledgments.md
+++ b/doc/_homeblocks/5-acknowledgments.md
@@ -1,0 +1,5 @@
+---
+title: Acknowledgments
+---
+
+The Drake developers would like to acknowledge significant support from the [Toyota Research Institute](http://tri.global/), [DARPA](http://www.darpa.mil/), the [National Science Foundation](https://nsf.gov/), the [Office of Naval Research](http://www.onr.navy.mil/), [Amazon.com](https://www.amazon.com/), and [The MathWorks](http://www.mathworks.com/).

--- a/doc/_homeblocks/7-using-drake.md
+++ b/doc/_homeblocks/7-using-drake.md
@@ -1,0 +1,6 @@
+---
+title: Using Drake From Other Programs
+---
+
+[![python](https://www.python.org/static/community_logos/python-logo-generic.svg){: .logo-link}](/python-bindings.html)
+[![julia](https://raw.githubusercontent.com/JuliaLang/julia-logo-graphics/master/images/julia-logo-color.svg){: .logo-link}](/julia-bindings.html)

--- a/doc/index.md
+++ b/doc/index.md
@@ -48,127 +48,17 @@ purpose of the front page (HTML for layout, Markdown for content).
 
 <section class="home-blocks padding">
   <div class="contain markdown-body">
-    <div class="home-blocks-grid grid grid-2col grid-wide" markdown="1">
-
-<!-- Begin main content. -->
-
-<article markdown="1">
-{% include video-autoplay.html
-  url = "https://user-images.githubusercontent.com/26719449/108152577-4d14f300-70a7-11eb-88c5-5da0c39b1e24.mp4"
-%}
+    <div class="home-blocks-grid grid grid-2col grid-wide">
+        {% for dev in site.homeblocks %}
+<article id="{{ dev.title }}" class="content-container">
+{% if dev.display-title != "dont" %}
+<h2 class="post__sub_title">{{ dev.title }}</h2>
+{% endif %}
+{{ dev.content }}
 </article>
-
-
-<article markdown="1">
-## Overview
-
-Drake ("dragon" in Middle English) is a C++ toolbox started by the
-[Robot Locomotion Group](http://groups.csail.mit.edu/locomotion/) at the MIT
-Computer Science and Artificial Intelligence Lab (CSAIL). The
-[development team](/credits.html) has now grown significantly, with core
-development led by the [Toyota Research Institute](https://www.tri.global/). It
-is a collection of tools for analyzing the dynamics of our robots and building
-control systems for them, with a heavy emphasis on optimization-based
-design/analysis.
-
-While there are an increasing number of simulation tools available for
-robotics, most of them function like a black box: commands go in, sensors come
-out. Drake aims to simulate even very complex dynamics of robots (e.g.
-including friction, contact, aerodynamics, …), but always with an emphasis on
-exposing the structure in the governing equations (sparsity, analytical
-gradients, polynomial structure, uncertainty quantification, …) and making this
-information available for advanced planning, control, and analysis algorithms.
-Drake provides an interface to Python to enable rapid-prototyping of new
-algorithms, and also aims to provide solid open-source implementations for many
-state-of-the-art algorithms. Finally, we hope Drake provides many compelling
-examples that can help people get started and provide much needed benchmarks.
-We are excited to accept user contributions to improve the coverage.
-
-We hope you find this tool useful. Please see
-[Getting Help](/getting-help.html) if you wish to share your comments,
-questions, success stories, or frustrations. And please contribute your best
-bug fixes, features, and examples!
-</article>
-
-
-<article markdown="1">
-## Tutorials
-
-We have Python tutorials that can be previewed and executed as Jupyter
-notebooks online with no need for local installation. You can use Binder to
-preview and execute the notebooks (but startup time may be long), or you can
-use nbviewer to only preview the notebook (where startup time is fast):
-
-If you are browsing on nbviewer, you may click on the Binder button at the
-top-right of the page.
-
-You may find more information about how to run these locally with Jupyter, the
-branch the tutorials use, how they are published to Binder, etc., in
-[drake/tutorials/README.md.](https://github.com/RobotLocomotion/drake/blob/master/tutorials/README.md)
-</article>
-
-
-<article markdown="1">
-## Citing Drake
-
-```
-@misc{drake,
- author = "Russ Tedrake and the Drake Development Team",
- title = "Drake: Model-based design and verification for robotics",
- year = 2019,
- url = "https://drake.mit.edu"
-}
-```
-</article>
-
-
-<article markdown="1">
-## Examples
-
-We have a number of use cases demonstrated under drake/examples in the
-[source tree](https://github.com/RobotLocomotion/drake/tree/master/examples),
-and more available through our [Drake Gallery](/gallery.html) (contributions
-welcome!).
-
-We also have a number of [examples of using Drake as a external library](
-https://github.com/RobotLocomotion/drake-external-examples) in your own
-projects, including examples with various build systems and examples of how you
-might set up continuous integration.
-</article>
-
-
-<article markdown="1">
-## Acknowledgements
-
-The Drake developers would like to acknowledge significant support from the
-[Toyota Research Institute](http://tri.global/),
-[DARPA](http://www.darpa.mil/), the
-[National Science Foundation](https://nsf.gov/), the
-[Office of Naval Research](http://www.onr.navy.mil/),
-[Amazon.com](https://www.amazon.com/), and
-[The MathWorks](http://www.mathworks.com/).
-</article>
-
-
-<article markdown="1">
-## From Other Languages
-
-### Python Bindings
-
-<a href="/python_bindings.html">
-  <img src="/third_party/images/python-logo-generic.svg" width="150px"/>
-</a>
-
-### Others
-
-[Julia](./julia_bindings.md)
-
-</article>
-
-<!-- End main content. -->
-
-</div>
-</div>
+        {% endfor %}
+    </div>
+  </div>
 </section>
 
 </div>


### PR DESCRIPTION
This factors the article blocks of the jekyll index page with
modular components from a _homeblocks collection.  This
substantially restores the homeblocks-based design from #14479

Toward #14577

Co-authored-by: Betsy McPhail <betsy.mcphail@kitware.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14676)
<!-- Reviewable:end -->
