### PR TITLE
[framework] Add ValueProducer

### DIFF
--- a/multibody/fixed_fem/dev/deformable_rigid_manager.h
+++ b/multibody/fixed_fem/dev/deformable_rigid_manager.h
@@ -102,7 +102,7 @@ class DeformableRigidManager final
    MultibodyPlant at `this` DeformableRigidManager. */
   void RegisterDeformableGeometries();
 
-  void DeclareCacheEntries(MultibodyPlant<T>* plant) final;
+  void DeclareCacheEntries() final;
 
   void DoCalcContactSolverResults(
       const systems::Context<T>& context,

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -705,6 +705,7 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
         "//systems/analysis:simulator",
+        "//systems/framework:abstract_value_cloner",
     ],
 )
 

--- a/multibody/plant/discrete_update_manager.cc
+++ b/multibody/plant/discrete_update_manager.cc
@@ -52,6 +52,17 @@ const MultibodyTree<T>& DiscreteUpdateManager<T>::internal_tree() const {
 }
 
 template <typename T>
+systems::CacheEntry& DiscreteUpdateManager<T>::DeclareCacheEntry(
+    std::string description, systems::ValueProducer value_producer,
+    std::set<systems::DependencyTicket> prerequisites_of_calc) {
+  DRAKE_DEMAND(mutable_plant_ != nullptr);
+  DRAKE_DEMAND(mutable_plant_ == plant_);
+  return MultibodyPlantDiscreteUpdateManagerAttorney<T>::DeclareCacheEntry(
+      mutable_plant_, std::move(description), std::move(value_producer),
+      std::move(prerequisites_of_calc));
+}
+
+template <typename T>
 const contact_solvers::internal::ContactSolverResults<T>&
 DiscreteUpdateManager<T>::EvalContactSolverResults(
     const systems::Context<T>& context) const {

--- a/multibody/plant/discrete_update_manager.h
+++ b/multibody/plant/discrete_update_manager.h
@@ -91,9 +91,10 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
     DRAKE_DEMAND(plant != nullptr);
     DRAKE_DEMAND(plant->is_finalized());
     plant_ = plant;
+    mutable_plant_ = plant;
     multibody_state_index_ = plant_->GetDiscreteStateIndexOrThrow();
     ExtractModelInfo();
-    DeclareCacheEntries(plant);
+    DeclareCacheEntries();
   }
 
   /* Given the state of the model stored in `context`, this method performs the
@@ -154,8 +155,8 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
   virtual void ExtractModelInfo() {}
 
   /* Derived DiscreteUpdateManager should override this method to declare
-   cache entries in the owning MultibodyPlant `plant`. */
-  virtual void DeclareCacheEntries(MultibodyPlant<T>*) {}
+   cache entries in the owning MultibodyPlant. */
+  virtual void DeclareCacheEntries() {}
 
   /* Returns the discrete state index of the rigid position and velocity states
    declared by MultibodyPlant. */
@@ -170,6 +171,10 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
   // MultibodyPlantDiscreteUpdateManagerAttorney spelling and order of same.
 
   const MultibodyTree<T>& internal_tree() const;
+
+  systems::CacheEntry& DeclareCacheEntry(std::string description,
+                                         systems::ValueProducer,
+                                         std::set<systems::DependencyTicket>);
 
   const contact_solvers::internal::ContactSolverResults<T>&
   EvalContactSolverResults(const systems::Context<T>& context) const;
@@ -234,6 +239,7 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
 
  private:
   const MultibodyPlant<T>* plant_{nullptr};
+  MultibodyPlant<T>* mutable_plant_{nullptr};
   systems::DiscreteStateIndex multibody_state_index_;
 };
 }  // namespace internal

--- a/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
+++ b/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
@@ -33,6 +33,15 @@ class MultibodyPlantDiscreteUpdateManagerAttorney {
     return plant.internal_tree();
   }
 
