### PR TITLE
Enable simple caching for FEM state dependent quantities

### DIFF
--- a/multibody/fixed_fem/dev/element_cache_entry.h
+++ b/multibody/fixed_fem/dev/element_cache_entry.h
@@ -5,7 +5,8 @@
 namespace drake {
 namespace multibody {
 namespace fixed_fem {
-/** %ElementCacheEntry provides basic caching capabilities for the
+namespace internal {
+/* %ElementCacheEntry provides basic caching capabilities for the
  per-element, state-dependent quantities used in an FEM simulation that are
  not states themselves. These quantities are stored in `ElementData`.
  @tparam ElementData    The state-dependent quantities of the element that are
@@ -21,7 +22,7 @@ class ElementCacheEntry {
                 "The template parameter 'ElementData' in ElementCacheEntry "
                 "must be default constructible. ");
 
-  /** Constructs a new %ElementCacheEntry with default initialized data. */
+  /* Constructs a new %ElementCacheEntry with default initialized data. */
   ElementCacheEntry() {}
 
   ~ElementCacheEntry() = default;
@@ -30,12 +31,15 @@ class ElementCacheEntry {
 
   const ElementData& element_data() const { return element_data_; }
 
-  // TODO(xuchenhan-tri): Add interface for marking cache entries stale when
-  //  caching is in place.
+  bool is_stale() const { return is_stale_; }
+
+  void set_stale(bool stale) { is_stale_ = stale; }
 
  private:
   ElementData element_data_;
+  bool is_stale_{true};
 };
+}  // namespace internal
 }  // namespace fixed_fem
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/fixed_fem/dev/fem_state.h
+++ b/multibody/fixed_fem/dev/fem_state.h
@@ -83,6 +83,9 @@ class FemState {
   @throw std::exception if elements[i].element_index() != i for some `i` = 0,
   ..., `element.size()-1`. */
   void MakeElementData(const std::vector<Element>& elements) {
+    /* Note: the element data is stored in a simple bespoke cache (see
+     internal::ElementCacheEntry). The newly created cache entries are
+     initially stale. */
     element_cache_.clear();
     for (int i = 0; i < static_cast<int>(elements.size()); ++i) {
       if (elements[i].element_index() != ElementIndex(i)) {
@@ -105,6 +108,7 @@ class FemState {
   Eigen::conservativeResize</a>. */
   void Resize(int num_generalized_positions) {
     DRAKE_ASSERT(num_generalized_positions >= 0);
+    InvalidateAllCacheEntries();
     q_.conservativeResize(num_generalized_positions);
     if constexpr (ode_order() >= 1)
       qdot_.conservativeResize(num_generalized_positions);
@@ -130,37 +134,49 @@ class FemState {
   /** @name State setters.
    The size of the values provided must match the current size of the states.
    @{ */
-  void set_q(const Eigen::Ref<const VectorX<T>>& value) {
+  void SetQ(const Eigen::Ref<const VectorX<T>>& value) {
     DRAKE_THROW_UNLESS(value.size() == q_.size());
     mutable_q() = value;
   }
 
-  void set_qdot(const Eigen::Ref<const VectorX<T>>& value) {
+  void SetQdot(const Eigen::Ref<const VectorX<T>>& value) {
     DRAKE_THROW_UNLESS(ode_order() >= 1);
     DRAKE_THROW_UNLESS(value.size() == qdot_.size());
     mutable_qdot() = value;
   }
 
-  void set_qddot(const Eigen::Ref<const VectorX<T>>& value) {
+  void SetQddot(const Eigen::Ref<const VectorX<T>>& value) {
     DRAKE_THROW_UNLESS(ode_order() == 2);
     DRAKE_THROW_UNLESS(value.size() == qddot_.size());
     mutable_qddot() = value;
   }
   /** @} */
 
-  /** @name Mutable state getters.
+  /** @name (Advanced) Mutable state getters.
    The values of the states are mutable but the sizes of the states are not
-   allowed to change.
+   allowed to change. Calling these mutable getters will invalidate all cache
+   entries associated with `this` %FemState. Users should, however, take extreme
+   caution if they decide to hold on to the mutable reference. If the mutable
+   reference is used to update the state again *after* element_data() is called,
+   the state-dependent data stored will *not* be updated according to the most
+   up-to-date state, and element_data() may (and most likely *will*) provide
+   incorrect results. Therefore, users of these mutable getters are advised to
+   keep the scope in which they are used as small as possible.
    @{ */
-  Eigen::VectorBlock<VectorX<T>> mutable_q() { return q_.head(q_.size()); }
+  Eigen::VectorBlock<VectorX<T>> mutable_q() {
+    InvalidateAllCacheEntries();
+    return q_.head(q_.size());
+  }
 
   Eigen::VectorBlock<VectorX<T>> mutable_qdot() {
     DRAKE_THROW_UNLESS(ode_order() >= 1);
+    InvalidateAllCacheEntries();
     return qdot_.head(qdot_.size());
   }
 
   Eigen::VectorBlock<VectorX<T>> mutable_qddot() {
     DRAKE_THROW_UNLESS(ode_order() == 2);
+    InvalidateAllCacheEntries();
     return qddot_.head(qddot_.size());
   }
   /** @} */
@@ -170,11 +186,12 @@ class FemState {
       const Element& element) const {
     ElementIndex id = element.element_index();
     DRAKE_ASSERT(id.is_valid() && id < element_cache_size());
-    // TODO(xuchenhan-tri): Currently the data is always recomputed when this
-    //  method is invoked. Cache these data in the future.
     typename Element::Traits::Data& data =
         element_cache_[id].mutable_element_data();
-    data = element.ComputeData(*this);
+    if (element_cache_[id].is_stale()) {
+      data = element.ComputeData(*this);
+      element_cache_[id].set_stale(false);
+    }
     return data;
   }
 
@@ -187,6 +204,19 @@ class FemState {
   }
 
  private:
+  friend class FemStateTest;
+
+  // TODO(xuchenhan-tri): Currently, all cache entries are thrashed when *any*
+  //  state (q, qdot, or qddot) is changed. For many FEM models (e.g.
+  //  static/dynamic elasticity), there exist more fine-grained caching
+  //  mechanisms which may improve the cache efficiency.
+  /* Mark all cache entries associated with `this` FemState as stale. */
+  void InvalidateAllCacheEntries() {
+    for (auto& element_cache_entry : element_cache_) {
+      element_cache_entry.set_stale(true);
+    }
+  }
+
   /* Generalized node positions. */
   VectorX<T> q_{};
   /* Time derivatives of generalized node positions. */
@@ -194,7 +224,8 @@ class FemState {
   /* Time second derivatives of generalized node positions. */
   VectorX<T> qddot_{};
   /* Owned element cache entries. */
-  mutable std::vector<ElementCacheEntry<typename Element::Traits::Data>>
+  mutable std::vector<
+      internal::ElementCacheEntry<typename Element::Traits::Data>>
       element_cache_{};
 };
 }  // namespace fixed_fem

--- a/multibody/fixed_fem/dev/newmark_scheme.h
+++ b/multibody/fixed_fem/dev/newmark_scheme.h
@@ -6,7 +6,7 @@ namespace drake {
 namespace multibody {
 namespace fixed_fem {
 /** Implements the interface StateUpdater with Newmark-beta time integration
- scheme. Given the value for the current time step accleration `a`, the states
+ scheme. Given the value for the current time step acceleration `a`, the states
  are calculated from states from the previous time step according to the
  following equations:
 
@@ -53,9 +53,9 @@ class NewmarkScheme final : public StateUpdater<State> {
     const VectorX<T>& a = state->qddot();
     const VectorX<T>& v = state->qdot();
     const VectorX<T>& x = state->q();
-    state->set_qddot(a + dz);
-    state->set_qdot(v + dt_ * gamma_ * dz);
-    state->set_q(x + dt_ * dt_ * beta_ * dz);
+    state->SetQddot(a + dz);
+    state->SetQdot(v + dt_ * gamma_ * dz);
+    state->SetQ(x + dt_ * dt_ * beta_ * dz);
   }
 
   /* Implements StateUpdater::DoAdvanceOneTimeStep(). */
@@ -64,8 +64,8 @@ class NewmarkScheme final : public StateUpdater<State> {
     const VectorX<T>& vn = prev_state.qdot();
     const VectorX<T>& xn = prev_state.q();
     const VectorX<T>& a = state->qddot();
-    state->set_qdot(vn + dt_ * (gamma_ * a + (1.0 - gamma_) * an));
-    state->set_q(xn + dt_ * vn + dt_ * dt_ * (beta_ * a + (0.5 - beta_) * an));
+    state->SetQdot(vn + dt_ * (gamma_ * a + (1.0 - gamma_) * an));
+    state->SetQ(xn + dt_ * vn + dt_ * dt_ * (beta_ * a + (0.5 - beta_) * an));
   }
 
   double dt_{0};

--- a/multibody/fixed_fem/dev/test/dummy_element.h
+++ b/multibody/fixed_fem/dev/test/dummy_element.h
@@ -83,10 +83,23 @@ class DummyElement final
    access the private implementations of this class. */
   friend Base;
 
-  /* Implements FemElement::ComputeData(). */
+  /* Implements FemElement::ComputeData(). Returns a dummy data if `state` is
+    empty. Otherwise return the sum of the last entries in each state. */
   typename Traits::Data DoComputeData(
       const FemState<DummyElement>& state) const {
-    return dummy_data();
+    const int num_dofs = state.num_generalized_positions();
+    if (state.num_generalized_positions() == 0) {
+      return dummy_data();
+    }
+    typename Traits::Data data;
+    data.value = state.q()(num_dofs - 1);
+    if constexpr (OdeOrder >= 1) {
+      data.value += state.qdot()(num_dofs - 1);
+    }
+    if constexpr (OdeOrder == 2) {
+      data.value += state.qddot()(num_dofs - 1);
+    }
+    return data;
   }
 
   /* Implements FemElement::CalcResidual(). */

--- a/multibody/fixed_fem/dev/test/dynamic_elasticity_model_test.cc
+++ b/multibody/fixed_fem/dev/test/dynamic_elasticity_model_test.cc
@@ -90,7 +90,7 @@ class DynamicElasticityModelTest : public ::testing::Test {
         math::autoDiffToValueMatrix(deformed_state.qddot()) + perturbation();
     Vector<T, kNumDofs> perturbed_qddot_autodiff;
     math::initializeAutoDiff(perturbed_qddot, perturbed_qddot_autodiff);
-    deformed_state.set_qddot(perturbed_qddot_autodiff);
+    deformed_state.SetQddot(perturbed_qddot_autodiff);
     /* It's important to set up the `deformed_state` with `state_updater_` so
      that the derivatives such as dq/dqddot are set up. */
     state_updater_.AdvanceOneTimeStep(reference_state, &deformed_state);

--- a/multibody/fixed_fem/dev/test/elasticity_element_test.cc
+++ b/multibody/fixed_fem/dev/test/elasticity_element_test.cc
@@ -207,7 +207,7 @@ TEST_F(ElasticityElementTest, UndeformedState) {
   for (int i = 0; i < kNumNodes; ++i) {
     rigid_transformed_X.col(i) = transform * X.col(i);
   }
-  state.set_q(Eigen::Map<Vector<T, kNumDofs>>(rigid_transformed_X.data(),
+  state.SetQ(Eigen::Map<Vector<T, kNumDofs>>(rigid_transformed_X.data(),
                                               rigid_transformed_X.size()));
   VerifyEnergyAndForceAreZero(state);
 }
@@ -219,7 +219,7 @@ TEST_F(ElasticityElementTest, DeformedState) {
   /* Deform the element by scaling the initial position by a factor of 2. The
    resulting deformation gradient would be a diagonal matrix with 2 on the
    diagonals. The linear strain then would the identity matrix. */
-  state.set_q(state.q() * 2.0);
+  state.SetQ(state.q() * 2.0);
   const auto strain = Matrix3<double>::Identity();
   const double trace_strain = strain.trace();
 

--- a/multibody/fixed_fem/dev/test/fem_solver_test.cc
+++ b/multibody/fixed_fem/dev/test/fem_solver_test.cc
@@ -111,7 +111,7 @@ class FemSolverTest : public ::testing::Test {
   static State MakeArbitraryState() {
     State state = MakeReferenceState();
     const VectorX<T> q = MakeArbitraryPositions();
-    state.set_q(q);
+    state.SetQ(q);
     std::unique_ptr<DirichletBoundaryCondition<State>> bc = MakeCeilingBc();
     bc->ApplyBoundaryConditions(&state);
     return state;

--- a/multibody/fixed_fem/dev/test/fem_state_test.cc
+++ b/multibody/fixed_fem/dev/test/fem_state_test.cc
@@ -3,14 +3,15 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/common/unused.h"
 #include "drake/multibody/fixed_fem/dev/element_cache_entry.h"
 #include "drake/multibody/fixed_fem/dev/test/dummy_element.h"
 
 namespace drake {
 namespace multibody {
 namespace fixed_fem {
-namespace test {
-namespace {
+using test::DummyElement;
+using test::DummyElementTraits;
 static constexpr int kNumDofs = 3;
 static constexpr int kNumElements = 2;
 const std::vector<ElementIndex> kElementIndices{ElementIndex(0),
@@ -33,12 +34,34 @@ class FemStateTest : public ::testing::Test {
   static VectorX<double> q() { return Vector3<double>(0.1, 0.2, 0.3); }
   static VectorX<double> qdot() { return Vector3<double>(0.3, 0.4, 0.5); }
 
+  const internal::ElementCacheEntry<DummyElement<1>::Traits::Data>& cache_entry(
+      int i) const {
+    return state_.element_cache_[i];
+  }
+
+  /* For each cache entry,
+   1) Verify it is stale initially,
+   2) Verify calling element_data() provides the correct result, and
+   3) Verify it is not stale after the call to element_data(). */
+  void VerifyCacheEntries() const {
+    for (int i = 0; i < kNumElements; ++i) {
+      const auto& element_cache_entry = cache_entry(i);
+      EXPECT_TRUE(element_cache_entry.is_stale());
+      /* For DummyElement, the element data value is set to be the sum of the
+       last entries of all the states. */
+      EXPECT_EQ((state_.q().tail(1) + state_.qdot().tail(1))(0),
+                state_.element_data(elements_[i]).value);
+      EXPECT_FALSE(element_cache_entry.is_stale());
+    }
+  }
+
   // TODO(xuchenhan-tri): Test the other constructors of FemState.
   /* FemState under test. */
   FemState<DummyElement<1>> state_{q(), qdot()};
   std::vector<DummyElement<1>> elements_;
 };
 
+namespace {
 /* Verify setters and getters are working properly. */
 TEST_F(FemStateTest, GetStates) {
   EXPECT_EQ(state_.num_generalized_positions(), kNumDofs);
@@ -52,16 +75,16 @@ TEST_F(FemStateTest, GetStates) {
 }
 
 TEST_F(FemStateTest, SetStates) {
-  state_.set_qdot(3.14 * qdot());
-  state_.set_q(-1.23 * q());
+  state_.SetQdot(3.14 * qdot());
+  state_.SetQ(-1.23 * q());
   EXPECT_EQ(state_.qdot(), 3.14 * qdot());
   EXPECT_EQ(state_.q(), -1.23 * q());
   /* Setting values with incompatible sizes should throw. */
-  EXPECT_THROW(state_.set_qdot(VectorXd::Constant(1, 1.0)), std::exception);
-  EXPECT_THROW(state_.set_q(VectorXd::Constant(1, 1.0)), std::exception);
+  EXPECT_THROW(state_.SetQdot(VectorXd::Constant(1, 1.0)), std::exception);
+  EXPECT_THROW(state_.SetQ(VectorXd::Constant(1, 1.0)), std::exception);
   /* The dummy element has order 1 and does not have second derivatives of the
    generalized positions. */
-  EXPECT_THROW(state_.set_qddot(VectorXd::Constant(3, 1.0)), std::exception);
+  EXPECT_THROW(state_.SetQddot(VectorXd::Constant(3, 1.0)), std::exception);
 }
 
 /* Verify resizing does not thrash existing values. */
@@ -84,7 +107,7 @@ TEST_F(FemStateTest, ConservativeResize) {
 TEST_F(FemStateTest, ElementData) {
   EXPECT_EQ(state_.element_cache_size(), kNumElements);
   for (int i = 0; i < kNumElements; ++i) {
-    EXPECT_EQ(DummyElement<1>::dummy_data().value,
+    EXPECT_EQ(state_.q()(kNumDofs - 1) + state_.qdot()(kNumDofs - 1),
               state_.element_data(elements_[i]).value);
   }
 }
@@ -97,8 +120,34 @@ TEST_F(FemStateTest, MakeElementData) {
       "Input element entry at 0 has index 1 instead of 0. The entry with index "
       "i must be stored at position i.");
 }
+
+/* Tests that element data cache is invalidated when the state changes and that
+ the request for the cached data triggers appropriate recalculations. */
+TEST_F(FemStateTest, ElementCache) {
+  /* Verify that cache entries are intially invalid and becomes valid after the
+   request for data triggers computation. */
+  VerifyCacheEntries();
+
+  /* Verify that state setters thrash the cache entries and the cached
+   quantities are correctly recomputed. */
+  state_.SetQ(2 * q());
+  VerifyCacheEntries();
+  state_.SetQdot(2 * qdot());
+  VerifyCacheEntries();
+
+  /* Verify that mutable getters thrash the cache entries and the cached
+   quantities are correctly recomputed. */
+  Eigen::VectorBlock<VectorX<double>> qdot = state_.mutable_qdot();
+  unused(qdot);
+  VerifyCacheEntries();
+
+  /* Verify that resizing thrashes the cache entries and the cached
+   quantities are correctly recomputed. */
+  const int state_size = 1;
+  state_.Resize(state_size);
+  VerifyCacheEntries();
+}
 }  // namespace
-}  // namespace test
 }  // namespace fixed_fem
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/fixed_fem/dev/test/newmark_scheme_test.cc
+++ b/multibody/fixed_fem/dev/test/newmark_scheme_test.cc
@@ -60,7 +60,7 @@ TEST_F(NewmarkSchemeTest, AdvanceOneTimeStep) {
   FemState<DummyElement<2>> state_np1(state_0);
   const int kTimeSteps = 10;
   for (int i = 0; i < kTimeSteps; ++i) {
-    state_np1.set_qddot(state_n.qddot());
+    state_np1.SetQddot(state_n.qddot());
     newmark_scheme_.AdvanceOneTimeStep(state_n, &state_np1);
     state_n = state_np1;
   }

--- a/multibody/fixed_fem/dev/test/static_elasticity_model_test.cc
+++ b/multibody/fixed_fem/dev/test/static_elasticity_model_test.cc
@@ -75,7 +75,7 @@ class StaticElasticityModelTest : public ::testing::Test {
         math::autoDiffToValueMatrix(state.q()) + perturbation();
     Vector<T, kNumDofs> perturbed_q_autodiff;
     math::initializeAutoDiff(perturbed_q, perturbed_q_autodiff);
-    state.set_q(perturbed_q_autodiff);
+    state.SetQ(perturbed_q_autodiff);
     return state;
   }
 

--- a/multibody/fixed_fem/dev/zeroth_order_state_updater.h
+++ b/multibody/fixed_fem/dev/zeroth_order_state_updater.h
@@ -27,7 +27,7 @@ class ZerothOrderStateUpdater final : public StateUpdater<State> {
 
   /* Implements StateUpdater::DoUpdateState(). */
   void DoUpdateState(const VectorX<T>& dz, State* state) const final {
-    state->set_q(state->q() + dz);
+    state->SetQ(state->q() + dz);
   }
 };
 }  // namespace fixed_fem


### PR DESCRIPTION
- Create a staleness flag for each element cache entry that defaults to true. When the element data is requested, if the staleness flag is true, then recompute the element data and set the staleness flag to false; if the staleness flag is false, return the element data without recalculating.
- *Any* modification to the state sets the staleness flags of all element cache entry to true.
- Modify element data of DummyElement to be non-constant to facilitate testing.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14698)
<!-- Reviewable:end -->
