### PR TITLE
[geometry] Deprecate the "is grad unique" flag from query results

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -796,7 +796,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
     auto cls = DefineTemplateClassWithDefault<Class>(
         m, "SignedDistanceToPoint", param, doc.SignedDistanceToPoint.doc);
     cls  // BR
-        .def(ParamInit<Class>(), doc.SignedDistanceToPoint.ctor.doc)
+        .def(ParamInit<Class>(), doc.SignedDistanceToPoint.ctor.doc_4args)
         .def_readwrite("id_G", &SignedDistanceToPoint<T>::id_G,
             doc.SignedDistanceToPoint.id_G.doc)
         .def_readwrite("p_GN", &SignedDistanceToPoint<T>::p_GN,

--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -769,7 +769,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
     auto cls = DefineTemplateClassWithDefault<Class>(
         m, "SignedDistancePair", param, doc.SignedDistancePair.doc);
     cls  // BR
-        .def(ParamInit<Class>(), doc.SignedDistancePair.ctor.doc_7args)
+        .def(ParamInit<Class>(), doc.SignedDistancePair.ctor.doc_6args)
         .def_readwrite("id_A", &SignedDistancePair<T>::id_A,
             doc.SignedDistancePair.id_A.doc)
         .def_readwrite("id_B", &SignedDistancePair<T>::id_B,
@@ -784,10 +784,22 @@ void DoScalarDependentDefinitions(py::module m, T) {
             doc.SignedDistancePair.distance.doc)
         .def_readwrite("nhat_BA_W", &SignedDistancePair<T>::nhat_BA_W,
             return_value_policy_for_scalar_type<T>(),
-            doc.SignedDistancePair.nhat_BA_W.doc)
-        .def_readwrite("is_nhat_BA_W_unique",
-            &SignedDistancePair<T>::is_nhat_BA_W_unique,
-            doc.SignedDistancePair.is_nhat_BA_W_unique.doc);
+            doc.SignedDistancePair.nhat_BA_W.doc);
+
+    constexpr char deprecated_unique_flag_doc[] =
+        "SignedDistancePair will no longer report uniqueness. If you require "
+        "knowledge of uniqueness, please contact the Drake team. This will be "
+        "removed on or after 2021-08-01.";
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls.def_property(
+        "is_nhat_BA_W_unique",
+        [](const Class* self) { return self->is_nhat_BA_W_unique; },
+        [](Class* self, int value) { self->is_nhat_BA_W_unique = value; },
+        deprecated_unique_flag_doc);
+#pragma GCC diagnostic pop
+
+    DeprecateAttribute(cls, "is_nhat_BA_W_unique", deprecated_unique_flag_doc);
   }
 
   // SignedDistanceToPoint

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -819,3 +819,21 @@ class TestGeometry(unittest.TestCase):
         self.assertEqual(current_engine.label_count, 1)
 
         # TODO(eric, duy): Test more properties.
+
+    def test_deprecated_struct_member(self):
+        """Tests successful deprecation of struct member"""
+        with catch_drake_warnings(expected_count=1):
+            # Initializing by referencing the deprecated field warns.
+            data = mut.SignedDistancePair(is_nhat_BA_W_unique=False)
+
+        data = mut.SignedDistancePair()
+        with catch_drake_warnings(expected_count=2):
+            # Setting the deprecated field warns.
+            data.is_nhat_BA_W_unique = False
+            _ = data.is_nhat_BA_W_unique
+
+        # Specifying all other members in constructor is fine.
+        data = mut.SignedDistancePair(id_A=mut.GeometryId.get_new_id(),
+                                      id_B=mut.GeometryId.get_new_id(),
+                                      p_ACa=[0, 0, 1], p_BCb=[1, 0, 0],
+                                      distance=13, nhat_BA_W=[0, 1, 0])

