### PR TITLE
sensors: Fix image_to_lcm_image_array uninitialized data

### DIFF
--- a/systems/sensors/image_to_lcm_image_array_t.h
+++ b/systems/sensors/image_to_lcm_image_array_t.h
@@ -25,9 +25,15 @@ namespace sensors {
 /// particular order of those images stored in lcmt_image_array,
 /// instead check the semantic of those images with
 /// lcmt_image::pixel_format before using them.
+///
+/// @note The output message's header field `seq` is always zero.
 class ImageToLcmImageArrayT : public systems::LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ImageToLcmImageArrayT)
+
+  /// Constructs an empty system with no input ports.
+  /// After construction, use DeclareImageInputPort() to add inputs.
+  explicit ImageToLcmImageArrayT(bool do_compress = false);
 
   /// An %ImageToLcmImageArrayT constructor.  Declares three input ports --
   /// one color image, one depth image, and one label image.
@@ -57,10 +63,6 @@ class ImageToLcmImageArrayT : public systems::LeafSystem<double> {
   /// Returns the abstract valued output port that contains a
   /// `Value<lcmt_image_array>`.
   const OutputPort<double>& image_array_t_msg_output_port() const;
-
-  /// Default constructor doesn't declare any ports.  Use the Add*Input()
-  /// methods to declare them.
-  explicit ImageToLcmImageArrayT(bool do_compress = false);
 
   template <PixelType kPixelType>
   const InputPort<double>& DeclareImageInputPort(const std::string& name) {


### PR DESCRIPTION
The implementation was leaving the outer `msg->header.seq` unset.

The implementation strategy was also unclear as to why we were taking the long way around.  I suspect it was for efficiency's sake, so here we document that fact along with comments to explain its correctness, as well as removing a large inner loop heap use + redundant copy when compression was enabled.

In the header, also shuffle the constructor to the top of the class per the style guide, and also improve its API doc for clarity.

Disclaim a TODO to set the image sequence number.  Doing so would be an odd job for a feedthrough system.  Assigning a sequence number typically requires a clock.  This system should just leave it at zero.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14984)
<!-- Reviewable:end -->
