### PR TITLE
Deprecate ComputeBasisFromAxis() in C++ and Python.

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -157,6 +157,7 @@ drake_pybind_library(
         "//bindings/pydrake:symbolic_types_pybind",
         "//bindings/pydrake/common:cpp_template_pybind",
         "//bindings/pydrake/common:default_scalars_pybind",
+        "//bindings/pydrake/common:deprecation_pybind",
         "//bindings/pydrake/common:eigen_pybind",
         "//bindings/pydrake/common:type_pack",
         "//bindings/pydrake/common:value_pybind",

--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -8,6 +8,7 @@
 #include "drake/bindings/pydrake/autodiff_types_pybind.h"
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
+#include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/eigen_pybind.h"
 #include "drake/bindings/pydrake/common/type_pack.h"
 #include "drake/bindings/pydrake/common/value_pybind.h"
@@ -319,12 +320,16 @@ void DoScalarIndependentDefinitions(py::module m) {
   // TODO(eric.cousineau): Bind remaining classes for all available scalar
   // types.
   using T = double;
-  m.def(
-      "ComputeBasisFromAxis",
-      [](int axis_index, const Vector3<T>& axis) {
-        return ComputeBasisFromAxis(axis_index, axis);
-      },
-      py::arg("axis_index"), py::arg("axis_W"), doc.ComputeBasisFromAxis.doc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  m.def("ComputeBasisFromAxis",
+      WrapDeprecated(doc.ComputeBasisFromAxis.doc_deprecated,
+          [](int axis_index, const Vector3<T>& axis) {
+            return ComputeBasisFromAxis(axis_index, axis);
+          }),
+      py::arg("axis_index"), py::arg("axis_W"),
+      doc.ComputeBasisFromAxis.doc_deprecated);
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
   py::class_<BarycentricMesh<T>>(m, "BarycentricMesh", doc.BarycentricMesh.doc)
       .def(py::init<BarycentricMesh<T>::MeshGrid>(),
           doc.BarycentricMesh.ctor.doc)

--- a/bindings/pydrake/test/math_test.py
+++ b/bindings/pydrake/test/math_test.py
@@ -6,6 +6,7 @@ from pydrake.common.eigen_geometry import Isometry3_, Quaternion_, AngleAxis_
 from pydrake.common.value import Value
 from pydrake.autodiffutils import AutoDiffXd
 from pydrake.symbolic import Expression
+from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 import pydrake.common.test_utilities.numpy_compare as numpy_compare
 from pydrake.common.test_utilities.pickle_compare import assert_pickle
 
@@ -399,10 +400,12 @@ class TestMath(unittest.TestCase):
         if T != Expression:
             self.assertEqual(value, T(.5))
 
+    # TODO(2021-10-01) Remove with completion of deprecation.
     def test_orthonormal_basis(self):
-        R = mut.ComputeBasisFromAxis(axis_index=0, axis_W=[1, 0, 0])
-        self.assertAlmostEqual(np.linalg.det(R), 1.0)
-        self.assertTrue(np.allclose(R.dot(R.T), np.eye(3)))
+        with catch_drake_warnings(expected_count=1):
+            R = mut.ComputeBasisFromAxis(axis_index=0, axis_W=[1, 0, 0])
+            self.assertAlmostEqual(np.linalg.det(R), 1.0)
+            self.assertTrue(np.allclose(R.dot(R.T), np.eye(3)))
 
     def test_random_rotations(self):
         g = RandomGenerator()

--- a/math/orthonormal_basis.h
+++ b/math/orthonormal_basis.h
@@ -2,6 +2,7 @@
 
 #include <limits>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 
 namespace drake {
@@ -22,6 +23,8 @@ namespace math {
 /// @throws std::logic_error if the norm of @p axis_W is within 1e-10 to zero or
 ///         @p axis_index does not lie in the range [0,2].
 template <class T>
+DRAKE_DEPRECATED("2021-10-01", "ComputeBasisFromAxis() has been deprecated "
+                 "for RotationMatrix::MakeFromOneVector().")
 Matrix3<T> ComputeBasisFromAxis(int axis_index, const Vector3<T>& axis_W) {
   // Verify that the correct axis is given.
   if (axis_index < 0 || axis_index > 2)

--- a/math/orthonormal_basis.h
+++ b/math/orthonormal_basis.h
@@ -23,8 +23,7 @@ namespace math {
 /// @throws std::logic_error if the norm of @p axis_W is within 1e-10 to zero or
 ///         @p axis_index does not lie in the range [0,2].
 template <class T>
-DRAKE_DEPRECATED("2021-10-01", "ComputeBasisFromAxis() has been deprecated "
-                 "for RotationMatrix::MakeFromOneVector().")
+DRAKE_DEPRECATED("2021-10-01", "Use RotationMatrix::MakeFromOneVector().")
 Matrix3<T> ComputeBasisFromAxis(int axis_index, const Vector3<T>& axis_W) {
   // Verify that the correct axis is given.
   if (axis_index < 0 || axis_index > 2)

--- a/math/test/orthonormal_basis_test.cc
+++ b/math/test/orthonormal_basis_test.cc
@@ -12,6 +12,8 @@ namespace drake {
 namespace math {
 namespace {
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 // Checks that the axes are set correctly.
 void CheckBasisOrthonomality(const Matrix3<double>& R) {
   const double tol = 10 * std::numeric_limits<double>::epsilon();
@@ -59,6 +61,7 @@ GTEST_TEST(ComputeBasisFromAxisTest, RightHandOrthogonal) {
     CheckBasis(i, z_axis);
   }
 }
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
 
 }  // namespace
 }  // namespace math


### PR DESCRIPTION
This PR #15154 deprecates C++ and Python calls to ComputeBasisFromAxis() in favor of RotationMatrix::MakeFromOneVector() and is the follow-on from PR #15055.  This PR also serves a pedagogical purpose, namely to provide **_partial_** insight into how to deprecate a C++ function that has Python bindings. 

FYI:  Before I submitted this PR to CI (Continuous Integration), I issued various commands (shown below) from my local computer's operating system prompt to test C++/Python deprecation and to lint and test Python bindings.

1.  To test C++ deprecation, **_e.g.,_** in orthonormal_basis_test.cc 
bazel test  orthonormal_basis_test         

2.  To lint, I issued the following command (it executes reasonably fast).  
bazel test --config lint //...

Note: Pydrake bindings for C++ code are unusual and difficult to format correctly by hand. 
Note: This command and others like it are documented at https://drake.mit.edu/bazel.html.
Alternative: To more selectively lint relevant code in this PR, one can instead issue the commands:
bazel test --config=lint //binding/pydrake/...
bazel_test --config=lint //math/...

3.  To test Python bindings, **_e.g.,_** in math_test.py and math_test_py.cc.  
bazel  test   bindings/pydrake:py/math_test

Note: This command took many minutes to execute on my computer (much code is rebuilt).

Note: This PR may be helpful for developers who like to learn from examples/extrapolation.  The information provided here is not a defining work on how to deprecate in C++ and Python.  Rather, it is a example of how to deprecate a function in the Drake codebase. This "simple" example PR affects 5 files and employs special code and bazel commands to deprecate, test, and lint.

Related link:
https://drake.mit.edu/doxygen_cxx/group__python__bindings.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15154)
<!-- Reviewable:end -->
