### PR TITLE
system: Support scalar conversion by template parameter

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -121,18 +121,12 @@ def get_index_class(cls, T):
 
 
 # Permits parametric scalar type conversion.
-# TODO(eric.cousineau): Consider hoisting this to `test_utilities` or adding
-# `System.ToType[T]`.
 def to_type(system, T):
     assert isinstance(system, System_[float])
     if T == float:
         return system
-    elif T == AutoDiffXd:
-        return system.ToAutoDiffXd()
-    elif T == Expression:
-        return system.ToSymbolic()
     else:
-        assert False, "Invalid type, {}".format(T)
+        return system.ToScalarType[T]()
 
 
 class TestPlant(unittest.TestCase):

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -469,6 +469,22 @@ Note: The above is for the C++ documentation. For Python, use
 Note: The above is for the C++ documentation. For Python, use
 `witnesses = GetWitnessFunctions(context)`)"")
                 .c_str());
+    auto def_to_scalar_type = [&system_cls, doc](auto dummy) {
+      using U = decltype(dummy);
+      AddTemplateMethod(
+          system_cls, "ToScalarType",
+          [](const System<T>& self) { return self.template ToScalarType<U>(); },
+          GetPyParam<U>(), doc.System.ToScalarType.doc_0args);
+    };
+    type_visit(def_to_scalar_type, CommonScalarPack{});
+
+    auto def_to_scalar_type_maybe = [&system_cls, doc](auto dummy) {
+      using U = decltype(dummy);
+      AddTemplateMethod(system_cls, "ToScalarTypeMaybe",
+          &System<T>::template ToScalarTypeMaybe<U>, GetPyParam<U>(),
+          doc.System.ToScalarTypeMaybe.doc);
+    };
+    type_visit(def_to_scalar_type_maybe, CommonScalarPack{});
 
     using AllocCallback = typename LeafOutputPort<T>::AllocCallback;
     using CalcCallback = typename LeafOutputPort<T>::CalcCallback;

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -359,14 +359,25 @@ class TestGeneral(unittest.TestCase):
             system = Adder_[T](1, 1)
             # N.B. Current scalar conversion does not permit conversion to and
             # from the same type.
+            if T != float:
+                methods = [Adder_[T].ToScalarType[float],
+                           Adder_[T].ToScalarTypeMaybe[float]]
+                for method in methods:
+                    system_float = method(system)
+                    self.assertIsInstance(system_float, System_[float])
+                    self._compare_system_instances(system, system_float)
             if T != AutoDiffXd:
-                methods = [Adder_[T].ToAutoDiffXd, Adder_[T].ToAutoDiffXdMaybe]
+                methods = [Adder_[T].ToAutoDiffXd, Adder_[T].ToAutoDiffXdMaybe,
+                           Adder_[T].ToScalarType[AutoDiffXd],
+                           Adder_[T].ToScalarTypeMaybe[AutoDiffXd]]
                 for method in methods:
                     system_ad = method(system)
                     self.assertIsInstance(system_ad, System_[AutoDiffXd])
                     self._compare_system_instances(system, system_ad)
             if T != Expression:
-                methods = [Adder_[T].ToSymbolic, Adder_[T].ToSymbolicMaybe]
+                methods = [Adder_[T].ToSymbolic, Adder_[T].ToSymbolicMaybe,
+                           Adder_[T].ToScalarType[Expression],
+                           Adder_[T].ToScalarTypeMaybe[Expression]]
                 for method in methods:
                     system_sym = method(system)
                     self.assertIsInstance(system_sym, System_[Expression])

--- a/bindings/pydrake/systems/test/scalar_conversion_test.py
+++ b/bindings/pydrake/systems/test/scalar_conversion_test.py
@@ -86,16 +86,20 @@ class TestScalarConversion(unittest.TestCase):
         for T, U in SystemScalarConverter.SupportedConversionPairs:
             system_U = Example_[U](100)
             self.assertIs(system_U.copied_from, None)
-            if T == AutoDiffXd:
-                method = LeafSystem_[U].ToAutoDiffXd
-            elif T == Expression:
-                method = LeafSystem_[U].ToSymbolic
-            else:
-                continue
-            system_T = method(system_U)
+            system_T = system_U.ToScalarType[T]()
             self.assertIsInstance(system_T, Example_[T])
             self.assertEqual(system_T.value, 100)
             self.assertIs(system_T.copied_from, system_U)
+            if T == AutoDiffXd:
+                system_ad = system_U.ToAutoDiffXd()
+                self.assertIsInstance(system_ad, Example_[T])
+                self.assertEqual(system_ad.value, 100)
+                self.assertIs(system_ad.copied_from, system_U)
+            if T == Expression:
+                system_sym = system_U.ToSymbolic()
+                self.assertIsInstance(system_sym, Example_[T])
+                self.assertEqual(system_sym.value, 100)
+                self.assertIs(system_sym.copied_from, system_U)
 
     def test_example_system_in_diagram(self):
         system_f = Example(value=10)

