### PR TITLE
Hydroelastic traction calculator had a bad square-root

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -265,6 +265,8 @@ drake_cc_googletest(
         ":hydroelastic_traction",
         "//common:find_resource",
         "//common/test_utilities:eigen_matrix_compare",
+        "//math:autodiff",
+        "//math:gradient",
         "//multibody/parsing",
     ],
 )

--- a/multibody/plant/hydroelastic_traction_calculator.cc
+++ b/multibody/plant/hydroelastic_traction_calculator.cc
@@ -222,16 +222,15 @@ HydroelasticTractionCalculator<T>::CalcTractionAtQHelper(
   using std::atan;
   using std::sqrt;
   const T squared_vt = traction_data.vt_BqAq_W.squaredNorm();
-  const T norm_vt = sqrt(squared_vt);
-  const T soft_norm_vt = sqrt(squared_vt +
-      vslip_regularizer_ * vslip_regularizer_);
+  const T soft_norm_vt =
+      sqrt(squared_vt + vslip_regularizer_ * vslip_regularizer_);
 
   // Get the regularized direction of slip.
   const Vector3<T> vt_hat_BqAq_W = traction_data.vt_BqAq_W / soft_norm_vt;
 
   // Compute the traction.
   const T frictional_scalar = mu_coulomb * normal_traction *
-      2.0 / M_PI * atan(norm_vt / T(vslip_regularizer_));
+      2.0 / M_PI * atan(soft_norm_vt / T(vslip_regularizer_));
   traction_data.traction_Aq_W = nhat_W * normal_traction -
       vt_hat_BqAq_W * frictional_scalar;
 

--- a/multibody/plant/hydroelastic_traction_calculator.h
+++ b/multibody/plant/hydroelastic_traction_calculator.h
@@ -132,6 +132,7 @@ class HydroelasticTractionCalculator {
   // HydroelasticTractionCalculator in HydroelasticReportingTests if we have
   // to "friend" too many testing functions.
   // To allow GTEST to test private functions.
+  friend class HydroelasticTractionCalculatorTester;
   friend class MultibodyPlantHydroelasticTractionTests;
   friend class HydroelasticReportingTests;
   friend class HydroelasticReportingTests_LinearTraction_Test;


### PR DESCRIPTION
If the relative velocity of the two bodies at a quadrature point is zero (e.g., if the bodies are both stationary), the calculation of traction, which included a square root in calculation of the norm of the relative
velocity, would introduce NaNs in the derivatives for AutoDiffXd-valued contact forces. The test included in this PR failed in exactly this way (before the included fix was applied).

This cause for this is that, more or less, the derivative of sqrt is 1/sqrt. If I'm taking the square root of zero it can (and does) lead to 0/0 in the derivatives. This eliminates the hard norm and replaces it with the soft norm already computed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14940)
<!-- Reviewable:end -->
