### PR TITLE
Remove deprecated code 2021-04-21

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -285,22 +285,6 @@ void DoScalarDependentDefinitions(py::module m, T) {
     // TODO(eric.cousineau): Include `CalcInverseDynamics` once there is an
     // overload that (a) services MBP directly and (b) uses body
     // association that is less awkward than implicit BodyNodeIndex.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    cls  // BR
-        .def("CalcCenterOfMassPosition",
-            WrapDeprecated(cls_doc.CalcCenterOfMassPosition.doc_deprecated,
-                overload_cast_explicit<Vector3<T>, const Context<T>&>(
-                    &Class::CalcCenterOfMassPosition)),
-            py::arg("context"), cls_doc.CalcCenterOfMassPosition.doc_deprecated)
-        .def("CalcCenterOfMassPosition",
-            WrapDeprecated(cls_doc.CalcCenterOfMassPosition.doc_deprecated,
-                overload_cast_explicit<Vector3<T>, const Context<T>&,
-                    const std::vector<ModelInstanceIndex>&>(
-                    &Class::CalcCenterOfMassPosition)),
-            py::arg("context"), py::arg("model_instances"),
-            cls_doc.CalcCenterOfMassPosition.doc_deprecated);
-#pragma GCC diagnostic pop
     cls  // BR
         .def("CalcTotalMass",
             overload_cast_explicit<T, const Context<T>&>(&Class::CalcTotalMass),

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -795,13 +795,6 @@ class TestPlant(unittest.TestCase):
             context=context, model_instances=[instance])
         self.assertTupleEqual(p_com.shape, (3, ))
 
-        with catch_drake_warnings(expected_count=2):
-            p_com = plant.CalcCenterOfMassPosition(context=context)
-            self.assertTupleEqual(p_com.shape, (3, ))
-            p_com = plant.CalcCenterOfMassPosition(
-                context=context, model_instances=[instance])
-            self.assertTupleEqual(p_com.shape, (3, ))
-
         nq = plant.num_positions()
         nv = plant.num_velocities()
         wrt_list = [

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -2479,13 +2479,6 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     return internal_tree().CalcCenterOfMassPositionInWorld(context);
   }
 
-  DRAKE_DEPRECATED("2021-04-21", "Use CalcCenterOfMassPositionInWorld() "
-                   "instead of CalcCenterOfMassPosition().")
-  Vector3<T> CalcCenterOfMassPosition(
-      const systems::Context<T>& context) const {
-    return CalcCenterOfMassPositionInWorld(context);
-  }
-
   /// Calculates the position vector from the world origin Wo to the center of
   /// mass of all bodies contained in model_instances, expressed in the world
   /// frame W.
@@ -2505,14 +2498,6 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     this->ValidateContext(context);
     return internal_tree().
         CalcCenterOfMassPositionInWorld(context, model_instances);
-  }
-
-  DRAKE_DEPRECATED("2021-04-21", "Use CalcCenterOfMassPositionInWorld() "
-                   "instead of CalcCenterOfMassPosition().")
-  Vector3<T> CalcCenterOfMassPosition(
-      const systems::Context<T>& context,
-      const std::vector<ModelInstanceIndex>& model_instances) const {
-    return CalcCenterOfMassPositionInWorld(context, model_instances);
   }
 
   /// Calculates system center of mass translational velocity in world frame W.

--- a/multibody/plant/test/multibody_plant_com_test.cc
+++ b/multibody/plant/test/multibody_plant_com_test.cc
@@ -27,15 +27,6 @@ GTEST_TEST(EmptyMultibodyPlantCenterOfMassTest, CalcCenterOfMassPosition) {
       "CalcCenterOfMassPositionInWorld\\(\\): This MultibodyPlant contains "
       "only the world_body\\(\\) so its center of mass is undefined.");
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      plant.CalcCenterOfMassPosition(*context_),
-      std::exception,
-      "CalcCenterOfMassPositionInWorld\\(\\): This MultibodyPlant contains "
-      "only the world_body\\(\\) so its center of mass is undefined.");
-#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
-
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant.CalcCenterOfMassTranslationalVelocityInWorld(*context_),
       std::exception,
@@ -90,14 +81,6 @@ class MultibodyPlantCenterOfMassTest : public ::testing::Test {
     // Allow for 3 bits (2^3 = 8) of error.
     const double kTolerance = 8 * std::numeric_limits<double>::epsilon();
     EXPECT_TRUE(CompareMatrices(p_WCcm, p_WCcm_expected, kTolerance));
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    Eigen::Vector3d p_WCcm_deprecated =
-        plant_.CalcCenterOfMassPosition(*context_);
-    EXPECT_TRUE(
-        CompareMatrices(p_WCcm_deprecated, p_WCcm_expected, kTolerance));
-#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
   }
 
   const RigidBody<double>& GetSphereBody() {
@@ -223,13 +206,6 @@ TEST_F(MultibodyPlantCenterOfMassTest, CenterOfMassPosition) {
   const double kTolerance = 8 * std::numeric_limits<double>::epsilon();
   EXPECT_TRUE(CompareMatrices(p_WCcm, result, kTolerance));
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  Eigen::Vector3d p_WCcm_deprecatedA =
-      plant_.CalcCenterOfMassPosition(*context_);
-  EXPECT_TRUE(CompareMatrices(p_WCcm_deprecatedA, result, kTolerance));
-#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
-
   // Verify the plant's center of mass location for an arbitrary input.
   const Eigen::Vector3d p_WSo_W(1.1, 2.3, 3.7);
   const Eigen::Vector3d p_WTo_W(-5.2, 10.4, -6.8);
@@ -297,13 +273,6 @@ TEST_F(MultibodyPlantCenterOfMassTest, CenterOfMassPosition) {
            (mass_S_ + mass_T_);
   p_WCcm = plant_.CalcCenterOfMassPositionInWorld(*context_, model_instances);
   EXPECT_TRUE(CompareMatrices(p_WCcm, result, kTolerance));
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  Eigen::Vector3d p_WCcm_deprecatedB =
-      plant_.CalcCenterOfMassPosition(*context_, model_instances);
-  EXPECT_TRUE(CompareMatrices(p_WCcm_deprecatedB, result, kTolerance));
-#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
 
   // Verify CalcCenterOfMassPositionInWorld() works for 2 objects in
   // model_instances, where the 2 objects have arbitrary orientation/position.


### PR DESCRIPTION
Missed previously, perhaps owing to idiosyncratic date.

* drake::multibody::MultiBodyPlant::CalcCenterOfMassPosition
  * all overloads

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15050)
<!-- Reviewable:end -->
