### PR TITLE
Add ability to convert GeometrySet into unordered_set<GeometryId>

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -475,6 +475,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.num_geometries.doc)
         .def("GetAllGeometryIds", &Class::GetAllGeometryIds,
             cls_doc.GetAllGeometryIds.doc)
+        .def("GetGeometryIds", &Class::GetGeometryIds, py::arg("geometry_set"),
+            py::arg("role") = std::nullopt, cls_doc.GetGeometryIds.doc)
         .def("NumGeometriesWithRole", &Class::NumGeometriesWithRole,
             py::arg("role"), cls_doc.NumGeometriesWithRole.doc)
         .def("NumDynamicGeometries", &Class::NumDynamicGeometries,
@@ -1359,6 +1361,9 @@ void DoScalarIndependentDefinitions(py::module m) {
     constexpr auto& cls_doc = doc.GeometrySet;
     py::class_<Class>(m, "GeometrySet", cls_doc.doc)
         .def(py::init(), doc.GeometrySet.ctor.doc);
+    // TODO(SeanCurtis-TRI) This is *useless* in python. I can only construct
+    //  an empty GeometrySet. Bind constructors and adders so that these APIs
+    //  can actually be used.
   }
 
   // GeometryVersion

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -87,6 +87,10 @@ class TestGeometry(unittest.TestCase):
         self.assertIsInstance(inspector.world_frame_id(), mut.FrameId)
         self.assertEqual(inspector.num_geometries(), 3)
         self.assertEqual(len(inspector.GetAllGeometryIds()), 3)
+        self.assertEqual(len(inspector.GetGeometryIds(mut.GeometrySet())), 0)
+        self.assertEqual(len(inspector.GetGeometryIds(mut.GeometrySet(),
+                                                      mut.Role.kProximity)),
+                         0)
         self.assertEqual(
             inspector.NumGeometriesWithRole(role=mut.Role.kUnassigned), 3)
         self.assertEqual(inspector.NumDynamicGeometries(), 2)

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -119,6 +119,10 @@ class GeometryState {
     return ids;
   }
 
+  /** Implementation of SceneGraphInspector::GetGeometryIds().  */
+  std::unordered_set<GeometryId> GetGeometryIds(
+      const GeometrySet& geometry_set, const std::optional<Role>& role) const;
+
   /** Implementation of SceneGraphInspector::NumGeometriesWithRole().  */
   int NumGeometriesWithRole(Role role) const;
 
@@ -630,6 +634,9 @@ class GeometryState {
   // defined in terms of geometry ids *and* frame ids). If GeometrySet only
   // has GeometryIds, it is essentially a copy. Ids that can't be identified
   // will cause an exception to be thrown.
+  // The ids can be optionally filtered based on role. If `role` is nullopt,
+  // no filtering takes place. Otherwise, just those geometries with the given
+  // role will be returned.
   // TODO(SeanCurtis-TRI): Because all geometries only have a single id
   // type, we have two sets of the same id type. The compiler cannot know
   // that only anchored geometries go into the anchored set and only dynamic go
@@ -643,7 +650,8 @@ class GeometryState {
   // id type in both sets.
   void CollectIds(const GeometrySet& geometry_set,
                   std::unordered_set<GeometryId>* dynamic,
-                  std::unordered_set<GeometryId>* anchored);
+                  std::unordered_set<GeometryId>* anchored,
+                  const std::optional<Role>& role) const;
 
   // Sets the kinematic poses for the frames indicated by the given ids.
   // @param poses The frame id and pose values.

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -121,6 +121,28 @@ class SceneGraphInspector {
     return state_->GetAllGeometryIds();
   }
 
+  /** Returns the geometry ids that are *implied* by the given GeometrySet and
+   `role`. Remember that a GeometrySet can reference a FrameId in place of the
+   ids of the individual geometries affixed to it. If a `role` is provided, only
+   geometries with that role assigned will be returned, otherwise all geometries
+   will be returned.
+
+   @note Specifying `role` *can* have the effect of filtering geometries *from*
+   the given geometry_set` -- if a GeometryId is an explicit member of the
+   geometry set but does not have the requested role, it will not be contained
+   in the output.
+
+   @param geometry_set    The encoding of the set of geometries.
+   @param role            The requested role; if omitted, all geometries
+                          registered to the frame are returned.
+   @returns The requested unique geometry ids.  */
+  std::unordered_set<GeometryId> GetGeometryIds(
+      const GeometrySet& geometry_set,
+      const std::optional<Role>& role = std::nullopt) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->GetGeometryIds(geometry_set, role);
+  }
+
   /** Reports the _total_ number of geometries in the scene graph with the
    indicated role.  */
   int NumGeometriesWithRole(Role role) const {

--- a/geometry/test/scene_graph_inspector_test.cc
+++ b/geometry/test/scene_graph_inspector_test.cc
@@ -47,6 +47,7 @@ GTEST_TEST(SceneGraphInspector, ExerciseEverything) {
   inspector.all_frame_ids();
   inspector.num_geometries();
   inspector.GetAllGeometryIds();
+  inspector.GetGeometryIds(GeometrySet{});
   inspector.NumGeometriesWithRole(Role::kUnassigned);
   inspector.NumDynamicGeometries();
   inspector.NumAnchoredGeometries();


### PR DESCRIPTION
The ability to convert also includes the ability to filter based on role. This includes the public-facing inspector API as well as the GeometryState implementation.

closes #13493

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14871)
<!-- Reviewable:end -->
