### PR TITLE
Fix sitemap generation

### DIFF
--- a/doc/build.py
+++ b/doc/build.py
@@ -96,13 +96,13 @@ def _build_sitemap(site_dir: str) -> None:
             location = relative_path.as_posix()
             location = urllib.parse.urljoin(ROOT_URL,
                                             urllib.parse.quote(location))
-            loc = ET.SubElement(url, "loc")
-            loc.text = location
-        sitemap = ET.ElementTree(urlset)
-        sitemap.write(os.path.join(site_dir, "sitemap.xml"),
-                      encoding="utf-8",
-                      pretty_print=True,
-                      xml_declaration=True)
+        loc = ET.SubElement(url, "loc")
+        loc.text = location
+    sitemap = ET.ElementTree(urlset)
+    sitemap.write(os.path.join(site_dir, "sitemap.xml"),
+                  encoding="utf-8",
+                  pretty_print=True,
+                  xml_declaration=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Something strange happened to the indent, so we have three broken tags and three urls missing.


From Google:
```
Sitemap can be read, but has errors
Missing XML tag   3 instances
This required tag is missing. Please add it and resubmit.
Examples
Line 5859    Parent tag: url
             Tag: loc
Line 9490    Parent tag: url
             Tag: loc
Line 9518    Parent tag: url
             Tag: loc
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14780)
<!-- Reviewable:end -->
