### PR TITLE
framework: Rephrase LeafSystem cache entry to avoid hasher warning

### DIFF
--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -2109,10 +2109,8 @@ class LeafSystem : public System<T> {
   // Model abstract parameters to be used during Context allocation.
   internal::ModelValues model_abstract_parameters_;
 
-  // The index of a cache entry that stores a vector of event pointers for use
-  // in managing events. It is only used in DoCalcNextUpdateTime(), but is
-  // allocated as a cache entry to avoid heap operations during simulation.
-  CacheIndex next_events_cache_index_{};
+  // The index of a cache entry for scratch storage.
+  CacheIndex scratch_cache_index_{};
 };
 
 }  // namespace systems


### PR DESCRIPTION
Hotfix for #15067.

Removes this console warning:
> [console] [warning] The `std::vector<drake::systems::Event<double>const*,std::allocator<drake::systems::Event<double>const*>>` class is incompatible with the typename hasher that provides the type-erasure checking for AbstractValue casts, most likely because the problematic class mixes template parameters with nested classes or non-type template parameters. As a result, operations on `Value<std::vector<drake::systems::Event<double>const*,std::allocator<drake::systems::Event<double>const*>>>` will suffer from slightly impaired performance. If the problem relates to nested classes, you may be able to resolve it by un-nesting the class in question. If the problem relates to a single non-type template parameter, you may be able to resolve it by adding 'using NonTypeTemplateParameter = ...'. See drake/common/test/value_test.cc for an example. This is the first instance of an impaired T within this process. Additional instances will not be warned about, but you may set the drake::log() level to 'debug' to see all instances.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15085)
<!-- Reviewable:end -->
