### PR TITLE
[FEM] Add abstract base class for FEM model and state

### DIFF
--- a/multibody/fixed_fem/dev/BUILD.bazel
+++ b/multibody/fixed_fem/dev/BUILD.bazel
@@ -11,6 +11,29 @@ package(
 )
 
 drake_cc_library(
+    name = "fem_model_base",
+    srcs = [
+        "fem_model_base.cc",
+    ],
+    hdrs = [
+        "fem_model_base.h",
+    ],
+    deps = [
+        ":dirichlet_boundary_condition",
+        ":fem_state_base",
+        "//common:default_scalars",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "fem_state_base",
+    hdrs = [
+        "fem_state_base.h",
+    ],
+)
+
+drake_cc_library(
     name = "constitutive_model",
     hdrs = [
         "constitutive_model.h",
@@ -81,7 +104,6 @@ drake_cc_library(
     ],
     deps = [
         ":fem_indexes",
-        ":fem_state",
         "//common:essential",
     ],
 )
@@ -105,6 +127,7 @@ drake_cc_library(
     deps = [
         ":damping_model",
         ":elasticity_model",
+        ":newmark_scheme",
         "//geometry/proximity:volume_mesh",
     ],
 )
@@ -186,7 +209,9 @@ drake_cc_library(
     deps = [
         ":fem_element",
         ":fem_indexes",
+        ":fem_model_base",
         ":fem_state",
+        ":state_updater",
         "//common:essential",
     ],
 )
@@ -197,7 +222,6 @@ drake_cc_library(
         "fem_solver.h",
     ],
     deps = [
-        ":dirichlet_boundary_condition",
         ":eigen_conjugate_gradient_solver",
         ":fem_model",
         ":linear_system_solver",
@@ -213,7 +237,9 @@ drake_cc_library(
         "fem_state.h",
     ],
     deps = [
+        ":dirichlet_boundary_condition",
         ":element_cache_entry",
+        ":fem_state_base",
         "//common:essential",
     ],
 )
@@ -343,6 +369,7 @@ drake_cc_library(
     ],
     deps = [
         ":elasticity_model",
+        ":zeroth_order_state_updater",
         "//geometry/proximity:volume_mesh",
     ],
 )
@@ -408,7 +435,6 @@ drake_cc_googletest(
         ":dynamic_elasticity_model",
         ":linear_constitutive_model",
         ":linear_simplex_element",
-        ":newmark_scheme",
         ":simplex_gaussian_quadrature",
         "//common/test_utilities:eigen_matrix_compare",
         "//geometry/proximity:make_box_mesh",
@@ -449,6 +475,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "fem_solver_test",
     deps = [
+        ":dummy_element",
         ":eigen_conjugate_gradient_solver",
         ":fem_solver",
         ":linear_constitutive_model",
@@ -458,6 +485,7 @@ drake_cc_googletest(
         ":static_elasticity_model",
         ":zeroth_order_state_updater",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
         "//geometry/proximity:make_box_mesh",
         "//math:gradient",
     ],
@@ -560,7 +588,6 @@ drake_cc_googletest(
         ":simplex_gaussian_quadrature",
         ":static_elasticity_element",
         ":static_elasticity_model",
-        ":zeroth_order_state_updater",
         "//common/test_utilities:eigen_matrix_compare",
         "//geometry/proximity:make_box_mesh",
         "//math:gradient",

--- a/multibody/fixed_fem/dev/dirichlet_boundary_condition.h
+++ b/multibody/fixed_fem/dev/dirichlet_boundary_condition.h
@@ -8,13 +8,10 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/fixed_fem/dev/fem_indexes.h"
-#include "drake/multibody/fixed_fem/dev/fem_state.h"
 
 namespace drake {
 namespace multibody {
 namespace fixed_fem {
-// TODO(xuchenhan-tri): Have FemModel own DirichletBoundaryCondition. See issue
-// #14668.
 /** %DirichletBoundaryCondition provides functionalities related to Dirichlet
  boundary conditions (BC) to the FEM solver. In particular, it provides the
  following functionalities:
@@ -23,39 +20,19 @@ namespace fixed_fem {
  3. modifying a given tangent matrix/residual that arises from the FEM system
  without BC and transform it into the tangent matrix/residual for the same
  system under the stored BC.
-
- The workflow for solving for an equilibrium in a system subject to BC looks
- like:
- ```
- // First, apply the boundary condition to the state.
- bc.ApplyBoundaryCondition(&state);
- // Then find the residual for the system without BC using FemModel.
- model.CalcResidual(state, &residual);
- // Modify the residual to account for the BC.
- bc.ApplyBcToResidual(&residual);
- // Enter Newton-Raphson iteration:
- while (residual.norm() > kTol){
-    // Find the tangent matrix and apply the BC.
-    model.CalcTangentMatrix(state, &tangent_matrix);
-    bc.ApplyBcToTangentMatrix(&tangent_matrix);
-    // Solve for the change in the state variable, dz, with a linear solver.
-    ...
-    // Advance the state with StateUpdater.
-    state_updater.UpdateState(dz, &state);
-    // Find the residual after the Newton-Raphson iteration.
-    model.CalcResidual(state, &residual);
-    bc.ApplyBcToResidual(&residual);
- }
- ```
- @tparam State    The type of FemState subject to the boundary condition.
- `State` must be an instantiation of FemState. */
-template <class State>
+ @tparam_nonsymbolic_scalar T. */
+template <class T>
 class DirichletBoundaryCondition {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DirichletBoundaryCondition);
-  using T = typename State::T;
 
-  DirichletBoundaryCondition() = default;
+  /* Constructs a new %DirichletBoundaryCondition that applies to an FEM model
+   that has the given `ode_order`. */
+  explicit DirichletBoundaryCondition(int ode_order) : ode_order_(ode_order) {}
+
+  /* Returns the ODE order of the FEM model that is compatible with `this`
+   %DirichletBoundaryCondition. */
+  int ode_order() const { return ode_order_; }
 
   /** Sets the dof with index `dof_index` to be subject to the prescribed
    `boundary_state`.
@@ -64,49 +41,24 @@ class DirichletBoundaryCondition {
    @param[in] boundary_state The tuple of prescibed state at `dof_index`. For a
    2nd-order ODE, it takes the form [q(dof_index), qdot(dof_index),
    qddot(dof_index)]. The `qdot` and `qddot` terms do not show up for lower
-   order ODEs. */
+   order ODEs.
+   @throw std::exception if boundary_state.size() != ode_order. */
   void AddBoundaryCondition(
-      DofIndex dof_index,
-      const Eigen::Ref<const Vector<T, State::ode_order() + 1>>&
-          boundary_state) {
+      DofIndex dof_index, const Eigen::Ref<const VectorX<T>>& boundary_state) {
+    if (boundary_state.size() != ode_order_ + 1) {
+      throw std::runtime_error(
+          std::to_string(ode_order_ + 1) +
+          " boundary states need to be specified. However, " +
+          std::to_string(boundary_state.size()) +
+          " boundary states were specified.");
+    }
     bcs_[dof_index] = boundary_state;
   }
 
-  /** Modifies the given `state` so that it complies with the stored boundary
-   conditions.
-   @pre state != nullptr.
-   @throw std::exception if the any of the indexes of the dofs under the
-   boundary condition specified by `this` %DirichletBoundaryCondition does
-   not exist in the input `state`. */
-  void ApplyBoundaryConditions(State* state) const {
-    DRAKE_DEMAND(state != nullptr);
-    if (bcs_.size() == 0) {
-      return;
-    }
-    /* Check validity of the dof indices stored. */
-    VerifyBcIndexes(state->num_generalized_positions());
-    using Eigen::VectorBlock;
-    /* Grab mutable states to write to. */
-    VectorBlock<VectorX<T>> q = state->mutable_q();
-    std::optional<VectorBlock<VectorX<T>>> qdot;
-    std::optional<VectorBlock<VectorX<T>>> qddot;
-    if constexpr (State::ode_order() >= 1) {
-      qdot = state->mutable_qdot();
-    }
-    if constexpr (State::ode_order() == 2) {
-      qddot = state->mutable_qddot();
-    }
-    /* Write the BC to the mutable state. */
-    for (const auto& [dof_index, boundary_state] : bcs_) {
-      q(dof_index) = boundary_state(0);
-      if constexpr (State::ode_order() >= 1) {
-        qdot.value()(dof_index) = boundary_state(1);
-      }
-      if constexpr (State::ode_order() == 2) {
-        qddot.value()(dof_index) = boundary_state(2);
-      }
-    }
-  }
+  /** Returns all boundary conditions stored in `this`
+   %DirichletBoundaryCondition as a `std::map` with the index of the dof as
+   key and the prescribed boundary values as value. */
+  const std::map<DofIndex, VectorX<T>>& get_bcs() const { return bcs_; }
 
   /** Modifies the given tangent matrix that arises from an FEM system without
    BC into the tangent matrix for the same system subject to `this` BC. More
@@ -160,8 +112,7 @@ class DirichletBoundaryCondition {
     }
   }
 
- private:
-  /* Verifies that the largest index for the dofs under BC is smaller than the
+  /** Verifies that the largest index for the dofs under BC is smaller than the
    given `size`. Otherwise, throw an exception. */
   void VerifyBcIndexes(int size) const {
     const auto& last_bc = bcs_.crbegin();
@@ -171,11 +122,16 @@ class DirichletBoundaryCondition {
     }
   }
 
+ private:
   /* We sort the boundary conditions according to dof indices for better
    cache consistency when applying the BC. The value of the map stores the
    value of q, qdot and qddot (in that order and when applicable) of the dof
    with index of the key. */
-  std::map<DofIndex, Vector<T, State::ode_order() + 1>> bcs_{};
+  std::map<DofIndex, VectorX<T>> bcs_{};
+
+  /* The ODE order of the FemModel that `this` DirichletBoundaryCondition
+   applies to. */
+  const int ode_order_;
 };
 }  // namespace fixed_fem
 }  // namespace multibody

--- a/multibody/fixed_fem/dev/dynamic_elasticity_model.h
+++ b/multibody/fixed_fem/dev/dynamic_elasticity_model.h
@@ -1,12 +1,14 @@
 #pragma once
 
 #include <array>
+#include <memory>
 #include <utility>
 
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/proximity/volume_mesh.h"
 #include "drake/multibody/fixed_fem/dev/damping_model.h"
 #include "drake/multibody/fixed_fem/dev/elasticity_model.h"
+#include "drake/multibody/fixed_fem/dev/newmark_scheme.h"
 
 namespace drake {
 namespace multibody {
@@ -25,7 +27,16 @@ class DynamicElasticityModel : public ElasticityModel<Element> {
   using T = typename Element::Traits::T;
   using ConstitutiveModel = typename Element::Traits::ConstitutiveModel;
 
-  DynamicElasticityModel() = default;
+  // TODO(xuchenhan-tri): Currently the time stepping scheme is hard coded to
+  // the mid-point rule. Consider letting the user configure the time stepping
+  // scheme.
+  /** Creates a new %DynamicElasticityModel with the given discrete time step.
+   */
+  explicit DynamicElasticityModel(double dt)
+      : ElasticityModel<Element>(
+            std::make_unique<NewmarkScheme<FemState<Element>>>(dt, 0.5, 0.25)) {
+  }
+
   ~DynamicElasticityModel() = default;
 
   /** Add tetrahedral DynamicElasticityElements to the %DynamicElasticityModel

--- a/multibody/fixed_fem/dev/elasticity_model.h
+++ b/multibody/fixed_fem/dev/elasticity_model.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <array>
+#include <memory>
+#include <utility>
 
 #include "drake/multibody/fixed_fem/dev/elasticity_element.h"
 #include "drake/multibody/fixed_fem/dev/fem_model.h"
@@ -115,7 +117,11 @@ class ElasticityModel : public FemModel<Element> {
 
  protected:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ElasticityModel);
-  ElasticityModel() = default;
+
+  explicit ElasticityModel(
+      std::unique_ptr<StateUpdater<FemState<Element>>> state_updater)
+      : FemModel<Element>(std::move(state_updater)) {}
+
   virtual ~ElasticityModel() = default;
 
   /** Parse a tetrahedral volume mesh, store the positions of the vertices in

--- a/multibody/fixed_fem/dev/fem_model.h
+++ b/multibody/fixed_fem/dev/fem_model.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <array>
+#include <memory>
+#include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -10,47 +12,28 @@
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/fixed_fem/dev/fem_element.h"
 #include "drake/multibody/fixed_fem/dev/fem_indexes.h"
+#include "drake/multibody/fixed_fem/dev/fem_model_base.h"
 #include "drake/multibody/fixed_fem/dev/fem_state.h"
+#include "drake/multibody/fixed_fem/dev/state_updater.h"
 
 namespace drake {
 namespace multibody {
 namespace fixed_fem {
-/** %FemModel calculates the components of the discretized FEM equations.
- Suppose the PDE at hand is of the form
 
-     F(z, ∇z, ...) = 0.
-
- where ... indicates possible higher derivatives that we aren't concerned with
- here. In this PDE, z: Ω ⊂ Rᴰ → Rᵈ, is the unknown function being solved for.
- Here, Ω is the domain, D is the dimension of the domain, and d is the solution
- dimension. For instance, if you are solving for the temperature of a 3D object,
- then the domain is three-dimensional (D = 3), while the solution, which is the
- temperature at a point within the object, is one-dimensional (d = 1). After
- spatial and time discretization, the PDE is reduced to a system of linear or
- nonlinear equations of the form:
-
-     G(z₁, z₂, ..., zₙ) = 0,
-
- where n is the number of nodes in the discretization and G is a function from
- Rⁿᵈ to Rⁿᵈ. The linear or nonlinear equation in the system associated with
- the node `a` has the form
-
-     Gₐ(z₁, z₂, ..., zₙ) = 0,
-
- where Gₐ is a function from Rⁿᵈ → Rᵈ and a = 1, ..., n. The nodal values z₁,
- z₂, ..., zₙ are solved for with a linear or nonlinear solver, and the solution
- z is interpolated from these nodal values.
-
- %FemModel calculates various components of the system of linear or nonlinear
- equations that supports solving the system. For example, CalcResidual()
- calculates the value of G evaluated at the current state and
- CalcTangentMatrix() calculates ∇G at the current state.
+/** %FemModel provides a fixed size implementaion of FemModelBase by
+ templatizing on the type of FemElement. See FemModelBase for more information
+ on the functionalities of this class. Many methods provided by FemModelBase
+ (e.g. FemModelBase::CalcTangentMatrix()) involve evaluating computationally
+ intensive loops over FemElement, and the overhead caused by virtual methods may
+ be significant. Therefore, this class is templated on the FemElement to avoid
+ the overhead of virtual methods. The type information at compile time also
+ helps eliminate heap allocations.
  @tparam Element    The type of FemElement that makes up this %FemModel.
  This template parameter provides the scalar type and the compile time constants
  such as the natural, spatial and solution dimensions and the number of
  nodes/quadrature points in each element. */
 template <class Element>
-class FemModel {
+class FemModel : public FemModelBase<typename Element::Traits::T> {
  public:
   static_assert(
       std::is_base_of_v<FemElement<Element, typename Element::Traits>, Element>,
@@ -68,26 +51,69 @@ class FemModel {
   }
 
   /** The number of degrees of freedom in the model. */
-  int num_dofs() const {
-    return Element::Traits::kSolutionDimension * num_nodes();
+  int num_dofs() const final {
+    return Element::Traits::kSolutionDimension * this->num_nodes();
   }
 
   /** The number of FemElements owned by `this` %FemModel. */
-  int num_elements() const { return elements_.size(); }
+  int num_elements() const final { return elements_.size(); }
 
-  /** The number of nodes that are associated with `this` %FemModel. */
-  int num_nodes() const { return num_nodes_; }
+ protected:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FemModel);
 
-  /** Calculates the residual at the given FemState by assembling the residual
-   from each element. Suppose the linear or nonlinear system generated from the
-   FEM discretization is G(z) = 0, then the output `residual` is equal to the
-   function G evaluated at the input `state`.
-   @param[in] state The FemState at which to evaluate the residual.
-   @param[out] residual The output residual evaluated at `state`.
-   @pre residual != nullptr.
-   @pre The size of the vector behind `residual` must be `num_dofs()`. */
-  void CalcResidual(const FemState<Element>& state,
-                    EigenPtr<VectorX<T>> residual) const {
+  explicit FemModel(
+      std::unique_ptr<StateUpdater<FemState<Element>>> state_updater)
+      : state_updater_(std::move(state_updater)) {}
+
+  virtual ~FemModel() = default;
+
+  /** Derived classes must implement this method to create a new FemState. */
+  virtual FemState<Element> DoMakeFemState() const = 0;
+
+  const Element& element(ElementIndex i) const {
+    DRAKE_ASSERT(i.is_valid());
+    DRAKE_ASSERT(i < num_elements());
+    return elements_[i];
+  }
+
+  Element& mutable_element(ElementIndex i) {
+    DRAKE_ASSERT(i.is_valid());
+    DRAKE_ASSERT(i < num_elements());
+    return elements_[i];
+  }
+
+  /** Moves the input `element` into the vector of elements held by `this`
+   %FemModel. */
+  void AddElement(Element&& element) {
+    elements_.emplace_back(std::move(element));
+  }
+
+  /** Alternative signature for adding a new element to `this` %FemModel.
+   Forwards the arguments `args` to the constructor of the Element and
+   potentially creates the new element in place. */
+  template <typename... Args>
+  void AddElement(Args&&... args) {
+    elements_.emplace_back(std::forward<Args>(args)...);
+  }
+
+  /** Adds per-vertex residuals that are explicitly specified at each vertex
+   instead of accumulated from elements. The default implementation is a
+   no-op. Derived classes must override this method if their residuals have
+   per-vertex contribution. */
+  virtual void AddExplicitResidual(EigenPtr<VectorX<T>> residual) const {}
+
+ private:
+  int ode_order() const final { return Element::Traits::kOdeOrder; }
+
+  /* Implements FemModelBase::MakeFemStateBase() by simply hiding the
+   result from MakeFemState() behind a unique_ptr to FemStateBase. */
+  std::unique_ptr<FemStateBase<T>> MakeFemStateBase() const final {
+    return std::make_unique<FemState<Element>>(MakeFemState());
+  }
+
+  /* Helper for DoCalcResidual(). */
+  void CalcResidualForConcreteState(const FemState<Element>& state,
+                                    EigenPtr<VectorX<T>> residual) const {
     DRAKE_DEMAND(residual != nullptr && residual->size() == num_dofs());
     DRAKE_DEMAND(state.element_cache_size() == num_elements());
     /* The values are accumulated in the residual, so it is important to clear
@@ -115,22 +141,10 @@ class FemModel {
     AddExplicitResidual(residual);
   }
 
-  /** Calculates the tangent matrix at the given FemState. The ij-th entry of
-   the tangent matrix is the derivative of the i-th entry of the residual
-   (calculated by CalcResidual()) with respect to the j-th generalized unknown
-   zⱼ.
-   @param[in] state    The FemState at which the residual is evaluated.
-   @param[in] weights    The ordered weights to combine stiffness matrix,
-   damping matrix and mass matrix into the tangent matrix.
-   @param[out] tangent_matrix    The output tangent_matrix. Suppose the linear
-   or nonlinear system generated from the FEM discretization is G(z) = 0, then
-   `tangent_matrix` is equal to ∇G evaluated at the input `state`.
-   @pre tangent_matrix != nullptr.
-   @pre The size of the matrix behind `tangent_matrix` is `num_dofs()` *
-   `num_dofs()`. */
-  void CalcTangentMatrix(const FemState<Element>& state,
-                         const Vector3<T>& weights,
-                         Eigen::SparseMatrix<T>* tangent_matrix) const {
+  /* Helper for DoCalcTangentMatrix(). */
+  void CalcTangentMatrixForConcreteState(
+      const FemState<Element>& state,
+      Eigen::SparseMatrix<T>* tangent_matrix) const {
     DRAKE_DEMAND(tangent_matrix != nullptr &&
                  tangent_matrix->rows() == num_dofs() &&
                  tangent_matrix->cols() == num_dofs());
@@ -145,6 +159,7 @@ class FemModel {
     /* Scratch space to store the contribution to the tangent matrix from each
      element. */
     Eigen::Matrix<T, kNumDofs, kNumDofs> element_tangent_matrix;
+    const Vector3<T>& weights = state_updater_->weights();
     for (ElementIndex e(0); e < num_elements(); ++e) {
       element_tangent_matrix = CalcElementTangentMatrix(state, weights, e);
       const std::array<NodeIndex, kNumNodes>& element_node_indices =
@@ -165,13 +180,9 @@ class FemModel {
     }
   }
 
-  /** Sets the sparsity pattern for the tangent matrix of this %FemModel.
-   @param[out] tangent_matrix    The tangent matrix of this %FemModel. Its
-   size and sparsity pattern will be set and it will be ready to be passed
-   into CalcTangentMatrix().
-   @pre `tangent_matrix` must not be the null pointer. */
-  void SetTangentMatrixSparsityPattern(
-      Eigen::SparseMatrix<T>* tangent_matrix) const {
+  /* Implements FemModelBase::SetTangentMatrixSparsityPattern(). */
+  void DoSetTangentMatrixSparsityPattern(
+      Eigen::SparseMatrix<T>* tangent_matrix) const final {
     DRAKE_DEMAND(tangent_matrix != nullptr);
     tangent_matrix->resize(num_dofs(), num_dofs());
     std::vector<Eigen::Triplet<T>> non_zero_entries;
@@ -205,49 +216,22 @@ class FemModel {
     tangent_matrix->makeCompressed();
   }
 
- protected:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FemModel);
-  FemModel() = default;
-  virtual ~FemModel() = default;
-
-  /** Derived classes must implement this method to create a new FemState. */
-  virtual FemState<Element> DoMakeFemState() const = 0;
-
-  const Element& element(ElementIndex i) const {
-    DRAKE_ASSERT(i.is_valid());
-    DRAKE_ASSERT(i < num_elements());
-    return elements_[i];
+  /* Implements FemModelBase::CalcResidual() by casting the FemStateBase
+   to its concrete type. */
+  void DoCalcResidual(const FemStateBase<T>& state,
+                      EigenPtr<VectorX<T>> residual) const final {
+    const FemState<Element>& concrete_state = cast_to_concrete_state(state);
+    CalcResidualForConcreteState(concrete_state, residual);
   }
 
-  Element& mutable_element(ElementIndex i) {
-    DRAKE_ASSERT(i.is_valid());
-    DRAKE_ASSERT(i < num_elements());
-    return elements_[i];
+  /* Implements FemModelBase::CalcTangentMatrix() by casting the
+   FemStateBase to its concrete type. */
+  void DoCalcTangentMatrix(const FemStateBase<T>& state,
+                           Eigen::SparseMatrix<T>* tangent_matrix) const final {
+    const FemState<Element>& concrete_state = cast_to_concrete_state(state);
+    CalcTangentMatrixForConcreteState(concrete_state, tangent_matrix);
   }
 
-  /** Moves the input `element` into the vector of elements held by `this`
-   %FemModel. */
-  void AddElement(Element&& element) {
-    elements_.emplace_back(std::move(element));
-  }
-
-  /** Alternative signature for adding a new element to `this` %FemModel.
-   Forwards the arguments `args` to the constructor of the Element and
-   potentially creates the new element in place. */
-  template <typename... Args>
-  void AddElement(Args&&... args) {
-    elements_.emplace_back(std::forward<Args>(args)...);
-  }
-
-  /** Adds per-vertex residuals that are explicitly specified at each vertex
-   instead of accumulated from elements. The default implementation is a no-op.
-   Derived classes must override this method if their residuals have
-   per-vertex contribution. */
-  virtual void AddExplicitResidual(EigenPtr<VectorX<T>> residual) const {}
-
-  void increment_num_nodes(int num_new_nodes) { num_nodes_ += num_new_nodes; }
-
- private:
   /* Builds the element tangent matrix for the element with index
    `element_index` by combining the stiffness matrix, damping matrix, and the
    mass matrix according to the given `weights`.
@@ -280,10 +264,70 @@ class FemModel {
            weights[2] * mass_matrix;
   }
 
+  /* Implements FemModelBase::DoUpdateStateFromChangeInUnknowns(). */
+  void DoUpdateStateFromChangeInUnknowns(const VectorX<T>& dz,
+                                         FemStateBase<T>* state) const final {
+    FemState<Element>& mutable_concrete_state =
+        cast_to_mutable_concrete_state(state);
+    state_updater_->UpdateStateFromChangeInUnknowns(dz,
+                                                    &mutable_concrete_state);
+  }
+
+  /* Implements FemModelBase::DoAdvanceOneTimeStep(). */
+  void DoAdvanceOneTimeStep(const FemStateBase<T>& prev_state,
+                            const VectorX<T>& highest_order_state,
+                            FemStateBase<T>* next_state) const final {
+    FemState<Element>& next_state_concrete =
+        cast_to_mutable_concrete_state(next_state);
+    const FemState<Element>& prev_state_concrete =
+        cast_to_concrete_state(prev_state);
+    state_updater_->AdvanceOneTimeStep(prev_state_concrete, highest_order_state,
+                                       &next_state_concrete);
+  }
+
+  /* Statically cast the given FemStateBase to the FemState compatible
+   with `this` FemModel.
+   @pre The given `abstract_state` is compatible with the `this` FemModel. */
+  const FemState<Element>& cast_to_concrete_state(
+      const FemStateBase<T>& abstract_state) const {
+    const auto& concrete_state =
+        static_cast<const FemState<Element>&>(abstract_state);
+    return concrete_state;
+  }
+
+  /* Mutable version of cast_to_concrete_state() that takes a pointer to the
+   abstract state.
+   @pre The given `abstract_state` is compatible with the `this` FemModel. */
+  FemState<Element>& cast_to_mutable_concrete_state(
+      FemStateBase<T>* abstract_state) const {
+    auto* concrete_state_ptr = static_cast<FemState<Element>*>(abstract_state);
+    return *concrete_state_ptr;
+  }
+
+  /* Implements FemModelBase::ThrowIfModelStateIncompatible(). */
+  void ThrowIfModelStateIncompatible(
+      const char* func, const FemStateBase<T>& abstract_state) const final {
+    const auto* concrete_state_ptr =
+        dynamic_cast<const FemState<Element>*>(&abstract_state);
+    if (concrete_state_ptr == nullptr) {
+      throw std::logic_error(
+          std::string(func) +
+          "(): The type of the FemState is incompatible with the type of the "
+          "FemModel.");
+    }
+    if (concrete_state_ptr->num_generalized_positions() != num_dofs()) {
+      throw std::logic_error(
+          fmt::format("{}(): The size of the FemState ({}) is incompatible "
+                      "with the size of the FemModel ({}).",
+                      func, concrete_state_ptr->num_generalized_positions(),
+                      num_dofs()));
+    }
+  }
+
   /* FemElements owned by this model. */
   std::vector<Element> elements_{};
-  /* The total number of nodes in the system. */
-  int num_nodes_{0};
+  /* The StateUpdater that updates the states for this model. */
+  std::unique_ptr<StateUpdater<FemState<Element>>> state_updater_;
 };
 }  // namespace fixed_fem
 }  // namespace multibody

--- a/multibody/fixed_fem/dev/fem_model_base.cc
+++ b/multibody/fixed_fem/dev/fem_model_base.cc
@@ -1,0 +1,72 @@
+#include "drake/multibody/fixed_fem/dev/fem_model_base.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+template <typename T>
+void FemModelBase<T>::CalcResidual(const FemStateBase<T>& state,
+                                   EigenPtr<VectorX<T>> residual) const {
+  DRAKE_DEMAND(residual != nullptr);
+  ThrowIfModelStateIncompatible(__func__, state);
+  DoCalcResidual(state, residual);
+  if (dirichlet_bc_ != nullptr) {
+    dirichlet_bc_->ApplyBcToResidual(residual);
+  }
+}
+
+template <typename T>
+void FemModelBase<T>::CalcTangentMatrix(
+    const FemStateBase<T>& state,
+    Eigen::SparseMatrix<T>* tangent_matrix) const {
+  DRAKE_DEMAND(tangent_matrix != nullptr);
+  DRAKE_DEMAND(tangent_matrix->rows() == num_dofs());
+  DRAKE_DEMAND(tangent_matrix->cols() == num_dofs());
+  ThrowIfModelStateIncompatible(__func__, state);
+  DoCalcTangentMatrix(state, tangent_matrix);
+  if (dirichlet_bc_ != nullptr) {
+    dirichlet_bc_->ApplyBcToTangentMatrix(tangent_matrix);
+  }
+}
+
+template <typename T>
+void FemModelBase<T>::SetTangentMatrixSparsityPattern(
+    Eigen::SparseMatrix<T>* tangent_matrix) const {
+  DRAKE_DEMAND(tangent_matrix != nullptr);
+  DoSetTangentMatrixSparsityPattern(tangent_matrix);
+}
+
+template <typename T>
+void FemModelBase<T>::UpdateStateFromChangeInUnknowns(
+    const VectorX<T>& dz, FemStateBase<T>* state) const {
+  DRAKE_DEMAND(state != nullptr);
+  DRAKE_DEMAND(dz.size() == state->num_generalized_positions());
+  ThrowIfModelStateIncompatible(__func__, *state);
+  DoUpdateStateFromChangeInUnknowns(dz, state);
+}
+
+template <typename T>
+void FemModelBase<T>::AdvanceOneTimeStep(const FemStateBase<T>& prev_state,
+                                         const VectorX<T>& highest_order_state,
+                                         FemStateBase<T>* next_state) const {
+  DRAKE_DEMAND(next_state != nullptr);
+  DRAKE_DEMAND(highest_order_state.size() ==
+               next_state->num_generalized_positions());
+  DRAKE_THROW_UNLESS(ode_order() > 0);
+  ThrowIfModelStateIncompatible(__func__, prev_state);
+  ThrowIfModelStateIncompatible(__func__, *next_state);
+  DoAdvanceOneTimeStep(prev_state, highest_order_state, next_state);
+}
+
+template <typename T>
+void FemModelBase<T>::ApplyBoundaryConditions(FemStateBase<T>* state) const {
+  DRAKE_DEMAND(state != nullptr);
+  ThrowIfModelStateIncompatible(__func__, *state);
+  if (dirichlet_bc_ != nullptr) {
+    state->ApplyBoundaryConditions(*dirichlet_bc_);
+  }
+}
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fixed_fem::FemModelBase);

--- a/multibody/fixed_fem/dev/fem_model_base.h
+++ b/multibody/fixed_fem/dev/fem_model_base.h
@@ -1,0 +1,199 @@
+#pragma once
+
+#include <array>
+#include <memory>
+#include <utility>
+
+#include <Eigen/Sparse>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/fixed_fem/dev/dirichlet_boundary_condition.h"
+#include "drake/multibody/fixed_fem/dev/fem_state_base.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+
+/** %FemModel calculates the components of the discretized FEM equations.
+ Suppose the PDE at hand is of the form
+
+     F(z, ∇z, ...) = 0.
+
+ where ... indicates possible higher derivatives that we aren't concerned with
+ here. In this PDE, z: Ω ⊂ Rᴰ → Rᵈ, is the unknown function being solved for
+ (see also UpdateStateFromChangeInUnknowns()). Here, Ω is the domain, D is the
+ dimension of the domain, and d is the solution dimension. For instance, if you
+ are solving for the temperature of a 3D object, then the domain is
+ three-dimensional (D = 3), while the solution, which is the temperature at a
+ point within the object, is one-dimensional (d = 1). After spatial and time
+ discretization, the PDE is reduced to a system of linear or nonlinear equations
+ of the form:
+
+     G(z₁, z₂, ..., zₙ) = 0,
+
+ where n is the number of nodes in the discretization and G is a function from
+ Rⁿᵈ to Rⁿᵈ. The linear or nonlinear equation in the system associated with
+ the node `a` has the form
+
+     Gₐ(z₁, z₂, ..., zₙ) = 0,
+
+ where Gₐ is a function from Rⁿᵈ → Rᵈ and a = 1, ..., n. The nodal values z₁,
+ z₂, ..., zₙ are solved for with a linear or nonlinear solver, and the solution
+ z is interpolated from these nodal values.
+
+ %FemModel calculates various components of the system of linear or nonlinear
+ equations that supports solving the system. For example, CalcResidual()
+ calculates the value of G evaluated at the current state and
+ CalcTangentMatrix() calculates ∇G at the current state.
+ @tparam_nonsymbolic_scalar T. */
+template <typename T>
+class FemModelBase {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FemModelBase);
+  FemModelBase() = default;
+  virtual ~FemModelBase() = default;
+
+  /** The order of the ODE problem associated with `this` %FemModel. */
+  virtual int ode_order() const = 0;
+
+  /** The number of nodes that are associated with `this` %FemModel. */
+  int num_nodes() const { return num_nodes_; }
+
+  /** The number of degrees of freedom in the model. */
+  virtual int num_dofs() const = 0;
+
+  /** The number of FemElements owned by `this` %FemModel. */
+  virtual int num_elements() const = 0;
+
+  /** Creates a new FemStateBase whose concrete FemState type is compatible
+   with the concrete FemModel type of `this` %FemModelBase. The new state's
+   number of generalized positions is equal to `num_dofs()`. The new state's
+   element data is constructed using the FemElements owned by this %FemModel. */
+  virtual std::unique_ptr<FemStateBase<T>> MakeFemStateBase() const = 0;
+
+  /** Calculates the residual at the given FemStateBase. Suppose the linear
+  or nonlinear system generated from the FEM discretization is G(z) = 0, then
+  the output `residual` is equal to the function G evaluated at the input
+  `state`.
+  @pre residual != nullptr.
+  @throw std::exception if the type of concrete FemState in `state` is not
+  compatible with the concrete FemModel in `this` model. */
+  void CalcResidual(const FemStateBase<T>& state,
+                    EigenPtr<VectorX<T>> residual) const;
+
+  /** Calculates the tangent matrix at the given FemStateBase. The ij-th
+   entry of the tangent matrix is the derivative of the i-th entry of the
+   residual (calculated by CalcResidual()) with respect to the j-th generalized
+   unknown zⱼ.
+   @param[in] state    The FemStateBase at which the residual is evaluated.
+   @param[out] tangent_matrix    The output tangent_matrix. Suppose the linear
+   or nonlinear system generated from the FEM discretization is G(z) = 0, then
+   `tangent_matrix` is equal to ∇G evaluated at the input `state`.
+   @pre tangent_matrix != nullptr.
+   @pre The size of the matrix behind `tangent_matrix` is `num_dofs()` *
+   `num_dofs()`.
+   @throw std::exception if the type of concrete FemState in `state` is not
+   compatible with the concrete FemModel in `this` model. */
+  void CalcTangentMatrix(const FemStateBase<T>& state,
+                         Eigen::SparseMatrix<T>* tangent_matrix) const;
+
+  /** Sets the sparsity pattern for the tangent matrix of this %FemModel.
+   @param[out] tangent_matrix    The tangent matrix of this %FemModel. Its size
+   and sparsity pattern will be set so that it will be ready to be passed into
+   CalcTangentMatrix().
+   @pre `tangent_matrix` must not be the null pointer. */
+  void SetTangentMatrixSparsityPattern(
+      Eigen::SparseMatrix<T>* tangent_matrix) const;
+
+  /** Updates the FemStateBase `state` given the change in the unknown variable
+   `dz`.
+   @pre state != nullptr.
+   @pre dz.size() == state->num_generalized_positions().
+   @throw std::exception if the type of concrete FemState for `state` is not
+   compatible with the concrete FemModel for `this` model. */
+  void UpdateStateFromChangeInUnknowns(const VectorX<T>& dz,
+                                       FemStateBase<T>* state) const;
+
+  /** For a dynamic FEM model, calculates the state at the next time step given
+   the state at the previous time step and the highest order state at the next
+   time step. If `this` %FemModel is static (ode_order() == 0), throw an
+   exception.
+   @param[in] prev_state The state at the previous time step.
+   @param[in] highest_order_state The highest order state at the next time step.
+   @param[out] next_state The state at the next time step.
+   @pre next_state != nullptr.
+   @pre next_state->num_generalized_positions() ==
+   prev_state.num_generalized_positions().
+   @pre next_state->num_generalized_positions() == highest_order_state.size().
+   @throw std::exception if the type of concrete FemState in `prev_state` or
+   `next_state` is not compatible with the concrete FemModel in `this` model.
+   @throw std::exception if ode_order() == 0. */
+  void AdvanceOneTimeStep(const FemStateBase<T>& prev_state,
+                          const VectorX<T>& highest_order_state,
+                          FemStateBase<T>* next_state) const;
+
+  /* Apply boundary condition set for this %FemModel to the input `state`. No-op
+   if no boundary condition is set.
+   @pre state != nullptr. */
+  void ApplyBoundaryConditions(FemStateBase<T>* state) const;
+
+  /** Takes ownership of the given Dirichlet boundary condition and apply it
+   when the model is evaluated. */
+  void SetDirichletBoundaryCondition(
+      std::unique_ptr<DirichletBoundaryCondition<T>> dirichlet_bc) {
+    dirichlet_bc_ = std::move(dirichlet_bc);
+  }
+
+  /** (Internal use only) Throws std::logic_error to report a mismatch between
+  the concrete types of `this` FemModelBase and the FemStateBase that was
+  passed to API method `func`. */
+  virtual void ThrowIfModelStateIncompatible(
+      const char* func, const FemStateBase<T>& state_base) const = 0;
+
+ protected:
+  /** Derived classes must override this method to provide an implementation
+   for the NVI CalcResidual(). The input `state` is guaranteed to be
+   compatible with `this` FEM model. */
+  virtual void DoCalcResidual(const FemStateBase<T>& state,
+                              EigenPtr<VectorX<T>> residual) const = 0;
+
+  /** Derived classes must override this method to provide an implementation for
+   the NVI CalcTangentMatrix(). The input `state` is guaranteed to be compatible
+   with `this` FEM model. */
+  virtual void DoCalcTangentMatrix(
+      const FemStateBase<T>& state,
+      Eigen::SparseMatrix<T>* tangent_matrix) const = 0;
+
+  /** Derived classes must override this method to provide an implementation for
+   the NVI SetTangentMatrixSparsityPattern(). */
+  virtual void DoSetTangentMatrixSparsityPattern(
+      Eigen::SparseMatrix<T>* tangent_matrix) const = 0;
+
+  /** Derived classes must override this method to provide an implementation for
+   the NVI UpdateStateFromChangeInUnknowns(). The input `state` is
+   guaranteed to be compatible with `this` FEM model. */
+  virtual void DoUpdateStateFromChangeInUnknowns(
+      const VectorX<T>& dz, FemStateBase<T>* state) const = 0;
+
+  /** Derived classes must override this method to provide an implementation for
+   the NVI AdvanceOneTimeStep(). The input `prev_state` and `next_state` are
+   guaranteed to be compatible with `this` FEM model. The size of `prev_state`,
+   `highest_order_state`, and `next_state` are guaranteed to be compatible. */
+  virtual void DoAdvanceOneTimeStep(const FemStateBase<T>& prev_state,
+                                    const VectorX<T>& highest_order_state,
+                                    FemStateBase<T>* next_state) const = 0;
+
+  void increment_num_nodes(int num_new_nodes) { num_nodes_ += num_new_nodes; }
+
+ private:
+  /* The total number of nodes in the system. */
+  int num_nodes_{0};
+  /* The Dirichlet boundary condition imposed on the model. */
+  std::unique_ptr<DirichletBoundaryCondition<T>> dirichlet_bc_;
+};
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fixed_fem::FemModelBase);

--- a/multibody/fixed_fem/dev/fem_solver.h
+++ b/multibody/fixed_fem/dev/fem_solver.h
@@ -6,80 +6,142 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/contact_solvers/sparse_linear_operator.h"
-#include "drake/multibody/fixed_fem/dev/dirichlet_boundary_condition.h"
 #include "drake/multibody/fixed_fem/dev/eigen_conjugate_gradient_solver.h"
-#include "drake/multibody/fixed_fem/dev/fem_model.h"
-#include "drake/multibody/fixed_fem/dev/linear_system_solver.h"
-#include "drake/multibody/fixed_fem/dev/state_updater.h"
+#include "drake/multibody/fixed_fem/dev/fem_model_base.h"
+#include "drake/multibody/fixed_fem/dev/fem_state_base.h"
 
 namespace drake {
 namespace multibody {
 namespace fixed_fem {
-// TODO(xuchenhan-tri): Remove the template by making the model and the state
-// abstract. See issue #14667.
+// TODO(xuchenhan-tri): Move the implementation of this class to a .cc file.
 /** %FemSolver solves for the state of a given FemModel at which residual of the
- FemModel is sufficiently close to zero. %FemSolver uses a simple Newton-Raphson
+ model is sufficiently close to zero. %FemSolver uses a simple Newton-Raphson
  solver to solve for the zero residual state. A common workflow looks like:
  ```
  // Creates a solver for a given FemModel and sets the LinearSystemSolver used
  // in the Newton-Raphson iterations.
- FemSolver<Model> solver(std::move(fem_model), std::move(linear_solver);
- // Optionally, sets the tolerance under which we deem the residual is
+ FemSolver solver(std::move(fem_model));
+ // Optionally, sets the tolerances under which we deem the residual is
  // effectively zero.
- solver.set_tolerance(kTolereance);
- // Optionally, sets the desired boundary condition.
- solver.SetDirichletBoundaryCondition(std::move(bc));
+ solver.set_absolute_tolerance(kAbsoluteTolereance);
+ solver.set_relative_tolerance(kRelativeTolereance);
  // Finally, provide an initial guess and solve for the zero residual state.
- solver.SolveWithInitialGuess(state_updater, &state);
- // Now the residual at `state` has 2-norm smaller than `kTolerance` if the
- // solver has converged.
+ solver.SolveWithInitialGuess(&state);
  ```
- @tparam Model    The type of model that `this` %FemSolver solves for. Must be
- derived from FemModel. */
-template <class Model>
+ @tparam_nonsymbolic_scalar T. */
+template <typename T>
 class FemSolver {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FemSolver);
-  static_assert(
-      std::is_base_of_v<FemModel<typename Model::ElementType>, Model>,
-      "The template parameter Model should be derived from FemModel. ");
-  using T = typename Model::T;
-  using State = FemState<typename Model::ElementType>;
 
-  // TODO(xuchenhan-tri): Consider moving LinearSystemSolver out of internal
-  // namespace and allow users to configure the linear solver.
+  // TODO(xuchenhan-tri): Consider allowing users to configure the linear
+  //  solver.
   /** Constructs a new FemSolver with the given FemModel and an Eigen Conjugate
-   Gradient solver as the linear solver. */
-  explicit FemSolver(std::unique_ptr<Model> model) : model_(std::move(model)) {
+   Gradient solver as the linear solver.
+   @pre model != nullptr. */
+  explicit FemSolver(std::unique_ptr<FemModelBase<T>> model)
+      : model_(std::move(model)) {
+    DRAKE_DEMAND(model_ != nullptr);
     Resize();
     linear_solver_ =
         std::make_unique<internal::EigenConjugateGradientSolver<T>>(&A_op_);
   }
 
-  /** Uses a Newton-Raphson solver to solve for the solution state at which the
-   residual of the FemModel is below the set tolerance (see set_tolerance()).
-   @param[in] state_updater    The StateUpdater used to update `state` in each
-   Newton-Raphson iteration.
-   @param[in, out] state    As input, `state` provides an initial guess of the
-   solution. As output, `state` reports the solution state at which the residual
-   of the FemModel is deemed sufficiently close to zero.
-   @pre state != nullptr. */
-  int SolveWithInitialGuess(const StateUpdater<State>& state_updater,
-                            State* state) const {
+  /** For dynamic models, advance the given FEM state from the previous time
+   step to the next time step. If the FEM model owned by `this` solver is
+   static, throw an exception.
+   @param[in] prev_state The state of the FEM model evaluated at the previous
+   time step.
+   @param[in, out] next_state As input, `next_state` provides an initial guess
+   for the state of the FEM model at the next time step. As output, `state`
+   stores the state of the FEM model evaluated at the next time step.
+   @pre next_state != nullptr.
+   @pre prev_state.num_generalized_positions() ==
+   next_state->num_generalized_positions().
+   @throw std::exception if the input `prev_state` or `next_state` is
+   incompatible with the FEM model associated with `this` %FemSolver, or if the
+   model is not dynamic (see is_dynamic()). */
+  void AdvanceOneTimeStep(const FemStateBase<T>& prev_state,
+                          FemStateBase<T>* next_state) const {
+    DRAKE_DEMAND(next_state != nullptr);
+    if (!is_model_dynamic()) {
+      throw std::logic_error(
+          fmt::format("{}() can only be called on a dynamic model!", __func__));
+    }
+    model_->ThrowIfModelStateIncompatible(__func__, prev_state);
+    model_->ThrowIfModelStateIncompatible(__func__, *next_state);
+    /* Grab the initial guess for the highest order state. */
+    const VectorX<T>& highest_order_state =
+        next_state->get_highest_order_state();
+    /* Since `highest_order_state` is only an initial guess, this only produces
+     an *initial guess* that is compatible with the previous time step. */
+    model_->AdvanceOneTimeStep(prev_state, highest_order_state, next_state);
+    SolveWithInitialGuess(next_state);
+  }
+
+  /** For static models, solve for the state at equilibrium given the initial
+   guess. If the FEM model owned by the solver is dynamic, throw an exception.
+   @pre next_state != nullptr.
+   @throw std::exception if the input `state` is incompatible with the FEM model
+   associated with `this` %FemSolver, or if the model is dynamic (see
+   is_dynamic()). */
+  void SolveStaticModelWithInitialGuess(FemStateBase<T>* state) const {
     DRAKE_DEMAND(state != nullptr);
-    DRAKE_DEMAND(model_ != nullptr);
-    DRAKE_DEMAND(linear_solver_ != nullptr);
+    if (is_model_dynamic()) {
+      throw std::logic_error(
+          fmt::format("{}() can only be called on a static model!", __func__));
+    }
+    model_->ThrowIfModelStateIncompatible(__func__, *state);
+    /* Throw if mode is *not* static. */
+    SolveWithInitialGuess(state);
+  }
+
+  /** Returns true if the FEM model owned by `this` solver has ODE order greater
+   than 0. Returns false otherwise. */
+  bool is_model_dynamic() const { return model_->ode_order() > 0; }
+
+  /** Returns the FemModel that this solver owns. */
+  const FemModelBase<T>& model() const { return *model_; }
+
+  /** Returns the mutable FemModel that this solver owns. */
+  FemModelBase<T>& mutable_model() { return *model_; }
+
+  /** Sets the relative tolerance, unitless. The Newton-Raphson iterations are
+   considered as converged if ‖dz‖ < `tolerance`⋅‖z‖ where z is the unknown
+   variable defined in FemModelBase. The default value is 1e-6. */
+  void set_relative_tolerance(const T& tolerance) {
+    relative_tolerance_ = tolerance;
+  }
+
+  /** Sets the absolute tolerance which has the same unit as the unknown
+   variable z defined in FemModelBase. For example, for dynamic elasticity, it
+   has the unit of m/s², and for static elasticity, it has the unit of m. The
+   Newton-Raphson iterations are considered as converged if the change in the
+   state is smaller than the absolute tolerance. The default value is 1e-6. */
+  void set_absolute_tolerance(const T& tolerance) {
+    absolute_tolerance_ = tolerance;
+  }
+
+  /** Sets the relative tolerance for the linear solver used in `this`
+   FemSolver if the linear solver is iterative. No-op if the linear solver is
+   direct. */
+  void set_linear_solve_tolerance(const T& tolerance) {
+    linear_solver_->set_tolerance(tolerance);
+  }
+
+ private:
+  /* Uses a Newton-Raphson solver to solve for the equilibrium state that
+   satisfies the tolerances. See set_relative_tolerance() and
+   set_absolute_tolerance(). The input `state` is non-null and is guaranteed to
+   be compatible with the model owned by `this` solver.
+   @param[in, out] state  As input, `state` provides an initial guess of
+   the solution. As output, `state` reports the equilibrium state. */
+  int SolveWithInitialGuess(FemStateBase<T>* state) const {
     /* Make sure the scratch quantities are of the correct size and apply BC if
      one is specified. */
     Resize();
-    if (dirichlet_bc_ != nullptr) {
-      dirichlet_bc_->ApplyBoundaryConditions(state);
-    }
-
+    model_->ApplyBoundaryConditions(state);
     model_->CalcResidual(*state, &b_);
-    if (dirichlet_bc_ != nullptr) {
-      dirichlet_bc_->ApplyBcToResidual(&b_);
-    }
     int iter = 0;
     /* Newton-Raphson iterations. We iterate until any of the following is true:
      1. The max number of allowed iterations is reached;
@@ -88,18 +150,12 @@ class FemSolver {
      3. The relative error (the norm of the change in the state divided by the
         norm of the state) is smaller than the unitless relative tolerance. */
     do {
-      model_->CalcTangentMatrix(*state, state_updater.weights(), &A_);
-      if (dirichlet_bc_ != nullptr) {
-        dirichlet_bc_->ApplyBcToTangentMatrix(&A_);
-      }
+      model_->CalcTangentMatrix(*state, &A_);
       linear_solver_->Compute();
       /* Solving for A * dz = -b. */
       linear_solver_->Solve(-b_, &dz_);
-      state_updater.UpdateState(dz_, state);
+      model_->UpdateStateFromChangeInUnknowns(dz_, state);
       model_->CalcResidual(*state, &b_);
-      if (dirichlet_bc_ != nullptr) {
-        dirichlet_bc_->ApplyBcToResidual(&b_);
-      }
       ++iter;
     } while (dz_.norm() >
                  std::max(relative_tolerance_ * state->HighestOrderStateNorm(),
@@ -116,50 +172,6 @@ class FemSolver {
     return iter;
   }
 
-  /** Returns the FemModel that this solver owns. */
-  const Model& model() const {
-    DRAKE_THROW_UNLESS(model_ != nullptr);
-    return *model_;
-  }
-
-  /** Returns the mutable FemModel that this solver owns. */
-  Model& mutable_model() {
-    DRAKE_THROW_UNLESS(model_ != nullptr);
-    return *model_;
-  }
-
-  /** Takes ownership of the given Dirichlet boundary condition and applies it
-   to the FemModel this solver owns. */
-  void SetDirichletBoundaryCondition(
-      std::unique_ptr<DirichletBoundaryCondition<State>> dirichlet_bc) {
-    dirichlet_bc_ = std::move(dirichlet_bc);
-  }
-
-  /** Sets the relative tolerance, unitless. The Newton-Raphson iterations are
-   considered as converged if the norm of the change in the state in one
-   iteration is smaller than the norm of the current state times the relative
-   tolerace. The default value is 1e-6. */
-  void set_relative_tolerance(const T& tolerance) {
-    relative_tolerance_ = tolerance;
-  }
-
-  /** Sets the absolute tolerance which has the same unit as the state with the
-   highest order of the model. For example, for dynamic elasticity, it has the
-   unit of m/s², and for static elasticity, it has the unit of m. The
-   Newton-Raphson iterations are considered as converged if the change in the
-   state is smaller than the absolute tolerance. The default value is 1e-6. */
-  void set_absolute_tolerance(const T& tolerance) {
-    absolute_tolerance_ = tolerance;
-  }
-
-  /** Sets the relative tolerance for the linear solver used in `this`
-   FemSolver if the linear solver is iterative. No-op if the linear solver is
-   direct. */
-  void set_linear_solve_tolerance(const T& tolerance) {
-    linear_solver_->set_tolerance(tolerance);
-  }
-
- private:
   /* Resize the scratch quantities to the size of the model. */
   void Resize() const {
     if (b_.size() != model_->num_dofs()) {
@@ -171,11 +183,9 @@ class FemSolver {
   }
 
   /* The FEM model being solved by `this` solver. */
-  std::unique_ptr<Model> model_;
+  std::unique_ptr<FemModelBase<T>> model_;
   /* The linear solver used to solve the FEM model. */
   std::unique_ptr<internal::LinearSystemSolver<T>> linear_solver_;
-  /* The Dirichlet boundary condition imposed on the model. */
-  std::unique_ptr<DirichletBoundaryCondition<State>> dirichlet_bc_;
   /* A scratch sparse matrix to store the tangent matrix of the model. */
   mutable Eigen::SparseMatrix<T> A_;
   /* The operator form of A_. */

--- a/multibody/fixed_fem/dev/fem_state_base.h
+++ b/multibody/fixed_fem/dev/fem_state_base.h
@@ -1,0 +1,40 @@
+#pragma once
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+
+template <typename T>
+class DirichletBoundaryCondition;
+
+/** An abstract base class for FemState that hides the templated Element type.
+ See FemState for more information. */
+template <typename T>
+class FemStateBase {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(FemStateBase);
+  FemStateBase() = default;
+  virtual ~FemStateBase() = default;
+
+  /** Calculates the norm of the state with the highest order. */
+  virtual T HighestOrderStateNorm() const = 0;
+
+  virtual int num_generalized_positions() const = 0;
+
+  // TODO(xuchenhan-tri): Consider whether this method should belong in
+  //  DirichletBoundaryCondition along with the methods that apply the BC to
+  //  residuals and tangent matrices.
+  /** Modifies `this` FEM state so that it complies with the given boundary
+   conditions.
+   @throw std::exception if the any of the indexes of the dofs under the
+   boundary condition specified by the given DirichletBoundaryCondition does
+   not exist in `this` FEM state`. */
+  virtual void ApplyBoundaryConditions(
+      const DirichletBoundaryCondition<T>& bc) = 0;
+
+  // TODO(xuchenhan-tri): Expose more public methods in FemState in
+  //  FemStateBase as needed.
+};
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/newmark_scheme.h
+++ b/multibody/fixed_fem/dev/newmark_scheme.h
@@ -48,8 +48,9 @@ class NewmarkScheme final : public StateUpdater<State> {
     return {beta_ * dt_ * dt_, gamma_ * dt_, 1.0};
   }
 
-  /* Implements StateUpdater::DoUpdateState(). */
-  void DoUpdateState(const VectorX<T>& dz, State* state) const final {
+  /* Implements StateUpdater::DoUpdateStateFromChangeInUnknowns(). */
+  void DoUpdateStateFromChangeInUnknowns(const VectorX<T>& dz,
+                                                  State* state) const final {
     const VectorX<T>& a = state->qddot();
     const VectorX<T>& v = state->qdot();
     const VectorX<T>& x = state->q();
@@ -59,11 +60,14 @@ class NewmarkScheme final : public StateUpdater<State> {
   }
 
   /* Implements StateUpdater::DoAdvanceOneTimeStep(). */
-  void DoAdvanceOneTimeStep(const State& prev_state, State* state) const final {
+  void DoAdvanceOneTimeStep(const State& prev_state,
+                            const VectorX<T>& highest_order_state,
+                            State* state) const final {
     const VectorX<T>& an = prev_state.qddot();
     const VectorX<T>& vn = prev_state.qdot();
     const VectorX<T>& xn = prev_state.q();
-    const VectorX<T>& a = state->qddot();
+    const VectorX<T>& a = highest_order_state;
+    state->SetQddot(a);
     state->SetQdot(vn + dt_ * (gamma_ * a + (1.0 - gamma_) * an));
     state->SetQ(xn + dt_ * vn + dt_ * dt_ * (beta_ * a + (0.5 - beta_) * an));
   }

--- a/multibody/fixed_fem/dev/state_updater.h
+++ b/multibody/fixed_fem/dev/state_updater.h
@@ -5,6 +5,8 @@
 namespace drake {
 namespace multibody {
 namespace fixed_fem {
+// TODO(xuchenhan-tri): Template this class on scalar type only so that
+//  FemModelBase can own it.
 /** %StateUpdater provides the interface to update FemState in NewtonSolver.
  In each Newton-Raphson iteration of the FEM solver, we are solving for an
  equation in the form of
@@ -63,14 +65,15 @@ class StateUpdater {
    0. */
   Vector3<T> weights() const { return do_get_weights(); }
 
-  /** Updates the FemState `state` given the change in the value of the key
-   variable `z`.
+  /** Updates the FemState `state` given the change in the unknown variable
+   `dz`.
    @pre state != nullptr.
    @pre dz.size() == state.num_generalized_positions(). */
-  void UpdateState(const VectorX<T>& dz, State* state) const {
+  void UpdateStateFromChangeInUnknowns(const VectorX<T>& dz,
+                                       State* state) const {
     DRAKE_DEMAND(state != nullptr);
     DRAKE_DEMAND(dz.size() == state->num_generalized_positions());
-    DoUpdateState(dz, state);
+    DoUpdateStateFromChangeInUnknowns(dz, state);
   }
 
   // TODO(xuchenhan-tri): Consider passing in more than one previous state when
@@ -87,9 +90,11 @@ class StateUpdater {
    input (and will not be modified) and `state->q()` and `state->qdot()` will be
    modified by numerically integrating in time.
    @pre state != nullptr. */
-  void AdvanceOneTimeStep(const State& prev_state, State* state) const {
+  void AdvanceOneTimeStep(const State& prev_state,
+                          const VectorX<T>& highest_order_state,
+                          State* state) const {
     DRAKE_DEMAND(state != nullptr);
-    DoAdvanceOneTimeStep(prev_state, state);
+    DoAdvanceOneTimeStep(prev_state, highest_order_state, state);
   }
 
  protected:
@@ -101,15 +106,18 @@ class StateUpdater {
   virtual Vector3<T> do_get_weights() const = 0;
 
   /** Derived classes must override this method to udpate the FemState `state`
-   given the key variable `dz` based on the time-stepping scheme of the derived
-   class. The `dz` provided here has compatible size with the number of
-   generalized positions in `state` and does not need to be checked again.  */
-  virtual void DoUpdateState(const VectorX<T>& dz, State* state) const = 0;
+   given the change in the unknown variable `dz` based on the time-stepping
+   scheme of the derived class. The `dz` provided here has compatible size with
+   the number of generalized positions in `state` and does not need to be
+   checked again.  */
+  virtual void DoUpdateStateFromChangeInUnknowns(const VectorX<T>& dz,
+                                                 State* state) const = 0;
 
   /** Derived classes templated on FemState whose ode_order() is greater than 0
    must override this method to advance a single time step according to the
    specific time stepping scheme. */
   virtual void DoAdvanceOneTimeStep(const State& prev_state,
+                                    const VectorX<T>& highest_order_state,
                                     State* state) const {
     if constexpr (State::ode_order() == 0) {
       throw std::logic_error(

--- a/multibody/fixed_fem/dev/static_elasticity_model.h
+++ b/multibody/fixed_fem/dev/static_elasticity_model.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include <array>
+#include <memory>
 #include <utility>
 
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/proximity/volume_mesh.h"
 #include "drake/multibody/fixed_fem/dev/elasticity_model.h"
+#include "drake/multibody/fixed_fem/dev/zeroth_order_state_updater.h"
 
 namespace drake {
 namespace multibody {
@@ -23,7 +25,10 @@ class StaticElasticityModel : public ElasticityModel<Element> {
   using T = typename Element::Traits::T;
   using ConstitutiveModel = typename Element::Traits::ConstitutiveModel;
 
-  StaticElasticityModel() = default;
+  StaticElasticityModel()
+      : ElasticityModel<Element>(
+            std::make_unique<ZerothOrderStateUpdater<FemState<Element>>>()) {}
+
   ~StaticElasticityModel() = default;
 
   /** Add tetrahedral StaticElasticityElements to the %StaticElasticityModel

--- a/multibody/fixed_fem/dev/test/dirichlet_boundary_condition_test.cc
+++ b/multibody/fixed_fem/dev/test/dirichlet_boundary_condition_test.cc
@@ -24,8 +24,8 @@ constexpr int kOdeOrder = Element::Traits::kOdeOrder;
 class DirichletBoundaryConditionTest : public ::testing::Test {
  protected:
   void SetUp() {
-    bc_.AddBoundaryCondition(DofIndex(0), Vector<double, kOdeOrder + 1>(3, 2));
-    bc_.AddBoundaryCondition(DofIndex(2), Vector<double, kOdeOrder + 1>(1, 0));
+    bc_.AddBoundaryCondition(DofIndex(0), Vector2<double>(3, 2));
+    bc_.AddBoundaryCondition(DofIndex(2), Vector2<double>(1, 0));
   }
 
   /* Makes an arbitrary residual vector with appropriate size. */
@@ -54,14 +54,14 @@ class DirichletBoundaryConditionTest : public ::testing::Test {
   }
 
   /* The DirichletBoundaryCondition under test. */
-  DirichletBoundaryCondition<State> bc_;
+  DirichletBoundaryCondition<double> bc_{kOdeOrder};
 };
 
 /* Tests that the DirichletBoundaryCondition under test successfully modifies
  a given state. */
 TEST_F(DirichletBoundaryConditionTest, ApplyBcToState) {
   State s = MakeState();
-  bc_.ApplyBoundaryConditions(&s);
+  s.ApplyBoundaryConditions(bc_);
   EXPECT_TRUE(CompareMatrices(s.q(), Vector<double, kNumDofs>{3, 0.2, 1, 0.4}));
   EXPECT_TRUE(
       CompareMatrices(s.qdot(), Vector<double, kNumDofs>{2, 0.6, 0, 0.8}));
@@ -100,7 +100,7 @@ TEST_F(DirichletBoundaryConditionTest, OutOfBound) {
   bc_.AddBoundaryCondition(DofIndex(4), Vector<double, kOdeOrder + 1>(3, 4));
   State state = MakeState();
   DRAKE_EXPECT_THROWS_MESSAGE(
-  bc_.ApplyBoundaryConditions(&state), std::exception,
+    state.ApplyBoundaryConditions(bc_), std::exception,
           "An index of the dirichlet boundary condition is out of the range.");
   VectorXd b = MakeResidual();
   DRAKE_EXPECT_THROWS_MESSAGE(

--- a/multibody/fixed_fem/dev/test/dynamic_elasticity_model_test.cc
+++ b/multibody/fixed_fem/dev/test/dynamic_elasticity_model_test.cc
@@ -9,7 +9,6 @@
 #include "drake/multibody/fixed_fem/dev/fem_state.h"
 #include "drake/multibody/fixed_fem/dev/linear_constitutive_model.h"
 #include "drake/multibody/fixed_fem/dev/linear_simplex_element.h"
-#include "drake/multibody/fixed_fem/dev/newmark_scheme.h"
 #include "drake/multibody/fixed_fem/dev/simplex_gaussian_quadrature.h"
 
 namespace drake {
@@ -40,8 +39,6 @@ constexpr int kNumDofs = kNumCubeVertices * kSolutionDimension;
 constexpr int kNumElements = 6;
 /* Parameters for Newmark scheme. */
 const double kDt = 1e-3;
-const double kGamma = 0.2;
-const double kBeta = 0.3;
 /* Parameters for the damping model. */
 const double kMassDamping = 0.01;
 const double kStiffnessDamping = 0.02;
@@ -52,7 +49,7 @@ class DynamicElasticityModelTest : public ::testing::Test {
   static geometry::VolumeMesh<T> MakeBoxTetMesh() {
     const double length = 0.1;
     geometry::Box box(length, length, length);
-    geometry::VolumeMesh mesh =
+    geometry::VolumeMesh<T> mesh =
         geometry::internal::MakeBoxVolumeMesh<T>(box, length);
     DRAKE_DEMAND(mesh.num_elements() == 6);
     return mesh;
@@ -90,16 +87,15 @@ class DynamicElasticityModelTest : public ::testing::Test {
         math::autoDiffToValueMatrix(deformed_state.qddot()) + perturbation();
     Vector<T, kNumDofs> perturbed_qddot_autodiff;
     math::initializeAutoDiff(perturbed_qddot, perturbed_qddot_autodiff);
-    deformed_state.SetQddot(perturbed_qddot_autodiff);
-    /* It's important to set up the `deformed_state` with `state_updater_` so
-     that the derivatives such as dq/dqddot are set up. */
-    state_updater_.AdvanceOneTimeStep(reference_state, &deformed_state);
+    /* It's important to set up the `deformed_state` with AdvanceOneTimeStep()
+     so that the derivatives such as dq/dqddot are set up. */
+    model_.AdvanceOneTimeStep(reference_state, perturbed_qddot_autodiff,
+                              &deformed_state);
     return deformed_state;
   }
 
   /* The model under test. */
-  DynamicElasticityModel<ElementType> model_;
-  const NewmarkScheme<FemState<ElementType>> state_updater_{kDt, kGamma, kBeta};
+  DynamicElasticityModel<ElementType> model_{kDt};
 };
 
 /* Tests the mesh has been successfully converted to elements. */
@@ -118,7 +114,7 @@ TEST_F(DynamicElasticityModelTest, TangentMatrixIsResidualDerivative) {
 
   Eigen::SparseMatrix<T> tangent_matrix;
   model_.SetTangentMatrixSparsityPattern(&tangent_matrix);
-  model_.CalcTangentMatrix(state, state_updater_.weights(), &tangent_matrix);
+  model_.CalcTangentMatrix(state, &tangent_matrix);
 
   /* In the discretization of the unit cube by 6 tetrahedra, there are 19 edges,
    and 8 nodes, creating 19*2 + 8 blocks of 3-by-3 nonzero entries. Hence the

--- a/multibody/fixed_fem/dev/test/newmark_scheme_test.cc
+++ b/multibody/fixed_fem/dev/test/newmark_scheme_test.cc
@@ -37,13 +37,13 @@ TEST_F(NewmarkSchemeTest, Weights) {
       Vector3<double>(kBeta * kDt * kDt, kGamma * kDt, 1.0), 0));
 }
 
-TEST_F(NewmarkSchemeTest, UpdateState) {
+TEST_F(NewmarkSchemeTest, UpdateStateFromChangeInUnknowns) {
   const Vector4<double> q = MakeQ();
   const Vector4<double> qdot = MakeQdot();
   const Vector4<double> qddot = MakeQddot();
   FemState<DummyElement<2>> state(q, qdot, qddot);
   const Vector4<double> dqddot(1.234, 4.567, 7.890, 0.123);
-  newmark_scheme_.UpdateState(dqddot, &state);
+  newmark_scheme_.UpdateStateFromChangeInUnknowns(dqddot, &state);
   EXPECT_TRUE(CompareMatrices(state.qddot(), qddot + dqddot, 0));
   EXPECT_TRUE(
       CompareMatrices(state.qdot(), qdot + dqddot * kDt * kGamma, kTol));
@@ -60,8 +60,7 @@ TEST_F(NewmarkSchemeTest, AdvanceOneTimeStep) {
   FemState<DummyElement<2>> state_np1(state_0);
   const int kTimeSteps = 10;
   for (int i = 0; i < kTimeSteps; ++i) {
-    state_np1.SetQddot(state_n.qddot());
-    newmark_scheme_.AdvanceOneTimeStep(state_n, &state_np1);
+    newmark_scheme_.AdvanceOneTimeStep(state_n, qddot, &state_np1);
     state_n = state_np1;
   }
   const double total_time = kDt * kTimeSteps;

--- a/multibody/fixed_fem/dev/test/static_elasticity_model_test.cc
+++ b/multibody/fixed_fem/dev/test/static_elasticity_model_test.cc
@@ -10,7 +10,6 @@
 #include "drake/multibody/fixed_fem/dev/linear_simplex_element.h"
 #include "drake/multibody/fixed_fem/dev/simplex_gaussian_quadrature.h"
 #include "drake/multibody/fixed_fem/dev/static_elasticity_element.h"
-#include "drake/multibody/fixed_fem/dev/zeroth_order_state_updater.h"
 
 namespace drake {
 namespace multibody {
@@ -45,7 +44,7 @@ class StaticElasticityModelTest : public ::testing::Test {
   static geometry::VolumeMesh<T> MakeBoxTetMesh() {
     const double length = 0.1;
     geometry::Box box(length, length, length);
-    geometry::VolumeMesh mesh =
+    geometry::VolumeMesh<T> mesh =
         geometry::internal::MakeBoxVolumeMesh<T>(box, length);
     return mesh;
   }
@@ -113,8 +112,7 @@ TEST_F(StaticElasticityModelTest, TangentMatrixIsResidualDerivative) {
 
   Eigen::SparseMatrix<T> tangent_matrix;
   model_.SetTangentMatrixSparsityPattern(&tangent_matrix);
-  ZerothOrderStateUpdater<FemState<ElementType>> state_updater;
-  model_.CalcTangentMatrix(state, state_updater.weights(), &tangent_matrix);
+  model_.CalcTangentMatrix(state, &tangent_matrix);
 
   /* In the discretization of the unit cube by 6 tetrahedra, there are 19 edges,
    and 8 nodes, creating 19*2 + 8 blocks of 3-by-3 nonzero entries. Hence the

--- a/multibody/fixed_fem/dev/test/zeroth_order_state_updater_test.cc
+++ b/multibody/fixed_fem/dev/test/zeroth_order_state_updater_test.cc
@@ -21,21 +21,21 @@ TEST_F(ZerothOrderStateUpdaterTest, Weights) {
       CompareMatrices(state_updater.weights(), Vector3<double>(1, 0, 0), 0));
 }
 
-TEST_F(ZerothOrderStateUpdaterTest, UpdateState) {
+TEST_F(ZerothOrderStateUpdaterTest, UpdateStateFromChangeInUnknowns) {
   const VectorX<double> q = Vector4<double>(1.23, 2.34, 3.45, 4.56);
   const VectorX<double> dq = Vector4<double>(0.23, 0.34, 0.45, 0.56);
   FemState<DummyElement<0>> state(q);
-  state_updater.UpdateState(dq, &state);
+  state_updater.UpdateStateFromChangeInUnknowns(dq, &state);
   EXPECT_TRUE(CompareMatrices(state.q(), q + dq, 0));
 }
 
-TEST_F(ZerothOrderStateUpdaterTest, IntegrateTime) {
+TEST_F(ZerothOrderStateUpdaterTest, AdvanceOneTimeStep) {
   const VectorX<double> q = Vector4<double>(1.23, 2.34, 3.45, 4.56);
   FemState<DummyElement<0>> prev_state(q);
   FemState<DummyElement<0>> new_state(prev_state);
   DRAKE_EXPECT_THROWS_MESSAGE(
-      state_updater.AdvanceOneTimeStep(prev_state, &new_state), std::exception,
-      "There is no notion of time in a zeroth order ODE.");
+      state_updater.AdvanceOneTimeStep(prev_state, q, &new_state),
+      std::exception, "There is no notion of time in a zeroth order ODE.");
 }
 }  // namespace
 }  // namespace test

--- a/multibody/fixed_fem/dev/zeroth_order_state_updater.h
+++ b/multibody/fixed_fem/dev/zeroth_order_state_updater.h
@@ -25,8 +25,9 @@ class ZerothOrderStateUpdater final : public StateUpdater<State> {
   /* Implements StateUpdater::weights(). */
   Vector3<T> do_get_weights() const final { return {1, 0, 0}; }
 
-  /* Implements StateUpdater::DoUpdateState(). */
-  void DoUpdateState(const VectorX<T>& dz, State* state) const final {
+  /* Implements StateUpdater::DoUpdateStateFromChangeInUnknowns(). */
+  void DoUpdateStateFromChangeInUnknowns(const VectorX<T>& dz,
+                                                  State* state) const final {
     state->SetQ(state->q() + dz);
   }
 };


### PR DESCRIPTION
- Create AbstractFemModel and AbstractFemState that are only templated
on the scalar type but not the FemElement type that concrete FemModel
and FemState inherit from.
- Remove the template on FemSolver.
- Let FemModel own the StateUpdater and DirichletBoundaryCondition it
uses.
- Fix a few minor bugs in documentation of FemSolver.
- Fixes #14667.
- Fixes #14668.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14681)
<!-- Reviewable:end -->
