### PR TITLE
framework: Avoid functor allocation for PublishEvents

### DIFF
--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -390,7 +390,14 @@ void DefineFrameworkPySemantics(py::module m) {
                  [](const typename PublishEvent<T>::PublishCallback& callback) {
                    return std::make_unique<PublishEvent<T>>(callback);
                  })),
-            py::arg("callback"), doc.PublishEvent.ctor.doc_1args)
+            py::arg("callback"), doc.PublishEvent.ctor.doc_1args_callback)
+        .def(py::init(WrapCallbacks(
+                 [](const typename PublishEvent<T>::SystemCallback&
+                         system_callback) {
+                   return std::make_unique<PublishEvent<T>>(system_callback);
+                 })),
+            py::arg("system_callback"),
+            doc.PublishEvent.ctor.doc_1args_system_callback)
         .def(
             py::init(WrapCallbacks(
                 [](const TriggerType& trigger_type,
@@ -399,6 +406,15 @@ void DefineFrameworkPySemantics(py::module m) {
                       trigger_type, callback);
                 })),
             py::arg("trigger_type"), py::arg("callback"),
+            "Users should not be calling these")
+        .def(py::init(WrapCallbacks(
+                 [](const TriggerType& trigger_type,
+                     const typename PublishEvent<T>::SystemCallback&
+                         system_callback) {
+                   return std::make_unique<PublishEvent<T>>(
+                       trigger_type, system_callback);
+                 })),
+            py::arg("trigger_type"), py::arg("system_callback"),
             "Users should not be calling these");
     DefineTemplateClassWithDefault<DiscreteUpdateEvent<T>, Event<T>>(
         m, "DiscreteUpdateEvent", GetPyParam<T>(), doc.DiscreteUpdateEvent.doc);

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -255,8 +255,20 @@ class TestGeneral(unittest.TestCase):
 
         def callback(context, event): pass
 
+        event = PublishEvent(callback=callback)
+        self.assertIsInstance(event, Event)
         event = PublishEvent(
             trigger_type=TriggerType.kInitialization, callback=callback)
+        self.assertIsInstance(event, Event)
+        self.assertEqual(event.get_trigger_type(), TriggerType.kInitialization)
+
+        def system_callback(system, context, event): pass
+
+        event = PublishEvent(system_callback=system_callback)
+        self.assertIsInstance(event, Event)
+        event = PublishEvent(
+            trigger_type=TriggerType.kInitialization,
+            system_callback=system_callback)
         self.assertIsInstance(event, Event)
         self.assertEqual(event.get_trigger_type(), TriggerType.kInitialization)
 

