### PR TITLE
jekyll: Misc fixes

### DIFF
--- a/doc/_pages/clion.md
+++ b/doc/_pages/clion.md
@@ -134,7 +134,7 @@ may be slightly different in previous versions.
 
 1. Open the Settings dialog (``File`` > ``Settings``) or ``Alt+Ctrl+S``.
 2. Navigate to ``Tools`` > ``External Tools``.
-3. Click the :raw-html:`<font size="5" color="green">+</font>` sign to add a new
+3. Click the {::nomarkdown}<font color="green">+</font>{:/} sign to add a new
    tool.
 4. Set the appropriate fields in the ``Edit Tool``. See the following tools for
    details.

--- a/doc/_pages/code_style_guide.md
+++ b/doc/_pages/code_style_guide.md
@@ -70,7 +70,7 @@ TODO(eric.cousineau): Move these clarifications and exceptions to styleguide
   syntax. Rationale: exceptions raised in lazy formatting get printed to
   ``stderr``, but are otherwise ignored, and thus may escape notice.
 * Executable Python files should be limited to *only* scripts which are not run
-  via Bazel-generated Python proxy scripts. If a script
+  via Bazel-generated Python proxy scripts [1]. If a script
   qualifies, use the following "shebang" line:
 
 ```
@@ -80,7 +80,7 @@ TODO(eric.cousineau): Move these clarifications and exceptions to styleguide
   executable. This is also recommended by
   [PEP 394](https://www.python.org/dev/peps/pep-0394/).
 
-Generally, this means scripts that run via ``bazel run``,
+[1] Generally, this means scripts that run via ``bazel run``,
    ``bazel test``, or ``./bazel-bin/...``.
 
 # Java Style

--- a/doc/_pages/from_binary.md
+++ b/doc/_pages/from_binary.md
@@ -42,4 +42,4 @@ following [these instructions](/jenkins.html#building-binary-packages-on-demand)
 # Historical Note
 
 Older releases were built around substantial MATLAB support, and are
-described on [release notes page](/release_notes/older_releases.html#older-releases).
+described on [release notes page](/release_notes/older_releases.html).

--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -57,4 +57,4 @@ full details at:
 # Historical Note
 
 Older releases were built around substantial MATLAB support, and are
-described on [this release notes page](/older_releases.html).
+described on [this release notes page](/release_notes/older_releases.html).


### PR DESCRIPTION
Fix HTML escaping for green CLion +.
Fix links to older_releases.
Add style guide footnote marker.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14684)
<!-- Reviewable:end -->
