### PR TITLE
pybind11: Remove stray coverage deps from mkdoc

### DIFF
--- a/tools/workspace/pybind11/BUILD.bazel
+++ b/tools/workspace/pybind11/BUILD.bazel
@@ -38,10 +38,6 @@ py_library(
 py_binary(
     name = "mkdoc",
     srcs = ["mkdoc.py"],
-    data = [
-        "pybind_coverage_libclang_parser.py",
-        "pybind_coverage_xml_parser.py",
-    ],
     visibility = ["//visibility:public"],
     deps = [
         ":libclang_setup_py",


### PR DESCRIPTION
Noted while debugging #14739.
This is a follow-up from #14187.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14743)
<!-- Reviewable:end -->
