### PR TITLE
pydrake: In pydrake.all, prefer pydrake.math over pydrake.symbolic

### DIFF
--- a/bindings/pydrake/all.py
+++ b/bindings/pydrake/all.py
@@ -24,6 +24,7 @@ Note:
 To see example usages, please see `doc/python_bindings.rst`.
 """
 
+import inspect as __inspect
 
 # Normal symbols.
 from . import getDrakePath
@@ -33,7 +34,11 @@ from .lcm import *
 from .math import *
 from .perception import *
 from .polynomial import *
-from .symbolic import *
+# "from .symbolic import *" but don't shadow pydrake.math's existing functions.
+from . import symbolic as __symbolic
+for __name, __value in __inspect.getmembers(__symbolic):
+    if __name[0] != '_':
+        locals().setdefault(__name, __value)
 from .trajectories import *
 
 # Submodules.

--- a/bindings/pydrake/test/all_test.py
+++ b/bindings/pydrake/test/all_test.py
@@ -66,6 +66,16 @@ class TestAll(unittest.TestCase):
         diagram = builder.Build()
         simulator = pydrake.systems.analysis.Simulator(diagram)
 
+    def test_math_overloads_shadowing(self):
+        """Tests that we end up with the more capable pydrake.math functions in
+        the all module, not the more limited pydrake.symbolic functions.
+        """
+        from pydrake.all import AutoDiffXd, Expression, Variable, sin
+        self.assertIsInstance(sin(1), float)
+        self.assertIsInstance(sin(AutoDiffXd(1, [1, 0])), AutoDiffXd)
+        self.assertIsInstance(sin(Expression(Variable('e'))), Expression)
+        self.assertIsInstance(sin(Variable('x')), Expression)
+
     def test_symbols_subset(self):
         """Tests a subset of symbols provided by `drake.all`. At least one
         symbol per submodule should be included.


### PR DESCRIPTION
Closes #15038.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15052)
<!-- Reviewable:end -->
