### PR TITLE
Remove DeclareCacheEntry() from DiscreteUpdateManager attorney

### DIFF
--- a/multibody/fixed_fem/dev/deformable_rigid_manager.cc
+++ b/multibody/fixed_fem/dev/deformable_rigid_manager.cc
@@ -76,9 +76,9 @@ void DeformableRigidManager<T>::DeclareCacheEntries(MultibodyPlant<T>* plant) {
       fem_state.SetQdot(qdot);
       fem_state.SetQddot(qddot);
     };
-    const auto& fem_state_cache_entry = this->DeclareCacheEntry(
-        plant, "FEM state", allocate_fem_state_base,
-        std::move(copy_to_fem_state), {systems::System<T>::xd_ticket()});
+    const auto& fem_state_cache_entry = plant->DeclareCacheEntry(
+        "FEM state", allocate_fem_state_base, std::move(copy_to_fem_state),
+        {systems::System<T>::xd_ticket()});
     fem_state_cache_indexes_.emplace_back(fem_state_cache_entry.cache_index());
 
     /* Lambda function to calculate the free-motion velocity for the deformable
@@ -103,7 +103,8 @@ void DeformableRigidManager<T>::DeclareCacheEntries(MultibodyPlant<T>* plant) {
     /* Declares the free-motion cache entry which only depends on the fem state.
      */
     free_motion_cache_indexes_.emplace_back(
-        this->DeclareCacheEntry(plant, "Free motion FEM state",
+        plant
+            ->DeclareCacheEntry("Free motion FEM state",
                                 std::move(allocate_fem_state_base),
                                 std::move(calc_fem_state_star),
                                 {fem_state_cache_entry.ticket()})

--- a/multibody/plant/discrete_update_manager.cc
+++ b/multibody/plant/discrete_update_manager.cc
@@ -11,17 +11,6 @@ template <typename T>
 const MultibodyTree<T>& DiscreteUpdateManager<T>::internal_tree() const {
   return MultibodyPlantDiscreteUpdateManagerAttorney<T>::internal_tree(plant());
 }
-
-template <typename T>
-systems::CacheEntry& DiscreteUpdateManager<T>::DeclareCacheEntry(
-    MultibodyPlant<T>* plant, std::string description,
-    systems::CacheEntry::AllocCallback alloc_function,
-    systems::CacheEntry::CalcCallback calc_function,
-    std::set<systems::DependencyTicket> prerequisites_of_calc) {
-  return MultibodyPlantDiscreteUpdateManagerAttorney<T>::DeclareCacheEntry(
-      plant, std::move(description), std::move(alloc_function),
-      std::move(calc_function), std::move(prerequisites_of_calc));
-}
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/plant/discrete_update_manager.h
+++ b/multibody/plant/discrete_update_manager.h
@@ -121,14 +121,6 @@ class DiscreteUpdateManager {
       const systems::Context<T>& context,
       systems::DiscreteValues<T>* updates) const = 0;
 
-  /* Protected SystemBase method exposed through MultibodyPlant. */
-  static systems::CacheEntry& DeclareCacheEntry(
-      MultibodyPlant<T>* plant, std::string description,
-      systems::CacheEntry::AllocCallback alloc_function,
-      systems::CacheEntry::CalcCallback calc_function,
-      std::set<systems::DependencyTicket> prerequisites_of_calc = {
-          systems::SystemBase::all_sources_ticket()});
-
  private:
   const MultibodyPlant<T>* plant_{nullptr};
   systems::DiscreteStateIndex multibody_state_index_;

--- a/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
+++ b/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
@@ -26,17 +26,6 @@ class MultibodyPlantDiscreteUpdateManagerAttorney {
   static const MultibodyTree<T>& internal_tree(const MultibodyPlant<T>& plant) {
     return plant.internal_tree();
   }
-
-  static systems::CacheEntry& DeclareCacheEntry(
-      MultibodyPlant<T>* plant, std::string description,
-      systems::CacheEntry::AllocCallback alloc_function,
-      systems::CacheEntry::CalcCallback calc_function,
-      std::set<systems::DependencyTicket> prerequisites_of_calc = {
-          systems::SystemBase::all_sources_ticket()}) {
-    return plant->DeclareCacheEntry(
-        std::move(description), std::move(alloc_function),
-        std::move(calc_function), std::move(prerequisites_of_calc));
-  }
 };
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/plant/physical_model.h
+++ b/multibody/plant/physical_model.h
@@ -44,7 +44,7 @@ class PhysicalModel {
   void DeclareSystemResources(MultibodyPlant<T>* plant) {
     DRAKE_DEMAND(plant != nullptr);
     DoDeclareSystemResources(plant);
-    system_resources_declared = true;
+    system_resources_declared_ = true;
   }
 
  protected:
@@ -56,7 +56,7 @@ class PhysicalModel {
    not be called after system resources are declared. The invoking method should
    pass its name so that the error message can include that detail. */
   void ThrowIfSystemResourcesDeclared(const char* source_method) const {
-    if (system_resources_declared) {
+    if (system_resources_declared_) {
       throw std::logic_error(
           "Calls to '" + std::string(source_method) +
           "()' after system resources have been declared are not allowed.");
@@ -67,7 +67,7 @@ class PhysicalModel {
    not be called before system resources are declared. The invoking method
    should pass its name so that the error message can include that detail. */
   void ThrowIfSystemResourcesNotDeclared(const char* source_method) const {
-    if (!system_resources_declared) {
+    if (!system_resources_declared_) {
       throw std::logic_error(
           "Calls to '" + std::string(source_method) +
           "()' before system resources have been declared are not allowed.");
@@ -96,7 +96,7 @@ class PhysicalModel {
  private:
   /* Flag to track whether the system resources requested by `this`
    PhysicalModel have been declared. */
-  bool system_resources_declared{false};
+  bool system_resources_declared_{false};
 };
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/plant/test/discrete_update_manager_test.cc
+++ b/multibody/plant/test/discrete_update_manager_test.cc
@@ -71,8 +71,9 @@ class DummyDiscreteUpdateManager : public DiscreteUpdateManager<double> {
   /* Declares a cache entry that stores twice the additional state value. */
   void DeclareCacheEntries(MultibodyPlant<double>* plant) final {
     cache_index_ =
-        this->DeclareCacheEntry(
-                plant, "Twice the additional_state value",
+        plant
+            ->DeclareCacheEntry(
+                "Twice the additional_state value",
                 [=]() {
                   const VectorXd model_value =
                       VectorXd::Zero(kNumAdditionalDofs);


### PR DESCRIPTION
DeclareCacheEntry() does not need to be exposed to DiscreteUpdateManager
through the attorney class because it is public to begin with.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15132)
<!-- Reviewable:end -->
