### PR TITLE
Add CollisionObject for deformable simulation

### DIFF
--- a/multibody/fixed_fem/dev/BUILD.bazel
+++ b/multibody/fixed_fem/dev/BUILD.bazel
@@ -12,6 +12,28 @@ package(
 )
 
 drake_cc_library(
+    name = "collision_objects",
+    srcs = [
+        "collision_objects.cc",
+    ],
+    hdrs = [
+        "collision_objects.h",
+    ],
+    deps = [
+        "//geometry:geometry_ids",
+        "//geometry:proximity_properties",
+        "//geometry:shape_specification",
+        "//geometry/proximity:make_box_mesh",
+        "//geometry/proximity:make_capsule_mesh",
+        "//geometry/proximity:make_cylinder_mesh",
+        "//geometry/proximity:make_ellipsoid_mesh",
+        "//geometry/proximity:make_sphere_mesh",
+        "//geometry/proximity:obj_to_surface_mesh",
+        "//geometry/proximity:surface_mesh",
+    ],
+)
+
+drake_cc_library(
     name = "constitutive_model",
     hdrs = [
         "constitutive_model.h",
@@ -499,14 +521,24 @@ drake_cc_library(
         ":state_updater",
     ],
 )
-# === test/ ===
 
+# === test/ ===
 drake_cc_library(
     name = "test_utilities",
     testonly = 1,
     hdrs = ["test/test_utilities.h"],
     deps = [
         "//common:essential",
+    ],
+)
+
+drake_cc_googletest(
+    name = "collision_objects_test",
+    data = ["//geometry:test_obj_files"],
+    deps = [
+        ":collision_objects",
+        "//common:find_resource",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/multibody/fixed_fem/dev/collision_objects.cc
+++ b/multibody/fixed_fem/dev/collision_objects.cc
@@ -1,0 +1,137 @@
+#include "drake/multibody/fixed_fem/dev/collision_objects.h"
+
+#include "drake/common/nice_type_name.h"
+#include "drake/geometry/proximity/make_box_mesh.h"
+#include "drake/geometry/proximity/make_capsule_mesh.h"
+#include "drake/geometry/proximity/make_cylinder_mesh.h"
+#include "drake/geometry/proximity/make_ellipsoid_mesh.h"
+#include "drake/geometry/proximity/make_sphere_mesh.h"
+#include "drake/geometry/proximity/obj_to_surface_mesh.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+namespace internal {
+using geometry::Box;
+using geometry::Capsule;
+using geometry::Convex;
+using geometry::Cylinder;
+using geometry::Ellipsoid;
+using geometry::HalfSpace;
+using geometry::Mesh;
+using geometry::ReadObjToSurfaceMesh;
+using geometry::Sphere;
+using geometry::SurfaceMesh;
+using geometry::internal::MakeBoxSurfaceMesh;
+using geometry::internal::MakeCapsuleSurfaceMesh;
+using geometry::internal::MakeCylinderSurfaceMesh;
+using geometry::internal::MakeEllipsoidSurfaceMesh;
+using geometry::internal::MakeSphereSurfaceMesh;
+
+template <typename ShapeType>
+SurfaceMesh<double> MakeRigidSurfaceMesh(const ShapeType& shape, double) {
+  throw std::logic_error(fmt::format(
+      "Trying to make a rigid surface mesh for an unsupported type shape. "
+      "The types supported are: Sphere, Box, Cylinder, Capsule, Ellipsoid, "
+      "Mesh and Convex. The shape provided is {}.",
+      NiceTypeName::Get(shape)));
+  DRAKE_UNREACHABLE();
+}
+
+SurfaceMesh<double> MakeRigidSurfaceMesh(const Sphere& sphere,
+                                         double resolution_hint) {
+  return MakeSphereSurfaceMesh<double>(sphere, resolution_hint);
+}
+
+SurfaceMesh<double> MakeRigidSurfaceMesh(const Box& box, double) {
+  // Use the coarsest mesh for the box. The safety factor 1.1 guarantees the
+  // resolution-hint argument is larger than the box size, so the mesh
+  // will have only 8 vertices and 12 triangles.
+  return MakeBoxSurfaceMesh<double>(box, 1.1 * box.size().maxCoeff());
+}
+
+SurfaceMesh<double> MakeRigidSurfaceMesh(const Cylinder& cylinder,
+                                         double resolution_hint) {
+  return MakeCylinderSurfaceMesh<double>(cylinder, resolution_hint);
+}
+
+SurfaceMesh<double> MakeRigidSurfaceMesh(const Capsule& capsule,
+                                         double resolution_hint) {
+  return MakeCapsuleSurfaceMesh<double>(capsule, resolution_hint);
+}
+
+SurfaceMesh<double> MakeRigidSurfaceMesh(const Ellipsoid& ellipsoid,
+                                         double resolution_hint) {
+  return MakeEllipsoidSurfaceMesh<double>(ellipsoid, resolution_hint);
+}
+
+SurfaceMesh<double> MakeRigidSurfaceMesh(const Mesh& mesh_spec, double) {
+  return ReadObjToSurfaceMesh(mesh_spec.filename(), mesh_spec.scale());
+}
+
+SurfaceMesh<double> MakeRigidSurfaceMesh(const Convex& convex_spec, double) {
+  return ReadObjToSurfaceMesh(convex_spec.filename(), convex_spec.scale());
+}
+
+template <typename T>
+void CollisionObjects<T>::ImplementGeometry(const Sphere& sphere,
+                                            void* user_data) {
+  MakeRigidRepresentation(sphere, *reinterpret_cast<ReifyData*>(user_data));
+}
+
+template <typename T>
+void CollisionObjects<T>::ImplementGeometry(const Cylinder& cylinder,
+                                            void* user_data) {
+  MakeRigidRepresentation(cylinder, *reinterpret_cast<ReifyData*>(user_data));
+}
+
+template <typename T>
+void CollisionObjects<T>::ImplementGeometry(const HalfSpace& half_space,
+                                            void* user_data) {
+  MakeRigidRepresentation(half_space, *reinterpret_cast<ReifyData*>(user_data));
+}
+
+template <typename T>
+void CollisionObjects<T>::ImplementGeometry(const Box& box, void* user_data) {
+  MakeRigidRepresentation(box, *reinterpret_cast<ReifyData*>(user_data));
+}
+
+template <typename T>
+void CollisionObjects<T>::ImplementGeometry(const Capsule& capsule,
+                                            void* user_data) {
+  MakeRigidRepresentation(capsule, *reinterpret_cast<ReifyData*>(user_data));
+}
+
+template <typename T>
+void CollisionObjects<T>::ImplementGeometry(const Ellipsoid& ellipsoid,
+                                            void* user_data) {
+  MakeRigidRepresentation(ellipsoid, *reinterpret_cast<ReifyData*>(user_data));
+}
+
+template <typename T>
+void CollisionObjects<T>::ImplementGeometry(const Mesh& mesh, void* user_data) {
+  MakeRigidRepresentation(mesh, *reinterpret_cast<ReifyData*>(user_data));
+}
+
+template <typename T>
+void CollisionObjects<T>::ImplementGeometry(const Convex& convex,
+                                            void* user_data) {
+  MakeRigidRepresentation(convex, *reinterpret_cast<ReifyData*>(user_data));
+}
+
+template <typename T>
+template <typename ShapeType>
+void CollisionObjects<T>::MakeRigidRepresentation(const ShapeType& shape,
+                                                  const ReifyData& data) {
+  rigid_representations_[data.id] = {
+      std::make_unique<SurfaceMesh<double>>(
+          MakeRigidSurfaceMesh(shape, kDefaultResolutionHint)),
+      data.properties};
+  geometry_ids_.emplace_back(data.id);
+}
+}  // namespace internal
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::fixed_fem::internal::CollisionObjects);

--- a/multibody/fixed_fem/dev/collision_objects.h
+++ b/multibody/fixed_fem/dev/collision_objects.h
@@ -1,0 +1,155 @@
+#pragma once
+
+#include <map>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "drake/common/copyable_unique_ptr.h"
+#include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/proximity/surface_mesh.h"
+#include "drake/geometry/proximity_properties.h"
+#include "drake/geometry/shape_specification.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+namespace internal {
+/* Representation of a group of rigid collision objects, consisting of their
+ poses in the world, surface meshes, and proximity properties. Collision objects
+ can be created by providing a unique GeometryId, a shape, and proximity
+ properties. Internally, a surface mesh is generated to approximate the given
+ shape. Collision objects can only be added but not removed. After a collision
+ object has been added, its proximity properties and surface mesh can be queried
+ with its unique GeometryId. Its pose can be queried and updated with the unique
+ GeometryId.
+ @tparam_default_scalar T. */
+template <typename T>
+class CollisionObjects : public geometry::ShapeReifier {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CollisionObjects);
+
+  CollisionObjects() = default;
+
+  /* Registers the geometry with the given `id`, `shape`, and
+   `proximity_properties` in `this` CollisionObjects. The newly added collision
+   object assumes the identity pose.
+   @pre No collision object with GeometryId `id` has been registered before. */
+  void AddCollisionObject(
+      geometry::GeometryId id, const geometry::Shape& shape,
+      const geometry::ProximityProperties& proximity_properties) {
+    DRAKE_DEMAND(rigid_representations_.count(id) == 0);
+    ReifyData data{id, proximity_properties};
+    shape.Reify(this, &data);
+  }
+
+  /* Returns the surface mesh of the geometry with GeometryId `id`.
+   @pre The geometry with `id` has been registered in `this` CollisionObject
+   with AddCollisionObject(). */
+  const geometry::SurfaceMesh<double>& mesh(geometry::GeometryId id) const {
+    const auto it = rigid_representations_.find(id);
+    DRAKE_DEMAND(it != rigid_representations_.end());
+    return *(it->second.surface_mesh);
+  }
+
+  /* Returns the proximity properties of the geometry with GeometryId `id`.
+   @pre The geometry with `id` has been registered in `this` CollisionObject
+   with AddCollisionObject(). */
+  const geometry::ProximityProperties& proximity_properties(
+      geometry::GeometryId id) const {
+    const auto it = rigid_representations_.find(id);
+    DRAKE_DEMAND(it != rigid_representations_.end());
+    return it->second.properties;
+  }
+
+  /* Returns the world pose of the geometry with GeometryId `id`.
+   @pre The geometry with `id` has been registered in `this` CollisionObject
+   with AddCollisionObject(). */
+  const math::RigidTransform<T>& pose_in_world(geometry::GeometryId id) const {
+    const auto it = rigid_representations_.find(id);
+    DRAKE_DEMAND(it != rigid_representations_.end());
+    return it->second.pose_in_world;
+  }
+
+  /* Updates the pose of the geometry with GeometryId `id` in world frame to the
+   given `pose`.
+   @pre The geometry with `id` has been registered in `this` CollisionObject
+   with AddCollisionObject(). */
+  void set_pose_in_world(geometry::GeometryId id,
+                         const math::RigidTransform<T>& pose) {
+    auto it = rigid_representations_.find(id);
+    DRAKE_DEMAND(it != rigid_representations_.end());
+    it->second.pose_in_world = pose;
+  }
+
+  /* Returns the GeometryIds for all collision objects with no particular order.
+   */
+  const std::vector<geometry::GeometryId>& geometry_ids() const {
+    return geometry_ids_;
+  }
+
+  // TODO(xuchenhan-tri): Configure this based on the measure of the geometry in
+  // question.
+  /* The default resolution hint for surface mesh representations of the rigid
+   geometries. */
+  static constexpr double kDefaultResolutionHint{0.01};
+
+ private:
+  /* Data to be used during reification. It is passed as the `user_data`
+   parameter in the ImplementGeometry API. */
+  struct ReifyData {
+    geometry::GeometryId id;
+    const geometry::ProximityProperties& properties;
+  };
+
+  /* The representation of a rigid collision object, consisting of a surface
+   mesh approximating the rigid geometry and the proximity properties of the
+   collision object. */
+  struct RigidRepresentation {
+    /* A default constructor is required so that RigidRepresentation can be used
+     as values in std::map. */
+    RigidRepresentation() = default;
+    /* Constructs a rigid representation with the given mesh and proximity
+     properties and identity pose in world. */
+    RigidRepresentation(std::unique_ptr<geometry::SurfaceMesh<double>> mesh,
+                        const geometry::ProximityProperties& props)
+        : surface_mesh(std::move(mesh)), properties(props) {}
+    /* We use copyable_unique_ptr here so that the data can be default
+     constructed and copy assigned. */
+    copyable_unique_ptr<geometry::SurfaceMesh<double>> surface_mesh;
+    geometry::ProximityProperties properties;
+    math::RigidTransform<T> pose_in_world;
+  };
+
+  void ImplementGeometry(const geometry::Sphere& sphere,
+                         void* user_data) override;
+  void ImplementGeometry(const geometry::Cylinder& cylinder,
+                         void* user_data) override;
+  void ImplementGeometry(const geometry::HalfSpace& half_space,
+                         void* user_data) override;
+  void ImplementGeometry(const geometry::Box& box, void* user_data) override;
+  void ImplementGeometry(const geometry::Capsule& capsule,
+                         void* user_data) override;
+  void ImplementGeometry(const geometry::Ellipsoid& ellipsoid,
+                         void* user_data) override;
+  void ImplementGeometry(const geometry::Mesh&, void*) override;
+  void ImplementGeometry(const geometry::Convex& convex,
+                         void* user_data) override;
+
+  /* Builds the rigid representation of the given `shape` with the given
+   ReifyData that includes the proximity properties of the geometry. Then
+   stores the rigid representation in a map from GeometryId to rigid
+   representations of all collision objects. */
+  template <typename ShapeType>
+  void MakeRigidRepresentation(const ShapeType& shape, const ReifyData& data);
+
+  std::map<geometry::GeometryId, RigidRepresentation> rigid_representations_;
+  /* GeometryIds for all rigid collision objects. */
+  std::vector<geometry::GeometryId> geometry_ids_;
+};
+}  // namespace internal
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::fixed_fem::internal::CollisionObjects);