--- a/geometry/proximity/distance_to_shape_callback.cc
+++ b/geometry/proximity/distance_to_shape_callback.cc
@@ -55,7 +55,10 @@ void DistancePairGeometry<T>::SphereShapeDistance(const fcl::Sphered& sphere_A,
   // p_BCb is the witness point on ∂B measured and expressed in B.
   result_->p_BCb = shape_B_to_point_Ao.p_GN;
   result_->nhat_BA_W = shape_B_to_point_Ao.grad_W;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   result_->is_nhat_BA_W_unique = shape_B_to_point_Ao.is_grad_W_unique;
+#pragma GCC diagnostic pop
   // p_ACa is the witness point on ∂A measured and expressed in A.
   const math::RotationMatrix<T> R_AW = X_WA_.rotation().transpose();
   result_->p_ACa = -sphere_A.radius * (R_AW * shape_B_to_point_Ao.grad_W);

--- a/geometry/proximity/distance_to_shape_callback.cc
+++ b/geometry/proximity/distance_to_shape_callback.cc
@@ -96,10 +96,16 @@ void CalcDistanceFallback<double>(const fcl::CollisionObjectd& a,
   //  is_nhat_BA_W_unique to true.
   if (std::abs(result.min_distance) < kEps) {
     pair_data->nhat_BA_W = Eigen::Vector3d(kNan, kNan, kNan);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     pair_data->is_nhat_BA_W_unique = false;
+#pragma GCC diagnostic pop
   } else {
     pair_data->nhat_BA_W = (p_WCa - p_WCb) / result.min_distance;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     pair_data->is_nhat_BA_W_unique = true;
+#pragma GCC diagnostic pop
   }
 }
 

--- a/geometry/proximity/test/distance_sphere_to_shape_test.cc
+++ b/geometry/proximity/test/distance_sphere_to_shape_test.cc
@@ -467,6 +467,8 @@ GTEST_TEST(ComputeNarrowPhaseDistance, sphere_touches_shape) {
   EXPECT_EQ(Vector3d(1, 0, 0), result.nhat_BA_W);
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 // Confirms that `is_nhat_BA_W_unique` is passed from point_distance to
 // shape_distance correctly. It is a pass through from DistanceToPoint() to
 // SphereShapeDistance(). We use Sphere-Box as a representative sample and
@@ -504,6 +506,7 @@ GTEST_TEST(ComputeNarrowPhaseDistance, is_nhat_BA_W_well_defined) {
     EXPECT_EQ(false, result.is_nhat_BA_W_unique);
   }
 }
+#pragma GCC diagnostic pop
 
 template <typename T>
 class CallbackScalarSupport : public ::testing::Test {

--- a/geometry/proximity/test/distance_to_point_callback_test.cc
+++ b/geometry/proximity/test/distance_to_point_callback_test.cc
@@ -81,7 +81,10 @@ class PointShapeAutoDiffSignedDistanceTester {
         GeometryId::get_new_id(), X_WG_.cast<AutoDiffXd>(), p_WQ_ad);
 
     SignedDistanceToPoint<AutoDiffXd> result = distance_to_point(shape_);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     EXPECT_EQ(result.is_grad_W_unique, is_grad_W_unique);
+#pragma GCC diagnostic pop
     if (std::abs(result.distance.value() - expected_distance) > tolerance_) {
       error = true;
       failure << "The difference between expected distance and tested distance "
@@ -145,7 +148,9 @@ class PointShapeAutoDiffSignedDistanceTester {
               << p_WQ_val_compare.message();
     }
 
-    if (result.is_grad_W_unique) {
+    // We'll only test the derivatives of the gradient if we expect it to be
+    // unique.
+    if (is_grad_W_unique) {
       auto p_WQ_derivative_compare = CompareMatrices(
           math::autoDiffToGradientMatrix(p_WQ_ad),
           math::autoDiffToGradientMatrix(p_WQ_ad_expected), tolerance_);

--- a/geometry/query_results/signed_distance_pair.h
+++ b/geometry/query_results/signed_distance_pair.h
@@ -3,6 +3,7 @@
 #include <utility>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/geometry_ids.h"
 
@@ -30,9 +31,55 @@ namespace geometry {
  */
 template <typename T>
 struct SignedDistancePair{
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SignedDistancePair)
+  // 2021-08-01 deprecation note: While deprecating the is_grad_W_unique, we
+  // cannot use the standard Drake mechanism for declaring copy and move
+  // semantics. The default implementations insist on writing to the deprecated
+  // member and the macro rebels against being enclosed in the
+  // deprecation-suppressing pragma. Once deprecation is complete restore the
+  // standard boilerplate:
+  //
+  //  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SignedDistancePair)
+  //  SignedDistancePair() = default;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  SignedDistancePair() = default;
+  /** @name Implements CopyConstructible, CopyAssignable, MoveConstructible,
+   MoveAssignable */
+  //@{
+  SignedDistancePair(const SignedDistancePair& other) = default;
+  SignedDistancePair(SignedDistancePair&& other) = default;
+  SignedDistancePair& operator=(const SignedDistancePair& other) =
+      default;
+  SignedDistancePair& operator=(SignedDistancePair&& other) =
+      default;
+  //@}
+#pragma GCC diagnostic pop
 
-  SignedDistancePair() {}
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+/* 2021-08-01 deprecation note: This constructor is wrapped in a deprecation
+ silencer because gcc will implicitly try to write to the deprecated member and
+ throw a build error. When the deprecated member is removed, we *keep* this
+ constructor, but lose the pragma manipulations (in contrast to the other
+ constructors which will just be deleted as noted). */
+  /** Constructor
+   @param a             The id of the first geometry (A).
+   @param b             The id of the second geometry (B).
+   @param p_ACa_in      The witness point on geometry A's surface, in A's frame.
+   @param p_BCb_in      The witness point on geometry B's surface, in B's frame.
+   @param dist          The signed distance between p_A and p_B.
+   @param nhat_BA_W_in  A direction of fastest increasing distance.
+   @pre nhat_BA_W_in is unit-length. */
+  SignedDistancePair(GeometryId a, GeometryId b, const Vector3<T>& p_ACa_in,
+                     const Vector3<T>& p_BCb_in, const T& dist,
+                     const Vector3<T>& nhat_BA_W_in)
+      : id_A(a),
+        id_B(b),
+        p_ACa(p_ACa_in),
+        p_BCb(p_BCb_in),
+        distance(dist),
+        nhat_BA_W(nhat_BA_W_in) {}
+#pragma GCC diagnostic pop
 
   /** Constructor
    @param a             The id of the first geometry (A).
@@ -43,6 +90,10 @@ struct SignedDistancePair{
    @param nhat_BA_W_in  A direction of fastest increasing distance.
    @param is_nhat_BA_W_unique_in  True if nhat_BA_W is unique.
    @pre nhat_BA_W_in is unit-length. */
+  DRAKE_DEPRECATED("2021-08-01",
+                   "SignedDistancePair will no longer report uniqueness. "
+                   "If you require knowledge of uniqueness, please contact the "
+                   "Drake team.")
   SignedDistancePair(GeometryId a, GeometryId b, const Vector3<T>& p_ACa_in,
                      const Vector3<T>& p_BCb_in, const T& dist,
                      const Vector3<T>& nhat_BA_W_in,
@@ -60,19 +111,15 @@ struct SignedDistancePair{
   //      DRAKE_DEMAND(nhat_BA_W.norm() == T(1.));
   {}
 
-  // TODO(DamrongGuoy): Remove this constructor when we have a full
-  //  implementation of computing nhat_BA_W in
-  //  ComputeSignedDistancePairwiseClosestPoints.  Right now many unit tests
-  //  need it.  The downside is that Python binder calls the doc for the
-  //  above constructor ctor.doc_7args and this one ctor.doc_5args (see
-  //  bindings/pydrake/geometry_py.cc).
   /** Constructor.
    We keep this constructor temporarily for backward compatibility.
    @param a         The id of the first geometry (A).
    @param b         The id of the second geometry (B).
    @param p_ACa_in  The witness point on geometry A's surface, in A's frame.
    @param p_BCb_in  The witness point on geometry B's surface, in B's frame.
-   @param dist      The signed distance between p_A and p_B.*/
+   @param dist      The signed distance between p_A and p_B. */
+  DRAKE_DEPRECATED("2021-08-01",
+                   "Please use default or full constructor instead.")
   SignedDistancePair(GeometryId a, GeometryId b, const Vector3<T>& p_ACa_in,
                      const Vector3<T>& p_BCb_in, const T& dist)
       : id_A(a),
@@ -112,7 +159,11 @@ struct SignedDistancePair{
   T distance{};
   /** A direction of fastest increasing distance. */
   Vector3<T> nhat_BA_W;
-  bool is_nhat_BA_W_unique;
+  DRAKE_DEPRECATED("2021-08-01",
+                   "SignedDistancePair will no longer report uniqueness. "
+                   "If you require knowledge of uniqueness, please contact the "
+                   "Drake team.")
+  bool is_nhat_BA_W_unique{false};
 };
 
 }  // namespace geometry

--- a/geometry/query_results/signed_distance_to_point.h
+++ b/geometry/query_results/signed_distance_to_point.h
@@ -3,6 +3,7 @@
 #include <cmath>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/geometry_ids.h"
 
@@ -22,9 +23,69 @@ namespace geometry {
  */
 template <typename T>
 struct SignedDistanceToPoint{
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SignedDistanceToPoint)
-
+  // 2021-08-01 deprecation note: While deprecating the is_grad_W_unique, we
+  // cannot use the standard Drake mechanism for declaring copy and move
+  // semantics. The default implementations insist on writing to the deprecated
+  // member and the macro rebels against being enclosed in the
+  // deprecation-suppressing pragma. Once deprecation is complete restore the
+  // standard boilerplate:
+  //
+  //  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SignedDistanceToPoint)
+  //  SignedDistanceToPoint() = default;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   SignedDistanceToPoint() = default;
+  /** @name Implements CopyConstructible, CopyAssignable, MoveConstructible,
+   MoveAssignable */
+  //@{
+  SignedDistanceToPoint(const SignedDistanceToPoint& other) = default;
+  SignedDistanceToPoint(SignedDistanceToPoint&& other) = default;
+  SignedDistanceToPoint& operator=(const SignedDistanceToPoint& other) =
+      default;
+  SignedDistanceToPoint& operator=(SignedDistanceToPoint&& other) =
+      default;
+  //@}
+#pragma GCC diagnostic pop
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+/* 2021-08-01 deprecation note: This constructor is wrapped in a deprecation
+ silencer because gcc will implicitly try to write to the deprecated member and
+ throw a build error. When the deprecated member is removed, we *keep* this
+ constructor, but lose the pragma manipulations (in contrast to the other
+ constructors which will just be deleted as noted). */
+  /** Constructs SignedDistanceToPoint struct from calculated results.
+   @param id_G_in     The id of the geometry G to which we measure distance from
+                      the query point Q.
+   @param p_GN_in     The position of the nearest point N on G's surface from
+                      the query point Q, expressed in G's frame.
+   @param distance_in The signed distance from the query point Q to the nearest
+                      point N on the surface of geometry G. It is positive if
+                      Q is outside G. It is negative if Q is inside G. It is
+                      zero if Q is on the boundary of G.
+   @param grad_W_in   The gradient vector of the distance function with respect
+                      to the query point Q, expressed in world frame W.
+
+   @note `grad_W` is not well defined everywhere. For example, when computing
+         the distance from a point to a sphere, and the point coincides with the
+         center of the sphere, grad_W is not well defined (as it can be computed
+         as p_GQ / |p_GQ|, but the denominator is 0). When grad_W is not
+         well defined, and we instantiate SignedDistanceToPoint<T> with T being
+         an AutoDiffScalar (like AutoDiffXd), the gradient of the query result
+         is not well defined either, so the user should use the gradient in
+         p_GN, distance and grad_W with caution.
+   @pre grad_W_in must not contain NaN.
+   */
+  SignedDistanceToPoint(GeometryId id_G_in, const Vector3<T>& p_GN_in,
+                        T distance_in, const Vector3<T>& grad_W_in)
+      : id_G(id_G_in),
+        p_GN(p_GN_in),
+        distance(distance_in),
+        grad_W(grad_W_in) {
+    using std::isnan;
+    DRAKE_ASSERT(!(isnan(grad_W(0)) || isnan(grad_W(1)) || isnan(grad_W(2))));
+  }
+#pragma GCC diagnostic pop
 
   /** Constructs SignedDistanceToPoint struct from calculated results.
    @param id_G_in     The id of the geometry G to which we measure distance from
@@ -49,6 +110,12 @@ struct SignedDistanceToPoint{
          p_GN, distance and grad_W with caution.
    @pre grad_W_in must not contain NaN.
    */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  DRAKE_DEPRECATED("2021-08-01",
+                   "SignedDistanceToPoint will no longer report uniqueness. "
+                   "If you require knowledge of uniqueness, please contact the "
+                   "Drake team.")
   SignedDistanceToPoint(GeometryId id_G_in, const Vector3<T>& p_GN_in,
                         T distance_in, const Vector3<T>& grad_W_in,
                         bool is_grad_W_unique_in)
@@ -60,6 +127,7 @@ struct SignedDistanceToPoint{
     using std::isnan;
     DRAKE_ASSERT(!(isnan(grad_W(0)) || isnan(grad_W(1)) || isnan(grad_W(2))));
   }
+#pragma GCC diagnostic pop
 
   /** The id of the geometry G to which we measure distance from the query
       point Q. */
@@ -75,10 +143,18 @@ struct SignedDistanceToPoint{
       point Q, expressed in world frame W. */
   Vector3<T> grad_W;
 
+  // TODO(SeanCurtis-TRI) When it comes time to deprecate (2021-08-01), ping the
+  //  listed author. Deprecation in this case entails more than simply removing
+  //  this field; it includes changing code in distance_to_point_callback.h,
+  //  its unit tests, and in distance_to_shape_callback.h.
   /** Whether grad_W is well defined.
    * Ref to the constructor SignedDistanceToPoint() for an explanation.
    */
-  bool is_grad_W_unique;
+  DRAKE_DEPRECATED("2021-08-01",
+                   "SignedDistanceToPoint will no longer report uniqueness. "
+                   "If you require knowledge of uniqueness, please contact the "
+                   "Drake team.")
+  bool is_grad_W_unique{false};
 };
 
 }  // namespace geometry

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -952,6 +952,18 @@ struct SignedDistanceToPointTestData {
         p_WQ(p_WQ_in),
         expected_result(expect_in) {}
 
+  static SignedDistanceToPointTestData Make(shared_ptr<Shape> shape,
+                                            const RigidTransformd& X_WG,
+                                            const Vector3d& p_WQ,
+                                            const Vector3d& p_GN,
+                                            double distance,
+                                            const Vector3d& grad_W) {
+    return SignedDistanceToPointTestData{
+        shape, X_WG, p_WQ,
+        SignedDistanceToPoint{GeometryId::get_new_id(), p_GN, distance,
+                              grad_W}};
+  }
+
   // Google Test uses this operator to report the test data in the log file
   // when a test fails.
   friend std::ostream& operator<<(std::ostream& os,
@@ -1007,25 +1019,20 @@ std::vector<SignedDistanceToPointTestData> GenDistanceTestDataSphere(
   auto sphere = make_shared<Sphere>(0.7);
   std::vector<SignedDistanceToPointTestData> test_data{
       // p_GQ = (2,3,6) is outside G at the positive distance 6.3 = 7 - 0.7.
-      {sphere, X_WG, X_WG * Vector3d{2.0, 3.0, 6.0},
-       SignedDistanceToPoint<double>(
-           GeometryId::get_new_id(), Vector3d(0.2, 0.3, 0.6), 6.3,
-           X_WG.rotation() * Vector3d(2.0, 3.0, 6.0) / 7.0,
-           true /* grad_W is well defined. */)},
+      SignedDistanceToPointTestData::Make(
+          sphere, X_WG, X_WG * Vector3d{2.0, 3.0, 6.0}, Vector3d(0.2, 0.3, 0.6),
+          6.3, X_WG.rotation() * Vector3d(2.0, 3.0, 6.0) / 7.0),
       // p_GQ = (0.1,0.15,0.3) is inside G at the negative distance -0.35.
-      {sphere, X_WG, X_WG * Vector3d{0.1, 0.15, 0.3},
-       SignedDistanceToPoint<double>(
-           GeometryId::get_new_id(), Vector3d(0.2, 0.3, 0.6), -0.35,
-           X_WG.rotation() * Vector3d(2.0, 3.0, 6.0) / 7.0,
-           true /* grad_W is well defined */)},
+      SignedDistanceToPointTestData::Make(
+          sphere, X_WG, X_WG * Vector3d{0.1, 0.15, 0.3},
+          Vector3d(0.2, 0.3, 0.6), -0.35,
+          X_WG.rotation() * Vector3d(2.0, 3.0, 6.0) / 7.0),
       // Reports an arbitrary gradient vector (as defined in the
       // QueryObject::ComputeSignedDistanceToPoint() documentation) at the
       // center of the sphere.
-      {sphere, X_WG, X_WG * Vector3d{0.0, 0.0, 0.0},
-       SignedDistanceToPoint<double>(GeometryId::get_new_id(),
-                                     Vector3d(0.7, 0., 0.), -0.7,
-                                     X_WG.rotation() * Vector3d(1.0, 0.0, 0.0),
-                                     false /* grad_W is not well defined */)}};
+      SignedDistanceToPointTestData::Make(
+          sphere, X_WG, X_WG * Vector3d{0.0, 0.0, 0.0}, Vector3d(0.7, 0., 0.),
+          -0.7, X_WG.rotation() * Vector3d(1.0, 0.0, 0.0))};
   return test_data;
 }
 
@@ -1064,8 +1071,7 @@ std::vector<SignedDistanceToPointTestData> GenDistanceTestDataOutsideBox(
     const Vector3d& grad_W = data.expected_result.grad_W;
     test_data.emplace_back(
         shape, X_WG, p_WQ,
-        SignedDistanceToPoint<double>(id, p_GN, distance, grad_W,
-                                      true /* grad_W is well defined */));
+        SignedDistanceToPoint<double>(id, p_GN, distance, grad_W));
   }
   return test_data;
 }
@@ -1123,16 +1129,9 @@ std::vector<SignedDistanceToPointTestData> GenDistanceTestDataBoxBoundary(
         const RotationMatrixd& R_WG = X_WG.rotation();
         const Vector3d grad_G = s_G.normalized();
         const Vector3d grad_W = R_WG * grad_G;
-        // grad_W is not well defined if the query point Q is on the edge or
-        // vertex of the box.
-        const int num_dim_on_boundary = static_cast<int>(sx != 0) +
-                                        static_cast<int>(sy != 0) +
-                                        static_cast<int>(sz != 0);
-        const bool is_grad_W_well_defined = num_dim_on_boundary <= 1;
         test_data.emplace_back(
             box, X_WG, p_WQ,
-            SignedDistanceToPoint<double>(id, p_GN, distance, grad_W,
-                                          is_grad_W_well_defined));
+            SignedDistanceToPoint<double>(id, p_GN, distance, grad_W));
       }
     }
   }
@@ -1192,8 +1191,7 @@ std::vector<SignedDistanceToPointTestData> GenDistTestDataInsideBoxUnique(
       const Vector3d grad_W = R_WG * grad_G;
       test_data.emplace_back(
           box, X_WG, p_WQ,
-          SignedDistanceToPoint<double>(id, p_GN, -d, grad_W,
-                                        true /* grad_W is well defined */));
+          SignedDistanceToPoint<double>(id, p_GN, -d, grad_W));
     }
   }
   return test_data;
@@ -1219,39 +1217,29 @@ std::vector<SignedDistanceToPointTestData> GenDistTestDataInsideBoxNonUnique() {
   const RigidTransformd& X_WG = RigidTransformd::Identity();
   std::vector<SignedDistanceToPointTestData> test_data{
       // Q is nearest to the face [-10,10]x[-5,5]x{5}.
-      {box, X_WG, X_WG * Vector3d{6., 1., 2.},
-       SignedDistanceToPoint<double>(GeometryId::get_new_id(),
-                                     Vector3d(6., 1., 5.), -3.,
-                                     X_WG.rotation() * Vector3d(0., 0., 1.),
-                                     true /* grad_W is well defined */)},
+      SignedDistanceToPointTestData::Make(
+          box, X_WG, X_WG * Vector3d{6., 1., 2.}, Vector3d(6., 1., 5.), -3.,
+          X_WG.rotation() * Vector3d(0., 0., 1.)),
       // Q is nearest to two faces {10}x[-5,5]x[-5,5] and [-10,10]x[-5,5]x{5}.
-      {box, X_WG, X_WG * Vector3d{6., 0., 1.},
-       SignedDistanceToPoint<double>(GeometryId::get_new_id(),
-                                     Vector3d(10., 0., 1.), -4.,
-                                     X_WG.rotation() * Vector3d(1., 0., 0.),
-                                     true /* grad_W is well defined */)},
+      SignedDistanceToPointTestData::Make(
+          box, X_WG, X_WG * Vector3d{6., 0., 1.}, Vector3d(10., 0., 1.), -4.,
+          X_WG.rotation() * Vector3d(1., 0., 0.)),
       // Q is nearest to three faces {10}x[-5,5]x[-5,5], [-10,10]x{5}x[-5,5],
       // and [-10,10]x[-5,5]x{5}.
-      {box, X_WG, X_WG * Vector3d{6., 1., 1.},
-       SignedDistanceToPoint<double>(GeometryId::get_new_id(),
-                                     Vector3d(10., 1., 1.), -4.,
-                                     X_WG.rotation() * Vector3d(1., 0., 0.),
-                                     true /* grad_W is well defined */)},
+      SignedDistanceToPointTestData::Make(
+          box, X_WG, X_WG * Vector3d{6., 1., 1.}, Vector3d(10., 1., 1.), -4.,
+          X_WG.rotation() * Vector3d(1., 0., 0.)),
       // Q at the center of the box is nearest to four faces
       // [-10,10]x{5}x[-5,5], [-10,10]x{-5}x[-5,5], [-10,10]x[5,-5]x{5},
       // and [-10,10]x[5,-5]x{-5}.
-      {box, X_WG, X_WG * Vector3d{0., 0., 0.},
-       SignedDistanceToPoint<double>(GeometryId::get_new_id(),
-                                     Vector3d(0., 5., 0.), -5.,
-                                     X_WG.rotation() * Vector3d(0., 1., 0.),
-                                     true /* grad_W is well defined */)},
+      SignedDistanceToPointTestData::Make(
+          box, X_WG, X_WG * Vector3d{0., 0., 0.}, Vector3d(0., 5., 0.), -5.,
+          X_WG.rotation() * Vector3d(0., 1., 0.)),
       // Q is nearest to five faces {10}x[-5,5]x[-5,5], [-10,10]x{5}x[-5,5],
       // [-10,10]x{-5}x[-5,5], [-10,10]x[5,-5]x{5}, and [-10,10]x[5,-5]x{-5}.
-      {box, X_WG, X_WG * Vector3d{5., 0., 0.},
-       SignedDistanceToPoint<double>(GeometryId::get_new_id(),
-                                     Vector3d(10., 0., 0.), -5.,
-                                     X_WG.rotation() * Vector3d(1., 0., 0.),
-                                     true /* grad_W is well defined */)}};
+      SignedDistanceToPointTestData::Make(
+          box, X_WG, X_WG * Vector3d{5., 0., 0.}, Vector3d(10., 0., 0.), -5.,
+          X_WG.rotation() * Vector3d(1., 0., 0.))};
   return test_data;
 }
 
