### PR TITLE
py mbp: Fix typo on docstring for SpatialVelocity.Rotate

### DIFF
--- a/bindings/pydrake/multibody/math_py.cc
+++ b/bindings/pydrake/multibody/math_py.cc
@@ -80,7 +80,7 @@ void BindSpatialVectorMixin(PyClass* pcls) {
           },
           py::arg("R_FE"),
           R"""(
-          Provides a Python-only implementation of rotating / re-expressing) a
+          Provides a Python-only implementation of rotating / re-expressing a
           spatial vector.
 
           Note:


### PR DESCRIPTION
Was doing visuomotor whatev things, came across this minor typo:
https://drake.mit.edu/pydrake/pydrake.multibody.math.html#pydrake.multibody.math.SpatialVelocity_.SpatialVelocity_[float].Rotate

Typo zoom-on:
> ![image](https://user-images.githubusercontent.com/26719449/110703857-466b2e80-81c2-11eb-9230-94b0c245f127.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14765)
<!-- Reviewable:end -->
