### PR TITLE
system constraint: Add compatibility checks

### DIFF
--- a/systems/framework/system.cc
+++ b/systems/framework/system.cc
@@ -989,6 +989,7 @@ SystemConstraintIndex System<T>::AddConstraint(
         GetSystemName(), constraint->description(),
         external_constraints_.front().description()));
   }
+  constraint->set_system_id(this->get_system_id());
   constraints_.push_back(std::move(constraint));
   return SystemConstraintIndex(constraints_.size() - 1);
 }

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -483,7 +483,10 @@ TEST_F(SystemTest, SystemConstraintTest) {
   EXPECT_EQ(test_constraint, 0);
 
   DRAKE_EXPECT_NO_THROW(system_.get_constraint(test_constraint));
-  EXPECT_EQ(system_.get_constraint(test_constraint).description(), "test");
+  const auto& constraint_ref = system_.get_constraint(test_constraint);
+  EXPECT_EQ(constraint_ref.description(), "test");
+  EXPECT_TRUE(constraint_ref.get_system_id().has_value());
+  EXPECT_EQ(*constraint_ref.get_system_id(), context_->get_system_id());
 
   const double tol = 1e-6;
   EXPECT_TRUE(system_.CheckSystemConstraintsSatisfied(*context_, tol));


### PR DESCRIPTION
Relevant to: #12560

Add system id label to SystemConstraint. Set the correct label on admission to a system via AddConstraint(). Check compatibility of contexts at public methods of SystemConstraint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15102)
<!-- Reviewable:end -->
