### PR TITLE
LeafSystem: remove allocations during simulation

### DIFF
--- a/systems/analysis/test/simulator_limit_malloc_test.cc
+++ b/systems/analysis/test/simulator_limit_malloc_test.cc
@@ -76,7 +76,7 @@ GTEST_TEST(SimulatorLimitMallocTest,
     // heap-free simulation after initialization, given careful system
     // construction.
     // TODO(rpoyner-tri): whittle allocations down to 0.
-    test::LimitMalloc heap_alloc_checker({.max_num_allocations = 84});
+    test::LimitMalloc heap_alloc_checker({.max_num_allocations = 63});
     simulator.AdvanceTo(1.0);
     simulator.AdvanceTo(2.0);
     simulator.AdvanceTo(3.0);

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -2108,6 +2108,11 @@ class LeafSystem : public System<T> {
 
   // Model abstract parameters to be used during Context allocation.
   internal::ModelValues model_abstract_parameters_;
+
+  // The index of a cache entry that stores a vector of event pointers for use
+  // in managing events. It is only used in DoCalcNextUpdateTime(), but is
+  // allocated as a cache entry to avoid heap operations during simulation.
+  CacheIndex next_events_cache_index_{};
 };
 
 }  // namespace systems


### PR DESCRIPTION
Relevant to: #14543

Replace a function-scoped vector with a cache entry. Decline all
invalidation services and use manual methods to ensure no data migrates
between uses.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15067)
<!-- Reviewable:end -->
