### PR TITLE
Use Reviewable's new Bazel syntax highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,5 @@
 # These lines tell reviewable.io how to highlight source code.
-WORKSPACE diff=python
-**/*.bazel diff=python
-**/*.bzl diff=python
+WORKSPACE diff=bazel
 **/*.cps diff=json
 **/site.webmanifest diff=json
 


### PR DESCRIPTION
Per https://github.com/Reviewable/Reviewable/issues/753#issuecomment-858076112.

Here's a screenshot showing the new `drake_cc_library(name = "scene_graph", ...` declaration hint now in effect for Bazel files:

![image](https://user-images.githubusercontent.com/17596505/121427790-f79c7480-c929-11eb-8741-5f65521b1cd8.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15163)
<!-- Reviewable:end -->
