### PR TITLE
pydrake: Add `__repr__` to several classes

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -976,13 +976,22 @@ void DoScalarIndependentDefinitions(py::module m) {
   {
     using Class = DrakeVisualizerParams;
     constexpr auto& cls_doc = doc.DrakeVisualizerParams;
-    py::class_<Class>(m, "DrakeVisualizerParams", cls_doc.doc)
+    py::class_<Class>(
+        m, "DrakeVisualizerParams", py::dynamic_attr(), cls_doc.doc)
         .def(ParamInit<Class>())
         .def_readwrite("publish_period", &DrakeVisualizerParams::publish_period,
             cls_doc.publish_period.doc)
         .def_readwrite("role", &DrakeVisualizerParams::role, cls_doc.role.doc)
         .def_readwrite("default_color", &DrakeVisualizerParams::default_color,
-            cls_doc.default_color.doc);
+            cls_doc.default_color.doc)
+        .def("__repr__", [](const Class& self) {
+          return py::str(
+              "DrakeVisualizerParams("
+              "publish_period={}, "
+              "role={}, "
+              "default_color={})")
+              .format(self.publish_period, self.role, self.default_color);
+        });
   }
 
   // Shape constructors

--- a/bindings/pydrake/perception_py.cc
+++ b/bindings/pydrake/perception_py.cc
@@ -43,7 +43,10 @@ void init_pc_flags(py::module m) {
         .def(py::self | py::self)
         .def(py::self & py::self)
         .def(py::self == py::self)
-        .def(py::self != py::self);
+        .def(py::self != py::self)
+        .def("__repr__", [](const Class& self) {
+          return py::str("Fields(base_fields={})").format(self.base_fields());
+        });
   }
 }
 

--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -64,7 +64,11 @@ PYBIND11_MODULE(analysis, m) {
         .def(ParamInit<Class>())
         .def_readwrite("suppress_initialization_events",
             &Class::suppress_initialization_events,
-            cls_doc.suppress_initialization_events.doc);
+            cls_doc.suppress_initialization_events.doc)
+        .def("__repr__", [](const Class& self) {
+          return py::str("InitializeParams(suppress_initialization_events={})")
+              .format(self.suppress_initialization_events);
+        });
   }
 
   auto bind_scalar_types = [m](auto dummy) {
@@ -253,7 +257,14 @@ PYBIND11_MODULE(analysis, m) {
             doc.RegionOfAttractionOptions.lyapunov_candidate.doc)
         .def_readwrite("state_variables",
             &RegionOfAttractionOptions::state_variables,
-            doc.RegionOfAttractionOptions.state_variables.doc);
+            doc.RegionOfAttractionOptions.state_variables.doc)
+        .def("__repr__", [](const RegionOfAttractionOptions& self) {
+          return py::str(
+              "RegionOfAttractionOptions("
+              "lyapunov_candidate={}, "
+              "state_variables={})")
+              .format(self.lyapunov_candidate, self.state_variables);
+        });
 
     m.def("RegionOfAttraction", &RegionOfAttraction, py::arg("system"),
         py::arg("context"), py::arg("options") = RegionOfAttractionOptions(),

--- a/bindings/pydrake/systems/controllers_py.cc
+++ b/bindings/pydrake/systems/controllers_py.cc
@@ -265,8 +265,17 @@ PYBIND11_MODULE(controllers, m) {
           doc.FiniteHorizonLinearQuadraticRegulatorOptions.N.doc)
       .def_readwrite("input_port_index",
           &FiniteHorizonLinearQuadraticRegulatorOptions::input_port_index,
-          doc.FiniteHorizonLinearQuadraticRegulatorOptions.input_port_index
-              .doc);
+          doc.FiniteHorizonLinearQuadraticRegulatorOptions.input_port_index.doc)
+      .def("__repr__",
+          [](const FiniteHorizonLinearQuadraticRegulatorOptions& self) {
+            return py::str(
+                "FiniteHorizonLinearQuadraticRegulatorOptions("
+                "Qf={}, "
+                "N={}, "
+                "input_port_index={})")
+                .format(self.Qf, self.N, self.input_port_index);
+          });
+
   DefReadWriteKeepAlive(&fhlqr_options, "x0",
       &FiniteHorizonLinearQuadraticRegulatorOptions::x0,
       doc.FiniteHorizonLinearQuadraticRegulatorOptions.x0.doc);

