### PR TITLE
[geometry] Adding collision filter manager - deprecate old API

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -376,6 +376,20 @@ void DoScalarDependentDefinitions(py::module m, T) {
   using namespace drake::geometry;
   py::module::import("pydrake.systems.framework");
 
+  //  CollisionFilterManager
+  {
+    using Class = CollisionFilterManager<T>;
+    constexpr auto& cls_doc = doc.CollisionFilterManager;
+    auto cls = DefineTemplateClassWithDefault<Class>(
+        m, "CollisionFilterManager", param, cls_doc.doc);
+    cls  // BR
+        .def("ExcludeCollisionsBetween", &Class::ExcludeCollisionsBetween,
+            py::arg("setA"), py::arg("setB"),
+            cls_doc.ExcludeCollisionsBetween.doc)
+        .def("ExcludeCollisionsWithin", &Class::ExcludeCollisionsWithin,
+            py::arg("set"), cls_doc.ExcludeCollisionsWithin.doc);
+  }
+
   //  SceneGraphInspector
   {
     using Class = SceneGraphInspector<T>;
@@ -548,26 +562,53 @@ void DoScalarDependentDefinitions(py::module m, T) {
                 &Class::RegisterAnchoredGeometry),
             py::arg("source_id"), py::arg("geometry"),
             cls_doc.RegisterAnchoredGeometry.doc)
+        .def("collision_filter_manager",
+            overload_cast_explicit<CollisionFilterManager<T>, Context<T>*>(
+                &Class::collision_filter_manager),
+            py::arg("context"),
+            // Keep alive, reference: `return` keeps `context` alive.
+            py::keep_alive<0, 2>(),  // BR.
+            cls_doc.collision_filter_manager.doc_1args)
+        .def("collision_filter_manager",
+            overload_cast_explicit<CollisionFilterManager<T>>(
+                &Class::collision_filter_manager),
+            // Keep alive, reference: `return` keeps `self` alive.
+            py::keep_alive<0, 1>(),  // BR
+            cls_doc.collision_filter_manager.doc_0args);
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
         .def("ExcludeCollisionsBetween",
-            py::overload_cast<const GeometrySet&, const GeometrySet&>(
-                &Class::ExcludeCollisionsBetween),
+            WrapDeprecated(
+                cls_doc.ExcludeCollisionsBetween.doc_deprecated_2args,
+                py::overload_cast<const GeometrySet&, const GeometrySet&>(
+                    &Class::ExcludeCollisionsBetween)),
             py_rvp::reference_internal, py::arg("setA"), py::arg("setB"),
-            cls_doc.ExcludeCollisionsBetween.doc_2args)
+            cls_doc.ExcludeCollisionsBetween.doc_deprecated_2args)
         .def("ExcludeCollisionsBetween",
-            overload_cast_explicit<void, Context<T>*, const GeometrySet&,
-                const GeometrySet&>(&Class::ExcludeCollisionsBetween),
+            WrapDeprecated(
+                cls_doc.ExcludeCollisionsBetween.doc_deprecated_3args,
+                overload_cast_explicit<void, Context<T>*, const GeometrySet&,
+                    const GeometrySet&>(&Class::ExcludeCollisionsBetween)),
             py_rvp::reference_internal, py::arg("context"), py::arg("setA"),
-            py::arg("setB"), cls_doc.ExcludeCollisionsBetween.doc_3args)
+            py::arg("setB"),
+            cls_doc.ExcludeCollisionsBetween.doc_deprecated_3args)
         .def("ExcludeCollisionsWithin",
-            py::overload_cast<const GeometrySet&>(
-                &Class::ExcludeCollisionsWithin),
+            WrapDeprecated(cls_doc.ExcludeCollisionsWithin.doc_deprecated_1args,
+                py::overload_cast<const GeometrySet&>(
+                    &Class::ExcludeCollisionsWithin)),
             py_rvp::reference_internal, py::arg("set"),
-            cls_doc.ExcludeCollisionsWithin.doc_1args)
+            cls_doc.ExcludeCollisionsWithin.doc_deprecated_1args)
         .def("ExcludeCollisionsWithin",
-            overload_cast_explicit<void, Context<T>*, const GeometrySet&>(
-                &Class::ExcludeCollisionsWithin),
+            WrapDeprecated(cls_doc.ExcludeCollisionsWithin.doc_deprecated_2args,
+                overload_cast_explicit<void, Context<T>*, const GeometrySet&>(
+                    &Class::ExcludeCollisionsWithin)),
             py_rvp::reference_internal, py::arg("context"), py::arg("set"),
-            cls_doc.ExcludeCollisionsWithin.doc_2args)
+            cls_doc.ExcludeCollisionsWithin.doc_deprecated_2args);
+#pragma GCC diagnostic pop
+
+    cls  // BR
         .def("AddRenderer", &Class::AddRenderer, py::arg("name"),
             py::arg("renderer"), cls_doc.AddRenderer.doc)
         .def("HasRenderer", &Class::HasRenderer, py::arg("name"),

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -756,10 +756,21 @@ class TestGeometry(unittest.TestCase):
         sg_context = sg.CreateDefaultContext()
         geometries = mut.GeometrySet()
 
-        sg.ExcludeCollisionsBetween(geometries, geometries)
-        sg.ExcludeCollisionsBetween(sg_context, geometries, geometries)
-        sg.ExcludeCollisionsWithin(geometries)
-        sg.ExcludeCollisionsWithin(sg_context, geometries)
+        # Mutate SceneGraph model.
+        dut = sg.collision_filter_manager()
+        dut.ExcludeCollisionsBetween(geometries, geometries)
+        dut.ExcludeCollisionsWithin(geometries)
+
+        # Mutate context.
+        dut = sg.collision_filter_manager(sg_context)
+        dut.ExcludeCollisionsBetween(geometries, geometries)
+        dut.ExcludeCollisionsWithin(geometries)
+
+        with catch_drake_warnings(expected_count=4):
+            sg.ExcludeCollisionsBetween(geometries, geometries)
+            sg.ExcludeCollisionsBetween(sg_context, geometries, geometries)
+            sg.ExcludeCollisionsWithin(geometries)
+            sg.ExcludeCollisionsWithin(sg_context, geometries)
 
     @numpy_compare.check_nonsymbolic_types
     def test_value_instantiations(self, T):

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -14,6 +14,7 @@ drake_cc_package_library(
     name = "geometry",
     visibility = ["//visibility:public"],
     deps = [
+        ":collision_filter_manager",
         ":drake_visualizer",
         ":frame_kinematics",
         ":geometry_frame",
@@ -61,6 +62,17 @@ drake_cc_library(
         "@fcl",
         "@fmt",
         "@tinyobjloader",
+    ],
+)
+
+drake_cc_library(
+    name = "collision_filter_manager",
+    srcs = ["collision_filter_manager.cc"],
+    hdrs = ["collision_filter_manager.h"],
+    deps = [
+        ":geometry_set",
+        ":geometry_state",
+        "//common:default_scalars",
     ],
 )
 
@@ -215,6 +227,7 @@ drake_cc_library(
         "scene_graph.h",
     ],
     deps = [
+        ":collision_filter_manager",
         ":geometry_state",
         ":scene_graph_inspector",
         "//common:essential",

--- a/geometry/collision_filter_manager.cc
+++ b/geometry/collision_filter_manager.cc
@@ -1,0 +1,30 @@
+#include "drake/geometry/collision_filter_manager.h"
+
+#include "drake/geometry/geometry_state.h"
+
+namespace drake {
+namespace geometry {
+
+template <typename T>
+CollisionFilterManager<T>::CollisionFilterManager(GeometryState<T>* state)
+    : state_(state) {
+  DRAKE_DEMAND(state != nullptr);
+}
+
+template <typename T>
+void CollisionFilterManager<T>::ExcludeCollisionsWithin(
+    const GeometrySet& set) {
+  state_->ExcludeCollisionsWithin(set);
+}
+
+template <typename T>
+void CollisionFilterManager<T>::ExcludeCollisionsBetween(
+    const GeometrySet& setA, const GeometrySet& setB) {
+  state_->ExcludeCollisionsBetween(setA, setB);
+}
+
+}  // namespace geometry
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::geometry::CollisionFilterManager)

--- a/geometry/collision_filter_manager.h
+++ b/geometry/collision_filter_manager.h
@@ -1,0 +1,132 @@
+#pragma once
+
+#include "drake/common/default_scalars.h"
+#include "drake/geometry/geometry_set.h"
+
+namespace drake {
+namespace geometry {
+
+// Forward declarations.
+template <typename T>
+class SceneGraph;
+template <typename T>
+class GeometryState;
+
+/** Class for configuring "collision filters"; collision filters limit the scope
+ of various proximity queries.
+
+ The sole source of %CollisionFilterManager instances is SceneGraph. See
+ @ref scene_graph_collision_filter_manager "SceneGraph's documentation" for
+ details on acquiring an instance. It is important that the lifespan of a
+ %CollisionFilterManager should *not* exceed the lifespan of its source -- a
+ SceneGraph for the model manager or the systems::Context for the context
+ manager.
+
+ The scene graph consists of the set of geometry
+ `G = D ⋃ A = {g₀, g₁, ..., gₙ}`, where D is the set of dynamic geometry and
+ A is the set of anchored geometry (by definition `D ⋂ A = ∅`). Many proximity
+ queries operate on pairs of geometries (e.g., (gᵢ, gⱼ)). The set of proximity
+ candidate pairs is initially defined as `C = (G × G) - (A × A) - F - I`,
+ where:
+     - `G × G = {(gᵢ, gⱼ)}, ∀ gᵢ, gⱼ ∈ G` is the cartesian product of the set of
+     %SceneGraph geometries.
+     - `A × A` represents all pairs consisting only of anchored geometry;
+     anchored geometry is never tested against other anchored geometry.
+     - `F = (gᵢ, gⱼ)`, such that `frame(gᵢ) == frame(gⱼ)`; the pair where both
+     geometries are rigidly affixed to the same frame. By implication,
+     `gᵢ, gⱼ ∈ D` as only dynamic geometries are affixed to frames.
+     - `I = {(g, g)}, ∀ g ∈ G` is the set of all pairs consisting of a geometry
+     with itself; there is no collision between a geometry and itself.
+
+ Only pairs contained in C will be included in pairwise proximity operations.
+ These methods allow users to modify the set C. Additional pairs can be removed,
+ but some pairs can never be re-introduced: e.g., the sets `A × A`, `F`, and `I`
+ will *never* be part of C; that is a SceneGraph invariant.
+
+ These manipulations take the form of declarations: e.g., exclude proximity
+ operations between the geometry pair (g, h). There is no penalty for
+ redundantly declaring that exclusion. After each declaration, the state of set
+ C will be modified (to the extent possible) to reflect the declaration (see
+ the earlier warning about pairs that are precluded from being a part of C).
+ Any declaration can be undone by subsequent declarations. The final
+ population of C is the aggregate result of a *sequence* of declarations. The
+ order of declarations matters. The declaration is applied immediately to the
+ current configuration of C.
+
+ @warning All collision filtering is done based on geometry state at the time
+ of the collision filtering calls. More concretely:
+ - For a particular FrameId in a GeometrySet instance, only those geometries
+    attached to the identified frame with the proximity role assigned at the
+    time of the call will be included in the filter. If geometries are
+    subsequently added or assigned the proximity role, they will not be
+    retroactively added to the user-declared filter.
+ - If the set includes geometries which have _not_ been assigned a proximity
+    role, those geometries will be ignored. If a proximity role is
+    subsequently assigned, those geometries will _still_ not be part of any
+    user-declared collision filters.
+ - In general, adding collisions and assigning proximity roles should
+    happen prior to collision filter configuration.
+
+ <h3>Collision filtering and geometry versions</h3>
+
+ Declaring a change to the set C will increment the proximity version (see
+ @ref scene_graph_versioning), even if applying the declaration doesn't actually
+ change the set C.
+
+ <!-- NOTE TO DEVELOPERS
+   There is no collision_filter_manager_test.cc. As this can only be constructed
+   by SceneGraph, the tests for this simple wrapper API are part of those tests
+   (exploiting the infrastructure for populating SceneGraph).
+ -->
+  */
+template <typename T>
+class CollisionFilterManager {
+ public:
+  /** @name Copy and move semantics
+
+   This class only implements MoveConstructible; copy construct and all
+   assignment are not allowed. */
+  //@{
+  CollisionFilterManager(const CollisionFilterManager&) = delete;
+  CollisionFilterManager& operator=(const CollisionFilterManager&) = delete;
+  /* Note: move construction is added to support python bindings. */
+  CollisionFilterManager(CollisionFilterManager&&) = default;
+  CollisionFilterManager& operator=(CollisionFilterManager&&) = delete;
+  //@}
+
+  /** Excludes geometry pairs from proximity operations by updating the
+   candidate pair set `C = C - P`, where `P = {(gᵢ, gⱼ)}, ∀ gᵢ, gⱼ ∈ G` and
+   `G = {g₀, g₁, ..., gₘ}` is the input `set` of geometries.
+
+   @throws std::logic_error if the set includes ids that don't exist in the
+                            scene graph.  */
+  void ExcludeCollisionsWithin(const GeometrySet& set);
+
+  /** Excludes geometry pairs from collision evaluation by updating the
+   candidate pair set `C = C - P`, where `P = {(a, b)}, ∀ a ∈ A, b ∈ B` and
+   `A = {a₀, a₁, ..., aₘ}` and `B = {b₀, b₁, ..., bₙ}` are the input sets of
+   geometries `setA` and `setB`, respectively. This does _not_ preclude
+   collisions between members of the _same_ set.
+
+   @throws std::logic_error if the groups include ids that don't exist in the
+                            scene graph.  */
+  void ExcludeCollisionsBetween(const GeometrySet& setA,
+                                const GeometrySet& setB);
+
+ private:
+  // Only SceneGraph can construct a collision filter manager.
+  template <typename>
+  friend class SceneGraph;
+
+  /* Constructs the manager with the underlying state instance that provides
+   support for the operations. */
+  explicit CollisionFilterManager(GeometryState<T>* state);
+
+  GeometryState<T>* state_{};
+};
+
+}  // namespace geometry
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::geometry::CollisionFilterManager)

--- a/geometry/geometry_set.h
+++ b/geometry/geometry_set.h
@@ -20,9 +20,9 @@ class GeometryState;
  frame to which the geometries are rigidly affixed.
 
  This class does no validation; it is a simple collection. Ultimately, it serves
- as the operand of SceneGraph operations (e.g.,
- SceneGraph::ExcludeCollisionsWithin()). If the _operation_ has a particular
- prerequisite on the members of a %GeometrySet, it is the operation's
+ as the operand of various operations (e.g.,
+ CollisionFilterManager::ExcludeCollisionsWithin()). If the _operation_ has a
+ particular prerequisite on the members of a %GeometrySet, it is the operation's
  responsibility to enforce that requirement.
 
  More formally, the SceneGraph consists of a set of geometries, each associated

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -325,6 +325,17 @@ const SceneGraphInspector<T>& SceneGraph<T>::model_inspector() const {
 }
 
 template <typename T>
+CollisionFilterManager<T> SceneGraph<T>::collision_filter_manager() {
+  return CollisionFilterManager<T>(&model_);
+}
+
+template <typename T>
+CollisionFilterManager<T> SceneGraph<T>::collision_filter_manager(
+    Context<T>* context) {
+  return CollisionFilterManager<T>(&mutable_geometry_state(context));
+}
+
+template <typename T>
 void SceneGraph<T>::ExcludeCollisionsWithin(const GeometrySet& geometry_set) {
   model_.ExcludeCollisionsWithin(geometry_set);
 }

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "drake/common/drake_deprecated.h"
+#include "drake/geometry/collision_filter_manager.h"
 #include "drake/geometry/geometry_set.h"
 #include "drake/geometry/geometry_state.h"
 #include "drake/geometry/query_object.h"
@@ -799,6 +800,38 @@ class SceneGraph final : public systems::LeafSystem<T> {
   const SceneGraphInspector<T>& model_inspector() const;
 
   /** @name         Collision filtering
+   @anchor scene_graph_collision_filter_manager
+
+   Control over "collision filtering" is handled by the CollisionFilterManager.
+   %SceneGraph provides access to the manager. As with other geometry data,
+   collision filters can be configured in %SceneGraph's *model* or in the copy
+   stored in a particular context. These methods provide access to the manager
+   for the data stored in either location.
+
+   Generally, it should be considered a bad practice to hang onto the instance
+   of CollisionFilterManager returned by collision_filter_manager(). It is not
+   immediately clear whether a particular CollisionFilterManager instance
+   refers to the %SceneGraph model or the Context data and persisting the
+   reference may lead to confusion. Keeping the reference for the duration of
+   a function is appropriate, but allowing it to persist outside of the scope
+   of acquisition is dangerous. Acquiring a new CollisionFilterManager is *very*
+   cheap, so feel free to discard and reacquire.  */
+  //@{
+
+  /** Returns the collision filter manager for this %SceneGraph instance's
+   *model*. `this` %SceneGraph must remain alive for at least as long as the
+   returned manager.  */
+  CollisionFilterManager<T> collision_filter_manager();
+
+  /** Returns the collision filter manager for data stored in `context`. The
+   context must remain alive for at least as long as the returned manager.  */
+  CollisionFilterManager<T> collision_filter_manager(
+      systems::Context<T>* context);
+  //@}
+
+  // TODO(SeanCurtis-TRI) Remove this entire group when we deprecate the methods
+  //  below.
+  /** @name         Collision filtering (deprecated)
    @anchor scene_graph_collision_filtering
    The interface for limiting the scope of penetration queries (i.e., "filtering
    collisions").
@@ -853,11 +886,19 @@ class SceneGraph final : public systems::LeafSystem<T> {
 
    @throws std::logic_error if the set includes ids that don't exist in the
                             scene graph.  */
+  DRAKE_DEPRECATED(
+      "2021-09-01",
+      "Please call collision_filter_manager().ExcludeCollisionsWithin() "
+      "instead")
   void ExcludeCollisionsWithin(const GeometrySet& set);
 
   /** systems::Context-modifying variant of ExcludeCollisionsWithin(). Rather
    than modifying %SceneGraph's model, it modifies the copy of the model stored
    in the provided context.  */
+  DRAKE_DEPRECATED(
+      "2021-09-01",
+      "Please call collision_filter_manager(context).ExcludeCollisionsWithin() "
+      "instead")
   void ExcludeCollisionsWithin(systems::Context<T>* context,
                                const GeometrySet& set) const;
 
@@ -873,12 +914,20 @@ class SceneGraph final : public systems::LeafSystem<T> {
 
    @throws std::logic_error if the groups include ids that don't exist in the
                             scene graph.  */
+  DRAKE_DEPRECATED(
+      "2021-09-01",
+      "Please call collision_filter_manager().ExcludeCollisionsBetween() "
+      "instead")
   void ExcludeCollisionsBetween(const GeometrySet& setA,
                                 const GeometrySet& setB);
 
   /** systems::Context-modifying variant of ExcludeCollisionsBetween(). Rather
    than modifying %SceneGraph's model, it modifies the copy of the model stored
    in the provided context.  */
+  DRAKE_DEPRECATED(
+      "2021-09-01",
+      "Please call collision_filter_manager(context).ExcludeCollisionsBetween()"
+      " instead")
   void ExcludeCollisionsBetween(systems::Context<T>* context,
                                 const GeometrySet& setA,
                                 const GeometrySet& setB) const;

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -165,12 +165,12 @@ class SceneGraphInspector {
   }
 
   /** Returns all pairs of geometries that are candidates for collision (in no
-   particular order). See SceneGraph::ExcludeCollisionsBetween() or
-   SceneGraph::ExcludeCollisionsWithin() for information on why a particular
-   pair may _not_ be a candidate. For candidate pair (A, B), the candidate is
-   always guaranteed to be reported in a fixed order (i.e., always (A, B) and
-   _never_ (B, A)). This is the same ordering as would be returned by, e.g.,
-   QueryObject::ComputePointPairPenetration().  */
+   particular order). See CollisionFilterManager::ExcludeCollisionsBetween() or
+   CollisionFilterManager::ExcludeCollisionsWithin() for information on why a
+   particular pair may _not_ be a candidate. For candidate pair (A, B), the
+   candidate is always guaranteed to be reported in a fixed order (i.e., always
+   (A, B) and _never_ (B, A)). This is the same ordering as would be returned
+   by, e.g., QueryObject::ComputePointPairPenetration().  */
   std::set<std::pair<GeometryId, GeometryId>> GetCollisionCandidates()
       const {
     DRAKE_DEMAND(state_ != nullptr);

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1322,9 +1322,9 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   /// For each of the provided `bodies`, collects up all geometries that have
   /// been registered to that body. Intended to be used in conjunction with
-  /// SceneGraph::ExcludeCollisionsWithin() and
-  /// SceneGraph::ExcludeCollisionsBetween() to filter collisions between the
-  /// geometries registered to the bodies.
+  /// CollisionFilterManager::ExcludeCollisionsWithin() and
+  /// CollisionFilterManager::ExcludeCollisionsBetween() to filter collisions
+  /// between the geometries registered to the bodies.
   ///
   /// For example:
   /// ```
@@ -1332,7 +1332,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// // `body2`, or `body3`.
   /// std::vector<const RigidBody<T>*> bodies{&body1, &body2, &body3};
   /// geometry::GeometrySet set = plant.CollectRegisteredGeometries(bodies);
-  /// scene_graph.ExcludeCollisionsWithin(set);
+  /// scene_graph.collision_filter_manager().ExcludeCollisionsWithin(set);
   /// ```
   ///
   /// @note There is a *very* specific order of operations:


### PR DESCRIPTION
In anticipation of expanding the functionality relating to working with collision filters, we're moving the collision filter API out of `SceneGraph` and into a custom class. `SceneGraph` can now produce the so-called `CollisionFilterManager`, but otherwise, knows nothing of the operations on collision filters.

To achieve this end:

  - Introduce new class: `CollisionFilterManager`.
  - Add new API: `SceneGraph::collision_filter_manager()`.
  - Deprecate old `SceneGraph::ExcludeCollisionsFoo()` methods.
  - Update references around the code from the old API to the new API.
  - For simplicity, the tests in `scene_graph_test.cc` related to this change have been duplicated. The test of the old API is labeled as deprecated (and decorated accordingly).
  - Extend `MultibodyPlant`'s `symbolic::Expression` stub for geometry to include the `CollisionFilterManager`.

Relates #15089.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15090)
<!-- Reviewable:end -->
