### PR TITLE
jekyll: Ports recent .rst changes to Markdown

### DIFF
--- a/doc/_pages/getting_help.md
+++ b/doc/_pages/getting_help.md
@@ -54,6 +54,16 @@ When reporting an issue, please consider providing the following information
     * Download URL
     * Contents of ``drake/share/doc/drake/VERSION.txt``
     * Building downstream project ([drake_cmake_installed](https://github.com/RobotLocomotion/drake-external-examples/tree/master/drake_cmake_installed))
+* If using Binder or Google Colaboratory:
+    * A version of your notebook that we can access. Please check this by
+      re-visiting your URL in a private browsing window. (You can add
+      notebooks to public GitHub Gists.)
+    * The version of ``pydrake`` you are using. To obtain the version
+      information it, please add the following code to a cell and execute it:
+
+          !cat /opt/drake/share/doc/drake/VERSION.TXT
+
+      The output should look something like ``YYYYMMDDHHMMSS <git-sha>``.
 
 # Older Sources
 

--- a/doc/_pages/release_playbook.md
+++ b/doc/_pages/release_playbook.md
@@ -35,7 +35,7 @@ Begin this process around 1 week prior to the intended release date.
    enabled (the checkbox is checked).
 5. For release notes, on an ongoing basis, add recent commit messages to the
    release notes draft using the ``tools/release_engineering/relnotes`` tooling.
-   (Instructions for using ``relnotes`` are found atop its [source code](https://github.com/RobotLocomotion/drake/blob/master/tools/release_engineering/relnotes.py>))
+   (Instructions can be found atop its source code: [``relnotes.py``](https://github.com/RobotLocomotion/drake/blob/master/tools/release_engineering/relnotes.py))
     1. On the first run, use ``--action=create`` to bootstrap the file.
        * The output is draft release notes in ``doc/release_notes/v0.N.0.rst``.
        * Be sure to add the new file to the list in ``doc/release_notes.rst``.
@@ -62,8 +62,8 @@ the main body of the document:
 * Many commit messages can be cut down to their summary strings and used as-is.
 * Expand all acronyms (eg, MBP -> MultibodyPlant, SG -> SceneGraph).
 * Commits can be omitted if they only affect tests or non-installed examples. {% comment %}TODO(jwnimmer-tri) Explain how to check if something is installed.{% endcomment %}
-* In general you should mention removed classes and methods using their exact
-  name (for easier searching).
+* In general you should mention new bindings and deprecated/removed classes and
+  methods using their exact name (for easier searching).
    * In the pydrake and deprecation sections in fact you can just put the
     fully-qualified name as the whole line item; the meaning is clear from
     context.
@@ -87,6 +87,10 @@ the main body of the document:
   fully supported.  Be sure to take note of which these are, or ask on
   `#platform_review` slack.
 
+* Keep all bullet points to one line.
+  * Using hard linebreaks to stay under 80 columns makes the bullet lists hard
+    to maintain over time.
+
 ## Cutting the release
 
 9. Find a plausible build to use
@@ -94,53 +98,35 @@ the main body of the document:
    2. Make sure [https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/)
       has nothing still running (modulo the ``*-coverage`` builds, which we can
       ignore)
-   3. Take
-      [https://drake-jenkins.csail.mit.edu/view/Packaging/job/mac-catalina-unprovisioned-clang-bazel-nightly-snopt-packaging/](https://drake-jenkins.csail.mit.edu/view/Packaging/job/mac-catalina-unprovisioned-clang-bazel-nightly-snopt-packaging/)
-      and
-      [https://drake-jenkins.csail.mit.edu/view/Packaging/job/linux-bionic-unprovisioned-gcc-bazel-nightly-snopt-packaging/](https://drake-jenkins.csail.mit.edu/view/Packaging/job/linux-bionic-unprovisioned-gcc-bazel-nightly-snopt-packaging/)
-      and
-      [https://drake-jenkins.csail.mit.edu/view/Packaging/job/linux-focal-unprovisioned-gcc-bazel-nightly-snopt-packaging/](https://drake-jenkins.csail.mit.edu/view/Packaging/job/linux-focal-unprovisioned-gcc-bazel-nightly-snopt-packaging/)
-      builds for that night and make sure they share the same git sha (``HEAD``
-      from the moment they were launched).  Note it.
-         * If the git sha for all three does not match, wait and try again
-           tomorrow night.
+   3. Open the latest builds from the following builds:
+      1. https://drake-jenkins.csail.mit.edu/view/Packaging/job/mac-catalina-unprovisioned-clang-bazel-nightly-snopt-packaging/
+      2. https://drake-jenkins.csail.mit.edu/view/Packaging/job/linux-bionic-unprovisioned-gcc-bazel-nightly-snopt-packaging/
+      3. https://drake-jenkins.csail.mit.edu/view/Packaging/job/linux-focal-unprovisioned-gcc-bazel-nightly-snopt-packaging/
    4. Check the logs for those packaging builds and find the URLs they posted
-      to.  It will be ``YYYYMMDD`` with today's date (they kick off after
-      midnight).  Note it.
-        * N.B. The packaging script uploads the file twice, with two different
-          names.  One is ``YYYYMMDD`` and one is ``latest``.  We will use the
-          ``YYYYMMDD`` one.
+      to (open the latest build, go to "View as plain text", and search for
+      ``drake/nightly/drake-20``), and find the date.  It will be ``YYYYMMDD``
+      with today's date (they kick off after midnight).  All of the builds
+      should have the same date. If not, wait until the following night.
+   5. Use the
+      ``tools/release_engineering/download_release_candidate`` tool to download
+      and verify that all the release candidates are built from the same
+      commit.  (It's usage
+      instructions are atop its source code:
+      [download_release_candidate.py](https://github.com/RobotLocomotion/drake/blob/master/tools/release_engineering/download_release_candidate.py).)
+
 10. Update the release notes to have the ``YYYYMMDD`` we choose, and to make
     sure that the nightly build git sha from the prior step matches the
     ``newest_commit`` whose changes are enumerated in the notes.
-11. Prepare the binaries
-    1. Make a local folder, maybe ``$HOME/tmp/v0.N.0``
-    2. Fetch all the things (
-       [https://drake-jenkins.csail.mit.edu/view/Packaging/job/mac-catalina-unprovisioned-clang-bazel-nightly-snopt-packaging/](https://drake-jenkins.csail.mit.edu/view/Packaging/job/mac-catalina-unprovisioned-clang-bazel-nightly-snopt-packaging/)
-       and
-       [https://drake-jenkins.csail.mit.edu/view/Packaging/job/linux-bionic-unprovisioned-gcc-bazel-nightly-snopt-packaging/](https://drake-jenkins.csail.mit.edu/view/Packaging/job/linux-bionic-unprovisioned-gcc-bazel-nightly-snopt-packaging/)
-       and
-       [https://drake-jenkins.csail.mit.edu/view/Packaging/job/linux-focal-unprovisioned-gcc-bazel-nightly-snopt-packaging/)](https://drake-jenkins.csail.mit.edu/view/Packaging/job/linux-focal-unprovisioned-gcc-bazel-nightly-snopt-packaging/)
-       * ``wget https://drake-packages.csail.mit.edu/drake/nightly/drake-YYYYMMDD-bionic.tar.gz``
-       * ``wget https://drake-packages.csail.mit.edu/drake/nightly/drake-YYYYMMDD-bionic.tar.gz.sha512``
-       * ``wget https://drake-packages.csail.mit.edu/drake/nightly/drake-YYYYMMDD-focal.tar.gz``
-       * ``wget https://drake-packages.csail.mit.edu/drake/nightly/drake-YYYYMMDD-focal.tar.gz.sha512``
-       * ``wget https://drake-packages.csail.mit.edu/drake/nightly/drake-YYYYMMDD-mac.tar.gz``
-       * ``wget https://drake-packages.csail.mit.edu/drake/nightly/drake-YYYYMMDD-mac.tar.gz.sha512``
-   3. Checksums
-       * ``sha512sum -c *.sha512``
-       * ``sha256sum drake-YYYYMMDD-bionic.tar.gz >  drake-YYYYMMDD-bionic.tar.gz.sha256``
-       * ``sha256sum drake-YYYYMMDD-focal.tar.gz >  drake-YYYYMMDD-focal.tar.gz.sha256``
-       * ``sha256sum drake-YYYYMMDD-mac.tar.gz >  drake-YYYYMMDD-mac.tar.gz.sha256``
-       * ``sha256sum -c *.sha256``
-12. Merge the release notes PR
+11. Merge the release notes PR
    1. After merge, go to [https://drake-jenkins.csail.mit.edu/view/Documentation/job/linux-bionic-gcc-bazel-nightly-documentation/](https://drake-jenkins.csail.mit.edu/view/Documentation/job/linux-bionic-gcc-bazel-nightly-documentation/) and push "Build now".
       * If you don't have "Build now" click "Log in" first in upper right.
-13. Open [https://github.com/RobotLocomotion/drake/releases](https://github.com/RobotLocomotion/drake/releases) and choose "Draft a
+12. Open [https://github.com/RobotLocomotion/drake/releases](https://github.com/RobotLocomotion/drake/releases) and choose "Draft a
     new release".  Note that this page does has neither history nor undo.  Be
     slow and careful!
     1. Tag version is: v0.N.0
     2. Target is: [the git sha from above]
+      *  You should select the commit from Target > Recent Commits. The search
+         via commit does not work if you don't use the correct length.
     3. Release title is: Drake v0.N.0
     4. The body of the release should be forked from the prior release (open the
        prior release's web page and click "Edit" to get the markdown), with
@@ -150,10 +136,12 @@ the main body of the document:
        them.", drag and drop the 9 release binary artifacts from above (the 3
        tarballs, and their 6 checksums)
     6. Choose "Save draft" and take a deep breath.
-14. Once the documentation build finishes, release!
+13. Once the documentation build finishes, release!
     1. Check that the link to drake.mit.edu docs from the GitHub release draft
        page actually works.
     2. Click "Publish release"
-    3. Notify @jamiesnape to manually tag docker images and upload the releases
-       to S3.
-    4. Party on, Wayne.
+    3. Notify @jamiesnape via a GitHub comment to manually tag docker images
+       and upload the releases to S3. Be sure to provide him with the binary
+       date, commit SHA, and release tag in the same ping.
+    4. Announce on Drake Slack, ``#general``.
+    5. Party on, Wayne.

--- a/doc/_release-notes/v0.27.0.md
+++ b/doc/_release-notes/v0.27.0.md
@@ -1,0 +1,206 @@
+---
+title: Drake v0.27.0
+---
+
+# Announcements
+
+* macOS Big Sur 11.x is now supported on Intel Macs ([#14632][_#14632])
+
+# Breaking changes since v0.26.0
+
+* DrakeVisualizer class is now templatized ([#14569][_#14569])
+    * We offer a C++ alias ``drake::geometry::DrakeVisualizerd`` (i.e., with a
+      ``d`` suffix) that matches the current uses of the ``double`` system.
+    * Python users do not need to make any changes. The new template
+      argument will not disturb pydrake.
+    * Certain compilers may not be able to infer the template argument (e.g.,
+      when referring to static methods).
+* ``end_effector_teleop_sliders`` is no longer supported on macOS ([#14632][_#14632])
+
+# Changes since v0.26.0
+
+## Dynamical Systems
+
+<!--- relnotes for systems go here --->
+
+New features
+
+* None
+
+Fixes
+
+* Promote some ASSERT to DEMAND in ``systems/primitives`` ([#14615][_#14615])
+
+## Mathematical Program
+
+<!--- relnotes for solvers go here --->
+
+New features
+
+* Allow passing time limit to OSQP via SolverOptions ([#14625][_#14625])
+
+Fixes
+
+* None
+
+## Multibody Dynamics
+
+<!--- relnotes for geometry,multibody go here --->
+
+
+New features
+
+* Implement discrete hydroelastic model approximation with TAMSI ([#14630][_#14630])
+* DrakeVisualizer class is now templatized ([#14569][_#14569])
+
+Fixes
+
+* Speed up hydroelastic visualization for Drake Visualizer ([#14622][_#14622])
+* Explicitly disable HalfSpace-HalfSpace point-pair penetration queries for all scalar types ([#14639][_#14639])
+
+## Tutorials and examples
+
+<!--- relnotes for examples,tutorials go here --->
+
+
+* Provide a complete end-to-end demonstration, using the stochastic schema mechanisms, of how Monte Carlo scenarios can be used to optimize the parameters for a controller ([#14541][_#14541])
+* Fix ``acrobot`` Spong controller LCM communication to actually work ([#14525][_#14525])
+* ``end_effector_teleop_sliders`` is no longer supported on macOS ([#14632][_#14632])
+* Fix output port index for ``kuka_simulation`` example ([#14631][_#14631])
+
+
+## Miscellaneous features and fixes
+
+<!--- relnotes for common,math,lcm,lcmtypes,manipulation,perception go here --->
+
+* Expose PiecewiseQuaternionSlerp's orientation getters ([#14585][_#14585])
+* Allow ``yaml`` to operate on non-default MaxRows or MaxCols storage ([#14618][_#14618])
+
+<!---
+Not installed:
+    * Add RenderEngineGL to the render engine benchmark ([#14540][_#14540])
+    * Fix ``render_benchmark`` build error under mac ([#14558][_#14558])
+    * Increase ProximityEngine introspection for unit tests ([#14640][_#14640])
+--->
+
+## pydrake bindings
+
+<!--- relnotes for bindings go here --->
+
+New features
+
+* None
+
+Fixes
+
+* None
+
+Newly bound
+
+* ``pydrake.solvers.mathematicalprogram.MathematicalProgram.NewNonnegativePolynomial`` ([#14627][_#14627])
+
+## Build system and dependencies
+
+<!--- relnotes for attic,cmake,doc,setup,third_party,tools go here --->
+
+* Add support for macOS Big Sur 11.x ([#14632][_#14632], [#14608][_#14608], [#14608][_#14608], [#14608][_#14608])
+* Upgrade fcl to latest commit ([#14620][_#14620])
+* Upgrade voxelized_geometry_tools to latest commit ([#14600][_#14600])
+* Fix ``pathutils.bzl`` globbing vs double-star matching ([#14564][_#14564])
+* Add retry to apt-get/brew update calls and add flag to skip update altogether ([#14492][_#14492])
+* Add lint check for unguarded OpenMP uses ([#14472][_#14472])
+* Distinguish test_rule_tags vs tags ([#14581][_#14581])
+* Add xmlrunner and use it for Python unittests ([#14560][_#14560])
+
+<!--
+Not installed:
+    * Start gathering sharable performance benchmarking infrastructure ([#14505][_#14505])
+    * Prepare for Jekyll website conversion ([#14531][_#14531], [#14612][_#14612])
+    * Minor cleanup ([#14582][_#14582], [#14572][_#14572], [#14563][_#14563], [#14554][_#14554], [#14580][_#14580])
+    * Define groupings in ``//doc`` to smooth our CI integration ([#14583][_#14583])
+    * Add consolidated ``//doc`` deployment tool ([#14587][_#14587])
+    * Remove `attic` from release notes template ([#14647][_#14647])
+-->
+
+## Un-deprecated APIs
+
+LCM messages
+
+* ``lcmtypes/lcmt_robot_state.lcm`` is no longer deprecated ([#14539][_#14539])
+
+## Newly-deprecated APIs
+
+C++
+
+* ``drake::multibody::MultibodyPlant::CalcCenterOfMassPosition -> CalcCenterOfMassPositionInWorld`` ([#14538][_#14538])
+
+Python
+
+* ``pydrake.multibody.plant.MultibodyPlant.CalcCenterOfMassPosition -> CalcCenterOfMassPositionInWorld`` ([#14538][_#14538])
+* ``pydrake.common.ToleranceType.absolute -> kAbsolute`` ([#14592][_#14592])
+* ``pydrake.common.ToleranceType.relative -> kRelative`` ([#14592][_#14592])
+
+
+## Removal of deprecated items
+
+C++
+
+* ``systems/sensors/accelerometer_sensor.h`` ([#14607][_#14607])
+* ``systems/sensors/gyroscope_sensor.h`` ([#14607][_#14607])
+* ``drake::multibody::SpatialVector::ScalarType`` ([#14607][_#14607])
+
+# Notes
+
+This release provides [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/v0.27.0) named
+``drake-20210216-{bionic|focal|mac}.tar.gz``. See [Nightly Releases](/from_binary.html#nightly-releases) for instructions on how to use them.
+
+Drake binary releases incorporate a pre-compiled version of [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the
+[Mathematical Program toolbox](https://drake.mit.edu/doxygen_cxx/group__solvers.html). Thanks to
+Philip E. Gill and Elizabeth Wong for their kind support.
+
+<!--- begin issue links --->
+[_#14472]: https://github.com/RobotLocomotion/drake/pull/14472
+[_#14492]: https://github.com/RobotLocomotion/drake/pull/14492
+[_#14505]: https://github.com/RobotLocomotion/drake/pull/14505
+[_#14525]: https://github.com/RobotLocomotion/drake/pull/14525
+[_#14531]: https://github.com/RobotLocomotion/drake/pull/14531
+[_#14538]: https://github.com/RobotLocomotion/drake/pull/14538
+[_#14539]: https://github.com/RobotLocomotion/drake/pull/14539
+[_#14540]: https://github.com/RobotLocomotion/drake/pull/14540
+[_#14541]: https://github.com/RobotLocomotion/drake/pull/14541
+[_#14554]: https://github.com/RobotLocomotion/drake/pull/14554
+[_#14558]: https://github.com/RobotLocomotion/drake/pull/14558
+[_#14560]: https://github.com/RobotLocomotion/drake/pull/14560
+[_#14563]: https://github.com/RobotLocomotion/drake/pull/14563
+[_#14564]: https://github.com/RobotLocomotion/drake/pull/14564
+[_#14569]: https://github.com/RobotLocomotion/drake/pull/14569
+[_#14572]: https://github.com/RobotLocomotion/drake/pull/14572
+[_#14580]: https://github.com/RobotLocomotion/drake/pull/14580
+[_#14581]: https://github.com/RobotLocomotion/drake/pull/14581
+[_#14582]: https://github.com/RobotLocomotion/drake/pull/14582
+[_#14583]: https://github.com/RobotLocomotion/drake/pull/14583
+[_#14585]: https://github.com/RobotLocomotion/drake/pull/14585
+[_#14587]: https://github.com/RobotLocomotion/drake/pull/14587
+[_#14592]: https://github.com/RobotLocomotion/drake/pull/14592
+[_#14600]: https://github.com/RobotLocomotion/drake/pull/14600
+[_#14607]: https://github.com/RobotLocomotion/drake/pull/14607
+[_#14608]: https://github.com/RobotLocomotion/drake/pull/14608
+[_#14612]: https://github.com/RobotLocomotion/drake/pull/14612
+[_#14615]: https://github.com/RobotLocomotion/drake/pull/14615
+[_#14618]: https://github.com/RobotLocomotion/drake/pull/14618
+[_#14620]: https://github.com/RobotLocomotion/drake/pull/14620
+[_#14622]: https://github.com/RobotLocomotion/drake/pull/14622
+[_#14625]: https://github.com/RobotLocomotion/drake/pull/14625
+[_#14627]: https://github.com/RobotLocomotion/drake/pull/14627
+[_#14630]: https://github.com/RobotLocomotion/drake/pull/14630
+[_#14631]: https://github.com/RobotLocomotion/drake/pull/14631
+[_#14632]: https://github.com/RobotLocomotion/drake/pull/14632
+[_#14639]: https://github.com/RobotLocomotion/drake/pull/14639
+[_#14640]: https://github.com/RobotLocomotion/drake/pull/14640
+[_#14647]: https://github.com/RobotLocomotion/drake/pull/14647
+<!--- end issue links --->
+
+<!--
+  Current oldest_commit 5b3377b92387cd149d5aa7b88f8ce5866347bbc1 (exclusive).
+  Current newest_commit fc1e0e5e7eb8cef3b9a38de650bd8ccdff04a4e4 (inclusive).
+-->

--- a/doc/release_playbook.rst
+++ b/doc/release_playbook.rst
@@ -38,7 +38,7 @@ Prior to release
    issue labels for now.
 5. For release notes, on an ongoing basis, add recent commit messages to the
    release notes draft using the ``tools/release_engineering/relnotes`` tooling.
-   (Instructions can be found atop its soure code: `relnotes.py
+   (Instructions can be found atop its source code: `relnotes.py
    <https://github.com/RobotLocomotion/drake/blob/master/tools/release_engineering/relnotes.py>`_.)
 
    a. On the first run, use ``--action=create`` to bootstrap the file.


### PR DESCRIPTION
The following commits port the recent changes merged into *.rst files (#14646, #14651 , #14660)  into their new *md Markdown counterparts. Each commit is a self-contained port, and this could easily be split into multiple PR's if that is preferable.

While performing the port, I found a typo in the source material of  `doc/release_playbook.rst`, which I fixed in both the rst and md files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14687)
<!-- Reviewable:end -->
