### PR TITLE
[geometry] Make rigid plane/soft mesh hydroelastic differentiable

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -832,6 +832,9 @@ drake_cc_googletest(
         ":mesh_plane_intersection",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
+        "//math:autodiff",
+        "//math:gradient",
+        "//math:orthonormal_basis",
     ],
 )
 


### PR DESCRIPTION
This work is about 5% tweaking the implementation and 95% testing.

1. Modifications to the underlying algorithm
   - making sure use of scalars is consistent.
   - Guaranteeing that even with `T = AutoDiffXd`, `Bvh` usage still works.
   - deleting the "AutoDiff throws" implementation.
   - incidental correction of notation error. I had frame P instead of
     R.
2. Modifications to unit tests
   - Elimination of "Autodiff throws" unit test.
   - Introduction of tests on the derivatives of various quantities:
     - Area, vertex position, normal direction, pressure.

relates #14136

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14952)
<!-- Reviewable:end -->