@@ -1263,10 +1251,9 @@ std::vector<SignedDistanceToPointTestData> GenDistanceTestDataTranslateBox() {
       // The position of the query point p_WQ(23,20,30) is closest to G at
       // (20,20,30) in World frame, which is p_GN=(10,0,0) in G's frame.
       // The gradient vector is expressed in both frames as (1,0,0).
-      {box, Translation3d(10., 20., 30.), Vector3d{23., 20., 30.},
-       SignedDistanceToPoint<double>(
-           GeometryId::get_new_id(), Vector3d(10., 0., 0.), 3.,
-           Vector3d(1., 0., 0.), true /* grad_W is well defined.*/)}};
+      SignedDistanceToPointTestData::Make(
+          box, Translation3d(10., 20., 30.), Vector3d{23., 20., 30.},
+          Vector3d(10., 0., 0.), 3., Vector3d(1., 0., 0.))};
   return test_data;
 }
 
@@ -1338,8 +1325,7 @@ GenDistTestDataCylinderBoundaryCircle(
       const Vector3d grad_W = R_WG * grad_G;
       test_data.emplace_back(cylinder, X_WG, p_WQ,
                              SignedDistanceToPoint<double>(
-                                 id, p_GN, distance, grad_W,
-                                 false /* grad_W is not well defined */));
+                                 id, p_GN, distance, grad_W));
     }
   }
   return test_data;
