### PR TITLE
Repair typos.

### DIFF
--- a/geometry/proximity/surface_mesh.h
+++ b/geometry/proximity/surface_mesh.h
@@ -153,7 +153,7 @@ class SurfaceMesh {
   //    SurfaceMesh<double>::Barycentric<double>
   //    SurfaceMesh<AutoDiffXd>::Barycentric<double>
   // But, ultimately both become Vector3d and, because they are simply aliases,
-  // are interchangable. It would be nice to have some way of formulating this
+  // are interchangeable. It would be nice to have some way of formulating this
   // that *doesn't* imply dependency on the scalar type of SurfaceMesh.
   /**
    Type of barycentric coordinates on a triangular element. Barycentric

--- a/geometry/proximity/test/plane_test.cc
+++ b/geometry/proximity/test/plane_test.cc
@@ -96,7 +96,7 @@ GTEST_TEST(PlaneTest, CalcHeight) {
 
 // Confirm that mixed-scalar computation "works". In the case of this test,
 // "works" means that the query point scalar type and plane scalar types are
-// indpendent, the return type is the promoted type, and derivatives propagate
+// independent, the return type is the promoted type, and derivatives propagate
 // through.
 GTEST_TEST(PlaneTest, MixedScalar) {
   // Arbitrary Normal and origins.

--- a/geometry/proximity/volume_mesh.h
+++ b/geometry/proximity/volume_mesh.h
@@ -170,7 +170,7 @@ class VolumeMesh {
   //    VolumeMesh<double>::Barycentric<double>
   //    VolumeMesh<AutoDiffXd>::Barycentric<double>
   // But, ultimately both become Vector4d and, because they are simply aliases,
-  // are interchangable. It would be nice to have some way of formulating this
+  // are interchangeable. It would be nice to have some way of formulating this
   // that *doesn't* imply dependency on the scalar type of VolumeMesh.
   /** Type of barycentric coordinates on a tetrahedral element. Barycentric
    coordinates (b₀, b₁, b₂, b₃) satisfy b₀ + b₁ + b₂ + b₃ = 1. It corresponds

--- a/lcm/drake_lcm_interface.h
+++ b/lcm/drake_lcm_interface.h
@@ -151,7 +151,7 @@ class DrakeSubscriptionInterface {
   virtual void set_unsubscribe_on_delete(bool enabled) = 0;
 
   /**
-   * Sets this subscription's queue depth to store messages inbetween calls to
+   * Sets this subscription's queue depth to store messages between calls to
    * DrakeLcmInterface::HandleSubscriptions.  When the queue becomes full, new
    * received messages will be discarded.  The default depth is 1.
    *

--- a/multibody/contact_solvers/pgs_solver.h
+++ b/multibody/contact_solvers/pgs_solver.h
@@ -9,7 +9,7 @@ namespace contact_solvers {
 namespace internal {
 
 struct PgsSolverParameters {
-  // Over-relaxation paramter, in (0, 1]
+  // Over-relaxation parameter, in (0, 1]
   double omega{1};
   // Absolute contact velocity tolerance, m/s. See VerifyConvergenceCriteria().
   double abs_tolerance{1.0e-4};

--- a/multibody/fixed_fem/dev/damping_model.h
+++ b/multibody/fixed_fem/dev/damping_model.h
@@ -6,7 +6,7 @@ namespace fixed_fem {
 /** A simple viscous Rayleigh damping model. The resulting damping matrix is a
 nonnegative linear combination of mass and stiffness matrices. Namely, D = αM +
 βK where α and β are nonnegative. The damping ratio ξ for a given frequency of
-the mode of vibration ω can be calculated by (α/ω + βω)/2. Noticably, the
+the mode of vibration ω can be calculated by (α/ω + βω)/2. Noticeably, the
 contribution by the stiffness term βK is proportional to the frequency of the
 mode while the damping ratio contributed by the mass term αM is inversely
 proportional to the frequency. Furthermore, one should note that the mass

--- a/multibody/fixed_fem/dev/deformable_visualizer.h
+++ b/multibody/fixed_fem/dev/deformable_visualizer.h
@@ -53,7 +53,7 @@ class DeformableVisualizer : public systems::LeafSystem<double> {
       lcm::DrakeLcmInterface* lcm = nullptr);
 
   // TODO(xuchenhan-tri): Rethink the initialization/update paradigm as the
-  //  intialization event may be received after update events.
+  //  initialization event may be received after update events.
   /** Send the mesh initialization message. This can be invoked explicitly but
    is generally not necessary. The initialization method is also called by
    an initialization event.  */

--- a/multibody/fixed_fem/dev/test/fem_state_test.cc
+++ b/multibody/fixed_fem/dev/test/fem_state_test.cc
@@ -107,7 +107,7 @@ TEST_F(FemStateTest, MakeElementData) {
 /* Tests that element data cache is invalidated when the state changes and that
  the request for the cached data triggers appropriate recalculations. */
 TEST_F(FemStateTest, ElementCache) {
-  /* Verify that cache entries are intially invalid and becomes valid after the
+  /* Verify that cache entries are initially invalid and becomes valid after the
    request for data triggers computation. */
   VerifyCacheEntries();
 

--- a/multibody/parsing/test/process_model_directives_test/add_scoped_mid.yaml
+++ b/multibody/parsing/test/process_model_directives_test/add_scoped_mid.yaml
@@ -1,6 +1,6 @@
 # The trio of `add_scoped_*.yaml` files are a test yaml structure that uses
 # each feature of the model directives system.  This file is the middle level
-# of a three-file inclusion hierarcy of model directives, and is also used as
+# of a three-file inclusion hierarchy of model directives, and is also used as
 # a smoke test of the inclusion mechanism.
 
 directives:

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1591,7 +1591,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 #endif
 
   // TODO(amcastro-tri): per work in #13064, we should reconsider whether to
-  // deprecate/remove this method alltogether or at least promote to proper
+  // deprecate/remove this method altogether or at least promote to proper
   // camel case per GSG.
   /// Sets the penetration allowance used to estimate the coefficients in the
   /// penalty method used to impose non-penetration among bodies. Refer to the
@@ -2457,7 +2457,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   ///   model_instances or 0 if model_instances is empty.
   /// @note The mass of the world_body() does not contribute to the total mass
   ///   and each body only contributes to the total mass once, even if the body
-  ///   has repeated occurence (instance) in model_instances.
+  ///   has repeated occurrence (instance) in model_instances.
   T CalcTotalMass(
       const systems::Context<T>& context,
       const std::vector<ModelInstanceIndex>& model_instances) const {

--- a/multibody/tree/joint_actuator.h
+++ b/multibody/tree/joint_actuator.h
@@ -308,7 +308,7 @@ class JointActuator final
 
   // The gear ratio between this actuator's rotor and output shaft. The default
   // value is set to 1.0 to allow convenient sysId by just varying the single
-  // rotor inertia paramter.
+  // rotor inertia parameter.
   double default_gear_ratio_{1.0};
 
   // System parameter index for `this` actuator's rotor inertia stored in a

--- a/multibody/tree/multibody_tree_system.h
+++ b/multibody/tree/multibody_tree_system.h
@@ -444,7 +444,7 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
   }
 
   // This method is called during Finalize(). It tells each MultibodyElement
-  // owned by `this` system to declare their system paramters on `this`.
+  // owned by `this` system to declare their system parameters on `this`.
   void DeclareMultibodyElementParameters();
 
   // Allow different specializations to access each other's private data for

--- a/multibody/tree/test/linear_bushing_roll_pitch_yaw_test.cc
+++ b/multibody/tree/test/linear_bushing_roll_pitch_yaw_test.cc
@@ -767,7 +767,7 @@ GTEST_TEST(LinearBushingRollPitchYawTest, BushingParameters) {
   bushing.SetForceStiffnessConstants(context.get(), new_force_stiffness);
   bushing.SetForceDampingConstants(context.get(), new_force_damping);
 
-  // Verify parameter changes propogate.
+  // Verify parameter changes propagate.
   const Vector3<double> new_default_torque_stiffness =
       bushing.GetTorqueStiffnessConstants(*context);
   const Vector3<double> new_default_torque_damping =

--- a/solvers/mosek_solver.cc
+++ b/solvers/mosek_solver.cc
@@ -1543,7 +1543,7 @@ MSKrescodee SetDualSolution(
     // Mosek dual variables for variable lower bounds (slx) and upper bounds
     // (sux). Refer to
     // https://docs.mosek.com/9.2/capi/alphabetic-functionalities.html#mosek.task.getsolution
-    // for more explaination.
+    // for more explanation.
     std::vector<MSKrealt> slx(num_mosek_vars);
     std::vector<MSKrealt> sux(num_mosek_vars);
     rescode = MSK_getslx(task, which_sol, slx.data());
@@ -1562,7 +1562,7 @@ MSKrescodee SetDualSolution(
     // Mosek dual variables for linear constraints lower bounds (slc) and upper
     // bounds (suc). Refer to
     // https://docs.mosek.com/9.2/capi/alphabetic-functionalities.html#mosek.task.getsolution
-    // for more explaination.
+    // for more explanation.
     std::vector<MSKrealt> slc(num_linear_constraints);
     std::vector<MSKrealt> suc(num_linear_constraints);
     rescode = MSK_getslc(task, which_sol, slc.data());

--- a/tools/install/install_test_helper.py
+++ b/tools/install/install_test_helper.py
@@ -73,7 +73,7 @@ def get_python_executable():
 
     Call python3.9 on macOS to force using the Python executable from the
     python@3.9 formula. Calling a different Python executable would result in a
-    crash since pydrake was not built agains the Python library corresponding
+    crash since pydrake was not built against the Python library corresponding
     to that executable. On other systems, it will just fall back to the current
     Python executable.
     """

--- a/tutorials/debug_mathematical_program.ipynb
+++ b/tutorials/debug_mathematical_program.ipynb
@@ -20,7 +20,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "After constructing and solving an optimization problem through Drake's `MathematicalProgram` interface, you might not get the desired results. For example, you might expect the problem to have a solution, while `MathematicalProgram` reports that the problem is not solved succesfully. In this tutorial we provide some tips to debug `MathematicalProgram` when it doesn't behave desirably.\n",
+    "After constructing and solving an optimization problem through Drake's `MathematicalProgram` interface, you might not get the desired results. For example, you might expect the problem to have a solution, while `MathematicalProgram` reports that the problem is not solved successfully. In this tutorial we provide some tips to debug `MathematicalProgram` when it doesn't behave desirably.\n",
     "\n",
     "First you should understand whether the optimization problem is convex or not. For a convex problem (like LP, QP, SDP), when the problem is feasible, then theoretically the solver should always find a solution; on the other hand if the problem is non-convex and solved through gradient-based solvers (like SNOPT/IPOPT), then the solver might fail to terminate at a feasible solution even if one exists. When the gradient-based solver (like SNOPT/IPOPT) reports the problem being infeasible, it only means that the solver gets stuck at an infeasible value, and it doesn't know how to reduce the infeasibility in the local neighbourhood. A solution could exist far away from where the solver gets stuck, but the solver is trapped and can't jump to the distant solution. One possible solution is to choose a different initial guess of the optimization program.\n",
     "\n",


### PR DESCRIPTION
These were found with `codespell`:
    
 $ apt install codespell
 $ codespell -wi3
    
A few false positives (binary files, identifiers that look like words) were
skipped.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15063)
<!-- Reviewable:end -->
