### PR TITLE
simulator_limit_malloc_test: Expand coverage of PublishEvents

### DIFF
--- a/systems/analysis/test/simulator_limit_malloc_test.cc
+++ b/systems/analysis/test/simulator_limit_malloc_test.cc
@@ -10,39 +10,59 @@ namespace drake {
 namespace systems {
 namespace {
 
-class ExamplePublishingSystem final : public LeafSystem<double> {
+class EventfulSystem final : public LeafSystem<double> {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ExamplePublishingSystem)
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(EventfulSystem)
 
-  ExamplePublishingSystem() {
-    DeclarePerStepPublishEvent(
-        &ExamplePublishingSystem::Update);
+  EventfulSystem() {
+    // These events were found to cause allocations at AdvanceTo() as
+    // originally implemented.
+    DeclarePeriodicPublishEvent(1.0, 0.5, &EventfulSystem::Update);
+    DeclarePerStepPublishEvent(&EventfulSystem::Update);
+
+    // These events were not found to allocate at AdvanceTo(); they are
+    // included for completeness.
+    DeclareForcedPublishEvent(&EventfulSystem::Update);
+
+    // It turns out that declaring an init event can actually *reduce* the
+    // allocation count, by forcing earlier allocations in underlying storage
+    // objects. See #14543 for discussion of this problem.
+    // TODO(rpoyner-tri): expand testing to cover this problem.
+    DeclareInitializationPublishEvent(&EventfulSystem::Update);
   }
 
  private:
-  systems::EventStatus Update(const systems::Context<double>&) const {
-    return systems::EventStatus::Succeeded();
+  EventStatus Update(const Context<double>&) const {
+    return EventStatus::Succeeded();
   }
 };
 
 // Tests that heap allocations do not occur from Simulator and the systems
-// framework for systems that do unrestricted updates and do not have continuous
-// state.
+// framework for systems that do various event updates and do not have
+// continuous state.
 GTEST_TEST(SimulatorLimitMallocTest,
            NoHeapAllocsInSimulatorForSystemsWithoutContinuousState) {
-  // Build a Diagram containing the Example system so we can test both Diagrams
+  // Build a Diagram containing the test system so we can test both Diagrams
   // and LeafSystems at once.
   DiagramBuilder<double> builder;
-  builder.AddSystem<ExamplePublishingSystem>();
+  builder.AddSystem<EventfulSystem>();
   auto diagram = builder.Build();
 
   // Create a Simulator and use it to advance time until t=3.
   Simulator<double> simulator(*diagram);
+  // Actually cause forced-publish events to be issued.
+  simulator.set_publish_every_time_step(true);
   // Trigger first (and only allowable) heap allocation.
   simulator.Initialize();
   {
+    // As long as there are any allocations allowed here, there are still
+    // defects to fix. The exact number doesn't much matter; it should be set
+    // to the minimum possible at any given revision, to catch regressions. The
+    // goal (see #14543) is for the simulator and framework to support
+    // heap-free simulation after initialization, given careful system
+    // construction.
     // TODO(rpoyner-tri): whittle allocations down to 0.
-    test::LimitMalloc heap_alloc_checker({.max_num_allocations = 16});
+    test::LimitMalloc heap_alloc_checker({.max_num_allocations = 49});
     simulator.AdvanceTo(1.0);
     simulator.AdvanceTo(2.0);
     simulator.AdvanceTo(3.0);


### PR DESCRIPTION
Relevant to: #14543

This is the fourth of a long PR train to make heapless simulation
possible, with careful system construction. Inspired by @edrumwri's
draft PR #14707.

This patch characterizes the heap allocations induced by all forms of
PublishEvents. It also improves naming and commentary.

Subsequent patches will reduce the measured heap usage from simulator
run-time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14950)
<!-- Reviewable:end -->
