### PR TITLE
Add DiscreteUpdateManager and PhysicalModel

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -55,12 +55,27 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "dummy_model",
+    testonly = 1,
+    hdrs = ["test/dummy_model.h"],
+    deps = [
+        ":multibody_plant_core",
+    ],
+)
+
+drake_cc_library(
     name = "multibody_plant_core",
     srcs = [
+        "discrete_update_manager.cc",
         "multibody_plant.cc",
+        "physical_model.cc",
     ],
     hdrs = [
+        "discrete_update_manager.h",
         "multibody_plant.h",
+        "multibody_plant_discrete_update_manager_attorney.h",
+        "multibody_plant_model_attorney.h",
+        "physical_model.h",
     ],
     visibility = ["//visibility:private"],
     deps = [
@@ -678,6 +693,16 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "discrete_update_manager_test",
+    deps = [
+        ":dummy_model",
+        ":multibody_plant_core",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//systems/analysis:simulator",
+    ],
+)
+
+drake_cc_googletest(
     name = "contact_permutation_test",
     data = [
         "//examples/kuka_iiwa_arm/models",
@@ -690,6 +715,16 @@ drake_cc_googletest(
         ":plant",
         "//common:find_resource",
         "//multibody/parsing",
+    ],
+)
+
+drake_cc_googletest(
+    name = "physical_model_test",
+    deps = [
+        ":dummy_model",
+        ":multibody_plant_core",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/multibody/plant/discrete_update_manager.cc
+++ b/multibody/plant/discrete_update_manager.cc
@@ -1,0 +1,16 @@
+#include "drake/multibody/plant/discrete_update_manager.h"
+
+#include "drake/multibody/plant/multibody_plant_discrete_update_manager_attorney.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+template <typename T>
+const MultibodyTree<T>& DiscreteUpdateManager<T>::internal_tree() const {
+  return MultibodyPlantDiscreteUpdateManagerAttorney<T>::internal_tree(plant());
+}
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::internal::DiscreteUpdateManager);

--- a/multibody/plant/discrete_update_manager.h
+++ b/multibody/plant/discrete_update_manager.h
@@ -1,0 +1,124 @@
+#pragma once
+#include <memory>
+
+#include "drake/multibody/contact_solvers/contact_solver_results.h"
+#include "drake/multibody/tree/multibody_tree.h"
+#include "drake/systems/framework/context.h"
+
+namespace drake {
+namespace multibody {
+template <typename T>
+class MultibodyPlant;
+
+namespace internal {
+template <typename T>
+class AccelerationKinematicsCache;
+
+/* This class is used to perform all calculations needed to advance state for a
+ MultibodyPlant with discrete state.
+
+ It is an abstract base class providing an interface for MultibodyPlant to
+ invoke, with the intent that a variety of concrete DiscreteUpdateManagers will
+ be derived from this base class. As of today a new manager can be set with the
+ experimental method MultibodyPlant::set_discrete_update_manager(). This allows
+ Drake developers to experiment with a variety of discrete update methods.
+
+ @tparam_default_scalar */
+template <typename T>
+class DiscreteUpdateManager {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiscreteUpdateManager);
+
+  DiscreteUpdateManager() = default;
+
+  virtual ~DiscreteUpdateManager() = default;
+
+  /* Returns the MultibodyPlant that owns this DiscreteUpdateManager.
+   @pre SetOwningMultibodyPlant() has been successfully invoked. */
+  const MultibodyPlant<T>& plant() const {
+    DRAKE_DEMAND(plant_ != nullptr);
+    return *plant_;
+  }
+
+  /* (Internal) Sets the given `plant` as the MultibodyPlant owning this
+   DiscreteUpdateManager. This method is meant to be called by
+   MultibodyPlant::set_discrete_update_manager() only.
+   @pre plant is Finalized. */
+  void SetOwningMultibodyPlant(const MultibodyPlant<T>* plant) {
+    DRAKE_DEMAND(plant != nullptr);
+    DRAKE_DEMAND(plant->is_finalized());
+    plant_ = plant;
+    multibody_state_index_ = plant_->GetDiscreteStateIndexOrThrow();
+    ExtractModelInfo();
+  }
+
+  /* Given the state of the model stored in `context`, this method performs the
+   entire computation that is needed to obtain contact forces and advance
+   state to the next step. Results pertaining to the multibody rigid degrees of
+   freedoms are written to the ContactSolverResults output parameter. */
+  void CalcContactSolverResults(
+      const systems::Context<T>& context,
+      contact_solvers::internal::ContactSolverResults<T>* results) const {
+    DRAKE_DEMAND(results != nullptr);
+    DoCalcContactSolverResults(context, results);
+  }
+
+  /* Computes acceleration kinematics quantities. MultibodyPlant evaluates (in
+   the systems:: sense of the word) the acceleration kinematics cache for
+   computations that depend on it. Examples include the computation of reaction
+   forces and the reporting of spatial accelerations. */
+  // TODO(amcastro-tri): Update AccelerationKinematicsCache to allow storing
+  // additional acceleration kinematics data for deformable models.
+  void CalcAccelerationKinematicsCache(
+      const systems::Context<T>& context,
+      internal::AccelerationKinematicsCache<T>* ac) const {
+    DRAKE_DEMAND(ac != nullptr);
+    DoCalcAccelerationKinematicsCache(context, ac);
+  }
+
+  /* MultibodyPlant invokes this method to perform the discrete variables
+   update. */
+  void CalcDiscreteValues(const systems::Context<T>& context,
+                          systems::DiscreteValues<T>* updates) const {
+    DRAKE_DEMAND(updates != nullptr);
+    DoCalcDiscreteValues(context, updates);
+  }
+
+ protected:
+  /* Derived DiscreteUpdateManager should override this method to extract
+   information from the owning MultibodyPlant. */
+  virtual void ExtractModelInfo() {}
+
+  /* Returns the discrete state index of the rigid position and velocity states
+   declared by MultibodyPlant. */
+  systems::DiscreteStateIndex multibody_state_index() const {
+    return multibody_state_index_;
+  }
+
+  /* Exposed MultibodyPlant private/protected method. */
+  const MultibodyTree<T>& internal_tree() const;
+
+  /* Concrete DiscreteUpdateManagers must override these NVI Calc methods to
+   provide an implementation. The output parameters are guaranteed to be
+   non-null and do not need to be checked again. */
+  virtual void DoCalcContactSolverResults(
+      const systems::Context<T>& context,
+      contact_solvers::internal::ContactSolverResults<T>* results) const = 0;
+
+  virtual void DoCalcAccelerationKinematicsCache(
+      const systems::Context<T>& context,
+      internal::AccelerationKinematicsCache<T>* ac) const = 0;
+
+  virtual void DoCalcDiscreteValues(
+      const systems::Context<T>& context,
+      systems::DiscreteValues<T>* updates) const = 0;
+
+ private:
+  const MultibodyPlant<T>* plant_{nullptr};
+  systems::DiscreteStateIndex multibody_state_index_;
+};
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::internal::DiscreteUpdateManager);

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1392,7 +1392,7 @@ void MultibodyPlant<T>::CalcContactResultsDiscretePointPair(
   const std::vector<RotationMatrix<T>>& R_WC_set =
       EvalContactJacobians(context).R_WC_list;
   const contact_solvers::internal::ContactSolverResults<T>& solver_results =
-      EvalTamsiResults(context);
+      EvalContactSolverResults(context);
 
   const VectorX<T>& fn = solver_results.fn;
   const VectorX<T>& ft = solver_results.ft;
@@ -1572,7 +1572,7 @@ void MultibodyPlant<T>::CalcHydroelasticContactForces(
     const Body<T>& bodyA = get_body(bodyA_index);
     const Body<T>& bodyB = get_body(bodyB_index);
 
-    // The the poses and spatial velocities of bodies A and B.
+    // The poses and spatial velocities of bodies A and B.
     const RigidTransform<T>& X_WA = bodyA.EvalPoseInWorld(context);
     const RigidTransform<T>& X_WB = bodyB.EvalPoseInWorld(context);
     const SpatialVelocity<T>& V_WA = bodyA.EvalSpatialVelocityInWorld(context);
@@ -2072,16 +2072,24 @@ MultibodyPlant<T>::CalcDiscreteContactPairs(
   }
 }
 
-// TODO(amcastro-tri): Rename this to CalcDiscreteSolverResults(), since also
-// applicable to all of our ContactSolver classes.
 template <typename T>
-void MultibodyPlant<T>::CalcTamsiResults(
+void MultibodyPlant<T>::CalcContactSolverResults(
     const drake::systems::Context<T>& context0,
     contact_solvers::internal::ContactSolverResults<T>* results) const {
   // Assert this method was called on a context storing discrete state.
   this->ValidateContext(context0);
-  DRAKE_ASSERT(context0.num_discrete_state_groups() == 1);
   DRAKE_ASSERT(context0.num_continuous_states() == 0);
+
+  // We use the custom manager if provided.
+  // TODO(amcastro-tri): remove the entirety of the code we are bypassing here.
+  // This requires one of our custom managers to become the default
+  // MultibodyPlant manager.
+  if (discrete_update_manager_ != nullptr) {
+    discrete_update_manager_->CalcContactSolverResults(context0, results);
+    return;
+  } else {
+    DRAKE_ASSERT(context0.num_discrete_state_groups() == 1);
+  }
 
   const int nq = this->num_positions();
   const int nv = this->num_velocities();
@@ -2461,9 +2469,17 @@ void MultibodyPlant<T>::DoCalcForwardDynamicsDiscrete(
   DRAKE_DEMAND(ac != nullptr);
   DRAKE_DEMAND(is_discrete());
 
+  // TODO(amcastro-tri): remove the entirety of the code we are bypassing here.
+  // This requires one of our custom managers to become the default
+  // MultibodyPlant manager.
+  if (discrete_update_manager_) {
+    discrete_update_manager_->CalcAccelerationKinematicsCache(context0, ac);
+    return;
+  }
+
   // Evaluate contact results.
   const contact_solvers::internal::ContactSolverResults<T>& solver_results =
-      EvalTamsiResults(context0);
+      EvalContactSolverResults(context0);
 
   // Retrieve the solution velocity for the next time step.
   const VectorX<T>& v_next = solver_results.v_next;
@@ -2486,6 +2502,14 @@ void MultibodyPlant<T>::DoCalcDiscreteVariableUpdates(
     const std::vector<const drake::systems::DiscreteUpdateEvent<T>*>&,
     drake::systems::DiscreteValues<T>* updates) const {
   this->ValidateContext(context0);
+
+  // TODO(amcastro-tri): remove the entirety of the code we are bypassing here.
+  // This requires one of our custom managers to become the default
+  // MultibodyPlant manager.
+  if (discrete_update_manager_) {
+    discrete_update_manager_->CalcDiscreteValues(context0, updates);
+    return;
+  }
 
   // Get the system state as raw Eigen vectors
   // (solution at the previous time step).
@@ -2656,13 +2680,13 @@ void MultibodyPlant<T>::DeclareStateCacheAndPorts() {
     const int instance_num_velocities = num_velocities(model_instance_index);
 
     if (is_discrete()) {
-      const auto& tamsi_solver_results_cache_entry =
-          this->get_cache_entry(cache_indexes_.tamsi_solver_results);
+      const auto& contact_solver_results_cache_entry =
+          this->get_cache_entry(cache_indexes_.contact_solver_results);
       auto calc = [this, model_instance_index](
                       const systems::Context<T>& context,
                       systems::BasicVector<T>* result) {
         const contact_solvers::internal::ContactSolverResults<T>&
-            solver_results = EvalTamsiResults(context);
+            solver_results = EvalContactSolverResults(context);
         this->CopyGeneralizedContactForcesOut(solver_results,
                                               model_instance_index, result);
       };
@@ -2671,7 +2695,7 @@ void MultibodyPlant<T>::DeclareStateCacheAndPorts() {
                   GetModelInstanceName(model_instance_index) +
                       "_generalized_contact_forces",
                   BasicVector<T>(instance_num_velocities), calc,
-                  {tamsi_solver_results_cache_entry.ticket()})
+                  {contact_solver_results_cache_entry.ticket()})
               .get_index();
     } else {
       const auto& generalized_contact_forces_continuous_cache_entry =
@@ -2711,6 +2735,12 @@ void MultibodyPlant<T>::DeclareStateCacheAndPorts() {
                                   &MultibodyPlant<T>::CopyContactResultsOutput,
                                   {contact_results_cache_entry.ticket()})
                               .get_index();
+
+  // Let external model managers declare their state, cache and ports in
+  // `this` MultibodyPlant.
+  for (auto& physical_model : physical_models_) {
+    physical_model->DeclareSystemResources(this);
+  }
 }
 
 template <typename T>
@@ -2810,7 +2840,7 @@ void MultibodyPlant<T>::DeclareCacheEntries() {
         auto& context = dynamic_cast<const Context<T>&>(context_base);
         auto& tamsi_solver_cache = cache_value->get_mutable_value<
             contact_solvers::internal::ContactSolverResults<T>>();
-        this->CalcTamsiResults(context,
+        this->CalcContactSolverResults(context,
                                           &tamsi_solver_cache);
       },
       // The Correct Solution:
@@ -2835,7 +2865,7 @@ void MultibodyPlant<T>::DeclareCacheEntries() {
       // discrete update of these values as if zero-order held, which is what we
       // want.
       {this->xd_ticket(), this->all_parameters_ticket()});
-  cache_indexes_.tamsi_solver_results =
+  cache_indexes_.contact_solver_results =
       tamsi_solver_cache_entry.cache_index();
 
   // Cache entry for spatial forces and contact info due to hydroelastic
@@ -2878,7 +2908,7 @@ void MultibodyPlant<T>::DeclareCacheEntries() {
     std::set<systems::DependencyTicket> tickets;
     if (is_discrete()) {
       tickets.insert(
-          this->cache_entry_ticket(cache_indexes_.tamsi_solver_results));
+          this->cache_entry_ticket(cache_indexes_.contact_solver_results));
     } else {
       tickets.insert(this->kinematics_ticket());
       if (use_hydroelastic) {

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -25,6 +25,8 @@
 #include "drake/multibody/plant/contact_results.h"
 #include "drake/multibody/plant/coulomb_friction.h"
 #include "drake/multibody/plant/discrete_contact_pair.h"
+#include "drake/multibody/plant/discrete_update_manager.h"
+#include "drake/multibody/plant/physical_model.h"
 #include "drake/multibody/plant/tamsi_solver.h"
 #include "drake/multibody/topology/multibody_graph.h"
 #include "drake/multibody/tree/force_element.h"
@@ -64,6 +66,11 @@ struct HydroelasticContactInfoAndBodySpatialForces {
   std::vector<HydroelasticContactInfo<T>> contact_info;
 };
 
+// Forward declaration.
+template <typename>
+class MultibodyPlantModelAttorney;
+template <typename>
+class MultibodyPlantDiscreteUpdateManagerAttorney;
 }  // namespace internal
 
 // TODO(amcastro-tri): Add a section on contact models in
@@ -1587,6 +1594,74 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     SolverType* solver_ptr = solver.get();
     contact_solver_ = std::move(solver);
     return *solver_ptr;
+  }
+
+  // (Experimental) set_discrete_update_manager() should only be called by
+  // advanced developers wanting to try out their custom time stepping
+  // strategies, including contact resolution. We choose not to show it in
+  // public documentations rather than making it private with friends. With this
+  // method MultibodyPlant takes ownership of `manager`.
+  //
+  // @note Setting a contact manager bypasses the mechanism to set a different
+  // contact solver with set_contact_solver(). Use only one of these two
+  // experimental mechanims but never both.
+  //
+  // @param manager
+  //   After this call the new manager is used to advance discrete states.
+  // @pre manager must not be nullptr.
+  // @pre ManagerType is a subclass of
+  //   multibody::internal::DiscreteUpdateManager.
+  // @returns a mutable reference to `manager`, now owned by `this`
+  // MultibodyPlant.
+  // @throws std::exception if called pre-finalize. See Finalize().
+  template <class ManagerType>
+  ManagerType& set_discrete_update_manager(
+      std::unique_ptr<ManagerType> manager) {
+    // N.B. This requirement is really more important on the side of the
+    // manager's constructor, since most likely it'll need MBP's topology at
+    // least to build the contact problem. However, here we play safe and demand
+    // finalization right here.
+    DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+    DRAKE_DEMAND(manager != nullptr);
+    static_assert(
+        std::is_base_of<internal::DiscreteUpdateManager<T>, ManagerType>::value,
+        "ManagerType must be a sub-class of DiscreteUpdateManager.");
+    manager->SetOwningMultibodyPlant(this);
+    discrete_update_manager_ = std::move(manager);
+    ManagerType* concrete_manager_ptr =
+        static_cast<ManagerType*>(discrete_update_manager_.get());
+    return *concrete_manager_ptr;
+  }
+
+  // (Experimental) AddPhysicalModel() should only be called by advanced
+  // developers wanting to try out their new physical models. We choose not to
+  // show it in public documentations rather than making it private with
+  // friends. With this method MultibodyPlant takes ownership of `model`
+  // and calls its DeclareSystemResources() method at Finalize(), giving
+  // specific physical model implementations a chance to declare the system
+  // resources it needs.
+  //
+  // @param model After this call the model is owned by `this` MultibodyPlant.
+  // @pre model != nullptr.
+  // @pre ModelType must be a subclass of multibody::internal::PhysicalModel.
+  // @returns a mutable reference to `model`, now owned by `this`
+  //          MultibodyPlant.
+  // @throws std::exception if called post-finalize. See Finalize().
+  template <class ModelType>
+  ModelType& AddPhysicalModel(std::unique_ptr<ModelType> model) {
+    DRAKE_MBP_THROW_IF_FINALIZED();
+    DRAKE_DEMAND(model != nullptr);
+    static_assert(std::is_base_of_v<internal::PhysicalModel<T>, ModelType>,
+                  "ModelType must be a sub-class of PhysicalModel.");
+    physical_models_.emplace_back(std::move(model));
+    ModelType* concrete_model_ptr =
+        static_cast<ModelType*>(physical_models_.back().get());
+    return *concrete_model_ptr;
+  }
+
+  const std::vector<std::unique_ptr<internal::PhysicalModel<T>>>&
+  physical_models() const {
+    return physical_models_;
   }
 #endif
 
@@ -3854,6 +3929,11 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // Friend class to facilitate testing.
   friend class MultibodyPlantTester;
 
+  // Friend attorney class to provide private access to those internal::
+  // implementations that need it.
+  friend class internal::MultibodyPlantModelAttorney<T>;
+  friend class internal::MultibodyPlantDiscreteUpdateManagerAttorney<T>;
+
   // This struct stores in one single place all indexes related to
   // MultibodyPlant specific cache entries. These are initialized at Finalize()
   // when the plant declares its cache entries.
@@ -3866,7 +3946,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     systems::CacheIndex hydro_fallback;
     systems::CacheIndex point_pairs;
     systems::CacheIndex spatial_contact_forces_continuous;
-    systems::CacheIndex tamsi_solver_results;
+    systems::CacheIndex contact_solver_results;
   };
 
   // Constructor to bridge testing from MultibodyTree to MultibodyPlant.
@@ -4076,19 +4156,18 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const VectorX<T>& stiffness, const VectorX<T>& damping,
       const VectorX<T>& mu, const VectorX<T>& v0, const VectorX<T>& fn0) const;
 
-  // This method uses the time stepping method described in
-  // TamsiSolver to advance the model's state stored in
-  // `context0` taking a time step of size time_step().
+  // This method performs the computation of the impulses to advance the state
+  // stored in `context0` in time.
   // Contact forces and velocities are computed and stored in `results`. See
   // ContactSolverResults for further details on the returned data.
-  void CalcTamsiResults(
+  void CalcContactSolverResults(
       const drake::systems::Context<T>& context0,
       contact_solvers::internal::ContactSolverResults<T>* results) const;
 
-  // Eval version of the method CalcTamsiResults().
-  const contact_solvers::internal::ContactSolverResults<T>& EvalTamsiResults(
-      const systems::Context<T>& context) const {
-    return this->get_cache_entry(cache_indexes_.tamsi_solver_results)
+  // Eval version of the method CalcContactSolverResults().
+  const contact_solvers::internal::ContactSolverResults<T>&
+  EvalContactSolverResults(const systems::Context<T>& context) const {
+    return this->get_cache_entry(cache_indexes_.contact_solver_results)
         .template Eval<contact_solvers::internal::ContactSolverResults<T>>(
             context);
   }
@@ -4673,6 +4752,16 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   // When not the nullptr, this is the solver to be used for discrete updates.
   std::unique_ptr<contact_solvers::internal::ContactSolver<T>> contact_solver_;
+
+  // When not the nullptr, this manager class is used to advance discrete
+  // states.
+  // TODO(amcastro-tri): migrate the entirety of computations related to contact
+  // resolution into a default contact manager.
+  std::unique_ptr<internal::DiscreteUpdateManager<T>>
+      discrete_update_manager_;
+
+  // (Experimental) The vector of physical models owned by MultibodyPlant.
+  std::vector<std::unique_ptr<internal::PhysicalModel<T>>> physical_models_;
 
   hydroelastics::internal::HydroelasticEngine<T> hydroelastics_engine_;
 

--- a/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
+++ b/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "drake/common/drake_assert.h"
+#include "drake/multibody/plant/multibody_plant.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+template <typename T>
+class DiscreteUpdateManager;
+
+/* This class is used to grant access to a selected collection of
+ MultibodyPlant's private methods to DiscreteUpdateManager.
+
+ @tparam_default_scalar */
+template <typename T>
+class MultibodyPlantDiscreteUpdateManagerAttorney {
+ private:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MultibodyPlantDiscreteUpdateManagerAttorney);
+
+  friend class DiscreteUpdateManager<T>;
+
+  static const MultibodyTree<T>& internal_tree(const MultibodyPlant<T>& plant) {
+    return plant.internal_tree();
+  }
+
+  static const contact_solvers::internal::ContactSolverResults<T>&
+  EvalContactSolverResults(const MultibodyPlant<T>& plant,
+                           const systems::Context<T>& context) {
+    return plant.EvalContactSolverResults(context);
+  }
+};
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/multibody_plant_model_attorney.h
+++ b/multibody/plant/multibody_plant_model_attorney.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <set>
+#include <string>
+#include <utility>
+
+#include "drake/common/drake_assert.h"
+#include "drake/multibody/plant/multibody_plant.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+template <typename T>
+class PhysicalModel;
+
+/* This class is used to grant access to a selected collection of
+ MultibodyPlant's private methods to PhysicalModel.
+
+ @tparam_default_scalar */
+template <typename T>
+class MultibodyPlantModelAttorney {
+ private:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MultibodyPlantModelAttorney);
+
+  friend class PhysicalModel<T>;
+
+  static systems::DiscreteStateIndex DeclareDiscreteState(
+      MultibodyPlant<T>* plant, const VectorX<T>& model_value) {
+    DRAKE_DEMAND(plant != nullptr);
+    return plant->DeclareDiscreteState(model_value);
+  }
+
+  static systems::LeafOutputPort<T>& DeclareAbstractOutputPort(
+      MultibodyPlant<T>* plant, std::string name,
+      typename systems::LeafOutputPort<T>::AllocCallback alloc_function,
+      typename systems::LeafOutputPort<T>::CalcCallback calc_function,
+      std::set<systems::DependencyTicket> prerequisites_of_calc = {
+          systems::System<T>::all_sources_ticket()}) {
+    DRAKE_DEMAND(plant != nullptr);
+    return plant->DeclareAbstractOutputPort(
+        std::move(name), std::move(alloc_function), std::move(calc_function),
+        std::move(prerequisites_of_calc));
+  }
+
+  static systems::LeafOutputPort<T>& DeclareVectorOutputPort(
+      MultibodyPlant<T>* plant, std::string name,
+      const systems::BasicVector<T>& model_vector,
+      typename systems::LeafOutputPort<T>::CalcVectorCallback
+          vector_calc_function,
+      std::set<systems::DependencyTicket> prerequisites_of_calc = {
+          systems::System<T>::all_sources_ticket()}) {
+    DRAKE_DEMAND(plant != nullptr);
+    return plant->DeclareVectorOutputPort(std::move(name), model_vector,
+                                          std::move(vector_calc_function),
+                                          std::move(prerequisites_of_calc));
+  }
+};
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/physical_model.cc
+++ b/multibody/plant/physical_model.cc
@@ -1,0 +1,44 @@
+#include "drake/multibody/plant/physical_model.h"
+
+#include <utility>
+
+#include "drake/multibody/plant/multibody_plant_model_attorney.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+template <typename T>
+systems::DiscreteStateIndex PhysicalModel<T>::DeclareDiscreteState(
+    MultibodyPlant<T>* plant, const VectorX<T>& model_value) {
+  return MultibodyPlantModelAttorney<T>::DeclareDiscreteState(plant,
+                                                              model_value);
+}
+
+template <typename T>
+systems::LeafOutputPort<T>& PhysicalModel<T>::DeclareAbstractOutputPort(
+    MultibodyPlant<T>* plant, std::string name,
+    typename systems::LeafOutputPort<T>::AllocCallback alloc_function,
+    typename systems::LeafOutputPort<T>::CalcCallback calc_function,
+    std::set<systems::DependencyTicket> prerequisites_of_calc) {
+  return MultibodyPlantModelAttorney<T>::DeclareAbstractOutputPort(
+      plant, std::move(name), std::move(alloc_function),
+      std::move(calc_function), std::move(prerequisites_of_calc));
+}
+
+template <typename T>
+systems::LeafOutputPort<T>& PhysicalModel<T>::DeclareVectorOutputPort(
+    MultibodyPlant<T>* plant, std::string name,
+    const systems::BasicVector<T>& model_vector,
+    typename systems::LeafOutputPort<T>::CalcVectorCallback
+        vector_calc_function,
+    std::set<systems::DependencyTicket> prerequisites_of_calc) {
+  return MultibodyPlantModelAttorney<T>::DeclareVectorOutputPort(
+      plant, std::move(name), model_vector, std::move(vector_calc_function),
+      std::move(prerequisites_of_calc));
+}
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::internal::PhysicalModel);

--- a/multibody/plant/physical_model.h
+++ b/multibody/plant/physical_model.h
@@ -1,0 +1,105 @@
+#pragma once
+#include <set>
+#include <string>
+
+#include "drake/common/default_scalars.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace multibody {
+template <typename T>
+class MultibodyPlant;
+
+namespace internal {
+
+/* PhysicalModel provides the functionalities to extend the type of
+ physical model of MultibodyPlant. Developers can derive from this
+ PhysicalModel to incorporate additional model elements coupled with the
+ rigid body dynamics. For instance, simulation of deformable objects requires
+ additional state and ports to interact with externals systems such as
+ visualization.
+
+ Similar to the routine of adding multiple model elements in MultibodyPlant,
+ users should add all the model elements they wish to add to a PhysicalModel
+ before the owning MultibodyPlant calls `Finalize()`. When `Finalize()` is
+ invoked, MultibodyPlant will allocate the system level context resources for
+ each PhysicalModel it owns. After the system resources are allocated, model
+ mutation in the PhysicalModels owned by MultibodyPlant is not allowed.
+
+ @tparam_default_scalar */
+template <typename T>
+class PhysicalModel {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PhysicalModel);
+
+  PhysicalModel() = default;
+
+  virtual ~PhysicalModel() = default;
+
+  /* (Internal) MultibodyPlant calls this from within Finalize() to declare
+   additional system resources. This method is only meant to be called by
+   MultibodyPlant. We pass in a MultibodyPlant pointer so that derived
+   PhysicalModels can use specific MultibodyPlant cache tickets.
+   @pre plant != nullptr. */
+  void DeclareSystemResources(MultibodyPlant<T>* plant) {
+    DRAKE_DEMAND(plant != nullptr);
+    DoDeclareSystemResources(plant);
+    system_resources_declared = true;
+  }
+
+ protected:
+  /* Derived class must override this to declare system resources for its
+   specific model. */
+  virtual void DoDeclareSystemResources(MultibodyPlant<T>* plant) = 0;
+
+  /* Helper method for throwing an exception within public methods that should
+   not be called after system resources are declared. The invoking method should
+   pass its name so that the error message can include that detail. */
+  void ThrowIfSystemResourcesDeclared(const char* source_method) const {
+    if (system_resources_declared) {
+      throw std::logic_error(
+          "Calls to '" + std::string(source_method) +
+          "()' after system resources have been declared are not allowed.");
+    }
+  }
+
+  /* Helper method for throwing an exception within public methods that should
+   not be called before system resources are declared. The invoking method
+   should pass its name so that the error message can include that detail. */
+  void ThrowIfSystemResourcesNotDeclared(const char* source_method) const {
+    if (!system_resources_declared) {
+      throw std::logic_error(
+          "Calls to '" + std::string(source_method) +
+          "()' before system resources have been declared are not allowed.");
+    }
+  }
+
+  /* Protected LeafSystem methods exposed through MultibodyPlant. */
+  static systems::DiscreteStateIndex DeclareDiscreteState(
+      MultibodyPlant<T>* plant, const VectorX<T>& model_value);
+
+  static systems::LeafOutputPort<T>& DeclareAbstractOutputPort(
+      MultibodyPlant<T>* plant, std::string name,
+      typename systems::LeafOutputPort<T>::AllocCallback alloc_function,
+      typename systems::LeafOutputPort<T>::CalcCallback calc_function,
+      std::set<systems::DependencyTicket> prerequisites_of_calc = {
+          systems::System<T>::all_sources_ticket()});
+
+  static systems::LeafOutputPort<T>& DeclareVectorOutputPort(
+      MultibodyPlant<T>* plant, std::string name,
+      const systems::BasicVector<T>& model_vector,
+      typename systems::LeafOutputPort<T>::CalcVectorCallback
+          vector_calc_function,
+      std::set<systems::DependencyTicket> prerequisites_of_calc = {
+          systems::System<T>::all_sources_ticket()});
+
+ private:
+  /* Flag to track whether the system resources requested by `this`
+   PhysicalModel have been declared. */
+  bool system_resources_declared{false};
+};
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::internal::PhysicalModel);

--- a/multibody/plant/test/discrete_update_manager_test.cc
+++ b/multibody/plant/test/discrete_update_manager_test.cc
@@ -1,0 +1,180 @@
+#include "drake/multibody/plant/discrete_update_manager.h"
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/plant/test/dummy_model.h"
+#include "drake/systems/analysis/simulator.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+namespace test {
+using contact_solvers::internal::ContactSolverResults;
+using Eigen::VectorXd;
+using systems::BasicVector;
+using systems::Context;
+using systems::DiscreteStateIndex;
+using systems::DiscreteValues;
+using systems::OutputPortIndex;
+// Dummy state data.
+constexpr int kNumRigidDofs = 6;
+constexpr int kNumAdditionalDofs = 9;
+constexpr double kDummyStateValue = 3.15;
+// Dummy contact data.
+constexpr int kNumContacts = 4;
+constexpr double kDummyVNext = 1.0;
+constexpr double kDummyFn = 2.0;
+constexpr double kDummyFt = 3.0;
+constexpr double kDummyVn = 4.0;
+constexpr double kDummyVt = 5.0;
+constexpr double kDummyTau = 6.0;
+constexpr double kDummyVdot = 7.0;
+constexpr double kDt = 0.1;
+
+/* A dummy manager class derived from DiscreteUpdateManager for testing
+ purpose. It implements the interface in DiscreteUpdateManager by filling in
+ dummy data. */
+class DummyDiscreteUpdateManager : public DiscreteUpdateManager<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DummyDiscreteUpdateManager);
+
+  DummyDiscreteUpdateManager() = default;
+
+  ~DummyDiscreteUpdateManager() = default;
+
+  /* Returns the number of times CalcContactSolverResults() is called. */
+  int num_calls_to_calc_contact_solver_results() const {
+    return num_calls_to_calc_contact_solver_results_;
+  }
+
+ private:
+  /* Extracts information about the additional discrete state that
+   DummyModel declares if one exists in the owning MultibodyPlant. */
+  void ExtractModelInfo() final {
+    /* For unit testing we verify there is a single physical model of type
+     DummyModel. */
+    DRAKE_DEMAND(plant().physical_models().size() == 1);
+    const auto* dummy_model =
+        dynamic_cast<const DummyModel*>(plant().physical_models()[0].get());
+    DRAKE_DEMAND(dummy_model != nullptr);
+    additional_state_index_ = dummy_model->discrete_state_index();
+  }
+
+  /* Increments the number of times CalcContactSolverResults() is called for
+   testing. */
+  void DoCalcContactSolverResults(
+      const Context<double>&,
+      ContactSolverResults<double>* results) const final {
+    ++num_calls_to_calc_contact_solver_results_;
+    results->Resize(kNumRigidDofs, kNumContacts);
+    results->v_next = VectorXd::Ones(kNumRigidDofs) * kDummyVNext;
+    results->fn = VectorXd::Ones(kNumContacts) * kDummyFn;
+    results->ft = VectorXd::Ones(2 * kNumContacts) * kDummyFt;
+    results->vn = VectorXd::Ones(kNumContacts) * kDummyVn;
+    results->vt = VectorXd::Ones(2 * kNumContacts) * kDummyVt;
+    results->tau_contact = VectorXd::Ones(kNumRigidDofs) * kDummyTau;
+  }
+
+  // TODO(xuchenhan-tri): Currently AccelerationKinematicsCache only caches
+  // acceleration for rigid dofs. Modify the dummy manager to test for
+  // deformable acclerations when they are supported.
+  /* Assigns dummy values to an AccelerationKinematicsCache. */
+  void DoCalcAccelerationKinematicsCache(
+      const Context<double>& context,
+      internal::AccelerationKinematicsCache<double>* ac) const final {
+    VectorXd& vdot = ac->get_mutable_vdot();
+    vdot = VectorXd::Ones(vdot.size()) * kDummyVdot;
+  }
+
+  /* Increments the discrete rigid dofs by 1 and additional discrete state by 2
+   if there is any. */
+  void DoCalcDiscreteValues(const Context<double>& context,
+                            DiscreteValues<double>* updates) const final {
+    auto multibody_data = updates->get_mutable_vector(multibody_state_index())
+                              .get_mutable_value();
+    multibody_data += VectorXd::Ones(multibody_data.size());
+    if (additional_state_index_.is_valid()) {
+      auto additional_data =
+          updates->get_mutable_vector(additional_state_index_)
+              .get_mutable_value();
+      additional_data += 2.0 * VectorXd::Ones(additional_data.size());
+    }
+  }
+
+ private:
+  systems::DiscreteStateIndex additional_state_index_;
+  mutable int num_calls_to_calc_contact_solver_results_{0};
+};
+
+namespace {
+class DiscreteUpdateManagerTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    plant_.AddRigidBody("rigid body", SpatialInertia<double>());
+    dummy_model_ = &plant_.AddPhysicalModel(std::make_unique<DummyModel>());
+    dummy_model_->AppendDiscreteState(dummy_discrete_state());
+    plant_.Finalize();
+    // MultibodyPlant::num_velocities() only reports the number of rigid
+    // generalized velocities for the rigid model.
+    EXPECT_EQ(plant_.num_velocities(), kNumRigidDofs);
+    discrete_update_manager_ = &plant_.set_discrete_update_manager(
+        std::make_unique<DummyDiscreteUpdateManager>());
+  }
+
+  static VectorXd dummy_discrete_state() {
+    return VectorXd::Ones(kNumAdditionalDofs) * kDummyStateValue;
+  }
+
+  // A discrete MultibodyPlant.
+  MultibodyPlant<double> plant_{kDt};
+  // A PhysicalModel to illustrate how physical models and discrete update
+  // managers interact.
+  DummyModel* dummy_model_{nullptr};
+  // The discrete update manager under test.
+  DummyDiscreteUpdateManager* discrete_update_manager_{nullptr};
+};
+
+/* Tests that the CalcDiscrete() method is correctly wired to MultibodyPlant. */
+TEST_F(DiscreteUpdateManagerTest, CalcDiscreteState) {
+  auto context = plant_.CreateDefaultContext();
+  auto simulator = systems::Simulator<double>(plant_, std::move(context));
+  const int time_steps = 2;
+  simulator.AdvanceTo(time_steps * kDt);
+  const VectorXd final_additional_state =
+      dummy_model_->get_vector_output_port().Eval(simulator.get_context());
+  EXPECT_EQ(final_additional_state.size(), kNumAdditionalDofs);
+  EXPECT_TRUE(
+      CompareMatrices(final_additional_state,
+                      dummy_discrete_state() +
+                          2.0 * VectorXd::Ones(kNumAdditionalDofs) * time_steps,
+                      std::numeric_limits<double>::epsilon()));
+}
+
+/* Tests that the CalcContactSolverResults() method is correctly wired to
+ MultibodyPlant. */
+TEST_F(DiscreteUpdateManagerTest, CalcContactSolverResults) {
+  auto context = plant_.CreateDefaultContext();
+  context->DisableCaching();
+  // Evaluates an output port whose Calc function invokes
+  // CalcContactSolverResults().
+  const auto& port = plant_.get_generalized_contact_forces_output_port(
+      default_model_instance());
+  port.Eval(*context);
+  EXPECT_EQ(
+      discrete_update_manager_->num_calls_to_calc_contact_solver_results(), 1);
+}
+
+/* Tests that the CalcAccelerationKinematicsCache() method is correctly wired
+ to MultibodyPlant. */
+TEST_F(DiscreteUpdateManagerTest, CalcAccelerationKinematicsCache) {
+  auto context = plant_.CreateDefaultContext();
+  const auto generalized_acceleration =
+      plant_.get_generalized_acceleration_output_port().Eval(*context);
+  EXPECT_TRUE(CompareMatrices(generalized_acceleration,
+                              VectorXd::Ones(kNumRigidDofs) * kDummyVdot));
+}
+}  // namespace
+}  // namespace test
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/test/dummy_model.h
+++ b/multibody/plant/test/dummy_model.h
@@ -1,0 +1,96 @@
+#pragma once
+#include <vector>
+
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/plant/physical_model.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+namespace test {
+using Eigen::VectorXd;
+using systems::BasicVector;
+using systems::Context;
+using systems::DiscreteStateIndex;
+using systems::OutputPortIndex;
+/* A dummy manager class derived from PhysicalModel for testing
+ purpose. This dummy manager declares a single group of discrete state that
+ concatenates the state added through `AppendDiscreteState()`. It also declares
+ a vector output port that reports this additional state and an abstract output
+ port that reports the the same state. */
+class DummyModel : public PhysicalModel<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DummyModel);
+
+  DummyModel() = default;
+
+  ~DummyModel() = default;
+
+  /* Appends additional entries to the single group of discrete state with the
+   given `model_value`. */
+  void AppendDiscreteState(const VectorXd& model_value) {
+    ThrowIfSystemResourcesDeclared(__func__);
+    num_dofs_ += model_value.size();
+    discrete_states_.emplace_back(model_value);
+  }
+
+  const systems::OutputPort<double>& get_abstract_output_port() const {
+    this->ThrowIfSystemResourcesNotDeclared(__func__);
+    return *abstract_output_port_;
+  }
+
+  const systems::OutputPort<double>& get_vector_output_port() const {
+    this->ThrowIfSystemResourcesNotDeclared(__func__);
+    return *vector_output_port_;
+  }
+
+  systems::DiscreteStateIndex discrete_state_index() const {
+    this->ThrowIfSystemResourcesNotDeclared(__func__);
+    return discrete_state_index_;
+  }
+
+ private:
+  /* Declares a single group of discrete state by concatenating all the state
+   added so far. It also declares two output ports that reports the value of the
+   dummy discrete state: one abstract output port with underlying value type
+   VectorXd and one plain-old vector port. We can verify the two ports report
+   the same results as a sanity check. */
+  void DoDeclareSystemResources(MultibodyPlant<double>* plant) final {
+    /* Declares the single group of discrete state. */
+    VectorXd model_state(num_dofs_);
+    int dof_offset = 0;
+    for (size_t i = 0; i < discrete_states_.size(); ++i) {
+      const VectorXd& s = discrete_states_[i];
+      model_state.segment(dof_offset, s.size()) = s;
+      dof_offset += s.size();
+    }
+    discrete_state_index_ = this->DeclareDiscreteState(plant, model_state);
+
+    /* Declare output ports. */
+    abstract_output_port_ = &this->DeclareAbstractOutputPort(
+        plant, "dummy_abstract_output_port",
+        [=]() { return AbstractValue::Make(model_state); },
+        [this](const Context<double>& context, AbstractValue* output) {
+          VectorXd& data = output->get_mutable_value<VectorXd>();
+          data = context.get_discrete_state(discrete_state_index_).get_value();
+        },
+        {systems::System<double>::xd_ticket()});
+    vector_output_port_ = &this->DeclareVectorOutputPort(
+        plant, "dummy_vector_output_port", BasicVector<double>(num_dofs_),
+        [this](const Context<double>& context, BasicVector<double>* output) {
+          auto data = output->get_mutable_value();
+          data = context.get_discrete_state(discrete_state_index_).get_value();
+        },
+        {systems::System<double>::xd_ticket()});
+  }
+
+  std::vector<VectorXd> discrete_states_{};
+  int num_dofs_{0};
+  const systems::OutputPort<double>* abstract_output_port_{nullptr};
+  const systems::OutputPort<double>* vector_output_port_{nullptr};
+  DiscreteStateIndex discrete_state_index_;
+};
+}  // namespace test
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/test/physical_model_test.cc
+++ b/multibody/plant/test/physical_model_test.cc
@@ -1,0 +1,69 @@
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/plant/test/dummy_model.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+namespace test {
+namespace {
+using Eigen::VectorXd;
+constexpr int kState1Dofs = 2;
+constexpr int kState2Dofs = 3;
+constexpr double kState1Value = 3.14;
+constexpr double kState2Value = 3.15;
+constexpr double kDt = 0.1;
+
+class PhysicalModelTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // TODO(xuchenhan-tri): Add a test with more than one physical model.
+    dummy_model_ = &plant_.AddPhysicalModel(std::make_unique<DummyModel>());
+    // An artificial scenario where the state is added in multiple passes.
+    dummy_model_->AppendDiscreteState(dummy_state1());
+    dummy_model_->AppendDiscreteState(dummy_state2());
+    plant_.Finalize();
+  }
+
+  static VectorXd dummy_state1() {
+    return VectorXd::Ones(kState1Dofs) * kState1Value;
+  }
+
+  static VectorXd dummy_state2() {
+    return VectorXd::Ones(kState2Dofs) * kState2Value;
+  }
+
+  MultibodyPlant<double> plant_{kDt};    // A discrete MbP.
+  DummyModel* dummy_model_{nullptr};  // The PhysicalModel under test.
+};
+
+// Tests that the state and output ports are properly set up.
+TEST_F(PhysicalModelTest, DiscreteStateAndOutputPorts) {
+  auto context = plant_.CreateDefaultContext();
+  const VectorXd additional_state =
+      dummy_model_->get_vector_output_port().Eval(*context);
+  EXPECT_EQ(additional_state.size(), kState1Dofs + kState2Dofs);
+  VectorXd expected_state(kState1Dofs + kState2Dofs);
+  expected_state.head(kState1Dofs) = dummy_state1();
+  expected_state.tail(kState2Dofs) = dummy_state2();
+  EXPECT_TRUE(CompareMatrices(additional_state, expected_state));
+
+  // Verifies that the vector and abstract output reports the same state.
+  const VectorXd state_through_abstract_port =
+      dummy_model_->get_abstract_output_port().Eval<VectorXd>(*context);
+  EXPECT_TRUE(CompareMatrices(additional_state, state_through_abstract_port));
+}
+
+// Tests that adding new state after Finalize is not allowed.
+TEST_F(PhysicalModelTest, PostFinalizeStateAdditionNotAllowed) {
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dummy_model_->AppendDiscreteState(dummy_state1()), std::exception,
+      "Calls to 'AppendDiscreteState\\(\\)' after system resources have been "
+      "declared are not allowed.");
+}
+}  // namespace
+}  // namespace test
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/tree/multibody_tree-inl.h
+++ b/multibody/tree/multibody_tree-inl.h
@@ -579,9 +579,10 @@ Eigen::VectorBlock<const VectorX<T>>
 MultibodyTree<T>::get_discrete_state_vector(
     const systems::Context<T>& context) const {
   DRAKE_ASSERT(is_state_discrete());
-  DRAKE_ASSERT(context.num_discrete_state_groups() == 1);
+  DRAKE_ASSERT(discrete_state_index_.is_valid());
+  // Only q and v.
   const systems::BasicVector<T>& discrete_state_vector =
-      context.get_discrete_state(0);  // Only q and v.
+      context.get_discrete_state(discrete_state_index_);
   DRAKE_ASSERT(discrete_state_vector.size() ==
                num_positions() + num_velocities());
   return discrete_state_vector.get_value();
@@ -593,9 +594,10 @@ MultibodyTree<T>::get_mutable_discrete_state_vector(
     systems::Context<T>* context) const {
   DRAKE_ASSERT(context != nullptr);
   DRAKE_ASSERT(is_state_discrete());
-  DRAKE_ASSERT(context->num_discrete_state_groups() == 1);
+  DRAKE_ASSERT(discrete_state_index_.is_valid());
+  // Only q and v.
   systems::BasicVector<T>& discrete_state_vector =
-      context->get_mutable_discrete_state(0);  // Only q and v.
+      context->get_mutable_discrete_state(discrete_state_index_);
   DRAKE_ASSERT(discrete_state_vector.size() ==
                num_positions() + num_velocities());
   return discrete_state_vector.get_mutable_value();
@@ -607,9 +609,10 @@ MultibodyTree<T>::get_mutable_discrete_state_vector(
     systems::State<T>* state) const {
   DRAKE_ASSERT(state != nullptr);
   DRAKE_ASSERT(is_state_discrete());
-  DRAKE_ASSERT(state->get_discrete_state().num_groups() == 1);
+  DRAKE_ASSERT(discrete_state_index_.is_valid());
+  // Only q and v.
   systems::BasicVector<T>& discrete_state_vector =
-      state->get_mutable_discrete_state(0);  // Only q and v.
+      state->get_mutable_discrete_state(discrete_state_index_);
   DRAKE_ASSERT(discrete_state_vector.size() ==
       num_positions() + num_velocities());
   return discrete_state_vector.get_mutable_value();

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -2369,6 +2369,7 @@ class MultibodyTree {
     tree_clone->instance_name_to_index_ = this->instance_name_to_index_;
     tree_clone->instance_index_to_name_ = this->instance_index_to_name_;
     tree_clone->joint_to_mobilizer_ = this->joint_to_mobilizer_;
+    tree_clone->discrete_state_index_ = this->discrete_state_index_;
 
     // All other internals templated on T are created with the following call to
     // FinalizeInternals().
@@ -2559,6 +2560,22 @@ class MultibodyTree {
       const systems::Context<T>& context,
       const PositionKinematicsCache<T>& pc,
       std::vector<Vector6<T>>* H_PB_W_cache) const;
+
+  // (Internal use only) Sets the discrete state index for the multibody
+  // state.
+  void set_discrete_state_index(systems::DiscreteStateIndex index) {
+    DRAKE_DEMAND(is_state_discrete());
+    discrete_state_index_ = index;
+  }
+
+  // (Internal use only) Returns the discrete state index for the multibody
+  // state.
+  systems::DiscreteStateIndex get_discrete_state_index() const {
+    DRAKE_DEMAND(tree_system_ != nullptr);
+    DRAKE_DEMAND(is_state_discrete());
+    DRAKE_DEMAND(topology_is_valid());
+    return discrete_state_index_;
+  }
 
  private:
   // Make MultibodyTree templated on every other scalar type a friend of
@@ -3083,6 +3100,9 @@ class MultibodyTree {
   MultibodyTreeTopology topology_;
 
   const MultibodyTreeSystem<T>* tree_system_{};
+
+  // The discrete state index for the multibody state if the system is discrete.
+  systems::DiscreteStateIndex discrete_state_index_;
 };
 
 }  // namespace internal

--- a/multibody/tree/multibody_tree_system.cc
+++ b/multibody/tree/multibody_tree_system.cc
@@ -138,7 +138,8 @@ void MultibodyTreeSystem<T>::Finalize() {
 
   // Declare state.
   if (is_discrete_) {
-    this->DeclareDiscreteState(tree_->num_states());
+    tree_->set_discrete_state_index(
+        this->DeclareDiscreteState(tree_->num_states()));
   } else {
     this->DeclareContinuousState(BasicVector<T>(tree_->num_states()),
                                  tree_->num_positions(),

--- a/multibody/tree/multibody_tree_system.h
+++ b/multibody/tree/multibody_tree_system.h
@@ -233,6 +233,22 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
     return this->get_cache_entry(cache_indexes_.acceleration_kinematics);
   }
 
+  /* Returns the DiscreteStateIndex for the one and only multibody discrete
+  state if the system is discrete and finalized. Throws otherwise. */
+  systems::DiscreteStateIndex GetDiscreteStateIndexOrThrow() const {
+    if (!is_discrete_) {
+      throw std::runtime_error(
+          "The MultibodyTreeSystem is modeled as a continuous system and there "
+          "does not exist any discrete state.");
+    }
+    if (!already_finalized_) {
+      throw std::logic_error(
+          "GetDiscreteStateIndexOrThrow() can only be "
+          "called post-Finalize().");
+    }
+    return tree_->get_discrete_state_index();
+  }
+
  protected:
   /* @name        Alternate API for derived classes
   Derived classes may use these methods to create a MultibodyTreeSystem


### PR DESCRIPTION
Add a DiscreteUpdateManager class that advances the discrete states for MultibodyPlant. DiscreteUpdateManager provides an interface that extends MbP and that MbP knows how to invoke. It allows more flexibility in experimenting with new solvers and can be compiled independently from MbP.

Add a PhysicalModel class that extends the physical models owned by MultibodyPlant. It allows more flexibility in experimenting new materials and models that may be simulated.

To enable DiscreteUpdateManager and PhysicalModel, introduce attorney classes MultibodyPlantModelAttorney and MultibodyPlantDiscreteUpdateManagerAttorney that grant the necessary protected/private methods in MultibodyPlant that PhysicalModel and DiscreteUpdateManager needs.

Co-authored-by: amcastro-tri <alejandro.castro@tri.global>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15033)
<!-- Reviewable:end -->
