### PR TITLE
[doc] Remove example using RenderEngineOspray

### DIFF
--- a/doc/_pages/gallery.md
+++ b/doc/_pages/gallery.md
@@ -71,30 +71,6 @@ as described in
 
 *Source Code:* [https://github.com/DAIRLab/dairlib-public/tree/master/systems/trajectory_optimization](https://github.com/DAIRLab/dairlib-public/tree/master/systems/trajectory_optimization)
 
-# Perception
-
-Drake aims to have a wide suite of simulated sensors. As these tools
-expand, we'll include video highlighting their functionality.
-
-This video is a sneak preview of an RGB sensor model using an advanced
-illumination model provided by [OSPRay](https://www.ospray.org/). This video
-was created by inserting a virtual RGB camera into the simulation (at an
-arbitrary fixed position in the simulation's world frame) of the controlled
-[Kuka arm](https://github.com/RobotLocomotion/drake/tree/master/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place).
-The material properties are simple to highlight the impact of the lighting model.
-(October 2018)
-
-(Update 2020) The OSPRay-based renderer had an impoverished API and was little
-used. For maintenance reasons, it has been removed. If, in the future, users
-feel they'd like to have it back, please post an issue and we can investigate
-its restoration and completion.
-
-{% include video.html
-  url = "https://www.youtube.com/embed/UKxytyIJmq8"
-  full_width = true
-%}
-
-
 # Task and Motion Planning
 
 Caelan Garrett has examples using Drake in his STRIPStream/PDDLStream

--- a/doc/gallery.rst
+++ b/doc/gallery.rst
@@ -72,30 +72,6 @@ as described in
 
 *Source Code:* https://github.com/DAIRLab/dairlib-public/tree/master/systems/trajectory_optimization
 
-Perception
-==========
-
-Drake aims to have a wide suite of simulated sensors. As these tools
-expand, we'll include video highlighting their functionality.
-
-This video is a sneak preview of an RGB sensor model using an advanced
-illumination model provided by `OSPRay <https://www.ospray.org/>`_. This video
-was created by inserting a virtual RGB camera into the simulation (at an
-arbitrary fixed position in the simulation's world frame) of the controlled
-`Kuka arm <https://github.com/RobotLocomotion/drake/tree/master/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place>`_.
-The material properties are simple to highlight the impact of the lighting model.
-(October 2018)
-
-(Update 2020) The OSPRay-based renderer had an impoverished API and was little
-used. For maintenance reasons, it has been removed. If, in the future, users
-feel they'd like to have it back, please post an issue and we can investigate
-its restoration and completion.
-
-.. raw :: html
-
-  <iframe width="800" height="224" src="https://www.youtube.com/embed/UKxytyIJmq8" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
-
-
 Task and Motion Planning
 ========================
 


### PR DESCRIPTION
RenderEngineOspray had been removed in the past. It no longer makes sense
to have an example that advertises it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14716)
<!-- Reviewable:end -->
