### PR TITLE
[hotfix] Fixes an address error in mesh-half space intersection

### DIFF
--- a/geometry/proximity/mesh_half_space_intersection.cc
+++ b/geometry/proximity/mesh_half_space_intersection.cc
@@ -341,10 +341,10 @@ ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
     const math::RigidTransform<T>& X_WR) {
   std::vector<SurfaceFaceIndex> tri_indices;
   tri_indices.reserve(mesh_R.num_elements());
-  const math::RotationMatrixd& R_WR = convert_to_double(X_WR).rotation();
   auto bvh_callback = [&tri_indices, &mesh_R,
                        R_WS = convert_to_double(X_WS).rotation(),
-                       &R_WR](SurfaceFaceIndex tri_index) {
+                       R_WR = convert_to_double(X_WR).rotation()](
+                          SurfaceFaceIndex tri_index) {
     // The gradient of the half space pressure field lies in the _opposite_
     // direction as its normal. Its normal is Sz. So, unit_grad_p_W = -Sz_W.
     const Eigen::Vector3d& unit_grad_p_W = -R_WS.col(2);


### PR DESCRIPTION
The converted rotation matrix *reference* was not surviving -- instead we'll safely copy.

replaces #14995

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/14996)
<!-- Reviewable:end -->