@@ -1419,18 +1405,15 @@ GenDistTestDataCylinderBoundarySurface(
   // test_data.
   auto convert = [&cylinder, &X_WG, &R_WG,
                   &test_data](const LocalTestData& local) {
-    // Generate new id for each test record.
-    const GeometryId id = GeometryId::get_new_id();
     const Vector3d p_WQ = X_WG * local.p_GQ;
     // Q on ∂G has distance zero.
     const double distance = 0.0;
     // Q is its own nearest point on ∂G.
     const Vector3d p_GN = local.p_GQ;
     const Vector3d grad_W = R_WG * local.grad_G;
-    test_data.emplace_back(
-        cylinder, X_WG, p_WQ,
-        SignedDistanceToPoint<double>(id, p_GN, distance, grad_W,
-                                      true /* grad_W is well defined */));
+    // Implicitly generate a new geometry id for every test record.
+    test_data.push_back(SignedDistanceToPointTestData::Make(
+        cylinder, X_WG, p_WQ, p_GN, distance, grad_W));
   };
   std::for_each(test_data_barrel.begin(), test_data_barrel.end(), convert);
   std::for_each(test_data_caps.begin(), test_data_caps.end(), convert);
@@ -1477,8 +1460,7 @@ std::vector<SignedDistanceToPointTestData> GenDistTestDataOutsideCylinder(
     const Vector3d& grad_W = data.expected_result.grad_W;
     test_data.emplace_back(
         shape, X_WG, p_WQ,
-        SignedDistanceToPoint<double>(id, p_GN, distance, grad_W,
-                                      true /* grad_W is well defined */));
+        SignedDistanceToPoint<double>(id, p_GN, distance, grad_W));
   }
   return test_data;
 }
