### PR TITLE
workspace: Deprecate the @sphinx repository

### DIFF
--- a/doc/pydrake/BUILD.bazel
+++ b/doc/pydrake/BUILD.bazel
@@ -33,7 +33,6 @@ _DEFAULT_TEST_TAGS = [
 drake_py_library(
     name = "sphinx_base",
     srcs = ["sphinx_base.py"],
-    data = ["@sphinx//:sphinx-build"],
     tags = _DEFAULT_BINARY_TAGS,
     deps = ["@rules_python//python/runfiles"],
 )
@@ -42,7 +41,6 @@ drake_py_library(
 drake_py_library(
     name = "pydrake_sphinx_extension_py",
     srcs = ["pydrake_sphinx_extension.py"],
-    tags = _DEFAULT_BINARY_TAGS,
     deps = [
         ":sphinx_base",
         "//bindings/pydrake/common:cpp_template_py",

--- a/doc/pydrake/sphinx_base.py
+++ b/doc/pydrake/sphinx_base.py
@@ -27,8 +27,8 @@ def gen_main(input_dir, strict, src_func=None):
         src_func: (optional) Callable of form `f(src_dir)` which will introduce
             additional source files to `src_dir`.
     """
-    sphinx_build = runfiles.Create().Rlocation("sphinx/sphinx-build")
-    assert isfile(sphinx_build), "Please execute via 'bazel run'"
+    sphinx_build = "/usr/share/sphinx/scripts/python3/sphinx-build"
+    assert isfile(sphinx_build)
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--out_dir", type=str, required=True,

--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -75,7 +75,6 @@ load("@drake//tools/workspace/sdformat:repository.bzl", "sdformat_repository")
 load("@drake//tools/workspace/semantic_version:repository.bzl", "semantic_version_repository")  # noqa
 load("@drake//tools/workspace/snopt:repository.bzl", "snopt_repository")
 load("@drake//tools/workspace/spdlog:repository.bzl", "spdlog_repository")
-load("@drake//tools/workspace/sphinx:repository.bzl", "sphinx_repository")
 load("@drake//tools/workspace/styleguide:repository.bzl", "styleguide_repository")  # noqa
 load("@drake//tools/workspace/suitesparse:repository.bzl", "suitesparse_repository")  # noqa
 load("@drake//tools/workspace/tinyobjloader:repository.bzl", "tinyobjloader_repository")  # noqa
@@ -247,8 +246,6 @@ def add_default_repositories(excludes = [], mirrors = DEFAULT_MIRRORS):
         snopt_repository(name = "snopt")
     if "spdlog" not in excludes:
         spdlog_repository(name = "spdlog", mirrors = mirrors)
-    if "sphinx" not in excludes:
-        sphinx_repository(name = "sphinx")
     if "styleguide" not in excludes:
         styleguide_repository(name = "styleguide", mirrors = mirrors)
     if "suitesparse" not in excludes:

--- a/tools/workspace/sphinx/repository.bzl
+++ b/tools/workspace/sphinx/repository.bzl
@@ -10,4 +10,5 @@ def sphinx_repository(name):
             "/usr/share/sphinx/scripts/python3",
         ],
         allow_missing = True,
+        build_epilog = 'print("DRAKE DEPRECATED: The @sphinx repository is being removed from Drake on or after 2021-07-01. Downstream projects should add it to their own WORKSPACE if needed.")',  # noqa
     )

--- a/tools/workspace/which.bzl
+++ b/tools/workspace/which.bzl
@@ -27,7 +27,9 @@ def _impl(repository_ctx):
 
 # A symlink to {}.
 exports_files(["{}"])
-""".format(found_command, command)
+
+{}
+""".format(found_command, command, repository_ctx.attr.build_epilog)
     repository_ctx.file(
         "BUILD.bazel",
         content = build_file_content,
@@ -39,6 +41,7 @@ which_repository = repository_rule(
         "command": attr.string(mandatory = True),
         "additional_search_paths": attr.string_list(),
         "allow_missing": attr.bool(default = False),
+        "build_epilog": attr.string(),
     },
     local = True,
     configure = True,
@@ -65,4 +68,5 @@ Args:
         build time instead of fetch time -- a failure to find the command will
         still result in a BUILD.bazel target that provides the command, but
         the target will be missing.
+    build_epilog: (Optional) Extra text to add to the generated BUILD.bazel.
 """


### PR DESCRIPTION
Our documentation tools are Ubuntu-only, so we don't need to ask Bazel to locate the correct binary -- we can just hard-code it.

This is prep work for #14803.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14804)
<!-- Reviewable:end -->
