### PR TITLE
[fix forward] Patch for mac difference in mac precision

### DIFF
--- a/geometry/proximity/test/penetration_as_point_pair_characterize_test.cc
+++ b/geometry/proximity/test/penetration_as_point_pair_characterize_test.cc
@@ -98,7 +98,7 @@ INSTANTIATE_TEST_SUITE_P(
         QueryInstance(kEllipsoid, kSphere, kThrows),
 
 
-        QueryInstance(kSphere, kSphere, 3e-15)),
+        QueryInstance(kSphere, kSphere, 4e-15)),
     QueryInstanceName);
 // clang-format on
 


### PR DESCRIPTION
#14795 had an error when running on mac -- the precision was too tight. This loosens the precision to pass on mac.

Replaces #14819

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14821)
<!-- Reviewable:end -->
