### PR TITLE
manip. station: Use same extrinsics+intrinsics for color+depth

### DIFF
--- a/examples/manipulation_station/manipulation_station.cc
+++ b/examples/manipulation_station/manipulation_station.cc
@@ -161,25 +161,30 @@ MakeD415CameraModel(const std::string& renderer_name) {
   // - w: 848, h: 480, fx: 616.285, fy: 615.778, ppx: 405.418, ppy: 232.864
   // DEPTH:
   // - w: 848, h: 480, fx: 645.138, fy: 645.138, ppx: 420.789, ppy: 239.13
+  // However, given that (a) these fixed constants will not always be true and
+  // (b) we do not have a quick RGBD registration algorithm in Drake, we will
+  // simply publish according to the RGB intrinsics and extrinsics.
   const int kHeight = 480;
   const int kWidth = 848;
 
-  // To pose the two sensors relative to the camera body, we'll assume X_BC = I,
-  // and select a representative value for X_CD drawn from calibration to define
-  // X_BD.
+  // From color camera.
+  const systems::sensors::CameraInfo intrinsics{
+      kWidth, kHeight, 616.285, 615.778, 405.418, 232.864};
+
+  const RigidTransformd X_BC;
+  // This is not necessarily true, but we simplify this s.t. we don't have a
+  // lie for generating point clouds.
+  const RigidTransformd X_BD;
+
   geometry::render::ColorRenderCamera color_camera{
       {renderer_name,
-       {kWidth, kHeight, 616.285, 615.778, 405.418, 232.864} /* intrinsics */,
+       intrinsics,
        {0.01, 3.0} /* clipping_range */,
-       {} /* X_BC */},
+       X_BC},
       false};
-  const RigidTransformd X_BD(
-      RotationMatrix<double>(RollPitchYaw<double>(
-          -0.19 * M_PI / 180, -0.016 * M_PI / 180, -0.03 * M_PI / 180)),
-      Vector3d(0.015, -0.00019, -0.0001));
   geometry::render::DepthRenderCamera depth_camera{
       {renderer_name,
-       {kWidth, kHeight, 645.138, 645.138, 420.789, 239.13} /* intrinsics */,
+       intrinsics,
        {0.01, 3.0} /* clipping_range */,
        X_BD},
       {0.1, 2.0} /* depth_range */};


### PR DESCRIPTION
Otherwise, point clouds are a lie

A short-term workaround for #12125
Motivated by review of #14991

\cc @RussTedrake @jwnimmer-tri @SeanCurtis-TRI

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15186)
<!-- Reviewable:end -->