--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -51,8 +51,11 @@ void DefineFrameworkPySemantics(py::module m) {
   using namespace drake::systems;
   constexpr auto& doc = pydrake_doc.drake.systems;
 
-  py::class_<UseDefaultName> use_default_name_cls(
-      m, "UseDefaultName", doc.UseDefaultName.doc);
+  {
+    using Class = UseDefaultName;
+    py::class_<Class>(m, "UseDefaultName", doc.UseDefaultName.doc)
+        .def("__repr__", [](const Class&) { return "kUseDefaultName"; });
+  }
   m.attr("kUseDefaultName") = kUseDefaultName;
 
   py::enum_<PortDataType>(m, "PortDataType")

--- a/bindings/pydrake/systems/test/analysis_test.py
+++ b/bindings/pydrake/systems/test/analysis_test.py
@@ -27,6 +27,10 @@ class TestAnalysis(unittest.TestCase):
         options.lyapunov_candidate = x*x
         options.state_variables = [x]
         V = RegionOfAttraction(system=sys, context=context, options=options)
+        self.assertEqual(repr(options), "".join([
+            "RegionOfAttractionOptions(",
+            "lyapunov_candidate=pow(x, 2), ",
+            "state_variables=[Variable('x', Continuous)])"]))
 
     def test_integrator_constructors(self):
         """Test all constructors for all integrator types."""

--- a/bindings/pydrake/systems/test/controllers_test.py
+++ b/bindings/pydrake/systems/test/controllers_test.py
@@ -337,6 +337,13 @@ class TestControllers(unittest.TestCase):
         self.assertIsNone(options.ud)
         self.assertEqual(options.input_port_index,
                          InputPortSelection.kUseFirstInputIfItExists)
+        self.assertRegex(repr(options), "".join([
+            r"FiniteHorizonLinearQuadraticRegulatorOptions\(",
+            # Don't be particular about numpy's whitespace in Qf.
+            r"Qf=\[\[ *1\. *0\.\]\s*\[ *0\. *1\.\]\], "
+            r"N=None, ",
+            r"input_port_index=",
+            r"InputPortSelection.kUseFirstInputIfItExists\)"]))
 
         context = double_integrator.CreateDefaultContext()
         double_integrator.get_input_port(0).FixValue(context, 0.0)

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -441,9 +441,14 @@ class TestGeneral(unittest.TestCase):
             # Reuse simulator over the same time interval, without
             # initialization events.
             context.SetTime(0.)
-            simulator.Initialize(InitializeParams(
-                suppress_initialization_events=True))
+            params = InitializeParams(suppress_initialization_events=True)
+            simulator.Initialize(params)
             simulator.AdvanceTo(1)
+
+            # Check repr while we're here.
+            self.assertEqual(repr(params), "".join([
+                "InitializeParams("
+                "suppress_initialization_events=True)"]))
 
     def test_copy(self):
         # Copy a context using `deepcopy` or `clone`.
@@ -881,3 +886,6 @@ class TestGeneral(unittest.TestCase):
         self.assertEqual(adder1.get_name(), "adder1")
         adder2 = builder.AddNamedSystem(name="adder2", system=Adder(5, 8))
         self.assertEqual(adder2.get_name(), "adder2")
+
+    def test_module_constants(self):
+        self.assertEqual(repr(kUseDefaultName), "kUseDefaultName")

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -292,6 +292,11 @@ class TestGeometry(unittest.TestCase):
         params = mut.DrakeVisualizerParams(
             publish_period=0.1, role=mut.Role.kIllustration,
             default_color=mut.Rgba(0.1, 0.2, 0.3, 0.4))
+        self.assertEqual(repr(params), "".join([
+            "DrakeVisualizerParams("
+            "publish_period=0.1, "
+            "role=Role.kIllustration, "
+            "default_color=Rgba(r=0.1, g=0.2, b=0.3, a=0.4))"]))
 
         # Add some subscribers to detect message broadcast.
         load_channel = "DRAKE_VIEWER_LOAD_ROBOT"

--- a/bindings/pydrake/test/perception_test.py
+++ b/bindings/pydrake/test/perception_test.py
@@ -22,6 +22,12 @@ class TestPerception(unittest.TestCase):
         self.assertEqual(fields, fields)
         fields_none = mut.Fields(enum.kNone)
         self.assertNotEqual(fields, fields_none)
+        # TODO(jwnimmer-tri) Ideally, these would map back to the bitwise
+        # constants, but for now this works; the ctor accepts bare ints.
+        self.assertEqual(repr(fields_none), "Fields(base_fields=0)")
+        self.assertEqual(repr(fields), "Fields(base_fields=2)")
+        repr_and_back = eval(repr(fields), dict(Fields=mut.Fields))
+        self.assertEqual(repr_and_back.base_fields(), enum.kXYZs)
 
     def check_array(self, x, dtype_expected, shape_expected):
         x = np.asarray(x)


### PR DESCRIPTION
Specifically, add `__repr__` for:
- pydrake.geometry.DrakeVisualizerParams
- pydrake.perception.Fields
- pydrake.systems.analysis.InitializeParams
- pydrake.systems.analysis.RegionOfAttractionOptions
- pydrake.systems.controllers.FiniteHorizonLinearQuadraticRegulatorOptions
- pydrake.systems.framework.UseDefaultName

Closes #13987.

I finally got fed up with commits like https://github.com/RobotLocomotion/RobotLocomotion.github.io/commit/8940aefddd1dfbe275fba1eaa9da2df5ee052367 being filled with spam, so I decided to break out some repr learning.

Using dataclasses or `__dict__` might be superior for frequently-changing types, but the boring thing seems sufficient for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14959)
<!-- Reviewable:end -->
