### PR TITLE
[geometry] New queries for hydroelastics in internal::ProximityEngine.

### DIFF
--- a/geometry/proximity_engine.h
+++ b/geometry/proximity_engine.h
@@ -223,16 +223,31 @@ class ProximityEngine {
       const;
 
   /* Implementation of GeometryState::ComputeContactSurfaces().
-   This includes `X_WGs`, the current poses of all geometries in World in the
-   current scalar type, keyed on each geometry's GeometryId.  */
+   @param X_WGs the current poses of all geometries in World in the
+                current scalar type, keyed on each geometry's GeometryId.  */
   std::vector<ContactSurface<T>> ComputeContactSurfaces(
       const std::unordered_map<GeometryId, math::RigidTransform<T>>& X_WGs)
       const;
 
+  /* Implementation of GeometryState::ComputePolygonalContactSurfaces().
+   @param X_WGs the current poses of all geometries in World in the
+                current scalar type, keyed on each geometry's GeometryId.  */
+  std::vector<ContactSurface<T>> ComputePolygonalContactSurfaces(
+      const std::unordered_map<GeometryId, math::RigidTransform<T>>& X_WGs)
+      const;
+
   /* Implementation of GeometryState::ComputeContactSurfacesWithFallback().
-   This includes `X_WGs`, the current poses of all geometries in World in the
-   current scalar type, keyed on each geometry's GeometryId.  */
+   @param X_WGs the current poses of all geometries in World in the
+                current scalar type, keyed on each geometry's GeometryId.  */
   void ComputeContactSurfacesWithFallback(
+      const std::unordered_map<GeometryId, math::RigidTransform<T>>& X_WGs,
+      std::vector<ContactSurface<T>>* surfaces,
+      std::vector<PenetrationAsPointPair<T>>* point_pairs) const;
+
+  /* Implement GeometryState::ComputePolygonalContactSurfacesWithFallback().
+   @param X_WGs the current poses of all geometries in World in the
+                current scalar type, keyed on each geometry's GeometryId.  */
+  void ComputePolygonalContactSurfacesWithFallback(
       const std::unordered_map<GeometryId, math::RigidTransform<T>>& X_WGs,
       std::vector<ContactSurface<T>>* surfaces,
       std::vector<PenetrationAsPointPair<T>>* point_pairs) const;


### PR DESCRIPTION
Another step in the [implementation plan for 14579](https://github.com/RobotLocomotion/drake/issues/14579#issuecomment-843618123).  This PR #15204 (ProximityEngine) is after PR #15200 (hydroelastic_callback).

The next PR is #15210 (QueryObject).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15204)
<!-- Reviewable:end -->
