### PR TITLE
diagram: Finish compatibility checks

### DIFF
--- a/systems/framework/context.cc
+++ b/systems/framework/context.cc
@@ -102,7 +102,7 @@ std::unique_ptr<Context<T>> Context<T>::Clone() const {
 template <typename T>
 std::unique_ptr<State<T>> Context<T>::CloneState() const {
   auto result = DoCloneState();
-  result->get_mutable_continuous_state().set_system_id(this->get_system_id());
+  result->set_system_id(this->get_system_id());
   return result;
 }
 

--- a/systems/framework/context_base.h
+++ b/systems/framework/context_base.h
@@ -577,7 +577,14 @@ class ContextBase : public internal::ContextMessageInterface {
   void set_system_name(const std::string& name) { system_name_ = name; }
 
   // Records the id of the subsystem that created this context.
-  void set_system_id(internal::SystemId id) { system_id_ = id; }
+  void set_system_id(internal::SystemId id) {
+    system_id_ = id;
+    notify_set_system_id(id);
+  }
+
+  // Notifies interested subclasses of the id of the subsystem that created
+  // this context.
+  virtual void notify_set_system_id(internal::SystemId) {}
 
   // Fixes the input port at `index` to the internal value source `port_value`.
   // If the port wasn't previously fixed, assigns a ticket and tracker for the

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -104,11 +104,6 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
 
   std::multimap<int, int> GetDirectFeedthroughs() const final;
 
-  /// Allocates a DiagramEventCollection for this Diagram.
-  /// @sa System::AllocateCompositeEventCollection().
-  std::unique_ptr<CompositeEventCollection<T>>
-  AllocateCompositeEventCollection() const final;
-
   void SetDefaultState(const Context<T>& context,
                        State<T>* state) const override;
 
@@ -327,6 +322,9 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
   // Allocates a default-constructed diagram context containing the complete
   // diagram substructure of default-constructed subcontexts.
   std::unique_ptr<ContextBase> DoAllocateContext() const final;
+
+  std::unique_ptr<CompositeEventCollection<T>>
+  DoAllocateCompositeEventCollection() const final;
 
   // Evaluates the value of the specified subsystem input
   // port in the given context. The port has already been determined _not_ to

--- a/systems/framework/diagram_context.cc
+++ b/systems/framework/diagram_context.cc
@@ -150,7 +150,7 @@ void DiagramContext<T>::MakeState() {
     state->set_substate(i, &Context<T>::access_mutable_state(&subcontext));
   }
   state->Finalize();
-  state->get_mutable_continuous_state().set_system_id(this->get_system_id());
+  state->set_system_id(this->get_system_id());
   state_ = std::move(state);
 }
 

--- a/systems/framework/event_collection.h
+++ b/systems/framework/event_collection.h
@@ -567,6 +567,18 @@ class CompositeEventCollection {
     return *unrestricted_update_events_;
   }
 
+  /**
+   * (Internal use only) Gets the id of the subsystem that created this
+   * collection.
+   */
+  internal::SystemId get_system_id() const { return system_id_; }
+
+  /**
+   * (Internal use only) Records the id of the subsystem that created this
+   * collection.
+   */
+  void set_system_id(internal::SystemId id) { system_id_ = id; }
+
  protected:
   /**
    * Takes ownership of `pub`, `discrete` and `unrestricted`. Aborts if any
@@ -590,6 +602,9 @@ class CompositeEventCollection {
       discrete_update_events_{nullptr};
   std::unique_ptr<EventCollection<UnrestrictedUpdateEvent<T>>>
       unrestricted_update_events_{nullptr};
+
+  // Unique id of the subsystem that created this collection.
+  internal::SystemId system_id_;
 };
 
 /**

--- a/systems/framework/leaf_context.cc
+++ b/systems/framework/leaf_context.cc
@@ -101,6 +101,11 @@ std::string LeafContext<T>::do_to_string() const {
   return os.str();
 }
 
+template <typename T>
+void LeafContext<T>::notify_set_system_id(internal::SystemId id) {
+  state_->set_system_id(id);
+}
+
 }  // namespace systems
 }  // namespace drake
 

--- a/systems/framework/leaf_context.h
+++ b/systems/framework/leaf_context.h
@@ -73,6 +73,8 @@ class LeafContext : public Context<T> {
     return *state_;
   }
 
+  void notify_set_system_id(internal::SystemId id) final;
+
   /// Returns a partial textual description of the Context, intended to be
   /// human-readable.  It is not guaranteed to be unambiguous nor complete.
   std::string do_to_string() const final;

--- a/systems/framework/leaf_system.cc
+++ b/systems/framework/leaf_system.cc
@@ -48,7 +48,7 @@ LeafSystem<T>::~LeafSystem() {}
 
 template <typename T>
 std::unique_ptr<CompositeEventCollection<T>>
-LeafSystem<T>::AllocateCompositeEventCollection() const {
+LeafSystem<T>::DoAllocateCompositeEventCollection() const {
   return std::make_unique<LeafCompositeEventCollection<T>>();
 }
 
@@ -144,6 +144,7 @@ void LeafSystem<T>::SetDefaultState(
     const Context<T>& context, State<T>* state) const {
   this->ValidateContext(context);
   DRAKE_DEMAND(state != nullptr);
+  this->ValidateCreatedForThisSystem(state);
   ContinuousState<T>& xc = state->get_mutable_continuous_state();
   xc.SetFromVector(model_continuous_state_vector_->get_value());
 
@@ -332,6 +333,10 @@ LeafSystem<T>::LeafSystem(SystemScalarConverter converter)
           []() { return AbstractValue::Make(Scratch<T>{}); },
           [](const ContextBase&, AbstractValue*) { /* do nothing */ },
           {this->nothing_ticket()}).cache_index();
