### PR TITLE
Add renamed copies of RobotLocomotion/lcmtypes used by Drake

### DIFF
--- a/lcmtypes/BUILD.bazel
+++ b/lcmtypes/BUILD.bazel
@@ -70,6 +70,12 @@ drake_lcm_cc_library(
 )
 
 drake_lcm_cc_library(
+    name = "header",
+    lcm_package = "drake",
+    lcm_srcs = ["lcmt_header.lcm"],
+)
+
+drake_lcm_cc_library(
     name = "hydroelastic_contact_surface_for_viz",
     lcm_package = "drake",
     lcm_srcs = ["lcmt_hydroelastic_contact_surface_for_viz.lcm"],
@@ -89,6 +95,29 @@ drake_lcm_cc_library(
     name = "hydroelastic_quadrature_per_point_data_for_viz",
     lcm_package = "drake",
     lcm_srcs = ["lcmt_hydroelastic_quadrature_per_point_data_for_viz.lcm"],
+)
+
+drake_lcm_cc_library(
+    name = "image",
+    lcm_package = "drake",
+    lcm_srcs = ["lcmt_image.lcm"],
+    deps = [":header"],
+)
+
+drake_lcm_cc_library(
+    name = "image_array",
+    lcm_package = "drake",
+    lcm_srcs = ["lcmt_image_array.lcm"],
+    deps = [
+        ":header",
+        ":image",
+    ],
+)
+
+drake_lcm_cc_library(
+    name = "point",
+    lcm_package = "drake",
+    lcm_srcs = ["lcmt_point.lcm"],
 )
 
 drake_lcm_cc_library(
@@ -116,6 +145,12 @@ drake_lcm_cc_library(
         "lcmt_planar_plant_state.lcm",
         "lcmt_force_torque.lcm",
     ],
+)
+
+drake_lcm_cc_library(
+    name = "quaternion",
+    lcm_package = "drake",
+    lcm_srcs = ["lcmt_quaternion.lcm"],
 )
 
 drake_lcm_cc_library(
@@ -230,6 +265,11 @@ LCMTYPES_CC = [
     ":acrobot",
     ":allegro",
     ":call_python",
+    ":point",
+    ":header",
+    ":quaternion",
+    ":image",
+    ":image_array",
     ":contact_results_for_viz",
     ":drake_signal",
     ":hydroelastic_contact_surface_for_viz",

--- a/lcmtypes/lcmt_header.lcm
+++ b/lcmtypes/lcmt_header.lcm
@@ -1,0 +1,13 @@
+package drake;
+
+// This holds timestamp and a particular coordinate frame.
+// This follows ROS's convention except the timestamp since
+// utime has been widely used in Drake LCM.
+struct lcmt_header {
+  // Sequence ID: consecutively increasing ID.
+  int32_t seq;
+  // Timestamp in microseconds.
+  int64_t utime;
+  // The name of a frame this data is associated with.
+  string frame_name;
+}

--- a/lcmtypes/lcmt_image.lcm
+++ b/lcmtypes/lcmt_image.lcm
@@ -1,0 +1,68 @@
+package drake;
+
+// A representation of an image.
+struct lcmt_image {
+  // The timestamp and the frame name where this image is obtained.
+  lcmt_header header;
+
+  // The image width in pixels.
+  int32_t width;
+
+  // The image height in pixels.
+  int32_t height;
+
+  // The physical memory size per a single row in bytes.
+  int32_t row_stride;
+
+  // The size of `data` in bytes.
+  int32_t size;
+
+  // The data that contains actual image.
+  byte data[size];
+
+  // The boolean to denote if the data is stored in the bigendian order.
+  boolean bigendian;
+
+  // The semantic meaning of pixels.
+  int8_t pixel_format;
+
+  // The data type for a channel.
+  int8_t channel_type;
+
+  // The compression method.
+  int8_t compression_method;
+
+  // enum for pixel_format.
+  const int8_t PIXEL_FORMAT_GRAY       = 0;
+  const int8_t PIXEL_FORMAT_RGB        = 1;
+  const int8_t PIXEL_FORMAT_BGR        = 2;
+  const int8_t PIXEL_FORMAT_RGBA       = 3;
+  const int8_t PIXEL_FORMAT_BGRA       = 4;
+  const int8_t PIXEL_FORMAT_DEPTH      = 5;
+  const int8_t PIXEL_FORMAT_LABEL      = 6;
+  const int8_t PIXEL_FORMAT_MASK       = 7;
+  const int8_t PIXEL_FORMAT_DISPARITY  = 8;
+  const int8_t PIXEL_FORMAT_BAYER_BGGR = 9;
+  const int8_t PIXEL_FORMAT_BAYER_RGGB = 10;
+  const int8_t PIXEL_FORMAT_BAYER_GBRG = 11;
+  const int8_t PIXEL_FORMAT_BAYER_GRBG = 12;
+  const int8_t PIXEL_FORMAT_INVALID    = -1;
+
+  // enum for channel_type.
+  const int8_t CHANNEL_TYPE_INT8    = 0;
+  const int8_t CHANNEL_TYPE_UINT8   = 1;
+  const int8_t CHANNEL_TYPE_INT16   = 2;
+  const int8_t CHANNEL_TYPE_UINT16  = 3;
+  const int8_t CHANNEL_TYPE_INT32   = 4;
+  const int8_t CHANNEL_TYPE_UINT32  = 5;
+  const int8_t CHANNEL_TYPE_FLOAT32 = 6;
+  const int8_t CHANNEL_TYPE_FLOAT64 = 7;
+  const int8_t CHANNEL_TYPE_INVALID = -1;
+
+  // enum for compression_method.
+  const int8_t COMPRESSION_METHOD_NOT_COMPRESSED = 0;
+  const int8_t COMPRESSION_METHOD_ZLIB           = 1;
+  const int8_t COMPRESSION_METHOD_JPEG           = 2;
+  const int8_t COMPRESSION_METHOD_PNG            = 3;
+  const int8_t COMPRESSION_METHOD_INVALID        = -1;
+}

--- a/lcmtypes/lcmt_image_array.lcm
+++ b/lcmtypes/lcmt_image_array.lcm
@@ -1,0 +1,19 @@
+package drake;
+
+// This is used for sending and/or receiving multiple images at the same time.
+struct lcmt_image_array {
+  // The timestamp and the frame name.
+  // The timestamp holds when this data is packed. It's convenient to store
+  // the latest timestamp among the timestamps in `images` since it is possible
+  // for each of `images` having different timestamps if their camera's shutters
+  // are not synchronized.
+  // The `frame_name` can be empty if each image_t in `images` contains the
+  // information in it.
+  lcmt_header header;
+
+  // The number of images.
+  int32_t num_images;
+
+  // An array of image_t.
+  lcmt_image images[num_images];
+}

--- a/lcmtypes/lcmt_point.lcm
+++ b/lcmtypes/lcmt_point.lcm
@@ -1,0 +1,8 @@
+package drake;
+
+// A representation of a 3D point.
+struct lcmt_point {
+  double x;
+  double y;
+  double z;
+}

--- a/lcmtypes/lcmt_quaternion.lcm
+++ b/lcmtypes/lcmt_quaternion.lcm
@@ -1,0 +1,9 @@
+package drake;
+
+// A representation of an orientation in quaternion.
+struct lcmt_quaternion {
+  double w;
+  double x;
+  double y;
+  double z;
+}


### PR DESCRIPTION
These are copied from https://github.com/RobotLocomotion/lcmtypes/tree/821ff4b, with edits to change the package and message names to match Drake conventions.

This is in preparation for #14884 towards #14362.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14885)
<!-- Reviewable:end -->
