### PR TITLE
framework: Avoid functor allocation for all event types

### DIFF
--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -427,7 +427,14 @@ void DefineFrameworkPySemantics(py::module m) {
                    return std::make_unique<UnrestrictedUpdateEvent<T>>(
                        callback);
                  })),
-            py::arg("callback"), doc.UnrestrictedUpdateEvent.ctor.doc_1args);
+            py::arg("callback"),
+            doc.UnrestrictedUpdateEvent.ctor.doc_1args_callback)
+        .def(py::init(WrapCallbacks([](const typename UnrestrictedUpdateEvent<
+                                        T>::SystemCallback& system_callback) {
+          return std::make_unique<UnrestrictedUpdateEvent<T>>(system_callback);
+        })),
+            py::arg("system_callback"),
+            doc.UnrestrictedUpdateEvent.ctor.doc_1args_system_callback);
 
     // Glue mechanisms.
     DefineTemplateClassWithDefault<DiagramBuilder<T>>(

--- a/examples/compass_gait/test/compass_gait_test.cc
+++ b/examples/compass_gait/test/compass_gait_test.cc
@@ -201,7 +201,7 @@ GTEST_TEST(CompassGaitTest, TestCollisionDynamics) {
   auto next_context = cg.CreateDefaultContext();
   dynamic_cast<const systems::UnrestrictedUpdateEvent<double>*>(
       foot_collision->get_event())
-      ->handle(*context, &next_context->get_mutable_state());
+      ->handle(cg, *context, &next_context->get_mutable_state());
 
   const double angular_momentum_after =
       CalcAngularMomentum(cg, *next_context, true);

--- a/systems/analysis/test/simulator_limit_malloc_test.cc
+++ b/systems/analysis/test/simulator_limit_malloc_test.cc
@@ -76,7 +76,7 @@ GTEST_TEST(SimulatorLimitMallocTest,
     // heap-free simulation after initialization, given careful system
     // construction.
     // TODO(rpoyner-tri): whittle allocations down to 0.
-    test::LimitMalloc heap_alloc_checker({.max_num_allocations = 126});
+    test::LimitMalloc heap_alloc_checker({.max_num_allocations = 84});
     simulator.AdvanceTo(1.0);
     simulator.AdvanceTo(2.0);
     simulator.AdvanceTo(3.0);

--- a/systems/framework/leaf_system.cc
+++ b/systems/framework/leaf_system.cc
@@ -725,7 +725,7 @@ void LeafSystem<T>::DoCalcDiscreteVariableUpdates(
     const std::vector<const DiscreteUpdateEvent<T>*>& events,
     DiscreteValues<T>* discrete_state) const {
   for (const DiscreteUpdateEvent<T>* event : events) {
-    event->handle(context, discrete_state);
+    event->handle(*this, context, discrete_state);
   }
 }
 
@@ -735,7 +735,7 @@ void LeafSystem<T>::DoCalcUnrestrictedUpdate(
     const std::vector<const UnrestrictedUpdateEvent<T>*>& events,
     State<T>* state) const {
   for (const UnrestrictedUpdateEvent<T>* event : events) {
-    event->handle(context, state);
+    event->handle(*this, context, state);
   }
 }
 

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -368,21 +368,20 @@ class LeafSystem : public System<T> {
           const) {
     static_assert(std::is_base_of<LeafSystem<T>, MySystem>::value,
                   "Expected to be invoked from a LeafSystem-derived System.");
-    auto this_ptr = dynamic_cast<const MySystem*>(this);
-    DRAKE_DEMAND(this_ptr != nullptr);
     DRAKE_DEMAND(update != nullptr);
 
     DeclarePeriodicEvent(
         period_sec, offset_sec,
-        DiscreteUpdateEvent<T>(TriggerType::kPeriodic,
-                               [this_ptr, update](const Context<T>& context,
-                                                  const DiscreteUpdateEvent<T>&,
-                                                  DiscreteValues<T>* xd) {
-                                 // TODO(sherm1) Forward the return status.
-                                 (this_ptr->*update)(
-                                     context,
-                                     &*xd);  // Ignore return status for now.
-                               }));
+        DiscreteUpdateEvent<T>(
+            TriggerType::kPeriodic,
+            [update](const System<T>& system,
+                     const Context<T>& context,
+                     const DiscreteUpdateEvent<T>&,
+                     DiscreteValues<T>* xd) {
+              const auto& sys = dynamic_cast<const MySystem&>(system);
+              // TODO(sherm1) Forward the return status.
+              (sys.*update)(context, &*xd);  // Ignore return status for now.
+            }));
   }
 
   /** This variant accepts a handler that is assumed to succeed rather than
@@ -398,19 +397,20 @@ class LeafSystem : public System<T> {
       void (MySystem::*update)(const Context<T>&, DiscreteValues<T>*) const) {
     static_assert(std::is_base_of<LeafSystem<T>, MySystem>::value,
                   "Expected to be invoked from a LeafSystem-derived System.");
-    auto this_ptr = dynamic_cast<const MySystem*>(this);
-    DRAKE_DEMAND(this_ptr != nullptr);
     DRAKE_DEMAND(update != nullptr);
 
     DeclarePeriodicEvent(
         period_sec, offset_sec,
-        DiscreteUpdateEvent<T>(TriggerType::kPeriodic,
-                               [this_ptr, update](const Context<T>& context,
-                                                  const DiscreteUpdateEvent<T>&,
-                                                  DiscreteValues<T>* xd) {
-                                 (this_ptr->*update)(context, &*xd);
-                                 // TODO(sherm1) return EventStatus::Succeeded()
-                               }));
+        DiscreteUpdateEvent<T>(
+            TriggerType::kPeriodic,
+            [update](const System<T>& system,
+                     const Context<T>& context,
+                     const DiscreteUpdateEvent<T>&,
+                     DiscreteValues<T>* xd) {
+              const auto& sys = dynamic_cast<const MySystem&>(system);
+              (sys.*update)(context, &*xd);
+              // TODO(sherm1) return EventStatus::Succeeded()
+            }));
   }
 
   /** Declares that an UnrestrictedUpdate event should occur periodically and
@@ -437,19 +437,18 @@ class LeafSystem : public System<T> {
       EventStatus (MySystem::*update)(const Context<T>&, State<T>*) const) {
     static_assert(std::is_base_of<LeafSystem<T>, MySystem>::value,
                   "Expected to be invoked from a LeafSystem-derived System.");
-    auto this_ptr = dynamic_cast<const MySystem*>(this);
-    DRAKE_DEMAND(this_ptr != nullptr);
     DRAKE_DEMAND(update != nullptr);
 
     DeclarePeriodicEvent(
         period_sec, offset_sec,
         UnrestrictedUpdateEvent<T>(
             TriggerType::kPeriodic,
-            [this_ptr, update](const Context<T>& context,
-                               const UnrestrictedUpdateEvent<T>&, State<T>* x) {
+            [update](const System<T>& system,
+                     const Context<T>& context,
+                     const UnrestrictedUpdateEvent<T>&, State<T>* x) {
+              const auto& sys = dynamic_cast<const MySystem&>(system);
               // TODO(sherm1) Forward the return status.
-              (this_ptr->*update)(context,
-                                  &*x);  // Ignore return status for now.
+              (sys.*update)(context, &*x);  // Ignore return status for now.
             }));
   }
 
@@ -465,17 +464,16 @@ class LeafSystem : public System<T> {
       void (MySystem::*update)(const Context<T>&, State<T>*) const) {
     static_assert(std::is_base_of<LeafSystem<T>, MySystem>::value,
                   "Expected to be invoked from a LeafSystem-derived System.");
-    auto this_ptr = dynamic_cast<const MySystem*>(this);
-    DRAKE_DEMAND(this_ptr != nullptr);
     DRAKE_DEMAND(update != nullptr);
 
     DeclarePeriodicEvent(
         period_sec, offset_sec,
         UnrestrictedUpdateEvent<T>(
             TriggerType::kPeriodic,
-            [this_ptr, update](const Context<T>& context,
-                               const UnrestrictedUpdateEvent<T>&, State<T>* x) {
-              (this_ptr->*update)(context, &*x);
+            [update](const System<T>& system, const Context<T>& context,
+                     const UnrestrictedUpdateEvent<T>&, State<T>* x) {
+              const auto& sys = dynamic_cast<const MySystem&>(system);
+              (sys.*update)(context, &*x);
               // TODO(sherm1) return EventStatus::Succeeded()
             }));
   }
@@ -647,18 +645,17 @@ class LeafSystem : public System<T> {
       const Context<T>&, DiscreteValues<T>*) const) {
     static_assert(std::is_base_of<LeafSystem<T>, MySystem>::value,
                   "Expected to be invoked from a LeafSystem-derived System.");
-    auto this_ptr = dynamic_cast<const MySystem*>(this);
-    DRAKE_DEMAND(this_ptr != nullptr);
     DRAKE_DEMAND(update != nullptr);
 
-    DeclarePerStepEvent(DiscreteUpdateEvent<T>(
-        TriggerType::kPerStep, [this_ptr, update](const Context<T>& context,
-                                                  const DiscreteUpdateEvent<T>&,
-                                                  DiscreteValues<T>* xd) {
-          // TODO(sherm1) Forward the return status.
-          (this_ptr->*update)(context,
-                              &*xd);  // Ignore return status for now.
-        }));
+    DeclarePerStepEvent(
+        DiscreteUpdateEvent<T>(
+            TriggerType::kPerStep,
+            [update](const System<T>& system, const Context<T>& context,
+                     const DiscreteUpdateEvent<T>&, DiscreteValues<T>* xd) {
+              const auto& sys = dynamic_cast<const MySystem&>(system);
+              // TODO(sherm1) Forward the return status.
+              (sys.*update)(context, &*xd);  // Ignore return status for now.
+            }));
   }
 
   /** Declares that an UnrestrictedUpdate event should occur at the start of
@@ -686,17 +683,15 @@ class LeafSystem : public System<T> {
       EventStatus (MySystem::*update)(const Context<T>&, State<T>*) const) {
     static_assert(std::is_base_of<LeafSystem<T>, MySystem>::value,
                   "Expected to be invoked from a LeafSystem-derived System.");
-    auto this_ptr = dynamic_cast<const MySystem*>(this);
-    DRAKE_DEMAND(this_ptr != nullptr);
     DRAKE_DEMAND(update != nullptr);
 
     DeclarePerStepEvent(UnrestrictedUpdateEvent<T>(
         TriggerType::kPerStep,
-        [this_ptr, update](const Context<T>& context,
-                           const UnrestrictedUpdateEvent<T>&, State<T>* x) {
+        [update](const System<T>& system, const Context<T>& context,
+                 const UnrestrictedUpdateEvent<T>&, State<T>* x) {
+          const auto& sys = dynamic_cast<const MySystem&>(system);
           // TODO(sherm1) Forward the return status.
-          (this_ptr->*update)(context,
-                              &*x);  // Ignore return status for now.
+          (sys.*update)(context, &*x);  // Ignore return status for now.
         }));
   }
 

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -466,7 +466,7 @@ TEST_F(LeafSystemTest, WitnessDeclarations) {
   auto de = dynamic_cast<const DiscreteUpdateEvent<double>*>(
       witness4->get_event());
   ASSERT_TRUE(de);
-  de->handle(context_, nullptr);
+  de->handle(system_, context_, nullptr);
   EXPECT_TRUE(system_.discrete_update_callback_called());
 
   auto witness5 = system_.MakeWitnessWithUnrestrictedUpdate();
@@ -480,7 +480,7 @@ TEST_F(LeafSystemTest, WitnessDeclarations) {
   auto ue = dynamic_cast<const UnrestrictedUpdateEvent<double>*>(
       witness5->get_event());
   ASSERT_TRUE(ue);
-  ue->handle(context_, nullptr);
+  ue->handle(system_, context_, nullptr);
   EXPECT_TRUE(system_.unrestricted_update_callback_called());
 
   auto witness6 = system_.DeclareLambdaWitnessWithoutEvent();


### PR DESCRIPTION
Relevant to: #14543

This is the seventh of a long PR train to make heapless simulation
possible, with careful system construction. Inspired by @edrumwri's
draft PR #14707.

This patch extends the techniques of PR #14969 to all of the event
types.

Subsequent patches will address other sources of heap allocation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15032)
<!-- Reviewable:end -->
