### PR TITLE
[framework] Factor calculation function internals for easier reuse

### DIFF
--- a/systems/framework/leaf_system.cc
+++ b/systems/framework/leaf_system.cc
@@ -747,6 +747,8 @@ LeafOutputPort<T>& LeafSystem<T>::DeclareStateOutputPort(
 }
 
 // (This function is deprecated.)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 template <typename T>
 LeafOutputPort<T>& LeafSystem<T>::DeclareVectorOutputPort(
     const BasicVector<T>& model_vector,
@@ -756,8 +758,11 @@ LeafOutputPort<T>& LeafSystem<T>::DeclareVectorOutputPort(
                                  std::move(vector_calc_function),
                                  std::move(prerequisites_of_calc));
 }
+#pragma GCC diagnostic pop
 
 // (This function is deprecated.)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 template <typename T>
 LeafOutputPort<T>& LeafSystem<T>::DeclareAbstractOutputPort(
     typename LeafOutputPort<T>::AllocCallback alloc_function,
@@ -767,6 +772,7 @@ LeafOutputPort<T>& LeafSystem<T>::DeclareAbstractOutputPort(
                                    std::move(calc_function),
                                    std::move(prerequisites_of_calc));
 }
+#pragma GCC diagnostic pop
 
 template <typename T>
 std::unique_ptr<WitnessFunction<T>> LeafSystem<T>::MakeWitnessFunction(

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -1463,18 +1463,15 @@ class LeafSystem : public System<T> {
                                      std::move(prerequisites_of_calc));
   }
 
-  /** Declares an abstract-valued output port by specifying member functions to
-  use both for the allocator and calculator. The signatures are:
-  @code
-  OutputType MySystem::MakeOutputValue() const;
-  void MySystem::CalcOutputValue(const Context<T>&, OutputType*) const;
-  @endcode
-  where `MySystem` is a class derived from `LeafSystem<T>` and `OutputType`
-  may be any concrete type such that `Value<OutputType>` is permitted.
-  See alternate signature if your allocator method needs a Context.
-  Template arguments will be deduced and do not need to be specified.
-  @see drake::Value */
+  // Declares an output port by specifying an allocator function pointer that
+  // returns by-value, and a calc function pointer.
   template <class MySystem, typename OutputType>
+  DRAKE_DEPRECATED("2021-11-01",
+      "This overload for DeclareAbstractOutputPort is rarely the best choice;"
+      " it is unusual for allocation to return an OutputType by value rather"
+      " than just Clone of a model_value. If the default constructor or a"
+      " model value cannot be used, use the AllocCallback overload (below)"
+      " instead.")
   LeafOutputPort<T>& DeclareAbstractOutputPort(
       std::variant<std::string, UseDefaultName> name,
       OutputType (MySystem::*make)() const,
@@ -1592,8 +1589,11 @@ class LeafSystem : public System<T> {
       void (MySystem::*calc)(const Context<T>&, OutputType*) const,
       std::set<DependencyTicket> prerequisites_of_calc = {
           all_sources_ticket()}) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     return DeclareAbstractOutputPort(kUseDefaultName, make, calc,
                                      std::move(prerequisites_of_calc));
+#pragma GCC diagnostic pop
   }
 
   DRAKE_DEPRECATED("2021-10-01", "Pass a port name as the first argument.")

--- a/systems/framework/system.cc
+++ b/systems/framework/system.cc
@@ -905,19 +905,19 @@ System<T>::System(SystemScalarConverter converter)
   // Use configuration, kinematics, and mass tickets when #9171 is resolved.
   potential_energy_cache_index_ =
       DeclareCacheEntry("potential energy",
-          &System<T>::CalcPotentialEnergy,
+          ValueProducer(this, &System<T>::CalcPotentialEnergy),
           {all_sources_ticket()})  // After #9171: configuration + mass.
           .cache_index();
 
   kinetic_energy_cache_index_ =
       DeclareCacheEntry("kinetic energy",
-          &System<T>::CalcKineticEnergy,
+          ValueProducer(this, &System<T>::CalcKineticEnergy),
           {all_sources_ticket()})  // After #9171: kinematics + mass.
           .cache_index();
 
   conservative_power_cache_index_ =
       DeclareCacheEntry("conservative power",
-          &System<T>::CalcConservativePower,
+          ValueProducer(this, &System<T>::CalcConservativePower),
           {all_sources_ticket()})  // After #9171: kinematics + mass.
           .cache_index();
 
