### PR TITLE
Perturbs multibody_plant_scalar_conversion_test to fix kcov failure

### DIFF
--- a/multibody/plant/test/multibody_plant_scalar_conversion_test.cc
+++ b/multibody/plant/test/multibody_plant_scalar_conversion_test.cc
@@ -48,9 +48,9 @@ GTEST_TEST(ScalarConversionTest, RevoluteJointAndSpring) {
   std::unique_ptr<MultibodyPlant<AutoDiffXd>> plant_ad;
   EXPECT_NO_THROW(plant_ad =
                       drake::systems::System<double>::ToAutoDiffXd(plant));
-  DRAKE_DEMAND(plant_ad->num_velocities() == 1);
-  DRAKE_DEMAND(plant_ad->num_positions() == 1);
-  DRAKE_DEMAND(plant_ad->num_force_elements() == 2);
+  EXPECT_EQ(plant.num_velocities(), plant_ad->num_velocities());
+  EXPECT_EQ(plant.num_positions(), plant_ad->num_positions());
+  EXPECT_EQ(plant.num_force_elements(), plant_ad->num_force_elements());
 
   // We verify the correct reference to the pin joint after conversion.
   const auto& pin_ad = plant_ad->GetJointByName<RevoluteJoint>(pin.name());


### PR DESCRIPTION
Fixes #14824.

Changes a few `DRAKE_DEMANDS` into equivalent `EXPECT_EQ` statements to perturb the binary.

The first 80 bytes of the binary are now:
```
00000000   7F 45 4C 46  02 01 01 00  00 00 00 00  00 00 00 00  .ELF............
00000010   03 00 3E 00  01 00 00 00  B0 1A 0D 00  00 00 00 00  ..>.............
00000020   40 00 00 00  00 00 00 00  08 96 68 1B  00 00 00 00  @.........h.....
00000030   00 00 00 00  40 00 38 00  09 00 40 00  28 00 27 00  ....@.8...@.(.'.
00000040   06 00 00 00  04 00 00 00  40 00 00 00  00 00 00 00  ........@.......
00000050   40 00 00 00  00 00 00 00  40 00 00 00  00 00 00 00  @.......@.......
```
Avoiding the issue described in SimonKagstrom/kcov#339.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14825)
<!-- Reviewable:end -->
