### PR TITLE
framework: Remove some allocations from event collections

### DIFF
--- a/manipulation/kuka_iiwa/iiwa_command_receiver.cc
+++ b/manipulation/kuka_iiwa/iiwa_command_receiver.cc
@@ -99,7 +99,7 @@ void IiwaCommandReceiver::DoCalcNextUpdateTime(
   // Schedule a discrete update event at now to latch the current position.
   *time = context.get_time();
   auto& discrete_events = events->get_mutable_discrete_update_events();
-  discrete_events.add_event(std::make_unique<DiscreteUpdateEvent<double>>(
+  discrete_events.AddEvent(DiscreteUpdateEvent<double>(
       [this](const Context<double>& event_context,
              const DiscreteUpdateEvent<double>&,
              DiscreteValues<double>* next_values) {

--- a/systems/analysis/test/simulator_limit_malloc_test.cc
+++ b/systems/analysis/test/simulator_limit_malloc_test.cc
@@ -76,7 +76,7 @@ GTEST_TEST(SimulatorLimitMallocTest,
     // heap-free simulation after initialization, given careful system
     // construction.
     // TODO(rpoyner-tri): whittle allocations down to 0.
-    test::LimitMalloc heap_alloc_checker({.max_num_allocations = 63});
+    test::LimitMalloc heap_alloc_checker({.max_num_allocations = 21});
     simulator.AdvanceTo(1.0);
     simulator.AdvanceTo(2.0);
     simulator.AdvanceTo(3.0);

--- a/systems/framework/event.h
+++ b/systems/framework/event.h
@@ -443,13 +443,6 @@ class Event {
   virtual ~Event() {}
   #endif
 
-  /** @name Does not allow move or assignment; copy constructor is private. */
-  ///@{
-  void operator=(const Event&) = delete;
-  Event(Event&&) = delete;
-  void operator=(Event&&) = delete;
-  ///@}
-
   // TODO(eric.cousineau): Deprecate and remove this alias.
   using TriggerType = systems::TriggerType;
 
@@ -485,7 +478,7 @@ class Event {
    * can be nullptr, which means this event does not have any associated
    * data.
    */
-  EventData* get_mutable_event_data() { return event_data_.get(); }
+  EventData* get_mutable_event_data() { return event_data_.get_mutable(); }
 
   // Note: Users should not be calling this.
   #if !defined(DRAKE_DOXYGEN_CXX)
@@ -527,10 +520,7 @@ class Event {
   }
 
  protected:
-  Event(const Event& other) : trigger_type_(other.trigger_type_) {
-    if (other.event_data_ != nullptr)
-      set_event_data(other.event_data_->Clone());
-  }
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Event);
 
   // Note: Users should not be calling this.
   #if !defined(DRAKE_DOXYGEN_CXX)
@@ -554,7 +544,7 @@ class Event {
 
  private:
   TriggerType trigger_type_;
-  std::unique_ptr<EventData> event_data_{nullptr};
+  copyable_unique_ptr<EventData> event_data_{nullptr};
 };
 
 /**
@@ -607,9 +597,7 @@ struct PeriodicEventDataComparator {
 template <typename T>
 class PublishEvent final : public Event<T> {
  public:
-  void operator=(const PublishEvent&) = delete;
-  PublishEvent(PublishEvent&&) = delete;
-  void operator=(PublishEvent&&) = delete;
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PublishEvent);
   bool is_discrete_update() const override { return false; }
 
   /** @name Publish Callbacks
@@ -682,8 +670,6 @@ class PublishEvent final : public Event<T> {
   }
 
  private:
-  PublishEvent(const PublishEvent&) = default;
-
   void DoAddToComposite(TriggerType trigger_type,
                         CompositeEventCollection<T>* events) const final {
     auto event = std::unique_ptr<PublishEvent<T>>(this->DoClone());
@@ -713,9 +699,7 @@ class PublishEvent final : public Event<T> {
 template <typename T>
 class DiscreteUpdateEvent final : public Event<T> {
  public:
-  void operator=(const DiscreteUpdateEvent&) = delete;
-  DiscreteUpdateEvent(DiscreteUpdateEvent&&) = delete;
-  void operator=(DiscreteUpdateEvent&&) = delete;
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DiscreteUpdateEvent);
   bool is_discrete_update() const override { return true; }
 
   /** @name Discrete Update Callbacks
@@ -794,8 +778,6 @@ class DiscreteUpdateEvent final : public Event<T> {
   }
 
  private:
-  DiscreteUpdateEvent(const DiscreteUpdateEvent&) = default;
-
   void DoAddToComposite(TriggerType trigger_type,
                         CompositeEventCollection<T>* events) const final {
     auto event = std::unique_ptr<DiscreteUpdateEvent<T>>(this->DoClone());
@@ -825,9 +807,7 @@ class DiscreteUpdateEvent final : public Event<T> {
 template <typename T>
 class UnrestrictedUpdateEvent final : public Event<T> {
  public:
-  void operator=(const UnrestrictedUpdateEvent&) = delete;
-  UnrestrictedUpdateEvent(UnrestrictedUpdateEvent&&) = delete;
-  void operator=(UnrestrictedUpdateEvent&&) = delete;
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(UnrestrictedUpdateEvent);
   bool is_discrete_update() const override { return false; }
 
   /** @name Unrestricted Update Callbacks
@@ -906,8 +886,6 @@ class UnrestrictedUpdateEvent final : public Event<T> {
   }
 
  private:
-  UnrestrictedUpdateEvent(const UnrestrictedUpdateEvent&) = default;
-
   void DoAddToComposite(TriggerType trigger_type,
                         CompositeEventCollection<T>* events) const final {
     auto event = std::unique_ptr<UnrestrictedUpdateEvent<T>>(this->DoClone());

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -943,7 +943,7 @@ class LeafSystem : public System<T> {
     DRAKE_DEMAND(publish != nullptr);
 
     // Instantiate the event.
-    auto forced = std::make_unique<PublishEvent<T>>(
+    PublishEvent<T> forced(
         TriggerType::kForced,
         [this_ptr, publish](const Context<T>& context, const PublishEvent<T>&) {
           // TODO(sherm1) Forward the return status.
@@ -951,7 +951,7 @@ class LeafSystem : public System<T> {
         });
 
     // Add the event to the collection of forced publish events.
-    this->get_mutable_forced_publish_events().add_event(std::move(forced));
+    this->get_mutable_forced_publish_events().AddEvent(std::move(forced));
   }
 
   /** Declares a function that is called whenever a user directly calls
@@ -981,7 +981,7 @@ class LeafSystem : public System<T> {
     DRAKE_DEMAND(update != nullptr);
 
     // Instantiate the event.
-    auto forced = std::make_unique<DiscreteUpdateEvent<T>>(
+    DiscreteUpdateEvent<T> forced(
         TriggerType::kForced,
         [this_ptr, update](const Context<T>& context,
                            const DiscreteUpdateEvent<T>&,
@@ -992,7 +992,7 @@ class LeafSystem : public System<T> {
         });
 
     // Add the event to the collection of forced discrete update events.
-    this->get_mutable_forced_discrete_update_events().add_event(
+    this->get_mutable_forced_discrete_update_events().AddEvent(
         std::move(forced));
   }
 
@@ -1023,7 +1023,7 @@ class LeafSystem : public System<T> {
     DRAKE_DEMAND(update != nullptr);
 
     // Instantiate the event.
-    auto forced = std::make_unique<UnrestrictedUpdateEvent<T>>(
+    UnrestrictedUpdateEvent<T> forced(
         TriggerType::kForced,
         [this_ptr, update](const Context<T>& context,
                            const UnrestrictedUpdateEvent<T>&, State<T>* state) {
@@ -1032,7 +1032,7 @@ class LeafSystem : public System<T> {
         });
 
     // Add the event to the collection of forced unrestricted update events.
-    this->get_mutable_forced_unrestricted_update_events().add_event(
+    this->get_mutable_forced_unrestricted_update_events().AddEvent(
         std::move(forced));
   }
   //@}

--- a/systems/lcm/lcm_log_playback_system.cc
+++ b/systems/lcm/lcm_log_playback_system.cc
@@ -43,8 +43,8 @@ void LcmLogPlaybackSystem::DoCalcNextUpdateTime(
 
   // Schedule a publish event at the next message time.
   *time = next_message_time;
-  events->get_mutable_publish_events().add_event(
-      std::make_unique<systems::PublishEvent<double>>(
+  events->get_mutable_publish_events().AddEvent(
+      systems::PublishEvent<double>(
           TriggerType::kTimed, callback));
 }
 

--- a/systems/lcm/lcm_subscriber_system.cc
+++ b/systems/lcm/lcm_subscriber_system.cc
@@ -128,8 +128,8 @@ void LcmSubscriberSystem::DoCalcNextUpdateTime(
   *time = context.get_time();
   EventCollection<UnrestrictedUpdateEvent<double>>& uu_events =
       events->get_mutable_unrestricted_update_events();
-  uu_events.add_event(
-      std::make_unique<systems::UnrestrictedUpdateEvent<double>>(
+  uu_events.AddEvent(
+      systems::UnrestrictedUpdateEvent<double>(
           TriggerType::kTimed, callback));
 }
 


### PR DESCRIPTION
Relevant to: #14543

Rewrite the storage of event collections to avoid most allocations,
while maintaining most of the pre-existing public API. To support this
change, allow fully-derived-type events to be copied and assigned. The
Clone() mechanism is still supported, primarily for interfacing with
Python.

This patch also deprecates EventCollection<E>::add_event() and any
overrides.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15081)
<!-- Reviewable:end -->