--- a/systems/framework/system.cc
+++ b/systems/framework/system.cc
@@ -813,14 +813,7 @@ std::unique_ptr<System<AutoDiffXd>> System<T>::ToAutoDiffXd() const {
 
 template <typename T>
 std::unique_ptr<System<AutoDiffXd>> System<T>::ToAutoDiffXdMaybe() const {
-  using U = AutoDiffXd;
-  auto result = system_scalar_converter_.Convert<U, T>(*this);
-  if (result) {
-    for (const auto& item : external_constraints_) {
-      result->AddExternalConstraint(item);
-    }
-  }
-  return result;
+  return ToScalarTypeMaybe<AutoDiffXd>();
 }
 
 template <typename T>
@@ -831,14 +824,7 @@ std::unique_ptr<System<symbolic::Expression>> System<T>::ToSymbolic() const {
 template <typename T>
 std::unique_ptr<System<symbolic::Expression>>
 System<T>::ToSymbolicMaybe() const {
-  using U = symbolic::Expression;
-  auto result = system_scalar_converter_.Convert<U, T>(*this);
-  if (result) {
-    for (const auto& item : external_constraints_) {
-      result->AddExternalConstraint(item);
-    }
-  }
-  return result;
+  return ToScalarTypeMaybe<symbolic::Expression>();
 }
 
 template <typename T>
@@ -1232,6 +1218,13 @@ const BasicVector<T>* System<T>::EvalBasicVectorInputImpl(
   return basic_vector;
 }
 
+template <typename T>
+void System<T>::AddExternalConstraints(
+    const std::vector<ExternalSystemConstraint>& constraints) {
+  for (const auto& item : constraints) {
+    AddExternalConstraint(item);
+  }
+}
 }  // namespace systems
 }  // namespace drake
 

--- a/systems/framework/system_base.cc
+++ b/systems/framework/system_base.cc
@@ -271,5 +271,15 @@ void SystemBase::ThrowValidateContextMismatch(
       context.GetSystemPathname()));
 }
 
+[[noreturn]] void SystemBase::ThrowUnsupportedScalarConversion(
+    const SystemBase& from, const std::string& destination_type_name) {
+  std::stringstream ss;
+  ss << "The object named [" << from.get_name() << "] of type "
+     << NiceTypeName::Get(from)
+     << " does not support scalar conversion to type ["
+     << destination_type_name <<"].";
+  throw std::logic_error(ss.str().c_str());
+}
+
 }  // namespace systems
 }  // namespace drake

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -1075,6 +1075,11 @@ class SystemBase : public internal::SystemMessageInterface {
   check(s) given by ValidateContext have failed. */
   [[noreturn]] void ThrowValidateContextMismatch(const ContextBase&) const;
 
+  /** (Internal use only) Throws a std::exception for unsupported scalar type
+  conversions. */
+  [[noreturn]] static void ThrowUnsupportedScalarConversion(
+      const SystemBase& from, const std::string& destination_type_name);
+
   /** This method must be invoked from within derived class DoAllocateContext()
   implementations right after the concrete Context object has been allocated.
   It allocates cache entries, sets up all intra-Context dependencies, and marks

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -515,14 +515,24 @@ TEST_F(SystemTest, TransmogrifyNotSupported) {
   // Use the static method.
   EXPECT_THROW(System<double>::ToAutoDiffXd<System>(system_), std::exception);
   EXPECT_THROW(System<double>::ToSymbolic<System>(system_), std::exception);
+  EXPECT_THROW(System<double>::ToScalarType<AutoDiffXd>(system_),
+               std::exception);
+  EXPECT_THROW(
+      System<double>::ToScalarType<symbolic::Expression>(system_),
+      std::exception);
 
   // Use the instance method that throws.
   EXPECT_THROW(system_.ToAutoDiffXd(), std::exception);
   EXPECT_THROW(system_.ToSymbolic(), std::exception);
+  EXPECT_THROW(system_.ToScalarType<AutoDiffXd>(), std::exception);
+  EXPECT_THROW(system_.ToScalarType<symbolic::Expression>(),
+               std::exception);
 
   // Use the instance method that returns nullptr.
   EXPECT_EQ(system_.ToAutoDiffXdMaybe(), nullptr);
   EXPECT_EQ(system_.ToSymbolicMaybe(), nullptr);
+  EXPECT_EQ(system_.ToScalarTypeMaybe<AutoDiffXd>(), nullptr);
+  EXPECT_EQ(system_.ToScalarTypeMaybe<symbolic::Expression>(), nullptr);
 
   // Spot check the specific converter object.
   EXPECT_FALSE((


### PR DESCRIPTION
Closes: #13313.

Adds various ToScalarType<U> methods to System, after the manner of
To{AutoDiffXd,Symbolic}, and refactors all of them to use the single templated
implementation. Also adds python bindings and unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14986)
<!-- Reviewable:end -->
