### PR TITLE
Revert "solvers: Improve documentation of available() vs enabled()"

### DIFF
--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -1248,7 +1248,6 @@ drake_cc_googletest(
         ":gurobi_solver",
         ":mathematical_program",
         "//common/test_utilities:expect_no_throw",
-        "//common/test_utilities:expect_throws_message",
     ],
 )
 
@@ -1367,7 +1366,6 @@ drake_cc_googletest(
         ":mathematical_program",
         ":mosek_solver",
         "//common/test_utilities:expect_no_throw",
-        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/solvers/gurobi_solver.h
+++ b/solvers/gurobi_solver.h
@@ -34,17 +34,6 @@ struct GurobiSolverDetails {
   double objective_bound{NAN};
 };
 
-/// An implementation of SolverInterface for the commercially-licensed Gurobi
-/// solver (https://www.gurobi.com/).
-///
-/// The default build of Drake is not configured to use Gurobi, so therefore
-/// SolverInterface::available() will return false. You must compile Drake
-/// from source in order to link against Gurobi. For details, refer to the
-/// documentation at https://drake.mit.edu/bazel.html#proprietary-solvers.
-///
-/// The GRB_LICENSE_FILE environment variable controls whether or not
-/// SolverInterface::enabled() returns true.  If it is set to any non-empty
-/// value, then the solver is enabled; otherwise, the solver is not enabled.
 class GurobiSolver final : public SolverBase {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(GurobiSolver)

--- a/solvers/mosek_solver.h
+++ b/solvers/mosek_solver.h
@@ -32,18 +32,6 @@ struct MosekSolverDetails {
 };
 
 /**
- * An implementation of SolverInterface for the commercially-licensed MOSEK
- * solver (https://www.mosek.com/).
- *
- * The default build of Drake is not configured to use MOSEK, so therefore
- * SolverInterface::available() will return false. You must compile Drake
- * from source in order to link against MOSEK. For details, refer to the
- * documentation at https://drake.mit.edu/bazel.html#mosek.
- *
- * The MOSEKLM_LICENSE_FILE environment variable controls whether or not
- * SolverInterface::enabled() returns true.  Iff it is set to any non-empty
- * value, then the solver is enabled; otherwise, the solver is not enabled.
- *
  * @note Mosek only cares about the initial guess of integer variables. The
  * initial guess of continuous variables are not passed to MOSEK. If all the
  * integer variables are set to some integer values, then MOSEK will be forced

--- a/solvers/snopt_solver.h
+++ b/solvers/snopt_solver.h
@@ -35,22 +35,6 @@ struct SnoptSolverDetails {
   Eigen::VectorXd Fmul;
 };
 
-/**
- * An implementation of SolverInterface for the commercially-licensed SNOPT
- * solver (https://ccom.ucsd.edu/~optimizers/solvers/snopt/).
- *
- * Builds of Drake from source do not compile SNOPT by default, so therefore
- * SolverInterface::available() will return false. You must opt-in to build
- * SNOPT per the documentation at https://drake.mit.edu/bazel.html#snopt.
- *
- * <a href="https://drake.mit.edu/from_binary.html">Drake's
- * pre-compiled binary releases</a> do incorporate SNOPT, so therefore
- * SolverInterface::available() will return true.
- * Thanks to Philip E. Gill and Elizabeth Wong for their kind support.
- *
- * There is no license configuration required to use SNOPT, so
- * SolverInterface::enabled() will always return true.
- */
 class SnoptSolver final : public SolverBase  {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SnoptSolver)

--- a/solvers/solver_base.cc
+++ b/solvers/solver_base.cc
@@ -34,33 +34,19 @@ MathematicalProgramResult SolverBase::Solve(
   return result;
 }
 
-namespace {
-std::string ShortName(const SolverInterface& solver) {
-  return NiceTypeName::RemoveNamespaces(NiceTypeName::Get(solver));
-}
-}  // namespace
-
 void SolverBase::Solve(const MathematicalProgram& prog,
                        const std::optional<Eigen::VectorXd>& initial_guess,
                        const std::optional<SolverOptions>& solver_options,
                        MathematicalProgramResult* result) const {
   *result = {};
   if (!available()) {
-    const std::string name = ShortName(*this);
     throw std::invalid_argument(fmt::format(
-        "{} cannot Solve because {}::available() is false, i.e.,"
-        " {} has not been compiled as part of this binary."
-        " Refer to the {} class overview documentation for how to compile it.",
-        name, name, name, name));
+        "The {} is not available in this build", NiceTypeName::Get(*this)));
   }
   if (!enabled()) {
-    const std::string name = ShortName(*this);
     throw std::invalid_argument(fmt::format(
-        "{} cannot Solve because {}::enabled() is false, i.e.,"
-        " {} has not been properly configured for use."
-        " Typically this means that an environment variable has not been set."
-        " Refer to the {} class overview documentation for how to enable it.",
-        name, name, name, name));
+        "{}::is_enabled() is false; see its documentation for how to enable.",
+        NiceTypeName::Get(*this)));
   }
   if (!AreProgramAttributesSatisfied(prog)) {
     throw std::invalid_argument(ExplainUnsatisfiedProgramAttributes(prog));
@@ -114,7 +100,7 @@ std::string SolverBase::ExplainUnsatisfiedProgramAttributes(
   }
   return fmt::format(
       "{} is unable to solve a MathematicalProgram with {}.",
-      ShortName(*this), to_string(prog.required_capabilities()));
+      NiceTypeName::Get(*this), to_string(prog.required_capabilities()));
 }
 
 }  // namespace solvers

