### PR TITLE
Fixes constness of JointActuator's SetRotorInertia() and SetGearRatio()

### DIFF
--- a/multibody/tree/joint_actuator.h
+++ b/multibody/tree/joint_actuator.h
@@ -214,14 +214,15 @@ class JointActuator final
 
   /// Sets the associated rotor inertia value for this actuator in `context`.
   /// See @ref reflected_inertia.
-  void SetRotorInertia(systems::Context<T>* context, const T& rotor_inertia) {
+  void SetRotorInertia(systems::Context<T>* context,
+                       const T& rotor_inertia) const {
     context->get_mutable_numeric_parameter(rotor_inertia_parameter_index_)[0] =
         rotor_inertia;
   }
 
   /// Sets the associated gear ratio value for this actuator in `context`.
   /// See @ref reflected_inertia.
-  void SetGearRatio(systems::Context<T>* context, const T& gear_ratio) {
+  void SetGearRatio(systems::Context<T>* context, const T& gear_ratio) const {
     context->get_mutable_numeric_parameter(gear_ratio_parameter_index_)[0] =
         gear_ratio;
   }


### PR DESCRIPTION
JointActuator's SetRotorInertia() and SetGearRatio() must be `const` since they only mutate the in/out context.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14983)
<!-- Reviewable:end -->
