### PR TITLE
Implements MultibodyPlant dofs permutation utility.

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -19,6 +19,7 @@ drake_cc_package_library(
     deps = [
         ":calc_distance_and_time_derivative",
         ":contact_jacobians",
+        ":contact_permutation",
         ":contact_results",
         ":coulomb_friction",
         ":discrete_contact_pair",
@@ -253,6 +254,15 @@ drake_cc_library(
     hdrs = ["propeller.h"],
     deps = [
         ":multibody_plant_core",
+    ],
+)
+
+drake_cc_library(
+    name = "contact_permutation",
+    srcs = ["contact_permutation.cc"],
+    hdrs = ["contact_permutation.h"],
+    deps = [
+        "//multibody/tree:multibody_tree_topology",
     ],
 )
 
@@ -663,6 +673,22 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
         "//systems/framework",
+    ],
+)
+
+drake_cc_googletest(
+    name = "contact_permutation_test",
+    data = [
+        "//examples/kuka_iiwa_arm/models",
+        "//examples/simple_gripper:simple_gripper_models",
+        "//manipulation/models/allegro_hand_description:models",
+        "//manipulation/models/iiwa_description:models",
+    ],
+    deps = [
+        ":contact_permutation",
+        ":plant",
+        "//common:find_resource",
+        "//multibody/parsing",
     ],
 )
 

