### PR TITLE
framework: Deprecate port declarations without names

### DIFF
--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -8,6 +8,7 @@
 
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
+#include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/eigen_pybind.h"
 #include "drake/bindings/pydrake/common/wrap_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
@@ -304,14 +305,25 @@ struct Impl {
                 std::optional<RandomDistribution>>(&PySystem::DeclareInputPort),
             py_rvp::reference_internal, py::arg("name"), py::arg("type"),
             py::arg("size"), py::arg("random_type") = std::nullopt,
-            doc.System.DeclareInputPort.doc_4args)
+            doc.System.DeclareInputPort.doc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    system_cls  // BR
         .def("DeclareInputPort",
-            overload_cast_explicit<  // BR
-                InputPort<T>&, PortDataType, int,
-                std::optional<RandomDistribution>>(&PySystem::DeclareInputPort),
+            WrapDeprecated(doc.System.DeclareInputPort.doc_deprecated,
+                [](PySystem* self, PortDataType type, int size,
+                    std::optional<RandomDistribution> random_type) {
+                  auto& result =
+                      self->DeclareInputPort(type, size, random_type);
+                  // WrapDeprecated cannot handle references, but a pointer
+                  // works and is equivalent as far as Python cares.
+                  return &result;
+                }),
             py_rvp::reference_internal, py::arg("type"), py::arg("size"),
-            py::arg("random_type") = std::nullopt)
-        // - Feedthrough.
+            py::arg("random_type") = std::nullopt,
+            doc.System.DeclareInputPort.doc_deprecated);
+#pragma GCC diagnostic pop
+    system_cls  // - Feedthrough.
         .def("HasAnyDirectFeedthrough", &System<T>::HasAnyDirectFeedthrough,
             doc.System.HasAnyDirectFeedthrough.doc)
         .def("HasDirectFeedthrough",
@@ -510,7 +522,7 @@ Note: The above is for the C++ documentation. For Python, use
               return self->DeclareAbstractInputPort(name, model_value);
             },
             py_rvp::reference_internal, py::arg("name"), py::arg("model_value"),
-            doc.LeafSystem.DeclareAbstractInputPort.doc_2args)
+            doc.LeafSystem.DeclareAbstractInputPort.doc)
         .def("DeclareAbstractParameter",
             &PyLeafSystem::DeclareAbstractParameter, py::arg("model_value"),
             doc.LeafSystem.DeclareAbstractParameter.doc)
@@ -528,15 +540,27 @@ Note: The above is for the C++ documentation. For Python, use
             py::arg("prerequisites_of_calc") =
                 std::set<DependencyTicket>{SystemBase::all_sources_ticket()},
             doc.LeafSystem.DeclareAbstractOutputPort
