### PR TITLE
doc: Rewrite generation instructions and top-level build script

### DIFF
--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -95,7 +95,6 @@ drake_py_binary(
         ":pages_input.txt",
     ],
     test_rule_args = ["--out_dir=<test>"],
-    test_rule_size = "medium",
     test_rule_tags = DEFAULT_TEST_TAGS,
     deps = [
         ":defs",
@@ -105,30 +104,27 @@ drake_py_binary(
 drake_py_binary(
     name = "build",
     srcs = ["build.py"],
+    add_test_rule = 1,
     data = [
         ":pages",
         "//doc/doxygen_cxx:build",
         "//doc/pydrake:build",
         "//doc/styleguide:build",
     ],
-    deps = [
-        "@bazel_tools//tools/python/runfiles",
+    test_rule_args = [
+        "--out_dir=<test>",
+        # Only generate some modules, so that the test provides quick feedback.
+        "--quick",
+        "drake/math",
+        "pages",
+        "pydrake.math",
+        "sitemap",
+        "styleguide",
     ],
-)
-
-# This rule is used by our CI scripts as a single point of entry to ensure that
-# all of our documentation binaries can be built successfully.  The "manual" in
-# its name is a bit of a misnomer (these all used to be tagged as manual, but
-# we no longer need to exclude them from the build); all of these binaries are
-# part of the default `bazel build //...`.
-filegroup(
-    name = "manual_binaries",
-    srcs = [
-        ":build",
-        ":pages",
-        "//doc/doxygen_cxx:build",
-        "//doc/pydrake:build",
-        "//doc/styleguide:build",
+    test_rule_tags = DEFAULT_TEST_TAGS,
+    deps = [
+        ":defs",
+        "@bazel_tools//tools/python/runfiles",
     ],
 )
 
@@ -138,6 +134,7 @@ test_suite(
     name = "manual_tests",
     tags = ["manual"],
     tests = [
+        ":build_test",
         ":pages_test",
         "//doc/doxygen_cxx:build_test",
         "//doc/pydrake:build_test",

--- a/doc/_pages/documentation_instructions.md
+++ b/doc/_pages/documentation_instructions.md
@@ -2,89 +2,115 @@
 title: Documentation Generation Instructions
 ---
 
-This page contains instructions on how to generate Drake's documentation,
-which uses a combination of
-[Jekyll](https://jekyllrb.com/),
-[Sphinx](http://www.sphinx-doc.org/en/stable/index.html), and
-[Doxygen](https://www.doxygen.nl/index.html).
-This includes [Drake's main website](https://drake.mit.edu/) and
-API documentation
-([C++](https://drake.mit.edu/doxygen_cxx/index.html) and
-[Python](https://drake.mit.edu/pydrake/index.html)).
+This page contains instructions on how to locally regenerate Drake's website.
 
+The website infrastructure uses a combination of
+[Jekyll](https://jekyllrb.com/) for the
+[main site](https://drake.mit.edu/) and
+[Style Guide](https://drake.mit.edu/styleguide/cppguide.html),
+[Doxygen](https://www.doxygen.nl/) for the
+[C++ API reference](https://drake.mit.edu/doxygen_cxx/), and
+[Sphinx](http://www.sphinx-doc.org/en/stable/) for the
+[Python API reference](https://drake.mit.edu/pydrake/).
+
+# Prerequisites
 
 Documentation generation and preview as described in this document are
-supported on Ubuntu only.
+supported on **Ubuntu only**.
 
-Before getting started, install Drake's prerequisites with the
+Before getting started, install Drake's prerequisites with the additional
 ``--with-doc-only`` command line option, i.e.:
 
-```
-$ ./setup/ubuntu/install_prereqs.sh --with-doc-only
-```
-
-# Drake's main website
-
-To preview changes locally:
-
-```
-$ bazel run //doc:pages -- --serve
+```sh
+$ sudo setup/ubuntu/install_prereqs.sh --with-doc-only
 ```
 
-To create output in the specified out_dir:
+# Previewing changes
 
-```
-$ bazel run //doc:pages -- --out_dir
-```
+To easily preview your changes, run the ``//doc:build --serve`` command.
 
-The output directory must not already exist.
+```sh
+# Read the usage message.
+$ bazel run //doc:build -- --help
 
-# Drake's API documentation
+# Preview the entire site, exactly how it will appear online.
+$ bazel run //doc:build -- --serve
 
-To generate the C++ API documentation:
+# Speed up the preview by limiting it to major section(s):
+$ bazel run //doc:build -- --serve pages       # Only the main site.
+$ bazel run //doc:build -- --serve doxygen     # Only the C++ API reference.
+$ bazel run //doc:build -- --serve pydrake     # Only the Python API reference.
+$ bazel run //doc:build -- --serve styleguide  # Only the Style Guide.
 
-```
-$ bazel run //doc/doxygen_cxx:build -- --serve
-```
+# Further speed up preview generating only some API modules, e.g., math:
+$ bazel run //doc:build -- --serve drake.math            # C++ math API.
+$ bazel run //doc:build -- --serve pydrake.math          # Python math API.
+$ bazel run //doc:build -- --serve {drake,pydrake}.math  # Both at once.
 
-If you only need to preview a subset of the API, you can speed up the
-rebuild by listing a subset of module names on the command line:
+# Further speed up preview by omitting expensive `dot` graphs:
+$ bazel run //doc:build -- --serve --quick drake.math
 
-```
-$ bazel run //doc/doxygen_cxx:build -- --serve drake/math
-```
-
-You may also specify ``--quick`` to skip the image generation.
-
-To generate the Python API documentation:
-
-```
-$ bazel run //doc/pydrake:build -- --serve
-```
-
-If you only need to preview a subset of the API, you can speed up the
-rebuild by listing a subset of module names on the command line:
-
-```
-$ bazel run //doc/pydrake:build -- --serve pydrake.common pydrake.math
+# Further speed up preview by avoiding rebuilding pydrake:
+$ bazel run //doc/doxygen_cxx:build -- --serve --quick drake.math
 ````
 
-# Style Guide
-
-To locally preview the Drake Style Guide:
-
-```
-$ bazel run //doc/styleguide:build -- --serve
-```
-
-To preview a local branch of the styleguide, set the
+To preview using a local branch of the styleguide instead of our pinned
+revision, be sure to set the
 [local_repository_override](https://github.com/RobotLocomotion/drake/blob/master/tools/workspace/README.md#exploring-github_archive-changes-from-a-local-clone)
-option in ``drake/tools/workspace/styleguide/`` before running the preview.
+option in ``drake/tools/workspace/styleguide/repository.bzl`` before running
+the preview command.
 
-# Continuous Integration
+# Testing locally
 
-To check that the documentation will pass Drake's Jenkins CI builds:
+The website is not part of Drake's default local build nor tests, because it
+requires heavy prerequisites to be installed (see ``--with-doc-only`` above).
+Therefore, a simple ``bazel test //...`` will not provide any feedback about
+local documentation edits.
+
+To check locally that documentation changes pass all build and test rules, run:
+
+<!-- Don't use "sh" literal mode here; it mis-colors the "test" non-keyword. -->
+```
+$ bazel test //doc/... //doc:manual_tests
+```
+
+# Testing in CI
+
+Only the Jenkins builds whose name ends with ``-documentation`` will run the
+documentation build steps and related tests.  By default, those builds run on
+the Continuous (i.e., post-merge) and Nightly schedules, not on pull requests.
+If you would like to check Jenkins results on a pull request, you need to
+[schedule an on-demand build](/jenkins.html#scheduling-an-on-demand-build)
+by posting a comment
 
 ```
-$ bazel test //doc:manual_tests //doc:manual_binaries
+@drake-jenkins-bot linux-bionic-unprovisioned-gcc-bazel-experimental-documentation please
 ```
+
+# Advanced Building
+
+This section contains details aimed at documentation infrastructure
+maintainers.
+
+There are in fact five available commands:
+
+```sh
+$ bazel run //doc:build               # Entire website (i.e., all of the below).
+$ bazel run //doc:pages_build         # Main site only.
+$ bazel run //doc/doxygen_cxx:build   # C++ API reference subdir only.
+$ bazel run //doc/pydrake:build       # Python API reference subdir only.
+$ bazel run //doc/styleguide:build    # Style Guide subdir only.
+```
+
+The first command provides options to rebuild subsets of the website, and so
+offers one-stop shopping for developers, as explained in the prior section.
+The latter commands are used for focused regression testing, and might be
+more convenient while modifying the documentation tooling.
+
+Each build command can be run in either "generate" mode (writing the files into
+a scratch folder) or "serve" mode (http serving for web browser preview).  The
+automated website deployment pipeline uses the former; most developers will use
+the latter.
+
+Each build command has a corresponding test defined as part of the
+``//doc:manual_tests`` test suite.

--- a/doc/build.py
+++ b/doc/build.py
@@ -1,54 +1,95 @@
 """Command-line tool to generate the full drake.mit.edu website contents.
 
-For now, this tool is only intended to be used by Drake's CI tooling.  In the
-future, we will enhance and document it for developer use.
+For instructions, see https://drake.mit.edu/documentation_instructions.html.
 """
 
-import argparse
 import os.path
 from pathlib import Path
-import shlex
-import subprocess
+import sys
 import urllib.parse
 
 from bazel_tools.tools.python.runfiles import runfiles
 import lxml.etree as ET
 
-
-def _check_call(args):
-    print("+ " + " ".join([shlex.quote(x) for x in args]), flush=True)
-    proc = subprocess.run(args, stderr=subprocess.STDOUT)
-    proc.check_returncode()
+from drake.doc.defs import check_call, main
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description=__doc__.strip())
-    parser.add_argument(
-        "--out_dir", type=str, metavar="DIR", required=True,
-        help="Output directory. Must be an absolute path and must not exist.")
+def _build(*, out_dir, temp_dir, quick, modules):
+    """Callback function that implements the bulk of main().
+    Generates into out_dir; writes scratch files into temp_dir.
+    As a precondition, both directories must already exist and be empty.
 
-    args = parser.parse_args()
-    out_dir = args.out_dir
-    if not os.path.isabs(out_dir):
-        parser.error(f"--out_dir={out_dir} is not an absolute path")
-    if os.path.exists(out_dir):
-        parser.error(f"--out_dir={out_dir} already exists")
-
+    If provided, the given modules can be either API reference modules such as
+    "drake.math" (C++) or "pydrake.math" (Python), or else the name of website
+    sections such as "pages", "styleguide", "pydrake", "doxygen_cxx", or etc.
+    """
+    # Find all of our helper tools.
     manifest = runfiles.Create()
     pages_build = manifest.Rlocation("drake/doc/pages")
+    styleguide_build = manifest.Rlocation("drake/doc/styleguide/build")
     pydrake_build = manifest.Rlocation("drake/doc/pydrake/build")
     doxygen_build = manifest.Rlocation("drake/doc/doxygen_cxx/build")
-    styleguide_build = manifest.Rlocation("drake/doc/styleguide/build")
-    for item in [pages_build, pydrake_build, doxygen_build, styleguide_build]:
+    for item in [pages_build, styleguide_build, pydrake_build, doxygen_build]:
         assert item and os.path.exists(item), item
 
-    _check_call([pages_build, f"--out_dir={out_dir}"])
-    _check_call([pydrake_build, f"--out_dir={out_dir}/pydrake"])
-    _check_call([styleguide_build, f"--out_dir={out_dir}/styleguide"])
-    _check_call([doxygen_build, f"--out_dir={out_dir}/doxygen_cxx"])
+    # Figure out which modules to ask for from each helper tool.
+    do_pages = True
+    do_styleguide = True
+    do_pydrake = True
+    do_doxygen = True
+    do_sitemap = True
+    pydrake_modules = []
+    doxygen_modules = []
+    if modules:
+        do_pages = False
+        do_styleguide = False
+        do_pydrake = False
+        do_doxygen = False
+        do_sitemap = False
+    for module in modules:
+        if module in ["pages"]:
+            do_pages = True
+        elif module in ["styleguide", "cppguide", "pyguide"]:
+            do_styleguide = True
+        elif module in ["pydrake"]:
+            do_pydrake = True
+        elif module in ["doxygen_cxx", "doxygen", "cxx"]:
+            do_doxygen = True
+        elif module in ["sitemap"]:
+            do_sitemap = True
+        elif module.startswith("pydrake."):
+            do_pydrake = True
+            pydrake_modules.append(module)
+        elif module.startswith("drake."):
+            do_doxygen = True
+            doxygen_modules.append(module)
+        else:
+            print(f"error: Unknown module '{module}'")
+            sys.exit(1)
 
-    _build_sitemap(out_dir)
+    # Invoke all of our helper tools.
+    if do_pages:
+        check_call([pages_build, f"--out_dir={out_dir}"])
+    if do_styleguide:
+        check_call([styleguide_build, f"--out_dir={out_dir}/styleguide"])
+    if do_pydrake:
+        check_call([pydrake_build, f"--out_dir={out_dir}/pydrake"]
+                   + pydrake_modules)
+    if do_doxygen:
+        maybe_quick = ["--quick"] if quick else []
+        check_call([doxygen_build, f"--out_dir={out_dir}/doxygen_cxx"]
+                   + doxygen_modules + maybe_quick)
+    if do_sitemap:
+        _build_sitemap(out_dir)
+
+    # The filenames to suggest as the starting point for preview.
+    result = []
+    result.append("") if do_pages else None
+    result.append("styleguide/cppguide.html") if do_styleguide else None
+    result.append("styleguide/pyguide.html") if do_styleguide else None
+    result.append("pydrake/") if do_pydrake else None
+    result.append("doxygen_cxx/") if do_doxygen else None
+    return result
 
 
 def _build_sitemap(site_dir: str) -> None:
@@ -100,4 +141,5 @@ def _build_sitemap(site_dir: str) -> None:
 
 
 if __name__ == '__main__':
-    main()
+    main(build=_build, subdir="", description=__doc__.strip(),
+         supports_modules=True, supports_quick=True)

--- a/doc/doxygen_cxx/BUILD.bazel
+++ b/doc/doxygen_cxx/BUILD.bazel
@@ -68,10 +68,13 @@ drake_py_binary(
         "@bazel_tools//tools/python/runfiles",
         "@doxygen",
     ],
-    test_rule_args = ["--out_dir=<test>"],
-    test_rule_size = "medium",
+    test_rule_args = [
+        "--out_dir=<test>",
+        # Only generate some modules, so that the test provides quick feedback.
+        "--quick",
+        "drake/math",
+    ],
     test_rule_tags = DEFAULT_TEST_TAGS,
-    test_rule_timeout = "long",
     visibility = ["//doc:__pkg__"],
     deps = [
         "//doc:defs",

--- a/doc/doxygen_cxx/build.py
+++ b/doc/doxygen_cxx/build.py
@@ -103,7 +103,7 @@ def _generate_doxyfile(*, manifest, out_dir, temp_dir, dot):
 
 def _build(*, out_dir, temp_dir, modules, quick):
     """Generates into out_dir; writes scratch files into temp_dir.
-    Both directories must already exist and be empty.
+    As a precondition, both directories must already exist and be empty.
     """
     manifest = runfiles.Create()
 

--- a/doc/pages.py
+++ b/doc/pages.py
@@ -13,7 +13,7 @@ from drake.doc.defs import check_call, main, symlink_input
 def _build(*, out_dir, temp_dir):
     """Callback function that implements the bulk of main().
     Generates into out_dir; writes scratch files into temp_dir.
-    Both directories must already exist and be empty.
+    As a precondition, both directories must already exist and be empty.
     """
     # Create a hermetic copy of our input.  This helps ensure that only files
     # listed in BUILD.bazel will render onto the website.

--- a/doc/pydrake/BUILD.bazel
+++ b/doc/pydrake/BUILD.bazel
@@ -46,8 +46,11 @@ drake_py_binary(
         ":sphinx_input",
         ":sphinx_input.txt",
     ],
-    test_rule_args = ["--out_dir=<test>"],
-    test_rule_size = "medium",
+    test_rule_args = [
+        "--out_dir=<test>",
+        # Only generate some modules, so that the test provides quick feedback.
+        "pydrake.math",
+    ],
     test_rule_tags = DEFAULT_TEST_TAGS,
     visibility = ["//doc:__pkg__"],
     deps = [

--- a/doc/pydrake/build.py
+++ b/doc/pydrake/build.py
@@ -107,7 +107,7 @@ def _write_module(name, f_name):
 
 def _build(*, out_dir, temp_dir, modules):
     """Generates into out_dir; writes scratch files into temp_dir.
-    Both directories must already exist and be empty.
+    As a precondition, both directories must already exist and be empty.
     If modules are provided, only generate those modules and their children.
     """
     assert len(os.listdir(temp_dir)) == 0

--- a/doc/styleguide/BUILD.bazel
+++ b/doc/styleguide/BUILD.bazel
@@ -40,9 +40,7 @@ drake_py_binary(
         ":jekyll_input.txt",
     ],
     test_rule_args = ["--out_dir=<test>"],
-    test_rule_size = "medium",
     test_rule_tags = DEFAULT_TEST_TAGS,
-    test_rule_timeout = "short",
     visibility = ["//doc:__pkg__"],
     deps = [
         "//doc:defs",

--- a/doc/styleguide/build.py
+++ b/doc/styleguide/build.py
@@ -31,7 +31,7 @@ def _add_title(*, temp_dir, filename, title):
 def _build(*, out_dir, temp_dir):
     """Callback function that implements the bulk of main().
     Generates into out_dir; writes scratch files into temp_dir.
-    Both directories must already exist and be empty.
+    As a precondition, both directories must already exist and be empty.
     """
     # Create a hermetic copy of our input.  This helps ensure that only files
     # listed in BUILD.bazel will render onto the website.


### PR DESCRIPTION
Remove manual_binaries filegroup; it is no longer used by drake-ci.

Change regression tests to use submodules for quicker turn-around.

(This is the final step of #14803.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14954)
<!-- Reviewable:end -->
