### PR TITLE
[bindings] Update documentation missed in previous code removal

### DIFF
--- a/bindings/pydrake/test/geometry_render_engine_subclass_test.py
+++ b/bindings/pydrake/test/geometry_render_engine_subclass_test.py
@@ -20,8 +20,8 @@ class TestRenderEngineSubclass(unittest.TestCase):
 
     def test_unimplemented_rendering(self):
         """The RenderEngine API throws exceptions for derived implementations
-        that don't override DoRender*Image (or Render*Image for the deprecated
-        API). This test confirms that behavior propagates down to Python."""
+        that don't override DoRender*Image. This test confirms that behavior
+        propagates down to Python."""
         class MinimalEngine(mut.render.RenderEngine):
             """Minimal implementation of the RenderEngine virtual API"""
             def UpdateViewpoint(self, X_WC):


### PR DESCRIPTION
 - This had some documentation referencing no longer valid deprecated APIs.

Relates to: #14686 and #14855.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14870)
<!-- Reviewable:end -->
