### PR TITLE
[geometry]Document QueryObject::ComputeContactSurfaces support Capsule.

### DIFF
--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -281,7 +281,7 @@ class QueryObject {
        | Sphere    |  yes  |  yes  |
        | Cylinder  |  yes  |  yes  |
        | Box       |  yes  |  yes  |
-       | Capsule   |  no   |  no   |
+       | Capsule   |  yes  |  yes  |
        | Ellipsoid |  yes  |  yes  |
        | HalfSpace |  yes  |  yes  |
        | Mesh      |  no   |  yes  |


### PR DESCRIPTION
Update documentation of QueryObject::ComputeContactSurfaces() that Capsule is already supported.
It's a one-line documentation change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14935)
<!-- Reviewable:end -->
