### PR TITLE
Add support for parsing acceleration limits for some joints in URDF and SDF

### DIFF
--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -286,13 +286,13 @@ void AddRevoluteSpringFromSpecification(
 }
 
 // Returns joint limits as the tuple (lower_limit, upper_limit,
-// velocity_limit).  The units of the limits depend on the particular joint
-// type.  For prismatic joints, units are meters for the position limits and
-// m/s for the velocity limit.  For revolute joints, units are radians for the
-// position limits and rad/s for the velocity limit.  The velocity limit is
-// always >= 0.  This method throws an exception if the joint type is not one
-// of revolute or prismatic.
-std::tuple<double, double, double> ParseJointLimits(
+// velocity_limit, acceleration_limit).  The units of the limits depend on the
+// particular joint type.  For prismatic joints, units are meters for the
+// position limits and m/s for the velocity limit.  For revolute joints, units
+// are radians for the position limits and rad/s for the velocity limit.
+// Velocity and acceleration limits are always >= 0.  This method throws an
+// exception if the joint type is not one of revolute or prismatic.
+std::tuple<double, double, double, double> ParseJointLimits(
     const sdf::Joint& joint_spec) {
   DRAKE_THROW_UNLESS(joint_spec.Type() == sdf::JointType::REVOLUTE ||
       joint_spec.Type() == sdf::JointType::PRISMATIC);
@@ -332,7 +332,23 @@ std::tuple<double, double, double> ParseJointLimits(
             "Velocity limit must be a non-negative number.");
   }
 
-  return std::make_tuple(lower_limit, upper_limit, velocity_limit);
+  // Read Drake-namespaced acceleration limit if present. If not, default to
+  // ±numeric_limits<double>::infinity().
+  double acceleration_limit = std::numeric_limits<double>::infinity();
+  if (axis->Element()->HasElement("limit")) {
+    const auto limit_element = axis->Element()->GetElement("limit");
+    if (limit_element->HasElement("drake:acceleration")) {
+      acceleration_limit = limit_element->Get<double>("drake:acceleration");
+      if (acceleration_limit < 0) {
+        throw std::runtime_error(
+          "Acceleration limit is negative for joint '" + joint_spec.Name() +
+              "'. Aceleration limit must be a non-negative number.");
+      }
+    }
+  }
+
+  return std::make_tuple(
+      lower_limit, upper_limit, velocity_limit, acceleration_limit);
 }
 
 // Helper method to add joints to a MultibodyPlant given an sdf::Joint
