### PR TITLE
[geometry] QueryObject's new queries for hydroelastics.

### DIFF
--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -398,6 +398,11 @@ class GeometryState {
     return geometry_engine_->ComputeContactSurfaces(X_WGs_);
   }
 
+  /** Implementation of QueryObject::ComputePolygonalContactSurfaces().  */
+  std::vector<ContactSurface<T>> ComputePolygonalContactSurfaces() const {
+    return geometry_engine_->ComputePolygonalContactSurfaces(X_WGs_);
+  }
+
   /** Implementation of QueryObject::ComputeContactSurfacesWithFallback().  */
   void ComputeContactSurfacesWithFallback(
       std::vector<ContactSurface<T>>* surfaces,
@@ -405,6 +410,17 @@ class GeometryState {
     DRAKE_DEMAND(surfaces);
     DRAKE_DEMAND(point_pairs);
     return geometry_engine_->ComputeContactSurfacesWithFallback(
+        X_WGs_, surfaces, point_pairs);
+  }
+
+  /** Implementation of
+   QueryObject::ComputePolygonalContactSurfacesWithFallback().  */
+  void ComputePolygonalContactSurfacesWithFallback(
+      std::vector<ContactSurface<T>>* surfaces,
+      std::vector<PenetrationAsPointPair<T>>* point_pairs) const {
+    DRAKE_DEMAND(surfaces);
+    DRAKE_DEMAND(point_pairs);
+    return geometry_engine_->ComputePolygonalContactSurfacesWithFallback(
         X_WGs_, surfaces, point_pairs);
   }
 

--- a/geometry/query_object.cc
+++ b/geometry/query_object.cc
@@ -114,6 +114,16 @@ QueryObject<T>::ComputeContactSurfaces() const {
 }
 
 template <typename T>
+std::vector<ContactSurface<T>>
+QueryObject<T>::ComputePolygonalContactSurfaces() const {
+  ThrowIfNotCallable();
+
+  FullPoseUpdate();
+  const GeometryState<T>& state = geometry_state();
+  return state.ComputePolygonalContactSurfaces();
+}
+
+template <typename T>
 void QueryObject<T>::ComputeContactSurfacesWithFallback(
     std::vector<ContactSurface<T>>* surfaces,
     std::vector<PenetrationAsPointPair<T>>* point_pairs) const {
@@ -125,6 +135,20 @@ void QueryObject<T>::ComputeContactSurfacesWithFallback(
   FullPoseUpdate();
   const GeometryState<T>& state = geometry_state();
   state.ComputeContactSurfacesWithFallback(surfaces, point_pairs);
+}
+
+template <typename T>
+void QueryObject<T>::ComputePolygonalContactSurfacesWithFallback(
+    std::vector<ContactSurface<T>>* surfaces,
+    std::vector<PenetrationAsPointPair<T>>* point_pairs) const {
+  DRAKE_DEMAND(surfaces);
+  DRAKE_DEMAND(point_pairs);
+
+  ThrowIfNotCallable();
+
+  FullPoseUpdate();
+  const GeometryState<T>& state = geometry_state();
+  state.ComputePolygonalContactSurfacesWithFallback(surfaces, point_pairs);
 }
 
 template <typename T>

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -263,10 +263,9 @@ class QueryObject {
            `throws` in the support table above.  */
   std::vector<PenetrationAsPointPair<T>> ComputePointPairPenetration() const;
 
-  /**
-   Reports pairwise intersections and characterizes each non-empty intersection
-   as a ContactSurface for hydroelastic contact model. The computation is
-   subject to collision filtering.
+  /** Reports pairwise intersections and characterizes each non-empty
+   intersection as a ContactSurface for hydroelastic contact model. The
+   computation is subject to collision filtering.
 
    For two intersecting geometries g_A and g_B, it is guaranteed that they will
    map to `id_A` and `id_B` in a fixed, repeatable manner, where `id_A` and
@@ -314,7 +313,38 @@ class QueryObject {
             the same.  */
   std::vector<ContactSurface<T>> ComputeContactSurfaces() const;
 
-  /** Reports pair-wise intersections and characterizes each non-empty
+  /** (Advanced) Reports polygonal contact surfaces between pairs of
+   intersecting geometries for hydroelastic contact model. It performs the
+   same task as ComputeContactSurfaces() with a different representation of
+   the output contact surfaces. The computation is subject to collision
+   filtering.
+
+   Each contact surface from this query consists of contact polygons, each of
+   which is an intersecting polygon between mesh elements of two geometries.
+
+   In the current incarnation, each contact polygon is represented by a
+   triangle with the same centroid, area, pressure value, and pressure
+   gradient as the contact polygon.
+
+   @warning The return type in this implementation is a std::vector of
+   ContactSurface that uses the representative triangles, and, in the future,
+   the return type will change to the true polygonal representation without
+   any deprecation period.
+
+   This query has the same handling of GeometryId's, limitations (supported
+   shapes and compliances), user-defined properties (elastic modulus and
+   tessellation), and scalar support (double and AutoDiffXd) as
+   ComputeContactSurfaces().
+
+   @returns A vector populated with all detected intersections characterized as
+            contact surfaces. The ordering of the results is guaranteed to be
+            consistent -- for fixed geometry poses, the results will remain
+            the same.
+   @throws std::exception for the same reason described in
+   ComputeContactSurfaces()  */
+  std::vector<ContactSurface<T>> ComputePolygonalContactSurfaces() const;
+
+  /** Reports pairwise intersections and characterizes each non-empty
    intersection as a ContactSurface _where possible_ and as a
    PenetrationAsPointPair where not.
 
@@ -343,6 +373,27 @@ class QueryObject {
    @throws std::exception for the reasons described in ComputeContactSurfaces()
                           and ComputePointPairPenetration(). */
   void ComputeContactSurfacesWithFallback(
+      std::vector<ContactSurface<T>>* surfaces,
+      std::vector<PenetrationAsPointPair<T>>* point_pairs) const;
+
+  /** (Advanced) Reports pairwise intersections and characterizes each
+   non-empty intersection as a polygonal contact surface _where possible_ and
+   as a PenetrationAsPointPair where not. It performs the same task as
+   ComputeContactSurfacesWithFallback() with a different representation of
+   the contact surfaces.
+
+   This method can be thought of as a combination of
+   ComputePolygonalContactSurfaces() and ComputePointPairPenetration().
+
+   @warning In the current incarnation, the output parameter `surfaces` in
+   this implementation uses ContactSurface consisting of one representative
+   triangle for each contact polygon. In the future, it will change to the
+   true polygonal representation without any deprecation period.
+
+   This method has the same ordering of the results, the same scalar support,
+   the same parameters, and the same exception as
+   ComputeContactSurfacesWithFallback().  */
+  void ComputePolygonalContactSurfacesWithFallback(
       std::vector<ContactSurface<T>>* surfaces,
       std::vector<PenetrationAsPointPair<T>>* point_pairs) const;
 

--- a/geometry/test/query_object_test.cc
+++ b/geometry/test/query_object_test.cc
@@ -166,10 +166,14 @@ TEST_F(QueryObjectTest, DefaultQueryThrows) {
   // Penetration queries.
   EXPECT_DEFAULT_ERROR(default_object.ComputePointPairPenetration());
   EXPECT_DEFAULT_ERROR(default_object.ComputeContactSurfaces());
+  EXPECT_DEFAULT_ERROR(default_object.ComputePolygonalContactSurfaces());
   std::vector<ContactSurface<double>> surfaces;
   std::vector<PenetrationAsPointPair<double>> point_pairs;
   EXPECT_DEFAULT_ERROR(default_object.ComputeContactSurfacesWithFallback(
       &surfaces, &point_pairs));
+  EXPECT_DEFAULT_ERROR(
+      default_object.ComputePolygonalContactSurfacesWithFallback(&surfaces,
+                                                                 &point_pairs));
 
   // Signed distance queries.
   EXPECT_DEFAULT_ERROR(


### PR DESCRIPTION
A step in the [implementation plan for 14579](https://github.com/RobotLocomotion/drake/issues/14579#issuecomment-843618123). This PR #15210 (QueryObject) is after PR #15204 (ProximityEngine).

After this PR, we'll move from `geometry` to `multibody` in PR #15436 (MultibodyPlant) .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15210)
<!-- Reviewable:end -->
