### PR TITLE
[geometry] Wire up hydroelastic derivatives all the way through QueryObject

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -693,6 +693,7 @@ drake_cc_googletest(
     deps = [
         ":hydroelastic_callback",
         "//common/test_utilities",
+        "//math:autodiff",
     ],
 )
 

--- a/geometry/proximity/hydroelastic_callback.h
+++ b/geometry/proximity/hydroelastic_callback.h
@@ -85,7 +85,6 @@ enum class CalcContactSurfaceResult {
                         //< pair.
   kHalfSpaceHalfSpace,  //< Contact between two half spaces; not allowed.
   kSameCompliance,      //< The two geometries have the same compliance type.
-  kUnsupportedScalar,   //< The computation scalar type is unsupported.
 };
 
 /* Computes ContactSurface using the algorithm appropriate to the Shape types
@@ -158,12 +157,6 @@ CalcContactSurfaceResult MaybeCalcContactSurface(
   }
   if (type_A == type_B) {
     return CalcContactSurfaceResult::kSameCompliance;
-  }
-
-  // If we have *generally* bad configured hydroelastics, we want that to be
-  // reported over a "bad" scalar type.
-  if constexpr (!std::is_same<T, double>::value) {
-    return CalcContactSurfaceResult::kUnsupportedScalar;
   }
 
   bool A_is_rigid = type_A == HydroelasticType::kRigid;
@@ -243,12 +236,6 @@ bool Callback(fcl::CollisionObjectd* object_A_ptr,
         throw std::logic_error(fmt::format(
             "Requested contact between two half spaces with ids {} and {}; "
             "that is not allowed", encoding_a.id(), encoding_b.id()));
-      case CalcContactSurfaceResult::kUnsupportedScalar:
-        throw std::logic_error(fmt::format(
-            "Requested AutoDiff-valued contact surface between two geometries "
-            "with hydroelastic representation but for scalar type {}; not "
-            "currently supported.",
-            NiceTypeName::Get<T>()));
       case CalcContactSurfaceResult::kCalculated:
         // Already handled above.
         break;
@@ -299,13 +286,6 @@ bool CallbackWithFallback(fcl::CollisionObjectd* object_A_ptr,
 
     // Surface calculated; we're done.
     if (result == CalcContactSurfaceResult::kCalculated) return false;
-    if (result == CalcContactSurfaceResult::kUnsupportedScalar) {
-      throw std::logic_error(fmt::format(
-          "Requested AutoDiff-valued contact surface between two geometries "
-          "with hydroelastic representation but for scalar type {}; not "
-          "currently supported.",
-          NiceTypeName::Get<T>()));
-    }
 
     // Fall back to point pair.
     penetration_as_point_pair::CallbackData<T> point_data{

--- a/geometry/proximity/hydroelastic_internal.cc
+++ b/geometry/proximity/hydroelastic_internal.cc
@@ -105,8 +105,8 @@ void Geometries::MakeShape(const ShapeType& shape, const ReifyData& data) {
       auto hydro_geometry = MakeSoftRepresentation(shape, data.properties);
       if (hydro_geometry) AddGeometry(data.id, move(*hydro_geometry));
     } break;
-    default:
-      // kUndefined requires no action.
+    case HydroelasticType::kUndefined:
+      // No action required.
       break;
   }
 }

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -387,6 +387,9 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     BuildTreeFromReference(dynamic_tree_, object_map, &engine->dynamic_tree_);
     BuildTreeFromReference(anchored_tree_, object_map, &engine->anchored_tree_);
 
+    engine->hydroelastic_geometries_ = this->hydroelastic_geometries_;
+    engine->distance_tolerance_ = this->distance_tolerance_;
+
     return engine;
   }
 


### PR DESCRIPTION
 - Callback
   - Eliminate the "unsupported" scalar code
   - Correct bug in which a switch on enum had a default case.
   - Unit test adds `AutoDiffXd` scalar to tests and tests for *presence* of appropriately sized derivatives (indicating derivative propagation).
 - `ProximityEngine`
   - Correct error that hydroelastic geometry was omitted in `ToAutoDiff()`
   - Extend test to check for appropriately sized derivatives where expected. Previously, it expected an exception to be thrown.
 - `QueryObject`
   - Update documentation vis a vis scalar support

relates #10907, #14136

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15040)
<!-- Reviewable:end -->
