### PR TITLE
pydrake: Expose some testing utilities to drake_bazel_external workflows

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -301,6 +301,20 @@ drake_py_library(
     deps = [":all_py"],
 )
 
+# Roll-up for publicly acccessible testing utilities (for development with
+# workflows like drake-external-examples/drake_bazel_external).
+drake_py_library(
+    name = "test_utilities_py",
+    testonly = 1,
+    visibility = ["//visibility:public"],
+    deps = [
+        # N.B. We depend on pydrake so as to keep symmetry with the currently
+        # offered public targets (rollup only, no granular access).
+        ":pydrake",
+        "//bindings/pydrake/common/test_utilities",
+    ],
+)
+
 install(
     name = "install",
     install_tests = [


### PR DESCRIPTION
Context: https://drakedevelopers.slack.com/archives/C3YB3EV5W/p1616474859009900

This is one possible solution.

> hongkai.dai:
> May I ask why the package `//bindings/pydrake/common/test_utilities:numpy_compare_py` is only visible inside drake? I would like to use this package in anzu but I can't do it due to visibility restriction
> 
> eric.cousineau:
> b/c it was for testing, and isn't installed.But that being said, I'm totes fine with it being exposed as a public bazel target, esp. if you're prototyping on this stuff w/in Anzu (TRI private codebase). (edited)
> 
> eric.cousineau:
> Oooohhhhhhhh shewt, forgot about weird interplays btw granular targets in Bazel and our encapsulated super-target, `//bindings/pydrake` ...Hm...

\cc @hongkai-dai

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14812)
<!-- Reviewable:end -->
