### PR TITLE
Add missing tutorials to build file

### DIFF
--- a/tutorials/BUILD.bazel
+++ b/tutorials/BUILD.bazel
@@ -37,6 +37,14 @@ drake_jupyter_py_binary(
 )
 
 drake_jupyter_py_binary(
+    name = "quadratic_program",
+    add_test_rule = 1,
+    deps = [
+        "//bindings/pydrake",
+    ],
+)
+
+drake_jupyter_py_binary(
     name = "dynamical_systems",
     add_test_rule = 1,
     deps = [
@@ -70,6 +78,14 @@ drake_jupyter_py_binary(
 
 drake_jupyter_py_binary(
     name = "sum_of_squares_optimization",
+    add_test_rule = 1,
+    deps = [
+        "//bindings/pydrake",
+    ],
+)
+
+drake_jupyter_py_binary(
+    name = "updating_costs_and_constraints",
     add_test_rule = 1,
     deps = [
         "//bindings/pydrake",

--- a/tutorials/mathematical_program_multibody_plant.ipynb
+++ b/tutorials/mathematical_program_multibody_plant.ipynb
@@ -106,7 +106,7 @@
     "## Writing our Custom Evaluator\n",
     "\n",
     "Our evaluator is implemented using the custom evaluator\n",
-    "`link_7_distance_to_target`, since the its functionality is not already\n",
+    "`link_7_distance_to_target`, since its functionality is not already\n",
     "handled by existing classes in the `inverse_kinematics` submodule.\n",
     "\n",
     "Note that in order to write a custom evaluator in Python, we must explicitly\n",

--- a/tutorials/nonlinear_program.ipynb
+++ b/tutorials/nonlinear_program.ipynb
@@ -21,7 +21,7 @@
     "An NLP is typically solved through gradient-based optimization (like gradient descent, SQP, interior point methods, etc). These methods rely on the gradient of the cost/constraints $\\partial f/\\partial x, \\partial g_i/\\partial x$. pydrake can compute the gradient of many functions through automatic differentiation, so very often the user doesn't need to manually provide the gradient.\n",
     "\n",
     "## Setting the objective\n",
-    "The user can call `AddCost` function to add a nonlinear cost into the program. Note that the user can call `AddCost` repeatedly, and the program will evaluatate the *summation* of each individual cost as the total cost."
+    "The user can call `AddCost` function to add a nonlinear cost into the program. Note that the user can call `AddCost` repeatedly, and the program will evaluate the *summation* of each individual cost as the total cost."
    ]
   },
   {

--- a/tutorials/updating_costs_and_constraints.ipynb
+++ b/tutorials/updating_costs_and_constraints.ipynb
@@ -111,13 +111,13 @@
     "x = prog.NewContinuousVariables(2)\n",
     "linear_constraint = prog.AddLinearConstraint(3 * x[0] + 4 * x[1] <= 5)\n",
     "linear_eq_constraint = prog.AddLinearConstraint(5 * x[0] + 2 * x[1] == 3)\n",
-    "print(f\"original linear constraint： {linear_constraint}\")\n",
+    "print(f\"original linear constraint: {linear_constraint}\")\n",
     "linear_constraint.evaluator().UpdateCoefficients(new_A = [[1, 3]], new_lb=[-2], new_ub=[3])\n",
-    "print(f\"updated linear constraint： {linear_constraint}\")\n",
+    "print(f\"updated linear constraint: {linear_constraint}\")\n",
     "\n",
-    "print(f\"original linear equality constraint： {linear_eq_constraint}\")\n",
+    "print(f\"original linear equality constraint: {linear_eq_constraint}\")\n",
     "linear_eq_constraint.evaluator().UpdateCoefficients(Aeq=[[3, 4]], beq=[2])\n",
-    "print(f\"updated linear equality constraint： {linear_eq_constraint}\")"
+    "print(f\"updated linear equality constraint: {linear_eq_constraint}\")"
    ]
   }
  ],


### PR DESCRIPTION
While going through tutorials, I noticed that the `quadratic_program` and `updating_costs_and_constraints` tutorials were missing from the bazel build file.  I couldn't find any obvious reason why these two are missing so supposed I should add them.

Also fix spelling.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14722)
<!-- Reviewable:end -->
