### PR TITLE
[framework] Remove manipulation_station dependency from test

### DIFF
--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -911,7 +911,6 @@ drake_cc_googletest(
     deps = [
         ":diagram_builder",
         ":system_html",
-        "//examples/manipulation_station",
         "//systems/primitives",
     ],
 )

--- a/systems/framework/test/system_html_test.cc
+++ b/systems/framework/test/system_html_test.cc
@@ -5,7 +5,6 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "drake/examples/manipulation_station/manipulation_station.h"
 #include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/system.h"
@@ -89,17 +88,6 @@ GTEST_TEST(SystemHtmlTest, SystemWithFanout) {
   // Proof of life test for fanout.
   EXPECT_THAT(html, HasSubstr(R"(from: "terp_u0", to: "drake/systems/Multiplexer)"));
   EXPECT_THAT(html, HasSubstr(R"(from: "terp_u0", to: "drake/systems/DiscreteDerivative)"));
-}
-
-GTEST_TEST(SystemHtmlTest, ManipulationStation) {
-  examples::manipulation_station::ManipulationStation<double> station;
-  station.SetupClutterClearingStation();
-  station.Finalize();
-  const std::string html = GenerateHtml(station);
-
-  // Proof of life test for a more complex diagram.
-  EXPECT_THAT(html,
-              HasSubstr(R"(key: "plant", group: "manipulation_station")"));
 }
 
 }  // namespace systems


### PR DESCRIPTION
The system_html_test used ManipulationStation to demonstrate a large and complex diagram. The problem was that bazel test //systems/framework/... was therefore rebuilding a huge amount of additional code, slowing down development on patches that change the framework. I've been using a version of this patch locally as I'm working on systems, but I think its time to improve it for everyone else.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15196)
<!-- Reviewable:end -->
