### PR TITLE
diagram: (breaking change) Fix access to internal methods

### DIFF
--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -138,13 +138,6 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
 
   std::unique_ptr<DiscreteValues<T>> AllocateDiscreteVariables() const final;
 
-  void DoCalcTimeDerivatives(const Context<T>& context,
-                             ContinuousState<T>* derivatives) const final;
-
-  void DoCalcImplicitTimeDerivativesResidual(
-      const Context<T>& context, const ContinuousState<T>& proposed_derivatives,
-      EigenPtr<VectorX<T>> residual) const final;
-
   /// Retrieves a reference to the subsystem with name @p name returned by
   /// get_name().
   /// @throws std::logic_error if a match cannot be found.
@@ -443,6 +436,13 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
   void DoGetInitializationEvents(
       const Context<T>& context,
       CompositeEventCollection<T>* event_info) const override;
+
+  void DoCalcTimeDerivatives(const Context<T>& context,
+                             ContinuousState<T>* derivatives) const final;
+
+  void DoCalcImplicitTimeDerivativesResidual(
+      const Context<T>& context, const ContinuousState<T>& proposed_derivatives,
+      EigenPtr<VectorX<T>> residual) const final;
 
   // A structural outline of a Diagram, produced by DiagramBuilder.
   struct Blueprint {


### PR DESCRIPTION
Relevant to: #12560

Move some methods to private that should have always been private, per
the NVI pattern.

This is a breaking change, since previously public methods are being
removed. The fix for client code is to call the related non-virtual
interface method instead; i.e.: remove 'Do' from the method name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15031)
<!-- Reviewable:end -->