+
+  per_step_events_.set_system_id(this->get_system_id());
+  initialization_events_.set_system_id(this->get_system_id());
+  model_discrete_state_.set_system_id(this->get_system_id());
 }
 
 template <typename T>

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -44,11 +44,6 @@ class LeafSystem : public System<T> {
 
   ~LeafSystem() override;
 
-  /** Allocates a CompositeEventCollection object for this system.
-  @sa System::AllocateCompositeEventCollection(). */
-  std::unique_ptr<CompositeEventCollection<T>>
-      AllocateCompositeEventCollection() const final;
-
   /** Shadows System<T>::AllocateContext to provide a more concrete return
   type LeafContext<T>. */
   std::unique_ptr<LeafContext<T>> AllocateContext() const;
@@ -1969,6 +1964,9 @@ class LeafSystem : public System<T> {
   // BasicVector, or else for abstract ports throws an exception.
   std::unique_ptr<AbstractValue> DoAllocateInput(
       const InputPort<T>& input_port) const final;
+
+  std::unique_ptr<CompositeEventCollection<T>>
+      DoAllocateCompositeEventCollection() const final;
 
   std::map<PeriodicEventData, std::vector<const Event<T>*>,
       PeriodicEventDataComparator> DoGetPeriodicEvents() const override;

--- a/systems/framework/state.h
+++ b/systems/framework/state.h
@@ -113,10 +113,24 @@ class State {
     abstract_state_->SetFrom(other.get_abstract_state());
   }
 
+  /// (Internal use only) Gets the id of the subsystem that created this state.
+  internal::SystemId get_system_id() const { return system_id_; }
+
+  /// (Internal use only) Records the id of the subsystem that created this
+  /// state.
+  void set_system_id(internal::SystemId id) {
+    system_id_ = id;
+    get_mutable_continuous_state().set_system_id(this->get_system_id());
+    get_mutable_discrete_state().set_system_id(this->get_system_id());
+  }
+
  private:
   std::unique_ptr<AbstractValues> abstract_state_;
   std::unique_ptr<ContinuousState<T>> continuous_state_;
   std::unique_ptr<DiscreteValues<T>> discrete_state_;
+
+  // Unique id of the subsystem that created this state.
+  internal::SystemId system_id_;
 };
 
 }  // namespace systems

--- a/systems/framework/system.cc
+++ b/systems/framework/system.cc
@@ -26,6 +26,14 @@ std::unique_ptr<Context<T>> System<T>::AllocateContext() const {
 }
 
 template <typename T>
