### PR TITLE
geometry: Remove redundant type annotation for DeclareCacheEntry

### DIFF
--- a/geometry/drake_visualizer.cc
+++ b/geometry/drake_visualizer.cc
@@ -237,7 +237,6 @@ DrakeVisualizer<T>::DrakeVisualizer(lcm::DrakeLcmInterface* lcm,
   // This cache entry depends on *nothing*.
   dynamic_data_cache_index_ =
       this->DeclareCacheEntry("dynamic_frames",
-                              vector<internal::DynamicFrameData>(),
                               &DrakeVisualizer<T>::CalcDynamicFrameData,
                               {this->nothing_ticket()})
           .cache_index();


### PR DESCRIPTION
Discovered as part of #15161 audit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15174)
<!-- Reviewable:end -->
