### PR TITLE
Test to ensure RigidTransform<double> can work with optimization instructions.…

### DIFF
--- a/math/rotation_matrix.h
+++ b/math/rotation_matrix.h
@@ -932,6 +932,12 @@ class RotationMatrix {
   Matrix3<T> R_AB_;
 };
 
+// To enable low-level optimizations we insist that RotationMatrix<double> is
+// packed into 9 consecutive doubles, with no extra alignment padding.
+static_assert(sizeof(RotationMatrix<double>) == 9 * sizeof(double),
+    "Low-level optimizations depend on RotationMatrix<double> being stored as "
+    "9 sequential doubles in memory, with no extra memory alignment padding.");
+
 /// Abbreviation (alias/typedef) for a RotationMatrix double scalar type.
 /// @relates RotationMatrix
 using RotationMatrixd = RotationMatrix<double>;


### PR DESCRIPTION
Optimization (e.g., AVX instructions for multiplying rotation matrices) can leverage a continuous memory layout of RotationMatrix<double> as 9 sequential doubles, with no additional memory padding for alignment.  

A static assertion ensures RotationMatrix<double> has this property, hence compilation fails if this is not the case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14678)
<!-- Reviewable:end -->
