### PR TITLE
[geometry] Make a deformable volume mesh

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -19,6 +19,7 @@ drake_cc_package_library(
         ":collision_filter_legacy",
         ":collisions_exist_callback",
         ":contact_surface_utility",
+        ":deformable_volume_mesh",
         ":distance_to_point_callback",
         ":distance_to_shape_callback",
         ":find_collision_candidates_callback",
@@ -34,6 +35,7 @@ drake_cc_package_library(
         ":make_ellipsoid_mesh",
         ":make_sphere_field",
         ":make_sphere_mesh",
+        ":mesh_deformer",
         ":mesh_field",
         ":mesh_half_space_intersection",
         ":mesh_intersection",
@@ -125,6 +127,16 @@ drake_cc_library(
     hdrs = ["contact_surface_utility.h"],
     deps = [
         ":surface_mesh",
+    ],
+)
+
+drake_cc_library(
+    name = "deformable_volume_mesh",
+    srcs = ["deformable_volume_mesh.cc"],
+    hdrs = ["deformable_volume_mesh.h"],
+    deps = [
+        ":mesh_deformer",
+        ":volume_mesh",
     ],
 )
 
@@ -579,6 +591,16 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "mesh_deformer",
+    srcs = ["mesh_deformer.cc"],
+    hdrs = ["mesh_deformer.h"],
+    deps = [
+        ":surface_mesh",
+        ":volume_mesh",
+    ],
+)
+
+drake_cc_library(
     name = "volume_to_surface_mesh",
     srcs = [
         "volume_to_surface_mesh.cc",
@@ -661,6 +683,15 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
         "//math:autodiff",
+    ],
+)
+
+drake_cc_googletest(
+    name = "deformable_volume_mesh_test",
+    deps = [
+        ":deformable_volume_mesh",
+        ":make_box_mesh",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -995,6 +1026,16 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//math:autodiff",
         "//math:geometric_transform",
+    ],
+)
+
+drake_cc_googletest(
+    name = "mesh_deformer_test",
+    deps = [
+        ":make_box_mesh",
+        ":mesh_deformer",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/geometry/proximity/deformable_volume_mesh.cc
+++ b/geometry/proximity/deformable_volume_mesh.cc
@@ -1,0 +1,18 @@
+#include "drake/geometry/proximity/deformable_volume_mesh.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+template <typename T>
+void DeformableVolumeMesh<T>::UpdateVertexPositions(
+    const Eigen::Ref<const VectorX<T>>& q) {
+  deformer_.SetAllPositions(q);
+}
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::geometry::internal::DeformableVolumeMesh)

--- a/geometry/proximity/deformable_volume_mesh.h
+++ b/geometry/proximity/deformable_volume_mesh.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <utility>
+
+#include "drake/geometry/proximity/mesh_deformer.h"
+#include "drake/geometry/proximity/volume_mesh.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+// TODO(SeanCurtis-TRI): When SceneGraph properly supports deformable meshes
+//  in a public manner, move this out of internal and into geometry along with
+//  VolumeMesh.
+/* Representation of a volume mesh whose vertices can be moved.
+
+ This is currently a speculative feature and not formally supported by
+ SceneGraph. When SceneGraph formally supports deformable geometry, this will
+ come out of the `internal` namespace. */
+template <typename T>
+class DeformableVolumeMesh {
+ public:
+  /* Constructs a deformable representation of the given mesh whose vertex
+   positions are measured and expressed in Frame M. When the vertex positions
+   are updated, those values must likewise be measured and expressed in this
+   same frame.
+
+   The %DeformableVolumeMesh will *own* its own underlying VolumeMesh. */
+  explicit DeformableVolumeMesh(VolumeMesh<T> mesh_M)
+      : mesh_(std::move(mesh_M)),
+        deformer_(&mesh_) {}
+
+  /* @name Implements CopyConstructible, CopyAssignable, MoveConstructible,
+   MoveAssignable */
+  //@{
+
+  DeformableVolumeMesh(const DeformableVolumeMesh& other)
+      : DeformableVolumeMesh(other.mesh()) {}
+
+  DeformableVolumeMesh& operator=(const DeformableVolumeMesh& other) {
+    if (this == &other) return *this;
+    mesh_ = other.mesh();
+    deformer_.set_mesh(&mesh_);
+    return *this;
+  }
+
+  // Note: MeshDeformer has no move or copy semantics, so we can't default
+  //  semantics here.
+
+  DeformableVolumeMesh(DeformableVolumeMesh&& other)
+      : mesh_(std::move(other.mesh_)), deformer_(&mesh_) {}
+
+  DeformableVolumeMesh& operator=(DeformableVolumeMesh&& other) {
+    mesh_ = std::move(other.mesh_);
+    deformer_.set_mesh(&mesh_);
+    return *this;
+  }
+
+  //@}
+
+  /* Access to the underlying mesh. Represent the most recent configuration
+   based either on construction or a call to UpdateVertexPositions(). */
+  const VolumeMesh<T>& mesh() const { return mesh_; }
+
+  /* Updates the vertex positions of the underlying mesh.
+
+  @param q  A vector of 3N values (where this mesh has N vertices). The iᵗʰ
+            vertex gets values <q(3i), q(3i + 1), q(3i + 2>. Each vertex is
+            assumed to be measured and expressed in the mesh's frame M.
+  @pre q.size == 3 * mesh().num_vertices(). */
+  void UpdateVertexPositions(const Eigen::Ref<const VectorX<T>>& q);
+
+ private:
+  VolumeMesh<T> mesh_;
+  MeshDeformer<VolumeMesh<T>> deformer_;
+};
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/mesh_deformer.cc
+++ b/geometry/proximity/mesh_deformer.cc
@@ -1,0 +1,34 @@
+#include "drake/geometry/proximity/mesh_deformer.h"
+
+#include <fmt/format.h>
+
+#include "drake/geometry/proximity/surface_mesh.h"
+#include "drake/geometry/proximity/volume_mesh.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+template <typename MeshType>
+void MeshDeformer<MeshType>::SetAllPositions(
+    const Eigen::Ref<const VectorX<T>>& p_MVs) {
+  if (p_MVs.size() != 3 * mesh_.num_vertices()) {
+    throw std::runtime_error(fmt::format(
+        "MeshDeformer::SetAllPositions(): Attempting to deform a mesh with {} "
+        "vertices with data for {} vertices",
+        mesh_.num_vertices(), p_MVs.size()));
+  }
+  for (int v = 0, i = 0; v < mesh_.num_vertices(); ++v, i += 3) {
+    mesh_.vertices_[v] =
+        VertexType(Vector3<T>(p_MVs[i], p_MVs[i + 1], p_MVs[i + 2]));
+  }
+}
+
+template class MeshDeformer<VolumeMesh<double>>;
+template class MeshDeformer<VolumeMesh<AutoDiffXd>>;
+template class MeshDeformer<SurfaceMesh<double>>;
+template class MeshDeformer<SurfaceMesh<AutoDiffXd>>;
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/mesh_deformer.h
+++ b/geometry/proximity/mesh_deformer.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+/* (Advanced) Class that serves an attorney-client role in allowing disciplined
+ deformation of a mesh -- in other words, vertex positions can be changed. The
+ topology of the mesh is preserved.
+
+ Deforming a mesh can be a dangerous proposition if that mesh is accessed or
+ referenced by some other class (e.g., MeshFieldLinear). Deforming the mesh can
+ cause downstream dependencies to become invalid. Meshes should only be deformed
+ by those who own all downstream dependencies and update them accordingly. */
+template <typename MeshType>
+class MeshDeformer {
+ public:
+  // Note: Because this contains a reference to some entity not owned by this
+  // class, copy and move semantics are problematic. We'll force users of this
+  // class to handle the semantics -- that is what the set_mesh() method is for.
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MeshDeformer);
+
+  /* The type of index used for referencing vertices in `MeshType`. */
+  using VertexIndexType = typename MeshType::VertexIndex;
+
+  /* The scalar type the mesh uses to report vertex positions. */
+  using T = typename MeshType::ScalarType;
+
+  /* Constructs a deformer for a particular `mesh_M`. `mesh_M` must remain alive
+   for at least as long as this deformer. The mesh has its vertex positions
+   measured and expressed in frame M; when updating the positions, new vertex
+   position values must likewise be measured and expressed in this same frame.
+
+   @param mesh_M  The mesh to be deformed.
+   @pre `mesh_M != nullptr`. */
+  explicit MeshDeformer(MeshType* mesh_M) : mesh_(*mesh_M) {
+    DRAKE_DEMAND(mesh_M != nullptr);
+  }
+
+  /* Sets the mesh for this deformer. */
+  void set_mesh(MeshType* mesh_M) {
+    DRAKE_DEMAND(mesh_M != nullptr);
+    mesh_ = *mesh_M;
+  }
+
+  /* Getter for the *const* version of the mesh to be deformed. */
+  const MeshType& mesh() const { return mesh_; }
+
+  /* Updates the position of all vertices in the mesh. Each sequential triple in
+   p_MVs (e.g., 3i, 3i + 1, 3i + 2), i ∈ ℤ, is interpreted as a position vector
+   associated with the iᵗʰ vertex. The position values are interpreted to be
+   measured and expressed in the same frame as the mesh to be deformed.
+
+   @param p_MVs  Vertex positions for the mesh's N vertices flattened into a
+                 vector (where each position vector is measured and expressed in
+                 the mesh's original frame).
+   @throws std::exception if p_MVs.size() != 3 * mesh().num_vertices() */
+  void SetAllPositions(const Eigen::Ref<const VectorX<T>>& p_MVs);
+
+ private:
+  using VertexType = typename MeshType::template VertexType<T>;
+
+  MeshType& mesh_;
+};
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/surface_mesh.h
+++ b/geometry/proximity/surface_mesh.h
@@ -105,6 +105,11 @@ class SurfaceFace {
   std::array<SurfaceVertexIndex, 3> vertex_;
 };
 
+namespace internal {
+// Forward declaration for friend declaration.
+template <typename> class MeshDeformer;
+}  // namespace internal
+
 // Forward declaration of SurfaceMeshTester<T>. SurfaceMesh<T> will
 // grant friend access to SurfaceMeshTester<T>.
 template <typename T> class SurfaceMeshTester;
@@ -140,6 +145,12 @@ class SurfaceMesh {
    Index for identifying a vertex.
    */
   using VertexIndex = SurfaceVertexIndex;
+  /* Note: the vertex type itself is templated (as opposed to just being an
+   alias for SurfaceVertex<T>), so that given a Mesh<AutoDiffXd> we can get a
+   double valued version of its vertex as: Mesh<AutoDiffXd>::VertexType<double>.
+   */
+  template <typename U = T>
+  using VertexType = SurfaceVertex<U>;
 
   /**
    Index for identifying a triangular element.
@@ -451,6 +462,9 @@ class SurfaceMesh {
   }
 
  private:
+  // Client attorney class that provides a means to modify vertex positions.
+  friend class internal::MeshDeformer<SurfaceMesh<T>>;
+
   // Calculates the areas and face normals of each triangle, the total area,
   // and the centroid of the surface.
   void CalcAreasNormalsAndCentroid();

--- a/geometry/proximity/test/deformable_volume_mesh_test.cc
+++ b/geometry/proximity/test/deformable_volume_mesh_test.cc
@@ -1,0 +1,196 @@
+#include "drake/geometry/proximity/deformable_volume_mesh.h"
+
+#include <limits>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/geometry/proximity/make_box_mesh.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace {
+
+/* In testing the move/copy semantics:
+
+1. For copy semantics, we want to confirm that the deformation mechanism is
+   wired up correctly. So, after copyping, we'll confirm the meshes match, but
+   when we update vertex positions for *one* of the meshes, we'll confirm they
+   no longer match.
+2. For move semantics, knowing something about move semantics on meshes we'll
+   confirm that the target of the move semantics doesn't match the source
+   mesh.
+For both, we'll make sure moving the vertices matches a reference mesh with
+the same vertex positions.
+
+For the assignment operators, we need to have *constructed* meshes that change
+values. So, we'll construct two meshes with identical topology but different
+scale (big and small), assigning the small to the big so that we can detect the
+efficacy of the assignment.
+
+This implicitly tests the UpdateVertexPositions() method over and over again; so
+there is no dedicated test for that method. */
+template <typename T>
+class DeformableVolumeMeshTest : public ::testing::Test {
+ public:
+  DeformableVolumeMeshTest() : ::testing::Test(), mesh_(MakeBox()) {}
+
+  /* Reports if the mesh coordinates match the arbitrary q-values to which we
+   will deform the mesh. We're *assuming* that q is correctly sized (i.e.,
+   q.size() == 3 * V, where V is the number of vertices). */
+  ::testing::AssertionResult MatchesQ(const VectorX<T>& q) const {
+    const VectorX<T> values = Eigen::Map<const VectorX<T>>(
+        reinterpret_cast<const T*>(mesh_.mesh().vertices().data()), q.size());
+    return CompareMatrices(values, q);
+  }
+
+  /* The box specification we're meshing. */
+  static Box box(double scale = 1) {
+    return Box(1 * scale, 2 * scale, 3 * scale);
+  }
+
+  /* Creates an instance of the box we'll use for the test. */
+  static VolumeMesh<T> MakeBox(double scale = 1) {
+    return MakeBoxVolumeMeshWithMa<T>(box(scale));
+  }
+
+  /* Given a mesh with N vertices, this returns a vector of 3N values which
+   represents a scaling of the vertex positions. */
+  static VectorX<T> ScaleVertexPositions(const VolumeMesh<T>& mesh,
+                                         double scale) {
+    const int num_vertices = mesh.num_vertices();
+    const auto& vertices = mesh.vertices();
+    VectorX<T> q(num_vertices * 3);
+    for (int v = 0, i = 0; v < num_vertices; ++v, i += 3) {
+      q.segment(i, 3) << vertices[v].r_MV() * scale;
+    }
+    return q;
+  }
+
+ protected:
+  DeformableVolumeMesh<T> mesh_;
+};
+
+using ScalarTypes = ::testing::Types<double, AutoDiffXd>;
+TYPED_TEST_SUITE(DeformableVolumeMeshTest, ScalarTypes);
+
+/* Generically poke around the mesh to make sure things are wired up correctly.
+   - the mesh is a copy of the input mesh. */
+TYPED_TEST(DeformableVolumeMeshTest, Construction) {
+  /* The test class constructs the deformable mesh; invocation is implicit in
+   test fixture. We'll simply confirm the listed properties. */
+
+  /* The contained mesh is a copy of the expected mesh. */
+  EXPECT_TRUE(this->mesh_.mesh().Equal(this->MakeBox()));
+}
+
+TYPED_TEST(DeformableVolumeMeshTest, CopyConstructor) {
+  using T = TypeParam;
+
+  DeformableVolumeMesh<T> copy(this->mesh_);
+
+  /* The copy's members are different *instances*, but equal values to the
+   source. */
+  EXPECT_NE(&copy.mesh(), &this->mesh_.mesh());
+  EXPECT_TRUE(copy.mesh().Equal(this->mesh_.mesh()));
+
+  /* Moving copy's vertex positions leaves mesh_'s vertex positions in place. */
+  constexpr double kScale = 0.3333;
+  const VectorX<T> q = this->ScaleVertexPositions(copy.mesh(), kScale);
+  copy.UpdateVertexPositions(q);
+  EXPECT_FALSE(copy.mesh().Equal(this->mesh_.mesh()));
+  /* However, if we construct a box with the same scaled factor, those meshes
+   will be equal. */
+  const VolumeMesh<T> ref = this->MakeBox(kScale);
+  EXPECT_TRUE(copy.mesh().Equal(ref, std::numeric_limits<double>::epsilon()));
+}
+
+TYPED_TEST(DeformableVolumeMeshTest, MoveConstructor) {
+  using T = TypeParam;
+  /* Construct a reference copy -- assumes the copy constructor works (see the
+   CopyConstructor test). */
+  const DeformableVolumeMesh<T> ref(this->mesh_);
+
+  DeformableVolumeMesh<T> moved(std::move(this->mesh_));
+
+  /* The targets's members are different *instances*, but equal values to the
+   reference. The source mesh is left in a state such that the moved mesh is
+   no longer equal to the source mesh. */
+  EXPECT_FALSE(moved.mesh().Equal(this->mesh_.mesh()));
+  EXPECT_TRUE(moved.mesh().Equal(ref.mesh()));
+
+  /* Now we confirm that such move-constructed mesh properly deforms (based on
+   comparing it with a reference mesh). */
+  constexpr double kScale = 0.3333;
+  const VectorX<T> q = this->ScaleVertexPositions(moved.mesh(), kScale);
+  moved.UpdateVertexPositions(q);
+  EXPECT_TRUE(moved.mesh().Equal(this->MakeBox(kScale),
+                                 std::numeric_limits<double>::epsilon()));
+}
+
+TYPED_TEST(DeformableVolumeMeshTest, CopyAssignment) {
+  using T = TypeParam;
+  DeformableVolumeMesh<T> big(this->MakeBox(2.0));
+  const DeformableVolumeMesh<T>& small = this->mesh_;
+
+  /* Confirm that the big mesh doesn't start equal to the small mesh. */
+  ASSERT_FALSE(big.mesh().Equal(small.mesh()));
+
+  big = small;
+
+  /* The copy's members are different *instances*, but equal values to the
+   source. */
+  EXPECT_NE(&big.mesh(), &small.mesh());
+  EXPECT_TRUE(big.mesh().Equal(small.mesh()));
+
+  /* Moving copy's vertex positions leaves mesh_'s vertex positions in place. */
+  constexpr double kScale = 0.3333;
+  const VectorX<T> q = this->ScaleVertexPositions(big.mesh(), kScale);
+  big.UpdateVertexPositions(q);
+  EXPECT_FALSE(big.mesh().Equal(small.mesh()));
+  /* However, if we construct a box with the same scaled factor, those meshes
+   will be equal. */
+  const VolumeMesh<T> ref = this->MakeBox(kScale);
+  EXPECT_TRUE(big.mesh().Equal(ref, std::numeric_limits<double>::epsilon()));
+}
+
+TYPED_TEST(DeformableVolumeMeshTest, MoveAssignment) {
+  using T = TypeParam;
+  /* With move *assignment*, we need a deformable mesh with an initial value
+   such that we can recognize successful reassignment. So, we create a mesh
+   that is "big" (compared to the "small" source mesh) and then move the small
+   mesh onto the big mesh. */
+  DeformableVolumeMesh<T> big(this->MakeBox(2.0));
+
+  /* Construct a reference copy -- assumes the copy constructor works (see the
+   CopyConstructor test). */
+  const DeformableVolumeMesh<T> small_ref(this->mesh_);
+
+  /* An alias for the "small" source deformable mesh. */
+  DeformableVolumeMesh<T>& small = this->mesh_;
+
+  /* Confirm that the big mesh doesn't start equal to the small mesh. */
+  ASSERT_FALSE(big.mesh().Equal(small.mesh()));
+
+  big = std::move(small);
+
+  /* The targets's members are different *instances*, but equal values to the
+   reference. */
+  EXPECT_FALSE(big.mesh().Equal(small.mesh()));
+  EXPECT_TRUE(big.mesh().Equal(small_ref.mesh()));
+
+  /* Now we confirm that such move-assigned mesh properly deforms (based on
+   comparing it with a reference mesh). */
+  constexpr double kScale = 0.3333;
+  const VectorX<T> q = this->ScaleVertexPositions(big.mesh(), kScale);
+  big.UpdateVertexPositions(q);
+  EXPECT_TRUE(big.mesh().Equal(this->MakeBox(kScale),
+                               std::numeric_limits<double>::epsilon()));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/mesh_deformer_test.cc
+++ b/geometry/proximity/test/mesh_deformer_test.cc
@@ -1,0 +1,131 @@
+#include "drake/geometry/proximity/mesh_deformer.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/proximity/make_box_mesh.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace {
+
+// N.B. We can't use partial specialization on functions, so we create a factory
+// struct to serve the purpose.
+template <typename T, template <typename> typename MeshType>
+struct BoxMaker {
+  static MeshType<T> make(const Box& box) {
+    throw std::logic_error("Unimplemented call to MakeBox");
+  }
+};
+
+template <typename T>
+struct BoxMaker<T, VolumeMesh> {
+  static VolumeMesh<T> make(const Box& box) {
+    return MakeBoxVolumeMeshWithMa<T>(box);
+  }
+};
+
+template <typename T>
+struct BoxMaker<T, SurfaceMesh> {
+  static SurfaceMesh<T> make(const Box& box) {
+    return ConvertVolumeToSurfaceMesh(MakeBoxVolumeMeshWithMa<T>(box));
+  }
+};
+
+using ScalarTypes = ::testing::Types<double, AutoDiffXd>;
+
+/* The mesh deformer has two independent axes to test: the type of mesh (volume
+ vs surface) and the scalar type for the mesh (double or AutoDiffXd). This test
+ provides the basis for testing the constructor and the vertex position
+ updating for all four combinations.
+
+ See below where we instantiate this test fixture explicitly on each type of
+ mesh and then use gtest to iterate over the scalar types. */
+template <typename T, template <typename> typename MeshType>
+class MeshDeformerTest : public ::testing::Test {
+ public:
+  MeshDeformerTest()
+      : ::testing::Test(),
+        mesh_(BoxMaker<T, MeshType>().make(Box(1, 2, 3))),
+        deformer_(&mesh_) {
+    // Create some nonsensical vertex positions -- these monotonically
+    // increasing values will *not* match the original box.
+    q_.resize(mesh_.num_vertices() * 3);
+    for (int i = 0; i < q_.size(); ++i) {
+      q_[i] = i;
+    }
+  }
+
+  /* Tests the constructor. */
+  void TestConstructor() {
+    // The test class constructs it, so, we'll simply confirm that the deformer
+    // has the mesh.
+    EXPECT_EQ(&deformer_.mesh(), &mesh_);
+  }
+
+  void TestSetAllPositions() {
+    // Quick reality check that we don't start in a deformed configuration.
+    ASSERT_FALSE(MatchesQ());
+    deformer_.SetAllPositions(q_);
+    EXPECT_TRUE(MatchesQ());
+
+    const int q_size = q_.rows();
+
+    const VectorX<T> too_small(q_size- 1);
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        deformer_.SetAllPositions(too_small), std::exception,
+        ".+SetAllPositions.+ \\d+ vertices with data for \\d+ vertices");
+
+    const VectorX<T> too_large(q_size + 1);
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        deformer_.SetAllPositions(too_large), std::exception,
+        ".+SetAllPositions.+ \\d+ vertices with data for \\d+ vertices");
+  }
+
+  /* Reports if the mesh coordinates match the arbitrary q-values to which we
+   will deform the mesh. */
+  ::testing::AssertionResult MatchesQ() const {
+    const VectorX<T> values = Eigen::Map<const VectorX<T>>(
+        reinterpret_cast<const T*>(mesh_.vertices().data()), q_.size());
+    return CompareMatrices(values, q_);
+  }
+
+ protected:
+  MeshType<T> mesh_;
+  MeshDeformer<MeshType<T>> deformer_;
+  VectorX<T> q_;
+};
+
+template <typename T>
+using VolumeMeshDeformerTest = MeshDeformerTest<T, VolumeMesh>;
+TYPED_TEST_SUITE(VolumeMeshDeformerTest, ScalarTypes);
+
+TYPED_TEST(VolumeMeshDeformerTest, Construction) {
+  this->TestConstructor();
+}
+
+TYPED_TEST(VolumeMeshDeformerTest, SetAllPositions) {
+  this->TestSetAllPositions();
+}
+
+template <typename T>
+using SurfaceMeshDeformerTest = MeshDeformerTest<T, SurfaceMesh>;
+TYPED_TEST_SUITE(SurfaceMeshDeformerTest, ScalarTypes);
+
+TYPED_TEST(SurfaceMeshDeformerTest, Construction) {
+  this->TestConstructor();
+}
+
+TYPED_TEST(SurfaceMeshDeformerTest, SetAllPositions) {
+  this->TestSetAllPositions();
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake
+
+


### PR DESCRIPTION
 - Introduce the generic `MeshDeformer` abstraction.
  - It is compatible with both `SurfaceMesh` and `VolumeMesh`. Each have been modified to support the deformer.
 - Add the `DeformableVolumeMesh`
  - Wraps a `VolumeMesh` with a corresponding `MeshDeformer` and provides an API for updating vertex positions.

In the near future, a "deformable" bvh will be added as well.

Relates #15080

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15117)
<!-- Reviewable:end -->
