### PR TITLE
valgrind suppressions for system version of libclp

### DIFF
--- a/tools/dynamic_analysis/valgrind.supp
+++ b/tools/dynamic_analysis/valgrind.supp
@@ -225,3 +225,21 @@
    fun:start_thread
    fun:clone
 }
+
+{
+   libclp: invalid read of size 4 in startup via SimplexPrimal
+   Memcheck:Addr4
+   fun:_ZN10ClpSimplex7startupEii
+   fun:_ZN16ClpSimplexPrimal6primalEii
+   fun:_ZN10ClpSimplex6primalEii
+   fun:_ZN10ClpSimplex15reducedGradientEi
+   fun:_ZN10ClpSimplex6primalEii
+}
+
+{
+   libclp: invalid read of size 4 in startup via SimplexNonlinear
+   Memcheck:Addr4
+   fun:_ZN10ClpSimplex7startupEii
+   fun:_ZN19ClpSimplexNonlinear6primalEv
+   fun:_ZN10ClpSimplex6primalEii
+}


### PR DESCRIPTION
Closes #14932.

Addresses nightly build failures following PR #14894.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14933)
<!-- Reviewable:end -->
