### PR TITLE
multibody: Improve error messages on element lookups

### DIFF
--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -166,7 +166,7 @@ GTEST_TEST(MultibodyPlantSdfParserTest, ModelInstanceTest) {
   // isn't specified.
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant.HasBodyNamed("Link1"), std::logic_error,
-      "Body Link1 appears in multiple model instances.");
+      ".*Body.*Link1.*multiple model instances.*");
 
   EXPECT_FALSE(plant.HasBodyNamed("Link1", instance1));
   EXPECT_TRUE(plant.HasBodyNamed("Link1", acrobot1));
@@ -182,12 +182,12 @@ GTEST_TEST(MultibodyPlantSdfParserTest, ModelInstanceTest) {
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant.GetBodyByName("Link1"), std::logic_error,
-      "Body Link1 appears in multiple model instances.");
+      ".*Body.*Link1.*multiple model instances.*");
 
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant.HasJointNamed("ShoulderJoint"), std::logic_error,
-      "Joint ShoulderJoint appears in multiple model instances.");
+      ".*Joint.*ShoulderJoint.*multiple model instances.*");
   EXPECT_FALSE(plant.HasJointNamed("ShoulderJoint", instance1));
   EXPECT_TRUE(plant.HasJointNamed("ShoulderJoint", acrobot1));
   EXPECT_TRUE(plant.HasJointNamed("ShoulderJoint", acrobot2));
@@ -202,11 +202,11 @@ GTEST_TEST(MultibodyPlantSdfParserTest, ModelInstanceTest) {
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant.GetJointByName("ShoulderJoint"), std::logic_error,
-      "Joint ShoulderJoint appears in multiple model instances.");
+      ".*Joint.*ShoulderJoint.*multiple model instances.*");
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant.HasJointActuatorNamed("ElbowJoint"), std::logic_error,
-      "Joint actuator ElbowJoint appears in multiple model instances.");
+      ".*JointActuator.*ElbowJoint.*multiple model instances.*");
 
   const JointActuator<double>& acrobot1_actuator =
       plant.GetJointActuatorByName("ElbowJoint", acrobot1);
@@ -216,7 +216,7 @@ GTEST_TEST(MultibodyPlantSdfParserTest, ModelInstanceTest) {
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant.GetJointActuatorByName("ElbowJoint"), std::logic_error,
-      "Joint actuator ElbowJoint appears in multiple model instances.");
+      ".*JointActuator.*ElbowJoint.*multiple model instances.*");
 
   const Frame<double>& acrobot1_link1_frame =
       plant.GetFrameByName("Link1", acrobot1);
@@ -226,7 +226,7 @@ GTEST_TEST(MultibodyPlantSdfParserTest, ModelInstanceTest) {
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant.GetFrameByName("Link1"), std::logic_error,
-      "Frame Link1 appears in multiple model instances.");
+      ".*Frame.*Link1.*multiple model instances.*");
 
   // Check model scope frames.
   auto context = plant.CreateDefaultContext();
@@ -802,7 +802,7 @@ GTEST_TEST(MultibodyPlantSdfParserTest, JointActuatorParsingTest) {
   // actuation.
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant.GetJointActuatorByName("prismatic_joint_zero_limit"),
-      std::logic_error, "There is no joint actuator named '.*' in the model.");
+      std::logic_error, ".*There is no JointActuator named.*");
 }
 
 // Verifies that the SDF parser parses the revolute spring parameters correctly.

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -285,8 +285,8 @@ GTEST_TEST(MultibodyPlant, SimpleModelCreation) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant->GetForceElement<RevoluteSpring>(gravity_field_index),
       std::logic_error,
-      ".*not of type '.*RevoluteSpring<double>' but of type "
-      "'.*UniformGravityFieldElement<double>'.");
+      ".*not of type .*RevoluteSpring.* but of type "
+      ".*UniformGravityFieldElement.*");
   const ForceElementIndex invalid_force_index(plant->num_force_elements() + 1);
   EXPECT_ANY_THROW(plant->GetForceElement<RevoluteSpring>(invalid_force_index));
 
@@ -320,8 +320,8 @@ GTEST_TEST(MultibodyPlant, SimpleModelCreation) {
       plant->GetJointByName<PrismaticJoint>(parameters.shoulder_joint_name(),
                                             shoulder.model_instance()),
       std::logic_error,
-      ".*not of type '.*PrismaticJoint<double>' but of type "
-      "'.*RevoluteJoint<double>'.");
+      ".*not of type .*PrismaticJoint.* but of type "
+      ".*RevoluteJoint.*");
 
   // MakeAcrobotPlant() has already called Finalize() on the acrobot model.
   // Therefore no more modeling elements can be added. Verify this.

--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -181,6 +181,7 @@ drake_cc_library(
         "//common:autodiff",
         "//common:nice_type_name",
         "//common:symbolic",
+        "//common:unused",
         "//math:geometric_transform",
         "//systems/framework:leaf_system",
     ],

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -2760,15 +2760,6 @@ class MultibodyTree {
     return *joint_variant;
   }
 
-  // Helper function to find the element index for an element in the tree from
-  // a multimap of name to index.  It finds the element from any model
-  // instance and ensures only one element of that name exists.
-  template <typename ElementIndex>
-  static ElementIndex GetElementIndex(
-      std::string_view name, const std::string& element_description,
-      const std::unordered_multimap<StringViewMapKey, ElementIndex>&
-          name_to_index);
-
   // When using a StringViewMapKey as the key type in an unordered map, the
   // instance *stored* in the map must own its string. This interface validates
   // that invariant and should be the sole mechanism by which entries are