--- a/multibody/fixed_fem/dev/test/collision_objects_test.cc
+++ b/multibody/fixed_fem/dev/test/collision_objects_test.cc
@@ -1,0 +1,183 @@
+#include "drake/multibody/fixed_fem/dev/collision_objects.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/proximity/make_box_mesh.h"
+#include "drake/geometry/proximity/make_capsule_mesh.h"
+#include "drake/geometry/proximity/make_cylinder_mesh.h"
+#include "drake/geometry/proximity/make_ellipsoid_mesh.h"
+#include "drake/geometry/proximity/make_sphere_mesh.h"
+#include "drake/geometry/proximity/obj_to_surface_mesh.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+namespace internal {
+namespace {
+using geometry::Box;
+using geometry::Capsule;
+using geometry::Convex;
+using geometry::Cylinder;
+using geometry::Ellipsoid;
+using geometry::GeometryId;
+using geometry::HalfSpace;
+using geometry::Mesh;
+using geometry::ProximityProperties;
+using geometry::ReadObjToSurfaceMesh;
+using geometry::Shape;
+using geometry::Sphere;
+using geometry::SurfaceMesh;
+using geometry::internal::MakeBoxSurfaceMesh;
+using geometry::internal::MakeCapsuleSurfaceMesh;
+using geometry::internal::MakeCylinderSurfaceMesh;
+using geometry::internal::MakeEllipsoidSurfaceMesh;
+using geometry::internal::MakeSphereSurfaceMesh;
+
+const char* const dummy_group_name = "group";
+const char* const dummy_property_name = "property";
+const double dummy_property_value = 3.14;
+
+class CollisionObjectsTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Make some dummy proximity properties.
+    proximity_properties_.AddProperty(dummy_group_name, dummy_property_name,
+                                      dummy_property_value);
+  }
+
+  void VerifyProximityProperties(GeometryId id) const {
+    const double retrieved_property =
+        collision_objects_.proximity_properties(id).GetProperty<double>(
+            dummy_group_name, dummy_property_name);
+    const double expected_property = proximity_properties_.GetProperty<double>(
+        dummy_group_name, dummy_property_name);
+    EXPECT_EQ(retrieved_property, expected_property);
+  }
+
+  CollisionObjects<double> collision_objects_;
+  ProximityProperties proximity_properties_;
+};
+
+TEST_F(CollisionObjectsTest, AddSphere) {
+  const GeometryId id = GeometryId::get_new_id();
+  const Sphere sphere(0.123);
+  collision_objects_.AddCollisionObject(id, sphere, proximity_properties_);
+
+  VerifyProximityProperties(id);
+
+  const SurfaceMesh<double> expected_surface_mesh =
+      MakeSphereSurfaceMesh<double>(
+          sphere, CollisionObjects<double>::kDefaultResolutionHint);
+  EXPECT_TRUE(expected_surface_mesh.Equal(collision_objects_.mesh(id)));
+}
+
+TEST_F(CollisionObjectsTest, AddBox) {
+  const GeometryId id = GeometryId::get_new_id();
+  const Box box(0.123, 0.456, 0.789);
+  collision_objects_.AddCollisionObject(id, box, proximity_properties_);
+
+  VerifyProximityProperties(id);
+
+  // The box mesh is always as coarse as possible.
+  const SurfaceMesh<double> expected_surface_mesh =
+      MakeBoxSurfaceMesh<double>(box, 1e10);
+  EXPECT_TRUE(expected_surface_mesh.Equal(collision_objects_.mesh(id)));
+}
+
+TEST_F(CollisionObjectsTest, AddCylinder) {
+  const GeometryId id = GeometryId::get_new_id();
+  const Cylinder cylinder(0.123, 0.456);
+  collision_objects_.AddCollisionObject(id, cylinder, proximity_properties_);
+
+  VerifyProximityProperties(id);
+
+  const SurfaceMesh<double> expected_surface_mesh =
+      MakeCylinderSurfaceMesh<double>(
+          cylinder, CollisionObjects<double>::kDefaultResolutionHint);
+  EXPECT_TRUE(expected_surface_mesh.Equal(collision_objects_.mesh(id)));
+}
+
+TEST_F(CollisionObjectsTest, AddCapsule) {
+  const GeometryId id = GeometryId::get_new_id();
+  const Capsule capsule(0.123, 0.456);
+  collision_objects_.AddCollisionObject(id, capsule, proximity_properties_);
+
+  VerifyProximityProperties(id);
+
+  const SurfaceMesh<double> expected_surface_mesh =
+      MakeCapsuleSurfaceMesh<double>(
+          capsule, CollisionObjects<double>::kDefaultResolutionHint);
+  EXPECT_TRUE(expected_surface_mesh.Equal(collision_objects_.mesh(id)));
+}
+
+TEST_F(CollisionObjectsTest, AddEllipsoid) {
+  const GeometryId id = GeometryId::get_new_id();
+  const Ellipsoid ellipsoid(0.123, 0.456, 0.789);
+  collision_objects_.AddCollisionObject(id, ellipsoid, proximity_properties_);
+
+  VerifyProximityProperties(id);
+
+  const SurfaceMesh<double> expected_surface_mesh =
+      MakeEllipsoidSurfaceMesh<double>(
+          ellipsoid, CollisionObjects<double>::kDefaultResolutionHint);
+  EXPECT_TRUE(expected_surface_mesh.Equal(collision_objects_.mesh(id)));
+}
+
+TEST_F(CollisionObjectsTest, AddConvex) {
+  const GeometryId id = GeometryId::get_new_id();
+  const Convex convex{drake::FindResourceOrThrow(
+      "drake/geometry/test/quad_cube.obj")};
+  collision_objects_.AddCollisionObject(id, convex, proximity_properties_);
+
+  VerifyProximityProperties(id);
+
+  const SurfaceMesh<double> expected_surface_mesh =
+      ReadObjToSurfaceMesh(convex.filename(), convex.scale());
+  EXPECT_TRUE(expected_surface_mesh.Equal(collision_objects_.mesh(id)));
+}
+
+TEST_F(CollisionObjectsTest, AddMesh) {
+  const GeometryId id = GeometryId::get_new_id();
+  const Mesh mesh{drake::FindResourceOrThrow(
+      "drake/geometry/test/non_convex_mesh.obj")};
+  collision_objects_.AddCollisionObject(id, mesh, proximity_properties_);
+
+  VerifyProximityProperties(id);
+
+  const SurfaceMesh<double> expected_surface_mesh =
+      ReadObjToSurfaceMesh(mesh.filename(), mesh.scale());
+  EXPECT_TRUE(expected_surface_mesh.Equal(collision_objects_.mesh(id)));
+}
+
+TEST_F(CollisionObjectsTest, AddHalfSpace) {
+  const GeometryId id = GeometryId::get_new_id();
+  const HalfSpace half_space;
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      collision_objects_.AddCollisionObject(id, half_space,
+                                            proximity_properties_),
+      std::exception,
+      "Trying to make a rigid surface mesh for an unsupported type shape. The "
+      "types supported are: Sphere, Box, Cylinder, Capsule, Ellipsoid, Mesh "
+      "and Convex. The shape provided is drake::geometry::HalfSpace.");
+}
+
+/* Exercises pose getter and setter. */
+TEST_F(CollisionObjectsTest, Poses) {
+  const GeometryId id = GeometryId::get_new_id();
+  const Box box(0.123, 0.456, 0.789);
+  collision_objects_.AddCollisionObject(id, box, proximity_properties_);
+  const auto identity = math::RigidTransform<double>();
+  EXPECT_TRUE(collision_objects_.pose_in_world(id).IsExactlyEqualTo(identity));
+  const math::RigidTransform<double> arbitrary_pose(
+      math::RollPitchYaw<double>(4., 5., 6.), Vector3<double>(1., 2., 3.));
+  collision_objects_.set_pose_in_world(id, arbitrary_pose);
+  EXPECT_TRUE(
+      collision_objects_.pose_in_world(id).IsExactlyEqualTo(arbitrary_pose));
+}
+}  // namespace
+}  // namespace internal
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Create a CollisionObject class that manages the geometric representations of rigid objects that are two-way coupled with deformable objects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15091)
<!-- Reviewable:end -->
