### PR TITLE
primitives: Establish AffineSystem feedthrough without symbolics

### DIFF
--- a/systems/primitives/affine_system.cc
+++ b/systems/primitives/affine_system.cc
@@ -1,5 +1,6 @@
 #include "drake/systems/primitives/affine_system.h"
 
+#include <set>
 #include <utility>
 
 #include <Eigen/Eigenvalues>
@@ -48,10 +49,10 @@ TimeVaryingAffineSystem<T>::TimeVaryingAffineSystem(
   if (num_inputs_ > 0)
     this->DeclareInputPort(kVectorValued, num_inputs_);
   if (num_outputs_ > 0) {
-    // TODO(sherm1, eric.cousineau): For subclasses that override CalcOutputY,
-    // ideally we would offer a mechanism for them to alter the prerequisites
-    // argument to DeclareOutputPort to match their implementation, either
-    // specific to this class, or generally via #12709.
+    // N.B. Subclasses that override CalcOutputY may want to fine-tune the
+    // output port's prerequisites; see AffineSystem's ctor for an example.
+    // By default, the output port will depend on everything (time, input,
+    // state, accuracy, etc.).
     this->DeclareVectorOutputPort(BasicVector<T>(num_outputs_),
                                   &TimeVaryingAffineSystem::CalcOutputY);
   }
@@ -226,8 +227,8 @@ AffineSystem<T>::AffineSystem(const Eigen::Ref<const Eigen::MatrixXd>& A,
 namespace {
 
 // Returns whether a matrix is "meaningful" when pre-multiplying a vector.
-bool IsMeaningful(const Eigen::MatrixXd& D) {
-  return D.size() > 0 && (D.array() != 0).any();
+bool IsMeaningful(const Eigen::MatrixXd& m) {
+  return m.size() > 0 && (m.array() != 0).any();
 }
 
 }  // namespace
@@ -251,8 +252,7 @@ AffineSystem<T>::AffineSystem(SystemScalarConverter converter,
       C_(C),
       D_(D),
       y0_(y0),
-      // This check permits a workaround for inadvertent computational loops
-      // (#12706).
+      has_meaningful_C_(IsMeaningful(C)),
       has_meaningful_D_(IsMeaningful(D)) {
   DRAKE_DEMAND(this->num_states() == A.rows());
   DRAKE_DEMAND(this->num_states() == A.cols());
@@ -262,6 +262,24 @@ AffineSystem<T>::AffineSystem(SystemScalarConverter converter,
   DRAKE_DEMAND(this->num_inputs() == D.cols());
   DRAKE_DEMAND(this->num_outputs() == C.rows());
   DRAKE_DEMAND(this->num_outputs() == D.rows());
+
+  // Specify our output port's dependencies more precisely than our base class
+  // is able to.  We know that output never depends on time nor parameters,
+  // only on state (iff C if non-zero) and input (iff D is non-zero).
+  if (this->num_outputs() > 0) {
+    const OutputPort<T>& output_port = this->get_output_port();
+    const auto& leaf_port = dynamic_cast<const LeafOutputPort<T>&>(output_port);
+    const CacheIndex cache_index = leaf_port.cache_entry().cache_index();
+    CacheEntry& cache_entry = this->get_mutable_cache_entry(cache_index);
+    std::set<DependencyTicket>& prereqs = cache_entry.mutable_prerequisites();
+    prereqs.clear();
+    if (has_meaningful_C_) {
+      prereqs.insert(this->all_state_ticket());
+    }
+    if (has_meaningful_D_) {
+      prereqs.insert(this->all_input_ports_ticket());
+    }
+  }
 }
 
 // Our copy constructor delegates to the public constructor; this used only by
@@ -315,7 +333,7 @@ void AffineSystem<T>::CalcOutputY(const Context<T>& context,
   auto y = output_vector->get_mutable_value();
   y = y0_;
 
-  if (this->num_states() > 0) {
+  if (has_meaningful_C_) {
     const VectorX<T>& x = (this->time_period() == 0.)
         ? dynamic_cast<const BasicVector<T>&>(
             context.get_continuous_state_vector()).get_value()
@@ -323,7 +341,7 @@ void AffineSystem<T>::CalcOutputY(const Context<T>& context,
     y += C_ * x;
   }
 
-  if (has_meaningful_D_ && this->num_inputs()) {
+  if (has_meaningful_D_) {
     const auto& u = this->get_input_port().Eval(context);
     y += D_ * u;
   }

--- a/systems/primitives/affine_system.h
+++ b/systems/primitives/affine_system.h
@@ -285,6 +285,7 @@ class AffineSystem : public TimeVaryingAffineSystem<T> {
   const Eigen::MatrixXd C_;
   const Eigen::MatrixXd D_;
   const Eigen::VectorXd y0_;
+  const bool has_meaningful_C_{};
   const bool has_meaningful_D_{};
 };
 


### PR DESCRIPTION
The output port of AffineSystem now responds to feedthrough queries without first scalar-converting itself to symbolic expressions.

This same change applies to LinearSystem, which inherits from AffineSystem.

This is likely to be more performant, and also ensures operation even for subclasses of affine or linear systems that choose not to support symbolic scalar conversion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15037)
<!-- Reviewable:end -->
