### PR TITLE
Calculate deformable rigid contact pair

### DIFF
--- a/multibody/fixed_fem/dev/BUILD.bazel
+++ b/multibody/fixed_fem/dev/BUILD.bazel
@@ -132,6 +132,17 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "deformable_rigid_contact_pair",
+    hdrs = ["deformable_rigid_contact_pair.h"],
+    deps = [
+        ":deformable_contact",
+        ":fem_indexes",
+        "//geometry:geometry_ids",
+        "//math:geometric_transform",
+    ],
+)
+
+drake_cc_library(
     name = "deformable_rigid_manager",
     srcs = [
         "deformable_rigid_manager.cc",
@@ -142,6 +153,7 @@ drake_cc_library(
     deps = [
         ":collision_objects",
         ":deformable_model",
+        ":deformable_rigid_contact_pair",
         ":fem_solver",
         "//common:essential",
         "//multibody/plant",

--- a/multibody/fixed_fem/dev/deformable_rigid_contact_pair.h
+++ b/multibody/fixed_fem/dev/deformable_rigid_contact_pair.h
@@ -1,0 +1,58 @@
+#pragma once
+#include <utility>
+#include <vector>
+
+#include "drake/geometry/geometry_ids.h"
+#include "drake/math/rotation_matrix.h"
+#include "drake/multibody/fixed_fem/dev/deformable_contact.h"
+#include "drake/multibody/fixed_fem/dev/fem_indexes.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+namespace internal {
+/* A wrapper around DeformableContactSurface that provides additional
+ information about the geometries/bodies involved in the contact and proximity
+ properties of the contacts. */
+template <typename T>
+struct DeformableRigidContactPair {
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DeformableRigidContactPair)
+  DeformableRigidContactPair(DeformableContactSurface<T> contact_surface_in,
+                             geometry::GeometryId rigid_id_in,
+                             SoftBodyIndex deformable_id_in, const T& k,
+                             const T& d, const T& mu)
+      : contact_surface(std::move(contact_surface_in)),
+        rigid_id(rigid_id_in),
+        deformable_id(deformable_id_in),
+        stiffness(k),
+        dissipation(d),
+        friction(mu),
+        R_CWs(contact_surface.num_polygons()) {
+    for (int ic = 0; ic < contact_surface.num_polygons(); ++ic) {
+      const Vector3<T>& nhat_W = contact_surface.polygon_data(ic).unit_normal;
+      constexpr int axis = 2;
+      auto R_WC = math::RotationMatrix<T>::MakeFromOneUnitVector(nhat_W, axis);
+      R_CWs[ic] = R_WC.transpose();
+    }
+  }
+
+  /* Returns the number of contact points between the rigid and deformable body.
+   */
+  int num_contact_points() const { return contact_surface.num_polygons(); }
+
+  DeformableContactSurface<T> contact_surface;
+  geometry::GeometryId rigid_id;  // The id of the rigid geometry in contact.
+  SoftBodyIndex deformable_id;    // The id of deformable body in contact.
+  T stiffness;                    // Combined stiffness at the contact point.
+  T dissipation;                  // Combined dissipation at the contact point.
+  T friction;                     // Combined friction at the contact point.
+  /* The rotation matrix mapping world frame quantities into contact frames at
+   each contact point. The i-th contact point has its own contact frame Cᵢ,
+   where R_CᵢW = R_CWs[i]. The basis vector Cᵢz is along the contact surface's
+   normal at that contact point. */
+  std::vector<math::RotationMatrix<T>> R_CWs;
+};
+}  // namespace internal
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/deformable_rigid_manager.h
+++ b/multibody/fixed_fem/dev/deformable_rigid_manager.h
@@ -10,6 +10,7 @@
 #include "drake/multibody/contact_solvers/contact_solver.h"
 #include "drake/multibody/fixed_fem/dev/collision_objects.h"
 #include "drake/multibody/fixed_fem/dev/deformable_model.h"
+#include "drake/multibody/fixed_fem/dev/deformable_rigid_contact_pair.h"
 #include "drake/multibody/fixed_fem/dev/fem_solver.h"
 #include "drake/multibody/plant/contact_jacobians.h"
 #include "drake/multibody/plant/discrete_update_manager.h"
@@ -160,6 +161,12 @@ class DeformableRigidManager final
   /* Updates the vertex positions for all deformable meshes. */
   void UpdateDeformableVertexPositions(
       const systems::Context<T>& context) const;
+
+  /* Calculates the contact information for the contact pair consisting of the
+   rigid body identified by `rigid_id` and the deformable body identified by
+   `deformable_id`. */
+  internal::DeformableRigidContactPair<T> CalcDeformableRigidContactPair(
+      geometry::GeometryId rigid_id, SoftBodyIndex deformable_id) const;
 
   /* The deformable models being solved by `this` manager. */
   const DeformableModel<T>* deformable_model_{nullptr};

--- a/multibody/plant/discrete_update_manager.cc
+++ b/multibody/plant/discrete_update_manager.cc
@@ -84,6 +84,18 @@ DiscreteUpdateManager<T>::collision_geometries() const {
   return MultibodyPlantDiscreteUpdateManagerAttorney<T>::collision_geometries(
       plant());
 }
+
+template <typename T>
+double DiscreteUpdateManager<T>::default_contact_stiffness() const {
+  return MultibodyPlantDiscreteUpdateManagerAttorney<
+      T>::default_contact_stiffness(plant());
+}
+
+template <typename T>
+double DiscreteUpdateManager<T>::default_contact_dissipation() const {
+  return MultibodyPlantDiscreteUpdateManagerAttorney<
+      T>::default_contact_dissipation(plant());
+}
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/plant/discrete_update_manager.h
+++ b/multibody/plant/discrete_update_manager.h
@@ -112,10 +112,13 @@ class DiscreteUpdateManager {
   /* Exposed MultibodyPlant private/protected methods.
    @{ */
   const MultibodyTree<T>& internal_tree() const;
+
   // TODO(xuchenhan-tri): Remove this when SceneGraph takes control of all
   //  geometries.
   const std::vector<std::vector<geometry::GeometryId>>& collision_geometries()
       const;
+  double default_contact_stiffness() const;
+  double default_contact_dissipation() const;
 
   const contact_solvers::internal::ContactSolverResults<T>&
   EvalContactSolverResults(const systems::Context<T>& context) const;

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -4917,6 +4917,25 @@ struct AddMultibodyPlantSceneGraphResult final {
   geometry::SceneGraph<T>* scene_graph_ptr{};
 };
 
+namespace internal {
+// Combines the contact stiffness and dissipation parameters from two bodies in
+// contact to create the contact stiffness and dissipation to be used for the
+// contact pair.
+// @tparam_default_scalar
+template <typename T>
+std::pair<T, T> CombinePointContactParameters(const T& k1, const T& k2,
+                                              const T& d1, const T& d2) {
+  // Simple utility to detect 0 / 0. As it is used in this method, denom
+  // can only be zero if num is also zero, so we'll simply return zero.
+  auto safe_divide = [](const T& num, const T& denom) {
+    return denom == 0.0 ? 0.0 : num / denom;
+  };
+  return std::pair(
+      safe_divide(k1 * k2, k1 + k2),                                   // k
+      safe_divide(k2, k1 + k2) * d1 + safe_divide(k1, k1 + k2) * d2);  // d
+}
+}  // namespace internal
+
 #ifndef DRAKE_DOXYGEN_CXX
 // Forward-declare specializations, prior to DRAKE_DECLARE... below.
 // See the .cc file for an explanation why we specialize these methods.

--- a/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
+++ b/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
@@ -86,6 +86,14 @@ class MultibodyPlantDiscreteUpdateManagerAttorney {
   collision_geometries(const MultibodyPlant<T>& plant) {
     return plant.collision_geometries_;
   }
+
+  static double default_contact_stiffness(const MultibodyPlant<T>& plant) {
+    return plant.penalty_method_contact_parameters_.geometry_stiffness;
+  }
+
+  static double default_contact_dissipation(const MultibodyPlant<T>& plant) {
+    return plant.penalty_method_contact_parameters_.dissipation;
+  }
 };
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -3550,6 +3550,20 @@ GTEST_TEST(MultibodyPlantTests, FixedOffsetFrameParameters) {
       CompareMatrices(X_WF_new.GetAsMatrix34(), X_WF_body_new.GetAsMatrix34()));
 }
 
+GTEST_TEST(MultibodyPlant, CombinePointContactParameters) {
+  // case: k1+k2 == 0.0.
+  {
+    const auto [k, d] = internal::CombinePointContactParameters(0., 0., 0., 0.);
+    EXPECT_TRUE(k == 0 && d == 0);
+  }
+  // case: k1+k2 != 0.0.
+  {
+    const auto [k, d] = internal::CombinePointContactParameters(1., 1., 1., 1.);
+    double kEps = std::numeric_limits<double>::epsilon();
+    EXPECT_NEAR(k, 0.5, 4 * kEps);
+    EXPECT_NEAR(d, 1.0, 4 * kEps);
+  }
+}
 }  // namespace
 }  // namespace multibody
 }  // namespace drake


### PR DESCRIPTION
This PR is a sequel to #15128. It provides the functionality to calculate deformable rigid contact pairs by adding a DeformableRigidManager::CalcDeformableRigidContactPair() method that calculates the contact information between a deformable body and a rigid collision geometry. It wraps around ComputeTetMeshTriMeshContact() to provide additional information about the contact such as friction, stiffness, dissipation, and the rotation matrices to transform world frame quantities into contact frames.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15160)
<!-- Reviewable:end -->
