### PR TITLE
Support rigid dofs update in DeformableRigidManager

### DIFF
--- a/multibody/fixed_fem/dev/BUILD.bazel
+++ b/multibody/fixed_fem/dev/BUILD.bazel
@@ -585,7 +585,9 @@ drake_cc_googletest(
         ":deformable_rigid_manager",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
+        "//examples/multibody/rolling_sphere:make_rolling_sphere_plant",
         "//geometry/proximity:make_box_mesh",
+        "//multibody/contact_solvers:pgs_solver",
         "//systems/analysis:simulator",
     ],
 )

--- a/multibody/fixed_fem/dev/deformable_rigid_manager.h
+++ b/multibody/fixed_fem/dev/deformable_rigid_manager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -8,6 +9,7 @@
 #include "drake/multibody/contact_solvers/contact_solver.h"
 #include "drake/multibody/fixed_fem/dev/deformable_model.h"
 #include "drake/multibody/fixed_fem/dev/fem_solver.h"
+#include "drake/multibody/plant/contact_jacobians.h"
 #include "drake/multibody/plant/discrete_update_manager.h"
 
 namespace drake {
@@ -44,18 +46,31 @@ class DeformableRigidManager final
 
   void DeclareCacheEntries(MultibodyPlant<T>* plant) final;
 
-  // TODO(xuchenhan-tri): Implement this.
   void DoCalcContactSolverResults(
-      const systems::Context<T>&,
-      contact_solvers::internal::ContactSolverResults<T>*) const final {
-    throw std::logic_error(
-        "CalcContactSolverResults() hasn't be implemented for "
-        "DeformableRigidManager yet.");
-  }
+      const systems::Context<T>& context,
+      contact_solvers::internal::ContactSolverResults<T>* results) const final;
+
+  /* Calculates all contact quantities needed by the contact solver and the
+   TAMSI solver from the given `context` and `rigid_contact_pairs`.
+   @pre All pointer parameters are non-null.
+   @pre The size of `v` and `minus_tau` are equal to the number of rigid
+        generalized velocities.
+   @pre `M` is square and has rows and columns equal to the number of rigid
+        generalized velocities.
+   @pre `mu`, `phi`, `fn`, `stiffness`, `damping`, and `rigid_contact_pairs`
+        have the same size. */
+  void CalcContactQuantities(
+      const systems::Context<T>& context,
+      const std::vector<multibody::internal::DiscreteContactPair<T>>&
+          rigid_contact_pairs,
+      multibody::internal::ContactJacobians<T>* rigid_contact_jacobians,
+      EigenPtr<VectorX<T>> v, EigenPtr<MatrixX<T>> M,
+      EigenPtr<VectorX<T>> minus_tau, EigenPtr<VectorX<T>> mu,
+      EigenPtr<VectorX<T>> phi, EigenPtr<VectorX<T>> fn,
+      EigenPtr<VectorX<T>> stiffness, EigenPtr<VectorX<T>> damping) const;
 
   // TODO(xuchenhan-tri): Implement this once AccelerationKinematicsCache
