### PR TITLE
geometry/render: Move vtk_util here

### DIFF
--- a/geometry/render/BUILD.bazel
+++ b/geometry/render/BUILD.bazel
@@ -21,6 +21,7 @@ drake_cc_package_library(
         ":render_engine_vtk_base",
         ":render_label",
         ":render_label_class",
+        ":vtk_util",
     ],
 )
 
@@ -73,10 +74,10 @@ drake_cc_library(
     deps = [
         ":render_engine",
         ":render_engine_vtk_base",
+        ":vtk_util",
         "//common",
         "//geometry/render/shaders:depth_shaders",
         "//systems/sensors:color_palette",
-        "//systems/sensors:vtk_util",
         "@eigen",
         "@vtk//:vtkCommonCore",
         "@vtk//:vtkCommonDataModel",
@@ -137,6 +138,24 @@ drake_cc_library(
     ],
 )
 
+drake_cc_library(
+    name = "vtk_util",
+    srcs = ["vtk_util.cc"],
+    hdrs = ["vtk_util.h"],
+    # We must not expose `#include <vtk/...>` in any of our installed headers;
+    # vtk_util.h is only included internally within this package.
+    install_hdrs_exclude = ["vtk_util.h"],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//common:essential",
+        "//math:geometric_transform",
+        "@eigen",
+        "@vtk//:vtkCommonCore",
+        "@vtk//:vtkCommonTransforms",
+        "@vtk//:vtkFiltersSources",
+    ],
+)
+
 # === test/ ===
 
 filegroup(
@@ -186,6 +205,11 @@ drake_cc_googletest(
         "//common/test_utilities:expect_no_throw",
         "//common/test_utilities:expect_throws_message",
     ],
+)
+
+drake_cc_googletest(
+    name = "vtk_util_test",
+    deps = [":vtk_util"],
 )
 
 add_lint_tests()

--- a/geometry/render/render_engine_vtk.cc
+++ b/geometry/render/render_engine_vtk.cc
@@ -21,8 +21,8 @@
 #include "drake/common/text_logging.h"
 #include "drake/geometry/render/render_engine_vtk_base.h"
 #include "drake/geometry/render/shaders/depth_shaders.h"
+#include "drake/geometry/render/vtk_util.h"
 #include "drake/systems/sensors/color_palette.h"
-#include "drake/systems/sensors/vtk_util.h"
 
 namespace drake {
 namespace geometry {
@@ -39,9 +39,9 @@ using systems::sensors::ImageDepth32F;
 using systems::sensors::ImageLabel16I;
 using systems::sensors::ImageRgba8U;
 using systems::sensors::InvalidDepth;
-using systems::sensors::vtk_util::ConvertToVtkTransform;
-using systems::sensors::vtk_util::CreateSquarePlane;
-using systems::sensors::vtk_util::MakeVtkPointerArray;
+using vtk_util::ConvertToVtkTransform;
+using vtk_util::CreateSquarePlane;
+using vtk_util::MakeVtkPointerArray;
 
 namespace {
 

--- a/geometry/render/test/vtk_util_test.cc
+++ b/geometry/render/test/vtk_util_test.cc
@@ -1,4 +1,4 @@
-#include "drake/systems/sensors/vtk_util.h"
+#include "drake/geometry/render/vtk_util.h"
 
 #include <cmath>
 #include <limits>
@@ -11,8 +11,8 @@
 #include <vtkSmartPointer.h>
 
 namespace drake {
-namespace systems {
-namespace sensors {
+namespace geometry {
+namespace render {
 namespace vtk_util {
 namespace {
 
@@ -91,6 +91,6 @@ GTEST_TEST(MakeVtkPointerArrayTest, ValidTest) {
 
 }  // namespace
 }  // namespace vtk_util
-}  // namespace sensors
-}  // namespace systems
+}  // namespace render
+}  // namespace geometry
 }  // namespace drake

--- a/geometry/render/vtk_util.cc
+++ b/geometry/render/vtk_util.cc
@@ -1,4 +1,4 @@
-#include "drake/systems/sensors/vtk_util.h"
+#include "drake/geometry/render/vtk_util.h"
 
 #include <Eigen/Dense>
 #include <vtkNew.h>
@@ -9,8 +9,8 @@
 #include "drake/math/rotation_matrix.h"
 
 namespace drake {
-namespace systems {
-namespace sensors {
+namespace geometry {
+namespace render {
 namespace vtk_util {
 
 vtkSmartPointer<vtkPlaneSource> CreateSquarePlane(double size) {
@@ -65,6 +65,6 @@ vtkSmartPointer<vtkTransform> ConvertToVtkTransform(
 }
 
 }  // namespace vtk_util
-}  // namespace sensors
-}  // namespace systems
+}  // namespace render
+}  // namespace geometry
 }  // namespace drake

--- a/geometry/render/vtk_util.h
+++ b/geometry/render/vtk_util.h
@@ -12,8 +12,8 @@
 #include "drake/math/rigid_transform.h"
 
 namespace drake {
-namespace systems {
-namespace sensors {
+namespace geometry {
+namespace render {
 namespace vtk_util {
 /// An array type for vtkSmartPointer.
 ///
@@ -54,6 +54,6 @@ const vtkPointerArray<T, N> MakeVtkPointerArray(
 }
 
 }  // namespace vtk_util
-}  // namespace sensors
-}  // namespace systems
+}  // namespace render
+}  // namespace geometry
 }  // namespace drake

--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -39,7 +39,6 @@ drake_cc_package_library(
         ":rgbd_sensor",
         ":robotlocomotion_compat",
         ":rotary_encoders",
-        ":vtk_util",
     ],
 )
 
@@ -194,29 +193,6 @@ drake_cc_binary(
         "//systems/analysis:simulator",
         "//systems/lcm:lcm_pubsub_system",
         "@gflags",
-    ],
-)
-
-drake_cc_library(
-    name = "vtk_util",
-    srcs = ["vtk_util.cc"],
-    hdrs = ["vtk_util.h"],
-    # We must not expose `#include <vtk/...>` in any of our installed headers;
-    # vtk_util.h is only included internally within this package.
-    install_hdrs_exclude = ["vtk_util.h"],
-    # TODO(SeanCurtis-TRI): Remove this from sensors when the VTK rendering
-    # completely lives in geometry/render.
-    # Temporarily public so this can be shared by the old RgbdCamera in sensors
-    # and the *new* rendering infrastructure in geometry/render. Once the old
-    # is deprecated, this can be moved into geometry/render and made private.
-    visibility = ["//visibility:public"],
-    deps = [
-        "//common:essential",
-        "//math:geometric_transform",
-        "@eigen",
-        "@vtk//:vtkCommonCore",
-        "@vtk//:vtkCommonTransforms",
-        "@vtk//:vtkFiltersSources",
     ],
 )
 
@@ -377,11 +353,6 @@ drake_cc_googletest(
         "//common/test_utilities:symbolic_test_util",
         "//systems/framework/test_utilities",
     ],
-)
-
-drake_cc_googletest(
-    name = "vtk_util_test",
-    deps = [":vtk_util"],
 )
 
 drake_cc_googletest(


### PR DESCRIPTION
Per the TODO in `systems/sensors`, this library is only used within `geometry/render` now so should live there.

I deem this _not_ to be a breaking change, because this header is not present in our binary releases.  If someone was using it via `drake_bazel_external`, that would be "own risk".

This gets us one step away from relying on VTK at runtime _only_ for the `RenderEngineVtk`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15025)
<!-- Reviewable:end -->
