### PR TITLE
[examples] Remove unnecessary model_value allocation boilerplate

### DIFF
--- a/examples/allegro_hand/allegro_lcm.cc
+++ b/examples/allegro_hand/allegro_lcm.cc
@@ -105,18 +105,7 @@ AllegroStatusSender::AllegroStatusSender(int num_joints)
           .get_index();
 
   this->DeclareAbstractOutputPort(systems::kUseDefaultName,
-                                  &AllegroStatusSender::MakeOutputStatus,
                                   &AllegroStatusSender::OutputStatus);
-}
-
-lcmt_allegro_status AllegroStatusSender::MakeOutputStatus() const {
-  lcmt_allegro_status msg{};
-  msg.num_joints = num_joints_;
-  msg.joint_position_measured.resize(msg.num_joints, 0);
-  msg.joint_velocity_estimated.resize(msg.num_joints, 0);
-  msg.joint_position_commanded.resize(msg.num_joints, 0);
-  msg.joint_torque_commanded.resize(msg.num_joints, 0);
-  return msg;
 }
 
 void AllegroStatusSender::OutputStatus(const Context<double>& context,
@@ -130,6 +119,11 @@ void AllegroStatusSender::OutputStatus(const Context<double>& context,
   const systems::BasicVector<double>* commanded_torque =
       this->EvalVectorInput(context, 2);
 
+  status.num_joints = num_joints_;
+  status.joint_position_measured.resize(num_joints_, 0);
+  status.joint_velocity_estimated.resize(num_joints_, 0);
+  status.joint_position_commanded.resize(num_joints_, 0);
+  status.joint_torque_commanded.resize(num_joints_, 0);
   for (int i = 0; i < num_joints_; ++i) {
     status.joint_position_measured[i] = state->GetAtIndex(i);
     status.joint_velocity_estimated[i] = state->GetAtIndex(i + num_joints_);

--- a/examples/allegro_hand/allegro_lcm.h
+++ b/examples/allegro_hand/allegro_lcm.h
@@ -104,9 +104,6 @@ class AllegroStatusSender : public systems::LeafSystem<double> {
   }
 
  private:
-  // This is the method to use for the output port allocator.
-  lcmt_allegro_status MakeOutputStatus() const;
-
   // This is the calculator method for the output port.
   void OutputStatus(const systems::Context<double>& context,
                     lcmt_allegro_status* output) const;

--- a/examples/planar_gripper/planar_gripper_lcm.cc
+++ b/examples/planar_gripper/planar_gripper_lcm.cc
@@ -205,16 +205,7 @@ GripperStatusEncoder::GripperStatusEncoder(int num_fingers)
   force_input_port_ = &this->DeclareInputPort(
       "fingertip_force", systems::kVectorValued, num_tip_forces_);
   this->DeclareAbstractOutputPort("lcmt_gripper_status",
-                                  &GripperStatusEncoder::MakeOutputStatus,
                                   &GripperStatusEncoder::OutputStatus);
-}
-
-lcmt_planar_gripper_status GripperStatusEncoder::MakeOutputStatus() const {
-  lcmt_planar_gripper_status msg{};
-  msg.utime = 0;
-  msg.num_fingers = num_fingers_;
-  msg.finger_status.resize(num_fingers_);
-  return msg;
 }
 
 void GripperStatusEncoder::OutputStatus(

--- a/examples/planar_gripper/planar_gripper_lcm.h
+++ b/examples/planar_gripper/planar_gripper_lcm.h
@@ -204,9 +204,6 @@ class GripperStatusEncoder : public systems::LeafSystem<double> {
   }
 
  private:
-  // This is the method to use for the output port allocator.
-  lcmt_planar_gripper_status MakeOutputStatus() const;
-
   // This is the calculator method for the output port.
   void OutputStatus(const systems::Context<double>& context,
                     lcmt_planar_gripper_status* output) const;

--- a/examples/planar_gripper/planar_manipuland_lcm.cc
+++ b/examples/planar_gripper/planar_manipuland_lcm.cc
@@ -50,15 +50,7 @@ PlanarManipulandStatusEncoder::PlanarManipulandStatusEncoder() {
   this->DeclareInputPort(systems::kUseDefaultName, systems::kVectorValued, 6);
   this->DeclareAbstractOutputPort(
       systems::kUseDefaultName,
-      &PlanarManipulandStatusEncoder::MakeOutputStatus,
       &PlanarManipulandStatusEncoder::OutputStatus);
-}
-
-lcmt_planar_manipuland_status PlanarManipulandStatusEncoder::MakeOutputStatus()
-    const {
-  lcmt_planar_manipuland_status msg{};
-  msg.utime = 0;
-  return msg;
 }
 
 void PlanarManipulandStatusEncoder::OutputStatus(

--- a/examples/planar_gripper/planar_manipuland_lcm.h
+++ b/examples/planar_gripper/planar_manipuland_lcm.h
@@ -67,9 +67,6 @@ class PlanarManipulandStatusEncoder : public systems::LeafSystem<double> {
   PlanarManipulandStatusEncoder();
 
  private:
-  // This is the method to use for the output port allocator.
-  lcmt_planar_manipuland_status MakeOutputStatus() const;
-
   // This is the calculator method for the output port.
   void OutputStatus(const systems::Context<double>& context,
                     lcmt_planar_manipuland_status* output) const;


### PR DESCRIPTION
Specifying a custom allocator for LCM message outputs is not a pattern we should encourage.

Found during #15161.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15190)
<!-- Reviewable:end -->
