### PR TITLE
[framework] Drop SystemScalarConverter::Remove<T> method

### DIFF
--- a/systems/framework/system_scalar_converter.cc
+++ b/systems/framework/system_scalar_converter.cc
@@ -31,31 +31,9 @@ void SystemScalarConverter::Insert(
   DRAKE_ASSERT(insert_result.second);
 }
 
-void SystemScalarConverter::Remove(const std::type_info& t_info) {
-  // Remove the items from `funcs_` whose key contains the type `T` that
-  // matches `t_info`. (This would use erase_if, if we had it.)
-  for (auto iter = funcs_.begin(); iter != funcs_.end();) {
-    const Key& key = iter->first;
-    if (key.first == t_info || key.second == t_info) {
-      iter = funcs_.erase(iter);
-    } else {
-      ++iter;
-    }
-  }
-}
-
 void SystemScalarConverter::Remove(const std::type_info& t_info,
                                    const std::type_info& u_info) {
-  // Remove the items from `funcs_` whose key contains the pair {T, U} that
-  // matches `t_info` and `u_info`. (This would use erase_if, if we had it.)
-  for (auto iter = funcs_.begin(); iter != funcs_.end();) {
-    const Key& key = iter->first;
-    if (key.first == t_info && key.second == u_info) {
-      iter = funcs_.erase(iter);
-    } else {
-      ++iter;
-    }
-  }
+  funcs_.erase(Key(t_info, u_info));
 }
 
 const SystemScalarConverter::ErasedConverterFunc* SystemScalarConverter::Find(

--- a/systems/framework/system_scalar_converter.h
+++ b/systems/framework/system_scalar_converter.h
@@ -136,12 +136,6 @@ class SystemScalarConverter {
   /// is false.  The subtype `S` need not be the same between this and `other`.
   void RemoveUnlessAlsoSupportedBy(const SystemScalarConverter& other);
 
-  /// Removes from this converter the ability to convert to or from System<T>.
-  template <typename T>
-  void Remove() {
-    Remove(typeid(T));
-  }
-
   /// Removes from this converter the ability to convert from System<U> to
   /// System<T>.
   template <typename T, typename U>
@@ -190,9 +184,6 @@ class SystemScalarConverter {
   void Insert(
       const std::type_info&, const std::type_info&,
       const ErasedConverterFunc&);
-
-  // Given typeid(T), removes the converter from or to T.
-  void Remove(const std::type_info&);
 
   // Given typeid(T) and typeid(U), removes the converter from U to T.
   void Remove(const std::type_info& t_info, const std::type_info& u_info);

--- a/systems/framework/test/system_scalar_converter_test.cc
+++ b/systems/framework/test/system_scalar_converter_test.cc
@@ -317,21 +317,15 @@ GTEST_TEST(SystemScalarConverterTest, Remove) {
   EXPECT_TRUE((dut.IsConvertible<Expression, AutoDiffXd>()));
 
   // We remove symbolic support.  Only double <=> AutoDiff remains.
-  dut.Remove<symbolic::Expression>();
+  dut.Remove<double,     Expression>();
+  dut.Remove<AutoDiffXd, Expression>();
+  dut.Remove<Expression, double    >();
+  dut.Remove<Expression, AutoDiffXd>();
   EXPECT_TRUE((dut.IsConvertible< double,     AutoDiffXd>()));
-  EXPECT_TRUE((dut.IsConvertible< AutoDiffXd, double    >()));
   EXPECT_FALSE((dut.IsConvertible<double,     Expression>()));
+  EXPECT_TRUE((dut.IsConvertible< AutoDiffXd, double    >()));
   EXPECT_FALSE((dut.IsConvertible<AutoDiffXd, Expression>()));
   EXPECT_FALSE((dut.IsConvertible<Expression, double    >()));
-  EXPECT_FALSE((dut.IsConvertible<Expression, AutoDiffXd>()));
-
-  // We remove double => AutoDiff support.  Only double <= AutoDiff remains.
-  dut.Remove<double, AutoDiffXd>();
-  EXPECT_FALSE((dut.IsConvertible<double, AutoDiffXd>()));
-  EXPECT_TRUE((dut.IsConvertible<AutoDiffXd, double>()));
-  EXPECT_FALSE((dut.IsConvertible<double, Expression>()));
-  EXPECT_FALSE((dut.IsConvertible<AutoDiffXd, Expression>()));
-  EXPECT_FALSE((dut.IsConvertible<Expression, double>()));
   EXPECT_FALSE((dut.IsConvertible<Expression, AutoDiffXd>()));
 
   // The conversion still actually works.


### PR DESCRIPTION
This method was recently added (#15159), but ended up being unused.

Fix the implementation of Remove<T, U> to use O(1) lookup instead of O(N) search.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15211)
<!-- Reviewable:end -->
