### PR TITLE
Add allow_nonconvex flag to QuadraticCost constructor.

### DIFF
--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -882,10 +882,9 @@ top-level documentation for :py:mod:`pydrake.math`.
           "Adds a cost function")
       .def("AddCost",
           static_cast<Binding<Cost> (MathematicalProgram::*)(
-              const Expression&)>(&MathematicalProgram::AddCost),
-          // N.B. There is no corresponding C++ method, so the docstring here
-          // is a literal, not a reference to documentation_pybind.h
-          "Adds a cost expression")
+              const Expression&, bool)>(&MathematicalProgram::AddCost),
+          py::arg("e"), py::arg("allow_nonconvex_quadratic") = false,
+          doc.MathematicalProgram.AddCost.doc_symbolic_expression_bool)
       .def("AddLinearCost",
           static_cast<Binding<LinearCost> (MathematicalProgram::*)(
               const Expression&)>(&MathematicalProgram::AddLinearCost),
@@ -901,29 +900,33 @@ top-level documentation for :py:mod:`pydrake.math`.
           static_cast<Binding<QuadraticCost> (MathematicalProgram::*)(
               const Eigen::Ref<const Eigen::MatrixXd>&,
               const Eigen::Ref<const Eigen::VectorXd>&,
-              const Eigen::Ref<const VectorXDecisionVariable>&)>(
+              const Eigen::Ref<const VectorXDecisionVariable>&, bool)>(
               &MathematicalProgram::AddQuadraticCost),
           py::arg("Q"), py::arg("b"), py::arg("vars"),
-          doc.MathematicalProgram.AddQuadraticCost.doc_3args)
+          py::arg("allow_nonconvex") = false,
+          doc.MathematicalProgram.AddQuadraticCost.doc_4args)
       .def("AddQuadraticCost",
           static_cast<Binding<QuadraticCost> (MathematicalProgram::*)(
               const Eigen::Ref<const Eigen::MatrixXd>&,
               const Eigen::Ref<const Eigen::VectorXd>&, double,
-              const Eigen::Ref<const VectorXDecisionVariable>&)>(
+              const Eigen::Ref<const VectorXDecisionVariable>&, bool)>(
               &MathematicalProgram::AddQuadraticCost),
           py::arg("Q"), py::arg("b"), py::arg("c"), py::arg("vars"),
-          doc.MathematicalProgram.AddQuadraticCost.doc_4args)
+          py::arg("allow_nonconvex") = false,
+          doc.MathematicalProgram.AddQuadraticCost.doc_5args)
       .def("AddQuadraticCost",
           static_cast<Binding<QuadraticCost> (MathematicalProgram::*)(
-              const Expression&)>(&MathematicalProgram::AddQuadraticCost),
-          py::arg("e"), doc.MathematicalProgram.AddQuadraticCost.doc_1args)
+              const Expression&, bool)>(&MathematicalProgram::AddQuadraticCost),
+          py::arg("e"), py::arg("allow_nonconvex") = false,
+          doc.MathematicalProgram.AddQuadraticCost.doc_2args)
       .def("AddQuadraticErrorCost",
           overload_cast_explicit<Binding<QuadraticCost>,
               const Eigen::Ref<const Eigen::MatrixXd>&,
               const Eigen::Ref<const Eigen::VectorXd>&,
-              const Eigen::Ref<const VectorXDecisionVariable>&>(
+              const Eigen::Ref<const VectorXDecisionVariable>&, bool>(
               &MathematicalProgram::AddQuadraticErrorCost),
           py::arg("Q"), py::arg("x_desired"), py::arg("vars"),
+          py::arg("allow_nonconvex") = false,
           doc.MathematicalProgram.AddQuadraticErrorCost.doc)
       .def("AddL2NormCost",
           overload_cast_explicit<Binding<QuadraticCost>,
@@ -1451,19 +1454,24 @@ for every column of ``prog_var_vals``. )""")
   py::class_<QuadraticCost, Cost, std::shared_ptr<QuadraticCost>>(
       m, "QuadraticCost", doc.QuadraticCost.doc)
       .def(py::init([](const Eigen::MatrixXd& Q, const Eigen::VectorXd& b,
-                        double c) {
-        return std::unique_ptr<QuadraticCost>(new QuadraticCost(Q, b, c));
+                        double c, bool allow_nonconvex) {
+        return std::unique_ptr<QuadraticCost>(
+            new QuadraticCost(Q, b, c, allow_nonconvex));
       }),
-          py::arg("Q"), py::arg("b"), py::arg("c"), doc.QuadraticCost.ctor.doc)
+          py::arg("Q"), py::arg("b"), py::arg("c"),
+          py::arg("allow_nonconvex") = false, doc.QuadraticCost.ctor.doc)
       .def("Q", &QuadraticCost::Q, doc.QuadraticCost.Q.doc)
       .def("b", &QuadraticCost::b, doc.QuadraticCost.b.doc)
       .def("c", &QuadraticCost::c, doc.QuadraticCost.c.doc)
       .def(
           "UpdateCoefficients",
           [](QuadraticCost& self, const Eigen::MatrixXd& new_Q,
-              const Eigen::VectorXd& new_b,
-              double new_c) { self.UpdateCoefficients(new_Q, new_b, new_c); },
+              const Eigen::VectorXd& new_b, double new_c,
+              bool allow_nonconvex) {
+            self.UpdateCoefficients(new_Q, new_b, new_c, allow_nonconvex);
+          },
           py::arg("new_Q"), py::arg("new_b"), py::arg("new_c") = 0,
+          py::arg("allow_nonconvex") = false,
           doc.QuadraticCost.UpdateCoefficients.doc);
 
   RegisterBinding<Cost>(&m, "Cost");

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -740,6 +740,7 @@ drake_cc_library(
     hdrs = ["gurobi_solver.h"],
     deps = select({
         "//tools:with_gurobi": [
+            ":aggregate_costs_constraints",
             ":mathematical_program",
             ":solver_base",
             "//math:eigen_sparse_triplet",
@@ -749,6 +750,7 @@ drake_cc_library(
             "@fmt",
         ],
         "//conditions:default": [
+            ":aggregate_costs_constraints",
             ":mathematical_program",
             ":solver_base",
         ],
@@ -771,9 +773,10 @@ drake_cc_library(
         ],
     }),
     hdrs = ["mosek_solver.h"],
-    deps = select({
+    deps = [
+        ":aggregate_costs_constraints",
+    ] + select({
         "//tools:with_mosek": [
-            ":aggregate_costs_constraints",
             ":mathematical_program",
             ":mathematical_program_result",
             ":solver_base",
@@ -832,12 +835,12 @@ drake_cc_library(
     }),
     hdrs = ["clp_solver.h"],
     deps = [
+        ":aggregate_costs_constraints",
         "mathematical_program",
         "solver_base",
     ] + select({
         "//conditions:default": [
             "@clp",
-            ":aggregate_costs_constraints",
             "//common:unused",
             "//math:autodiff",
         ],
@@ -915,12 +918,14 @@ drake_cc_library(
     hdrs = ["osqp_solver.h"],
     deps = select({
         "//conditions:default": [
+            ":aggregate_costs_constraints",
             ":mathematical_program",
             ":solver_base",
             "//math:eigen_sparse_triplet",
             "@osqp",
         ],
         "//tools:no_osqp": [
+            ":aggregate_costs_constraints",
             ":mathematical_program",
             ":solver_base",
         ],
@@ -942,6 +947,7 @@ drake_cc_library(
     hdrs = ["scs_solver.h"],
     deps = select({
         "//conditions:default": [
+            ":aggregate_costs_constraints",
             ":mathematical_program",
             ":solver_base",
             "//common:essential",
@@ -949,6 +955,7 @@ drake_cc_library(
             "@scs//:scsdir",
         ],
         "//tools:no_scs": [
+            ":aggregate_costs_constraints",
             ":mathematical_program",
             ":solver_base",
         ],
@@ -1113,6 +1120,7 @@ drake_cc_googletest(
         ":generic_trivial_cost",
         "//common:symbolic",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
         "//common/test_utilities:is_dynamic_castable",
         "//common/test_utilities:symbolic_test_util",
         "//math:gradient",
@@ -1125,6 +1133,16 @@ drake_cc_googletest(
     deps = [
         ":mathematical_program",
         ":solve",
+    ],
+)
+
+drake_cc_googletest(
+    name = "create_cost_test",
+    deps = [
+        ":create_cost",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+        "//common/test_utilities:symbolic_test_util",
     ],
 )
 

--- a/solvers/aggregate_costs_constraints.cc
+++ b/solvers/aggregate_costs_constraints.cc
@@ -197,5 +197,14 @@ void AggregateBoundingBoxConstraints(const MathematicalProgram& prog,
     }
   }
 }
+
+bool AllQuadraticCostsConvex(const std::vector<Binding<QuadraticCost>>& costs) {
+  for (const auto& cost : costs) {
+    if (cost.evaluator()->allow_nonconvex()) {
+      return false;
+    }
+  }
+  return true;
+}
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/aggregate_costs_constraints.h
+++ b/solvers/aggregate_costs_constraints.h
@@ -79,5 +79,14 @@ std::unordered_map<symbolic::Variable, Bound> AggregateBoundingBoxConstraints(
 void AggregateBoundingBoxConstraints(const MathematicalProgram& prog,
                                      Eigen::VectorXd* lower,
                                      Eigen::VectorXd* upper);
+
+/**
+ * Returns true if all of the quadratic costs are *deemed* convex.
+ *
+ * If QuadraticCost::allow_nonconvex() is false, then this cost is deemed
+ * convex.
+ */
+bool AllQuadraticCostsConvex(const std::vector<Binding<QuadraticCost>>& costs);
+
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/clp_solver_common.cc
+++ b/solvers/clp_solver_common.cc
@@ -3,6 +3,7 @@
 /* clang-format on */
 
 #include "drake/common/never_destroyed.h"
+#include "drake/solvers/aggregate_costs_constraints.h"
 #include "drake/solvers/mathematical_program.h"
 
 namespace drake {
@@ -27,7 +28,8 @@ bool ClpSolver::ProgramAttributesSatisfied(const MathematicalProgram& prog) {
           ProgramAttribute::kLinearConstraint, ProgramAttribute::kLinearCost,
           ProgramAttribute::kQuadraticCost});
   return AreRequiredAttributesSupported(prog.required_capabilities(),
-                                        solver_capabilities.access());
+                                        solver_capabilities.access()) &&
+         AllQuadraticCostsConvex(prog.quadratic_costs());
 }
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/cost.cc
+++ b/solvers/cost.cc
@@ -103,9 +103,10 @@ std::ostream& QuadraticCost::DoDisplay(
 
 shared_ptr<QuadraticCost> MakeQuadraticErrorCost(
     const Eigen::Ref<const MatrixXd>& Q,
-    const Eigen::Ref<const VectorXd>& x_desired) {
+    const Eigen::Ref<const VectorXd>& x_desired, bool allow_nonconvex) {
   const double c = x_desired.dot(Q * x_desired);
-  return make_shared<QuadraticCost>(2 * Q, -2 * Q * x_desired, c);
+  return make_shared<QuadraticCost>(2 * Q, -2 * Q * x_desired, c,
+                                    allow_nonconvex);
 }
 
 shared_ptr<QuadraticCost> MakeL2NormCost(

--- a/solvers/create_cost.h
+++ b/solvers/create_cost.h
@@ -21,7 +21,8 @@ Binding<LinearCost> ParseLinearCost(const symbolic::Expression& e);
 /*
  * Assist MathematicalProgram::AddQuadraticCost(...).
  */
-Binding<QuadraticCost> ParseQuadraticCost(const symbolic::Expression& e);
+Binding<QuadraticCost> ParseQuadraticCost(const symbolic::Expression& e,
+                                          bool allow_nonconvex);
 
 /*
  * Assist MathematicalProgram::AddPolynomialCost(...).
@@ -31,7 +32,8 @@ Binding<PolynomialCost> ParsePolynomialCost(const symbolic::Expression& e);
 /*
  * Assist MathematicalProgram::AddCost(...).
  */
-Binding<Cost> ParseCost(const symbolic::Expression& e);
+Binding<Cost> ParseCost(const symbolic::Expression& e,
+                        bool allow_nonconvex_quadratic);
 
 // TODO(eric.cousineau): Remove this when functor cost is no longer exposed
 // externally, and must be explicitly called.

--- a/solvers/gurobi_solver_common.cc
+++ b/solvers/gurobi_solver_common.cc
@@ -6,6 +6,7 @@
 #include <cstring>
 
 #include "drake/common/never_destroyed.h"
+#include "drake/solvers/aggregate_costs_constraints.h"
 #include "drake/solvers/mathematical_program.h"
 
 // This file contains implementations that are common to both the available and
@@ -42,7 +43,8 @@ bool GurobiSolver::ProgramAttributesSatisfied(const MathematicalProgram& prog) {
           ProgramAttribute::kRotatedLorentzConeConstraint,
           ProgramAttribute::kBinaryVariable});
   return AreRequiredAttributesSupported(prog.required_capabilities(),
-                                        solver_capabilities.access());
+                                        solver_capabilities.access()) &&
+         AllQuadraticCostsConvex(prog.quadratic_costs());
 }
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -438,29 +438,32 @@ Binding<QuadraticCost> MathematicalProgram::AddCost(
 }
 
 Binding<QuadraticCost> MathematicalProgram::AddQuadraticCost(
-    const Expression& e) {
-  return AddCost(internal::ParseQuadraticCost(e));
+    const Expression& e, bool allow_nonconvex) {
+  return AddCost(internal::ParseQuadraticCost(e, allow_nonconvex));
 }
 
 Binding<QuadraticCost> MathematicalProgram::AddQuadraticErrorCost(
     const Eigen::Ref<const Eigen::MatrixXd>& Q,
     const Eigen::Ref<const Eigen::VectorXd>& x_desired,
-    const Eigen::Ref<const VectorXDecisionVariable>& vars) {
-  return AddCost(MakeQuadraticErrorCost(Q, x_desired), vars);
+    const Eigen::Ref<const VectorXDecisionVariable>& vars,
+    bool allow_nonconvex) {
+  return AddCost(MakeQuadraticErrorCost(Q, x_desired, allow_nonconvex), vars);
 }
 
 Binding<QuadraticCost> MathematicalProgram::AddQuadraticCost(
     const Eigen::Ref<const Eigen::MatrixXd>& Q,
     const Eigen::Ref<const Eigen::VectorXd>& b, double c,
-    const Eigen::Ref<const VectorXDecisionVariable>& vars) {
-  return AddCost(make_shared<QuadraticCost>(Q, b, c), vars);
+    const Eigen::Ref<const VectorXDecisionVariable>& vars,
+    bool allow_nonconvex) {
+  return AddCost(make_shared<QuadraticCost>(Q, b, c, allow_nonconvex), vars);
 }
 
 Binding<QuadraticCost> MathematicalProgram::AddQuadraticCost(
     const Eigen::Ref<const Eigen::MatrixXd>& Q,
     const Eigen::Ref<const Eigen::VectorXd>& b,
-    const Eigen::Ref<const VectorXDecisionVariable>& vars) {
-  return AddQuadraticCost(Q, b, 0., vars);
+    const Eigen::Ref<const VectorXDecisionVariable>& vars,
+    bool allow_nonconvex) {
+  return AddQuadraticCost(Q, b, 0., vars, allow_nonconvex);
 }
 
 Binding<PolynomialCost> MathematicalProgram::AddPolynomialCost(
@@ -469,8 +472,9 @@ Binding<PolynomialCost> MathematicalProgram::AddPolynomialCost(
   return internal::BindingDynamicCast<PolynomialCost>(binding);
 }
 
-Binding<Cost> MathematicalProgram::AddCost(const Expression& e) {
-  return AddCost(internal::ParseCost(e));
+Binding<Cost> MathematicalProgram::AddCost(const Expression& e,
+                                           bool allow_nonconvex_quadratic) {
+  return AddCost(internal::ParseCost(e, allow_nonconvex_quadratic));
 }
 
 void MathematicalProgram::AddMaximizeLogDeterminantSymmetricMatrixCost(

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -870,6 +870,7 @@ class MathematicalProgram {
 
   /**
    * Adds a generic cost to the optimization program.
+   * @pydrake_mkdoc_identifier{const_binding}
    */
   Binding<Cost> AddCost(const Binding<Cost>& binding);
 
@@ -877,6 +878,7 @@ class MathematicalProgram {
    * Adds a cost type to the optimization program.
    * @param obj The added objective.
    * @param vars The decision variables on which the cost depend.
+   * @pydrake_mkdoc_identifier{cost_pointer_bound_vars}
    */
   template <typename C>
   auto AddCost(const std::shared_ptr<C>& obj,
@@ -890,6 +892,7 @@ class MathematicalProgram {
    * Adds a generic cost to the optimization program.
    * @param obj The added objective.
    * @param vars The decision variables on which the cost depend.
+   * @exclude_from_pydrake_mkdoc{Not bound in pydrake.}
    */
   template <typename C>
   auto AddCost(const std::shared_ptr<C>& obj, const VariableRefList& vars) {
@@ -909,6 +912,7 @@ class MathematicalProgram {
   /**
    * Adds a cost to the optimization program on a list of variables.
    * @tparam F it should define functions numInputs, numOutputs and eval. Check
+   * @exclude_from_pydrake_mkdoc{Not bound in pydrake.}
    */
   template <typename F>
   typename std::enable_if<internal::is_cost_functor_candidate<F>::value,
@@ -921,6 +925,8 @@ class MathematicalProgram {
    * Adds a cost to the optimization program on an Eigen::Vector containing
    * decision variables.
    * @tparam F Type that defines functions numInputs, numOutputs and eval.
+   *
+   * @exclude_from_pydrake_mkdoc{Not bound in pydrake.}
    */
   template <typename F>
   typename std::enable_if<internal::is_cost_functor_candidate<F>::value,
@@ -934,6 +940,8 @@ class MathematicalProgram {
    * Statically assert if a user inadvertently passes a
    * binding-compatible Constraint.
    * @tparam F The type to check.
+   *
+   * @exclude_from_pydrake_mkdoc{Not bound in pydrake.}
    */
   template <typename F, typename Vars>
   typename std::enable_if<internal::assert_if_is_constraint<F>::value,
@@ -946,6 +954,8 @@ class MathematicalProgram {
    * Adds a cost term of the form c'*x.
    * Applied to a subset of the variables and pushes onto
    * the linear cost data structure.
+   *
+   * @pydrake_mkdoc_identifier{linear_cost}
    */
   Binding<LinearCost> AddCost(const Binding<LinearCost>& binding);
 
@@ -994,6 +1004,8 @@ class MathematicalProgram {
    * Adds a cost term of the form 0.5*x'*Q*x + b'x.
    * Applied to subset of the variables and pushes onto
    * the quadratic cost data structure.
+   *
+   * @pydrake_mkdoc_identifier{quadratic_cost}
    */
   Binding<QuadraticCost> AddCost(const Binding<QuadraticCost>& binding);
 
@@ -1002,29 +1014,38 @@ class MathematicalProgram {
    * Notice that in the optimization program, the constant term `c` in the cost
    * is ignored.
    * @param e A quadratic symbolic expression.
+   * @param allow_nonconvex Whether we allow non-convex quadratic cost. If
+   * allow_nonconvex = false and `e` is not a convex quadratic function, then
+   * throw std::invalid_argument.
    * @throws std::runtime error if the expression is not quadratic.
    * @return The newly added cost together with the bound variables.
    */
-  Binding<QuadraticCost> AddQuadraticCost(const symbolic::Expression& e);
+  Binding<QuadraticCost> AddQuadraticCost(const symbolic::Expression& e,
+                                          bool allow_nonconvex = false);
 
   /**
    * Adds a cost term of the form (x-x_desired)'*Q*(x-x_desired).
+   * @param allow_nonconvex If allow_nonconvex is false and Q is not positive
+   * semidefinite, then throw a std::invalid_argument error.
    */
   Binding<QuadraticCost> AddQuadraticErrorCost(
       const Eigen::Ref<const Eigen::MatrixXd>& Q,
       const Eigen::Ref<const Eigen::VectorXd>& x_desired,
-      const VariableRefList& vars) {
-    return AddQuadraticErrorCost(Q, x_desired,
-                                 ConcatenateVariableRefList(vars));
+      const VariableRefList& vars, bool allow_nonconvex = false) {
+    return AddQuadraticErrorCost(Q, x_desired, ConcatenateVariableRefList(vars),
+                                 allow_nonconvex);
   }
 
   /**
    * Adds a cost term of the form (x-x_desired)'*Q*(x-x_desired).
+   * @param allow_nonconvex If allow_nonconvex is false and Q is not positive
+   * semidefinite, then throw a std::invalid_argument error.
    */
   Binding<QuadraticCost> AddQuadraticErrorCost(
       const Eigen::Ref<const Eigen::MatrixXd>& Q,
       const Eigen::Ref<const Eigen::VectorXd>& x_desired,
-      const Eigen::Ref<const VectorXDecisionVariable>& vars);
+      const Eigen::Ref<const VectorXDecisionVariable>& vars,
+      bool allow_nonconvex = false);
 
   /**
    * Adds a cost term of the form | Ax - b |^2.
@@ -1048,32 +1069,42 @@ class MathematicalProgram {
   /**
    * Adds a cost term of the form 0.5*x'*Q*x + b'x.
    * Applied to subset of the variables.
+   * @param allow_nonconvex If allow_nonconvex is false and Q is not positive
+   * semidefinite, then throw a std::invalid_argument error.
    *
    * @exclude_from_pydrake_mkdoc{Not bound in pydrake.}
    */
   Binding<QuadraticCost> AddQuadraticCost(
       const Eigen::Ref<const Eigen::MatrixXd>& Q,
-      const Eigen::Ref<const Eigen::VectorXd>& b, const VariableRefList& vars) {
-    return AddQuadraticCost(Q, b, ConcatenateVariableRefList(vars));
+      const Eigen::Ref<const Eigen::VectorXd>& b, const VariableRefList& vars,
+      bool allow_nonconvex = false) {
+    return AddQuadraticCost(Q, b, ConcatenateVariableRefList(vars),
+                            allow_nonconvex);
   }
 
   /**
    * Adds a cost term of the form 0.5*x'*Q*x + b'x + c
    * Applied to subset of the variables.
+   * @param allow_nonconvex If allow_nonconvex is false and Q is not positive
+   * semidefinite, then throw a std::invalid_argument error.
    */
   Binding<QuadraticCost> AddQuadraticCost(
       const Eigen::Ref<const Eigen::MatrixXd>& Q,
       const Eigen::Ref<const Eigen::VectorXd>& b, double c,
-      const Eigen::Ref<const VectorXDecisionVariable>& vars);
+      const Eigen::Ref<const VectorXDecisionVariable>& vars,
+      bool allow_nonconvex = false);
 
   /**
    * Adds a cost term of the form 0.5*x'*Q*x + b'x
    * Applied to subset of the variables.
+   * @param allow_nonconvex If allow_nonconvex is false and Q is not positive
+   * semidefinite, then throw a std::invalid_argument error.
    */
   Binding<QuadraticCost> AddQuadraticCost(
       const Eigen::Ref<const Eigen::MatrixXd>& Q,
       const Eigen::Ref<const Eigen::VectorXd>& b,
-      const Eigen::Ref<const VectorXDecisionVariable>& vars);
+      const Eigen::Ref<const VectorXDecisionVariable>& vars,
+      bool allow_nonconvex = false);
 
   /**
    * Adds a cost term in the polynomial form.
@@ -1088,10 +1119,15 @@ class MathematicalProgram {
    * `e = x + 2`, then only the cost on `x` is added, the constant term 2 is
    * ignored.
    * @param e The linear or quadratic expression of the cost.
+   * @param allow_nonconvex_quadratic If allow_nonconvex_quadratic=false and e
+   * is quadratic but not convex, then this function will throw a
+   * std::invalid_argument error.
    * @pre `e` is linear or `e` is quadratic. Otherwise throws a runtime error.
    * @return The newly created cost, together with the bound variables.
+   * @pydrake_mkdoc_identifier{symbolic_expression_bool}
    */
-  Binding<Cost> AddCost(const symbolic::Expression& e);
+  Binding<Cost> AddCost(const symbolic::Expression& e,
+                        bool allow_nonconvex_quadratic = false);
 
   /**
    * Adds the cost to maximize the log determinant of symmetric matrix X.

--- a/solvers/mosek_solver_common.cc
+++ b/solvers/mosek_solver_common.cc
@@ -6,6 +6,7 @@
 #include <cstring>
 
 #include "drake/common/never_destroyed.h"
+#include "drake/solvers/aggregate_costs_constraints.h"
 #include "drake/solvers/mathematical_program.h"
 
 namespace drake {
@@ -40,7 +41,8 @@ bool MosekSolver::ProgramAttributesSatisfied(const MathematicalProgram& prog) {
           ProgramAttribute::kLinearCost, ProgramAttribute::kQuadraticCost,
           ProgramAttribute::kBinaryVariable});
   return AreRequiredAttributesSupported(prog.required_capabilities(),
-                                        solver_capabilities.access());
+                                        solver_capabilities.access()) &&
+         AllQuadraticCostsConvex(prog.quadratic_costs());
 }
 
 }  // namespace solvers

--- a/solvers/osqp_solver_common.cc
+++ b/solvers/osqp_solver_common.cc
@@ -3,6 +3,7 @@
 /* clang-format on */
 
 #include "drake/common/never_destroyed.h"
+#include "drake/solvers/aggregate_costs_constraints.h"
 #include "drake/solvers/mathematical_program.h"
 
 // This file contains implementations that are common to both the available and
@@ -33,7 +34,8 @@ bool OsqpSolver::ProgramAttributesSatisfied(const MathematicalProgram& prog) {
   return AreRequiredAttributesSupported(prog.required_capabilities(),
                                         solver_capabilities.access()) &&
          prog.required_capabilities().count(ProgramAttribute::kQuadraticCost) >
-             0;
+             0 &&
+         AllQuadraticCostsConvex(prog.quadratic_costs());
 }
 
 }  // namespace solvers

--- a/solvers/scs_solver_common.cc
+++ b/solvers/scs_solver_common.cc
@@ -3,6 +3,7 @@
 /* clang-format on */
 
 #include "drake/common/never_destroyed.h"
+#include "drake/solvers/aggregate_costs_constraints.h"
 #include "drake/solvers/mathematical_program.h"
 
 namespace drake {
@@ -23,15 +24,17 @@ bool ScsSolver::is_enabled() { return true; }
 
 bool ScsSolver::ProgramAttributesSatisfied(const MathematicalProgram& prog) {
   return AreRequiredAttributesSupported(
-      prog.required_capabilities(),
-      ProgramAttributes({ProgramAttribute::kLinearEqualityConstraint,
-                         ProgramAttribute::kLinearConstraint,
-                         ProgramAttribute::kLorentzConeConstraint,
-                         ProgramAttribute::kRotatedLorentzConeConstraint,
-                         ProgramAttribute::kPositiveSemidefiniteConstraint,
-                         ProgramAttribute::kExponentialConeConstraint,
-                         ProgramAttribute::kLinearCost,
-                         ProgramAttribute::kQuadraticCost}));
+             prog.required_capabilities(),
+             ProgramAttributes(
+                 {ProgramAttribute::kLinearEqualityConstraint,
+                  ProgramAttribute::kLinearConstraint,
+                  ProgramAttribute::kLorentzConeConstraint,
+                  ProgramAttribute::kRotatedLorentzConeConstraint,
+                  ProgramAttribute::kPositiveSemidefiniteConstraint,
+                  ProgramAttribute::kExponentialConeConstraint,
+                  ProgramAttribute::kLinearCost,
+                  ProgramAttribute::kQuadraticCost})) &&
+         AllQuadraticCostsConvex(prog.quadratic_costs());
 }
 
 }  // namespace solvers

--- a/solvers/test/aggregate_costs_constraints_test.cc
+++ b/solvers/test/aggregate_costs_constraints_test.cc
@@ -34,8 +34,8 @@ TEST_F(TestAggregateCostsAndConstraints, TestQuadraticCostsOnly) {
   const Eigen::Vector2d b1(5, 0.);
   const double c1{2};
   const Vector2<symbolic::Variable> vars1(x_[0], x_[2]);
-  quadratic_costs.emplace_back(std::make_shared<QuadraticCost>(Q1, b1, c1),
-                               vars1);
+  quadratic_costs.emplace_back(
+      std::make_shared<QuadraticCost>(Q1, b1, c1, true), vars1);
 
   Eigen::SparseMatrix<double> Q_lower;
   Eigen::SparseVector<double> linear_coeff;
@@ -66,8 +66,8 @@ TEST_F(TestAggregateCostsAndConstraints, TestQuadraticCostsOnly) {
   const Eigen::Vector3d b2(10, 0, 50);
   const double c2 = 40;
   const Vector3<symbolic::Variable> vars2(x_[2], x_[1], x_[3]);
-  quadratic_costs.emplace_back(std::make_shared<QuadraticCost>(Q2, b2, c2),
-                               vars2);
+  quadratic_costs.emplace_back(
+      std::make_shared<QuadraticCost>(Q2, b2, c2, true), vars2);
   AggregateQuadraticAndLinearCosts(quadratic_costs, {}, &Q_lower,
                                    &quadratic_vars, &linear_coeff, &linear_vars,
                                    &constant_cost);
@@ -172,8 +172,8 @@ TEST_F(TestAggregateCostsAndConstraints, QuadraticAndLinearCosts) {
   const Eigen::Vector3d b1(1, 0, 2);
   const double c1{3};
   const Vector3<symbolic::Variable> vars1(x_[0], x_[2], x_[1]);
-  quadratic_costs.emplace_back(std::make_shared<QuadraticCost>(Q1, b1, c1),
-                               vars1);
+  quadratic_costs.emplace_back(
+      std::make_shared<QuadraticCost>(Q1, b1, c1, true), vars1);
 
   const Eigen::Vector3d b2(2, -1, 0);
   const double c2{1};
@@ -210,8 +210,8 @@ TEST_F(TestAggregateCostsAndConstraints, QuadraticAndLinearCosts) {
   const Eigen::Vector2d b3(20, 30);
   const double c3{40};
   const Vector2<symbolic::Variable> vars3(x_[3], x_[1]);
-  quadratic_costs.emplace_back(std::make_shared<QuadraticCost>(Q3, b3, c3),
-                               vars3);
+  quadratic_costs.emplace_back(
+      std::make_shared<QuadraticCost>(Q3, b3, c3, true), vars3);
   const Eigen::Vector4d b4(20, 0, 30, 40);
   const double c4{10};
   const Vector4<symbolic::Variable> vars4(x_[2], x_[1], x_[3], x_[0]);
@@ -306,6 +306,16 @@ TEST_F(TestAggregateCostsAndConstraints, AggregateBoundingBoxConstraints2) {
   AggregateBoundingBoxConstraints(prog, &lower, &upper);
   EXPECT_TRUE(CompareMatrices(lower, Eigen::Vector4d(-1, -kInf, 1, 1)));
   EXPECT_TRUE(CompareMatrices(upper, Eigen::Vector4d(2, kInf, 3, 2)));
+}
+
+GTEST_TEST(AllQuadraticCostsConvexTest, Test) {
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<2>();
+  prog.AddQuadraticCost(x(0) * x(0) + x(1) * x(1));
+  prog.AddQuadraticCost(x(0) * x(0) + x(0) * x(1) + x(1) * x(1));
+  EXPECT_TRUE(AllQuadraticCostsConvex(prog.quadratic_costs()));
+  prog.AddQuadraticCost(-x(0) * x(0), true);
+  EXPECT_FALSE(AllQuadraticCostsConvex(prog.quadratic_costs()));
 }
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/clp_solver_test.cc
+++ b/solvers/test/clp_solver_test.cc
@@ -177,6 +177,13 @@ GTEST_TEST(ClpSolverTest, EqualityConstrainedQPDualSolution2) {
   ClpSolver solver;
   TestEqualityConstrainedQPDualSolution2(solver);
 }
+
+GTEST_TEST(ClpSolverTest, NonconvexQP) {
+  ClpSolver solver;
+  if (solver.available()) {
+    TestNonconvexQP(solver, true);
+  }
+}
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/create_cost_test.cc
+++ b/solvers/test/create_cost_test.cc
@@ -1,0 +1,70 @@
+#include "drake/solvers/create_cost.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities//expect_throws_message.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/symbolic_test_util.h"
+
+namespace drake {
+namespace solvers {
+namespace internal {
+class CreateCostTest : public ::testing::Test {
+ protected:
+  const symbolic::Variable x_{"x"};
+  const symbolic::Variable y_{"y"};
+  const symbolic::Variable z_{"z"};
+};
+
+TEST_F(CreateCostTest, CreateQuadraticCostConvex) {
+  const symbolic::Expression e1(x_ * x_ + 4 * y_ * y_ + 3 * x_ * y_ + 2 * x_ +
+                                1);
+  const auto constraint1 =
+      ParseQuadraticCost(e1, false /* allow_nonconvex=false */);
+  EXPECT_FALSE(constraint1.evaluator()->allow_nonconvex());
+  EXPECT_EQ(constraint1.variables().rows(), 2);
+  if (constraint1.variables()(0).get_id() == x_.get_id()) {
+    EXPECT_PRED2(symbolic::test::VarEqual, constraint1.variables()(1), y_);
+    EXPECT_TRUE(CompareMatrices(constraint1.evaluator()->Q(),
+                                (Eigen::Matrix2d() << 2, 3, 3, 8).finished()));
+    EXPECT_TRUE(
+        CompareMatrices(constraint1.evaluator()->b(), Eigen::Vector2d(2, 0)));
+  } else if (constraint1.variables()(0).get_id() == y_.get_id()) {
+    EXPECT_PRED2(symbolic::test::VarEqual, constraint1.variables()(1), x_);
+    EXPECT_TRUE(CompareMatrices(constraint1.evaluator()->Q(),
+                                (Eigen::Matrix2d() << 8, 3, 3, 2).finished()));
+    EXPECT_TRUE(
+        CompareMatrices(constraint1.evaluator()->b(), Eigen::Vector2d(0, 2)));
+  }
+  EXPECT_EQ(constraint1.evaluator()->c(), 1);
+}
+
+TEST_F(CreateCostTest, CreateQuadraticCostNonConvex) {
+  const symbolic::Expression e(x_ * x_ + 4 * y_ * y_ + 5 * x_ * y_ + 2 * x_ +
+                               1);
+  const auto constraint = ParseQuadraticCost(e, true /* allow_nonconvex=true*/);
+  EXPECT_TRUE(constraint.evaluator()->allow_nonconvex());
+  EXPECT_EQ(constraint.variables().rows(), 2);
+  if (constraint.variables()(0).get_id() == x_.get_id()) {
+    EXPECT_PRED2(symbolic::test::VarEqual, constraint.variables()(1), y_);
+    EXPECT_TRUE(CompareMatrices(constraint.evaluator()->Q(),
+                                (Eigen::Matrix2d() << 2, 5, 5, 8).finished()));
+    EXPECT_TRUE(
+        CompareMatrices(constraint.evaluator()->b(), Eigen::Vector2d(2, 0)));
+  } else if (constraint.variables()(0).get_id() == y_.get_id()) {
+    EXPECT_PRED2(symbolic::test::VarEqual, constraint.variables()(1), x_);
+    EXPECT_TRUE(CompareMatrices(constraint.evaluator()->Q(),
+                                (Eigen::Matrix2d() << 8, 5, 5, 2).finished()));
+    EXPECT_TRUE(
+        CompareMatrices(constraint.evaluator()->b(), Eigen::Vector2d(0, 2)));
+  }
+  EXPECT_EQ(constraint.evaluator()->c(), 1);
+
+  // Now parse the cost with allow_nonconvex=false. Expect to throw an error.
+  DRAKE_EXPECT_THROWS_MESSAGE(ParseQuadraticCost(e, false),
+                              std::invalid_argument,
+                              ".* the input Hessian matrix .*");
+}
+}  // namespace internal
+}  // namespace solvers
+}  // namespace drake

--- a/solvers/test/equality_constrained_qp_solver_test.cc
+++ b/solvers/test/equality_constrained_qp_solver_test.cc
@@ -147,7 +147,7 @@ GTEST_TEST(testEqualityConstrainedQPSolver,
   // is unbounded.
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<2>("x");
-  prog.AddCost(x(0) * x(0) - x(1) * x(1));
+  prog.AddCost(x(0) * x(0) - x(1) * x(1), true);
   EqualityConstrainedQPSolver solver;
   auto result = solver.Solve(prog, {}, {});
   EXPECT_EQ(result.get_solution_result(), SolutionResult::kUnbounded);
@@ -172,7 +172,7 @@ GTEST_TEST(testEqualityConstrainedQPSolver, testNegativeDefiniteHessianQP) {
   // The problem is unbounded.
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<2>("x");
-  prog.AddCost(-x(0) * x(0) - 2 * x(1));
+  prog.AddCost(-x(0) * x(0) - 2 * x(1), true);
   EqualityConstrainedQPSolver solver;
   auto result = solver.Solve(prog, {}, {});
   EXPECT_EQ(result.get_solution_result(), SolutionResult::kUnbounded);
@@ -205,7 +205,7 @@ GTEST_TEST(testEqualityConstrainedQPSolver,
 GTEST_TEST(testEqualityConstrainedQPSolver, testIndefiniteHessian) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<2>("x");
-  prog.AddCost(x(0) * x(0) - x(1) * x(1));
+  prog.AddCost(x(0) * x(0) - x(1) * x(1), true);
   auto constraint = prog.AddLinearConstraint(x(1) == 1);
   EqualityConstrainedQPSolver solver;
   auto result = solver.Solve(prog, {}, {});
@@ -238,7 +238,7 @@ GTEST_TEST(testEqualityConstrainedQPSolver, testPSDhessianUnbounded) {
 GTEST_TEST(testEqualityConstrainedQPSolver, testNegativeHessianUniqueOptimum) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<2>("x");
-  prog.AddCost(-x(0) * x(0) - x(1) * x(1));
+  prog.AddCost(-x(0) * x(0) - x(1) * x(1), true);
   Eigen::Matrix2d Aeq;
   Aeq << 1, 1, 1, -1;
   auto constraint =
@@ -259,7 +259,7 @@ GTEST_TEST(testEqualityConstrainedQPSolver, testNegativeHessianUniqueOptimum) {
 GTEST_TEST(testEqualityConstrainedQPSolver, testNegativeHessianUnbounded) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<2>("x");
-  prog.AddCost(-x(0) * x(0) - x(1) * x(1));
+  prog.AddCost(-x(0) * x(0) - x(1) * x(1), true);
   prog.AddLinearConstraint(x(0) + x(1) == 1);
   EqualityConstrainedQPSolver solver;
   auto result = solver.Solve(prog, {}, {});
@@ -295,7 +295,7 @@ GTEST_TEST(testEqualityConstrainedQPSolver, testPSDHessianUniqueOptimal) {
 GTEST_TEST(testEqualityConstrainedQPSolver, testIndefiniteHessianInfeasible) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<2>("x");
-  prog.AddCost(x(0) * x(0) - 2 * x(1) * x(1));
+  prog.AddCost(x(0) * x(0) - 2 * x(1) * x(1), true);
   prog.AddLinearConstraint(x(0) + 2 * x(1) == 1 && -x(0) + 3 * x(1) == 2 &&
                            2 * x(0) - 3 * x(1) == 3);
   EqualityConstrainedQPSolver solver;

--- a/solvers/test/gurobi_solver_test.cc
+++ b/solvers/test/gurobi_solver_test.cc
@@ -367,15 +367,6 @@ GTEST_TEST(GurobiTest, GurobiErrorCode) {
     const int UNKNOWN_PARAMETER{10007};
     EXPECT_EQ(result.get_solver_details<GurobiSolver>().error_code,
               UNKNOWN_PARAMETER);
-
-    // Report error if the Q matrix in the QP cost is not positive semidefinite.
-    prog.AddQuadraticCost(x(0) * x(0) - x(1) * x(1));
-    result = solver.Solve(prog, {}, {});
-    // The error code is listed in
-    // https://www.gurobi.com/documentation/9.0/refman/error_codes.html
-    const int Q_NOT_PSD{10020};
-    EXPECT_EQ(result.get_solver_details<GurobiSolver>().error_code,
-              Q_NOT_PSD);
   }
 }
 
@@ -537,6 +528,12 @@ GTEST_TEST(GurobiTest, SOCPDualSolution2) {
   }
 }
 
+GTEST_TEST(GurobiTest, NonconvexQP) {
+  GurobiSolver solver;
+  if (solver.available()) {
+    TestNonconvexQP(solver, true);
+  }
+}
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/mosek_solver_test.cc
+++ b/solvers/test/mosek_solver_test.cc
@@ -487,6 +487,13 @@ GTEST_TEST(MosekTest, SDPDualSolution1) {
     TestSDPDualSolution1(solver, 3E-6);
   }
 }
+
+GTEST_TEST(MosekTest, NonconvexQP) {
+  MosekSolver solver;
+  if (solver.available()) {
+    TestNonconvexQP(solver, true);
+  }
+}
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/optimization_examples.cc
+++ b/solvers/test/optimization_examples.cc
@@ -248,7 +248,7 @@ void NonConvexQPproblem1::AddQuadraticCost() {
   Eigen::Matrix<double, 5, 1> c;
   c << 42, 44, 45, 47, 47.5;
   double r = -100;
-  prog_->AddQuadraticCost(Q, c, r, x_);
+  prog_->AddQuadraticCost(Q, c, r, x_, true /* allow_nonconvex */);
 }
 
 NonConvexQPproblem2::NonConvexQPproblem2(CostForm cost_form,
@@ -309,7 +309,7 @@ void NonConvexQPproblem2::AddQuadraticCost() {
   Eigen::Matrix<double, 6, 1> c{};
   c << -10.5, -7.5, -3.5, -2.5, -1.5, -10.0;
 
-  prog_->AddQuadraticCost(Q, c, x_);
+  prog_->AddQuadraticCost(Q, c, x_, true /* allow_nonconvex */);
 }
 
 void NonConvexQPproblem2::AddNonSymbolicConstraint() {

--- a/solvers/test/osqp_solver_test.cc
+++ b/solvers/test/osqp_solver_test.cc
@@ -220,6 +220,13 @@ GTEST_TEST(OsqpSolverTest, TimeLimitTest) {
   }
 }
 
+GTEST_TEST(OsqpSolverTest, NonconvexQP) {
+  OsqpSolver solver;
+  if (solver.available()) {
+    TestNonconvexQP(solver, true);
+  }
+}
+
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/quadratic_program_examples.cc
+++ b/solvers/test/quadratic_program_examples.cc
@@ -646,6 +646,25 @@ void TestEqualityConstrainedQPDualSolution2(const SolverInterface& solver) {
   }
 }
 
+void TestNonconvexQP(const SolverInterface& solver, bool convex_solver,
+                     double tol) {
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<2>();
+  prog.AddQuadraticCost(-x(0) * x(0) + x(1) * x(1) + 2,
+                        true /* allow nonconvex */);
+  prog.AddBoundingBoxConstraint(0, 1, x);
+  if (convex_solver) {
+    EXPECT_FALSE(solver.AreProgramAttributesSatisfied(prog));
+  } else {
+    MathematicalProgramResult result;
+    solver.Solve(prog, std::nullopt, std::nullopt, &result);
+    EXPECT_TRUE(result.is_success());
+    EXPECT_TRUE(
+        CompareMatrices(result.GetSolution(x), Eigen::Vector2d(1, 0), tol));
+    EXPECT_NEAR(result.get_optimal_cost(), 1., tol);
+  }
+}
+
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/quadratic_program_examples.h
+++ b/solvers/test/quadratic_program_examples.h
@@ -184,6 +184,12 @@ void TestEqualityConstrainedQPDualSolution1(const SolverInterface& solver);
  * Test getting the dual solution for an equality constrained QP.
  */
 void TestEqualityConstrainedQPDualSolution2(const SolverInterface& solver);
+
+/**
+ * Test nonconvex QP.
+ */
+void TestNonconvexQP(const SolverInterface& solver, bool convex_solver,
+                     double tol = 1E-5);
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/scs_solver_test.cc
+++ b/solvers/test/scs_solver_test.cc
@@ -393,6 +393,13 @@ GTEST_TEST(TestScs, UnivariateNonnegative1) {
     dut.CheckResult(result, 1E-6);
   }
 }
+
+GTEST_TEST(TestScs, NonconvexQP) {
+  ScsSolver solver;
+  if (solver.is_available()) {
+    TestNonconvexQP(solver, true);
+  }
+}
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake

--- a/tutorials/mathematical_program.ipynb
+++ b/tutorials/mathematical_program.ipynb
@@ -484,7 +484,7 @@
     "prog = MathematicalProgram()\n",
     "x = prog.NewContinuousVariables(2)\n",
     "prog.AddConstraint(x[0]**2 + x[1]**2 == 100.)\n",
-    "prog.AddCost(x[0]**2-x[1]**2)\n",
+    "prog.AddCost(x[0]**2-x[1]**2, allow_nonconvex_quadratic=True)\n",
     "solver = IpoptSolver()\n",
     "# The user doesn't provide an initial guess.\n",
     "result = solver.Solve(prog, None, None)\n",

--- a/tutorials/nonlinear_program.ipynb
+++ b/tutorials/nonlinear_program.ipynb
@@ -136,7 +136,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cost4 = prog.AddQuadraticCost(x[0]**2 + 3 * x[1]**2 + 2*x[0]*x[1] + 2*x[1] * x[0] + 1)\n",
+    "cost4 = prog.AddQuadraticCost(x[0]**2 + 4 * x[1]**2 + 2*x[0]*x[1] + 2*x[1] * x[0] + 1)\n",
     "print(cost4)"
    ]
   },


### PR DESCRIPTION
Throws an error if the cost is non-convex, and allow_nonconvex=false.

Resolves #15008

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15014)
<!-- Reviewable:end -->
