### PR TITLE
pydrake: Remove spurious documentation header dependencies

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -65,13 +65,6 @@ generate_pybind_documentation_header(
     root_name = "pydrake_doc",
     targets = [
         "//tools/install/libdrake:drake_headers",
-        "//examples/compass_gait:compass_gait",
-        "//examples/manipulation_station:manipulation_station",
-        "//examples/manipulation_station:manipulation_station_hardware_interface",  # noqa
-        "//examples/pendulum:pendulum_plant",
-        "//examples/quadrotor:quadrotor_plant",
-        "//examples/rimless_wheel:rimless_wheel",
-        "//examples/van_der_pol:van_der_pol",
     ],
 )
 


### PR DESCRIPTION
These were added in #9603 at a time when our pydrake linking was broken.  We were linking the examples' libraries outside of libdrake.so, so their headers were not part of libdrake's headers, so for mkdoc to find them we needed to list them here individually.

Now that we link the examples correctly (i.e., directly into libdrake.so; see #9826), we no longer need to feed the redundant dependencies to mkdoc.

As of Bazel 4.1.0, the redundant headers actually break mkdoc, because we try to add these headers twice, with the second path spelling not matching any valid include path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15068)
<!-- Reviewable:end -->