--- a/solvers/solver_interface.h
+++ b/solvers/solver_interface.h
@@ -21,39 +21,14 @@ class SolverInterface {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SolverInterface)
   virtual ~SolverInterface();
 
-  /// Returns true iff support for this solver has been compiled into Drake.
+  /// Returns true iff this solver was enabled at compile-time. Certain solvers
+  /// may be excluded at compile-time due to licensing or linking restrictions.
   /// When this method returns false, the Solve method will throw.
-  ///
-  /// Most solver implementations will always return true, but certain solvers
-  /// may have been excluded at compile-time due to licensing restrictions, or
-  /// to narrow Drake's dependency footprint. In Drake's default build, only
-  /// commercially-licensed solvers might return false.
-  ///
-  /// Contrast this with enabled(), which reflects whether a solver has been
-  /// configured for use at runtime (not compile-time).
-  ///
-  /// For details on linking commercial solvers, refer to the solvers' class
-  /// overview documentation, e.g., SnoptSolver, MosekSolver, GurobiSolver.
   virtual bool available() const = 0;
 
-  /// Returns true iff this solver is properly configured for use at runtime.
-  /// When this method returns false, the Solve method will throw.
-  ///
-  /// Most solver implementation will always return true, but certain solvers
-  /// require additional configuration before they may be used, e.g., setting
-  /// an environment variable to specify a license file or license server.
-  /// In Drake's default build, only commercially-licensed solvers might return
-  /// false.
-  ///
-  /// Contrast this with available(), which reflects whether a solver has been
-  /// incorporated into Drake at compile-time (and has nothing to do with the
-  /// runtime configuration). A solver where available() returns false may still
-  /// return true for enabled() if it is properly configured.
-  ///
-  /// The mechanism to configure a particular solver implementation is specific
-  /// to the solver in question, but typically uses an environment variable.
-  /// For details on configuring commercial solvers, refer to the solvers' class
-  /// overview documentation, e.g., SnoptSolver, MosekSolver, GurobiSolver.
+  /// Returns true iff this solver is enabled at runtime. The toggle mechanism
+  /// is specific to the solver in question, but typically uses an environment
+  /// variable. When this method returns false, the Solve method will throw.
   virtual bool enabled() const = 0;
 
   /// Solves an optimization program with optional initial guess and solver

--- a/solvers/test/mosek_solver_moseklm_license_file_test.cc
+++ b/solvers/test/mosek_solver_moseklm_license_file_test.cc
@@ -4,7 +4,6 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/expect_no_throw.h"
-#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/solvers/mathematical_program.h"
 #include "drake/solvers/mosek_solver.h"
 
