### PR TITLE
add screw joint

### DIFF
--- a/multibody/tree/BUILD.bazel
+++ b/multibody/tree/BUILD.bazel
@@ -121,6 +121,7 @@ drake_cc_library(
         "revolute_mobilizer.cc",
         "revolute_spring.cc",
         "rigid_body.cc",
+        "screw_joint.cc",
         "screw_mobilizer.cc",
         "space_xyz_floating_mobilizer.cc",
         "space_xyz_mobilizer.cc",
@@ -162,6 +163,7 @@ drake_cc_library(
         "revolute_mobilizer.h",
         "revolute_spring.h",
         "rigid_body.h",
+        "screw_joint.h",
         "screw_mobilizer.h",
         "space_xyz_floating_mobilizer.h",
         "space_xyz_mobilizer.h",
@@ -565,6 +567,13 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "prismatic_joint_test",
+    deps = [
+        ":tree",
+    ],
+)
+
+drake_cc_googletest(
+    name = "screw_joint_test",
     deps = [
         ":tree",
     ],

--- a/multibody/tree/screw_joint.cc
+++ b/multibody/tree/screw_joint.cc
@@ -1,0 +1,71 @@
+#include "drake/multibody/tree/screw_joint.h"
+
+#include <memory>
+
+#include "drake/multibody/tree/multibody_tree.h"
+
+namespace drake {
+namespace multibody {
+
+template <typename T>
+template <typename ToScalar>
+std::unique_ptr<Joint<ToScalar>> ScrewJoint<T>::TemplatedDoCloneToScalar(
+    const internal::MultibodyTree<ToScalar>& tree_clone) const {
+  const Frame<ToScalar>& frame_on_parent_body_clone =
+      tree_clone.get_variant(this->frame_on_parent());
+  const Frame<ToScalar>& frame_on_child_body_clone =
+      tree_clone.get_variant(this->frame_on_child());
+
+  // Make the Joint<T> clone.
+  auto joint_clone = std::make_unique<ScrewJoint<ToScalar>>(
+      this->name(), frame_on_parent_body_clone, frame_on_child_body_clone,
+      this->screw_pitch(),
+      this->damping());
+  joint_clone->set_position_limits(this->position_lower_limits(),
+                                   this->position_upper_limits());
+  joint_clone->set_velocity_limits(this->velocity_lower_limits(),
+                                   this->velocity_upper_limits());
+  joint_clone->set_acceleration_limits(this->acceleration_lower_limits(),
+                                       this->acceleration_upper_limits());
+  joint_clone->set_default_positions(this->default_positions());
+
+  return joint_clone;
+}
+
+template <typename T>
+std::unique_ptr<Joint<double>> ScrewJoint<T>::DoCloneToScalar(
+    const internal::MultibodyTree<double>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
+template <typename T>
+std::unique_ptr<Joint<AutoDiffXd>> ScrewJoint<T>::DoCloneToScalar(
+    const internal::MultibodyTree<AutoDiffXd>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
+template <typename T>
+std::unique_ptr<Joint<symbolic::Expression>> ScrewJoint<T>::DoCloneToScalar(
+    const internal::MultibodyTree<symbolic::Expression>& tree_clone) const {
+  return TemplatedDoCloneToScalar(tree_clone);
+}
+
+// N.B. Due to esoteric linking errors on Mac (see #9345) involving
+// `MobilizerImpl`, we must place this implementation in the source file, not
+// in the header file.
+template <typename T>
+std::unique_ptr<typename Joint<T>::BluePrint>
+ScrewJoint<T>::MakeImplementationBlueprint() const {
+  auto blue_print = std::make_unique<typename Joint<T>::BluePrint>();
+  auto screw_mobilizer = std::make_unique<internal::ScrewMobilizer<T>>(
+      this->frame_on_parent(), this->frame_on_child(), screw_pitch_);
+  screw_mobilizer->set_default_position(this->default_positions());
+  blue_print->mobilizers_.push_back(std::move(screw_mobilizer));
+  return blue_print;
+}
+
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::ScrewJoint)

--- a/multibody/tree/screw_joint.h
+++ b/multibody/tree/screw_joint.h
@@ -1,0 +1,348 @@
+#pragma once
+
+#include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/multibody/tree/joint.h"
+#include "drake/multibody/tree/multibody_forces.h"
+#include "drake/multibody/tree/screw_mobilizer.h"
+
+namespace drake {
+namespace multibody {
+
+/// This joint models a screw joint allowing two bodies to rotate
+/// about one axis while translating along that same axis with one degree of
+///  freedom.
+/// That is, given a frame F attached to the parent body P and a frame M
+/// attached to the child body B (see the Joint class's documentation), this
+/// joint allows frame M to translate (while rotating) along the z axis
+/// of frame F, with M's z-axis Mz and F's z-axis Fz coincident at
+/// all times. The rotation about z-axis of F  and their rate
+/// specify the state of the joint.
+/// Zero (θ) corresponds to frames F and M being coincident and aligned.
+/// Translation z is defined to be positive in the direction of the
+/// respective axis and the rotation θ is defined to be positive according to
+/// the right-hand-rule with the thumb aligned in the direction of frame F's
+/// z-axis.
+///
+/// @tparam_default_scalar
+template <typename T>
+class ScrewJoint final : public Joint<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ScrewJoint)
+
+  template <typename Scalar>
+  using Context = systems::Context<Scalar>;
+
+  /// The name for this Joint type.
+  static constexpr char kTypeName[] = "screw";
+
+  /// Constructor to create a screw joint between two bodies so that frame F
+  /// attached to the parent body P and frame M attached to the child body B
+  /// translate and rotate as described in the class's documentation.
+  /// This constructor signature creates a joint with no joint limits, i.e. the
+  /// joint angular position, angular velocity and angular acceleration limits
+  /// are the pair `(-∞, ∞)`.
+  /// These can be set using the Joint methods set_position_limits(),
+  /// set_velocity_limits() and set_acceleration_limits() in radians,
+  /// radians/sec, radians/sec^2 units.
+  /// The first three arguments to this constructor are those of the Joint class
+  /// constructor. See the Joint class's documentation for details.
+  /// The additional parameters are:
+  /// @param[in] screw_pitch
+  ///   Amount of translation in meters occuring over a one full
+  ///   screw revolution. It's domain is (-∞, ∞). When the screw pitch is
+  ///   negative, positive rotation will result in translating towards the
+  ///   negative direction of z-axis. When the screw pitch is zero, this joint
+  ///   will behave like a revolute joint.
+  /// @param[in] damping
+  ///   Viscous damping coefficient, N⋅m⋅s/rad for
+  ///   rotation, used to model losses within the joint. See documentation of
+  ///   damping() for details on modelling of the damping torque.
+  /// @throws std::exception if damping is negative.
+  ScrewJoint(const std::string& name, const Frame<T>& frame_on_parent,
+              const Frame<T>& frame_on_child,
+              double screw_pitch,
+              double damping)
+      : Joint<T>(name, frame_on_parent, frame_on_child,
+                 VectorX<double>::Constant(
+                     1, -std::numeric_limits<double>::infinity()),
+                 VectorX<double>::Constant(
+                     1, std::numeric_limits<double>::infinity()),
+                 VectorX<double>::Constant(
+                     1, -std::numeric_limits<double>::infinity()),
+                 VectorX<double>::Constant(
+                     1, std::numeric_limits<double>::infinity()),
+                 VectorX<double>::Constant(
+                     1, -std::numeric_limits<double>::infinity()),
+                 VectorX<double>::Constant(
+                     1, std::numeric_limits<double>::infinity()))
+      , screw_pitch_{screw_pitch}
+      , damping_{damping} {
+    DRAKE_THROW_UNLESS(damping >= 0);
+  }
+
+  const std::string& type_name() const final {
+    static const never_destroyed<std::string> name{kTypeName};
+    return name.access();
+  }
+
+  /// Returns `this` joint's amount of translation in meters
+  /// occuring over a one full revolution.
+  double screw_pitch() const { return screw_pitch_; }
+
+  /// Returns `this` joint's damping constant N⋅m⋅s for the rotational degree.
+  /// The damping torque (in N⋅m) is modeled as `τ = -damping⋅ω` i.e.
+  ///  opposing motion, with ω the angular rate for `this` joint
+  ///  (see get_angular_velocity()) and τ the torque on
+  /// child body B expressed in frame F as t_B_F = τ⋅Fz_F.
+  double damping() const { return damping_; }
+
+  /// @name Context-dependent value access
+  /// @{
+
+  /// Gets the translation of `this` joint from `context`.
+  ///
+  /// @param[in] context The context of the model this joint belongs to.
+  /// @retval z The translation of `this` joint stored in the `context` as (z).
+  ///           See class documentation for details.
+  T get_translation(const Context<T>& context) const {
+    return get_mobilizer()->get_translation(context);
+  }
+
+  /// Sets the `context` so that the translation of `this` joint equals to (z).
+  ///
+  /// @param[in] context The context of the model this joint belongs to.
+  /// @param[in] z The desired translation in meters to be stored in `context`
+  ///              as (z). See class documentation for details.
+  /// @returns a constant reference to `this` joint.
+  const ScrewJoint<T>& set_translation(Context<T>* context,
+                                       const T& z) const {
+    get_mobilizer()->set_translation(context, z);
+    return *this;
+  }
+
+  /// Gets the angle θ of `this` joint from `context`.
+  ///
+  /// @param[in] context The context of the model this joint belongs to.
+  /// @retval theta The angle of `this` joint stored in the `context`. See class
+  ///               documentation for details.
+  T get_rotation(const systems::Context<T>& context) const {
+    return get_mobilizer()->get_angle(context);
+  }
+
+  /// Sets the `context` so that the angle θ of `this` joint equals `theta`.
+  ///
+  /// @param[in] context The context of the model this joint belongs to.
+  /// @param[in] theta The desired angle in radians to be stored in `context`.
+  ///                  See class documentation for details.
+  /// @returns a constant reference to `this` joint.
+  const ScrewJoint<T>& set_rotation(systems::Context<T>* context,
+                                     const T& theta) const {
+    get_mobilizer()->set_angle(context, theta);
+    return *this;
+  }
+
+  /// Gets the translational velocity vz, in meters per second, of `this`
+  /// joint's Mo measured and expressed in frame F from `context`.
+  /// @param[in] context The context of the model this joint belongs to.
+  /// @retval vz The translational velocity of `this` joint as stored in the
+  ///            `context`.
+  T get_translational_velocity(
+      const systems::Context<T>& context) const {
+    return get_mobilizer()->get_translation_rate(context);
+  }
+
+  /// Sets the translational velocity, in meters per second, of this `this`
+  /// joint's Mo along frame F's Z-axis to `vz`. The new
+  /// translational velocity gets stored in `context`.
+  /// @param[in] context The context of the model this joint belongs to.
+  /// @param[in] vz The desired translational velocity of `this` joint in meters
+  ///               per second along F frame's Z-axis.
+  /// @returns a constant reference to `this` joint.
+  const ScrewJoint<T>& set_translational_velocity(
+      systems::Context<T>* context, const T& vz) const {
+    get_mobilizer()->set_translation_rate(context, vz);
+    return *this;
+  }
+
+  /// Gets the rate of change, in radians per second, of `this` joint's angle
+  /// θ from `context`.  See class documentation for the definition of this
+  /// angle.
+  ///
+  /// @param[in] context The context of the model this joint belongs to.
+  /// @retval theta_dot The rate of change of `this` joint's angle θ as
+  ///                   stored in the `context`.
+  T get_angular_velocity(const systems::Context<T>& context) const {
+    return get_mobilizer()->get_angular_rate(context);
+  }
+
+  /// Sets the rate of change, in radians per second, of `this` joint's angle
+  /// θ (see class documentation) to `theta_dot`. The new rate of change gets
+  /// stored in `context`.
+  ///
+  /// @param[in] context The context of the model this joint belongs to.
+  /// @param[in] theta_dot The desired rates of change of `this` joint's
+  ///                      angle in radians per second.
+  /// @returns a constant reference to `this` joint.
+  const ScrewJoint<T>& set_angular_velocity(systems::Context<T>* context,
+                                             const T& theta_dot) const {
+    get_mobilizer()->set_angular_rate(context, theta_dot);
+    return *this;
+  }
+
+  /// @}
+
+  /// Gets the default position for `this` joint.
+  /// @retval z The default position of `this` joint.
+  T get_default_translation() const {
+    return internal::get_screw_translation_from_rotation(
+        this->default_positions()[0], screw_pitch());
+  }
+
+  /// Sets the default translation of this joint. This will change
+  /// the `default_rotation` too, which are not independent in this joint.
+  /// @param[in] z The desired default translation of the joint
+  /// @throws std::exception if pitch is very near zero.
+  void set_default_translation(const double& z) {
+    Vector1<double> state(internal::get_screw_rotation_from_translation(
+        z, screw_pitch()));
+    this->set_default_positions(state);
+  }
+
+  /// Gets the default angle for `this` joint.
+  /// @retval theta The default angle of `this` joint.
+  double get_default_rotation() const { return this->default_positions()[0]; }
+
+  /// Sets the default angle of this joint. This will change the
+  /// `default_translation` too, because they are not independent in this joint.
+  /// @param[in] theta The desired default angle of the joint
+  void set_default_rotation(double theta) {
+    Vector1<double> state(theta);
+    this->set_default_positions(state);
+  }
+
+  /// Sets the random distribution that the angle of this
+  /// joint will be randomly sampled from. See class documentation for details
+  /// on the definition of the position and angle.
+  void set_random_pose_distribution(
+      const Vector1<symbolic::Expression>& theta) {
+    get_mutable_mobilizer()->set_random_position_distribution(theta);
+  }
+
+ private:
+  /* Joint<T> override called through public NVI, Joint::AddInForce().
+   Therefore arguments were already checked to be valid.
+   For a ScrewJoint, we must always have `joint_dof = 0` since there is
+   one degree of freedom (num_velocities() == 1). `joint_tau` is the torque
+   about the z-axis of the parent frame F if `joint_dof = 0`.
+   The force is applied to the body declared as child (according to the
+   screw joint's constructor) at the origin of the child frame M. The force
+   is defined to be positive in the direction of the selected axis and the
+   torque is defined to be positive according to the right hand rule about
+   the selected axis. That is, a positive force causes a positive
+   translational acceleration and a positive torque causes a positive angular
+   acceleration (of the child body frame) [assuming a positive screw pitch]. */
+  void DoAddInOneForce(const systems::Context<T>&, int joint_dof,
+                       const T& joint_tau,
+                       MultibodyForces<T>* forces) const final {
+    DRAKE_DEMAND(joint_dof < 1);
+    Eigen::VectorBlock<Eigen::Ref<VectorX<T>>> tau_mob =
+        get_mobilizer()->get_mutable_generalized_forces_from_array(
+            &forces->mutable_generalized_forces());
+    tau_mob(joint_dof) += joint_tau;
+  }
+
+  /*  Joint<T> override called through public NVI, Joint::AddInDamping().
+    Therefore arguments were already checked to be valid.
+    This method adds into `forces` a dissipative force according to the
+    viscous law `f = -d⋅v`, with d the damping coefficient (see damping()). */
+  void DoAddInDamping(const systems::Context<T>& context,
+                      MultibodyForces<T>* forces) const final {
+    Eigen::VectorBlock<Eigen::Ref<VectorX<T>>> tau =
+        get_mobilizer()->get_mutable_generalized_forces_from_array(
+            &forces->mutable_generalized_forces());
+    const T& v_angular = get_angular_velocity(context);
+    tau[0] -= damping() * v_angular;
+  }
+
+  int do_get_velocity_start() const final {
+    return get_mobilizer()->velocity_start_in_v();
+  }
+
+  int do_get_num_velocities() const final { return 1; }
+
+  int do_get_position_start() const final {
+    return get_mobilizer()->position_start_in_q();
+  }
+
+  int do_get_num_positions() const final { return 1; }
+
+  void do_set_default_positions(
+      const VectorX<double>& default_positions) final {
+    if (this->has_implementation()) {
+      get_mutable_mobilizer()->set_default_position(default_positions);
+    }
+  }
+
+  // Joint<T> overrides:
+  std::unique_ptr<typename Joint<T>::BluePrint> MakeImplementationBlueprint()
+      const final;
+
+  std::unique_ptr<Joint<double>> DoCloneToScalar(
+      const internal::MultibodyTree<double>& tree_clone) const final;
+
+  std::unique_ptr<Joint<AutoDiffXd>> DoCloneToScalar(
+      const internal::MultibodyTree<AutoDiffXd>& tree_clone) const final;
+
+  std::unique_ptr<Joint<symbolic::Expression>> DoCloneToScalar(
+      const internal::MultibodyTree<symbolic::Expression>&) const final;
+
+  // Make ScrewJoint templated on every other scalar type a friend of
+  // ScrewJoint<T> so that CloneToScalar<ToAnyOtherScalar>() can access
+  // private members of ScrewJoint<T>.
+  template <typename>
+  friend class ScrewJoint;
+
+  // Returns the mobilizer implementing this joint.
+  // The internal implementation of this joint could change in a future version.
+  // However its public API should remain intact.
+  const internal::ScrewMobilizer<T>* get_mobilizer() const {
+    // This implementation should only have one mobilizer.
+    DRAKE_DEMAND(this->get_implementation().num_mobilizers() == 1);
+    const internal::ScrewMobilizer<T>* mobilizer =
+        dynamic_cast<const internal::ScrewMobilizer<T>*>(
+            this->get_implementation().mobilizers_[0]);
+    DRAKE_DEMAND(mobilizer != nullptr);
+    return mobilizer;
+  }
+
+  internal::ScrewMobilizer<T>* get_mutable_mobilizer() {
+    // This implementation should only have one mobilizer.
+    DRAKE_DEMAND(this->get_implementation().num_mobilizers() == 1);
+    auto* mobilizer = dynamic_cast<internal::ScrewMobilizer<T>*>(
+        this->get_implementation().mobilizers_[0]);
+    DRAKE_DEMAND(mobilizer != nullptr);
+    return mobilizer;
+  }
+
+  // Helper method to make a clone templated on ToScalar.
+  template <typename ToScalar>
+  std::unique_ptr<Joint<ToScalar>> TemplatedDoCloneToScalar(
+      const internal::MultibodyTree<ToScalar>& tree_clone) const;
+
+  // The amount of translation in meters occuring over a one full revolution.
+  double screw_pitch_;
+  // This joint's damping constant in N⋅m⋅s/rad for rotation.
+  double damping_;
+};
+
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::ScrewJoint)

--- a/multibody/tree/test/screw_joint_test.cc
+++ b/multibody/tree/test/screw_joint_test.cc
@@ -1,0 +1,246 @@
+// clang-format: off
+#include "drake/multibody/tree/multibody_tree-inl.h"
+// clang-format: on
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/tree/rigid_body.h"
+#include "drake/multibody/tree/screw_joint.h"
+
+namespace drake {
+namespace multibody {
+namespace {
+
+using Eigen::Vector2d;
+using Eigen::Vector3d;
+using systems::Context;
+
+constexpr double kPositionLowerLimit = -1.0;
+constexpr double kPositionUpperLimit = 1.5;
+constexpr double kVelocityLowerLimit = -1.1;
+constexpr double kVelocityUpperLimit = 1.6;
+constexpr double kAccelerationLowerLimit = -1.2;
+constexpr double kAccelerationUpperLimit = 1.7;
+constexpr double kScrewPitch = 1.e-2;
+constexpr double kDamping = 3;
+constexpr double kPositionNonZeroDefault = 0.25;
+
+class ScrewJointTest : public ::testing::Test {
+ public:
+  // Creates a MultibodyTree model with a body attached to the world via a
+  // screw joint.
+  void SetUp() override {
+    auto model = std::make_unique<internal::MultibodyTree<double>>();
+    body_ = &model->AddBody<RigidBody>(SpatialInertia<double>{});
+
+    // Add a screw joint between the world and body1:
+    joint_ = &model->AddJoint<ScrewJoint>("Joint", model->world_body(),
+                                          std::nullopt, *body_, std::nullopt,
+                                          kScrewPitch, kDamping);
+    mutable_joint_ = dynamic_cast<ScrewJoint<double>*>(
+        &model->get_mutable_joint(joint_->index()));
+    DRAKE_DEMAND(mutable_joint_);
+    mutable_joint_->set_position_limits(
+        Vector1d::Constant(kPositionLowerLimit),
+        Vector1d::Constant(kPositionUpperLimit));
+    mutable_joint_->set_velocity_limits(
+        Vector1d::Constant(kVelocityLowerLimit),
+        Vector1d::Constant(kVelocityUpperLimit));
+    mutable_joint_->set_acceleration_limits(
+        Vector1d::Constant(kAccelerationLowerLimit),
+        Vector1d::Constant(kAccelerationUpperLimit));
+
+    system_ = std::make_unique<internal::MultibodyTreeSystem<double>>(
+        std::move(model));
+    context_ = system_->CreateDefaultContext();
+  }
+
+  const internal::MultibodyTree<double>& tree() const {
+    return internal::GetInternalTree(*system_);
+  }
+
+ protected:
+  std::unique_ptr<internal::MultibodyTreeSystem<double>> system_;
+  std::unique_ptr<Context<double>> context_;
+
+  const RigidBody<double>* body_{nullptr};
+  const ScrewJoint<double>* joint_{nullptr};
+  ScrewJoint<double>* mutable_joint_{nullptr};
+};
+
+TEST_F(ScrewJointTest, Type) {
+  const ScrewJoint<double>& base = *joint_;
+  EXPECT_EQ(base.type_name(), "screw");
+}
+
+// Verify the expected number of dofs.
+TEST_F(ScrewJointTest, NumDOFs) {
+  EXPECT_EQ(tree().num_positions(), 1);
+  EXPECT_EQ(tree().num_velocities(), 1);
+  EXPECT_EQ(joint_->num_positions(), 1);
+  EXPECT_EQ(joint_->num_velocities(), 1);
+  EXPECT_EQ(joint_->position_start(), 0);
+  EXPECT_EQ(joint_->velocity_start(), 0);
+}
+
+TEST_F(ScrewJointTest, GetJointLimits) {
+  EXPECT_EQ(joint_->position_lower_limits().size(), 1);
+  EXPECT_EQ(joint_->position_upper_limits().size(), 1);
+  EXPECT_EQ(joint_->velocity_lower_limits().size(), 1);
+  EXPECT_EQ(joint_->velocity_upper_limits().size(), 1);
+  EXPECT_EQ(joint_->acceleration_lower_limits().size(), 1);
+  EXPECT_EQ(joint_->acceleration_upper_limits().size(), 1);
+
+  EXPECT_EQ(joint_->position_lower_limits(),
+            Vector1d::Constant(kPositionLowerLimit));
+  EXPECT_EQ(joint_->position_upper_limits(),
+            Vector1d::Constant(kPositionUpperLimit));
+  EXPECT_EQ(joint_->velocity_lower_limits(),
+            Vector1d::Constant(kVelocityLowerLimit));
+  EXPECT_EQ(joint_->velocity_upper_limits(),
+            Vector1d::Constant(kVelocityUpperLimit));
+  EXPECT_EQ(joint_->acceleration_lower_limits(),
+            Vector1d::Constant(kAccelerationLowerLimit));
+  EXPECT_EQ(joint_->acceleration_upper_limits(),
+            Vector1d::Constant(kAccelerationUpperLimit));
+  EXPECT_EQ(joint_->damping(), kDamping);
+}
+
+// Context-dependent value access.
+TEST_F(ScrewJointTest, ContextDependentAccess) {
+  const double translation1(1.0);
+  const double angle1 = 1.5;
+
+  // Position access:
+  joint_->set_translation(context_.get(), translation1);
+  EXPECT_EQ(joint_->get_translation(*context_), translation1);
+  joint_->set_rotation(context_.get(), angle1);
+  EXPECT_EQ(joint_->get_rotation(*context_), angle1);
+
+  // Velocity access:
+  joint_->set_translational_velocity(context_.get(), translation1);
+  EXPECT_EQ(joint_->get_translational_velocity(*context_), translation1);
+  joint_->set_angular_velocity(context_.get(), angle1);
+  EXPECT_EQ(joint_->get_angular_velocity(*context_), angle1);
+}
+
+// Tests API to apply torques to individual dof of joint. Ensures that adding
+// forces individually is equivalent to adding forces collectively.
+TEST_F(ScrewJointTest, AddInOneForce) {
+  const double force_value = M_PI_2;
+  const double kEpsilon = std::numeric_limits<double>::epsilon();
+  MultibodyForces<double> forces1(tree());
+  MultibodyForces<double> forces2(tree());
+
+  for (int ii = 0; ii < joint_->num_positions(); ii++) {
+    // Add value twice:
+    joint_->AddInOneForce(*context_, ii, force_value, &forces1);
+    joint_->AddInOneForce(*context_, ii, force_value, &forces1);
+    // Add value only once:
+    joint_->AddInOneForce(*context_, ii, force_value, &forces2);
+  }
+  // Add forces2 into itself (same as adding torque twice):
+  forces2.AddInForces(forces2);
+
+  // forces1 and forces2 should be equal:
+  EXPECT_EQ(forces1.generalized_forces(), forces2.generalized_forces());
+  auto F2 = forces2.body_forces().cbegin();
+  for (auto& F1 : forces1.body_forces())
+    EXPECT_TRUE(F1.IsApprox(*F2++, kEpsilon));
+}
+
+TEST_F(ScrewJointTest, Clone) {
+  auto model_clone = tree().CloneToScalar<AutoDiffXd>();
+  const auto& joint_clone = model_clone->get_variant(*joint_);
+
+  EXPECT_EQ(joint_clone.name(), joint_->name());
+  EXPECT_EQ(joint_clone.frame_on_parent().index(),
+            joint_->frame_on_parent().index());
+  EXPECT_EQ(joint_clone.frame_on_child().index(),
+            joint_->frame_on_child().index());
+  EXPECT_EQ(joint_clone.position_lower_limits(),
+            joint_->position_lower_limits());
+  EXPECT_EQ(joint_clone.position_upper_limits(),
+            joint_->position_upper_limits());
+  EXPECT_EQ(joint_clone.velocity_lower_limits(),
+            joint_->velocity_lower_limits());
+  EXPECT_EQ(joint_clone.velocity_upper_limits(),
+            joint_->velocity_upper_limits());
+  EXPECT_EQ(joint_clone.acceleration_lower_limits(),
+            joint_->acceleration_lower_limits());
+  EXPECT_EQ(joint_clone.acceleration_upper_limits(),
+            joint_->acceleration_upper_limits());
+  EXPECT_EQ(joint_clone.damping(), joint_->damping());
+  EXPECT_EQ(joint_clone.get_default_rotation(), joint_->get_default_rotation());
+  EXPECT_EQ(joint_clone.get_default_translation(),
+            joint_->get_default_translation());
+}
+
+TEST_F(ScrewJointTest, DefaultState) {
+  const double new_default_translation = kPositionNonZeroDefault;
+  const double out_of_bounds_low_translation = kPositionLowerLimit - 1;
+  const double out_of_bounds_high_translation = kPositionUpperLimit + 1;
+
+  const double new_default_rotation = kPositionNonZeroDefault;
+  const double out_of_bounds_low_rotation = kPositionLowerLimit - 1;
+  const double out_of_bounds_high_rotation = kPositionUpperLimit + 1;
+
+  // Constructor should set the default translation to Vector2d::Zero() and
+  // rotation to zero.
+  EXPECT_EQ(joint_->get_default_translation(), 0.0);
+  EXPECT_EQ(joint_->get_default_rotation(), 0.0);
+
+  // Setting a new default translation should propagate so that
+  // `get_default_translation()` remains correct.
+  mutable_joint_->set_default_translation(new_default_translation);
+  EXPECT_EQ(joint_->get_default_translation(), new_default_translation);
+
+  // Setting a new default rotation should propagate so that
+  // `get_default_rotation()` remains correct.
+  mutable_joint_->set_default_rotation(new_default_rotation);
+  EXPECT_EQ(joint_->get_default_rotation(), new_default_rotation);
+
+  // Setting the default translation or rotation out of the bounds of the limits
+  // should NOT throw an exception.
+  EXPECT_NO_THROW(
+      mutable_joint_->set_default_translation(out_of_bounds_low_translation));
+  EXPECT_NO_THROW(
+      mutable_joint_->set_default_translation(out_of_bounds_high_translation));
+  EXPECT_NO_THROW(
+      mutable_joint_->set_default_rotation(out_of_bounds_low_rotation));
+  EXPECT_NO_THROW(
+      mutable_joint_->set_default_rotation(out_of_bounds_high_rotation));
+}
+
+TEST_F(ScrewJointTest, RandomState) {
+  RandomGenerator generator;
+  std::uniform_real_distribution<symbolic::Expression> uniform;
+
+  tree().SetRandomState(*context_, &context_->get_mutable_state(), &generator);
+
+  EXPECT_EQ(joint_->get_translation(*context_), 0.0);
+  EXPECT_EQ(joint_->get_rotation(*context_), 0.0);
+
+  mutable_joint_->set_random_pose_distribution(
+      Vector1<symbolic::Expression>(uniform(generator) + 1.0));
+  tree().SetRandomState(*context_, &context_->get_mutable_state(), &generator);
+  EXPECT_GE(joint_->get_rotation(*context_), 1.0);
+  EXPECT_LE(joint_->get_rotation(*context_), 2.0);
+
+  EXPECT_GE(joint_->get_translation(*context_),
+            1.0 / (2. * M_PI) * kScrewPitch);
+  EXPECT_LE(joint_->get_translation(*context_),
+            2.0 / (2. * M_PI) * kScrewPitch);
+
+  // Check that they change on a second draw from the distribution.
+  const double last_translation = joint_->get_translation(*context_);
+  const double last_rotation = joint_->get_rotation(*context_);
+  tree().SetRandomState(*context_, &context_->get_mutable_state(), &generator);
+  EXPECT_NE(joint_->get_translation(*context_), last_translation);
+  EXPECT_NE(joint_->get_rotation(*context_), last_rotation);
+}
+
+}  // namespace
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Adds a 1 dof screw joint that allows motion along and rotation about the z-axis of the parent frame.

Depends on  #15104
Towards #12404
@mpetersen94

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15105)
<!-- Reviewable:end -->
