### PR TITLE
[patch] Adds the missing std header causing mac to fail

### DIFF
--- a/multibody/tree/test/string_view_map_key_test.cc
+++ b/multibody/tree/test/string_view_map_key_test.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/tree/string_view_map_key.h"
 
+#include <unordered_map>
+
 #include <gtest/gtest.h>
 
 namespace drake {


### PR DESCRIPTION
This includes the missing <unordered_map> header which ubuntu is letting
slide but mac is justifiably angry about.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14756)
<!-- Reviewable:end -->
