### PR TITLE
[geometry] Allow meshes and fields to handle mixed-scalar calculations

### DIFF
--- a/examples/scene_graph/simple_contact_surface_vis.cc
+++ b/examples/scene_graph/simple_contact_surface_vis.cc
@@ -225,6 +225,7 @@ class ContactResultMaker final : public LeafSystem<double> {
       surface_msg.triangles.resize(surface_msg.num_triangles);
 
       // Loop through each contact triangle on the contact surface.
+      const auto& field = surfaces[i].e_MN();
       for (SurfaceFaceIndex j(0); j < surface_msg.num_triangles; ++j) {
         lcmt_hydroelastic_contact_surface_tri_for_viz& tri_msg =
             surface_msg.triangles[j];
@@ -239,9 +240,9 @@ class ContactResultMaker final : public LeafSystem<double> {
         write_double3(vB.r_MV(), tri_msg.p_WB);
         write_double3(vC.r_MV(), tri_msg.p_WC);
 
-        tri_msg.pressure_A = surfaces[i].EvaluateE_MN(face.vertex(0));
-        tri_msg.pressure_B = surfaces[i].EvaluateE_MN(face.vertex(1));
-        tri_msg.pressure_C = surfaces[i].EvaluateE_MN(face.vertex(2));
+        tri_msg.pressure_A = field.EvaluateAtVertex(face.vertex(0));
+        tri_msg.pressure_B = field.EvaluateAtVertex(face.vertex(1));
+        tri_msg.pressure_C = field.EvaluateAtVertex(face.vertex(2));
       }
     }
 

--- a/geometry/profiling/contact_surface_rigid_bowl_soft_ball.cc
+++ b/geometry/profiling/contact_surface_rigid_bowl_soft_ball.cc
@@ -284,6 +284,7 @@ class ContactResultMaker final : public LeafSystem<double> {
       surface_msg.triangles.resize(surface_msg.num_triangles);
 
       // Loop through each contact triangle on the contact surface.
+      const auto& field = contacts[i].e_MN();
       for (SurfaceFaceIndex j(0); j < surface_msg.num_triangles; ++j) {
         lcmt_hydroelastic_contact_surface_tri_for_viz& tri_msg =
             surface_msg.triangles[j];
@@ -298,9 +299,9 @@ class ContactResultMaker final : public LeafSystem<double> {
         write_double3(vB.r_MV(), tri_msg.p_WB);
         write_double3(vC.r_MV(), tri_msg.p_WC);
 
-        tri_msg.pressure_A = contacts[i].EvaluateE_MN(face.vertex(0));
-        tri_msg.pressure_B = contacts[i].EvaluateE_MN(face.vertex(1));
-        tri_msg.pressure_C = contacts[i].EvaluateE_MN(face.vertex(2));
+        tri_msg.pressure_A = field.EvaluateAtVertex(face.vertex(0));
+        tri_msg.pressure_B = field.EvaluateAtVertex(face.vertex(1));
+        tri_msg.pressure_C = field.EvaluateAtVertex(face.vertex(2));
       }
     }
   }

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -38,6 +38,7 @@ drake_cc_package_library(
         ":mesh_intersection",
         ":mesh_plane_intersection",
         ":mesh_to_vtk",
+        ":mesh_traits",
         ":meshing_utilities",
         ":obb",
         ":obj_to_surface_mesh",
@@ -353,6 +354,7 @@ drake_cc_library(
         "volume_mesh_field.h",
     ],
     deps = [
+        ":mesh_traits",
         ":surface_mesh",
         ":volume_mesh",
         "//common",
@@ -419,6 +421,12 @@ drake_cc_library(
         ":volume_mesh",
         "@fmt",
     ],
+)
+
+drake_cc_library(
+    name = "mesh_traits",
+    hdrs = ["mesh_traits.h"],
+    deps = ["//common:autodiff"],
 )
 
 drake_cc_library(
@@ -526,6 +534,7 @@ drake_cc_library(
     srcs = ["surface_mesh.cc"],
     hdrs = ["surface_mesh.h"],
     deps = [
+        ":mesh_traits",
         "//common",
         "//math:geometric_transform",
     ],
@@ -546,6 +555,7 @@ drake_cc_library(
         "volume_mesh_field.h",
     ],
     deps = [
+        ":mesh_traits",
         "//common",
         "//geometry:geometry_ids",
     ],
@@ -791,6 +801,7 @@ drake_cc_googletest(
         ":make_box_mesh",
         ":mesh_field",
         "//common/test_utilities:eigen_matrix_compare",
+        "//math:autodiff",
         "//math:geometric_transform",
     ],
 )
@@ -834,6 +845,13 @@ drake_cc_googletest(
         "//common:temp_directory",
         "//geometry:shape_specification",
         "//math:geometric_transform",
+    ],
+)
+
+drake_cc_googletest(
+    name = "mesh_traits_test",
+    deps = [
+        ":mesh_traits",
     ],
 )
 
@@ -927,6 +945,7 @@ drake_cc_googletest(
     deps = [
         ":surface_mesh",
         "//common/test_utilities:eigen_matrix_compare",
+        "//math:autodiff",
         "//math:geometric_transform",
     ],
 )
@@ -937,6 +956,7 @@ drake_cc_googletest(
         ":mesh_field",
         ":volume_mesh",
         "//common/test_utilities:eigen_matrix_compare",
+        "//math:autodiff",
         "//math:geometric_transform",
     ],
 )

--- a/geometry/proximity/mesh_traits.h
+++ b/geometry/proximity/mesh_traits.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <type_traits>
+
+#include "drake/common/autodiff.h"
+
+namespace drake {
+namespace geometry {
+
+/** Given the two scalar types U and T, returns the most "promoted" type. The
+ scalars must be either `double` or `AutoDiffXd`.
+
+ This trait implicitly encodes the logic: if either B or T are AutoDiffXd,
+ return AutoDiffXd. The logic is illustrated with this truth table:
+
+ |      T       |      U       |    Result    |
+ | :----------: | :----------: | :----------: |
+ |  AutoDiffXd  |  AutoDiffXd  |  AutoDiffXd  |
+ |    double    |  AutoDiffXd  |  AutoDiffXd  |
+ |  AutoDiffXd  |    double    |  AutoDiffXd  |
+ |    double    |    double    |    double    |
+
+ This also includes the helper type:
+
+ ```
+ template <typename T, typename U>
+ using promoted_numerical_t = typename promoted_numerical<T, U>::type;
+ ```
+ */
+template <typename T, typename U>
+struct promoted_numerical {
+  static_assert(
+      std::conjunction_v<std::disjunction<std::is_same<U, double>,
+                                          std::is_same<U, AutoDiffXd>>,
+                         std::disjunction<std::is_same<T, double>,
+                                          std::is_same<T, AutoDiffXd>>>,
+      "This utility is only compatible with 'double' and 'AutoDiffXd' scalar "
+      "types");
+  /* If U is double, then the return type is ultimately determined by T. If
+   U is AutoDiff (i.e. "not double"), then we can just return that. If we ever
+   change the space of scalar types this supports, this logic will have to
+   change. */
+  using type = std::conditional_t<std::is_same_v<U, double>, T, U>;
+};
+
+template <typename T, typename U>
+using promoted_numerical_t = typename promoted_numerical<T, U>::type;
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/contact_surface_test.cc
+++ b/geometry/proximity/test/contact_surface_test.cc
@@ -131,9 +131,10 @@ ContactSurface<T> TestContactSurface() {
   // Tests evaluation of `e` on face f0 {0, 1, 2}.
   {
     const SurfaceFaceIndex f0(0);
-    const typename SurfaceMesh<T>::Barycentric b{0.2, 0.3, 0.5};
+    const typename SurfaceMesh<T>::template Barycentric<double> b{0.2, 0.3,
+                                                                  0.5};
     const T expect_e = b(0) * e0 + b(1) * e1 + b(2) * e2;
-    EXPECT_EQ(expect_e, contact_surface.EvaluateE_MN(f0, b));
+    EXPECT_EQ(expect_e, contact_surface.e_MN().Evaluate(f0, b));
   }
   // Tests area() of triangular faces.
   {
@@ -281,8 +282,8 @@ GTEST_TEST(ContactSurfaceTest, TestCopy) {
 
   // We check evaluation of field values only at one position.
   const SurfaceFaceIndex f(0);
-  const typename SurfaceMesh<double>::Barycentric b{0.2, 0.3, 0.5};
-  EXPECT_EQ(original.EvaluateE_MN(f, b), copy.EvaluateE_MN(f, b));
+  const typename SurfaceMesh<double>::Barycentric<double> b{0.2, 0.3, 0.5};
+  EXPECT_EQ(original.e_MN().Evaluate(f, b), copy.e_MN().Evaluate(f, b));
 }
 
 // Tests the equality comparisons.
@@ -356,9 +357,9 @@ GTEST_TEST(ContactSurfaceTest, TestSwapMAndN) {
 
   // Evaluate the mesh field, once per face for an arbitrary point Q on the
   // interior of the triangle. We expect e_MN function hasn't changed.
-  const SurfaceMesh<double>::Barycentric b_Q{0.25, 0.25, 0.5};
+  const SurfaceMesh<double>::Barycentric<double> b_Q{0.25, 0.25, 0.5};
   for (SurfaceFaceIndex f(0); f < original.mesh_W().num_faces(); ++f) {
-    EXPECT_EQ(dut.EvaluateE_MN(f, b_Q), original.EvaluateE_MN(f, b_Q));
+    EXPECT_EQ(dut.e_MN().Evaluate(f, b_Q), original.e_MN().Evaluate(f, b_Q));
   }
 }
 

--- a/geometry/proximity/test/mesh_intersection_test.cc
+++ b/geometry/proximity/test/mesh_intersection_test.cc
@@ -1060,11 +1060,11 @@ void TestComputeContactSurfaceSoftRigid() {
   //  that is officially documented as a property of the ContactSurface.
 
   // The "pressure" field is frame invariant and should be equal.
-  const typename SurfaceMesh<T>::Barycentric centroid(1. / 3., 1. / 3.,
-                                                      1. / 3.);
+  const typename SurfaceMesh<T>::template Barycentric<double> centroid(
+      1. / 3., 1. / 3., 1. / 3.);
   const SurfaceFaceIndex f_index(0);
-  EXPECT_EQ(contact_SR->EvaluateE_MN(f_index, centroid),
-            contact_RS->EvaluateE_MN(f_index, centroid));
+  EXPECT_EQ(contact_SR->e_MN().Evaluate(f_index, centroid),
+            contact_RS->e_MN().Evaluate(f_index, centroid));
 
   // The gradients for the pressure field of the soft mesh are expresssed in the
   // world frame. To determine the world transformation has taken place, we'll
@@ -1135,9 +1135,10 @@ bool FindVertex(Vector3d p_MQ, const Mesh& mesh_M,
 //       being inside due to numerical roundings.
 bool FindElement(Vector3d p_MQ, const VolumeMesh<double>& volume_M,
                  VolumeElementIndex* element_E,
-                 VolumeMesh<double>::Barycentric* b_EQ) {
+                 VolumeMesh<double>::Barycentric<double>* b_EQ) {
   for (VolumeElementIndex e(0); e < volume_M.num_elements(); ++e) {
-    VolumeMesh<double>::Barycentric b = volume_M.CalcBarycentric(p_MQ, e);
+    VolumeMesh<double>::Barycentric<double> b =
+        volume_M.CalcBarycentric(p_MQ, e);
     if ((b.array() >= -1e-14).all()) {
       *element_E = e;
       *b_EQ = b;
@@ -1198,7 +1199,7 @@ GTEST_TEST(MeshIntersectionTest, ComputeContactSurfaceSoftRigidMoving) {
       // Index of contact surface C's vertex coincident with Q.
       SurfaceVertexIndex index_C;
       ASSERT_TRUE(FindVertex(p_WQ, contact->mesh_W(), &index_C));
-      const double pressure_at_C = contact->EvaluateE_MN(index_C);
+      const double pressure_at_C = contact->e_MN().EvaluateAtVertex(index_C);
       // Index of Q in the volume mesh.
       VolumeVertexIndex index_Q;
       ASSERT_TRUE(FindVertex(p_SQ, pressure_S->mesh(), &index_Q));
@@ -1248,11 +1249,11 @@ GTEST_TEST(MeshIntersectionTest, ComputeContactSurfaceSoftRigidMoving) {
     // Index of C's vertex coincident with Q.
     SurfaceVertexIndex c_vertex;
     ASSERT_TRUE(FindVertex(p_WQ, contact->mesh_W(), &c_vertex));
-    const double c_pressure = contact->EvaluateE_MN(c_vertex);
+    const double c_pressure = contact->e_MN().EvaluateAtVertex(c_vertex);
 
     // Find the tetrahedral element of S containing Q.
     VolumeElementIndex tetrahedron;
-    VolumeMesh<double>::Barycentric b_Q;
+    VolumeMesh<double>::Barycentric<double> b_Q;
     ASSERT_TRUE(FindElement(p_SQ, pressure_S->mesh(), &tetrahedron, &b_Q));
     const double s_pressure = pressure_S->Evaluate(tetrahedron, b_Q);
 

--- a/geometry/proximity/test/mesh_plane_intersection_test.cc
+++ b/geometry/proximity/test/mesh_plane_intersection_test.cc
@@ -440,7 +440,7 @@ class SliceTetWithPlaneTest : public ::testing::Test {
     for (const auto& V_W : vertices_W_) {
       const Vector3d& p_WV = V_W.r_MV();
       const Vector3d& p_FV = X_FW * p_WV;
-      const VolumeMesh<double>::Barycentric b_V =
+      const VolumeMesh<double>::Barycentric<double> b_V =
           field_F.mesh().CalcBarycentric(p_FV, tet_index);
       for (int i = 0; i < 4; ++i) {
         if (!(b_V(i) >= -kEps && b_V(i) <= 1 + kEps)) {

--- a/geometry/proximity/test/mesh_traits_test.cc
+++ b/geometry/proximity/test/mesh_traits_test.cc
@@ -1,0 +1,27 @@
+#include "drake/geometry/proximity/mesh_traits.h"
+
+#include <type_traits>
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace geometry {
+namespace {
+
+GTEST_TEST(PromoteNumerical, Promotion) {
+  static_assert(std::is_same_v<promoted_numerical_t<double, double>, double>,
+                "Double-double should be double");
+  static_assert(
+      std::is_same_v<promoted_numerical_t<double, AutoDiffXd>, AutoDiffXd>,
+      "double-AutoDiffXd should be AutoDiffXd");
+  static_assert(
+      std::is_same_v<promoted_numerical_t<AutoDiffXd, double>, AutoDiffXd>,
+      "AutoDiffXd-double should be AutoDiffXd");
+  static_assert(
+      std::is_same_v<promoted_numerical_t<AutoDiffXd, AutoDiffXd>, AutoDiffXd>,
+      "AutoDiffXd-AutoDiffXd should be AutoDiffXd");
+}
+
+}  // namespace
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/query_results/contact_surface.h
+++ b/geometry/query_results/contact_surface.h
@@ -224,28 +224,6 @@ class ContactSurface {
   /** Returns the geometry id of Geometry N. */
   GeometryId id_N() const { return id_N_; }
 
-  // TODO(damrongguoy) Consider removing these evaluation methods and instead
-  // make the fields accessible, and then evaluate the fields directly.
-
-  /** Evaluates the scalar field eₘₙ at Point Q in a triangle.
-    Point Q is specified by its barycentric coordinates.
-    @param face         The face index of the triangle.
-    @param barycentric  The barycentric coordinates of Q on the triangle.
-   */
-  T EvaluateE_MN(
-      SurfaceFaceIndex face,
-      const typename SurfaceMesh<T>::Barycentric& barycentric) const {
-    return e_MN_->Evaluate(face, barycentric);
-  }
-
-  /** Evaluates the scalar field eₘₙ at the given vertex on the contact surface
-    mesh.
-    @param vertex       The index of the vertex in the mesh.
-   */
-  T EvaluateE_MN(SurfaceVertexIndex vertex) const {
-    return e_MN_->EvaluateAtVertex(vertex);
-  }
-
   /** @name  Evaluation of constituent pressure fields
 
    The %ContactSurface *provisionally* includes the gradients of the constituent

--- a/multibody/plant/contact_results_to_lcm.cc
+++ b/multibody/plant/contact_results_to_lcm.cc
@@ -131,6 +131,7 @@ void ContactResultsToLcmSystem<T>::CalcLcmContactOutput(
     }
 
     // Loop through each contact triangle on the contact surface.
+    const auto& field = contact_surface.e_MN();
     for (geometry::SurfaceFaceIndex j(0); j < surface_msg.num_triangles; ++j) {
       lcmt_hydroelastic_contact_surface_tri_for_viz& tri_msg =
           surface_msg.triangles[j];
@@ -147,11 +148,11 @@ void ContactResultsToLcmSystem<T>::CalcLcmContactOutput(
 
       // Record the pressures.
       tri_msg.pressure_A =
-          ExtractDoubleOrThrow(contact_surface.EvaluateE_MN(face.vertex(0)));
+          ExtractDoubleOrThrow(field.EvaluateAtVertex(face.vertex(0)));
       tri_msg.pressure_B =
-          ExtractDoubleOrThrow(contact_surface.EvaluateE_MN(face.vertex(1)));
+          ExtractDoubleOrThrow(field.EvaluateAtVertex(face.vertex(1)));
       tri_msg.pressure_C =
-          ExtractDoubleOrThrow(contact_surface.EvaluateE_MN(face.vertex(2)));
+          ExtractDoubleOrThrow(field.EvaluateAtVertex(face.vertex(2)));
     }
   }
 }

--- a/multibody/plant/hydroelastic_traction_calculator.cc
+++ b/multibody/plant/hydroelastic_traction_calculator.cc
@@ -132,15 +132,15 @@ SpatialForce<T> HydroelasticTractionCalculator<T>::
 template <typename T>
 HydroelasticQuadraturePointData<T>
 HydroelasticTractionCalculator<T>::CalcTractionAtPoint(
-    const Data& data,
-    SurfaceFaceIndex face_index,
-    const typename SurfaceMesh<T>::Barycentric& Q_barycentric,
+    const Data& data, SurfaceFaceIndex face_index,
+    // NOLINTNEXTLINE(runtime/references): "template Bar..." confuses cpplint.
+    const typename SurfaceMesh<T>::template Barycentric<T>& Q_barycentric,
     double dissipation, double mu_coulomb) const {
   // Compute the point of contact in the world frame.
   const Vector3<T> p_WQ = data.surface.mesh_W().CalcCartesianFromBarycentric(
       face_index, Q_barycentric);
 
-  const T e = data.surface.EvaluateE_MN(face_index, Q_barycentric);
+  const T e = data.surface.e_MN().Evaluate(face_index, Q_barycentric);
 
   // Contact surfaces are documented to have face normals that point *out of* N
   // and *into* M -- which is the face normal of the contact surface (as

--- a/multibody/plant/hydroelastic_traction_calculator.h
+++ b/multibody/plant/hydroelastic_traction_calculator.h
@@ -139,7 +139,8 @@ class HydroelasticTractionCalculator {
 
   HydroelasticQuadraturePointData<T> CalcTractionAtPoint(
       const Data& data, geometry::SurfaceFaceIndex face_index,
-      const typename geometry::SurfaceMesh<T>::Barycentric& Q_barycentric,
+      const typename geometry::SurfaceMesh<T>::template Barycentric<T>&
+          Q_barycentric,
       double dissipation, double mu_coulomb) const;
 
   HydroelasticQuadraturePointData<T> CalcTractionAtQHelper(

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1991,7 +1991,7 @@ MultibodyPlant<T>::CalcDiscreteContactPairs(
               const Vector3<T> barycentric(xi[qp](0), xi[qp](1),
                                            1.0 - xi[qp](0) - xi[qp](1));
               // Pressure at the quadrature point.
-              const T p0 = s.EvaluateE_MN(face, barycentric);
+              const T p0 = s.e_MN().Evaluate(face, barycentric);
 
               // Force contribution by this quadrature point.
               const T fn0 = wq[qp] * Ae * p0;

--- a/multibody/plant/test/hydroelastic_traction_test.cc
+++ b/multibody/plant/test/hydroelastic_traction_test.cc
@@ -169,8 +169,8 @@ public ::testing::TestWithParam<RigidTransform<double>> {
     HydroelasticQuadraturePointData<double> output =
         traction_calculator().CalcTractionAtPoint(
             calculator_data(), SurfaceFaceIndex(0),
-            SurfaceMesh<double>::Barycentric(1.0, 0.0, 0.0), dissipation,
-            mu_coulomb);
+            SurfaceMesh<double>::Barycentric<double>(1.0, 0.0, 0.0),
+            dissipation, mu_coulomb);
 
     // Compute the expected point of contact in the world frame. The class
     // definition and SetUp() note that the parameter to this test transforms

--- a/multibody/plant/test/multibody_plant_hydroelastic_contact_results_output_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_contact_results_output_test.cc
@@ -216,7 +216,7 @@ TEST_F(HydroelasticContactResultsOutputTester, Traction) {
         results.contact_surface().mesh_W().CalcBarycentric(
             quadrature_point_datum.p_WQ, quadrature_point_datum.face_index);
 
-    const double pressure = results.contact_surface().EvaluateE_MN(
+    const double pressure = results.contact_surface().e_MN().Evaluate(
         quadrature_point_datum.face_index, p_barycentric);
 
     // The conversion from Cartesian to barycentric coordinates introduces some


### PR DESCRIPTION
The key principle is that a mesh (and related calculations) can get unique scalar types from various quantities:

  - Position of vertices stored in the mesh.
  - Barycentric coordinates as parameter to methods.
  - Cartesian coordinates as parameter to methods.

In the current implementation they must all be the same. But that doesn't support flexible computation. For example, a `double`-valued mesh, posed with `AutoDiffXd`-valued transform should produce `AutoDiffXd`-valued results in the posed frame. This is the kind of functionality we need to support.

To this end:

 1. Introduce the `mesh_traits.h` providing a compile-time utility for reconciling what the return type should be based on the various scalar types included in the calculation.
 2. Reformulate the meshes so that the appropriate calculations can take mixed scalar types.
    - Also removed the no longer useful alias `Cartesian` and mutated the `Barycentric` alias to allow for independent scalar type.
 3. Reformulate `MeshFieldLinear` so that it can also support mixed-scalar invocations.
 4. Clean up `ContactSurface`.
    - Kill methods that wrapped `SurfaceMeshField` APIs and just leave the getter for that field.
    - We don't *deprecate* the old methods, we simply delete them.

relates #14136
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14904)
<!-- Reviewable:end -->
