### PR TITLE
multibody: Adjust unit test to avoid scalar type violations

### DIFF
--- a/math/rotation_matrix.h
+++ b/math/rotation_matrix.h
@@ -1051,11 +1051,8 @@ double ProjectMatToRotMatWithAxis(const Eigen::MatrixBase<Derived>& M,
   return theta;
 }
 
-// @internal Initially, this code was in rotation_matrix.cc.  After
-// RotationMatrix was instantiated on symbolic expression, there was a linker
-// error that arose, but only during release builds and when tests in
-// rotation_matrix_test.cc used symbolic expressions.  I (Paul) spent a fair
-// amount of time trying to understand this problem (with Sherm & Sean).
+// TODO(jwnimmer-tri) Move this into the cc file, by replacing SFINAE with
+// "if constexpr".
 template <typename T>
 template <typename S>
 typename std::enable_if_t<scalar_predicate<S>::is_bool>

--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -372,6 +372,7 @@ drake_cc_googletest(
     name = "unit_inertia_test",
     deps = [
         ":unit_inertia",
+        "//common/test_utilities:eigen_matrix_compare",
         "//math:geometric_transform",
         "//math:gradient",
     ],


### PR DESCRIPTION
The `RotationMatrix` class only supports Drake's default scalars.
Instantiating `RotationMatrix<AutoDiff1d>` is an API violation.

This is a prerequisite of #14860.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14862)
<!-- Reviewable:end -->
