### PR TITLE
package_map: Add ResolveUri() for better usability

### DIFF
--- a/bindings/pydrake/common/module_py.cc
+++ b/bindings/pydrake/common/module_py.cc
@@ -172,19 +172,22 @@ PYBIND11_MODULE(_module_py, m) {
     }
   });
   // Convenient wrapper for querying FindResource(resource_path).
-  m.def("FindResourceOrThrow", &FindResourceOrThrow,
-      "Attempts to locate a Drake resource named by the given path string. "
-      "The path refers to the relative path within the Drake repository, "
-      "e.g., drake/examples/pendulum/Pendulum.urdf. Raises an exception "
-      "if the resource was not found.",
-      py::arg("resource_path"), doc.FindResourceOrThrow.doc);
-  m.def("temp_directory", &temp_directory,
-      "Returns a directory location suitable for temporary files that is "
-      "the value of the environment variable TEST_TMPDIR if defined or "
-      "otherwise ${TMPDIR:-/tmp}/robotlocomotion_drake_XXXXXX where each X "
-      "is replaced by a character from the portable filename character set. "
-      "Any trailing / will be stripped from the output.",
-      doc.temp_directory.doc);
+  m.def("FindResourceOrThrow", &FindResourceOrThrow, py::arg("resource_path"),
+      doc.FindResourceOrThrow.doc);
+  {
+    using Class = FindResourceResult;
+    constexpr auto& cls_doc = doc.FindResourceResult;
+    py::class_<Class>(m, "FindResourceResult", cls_doc.doc)
+        .def("get_absolute_path", &Class::get_absolute_path,
+            cls_doc.get_absolute_path.doc)
+        .def("get_error_message", &Class::get_error_message,
+            cls_doc.get_error_message.doc)
+        .def("get_resource_path", &Class::get_resource_path,
+            cls_doc.get_resource_path.doc);
+  }
+  m.def("FindResource", &FindResource, py::arg("resource_path"),
+      doc.FindResourceOrThrow.doc);
+  m.def("temp_directory", &temp_directory, doc.temp_directory.doc);
   // The pydrake function named GetDrakePath is residue from when there used to
   // be a C++ method named drake::GetDrakePath(). For backward compatibility,
   // we'll keep the pydrake function name intact even though there's no

--- a/bindings/pydrake/common/test/module_test.py
+++ b/bindings/pydrake/common/test/module_test.py
@@ -25,10 +25,15 @@ class TestCommon(unittest.TestCase):
                     " condition 'false' failed",
                 ]))
 
-    def test_find_resource_or_throw(self):
-        mut.FindResourceOrThrow(
-            'drake/examples/atlas/urdf/atlas_convex_hull.urdf'
-            )
+    def test_find_resource(self):
+        relpath = 'drake/examples/atlas/urdf/atlas_convex_hull.urdf'
+        abspath = mut.FindResourceOrThrow(relpath)
+        self.assertIsInstance(abspath, str)
+        result = mut.FindResource(relpath)
+        self.assertIsInstance(result, mut.FindResourceResult)
+        self.assertEqual(abspath, result.get_absolute_path())
+        self.assertIsNone(result.get_error_message())
+        self.assertEqual(relpath, result.get_resource_path())
 
     def test_temp_directory(self):
         self.assertEqual(os.environ.get('TEST_TMPDIR'),

--- a/bindings/pydrake/multibody/parsing_py.cc
+++ b/bindings/pydrake/multibody/parsing_py.cc
@@ -44,7 +44,8 @@ PYBIND11_MODULE(parsing, m) {
             py::arg("environment_variable"),
             cls_doc.PopulateFromEnvironment.doc)
         .def("PopulateUpstreamToDrake", &Class::PopulateUpstreamToDrake,
-            py::arg("model_file"), cls_doc.PopulateUpstreamToDrake.doc);
+            py::arg("model_file"), cls_doc.PopulateUpstreamToDrake.doc)
+        .def("ResolveUri"
   }
 
   // Parser

