### PR TITLE
multibody tree: Validate contexts at public methods

### DIFF
--- a/multibody/tree/multibody_tree_system.h
+++ b/multibody/tree/multibody_tree_system.h
@@ -94,6 +94,7 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
   given Context, recalculating it first if necessary. */
   const PositionKinematicsCache<T>& EvalPositionKinematics(
       const systems::Context<T>& context) const {
+    this->ValidateContext(context);
     return position_kinematics_cache_entry()
         .template Eval<PositionKinematicsCache<T>>(context);
   }
@@ -103,6 +104,7 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
   PositionKinematicsCache will be recalculated as well. */
   const VelocityKinematicsCache<T>& EvalVelocityKinematics(
       const systems::Context<T>& context) const {
+    this->ValidateContext(context);
     return velocity_kinematics_cache_entry()
         .template Eval<VelocityKinematicsCache<T>>(context);
   }
@@ -113,6 +115,7 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
   VelocityKinematicsCache will be recalculated as well. */
   const internal::AccelerationKinematicsCache<T>& EvalForwardDynamics(
       const systems::Context<T>& context) const {
+    this->ValidateContext(context);
     return acceleration_kinematics_cache_entry()
         .template Eval<AccelerationKinematicsCache<T>>(context);
   }
@@ -123,6 +126,7 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
   "Articulated Body Algorithm Forward Dynamics" for further details. */
   const ArticulatedBodyInertiaCache<T>& EvalArticulatedBodyInertiaCache(
       const systems::Context<T>& context) const {
+    this->ValidateContext(context);
     return this->get_cache_entry(cache_indexes_.abi_cache_index)
         .template Eval<ArticulatedBodyInertiaCache<T>>(context);
   }
@@ -131,6 +135,7 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
   in the given Context, recalculating it first if necessary. */
   const std::vector<SpatialInertia<T>>& EvalSpatialInertiaInWorldCache(
       const systems::Context<T>& context) const {
+    this->ValidateContext(context);
     return this->get_cache_entry(cache_indexes_.spatial_inertia_in_world)
         .template Eval<std::vector<SpatialInertia<T>>>(context);
   }
@@ -139,6 +144,7 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
   in the given Context, recalculating it first if necessary. */
   const VectorX<T>& EvalReflectedInertiaCache(
       const systems::Context<T>& context) const {
+    this->ValidateContext(context);
     return this->get_cache_entry(cache_indexes_.reflected_inertia)
         .template Eval<VectorX<T>>(context);
   }
@@ -147,6 +153,7 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
   in the given Context, recalculating it first if necessary. */
   const std::vector<SpatialInertia<T>>& EvalCompositeBodyInertiaInWorldCache(
       const systems::Context<T>& context) const {
+    this->ValidateContext(context);
     return this->get_cache_entry(cache_indexes_.composite_body_inertia_in_world)
         .template Eval<std::vector<SpatialInertia<T>>>(context);
   }
@@ -159,6 +166,7 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
   `F_Bo_W` is the spatial force on B about Bo, expressed in W. */
   const std::vector<SpatialForce<T>>& EvalDynamicBiasCache(
       const systems::Context<T>& context) const {
+    this->ValidateContext(context);
     return this->get_cache_entry(cache_indexes_.dynamic_bias)
         .template Eval<std::vector<SpatialForce<T>>>(context);
   }
@@ -175,6 +183,7 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
   See @ref abi_computing_accelerations for further details. */
   const std::vector<SpatialAcceleration<T>>& EvalSpatialAccelerationBiasCache(
       const systems::Context<T>& context) const {
+    this->ValidateContext(context);
     return this->get_cache_entry(cache_indexes_.spatial_acceleration_bias)
         .template Eval<std::vector<SpatialAcceleration<T>>>(context);
   }
@@ -187,6 +196,7 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
   const std::vector<SpatialForce<T>>&
   EvalArticulatedBodyForceBiasCache(
       const systems::Context<T>& context) const {
+    this->ValidateContext(context);
     return this->get_cache_entry(cache_indexes_.articulated_body_force_bias)
         .template Eval<std::vector<SpatialForce<T>>>(context);
   }
@@ -196,6 +206,7 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
   the velocity-dependent bias forces and applied forces. */
   const ArticulatedBodyForceCache<T>&
   EvalArticulatedBodyForceCache(const systems::Context<T>& context) const {
+    this->ValidateContext(context);
     return this->get_cache_entry(cache_indexes_.articulated_body_forces)
         .template Eval<ArticulatedBodyForceCache<T>>(context);
   }
@@ -214,6 +225,7 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
   const std::vector<Vector6<T>>&
   EvalAcrossNodeJacobianWrtVExpressedInWorld(
       const systems::Context<T>& context) const {
+    this->ValidateContext(context);
     return this->get_cache_entry(cache_indexes_.across_node_jacobians)
         .template Eval<std::vector<Vector6<T>>>(context);
   }


### PR DESCRIPTION
Closes #11252.

Since all of the context-taking methods in multibody/tree lead
eventually to MultiBodyTreeSystem, ensure that all of its public methods
validate the context.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15129)
<!-- Reviewable:end -->
