### PR TITLE
systems: Avoid redundantly computing subsystem feedthrough maps

### DIFF
--- a/systems/framework/diagram.cc
+++ b/systems/framework/diagram.cc
@@ -1025,9 +1025,9 @@ bool Diagram<T>::DiagramHasDirectFeedthrough(int input_port, int output_port)
     size_t removed_count = active_set.erase(current_output_id);
     DRAKE_ASSERT(removed_count == 1);
     const System<T>* sys = current_output_id.first;
-    for (InputPortIndex i(0); i < sys->num_input_ports(); ++i) {
-      if (sys->HasDirectFeedthrough(i, current_output_id.second)) {
-        const InputPortLocator curr_input_id(sys, i);
+    for (const auto& [sys_input, sys_output] : sys->GetDirectFeedthroughs()) {
+      if (sys_output == current_output_id.second) {
+        const InputPortLocator curr_input_id(sys, sys_input);
         if (target_input_ids.count(curr_input_id)) {
           // We've found a direct-feedthrough path to the input_port.
           return true;


### PR DESCRIPTION
We can compute the map once per system and reuse it as we search, instead of once per possible input.  This removes some super-linear growth factor in diagram size that ends up being problematic.

The key observation is that `HasDirectFeedthrough` was always computing the full `GetDirectFeedthroughs` and then throwing away all but the one map entry.

Closes #14787 (by replacing it with a different implementation).

This is a step towards #14774, which would refine the implementation further.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14788)
<!-- Reviewable:end -->