-  // also
-  //  caches acceleration for deformable dofs.
+  //  also caches acceleration for deformable dofs.
   void DoCalcAccelerationKinematicsCache(
       const systems::Context<T>&,
       multibody::internal::AccelerationKinematicsCache<T>*) const final {

--- a/multibody/fixed_fem/dev/test/deformable_rigid_manager_test.cc
+++ b/multibody/fixed_fem/dev/test/deformable_rigid_manager_test.cc
@@ -4,7 +4,9 @@
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/examples/multibody/rolling_sphere/make_rolling_sphere_plant.h"
 #include "drake/geometry/proximity/make_box_mesh.h"
+#include "drake/multibody/contact_solvers/pgs_solver.h"
 #include "drake/multibody/fixed_fem/dev/deformable_model.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/systems/analysis/simulator.h"
@@ -27,7 +29,10 @@ const double kDt = 0.0123;
 const double kGravity = -9.81;
 /* Number of vertices in the box mesh (see below). */
 constexpr int kNumVertices = 8;
+using Eigen::Vector3d;
 using Eigen::VectorXd;
+using geometry::SceneGraph;
+using systems::Context;
 
 class DeformableRigidManagerTest : public ::testing::Test {
  protected:
@@ -38,8 +43,7 @@ class DeformableRigidManagerTest : public ::testing::Test {
     auto deformable_model = std::make_unique<DeformableModel<double>>(&plant_);
     deformable_model->RegisterDeformableBody(MakeBoxTetMesh(), "box",
                                              MakeDeformableBodyConfig());
-    deformable_model_ =
-        &plant_.AddPhysicalModel(std::move(deformable_model));
+    deformable_model_ = &plant_.AddPhysicalModel(std::move(deformable_model));
     plant_.Finalize();
     auto deformable_rigid_manager =
         std::make_unique<DeformableRigidManager<double>>();
@@ -58,7 +62,7 @@ class DeformableRigidManagerTest : public ::testing::Test {
     return mesh;
   }
 
-  /* Create a dummy DeformableConfig. */
+  /* Create a dummy DeformableBodyConfig. */
   static DeformableBodyConfig<double> MakeDeformableBodyConfig() {
     DeformableBodyConfig<double> config;
     config.set_youngs_modulus(kYoungsModulus);
@@ -109,16 +113,6 @@ TEST_F(DeformableRigidManagerTest, CalcDiscreteValue) {
   }
 }
 
-// TODO(xuchenhan-tri): Update the unit test once the CalcContactSolverResults()
-//  method is implemented.
-TEST_F(DeformableRigidManagerTest, CalcContactSolverResults) {
-  auto context = plant_.CreateDefaultContext();
-  contact_solvers::internal::ContactSolverResults<double> results;
-  EXPECT_THROW(deformable_rigid_manager_->CalcContactSolverResults(
-                   *context, &results),
-               std::exception);
-}
-
 // TODO(xuchenhan-tri): Update the unit test once the
 //  CalcAccelerationKinematicsCache() method is implemented.
 TEST_F(DeformableRigidManagerTest, CalcAccelerationKinematicsCache) {
@@ -127,6 +121,125 @@ TEST_F(DeformableRigidManagerTest, CalcAccelerationKinematicsCache) {
                std::exception);
 }
 
+/* Makes a finalized MultibodyPlant model of a ball falling into a plane. Sets a
+ DiscreteUpdateManager for the plant if the `use_manager` flag is on. The given
+ `scene_graph` is used to manage geometries and must be non-null. */
+std::unique_ptr<MultibodyPlant<double>> MakePlant(
+    std::unique_ptr<contact_solvers::internal::ContactSolver<double>>
+        contact_solver,
+    bool use_manager, SceneGraph<double>* scene_graph) {
+  EXPECT_NE(scene_graph, nullptr);
+  constexpr double kBouncingBallDt = 1e-3;  // s
+  constexpr double kBallRadius = 0.05;      // m
+  constexpr double kBallMass = 0.1;         // kg
+  constexpr double kElasticModulus = 5e4;   // Pa
+  constexpr double kDissipation = 5;        // s/m
+  const CoulombFriction<double> kFriction(0.3, 0.3);
+  std::unique_ptr<MultibodyPlant<double>> plant =
+      examples::multibody::bouncing_ball::MakeBouncingBallPlant(
+          kBouncingBallDt, kBallRadius, kBallMass, kElasticModulus,
+          kDissipation, kFriction, kGravity * Vector3d::UnitZ(), true, false,
+          scene_graph);
+  if (use_manager) {
+    auto deformable_model =
+        std::make_unique<DeformableModel<double>>(plant.get());
+    plant->AddPhysicalModel(std::move(deformable_model));
+  }
+  plant->Finalize();
+  if (use_manager) {
+    auto deformable_rigid_manager =
+        std::make_unique<DeformableRigidManager<double>>();
+    DeformableRigidManager<double>* deformable_rigid_manager_ptr =
+        &plant->set_discrete_update_manager(
+            std::move(deformable_rigid_manager));
+    if (contact_solver != nullptr) {
+      deformable_rigid_manager_ptr->set_contact_solver(
+          std::move(contact_solver));
+    }
+  } else {
+    if (contact_solver != nullptr) {
+      plant->set_contact_solver(std::move(contact_solver));
+    }
+  }
+  return plant;
+}
+
+/* Sets up a discrete simulation with a rigid sphere in contact with a rigid
+ ground and runs the simulation until `kFinalTime` and returns the final
+ discrete states. The given `contact_solver` is used to solve the rigid
+ contacts. If `contact_solver == nullptr`, then the TAMSI solver is used. If
+ `use_manager` is true, use DiscreteUpdateManager to perform the discrete
+ updates. Otherwise, use the MultibodyPlant discrete updates. */
+VectorXd CalcFinalState(
+    std::unique_ptr<contact_solvers::internal::ContactSolver<double>>
+        contact_solver,
+    bool use_manager) {
+  systems::DiagramBuilder<double> builder;
+  SceneGraph<double>& scene_graph = *builder.AddSystem<SceneGraph<double>>();
+  scene_graph.set_name("scene_graph");
+  MultibodyPlant<double>& plant = *builder.AddSystem(
+      MakePlant(std::move(contact_solver), use_manager, &scene_graph));
+  DRAKE_DEMAND(plant.num_velocities() == 6);
+  DRAKE_DEMAND(plant.num_positions() == 7);
+
+  /* Wire up the plant and the scene graph. */
+  DRAKE_DEMAND(!!plant.get_source_id());
+  builder.Connect(scene_graph.get_query_output_port(),
+                  plant.get_geometry_query_input_port());
+  builder.Connect(
+      plant.get_geometry_poses_output_port(),
+      scene_graph.get_source_pose_port(plant.get_source_id().value()));
+  auto diagram = builder.Build();
+
+  std::unique_ptr<Context<double>> diagram_context =
+      diagram->CreateDefaultContext();
+  Context<double>& plant_context =
+      diagram->GetMutableSubsystemContext(plant, diagram_context.get());
+
+  /* Set non-trivial initial pose and velocity. */
+  const math::RotationMatrixd R_WB(
+      math::RollPitchYawd(Vector3<double>{100, 200, 300}));
+  constexpr double kZ0 = 0.05;  // Initial ball height [m].
+  const math::RigidTransformd X_WB(R_WB, Vector3d(0.0, 0.0, kZ0));
+  plant.SetFreeBodyPose(&plant_context, plant.GetBodyByName("Ball"), X_WB);
+  const SpatialVelocity<double> V_WB(Vector3d(100, 200, 300),
+                                     Vector3d(1.5, 1.6, 1.7));
+  plant.SetFreeBodySpatialVelocity(&plant_context, plant.GetBodyByName("Ball"),
+                                   V_WB);
+
+  /* Builds the simulator and simulate to final time. */
+  systems::Simulator<double> simulator(*diagram, std::move(diagram_context));
+  constexpr double kFinalTime = 0.1;
+  simulator.AdvanceTo(kFinalTime);
+  const Context<double>& final_plant_context =
+      plant.GetMyContextFromRoot(simulator.get_context());
+  return final_plant_context.get_discrete_state().get_vector().get_value();
+}
+
+/* Given a scene with no deformable body, verify that the simulation results
+ obtained through the DeformableRigidManager is the same as the one obtained
+ without when no contact solver is assigned. */
+GTEST_TEST(RigidUpdateTest, TamsiSolver) {
+  const VectorXd final_state_with_manager = CalcFinalState(nullptr, true);
+  const VectorXd final_state_without_manager = CalcFinalState(nullptr, false);
+  EXPECT_TRUE(
+      CompareMatrices(final_state_with_manager, final_state_without_manager));
+  /* Sanity check that the final state is not NaN. */
+  EXPECT_FALSE(final_state_with_manager.hasNaN());
+}
+
+/* Similar to the test above but uses a contact solver instead of the TAMSI
+ solver to solve rigid contacts. */
+GTEST_TEST(RigidUpdateTest, ContactSolver) {
+  const VectorXd final_state_with_manager = CalcFinalState(
+      std::make_unique<contact_solvers::internal::PgsSolver<double>>(), true);
+  const VectorXd final_state_without_manager = CalcFinalState(
+      std::make_unique<contact_solvers::internal::PgsSolver<double>>(), false);
+  EXPECT_TRUE(
+      CompareMatrices(final_state_with_manager, final_state_without_manager));
+  /* Sanity check that the final state is not NaN. */
+  EXPECT_FALSE(final_state_with_manager.hasNaN());
+}
 }  // namespace
 }  // namespace fixed_fem
 }  // namespace multibody

