### PR TITLE
[geometry] Create general bounding volume hierarchy

### DIFF
--- a/geometry/benchmarking/mesh_intersection_benchmark.cc
+++ b/geometry/benchmarking/mesh_intersection_benchmark.cc
@@ -231,8 +231,8 @@ BENCHMARK_DEFINE_F(MeshIntersectionBenchmark, RigidSoftMesh)
 // NOLINTNEXTLINE(runtime/references)
 (benchmark::State& state) {
   SetupMeshes(state);
-  const auto bvh_S = Bvh<VolumeMesh<double>>(mesh_S_);
-  const auto bvh_R = Bvh<SurfaceMesh<double>>(mesh_R_);
+  const auto bvh_S = Bvh<Obb, VolumeMesh<double>>(mesh_S_);
+  const auto bvh_R = Bvh<Obb, SurfaceMesh<double>>(mesh_R_);
   std::unique_ptr<SurfaceMesh<double>> surface_SR;
   std::unique_ptr<SurfaceMeshFieldLinear<double, double>> e_SR;
   std::vector<Vector3<double>> grad_eM_Ms;

--- a/geometry/proximity/hydroelastic_callback.h
+++ b/geometry/proximity/hydroelastic_callback.h
@@ -100,7 +100,7 @@ std::unique_ptr<ContactSurface<T>> DispatchRigidSoftCalculation(
       DRAKE_DEMAND(!rigid.is_half_space());
       // Soft half space with rigid mesh.
       const SurfaceMesh<double>& mesh_R = rigid.mesh();
-      const Bvh<SurfaceMesh<double>>& bvh_R = rigid.bvh();
+      const Bvh<Obb, SurfaceMesh<double>>& bvh_R = rigid.bvh();
 
       return ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
           id_S, X_WS, soft.pressure_scale(), id_R, mesh_R, bvh_R, X_WR);
@@ -110,7 +110,7 @@ std::unique_ptr<ContactSurface<T>> DispatchRigidSoftCalculation(
       const auto& field_S =
           dynamic_cast<const VolumeMeshFieldLinear<double, double>&>(
               soft.pressure_field());
-      const Bvh<VolumeMesh<double>>& bvh_S = soft.bvh();
+      const Bvh<Obb, VolumeMesh<double>>& bvh_S = soft.bvh();
       return ComputeContactSurfaceFromSoftVolumeRigidHalfSpace(
           id_S, field_S, bvh_S, X_WS, id_R, X_WR);
     }
@@ -118,9 +118,9 @@ std::unique_ptr<ContactSurface<T>> DispatchRigidSoftCalculation(
     // soft cannot be a half space; so this must be mesh-mesh.
     const VolumeMeshFieldLinear<double, double>& field_S =
         soft.pressure_field();
-    const Bvh<VolumeMesh<double>>& bvh_S = soft.bvh();
+    const Bvh<Obb, VolumeMesh<double>>& bvh_S = soft.bvh();
     const SurfaceMesh<double>& mesh_R = rigid.mesh();
-    const Bvh<SurfaceMesh<double>>& bvh_R = rigid.bvh();
+    const Bvh<Obb, SurfaceMesh<double>>& bvh_R = rigid.bvh();
 
     return ComputeContactSurfaceFromSoftVolumeRigidSurface(
         id_S, field_S, bvh_S, X_WS, id_R, mesh_R, bvh_R, X_WR);

--- a/geometry/proximity/hydroelastic_internal.cc
+++ b/geometry/proximity/hydroelastic_internal.cc
@@ -33,7 +33,7 @@ SoftMesh& SoftMesh::operator=(const SoftMesh& s) {
   // We can't simply copy the mesh field; the copy must contain a pointer to
   // the new mesh. So, we use CloneAndSetMesh() instead.
   pressure_ = s.pressure().CloneAndSetMesh(mesh_.get());
-  bvh_ = make_unique<Bvh<VolumeMesh<double>>>(s.bvh());
+  bvh_ = make_unique<Bvh<Obb, VolumeMesh<double>>>(s.bvh());
 
   return *this;
 }

--- a/geometry/proximity/hydroelastic_internal.h
+++ b/geometry/proximity/hydroelastic_internal.h
@@ -36,7 +36,7 @@ class SoftMesh {
            std::unique_ptr<VolumeMeshFieldLinear<double, double>> pressure)
       : mesh_(std::move(mesh)),
         pressure_(std::move(pressure)),
-        bvh_(std::make_unique<Bvh<VolumeMesh<double>>>(*mesh_)) {
+        bvh_(std::make_unique<Bvh<Obb, VolumeMesh<double>>>(*mesh_)) {
     DRAKE_ASSERT(mesh_.get() == &pressure_->mesh());
   }
 
@@ -53,7 +53,7 @@ class SoftMesh {
     DRAKE_DEMAND(pressure_ != nullptr);
     return *pressure_;
   }
-  const Bvh<VolumeMesh<double>>& bvh() const {
+  const Bvh<Obb, VolumeMesh<double>>& bvh() const {
     DRAKE_DEMAND(bvh_ != nullptr);
     return *bvh_;
   }
@@ -61,7 +61,7 @@ class SoftMesh {
  private:
   std::unique_ptr<VolumeMesh<double>> mesh_;
   std::unique_ptr<VolumeMeshFieldLinear<double, double>> pressure_;
-  std::unique_ptr<Bvh<VolumeMesh<double>>> bvh_;
+  std::unique_ptr<Bvh<Obb, VolumeMesh<double>>> bvh_;
 };
 
 /* Defines a soft half space. The half space is defined such that the half
@@ -151,7 +151,7 @@ class SoftGeometry {
 
   /* Returns a reference to the bounding volume hierarchy -- calling this will
    throw if is_half_space() returns `true`.  */
-  const Bvh<VolumeMesh<double>>& bvh() const {
+  const Bvh<Obb, VolumeMesh<double>>& bvh() const {
     if (is_half_space()) {
       throw std::runtime_error(
           "SoftGeometry::bvh() cannot be invoked for soft half space");
@@ -184,7 +184,7 @@ class RigidMesh {
 
   explicit RigidMesh(std::unique_ptr<SurfaceMesh<double>> mesh)
       : mesh_(std::move(mesh)),
-        bvh_(std::make_unique<Bvh<SurfaceMesh<double>>>(
+        bvh_(std::make_unique<Bvh<Obb, SurfaceMesh<double>>>(
             *mesh_)) {}
 
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(RigidMesh)
@@ -193,14 +193,14 @@ class RigidMesh {
     DRAKE_DEMAND(mesh_ != nullptr);
     return *mesh_;
   }
-  const Bvh<SurfaceMesh<double>>& bvh() const {
+  const Bvh<Obb, SurfaceMesh<double>>& bvh() const {
     DRAKE_DEMAND(bvh_ != nullptr);
     return *bvh_;
   }
 
  private:
   copyable_unique_ptr<SurfaceMesh<double>> mesh_;
-  copyable_unique_ptr<Bvh<SurfaceMesh<double>>> bvh_;
+  copyable_unique_ptr<Bvh<Obb, SurfaceMesh<double>>> bvh_;
 };
 
 /* The base representation of rigid geometries. Generally, a rigid geometry
@@ -235,7 +235,7 @@ class RigidGeometry {
 
   /* Returns a reference to the bounding volume hierarchy -- calling this will
    throw unless is_half_space() returns false.  */
-  const Bvh<SurfaceMesh<double>>& bvh() const {
+  const Bvh<Obb, SurfaceMesh<double>>& bvh() const {
     if (is_half_space()) {
       throw std::runtime_error(
           "RigidGeometry::bvh() cannot be invoked for rigid half space");

--- a/geometry/proximity/mesh_half_space_intersection.cc
+++ b/geometry/proximity/mesh_half_space_intersection.cc
@@ -337,7 +337,7 @@ std::unique_ptr<ContactSurface<T>>
 ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
     GeometryId id_S, const math::RigidTransform<T>& X_WS, double pressure_scale,
     GeometryId id_R, const SurfaceMesh<double>& mesh_R,
-    const Bvh<SurfaceMesh<double>>& bvh_R,
+    const Bvh<Obb, SurfaceMesh<double>>& bvh_R,
     const math::RigidTransform<T>& X_WR) {
   std::vector<SurfaceFaceIndex> tri_indices;
   tri_indices.reserve(mesh_R.num_elements());
@@ -454,13 +454,13 @@ ConstructSurfaceMeshFromMeshHalfspaceIntersection(
 template std::unique_ptr<ContactSurface<double>>
 ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
     GeometryId, const math::RigidTransform<double>&, double, GeometryId,
-    const SurfaceMesh<double>&, const Bvh<SurfaceMesh<double>>&,
+    const SurfaceMesh<double>&, const Bvh<Obb, SurfaceMesh<double>>&,
     const math::RigidTransform<double>&);
 
 template std::unique_ptr<ContactSurface<AutoDiffXd>>
 ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
     GeometryId, const math::RigidTransform<AutoDiffXd>&, double, GeometryId,
-    const SurfaceMesh<double>&, const Bvh<SurfaceMesh<double>>&,
+    const SurfaceMesh<double>&, const Bvh<Obb, SurfaceMesh<double>>&,
     const math::RigidTransform<AutoDiffXd>&);
 
 }  // namespace internal

--- a/geometry/proximity/mesh_half_space_intersection.h
+++ b/geometry/proximity/mesh_half_space_intersection.h
@@ -143,7 +143,8 @@ std::unique_ptr<ContactSurface<T>>
 ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
     GeometryId id_S, const math::RigidTransform<T>& X_WS, double pressure_scale,
     GeometryId id_R, const SurfaceMesh<double>& mesh_R,
-    const Bvh<SurfaceMesh<double>>& bvh_R, const math::RigidTransform<T>& X_WR);
+    const Bvh<Obb, SurfaceMesh<double>>& bvh_R,
+    const math::RigidTransform<T>& X_WR);
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/mesh_intersection.cc
+++ b/geometry/proximity/mesh_intersection.cc
@@ -293,8 +293,10 @@ bool SurfaceVolumeIntersector<T>::IsFaceNormalAlongPressureGradient(
 template <typename T>
 void SurfaceVolumeIntersector<T>::SampleVolumeFieldOnSurface(
     const VolumeMeshFieldLinear<double, double>& volume_field_M,
-    const Bvh<VolumeMesh<double>>& bvh_M, const SurfaceMesh<double>& surface_N,
-    const Bvh<SurfaceMesh<double>>& bvh_N, const math::RigidTransform<T>& X_MN,
+    const Bvh<Obb, VolumeMesh<double>>& bvh_M,
+    const SurfaceMesh<double>& surface_N,
+    const Bvh<Obb, SurfaceMesh<double>>& bvh_N,
+    const math::RigidTransform<T>& X_MN,
     std::unique_ptr<SurfaceMesh<T>>* surface_MN_M,
     std::unique_ptr<SurfaceMeshFieldLinear<T, T>>* e_MN,
     std::vector<Vector3<T>>* grad_eM_Ms) {
@@ -390,9 +392,10 @@ template <typename T>
 std::unique_ptr<ContactSurface<T>>
 ComputeContactSurfaceFromSoftVolumeRigidSurface(
     const GeometryId id_S, const VolumeMeshFieldLinear<double, double>& field_S,
-    const Bvh<VolumeMesh<double>>& bvh_S, const math::RigidTransform<T>& X_WS,
-    const GeometryId id_R, const SurfaceMesh<double>& mesh_R,
-    const Bvh<SurfaceMesh<double>>& bvh_R,
+    const Bvh<Obb, VolumeMesh<double>>& bvh_S,
+    const math::RigidTransform<T>& X_WS, const GeometryId id_R,
+    const SurfaceMesh<double>& mesh_R,
+    const Bvh<Obb, SurfaceMesh<double>>& bvh_R,
     const math::RigidTransform<T>& X_WR) {
   // TODO(SeanCurtis-TRI): This function is insufficiently templated. Generally,
   //  there are three types of scalars: the pose scalar, the mesh field *value*
@@ -454,16 +457,16 @@ template class SurfaceVolumeIntersector<AutoDiffXd>;
 template std::unique_ptr<ContactSurface<double>>
 ComputeContactSurfaceFromSoftVolumeRigidSurface(
     const GeometryId, const VolumeMeshFieldLinear<double, double>&,
-    const Bvh<VolumeMesh<double>>&, const math::RigidTransform<double>&,
+    const Bvh<Obb, VolumeMesh<double>>&, const math::RigidTransform<double>&,
     const GeometryId, const SurfaceMesh<double>&,
-    const Bvh<SurfaceMesh<double>>&, const math::RigidTransform<double>&);
+    const Bvh<Obb, SurfaceMesh<double>>&, const math::RigidTransform<double>&);
 
 template std::unique_ptr<ContactSurface<AutoDiffXd>>
 ComputeContactSurfaceFromSoftVolumeRigidSurface(
     const GeometryId, const VolumeMeshFieldLinear<double, double>&,
-    const Bvh<VolumeMesh<double>>&, const math::RigidTransform<AutoDiffXd>&,
-    const GeometryId, const SurfaceMesh<double>&,
-    const Bvh<SurfaceMesh<double>>&,
+    const Bvh<Obb, VolumeMesh<double>>&,
+    const math::RigidTransform<AutoDiffXd>&, const GeometryId,
+    const SurfaceMesh<double>&, const Bvh<Obb, SurfaceMesh<double>>&,
     const math::RigidTransform<AutoDiffXd>&);
 
 }  // namespace internal

--- a/geometry/proximity/mesh_intersection.h
+++ b/geometry/proximity/mesh_intersection.h
@@ -80,9 +80,9 @@ class SurfaceVolumeIntersector {
    */
   void SampleVolumeFieldOnSurface(
       const VolumeMeshFieldLinear<double, double>& volume_field_M,
-      const Bvh<VolumeMesh<double>>& bvh_M,
+      const Bvh<Obb, VolumeMesh<double>>& bvh_M,
       const SurfaceMesh<double>& surface_N,
-      const Bvh<SurfaceMesh<double>>& bvh_N,
+      const Bvh<Obb, SurfaceMesh<double>>& bvh_N,
       const math::RigidTransform<T>& X_MN,
       std::unique_ptr<SurfaceMesh<T>>* surface_MN_M,
       std::unique_ptr<SurfaceMeshFieldLinear<T, T>>* e_MN,
@@ -362,9 +362,11 @@ template <typename T>
 std::unique_ptr<ContactSurface<T>>
 ComputeContactSurfaceFromSoftVolumeRigidSurface(
     const GeometryId id_S, const VolumeMeshFieldLinear<double, double>& field_S,
-    const Bvh<VolumeMesh<double>>& bvh_S, const math::RigidTransform<T>& X_WS,
-    const GeometryId id_R, const SurfaceMesh<double>& mesh_R,
-    const Bvh<SurfaceMesh<double>>& bvh_R, const math::RigidTransform<T>& X_WR);
+    const Bvh<Obb, VolumeMesh<double>>& bvh_S,
+    const math::RigidTransform<T>& X_WS, const GeometryId id_R,
+    const SurfaceMesh<double>& mesh_R,
+    const Bvh<Obb, SurfaceMesh<double>>& bvh_R,
+    const math::RigidTransform<T>& X_WR);
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/mesh_plane_intersection.cc
+++ b/geometry/proximity/mesh_plane_intersection.cc
@@ -196,8 +196,9 @@ template <typename T>
 std::unique_ptr<ContactSurface<T>>
 ComputeContactSurfaceFromSoftVolumeRigidHalfSpace(
     const GeometryId id_S, const VolumeMeshFieldLinear<double, double>& field_S,
-    const Bvh<VolumeMesh<double>>& bvh_S, const math::RigidTransform<T>& X_WS,
-    const GeometryId id_R, const math::RigidTransform<T>& X_WR) {
+    const Bvh<Obb, VolumeMesh<double>>& bvh_S,
+    const math::RigidTransform<T>& X_WS, const GeometryId id_R,
+    const math::RigidTransform<T>& X_WR) {
   std::vector<VolumeElementIndex> tet_indices;
   tet_indices.reserve(field_S.mesh().num_elements());
   auto callback = [&tet_indices](VolumeElementIndex tet_index) {
@@ -253,15 +254,15 @@ template std::unique_ptr<ContactSurface<AutoDiffXd>> ComputeContactSurface(
 template std::unique_ptr<ContactSurface<double>>
 ComputeContactSurfaceFromSoftVolumeRigidHalfSpace(
     const GeometryId, const VolumeMeshFieldLinear<double, double>&,
-    const Bvh<VolumeMesh<double>>&, const math::RigidTransform<double>&,
+    const Bvh<Obb, VolumeMesh<double>>&, const math::RigidTransform<double>&,
     const GeometryId, const math::RigidTransform<double>&);
 
 template std::unique_ptr<ContactSurface<AutoDiffXd>>
 ComputeContactSurfaceFromSoftVolumeRigidHalfSpace(
     const GeometryId, const VolumeMeshFieldLinear<double, double>&,
-    const Bvh<VolumeMesh<double>>&, const math::RigidTransform<AutoDiffXd>&,
-    const GeometryId, const math::RigidTransform<AutoDiffXd>&);
-
+    const Bvh<Obb, VolumeMesh<double>>&,
+    const math::RigidTransform<AutoDiffXd>&, const GeometryId,
+    const math::RigidTransform<AutoDiffXd>&);
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/mesh_plane_intersection.h
+++ b/geometry/proximity/mesh_plane_intersection.h
@@ -145,8 +145,9 @@ template <typename T>
 std::unique_ptr<ContactSurface<T>>
 ComputeContactSurfaceFromSoftVolumeRigidHalfSpace(
     const GeometryId id_S, const VolumeMeshFieldLinear<double, double>& field_S,
-    const Bvh<VolumeMesh<double>>& bvh_S, const math::RigidTransform<T>& X_WS,
-    const GeometryId id_R, const math::RigidTransform<T>& X_WR);
+    const Bvh<Obb, VolumeMesh<double>>& bvh_S,
+    const math::RigidTransform<T>& X_WS, const GeometryId id_R,
+    const math::RigidTransform<T>& X_WR);
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/obb.h
+++ b/geometry/proximity/obb.h
@@ -16,6 +16,7 @@ namespace geometry {
 namespace internal {
 
 // Forward declarations.
+template <typename> class ObbMaker;
 class Aabb;
 
 /* Oriented bounding box used in Bvh. The box is defined in a canonical
@@ -35,6 +36,10 @@ class Aabb;
 class Obb {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Obb)
+
+  /** The class used for various creation operations on this bounding volume. */
+  template <typename MeshType>
+  using Maker = ObbMaker<MeshType>;
 
   /* Constructs an oriented bounding box measured and expressed in frame H.
 

--- a/geometry/proximity/test/hydroelastic_internal_test.cc
+++ b/geometry/proximity/test/hydroelastic_internal_test.cc
@@ -95,7 +95,7 @@ GTEST_TEST(SoftMeshTest, TestCopyMoveAssignConstruct) {
     const VolumeMesh<double>* const mesh_ptr = &start.mesh();
     const VolumeMeshFieldLinear<double, double>* const pressure_ptr =
         &start.pressure();
-    const Bvh<VolumeMesh<double>>* const bvh_ptr = &start.bvh();
+    const Bvh<Obb, VolumeMesh<double>>* const bvh_ptr = &start.bvh();
 
     // Test move constructor.
     SoftMesh move_constructed(std::move(start));
@@ -186,7 +186,7 @@ GTEST_TEST(SoftGeometryTest, TestCopyMoveAssignConstruct) {
     const VolumeMesh<double>* const mesh_ptr = &start.mesh();
     const VolumeMeshFieldLinear<double, double>* const pressure_ptr =
         &start.pressure_field();
-    const Bvh<VolumeMesh<double>>* const bvh_ptr = &start.bvh();
+    const Bvh<Obb, VolumeMesh<double>>* const bvh_ptr = &start.bvh();
 
     // Test move constructor.
     SoftGeometry move_constructed(std::move(start));
@@ -249,7 +249,7 @@ GTEST_TEST(RigidMeshTest, TestCopyMoveAssignConstruct) {
     // Grab raw pointers so we can determine that their ownership changes due to
     // move semantics.
     const SurfaceMesh<double>* const mesh_ptr = &start.mesh();
-    const Bvh<SurfaceMesh<double>>* const bvh_ptr = &start.bvh();
+    const Bvh<Obb, SurfaceMesh<double>>* const bvh_ptr = &start.bvh();
 
     // Test move constructor.
     RigidMesh move_constructed(std::move(start));
@@ -313,7 +313,7 @@ GTEST_TEST(RigidGeometryTest, TestCopyMoveAssignConstruct) {
     // Grab raw pointers so we can determine that their ownership changes due to
     // move semantics.
     const SurfaceMesh<double>* const mesh_ptr = &start.mesh();
-    const Bvh<SurfaceMesh<double>>* const bvh_ptr = &start.bvh();
+    const Bvh<Obb, SurfaceMesh<double>>* const bvh_ptr = &start.bvh();
 
     // Test move constructor.
     RigidGeometry move_constructed(std::move(start));

--- a/geometry/proximity/test/mesh_half_space_intersection_test.cc
+++ b/geometry/proximity/test/mesh_half_space_intersection_test.cc
@@ -788,7 +788,7 @@ GTEST_TEST(ComputeContactSurfaceFromSoftHalfSpaceRigidMeshTest, DoubleValued) {
       Vector3<double>(1.0, 2.0, 3.0));
   const SurfaceMesh<double> mesh_F = CreateBoxMesh(X_FB);
   const GeometryId mesh_id = GeometryId::get_new_id();
-  const Bvh<SurfaceMesh<double>> bvh_F(mesh_F);
+  const Bvh<Obb, SurfaceMesh<double>> bvh_F(mesh_F);
 
   // Construct the half-space.
   const GeometryId hs_id = GeometryId::get_new_id();
@@ -911,7 +911,7 @@ GTEST_TEST(CompupteContactSurfaceFromSoftHalfSpaceRigidMeshTest, BackfaceCull) {
 
   const SurfaceMesh<double> mesh_F = CreateBoxMesh(X_FB);
   const GeometryId mesh_id = GeometryId::get_new_id();
-  const Bvh<SurfaceMesh<double>> bvh_F(mesh_F);
+  const Bvh<Obb, SurfaceMesh<double>> bvh_F(mesh_F);
 
   // Construct the half-space.
   const GeometryId hs_id = GeometryId::get_new_id();
@@ -1040,7 +1040,7 @@ class MeshHalfSpaceDerivativesTest : public ::testing::Test {
     vector<Face> faces{{Face{VIndex(0), VIndex(1), VIndex(2)}}};
     id_R_ = GeometryId::get_new_id();
     mesh_R_ = make_unique<SurfaceMesh<double>>(move(faces), move(vertices));
-    bvh_R_ = make_unique<Bvh<SurfaceMesh<double>>>(*mesh_R_);
+    bvh_R_ = make_unique<Bvh<Obb, SurfaceMesh<double>>>(*mesh_R_);
   }
 
   /* Indicator for the relative pose of the mesh (tri) relative to the half
@@ -1176,7 +1176,7 @@ class MeshHalfSpaceDerivativesTest : public ::testing::Test {
   /* The rigid mesh. */
   GeometryId id_R_;
   unique_ptr<SurfaceMesh<double>> mesh_R_;
-  unique_ptr<Bvh<SurfaceMesh<double>>> bvh_R_;
+  unique_ptr<Bvh<Obb, SurfaceMesh<double>>> bvh_R_;
 
   /* The amount we penetrate the triangle mesh into the half space.  */
   static constexpr double kDepth = 0.25;

--- a/geometry/proximity/test/mesh_intersection_test.cc
+++ b/geometry/proximity/test/mesh_intersection_test.cc
@@ -800,10 +800,10 @@ VolumeElementIndex GetTetForTriangle(const SurfaceMesh<T>& surface_S,
 
 GTEST_TEST(MeshIntersectionTest, SampleVolumeFieldOnSurface) {
   auto volume_M = TrivialVolumeMesh<double>();
-  const Bvh<VolumeMesh<double>> bvh_volume_M(*volume_M);
+  const Bvh<Obb, VolumeMesh<double>> bvh_volume_M(*volume_M);
   auto volume_field_M = TrivialVolumeMeshField<double>(volume_M.get());
   auto rigid_N = TrivialSurfaceMesh<double>();
-  const Bvh<SurfaceMesh<double>> bvh_rigid_N(*rigid_N);
+  const Bvh<Obb, SurfaceMesh<double>> bvh_rigid_N(*rigid_N);
   // Transform the surface (single triangle) so that it intersects with *both*
   // tets in the volume mesh. The surface lies on the y = 0.75 plane.
   // Each tet gets intersected into a isosceles right triangle with a leg
@@ -1019,9 +1019,9 @@ void TestComputeContactSurfaceSoftRigid() {
   unique_ptr<VolumeMesh<double>> mesh_S = OctahedronVolume<double>();
   unique_ptr<VolumeMeshFieldLinear<double, double>> field_S =
       OctahedronPressureField<double>(mesh_S.get());
-  const Bvh<VolumeMesh<double>> bvh_mesh_S(*mesh_S);
+  const Bvh<Obb, VolumeMesh<double>> bvh_mesh_S(*mesh_S);
   unique_ptr<SurfaceMesh<double>> surface_R = PyramidSurface<double>();
-  const Bvh<SurfaceMesh<double>> bvh_surface_R(*surface_R);
+  const Bvh<Obb, SurfaceMesh<double>> bvh_surface_R(*surface_R);
   // Move the rigid pyramid up, so only its square base intersects the top
   // part of the soft octahedron.
   const RigidTransform<T> X_SR(Vector3<T>(0, 0, 0.5));
@@ -1169,13 +1169,13 @@ GTEST_TEST(MeshIntersectionTest, ComputeContactSurfaceSoftRigidMoving) {
   // Soft octahedron volume S with pressure field.
   auto s_id = GeometryId::get_new_id();
   unique_ptr<VolumeMesh<double>> volume_S = OctahedronVolume<double>();
-  const Bvh<VolumeMesh<double>> bvh_volume_S(*volume_S);
+  const Bvh<Obb, VolumeMesh<double>> bvh_volume_S(*volume_S);
   unique_ptr<VolumeMeshFieldLinear<double, double>> pressure_S =
       OctahedronPressureField<double>(volume_S.get());
   // Rigid pyramid surface R.
   auto r_id = GeometryId::get_new_id();
   unique_ptr<SurfaceMesh<double>> surface_R = PyramidSurface<double>();
-  const Bvh<SurfaceMesh<double>> bvh_surface_R(*surface_R);
+  const Bvh<Obb, SurfaceMesh<double>> bvh_surface_R(*surface_R);
 
   // We use 1e-14 instead of std::numeric_limits<double>::epsilon() to
   // compensate for the rounding due to general rigid transform.
@@ -1332,7 +1332,7 @@ class MeshMeshDerivativesTest : public ::testing::Test {
                                               std::move(vertices_S));
     field_S_ = make_unique<VolumeMeshFieldLinear<double, double>>(
         "pressure", vector<double>{0.25, 0.5, 0.75, 1}, tet_mesh_S_.get());
-    bvh_S_ = std::make_unique<Bvh<VolumeMesh<double>>>(*tet_mesh_S_);
+    bvh_S_ = std::make_unique<Bvh<Obb, VolumeMesh<double>>>(*tet_mesh_S_);
 
     /* Rigid triangle mesh; tilt and offset the triangle's plane so things are
      interesting. */
@@ -1343,7 +1343,7 @@ class MeshMeshDerivativesTest : public ::testing::Test {
     using VIndex = SurfaceVertexIndex;
     vector<SurfaceFace> faces({SurfaceFace{VIndex(0), VIndex(1), VIndex(2)}});
     tri_mesh_R_ = make_unique<SurfaceMesh<double>>(move(faces), move(vertices));
-    bvh_R_ = make_unique<Bvh<SurfaceMesh<double>>>(*tri_mesh_R_);
+    bvh_R_ = make_unique<Bvh<Obb, SurfaceMesh<double>>>(*tri_mesh_R_);
     X_WR_ = HalfSpace::MakePose(Vector3d{1, 2, 3}.normalized(),
                                 Vector3d{0.25, 0.1, -0.2})
                 .cast<AutoDiffXd>();
@@ -1512,12 +1512,12 @@ class MeshMeshDerivativesTest : public ::testing::Test {
   GeometryId id_S_;
   unique_ptr<VolumeMesh<double>> tet_mesh_S_;
   unique_ptr<VolumeMeshFieldLinear<double, double>> field_S_;
-  unique_ptr<Bvh<VolumeMesh<double>>> bvh_S_;
+  unique_ptr<Bvh<Obb, VolumeMesh<double>>> bvh_S_;
 
   /* Rigid triangle mesh. */
   RigidTransform<AutoDiffXd> X_WR_;
   unique_ptr<SurfaceMesh<double>> tri_mesh_R_;
-  unique_ptr<Bvh<SurfaceMesh<double>>> bvh_R_;
+  unique_ptr<Bvh<Obb, SurfaceMesh<double>>> bvh_R_;
   GeometryId id_R_;
 
   /* The amount I penetrate triangle into the tet.  */

--- a/geometry/proximity/test/mesh_plane_intersection_test.cc
+++ b/geometry/proximity/test/mesh_plane_intersection_test.cc
@@ -1215,7 +1215,7 @@ GTEST_TEST(MeshPlaneIntersectionTest, SoftVolumeRigidHalfSpace) {
   const VolumeMesh<double> mesh_F = TrivialVolumeMesh(RigidTransformd{});
   const VolumeMeshFieldLinear<double, double> field_F{
       "pressure", vector<double>{0.25, 0.5, 0.75, 1, -1}, &mesh_F};
-  const Bvh<VolumeMesh<double>> bvh_F(mesh_F);
+  const Bvh<Obb, VolumeMesh<double>> bvh_F(mesh_F);
 
   // We'll pose the plane in the soft mesh's frame S and then transform the
   // whole system.
@@ -1344,7 +1344,7 @@ class MeshPlaneDerivativesTest : public ::testing::Test {
                                               std::move(vertices_S));
     field_S_ = make_unique<VolumeMeshFieldLinear<double, double>>(
         "pressure", vector<double>{0.25, 0.5, 0.75, 1}, mesh_S_.get());
-    bvh_S_ = std::make_unique<Bvh<VolumeMesh<double>>>(*mesh_S_);
+    bvh_S_ = std::make_unique<Bvh<Obb, VolumeMesh<double>>>(*mesh_S_);
 
     /* Rigid plane; tilt and offset the plane so things are interesting. */
     X_WR_ = HalfSpace::MakePose(Vector3d{1, 2, 3}.normalized(),
@@ -1515,7 +1515,7 @@ class MeshPlaneDerivativesTest : public ::testing::Test {
   GeometryId id_S_;
   unique_ptr<VolumeMesh<double>> mesh_S_;
   unique_ptr<VolumeMeshFieldLinear<double, double>> field_S_;
-  unique_ptr<Bvh<VolumeMesh<double>>> bvh_S_;
+  unique_ptr<Bvh<Obb, VolumeMesh<double>>> bvh_S_;
 
   /* Rigid plane. No geometry is required; it's implied by the pose. */
   RigidTransform<AutoDiffXd> X_WR_;

--- a/geometry/proximity/test/mesh_to_vtk_test.cc
+++ b/geometry/proximity/test/mesh_to_vtk_test.cc
@@ -64,7 +64,7 @@ unique_ptr<ContactSurface<double>> BoxContactSurface() {
   const double kElasticModulus = 1.0e+5;
   const VolumeMeshFieldLinear<double, double> field_S =
       MakeBoxPressureField<double>(soft_box, &volume_S, kElasticModulus);
-  const Bvh<VolumeMesh<double>> bvh_volume_S(volume_S);
+  const Bvh<Obb, VolumeMesh<double>> bvh_volume_S(volume_S);
   // The soft box is at the center of World.
   RigidTransformd X_WS = RigidTransformd::Identity();
 
@@ -72,7 +72,7 @@ unique_ptr<ContactSurface<double>> BoxContactSurface() {
   // Very coarse resolution_hint 4.0 should give the coarsest mesh.
   const SurfaceMesh<double> surface_R =
       MakeBoxSurfaceMesh<double>(rigid_box, 4.0);
-  const Bvh<SurfaceMesh<double>> bvh_surface_R(surface_R);
+  const Bvh<Obb, SurfaceMesh<double>> bvh_surface_R(surface_R);
   // The rigid box intersects the soft box in a unit cube at the corner
   // (2.0, 2.0, 1.0).
   RigidTransformd X_WR(Vector3d{3., 3., 1.});


### PR DESCRIPTION
The `Bvh` code is now templated on bounding volume type so the same *hierarchy* logic can be used for different bounding volume types. Furthermore, support collision *between* hierarchies of different bounding volume types (in so far as the bounding volumes themselves support overlap tests.

The majority of the meaningful changes are in:
  `bvh.{h|cc}`, `obb.h` and `bvh_test.cc`.

All other changes are simply respellings of the `Bvh` invocation to account for the change in type declaration.

Relates #15080

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15084)
<!-- Reviewable:end -->
