### PR TITLE
Use kDefaultPortName throughout

### DIFF
--- a/bindings/pydrake/systems/test/pyplot_visualizer_test.py
+++ b/bindings/pydrake/systems/test/pyplot_visualizer_test.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from pydrake.systems.analysis import Simulator
 from pydrake.systems.framework import (
-    Context, DiagramBuilder, PortDataType, VectorSystem)
+    Context, DiagramBuilder, PortDataType, VectorSystem, kUseDefaultName)
 from pydrake.systems.primitives import SignalLogger
 from pydrake.systems.pyplot_visualizer import PyPlotVisualizer
 from pydrake.trajectories import PiecewisePolynomial
@@ -24,7 +24,8 @@ class TestVisualizer(PyPlotVisualizer):
 
     def __init__(self, size):
         PyPlotVisualizer.__init__(self)
-        self.DeclareInputPort(PortDataType.kVectorValued, size)
+        self.DeclareInputPort(kUseDefaultName, PortDataType.kVectorValued,
+                              size)
 
         self.ax.set_xlim(*self.XLIM)
         self.ax.set_ylim(*self.YLIM)

--- a/examples/allegro_hand/allegro_lcm.cc
+++ b/examples/allegro_hand/allegro_lcm.cc
@@ -22,11 +22,13 @@ AllegroCommandReceiver::AllegroCommandReceiver(int num_joints,
       systems::kUseDefaultName,
       Value<lcmt_allegro_command>{});
   state_output_port_ = this->DeclareVectorOutputPort(
+      systems::kUseDefaultName,
       systems::BasicVector<double>(num_joints_ * 2),
       [this](const Context<double>& c, BasicVector<double>* o) {
         this->CopyStateToOutput(c, 0, num_joints_ * 2, o);
       }).get_index();
   torque_output_port_ = this->DeclareVectorOutputPort(
+      systems::kUseDefaultName,
       systems::BasicVector<double>(num_joints_),
       [this](const Context<double>& c, BasicVector<double>* o) {
         this->CopyStateToOutput(c, num_joints_ * 2, num_joints_, o);
@@ -91,15 +93,19 @@ AllegroStatusSender::AllegroStatusSender(int num_joints)
     : num_joints_(num_joints) {
   // Commanded state.
   command_input_port_ = this->DeclareInputPort(
-                        systems::kVectorValued, num_joints_ * 2).get_index();
+      systems::kUseDefaultName, systems::kVectorValued, num_joints_ * 2)
+          .get_index();
   // Measured state.
   state_input_port_ = this->DeclareInputPort(
-                      systems::kVectorValued, num_joints_ * 2).get_index();
+      systems::kUseDefaultName, systems::kVectorValued, num_joints_ * 2)
+          .get_index();
   // Commanded torque.
   command_torque_input_port_ = this->DeclareInputPort(
-                              systems::kVectorValued, num_joints_).get_index();
+      systems::kUseDefaultName, systems::kVectorValued, num_joints_)
+          .get_index();
 
-  this->DeclareAbstractOutputPort(&AllegroStatusSender::MakeOutputStatus,
+  this->DeclareAbstractOutputPort(systems::kUseDefaultName,
+                                  &AllegroStatusSender::MakeOutputStatus,
                                   &AllegroStatusSender::OutputStatus);
 }
 

