### PR TITLE
Add AVX support for inverse-rotation matrix times rotation matrix.

### DIFF
--- a/math/fast_pose_composition_functions.cc
+++ b/math/fast_pose_composition_functions.cc
@@ -1,6 +1,7 @@
 #include "drake/math/fast_pose_composition_functions.h"
 
 #include <algorithm>
+#include <cassert>
 
 #if defined(__AVX2__) && defined(__FMA__)
 #include <cstdint>
@@ -8,31 +9,53 @@
 #include <immintrin.h>
 #endif
 
+/* Note that we do not include code from drake/common here so that we don't
+have to fight with Eigen regarding the enabling of AVX instructions. */
+
 namespace drake {
 namespace math {
+namespace internal {
 
 /* The portable C++ versions are always defined. They should be written
 to maximize the chance that a dumb compiler can generate fast code.
-
+ 
 The AVX functions are optionally defined depending on the compiler flags used
 for this compilation unit. If defined, the no-suffix, publicly-visible functions
 like ComposeRR() are implemented with the "...Avx" methods, otherwise with the
 "...Portable" methods.
-
+ 
 The AVX functions are strictly local to this file, but the portable ones are
 placed in namespace internal so that they can be unit tested regardless of
 whether they are used on this platform to implement the publicly-visible
 functions.
-
+ 
 Note that, except when explicitly marked "...NoAlias", the methods below must
 allow for the output argument's memory to overlap with any of the input
-arguments' memory. */
+arguments' memory.
+
+We make judicious use below of potentially-dangerous reinterpret_casts to
+convert from user-friendly APIs written in terms of RotationMatrix& and
+RigidTransform& (whose declarations are necessarily unknown here) to
+implementation-friendly double* types. Why this is safe here:
+  - our implementations of these classes guarantee a particular memory
+    layout on which we can depend,
+  - the address of a class is the address of its first member (mandated by
+    the standard), and
+  - reinterpret_cast of a pointer to another pointer type and back yields the
+    same pointer, i.e. the bit pattern does not change.
+ */
 
 namespace {
 /* Dot product of a row of l and a column of m, where both l and m are 3x3s
 in column order. */
 double row_x_col(const double* l, const double* m) {
   return l[0] * m[0] + l[3] * m[1] + l[6] * m[2];
+}
+
+/* Dot product of a column of l and a column of m, where both l and m are 3x3s
+in column order. */
+double col_x_col(const double* l, const double* m) {
+  return l[0] * m[0] + l[1] * m[1] + l[2] * m[2];
 }
 
 /* @pre R_AC is disjoint in memory from the inputs. */
@@ -47,19 +70,49 @@ void ComposeRRNoAlias(const double* R_AB, const double* R_BC, double* R_AC) {
   R_AC[7] = row_x_col(&R_AB[1], &R_BC[6]);
   R_AC[8] = row_x_col(&R_AB[2], &R_BC[6]);
 }
-}  // namespace
 
-namespace internal {
+/* @pre R_AC is disjoint in memory from the inputs. */
+void ComposeRinvRNoAlias(const double* R_BA, const double* R_BC, double* R_AC) {
+  R_AC[0] = col_x_col(&R_BA[0], &R_BC[0]);
+  R_AC[1] = col_x_col(&R_BA[3], &R_BC[0]);
+  R_AC[2] = col_x_col(&R_BA[6], &R_BC[0]);
+  R_AC[3] = col_x_col(&R_BA[0], &R_BC[3]);
+  R_AC[4] = col_x_col(&R_BA[3], &R_BC[3]);
+  R_AC[5] = col_x_col(&R_BA[6], &R_BC[3]);
+  R_AC[6] = col_x_col(&R_BA[0], &R_BC[6]);
+  R_AC[7] = col_x_col(&R_BA[3], &R_BC[6]);
+  R_AC[8] = col_x_col(&R_BA[6], &R_BC[6]);
+}
+}  // namespace
 
 /* Composition of rotation matrices R_AC = R_AB * R_BC. Each matrix is 9
 consecutive doubles in column order. */
-void ComposeRRPortable(const double* R_AB, const double* R_BC, double* R_AC) {
+void ComposeRRPortable(const RotationMatrix<double>& R_AB,
+                       const RotationMatrix<double>& R_BC,
+                       RotationMatrix<double>* R_AC) {
+  assert(R_AC != nullptr);
   double R_AC_temp[9];  // Protect from overlap with inputs.
-  ComposeRRNoAlias(R_AB, R_BC, R_AC_temp);
-  std::copy(R_AC_temp, R_AC_temp + 9, R_AC);
+  // See note above as to why these reinterpret_casts are safe.
+  ComposeRRNoAlias(reinterpret_cast<const double*>(&R_AB),
+                   reinterpret_cast<const double*>(&R_BC), R_AC_temp);
+  std::copy(R_AC_temp, R_AC_temp + 9, reinterpret_cast<double*>(R_AC));
 }
 
-}  // namespace internal
+/* Composition of rotation matrices R_AC = R_BA⁻¹ * R_BC. Each matrix is 9
+consecutive doubles in column order (the inverse can be viewed as the same
+matrix in row order). */
+void ComposeRinvRPortable(const RotationMatrix<double>& R_BA,
+                          const RotationMatrix<double>& R_BC,
+                          RotationMatrix<double>* R_AC) {
+  assert(R_AC != nullptr);
+  double R_AC_temp[9];  // Protect from overlap with inputs.
+  // See note above as to why these reinterpret_casts are safe.
+  ComposeRinvRNoAlias(reinterpret_cast<const double*>(&R_BA),
+                      reinterpret_cast<const double*>(&R_BC), R_AC_temp);
+  std::copy(R_AC_temp, R_AC_temp + 9, reinterpret_cast<double*>(R_AC));
+}
+
+// TODO(sherm1) ComposeXXPortable() and ComposeXinvXPortable().
 
 #if defined(__AVX2__) && defined(__FMA__)
 
@@ -93,8 +146,8 @@ store past the last element.
 This requires 45 flops (9 dot products) but we're doing 60 here and throwing
 away 15 of them. However, we only issue 9 floating point instructions. */
 void ComposeRRAvx(const double* R_AB, const double* R_BC, double* R_AC) {
-  constexpr int64_t yes = int64_t(1) << 63;
-  constexpr int64_t no  = int64_t(0);
+  constexpr uint64_t yes = uint64_t(1ull << 63);
+  constexpr uint64_t no  = uint64_t(0);
   const __m256i mask = _mm256_setr_epi64x(yes, yes, yes, no);
 
   // Aliases for readability (named after first entries in comment above).
@@ -131,23 +184,132 @@ void ComposeRRAvx(const double* R_AB, const double* R_BC, double* R_AC) {
   // The compiler will generate a vzeroupper instruction if needed.
 }
 
+/* Composition of rotation matrices R_AC = R_BA⁻¹ * R_BC.
+Each matrix is 9 consecutive doubles in column order.
+
+We want to perform this 3x3 matrix multiply:
+
+     R_AC    R_BA⁻¹  R_BC
+
+    r u x   a b c   A D G
+    s v y = d e f * B E H     R_BA⁻¹ is row ordered; R_BC col ordered
+    t w z   g h i   C F I
+
+This is 45 flops altogether.
+
+Strategy: compute column rst in parallel, then uvw, then xyz.
+r = aA+bB+cC
+s = dA+eB+fC  etc.
+t = gA+hB+iC
+
+Load columns from left matrix, duplicate elements from right. (Tricky here since
+the inverse is row ordered -- we pull in the rows and then shuffle things.)
+Peform 4 operations in parallel but ignore the 4th result. Be careful not to
+load or store past the last element.
+
+We end up doing 3*4 + 6*8 = 60 flops to get 45 useful ones. However, we do that
+in only 9 floating point instructions (3 packed multiplies, 6 packed
+fused-multiply-adds).
+
+It is OK if the result R_AC overlaps one or both of the inputs. */
+void ComposeRinvRAvx(const double* R_BA, const double* R_BC, double* R_AC) {
+  constexpr uint64_t yes = uint64_t(1ull << 63);
+  constexpr uint64_t no  = uint64_t(0);
+  const __m256i mask = _mm256_setr_epi64x(yes, yes, yes, no);
+
+  // Aliases for readability (named after first entries in comment above).
+  const double* a = R_BA; const double* A = R_BC; double* r = R_AC;
+
+  __m256d a0, a1, a2;  // Accumulators.
+
+  // Load columns of R_AB (rows of the given R_BA) into registers via a
+  // series of loads, blends, and permutes. See above for the meaning of these
+  // element names.
+  const __m256d abcd = _mm256_loadu_pd(a);                   // a b c d
+  const __m256d efgh = _mm256_loadu_pd(a+4);                 // e f g h
+  const __m256d ebgh = _mm256_blend_pd(abcd, efgh, 0b1101);  // e b g h
+  const __m256d behg = _mm256_permute_pd(ebgh, 0b0101);      // b e h (g) col1
+
+  const __m256d cdgh = _mm256_permute2f128_pd(abcd, efgh,
+                                              0b00110001);   // c d g h
+  const __m256d adgh = _mm256_blend_pd(abcd, cdgh, 0b1110);  // a d g (h) col0
+
+  const __m256d fghi = _mm256_loadu_pd(a+5);                 // f g h i
+  const __m256d ffih = _mm256_permute_pd(fghi, 0b0100);      // f f i h
+  const __m256d cfih = _mm256_blend_pd(cdgh, ffih, 0b0110);  // c f i (h) col2
+
+  const __m256d ABCD = _mm256_loadu_pd(A);     // A B C D
+  const __m256d EFGH = _mm256_loadu_pd(A+4);   // E F G H
+  const double I = *(A+8);                     // I
+
+  a0 = _mm256_mul_pd(adgh, four(ABCD[0]));   // aA dA gA (hA)
+  a1 = _mm256_mul_pd(adgh, four(ABCD[3]));   // aD dD gD (hD)
+  a2 = _mm256_mul_pd(adgh, four(EFGH[2]));   // aG dG gG (hG)
+
+  a0 = _mm256_fmadd_pd(behg, four(ABCD[1]), a0);  // aA+bB dA+eB gA+hB (hA+gB)
+  a1 = _mm256_fmadd_pd(behg, four(EFGH[0]), a1);  // aD+bE dD+eE gD+hE (hD+gE)
+  a2 = _mm256_fmadd_pd(behg, four(EFGH[3]), a2);  // aG+bH dG+eH gG+hH (hG+gH)
+
+  a0 = _mm256_fmadd_pd(cfih, four(ABCD[2]), a0);  // aA+bB+cC dA+eB+fC gA+hB+iC
+                                                  //                  (hA+cB+hC)
+  _mm256_storeu_pd(r, a0);                        // r s t (u) will overwrite u
+
+  a1 = _mm256_fmadd_pd(cfih, four(EFGH[1]), a1);  // aD+bE+cF dD+eE+fF gD+hE+iF
+                                                  //                  (hD+cE+hF)
+  _mm256_storeu_pd(r+3, a1);                      // u v w (x) will overwrite x
+
+  a2 = _mm256_fmadd_pd(cfih, four(I), a2);        // aG+bH+cI dG+eH+fI gG+hH+iI
+                                                  //                  (hG+cH+hI)
+  _mm256_maskstore_pd(r+6, mask, a2);             // x y z
+
+  // The compiler will generate a vzeroupper instruction if needed.
+}
+
 }  // namespace
 
 /* Use AVX methods. */
-bool IsUsingPortableCompositionMethods() { return false; }
+bool IsUsingPortableCompositionFunctions() { return false; }
 
-void ComposeRR(const double* R_AB, const double* R_BC, double* R_AC) {
-  ComposeRRAvx(R_AB, R_BC, R_AC);
+// See note above as to why these reinterpret_casts are safe.
+
+void ComposeRR(const RotationMatrix<double>& R_AB,
+               const RotationMatrix<double>& R_BC,
+               RotationMatrix<double>* R_AC) {
+  assert(R_AC != nullptr);
+  ComposeRRAvx(reinterpret_cast<const double*>(&R_AB),
+               reinterpret_cast<const double*>(&R_BC),
+               reinterpret_cast<double*>(R_AC));
 }
+void ComposeRinvR(const RotationMatrix<double>& R_BA,
+                  const RotationMatrix<double>& R_BC,
+                  RotationMatrix<double>* R_AC) {
+  assert(R_AC != nullptr);
+  ComposeRinvRAvx(reinterpret_cast<const double*>(&R_BA),
+                  reinterpret_cast<const double*>(&R_BC),
+                  reinterpret_cast<double*>(R_AC));
+}
+
+// TODO(sherm1) ComposeXX() and ComposeXinvX().
 
 #else
-/* Use portable methods. */
-bool IsUsingPortableCompositionMethods() { return true; }
+/* Use portable functions. */
+bool IsUsingPortableCompositionFunctions() { return true; }
 
-void ComposeRR(const double* R_AB, const double* R_BC, double* R_AC) {
+void ComposeRR(const RotationMatrix<double>& R_AB,
+               const RotationMatrix<double>& R_BC,
+               RotationMatrix<double>* R_AC) {
   internal::ComposeRRPortable(R_AB, R_BC, R_AC);
 }
+void ComposeRinvR(const RotationMatrix<double>& R_BA,
+                  const RotationMatrix<double>& R_BC,
+                  RotationMatrix<double>* R_AC) {
+  internal::ComposeRinvRPortable(R_BA, R_BC, R_AC);
+}
+
+// TODO(sherm1) ComposeXX() and ComposeXinvX().
+
 #endif
 
+}  // namespace internal
 }  // namespace math
 }  // namespace drake

--- a/math/fast_pose_composition_functions.h
+++ b/math/fast_pose_composition_functions.h
@@ -6,36 +6,65 @@ matrices with known memory layouts. Ideally these are implemented using
 platform-specific SIMD instructions for speed. There is always a straight
 C++ fallback. */
 
+/* Do not include code from drake/common here because this file will be
+included by a compilation unit that may have a different opinion about whether
+SIMD instructions are enabled than Eigen does in the rest of Drake. */
+
 namespace drake {
 namespace math {
 
-/** Composes two drake::math::RotationMatrix<double> objects as quickly as
-possible. Drake RotationMatrix objects are stored as 3x3 column-ordered
-matrices in nine consecutive doubles.
+/* We do not have access to the declaration for RotationMatrix
+here. Instead, these functions depend on knowledge of the internal storage
+format of this class, which is guaranteed and enforced by the class
+declaration: Drake RotationMatrix objects are stored as 3x3 column-ordered
+matrices in nine consecutive doubles.*/
+template <typename>
+class RotationMatrix;
 
-This method can also be used to form the product of two general 3x3 matrices.
+namespace internal {
+
+/* Composes two drake::math::RotationMatrix<double> objects as quickly as
+possible, resulting in a new RotationMatrix.
 
 Here we calculate `R_AC = R_AB * R_BC`. It is OK for R_AC to overlap
 with one or both inputs. */
-void ComposeRR(const double* R_AB, const double* R_BC, double* R_AC);
+void ComposeRR(const RotationMatrix<double>& R_AB,
+               const RotationMatrix<double>& R_BC,
+               RotationMatrix<double>* R_AC);
 
-// TODO(sherm1) ComposeRinvR(), ComposeXX(), ComposeXinvX()
+/* Composes the inverse of a drake::math::RotationMatrix<double> object with
+another (non-inverted) drake::math::RotationMatrix<double> as quickly as
+possible, resulting in a new RotationMatrix.
 
-/** Returns `true` if we are using the portable fallback implementations for
-the above methods. */
-bool IsUsingPortableCompositionMethods();
+@note A valid RotationMatrix is orthonormal, and the inverse of an orthonormal
+matrix is just its transpose. This function assumes orthonormality and hence
+simply multiplies the transpose of its first argument by the second.
 
-namespace internal {
+Here we calculate `R_AC = R_BA⁻¹ * R_BC`. It is OK for R_AC to overlap
+with one or both inputs. */
+void ComposeRinvR(const RotationMatrix<double>& R_BA,
+                  const RotationMatrix<double>& R_BC,
+                  RotationMatrix<double>* R_AC);
+
+// TODO(sherm1) ComposeXX() and ComposeXinvX().
+
+/* Returns `true` if we are using the portable fallback implementations for
+the above functions. */
+bool IsUsingPortableCompositionFunctions();
+
 /* These portable implementations are exposed so they can be unit tested.
-Call IsUsingPortableCompositionMethods() to determine whether these are being
-used to implement the above methods. */
+Call IsUsingPortableCompositionFunctions() to determine whether these are being
+used to implement the above functions. */
 
-void ComposeRRPortable(const double* R_AB, const double* R_BC, double* R_AC);
+void ComposeRRPortable(const RotationMatrix<double>& R_AB,
+                       const RotationMatrix<double>& R_BC,
+                       RotationMatrix<double>* R_AC);
+void ComposeRinvRPortable(const RotationMatrix<double>& R_BA,
+                          const RotationMatrix<double>& R_BC,
+                          RotationMatrix<double>* R_AC);
 
-// TODO(sherm1) ComposeRinvRPortable(), ComposeXXPortable(),
-//              ComposeXinvXPortable()
+// TODO(sherm1) ComposeXXPortable() and ComposeXinvXPortable().
 
 }  // namespace internal
-
 }  // namespace math
 }  // namespace drake

--- a/math/test/fast_pose_composition_functions_test.cc
+++ b/math/test/fast_pose_composition_functions_test.cc
@@ -1,5 +1,6 @@
 #include "drake/math/fast_pose_composition_functions.h"
 
+#include <cstdio>
 #include <limits>
 
 #include <Eigen/Dense>
@@ -9,6 +10,7 @@
 
 namespace drake {
 namespace math {
+
 namespace  {
 using Eigen::Matrix3d;
 
@@ -19,52 +21,102 @@ GTEST_TEST(TestFastPoseCompositionFunctions, UsingAVX) {
   constexpr bool kApple = false;
 #endif
 
-  EXPECT_EQ(IsUsingPortableCompositionMethods(), kApple);
+  EXPECT_EQ(internal::IsUsingPortableCompositionFunctions(), kApple);
 }
 
 // Test the given RotationMatrix composition function for correct functionality
-// (just a matrix multiply in this case) and that it still works when the output
-// overlaps in memory with the inputs.
-void TestRR(
-    std::function<void(const double*, const double*, double*)> compose_RR) {
-  Matrix3d M, N;
-  M << 1, 5, 9, 2, 6, 10, 3, 7, 11;
-  N << 13, 17, 21, 14, 18, 22, 15, 19, 23;
-  const Matrix3d MM_expected = M * M;
-  const Matrix3d MN_expected = M * N;
+// (just matrix multiply or matrix transpose multiply here) and that it still
+// works when the output overlaps in memory with the inputs.
+//
+// To avoid circular dependencies we have to test this functionality without
+// access to the declaration of RotationMatrix (we have only a forward
+// reference). We are guaranteed, however, that a RotationMatrix is just an
+// array of nine consecutive doubles (by a static_assert in rotation_matrix.h)
+// and in column order (by Eigen's default storage order for matrices).
+void RawTestRxR(
+    std::function<void(const double*, const double*, double*)> compose_RxR,
+    bool invert_first_matrix) {
 
-  Matrix3d MN;
-  compose_RR(M.data(), N.data(), MN.data());
+  // Note that M and N are not legitimate RotationMatrix values. We are just
+  // testing that the correct matrix operations are performed.
+  Matrix3d M, N;
+  M << 1, 5, 9,
+       2, 6, 10,
+       3, 7, 11;
+  N << 13, 17, 21,
+       14, 18, 22,
+       15, 19, 23;
+  // Inverse is just transpose for a RotationMatrix.
+  const Matrix3d Mx = invert_first_matrix ? M.transpose() : M;
+  const Matrix3d MxM_expected = Mx * M;
+  const Matrix3d MxN_expected = Mx * N;
+
+  Matrix3d MxN;
+  compose_RxR(M.data(), N.data(), MxN.data());
 
   // Should be a perfect match with integer elements.
-  EXPECT_TRUE(CompareMatrices(MN, MN_expected, 0));
+  EXPECT_TRUE(CompareMatrices(MxN, MxN_expected, 0));
 
   // Now test in-place compositions.
   Matrix3d Mwork = M, Nwork = N;  // Copies to overwrite.
 
   // Results should be perfect match with integer elements.
-  compose_RR(Mwork.data(), Nwork.data(), Mwork.data());  // Mwork=M*N
-  EXPECT_TRUE(CompareMatrices(Mwork, MN_expected, 0));
-  Mwork = M;                                             // Restore value.
-  compose_RR(Mwork.data(), Nwork.data(), Nwork.data());  // Nwork=M*N
-  EXPECT_TRUE(CompareMatrices(Nwork, MN_expected, 0));
-  compose_RR(Mwork.data(), Mwork.data(), Mwork.data());  // Mwork=M*M
-  EXPECT_TRUE(CompareMatrices(Mwork, MM_expected, 0));
+  compose_RxR(Mwork.data(), Nwork.data(), Mwork.data());  // Mwork=Mx*N
+  EXPECT_TRUE(CompareMatrices(Mwork, MxN_expected, 0));
+  Mwork = M;  // Restore value.
+  compose_RxR(Mwork.data(), Nwork.data(), Nwork.data());  // Nwork=Mx*N
+  EXPECT_TRUE(CompareMatrices(Nwork, MxN_expected, 0));
+  compose_RxR(Mwork.data(), Mwork.data(), Mwork.data());  // Mwork=Mx*M
+  EXPECT_TRUE(CompareMatrices(Mwork, MxM_expected, 0));
+}
+
+// TODO(sherm1) TestXxX() function for ComposeXX() and ComposeXinvX().
+
+// Wraps the given composition function in one that can work directly with
+// arrays of doubles for testing.
+void TestRxR(std::function<void(const RotationMatrix<double>& R1,
+                                const RotationMatrix<double>& R2,
+                                RotationMatrix<double>* ROut)>
+                 compose_RxR,
+             bool invert_first_matrix) {
+  RawTestRxR(
+      [&](const double* R_1, const double* R_2, double* R_out) {
+        compose_RxR(reinterpret_cast<const RotationMatrix<double>&>(*R_1),
+                    reinterpret_cast<const RotationMatrix<double>&>(*R_2),
+                    reinterpret_cast<RotationMatrix<double>*>(R_out));
+      },
+      invert_first_matrix);
 }
 
 /* Test the user-callable methods first. Those are ideally implemented
 with SIMD instructions, however they may just punt to the plain C++ fallback
 methods, which we'll test separately below. */
-GTEST_TEST(TestFastPoseCompositionFunctions, TestRotationCompositions) {
+
+GTEST_TEST(TestFastPoseCompositionFunctions, TestRR) {
   SCOPED_TRACE("testing ComposeRR()");
-  TestRR(ComposeRR);
+  TestRxR(internal::ComposeRR, false);
+}
+GTEST_TEST(TestFastPoseCompositionFunctions, TestRinvR) {
+  SCOPED_TRACE("testing ComposeRinvR()");
+  TestRxR(internal::ComposeRinvR, true);
 }
 
-GTEST_TEST(TestFastPoseCompositionFunctions, TestPortableRotationCompositions) {
+// TODO(sherm1) ComposeXX() and ComposeXinvX() tests.
+
+/* Now repeat these tests for the portable methods. */
+
+GTEST_TEST(TestFastPoseCompositionFunctions, TestRRPortable) {
   SCOPED_TRACE("testing internal::ComposeRRPortable()");
-  TestRR(internal::ComposeRRPortable);
+  TestRxR(internal::ComposeRRPortable, false);
 }
+GTEST_TEST(TestFastPoseCompositionFunctions, TestRinvRPortable) {
+  SCOPED_TRACE("testing internal::ComposeRinvRPortable()");
+  TestRxR(internal::ComposeRinvRPortable, true);
+}
+
+// TODO(sherm1) ComposeXXPortable() and ComposeXinvXPortable() tests.
 
 }  // namespace
+
 }  // namespace math
 }  // namespace drake

--- a/math/test/rigid_transform_test.cc
+++ b/math/test/rigid_transform_test.cc
@@ -414,7 +414,10 @@ GTEST_TEST(RigidTransform, Inverse) {
   EXPECT_TRUE(I.IsNearlyEqualTo(X_identity, 8 * kEpsilon));
 }
 
-// Tests RigidTransform multiplied by another RigidTransform
+// Tests RigidTransform multiplied by another RigidTransform, for both the
+// infix operator*() and assignment operator*=(). Note that these may be
+// specialized for double, so we have to test both double and some non-double
+// type to make sure both paths are exercised.
 GTEST_TEST(RigidTransform, OperatorMultiplyByRigidTransform) {
   const RigidTransform<double> X_BA = GetRigidTransformA();
   const RigidTransform<double> X_CB = GetRigidTransformB();
@@ -442,7 +445,27 @@ GTEST_TEST(RigidTransform, OperatorMultiplyByRigidTransform) {
   // slightly larger than the characteristic length |p_CoAo_C| = 14.2
   const RigidTransform<double> X_CA_expected(R_CA_expected, p_CoAo_C_expected);
   EXPECT_TRUE(X_CA.IsNearlyEqualTo(X_CA_expected, 32 * kEpsilon));
+
+  // Let's try to create the same result with operator*=().
+  RigidTransform<double> will_be_X_CA(X_CB);
+  will_be_X_CA *= X_BA;
+  EXPECT_TRUE(will_be_X_CA.IsNearlyEqualTo(X_CA_expected, 32 * kEpsilon));
+
+  // Repeat both tests for the non-double implementations.
+  using symbolic::Expression;
+  const RigidTransform<Expression> X_BAx = X_BA.cast<Expression>();
+  const RigidTransform<Expression> X_CBx = X_CB.cast<Expression>();
+  const RigidTransform<Expression> X_CAx = X_CBx * X_BAx;
+  EXPECT_TRUE(CompareMatrices(symbolic::Evaluate(X_CAx.GetAsMatrix34()),
+                              X_CA_expected.GetAsMatrix34(), 32 * kEpsilon));
+
+  RigidTransform<Expression> will_be_X_CAx(X_CBx);
+  will_be_X_CAx *= X_BAx;
+  EXPECT_TRUE(CompareMatrices(symbolic::Evaluate(will_be_X_CAx.GetAsMatrix34()),
+                              X_CA_expected.GetAsMatrix34(), 32 * kEpsilon));
 }
+
+// TODO(sherm1) Test for RigidTransform::InvertAndCompose().
 
 // Tests RigidTransform multiplied by a position vector.
 GTEST_TEST(RigidTransform, OperatorMultiplyByPositionVector) {

--- a/multibody/plant/test/frame_kinematics_test.cc
+++ b/multibody/plant/test/frame_kinematics_test.cc
@@ -76,7 +76,7 @@ TEST_F(KukaIiwaModelTests, FramesKinematics) {
       link3.body_frame().CalcRotationMatrix(*context_, *frame_H_);
   const RotationMatrix<double> R_WL3 =
       link3.body_frame().CalcRotationMatrixInWorld(*context_);
-  const RotationMatrix<double> R_HL3_expected = R_WH.inverse() * R_WL3;
+  const RotationMatrix<double> R_HL3_expected = R_WH.InvertAndCompose(R_WL3);
   EXPECT_TRUE(CompareMatrices(R_HL3.matrix(), R_HL3_expected.matrix(),
                               kTolerance, MatrixCompareType::relative));
 

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -1219,7 +1219,7 @@ RotationMatrix<T> MultibodyTree<T>::CalcRelativeRotationMatrix(
   const RotationMatrix<T> R_BG = frame_G.CalcRotationMatrixInBodyFrame(context);
   const RotationMatrix<T> R_WF = R_WA * R_AF;
   const RotationMatrix<T> R_WG = R_WB * R_BG;
-  return R_WF.inverse() * R_WG;  // R_FG = R_FW * R_WG;
+  return R_WF.InvertAndCompose(R_WG);  // R_FG = R_FW * R_WG;
 }
 
 template <typename T>


### PR DESCRIPTION
This is the second PR (following #15013) in a train leading up to #14768 which provides a family of AVX methods. #15013 added the infrastructure and rotation matrix composition method ComposeRR(). This one adds the method for inverse-rotation composed with rotation, internal::ComposeRinvR().

Measured throughput in gigaflops (thanks to @joemasterjohn):
|              | ComposeRinvR() 
| ---------:|:---------:|
|   C++     |    5.46   |
|   AVX      | 13.02      |
| Speedup | **2.4X** |

This PR also changes (without deprecation) the signature of last week's ComposeRR() function and moves it into the internal:: namespace where it should have been in the first place. That is a breaking change if anyone was using it directly, which they should not have been doing!

We also add some missing tests for RigidTransform which will matter more when the AVX RigidTransform methods are added in the next PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15073)
<!-- Reviewable:end -->
