### PR TITLE
[framework] Enable context validation for ports in Release builds

### DIFF
--- a/systems/framework/cache_entry.h
+++ b/systems/framework/cache_entry.h
@@ -260,6 +260,7 @@ class CacheEntry {
   all circumstances. */
   const CacheEntryValue& get_cache_entry_value(
       const ContextBase& context) const {
+    DRAKE_ASSERT_VOID(owning_system_->ValidateContext(context));
     return context.get_cache().get_cache_entry_value(cache_index_);
   }
 
@@ -270,6 +271,7 @@ class CacheEntry {
   all circumstances. */
   CacheEntryValue& get_mutable_cache_entry_value(
       const ContextBase& context) const {
+    DRAKE_ASSERT_VOID(owning_system_->ValidateContext(context));
     return context.get_mutable_cache().get_mutable_cache_entry_value(
         cache_index_);
   }

--- a/systems/framework/diagram.cc
+++ b/systems/framework/diagram.cc
@@ -1533,6 +1533,7 @@ void Diagram<T>::ExportOutput(const OutputPortLocator& port, std::string name) {
   auto diagram_port = internal::FrameworkFactory::Make<DiagramOutputPort<T>>(
       this,  // implicit_cast<const System<T>*>(this)
       this,  // implicit_cast<SystemBase*>(this)
+      this->get_system_id(),
       std::move(name), OutputPortIndex(this->num_output_ports()),
       this->assign_next_dependency_ticket(), &source_output_port,
       GetSystemIndexOrAbort(&source_output_port.get_system()));

--- a/systems/framework/diagram_output_port.h
+++ b/systems/framework/diagram_output_port.h
@@ -46,6 +46,7 @@ class DiagramOutputPort final : public OutputPort<T> {
   //
   // @param diagram The Diagram that will own this port.
   // @param system_interface The same Diagram cast to its base class.
+  // @param system_id The ID of the same Diagram.
   // @param name A name for the port.  Output ports names must be unique
   //     within the `diagram` System.
   // @param index The output port index to be assigned to the new port.
@@ -71,13 +72,14 @@ class DiagramOutputPort final : public OutputPort<T> {
   // the caller to do that cast for us so take a System<T> here.
   DiagramOutputPort(const System<T>* diagram,
                     internal::SystemMessageInterface* system_interface,
+                    internal::SystemId system_id,
                     std::string name,
                     OutputPortIndex index,
                     DependencyTicket ticket,
                     const OutputPort<T>* source_output_port,
                     SubsystemIndex source_subsystem_index)
-      : OutputPort<T>(diagram, system_interface, std::move(name), index, ticket,
-                      source_output_port->get_data_type(),
+      : OutputPort<T>(diagram, system_interface, system_id, std::move(name),
+                      index, ticket, source_output_port->get_data_type(),
                       source_output_port->size()),
         source_output_port_(source_output_port),
         source_subsystem_index_(source_subsystem_index) {

--- a/systems/framework/input_port_base.cc
+++ b/systems/framework/input_port_base.cc
@@ -11,13 +11,14 @@ namespace drake {
 namespace systems {
 
 InputPortBase::InputPortBase(
-    internal::SystemMessageInterface* owning_system, std::string name,
+    internal::SystemMessageInterface* owning_system,
+    internal::SystemId owning_system_id, std::string name,
     InputPortIndex index, DependencyTicket ticket,
     PortDataType data_type, int size,
     const std::optional<RandomDistribution>& random_type,
     EvalAbstractCallback eval)
-    : PortBase("Input", owning_system, std::move(name), index, ticket,
-               data_type, size),
+    : PortBase("Input", owning_system, owning_system_id, std::move(name),
+               index, ticket, data_type, size),
       eval_(std::move(eval)),
       random_type_(random_type) {
   if (is_random() && data_type != kVectorValued) {

--- a/systems/framework/input_port_base.h
+++ b/systems/framework/input_port_base.h
@@ -56,6 +56,8 @@ class InputPortBase : public PortBase {
 
   @param owning_system
     The System that owns this input port.
+  @param owning_system_id
+    The ID of owning_system.
   @param name
     A name for the port. Input port names should be non-empty and unique
     within a single System.
@@ -72,7 +74,8 @@ class InputPortBase : public PortBase {
     Input ports may optionally be labeled as random, if the port is intended to
     model a random-source "noise" or "disturbance" input. */
   InputPortBase(
-      internal::SystemMessageInterface* owning_system, std::string name,
+      internal::SystemMessageInterface* owning_system,
+      internal::SystemId owning_system_id, std::string name,
       InputPortIndex index, DependencyTicket ticket, PortDataType data_type,
       int size, const std::optional<RandomDistribution>& random_type,
       EvalAbstractCallback eval);

--- a/systems/framework/leaf_output_port.h
+++ b/systems/framework/leaf_output_port.h
@@ -73,11 +73,12 @@ class LeafOutputPort final : public OutputPort<T> {
   // object as the `system_interface` parameter.
   LeafOutputPort(const System<T>* system,
                  internal::SystemMessageInterface* system_interface,
+                 internal::SystemId system_id,
                  std::string name, OutputPortIndex index,
                  DependencyTicket ticket, PortDataType data_type, int size,
                  CacheEntry* cache_entry)
-      : OutputPort<T>(system, system_interface, std::move(name), index, ticket,
-                      data_type, size),
+      : OutputPort<T>(system, system_interface, system_id, std::move(name),
+                      index, ticket, data_type, size),
         cache_entry_(cache_entry) {
     DRAKE_DEMAND(cache_entry != nullptr);
   }

--- a/systems/framework/leaf_system.cc
+++ b/systems/framework/leaf_system.cc
@@ -963,6 +963,7 @@ LeafOutputPort<T>& LeafSystem<T>::CreateCachedLeafOutputPort(
   auto port = internal::FrameworkFactory::Make<LeafOutputPort<T>>(
       this,  // implicit_cast<const System<T>*>(this)
       this,  // implicit_cast<const SystemBase*>(this)
+      this->get_system_id(),
       std::move(name),
       oport_index, this->assign_next_dependency_ticket(),
       fixed_size.has_value() ? kVectorValued : kAbstractValued,

--- a/systems/framework/output_port.h
+++ b/systems/framework/output_port.h
@@ -106,7 +106,7 @@ class OutputPort : public OutputPortBase {
   template <typename ValueType, typename = std::enable_if_t<
       std::is_same_v<AbstractValue, ValueType>>>
   const AbstractValue& Eval(const Context<T>& context) const {
-    DRAKE_ASSERT_VOID(get_system_interface().ValidateContext(context));
+    ValidateSystemId(context.get_system_id());
     return DoEval(context);
   }
   // With anything but a BasicVector subclass, we can just DoEval then cast.
@@ -115,7 +115,7 @@ class OutputPort : public OutputPortBase {
         !std::is_base_of_v<BasicVector<T>, ValueType> ||
         std::is_same_v<BasicVector<T>, ValueType>)>>
   const ValueType& Eval(const Context<T>& context) const {
-    DRAKE_ASSERT_VOID(get_system_interface().ValidateContext(context));
+    ValidateSystemId(context.get_system_id());
     return PortEvalCast<ValueType>(DoEval(context));
   }
   // With a BasicVector subclass, we need to downcast twice.
@@ -154,7 +154,7 @@ class OutputPort : public OutputPortBase {
   the Allocate() method. */
   void Calc(const Context<T>& context, AbstractValue* value) const {
     DRAKE_DEMAND(value != nullptr);
-    DRAKE_ASSERT_VOID(get_system_interface().ValidateContext(context));
+    ValidateSystemId(context.get_system_id());
     DRAKE_ASSERT_VOID(ThrowIfInvalidPortValueType(context, *value));
     DoCalc(context, value);
   }
@@ -186,10 +186,11 @@ class OutputPort : public OutputPortBase {
   // access to System's declaration here so can't cast but the caller can.
   OutputPort(const System<T>* system,
              internal::SystemMessageInterface* system_interface,
-             std::string name, OutputPortIndex index, DependencyTicket ticket,
+             internal::SystemId system_id, std::string name,
+             OutputPortIndex index, DependencyTicket ticket,
              PortDataType data_type, int size)
-      : OutputPortBase(system_interface, std::move(name), index, ticket,
-                       data_type, size),
+      : OutputPortBase(system_interface, system_id, std::move(name), index,
+                       ticket, data_type, size),
         system_{*system} {
     // Check the precondition on identical parameters; note that comparing as
     // void* is only valid because we have single inheritance.

--- a/systems/framework/output_port_base.cc
+++ b/systems/framework/output_port_base.cc
@@ -6,11 +6,12 @@ namespace drake {
 namespace systems {
 
 OutputPortBase::OutputPortBase(
-    internal::SystemMessageInterface* owning_system, std::string name,
+    internal::SystemMessageInterface* owning_system,
+    internal::SystemId owning_system_id, std::string name,
     OutputPortIndex index, DependencyTicket ticket, PortDataType data_type,
     int size)
-    : PortBase("Output", owning_system, std::move(name), index, ticket,
-               data_type, size) {}
+    : PortBase("Output", owning_system, owning_system_id, std::move(name),
+               index, ticket, data_type, size) {}
 
 OutputPortBase::~OutputPortBase() = default;
 

--- a/systems/framework/output_port_base.h
+++ b/systems/framework/output_port_base.h
@@ -46,6 +46,8 @@ class OutputPortBase : public PortBase {
 
   @param owning_system
     The System that owns this output port.
+  @param owning_system_id
+    The ID of owning_system.
   @param name
     A name for the port. Must not be empty. Output port names should be unique
     within a single System.
@@ -59,7 +61,8 @@ class OutputPortBase : public PortBase {
     If the port described is vector-valued, the number of elements expected,
     otherwise ignored. */
   OutputPortBase(
-      internal::SystemMessageInterface* owning_system, std::string name,
+      internal::SystemMessageInterface* owning_system,
+      internal::SystemId owning_system_id, std::string name,
       OutputPortIndex index, DependencyTicket ticket, PortDataType data_type,
       int size);
 

--- a/systems/framework/port_base.cc
+++ b/systems/framework/port_base.cc
@@ -12,10 +12,11 @@ namespace systems {
 
 PortBase::PortBase(
     const char* kind_string, internal::SystemMessageInterface* owning_system,
-    std::string name, int index, DependencyTicket ticket,
-    PortDataType data_type, int size)
+    internal::SystemId owning_system_id, std::string name, int index,
+    DependencyTicket ticket, PortDataType data_type, int size)
     : kind_string_(kind_string),
       owning_system_(*owning_system),
+      owning_system_id_(owning_system_id),
       index_(index),
       ticket_(ticket),
       data_type_(data_type),
@@ -23,6 +24,7 @@ PortBase::PortBase(
       name_(std::move(name)) {
   DRAKE_DEMAND(kind_string != nullptr);
   DRAKE_DEMAND(owning_system != nullptr);
+  DRAKE_DEMAND(owning_system_id.is_valid());
   DRAKE_DEMAND(!name_.empty());
 }
 
@@ -33,6 +35,12 @@ std::string PortBase::GetFullDescription() const {
       "{}Port[{}] ({}) of System {} ({})",
       kind_string_, index_, name_, get_system_interface().GetSystemPathname(),
       NiceTypeName::RemoveNamespaces(get_system_interface().GetSystemType()));
+}
+
+void PortBase::ThrowValidateContextMismatch() const {
+  throw std::logic_error(fmt::format(
+      "{}Port: The Context given as an argument was not created for this {}",
+      kind_string_, GetFullDescription()));
 }
 
 void PortBase::ThrowBadCast(

--- a/systems/framework/system.cc
+++ b/systems/framework/system.cc
@@ -968,8 +968,8 @@ InputPort<T>& System<T>::DeclareInputPort(
     return this->EvalAbstractInput(context_base, port_index);
   };
   auto port = internal::FrameworkFactory::Make<InputPort<T>>(
-      this, this, NextInputPortName(std::move(name)), port_index, port_ticket,
-      type, size, random_type, std::move(eval));
+      this, this, get_system_id(), NextInputPortName(std::move(name)),
+      port_index, port_ticket, type, size, random_type, std::move(eval));
   InputPort<T>* port_ptr = port.get();
   this->AddInputPort(std::move(port));
   return *port_ptr;

--- a/systems/framework/test/output_port_test.cc
+++ b/systems/framework/test/output_port_test.cc
@@ -37,6 +37,7 @@ class DummySystem : public LeafSystem<double> {
   DummySystem() {}
   ~DummySystem() override {}
   using SystemBase::assign_next_dependency_ticket;
+  using SystemBase::get_system_id;
 };
 
 // The only concrete output ports we expect to encounter are LeafOutputPort
@@ -45,19 +46,17 @@ class DummySystem : public LeafSystem<double> {
 // introduce errors.
 class MyOutputPort : public OutputPort<double> {
  public:
-  MyOutputPort(const System<double>* diagram,
-               internal::SystemMessageInterface* system_interface,
-               OutputPortIndex index, DependencyTicket ticket)
-      : OutputPort<double>(diagram, system_interface, "my_output", index,
-                            ticket, kVectorValued, 2) {}
+  MyOutputPort(DummySystem* dummy, OutputPortIndex index,
+               DependencyTicket ticket)
+      : OutputPort<double>(dummy, dummy, dummy->get_system_id(),
+                           "my_output", index, ticket, kVectorValued, 2) {}
 
   std::unique_ptr<AbstractValue> DoAllocate() const override {
     return AbstractValue::Make<BasicVector<double>>(
         MyVector2d(Vector2d(1., 2.)));
   }
 
-  void DoCalc(const Context<double>& diagram_context,
-              AbstractValue* value) const override {
+  void DoCalc(const Context<double>&, AbstractValue* value) const override {
     EXPECT_NE(value, nullptr);
     DRAKE_EXPECT_NO_THROW(
         value->set_value<BasicVector<double>>(MyVector2d(Vector2d(3., 4.))));
@@ -76,7 +75,7 @@ class MyOutputPort : public OutputPort<double> {
   }
 
   void ThrowIfInvalidPortValueType(
-      const Context<double>& context,
+      const Context<double>&,
       const AbstractValue& proposed_value) const final {
     // Note: this is a very expensive way to check -- fine for this test
     // case (which has no alternative) but don't copy into real code!
@@ -126,12 +125,12 @@ class MyNullAllocatorPort : public MyOutputPort {
 // or (b) implementation changes to existing ports or error handling in caching.
 GTEST_TEST(TestBaseClass, BadAllocators) {
   DummySystem dummy;
-  MyStringAllocatorPort string_allocator{&dummy, &dummy, OutputPortIndex(0),
+  MyStringAllocatorPort string_allocator{&dummy, OutputPortIndex(0),
                                          dummy.assign_next_dependency_ticket()};
   MyBadSizeAllocatorPort bad_size_allocator{
-      &dummy, &dummy, OutputPortIndex(1),
+      &dummy, OutputPortIndex(1),
       dummy.assign_next_dependency_ticket()};
-  MyNullAllocatorPort null_allocator{&dummy, &dummy, OutputPortIndex(2),
+  MyNullAllocatorPort null_allocator{&dummy, OutputPortIndex(2),
                                      dummy.assign_next_dependency_ticket()};
 
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(
@@ -152,7 +151,7 @@ GTEST_TEST(TestBaseClass, BadAllocators) {
 // This message can be caused by user action.
 GTEST_TEST(TestBaseClass, BadOutputType) {
   DummySystem dummy;
-  MyOutputPort port{&dummy, &dummy, OutputPortIndex(0),
+  MyOutputPort port{&dummy, OutputPortIndex(0),
                     dummy.assign_next_dependency_ticket()};
   auto context = dummy.AllocateContext();
   auto good_port_value = port.Allocate();
@@ -212,6 +211,7 @@ class LeafOutputPortTest : public ::testing::Test {
       internal::FrameworkFactory::Make<LeafOutputPort<double>>(
           &dummy_,  // implicit_cast<const System<T>*>(&dummy_)
           &dummy_,  // implicit_cast<SystemBase*>(&dummy_)
+          dummy_.get_system_id(),
           "absport",
           OutputPortIndex(dummy_.num_output_ports()),
           dummy_.assign_next_dependency_ticket(), kAbstractValued, 0 /* size */,
@@ -222,6 +222,7 @@ class LeafOutputPortTest : public ::testing::Test {
       internal::FrameworkFactory::Make<LeafOutputPort<double>>(
           &dummy_,  // implicit_cast<const System<T>*>(&dummy_)
           &dummy_,  // implicit_cast<SystemBase*>(&dummy_)
+          dummy_.get_system_id(),
           "vecport",
           OutputPortIndex(dummy_.num_output_ports()),
           dummy_.assign_next_dependency_ticket(), kVectorValued, 3 /* size */,
@@ -324,6 +325,7 @@ TEST_F(LeafOutputPortTest, ThrowIfNullAlloc) {
   auto null_port = internal::FrameworkFactory::Make<LeafOutputPort<double>>(
       &dummy_,  // implicit_cast<const System<T>*>(&dummy_)
       &dummy_,  // implicit_cast<SystemBase*>(&dummy_),
+      dummy_.get_system_id(),
       "null_port",
       OutputPortIndex(dummy_.num_output_ports()),
       dummy_.assign_next_dependency_ticket(),
@@ -427,6 +429,14 @@ GTEST_TEST(DiagramOutputPortTest, OneLevel) {
   out1.Calc(*context, value1.get());
   EXPECT_EQ(*int0, 1);  // Make sure we got the right Context.
   EXPECT_EQ(*int1, 2);
+
+  // When given an inapproprate context, we fail-fast.
+  const auto& diagram_context = dynamic_cast<DiagramContext<double>&>(*context);
+  const auto& sys1_context = diagram_context.GetSubsystemContext(
+      SubsystemIndex{0});
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      out0.Eval<int>(sys1_context), std::exception,
+      ".*Context.*was not created for this OutputPort.*");
 }
 
 GTEST_TEST(DiagramOutputPortTest, Nested) {

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -184,6 +184,7 @@ class TestSystem : public TestSystemBase<double> {
     auto port = internal::FrameworkFactory::Make<LeafOutputPort<double>>(
         this,  // implicit_cast<const System<T>*>(this)
         this,  // implicit_cast<const SystemBase*>(this)
+        this->get_system_id(),
         "y" + std::to_string(num_output_ports()),
         OutputPortIndex(this->num_output_ports()),
         assign_next_dependency_ticket(),
@@ -605,6 +606,7 @@ class ValueIOTestSystem : public TestSystemBase<T> {
     this->AddOutputPort(internal::FrameworkFactory::Make<LeafOutputPort<T>>(
         this,  // implicit_cast<const System<T>*>(this)
         this,  // implicit_cast<const SystemBase*>(this)
+        this->get_system_id(),
         "absport",
         OutputPortIndex(this->num_output_ports()),
         this->assign_next_dependency_ticket(),
@@ -623,6 +625,7 @@ class ValueIOTestSystem : public TestSystemBase<T> {
     this->AddOutputPort(internal::FrameworkFactory::Make<LeafOutputPort<T>>(
         this,  // implicit_cast<const System<T>*>(this)
         this,  // implicit_cast<const SystemBase*>(this)
+        this->get_system_id(),
         "vecport",
         OutputPortIndex(this->num_output_ports()),
         this->assign_next_dependency_ticket(),


### PR DESCRIPTION
Doing this without eating a virtual function call means that we need to pass the SystemId into the Port objects so that they can perform the guard locally, without asking SystemMessageInterface.

Add some Debug-only context validation checks to CacheEntry, to help backstop the rare cases where a user might be evaluating their cache entry without first checking the Context they were given.

Closes #15177.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15181)
<!-- Reviewable:end -->
