### PR TITLE
Use C++17 type_traits throughout

### DIFF
--- a/math/autodiff.h
+++ b/math/autodiff.h
@@ -51,29 +51,29 @@ typename AutoDiffToValueMatrix<Derived>::type autoDiffToValueMatrix(
  * @see DiscardZeroGradient
  */
 template <typename Derived>
-typename std::enable_if<
-    !std::is_same<typename Derived::Scalar, double>::value,
+typename std::enable_if_t<
+    !std::is_same_v<typename Derived::Scalar, double>,
     Eigen::Matrix<typename Derived::Scalar::Scalar, Derived::RowsAtCompileTime,
                   Derived::ColsAtCompileTime, 0, Derived::MaxRowsAtCompileTime,
-                  Derived::MaxColsAtCompileTime>>::type
+                  Derived::MaxColsAtCompileTime>>
 DiscardGradient(const Eigen::MatrixBase<Derived>& auto_diff_matrix) {
   return autoDiffToValueMatrix(auto_diff_matrix);
 }
 
 /// @see DiscardGradient().
 template <typename Derived>
-typename std::enable_if<
-    std::is_same<typename Derived::Scalar, double>::value,
-    const Eigen::MatrixBase<Derived>&>::type
+typename std::enable_if_t<
+    std::is_same_v<typename Derived::Scalar, double>,
+    const Eigen::MatrixBase<Derived>&>
 DiscardGradient(const Eigen::MatrixBase<Derived>& matrix) {
   return matrix;
 }
 
 /// @see DiscardGradient().
 template <typename _Scalar, int _Dim, int _Mode, int _Options>
-typename std::enable_if<
-    !std::is_same<_Scalar, double>::value,
-    Eigen::Transform<typename _Scalar::Scalar, _Dim, _Mode, _Options>>::type
+typename std::enable_if_t<
+    !std::is_same_v<_Scalar, double>,
+    Eigen::Transform<typename _Scalar::Scalar, _Dim, _Mode, _Options>>
 DiscardGradient(const Eigen::Transform<_Scalar, _Dim, _Mode, _Options>&
                     auto_diff_transform) {
   return Eigen::Transform<typename _Scalar::Scalar, _Dim, _Mode, _Options>(
@@ -82,9 +82,9 @@ DiscardGradient(const Eigen::Transform<_Scalar, _Dim, _Mode, _Options>&
 
 /// @see DiscardGradient().
 template <typename _Scalar, int _Dim, int _Mode, int _Options>
-typename std::enable_if<std::is_same<_Scalar, double>::value,
-                        const Eigen::Transform<_Scalar, _Dim, _Mode,
-    _Options>&>::type
+typename std::enable_if_t<std::is_same_v<_Scalar, double>,
+                          const Eigen::Transform<_Scalar, _Dim, _Mode,
+    _Options>&>
 DiscardGradient(
     const Eigen::Transform<_Scalar, _Dim, _Mode, _Options>& transform) {
   return transform;

--- a/math/autodiff_gradient.h
+++ b/math/autodiff_gradient.h
@@ -89,8 +89,8 @@ void initializeAutoDiffGivenGradientMatrix(
   static_assert(static_cast<int>(ExpectedAutoDiffType::ColsAtCompileTime) ==
                     static_cast<int>(DerivedAutoDiff::ColsAtCompileTime),
                 "auto diff matrix has wrong number of columns at compile time");
-  static_assert(std::is_same<typename DerivedAutoDiff::Scalar,
-                             typename ExpectedAutoDiffType::Scalar>::value,
+  static_assert(std::is_same_v<typename DerivedAutoDiff::Scalar,
+                               typename ExpectedAutoDiffType::Scalar>,
                 "wrong auto diff scalar type");
 
   typedef typename Eigen::MatrixBase<DerivedGradient>::Index Index;
@@ -157,11 +157,11 @@ void gradientMatrixToAutoDiff(
  * @see DiscardGradient
  */
 template <typename Derived>
-typename std::enable_if<
-    !std::is_same<typename Derived::Scalar, double>::value,
+typename std::enable_if_t<
+    !std::is_same_v<typename Derived::Scalar, double>,
     Eigen::Matrix<typename Derived::Scalar::Scalar, Derived::RowsAtCompileTime,
                   Derived::ColsAtCompileTime, 0, Derived::MaxRowsAtCompileTime,
-                  Derived::MaxColsAtCompileTime>>::type
+                  Derived::MaxColsAtCompileTime>>
 DiscardZeroGradient(
     const Eigen::MatrixBase<Derived>& auto_diff_matrix,
     const typename Eigen::NumTraits<
@@ -177,8 +177,8 @@ DiscardZeroGradient(
 
 /// @see DiscardZeroGradient().
 template <typename Derived>
-typename std::enable_if<std::is_same<typename Derived::Scalar, double>::value,
-                        const Eigen::MatrixBase<Derived>&>::type
+typename std::enable_if_t<std::is_same_v<typename Derived::Scalar, double>,
+                          const Eigen::MatrixBase<Derived>&>
 DiscardZeroGradient(const Eigen::MatrixBase<Derived>& matrix,
                    double precision = 0.) {
   unused(precision);
@@ -187,9 +187,9 @@ DiscardZeroGradient(const Eigen::MatrixBase<Derived>& matrix,
 
 /// @see DiscardZeroGradient().
 template <typename _Scalar, int _Dim, int _Mode, int _Options>
-typename std::enable_if<
-    !std::is_same<_Scalar, double>::value,
-    Eigen::Transform<typename _Scalar::Scalar, _Dim, _Mode, _Options>>::type
+typename std::enable_if_t<
+    !std::is_same_v<_Scalar, double>,
+    Eigen::Transform<typename _Scalar::Scalar, _Dim, _Mode, _Options>>
 DiscardZeroGradient(
     const Eigen::Transform<_Scalar, _Dim, _Mode, _Options>& auto_diff_transform,
     const typename Eigen::NumTraits<typename _Scalar::Scalar>::Real& precision =
@@ -200,9 +200,9 @@ DiscardZeroGradient(
 
 /// @see DiscardZeroGradient().
 template <typename _Scalar, int _Dim, int _Mode, int _Options>
-typename std::enable_if<
-    std::is_same<_Scalar, double>::value,
-    const Eigen::Transform<_Scalar, _Dim, _Mode, _Options>&>::type
+typename std::enable_if_t<
+    std::is_same_v<_Scalar, double>,
+    const Eigen::Transform<_Scalar, _Dim, _Mode, _Options>&>
 DiscardZeroGradient(
     const Eigen::Transform<_Scalar, _Dim, _Mode, _Options>& transform,
     double precision = 0.) {

--- a/math/bspline_basis.h
+++ b/math/bspline_basis.h
@@ -195,7 +195,7 @@ class BsplineBasis final {
 #else
   // Restrict this method to T = double only; we must mix "Archive" into the
   // conditional type for SFINAE to work, so we just check it against void.
-  std::enable_if_t<std::is_same_v<T, double> && !std::is_void<Archive>::value>
+  std::enable_if_t<std::is_same_v<T, double> && !std::is_void_v<Archive>>
 #endif
   Serialize(Archive* a) {
     a->Visit(MakeNameValue("order", &order_));

--- a/math/convert_time_derivative.h
+++ b/math/convert_time_derivative.h
@@ -41,9 +41,9 @@ Vector3<typename v_Type::Scalar> ConvertTimeDerivativeToOtherFrame(
   EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Eigen::MatrixBase<w_AB_Type>, 3);
   typedef typename v_Type::Scalar T;
   // All input vectors must be templated on the same scalar type.
-  static_assert(std::is_same<typename DtB_v_Type::Scalar, T>::value,
+  static_assert(std::is_same_v<typename DtB_v_Type::Scalar, T>,
                 "DtB_v_E must be templated on the same scalar type as v_E");
-  static_assert(std::is_same<typename w_AB_Type::Scalar, T>::value,
+  static_assert(std::is_same_v<typename w_AB_Type::Scalar, T>,
                 "w_AB_E must be templated on the same scalar type as v_E");
   return DtB_v_E + w_AB_E.cross(v_E);
 }

--- a/math/jacobian.h
+++ b/math/jacobian.h
@@ -59,7 +59,7 @@ decltype(auto) jacobian(F &&f, Arg &&x) {
   using Eigen::Index;
   using Eigen::Matrix;
 
-  using ArgNoRef = typename std::remove_reference<Arg>::type;
+  using ArgNoRef = typename std::remove_reference_t<Arg>;
 
   // Argument scalar type.
   using ArgScalar = typename ArgNoRef::Scalar;

--- a/math/test/gray_code_test.cc
+++ b/math/test/gray_code_test.cc
@@ -33,10 +33,10 @@ void TestGrayCode(const Eigen::Ref<const Eigen::MatrixXi>& gray_codes) {
   auto gray_codes_dynamic = CalculateReflectedGrayCodes(NumDigits);
   auto gray_codes_static = CalculateReflectedGrayCodes<NumDigits>();
   static_assert(
-      std::is_same<decltype(gray_codes_dynamic), Eigen::MatrixXi>::value,
+      std::is_same_v<decltype(gray_codes_dynamic), Eigen::MatrixXi>,
       "Should be a dynamic sized matrix");
-  static_assert(std::is_same<decltype(gray_codes_static),
-                             Eigen::Matrix<int, NumCodes, NumDigits>>::value,
+  static_assert(std::is_same_v<decltype(gray_codes_static),
+                               Eigen::Matrix<int, NumCodes, NumDigits>>,
                 "Should be a static sized matrix");
   EXPECT_TRUE(CompareMatrices(gray_codes, gray_codes_dynamic, 1E-5,
                               MatrixCompareType::absolute));

--- a/math/test/jacobian_test.cc
+++ b/math/test/jacobian_test.cc
@@ -38,7 +38,7 @@ TEST_F(AutodiffJacobianTest, QuadraticForm) {
 #pragma GCC diagnostic ignored "-Wshadow"
   auto quadratic_form = [&](const auto& x) {
 #pragma GCC diagnostic pop
-    using Scalar = typename std::remove_reference<decltype(x)>::type::Scalar;
+    using Scalar = typename std::remove_reference_t<decltype(x)>::Scalar;
     return (x.transpose() * A.cast<Scalar>().eval() * x).eval();
   };
 
@@ -50,14 +50,14 @@ TEST_F(AutodiffJacobianTest, QuadraticForm) {
   auto jac_chunk_size_6 = jacobian<6>(quadratic_form, x);
 
   // Ensure that chunk size has no effect on output type.
-  static_assert(std::is_same<decltype(jac_chunk_size_default),
-                             decltype(jac_chunk_size_1)>::value,
+  static_assert(std::is_same_v<decltype(jac_chunk_size_default),
+                               decltype(jac_chunk_size_1)>,
                 "jacobian output type mismatch");
-  static_assert(std::is_same<decltype(jac_chunk_size_default),
-                             decltype(jac_chunk_size_3)>::value,
+  static_assert(std::is_same_v<decltype(jac_chunk_size_default),
+                               decltype(jac_chunk_size_3)>,
                 "jacobian output type mismatch");
-  static_assert(std::is_same<decltype(jac_chunk_size_default),
-                             decltype(jac_chunk_size_6)>::value,
+  static_assert(std::is_same_v<decltype(jac_chunk_size_default),
+                               decltype(jac_chunk_size_6)>,
                 "jacobian output type mismatch");
 
   // Ensure that the results are the same.
@@ -109,7 +109,7 @@ TEST_F(AutoDiffHessianTest, QuadraticFunction) {
 #pragma GCC diagnostic ignored "-Wshadow"
   auto quadratic_function = [&](const auto& x) {
 #pragma GCC diagnostic pop
-    using Scalar = typename std::remove_reference<decltype(x)>::type::Scalar;
+    using Scalar = typename std::remove_reference_t<decltype(x)>::Scalar;
     return ((A.cast<Scalar>() * x + b.cast<Scalar>()).transpose() *
             C.cast<Scalar>() * (D.cast<Scalar>() * x + e.cast<Scalar>()))
         .eval();
@@ -122,8 +122,8 @@ TEST_F(AutoDiffHessianTest, QuadraticFunction) {
   auto hess_chunk_size_2_4 = hessian<2, 4>(quadratic_function, x);
 
   // Ensure that chunk size has no effect on output type.
-  static_assert(std::is_same<decltype(hess_chunk_size_default),
-                             decltype(hess_chunk_size_2_4)>::value,
+  static_assert(std::is_same_v<decltype(hess_chunk_size_default),
+                               decltype(hess_chunk_size_2_4)>,
                 "hessian output type mismatch");
 
   // Ensure that the results are the same.

--- a/perception/test/depth_image_to_point_cloud_test.cc
+++ b/perception/test/depth_image_to_point_cloud_test.cc
@@ -308,7 +308,7 @@ TYPED_TEST(DepthImageToPointCloudTest, NanValue) {
 
   // This test only applies for 32F images; there is no NaN for 16U images.
   constexpr bool is_meaningful_nan =
-      !std::is_same<TestFixturePixel, uint16_t>::value;
+      !std::is_same_v<TestFixturePixel, uint16_t>;
   if (!is_meaningful_nan) {
     return;
   }

--- a/perception/test/point_cloud_flags_test.cc
+++ b/perception/test/point_cloud_flags_test.cc
@@ -21,7 +21,7 @@ GTEST_TEST(PointCloudFlagsTest, ConstExpr) {
   // `constexpr` is attempted with a non-literal-type class (as of C++14).
   // TODO(eric.cousineau): Replace with the successor of is_literal_type.
   // @ref https://stackoverflow.com/a/40352351/7829525
-  EXPECT_TRUE(std::is_literal_type<pcf::DescriptorType>::value);
+  EXPECT_TRUE(std::is_literal_type_v<pcf::DescriptorType>);
 }
 
 GTEST_TEST(PointCloudFlagsTest, Formatting) {

--- a/tools/vector_gen/lcm_vector_gen.py
+++ b/tools/vector_gen/lcm_vector_gen.py
@@ -195,7 +195,7 @@ SET_TO_NAMED_VARIABLES_BEGIN = """
   /// Create a symbolic::Variable for each element with the known variable
   /// name.  This is only available for T == symbolic::Expression.
   template <typename U=T>
-  typename std::enable_if<std::is_same<U, symbolic::Expression>::value>::type
+  typename std::enable_if_t<std::is_same_v<U, symbolic::Expression>>
   SetToNamedVariables() {
 """
 SET_TO_NAMED_VARIABLES_BODY = """

--- a/tools/vector_gen/test/goal/sample.h
+++ b/tools/vector_gen/test/goal/sample.h
@@ -83,7 +83,7 @@ class Sample final : public drake::systems::BasicVector<T> {
   /// Create a symbolic::Variable for each element with the known variable
   /// name.  This is only available for T == symbolic::Expression.
   template <typename U = T>
-  typename std::enable_if<std::is_same<U, symbolic::Expression>::value>::type
+  typename std::enable_if_t<std::is_same_v<U, symbolic::Expression>>
   SetToNamedVariables() {
     this->set_x(symbolic::Variable("x"));
     this->set_two_word(symbolic::Variable("two_word"));

--- a/tools/vector_gen/test/sample_test.cc
+++ b/tools/vector_gen/test/sample_test.cc
@@ -88,7 +88,7 @@ GTEST_TEST(SampleTest, SimpleCoverage) {
 // When inheritance is in use, we should only permit public copy & move
 // operations to exist on classes that are marked as final.
 static_assert(
-    std::is_final<Sample<double>>::value,
+    std::is_final_v<Sample<double>>,
     "Sample<T> should have been final");
 
 // Confirm that copy semantics work.


### PR DESCRIPTION
This tidies up math, perception, and vector_gen.

I think these are the last remaining uses of the pre-17 spellings within Drake.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15157)
<!-- Reviewable:end -->
