### PR TITLE
Bump CRU and VGT externals to latest

### DIFF
--- a/tools/workspace/common_robotics_utilities/repository.bzl
+++ b/tools/workspace/common_robotics_utilities/repository.bzl
@@ -14,8 +14,8 @@ def common_robotics_utilities_repository(
         repository = "ToyotaResearchInstitute/common_robotics_utilities",
         # When updating, ensure that any new unit tests are reflected in
         # package.BUILD.bazel and BUILD.bazel in drake.
-        commit = "9148b7699b0ddbdbe8710b566bf8a017cd99f257",
-        sha256 = "e55579d22ddae444fbaa8167d0c5524e1938bdb0a9b4fe7731cf3b201aeabae3",  # noqa
+        commit = "f5592fd83d1c8e238117c030775eef414ad949d5",
+        sha256 = "fa208a5e575f3d86e697f47b6232ae1fe93a3735c3a7cded50f90c92df001b97",  # noqa
         build_file = "//tools/workspace/common_robotics_utilities:package.BUILD.bazel",  # noqa
         mirrors = mirrors,
     )

--- a/tools/workspace/voxelized_geometry_tools/repository.bzl
+++ b/tools/workspace/voxelized_geometry_tools/repository.bzl
@@ -14,8 +14,8 @@ def voxelized_geometry_tools_repository(
         repository = "ToyotaResearchInstitute/voxelized_geometry_tools",
         # When updating, ensure that any new unit tests are reflected in
         # package.BUILD.bazel and BUILD.bazel in drake.
-        commit = "ce62e93546f6468e0689fa8bdce21d05f816f935",
-        sha256 = "f5b4b0a942cfab0c0e205c9aca090855fce5a54e0dfa7bd4b75a93385b498f1b",  # noqa
+        commit = "0a2fa88a869c9847d57c98d697a7110b634f64d6",
+        sha256 = "c1946a77b058f5656b7180c7b8ff75d4c643a1254102a2df654f7185bb8b5bd5",  # noqa
         build_file = "//tools/workspace/voxelized_geometry_tools:package.BUILD.bazel",  # noqa
         mirrors = mirrors,
     )


### PR DESCRIPTION
Updates `common_robotics_utilities` and `voxelized_geometry_tools` to latest. Changes in the externals:
- Change in CRU to properly handle varying Eigen alignment requirements in Eigen alignment enforcement
- Adds backend enumeration in VGT to enumerate possible voxelizers, and uses that enumeration to run voxelizer test case on all possible voxelizers (note - only the basic CPU implementation is available here).

+@ggould-tri for feature review, thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14728)
<!-- Reviewable:end -->
