### PR TITLE
proximity: Don't warn when parsing meshes with mtl files

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -1283,11 +1283,14 @@ void DoScalarIndependentDefinitions(py::module m) {
       py_rvp::reference_internal, py::arg("diffuse"),
       doc.MakePhongIllustrationProperties.doc);
 
-  m.def("ReadObjToSurfaceMesh",
-      py::overload_cast<const std::string&, double>(
-          &geometry::ReadObjToSurfaceMesh),
+  m.def(
+      "ReadObjToSurfaceMesh",
+      [](const std::string& filename, double scale) {
+        return geometry::ReadObjToSurfaceMesh(filename, scale);
+      },
       py::arg("filename"), py::arg("scale") = 1.0,
-      doc.ReadObjToSurfaceMesh.doc_2args_filename_scale);
+      // N.B. We have not bound the optional "on_warning" argument.
+      doc.ReadObjToSurfaceMesh.doc_3args_filename_scale_on_warning);
 }
 
 void def_geometry(py::module m) {

--- a/geometry/proximity/obj_to_surface_mesh.h
+++ b/geometry/proximity/obj_to_surface_mesh.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <functional>
 #include <istream>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "drake/geometry/proximity/surface_mesh.h"
@@ -19,18 +21,26 @@ namespace geometry {
      A valid file name with absolute path or relative path.
  @param scale
      An optional scale to coordinates.
+ @param on_warning
+     An optional callback that will receive warning message(s) encountered
+     while reading the mesh.  When not provided, drake::log() will be used.
  @throws std::runtime_error if `filename` doesn't have a valid file path, or the
      file has no faces.
  @return surface mesh
  */
-SurfaceMesh<double> ReadObjToSurfaceMesh(const std::string& filename,
-                                         double scale = 1.0);
+SurfaceMesh<double> ReadObjToSurfaceMesh(
+    const std::string& filename,
+    double scale = 1.0,
+    std::function<void(std::string_view)> on_warning = {});
 
 /**
  Overload of @ref ReadObjToSurfaceMesh(const std::string&, double) with the
  Wavefront .obj file given in std::istream.
  */
-SurfaceMesh<double> ReadObjToSurfaceMesh(std::istream* input_stream,
-                                         double scale = 1.0);
+SurfaceMesh<double> ReadObjToSurfaceMesh(
+    std::istream* input_stream,
+    double scale = 1.0,
+    std::function<void(std::string_view)> on_warning = {});
+
 }  // namespace geometry
 }  // namespace drake


### PR DESCRIPTION
When reusing a visual mesh for collision purposes, we would get warning logspam while skipping the mtl files.  This was a regression as of #14656.

See also [slack discussion](https://app.slack.com/client/T0JNB2DS4/C2WBPQDB7/thread/C2WBPQDB7-1619718920.052300).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14974)
<!-- Reviewable:end -->
