### PR TITLE
solvers: Amend SolverInterface for more detailed error messages

### DIFF
--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -279,6 +279,12 @@ class PySolverInterface : public py::wrapper<solvers::SolverInterface> {
     PYBIND11_OVERLOAD_PURE(
         bool, solvers::SolverInterface, AreProgramAttributesSatisfied, prog);
   }
+
+  std::string ExplainUnsatisfiedProgramAttributes(
+      const MathematicalProgram& prog) const override {
+    PYBIND11_OVERLOAD_PURE(std::string, solvers::SolverInterface,
+        ExplainUnsatisfiedProgramAttributes, prog);
+  }
 };
 }  // namespace
 
@@ -312,6 +318,14 @@ top-level documentation for :py:mod:`pydrake.math`.
           },
           py::arg("prog"),
           doc.SolverInterface.AreProgramAttributesSatisfied.doc)
+      .def(
+          "ExplainUnsatisfiedProgramAttributes",
+          [](const SolverInterface& self,
+              const solvers::MathematicalProgram& prog) {
+            return self.ExplainUnsatisfiedProgramAttributes(prog);
+          },
+          py::arg("prog"),
+          doc.SolverInterface.ExplainUnsatisfiedProgramAttributes.doc)
       .def(
           "Solve",
           [](const SolverInterface& self,

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -93,6 +93,7 @@ class TestMathematicalProgram(unittest.TestCase):
         solver = mp.MakeSolver(solver_id)
         self.assertEqual(solver.solver_id().name(), "Linear system")
         self.assertTrue(solver.AreProgramAttributesSatisfied(prog))
+        self.assertEqual(solver.ExplainUnsatisfiedProgramAttributes(prog), "")
         result = solver.Solve(prog)
         self.assertTrue(result.is_success())
         result = solver.Solve(prog, None, None)
@@ -102,6 +103,7 @@ class TestMathematicalProgram(unittest.TestCase):
         # doesn't work anymore.
         prog.AddLinearConstraint(x[0] >= 0)
         self.assertFalse(solver.AreProgramAttributesSatisfied(prog))
+        self.assertTrue(solver.ExplainUnsatisfiedProgramAttributes(prog))
         with self.assertRaises(ValueError):
             solver.Solve(prog, None, None)
 

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -1298,6 +1298,7 @@ drake_cc_googletest(
         ":optimization_examples",
         ":solve",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/solvers/linear_system_solver.h
+++ b/solvers/linear_system_solver.h
@@ -22,6 +22,7 @@ class LinearSystemSolver final : public SolverBase {
   static bool is_available();
   static bool is_enabled();
   static bool ProgramAttributesSatisfied(const MathematicalProgram&);
+  static std::string UnsatisfiedProgramAttributes(const MathematicalProgram&);
   //@}
 
   // A using-declaration adds these methods into our class's Doxygen.

--- a/solvers/osqp_solver.h
+++ b/solvers/osqp_solver.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "drake/common/drake_copyable.h"
 #include "drake/solvers/solver_base.h"
 
@@ -51,6 +53,7 @@ class OsqpSolver final : public SolverBase {
   static bool is_available();
   static bool is_enabled();
   static bool ProgramAttributesSatisfied(const MathematicalProgram&);
+  static std::string UnsatisfiedProgramAttributes(const MathematicalProgram&);
   //@}
 
   // A using-declaration adds these methods into our class's Doxygen.

--- a/solvers/osqp_solver_common.cc
+++ b/solvers/osqp_solver_common.cc
@@ -12,8 +12,8 @@ namespace drake {
 namespace solvers {
 
 OsqpSolver::OsqpSolver()
-    : SolverBase(&id, &is_available, &is_enabled,
-                 &ProgramAttributesSatisfied) {}
+    : SolverBase(&id, &is_available, &is_enabled, &ProgramAttributesSatisfied,
+                 &UnsatisfiedProgramAttributes) {}
 
 OsqpSolver::~OsqpSolver() = default;
 
@@ -24,16 +24,56 @@ SolverId OsqpSolver::id() {
 
 bool OsqpSolver::is_enabled() { return true; }
 
-bool OsqpSolver::ProgramAttributesSatisfied(const MathematicalProgram& prog) {
+namespace {
+// If the program is compatible with this solver, returns true and clears the
+// explanation.  Otherwise, returns false and sets the explanation.  In either
+// case, the explanation can be nullptr in which case it is ignored.
+bool CheckAttributes(
+    const MathematicalProgram& prog,
+    std::string* explanation) {
   static const never_destroyed<ProgramAttributes> solver_capabilities(
       std::initializer_list<ProgramAttribute>{
-          ProgramAttribute::kLinearCost, ProgramAttribute::kQuadraticCost,
+          ProgramAttribute::kLinearCost,
+          ProgramAttribute::kQuadraticCost,
           ProgramAttribute::kLinearConstraint,
           ProgramAttribute::kLinearEqualityConstraint});
-  return AreRequiredAttributesSupported(prog.required_capabilities(),
-                                        solver_capabilities.access()) &&
-         prog.required_capabilities().count(ProgramAttribute::kQuadraticCost) >
-             0;
+  const ProgramAttributes& required_capabilities = prog.required_capabilities();
+  const bool capabilities_match = AreRequiredAttributesSupported(
+      required_capabilities, solver_capabilities.access(), explanation);
+  if (!capabilities_match) {
+    if (explanation) {
+      *explanation = fmt::format(
+          "OsqpSolver is unable to solve because {}.", *explanation);
+    }
+    return false;
+  }
+  if (required_capabilities.count(ProgramAttribute::kQuadraticCost) == 0) {
+    if (explanation) {
+      *explanation =
+          "OsqpSolver is unable to solve because a QuadraticCost is required"
+          " but has not beed declared; OSQP works best with a quadratic cost."
+          " Please use a different solver such as CLP (for linear programming)"
+          " or IPOPT/SNOPT (for nonlinear programming) if you don't want to add"
+          " a quadratic cost to this program.";
+    }
+    return false;
+  }
+  if (explanation) {
+    explanation->clear();
+  }
+  return true;
+}
+}  // namespace
+
+bool OsqpSolver::ProgramAttributesSatisfied(const MathematicalProgram& prog) {
+  return CheckAttributes(prog, nullptr);
+}
+
+std::string OsqpSolver::UnsatisfiedProgramAttributes(
+    const MathematicalProgram& prog) {
+  std::string explanation;
+  CheckAttributes(prog, &explanation);
+  return explanation;
 }
 
 }  // namespace solvers

--- a/solvers/program_attribute.h
+++ b/solvers/program_attribute.h
@@ -38,11 +38,16 @@ enum class ProgramAttribute {
 
 using ProgramAttributes = std::unordered_set<ProgramAttribute, DefaultHash>;
 
-/**
- * Returns true if @p required is a subset of @p supported.
- */
+/** Returns true iff @p required is a subset of @p supported.
+
+@param[out] unsupported_message (Optional) When provided, if this function
+returns false, the message will be set to a phrase describing the unsupported
+attributes; or if this function returns true, the message will be set to the
+empty string.
+*/
 bool AreRequiredAttributesSupported(const ProgramAttributes& required,
-                                    const ProgramAttributes& supported);
+                                    const ProgramAttributes& supported,
+                                    std::string* unsupported_message = nullptr);
 
 std::string to_string(const ProgramAttribute&);
 std::ostream& operator<<(std::ostream&, const ProgramAttribute&);

--- a/solvers/solver_base.h
+++ b/solvers/solver_base.h
@@ -2,6 +2,7 @@
 
 #include <functional>
 #include <optional>
+#include <string>
 
 #include <Eigen/Core>
 
@@ -37,19 +38,24 @@ class SolverBase : public SolverInterface {
   bool enabled() const override;
   SolverId solver_id() const override;
   bool AreProgramAttributesSatisfied(const MathematicalProgram&) const override;
+  std::string ExplainUnsatisfiedProgramAttributes(
+      const MathematicalProgram&) const override;
 
  protected:
   /// Constructs a SolverBase with the given default implementations of the
-  /// solver_id(), available(), enabled(), and AreProgramAttributesSatisfied()
-  /// methods.  (Typically, the subclass will just pass the address of its
-  /// static method, e.g. `&id`, for these functors.)  Any of the functors can
-  /// be nullptr, in which case the subclass should override the virtual method
-  /// instead.
+  /// solver_id(), available(), enabled(), AreProgramAttributesSatisfied(),
+  /// and ExplainUnsatisfiedProgramAttributes() methods.  Typically, the
+  /// subclass will simply pass the address of its static method, e.g. `&id`,
+  /// for these functors.)  Any of the functors can be nullptr, in which case
+  /// the subclass must override the matching virtual method instead, except
+  /// for `explain_unsatisfied` which already has a default implementation.
   SolverBase(
       std::function<SolverId()> id,
       std::function<bool()> available,
       std::function<bool()> enabled,
-      std::function<bool(const MathematicalProgram&)> satisfied);
+      std::function<bool(const MathematicalProgram&)> are_satisfied,
+      std::function<std::string(const MathematicalProgram&)>
+          explain_unsatisfied = nullptr);
 
   /// Hook for subclasses to implement Solve.  Prior to the SolverBase's call
   /// to this method, the solver's availability and capabilities vs the program
@@ -67,7 +73,9 @@ class SolverBase : public SolverInterface {
   std::function<SolverId()> default_id_;
   std::function<bool()> default_available_;
   std::function<bool()> default_enabled_;
-  std::function<bool(const MathematicalProgram&)> default_satisfied_;
+  std::function<bool(const MathematicalProgram&)> default_are_satisfied_;
+  std::function<std::string(const MathematicalProgram&)>
+      default_explain_unsatisfied_;
 };
 
 }  // namespace solvers

--- a/solvers/solver_interface.h
+++ b/solvers/solver_interface.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <optional>
+#include <string>
 
 #include <Eigen/Core>
 
@@ -44,9 +45,15 @@ class SolverInterface {
   /// Returns the identifier of this solver.
   virtual SolverId solver_id() const = 0;
 
-  /// Returns true if the program attributes are satisfied by the solver's
-  /// capability.
+  /// Returns true iff the program's attributes are compatible with this
+  /// solver's capabilities.
   virtual bool AreProgramAttributesSatisfied(
+      const MathematicalProgram& prog) const = 0;
+
+  /// Describes the reasons (if any) why the program is incompatible with this
+  /// solver's capabilities. If AreProgramAttributesSatisfied would return true
+  /// for the program, then this function returns the empty string.
+  virtual std::string ExplainUnsatisfiedProgramAttributes(
       const MathematicalProgram& prog) const = 0;
 
  protected:

--- a/solvers/test/osqp_solver_test.cc
+++ b/solvers/test/osqp_solver_test.cc
@@ -1,14 +1,18 @@
 #include "drake/solvers/osqp_solver.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/solvers/mathematical_program.h"
 #include "drake/solvers/test/quadratic_program_examples.h"
 
+using ::testing::HasSubstr;
+
 namespace drake {
 namespace solvers {
 namespace test {
+
 GTEST_TEST(QPtest, TestUnconstrainedQP) {
   MathematicalProgram prog;
   auto x = prog.NewContinuousVariables<3>("x");
@@ -218,6 +222,33 @@ GTEST_TEST(OsqpSolverTest, TimeLimitTest) {
     EXPECT_EQ(result.get_solver_details<OsqpSolver>().status_val,
               OSQP_TIME_LIMIT_REACHED);
   }
+}
+
+GTEST_TEST(OsqpSolverTest, ProgramAttributesGood) {
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<1>("x");
+  prog.AddQuadraticCost(x(0) * x(0));
+
+  EXPECT_TRUE(OsqpSolver::ProgramAttributesSatisfied(prog));
+  EXPECT_EQ(OsqpSolver::UnsatisfiedProgramAttributes(prog), "");
+}
+
+GTEST_TEST(OsqpSolverTest, ProgramAttributesBad) {
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<1>("x");
+  prog.AddCost(x(0) * x(0) * x(0));
+  EXPECT_FALSE(OsqpSolver::ProgramAttributesSatisfied(prog));
+  EXPECT_THAT(OsqpSolver::UnsatisfiedProgramAttributes(prog),
+              HasSubstr("GenericCost was declared"));
+}
+
+GTEST_TEST(OsqpSolverTest, ProgramAttributesMisfit) {
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<1>("x");
+  prog.AddLinearCost(4 * x(0) + 5);
+  EXPECT_FALSE(OsqpSolver::ProgramAttributesSatisfied(prog));
+  EXPECT_THAT(OsqpSolver::UnsatisfiedProgramAttributes(prog),
+              HasSubstr("QuadraticCost is required"));
 }
 
 }  // namespace test

--- a/solvers/test/program_attribute_test.cc
+++ b/solvers/test/program_attribute_test.cc
@@ -1,5 +1,9 @@
 #include "drake/solvers/program_attribute.h"
 
+#include <string>
+#include <tuple>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 namespace drake {
@@ -22,6 +26,66 @@ GTEST_TEST(ProgramAttributeTest, ToString) {
   os = std::ostringstream{};
   os << attrs;
   EXPECT_EQ(os.str(), "{ProgramAttributes: GenericCost, GenericConstraint}");
+}
+
+GTEST_TEST(ProgramAttributeTest, Supported) {
+  // Define some helpful abbreviations.
+  const ProgramAttributes lin_cons{
+      ProgramAttribute::kLinearConstraint};
+  const ProgramAttributes quad_cost{
+      ProgramAttribute::kQuadraticCost};
+  const ProgramAttributes quad_cost_cons{
+      ProgramAttribute::kQuadraticCost,
+      ProgramAttribute::kQuadraticConstraint};
+  const ProgramAttributes lin_cons_quad_cost{
+      ProgramAttribute::kLinearConstraint,
+      ProgramAttribute::kQuadraticCost};
+  const ProgramAttributes quad_cost_cons_generic_cost{
+      ProgramAttribute::kQuadraticCost,
+      ProgramAttribute::kQuadraticConstraint,
+      ProgramAttribute::kGenericCost};
+
+  // List out all of our test cases, formatted as tuples of:
+  // - required attributes,
+  // - supported attributes,
+  // - expected unsupported message (if any).
+  std::vector<std::tuple<ProgramAttributes, ProgramAttributes, std::string>>
+  cases{
+    {quad_cost, quad_cost, ""},
+    {quad_cost, quad_cost_cons, ""},
+    {quad_cost, quad_cost_cons_generic_cost, ""},
+    {quad_cost_cons, quad_cost_cons, ""},
+    {quad_cost_cons, quad_cost_cons_generic_cost, ""},
+    {lin_cons, quad_cost,
+     "a LinearConstraint was declared but is not supported"},
+    {lin_cons_quad_cost, quad_cost_cons,
+     "a LinearConstraint was declared but is not supported"},
+    {quad_cost_cons_generic_cost, quad_cost,
+     "a GenericCost and QuadraticConstraint were declared"
+     " but are not supported"},
+    {quad_cost_cons_generic_cost, lin_cons,
+     "a GenericCost, QuadraticCost, and QuadraticConstraint were declared"
+     " but are not supported"},
+  };
+
+  // Run all of the tests.
+  for (const auto& one_case : cases) {
+    const auto& required = std::get<0>(one_case);
+    const auto& supported = std::get<1>(one_case);
+    const auto& expected_message = std::get<2>(one_case);
+    const bool expected_is_supported = expected_message.empty();
+    SCOPED_TRACE(to_string(required) + " vs " + to_string(supported));
+
+    const bool is_supported_1 = AreRequiredAttributesSupported(
+        required, supported);
+    EXPECT_EQ(is_supported_1, expected_is_supported);
+
+    std::string message{"this should be clobbered"};
+    const bool is_supported_2 = AreRequiredAttributesSupported(
+        required, supported, &message);
+    EXPECT_EQ(is_supported_2, expected_is_supported);
+    EXPECT_EQ(message, expected_message);
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
This is breaking change; any direct subclasses of SolverInterface need to implement the new ExplainUnsatisfiedProgramAttributes method.

Suggested order for code review:
- osqp_solver_test
- osqp_solver
- linear_system_solver_test
- linear_system_solver
- solver_interface
- solver_base and its unit test
- program_attribute and its unit test
- pydrake changes

Resolves #15019.  Closes #15020.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15028)
<!-- Reviewable:end -->
