### PR TITLE
multibody/tree: Clarify that continuous/discrete mode is invariant

### DIFF
--- a/multibody/tree/multibody_tree_system.h
+++ b/multibody/tree/multibody_tree_system.h
@@ -515,8 +515,7 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
                       std::unique_ptr<MultibodyTree<T>> tree,
                       bool is_discrete);
 
-  // Use continuous state variables by default.
-  bool is_discrete_{false};
+  const bool is_discrete_;
 
   std::unique_ptr<drake::multibody::internal::MultibodyTree<T>> tree_;
 


### PR DESCRIPTION
It took me a few minutes to reason out whether or not this could ever change out from under us.  I'm saving the next reader that trouble.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15173)
<!-- Reviewable:end -->
