### PR TITLE
[tools:drake_visualizer] Simple vector menu for hydroelastic contact.

### DIFF
--- a/tools/workspace/drake_visualizer/_drake_visualizer_builtin_scripts/show_point_pair_contact.py
+++ b/tools/workspace/drake_visualizer/_drake_visualizer_builtin_scripts/show_point_pair_contact.py
@@ -55,7 +55,7 @@ class _ContactConfigDialog(QtGui.QDialog):
     '''A simple dialog for configuring the contact visualization'''
     def __init__(self, visualizer, parent=None):
         QtGui.QDialog.__init__(self, parent)
-        self.setWindowTitle("Force Vector Visualization")
+        self.setWindowTitle("Point-Contact Force Vector Visualization")
         layout = QtGui.QGridLayout()
         layout.setColumnStretch(0, 0)
         layout.setColumnStretch(1, 1)
@@ -63,7 +63,7 @@ class _ContactConfigDialog(QtGui.QDialog):
         row = 0
 
         # Magnitude representation
-        layout.addWidget(QtGui.QLabel("Magnitude representation"), row, 0)
+        layout.addWidget(QtGui.QLabel("Vector scaling mode"), row, 0)
         self.magnitude_mode = QtGui.QComboBox()
         modes = ContactVisModes.get_modes()
         mode_labels = [ContactVisModes.get_mode_string(m) for m in modes]
@@ -125,7 +125,7 @@ def get_sub_menu_or_make(menu, menu_name):
 class ContactVisualizer:
     def __init__(self):
         self._folder_name = 'Point Pair Contact Results'
-        self._name = "Contact Visualizer"
+        self._name = "Point Pair Contact Visualizer"
         self._enabled = False
         self._sub = None
 
@@ -160,7 +160,7 @@ class ContactVisualizer:
 
     def update_screen_text(self):
         folder = om.getOrCreateContainer(self._folder_name)
-        my_text = 'Contact vector: {}'.format(
+        my_text = 'Point contact vector: {}'.format(
             ContactVisModes.get_mode_string(self.magnitude_mode))
 
         # TODO(SeanCurtis-TRI): Figure out how to anchor this in the bottom-


### PR DESCRIPTION
This is a baby step towards solving #14680.

It allows users to choose one of the three vector scaling modes (default Fixed Length) as Sean explained in #14680:

  - __Fixed Length__: All force vectors are drawn as a fixed length arrows. Direction is clear, but there is no way to assess relative magnitude.
  - __Scaled__: All force arrows' lengths are drawn proportional to the force magnitude.
  - __Auto Scaled__: The largest *instantaneous* force is rendered with a fixed length arrow. All other force arrows are scaled smaller, based on their relative proportion to the maximum magnitude.

Users can also set the `global scale of all vectors` and the threshold of `minimum vectors` to draw.

![image](https://user-images.githubusercontent.com/42557859/108783138-c1c1b480-7521-11eb-9b43-cd813453aa12.png)

However, these settings apply to all kinds of vectors (force, moment, traction, and slip velocity) at the same time. This PR does not have a way to configure each kind of vector separately as requested by #14680.

These pictures show the same set of vectors with three different vector scaling modes: `Fixed Length`, `Scaled`, and `Auto Scaled`, respectively.

![image](https://user-images.githubusercontent.com/42557859/108782848-33e5c980-7521-11eb-85db-ee7d96ce6bed.png)
![image](https://user-images.githubusercontent.com/42557859/108782933-5aa40000-7521-11eb-961e-162b07ddf565.png)
![image](https://user-images.githubusercontent.com/42557859/108782996-75767480-7521-11eb-8227-4ad55617c5d6.png)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14679)
<!-- Reviewable:end -->