--- a/examples/bead_on_a_wire/bead_on_a_wire.cc
+++ b/examples/bead_on_a_wire/bead_on_a_wire.cc
@@ -13,13 +13,15 @@ template <typename T>
 BeadOnAWire<T>::BeadOnAWire(BeadOnAWire<T>::CoordinateType type) {
   if (type == BeadOnAWire<T>::kMinimalCoordinates) {
     this->DeclareContinuousState(1, 1, 0);
-    this->DeclareInputPort(systems::kVectorValued, 1);
-    this->DeclareVectorOutputPort(systems::BasicVector<T>(2),
+    this->DeclareInputPort(systems::kUseDefaultName, systems::kVectorValued, 1);
+    this->DeclareVectorOutputPort(systems::kUseDefaultName,
+                                  systems::BasicVector<T>(2),
                                   &BeadOnAWire::CopyStateOut);
   } else {
     this->DeclareContinuousState(3, 3, 0);
-    this->DeclareInputPort(systems::kVectorValued, 3);
-    this->DeclareVectorOutputPort(systems::BasicVector<T>(6),
+    this->DeclareInputPort(systems::kUseDefaultName, systems::kVectorValued, 3);
+    this->DeclareVectorOutputPort(systems::kUseDefaultName,
+                                  systems::BasicVector<T>(6),
                                   &BeadOnAWire::CopyStateOut);
   }
   coordinate_type_ = type;

--- a/examples/bouncing_ball/bouncing_ball.h
+++ b/examples/bouncing_ball/bouncing_ball.h
@@ -32,7 +32,8 @@ class BouncingBall final : public systems::LeafSystem<T> {
     this->DeclareContinuousState(1, 1, 0);
 
     // The state of the system is output.
-    this->DeclareVectorOutputPort(systems::BasicVector<T>(2),
+    this->DeclareVectorOutputPort(systems::kUseDefaultName,
+                                  systems::BasicVector<T>(2),
                                   &BouncingBall::CopyStateOut);
 
     // Declare the witness function.

--- a/examples/kuka_iiwa_arm/kuka_torque_controller.cc
+++ b/examples/kuka_iiwa_arm/kuka_torque_controller.cc
@@ -35,8 +35,9 @@ class StateDependentDamper : public LeafSystem<T> {
     DRAKE_DEMAND(stiffness.size() == num_v);
     DRAKE_DEMAND(damping_ratio.size() == num_v);
 
-    this->DeclareInputPort(kVectorValued, num_x);
-    this->DeclareVectorOutputPort(BasicVector<T>(num_v),
+    this->DeclareInputPort(systems::kUseDefaultName, kVectorValued, num_x);
+    this->DeclareVectorOutputPort(systems::kUseDefaultName,
+                                  BasicVector<T>(num_v),
                                   &StateDependentDamper<T>::CalcTorque);
     // Make context with default parameters.
     plant_context_ = plant_.CreateDefaultContext();

--- a/examples/mass_spring_cloth/cloth_spring_model.cc
+++ b/examples/mass_spring_cloth/cloth_spring_model.cc
@@ -32,7 +32,8 @@ ClothSpringModel<T>::ClothSpringModel(int nx, int ny, T h, double dt)
     this->DeclareContinuousState(initial_state, 3 * num_particles_,
                                  3 * num_particles_, 0);
     // A 3*N dimensional output vector for positions.
-    this->DeclareVectorOutputPort(systems::BasicVector<T>(3 * num_particles_),
+    this->DeclareVectorOutputPort(systems::kUseDefaultName,
+                                  systems::BasicVector<T>(3 * num_particles_),
                                   &ClothSpringModel::CopyContinuousStateOut);
   }
   param_index_ = this->DeclareNumericParameter(ClothSpringModelParams<T>());

--- a/examples/particles/particle.cc
+++ b/examples/particles/particle.cc
@@ -7,11 +7,12 @@ namespace particles {
 template <typename T>
 Particle<T>::Particle() {
   // A 1D input vector for acceleration.
-  this->DeclareInputPort(systems::kVectorValued, 1);
+  this->DeclareInputPort(systems::kUseDefaultName, systems::kVectorValued, 1);
   // Adding one generalized position and one generalized velocity.
   this->DeclareContinuousState(1, 1, 0);
   // A 2D output vector for position and velocity.
-  this->DeclareVectorOutputPort(systems::BasicVector<T>(2),
+  this->DeclareVectorOutputPort(systems::kUseDefaultName,
+                                systems::BasicVector<T>(2),
                                 &Particle::CopyStateOut);
 }
 

--- a/examples/pendulum/energy_shaping_simulation.cc
+++ b/examples/pendulum/energy_shaping_simulation.cc
@@ -24,8 +24,8 @@ template <typename T>
 class PendulumEnergyShapingController : public systems::LeafSystem<T> {
  public:
   explicit PendulumEnergyShapingController(const PendulumParams<T>& params) {
-    this->DeclareVectorInputPort(PendulumState<T>());
-    this->DeclareVectorOutputPort(PendulumInput<T>(),
+    this->DeclareVectorInputPort(systems::kUseDefaultName, PendulumState<T>());
+    this->DeclareVectorOutputPort(systems::kUseDefaultName, PendulumInput<T>(),
                                   &PendulumEnergyShapingController::CalcTau);
     this->DeclareNumericParameter(params);
   }

--- a/examples/planar_gripper/planar_manipuland_lcm.cc
+++ b/examples/planar_gripper/planar_manipuland_lcm.cc
@@ -4,7 +4,8 @@ namespace drake {
 namespace examples {
 namespace planar_gripper {
 PlanarManipulandStatusDecoder::PlanarManipulandStatusDecoder() {
-  this->DeclareVectorOutputPort(systems::BasicVector<double>(6),
+  this->DeclareVectorOutputPort(systems::kUseDefaultName,
+                                systems::BasicVector<double>(6),
                                 &PlanarManipulandStatusDecoder::OutputStatus);
   this->DeclareAbstractInputPort("manipuland_state",
                                  Value<lcmt_planar_manipuland_status>{});
@@ -46,8 +47,9 @@ void PlanarManipulandStatusDecoder::OutputStatus(
 }
 
 PlanarManipulandStatusEncoder::PlanarManipulandStatusEncoder() {
-  this->DeclareInputPort(systems::kVectorValued, 6);
+  this->DeclareInputPort(systems::kUseDefaultName, systems::kVectorValued, 6);
   this->DeclareAbstractOutputPort(
+      systems::kUseDefaultName,
       &PlanarManipulandStatusEncoder::MakeOutputStatus,
       &PlanarManipulandStatusEncoder::OutputStatus);
 }

--- a/examples/rimless_wheel/rimless_wheel.cc
+++ b/examples/rimless_wheel/rimless_wheel.cc
@@ -21,11 +21,13 @@ RimlessWheel<T>::RimlessWheel()
   this->DeclareAbstractState(Value<bool>(double_support));
 
   // The minimal state of the system.
-  this->DeclareVectorOutputPort(RimlessWheelContinuousState<T>(),
+  this->DeclareVectorOutputPort(systems::kUseDefaultName,
+                                RimlessWheelContinuousState<T>(),
                                 &RimlessWheel::MinimalStateOut);
 
   // The floating-base (RPY) state of the system (useful for visualization).
-  this->DeclareVectorOutputPort(systems::BasicVector<T>(12),
+  this->DeclareVectorOutputPort(systems::kUseDefaultName,
+                                systems::BasicVector<T>(12),
                                 &RimlessWheel::FloatingBaseStateOut);
 
   this->DeclareNumericParameter(RimlessWheelParams<T>());

--- a/examples/rod2d/rod2d.cc
+++ b/examples/rod2d/rod2d.cc
@@ -45,7 +45,7 @@ Rod2D<T>::Rod2D(SystemType system_type, double dt)
   // TODO(edrumwri): When type is SystemType::kPiecewiseDAE, allocate the
   // abstract mode variables.
 
-  this->DeclareInputPort(systems::kVectorValued, 3);
+  this->DeclareInputPort(systems::kUseDefaultName, systems::kVectorValued, 3);
   state_output_port_ = &this->DeclareVectorOutputPort(
       "state_output", systems::BasicVector<T>(6), &Rod2D::CopyStateOut);
 }

--- a/examples/scene_graph/bouncing_ball_plant.cc
+++ b/examples/scene_graph/bouncing_ball_plant.cc
@@ -44,7 +44,8 @@ BouncingBallPlant<T>::BouncingBallPlant(SourceId source_id,
       systems::kUseDefaultName, Value<geometry::QueryObject<T>>{})
           .get_index();
   state_port_ =
-      this->DeclareVectorOutputPort(BouncingBallVector<T>(),
+      this->DeclareVectorOutputPort(systems::kUseDefaultName,
+                                    BouncingBallVector<T>(),
                                     &BouncingBallPlant::CopyStateToOutput,
                                     {this->all_state_ticket()})
           .get_index();
@@ -72,6 +73,7 @@ BouncingBallPlant<T>::BouncingBallPlant(SourceId source_id,
 
   // Allocate the output port now that the frame has been registered.
   geometry_pose_port_ = this->DeclareAbstractOutputPort(
+          systems::kUseDefaultName,
           &BouncingBallPlant::CalcFramePoseOutput,
           {this->configuration_ticket()})
       .get_index();

--- a/examples/scene_graph/solar_system.cc
+++ b/examples/scene_graph/solar_system.cc
@@ -68,7 +68,8 @@ SolarSystem<T>::SolarSystem(SceneGraph<T>* scene_graph) {
 
   // Now that frames have been registered, allocate the output port.
   geometry_pose_port_ =
-      this->DeclareAbstractOutputPort(&SolarSystem::CalcFramePoseOutput,
+      this->DeclareAbstractOutputPort(systems::kUseDefaultName,
+                                      &SolarSystem::CalcFramePoseOutput,
                                       {this->configuration_ticket()})
           .get_index();
 }

--- a/examples/van_der_pol/van_der_pol.cc
+++ b/examples/van_der_pol/van_der_pol.cc
@@ -18,11 +18,13 @@ VanDerPolOscillator<T>::VanDerPolOscillator()
   this->DeclareContinuousState(1, 1, 0);
 
   // First output, y₁ = q, for interesting estimation problems.
-  this->DeclareVectorOutputPort(systems::BasicVector<T>(1),
+  this->DeclareVectorOutputPort(systems::kUseDefaultName,
+                                systems::BasicVector<T>(1),
                                 &VanDerPolOscillator::CopyPositionToOutput);
 
   // Second output, y₂ = [q,q̇]', for e.g. visualizing the full state.
-  this->DeclareVectorOutputPort(systems::BasicVector<T>(2),
+  this->DeclareVectorOutputPort(systems::kUseDefaultName,
+                                systems::BasicVector<T>(2),
                                 &VanDerPolOscillator::CopyFullStateToOutput);
 
   // Single parameter, μ, with default μ=1.

--- a/geometry/test/drake_visualizer_test.cc
+++ b/geometry/test/drake_visualizer_test.cc
@@ -87,7 +87,8 @@ class PoseSource : public systems::LeafSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PoseSource)
   PoseSource() {
-    this->DeclareAbstractOutputPort(FramePoseVector<T>(),
+    this->DeclareAbstractOutputPort(systems::kUseDefaultName,
+                                    FramePoseVector<T>(),
                                     &PoseSource<T>::ReadPoses);
   }
 

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -473,6 +473,7 @@ class GeometrySourceSystem : public systems::LeafSystem<double> {
 
     // Set up output port now that the frame is registered.
     this->DeclareAbstractOutputPort(
+        systems::kUseDefaultName,
         &GeometrySourceSystem::CalcFramePoseOutput);
   }
   SourceId get_source_id() const { return source_id_; }

--- a/manipulation/perception/optitrack_pose_extractor.cc
+++ b/manipulation/perception/optitrack_pose_extractor.cc
@@ -63,6 +63,7 @@ OptitrackPoseExtractor::OptitrackPoseExtractor(
     : object_id_(object_id),
       measured_pose_output_port_{
           this->DeclareAbstractOutputPort(
+                  systems::kUseDefaultName,
                   &OptitrackPoseExtractor::OutputMeasuredPose)
               .get_index()},
       X_WO_(X_WO) {

--- a/manipulation/perception/pose_smoother.cc
+++ b/manipulation/perception/pose_smoother.cc
@@ -91,10 +91,14 @@ PoseSmoother::PoseSmoother(double desired_max_linear_velocity,
                            double desired_max_angular_velocity,
                            double period_sec, int filter_window_size)
     : smoothed_pose_output_port_(
-          this->DeclareAbstractOutputPort(&PoseSmoother::OutputSmoothedPose)
+          this->DeclareAbstractOutputPort(
+                  systems::kUseDefaultName,
+                  &PoseSmoother::OutputSmoothedPose)
               .get_index()),
       smoothed_velocity_output_port_(
-          this->DeclareAbstractOutputPort(&PoseSmoother::OutputSmoothedVelocity)
+          this->DeclareAbstractOutputPort(
+                  systems::kUseDefaultName,
+                  &PoseSmoother::OutputSmoothedVelocity)
               .get_index()),
       max_linear_velocity_(desired_max_linear_velocity),
       max_angular_velocity_(desired_max_angular_velocity),

--- a/manipulation/schunk_wsg/schunk_wsg_lcm.cc
+++ b/manipulation/schunk_wsg/schunk_wsg_lcm.cc
@@ -123,11 +123,12 @@ void SchunkWsgStatusReceiver::CopyForceOut(
 }
 
 SchunkWsgStatusSender::SchunkWsgStatusSender() {
-  state_input_port_ =
-      this->DeclareInputPort(systems::kVectorValued, 2).get_index();
-  force_input_port_ =
-      this->DeclareInputPort(systems::kVectorValued, 1).get_index();
-  this->DeclareAbstractOutputPort(&SchunkWsgStatusSender::OutputStatus);
+  state_input_port_ = this->DeclareInputPort(
+      systems::kUseDefaultName, systems::kVectorValued, 2).get_index();
+  force_input_port_ = this->DeclareInputPort(
+      systems::kUseDefaultName, systems::kVectorValued, 1).get_index();
+  this->DeclareAbstractOutputPort(
+      systems::kUseDefaultName, &SchunkWsgStatusSender::OutputStatus);
 }
 
 void SchunkWsgStatusSender::OutputStatus(const Context<double>& context,

--- a/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.cc
+++ b/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.cc
@@ -22,14 +22,15 @@ SchunkWsgTrajectoryGenerator::SchunkWsgTrajectoryGenerator(int input_size,
               "force_limit", BasicVector<double>(1)).get_index()),
       state_input_port_(
           this->DeclareInputPort(
-              systems::kVectorValued, input_size).get_index()),
+              systems::kUseDefaultName, systems::kVectorValued, input_size)
+                  .get_index()),
       target_output_port_(
           this->DeclareVectorOutputPort(
-              BasicVector<double>(2),
+              systems::kUseDefaultName, BasicVector<double>(2),
               &SchunkWsgTrajectoryGenerator::OutputTarget).get_index()),
       max_force_output_port_(
           this->DeclareVectorOutputPort(
-              BasicVector<double>(1),
+              systems::kUseDefaultName, BasicVector<double>(1),
               &SchunkWsgTrajectoryGenerator::OutputForce).get_index()) {
   this->DeclareDiscreteState(
       SchunkWsgTrajectoryGeneratorStateVector<double>());

--- a/multibody/plant/contact_results_to_lcm.cc
+++ b/multibody/plant/contact_results_to_lcm.cc
@@ -27,9 +27,11 @@ ContactResultsToLcmSystem<T>::ContactResultsToLcmSystem(
   }
 
   this->set_name("ContactResultsToLcmSystem");
-  contact_result_input_port_index_ =
-      this->DeclareAbstractInputPort(Value<ContactResults<T>>()).get_index();
+  contact_result_input_port_index_ = this->DeclareAbstractInputPort(
+      systems::kUseDefaultName,
+      Value<ContactResults<T>>()).get_index();
   message_output_port_index_ = this->DeclareAbstractOutputPort(
+      systems::kUseDefaultName,
       &ContactResultsToLcmSystem::CalcLcmContactOutput).get_index();
 }
 

--- a/systems/analysis/test_utilities/spring_mass_system.cc
+++ b/systems/analysis/test_utilities/spring_mass_system.cc
@@ -72,10 +72,12 @@ SpringMassSystem<T>::SpringMassSystem(
       mass_kg_(mass_kg),
       system_is_forced_(system_is_forced) {
   // Declares input port for forcing term.
-  if (system_is_forced_) this->DeclareInputPort(kVectorValued, 1);
+  if (system_is_forced_) {
+    this->DeclareInputPort(kUseDefaultName, kVectorValued, 1);
+  }
 
   // Declares output port for q, qdot, Energy.
-  this->DeclareVectorOutputPort(SpringMassStateVector<T>(),
+  this->DeclareVectorOutputPort(kUseDefaultName, SpringMassStateVector<T>(),
                                 &SpringMassSystem::SetOutputValues);
 
   this->DeclareContinuousState(SpringMassStateVector<T>(),

--- a/systems/controllers/inverse_dynamics.cc
+++ b/systems/controllers/inverse_dynamics.cc
@@ -20,9 +20,10 @@ InverseDynamics<T>::InverseDynamics(const MultibodyPlant<T>* plant,
   DRAKE_DEMAND(plant->is_finalized());
 
   input_port_index_state_ =
-      this->DeclareInputPort(kVectorValued, q_dim_ + v_dim_).get_index();
+      this->DeclareInputPort(kUseDefaultName, kVectorValued, q_dim_ + v_dim_)
+          .get_index();
   output_port_index_force_ =
-      this->DeclareVectorOutputPort(BasicVector<T>(v_dim_),
+      this->DeclareVectorOutputPort(kUseDefaultName, BasicVector<T>(v_dim_),
                                     &InverseDynamics<T>::CalcOutputForce)
           .get_index();
 
@@ -56,7 +57,8 @@ InverseDynamics<T>::InverseDynamics(const MultibodyPlant<T>* plant,
             .cache_index();
 
     input_port_index_desired_acceleration_ =
-        this->DeclareInputPort(kVectorValued, v_dim_).get_index();
+        this->DeclareInputPort(kUseDefaultName, kVectorValued, v_dim_)
+            .get_index();
   }
 }
 

--- a/systems/controllers/linear_model_predictive_controller.cc
+++ b/systems/controllers/linear_model_predictive_controller.cc
@@ -21,16 +21,18 @@ LinearModelPredictiveController<T>::LinearModelPredictiveController(
     const Eigen::MatrixXd& Q, const Eigen::MatrixXd& R, double time_period,
     double time_horizon)
     : state_input_index_(
-          this->DeclareVectorInputPort(BasicVector<T>(Q.cols())).get_index()),
+          this->DeclareVectorInputPort(kUseDefaultName,
+                                       BasicVector<T>(Q.cols()))
+              .get_index()),
       control_output_index_(
           this->DeclareVectorOutputPort(
+                  kUseDefaultName,
                   BasicVector<T>(R.cols()),
                   &LinearModelPredictiveController<T>::CalcControl)
               .get_index()),
       model_(std::move(model)),
       base_context_(std::move(base_context)),
-      num_states_(
-          model_->CreateDefaultContext()->get_discrete_state(0).size()),
+      num_states_(model_->CreateDefaultContext()->get_discrete_state(0).size()),
       num_inputs_(model_->get_input_port(0).size()),
       Q_(Q),
       R_(R),

--- a/systems/controllers/test/linear_model_predictive_controller_test.cc
+++ b/systems/controllers/test/linear_model_predictive_controller_test.cc
@@ -90,8 +90,8 @@ class CubicPolynomialSystem final : public LeafSystem<T> {
   explicit CubicPolynomialSystem(double time_step)
       : LeafSystem<T>(SystemTypeTag<CubicPolynomialSystem>{}),
         time_step_(time_step) {
-    this->DeclareInputPort(systems::kVectorValued, 1);
-    this->DeclareVectorOutputPort(BasicVector<T>(2),
+    this->DeclareInputPort(kUseDefaultName, kVectorValued, 1);
+    this->DeclareVectorOutputPort(kUseDefaultName, BasicVector<T>(2),
                                   &CubicPolynomialSystem::OutputState,
                                   {this->all_state_ticket()});
     this->DeclareDiscreteState(2);

--- a/systems/controllers/test/pid_controlled_system_test.cc
+++ b/systems/controllers/test/pid_controlled_system_test.cc
@@ -45,8 +45,8 @@ class TestPlant : public LeafSystem<double> {
 class TestPlantWithMinOutputs : public TestPlant {
  public:
   TestPlantWithMinOutputs() {
-    DeclareVectorInputPort(BasicVector<double>(1));
-    DeclareVectorOutputPort(BasicVector<double>(2),
+    DeclareVectorInputPort(kUseDefaultName, BasicVector<double>(1));
+    DeclareVectorOutputPort(kUseDefaultName, BasicVector<double>(2),
                             &TestPlantWithMinOutputs::CalcOutputVector,
                             {this->nothing_ticket()});
   }
@@ -80,8 +80,8 @@ class TestPlantWithMinOutputs : public TestPlant {
 class TestPlantWithMoreOutputs : public TestPlant {
  public:
   TestPlantWithMoreOutputs() {
-    DeclareVectorInputPort(BasicVector<double>(1));
-    DeclareVectorOutputPort(BasicVector<double>(6),
+    DeclareVectorInputPort(kUseDefaultName, BasicVector<double>(1));
+    DeclareVectorOutputPort(kUseDefaultName, BasicVector<double>(6),
                             &TestPlantWithMoreOutputs::CalcOutputVector,
                             {this->nothing_ticket()});
   }
@@ -102,15 +102,15 @@ class TestPlantWithMoreOutputPorts : public TestPlant {
  public:
   TestPlantWithMoreOutputPorts() {
     // Declare some empty plant input port.
-    DeclareVectorInputPort(BasicVector<double>(0));
-    DeclareVectorInputPort(BasicVector<double>(1));
+    DeclareVectorInputPort(kUseDefaultName, BasicVector<double>(0));
+    DeclareVectorInputPort(kUseDefaultName, BasicVector<double>(1));
     // Declare some non-state output port.
     DeclareVectorOutputPort(
-        BasicVector<double>(3),
+        kUseDefaultName, BasicVector<double>(3),
         &TestPlantWithMoreOutputPorts::CalcNonStateOutputVector,
         {this->nothing_ticket()});
     DeclareVectorOutputPort(
-        BasicVector<double>(2),
+        kUseDefaultName, BasicVector<double>(2),
         &TestPlantWithMoreOutputPorts::CalcStateOutputVector,
         {this->nothing_ticket()});
   }

--- a/systems/framework/single_output_vector_source.h
+++ b/systems/framework/single_output_vector_source.h
@@ -79,7 +79,7 @@ class SingleOutputVectorSource : public LeafSystem<T> {
       SystemScalarConverter converter, const BasicVector<T>& model_vector)
       : LeafSystem<T>(std::move(converter)) {
     this->DeclareVectorOutputPort(
-        model_vector,
+        kUseDefaultName, model_vector,
         &SingleOutputVectorSource<T>::CalcVectorOutput);
   }
 

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -1423,7 +1423,7 @@ class PublishingSystem : public LeafSystem<double> {
  public:
   explicit PublishingSystem(std::function<void(double)> callback)
       : callback_(callback) {
-    this->DeclareInputPort(kVectorValued, 1);
+    this->DeclareInputPort(kUseDefaultName, kVectorValued, 1);
   }
 
  protected:
@@ -1581,10 +1581,12 @@ TEST_F(DiagramTest, SubclassTransmogrificationTest) {
 class Reduce : public LeafSystem<double> {
  public:
   Reduce() {
-    const auto& input0 = this->DeclareInputPort(kVectorValued, 1);
+    const auto& input0 = this->DeclareInputPort(
+        kUseDefaultName, kVectorValued, 1);
     feedthrough_input_ = input0.get_index();
-    sink_input_ = this->DeclareInputPort(kVectorValued, 1).get_index();
-    this->DeclareVectorOutputPort(BasicVector<double>(1),
+    sink_input_ = this->DeclareInputPort(
+        kUseDefaultName, kVectorValued, 1).get_index();
+    this->DeclareVectorOutputPort(kUseDefaultName, BasicVector<double>(1),
                                   &Reduce::CalcFeedthrough,
                                   {input0.ticket()});
   }
@@ -1713,7 +1715,7 @@ class SecondOrderStateVector : public BasicVector<double> {
 class SecondOrderStateSystem : public LeafSystem<double> {
  public:
   SecondOrderStateSystem() {
-    DeclareInputPort(kVectorValued, 1);
+    DeclareInputPort(kUseDefaultName, kVectorValued, 1);
     DeclareContinuousState(SecondOrderStateVector{},
                            1 /* num_q */, 1 /* num_v */, 0 /* num_z */);
   }

--- a/systems/framework/test/output_port_test.cc
+++ b/systems/framework/test/output_port_test.cc
@@ -370,7 +370,8 @@ class SystemWithNStates : public LeafSystem<double> {
  public:
   explicit SystemWithNStates(int num_states) {
     DeclareContinuousState(num_states);
-    DeclareAbstractOutputPort(&SystemWithNStates::ReturnNumContinuous);
+    DeclareAbstractOutputPort(
+        kUseDefaultName, &SystemWithNStates::ReturnNumContinuous);
   }
   ~SystemWithNStates() override {}
  private:

--- a/systems/framework/test/system_scalar_converter_test.cc
+++ b/systems/framework/test/system_scalar_converter_test.cc
@@ -45,9 +45,9 @@ class NonSymbolicSystem : public LeafSystem<T> {
   explicit NonSymbolicSystem(int magic)
       : magic_(magic) {
     // Declare input-output relation of `y[0] = copysign(magic, u[0])`.
-    this->DeclareVectorInputPort(BasicVector<T>(1));
+    this->DeclareVectorInputPort(kUseDefaultName, BasicVector<T>(1));
     this->DeclareVectorOutputPort(
-        BasicVector<T>(1),
+        kUseDefaultName, BasicVector<T>(1),
         [this](const Context<T>& context, BasicVector<T>* output) {
           const auto& input = this->get_input_port(0).Eval(context);
           (*output)[0] = test::copysign_int_to_non_symbolic_scalar(

--- a/systems/framework/test/system_symbolic_inspector_test.cc
+++ b/systems/framework/test/system_symbolic_inspector_test.cc
@@ -17,13 +17,15 @@ const int kSize = 2;
 class SparseSystem : public LeafSystem<symbolic::Expression> {
  public:
   SparseSystem() {
-    this->DeclareInputPort(kVectorValued, kSize);
-    this->DeclareInputPort(kVectorValued, kSize);
+    this->DeclareInputPort(kUseDefaultName, kVectorValued, kSize);
+    this->DeclareInputPort(kUseDefaultName, kVectorValued, kSize);
 
-    this->DeclareVectorOutputPort(BasicVector<symbolic::Expression>(kSize),
-                                  &SparseSystem::CalcY0);
-    this->DeclareVectorOutputPort(BasicVector<symbolic::Expression>(kSize),
-                                  &SparseSystem::CalcY1);
+    this->DeclareVectorOutputPort(
+        kUseDefaultName, BasicVector<symbolic::Expression>(kSize),
+        &SparseSystem::CalcY0);
+    this->DeclareVectorOutputPort(
+        kUseDefaultName, BasicVector<symbolic::Expression>(kSize),
+        &SparseSystem::CalcY1);
     this->DeclareAbstractOutputPort("port_42", 42, &SparseSystem::CalcNothing);
 
     this->DeclareContinuousState(kSize);

--- a/systems/framework/test/vector_system_test.cc
+++ b/systems/framework/test/vector_system_test.cc
@@ -148,6 +148,7 @@ TEST_F(VectorSystemTest, TopologyFailFast) {
     TestVectorSystem dut;
     DRAKE_EXPECT_NO_THROW(dut.CreateDefaultContext());
     dut.DeclareAbstractOutputPort(
+        kUseDefaultName,
         []() { return AbstractValue::Make<int>(0); },  // Dummies.
         [](const ContextBase&, AbstractValue*) {});
     EXPECT_THROW(dut.CreateDefaultContext(), std::exception);

--- a/systems/framework/vector_system.h
+++ b/systems/framework/vector_system.h
@@ -76,7 +76,7 @@ class VectorSystem : public LeafSystem<T> {
                std::optional<bool> direct_feedthrough = std::nullopt)
       : LeafSystem<T>(std::move(converter)) {
     if (input_size > 0) {
-      this->DeclareInputPort(kVectorValued, input_size);
+      this->DeclareInputPort(kUseDefaultName, kVectorValued, input_size);
     }
     if (output_size > 0) {
       std::set<DependencyTicket> prerequisites_of_calc;
@@ -95,8 +95,8 @@ class VectorSystem : public LeafSystem<T> {
         };
       }
       this->DeclareVectorOutputPort(
-          BasicVector<T>(output_size), &VectorSystem::CalcVectorOutput,
-          std::move(prerequisites_of_calc));
+          kUseDefaultName, BasicVector<T>(output_size),
+          &VectorSystem::CalcVectorOutput, std::move(prerequisites_of_calc));
     }
   }
 

--- a/systems/lcm/lcm_subscriber_system.cc
+++ b/systems/lcm/lcm_subscriber_system.cc
@@ -42,6 +42,7 @@ LcmSubscriberSystem::LcmSubscriberSystem(
   // Use the "advanced" method to construct explicit non-member functors to
   // deal with the unusual methods we have available.
   DeclareAbstractOutputPort(
+      kUseDefaultName,
       [this]() {
         return this->AllocateSerializerOutputValue();
       },

--- a/systems/primitives/affine_system.cc
+++ b/systems/primitives/affine_system.cc
@@ -47,13 +47,13 @@ TimeVaryingAffineSystem<T>::TimeVaryingAffineSystem(
   }
 
   if (num_inputs_ > 0)
-    this->DeclareInputPort(kVectorValued, num_inputs_);
+    this->DeclareInputPort(kUseDefaultName, kVectorValued, num_inputs_);
   if (num_outputs_ > 0) {
     // N.B. Subclasses that override CalcOutputY may want to fine-tune the
     // output port's prerequisites; see AffineSystem's ctor for an example.
     // By default, the output port will depend on everything (time, input,
     // state, accuracy, etc.).
-    this->DeclareVectorOutputPort(BasicVector<T>(num_outputs_),
+    this->DeclareVectorOutputPort(kUseDefaultName, BasicVector<T>(num_outputs_),
                                   &TimeVaryingAffineSystem::CalcOutputY);
   }
 }

--- a/systems/primitives/constant_value_source.cc
+++ b/systems/primitives/constant_value_source.cc
@@ -10,6 +10,7 @@ ConstantValueSource<T>::ConstantValueSource(const AbstractValue& value)
   // Use the "advanced" method to provide explicit non-member functors here
   // since we already have AbstractValues.
   this->DeclareAbstractOutputPort(
+      kUseDefaultName,
       [this]() {
         return source_value_->Clone();
       },

--- a/systems/primitives/demultiplexer.cc
+++ b/systems/primitives/demultiplexer.cc
@@ -17,7 +17,7 @@ Demultiplexer<T>::Demultiplexer(const std::vector<int>& output_ports_sizes)
   const int size =
       std::accumulate(output_ports_sizes.begin(), output_ports_sizes.end(), 0);
 
-  this->DeclareInputPort(kVectorValued, size);
+  this->DeclareInputPort(kUseDefaultName, kVectorValued, size);
 
   // TODO(david-german-tri): Provide a way to infer the type.
   const int num_output_ports = output_ports_sizes.size();
@@ -27,7 +27,7 @@ Demultiplexer<T>::Demultiplexer(const std::vector<int>& output_ports_sizes)
     // Require no zero size output port.
     DRAKE_THROW_UNLESS(output_port_size >= 1);
     this->DeclareVectorOutputPort(
-        BasicVector<T>(output_port_size),
+        systems::kUseDefaultName, BasicVector<T>(output_port_size),
         [this, i](const Context<T>& context, BasicVector<T>* vector) {
           this->CopyToOutput(context, OutputPortIndex(i), vector);
         });

--- a/systems/primitives/multiplexer.cc
+++ b/systems/primitives/multiplexer.cc
@@ -40,9 +40,9 @@ Multiplexer<T>::Multiplexer(SystemScalarConverter converter,
                                                       input_sizes_.end(), 0,
                                                       std::plus<int>{}));
   for (const int input_size : input_sizes_) {
-    this->DeclareInputPort(kVectorValued, input_size);
+    this->DeclareInputPort(kUseDefaultName, kVectorValued, input_size);
   }
-  this->DeclareVectorOutputPort(model_vector,
+  this->DeclareVectorOutputPort(kUseDefaultName, model_vector,
                                 &Multiplexer::CombineInputsToOutput);
 }
 

--- a/systems/primitives/saturation.cc
+++ b/systems/primitives/saturation.cc
@@ -21,12 +21,15 @@ Saturation<T>::Saturation(int input_size)
 
   // Input and outputs are of same dimension.
   input_port_index_ =
-      this->DeclareInputPort(kVectorValued, input_size_).get_index();
+      this->DeclareInputPort(kUseDefaultName, kVectorValued, input_size_)
+          .get_index();
   max_value_port_index_ =
-      this->DeclareInputPort(kVectorValued, input_size_).get_index();
+      this->DeclareInputPort(kUseDefaultName, kVectorValued, input_size_)
+          .get_index();
   min_value_port_index_ =
-      this->DeclareInputPort(kVectorValued, input_size_).get_index();
-  this->DeclareVectorOutputPort(BasicVector<T>(input_size_),
+      this->DeclareInputPort(kUseDefaultName, kVectorValued, input_size_)
+          .get_index();
+  this->DeclareVectorOutputPort(kUseDefaultName, BasicVector<T>(input_size_),
                                 &Saturation::CalcSaturatedOutput)
       .get_index();
 }
@@ -47,10 +50,11 @@ Saturation<T>::Saturation(const VectorX<T>& min_value,
   DRAKE_THROW_UNLESS((min_value_.array() <= max_value_.array()).all());
 
   input_port_index_ =
-      this->DeclareInputPort(kVectorValued, input_size_).get_index();
-  this->DeclareVectorOutputPort(BasicVector<T>(input_size_),
+      this->DeclareInputPort(kUseDefaultName, kVectorValued, input_size_)
+          .get_index();
+  this->DeclareVectorOutputPort(kUseDefaultName, BasicVector<T>(input_size_),
                                 &Saturation::CalcSaturatedOutput)
-      .get_index();
+          .get_index();
 }
 
 template <typename T>

--- a/systems/primitives/sine.cc
+++ b/systems/primitives/sine.cc
@@ -37,19 +37,19 @@ Sine<T>::Sine(const Eigen::VectorXd& amplitudes,
   // is not system time based, create an input port that contains the signal to
   // be used as the time variable.
   if (!is_time_based) {
-    this->DeclareInputPort(kVectorValued, amplitudes.size());
+    this->DeclareInputPort(kUseDefaultName, kVectorValued, amplitudes.size());
   }
   value_output_port_index_ =
       this->DeclareVectorOutputPort(
-          BasicVector<T>(amplitudes.size()),
+          kUseDefaultName, BasicVector<T>(amplitudes.size()),
           &Sine::CalcValueOutput).get_index();
   first_derivative_output_port_index_ =
       this->DeclareVectorOutputPort(
-          BasicVector<T>(amplitudes.size()),
+          kUseDefaultName, BasicVector<T>(amplitudes.size()),
           &Sine::CalcFirstDerivativeOutput).get_index();
   second_derivative_output_port_index_ =
       this->DeclareVectorOutputPort(
-          BasicVector<T>(amplitudes.size()),
+          kUseDefaultName, BasicVector<T>(amplitudes.size()),
           &Sine::CalcSecondDerivativeOutput).get_index();
 }
 

--- a/systems/primitives/symbolic_vector_system.cc
+++ b/systems/primitives/symbolic_vector_system.cc
@@ -117,7 +117,7 @@ SymbolicVectorSystem<T>::SymbolicVectorSystem(
   DRAKE_DEMAND(static_cast<int>(all_vars.size()) == vars_vec.size());
 
   if (input_vars_.size() > 0) {
-    this->DeclareInputPort(kVectorValued, input_vars_.size());
+    this->DeclareInputPort(kUseDefaultName, kVectorValued, input_vars_.size());
   }
   for (int i = 0; i < state_vars_.size(); i++) {
     state_var_to_index_.emplace(state_vars_[i].get_id(), i);
@@ -140,7 +140,8 @@ SymbolicVectorSystem<T>::SymbolicVectorSystem(
     for (int i = 0; i < output_.size(); i++) {
       DRAKE_ASSERT(output_[i].GetVariables().IsSubsetOf(all_vars));
     }
-    this->DeclareVectorOutputPort(BasicVector<T>(output_.size()),
+    this->DeclareVectorOutputPort(kUseDefaultName,
+                                  BasicVector<T>(output_.size()),
                                   &SymbolicVectorSystem<T>::CalcOutput);
   }
 

--- a/systems/primitives/test/linear_system_test.cc
+++ b/systems/primitives/test/linear_system_test.cc
@@ -30,7 +30,7 @@ class LinearSystemPlusEmptyVectorPort final : public LinearSystem<double> {
         const Eigen::Ref<const Eigen::MatrixXd>& C,
         const Eigen::Ref<const Eigen::MatrixXd>& D)
       : LinearSystem(SystemScalarConverter{}, A, B, C, D, 0.0) {
-    this->DeclareInputPort(kVectorValued, 0);
+    this->DeclareInputPort(kUseDefaultName, kVectorValued, 0);
   }
 };
 
@@ -393,7 +393,8 @@ class EmptyStateSystemWithMixedInputs final : public LeafSystem<T> {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(EmptyStateSystemWithMixedInputs);
   EmptyStateSystemWithMixedInputs()
       : LeafSystem<T>(SystemTypeTag<EmptyStateSystemWithMixedInputs>{}) {
-    this->DeclareVectorInputPort(BasicVector<T>(1) /* scalar input */);
+    this->DeclareVectorInputPort(
+        kUseDefaultName, BasicVector<T>(1) /* scalar input */);
     this->DeclareAbstractInputPort(
         "dummy", Value<std::vector<double>>() /* Arbitrary data type */);
   }
@@ -715,8 +716,8 @@ class MimoSystem final : public LeafSystem<T> {
   explicit MimoSystem(bool is_discrete)
       : LeafSystem<T>(SystemTypeTag<MimoSystem>{}),
         is_discrete_(is_discrete) {
-    this->DeclareInputPort(kVectorValued, 1);
-    this->DeclareInputPort(kVectorValued, 3);
+    this->DeclareInputPort(kUseDefaultName, kVectorValued, 1);
+    this->DeclareInputPort(kUseDefaultName, kVectorValued, 3);
 
     if (is_discrete) {
       this->DeclareDiscreteState(2);
@@ -724,8 +725,10 @@ class MimoSystem final : public LeafSystem<T> {
     } else {
       this->DeclareContinuousState(2);
     }
-    this->DeclareVectorOutputPort(BasicVector<T>(1), &MimoSystem::CalcOutput0);
-    this->DeclareVectorOutputPort(BasicVector<T>(3), &MimoSystem::CalcOutput1);
+    this->DeclareVectorOutputPort(
+        kUseDefaultName, BasicVector<T>(1), &MimoSystem::CalcOutput0);
+    this->DeclareVectorOutputPort(
+        kUseDefaultName, BasicVector<T>(3), &MimoSystem::CalcOutput1);
 
     A_ << 1, 2, 3, 4;
     B0_ << 5, 6;

--- a/systems/primitives/test/symbolic_vector_system_test.cc
+++ b/systems/primitives/test/symbolic_vector_system_test.cc
@@ -235,7 +235,7 @@ class CalcRecorder final : public LeafSystem<T> {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(CalcRecorder);
 
   explicit CalcRecorder(int output_size = 1) {
-    this->DeclareVectorOutputPort(BasicVector<T>(output_size),
+    this->DeclareVectorOutputPort(kUseDefaultName, BasicVector<T>(output_size),
         &CalcRecorder::CalcOutput);
   }
 

--- a/systems/primitives/wrap_to_system.cc
+++ b/systems/primitives/wrap_to_system.cc
@@ -12,8 +12,8 @@ template <typename T>
 WrapToSystem<T>::WrapToSystem(int input_size) : input_size_(input_size) {
   DRAKE_DEMAND(input_size_ > 0);
 
-  this->DeclareInputPort(kVectorValued, input_size_);
-  this->DeclareVectorOutputPort(BasicVector<T>(input_size_),
+  this->DeclareInputPort(kUseDefaultName, kVectorValued, input_size_);
+  this->DeclareVectorOutputPort(kUseDefaultName, BasicVector<T>(input_size_),
                                 &WrapToSystem::CalcWrappedOutput);
 }
 

--- a/systems/rendering/pose_aggregator.cc
+++ b/systems/rendering/pose_aggregator.cc
@@ -18,7 +18,8 @@ PoseAggregator<T>::PoseAggregator()
   // Declare the output port and provide an allocator for a PoseBundle of length
   // equal to the concatenation of all inputs. This can't be done with a model
   // value because we don't know at construction how big the output will be.
-  this->DeclareAbstractOutputPort(&PoseAggregator::MakePoseBundle,
+  this->DeclareAbstractOutputPort(kUseDefaultName,
+                                  &PoseAggregator::MakePoseBundle,
                                   &PoseAggregator::CalcPoseBundle);
 }
 
@@ -177,9 +178,9 @@ PoseAggregator<T>::DeclareInput(const InputRecord& record) {
   input_records_.push_back(record);
   switch (record.type) {
     case InputRecord::kSinglePose:
-      return this->DeclareVectorInputPort(PoseVector<T>());
+      return this->DeclareVectorInputPort(kUseDefaultName, PoseVector<T>());
     case InputRecord::kSingleVelocity:
-      return this->DeclareVectorInputPort(FrameVelocity<T>());
+      return this->DeclareVectorInputPort(kUseDefaultName, FrameVelocity<T>());
     case InputRecord::kBundle:
       return this->DeclareAbstractInputPort(
           kUseDefaultName, Value<PoseBundle<T>>());

--- a/systems/rendering/pose_bundle_to_draw_message.cc
+++ b/systems/rendering/pose_bundle_to_draw_message.cc
@@ -13,7 +13,7 @@ PoseBundleToDrawMessage::PoseBundleToDrawMessage() {
   this->DeclareAbstractInputPort(
       kUseDefaultName, Value<PoseBundle<double>>());
   this->DeclareAbstractOutputPort(
-      &PoseBundleToDrawMessage::CalcViewerDrawMessage);
+      kUseDefaultName, &PoseBundleToDrawMessage::CalcViewerDrawMessage);
 }
 
 PoseBundleToDrawMessage::~PoseBundleToDrawMessage() {}

--- a/systems/rendering/render_pose_to_geometry_pose.cc
+++ b/systems/rendering/render_pose_to_geometry_pose.cc
@@ -21,8 +21,9 @@ RenderPoseToGeometryPose<T>::RenderPoseToGeometryPose(
       frame_id_(frame_id) {
   using Input = PoseVector<T>;
   using Output = geometry::FramePoseVector<T>;
-  this->DeclareVectorInputPort(Input{});
+  this->DeclareVectorInputPort(kUseDefaultName, Input{});
   this->DeclareAbstractOutputPort(
+      kUseDefaultName,
       []() { return Value<Output>{}.Clone(); },
       [this, frame_id](const Context<T>& context, AbstractValue* calculated) {
         const Input& input =

--- a/systems/sensors/image_to_lcm_image_array_t.cc
+++ b/systems/sensors/image_to_lcm_image_array_t.cc
@@ -132,8 +132,8 @@ void PackImageToLcmImageT(const AbstractValue& untyped_image,
 
 ImageToLcmImageArrayT::ImageToLcmImageArrayT(bool do_compress)
     : do_compress_(do_compress) {
-  image_array_t_msg_output_port_index_ =
-      DeclareAbstractOutputPort(&ImageToLcmImageArrayT::CalcImageArray)
+  image_array_t_msg_output_port_index_ = DeclareAbstractOutputPort(
+      kUseDefaultName, &ImageToLcmImageArrayT::CalcImageArray)
           .get_index();
 }
 
@@ -149,8 +149,8 @@ ImageToLcmImageArrayT::ImageToLcmImageArrayT(const string& color_frame_name,
   label_image_input_port_index_ =
       DeclareImageInputPort<PixelType::kLabel16I>(label_frame_name).get_index();
 
-  image_array_t_msg_output_port_index_ =
-      DeclareAbstractOutputPort(&ImageToLcmImageArrayT::CalcImageArray)
+  image_array_t_msg_output_port_index_ = DeclareAbstractOutputPort(
+      kUseDefaultName, &ImageToLcmImageArrayT::CalcImageArray)
           .get_index();
 }
 

--- a/systems/sensors/optitrack_sender.cc
+++ b/systems/sensors/optitrack_sender.cc
@@ -35,6 +35,7 @@ OptitrackLcmFrameSender::OptitrackLcmFrameSender(
       kUseDefaultName,
       Value<geometry::FramePoseVector<double>>()).get_index();
   this->DeclareAbstractOutputPort(
+      kUseDefaultName,
       optitrack::optitrack_frame_t(),
       &OptitrackLcmFrameSender::PopulatePoseMessage);
 }


### PR DESCRIPTION
This is in preparation for deprecating the overloads that allow the user to omit the port name (#15179, #9447).

In many cases we should probably be using a more specific string literal instead of the kDefaultPortName, but for simplicity this commit converts everything to kDefaultPortName in bulk.  We can go back through each directory later one by one and have the subject matter experts choose better names.

The only call sites not changed are the direct unit tests for System and LeafSytem (and their Python bindings).  Those need to be more carefully adjusted as part of the deprecation commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15182)
<!-- Reviewable:end -->
