### PR TITLE
diagram: Refactor allocation for analyzing events by time

### DIFF
--- a/systems/analysis/test/simulator_limit_malloc_test.cc
+++ b/systems/analysis/test/simulator_limit_malloc_test.cc
@@ -42,7 +42,7 @@ GTEST_TEST(SimulatorLimitMallocTest,
   simulator.Initialize();
   {
     // TODO(rpoyner-tri): whittle allocations down to 0.
-    test::LimitMalloc heap_alloc_checker({.max_num_allocations = 20});
+    test::LimitMalloc heap_alloc_checker({.max_num_allocations = 16});
     simulator.AdvanceTo(1.0);
     simulator.AdvanceTo(2.0);
     simulator.AdvanceTo(3.0);

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -529,6 +529,11 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
   // The map of subsystem inputs to inputs of this Diagram.
   std::map<InputPortLocator, InputPortIndex> input_port_map_;
 
+  // The index of a cache entry that stores a buffer of time data for use in
+  // managing events. It is only used in DoCalcNextUpdateTime(), but is
+  // allocated as a cache entry to avoid heap operations during simulation.
+  CacheIndex event_times_buffer_cache_index_{};
+
   // For all T, Diagram<T> considers DiagramBuilder<T> a friend, so that the
   // builder can set the internal state correctly.
   friend class DiagramBuilder<T>;


### PR DESCRIPTION
Relevant to: #14543

This is the third of a long PR train to make heapless simulation
possible, with careful system construction. Inspired by @edrumwri's
draft PR #14707.

This patch, like the last, just moves some method-level heap use into
longer-lived object data; the data flows are the same, but storage gets
reused over successive simulation steps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14929)
<!-- Reviewable:end -->
