### PR TITLE
Utility to adjust multibody plant contexts out of collision

### DIFF
--- a/multibody/optimization/BUILD.bazel
+++ b/multibody/optimization/BUILD.bazel
@@ -26,6 +26,20 @@ drake_cc_package_library(
 )
 
 drake_cc_library(
+    name = "collision_remover",
+    srcs = ["collision_remover.cc"],
+    hdrs = ["collision_remover.h"],
+    deps = [
+        "//multibody/inverse_kinematics",
+        "//multibody/plant",
+        "//solvers:mathematical_program",
+        "//solvers:solve",
+        "//systems/framework:diagram_builder",
+        "//systems/optimization",
+    ],
+)
+
+drake_cc_library(
     name = "contact_wrench",
     srcs = [],
     hdrs = ["contact_wrench.h"],
@@ -144,6 +158,16 @@ drake_cc_library(
         "//systems/analysis:simulator",
         "//systems/framework:diagram",
     ],
+)
+
+drake_cc_googletest(
+    name = "collision_remover_test",
+    deps = [
+        ":collision_remover",
+        "//common:find_resource",
+        "//multibody/parsing",
+    ],
+    data = ["test/collision_remover_test.urdf"],
 )
 
 drake_cc_googletest(

--- a/multibody/optimization/BUILD.bazel
+++ b/multibody/optimization/BUILD.bazel
@@ -14,6 +14,7 @@ drake_cc_package_library(
     name = "optimization",
     visibility = ["//visibility:public"],
     deps = [
+        ":collision_remover",
         ":contact_wrench",
         ":contact_wrench_evaluator",
         ":manipulator_equation_constraint",
@@ -162,12 +163,12 @@ drake_cc_library(
 
 drake_cc_googletest(
     name = "collision_remover_test",
+    data = ["test/collision_remover_test.urdf"],
     deps = [
         ":collision_remover",
         "//common:find_resource",
         "//multibody/parsing",
     ],
-    data = ["test/collision_remover_test.urdf"],
 )
 
 drake_cc_googletest(

--- a/multibody/optimization/collision_remover.cc
+++ b/multibody/optimization/collision_remover.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <limits>
 #include <ostream>
 #include <string>
 #include <vector>

--- a/multibody/optimization/collision_remover.cc
+++ b/multibody/optimization/collision_remover.cc
@@ -1,0 +1,537 @@
+#include "sim/common/collision_remover.h"
+
+#include <algorithm>
+#include <functional>
+#include <ostream>
+#include <string>
+#include <vector>
+
+#include "drake/common/constants.h"
+#include "drake/common/sorted_pair.h"
+#include "drake/common/symbolic_variable.h"
+#include "drake/geometry/query_object.h"
+#include "drake/geometry/scene_graph.h"
+#include "drake/math/saturate.h"
+#include "drake/multibody/inverse_kinematics/inverse_kinematics.h"
+#include "drake/multibody/inverse_kinematics/minimum_distance_constraint.h"
+#include "drake/solvers/mathematical_program.h"
+#include "drake/solvers/solve.h"
+#include "common/mathematical_program_to_string.h"
+
+using Eigen::VectorXd;
+using drake::geometry::SceneGraph;
+using drake::solvers::MathematicalProgram;
+using drake::systems::Context;
+using drake::systems::Diagram;
+using drake::multibody::Body;
+using drake::multibody::BodyIndex;
+using drake::multibody::Joint;
+using drake::multibody::JointIndex;
+using drake::multibody::MultibodyPlant;
+
+namespace anzu {
+namespace sim {
+
+namespace geom = drake::geometry;
+
+namespace {
+// How many iterations of bisect to try.  Setting this high doesn't help much.
+constexpr static int kBisectIterations = 10;
+
+// How far back from collision the IK MinimumDistanceConstraint should aim;
+// setting this too low is bad due to numeric issues in the constraint function.
+constexpr static double kIkMinDistance = 1e-2;
+
+enum class IkMode {
+  kInsideOut = 1,
+  kOutsideIn = 2,
+};
+
+std::string PositionAsString(const MultibodyPlant<double>& plant,
+                             VectorXd pos) {
+  std::ostringstream output;
+  for (int i = 0; i < pos.size(); ++i) {
+    bool found = false;
+    for (drake::multibody::ModelInstanceIndex m(0);
+         m < plant.num_model_instances(); ++m) {
+      for (JointIndex j : plant.GetJointIndices(m)) {
+        const Joint<double>& joint = plant.get_joint(j);
+        int index_in_joint = i - joint.position_start();
+        if (index_in_joint >= 0 && index_in_joint < joint.num_positions()) {
+          output << joint.name() << "[" << index_in_joint << "] == "
+                 << pos[i] << std::endl;
+          found = true;
+          break;
+        }
+      }
+      if (found) { break; }
+    }
+    if (found) { continue; }
+    for (BodyIndex b : plant.GetFloatingBaseBodies()) {
+      const Body<double>& body = plant.get_body(b);
+      if (body.is_floating()) {
+        // Per https://github.com/RobotLocomotion/drake/issues/12807 we don't
+        // really know the number of positions for a free body without knowing
+        // details of its underlying mobilizer.  If we have quaternion DoFs
+        // then we guess that it's 7; otherwise we make no assumption.
+        if (!body.has_quaternion_dofs()) {
+          continue;
+        }
+        int index_in_body = i - body.floating_positions_start();
+        if (index_in_body >= 0 && index_in_body < 7) {
+          output << body.name() << "[" << index_in_body << "] == "
+                 << pos[i] << std::endl;
+          found = true;
+          break;
+        }
+      }
+    }
+    if (!found) {
+      output << "UNKNOWN q[" << i << "] == " << pos[i] << std::endl;
+    }
+  }
+  return output.str();
+}
+
+}  // namespace
+
+
+class CollisionRemover::Impl {
+ public:
+  Impl(const Diagram<double>* diagram,
+       const MultibodyPlant<double>* plant,
+       const SceneGraph<double>* scene_graph)
+      : diagram_(diagram),
+        plant_(plant),
+        scene_graph_(scene_graph) {}
+
+  ~Impl() {}
+
+  bool AdjustPositions(
+      Context<double>* root_context,
+      const std::set<JointIndex>& joints_to_adjust,
+      const std::set<BodyIndex>& floating_bodies_to_adjust,
+      const std::optional<const std::set<BodyIndex>>& bodies_to_decollide,
+      const VectorXd& known_valid_position) {
+    // Preconditions:
+    DRAKE_DEMAND(root_context->GetSystemPathname() ==
+                 diagram_->GetSystemPathname());
+    for (const BodyIndex id : floating_bodies_to_adjust) {
+      DRAKE_DEMAND(plant_->get_body(id).is_floating());
+    }
+
+    // Short-circuit checks.
+    const Context<double>& plant_context =
+        diagram_->GetSubsystemContext(*plant_, *root_context);
+    if (bodies_to_decollide && bodies_to_decollide->empty()) {
+      drake::log()->debug("AdjustPositions called with an empty body set.");
+      return true;
+    } else if (!Collides(plant_context, bodies_to_decollide)) {
+      drake::log()->debug("AdjustPositions but no collisions are present.");
+      return true;
+    }
+    if (joints_to_adjust.empty() && floating_bodies_to_adjust.empty()) {
+      return false;  // If we cannot adjust, failure is assured.
+    }
+
+    // Dispatch to our strategies.  Try IK first; if it fails then bisect.
+    std::vector<std::function<VectorXd(void)>> methods = {
+      [&]() {
+        return AdjustPositionsUsingIk(*root_context, joints_to_adjust,
+                                      floating_bodies_to_adjust,
+                                      bodies_to_decollide,
+                                      known_valid_position,
+                                      IkMode::kInsideOut);
+      },
+      [&]() {
+        return AdjustPositionsUsingIk(*root_context, joints_to_adjust,
+                                      floating_bodies_to_adjust,
+                                      bodies_to_decollide,
+                                      known_valid_position,
+                                      IkMode::kOutsideIn);
+      },
+      [&]() {
+        return AdjustPositionsUsingBisect(*root_context, joints_to_adjust,
+                                          floating_bodies_to_adjust,
+                                          bodies_to_decollide,
+                                          known_valid_position);
+      }};
+    for (auto method : methods) {
+      VectorXd better_q;
+      better_q = method();
+
+      // Copy the result from the program into the (external) plant context.
+      VectorXd new_positions = plant_->GetPositions(plant_context);
+      std::vector<int> indexes_to_copy;
+      for (const JointIndex j : joints_to_adjust) {
+        const Joint<double>& joint = plant_->get_joint(j);
+        for (int i = 0; i < joint.num_positions(); ++i) {
+          int absolute_index = joint.position_start() + i;
+          if (new_positions(absolute_index) != better_q(absolute_index)) {
+            drake::log()->debug(
+                "...repositioned {} (q[{}]) from {} to {} to avoid collisions.",
+                joint.name(), absolute_index,
+                new_positions(absolute_index), better_q(absolute_index));
+          }
+          new_positions[absolute_index] = better_q(absolute_index);
+        }
+      }
+      for (const BodyIndex b : floating_bodies_to_adjust) {
+        const Body<double>& body = plant_->get_body(b);
+        if (!body.has_quaternion_dofs()) {
+          // See above re: Drake#12807: we don't know the number of positions.
+          continue;
+        }
+        for (int i = 0; i < 7; ++i) {
+          int absolute_index = body.floating_positions_start() + i;
+          if (new_positions(absolute_index) != better_q(absolute_index)) {
+            drake::log()->debug(
+                "...repositioned {} (q[{}]) from {} to {} to avoid collisions.",
+                body.name(), absolute_index,
+                new_positions(absolute_index), better_q(absolute_index));
+          }
+          new_positions[absolute_index] = better_q(absolute_index);
+        }
+      }
+
+      // Copy our final result into a temporary context to verify that it is
+      // collision-free.
+      std::unique_ptr<Context<double>> working_root_context =
+          root_context->Clone();
+      Context<double>* working_plant_context =
+          &diagram_->GetMutableSubsystemContext(*plant_,
+                                                working_root_context.get());
+      plant_->SetPositions(working_plant_context, new_positions);
+
+      bool success = !Collides(*working_plant_context, bodies_to_decollide);
+      if (success) {
+        plant_->SetPositions(
+            &diagram_->GetMutableSubsystemContext(*plant_, root_context),
+            new_positions);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // Return the set of indexes in the state vector that *are not* adjustable
+  // during optimization of the specified joint and body positions.
+  std::set<int> ConstrainedStateIndexes(
+      const std::set<JointIndex>& joints_to_adjust,
+      const std::set<BodyIndex>& floating_bodies_to_adjust) {
+    std::set<int> constrained_state_indexes;
+    for (JointIndex j(0); j < plant_->num_joints(); ++j) {
+      if (joints_to_adjust.count(j)) { continue; }
+      const Joint<double>& joint = plant_->get_joint(j);
+      int joint_begin = joint.position_start();
+      int joint_end = joint.position_start() + joint.num_positions();
+      for (int i = joint_begin; i < joint_end; ++i) {
+        constrained_state_indexes.insert(i);
+      }
+    }
+    for (BodyIndex b(0); b < plant_->num_bodies(); ++b) {
+      if (floating_bodies_to_adjust.count(b)) { continue; }
+      const Body<double>& body = plant_->get_body(b);
+      if (!body.is_floating()) { continue; }
+      int body_begin = body.floating_positions_start();
+      int body_end = body.floating_positions_start() +
+          (body.has_quaternion_dofs() ? 7 : 6);
+      DRAKE_DEMAND(body.floating_positions_start() >= 0);
+      for (int i = body_begin; i < body_end; ++i) {
+        constrained_state_indexes.insert(i);
+      }
+    }
+    return constrained_state_indexes;
+  }
+
+  // IK-based joint adjustment
+  // @return a "q" value (vector of joint positions) better than that in `data`.
+  //
+  // The joint adjustment process here is a bit complicated.  There are in
+  // principle two optimization approaches we could take to project to a valid
+  // state:
+  //
+  //  * Inside-out:  Use the target condition as the initial conditions and
+  //    adjustment distance as a cost function.
+  //  * Outside-in: Use a known valid condition(*) as the initial conditions
+  //    and distance-from-target-condition as a cost function.
+  //
+  // Empirically SNOPT is very bad at optimizing outward from an invalid
+  // starting condition.  However the outside-in approach will often be slow
+  // and can fail to find even a valid target condition if the constraints are
+  // sufficiently nonconvex.
+  //
+  // For this reason we first attempt the inside-out problem.  This will
+  // succeed quickly if the target is valid or almost valid and fail quickly
+  // otherwise.  If it fails only then will we attempt the more expensive and
+  // less accurate but likely-to-succeed outside-in approach.
+  //
+  // (* for joints subject to adjustment; insofar as the known valid
+  // conditions don't match the target conditions for joints that are not
+  // subject to adjustment, we must keep using the target conditions)
+  VectorXd AdjustPositionsUsingIk(
+      const Context<double>& root_context,
+      const std::set<JointIndex>& joints_to_adjust,
+      const std::set<BodyIndex>& floating_bodies_to_adjust,
+      const std::optional<const std::set<BodyIndex>>& bodies_to_decollide,
+      const VectorXd& known_valid_position,
+      const IkMode mode) {
+    // Contexts to use as scratch space, since Drake IK invalidates its
+    // passed-in context argment if any Solve call fails.
+    std::unique_ptr<Context<double>> working_root_context =
+        root_context.Clone();
+    Context<double>* working_plant_context =
+        &diagram_->GetMutableSubsystemContext(*plant_,
+                                              working_root_context.get());
+
+    if (bodies_to_decollide) {
+      // Reformulate our bodies of interest into vectors of Body* (because all
+      // of the body-related methods take different types).
+      std::vector<const Body<double>*> extraneous_bodies_vec;
+      for (BodyIndex i(0); i < plant_->num_bodies(); ++i) {
+        if (!bodies_to_decollide->count(i)) {
+          extraneous_bodies_vec.push_back(&plant_->get_body(i));
+        }
+      }
+      std::vector<const Body<double>*> bodies_to_decollide_vec;
+      for (const BodyIndex body_index : *bodies_to_decollide) {
+        bodies_to_decollide_vec.push_back(&plant_->get_body(body_index));
+      }
+      geom::GeometrySet decollide_geometries =
+          plant_->CollectRegisteredGeometries(bodies_to_decollide_vec);
+      geom::GeometrySet extraneous_geometries =
+          plant_->CollectRegisteredGeometries(extraneous_bodies_vec);
+
+      // Filter away all of the collisions not between members of `bodies`.
+      Context<double>& working_sg_context =
+          diagram_->GetMutableSubsystemContext(
+              *scene_graph_, working_root_context.get());
+      scene_graph_->ExcludeCollisionsWithin(&working_sg_context,
+                                            extraneous_geometries);
+      scene_graph_->ExcludeCollisionsBetween(&working_sg_context,
+                                             decollide_geometries,
+                                             extraneous_geometries);
+    }
+
+    // Build a MathematicalProgram for the IK solve.
+    drake::multibody::InverseKinematics ik(*plant_, working_plant_context);
+    ik.AddMinimumDistanceConstraint(kIkMinDistance);
+    MathematicalProgram* program = ik.get_mutable_prog();
+    VectorXd target_positions = plant_->GetPositions(*working_plant_context);
+    const drake::solvers::VectorXDecisionVariable& vars = ik.q();
+
+    // Constrain all variables other than positions of joints/bodies of concern.
+    // Per Drake#12849 this has to warp to the joint limits.
+    std::set<int> constrained_state_indexes =
+        ConstrainedStateIndexes(joints_to_adjust, floating_bodies_to_adjust);
+    for (const int i : constrained_state_indexes) {
+      drake::symbolic::Variable var_in_program = vars(i);
+      double target = drake::math::saturate(
+          target_positions(i),
+          plant_->GetPositionLowerLimits()(i),
+          plant_->GetPositionUpperLimits()(i));
+      program->AddConstraint(var_in_program == target);
+    }
+
+    // Constrain any unconstrained floating body quaternions to be unit-norm.
+    // TODO(ggould) Possibly this belongs inside the drake::InverseKinematics
+    // ctor rather than here?
+    for (const BodyIndex id : floating_bodies_to_adjust) {
+      if (plant_->get_body(id).has_quaternion_dofs()) {
+        // Per `Body::floating_positions_start()`, the first four entries in
+        // the floating position are guaranteed to be the quaternion.
+        int quat_index = plant_->get_body(id).floating_positions_start();
+        drake::symbolic::Expression norm = 0;
+        for (int i = quat_index; i < quat_index + drake::kQuaternionSize; ++i) {
+          norm += vars(i) * vars(i);
+        }
+        program->AddConstraint(norm == 1);
+      }
+    }
+
+    // Add a cost function to prefer positions near the target.
+    program->AddQuadraticErrorCost(
+        drake::MatrixX<double>::Identity(vars.size(), vars.size()),
+        target_positions, vars);
+
+    // Configure the appropriate problem.
+    switch (mode) {
+      case IkMode::kInsideOut: {
+        program->SetInitialGuess(vars, target_positions);
+        drake::log()->debug(common::MathematicalProgramToString(
+            "Inside-out program (start at target, hunt for valid)", *program));
+        break;
+      }
+      case IkMode::kOutsideIn: {
+        VectorXd guess = known_valid_position;
+        for (const int i : constrained_state_indexes) {
+          guess(i) = target_positions(i);
+        }
+        program->SetInitialGuess(vars, guess);
+        drake::log()->debug(common::MathematicalProgramToString(
+            "Outside-in program (start at valid, hunt for target)", *program));
+        break;
+      }
+      default:
+        DRAKE_UNREACHABLE();
+    }
+
+    // Try to solve.
+    drake::solvers::MathematicalProgramResult result =
+        drake::solvers::Solve(*program);
+    if (!result.is_success()) {
+      drake::log()->debug("Unable to solve AdjustPositions problem: {}",
+                          result.get_solution_result());
+    }
+    return result.get_x_val();
+  }
+
+  // Bisect-based joint adjustment
+  // @return a "q" value (vector of joint positions) better than that in `data`.
+  //
+  // Unlike IK, which can actually give us pretty and parsimonious adjustments
+  // subject to interesting criteria, bisect is crude and nasty.  We take a
+  // known valid position and simply bisect between it and the current context
+  // value for a fixed number of iterations.  The result is demonstrably near
+  // (but not likely *at*) some boundary of the constraint (but not
+  // necessarily a particlarly *good* boundary or even the *outermost*
+  // boundary for nonconvex constraints).
+  //
+  // The advantage is that it always works.  This makes it a very appealing
+  // fallback when IK-based decollision is unavailable or unavailing.
+  VectorXd AdjustPositionsUsingBisect(
+      const Context<double>& root_context,
+      const std::set<JointIndex>& joints_to_adjust,
+      const std::set<BodyIndex>& floating_bodies_to_adjust,
+      const std::optional<const std::set<BodyIndex>>& bodies_to_decollide,
+      const VectorXd& known_valid_position) {
+    // Context scratch space for collision checking.
+    std::unique_ptr<Context<double>> working_root_context =
+        root_context.Clone();
+    Context<double>* working_plant_context =
+        &diagram_->GetMutableSubsystemContext(*plant_,
+                                              working_root_context.get());
+    VectorXd original_q = plant_->GetPositions(*working_plant_context);
+
+    // The validity function on which we will bisect:
+    auto collides_at = [&](const VectorXd& q) -> bool {
+      plant_->SetPositions(working_plant_context, q);
+      return Collides(*working_plant_context, bodies_to_decollide);
+    };
+
+    // Start our search at `known_valid_position` for the `joints_to_adjust`
+    // and at `root_context`'s current position for all other joints.
+    VectorXd bad_value = original_q;
+    VectorXd good_value = known_valid_position;
+    std::set<int> constrained_state_indexes =
+        ConstrainedStateIndexes(joints_to_adjust, floating_bodies_to_adjust);
+    for (const int index : constrained_state_indexes) {
+      good_value[index] = original_q[index];
+    }
+
+    drake::log()->debug("Attempting bisect between (bad)\n{} and (good)\n{}...",
+                        PositionAsString(*plant_, bad_value),
+                        PositionAsString(*plant_, good_value));
+    for (int i = 0; i < kBisectIterations; ++i) {
+      // Invariant for the bisect.
+      DRAKE_DEMAND(collides_at(bad_value));
+      // This is not guaranteed to always be true due to non-known-good values
+      // in the constrained joints.  However we also don't have any useful
+      // fallback from this state, so failing here gives a clearer crash than
+      // returning false and letting the caller fail.
+      // TODO(ggould) Find a better plan for this if it happens in practice.
+      DRAKE_DEMAND(!collides_at(good_value));
+
+      VectorXd halfway = (bad_value + good_value) / 2;
+
+      // The "/ 2" there could have denormed our quaternions.  Fix them.
+      for (const BodyIndex id : floating_bodies_to_adjust) {
+        if (plant_->get_body(id).has_quaternion_dofs()) {
+          // Per `Body::floating_positions_start()`, the first four entries in
+          // the floating position are guaranteed to be the quaternion.
+          int quat_index = plant_->get_body(id).floating_positions_start();
+          Eigen::VectorBlock<VectorXd, drake::kQuaternionSize>(
+              halfway, quat_index).normalize();
+        }
+      }
+
+      if (collides_at(halfway)) {
+        bad_value = halfway;
+      } else {
+        good_value = halfway;
+      }
+    }
+    drake::log()->debug("...found non-colliding value {}.", good_value);
+    return good_value;
+  }
+
+  bool Collides(const Context<double>& plant_context,
+                const std::optional<const std::set<BodyIndex>>& bodies) const {
+    // Precondition:
+    DRAKE_DEMAND(plant_context.GetSystemPathname() ==
+                 plant_->GetSystemPathname());
+
+    geom::QueryObject<double> query_object =
+        plant_->get_geometry_query_input_port().
+        Eval<geom::QueryObject<double>>(plant_context);
+    const geom::SceneGraphInspector<double>& inspector =
+        query_object.inspector();
+    const std::vector<geom::PenetrationAsPointPair<double>>& point_pairs =
+        query_object.ComputePointPairPenetration();
+    if (point_pairs.empty()) {
+      drake::log()->debug("Configuration is collision-free ({} bodies).",
+                          bodies ? std::to_string(bodies->size()) : "default");
+    }
+
+    for (const geom::PenetrationAsPointPair<double>& point_pair : point_pairs) {
+      const geom::FrameId frame_id_A = inspector.GetFrameId(point_pair.id_A);
+      const geom::FrameId frame_id_B = inspector.GetFrameId(point_pair.id_B);
+      const Body<double>* body_A = plant_->GetBodyFromFrameId(frame_id_A);
+      const Body<double>* body_B = plant_->GetBodyFromFrameId(frame_id_B);
+      DRAKE_THROW_UNLESS(body_A);
+      DRAKE_THROW_UNLESS(body_B);
+      drake::log()->debug("Found collision between {} and {}...",
+                          body_A->name(), body_B->name());
+      if (!bodies || (
+              bodies->count(body_A->index()) &&
+              bodies->count(body_B->index()))) {
+        drake::log()->debug("...which is flagged as a collision.");
+        return true;
+      }
+      drake::log()->debug("...and ignored it.");
+    }
+    return false;
+  }
+
+  const Diagram<double>* diagram_;
+  const MultibodyPlant<double>* plant_;
+  const SceneGraph<double>* scene_graph_;
+};
+
+CollisionRemover::CollisionRemover(
+    const Diagram<double>* diagram,
+    const MultibodyPlant<double>* plant,
+    const SceneGraph<double>* scene_graph)
+  : impl_(new CollisionRemover::Impl(diagram, plant, scene_graph)) {}
+
+CollisionRemover::~CollisionRemover() {}
+
+bool CollisionRemover::AdjustPositions(
+    Context<double>* root_context,
+    const std::set<JointIndex>& joints_to_adjust,
+    const std::set<BodyIndex>& floating_bodies_to_adjust,
+    const std::optional<const std::set<BodyIndex>>& bodies_to_decollide,
+    const VectorXd& known_valid_position) const {
+  return impl_->AdjustPositions(root_context, joints_to_adjust,
+                             floating_bodies_to_adjust, bodies_to_decollide,
+                             known_valid_position);
+}
+
+bool CollisionRemover::Collides(
+    const Context<double>& context,
+    const std::optional<const std::set<BodyIndex>>& bodies_to_decollide) const {
+  return impl_->Collides(context, bodies_to_decollide);
+}
+
+}  // namespace sim
+}  // namespace anzu

--- a/multibody/optimization/collision_remover.h
+++ b/multibody/optimization/collision_remover.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <set>
+
+#include "drake/geometry/scene_graph.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/tree/body.h"
+#include "drake/multibody/tree/joint.h"
+#include "drake/systems/framework/context.h"
+#include "drake/systems/framework/diagram.h"
+
+namespace anzu {
+namespace sim {
+
+/// Given a MultibodyPlant, this class provides a mechanism for adjusting
+/// a `Context` on that plant to remove collisions.  This is intended for
+/// replacing randomly generated states with their nearest collision-free
+/// neighbors.
+///
+/// @warn Empirically this class is very good at finding bugs in collision
+/// libraries.  If you get an exception from FCL (the collision library used
+/// by our inverse kinematics optimization) please report it to the FCL team
+/// at https://github.com/flexible-collision-library/fcl/issues
+class CollisionRemover {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(CollisionRemover);
+
+  /// Construct a CollisionRemover that can adjust robots out of colliding
+  /// positions.
+  ///
+  /// @p diagram The root system of the simulation
+  /// @p plant The MultibodyPlant on which IK will be performed to adjust
+  ///    joint and floating body positions
+  /// @p scene_graph the SceneGraph used to detect collisions
+  CollisionRemover(
+      const drake::systems::Diagram<double>* diagram,
+      const drake::multibody::MultibodyPlant<double>* plant,
+      const drake::geometry::SceneGraph<double>* scene_graph);
+
+  ~CollisionRemover();
+
+  /// Given a @p root_context, try to adjust the position DOFs of @p
+  /// joints_to_adjust and @p floating_bodies_to_adjust to remove collisions
+  /// among the bodies listed in @p bodies_to_deconflict.
+  ///
+  /// Callers must provide a @p known_valid_position -- a position that
+  /// satisfies the constraints.  This should be the Q value for `plant` in a
+  /// valid configuration, eg via:
+  /// `plant->GetPositions(diagram->GetSubsystemContext(*plant, context))`
+  /// from a known good context value.
+  ///
+  /// If `bodies_to_deconflict` is set to `nullopt` then uses the context's
+  /// pre-existing collision graph.  This is typically clumsy and expensive to
+  /// run and can be quite brittle or even nondeterministic; you should run it
+  /// only with a small number of DOFs in the `..._to_adjust` parameters.
+  ///
+  /// @return true on success, ie no collisions remain among the bodies.
+  ///
+  /// `root_context` may be updated to a less-colliding state even on failure.
+  bool AdjustPositions(
+      drake::systems::Context<double>* root_context,
+      const std::set<drake::multibody::JointIndex>& joints_to_adjust,
+      const std::set<drake::multibody::BodyIndex>& floating_bodies_to_adjust,
+      const std::optional<const std::set<drake::multibody::BodyIndex>>&
+      bodies_to_deconflict,
+      const drake::VectorX<double>& known_valid_position) const;
+
+  /// For convenience (and unit testing), determine whether any of @p bodies
+  /// (or, if `nullopt`, anything at all) collide if the plant of this
+  /// `CollisionRemover` had context @p plant_context.
+  bool Collides(
+      const drake::systems::Context<double>& plant_context,
+      const std::optional<const std::set<drake::multibody::BodyIndex>>&
+      bodies = std::nullopt) const;
+
+ private:
+  class Impl;
+  const std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace sim
+}  // namespace anzu

--- a/multibody/optimization/collision_remover.h
+++ b/multibody/optimization/collision_remover.h
@@ -11,8 +11,8 @@
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/diagram.h"
 
-namespace anzu {
-namespace sim {
+namespace drake {
+namespace multibody {
 
 /// Given a MultibodyPlant, this class provides a mechanism for adjusting
 /// a `Context` on that plant to remove collisions.  This is intended for
@@ -80,5 +80,5 @@ class CollisionRemover {
   const std::unique_ptr<Impl> impl_;
 };
 
-}  // namespace sim
-}  // namespace anzu
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/optimization/test/collision_remover_test.cc
+++ b/multibody/optimization/test/collision_remover_test.cc
@@ -1,0 +1,180 @@
+#include "sim/common/collision_remover.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/tree/revolute_joint.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "common/find_resource.h"
+
+using drake::multibody::BodyIndex;
+using drake::multibody::JointIndex;
+using drake::multibody::RevoluteJoint;
+using Contextd = drake::systems::Context<double>;
+using MultibodyPlantd = drake::multibody::MultibodyPlant<double>;
+using RigidTransformd = drake::math::RigidTransform<double>;
+
+namespace anzu {
+namespace sim {
+namespace {
+
+class CollisionRemoverFixture : public ::testing::Test {
+ public:
+  CollisionRemoverFixture() {
+    drake::systems::DiagramBuilder<double> builder;
+    std::tie(plant, scene_graph) =
+        drake::multibody::AddMultibodyPlantSceneGraph(&builder, 0.001);
+    drake::multibody::Parser(plant, scene_graph)
+        .AddAllModelsFromFile(FindAnzuResourceOrThrow(
+            "sim/common/test/collision_remover_test.urdf"));
+    plant->Finalize();
+    diagram = builder.Build();
+    pendulum_1 = plant->GetBodyByName("pendulum_1_arm").index();
+    pendulum_2 = plant->GetBodyByName("pendulum_2_arm").index();
+    brick = plant->GetBodyByName("floating_brick").index();
+    dut = std::make_unique<anzu::sim::CollisionRemover>(
+        diagram.get(), plant, scene_graph);
+    known_valid_position = plant->GetPositions(
+        diagram->GetSubsystemContext(*plant, *diagram->CreateDefaultContext()));
+  }
+  ~CollisionRemoverFixture() {}
+
+  std::unique_ptr<drake::systems::Diagram<double>> diagram;
+  MultibodyPlantd* plant = nullptr;
+  drake::geometry::SceneGraph<double>* scene_graph = nullptr;
+  std::unique_ptr<anzu::sim::CollisionRemover> dut;
+  BodyIndex pendulum_1{};
+  BodyIndex pendulum_2{};
+  BodyIndex brick{};
+  drake::VectorX<double> known_valid_position{};
+};
+
+// Check the fixture (and the collision checker) to ensure that we get the
+// collisions we expect.  Otherwise none of our other tests would mean much.
+TEST_F(CollisionRemoverFixture, FixtureSmokeTest) {
+  auto root_context = diagram->CreateDefaultContext();
+  Contextd& plant_context =
+      diagram->GetMutableSubsystemContext(*plant, root_context.get());
+  EXPECT_FALSE(dut->Collides(plant_context, std::nullopt));
+
+  // Turn the left pendulum to collide with the right pendulum and the brick.
+  plant->GetJointByName<RevoluteJoint>("pendulum_1_theta")
+      .set_angle(&plant_context, -1.5);
+  EXPECT_TRUE(dut->Collides(plant_context, {{pendulum_1, pendulum_2}}));
+  EXPECT_TRUE(dut->Collides(plant_context, {{pendulum_1, brick}}));
+  EXPECT_FALSE(dut->Collides(plant_context, {{pendulum_2, brick}}));
+  EXPECT_TRUE(dut->Collides(plant_context, std::nullopt));
+
+  // Turn the right pendulum to a parallel position, so there is no collision
+  // between the pendula but the brick is still in collision.
+  plant->GetJointByName<RevoluteJoint>("pendulum_2_theta")
+      .set_angle(&plant_context, -1.5);
+  EXPECT_FALSE(dut->Collides(plant_context, {{pendulum_1, pendulum_2}}));
+  EXPECT_TRUE(dut->Collides(plant_context, {{pendulum_1, brick}}));
+  EXPECT_FALSE(dut->Collides(plant_context, {{pendulum_2, brick}}));
+  EXPECT_TRUE(dut->Collides(plant_context, std::nullopt));
+
+  // Move the brick out of collision.
+  plant->SetFreeBodyPose(
+      &plant_context, plant->get_body(brick),
+      RigidTransformd(Eigen::Vector3d{0., 0., 1.}));
+  EXPECT_FALSE(dut->Collides(plant_context, {{pendulum_1, pendulum_2}}));
+  EXPECT_FALSE(dut->Collides(plant_context, {{pendulum_1, brick}}));
+  EXPECT_FALSE(dut->Collides(plant_context, {{pendulum_2, brick}}));
+  EXPECT_FALSE(dut->Collides(plant_context, std::nullopt));
+}
+
+// Raise one pendulum into collision; let AdjustPositions rotate it out of
+// collision.
+TEST_F(CollisionRemoverFixture, SingleJointTest) {
+  auto root_context = diagram->CreateDefaultContext();
+  Contextd& plant_context =
+      diagram->GetMutableSubsystemContext(*plant, root_context.get());
+  const RevoluteJoint<double>& theta_joint =
+      plant->GetJointByName<RevoluteJoint>("pendulum_1_theta");
+  theta_joint.set_angle(&plant_context, -1.5);
+
+  EXPECT_TRUE(dut->Collides(plant_context, std::nullopt));
+  dut->AdjustPositions(root_context.get(), {theta_joint.index()}, {},
+                       std::nullopt,
+                       known_valid_position);
+  EXPECT_FALSE(dut->Collides(plant_context, std::nullopt));
+}
+
+// Move the brick into collision; let AdjustPositions slide it out of
+// collision.
+TEST_F(CollisionRemoverFixture, SingleBodyTest) {
+  auto root_context = diagram->CreateDefaultContext();
+  Contextd& plant_context =
+      diagram->GetMutableSubsystemContext(*plant, root_context.get());
+  plant->SetFreeBodyPose(&plant_context, plant->get_body(brick),
+                         RigidTransformd(Eigen::Vector3d{-0.24, 0., 0.}));
+
+  EXPECT_TRUE(dut->Collides(plant_context, std::nullopt));
+  dut->AdjustPositions(root_context.get(), {}, {brick},
+                       std::nullopt,
+                       known_valid_position);
+  EXPECT_FALSE(dut->Collides(plant_context, std::nullopt));
+}
+
+// Bring all three objects into collision.  Resolve the collision one element
+// at a time (this is the preferred use case).
+TEST_F(CollisionRemoverFixture, StepByStepTest) {
+  auto root_context = diagram->CreateDefaultContext();
+  Contextd& plant_context =
+      diagram->GetMutableSubsystemContext(*plant, root_context.get());
+  const RevoluteJoint<double>& theta_1_joint =
+      plant->GetJointByName<RevoluteJoint>("pendulum_1_theta");
+  const RevoluteJoint<double>& theta_2_joint =
+      plant->GetJointByName<RevoluteJoint>("pendulum_2_theta");
+  theta_1_joint.set_angle(&plant_context, -1.5);
+  theta_2_joint.set_angle(&plant_context, 1.5);
+
+  EXPECT_TRUE(dut->Collides(plant_context, {{pendulum_1, pendulum_2}}));
+  EXPECT_TRUE(dut->Collides(plant_context, {{pendulum_1, brick}}));
+  EXPECT_TRUE(dut->Collides(plant_context, {{pendulum_2, brick}}));
+
+  EXPECT_TRUE(dut->Collides(plant_context, std::nullopt));
+
+  dut->AdjustPositions(root_context.get(), {theta_1_joint.index()}, {},
+                       {{pendulum_1, pendulum_2}},
+                       known_valid_position);
+  EXPECT_FALSE(dut->Collides(plant_context, {{pendulum_1, pendulum_2}}));
+
+  dut->AdjustPositions(root_context.get(), {}, {brick},
+                       std::nullopt,
+                       known_valid_position);
+  EXPECT_FALSE(dut->Collides(plant_context, std::nullopt));
+}
+
+// Bring all three objects into collision.  Resolve the collisions in a single
+// call (this is a common starting case, although it is expensive and not
+// usually what you want to end up with).
+TEST_F(CollisionRemoverFixture, BigBangTest) {
+  auto root_context = diagram->CreateDefaultContext();
+  Contextd& plant_context =
+      diagram->GetMutableSubsystemContext(*plant, root_context.get());
+  const RevoluteJoint<double>& theta_1_joint =
+      plant->GetJointByName<RevoluteJoint>("pendulum_1_theta");
+  const RevoluteJoint<double>& theta_2_joint =
+      plant->GetJointByName<RevoluteJoint>("pendulum_2_theta");
+  theta_1_joint.set_angle(&plant_context, -1.5);
+  theta_2_joint.set_angle(&plant_context, 1.5);
+
+  EXPECT_TRUE(dut->Collides(plant_context, {{pendulum_1, pendulum_2}}));
+  EXPECT_TRUE(dut->Collides(plant_context, {{pendulum_1, brick}}));
+  EXPECT_TRUE(dut->Collides(plant_context, {{pendulum_2, brick}}));
+
+  EXPECT_TRUE(dut->Collides(plant_context, std::nullopt));
+  dut->AdjustPositions(root_context.get(),
+                       {theta_1_joint.index(), theta_1_joint.index()},
+                       {brick},
+                       {},
+                       known_valid_position);
+  EXPECT_FALSE(dut->Collides(plant_context, std::nullopt));
+}
+
+}  // namespace
+}  // namespace sim
+}  // namespace anzu

--- a/multibody/optimization/test/collision_remover_test.cc
+++ b/multibody/optimization/test/collision_remover_test.cc
@@ -1,4 +1,4 @@
-#include "sim/common/collision_remover.h"
+#include "drake/multibody/optimization/collision_remover.h"
 
 #include <gtest/gtest.h>
 
@@ -6,17 +6,14 @@
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/multibody/tree/revolute_joint.h"
 #include "drake/systems/framework/diagram_builder.h"
-#include "common/find_resource.h"
+#include "drake/common/find_resource.h"
 
-using drake::multibody::BodyIndex;
-using drake::multibody::JointIndex;
-using drake::multibody::RevoluteJoint;
 using Contextd = drake::systems::Context<double>;
 using MultibodyPlantd = drake::multibody::MultibodyPlant<double>;
 using RigidTransformd = drake::math::RigidTransform<double>;
 
-namespace anzu {
-namespace sim {
+namespace drake {
+namespace multibody {
 namespace {
 
 class CollisionRemoverFixture : public ::testing::Test {
@@ -26,14 +23,14 @@ class CollisionRemoverFixture : public ::testing::Test {
     std::tie(plant, scene_graph) =
         drake::multibody::AddMultibodyPlantSceneGraph(&builder, 0.001);
     drake::multibody::Parser(plant, scene_graph)
-        .AddAllModelsFromFile(FindAnzuResourceOrThrow(
-            "sim/common/test/collision_remover_test.urdf"));
+        .AddAllModelsFromFile(FindResourceOrThrow(
+            "drake/multibody/optimization/test/collision_remover_test.urdf"));
     plant->Finalize();
     diagram = builder.Build();
     pendulum_1 = plant->GetBodyByName("pendulum_1_arm").index();
     pendulum_2 = plant->GetBodyByName("pendulum_2_arm").index();
     brick = plant->GetBodyByName("floating_brick").index();
-    dut = std::make_unique<anzu::sim::CollisionRemover>(
+    dut = std::make_unique<CollisionRemover>(
         diagram.get(), plant, scene_graph);
     known_valid_position = plant->GetPositions(
         diagram->GetSubsystemContext(*plant, *diagram->CreateDefaultContext()));
@@ -43,7 +40,7 @@ class CollisionRemoverFixture : public ::testing::Test {
   std::unique_ptr<drake::systems::Diagram<double>> diagram;
   MultibodyPlantd* plant = nullptr;
   drake::geometry::SceneGraph<double>* scene_graph = nullptr;
-  std::unique_ptr<anzu::sim::CollisionRemover> dut;
+  std::unique_ptr<CollisionRemover> dut;
   BodyIndex pendulum_1{};
   BodyIndex pendulum_2{};
   BodyIndex brick{};
@@ -176,5 +173,5 @@ TEST_F(CollisionRemoverFixture, BigBangTest) {
 }
 
 }  // namespace
-}  // namespace sim
-}  // namespace anzu
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/optimization/test/collision_remover_test.urdf
+++ b/multibody/optimization/test/collision_remover_test.urdf
@@ -1,0 +1,68 @@
+<?xml version="1.0"?>
+<robot xmlns="https://drake.mit.edu" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="CollisionRemoverTest">
+
+  <!-- Two 1m pendula, rotating in the xz plane, hang at +/- 25cm along x from
+       the origin.  A 10cm brick sits between them. -->
+
+  <link name="pendulum_1_base"/>
+  <joint name="base_weld_1" type="fixed">
+    <parent link="world"/>
+    <child link="pendulum_1_base"/>
+    <origin xyz="-0.25 0 0"/>
+  </joint>
+  <link name="pendulum_1_arm">
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0 -.5"/>
+      <mass value="1"/>
+      <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/>
+    </inertial>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 -.5"/>
+      <geometry>
+        <cylinder length="1" radius=".001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="pendulum_1_theta" type="continuous">
+    <parent link="pendulum_1_base"/>
+    <child link="pendulum_1_arm"/>
+    <axis xyz="0 1 0"/>
+  </joint>
+
+  <link name="pendulum_2_base"/>
+  <joint name="base_weld_2" type="fixed">
+    <parent link="world"/>
+    <child link="pendulum_2_base"/>
+    <origin xyz="0.25 0 0"/>
+  </joint>
+  <link name="pendulum_2_arm">
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0 -.5"/>
+      <mass value="1"/>
+      <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/>
+    </inertial>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 -.5"/>
+      <geometry>
+        <cylinder length="1" radius=".001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="pendulum_2_theta" type="continuous">
+    <parent link="pendulum_2_base"/>
+    <child link="pendulum_2_arm"/>
+    <axis xyz="0 1 0"/>
+  </joint>
+
+  <link name="floating_brick">
+    <inertial>
+      <mass value="1"/>
+      <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/>
+    </inertial>
+    <collision>
+      <geometry>
+        <box size="0.1 0.1 0.1"/>
+      </geometry>
+    </collision>
+ </link>
+</robot>


### PR DESCRIPTION
* Verbatim copy of downstream (anzu) utility.
* Resolves #13308

Co-authored-by: Jeremy Nimmer <jeremy.nimmer@tri.global>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14830)
<!-- Reviewable:end -->
