### PR TITLE
[fem] Move systems:: level API from SoftsimSystem to MbP

### DIFF
--- a/multibody/contact_solvers/contact_solver_results.h
+++ b/multibody/contact_solvers/contact_solver_results.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <vector>
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/eigen_types.h"
@@ -44,6 +45,12 @@ struct ContactSolverResults {
 
   // Vector of generalized forces due to contact, of size `nv`.
   VectorX<T> tau_contact;
+
+  // A temporary solution to store deformable velocities as deformable objects
+  // don't participate in contact solve yet.
+  // TODO(xuchenhan-tri): Remove this data member and store the deformable
+  // velocity at the next time step in v_next.
+  std::vector<VectorX<T>> deformable_v_next;
 };
 
 }  // namespace internal

--- a/multibody/fixed_fem/dev/BUILD.bazel
+++ b/multibody/fixed_fem/dev/BUILD.bazel
@@ -282,6 +282,7 @@ drake_cc_library(
         ":simplex_gaussian_quadrature",
         "//common:essential",
         "//geometry/proximity:volume_mesh",
+        "//multibody/plant",
         "//systems/framework:leaf_system",
     ],
 )

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -56,10 +56,14 @@ drake_cc_library(
 drake_cc_library(
     name = "multibody_plant_core",
     srcs = [
+        "deformable_solver_base.cc",
         "multibody_plant.cc",
+        "multibody_plant_deformable_solver_attorney.cc",
     ],
     hdrs = [
+        "deformable_solver_base.h",
         "multibody_plant.h",
+        "multibody_plant_deformable_solver_attorney.h",
     ],
     visibility = ["//visibility:private"],
     deps = [

--- a/multibody/plant/deformable_solver_base.cc
+++ b/multibody/plant/deformable_solver_base.cc
@@ -1,0 +1,30 @@
+#include "drake/multibody/plant/deformable_solver_base.h"
+
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/plant/multibody_plant_deformable_solver_attorney.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+template <typename T>
+const Vector3<double>& DeformableSolverBase<T>::gravity() const {
+  return mbp_->gravity_field().gravity_vector();
+}
+
+template <typename T>
+double DeformableSolverBase<T>::dt() const {
+  return mbp_->time_step();
+}
+
+template <typename T>
+void DeformableSolverBase<T>::DeclareDeformableState(const VectorX<T>& q,
+                                                     const VectorX<T>& qdot,
+                                                     const VectorX<T>& qddot) {
+  MultibodyPlantDeformableSolverAttorney<T>::DeclareDeformableState(
+      q, qdot, qddot, mbp_);
+}
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::internal::DeformableSolverBase);

--- a/multibody/plant/deformable_solver_base.h
+++ b/multibody/plant/deformable_solver_base.h
@@ -1,0 +1,60 @@
+#pragma once
+#include "drake/common/default_scalars.h"
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace multibody {
+template <typename T>
+class MultibodyPlant;
+
+namespace internal {
+/* DeformableSolverBase is a pure virtual deformable interface class that serves
+ as the one-stop shop for all deformable-related functionalities for the owning
+ MbP to advance its forward dynamics. It serves as a temporary solution for MbP
+ to access the deformable functionalities that live in dev now (because MbP,
+ being out of dev, cannot depend on dev functionalities). This class should be
+ retired when the deformable functionalities come out of time. When that
+ happens, MbP should be able to directly depend on these deformable
+ functionalities. */
+template <typename T>
+class DeformableSolverBase {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DeformableSolverBase)
+
+  /* Creates a DeformableSolverBase that is owned by the given `mbp`. */
+  explicit DeformableSolverBase(multibody::MultibodyPlant<T>* mbp) : mbp_(mbp) {
+    DRAKE_DEMAND(mbp_ != nullptr);
+  }
+
+  virtual ~DeformableSolverBase() = default;
+
+  /* Calculates the state of the deformable body indexed with
+   `deformable_body_index` in the absense of contact force over a single time
+   step.
+   @param state0                 The deformable body's state at the beginning of
+                                 the time step.
+   @param deformable_body_index  The index of the deformable body. */
+  virtual VectorX<T> CalcFreeMotion(const VectorX<T>& state0,
+                                    int deformable_body_index) const = 0;
+
+ protected:
+  /* Returns the gravity vector of the owning MbP. */
+  const Vector3<double>& gravity() const;
+
+  /* Returns the discrete time step of the owning MbP. */
+  double dt() const;
+
+  /* Declares a discrete deformable state in the owning MbP with the given `q`,
+   `qdot` and `qddot` as model values. */
+  void DeclareDeformableState(const VectorX<T>& q, const VectorX<T>& qdot,
+                              const VectorX<T>& qddot);
+
+ private:
+  // Back pointer to owning MbP.
+  MultibodyPlant<T>* mbp_;
+};
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::internal::DeformableSolverBase);

--- a/multibody/plant/multibody_plant_deformable_solver_attorney.cc
+++ b/multibody/plant/multibody_plant_deformable_solver_attorney.cc
@@ -1,0 +1,19 @@
+#include "drake/multibody/plant/multibody_plant_deformable_solver_attorney.h"
+
+#include "drake/multibody/plant/multibody_plant.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+template <typename T>
+void MultibodyPlantDeformableSolverAttorney<T>::DeclareDeformableState(
+    const VectorX<T>& q, const VectorX<T>& qdot, const VectorX<T>& qddot,
+    MultibodyPlant<T>* mbp) {
+  mbp->DeclareDeformableState(q, qdot, qddot);
+}
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::internal::MultibodyPlantDeformableSolverAttorney);

--- a/multibody/plant/multibody_plant_deformable_solver_attorney.h
+++ b/multibody/plant/multibody_plant_deformable_solver_attorney.h
@@ -1,0 +1,41 @@
+#pragma once
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+namespace drake {
+namespace multibody {
+template <typename T>
+class MultibodyPlant;
+
+namespace internal {
+template <typename T>
+class DeformableSolverBase;
+
+/* This is an attorney-client pattern providing DeformableSolverBase access to
+ the private data/methods of MultibodyPlant in order to be able construct
+ contact solver data. This class is meant to be a short-term solution to
+ quickly facilitate integration of deformable simulation with MultibodyPlant
+ without moving the deformable functionalities out of the dev directory. When
+ the deformable functionalities graduates from the dev direction, this class
+ should be retired along with DeformableSolverBase. */
+template <typename T>
+class MultibodyPlantDeformableSolverAttorney {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MultibodyPlantDeformableSolverAttorney);
+  MultibodyPlantDeformableSolverAttorney() = delete;
+
+ private:
+  friend class DeformableSolverBase<T>;
+
+  /* Declares a deformable state with the given position, velocity and
+   acceleration in the given `mbp`. */
+  static void DeclareDeformableState(const VectorX<T>& q,
+                                     const VectorX<T>& qdot,
+                                     const VectorX<T>& qddot,
+                                     MultibodyPlant<T>* mbp);
+};
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::internal::MultibodyPlantDeformableSolverAttorney);

--- a/multibody/tree/multibody_tree_system.cc
+++ b/multibody/tree/multibody_tree_system.cc
@@ -138,7 +138,7 @@ void MultibodyTreeSystem<T>::Finalize() {
 
   // Declare state.
   if (is_discrete_) {
-    this->DeclareDiscreteState(tree_->num_states());
+    discrete_state_index_ = this->DeclareDiscreteState(tree_->num_states());
   } else {
     this->DeclareContinuousState(BasicVector<T>(tree_->num_states()),
                                  tree_->num_positions(),

--- a/multibody/tree/multibody_tree_system.h
+++ b/multibody/tree/multibody_tree_system.h
@@ -301,6 +301,17 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
   void SetDefaultState(const systems::Context<T>& context,
                        systems::State<T>* state) const override;
 
+  /* Returns the DiscreteStateIndex for the one and only discrete state if the
+  system is discrete. Throws otherwise. */
+  systems::DiscreteStateIndex get_discrete_state_index_or_throw() const {
+    if (!is_discrete_) {
+      throw std::logic_error(
+          "The MultibodyTreeSystem is modeled as a continuous system and there "
+          "does not exist any discrete state.");
+    }
+    return discrete_state_index_;
+  }
+
  private:
   // This is only meaningful in continuous mode.
   void DoCalcTimeDerivatives(
@@ -491,6 +502,10 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
 
   // Used to enforce "finalize once" restriction for protected-API users.
   bool already_finalized_{false};
+
+  // The discrete state index for the one and only discrete state if the system
+  // is discrete.
+  systems::DiscreteStateIndex discrete_state_index_;
 };
 
 /* Access internal tree outside of MultibodyTreeSystem. */


### PR DESCRIPTION
This is the first step towards integrating `SoftsimSystem` with `MbP`.

1. Remove systems:: level API from `SoftsimSystem` and make `SoftsimSystem` not inherit from `LeafSystem` anymore.
2. Move the states and ports originally in `SoftsimSystem` to `MbP`.
3. Introduce a pure virtual internal deformable utility class `DeformableSolverBase` out of the dev folder that `SoftsimSystem` inherits from. An instance of `DeformableSolverBase` is owned by MbP and it serves as the one-stop shop for all deformable related utilities.

TODO: As `SoftsimSystem` is no longer a `LeafSystem`, the name is not appropriate any more. To limit the number of lines changes in this PR, a separate PR will rename `SoftsimSystem` to `DeformableSolver`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14972)
<!-- Reviewable:end -->
