### PR TITLE
Implements SpaceXYZFloatingMobilizer

### DIFF
--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -121,6 +121,7 @@ drake_cc_library(
         "revolute_mobilizer.cc",
         "revolute_spring.cc",
         "rigid_body.cc",
+        "space_xyz_floating_mobilizer.cc",
         "space_xyz_mobilizer.cc",
         "uniform_gravity_field_element.cc",
         "universal_joint.cc",
@@ -160,6 +161,7 @@ drake_cc_library(
         "revolute_mobilizer.h",
         "revolute_spring.h",
         "rigid_body.h",
+        "space_xyz_floating_mobilizer.h",
         "space_xyz_mobilizer.h",
         "uniform_gravity_field_element.h",
         "universal_joint.h",
@@ -426,6 +428,15 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "space_xyz_mobilizer_test",
+    deps = [
+        ":mobilizer_tester",
+        ":tree",
+        "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "space_xyz_floating_mobilizer_test",
     deps = [
         ":mobilizer_tester",
         ":tree",

--- a/multibody/tree/mobilizer_impl.cc
+++ b/multibody/tree/mobilizer_impl.cc
@@ -29,6 +29,8 @@ class MobilizerImpl2x2 : public MobilizerImpl<T, 2, 2> {};
 template <typename T>
 class MobilizerImpl3x3 : public MobilizerImpl<T, 3, 3> {};
 template <typename T>
+class MobilizerImpl6x6 : public MobilizerImpl<T, 6, 6> {};
+template <typename T>
 class MobilizerImpl7x6 : public MobilizerImpl<T, 7, 6> {};
 
 }  // namespace internal
@@ -43,5 +45,7 @@ DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::internal::MobilizerImpl2x2)
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::internal::MobilizerImpl3x3)
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::internal::MobilizerImpl6x6)
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::multibody::internal::MobilizerImpl7x6)