--- a/multibody/plant/discrete_update_manager.cc
+++ b/multibody/plant/discrete_update_manager.cc
@@ -11,6 +11,72 @@ template <typename T>
 const MultibodyTree<T>& DiscreteUpdateManager<T>::internal_tree() const {
   return MultibodyPlantDiscreteUpdateManagerAttorney<T>::internal_tree(plant());
 }
+
+template <typename T>
+const contact_solvers::internal::ContactSolverResults<T>&
+DiscreteUpdateManager<T>::EvalContactSolverResults(
+    const systems::Context<T>& context) const {
+  return MultibodyPlantDiscreteUpdateManagerAttorney<
+      T>::EvalContactSolverResults(plant(), context);
+}
+
+template <typename T>
+const internal::ContactJacobians<T>&
+DiscreteUpdateManager<T>::EvalContactJacobians(
+    const systems::Context<T>& context) const {
+  return MultibodyPlantDiscreteUpdateManagerAttorney<T>::EvalContactJacobians(
+      plant(), context);
+}
+
+template <typename T>
+std::vector<CoulombFriction<double>>
+DiscreteUpdateManager<T>::CalcCombinedFrictionCoefficients(
+    const systems::Context<T>& context,
+    const std::vector<internal::DiscreteContactPair<T>>& contact_pairs) const {
+  return MultibodyPlantDiscreteUpdateManagerAttorney<
+      T>::CalcCombinedFrictionCoefficients(plant(), context, contact_pairs);
+}
+
+template <typename T>
+void DiscreteUpdateManager<T>::CalcNonContactForces(
+    const systems::Context<T>& context, bool discrete,
+    MultibodyForces<T>* forces) const {
+  MultibodyPlantDiscreteUpdateManagerAttorney<T>::CalcNonContactForces(
+      plant(), context, discrete, forces);
+}
+
+template <typename T>
+std::vector<internal::DiscreteContactPair<T>>
+DiscreteUpdateManager<T>::CalcDiscreteContactPairs(
+    const systems::Context<T>& context) const {
+  return MultibodyPlantDiscreteUpdateManagerAttorney<
+      T>::CalcDiscreteContactPairs(plant(), context);
+}
+
+template <typename T>
+void DiscreteUpdateManager<T>::CallTamsiSolver(
+    const T& time0, const VectorX<T>& v0, const MatrixX<T>& M0,
+    const VectorX<T>& minus_tau, const VectorX<T>& fn0, const MatrixX<T>& Jn,
+    const MatrixX<T>& Jt, const VectorX<T>& stiffness,
+    const VectorX<T>& damping, const VectorX<T>& mu,
+    contact_solvers::internal::ContactSolverResults<T>* results) const {
+  MultibodyPlantDiscreteUpdateManagerAttorney<T>::CallTamsiSolver(
+      plant(), time0, v0, M0, minus_tau, fn0, Jn, Jt, stiffness, damping, mu,
+      results);
+}
+
+template <typename T>
+void DiscreteUpdateManager<T>::CallContactSolver(
+    contact_solvers::internal::ContactSolver<T>* contact_solver,
+    const T& time0, const VectorX<T>& v0, const MatrixX<T>& M0,
+    const VectorX<T>& minus_tau, const VectorX<T>& phi0, const MatrixX<T>& Jc,
+    const VectorX<T>& stiffness, const VectorX<T>& damping,
+    const VectorX<T>& mu,
+    contact_solvers::internal::ContactSolverResults<T>* results) const {
+  MultibodyPlantDiscreteUpdateManagerAttorney<T>::CallContactSolver(
+      plant(), contact_solver, time0, v0, M0, minus_tau, phi0, Jc, stiffness,
+      damping, mu, results);
+}
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -2162,8 +2162,9 @@ void MultibodyPlant<T>::CalcContactSolverResults(
   }
 
   if (contact_solver_ != nullptr) {
-    CallContactSolver(context0.get_time(), v0, M0, minus_tau, phi0,
-                      contact_jacobians.Jc, stiffness, damping, mu, results);
+    CallContactSolver(contact_solver_.get(), context0.get_time(), v0, M0,
+                      minus_tau, phi0, contact_jacobians.Jc, stiffness, damping,
+                      mu, results);
   } else {
     CallTamsiSolver(context0.get_time(), v0, M0, minus_tau, fn0,
                     contact_jacobians.Jn, contact_jacobians.Jt, stiffness,
@@ -2237,6 +2238,7 @@ void MultibodyPlant<T>::CallTamsiSolver(
 
 template <>
 void MultibodyPlant<symbolic::Expression>::CallContactSolver(
+    contact_solvers::internal::ContactSolver<symbolic::Expression>*,
     const symbolic::Expression&, const VectorX<symbolic::Expression>&,
     const MatrixX<symbolic::Expression>&, const VectorX<symbolic::Expression>&,
     const VectorX<symbolic::Expression>&, const MatrixX<symbolic::Expression>&,
@@ -2250,6 +2252,7 @@ void MultibodyPlant<symbolic::Expression>::CallContactSolver(
 
 template <typename T>
 void MultibodyPlant<T>::CallContactSolver(
+    contact_solvers::internal::ContactSolver<T>* contact_solver,
     const T& time0, const VectorX<T>& v0, const MatrixX<T>& M0,
     const VectorX<T>& minus_tau, const VectorX<T>& phi0, const MatrixX<T>& Jc,
     const VectorX<T>& stiffness, const VectorX<T>& damping,
@@ -2312,8 +2315,8 @@ void MultibodyPlant<T>::CallContactSolver(
   contact_solvers::internal::PointContactData<T> contact_data(
       &phi0, &Jc_op, &stiffness, &damping, &mu);
   const contact_solvers::internal::ContactSolverStatus info =
-      contact_solver_->SolveWithGuess(time_step(), dynamics_data, contact_data,
-                                      v0, &*results);
+      contact_solver->SolveWithGuess(time_step(), dynamics_data, contact_data,
+                                    v0, &*results);
 
   if (info != contact_solvers::internal::ContactSolverStatus::kSuccess) {
     const std::string msg =

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -4538,7 +4538,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
                               joint.child_body().index());
   }
 
-  // Helper to invoke our TamsiSolver.
+  // Helper to invoke our TamsiSolver. This method and `CallContactSolver()` are
+  // disjoint methods. One should only use one or the other, but not both.
   void CallTamsiSolver(
       const T& time0, const VectorX<T>& v0, const MatrixX<T>& M0,
       const VectorX<T>& minus_tau, const VectorX<T>& fn0, const MatrixX<T>& Jn,
@@ -4546,8 +4547,11 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
       const VectorX<T>& damping, const VectorX<T>& mu,
       contact_solvers::internal::ContactSolverResults<T>* results) const;
 
-  // Helper to invoke ContactSolver when one is available.
+  // Helper to invoke ContactSolver when one is available. This method and
+  // `CallTamsiSolver()` are disjoint methods. One should only use one or the
+  // other, but not both.
   void CallContactSolver(
+      contact_solvers::internal::ContactSolver<T>* contact_solver,
       const T& time0, const VectorX<T>& v0, const MatrixX<T>& M0,
       const VectorX<T>& minus_tau, const VectorX<T>& phi0, const MatrixX<T>& Jc,
       const VectorX<T>& stiffness, const VectorX<T>& damping,
@@ -4949,6 +4953,7 @@ void MultibodyPlant<symbolic::Expression>::CalcHydroelasticWithFallback(
     internal::HydroelasticFallbackCacheData<symbolic::Expression>*) const;
 template <>
 void MultibodyPlant<symbolic::Expression>::CallContactSolver(
+    contact_solvers::internal::ContactSolver<symbolic::Expression>*,
     const symbolic::Expression&, const VectorX<symbolic::Expression>&,
     const MatrixX<symbolic::Expression>&, const VectorX<symbolic::Expression>&,
     const VectorX<symbolic::Expression>&, const MatrixX<symbolic::Expression>&,

--- a/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
+++ b/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
@@ -2,6 +2,7 @@
 #include <set>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "drake/common/drake_assert.h"
 #include "drake/multibody/plant/multibody_plant.h"
@@ -25,6 +26,56 @@ class MultibodyPlantDiscreteUpdateManagerAttorney {
 
   static const MultibodyTree<T>& internal_tree(const MultibodyPlant<T>& plant) {
     return plant.internal_tree();
+  }
+
+  static const contact_solvers::internal::ContactSolverResults<T>&
+  EvalContactSolverResults(const MultibodyPlant<T>& plant,
+                           const systems::Context<T>& context) {
+    return plant.EvalContactSolverResults(context);
+  }
+
+  static const internal::ContactJacobians<T>& EvalContactJacobians(
+      const MultibodyPlant<T>& plant, const systems::Context<T>& context) {
+    return plant.EvalContactJacobians(context);
+  }
+
+  static std::vector<CoulombFriction<double>> CalcCombinedFrictionCoefficients(
+      const MultibodyPlant<T>& plant, const systems::Context<T>& context,
+      const std::vector<internal::DiscreteContactPair<T>>& contact_pairs) {
+    return plant.CalcCombinedFrictionCoefficients(context, contact_pairs);
+  }
+
+  static void CalcNonContactForces(const MultibodyPlant<T>& plant,
+                                   const systems::Context<T>& context,
+                                   bool discrete, MultibodyForces<T>* forces) {
+    plant.CalcNonContactForces(context, discrete, forces);
+  }
+
+  static std::vector<internal::DiscreteContactPair<T>> CalcDiscreteContactPairs(
+      const MultibodyPlant<T>& plant, const systems::Context<T>& context) {
+    return plant.CalcDiscreteContactPairs(context);
+  }
+
+  static void CallTamsiSolver(
+      const MultibodyPlant<T>& plant, const T& time0, const VectorX<T>& v0,
+      const MatrixX<T>& M0, const VectorX<T>& minus_tau, const VectorX<T>& fn0,
+      const MatrixX<T>& Jn, const MatrixX<T>& Jt, const VectorX<T>& stiffness,
+      const VectorX<T>& damping, const VectorX<T>& mu,
+      contact_solvers::internal::ContactSolverResults<T>* results) {
+    plant.CallTamsiSolver(time0, v0, M0, minus_tau, fn0, Jn, Jt, stiffness,
+                          damping, mu, results);
+  }
+
+  static void CallContactSolver(
+      const MultibodyPlant<T>& plant,
+      contact_solvers::internal::ContactSolver<T>* contact_solver,
+      const T& time0, const VectorX<T>& v0, const MatrixX<T>& M0,
+      const VectorX<T>& minus_tau, const VectorX<T>& phi0, const MatrixX<T>& Jc,
+      const VectorX<T>& stiffness, const VectorX<T>& damping,
+      const VectorX<T>& mu,
+      contact_solvers::internal::ContactSolverResults<T>* results) {
+    plant.CallContactSolver(contact_solver, time0, v0, M0, minus_tau, phi0, Jc,
+                            stiffness, damping, mu, results);
   }
 };
 }  // namespace internal


### PR DESCRIPTION
Copy the contact solve logic for rigid dofs in MultibodyPlant to DeformableRigidManager. Add unit test to verify that when only rigid
dofs exist, the simulation results obtained through the discrete update manager is the same as that obtained from internal MultibodyPlant logic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15123)
<!-- Reviewable:end -->
