### PR TITLE
direct_transcription: Parallelize test cases

### DIFF
--- a/systems/trajectory_optimization/BUILD.bazel
+++ b/systems/trajectory_optimization/BUILD.bazel
@@ -118,8 +118,8 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "direct_transcription_test",
     data = ["//examples/pendulum:prod_models"],
-    # This test times out intermittently under asan.
-    tags = ["no_asan"],
+    # This test has two long cases; run them in parallel.
+    shard_count = 2,
     deps = [
         ":direct_transcription",
         "//common/test_utilities:eigen_matrix_compare",

--- a/systems/trajectory_optimization/test/direct_transcription_test.cc
+++ b/systems/trajectory_optimization/test/direct_transcription_test.cc
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <vector>
 
+#include <fmt/format.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"
@@ -268,15 +269,15 @@ GTEST_TEST(DirectTranscriptionTest, ContinuousTimeSymbolicConstraintTest) {
   }
 }
 
-// Tests that MultibodyPlant can be optimized using both the discrete and
-// continuous time entry points into the plant.
-GTEST_TEST(DirectTranscriptionTest, MultibodyTest) {
+void SolvePendulumTrajectory(bool continuous_time) {
   // Only solve under SNOPT (IPOPT is unreliable here).
   solvers::SnoptSolver snopt_solver;
   if (!snopt_solver.is_available()) {
     drake::log()->warn("SNOPT is unavaible; this test shall be skipped.");
     return;
   }
+
+  SCOPED_TRACE(fmt::format("continuous_time = {}", continuous_time));
 
   const char* const urdf_path =
       "drake/examples/pendulum/Pendulum.urdf";
@@ -285,70 +286,75 @@ GTEST_TEST(DirectTranscriptionTest, MultibodyTest) {
   // provides a reasonably fast solve.
   const double kFixedTimeStep = 0.1;
 
-  for (bool continuous_time : {false, true}) {
-    const double kTimeStep = continuous_time ? 0 : kFixedTimeStep;
+  const double kTimeStep = continuous_time ? 0 : kFixedTimeStep;
 
-    auto pendulum =
-        std::make_unique<multibody::MultibodyPlant<double>>(kTimeStep);
-    multibody::Parser parser(pendulum.get());
-    parser.AddModelFromFile(FindResourceOrThrow(urdf_path));
-    pendulum->WeldFrames(pendulum->world_frame(),
-                        pendulum->GetFrameByName("base"));
-    pendulum->Finalize();
+  auto pendulum =
+      std::make_unique<multibody::MultibodyPlant<double>>(kTimeStep);
+  multibody::Parser parser(pendulum.get());
+  parser.AddModelFromFile(FindResourceOrThrow(urdf_path));
+  pendulum->WeldFrames(pendulum->world_frame(),
+                       pendulum->GetFrameByName("base"));
+  pendulum->Finalize();
 
-    // Create the DirectTranscription object, and specify which input port
-    // on the MultibodyPlant corresponds to the control input.
-    auto context = pendulum->CreateDefaultContext();
-    const InputPortIndex actuation_port_index =
-        pendulum->get_actuation_input_port().get_index();
-    const int kNumTimeSamples = 50;
-    std::unique_ptr<DirectTranscription> dirtran{};
-    if (continuous_time) {
-      dirtran = std::make_unique<DirectTranscription>(
+  // Create the DirectTranscription object, and specify which input port
+  // on the MultibodyPlant corresponds to the control input.
+  auto context = pendulum->CreateDefaultContext();
+  const InputPortIndex actuation_port_index =
+      pendulum->get_actuation_input_port().get_index();
+  const int kNumTimeSamples = 50;
+  std::unique_ptr<DirectTranscription> dirtran{};
+  if (continuous_time) {
+    dirtran = std::make_unique<DirectTranscription>(
         pendulum.get(), *context, kNumTimeSamples, TimeStep(kFixedTimeStep),
-                                actuation_port_index);
-    } else {
-      dirtran = std::make_unique<DirectTranscription>(
+        actuation_port_index);
+  } else {
+    dirtran = std::make_unique<DirectTranscription>(
         pendulum.get(), *context, kNumTimeSamples,
-                                actuation_port_index);
-    }
-
-    // Adds a torque actuation limit.
-    const double kTorqueLimit = 3.0;  // N*m.
-    const solvers::VectorXDecisionVariable& u = dirtran->input();
-    dirtran->AddConstraintToAllKnotPoints(-kTorqueLimit <= u(0));
-    dirtran->AddConstraintToAllKnotPoints(u(0) <= kTorqueLimit);
-
-    BasicVector<double> initial_state(Eigen::VectorXd::Zero(2));
-    BasicVector<double> final_state(Eigen::VectorXd::Zero(2));
-
-    DRAKE_DEMAND(initial_state.size() == 2);
-    DRAKE_DEMAND(final_state.size() == 2);
-
-    // Set the initial and final state constraints.
-    const int kTheta_index = 0, kThetadot_index = 1;
-    initial_state.SetAtIndex(kTheta_index, 0.0);
-    initial_state.SetAtIndex(kThetadot_index, 0.0);
-    final_state.SetAtIndex(kTheta_index, M_PI);
-    final_state.SetAtIndex(kThetadot_index, 0.0);
-    dirtran->AddLinearConstraint(dirtran->initial_state() ==
-                                 initial_state.get_value());
-    dirtran->AddLinearConstraint(dirtran->final_state() ==
-                                 final_state.get_value());
-
-    const double R = 10;  // Cost on input "effort".
-    dirtran->AddRunningCost((R * u) * u);
-
-    // Create an initial guess for the state trajectory.
-    const double timespan_init = 4;
-    auto traj_init_x = PiecewisePolynomial<double>::FirstOrderHold(
-        {0, timespan_init},
-        {initial_state.get_value(), final_state.get_value()});
-    dirtran->SetInitialTrajectory(PiecewisePolynomial<double>(), traj_init_x);
-
-    const auto result = snopt_solver.Solve(*dirtran, {}, {});
-    DRAKE_DEMAND(result.is_success());
+        actuation_port_index);
   }
+
+  // Adds a torque actuation limit.
+  const double kTorqueLimit = 3.0;  // N*m.
+  const solvers::VectorXDecisionVariable& u = dirtran->input();
+  dirtran->AddConstraintToAllKnotPoints(-kTorqueLimit <= u(0));
+  dirtran->AddConstraintToAllKnotPoints(u(0) <= kTorqueLimit);
+
+  BasicVector<double> initial_state(Eigen::VectorXd::Zero(2));
+  BasicVector<double> final_state(Eigen::VectorXd::Zero(2));
+
+  // Set the initial and final state constraints.
+  const int kTheta_index = 0, kThetadot_index = 1;
+  initial_state.SetAtIndex(kTheta_index, 0.0);
+  initial_state.SetAtIndex(kThetadot_index, 0.0);
+  final_state.SetAtIndex(kTheta_index, M_PI);
+  final_state.SetAtIndex(kThetadot_index, 0.0);
+  dirtran->AddLinearConstraint(dirtran->initial_state() ==
+                               initial_state.get_value());
+  dirtran->AddLinearConstraint(dirtran->final_state() ==
+                               final_state.get_value());
+
+  const double R = 10;  // Cost on input "effort".
+  dirtran->AddRunningCost((R * u) * u);
+
+  // Create an initial guess for the state trajectory.
+  const double timespan_init = 4;
+  auto traj_init_x = PiecewisePolynomial<double>::FirstOrderHold(
+      {0, timespan_init},
+      {initial_state.get_value(), final_state.get_value()});
+  dirtran->SetInitialTrajectory(PiecewisePolynomial<double>(), traj_init_x);
+
+  const auto result = snopt_solver.Solve(*dirtran, {}, {});
+  EXPECT_TRUE(result.is_success());
+}
+
+// Tests that MultibodyPlant can be optimized using both the discrete and
+// continuous time entry points into the plant.
+GTEST_TEST(DirectTranscriptionTest, MultibodyDiscreteTest) {
+  SolvePendulumTrajectory(false);
+}
+
+GTEST_TEST(DirectTranscriptionTest, MultibodyContinuousTest) {
+  SolvePendulumTrajectory(true);
 }
 
 GTEST_TEST(DirectTranscriptionTest, DiscreteTimeLinearSystemTest) {


### PR DESCRIPTION
This commit replaces the first-aid fix of #14854, which addressed test
timeouts introduced at #14840.

Run the test in 2 shards. Most of the cases are vanishingly fast, but
the discrete- and continuous-mode SNOPT solves of Multibody*Test are
quite long under slow tooling (ASAN). This reshuffle should bring the
test latency down enough to avoid timeouts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14859)
<!-- Reviewable:end -->
