### PR TITLE
Add template specialization of not_equal_strict for symbolic::Expression

### DIFF
--- a/common/symbolic_formula.h
+++ b/common/symbolic_formula.h
@@ -1328,5 +1328,23 @@ struct scalar_cmp_op<drake::symbolic::Variable, drake::symbolic::Variable,
 };
 
 }  // namespace internal
+
+// not_equal_strict was only added in Eigen 3.3.5. Since the current minimum
+// Eigen version used by drake is 3.3.4, a version check is needed.
+#if EIGEN_VERSION_AT_LEAST(3, 3, 5)
+namespace numext {
+/// Provides specialization for not_equal_strict with Expression.
+/// As of Eigen 3.4.0, this is called at least as part of triangular vector
+/// solve (though it could also potentially come up elsewhere). The default
+/// template relies on an implicit conversion to bool but our bool operator
+/// is explicit, so we need to specialize.
+template <>
+EIGEN_STRONG_INLINE bool not_equal_strict(
+    const drake::symbolic::Expression& x,
+    const drake::symbolic::Expression& y) {
+  return static_cast<bool>(x != y);
+}
+}  // namespace numext
+#endif
 }  // namespace Eigen
 #endif  // !defined(DRAKE_DOXYGEN_CXX)

--- a/common/test/symbolic_expression_test.cc
+++ b/common/test/symbolic_expression_test.cc
@@ -881,6 +881,19 @@ TEST_F(SymbolicExpressionTest, UnaryPlus) {
   EXPECT_PRED2(ExprEqual, Expression(var_x_), +var_x_);
 }
 
+// Confirm that Eigen::numext::not_equal_strict is appropriately specialized
+// for Expression.
+// We only need a limited set of cases because if the specialization doesn't
+// exist, this would result in a compile error.
+// This function was only introduced in eigen 3.3.5. Therefore, we only want to
+// test if the eigen version is at least that.
+#if EIGEN_VERSION_AT_LEAST(3, 3, 5)
+TEST_F(SymbolicExpressionTest, EigenNotEqualStrict) {
+  EXPECT_TRUE(Eigen::numext::not_equal_strict(c3_, c4_));
+  EXPECT_FALSE(Eigen::numext::not_equal_strict(c3_, c3_));
+}
+
+#endif
 TEST_F(SymbolicExpressionTest, UnaryMinus) {
   EXPECT_PRED2(ExprEqual, -Expression(var_x_), -var_x_);
   EXPECT_PRED2(ExprNotEqual, c3_, -c3_);


### PR DESCRIPTION
This is needed for Eigen >= 3.3.5. not_equal_strict relies on an
implicit conversion to bool. Since Expression has an explicit bool()
operator, we need to specialize the call. As of Eigen 3.3.5, this
function is called at least as part of triangular vector solve.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14868)
<!-- Reviewable:end -->
