### PR TITLE
jekyll: Move release_notes index into the collection

### DIFF
--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -99,7 +99,6 @@ filegroup(
     srcs = [
         "_config.yml",
         "index.md",
-        "release_notes.md",
     ] + glob([
         "_includes/*.html",
         "_includes/*.md",

--- a/doc/README.txt
+++ b/doc/README.txt
@@ -15,8 +15,7 @@ doc/
 ├── _pages/ - Jekyll collection: Add'l root-level pages. Can render Markdown.
 ├── _release-notes/ - Jekyll collection: Index of versioned releases.
 ├── third_party/ - Third party assets.
-├── index.md - Home page.
-└── release_notes.md - Index for release notes.
+└── index.md - Home page.
 ```
 
 <!--

--- a/doc/_layouts/release.html
+++ b/doc/_layouts/release.html
@@ -13,7 +13,7 @@ layout: default
   <section class="padding">
     <div class="contain">
       <article class="markdown-body">
-        <a href="{{ '/release_notes.html' | relative_url }}">Back to Release Notes</a>
+        <a href="{{ '/release_notes/release_notes.html' | relative_url }}">Back to Release Notes</a>
         <hr/>
         {{ page.content }}
       </article>

--- a/doc/_pages/installation.md
+++ b/doc/_pages/installation.md
@@ -19,4 +19,4 @@ You can choose to download a pre-compiled version of Drake, or to build it from 
 * [Binary installation (macOS, Ubuntu)](/from_binary.html)  
 * [Source installation (macOS, Ubuntu)](/from_source.html)  
 * [Using the Drake Docker Images From Docker Hub](/docker.html)  
-* [Release Notes](/release_notes.html)  
+* [Release Notes](/release_notes/release_notes.html)

--- a/doc/_release-notes/release_notes.md
+++ b/doc/_release-notes/release_notes.md
@@ -20,7 +20,9 @@ title: Release Notes
 Latest releases are first:
 
 {% for note in site.release-notes reversed %}
+{% if note.title != "Release Notes" %}
 * <a href="{{ note.url }}.html">{{ note.title }}</a>
+{% endif %}
 {% endfor %}
 
 </div>


### PR DESCRIPTION
This matches the index URL in Jekyll flavor to what the Sphinx flavor had, to avoid breaking users' bookmarks.

Relates #14577.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14683)
<!-- Reviewable:end -->
