### PR TITLE
framework: Remove more heap allocations from events

### DIFF
--- a/systems/analysis/test/simulator_limit_malloc_test.cc
+++ b/systems/analysis/test/simulator_limit_malloc_test.cc
@@ -54,6 +54,7 @@ class EventfulSystem final : public LeafSystem<double> {
 // Tests that heap allocations do not occur from Simulator and the systems
 // framework for systems that do various event updates and do not have
 // continuous state.
+// TODO(rpoyner-tri): add testing for witness functions.
 GTEST_TEST(SimulatorLimitMallocTest,
            NoHeapAllocsInSimulatorForSystemsWithoutContinuousState) {
   // Build a Diagram containing the test system so we can test both Diagrams
@@ -75,8 +76,7 @@ GTEST_TEST(SimulatorLimitMallocTest,
     // goal (see #14543) is for the simulator and framework to support
     // heap-free simulation after initialization, given careful system
     // construction.
-    // TODO(rpoyner-tri): whittle allocations down to 0.
-    test::LimitMalloc heap_alloc_checker({.max_num_allocations = 21});
+    test::LimitMalloc heap_alloc_checker({.max_num_allocations = 0});
     simulator.AdvanceTo(1.0);
     simulator.AdvanceTo(2.0);
     simulator.AdvanceTo(3.0);

--- a/systems/framework/event.h
+++ b/systems/framework/event.h
@@ -672,9 +672,9 @@ class PublishEvent final : public Event<T> {
  private:
   void DoAddToComposite(TriggerType trigger_type,
                         CompositeEventCollection<T>* events) const final {
-    auto event = std::unique_ptr<PublishEvent<T>>(this->DoClone());
-    event->set_trigger_type(trigger_type);
-    events->add_publish_event(std::move(event));
+    PublishEvent event(*this);
+    event.set_trigger_type(trigger_type);
+    events->AddPublishEvent(std::move(event));
   }
 
   // Clones PublishEvent-specific data.
@@ -780,9 +780,9 @@ class DiscreteUpdateEvent final : public Event<T> {
  private:
   void DoAddToComposite(TriggerType trigger_type,
                         CompositeEventCollection<T>* events) const final {
-    auto event = std::unique_ptr<DiscreteUpdateEvent<T>>(this->DoClone());
-    event->set_trigger_type(trigger_type);
-    events->add_discrete_update_event(std::move(event));
+    DiscreteUpdateEvent<T> event(*this);
+    event.set_trigger_type(trigger_type);
+    events->AddDiscreteUpdateEvent(std::move(event));
   }
 
   // Clones DiscreteUpdateEvent-specific data.
@@ -888,9 +888,9 @@ class UnrestrictedUpdateEvent final : public Event<T> {
  private:
   void DoAddToComposite(TriggerType trigger_type,
                         CompositeEventCollection<T>* events) const final {
-    auto event = std::unique_ptr<UnrestrictedUpdateEvent<T>>(this->DoClone());
-    event->set_trigger_type(trigger_type);
-    events->add_unrestricted_update_event(std::move(event));
+    UnrestrictedUpdateEvent<T> event(*this);
+    event.set_trigger_type(trigger_type);
+    events->AddUnrestrictedUpdateEvent(std::move(event));
   }
 
   // Clones event data specific to UnrestrictedUpdateEvent.

--- a/systems/framework/event_collection.h
+++ b/systems/framework/event_collection.h
@@ -341,7 +341,7 @@ class LeafEventCollection final : public EventCollection<EventType> {
   MakeForcedEventCollection() {
     auto ret = std::make_unique<LeafEventCollection<EventType>>();
     EventType event(EventType::TriggerType::kForced);
-    ret->AddEvent(event);
+    ret->AddEvent(std::move(event));
     return ret;
   }
 
@@ -520,11 +520,22 @@ class CompositeEventCollection {
    * transferred) to it.
    * @throws std::bad_cast if the assumption is incorrect.
    */
+  DRAKE_DEPRECATED("2021-09-01", "Use AddPublishEvent instead.")
   void add_publish_event(std::unique_ptr<PublishEvent<T>> event) {
     DRAKE_DEMAND(event != nullptr);
+    AddPublishEvent(std::move(*event));
+  }
+
+  /**
+   * Assuming the internal publish event collection is an instance of
+   * LeafEventCollection, adds the publish event `event` (ownership is also
+   * transferred) to it.
+   * @throws std::bad_cast if the assumption is incorrect.
+   */
+  void AddPublishEvent(PublishEvent<T> event) {
     auto& events = dynamic_cast<LeafEventCollection<PublishEvent<T>>&>(
         this->get_mutable_publish_events());
-    events.add_event(std::move(event));
+    events.AddEvent(std::move(event));
   }
 
   /**
@@ -533,12 +544,23 @@ class CompositeEventCollection {
    * also transferred) to it.
    * @throws std::bad_cast if the assumption is incorrect.
    */
+  DRAKE_DEPRECATED("2021-09-01", "Use AddDiscreteUpdateEvent instead.")
   void add_discrete_update_event(
       std::unique_ptr<DiscreteUpdateEvent<T>> event) {
     DRAKE_DEMAND(event != nullptr);
+    AddDiscreteUpdateEvent(std::move(*event));
+  }
+
+  /**
+   * Assuming the internal discrete update event collection is an instance of
+   * LeafEventCollection, adds the discrete update event `event` (ownership is
+   * also transferred) to it.
+   * @throws std::bad_cast if the assumption is incorrect.
+   */
+  void AddDiscreteUpdateEvent(DiscreteUpdateEvent<T> event) {
     auto& events = dynamic_cast<LeafEventCollection<DiscreteUpdateEvent<T>>&>(
         this->get_mutable_discrete_update_events());
-    events.add_event(std::move(event));
+    events.AddEvent(std::move(event));
   }
 
   /**
@@ -547,13 +569,24 @@ class CompositeEventCollection {
    * (ownership is also transferred) to it.
    * @throws std::bad_cast if the assumption is incorrect.
    */
+  DRAKE_DEPRECATED("2021-09-01", "Use AddUnrestrictedUpdateEvent instead.")
   void add_unrestricted_update_event(
       std::unique_ptr<UnrestrictedUpdateEvent<T>> event) {
     DRAKE_DEMAND(event != nullptr);
+    AddUnrestrictedUpdateEvent(std::move(*event));
+  }
+
+  /**
+   * Assuming the internal unrestricted update event collection is an instance
+   * of LeafEventCollection, adds the unrestricted update event `event`
+   * (ownership is also transferred) to it.
+   * @throws std::bad_cast if the assumption is incorrect.
+   */
+  void AddUnrestrictedUpdateEvent(UnrestrictedUpdateEvent<T> event) {
     auto& events =
         dynamic_cast<LeafEventCollection<UnrestrictedUpdateEvent<T>>&>(
             this->get_mutable_unrestricted_update_events());
-    events.add_event(std::move(event));
+    events.AddEvent(std::move(event));
   }
 
   /**


### PR DESCRIPTION
Relevant to: #14543

Remove unnecessary heap allocations from the rest of the event system.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15101)
<!-- Reviewable:end -->