@@ -12,50 +11,51 @@ namespace drake {
 namespace solvers {
 namespace {
 
-// These tests are deliberately not in mosek_solver_test.cc to avoid causing
+// These tests is deliberately not in mosek_solver_test.cc to avoid causing
 // license issues during tests in that file.
 
-class MoseklmLicenseFileTest : public ::testing::Test {
- protected:
-  MoseklmLicenseFileTest()
-      : orig_moseklm_license_file_(std::getenv("MOSEKLM_LICENSE_FILE")) {}
+GTEST_TEST(MoseklmLicenseFileTest, MoseklmLicenseFileSet) {
+  const char* moseklm_license_file = std::getenv("MOSEKLM_LICENSE_FILE");
+  ASSERT_STRNE(nullptr, moseklm_license_file);
 
-  void SetUp() override {
-    ASSERT_EQ(solver_.available(), true);
-    ASSERT_STRNE(orig_moseklm_license_file_, nullptr);
+  MathematicalProgram program;
+  // Add a variable to avoid the "Solve" function terminating without calling
+  // the external MOSEK solver.
+  const auto x = program.NewContinuousVariables<1>();
+  MosekSolver solver;
 
-    // Add a variable to avoid the "Solve" function terminating without calling
-    // the external MOSEK solver.
-    prog_.NewContinuousVariables<1>();
-  }
-
-  void TearDown() override {
-    if (orig_moseklm_license_file_) {
-      const int setenv_result = ::setenv(
-          "MOSEKLM_LICENSE_FILE", orig_moseklm_license_file_, 1);
-      EXPECT_EQ(setenv_result, 0);
-    }
-  }
-
-  const char* const orig_moseklm_license_file_;
-  MathematicalProgram prog_;
-  MosekSolver solver_;
-};
-
-TEST_F(MoseklmLicenseFileTest, MoseklmLicenseFileSet) {
-  EXPECT_EQ(solver_.enabled(), true);
-  DRAKE_EXPECT_NO_THROW(solver_.Solve(prog_));
+  MathematicalProgramResult result;
+  DRAKE_EXPECT_NO_THROW(solver.Solve(program, {}, {}, &result));
 }
 
-TEST_F(MoseklmLicenseFileTest, MoseklmLicenseFileUnset) {
-  EXPECT_EQ(solver_.enabled(), true);
-  const int unsetenv_result = ::unsetenv("MOSEKLM_LICENSE_FILE");
-  ASSERT_EQ(unsetenv_result, 0);
-  EXPECT_EQ(solver_.enabled(), false);
+GTEST_TEST(MoseklmLicenseFileTest, MoseklmLicenseFileUnset) {
+  const char* moseklm_license_file = std::getenv("MOSEKLM_LICENSE_FILE");
+  ASSERT_STRNE(nullptr, moseklm_license_file);
 
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      solver_.Solve(prog_), std::exception,
-      ".*MosekSolver has not been properly configured.*");
+  const int unsetenv_result = ::unsetenv("MOSEKLM_LICENSE_FILE");
+  ASSERT_EQ(0, unsetenv_result);
+
+  MathematicalProgram program;
+  // Add a variable to avoid the "Solve" function terminating without calling
+  // the external MOSEK solver.
+  const auto x = program.NewContinuousVariables<1>();
+  MosekSolver solver;
+
+  try {
+    MathematicalProgramResult result;
+    solver.Solve(program, {}, {}, &result);
+    ADD_FAILURE() << "Expected exception of type std::runtime_error.";
+  } catch (const std::exception& err) {
+    EXPECT_EQ(err.what(), std::string(
+        "drake::solvers::MosekSolver::is_enabled() is false; "
+        "see its documentation for how to enable."));
+  } catch (...) {
+    ADD_FAILURE() << "Expected std::exception.";
+  }
+
+  const int setenv_result =
+      ::setenv("MOSEKLM_LICENSE_FILE", moseklm_license_file, 1);
+  ASSERT_EQ(0, setenv_result);
 }
 
 }  // namespace

--- a/solvers/test/solver_base_test.cc
+++ b/solvers/test/solver_base_test.cc
@@ -159,7 +159,7 @@ GTEST_TEST(SolverBaseTest, AvailableError) {
   dut.available_ = false;
   DRAKE_EXPECT_THROWS_MESSAGE(
       dut.Solve(prog, {}, {}), std::exception,
-      ".*StubSolverBase has not been compiled.*");
+      "The .*StubSolverBase is not available in this build");
 }
 
 // Check the error message when attributes are not satisfied.


### PR DESCRIPTION
Dear @jwnimmer-tri ,

 The on-call build cop, @BetsyMcPhail , believes that your PR #15114 may have
 broken one or more of Drake's continuous integration builds [1]. It is
 possible to break a build even if your PR passed continuous integration
 pre-merge because additional platforms are tested post-merge.

 The specific build failures under investigation are:
https://drake-jenkins.csail.mit.edu/job/mac-big-sur-clang-bazel-nightly-everything-address-sanitizer/121/

 Therefore, the build cop has created this revert PR and started a complete
 post-merge build to determine whether your PR was in fact the cause of the
 problem. If that build passes, this revert PR will be merged 60 minutes from
 now. You can then fix the problem at your leisure, and send a new PR to
 reinstate your change.

 If you believe your original PR did not actually break the build, please
 explain on this thread.

 If you believe you can fix the break promptly in lieu of a revert, please
 explain on this thread, and send a PR to the build cop for review ASAP.

 If you believe your original PR definitely did break the build and should be
 reverted, please review and LGTM this PR. This allows the build cop to merge
 without waiting for CI results.

 For advice on how to handle a build cop revert, see [2].

 Thanks!
 Your Friendly On-call Build Cop

 [1] CI Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Production/
 [2] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15151)
<!-- Reviewable:end -->
