### PR TITLE
install_test: Skip for kcov due to failure in drake visualizer

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -75,9 +75,14 @@ install_test(
         ":install",
         _INSTALL_TEST_COMMANDS,
     ],
-    # Running acceptance tests under Valgrind tools is extremely slow and of
-    # limited value, so skip them.
-    tags = ["no_valgrind_tools"],
+    tags = [
+        # Running acceptance tests under coverage (kcov) can fail for presently
+        # unknown reasons when it comes to drake_visualizer, so skip them.
+        "no_kcov",
+        # Running acceptance tests under Valgrind tools is extremely slow and
+        # of limited value, so skip them.
+        "no_valgrind_tools",
+    ],
 )
 
 add_lint_tests()


### PR DESCRIPTION
`./bin/drake-visualizer --help` from install tree returns a non-zero
error code, for reasons presently unknown.

Context: https://drakedevelopers.slack.com/archives/C270MN28G/p1617722383078400

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14869)
<!-- Reviewable:end -->