@@ -375,6 +391,7 @@ void AddJointFromSpecification(
   double lower_limit = 0;
   double upper_limit = 0;
   double velocity_limit = 0;
+  double acceleration_limit = 0;
 
   switch (joint_spec.Type()) {
     case sdf::JointType::FIXED: {
@@ -388,7 +405,7 @@ void AddJointFromSpecification(
     case sdf::JointType::PRISMATIC: {
       const double damping = ParseJointDamping(joint_spec);
       Vector3d axis_J = ExtractJointAxis(model_spec, joint_spec);
-      std::tie(lower_limit, upper_limit, velocity_limit) =
+      std::tie(lower_limit, upper_limit, velocity_limit, acceleration_limit) =
           ParseJointLimits(joint_spec);
       const auto& joint = plant->AddJoint<PrismaticJoint>(
           joint_spec.Name(),
@@ -396,13 +413,15 @@ void AddJointFromSpecification(
           child_body, X_CJ, axis_J, lower_limit, upper_limit, damping);
       plant->get_mutable_joint(joint.index()).set_velocity_limits(
           Vector1d(-velocity_limit), Vector1d(velocity_limit));
+      plant->get_mutable_joint(joint.index()).set_acceleration_limits(
+          Vector1d(-acceleration_limit), Vector1d(acceleration_limit));
       AddJointActuatorFromSpecification(joint_spec, joint, plant);
       break;
     }
     case sdf::JointType::REVOLUTE: {
       const double damping = ParseJointDamping(joint_spec);
       Vector3d axis_J = ExtractJointAxis(model_spec, joint_spec);
-      std::tie(lower_limit, upper_limit, velocity_limit) =
+      std::tie(lower_limit, upper_limit, velocity_limit, acceleration_limit) =
           ParseJointLimits(joint_spec);
       const auto& joint = plant->AddJoint<RevoluteJoint>(
           joint_spec.Name(),
@@ -410,6 +429,8 @@ void AddJointFromSpecification(
           child_body, X_CJ, axis_J, lower_limit, upper_limit, damping);
       plant->get_mutable_joint(joint.index()).set_velocity_limits(
           Vector1d(-velocity_limit), Vector1d(velocity_limit));
+      plant->get_mutable_joint(joint.index()).set_acceleration_limits(
+          Vector1d(-acceleration_limit), Vector1d(acceleration_limit));
       AddJointActuatorFromSpecification(joint_spec, joint, plant);
       AddRevoluteSpringFromSpecification(joint_spec, joint, plant);
       break;

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -681,6 +681,10 @@ GTEST_TEST(MultibodyPlantSdfParserTest, JointParsingTest) {
       revolute_joint.velocity_lower_limits(), Vector1d(-100)));
   EXPECT_TRUE(CompareMatrices(
       revolute_joint.velocity_upper_limits(), Vector1d(100)));
+  EXPECT_TRUE(CompareMatrices(
+      revolute_joint.acceleration_lower_limits(), Vector1d(-200)));
+  EXPECT_TRUE(CompareMatrices(
+      revolute_joint.acceleration_upper_limits(), Vector1d(200)));
 
   // Prismatic joint
   DRAKE_EXPECT_NO_THROW(
@@ -700,6 +704,10 @@ GTEST_TEST(MultibodyPlantSdfParserTest, JointParsingTest) {
       prismatic_joint.velocity_lower_limits(), Vector1d(-5)));
   EXPECT_TRUE(CompareMatrices(
       prismatic_joint.velocity_upper_limits(), Vector1d(5)));
+  EXPECT_TRUE(CompareMatrices(
+      prismatic_joint.acceleration_lower_limits(), Vector1d(-10)));
+  EXPECT_TRUE(CompareMatrices(
+      prismatic_joint.acceleration_upper_limits(), Vector1d(10)));
 
   // Limitless revolute joint
   DRAKE_EXPECT_NO_THROW(

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -724,6 +724,9 @@ GTEST_TEST(MultibodyPlantSdfParserTest, JointParsingTest) {
   EXPECT_TRUE(CompareMatrices(no_limit_joint.position_upper_limits(), inf));
   EXPECT_TRUE(CompareMatrices(no_limit_joint.velocity_lower_limits(), neg_inf));
   EXPECT_TRUE(CompareMatrices(no_limit_joint.velocity_upper_limits(), inf));
+  EXPECT_TRUE(CompareMatrices(
+      no_limit_joint.acceleration_lower_limits(), neg_inf));
+  EXPECT_TRUE(CompareMatrices(no_limit_joint.acceleration_upper_limits(), inf));
 
   // Ball joint
   DRAKE_EXPECT_NO_THROW(plant.GetJointByName<BallRpyJoint>("ball_joint"));

--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -272,6 +272,9 @@ GTEST_TEST(MultibodyPlantUrdfParserTest, JointParsingTest) {
   EXPECT_TRUE(CompareMatrices(no_limit_joint.position_upper_limits(), inf));
   EXPECT_TRUE(CompareMatrices(no_limit_joint.velocity_lower_limits(), neg_inf));
   EXPECT_TRUE(CompareMatrices(no_limit_joint.velocity_upper_limits(), inf));
+  EXPECT_TRUE(CompareMatrices(
+      no_limit_joint.acceleration_lower_limits(), neg_inf));
+  EXPECT_TRUE(CompareMatrices(no_limit_joint.acceleration_upper_limits(), inf));
   EXPECT_GT(no_limit_joint.index(), ball_joint.index());
 
   // Limitless revolute actuator

--- a/multibody/parsing/test/detail_urdf_parser_test.cc
+++ b/multibody/parsing/test/detail_urdf_parser_test.cc
@@ -207,6 +207,10 @@ GTEST_TEST(MultibodyPlantUrdfParserTest, JointParsingTest) {
       CompareMatrices(revolute_joint.velocity_lower_limits(), Vector1d(-100)));
   EXPECT_TRUE(
       CompareMatrices(revolute_joint.velocity_upper_limits(), Vector1d(100)));
+  EXPECT_TRUE(CompareMatrices(
+      revolute_joint.acceleration_lower_limits(), Vector1d(-200)));
+  EXPECT_TRUE(CompareMatrices(
+      revolute_joint.acceleration_upper_limits(), Vector1d(200)));
 
   // Revolute actuator
   const JointActuator<double>& revolute_actuator =
@@ -231,6 +235,10 @@ GTEST_TEST(MultibodyPlantUrdfParserTest, JointParsingTest) {
       CompareMatrices(prismatic_joint.velocity_lower_limits(), Vector1d(-5)));
   EXPECT_TRUE(
       CompareMatrices(prismatic_joint.velocity_upper_limits(), Vector1d(5)));
+  EXPECT_TRUE(CompareMatrices(
+      prismatic_joint.acceleration_lower_limits(), Vector1d(-10)));
+  EXPECT_TRUE(CompareMatrices(
+      prismatic_joint.acceleration_upper_limits(), Vector1d(10)));
   EXPECT_FALSE(plant.HasJointActuatorNamed("prismatic_actuator"));
 
   // Ball joint

--- a/multibody/parsing/test/sdf_parser_test/joint_parsing_test.sdf
+++ b/multibody/parsing/test/sdf_parser_test/joint_parsing_test.sdf
@@ -40,6 +40,7 @@ Defines an SDF model with various types of joints used for testing the parser.
           <upper>2</upper>
           <effort>100</effort>
           <velocity>100</velocity>
+          <drake:acceleration>200</drake:acceleration>
         </limit>
         <dynamics>
           <damping>0.2</damping>
@@ -71,6 +72,7 @@ Defines an SDF model with various types of joints used for testing the parser.
           <upper>1</upper>
           <effort>100</effort>
           <velocity>5</velocity>
+          <drake:acceleration>10</drake:acceleration>
         </limit>
         <dynamics>
           <damping>0.3</damping>

--- a/multibody/parsing/test/urdf_parser_test/joint_parsing_test.urdf
+++ b/multibody/parsing/test/urdf_parser_test/joint_parsing_test.urdf
@@ -54,7 +54,7 @@ Defines a URDF model with various types of joints.
     <parent link="link1"/>
     <child link="link2"/>
     <origin rpy="0 0 0" xyz="0 0 0"/>
-    <limit effort="100" lower="-1" upper="2" velocity="100"/>
+    <limit effort="100" lower="-1" upper="2" velocity="100" drake:acceleration="200"/>
     <dynamics damping="0.1"/>
   </joint>
   <joint name="prismatic_joint" type="prismatic">
@@ -62,7 +62,7 @@ Defines a URDF model with various types of joints.
     <parent link="link2"/>
     <child link="link3"/>
     <origin rpy="0 0 0" xyz="0 0 0"/>
-    <limit effort="0" lower="-2" upper="1" velocity="5"/>
+    <limit effort="0" lower="-2" upper="1" velocity="5" drake:acceleration="10"/>
     <dynamics damping="0.1"/>
   </joint>
   <drake:joint name="ball_joint" type="ball">


### PR DESCRIPTION
From discussions on [slack](https://drakedevelopers.slack.com/archives/C2WBPQDB7/p1622670322026300), trying out adding support for parsing acceleration limits for some (continuous, revolute, and prismatic) joints.

I'm not sure I understand the structure of SDF parsing to know where the equivalent would be implemented for SDF models.

@sammy-tri

cc @jwnimmer-tri @ggould-tri @SeanCurtis-TRI

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15122)
<!-- Reviewable:end -->