@@ -1510,8 +1492,7 @@ std::vector<SignedDistanceToPointTestData> GenDistTestDataInsideCylinder(
     const Vector3d& grad_W = data.expected_result.grad_W;
     test_data.emplace_back(
         shape, X_WG, p_WQ,
-        SignedDistanceToPoint<double>(id, p_GN, kNegativeDistance, grad_W,
-                                      true /* grad_W is well defined */));
+        SignedDistanceToPoint<double>(id, p_GN, kNegativeDistance, grad_W));
   }
   return test_data;
 }
@@ -1536,8 +1517,7 @@ std::vector<SignedDistanceToPointTestData> GenDistTestDataCylinderCenter(
   std::vector<SignedDistanceToPointTestData> test_data;
   test_data.emplace_back(
       long_cylinder, X_WG, p_WQ,
-      SignedDistanceToPoint<double>(id, p_GN, distance, grad_W,
-                                    true /* grad_W is well defined */));
+      SignedDistanceToPoint<double>(id, p_GN, distance, grad_W));
   return test_data;
 }
 
@@ -1566,7 +1546,6 @@ std::vector<SignedDistanceToPointTestData> GenDistTestDataHalfSpace() {
                               Vector3d{10., 11., 12.});
   auto hs = make_shared<HalfSpace>();
   const GeometryId id = GeometryId::get_new_id();
