### PR TITLE
Change MbP component setters' signature

### DIFF
--- a/multibody/contact_solvers/test/contact_solver_test.cc
+++ b/multibody/contact_solvers/test/contact_solver_test.cc
@@ -46,10 +46,10 @@ class ParticleSolver final : public ContactSolver<T> {
   // on the data supplied by MultibodyPlant. We must perform these tests at this
   // scope to ensure data references are still "alive".
   ContactSolverStatus SolveWithGuess(const T& time_step,
-                                   const SystemDynamicsData<T>& dynamics_data,
-                                   const PointContactData<T>& contact_data,
-                                   const VectorX<T>& v_guess,
-                                   ContactSolverResults<T>* results) final {
+                                     const SystemDynamicsData<T>& dynamics_data,
+                                     const PointContactData<T>& contact_data,
+                                     const VectorX<T>& v_guess,
+                                     ContactSolverResults<T>* results) final {
     const int nv = dynamics_data.num_velocities();
     const int nc = contact_data.num_contacts();
 
@@ -72,8 +72,8 @@ class ParticleSolver final : public ContactSolver<T> {
     // Generalized velocities when contact forces are zero.
     VectorX<T> vc_star(3 * nc);
     Jc.Multiply(v_star, &vc_star);  // vc_star = Jc⋅v_star
-    const T vn_star = vc_star(2);         // Normal velocity.
-    const T Wnn = W(2, 2);                // Normal equation.
+    const T vn_star = vc_star(2);   // Normal velocity.
+    const T Wnn = W(2, 2);          // Normal equation.
     // We now need to solve the 1D  problem:
     //   0 ≤ Wnn π + vₙ* ⊥ π ≥ 0
     // Which, given Wnn > 0, has unique solution:
@@ -126,7 +126,7 @@ class ParticleSolver final : public ContactSolver<T> {
   VectorX<T> v_{6};      // Generalized velocity, in this cases equals vn.
   // Cache, i.e. state dependent quantities.
   VectorX<T> jc_{6};  // Generalized contact impulse.
-  VectorX<T> vc_{3};     // Contact velocity.
+  VectorX<T> vc_{3};  // Contact velocity.
 
   // Problem parameters, for unit testing, an actual solver won't know
   // these.
@@ -152,8 +152,9 @@ class ParticleTest : public ::testing::Test {
     // Assert plant sizes.
     ASSERT_EQ(nq, 7);  // 4 dofs for a quaternion, 3 dofs for translation.
     ASSERT_EQ(nv, 6);  // 6 dofs for angular and translational velocity.
-    solver_ = &driver_.mutable_plant().SetContactSolver(
-        std::make_unique<ParticleSolver<double>>(kParticleMass));
+    auto solver = std::make_unique<ParticleSolver<double>>(kParticleMass);
+    solver_ = solver.get();
+    driver_.mutable_plant().SetContactSolver(std::move(solver));
 
     // Verify that solvers/test/particle.sdf is in sync with this test.
     const double mass = particle.get_default_mass();

--- a/multibody/fixed_fem/dev/run_cantilever_beam.cc
+++ b/multibody/fixed_fem/dev/run_cantilever_beam.cc
@@ -113,8 +113,8 @@ int DoMain() {
   auto* visualizer = builder.AddSystem<DeformableVisualizer>(
       1.0 / 60.0, deformable_model->names(),
       deformable_model->reference_configuration_meshes());
-  const DeformableModel<double>* deformable_model_ptr =
-      &plant->AddPhysicalModel(std::move(deformable_model));
+  const DeformableModel<double>* deformable_model_ptr = deformable_model.get();
+  plant->AddPhysicalModel(std::move(deformable_model));
   plant->Finalize();
   /* Creates a DeformableRigidManager with no contact solver assigned as there
    is no contact in this demo. */

--- a/multibody/fixed_fem/dev/test/deformable_model_test.cc
+++ b/multibody/fixed_fem/dev/test/deformable_model_test.cc
@@ -106,13 +106,13 @@ TEST_F(DeformableModelTest, RegisterDeformableBodyUniqueNameRequirement) {
 
 TEST_F(DeformableModelTest, VertexPositionsOutputPort) {
   AddDeformableBox(deformable_model_.get(), "box");
-  DeformableModel<double>* model_ptr =
-      &plant_.AddPhysicalModel(std::move(deformable_model_));
+  DeformableModel<double>* deformable_model = deformable_model_.get();
+  plant_.AddPhysicalModel(std::move(deformable_model_));
   plant_.Finalize();
   auto context = plant_.CreateDefaultContext();
   const std::vector<VectorXd> vertex_positions_vector =
-      model_ptr->get_vertex_positions_output_port().Eval<std::vector<VectorXd>>(
-          *context);
+      deformable_model->get_vertex_positions_output_port()
+          .Eval<std::vector<VectorXd>>(*context);
   EXPECT_EQ(vertex_positions_vector.size(), 1);
   const VectorXd& vertex_positions = vertex_positions_vector[0];
   EXPECT_EQ(vertex_positions.size(), 3 * kNumVertices);

--- a/multibody/fixed_fem/dev/test/deformable_rigid_manager_test.cc
+++ b/multibody/fixed_fem/dev/test/deformable_rigid_manager_test.cc
@@ -49,7 +49,8 @@ class DeformableRigidManagerTest : public ::testing::Test {
     deformable_model->RegisterDeformableBody(MakeBoxTetMesh(), "box",
                                              MakeDeformableBodyConfig(),
                                              MakeProximityProperties());
-    deformable_model_ = &plant_.AddPhysicalModel(std::move(deformable_model));
+    deformable_model_ = deformable_model.get();
+    plant_.AddPhysicalModel(std::move(deformable_model));
     /* Add a collision geometry. */
     plant_.RegisterAsSourceForSceneGraph(&scene_graph_);
     plant_.RegisterCollisionGeometry(
@@ -58,8 +59,8 @@ class DeformableRigidManagerTest : public ::testing::Test {
     plant_.Finalize();
     auto deformable_rigid_manager =
         std::make_unique<DeformableRigidManager<double>>();
-    deformable_rigid_manager_ = &plant_.SetDiscreteUpdateManager(
-        std::move(deformable_rigid_manager));
+    deformable_rigid_manager_ = deformable_rigid_manager.get();
+    plant_.SetDiscreteUpdateManager(std::move(deformable_rigid_manager));
     deformable_rigid_manager_->RegisterCollisionObjects(scene_graph_);
   }
 
@@ -196,11 +197,10 @@ std::unique_ptr<MultibodyPlant<double>> MakePlant(
     auto deformable_rigid_manager =
         std::make_unique<DeformableRigidManager<double>>();
     DeformableRigidManager<double>* deformable_rigid_manager_ptr =
-        &plant->SetDiscreteUpdateManager(
-            std::move(deformable_rigid_manager));
+        deformable_rigid_manager.get();
+    plant->SetDiscreteUpdateManager(std::move(deformable_rigid_manager));
     if (contact_solver != nullptr) {
-      deformable_rigid_manager_ptr->SetContactSolver(
-          std::move(contact_solver));
+      deformable_rigid_manager_ptr->SetContactSolver(std::move(contact_solver));
     }
   } else {
     if (contact_solver != nullptr) {

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1022,6 +1022,29 @@ void MultibodyPlant<T>::CalcContactJacobiansCache(
 }
 
 template <typename T>
+void MultibodyPlant<T>::SetDiscreteUpdateManager(
+    std::unique_ptr<internal::DiscreteUpdateManager<T>> manager) {
+  // N.B. This requirement is really more important on the side of the
+  // manager's constructor, since most likely it'll need MBP's topology at
+  // least to build the contact problem. However, here we play safe and demand
+  // finalization right here.
+  DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+  DRAKE_DEMAND(manager != nullptr);
+  manager->SetOwningMultibodyPlant(this);
+  discrete_update_manager_ = std::move(manager);
+  RemoveUnsupportedScalars(*discrete_update_manager_);
+}
+
+template <typename T>
+void MultibodyPlant<T>::AddPhysicalModel(
+    std::unique_ptr<internal::PhysicalModel<T>> model) {
+  DRAKE_MBP_THROW_IF_FINALIZED();
+  DRAKE_DEMAND(model != nullptr);
+  auto& added_model = physical_models_.emplace_back(std::move(model));
+  RemoveUnsupportedScalars(*added_model);
+}
+
+template <typename T>
 void MultibodyPlant<T>::set_penetration_allowance(
     double penetration_allowance) {
   if (penetration_allowance <= 0) {

--- a/multibody/plant/test/discrete_update_manager_test.cc
+++ b/multibody/plant/test/discrete_update_manager_test.cc
@@ -173,15 +173,17 @@ class DiscreteUpdateManagerTest : public ::testing::Test {
  protected:
   void SetUp() override {
     plant_.AddRigidBody("rigid body", SpatialInertia<double>());
-    dummy_model_ =
-        &plant_.AddPhysicalModel(std::make_unique<DummyModel<double>>());
+    auto dummy_model = std::make_unique<DummyModel<double>>();
+    dummy_model_ = dummy_model.get();
+    plant_.AddPhysicalModel(std::move(dummy_model));
     dummy_model_->AppendDiscreteState(dummy_discrete_state());
     plant_.Finalize();
     // MultibodyPlant::num_velocities() only reports the number of rigid
     // generalized velocities for the rigid model.
     EXPECT_EQ(plant_.num_velocities(), kNumRigidDofs);
-    dummy_manager_ = &plant_.SetDiscreteUpdateManager(
-        std::make_unique<DummyDiscreteUpdateManager<double>>());
+    auto dummy_manager = std::make_unique<DummyDiscreteUpdateManager<double>>();
+    dummy_manager_ = dummy_manager.get();
+    plant_.SetDiscreteUpdateManager(std::move(dummy_manager));
   }
 
   static VectorXd dummy_discrete_state() {

--- a/multibody/plant/test/physical_model_test.cc
+++ b/multibody/plant/test/physical_model_test.cc
@@ -19,8 +19,9 @@ class PhysicalModelTest : public ::testing::Test {
  protected:
   void SetUp() override {
     // TODO(xuchenhan-tri): Add a test with more than one physical model.
-    dummy_model_ =
-        &plant_.AddPhysicalModel(std::make_unique<DummyModel<double>>());
+    auto dummy_model = std::make_unique<DummyModel<double>>();
+    dummy_model_ = dummy_model.get();
+    plant_.AddPhysicalModel(std::move(dummy_model));
     // An artificial scenario where the state is added in multiple passes.
     dummy_model_->AppendDiscreteState(dummy_state1());
     dummy_model_->AppendDiscreteState(dummy_state2());


### PR DESCRIPTION
* Change SetContactSolver(), AddPhysicalModel(), and SetDiscreteUpdateManager() to void methods that take a unique pointer
to the base class.

* Move definition of these methods to .cc file to comply with GSG.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15195)
<!-- Reviewable:end -->