+  static systems::CacheEntry& DeclareCacheEntry(
+      MultibodyPlant<T>* plant, std::string description,
+      systems::ValueProducer value_producer,
+      std::set<systems::DependencyTicket> prerequisites_of_calc) {
+    return plant->DeclareCacheEntry(std::move(description),
+                                    std::move(value_producer),
+                                    std::move(prerequisites_of_calc));
+  }
+
   static const contact_solvers::internal::ContactSolverResults<T>&
   EvalContactSolverResults(const MultibodyPlant<T>& plant,
                            const systems::Context<T>& context) {

--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -18,6 +18,7 @@ drake_cc_package_library(
     name = "framework",
     visibility = ["//visibility:public"],
     deps = [
+        ":abstract_value_cloner",
         ":abstract_values",
         ":cache_and_dependency_tracker",
         ":cache_entry",
@@ -55,6 +56,7 @@ drake_cc_package_library(
         ":system_symbolic_inspector",
         ":system_visitor",
         ":value_checker",
+        ":value_producer",
         ":value_to_abstract_value",
         ":vector",
         ":vector_system",
@@ -107,6 +109,16 @@ drake_cc_library(
         ":vector",
         "//common:essential",
         "//common:nice_type_name",
+        "//common:value",
+    ],
+)
+
+drake_cc_library(
+    name = "abstract_value_cloner",
+    srcs = ["abstract_value_cloner.cc"],
+    hdrs = ["abstract_value_cloner.h"],
+    deps = [
+        "//common:copyable_unique_ptr",
         "//common:value",
     ],
 )
@@ -261,6 +273,7 @@ drake_cc_library(
     ],
     deps = [
         ":context_base",
+        ":value_producer",
     ],
 )
 
@@ -320,10 +333,12 @@ drake_cc_library(
         "system_base.h",
     ],
     deps = [
+        ":abstract_value_cloner",
         ":cache_entry",
         ":context_base",
         ":input_port_base",
         ":output_port_base",
+        ":value_producer",
     ],
 )
 
@@ -431,6 +446,18 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "value_producer",
+    srcs = ["value_producer.cc"],
+    hdrs = ["value_producer.h"],
+    deps = [
+        ":context_base",
+        ":framework_common",
+        "//common:copyable_unique_ptr",
+        "//common:value",
+    ],
+)
+
+drake_cc_library(
     name = "system",
     srcs = ["system.cc"],
     hdrs = ["system.h"],
@@ -465,6 +492,7 @@ drake_cc_library(
         ":cache_entry",
         ":framework_common",
         ":output_port",
+        ":value_producer",
         ":vector",
         "//common:default_scalars",
         "//common:essential",
@@ -510,6 +538,7 @@ drake_cc_library(
     srcs = ["leaf_system.cc"],
     hdrs = ["leaf_system.h"],
     deps = [
+        ":abstract_value_cloner",
         ":leaf_context",
         ":leaf_output_port",
         ":model_values",
@@ -517,6 +546,7 @@ drake_cc_library(
         ":system_scalar_converter",
         ":system_symbolic_inspector",
         ":value_checker",
+        ":value_producer",
         "//common:default_scalars",
         "//common:essential",
         "//common:pointer_cast",
@@ -594,6 +624,7 @@ drake_cc_library(
     srcs = ["diagram.cc"],
     hdrs = ["diagram.h"],
     deps = [
+        ":abstract_value_cloner",
         ":diagram_context",
         ":diagram_output_port",
         ":system",
@@ -670,6 +701,14 @@ drake_cc_library(
 )
 
 # === test/ ===
+
+drake_cc_googletest(
+    name = "abstract_value_cloner_test",
+    deps = [
+        ":abstract_value_cloner",
+        ":vector",
+    ],
+)
 
 drake_cc_googletest(
     name = "basic_vector_test",
@@ -951,6 +990,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "system_test",
     deps = [
+        ":abstract_value_cloner",
         ":leaf_context",
         ":leaf_output_port",
         ":system",
@@ -1032,6 +1072,16 @@ drake_cc_googletest(
     name = "system_scalar_conversion_doxygen_test",
     deps = [
         "//examples/pendulum:pendulum_plant",
+    ],
+)
+
+drake_cc_googletest(
+    name = "value_producer_test",
+    deps = [
+        ":abstract_value_cloner",
+        ":leaf_context",
+        ":value_producer",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/systems/framework/abstract_value_cloner.cc
+++ b/systems/framework/abstract_value_cloner.cc
@@ -1,0 +1,27 @@
+#include "drake/systems/framework/abstract_value_cloner.h"
+
+#include <utility>
+
+namespace drake {
+namespace systems {
+namespace internal {
+
+// We don't need to clone the model_value here (we can move it directly into
+// our storage) because this constructor is private and the public constructor
+// always makes a copy before calling us, which means we're guaranteed that
+// nobody else has an alias of this model_value to mutate it out from under us.
+AbstractValueCloner::AbstractValueCloner(
+    std::unique_ptr<AbstractValue> model_value)
+    : model_value_(std::move(model_value)) {
+  DRAKE_DEMAND(model_value_ != nullptr);
+}
+
+AbstractValueCloner::~AbstractValueCloner() = default;
+
+std::unique_ptr<AbstractValue> AbstractValueCloner::operator()() const {
+  return model_value_->Clone();
+}
+
+}  // namespace internal
+}  // namespace systems
+}  // namespace drake

--- a/systems/framework/abstract_value_cloner.h
+++ b/systems/framework/abstract_value_cloner.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <memory>
+
+#include "drake/common/copyable_unique_ptr.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/value.h"
+
+namespace drake {
+namespace systems {
+namespace internal {
+
+/* Provies a ValueProducer::AllocateCallback functor that clones the given
+model_value. */
+class AbstractValueCloner final {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(AbstractValueCloner)
+
+  /* Creates a clone functor for the given model value. */
+  template <typename SomeOutput>
+  explicit AbstractValueCloner(const SomeOutput& model_value)
+      : AbstractValueCloner(AbstractValue::Make<SomeOutput>(model_value)) {}
+
+  ~AbstractValueCloner();
+
+  /* Returns a Clone of the model_value passed into the constructor. */
+  std::unique_ptr<AbstractValue> operator()() const;
+
+ private:
+  /* Creates a clone functor for the given model value. */
+  explicit AbstractValueCloner(std::unique_ptr<AbstractValue> model_value);
+
+  copyable_unique_ptr<AbstractValue> model_value_;
+};
+
+}  // namespace internal
+}  // namespace systems
+}  // namespace drake

--- a/systems/framework/diagram.cc
+++ b/systems/framework/diagram.cc
@@ -6,6 +6,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/text_logging.h"
+#include "drake/systems/framework/abstract_value_cloner.h"
 #include "drake/systems/framework/subvector.h"
 #include "drake/systems/framework/system_constraint.h"
 #include "drake/systems/framework/system_visitor.h"
@@ -1420,12 +1421,10 @@ void Diagram<T>::Initialize(std::unique_ptr<Blueprint> blueprint) {
   // used.
   event_times_buffer_cache_index_ =
       this->DeclareCacheEntry(
-          "event_times_buffer",
-          [this]() {
-            std::vector<T> vec(num_subsystems());
-            return AbstractValue::Make<std::vector<T>>(vec);
-          },
-          [](const ContextBase&, AbstractValue*) { /* do nothing */ },
+          "event_times_buffer", ValueProducer(
+              // TODO(jwnimmer-tri) Improve ValueProducer constructor sugar.
+              internal::AbstractValueCloner(std::vector<T>(num_subsystems())),
+              &ValueProducer::NoopCalc),
           {this->nothing_ticket()}).cache_index();
 
   // Generate a map from the System pointer to its index in the registered

--- a/systems/framework/leaf_output_port.h
+++ b/systems/framework/leaf_output_port.h
@@ -13,6 +13,7 @@
 #include "drake/systems/framework/cache_entry.h"
 #include "drake/systems/framework/framework_common.h"
 #include "drake/systems/framework/output_port.h"
+#include "drake/systems/framework/value_producer.h"
 
 namespace drake {
 namespace systems {
@@ -33,13 +34,10 @@ class LeafOutputPort final : public OutputPort<T> {
 
   ~LeafOutputPort() final = default;
 
-  // TODO(sherm1) These callbacks should not be specific to this class. Move
-  // elsewhere, e.g. framework_common.h so they can be shared with cache entry.
-
   /** Signature of a function suitable for allocating an object that can hold
   a value of a particular output port. The result is returned as an
   AbstractValue even if this is a vector-valued port. */
-  using AllocCallback = std::function<std::unique_ptr<AbstractValue>()>;
+  using AllocCallback = ValueProducer::AllocateCallback;
 
   /** Signature of a function suitable for calculating a value of a particular
   output port, given a place to put the value. */

--- a/systems/framework/system.cc
+++ b/systems/framework/system.cc
@@ -933,11 +933,12 @@ System<T>::System(SystemScalarConverter converter)
   // For the time derivative cache we need to use the general form for
   // cache creation because we're dealing with pre-defined allocator and
   // calculator method signatures.
-  CacheEntry::AllocCallback alloc_derivatives = [this]() {
+  // TODO(jwnimmer-tri) Improve ValueProducer constructor sugar.
+  ValueProducer::AllocateCallback alloc_derivatives = [this]() {
     return std::make_unique<Value<ContinuousState<T>>>(
         this->AllocateTimeDerivatives());
   };
-  CacheEntry::CalcCallback calc_derivatives = [this](
+  ValueProducer::CalcCallback calc_derivatives = [this](
       const ContextBase& context_base, AbstractValue* result) {
     DRAKE_DEMAND(result != nullptr);
     ContinuousState<T>& state =
@@ -950,7 +951,8 @@ System<T>::System(SystemScalarConverter converter)
   time_derivatives_cache_index_ =
       this->DeclareCacheEntryWithKnownTicket(
               xcdot_ticket(), "time derivatives",
-              std::move(alloc_derivatives), std::move(calc_derivatives),
+              ValueProducer(
+                  std::move(alloc_derivatives), std::move(calc_derivatives)),
               {all_sources_ticket()})
           .cache_index();
 

--- a/systems/framework/test/abstract_value_cloner_test.cc
+++ b/systems/framework/test/abstract_value_cloner_test.cc
@@ -1,0 +1,30 @@
+#include "drake/systems/framework/abstract_value_cloner.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/systems/framework/basic_vector.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+// Tests AbstractValueCloner on a copyable type.
+GTEST_TEST(AbstractValueClonerTest, Copyable) {
+  const internal::AbstractValueCloner dut(std::string("foo"));
+  const internal::AbstractValueCloner dut_copy(dut);
+  std::unique_ptr<AbstractValue> new_value = dut_copy();
+  EXPECT_EQ(new_value->get_value<std::string>(), "foo");
+}
+
+// Tests AbstractValueCloner on a non-copyable, cloneable type.
+GTEST_TEST(AbstractValueClonerTest, Cloneable) {
+  static_assert(is_cloneable<BasicVector<double>>::value, "");
+  const internal::AbstractValueCloner dut(BasicVector<double>(2));
+  const internal::AbstractValueCloner dut_copy(dut);
+  std::unique_ptr<AbstractValue> new_value = dut_copy();
+  EXPECT_EQ(new_value->get_value<BasicVector<double>>().size(), 2);
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake

--- a/systems/framework/test/output_port_test.cc
+++ b/systems/framework/test/output_port_test.cc
@@ -216,7 +216,7 @@ class LeafOutputPortTest : public ::testing::Test {
           OutputPortIndex(dummy_.num_output_ports()),
           dummy_.assign_next_dependency_ticket(), kAbstractValued, 0 /* size */,
           &dummy_.DeclareCacheEntry(
-              "absport", alloc_string, calc_string));
+              "absport", ValueProducer(alloc_string, calc_string)));
   LeafOutputPort<double>& absport_general_ = *absport_general_ptr_;
   std::unique_ptr<LeafOutputPort<double>> vecport_general_ptr_ =
       internal::FrameworkFactory::Make<LeafOutputPort<double>>(
@@ -227,7 +227,7 @@ class LeafOutputPortTest : public ::testing::Test {
           OutputPortIndex(dummy_.num_output_ports()),
           dummy_.assign_next_dependency_ticket(), kVectorValued, 3 /* size */,
           &dummy_.DeclareCacheEntry(
-              "vecport", alloc_myvector3, calc_vector3));
+              "vecport", ValueProducer(alloc_myvector3, calc_vector3)));
   LeafOutputPort<double>& vecport_general_ = *vecport_general_ptr_;
   unique_ptr<Context<double>> context_{dummy_.CreateDefaultContext()};
 };
@@ -330,7 +330,8 @@ TEST_F(LeafOutputPortTest, ThrowIfNullAlloc) {
       OutputPortIndex(dummy_.num_output_ports()),
       dummy_.assign_next_dependency_ticket(),
       kAbstractValued, 0 /* size */,
-      &dummy_.DeclareCacheEntry("null", alloc_null, calc_string));
+      &dummy_.DeclareCacheEntry(
+          "null", ValueProducer(alloc_null, calc_string)));
 
   // Creating a context for this system should fail when it tries to allocate
   // a cache entry for null_port.

--- a/systems/framework/test/value_producer_test.cc
+++ b/systems/framework/test/value_producer_test.cc
@@ -1,0 +1,94 @@
+#include "drake/systems/framework/value_producer.h"
+
+#include <stdexcept>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/systems/framework/abstract_value_cloner.h"
+#include "drake/systems/framework/leaf_context.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+using AllocateCallback = ValueProducer::AllocateCallback;
+using CalcCallback = ValueProducer::CalcCallback;
+
+std::unique_ptr<AbstractValue> AllocateFoo() {
+  return AbstractValue::Make<std::string>("foo");
+}
+
+void CalcBar(const ContextBase&, AbstractValue* out) {
+  out->set_value<std::string>("bar");
+}
+
+class ValueProducerTest : public ::testing::Test {
+ protected:
+  void CheckValues(
+      const ValueProducer& dut,
+      std::string_view expected_allocate_value,
+      std::string_view expected_calc_value) {
+    EXPECT_TRUE(dut.is_valid());
+    std::unique_ptr<AbstractValue> output = dut.Allocate();
+    EXPECT_EQ(output->get_value<std::string>(), expected_allocate_value);
+    dut.Calc(context_, output.get());
+    EXPECT_EQ(output->get_value<std::string>(), expected_calc_value);
+  }
+
+  const LeafContext<double> context_;
+};
+
+// Test the default constructor, as well as that operations on a default-
+// constructed object produce suitable results (including operations on
+// copies of a default-constructed object).
+TEST_F(ValueProducerTest, DefaultCtor) {
+  auto storage = AbstractValue::Make<int>(0);
+
+  const ValueProducer empty;
+  EXPECT_FALSE(empty.is_valid());
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      empty.Allocate(), std::exception,
+      ".* null Allocate.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      empty.Calc(context_, storage.get()), std::exception,
+      ".* null Calc.*");
+
+  const ValueProducer empty_copy(empty);
+  EXPECT_FALSE(empty_copy.is_valid());
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      empty_copy.Allocate(), std::exception,
+      ".* null Allocate.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      empty_copy.Calc(context_, storage.get()), std::exception,
+      ".* null Calc.*");
+}
+
+// Test the constructor when given invalid function(s).
+TEST_F(ValueProducerTest, InvalidCallbacks) {
+  const AllocateCallback good_allocate = internal::AbstractValueCloner(0);
+  const AllocateCallback bad_allocate;
+  const CalcCallback good_calc = &ValueProducer::NoopCalc;
+  const CalcCallback bad_calc;
+  EXPECT_NO_THROW(ValueProducer(good_allocate, good_calc));
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      ValueProducer(bad_allocate, good_calc), std::exception,
+      ".* null Allocate.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      ValueProducer(good_allocate, bad_calc), std::exception,
+      ".* null Calc.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      ValueProducer(bad_allocate, bad_calc), std::exception,
+      ".* null .*");
+}
+
+// Test the constructor when given plain functions.
+TEST_F(ValueProducerTest, PlainFunction) {
+  const ValueProducer dut(&AllocateFoo, &CalcBar);
+  CheckValues(dut, "foo", "bar");
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake

--- a/systems/framework/value_producer.cc
+++ b/systems/framework/value_producer.cc
@@ -1,0 +1,54 @@
+#include "drake/systems/framework/value_producer.h"
+
+#include <stdexcept>
+#include <utility>
+
+namespace drake {
+namespace systems {
+
+ValueProducer::ValueProducer() = default;
+
+ValueProducer::ValueProducer(
+    AllocateCallback allocate, CalcCallback calc)
+    : allocate_(std::move(allocate)), calc_(std::move(calc)) {
+  if (allocate_ == nullptr) {
+    throw std::logic_error(
+        "Cannot create a ValueProducer with a null AllocateCallback");
+  }
+  if (calc_ == nullptr) {
+    throw std::logic_error(
+        "Cannot create a ValueProducer with a null Calc");
+  }
+}
+
+ValueProducer::~ValueProducer() = default;
+
+bool ValueProducer::is_valid() const {
+  return (allocate_ != nullptr) && (calc_ != nullptr);
+}
+
+void ValueProducer::NoopCalc(const ContextBase&, AbstractValue*) {}
+
+std::unique_ptr<AbstractValue> ValueProducer::Allocate() const {
+  if (allocate_ == nullptr) {
+    throw std::logic_error(
+        "ValueProducer cannot invoke a null AllocateCallback");
+  }
+  return allocate_();
+}
+
+void ValueProducer::Calc(const ContextBase& context,
+                         AbstractValue* output) const {
+  if (output == nullptr) {
+    throw std::logic_error(
+        "ValueProducer output was nullptr");
+  }
+  if (calc_ == nullptr) {
+    throw std::logic_error(
+        "ValueProducer cannot invoke a null CalcCallback");
+  }
+  return calc_(context, output);
+}
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/framework/value_producer.h
+++ b/systems/framework/value_producer.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/value.h"
+#include "drake/systems/framework/context_base.h"
+
+namespace drake {
+namespace systems {
+
+/** %ValueProducer computes an AbstractValue output based on a ContextBase
+input.
+
+It provides two functions for that purpose:
+- Allocate() returns new storage that is suitably typed to hold the output.
+- Calc() takes a context as input and writes to an output pointer.
+
+@note At the moment, this class only serves to consolidate its two function
+objects within single class. In the future, we will add more convenient
+syntactic sugar in support of simpler callback functions. */
+class ValueProducer final {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ValueProducer)
+
+  /** Signature of a function suitable for allocating an object that can hold
+  a value compatible with our Calc function. The result is always returned as
+  an AbstractValue but must contain the correct concrete type. */
+  using AllocateCallback = std::function<std::unique_ptr<AbstractValue>()>;
+
+  /** Signature of a function suitable for calculating a context-dependent
+  value, given a place to put the value. The function may presume that the
+  storage pointed to by the second argument will be of the proper type (as
+  returned by an AllocateCallback), but should not presume that the storage
+  has been initialized with any particular value; the function should always
+  fully overwrite the output storage with a new value. */
+  using CalcCallback = std::function<void(const ContextBase&, AbstractValue*)>;
+
+  /** Creates an invalid object; calls to Allocate or Calc will throw. */
+  ValueProducer();
+
+  /** Creates an object that allocates and calculates using the given functors.
+  @throws std::exception if either argument is nullptr. */
+  ValueProducer(AllocateCallback allocate, CalcCallback calc);
+
+  // TODO(jwnimmer-tri) Add constructor sugar for using model values and/or
+  // member function pointers.
+
+  ~ValueProducer();
+
+  /** Returns true iff the allocate and calc callbacks are both non-null.
+  (The only way they can be null is if the ValueProducer was default constructed
+  or moved from.) */
+  bool is_valid() const;
+
+  /** This static function is provided for users who need an empty CalcCallback.
+  Passing `&ValueProducer::NoopCalc` as ValueProducer's last constructor
+  argument will create a function that does not compute anything, but can still
+  allocate. */
+  static void NoopCalc(const ContextBase&, AbstractValue*);
+
+  /** Invokes the allocate function provided to the constructor.
+  @throws std::exception if is_valid() is false. */
+  std::unique_ptr<AbstractValue> Allocate() const;
+
+  /** Invokes the calc function provided to the constructor.
+  @throws std::exception if is_valid() is false. */
+  void Calc(const ContextBase& context, AbstractValue* output) const;
+
+ private:
+  AllocateCallback allocate_;
+  CalcCallback calc_;
+};
+
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
The allocation and calculation functions must always work together as a team, so it makes sense to abstract them as a single component, which then paves the way for consolidating the function wrapping sugar for reuse across cache entries, output ports, time derivatives, etc.

(The overall goal is on display at #15161.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15198)
<!-- Reviewable:end -->
