### PR TITLE
Make CalcCenterOfMassPositionInWorld() and CalcCenterOfMassTranslationalVelocityInWorld() consistent with CalcTotalMass().

### DIFF
--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -2468,11 +2468,13 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// Calculates the position vector from the world origin Wo to the center of
   /// mass of all bodies in this MultibodyPlant, expressed in the world frame W.
   /// @param[in] context Contains the state of the model.
-  /// @retval p_WScm_W position vector from Wo to Scm expressed in world frame
+  /// @retval p_WoScm_W position vector from Wo to Scm expressed in world frame
   /// W, where Scm is the center of mass of the system S stored by `this` plant.
   /// @throws std::exception if `this` has no body except world_body().
-  /// @throws std::exception if mₛ ≤ 0 (mₛ is the mass of `this` system S).
-  /// @note The world_body() is ignored.
+  /// @throws std::exception if mₛ ≤ 0 (where mₛ is the mass of system S).
+  /// @note The world_body() is ignored.  p_WoScm_W = ∑ (mᵢ pᵢ) / mₛ, where
+  /// mₛ = ∑ mᵢ, mᵢ is the mass of the iᵗʰ body, and pᵢ is Bcm's position vector
+  /// from Wo expressed in frame W (Bcm is the center of mass of the iᵗʰ body).
   Vector3<T> CalcCenterOfMassPositionInWorld(
       const systems::Context<T>& context) const {
     this->ValidateContext(context);
@@ -2480,18 +2482,20 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   }
 
   /// Calculates the position vector from the world origin Wo to the center of
-  /// mass of all bodies contained in model_instances, expressed in the world
-  /// frame W.
+  /// mass of all non-world bodies contained in model_instances, expressed in
+  /// the world frame W.
   /// @param[in] context Contains the state of the model.
-  /// @param[in] model_instances Vector of selected model instances. This method
-  /// does not distinguish between welded, joint connected, or floating bodies.
-  /// @retval p_WScm_W position vector from world origin Wo to Scm expressed in
+  /// @param[in] model_instances Vector of selected model instances.  If a model
+  /// instance is repeated in the vector (unusual), it is only counted once.
+  /// @retval p_WoScm_W position vector from world origin Wo to Scm expressed in
   /// the world frame W, where Scm is the center of mass of the system S of
