### PR TITLE
[geometry] Allow Plane and PoseHalfSpace to do mixed-scalar computation

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -486,7 +486,10 @@ drake_cc_library(
 drake_cc_library(
     name = "plane",
     hdrs = ["plane.h"],
-    deps = ["//common:essential"],
+    deps = [
+        ":mesh_traits",
+        "//common:essential",
+    ],
 )
 
 drake_cc_library(
@@ -916,6 +919,7 @@ drake_cc_googletest(
         ":plane",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
+        "//math:autodiff",
     ],
 )
 
@@ -925,6 +929,7 @@ drake_cc_googletest(
         ":posed_half_space",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
+        "//math:autodiff",
     ],
 )
 

--- a/geometry/proximity/plane.h
+++ b/geometry/proximity/plane.h
@@ -8,6 +8,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
+#include "drake/geometry/proximity/mesh_traits.h"
 
 namespace drake {
 namespace geometry {
@@ -77,8 +78,14 @@ class Plane {
   /* Computes the height of Point Q relative to the plane. A positive height
    indicates the point lies _above_ the plane; negative height indicates
    _below_. The point must be measured and expressed in the same frame as the
-   plane.   */
-  T CalcHeight(const Vector3<T>& p_FQ) const {
+   plane.
+
+   The return type depends on both the plane's scalar type `T` and the given
+   query point's scalar type `U`. See
+   @ref drake::geometry::promoted_numerical "promoted_numerical_t" for details.
+   */
+  template <typename U = T>
+  promoted_numerical_t<U, T> CalcHeight(const Vector3<U>& p_FQ) const {
     return nhat_F_.dot(p_FQ) - displacement_;
   }
 

--- a/geometry/proximity/posed_half_space.h
+++ b/geometry/proximity/posed_half_space.h
@@ -5,6 +5,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
+#include "drake/geometry/proximity/mesh_traits.h"
 #include "drake/geometry/proximity/plane.h"
 
 namespace drake {
@@ -46,8 +47,14 @@ class PosedHalfSpace {
   /* Computes the signed distance to the point Q (measured and expressed in
    Frame F). If Q's signed distance is positive, it lies outside the half space.
    If it is negative, it lies inside. If it is zero, it lies on the boundary
-   plane of the half space.  */
-  T CalcSignedDistance(const Vector3<T>& p_FQ) const {
+   plane of the half space.
+
+   The return type depends on both the half space's scalar type `T` and the
+   given query point's scalar type `U`. See
+   @ref drake::geometry::promoted_numerical "promoted_numerical_t" for details.
+   */
+  template <typename U = T>
+  promoted_numerical_t<U, T> CalcSignedDistance(const Vector3<U>& p_FQ) const {
     return plane_.CalcHeight(p_FQ);
   }
 

--- a/geometry/proximity/test/plane_test.cc
+++ b/geometry/proximity/test/plane_test.cc
@@ -10,6 +10,7 @@
 #include "drake/common/eigen_types.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/math/autodiff.h"
 
 namespace drake {
 namespace geometry {
@@ -90,6 +91,59 @@ GTEST_TEST(PlaneTest, CalcHeight) {
     for (int i = 0; i < 2; ++i) {
       EXPECT_NEAR(plane_F.CalcHeight(p_FQs[i]), -h_Qs[i], kEps);
     }
+  }
+}
+
+// Confirm that mixed-scalar computation "works". In the case of this test,
+// "works" means that the query point scalar type and plane scalar types are
+// indpendent, the return type is the promoted type, and derivatives propagate
+// through.
+GTEST_TEST(PlaneTest, MixedScalar) {
+  // Arbitrary Normal and origins.
+  const Vector3d nhat_F_d = Vector3d{-1, 0.25, 1.3}.normalized();
+  const Vector3d p_FB_d{0.25, 0.5, -1};
+  Plane<double> plane_F_d(nhat_F_d, p_FB_d);
+
+  const Vector3<AutoDiffXd> p_FB_ad = math::initializeAutoDiff(p_FB_d);
+  Plane<AutoDiffXd> plane_F_ad(nhat_F_d.cast<AutoDiffXd>(), p_FB_ad);
+
+  const double expected_distance = 0.125;
+  const Vector3d p_FQ_d = p_FB_d + expected_distance * nhat_F_d;
+  const Vector3<AutoDiffXd> p_FQ_ad_derivs = math::initializeAutoDiff(p_FQ_d);
+  const Vector3<AutoDiffXd> p_FQ_ad_no_derivs = p_FQ_d.cast<AutoDiffXd>();
+
+  {
+    // Double-valued plane and double-valued point -> double valued result.
+    const double distance = plane_F_d.CalcHeight(p_FQ_d);
+    EXPECT_EQ(distance, expected_distance);
+  }
+
+  {
+    // Double-valued plane and AutoDiff-valued point -> AutoDiff valued result
+    // with the same number of derivatives as the point.
+    const AutoDiffXd distance1 = plane_F_d.CalcHeight(p_FQ_ad_derivs);
+    EXPECT_EQ(distance1.value(), expected_distance);
+    EXPECT_EQ(distance1.derivatives().size(), 3);
+
+    const AutoDiffXd distance2 = plane_F_d.CalcHeight(p_FQ_ad_no_derivs);
+    EXPECT_EQ(distance2.value(), expected_distance);
+    EXPECT_EQ(distance2.derivatives().size(), 0);
+  }
+
+  {
+    // AutoDiff-valued plane and double-valued point -> AutoDiff valued result
+    // with the same number of derivatives as the plane.
+    const AutoDiffXd distance = plane_F_ad.CalcHeight(p_FQ_d);
+    EXPECT_EQ(distance.value(), expected_distance);
+    EXPECT_EQ(distance.derivatives().size(), 3);
+  }
+
+  {
+    // AutoDiff-valued plane and AutoDiff-valued point -> AutoDiff valued result
+    // with the same number of derivatives as the plane (and point).
+    const AutoDiffXd distance = plane_F_ad.CalcHeight(p_FQ_ad_derivs);
+    EXPECT_EQ(distance.value(), expected_distance);
+    EXPECT_EQ(distance.derivatives().size(), 3);
   }
 }
 

--- a/geometry/proximity/test/posed_half_space_test.cc
+++ b/geometry/proximity/test/posed_half_space_test.cc
@@ -9,6 +9,7 @@
 #include "drake/common/eigen_types.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/math/autodiff.h"
 
 namespace drake {
 namespace geometry {
@@ -55,8 +56,63 @@ GTEST_TEST(PosedHalfSpaceTest, CalcSignedDistance) {
 
   const PosedHalfSpace<double> hs_F(nhat_F, p_FP);
 
-  EXPECT_NEAR(hs_F.CalcSignedDistance(p_FP + 0.5 * nhat_F), 0.5, kEps);
-  EXPECT_NEAR(hs_F.CalcSignedDistance(p_FP - 0.5 * nhat_F), -0.5, kEps);
+  EXPECT_NEAR(hs_F.CalcSignedDistance(Vector3d{p_FP + 0.5 * nhat_F}), 0.5,
+              kEps);
+  EXPECT_NEAR(hs_F.CalcSignedDistance(Vector3d{p_FP - 0.5 * nhat_F}), -0.5,
+              kEps);
+}
+
+// Confirm that mixed-scalar computation "works". In the case of this test,
+// "works" means that the query point scalar type and half space scalar types
+// are independent, the return type is the promoted type, and derivatives
+// propagate through.
+GTEST_TEST(PosedHalfSpaceTest, MixedScalar) {
+  // Arbitrary Normal and origins.
+  const Vector3d nhat_F_d = Vector3d{-1, 0.25, 1.3}.normalized();
+  const Vector3d p_FB_d{0.25, 0.5, -1};
+  PosedHalfSpace<double> hs_F_d(nhat_F_d, p_FB_d);
+
+  const Vector3<AutoDiffXd> p_FB_ad = math::initializeAutoDiff(p_FB_d);
+  PosedHalfSpace<AutoDiffXd> hs_F_ad(nhat_F_d.cast<AutoDiffXd>(), p_FB_ad);
+
+  const double expected_distance = 0.125;
+  const Vector3d p_FQ_d = p_FB_d + expected_distance * nhat_F_d;
+  const Vector3<AutoDiffXd> p_FQ_ad_derivs = math::initializeAutoDiff(p_FQ_d);
+  const Vector3<AutoDiffXd> p_FQ_ad_no_derivs = p_FQ_d.cast<AutoDiffXd>();
+
+  {
+    // Double-valued plane and double-valued point -> double valued result.
+    const double distance = hs_F_d.CalcSignedDistance(p_FQ_d);
+    EXPECT_EQ(distance, expected_distance);
+  }
+
+  {
+    // Double-valued plane and AutoDiff-valued point -> AutoDiff valued result
+    // with the same number of derivatives as the point.
+    const AutoDiffXd distance1 = hs_F_d.CalcSignedDistance(p_FQ_ad_derivs);
+    EXPECT_EQ(distance1.value(), expected_distance);
+    EXPECT_EQ(distance1.derivatives().size(), 3);
+
+    const AutoDiffXd distance2 = hs_F_d.CalcSignedDistance(p_FQ_ad_no_derivs);
+    EXPECT_EQ(distance2.value(), expected_distance);
+    EXPECT_EQ(distance2.derivatives().size(), 0);
+  }
+
+  {
+    // AutoDiff-valued plane and double-valued point -> AutoDiff valued result
+    // with the same number of derivatives as the plane.
+    const AutoDiffXd distance = hs_F_ad.CalcSignedDistance(p_FQ_d);
+    EXPECT_EQ(distance.value(), expected_distance);
+    EXPECT_EQ(distance.derivatives().size(), 3);
+  }
+
+  {
+    // AutoDiff-valued plane and AutoDiff-valued point -> AutoDiff valued result
+    // with the same number of derivatives as the plane (and point).
+    const AutoDiffXd distance = hs_F_ad.CalcSignedDistance(p_FQ_ad_derivs);
+    EXPECT_EQ(distance.value(), expected_distance);
+    EXPECT_EQ(distance.derivatives().size(), 3);
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
`Plane::CalcHeight()` and `PosedHalfSpace::CalcSignedDistance()` can now support mixed numerical scalars (`double` and `AutoDiffXd`).

relates #14136

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14951)
<!-- Reviewable:end -->
