### PR TITLE
ik: use translational jacobian for position constraint

### DIFF
--- a/multibody/inverse_kinematics/position_constraint.cc
+++ b/multibody/inverse_kinematics/position_constraint.cc
@@ -56,11 +56,12 @@ void EvalConstraintGradient(const systems::Context<double>& context,
                             const Eigen::Vector3d& p_BQ,
                             const Eigen::Ref<const AutoDiffVecXd>& x,
                             AutoDiffVecXd* y) {
-  Eigen::MatrixXd Jq_V_ABq(6, plant.num_positions());
-  plant.CalcJacobianSpatialVelocity(context, JacobianWrtVariable::kQDot, frameB,
-                                    p_BQ, frameA, frameA, &Jq_V_ABq);
+  Eigen::Matrix3Xd Jq_V_ABq(3, plant.num_positions());
+  plant.CalcJacobianTranslationalVelocity(context, JacobianWrtVariable::kQDot,
+                                          frameB, p_BQ, frameA, frameA,
+                                          &Jq_V_ABq);
   *y = math::initializeAutoDiffGivenGradientMatrix(
-      p_AQ, Jq_V_ABq.bottomRows<3>() * math::autoDiffToGradientMatrix(x));
+      p_AQ, Jq_V_ABq * math::autoDiffToGradientMatrix(x));
 }
 
 template <typename T, typename S>


### PR DESCRIPTION
Presumably this version of the Jacobian  wasn't available when the constraint was first authored.  But this should only be better.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14945)
<!-- Reviewable:end -->
