### PR TITLE
multibody_tree: Fix missing space for GetModelInstanceByName error

### DIFF
--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1053,8 +1053,8 @@ class MultibodyTree {
       std::string_view name) const {
     const auto it = instance_name_to_index_.find(name);
     if (it == instance_name_to_index_.end()) {
-      throw std::logic_error(fmt::format("There is no model instance named '{}'"
-          "in the model.", name));
+      throw std::logic_error(fmt::format(
+          "There is no model instance named '{}' in the model.", name));
     }
     return it->second;
   }


### PR DESCRIPTION
In Anzu, was debugging some code. I had a model `right::panda`, but code was referencing `panda`; I added `GetModelInstanceByName`, and noticed that space was missing :shrug: 

Before:
```
terminate called after throwing an instance of 'std::logic_error'
  what():  There is no model instance named 'panda'in the model.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15042)
<!-- Reviewable:end -->
