### PR TITLE
drake_visualizer: Use Drake's native lcmtypes for builtin_scripts

### DIFF
--- a/tools/workspace/drake_visualizer/_drake_visualizer_builtin_scripts/show_frame.py
+++ b/tools/workspace/drake_visualizer/_drake_visualizer_builtin_scripts/show_frame.py
@@ -6,7 +6,8 @@ from director import applogic
 from director import objectmodel as om
 from director import transformUtils
 from director import visualization as vis
-import robotlocomotion as lcmrobotlocomotion
+
+from drake import lcmt_viewer_draw
 
 from _drake_visualizer_builtin_scripts import scoped_singleton_func
 
@@ -57,7 +58,7 @@ class FramesVisualizer:
 
         self._subscriber = lcmUtils.addSubscriber(
             'DRAKE_DRAW_FRAMES.*',
-            messageClass=lcmrobotlocomotion.viewer_draw_t,
+            messageClass=lcmt_viewer_draw,
             callback=self._handle_message,
             callbackNeedsChannel=True)
         self._subscriber.setNotifyAllMessagesEnabled(True)

--- a/tools/workspace/drake_visualizer/_drake_visualizer_builtin_scripts/show_time.py
+++ b/tools/workspace/drake_visualizer/_drake_visualizer_builtin_scripts/show_time.py
@@ -1,9 +1,10 @@
 import time
 
-import bot_core as lcmbotcore
 from director import lcmUtils
 from director import applogic
 from director.visualization import updateText
+
+import drake
 
 from _drake_visualizer_builtin_scripts import scoped_singleton_func
 
@@ -26,7 +27,7 @@ class TimeVisualizer:
 
         self._subscriber = lcmUtils.addSubscriber(
             'DRAKE_VIEWER_DRAW',
-            messageClass=lcmbotcore.viewer_draw_t,
+            messageClass=drake.lcmt_viewer_draw,
             callback=self.handle_message)
 
     def remove_subscriber(self):


### PR DESCRIPTION
Do not use the (deprecated) RobotLocomotion/lcmtypes.

Note that we already use `from drake import ...` in other `builtin_scripts`, so we know that the `PYTHONPATH` stuff is correct.

Follow-up from #14884.
Towards #14362.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14981)
<!-- Reviewable:end -->
