### PR TITLE
Suppress PackageMap warning on different directory spellings

### DIFF
--- a/multibody/parsing/package_map.cc
+++ b/multibody/parsing/package_map.cc
@@ -138,8 +138,9 @@ void PackageMap::AddPackageIfNew(const string& package_name,
         "PackageMap: Adding package://{}: {}", package_name, path);
     Add(package_name, path);
   } else {
+    // Don't warn if we've found the same path with a different spelling.
     const string existing_path = GetPath(package_name);
-    if (path != existing_path) {
+    if (!filesystem::equivalent(existing_path, path)) {
       drake::log()->warn(
           "PackageMap is ignoring newly-found path \"{}\" for package \"{}\""
           " and will continue using the previously-known path at \"{}\".",


### PR DESCRIPTION
The spelling of a package path in the map isn't
standardized/normalized at all, so this can happen fairly easily
(e.g. if a trailing / is present or not).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14939)
<!-- Reviewable:end -->
