### PR TITLE
Revert "doc: Remove manual tag from documentation binaries (#14892)"

### DIFF
--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -9,6 +9,7 @@ load(
 )
 load(
     ":defs.bzl",
+    "DEFAULT_BINARY_TAGS",
     "DEFAULT_TEST_TAGS",
     "enumerate_filegroup",
 )
@@ -111,16 +112,14 @@ drake_py_binary(
         "//doc/pydrake:gen_sphinx",
         "//doc/styleguide:build",
     ],
+    tags = DEFAULT_BINARY_TAGS,
     deps = [
         "@bazel_tools//tools/python/runfiles",
     ],
 )
 
 # This rule is used by our CI scripts as a single point of entry to ensure that
-# all of our documentation binaries can be built successfully.  The "manual" in
-# its name is a bit of a misnomer (these all used to be tagged as manual, but
-# we no longer need to exclude them from the build); all of these binaries are
-# part of the default `bazel build //...`.
+# all of our manually-tagged documentation binaries can be built successfully.
 filegroup(
     name = "manual_binaries",
     srcs = [
@@ -131,6 +130,7 @@ filegroup(
         "//doc/pydrake:serve_sphinx",
         "//doc/styleguide:build",
     ],
+    tags = ["manual"],
 )
 
 # This rule is used by our CI scripts as a single point of entry to ensure that

--- a/doc/defs.bzl
+++ b/doc/defs.bzl
@@ -5,6 +5,14 @@
 # within @drake//doc/...).
 
 # Unless `setup/ubuntu/install_prereqs.sh --with-doc-only` has been run, most
+# targets in //doc/... will fail to build, so by default we'll disable them.
+#
+# A developer will have to explicitly opt-in in order to build these.
+DEFAULT_BINARY_TAGS = [
+    "manual",
+]
+
+# Unless `setup/ubuntu/install_prereqs.sh --with-doc-only` has been run, most
 # tests in //doc/... will fail to pass, so by default we'll disable them.
 #
 # A developer will have to explicitly opt-in in order to test these.

--- a/doc/doxygen_cxx/BUILD.bazel
+++ b/doc/doxygen_cxx/BUILD.bazel
@@ -10,6 +10,7 @@ load(
 )
 load(
     "//doc:defs.bzl",
+    "DEFAULT_BINARY_TAGS",
     "DEFAULT_TEST_TAGS",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
@@ -37,6 +38,7 @@ drake_py_binary(
         "@bazel_tools//tools/python/runfiles",
         "@doxygen",
     ],
+    tags = DEFAULT_BINARY_TAGS,
     visibility = ["//doc:__pkg__"],
 )
 

--- a/doc/pydrake/BUILD.bazel
+++ b/doc/pydrake/BUILD.bazel
@@ -9,6 +9,7 @@ load(
 )
 load(
     "//doc:defs.bzl",
+    "DEFAULT_BINARY_TAGS",
     "DEFAULT_TEST_TAGS",
 )
 load("//bindings/pydrake:pydrake.bzl", "add_lint_tests_pydrake")
@@ -16,6 +17,7 @@ load("//bindings/pydrake:pydrake.bzl", "add_lint_tests_pydrake")
 drake_py_library(
     name = "sphinx_base",
     srcs = ["sphinx_base.py"],
+    tags = DEFAULT_BINARY_TAGS,
     deps = ["@rules_python//python/runfiles"],
 )
 
@@ -43,6 +45,7 @@ drake_py_binary(
     ],
     imports = ["."],
     main = "build.py",
+    tags = DEFAULT_BINARY_TAGS,
     test_rule_args = ["--out_dir=<test>"],
     test_rule_size = "medium",
     test_rule_tags = DEFAULT_TEST_TAGS,
@@ -58,6 +61,7 @@ drake_py_binary(
     name = "serve_sphinx",
     srcs = ["serve_sphinx.py"],
     data = [":gen_sphinx"],
+    tags = DEFAULT_BINARY_TAGS,
     visibility = ["//doc:__pkg__"],
     deps = [":sphinx_base"],
 )

--- a/doc/styleguide/BUILD.bazel
+++ b/doc/styleguide/BUILD.bazel
@@ -8,6 +8,7 @@ load(
 )
 load(
     "//doc:defs.bzl",
+    "DEFAULT_BINARY_TAGS",
     "DEFAULT_TEST_TAGS",
     "enumerate_filegroup",
 )
@@ -39,6 +40,7 @@ drake_py_binary(
         ":jekyll_input",
         ":jekyll_input.txt",
     ],
+    tags = DEFAULT_BINARY_TAGS,
     test_rule_args = ["--out_dir=<test>"],
     test_rule_size = "medium",
     test_rule_tags = DEFAULT_TEST_TAGS,


### PR DESCRIPTION
This reverts commit f22df9831a5d2a167bc442914a000b1d44e7c420.

Dear @jwnimmer-tri,

The on-call build cop, Eric, believes that your PR #14892 may have
broken one or more of Drake's continuous integration builds [1]. It is
possible to break a build even if your PR passed continuous integration
pre-merge because additional platforms are tested post-merge.

Some of the specific build failures under investigation are:
https://drake-jenkins.csail.mit.edu/view/Production/job/mac-big-sur-clang-bazel-continuous-release/133/
https://drake-jenkins.csail.mit.edu/view/Production/job/mac-big-sur-clang-bazel-nightly-everything-release/64/

Zoom-in example:
https://drake-cdash.csail.mit.edu/viewBuildError.php?buildid=1398489
```
ERROR: /Users/bigsur/workspace/mac-big-sur-clang-bazel-nightly-everything-release/src/doc/BUILD.bazel:124:10: //doc:manual_binaries: missing input file 'external/doxygen/doxygen', owner: '@doxygen//:doxygen'
```

Therefore, the build cop has created this revert PR and started a complete
post-merge build to determine whether your PR was in fact the cause of the
problem. If that build passes, this revert PR will be merged in a few hour
from now. You can then fix the problem at your leisure, and send a new PR to
reinstate your change.

If you believe your original PR did not actually break the build, please
explain on this thread.

If you believe you can fix the break promptly in lieu of a revert, please
explain on this thread, and send a PR to the build cop for review ASAP.

If you believe your original PR definitely did break the build and should be
reverted, please review and LGTM this PR. This allows the build cop to merge
without waiting for CI results.

For advice on how to handle a build cop revert, see [2].

Thanks!
Your Friendly On-call Build Cop

[1] CI Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Production/
[2] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14895)
<!-- Reviewable:end -->
