### PR TITLE
[geometry] Introduce BvhUpdater and add it to DeformableVolumeMesh

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -16,6 +16,7 @@ drake_cc_package_library(
     deps = [
         ":bv",
         ":bvh",
+        ":bvh_updater",
         ":collision_filter",
         ":collision_filter_legacy",
         ":collisions_exist_callback",
@@ -97,6 +98,16 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "bvh_updater",
+    hdrs = ["bvh_updater.h"],
+    deps = [
+        ":bv",
+        ":bvh",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
     name = "collision_filter",
     srcs = ["collision_filter.cc"],
     hdrs = ["collision_filter.h"],
@@ -149,6 +160,8 @@ drake_cc_library(
     srcs = ["deformable_volume_mesh.cc"],
     hdrs = ["deformable_volume_mesh.h"],
     deps = [
+        ":bvh",
+        ":bvh_updater",
         ":mesh_deformer",
         ":volume_mesh",
     ],
@@ -682,6 +695,17 @@ drake_cc_library(
 drake_cc_googletest(
     name = "characterization_utilities_test",
     deps = [":characterization_utilities"],
+)
+
+drake_cc_googletest(
+    name = "bvh_updater_test",
+    deps = [
+        ":bvh",
+        ":bvh_updater",
+        ":make_sphere_mesh",
+        ":mesh_deformer",
+        "//common/test_utilities:eigen_matrix_compare",
+    ],
 )
 
 drake_cc_googletest(

--- a/geometry/proximity/aabb.h
+++ b/geometry/proximity/aabb.h
@@ -14,6 +14,7 @@ namespace internal {
 
 // Forward declarations.
 template <typename> class AabbMaker;
+template <typename> class BvhUpdater;
 class Obb;
 
 /* Axis-aligned bounding box. The box is defined in a canonical frame B such
@@ -130,6 +131,18 @@ class Aabb {
   }
 
  private:
+  // Allow the BvhUpdater access to set_bounds().
+  template <typename> friend class BvhUpdater;
+
+  // Provides access to the BvhUpdater to refit the Aabb. Sets the extents of
+  // the bounding box based on a box spanned by the given `lower` and `upper`
+  // corners.
+  // @pre lower(i) ≤ upper(i), ∀ i ∈ {0, 1, 2}.
+  void set_bounds(const Vector3<double>& lower, const Vector3<double>& upper) {
+    center_ = (lower + upper) / 2;
+    half_width_ = (upper - lower) / 2;
+  }
+
   // Center point of the box.
   Vector3<double> center_;
   // Half width extents along each axes.

--- a/geometry/proximity/bvh_updater.h
+++ b/geometry/proximity/bvh_updater.h
@@ -1,0 +1,129 @@
+#pragma once
+
+#include <limits>
+#include <vector>
+
+#include "drake/geometry/proximity/aabb.h"
+#include "drake/geometry/proximity/bvh.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+/* This class can be used to update a bounding-volume hierarchy (BVH). It
+ doesn't own the BVH or the corresponding mesh, but merely applies an algorithm
+ to the BVH which compares its current configuration against the underlying
+ mesh data, updating the BVH state to maintain correct spatial culling.
+
+ This will frequently be combined with a MeshDeformer so that when a mesh is
+ updated, the corresponding Bvh can likewise be updated.
+
+ This current incarnation only supports Bvhs constructed with axis-aligned
+ bounding boxes.
+
+ This class cannot be moved or copied. It is assumed upon creation that it will
+ be permanently associated with *specific* MeshType and Bvh instances and
+ maintain those associations for its entire lifetime (see DeformableVolumeMesh
+ as an example).
+
+ @tparam MeshType SurfaceMesh<T> or VolumeMesh<T> where T is double or
+                  AutoDiffXd. */
+template <typename MeshType>
+class BvhUpdater {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BvhUpdater)
+
+  /* Constructs a %BvhUpdater for the given BVH and its corresponding mesh.
+   Both the mesh and the bvh must remain alive at least as long as this
+   updater.
+
+   @param mesh_M   The underlying mesh, measured and expressed in Frame M.
+   @param bvh_M    The Bvh for the mesh, likewise measured and expressed in the
+                   mesh's frame M.
+   @pre bvh_M was constructed on mesh_M.
+   @pre mesh_M != nullptr and bvh_M != nullptr. */
+  BvhUpdater(const MeshType* mesh_M, Bvh<Aabb, MeshType>* bvh_M)
+      : mesh_(*mesh_M), bvh_(*bvh_M) {
+    DRAKE_DEMAND(mesh_M != nullptr);
+    DRAKE_DEMAND(bvh_M != nullptr);
+  }
+
+  const MeshType& mesh() const { return mesh_; }
+  const Bvh<Aabb, MeshType>& bvh() const { return bvh_; }
+
+  /* Updates the referenced bvh to maintain a good fit on the referenced mesh.
+   */
+  void Update() {
+    /* Get the *double-valued* mesh vertices. */
+    const auto& vertices = GetMeshVertices(mesh_.vertices());
+    if (vertices.size() == 0) return;
+
+    /* This implementation doesn't change the bvh topology; it simply passes
+     through each box in a bottom-up manner refitting the box to the data. */
+    UpdateRecursive(&bvh_.mutable_root_node(), vertices);
+  }
+
+ private:
+  template <typename T>
+  using VertexType = typename MeshType::template VertexType<T>;
+
+  // If the mesh type is already double-valued, simply return the mesh vertices.
+  static const std::vector<VertexType<double>>& GetMeshVertices(
+      const std::vector<VertexType<double>>& vertices) {
+    return vertices;
+  }
+
+  // If the mesh type is AutoDiffXd-valued, return double-valued vertices.
+  static const std::vector<VertexType<double>> GetMeshVertices(
+      const std::vector<VertexType<AutoDiffXd>>& vertices) {
+    std::vector<VertexType<double>> vertices_dbl;
+    vertices_dbl.reserve(vertices.size());
+    for (const auto& v : vertices) {
+      vertices_dbl.emplace_back(convert_to_double(v.r_MV()));
+    }
+    return vertices_dbl;
+  }
+
+  // Helper function to perform a bottom-up refit.
+  void UpdateRecursive(
+      typename Bvh<Aabb, MeshType>::NodeType* node,
+      const std::vector<typename MeshType::template VertexType<double>>&
+          vertices) {
+    using Vector3d = Eigen::Vector3d;
+    /* Intentionally uninitialized. */
+    Vector3d lower, upper;
+    constexpr int kElementVertexCount = MeshType::kVertexPerElement;
+    constexpr double kInf = std::numeric_limits<double>::infinity();
+    if (node->is_leaf()) {
+      // TODO(SeanCurtis-TRI): This is the limiting factor on supporting Obb.
+      //  This functionality needs to be a function of the bounding volume type
+      //  and not encoded in this class.
+      lower << kInf, kInf, kInf;
+      upper = -lower;
+      const int num_elements = node->num_element_indices();
+      for (int e = 0; e < num_elements; ++e) {
+        const auto& element = mesh_.element(node->element_index(e));
+        for (int i = 0; i < kElementVertexCount; ++i) {
+          const Vector3d& p_MV =
+              convert_to_double(vertices[element.vertex(i)].r_MV());
+          lower = lower.cwiseMin(p_MV);
+          upper = upper.cwiseMax(p_MV);
+        }
+      }
+    } else {
+      UpdateRecursive(&node->left(), vertices);
+      UpdateRecursive(&node->right(), vertices);
+      // Update box on child boxes.
+      lower = node->left().bv().lower().cwiseMin(node->right().bv().lower());
+      upper = node->left().bv().upper().cwiseMax(node->right().bv().upper());
+    }
+    node->bv().set_bounds(lower, upper);
+  }
+
+  const MeshType& mesh_;
+  Bvh<Aabb, MeshType>& bvh_;
+};
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/deformable_volume_mesh.cc
+++ b/geometry/proximity/deformable_volume_mesh.cc
@@ -8,6 +8,7 @@ template <typename T>
 void DeformableVolumeMesh<T>::UpdateVertexPositions(
     const Eigen::Ref<const VectorX<T>>& q) {
   deformer_.SetAllPositions(q);
+  bvh_updater_.Update();
 }
 
 }  // namespace internal

--- a/geometry/proximity/deformable_volume_mesh.h
+++ b/geometry/proximity/deformable_volume_mesh.h
@@ -2,6 +2,8 @@
 
 #include <utility>
 
+#include "drake/geometry/proximity/bvh.h"
+#include "drake/geometry/proximity/bvh_updater.h"
 #include "drake/geometry/proximity/mesh_deformer.h"
 #include "drake/geometry/proximity/volume_mesh.h"
 
@@ -28,31 +30,39 @@ class DeformableVolumeMesh {
    The %DeformableVolumeMesh will *own* its own underlying VolumeMesh. */
   explicit DeformableVolumeMesh(VolumeMesh<T> mesh_M)
       : mesh_(std::move(mesh_M)),
-        deformer_(&mesh_) {}
+        deformer_(&mesh_),
+        bvh_(mesh_),
+        bvh_updater_(&mesh_, &bvh_) {}
 
   /* @name Implements CopyConstructible, CopyAssignable, MoveConstructible,
    MoveAssignable */
   //@{
 
+  // Note: Neither MeshDeformer nor BvhUpdater have copy/move semantics. So,
+  // we can't default those semantics on DeformableVolumeMesh. The deformer_
+  // and bvh_updater_ are configured to *always* point to the instance's
+  // *members* mesh_ and bvh_. That never changes during the entire lifetime of
+  // a DeformableVolumeMesh instance. So, the assignment operators only have to
+  // worry about setting the member mesh and bvh to the assigned data; we don't
+  // have to (and can't) make any modifications to the deformer or bvh updater.
+
   DeformableVolumeMesh(const DeformableVolumeMesh& other)
-      : DeformableVolumeMesh(other.mesh()) {}
+      : DeformableVolumeMesh(other.mesh_, other.bvh_) {}
 
   DeformableVolumeMesh& operator=(const DeformableVolumeMesh& other) {
     if (this == &other) return *this;
     mesh_ = other.mesh();
-    deformer_.set_mesh(&mesh_);
+    bvh_ = other.bvh_;
     return *this;
   }
 
-  // Note: MeshDeformer has no move or copy semantics, so we can't default
-  //  semantics here.
-
   DeformableVolumeMesh(DeformableVolumeMesh&& other)
-      : mesh_(std::move(other.mesh_)), deformer_(&mesh_) {}
+      : DeformableVolumeMesh(std::move(other.mesh_), std::move(other.bvh_)) {}
 
   DeformableVolumeMesh& operator=(DeformableVolumeMesh&& other) {
+    if (this == &other) return *this;
     mesh_ = std::move(other.mesh_);
-    deformer_.set_mesh(&mesh_);
+    bvh_ = std::move(other.bvh_);
     return *this;
   }
 
@@ -61,6 +71,14 @@ class DeformableVolumeMesh {
   /* Access to the underlying mesh. Represent the most recent configuration
    based either on construction or a call to UpdateVertexPositions(). */
   const VolumeMesh<T>& mesh() const { return mesh_; }
+
+  // TODO(SeanCurtis-TRI): We're currently returning an object defined in the
+  //  internal namespace. Right now it's not bad because DeformableVolumeMesh is
+  //  also defined in the internal namespace. But when *this* class moves into
+  //  the geometry namespace, we'll either have to bring Bvh along or make this
+  //  method private with friend access.
+  /* The dynamic bounding volume hierarchy for this mesh. */
+  const internal::Bvh<Aabb, VolumeMesh<T>>& bvh() const { return bvh_; }
 
   /* Updates the vertex positions of the underlying mesh.
 
@@ -71,8 +89,22 @@ class DeformableVolumeMesh {
   void UpdateVertexPositions(const Eigen::Ref<const VectorX<T>>& q);
 
  private:
+  // The delegate constructor used by move and copy constructors. We can't have
+  // all three constructors delegate to this same constructor because the base
+  // constructor *creates* a bvh on the fly -- so, it is, in a sense, optional.
+  // I have not been able to create a constructor that supports both optional
+  // and maintains semantics. So, the mesh-only constructor defines its own
+  // initialization.
+  DeformableVolumeMesh(VolumeMesh<T> mesh_M, Bvh<Aabb, VolumeMesh<T>> bvh_M )
+      : mesh_(std::move(mesh_M)),
+        deformer_(&mesh_),
+        bvh_(std::move(bvh_M)),
+        bvh_updater_(&mesh_, &bvh_) {}
+
   VolumeMesh<T> mesh_;
   MeshDeformer<VolumeMesh<T>> deformer_;
+  Bvh<Aabb, VolumeMesh<T>> bvh_;
+  BvhUpdater<VolumeMesh<T>> bvh_updater_;
 };
 
 }  // namespace internal

--- a/geometry/proximity/mesh_deformer.h
+++ b/geometry/proximity/mesh_deformer.h
@@ -14,13 +14,15 @@ namespace internal {
  Deforming a mesh can be a dangerous proposition if that mesh is accessed or
  referenced by some other class (e.g., MeshFieldLinear). Deforming the mesh can
  cause downstream dependencies to become invalid. Meshes should only be deformed
- by those who own all downstream dependencies and update them accordingly. */
+ by those who own all downstream dependencies and update them accordingly.
+
+ This class cannot be moved or copied. It is assumed upon creation that it will
+ be permanently associated with a *specific* MeshType instance and maintain that
+ association for its entire lifetime (see DeformableVolumeMesh as an example).
+ */
 template <typename MeshType>
 class MeshDeformer {
  public:
-  // Note: Because this contains a reference to some entity not owned by this
-  // class, copy and move semantics are problematic. We'll force users of this
-  // class to handle the semantics -- that is what the set_mesh() method is for.
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MeshDeformer);
 
   /* The type of index used for referencing vertices in `MeshType`. */
@@ -38,12 +40,6 @@ class MeshDeformer {
    @pre `mesh_M != nullptr`. */
   explicit MeshDeformer(MeshType* mesh_M) : mesh_(*mesh_M) {
     DRAKE_DEMAND(mesh_M != nullptr);
-  }
-
-  /* Sets the mesh for this deformer. */
-  void set_mesh(MeshType* mesh_M) {
-    DRAKE_DEMAND(mesh_M != nullptr);
-    mesh_ = *mesh_M;
   }
 
   /* Getter for the *const* version of the mesh to be deformed. */

--- a/geometry/proximity/test/bvh_updater_test.cc
+++ b/geometry/proximity/test/bvh_updater_test.cc
@@ -1,0 +1,201 @@
+#include "drake/geometry/proximity/bvh_updater.h"
+
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/geometry/proximity/bvh.h"
+#include "drake/geometry/proximity/mesh_deformer.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+namespace {
+
+using Eigen::Vector3d;
+using math::RotationMatrix;
+using std::vector;
+
+template <class MeshType>
+class BvhUpdaterTest : public ::testing::Test {
+ protected:
+  /* Creates a generic mesh of two disjoint elements as shown below.
+
+                          Az    Ay
+                 v5       ┆   ╱
+                  ●       ┆  ╱    ● v2
+                  ┆       ┆ ╱     ┆
+          v4      ┆v7     ┆╱    v6┆       v1
+    ┄┄┄┄┄┄┄●┄┄┄┄┄┄●┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄●┄┄┄┄┄┄●┄ Ax
+                 ╱       ╱┆      ╱
+                ╱       ╱ ┆     ╱
+               ●       ╱  ┆    ● v0
+              V3      ╱   ┆
+
+
+    If the MeshType is a surface mesh, triangles (0, 1, 2) and (3, 4, 5) are
+    created. If MeshType is a volume mesh, tetrahedra (0, 1, 2, 6) and
+    (3, 4, 5, 7) are created. The axis aligned boxes for both of those element
+    pairs will be the same.
+
+    We're not going to worry about the mesh having "too many" vertices for a
+    surface mesh; they won't affect the Bvh.
+
+    The goal is to create an Aabb Bvh which will have a single root node and
+    two leaf nodes (see the UpdateNode test below). The Bvh can be configured
+    to contain an *arbitrary* number of elements in the leaf nodes. To guarantee
+    the desired Bvh structure, we'll duplicate each element enough times to
+    produce two full leaf nodes (with identical elements).
+
+    @param dist  The distance from the origin to the "origin" of the elements
+                 (i.e., vertices 6 and 7).  */
+  static MeshType MakeMesh(double dist = 2) {
+    using T = typename MeshType::ScalarType;
+    using V = typename MeshType::template VertexType<T>;
+    using VI = typename MeshType::VertexIndex;
+    const Vector3<T> offset{dist, 0, 0};
+    // clang-format off
+    vector<V> vertices{
+        {V(Vector3<T>{0, -1, 0} + offset),
+         V(Vector3<T>{1, 0, 0} + offset),
+         V(Vector3<T>{0, 0, 1} + offset),
+         V(Vector3<T>{0, -1, 0} - offset),
+         V(Vector3<T>{-1, 0, 0} - offset),
+         V(Vector3<T>{0, 0, 1} - offset),
+         V(offset),
+         V(-offset)}};
+    // clang-format on
+    if constexpr (std::is_same_v<MeshType, SurfaceMesh<T>>) {
+      /* The winding of the triangles don't matter. */
+      vector<SurfaceFace> triangles;
+      for (int i = 0; i < MeshTraits<MeshType>::kMaxElementPerBvhLeaf; ++i) {
+        triangles.push_back(SurfaceFace(VI(0), VI(1), VI(2)));
+        triangles.push_back(SurfaceFace(VI(3), VI(4), VI(5)));
+      }
+      return MeshType(std::move(triangles), std::move(vertices));
+    } else {
+      /* We don't have to worry about whether the tet is "inside out" or not
+       (the 3D version of "winding"). */
+      vector<VolumeElement> tets;
+      for (int i = 0; i < MeshTraits<MeshType>::kMaxElementPerBvhLeaf; ++i) {
+        tets.emplace_back(VI(0), VI(1), VI(2), VI(6));
+        tets.emplace_back(VI(3), VI(4), VI(5), VI(7));
+      }
+      return MeshType(std::move(tets), std::move(vertices));
+    }
+  }
+};
+
+using MeshTypes = ::testing::Types<SurfaceMesh<double>, SurfaceMesh<AutoDiffXd>,
+                                   VolumeMesh<double>, VolumeMesh<AutoDiffXd>>;
+
+TYPED_TEST_SUITE(BvhUpdaterTest, MeshTypes);
+
+/* Tests construction logic for the combination of mesh type and scalar type.
+ Confirms direct and move constructors (copy constructors have been disabled).
+ */
+TYPED_TEST(BvhUpdaterTest, Construction) {
+  using MeshType = TypeParam;
+  const MeshType mesh = this->MakeMesh();
+  Bvh<Aabb, MeshType> bvh(mesh);
+  BvhUpdater<MeshType> updater(&mesh, &bvh);
+  EXPECT_EQ(&updater.mesh(), &mesh);
+  EXPECT_EQ(&updater.bvh(), &bvh);
+}
+
+/* Tests that the updater refits the bounding volumes as expected. Using the
+ mesh created by MakeMesh(), we can easily predict the expected bounding boxes.
+ We apply an arbitrary transformation to the vertices and confirm that the
+ bounding boxes change as expected. */
+TYPED_TEST(BvhUpdaterTest, Update) {
+  using MeshType = TypeParam;
+  using T = typename MeshType::ScalarType;
+
+  const double dist = 3;
+  MeshType mesh = this->MakeMesh(dist);
+  Bvh<Aabb, MeshType> bvh(mesh);
+  BvhUpdater<MeshType> updater(&mesh, &bvh);
+  MeshDeformer<MeshType> deformer(&mesh);
+
+  /* First, confirm the initial conditions:
+    - Topology of the BVH (a root with two leaves)
+    - Domains of the three bounding volumes */
+
+  /* Quick test of the topology */
+  const auto& root = bvh.root_node();
+  ASSERT_FALSE(root.is_leaf());
+  ASSERT_TRUE(root.left().is_leaf());
+  ASSERT_TRUE(root.right().is_leaf());
+
+  const auto& left = root.left();
+  const auto& right = root.right();
+
+  const Aabb expected_root_bv(Vector3d{0, -0.5, 0.5},
+                              Vector3d{dist + 1, 0.5, 0.5});
+  const Aabb expected_left_bv(Vector3d{-dist - 0.5, -0.5, 0.5},
+                              Vector3d{0.5, 0.5, 0.5});
+  const Aabb expected_right_bv(Vector3d{dist + 0.5, -0.5, 0.5},
+                               Vector3d{0.5, 0.5, 0.5});
+
+  /* Test the domains of the bounding boxes. */
+  ASSERT_TRUE(CompareMatrices(root.bv().center(), expected_root_bv.center()));
+  ASSERT_TRUE(
+      CompareMatrices(root.bv().half_width(), expected_root_bv.half_width()));
+
+  ASSERT_TRUE(CompareMatrices(left.bv().center(), expected_left_bv.center()));
+  ASSERT_TRUE(
+      CompareMatrices(left.bv().half_width(), expected_left_bv.half_width()));
+
+  ASSERT_TRUE(CompareMatrices(right.bv().center(), expected_right_bv.center()));
+  ASSERT_TRUE(
+      CompareMatrices(right.bv().half_width(), expected_right_bv.half_width()));
+
+  // TODO(SeanCurtis-TRI): Rather than limiting ourselves to this 90-degree
+  // rotation. We can construct a new BVH from a new mesh and compare the
+  // updated and freshly constructed bvhs.
+
+  /* Second, deform the mesh; we'll simply rotate all vertices 90 degrees. We
+   pick the 90-degree rotation to simplify the logic to know what BV to expect
+   at the end. A 90-degree rotation of the vertices essentially mean that the
+   bounding boxes will likewise be a 90-degree rotation. That won't be true for
+   just about any other angle. */
+  RotationMatrix<T> R = RotationMatrix<T>::MakeZRotation(M_PI / 2);
+
+  /* 3 doubles for each of M vertices */
+  VectorX<T> p_MVs(3 * mesh.num_vertices());
+  using VIndex = typename MeshType::VertexIndex;
+  for (VIndex i(0); i < mesh.num_vertices(); ++i) {
+    p_MVs.segment(i * 3, 3) << R * mesh.vertex(i).r_MV();
+  }
+  deformer.SetAllPositions(p_MVs);
+  updater.Update();
+
+  /* Third, compare the updated bounding volumes with the expected boxes. In
+   this case, they are a rotation of the original boxes.  The act of rotation
+   can introduce epsilon rounding error, so we test with respect to round-off
+   scaled tolerance. */
+  constexpr double kEps = std::numeric_limits<double>::epsilon();
+
+  EXPECT_TRUE(CompareMatrices(root.bv().center(),
+                              R * expected_root_bv.center().cast<T>(), kEps));
+  EXPECT_TRUE(CompareMatrices(
+      root.bv().half_width(),
+      (R * expected_root_bv.half_width().cast<T>()).cwiseAbs(), 2 * kEps));
+  EXPECT_TRUE(CompareMatrices(left.bv().center(),
+                              R * expected_left_bv.center().cast<T>(), kEps));
+  EXPECT_TRUE(CompareMatrices(
+      left.bv().half_width(),
+      (R * expected_left_bv.half_width().cast<T>()).cwiseAbs(), 2 * kEps));
+  EXPECT_TRUE(CompareMatrices(right.bv().center(),
+                              R * expected_right_bv.center().cast<T>(), kEps));
+  EXPECT_TRUE(CompareMatrices(
+      right.bv().half_width(),
+      (R * expected_right_bv.half_width().cast<T>()).cwiseAbs(), 2 * kEps));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
The `BvhUpdater` is a "modifier" for a `Bvh`. Given a mesh and its corresponding `Bvh`, it causes the `Bvh` to update given the current position of the mesh's vertices -- it assumes no topological changes.

This initial implementation is simple.
  - It only updates `Bvh`s built on `Aabb`.
  - It only refits bounding volumes -- it doesn't change the topology at all.

This also adds a `Bvh` and `BvhUpdater` to the `DeformableVolumeMesh`. This keeps the deformable mesh in sync.

(Incidentally cleans up some redundant semantics in the `MeshDeformer` - removing `set_mesh()` and documenting why it isn't necessary.)

Relates #15080
Closes #15170

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15221)
<!-- Reviewable:end -->