-                .doc_4args_name_alloc_function_calc_function_prerequisites_of_calc)
+                .doc_4args_name_alloc_function_calc_function_prerequisites_of_calc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    leaf_system_cls  // BR
         .def("DeclareAbstractOutputPort",
-            WrapCallbacks([](PyLeafSystem* self, AllocCallback arg1,
-                              CalcCallback arg2) -> const OutputPort<T>& {
-              return self->DeclareAbstractOutputPort(arg1, arg2);
-            }),
+            WrapDeprecated(
+                doc.LeafSystem.DeclareAbstractOutputPort
+                    .doc_deprecated_deprecated_3args_constOutputType_voidMySystemconstContextOutputTypeconst_stdset,
+                WrapCallbacks(
+                    [](PyLeafSystem* self, AllocCallback arg1,
+                        CalcCallback arg2) -> const LeafOutputPort<T>* {
+                      // WrapDeprecated cannot handle references, but a pointer
+                      // works and is equivalent as far as Python cares, thus
+                      // the use of `&` here.
+                      return &self->DeclareAbstractOutputPort(arg1, arg2);
+                    })),
             py_rvp::reference_internal, py::arg("alloc"), py::arg("calc"),
             doc.LeafSystem.DeclareAbstractOutputPort
-                .doc_4args_name_alloc_function_calc_function_prerequisites_of_calc)
+                .doc_deprecated_deprecated_3args_constOutputType_voidMySystemconstContextOutputTypeconst_stdset);
+#pragma GCC diagnostic pop
+    leaf_system_cls  // BR
         .def(
             "DeclareVectorInputPort",
             [](PyLeafSystem* self, std::string name,
@@ -548,7 +572,7 @@ Note: The above is for the C++ documentation. For Python, use
             },
             py_rvp::reference_internal, py::arg("name"),
             py::arg("model_vector"), py::arg("random_type") = std::nullopt,
-            doc.LeafSystem.DeclareVectorInputPort.doc_3args)
+            doc.LeafSystem.DeclareVectorInputPort.doc)
         .def("DeclareVectorOutputPort",
             WrapCallbacks(
                 [](PyLeafSystem* self, const std::string& name,
@@ -562,15 +586,27 @@ Note: The above is for the C++ documentation. For Python, use
             py::arg("prerequisites_of_calc") =
                 std::set<DependencyTicket>{SystemBase::all_sources_ticket()},
             doc.LeafSystem.DeclareVectorOutputPort
-                .doc_4args_name_model_vector_vector_calc_function_prerequisites_of_calc)
+                .doc_4args_name_model_vector_vector_calc_function_prerequisites_of_calc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    leaf_system_cls  // BR
         .def("DeclareVectorOutputPort",
-            WrapCallbacks([](PyLeafSystem* self, const BasicVector<T>& arg1,
-                              CalcVectorCallback arg2) -> const OutputPort<T>& {
-              return self->DeclareVectorOutputPort(arg1, arg2);
-            }),
+            WrapDeprecated(
+                doc.LeafSystem.DeclareVectorOutputPort
+                    .doc_deprecated_deprecated_3args_constBasicVectorSubtype_voidMySystemconstContextBasicVectorSubtypeconst_stdset,
+                WrapCallbacks(
+                    [](PyLeafSystem* self, const BasicVector<T>& arg1,
+                        CalcVectorCallback arg2) -> const OutputPort<T>* {
+                      // WrapDeprecated cannot handle references, but a
+                      // pointer works and is equivalent as far as Python
+                      // cares, thus the use of `&` here.
+                      return &self->DeclareVectorOutputPort(arg1, arg2);
+                    })),
             py_rvp::reference_internal,
             doc.LeafSystem.DeclareVectorOutputPort
-                .doc_4args_name_model_vector_vector_calc_function_prerequisites_of_calc)
+                .doc_deprecated_deprecated_3args_constBasicVectorSubtype_voidMySystemconstContextBasicVectorSubtypeconst_stdset);
+#pragma GCC diagnostic pop
+    leaf_system_cls  // BR
         .def(
             "DeclareInitializationEvent",
             [](PyLeafSystem* self, const Event<T>& event) {

--- a/systems/framework/leaf_system.cc
+++ b/systems/framework/leaf_system.cc
@@ -651,6 +651,7 @@ InputPort<T>& LeafSystem<T>::DeclareAbstractInputPort(
                                 kAbstractValued, 0 /* size */);
 }
 
+// (This function is deprecated.)
 template <typename T>
 InputPort<T>& LeafSystem<T>::DeclareVectorInputPort(
     const BasicVector<T>& model_vector,
@@ -658,6 +659,7 @@ InputPort<T>& LeafSystem<T>::DeclareVectorInputPort(
   return DeclareVectorInputPort(kUseDefaultName, model_vector, random_type);
 }
 
+// (This function is deprecated.)
 template <typename T>
 InputPort<T>& LeafSystem<T>::DeclareAbstractInputPort(
     const AbstractValue& model_value) {
@@ -688,6 +690,7 @@ LeafOutputPort<T>& LeafSystem<T>::DeclareAbstractOutputPort(
   return port;
 }
 
+// (This function is deprecated.)
 template <typename T>
 LeafOutputPort<T>& LeafSystem<T>::DeclareVectorOutputPort(
     const BasicVector<T>& model_vector,
@@ -698,6 +701,7 @@ LeafOutputPort<T>& LeafSystem<T>::DeclareVectorOutputPort(
                                  std::move(prerequisites_of_calc));
 }
 
+// (This function is deprecated.)
 template <typename T>
 LeafOutputPort<T>& LeafSystem<T>::DeclareAbstractOutputPort(
     typename LeafOutputPort<T>::AllocCallback alloc_function,

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -14,6 +14,7 @@
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/unused.h"
 #include "drake/common/value.h"
@@ -1184,23 +1185,17 @@ class LeafSystem : public System<T> {
   //@}
 
   // =========================================================================
-  /** @name          To-be-deprecated input port declarations
+  /** @name             Deprecated input port declarations
   Methods in this section leave out the name parameter and are the same
-  as invoking the corresponding method with `kUseDefaultName` as the name.
-  We intend to make specifying the name required and will deprecate these
-  soon. Don't use them. */
+  as invoking the corresponding method with `kUseDefaultName` as the name. */
   //@{
 
-  /** See the nearly identical signature with an additional (first) argument
-  specifying the port name.  This version will be deprecated as discussed
-  in #9447. */
+  DRAKE_DEPRECATED("2021-10-01", "Pass a port name as the first argument.")
   InputPort<T>& DeclareVectorInputPort(
       const BasicVector<T>& model_vector,
       std::optional<RandomDistribution> random_type = std::nullopt);
 
-  /** See the nearly identical signature with an additional (first) argument
-  specifying the port name.  This version will be deprecated as discussed
-  in #9447. */
+  DRAKE_DEPRECATED("2021-10-01", "Pass a port name as the first argument.")
   InputPort<T>& DeclareAbstractInputPort(
       const AbstractValue& model_value);
   //@}
@@ -1512,17 +1507,13 @@ class LeafSystem : public System<T> {
   //@}
 
   // =========================================================================
-  /** @name          To-be-deprecated output port declarations
+  /** @name             Deprecated output port declarations
   Methods in this section leave out the name parameter and are the same
-  as invoking the corresponding method with `kUseDefaultName` as the name.
-  We intend to make specifying the name required and will deprecate these
-  soon. Don't use them. */
+  as invoking the corresponding method with `kUseDefaultName` as the name. */
   //@{
 
-  /** See the nearly identical signature with an additional (first) argument
-  specifying the port name.  This version will be deprecated as discussed
-  in #9447. */
   template <class MySystem, typename BasicVectorSubtype>
+  DRAKE_DEPRECATED("2021-10-01", "Pass a port name as the first argument.")
   LeafOutputPort<T>& DeclareVectorOutputPort(
       const BasicVectorSubtype& model_vector,
       void (MySystem::*calc)(const Context<T>&, BasicVectorSubtype*) const,
@@ -1532,10 +1523,8 @@ class LeafSystem : public System<T> {
                                    std::move(prerequisites_of_calc));
   }
 
-  /** See the nearly identical signature with an additional (first) argument
-  specifying the port name.  This version will be deprecated as discussed
-  in #9447. */
   template <class MySystem, typename BasicVectorSubtype>
+  DRAKE_DEPRECATED("2021-10-01", "Pass a port name as the first argument.")
   LeafOutputPort<T>& DeclareVectorOutputPort(
       void (MySystem::*calc)(const Context<T>&, BasicVectorSubtype*) const,
       std::set<DependencyTicket> prerequisites_of_calc = {
@@ -1544,21 +1533,15 @@ class LeafSystem : public System<T> {
                                    std::move(prerequisites_of_calc));
   }
 
-  /** See the nearly identical signature with an additional (first) argument
-  specifying the port name.  This version will be deprecated as discussed
-  in #9447. */
+  DRAKE_DEPRECATED("2021-10-01", "Pass a port name as the first argument.")
   LeafOutputPort<T>& DeclareVectorOutputPort(
       const BasicVector<T>& model_vector,
       typename LeafOutputPort<T>::CalcVectorCallback vector_calc_function,
       std::set<DependencyTicket> prerequisites_of_calc = {
           all_sources_ticket()});
 
-  /** See the nearly identical signature with an additional (first) argument
-  specifying the port name.  This version will be deprecated as discussed
-  in #9447. Note that the deprecated method is not available for
-  `OutputType` std::string as that would create an ambiguity. In that
-  case the name is required. */
   template <class MySystem, typename OutputType>
+  DRAKE_DEPRECATED("2021-10-01", "Pass a port name as the first argument.")
   std::enable_if_t<!std::is_same_v<OutputType, std::string>,
                    LeafOutputPort<T>&>
   DeclareAbstractOutputPort(const OutputType& model_value,
@@ -1570,10 +1553,8 @@ class LeafSystem : public System<T> {
                                      std::move(prerequisites_of_calc));
   }
 
-  /** See the nearly identical signature with an additional (first) argument
-  specifying the port name.  This version will be deprecated as discussed
-  in #9447. */
   template <class MySystem, typename OutputType>
+  DRAKE_DEPRECATED("2021-10-01", "Pass a port name as the first argument.")
   LeafOutputPort<T>& DeclareAbstractOutputPort(
       void (MySystem::*calc)(const Context<T>&, OutputType*) const,
       std::set<DependencyTicket> prerequisites_of_calc = {
@@ -1582,10 +1563,8 @@ class LeafSystem : public System<T> {
         kUseDefaultName, calc, std::move(prerequisites_of_calc));
   }
 
-  /** See the nearly identical signature with an additional (first) argument
-  specifying the port name.  This version will be deprecated as discussed
-  in #9447. */
   template <class MySystem, typename OutputType>
+  DRAKE_DEPRECATED("2021-10-01", "Pass a port name as the first argument.")
   LeafOutputPort<T>& DeclareAbstractOutputPort(
       OutputType (MySystem::*make)() const,
       void (MySystem::*calc)(const Context<T>&, OutputType*) const,
@@ -1595,9 +1574,7 @@ class LeafSystem : public System<T> {
                                      std::move(prerequisites_of_calc));
   }
 
-  /** See the nearly identical signature with an additional (first) argument
-  specifying the port name.  This version will be deprecated as discussed
-  in #9447. */
+  DRAKE_DEPRECATED("2021-10-01", "Pass a port name as the first argument.")
   LeafOutputPort<T>& DeclareAbstractOutputPort(
       typename LeafOutputPort<T>::AllocCallback alloc_function,
       typename LeafOutputPort<T>::CalcCallback calc_function,

--- a/systems/framework/system.cc
+++ b/systems/framework/system.cc
@@ -975,6 +975,7 @@ InputPort<T>& System<T>::DeclareInputPort(
   return *port_ptr;
 }
 
+// (This function is deprecated.)
 template <typename T>
 InputPort<T>& System<T>::DeclareInputPort(
     PortDataType type, int size,

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -18,6 +18,7 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_bool.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/nice_type_name.h"
 #include "drake/common/pointer_cast.h"
@@ -1382,16 +1383,14 @@ class System : public SystemBase {
   //@}
 
   // =========================================================================
-  /** @name             To-be-deprecated declarations
+  /** @name                Deprecated declarations
   Methods in this section leave out the port name parameter and are the same
   as invoking the corresponding method with `kUseDefaultName` as the name.
   We intend to make specifying the name required and will deprecate these
   soon. Don't use them. */
   //@{
 
-  /** See the nearly identical signature with an additional (first) argument
-  specifying the port name.  This version will be deprecated as discussed
-  in #9447. */
+  DRAKE_DEPRECATED("2021-10-01", "Pass a port name as the first argument.")
   InputPort<T>& DeclareInputPort(
       PortDataType type, int size,
       std::optional<RandomDistribution> random_type = std::nullopt);

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -420,7 +420,8 @@ TEST_F(SystemTest, ExactlyOnePortConvenience) {
 }
 
 TEST_F(SystemTest, PortNameTest) {
-  const auto& unnamed_input = system_.DeclareInputPort(kVectorValued, 2);
+  const auto& unnamed_input =
+      system_.DeclareInputPort(kUseDefaultName, kVectorValued, 2);
   const auto& named_input =
       system_.DeclareInputPort("my_input", kVectorValued, 3);
   const auto& named_abstract_input =
@@ -615,7 +616,7 @@ class ValueIOTestSystem : public TestSystemBase<T> {
             [this](const ContextBase& context, AbstractValue* output) {
               this->CalcStringOutput(context, output);
             })));
-    this->DeclareInputPort(kVectorValued, 1);
+    this->DeclareInputPort(kUseDefaultName, kVectorValued, 1);
     this->DeclareInputPort("uniform", kVectorValued, 1,
                            RandomDistribution::kUniform);
     this->DeclareInputPort("gaussian", kVectorValued, 1,


### PR DESCRIPTION
When declaring an input or output port, users should pass a name as the first argument, or else say kUseDefaultName to default to u0, u1, ... or y0, y1, ... respectively.  The overloads that skipped the name are now deprecated.  This change was forewarned in the API documentation.

Closes #9447.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15179)
<!-- Reviewable:end -->
