### PR TITLE
parsing: Remove implicit frames created for nested models

### DIFF
--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -811,15 +811,6 @@ std::vector<ModelInstanceIndex> AddModelsFromSpecification(
             nested_model, sdf::JoinName(model_name, nested_model.Name()), X_WM,
             plant, package_map, root_dir);
 
-    DRAKE_DEMAND(!nested_model_instances.empty());
-    const ModelInstanceIndex nested_model_instance =
-        nested_model_instances.front();
-
-    plant->AddFrame(std::make_unique<FixedOffsetFrame<double>>(
-        nested_model.Name(),
-        plant->GetFrameByName("__model__", nested_model_instance),
-        RigidTransformd::Identity(), model_instance));
-
     added_model_instances.insert(added_model_instances.end(),
                                  nested_model_instances.begin(),
                                  nested_model_instances.end());

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -1486,16 +1486,8 @@ GTEST_TEST(SdfParser, ModelPlacementFrame) {
   ASSERT_TRUE(plant->HasModelInstanceNamed("table::mug"));
   ModelInstanceIndex model_m = plant->GetModelInstanceByName("table::mug");
 
-  ASSERT_TRUE(plant->HasFrameNamed("mug"));
-  const Frame<double>& frame_M = plant->GetFrameByName("mug");
   ASSERT_TRUE(plant->HasFrameNamed("__model__", model_m));
-  // frame M is equivalent to mug::__model__
-  EXPECT_TRUE(CompareMatrices(
-      plant->GetFrameByName("__model__", model_m)
-          .CalcPoseInWorld(*context)
-          .GetAsMatrix4(),
-      plant->GetFrameByName("mug").CalcPoseInWorld(*context).GetAsMatrix4(),
-      kEps));
+  const Frame<double>& frame_M = plant->GetFrameByName("__model__", model_m);
 
   ASSERT_TRUE(plant->HasFrameNamed("table_top"));
   const Frame<double>& frame_S = plant->GetFrameByName("table_top");


### PR DESCRIPTION
This removes additional implicit model frames created for nested models that were missed in #15099.

/cc @EricCousineau-TRI

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15208)
<!-- Reviewable:end -->
