### PR TITLE
[FEM] Add support for basic deformable contact

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -1004,7 +1004,12 @@ void DoScalarDependentDefinitions(py::module m, T) {
     cls  // BR
         .def(
             py::init<std::vector<SurfaceFace>, std::vector<SurfaceVertex<T>>>(),
-            py::arg("faces"), py::arg("vertices"), doc.SurfaceMesh.ctor.doc)
+            py::arg("faces"), py::arg("vertices"),
+            doc.SurfaceMesh.ctor.doc_2args)
+        .def(py::init<std::vector<SurfaceFace>, std::vector<Vector3<T>>,
+                 std::vector<T>, std::vector<SurfaceVertex<T>>>(),
+            py::arg("faces"), py::arg("normals"), py::arg("areas"),
+            py::arg("vertices"), doc.SurfaceMesh.ctor.doc_4args)
         .def("faces", &Class::faces, doc.SurfaceMesh.faces.doc)
         .def("vertices", &Class::vertices, doc.SurfaceMesh.vertices.doc)
         .def("centroid", &Class::centroid, doc.SurfaceMesh.centroid.doc);

--- a/multibody/fixed_fem/dev/BUILD.bazel
+++ b/multibody/fixed_fem/dev/BUILD.bazel
@@ -75,6 +75,17 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "deformable_contact",
+    srcs = ["deformable_contact.cc"],
+    hdrs = ["deformable_contact.h"],
+    deps = [
+        "//geometry/proximity:posed_half_space",
+        "//geometry/proximity:surface_mesh",
+        "//geometry/proximity:volume_mesh",
+    ],
+)
+
+drake_cc_library(
     name = "deformable_visualizer",
     srcs = ["deformable_visualizer.cc"],
     hdrs = ["deformable_visualizer.h"],
@@ -496,6 +507,17 @@ drake_cc_library(
     hdrs = ["test/test_utilities.h"],
     deps = [
         "//common:essential",
+    ],
+)
+
+drake_cc_googletest(
+    name = "deformable_contact_test",
+    deps = [
+        ":deformable_contact",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//geometry/proximity:mesh_intersection",
+        "//geometry/proximity:surface_mesh",
+        "//geometry/proximity:volume_mesh",
     ],
 )
 

--- a/multibody/fixed_fem/dev/deformable_contact.cc
+++ b/multibody/fixed_fem/dev/deformable_contact.cc
@@ -1,0 +1,495 @@
+#include "drake/multibody/fixed_fem/dev/deformable_contact.h"
+
+#include <array>
+#include <utility>
+#include <vector>
+
+#include "drake/geometry/proximity/posed_half_space.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+
+using geometry::SurfaceFace;
+using geometry::SurfaceFaceIndex;
+using geometry::SurfaceMesh;
+using geometry::SurfaceVertex;
+using geometry::SurfaceVertexIndex;
+using geometry::VolumeElementIndex;
+using geometry::VolumeMesh;
+using geometry::VolumeVertexIndex;
+using geometry::internal::PosedHalfSpace;
+using std::array;
+using std::move;
+using std::vector;
+
+namespace {
+/* %Intersector performs a mesh-intersection algorithm between a triangulated
+ surface mesh and a tetrahedral volume mesh. Calculates the mesh and the
+ per-triangle quantities defined in ContactTriangleData.
+
+ This is a bunch of modified copypasta from mesh_intersection.{h|cc}.  */
+template <typename T>
+class Intersector {
+ public:
+  Intersector() {
+    // We know that each contact polygon has at most 7 vertices.
+    // Each surface triangle is clipped by four half-spaces of the four
+    // triangular faces of a tetrahedron.
+    polygon_[0].reserve(7);
+    polygon_[1].reserve(7);
+  }
+
+  /* Intersects a volume mesh (union of tetrahedra) with a surface mesh (union
+   of triangles). It encompasses the algorithms to perform the intersection in
+   an efficient manner and produces a DeformableContactSurface.
+
+   @param[in] tet_mesh_D   The tet mesh with vertices measured and expressed in
+                           the deformable frame D.
+   @param[in] surface_R    The surface mesh, whose vertices are measured and
+                           expressed in the rigid frame R.
+   @param[in] X_DR  The pose of frame R relative to the world frame D.
+   @returns The (possibly empty) contact surface representing the intersection
+            between the two meshes.  */
+  DeformableContactSurface<T> Intersect(const VolumeMesh<T>& tet_mesh_D,
+                                        const SurfaceMesh<double>& surface_R,
+                                        const math::RigidTransform<T>& X_DR) {
+    // Components of the contact surface; we'll aggregate into these.
+    vector<SurfaceFace> out_faces;
+    vector<SurfaceVertex<T>> out_vertices_D;
+    vector<T> out_areas;
+    vector<Vector3<T>> out_normals;
+    vector<ContactTriangleData<T>> out_tri_data;
+
+    // Local workspace.
+    using VIndex = SurfaceVertexIndex;
+
+    for (VolumeElementIndex tet_index(0); tet_index < tet_mesh_D.num_elements();
+         ++tet_index) {
+      for (SurfaceFaceIndex tri_index(0); tri_index < surface_R.num_faces();
+           ++tri_index) {
+        const vector<IntersectionVertex<T>>& poly_vertices_D =
+            ClipTriangleByTetrahedron(tet_index, tet_mesh_D, tri_index,
+                                      surface_R, X_DR);
+        const int poly_vertex_count = static_cast<int>(poly_vertices_D.size());
+        if (poly_vertex_count < 3) continue;
+
+        // Store the index of the first new vertex we're adding for later use.
+        const VIndex vertex_0(out_vertices_D.size());
+        for (const auto& i_vertex_D : poly_vertices_D) {
+          out_vertices_D.emplace_back(i_vertex_D.cartesian);
+        }
+        const Vector3<T>& nhat_D =
+            X_DR.rotation() * surface_R.face_normal(tri_index).cast<T>();
+
+        // Computes the area of the triangle spanned by the three vertices. This
+        // is *not* a robust calculation.
+        auto calc_area = [&nhat_D](
+                             int v0, int v1, int v2,
+                             const vector<IntersectionVertex<T>>& vertices_D) {
+          const Vector3<T> p_01_D =
+              vertices_D[v1].cartesian - vertices_D[v0].cartesian;
+          const Vector3<T> p_02_D =
+              vertices_D[v2].cartesian - vertices_D[v0].cartesian;
+          return p_01_D.cross(p_02_D).dot(nhat_D) / 2;
+        };
+
+        // Computes the centroid of the triangle spanned by the three vertices
+        // in both Cartesian and Barycentric coordinates.
+        auto calc_centroid = [](int v0, int v1, int v2,
+                                const vector<IntersectionVertex<T>>& vertices_D)
+            -> IntersectionVertex<T> {
+          Vector3<T> centroid_D =
+              (vertices_D[v0].cartesian + vertices_D[v1].cartesian +
+               vertices_D[v2].cartesian) /
+              3;
+          Vector4<T> b_centroid = (vertices_D[v0].bary + vertices_D[v1].bary +
+                                   vertices_D[v2].bary) /
+                                  3;
+          return {centroid_D, b_centroid};
+        };
+
+        // We construct a triangle fan from the polygon with vertex 0 as the
+        // common vertex: e.g., triangles (0, 1, 2), (0, 2, 3), ... Generally,
+        // a triangle from a fan with N vertices is (0, i, i + 1), for
+        // i ∈ [1, N - 2]. For each triangle, compute the ContactTriangleData
+        // data.
+        for (int i = 1; i < poly_vertex_count - 1; ++i) {
+          // Mesh quantities.
+          out_faces.emplace_back(vertex_0, VIndex(vertex_0 + i),
+                                 VIndex(vertex_0 + i + 1));
+          out_areas.emplace_back(calc_area(0, i, i + 1, poly_vertices_D));
+          out_normals.push_back(nhat_D);
+          // Additional per-triangle data.
+          const IntersectionVertex<T> centroid_D =
+              calc_centroid(0, i, i + 1, poly_vertices_D);
+          out_tri_data.push_back(
+              {centroid_D.cartesian, centroid_D.bary, tet_index});
+        }
+      }
+    }
+
+    return DeformableContactSurface<T>({move(out_faces), move(out_normals),
+                                        move(out_areas), move(out_vertices_D)},
+                                       move(out_tri_data));
+  }
+
+ private:
+  /* The vertex of the polygon formed by intersecting a tet with a tri. The
+   vertex has a dual representation: as a point in cartesian coordinates
+   (measured and expressed in the frame indicated by notation) and the
+   barycentric coordinates of the tet.  */
+  template <typename U = T>
+  struct IntersectionVertex {
+    Vector3<U> cartesian;
+    Vector4<U> bary;
+  };
+
+  /* Calculates the intersection point between an infinite straight line
+   spanning points A and B and the bounding plane of the half space H, all
+   measured and expressed in the common frame D.
+
+   @param p_DA            The intersection point A.
+   @param p_DB            The intersection point B.
+   @param H_D   The half space H measured and expressed in frame D.
+   @pre One of A and B is outside the half space, and the other is inside or
+        on the boundary of the half space.  */
+  static IntersectionVertex<T> CalcIntersection(
+      const IntersectionVertex<T>& p_DA, const IntersectionVertex<T>& p_DB,
+      const PosedHalfSpace<T>& H_D) {
+    const T a = H_D.CalcSignedDistance(p_DA.cartesian);
+    const T b = H_D.CalcSignedDistance(p_DB.cartesian);
+    // We require that A and B classify in opposite directions (one inside and
+    // one outside). Outside has a strictly positive distance, inside is
+    // non-positive. We confirm that their product is non-positive and that at
+    // least one of the values is positive -- they can't both be zero. This
+    // prevents b - a becoming zero and the corresponding division by zero.
+    DRAKE_ASSERT(a * b <= 0 && (a > 0 || b > 0));
+    const T wa = b / (b - a);
+    const T wb = T(1.0) - wa;  // Enforce a + b = 1.
+    // Compute the intersection point I in Cartesian and Barycentric coords.
+    const Vector3<T> p_DI = wa * p_DA.cartesian + wb * p_DB.cartesian;
+    const Vector4<T> b_I = wa * p_DA.bary + wb * p_DB.bary;
+    // Empirically we found that numeric_limits<double>::epsilon() 2.2e-16 is
+    // too small.
+    const T kEps(1e-14);
+    // TODO(SeanCurtis-TRI): Consider refactoring this fuzzy test *into*
+    //  PosedHalfSpace if it turns out we need to perform this test at other
+    //  sites.
+    // Verify that the intersection point is on the plane of the half space.
+    using std::abs;
+    DRAKE_DEMAND(abs(H_D.CalcSignedDistance(p_DI)) < kEps);
+    return {p_DI, b_I};
+    // Justification.
+    // 1. We set up the weights wa and wb such that wa + wb = 1, which
+    //    guarantees that the linear combination is on the straight line
+    //    through A and B.
+    // 2. We show that the H_D.signed_distance(wa * A + wb * B) is zero.
+    //    Let H_D.signed_distance be sdf(P) = N.dot(P) + d.
+    //      sdf(wa * A + wb * B)
+    //      = N.dot(wa * A + wb * B) + d
+    //      = wa * N.dot(A) + wb * N.dot(B) + d
+    //      = b * N.dot(A)/(b - a) + a * N.dot(B)/(a - b) + d
+    //      = b * N.dot(A)/(b - a) - a * N.dot(B)/(b - a) + d
+    //      = (b * N.dot(A) - a * N.dot(B) + (b - a) * d) / (b - a)
+    //      = (b * (N.dot(A) + d) - a * (N.dot(B) + d)) / (b-a)
+    //      = (b * sdf(A) - a * sdf(B)) / (b-a)
+    //      = (b * a - a * b) / (b-a)
+    //      = 0 when a != b.
+  }
+
+  // TODO(SeanCurtis-TRI): This function duplicates functionality implemented in
+  //  mesh_half_space_intersection.h. Reconcile the two implementations.
+  // TODO(DamrongGuoy): Avoid duplicate vertices mentioned in the note below and
+  //  check whether we can have other as yet undocumented degenerate cases.
+  /* Intersects a polygon with the half space H. It keeps the part of
+   the polygon contained in the half space (signed distance is <= 0).
+   The half space `H_F` and vertex positions of `input_vertices_F` are both
+   defined in a common frame F.
+   @param[in] input_vertices_F
+       Input polygon is represented as a sequence of positions of its vertices.
+       The input polygon is allowed to have zero area.
+   @param[in] H_F
+       The clipping half space H in frame F.
+   @param[out] output_vertices_F
+       Output polygon is represented as a sequence of positions of its vertices.
+       It could be an empty sequence if the input polygon is entirely outside
+       the half space. It could be the same as the input polygon if the input
+       polygon is entirely inside the half space. The output polygon is
+       guaranteed to be planar (within floating point tolerance) and, if the
+       polygon has area, the normal implied by the winding will be the same
+       as the input polygon.
+   @pre `input_vertices_F` has at least three vertices.
+   @pre the vertices in `input_vertices_F` are all planar.
+   @note
+       1. For an input polygon P that is parallel to the plane of the half
+          space, there are three cases:
+          1.1 If P is completely inside the half space, the output polygon
+              will be the same as P.
+          1.2 If P is completely outside the half space, the output polygon
+              will be empty.
+          1.3 If P is on the plane of the half space, the output polygon will
+              be the same as P.
+       2. For an input polygon P outside the half space with one edge on the
+          plane of the half space, the output polygon will be a zero-area
+          4-gon with two pairs of duplicate vertices.
+       3. For an input polygon P outside the half space with one vertex on the
+          plane of the half space, the output polygon will be a zero-area
+          triangle with three duplicate vertices.
+  */
+  static void ClipPolygonByHalfSpace(
+      const std::vector<IntersectionVertex<T>>& input_vertices_F,
+      const PosedHalfSpace<T>& H_F,
+      std::vector<IntersectionVertex<T>>* output_vertices_F) {
+    DRAKE_ASSERT(output_vertices_F != nullptr);
+    // Note: this is the inner loop of a modified Sutherland-Hodgman algorithm
+    // for clipping a polygon.
+    output_vertices_F->clear();
+    // Note: This code is correct for size < 3, but pointless so we make no
+    // effort to support it or test it.
+    const int size = static_cast<int>(input_vertices_F.size());
+
+    // TODO(SeanCurtis-TRI): If necessary, this can be made more efficient:
+    //  eliminating the modulus and eliminating the redundant "inside"
+    //  calculation on previous (by pre-determining previous and its
+    //  "containedness" and then propagating current -> previous in each loop.
+    //  Probably a desirable optimization as we need to make all of this work as
+    //  cheap as possible.
+    int p = size - 1;
+    for (int i = 0; i < size; ++i) {
+      const IntersectionVertex<T>& current_F = input_vertices_F[i];
+      const IntersectionVertex<T>& previous_F = input_vertices_F[p];
+      const bool current_contained =
+          H_F.CalcSignedDistance(current_F.cartesian) <= 0;
+      const bool previous_contained =
+          H_F.CalcSignedDistance(previous_F.cartesian) <= 0;
+      if (current_contained) {
+        if (!previous_contained) {
+          // Current is inside and previous is outside. Compute the point where
+          // that edge enters the half space. This is a new vertex in the
+          // clipped polygon and must be included before current.
+          output_vertices_F->push_back(
+              CalcIntersection(current_F, previous_F, H_F));
+        }
+        output_vertices_F->push_back(current_F);
+      } else if (previous_contained) {
+        // Current is outside and previous is inside. Compute the point where
+        // the edge exits the half space. This is a new vertex in the clipped
+        // polygon and is included *instead* of current.
+        output_vertices_F->push_back(
+            CalcIntersection(current_F, previous_F, H_F));
+      }
+      p = i;
+    }
+  }
+
+  /* Remove duplicate vertices from a polygon represented as a cyclical
+   sequence of vertex positions. In other words, for a sequence `A,B,B,C,A`, the
+   pair of B's is reduced to one B and the first and last A vertices are
+   considered duplicates and the result would be `A,B,C`. The polygon might be
+   reduced to a pair of points (i.e., `A,A,B,B` becomes `A,B`) or a single point
+   (`A,A,A` becomes `A`).
+   @param[in,out] polygon
+       The input polygon, and the output equivalent polygon with no duplicate
+       vertices.
+   */
+  static void RemoveDuplicateVertices(
+      std::vector<IntersectionVertex<T>>* polygon) {
+    DRAKE_ASSERT(polygon != nullptr);
+
+    // TODO(SeanCurtis-TRI): The resulting polygon depends on the order of the
+    //  inputs. Imagine I have vertices A, A', A'' (such that |X - X'| < eps.
+    //  The sequence AA'A'' would be reduced to AA''
+    //  The sequence A'A''A would be reduced to A'.
+    //  The sequence A''AA' would be reduced to A''A.
+    //  In all three cases, the exact same polygon is defined on input, but the
+    //  output is different. This should be documented and/or fixed.
+    if (polygon->size() <= 1) return;
+
+    auto near = [](const IntersectionVertex<T>& p,
+                   const IntersectionVertex<T>& q) -> bool {
+      // TODO(SeanCurtis-TRI): This represents 5-6 bits of loss. Confirm that a
+      //  tighter epsilon can't be used. This should probably be a function of
+      //  the longest edge involved.
+      // Empirically we found that numeric_limits<double>::epsilon() 2.2e-16 is
+      // too small, especially when the objects are not axis-aligned.
+      const double kEpsSquared(1e-14 * 1e-14);
+      return (p.cartesian - q.cartesian).squaredNorm() < kEpsSquared;
+    };
+
+    // Remove consecutive vertices that are duplicated in the linear order.  It
+    // will change "A,B,B,C,C,A" to "A,B,C,A". To close the cyclic order, we
+    // will check the first and the last vertices again near the end of the
+    // function.
+    // TODO(DamrongGuoy): This doesn't strictly satisfy the requirement of
+    //  std::unique that the predicate represent an equivalence relation (i.e.,
+    //  point A could be "near" points B and C, but that doesn't mean B and C
+    //  are near each other). We need to figure out if that matters for this
+    //  usage and, if not, document why here.
+    auto it = std::unique(polygon->begin(), polygon->end(), near);
+    polygon->resize(it - polygon->begin());
+
+    if (polygon->size() >= 3) {
+      // Check the first and the last vertices in the sequence. For example,
+      // given "A,B,C,A", we want "A,B,C".
+      if (near((*polygon)[0], *(polygon->rbegin()))) {
+        polygon->pop_back();
+      }
+    }
+
+    DRAKE_ASSERT(polygon->size() != 2 || !near((*polygon)[0], (*polygon)[1]));
+  }
+
+  /* Intersects a triangle with a tetrahedron, returning the portion of the
+   triangle with non-zero area contained in the tetrahedron.
+   @param tet_index
+       Index of the tetrahedron in the volume mesh.
+   @param tet_mesh_D
+       The volume mesh whose vertex positions are expressed Frame D.
+   @param face
+       Index of the triangle in the surface mesh.
+   @param surface_R
+       The surface mesh whose vertex positions are expressed in Frame R.
+   @param X_DF
+       The pose of the surface frame D in the volume frame R.
+   @retval polygon_D
+       The output polygon represented by a sequence of positions of its
+       vertices, expressed in D's frame. The nature of triangle-tetrahedron
+       intersection means that this polygon can have up to seven vertices.
+       The following picture shows such an example. The plane of the triangle
+       cuts the tetrahedron into a rectangle ABCD with A lying inside the
+       triangle. Each of B,C,D is outside the triangle and has two edges that
+       intersect an edge of the triangle.
+
+          *
+           * *
+            *   *
+             *     *
+              *       *
+               *  A------x-----D
+                * |         *  |
+                 *|            x
+                  x            |  *
+                  |*           x
+                  | *       *  |
+                  B--x---x-----C
+                      *
+
+   @note
+       1. If the triangle is outside the tetrahedron with one vertex on a
+          face of the tetrahedron, the output polygon will be empty.
+       2. If the triangle is outside the tetrahedron with an edge on a face
+          of the tetrahedron, the output polygon will be empty.
+       3. If the triangle lies on the plane of a tetrahedron face, the output
+          polygon will be that part of the triangle inside the face of the
+          tetrahedron (non-zero area restriction still applies).
+   */
+  const std::vector<IntersectionVertex<T>>& ClipTriangleByTetrahedron(
+      VolumeElementIndex tet_index, const VolumeMesh<T>& tet_mesh_D,
+      SurfaceFaceIndex face, const SurfaceMesh<double>& surface_R,
+      const math::RigidTransform<T>& X_DR) {
+    // Although polygon_D starts out pointing to polygon_[0], that is not an
+    // invariant in this function.
+    std::vector<IntersectionVertex<T>>* polygon_D = &(polygon_[0]);
+    // Initialize output polygon in D's frame from the triangular `face` of
+    // surface_R.
+    polygon_D->clear();
+    for (int i = 0; i < 3; ++i) {
+      const SurfaceVertexIndex v = surface_R.element(face).vertex(i);
+      const Vector3<T> p_DV = X_DR * surface_R.vertex(v).r_MV().cast<T>();
+      polygon_D->push_back({p_DV, tet_mesh_D.CalcBarycentric(p_DV, tet_index)});
+    }
+    // Get the positions, in Frame D, of the four vertices of the tet.
+    Vector3<T> p_DVs[4];
+    for (int i = 0; i < 4; ++i) {
+      const VolumeVertexIndex v = tet_mesh_D.element(tet_index).vertex(i);
+      p_DVs[i] = tet_mesh_D.vertex(v).r_MV();
+    }
+
+    /* Sets up the four half spaces associated with the four triangular faces of
+     the tetrahedron.
+
+     A typical tetrahedral element looks like:
+          p2 *
+             |
+             |
+          p3 *---* p0
+            /
+           /
+       p1 *
+     The index order for a particular tetrahedron has the order [p0, p1, p2,
+     p3]. These local indices enumerate each of the tet faces with
+     outward-pointing normals with respect to the right-hand rule.  */
+    const array<array<int, 3>, 4> faces{
+        {{{1, 0, 2}}, {{3, 0, 1}}, {{3, 1, 2}}, {{2, 0, 3}}}};
+
+    // Although this assertion appears trivially true, its presence is
+    // protection for the subsequent code, which heavily relies on it being
+    // true, from any changes that may be applied to the previous code.
+    DRAKE_ASSERT(polygon_D == &(polygon_[0]));
+    std::vector<IntersectionVertex<T>>* out_D = &(polygon_[1]);
+    for (auto& face_vertex : faces) {
+      const Vector3<T>& p_DA = p_DVs[face_vertex[0]];
+      const Vector3<T>& p_DB = p_DVs[face_vertex[1]];
+      const Vector3<T>& p_DC = p_DVs[face_vertex[2]];
+      // We'll allow the PosedHalfSpace to normalize our vector.
+      const Vector3<T> normal_D = (p_DB - p_DA).cross(p_DC - p_DA);
+      PosedHalfSpace<T> half_space_D(normal_D, p_DA);
+      // Intersects the output polygon by the half space of each face of the
+      // tetrahedron.
+      ClipPolygonByHalfSpace(*polygon_D, half_space_D, out_D);
+      std::swap(polygon_D, out_D);
+    }
+
+    // TODO(DamrongGuoy): Remove the code below when ClipPolygonByHalfSpace()
+    //  stops generating duplicate vertices. See the note in
+    //  ClipPolygonByHalfSpace().
+
+    // Remove possible duplicate vertices from ClipPolygonByHalfSpace().
+    RemoveDuplicateVertices(polygon_D);
+    if (polygon_D->size() < 3) {
+      // RemoveDuplicateVertices() may have shrunk the polygon down to one or
+      // two vertices, so we empty the polygon.
+      polygon_D->clear();
+    }
+
+    // TODO(DamrongGuoy): Calculate area of the polygon. If it's too small,
+    //  return an empty polygon.
+
+    // The output polygon could be at most a heptagon.
+    DRAKE_DEMAND(polygon_D->size() <= 7);
+    return *polygon_D;
+  }
+
+  /* To avoid heap allocation by std::vector in low-level functions, we use
+   these member variables instead of local variables in the functions.
+   The two vectors are not guaranteed to have any particular semantic
+   interpretation during the execution of this class's main method. This array
+   represents a pool of resources; any entry could have arbitrary meaning (or
+   none at all) depending where in the algorithm they are inspected.
+   Furthermore, any changes to the existing algorithm that make use of these
+   pool variables should take care that conflicting use of the resources are
+   not introduced.  */
+  std::vector<IntersectionVertex<T>> polygon_[2];
+};
+}  // namespace
+
+template <typename T>
+DeformableContactSurface<T> ComputeTetMeshTriMeshContact(
+    const geometry::VolumeMesh<T>& tet_mesh_D,
+    const geometry::SurfaceMesh<double>& tri_mesh_R,
+    const math::RigidTransform<T>& X_DR) {
+  return Intersector<T>().Intersect(tet_mesh_D, tri_mesh_R, X_DR);
+}
+
+template DeformableContactSurface<double> ComputeTetMeshTriMeshContact(
+    const geometry::VolumeMesh<double>&, const geometry::SurfaceMesh<double>&,
+    const math::RigidTransform<double>&);
+
+template DeformableContactSurface<AutoDiffXd> ComputeTetMeshTriMeshContact(
+    const geometry::VolumeMesh<AutoDiffXd>&,
+    const geometry::SurfaceMesh<double>&,
+    const math::RigidTransform<AutoDiffXd>&);
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/deformable_contact.h
+++ b/multibody/fixed_fem/dev/deformable_contact.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include <Eigen/Dense>
+
+#include "drake/common/eigen_types.h"
+#include "drake/geometry/proximity/surface_mesh.h"
+#include "drake/geometry/proximity/volume_mesh.h"
+#include "drake/math/rigid_transform.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+
+// TODO(SeanCurtis-TRI) The application of the template parameter T is *not*
+//  well reasoned. Currently, we're assuming that *all* quantities can and
+//  should be expressed in the same scalar. It is *not* clear that *should*
+//  be the case. But for now, we'll assume a homogenous scalar environment.
+
+/** The per-triangle data associated with the mesh triangles in a
+ DeformableContactSurface that *cannot* be queried from the contact surface's
+ mesh.  */
+template <typename T>
+struct ContactTriangleData {
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ContactTriangleData)
+  /** The triangle's centroid, measured and expressed in the the *deformable*
+   volume mesh's frame D. */
+  Vector3<T> centroid;
+  /** The triangle's centroid, described in barycentric coordinates of a
+   tetrahedron drawn from the intersecting tet-mesh element. See `tet_index`. */
+  Vector4<T> b_centroid;
+  /** The index of the tetrahedron element in the intersecting tet-mesh in which
+   this data's triangle is completely contained.  */
+  geometry::VolumeElementIndex tet_index;
+};
+
+/** Characterization of the contact surface between a deformable volume (tet)
+ mesh and a rigid surface (tri) mesh. The contact surface is, itself, a triangle
+ mesh. The mesh can be directly queried for per-triangle data (e.g., area and
+ normal). This class also contains additional per-triangle data (see
+ ContactTriangleData).  */
+template <typename T>
+class DeformableContactSurface {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DeformableContactSurface)
+
+  /** Constructs the contact surface from the given mesh (with vertex positions
+   measured and expressed in the *deformable* volume mesh's frame D) and
+   per-triangle data.
+   @pre tri_data.size() == mesh_D.num_elements().  */
+  DeformableContactSurface(geometry::SurfaceMesh<T> mesh_D,
+                           std::vector<ContactTriangleData<T>> tri_data)
+      : mesh_D_(std::move(mesh_D)), triangle_data_(std::move(tri_data)) {
+    DRAKE_DEMAND(mesh_D_.num_elements() ==
+                 static_cast<int>(triangle_data_.size()));
+  }
+
+  /** Returns `true` if this surface has no data -- there is no surface.  */
+  bool is_empty() const { return mesh_D_.num_elements() == 0; }
+
+  /** Returns the contact surface's underlying triangle mesh with vertices
+   measured and expressed in the *deformable* volume mesh's frame D.  */
+  const geometry::SurfaceMesh<T>& mesh() const { return mesh_D_; }
+
+  /** Returns the data associated with the triangle indexed by `tri_index` in
+   mesh().  */
+  const ContactTriangleData<T>& triangle_data(int tri_index) const {
+    return triangle_data_[tri_index];
+  }
+
+ private:
+  /* The surface mesh spanning the contact surface. Vertex positions are
+  measured and expressed in the *deformable* volume mesh's frame D.  */
+  geometry::SurfaceMesh<T> mesh_D_;
+
+  /* The per-triangle data for the contact surface. It should be an invariant
+   that mesh_D_.num_elements() == triangle_data_.size().  */
+  std::vector<ContactTriangleData<T>> triangle_data_;
+};
+
+// TODO(SeanCurtis-TRI) This needs some acceleration; we need an OBB BVH for
+//  the triangle mesh and an AABB BVH for the tet mesh (one that updates
+//  based on deformations). The Obb BVH exists and we could use it assuming
+//  we add the OBB-Tet intersection test.
+
+/** Computes the contact between a deformable tet mesh and a rigid tri mesh. The
+ contact is characterized by contact surface consisting of a triangle mesh and
+ a collection of additional per-triangle quantities (see
+ DeformableContactSurface).
+
+If there is no contact, the result will be empty.
+
+@param tet_mesh_D   The tetrahedral mesh, with vertex positions measured and
+                    expressed in the *deformable* mesh's frame D.
+@param tri_mesh_R   The triangle mesh, with vertex positions measured and
+                    expressed in the *rigid* mesh's frame R.
+@param X_DR         The pose of the triangle mesh in the volume mesh's frame.
+@returns The contact surface formed by the intersection of the volume and
+         surface meshes. If there is no intersection, the resulting surface will
+         report as "empty".  */
+template <typename T>
+DeformableContactSurface<T> ComputeTetMeshTriMeshContact(
+    const geometry::VolumeMesh<T>& tet_mesh_D,
+    const geometry::SurfaceMesh<double>& tri_mesh_R,
+    const math::RigidTransform<T>& X_DR);
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/test/deformable_contact_test.cc
+++ b/multibody/fixed_fem/dev/test/deformable_contact_test.cc
@@ -1,0 +1,266 @@
+#include "drake/multibody/fixed_fem/dev/deformable_contact.h"
+
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/autodiff.h"
+#include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/geometry/proximity/mesh_intersection.h"
+#include "drake/geometry/proximity/surface_mesh.h"
+#include "drake/geometry/proximity/volume_mesh.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/math/roll_pitch_yaw.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+namespace {
+
+using geometry::SurfaceFaceIndex;
+using geometry::SurfaceMesh;
+using geometry::VolumeElementIndex;
+using geometry::VolumeMesh;
+using geometry::internal::SurfaceVolumeIntersector;
+using std::vector;
+
+/* The OctahedronVolume() and MakePyramidSurface() methods are stolen from
+ mesh_intersection_test.cc. */
+
+/* Generates a volume mesh of an octahedron comprising of eight tetrahedral
+ elements with vertices on the coordinate axes and the origin like this:
+
+                +Z   -X
+                 |   /
+              v5 ●  ● v3
+                 | /
+       v4     v0 |/
+  -Y----●--------●------●----+Y
+                /|      v2
+               / |
+           v1 ●  ● v6
+             /   |
+           +X    |
+                -Z
+*/
+template <typename T>
+VolumeMesh<T> OctahedronVolume() {
+  const int element_data[8][4] = {
+      // The top four tetrahedrons share the top vertex v5.
+      {0, 1, 2, 5},
+      {0, 2, 3, 5},
+      {0, 3, 4, 5},
+      {0, 4, 1, 5},
+      // The bottom four tetrahedrons share the bottom vertex v6.
+      {0, 2, 1, 6},
+      {0, 3, 2, 6},
+      {0, 4, 3, 6},
+      {0, 1, 4, 6}};
+  vector<geometry::VolumeElement> elements;
+  for (const auto& element : element_data) {
+    elements.emplace_back(element);
+  }
+  // clang-format off
+  const Vector3<T> vertex_data[7] = {
+      { 0,  0,  0},
+      { 1,  0,  0},
+      { 0,  1,  0},
+      {-1,  0,  0},
+      { 0, -1,  0},
+      { 0,  0,  1},
+      { 0,  0, -1}};
+  // clang-format on
+  vector<geometry::VolumeVertex<T>> vertices;
+  for (const auto& vertex : vertex_data) {
+    vertices.emplace_back(vertex);
+  }
+  return VolumeMesh<T>(std::move(elements), std::move(vertices));
+}
+
+/* Generates a simple surface mesh of a pyramid with vertices on the
+ coordinate axes and the origin like this:
+
+                +Z   -X
+                 |   /
+              v5 ●  ● v3
+                 | /
+        v4    v0 |/
+  -Y-----●-------●------●---+Y
+                /      v2
+               /
+              ● v1
+             /
+           +X
+*/
+template <typename T>
+SurfaceMesh<T> MakePyramidSurface() {
+  const int face_data[8][3] = {// The top four faces share the apex vertex v5.
+                               {1, 2, 5},
+                               {2, 3, 5},
+                               {3, 4, 5},
+                               {4, 1, 5},
+                               // The bottom four faces share the origin v0.
+                               {4, 3, 0},
+                               {3, 2, 0},
+                               {2, 1, 0},
+                               {1, 4, 0}};
+  vector<geometry::SurfaceFace> faces;
+  for (auto& face : face_data) {
+    faces.emplace_back(face);
+  }
+  // clang-format off
+  const Vector3<T> vertex_data[6] = {
+      { 0,  0, 0},
+      { 1,  0, 0},
+      { 0,  1, 0},
+      {-1,  0, 0},
+      { 0, -1, 0},
+      { 0,  0, 1}
+  };
+  // clang-format on
+  vector<geometry::SurfaceVertex<T>> vertices;
+  for (auto& vertex : vertex_data) {
+    vertices.emplace_back(vertex);
+  }
+  return SurfaceMesh<T>(std::move(faces), std::move(vertices));
+}
+
+/* The per-triangle data we're testing for.  */
+template <typename T>
+struct TriangleData {
+  T area{};
+  Vector3<T> normal;
+  /* The centroid computed from *triangle* vertex positions.  */
+  Vector3<T> centroid;
+  /* The centroid computed from weighted combination of tetrahedron vertices. */
+  Vector3<T> centroid_from_bary;
+};
+
+/* Given a triangle from the DeformableContactSurface's triangle mesh, computes
+ some quantities to test the *consistency* between the actual mesh and the
+ stored per-triangle quantities reported in the DeformableContactSurface.  */
+template <typename T>
+TriangleData<T> CalcTriangleData(const SurfaceMesh<T>& surface_D,
+                                 SurfaceFaceIndex tri_index,
+                                 const VolumeMesh<T>& volume_D,
+                                 VolumeElementIndex tet_index,
+                                 const Vector4<T>& b_Q) {
+  TriangleData<T> data_D;
+  const geometry::SurfaceFace& tri = surface_D.element(tri_index);
+  const auto& p_DA = surface_D.vertex(tri.vertex(0)).r_MV();
+  const auto& p_DB = surface_D.vertex(tri.vertex(1)).r_MV();
+  const auto& p_DC = surface_D.vertex(tri.vertex(2)).r_MV();
+  data_D.centroid = (p_DA + p_DB + p_DC) / 3;
+
+  const Vector3<T> cross_D = (p_DB - p_DA).cross(p_DC - p_DA);
+  const T mag = cross_D.norm();
+  data_D.area = mag / 2;
+  data_D.normal = cross_D / mag;
+
+  Vector3<T> centroid = Vector3<T>::Zero();
+  const auto& tet = volume_D.element(tet_index);
+  for (int v = 0; v < 4; ++v) {
+    centroid += b_Q(v) * volume_D.vertex(tet.vertex(v)).r_MV();
+  }
+  data_D.centroid_from_bary = centroid;
+  return data_D;
+}
+
+/* Limited test to show correctness of ComputeTetMeshTriMeshContact<T>().
+ Given a simple, tractable set of input meshes, we compute the surface and
+ evaluate it in two ways:
+
+   1. Make sure it's the "right" manifold.
+   2. The per-triangle data is consistent with the mesh.
+ */
+template <typename T>
+void TestComputeTetMeshTriMeshContact() {
+  constexpr double kEps = std::numeric_limits<double>::epsilon();
+  const VolumeMesh<T> volume_D = OctahedronVolume<T>();
+  /* FEM contact assumes the rigid surface is double-valued, regardless of the
+   scalar value for the volume mesh.  */
+  const SurfaceMesh<double> surface_R = MakePyramidSurface<double>();
+  /* Move the rigid pyramid up, so only its square base intersects the top
+   pyramidal region of the deformable octahedron.  */
+  const auto X_DR = math::RigidTransform<T>(Vector3<T>(0, 0, 0.5));
+
+  const DeformableContactSurface<T> contact_D =
+      ComputeTetMeshTriMeshContact<T>(volume_D, surface_R, X_DR);
+  const SurfaceMesh<T>& mesh_D = contact_D.mesh();
+
+  /* First, we need to test that the mesh in the contact surface is the
+   expected manifold. This is *challenging*. Instead, we're going to compute
+   the corresponding hydroleastic contact surface and confirm that its mesh
+   has the same total area and same geometric centroid. That will be considered
+   evidence that the mesh is correct.
+
+   A more direct comparison is impractical because the two meshes, by design,
+   tesselate the contact surface differently. The logic to reconcile those two
+   different decompositions is more work than it's worth.  */
+
+  /* Construct arguments for hydroelastic query.  */
+
+  /* Construct the output parameters. We only care about the test_mesh, the
+   field and gradient will otherwise be ignored.  */
+  std::unique_ptr<SurfaceMesh<T>> test_mesh_D{};
+  std::unique_ptr<geometry::SurfaceMeshFieldLinear<T, T>> ignored_field;
+  vector<Vector3<T>> ignored_gradient;
+
+  /* Construct the input parameters.  */
+  geometry::internal::Bvh<VolumeMesh<T>> bvh_volume_D(volume_D);
+  vector<T> values(volume_D.num_vertices(), T(0));
+  geometry::VolumeMeshFieldLinear<T, T> field_D(
+      "ignored", move(values), &volume_D, true /* calculate_gradient */);
+  /* Hydroelastic intersection assumes the surface has the same scalar value as
+   the volume mesh; reconstruct a T-valued triangle mesh.  */
+  const SurfaceMesh<T> surface_R_T = MakePyramidSurface<T>();
+  geometry::internal::Bvh<SurfaceMesh<T>> bvh_surface(surface_R_T);
+
+  geometry::internal::SurfaceVolumeIntersector<T>().SampleVolumeFieldOnSurface(
+      field_D, bvh_volume_D, surface_R_T, bvh_surface, X_DR, &test_mesh_D,
+      &ignored_field, &ignored_gradient);
+
+  EXPECT_NEAR(ExtractDoubleOrThrow(test_mesh_D->total_area()),
+              ExtractDoubleOrThrow(mesh_D.total_area()), kEps);
+  EXPECT_TRUE(
+      CompareMatrices(test_mesh_D->centroid(), mesh_D.centroid(), kEps));
+
+  /* Second, we confirm the data is internally consistent. I.e.,
+      - normal is perpendicular to triangle.
+      - area is as expected.
+      - centroid in Cartesian is correct; truly the average position.
+      - centroid in Barycentric produces Cartesian point (with tet
+        index).  */
+  for (SurfaceFaceIndex f(0); f < mesh_D.num_faces(); ++f) {
+    const ContactTriangleData<T>& f_data_D = contact_D.triangle_data(f);
+    const TriangleData<T> expected_D = CalcTriangleData(
+        mesh_D, f, volume_D, VolumeElementIndex(f_data_D.tet_index),
+        f_data_D.b_centroid);
+
+    EXPECT_NEAR(ExtractDoubleOrThrow(mesh_D.area(f)),
+                ExtractDoubleOrThrow(expected_D.area), 1e-15);
+    EXPECT_TRUE(
+        CompareMatrices(mesh_D.face_normal(f), expected_D.normal, kEps));
+
+    /* Make sure centroid *is* the centroid of the triangle.  */
+    EXPECT_TRUE(CompareMatrices(f_data_D.centroid, expected_D.centroid, kEps));
+    /* Confirm that b_centroid + volume mesh vertices = centroid.  */
+    EXPECT_TRUE(CompareMatrices(f_data_D.centroid,
+                                expected_D.centroid_from_bary, kEps));
+  }
+}
+
+GTEST_TEST(DeformableContactTest, ComputeTetMeshTriMeshContactDouble) {
+  TestComputeTetMeshTriMeshContact<double>();
+}
+
+GTEST_TEST(DeformableContactTest, ComputeTetMeshTriMeshContactAutoDiff) {
+  TestComputeTetMeshTriMeshContact<AutoDiffXd>();
+}
+
+}  // namespace
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Provide the public API:

- DeformableContactSurface: a representation of the contact between a
  volume (tetrahedral) mesh and a surface (triangle) mesh. The result
  is a triangle mesh. Each triangle in the mesh can report: normal,
  area, centroid (in Cartesian and Barycentric coordinates) and the tet
  in the volume mesh that produced the triangle.
  - This includes the supporting struct DeformableContactTriangle which
    provides per-triangle data that the geometry::SurfaceMesh does not.
- Defines the function: ComputeTetMeshTriMeshContact.

Changes made to support the goal:

  - SurfaceMesh was given an 'advanced' constructor so algorithms that
    have cheap access to triangle normals can pass them along without
    paying the normalization cost. (Likewise for triangle areas.)

Co-authored-by: Sean Curtis <sean.curtis@tri.global>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14760)
<!-- Reviewable:end -->
