### PR TITLE
Add deformable visualizer

### DIFF
--- a/lcmtypes/BUILD.bazel
+++ b/lcmtypes/BUILD.bazel
@@ -105,6 +105,18 @@ drake_lcm_cc_library(
 )
 
 drake_lcm_cc_library(
+    name = "experimental_deformable_mesh",
+    lcm_package = "drake",
+    lcm_srcs = [
+        "experimental_lcmt_deformable_tri.lcm",
+        "experimental_lcmt_deformable_tri_mesh_init.lcm",
+        "experimental_lcmt_deformable_tri_meshes_init.lcm",
+        "experimental_lcmt_deformable_tri_mesh_update.lcm",
+        "experimental_lcmt_deformable_tri_meshes_update.lcm",
+    ],
+)
+
+drake_lcm_cc_library(
     name = "desired_body_motion",
     deprecation = _DEPRECATION_2021_04,
     lcm_package = "drake",

--- a/lcmtypes/experimental_lcmt_deformable_tri.lcm
+++ b/lcmtypes/experimental_lcmt_deformable_tri.lcm
@@ -1,0 +1,6 @@
+package drake;
+
+struct experimental_lcmt_deformable_tri {
+  // Indices into an array of vertex positions.
+  int32_t vertices[3];
+}

--- a/lcmtypes/experimental_lcmt_deformable_tri_mesh_init.lcm
+++ b/lcmtypes/experimental_lcmt_deformable_tri_mesh_init.lcm
@@ -1,0 +1,12 @@
+package drake;
+// For the mesh with the given `name`, provide the minimum number of vertices
+// expected from subsequent update messages as well as the connectivity of
+// the surface triangle mesh, which is assumed to be unchanged throughout the
+// entire simulation.
+struct experimental_lcmt_deformable_tri_mesh_init {
+  // Unique name for the mesh.
+  string name;
+  int32_t num_vertices;
+  int32_t num_tris;
+  experimental_lcmt_deformable_tri tris[num_tris];
+}

--- a/lcmtypes/experimental_lcmt_deformable_tri_mesh_update.lcm
+++ b/lcmtypes/experimental_lcmt_deformable_tri_mesh_update.lcm
@@ -1,0 +1,11 @@
+package drake;
+// An update to the vertex positions of the mesh named `name`.
+//  * `num_vertices` is the number of vertex positions to be passed in this
+//    message.
+//  * `vertices_W[i]` contains the world space position of the i-th vertex
+//    passed in this message.
+struct experimental_lcmt_deformable_tri_mesh_update {
+  string name;
+  int32_t num_vertices;
+  double vertices_W[num_vertices][3];
+}

--- a/lcmtypes/experimental_lcmt_deformable_tri_meshes_init.lcm
+++ b/lcmtypes/experimental_lcmt_deformable_tri_meshes_init.lcm
@@ -1,0 +1,6 @@
+package drake;
+
+struct experimental_lcmt_deformable_tri_meshes_init {
+  int32_t num_meshes;
+  experimental_lcmt_deformable_tri_mesh_init meshes[num_meshes];
+}

--- a/lcmtypes/experimental_lcmt_deformable_tri_meshes_update.lcm
+++ b/lcmtypes/experimental_lcmt_deformable_tri_meshes_update.lcm
@@ -1,0 +1,10 @@
+package drake;
+// For each mesh included in this message, provide the number of vertices and
+// their positions in world space at time `timestamp`.
+struct experimental_lcmt_deformable_tri_meshes_update {
+  // in microseconds
+  int64_t timestamp;
+
+  int32_t num_meshes;
+  experimental_lcmt_deformable_tri_mesh_update meshes[num_meshes];
+}

--- a/multibody/fixed_fem/dev/BUILD.bazel
+++ b/multibody/fixed_fem/dev/BUILD.bazel
@@ -2,6 +2,7 @@
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load(
     "//tools/skylark:drake_cc.bzl",
+    "drake_cc_binary",
     "drake_cc_googletest",
     "drake_cc_library",
 )
@@ -60,6 +61,20 @@ drake_cc_library(
     name = "damping_model",
     hdrs = [
         "damping_model.h",
+    ],
+)
+
+drake_cc_library(
+    name = "deformable_visualizer",
+    srcs = ["deformable_visualizer.cc"],
+    hdrs = ["deformable_visualizer.h"],
+    deps = [
+        "//common:essential",
+        "//geometry/proximity:sorted_triplet",
+        "//geometry/proximity:volume_mesh",
+        "//lcm:drake_lcm",
+        "//lcmtypes:experimental_deformable_mesh",
+        "//systems/framework:leaf_system",
     ],
 )
 
@@ -303,6 +318,20 @@ drake_cc_library(
     deps = [
         "//common:default_scalars",
         "//common:essential",
+    ],
+)
+
+drake_cc_binary(
+    name = "run_scripted_deformable_motion",
+    srcs = [
+        "run_scripted_deformable_motion.cc",
+    ],
+    deps = [
+        ":deformable_visualizer",
+        "//common:add_text_logging_gflags",
+        "//geometry/proximity:make_box_mesh",
+        "//systems/analysis:simulator_gflags",
+        "//systems/framework:diagram_builder",
     ],
 )
 

--- a/multibody/fixed_fem/dev/deformable_visualizer.cc
+++ b/multibody/fixed_fem/dev/deformable_visualizer.cc
@@ -1,0 +1,226 @@
+#include "drake/multibody/fixed_fem/dev/deformable_visualizer.h"
+
+#include <algorithm>
+#include <array>
+#include <map>
+#include <set>
+#include <utility>
+
+#include "drake/experimental_lcmt_deformable_tri.hpp"
+#include "drake/experimental_lcmt_deformable_tri_mesh_init.hpp"
+#include "drake/experimental_lcmt_deformable_tri_mesh_update.hpp"
+#include "drake/experimental_lcmt_deformable_tri_meshes_init.hpp"
+#include "drake/experimental_lcmt_deformable_tri_meshes_update.hpp"
+#include "drake/geometry/proximity/sorted_triplet.h"
+#include "drake/lcm/drake_lcm.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+
+using geometry::VolumeElement;
+using geometry::VolumeMesh;
+using geometry::internal::SortedTriplet;
+using std::array;
+using std::map;
+using std::set;
+using std::vector;
+using systems::Context;
+using systems::EventStatus;
+
+DeformableVisualizer::DeformableVisualizer(
+    double update_period, vector<std::string> mesh_names,
+    const vector<VolumeMesh<double>>& tet_meshes, lcm::DrakeLcmInterface* lcm)
+    : lcm_(lcm), mesh_names_(std::move(mesh_names)) {
+  if (lcm == nullptr) {
+    owned_lcm_ = std::make_unique<lcm::DrakeLcm>();
+    lcm_ = owned_lcm_.get();
+  }
+
+  AnalyzeTets(tet_meshes);
+
+  vertex_positions_port_ =
+      this->DeclareAbstractInputPort("vertex_positions",
+                                     Value<vector<VectorX<double>>>())
+          .get_index();
+  this->DeclareInitializationPublishEvent(
+      &DeformableVisualizer::PublishMeshInit);
+  this->DeclarePeriodicPublishEvent(update_period, 0.0,
+                                    &DeformableVisualizer::PublishMeshUpdate);
+}
+
+void DeformableVisualizer::AnalyzeTets(
+    const vector<VolumeMesh<double>>& tet_meshes) {
+  /* For each tet mesh, extract all the border faces. Those are the triangles
+   that are only referenced by a single face. So, for every tet, we examine its
+   four faces and determine if any other tet shares it. Any face that is only
+   referenced once is a border face.
+
+   Each face has a unique key: a SortedTriplet (so the ordering of the vertices
+   won't matter). The first time we see a face, we add it to a map. The second
+   time we see the face, we remove it. When we're done, the keys in the map
+   will be those faces only referenced once.
+
+   The values in the map represent the triangle, with the vertices ordered so
+   that they point *out* of the tetrahedron. Therefore, they will also point
+   outside of the mesh.
+
+   A typical tetrahedral element looks like:
+       p2 *
+          |
+          |
+       p3 *---* p0
+         /
+        /
+    p1 *
+   The index order for a particular tetrahedron has the order [p0, p1, p2, p3].
+   These local indices enumerate each of the tet faces with outward-pointing
+   normals with respect to the right-hand rule.  */
+  const array<array<int, 3>, 4> local_indices{
+      {{{1, 0, 2}}, {{3, 0, 1}}, {{3, 1, 2}}, {{2, 0, 3}}}};
+
+  volume_vertex_counts_.resize(tet_meshes.size());
+  surface_to_volume_vertices_.resize(tet_meshes.size());
+  surface_triangles_.resize(tet_meshes.size());
+  for (int i = 0; i < static_cast<int>(tet_meshes.size()); ++i) {
+    /* While visiting all of the referenced vertices, identify the largest
+     index.  */
+    int largest_index = -1;
+    const VolumeMesh<double>& tet_mesh = tet_meshes[i];
+    map<SortedTriplet<int>, array<int, 3>> border_faces;
+    for (const VolumeElement& tet : tet_mesh.tetrahedra()) {
+      for (const array<int, 3>& tet_face : local_indices) {
+        const array<int, 3> face{tet.vertex(tet_face[0]),
+                                 tet.vertex(tet_face[1]),
+                                 tet.vertex(tet_face[2])};
+        largest_index = std::max({largest_index, face[0], face[1], face[2]});
+        const SortedTriplet face_key(face[0], face[1], face[2]);
+        if (auto itr = border_faces.find(face_key); itr != border_faces.end()) {
+          border_faces.erase(itr);
+        } else {
+          border_faces[face_key] = face;
+        }
+      }
+    }
+    /* Record the expected minimum number of vertex positions to be received.
+     For simplicity we choose a generous upper bound: the total number of
+     vertices in the tetrahedral mesh, even though we really only need the
+     positions of the vertices on the surface. */
+    // TODO(xuchenhan-tri) It might be worthwhile to make largest_index the
+    //  largest index that lies on the surface. Then, when we create our meshes,
+    //  if we intentionally construct them so that the surface vertices come
+    //  first, we will process a very compact representation.
+    volume_vertex_counts_[i] = largest_index + 1;
+
+    /* Using a set because the vertices will be nicely ordered. Ideally, we'll
+     be extracting a subset of the vertex positions from the input port. We
+     optimize cache coherency if we march in a monotonically increasing pattern.
+     So, we'll map triangle vertex indices to volume vertex indices in a
+     strictly monotonically increasing relationship.  */
+    set<int> unique_vertices;
+    for (const auto& [face_key, face] : border_faces) {
+      unused(face_key);
+      for (int j = 0; j < 3; ++j) unique_vertices.insert(face[j]);
+    }
+    /* This is the *second* documented responsibility of this function: populate
+     the mapping from surface to volume so that we can efficiently extract the
+     *surface* vertex positions from the *volume* vertex input.  */
+    surface_to_volume_vertices_[i].clear();  // just to be safe.
+    surface_to_volume_vertices_[i].insert(
+        surface_to_volume_vertices_[i].begin(), unique_vertices.begin(),
+        unique_vertices.end());
+
+    /* The border faces all include indices into the volume vertices. To turn
+     them into surface triangles, they need to include indices into the surface
+     vertices. Create the volume index --> surface map to facilitate the
+     transformation.  */
+    const int surface_vertex_count =
+        static_cast<int>(surface_to_volume_vertices_[i].size());
+    map<int, int> volume_to_surface;
+    for (int j = 0; j < surface_vertex_count; ++j) {
+      volume_to_surface[surface_to_volume_vertices_[i][j]] = j;
+    }
+
+    /* This is the *first* documented responsibility: create the topology of the
+     surface triangle mesh for each volume mesh. Each triangle consists of three
+     indices into the set of *surface* vertex positions.  */
+    surface_triangles_[i].clear();
+    surface_triangles_[i].reserve(border_faces.size());
+    for (auto& [face_key, face] : border_faces) {
+      unused(face_key);
+      surface_triangles_[i].emplace_back(volume_to_surface[face[0]],
+                                         volume_to_surface[face[1]],
+                                         volume_to_surface[face[2]]);
+    }
+  }
+}
+
+void DeformableVisualizer::SendMeshInit() const {
+  experimental_lcmt_deformable_tri_meshes_init message;
+  message.num_meshes = static_cast<int>(surface_to_volume_vertices_.size());
+  message.meshes.resize(message.num_meshes);
+  for (int i = 0; i < message.num_meshes; ++i) {
+    auto& mesh = message.meshes[i];
+    mesh.name = mesh_names_[i];
+    mesh.num_vertices = static_cast<int>(surface_to_volume_vertices_[i].size());
+    // TODO(xuchenhan-tri): Consider flatten the message hierarchy by sending 3T
+    //  indices instead of T triangles.
+    mesh.num_tris = static_cast<int>(surface_triangles_[i].size());
+    mesh.tris.resize(mesh.num_tris);
+    for (int t = 0; t < message.meshes[i].num_tris; ++t) {
+      mesh.tris[t].vertices[0] = surface_triangles_[i][t](0);
+      mesh.tris[t].vertices[1] = surface_triangles_[i][t](1);
+      mesh.tris[t].vertices[2] = surface_triangles_[i][t](2);
+    }
+  }
+
+  lcm::Publish(lcm_, "DEFORMABLE_MESHES_INIT", message);
+}
+
+EventStatus DeformableVisualizer::PublishMeshInit(
+    const Context<double>&) const {
+  SendMeshInit();
+  return EventStatus::Succeeded();
+}
+
+void DeformableVisualizer::PublishMeshUpdate(
+    const Context<double>& context) const {
+  experimental_lcmt_deformable_tri_meshes_update message;
+  message.timestamp =
+      static_cast<int64_t>(ExtractDoubleOrThrow(context.get_time()) * 1e6);
+
+  const int num_meshes = static_cast<int>(surface_to_volume_vertices_.size());
+  // The volume vertex positions are one flat vector. Such that the position
+  // of the i-th volume vertex is in entries j, j + 1, and j + 2, j = 3i.
+  const vector<VectorX<double>>& vertex_states =
+      vertex_positions_input_port().Eval<vector<VectorX<double>>>(context);
+  vector<int> vertex_index_offsets{0};
+  message.num_meshes = vertex_states.size();
+  message.meshes.resize(message.num_meshes);
+  for (int i = 0; i < num_meshes; ++i) {
+    if (vertex_states[i].size() < volume_vertex_counts_[i]) {
+      throw std::logic_error(fmt::format(
+          "For mesh {}, named '{}', The number of given vertex positions "
+          "({}) is smaller than the "
+          "minimum expected number of positions ({}).",
+          i, mesh_names_[i], vertex_states[i].size(),
+          volume_vertex_counts_[i]));
+    }
+    auto& mesh = message.meshes[i];
+    mesh.name = mesh_names_[i];
+    const int v_count = static_cast<int>(surface_to_volume_vertices_[i].size());
+    mesh.num_vertices = v_count;
+    mesh.vertices_W.resize(mesh.num_vertices);
+    for (int v = 0; v < v_count; ++v) {
+      const int state_index = (surface_to_volume_vertices_[i][v]) * 3;
+      mesh.vertices_W[v].resize(3);
+      for (int d = 0; d < 3; ++d) {
+        mesh.vertices_W[v][d] = vertex_states[i](state_index + d);
+      }
+    }
+  }
+  lcm::Publish(lcm_, "DEFORMABLE_MESHES_UPDATE", message);
+}
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/deformable_visualizer.h
+++ b/multibody/fixed_fem/dev/deformable_visualizer.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/geometry/proximity/volume_mesh.h"
+#include "drake/lcm/drake_lcm_interface.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+
+/** A class for visualizing deformable meshes in `drake_visualizer`.
+ Specifically, it dispatches LCM messages to initialize mesh definitions and
+ then updates vertex positions at a fixed frequency. Although the inputs are
+ volume (aka tetrahedral) meshes, only the surface triangular mesh gets
+ visualized.
+ @system
+ name: DeformableVisualizer
+ input_ports:
+ - vertex_positions
+ @endsystem
+ The input port is an abstract-valued port containing
+ std::vector<VectorX<double>>. There is one VectorX for each mesh with which the
+ visualizer was instantiated. The ith mesh corresponds to the ith VectorX. The
+ ith VectorX has 3N doubles where N + 1 is the largest vertex index referenced
+ by the ith tetrahedral mesh. For mesh i, the x-, y-, and z-positions (measured
+ and expressed in the world frame) of the jth vertex are 3j, 3j + 1, and 3j + 2
+ in the ith VectorX from the input port. */
+class DeformableVisualizer : public systems::LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DeformableVisualizer)
+
+  /** Constructs a visualizer for a vector of tetrahedral meshes.
+   @param update_period  The duration (in seconds) between publications of mesh
+                         state.
+   @param mesh_names     The names for the meshes (as they will appear in
+                         drake_visualizer).
+   @param tet_meshes     The definition of the tetrahedral mesh topologies.
+   @param lcm            If non-nullptr, `this` will use the provided lcm
+                         interface to broadcast lcm messages. The system will
+                         keep a reference to the instance and it should stay
+                         alive as long as this class. Otherwise, `this` will
+                         create its own instance.
+   @pre update_period > 0.
+   @pre mesh_names.size() == tet_meshes.size().  */
+  DeformableVisualizer(
+      double update_period, std::vector<std::string> mesh_names,
+      const std::vector<geometry::VolumeMesh<double>>& tet_meshes,
+      lcm::DrakeLcmInterface* lcm = nullptr);
+
+  // TODO(xuchenhan-tri): Rethink the initialization/update paradigm as the
+  //  intialization event may be received after update events.
+  /** Send the mesh initialization message. This can be invoked explicitly but
+   is generally not necessary. The initialization method is also called by
+   an initialization event.  */
+  void SendMeshInit() const;
+
+  /** Returns the input port for vertex positions.  */
+  const systems::InputPort<double>& vertex_positions_input_port() const {
+    return systems::System<double>::get_input_port(vertex_positions_port_);
+  }
+
+ private:
+  /* Analyzes the tet mesh topologies to do the following:
+    1. Build a surface mesh from each volume mesh.
+    2. Create a mapping from surface vertex to volume vertex for each mesh.
+    3. Record the expected number of vertices referenced by each tet mesh.  */
+  void AnalyzeTets(const std::vector<geometry::VolumeMesh<double>>& tet_meshes);
+
+  /* Call SendMeshInit in an initialization event.  */
+  systems::EventStatus PublishMeshInit(const systems::Context<double>&) const;
+
+  /* Broadcast the current vertex positions for the mesh.  */
+  void PublishMeshUpdate(const systems::Context<double>& context) const;
+
+  /* The LCM interface used to broadcast its messages. This system can
+   optionally own its lcm interface.  */
+  lcm::DrakeLcmInterface* lcm_{};
+  std::unique_ptr<lcm::DrakeLcmInterface> owned_lcm_{};
+
+  /* The names of the meshes. Included in all lcm messages.  */
+  const std::vector<std::string> mesh_names_;
+
+  /* An *implicit* map from *surface* vertex indices to volume vertex indices.
+   For the iᵗʰ mesh, the jᵗʰ surface vertex corresponds to the volume vertex
+   with index `surface_to_volume_vertices_[i][j]`.  */
+  std::vector<std::vector<int>> surface_to_volume_vertices_;
+
+  /* Surface meshes representing the topology of the volume meshes' surfaces. */
+  std::vector<std::vector<Vector3<int>>> surface_triangles_;
+
+  /* The total number of vertices expected on the input port as implied by the
+   tetrahedra definitions.  */
+  std::vector<int> volume_vertex_counts_{};
+
+  /* Port Indexes.  */
+  systems::InputPortIndex vertex_positions_port_{};
+};
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/run_scripted_deformable_motion.cc
+++ b/multibody/fixed_fem/dev/run_scripted_deformable_motion.cc
@@ -1,0 +1,159 @@
+/**
+A demo to test deformable visualizer.
+
+To run the demo. First ensure that you have the visualizer and the demo itself
+built:
+
+```
+bazel build //tools:drake_visualizer
+bazel build //multibody/fixed_fem/dev:run_scripted_deformable_motion
+```
+
+Then, in one terminal, launch the visualizer
+```
+bazel-bin/tools/drake_visualizer
+```
+
+In another terminal, launch the demo
+```
+bazel-bin/multibody/fixed_fem/dev/run_scripted_deformable_motion
+-simulator_target_realtime_rate 1
+```
+
+Notice that without the realtime flag the simulation is likely to progress too
+fast to visualize. */
+
+#include <cstdlib>
+#include <memory>
+
+#include <gflags/gflags.h>
+
+#include "drake/geometry/proximity/make_box_mesh.h"
+#include "drake/multibody/fixed_fem/dev/deformable_visualizer.h"
+#include "drake/systems/analysis/simulator_gflags.h"
+#include "drake/systems/framework/diagram.h"
+#include "drake/systems/framework/diagram_builder.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+
+/** A dummy softsim system that deforms registered geometry with a sinusoidal
+ ripple motion. */
+class DummySoftsimSystem final : public systems::LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DummySoftsimSystem)
+
+  /** Construct a DummySoftSimSystem. */
+  DummySoftsimSystem() {
+    this->DeclareAbstractOutputPort(
+        "vertex_positions", &DummySoftsimSystem::CopyVertexPositionsOut);
+  }
+
+  /** Adds a geometry modeled with the given geometry to the system.
+   @param[in] mesh The input tetrahedral mesh that describes the connectivity
+   and the positions of the vertices that make up the geometry.
+   @param[in] name Name of the newly added geometry.
+   @param[in] amplitude The amplitude of the sinusoidal motion for the new
+   geometry.
+   @param[in] velocity The velocity of the sinusoidal motion for the new
+   geometry.
+   @param[in] p_WM The origin of the input mesh in world frame. */
+  void RegisterBody(const geometry::VolumeMesh<double>& mesh, std::string name,
+                    double amplitude, double velocity,
+                    const Vector3<double>& p_WM) {
+    const std::vector<geometry::VolumeVertex<double>>& verts = mesh.vertices();
+    std::vector<geometry::VolumeElement> elements = mesh.tetrahedra();
+    std::vector<geometry::VolumeVertex<double>> verts_W;
+    /* Shift the vertices to world frame. */
+    for (const auto& v : verts) {
+      verts_W.emplace_back(v.r_MV() + p_WM);
+    }
+    meshes_.emplace_back(std::move(elements), std::move(verts_W));
+    names_.emplace_back(std::move(name));
+    amplitudes_.emplace_back(amplitude);
+    velocities_.emplace_back(velocity);
+  }
+
+  /** Get the abstract-valued port containing an `std::vector` of `VectorX`
+   values for the vertex positions of each geometry. */
+  const systems::OutputPort<double>& get_vertex_positions_output_port() const {
+    return systems::System<double>::get_output_port(0);
+  }
+
+  int num_geometries() const { return meshes_.size(); }
+
+  /** Get the volume meshes of the registered geometries. */
+  const std::vector<geometry::VolumeMesh<double>>& get_meshes() const {
+    return meshes_;
+  }
+
+  /** Get the names of all the registered geometries. */
+  const std::vector<std::string>& get_names() const { return names_; }
+
+ private:
+  /* Copies the generalized positions of each geometry to the given `output`. */
+  void CopyVertexPositionsOut(const systems::Context<double>& context,
+                              std::vector<VectorX<double>>* output) const {
+    output->resize(num_geometries());
+    const double t = context.get_time();
+    for (int i = 0; i < num_geometries(); ++i) {
+      const std::vector<geometry::VolumeVertex<double>> vertices =
+          meshes_[i].vertices();
+      const int num_vertices = meshes_[i].num_vertices();
+      VectorX<double> q(num_vertices * 3);
+      const double v = velocities_[i];
+      const double h = amplitudes_[i];
+      for (int j = 0; j < num_vertices; ++j) {
+        Vector3<double> r_MV = vertices[j].r_MV();
+        r_MV(2) += h * std::sin(frequency_ * (r_MV(0) + v * t));
+        q.template segment<3>(3 * j) = r_MV;
+      }
+      (*output)[i] = q;
+    }
+  }
+
+  /* The amplitude of the sinusoidal motion for each geometry. */
+  std::vector<double> amplitudes_{};
+  /* The velocity of the sinusoidal motion for each geometry. */
+  std::vector<double> velocities_{};
+  /* The frequency of the sinusoidal wave with unit m⁻¹. */
+  const double frequency_{30};
+  std::vector<geometry::VolumeMesh<double>> meshes_{};
+  std::vector<std::string> names_{};
+};
+
+int DoMain() {
+  systems::DiagramBuilder<double> builder;
+  auto* dummy_softsim_system = builder.AddSystem<DummySoftsimSystem>();
+  const double dx = 0.03;
+  const int Nx = 20;
+  const int Ny = 4;
+  const int Nz = 4;
+  const geometry::Box box(Nx * dx, Ny * dx, Nz * dx);
+  const geometry::VolumeMesh<double> box_mesh =
+      geometry::internal::MakeBoxVolumeMesh<double>(box, dx);
+  dummy_softsim_system->RegisterBody(box_mesh, "box1", 0.03, 0.2, {0, 0, 0});
+  dummy_softsim_system->RegisterBody(box_mesh, "box2", 0.015, 0.6,
+                                       {0, 0.6, 0});
+
+  auto& visualizer = *builder.AddSystem<DeformableVisualizer>(
+      1.0 / 30.0, dummy_softsim_system->get_names(),
+      dummy_softsim_system->get_meshes());
+  builder.Connect(*dummy_softsim_system, visualizer);
+  auto diagram = builder.Build();
+  auto context = diagram->CreateDefaultContext();
+  auto simulator =
+      systems::MakeSimulatorFromGflags(*diagram, std::move(context));
+  simulator->AdvanceTo(10);
+  return 0;
+}
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake
+
+int main(int argc, char** argv) {
+  gflags::SetUsageMessage("Test for deformable visualizer.");
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  return drake::multibody::fixed_fem::DoMain();
+}

