### PR TITLE
[common] Add explicit function template instantiation macro on scalars

### DIFF
--- a/common/default_scalars.h
+++ b/common/default_scalars.h
@@ -37,14 +37,15 @@
 /// possible, prefer to use these commands instead of writing out a @c \@tparam
 /// line manually.
 
-/// @name Template instantiation macros
+/// @name Class template instantiation macros
 /// These macros either declare or define class template instantiations for
 /// Drake's supported scalar types (see @ref default_scalars), either "default
 /// scalars" or "default nonsymbolic scalars".  Use the `DECLARE` macros only
 /// in .h files; use the `DEFINE` macros only in .cc files.
 ///
 /// @param SomeType the template typename to instantiate, *including* the
-/// leading `class` or `struct` keyword.
+/// leading `class` or `struct` keyword, but *excluding* the template argument
+/// for the scalar type.
 ///
 /// Example `my_system.h`:
 /// @code
@@ -103,5 +104,128 @@ extern template SomeType<::drake::symbolic::Expression>;
       SomeType) \
 extern template SomeType<double>; \
 extern template SomeType<::drake::AutoDiffXd>;
+
+/// @}
+
+/// @name Function template instantiation macros
+/// These macros define template function instantiations for Drake's supported
+/// scalar types (see @ref default_scalars), either "default scalars" or
+/// "default nonsymbolic scalars".  Use the `DEFINE` macros only in .cc files.
+///
+/// @param FunctionPointersTuple a parenthesized, comma-separated list of
+/// functions to instantiate (provided as function pointers), *including*
+/// the template argument(s) for the scalar type.  The template arguments `T`
+/// and `U` will be provided by the macro; the function will be instantiated
+/// for all combinations of `T` and `U` over the default scalars.
+///
+/// Example `example.h`:
+/// @code
+/// #include "drake/common/default_scalars.h"
+///
+/// namespace sample {
+///
+/// template <typename T>
+/// double Func1(const T&);
+///
+/// template <typename T, typename U>
+/// double Func2(const T&, const U&);
+///
+/// template <typename T>
+/// class SomeClass {
+///   ...
+///   template <typename U>
+///   SomeClass cast() const;
+///   ...
+/// };
+///
+/// }  // namespace sample
+/// @endcode
+///
+/// Example `example.cc`:
+/// @code
+/// #include "example.h"
+///
+/// namespace sample {
+///
+/// template <typename T>
+/// double Func1(const T&) {
+///   ...
+/// }
+///
+/// template <typename T, typename U>
+/// double Func2(const T&, const U&) {
+///   ...
+/// }
+///
+/// template <typename T>
+/// template <typename U>
+/// SomeClass<T>::SomeClass::cast() const {
+///   ...
+/// };
+///
+/// // N.B. Place the macro invocation inside the functions' namespace.
+/// DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
+///     &Func1<T>,
+///     &Func2<T, U>,
+///     &SomeClass<T>::template cast<U>
+/// ))
+///
+/// }  // namespace sample
+/// @endcode
+///
+/// @note In the case of an overloaded function, the `&FunctionName<T>` syntax
+/// is ambiguous.  To resolve the ambiguity, you will need a
+/// <a href=https://en.cppreference.com/w/cpp/language/static_cast#Notes>static_cast</a>.
+
+// N.B. Below we use "Make_Function_Pointers" (etc.) as function names and
+// static variable names, which violates our function name style guide by mixing
+// inner capitalization with underscores.  However, we've done this on purpose,
+// to avoid conflicts with user-provided code in the same translation unit.  We
+// can't use a namespace because we need to allow for easy friendship in case a
+// member function does not have public access.
+
+/// Defines template instantiations for Drake's default scalars.
+/// This should only be used in .cc files, never in .h files.
+#define DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS( \
+    FunctionPointersTuple) \
+template<typename T, typename U> \
+constexpr auto Make_Function_Pointers() { \
+  return std::make_tuple FunctionPointersTuple ; \
+} \
+template<typename T, typename... Us> \
+constexpr auto Make_Function_Pointers_Pack2() { \
+  return std::tuple_cat(Make_Function_Pointers<T, Us>()...); \
+} \
+template<typename... Ts> \
+constexpr auto Make_Function_Pointers_Pack1() { \
+  return std::tuple_cat(Make_Function_Pointers_Pack2<Ts, Ts...>()...); \
+} \
+static constexpr auto Function_Femplates __attribute__((used)) = \
+    Make_Function_Pointers_Pack1< \
+        double, \
+        ::drake::AutoDiffXd, \
+        ::drake::symbolic::Expression>();
+
+/// Defines template instantiations for Drake's default nonsymbolic scalars.
+/// This should only be used in .cc files, never in .h files.
+#define \
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS( \
+    FunctionPointersTuple) \
+template<typename T, typename U> \
+constexpr auto Make_Function_Pointers_Nonsym() { \
+  return std::make_tuple FunctionPointersTuple ; \
+} \
+template<typename T, typename... Us> \
+constexpr auto Make_Function_Pointers_Nonsym_Pack2() { \
+  return std::tuple_cat(Make_Function_Pointers_Nonsym<T, Us>()...); \
+} \
+template<typename... Ts> \
+constexpr auto Make_Function_Pointers_Nonsym_Pack1() { \
+  return std::tuple_cat(Make_Function_Pointers_Nonsym_Pack2<Ts, Ts...>()...); \
+} \
+static constexpr auto Function_Templates_Nonsym __attribute__((used)) = \
+    Make_Function_Pointers_Nonsym_Pack1< \
+        double, \
+        ::drake::AutoDiffXd>();
 
 /// @}

--- a/common/random.cc
+++ b/common/random.cc
@@ -31,6 +31,8 @@ T CalcProbabilityDensity(RandomDistribution distribution,
   DRAKE_UNREACHABLE();
 }
 
