### PR TITLE
multibody: Rename parameters of WeldJoint() and WeldFrames()

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -246,6 +246,20 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("WeldFrames",
             py::overload_cast<const Frame<T>&, const Frame<T>&,
                 const RigidTransform<double>&>(&Class::WeldFrames),
+            py::arg("frame_on_parent_P"), py::arg("frame_on_child_C"),
+            py::arg("X_PC") = RigidTransform<double>::Identity(),
+            py_rvp::reference_internal, cls_doc.WeldFrames.doc)
+        .def(
+            "WeldFrames",
+            [](Class* self, const Frame<T>& A, const Frame<T>& B,
+                const RigidTransform<double>& X_AB) -> const WeldJoint<T>& {
+              WarnDeprecated(
+                  "Please use MultibodyPlant.WeldFrames("
+                  "frame_on_parent_P=value1, frame_on_child_C=value2,"
+                  " X_PC=value3) instead. This variant will be removed"
+                  " after 2021-07-01.");
+              return self->WeldFrames(A, B, X_AB);
+            },
             py::arg("A"), py::arg("B"),
             py::arg("X_AB") = RigidTransform<double>::Identity(),
             py_rvp::reference_internal, cls_doc.WeldFrames.doc)

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -617,6 +617,18 @@ void DoScalarDependentDefinitions(py::module m, T) {
     cls  // BR
         .def(py::init<const string&, const Frame<T>&, const Frame<T>&,
                  const RigidTransform<double>&>(),
+            py::arg("name"), py::arg("frame_on_parent_P"),
+            py::arg("frame_on_child_C"), py::arg("X_PC"), cls_doc.ctor.doc)
+        .def(py::init([](const string& name, const Frame<T>& parent_frame_P,
+                          const Frame<T>& child_frame_C,
+                          const RigidTransform<double>& X_PC) {
+          WarnDeprecated(
+              "Please use WeldJoint(frame_on_parent_P=value1,"
+              " frame_on_child_C=value2, X_PC=value3) instead. This variant"
+              " will be removed after 2021-07-01.");
+          return std::make_unique<Class>(
+              name, parent_frame_P, child_frame_C, X_PC);
+        }),
             py::arg("name"), py::arg("parent_frame_P"),
             py::arg("child_frame_C"), py::arg("X_PC"), cls_doc.ctor.doc)
         .def(

--- a/bindings/pydrake/systems/test/meshcat_visualizer_test.py
+++ b/bindings/pydrake/systems/test/meshcat_visualizer_test.py
@@ -421,9 +421,9 @@ class TestMeshcat(unittest.TestCase):
 
         # Weld table to world.
         plant.WeldFrames(
-            A=plant.world_frame(),
-            B=plant.GetFrameByName("link", table_model),
-            X_AB=RigidTransform(RotationMatrix.MakeXRotation(0.2)))
+            frame_on_parent_P=plant.world_frame(),
+            frame_on_child_C=plant.GetFrameByName("link", table_model),
+            X_PC=RigidTransform(RotationMatrix.MakeXRotation(0.2)))
 
         plant.Finalize()
 

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1018,14 +1018,18 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     return joint;
   }
 
-  /// Welds frames A and B with relative pose `X_AB`. That is, the pose of
-  /// frame B in frame A is fixed, with value `X_AB`.
-  /// The call to this method creates and adds a new WeldJoint to the model.
-  /// The new WeldJoint is named as: A.name() + "_welds_to_" + B.name().
-  /// @returns a constant reference to the WeldJoint welding frames A and B.
-  const WeldJoint<T>& WeldFrames(const Frame<T>& A, const Frame<T>& B,
-                                 const math::RigidTransform<double>& X_AB =
-                                 math::RigidTransform<double>::Identity());
+  /// Welds `frame_on_parent_P` and `frame_on_child_C` with relative pose
+  /// `X_PC`. That is, the pose of frame C in frame P is fixed, with value
+  /// `X_PC`.  If `X_PC` is omitted, the identity transform will be used. The
+  /// call to this method creates and adds a new WeldJoint to the model.  The
+  /// new WeldJoint is named as: P.name() + "_welds_to_" + C.name().
+  /// @returns a constant reference to the WeldJoint welding frames
+  /// P and C.
+  /// @throws std::exception if the weld produces a duplicate joint name.
+  const WeldJoint<T>& WeldFrames(const Frame<T>& frame_on_parent_P,
+                                 const Frame<T>& frame_on_child_C,
+                                 const math::RigidTransform<double>& X_PC =
+                                     math::RigidTransform<double>::Identity());
 
   /// Adds a new force element model of type `ForceElementType` to `this`
   /// %MultibodyPlant.  The arguments to this method `args` are forwarded to

