### PR TITLE
workspace: Disable voxelized_geometry_tools unit test

### DIFF
--- a/tools/workspace/voxelized_geometry_tools/BUILD.bazel
+++ b/tools/workspace/voxelized_geometry_tools/BUILD.bazel
@@ -3,8 +3,11 @@
 
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
-sh_test(
+# TODO(jwnimmer-tri) Re-enable this test (rename it to sh_test), while ensuring
+# that it is only tested on Ubuntu; it does not pass on macOS.
+sh_binary(
     name = "pointcloud_voxelization_test",
+    testonly = True,
     srcs = ["@voxelized_geometry_tools//:pointcloud_voxelization_test"],
 )
 


### PR DESCRIPTION
It no longer passes on macOS ([link](https://drake-cdash.csail.mit.edu/test/192474043)) after the latest Apple upgrade ([link](https://discussions.apple.com/thread/252710156)).

Later, we should re-enable this test, while ensuring that it is only tested on Ubuntu.  For now, the goal is just to put out the CI fires.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15005)
<!-- Reviewable:end -->