+// TODO(jwnimmer-tri) Use DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_...
+// here, once we can break the dependency cycle.
 template double CalcProbabilityDensity<double>(
     RandomDistribution, const Eigen::Ref<const VectorX<double>>&);
 template AutoDiffXd CalcProbabilityDensity<AutoDiffXd>(

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -127,6 +127,7 @@ drake_cc_library(
     hdrs = ["contact_surface_utility.h"],
     deps = [
         ":surface_mesh",
+        "//common:default_scalars",
     ],
 )
 
@@ -151,6 +152,7 @@ drake_cc_library(
     ],
     deps = [
         ":proximity_utilities",
+        "//common:default_scalars",
         "//common:essential",
         "//geometry:geometry_ids",
         "//geometry/query_results:signed_distance_to_point",
@@ -172,6 +174,7 @@ drake_cc_library(
         ":collision_filter_legacy",
         ":distance_to_point_callback",
         ":proximity_utilities",
+        "//common:default_scalars",
         "//geometry/query_results:signed_distance_pair",
     ],
 )
@@ -261,6 +264,7 @@ drake_cc_library(
     deps = [
         ":distance_to_point_callback",
         ":mesh_field",
+        "//common:default_scalars",
         "//common:essential",
         "//common:unused",
         "//geometry:shape_specification",
@@ -276,6 +280,7 @@ drake_cc_library(
         ":surface_mesh",
         ":volume_mesh",
         ":volume_to_surface_mesh",
+        "//common:default_scalars",
         "//geometry:shape_specification",
     ],
 )
@@ -288,6 +293,7 @@ drake_cc_library(
         ":distance_to_point_callback",
         ":mesh_field",
         ":volume_to_surface_mesh",
+        "//common:default_scalars",
         "//common:essential",
         "//common:unused",
         "//geometry:shape_specification",
@@ -315,6 +321,7 @@ drake_cc_library(
         ":surface_mesh",
         ":volume_mesh",
         ":volume_to_surface_mesh",
+        "//common:default_scalars",
         "//common:essential",
         "//geometry:shape_specification",
     ],
@@ -330,6 +337,7 @@ drake_cc_library(
         ":surface_mesh",
         ":volume_mesh",
         ":volume_to_surface_mesh",
+        "//common:default_scalars",
         "//common:essential",
         "//geometry:shape_specification",
     ],
@@ -411,6 +419,7 @@ drake_cc_library(
         ":contact_surface_utility",
         ":posed_half_space",
         ":surface_mesh",
+        "//common:default_scalars",
         "//common:essential",
         "//geometry:geometry_ids",
         "//geometry:utilities",
@@ -429,6 +438,7 @@ drake_cc_library(
         ":posed_half_space",
         ":surface_mesh",
         ":volume_mesh",
+        "//common:default_scalars",
         "//common:essential",
         "//geometry/query_results:contact_surface",
         "//math:geometric_transform",
@@ -445,6 +455,7 @@ drake_cc_library(
         ":mesh_field",
         ":plane",
         ":volume_mesh",
+        "//common:default_scalars",
         "//geometry/query_results:contact_surface",
         "//math:geometric_transform",
     ],
@@ -502,6 +513,7 @@ drake_cc_library(
     deps = [
         ":collision_filter_legacy",
         ":distance_to_point_callback",
+        "//common:default_scalars",
         "//geometry/query_results:penetration_as_point_pair",
         "//geometry/query_results:signed_distance_to_point",
         "@fcl",

--- a/geometry/proximity/contact_surface_utility.cc
+++ b/geometry/proximity/contact_surface_utility.cc
@@ -5,6 +5,8 @@
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 
+#include "drake/common/default_scalars.h"
+
 namespace drake {
 
 namespace geometry {
@@ -351,58 +353,21 @@ bool IsFaceNormalInNormalDirection(const Vector3<T>& normal_F,
 }
 
 // Instantiation to facilitate unit testing of this support function.
-template
-Vector3<double> CalcPolygonCentroid(
-    const std::vector<SurfaceVertexIndex>& polygon,
-    const Vector3<double>& n_F,
-    const std::vector<SurfaceVertex<double>>& vertices_F);
-
-template
-Vector3<AutoDiffXd> CalcPolygonCentroid(
-    const std::vector<SurfaceVertexIndex>& polygon,
-    const Vector3<AutoDiffXd>& n_F,
-    const std::vector<SurfaceVertex<AutoDiffXd>>& vertices_F);
-
-template Vector3<double> CalcPolygonCentroid(
-    const std::vector<Vector3<double>>&, const Vector3<double>&);
-
-template Vector3<AutoDiffXd> CalcPolygonCentroid(
-    const std::vector<Vector3<AutoDiffXd>>&, const Vector3<AutoDiffXd>&);
-
-template double CalcPolygonArea(const std::vector<Vector3<double>>&,
-                                const Vector3<double>&);
-
-template AutoDiffXd CalcPolygonArea(const std::vector<Vector3<AutoDiffXd>>&,
-                                    const Vector3<AutoDiffXd>&);
-
-template void AddPolygonToMeshData(
-    const std::vector<SurfaceVertexIndex>& polygon,
-    const Vector3<double>& n_F,
-    std::vector<SurfaceFace>* faces,
-    std::vector<SurfaceVertex<double>>* vertices_F);
-
-template void AddPolygonToMeshData(
-    const std::vector<SurfaceVertexIndex>& polygon,
-    const Vector3<AutoDiffXd>& n_F,
-    std::vector<SurfaceFace>* faces,
-    std::vector<SurfaceVertex<AutoDiffXd>>* vertices_F);
-
-template void AddPolygonToMeshDataAsOneTriangle(
-    const std::vector<Vector3<double>>&, const Vector3<double>&,
-    std::vector<SurfaceFace>*, std::vector<SurfaceVertex<double>>*);
-
-template void AddPolygonToMeshDataAsOneTriangle(
-    const std::vector<Vector3<AutoDiffXd>>&, const Vector3<AutoDiffXd>&,
-    std::vector<SurfaceFace>*, std::vector<SurfaceVertex<AutoDiffXd>>*);
-
-template bool IsFaceNormalInNormalDirection(
-    const Vector3<double>& normal_F, const SurfaceMesh<double>& surface_M,
-    SurfaceFaceIndex tri_index, const math::RotationMatrix<double>& R_FM);
-
-template bool IsFaceNormalInNormalDirection(
-    const Vector3<AutoDiffXd>& normal_F,
-    const SurfaceMesh<AutoDiffXd>& surface_M, SurfaceFaceIndex tri_index,
-    const math::RotationMatrix<AutoDiffXd>& R_FM);
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS((
+    &AddPolygonToMeshData<T>,
+    &AddPolygonToMeshDataAsOneTriangle<T>,
+    &CalcPolygonArea<T>,
+    &IsFaceNormalInNormalDirection<T>,
+    /* Use static_cast to disambiguate the two different overloads. */
+    static_cast<Vector3<T>(*)(
+       const std::vector<SurfaceVertexIndex>&,
+       const Vector3<T>&,
+       const std::vector<SurfaceVertex<T>>&)>(&CalcPolygonCentroid),
+    /* Use static_cast to disambiguate the two different overloads. */
+    static_cast<Vector3<T>(*)(
+       const std::vector<Vector3<T>>&,
+       const Vector3<T>&)>(&CalcPolygonCentroid)
+))
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/contact_surface_utility.h
+++ b/geometry/proximity/contact_surface_utility.h
@@ -36,7 +36,7 @@ namespace internal {
  @pre `n_F` is  perpendicular to the defined `polygon`'s plane.
  @pre `n_F` has non-trivial length.
  @pre `polygon` is planar.
- @tparam T  The computational scalar type. Only supports double and AutoDiffXd.
+ @tparam_nonsymbolic_scalar
  */
 template <typename T>
 Vector3<T> CalcPolygonCentroid(
@@ -51,7 +51,7 @@ Vector3<T> CalcPolygonCentroid(
 
 /* Overload that takes a polygon represented as an ordered list of positional
  vectors `p_FVs` of its vertices, each measured and expressed in frame F.
- */
+ @tparam_nonsymbolic_scalar */
 template <typename T>
 Vector3<T> CalcPolygonCentroid(
     const std::vector<Vector3<T>>& p_FVs,
@@ -71,7 +71,7 @@ Vector3<T> CalcPolygonCentroid(
  @param[in] nhat_F  Unit normal vector of the polygon.
  @pre `p_FVs.size()` >= 3.
  @pre nhat_F is consistent with the winding of the polygon.
- */
+ @tparam_nonsymbolic_scalar */
 template <typename T>
 T CalcPolygonArea(const std::vector<Vector3<T>>& p_FVs,
                   const Vector3<T>& nhat_F);
@@ -107,8 +107,7 @@ T CalcPolygonArea(const std::vector<Vector3<T>>& p_FVs,
  @pre `polygon` is planar.
  @pre `n_F` is perpendicular to the defined `polygon`.
  @pre `n_F` has non-trivial length.
- @tparam T  The computational scalar type. Only supports double and AutoDiffXd.
- */
+ @tparam_nonsymbolic_scalar */
 template <typename T>
 void AddPolygonToMeshData(
     const std::vector<SurfaceVertexIndex>& polygon,
@@ -161,8 +160,7 @@ constexpr double kMinimumPolygonArea = 1e-13;
        2. For the scalar type AutoDiffXd, such a polygon may cause unstable
           calculation of derivatives of the representative triangle.
 
- @tparam T  The computational scalar type. Only supports double and AutoDiffXd.
- */
+ @tparam_nonsymbolic_scalar */
 template <typename T>
 void AddPolygonToMeshDataAsOneTriangle(
     const std::vector<Vector3<T>>& polygon_F, const Vector3<T>& nhat_F,
@@ -193,8 +191,7 @@ enum class ContactPolygonRepresentation {
  @pre `normal_F` is unit length.
  @return `true` if the angle between `normal_F` and the triangle normal lies
           within the hard-coded tolerance.
- @tparam T  The computational scalar type. Only supports double and AutoDiffXd.
- */
+ @tparam_nonsymbolic_scalar */
 template <typename T>
 bool IsFaceNormalInNormalDirection(const Vector3<T>& normal_F,
                                    const SurfaceMesh<T>& surface_M,

--- a/geometry/proximity/distance_to_point_callback.cc
+++ b/geometry/proximity/distance_to_point_callback.cc
@@ -1,5 +1,7 @@
 #include "drake/geometry/proximity/distance_to_point_callback.h"
 
+#include "drake/common/default_scalars.h"
+
 namespace drake {
 namespace geometry {
 namespace internal {
@@ -539,10 +541,9 @@ bool Callback(fcl::CollisionObjectd* object_A_ptr,
   return false;  // Returning false tells fcl to continue to other objects.
 }
 
-template bool Callback<double>(fcl::CollisionObjectd*, fcl::CollisionObjectd*,
-                               void*, double&);
-template bool Callback<AutoDiffXd>(fcl::CollisionObjectd*,
-                                   fcl::CollisionObjectd*, void*, double&);
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS((
+    &Callback<T>
+))
 
 }  // namespace point_distance
 }  // namespace internal

--- a/geometry/proximity/distance_to_shape_callback.cc
+++ b/geometry/proximity/distance_to_shape_callback.cc
@@ -4,6 +4,7 @@
 #include <limits>
 #include <utility>
 
+#include "drake/common/default_scalars.h"
 #include "drake/geometry/proximity/distance_to_point_callback.h"
 #include "drake/math/rotation_matrix.h"
 
@@ -297,19 +298,10 @@ bool Callback(fcl::CollisionObjectd* object_A_ptr,
   return false;
 }
 
-template void ComputeNarrowPhaseDistance<double>(
-    const fcl::CollisionObjectd&, const math::RigidTransform<double>&,
-    const fcl::CollisionObjectd&, const math::RigidTransform<double>&,
-    const fcl::DistanceRequestd&, SignedDistancePair<double>*);
-template void ComputeNarrowPhaseDistance<AutoDiffXd>(
-    const fcl::CollisionObjectd&, const math::RigidTransform<AutoDiffXd>&,
-    const fcl::CollisionObjectd&, const math::RigidTransform<AutoDiffXd>&,
-    const fcl::DistanceRequestd&, SignedDistancePair<AutoDiffXd>*);
-
-template bool Callback<double>(fcl::CollisionObjectd*, fcl::CollisionObjectd*,
-                               void*, double&);
-template bool Callback<AutoDiffXd>(fcl::CollisionObjectd*,
-                                   fcl::CollisionObjectd*, void*, double&);
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS((
+    &ComputeNarrowPhaseDistance<T>,
+    &Callback<T>
+))
 
 }  // namespace shape_distance
 }  // namespace internal

--- a/geometry/proximity/make_box_field.cc
+++ b/geometry/proximity/make_box_field.cc
@@ -3,6 +3,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/unused.h"
 #include "drake/geometry/proximity/distance_to_point_callback.h"
@@ -55,10 +56,9 @@ VolumeMeshFieldLinear<T, T> MakeBoxPressureField(
                                      mesh_B);
 }
 
-template VolumeMeshFieldLinear<double, double> MakeBoxPressureField(
-    const Box&, const VolumeMesh<double>*, const double);
-template VolumeMeshFieldLinear<AutoDiffXd, AutoDiffXd> MakeBoxPressureField(
-    const Box&, const VolumeMesh<AutoDiffXd>*, const AutoDiffXd);
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS((
+    &MakeBoxPressureField<T>
+))
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/make_box_field.h
+++ b/geometry/proximity/make_box_field.h
@@ -26,6 +26,7 @@ namespace internal {
                          by the mesh should be exactly the same space as the
                          box specification). `mesh_B` has enough resolution
                          to approximate the pressure field.
+ @tparam_nonsymbolic_scalar
  */
 template <typename T>
 VolumeMeshFieldLinear<T, T> MakeBoxPressureField(const Box& box,

--- a/geometry/proximity/make_box_mesh.cc
+++ b/geometry/proximity/make_box_mesh.cc
@@ -4,6 +4,7 @@
 #include <array>
 #include <unordered_set>
 
+#include "drake/common/default_scalars.h"
 #include "drake/geometry/proximity/proximity_utilities.h"
 
 namespace drake {
@@ -453,15 +454,10 @@ VolumeMesh<T> MakeBoxVolumeMesh(const Box& box, double resolution_hint) {
   return VolumeMesh<T>(std::move(elements), std::move(vertices));
 }
 
-template VolumeMesh<double> MakeBoxVolumeMeshWithMa(const Box&);
-template VolumeMesh<AutoDiffXd> MakeBoxVolumeMeshWithMa(const Box&);
-
-// Explicit instantiations for double and AutoDiffXd to support the
-// documentation.
-template VolumeMesh<double> MakeBoxVolumeMesh(const Box& box,
-                                              double resolution_hint);
-template VolumeMesh<AutoDiffXd> MakeBoxVolumeMesh(const Box& box,
-                                                  double resolution_hint);
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS((
+    &MakeBoxVolumeMesh<T>,
+    &MakeBoxVolumeMeshWithMa<T>
+))
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/make_capsule_mesh.cc
+++ b/geometry/proximity/make_capsule_mesh.cc
@@ -2,6 +2,7 @@
 
 #include <cmath>
 
+#include "drake/common/default_scalars.h"
 #include "drake/geometry/proximity/meshing_utilities.h"
 #include "drake/geometry/proximity/proximity_utilities.h"
 
@@ -180,10 +181,9 @@ VolumeMesh<T> MakeCapsuleVolumeMesh(const Capsule& capsule,
   return {std::move(mesh_elements), std::move(mesh_vertices)};
 }
 
-template VolumeMesh<double> MakeCapsuleVolumeMesh(const Capsule&,
-                                                  double resolution_hint);
-template VolumeMesh<AutoDiffXd> MakeCapsuleVolumeMesh(const Capsule&,
-                                                      double resolution_hint);
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS((
+    &MakeCapsuleVolumeMesh<T>
+))
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/make_cylinder_field.cc
+++ b/geometry/proximity/make_cylinder_field.cc
@@ -4,6 +4,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/proximity/distance_to_point_callback.h"
 #include "drake/geometry/proximity/volume_to_surface_mesh.h"
@@ -72,12 +73,9 @@ VolumeMeshFieldLinear<T, T> MakeCylinderPressureField(
                                      std::move(pressure_values), mesh_C);
 }
 
-template VolumeMeshFieldLinear<double, double> MakeCylinderPressureField(
-    const Cylinder&, const VolumeMesh<double>*, const double);
-
-template VolumeMeshFieldLinear<AutoDiffXd, AutoDiffXd>
-MakeCylinderPressureField(const Cylinder&, const VolumeMesh<AutoDiffXd>*,
-                          const AutoDiffXd);
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS((
+    &MakeCylinderPressureField<T>
+))
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/make_cylinder_field.h
+++ b/geometry/proximity/make_cylinder_field.h
@@ -44,8 +44,7 @@ namespace internal {
  @pre                    `elastic_modulus` is strictly positive.
                          `mesh_C` represents the cylinder and has enough
                          resolution to represent the pressure field.
- @tparam T               The scalar type for representing the mesh vertex
-                         positions and the pressure value.
+ @tparam_nonsymbolic_scalar
  */
 template <typename T>
 VolumeMeshFieldLinear<T, T> MakeCylinderPressureField(

--- a/geometry/proximity/make_cylinder_mesh.cc
+++ b/geometry/proximity/make_cylinder_mesh.cc
@@ -2,6 +2,7 @@
 
 #include <cmath>
 
+#include "drake/common/default_scalars.h"
 #include "drake/geometry/proximity/meshing_utilities.h"
 #include "drake/geometry/proximity/proximity_utilities.h"
 
@@ -430,10 +431,9 @@ VolumeMesh<T> MakeCylinderVolumeMeshWithMa(const Cylinder& cylinder,
   return {std::move(mesh_elements), std::move(mesh_vertices)};
 }
 
-template VolumeMesh<double> MakeCylinderVolumeMeshWithMa(
-    const Cylinder&, double resolution_hint);
-template VolumeMesh<AutoDiffXd> MakeCylinderVolumeMeshWithMa(
-    const Cylinder&, double resolution_hint);
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS((
+    &MakeCylinderVolumeMeshWithMa<T>
+))
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/mesh_half_space_intersection.cc
+++ b/geometry/proximity/mesh_half_space_intersection.cc
@@ -5,6 +5,7 @@
 #include <limits>
 #include <utility>
 
+#include "drake/common/default_scalars.h"
 #include "drake/geometry/proximity/contact_surface_utility.h"
 
 namespace drake {
@@ -414,53 +415,11 @@ ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
                                              std::move(grad_eS_W), nullptr);
 }
 
-template void ConstructTriangleHalfspaceIntersectionPolygon(
-    const SurfaceMesh<double>& mesh_F, SurfaceFaceIndex tri_index,
-    const PosedHalfSpace<double>& half_space_F,
-    const math::RigidTransform<double>& X_WF,
-    std::vector<SurfaceVertex<double>>* new_vertices_W,
-    std::vector<SurfaceFace>* new_faces,
-    std::unordered_map<SurfaceVertexIndex, SurfaceVertexIndex>*
-        vertices_to_newly_created_vertices,
-    std::unordered_map<SortedPair<SurfaceVertexIndex>, SurfaceVertexIndex>*
-        edges_to_newly_created_vertices);
-
-template void ConstructTriangleHalfspaceIntersectionPolygon(
-    const SurfaceMesh<double>& mesh_F, SurfaceFaceIndex tri_index,
-    const PosedHalfSpace<AutoDiffXd>& half_space_F,
-    const math::RigidTransform<AutoDiffXd>& X_WF,
-    std::vector<SurfaceVertex<AutoDiffXd>>* new_vertices_W,
-    std::vector<SurfaceFace>* new_faces,
-    std::unordered_map<SurfaceVertexIndex, SurfaceVertexIndex>*
-        vertices_to_newly_created_vertices,
-    std::unordered_map<SortedPair<SurfaceVertexIndex>, SurfaceVertexIndex>*
-        edges_to_newly_created_vertices);
-
-template std::unique_ptr<SurfaceMesh<double>>
-ConstructSurfaceMeshFromMeshHalfspaceIntersection(
-    const SurfaceMesh<double>& input_mesh_F,
-    const PosedHalfSpace<double>& half_space_F,
-    const std::vector<SurfaceFaceIndex>& tri_indices,
-    const math::RigidTransform<double>& X_WF);
-
-template std::unique_ptr<SurfaceMesh<AutoDiffXd>>
-ConstructSurfaceMeshFromMeshHalfspaceIntersection(
-    const SurfaceMesh<double>& input_mesh_F,
-    const PosedHalfSpace<AutoDiffXd>& half_space_F,
-    const std::vector<SurfaceFaceIndex>& tri_indices,
-    const math::RigidTransform<AutoDiffXd>& X_WF);
-
-template std::unique_ptr<ContactSurface<double>>
-ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
-    GeometryId, const math::RigidTransform<double>&, double, GeometryId,
-    const SurfaceMesh<double>&, const Bvh<Obb, SurfaceMesh<double>>&,
-    const math::RigidTransform<double>&);
-
-template std::unique_ptr<ContactSurface<AutoDiffXd>>
-ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
-    GeometryId, const math::RigidTransform<AutoDiffXd>&, double, GeometryId,
-    const SurfaceMesh<double>&, const Bvh<Obb, SurfaceMesh<double>>&,
-    const math::RigidTransform<AutoDiffXd>&);
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS((
+    &ConstructTriangleHalfspaceIntersectionPolygon<T>,
+    &ConstructSurfaceMeshFromMeshHalfspaceIntersection<T>,
+    &ComputeContactSurfaceFromSoftHalfSpaceRigidMesh<T>
+))
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/mesh_intersection.cc
+++ b/geometry/proximity/mesh_intersection.cc
@@ -7,6 +7,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/proximity/bvh.h"
@@ -462,24 +463,12 @@ ComputeContactSurfaceFromSoftVolumeRigidSurface(
                                              std::move(grad_eS_W), nullptr);
 }
 
-template class SurfaceVolumeIntersector<double>;
-template class SurfaceVolumeIntersector<AutoDiffXd>;
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class SurfaceVolumeIntersector)
 
-template std::unique_ptr<ContactSurface<double>>
-ComputeContactSurfaceFromSoftVolumeRigidSurface(
-    const GeometryId, const VolumeMeshFieldLinear<double, double>&,
-    const Bvh<Obb, VolumeMesh<double>>&, const math::RigidTransform<double>&,
-    const GeometryId, const SurfaceMesh<double>&,
-    const Bvh<Obb, SurfaceMesh<double>>&, const math::RigidTransform<double>&,
-    ContactPolygonRepresentation);
-
-template std::unique_ptr<ContactSurface<AutoDiffXd>>
-ComputeContactSurfaceFromSoftVolumeRigidSurface(
-    const GeometryId, const VolumeMeshFieldLinear<double, double>&,
-    const Bvh<Obb, VolumeMesh<double>>&,
-    const math::RigidTransform<AutoDiffXd>&, const GeometryId,
-    const SurfaceMesh<double>&, const Bvh<Obb, SurfaceMesh<double>>&,
-    const math::RigidTransform<AutoDiffXd>&, ContactPolygonRepresentation);
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS((
+    &ComputeContactSurfaceFromSoftVolumeRigidSurface<T>
+))
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/mesh_intersection.h
+++ b/geometry/proximity/mesh_intersection.h
@@ -27,7 +27,7 @@ template <typename T> class SurfaceVolumeIntersectorTester;
  variable. It also interpolates the field variable onto the resulted
  surface.
 
- @tparam T Currently, only T = double is supported.
+ @tparam_nonsymbolic_scalar
  */
 template <typename T>
 class SurfaceVolumeIntersector {

--- a/geometry/proximity/mesh_plane_intersection.cc
+++ b/geometry/proximity/mesh_plane_intersection.cc
@@ -3,6 +3,7 @@
 #include <array>
 #include <utility>
 
+#include "drake/common/default_scalars.h"
 #include "drake/geometry/proximity/contact_surface_utility.h"
 #include "drake/geometry/proximity/surface_mesh_field.h"
 #include "drake/geometry/proximity/volume_mesh.h"
@@ -226,43 +227,11 @@ ComputeContactSurfaceFromSoftVolumeRigidHalfSpace(
   return ComputeContactSurface(id_S, field_S, id_R, plane_S, tet_indices, X_WS);
 }
 
-template void SliceTetWithPlane<double>(
-    VolumeElementIndex, const VolumeMeshFieldLinear<double, double>&,
-    const Plane<double>&, const math::RigidTransform<double>&,
-    std::vector<SurfaceFace>*, std::vector<SurfaceVertex<double>>*,
-    std::vector<double>*,
-    std::unordered_map<SortedPair<VolumeVertexIndex>, SurfaceVertexIndex>*);
-
-template void SliceTetWithPlane<AutoDiffXd>(
-    VolumeElementIndex, const VolumeMeshFieldLinear<double, double>&,
-    const Plane<AutoDiffXd>&, const math::RigidTransform<AutoDiffXd>&,
-    std::vector<SurfaceFace>*, std::vector<SurfaceVertex<AutoDiffXd>>*,
-    std::vector<AutoDiffXd>*,
-    std::unordered_map<SortedPair<VolumeVertexIndex>, SurfaceVertexIndex>*);
-
-template std::unique_ptr<ContactSurface<double>> ComputeContactSurface(
-    GeometryId, const VolumeMeshFieldLinear<double, double>&,
-    GeometryId plane_id, const Plane<double>&,
-    const std::vector<VolumeElementIndex>, const math::RigidTransform<double>&);
-
-template std::unique_ptr<ContactSurface<AutoDiffXd>> ComputeContactSurface(
-    GeometryId, const VolumeMeshFieldLinear<double, double>&,
-    GeometryId plane_id, const Plane<AutoDiffXd>&,
-    const std::vector<VolumeElementIndex>,
-    const math::RigidTransform<AutoDiffXd>&);
-
-template std::unique_ptr<ContactSurface<double>>
-ComputeContactSurfaceFromSoftVolumeRigidHalfSpace(
-    const GeometryId, const VolumeMeshFieldLinear<double, double>&,
-    const Bvh<Obb, VolumeMesh<double>>&, const math::RigidTransform<double>&,
-    const GeometryId, const math::RigidTransform<double>&);
-
-template std::unique_ptr<ContactSurface<AutoDiffXd>>
-ComputeContactSurfaceFromSoftVolumeRigidHalfSpace(
-    const GeometryId, const VolumeMeshFieldLinear<double, double>&,
-    const Bvh<Obb, VolumeMesh<double>>&,
-    const math::RigidTransform<AutoDiffXd>&, const GeometryId,
-    const math::RigidTransform<AutoDiffXd>&);
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS((
+    &ComputeContactSurface<T>,
+    &ComputeContactSurfaceFromSoftVolumeRigidHalfSpace<T>,
+    &SliceTetWithPlane<T>
+))
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/mesh_plane_intersection.h
+++ b/geometry/proximity/mesh_plane_intersection.h
@@ -139,7 +139,7 @@ std::unique_ptr<ContactSurface<T>> ComputeContactSurface(
  @returns `nullptr` if there is no collision, otherwise the ContactSurface
           between geometries S and R. The normals of the contact surface mesh
           will all be parallel with the plane normal.
- @tparam T The underlying scalar type. Must be a valid Eigen scalar.
+ @tparam_nonsymbolic_scalar
  */
 template <typename T>
 std::unique_ptr<ContactSurface<T>>

--- a/geometry/proximity/penetration_as_point_pair_callback.cc
+++ b/geometry/proximity/penetration_as_point_pair_callback.cc
@@ -3,6 +3,7 @@
 #include <limits>
 #include <utility>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/proximity/distance_to_point_callback.h"
 #include "drake/geometry/query_results/signed_distance_to_point.h"
@@ -422,10 +423,9 @@ bool Callback(fcl::CollisionObjectd* fcl_object_A_ptr,
   return false;
 }
 
-template bool Callback<double>(fcl::CollisionObjectd*, fcl::CollisionObjectd*,
-                               void*);
-template bool Callback<AutoDiffXd>(fcl::CollisionObjectd*,
-                                   fcl::CollisionObjectd*, void*);
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS((
+    &Callback<T>
+))
 
 }  // namespace penetration_as_point_pair
 }  // namespace internal

--- a/geometry/proximity/test/characterization_utilities.cc
+++ b/geometry/proximity/test/characterization_utilities.cc
@@ -443,14 +443,6 @@ RigidTransform<T> AlignPlanes(const Vector3<T>& P, const Vector3<T>& m,
   return RigidTransform<T>{R, p_QP_A};
 }
 
-template RigidTransform<double> AlignPlanes<double>(const Vector3<double>&,
-                                                    const Vector3<double>&,
-                                                    const Vector3<double>&,
-                                                    const Vector3<double>&);
-template RigidTransform<AutoDiffXd> AlignPlanes<AutoDiffXd>(
-    const Vector3<AutoDiffXd>&, const Vector3<AutoDiffXd>&,
-    const Vector3<AutoDiffXd>&, const Vector3<AutoDiffXd>&);
-
 template <typename T>
 void CharacterizeResultTest<T>::RunCallback(
     const QueryInstance& query, fcl::CollisionObjectd* obj_A,
@@ -724,6 +716,10 @@ template <typename T>
 Sphere CharacterizeResultTest<T>::sphere(bool) {
   return Sphere(kDistance * 100);
 }
+
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS((
+    &AlignPlanes<T>
+))
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/test/characterization_utilities.h
+++ b/geometry/proximity/test/characterization_utilities.h
@@ -254,7 +254,9 @@ In other words, we transform the second plane (Q, n⃗) so Q and P are coinciden
 and m⃗ and n⃗ are anti-parallel. The notation is frameless, because we're
 not really relating two frames so much as creating a transform operator
 (although we *do* assume that all quantities are measured and expressed in a
-common frame). */
+common frame).
+
+@tparam_nonsymbolic_scalar */
 template <typename T>
 math::RigidTransform<T> AlignPlanes(const Vector3<T>& P, const Vector3<T>& m,
                                     const Vector3<T>& Q, const Vector3<T>& n);

--- a/manipulation/util/BUILD.bazel
+++ b/manipulation/util/BUILD.bazel
@@ -79,6 +79,7 @@ drake_cc_library(
         "robot_plan_utils.h",
     ],
     deps = [
+        "//common:default_scalars",
         "//lcmtypes:robot_plan",
         "//multibody/plant",
     ],

--- a/manipulation/util/robot_plan_utils.cc
+++ b/manipulation/util/robot_plan_utils.cc
@@ -108,14 +108,10 @@ lcmt_robot_plan EncodeKeyFrames(
   return plan;
 }
 
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
+    &GetJointNames<T>
+))
 
 }  // namespace util
 }  // namespace manipulation
 }  // namespace drake
-
-template std::vector<std::string> drake::manipulation::util::GetJointNames(
-    const drake::multibody::MultibodyPlant<double>&);
-template std::vector<std::string> drake::manipulation::util::GetJointNames(
-    const drake::multibody::MultibodyPlant<::drake::AutoDiffXd>&);
-template std::vector<std::string> drake::manipulation::util::GetJointNames(
-    const drake::multibody::MultibodyPlant<::drake::symbolic::Expression>&);

--- a/math/rigid_transform.cc
+++ b/math/rigid_transform.cc
@@ -22,12 +22,10 @@ std::ostream& operator<<(std::ostream& out, const RigidTransform<T>& X) {
   return out;
 }
 
-template std::ostream& operator<< <double>(std::ostream&,
-                                           const RigidTransform<double>&);
-template std::ostream& operator<< <AutoDiffXd>(
-    std::ostream&, const RigidTransform<AutoDiffXd>&);
-template std::ostream& operator<< <symbolic::Expression>(
-    std::ostream&, const RigidTransform<symbolic::Expression>&);
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
+    static_cast<std::ostream&(*)(std::ostream&, const RigidTransform<T>&)>(
+        &operator<< )
+))
 
 }  // namespace math
 }  // namespace drake

--- a/multibody/benchmarks/kuka_iiwa_robot/BUILD.bazel
+++ b/multibody/benchmarks/kuka_iiwa_robot/BUILD.bazel
@@ -31,6 +31,7 @@ drake_cc_library(
     ],
     deps = [
         ":make_kuka_iiwa_model",
+        "//common:default_scalars",
         "//math:geometric_transform",
         "//multibody/plant",
         "//multibody/test_utilities:spatial_kinematics",

--- a/multibody/benchmarks/kuka_iiwa_robot/drake_kuka_iiwa_robot.cc
+++ b/multibody/benchmarks/kuka_iiwa_robot/drake_kuka_iiwa_robot.cc
@@ -1,18 +1,16 @@
 #include "drake/multibody/benchmarks/kuka_iiwa_robot/drake_kuka_iiwa_robot.h"
 
-#include "drake/common/eigen_autodiff_types.h"
+#include "drake/common/default_scalars.h"
 
 namespace drake {
 namespace multibody {
 namespace benchmarks {
 namespace kuka_iiwa_robot {
 
-// Explicitly instantiates on the most common scalar types.
-template struct KukaRobotJointReactionForces<double>;
-template struct KukaRobotJointReactionForces<AutoDiffXd>;
-
-template class DrakeKukaIIwaRobot<double>;
-template class DrakeKukaIIwaRobot<AutoDiffXd>;
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    struct KukaRobotJointReactionForces)
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class DrakeKukaIIwaRobot)
 
 }  // namespace kuka_iiwa_robot
 }  // namespace benchmarks

--- a/multibody/fixed_fem/dev/BUILD.bazel
+++ b/multibody/fixed_fem/dev/BUILD.bazel
@@ -101,6 +101,7 @@ drake_cc_library(
     srcs = ["deformable_contact.cc"],
     hdrs = ["deformable_contact.h"],
     deps = [
+        "//common:default_scalars",
         "//geometry/proximity:posed_half_space",
         "//geometry/proximity:surface_mesh",
         "//geometry/proximity:volume_mesh",

--- a/multibody/fixed_fem/dev/collision_objects.h
+++ b/multibody/fixed_fem/dev/collision_objects.h
@@ -23,7 +23,7 @@ namespace internal {
  object has been added, its proximity properties and surface mesh can be queried
  with its unique GeometryId. Its pose can be queried and updated with the unique
  GeometryId.
- @tparam_default_scalar T. */
+ @tparam_default_scalar */
 template <typename T>
 class CollisionObjects : public geometry::ShapeReifier {
  public:

--- a/multibody/fixed_fem/dev/deformable_contact.cc
+++ b/multibody/fixed_fem/dev/deformable_contact.cc
@@ -4,6 +4,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/default_scalars.h"
 #include "drake/geometry/proximity/posed_half_space.h"
 
 namespace drake {
@@ -476,14 +477,10 @@ DeformableContactSurface<T> ComputeTetMeshTriMeshContact(
   return Intersector<T>().Intersect(tet_mesh_D, tri_mesh_R, X_DR);
 }
 
-template DeformableContactSurface<double> ComputeTetMeshTriMeshContact(
-    const geometry::VolumeMesh<double>&, const geometry::SurfaceMesh<double>&,
-    const math::RigidTransform<double>&);
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS((
+    &ComputeTetMeshTriMeshContact<T>
+))
 
-template DeformableContactSurface<AutoDiffXd> ComputeTetMeshTriMeshContact(
-    const geometry::VolumeMesh<AutoDiffXd>&,
-    const geometry::SurfaceMesh<double>&,
-    const math::RigidTransform<AutoDiffXd>&);
 }  // namespace fixed_fem
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/fixed_fem/dev/mesh_utilities.cc
+++ b/multibody/fixed_fem/dev/mesh_utilities.cc
@@ -109,10 +109,10 @@ VolumeMesh<T> MakeDiamondCubicBoxVolumeMesh(
   return VolumeMesh<T>(std::move(elements), std::move(vertices));
 }
 
-template VolumeMesh<double> MakeDiamondCubicBoxVolumeMesh(
-    const geometry::Box&, double, const math::RigidTransform<double>&);
-template VolumeMesh<AutoDiffXd> MakeDiamondCubicBoxVolumeMesh(
-    const geometry::Box&, double, const math::RigidTransform<AutoDiffXd>&);
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS((
+    &MakeDiamondCubicBoxVolumeMesh<T>
+))
+
 }  // namespace fixed_fem
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/fixed_fem/dev/mesh_utilities.h
+++ b/multibody/fixed_fem/dev/mesh_utilities.h
@@ -39,7 +39,7 @@ distributed with the source code.
      dimension.
  @param[in] X_WB
      The pose of the rectanglur volume mesh in the world frame.
- @tparam_nonsymbolic_scalar T. */
+ @tparam_nonsymbolic_scalar */
 template <typename T>
 geometry::VolumeMesh<T> MakeDiamondCubicBoxVolumeMesh(
     const geometry::Box& box, double resolution_hint,

--- a/multibody/inverse_kinematics/BUILD.bazel
+++ b/multibody/inverse_kinematics/BUILD.bazel
@@ -54,6 +54,7 @@ drake_cc_library(
         "unit_quaternion_constraint.h",
     ],
     deps = [
+        "//common:default_scalars",
         "//math:geometric_transform",
         "//math:gradient",
         "//multibody/plant",
@@ -106,6 +107,7 @@ drake_cc_library(
         "//manipulation/models/iiwa_description:models",
     ],
     deps = [
+        "//common:default_scalars",
         "//common:find_resource",
         "//common/test_utilities:eigen_matrix_compare",
         "//math:compute_numerical_gradient",

--- a/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.cc
+++ b/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <utility>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/find_resource.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/systems/framework/diagram_builder.h"
@@ -225,19 +226,10 @@ T BoxSphereSignedDistance(const Eigen::Ref<const Eigen::Vector3d>& box_size,
   }
 }
 
-template std::unique_ptr<MultibodyPlant<double>>
-ConstructTwoFreeBodiesPlant<double>();
-template std::unique_ptr<MultibodyPlant<AutoDiffXd>>
-ConstructTwoFreeBodiesPlant<AutoDiffXd>();
-
-template double BoxSphereSignedDistance<double>(
-    const Eigen::Ref<const Eigen::Vector3d>& box_size, double radius,
-    const math::RigidTransform<double>& X_WB,
-    const math::RigidTransform<double>& X_WS);
-template AutoDiffXd BoxSphereSignedDistance<AutoDiffXd>(
-    const Eigen::Ref<const Eigen::Vector3d>& box_size, double radius,
-    const math::RigidTransform<AutoDiffXd>& X_WB,
-    const math::RigidTransform<AutoDiffXd>& X_WS);
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS((
+    &ConstructTwoFreeBodiesPlant<T>,
+    &BoxSphereSignedDistance<T>
+))
 
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h
+++ b/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h
@@ -26,6 +26,7 @@ void AddTwoFreeBodiesToPlant(MultibodyPlant<T>* model);
 
 /**
  * Constructs a MultibodyPlant consisting of two free bodies.
+ * @tparam_nonsymbolic_scalar
  */
 template <typename T>
 std::unique_ptr<MultibodyPlant<T>> ConstructTwoFreeBodiesPlant();
@@ -141,6 +142,7 @@ class TwoFreeSpheresTest : public ::testing::Test {
  * @param radius The radius of the sphere.
  * @param X_WB the pose of the box (B) in the world frame (W).
  * @param X_WS the pose of the sphere (S) in the world frame (W).
+ * @tparam_nonsymbolic_scalar
  */
 template <typename T>
 T BoxSphereSignedDistance(const Eigen::Ref<const Eigen::Vector3d>& box_size,

--- a/multibody/inverse_kinematics/unit_quaternion_constraint.cc
+++ b/multibody/inverse_kinematics/unit_quaternion_constraint.cc
@@ -1,5 +1,7 @@
 #include "drake/multibody/inverse_kinematics/unit_quaternion_constraint.h"
 
+#include "drake/common/default_scalars.h"
+
 namespace drake {
 namespace multibody {
 UnitQuaternionConstraint::UnitQuaternionConstraint()
@@ -38,18 +40,9 @@ void AddUnitQuaternionConstraintOnPlant(
   }
 }
 
-// Explicit instantiation
-template void AddUnitQuaternionConstraintOnPlant<double>(
-    const MultibodyPlant<double>& plant,
-    const Eigen::Ref<const VectorX<symbolic::Variable>>& q_vars,
-    solvers::MathematicalProgram* prog);
-template void AddUnitQuaternionConstraintOnPlant<AutoDiffXd>(
-    const MultibodyPlant<AutoDiffXd>& plant,
-    const Eigen::Ref<const VectorX<symbolic::Variable>>& q_vars,
-    solvers::MathematicalProgram* prog);
-template void AddUnitQuaternionConstraintOnPlant<symbolic::Expression>(
-    const MultibodyPlant<symbolic::Expression>& plant,
-    const Eigen::Ref<const VectorX<symbolic::Variable>>& q_vars,
-    solvers::MathematicalProgram* prog);
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
+    &AddUnitQuaternionConstraintOnPlant<T>
+))
+
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/inverse_kinematics/unit_quaternion_constraint.h
+++ b/multibody/inverse_kinematics/unit_quaternion_constraint.h
@@ -47,6 +47,7 @@ class UnitQuaternionConstraint : public solvers::Constraint {
  * @param q_vars The decision variables for the generalized position of the
  * plant.
  * @param prog The unit quaternion constraints are added to this prog.
+ * @tparam_default_scalar
  */
 template <typename T>
 void AddUnitQuaternionConstraintOnPlant(

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -3381,40 +3381,19 @@ AddMultibodyPlantSceneGraphResult<T> AddMultibodyPlantSceneGraph(
                                      std::move(scene_graph));
 }
 
-template <typename T>
-AddMultibodyPlantSceneGraphResult<T> AddMultibodyPlantSceneGraph(
-    systems::DiagramBuilder<T>* builder) {
-  return AddMultibodyPlantSceneGraph(builder, 0.0);
-}
-
-// Add explicit instantiations for `AddMultibodyPlantSceneGraph`.
-// This does *not* support symbolic::Expression.
-template AddMultibodyPlantSceneGraphResult<double> AddMultibodyPlantSceneGraph(
-    systems::DiagramBuilder<double>* builder,
-    std::unique_ptr<MultibodyPlant<double>> plant,
-    std::unique_ptr<geometry::SceneGraph<double>> scene_graph);
-
-template AddMultibodyPlantSceneGraphResult<double> AddMultibodyPlantSceneGraph(
-    systems::DiagramBuilder<double>* builder, double time_step,
-    std::unique_ptr<geometry::SceneGraph<double>> scene_graph);
-
-template AddMultibodyPlantSceneGraphResult<double> AddMultibodyPlantSceneGraph(
-    systems::DiagramBuilder<double>* builder);
-
-template
-AddMultibodyPlantSceneGraphResult<AutoDiffXd>
-AddMultibodyPlantSceneGraph(
-    systems::DiagramBuilder<AutoDiffXd>* builder,
-    std::unique_ptr<MultibodyPlant<AutoDiffXd>> plant,
-    std::unique_ptr<geometry::SceneGraph<AutoDiffXd>> scene_graph);
-
-template AddMultibodyPlantSceneGraphResult<AutoDiffXd>
-AddMultibodyPlantSceneGraph(
-    systems::DiagramBuilder<AutoDiffXd>* builder, double time_step,
-    std::unique_ptr<geometry::SceneGraph<AutoDiffXd>> scene_graph);
-
-template AddMultibodyPlantSceneGraphResult<AutoDiffXd>
-AddMultibodyPlantSceneGraph(systems::DiagramBuilder<AutoDiffXd>* builder);
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS((
+    /* Use static_cast to disambiguate the two different overloads. */
+    static_cast<AddMultibodyPlantSceneGraphResult<T>(*)(
+        systems::DiagramBuilder<T>*, double,
+        std::unique_ptr<geometry::SceneGraph<T>>)>(
+            &AddMultibodyPlantSceneGraph),
+    /* Use static_cast to disambiguate the two different overloads. */
+    static_cast<AddMultibodyPlantSceneGraphResult<T>(*)(
+        systems::DiagramBuilder<T>*,
+        std::unique_ptr<MultibodyPlant<T>>,
+        std::unique_ptr<geometry::SceneGraph<T>>)>(
+            &AddMultibodyPlantSceneGraph)
+))
 
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -4839,6 +4839,7 @@ struct AddMultibodyPlantSceneGraphResult;
 ///   used.
 /// @return Pair of the registered plant and scene graph.
 /// @pre `builder` must be non-null.
+/// @tparam_nonsymbolic_scalar
 /// @relates MultibodyPlant
 template <typename T>
 AddMultibodyPlantSceneGraphResult<T>
@@ -4861,6 +4862,7 @@ AddMultibodyPlantSceneGraph(
 ///   used.
 /// @return Pair of the registered plant and scene graph.
 /// @pre `builder` and `plant` must be non-null.
+/// @tparam_nonsymbolic_scalar
 /// @relates MultibodyPlant
 template <typename T>
 AddMultibodyPlantSceneGraphResult<T>
@@ -4873,6 +4875,7 @@ AddMultibodyPlantSceneGraph(
 /// constructed outside of this method.
 /// @warning Do NOT use this as a function argument or member variable. The
 /// lifetime of this object should be as short as possible.
+/// @tparam_default_scalar
 template <typename T>
 struct AddMultibodyPlantSceneGraphResult final {
   MultibodyPlant<T>& plant;

--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -89,6 +89,7 @@ drake_cc_library(
         ":simulator",
         ":simulator_config",
         ":velocity_implicit_euler_integrator",
+        "//common:default_scalars",
         "//common:essential",
         "//common:nice_type_name",
         "//systems/framework:leaf_system",

--- a/systems/analysis/simulator_config_functions.cc
+++ b/systems/analysis/simulator_config_functions.cc
@@ -174,13 +174,6 @@ const vector<string>& GetIntegrationSchemes() {
   return result.access();
 }
 
-// Explicit instantiations.
-// We can't support T=symbolic::Expression because Simulator doesn't support it.
-template IntegratorBase<double>& ResetIntegratorFromFlags(
-    Simulator<double>*, const string&, const double&);
-template IntegratorBase<AutoDiffXd>& ResetIntegratorFromFlags(
-    Simulator<AutoDiffXd>*, const string&, const AutoDiffXd&);
-
 void ApplySimulatorConfig(
     Simulator<double>* simulator,
     const SimulatorConfig& config) {
@@ -219,6 +212,11 @@ SimulatorConfig ExtractSimulatorConfig(
   result.publish_every_time_step = simulator.get_publish_every_time_step();
   return result;
 }
+
+// We can't support T=symbolic::Expression because Simulator doesn't support it.
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS((
+    &ResetIntegratorFromFlags<T>
+))
 
 }  // namespace systems
 }  // namespace drake

--- a/systems/analysis/simulator_config_functions.h
+++ b/systems/analysis/simulator_config_functions.h
@@ -28,8 +28,8 @@ system associated with `simulator` according to the given arguments.
   GetIntegrationSchemes() for a the list of valid options.
 @param[in] max_step_size The IntegratorBase::set_maximum_step_size() value.
 @returns A reference to the newly created integrator owned by `simulator`.
+@tparam_nonsymbolic_scalar
 
-@tparam_default_nonsymbolic_scalar
 @ingroup simulator_configuration */
 template <typename T>
 IntegratorBase<T>& ResetIntegratorFromFlags(

--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -498,11 +498,10 @@ drake_cc_library(
         "system_type_tag.h",
     ],
     deps = [
-        "//common:autodiff",
+        "//common:default_scalars",
         "//common:essential",
         "//common:hash",
         "//common:nice_type_name",
-        "//common:symbolic",
     ],
 )
 

--- a/systems/framework/system_scalar_converter.cc
+++ b/systems/framework/system_scalar_converter.cc
@@ -1,5 +1,6 @@
 #include "drake/systems/framework/system_scalar_converter.h"
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/hash.h"
 
 using std::pair;
@@ -31,9 +32,9 @@ void SystemScalarConverter::Insert(
   DRAKE_ASSERT(insert_result.second);
 }
 
-void SystemScalarConverter::Remove(const std::type_info& t_info,
-                                   const std::type_info& u_info) {
-  funcs_.erase(Key(t_info, u_info));
+template <typename T, typename U>
+void SystemScalarConverter::Remove() {
+  funcs_.erase(Key(typeid(T), typeid(U)));
 }
 
 const SystemScalarConverter::ErasedConverterFunc* SystemScalarConverter::Find(
@@ -60,6 +61,10 @@ void SystemScalarConverter::RemoveUnlessAlsoSupportedBy(
     }
   }
 }
+
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
+    &SystemScalarConverter::Remove<T, U>
+))
 
 }  // namespace systems
 }  // namespace drake

--- a/systems/framework/system_scalar_converter.h
+++ b/systems/framework/system_scalar_converter.h
@@ -139,9 +139,7 @@ class SystemScalarConverter {
   /// Removes from this converter the ability to convert from System<U> to
   /// System<T>.
   template <typename T, typename U>
-  void Remove() {
-    Remove(typeid(T), typeid(U));
-  }
+  void Remove();
 
   /// Returns true iff this object can convert a System<U> into a System<T>,
   /// i.e., whether Convert() will return non-null.
@@ -184,9 +182,6 @@ class SystemScalarConverter {
   void Insert(
       const std::type_info&, const std::type_info&,
       const ErasedConverterFunc&);
-
-  // Given typeid(T) and typeid(U), removes the converter from U to T.
-  void Remove(const std::type_info& t_info, const std::type_info& u_info);
 
   // Maps from {T, U} to the function that converts from U into T.
   std::unordered_map<Key, ErasedConverterFunc, KeyHasher> funcs_;

--- a/systems/primitives/BUILD.bazel
+++ b/systems/primitives/BUILD.bazel
@@ -225,6 +225,7 @@ drake_cc_library(
     srcs = ["random_source.cc"],
     hdrs = ["random_source.h"],
     deps = [
+        "//common:default_scalars",
         "//common:essential",
         "//common:unused",
         "//systems/framework:diagram_builder",

--- a/systems/primitives/affine_system.cc
+++ b/systems/primitives/affine_system.cc
@@ -90,6 +90,20 @@ void TimeVaryingAffineSystem<T>::configure_random_state(
                         .operatorSqrt();
 }
 
+template <typename T>
+template <typename U>
+void TimeVaryingAffineSystem<T>::ConfigureDefaultAndRandomStateFrom(
+    const TimeVaryingAffineSystem<U>& other) {
+  // Convert default state from U -> double -> T.
+  VectorX<T> x0(other.num_states());
+  const VectorX<U>& other_x0 = other.get_default_state();
+  for (int i = 0; i < other.num_states(); i++) {
+    x0[i] = ExtractDoubleOrThrow(other_x0[i]);
+  }
+  this->configure_default_state(x0);
+  this->configure_random_state(other.get_random_state_covariance());
+}
+
 // This is the default implementation for this virtual method.
 template <typename T>
 void TimeVaryingAffineSystem<T>::CalcOutputY(
@@ -385,6 +399,9 @@ void AffineSystem<T>::DoCalcDiscreteVariableUpdates(
   updates->get_mutable_vector().SetFromVector(xnext);
 }
 
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
+    &TimeVaryingAffineSystem<T>::template ConfigureDefaultAndRandomStateFrom<U>
+))
 
 }  // namespace systems
 }  // namespace drake

--- a/systems/primitives/affine_system.h
+++ b/systems/primitives/affine_system.h
@@ -105,19 +105,10 @@ class TimeVaryingAffineSystem : public LeafSystem<T> {
                           double time_period);
 
   /// Helper method.  Derived classes should call this from the
-  // scalar-converting copy constructor.
+  /// scalar-converting copy constructor.
   template <typename U>
   void ConfigureDefaultAndRandomStateFrom(
-      const TimeVaryingAffineSystem<U>& other) {
-    // Convert default state from U -> double -> T.
-    VectorX<T> x0(other.num_states());
-    const VectorX<U>& other_x0 = other.get_default_state();
-    for (int i = 0; i < other.num_states(); i++) {
-      x0[i] = ExtractDoubleOrThrow(other_x0[i]);
-    }
-    this->configure_default_state(x0);
-    this->configure_random_state(other.get_random_state_covariance());
-  }
+      const TimeVaryingAffineSystem<U>& other);
 
   /// Computes @f[ y(t) = C(t) x(t) + D(t) u(t) + y_0(t), @f] with by calling
   /// `C(t)`, `D(t)`, and `y0(t)` with runtime size checks.  Derived classes
@@ -148,6 +139,11 @@ class TimeVaryingAffineSystem : public LeafSystem<T> {
       RandomGenerator* generator) const override;
 
  private:
+  // For use by DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS... because the
+  // function it needs to instantiate is protected.
+  template<typename, typename>
+  friend constexpr auto Make_Function_Pointers();
+
   const int num_states_{0};
   const int num_inputs_{0};
   const int num_outputs_{0};

--- a/systems/primitives/random_source.cc
+++ b/systems/primitives/random_source.cc
@@ -4,6 +4,7 @@
 #include <random>
 #include <variant>
 
+#include "drake/common/default_scalars.h"
 #include "drake/common/never_destroyed.h"
 
 namespace drake {
@@ -205,8 +206,9 @@ int AddRandomInputs(double sampling_interval_sec, DiagramBuilder<T>* builder) {
   return count;
 }
 
-template int AddRandomInputs<double>(double, DiagramBuilder<double>*);
-template int AddRandomInputs<AutoDiffXd>(double, DiagramBuilder<AutoDiffXd>*);
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS((
+    &AddRandomInputs<T>
+))
 
 }  // namespace systems
 }  // namespace drake


### PR DESCRIPTION
Port several different kinds of call sites to use it, as a demonstration of sufficiency and correctness.

Special thanks for "h.m.m." for the inspiration https://stackoverflow.com/a/50350144/13032709.  This improves on the idea by using constexpr and attribute-used.

The trigger for this was when I ran `bloaty` on `libdrake.so` and it showed almost 2% of our binary size was the inlined use of `operator<<` and `NiceTypeName::Get<>` when `SystemScalarConverter` wanted to report an error message.  However, function instantiation in cc files is really something we should have been doing since a long time ago, as evidenced by all of the pasta this allows us to remove.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15218)
<!-- Reviewable:end -->
