### PR TITLE
mkdoc: output argument is not optional

### DIFF
--- a/tools/workspace/pybind11/mkdoc.py
+++ b/tools/workspace/pybind11/mkdoc.py
@@ -32,7 +32,7 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 #  Syntax:
-#     mkdoc.py [-output=<file>] [-I<path> ..] [-quiet] [.. header files ..]
+#     mkdoc.py -output=<file> [-I<path> ..] [-quiet] [.. header files ..]
 #
 #  Extract documentation from C++ header files to use it in Python bindings
 #


### PR DESCRIPTION
Just a minor touch-up.  I tried running mkdoc without output specified (thinking it might print to the console), but it turns out that argument is actually required.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15093)
<!-- Reviewable:end -->
