### PR TITLE
py render: Bind RenderEngineGlParams

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -410,7 +410,23 @@ void def_geometry_render(py::module m) {
       .def_readwrite("default_diffuse", &RenderEngineVtkParams::default_diffuse,
           doc.RenderEngineVtkParams.default_diffuse.doc);
 
-  m.def("MakeRenderEngineGl", &MakeRenderEngineGl, doc.MakeRenderEngineGl.doc);
+  {
+    using Class = RenderEngineGlParams;
+    constexpr auto& cls_doc = doc.RenderEngineGlParams;
+    py::class_<Class>(m, "RenderEngineGlParams", cls_doc.doc)
+        .def(ParamInit<Class>())
+        .def_readwrite("default_clear_color", &Class::default_clear_color,
+            cls_doc.default_clear_color.doc)
+        .def_readwrite("default_diffuse", &Class::default_diffuse,
+            cls_doc.default_diffuse.doc)
+        .def_readwrite(
+            "default_label", &Class::default_label, cls_doc.default_label.doc);
+  }
+
+  m.def("MakeRenderEngineGl",
+      static_cast<std::unique_ptr<RenderEngine> (*)(RenderEngineGlParams)>(
+          &MakeRenderEngineGl),
+      py::arg("params") = RenderEngineGlParams(), doc.MakeRenderEngineGl.doc);
 
   m.def("MakeRenderEngineVtk", &MakeRenderEngineVtk, py::arg("params"),
       doc.MakeRenderEngineVtk.doc);

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -600,6 +600,49 @@ class TestGeometry(unittest.TestCase):
         self.assertEqual(params.default_label, label)
         self.assertTrue((params.default_diffuse == diffuse).all())
 
+    def test_render_engine_vtk(self):
+        self.assertIsInstance(
+            mut.render.MakeRenderEngineVtk(
+                params=mut.render.RenderEngineVtkParams()
+            ),
+            mut.render.RenderEngine,
+        )
+
+    def test_render_engine_gl_params(self):
+        # Confirm default construction of params.
+        params = mut.render.RenderEngineGlParams()
+        self.assertEqual(
+            params.default_clear_color,
+            mut.Rgba(204 / 255., 229 / 255., 255 / 255., 1.0),
+        )
+        self.assertEqual(
+            params.default_label, mut.render.RenderLabel.kUnspecified,
+        )
+        self.assertEqual(params.default_diffuse, mut.Rgba(0.9, 0.7, 0.2, 1.0))
+
+        label = mut.render.RenderLabel(10)
+        diffuse = mut.Rgba(1.0, 0.0, 0.0, 0.0)
+        params = mut.render.RenderEngineGlParams(
+            default_clear_color=diffuse,
+            default_label=label,
+            default_diffuse=diffuse,
+        )
+        self.assertEqual(params.default_clear_color, diffuse)
+        self.assertEqual(params.default_label, label)
+        self.assertEqual(params.default_diffuse, diffuse)
+
+    def test_render_engine_gl(self):
+        self.assertIsInstance(
+            mut.render.MakeRenderEngineGl(),
+            mut.render.RenderEngine,
+        )
+        self.assertIsInstance(
+            mut.render.MakeRenderEngineGl(
+                params=mut.render.RenderEngineGlParams()
+            ),
+            mut.render.RenderEngine,
+        )
+
     def test_render_depth_camera_properties_deprecated(self):
         with catch_drake_warnings(expected_count=1):
             obj = mut.render.DepthCameraProperties(


### PR DESCRIPTION
Uses largely reformatted bindings from autopybind prototype

This is part of #14827 (now #15205); though it's a bit contaminating for me to say this, could you please review this as you would normally review bindings?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14828)
<!-- Reviewable:end -->
