### PR TITLE
jekyll: Add landing page links to binder and nbviewer

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -99,6 +99,13 @@ notebooks online with no need for local installation. You can use Binder to
 preview and execute the notebooks (but startup time may be long), or you can
 use nbviewer to only preview the notebook (where startup time is fast):
 
+<a target="_doc" href="https://mybinder.org/v2/gh/RobotLocomotion/drake/nightly-release-binder?filepath=tutorials">
+  <img src="https://mybinder.org/badge_logo.svg"/>
+</a>
+<a target="_doc" href="https://nbviewer.jupyter.org/github/RobotLocomotion/drake/blob/nightly-release/tutorials/">
+  <img src="https://img.shields.io/badge/view%20on-nbviewer-brightgreen.svg"/>
+</a>
+
 If you are browsing on nbviewer, you may click on the Binder button at the
 top-right of the page.
 


### PR DESCRIPTION
On Drake's [current website](https://drake.mit.edu/#tutorials), the tutorials block looks like this:

<img src="https://user-images.githubusercontent.com/17596505/108542259-6204a880-7298-11eb-9a6f-fa7a45c28617.png" width="300"/>

On the contractor's [refresh of the website](https://drake.sky.a2hosted.com/#Tutorials), the tutorials block looks like this:

<img src="https://user-images.githubusercontent.com/17596505/108542619-d17a9800-7298-11eb-81c2-240a82507c40.png" width="300"/>

That is, the buttons and links to the tutorial previews have gone missing.

This PR adds back the buttons.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14685)
<!-- Reviewable:end -->
