### PR TITLE
trajopt: remove unused variables from DirectCollocationConstraint

### DIFF
--- a/systems/trajectory_optimization/direct_collocation.cc
+++ b/systems/trajectory_optimization/direct_collocation.cc
@@ -105,16 +105,14 @@ void DirectCollocationConstraint::DoEval(
   const auto u0 = x.segment(1 + (2 * num_states_), num_inputs_);
   const auto u1 = x.segment(1 + (2 * num_states_) + num_inputs_, num_inputs_);
 
-  // TODO(sam.creasey): Use caching (when it arrives) to avoid recomputing
-  // the dynamics.  Currently the dynamics evaluated here as {u1,x1} are
-  // recomputed in the next constraint as {u0,x0}.
+  // TODO(sam.creasey): Use caching to avoid recomputing the dynamics.
+  // Currently the dynamics evaluated here as {u1,x1} are recomputed in the
+  // next constraint as {u0,x0}.
   AutoDiffVecXd xdot0;
   dynamics(x0, u0, &xdot0);
-  const Eigen::MatrixXd dxdot0 = math::autoDiffToGradientMatrix(xdot0);
 
   AutoDiffVecXd xdot1;
   dynamics(x1, u1, &xdot1);
-  const Eigen::MatrixXd dxdot1 = math::autoDiffToGradientMatrix(xdot1);
 
   // Cubic interpolation to get xcol and xdotcol.
   const AutoDiffVecXd xcol = 0.5 * (x0 + x1) + h / 8 * (xdot0 - xdot1);


### PR DESCRIPTION
Not sure why those two variables were computed but never used.  The compiler probably optimized it out?  But I'm not sure why it didn't flag this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15051)
<!-- Reviewable:end -->
