### PR TITLE
[hotfix] Fix a mac ci build - test tolerance was too tight

### DIFF
--- a/multibody/plant/test/multibody_plant_forward_dynamics_test.cc
+++ b/multibody/plant/test/multibody_plant_forward_dynamics_test.cc
@@ -181,10 +181,10 @@ GTEST_TEST(MultibodyPlantForwardDynamics, AtlasRobot) {
   // Verify that the implicit dynamics match the continuous ones.
   Eigen::VectorXd residual = plant.AllocateImplicitTimeDerivativesResidual();
   plant.CalcImplicitTimeDerivativesResidual(*context, *derivatives, &residual);
-  // Note the slightly looser tolerance of 1e-13 which was required for this
+  // Note the slightly looser tolerance of 2e-13 which was required for this
   // test.
   EXPECT_TRUE(CompareMatrices(
-      residual, Eigen::VectorXd::Zero(plant.num_multibody_states()), 1e-13));
+      residual, Eigen::VectorXd::Zero(plant.num_multibody_states()), 2e-13));
 }
 
 // TODO(amcastro-tri): Include test with non-zero actuation and external forces.


### PR DESCRIPTION
The mac (in debug) needed a bit more tolerance in the test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15094)
<!-- Reviewable:end -->
