### PR TITLE
Autodiffable hydroelastics traction

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -289,6 +289,8 @@ drake_cc_googletest(
         ":hydroelastic_traction",
         "//common:find_resource",
         "//common/test_utilities:eigen_matrix_compare",
+        "//math:autodiff",
+        "//math:gradient",
         "//multibody/parsing",
     ],
 )


### PR DESCRIPTION
This PR implements an expression for the hydroelastic traction that can be automatically differentiated with AutoDiffXd (the current version leads to NaNs for zero slip velocities as @SeanCurtis-TRI discovered).
This new expression is mathematically equivalent to the atan() functional form of regularization currently used, but it simplifies the math by hand near zero in order to lead to expression that do not require the evaluation of square roots (which were responsible for division by zero when differentiated automatically).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14963)
<!-- Reviewable:end -->
