### PR TITLE
pybind11: Inject CPS nonce to make pybind11Tools happy

### DIFF
--- a/tools/workspace/pybind11/package-create-cps.py
+++ b/tools/workspace/pybind11/package-create-cps.py
@@ -2,15 +2,38 @@ import sys
 
 from drake.tools.install.cpsutils import read_defs
 
-# Targets correct as of pybind11/pybind11@6d0b470. Ensure that SHA is taken
-# from pybind11/pybind11 and not RobotLocomotion/pybind11.
+# Targets correct as of the following list for upstream:
+# https://github.com/pybind/pybind11/blob/9c0aa699/tools/pybind11Common.cmake#L8-L13
 
-defs = read_defs("#define PYBIND11_(VERSION[^\s]+)\s+([^\s]+)")
+defs = read_defs(r"#define PYBIND11_(VERSION[^\s]+)\s+([^\s]+)")
 
 if sys.platform.startswith('darwin'):
     defs["MODULE_LINK_FLAGS"] = '"Link-Flags": ["-undefined dynamic_lookup"],'
 else:
     defs["MODULE_LINK_FLAGS"] = ""
+
+# These are naively ported targets that are meant to ensure pybind11Tools does
+# not fail fast. They may not match what is provided.
+non_ported_targets = [
+    "lto",
+    "thin_lto",
+    "python_link_helper",
+    "python2_no_register",
+    "windows_extras",
+    "opt_size",
+]
+items = []
+for target in non_ported_targets:
+    items.append(f"""
+    "{target}": {{
+      "Type": "interface",
+      "Includes": [
+        "@prefix@/include/pybind11",
+        "${{PYTHON_INCLUDE_DIRS}}"
+      ],
+      "Compile-Features": ["c++14"]
+    }}""")
+defs["NON_PORTED_TARGETS"] = ",\n".join(items)
 
 content = """
 {
@@ -48,7 +71,8 @@ content = """
         "${PYTHON_INCLUDE_DIRS}"
       ],
       "Compile-Features": ["c++14"]
-    }
+    },
+%(NON_PORTED_TARGETS)s
   },
   "X-CMake-Includes": ["${CMAKE_CURRENT_LIST_DIR}/pybind11Tools.cmake"],
   "X-CMake-Variables-Init": {


### PR DESCRIPTION
The scope of this PR is to unblock fix basic CI errors on `drake-external-examples`, not to be correct in terms of mirroring CMake logic across the hoops of CPS + Bazel.

See: https://drakedevelopers.slack.com/archives/C270MN28G/p1615308431035600

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14755)
<!-- Reviewable:end -->
