### PR TITLE
doc: Remove manual tag from documentation binaries

### DIFF
--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -9,7 +9,6 @@ load(
 )
 load(
     ":defs.bzl",
-    "DEFAULT_BINARY_TAGS",
     "DEFAULT_TEST_TAGS",
     "enumerate_filegroup",
 )
@@ -112,14 +111,16 @@ drake_py_binary(
         "//doc/pydrake:gen_sphinx",
         "//doc/styleguide:build",
     ],
-    tags = DEFAULT_BINARY_TAGS,
     deps = [
         "@bazel_tools//tools/python/runfiles",
     ],
 )
 
 # This rule is used by our CI scripts as a single point of entry to ensure that
-# all of our manually-tagged documentation binaries can be built successfully.
+# all of our documentation binaries can be built successfully.  The "manual" in
+# its name is a bit of a misnomer (these all used to be tagged as manual, but
+# we no longer need to exclude them from the build); all of these binaries are
+# part of the default `bazel build //...`.
 filegroup(
     name = "manual_binaries",
     srcs = [
@@ -130,7 +131,6 @@ filegroup(
         "//doc/pydrake:serve_sphinx",
         "//doc/styleguide:build",
     ],
-    tags = ["manual"],
 )
 
 # This rule is used by our CI scripts as a single point of entry to ensure that

--- a/doc/defs.bzl
+++ b/doc/defs.bzl
@@ -5,14 +5,6 @@
 # within @drake//doc/...).
 
 # Unless `setup/ubuntu/install_prereqs.sh --with-doc-only` has been run, most
-# targets in //doc/... will fail to build, so by default we'll disable them.
-#
-# A developer will have to explicitly opt-in in order to build these.
-DEFAULT_BINARY_TAGS = [
-    "manual",
-]
-
-# Unless `setup/ubuntu/install_prereqs.sh --with-doc-only` has been run, most
 # tests in //doc/... will fail to pass, so by default we'll disable them.
 #
 # A developer will have to explicitly opt-in in order to test these.

--- a/doc/doxygen_cxx/BUILD.bazel
+++ b/doc/doxygen_cxx/BUILD.bazel
@@ -10,7 +10,6 @@ load(
 )
 load(
     "//doc:defs.bzl",
-    "DEFAULT_BINARY_TAGS",
     "DEFAULT_TEST_TAGS",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
@@ -38,7 +37,6 @@ drake_py_binary(
         "@bazel_tools//tools/python/runfiles",
         "@doxygen",
     ],
-    tags = DEFAULT_BINARY_TAGS,
     visibility = ["//doc:__pkg__"],
 )
 

--- a/doc/pydrake/BUILD.bazel
+++ b/doc/pydrake/BUILD.bazel
@@ -9,7 +9,6 @@ load(
 )
 load(
     "//doc:defs.bzl",
-    "DEFAULT_BINARY_TAGS",
     "DEFAULT_TEST_TAGS",
 )
 load("//bindings/pydrake:pydrake.bzl", "add_lint_tests_pydrake")
@@ -17,7 +16,6 @@ load("//bindings/pydrake:pydrake.bzl", "add_lint_tests_pydrake")
 drake_py_library(
     name = "sphinx_base",
     srcs = ["sphinx_base.py"],
-    tags = DEFAULT_BINARY_TAGS,
     deps = ["@rules_python//python/runfiles"],
 )
 
@@ -45,7 +43,6 @@ drake_py_binary(
     ],
     imports = ["."],
     main = "build.py",
-    tags = DEFAULT_BINARY_TAGS,
     test_rule_args = ["--out_dir=<test>"],
     test_rule_size = "medium",
     test_rule_tags = DEFAULT_TEST_TAGS,
@@ -61,7 +58,6 @@ drake_py_binary(
     name = "serve_sphinx",
     srcs = ["serve_sphinx.py"],
     data = [":gen_sphinx"],
-    tags = DEFAULT_BINARY_TAGS,
     visibility = ["//doc:__pkg__"],
     deps = [":sphinx_base"],
 )

--- a/doc/styleguide/BUILD.bazel
+++ b/doc/styleguide/BUILD.bazel
@@ -8,7 +8,6 @@ load(
 )
 load(
     "//doc:defs.bzl",
-    "DEFAULT_BINARY_TAGS",
     "DEFAULT_TEST_TAGS",
     "enumerate_filegroup",
 )
@@ -40,7 +39,6 @@ drake_py_binary(
         ":jekyll_input",
         ":jekyll_input.txt",
     ],
-    tags = DEFAULT_BINARY_TAGS,
     test_rule_args = ["--out_dir=<test>"],
     test_rule_size = "medium",
     test_rule_tags = DEFAULT_TEST_TAGS,


### PR DESCRIPTION
There are no repository rules anymore that fail when `--with-doc-only` is absent (as of #14804), so it's always safe to compile our documentation tooling.

Note that building the tooling does not actually generate the output by default -- the tests are still tagged as manual.

Towards #14803.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14892)
<!-- Reviewable:end -->