+std::unique_ptr<CompositeEventCollection<T>>
+System<T>::AllocateCompositeEventCollection() const {
+  auto result = DoAllocateCompositeEventCollection();
+  result->set_system_id(get_system_id());
+  return result;
+}
+
+template <typename T>
 std::unique_ptr<BasicVector<T>> System<T>::AllocateInputVector(
     const InputPort<T>& input_port) const {
   DRAKE_THROW_UNLESS(input_port.get_data_type() == kVectorValued);

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -90,8 +90,8 @@ class System : public SystemBase {
   instance is used for populating collections of triggered events; for
   example, Simulator passes this object to System::CalcNextUpdateTime() to
   allow the system to identify and handle upcoming events. */
-  virtual std::unique_ptr<CompositeEventCollection<T>>
-  AllocateCompositeEventCollection() const = 0;
+  std::unique_ptr<CompositeEventCollection<T>>
+  AllocateCompositeEventCollection() const;
 
   /** Given an input port, allocates the vector storage.  The @p input_port
   must match a port declared via DeclareInputPort. */
@@ -1739,6 +1739,13 @@ class System : public SystemBase {
   // specified by @p input_port.  This is final in LeafSystem and Diagram.
   virtual std::unique_ptr<AbstractValue> DoAllocateInput(
       const InputPort<T>& input_port) const = 0;
+
+  // Allocates a composite event collection for use with this system.
+  // Implementers should not set system_id; that is done by the wrapping
+  // AllocateCompositeEventCollection method. This method is final in
+  // LeafSystem and Diagram.
+  virtual std::unique_ptr<CompositeEventCollection<T>>
+  DoAllocateCompositeEventCollection() const = 0;
 
   std::function<void(const AbstractValue&)> MakeFixInputPortTypeChecker(
       InputPortIndex port_index) const final;

--- a/systems/framework/test/diagram_context_test.cc
+++ b/systems/framework/test/diagram_context_test.cc
@@ -716,6 +716,9 @@ TEST_F(DiagramContextTest, Clone) {
   const ContinuousState<double>& xc = clone->get_continuous_state();
   EXPECT_TRUE(xc.get_system_id().is_valid());
   EXPECT_EQ(xc.get_system_id(), context_->get_system_id());
+  const DiscreteValues<double>& xd = clone->get_discrete_state();
+  EXPECT_TRUE(xd.get_system_id().is_valid());
+  EXPECT_EQ(xd.get_system_id(), context_->get_system_id());
 
   // Verify that the state has the same value.
   VerifyClonedState(clone->get_state());
@@ -746,10 +749,17 @@ TEST_F(DiagramContextTest, CloneState) {
   VerifyClonedState(*state);
   // Verify that the underlying type was preserved.
   EXPECT_NE(nullptr, dynamic_cast<DiagramState<double>*>(state.get()));
-  ContinuousState<double>& xc = state->get_mutable_continuous_state();
+
   // Verify that the system id was copied.
+  EXPECT_TRUE(state->get_system_id().is_valid());
+  EXPECT_EQ(state->get_system_id(), context_->get_system_id());
+  ContinuousState<double>& xc = state->get_mutable_continuous_state();
   EXPECT_TRUE(xc.get_system_id().is_valid());
   EXPECT_EQ(xc.get_system_id(), context_->get_system_id());
+  const DiscreteValues<double>& xd = state->get_discrete_state();
+  EXPECT_TRUE(xd.get_system_id().is_valid());
+  EXPECT_EQ(xd.get_system_id(), context_->get_system_id());
+
   // Verify that changes to the state do not write through to the original
   // context.
   xc[1] = 1024.0;

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -878,6 +878,7 @@ TEST_F(DiagramTest, CalcTimeDerivatives) {
   AttachInputs();
   std::unique_ptr<ContinuousState<double>> derivatives =
       diagram_->AllocateTimeDerivatives();
+  EXPECT_EQ(derivatives->get_system_id(), context_->get_system_id());
 
   diagram_->CalcTimeDerivatives(*context_, derivatives.get());
 
@@ -1970,6 +1971,7 @@ TEST_F(DiscreteStateTest, UpdateDiscreteVariables) {
   // Allocate the discrete variables.
   std::unique_ptr<DiscreteValues<double>> updates =
       diagram_.AllocateDiscreteVariables();
+  EXPECT_EQ(updates->get_system_id(), context_->get_system_id());
   const DiscreteValues<double>& updates1 =
       diagram_
           .GetSubsystemDiscreteValues(*diagram_.hold1(), *updates);
@@ -3175,6 +3177,7 @@ GTEST_TEST(MyEventTest, MyEventTestLeaf) {
   MyEventTestSystem dut("sys", 0.2);
   auto events = dut.AllocateCompositeEventCollection();
   auto context = dut.CreateDefaultContext();
+  EXPECT_EQ(events->get_system_id(), context->get_system_id());
 
   double time = dut.CalcNextUpdateTime(*context, events.get());
   context->SetTime(time);

--- a/systems/framework/test/discrete_values_test.cc
+++ b/systems/framework/test/discrete_values_test.cc
@@ -89,9 +89,11 @@ TEST_F(DiscreteValuesTest, Clone) {
   // Create a DiscreteValues object with unowned contents.
   DiscreteValues<double> xd(
       std::vector<BasicVector<double>*>{data_[0].get(), data_[1].get()});
+  xd.set_system_id(internal::SystemId::get_new_id());
   std::unique_ptr<DiscreteValues<double>> clone = xd.Clone();
 
   // First check that the clone has the original values.
+  EXPECT_EQ(clone->get_system_id(), xd.get_system_id());
   EXPECT_EQ(clone->get_vector(0).get_value(), v00_);
   EXPECT_EQ(clone->get_vector(1).get_value(), v01_);
 

--- a/systems/framework/test/leaf_context_test.cc
+++ b/systems/framework/test/leaf_context_test.cc
@@ -443,6 +443,9 @@ TEST_F(LeafContextTest, Clone) {
   ContinuousState<double>& xc = clone->get_mutable_continuous_state();
   EXPECT_TRUE(xc.get_system_id().is_valid());
   EXPECT_EQ(xc.get_system_id(), context_.get_system_id());
+  const DiscreteValues<double>& xd = clone->get_discrete_state();
+  EXPECT_TRUE(xd.get_system_id().is_valid());
+  EXPECT_EQ(xd.get_system_id(), context_.get_system_id());
 
   // Verify that the cloned input ports contain the same data,
   // but are different pointers.
@@ -523,9 +526,14 @@ TEST_F(LeafContextTest, CloneState) {
   VerifyClonedState(*clone);
 
   // Verify that the system id was copied.
+  EXPECT_TRUE(clone->get_system_id().is_valid());
+  EXPECT_EQ(clone->get_system_id(), context_.get_system_id());
   const ContinuousState<double>& xc = clone->get_continuous_state();
   EXPECT_TRUE(xc.get_system_id().is_valid());
   EXPECT_EQ(xc.get_system_id(), context_.get_system_id());
+  const DiscreteValues<double>& xd = clone->get_discrete_state();
+  EXPECT_TRUE(xd.get_system_id().is_valid());
+  EXPECT_EQ(xd.get_system_id(), context_.get_system_id());
 }
 
 // Tests that the State can be copied from another State.

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -102,6 +102,7 @@ GTEST_TEST(ForcedDispatchOverrideSystemTest, Dispatchers) {
   ForcedDispatchOverrideSystem system;
   auto context = system.CreateDefaultContext();
   auto discrete_values = system.AllocateDiscreteVariables();
+  EXPECT_EQ(discrete_values->get_system_id(), context->get_system_id());
   auto state = context->CloneState();
   system.Publish(*context);
   system.CalcDiscreteVariableUpdates(*context, discrete_values.get());
@@ -845,6 +846,7 @@ TEST_F(LeafSystemTest, ContinuousStateBelongsWithSystem) {
   // Successfully calc using a storage that was created by the system.
   std::unique_ptr<ContinuousState<double>> derivatives =
       system_.AllocateTimeDerivatives();
+  EXPECT_EQ(derivatives->get_system_id(), context_.get_system_id());
   DRAKE_EXPECT_NO_THROW(
       system_.CalcTimeDerivatives(context_, derivatives.get()));
 
@@ -2724,6 +2726,7 @@ GTEST_TEST(InitializationTest, InitializationTest) {
   auto discrete_updates = dut.AllocateDiscreteVariables();
   auto state = context->CloneState();
   auto init_events = dut.AllocateCompositeEventCollection();
+  EXPECT_EQ(init_events->get_system_id(), context->get_system_id());
   dut.GetInitializationEvents(*context, init_events.get());
 
   dut.Publish(*context, init_events->get_publish_events());

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -60,7 +60,7 @@ class TestSystem : public System<double> {
   }
 
   std::unique_ptr<CompositeEventCollection<double>>
-  AllocateCompositeEventCollection() const override {
+  DoAllocateCompositeEventCollection() const override {
     return std::make_unique<LeafCompositeEventCollection<double>>();
   }
 
@@ -644,7 +644,7 @@ class ValueIOTestSystem : public System<T> {
   }
 
   std::unique_ptr<CompositeEventCollection<T>>
-  AllocateCompositeEventCollection() const override {
+  DoAllocateCompositeEventCollection() const override {
     return std::make_unique<LeafCompositeEventCollection<T>>();
   }
 
@@ -1020,7 +1020,7 @@ class ComputationTestSystem final : public System<double> {
 
   // These are required by the base class but not used here.
   std::unique_ptr<CompositeEventCollection<double>>
-  AllocateCompositeEventCollection() const final { return {}; }
+  DoAllocateCompositeEventCollection() const final { return {}; }
   void SetDefaultState(const Context<double>&, State<double>*) const final {}
   void SetDefaultParameters(const Context<double>&,
                             Parameters<double>*) const final {}


### PR DESCRIPTION
Relevant to: #12560

Add system-id labeling to State, DiscreteValues, and
CompositeEventCollection types. Check compatibility of objects at public
Diagram methods. Move some methods to private access that should have
been private all along.

This patch completes compatibility checking for Diagram<T>. Further work
remains to close the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15030)
<!-- Reviewable:end -->