@@ -926,8 +926,8 @@ System<T>::System(SystemScalarConverter converter)
   // EvalNonConservativePower() to see why.
   nonconservative_power_cache_index_ =
       DeclareCacheEntry("non-conservative power",
-                        &System<T>::CalcNonConservativePower,
-                        {all_sources_ticket()})  // This is correct.
+          ValueProducer(this, &System<T>::CalcNonConservativePower),
+          {all_sources_ticket()})  // This is correct.
           .cache_index();
 
   // We must assume that time derivatives can depend on *any* context source.

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -377,21 +377,17 @@ class SystemBase : public internal::SystemMessageInterface {
       std::set<DependencyTicket> prerequisites_of_calc = {
           all_sources_ticket()});
 
-  /** Declares a cache entry by specifying member functions to use both for the
-  allocator and calculator. The signatures are: @code
-    ValueType MySystem::MakeValueType() const;
-    void MySystem::CalcCacheValue(const MyContext&, ValueType*) const;
-  @endcode
-  where `MySystem` is a class derived from `SystemBase`, `MyContext` is a class
-  derived from `ContextBase`, and `ValueType` is any concrete type such that
-  `Value<ValueType>` is permitted. (The method names are arbitrary.) Template
-  arguments will be deduced and do not need to be specified. See the
-  @ref DeclareCacheEntry_primary "primary DeclareCacheEntry() signature"
-  for more information about the parameters and behavior.
-  @see drake::Value
-  @warning This method is currently specified as `public` access, but will be
-  demoted to `protected` access on or after 2021-10-01. */
+  // Declares a cache entry by specifying two member function pointers.
+  // This will be demoted to `protected` access on or after 2021-10-01.
   template <class MySystem, class MyContext, typename ValueType>
