### PR TITLE
Document Drake's dependence on AVX2 and FMA instructions

### DIFF
--- a/doc/_pages/developers.md
+++ b/doc/_pages/developers.md
@@ -79,6 +79,12 @@ supported architecture and running Drake under Rosetta 2 emulation on arm64 is
 not supported. Plans for any future arm64 support on macOS and/or Ubuntu are
 discussed in [issue #13514](https://github.com/RobotLocomotion/drake/issues/13514).
 
+Drake Ubuntu builds assume support for Intel's AVX2 and FMA instructions,
+introduced with the Haswell architecture in 2013 with substantial performance
+improvements in the Broadwell architecture in 2014. Drake is compiled with
+`-march=broadwell` to exploit these instructions (that also works for Haswell
+machines). Drake can be used on older machines if necessary by building from
+source with that flag removed.
 
 ## Configuration Management Non-Determinism
 

--- a/doc/_pages/from_binary.md
+++ b/doc/_pages/from_binary.md
@@ -25,6 +25,13 @@ Note that Drake no longer supports Ubuntu 16.04 (Xenial), but older packages are
 
 Individual packages are archived two years from their date of creation.
 
+Note that for release v0.30.0 and later, Ubuntu binaries require support for
+Intel's AVX2 and FMA instruction sets which were introduced with the Haswell
+architecture in 2013 with substantial performance improvements in the Broadwell
+architecture in 2014. Drake is compiled with `-march=broadwell` to exploit these
+instructions (that also works for Haswell machines). Drake can be used on older
+machines if necessary by building from source with that flag removed.
+
 For the compilers used to produce these releases, see
 [Binary Packages](/developers.html#binary-packages).
 


### PR DESCRIPTION
Document that Drake builds (since v0.30.0) require AVX2 and FMA instruction support.

This does not include detailed instructions for building on pre-2013 machines, but provides enough information for doing so (perhaps with some help from stackoverflow if necessary).

Resolves #15125

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15165)
<!-- Reviewable:end -->