--- a/multibody/tree/weld_joint.h
+++ b/multibody/tree/weld_joint.h
@@ -28,13 +28,13 @@ class WeldJoint final : public Joint<T> {
 
   static const char kTypeName[];
 
-  /// Constructor for a %WeldJoint between a `parent_frame_P` and a
-  /// `child_frame_C` so that their relative pose `X_PC` is fixed as if they
-  /// were "welded" together.
-  WeldJoint(const std::string& name, const Frame<T>& parent_frame_P,
-            const Frame<T>& child_frame_C,
+  /// Constructor for a %WeldJoint between a `frame_on_parent_P` and a
+  /// `frame_on_child_C` so that their relative pose `X_PC` is fixed as if
+  /// they were "welded" together.
+  WeldJoint(const std::string& name, const Frame<T>& frame_on_parent_P,
+            const Frame<T>& frame_on_child_C,
             const math::RigidTransform<double>& X_PC)
-      : Joint<T>(name, parent_frame_P, child_frame_C,
+      : Joint<T>(name, frame_on_parent_P, frame_on_child_C,
                  VectorX<double>() /* no pos lower limits */,
                  VectorX<double>() /* no pos upper limits */,
                  VectorX<double>() /* no vel lower limits */,

--- a/tutorials/rendering_multibody_plant.ipynb
+++ b/tutorials/rendering_multibody_plant.ipynb
@@ -169,8 +169,9 @@
    "source": [
     "iiwa_1 = parser.AddModelFromFile(iiwa_file, model_name=\"iiwa_1\")\n",
     "plant.WeldFrames(\n",
-    "    plant.world_frame(), plant.GetFrameByName(\"iiwa_link_0\", iiwa_1),\n",
-    "    X_AB=xyz_rpy_deg([0, 0, 0], [0, 0, 0]))"
+    "    frame_on_parent_P=plant.world_frame(),\n",
+    "    frame_on_child_C=plant.GetFrameByName(\"iiwa_link_0\", iiwa_1),\n",
+    "    X_PC=xyz_rpy_deg([0, 0, 0], [0, 0, 0]))"
    ]
   },
   {
@@ -188,8 +189,9 @@
    "source": [
     "iiwa_2 = parser.AddModelFromFile(iiwa_file, model_name=\"iiwa_2\")\n",
     "plant.WeldFrames(\n",
-    "    plant.world_frame(), plant.GetFrameByName(\"iiwa_link_0\", iiwa_2),\n",
-    "    X_AB=xyz_rpy_deg([0, 1, 0], [0, 0, 0]))"
+    "    frame_on_parent_P=plant.world_frame(),\n",
+    "    frame_on_child_C=plant.GetFrameByName(\"iiwa_link_0\", iiwa_2),\n",
+    "    X_PC=xyz_rpy_deg([0, 1, 0], [0, 0, 0]))"
    ]
   },
   {


### PR DESCRIPTION
Closes #14641.

The parameter names were variously confusing (WeldFrames, see #14641)
and/or inconsistent with other joints (WeldJoint constructor).

This patch moves both entry points to use naming consistent with other
joint APIs, clarifies monogram notation issues in documentation, and
deprecates the old parameter names in python bindings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14805)
<!-- Reviewable:end -->
