### PR TITLE
multibody: Defer joint limits warning until it's relevant

### DIFF
--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -718,24 +718,20 @@ void MultibodyPlant<T>::SetUpJointLimitsParameters() {
 
   // Since currently MBP only handles joint limits for discrete models, we
   // verify that there are no joint limits when the model is continuous.
-  // Therefore we print an appropriate warning message when a user
-  // specifies joint limits for a continuous model.
+  // If there are limits defined, we prepare a warning message that will be
+  // logged iff the user attempts to do anything that would have needed them.
   if (!is_discrete() && !joint_limits_parameters_.joints_with_limits.empty()) {
-    drake::log()->warn(
-        "Currently MultibodyPlant does not handle joint limits for "
-        "continuous models. "
-        "However some joints do specify limits. "
-        "Consider setting a non-zero time step in the MultibodyPlant "
-        "constructor; this will put MultibodyPlant in discrete-time mode, "
-        "which does support joint limits.");
-
-    std::string joints_names;
-    for (size_t i = 0; i < joint_limits_parameters_.stiffness.size(); ++i) {
-      const JointIndex index = joint_limits_parameters_.joints_with_limits[i];
-      if (i > 0) joints_names += ", ";
-      joints_names += fmt::format("`{}`", get_joint(index).name());
+    std::string joint_names_with_limits;
+    for (auto joint_index : joint_limits_parameters_.joints_with_limits) {
+      joint_names_with_limits += fmt::format(
+          ", '{}'", get_joint(joint_index).name());
     }
-    drake::log()->warn("Joints that specify limits are: {}.", joints_names);
+    joint_limits_parameters_.pending_warning_message =
+        "Currently MultibodyPlant does not handle joint limits for continuous "
+        "models. However some joints do specify limits. Consider setting a "
+        "non-zero time step in the MultibodyPlant constructor; this will put "
+        "the plant in discrete-time mode, which does support joint limits. "
+        "Joints that specify limits are: " + joint_names_with_limits.substr(2);
   }
 }
 
@@ -2427,7 +2423,15 @@ void MultibodyPlant<T>::CalcNonContactForces(
   AddInForcesFromInputPorts(context, forces);
 
   // Only discrete models support joint limits.
-  if (discrete) AddJointLimitsPenaltyForces(context, forces);
+  if (discrete) {
+    AddJointLimitsPenaltyForces(context, forces);
+  } else {
+    auto& warning = joint_limits_parameters_.pending_warning_message;
+    if (!warning.empty()) {
+      drake::log()->warn(warning);
+      warning.clear();
+    }
+  }
 }
 
 template <typename T>

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -4551,6 +4551,11 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     // AddJointLimitsPenaltyForces().
     std::vector<double> stiffness;
     std::vector<double> damping;
+    // If these joint limits will be ignored (because the plant uses continuous
+    // time) and we have not yet warned the user about that fact, this contains
+    // the warning message to be printed. Marked mutable because it's not part
+    // of our dynamics, so that we can clear it from a const method.
+    mutable std::string pending_warning_message;
   } joint_limits_parameters_;
 
   // Iteration order on this map DOES matter, and therefore we use an std::map.

--- a/multibody/plant/test/joint_limits_test.cc
+++ b/multibody/plant/test/joint_limits_test.cc
@@ -315,6 +315,18 @@ GTEST_TEST(JointLimitsTest, KukaArmFloating) {
                               plant.GetPositionUpperLimits()));
 }
 
+// Invokes a method that putatively uses joint limits, but which are ignored
+// for a continuous plant. This is merely to confirm that nothing crashes.
+GTEST_TEST(JointLimitsTest, ContinuousLimitsDoNotFault) {
+  MultibodyPlant<double> plant(0.0);
+  Parser(&plant).AddModelFromFile(FindResourceOrThrow(kIiwaFilePath));
+  plant.Finalize();
+  auto context = plant.CreateDefaultContext();
+  plant.get_actuation_input_port().FixValue(context.get(),
+      Eigen::VectorXd::Zero(7));
+  plant.get_reaction_forces_output_port().Eval<AbstractValue>(*context);
+}
+
 }  // namespace
 }  // namespace multibody
 }  // namespace drake


### PR DESCRIPTION
This allows for creating kinematic models for planning using a zero time step, while avoiding console spam.

Relates #14688.

Proof that the warning still happens:
```console
[ RUN      ] JointLimitsTest.ContinuousLimitsDoNotFault
[2021-05-06 09:31:44.380] [console] [warning] Currently MultibodyPlant does not handle joint limits for continuous models. However some joints do specify limits. Consider setting a non-zero time step in the MultibodyPlant constructor; this will put the plant in discrete-time mode, which does support joint limits. Joints that specify limits are: 'iiwa_joint_1', 'iiwa_joint_2', 'iiwa_joint_3', 'iiwa_joint_4', 'iiwa_joint_5', 'iiwa_joint_6', 'iiwa_joint_7'
[       OK ] JointLimitsTest.ContinuousLimitsDoNotFault (31 ms)
```