### PR TITLE
[geometry] Introduce new bounding volume: axis-aligned bounding box

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -14,6 +14,7 @@ drake_cc_package_library(
     name = "proximity",
     visibility = ["//visibility:public"],
     deps = [
+        ":bv",
         ":bvh",
         ":collision_filter_legacy",
         ":collisions_exist_callback",
@@ -40,7 +41,6 @@ drake_cc_package_library(
         ":mesh_to_vtk",
         ":mesh_traits",
         ":meshing_utilities",
-        ":obb",
         ":obj_to_surface_mesh",
         ":penetration_as_point_pair_callback",
         ":plane",
@@ -55,11 +55,34 @@ drake_cc_package_library(
 )
 
 drake_cc_library(
+    name = "bv",
+    srcs = [
+        "aabb.cc",
+        "boxes_overlap.cc",
+        "obb.cc",
+    ],
+    hdrs = [
+        "aabb.h",
+        "boxes_overlap.h",
+        "obb.h",
+    ],
+    deps = [
+        ":posed_half_space",
+        ":surface_mesh",
+        ":volume_mesh",
+        "//common:essential",
+        "//geometry:shape_specification",
+        "//geometry:utilities",
+        "//math:geometric_transform",
+    ],
+)
+
+drake_cc_library(
     name = "bvh",
     srcs = ["bvh.cc"],
     hdrs = ["bvh.h"],
     deps = [
-        ":obb",
+        ":bv",
         ":posed_half_space",
         ":surface_mesh",
         ":volume_mesh",
@@ -440,21 +463,6 @@ drake_cc_library(
 )
 
 drake_cc_library(
-    name = "obb",
-    srcs = ["obb.cc"],
-    hdrs = ["obb.h"],
-    deps = [
-        ":posed_half_space",
-        ":surface_mesh",
-        ":volume_mesh",
-        "//common:essential",
-        "//geometry:shape_specification",
-        "//geometry:utilities",
-        "//math:geometric_transform",
-    ],
-)
-
-drake_cc_library(
     name = "obj_to_surface_mesh",
     srcs = ["obj_to_surface_mesh.cc"],
     hdrs = ["obj_to_surface_mesh.h"],
@@ -580,6 +588,14 @@ drake_cc_library(
         ":surface_mesh",
         ":volume_mesh",
         "//common:essential",
+    ],
+)
+
+drake_cc_googletest(
+    name = "aabb_test",
+    deps = [
+        ":bv",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -880,10 +896,10 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "obb_test",
     deps = [
+        ":bv",
         ":make_box_mesh",
         ":make_ellipsoid_mesh",
         ":make_sphere_mesh",
-        ":obb",
         ":surface_mesh",
         ":volume_mesh",
         "//common/test_utilities:eigen_matrix_compare",

--- a/geometry/proximity/aabb.cc
+++ b/geometry/proximity/aabb.cc
@@ -1,0 +1,77 @@
+#include "drake/geometry/proximity/aabb.h"
+
+#include "drake/geometry/proximity/boxes_overlap.h"
+#include "drake/geometry/proximity/obb.h"
+#include "drake/geometry/proximity/surface_mesh.h"
+#include "drake/geometry/proximity/volume_mesh.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+using Eigen::Matrix3d;
+using Eigen::Vector3d;
+using math::RigidTransformd;
+using math::RotationMatrixd;
+
+bool Aabb::HasOverlap(const Aabb& a_G, const Aabb& b_H,
+                      const RigidTransformd& X_GH) {
+  /* For this analysis, a_G has local frame A and b_H has local frame B.
+
+     R_GA = R_HB = I because they are Aabb. Therefore,
+     R_AB = R_AG * R_GH * R_HB
+          = I * R_GH * I
+          = R_GH.
+     p_AB_A = R_AG * p_AB_G
+            = p_AB_G                           // R_AG = R_GA = I
+            = p_GB_G - p_GA_G
+            = X_GH * p_HB_H - p_GA_G
+            = X_GH * b_H.center() - a_G.center()  */
+  const RigidTransformd X_AB(X_GH.rotation(),
+                             X_GH * b_H.center() - a_G.center());
+  return BoxesOverlap(a_G.half_width(), b_H.half_width(), X_AB);
+}
+
+bool Aabb::HasOverlap(const Aabb& aabb_G, const Obb& obb_H,
+                      const math::RigidTransformd& X_GH) {
+  /* For this analysis, aabb has local frame A and obb has local frame O.
+
+     R_AO = R_AG * R_GH * R_HO
+          = I * R_GH * R_HO                    // A is Aabb --> R_AG = R_GA = I.
+          = R_GH * R_HO
+     p_AO_A = R_AG * p_AO_G
+            = p_AO_G                           // R_AG = R_GA = I
+            = p_GO_G - p_GA_G
+            = X_GH * p_HO_H - p_GA_G
+            = X_GH * p_HO_H - aabb_G.center()  */
+  const RigidTransformd X_AO(
+      X_GH.rotation() * obb_H.pose().rotation(),
+      X_GH * obb_H.pose().translation() - aabb_G.center());
+  return BoxesOverlap(aabb_G.half_width(), obb_H.half_width(), X_AO);
+}
+
+template <typename MeshType>
+Aabb AabbMaker<MeshType>::Compute() const {
+  auto itr = vertices_.begin();
+  Vector3d max_bounds = convert_to_double(mesh_M_.vertex(*itr).r_MV());
+  Vector3d min_bounds = max_bounds;
+  ++itr;
+  for (; itr != vertices_.end(); ++itr) {
+    const Vector3d& vertex = convert_to_double(mesh_M_.vertex(*itr).r_MV());
+    // Compare its extent along each of the 3 axes.
+    min_bounds = min_bounds.cwiseMin(vertex);
+    max_bounds = max_bounds.cwiseMax(vertex);
+  }
+  const Vector3d center = (min_bounds + max_bounds) / 2;
+  const Vector3d half_width = max_bounds - center;
+  return Aabb(center, half_width);
+}
+
+template class AabbMaker<SurfaceMesh<double>>;
+template class AabbMaker<SurfaceMesh<AutoDiffXd>>;
+template class AabbMaker<VolumeMesh<double>>;
+template class AabbMaker<VolumeMesh<AutoDiffXd>>;
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/aabb.h
+++ b/geometry/proximity/aabb.h
@@ -1,0 +1,177 @@
+#pragma once
+
+#include <set>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/geometry/utilities.h"
+#include "drake/math/rigid_transform.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+// Forward declarations.
+template <typename> class AabbMaker;
+class Obb;
+
+/* Axis-aligned bounding box. The box is defined in a canonical frame B such
+ that it is centered on Bo and its extents are aligned with B's axes. However,
+ the box is posed in a hierarchical frame H. Because this is an _axis-aligned_
+ bounding box, `R_HB = I`. Therefore the pose of the box is completely captured
+ with p_HoBo_H (see center()).
+
+ Because of this, an instance of Aabb is a frame-dependent quantity and should
+ be expressed that way. For example, for a mesh measured and expressed in frame
+ M, the bounding boxes on its triangles will be measured and expressed in the
+ same frame.
+
+ ```
+ auto mesh_M = ...;
+ Aabb bv_M = ...;  // A bounding volume for mesh_M in the same frame.
+ ```
+ */
+class Aabb {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Aabb)
+
+  /* The class used for various creation operations on this bounding volume. */
+  template <typename MeshType>
+  using Maker = AabbMaker<MeshType>;
+
+  /* Constructs an axis-aligned bounding box measured and expressed in frame H.
+
+   @param p_HoBo_H      The position vector from the hierarchy frame's origin to
+                        the box's canonical origin, expressed in frame H. The
+                        box is centered on Bo and aligned with Bx, By, and Bz.
+   @param half_width    The _half_ measures of the box in each of the Bx, By,
+                        and Bz directions. (Also the half measures in the Hx,
+                        Hy, and Hz directions because R_HB = I.)
+   @pre half_width.x(), half_width.y(), half_width.z() are not negative.
+  */
+  Aabb(const Vector3<double>& p_HoBo, const Vector3<double>& half_width)
+      : center_(p_HoBo), half_width_(half_width) {
+    DRAKE_DEMAND(half_width.x() >= 0.0);
+    DRAKE_DEMAND(half_width.y() >= 0.0);
+    DRAKE_DEMAND(half_width.z() >= 0.0);
+  }
+
+  /* Returns the center of the box -- equivalent to the position vector from
+   the hierarchy frame's origin Ho to `this` box's origin Bo: `p_HoBo_H`. */
+  const Vector3<double>& center() const { return center_; }
+
+  /* Returns the half_width. */
+  const Vector3<double>& half_width() const { return half_width_; }
+
+  /* The point on the axis-aligned box with the smallest measures along the Bx-,
+   By-, and Bz-directions. */
+  Vector3<double> lower() const { return center_ - half_width_; }
+
+  /* The point on the axis-aligned box with the largest measures along the Bx-,
+   By-, and Bz-directions. */
+  Vector3<double> upper() const { return center_ + half_width_; }
+
+  // TODO(SeanCurtis-TRI): I've added this to be compatible with the Obb in
+  //  terms of the generic BVH. The generic BVH sorts the vertices along a
+  //  particular axis. For aabb. the axis is always one of the basis axes,
+  //  therefore, it is sufficient to simply compare two floats. For Obb, we have
+  //  to compare two dot products; I dot each vertex position w.r.t. one of the
+  //  axes of the containing Obb. It would be better if this operation weren't
+  //  built into the BVH but a function of the geometry type.
+  //  The challenge in doing this is *what* I'm sorting. "CentroidPair" is
+  //  defined inside the Bvh. I'll need to do some refactoring so that I don't
+  //  get a circular dependency or any such thing (Or do things in a weird
+  //  template-y fashion).
+  /* Returns the pose X_HB of the box frame B in the hierarchy frame H. */
+  math::RigidTransformd pose() const { return math::RigidTransformd{center_}; }
+
+  /* @return Volume of the bounding box.  */
+  double CalcVolume() const {
+    // Double the three half widths using * 8 instead of repeating * 2 three
+    // times to help the compiler out.
+    return half_width_[0] * half_width_[1] * half_width_[2] * 8;
+  }
+
+  /* Reports whether the two axis-aligned bounding boxes `a_G` and `b_H`
+   intersect. The poses of `a_G` and `b_H` are defined in their corresponding
+   hierarchy frames G and H, respectively.
+
+   @param a_G       The first axis-aligned box.
+   @param b_H       The second axis-aligned box.
+   @param X_GH      The relative pose between hierarchy frame G and hierarchy
+                    frame H.
+   @returns `true` if the boxes intersect.   */
+  static bool HasOverlap(const Aabb& a_G, const Aabb& b_H,
+                         const math::RigidTransformd& X_GH);
+
+  /* Reports whether axis-aligned bounding box `aabb_G` intersects the given
+   oriented bounding box `obb_H`. The poses of `aabb_G` and `obb_H` are defined
+   in their corresponding hierarchy frames G and H, respectively.
+
+   @param aabb_G   The axis-aligned box.
+   @param obb_H     The oriented box.
+   @param X_GH      The relative pose between the aabb hierarchy frame G and the
+                    obb hierarchy frame H.
+   @returns `true` if the boxes intersect.   */
+  static bool HasOverlap(const Aabb& aabb_G, const Obb& obb_H,
+                         const math::RigidTransformd& X_GH);
+
+  // TODO(SeanCurtis-TRI): Support collision with primitives as appropriate
+  //  (see obb.h for an example).
+
+  /* Compares the values of the two Aabb instances for exact equality down to
+   the last bit. Assumes that the quantities are measured and expressed in
+   the same frame. */
+  bool Equal(const Aabb& other) const {
+    if (this == &other) return true;
+    return center_ == other.center_ &&
+           half_width_ == other.half_width_;
+  }
+
+ private:
+  // Center point of the box.
+  Vector3<double> center_;
+  // Half width extents along each axes.
+  Vector3<double> half_width_;
+};
+
+/* %AabbMaker implements the logic to fit an Aabb to a collection of points.
+ The points are the position of a subset of verties in a mesh. The Aabb will
+ be measured and expressed in the same frame as the mesh.
+
+ This serves as the interface to Bvh, allowing the Bvh to fit volumes to
+ geometry without knowing the details of the bounding volume types.
+
+ @tparam MeshType is either SurfaceMesh<T> or VolumeMesh<T>, where T is
+         double or AutoDiffXd.  */
+template <class MeshType>
+class AabbMaker {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(AabbMaker)
+
+  /* Constructs the maker with the reference mesh and the subset of vertices to
+   fit (indicated by corresponding index).
+
+   @param mesh_M     The mesh frame M.
+   @param vertices   The subset of vertices to fit.
+   @pre `vertices` is not empty, and each of its entry is in the
+        range [0, mesh_M.num_vertices()).  */
+  AabbMaker(const MeshType& mesh_M,
+            const std::set<typename MeshType::VertexIndex>& vertices)
+      : mesh_M_(mesh_M), vertices_(vertices) {
+    DRAKE_DEMAND(vertices_.size() > 0);
+  }
+
+  /* Computes the bounding volume of the vertices specified in the constructor.
+   @retval aabb_M    The axis-aligned bounding box posed in mesh frame M.  */
+  Aabb Compute() const;
+
+ private:
+  const MeshType& mesh_M_;
+  const std::set<typename MeshType::VertexIndex>& vertices_;
+};
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/boxes_overlap.cc
+++ b/geometry/proximity/boxes_overlap.cc
@@ -1,0 +1,71 @@
+#include "drake/geometry/proximity/boxes_overlap.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+using Eigen::Matrix3d;
+using Eigen::Vector3d;
+using math::RigidTransformd;
+
+// TODO(SeanCurtis-TRI) This code is tested in obb_test.cc for historical
+//  reasons. If that causes confusion/difficulty, move it into its own unit test
+//  and rework the Obb tests.
+bool BoxesOverlap(const Vector3d& half_size_a, const Vector3d& half_size_b,
+                  const RigidTransformd& X_AB) {
+  // We need to split the transform into the position and rotation components,
+  // `p_AB` and `R_AB`. For the purposes of streamlining the math below, they
+  // will henceforth be named `t` and `r` respectively.
+  const Vector3d& t = X_AB.translation();
+  const Matrix3d& r = X_AB.rotation().matrix();
+
+  // Compute some common subexpressions and add epsilon to counteract
+  // arithmetic error, e.g. when two edges are parallel. We use the value as
+  // specified from Gottschalk's OBB robustness tests.
+  const double kEpsilon = 0.000001;
+  Matrix3d abs_r = r;
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      abs_r(i, j) = abs(abs_r(i, j)) + kEpsilon;
+    }
+  }
+
+  // First category of cases separating along a's axes.
+  for (int i = 0; i < 3; ++i) {
+    if (abs(t[i]) > half_size_a[i] + half_size_b.dot(abs_r.block<1, 3>(i, 0))) {
+      return false;
+    }
+  }
+
+  // Second category of cases separating along b's axes.
+  for (int i = 0; i < 3; ++i) {
+    if (abs(t.dot(r.block<3, 1>(0, i))) >
+        half_size_b[i] + half_size_a.dot(abs_r.block<3, 1>(0, i))) {
+      return false;
+    }
+  }
+
+  // Third category of cases separating along the axes formed from the cross
+  // products of a's and b's axes.
+  int i1 = 1;
+  for (int i = 0; i < 3; ++i) {
+    const int i2 = (i1 + 1) % 3;  // Calculate common sub expressions.
+    int j1 = 1;
+    for (int j = 0; j < 3; ++j) {
+      const int j2 = (j1 + 1) % 3;
+      if (abs(t[i2] * r(i1, j) - t[i1] * r(i2, j)) >
+          half_size_a[i1] * abs_r(i2, j) + half_size_a[i2] * abs_r(i1, j) +
+              half_size_b[j1] * abs_r(i, j2) + half_size_b[j2] * abs_r(i, j1)) {
+        return false;
+      }
+      j1 = j2;
+    }
+    i1 = i2;
+  }
+
+  return true;
+}
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/boxes_overlap.h
+++ b/geometry/proximity/boxes_overlap.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "drake/common/eigen_types.h"
+#include "drake/math/rigid_transform.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+/* Helper function for detecting overlap between two boxes A and B. Each box is
+ defined in its own canonical frame. The box is aligned with the frame and
+ described by a vector describing its "half size" (half its extent along each of
+ its frame's axes). Another way to think about the half size is that it's the
+ position vector from the box's center to its most positive corner (expressed
+ in the box's canonical frame).
+
+ @param half_size_a   The half size of box A expressed in A's canonical frame.
+ @param half_size_b   The half size of box B expressed in B's canonical frame.
+ @param X_AB          The relative pose between boxes A and B. */
+bool BoxesOverlap(const Vector3<double>& half_size_a,
+                  const Vector3<double>& half_size_b,
+                  const math::RigidTransformd& X_AB);
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/obb.h
+++ b/geometry/proximity/obb.h
@@ -15,6 +15,9 @@ namespace drake {
 namespace geometry {
 namespace internal {
 
+// Forward declarations.
+class Aabb;
+
 /* Oriented bounding box used in Bvh. The box is defined in a canonical
  frame B such that it is centered on Bo and its extents are aligned with
  B's axes. However, the box is posed in a hierarchical frame H (see pose()).
@@ -70,11 +73,28 @@ class Obb {
     return half_width_[0] * half_width_[1] * half_width_[2] * 8;
   }
 
-  /* Checks whether the two bounding volumes `a` and `b` overlap by applying
-   transforms between frames of boxes and hierarchies and using Gottschalk's
-   OBB overlap test. Box `a` has its frame A posed in hierarchy frame G, and
-   box `b` has its frame B posed in hierarchy frame H. */
+  /* Reports whether the two oriented bounding boxes `a_G` and `b_H` intersect.
+   The poses of `a_G` and `b_H` are defined in their corresponding hierarchy
+   frames G and H, respectively.
+
+   @param a_G       The first oriented box.
+   @param b_H       The second oriented box.
+   @param X_GH      The relative pose between hierarchy frame G and hierarchy
+                    frame H.
+   @returns `true` if the boxes intersect.   */
   static bool HasOverlap(const Obb& a_G, const Obb& b_H,
+                         const math::RigidTransformd& X_GH);
+
+  /* Reports whether oriented bounding box `obb_G` intersects the given
+   axis-aligned bounding box `aabb_H`. The poses of `obb_G` and `aabb_H` are
+   defined in their corresponding hierarchy frames G and H, respectively.
+
+   @param obb_G     The oriented box.
+   @param aabb_H    The axis-aligned box.
+   @param X_GH      The relative pose between the obb hierarchy frame G and the
+                    aabb hierarchy frame H.
+   @returns `true` if the boxes intersect.   */
+  static bool HasOverlap(const Obb& obb_G, const Aabb& aabb_H,
                          const math::RigidTransformd& X_GH);
 
   /* Checks whether bounding volume `bv` intersects the given plane. The
@@ -170,7 +190,7 @@ class ObbMaker {
   }
 
   /* Computes the bounding volume of the vertices specified in the constructor.
-   @return obb_M   The oriented bounding box posed in frame M.  */
+   @retval obb_M   The oriented bounding box posed in frame M.  */
   Obb Compute() const;
 
  private:

--- a/geometry/proximity/test/aabb_test.cc
+++ b/geometry/proximity/test/aabb_test.cc
@@ -1,0 +1,237 @@
+#include "drake/geometry/proximity/aabb.h"
+
+#include <limits>
+#include <set>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/geometry/proximity/obb.h"
+#include "drake/geometry/proximity/surface_mesh.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+using Eigen::AngleAxisd;
+using Eigen::Vector3d;
+using math::RigidTransformd;
+using math::RotationMatrixd;
+using std::set;
+using std::vector;
+
+namespace {
+
+/* This tests the constructor and that the expected values get to the expected
+ fields. */
+GTEST_TEST(AabbTest, Construction) {
+  const Vector3d p_HB{1, 2, 3};
+  const Vector3d half_size{0.75, 0.875, 1.25};
+  const double expected_volume =
+      2 * half_size.x() * 2 * half_size.y() * 2 * half_size.z();
+
+  const Aabb aabb(p_HB, half_size);
+
+  EXPECT_TRUE(CompareMatrices(aabb.center(), p_HB));
+  EXPECT_TRUE(CompareMatrices(aabb.half_width(), half_size));
+  EXPECT_EQ(aabb.CalcVolume(), expected_volume);
+  EXPECT_TRUE(CompareMatrices(aabb.lower(), p_HB - half_size));
+  EXPECT_TRUE(CompareMatrices(aabb.upper(), p_HB + half_size));
+
+  EXPECT_TRUE(aabb.pose().rotation().IsExactlyIdentity());
+  EXPECT_TRUE(CompareMatrices(aabb.pose().translation(), p_HB));
+}
+
+/* This tests the overlap query for aabb-aabb and aabb-obb. We rely on the
+ tests in obb_test.cc to generally cover the underlying Gottschalk algorithm.
+ It's enough test to cover colliding/non-colliding cases. */
+GTEST_TEST(AabbTest, BoxOverlap) {
+  /* Methodology:
+    - Define two boxes that are definitely overlapping.
+      - in a common frame, move them in opposite directions along the x-axis
+        so they are just in contact.
+      - Introduce two arbitrary *hierarchy* frames and define Aabb/Obb such
+        that in the *world* frame, they are in the expected position (and
+        orientation). */
+  /* The half measures of the two boxes. */
+  const Vector3d half_sizeA{0.5, 0.75, 0.125};
+  const Vector3d half_sizeB{0.3, 0.6, 0.45};
+
+  /* Produce a pair of poses such that the boxes near the origin overlap for
+   distance < 0. */
+  auto world_poses = [&half_sizeA, &half_sizeB](double distance) {
+    const double half_distance = distance / 2;
+    RigidTransformd X_WA{Vector3d{-half_sizeA.x() - half_distance, 0, 0}};
+    RigidTransformd X_WB{Vector3d{half_sizeB.x() + half_distance, 0, 0}};
+    return std::make_pair(X_WA, X_WB);
+  };
+
+  for (double distance : {-0.001, 0.001}) {
+    const auto [X_WA, X_WB] = world_poses(distance);
+    const bool expect_overlap = distance < 0;
+
+    SCOPED_TRACE(fmt::format("distance = {}", distance));
+
+    /* Quick reality check -- the two boxes, in their common frame overlap. */
+    EXPECT_EQ(Aabb::HasOverlap(Aabb(X_WA.translation(), half_sizeA),
+                               Aabb(X_WB.translation(), half_sizeB),
+                               RigidTransformd::Identity()),
+              expect_overlap);
+
+    {
+      /* Two Aabb, but with more interesting frames. We'll define Frames G and H
+       arbitrarily but satisfy the constraint that the final box poses are X_WA
+       and X_WB, i.e., we require R_GA = R_HB = I for Aabbs. */
+      const RigidTransformd X_GA{Vector3d{-0.5, 3, 1.5}};
+      const RigidTransformd X_WG = X_WA * X_GA.inverse();
+      const RigidTransformd X_HB{Vector3d{-1, 1, -1}};
+      const RigidTransformd X_WH = X_WB * X_HB.inverse();
+
+      const Aabb aabbA_G(X_GA.translation(), half_sizeA);
+      const Aabb aabbB_H(X_HB.translation(), half_sizeB);
+      const RigidTransformd X_GH = X_WG.inverse() * X_WH;
+
+      EXPECT_EQ(Aabb::HasOverlap(aabbA_G, aabbB_H, X_GH), expect_overlap);
+    }
+
+    {
+      /* Box B is now an Obb so R_HB = I is no longer a requirement. */
+      const RigidTransformd X_GA{Vector3d{-0.5, 3, 1.5}};
+      const RigidTransformd X_WG = X_WA * X_GA.inverse();
+      const RigidTransformd X_HB{
+          AngleAxisd{M_PI / 7, Vector3d{1, -2, 3}.normalized()},
+          Vector3d{-1, 1, -1}};
+      const RigidTransformd X_WH = X_WB * X_HB.inverse();
+
+      const Aabb aabbA_G(X_GA.translation(), half_sizeA);
+      const Obb obbB_H(X_HB, half_sizeB);
+      const RigidTransformd X_GH = X_WG.inverse() * X_WH;
+
+      EXPECT_EQ(Aabb::HasOverlap(aabbA_G, obbB_H, X_GH), expect_overlap);
+    }
+  }
+}
+
+GTEST_TEST(AabbTest, TestEqual) {
+  const Vector3d p_HB{0.5, 0.25, -0.75};
+  const Vector3d half_size{1, 2, 3};
+  const Aabb a{p_HB, half_size};
+  /* Equal to itself.  */
+  EXPECT_TRUE(a.Equal(a));
+  /* Different pose.  */
+  const Aabb b{p_HB * 1.1, half_size};
+  EXPECT_FALSE(a.Equal(b));
+  /* Different half_width.  */
+  const Aabb c{p_HB, half_size * 1.1};
+  EXPECT_FALSE(a.Equal(c));
+  /* Same values, different instances.  */
+  const Aabb d{p_HB, half_size};
+  EXPECT_TRUE(a.Equal(d));
+  /* It is *exactly* equals; epsilon is insufficient.  */
+  constexpr double kEps = std::numeric_limits<double>::epsilon();
+  const Aabb e(p_HB + Vector3d(kEps, 0, 0), half_size);
+  EXPECT_FALSE(a.Equal(e));
+}
+
+/* Confirm that the AabbMaker successfully makes the expected bounding boxes.
+ We'll do this by creating a fake mesh with carefully curated vertices (the
+ elements of the mesh will be garbage). Then we'll successively build Aabb
+ instances from subsets of the vertices. */
+GTEST_TEST(AabbMakerTest, Compute) {
+  using Vertex = SurfaceVertex<double>;
+  using VIndex = SurfaceVertexIndex;
+
+  /* The vertices are all located at box corners.
+
+        V₃--------------V₇
+       / |             / |
+      /  |            /  |      z   y
+     /   |           /   |      | /
+   V₁--------------V₅    |      |/
+   |     |         |     |      o-------x
+   |    V₂---------|----V₆
+   |   /           |   /
+   |  /            |  /
+   | /             | /
+   V₀--------------V₄
+   */
+  const Vector3d half_size{0.5, 1.5, 1.25};
+  vector<Vertex> vertices;
+  for (double x : {-1, 1}) {
+    for (double y : {-1, 1}) {
+      for (double z : {-1, 1}) {
+        vertices.emplace_back(Vector3d{x, y, z}.cwiseProduct(half_size));
+      }
+    }
+  }
+  vector<SurfaceFace> faces{{SurfaceFace{VIndex(0), VIndex(1), VIndex(2)}}};
+  SurfaceMesh<double> mesh{std::move(faces), std::move(vertices)};
+
+  ASSERT_EQ(mesh.num_vertices(), 8);
+
+  const VIndex v0(0);
+  const VIndex v3(3);
+  const VIndex v4(4);
+  const VIndex v7(7);
+  {
+    /* Case: single vertex. */
+    const set<VIndex> fit_vertices = {VIndex(0)};
+    const Aabb::Maker<SurfaceMesh<double>> maker(mesh, fit_vertices);
+    const Aabb aabb = maker.Compute();
+    EXPECT_TRUE(CompareMatrices(aabb.center(), mesh.vertex(VIndex(0)).r_MV()));
+    EXPECT_TRUE(CompareMatrices(aabb.half_width(), Vector3d::Zero()));
+  }
+
+  {
+    /* Case: Two vertices forming an axis-aligned edge. */
+    const set<VIndex> fit_vertices = {VIndex(3), VIndex(7)};
+    const Aabb::Maker<SurfaceMesh<double>> maker(mesh, fit_vertices);
+    const Aabb aabb = maker.Compute();
+    EXPECT_TRUE(CompareMatrices(aabb.center(),
+                                Vector3d{0, 1, 1}.cwiseProduct(half_size)));
+    EXPECT_TRUE(CompareMatrices(aabb.half_width(),
+                                Vector3d{1, 0, 0}.cwiseProduct(half_size)));
+  }
+
+  {
+    /* Case: Two vertices lying completely on a plane. */
+    const set<VIndex> fit_vertices = {VIndex(4), VIndex(7)};
+    const Aabb::Maker<SurfaceMesh<double>> maker(mesh, fit_vertices);
+    const Aabb aabb = maker.Compute();
+    EXPECT_TRUE(CompareMatrices(aabb.center(),
+                                Vector3d{1, 0, 0}.cwiseProduct(half_size)));
+    EXPECT_TRUE(CompareMatrices(aabb.half_width(),
+                                Vector3d{0, 1, 1}.cwiseProduct(half_size)));
+  }
+
+  {
+    /* Case: Two vertices lying diagonally across the box. */
+    const set<VIndex> fit_vertices = {VIndex(3), VIndex(4)};
+    const Aabb::Maker<SurfaceMesh<double>> maker(mesh, fit_vertices);
+    const Aabb aabb = maker.Compute();
+    EXPECT_TRUE(CompareMatrices(aabb.center(), Vector3d::Zero()));
+    EXPECT_TRUE(CompareMatrices(aabb.half_width(), half_size));
+  }
+
+  {
+    /* Case: Once I have the minimum support for the full box (e.g., vertices
+     3 and 4), adding other vertices will not change the outcome. */
+    const set<VIndex> base_set = {VIndex(3), VIndex(4)};
+    for (VIndex v :
+         {VIndex(0), VIndex(1), VIndex(2), VIndex(5), VIndex(6), VIndex(7)}) {
+      set<VIndex> fit_vertices(base_set);
+      fit_vertices.emplace(v);
+      const Aabb::Maker<SurfaceMesh<double>> maker(mesh, fit_vertices);
+      const Aabb aabb = maker.Compute();
+      EXPECT_TRUE(CompareMatrices(aabb.center(), Vector3d::Zero()));
+      EXPECT_TRUE(CompareMatrices(aabb.half_width(), half_size));
+    }
+  }
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
1. Moves the Gottschalk box-overlap test *out* of `Obb` and into its own file. This is *just* movement, no changes in implementation.
   - Note, we're still using the `Obb` tests to test this code.
2. Adds the `Aabb` bounding volume class.
3. Add overlap tests between `Aabb` and `Obb`.
4. In build, roll the bounding volumes into a single build target to mitigate interdependencies.

Relates #15080

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15058)
<!-- Reviewable:end -->
