### PR TITLE
Revert "Hardcode python version to 3.6 in setup_drake_colab"

### DIFF
--- a/tools/install/colab/setup_drake_colab.py
+++ b/tools/install/colab/setup_drake_colab.py
@@ -60,7 +60,7 @@ def setup_drake(*, version, build='nightly'):
 
     # Check for conflicting pydrake installations.
     v = sys.version_info
-    path = f"/opt/drake/lib/python3.6/site-packages"
+    path = f"/opt/drake/lib/python{v.major}.{v.minor}/site-packages"
     spec = importlib.util.find_spec('pydrake')
     if spec is not None and path not in spec.origin:
         raise Exception("Found a conflicting version of pydrake on your "


### PR DESCRIPTION
Reverts RobotLocomotion/drake#14693.

The hard-coding did not resolve the problem, and technically the major.minor spelling is less incorrect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14766)
<!-- Reviewable:end -->