--- a/tools/workspace/drake_visualizer/_drake_visualizer_builtin_scripts/BUILD.bazel
+++ b/tools/workspace/drake_visualizer/_drake_visualizer_builtin_scripts/BUILD.bazel
@@ -13,6 +13,7 @@ py_library(
 py_library(
     name = "_drake_visualizer_builtin_scripts",
     srcs = [
+        "experimental_show_deformable_mesh.py",
         "grid_wireframe.py",
         "limit_clipping_range.py",
         "show_frame.py",

--- a/tools/workspace/drake_visualizer/_drake_visualizer_builtin_scripts/__init__.py
+++ b/tools/workspace/drake_visualizer/_drake_visualizer_builtin_scripts/__init__.py
@@ -18,6 +18,7 @@ import weakref
 # N.B. Keep this in sync (with the same ordering) as the keys defined in
 # `available` in `use_builtin_scripts.py`.
 AVAILABLE_SCRIPTS = [
+    "experimental_deformable_mesh",
     "frame",
     "hydroelastic_contact",
     "image",

--- a/tools/workspace/drake_visualizer/_drake_visualizer_builtin_scripts/experimental_show_deformable_mesh.py
+++ b/tools/workspace/drake_visualizer/_drake_visualizer_builtin_scripts/experimental_show_deformable_mesh.py
@@ -1,0 +1,174 @@
+# Note that this script runs in the main context of drake-visualizer,
+# where many modules and variables already exist in the global scope.
+
+from director import lcmUtils
+from director import applogic
+from director import objectmodel as om
+from director import visualization as vis
+import director.vtkAll as vtk
+
+import drake as lcmdrakemsg
+
+from _drake_visualizer_builtin_scripts import scoped_singleton_func
+
+
+class ExperimentalDeformableMeshVisualizer:
+    def __init__(self):
+        self._folder_name = "DeformableMesh"
+        self._name = "Deformable Mesh Visualizer"
+        self._enabled = False
+        # The subscribers: one for init and one for update.
+        self._subs = None
+        self._names = []
+        self._vertex_counts = []
+        self._poly_data_list = []
+        self._poly_item_list = []
+
+        self.set_enabled(True)
+
+    def add_subscriber(self):
+        if self._subs is not None:
+            return
+
+        self._subs = []
+        self._subs.append(
+            lcmUtils.addSubscriber(
+                "DEFORMABLE_MESHES_INIT",
+                messageClass=lcmdrakemsg.
+                experimental_lcmt_deformable_tri_meshes_init,
+                callback=self.handle_init_message,
+            )
+        )
+
+        self._subs.append(
+            lcmUtils.addSubscriber(
+                "DEFORMABLE_MESHES_UPDATE",
+                messageClass=lcmdrakemsg.
+                experimental_lcmt_deformable_tri_meshes_update,
+                callback=self.handle_update_message,
+            )
+        )
+
+        print(self._name + " subscribers added.")
+
+    def remove_subscriber(self):
+        if self._subs is None:
+            return
+
+        for sub in self._subs:
+            lcmUtils.removeSubscriber(sub)
+        self._subs = None
+        print(self._name + " subscribers removed.")
+
+    def is_enabled(self):
+        return self._enabled
+
+    def set_enabled(self, enable, clear=True):
+        print("DeformableVisualizer set_enabled", enable)
+        self._enabled = enable
+        if enable:
+            self.add_subscriber()
+        else:
+            self.remove_subscriber()
+            # Removes the folder completely and resets the known meshes.
+            om.removeFromObjectModel(
+                om.findObjectByName(self._folder_name)
+            )
+            self._poly_item_list = []
+
+    def handle_init_message(self, msg):
+        """Creates the polydata for the deformable mesh specified in msg."""
+        folder = om.getOrCreateContainer(self._folder_name)
+        for poly_item in self._poly_item_list:
+            om.removeFromObjectModel(poly_item)
+
+        self._names = []
+        self._vertex_counts = []
+        self._poly_data_list = []
+        self._poly_item_list = []
+        for mesh in msg.meshes:
+            self._names.append(mesh.name)
+            # Initial vertex positions are garbage; meaningful values will be
+            # set by the update message.
+            points = vtk.vtkPoints()
+            self._vertex_counts.append(mesh.num_vertices)
+            for i in range(mesh.num_vertices):
+                points.InsertNextPoint(0, 0, 0)
+            triangles = vtk.vtkCellArray()
+            for tri in mesh.tris:
+                triangles.InsertNextCell(3)
+                for i in tri.vertices:
+                    triangles.InsertCellPoint(i)
+            poly_data = vtk.vtkPolyData()
+            poly_data.SetPoints(points)
+            poly_data.SetPolys(triangles)
+            poly_item = vis.showPolyData(
+                poly_data, mesh.name, parent=folder
+            )
+            poly_item.setProperty("Surface Mode", "Surface with edges")
+            self._poly_data_list.append(poly_data)
+            self._poly_item_list.append(poly_item)
+
+    def handle_update_message(self, msg):
+        """Updates vertex data for the deformable meshes specified in msg."""
+        if not len(self._poly_data_list) == msg.num_meshes:
+            print(
+                "Received a deformable mesh update message with '{}' meshes; "
+                "expected {} meshes.".format(
+                    msg.num_meshes, len(self._poly_data_list)
+                )
+            )
+            return
+        for mesh_id in range(msg.num_meshes):
+            mesh = msg.meshes[mesh_id]
+            if mesh.name != self._names[mesh_id]:
+                print(
+                    "The deformable mesh update message contains data for "
+                    "a mesh named '{}', expected name '{}'.".format(
+                        mesh.name, self._names[mesh_id]
+                    )
+                )
+                return
+            if mesh.num_vertices != self._vertex_counts[mesh_id]:
+                print(
+                    "The deformable mesh update message contains data for {} "
+                    "vertices; expected {}.".format(
+                        mesh.num_vertices, self._vertex_count
+                    )
+                )
+                return
+            points = vtk.vtkPoints()
+            for i in range(0, mesh.num_vertices):
+                points.InsertNextPoint(
+                    mesh.vertices_W[i][0],
+                    mesh.vertices_W[i][1],
+                    mesh.vertices_W[i][2]
+                )
+            # TODO(SeanCurtis-TRI): Instead of creating a new set of points and
+            # stomping on the old; can I just update the values? That might
+            # improve performance.
+            self._poly_data_list[mesh_id].SetPoints(points)
+            self._poly_item_list[mesh_id].setPolyData(
+                self._poly_data_list[mesh_id]
+            )
+            self._poly_item_list[mesh_id]._renderAllViews()
+
+
+@scoped_singleton_func
+def init_visualizer():
+    # Create a visualizer instance.
+    my_visualizer = ExperimentalDeformableMeshVisualizer()
+    # Adds to the "Tools" menu.
+    applogic.MenuActionToggleHelper(
+        "Tools",
+        my_visualizer._name,
+        my_visualizer.is_enabled,
+        my_visualizer.set_enabled,
+    )
+    return my_visualizer
+
+
+# Activate the plugin if this script is run directly; store the results to keep
+# the plugin objects in scope.
+if __name__ == "__main__":
+    deform_viz = init_visualizer()

--- a/tools/workspace/drake_visualizer/_drake_visualizer_builtin_scripts/use_builtin_scripts.py
+++ b/tools/workspace/drake_visualizer/_drake_visualizer_builtin_scripts/use_builtin_scripts.py
@@ -10,6 +10,7 @@ from _drake_visualizer_builtin_scripts import (
     grid_wireframe,
     limit_clipping_range,
     scoped_singleton_func,
+    experimental_show_deformable_mesh,
     show_frame,
     show_hydroelastic_contact,
     show_image,
@@ -21,6 +22,8 @@ from _drake_visualizer_builtin_scripts import (
 @scoped_singleton_func
 def init_visualizer():
     available = OrderedDict((
+        ("experimental_deformable_mesh",
+            experimental_show_deformable_mesh.init_visualizer),
         ("frame", show_frame.init_visualizer),
         ("hydroelastic_contact", show_hydroelastic_contact.init_visualizer),
         ("image", show_image.init_visualizer),


### PR DESCRIPTION
The deformable visualizer was originally author by @SeanCurtis-TRI. I
have since made modifications to allow it to visualize more than one
object.

A simple demo `run_scripted_deformable_motion` is added to visually test
the deformable visualizer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14697)
<!-- Reviewable:end -->