--- a/multibody/tree/test/multibody_tree_test.cc
+++ b/multibody/tree/test/multibody_tree_test.cc
@@ -125,7 +125,11 @@ void VerifyModelBasics(const MultibodyTree<T>& model) {
   }
   DRAKE_EXPECT_THROWS_MESSAGE(
       model.GetBodyByName(kInvalidName), std::logic_error,
-      "There is no body named '.*' in the model.");
+      ".*There is no Body named.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      model.GetBodyByName(kLinkNames[0], world_model_instance()),
+      std::logic_error,
+      ".*There is no Body.*but one does exist in other model instances.*");
 
   // Test we can also retrieve links as RigidBody objects.
   for (const std::string& link_name : kLinkNames) {
@@ -134,7 +138,7 @@ void VerifyModelBasics(const MultibodyTree<T>& model) {
   }
   DRAKE_EXPECT_THROWS_MESSAGE(
       model.GetRigidBodyByName(kInvalidName), std::logic_error,
-      "There is no body named '.*' in the model.");
+      ".*There is no Body named.*");
 
   // Get frames by name.
   for (const std::string& frame_name : kFrameNames) {
@@ -145,7 +149,7 @@ void VerifyModelBasics(const MultibodyTree<T>& model) {
   }
   DRAKE_EXPECT_THROWS_MESSAGE(
       model.GetFrameByName(kInvalidName), std::logic_error,
-      "There is no frame named '.*' in the model.");
+      ".*There is no Frame named.*");
 
   // Get joints by name.
   for (const std::string& joint_name : kJointNames) {
@@ -154,9 +158,9 @@ void VerifyModelBasics(const MultibodyTree<T>& model) {
   }
   DRAKE_EXPECT_THROWS_MESSAGE(
       model.GetJointByName(kInvalidName), std::logic_error,
-      "There is no joint named '.*' in the model.");
+      ".*There is no Joint named.*");
 
-  // Templatized version to obtain retrieve a particular known type of joint.
+  // Templatized version to obtain a particular known type of joint.
   for (const std::string& joint_name : kJointNames) {
     const RevoluteJoint<T>& joint =
         model.template GetJointByName<RevoluteJoint>(joint_name);
@@ -164,7 +168,7 @@ void VerifyModelBasics(const MultibodyTree<T>& model) {
   }
   DRAKE_EXPECT_THROWS_MESSAGE(
       model.template GetJointByName<RevoluteJoint>(kInvalidName),
-      std::logic_error, "There is no joint named '.*' in the model.");
+      std::logic_error, ".*There is no Joint named.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
       model.template GetJointByName<PrismaticJoint>(kJointNames[0]),
       std::logic_error, ".*not of type.*PrismaticJoint.*but.*RevoluteJoint.*");
@@ -177,7 +181,7 @@ void VerifyModelBasics(const MultibodyTree<T>& model) {
   }
   DRAKE_EXPECT_THROWS_MESSAGE(
       model.GetJointActuatorByName(kInvalidName), std::logic_error,
-      "There is no joint actuator named '.*' in the model.");
+      ".*There is no JointActuator named.*");
 
   // Test we can retrieve joints from the actuators.
   int names_index = 0;
@@ -248,6 +252,35 @@ GTEST_TEST(MultibodyTree, VerifyModelBasics) {
   EXPECT_THROW(model->Finalize(), std::logic_error);
 
   VerifyModelBasics(*model);
+}
+
+// Exercises the error detection and reporting for retrieving model elements by
+// name when the same name exists in multiple model instances.  Since the code
+// for Body, Frame, Joint, etc. all use the same templated implementation, it's
+// sufficient to just test one element type.
+GTEST_TEST(MultibodyTree, RetrievingAmbiguousNames) {
+  std::unique_ptr<MultibodyTree<double>> model =
+      MakeKukaIiwaModel<double>(false /* non-finalized model. */);
+
+  // Add a duplicate body, but on a different model instance.
+  const std::string link_name = "iiwa_link_5";
+  EXPECT_NO_THROW(
+      model->AddRigidBody(link_name, world_model_instance(),
+                          SpatialInertia<double>()));
+  EXPECT_NO_THROW(model->Finalize());
+
+  // Checking if the name exists throws (unfortunately), unless we specify the
+  // intended model instance.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      model->HasBodyNamed(link_name), std::logic_error,
+      ".*Body.*appears in multiple model instances.*disambiguate.*");
+  EXPECT_TRUE(model->HasBodyNamed(link_name, default_model_instance()));
+
+  // Accessing by name throws, unless we specify the intended model instance.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      model->GetBodyByName(link_name), std::logic_error,
+      ".*Body.*appears in multiple model instances.*disambiguate.*");
+  EXPECT_NO_THROW(model->GetBodyByName(link_name, default_model_instance()));
 }
 
 // MBPlant provides most of the testing for MBTreeSystem. Here we just want


### PR DESCRIPTION
Specifically, when the model instance filtering is misconfigured, provide more information about what models might have matched.

Inspired by painful debugging while diagnosing #15079.

Paves the way for improvements on the #10309 front, eventually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15083)
<!-- Reviewable:end -->
