### PR TITLE
Use row major Delassus operator in PGS solver

### DIFF
--- a/multibody/contact_solvers/pgs_solver.cc
+++ b/multibody/contact_solvers/pgs_solver.cc
@@ -26,7 +26,9 @@ ContactSolverStatus PgsSolver<T>::SolveWithGuess(
   const auto& v_star = pre_proc_data_.v_star;
   const auto& vc_star = pre_proc_data_.vc_star;
   const auto& Dinv = pre_proc_data_.Dinv;
-  const auto& W = pre_proc_data_.W;
+  // Use the Delassus operator in row major form for better locality in the
+  // Gauss-Seidel solve.
+  const auto& W = pre_proc_data_.W_row_major;
 
   // Aliases to solver's (mutable) state.
   auto& v = state_.mutable_v();
@@ -78,7 +80,7 @@ ContactSolverStatus PgsSolver<T>::SolveWithGuess(
       auto vci_kp = vc_kp.template segment<3>(i3);
       // Contribution from contact impulses 0, 1, ..., i-1.
       vci_kp += W.block(i3, 0, 3, i3) * gamma_kp.head(i3);
-      // Contribution from contact impulses i+1, i+2, ..., nc.
+      // Contribution from contact impulses i, i+1, i+2, ..., nc.
       vci_kp += W.block(i3, i3, 3, 3 * (nc - i)) * gamma.tail(3 * (nc - i));
       const auto& gammai = gamma.template segment<3>(i3);
       auto gammai_kp = gamma_kp.template segment<3>(i3);
@@ -118,6 +120,7 @@ ContactSolverStatus PgsSolver<T>::SolveWithGuess(
 template <typename T>
 void PgsSolver<T>::PreProcessedData::Resize(int nv, int nc) {
   W.resize(3 * nc, 3 * nc);
+  W_row_major.resize(3 * nc, 3 * nc);
   vc_star.resize(3 * nc);
   v_star.resize(nv);
   Wii_norm.resize(nc);
@@ -160,6 +163,7 @@ void PgsSolver<T>::PreProcessData(const SystemDynamicsData<T>& dynamics_data,
     this->FormDelassusOperatorMatrix(contact_data.get_Jc(),
                                      dynamics_data.get_Ainv(),
                                      contact_data.get_Jc(), &W);
+    pre_proc_data_.W_row_major = W;
 
     // Compute scaling factors, one per contact.
     auto& Wii_norm = pre_proc_data_.Wii_norm;

--- a/multibody/contact_solvers/pgs_solver.h
+++ b/multibody/contact_solvers/pgs_solver.h
@@ -17,7 +17,7 @@ struct PgsSolverParameters {
   // VerifyConvergenceCriteria().
   double rel_tolerance{1.0e-4};
   // Maximum number of PGS iterations.
-  int max_iterations{20};
+  int max_iterations{100};
 };
 
 struct PgsSolverStats {
@@ -92,6 +92,9 @@ class PgsSolver final : public ContactSolver<T> {
   struct PreProcessedData {
     // The Delassus operator.
     Eigen::SparseMatrix<T> W;
+    // The row major form of the Delassus operator used in the Gauss-Seidel
+    // iterations for better locality.
+    Eigen::SparseMatrix<T, Eigen::RowMajor> W_row_major;
     // The contact velocity solution to the problem when there is no contact.
     VectorX<T> vc_star;
     // The generalized velocities before the solve.

--- a/multibody/contact_solvers/pgs_solver.h
+++ b/multibody/contact_solvers/pgs_solver.h
@@ -92,9 +92,6 @@ class PgsSolver final : public ContactSolver<T> {
   struct PreProcessedData {
     // The Delassus operator.
     Eigen::SparseMatrix<T> W;
-    // The row major form of the Delassus operator used in the Gauss-Seidel
-    // iterations for better locality.
-    Eigen::SparseMatrix<T, Eigen::RowMajor> W_row_major;
     // The contact velocity solution to the problem when there is no contact.
     VectorX<T> vc_star;
     // The generalized velocities before the solve.


### PR DESCRIPTION
With the change in storage order, the average time spent on 100 PGS iterations for a sim with ~80 contact points reduces from ~1.3e-3 second to around ~1e-4 second, which is a ~13x improvement.

In addition, change the default number of iterations for PGS to 100.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15223)
<!-- Reviewable:end -->
