### PR TITLE
system: Finish compatibility checks

### DIFF
--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -25,8 +25,9 @@ namespace systems {
 /// DiagramContext and are discouraged from subclassing LeafContext.
 ///
 /// A %Context is designed to be used only with the System that created it.
-/// State and Parameter data can be copied between contexts for compatible
-/// systems as necessary.
+/// Data encapsulated with State and Parameter objects can be copied between
+/// contexts for compatible systems with some restrictions. For details, see
+/// @ref system_compatibility.
 ///
 /// @tparam_default_scalar
 template <typename T>

--- a/systems/framework/context_base.h
+++ b/systems/framework/context_base.h
@@ -125,7 +125,8 @@ class ContextBase : public internal::ContextMessageInterface {
                                 : system_name_;
   }
 
-  /** (Internal) Gets the id of the subsystem that created this context. */
+  /** (Internal) Gets the id of the subsystem that created this context. For
+   * more information, see @ref system_compatibility. */
   internal::SystemId get_system_id() const { return system_id_; }
 
   /** Returns the full pathname of the subsystem for which this is the Context.

--- a/systems/framework/continuous_state.h
+++ b/systems/framework/continuous_state.h
@@ -194,11 +194,15 @@ class ContinuousState {
   /// Returns a copy of the entire continuous state vector into an Eigen vector.
   VectorX<T> CopyToVector() const { return this->get_vector().CopyToVector(); }
 
+  /** @name System compatibility
+  See @ref system_compatibility. */
+  //@{
   /** (Internal) Gets the id of the subsystem that created this state. */
   internal::SystemId get_system_id() const { return system_id_; }
 
   /** (Internal) Records the id of the subsystem that created this state. */
   void set_system_id(internal::SystemId id) { system_id_ = id; }
+  //@}
 
  protected:
   /// Constructs a continuous state that exposes second-order structure, with

--- a/systems/framework/diagram.cc
+++ b/systems/framework/diagram.cc
@@ -123,6 +123,8 @@ void Diagram<T>::SetDefaultParameters(const Context<T>& context,
   auto diagram_context = dynamic_cast<const DiagramContext<T>*>(&context);
   DRAKE_DEMAND(diagram_context != nullptr);
 
+  this->ValidateCreatedForThisSystem(params);
+
   int numeric_parameter_offset = 0;
   int abstract_parameter_offset = 0;
 
@@ -162,6 +164,7 @@ void Diagram<T>::SetDefaultParameters(const Context<T>& context,
         std::make_unique<DiscreteValues<T>>(numeric_params));
     subparameters.set_abstract_parameters(
         std::make_unique<AbstractValues>(abstract_params));
+    subparameters.set_system_id(subcontext.get_system_id());
 
     registered_systems_[i]->SetDefaultParameters(subcontext, &subparameters);
   }
@@ -174,6 +177,7 @@ void Diagram<T>::SetRandomState(const Context<T>& context, State<T>* state,
   auto diagram_context = dynamic_cast<const DiagramContext<T>*>(&context);
   DRAKE_DEMAND(diagram_context != nullptr);
 
+  this->ValidateCreatedForThisSystem(state);
   auto diagram_state = dynamic_cast<DiagramState<T>*>(state);
   DRAKE_DEMAND(diagram_state != nullptr);
 
@@ -192,6 +196,8 @@ void Diagram<T>::SetRandomParameters(const Context<T>& context,
   this->ValidateContext(context);
   auto diagram_context = dynamic_cast<const DiagramContext<T>*>(&context);
   DRAKE_DEMAND(diagram_context != nullptr);
+
+  this->ValidateCreatedForThisSystem(params);
 
   int numeric_parameter_offset = 0;
   int abstract_parameter_offset = 0;
@@ -230,6 +236,7 @@ void Diagram<T>::SetRandomParameters(const Context<T>& context,
         std::make_unique<DiscreteValues<T>>(numeric_params));
     subparameters.set_abstract_parameters(
         std::make_unique<AbstractValues>(abstract_params));
+    subparameters.set_system_id(subcontext.get_system_id());
 
     registered_systems_[i]->SetRandomParameters(subcontext, &subparameters,
                                                 generator);

--- a/systems/framework/diagram_context.cc
+++ b/systems/framework/diagram_context.cc
@@ -174,6 +174,7 @@ void DiagramContext<T>::MakeParameters() {
       std::make_unique<DiscreteValues<T>>(numeric_params));
   params->set_abstract_parameters(
       std::make_unique<AbstractValues>(abstract_params));
+  params->set_system_id(this->get_system_id());
   this->init_parameters(std::move(params));
 }
 

--- a/systems/framework/discrete_values.h
+++ b/systems/framework/discrete_values.h
@@ -171,12 +171,16 @@ class DiscreteValues {
     return result;
   }
 
+  /// @name System compatibility
+  /// See @ref system_compatibility.
+  //@{
   /// (Internal use only) Gets the id of the subsystem that created this object.
   internal::SystemId get_system_id() const { return system_id_; }
 
   /// (Internal use only) Records the id of the subsystem that created this
   /// object.
   void set_system_id(internal::SystemId id) { system_id_ = id; }
+  //@}
 
  private:
   // Throw unless this object is compatible with convenience methods; i.e., it

--- a/systems/framework/event_collection.h
+++ b/systems/framework/event_collection.h
@@ -658,6 +658,9 @@ class CompositeEventCollection {
     return *unrestricted_update_events_;
   }
 
+  /** @name System compatibility
+  See @ref system_compatibility. */
+  //@{
   /**
    * (Internal use only) Gets the id of the subsystem that created this
    * collection.
@@ -669,6 +672,7 @@ class CompositeEventCollection {
    * collection.
    */
   void set_system_id(internal::SystemId id) { system_id_ = id; }
+  //@}
 
  protected:
   /**

--- a/systems/framework/framework_common.h
+++ b/systems/framework/framework_common.h
@@ -108,7 +108,8 @@ class SystemBase;
 
 namespace internal {
 
-// Type used to match a Context to its System.
+// Type used to match a Context or other data object to its System. For
+// details, see @ref system_compatibility.
 using SystemId = drake::Identifier<class SystemIdTag>;
 
 // A utility to call the package-private constructor of some framework classes.

--- a/systems/framework/leaf_system.cc
+++ b/systems/framework/leaf_system.cc
@@ -172,6 +172,7 @@ template <typename T>
 void LeafSystem<T>::SetDefaultParameters(
     const Context<T>& context, Parameters<T>* parameters) const {
   this->ValidateContext(context);
+  this->ValidateCreatedForThisSystem(parameters);
   for (int i = 0; i < parameters->num_numeric_parameter_groups(); i++) {
     BasicVector<T>& p = parameters->get_mutable_numeric_parameter(i);
     auto model_vector = model_numeric_parameters_.CloneVectorModel<T>(i);
@@ -497,8 +498,10 @@ std::unique_ptr<Parameters<T>> LeafSystem<T>::AllocateParameters() const {
     DRAKE_ASSERT(param != nullptr);
     abstract_params.emplace_back(std::move(param));
   }
-  return std::make_unique<Parameters<T>>(std::move(numeric_params),
-                                         std::move(abstract_params));
+  auto result = std::make_unique<Parameters<T>>(std::move(numeric_params),
+                                                std::move(abstract_params));
+  result->set_system_id(this->get_system_id());
+  return result;
 }
 
 template <typename T>

--- a/systems/framework/parameters.h
+++ b/systems/framework/parameters.h
@@ -136,19 +136,38 @@ class Parameters {
     auto clone = std::make_unique<Parameters<T>>();
     clone->set_numeric_parameters(numeric_parameters_->Clone());
     clone->set_abstract_parameters(abstract_parameters_->Clone());
+    clone->set_system_id(get_system_id());
     return clone;
   }
 
-  /// Initializes this state from `other`.
+  /// Initializes this object from `other`.
   template <typename U>
   void SetFrom(const Parameters<U>& other) {
     numeric_parameters_->SetFrom(other.get_numeric_parameters());
     abstract_parameters_->SetFrom(other.get_abstract_parameters());
   }
 
+  /// @name System compatibility
+  /// See @ref system_compatibility.
+  //@{
+  /// (Internal use only) Gets the id of the subsystem that created this
+  /// object.
+  internal::SystemId get_system_id() const { return system_id_; }
+
+  /// (Internal use only) Records the id of the subsystem that created this
+  /// object.
+  void set_system_id(internal::SystemId id) {
+    system_id_ = id;
+    numeric_parameters_->set_system_id(id);
+  }
+  //@}
+
  private:
   std::unique_ptr<DiscreteValues<T>> numeric_parameters_;
   std::unique_ptr<AbstractValues> abstract_parameters_;
+
+  // Unique id of the subsystem that created this object.
+  internal::SystemId system_id_;
 };
 
 }  // namespace systems

--- a/systems/framework/state.h
+++ b/systems/framework/state.h
@@ -113,6 +113,9 @@ class State {
     abstract_state_->SetFrom(other.get_abstract_state());
   }
 
+  /// @name System compatibility
+  /// See @ref system_compatibility.
+  //@{
   /// (Internal use only) Gets the id of the subsystem that created this state.
   internal::SystemId get_system_id() const { return system_id_; }
 
@@ -123,6 +126,7 @@ class State {
     get_mutable_continuous_state().set_system_id(this->get_system_id());
     get_mutable_discrete_state().set_system_id(this->get_system_id());
   }
+  //@}
 
  private:
   std::unique_ptr<AbstractValues> abstract_state_;

--- a/systems/framework/system.cc
+++ b/systems/framework/system.cc
@@ -284,6 +284,7 @@ void System<T>::CalcDiscreteVariableUpdates(
     const EventCollection<DiscreteUpdateEvent<T>>& events,
     DiscreteValues<T>* discrete_state) const {
   ValidateContext(context);
+  ValidateCreatedForThisSystem(discrete_state);
 
   DispatchDiscreteVariableUpdateHandler(context, events, discrete_state);
 }
@@ -293,6 +294,7 @@ void System<T>::ApplyDiscreteVariableUpdate(
     const EventCollection<DiscreteUpdateEvent<T>>& events,
     DiscreteValues<T>* discrete_state, Context<T>* context) const {
   ValidateContext(context);
+  ValidateCreatedForThisSystem(discrete_state);
   DoApplyDiscreteVariableUpdate(events, discrete_state, context);
 }
 
@@ -310,6 +312,7 @@ void System<T>::CalcUnrestrictedUpdate(
     const EventCollection<UnrestrictedUpdateEvent<T>>& events,
     State<T>* state) const {
   ValidateContext(context);
+  ValidateCreatedForThisSystem(state);
   const int continuous_state_dim = state->get_continuous_state().size();
   const int discrete_state_dim = state->get_discrete_state().num_groups();
   const int abstract_state_dim = state->get_abstract_state().size();
@@ -329,6 +332,7 @@ void System<T>::ApplyUnrestrictedUpdate(
     const EventCollection<UnrestrictedUpdateEvent<T>>& events,
     State<T>* state, Context<T>* context) const {
   ValidateContext(context);
+  ValidateCreatedForThisSystem(state);
   DoApplyUnrestrictedUpdate(events, state, context);
 }
 
@@ -343,6 +347,7 @@ template <typename T>
 T System<T>::CalcNextUpdateTime(const Context<T>& context,
                                 CompositeEventCollection<T>* events) const {
   ValidateContext(context);
+  ValidateCreatedForThisSystem(events);
   DRAKE_DEMAND(events != nullptr);
   events->Clear();
   T time{NAN};
@@ -384,7 +389,7 @@ template <typename T>
 void System<T>::GetPerStepEvents(const Context<T>& context,
                                  CompositeEventCollection<T>* events) const {
   ValidateContext(context);
-  DRAKE_DEMAND(events != nullptr);
+  ValidateCreatedForThisSystem(events);
   events->Clear();
   DoGetPerStepEvents(context, events);
 }
@@ -394,7 +399,7 @@ void System<T>::GetInitializationEvents(
     const Context<T>& context,
     CompositeEventCollection<T>* events) const {
   ValidateContext(context);
-  DRAKE_DEMAND(events != nullptr);
+  ValidateCreatedForThisSystem(events);
   events->Clear();
   DoGetInitializationEvents(context, events);
 }

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -1152,7 +1152,7 @@ class SystemBase : public internal::SystemMessageInterface {
   }
 
   /** (Internal) Gets the id used to tag context data as being created by this
-  system. */
+  system. See @ref system_compatibility. */
   internal::SystemId get_system_id() const { return system_id_; }
 
  private:

--- a/systems/framework/system_compatibility_doxygen.h
+++ b/systems/framework/system_compatibility_doxygen.h
@@ -1,0 +1,76 @@
+/** @file
+ Doxygen-only documentation for @ref system_compatibility.  */
+
+//------------------------------------------------------------------------------
+/** @defgroup system_compatibility System Compatibility
+    @ingroup technical_notes
+
+System compatibility refers to the correspondence between a System and data
+structures used to hold the results of computation. Examples include Context,
+State, Parameters, etc. To avoid hard-to-debug errors when the wrong object is
+used with a System, public methods of System and System-derived classes check
+compatibility with objects by using unique system IDs. These IDs are applied to
+objects when System-provided methods are used to construct them:
+AllocateContext(), AllocateOutput(), etc.
+
+In most cases users should be able to ignore this compatibility checking
+mechanism; setting and checking of IDs should happen naturally in most
+cases. However, when copying data values between similar systems, some case
+must be taken. for example, a Clone() of a checked object will not work with a
+system different from its source, but constructing a destination object using
+methods of the destination System and using SetFrom() or lower level value
+accessors will work.
+
+<h2>Details</h2>
+
+A system ID is required for checking the correspondence between a
+system-specific data structure like a Context or DiscreteValues and the
+(unique) System which can accept it as a value. A data structure participates
+in the system ID hinting family by implementing the following concept:
+@code
+    internal::SystemId get_system_id() const;
+    void set_system_id(internal::SystemId id);
+@endcode
+get_system_id of an object whose set_system_id has not been called will return
+an invalid (default-constructed, zero-valued) ID.
+
+A System method participates by calling ValidateCreatedForThisSystem(&object)
+on an object that implements the concept.
+
+An invalid system ID represents the absence of information about the associated
+System; an object carrying an invalid system ID cannot be used in any
+participating System method, under penalty of std::exception.
+
+Likewise passing an object with valid system ID into a method of a System with
+different ID will result in a std::exception.
+
+An ID-bearing structure may contain ID-bearing substructures which have
+different (or invalid) IDs from their parent. Using such a structure may, but
+is not guaranteed to, result in a std::exception, depending on the semantics of
+the method called.
+
+Where an ID-bearing object implements Clone(), it MUST clone the system ID and,
+recursively, those of its members, whether valid or invalid.
+
+Where an ID-bearing object implements the potentially-scalar-converting
+SetFrom(), if the scalar types differ, it MUST NOT set the system IDs, nor may it
+set the system IDs of its copied members (because being of the wrong type it is
+no longer valid data for the original System). This prohibition does not apply
+when the scalar types are the same.
+
+Data types that currently implement the above-described scheme include Context,
+ContinuousState, DiscreteValues, CompositeEventCollection, Parameters, State,
+and SystemOutput.
+
+The SystemConstraint class uses a custom mechanism to extend checking of
+Context compatibility to its public methods.
+
+<h2>Effects on Public API</h2>
+
+This change does not declare a deprecation because virtually all of the
+affected use cases were invalid to begin with and would have resulted in errors
+later in the affected code. The exception is hand-constructed objects (i.e.,
+objects with public constructors that were not constructed through methods of
+System); most such objects have not worked reliably in the past anyway.
+
+*/

--- a/systems/framework/system_constraint.h
+++ b/systems/framework/system_constraint.h
@@ -258,6 +258,9 @@ class SystemConstraint final {
   const Eigen::VectorXd& upper_bound() const { return bounds_.upper(); }
   const std::string& description() const { return description_; }
 
+  /// @name System compatibility
+  /// See @ref system_compatibility.
+  //@{
   /// (Internal use only) Gets the id of the subsystem associated with this
   /// object, if one has been set.
   const std::optional<internal::SystemId>& get_system_id() const {
@@ -267,6 +270,7 @@ class SystemConstraint final {
   /// (Internal use only) Records the id of the subsystem associated with this
   /// object.
   void set_system_id(internal::SystemId id) { system_id_ = id; }
+  //@}
 
  private:
   static void NoopSystemConstraintCalc(

--- a/systems/framework/system_output.h
+++ b/systems/framework/system_output.h
@@ -91,9 +91,11 @@ class SystemOutput {
   }
 
   // Gets the id of the subsystem that created this output.
+  // See @ref system_compatibility.
   internal::SystemId get_system_id() const { return system_id_; }
 
   // Records the id of the subsystem that created this output.
+  // See @ref system_compatibility.
   void set_system_id(internal::SystemId id) { system_id_ = id; }
 
   std::vector<copyable_unique_ptr<AbstractValue>> port_values_;

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -3109,23 +3109,23 @@ GTEST_TEST(SystemTest, MissedEventIssue12620) {
     const double trigger_time_;
   };
 
-  LeafCompositeEventCollection<double> events;
-
   // First test returns NaN, which should be detected.
   TriggerTimeButNoEventSystem nan_system(NAN);
   auto nan_context = nan_system.AllocateContext();
+  auto events = nan_system.AllocateCompositeEventCollection();
   nan_context->SetTime(0.25);
   DRAKE_EXPECT_THROWS_MESSAGE(
-      nan_system.CalcNextUpdateTime(*nan_context, &events), std::exception,
+      nan_system.CalcNextUpdateTime(*nan_context, events.get()), std::exception,
       ".*CalcNextUpdateTime.*TriggerTimeButNoEventSystem.*MyTriggerSystem.*"
       "time=0.25.*no update time.*NaN.*Return infinity.*");
 
   // Second test returns a trigger time but no Event object.
   TriggerTimeButNoEventSystem trigger_system(0.375);
   auto trigger_context = trigger_system.AllocateContext();
+  events = trigger_system.AllocateCompositeEventCollection();
   trigger_context->SetTime(0.25);
   DRAKE_EXPECT_THROWS_MESSAGE(
-      trigger_system.CalcNextUpdateTime(*trigger_context, &events),
+      trigger_system.CalcNextUpdateTime(*trigger_context, events.get()),
       std::exception,
       ".*CalcNextUpdateTime.*TriggerTimeButNoEventSystem.*MyTriggerSystem.*"
       "time=0.25.*update time 0.375.*empty Event collection.*"
@@ -3148,13 +3148,12 @@ GTEST_TEST(SystemTest, ForgotToSetTheUpdateTime) {
     }
   };
 
-  LeafCompositeEventCollection<double> events;
-
   ForgotToSetTimeSystem forgot_system;
   auto forgot_context = forgot_system.AllocateContext();
+  auto events = forgot_system.AllocateCompositeEventCollection();
   forgot_context->SetTime(0.25);
   DRAKE_EXPECT_THROWS_MESSAGE(
-      forgot_system.CalcNextUpdateTime(*forgot_context, &events),
+      forgot_system.CalcNextUpdateTime(*forgot_context, events.get()),
       std::exception,
       ".*CalcNextUpdateTime.*ForgotToSetTimeSystem.*MyForgetfulSystem.*"
       "time=0.25.*no update time.*NaN.*Return infinity.*");

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -51,12 +51,16 @@ class TestSystem : public System<double> {
 
   std::unique_ptr<ContinuousState<double>> AllocateTimeDerivatives()
       const override {
-    return std::make_unique<ContinuousState<double>>();
+    auto result = std::make_unique<ContinuousState<double>>();
+    result->set_system_id(this->get_system_id());
+    return result;
   }
 
   std::unique_ptr<DiscreteValues<double>> AllocateDiscreteVariables()
       const override {
-    return std::make_unique<DiscreteValues<double>>();
+    auto result = std::make_unique<DiscreteValues<double>>();
+    result->set_system_id(this->get_system_id());
+    return result;
   }
 
   std::unique_ptr<CompositeEventCollection<double>>


### PR DESCRIPTION
Relevant to: #12560

Add system-id labeling to the Parameters type. Check compatibility of
objects at public methods of System, Diagram, and LeafSystem.

This patch completes compatibility checking for System and its derived
classes, including some Diagram methods missed in #15030. Further work
remains to close the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15098)
<!-- Reviewable:end -->