--- a/systems/analysis/test/simulator_limit_malloc_test.cc
+++ b/systems/analysis/test/simulator_limit_malloc_test.cc
@@ -62,7 +62,7 @@ GTEST_TEST(SimulatorLimitMallocTest,
     // heap-free simulation after initialization, given careful system
     // construction.
     // TODO(rpoyner-tri): whittle allocations down to 0.
-    test::LimitMalloc heap_alloc_checker({.max_num_allocations = 49});
+    test::LimitMalloc heap_alloc_checker({.max_num_allocations = 28});
     simulator.AdvanceTo(1.0);
     simulator.AdvanceTo(2.0);
     simulator.AdvanceTo(3.0);

--- a/systems/framework/leaf_system.cc
+++ b/systems/framework/leaf_system.cc
@@ -715,7 +715,7 @@ void LeafSystem<T>::DoPublish(
     const Context<T>& context,
     const std::vector<const PublishEvent<T>*>& events) const {
   for (const PublishEvent<T>* event : events) {
-    event->handle(context);
+    event->handle(*this, context);
   }
 }
 

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -301,17 +301,17 @@ class LeafSystem : public System<T> {
       EventStatus (MySystem::*publish)(const Context<T>&) const) {
     static_assert(std::is_base_of<LeafSystem<T>, MySystem>::value,
                   "Expected to be invoked from a LeafSystem-derived System.");
-    auto this_ptr = dynamic_cast<const MySystem*>(this);
-    DRAKE_DEMAND(this_ptr != nullptr);
     DRAKE_DEMAND(publish != nullptr);
 
     DeclarePeriodicEvent(
         period_sec, offset_sec,
-        PublishEvent<T>(TriggerType::kPeriodic, [this_ptr, publish](
-                                                    const Context<T>& context,
-                                                    const PublishEvent<T>&) {
+        PublishEvent<T>(TriggerType::kPeriodic, [publish](
+                            const System<T>& system,
+                            const Context<T>& context,
+                            const PublishEvent<T>&) {
+          const auto& sys = dynamic_cast<const MySystem&>(system);
           // TODO(sherm1) Forward the return status.
-          (this_ptr->*publish)(context);  // Ignore return status for now.
+          (sys.*publish)(context);  // Ignore return status for now.
         }));
   }
 
@@ -327,18 +327,19 @@ class LeafSystem : public System<T> {
                                        const) {
     static_assert(std::is_base_of<LeafSystem<T>, MySystem>::value,
                   "Expected to be invoked from a LeafSystem-derived System.");
-    auto this_ptr = dynamic_cast<const MySystem*>(this);
-    DRAKE_DEMAND(this_ptr != nullptr);
     DRAKE_DEMAND(publish != nullptr);
 
     DeclarePeriodicEvent(
         period_sec, offset_sec,
-        PublishEvent<T>(TriggerType::kPeriodic,
-                        [this_ptr, publish](const Context<T>& context,
-                                            const PublishEvent<T>&) {
-                          (this_ptr->*publish)(context);
-                          // TODO(sherm1) return EventStatus::Succeeded()
-                        }));
+        PublishEvent<T>(
+            TriggerType::kPeriodic,
+            [publish](const System<T>& system,
+                      const Context<T>& context,
+                      const PublishEvent<T>&) {
+              const auto& sys = dynamic_cast<const MySystem&>(system);
+              (sys.*publish)(context);
+              // TODO(sherm1) return EventStatus::Succeeded()
+            }));
   }
 
   /** Declares that a DiscreteUpdate event should occur periodically and that it
@@ -609,15 +610,15 @@ class LeafSystem : public System<T> {
       EventStatus (MySystem::*publish)(const Context<T>&) const) {
     static_assert(std::is_base_of<LeafSystem<T>, MySystem>::value,
                   "Expected to be invoked from a LeafSystem-derived System.");
-    auto this_ptr = dynamic_cast<const MySystem*>(this);
-    DRAKE_DEMAND(this_ptr != nullptr);
     DRAKE_DEMAND(publish != nullptr);
 
     DeclarePerStepEvent<PublishEvent<T>>(PublishEvent<T>(
         TriggerType::kPerStep,
-        [this_ptr, publish](const Context<T>& context, const PublishEvent<T>&) {
+        [publish](const System<T>& system, const Context<T>& context,
+                  const PublishEvent<T>&) {
+          const auto& sys = dynamic_cast<const MySystem&>(system);
           // TODO(sherm1) Forward the return status.
-          (this_ptr->*publish)(context);  // Ignore return status for now.
+          (sys.*publish)(context);  // Ignore return status for now.
         }));
   }
 

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -452,7 +452,7 @@ TEST_F(LeafSystemTest, WitnessDeclarations) {
   EXPECT_EQ(witness3->CalcWitnessValue(context_), 3.0);
   auto pe = dynamic_cast<const PublishEvent<double>*>(witness3->get_event());
   ASSERT_TRUE(pe);
-  pe->handle(context_);
+  pe->handle(system_, context_);
   EXPECT_TRUE(system_.publish_callback_called());
 
   auto witness4 = system_.MakeWitnessWithDiscreteUpdate();
@@ -2223,7 +2223,7 @@ class TestTriggerSystem : public LeafSystem<double> {
         continue;
 
       // Call custom callback handler.
-      event->handle(context);
+      event->handle(*this, context);
     }
 
     publish_count_++;


### PR DESCRIPTION
Relevant to: #14543

This is the fifth of a long PR train to make heapless simulation
possible, with careful system construction. Inspired by @edrumwri's
draft PR #14707.

This patch introduces a new callback type for PublishEvents that avoids
heap allocations induced by lambda captures.

Subsequent patches will expand this technique (and test coverage) to the
other event types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14969)
<!-- Reviewable:end -->