--- a/multibody/tree/space_xyz_floating_mobilizer.cc
+++ b/multibody/tree/space_xyz_floating_mobilizer.cc
@@ -1,0 +1,405 @@
+#include "drake/multibody/tree/space_xyz_floating_mobilizer.h"
+
+#include <memory>
+#include <stdexcept>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/eigen_types.h"
+#include "drake/math/roll_pitch_yaw.h"
+#include "drake/math/rotation_matrix.h"
+#include "drake/multibody/tree/multibody_tree.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+template <typename T>
+Vector6<T> SpaceXYZFloatingMobilizer<T>::get_generalized_positions(
+    const systems::Context<T>& context) const {
+  return this->get_positions(context);
+}
+
+template <typename T>
+Vector6<T> SpaceXYZFloatingMobilizer<T>::get_generalized_velocities(
+    const systems::Context<T>& context) const {
+  return this->get_velocities(context);
+}
+
+template <typename T>
+Vector3<T> SpaceXYZFloatingMobilizer<T>::get_angles(
+    const systems::Context<T>& context) const {
+  return this->get_positions(context).template head<3>();
+}
+
+template <typename T>
+Vector3<T> SpaceXYZFloatingMobilizer<T>::get_translation(
+    const systems::Context<T>& context) const {
+  return this->get_positions(context).template tail<3>();
+}
+
+template <typename T>
+Vector3<T> SpaceXYZFloatingMobilizer<T>::get_angular_velocity(
+    const systems::Context<T>& context) const {
+  return this->get_velocities(context).template head<3>();
+}
+
+template <typename T>
+Vector3<T> SpaceXYZFloatingMobilizer<T>::get_translational_velocity(
+    const systems::Context<T>& context) const {
+  return this->get_velocities(context).template tail<3>();
+}
+
+template <typename T>
+const SpaceXYZFloatingMobilizer<T>& SpaceXYZFloatingMobilizer<T>::set_angles(
+    systems::Context<T>* context, const Vector3<T>& angles) const {
+  auto q = this->get_mutable_positions(context).template head<3>();
+  q = angles;
+  return *this;
+}
+
+template <typename T>
+const SpaceXYZFloatingMobilizer<T>&
+SpaceXYZFloatingMobilizer<T>::set_translation(systems::Context<T>* context,
+                                              const Vector3<T>& p_FM) const {
+  auto q = this->get_mutable_positions(context).template tail<3>();
+  q = p_FM;
+  return *this;
+}
+
+template <typename T>
+const SpaceXYZFloatingMobilizer<T>&
+SpaceXYZFloatingMobilizer<T>::set_angular_velocity(
+    systems::Context<T>* context, const Vector3<T>& w_FM) const {
+  auto v = this->get_mutable_velocities(context).template head<3>();
+  v = w_FM;
+  return *this;
+}
+
+template <typename T>
+const SpaceXYZFloatingMobilizer<T>&
+SpaceXYZFloatingMobilizer<T>::set_translational_velocity(
+    systems::Context<T>* context, const Vector3<T>& v_FM) const {
+  auto v = this->get_mutable_velocities(context).template tail<3>();
+  v = v_FM;
+  return *this;
+}
+
+template <typename T>
+const SpaceXYZFloatingMobilizer<T>&
+SpaceXYZFloatingMobilizer<T>::SetFromRigidTransform(
+    systems::Context<T>* context, const math::RigidTransform<T>& X_FM) const {
+  set_angles(context, math::RollPitchYaw<T>(X_FM.rotation()).vector());
+  set_translation(context, X_FM.translation());
+  return *this;
+}
+
+template <typename T>
+math::RigidTransform<T>
+SpaceXYZFloatingMobilizer<T>::CalcAcrossMobilizerTransform(
+    const systems::Context<T>& context) const {
+  const auto rpy = this->get_angles(context);
+  const auto p_FM = this->get_translation(context);
+  const math::RollPitchYaw<T> roll_pitch_yaw(rpy(0), rpy(1), rpy(2));
+  return math::RigidTransform<T>(roll_pitch_yaw, p_FM);
+}
+
+template <typename T>
+SpatialVelocity<T>
+SpaceXYZFloatingMobilizer<T>::CalcAcrossMobilizerSpatialVelocity(
+    const systems::Context<T>&, const Eigen::Ref<const VectorX<T>>& v) const {
+  DRAKE_ASSERT(v.size() == kNv);
+  return SpatialVelocity<T>(v);
+}
+
+template <typename T>
+SpatialAcceleration<T>
+SpaceXYZFloatingMobilizer<T>::CalcAcrossMobilizerSpatialAcceleration(
+    const systems::Context<T>&,
+    const Eigen::Ref<const VectorX<T>>& vdot) const {
+  DRAKE_ASSERT(vdot.size() == kNv);
+  return SpatialAcceleration<T>(vdot);
+}
+
+template <typename T>
+void SpaceXYZFloatingMobilizer<T>::ProjectSpatialForce(
+    const systems::Context<T>&, const SpatialForce<T>& F_Mo_F,
+    Eigen::Ref<VectorX<T>> tau) const {
+  DRAKE_ASSERT(tau.size() == kNv);
+  tau = F_Mo_F.get_coeffs();
+}
+
+template <typename T>
+void SpaceXYZFloatingMobilizer<T>::DoCalcNMatrix(
+    const systems::Context<T>& context, EigenPtr<MatrixX<T>> N) const {
+  using std::abs;
+  using std::cos;
+  using std::sin;
+
+  // The linear map E_F(q) allows computing v from q̇ as:
+  // w_FM = E_F(q) * q̇; q̇ = [ṙ, ṗ, ẏ]ᵀ
+  //
+  // Here, following a convention used by many dynamicists, we are calling the
+  // angles q0, q1, q2 as roll (r), pitch (p) and yaw (y), respectively.
+  //
+  // The linear map from v to q̇ is given by the inverse of E_F(q):
+  //          [          cos(y) / cos(p),          sin(y) / cos(p), 0]
+  // Einv_F = [                  -sin(y),                   cos(y), 0]
+  //          [ sin(p) * cos(y) / cos(p), sin(p) * sin(y) / cos(p), 1]
+  //
+  // such that q̇ = Einv_F(q) * w_FM; q̇ = [ṙ, ṗ, ẏ]ᵀ
+  // See developer notes in MapVelocityToQdot() for further details.
+
+  const Vector3<T> angles = get_angles(context);
+  const T cp = cos(angles[1]);
+  // Demand for the computation to be away from a state for which Einv_F is
+  // singular.
+  DRAKE_DEMAND(abs(cp) > 1.0e-3);
+
+  const T sp = sin(angles[1]);
+  const T sy = sin(angles[2]);
+  const T cy = cos(angles[2]);
+  const T cpi = 1.0 / cp;
+
+  const T cy_x_cpi = cy * cpi;
+  const T sy_x_cpi = sy * cpi;
+
+  Matrix3<T> Einv_F;
+  // clang-format off
+  Einv_F <<
+         cy_x_cpi,      sy_x_cpi, 0.0,
+              -sy,            cy, 0.0,
+    cy_x_cpi * sp, sy_x_cpi * sp, 1.0;
+  // clang-format on
+
+  N->setIdentity();
+  N->template topLeftCorner<3, 3>() = Einv_F;
+}
+
+template <typename T>
+void SpaceXYZFloatingMobilizer<T>::DoCalcNplusMatrix(
+    const systems::Context<T>& context, EigenPtr<MatrixX<T>> Nplus) const {
+  // The linear map between q̇ and v is given by matrix E_F(q) defined by:
+  //          [ cos(y) * cos(p), -sin(y), 0]
+  // E_F(q) = [ sin(y) * cos(p),  cos(y), 0]
+  //          [         -sin(p),       0, 1]
+  //
+  // w_FM = E_F(q) * q̇; q̇ = [ṙ, ṗ, ẏ]ᵀ
+  //
+  // Here, following a convention used by many dynamicists, we are calling the
+  // angles q0, q1, q2 as roll (r), pitch (p) and yaw (y), respectively.
+  //
+  // See detailed developer comments for E_F(q) in the implementation for
+  // MapQDotToVelocity().
+
+  const Vector3<T> angles = get_angles(context);
+
+  const T sp = sin(angles[1]);
+  const T cp = cos(angles[1]);
+  const T sy = sin(angles[2]);
+  const T cy = cos(angles[2]);
+
+  Matrix3<T> E_F;
+  // clang-format off
+  E_F <<
+    cy * cp, -sy, 0.0,
+    sy * cp,  cy, 0.0,
+        -sp, 0.0, 1.0;
+  // clang-format on
+
+  Nplus->setIdentity();
+  Nplus->template topLeftCorner<3, 3>() = E_F;
+}
+
+template <typename T>
+void SpaceXYZFloatingMobilizer<T>::MapVelocityToQDot(
+    const systems::Context<T>& context, const Eigen::Ref<const VectorX<T>>& v,
+    EigenPtr<VectorX<T>> qdot) const {
+  DRAKE_ASSERT(v.size() == kNv);
+  DRAKE_ASSERT(qdot != nullptr);
+  DRAKE_ASSERT(qdot->size() == kNq);
+
+  using std::abs;
+  using std::cos;
+  using std::sin;
+
+  // The linear map E_F(q) allows computing v from q̇ as:
+  // w_FM = E_F(q) * q̇; q̇ = [ṙ, ṗ, ẏ]ᵀ
+  //
+  // Here, following a convention used by many dynamicists, we are calling the
+  // angles θ₁, θ₂, θ₃ as roll (r), pitch (p) and yaw (y), respectively.
+  //
+  // The linear map from v to q̇ is given by the inverse of E_F(q):
+  //          [          cos(y) / cos(p),          sin(y) / cos(p), 0]
+  // Einv_F = [                  -sin(y),                   cos(y), 0]
+  //          [ sin(p) * cos(y) / cos(p), sin(p) * sin(y) / cos(p), 1]
+  //
+  // such that q̇ = Einv_F(q) * w_FM; q̇ = [ṙ, ṗ, ẏ]ᵀ
+  // where we intentionally wrote the expression for Einv_F in terms of sines
+  // and cosines only to arrive to the more computationally efficient version
+  // below.
+  //
+  // Notice Einv_F is singular for p = π/2 + kπ, ∀ k ∈ ℤ.
+  //
+  // Note to developers:
+  // Matrix E_F(q) is obtained by computing w_FM as the composition of the
+  // angular velocity induced by each Euler angle rate in its respective
+  // body-fixed frame. This is outlined in [Diebel 2006, §5.2;
+  // Mitiguy (July 22) 2016, §9.3]. Notice however that our rotation matrix R_FM
+  // is the transpose of that in [Diebel 2006], Eq. 67, given the convention
+  // used there. Still, the expression for Einv_F in [Diebel 2006], Eq. 76, is
+  // exactly the same here presented.
+  //
+  // The expression for Einv_F was symbolically generated with the following
+  // Maxima script (which can be copy/pasted and executed as is):
+  //
+  // Rx:matrix([1,0,0],[0,cos(r),-sin(r)],[0,sin(r),cos(r)]);
+  // Ry:matrix([cos(p),0,sin(p)],[0,1,0],[-sin(p),0,cos(p)]);
+  // Rz:matrix([cos(y),-sin(y),0],[sin(y),cos(y),0],[0,0,1]);
+  // R_FM:Rz . Ry . Rx;
+  // R_MF:transpose(R_FM);
+  // E_F: transpose(append(transpose(
+  //             Rz . Ry . [1,0,0]),transpose(Rz . [0,1,0]),matrix([0,0,1])));
+  // detout: true$
+  // doallmxops: false$
+  // doscmxops: false$
+  // Einv_F: trigsimp(invert(E_F));
+  //
+  // [Diebel 2006] Representing attitude: Euler angles, unit quaternions, and
+  //               rotation vectors. Stanford University.
+  // [Mitiguy (July 22) 2016] Mitiguy, P., 2016. Advanced Dynamics & Motion
+  //                          Simulation.
+
+  const Vector3<T> angles = get_angles(context);
+  const T cp = cos(angles[1]);
+  DRAKE_DEMAND(abs(cp) > 1.0e-3);
+
+  const T& w0 = v[0];
+  const T& w1 = v[1];
+  const T& w2 = v[2];
+
+  const T sp = sin(angles[1]);
+  const T sy = sin(angles[2]);
+  const T cy = cos(angles[2]);
+  const T cpi = 1.0 / cp;
+
+  // Although the linear equations relating v to q̇ can be used to explicitly
+  // solve the equation w_FM = E_F(q) * q̇ for q̇, a more computational
+  // efficient solution results by implicit solution of those linear equations.
+  // Namely, the first two equations in w_FM = E_F(q) * q̇ are used to solve for
+  // ṙ and ṗ, then the third equation is used to solve for ẏ in terms of just
+  // ṙ and w2:
+  // ṙ = (cos(y) * w0 + sin(y) * w1) / cos(p)
+  // ṗ = -sin(y) * w0 + cos(y) * w1
+  // ẏ = sin(p) * ṙ + w2
+  const T t = (cy * w0 + sy * w1) * cpi;  // Common factor.
+  qdot->template head<3>() = Vector3<T>(t, -sy * w0 + cy * w1, sp * t + w2);
+  qdot->template tail<3>() = v.template tail<3>();
+}
+
+template <typename T>
+void SpaceXYZFloatingMobilizer<T>::MapQDotToVelocity(
+    const systems::Context<T>& context,
+    const Eigen::Ref<const VectorX<T>>& qdot, EigenPtr<VectorX<T>> v) const {
+  DRAKE_ASSERT(qdot.size() == kNq);
+  DRAKE_ASSERT(v != nullptr);
+  DRAKE_ASSERT(v->size() == kNv);
+  using std::cos;
+  using std::sin;
+
+  // The linear map between q̇ and v is given by matrix E_F(q) defined by:
+  //          [ cos(y) * cos(p), -sin(y), 0]
+  // E_F(q) = [ sin(y) * cos(p),  cos(y), 0]
+  //          [         -sin(p),       0, 1]
+  //
+  // w_FM = E_F(q) * q̇; q̇ = [ṙ, ṗ, ẏ]ᵀ
+  //
+  // Here, following a convention used by many dynamicists, we are calling the
+  // angles θ₁, θ₂, θ₃ as roll (r), pitch (p) and yaw (y), respectively.
+  //
+  // Note to developers:
+  // Matrix E_F(q) is obtained by computing w_FM as the composition of the
+  // angular velocity induced by each Euler angle rate in its respective
+  // body-fixed frame. This is outlined in [Diebel 2006, §5.2;
+  // Mitiguy (July 22) 2016, §9.3]. Notice however that our rotation matrix R_FM
+  // is the transpose of that in [Diebel 2006], Eq. 67, given the convention
+  // used there. Still, the expression for E_F in [Diebel 2006], Eq. 74, is
+  // exactly the same here presented.
+  //
+  // The expression for E_F was symbolically generated with the following
+  // Maxima script (which can be copy/pasted and executed as is):
+  //
+  // Rx:matrix([1,0,0],[0,cos(r),-sin(r)],[0,sin(r),cos(r)]);
+  // Ry:matrix([cos(p),0,sin(p)],[0,1,0],[-sin(p),0,cos(p)]);
+  // Rz:matrix([cos(y),-sin(y),0],[sin(y),cos(y),0],[0,0,1]);
+  // R_FM:Rz . Ry . Rx;
+  // R_MF:transpose(R_FM);
+  // E_F: transpose(append(transpose(
+  //             Rz . Ry . [1,0,0]),transpose(Rz . [0,1,0]),matrix([0,0,1])));
+  //
+  // [Diebel 2006] Representing attitude: Euler angles, unit quaternions, and
+  //               rotation vectors. Stanford University.
+  // [Mitiguy (July 22) 2016] Mitiguy, P., 2016. Advanced Dynamics & Motion
+  //                          Simulation.
+
+  const Vector3<T> angles = get_angles(context);
+  const T& rdot = qdot[0];
+  const T& pdot = qdot[1];
+  const T& ydot = qdot[2];
+
+  const T sp = sin(angles[1]);
+  const T cp = cos(angles[1]);
+  const T sy = sin(angles[2]);
+  const T cy = cos(angles[2]);
+  const T cp_x_rdot = cp * rdot;
+
+  // Compute the product w_FM = E_W * q̇ directly since it's cheaper than
+  // explicitly forming E_F and then multiplying with q̇.
+  // clang-format off
+  v->template head<3>() = Vector3<T>(
+    cy * cp_x_rdot    - sy * pdot, /* + 0 * ydot */
+    sy * cp_x_rdot    + cy * pdot, /* + 0 * ydot */
+        -sp * rdot /* +  0 * pdot */  +     ydot);
+  // clang-format on
+  v->template tail<3>() = qdot.template tail<3>();
+}
+
+template <typename T>
+template <typename ToScalar>
+std::unique_ptr<Mobilizer<ToScalar>>
+SpaceXYZFloatingMobilizer<T>::TemplatedDoCloneToScalar(
+    const MultibodyTree<ToScalar>& tree_clone) const {
+  const Frame<ToScalar>& inboard_frame_clone =
+      tree_clone.get_variant(this->inboard_frame());
+  const Frame<ToScalar>& outboard_frame_clone =
+      tree_clone.get_variant(this->outboard_frame());
+  return std::make_unique<SpaceXYZFloatingMobilizer<ToScalar>>(
+      inboard_frame_clone, outboard_frame_clone);
+}
+
+template <typename T>
+std::unique_ptr<Mobilizer<double>>
+SpaceXYZFloatingMobilizer<T>::DoCloneToScalar(
+    const MultibodyTree<double>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
+template <typename T>
+std::unique_ptr<Mobilizer<AutoDiffXd>>
+SpaceXYZFloatingMobilizer<T>::DoCloneToScalar(
+    const MultibodyTree<AutoDiffXd>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
+template <typename T>
+std::unique_ptr<Mobilizer<symbolic::Expression>>
+SpaceXYZFloatingMobilizer<T>::DoCloneToScalar(
+    const MultibodyTree<symbolic::Expression>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::internal::SpaceXYZFloatingMobilizer)

--- a/multibody/tree/space_xyz_floating_mobilizer.h
+++ b/multibody/tree/space_xyz_floating_mobilizer.h
@@ -1,0 +1,313 @@
+#pragma once
+
+#include <memory>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/tree/frame.h"
+#include "drake/multibody/tree/mobilizer_impl.h"
+#include "drake/multibody/tree/multibody_tree_topology.h"
+#include "drake/systems/framework/context.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+// This mobilizer introduces six degrees of freedom to model arbitrary rigid
+// body motions of an outboard frame M relative to an inboard frame F.
+// Translational motions of M in F are parametrized by the position `p_FM` of
+// frame M in F, measured in frame F.
+// As hinted by the name of this class, the orientation `R_FM` of the outboard
+// frame M in F is parameterized with space `x-y-z` Euler angles (also known as
+// extrinsic angles). That is, the generalized coordinates for this mobilizer
+// correspond to angles θ₁, θ₂, θ₃, for a sequence of rotations about the x̂,
+// ŷ, ẑ axes solidary with frame F, respectively. Mathematically, rotation
+// `R_FM` is given in terms of angles θ₁, θ₂, θ₃ by: <pre>
+//   R_FM(q) = Rz(θ₃) * Ry(θ₂) * Rx(θ₁)
+// </pre>
+// where `Rx(θ)`, `Ry(θ)` and `Rz(θ)` correspond to the elemental rotations in
+// amount of θ about the x, y and z axes respectively. Refer to
+// math::RollPitchYaw for further details on this representation.
+// Zero θ₁, θ₂, θ₃ angles and zero position `p_FM` define the "zero
+// configuration" which corresponds to frames F and M being coincident, see
+// set_zero_state(). Angles θ₁, θ₂, θ₃ are defined to be positive according to
+// the right-hand-rule with the thumb aligned in the direction of their
+// respective axes.
+//
+// The generalized velocities for this mobilizer correspond to the angular
+// velocity `w_FM` of frame M in F and to the translational velocity `v_FM` of M
+// in F, both expressed in the inboard frame F.
+//
+// While the mapping MapQDotToVelocity() always exists, its inverse
+// MapVelocityToQDot() is singular for values of θ₂ (many times referred to as
+// the pitch angle) such that `θ₂ = π/2 + kπ, ∀ k ∈ ℤ`.
+// In a related matter, there are no range limits on the allowed values of the
+// space x-y-z angles θ₁, θ₂, θ₃. All operations performed by this mobilizer are
+// valid for θᵢ ∈ ℝ. The only operations that are not well defined at
+// `θ₂ = π/2 + kπ, ∀ k ∈ ℤ` are those related with the kinematic mapping from
+// angular velocity `w_FM` to Euler angles' rates, namely MapVelocityToQDot()
+// and CalcNMatrix().
+//
+// @note Space `x-y-z` angles (extrinsic) are equivalent to Body `z-y-x` angles
+// (intrinsic).
+//
+// @note This particular choice of generalized coordinates θ₁, θ₂, θ₃ for this
+// mobilizer is many times referred to as the roll, pitch and yaw angles by
+// many dynamicists. They are also known as the Tait-Bryan angles or Cardan
+// angles.
+//
+// @note The mapping from angular velocity to Euler angle's rates is singular
+// for angle `θ₂` (many times referred to as the pitch angle) such that
+// `θ₂ = π/2 + kπ, ∀ k ∈ ℤ`.
+//
+// @tparam_default_scalar
+template <typename T>
+class SpaceXYZFloatingMobilizer final : public MobilizerImpl<T, 6, 6> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SpaceXYZFloatingMobilizer)
+
+  // Constructor for a SpaceXYZFloatingMobilizer between an inboard frame F
+  // `inboard_frame_F` and an outboard frame M `outboard_frame_M`.
+  SpaceXYZFloatingMobilizer(const Frame<T>& inboard_frame_F,
+                            const Frame<T>& outboard_frame_M)
+      : MobilizerBase(inboard_frame_F, outboard_frame_M) {}
+
+  bool is_floating() const override { return true; }
+
+  bool has_quaternion_dofs() const override { return false; }
+
+  // Returns the generalized postions for this mobilizer stored in `context`.
+  // Generalized positions q for this mobilizer are packed in exactly the
+  // following order: `q = [θ₁, θ₂, θ₃, px_FM, py_FM, pz_FM]` that is, rpy
+  // angles are stored in the first three entries of the configuration vector,
+  // followed by the three translational coordinates.
+  Vector6<T> get_generalized_positions(
+      const systems::Context<T>& context) const;
+
+  // Returns the generalized velocities for this mobilizer stored in `context`.
+  // Generalized velocities v for this mobilizer are packed in exactly the
+  // following order: `v = [wx_FM, wy_FM, wz_FM, vx_FM, vy_FM, vz_FM]` that is,
+  // the components of the angular velocity `w_FM` are stored in the first three
+  // entries of the generalized velocities vector, followed by the three
+  // components of the translational velocity `v_FM`.
+  Vector6<T> get_generalized_velocities(
+      const systems::Context<T>& context) const;
+
+  // Retrieves the three space x-y-z angles θ₁, θ₂, θ₃ stored in `context`,
+  // which describe the state for `this` mobilizer as documented in this class's
+  // documentation.
+  //
+  // @param[in] context
+  //   The context of the model this mobilizer belongs to.
+  // @retval angles
+  //   The three space x-y-z angles θ₁, θ₂, θ₃, associated with the sequence of
+  //   rotations about the space fixed axes x̂, ŷ, ẑ, respectively packed and
+  //   returned as a Vector3 with entries `angles(0) = θ₁`, `angles(1) = θ₂`,
+  //   `angles(2) = θ₃`. There are no range limits for the angular values.
+  Vector3<T> get_angles(const systems::Context<T>& context) const;
+
+  // Retrieves the position `p_FM` stored in `context`.
+  //
+  // @param[in] context
+  //   The context of the model this mobilizer belongs to.
+  // @retval p_FM
+  //   The position of M in F.
+  Vector3<T> get_translation(const systems::Context<T>& context) const;
+
+  // Retrieves from `context` the angular velocity `w_FM` of the outboard frame
+  // M in the inboard frame F, expressed in F.
+  //
+  // @param[in] context
+  //   The context of the model this mobilizer belongs to.
+  // @retval w_FM
+  //   A vector in ℝ³ with the angular velocity of the outboard frame M in the
+  //   inboard frame F, expressed in F.
+  Vector3<T> get_angular_velocity(const systems::Context<T>& context) const;
+
+  // Retrieves from `context` the translational velocity `v_FM` of the outboard
+  // frame M in the inboard frame F, expressed in F.
+  //
+  // @param[in] context
+  //   The context of the model this mobilizer belongs to.
+  // @retval v_FM
+  //   A vector in ℝ³ with the translational velocity of the outboard frame M in
+  //   the inboard frame F, expressed in F.
+  Vector3<T> get_translational_velocity(
+      const systems::Context<T>& context) const;
+
+  // Stores in `context` the space x-y-z angles θ₁, θ₂, θ₃, provided in the
+  // input argument `angles`, which stores the with the format `angles = [θ₁,
+  // θ₂, θ₃]`.
+  //
+  // @param[in,out] context
+  //   The context of the model this mobilizer belongs to.
+  // @param[in] angles
+  //   A Vector3 which must pack values for the space x-y-z angles θ₁, θ₂, θ₃,
+  //   described in this class's documentation, at entries `angles(0)`,
+  //   `angles(1)` and `angles(2)`, respectively.
+  // @returns a constant reference to `this` mobilizer.
+  const SpaceXYZFloatingMobilizer<T>& set_angles(
+      systems::Context<T>* context, const Vector3<T>& angles) const;
+
+  // Stores in `context` the position `p_FM` of M in F.
+  //
+  // @param[in,out] context
+  //   The context of the model this mobilizer belongs to.
+  // @param[in] p_FM
+  //   Position of F in M.
+  // @returns a constant reference to `this` mobilizer.
+  const SpaceXYZFloatingMobilizer<T>& set_translation(
+      systems::Context<T>* context, const Vector3<T>& p_FM) const;
+
+  // Sets in `context` the state for `this` mobilizer so that the angular
+  // velocity of the outboard frame M in the inboard frame F is `w_FM`.
+  // @param[in,out] context
+  //   The context of the model this mobilizer belongs to.
+  // @param[in] w_FM
+  //   A vector in ℝ³ with the desired angular velocity of the outboard frame M
+  //   in the inboard frame F, expressed in F.
+  // @returns a constant reference to `this` mobilizer.
+  const SpaceXYZFloatingMobilizer<T>& set_angular_velocity(
+      systems::Context<T>* context, const Vector3<T>& w_FM) const;
+
+  // Stores in `context` the translational velocity `v_FM` of M in F.
+  //
+  // @param[in,out] context
+  //   The context of the model this mobilizer belongs to.
+  // @param[in] v_FM
+  //   Translational velocity of F in M.
+  // @returns a constant reference to `this` mobilizer.
+  const SpaceXYZFloatingMobilizer<T>& set_translational_velocity(
+      systems::Context<T>* context, const Vector3<T>& v_FM) const;
+
+  // Sets `context` so this mobilizer's generalized coordinates (space x-y-z
+  // angles θ₁, θ₂, θ₃ and position p_FM) represent the given rigid
+  // transform `X_FM`.
+  // @param[in,out] context
+  //   The context of the model that this mobilizer belongs to.
+  // @param[in] X_FM
+  //   Pose of M in F.
+  // @returns a constant reference to `this` mobilizer.
+  // @note Even though there is no range limit for the space x-y-z angles θ₁,
+  // θ₂, θ₃, this specific method will generate roll-pitch-yaw angles in the
+  // range `-π <= θ₁ <= π`, `-π/2 <= θ₂ <= π/2`, `-π <= θ₃ <= π`.
+  const SpaceXYZFloatingMobilizer<T>& SetFromRigidTransform(
+      systems::Context<T>* context, const math::RigidTransform<T>& X_FM) const;
+
+  // Computes the across-mobilizer transform `X_FM(q)` between the inboard
+  // frame F and the outboard frame M as a function of the configuration q
+  // stored in `context`.
+  math::RigidTransform<T> CalcAcrossMobilizerTransform(
+      const systems::Context<T>& context) const override;
+
+  // Computes the across-mobilizer velocity `V_FM(q, v)` of the outboard frame M
+  // measured and expressed in frame F as a function of the configuration stored
+  // in `context` and of the input generalized velocity v, packed as documented
+  // in get_generalized_velocities().
+  SpatialVelocity<T> CalcAcrossMobilizerSpatialVelocity(
+      const systems::Context<T>& context,
+      const Eigen::Ref<const VectorX<T>>& v) const override;
+
+  // Computes the across-mobilizer acceleration `A_FM(q, v, v̇)` of the
+  // outboard frame M in the inboard frame F.
+  // The acceleration `A_FM` will be a function of the generalized positions q
+  // and generalized velocities v stored in `context` and of the supplied
+  // generalized accelerations `vdot`. `vdot` must contain the rates of change
+  // of each of the generalized velocities components packed in the order
+  // documented in get_generalized_velocities(). For this mobilizer this
+  // corresponds to `vdot = [alpha_FM; a_FM]`, with `alpha_FM = Dt_F(w_FM)` and
+  // `a_FM` the angular and translational accelerations of M in F, respectively
+  // (see @ref Dt_multibody_quantities for our notation of time derivatives in
+  // different reference frames.)
+  SpatialAcceleration<T> CalcAcrossMobilizerSpatialAcceleration(
+      const systems::Context<T>& context,
+      const Eigen::Ref<const VectorX<T>>& vdot) const override;
+
+  // See Mobilizer::ProjectSpatialForce() for details.
+  void ProjectSpatialForce(const systems::Context<T>& context,
+                           const SpatialForce<T>& F_Mo_F,
+                           Eigen::Ref<VectorX<T>> tau) const override;
+
+  // Maps the generalized velocity v to time derivatives of configuration
+  // `qdot`.
+  //
+  // @param[in] context
+  //   The context of the model this mobilizer belongs to.
+  // @param[in] v
+  //   A vector of generalized velocities for this mobilizer, packed as
+  //   documented in get_generalized_velocities().
+  // @param[out] qdot
+  //   Rates of the generalized positions, packed as documented in
+  //   get_generalized_positions().
+  //
+  // @warning The mapping from angular velocity to Euler angle's rates is
+  // singular for angle `θ₂` such that `θ₂ = π/2 + kπ, ∀ k ∈ ℤ`. To avoid
+  // working close to this singularity (which could potentially result in large
+  // errors for `qdot`), this method aborts when the absolute value of the
+  // cosine of θ₂ is smaller than 10⁻³, a number arbitrarily chosen to this end.
+  void MapVelocityToQDot(const systems::Context<T>& context,
+                         const Eigen::Ref<const VectorX<T>>& v,
+                         EigenPtr<VectorX<T>> qdot) const override;
+
+  // Maps time derivatives of the configuration in `qdot` to
+  // the generalized velocities v.
+  //
+  // @param[in] context
+  //   The context of the model this mobilizer belongs to.
+  // @param[in] qdot
+  //   Rates of the generalized positions, packed as documented in
+  //   get_generalized_positions().
+  // @param[out] v
+  //   A vector of generalized velocities for this mobilizer, packed as
+  //   documented in get_generalized_velocities().
+  void MapQDotToVelocity(const systems::Context<T>& context,
+                         const Eigen::Ref<const VectorX<T>>& qdot,
+                         EigenPtr<VectorX<T>> v) const override;
+
+ protected:
+  // Implements Mobilizer's NVI, see Mobilizer::CalcNMatrix() for details.
+  // @warning The mapping from angular velocity to Euler angle's rates is
+  // singular for angle `θ₂` such that `θ₂ = π/2 + kπ, ∀ k ∈ ℤ`. To avoid
+  // working close to this singularity (which could potentially result in large
+  // errors for `qdot`), this method aborts when the absolute value of the
+  // cosine of θ₂ is smaller than 10⁻³, a number arbitrarily chosen to this end.
+  void DoCalcNMatrix(const systems::Context<T>& context,
+                     EigenPtr<MatrixX<T>> N) const override;
+
+  // Implements Mobilizer's NVI, see Mobilizer::DoCalcNplusMatrix() for details.
+  void DoCalcNplusMatrix(const systems::Context<T>& context,
+                         EigenPtr<MatrixX<T>> Nplus) const override;
+
+  std::unique_ptr<Mobilizer<double>> DoCloneToScalar(
+      const MultibodyTree<double>& tree_clone) const override;
+
+  std::unique_ptr<Mobilizer<AutoDiffXd>> DoCloneToScalar(
+      const MultibodyTree<AutoDiffXd>& tree_clone) const override;
+
+  std::unique_ptr<Mobilizer<symbolic::Expression>> DoCloneToScalar(
+      const MultibodyTree<symbolic::Expression>& tree_clone) const override;
+
+ private:
+  typedef MobilizerImpl<T, 6, 6> MobilizerBase;
+  // Bring the handy number of position and velocities MobilizerImpl enums into
+  // this class' scope. This is useful when writing mathematical expressions
+  // with fixed-sized vectors since we can do things like Vector<T, kNq>.
+  // Operations with fixed-sized quantities can be optimized at compile time
+  // and therefore they are highly preferred compared to the very slow dynamic
+  // sized quantities.
+  using MobilizerBase::kNq;
+  using MobilizerBase::kNv;
+
+  // Helper method to make a clone templated on ToScalar.
+  template <typename ToScalar>
+  std::unique_ptr<Mobilizer<ToScalar>> TemplatedDoCloneToScalar(
+      const MultibodyTree<ToScalar>& tree_clone) const;
+};
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::internal::SpaceXYZFloatingMobilizer)

