### PR TITLE
Add AVX infrastructure and one AVX composition method.

### DIFF
--- a/geometry/proximity/test/mesh_half_space_intersection_test.cc
+++ b/geometry/proximity/test/mesh_half_space_intersection_test.cc
@@ -1458,7 +1458,7 @@ TEST_F(MeshHalfSpaceDerivativesTest, FaceNormalsWrtPosition) {
     for (SurfaceFaceIndex t(0); t < surface.mesh_W().num_elements(); ++t) {
       const Vector3<AutoDiffXd> n_W = surface.mesh_W().face_normal(t);
       EXPECT_TRUE(CompareMatrices(math::autoDiffToGradientMatrix(n_W),
-                                  zero_matrix, 16 * kEps));
+                                  zero_matrix, 32 * kEps));
     }
   };
 

--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -24,6 +24,7 @@ drake_cc_package_library(
         ":discrete_lyapunov_equation",
         ":eigen_sparse_triplet",
         ":evenly_distributed_pts_on_sphere",
+        ":fast_pose_composition_functions",
         ":geometric_transform",
         ":gradient",
         ":gray_code",
@@ -140,6 +141,7 @@ drake_cc_library(
         "rotation_matrix.h",
     ],
     deps = [
+        ":fast_pose_composition_functions",
         "//common:default_scalars",
         "//common:drake_bool",
         "//common:essential",
@@ -267,6 +269,23 @@ drake_cc_library(
         "//common:double",
         "//common:essential",
     ],
+)
+
+# This should be compiled with Intel AVX2 and FMA enabled if possible.
+# Currently (March 2021) we can't do that on Apple even if it is Intel-based
+# due to our old Mac CI machines. Compiling for Broadwell (or later) gets
+# those instructions.
+drake_cc_library(
+    name = "fast_pose_composition_functions",
+    srcs = ["fast_pose_composition_functions.cc"],
+    hdrs = ["fast_pose_composition_functions.h"],
+    copts = select({
+        "//tools/cc_toolchain:apple": [],
+        "//conditions:default": [
+            "-march=broadwell",
+        ],
+    }),
+    deps = [],
 )
 
 # === test/ ===
@@ -504,6 +523,15 @@ drake_cc_googletest(
     name = "wrap_to_test",
     deps = [
         ":wrap_to",
+    ],
+)
+
+drake_cc_googletest(
+    name = "fast_pose_composition_functions_test",
+    deps = [
+        ":fast_pose_composition_functions",
+        "//common:essential",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/math/fast_pose_composition_functions.cc
+++ b/math/fast_pose_composition_functions.cc
@@ -1,0 +1,153 @@
+#include "drake/math/fast_pose_composition_functions.h"
+
+#include <algorithm>
+
+#if defined(__AVX2__) && defined(__FMA__)
+#include <cstdint>
+
+#include <immintrin.h>
+#endif
+
+namespace drake {
+namespace math {
+
+/* The portable C++ versions are always defined. They should be written
+to maximize the chance that a dumb compiler can generate fast code.
+
+The AVX functions are optionally defined depending on the compiler flags used
+for this compilation unit. If defined, the no-suffix, publicly-visible functions
+like ComposeRR() are implemented with the "...Avx" methods, otherwise with the
+"...Portable" methods.
+
+The AVX functions are strictly local to this file, but the portable ones are
+placed in namespace internal so that they can be unit tested regardless of
+whether they are used on this platform to implement the publicly-visible
+functions.
+
+Note that, except when explicitly marked "...NoAlias", the methods below must
+allow for the output argument's memory to overlap with any of the input
+arguments' memory. */
+
+namespace {
+/* Dot product of a row of l and a column of m, where both l and m are 3x3s
+in column order. */
+double row_x_col(const double* l, const double* m) {
+  return l[0] * m[0] + l[3] * m[1] + l[6] * m[2];
+}
+
+/* @pre R_AC is disjoint in memory from the inputs. */
+void ComposeRRNoAlias(const double* R_AB, const double* R_BC, double* R_AC) {
+  R_AC[0] = row_x_col(&R_AB[0], &R_BC[0]);
+  R_AC[1] = row_x_col(&R_AB[1], &R_BC[0]);
+  R_AC[2] = row_x_col(&R_AB[2], &R_BC[0]);
+  R_AC[3] = row_x_col(&R_AB[0], &R_BC[3]);
+  R_AC[4] = row_x_col(&R_AB[1], &R_BC[3]);
+  R_AC[5] = row_x_col(&R_AB[2], &R_BC[3]);
+  R_AC[6] = row_x_col(&R_AB[0], &R_BC[6]);
+  R_AC[7] = row_x_col(&R_AB[1], &R_BC[6]);
+  R_AC[8] = row_x_col(&R_AB[2], &R_BC[6]);
+}
+}  // namespace
+
+namespace internal {
+
+/* Composition of rotation matrices R_AC = R_AB * R_BC. Each matrix is 9
+consecutive doubles in column order. */
+void ComposeRRPortable(const double* R_AB, const double* R_BC, double* R_AC) {
+  double R_AC_temp[9];  // Protect from overlap with inputs.
+  ComposeRRNoAlias(R_AB, R_BC, R_AC_temp);
+  std::copy(R_AC_temp, R_AC_temp + 9, R_AC);
+}
+
+}  // namespace internal
+
+#if defined(__AVX2__) && defined(__FMA__)
+
+namespace {
+
+// Turn d into d d d d.
+__m256d four(double d) {
+  return _mm256_set1_pd(d);
+}
+
+/* Composition of rotation matrices R_AC = R_AB * R_BC.
+Each matrix is 9 consecutive doubles in column order.
+
+We want to perform this 3x3 matrix multiply:
+
+     R_AC    R_AB    R_BC
+
+    r u x   a d g   A D G
+    s v y = b e h * B E H     All column ordered in memory.
+    t w z   c f i   C F I
+
+Strategy: compute column rst in parallel, then uvw, then xyz.
+r = aA+dB+gC
+s = bA+eB+hC  etc.
+t = cA+fB+iC
+
+Load columns from left matrix, duplicate elements from right. Perform 4
+operations in parallel but ignore the 4th result. Be careful not to load or
+store past the last element.
+
+This requires 45 flops (9 dot products) but we're doing 60 here and throwing
+away 15 of them. However, we only issue 9 floating point instructions. */
+void ComposeRRAvx(const double* R_AB, const double* R_BC, double* R_AC) {
+  constexpr int64_t yes = int64_t(1) << 63;
+  constexpr int64_t no  = int64_t(0);
+  const __m256i mask = _mm256_setr_epi64x(yes, yes, yes, no);
+
+  // Aliases for readability (named after first entries in comment above).
+  const double* a = R_AB; const double* A = R_BC; double* r = R_AC;
+
+  const __m256d col0 = _mm256_loadu_pd(a);             // a b c (d)  d unused
+  const __m256d col1 = _mm256_loadu_pd(a+3);           // d e f (g)  g unused
+  const __m256d col2 = _mm256_maskload_pd(a+6, mask);  // g h i (0)
+
+  const __m256d ABCD = _mm256_loadu_pd(A);             // A B C D
+  const __m256d EFGH = _mm256_loadu_pd(A+4);           // E F G H
+  const double I = *(A+8);                             // I
+
+  __m256d res;
+
+  // Column rst                                         r   s   t   (-)
+  res = _mm256_mul_pd(col0, four(ABCD[0]));         //  aA  bA  cA ( dA)
+  res = _mm256_fmadd_pd(col1, four(ABCD[1]), res);  // +dB +eB +fB (+gB)
+  res = _mm256_fmadd_pd(col2, four(ABCD[2]), res);  // +gC +hC +iC (+0C)
+  _mm256_storeu_pd(r, res);  // r s t (u)  we will overwrite u
+
+  // Column uvw                                         u   v   w   (-)
+  res = _mm256_mul_pd(col0, four(ABCD[3]));         //  aD  bD  cD ( dD)
+  res = _mm256_fmadd_pd(col1, four(EFGH[0]), res);  // +dE +eE +fE (+gE)
+  res = _mm256_fmadd_pd(col2, four(EFGH[1]), res);  // +gF +hF +iF (+0F)
+  _mm256_storeu_pd(r+3, res);  // u v w (x)  we will overwrite x
+
+  // Column xyz                                         x   y   z   (-)
+  res = _mm256_mul_pd(col0, four(EFGH[2]));         //  aG  bG  cG ( dG)
+  res = _mm256_fmadd_pd(col1, four(EFGH[3]), res);  // +dH +eH +fH (+gH)
+  res = _mm256_fmadd_pd(col2, four(I), res);        // +gI +hI +iI (+0I)
+  _mm256_maskstore_pd(r+6, mask, res);  // x y z
+
+  // The compiler will generate a vzeroupper instruction if needed.
+}
+
+}  // namespace
+
+/* Use AVX methods. */
+bool IsUsingPortableCompositionMethods() { return false; }
+
+void ComposeRR(const double* R_AB, const double* R_BC, double* R_AC) {
+  ComposeRRAvx(R_AB, R_BC, R_AC);
+}
+
+#else
+/* Use portable methods. */
+bool IsUsingPortableCompositionMethods() { return true; }
+
+void ComposeRR(const double* R_AB, const double* R_BC, double* R_AC) {
+  internal::ComposeRRPortable(R_AB, R_BC, R_AC);
+}
+#endif
+
+}  // namespace math
+}  // namespace drake

--- a/math/fast_pose_composition_functions.h
+++ b/math/fast_pose_composition_functions.h
@@ -1,0 +1,41 @@
+#pragma once
+
+/** @file
+Declarations for fast, low-level functions for handling objects stored in small
+matrices with known memory layouts. Ideally these are implemented using
+platform-specific SIMD instructions for speed. There is always a straight
+C++ fallback. */
+
+namespace drake {
+namespace math {
+
+/** Composes two drake::math::RotationMatrix<double> objects as quickly as
+possible. Drake RotationMatrix objects are stored as 3x3 column-ordered
+matrices in nine consecutive doubles.
+
+This method can also be used to form the product of two general 3x3 matrices.
+
+Here we calculate `R_AC = R_AB * R_BC`. It is OK for R_AC to overlap
+with one or both inputs. */
+void ComposeRR(const double* R_AB, const double* R_BC, double* R_AC);
+
+// TODO(sherm1) ComposeRinvR(), ComposeXX(), ComposeXinvX()
+
+/** Returns `true` if we are using the portable fallback implementations for
+the above methods. */
+bool IsUsingPortableCompositionMethods();
+
+namespace internal {
+/* These portable implementations are exposed so they can be unit tested.
+Call IsUsingPortableCompositionMethods() to determine whether these are being
+used to implement the above methods. */
+
+void ComposeRRPortable(const double* R_AB, const double* R_BC, double* R_AC);
+
+// TODO(sherm1) ComposeRinvRPortable(), ComposeXXPortable(),
+//              ComposeXinvXPortable()
+
+}  // namespace internal
+
+}  // namespace math
+}  // namespace drake

--- a/math/test/fast_pose_composition_functions_test.cc
+++ b/math/test/fast_pose_composition_functions_test.cc
@@ -1,0 +1,70 @@
+#include "drake/math/fast_pose_composition_functions.h"
+
+#include <limits>
+
+#include <Eigen/Dense>
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+
+namespace drake {
+namespace math {
+namespace  {
+using Eigen::Matrix3d;
+
+GTEST_TEST(TestFastPoseCompositionFunctions, UsingAVX) {
+#ifdef __APPLE__
+  constexpr bool kApple = true;
+#else
+  constexpr bool kApple = false;
+#endif
+
+  EXPECT_EQ(IsUsingPortableCompositionMethods(), kApple);
+}
+
+// Test the given RotationMatrix composition function for correct functionality
+// (just a matrix multiply in this case) and that it still works when the output
+// overlaps in memory with the inputs.
+void TestRR(
+    std::function<void(const double*, const double*, double*)> compose_RR) {
+  Matrix3d M, N;
+  M << 1, 5, 9, 2, 6, 10, 3, 7, 11;
+  N << 13, 17, 21, 14, 18, 22, 15, 19, 23;
+  const Matrix3d MM_expected = M * M;
+  const Matrix3d MN_expected = M * N;
+
+  Matrix3d MN;
+  compose_RR(M.data(), N.data(), MN.data());
+
+  // Should be a perfect match with integer elements.
+  EXPECT_TRUE(CompareMatrices(MN, MN_expected, 0));
+
+  // Now test in-place compositions.
+  Matrix3d Mwork = M, Nwork = N;  // Copies to overwrite.
+
+  // Results should be perfect match with integer elements.
+  compose_RR(Mwork.data(), Nwork.data(), Mwork.data());  // Mwork=M*N
+  EXPECT_TRUE(CompareMatrices(Mwork, MN_expected, 0));
+  Mwork = M;                                             // Restore value.
+  compose_RR(Mwork.data(), Nwork.data(), Nwork.data());  // Nwork=M*N
+  EXPECT_TRUE(CompareMatrices(Nwork, MN_expected, 0));
+  compose_RR(Mwork.data(), Mwork.data(), Mwork.data());  // Mwork=M*M
+  EXPECT_TRUE(CompareMatrices(Mwork, MM_expected, 0));
+}
+
+/* Test the user-callable methods first. Those are ideally implemented
+with SIMD instructions, however they may just punt to the plain C++ fallback
+methods, which we'll test separately below. */
+GTEST_TEST(TestFastPoseCompositionFunctions, TestRotationCompositions) {
+  SCOPED_TRACE("testing ComposeRR()");
+  TestRR(ComposeRR);
+}
+
+GTEST_TEST(TestFastPoseCompositionFunctions, TestPortableRotationCompositions) {
+  SCOPED_TRACE("testing internal::ComposeRRPortable()");
+  TestRR(internal::ComposeRRPortable);
+}
+
+}  // namespace
+}  // namespace math
+}  // namespace drake


### PR DESCRIPTION
This is the first PR in a train leading up to #14768 which provides a family of AVX methods. Here we have just the infrastructure and the simplest AVX method for composition of two 3x3 rotation matrices.

Measured throughput in gigaflops (thanks to @joemasterjohn):
|              | ComposeRR() 
| ---------:|:---------:|
|   C++     |    5.38   |
|   AVX      | 14.16      |
| Speedup | **2.6X** |


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15013)
<!-- Reviewable:end -->
