### PR TITLE
doc: Fix release notes template to unpin old version

### DIFF
--- a/doc/_release-notes/template.txt
+++ b/doc/_release-notes/template.txt
@@ -99,7 +99,7 @@ Newly bound
 # Notes
 
 
-This release provides [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/v0.27.0) named
+This release provides [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/{version}) named
 ``drake-YYYYMMDD-{{bionic|focal|mac}}.tar.gz``. See [Nightly Releases](/from_binary.html#nightly-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the


### PR DESCRIPTION
To avoid #14921 happening again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14922)
<!-- Reviewable:end -->