-  const bool well_defined_grad = true;
 
   for (const auto& X_WG : {RigidTransformd(), X_WG1}) {
     const auto& R_WG = X_WG.rotation();
@@ -1577,21 +1556,20 @@ std::vector<SignedDistanceToPointTestData> GenDistTestDataHalfSpace() {
     // Outside the half space.
     const double distance = 1.5;
     const Vector3d p_WQ1 = p_WN + distance * grad_W;
-    test_data.emplace_back(hs, X_WG, p_WQ1,
-                           SignedDistanceToPoint<double>(
-                               id, p_GN, distance, grad_W, well_defined_grad));
+    test_data.emplace_back(
+        hs, X_WG, p_WQ1,
+        SignedDistanceToPoint<double>(id, p_GN, distance, grad_W));
 
     // On the half space boundary.
     const Vector3d p_WQ2 = p_WN;
-    test_data.emplace_back(hs, X_WG, p_WQ2,
-                           SignedDistanceToPoint<double>(id, p_GN, 0.0, grad_W,
-                                                         well_defined_grad));
+    test_data.emplace_back(
+        hs, X_WG, p_WQ2, SignedDistanceToPoint<double>(id, p_GN, 0.0, grad_W));
 
     // Inside the half space.
     const Vector3d p_WQ3 = p_WN - distance * grad_W;
-    test_data.emplace_back(hs, X_WG, p_WQ3,
-                           SignedDistanceToPoint<double>(
-                               id, p_GN, -distance, grad_W, well_defined_grad));
+    test_data.emplace_back(
+        hs, X_WG, p_WQ3,
+        SignedDistanceToPoint<double>(id, p_GN, -distance, grad_W));
   }
 
   return test_data;


### PR DESCRIPTION
The signed distance to point and signed distance pair query results had a flag indicating whether the returned gradient value was unique or not. While motivated by the best of intentions, it is not used and not correctly implemented (as extensively documented in #14781). The agreed-upon resolution is to simply deprecate that field.

This deprecates the fields in the two structs (and handles the downstream ramifcations).

It is authored as *two* commits -- one for each query result type, to afford the reviewer some convenience in mentally separating the two tasks. The idea is that there is value in keeping all the deprecations in the same PR (as they have enough in common to share mental context), but keep the two slices separate to provide locality). The commits will be treated as curated upon completion.

Closes #14781.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14875)
<!-- Reviewable:end -->
