### PR TITLE
[geometry] Extend characterization framework, apply to point-pair penetration (2 of 4)

### DIFF
--- a/geometry/proximity/test/characterization_utilities.cc
+++ b/geometry/proximity/test/characterization_utilities.cc
@@ -9,8 +9,10 @@
 #include "drake/common/nice_type_name.h"
 #include "drake/common/temp_directory.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/proximity/proximity_utilities.h"
 #include "drake/geometry/proximity_engine.h"
 #include "drake/geometry/utilities.h"
+#include "drake/math/orthonormal_basis.h"
 #include "drake/math/rotation_matrix.h"
 
 namespace drake {
@@ -21,43 +23,165 @@ using Eigen::Vector3d;
 using math::RigidTransform;
 using std::vector;
 
-std::string to_string(const fcl::NODE_TYPE& node) {
-  switch (node) {
-    case fcl::BV_UNKNOWN:
-    case fcl::BV_AABB:
-    case fcl::BV_OBB:
-    case fcl::BV_RSS:
-    case fcl::BV_kIOS:
-    case fcl::BV_OBBRSS:
-    case fcl::BV_KDOP16:
-    case fcl::BV_KDOP18:
-    case fcl::BV_KDOP24:
-    case fcl::GEOM_CONE:
-    case fcl::GEOM_PLANE:
-    case fcl::GEOM_TRIANGLE:
-    case fcl::GEOM_OCTREE:
-    case fcl::NODE_COUNT:
-      return "unsupported type";
-    case fcl::GEOM_BOX:
-      return "Box";
-    case fcl::GEOM_SPHERE:
-      return "Sphere";
-    case fcl::GEOM_ELLIPSOID:
-      return "Ellipsoid";
-    case fcl::GEOM_CAPSULE:
-      return "Capsule";
-    case fcl::GEOM_CYLINDER:
-      return "Cylinder";
-    case fcl::GEOM_CONVEX:
-      return "Convex";
-    case fcl::GEOM_HALFSPACE:
-      return "HalfSpace";
+std::ostream& operator<<(std::ostream& out, GeometryType s) {
+  switch (s) {
+    case kCapsule:
+      out << "Capsule";
+      break;
+    case kEllipsoid:
+      out << "Ellipsoid";
+      break;
+    case kSphere:
+      out << "Sphere";
+      break;
   }
-  DRAKE_UNREACHABLE();
+  return out;
+}
+
+QueryInstance::QueryInstance(GeometryType shape1_in, GeometryType shape2_in,
+                             double error_in)
+    : shape1(shape1_in),
+      shape2(shape2_in),
+      error(error_in),
+      outcome(kSupported) {
+  DRAKE_DEMAND(error >= 0);
+}
+
+QueryInstance::QueryInstance(GeometryType shape1_in, GeometryType shape2_in,
+                             Outcome outcome_in)
+    : shape1(shape1_in), shape2(shape2_in), error(-1), outcome(outcome_in) {
+  DRAKE_DEMAND(outcome != kSupported);
+}
+std::ostream& operator<<(std::ostream& out, const QueryInstance& c) {
+  out << c.shape1 << " vs " << c.shape2;
+  switch (c.outcome) {
+    case kSupported:
+      out << " with expected error: " << c.error;
+      break;
+    case kThrows:
+      out << " should throw";
+      break;
+  }
+  return out;
+}
+
+std::string QueryInstanceName(
+    const testing::TestParamInfo<QueryInstance>& info) {
+  return fmt::format("{}Vs{}", info.param.shape1, info.param.shape2);
+}
+
+template <typename T>
+ShapeConfigurations<T>::ShapeConfigurations(const Shape& shape, double distance)
+    : ShapeReifier(), distance_(distance) {
+  shape.Reify(this);
+}
+
+template <typename T>
+void ShapeConfigurations<T>::ImplementGeometry(const Capsule& capsule, void*) {
+  if (distance_ < 0) {
+    const double depth = -distance_;
+    if (depth > capsule.radius()) {
+      throw std::runtime_error(
+          fmt::format("The capsule (with radius {}) isn't large enough for "
+                      "penetration depth of {}",
+                      capsule.radius(), depth));
+    }
+  }
+  /* We'll arbitrarily return one point on a spherical cap, and one on the
+   barrel. */
+  const double barrel_theta = 6 * M_PI / 7;
+  using std::cos;
+  using std::sin;
+  const Vector3<T> n_barrel_C{cos(barrel_theta), sin(barrel_theta), 0};
+  const Vector3<T> p_CB{n_barrel_C[0] * capsule.radius(),
+                        n_barrel_C[1] * capsule.radius(),
+                        capsule.length() * 0.3};
+
+  const Vector3<T> n_sphere_C = Vector3<T>{2, 0.3, 1.1}.normalized();
+  const Vector3<T> p_CS =
+      Vector3<T>{0, 0, capsule.length() / 2} + n_sphere_C * capsule.radius();
+  configs_ = vector<ShapeTangentPlane<T>>{
+      {p_CB, n_barrel_C, capsule.radius(), "Capsule barrel"},
+      {p_CS, n_sphere_C, capsule.radius(), "Capsule +z cap"}};
+}
+
+template <typename T>
+void ShapeConfigurations<T>::ImplementGeometry(const Ellipsoid& ellipsoid,
+                                               void*) {
+  const double min_axis =
+      std::min({ellipsoid.a(), ellipsoid.b(), ellipsoid.c()});
+  if (distance_ < 0) {
+    const double depth = -distance_;
+    if (depth > min_axis) {
+      throw std::runtime_error(
+          fmt::format("The ellipsoid (with radii = {}, {}, and {}) isn't "
+                      "large enough for penetration depth of {}",
+                      ellipsoid.a(), ellipsoid.b(), ellipsoid.c(), depth));
+    }
+  }
+
+  auto uv_sample = [&ellipsoid](double u, double v) {
+    // Compute a point on the surface of the ellipsoid and the normal at
+    // that point. For the point, we use the parametric equation of the
+    // ellipsoid (on two periodic parameters):
+    //    E = [a⋅cos(u)⋅sin(v), b⋅sin(u)⋅sin(v), c⋅cos(v)].
+    // For the normal, we normalize the gradient of
+    //    f = x² / a² + y² / b² + z² / c²
+    //    ∇f = <2x / a², 2y / b², 2z / c²>
+    //    n = ∇f / |∇f|
+    const double a = ellipsoid.a();
+    const double b = ellipsoid.b();
+    const double c = ellipsoid.c();
+    const double x = a * std::cos(u) * std::sin(v);
+    const double y = b * std::sin(u) * std::sin(v);
+    const double z = c * std::cos(v);
+    // Because we're normalizing the gradient, we simply omit the redundant
+    // scale factor of 2.
+    return std::make_pair(
+        Vector3d{x, y, z},
+        Vector3d{x / a / a, y / b / b, z / c / c}.normalized());
+  };
+
+  const auto& [p1, n1] = uv_sample(M_PI / 3, M_PI / 7);
+  const auto& [p2, n2] = uv_sample(13 * M_PI / 7, 5 * M_PI / 6);
+  configs_ = vector<ShapeTangentPlane<T>>{
+      {p1, n1, min_axis, "ellipsoid's -x/+y/+z octant"},
+      {p2, n2, min_axis, "ellipsoid's +x/-y/+z octant"}};
+}
+
+template <typename T>
+void ShapeConfigurations<T>::ImplementGeometry(const Sphere& sphere, void*) {
+  const double r = sphere.radius();
+  if (distance_ < 0) {
+    const double depth = -distance_;
+    if (depth > r) {
+      throw std::runtime_error(
+          fmt::format("The sphere (with radius = {}) isn't large enough for "
+                      "penetration depth of {}",
+                      r, depth));
+    }
+  }
+  /* A couple of random points in arbitrary directions. */
+  const Vector3<T> n1 = Vector3<T>{-1, 1, 1.5}.normalized();
+  const Vector3<T> p1 = n1 * r;
+  const Vector3<T> n2 = Vector3<T>{1, -2, 0.3}.normalized();
+  const Vector3<T> p2 = n2 * r;
+  configs_ =
+      vector<ShapeTangentPlane<T>>{{p1, n1, r, "sphere's -x/+y/+z octant"},
+                                   {p2, n2, r, "sphere's +x/-y/+z octant"}};
 }
 
 MakeFclShape::MakeFclShape(const Shape& shape) : ShapeReifier() {
   shape.Reify(this);
+}
+
+void MakeFclShape::ImplementGeometry(const Capsule& capsule, void*) {
+  object_ = std::make_shared<fcl::Capsuled>(capsule.radius(), capsule.length());
+}
+
+void MakeFclShape::ImplementGeometry(const Ellipsoid& ellipsoid, void*) {
+  object_ = std::make_shared<fcl::Ellipsoidd>(ellipsoid.a(), ellipsoid.b(),
+                                              ellipsoid.c());
 }
 
 void MakeFclShape::ImplementGeometry(const Sphere& sphere, void*) {
@@ -65,20 +189,72 @@ void MakeFclShape::ImplementGeometry(const Sphere& sphere, void*) {
 }
 
 template <typename T>
+RigidTransform<T> AlignPlanes(const Vector3<T>& P, const Vector3<T>& m,
+                              const Vector3<T>& Q, const Vector3<T>& n) {
+  /* For notation, we'll assume |n| = |m| = 1 (in the code we'll enforce it).
+
+  We find rotation R such that -m = R⋅n.
+  The angle between -m and n is simply acos(n.dot(-m)).
+  The vector around which to rotate n is given by their cross product. */
+  const Vector3<T> neg_mhat = -m.normalized();
+  const Vector3<T> nhat = n.normalized();
+  const T cos_theta = nhat.dot(neg_mhat);
+
+  /* Default to identity if n and m are already aligned. */
+  math::RotationMatrix<T> R;
+  constexpr double kAlmostOne = 1 - std::numeric_limits<double>::epsilon();
+  if (cos_theta < kAlmostOne) {
+    /* They aren't already anti-parallel. */
+    if (cos_theta < -kAlmostOne) {
+      /* We need a normal perpendicular to nhat. Extract it from a valid
+       basis. */
+      const Matrix3<T> basis = math::ComputeBasisFromAxis(2, nhat);
+      const Vector3<T> rhat = basis.col(0);
+      R = math::RotationMatrix<T>(AngleAxis<T>{M_PI, rhat});
+    } else {
+      const Vector3<T> rhat = nhat.cross(neg_mhat).normalized();
+      using std::acos;
+      R = math::RotationMatrix<T>(AngleAxis<T>{acos(cos_theta), rhat});
+      if ((R * nhat).dot(neg_mhat) < kAlmostOne) {
+        /* Detect if we rotated in the wrong direction. By construction this
+         shouldn't happen. The direction of rhat will always make use of the
+         *positive* angle that we computed with acos.  */
+        DRAKE_UNREACHABLE();
+      }
+    }
+  }
+
+  const Vector3<T> p_QP_A = P - R * Q;
+  return RigidTransform<T>{R, p_QP_A};
+}
+
+template RigidTransform<double> AlignPlanes<double>(const Vector3<double>&,
+                                                    const Vector3<double>&,
+                                                    const Vector3<double>&,
+                                                    const Vector3<double>&);
+template RigidTransform<AutoDiffXd> AlignPlanes<AutoDiffXd>(
+    const Vector3<AutoDiffXd>&, const Vector3<AutoDiffXd>&,
+    const Vector3<AutoDiffXd>&, const Vector3<AutoDiffXd>&);
+
+template <typename T>
 void CharacterizeResultTest<T>::RunCallback(
-    const Expectation& expectation, fcl::CollisionObjectd* obj_A,
+    const QueryInstance& query, fcl::CollisionObjectd* obj_A,
     fcl::CollisionObjectd* obj_B, const CollisionFilterLegacy* collision_filter,
     const std::unordered_map<GeometryId, RigidTransform<T>>* X_WGs)
     const {
   callback_->ClearResults();
   ASSERT_EQ(callback_->GetNumResults(), 0);
-  if (expectation.can_compute) {
-    ASSERT_FALSE(callback_->Invoke(obj_A, obj_B, collision_filter, X_WGs));
-    ASSERT_EQ(callback_->GetNumResults(), 1) << "No results reported!";
-  } else {
-    DRAKE_ASSERT_THROWS_MESSAGE(
-        callback_->Invoke(obj_A, obj_B, collision_filter, X_WGs),
-        std::exception, expectation.error_message);
+  switch (query.outcome) {
+    case kSupported:
+      ASSERT_FALSE(callback_->Invoke(obj_A, obj_B, collision_filter, X_WGs));
+      ASSERT_EQ(callback_->GetNumResults(), 1) << "No results reported!";
+      break;
+    case kThrows:
+      DRAKE_ASSERT_THROWS_MESSAGE(
+          callback_->Invoke(obj_A, obj_B, collision_filter, X_WGs),
+          std::exception,
+          ".+ queries between shapes .+ and .+ are not supported.+");
+      break;
   }
 }
 
@@ -96,8 +272,53 @@ std::optional<double> CharacterizeResultTest<T>::ComputeErrorMaybe(
 }
 
 template <typename T>
+vector<Configuration<T>> CharacterizeResultTest<T>::MakeConfigurations(
+    const Shape& shape_A, const Shape& shape_B,
+    const vector<double>& signed_distances) const {
+  vector<Configuration<T>> configs;
+  for (const double signed_distance : signed_distances) {
+    /* In order to pose the geometries, we start with X_WA = X_WB = I. That
+     means all quantities measured and expressed in frames A and B, are
+     likewise measured and expressed in the world frame. The notation below
+     reflects this. */
+    const vector<ShapeTangentPlane<T>> samples_A =
+        ShapeConfigurations<T>(shape_A, signed_distance).configs();
+    const vector<ShapeTangentPlane<T>> samples_B =
+        ShapeConfigurations<T>(shape_B, signed_distance).configs();
+    for (const auto& sample_A : samples_A) {
+      const Vector3<T>& p_WA = sample_A.point;
+      const Vector3<T>& a_norm_W = sample_A.normal;
+      /* The witness point. When penetrating, signed_distance is negative and
+       we offset from the surface *into* the shape (via the negatively scaled
+       normal). When separating, we move in the positive direction.  */
+      const Vector3<T> p_WC = p_WA + a_norm_W * signed_distance;
+      for (const auto& sample_B : samples_B) {
+        /* We can only combine these two samples if at least *one* of them
+         can accommodate the requested penetration depth. Note that the sample
+         record the value of the maximum *depth* (negative of signed distance).
+         */
+        using std::max;
+        if (max(sample_A.max_depth, sample_B.max_depth) < -signed_distance) {
+          continue;
+        }
+        const Vector3<T>& p_WB = sample_B.point;
+        const Vector3<T>& b_norm_W = sample_B.normal;
+        const std::string relates =
+            signed_distance < 0
+                ? " penetrates into "
+                : (signed_distance > 0 ? " separated from " : " touching ");
+        configs.push_back(
+            {AlignPlanes(p_WC, a_norm_W, p_WB, b_norm_W), signed_distance,
+             sample_B.description + relates + sample_A.description});
+      }
+    }
+  }
+  return configs;
+}
+
+template <typename T>
 void CharacterizeResultTest<T>::RunCharacterization(
-    const Expectation& expectation, const Shape& shape_A, const Shape& shape_B,
+    const QueryInstance& query, const Shape& shape_A, const Shape& shape_B,
     const vector<Configuration<T>>& configs) {
   fcl::CollisionObjectd object_A = MakeFclShape(shape_A).object();
   const GeometryId id_A = EncodeData(&object_A);
@@ -110,21 +331,21 @@ void CharacterizeResultTest<T>::RunCharacterization(
   std::optional<Configuration<T>> worst_config;
 
   auto evaluate_callback =
-      [this, &expectation, &worst_error, &worst_config](
+      [this, &query, &worst_error, &worst_config](
           char first, fcl::CollisionObjectd* obj_A, char second,
           fcl::CollisionObjectd* obj_B, auto test_config,
           const std::unordered_map<GeometryId, RigidTransform<T>>&
               world_poses) {
         SCOPED_TRACE(fmt::format(
             "\n{}-{} (obj {}-obj {}) query:"
+            "\n  {}"
             "\n  Expected signed distance: {}"
             "\n  X_AB"
             "\n{}\n",
-            to_string(obj_A->collisionGeometry()->getNodeType()),
-            to_string(obj_B->collisionGeometry()->getNodeType()), first, second,
-            test_config.signed_distance, test_config.X_AB.GetAsMatrix34()));
-        RunCallback(expectation, obj_A, obj_B, &collision_filter_,
-                    &world_poses);
+            GetGeometryName(*obj_A), GetGeometryName(*obj_B), first, second,
+            test_config.description, test_config.signed_distance,
+            test_config.X_AB.GetAsMatrix34()));
+        RunCallback(query, obj_A, obj_B, &collision_filter_, &world_poses);
         const std::optional<double> error =
             ComputeErrorMaybe(test_config.signed_distance);
         if (error.has_value() &&
@@ -146,28 +367,39 @@ void CharacterizeResultTest<T>::RunCharacterization(
     }
   }
 
-  /* Last reality check. If the expectation was for computability, we better
+  /* Last reality check. If the query was expected to be supported, we better
    report *some* value as an error, even if it's zero. */
-  ASSERT_EQ(expectation.can_compute, worst_error.has_value());
+  ASSERT_EQ(query.outcome == kSupported, worst_error.has_value());
   /* The only way worst_error has no value, is that we expected *every*
    configuration to fail. Then no value is the correct outcome. */
   if (worst_error.has_value()) {
     /* Our definition of "close" to epsilon: within 2 bits. Still a tight
      bound but gives a modicum of breathing room. */
     constexpr double cutoff = 4 * std::numeric_limits<double>::epsilon();
-    if (expectation.max_error > cutoff) {
-      EXPECT_GT(*worst_error, expectation.max_error / 2)
+    if (query.error > cutoff) {
+      EXPECT_GT(*worst_error, query.error / 2)
           << "Expected error is too big!"
-          << "\n    Expected error: " << expectation.max_error
+          << "\n  " << worst_config->description
+          << "\n    Expected error: " << query.error
           << "\n    Observed error: " << (*worst_error)
           << "\n    For distance: " << worst_config->signed_distance;
     }
-    EXPECT_LE(*worst_error, expectation.max_error)
+    EXPECT_LE(*worst_error, query.error)
         << "Expected error is too small!"
-        << "\n    Expected error: " << expectation.max_error
+        << "\n  " << worst_config->description
+        << "\n    Expected error: " << query.error
         << "\n    Observed error: " << (*worst_error)
         << "\n    For distance: " << worst_config->signed_distance;
   }
+}
+
+template <typename T>
+void CharacterizeResultTest<T>::RunCharacterization(
+    const QueryInstance& query) {
+  auto shape1 = MakeShape(query.shape1, false /* use_alt */);
+  auto shape2 = MakeShape(query.shape2, query.shape1 == query.shape2);
+  RunCharacterization(query, *shape1, *shape2,
+                      MakeConfigurations(*shape1, *shape2, TestDistances()));
 }
 
 template <typename T>
@@ -190,9 +422,48 @@ vector<RigidTransform<T>> CharacterizeResultTest<T>::X_WAs() {
                         Vector3<T>{-10.0, 20.2, -12.3}}};
 }
 
+template <typename T>
+std::unique_ptr<Shape> CharacterizeResultTest<T>::MakeShape(GeometryType shape,
+                                                            bool use_alt) {
+  switch (shape) {
+    case kCapsule:
+      return std::make_unique<Capsule>(capsule(use_alt));
+    case kEllipsoid:
+      return std::make_unique<Ellipsoid>(ellipsoid(use_alt));
+    case kSphere:
+      return std::make_unique<Sphere>(sphere(use_alt));
+  }
+  DRAKE_UNREACHABLE();
+}
+
+template <typename T>
+Capsule CharacterizeResultTest<T>::capsule(bool alt) {
+  if (alt) {
+    return Capsule{kDistance * 19, kDistance * 100};
+  } else {
+    return Capsule{kDistance * 100, kDistance * 51};
+  }
+}
+
+template <typename T>
+Ellipsoid CharacterizeResultTest<T>::ellipsoid(bool alt) {
+  if (alt) {
+    return Ellipsoid{kDistance * 35, kDistance * 100, kDistance * 68};
+  } else {
+    return Ellipsoid{kDistance * 47, kDistance * 26, kDistance * 100};
+  }
+}
+
+template <typename T>
+Sphere CharacterizeResultTest<T>::sphere(bool) {
+  return Sphere(kDistance * 100);
+}
+
 }  // namespace internal
 }  // namespace geometry
 }  // namespace drake
 
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
   class ::drake::geometry::internal::CharacterizeResultTest)
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+  class ::drake::geometry::internal::ShapeConfigurations)

