### PR TITLE
system: Add compatibility checks for output using methods

### DIFF
--- a/systems/controllers/test/pid_controlled_system_test.cc
+++ b/systems/controllers/test/pid_controlled_system_test.cc
@@ -269,13 +269,15 @@ class ConnectControllerTest : public ::testing::Test {
   double ComputePidInput() {
     auto standard_diagram = builder_.Build();
     auto context = standard_diagram->CreateDefaultContext();
-    auto output = standard_diagram->AllocateOutput();
 
+    auto plant_output =
+        standard_diagram->GetSubsystemByName(plant_->get_name())
+        .AllocateOutput();
     auto& plant_context =
         standard_diagram->GetSubsystemContext(*plant_, *context);
 
-    plant_->CalcOutput(plant_context, output.get());
-    const BasicVector<double>* output_vec = output->get_vector_data(0);
+    plant_->CalcOutput(plant_context, plant_output.get());
+    const BasicVector<double>* output_vec = plant_output->get_vector_data(0);
     const double pid_input =
         dynamic_cast<TestPlant*>(plant_)->GetInputValue(plant_context);
 

--- a/systems/framework/system.cc
+++ b/systems/framework/system.cc
@@ -52,6 +52,7 @@ std::unique_ptr<SystemOutput<T>> System<T>::AllocateOutput() const {
     const OutputPort<T>& port = this->get_output_port(i);
     output->add_port(port.Allocate());
   }
+  output->set_system_id(get_system_id());
   return output;
 }
 
@@ -439,7 +440,7 @@ void System<T>::CalcOutput(const Context<T>& context,
                            SystemOutput<T>* outputs) const {
   DRAKE_DEMAND(outputs != nullptr);
   ValidateContext(context);
-  DRAKE_ASSERT_VOID(CheckValidOutput(outputs));
+  ValidateCreatedForThisSystem(outputs);
   for (OutputPortIndex i(0); i < num_output_ports(); ++i) {
     // TODO(sherm1) Would be better to use Eval() here but we don't have
     // a generic abstract assignment capability that would allow us to
@@ -742,26 +743,6 @@ boolean<T> System<T>::CheckSystemConstraintsSatisfied(
     }
   }
   return result;
-}
-
-template <typename T>
-void System<T>::CheckValidOutput(const SystemOutput<T>* output) const {
-  DRAKE_THROW_UNLESS(output != nullptr);
-
-  // Checks that the number of output ports in the system output is consistent
-  // with the number of output ports declared by the System.
-  DRAKE_THROW_UNLESS(output->num_ports() == num_output_ports());
-
-  // Checks the validity of each output port.
-  for (int i = 0; i < num_output_ports(); ++i) {
-    // TODO(sherm1): consider adding (very expensive) validation of the
-    // abstract ports also.
-    if (get_output_port(i).get_data_type() == kVectorValued) {
-      const BasicVector<T>* output_vector = output->get_vector_data(i);
-      DRAKE_THROW_UNLESS(output_vector != nullptr);
-      DRAKE_THROW_UNLESS(output_vector->size() == get_output_port(i).size());
-    }
-  }
 }
 
 template <typename T>
@@ -1117,6 +1098,8 @@ template <typename T>
 Eigen::VectorBlock<VectorX<T>> System<T>::GetMutableOutputVector(
     SystemOutput<T>* output, int port_index) const {
   DRAKE_ASSERT(0 <= port_index && port_index < num_output_ports());
+  DRAKE_DEMAND(output != nullptr);
+  ValidateCreatedForThisSystem(output);
 
   BasicVector<T>* output_vector = output->GetMutableVectorData(port_index);
   DRAKE_ASSERT(output_vector != nullptr);

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -1012,12 +1012,6 @@ class System : public SystemBase {
   boolean<T> CheckSystemConstraintsSatisfied(
       const Context<T>& context, double tol) const;
 
-  /** Checks that @p output is consistent with the number and size of output
-  ports declared by the system.
-  @throws std::exception unless `output` is non-null and valid for this
-  system. */
-  void CheckValidOutput(const SystemOutput<T>* output) const;
-
   /** Returns a copy of the continuous state vector x꜀ into an Eigen
   vector. */
   VectorX<T> CopyContinuousStateVector(const Context<T>& context) const;

--- a/systems/framework/system_output.h
+++ b/systems/framework/system_output.h
@@ -9,6 +9,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/value.h"
 #include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/framework_common.h"
 
 namespace drake {
 namespace systems {
@@ -89,7 +90,16 @@ class SystemOutput {
     port_values_.emplace_back(std::move(model_value));
   }
 
+  // Gets the id of the subsystem that created this output.
+  internal::SystemId get_system_id() const { return system_id_; }
+
+  // Records the id of the subsystem that created this output.
+  void set_system_id(internal::SystemId id) { system_id_ = id; }
+
   std::vector<copyable_unique_ptr<AbstractValue>> port_values_;
+
+  // Unique id of the subsystem that created this output.
+  internal::SystemId system_id_;
 };
 
 }  // namespace systems


### PR DESCRIPTION
Relevant to: #12560

Add system-id labeling to the SystemOutput class, and use that to
implement checks using ValidateCreatedForThisSystem(). Retire the
expensive, and less-precise CheckValidOutput() method.

This should complete compatibility checking for public methods of
System<T>. Several other classes need work to be fully checked.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15007)
<!-- Reviewable:end -->
