### PR TITLE
Manage collision geometries with DeformableRigidManager

### DIFF
--- a/multibody/fixed_fem/dev/BUILD.bazel
+++ b/multibody/fixed_fem/dev/BUILD.bazel
@@ -140,6 +140,7 @@ drake_cc_library(
         "deformable_rigid_manager.h",
     ],
     deps = [
+        ":collision_objects",
         ":deformable_model",
         ":fem_solver",
         "//common:essential",

--- a/multibody/fixed_fem/dev/deformable_model.cc
+++ b/multibody/fixed_fem/dev/deformable_model.cc
@@ -16,7 +16,8 @@ namespace fixed_fem {
 template <typename T>
 SoftBodyIndex DeformableModel<T>::RegisterDeformableBody(
     const geometry::VolumeMesh<T>& mesh, std::string name,
-    const DeformableBodyConfig<T>& config) {
+    const DeformableBodyConfig<T>& config,
+    geometry::ProximityProperties proximity_props) {
   /* Throw if name is not unique. */
   for (int i = 0; i < num_bodies(); ++i) {
     if (name == names_[i]) {
@@ -36,6 +37,7 @@ SoftBodyIndex DeformableModel<T>::RegisterDeformableBody(
                                                    config);
       break;
   }
+  proximity_properties_.emplace_back(std::move(proximity_props));
   return body_index;
 }
 

--- a/multibody/fixed_fem/dev/deformable_model.h
+++ b/multibody/fixed_fem/dev/deformable_model.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "drake/common/eigen_types.h"
+#include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/proximity/volume_mesh.h"
 #include "drake/multibody/fixed_fem/dev/deformable_body_config.h"
 #include "drake/multibody/fixed_fem/dev/fem_model_base.h"
@@ -59,14 +60,18 @@ class DeformableModel final : public multibody::internal::PhysicalModel<T> {
   // TODO(xuchenhan-tri): Identify deformable bodies with actual identifiers,
   //  which would make deleting deformable bodies easier to track in the future.
   /** Adds a deformable body modeled with linear simplex element, linear
-   quadrature rule and the physical properties specified by the given `config`.
-   Returns the index of the newly added deformable body.
+   quadrature rule, the physical properties specified by the given `config`,
+   and proximity properties specified by the given `proximity_props`. Returns
+   the index of the newly added deformable body.
    @pre config.IsValid() == true.
+   @pre `proximity_props` includes the (`material`, `coulomb_friction`) property
+   of type CoulombFriction<double>.
    @throw std::exception if `name` is not distinct from names of all previously
    registered bodies. */
-  SoftBodyIndex RegisterDeformableBody(const geometry::VolumeMesh<T>& mesh,
-                                       std::string name,
-                                       const DeformableBodyConfig<T>& config);
+  SoftBodyIndex RegisterDeformableBody(
+      const geometry::VolumeMesh<T>& mesh, std::string name,
+      const DeformableBodyConfig<T>& config,
+      geometry::ProximityProperties proximity_props);
 
   /** Sets zero Dirichlet boundary conditions for a given body. All vertices in
    the mesh of corresponding to the deformable body with `body_id` within
@@ -102,6 +107,13 @@ class DeformableModel final : public multibody::internal::PhysicalModel<T> {
   const std::vector<geometry::VolumeMesh<T>>& reference_configuration_meshes()
       const {
     return reference_configuration_meshes_;
+  }
+
+  /* Returns the proximity properties of the registered deformable bodies in the
+   same order as they are registered. */
+  const std::vector<geometry::ProximityProperties>& proximity_properties()
+      const {
+    return proximity_properties_;
   }
 
   /** Returns the names of all the registered deformable bodies in the same
@@ -146,6 +158,8 @@ class DeformableModel final : public multibody::internal::PhysicalModel<T> {
    reference_configuration_meshes_, but is stored in a more convenient format.
   */
   std::vector<VectorX<T>> model_discrete_states_;
+  /* Proximity properties for all registered deformable bodies. */
+  std::vector<geometry::ProximityProperties> proximity_properties_{};
   /* Names of all registered deformable bodies. */
   std::vector<std::string> names_{};
   /* OutputPorts. */

--- a/multibody/fixed_fem/dev/deformable_rigid_manager.cc
+++ b/multibody/fixed_fem/dev/deformable_rigid_manager.cc
@@ -5,6 +5,34 @@
 namespace drake {
 namespace multibody {
 namespace fixed_fem {
+
+template <typename T>
+void DeformableRigidManager<T>::RegisterCollisionObjects(
+    const geometry::SceneGraph<T>& scene_graph) {
+  const geometry::SceneGraphInspector<T>& inspector =
+      scene_graph.model_inspector();
+  /* Make sure that the owning plant is registered at the given scene graph.
+   */
+  DRAKE_THROW_UNLESS(
+      inspector.SourceIsRegistered(this->plant().get_source_id().value()));
+  for (const auto& per_body_collision_geometries :
+       this->collision_geometries()) {
+    for (geometry::GeometryId id : per_body_collision_geometries) {
+      /* Sanity check that the geometry comes from the owning MultibodyPlant
+       indeed. */
+      DRAKE_DEMAND(
+          inspector.BelongsToSource(id, this->plant().get_source_id().value()));
+      const geometry::Shape& shape = inspector.GetShape(id);
+      const geometry::ProximityProperties* props =
+          dynamic_cast<const geometry::ProximityProperties*>(
+              inspector.GetProperties(id, geometry::Role::kProximity));
+      /* Collision geometry must have proximity properties attached to it. */
+      DRAKE_DEMAND(props != nullptr);
+      collision_objects_.AddCollisionObject(id, shape, *props);
+    }
+  }
+}
+
 template <typename T>
 void DeformableRigidManager<T>::ExtractModelInfo() {
   bool extracted_deformable_model = false;
@@ -21,6 +49,7 @@ void DeformableRigidManager<T>::ExtractModelInfo() {
       }
       deformable_model_ = deformable_model;
       MakeFemSolvers();
+      RegisterDeformableGeometries();
       extracted_deformable_model = true;
     }
   }
@@ -38,6 +67,12 @@ void DeformableRigidManager<T>::MakeFemSolvers() {
         deformable_model_->fem_model(SoftBodyIndex(i));
     fem_solvers_.emplace_back(std::make_unique<FemSolver<T>>(&fem_model));
   }
+}
+
+template <typename T>
+void DeformableRigidManager<T>::RegisterDeformableGeometries() {
+  DRAKE_DEMAND(deformable_model_ != nullptr);
+  deformable_meshes_ = deformable_model_->reference_configuration_meshes();
 }
 
 template <typename T>
@@ -280,6 +315,44 @@ void DeformableRigidManager<T>::DoCalcDiscreteValues(
     next_discrete_value.head(num_dofs) = state_star.q();
     next_discrete_value.segment(num_dofs, num_dofs) = state_star.qdot();
     next_discrete_value.tail(num_dofs) = state_star.qddot();
+  }
+}
+
+template <typename T>
+void DeformableRigidManager<T>::UpdateCollisionObjectPoses(
+    const systems::Context<T>& context) const {
+  const geometry::QueryObject<T>& query_object =
+      this->plant()
+          .get_geometry_query_input_port()
+          .template Eval<geometry::QueryObject<T>>(context);
+  const std::vector<geometry::GeometryId>& geometry_ids =
+      collision_objects_.geometry_ids();
+  for (const geometry::GeometryId id : geometry_ids) {
+    const math::RigidTransform<T>& X_WG = query_object.GetPoseInWorld(id);
+    collision_objects_.set_pose_in_world(id, X_WG);
+  }
+}
+
+template <typename T>
+void DeformableRigidManager<T>::UpdateDeformableVertexPositions(
+    const systems::Context<T>& context) const {
+  const std::vector<VectorX<T>>& vertex_positions =
+      deformable_model_->get_vertex_positions_output_port()
+          .template Eval<std::vector<VectorX<T>>>(context);
+  DRAKE_DEMAND(vertex_positions.size() == deformable_meshes_.size());
+  for (int i = 0; i < static_cast<int>(vertex_positions.size()); ++i) {
+    const VectorX<T>& q = vertex_positions[i];
+    const auto p_WVs = Eigen::Map<const Matrix3X<T>>(q.data(), 3, q.size() / 3);
+    std::vector<geometry::VolumeElement> tets =
+        deformable_meshes_[i].tetrahedra();
+    // TODO(xuchenhan-tri): We assume the deformable body frame is always the
+    //  same as the world frame for now. It probably makes sense to have the
+    //  frame move with the body in the future.
+    std::vector<geometry::VolumeVertex<T>> vertices_D;
+    for (int j = 0; j < p_WVs.cols(); ++j) {
+      vertices_D.push_back(geometry::VolumeVertex<T>(p_WVs.col(j)));
+    }
+    deformable_meshes_[i] = {std::move(tets), std::move(vertices_D)};
   }
 }
 }  // namespace fixed_fem

--- a/multibody/fixed_fem/dev/run_cantilever_beam.cc
+++ b/multibody/fixed_fem/dev/run_cantilever_beam.cc
@@ -66,6 +66,12 @@ int DoMain() {
   auto* plant = builder.AddSystem<MultibodyPlant<double>>(dt);
   auto deformable_model = std::make_unique<DeformableModel<double>>(plant);
   const geometry::Box box(1.5, 0.2, 0.2);
+  /* A dummy proximity property that's used since there is no contact in this
+   demo. */
+  geometry::ProximityProperties dummy_proximity_props;
+  geometry::AddContactMaterial({}, {}, {},
+                               multibody::CoulombFriction<double>(0, 0),
+                               &dummy_proximity_props);
 
   /* Set up the corotated bar. */
   const math::RigidTransform<double> translation_left(
@@ -81,7 +87,8 @@ int DoMain() {
       MakeDiamondCubicBoxVolumeMesh<double>(box, dx, translation_left);
   const SoftBodyIndex nonlinear_bar_body_index =
       deformable_model->RegisterDeformableBody(
-          nonlinear_bar_geometry, "Corotated", nonlinear_bar_config);
+          nonlinear_bar_geometry, "Corotated", nonlinear_bar_config,
+          dummy_proximity_props);
 
   /* Set up the linear bar. */
   DeformableBodyConfig<double> linear_bar_config(nonlinear_bar_config);
@@ -92,7 +99,8 @@ int DoMain() {
       MakeDiamondCubicBoxVolumeMesh<double>(box, dx, translation_right);
   const SoftBodyIndex linear_bar_body_index =
       deformable_model->RegisterDeformableBody(linear_bar_geometry, "Linear",
-                                               linear_bar_config);
+                                               linear_bar_config,
+                                               dummy_proximity_props);
 
   /* Plug the two bars in to a wall. */
   const Vector3<double> wall_origin(-0.75, 0, 0);

--- a/multibody/fixed_fem/dev/test/deformable_model_test.cc
+++ b/multibody/fixed_fem/dev/test/deformable_model_test.cc
@@ -51,11 +51,21 @@ class DeformableModelTest : public ::testing::Test {
     return config;
   }
 
+  /* Creates a dummy proximity property. */
+  static geometry::ProximityProperties MakeProximityProps() {
+    geometry::ProximityProperties dummy_proximity_props;
+    geometry::AddContactMaterial({}, {}, {},
+                                 multibody::CoulombFriction<double>(0, 0),
+                                 &dummy_proximity_props);
+    return dummy_proximity_props;
+  }
+
   /* Add a dummy box shaped deformable body with the given "name". */
   int AddDeformableBox(DeformableModel<double>* deformable_model,
                        std::string name) {
     return deformable_model_->RegisterDeformableBody(
-        MakeBoxTetMesh(), std::move(name), MakeDeformableConfig());
+        MakeBoxTetMesh(), std::move(name), MakeDeformableConfig(),
+        MakeProximityProps());
   }
 
   MultibodyPlant<double> plant_{kDt};

--- a/multibody/fixed_fem/dev/test/deformable_rigid_manager_test.cc
+++ b/multibody/fixed_fem/dev/test/deformable_rigid_manager_test.cc
@@ -29,9 +29,14 @@ const double kDt = 0.0123;
 const double kGravity = -9.81;
 /* Number of vertices in the box mesh (see below). */
 constexpr int kNumVertices = 8;
+constexpr double kBoxLength = 1;
+const CoulombFriction kFriction{0.3, 0.2};
 using Eigen::Vector3d;
 using Eigen::VectorXd;
+using geometry::GeometryId;
+using geometry::ProximityProperties;
 using geometry::SceneGraph;
+using geometry::SurfaceMesh;
 using systems::Context;
 
 class DeformableRigidManagerTest : public ::testing::Test {
@@ -42,24 +47,42 @@ class DeformableRigidManagerTest : public ::testing::Test {
   void SetUp() override {
     auto deformable_model = std::make_unique<DeformableModel<double>>(&plant_);
     deformable_model->RegisterDeformableBody(MakeBoxTetMesh(), "box",
-                                             MakeDeformableBodyConfig());
+                                             MakeDeformableBodyConfig(),
+                                             MakeProximityProperties());
     deformable_model_ = &plant_.AddPhysicalModel(std::move(deformable_model));
+    /* Add a collision geometry. */
+    plant_.RegisterAsSourceForSceneGraph(&scene_graph_);
+    plant_.RegisterCollisionGeometry(
+        plant_.world_body(), math::RigidTransform<double>(), MakeBoxShape(),
+        "collision", MakeProximityProperties());
     plant_.Finalize();
     auto deformable_rigid_manager =
         std::make_unique<DeformableRigidManager<double>>();
     deformable_rigid_manager_ = &plant_.set_discrete_update_manager(
         std::move(deformable_rigid_manager));
+    deformable_rigid_manager_->RegisterCollisionObjects(scene_graph_);
   }
 
-  /* Make a box and subdivide it into 6 tetrahedra. */
+  static geometry::Box MakeBoxShape() {
+    return geometry::Box(kBoxLength, kBoxLength, kBoxLength);
+  }
+
+  /* Makes a box and subdivide it into 6 tetrahedra. */
   static geometry::VolumeMesh<double> MakeBoxTetMesh() {
-    const double length = 1;
-    geometry::Box box(length, length, length);
     geometry::VolumeMesh<double> mesh =
-        geometry::internal::MakeBoxVolumeMesh<double>(box, length);
+        geometry::internal::MakeBoxVolumeMesh<double>(MakeBoxShape(),
+                                                      kBoxLength);
     DRAKE_DEMAND(mesh.num_elements() == 6);
     DRAKE_DEMAND(mesh.num_vertices() == kNumVertices);
     return mesh;
+  }
+
+  /* Returns a proximity property with default elastic modulus and dissipation
+   and an arbitrary friction. */
+  static ProximityProperties MakeProximityProperties() {
+    ProximityProperties proximity_properties;
+    geometry::AddContactMaterial({}, {}, kFriction, &proximity_properties);
+    return proximity_properties;
   }
 
   /* Create a dummy DeformableBodyConfig. */
@@ -74,9 +97,32 @@ class DeformableRigidManagerTest : public ::testing::Test {
     return config;
   }
 
+  /* Verifies that there exists one and only one collision object registered
+   with the DeformableRigidManager under test and return its geometry id. */
+  void get_collision_geometry(GeometryId* geometry_id) const {
+    const std::vector<std::vector<GeometryId>> collision_geometries =
+        deformable_rigid_manager_->collision_geometries();
+    ASSERT_EQ(collision_geometries.size(), 1);
+    ASSERT_EQ(collision_geometries[0].size(), 1);
+    *geometry_id = collision_geometries[0][0];
+  }
+
+  const std::vector<geometry::VolumeMesh<double>>& EvalDeformableMeshes(
+      const systems::Context<double>& context) const {
+    deformable_rigid_manager_->UpdateDeformableVertexPositions(context);
+    return deformable_rigid_manager_->deformable_meshes_;
+  }
+
+  /* Returns the CollisionObjects owned by the DeformableRigidManager under
+   test. */
+  const internal::CollisionObjects<double> get_collision_objects() const {
+    return deformable_rigid_manager_->collision_objects_;
+  }
+
+  SceneGraph<double> scene_graph_;
   MultibodyPlant<double> plant_{kDt};
   const DeformableModel<double>* deformable_model_;
-  const DeformableRigidManager<double>* deformable_rigid_manager_;
+  DeformableRigidManager<double>* deformable_rigid_manager_;
 };
 
 namespace {
@@ -239,6 +285,65 @@ GTEST_TEST(RigidUpdateTest, ContactSolver) {
       CompareMatrices(final_state_with_manager, final_state_without_manager));
   /* Sanity check that the final state is not NaN. */
   EXPECT_FALSE(final_state_with_manager.hasNaN());
+}
+/* Verifies that RegisterCollisionGeometry registers the rigid objects from
+ MultibodyPlant in DeformableRigidManager as intended. */
+TEST_F(DeformableRigidManagerTest, RegisterCollisionGeometry) {
+  const internal::CollisionObjects<double>& collision_objects =
+      get_collision_objects();
+  GeometryId id;
+  get_collision_geometry(&id);
+  /* Verify the surface mesh is as expected. */
+  const SurfaceMesh<double> expected_surface_mesh =
+      geometry::internal::MakeBoxSurfaceMesh<double>(MakeBoxShape(),
+                                                     kBoxLength);
+  EXPECT_TRUE(expected_surface_mesh.Equal(collision_objects.mesh(id)));
+  /* Verify proximity property is as expected. */
+  const CoulombFriction<double> mu = collision_objects.proximity_properties(id)
+                                         .GetProperty<CoulombFriction<double>>(
+                                             geometry::internal::kMaterialGroup,
+                                             geometry::internal::kFriction);
+  EXPECT_EQ(mu, kFriction);
+}
+
+// TODO(xuchenhan-tri): Add a unit test for UpdateCollisionObjectPoses() once
+//  PR#15123 is merged.
+
+/* Verifies that deformable vertex positions gets updated as expected. */
+TEST_F(DeformableRigidManagerTest, UpdateDeformableVertexPositions) {
+  auto context = plant_.CreateDefaultContext();
+  auto simulator = systems::Simulator<double>(plant_, std::move(context));
+  simulator.AdvanceTo(kDt);
+  const std::vector<geometry::VolumeMesh<double>>&
+      reference_configuration_meshes =
+          deformable_model_->reference_configuration_meshes();
+  DRAKE_DEMAND(reference_configuration_meshes.size() == 1);
+  const std::vector<geometry::VolumeMesh<double>>& deformed_meshes =
+      EvalDeformableMeshes(simulator.get_context());
+  DRAKE_DEMAND(deformed_meshes.size() == 1);
+  DRAKE_DEMAND(deformed_meshes[0].num_vertices() ==
+               reference_configuration_meshes[0].num_vertices());
+  DRAKE_DEMAND(deformed_meshes[0].num_elements() ==
+               reference_configuration_meshes[0].num_elements());
+  /* Verify that the elements of the deformed mesh is the same as the elements
+   of the initial mesh. */
+  for (geometry::VolumeElementIndex i(0); i < deformed_meshes[0].num_elements();
+       ++i) {
+    EXPECT_EQ(deformed_meshes[0].element(i),
+              reference_configuration_meshes[0].element(i));
+  }
+
+  /* Verify that the vertices of the mesh is as expected. */
+  const auto current_positions =
+      deformable_model_->get_vertex_positions_output_port()
+          .Eval<std::vector<VectorXd>>(simulator.get_context());
+  EXPECT_EQ(current_positions.size(), 1);
+  EXPECT_EQ(current_positions[0].size(), deformed_meshes[0].num_vertices() * 3);
+  for (geometry::VolumeVertexIndex i(0); i < deformed_meshes[0].num_vertices();
+       ++i) {
+    const Vector3<double> p_WV = current_positions[0].segment<3>(3 * i);
+    EXPECT_TRUE(CompareMatrices(p_WV, deformed_meshes[0].vertex(i).r_MV()));
+  }
 }
 }  // namespace
 }  // namespace fixed_fem

--- a/multibody/plant/discrete_update_manager.cc
+++ b/multibody/plant/discrete_update_manager.cc
@@ -76,6 +76,13 @@ void DiscreteUpdateManager<T>::CallContactSolver(
   MultibodyPlantDiscreteUpdateManagerAttorney<T>::CallContactSolver(
       plant(), contact_solver, time0, v0, M0, minus_tau, phi0, Jc, stiffness,
       damping, mu, results);
+    }
+
+template <typename T>
+const std::vector<std::vector<geometry::GeometryId>>&
+DiscreteUpdateManager<T>::collision_geometries() const {
+  return MultibodyPlantDiscreteUpdateManagerAttorney<T>::collision_geometries(
+      plant());
 }
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/plant/discrete_update_manager.h
+++ b/multibody/plant/discrete_update_manager.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include "drake/geometry/geometry_ids.h"
 #include "drake/multibody/contact_solvers/contact_solver.h"
 #include "drake/multibody/contact_solvers/contact_solver_results.h"
 #include "drake/multibody/plant/contact_jacobians.h"
@@ -111,6 +112,10 @@ class DiscreteUpdateManager {
   /* Exposed MultibodyPlant private/protected methods.
    @{ */
   const MultibodyTree<T>& internal_tree() const;
+  // TODO(xuchenhan-tri): Remove this when SceneGraph takes control of all
+  //  geometries.
+  const std::vector<std::vector<geometry::GeometryId>>& collision_geometries()
+      const;
 
   const contact_solvers::internal::ContactSolverResults<T>&
   EvalContactSolverResults(const systems::Context<T>& context) const;

--- a/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
+++ b/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
@@ -77,6 +77,15 @@ class MultibodyPlantDiscreteUpdateManagerAttorney {
     plant.CallContactSolver(contact_solver, time0, v0, M0, minus_tau, phi0, Jc,
                             stiffness, damping, mu, results);
   }
+
+  // TODO(xuchenhan-tri): Remove this when SceneGraph takes control of all
+  //  geometries.
+  /* Returns the per-body arrays of collision geometries indexed by BodyIndex
+   for the given `plant`. */
+  static const std::vector<std::vector<geometry::GeometryId>>&
+  collision_geometries(const MultibodyPlant<T>& plant) {
+    return plant.collision_geometries_;
+  }
 };
 }  // namespace internal
 }  // namespace multibody


### PR DESCRIPTION
This is a step towards integration of deformable and rigid simulation through contact. SceneGraph does not support deformable geometries yet, so we delegate collision geometry management to DeformableRigidManager for the moment. To that end, this PR does the following:

- Add RegisterCollisionObjects() that registers all rigid collision geometries registered in MultibodyPlant at the corresponding DeformableRigidManager.
- Add RegisterDeformableGeometries() that registers all deformable geometries registered in DeformableModel at the corresponding DeformableRigidManager.
- Add UpdateCollisionOjbectPoses() and UpdateDeformableVertexPositions() that update the geometries based on context.

This is meant to be a temporary solution. When SceneGraph takes control of deformable geometries, much of the code here can be migrated to SceneGraph with some modifications.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15128)
<!-- Reviewable:end -->
