### PR TITLE
run_scripted_deformable_motion: Fix minor typo in documentation

### DIFF
--- a/multibody/fixed_fem/dev/run_scripted_deformable_motion.cc
+++ b/multibody/fixed_fem/dev/run_scripted_deformable_motion.cc
@@ -16,8 +16,8 @@ bazel-bin/tools/drake_visualizer
 
 In another terminal, launch the demo
 ```
-bazel-bin/multibody/fixed_fem/dev/run_scripted_deformable_motion
--simulator_target_realtime_rate 1
+bazel-bin/multibody/fixed_fem/dev/run_scripted_deformable_motion \
+    --simulator_target_realtime_rate=1
 ```
 
 Notice that without the realtime flag the simulation is likely to progress too


### PR DESCRIPTION
Need line continuation for it to be valid shell command
Also use `--` (POSIX) rather than vanilla `-` for flag

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15056)
<!-- Reviewable:end -->
