### PR TITLE
Change FemSolver constructor to take a const pointer to FemModelBase

### DIFF
--- a/multibody/fixed_fem/dev/softsim_system.cc
+++ b/multibody/fixed_fem/dev/softsim_system.cc
@@ -52,8 +52,7 @@ void SoftsimSystem<T>::SetWallBoundaryCondition(SoftBodyIndex body_id,
   const Vector3<T>& n_hatW = n_W.normalized();
   DRAKE_THROW_UNLESS(body_id < num_bodies());
   const int kDim = 3;
-  FemSolver<T>& fem_solver = *fem_solvers_[body_id];
-  FemModelBase<T>& fem_model = fem_solver.mutable_model();
+  FemModelBase<T>& fem_model = *fem_models_[body_id];
   const int num_nodes = fem_model.num_nodes();
   // TODO(xuchenhan-tri): FemModel should support an easier way to retrieve its
   //  reference positions.
@@ -120,8 +119,8 @@ void SoftsimSystem<T>::RegisterDeformableBodyHelper(
 
   prev_fem_states_.emplace_back(std::make_unique<StateType>(state));
   next_fem_states_.emplace_back(std::make_unique<StateType>(state));
-  fem_solvers_.emplace_back(
-      std::make_unique<FemSolver<T>>(std::move(fem_model)));
+  fem_solvers_.emplace_back(std::make_unique<FemSolver<T>>(fem_model.get()));
+  fem_models_.emplace_back(std::move(fem_model));
   initial_meshes_.emplace_back(mesh);
   names_.emplace_back(std::move(name));
 }

--- a/multibody/fixed_fem/dev/softsim_system.h
+++ b/multibody/fixed_fem/dev/softsim_system.h
@@ -135,6 +135,7 @@ class SoftsimSystem final : public systems::LeafSystem<T> {
   /* Initial mesh for all bodies at time of registration. */
   std::vector<geometry::VolumeMesh<T>> initial_meshes_{};
   /* Solvers for all bodies. */
+  std::vector<std::unique_ptr<FemModelBase<T>>> fem_models_{};
   std::vector<std::unique_ptr<FemSolver<T>>> fem_solvers_{};
   /* Names of all registered bodies. */
   std::vector<std::string> names_{};


### PR DESCRIPTION
By having FemSolver not own the FemModel, we allow softsim to be refactored into two more-or-less independent components: a modelling component that owns FemModels and a DiscreteUpdateManager component that owns FemSolvers. We have to internally keep track of the solver/model pair so that the model outlives the solver after this change, but since we don't currently allow removing deformable objects, this does not create any actual burdens in the near future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15082)
<!-- Reviewable:end -->
