### PR TITLE
[geometry] Remove 50-million-tetrahedron test of the old cylinder mesh.

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -721,10 +721,6 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "make_cylinder_mesh_test",
-    # This test includes generating the finest mesh allowed for a particular
-    # cylinder. The test size is increased to "medium" so that debug builds
-    # are successful in CI.
-    size = "medium",
     deps = [
         ":make_cylinder_mesh",
         ":proximity_utilities",
@@ -733,10 +729,6 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "make_capsule_mesh_test",
-    # This test includes generating the finest mesh allowed for a particular
-    # cylinder. The test size is increased to "medium" so that debug builds
-    # are successful in CI.
-    size = "medium",
     deps = [
         ":make_capsule_mesh",
         ":proximity_utilities",

--- a/geometry/proximity/test/make_cylinder_mesh_test.cc
+++ b/geometry/proximity/test/make_cylinder_mesh_test.cc
@@ -328,44 +328,6 @@ GTEST_TEST(MakeCylinderVolumeMesh, CoarsestMesh) {
   EXPECT_EQ(192, mesh_fine.num_elements());
 }
 
-// The test size is increased to "medium" so that debug builds are successful
-// in CI. See BUILD.bazel.
-GTEST_TEST(MakeCylinderVolumeMesh, FinestMesh) {
-  const double radius = 1.0;
-  const double length = 2.0;
-  // The initial mesh of a cylinder with radius 1 and length 2 has 24
-  // tetrahedra. Each refinement level increases the number of tetrahedra by
-  // a factor of 8. A refinement level ℒ that could increase tetrahedra beyond
-  // 100 million is ℒ = 8, which will give 24 * 8⁸ = 402,653,184 tetrahedra.
-  // (However, we will confirm later that the algorithm will limit the number
-  // of tetrahedra within 100 million, so it should give
-  // 24 * 8⁷ = 50,331,648 tetrahedra instead.) We will calculate the
-  // resolution hint that could trigger ℒ = 8.
-  //     Each edge of the mesh on the boundary circle of the top and bottom
-  // caps is a chord of the circle with a central angle θ. The edge length e
-  // is calculated from θ and radius r as:
-  //     e = 2⋅r⋅sin(θ/2)
-  // The central angle is initially π/2, and each level of refinement
-  // decreases it by a factor of 2. For ℒ = 8, we have:
-  //     θ = (π/2)/(2⁸) = π/512
-  // Thus, we have e = 2 sin (π/512) = 0.0122717...
-  //     We use a resolution hint smaller than e in the sixth decimal digit to
-  // request 402,653,184 tetrahedra, but the algorithm should limit the
-  // number of tetrahedra within 100 million. As a result, we should have
-  // 50,331,648 tetrahedra instead.
-  const double resolution_hint_limit = 1.2271e-2;
-  auto mesh_limit = MakeCylinderVolumeMesh<double>(Cylinder(radius, length),
-                                                   resolution_hint_limit);
-  EXPECT_EQ(50331648, mesh_limit.num_elements());
-
-  // Confirm that going ten times finer resolution hint does not increase the
-  // number of tetrahedra.
-  const double resolution_hint_finer = 1.2271e-3;
-  auto mesh_same = MakeCylinderVolumeMesh<double>(Cylinder(radius, length),
-                                                   resolution_hint_finer);
-  EXPECT_EQ(50331648, mesh_same.num_elements());
-}
-
 // This test verifies that the volume of the tessellated
 // cylinder converges to the exact value as the tessellation is refined.
 GTEST_TEST(MakeCylinderVolumeMesh, VolumeConvergence) {


### PR DESCRIPTION
Resolve the long running time of make_cylinder_mesh_test on CI `mac-catalina-clang-bazel-nightly-everything-address-sanitizer` as report in Console output of this one:

[mac-catalina-clang-bazel-nightly-everything-address-sanitizer/506](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-catalina-clang-bazel-nightly-everything-address-sanitizer/506/console)

[6:38:22 AM]  //geometry/proximity:make_cylinder_mesh_test                             PASSED in 1038.5s

<h3>Update</h3>
Now it's

[12:57:24 PM] //geometry/proximity:make_cylinder_mesh_test                            PASSED in 114.0s

I also removed "size=medium" from BUILD.bazel for make_capsule_mesh_test, which is so fast that it didn't need the flag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14726)
<!-- Reviewable:end -->