--- a/multibody/tree/test/space_xyz_floating_mobilizer_test.cc
+++ b/multibody/tree/test/space_xyz_floating_mobilizer_test.cc
@@ -1,0 +1,184 @@
+#include "drake/multibody/tree/space_xyz_floating_mobilizer.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/math/rotation_matrix.h"
+#include "drake/multibody/tree/multibody_tree-inl.h"
+#include "drake/multibody/tree/multibody_tree_system.h"
+#include "drake/multibody/tree/test/mobilizer_tester.h"
+#include "drake/systems/framework/context.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+namespace {
+
+using Eigen::Vector3d;
+using math::RigidTransformd;
+using math::RollPitchYawd;
+using math::RotationMatrixd;
+
+constexpr double kTolerance = 10 * std::numeric_limits<double>::epsilon();
+
+// Fixture to setup a simple model containing a space xyz floating mobilizer.
+class SpaceXYZFloatingMobilizerTest : public MobilizerTester {
+ public:
+  // Creates a simple model consisting of a single body with a space xyz
+  // floating mobilizer connecting it to the world.
+  void SetUp() override {
+    mobilizer_ = &AddMobilizerAndFinalize(
+        std::make_unique<SpaceXYZFloatingMobilizer<double>>(
+            tree().world_body().body_frame(), body_->body_frame()));
+  }
+
+  // Helper to set the this fixture's context to an arbitrary non-zero state
+  // comprised of arbitrary_rpy() and arbitrary_translation().
+  void SetArbitraryNonZeroState() {
+    mobilizer_->set_angles(context_.get(), arbitrary_rpy().vector());
+    mobilizer_->set_translation(context_.get(), arbitrary_translation());
+  }
+
+  RollPitchYawd arbitrary_rpy() const {
+    return RollPitchYawd(M_PI / 3, -M_PI / 3, M_PI / 5);
+  }
+  Vector3d arbitrary_translation() const { return Vector3d(1.0, 2.0, 3.0); }
+
+ protected:
+  const SpaceXYZFloatingMobilizer<double>* mobilizer_{nullptr};
+};
+
+// Verifies methods to mutate and access the context.
+TEST_F(SpaceXYZFloatingMobilizerTest, BasicIntrospection) {
+  EXPECT_TRUE(mobilizer_->is_floating());
+  EXPECT_FALSE(mobilizer_->has_quaternion_dofs());
+}
+
+// Verifies methods to mutate and access the context.
+TEST_F(SpaceXYZFloatingMobilizerTest, ConfigurationAccessAndMutation) {
+  SetArbitraryNonZeroState();
+  EXPECT_EQ(mobilizer_->get_angles(*context_), arbitrary_rpy().vector());
+  EXPECT_EQ(mobilizer_->get_translation(*context_), arbitrary_translation());
+  Vector6<double> q;
+  q << arbitrary_rpy().vector(), arbitrary_translation();
+  EXPECT_EQ(mobilizer_->get_generalized_positions(*context_), q);
+}
+
+TEST_F(SpaceXYZFloatingMobilizerTest, SetFromRigidTransform) {
+  SetArbitraryNonZeroState();
+  const RigidTransformd X_WB(arbitrary_rpy(), arbitrary_translation());
+  mobilizer_->SetFromRigidTransform(context_.get(), X_WB);
+  EXPECT_TRUE(CompareMatrices(mobilizer_->get_angles(*context_),
+                              arbitrary_rpy().vector(), kTolerance,
+                              MatrixCompareType::relative));
+  EXPECT_EQ(mobilizer_->get_translation(*context_), arbitrary_translation());
+}
+
+TEST_F(SpaceXYZFloatingMobilizerTest, VelocityAccessAndMutation) {
+  const Vector3d w_FM(M_PI / 3, -M_PI / 3, M_PI / 5);
+  mobilizer_->set_angular_velocity(context_.get(), w_FM);
+  EXPECT_EQ(mobilizer_->get_angular_velocity(*context_), w_FM);
+
+  const Vector3d v_FM(1.0, 2.0, 3.0);
+  mobilizer_->set_translational_velocity(context_.get(), v_FM);
+  EXPECT_EQ(mobilizer_->get_translational_velocity(*context_), v_FM);
+
+  const auto v = (Vector6<double>() << w_FM, v_FM).finished();
+  EXPECT_EQ(mobilizer_->get_generalized_velocities(*context_), v);
+}
+
+TEST_F(SpaceXYZFloatingMobilizerTest, ZeroState) {
+  SetArbitraryNonZeroState();
+
+  // The non-zero state is not the identity transform as expected.
+  EXPECT_FALSE(
+      mobilizer_->CalcAcrossMobilizerTransform(*context_).IsExactlyIdentity());
+
+  // Set the "zero state" for this mobilizer, which does happen to be that of
+  // an identity rigid transform.
+  mobilizer_->set_zero_state(*context_, &context_->get_mutable_state());
+  EXPECT_TRUE(
+      mobilizer_->CalcAcrossMobilizerTransform(*context_).IsExactlyIdentity());
+}
+
+// Verify the correctness of across-mobilizer quantities; X_FM, V_FM, A_FM.
+TEST_F(SpaceXYZFloatingMobilizerTest, CalcAcrossMobilizer) {
+  SetArbitraryNonZeroState();
+
+  const RigidTransformd X_FM_expected(arbitrary_rpy(), arbitrary_translation());
+  const RigidTransformd X_FM =
+      mobilizer_->CalcAcrossMobilizerTransform(*context_);
+  EXPECT_TRUE(CompareMatrices(X_FM.GetAsMatrix34(),
+                              X_FM_expected.GetAsMatrix34(), kTolerance,
+                              MatrixCompareType::relative));
+
+  // Verify across mobilizer spatial velocity for an arbitrary non-zero state.
+  Vector6<double> v;
+  v << 1, 2, 3, 4, 5, 6;
+  const SpatialVelocity<double> V_FM =
+      mobilizer_->CalcAcrossMobilizerSpatialVelocity(*context_, v);
+  EXPECT_TRUE(CompareMatrices(V_FM.get_coeffs(), v, kTolerance,
+                              MatrixCompareType::relative));
+
+  // Verify across mobilizer spatial velocity for an arbitrary non-zero state
+  // and generalized accelrations.
+  const SpatialAcceleration<double> A_FM =
+      mobilizer_->CalcAcrossMobilizerSpatialAcceleration(*context_, v);
+  EXPECT_TRUE(CompareMatrices(A_FM.get_coeffs(), v, kTolerance,
+                              MatrixCompareType::relative));
+
+  // Force projection across the mobilizer. Since the generalized velocities for
+  // this mobilizer correspond to the spatial velocity across the mobilizer, the
+  // generalized forces must equal the spatial force on the mobilizer frame due
+  // to the principle of virtual work.
+  SpatialForce<double> F(v);
+  Vector6<double> tau;
+  mobilizer_->ProjectSpatialForce(*context_, F, tau);
+  EXPECT_TRUE(CompareMatrices(F.get_coeffs(), tau, kTolerance,
+                              MatrixCompareType::relative));
+}
+
+TEST_F(SpaceXYZFloatingMobilizerTest, MapVelocityToQdotAndBack) {
+  SetArbitraryNonZeroState();
+  const Vector6<double> v = (Vector6<double>() << 1, 2, 3, 4, 5, 6).finished();
+  Vector6<double> qdot;
+  mobilizer_->MapVelocityToQDot(*context_, v, &qdot);
+  Vector6<double> v_back;
+  mobilizer_->MapQDotToVelocity(*context_, qdot, &v_back);
+  EXPECT_TRUE(
+      CompareMatrices(v, v_back, kTolerance, MatrixCompareType::relative));
+}
+
+// For an arbitrary state verify that the computed Nplus(q) matrix is the
+// inverse of N(q).
+TEST_F(SpaceXYZFloatingMobilizerTest, KinematicMapping) {
+  RollPitchYawd rpy(M_PI / 3, -M_PI / 3, M_PI / 5);
+  mobilizer_->set_angles(context_.get(), rpy.vector());
+
+  ASSERT_EQ(mobilizer_->num_positions(), 6);
+  ASSERT_EQ(mobilizer_->num_velocities(), 6);
+
+  // Compute N.
+  Matrix6<double> N;
+  mobilizer_->CalcNMatrix(*context_, &N);
+
+  // Compute Nplus.
+  Matrix6<double> Nplus;
+  mobilizer_->CalcNplusMatrix(*context_, &Nplus);
+
+  // Verify that Nplus is the inverse of N.
+  MatrixX<double> N_x_Nplus = N * Nplus;
+  MatrixX<double> Nplus_x_N = Nplus * N;
+
+  EXPECT_TRUE(CompareMatrices(N_x_Nplus, Matrix6<double>::Identity(),
+                              kTolerance, MatrixCompareType::relative));
+  EXPECT_TRUE(CompareMatrices(Nplus_x_N, Matrix6<double>::Identity(),
+                              kTolerance, MatrixCompareType::relative));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Towards #14949.

Mobilizer to model free bodies using rpy angles instead of quaternions. 
Joint + bindings and parsing will come in separate PRs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14961)
<!-- Reviewable:end -->
