### PR TITLE
getting_help: Fix typo (should be all-caps)

### DIFF
--- a/doc/_pages/getting_help.md
+++ b/doc/_pages/getting_help.md
@@ -52,7 +52,7 @@ When reporting an issue, please consider providing the following information
     * [Building Drake](/from_source.html) vs. downstream project (like [drake_bazel_external](https://github.com/RobotLocomotion/drake-external-examples/tree/master/drake_bazel_external), [drake_cmake_external](https://github.com/RobotLocomotion/drake-external-examples/tree/master/drake_cmake_external))
 * If using binary release:
     * Download URL
-    * Contents of ``drake/share/doc/drake/VERSION.txt``
+    * Contents of ``drake/share/doc/drake/VERSION.TXT``
     * Building downstream project ([drake_cmake_installed](https://github.com/RobotLocomotion/drake-external-examples/tree/master/drake_cmake_installed))
 * If using Binder or Google Colaboratory:
     * A version of your notebook that we can access. Please check this by


### PR DESCRIPTION
Came across due to: https://github.com/RobotLocomotion/drake-external-examples/pull/198

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14764)
<!-- Reviewable:end -->
