### PR TITLE
Add back frame visualization in Meshcat

### DIFF
--- a/bindings/pydrake/systems/test/meshcat_visualizer_test.py
+++ b/bindings/pydrake/systems/test/meshcat_visualizer_test.py
@@ -117,12 +117,17 @@ class TestMeshcat(unittest.TestCase):
         Parser(plant=kuka).AddModelFromFile(file_name)
         kuka.Finalize()
 
-        # Make sure that the frames to visualize exist.
-        kuka.GetModelInstanceByName("iiwa14")
-        kuka.GetFrameByName("iiwa_link_7")
-        kuka.GetFrameByName("iiwa_link_6")
+        frames_name_list = ["iiwa_link_7", "iiwa_link_6"]
+        frames_to_draw = []
 
-        frames_to_draw = {"iiwa14": {"iiwa_link_7", "iiwa_link_6"}}
+        for frame_name in frames_name_list:
+            frames_to_draw.append(
+                # Make sure the frames to visualize exists.
+                kuka.GetBodyFrameIdOrThrow(
+                    kuka.GetBodyByName(frame_name).index()
+                )
+            )
+
         visualizer = builder.AddSystem(MeshcatVisualizer(
             zmq_url=ZMQ_URL,
             open_browser=False,


### PR DESCRIPTION
The `frames_to_draw` argument in `ConnectMeshcatVisualizer` got accidentally deprecated in #14292 (this seems to be unintentional.) 

This is a tiny PR to add back the feature with the model inspector syntax.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14979)
<!-- Reviewable:end -->