-  /// bodies contained in model_instances.
-  /// @throws std::exception if model_instance only has world_model_instance(),
-  /// i.e., model_instances has no body except world_body().
-  /// @throws std::exception if mₛ ≤ 0 (mₛ is the mass of the system S).
-  /// @note The world_body() is ignored.
+  /// non-world bodies contained in model_instances.
+  /// @throws std::exception if model_instances is empty or only has world body.
+  /// @throws std::exception if mₛ ≤ 0 (where mₛ is the mass of system S).
+  /// @note The world_body() is ignored.  p_WoScm_W = ∑ (mᵢ pᵢ) / mₛ, where
+  /// mₛ = ∑ mᵢ, mᵢ is the mass of the iᵗʰ body contained in model_instances,
+  /// and pᵢ is Bcm's position vector from Wo expressed in frame W
+  /// (Bcm is the center of mass of the iᵗʰ body).
   Vector3<T> CalcCenterOfMassPositionInWorld(
       const systems::Context<T>& context,
       const std::vector<ModelInstanceIndex>& model_instances) const {
@@ -2505,8 +2509,10 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @retval v_WScm_W Scm's translational velocity in frame W, expressed in W,
   /// where Scm is the center of mass of the system S stored by `this` plant.
   /// @throws std::exception if `this` has no body except world_body().
-  /// @throws std::exception if mₛ ≤ 0 (mₛ is the mass of `this` system S).
-  /// @note The world_body() is ignored.
+  /// @throws std::exception if mₛ ≤ 0 (where mₛ is the mass of system S).
+  /// @note The world_body() is ignored.  v_WScm_W = ∑ (mᵢ vᵢ) / mₛ, where
+  /// mₛ = ∑ mᵢ, mᵢ is the mass of the iᵗʰ body, and vᵢ is Bcm's velocity in
+  /// world W (Bcm is the center of mass of the iᵗʰ body).
   Vector3<T> CalcCenterOfMassTranslationalVelocityInWorld(
       const systems::Context<T>& context) const {
     return internal_tree().CalcCenterOfMassTranslationalVelocityInWorld(
@@ -2515,13 +2521,17 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   /// Calculates system center of mass translational velocity in world frame W.
   /// @param[in] context The context contains the state of the model.
-  /// @param[in] model_instances The vector of selected model instances.
+  /// @param[in] model_instances Vector of selected model instances.  If a model
+  /// instance is repeated in the vector (unusual), it is only counted once.
   /// @retval v_WScm_W Scm's translational velocity in frame W, expressed in W,
-  /// where Scm is the center of mass of the system S in model_instances.
-  /// @throws std::exception if `this` has no body except world_body().
-  /// @throws std::exception if mₛ ≤ 0 (mₛ is the mass of `this` system S).
-  /// @note This method does not distinguish between welded bodies, joint
-  /// connected bodies, and free bodies.  The world_body() is ignored.
+  /// where Scm is the center of mass of the system S of non-world bodies
+  /// contained in model_instances.
+  /// @throws std::exception if model_instances is empty or only has world body.
+  /// @throws std::exception if mₛ ≤ 0 (where mₛ is the mass of system S).
+  /// @note The world_body() is ignored.  v_WScm_W = ∑ (mᵢ vᵢ) / mₛ, where
+  /// mₛ = ∑ mᵢ, mᵢ is the mass of the iᵗʰ body contained in model_instances,
+  /// and vᵢ is Bcm's velocity in world W expressed in frame W
+  /// (Bcm is the center of mass of the iᵗʰ body).
   Vector3<T> CalcCenterOfMassTranslationalVelocityInWorld(
       const systems::Context<T>& context,
       const std::vector<ModelInstanceIndex>& model_instances) const {

--- a/multibody/plant/test/multibody_plant_com_test.cc
+++ b/multibody/plant/test/multibody_plant_com_test.cc
@@ -24,8 +24,8 @@ GTEST_TEST(EmptyMultibodyPlantCenterOfMassTest, CalcCenterOfMassPosition) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant.CalcCenterOfMassPositionInWorld(*context_),
       std::exception,
-      "CalcCenterOfMassPositionInWorld\\(\\): This MultibodyPlant contains "
-      "only the world_body\\(\\) so its center of mass is undefined.");
+      "CalcCenterOfMassPositionInWorld\\(\\): This MultibodyPlant "
+      "only contains the world_body\\(\\) so its center of mass is undefined.");
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant.CalcCenterOfMassTranslationalVelocityInWorld(*context_),
@@ -230,15 +230,15 @@ TEST_F(MultibodyPlantCenterOfMassTest, CenterOfMassPosition) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant_.CalcCenterOfMassPositionInWorld(*context_, model_instances),
       std::exception,
-      "CalcCenterOfMassPositionInWorld\\(\\): There were no bodies specified. "
-      "You must provide at least one selected body.");
+      "CalcCenterOfMassPositionInWorld\\(\\): There must be at "
+      "least one non-world body contained in model_instances.");
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant_.CalcCenterOfMassTranslationalVelocityInWorld(*context_,
                                                           model_instances),
       std::exception,
-      "CalcCenterOfMassTranslationalVelocityInWorld\\(\\): There were no "
-      "bodies specified. You must provide at least one selected body.");
+      "CalcCenterOfMassTranslationalVelocityInWorld\\(\\): There must be at "
+      "least one non-world body contained in model_instances.");
 
   // Ensure an exception is thrown when a model instance has one world body.
   const ModelInstanceIndex world_model_instance =
