### PR TITLE
doc: Tidy up Jekyll instructions

### DIFF
--- a/doc/_pages/documentation_instructions.md
+++ b/doc/_pages/documentation_instructions.md
@@ -5,6 +5,15 @@ title: Documentation Generation Instructions
 Documentation generation and preview as described in this document are
 supported on Ubuntu only.
 
+Before getting started, install the appropriate prerequisites with the
+``--with-doc-only`` command line option, e.g.:
+
+```
+$ ./setup/ubuntu/install_prereqs.sh --with-doc-only
+```
+
+# Sphinx and Doxygen
+
 *Note: Before proceeding, please*
 [build Drake from source](/from_source.html). This is necessary because
 otherwise the various build targets mentioned below will not exist.
@@ -18,16 +27,7 @@ This includes API documentation
 [Python](https://drake.mit.edu/pydrake/index.html)) and
 [Drake’s website](https://drake.mit.edu/).
 
-# When using Bazel
-
-First, install the appropriate prerequisites with the ``--with-doc-only`` command
-line option, e.g., :
-
-```
-$ ./setup/ubuntu/install_prereqs.sh --with-doc-only
-```
-
-Then, to generate the website and serve it locally with
+To generate the website and serve it locally with
 [webbrowser](https://docs.python.org/2/library/webbrowser.html):
 
 ```
@@ -56,3 +56,23 @@ $ bazel run //bindings/pydrake/doc:serve_sphinx [-- --browser=false]
 
 The contents of the Python API documentation are also available via
 ``bazel build //bindings/pydrake/doc:sphinx.zip``.
+
+# Jekyll
+
+It is *not* necessary to build Drake prior to running either command below.
+
+To serve page locally at ``http://127.0.0.1:<n>``:
+
+```
+$ bazel run //doc:serve_jekyll [-- --default_port <n>]
+```
+
+If not specified, the default port is 8000.
+
+To create output in the specified out_dir:
+
+```
+$ bazel run //doc:gen_jekyll -- --out_dir
+```
+
+The output directory must not already exist.

--- a/doc/documentation_instructions.rst
+++ b/doc/documentation_instructions.rst
@@ -54,8 +54,8 @@ The contents of the Python API documentation are also available via
 Jekyll
 ======
 
-*Note: Jekyll documentation is a work in progress and is not published live
-yet.* Currently, this process will generate or serve an empty page (index.html).
+*Note: Jekyll documentation is a work in progress and is not published on
+the drake.mit.edu website yet. You can still preview it locally.*
 
 It is *not* necessary to build Drake prior to running either command below.
 


### PR DESCRIPTION
Propagate some rst diffs from [2290ae0](https://github.com/RobotLocomotion/drake/commit/2290ae07e4b7c9064af9742caa644487ebab8e6c#diff-c2ffe499c54c8af6910c806e91891cacff54b74144d801dade6c35b23d6f772d) back into the md copy of the site.

Remove the stale "serves an empty page" disclaimer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14696)
<!-- Reviewable:end -->
