### PR TITLE
Reenable VGT test now that Catalina OpenCL is fixed

### DIFF
--- a/tools/workspace/voxelized_geometry_tools/BUILD.bazel
+++ b/tools/workspace/voxelized_geometry_tools/BUILD.bazel
@@ -3,11 +3,8 @@
 
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
-# TODO(jwnimmer-tri) Re-enable this test (rename it to sh_test), while ensuring
-# that it is only tested on Ubuntu; it does not pass on macOS.
-sh_binary(
+sh_test(
     name = "pointcloud_voxelization_test",
-    testonly = True,
     srcs = ["@voxelized_geometry_tools//:pointcloud_voxelization_test"],
 )
 


### PR DESCRIPTION
This test was previously disabled due to a bug introduced by Apple security update 2021-002 on Catalina, which caused OpenCL kernel compilation to fail. Now that the bug has been fixed by security update 2021-003, it can be reenabled.

See #15006 and #15005 for more details.

_Edit: Closes #15006._

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15095)
<!-- Reviewable:end -->
