### PR TITLE
Add DeformableContactData

### DIFF
--- a/multibody/fixed_fem/dev/BUILD.bazel
+++ b/multibody/fixed_fem/dev/BUILD.bazel
@@ -108,6 +108,15 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "deformable_contact_data",
+    srcs = ["deformable_contact_data.cc"],
+    hdrs = ["deformable_contact_data.h"],
+    deps = [
+        ":deformable_rigid_contact_pair",
+    ],
+)
+
+drake_cc_library(
     name = "deformable_model",
     srcs = [
         "deformable_model.cc",
@@ -152,6 +161,7 @@ drake_cc_library(
     ],
     deps = [
         ":collision_objects",
+        ":deformable_contact_data",
         ":deformable_model",
         ":deformable_rigid_contact_pair",
         ":fem_solver",
@@ -576,6 +586,7 @@ drake_cc_googletest(
     name = "deformable_contact_test",
     deps = [
         ":deformable_contact",
+        ":deformable_contact_data",
         "//common/test_utilities:eigen_matrix_compare",
         "//geometry/proximity:surface_mesh",
         "//geometry/proximity:volume_mesh",

--- a/multibody/fixed_fem/dev/deformable_contact_data.cc
+++ b/multibody/fixed_fem/dev/deformable_contact_data.cc
@@ -1,0 +1,85 @@
+#include "drake/multibody/fixed_fem/dev/deformable_contact_data.h"
+
+#include <algorithm>
+#include <set>
+#include <utility>
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+namespace internal {
+
+template <typename T>
+DeformableContactData<T>::DeformableContactData(
+    std::vector<DeformableRigidContactPair<T>> contact_pairs,
+    const geometry::VolumeMesh<T>& deformable_mesh)
+    : contact_pairs_(std::move(contact_pairs)),
+      permuted_vertex_indexes_(deformable_mesh.num_vertices(), -1),
+      permuted_to_original_indexes_(deformable_mesh.num_vertices()) {
+  num_contact_points_ = 0;
+  if (!contact_pairs_.empty()) {
+    CalcParticipatingVertices(deformable_mesh);
+    for (const auto& contact_pair : contact_pairs_) {
+      num_contact_points_ += contact_pair.num_contact_points();
+    }
+  } else {
+    std::iota(std::begin(permuted_vertex_indexes_),
+              std::end(permuted_vertex_indexes_), 0);
+    std::iota(std::begin(permuted_to_original_indexes_),
+              std::end(permuted_to_original_indexes_), 0);
+  }
+}
+
+template <typename T>
+void DeformableContactData<T>::CalcParticipatingVertices(
+    const geometry::VolumeMesh<T>& deformable_mesh) {
+  constexpr int kNumVerticesInTetrahedron =
+      geometry::VolumeMesh<T>::kVertexPerElement;
+
+  /* Build the permutation for vertices in contact first. */
+  num_vertices_in_contact_ = 0;
+  for (int i = 0; i < num_contact_pairs(); ++i) {
+    const DeformableContactSurface<T>& contact_surface =
+        contact_pairs_[i].contact_surface;
+    for (int j = 0; j < contact_surface.num_polygons(); ++j) {
+      const geometry::VolumeElementIndex tet_in_contact =
+          contact_surface.polygon_data(j).tet_index;
+      for (int k = 0; k < kNumVerticesInTetrahedron; ++k) {
+        const int v = deformable_mesh.element(tet_in_contact).vertex(k);
+        if (permuted_vertex_indexes_[v] == -1) {
+          permuted_vertex_indexes_[v] = num_vertices_in_contact_;
+          permuted_to_original_indexes_[num_vertices_in_contact_] = v;
+          ++num_vertices_in_contact_;
+        }
+      }
+    }
+  }
+
+  /* Sort the participating vertices in the inverse permutation for stability.
+   */
+  std::sort(permuted_to_original_indexes_.begin(),
+            permuted_to_original_indexes_.begin() + num_vertices_in_contact_);
+  /* Fix the original permutation. */
+  for (int i = 0; i < num_vertices_in_contact_; ++i) {
+    permuted_vertex_indexes_[permuted_to_original_indexes_[i]] = i;
+  }
+
+  /* Add the remaining vertices to the permutations. */
+  int index = num_vertices_in_contact_;
+  for (int i = 0; i < static_cast<int>(permuted_vertex_indexes_.size()); ++i) {
+    if (permuted_vertex_indexes_[i] == -1) {
+      permuted_vertex_indexes_[i] = index;
+      permuted_to_original_indexes_[index] = i;
+      ++index;
+    }
+  }
+
+  DRAKE_DEMAND(index == static_cast<int>(permuted_to_original_indexes_.size()));
+}
+
+}  // namespace internal
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fixed_fem::internal::DeformableContactData)

--- a/multibody/fixed_fem/dev/deformable_contact_data.h
+++ b/multibody/fixed_fem/dev/deformable_contact_data.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/multibody/fixed_fem/dev/deformable_rigid_contact_pair.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+namespace internal {
+
+/* DeformbaleContactData stores all the contact query information related to a
+ particular deformable body. In addition, it stores information about the
+ indexes of vertices participating in contact for this deformable body. See
+ below for an example. */
+template <typename T>
+class DeformableContactData {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DeformableContactData)
+  /* Constructs the DeformableContactData for a deformable body given all
+   deformable-rigid contact pairs involving the deformable body and the volume
+   mesh representing the deformable body geometry. */
+  DeformableContactData(
+      std::vector<DeformableRigidContactPair<T>> contact_pairs,
+      const geometry::VolumeMesh<T>& deformable_mesh);
+
+  /* A 2D anologue of a deformable mesh D in contact with a rigid body R. The
+   deformable mesh has 6 vertices with indexes v0-v5. Vertices v1, v2, and v5
+   are said to be "participating in contact" as the element that they are
+   incident to is in contact with the rigid body R.
+
+                          v3       v4       v5
+                           ●--------●--------●
+                           |\       |       /|
+                           | \      |      / |
+                           |  \  D  |     /  |
+                           |   \    |    /   |
+                           |    \   |   /    |
+                           |     \  |  /     |
+                           |      \ | /   ●--+----●
+                           |       \|/    |  |    |
+                           ●--------●-----+--●    |
+                          v0       v1     | v2    |
+                                          |       |
+                                          |  R    |
+                                          ●-------●                */
+
+  /* Returns a vector v such that v[i] gives the permuted vertex index for
+   vertex i. The vertex indexes are permuted in a way characterized by the
+   following properties:
+      1. The permuted index of any vertex participating in contact is smaller
+         than the permuted index of any vertex not participating in contact.
+      2. If vertices with original indexes i and j (with i < j) are both
+         participating in contact or both not participating in contact, then the
+         permuted indexes satisfy v[i] < v[j].
+
+   In the example shown above, v1, v2, and v5 are participating in contact and
+   thus have new indexes 0, 1 and 2. v0, v3, and v4 are not participating in
+   contact and have new indexes 3, 4, and 5.
+
+   Hence the returned vector would be {3, 0, 1, 4, 5, 2}. */
+  const std::vector<int>& permuted_vertex_indexes() const {
+    return permuted_vertex_indexes_;
+  }
+
+  /* Returns the inverse mapping of `permuted_vertex_indexes()`. For the example
+   above, the returned vector would be {1, 2, 5, 0, 3, 4}. */
+  const std::vector<int>& permuted_to_original_indexes() const {
+    return permuted_vertex_indexes_;
+  }
+
+  /* Returns the number of vertices of the deformable body that participate in
+   contact. */
+  int num_vertices_in_contact() const { return num_vertices_in_contact_; }
+
+  /* Returns the total number of contact points that have the deformable body as
+   one of the bodies in contact. */
+  int num_contact_points() const { return num_contact_points_; }
+
+  /* Returns the number of deformable rigid contact pairs that involve this
+   deformable body. */
+  int num_contact_pairs() const { return contact_pairs_.size(); }
+
+  /* Returns all deformable-rigid contact pairs that involve this deformable
+   body with no particular order. */
+  const std::vector<DeformableRigidContactPair<T>>& contact_pairs() const {
+    return contact_pairs_;
+  }
+
+ private:
+  /* Populates the data member `permuted_vertex_indexes_`. Only called by the
+   constructor when there exists at least one contact pair. */
+  void CalcParticipatingVertices(
+      const geometry::VolumeMesh<T>& deformable_mesh);
+
+  /* All contact pairs involving the deformable body of interest. */
+  std::vector<DeformableRigidContactPair<T>> contact_pairs_{};
+  /* Maps vertex indexes to "permuted vertex indexes". See the getter method for
+   more info. */
+  std::vector<int> permuted_vertex_indexes_{};
+  std::vector<int> permuted_to_original_indexes_{};
+  int num_contact_points_{0};
+  int num_vertices_in_contact_{0};
+};
+
+}  // namespace internal
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fixed_fem::internal::DeformableContactData)

--- a/multibody/fixed_fem/dev/deformable_rigid_manager.h
+++ b/multibody/fixed_fem/dev/deformable_rigid_manager.h
@@ -9,6 +9,7 @@
 #include "drake/geometry/scene_graph.h"
 #include "drake/multibody/contact_solvers/contact_solver.h"
 #include "drake/multibody/fixed_fem/dev/collision_objects.h"
+#include "drake/multibody/fixed_fem/dev/deformable_contact_data.h"
 #include "drake/multibody/fixed_fem/dev/deformable_model.h"
 #include "drake/multibody/fixed_fem/dev/deformable_rigid_contact_pair.h"
 #include "drake/multibody/fixed_fem/dev/fem_solver.h"
@@ -170,6 +171,18 @@ class DeformableRigidManager final
    `deformable_id`. */
   internal::DeformableRigidContactPair<T> CalcDeformableRigidContactPair(
       geometry::GeometryId rigid_id, SoftBodyIndex deformable_id) const;
+
+  /* Calculates and returns the DeformableContactData that contains information
+   about all deformable-rigid contacts associated with the deformable body
+   identified by `deformable_id`. */
+  internal::DeformableContactData<T> CalcDeformableContactData(
+      SoftBodyIndex deformable_id) const;
+
+  /* Calculates all deforamble-rigid contacts and returns a vector of
+   DeformableContactData in which the i-th entry contains contact information
+   about the i-th deformable body against all rigid bodies. */
+  std::vector<internal::DeformableContactData<T>> CalcDeformableRigidContact(
+      const systems::Context<T>& context) const;
 
   /* The deformable models being solved by `this` manager. */
   const DeformableModel<T>* deformable_model_{nullptr};

--- a/multibody/fixed_fem/dev/test/deformable_rigid_manager_test.cc
+++ b/multibody/fixed_fem/dev/test/deformable_rigid_manager_test.cc
@@ -451,6 +451,10 @@ TEST_F(DeformableRigidManagerTest, CalcDeformableRigidContactPair) {
   }
 }
 
+// TODO(xuchenhan-tri): Add a unit test that covers
+//  DeformableRigidManager::CalcDeformableRigidContact() in the PR that
+//  introduces contact jacobian calculation.
+
 }  // namespace
 }  // namespace fixed_fem
 }  // namespace multibody


### PR DESCRIPTION
DeformableContactData stores all contact information associated with a single deformable body. 

In particular, it stores all deforamble-rigid contact pairs associated with the deformable body. It also calculates a permuted set of vertex indexes for the deformable vertices based on contact participation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15201)
<!-- Reviewable:end -->
