### PR TITLE
Deprecate robotlocomotion_lcmtypes and bot2_core_lcmtypes

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -509,7 +509,7 @@ drake_py_unittest(
     name = "lcm_test",
     deps = [
         ":lcm_py",
-        "@lcmtypes_robotlocomotion//:lcmtypes_robotlocomotion_py",
+        "//lcmtypes:lcmtypes_drake_py",
     ],
 )
 

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -214,6 +214,9 @@ drake_pybind_library(
     cc_deps = [
         ":lcm_pybind",
         "//bindings/pydrake:documentation_pybind",
+        "//lcmtypes:contact_results_for_viz",
+        "//lcmtypes:image_array",
+        "//lcmtypes:quaternion",
     ],
     cc_srcs = [
         "lcm_py.cc",
@@ -226,7 +229,6 @@ drake_pybind_library(
         ":module_py",
         "//bindings/pydrake:lcm_py",
         "//lcmtypes:lcmtypes_drake_py",
-        "@lcmtypes_robotlocomotion//:lcmtypes_robotlocomotion_py",
     ],
     py_srcs = ["_lcm_extra.py"],
 )

--- a/bindings/pydrake/systems/lcm_py_bind_cpp_serializers.cc
+++ b/bindings/pydrake/systems/lcm_py_bind_cpp_serializers.cc
@@ -1,10 +1,9 @@
 #include "drake/bindings/pydrake/systems/lcm_py_bind_cpp_serializers.h"
 
-#include "robotlocomotion/image_array_t.hpp"
-#include "robotlocomotion/quaternion_t.hpp"
-
 #include "drake/bindings/pydrake/systems/lcm_pybind.h"
 #include "drake/lcmt_contact_results_for_viz.hpp"
+#include "drake/lcmt_image_array.hpp"
+#include "drake/lcmt_quaternion.hpp"
 
 namespace drake {
 namespace pydrake {
@@ -13,10 +12,10 @@ namespace pylcm {
 
 void BindCppSerializers() {
   // N.B. At least one type should be bound to ensure the template is defined.
-  // N.B. These should be placed in the same order has the headers.
-  BindCppSerializer<robotlocomotion::image_array_t>("robotlocomotion");
-  BindCppSerializer<robotlocomotion::quaternion_t>("robotlocomotion");
+  // N.B. These should be placed in the same order as the headers.
   BindCppSerializer<drake::lcmt_contact_results_for_viz>("drake");
+  BindCppSerializer<drake::lcmt_image_array>("drake");
+  BindCppSerializer<drake::lcmt_quaternion>("drake");
 }
 
 }  // namespace pylcm

--- a/bindings/pydrake/test/lcm_test.py
+++ b/bindings/pydrake/test/lcm_test.py
@@ -2,14 +2,14 @@ import unittest
 
 from pydrake.lcm import DrakeLcm, DrakeLcmInterface, DrakeMockLcm, Subscriber
 
-from robotlocomotion import quaternion_t
+from drake import lcmt_quaternion
 
 
 class TestLcm(unittest.TestCase):
     def setUp(self):
         # Create a simple ground-truth message.
         self.wxyz = (1, 2, 3, 4)
-        quat = quaternion_t()
+        quat = lcmt_quaternion()
         quat.w, quat.x, quat.y, quat.z = self.wxyz
         self.quat = quat
         self.count = 0
@@ -22,7 +22,7 @@ class TestLcm(unittest.TestCase):
         dut.HandleSubscriptions
 
     def _handler(self, raw):
-        quat = quaternion_t.decode(raw)
+        quat = lcmt_quaternion.decode(raw)
         self.assertTupleEqual((quat.w, quat.x, quat.y, quat.z), self.wxyz)
         self.count += 1
 
@@ -37,7 +37,7 @@ class TestLcm(unittest.TestCase):
 
     def test_subscriber(self):
         lcm = DrakeLcm()
-        dut = Subscriber(lcm=lcm, channel="CHANNEL", lcm_type=quaternion_t)
+        dut = Subscriber(lcm=lcm, channel="CHANNEL", lcm_type=lcmt_quaternion)
         lcm.Publish(channel="CHANNEL", buffer=self.quat.encode())
         self.assertEqual(dut.count, 0)
         self.assertEqual(len(dut.raw), 0)

--- a/examples/manipulation_station/end_effector_teleop_sliders.py
+++ b/examples/manipulation_station/end_effector_teleop_sliders.py
@@ -37,7 +37,7 @@ from pydrake.systems.planar_scenegraph_visualizer import \
 
 from drake.examples.manipulation_station.differential_ik import DifferentialIK
 
-from robotlocomotion import image_array_t
+from drake import lcmt_image_array
 
 
 # TODO(russt): Generalize this and move it to pydrake.manipulation.simple_ui.
@@ -287,7 +287,7 @@ def main():
             image_array_lcm_publisher = builder.AddSystem(
                 LcmPublisherSystem.Make(
                     channel="DRAKE_RGBD_CAMERA_IMAGES",
-                    lcm_type=image_array_t,
+                    lcm_type=lcmt_image_array,
                     lcm=None,
                     publish_period=0.1,
                     use_cpp_serializer=True))

--- a/examples/manipulation_station/manipulation_station_hardware_interface.cc
+++ b/examples/manipulation_station/manipulation_station_hardware_interface.cc
@@ -2,12 +2,11 @@
 
 #include <utility>
 
-#include "robotlocomotion/image_array_t.hpp"
-
 #include "drake/common/find_resource.h"
 #include "drake/lcm/drake_lcm.h"
 #include "drake/lcmt_iiwa_command.hpp"
 #include "drake/lcmt_iiwa_status.hpp"
+#include "drake/lcmt_image_array.hpp"
 #include "drake/lcmt_schunk_wsg_command.hpp"
 #include "drake/lcmt_schunk_wsg_status.hpp"
 #include "drake/manipulation/kuka_iiwa/iiwa_command_sender.h"
@@ -29,7 +28,6 @@ using Eigen::Isometry3d;
 using Eigen::Vector3d;
 using multibody::MultibodyPlant;
 using multibody::Parser;
-using robotlocomotion::image_array_t;
 
 // TODO(russt): Consider taking DrakeLcmInterface as an argument instead of
 // (only) constructing one internally.
@@ -111,7 +109,7 @@ ManipulationStationHardwareInterface::ManipulationStationHardwareInterface(
 
   for (const std::string& name : camera_names_) {
     auto camera_subscriber = builder.AddSystem(
-        systems::lcm::LcmSubscriberSystem::Make<image_array_t>(
+        systems::lcm::LcmSubscriberSystem::Make<lcmt_image_array>(
             "DRAKE_RGBD_CAMERA_IMAGES_" + name, lcm));
     auto array_to_images =
         builder.AddSystem<systems::sensors::LcmImageArrayToImages>();

--- a/examples/manipulation_station/proof_of_life.cc
+++ b/examples/manipulation_station/proof_of_life.cc
@@ -84,7 +84,7 @@ int do_main(int argc, char* argv[]) {
                     cam_port);
   }
   auto image_array_lcm_publisher = builder.template AddSystem(
-      systems::lcm::LcmPublisherSystem::Make<robotlocomotion::image_array_t>(
+      systems::lcm::LcmPublisherSystem::Make<lcmt_image_array>(
           "DRAKE_RGBD_CAMERA_IMAGES", nullptr,
           1.0 / 10 /* 10 fps publish period */));
   image_array_lcm_publisher->set_name("rgbd_publisher");

--- a/examples/planar_gripper/BUILD.bazel
+++ b/examples/planar_gripper/BUILD.bazel
@@ -22,7 +22,6 @@ drake_cc_library(
         "//common:find_resource",
         "//multibody/plant",
         "//systems/lcm:lcm_interface_system",
-        "@lcmtypes_robotlocomotion",
     ],
 )
 

--- a/examples/scene_graph/bouncing_ball_run_dynamics.cc
+++ b/examples/scene_graph/bouncing_ball_run_dynamics.cc
@@ -146,7 +146,7 @@ int do_main() {
     if ((FLAGS_color || FLAGS_depth || FLAGS_label)) {
       image_array_lcm_publisher =
           builder.template AddSystem(systems::lcm::LcmPublisherSystem::Make<
-              robotlocomotion::image_array_t>(
+              lcmt_image_array>(
               "DRAKE_RGBD_CAMERA_IMAGES", &lcm,
               1. / FLAGS_render_fps /* publish period */));
       image_array_lcm_publisher->set_name("publisher");

--- a/lcmtypes/BUILD.bazel
+++ b/lcmtypes/BUILD.bazel
@@ -249,7 +249,6 @@ drake_py_library(
     srcs = ["__init__.py"],
     deps = [
         ":_generated_lcmtypes_drake_py",
-        "@lcmtypes_bot2_core//:lcmtypes_bot2_core_py",
     ],
 )
 
@@ -257,7 +256,6 @@ drake_lcm_java_library(
     name = "lcmtypes_drake_java",
     lcm_package = "drake",
     lcm_srcs = glob(["*.lcm"]),
-    deps = ["@lcmtypes_bot2_core//:lcmtypes_bot2_core_java"],
 )
 
 # This should list every LCM type that is known to Drake.
@@ -294,8 +292,6 @@ drake_java_binary(
     visibility = ["//visibility:private"],
     runtime_deps = [
         ":lcmtypes_drake_java",
-        "@lcmtypes_bot2_core//:lcmtypes_bot2_core_java",
-        "@lcmtypes_robotlocomotion//:lcmtypes_robotlocomotion_java",
         "@optitrack_driver//lcmtypes:lcmtypes_optitrack",
     ],
 )
@@ -342,7 +338,9 @@ install(
         ":install_drake_cc_headers",
         "//tools/workspace/optitrack_driver:install",
         "@lcm//:install",
+        # N.B. The lcmtypes_bot2_core is deprecated and will be removed.
         "@lcmtypes_bot2_core//:install",
+        # N.B. The lcmtypes_robotlocomotion is deprecated and will be removed.
         "@lcmtypes_robotlocomotion//:install",
     ],
 )

--- a/manipulation/planner/BUILD.bazel
+++ b/manipulation/planner/BUILD.bazel
@@ -120,7 +120,6 @@ drake_cc_googletest(
         ":robot_plan_interpolator",
         "//common:find_resource",
         "//systems/framework",
-        "@lcmtypes_robotlocomotion",
     ],
 )
 

--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -37,6 +37,7 @@ drake_cc_package_library(
         ":lcm_image_traits",
         ":optitrack_sender",
         ":rgbd_sensor",
+        ":robotlocomotion_compat",
         ":rotary_encoders",
         ":vtk_util",
     ],
@@ -114,6 +115,21 @@ drake_cc_library(
     ],
 )
 
+# TODO(jwnimmer-tri) This header assists with the deprecation of the
+# @lcmtypes_robotlocomotion repository; remove it on or after 2021-08-01.
+drake_cc_library(
+    name = "robotlocomotion_compat",
+    hdrs = ["robotlocomotion_compat.h"],
+    deps = [
+        "//common:essential",
+        "//lcmtypes:header",
+        "//lcmtypes:image",
+        "//lcmtypes:image_array",
+        "//lcmtypes:point",
+        "//lcmtypes:quaternion",
+    ],
+)
+
 drake_cc_library(
     name = "lcm_image_traits",
     srcs = [
@@ -124,7 +140,8 @@ drake_cc_library(
     ],
     deps = [
         ":image",
-        "@lcmtypes_robotlocomotion",
+        ":robotlocomotion_compat",
+        "//lcmtypes:image",
     ],
 )
 
@@ -138,7 +155,9 @@ drake_cc_library(
     ],
     deps = [
         ":lcm_image_traits",
+        ":robotlocomotion_compat",
         "//common:essential",
+        "//lcmtypes:image_array",
         "//systems/framework",
         "@zlib",
     ],
@@ -155,8 +174,8 @@ drake_cc_library(
     deps = [
         ":lcm_image_traits",
         "//common:essential",
+        "//lcmtypes:image_array",
         "//systems/framework",
-        "@lcmtypes_robotlocomotion",
         "@libpng",
         "@vtk//:vtkIOImage",
         "@zlib",
@@ -372,6 +391,19 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "lcm_image_array_to_images_test",
+    data = glob([
+        "test/*.jpg",
+        "test/*.png",
+    ]),
+    deps = [
+        ":lcm_image_array_to_images",
+        "//common:find_resource",
+    ],
+)
+
+drake_cc_googletest(
+    name = "lcm_image_array_to_images_deprecated_test",
+    copts = ["-Wno-deprecated-declarations"],
     data = glob([
         "test/*.jpg",
         "test/*.png",

--- a/systems/sensors/image_to_lcm_image_array_t.h
+++ b/systems/sensors/image_to_lcm_image_array_t.h
@@ -3,25 +3,28 @@
 #include <string>
 #include <vector>
 
-#include "robotlocomotion/image_array_t.hpp"
-
 #include "drake/common/drake_copyable.h"
+#include "drake/lcmt_image_array.hpp"
 #include "drake/systems/framework/leaf_system.h"
 #include "drake/systems/sensors/image.h"
 #include "drake/systems/sensors/pixel_types.h"
+#include "drake/systems/sensors/robotlocomotion_compat.h"
 
 namespace drake {
 namespace systems {
 namespace sensors {
 
+// TODO(jwnimmer-tri) Throughout this filename, classname, and method names, the
+// the "_t" or "T" suffix is superfluous and should be removed.
+
 /// An ImageToLcmImageArrayT takes as input an ImageRgba8U, ImageDepth32F and
 /// ImageLabel16I. This system outputs an AbstractValue containing a
-/// `Value<robotlocomotion::image_array_t>` LCM message that defines an array
-/// of images (image_t). This message can then be sent to other processes that
+/// `Value<lcmt_image_array>` LCM message that defines an array of images
+/// (lcmt_image). This message can then be sent to other processes that
 /// sbscribe it using LcmPublisherSystem. Note that you should NOT assume any
-/// particular order of those images stored in robotlocomotion::image_array_t,
+/// particular order of those images stored in lcmt_image_array,
 /// instead check the semantic of those images with
-/// robotlocomotion::image_t::pixel_format before using them.
+/// lcmt_image::pixel_format before using them.
 class ImageToLcmImageArrayT : public systems::LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ImageToLcmImageArrayT)
@@ -52,7 +55,7 @@ class ImageToLcmImageArrayT : public systems::LeafSystem<double> {
   const InputPort<double>& label_image_input_port() const;
 
   /// Returns the abstract valued output port that contains a
-  /// `Value<robotlocomotion::image_array_t>`.
+  /// `Value<lcmt_image_array>`.
   const OutputPort<double>& image_array_t_msg_output_port() const;
 
   /// Default constructor doesn't declare any ports.  Use the Add*Input()
@@ -68,7 +71,7 @@ class ImageToLcmImageArrayT : public systems::LeafSystem<double> {
 
  private:
   void CalcImageArray(const systems::Context<double>& context,
-                      robotlocomotion::image_array_t* msg) const;
+                      lcmt_image_array* msg) const;
 
   int color_image_input_port_index_{-1};
   int depth_image_input_port_index_{-1};

--- a/systems/sensors/lcm_image_array_receive_example.cc
+++ b/systems/sensors/lcm_image_array_receive_example.cc
@@ -1,12 +1,12 @@
 /// @file This program is an example of using the LcmImageArrayToImages and
 /// ImageToLcmImageArrayT systems.  It receives an incoming stream of
-/// robotlocomotion::image_array_t messages, unpacks and repacks the color and
+/// lcmt_image_array messages, unpacks and repacks the color and
 /// depth frames, and retransmits the images.  The output can be viewed in
 /// drake_visualizer.
 
-#include "robotlocomotion/image_array_t.hpp"
 #include <gflags/gflags.h>
 
+#include "drake/lcmt_image_array.hpp"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/lcm/lcm_interface_system.h"
@@ -15,8 +15,6 @@
 #include "drake/systems/sensors/image.h"
 #include "drake/systems/sensors/image_to_lcm_image_array_t.h"
 #include "drake/systems/sensors/lcm_image_array_to_images.h"
-
-using robotlocomotion::image_array_t;
 
 DEFINE_string(channel_name, "DRAKE_RGBD_CAMERA_IMAGES_IN",
               "Channel name to receive images on");
@@ -34,7 +32,7 @@ int DoMain() {
 
   auto lcm = builder.AddSystem<systems::lcm::LcmInterfaceSystem>();
   auto image_sub = builder.AddSystem(
-      systems::lcm::LcmSubscriberSystem::Make<image_array_t>(
+      systems::lcm::LcmSubscriberSystem::Make<lcmt_image_array>(
           FLAGS_channel_name, lcm));
   auto array_to_images = builder.AddSystem<LcmImageArrayToImages>();
   builder.Connect(image_sub->get_output_port(),
@@ -51,7 +49,7 @@ int DoMain() {
           "depth"));
 
   auto image_array_lcm_publisher = builder.AddSystem(
-      lcm::LcmPublisherSystem::Make<robotlocomotion::image_array_t>(
+      lcm::LcmPublisherSystem::Make<lcmt_image_array>(
           FLAGS_publish_name, lcm, 0.1 /* publish period */));
   builder.Connect(
       image_to_lcm_image_array->image_array_t_msg_output_port(),

--- a/systems/sensors/lcm_image_array_to_images.h
+++ b/systems/sensors/lcm_image_array_to_images.h
@@ -5,14 +5,15 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/leaf_system.h"
 #include "drake/systems/sensors/image.h"
+#include "drake/systems/sensors/robotlocomotion_compat.h"
 
 namespace drake {
 namespace systems {
 namespace sensors {
 
 /// An LcmImageArrayToImages takes as input an AbstractValue containing a
-/// `Value<robotlocomotion::image_array_t>` LCM message that defines an array
-/// of images (image_t).  The system has output ports for one color image as
+/// `Value<lcmt_image_array>` LCM message that defines an array
+/// of images (lcmt_image).  The system has output ports for one color image as
 /// an ImageRgba8U and one depth image as ImageDepth32F (intended to be
 /// similar to the API of RgbdCamera, though without the label image port).
 class LcmImageArrayToImages : public LeafSystem<double> {
@@ -21,8 +22,10 @@ class LcmImageArrayToImages : public LeafSystem<double> {
 
   LcmImageArrayToImages();
 
+  // TODO(jwnimmer-tri) The "_t" or "T" suffix on this method name is
+  // superfluous and should be removed.
   /// Returns the abstract valued input port that expects a
-  /// `Value<robotlocomotion::image_array_t>`.
+  /// `Value<lcmt_image_array>`.
   const InputPort<double>& image_array_t_input_port() const {
     return this->get_input_port(image_array_t_input_port_index_);
   }

--- a/systems/sensors/lcm_image_traits.h
+++ b/systems/sensors/lcm_image_traits.h
@@ -2,9 +2,9 @@
 
 #include <cstdint>
 
-#include "robotlocomotion/image_t.hpp"
-
+#include "drake/lcmt_image.hpp"
 #include "drake/systems/sensors/pixel_types.h"
+#include "drake/systems/sensors/robotlocomotion_compat.h"
 
 namespace drake {
 namespace systems {
@@ -16,43 +16,43 @@ struct LcmPixelTraits;
 template <>
 struct LcmPixelTraits<PixelFormat::kRgb> {
   static constexpr uint8_t kPixelFormat =
-      robotlocomotion::image_t::PIXEL_FORMAT_RGB;
+      lcmt_image::PIXEL_FORMAT_RGB;
 };
 
 template <>
 struct LcmPixelTraits<PixelFormat::kBgr> {
   static constexpr uint8_t kPixelFormat =
-      robotlocomotion::image_t::PIXEL_FORMAT_BGR;
+      lcmt_image::PIXEL_FORMAT_BGR;
 };
 
 template <>
 struct LcmPixelTraits<PixelFormat::kRgba> {
   static constexpr uint8_t kPixelFormat =
-      robotlocomotion::image_t::PIXEL_FORMAT_RGBA;
+      lcmt_image::PIXEL_FORMAT_RGBA;
 };
 
 template <>
 struct LcmPixelTraits<PixelFormat::kBgra> {
   static constexpr uint8_t kPixelFormat =
-      robotlocomotion::image_t::PIXEL_FORMAT_BGRA;
+      lcmt_image::PIXEL_FORMAT_BGRA;
 };
 
 template <>
 struct LcmPixelTraits<PixelFormat::kGrey> {
   static constexpr uint8_t kPixelFormat =
-      robotlocomotion::image_t::PIXEL_FORMAT_GRAY;
+      lcmt_image::PIXEL_FORMAT_GRAY;
 };
 
 template <>
 struct LcmPixelTraits<PixelFormat::kDepth> {
   static constexpr uint8_t kPixelFormat =
-      robotlocomotion::image_t::PIXEL_FORMAT_DEPTH;
+      lcmt_image::PIXEL_FORMAT_DEPTH;
 };
 
 template <>
 struct LcmPixelTraits<PixelFormat::kLabel> {
   static constexpr uint8_t kPixelFormat =
-      robotlocomotion::image_t::PIXEL_FORMAT_LABEL;
+      lcmt_image::PIXEL_FORMAT_LABEL;
 };
 
 template <PixelType>
@@ -61,49 +61,49 @@ struct LcmImageTraits;
 template <>
 struct LcmImageTraits<PixelType::kRgb8U> {
   static constexpr uint8_t kChannelType =
-      robotlocomotion::image_t::CHANNEL_TYPE_UINT8;
+      lcmt_image::CHANNEL_TYPE_UINT8;
 };
 
 template <>
 struct LcmImageTraits<PixelType::kBgr8U> {
   static constexpr uint8_t kChannelType =
-      robotlocomotion::image_t::CHANNEL_TYPE_UINT8;
+      lcmt_image::CHANNEL_TYPE_UINT8;
 };
 
 template <>
 struct LcmImageTraits<PixelType::kRgba8U> {
   static constexpr uint8_t kChannelType =
-      robotlocomotion::image_t::CHANNEL_TYPE_UINT8;
+      lcmt_image::CHANNEL_TYPE_UINT8;
 };
 
 template <>
 struct LcmImageTraits<PixelType::kBgra8U> {
   static constexpr uint8_t kChannelType =
-      robotlocomotion::image_t::CHANNEL_TYPE_UINT8;
+      lcmt_image::CHANNEL_TYPE_UINT8;
 };
 
 template <>
 struct LcmImageTraits<PixelType::kGrey8U> {
   static constexpr uint8_t kChannelType =
-      robotlocomotion::image_t::CHANNEL_TYPE_UINT8;
+      lcmt_image::CHANNEL_TYPE_UINT8;
 };
 
 template <>
 struct LcmImageTraits<PixelType::kDepth16U> {
   static constexpr uint8_t kChannelType =
-      robotlocomotion::image_t::CHANNEL_TYPE_UINT16;
+      lcmt_image::CHANNEL_TYPE_UINT16;
 };
 
 template <>
 struct LcmImageTraits<PixelType::kDepth32F> {
   static constexpr uint8_t kChannelType =
-      robotlocomotion::image_t::CHANNEL_TYPE_FLOAT32;
+      lcmt_image::CHANNEL_TYPE_FLOAT32;
 };
 
 template <>
 struct LcmImageTraits<PixelType::kLabel16I> {
   static constexpr uint8_t kChannelType =
-      robotlocomotion::image_t::CHANNEL_TYPE_INT16;
+      lcmt_image::CHANNEL_TYPE_INT16;
 };
 
 }  // namespace sensors

--- a/systems/sensors/robotlocomotion_compat.h
+++ b/systems/sensors/robotlocomotion_compat.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "drake/common/drake_deprecated.h"
+#include "drake/lcmt_header.hpp"
+#include "drake/lcmt_image.hpp"
+#include "drake/lcmt_image_array.hpp"
+#include "drake/lcmt_point.hpp"
+#include "drake/lcmt_quaternion.hpp"
+
+// @file
+//
+// To ease the deprecation process for the @lcmtypes_robotlocomotion external,
+// we provide this header that calling code may temporarily #include in order
+// to alias the robotlocomotion message names to their new Drake equivalent.
+//
+// This file will be removed on 2021-08-01.
+
+namespace robotlocomotion {
+
+using header_t DRAKE_DEPRECATED("2021-08-01",
+    "The @lcmtypes_robotlocomotion repository is being removed from Drake. "
+    "Downstream projects should add it to their own WORKSPACE if needed.")
+    = drake::lcmt_header;
+
+using image_t DRAKE_DEPRECATED("2021-08-01",
+    "The @lcmtypes_robotlocomotion repository is being removed from Drake. "
+    "Downstream projects should add it to their own WORKSPACE if needed.")
+    = drake::lcmt_image;
+
+using image_array_t DRAKE_DEPRECATED("2021-08-01",
+    "The @lcmtypes_robotlocomotion repository is being removed from Drake. "
+    "Downstream projects should add it to their own WORKSPACE if needed.")
+    = drake::lcmt_image_array;
+
+using point_t DRAKE_DEPRECATED("2021-08-01",
+    "The @lcmtypes_robotlocomotion repository is being removed from Drake. "
+    "Downstream projects should add it to their own WORKSPACE if needed.")
+    = drake::lcmt_point;
+
+using quaternion_t DRAKE_DEPRECATED("2021-08-01",
+    "The @lcmtypes_robotlocomotion repository is being removed from Drake. "
+    "Downstream projects should add it to their own WORKSPACE if needed.")
+    = drake::lcmt_quaternion;
+
+}  // namespace robotlocomotion

--- a/systems/sensors/test/image_to_lcm_image_array_t_test.cc
+++ b/systems/sensors/test/image_to_lcm_image_array_t_test.cc
@@ -1,16 +1,14 @@
 #include "drake/systems/sensors/image_to_lcm_image_array_t.h"
 
-#include "robotlocomotion/image_array_t.hpp"
 #include <gtest/gtest.h>
 
+#include "drake/lcmt_image_array.hpp"
 #include "drake/systems/sensors/image.h"
 
 namespace drake {
 namespace systems {
 namespace sensors {
 namespace {
-
-using robotlocomotion::image_t;
 
 const char* kColorFrameName = "color_frame_name";
 const char* kDepthFrameName = "depth_frame_name";
@@ -20,7 +18,7 @@ const char* kLabelFrameName = "label_frame_name";
 const int kImageWidth = 8;
 const int kImageHeight = 6;
 
-robotlocomotion::image_array_t SetUpInputAndOutput(
+lcmt_image_array SetUpInputAndOutput(
     ImageToLcmImageArrayT* dut, const ImageRgba8U& color_image,
     const ImageDepth32F& depth_image, const ImageLabel16I& label_image) {
   const InputPort<double>& color_image_input_port =
@@ -36,7 +34,7 @@ robotlocomotion::image_array_t SetUpInputAndOutput(
   label_image_input_port.FixValue(context.get(), label_image);
 
   return dut->image_array_t_msg_output_port().
-      Eval<robotlocomotion::image_array_t>(*context);
+      Eval<lcmt_image_array>(*context);
 }
 
 GTEST_TEST(ImageToLcmImageArrayT, ValidTest) {
@@ -46,16 +44,16 @@ GTEST_TEST(ImageToLcmImageArrayT, ValidTest) {
 
   auto Verify = [color_image, depth_image, label_image](
                    const ImageToLcmImageArrayT& dut,
-                   const robotlocomotion::image_array_t& output_image_array,
+                   const lcmt_image_array& output_image_array,
                    uint8_t compression_method) {
-    // Verifyies image_array_t
+    // Verifyies lcmt_image_array
     EXPECT_EQ(output_image_array.header.seq, 0);
     EXPECT_EQ(output_image_array.header.utime, 0);
     EXPECT_EQ(output_image_array.header.frame_name, "");
     EXPECT_EQ(output_image_array.num_images, 3);
     EXPECT_EQ(output_image_array.images.size(), 3);
 
-    // Verifyies each image_t.
+    // Verifyies each lcmt_image.
     for (auto const& image : output_image_array.images) {
       EXPECT_EQ(image.header.seq, 0);
       EXPECT_EQ(image.header.utime, 0);
@@ -69,24 +67,24 @@ GTEST_TEST(ImageToLcmImageArrayT, ValidTest) {
       int row_stride;
       int8_t pixel_format;
       int8_t channel_type;
-      if (image.pixel_format == image_t::PIXEL_FORMAT_RGBA) {
+      if (image.pixel_format == lcmt_image::PIXEL_FORMAT_RGBA) {
         frame_name = kColorFrameName;
         row_stride = color_image.width() * color_image.kNumChannels *
             sizeof(*color_image.at(0, 0));
-        pixel_format = image_t::PIXEL_FORMAT_RGBA;
-        channel_type = image_t::CHANNEL_TYPE_UINT8;
-      } else if (image.pixel_format == image_t::PIXEL_FORMAT_DEPTH) {
+        pixel_format = lcmt_image::PIXEL_FORMAT_RGBA;
+        channel_type = lcmt_image::CHANNEL_TYPE_UINT8;
+      } else if (image.pixel_format == lcmt_image::PIXEL_FORMAT_DEPTH) {
         frame_name = kDepthFrameName;
         row_stride = depth_image.width() * depth_image.kNumChannels *
             sizeof(*depth_image.at(0, 0));
-        pixel_format = image_t::PIXEL_FORMAT_DEPTH;
-        channel_type = image_t::CHANNEL_TYPE_FLOAT32;
-      } else if (image.pixel_format == image_t::PIXEL_FORMAT_LABEL) {
+        pixel_format = lcmt_image::PIXEL_FORMAT_DEPTH;
+        channel_type = lcmt_image::CHANNEL_TYPE_FLOAT32;
+      } else if (image.pixel_format == lcmt_image::PIXEL_FORMAT_LABEL) {
         frame_name = kLabelFrameName;
         row_stride = label_image.width() * label_image.kNumChannels *
             sizeof(*label_image.at(0, 0));
-        pixel_format = image_t::PIXEL_FORMAT_LABEL;
-        channel_type = image_t::CHANNEL_TYPE_INT16;
+        pixel_format = lcmt_image::PIXEL_FORMAT_LABEL;
+        channel_type = lcmt_image::CHANNEL_TYPE_INT16;
       } else {
         EXPECT_FALSE(true);
       }
@@ -103,14 +101,14 @@ GTEST_TEST(ImageToLcmImageArrayT, ValidTest) {
   auto image_array_t_compressed = SetUpInputAndOutput(
           &dut_compressed, color_image, depth_image, label_image);
   Verify(dut_compressed, image_array_t_compressed,
-         image_t::COMPRESSION_METHOD_ZLIB);
+         lcmt_image::COMPRESSION_METHOD_ZLIB);
 
   ImageToLcmImageArrayT dut_uncompressed(
       kColorFrameName, kDepthFrameName, kLabelFrameName, false);
   auto image_array_t_uncompressed = SetUpInputAndOutput(
       &dut_uncompressed, color_image, depth_image, label_image);
   Verify(dut_uncompressed, image_array_t_uncompressed,
-         image_t::COMPRESSION_METHOD_NOT_COMPRESSED);
+         lcmt_image::COMPRESSION_METHOD_NOT_COMPRESSED);
 }
 
 }  // namespace

--- a/systems/sensors/test/lcm_image_array_to_images_deprecated_test.cc
+++ b/systems/sensors/test/lcm_image_array_to_images_deprecated_test.cc
@@ -1,20 +1,25 @@
 #include "drake/systems/sensors/lcm_image_array_to_images.h"
 
+// TODO(jwnimmer-tri) Remove this entire file as of the 2021-08-01 deprecation
+// date for the @lcmtypes_robotlocomotion external.
+
 #include <fstream>
 #include <memory>
 
 #include <gtest/gtest.h>
 
 #include "drake/common/find_resource.h"
-#include "drake/lcmt_image_array.hpp"
 #include "drake/systems/sensors/image.h"
+
+using robotlocomotion::image_array_t;
+using robotlocomotion::image_t;
 
 namespace drake {
 namespace systems {
 namespace sensors {
 namespace {
 
-void LoadImageData(const std::string& filename, lcmt_image* image) {
+void LoadImageData(const std::string& filename, image_t* image) {
   std::ifstream is(filename, std::ios::binary);
   EXPECT_TRUE(is.good());
 
@@ -31,7 +36,7 @@ void LoadImageData(const std::string& filename, lcmt_image* image) {
 }
 
 void DecodeImageArray(
-    LcmImageArrayToImages* dut, const lcmt_image_array& lcm_images,
+    LcmImageArrayToImages* dut, const image_array_t& lcm_images,
     ImageRgba8U* color_image, ImageDepth32F* depth_image) {
   std::unique_ptr<Context<double>> context = dut->CreateDefaultContext();
   dut->image_array_t_input_port().FixValue(context.get(), lcm_images);
@@ -41,7 +46,7 @@ void DecodeImageArray(
 }
 
 GTEST_TEST(LcmImageArrayToImagesTest, EmptyArrayTest) {
-  lcmt_image_array lcm_images{};
+  image_array_t lcm_images{};
 
   // Populate our expected images with some width/height and expect they're
   // cleared.
@@ -61,19 +66,19 @@ GTEST_TEST(LcmImageArrayToImagesTest, JpegTest) {
   // Start with a populated depth image, expect it will be cleared.
   ImageDepth32F depth_image(32, 32);
 
-  lcmt_image jpeg_image{};
+  image_t jpeg_image{};
   jpeg_image.width = 32;
   jpeg_image.height = 32;
   jpeg_image.row_stride = jpeg_image.width * 3;
   jpeg_image.bigendian = 0;
-  jpeg_image.pixel_format = lcmt_image::PIXEL_FORMAT_RGB;
-  jpeg_image.channel_type = lcmt_image::CHANNEL_TYPE_UINT8;
-  jpeg_image.compression_method = lcmt_image::COMPRESSION_METHOD_JPEG;
+  jpeg_image.pixel_format = image_t::PIXEL_FORMAT_RGB;
+  jpeg_image.channel_type = image_t::CHANNEL_TYPE_UINT8;
+  jpeg_image.compression_method = image_t::COMPRESSION_METHOD_JPEG;
   LoadImageData(
       FindResourceOrThrow("drake/systems/sensors/test/jpeg_test.jpg"),
       &jpeg_image);
 
-  lcmt_image_array lcm_images{};
+  image_array_t lcm_images{};
   lcm_images.num_images = 1;
   lcm_images.images.push_back(jpeg_image);
 
@@ -84,25 +89,25 @@ GTEST_TEST(LcmImageArrayToImagesTest, JpegTest) {
 }
 
 GTEST_TEST(LcmImageArrayToImagesTest, PngTest) {
-  lcmt_image png_image{};
+  image_t png_image{};
   png_image.width = 32;
   png_image.height = 32;
   png_image.row_stride = png_image.width * 3;
   png_image.bigendian = 0;
-  png_image.pixel_format = lcmt_image::PIXEL_FORMAT_RGB;
-  png_image.channel_type = lcmt_image::CHANNEL_TYPE_UINT8;
-  png_image.compression_method = lcmt_image::COMPRESSION_METHOD_PNG;
+  png_image.pixel_format = image_t::PIXEL_FORMAT_RGB;
+  png_image.channel_type = image_t::CHANNEL_TYPE_UINT8;
+  png_image.compression_method = image_t::COMPRESSION_METHOD_PNG;
   LoadImageData(
       FindResourceOrThrow("drake/systems/sensors/test/png_color_test.png"),
       &png_image);
 
-  lcmt_image_array lcm_images{};
+  image_array_t lcm_images{};
   lcm_images.num_images = 1;
   lcm_images.images.push_back(png_image);
 
   png_image.row_stride = png_image.width * 2;
-  png_image.pixel_format = lcmt_image::PIXEL_FORMAT_DEPTH;
-  png_image.channel_type = lcmt_image::CHANNEL_TYPE_UINT16;
+  png_image.pixel_format = image_t::PIXEL_FORMAT_DEPTH;
+  png_image.channel_type = image_t::CHANNEL_TYPE_UINT16;
   LoadImageData(
       FindResourceOrThrow("drake/systems/sensors/test/png_gray16_test.png"),
       &png_image);

--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -253,8 +253,6 @@ cc_library(
         "//lcmtypes:lcmtypes_drake_cc",
         "@eigen",
         "@fmt",
-        "@lcmtypes_bot2_core",
-        "@lcmtypes_robotlocomotion",
         "@optitrack_driver//lcmtypes:optitrack_lcmtypes",
     ],
 )

--- a/tools/install/libdrake/drake.cps
+++ b/tools/install/libdrake/drake.cps
@@ -7,10 +7,6 @@
   "Name": "drake",
   "Website": "https://drake.mit.edu/",
   "Requires": {
-    "bot2-core-lcmtypes": {
-      "Hints": ["@prefix@/lib/cmake/bot2-core-lcmtypes"],
-      "X-CMake-Find-Args": ["CONFIG"]
-    },
     "Eigen3": {
       "Version": "3.3.4",
       "X-CMake-Find-Args": ["CONFIG"]
@@ -34,10 +30,6 @@
       "Hints": ["@prefix@/lib/cmake/optitrack"],
       "X-CMake-Find-Args": ["CONFIG"]
     },
-    "robotlocomotion-lcmtypes": {
-      "Hints": ["@prefix@/lib/cmake/robotlocomotion-lcmtypes"],
-      "X-CMake-Find-Args": ["CONFIG"]
-    },
     "spdlog": {
       "Version": "1.5",
       "Hints": ["@prefix@/lib/cmake/spdlog"],
@@ -58,13 +50,11 @@
       "Requires": [
         ":drake-lcmtypes-cpp",
         ":drake-marker",
-        "bot2-core-lcmtypes:lcmtypes_bot2-core-cpp",
         "Eigen3:Eigen",
         "fmt:fmt-header-only",
         "ignition-math6:ignition-math6",
         "lcm:lcm",
         "optitrack:optitrack-lcmtypes-cpp",
-        "robotlocomotion-lcmtypes:robotlocomotion-lcmtypes-cpp",
         "spdlog:spdlog",
         "tinyxml2:tinyxml2",
         "yaml-cpp"

--- a/tools/workspace/drake_visualizer/repository.bzl
+++ b/tools/workspace/drake_visualizer/repository.bzl
@@ -92,9 +92,15 @@ py_library(
     name = "drake_visualizer_python_deps",
     deps = [
         "@lcm//:lcm-python",
+        # TODO(jwnimmer-tri): The visualizer binary should incorporate its own
+        # build of whatever LCM messages it needs -- we should not need to
+        # supply it with extra dependencies.  For now, we'll use deprecated
+        # Drake targets for these messages.  If this problem is not fixed
+        # prior to the deprecation removal date, we'll have to keep the 
+        # dependency around for a little while longer until it is fixed.
         "@lcmtypes_bot2_core//:lcmtypes_bot2_core_py",
+        "@lcmtypes_robotlocomotion//:lcmtypes_robotlocomotion_py_nondeprecated",  # noqa
         # TODO(eric.cousineau): Expose VTK Python libraries here for Linux.
-        "@lcmtypes_robotlocomotion//:lcmtypes_robotlocomotion_py",
     ],
     visibility = ["//visibility:public"],
 )

--- a/tools/workspace/lcmtypes_bot2_core/package.BUILD.bazel
+++ b/tools/workspace/lcmtypes_bot2_core/package.BUILD.bazel
@@ -12,6 +12,10 @@ load(
     "lcm_java_library",
     "lcm_py_library",
 )
+load(
+    "@rules_python//python:defs.bzl",
+    "py_library",
+)
 
 licenses([
     "none",
@@ -19,6 +23,8 @@ licenses([
 ])
 
 package(default_visibility = ["//visibility:public"])
+
+_DEPRECATION = "DRAKE DEPRECATED: The @lcmtypes_bot2_core repository is being removed from Drake on or after 2021-08-01. Downstream projects should add it to their own WORKSPACE if needed."  # noqa
 
 LCM_SRCS = glob(["lcmtypes/*.lcm"])
 
@@ -35,6 +41,13 @@ lcm_cc_library(
     lcm_package = "bot_core",
     lcm_srcs = LCM_SRCS,
     lcm_structs = LCM_STRUCTS,
+    deprecation = _DEPRECATION,
+)
+
+cc_library(
+    name = "lcmtypes_bot2_core_nondeprecated",
+    deps = ["lcmtypes_bot2_core"],
+    visibility = ["@lcmtypes_robotlocomotion//:__pkg__"],
 )
 
 lcm_java_library(
@@ -42,6 +55,7 @@ lcm_java_library(
     lcm_package = "bot_core",
     lcm_srcs = LCM_SRCS,
     lcm_structs = LCM_STRUCTS,
+    deprecation = _DEPRECATION,
 )
 
 lcm_py_library(
@@ -50,6 +64,16 @@ lcm_py_library(
     lcm_package = "bot_core",
     lcm_srcs = LCM_SRCS,
     lcm_structs = LCM_STRUCTS,
+    deprecation = _DEPRECATION,
+)
+
+py_library(
+    name = "lcmtypes_bot2_core_py_nondeprecated",
+    deps = ["lcmtypes_bot2_core_py"],
+    visibility = [
+        "@drake_visualizer//:__pkg__",
+        "@lcmtypes_robotlocomotion//:__pkg__",
+    ],
 )
 
 CMAKE_PACKAGE = "bot2-core-lcmtypes"

--- a/tools/workspace/lcmtypes_robotlocomotion/package.BUILD.bazel
+++ b/tools/workspace/lcmtypes_robotlocomotion/package.BUILD.bazel
@@ -16,6 +16,12 @@ load(
     "lcm_java_library",
     "lcm_py_library",
 )
+load(
+    "@rules_python//python:defs.bzl",
+    "py_library",
+)
+
+_DEPRECATION = "DRAKE DEPRECATED: The @lcmtypes_robotlocomotion repository is being removed from Drake on or after 2021-08-01. Downstream projects should add it to their own WORKSPACE if needed."  # noqa
 
 LCM_SRCS = glob(["lcmtypes/*.lcm"])
 
@@ -24,13 +30,15 @@ lcm_cc_library(
     includes = ["lcmtypes"],
     lcm_package = "robotlocomotion",
     lcm_srcs = LCM_SRCS,
-    deps = ["@lcmtypes_bot2_core"],
+    deprecation = _DEPRECATION,
+    deps = ["@lcmtypes_bot2_core//:lcmtypes_bot2_core_nondeprecated"],
 )
 
 lcm_java_library(
     name = "lcmtypes_robotlocomotion_java",
     lcm_package = "robotlocomotion",
     lcm_srcs = LCM_SRCS,
+    deprecation = _DEPRECATION,
     deps = ["@lcmtypes_bot2_core//:lcmtypes_bot2_core_java"],
 )
 
@@ -39,7 +47,14 @@ lcm_py_library(
     imports = ["lcmtypes"],
     lcm_package = "robotlocomotion",
     lcm_srcs = LCM_SRCS,
+    deprecation = _DEPRECATION,
     deps = ["@lcmtypes_bot2_core//:lcmtypes_bot2_core_py"],
+)
+
+py_library(
+    name = "lcmtypes_robotlocomotion_py_nondeprecated",
+    deps = ["lcmtypes_robotlocomotion_py"],
+    visibility = ["@drake_visualizer//:__pkg__"],
 )
 
 CMAKE_PACKAGE = "robotlocomotion-lcmtypes"


### PR DESCRIPTION
Port existing Drake code to use the new types.

Add helper header `drake/systems/sensors/robotlocomotion_compat.h` to alias the old names onto the new names, along with a deprecation warning.

Requires #14885 first.  Towards #14362.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14884)
<!-- Reviewable:end -->
