### PR TITLE
geometry: Fix set of installed headers to be consistent

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -73,6 +73,11 @@ drake_cc_library(
 drake_cc_library(
     name = "collision_filter_legacy",
     hdrs = ["collision_filter_legacy.h"],
+    install_hdrs_exclude = [
+        # This header includes proximity_utilities.h which itself is
+        # marked as install_hdrs_exclude, so we need to do the same.
+        "collision_filter_legacy.h",
+    ],
     deps = [
         ":proximity_utilities",
         "//common:essential",
@@ -222,6 +227,11 @@ drake_cc_library(
 drake_cc_library(
     name = "make_box_field",
     hdrs = ["make_box_field.h"],
+    install_hdrs_exclude = [
+        # This header includes distance_to_point_callback.h which itself is
+        # marked as install_hdrs_exclude, so we need to do the same.
+        "make_box_field.h",
+    ],
     deps = [
         ":distance_to_point_callback",
         ":mesh_field",
@@ -247,6 +257,11 @@ drake_cc_library(
 drake_cc_library(
     name = "make_cylinder_field",
     hdrs = ["make_cylinder_field.h"],
+    install_hdrs_exclude = [
+        # This header includes distance_to_point_callback.h which itself is
+        # marked as install_hdrs_exclude, so we need to do the same.
+        "make_cylinder_field.h",
+    ],
     deps = [
         ":distance_to_point_callback",
         ":mesh_field",


### PR DESCRIPTION
The installed headers are parsed by mkdoc to create pydrake docstrings.

When mkdoc scans an installed header that includes an uninstalled header, it results in a build failure, so we must be careful to only install headers that can be parsed.  This is also cleaner for our users.

This ends up being a blocker for the bazel 4.1 upgrade.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15066)
<!-- Reviewable:end -->
