### PR TITLE
Add sugar for declaring cache entries in MbP

### DIFF
--- a/multibody/fixed_fem/dev/deformable_rigid_manager.h
+++ b/multibody/fixed_fem/dev/deformable_rigid_manager.h
@@ -54,8 +54,7 @@ class DeformableRigidManager final
   }
 
   // TODO(xuchenhan-tri): Implement this once AccelerationKinematicsCache
-  // also
-  //  caches acceleration for deformable dofs.
+  //  also caches acceleration for deformable dofs.
   void DoCalcAccelerationKinematicsCache(
       const systems::Context<T>&,
       multibody::internal::AccelerationKinematicsCache<T>*) const final {


### PR DESCRIPTION
Towards #15133.

Add sugar for declaring cache entries in MbP that takes a class member method of an external auxiliary DiscreteUpdateManager.

Unfortunately these sugar are not immediately used by the only update manager we have at the moment (DeformableRigidManager), but subsequent PRs for developing this manager will benefit from these sugar.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15144)
<!-- Reviewable:end -->
