### PR TITLE
[FEM] Improve API for FemStateBase

### DIFF
--- a/multibody/fixed_fem/dev/BUILD.bazel
+++ b/multibody/fixed_fem/dev/BUILD.bazel
@@ -12,29 +12,6 @@ package(
 )
 
 drake_cc_library(
-    name = "fem_model_base",
-    srcs = [
-        "fem_model_base.cc",
-    ],
-    hdrs = [
-        "fem_model_base.h",
-    ],
-    deps = [
-        ":dirichlet_boundary_condition",
-        ":fem_state_base",
-        "//common:default_scalars",
-        "//common:essential",
-    ],
-)
-
-drake_cc_library(
-    name = "fem_state_base",
-    hdrs = [
-        "fem_state_base.h",
-    ],
-)
-
-drake_cc_library(
     name = "constitutive_model",
     hdrs = [
         "constitutive_model.h",
@@ -232,6 +209,22 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "fem_model_base",
+    srcs = [
+        "fem_model_base.cc",
+    ],
+    hdrs = [
+        "fem_model_base.h",
+    ],
+    deps = [
+        ":dirichlet_boundary_condition",
+        ":fem_state_base",
+        "//common:default_scalars",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
     name = "fem_solver",
     hdrs = [
         "fem_solver.h",
@@ -252,10 +245,23 @@ drake_cc_library(
         "fem_state.h",
     ],
     deps = [
-        ":dirichlet_boundary_condition",
         ":element_cache_entry",
         ":fem_state_base",
         "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "fem_state_base",
+    srcs = [
+        "fem_state_base.cc",
+    ],
+    hdrs = [
+        "fem_state_base.h",
+    ],
+    deps = [
+        ":dirichlet_boundary_condition",
+        "//common:default_scalars",
     ],
 )
 

--- a/multibody/fixed_fem/dev/fem_model.h
+++ b/multibody/fixed_fem/dev/fem_model.h
@@ -107,7 +107,7 @@ class FemModel : public FemModelBase<typename Element::Traits::T> {
 
   /* Implements FemModelBase::MakeFemStateBase() by simply hiding the
    result from MakeFemState() behind a unique_ptr to FemStateBase. */
-  std::unique_ptr<FemStateBase<T>> MakeFemStateBase() const final {
+  std::unique_ptr<FemStateBase<T>> DoMakeFemStateBase() const final {
     return std::make_unique<FemState<Element>>(MakeFemState());
   }
 

--- a/multibody/fixed_fem/dev/fem_model_base.cc
+++ b/multibody/fixed_fem/dev/fem_model_base.cc
@@ -4,6 +4,11 @@ namespace drake {
 namespace multibody {
 namespace fixed_fem {
 template <typename T>
+std::unique_ptr<FemStateBase<T>> FemModelBase<T>::MakeFemStateBase() const {
+  return DoMakeFemStateBase();
+}
+
+template <typename T>
 void FemModelBase<T>::CalcResidual(const FemStateBase<T>& state,
                                    EigenPtr<VectorX<T>> residual) const {
   DRAKE_DEMAND(residual != nullptr);
@@ -58,11 +63,11 @@ void FemModelBase<T>::AdvanceOneTimeStep(const FemStateBase<T>& prev_state,
 }
 
 template <typename T>
-void FemModelBase<T>::ApplyBoundaryConditions(FemStateBase<T>* state) const {
+void FemModelBase<T>::ApplyBoundaryCondition(FemStateBase<T>* state) const {
   DRAKE_DEMAND(state != nullptr);
   ThrowIfModelStateIncompatible(__func__, *state);
   if (dirichlet_bc_ != nullptr) {
-    state->ApplyBoundaryConditions(*dirichlet_bc_);
+    state->ApplyBoundaryCondition(*dirichlet_bc_);
   }
 }
 }  // namespace fixed_fem

--- a/multibody/fixed_fem/dev/fem_model_base.h
+++ b/multibody/fixed_fem/dev/fem_model_base.h
@@ -70,7 +70,7 @@ class FemModelBase {
    with the concrete FemModel type of `this` %FemModelBase. The new state's
    number of generalized positions is equal to `num_dofs()`. The new state's
    element data is constructed using the FemElements owned by this %FemModel. */
-  virtual std::unique_ptr<FemStateBase<T>> MakeFemStateBase() const = 0;
+  std::unique_ptr<FemStateBase<T>> MakeFemStateBase() const;
 
   /** Calculates the residual at the given FemStateBase. Suppose the linear
   or nonlinear system generated from the FEM discretization is G(z) = 0, then
@@ -136,7 +136,7 @@ class FemModelBase {
   /* Apply boundary condition set for this %FemModel to the input `state`. No-op
    if no boundary condition is set.
    @pre state != nullptr. */
-  void ApplyBoundaryConditions(FemStateBase<T>* state) const;
+  void ApplyBoundaryCondition(FemStateBase<T>* state) const;
 
   /** Takes ownership of the given Dirichlet boundary condition and apply it
    when the model is evaluated. */
@@ -152,6 +152,10 @@ class FemModelBase {
       const char* func, const FemStateBase<T>& state_base) const = 0;
 
  protected:
+  /** Derived classes must override this method to provide an implementation for
+    the NVI MakeFemStateBase(). */
+  virtual std::unique_ptr<FemStateBase<T>> DoMakeFemStateBase() const = 0;
+
   /** Derived classes must override this method to provide an implementation
    for the NVI CalcResidual(). The input `state` is guaranteed to be
    compatible with `this` FEM model. */

--- a/multibody/fixed_fem/dev/fem_solver.h
+++ b/multibody/fixed_fem/dev/fem_solver.h
@@ -140,7 +140,7 @@ class FemSolver {
     /* Make sure the scratch quantities are of the correct size and apply BC if
      one is specified. */
     Resize();
-    model_->ApplyBoundaryConditions(state);
+    model_->ApplyBoundaryCondition(state);
     model_->CalcResidual(*state, &b_);
     int iter = 0;
     /* Newton-Raphson iterations. We iterate until any of the following is true:

--- a/multibody/fixed_fem/dev/fem_state.h
+++ b/multibody/fixed_fem/dev/fem_state.h
@@ -12,9 +12,8 @@ namespace multibody {
 namespace fixed_fem {
 
 /** %FemState implements FemStateBase for a particular type of FemElement.
- Templated on the type of FemElement, FemState knows its topological properties
- such as the natural and spatial dimension as well as its physical properties
- such as its ode_order() at compile time. It also stores the per-element
+ It is templated on the concrete FemElement type in order to allow compile time
+ optimizations based on fixed sizes. It also stores the per-element
  state-dependent quantities for its corresponding elements (see
  ElementCacheEntry).
  @tparam Element The type of FemElement that consumes this %FemState. This
@@ -40,7 +39,9 @@ class FemState : public FemStateBase<typename Element::T> {
    @param[in] q    The prescribed generalized positions.
    @pre ode_order() == 0. */
   explicit FemState(const Eigen::Ref<const VectorX<T>>& q)
-      : FemStateBase<T>(q) {}
+      : FemStateBase<T>(q) {
+    DRAKE_THROW_UNLESS(ode_order() == 0);
+  }
 
   /** Constructs an %FemState of a first order equation with prescribed
    generalized positions and their time derivatives.
@@ -52,7 +53,6 @@ class FemState : public FemStateBase<typename Element::T> {
            const Eigen::Ref<const VectorX<T>>& qdot)
       : FemStateBase<T>(q, qdot) {
     DRAKE_THROW_UNLESS(ode_order() == 1);
-    DRAKE_THROW_UNLESS(q.size() == qdot.size());
   }
 
   /** Constructs an %FemState of a second order equation with prescribed
@@ -69,8 +69,6 @@ class FemState : public FemStateBase<typename Element::T> {
            const Eigen::Ref<const VectorX<T>>& qddot)
       : FemStateBase<T>(q, qdot, qddot) {
     DRAKE_THROW_UNLESS(ode_order() == 2);
-    DRAKE_THROW_UNLESS(q.size() == qdot.size());
-    DRAKE_THROW_UNLESS(q.size() == qddot.size());
   }
 
   /** Creates the per-element state-dependent data for the given `elements`. The

--- a/multibody/fixed_fem/dev/fem_state.h
+++ b/multibody/fixed_fem/dev/fem_state.h
@@ -1,11 +1,8 @@
 #pragma once
 
-#include <memory>
-#include <utility>
 #include <vector>
 
 #include "drake/common/eigen_types.h"
-#include "drake/multibody/fixed_fem/dev/dirichlet_boundary_condition.h"
 #include "drake/multibody/fixed_fem/dev/element_cache_entry.h"
 #include "drake/multibody/fixed_fem/dev/fem_indexes.h"
 #include "drake/multibody/fixed_fem/dev/fem_state_base.h"
@@ -14,11 +11,12 @@ namespace drake {
 namespace multibody {
 namespace fixed_fem {
 
-/** Stores the fem model state and per-element state-dependent quantities.The
- states include the generalized positions associated with each node, `q`, and
- optionally, their first and second time derivatives, `qdot` and `qddot`.
- %FemState also stores the per-element state-dependent quantities for its
- corresponding elements (see ElementCacheEntry).
+/** %FemState implements FemStateBase for a particular type of FemElement.
+ Templated on the type of FemElement, FemState knows its topological properties
+ such as the natural and spatial dimension as well as its physical properties
+ such as its ode_order() at compile time. It also stores the per-element
+ state-dependent quantities for its corresponding elements (see
+ ElementCacheEntry).
  @tparam Element The type of FemElement that consumes this %FemState. This
  template parameter provides the scalar type, the type of per-element data
  this %FemState stores and the order of the ODE after FEM spatial
@@ -41,11 +39,8 @@ class FemState : public FemStateBase<typename Element::T> {
    generalized positions.
    @param[in] q    The prescribed generalized positions.
    @pre ode_order() == 0. */
-  explicit FemState(const Eigen::Ref<const VectorX<T>>& q) : q_(q) {
-    DRAKE_THROW_UNLESS(ode_order() == 0);
-    DRAKE_ASSERT(qdot_.size() == 0);
-    DRAKE_ASSERT(qddot_.size() == 0);
-  }
+  explicit FemState(const Eigen::Ref<const VectorX<T>>& q)
+      : FemStateBase<T>(q) {}
 
   /** Constructs an %FemState of a first order equation with prescribed
    generalized positions and their time derivatives.
@@ -55,10 +50,9 @@ class FemState : public FemStateBase<typename Element::T> {
    @pre q.size() == qdot.size(). */
   FemState(const Eigen::Ref<const VectorX<T>>& q,
            const Eigen::Ref<const VectorX<T>>& qdot)
-      : q_(q), qdot_(qdot) {
+      : FemStateBase<T>(q, qdot) {
     DRAKE_THROW_UNLESS(ode_order() == 1);
-    DRAKE_THROW_UNLESS(q_.size() == qdot_.size());
-    DRAKE_ASSERT(qddot_.size() == 0);
+    DRAKE_THROW_UNLESS(q.size() == qdot.size());
   }
 
   /** Constructs an %FemState of a second order equation with prescribed
@@ -73,10 +67,10 @@ class FemState : public FemStateBase<typename Element::T> {
   FemState(const Eigen::Ref<const VectorX<T>>& q,
            const Eigen::Ref<const VectorX<T>>& qdot,
            const Eigen::Ref<const VectorX<T>>& qddot)
-      : q_(q), qdot_(qdot), qddot_(qddot) {
+      : FemStateBase<T>(q, qdot, qddot) {
     DRAKE_THROW_UNLESS(ode_order() == 2);
-    DRAKE_THROW_UNLESS(q_.size() == qdot_.size());
-    DRAKE_THROW_UNLESS(q_.size() == qddot_.size());
+    DRAKE_THROW_UNLESS(q.size() == qdot.size());
+    DRAKE_THROW_UNLESS(q.size() == qddot.size());
   }
 
   /** Creates the per-element state-dependent data for the given `elements`. The
@@ -102,87 +96,7 @@ class FemState : public FemStateBase<typename Element::T> {
     element_cache_.resize(elements.size());
   }
 
-  int num_generalized_positions() const final { return q_.size(); }
-
   int element_cache_size() const { return element_cache_.size(); }
-  /** `q`, `qdot`, and `qddot` are resized (if they exist) with the semantics
-  outlined in <a
-  href="https://eigen.tuxfamily.org/dox/classEigen_1_1PlainObjectBase.html#a78a42a7c0be768374781f67f40c9ab0d">
-  Eigen::conservativeResize</a>. */
-  void Resize(int num_generalized_positions) {
-    DRAKE_ASSERT(num_generalized_positions >= 0);
-    InvalidateAllCacheEntries();
-    q_.conservativeResize(num_generalized_positions);
-    if constexpr (ode_order() >= 1)
-      qdot_.conservativeResize(num_generalized_positions);
-    if constexpr (ode_order() == 2)
-      qddot_.conservativeResize(num_generalized_positions);
-  }
-
-  /** @name State getters.
-   @{ */
-  const VectorX<T>& q() const { return q_; }
-
-  const VectorX<T>& qdot() const {
-    DRAKE_THROW_UNLESS(ode_order() >= 1);
-    return qdot_;
-  }
-
-  const VectorX<T>& qddot() const {
-    DRAKE_THROW_UNLESS(ode_order() == 2);
-    return qddot_;
-  }
-  /** @} */
-
-  /** @name State setters.
-   The size of the values provided must match the current size of the states.
-   @{ */
-  void SetQ(const Eigen::Ref<const VectorX<T>>& value) {
-    DRAKE_THROW_UNLESS(value.size() == q_.size());
-    mutable_q() = value;
-  }
-
-  void SetQdot(const Eigen::Ref<const VectorX<T>>& value) {
-    DRAKE_THROW_UNLESS(ode_order() >= 1);
-    DRAKE_THROW_UNLESS(value.size() == qdot_.size());
-    mutable_qdot() = value;
-  }
-
-  void SetQddot(const Eigen::Ref<const VectorX<T>>& value) {
-    DRAKE_THROW_UNLESS(ode_order() == 2);
-    DRAKE_THROW_UNLESS(value.size() == qddot_.size());
-    mutable_qddot() = value;
-  }
-  /** @} */
-
-  /** @name (Advanced) Mutable state getters.
-   The values of the states are mutable but the sizes of the states are not
-   allowed to change. Calling these mutable getters will invalidate all cache
-   entries associated with `this` %FemState. Users should, however, take extreme
-   caution if they decide to hold on to the mutable reference. If the mutable
-   reference is used to update the state again *after* element_data() is called,
-   the state-dependent data stored will *not* be updated according to the most
-   up-to-date state, and element_data() may (and most likely *will*) provide
-   incorrect results. Therefore, users of these mutable getters are advised to
-   keep the scope in which they are used as small as possible.
-   @{ */
-  Eigen::VectorBlock<VectorX<T>> mutable_q() {
-    InvalidateAllCacheEntries();
-    return q_.head(q_.size());
-  }
-
-  Eigen::VectorBlock<VectorX<T>> mutable_qdot() {
-    DRAKE_THROW_UNLESS(ode_order() >= 1);
-    InvalidateAllCacheEntries();
-    return qdot_.head(qdot_.size());
-  }
-
-  Eigen::VectorBlock<VectorX<T>> mutable_qddot() {
-    DRAKE_THROW_UNLESS(ode_order() == 2);
-    InvalidateAllCacheEntries();
-    return qddot_.head(qddot_.size());
-  }
-  /** @} */
 
   /** Getter for element state-dependpent quantities. */
   const typename Element::Traits::Data& element_data(
@@ -198,33 +112,6 @@ class FemState : public FemStateBase<typename Element::T> {
     return data;
   }
 
-  /** Calculates the norm of the state with the highest order. */
-  T HighestOrderStateNorm() const final {
-    if constexpr (ode_order() == 0) return q_.norm();
-    if constexpr (ode_order() == 1) return qdot_.norm();
-    if constexpr (ode_order() == 2) return qddot_.norm();
-    DRAKE_UNREACHABLE();
-  }
-
-  /* Implements FemStateBase::ApplyBoundaryConditions(). */
-  void ApplyBoundaryConditions(const DirichletBoundaryCondition<T>& bc) final {
-    const auto& bcs = bc.get_bcs();
-    if (bcs.size() == 0) {
-      return;
-    }
-    bc.VerifyBcIndexes(num_generalized_positions());
-    /* Write the BC to the mutable state. */
-    for (const auto& [dof_index, boundary_state] : bcs) {
-      q_(dof_index) = boundary_state(0);
-      if constexpr (ode_order() >= 1) {
-        qdot_(dof_index) = boundary_state(1);
-      }
-      if constexpr (ode_order() == 2) {
-        qddot_(dof_index) = boundary_state(2);
-      }
-    }
-  }
-
  private:
   friend class FemStateTest;
 
@@ -233,18 +120,12 @@ class FemState : public FemStateBase<typename Element::T> {
   //  static/dynamic elasticity), there exist more fine-grained caching
   //  mechanisms which may improve the cache efficiency.
   /* Mark all cache entries associated with `this` FemState as stale. */
-  void InvalidateAllCacheEntries() {
+  void InvalidateAllCacheEntries() final {
     for (auto& element_cache_entry : element_cache_) {
       element_cache_entry.set_stale(true);
     }
   }
 
-  /* Generalized node positions. */
-  VectorX<T> q_{};
-  /* Time derivatives of generalized node positions. */
-  VectorX<T> qdot_{};
-  /* Time second derivatives of generalized node positions. */
-  VectorX<T> qddot_{};
   /* Owned element cache entries. */
   mutable std::vector<
       internal::ElementCacheEntry<typename Element::Traits::Data>>

--- a/multibody/fixed_fem/dev/fem_state_base.cc
+++ b/multibody/fixed_fem/dev/fem_state_base.cc
@@ -1,0 +1,63 @@
+#include "drake/multibody/fixed_fem/dev/fem_state_base.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+template <typename T>
+void FemStateBase<T>::Resize(int num_generalized_positions) {
+  DRAKE_ASSERT(num_generalized_positions >= 0);
+  InvalidateAllCacheEntries();
+  q_.conservativeResize(num_generalized_positions);
+  if (ode_order() >= 1)
+    qdot_.conservativeResize(num_generalized_positions);
+  if (ode_order() == 2)
+    qddot_.conservativeResize(num_generalized_positions);
+}
+
+template <typename T>
+void FemStateBase<T>::SetQ(const Eigen::Ref<const VectorX<T>>& value) {
+  DRAKE_THROW_UNLESS(value.size() == q_.size());
+  InvalidateAllCacheEntries();
+  q_ = value;
+}
+
+template <typename T>
+void FemStateBase<T>::SetQdot(const Eigen::Ref<const VectorX<T>>& value) {
+  DRAKE_THROW_UNLESS(ode_order() >= 1);
+  DRAKE_THROW_UNLESS(value.size() == qdot_.size());
+  InvalidateAllCacheEntries();
+  qdot_ = value;
+}
+
+template <typename T>
+void FemStateBase<T>::SetQddot(const Eigen::Ref<const VectorX<T>>& value) {
+  DRAKE_THROW_UNLESS(ode_order() == 2);
+  DRAKE_THROW_UNLESS(value.size() == qddot_.size());
+  InvalidateAllCacheEntries();
+  qddot_ = value;
+}
+
+template <typename T>
+void FemStateBase<T>::ApplyBoundaryCondition(
+    const DirichletBoundaryCondition<T>& bc) {
+  const auto& bcs = bc.get_bcs();
+  if (bcs.size() == 0) {
+    return;
+  }
+  bc.VerifyBcIndexes(this->num_generalized_positions());
+  /* Write the BC to the mutable state. */
+  for (const auto& [dof_index, boundary_state] : bcs) {
+    q_(dof_index) = boundary_state(0);
+    if (ode_order() >= 1) {
+      qdot_(dof_index) = boundary_state(1);
+    }
+    if (ode_order() == 2) {
+      qddot_(dof_index) = boundary_state(2);
+    }
+  }
+}
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fixed_fem::FemStateBase);

--- a/multibody/fixed_fem/dev/fem_state_base.cc
+++ b/multibody/fixed_fem/dev/fem_state_base.cc
@@ -4,17 +4,6 @@ namespace drake {
 namespace multibody {
 namespace fixed_fem {
 template <typename T>
-void FemStateBase<T>::Resize(int num_generalized_positions) {
-  DRAKE_ASSERT(num_generalized_positions >= 0);
-  InvalidateAllCacheEntries();
-  q_.conservativeResize(num_generalized_positions);
-  if (ode_order() >= 1)
-    qdot_.conservativeResize(num_generalized_positions);
-  if (ode_order() == 2)
-    qddot_.conservativeResize(num_generalized_positions);
-}
-
-template <typename T>
 void FemStateBase<T>::SetQ(const Eigen::Ref<const VectorX<T>>& value) {
   DRAKE_THROW_UNLESS(value.size() == q_.size());
   InvalidateAllCacheEntries();

--- a/multibody/fixed_fem/dev/fem_state_base.h
+++ b/multibody/fixed_fem/dev/fem_state_base.h
@@ -19,12 +19,6 @@ class FemStateBase {
  public:
   virtual ~FemStateBase() = default;
 
-  /** Resize `this` state to the given `num_generalized_positions`. `q`, `qdot`,
-  and `qddot` are resized (if they exist) with the semantics outlined in <a
-  href="https://eigen.tuxfamily.org/dox/classEigen_1_1PlainObjectBase.html#a78a42a7c0be768374781f67f40c9ab0d">
-  Eigen::conservativeResize</a>. */
-  void Resize(int num_generalized_positions);
-
   /** @name State getters. Throw an exception if the state doesn't exist.
    @{ */
   const VectorX<T>& q() const { return q_; }

--- a/multibody/fixed_fem/dev/fem_state_base.h
+++ b/multibody/fixed_fem/dev/fem_state_base.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "drake/common/default_scalars.h"
+#include "drake/multibody/fixed_fem/dev/dirichlet_boundary_condition.h"
+
 namespace drake {
 namespace multibody {
 namespace fixed_fem {
@@ -7,19 +10,66 @@ namespace fixed_fem {
 template <typename T>
 class DirichletBoundaryCondition;
 
-/** An abstract base class for FemState that hides the templated Element type.
- See FemState for more information. */
+/** An abstract state class that stores the fem states. The states include the
+ generalized positions associated with each node, `q`, and optionally, their
+ first and second time derivatives, `qdot` and `qddot`.
+ @tparam_nonsymbolic_scalar T. */
 template <typename T>
 class FemStateBase {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(FemStateBase);
-  FemStateBase() = default;
   virtual ~FemStateBase() = default;
 
-  /** Calculates the norm of the state with the highest order. */
-  virtual T HighestOrderStateNorm() const = 0;
+  /** Resize `this` state to the given `num_generalized_positions`. `q`, `qdot`,
+  and `qddot` are resized (if they exist) with the semantics outlined in <a
+  href="https://eigen.tuxfamily.org/dox/classEigen_1_1PlainObjectBase.html#a78a42a7c0be768374781f67f40c9ab0d">
+  Eigen::conservativeResize</a>. */
+  void Resize(int num_generalized_positions);
 
-  virtual int num_generalized_positions() const = 0;
+  /** @name State getters. Throw an exception if the state doesn't exist.
+   @{ */
+  const VectorX<T>& q() const { return q_; }
+
+  const VectorX<T>& qdot() const {
+    DRAKE_THROW_UNLESS(ode_order() >= 1);
+    return qdot_;
+  }
+
+  const VectorX<T>& qddot() const {
+    DRAKE_THROW_UNLESS(ode_order() == 2);
+    return qddot_;
+  }
+  /** @} */
+
+  /** @name State setters.
+   The size of the values provided must match the current size of the states.
+   Throw an exception otherwise. Throw an exception if the state being set does
+   not exist.
+   @{ */
+  void SetQ(const Eigen::Ref<const VectorX<T>>& value);
+
+  void SetQdot(const Eigen::Ref<const VectorX<T>>& value);
+
+  void SetQddot(const Eigen::Ref<const VectorX<T>>& value);
+  /** @} */
+
+  // TODO(xuchenhan-tri): Change the API to calculate the norm of the unknown
+  //  instead.
+  /** Calculates the norm of the state with the highest order. */
+  T HighestOrderStateNorm() const { return get_highest_order_state().norm(); }
+
+  // TODO(xuchenhan-tri): Change the API to get the the unknown state
+  //  instead.
+  const VectorX<T>& get_highest_order_state() const {
+    if (ode_order() == 0) return q_;
+    if (ode_order() == 1) return qdot_;
+    if (ode_order() == 2) return qddot_;
+    DRAKE_UNREACHABLE();
+  }
+
+  int num_generalized_positions() const { return q_.size(); }
+
+  /** The order of the ODE problem after FEM spatial discretization. */
+  int ode_order() const { return ode_order_; }
 
   // TODO(xuchenhan-tri): Consider whether this method should belong in
   //  DirichletBoundaryCondition along with the methods that apply the BC to
@@ -29,12 +79,64 @@ class FemStateBase {
    @throw std::exception if the any of the indexes of the dofs under the
    boundary condition specified by the given DirichletBoundaryCondition does
    not exist in `this` FEM state`. */
-  virtual void ApplyBoundaryConditions(
-      const DirichletBoundaryCondition<T>& bc) = 0;
+  void ApplyBoundaryCondition(const DirichletBoundaryCondition<T>& bc);
 
-  // TODO(xuchenhan-tri): Expose more public methods in FemState in
-  //  FemStateBase as needed.
+ protected:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(FemStateBase);
+
+  /** Constructs an %FemStateBase of a zero-th order equation with prescribed
+   generalized positions.
+   @param[in] q    The prescribed generalized positions. */
+  explicit FemStateBase(const Eigen::Ref<const VectorX<T>>& q)
+      : ode_order_(0), q_(q) {
+    DRAKE_DEMAND(qdot_.size() == 0);
+    DRAKE_DEMAND(qddot_.size() == 0);
+  }
+
+  /** Constructs an %FemStateBase of a first order equation with prescribed
+   generalized positions and their time derivatives.
+   @param[in] q    The prescribed generalized positions.
+   @param[in] qdot    The prescribed time derivatives of generalized positions.
+   @pre q.size() == qdot.size(). */
+  FemStateBase(const Eigen::Ref<const VectorX<T>>& q,
+               const Eigen::Ref<const VectorX<T>>& qdot)
+      : ode_order_(1), q_(q), qdot_(qdot) {
+    DRAKE_DEMAND(q_.size() == qdot_.size());
+    DRAKE_DEMAND(qddot_.size() == 0);
+  }
+
+  /** Constructs an %FemStateBase of a second order equation with prescribed
+   generalized positions and their first and second order time derivatives.
+   @param[in] q    The prescribed generalized positions.
+   @param[in] qdot    The prescribed time derivatives of generalized positions.
+   @param[in] qddot    The prescribed time second derivatives of generalized
+   positions.
+   @pre q.size() == qdot.size().
+   @pre q.size() == qddot.size(). */
+  FemStateBase(const Eigen::Ref<const VectorX<T>>& q,
+               const Eigen::Ref<const VectorX<T>>& qdot,
+               const Eigen::Ref<const VectorX<T>>& qddot)
+      : ode_order_(2), q_(q), qdot_(qdot), qddot_(qddot) {
+    DRAKE_DEMAND(q_.size() == qdot_.size());
+    DRAKE_DEMAND(q_.size() == qddot_.size());
+  }
+
+ private:
+  /* Invalidate state-dependent quantities. Should be called on state changes.
+   */
+  virtual void InvalidateAllCacheEntries() = 0;
+
+  /* The order of ODE arising from the discretized FEM model. */
+  int ode_order_{-1};
+  /* Generalized node positions. */
+  VectorX<T> q_{};
+  /* Time derivatives of generalized node positions. */
+  VectorX<T> qdot_{};
+  /* Time second derivatives of generalized node positions. */
+  VectorX<T> qddot_{};
 };
 }  // namespace fixed_fem
 }  // namespace multibody
 }  // namespace drake
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fixed_fem::FemStateBase);

--- a/multibody/fixed_fem/dev/test/dirichlet_boundary_condition_test.cc
+++ b/multibody/fixed_fem/dev/test/dirichlet_boundary_condition_test.cc
@@ -61,7 +61,7 @@ class DirichletBoundaryConditionTest : public ::testing::Test {
  a given state. */
 TEST_F(DirichletBoundaryConditionTest, ApplyBcToState) {
   State s = MakeState();
-  s.ApplyBoundaryConditions(bc_);
+  s.ApplyBoundaryCondition(bc_);
   EXPECT_TRUE(CompareMatrices(s.q(), Vector<double, kNumDofs>{3, 0.2, 1, 0.4}));
   EXPECT_TRUE(
       CompareMatrices(s.qdot(), Vector<double, kNumDofs>{2, 0.6, 0, 0.8}));
@@ -100,7 +100,7 @@ TEST_F(DirichletBoundaryConditionTest, OutOfBound) {
   bc_.AddBoundaryCondition(DofIndex(4), Vector<double, kOdeOrder + 1>(3, 4));
   State state = MakeState();
   DRAKE_EXPECT_THROWS_MESSAGE(
-    state.ApplyBoundaryConditions(bc_), std::exception,
+    state.ApplyBoundaryCondition(bc_), std::exception,
           "An index of the dirichlet boundary condition is out of the range.");
   VectorXd b = MakeResidual();
   DRAKE_EXPECT_THROWS_MESSAGE(

--- a/multibody/fixed_fem/dev/test/fem_solver_test.cc
+++ b/multibody/fixed_fem/dev/test/fem_solver_test.cc
@@ -113,7 +113,7 @@ class FemSolverTest : public ::testing::Test {
     const VectorX<T> q = MakeArbitraryPositions();
     state.SetQ(q);
     std::unique_ptr<DirichletBoundaryCondition<T>> bc = MakeCeilingBc();
-    state.ApplyBoundaryConditions(*bc);
+    state.ApplyBoundaryCondition(*bc);
     return state;
   }
 

--- a/multibody/fixed_fem/dev/test/fem_state_test.cc
+++ b/multibody/fixed_fem/dev/test/fem_state_test.cc
@@ -86,22 +86,6 @@ TEST_F(FemStateTest, SetStates) {
   EXPECT_THROW(state_.SetQddot(VectorXd::Constant(3, 1.0)), std::exception);
 }
 
-/* Verify resizing does not thrash existing values. */
-TEST_F(FemStateTest, ConservativeResize) {
-  state_.Resize(2 * kNumDofs);
-  EXPECT_EQ(state_.num_generalized_positions(), 2 * kNumDofs);
-  /* The first kDof entries should remain unchanged. */
-  EXPECT_EQ(state_.qdot().head(kNumDofs), qdot());
-  EXPECT_EQ(state_.q().head(kNumDofs), q());
-  /* After downsizing, the first `smaller_size` entries should remain unchanged.
-   */
-  int smaller_size = kNumDofs / 2;
-  state_.Resize(smaller_size);
-  EXPECT_EQ(state_.num_generalized_positions(), smaller_size);
-  EXPECT_EQ(state_.qdot().head(smaller_size), qdot().head(smaller_size));
-  EXPECT_EQ(state_.q().head(smaller_size), q().head(smaller_size));
-}
-
 /* Test that element_data() retrieves the updated data. */
 TEST_F(FemStateTest, ElementData) {
   EXPECT_EQ(state_.element_cache_size(), kNumElements);
@@ -132,12 +116,6 @@ TEST_F(FemStateTest, ElementCache) {
   state_.SetQ(2 * q());
   VerifyCacheEntries();
   state_.SetQdot(2 * qdot());
-  VerifyCacheEntries();
-
-  /* Verify that resizing thrashes the cache entries and the cached
-   quantities are correctly recomputed. */
-  const int state_size = 1;
-  state_.Resize(state_size);
   VerifyCacheEntries();
 }
 }  // namespace

--- a/multibody/fixed_fem/dev/test/fem_state_test.cc
+++ b/multibody/fixed_fem/dev/test/fem_state_test.cc
@@ -3,7 +3,6 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_throws_message.h"
-#include "drake/common/unused.h"
 #include "drake/multibody/fixed_fem/dev/element_cache_entry.h"
 #include "drake/multibody/fixed_fem/dev/test/dummy_element.h"
 
@@ -133,12 +132,6 @@ TEST_F(FemStateTest, ElementCache) {
   state_.SetQ(2 * q());
   VerifyCacheEntries();
   state_.SetQdot(2 * qdot());
-  VerifyCacheEntries();
-
-  /* Verify that mutable getters thrash the cache entries and the cached
-   quantities are correctly recomputed. */
-  Eigen::VectorBlock<VectorX<double>> qdot = state_.mutable_qdot();
-  unused(qdot);
   VerifyCacheEntries();
 
   /* Verify that resizing thrashes the cache entries and the cached


### PR DESCRIPTION
- Move all state related API from FemState to FemStateBase for easier
access. FemState now only handles state-dependent quantities whereas
FemStateBase handles all state quantities.

- Add a missing API: get_highest_order_state().

- Minor bug fixes in FemModelBase API:
  - ApplyDirichletBoundaryConditions->ApplyDirichletBoundaryCondition
  - MakeFemStateBase is turned into a proper NVI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14723)
<!-- Reviewable:end -->