@@ -249,8 +249,8 @@ TEST_F(MultibodyPlantCenterOfMassTest, CenterOfMassPosition) {
       plant_.CalcCenterOfMassTranslationalVelocityInWorld(*context_,
           world_model_instance_array),
       std::exception,
-      "CalcCenterOfMassTranslationalVelocityInWorld\\(\\): There were no "
-      "bodies specified. You must provide at least one selected body.");
+      "CalcCenterOfMassTranslationalVelocityInWorld\\(\\): There must be at "
+      "least one non-world body contained in model_instances.");
 
   // Ensure an exception is thrown when a model instance has two world bodies.
   world_model_instance_array.push_back(world_model_instance);
@@ -258,8 +258,8 @@ TEST_F(MultibodyPlantCenterOfMassTest, CenterOfMassPosition) {
       plant_.CalcCenterOfMassTranslationalVelocityInWorld(*context_,
           world_model_instance_array),
       std::exception,
-      "CalcCenterOfMassTranslationalVelocityInWorld\\(\\): There were no "
-      "bodies specified. You must provide at least one selected body.");
+      "CalcCenterOfMassTranslationalVelocityInWorld\\(\\): There must be at "
+      "least one non-world body contained in model_instances.");
 
   // Try one instance in model_instances.
   model_instances.push_back(triangle_instance_);

--- a/multibody/plant/test/multibody_plant_com_test.cc
+++ b/multibody/plant/test/multibody_plant_com_test.cc
@@ -249,8 +249,8 @@ TEST_F(MultibodyPlantCenterOfMassTest, CenterOfMassPosition) {
       plant_.CalcCenterOfMassTranslationalVelocityInWorld(*context_,
           world_model_instance_array),
       std::exception,
-      "CalcCenterOfMassTranslationalVelocityInWorld\\(\\): This system only "
-      "contains the world_body\\(\\) so its center of mass is undefined.");
+      "CalcCenterOfMassTranslationalVelocityInWorld\\(\\): There were no "
+      "bodies specified. You must provide at least one selected body.");
 
   // Ensure an exception is thrown when a model instance has two world bodies.
   world_model_instance_array.push_back(world_model_instance);
