### PR TITLE
[common] Add AbstractValue::Make overload for default construction

### DIFF
--- a/bindings/pydrake/common/test/value_test_util_py.cc
+++ b/bindings/pydrake/common/test/value_test_util_py.cc
@@ -54,7 +54,7 @@ PYBIND11_MODULE(value_test_util, m) {
   AddValueInstantiation<std::vector<CustomType>>(m);
 
   m.def("make_abstract_value_cc_type_unregistered",
-      []() { return AbstractValue::Make(UnregisteredType{}); });
+      []() { return AbstractValue::Make<UnregisteredType>(); });
 }
 
 }  // namespace pydrake

--- a/common/test/value_test.cc
+++ b/common/test/value_test.cc
@@ -153,6 +153,11 @@ TYPED_TEST(TypedValueTest, Make) {
   EXPECT_EQ(42, abstract_value->template get_value<T>());
 }
 
+GTEST_TEST(TypedValueTest, MakeDefault) {
+  EXPECT_EQ(0, AbstractValue::Make<int>()->get_value<int>());
+  EXPECT_EQ("", AbstractValue::Make<std::string>()->get_value<std::string>());
+}
+
 GTEST_TEST(ValueTest, NiceTypeName) {
   auto double_value = AbstractValue::Make<double>(3.);
   auto string_value = AbstractValue::Make<std::string>("hello");

--- a/common/value.h
+++ b/common/value.h
@@ -70,6 +70,15 @@ class AbstractValue {
 
   virtual ~AbstractValue();
 
+  /// Constructs an AbstractValue using T's default constructor, if available.
+  /// This is only available for T's that support default construction.
+#if !defined(DRAKE_DOXYGEN_CXX)
+  template <typename T,
+            typename = typename std::enable_if_t<
+                std::is_default_constructible_v<T>>>
+#endif
+  static std::unique_ptr<AbstractValue> Make();
+
   /// Returns an AbstractValue containing the given @p value.
   template <typename T>
   static std::unique_ptr<AbstractValue> Make(const T& value);
@@ -185,7 +194,6 @@ class Value : public AbstractValue {
   /// Constructs a Value<T> using T's default constructor, if available.
   /// This is only available for T's that support default construction.
 #if !defined(DRAKE_DOXYGEN_CXX)
-  // T1 is template boilerplate; do not specify it at call sites.
   template <typename T1 = T,
             typename = typename std::enable_if_t<
                 std::is_default_constructible_v<T1>>>
@@ -640,6 +648,11 @@ struct ValueTraitsImpl<T, false> {
 };
 
 }  // namespace internal
+
+template <typename T, typename>
+std::unique_ptr<AbstractValue> AbstractValue::Make() {
+  return std::unique_ptr<AbstractValue>(new Value<T>());
+}
 
 template <typename T>
 std::unique_ptr<AbstractValue> AbstractValue::Make(const T& value) {

--- a/multibody/fixed_fem/dev/deformable_model.cc
+++ b/multibody/fixed_fem/dev/deformable_model.cc
@@ -130,7 +130,7 @@ void DeformableModel<T>::DoDeclareSystemResources(MultibodyPlant<T>* plant) {
   /* Declare output ports. */
   vertex_positions_port_ = &this->DeclareAbstractOutputPort(
       plant, "vertex_positions",
-      []() { return AbstractValue::Make(std::vector<VectorX<T>>{}); },
+      []() { return AbstractValue::Make<std::vector<VectorX<T>>>(); },
       [this](const systems::Context<T>& context, AbstractValue* output) {
         std::vector<VectorX<T>>& output_value =
             output->get_mutable_value<std::vector<VectorX<T>>>();

--- a/perception/point_cloud_to_lcm.cc
+++ b/perception/point_cloud_to_lcm.cc
@@ -181,7 +181,7 @@ PointCloudToLcm::PointCloudToLcm(std::string frame_name)
   DeclareAbstractInputPort("point_cloud", Value<PointCloud>());
   DeclareAbstractOutputPort(
       "lcmt_point_cloud",
-      []() { return AbstractValue::Make<lcmt_point_cloud>({}); },
+      []() { return AbstractValue::Make<lcmt_point_cloud>(); },
       [this](const systems::Context<double>& context, AbstractValue* value) {
         auto& cloud = this->get_input_port().template Eval<PointCloud>(context);
         auto& message = value->get_mutable_value<lcmt_point_cloud>();

--- a/systems/framework/cache.h
+++ b/systems/framework/cache.h
@@ -482,7 +482,7 @@ class CacheEntryValue {
   // Default constructor can only be used privately to construct an empty
   // CacheEntryValue with description "DUMMY" and a meaningless value.
   CacheEntryValue()
-      : description_("DUMMY"), value_(AbstractValue::Make<int>(0)) {}
+      : description_("DUMMY"), value_(AbstractValue::Make<int>()) {}
 
   // Creates a new cache value with the given human-readable description and
   // (optionally) an abstract value that defines the right concrete type for

--- a/systems/framework/leaf_system.cc
+++ b/systems/framework/leaf_system.cc
@@ -331,7 +331,7 @@ LeafSystem<T>::LeafSystem(SystemScalarConverter converter)
   scratch_cache_index_ =
       this->DeclareCacheEntry(
           "scratch",
-          []() { return AbstractValue::Make(Scratch<T>{}); },
+          []() { return AbstractValue::Make<Scratch<T>>(); },
           [](const ContextBase&, AbstractValue*) { /* do nothing */ },
           {this->nothing_ticket()}).cache_index();
 

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -456,7 +456,7 @@ class AllThingsDeprecated final : public LeafSystem<double> {
         &AllThingsDeprecated::MakeInt,
         &AllThingsDeprecated::CalcInt);
     DeclareAbstractOutputPort(
-        []() { return AbstractValue::Make<int>(0); },
+        []() { return AbstractValue::Make<int>(); },
         [](const Context<double>&, AbstractValue*) {});
   }
 
@@ -1836,7 +1836,7 @@ class DefaultFeedthroughSystem : public LeafSystem<double> {
   OutputPortIndex AddAbstractOutputPort(
       std::optional<std::set<DependencyTicket>> prerequisites_of_calc = {}) {
     // Dummies.
-    auto alloc = []() { return AbstractValue::Make<int>(0); };
+    auto alloc = []() { return AbstractValue::Make<int>(); };
     auto calc = [](const ContextBase&, AbstractValue*) {};
     if (prerequisites_of_calc) {
       return this->DeclareAbstractOutputPort(

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -614,7 +614,7 @@ class ValueIOTestSystem : public TestSystemBase<T> {
         kAbstractValued, 0 /* size */,
         &this->DeclareCacheEntry(
             "absport",
-            []() { return AbstractValue::Make(std::string()); },
+            []() { return AbstractValue::Make<std::string>(); },
             [this](const ContextBase& context, AbstractValue* output) {
               this->CalcStringOutput(context, output);
             })));
@@ -646,7 +646,7 @@ class ValueIOTestSystem : public TestSystemBase<T> {
   std::unique_ptr<AbstractValue> DoAllocateInput(
       const InputPort<T>& input_port) const override {
     if (input_port.get_index() == 0) {
-      return AbstractValue::Make<std::string>("");
+      return AbstractValue::Make<std::string>();
     } else {
       return std::make_unique<Value<BasicVector<T>>>(TestTypedVector<T>{});
     }

--- a/systems/framework/test/vector_system_test.cc
+++ b/systems/framework/test/vector_system_test.cc
@@ -149,7 +149,7 @@ TEST_F(VectorSystemTest, TopologyFailFast) {
     DRAKE_EXPECT_NO_THROW(dut.CreateDefaultContext());
     dut.DeclareAbstractOutputPort(
         kUseDefaultName,
-        []() { return AbstractValue::Make<int>(0); },  // Dummies.
+        []() { return AbstractValue::Make<int>(); },  // Dummies.
         [](const ContextBase&, AbstractValue*) {});
     EXPECT_THROW(dut.CreateDefaultContext(), std::exception);
   }

--- a/systems/rendering/render_pose_to_geometry_pose.cc
+++ b/systems/rendering/render_pose_to_geometry_pose.cc
@@ -24,7 +24,7 @@ RenderPoseToGeometryPose<T>::RenderPoseToGeometryPose(
   this->DeclareVectorInputPort(kUseDefaultName, Input{});
   this->DeclareAbstractOutputPort(
       kUseDefaultName,
-      []() { return Value<Output>{}.Clone(); },
+      []() { return AbstractValue::Make<Output>(); },
       [this, frame_id](const Context<T>& context, AbstractValue* calculated) {
         const Input& input =
             this->get_input_port().template Eval<Input>(context);


### PR DESCRIPTION
This enables a few small cleanups, but most importantly gives us a function pointer that we can use as an allocator callback, towards #15161.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15209)
<!-- Reviewable:end -->
