### PR TITLE
framework: Add more checks that a Context matches its System

### DIFF
--- a/systems/framework/diagram.cc
+++ b/systems/framework/diagram.cc
@@ -360,6 +360,7 @@ template <typename T>
 const ContinuousState<T>& Diagram<T>::GetSubsystemDerivatives(
     const System<T>& subsystem,
     const ContinuousState<T>& derivatives) const {
+  System<T>::ValidateChildOfContext(&derivatives);
   auto diagram_derivatives =
       dynamic_cast<const DiagramContinuousState<T>*>(&derivatives);
   DRAKE_DEMAND(diagram_derivatives != nullptr);

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -273,6 +273,7 @@ class System : public SystemBase {
        get_time_derivatives_cache_entry() */
   const ContinuousState<T>& EvalTimeDerivatives(
       const Context<T>& context) const {
+    ValidateContext(context);
     const CacheEntry& entry = get_time_derivatives_cache_entry();
     return entry.Eval<ContinuousState<T>>(context);
   }

--- a/systems/framework/system_base.cc
+++ b/systems/framework/system_base.cc
@@ -263,5 +263,13 @@ void SystemBase::ThrowCantEvaluateInputPort(const char* func,
                   GetSystemPathname()));
 }
 
+void SystemBase::ThrowValidateContextMismatch(
+    const ContextBase& context) const {
+  throw std::logic_error(fmt::format(
+      "Context was not created for {} system {}; it was created for system {}",
+      this->GetSystemType(), this->GetSystemPathname(),
+      context.GetSystemPathname()));
+}
+
 }  // namespace systems
 }  // namespace drake

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -800,11 +800,7 @@ class SystemBase : public internal::SystemMessageInterface {
   @note This method is sufficiently fast for performance sensitive code. */
   void ValidateContext(const ContextBase& context) const final {
     if (context.get_system_id() != system_id_) {
-      throw std::logic_error(
-          fmt::format("Context was not created for {} system {}; it was "
-                      "created for system {}",
-                      this->GetSystemType(), this->GetSystemPathname(),
-                      context.GetSystemPathname()));
+      ThrowValidateContextMismatch(context);
     }
   }
 
@@ -1074,6 +1070,10 @@ class SystemBase : public internal::SystemMessageInterface {
       ThrowOutputPortIndexOutOfRange(func, port);
     return *output_ports_[port_index];
   }
+
+  /** (Internal use only) Throws std::exception with a message that the sanity
+  check(s) given by ValidateContext have failed. */
+  [[noreturn]] void ThrowValidateContextMismatch(const ContextBase&) const;
 
   /** This method must be invoked from within derived class DoAllocateContext()
   implementations right after the concrete Context object has been allocated.


### PR DESCRIPTION
Part of #12560.

Specifically, fix up EvalTimeDerivatives and GetSubsystemDerivatives.

Also relocate the exception message implementation into the cc file to improve build size and time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14738)
<!-- Reviewable:end -->