@@ -258,8 +258,8 @@ TEST_F(MultibodyPlantCenterOfMassTest, CenterOfMassPosition) {
       plant_.CalcCenterOfMassTranslationalVelocityInWorld(*context_,
           world_model_instance_array),
       std::exception,
-      "CalcCenterOfMassTranslationalVelocityInWorld\\(\\): This system only "
-      "contains the world_body\\(\\) so its center of mass is undefined.");
+      "CalcCenterOfMassTranslationalVelocityInWorld\\(\\): There were no "
+      "bodies specified. You must provide at least one selected body.");
 
   // Try one instance in model_instances.
   model_instances.push_back(triangle_instance_);

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -1241,7 +1241,7 @@ void MultibodyTree<T>::CalcPointsPositions(
 template <typename T>
 T MultibodyTree<T>::CalcTotalMass(const systems::Context<T>& context) const {
   T total_mass = 0;
-  for (BodyIndex body_index{1}; body_index < num_bodies(); ++body_index) {
+  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
     const Body<T>& body = get_body(body_index);
     const T& body_mass = body.get_mass(context);
     total_mass += body_mass;
@@ -1269,16 +1269,16 @@ template <typename T>
 Vector3<T> MultibodyTree<T>::CalcCenterOfMassPositionInWorld(
     const systems::Context<T>& context) const {
   if (num_bodies() <= 1) {
-    throw std::logic_error(
-        "CalcCenterOfMassPositionInWorld(): This MultibodyPlant contains "
-        "only the world_body() so its center of mass is undefined.");
+    std::string message = fmt::format("{}(): This MultibodyPlant only contains "
+        "the world_body() so its center of mass is undefined.", __func__);
+    throw std::logic_error(message);
   }
 
   T total_mass = 0;
   Vector3<T> sum_mi_pi = Vector3<T>::Zero();
 
   // Sum over all the bodies except the 0th body (which is the world body).
-  for (BodyIndex body_index{1}; body_index < num_bodies(); ++body_index) {
+  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
     const Body<T>& body = get_body(body_index);
 
     // total mass = ∑ mᵢ.
@@ -1292,8 +1292,9 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassPositionInWorld(
   }
 
   if (total_mass <= 0) {
-    throw std::logic_error("CalcCenterOfMassPositionInWorld(): The "
-                           "system's total mass must be greater than zero.");
+    std::string message = fmt::format("{}(): The system's total mass must "
+                                      "be greater than zero.", __func__);
+    throw std::logic_error(message);
   }
 
   return sum_mi_pi / total_mass;
@@ -1305,18 +1306,23 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassPositionInWorld(
     const std::vector<ModelInstanceIndex>& model_instances) const {
   // Reminder: MultibodyTree always declares a world body and 2 model instances
   // "world" and "default" so num_model_instances() should always be >= 2.
-  if (num_bodies() <= 1 || num_model_instances() <= 1) {
-    throw std::logic_error(
-        "CalcCenterOfMassPositionInWorld(): This MultibodyPlant contains "
-        "only the world_body() so its center of mass is undefined.");
+  if (num_bodies() <= 1) {
+    std::string message = fmt::format("{}(): This MultibodyPlant only contains "
+        "the world_body() so its center of mass is undefined.", __func__);
+    throw std::logic_error(message);
   }
 
   T total_mass = 0;
   Vector3<T> sum_mi_pi = Vector3<T>::Zero();
 
   // Sum over all the bodies that are in model_instances except for the 0th body
-  // (which is the world body).  It is a upstream user error for the same body
-  // to appear in multiple model_instances, so count each body only once.
+  // (which is the world body), and count each body's contribution only once.
+  // Reminder: Although it is not possible for a body to belong to multiple
+  // model instances [as Body::model_instance() returns a body's unique model
+  // instance], it is possible for the same model instance to be added multiple
+  // times to std::vector<ModelInstanceIndex>& model_instances).  The code below
+  // ensures a body's contribution to the sum occurs only once.  Duplicate
+  // model_instances in std::vector are considered an upstream user error.
   int number_of_non_world_bodies_processed = 0;
   for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
     const Body<T>& body = get_body(body_index);
@@ -1336,14 +1342,15 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassPositionInWorld(
 
   // Throw an exception if there are zero non-world bodies in model_instances.
   if (number_of_non_world_bodies_processed == 0) {
-    throw std::logic_error(
-        "CalcCenterOfMassPositionInWorld(): There were no bodies specified. "
-        "You must provide at least one selected body.");
+    std::string message = fmt::format("{}(): There must be at least one "
+        "non-world body contained in model_instances.", __func__);
+    throw std::logic_error(message);
   }
 
   if (total_mass <= 0) {
-    throw std::logic_error("CalcCenterOfMassPositionInWorld(): The "
-                           "system's total mass must be greater than zero.");
+    std::string message = fmt::format("{}(): The system's total mass must "
+                                      "be greater than zero.", __func__);
+    throw std::logic_error(message);
   }
 
   return sum_mi_pi / total_mass;
@@ -1362,7 +1369,7 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalVelocityInWorld(
   Vector3<T> sum_mi_vi = Vector3<T>::Zero();
 
   // Sum over all the bodies except the 0th body (which is the world body).
-  for (BodyIndex body_index{1}; body_index < num_bodies(); ++body_index) {
+  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
     const Body<T>& body = get_body(body_index);
 
     // total mass = ∑ mᵢ.
@@ -1376,8 +1383,8 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalVelocityInWorld(
   }
 
   if (total_mass <= 0) {
-    std::string message = fmt::format("{}(): The system's "
-        "total mass must be greater than zero.", __func__);
+    std::string message = fmt::format("{}(): The system's total mass must "
+                                      "be greater than zero.", __func__);
     throw std::logic_error(message);
   }
 
@@ -1394,7 +1401,7 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalVelocityInWorld(
     const std::vector<ModelInstanceIndex>& model_instances) const {
   // Reminder: MultibodyTree always declares a world body and 2 model instances
   // "world" and "default" so num_model_instances() should always be >= 2.
-  if (num_bodies() <= 1 || num_model_instances() <= 1) {
+  if (num_bodies() <= 1) {
     std::string message = fmt::format("{}(): This MultibodyPlant only contains "
         "the world_body() so its center of mass is undefined.", __func__);
     throw std::logic_error(message);
@@ -1404,8 +1411,13 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalVelocityInWorld(
   Vector3<T> sum_mi_vi = Vector3<T>::Zero();
 
   // Sum over all the bodies that are in model_instances except for the 0th body
-  // (which is the world body).  It is a upstream user error for the same body
-  // to appear in multiple model_instances, so count each body only once.
+  // (which is the world body), and count each body's contribution only once.
+  // Reminder: Although it is not possible for a body to belong to multiple
+  // model instances [as Body::model_instance() returns a body's unique model
+  // instance], it is possible for the same model instance to be added multiple
+  // times to std::vector<ModelInstanceIndex>& model_instances).  The code below
+  // ensures a body's contribution to the sum occurs only once.  Duplicate
+  // model_instances in std::vector are considered an upstream user error.
   int number_of_non_world_bodies_processed = 0;
   for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
     const Body<T>& body = get_body(body_index);
@@ -1425,21 +1437,17 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalVelocityInWorld(
 
   // Throw an exception if there are zero non-world bodies in model_instances.
   if (number_of_non_world_bodies_processed == 0) {
-    std::string message = fmt::format("{}(): There were no bodies specified. "
-        "You must provide at least one selected body.", __func__);
+    std::string message = fmt::format("{}(): There must be at least one "
+        "non-world body contained in model_instances.", __func__);
     throw std::logic_error(message);
   }
 
   if (total_mass <= 0) {
-    std::string message = fmt::format("{}(): The system's "
-        "total mass must be greater than zero.", __func__);
+    std::string message = fmt::format("{}(): The system's total mass must "
+                                      "be greater than zero.", __func__);
     throw std::logic_error(message);
   }
 
-  // For a system S with center of mass Scm, Scm's translational velocity in the
-  // world frame W is calculated as v_WScm_W = ∑ (mᵢ vᵢ)  / mₛ, where mₛ = ∑ mᵢ,
-  // mᵢ is the mass of the  iᵗʰ body, and vᵢ is Bcm's velocity in world frame W
-  // (Bcm is the center of mass of the iᵗʰ body).
   return sum_mi_vi / total_mass;
 }
 

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -1269,9 +1269,9 @@ template <typename T>
 Vector3<T> MultibodyTree<T>::CalcCenterOfMassPositionInWorld(
     const systems::Context<T>& context) const {
   if (num_bodies() <= 1) {
-    throw std::runtime_error(
-        "CalcCenterOfMassPositionInWorld(): This MultibodyPlant contains only "
-        "the world_body() so its center of mass is undefined.");
+    throw std::logic_error(
+        "CalcCenterOfMassPositionInWorld(): This MultibodyPlant contains "
+        "only the world_body() so its center of mass is undefined.");
   }
 
   T total_mass = 0;
@@ -1303,18 +1303,21 @@ template <typename T>
 Vector3<T> MultibodyTree<T>::CalcCenterOfMassPositionInWorld(
     const systems::Context<T>& context,
     const std::vector<ModelInstanceIndex>& model_instances) const {
+  // Reminder: MultibodyTree always declares a world body and 2 model instances
+  // "world" and "default" so num_model_instances() should always be >= 2.
   if (num_bodies() <= 1 || num_model_instances() <= 1) {
-    throw std::runtime_error(
-        "CalcCenterOfMassPositionInWorld(): This MultibodyPlant contains only "
-        "the world_body() so its center of mass is undefined.");
+    throw std::logic_error(
+        "CalcCenterOfMassPositionInWorld(): This MultibodyPlant contains "
+        "only the world_body() so its center of mass is undefined.");
   }
 
   T total_mass = 0;
   Vector3<T> sum_mi_pi = Vector3<T>::Zero();
 
   // Sum over all the bodies that are in model_instances except for the 0th body
-  // (which is the world body).  It is considered an error for the same body to
-  // appear in multiple model_instances, so count each body only once.
+  // (which is the world body).  It is a upstream user error for the same body
+  // to appear in multiple model_instances, so count each body only once.
+  int number_of_non_world_bodies_processed = 0;
   for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
     const Body<T>& body = get_body(body_index);
     if (std::find(model_instances.begin(), model_instances.end(),
@@ -1322,12 +1325,20 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassPositionInWorld(
       // total mass = ∑ mᵢ.
       const T& body_mass = body.get_mass(context);
       total_mass += body_mass;
+      ++number_of_non_world_bodies_processed;
 
       // sum_mi_pi = ∑ mᵢ * pi_WoBcm_W.
       const Vector3<T> pi_BoBcm_B = body.CalcCenterOfMassInBodyFrame(context);
       const Vector3<T> pi_WoBcm_W = body.EvalPoseInWorld(context) * pi_BoBcm_B;
       sum_mi_pi += body_mass * pi_WoBcm_W;
     }
+  }
+
+  // Throw an exception if there are zero non-world bodies in model_instances.
+  if (number_of_non_world_bodies_processed == 0) {
+    throw std::logic_error(
+        "CalcCenterOfMassPositionInWorld(): There were no bodies specified. "
+        "You must provide at least one selected body.");
   }
 
   if (total_mass <= 0) {
@@ -1341,89 +1352,95 @@ Vector3<T> MultibodyTree<T>::CalcCenterOfMassPositionInWorld(
 template <typename T>
 Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalVelocityInWorld(
     const systems::Context<T>& context) const {
-  // Each multibody tree contains the world body.
-  // Ensure this multibody tree contains at least one non-world body.
   if (num_bodies() <= 1) {
     std::string message = fmt::format("{}(): This MultibodyPlant only contains "
         "the world_body() so its center of mass is undefined.", __func__);
     throw std::logic_error(message);
   }
 
-  std::vector<ModelInstanceIndex> model_instances;
-  for (ModelInstanceIndex model_instance_index(1);
-       model_instance_index < num_model_instances(); ++model_instance_index)
-    model_instances.push_back(model_instance_index);
+  T total_mass = 0;
+  Vector3<T> sum_mi_vi = Vector3<T>::Zero();
 
-  return CalcCenterOfMassTranslationalVelocityInWorld(context, model_instances);
+  // Sum over all the bodies except the 0th body (which is the world body).
+  for (BodyIndex body_index{1}; body_index < num_bodies(); ++body_index) {
+    const Body<T>& body = get_body(body_index);
+
+    // total mass = ∑ mᵢ.
+    const T& body_mass = body.get_mass(context);
+    total_mass += body_mass;
+
+    // sum_mi_vi = ∑ mᵢ * vi_WBcm_W.
+    const Vector3<T> vi_WBcm_W =
+        body.CalcCenterOfMassTranslationalVelocityInWorld(context);
+    sum_mi_vi += body_mass * vi_WBcm_W;
+  }
+
+  if (total_mass <= 0) {
+    std::string message = fmt::format("{}(): The system's "
+        "total mass must be greater than zero.", __func__);
+    throw std::logic_error(message);
+  }
+
+  // For a system S with center of mass Scm, Scm's translational velocity in the
+  // world frame W is calculated as v_WScm_W = ∑ (mᵢ vᵢ)  / mₛ, where mₛ = ∑ mᵢ,
+  // mᵢ is the mass of the  iᵗʰ body, and vᵢ is Bcm's velocity in world frame W
+  // (Bcm is the center of mass of the iᵗʰ body).
+  return sum_mi_vi / total_mass;
 }
 
 template <typename T>
 Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalVelocityInWorld(
     const systems::Context<T>& context,
     const std::vector<ModelInstanceIndex>& model_instances) const {
-  // Reminder: MultibodyTree always declares 2 model instances "world" and
-  // "default" so num_model_instances() should always be >= 2.
-  std::vector<BodyIndex> body_indexes;
-  for (auto model_instance : model_instances) {
-    DRAKE_THROW_UNLESS(model_instance.is_valid());
-    DRAKE_THROW_UNLESS(model_instance < num_model_instances());
-    const std::vector<BodyIndex> body_index_in_instance =
-        GetBodyIndices(model_instance);
-    for (BodyIndex body_index : body_index_in_instance)
-      body_indexes.push_back(body_index);
-  }
-
-  return CalcCenterOfMassTranslationalVelocityInWorldHelper(context,
-                                                            body_indexes,
-                                                            __func__);
-}
-
-template <typename T>
-Vector3<T> MultibodyTree<T>::CalcCenterOfMassTranslationalVelocityInWorldHelper(
-    const systems::Context<T>& context,
-    const std::vector<BodyIndex>& body_indexes,
-    const char* function_name) const {
-  if (body_indexes.empty()) {
-    std::string message = fmt::format("{}(): There were no bodies specified. "
-        "You must provide at least one selected body.", function_name);
+  // Reminder: MultibodyTree always declares a world body and 2 model instances
+  // "world" and "default" so num_model_instances() should always be >= 2.
+  if (num_bodies() <= 1 || num_model_instances() <= 1) {
+    std::string message = fmt::format("{}(): This MultibodyPlant only contains "
+        "the world_body() so its center of mass is undefined.", __func__);
     throw std::logic_error(message);
   }
 
-  // For a system S with center of mass Scm, Scm's translational velocity in
-  // frame A is calculated as v_AScm = ∑ (mᵢ vᵢ)  / mₛ, where mₛ = ∑ mᵢ,
-  // mᵢ is the mass of the  iᵗʰ body, and vᵢ is the velocity of Bcm in frame A
-  // (Bcm is the center of mass of the iᵗʰ body).
-  T composite_mass = 0;                       // mₛ = ∑ mᵢ (mass of the system).
-  Vector3<T> sum_mi_vi = Vector3<T>::Zero();  // sum_mi_vi = ∑ (mᵢ vᵢ).
+  T total_mass = 0;
+  Vector3<T> sum_mi_vi = Vector3<T>::Zero();
 
+  // Sum over all the bodies that are in model_instances except for the 0th body
+  // (which is the world body).  It is a upstream user error for the same body
+  // to appear in multiple model_instances, so count each body only once.
   int number_of_non_world_bodies_processed = 0;
-  for (BodyIndex body_index : body_indexes) {
-    if (body_index == 0) continue;
+  for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
+    const Body<T>& body = get_body(body_index);
+    if (std::find(model_instances.begin(), model_instances.end(),
+                  body.model_instance()) != model_instances.end()) {
+      // total mass = ∑ mᵢ.
+      const T& body_mass = body.get_mass(context);
+      total_mass += body_mass;
+      ++number_of_non_world_bodies_processed;
 
-    const Body<T>& body_B = get_body(body_index);
-    const Vector3<T> v_ABcm_E =
-        body_B.CalcCenterOfMassTranslationalVelocityInWorld(context);
-
-    // Form (mᵢ vᵢ) and add to sum, i.e., sum_mi_vi = ∑ (mᵢ vᵢ).
-    const T& body_mass = body_B.get_mass(context);
-    sum_mi_vi += body_mass * v_ABcm_E;
-    composite_mass += body_mass;
-    ++number_of_non_world_bodies_processed;
+      // sum_mi_vi = ∑ mᵢ * vi_WBcm_W.
+      const Vector3<T> vi_WBcm_W =
+        body.CalcCenterOfMassTranslationalVelocityInWorld(context);
+      sum_mi_vi += body_mass * vi_WBcm_W;
+    }
   }
 
-  // Throw an exception if body_indexes only contains one (or more) world_body.
+  // Throw an exception if there are zero non-world bodies in model_instances.
   if (number_of_non_world_bodies_processed == 0) {
-    std::string message = fmt::format("{}(): This system only contains "
-        "the world_body() so its center of mass is undefined.", function_name);
+    std::string message = fmt::format("{}(): There were no bodies specified. "
+        "You must provide at least one selected body.", __func__);
     throw std::logic_error(message);
   }
 
-  if (composite_mass <= 0) {
+  if (total_mass <= 0) {
     std::string message = fmt::format("{}(): The system's "
-        "total mass must be greater than zero.", function_name);
+        "total mass must be greater than zero.", __func__);
     throw std::logic_error(message);
   }
-  return sum_mi_vi / composite_mass;
+
+  // For a system S with center of mass Scm, Scm's translational velocity in the
+  // world frame W is calculated as v_WScm_W = ∑ (mᵢ vᵢ)  / mₛ, where mₛ = ∑ mᵢ,
+  // mᵢ is the mass of the  iᵗʰ body, and vᵢ is Bcm's velocity in world frame W
+  // (Bcm is the center of mass of the iᵗʰ body).
+  return sum_mi_vi / total_mass;
 }
 
 template <typename T>

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1307,22 +1307,6 @@ class MultibodyTree {
       const systems::Context<T>& context,
       const std::vector<ModelInstanceIndex>& model_instances) const;
 
-  // Calculates the position vector from the world origin Wo to the center of
-  // mass of all bodies specified by body_indexes, expressed in world frame W.
-  // @param[in] context Contains the state of the model.
-  // @param[in] body_indexes  The vector of selected bodies.  This method does
-  // not distinguish between welded, joint connected, or floating bodies.
-  // @retval p_WScm_W position vector from Wo to Scm expressed in world frame W,
-  // where Scm is the center of mass of the system S of bodies specified by
-  // body_indexes.
-  // @throws std::exception if body_indexes is empty or body_indexes has no body
-  // except world_body().
-  // @throws std::exception if mₛ ≤ 0 (mₛ is the mass of the system S).
-  // @note The world_body() is ignored.
-  Vector3<T> CalcCenterOfMassPositionInWorld(
-      const systems::Context<T>& context,
-      const std::vector<BodyIndex>& body_indexes) const;
-
   // See MultibodyPlant method.
   Vector3<T> CalcCenterOfMassTranslationalVelocityInWorld(
       const systems::Context<T>& context) const;
@@ -2601,22 +2585,6 @@ class MultibodyTree {
   // The world body is special in that it is the only body in the model with no
   // mobilizer, even after Finalize().
   void AddQuaternionFreeMobilizerToAllBodiesWithNoMobilizer();
-
-
-  // Calculates system center of mass translational velocity in world frame W.
-  // @param[in] context The context contains the state of the model.
-  // @param[in] body_indexes The vector of selected bodies (cannot be empty)..
-  // @retval v_WScm_W Scm's translational velocity in frame W, expressed in W,
-  // where Scm is the center of mass of the system S in body_indexes.
-  // @throws std::exception if `this` has no body except world_body().
-  // @throws std::exception if mₛ ≤ 0 (mₛ is the mass of `this` system S).
-  // @throws std::exception if `body_indexes.empty() == true`.
-  // @note This method does not distinguish between welded bodies, joint
-  // connected bodies, and free bodies.  The world_body() is ignored.
-  Vector3<T> CalcCenterOfMassTranslationalVelocityInWorldHelper(
-      const systems::Context<T>& context,
-      const std::vector<BodyIndex>& body_indexes,
-      const char* function_name) const;
 
   // For a frame Fp that is fixed/welded to a frame_F, this method computes
   // A_AFp_E, Fp's spatial acceleration in a body_A, expressed in a frame_E.


### PR DESCRIPTION
Resolve issue #14997.  Update CalcCenterOfMassPositionInWorld() and Make CalcCenterOfMassPositionInWorld() and CalcCenterOfMassTranslationalVelocityInWorld() so their calculations are consistent with the calculations in CalcTotalMass().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15054)
<!-- Reviewable:end -->
