### PR TITLE
Adding collision filter manager API

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -14,6 +14,8 @@ drake_cc_package_library(
     name = "geometry",
     visibility = ["//visibility:public"],
     deps = [
+        ":collision_filter_declaration",
+        ":collision_filter_manager",
         ":drake_visualizer",
         ":frame_kinematics",
         ":geometry_frame",
@@ -61,6 +63,29 @@ drake_cc_library(
         "@fcl",
         "@fmt",
         "@tinyobjloader",
+    ],
+)
+
+drake_cc_library(
+    name = "collision_filter_declaration",
+    srcs = ["collision_filter_declaration.cc"],
+    hdrs = ["collision_filter_declaration.h"],
+    deps = [
+        ":geometry_set",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "collision_filter_manager",
+    srcs = ["collision_filter_manager.cc"],
+    hdrs = ["collision_filter_manager.h"],
+    deps = [
+        ":collision_filter_declaration",
+        ":geometry_ids",
+        ":geometry_set",
+        ":geometry_state",
+        "//common:default_scalars",
     ],
 )
 
@@ -179,6 +204,7 @@ drake_cc_library(
     srcs = ["geometry_state.cc"],
     hdrs = ["geometry_state.h"],
     deps = [
+        ":collision_filter_declaration",
         ":frame_kinematics",
         ":geometry_frame",
         ":geometry_ids",
@@ -215,6 +241,7 @@ drake_cc_library(
         "scene_graph.h",
     ],
     deps = [
+        ":collision_filter_manager",
         ":geometry_state",
         ":scene_graph_inspector",
         "//common:essential",
@@ -311,6 +338,23 @@ filegroup(
         "test/non_convex_mesh.obj",
         "test/quad_cube.mtl",
         "test/quad_cube.obj",
+    ],
+)
+
+drake_cc_googletest(
+    name = "collision_filter_declaration_test",
+    deps = [
+        ":collision_filter_declaration",
+        ":geometry_ids",
+    ],
+)
+
+drake_cc_googletest(
+    name = "collision_filter_manager_test",
+    deps = [
+        ":collision_filter_manager",
+        ":scene_graph",
+        "//common/test_utilities:expect_no_throw",
     ],
 )
 

--- a/geometry/collision_filter_declaration.cc
+++ b/geometry/collision_filter_declaration.cc
@@ -1,0 +1,1 @@
+#include "drake/geometry/collision_filter_declaration.h"

--- a/geometry/collision_filter_declaration.h
+++ b/geometry/collision_filter_declaration.h
@@ -1,0 +1,115 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/geometry/geometry_set.h"
+
+namespace drake {
+namespace geometry {
+
+#ifndef DRAKE_DOXYGEN_CXX
+// Forward declarations.
+template <typename>
+class GeometryState;
+#endif
+
+/** Class for articulating changes to the configuration of SceneGraph's
+ "collision filters"; collision filters limit the scope of various proximity
+  queries.
+
+ This class provides the basis for *declaring* what pairs should or should not
+ be included in the set C.
+
+ A declaration consists of zero or more *statements*. Each statement can
+ declare, for example, that the pair (g₁, g₂) should be excluded from C (also
+ known as "filtering the pair"). That statement is added to the declaration by
+ invoking the corresponding statement method (see below), and the result of the
+ invocation, is that the statement is appended to the declaration.
+
+ Each statement method returns a reference to the declaration instance, so a
+ number of statements can be chained together, i.e.,
+
+ ```
+ collision_filter_manager.Apply(
+   CollisionFilterDeclaration()
+       .ExcludeWithin(some_geometry_set)
+       .ExcludeBetween(set_A, set_B));
+ ```
+
+ It's worth noting, that the statements are evaluated in *invocation* order such
+ that a later statement can partially or completely undo the effect of an
+ earlier statement. The full declaration is evaluated by
+ CollisionFilterManager::Apply(). */
+class CollisionFilterDeclaration {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CollisionFilterDeclaration)
+
+  CollisionFilterDeclaration() = default;
+
+  /** @name  Excluding pairs from consideration (adding collision filters)
+
+   These methods provide mechanisms which implicitly define a set of pairs and
+   subtracts each pair from the set C (see the documentation for
+   CollisionFilterManager for definition of set C). Each method provides the
+   definition for the set of pairs.
+
+   The *declared* pairs can be invalid (e.g., containing GeometryId values that
+   aren't part of the SceneGraph data). This will only be detected when applying
+   the declaration (see CollisionFilterManager::Apply()).  */
+  //@{
+
+  /** Excludes geometry pairs from proximity evaluation by updating the
+   candidate pair set `C = C - P`, where `P = {(a, b)}, ∀ a ∈ A, b ∈ B` and
+   `A = {a₀, a₁, ..., aₘ}` and `B = {b₀, b₁, ..., bₙ}` are the input sets of
+   geometries `set_A` and `set_B`, respectively.  */
+  CollisionFilterDeclaration& ExcludeBetween(GeometrySet set_A,
+                                             GeometrySet set_B) {
+    statements_.emplace_back(kExcludeBetween, std::move(set_A),
+                             std::move(set_B));
+    return *this;
+  }
+
+  /** Excludes geometry pairs from proximity evaluation by updating the
+   candidate pair set `C = C - P`, where `P = {(gᵢ, gⱼ)}, ∀ gᵢ, gⱼ ∈ G` and
+   `G = {g₀, g₁, ..., gₘ}` is the input `geometry_set` of geometries.  */
+  CollisionFilterDeclaration& ExcludeWithin(GeometrySet geometry_set) {
+    statements_.emplace_back(kExcludeWithin, std::move(geometry_set),
+                             GeometrySet{});
+    return *this;
+  }
+
+  //@}
+
+ private:
+  friend class CollisionFilterDeclTester;
+  template <typename>
+  friend class GeometryState;
+
+  // The various kinds of operations that can be made.
+  enum StatementOp {
+    kExcludeWithin,
+    kExcludeBetween,
+  };
+
+  // The record of a single statement.
+  struct Statement {
+    Statement(StatementOp op_in, GeometrySet A_in, GeometrySet B_in) :
+      operation(op_in), set_A(std::move(A_in)), set_B(std::move(B_in)) {}
+    StatementOp operation;
+    GeometrySet set_A;
+    GeometrySet set_B;  // May be unused for some operations.
+  };
+
+  // Although we've given GeometryState friend access, rather than have it
+  // access statements_ directly, we'll provide an API that will better insulate
+  // it from the declaration implementation.
+  const std::vector<Statement>& statements() const { return statements_; }
+
+  // The sequence of statements in this declaration.
+  std::vector<Statement> statements_;
+};
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/collision_filter_manager.cc
+++ b/geometry/collision_filter_manager.cc
@@ -1,0 +1,24 @@
+#include "drake/geometry/collision_filter_manager.h"
+
+#include "drake/geometry/geometry_state.h"
+
+namespace drake {
+namespace geometry {
+
+template <typename T>
+CollisionFilterManager<T>::CollisionFilterManager(GeometryState<T>* state)
+    : state_(state) {
+  DRAKE_DEMAND(state != nullptr);
+}
+
+template <typename T>
+void CollisionFilterManager<T>::Apply(
+    const CollisionFilterDeclaration& declaration) {
+  state_->ApplyFilterDeclaration(declaration);
+}
+
+}  // namespace geometry
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::geometry::CollisionFilterManager)

--- a/geometry/collision_filter_manager.h
+++ b/geometry/collision_filter_manager.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/geometry/collision_filter_declaration.h"
+#include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/geometry_set.h"
+
+namespace drake {
+namespace geometry {
+
+// Forward declarations.
+template <typename T>
+class SceneGraph;
+template <typename T>
+class GeometryState;
+
+/** Class for configuring "collision filters"; collision filters limit the scope
+ of various proximity queries.
+
+ The sole source of %CollisionFilterManager instances is SceneGraph. See
+ @ref scene_graph_collision_filter_manager "SceneGraph's documentation" for
+ details on acquiring an instance.
+
+ A SceneGraph instance contains the set of geometry
+ `G = D ⋃ A = {g₀, g₁, ..., gₙ}`, where D is the set of dynamic geometries and
+ A is the set of anchored geometries (by definition `D ⋂ A = ∅`). `Gₚ ⊂ G` is
+ the subset of geometries that have a proximity role (with an analogous
+ interpretation of `Dₚ` and `Aₚ`). Many proximity queries operate on pairs of
+ geometries (e.g., (gᵢ, gⱼ)). The set of proximity candidate pairs is initially
+ defined as `C = (Gₚ × Gₚ) - (Aₚ × Aₚ) - Fₚ - Iₚ`, where:
+
+  - `Gₚ × Gₚ = {(gᵢ, gⱼ)}, ∀ gᵢ, gⱼ ∈ Gₚ` is the cartesian product of the set
+    of SceneGraph geometries.
+  - `Aₚ × Aₚ` represents all pairs consisting only of anchored geometries;
+    anchored geometry is never tested against other anchored geometry.
+  - `Fₚ = {(gᵢ, gⱼ)} ∀ i, j`, such that `gᵢ, gⱼ ∈ Dₚ` and
+    `frame(gᵢ) == frame(gⱼ)`; the pairs where both geometries are rigidly
+    affixed to the same frame.
+  - `Iₚ = {(g, g)}, ∀ g ∈ Gₚ` is the set of all pairs consisting of a
+    geometry with itself; there is no meaningful proximity query on a
+    geometry with itself.
+
+ Only pairs contained in C will be included in pairwise proximity operations.
+
+ The manager provides an interface to modify the set C. Changes to C are
+ articulated with CollisionFilterDeclaration. Once a change has been *declared*
+ it is applied via the manager's API to change the configuration of C.
+
+ There are limits to how C can be modified.
+
+   - `∀ (gᵢ, gⱼ) ∈ C`, both gᵢ and gⱼ must be registered with SceneGraph; you
+     can't inject arbitrary ids. Attempting to do so will result in an error.
+   - No pairs in `Aₚ × Aₚ`, `Fₚ`, or `Iₚ` can ever be added to C. Excluding
+     those pairs is a SceneGraph invariant. Attempts to do so will be ignored.
+
+ The current configuration of C depends on the sequence of filter declarations
+ that have been applied in the manager. Changing the order can change the end
+ result.
+
+ @warning The effect of applying a declaration is based on the state of
+ SceneGraph's geometry data at the time of application. More concretely:
+ - For a particular FrameId in a GeometrySet instance, only those geometries
+    attached to the identified frame with the proximity role assigned at the
+    time of the call will be included in the filter. If geometries are
+    subsequently added or assigned the proximity role, they will not be
+    retroactively added to the user-declared filter.
+ - If the set includes geometries which have _not_ been assigned a proximity
+    role, those geometries will be ignored. If a proximity role is
+    subsequently assigned, those geometries will _still_ not be part of any
+    user-declared collision filters.
+ - In general, adding collisions and assigning proximity roles should
+    happen prior to collision filter configuration.
+
+ <h3>Collision filtering and geometry versions</h3>
+
+ Declaring a change to the set C will increment the proximity version (see
+ @ref scene_graph_versioning), even if applying the declaration doesn't actually
+ change the set C.  */
+template <typename T>
+class CollisionFilterManager {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CollisionFilterManager)
+
+  /** Applies the given `declaration` to the geometry state managed by `this`
+   instance.
+
+   The process of *applying* the collision filter data also validates it. The
+   following polices are implemented during validation:
+
+     - Referencing an invalid id (FrameId or GeometryId): throws.
+     - Declaring a filtered pair that is already filtered: no discernible
+       change.
+
+   @throws std::exception if the declaration references invalid ids.  */
+  void Apply(const CollisionFilterDeclaration& declaration);
+
+ private:
+  // Only SceneGraph can construct a collision filter manager.
+  template <typename>
+  friend class SceneGraph;
+
+  /* Constructs the manager with the underlying state instance that provides
+   support for the operations. */
+  explicit CollisionFilterManager(GeometryState<T>* state);
+
+  GeometryState<T>* state_{};
+};
+
+}  // namespace geometry
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::geometry::CollisionFilterManager)

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -928,6 +928,21 @@ int GeometryState<T>::RemoveFromRenderer(const std::string& renderer_name,
 }
 
 template <typename T>
+void GeometryState<T>::ApplyFilterDeclaration(
+    const CollisionFilterDeclaration& declaration) {
+  for (const auto& statement : declaration.statements()) {
+    switch (statement.operation) {
+      case CollisionFilterDeclaration::kExcludeWithin:
+        ExcludeCollisionsWithin(statement.set_A);
+        break;
+      case CollisionFilterDeclaration::kExcludeBetween:
+        ExcludeCollisionsBetween(statement.set_A, statement.set_B);
+        break;
+    }
+  }
+}
+
+template <typename T>
 void GeometryState<T>::ExcludeCollisionsWithin(const GeometrySet& set) {
   // There is no work to be done if:
   //   1. the set contains a single frame and no geometries -- geometries *on*

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -11,6 +11,7 @@
 
 #include "drake/common/autodiff.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/geometry/collision_filter_declaration.h"
 #include "drake/geometry/frame_kinematics_vector.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/geometry_index.h"
@@ -418,6 +419,9 @@ class GeometryState {
   }
 
   //@}
+
+  /** Implementation of CollisionFilterManager::ApplyFilterDeclaration(). */
+  void ApplyFilterDeclaration(const CollisionFilterDeclaration& declaration);
 
   /** @name               Proximity filters
 

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -325,6 +325,17 @@ const SceneGraphInspector<T>& SceneGraph<T>::model_inspector() const {
 }
 
 template <typename T>
+CollisionFilterManager<T> SceneGraph<T>::collision_filter_manager() {
+  return CollisionFilterManager<T>(&model_);
+}
+
+template <typename T>
+CollisionFilterManager<T> SceneGraph<T>::collision_filter_manager(
+    Context<T>* context) const {
+  return CollisionFilterManager<T>(&mutable_geometry_state(context));
+}
+
+template <typename T>
 void SceneGraph<T>::ExcludeCollisionsWithin(const GeometrySet& geometry_set) {
   model_.ExcludeCollisionsWithin(geometry_set);
 }

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "drake/common/drake_deprecated.h"
+#include "drake/geometry/collision_filter_manager.h"
 #include "drake/geometry/geometry_set.h"
 #include "drake/geometry/geometry_state.h"
 #include "drake/geometry/query_object.h"
@@ -799,6 +800,35 @@ class SceneGraph final : public systems::LeafSystem<T> {
   const SceneGraphInspector<T>& model_inspector() const;
 
   /** @name         Collision filtering
+   @anchor scene_graph_collision_filter_manager
+
+   Control over "collision filtering" is handled by the CollisionFilterManager.
+   %SceneGraph provides access to the manager. As with other geometry data,
+   collision filters can be configured in %SceneGraph's *model* or in the copy
+   stored in a particular context. These methods provide access to the manager
+   for the data stored in either location.
+
+   Generally, it should be considered a bad practice to hang onto the instance
+   of CollisionFilterManager returned by collision_filter_manager(). It is not
+   immediately clear whether a particular CollisionFilterManager instance
+   refers to the %SceneGraph model or the Context data and persisting the
+   reference may lead to confusion. Keeping the reference for the duration of
+   a function is appropriate, but allowing it to persist outside of the scope
+   of acquisition is dangerous. Acquiring a new CollisionFilterManager is *very*
+   cheap, so feel free to discard and reacquire.  */
+  //@{
+
+  /** Returns the collision filter manager for this %SceneGraph instance's
+   *model*. */
+  CollisionFilterManager<T> collision_filter_manager();
+
+  /** Returns the collision filter manager for data stored in `context`. The
+   context must remain alive for at least as long as the returned manager.  */
+  CollisionFilterManager<T> collision_filter_manager(
+      systems::Context<T>* context) const;
+  //@}
+
+  /** @name         Collision filtering (legacy)
    @anchor scene_graph_collision_filtering
    The interface for limiting the scope of penetration queries (i.e., "filtering
    collisions").

--- a/geometry/test/collision_filter_declaration_test.cc
+++ b/geometry/test/collision_filter_declaration_test.cc
@@ -1,0 +1,136 @@
+#include "drake/geometry/collision_filter_declaration.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/geometry/geometry_ids.h"
+
+namespace drake {
+namespace geometry {
+
+using std::vector;
+
+class CollisionFilterDeclTester {
+ public:
+  using Statement = CollisionFilterDeclaration::Statement;
+  using StatementOp = CollisionFilterDeclaration::StatementOp;
+
+  static const vector<Statement>& statements(
+      const CollisionFilterDeclaration& decl) {
+    return decl.statements_;
+  }
+};
+
+class GeometrySetTester {
+ public:
+  static bool AreEqual(const GeometrySet& set_A, const GeometrySet& set_B) {
+    return set_A.geometry_ids_ == set_B.geometry_ids_ &&
+           set_A.frame_ids_ == set_B.frame_ids_;
+  }
+};
+
+namespace {
+
+using Tester = CollisionFilterDeclTester;
+
+GTEST_TEST(CollisionFilterDeclTest, DefaultConstructor) {
+  CollisionFilterDeclaration decl;
+  EXPECT_EQ(Tester::statements(decl).size(), 0);
+}
+
+GTEST_TEST(CollisionFilterDeclTest, ExcludeBetween) {
+  const GeometrySet set_A({GeometryId::get_new_id(), GeometryId::get_new_id()});
+  const GeometrySet set_B({FrameId::get_new_id(), FrameId::get_new_id()});
+
+  CollisionFilterDeclaration decl;
+  decl.ExcludeBetween(set_A, set_B);
+
+  const auto& statements = Tester::statements(decl);
+  EXPECT_EQ(statements.size(), 1);
+  EXPECT_EQ(statements[0].operation, Tester::StatementOp::kExcludeBetween);
+  EXPECT_TRUE(GeometrySetTester::AreEqual(statements[0].set_A, set_A));
+  EXPECT_TRUE(GeometrySetTester::AreEqual(statements[0].set_B, set_B));
+}
+
+GTEST_TEST(CollisionFilterDeclTest, ExcludeWithin) {
+  const GeometrySet set_A({GeometryId::get_new_id(), GeometryId::get_new_id()});
+  const GeometrySet set_B({FrameId::get_new_id(), FrameId::get_new_id()});
+
+  for (const auto& geo_set : {set_A, set_B}) {
+    CollisionFilterDeclaration decl;
+    decl.ExcludeWithin(geo_set);
+
+    const auto& statements = Tester::statements(decl);
+    EXPECT_EQ(statements.size(), 1);
+    EXPECT_EQ(statements[0].operation, Tester::StatementOp::kExcludeWithin);
+    EXPECT_TRUE(GeometrySetTester::AreEqual(statements[0].set_A, geo_set));
+    EXPECT_TRUE(
+        GeometrySetTester::AreEqual(statements[0].set_B, GeometrySet()));
+  }
+}
+
+// A simple test that confirms the *mechanism* for chaining; each statement
+// method returns a pointer to itself. This method should exercise *every*
+// statement method; as they get added to the class, they should be added here.
+GTEST_TEST(CollisionFilterDeclTest, ChainingStatements) {
+  const GeometrySet set_A({GeometryId::get_new_id(), GeometryId::get_new_id()});
+  CollisionFilterDeclaration decl;
+  EXPECT_EQ(&decl.ExcludeBetween(set_A, set_A), &decl);
+  EXPECT_EQ(&decl.ExcludeWithin(set_A), &decl);
+}
+
+// Confirms that the order of the statements given is preserved. We'll confirm
+// that each statement method appends the expected data to the sequence of
+// statements, leaving the previous statements untouched.
+GTEST_TEST(CollisionFilterDeclTest, StatementOrder) {
+  const GeometrySet set_A({GeometryId::get_new_id(), GeometryId::get_new_id()});
+  const GeometrySet set_B({GeometryId::get_new_id(), GeometryId::get_new_id()});
+
+  CollisionFilterDeclaration decl_original;
+  decl_original.ExcludeWithin(set_A);
+  // Validates the configuration of the *first* statement. It has the prereq
+  // that the declaration contains at least one statement.
+  auto validate_base = [&set_A](const CollisionFilterDeclaration& declaration) {
+    const auto& s = Tester::statements(declaration)[0];
+    EXPECT_EQ(s.operation, Tester::StatementOp::kExcludeWithin);
+    EXPECT_TRUE(GeometrySetTester::AreEqual(s.set_A, set_A));
+    EXPECT_TRUE(GeometrySetTester::AreEqual(s.set_B, GeometrySet{}));
+  };
+
+  // Confirm that the baseline declaration has the expected statement.
+  EXPECT_GE(Tester::statements(decl_original).size(), 1);
+  validate_base(decl_original);
+
+  // Confirm that there's a second statement, and its parameters are the given
+  // set of expectations.
+  auto validate = [&validate_base](
+                      const Tester::Statement expected,
+                      const CollisionFilterDeclaration& declaration) {
+    const auto& statements = Tester::statements(declaration);
+    EXPECT_EQ(statements.size(), 2);
+    validate_base(declaration);
+    const auto& s = statements[1];
+    EXPECT_EQ(s.operation, expected.operation);
+    EXPECT_TRUE(GeometrySetTester::AreEqual(s.set_A, expected.set_A));
+    EXPECT_TRUE(GeometrySetTester::AreEqual(s.set_B, expected.set_B));
+  };
+
+  // Exercise each of the statement methods and confirm that it is appended to
+  // the end.
+  {
+    CollisionFilterDeclaration decl(decl_original);
+    decl.ExcludeBetween(set_B, set_A);
+    SCOPED_TRACE("ExcludeBetween");
+    validate({Tester::StatementOp::kExcludeBetween, set_B, set_A}, decl);
+  }
+
+  {
+    CollisionFilterDeclaration decl(decl_original);
+    decl.ExcludeWithin(set_B);
+    SCOPED_TRACE("ExcludeWithin");
+    validate({Tester::StatementOp::kExcludeWithin, set_B, GeometrySet()}, decl);
+  }
+}
+
+}  // namespace
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/test/collision_filter_manager_test.cc
+++ b/geometry/test/collision_filter_manager_test.cc
@@ -1,0 +1,109 @@
+#include "drake/geometry/collision_filter_manager.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_no_throw.h"
+#include "drake/geometry/geometry_frame.h"
+#include "drake/geometry/geometry_instance.h"
+#include "drake/geometry/geometry_properties.h"
+#include "drake/geometry/query_object.h"
+#include "drake/geometry/scene_graph.h"
+#include "drake/geometry/scene_graph_inspector.h"
+#include "drake/geometry/shape_specification.h"
+#include "drake/math/rigid_transform.h"
+
+namespace drake {
+namespace geometry {
+
+// Friend class for accessing SceneGraph protected/private functionality.
+class SceneGraphTester {
+ public:
+  template <typename T>
+  static void GetQueryObjectPortValue(const SceneGraph<T>& scene_graph,
+                                      const systems::Context<T>& context,
+                                      QueryObject<T>* handle) {
+    scene_graph.CalcQueryObject(context, handle);
+  }
+};
+
+namespace {
+
+using math::RigidTransformd;
+using std::make_unique;
+using std::unique_ptr;
+
+// Convenience function for making a geometry instance.
+unique_ptr<GeometryInstance> make_sphere_instance(
+    double radius = 1.0) {
+  return make_unique<GeometryInstance>(RigidTransformd::Identity(),
+                                       make_unique<Sphere>(radius), "sphere");
+}
+
+GTEST_TEST(CollisionFilterManagerTest, ExcludeBetween) {
+  // Initializes the scene graph and context.
+  SceneGraph<double> scene_graph;
+  // Simple scene with three frames, each with a sphere which, by default
+  // collide.
+  SourceId source_id = scene_graph.RegisterSource("source");
+  FrameId f_id1 =
+      scene_graph.RegisterFrame(source_id, GeometryFrame("frame_1"));
+  FrameId f_id2 =
+      scene_graph.RegisterFrame(source_id, GeometryFrame("frame_2"));
+  FrameId f_id3 =
+      scene_graph.RegisterFrame(source_id, GeometryFrame("frame_3"));
+  GeometryId g_id1 =
+      scene_graph.RegisterGeometry(source_id, f_id1, make_sphere_instance());
+  scene_graph.AssignRole(source_id, g_id1, ProximityProperties());
+  GeometryId g_id2 =
+      scene_graph.RegisterGeometry(source_id, f_id2, make_sphere_instance());
+  scene_graph.AssignRole(source_id, g_id2, ProximityProperties());
+  GeometryId g_id3 =
+      scene_graph.RegisterGeometry(source_id, f_id3, make_sphere_instance());
+  scene_graph.AssignRole(source_id, g_id3, ProximityProperties());
+
+  // Confirm that the model reports no filtered pairs.
+  const auto& model_inspector = scene_graph.model_inspector();
+  EXPECT_FALSE(model_inspector.CollisionFiltered(g_id1, g_id2));
+  EXPECT_FALSE(model_inspector.CollisionFiltered(g_id1, g_id3));
+  EXPECT_FALSE(model_inspector.CollisionFiltered(g_id2, g_id3));
+
+  auto context = scene_graph.CreateDefaultContext();
+
+  // Confirms the state. NOTE: Because we're not copying the query object or
+  // changing context, this query object and inspector are valid for querying
+  // the modified context.
+  QueryObject<double> query_object;
+  SceneGraphTester::GetQueryObjectPortValue(scene_graph, *context,
+                                            &query_object);
+  const auto& inspector = query_object.inspector();
+
+  // Confirm unfiltered state.
+  EXPECT_FALSE(inspector.CollisionFiltered(g_id1, g_id2));
+  EXPECT_FALSE(inspector.CollisionFiltered(g_id1, g_id3));
+  EXPECT_FALSE(inspector.CollisionFiltered(g_id2, g_id3));
+
+  auto filter_manager = scene_graph.collision_filter_manager(context.get());
+
+  filter_manager.Apply(
+      CollisionFilterDeclaration().ExcludeWithin(GeometrySet({g_id1, g_id2})));
+  EXPECT_TRUE(inspector.CollisionFiltered(g_id1, g_id2));
+  EXPECT_FALSE(inspector.CollisionFiltered(g_id1, g_id3));
+  EXPECT_FALSE(inspector.CollisionFiltered(g_id2, g_id3));
+
+  filter_manager.Apply(CollisionFilterDeclaration().ExcludeBetween(
+      GeometrySet({g_id1, g_id2}), GeometrySet({g_id3})));
+  EXPECT_TRUE(inspector.CollisionFiltered(g_id1, g_id2));
+  EXPECT_TRUE(inspector.CollisionFiltered(g_id1, g_id3));
+  EXPECT_TRUE(inspector.CollisionFiltered(g_id2, g_id3));
+
+  // Note that the underlying model *didn't* change.
+  EXPECT_FALSE(model_inspector.CollisionFiltered(g_id1, g_id2));
+  EXPECT_FALSE(model_inspector.CollisionFiltered(g_id1, g_id3));
+  EXPECT_FALSE(model_inspector.CollisionFiltered(g_id2, g_id3));
+}
+
+}  // namespace
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -366,7 +366,7 @@ TEST_F(SceneGraphTest, TransmogrifyContext) {
 
 // Tests that exercising the collision filtering logic *after* allocation is
 // allowed.
-TEST_F(SceneGraphTest, PostAllocationCollisionFiltering) {
+TEST_F(SceneGraphTest, PostAllocationCollisionFilteringLegacy) {
   SourceId source_id = scene_graph_.RegisterSource("filter_after_allocation");
   FrameId frame_id =
       scene_graph_.RegisterFrame(source_id, GeometryFrame("dummy"));
@@ -735,7 +735,7 @@ GTEST_TEST(SceneGraphContextModifier, RegisterGeometry) {
       "Referenced geometry \\d+ has not been registered.");
 }
 
-GTEST_TEST(SceneGraphContextModifier, CollisionFilters) {
+GTEST_TEST(SceneGraphContextModifier, CollisionFiltersLegacy) {
   // Initializes the scene graph and context.
   SceneGraph<double> scene_graph;
   // Simple scene with three frames, each with a sphere which, by default


### PR DESCRIPTION
In anticipation of expanding the functionality relating to working with collision filters, we're changing the public API. This introduces a *parallel* API and labels the old API as "legacy". The legacy API will be deprecated in a follow up PR.

The purpose of the API is to reduce `SceneGraph`'s knowledge of working with collision filters. `SceneGraph` produces a `CollisionFilterManager`, but all manipulation of collision filter configuration now belongs to that manager (reducing the churn on `SceneGraph`'s already large API).

To achieve this end:

  - Introduce new classes: `CollisionFilterManager` and `CollisionFilterDeclaration`.
    - The unit tests for `CollisionFilterManager` are copied from `scene_graph_test.cc` (as the manager can only be constructed by `SceneGraph`). The source test code is marked as Legacy for future deprecation.
  - Add new API: `SceneGraph::collision_filter_manager()`.
  - `GeometryState` updates API to support new manager/declaration API.

This does *not* include bindings. Those will be included when we deprecate the legacy API in a follow-up PR.

Relates #15089.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15115)
<!-- Reviewable:end -->
