### PR TITLE
manipulation_station: Add LCM cameras to mock simulation

### DIFF
--- a/examples/manipulation_station/BUILD.bazel
+++ b/examples/manipulation_station/BUILD.bazel
@@ -96,6 +96,7 @@ drake_cc_binary(
         "//manipulation/schunk_wsg:schunk_wsg_lcm",
         "//systems/analysis:simulator",
         "//systems/lcm",
+        "//systems/sensors:image_to_lcm_image_array_t",
         "@gflags",
     ],
 )


### PR DESCRIPTION
This is a warm-up exercise before the next step of publishing the cameras' point clouds (#14985).

![image](https://user-images.githubusercontent.com/17596505/116733275-bf0b9180-a9a0-11eb-95ef-bd8922779511.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14982)
<!-- Reviewable:end -->