--- a/geometry/proximity/test/characterization_utilities.h
+++ b/geometry/proximity/test/characterization_utilities.h
@@ -56,15 +56,46 @@ class DistanceCallback {
   virtual T GetFirstSignedDistance() const = 0;
 };
 
-/* Reports the expected outcome for a characterized result test. If can_compute
- is true, `max_error` should be non-negative measure (in meters) which should
- be *near* the worst observed error. If false, `error_message` should be valid.
- */
-struct Expectation {
-  bool can_compute{};
-  double max_error{};
-  std::string error_message;
+/* Encodes the possible outcomes of performing a proximity query. For a given
+ set of query parameters/scalar attempting to perform the query should either
+ work or not. */
+enum Outcome { kSupported, kThrows };
+
+/* The types of geometries that can be considered for characterization tests.
+ Note: the geometries enumerated here includes a Point (which is not a
+ drake::Shape). */
+enum GeometryType {
+  kCapsule,
+  kEllipsoid,
+  kSphere
 };
+std::ostream& operator<<(std::ostream& out, GeometryType s);
+
+/* This represents a single cell of the table -- an instance of invoking a
+ proximity query. It explicitly calls out the two shapes and the expected
+ outcome, and relies on the context to define the scalar. */
+struct QueryInstance {
+  /* Constructs a query instance that should successfully evaluate, producing a
+   result with the given error. */
+  QueryInstance(GeometryType shape1, GeometryType shape2, double error);
+
+  /* Constructs a query instance that doesn't successfully evaluate -- the test
+   may throw or silently do nothing as indicated by the declared `outcome`.
+   @pre outcome != kSupported */
+  QueryInstance(GeometryType shape1, GeometryType shape2, Outcome outcome);
+
+  const GeometryType shape1{};
+  const GeometryType shape2{};
+  const double error{};
+  const Outcome outcome{};
+};
+
+std::ostream& operator<<(std::ostream& out, const QueryInstance& c);
+
+/* Function to convert QueryInstance values into meaningful value test names
+ for gtest.  */
+std::string QueryInstanceName(
+    const testing::TestParamInfo<QueryInstance>& info);
 
 /* Defines a test configuration for two shapes: the pose between the two
  shapes, the expected signed_distance, and a description to aid in assessing
@@ -73,12 +104,86 @@ template <typename T>
 struct Configuration {
   math::RigidTransform<T> X_AB;
   double signed_distance{};
+  std::string description;
 };
 
-/* Renders an FCL enumeration into a string to support intelligible error
- messages. Note: we're only covering the enumeration values that Drake
- specifically uses.  */
-std::string to_string(const fcl::NODE_TYPE& node);
+/* The challenge of testing signed distance (and related) queries, is to put
+ two arbitrary shapes into a non-trivial relative pose which, nevertheless,
+ should produce an unambiguous distance value. All of the following code
+ supports that effort. See specific notes below.  */
+
+/* Defines a tangent plane on the surface of a shape (in whatever frame the
+ shape itself is expressed in). The given `point` lies on both the plane and
+ the surface of the shape. The normal should point *out* of the shape such that
+ the shape is "under" the plane (i.e., the signed distance to the plane is <= 0
+ for all points in the shape). The normal direction may not be unique (e.g., for
+ a box's vertex, the associated normal is any direction in the corresponding
+ octant).
+
+ The tangent plane contains one further piece of information. Given the tangent
+ plane defined by point P and normal n, we define a set of points
+ Q = P - δ⋅n (for δ ≥ 0). We report a `max_depth` value -- the largest value of
+ δ such that we can guarantee that P is the closest point on the surface of the
+ geometry to all of the Qs for δ ∈ [0, δₘₐₓ]. This will inform us as to which
+ samples can be combined into a valid configuration. To be a valid configuration
+ for penetration, at least *one* of the samples needs to have a `max_depth`
+ value that is greater than or equal to the targeted depth.
+
+ We use the TangentPlane to pose geometries; see AlignTangentPlanes for
+ details.  */
+template <typename T>
+struct ShapeTangentPlane {
+  Vector3<T> point;
+  Vector3<T> normal;
+  double max_depth{};
+  std::string description;
+};
+
+/* Creates a set of "interesting" samples (each a tangent plane) on the given
+ geometry.
+
+ The samples we return must be able to support an expected signed distance
+ query result. In some cases, the sign and magnitude of the targeted distance
+ can change what the samples are. See the various implementations for details.
+ */
+template <typename T>
+class ShapeConfigurations : public ShapeReifier {
+ public:
+  /* Constructs the configurations for the given shape and requested distance.
+   */
+  ShapeConfigurations(const Shape& shape, double distance);
+
+  /* @name Implementation of ShapeReifier interface
+
+   Where meaningful, each of these implementations will test the geometry
+   against *negative* signed distance to confirm the shape is large enough to be
+   able to manifest penetration depth of the requested magnitude. If the test
+   fails, the method throws.  */
+  //@{
+
+  using ShapeReifier::ImplementGeometry;
+  /* The capsule samples do *not* depend on `signed_distance`. One is located on
+   one of the spherical caps, the other on the barrel.  */
+  void ImplementGeometry(const Capsule& capsule, void*) final;
+
+  /* The sampling of the ellipsoid does *not* depend on `signed_distance`.
+   The samples are simply two arbitrary points on the surface of the ellipsoid
+   in different octants.  */
+  void ImplementGeometry(const Ellipsoid& ellipsoid, void*) final;
+
+  /* The samples are at two arbitrary points in different octants of the sphere.
+   */
+  void ImplementGeometry(const Sphere& sphere, void*) final;
+  //@}
+
+  /* We're returning a *copy* because we're using this in a manner in which the
+   owning reifier may not stay alive. */
+  std::vector<ShapeTangentPlane<T>> configs() const { return configs_; }
+
+ private:
+  double distance_{};
+  std::vector<ShapeTangentPlane<T>> configs_;
+};
 
 /* @name Fcl geometry from drake shape specifications. */
 class MakeFclShape : public ShapeReifier {
@@ -87,6 +192,8 @@ class MakeFclShape : public ShapeReifier {
 
   /* Implementation of ShapeReifier interface  */
   using ShapeReifier::ImplementGeometry;
+  void ImplementGeometry(const Capsule& capsule, void*) final;
+  void ImplementGeometry(const Ellipsoid& ellipsoid, void*) final;
   void ImplementGeometry(const Sphere& sphere, void*) final;
 
   std::shared_ptr<fcl::CollisionGeometry<double>> object() const {
@@ -96,6 +203,21 @@ class MakeFclShape : public ShapeReifier {
  private:
   std::shared_ptr<fcl::CollisionGeometry<double>> object_{};
 };
+
+/* Creates a transform to align two planes. The planes are defined by a
+ (point, normal) pair -- the point lies on the plane and the normal is
+ perpendicular to the plane. In this case, we have planes (P, m⃗) and (Q, n⃗). We
+ produce a transform X = [R t] such that:
+   X ⋅ Q = P
+   R ⋅ n⃗ = -m⃗
+In other words, we transform the second plane (Q, n⃗) so Q and P are coincident
+and m⃗ and n⃗ are anti-parallel. The notation is frameless, because we're
+not really relating two frames so much as creating a transform operator
+(although we *do* assume that all quantities are measured and expressed in a
+common frame). */
+template <typename T>
+math::RigidTransform<T> AlignPlanes(const Vector3<T>& P, const Vector3<T>& m,
+                                    const Vector3<T>& Q, const Vector3<T>& n);
 
 /* This test provides a common framework for testing signed-distance based
  proximity queries. Specifically, it provides *direct* support in populating
@@ -124,12 +246,12 @@ class CharacterizeResultTest : public ::testing::Test {
       : callback_(std::move(callback)) {}
 
   /* Runs a single instance of the callback for the given collision objects.
-   Confirms the computability of the callback against the expectation. If
-   expectation.can_compute is true, it confirms the successful execution of the
-   query reports a single result. Otherwise, confirms that the callback
-   throws with an error matching that contained in the expectation. */
+   Confirms the callback result against the expected outcome. If query.outcome
+   is kSupported, it confirms the successful execution of the query reports a
+   single result. Otherwise, confirms that the callback throws with a common
+   "unsupported operation" type exception message. */
   void RunCallback(
-      const Expectation& expectation, fcl::CollisionObjectd* obj_A,
+      const QueryInstance& query, fcl::CollisionObjectd* obj_A,
       fcl::CollisionObjectd* obj_B,
       const CollisionFilterLegacy* collision_filter,
       const std::unordered_map<GeometryId, math::RigidTransform<T>>* X_WGs)
@@ -141,6 +263,15 @@ class CharacterizeResultTest : public ::testing::Test {
    @pre expected_distance != 0. */
   std::optional<double> ComputeErrorMaybe(double expected_distance) const;
 
+  // TODO(SeanCurtis-TRI) I don't need a bunch of configurations if my
+  //  expectation is that it will fail. So, I should use that information to
+  //  reduce the work I do.
+  /* Creates a set of configurations for the two shapes based on the surface
+   sample points defined for each shape type (see SampleShapeSurface below). */
+  virtual std::vector<Configuration<T>> MakeConfigurations(
+      const Shape& shape_A, const Shape& shape_B,
+      const std::vector<double>& signed_distances) const;
+
   /* Runs the test to characterize the query error between geometries of
    two shape types: Shape1 and Shape2. The caller provides one or more
    configuration specifications (including relative poses of the two shapes
@@ -151,14 +282,14 @@ class CharacterizeResultTest : public ::testing::Test {
    we're testing the query under non-trivial transforms. The query is repeated
    twice: once as (A, B) and again as (B, A) for each configuration.
 
-   The expected outcome of the query is contained in the given `expectation`. It
-   declares whether the query runs at all (`expectation.can_compute`). If it
-   can be computed, error is computed between the returned signed distance and
-   the expected signed distance. Across *all* queries, the worst error is
-   stored. The worst error can't be too much worse or too much *better* than the
-   expected value (`expectation.max_error`) to pass. If the expectation is
-   that the query cannot be computed, we confirm an exception with the given
-   `expectation`'s error message.
+   The expected outcome of the query is contained in `query.outcome`. It
+   declares whether the query expects to compute (`kSuported`). If it is
+   supported, error is computed between the returned signed distance and the
+   expected signed distance. Across *all* queries, the worst error is stored.
+   The worst error can't be too much worse or too much *better* than the
+   expected value (`query.error`) to pass. If the expectation is
+   that the query cannot be computed, we confirm an exception based on a
+   standard "unsupported" message used throughout the callbacks.
 
    This test does most of the work to run the test (accumulating and testing
    worst error), but it uses `RunCallback` to execute the callback and assert
@@ -167,7 +298,7 @@ class CharacterizeResultTest : public ::testing::Test {
    The test passes if the worst error lies in the interval:
 
                 |    error    |
-                |-------------|     e = expectation.max_error
+                |-------------|     e = query.error
                 |             |
                e/2            e
 
@@ -177,7 +308,7 @@ class CharacterizeResultTest : public ::testing::Test {
    *open* interval:
 
                     error    |
-                -------------|     e = expectation.max_error
+                -------------|     e = query.error
                              |
                              3
 
@@ -196,14 +327,23 @@ class CharacterizeResultTest : public ::testing::Test {
    can get the correct answer to within machine epsilon. We want to report the
    *worst case* error and the tests should be articulated as such.
 
-   @param expectation  The expectation for the query result.
+   @param query        The query instance (which contains the expected error).
    @param shape_A      The first shape in the pair.
    @param shape_B      The second shape in the pair.
    @param configs      A collection of test configurations against which we
                        evaluate the callback. */
-  void RunCharacterization(const Expectation& expectation, const Shape& shape_A,
+  void RunCharacterization(const QueryInstance& query, const Shape& shape_A,
                            const Shape& shape_B,
                            const std::vector<Configuration<T>>& configs);
+
+  /* Variant of RunCharacterization that creates a collection of configurations
+   with using the distances given by TestDistances applied to the shapes
+   implied by the query.  */
+  void RunCharacterization(const QueryInstance& query);
+
+  /* Each subclass should define the distances over which it should be
+   evaluated. */
+  virtual std::vector<double> TestDistances() const = 0;
 
   /* Generates a geometry id for the given collision object, encodes the id
    into the object, and returns the id.  */
@@ -230,10 +370,13 @@ class CharacterizeResultTest : public ::testing::Test {
    queries are characterized. */
   static constexpr double kDistance{2e-3};
 
-  static Sphere sphere(bool alt = false) {
-    unused(alt);
-    return Sphere(kDistance * 100);
-  }
+  static std::unique_ptr<Shape> MakeShape(GeometryType shape, bool use_alt);
+
+  static Capsule capsule(bool alt = false);
+
+  static Ellipsoid ellipsoid(bool alt = false);
+
+  static Sphere sphere(bool alt = false);
 
   //}
 
@@ -248,3 +391,5 @@ class CharacterizeResultTest : public ::testing::Test {
 
 DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
   class ::drake::geometry::internal::CharacterizeResultTest)
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+  class ::drake::geometry::internal::ShapeConfigurations)

--- a/geometry/proximity/test/characterization_utilities_test.cc
+++ b/geometry/proximity/test/characterization_utilities_test.cc
@@ -16,6 +16,7 @@ namespace internal {
 
 using Eigen::Vector3d;
 using math::RigidTransformd;
+using std::pair;
 using std::vector;
 
 namespace {
@@ -30,14 +31,185 @@ namespace {
 
 /* The MakeFclShapeTest tests confirm that Drake shape specifications turn into
  the expected fcl geometries. */
-// TODO(SeanCurtis-TRI) Consider templating this on T so I can show I get the
-//  same thing across double and AutoDiffXd.
+
+GTEST_TEST(MakeFclShapeTest, Capsule) {
+  const Capsule capsule(0.25, 0.75);
+  auto fcl_geometry = MakeFclShape(capsule).object();
+  const auto& fcl_capsule = dynamic_cast<fcl::Capsuled&>(*fcl_geometry);
+  EXPECT_EQ(fcl_capsule.radius, capsule.radius());
+  EXPECT_EQ(fcl_capsule.lz, capsule.length());
+}
+
+GTEST_TEST(MakeFclShapeTest, Ellipsoid) {
+  const Ellipsoid ellipsoid(0.25, 0.75, 0.6);
+  auto fcl_geometry = MakeFclShape(ellipsoid).object();
+  const auto& fcl_ellipsoid = dynamic_cast<fcl::Ellipsoidd&>(*fcl_geometry);
+  EXPECT_EQ(fcl_ellipsoid.radii[0], ellipsoid.a());
+  EXPECT_EQ(fcl_ellipsoid.radii[1], ellipsoid.b());
+  EXPECT_EQ(fcl_ellipsoid.radii[2], ellipsoid.c());
+}
 
 GTEST_TEST(MakeFclShapeTest, Sphere) {
   const Sphere sphere(0.7);
   auto fcl_geometry = MakeFclShape(sphere).object();
   const auto& fcl_sphere = dynamic_cast<fcl::Sphered&>(*fcl_geometry);
   EXPECT_EQ(fcl_sphere.radius, sphere.radius());
+}
+
+/* The SampleShapeSurfaceTest tests confirm the two important properties of
+ the sample:
+   - The point on the plane lies on the surface of the shape.
+   - The entire shape lies "under" the plane (i.e. for every point, the signed
+     distance to the plane is <= 0).
+
+ For each shape, we determine the *second* item by identifying a/the most
+ extreme point of the shape in the direction of the plane normal. As long as its
+ distance to the plane is <= 0, then all other points must likewise satisfy the
+ requirement.  */
+// TODO(SeanCurtis-TRI) When we write our own implementation of GJK/EPA the
+//  logic used here to compute the extreme point should be refactored as the
+//  per-shape support function (except for Convex).
+
+GTEST_TEST(SampleShapeSurfaceTest, Capsule) {
+  const double kEps = std::numeric_limits<double>::epsilon();
+
+  const Capsule capsule(0.5, 0.75);
+
+  /* We validate for a requested penetration that is too deep.  */
+  EXPECT_THROW(ShapeConfigurations<double>(capsule, -capsule.radius() * 1.01),
+               std::exception);
+  /* Otherwise, any distance value larger is fine. */
+  for (const auto& tangent_plane :
+       ShapeConfigurations<double>(capsule, 0.0).configs()) {
+    const Vector3d p_GP = tangent_plane.point;
+    const Vector3d n_G = tangent_plane.normal;
+    /* A capsule is the Minkowski sum of a sphere and a line segment. So, the
+     extreme point E will always be a point on a sphere with the capsule radius
+     whose center is located on the line segment. Specifically, it's the point
+     of the sphere in the plane normal direction. So, the only challenge is
+     figuring out where the sphere center is: the point on the *line* segment
+     that is most in the plane normal direction.
+
+     The capsule is defined with its axis aligned with Gz. If n_G.z() is
+     positive, the segment's extreme point (and sphere center C) lies at
+     (0, 0, l/2), if  negative, (0, 0, -l/2). Otherwise, all points on the line
+     are equally close to the plane. */
+    const double half_length = capsule.length() / 2;
+    const Vector3d p_GC(0, 0, half_length * (n_G.z() > 0 ? 1 : -1));
+    const Vector3d p_GE = p_GC + n_G * capsule.radius();
+    /* Now confirm the extreme point lies "under" the plane. */
+    ASSERT_LE((p_GE - p_GP).dot(n_G), kEps);
+
+    /* Point p_GP should be radius distance from the line segment. We find the
+     nearest point to P on the line segment as (0, 0, z) and determine the
+     distance is equal to the capsule radius. */
+    const double z = std::clamp(p_GP.z(), -half_length, half_length);
+    ASSERT_NEAR((p_GP - Vector3d(0, 0, z)).norm(), capsule.radius(), kEps);
+  }
+}
+
+GTEST_TEST(SampleShapeSurfaceTest, Ellipsoid) {
+  /* We need a bit more slack in determining the calculations of the ellipsoid.
+   Empirically, one bit seemed sufficient, we'll take two to buy some
+   cross-platform resiliency. */
+  const double kEps = 4 * std::numeric_limits<double>::epsilon();
+
+  const Ellipsoid ellipsoid(0.5, 0.75, 0.325);
+
+  /* We validate for a requested penetration that is too deep. And we're
+   exploiting the knowledge that we constructed the ellipsoid with c as the
+   minimum coefficient. */
+  EXPECT_THROW(ShapeConfigurations<double>(ellipsoid, -ellipsoid.c() * 1.01),
+               std::exception);
+
+  /* These quantities are for the calculation documented below. */
+  const Vector3d axes(ellipsoid.a(), ellipsoid.b(), ellipsoid.c());
+  const Vector3d axes_squared = axes.cwiseProduct(axes);
+
+  /* Otherwise, any distance value larger is fine. */
+  for (const auto& tangent_plane :
+       ShapeConfigurations<double>(ellipsoid, 0.0).configs()) {
+    const Vector3d p_GP = tangent_plane.point;
+    const Vector3d n_G = tangent_plane.normal;
+    /* The extreme point on the ellipsoid in the n_G direction can be found by
+     (1) applying an affine transformation to transform the ellipsoid and
+     normal such that the ellipsoid becomes a unit sphere, (2) find the point on
+     the sphere S whose normal is in the same direction as the transformed
+     normal, and (3) transform the S to its corresponding point on the ellipsoid
+     E.
+
+     Note: The affine transformation from ellipsoid to sphere is as follows:
+       - for *point* P on ellipsoid: <Px/a, Py/b, Pz/c>
+       - for *normal* n on ellipsoid: <a⋅nx, b⋅ny, c⋅nz>
+     We reverse them to map the other way.
+
+       n_G = <nx, ny, nz>
+       n_S = <a⋅nx, b⋅ny, c⋅nz>       (1) Affine transform the *normal*.
+       S = n_S / |n_S|                (2) We get the normal by normalizing the
+                                          direction to the point on the sphere.
+       E = <a⋅Sx, b⋅Sy, c⋅Sz>         (3) Affine transform of *point*.
+
+     With some algebra, it looks like this:
+
+       E = <a²⋅nx, b²⋅ny, c²⋅nz> / sqrt(a²⋅nx² + b²⋅ny² + c²⋅nz²) */
+    const Vector3d E_scaled = n_G.cwiseProduct(axes_squared);
+    const Vector3d p_GE = E_scaled / std::sqrt(n_G.dot(E_scaled));
+    /* Validate E lies on the ellipsoid: x²/a² + y²/b² + z²/c² = 1. */
+    ASSERT_NEAR(p_GE.cwiseProduct(p_GE).cwiseQuotient(axes_squared).sum(), 1.0,
+                kEps);
+    /* Now confirm the extreme point lies "under" the plane. */
+    ASSERT_LE((p_GE - p_GP).dot(n_G), kEps);
+
+    /* Validate P lies on the ellipsoid: x²/a² + y²/b² + z²/c² = 1. */
+    ASSERT_NEAR(p_GP.cwiseProduct(p_GP).cwiseQuotient(axes_squared).sum(), 1.0,
+                kEps);
+  }
+}
+
+GTEST_TEST(SampleShapeSurfaceTest, Sphere) {
+  const double kEps = std::numeric_limits<double>::epsilon();
+
+  const Sphere sphere(0.75);
+
+  /* We validate for a requested penetration that is too deep.  */
+  EXPECT_THROW(ShapeConfigurations<double>(sphere, -sphere.radius() * 1.01),
+               std::exception);
+  /* Otherwise, any distance value larger is fine. */
+  for (const auto& tangent_plane :
+       ShapeConfigurations<double>(sphere, 0.0).configs()) {
+    const Vector3d p_GP = tangent_plane.point;
+    const Vector3d n_G = tangent_plane.normal;
+    /* The extreme point is simply a point radius distance from the origin in
+     the n_G direction. */
+    const Vector3d p_GE = n_G * sphere.radius();
+    /* Now confirm the extreme point lies "under" the plane. */
+    ASSERT_LE((p_GE - p_GP).dot(n_G), kEps);
+
+    /* The point P must be radius distance from the origin.  */
+    EXPECT_NEAR(p_GP.norm(), sphere.radius(), kEps);
+  }
+}
+
+/* This confirms that AlignPlanes successfully aligns the planes; the pose given
+ makes the points coincident and the normals anti-parallel. */
+GTEST_TEST(AlignPlanes, Correctness) {
+  const double kEps = std::numeric_limits<double>::epsilon();
+
+  /* We pick an arbitrary, ugly point and normal. */
+  const Vector3d p_WP(0.123, -0.456, 0.789);
+  const Vector3d m_W = Vector3d(1, 2, -3).normalized();
+
+  /* We'll create a sequence of tangent planes and confirm that they get
+   properly aligned. */
+  vector<pair<Vector3d, Vector3d>> test_planes{
+      {Vector3d{0, 0, 1}, Vector3d{0, -1, 0}},
+      {Vector3d{0.125, 0.25, 0.5}, Vector3d{-1, 2, 0}.normalized()},
+      {Vector3d{-0.3, -0.7, 0.9}, Vector3d{3, -1, -2}.normalized()}};
+  for (const auto& [p_WQ, n_W] : test_planes) {
+    const RigidTransformd X_AB = AlignPlanes<double>(p_WP, m_W, p_WQ, n_W);
+    EXPECT_TRUE(CompareMatrices(X_AB * p_WQ, p_WP, kEps));
+    EXPECT_TRUE(CompareMatrices(X_AB.rotation() * n_W, -m_W, kEps));
+  }
 }
 
 /* Dummy callback, callback data, and traits for the CharacterizeResultTest.  */
@@ -70,7 +242,7 @@ GTEST_TEST(MakeFclShapeTest, Sphere) {
 template <typename T>
 class DummyCallbackData {
  public:
-  explicit DummyCallbackData(std::vector<T>* results) : results_(results) {
+  explicit DummyCallbackData(vector<T>* results) : results_(results) {
     DRAKE_DEMAND(results != nullptr);
   }
 
@@ -111,20 +283,20 @@ class DummyCallbackData {
 
   static size_t get_invocations() { return invocations; }
 
-  std::vector<T>& results() { return *results_; }
-  const std::vector<T>& results() const { return *results_; }
+  vector<T>& results() { return *results_; }
+  const vector<T>& results() const { return *results_; }
 
  private:
   static size_t invocations;
-  static std::vector<T> sequence;
-  std::vector<T>* results_;
+  static vector<T> sequence;
+  vector<T>* results_;
 };
 
 template <typename T>
 size_t DummyCallbackData<T>::invocations = 0;
 
 template <typename T>
-std::vector<T> DummyCallbackData<T>::sequence;
+vector<T> DummyCallbackData<T>::sequence;
 
 template <typename T>
 bool DummyCallback(fcl::CollisionObjectd*, fcl::CollisionObjectd*, void* data) {
@@ -143,7 +315,7 @@ GTEST_TEST(DummyCallbackTest, ConfirmErrorSequence) {
     for (double truth : {-0.5, 0.75}) {
       for (double precision : {1e-3, 1e-10, 1e-15}) {
         DummyCallbackData<double>::SetValueSequence(count, truth, precision);
-        std::vector<double> results;
+        vector<double> results;
         DummyCallbackData<double> data(&results);
         for (int i = 0; i < count; ++i) {
           DummyCallback<double>(nullptr, nullptr, &data);
@@ -191,8 +363,7 @@ class DummyImplementation : public DistanceCallback<T> {
 
  In this case, we use the DummyCallback (documented above) with *known*
  semantics. Given the number of known invocations, a truth value, and a
- precision we want to predict, we want to confirm that the test detects that
- precision.
+ predicted error, we confirm that the test detects that error.
 
  We need to know the number of expected invocations. For each unique
  configuration, RunCharacterization invokes the callback multiple times:
@@ -201,31 +372,72 @@ class DummyImplementation : public DistanceCallback<T> {
      N is the number of poses reported by X_WAs().
    - Once as geometry pair (A, B) and once for (B, A) (in case there's an
      asymmetry in the algorithm that produces bad answers).
+   - We override MakeConfigurations so that there's only a single configuration
+     between the two shapes.
 
   Therefore, for one configuration there will be 2N calls to callback. */
-class RunCharacterizationTest
-    : public CharacterizeResultTest<double> {
+class RunCharacterizationCustomTest : public CharacterizeResultTest<double> {
+ public:
+  RunCharacterizationCustomTest()
+      : CharacterizeResultTest<double>(
+            std::make_unique<DummyImplementation<double>>()) {}
+
+  vector<double> TestDistances() const final { return {kTruth}; }
+
+  vector<Configuration<double>> MakeConfigurations(
+      const Shape&, const Shape&, const vector<double>&) const final {
+    return {Configuration<double>{{}, kTruth, "Dummy"}};
+  }
+
+  static constexpr double kTruth{1.0};
+};
+
+/* Create a single configuration and confirm the expected results.  */
+TEST_F(RunCharacterizationCustomTest, CustomConfigurations) {
+  const int call_count = 2 * static_cast<int>(X_WAs().size());
+  for (const double target_precision : {1e-2, 1e-7, 1e-14}) {
+    DummyCallbackData<double>::SetValueSequence(call_count, this->kTruth,
+                                                target_precision);
+    const QueryInstance query{kSphere, kSphere, target_precision};
+    /* If this test passes, it detected the expected precision. */
+    RunCharacterization(query);
+    /* If this test passes, it did all the required work. */
+    EXPECT_EQ(DummyCallbackData<double>::get_invocations(), call_count);
+  }
+}
+
+/* In this case, we confirm that if MakeConfigurations is *not* overridden, that
+ we'll get the expected collection (at least by count) of configurations
+ automatically generated. Contrast that with RunCharacterizationCustomTest. */
+class RunCharacterizationTest : public CharacterizeResultTest<double> {
  public:
   RunCharacterizationTest()
       : CharacterizeResultTest<double>(
             std::make_unique<DummyImplementation<double>>()) {}
+
+  vector<double> TestDistances() const final {
+    return {this->sphere().radius() * 0.25};
+  }
 };
 
-/* Create a single configuration and confirm the expected results.  */
-TEST_F(RunCharacterizationTest, CustomConfigurations) {
-  const int call_count = 2 * static_cast<int>(X_WAs().size());
-  const double truth = 1;
-  for (const double target_precision : {1e-2, 1e-7, 1e-14}) {
-    DummyCallbackData<double>::SetValueSequence(call_count, truth,
-                                                target_precision);
-    const Expectation expectation{true, target_precision, ""};
-    const Configuration<double> config{{}, truth};
-    /* If this test passes, it detected the expected precision. */
-    RunCharacterization(expectation, this->sphere(), this->sphere(true),
-                        {config});
-    /* If this test passes, it did all the required work. */
-    EXPECT_EQ(DummyCallbackData<double>::get_invocations(), call_count);
-  }
+/* Confirm that when we don't explicitly enumerate the configurations, but
+ rely on the test to generate its own, that we get the results we expect. */
+TEST_F(RunCharacterizationTest, DefaultConfigurations) {
+  const Sphere sphere = this->sphere();
+  const int sphere_config_count =
+      static_cast<int>(ShapeConfigurations<double>(sphere, 0).configs().size());
+  const int pose_count = static_cast<int>(X_WAs().size());
+  const int call_count =
+      2 * sphere_config_count * sphere_config_count * pose_count;
+
+  const double truth = TestDistances()[0];
+  const double max_error = truth * 1e-5;
+  DummyCallbackData<double>::SetValueSequence(call_count, truth, max_error);
+  const QueryInstance query(kSphere, kSphere, max_error);
+  /* If this test passes, it detected the expected max_error. */
+  RunCharacterization(query);
+  /* If this test passes, it did all the required work. */
+  EXPECT_EQ(DummyCallbackData<double>::get_invocations(), call_count);
 }
 
 }  // namespace

--- a/geometry/proximity/test/penetration_as_point_pair_characterize_test.cc
+++ b/geometry/proximity/test/penetration_as_point_pair_characterize_test.cc
@@ -53,29 +53,57 @@ class CharacterizePointPairResultTest : public CharacterizeResultTest<T> {
  public:
   CharacterizePointPairResultTest()
       : CharacterizeResultTest<T>(make_unique<PenetrationCallback<T>>()) {}
+
+  std::vector<double> TestDistances() const final {
+    return {-this->kDistance};
+  }
 };
 
-using ScalarTypes = ::testing::Types<double, AutoDiffXd>;
-TYPED_TEST_SUITE(CharacterizePointPairResultTest, ScalarTypes);
+class DoubleTest : public CharacterizePointPairResultTest<double>,
+                   public testing::WithParamInterface<QueryInstance> {};
 
-TYPED_TEST(CharacterizePointPairResultTest, SphereSphere) {
-  using T = TypeParam;
-  Expectation expect{.can_compute = true, .max_error = -1, .error_message = ""};
-  if constexpr (std::is_same<T, double>::value) {
-    expect.max_error = 8e-16;
-  } else {
-    expect.max_error = 3e-15;
-  }
-  // Orient the sphere arbitrarily and separate them *almost* by their combined
-  // radii.
-  const Sphere sphere = this->sphere();
-  const RigidTransform<T> X_AB(
-      RotationMatrix<T>(
-          AngleAxis<T>(M_PI * 9 / 7, Vector3<T>{-1, 2, 1}.normalized())),
-      Vector3<T>{1, -1, 2}.normalized() *
-          (sphere.radius() * 2 - this->kDistance));
-  vector<Configuration<T>> configs{{X_AB, -this->kDistance}};
-  this->RunCharacterization(expect, sphere, sphere, configs);
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(
+    PenetrationAsPointPair, DoubleTest,
+    testing::Values(
+        QueryInstance(kCapsule, kCapsule, 2e-5),
+        QueryInstance(kCapsule, kEllipsoid, 2e-4),
+        QueryInstance(kCapsule, kSphere, 3e-15),
+
+
+        QueryInstance(kEllipsoid, kEllipsoid, 5e-4),
+        QueryInstance(kEllipsoid, kSphere, 2e-4),
+
+
+        QueryInstance(kSphere, kSphere, 3e-15)),
+    QueryInstanceName);
+// clang-format on
+
+TEST_P(DoubleTest, Characterize) {
+  this->RunCharacterization(GetParam());
+}
+
+class AutoDiffTest : public CharacterizePointPairResultTest<AutoDiffXd>,
+                     public testing::WithParamInterface<QueryInstance> {};
+
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(
+    PenetrationAsPointPair, AutoDiffTest,
+    testing::Values(
+        QueryInstance(kCapsule, kCapsule, kThrows),
+        QueryInstance(kCapsule, kEllipsoid, kThrows),
+        QueryInstance(kCapsule, kSphere, 3e-15),
+
+        QueryInstance(kEllipsoid, kEllipsoid, kThrows),
+        QueryInstance(kEllipsoid, kSphere, kThrows),
+
+
+        QueryInstance(kSphere, kSphere, 3e-15)),
+    QueryInstanceName);
+// clang-format on
+
+TEST_P(AutoDiffTest, Characterize) {
+  this->RunCharacterization(GetParam());
 }
 
 }  // namespace


### PR DESCRIPTION
This does the following:

1. Introduces shapes `Capsule` and `Ellipsoid` into the analysis.
   - `penetration_as_point_pair_characterize_test` now evaluates (capsule, capsule), (capsule, ellipsoid), (capsule, sphere), (ellipsoid, ellipsoid), (ellipsoid, sphere) and (sphere, sphere)
2. The increase in pairings calls for efficient configuration construction
   - We create configurations by:
     1. Selecting a set of curated tangent planes to the various shapes.
     2. We pose the shapes relative to each other by posing the planes relative to each other and then offsetting along the planes' shared normals.
3. Unit tests for the additional framework code.
4. Add some macros in penetration_as_point_pair_characterize_test to further make the expression of tests compact.

Follow up PR will complete the framework and the penetration as point pair characterization.

Relates #10907
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14795)
<!-- Reviewable:end -->