--- a/multibody/plant/contact_permutation.cc
+++ b/multibody/plant/contact_permutation.cc
@@ -1,0 +1,78 @@
+#include "drake/multibody/plant/contact_permutation.h"
+
+#include <vector>
+
+#include "drake/common/drake_assert.h"
+#include "drake/multibody/tree/multibody_tree_topology.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+// Helper to deep traverse a tree from its base at base_node_index.
+void TreeDepthFirstTraversal(const MultibodyTreeTopology& tree_topology,
+                             BodyNodeIndex base_node_index,
+                             std::vector<int>* tree_velocity_permutation,
+                             std::vector<BodyIndex>* tree_bodies) {
+  const BodyNodeTopology& node = tree_topology.get_body_node(base_node_index);
+  tree_bodies->push_back(node.body);
+
+  for (BodyNodeIndex child_index : node.child_nodes) {
+    TreeDepthFirstTraversal(tree_topology, child_index,
+                            tree_velocity_permutation, tree_bodies);
+  }
+
+  // Push the velocity indexes for this node.
+  for (int i = 0; i < node.num_mobilizer_velocities; ++i) {
+    const int m = node.mobilizer_velocities_start_in_v + i;
+    tree_velocity_permutation->push_back(m);
+  }
+}
+
+// Recall, v = velocity_permutation[t][vt]
+// where:
+//   t: tree index.
+//   vt: local velocity index in tree t with DFS order.
+//   v: original velocity index in tree_topology.
+// and t = body_to_tree_map[body_index]. t < 0 if body_index
+// is anchored to the world. Therefore body_to_tree_map[0] < 0 always.
+void ComputeDfsPermutation(const MultibodyTreeTopology& tree_topology,
+                           std::vector<std::vector<int>>* velocity_permutation,
+                           std::vector<int>* body_to_tree_map) {
+  DRAKE_DEMAND(velocity_permutation != nullptr);
+  DRAKE_DEMAND(body_to_tree_map != nullptr);
+
+  velocity_permutation->clear();
+  body_to_tree_map->clear();
+
+  const BodyNodeTopology& world_node =
+      tree_topology.get_body_node(BodyNodeIndex(0));
+
+  // Invalid (negative) index for the world. It does not belong to any tree in
+  // particular, but it's the "floor" of the forest. Also any "tree" that is
+  // anchored to the world is labeled with -1.
+  body_to_tree_map->resize(tree_topology.num_bodies(), -1);
+
+  // We deep traverse one tree at a time.
+  for (BodyNodeIndex base_index : world_node.child_nodes) {
+    // Bodies of the tree with base_index at the base.
+    std::vector<BodyIndex> tree_bodies;
+    // The permutation for the tree with base_index at its base.
+    std::vector<int> tree_permutation;
+    TreeDepthFirstTraversal(tree_topology, base_index, &tree_permutation,
+                            &tree_bodies);
+    const int tree_num_velocities = tree_permutation.size();
+    // Trees with zero dofs are not considered.
+    if (tree_num_velocities != 0) {
+      const int t = velocity_permutation->size();
+      velocity_permutation->push_back(tree_permutation);
+      for (BodyIndex body_index : tree_bodies) {
+        (*body_to_tree_map)[body_index] = t;
+      }
+    }
+  }
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/contact_permutation.h
+++ b/multibody/plant/contact_permutation.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/multibody/tree/multibody_tree_topology.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+// Computes a permutation to go from velocities in the order specified by
+// `tree_topology` (currently BFS order) to DFS order, so that all dofs for a
+// tree are contiguous.
+//
+// This new ordering depicts the mental model of a "forest of trees" topology.
+// Each tree in this forest has a base body which is a direct child of the world
+// body. Trees are assigned arbitrary contiguous positive indices.
+// In this picture, the world body is the "ground" of this forest and is not
+// assigned to any particular tree. Therefore the "ground" is identified with an
+// invalid, negative, tree index. Any other bodies or entire kinematic trees
+// that are anchored to the world are also assigned a negative index. That is,
+// only trees with non-zero dofs are assigned a positive tree index. Refer to
+// contact_permutation_test.cc for worked examples illustrating these
+// properties.
+//
+// The permutation is a bijection, i.e. there is a one-to-one correspondence
+// between the original dofs ordering in `tree_toplogy` and the new DFS
+// ordering.
+//
+// For each velocity dof with index v in tree_topology, the new permutation will
+// assign a dof with index vt within a tree with index t. A tree will have nt
+// dofs in total, and therefore dofs vt for t will be in the range [0, nt-1].
+//
+// NOTE: We use a "reverse" DFS order (that is, deeper dofs are first)
+// since for complex tree structures with a free floating base (consider the
+// Allegro hand for instance) the mass matrix will have an arrow sparsity
+// pattern (pointing to the bottom right). With a traditional DFS ordering we
+// also get an arrow pattern, but pointing to the upper left. The distinction
+// here is when performing Cholesky on the resulting mass matrix. In principle,
+// the two matrices above (with "forward" and "reverse" DFS order) have the same
+// underlying sparsity pattern and the choice of ordering does not hinder our
+// ability to exploit it. However if we wanted to use a general purpose sparse
+// Cholesky with no reordering (as we'd do for prototyping or even to avoid the
+// overhead of computing the permutation), the Cholesky factorization of the
+// mass matrix with reverse DFS proceeds without fill-in (that is, zero entries
+// in the mass matrix remain zero in the Cholesky factor). Ideally, we'd write
+// custom factorizations that exploit branch-induced sparsity but using this
+// ordering allow us to get away without this special purpose code using general
+// purpose sparse algebra. For more on this interesting subject refer to
+// [Featherstone, 2005].
+//
+// NOTE: There are multiple DFS numbering of dofs for the same topology
+// depending on the order branches are traversed. They all describe the same
+// topology and they all lead to zero fill-in. For convenience and speed, this
+// method simply traverses branches in tree_topology in the order they are
+// loaded for each node of the tree, see BodyNodeTopology::child_nodes.
+//
+// - [Featherstone, 2005] Featherstone, R., 2005. Efficient factorization of the
+//   joint-space inertia matrix for branched kinematic trees. The International
+//   Journal of Robotics Research, 24(6), pp.487-500.
+//
+// @param[in] tree_topology The topology of our multibody model. There is no
+//   requiremnt on the specific ordering, though currently it uses a BFS
+//   ordering.
+// @param[out] velocity_permutation
+//   The permutation is built such that dof vt of tree t maps to dof
+//   v = velocity_permutation[t][vt] in the original tree_topology.
+//   Valid vt indexes are in the range [0, nt-1], with nt =
+//   velocity_permutation[t].size(), the number of dofs for tree with index t.
+//   The total number of trees is given by velocity_permutation.size().
+//   The mapping is a bijection, and therefore each and every dof v in
+//   tree_topology is mapped by a dof vt in its tree t.
+//   Summarizing.
+//     v = velocity_permutation[t][vt]
+//   where:
+//     t: tree index.
+//     vt: local velocity index in tree t with DFS order.
+//     v: original velocity index in tree_topology.
+// @param[out] body_to_tree_map
+//   This map stores what tree each body belongs to. It is built such that
+//   t = body_to_tree_map[body_index] is the tree to which body_index belongs.
+//   t < 0 if body_index is anchored to the world. body_to_tree_map[0] < 0
+//   always since body_index = 0 corresponds to the world body.
+void ComputeDfsPermutation(
+    const MultibodyTreeTopology& tree_topology,
+    std::vector<std::vector<int>>* velocity_permutation,
+    std::vector<int>* body_to_tree_map);
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/test/contact_permutation_test.cc
+++ b/multibody/plant/test/contact_permutation_test.cc
@@ -1,0 +1,338 @@
+#include "drake/multibody/plant/contact_permutation.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/plant/multibody_plant.h"
+
+using drake::math::RigidTransform;
+using drake::math::RigidTransformd;
+using Eigen::Vector3d;
+
+namespace drake {
+namespace multibody {
+
+// Builds a complex enough model leading to a forest topology with four trees.
+// The model consists of two Kuka arms mounted on top of a robot table. A second
+// table is used for objects. The model also includes two free floating mug
+// models.
+// A few things to notice about this model:
+// 1. We add each component of the model in a rather arbitrary, probably not
+//    common order. That is, we add a robot then a mug, followed by a robot and
+//    yet another mug. Instead of adding all robots first followed by objects.
+//    We do this intentionally to "mix" the dofs and make the unit test more
+//    interesting.
+// 2. The two robots are directly welded to the world rather than to the table,
+//    as it'd be in real life. Though equivalent, this leads to two tables
+//    anchored to the world. We want to test these do not show up in our
+//    permutation since they are not even considered part of a "tree".
+void AddScenarioWithTwoArms(MultibodyPlant<double>* plant) {
+  DRAKE_DEMAND(!plant->is_finalized());
+
+  const std::string iiwa_sdf_path = FindResourceOrThrow(
+      "drake/manipulation/models/iiwa_description/sdf/"
+      "iiwa14_no_collision.sdf");
+
+  const std::string table_sdf_path = FindResourceOrThrow(
+      "drake/examples/kuka_iiwa_arm/models/table/"
+      "extra_heavy_duty_table_surface_only_collision.sdf");
+
+  const std::string mug_sdf_path =
+      FindResourceOrThrow("drake/examples/simple_gripper/simple_mug.sdf");
+
+  // Load a model of a table for the robot.
+  Parser parser(&*plant);
+  const ModelInstanceIndex robot_table_model =
+      parser.AddModelFromFile(table_sdf_path, "robot_table");
+  plant->WeldFrames(plant->world_frame(),
+                    plant->GetFrameByName("link", robot_table_model));
+
+  // Load the robot and weld it on top of the robot table.
+  const ModelInstanceIndex arm1_model =
+      parser.AddModelFromFile(iiwa_sdf_path, "robot1");
+
+  // Add a floating mug.
+  parser.AddModelFromFile(mug_sdf_path, "mug1");
+
+  const ModelInstanceIndex arm2_model =
+      parser.AddModelFromFile(iiwa_sdf_path, "robot2");
+
+  // Add a second floating mug.
+  parser.AddModelFromFile(mug_sdf_path, "mug2");
+
+  // Though only the topology is important for this test, we place the robot
+  // somewhere reasonble on top of the robot table.
+  const double table_top_z_in_world =
+      // table's top height
+      0.736 +
+      // table's top width
+      0.057 / 2;
+  const RigidTransformd X_WRobot1Link0(
+      Vector3d(0.0, 0.0, table_top_z_in_world));
+  plant->WeldFrames(plant->world_frame(),
+                    plant->GetFrameByName("iiwa_link_0", arm1_model),
+                    X_WRobot1Link0);
+
+  // Second arm.
+  const RigidTransformd X_WRobot2Link0(
+      Vector3d(0.5, 0.0, table_top_z_in_world));
+  plant->WeldFrames(plant->world_frame(),
+                    plant->GetFrameByName("iiwa_link_0", arm2_model),
+                    X_WRobot2Link0);
+
+  // Load a second table for objects.
+  const ModelInstanceIndex objects_table_model =
+      parser.AddModelFromFile(table_sdf_path, "objects_table");
+  const RigidTransformd X_WT(Vector3d(0.8, 0.0, 0.0));
+  plant->WeldFrames(plant->world_frame(),
+                    plant->GetFrameByName("link", objects_table_model), X_WT);
+
+  plant->Finalize();
+}
+
+int VerifyModelInstanceIsATreeAndReturnTreeIndex(
+    const MultibodyPlant<double>& plant, const std::string& model_instance_name,
+    const std::vector<int>& body_to_tree_map) {
+  const std::vector<BodyIndex> model_bodies =
+      plant.GetBodyIndices(plant.GetModelInstanceByName(model_instance_name));
+  DRAKE_DEMAND(model_bodies.size() > 0);
+  // For the purpose of these tests, verify the entire model instance belongs to
+  // the same tree.
+  const int t = body_to_tree_map[model_bodies[0]];  // tree for the first body.
+  for (const BodyIndex body_index : model_bodies) {
+    EXPECT_EQ(body_to_tree_map[body_index], t);
+  }
+  return t;
+}
+
+void VerifyDofsWhenModelInstanceIsATree(
+    const MultibodyPlant<double>& plant, const std::string& model_instance_name,
+    const std::vector<std::string>& joint_names,
+    const std::vector<int>& tree_permutation, bool is_floating = false) {
+  const ModelInstanceIndex model_instance =
+      plant.GetModelInstanceByName(model_instance_name);
+  const int nt = tree_permutation.size();
+  if (is_floating) {
+    // We expect 1 dof per joint + the floating base.
+    EXPECT_EQ(tree_permutation.size(), joint_names.size() + 6);
+
+    const auto& base_body = plant.GetUniqueFreeBaseBodyOrThrow(model_instance);
+    const int nq = plant.num_positions();
+    for (int i = 0; i < 6; ++i) {
+      // Dof index for a vector of velocities, therefore we subtract nq.
+      const int v = base_body.floating_velocities_start() + i - nq;
+      // N.B. Since we use a "reverse DFS order", the six dofs of a floating
+      // base will always be at the end of a tree's dofs.
+      EXPECT_EQ(tree_permutation[nt - 6 + i], v);
+    }
+
+  } else {
+    // In these tests we expect one dof per joint.
+    EXPECT_EQ(tree_permutation.size(), joint_names.size());
+  }
+
+  for (size_t i = 0; i < joint_names.size(); ++i) {
+    const auto& joint = plant.GetJointByName(joint_names[i], model_instance);
+    // Here we are implicitly assuming 1 dof per joint. Verify this.
+    ASSERT_EQ(joint.num_velocities(), 1);
+    // Verify dof.
+    EXPECT_EQ(tree_permutation[i], joint.velocity_start());
+  }
+}
+
+class MultibodyPlantTester {
+ public:
+  MultibodyPlantTester() = delete;
+  static const internal::MultibodyTreeTopology& get_topology(
+      const MultibodyPlant<double>& plant) {
+    DRAKE_DEMAND(plant.is_finalized());
+    return plant.internal_tree().get_topology();
+  }
+};
+
+namespace {
+
+GTEST_TEST(DofsPermutation, VelocitiesPermutation) {
+  MultibodyPlant<double> plant(0.0);
+  AddScenarioWithTwoArms(&plant);
+  // Two 7 dofs arms + two 6 dofs free bodies.
+  EXPECT_EQ(plant.num_velocities(), 26);
+
+  std::vector<std::vector<int>> velocity_permutation;
+  std::vector<int> body_to_tree_map;
+
+  const internal::MultibodyTreeTopology& topology =
+      MultibodyPlantTester::get_topology(plant);
+  drake::multibody::internal::ComputeDfsPermutation(
+      topology, &velocity_permutation, &body_to_tree_map);
+  // We expect four trees in the forest.
+  EXPECT_EQ(velocity_permutation.size(), 4);
+
+  // The permutation is a bijection. Verify the number of permuted dofs matches
+  // the total number of velocities in the model.
+  const int num_permuted_dofs =
+      std::accumulate(velocity_permutation.begin(), velocity_permutation.end(),
+                      0, [](int current, const std::vector<int>& tperm) {
+                        return current + tperm.size();
+                      });
+  EXPECT_EQ(num_permuted_dofs, plant.num_velocities());
+
+  // The world body does not belong to any tree.
+  EXPECT_LT(body_to_tree_map[0], 0);
+
+  // We form a vector of joint names in the order we expect them to be in
+  // (reversed) DFS order.
+  std::vector<std::string> joint_names = {
+      "iiwa_joint_7", "iiwa_joint_6", "iiwa_joint_5", "iiwa_joint_4",
+      "iiwa_joint_3", "iiwa_joint_2", "iiwa_joint_1"};
+
+  // Verify permutation for robot1.
+  const int robot1_tree = VerifyModelInstanceIsATreeAndReturnTreeIndex(
+      plant, "robot1", body_to_tree_map);
+  ASSERT_GE(robot1_tree, 0);  // non-zero dofs tree.
+  VerifyDofsWhenModelInstanceIsATree(plant, "robot1", joint_names,
+                                     velocity_permutation[robot1_tree]);
+
+  // Verify permutation for robot2.
+  const int robot2_tree = VerifyModelInstanceIsATreeAndReturnTreeIndex(
+      plant, "robot2", body_to_tree_map);
+  ASSERT_GE(robot2_tree, 0);  // non-zero dofs tree.
+  VerifyDofsWhenModelInstanceIsATree(plant, "robot2", joint_names,
+                                     velocity_permutation[robot2_tree]);
+
+  // We expect anchored models to have a negative tree index.
+  const int robot_table = VerifyModelInstanceIsATreeAndReturnTreeIndex(
+      plant, "robot_table", body_to_tree_map);
+  EXPECT_LT(robot_table, 0);  // zero dofs tree.
+  const int objects_table = VerifyModelInstanceIsATreeAndReturnTreeIndex(
+      plant, "objects_table", body_to_tree_map);
+  EXPECT_LT(objects_table, 0);  // zero dofs tree.
+
+  // Verify permutation for mug1.
+  const int mug1_tree = VerifyModelInstanceIsATreeAndReturnTreeIndex(
+      plant, "mug1", body_to_tree_map);
+  ASSERT_GE(mug1_tree, 0);  // non-zero dofs tree.
+  VerifyDofsWhenModelInstanceIsATree(plant, "mug1", {},
+                                     velocity_permutation[mug1_tree], true);
+
+  // Verify permutation for mug2.
+  const int mug2_tree = VerifyModelInstanceIsATreeAndReturnTreeIndex(
+      plant, "mug2", body_to_tree_map);
+  ASSERT_GE(mug2_tree, 0);  // non-zero dofs tree.
+  VerifyDofsWhenModelInstanceIsATree(plant, "mug2", {},
+                                     velocity_permutation[mug2_tree], true);
+}
+
+GTEST_TEST(DofsPermutation, AllegroHands) {
+  const std::string right_hand_model_path = FindResourceOrThrow(
+      "drake/manipulation/models/"
+      "allegro_hand_description/sdf/allegro_hand_description_right.sdf");
+
+  const std::string left_hand_model_path = FindResourceOrThrow(
+      "drake/manipulation/models/"
+      "allegro_hand_description/sdf/allegro_hand_description_left.sdf");
+
+  MultibodyPlant<double> plant(0);
+  Parser parser(&plant);
+  parser.AddModelFromFile(right_hand_model_path, "right hand");
+  const ModelInstanceIndex left_hand =
+      parser.AddModelFromFile(left_hand_model_path, "left hand");
+
+  // We weld the left hand to the world while the right hand is free.
+  plant.WeldFrames(plant.world_frame(),
+                   plant.GetFrameByName("hand_root", left_hand));
+  plant.Finalize();
+
+  // Compute BFS to DFS permutation.
+  std::vector<std::vector<int>> velocity_permutation;
+  std::vector<int> body_to_tree_map;
+  const internal::MultibodyTreeTopology& topology =
+      MultibodyPlantTester::get_topology(plant);
+  drake::multibody::internal::ComputeDfsPermutation(
+      topology, &velocity_permutation, &body_to_tree_map);
+
+  // We expect two trees in the forest, one for each hand.
+  EXPECT_EQ(velocity_permutation.size(), 2);
+
+  // The permutation is bijective. Verify the number of permuted dofs matches
+  // the total number of velocities in the model.
+  const int num_permuted_dofs =
+      velocity_permutation[0].size() + velocity_permutation[1].size();
+  EXPECT_EQ(num_permuted_dofs, plant.num_velocities());
+
+  // The world body does not belong to any tree.
+  EXPECT_LT(body_to_tree_map[0], 0);
+
+  // N.B. The order in which specific fingers show in the model depends on how
+  // the model was constructed. This ultimately has to do with the specific
+  // order given in the original SDF file. Therefore the ordering of the names
+  // in this test must be kept in sync with the original SDF file model.
+  std::vector<std::string> left_hand_joint_names;
+  // Ring finger
+  left_hand_joint_names.push_back("joint_11");
+  left_hand_joint_names.push_back("joint_10");
+  left_hand_joint_names.push_back("joint_9");
+  left_hand_joint_names.push_back("joint_8");
+
+  // Thumb finger
+  left_hand_joint_names.push_back("joint_15");
+  left_hand_joint_names.push_back("joint_14");
+  left_hand_joint_names.push_back("joint_13");
+  left_hand_joint_names.push_back("joint_12");
+
+  // Middle finger
+  left_hand_joint_names.push_back("joint_7");
+  left_hand_joint_names.push_back("joint_6");
+  left_hand_joint_names.push_back("joint_5");
+  left_hand_joint_names.push_back("joint_4");
+
+  // Index finger
+  left_hand_joint_names.push_back("joint_3");
+  left_hand_joint_names.push_back("joint_2");
+  left_hand_joint_names.push_back("joint_1");
+  left_hand_joint_names.push_back("joint_0");
+
+  std::vector<std::string> right_hand_joint_names;
+  // Index finger
+  right_hand_joint_names.push_back("joint_3");
+  right_hand_joint_names.push_back("joint_2");
+  right_hand_joint_names.push_back("joint_1");
+  right_hand_joint_names.push_back("joint_0");
+
+  // Thumb finger
+  right_hand_joint_names.push_back("joint_15");
+  right_hand_joint_names.push_back("joint_14");
+  right_hand_joint_names.push_back("joint_13");
+  right_hand_joint_names.push_back("joint_12");
+
+  // Middle finger
+  right_hand_joint_names.push_back("joint_7");
+  right_hand_joint_names.push_back("joint_6");
+  right_hand_joint_names.push_back("joint_5");
+  right_hand_joint_names.push_back("joint_4");
+
+  // Ring finger
+  right_hand_joint_names.push_back("joint_11");
+  right_hand_joint_names.push_back("joint_10");
+  right_hand_joint_names.push_back("joint_9");
+  right_hand_joint_names.push_back("joint_8");
+
+  // Verify permutation for the left hand.
+  const int left_hand_tree = VerifyModelInstanceIsATreeAndReturnTreeIndex(
+      plant, "left hand", body_to_tree_map);
+  VerifyDofsWhenModelInstanceIsATree(plant, "left hand", left_hand_joint_names,
+                                     velocity_permutation[left_hand_tree]);
+
+  // Verify permutation for the right hand. The right hand is floating.
+  const int right_hand_tree = VerifyModelInstanceIsATreeAndReturnTreeIndex(
+      plant, "right hand", body_to_tree_map);
+  VerifyDofsWhenModelInstanceIsATree(
+      plant, "right hand", right_hand_joint_names,
+      velocity_permutation[right_hand_tree], true);
+}
+
+}  // namespace
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Our current internal implementation of MultibodyPlant models orders dofs in a breadth-first traversal order. 
For everything we do today that is fine. However when building the sparse system of equations we need in our contact solvers for instance, this ordering leads to matrices (even the mass matrix) that look like gruyere cheese, with wholes (zeros) everywhere. 
Ideally we'd like depth-first ordering for these kind of operations, which leads to very nice block sparse structures we can exploit with custom algebra for this kind of sparsity (we are talking of a 10-20 X speed up here, not negligible at all).

Reordering dofs within MultibodyPlant, even if internal, is a major project. We must do it, but it's not the purpose of this PR. This PR is simply the first in a chain of PRs to offer a set of utilities to permute state and contact pairs so that they can be used within our contact solvers without having to go into the major project it'd be reordering states in MBP (doable, but since many users rely on their own understanding of state rather than using our APIs, most likely a change like that would break users' code, even if it shouldn't happen).

cc'ing @xuchenhan-tri since this is part of what you need.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14975)
<!-- Reviewable:end -->
