### PR TITLE
[geometry] Utility to add one representative triangle for each contact polygon. 

### DIFF
--- a/geometry/proximity/contact_surface_utility.cc
+++ b/geometry/proximity/contact_surface_utility.cc
@@ -266,6 +266,71 @@ void AddPolygonToMeshData(
 }
 
 template <typename T>
+void AddPolygonToMeshDataAsOneTriangle(
+    const std::vector<Vector3<T>>& polygon_F, const Vector3<T>& nhat_F,
+    std::vector<SurfaceFace>* faces,
+    std::vector<SurfaceVertex<T>>* vertices_F) {
+  DRAKE_DEMAND(faces != nullptr);
+  DRAKE_DEMAND(vertices_F != nullptr);
+  DRAKE_DEMAND(polygon_F.size() >= 3);
+  const T polygon_area = CalcPolygonArea(polygon_F, nhat_F);
+  if (polygon_area < kMinimumPolygonArea) {
+    return;
+  }
+
+  // Locations of vertices of the representative triangle.
+  Vector3<T> p_FVs[3];
+  if (polygon_F.size() == 3) {
+    p_FVs[0] = polygon_F[0];
+    p_FVs[1] = polygon_F[1];
+    p_FVs[2] = polygon_F[2];
+  } else {
+    Vector3<T> p_FC = CalcPolygonCentroid(polygon_F, nhat_F);
+
+    // We will set the representative triangle as an isosceles right triangle
+    // in a local frame G such that its third basis vector Gz_F, expressed in
+    // frame F, is the same as the face normal vector nhat_F. The triangle
+    // has centroid C (coincident with the polygon's centroid) at Go, and its
+    // two edges V₀V₁ and V₀V₂ are parallel to Gx and Gy respectively, as shown
+    // in the following picture (Gz points outward from the screen).
+    //
+    //               Gy
+    //               ^
+    //               |
+    //        V₂ ●   |
+    //           x x |
+    //           x   x
+    //        l  x   | x
+    //           x C ○---x--------> Gx
+    //           x         x
+    //       V₀  ● x x x x x ●
+    //                 l     V₁
+    //
+    // The two edges of the triangle in Gx and Gy directions have the same
+    // length l such that the triangle has the same area as the polygon:
+    //      l²/2 = polygon_area
+    //      l    = √(2 * polygon_area)
+    // N.B. We should have positive polygon_area, so the scalar type AutoDiffXd
+    // would be fine with sqrt().
+    const T l = sqrt(2. * polygon_area);
+    // Pass axis_index = 2, so that Gz_F = R_FG.col(2) = nhat_F.
+    const auto R_FG = math::RotationMatrix<T>::MakeFromOneUnitVector(nhat_F, 2);
+    const Vector3<T> Gx_F = R_FG.col(0);
+    const Vector3<T> Gy_F = R_FG.col(1);
+    p_FVs[0] = p_FC + (l / 3) * (   -Gx_F      - Gy_F);  // V₀ #NOLINT
+    p_FVs[1] = p_FC + (l / 3) * (2 * Gx_F      - Gy_F);  // V₁ #NOLINT
+    p_FVs[2] = p_FC + (l / 3) * (   -Gx_F + 2. * Gy_F);  // V₂ #NOLINT
+  }
+
+  const int n = vertices_F->size();
+  const int v[3] = {n, n + 1, n + 2};
+  faces->emplace_back(v);
+  vertices_F->emplace_back(p_FVs[0]);
+  vertices_F->emplace_back(p_FVs[1]);
+  vertices_F->emplace_back(p_FVs[2]);
+}
+
+template <typename T>
 bool IsFaceNormalInNormalDirection(const Vector3<T>& normal_F,
                                    const SurfaceMesh<T>& surface_M,
                                    SurfaceFaceIndex tri_index,
@@ -321,6 +386,14 @@ template void AddPolygonToMeshData(
     const Vector3<AutoDiffXd>& n_F,
     std::vector<SurfaceFace>* faces,
     std::vector<SurfaceVertex<AutoDiffXd>>* vertices_F);
+
+template void AddPolygonToMeshDataAsOneTriangle(
+    const std::vector<Vector3<double>>&, const Vector3<double>&,
+    std::vector<SurfaceFace>*, std::vector<SurfaceVertex<double>>*);
+
+template void AddPolygonToMeshDataAsOneTriangle(
+    const std::vector<Vector3<AutoDiffXd>>&, const Vector3<AutoDiffXd>&,
+    std::vector<SurfaceFace>*, std::vector<SurfaceVertex<AutoDiffXd>>*);
 
 template bool IsFaceNormalInNormalDirection(
     const Vector3<double>& normal_F, const SurfaceMesh<double>& surface_M,

--- a/geometry/proximity/contact_surface_utility.h
+++ b/geometry/proximity/contact_surface_utility.h
@@ -116,6 +116,58 @@ void AddPolygonToMeshData(
     std::vector<SurfaceFace>* faces,
     std::vector<SurfaceVertex<T>>* vertices_F);
 
+// Any polygon with area less than this threshold is considered having
+// near-zero area in AddPolygonToMeshDataAsOneTriangle() below.
+constexpr double kMinimumPolygonArea = 1e-13;
+
+// TODO(14579) The following AddPolygonToMeshDataAsOneTriangle() is expected to
+//  simply go away when we implement the final support for discrete
+//  hydroelastics. If it persists (for whatever reason), find a better way to
+//  deal with a polygon with zero or near-zero area. Perhaps we should
+//  allow users to specify criteria to classify such polygons instead of
+//  relying on the threshold kMinimumPolygonArea above.
+
+/* Adds a representative triangle of a convex polygon to the given set of
+ `faces` and `vertices`. The triangle has the same centroid, area, and normal
+ vector as the polygon. The three vertices of the representative triangle are
+ introduced into `vertices`.
+
+ The exact choice of the representative triangle is arbitrary subject to the
+ constraints in the previous paragraph.
+
+ In debug builds, this function will do _expensive_ validation of its
+ parameters.
+
+ @param[in] polygon_F
+     The input polygon is represented by position vectors of its vertices,
+     measured and expressed in frame F. This polygon is _not_ in `faces` or
+     `vertices`.
+ @param[in] nhat_F
+     The unit normal vector to the polygon, expressed in frame F.
+ @param[out] faces
+     The new triangle is added into `faces` with the same orientation (same
+     normal vector) as the input polygon.
+ @param[out] vertices_F
+     The set of vertex positions to be extended; each vertex is measured and
+     expressed in frame F. Three vertices will be added.
+
+ @pre `faces` and `vertices_F` are not `nullptr`.
+ @pre The polygon is simple (does not intersect itself and has no holes).
+ @pre The winding of `polygon_F` is consistent with the direction of `nhat_F`.
+      They must respect the right-hand rule.
+
+ @note There are two reasons for skipping a polygon with zero or near-zero area.
+       1. Such a polygon contributes negligibly to contact force and moment.
+       2. For the scalar type AutoDiffXd, such a polygon may cause unstable
+          calculation of derivatives of the representative triangle.
+
+ @tparam T  The computational scalar type. Only supports double and AutoDiffXd.
+ */
+template <typename T>
+void AddPolygonToMeshDataAsOneTriangle(
+    const std::vector<Vector3<T>>& polygon_F, const Vector3<T>& nhat_F,
+    std::vector<SurfaceFace>* faces, std::vector<SurfaceVertex<T>>* vertices_F);
+
 /* Determines if the indicated triangle has a face normal that is "in the
  direction" of the given normal.
 


### PR DESCRIPTION
This PR is a building block towards a solution for issue #14579.

It will be used for speeding up discrete hydroelastic contact model.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15035)
<!-- Reviewable:end -->
