### PR TITLE
Add SystemScalarConverter::Remove()

### DIFF
--- a/systems/framework/diagram.cc
+++ b/systems/framework/diagram.cc
@@ -1476,7 +1476,7 @@ void Diagram<T>::Initialize(std::unique_ptr<Blueprint> blueprint) {
   // Identify the intersection of the subsystems' scalar conversion support.
   // Remove all conversions that at least one subsystem did not support.
   SystemScalarConverter& this_scalar_converter =
-      SystemImpl::get_mutable_system_scalar_converter(this);
+      this->get_mutable_system_scalar_converter();
   for (const auto& system : registered_systems_) {
     this_scalar_converter.RemoveUnlessAlsoSupportedBy(
         system->get_system_scalar_converter());

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -36,31 +36,6 @@
 namespace drake {
 namespace systems {
 
-#if !defined(DRAKE_DOXYGEN_CXX)
-// Private helper class for System.
-class SystemImpl {
- public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SystemImpl)
-  SystemImpl() = delete;
-
- private:
-  // Attorney-Client idiom to expose a subset of private elements of System.
-  // We are the attorney.  These are the clients that can access our private
-  // members, and thus access some subset of System's private members.
-  template <typename> friend class Diagram;
-
-  // Return a mutable reference to the System's SystemScalarConverter.  Diagram
-  // needs this in order to withdraw support for certain scalar type conversion
-  // operations once it learns about what its subsystems support.
-  template <typename T>
-  static SystemScalarConverter& get_mutable_system_scalar_converter(
-      System<T>* system) {
-    DRAKE_DEMAND(system != nullptr);
-    return system->system_scalar_converter_;
-  }
-};
-#endif  // DRAKE_DOXYGEN_CXX
-
 /** Base class for all System functionality that is dependent on the templatized
 scalar type T for input, state, parameters, and outputs.
 
@@ -1699,6 +1674,11 @@ class System : public SystemBase {
     forced_unrestricted_update_events_ = std::move(forced);
   }
 
+  /** Returns the SystemScalarConverter for `this` system. */
+  SystemScalarConverter& get_mutable_system_scalar_converter() {
+    return system_scalar_converter_;
+  }
+
   /** Checks whether the given object was created for this system.
   @note This method is sufficiently fast for performance sensitive code. */
   template <template <typename> class Clazz>
@@ -1726,10 +1706,6 @@ class System : public SystemBase {
   }
 
  private:
-  // Attorney-Client idiom to expose a subset of private elements of System.
-  // Refer to SystemImpl comments for details.
-  friend class SystemImpl;
-
   // For any T1 & T2, System<T1> considers System<T2> a friend, so that System
   // can safely and efficiently convert scalar types. See for example
   // System<T>::ToScalarTypeMaybe.

--- a/systems/framework/system_scalar_converter.cc
+++ b/systems/framework/system_scalar_converter.cc
@@ -31,6 +31,19 @@ void SystemScalarConverter::Insert(
   DRAKE_ASSERT(insert_result.second);
 }
 
+void SystemScalarConverter::Remove(const std::type_info& t_info) {
+  // Remove the items from `funcs_` whose key contains the type `T` that
+  // matches `t_info`. (This would use erase_if, if we had it.)
+  for (auto iter = funcs_.begin(); iter != funcs_.end();) {
+    const Key& key = iter->first;
+    if (key.first == t_info || key.second == t_info) {
+      iter = funcs_.erase(iter);
+    } else {
+      ++iter;
+    }
+  }
+}
+
 const SystemScalarConverter::ErasedConverterFunc* SystemScalarConverter::Find(
     const std::type_info& t_info, const std::type_info& u_info) const {
   const auto& key = Key{t_info, u_info};

--- a/systems/framework/system_scalar_converter.h
+++ b/systems/framework/system_scalar_converter.h
@@ -136,6 +136,12 @@ class SystemScalarConverter {
   /// is false.  The subtype `S` need not be the same between this and `other`.
   void RemoveUnlessAlsoSupportedBy(const SystemScalarConverter& other);
 
+  /// Removes from this converter the ability to convert to or from System<T>.
+  template <typename T>
+  void Remove() {
+    Remove(typeid(T));
+  }
+
   /// Returns true iff this object can convert a System<U> into a System<T>,
   /// i.e., whether Convert() will return non-null.
   ///
@@ -177,6 +183,9 @@ class SystemScalarConverter {
   void Insert(
       const std::type_info&, const std::type_info&,
       const ErasedConverterFunc&);
+
+  // Given typeid(T), removes all converter to or from type T.
+  void Remove(const std::type_info&);
 
   // Maps from {T, U} to the function that converts from U into T.
   std::unordered_map<Key, ErasedConverterFunc, KeyHasher> funcs_;

--- a/systems/framework/test/system_scalar_converter_test.cc
+++ b/systems/framework/test/system_scalar_converter_test.cc
@@ -305,6 +305,32 @@ GTEST_TEST(SystemScalarConverterTest, RemoveUnlessAlsoSupportedBy) {
       dut.Convert<AutoDiffXd, double>(system)));
 }
 
+GTEST_TEST(SystemScalarConverterTest, Remove) {
+  SystemScalarConverter dut(SystemTypeTag<AnyToAnySystem>{});
+
+  // These are the defaults per TestAnyToAnySystem above.
+  EXPECT_TRUE((dut.IsConvertible<double,     AutoDiffXd>()));
+  EXPECT_TRUE((dut.IsConvertible<double,     Expression>()));
+  EXPECT_TRUE((dut.IsConvertible<AutoDiffXd, double    >()));
+  EXPECT_TRUE((dut.IsConvertible<AutoDiffXd, Expression>()));
+  EXPECT_TRUE((dut.IsConvertible<Expression, double    >()));
+  EXPECT_TRUE((dut.IsConvertible<Expression, AutoDiffXd>()));
+
+  // We remove symbolic support.  Only double <=> AutoDiff remains.
+  dut.Remove<symbolic::Expression>();
+  EXPECT_TRUE((dut.IsConvertible< double,     AutoDiffXd>()));
+  EXPECT_TRUE((dut.IsConvertible< AutoDiffXd, double    >()));
+  EXPECT_FALSE((dut.IsConvertible<double,     Expression>()));
+  EXPECT_FALSE((dut.IsConvertible<AutoDiffXd, Expression>()));
+  EXPECT_FALSE((dut.IsConvertible<Expression, double    >()));
+  EXPECT_FALSE((dut.IsConvertible<Expression, AutoDiffXd>()));
+
+  // The conversion still actually works.
+  const AnyToAnySystem<double> system{22};
+  EXPECT_TRUE(is_dynamic_castable<AnyToAnySystem<AutoDiffXd>>(
+      dut.Convert<AutoDiffXd, double>(system)));
+}
+
 }  // namespace
 }  // namespace systems
 }  // namespace drake


### PR DESCRIPTION
Support prohibiting scalar conversion to and from a particular scalar type at run time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15159)
<!-- Reviewable:end -->
