### PR TITLE
doc: Fix styleguide publication on Focal

### DIFF
--- a/doc/styleguide/_config.yml
+++ b/doc/styleguide/_config.yml
@@ -1,7 +1,6 @@
 # For more information, see: https://jekyllrb.com/docs/configuration/
 
 title: Google Style Guide for Drake
-theme: minima
 
 defaults:
   - scope:


### PR DESCRIPTION
Our config file asked for the "minima" theme, which does not exist on either Bionic nor Focal -- but on Focal a missing theme is a hard error, while on Bionic it seems to be silently ignored.

Hotfix for #14811.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14831)
<!-- Reviewable:end -->
