### PR TITLE
Make soft half space/rigid mesh differentiable

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -789,6 +789,8 @@ drake_cc_googletest(
         ":mesh_half_space_intersection",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
+        "//math:autodiff",
+        "//math:gradient",
     ],
 )
 

--- a/geometry/proximity/mesh_half_space_intersection.cc
+++ b/geometry/proximity/mesh_half_space_intersection.cc
@@ -342,7 +342,8 @@ ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
   std::vector<SurfaceFaceIndex> tri_indices;
   tri_indices.reserve(mesh_R.num_elements());
   const math::RotationMatrixd& R_WR = convert_to_double(X_WR).rotation();
-  auto bvh_callback = [&tri_indices, &mesh_R, &R_WS = X_WS.rotation(),
+  auto bvh_callback = [&tri_indices, &mesh_R,
+                       &R_WS = convert_to_double(X_WS).rotation(),
                        &R_WR](SurfaceFaceIndex tri_index) {
     // The gradient of the half space pressure field lies in the _opposite_
     // direction as its normal. Its normal is Sz. So, unit_grad_p_W = -Sz_W.
@@ -359,7 +360,7 @@ ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
   //   - X_PH - pose of the hierarchy in the primitive frame or, in this
   //     context, the hierarchy of the _rigid_ mesh_R in the half space
   //     primitive: X_SR.
-  bvh_R.Collide(HalfSpace{}, X_RS.inverse(), bvh_callback);
+  bvh_R.Collide(HalfSpace{}, convert_to_double(X_RS).inverse(), bvh_callback);
 
   if (tri_indices.size() == 0) return nullptr;
 
@@ -389,7 +390,7 @@ ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
   const PosedHalfSpace<T> hs_W{X_WR.rotation() * hs_R.normal(), X_WR * p_RSo};
   vertex_pressures.reserve(mesh_W->num_vertices());
   for (SurfaceVertexIndex v(0); v < mesh_W->num_vertices(); ++v) {
-    const Vector3<double> p_WV = mesh_W->vertex(v).r_MV();
+    const Vector3<T> p_WV = mesh_W->vertex(v).r_MV();
     // The signed distance of the point is the negative of the penetration
     // depth. We can use the pressure_scale to directly compute pressure at the
     // point.
@@ -403,7 +404,7 @@ ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
   // TODO(SeanCurtis-TRI) In this case, the gradient across the contact surface
   //  is a constant. It would be good if we could exploit this and *not* copy
   //  the same vector value once per triangle.
-  const Eigen::Vector3d& unit_grad_p_W = X_WS.rotation().col(2);
+  const Vector3<T>& unit_grad_p_W = X_WS.rotation().col(2);
   auto grad_eS_W = std::make_unique<std::vector<Vector3<T>>>(
       mesh_W->num_elements(), -pressure_scale * unit_grad_p_W);
 
@@ -452,11 +453,17 @@ ConstructSurfaceMeshFromMeshHalfspaceIntersection(
 
 template std::unique_ptr<ContactSurface<double>>
 ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
-    GeometryId id_S, const math::RigidTransform<double>& X_WS,
-    double pressure_scale, GeometryId id_R, const SurfaceMesh<double>& field_R,
-    const Bvh<SurfaceMesh<double>>& bvh_R,
-    const math::RigidTransform<double>& X_WR);
+    GeometryId, const math::RigidTransform<double>&, double, GeometryId,
+    const SurfaceMesh<double>&, const Bvh<SurfaceMesh<double>>&,
+    const math::RigidTransform<double>&);
 
+#if 1
+template std::unique_ptr<ContactSurface<AutoDiffXd>>
+ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
+    GeometryId, const math::RigidTransform<AutoDiffXd>&, double, GeometryId,
+    const SurfaceMesh<double>&, const Bvh<SurfaceMesh<double>>&,
+    const math::RigidTransform<AutoDiffXd>&);
+#else
 template <>
 std::unique_ptr<ContactSurface<AutoDiffXd>>
 ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
@@ -467,6 +474,7 @@ ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
       "AutoDiff-valued ContactSurface calculations are not currently "
       "supported");
 }
+#endif
 
 }  // namespace internal
 }  // namespace geometry


### PR DESCRIPTION
1. Modifications to the underlying algorithm
   TODO: Elaborate
2. Addition to unit tests to assess the quality of the derivatives.

TODO:
 - Do the same for rigid half space and soft mesh.
 - Do the same for rigid/soft meshes
 - Fix the logic in hydroelastic callback to let them through.
 - Add characterization/support matrix in query_object.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14836)
<!-- Reviewable:end -->
