### PR TITLE
fix for jupyter runAll when using process_ipywidget_events

### DIFF
--- a/bindings/pydrake/common/jupyter.py
+++ b/bindings/pydrake/common/jupyter.py
@@ -52,10 +52,7 @@ def process_ipywidget_events(num_events_to_process=1):
         sys.stderr.flush()
         for stream, ident, parent in events:
             kernel.set_parent(ident, parent)
-            if kernel._aborting:
-                kernel._send_abort_reply(stream, parent, ident)
-            else:
-                kernel.execute_request(stream, ident, parent)
+            kernel.execute_request(stream, ident, parent)
 
     if len(events) > 0:
         loop = asyncio.get_event_loop()


### PR DESCRIPTION
The `runAll` behavior of jupyter notebooks, which we effectively have no mechanism to unit test in drake, is broken in python 3.6 and above when calling my `process_ipywidget_events` method.  This patch removes the problematic code.

To test, use 
```
bazel run //bindings/pydrake/systems:jupyter_widgets_examples
```
and change the first line to `True` as instructed in the first cell, and then use the dropdown menu to perform a 'kernel=>restart and run all'.  you will have to press 'stop simulation' in the second cell to move to execution of the remaining cells, and will see the error.
After this PR, you will see the remaining cells run successfully.

The change here removes the "abort" handling logic that was based on a "private" variable which was removed.  So if you were to "runAll", and then interrupt the kernel (e.g. with the "stop" button) when blocked in the first cell, instead of pressing stop simulation, then the remain cells will no proceed to execute.  Previously they would have been knocked off the queue to be consistent with the abort.

I poked around looking for a less byzantine/fragile way to handle the abort in the updated kernel, but now believe that this small nuisance (extra cells may run) is better than fragile support of the original behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14742)
<!-- Reviewable:end -->
