### PR TITLE
simulator: Remove allocations in AdvanceTo()

### DIFF
--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -836,6 +836,10 @@ class Simulator {
   // AdvanceTo(). This collection is constructed within Initialize().
   std::unique_ptr<CompositeEventCollection<T>> witnessed_events_;
 
+  // All events merged together. This collection is constructed within
+  // Initialize().
+  std::unique_ptr<CompositeEventCollection<T>> merged_events_;
+
   // Indicates when a timed or witnessed event needs to be handled on the next
   // call to AdvanceTo().
   TimeOrWitnessTriggered time_or_witness_triggered_{

--- a/systems/analysis/test/simulator_limit_malloc_test.cc
+++ b/systems/analysis/test/simulator_limit_malloc_test.cc
@@ -42,7 +42,7 @@ GTEST_TEST(SimulatorLimitMallocTest,
   simulator.Initialize();
   {
     // TODO(rpoyner-tri): whittle allocations down to 0.
-    test::LimitMalloc heap_alloc_checker({.max_num_allocations = 88});
+    test::LimitMalloc heap_alloc_checker({.max_num_allocations = 20});
     simulator.AdvanceTo(1.0);
     simulator.AdvanceTo(2.0);
     simulator.AdvanceTo(3.0);


### PR DESCRIPTION
Relevant to: #14543

This is the second of a long PR train to make heapless simulation
possible, with careful system construction. Inspired by @edrumwri's PR

This patch just moves some method-level heap use into longer-lived
object data; the data flows are the same, but storage gets reused over
successive AdvanceTo() steps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14912)
<!-- Reviewable:end -->