--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -45,9 +45,11 @@ drake_cc_package_library(
 drake_cc_library(
     name = "package_map",
     srcs = [
+        "detail_path_utils.cc",
         "package_map.cc",
     ],
     hdrs = [
+        "detail_path_utils.h",
         "package_map.h",
     ],
     visibility = [
@@ -64,13 +66,11 @@ drake_cc_library(
     srcs = [
         "detail_common.cc",
         "detail_ignition.cc",
-        "detail_path_utils.cc",
         "detail_tinyxml.cc",
     ],
     hdrs = [
         "detail_common.h",
         "detail_ignition.h",
-        "detail_path_utils.h",
         "detail_tinyxml.h",
     ],
     install_hdrs_exclude = [
@@ -376,6 +376,7 @@ drake_cc_googletest(
         ":package_map",
         "//common:filesystem",
         "//common:find_resource",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/multibody/parsing/detail_path_utils.h
+++ b/multibody/parsing/detail_path_utils.h
@@ -2,6 +2,7 @@
 
 #include <string>
 
+#include "drake/common/find_resource.h"
 #include "drake/multibody/parsing/package_map.h"
 
 namespace drake {
@@ -17,28 +18,10 @@ namespace internal {
 // file_name is empty.
 std::string GetFullPath(const std::string& file_name);
 
-// Resolves the full path of a URI. If @p uri starts with "package:" or
-// "model:", the ROS packages specified in @p package_map are searched.
-// Otherwise, iff a root_dir was provided then @p uri is appended to the end
-// of @p root_dir (if it's not already an absolute path) and checked for
-// existence.  If the file does not exist or is not found, a warning is
-// printed to `std::cerr` and an empty string is returned. The returned path
-// will be lexically normalized. In other words, a path like
-// `/some//path/to/ignored/../file.txt` (with duplicate slashes, directory
-// changes, etc.) would be boiled down to `/some/path/to/file.txt`.
-//
-// @param[in] uri The name of the resource to find.
-//
-// @param[in] package_map A map where the keys are ROS package names and the
-// values are the paths to the packages. This is only used if @p filename
-// starts with "package:"or "model:".
-//
-// @param[in] root_dir The root directory to look in. This is only used when
-// @p filename does not start with "package:".  Can be empty when only URIs
-// (not relative paths) should be allowed for @p uri.
-//
-// @return The file's full path, lexically normalized, or an empty string if
-// the file is not found or does not exist.
+// Implementations for PackageMap::ResolveUri.
+FindResourceResult ResolveUriToResult(
+    const std::string& uri, const PackageMap& package_map,
+    const std::string& root_dir);
 std::string ResolveUri(const std::string& uri,
                        const PackageMap& package_map,
                        const std::string& root_dir);

--- a/multibody/parsing/package_map.cc
+++ b/multibody/parsing/package_map.cc
@@ -13,6 +13,7 @@
 #include "drake/common/drake_throw.h"
 #include "drake/common/filesystem.h"
 #include "drake/common/text_logging.h"
+#include "drake/multibody/parsing/detail_path_utils.h"
 
 namespace drake {
 namespace multibody {
@@ -73,6 +74,18 @@ void PackageMap::PopulateFromEnvironment(const string& environment_variable) {
       CrawlForPackages(path);
     }
   }
+}
+
+std::string PackageMap::ResolveUri(
+    const std::string& path, std::optional<std::string> root_dir) const {
+  auto result = MaybeResolveUri(path, root_dir);
+  return result.get_absolute_path_or_throw();
+}
+
+FindResourceResult PackageMap::MaybeResolveUri(
+    const std::string& path, std::optional<std::string> root_dir) const {
+  const std::string cwd = filesystem::current_path().string();
+  return internal::ResolveUriToResult(path, *this, root_dir.value_or(cwd));
 }
 
 namespace {

--- a/multibody/parsing/test/detail_path_utils_test.cc
+++ b/multibody/parsing/test/detail_path_utils_test.cc
@@ -155,8 +155,13 @@ GTEST_TEST(ResolveUriTest, TestNoRoot) {
   unused(FindResourceOrThrow("drake/" + rel_path));
   const PackageMap package_map;
   const std::string root_dir;
-  string path = ResolveUri(rel_path, package_map, root_dir);
-  EXPECT_EQ(path, "");
+  FindResourceResult result =
+      ResolveUriToResult(rel_path, package_map, root_dir);
+  EXPECT_EQ(
+      *result.get_error_message(),
+      "URI 'multibody/parsing/test/package_map_test_packages/"
+      "package_map_test_package_a/sdf/test_model.sdf' is invalid when parsing "
+      "a string instead of a filename.");
 }
 
 // Verifies that ResolveUri() resolves to the proper file using the scheme


### PR DESCRIPTION
Per discussion w/ @sammy-tri about Anzu PR 6571

FWIW I deviated slightly from `FindResourceOrThrow` vs. `FindResource` - I like shorter names for more-used variants, hence `ResolveUri` vs. `MaybeResolveUri`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14817)
<!-- Reviewable:end -->