+  DRAKE_DEPRECATED("2021-11-01",
+      "This overload for DeclareCacheEntry is rarely the best choice; it is"
+      " unusual for allocation to actually require a boutique callback rather"
+      " than just a Clone of a model_value. We found that most uses of this"
+      " overload hindered readability, because other overloads would often do"
+      " the job more directly. If no existing overload works, you may wrap a"
+      " ValueProducer around your existing make method and call the primary"
+      " DeclareCacheEntry overload that takes a ValueProducer, instead.")
   CacheEntry& DeclareCacheEntry(
       std::string description,
       ValueType (MySystem::*make)() const,
@@ -421,17 +417,18 @@ class SystemBase : public internal::SystemMessageInterface {
       std::set<DependencyTicket> prerequisites_of_calc = {
           all_sources_ticket()});
 
-  /** Declares a cache entry by specifying a model value of concrete type
-  `ValueType` and a calculator function that is a class member function (method)
-  with signature: @code
-    ValueType MySystem::CalcCacheValue(const MyContext&) const;
-  @endcode
-  Other than the calculator signature, this is identical to the other
-  @ref DeclareCacheEntry_model_and_calc "model and calculator signature",
-  please look there for more information.
-  @warning This method is currently specified as `public` access, but will be
-  demoted to `protected` access on or after 2021-10-01. */
+  // Declares a cache entry by specifying a model value and a calculator member
+  // function pointer.
+  // This will be demoted to `protected` access on or after 2021-10-01.
   template <class MySystem, class MyContext, typename ValueType>
+  DRAKE_DEPRECATED("2021-11-01",
+      "This overload for DeclareCacheEntry is dispreferred because it might"
+      " not reuse heap storage from one calculation to the next, and so is"
+      " typically less inefficient than the other overloads. A better option"
+      " is to change the ValueType returned by-value to be an output pointer"
+      " instead, and return void. If that is not possible, you may wrap a"
+      " ValueProducer around your existing method and call the primary"
+      " DeclareCacheEntry overload that takes a ValueProducer, instead.")
   CacheEntry& DeclareCacheEntry(
       std::string description, const ValueType& model_value,
       ValueType (MySystem::*calc)(const MyContext&) const,
@@ -469,17 +466,18 @@ class SystemBase : public internal::SystemMessageInterface {
       std::set<DependencyTicket> prerequisites_of_calc = {
           all_sources_ticket()});
 
-  /** Declares a cache entry by specifying only a calculator function that is a
-  class member function (method) with signature:
-  @code
-    ValueType MySystem::CalcCacheValue(const MyContext&) const;
-  @endcode
-  Other than the calculator method's signature, this is identical to the other
-  @ref DeclareCacheEntry_calc_only "calculator-only signature";
-  please look there for more information.
-  @warning This method is currently specified as `public` access, but will be
-  demoted to `protected` access on or after 2021-10-01. */
+  // Declares a cache entry by specifying only a calculator member function
+  // pointer.
+  // This will be demoted to `protected` access on or after 2021-10-01.
   template <class MySystem, class MyContext, typename ValueType>
+  DRAKE_DEPRECATED("2021-11-01",
+      "This overload for DeclareCacheEntry is dispreferred because it might"
+      " not reuse heap storage from one calculation to the next, and so is"
+      " typically less inefficient than the other overloads. A better option"
+      " is to change the ValueType returned by-value to be an output pointer"
+      " instead, and return void. If that is not possible, you may wrap a"
+      " ValueProducer around your existing method and call the primary"
+      " DeclareCacheEntry overload that takes a ValueProducer, instead.")
   CacheEntry& DeclareCacheEntry(
       std::string description,
       ValueType (MySystem::*calc)(const MyContext&) const,
@@ -1259,6 +1257,7 @@ class SystemBase : public internal::SystemMessageInterface {
 
 // Implementations of templatized DeclareCacheEntry() methods.
 
+// (This overload is deprecated.)
 // Takes make() and calc() member functions.
 template <class MySystem, class MyContext, typename ValueType>
 CacheEntry& SystemBase::DeclareCacheEntry(
@@ -1306,10 +1305,9 @@ CacheEntry& SystemBase::DeclareCacheEntry(
   return entry;
 }
 
+// (This overload is deprecated.)
 // Takes an initial value and value-returning calc() member function.
 // See the above output-argument signature for an explanation of the code.
-// TODO(sherm1) Consider whether common code in this and the previous method
-// can be factored out and shared rather than repeated.
 template <class MySystem, class MyContext, typename ValueType>
 CacheEntry& SystemBase::DeclareCacheEntry(
     std::string description, const ValueType& model_value,
@@ -1352,6 +1350,7 @@ CacheEntry& SystemBase::DeclareCacheEntry(
                            std::move(prerequisites_of_calc));
 }
 
+// (This overload is deprecated.)
 // Takes just a value-returning calc() member function, and
 // value-initializes the entry. See previous method for more information.
 template <class MySystem, class MyContext, typename ValueType>
@@ -1363,8 +1362,11 @@ CacheEntry& SystemBase::DeclareCacheEntry(
       std::is_default_constructible_v<ValueType>,
       "SystemBase::DeclareCacheEntry(calc): the calc-only overloads of "
       "this method requires that the output type has a default constructor");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   return DeclareCacheEntry(std::move(description), ValueType{}, calc,
                            std::move(prerequisites_of_calc));
+#pragma GCC diagnostic pop
 }
 
 }  // namespace systems

--- a/systems/framework/test/cache_entry_test.cc
+++ b/systems/framework/test/cache_entry_test.cc
@@ -88,61 +88,78 @@ class MyContextBase : public ContextBase {
 class MySystemBase final : public SystemBase {
  public:
   // Use at least one of each of the six DeclareCacheEntry() variants.
-  MySystemBase()
-        // 1. Use the most general method, taking free functions. Unspecified
-        //    prerequisites should default to all_sources_ticket().
-      : entry0_(DeclareCacheEntry("entry0", ValueProducer(Alloc3, Calc99))),
-        // 2. Use the method that takes two member functions.
-        entry1_(DeclareCacheEntry("entry1", &MySystemBase::MakeInt1,
-                                  &MySystemBase::CalcInt98,
-                                  {entry0_.ticket()})),
-        // 3a. Use the method that takes a model value and member calculator.
-        entry2_(DeclareCacheEntry("entry2", 2, &MySystemBase::CalcInt98,
-                                  {entry0_.ticket(), entry1_.ticket()})),
-        // 4. Use the method that takes a model value and member calculator that
-        // uses function return for its value.
-        entry3_(DeclareCacheEntry("entry3", 17, &MySystemBase::CalcReturnInt11,
-                                  {entry0_.ticket(), entry1_.ticket()})),
-        // 5. Use the method that takes just a member calculator that uses
-        // an output argument. (Entry will be value-initialized.)
-        entry4_(DeclareCacheEntry("entry4",
-                                  &MySystemBase::CalcInt98,
-                                  {entry0_.ticket(), entry1_.ticket()})),
-        // 6. Use the method that takes just a member calculator that uses
-        // function return for its value. (Entry will be value-initialized.)
-        entry5_(DeclareCacheEntry("entry5",
-                                  &MySystemBase::CalcReturnInt11,
-                                  {entry0_.ticket(), entry1_.ticket()})),
-        // 6b. Use the method that takes just a member calculator with output
-        // argument (value-initializes the cache entry).
-        string_entry_(DeclareCacheEntry("string thing",
-                                        &MySystemBase::CalcString,
-                                        {time_ticket()})),
-        // 3b. Also a model value and member calculator.
-        vector_entry_(
-            DeclareCacheEntry("vector thing", MyVector3d(Vector3d(1., 2., 3.)),
-                              &MySystemBase::CalcMyVector3,
-                              {xc_ticket(), string_entry_.ticket()})) {
+  MySystemBase() {
+    // 1. Use the most general method, taking free functions. Unspecified
+    //    prerequisites should default to all_sources_ticket().
+    entry0_ = &DeclareCacheEntry("entry0", ValueProducer(Alloc3, Calc99));
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    // 2. Use the method that takes two member functions.
+    entry1_ = &DeclareCacheEntry("entry1", &MySystemBase::MakeInt1,
+                                 &MySystemBase::CalcInt98,
+                                 {entry0_->ticket()});
+#pragma GCC diagnostic pop
+
+    // 3a. Use the method that takes a model value and member calculator.
+    entry2_ = &DeclareCacheEntry("entry2", 2, &MySystemBase::CalcInt98,
+                                 {entry0_->ticket(), entry1_->ticket()});
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    // 4. Use the method that takes a model value and member calculator that
+    // uses function return for its value.
+    entry3_ = &DeclareCacheEntry("entry3", 17, &MySystemBase::CalcReturnInt11,
+                                 {entry0_->ticket(), entry1_->ticket()});
+#pragma GCC diagnostic pop
+
+    // 5. Use the method that takes just a member calculator that uses
+    // an output argument. (Entry will be value-initialized.)
+    entry4_ = &DeclareCacheEntry("entry4",
+                                 &MySystemBase::CalcInt98,
+                                 {entry0_->ticket(), entry1_->ticket()});
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    // 6. Use the method that takes just a member calculator that uses
+    // function return for its value. (Entry will be value-initialized.)
+    entry5_ = &DeclareCacheEntry("entry5",
+                                 &MySystemBase::CalcReturnInt11,
+                                 {entry0_->ticket(), entry1_->ticket()});
+#pragma GCC diagnostic pop
+
+    // 6b. Use the method that takes just a member calculator with output
+    // argument (value-initializes the cache entry).
+    string_entry_ = &DeclareCacheEntry("string thing",
+                                       &MySystemBase::CalcString,
+                                       {time_ticket()});
+
+    // 3b. Also a model value and member calculator.
+    vector_entry_ =
+        &DeclareCacheEntry("vector thing", MyVector3d(Vector3d(1., 2., 3.)),
+                           &MySystemBase::CalcMyVector3,
+                           {xc_ticket(), string_entry_->ticket()});
+
     set_name("cache_entry_test_system");
 
     // We'll make entry4 disabled by default; everything else is enabled.
-    entry4_.disable_caching_by_default();
+    entry4_->disable_caching_by_default();
 
     EXPECT_EQ(num_cache_entries(), 8);
     EXPECT_EQ(GetSystemName(), "cache_entry_test_system");
 
-    EXPECT_FALSE(entry3_.is_disabled_by_default());
-    EXPECT_TRUE(entry4_.is_disabled_by_default());
+    EXPECT_FALSE(entry3_->is_disabled_by_default());
+    EXPECT_TRUE(entry4_->is_disabled_by_default());
   }
 
-  const CacheEntry& entry0() const { return entry0_; }
-  const CacheEntry& entry1() const { return entry1_; }
-  const CacheEntry& entry2() const { return entry2_; }
-  const CacheEntry& entry3() const { return entry3_; }
-  const CacheEntry& entry4() const { return entry4_; }
-  const CacheEntry& entry5() const { return entry5_; }
-  const CacheEntry& string_entry() const { return string_entry_; }
-  const CacheEntry& vector_entry() const { return vector_entry_; }
+  const CacheEntry& entry0() const { return *entry0_; }
+  const CacheEntry& entry1() const { return *entry1_; }
+  const CacheEntry& entry2() const { return *entry2_; }
+  const CacheEntry& entry3() const { return *entry3_; }
+  const CacheEntry& entry4() const { return *entry4_; }
+  const CacheEntry& entry5() const { return *entry5_; }
+  const CacheEntry& string_entry() const { return *string_entry_; }
+  const CacheEntry& vector_entry() const { return *vector_entry_; }
 
   // For use as an allocator.
   int MakeInt1() const { return 1; }
@@ -178,14 +195,14 @@ class MySystemBase final : public SystemBase {
     throw std::logic_error("GetDirectFeedthroughs is not implemented");
   }
 
-  CacheEntry& entry0_;
-  CacheEntry& entry1_;
-  CacheEntry& entry2_;
-  CacheEntry& entry3_;
-  CacheEntry& entry4_;
-  CacheEntry& entry5_;
-  CacheEntry& string_entry_;
-  CacheEntry& vector_entry_;
+  CacheEntry* entry0_{};
+  CacheEntry* entry1_{};
+  CacheEntry* entry2_{};
+  CacheEntry* entry3_{};
+  CacheEntry* entry4_{};
+  CacheEntry* entry5_{};
+  CacheEntry* string_entry_{};
+  CacheEntry* vector_entry_{};
 };
 
 // An allocator is not permitted to return null. That should be caught when

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -1516,12 +1516,15 @@ class DeclaredNonModelOutputSystem : public LeafSystem<double> {
         });
     unused(port);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     // Output port 3 is declared with a commonly-used signature taking
     // methods for both allocator and calculator for an abstract port.
     port = &DeclareAbstractOutputPort(
         kUseDefaultName, &DeclaredNonModelOutputSystem::MakeString,
         &DeclaredNonModelOutputSystem::CalcString);
     unused(port);
+#pragma GCC diagnostic pop
 
     // Output port 4 uses a default-constructed bare struct which should be
     // value-initialized.


### PR DESCRIPTION
This is a WIP branch to assist with #15133, that will be continuously refined and flow into PRs.

The overall motivation is as follows:

(1) It’s more finely slicing the separation of concerns.  By having ValueProducer encapsulate most of the complexity of the callback syntax and overloads, it allows System to focus on the parts it cares about, rather than all of the overload sugar.  Therefore, it lets us reuse the sugar for output ports, cache entries, etc;

(2) The DiscreteUpdateManager can't easily use the System’s sugar, since everything has to go through an attorney.  By denoting the callback (+ sugar) with its own first-class datatype, that makes it easier for the attorney to forward it along to the plant.  (This is the useful outcome for #15133.)

(3) By centralizing the implementation of the codepath for Calc, in the future we’ll be able to remove dynamic_cast (#15421) and std::function (TBD) performance penalties that are currently sprinkled everywhere.

- [x] #15174
- [x] #15175
- [x] #15176
- [x] #15190
- [x] #15193
- [x] #15198
- [x] #15209
- [x] #15271
- [x] #15402
- [x] #15443
- [x] #15485
- [ ] #15557

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15161)
<!-- Reviewable:end -->
