### PR TITLE
[geometry] Add core of new collision filter system

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -14,6 +14,7 @@ drake_cc_package_library(
     name = "geometry",
     visibility = ["//visibility:public"],
     deps = [
+        ":collision_filter_declaration",
         ":drake_visualizer",
         ":frame_kinematics",
         ":geometry_frame",
@@ -61,6 +62,16 @@ drake_cc_library(
         "@fcl",
         "@fmt",
         "@tinyobjloader",
+    ],
+)
+
+drake_cc_library(
+    name = "collision_filter_declaration",
+    srcs = ["collision_filter_declaration.cc"],
+    hdrs = ["collision_filter_declaration.h"],
+    deps = [
+        ":geometry_set",
+        "//common:essential",
     ],
 )
 
@@ -311,6 +322,14 @@ filegroup(
         "test/non_convex_mesh.obj",
         "test/quad_cube.mtl",
         "test/quad_cube.obj",
+    ],
+)
+
+drake_cc_googletest(
+    name = "collision_filter_declaration_test",
+    deps = [
+        ":collision_filter_declaration",
+        ":geometry_ids",
     ],
 )
 

--- a/geometry/collision_filter_declaration.cc
+++ b/geometry/collision_filter_declaration.cc
@@ -1,0 +1,1 @@
+#include "drake/geometry/collision_filter_declaration.h"

--- a/geometry/collision_filter_declaration.h
+++ b/geometry/collision_filter_declaration.h
@@ -1,0 +1,135 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/geometry/geometry_set.h"
+
+namespace drake {
+namespace geometry {
+
+#ifndef DRAKE_DOXYGEN_CXX
+// Forward declarations.
+namespace internal {
+class CollisionFilter;
+}  // namespace internal
+#endif
+
+/** Class for articulating changes to the configuration of SceneGraph's
+ "collision filters"; collision filters limit the scope of various proximity
+ queries.
+
+ A SceneGraph instance contains the set of geometry
+ `G = D ⋃ A = {g₀, g₁, ..., gₙ}`, where D is the set of dynamic geometries and
+ A is the set of anchored geometries (by definition `D ⋂ A = ∅`). `Gₚ ⊂ G` is
+ the subset of geometries that have a proximity role (with an analogous
+ interpretation of `Dₚ` and `Aₚ`). Many proximity queries operate on pairs of
+ geometries (e.g., (gᵢ, gⱼ)). The set of proximity candidate pairs for such
+ queries is initially defined as `C = (Gₚ × Gₚ) - (Aₚ × Aₚ) - Fₚ - Iₚ`, where:
+
+  - `Gₚ × Gₚ = {(gᵢ, gⱼ)}, ∀ gᵢ, gⱼ ∈ Gₚ` is the Cartesian product of the set
+    of SceneGraph proximity geometries.
+  - `Aₚ × Aₚ` represents all pairs consisting only of anchored geometries;
+    an anchored geometry is never tested against another anchored geometry.
+  - `Fₚ = {(gᵢ, gⱼ)} ∀ i, j`, such that `gᵢ, gⱼ ∈ Dₚ` and
+    `frame(gᵢ) == frame(gⱼ)`; the pairs where both geometries are rigidly
+    affixed to the same frame.
+  - `Iₚ = {(g, g)}, ∀ g ∈ Gₚ` is the set of all pairs consisting of a
+    geometry with itself; there is no meaningful proximity query on a
+    geometry with itself.
+
+ Only pairs contained in C will be included in pairwise proximity operations.
+
+ This class provides the basis for *declaring* what pairs should not be included
+ in the set C.
+
+ A declaration consists of zero or more *statements*. Each statement can
+ declare, for example, that the pair (g₁, g₂) should be excluded from C (also
+ known as "filtering the pair"). That statement is added to the declaration by
+ invoking the corresponding statement method (see below), and the result of the
+ invocation, is that the statement is appended to the declaration.
+
+ Each statement method returns a reference to the declaration instance, so a
+ number of statements can be chained together, i.e.,
+
+ ```
+ collision_filter_manager.Apply(
+   CollisionFilterDeclaration()
+       .ExcludeWithin(some_geometry_set)
+       .ExcludeBetween(set_A, set_B));
+ ```
+
+ It's worth noting, that the statements are evaluated in *invocation* order such
+ that a later statement can partially or completely undo the effect of an
+ earlier statement. */
+class CollisionFilterDeclaration {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CollisionFilterDeclaration)
+
+  CollisionFilterDeclaration() = default;
+
+  /** @name  Excluding pairs from consideration (adding collision filters)
+
+   These methods provide mechanisms which implicitly define a set of pairs and
+   subtracts each implied pair from the set C. The documentation of each method
+   explains the relationship between the input parameters and the set of implied
+   geometry pairs.
+
+   The *declared* pairs may be invalid (e.g., containing GeometryId values that
+   aren't part of the SceneGraph data). This will only be detected when applying
+   the declaration. */
+  //@{
+
+  /** Excludes geometry pairs from proximity evaluation by updating the
+   candidate pair set `C ← C - P`, where `P = {(a, b)}, ∀ a ∈ A, b ∈ B` and
+   `A = {a₀, a₁, ..., aₘ}` and `B = {b₀, b₁, ..., bₙ}` are the input sets of
+   geometries `set_A` and `set_B`, respectively. */
+  CollisionFilterDeclaration& ExcludeBetween(GeometrySet set_A,
+                                             GeometrySet set_B) {
+    statements_.emplace_back(kExcludeBetween, std::move(set_A),
+                             std::move(set_B));
+    return *this;
+  }
+
+  /** Excludes geometry pairs from proximity evaluation by updating the
+   candidate pair set `C ← C - P`, where `P = {(gᵢ, gⱼ)}, ∀ gᵢ, gⱼ ∈ G` and
+   `G = {g₀, g₁, ..., gₘ}` is the input `geometry_set` of geometries. */
+  CollisionFilterDeclaration& ExcludeWithin(GeometrySet geometry_set) {
+    statements_.emplace_back(kExcludeWithin, std::move(geometry_set),
+                             GeometrySet{});
+    return *this;
+  }
+
+  //@}
+
+ private:
+  friend class CollisionFilterDeclTester;
+  friend class internal::CollisionFilter;
+
+  // The various kinds of statements that can be made.
+  enum StatementOp {
+    kExcludeBetween,
+    kExcludeWithin
+  };
+
+  // The record of a single statement.
+  struct Statement {
+    Statement(StatementOp op_in, GeometrySet A_in, GeometrySet B_in) :
+      operation(op_in), set_A(std::move(A_in)), set_B(std::move(B_in)) {}
+    StatementOp operation;
+    GeometrySet set_A;
+    GeometrySet set_B;  // May be unused for unary statements.
+  };
+
+  // Although we've given CollisionFilter friend access, rather than have it
+  // access statements_ directly, we'll provide an API that will better insulate
+  // it from the declaration implementation.
+  const std::vector<Statement>& statements() const { return statements_; }
+
+  // The sequence of statements in this declaration.
+  std::vector<Statement> statements_;
+};
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -16,6 +16,7 @@ drake_cc_package_library(
     deps = [
         ":bv",
         ":bvh",
+        ":collision_filter",
         ":collision_filter_legacy",
         ":collisions_exist_callback",
         ":contact_surface_utility",
@@ -92,6 +93,18 @@ drake_cc_library(
         "//geometry:shape_specification",
         "//geometry:utilities",
         "//math:geometric_transform",
+    ],
+)
+
+drake_cc_library(
+    name = "collision_filter",
+    srcs = ["collision_filter.cc"],
+    hdrs = ["collision_filter.h"],
+    deps = [
+        "//common:essential",
+        "//common:unused",
+        "//geometry:collision_filter_declaration",
+        "//geometry:geometry_ids",
     ],
 )
 
@@ -663,6 +676,13 @@ drake_cc_googletest(
     name = "collisions_exist_callback_test",
     deps = [
         ":collisions_exist_callback",
+    ],
+)
+
+drake_cc_googletest(
+    name = "collision_filter_test",
+    deps = [
+        ":collision_filter",
     ],
 )
 

--- a/geometry/proximity/collision_filter.cc
+++ b/geometry/proximity/collision_filter.cc
@@ -1,0 +1,111 @@
+#include "drake/geometry/proximity/collision_filter.h"
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/unused.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+using std::unordered_set;
+
+void CollisionFilter::Apply(const CollisionFilterDeclaration& declaration,
+                            const CollisionFilter::ExtractIds& extract_ids) {
+  using Operation = CollisionFilterDeclaration::StatementOp;
+  for (const auto& statement : declaration.statements()) {
+    switch (statement.operation) {
+      case Operation::kExcludeWithin:
+        AddFiltersBetween(statement.set_A, statement.set_A, extract_ids);
+        break;
+      case Operation::kExcludeBetween:
+        AddFiltersBetween(statement.set_A, statement.set_B, extract_ids);
+        break;
+    }
+  }
+}
+
+void CollisionFilter::AddGeometry(GeometryId new_id) {
+  DRAKE_DEMAND(filter_state_.count(new_id) == 0);
+  GeometryMap& new_map = filter_state_[new_id] = {};
+  for (auto& [other_id, other_map] : filter_state_) {
+    /* Whichever id is *smaller* tracks the relationship with the other.
+     That relationship defaults to unfiltered (i.e., "can collide").
+
+     Note: we're iterating over filter_state_ and assigning to either new_map
+     or other_map. This doesn't invalidate the implicit iterator of the range
+     operator. We never change the *keys* of filter_state_ in this loop, only
+     its values. And we don't do any iteration in the new_map or other_map
+     so don't depend on their iterators. */
+    if (other_id < new_id) {
+      other_map[new_id] = kUnfiltered;
+    } else {
+      new_map[other_id] = kUnfiltered;
+    }
+  }
+}
+
+void CollisionFilter::RemoveGeometry(GeometryId remove_id) {
+  DRAKE_DEMAND(filter_state_.count(remove_id) == 1);
+  filter_state_.erase(remove_id);
+  for (auto& [other_id, other_map] : filter_state_) {
+    /* remove_id will only be found in maps belonging to geometries with ids
+     that are smaller than remove_id. Those that are larger were deleted when we
+     removed remove_id's entry. */
+    if (other_id < remove_id) {
+      other_map.erase(remove_id);
+    }
+  }
+}
+
+bool CollisionFilter::CanCollideWith(GeometryId id_A, GeometryId id_B) const {
+  if (id_A == id_B) return false;
+  if (id_A < id_B) {
+    return filter_state_.at(id_A).at(id_B) == kUnfiltered;
+  } else {
+    return filter_state_.at(id_B).at(id_A) == kUnfiltered;
+  }
+}
+
+void CollisionFilter::AddFiltersBetween(
+    const GeometrySet& set_A, const GeometrySet& set_B,
+    const CollisionFilter::ExtractIds& extract_ids) {
+  const unordered_set<GeometryId> ids_A = extract_ids(set_A);
+  const unordered_set<GeometryId>& ids_B =
+      &set_A == &set_B ? ids_A : extract_ids(set_B);
+  for (GeometryId id_A : ids_A) {
+    for (GeometryId id_B : ids_B) {
+      AddFilteredPair(id_A, id_B);
+    }
+  }
+}
+
+void CollisionFilter::AddFilteredPair(GeometryId id_A, GeometryId id_B) {
+  DRAKE_DEMAND(filter_state_.count(id_A) == 1 &&
+               filter_state_.count(id_B) == 1);
+
+  if (id_A == id_B) return;
+  PairFilterState& pair_state =
+      id_A < id_B ? filter_state_[id_A][id_B] : filter_state_[id_B][id_A];
+  pair_state = kFiltered;
+}
+
+bool CollisionFilter::operator==(const CollisionFilter& other) const {
+  if (this == &other) return true;
+  if (filter_state_.size() != other.filter_state_.size()) return false;
+  for (const auto& [this_id, this_map] : filter_state_) {
+    if (!other.HasGeometry(this_id)) return false;
+    for (const auto& [this_pair_id, can_collide] : this_map) {
+      unused(can_collide);
+      if (!other.HasGeometry(this_pair_id)) return false;
+      if (CanCollideWith(this_id, this_pair_id) !=
+          other.CanCollideWith(this_id, this_pair_id)) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/collision_filter.h
+++ b/geometry/proximity/collision_filter.h
@@ -1,0 +1,133 @@
+#pragma once
+
+#include <functional>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "drake/geometry/collision_filter_declaration.h"
+#include "drake/geometry/geometry_ids.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+/* Implementation of a collision filter policy. Collision filters operate on
+ pairs of geometries. A pair is either filtered or not. Most proximity queries
+ rely on the collision filter policy to determine if they should compute results
+ for a given geometry pair. Filtered pairs do not contribute to the results.
+
+ Geometries are identified by their geometry ids. The filter status of the
+ geometry pair (g, h) can only be modified if both g and h have already been
+ added to this filter system (via AddGeometry()). */
+class CollisionFilter {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CollisionFilter)
+
+  CollisionFilter() = default;
+
+  /* The callback function type for resolving a GeometrySet in a declaration
+   into an explicitly enumerated set of GeometryIds. All ids in the resultant
+   set must have previously been added to this filter system.
+
+   This callback should throw if the GeometrySet contains FrameId values that
+   cannot be mapped to GeometryIds. */
+  using ExtractIds =
+      std::function<std::unordered_set<GeometryId>(const GeometrySet&)>;
+
+  /* Applies the collision filter declaration. The callback `extract_ids`
+   provides a means to convert the GeometrySet into an explicit, unique set of
+   GeometryIds for each GeometrySet defined in the given `declaration`.
+
+   @param declaration       The declaration to apply.
+   @param extract_ids       A callback to convert a GeometrySet into the
+                            explicit set of geometry ids.
+   @throws std::exception if any GeometryId referenced by the declaration has
+                          not previously been added to `this` filter system. */
+  void Apply(const CollisionFilterDeclaration& declaration,
+             const ExtractIds& extract_ids);
+
+  /* Adds a geometry to the filter system. When added, it will not be part of
+   any filtered pairs.
+   @pre `new_id` has not been previously added to this filter system. */
+  void AddGeometry(GeometryId new_id);
+
+  /* Removes a geometry from the filter system. All filtered collision pairs
+   including `remove_id` will be removed.
+   @pre `remove_id` is part of this filter system. */
+  void RemoveGeometry(GeometryId remove_id);
+
+  /* Reports true if the geometry pair (`id_A`, `id_B`) is considered to be
+   unfiltered.
+   @pre `id_A` and `id_B` are both part of this filter system. */
+  bool CanCollideWith(GeometryId id_A, GeometryId id_B) const;
+
+  /* Reports if two collision filters are configured the same. They are
+   considered the same if the two filter systems report the same results for
+   all calls to `CanCollideWith()`. This implies they have the same geometries
+   registered, and equivalent filter state for each pair. */
+  bool operator==(const CollisionFilter& other) const;
+
+  /* Reports if two collision filters are configured differently.  See
+   operator==() for what this means. */
+  bool operator!=(const CollisionFilter& other) const {
+    return !(*this == other);
+  }
+
+  /* Reports if the given `id` has been added to this filter system. */
+  bool HasGeometry(GeometryId id) const { return filter_state_.count(id) > 0; }
+
+ private:
+  /* The collision filter state between a pair of geometries. */
+  enum PairFilterState {
+    kUnfiltered,      // No filter has been declared.
+    kFiltered         // A filter has been declared.
+  };
+
+  /* The "filter state" is a 2d table. For N registered geometries, it is
+   an NxN table where cell (i, j) reports the filter status of the ith and jth
+   geometries (although i and j are actually GeometryIds).
+
+   Because a pair's filter status is symmetric (e.g., (a, b) and (b, a) are
+   equivalent), we only encode a triangular portion of the table. We have two
+   types that work together to define the table: GeometryMap and FilterState.
+
+   FilterState maps a GeometryId to the filter relationship with all other
+   registered geometries with *greater* GeometryId values. That set of
+   geometries is contained in a GeometryMap, where each entry on that "row"
+   is the key-value pair (other_id, filter_pair_state).
+
+   So, given a FilterState instance (filter_state) and two GeometryIds, a and b,
+   we could set the filtered state as (assuming a < b):
+
+      filter_state[a][b] = kFiltered;
+
+   As a concrete example, if we've registered GeometryId values 10, 20, 30, 40,
+   the filter state would have keys {10, 20, 30, 40} which each maps to a
+   corresponding GeometryMap as illustrated below.
+     10 -> {(20, PairFilterState), (30, PairFilterState), (40, PairFilterState)}
+     20 -> {(30, PairFilterState), (40, PairFilterState)}
+     30 -> {(40, PairFilterState)}
+     40 -> {} */
+  using GeometryMap = std::unordered_map<GeometryId, PairFilterState>;
+
+  using FilterState = std::unordered_map<GeometryId, GeometryMap>;
+
+  /* Declares pairs (`id_A`, `id_B`) `∀ id_A ∈ set_A, id_B ∈ set_B` to be
+   filtered. For each pair, if they are already filtered, no discernible change
+   is made.
+
+   @pre All ids in `id_A` and `id_B` are part of the system. */
+  void AddFiltersBetween(const GeometrySet& set_A, const GeometrySet& set_B,
+                         const ExtractIds& extract_ids);
+
+  /* Atomic operation in support of AddFiltersBetween(). */
+  void AddFilteredPair(GeometryId id_A, GeometryId id_B);
+
+  /* The filter state of all pairs of geometry. */
+  FilterState filter_state_;
+};
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/proximity/test/collision_filter_test.cc
+++ b/geometry/proximity/test/collision_filter_test.cc
@@ -1,0 +1,213 @@
+#include "drake/geometry/proximity/collision_filter.h"
+
+#include <tuple>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace geometry {
+
+/* Use GeometrySetTester's friend status with GeometrySet to leak its geometry
+ ids to support the tests below. */
+class GeometrySetTester {
+ public:
+  static std::unordered_set<GeometryId> geometries(const GeometrySet& s) {
+    return s.geometries();
+  }
+};
+
+namespace internal {
+
+using std::vector;
+
+constexpr bool kCanCollide = true;
+/* Helper function to test the invariance of CollisionFilter::CanCollideWith()
+ to the geometry id order. */
+::testing::AssertionResult ExpectCanCollide(const CollisionFilter& filter,
+                                            GeometryId id_A, GeometryId id_B,
+                                            bool expect_collidable) {
+  const bool result1 = filter.CanCollideWith(id_A, id_B);
+  const bool result2 = filter.CanCollideWith(id_B, id_A);
+  if (result1 != result2) {
+    return ::testing::AssertionFailure()
+           << "The collision filter state for " << id_A << " and " << id_B
+           << " changed based on ordering";
+  }
+  if (result1 != expect_collidable) {
+    return ::testing::AssertionFailure()
+           << "For pair (" << id_A << ", " << id_B
+           << "), our expectation for can-collide was " << expect_collidable
+           << ", but the filter reported " << result1;
+  }
+  return ::testing::AssertionSuccess();
+}
+
+/* For all of these tests, we use GeometrySets that only consist of GeometryIds.
+ This way we don't need a *real* implementation of CollisionFilter::ExtractIds.
+ For our purposes, it's simply a case of extracting the geometries. In the real
+ world, we'd receive a different callback and we rely on unit tests of that
+ callback to be tested elsewhere.  */
+class CollisionFilterTest : public ::testing::Test {
+ protected:
+  /* Populate the given `filter` with three ids, and then return the ids. */
+  static std::tuple<GeometryId, GeometryId, GeometryId> InitIds(
+      CollisionFilter* filter) {
+    vector<GeometryId> ids{GeometryId::get_new_id(), GeometryId::get_new_id(),
+                           GeometryId::get_new_id()};
+    for (auto id : ids) {
+      filter->AddGeometry(id);
+      EXPECT_TRUE(filter->HasGeometry(id));
+    }
+    return std::make_tuple(ids[0], ids[1], ids[2]);
+  }
+
+  /* Apply collision filters between geometries in the list. */
+  static void FilterAllPairs(CollisionFilter* filter,
+                             std::initializer_list<GeometryId> ids) {
+    filter->Apply(CollisionFilterDeclaration().ExcludeWithin(GeometrySet(ids)),
+                  get_extract_ids_functor());
+
+    for (GeometryId id_A : ids) {
+      for (GeometryId id_B : ids) {
+        ASSERT_TRUE(ExpectCanCollide(*filter, id_A, id_B, !kCanCollide));
+      }
+    }
+  }
+
+  /* Returns a value for the collision filter id extraction functor. */
+  static CollisionFilter::ExtractIds get_extract_ids_functor() {
+    return &GeometrySetTester::geometries;
+  }
+};
+
+/* Tests that declaration statements that exclude collisions between geometries
+ in different sets are properly handled. */
+TEST_F(CollisionFilterTest, ExcludeBetween) {
+  CollisionFilter filters;
+  auto [id_A, id_B, id_C] = this->InitIds(&filters);
+
+  /* Initial condition: everything can collide. */
+  EXPECT_TRUE(ExpectCanCollide(filters, id_A, id_B, kCanCollide));
+  EXPECT_TRUE(ExpectCanCollide(filters, id_A, id_C, kCanCollide));
+  EXPECT_TRUE(ExpectCanCollide(filters, id_B, id_C, kCanCollide));
+
+  filters.Apply(CollisionFilterDeclaration().ExcludeBetween(
+                    GeometrySet(id_A), GeometrySet({id_B, id_C})),
+                this->get_extract_ids_functor());
+
+  EXPECT_TRUE(ExpectCanCollide(filters, id_A, id_B, !kCanCollide));
+  EXPECT_TRUE(ExpectCanCollide(filters, id_A, id_C, !kCanCollide));
+  EXPECT_TRUE(ExpectCanCollide(filters, id_B, id_C, kCanCollide));
+}
+
+/* Tests that declaration statements that exclude collisions between geometries
+ in a single set are properly handled. */
+TEST_F(CollisionFilterTest, ExcludeWithin) {
+  CollisionFilter filters;
+  auto [id_A, id_B, id_C] = this->InitIds(&filters);
+  const GeometryId id_D = GeometryId::get_new_id();
+  filters.AddGeometry(id_D);
+
+  /* Initial condition: everything can collide. */
+  EXPECT_TRUE(ExpectCanCollide(filters, id_A, id_B, kCanCollide));
+  EXPECT_TRUE(ExpectCanCollide(filters, id_A, id_C, kCanCollide));
+  EXPECT_TRUE(ExpectCanCollide(filters, id_A, id_D, kCanCollide));
+  EXPECT_TRUE(ExpectCanCollide(filters, id_B, id_C, kCanCollide));
+  EXPECT_TRUE(ExpectCanCollide(filters, id_B, id_D, kCanCollide));
+  EXPECT_TRUE(ExpectCanCollide(filters, id_C, id_D, kCanCollide));
+
+  filters.Apply(CollisionFilterDeclaration()
+                    .ExcludeWithin(GeometrySet({id_A, id_B, id_D}))
+                    .ExcludeWithin(GeometrySet({id_A, id_C})),
+                this->get_extract_ids_functor());
+
+  EXPECT_TRUE(ExpectCanCollide(filters, id_A, id_B, !kCanCollide));
+  EXPECT_TRUE(ExpectCanCollide(filters, id_A, id_C, !kCanCollide));
+  EXPECT_TRUE(ExpectCanCollide(filters, id_A, id_D, !kCanCollide));
+  EXPECT_TRUE(ExpectCanCollide(filters, id_B, id_C, kCanCollide));
+  EXPECT_TRUE(ExpectCanCollide(filters, id_B, id_D, !kCanCollide));
+  EXPECT_TRUE(ExpectCanCollide(filters, id_C, id_D, kCanCollide));
+}
+
+/* Simply confirms that regardless of efforts, a geometry will never report that
+ it can collide with itself. */
+TEST_F(CollisionFilterTest, NoSelfCollision) {
+  CollisionFilter filters;
+  auto [id_A, id_B, id_C] = this->InitIds(&filters);
+
+  /* Initial condition: no self collision. */
+  EXPECT_FALSE(filters.CanCollideWith(id_A, id_A));
+  EXPECT_FALSE(filters.CanCollideWith(id_B, id_B));
+  EXPECT_FALSE(filters.CanCollideWith(id_C, id_C));
+
+  // TODO(SeanCurtis-TRI): When we add filter *removal* confirm that attempts to
+  // add pair (A, A) back into candidate set C doesn't work.
+}
+
+/* In this test, we're confirming the logic of operator== and operator!=. As
+ such, we explicitly call those operators so we don't rely on gtest's
+ implementation details. */
+TEST_F(CollisionFilterTest, Equality) {
+  const GeometryId id_A = GeometryId::get_new_id();
+  const GeometryId id_B = GeometryId::get_new_id();
+  const GeometryId id_C = GeometryId::get_new_id();
+
+  CollisionFilter filters1;
+  CollisionFilter filters2;
+
+  /* Filters with no registered geometries are equal. */
+  EXPECT_EQ(filters1, filters2);
+
+  /* Filters with different registered geometries are unequal. */
+  /* Disjoint sets of geometries. */
+  filters1.AddGeometry(id_A);
+  filters2.AddGeometry(id_B);
+  EXPECT_FALSE(filters1 == filters2);
+  EXPECT_TRUE(filters1 != filters2);
+  /* Sets have non-zero intersection, but are still not equal. */
+  filters1.AddGeometry(id_C);
+  filters2.AddGeometry(id_C);
+  EXPECT_FALSE(filters1 == filters2);
+  EXPECT_TRUE(filters1 != filters2);
+  /* Sets have equal, non-empty sets of registered geometry and *no* filters. */
+  filters1.AddGeometry(id_B);
+  filters2.AddGeometry(id_A);
+  EXPECT_TRUE(filters1 == filters2);
+  EXPECT_FALSE(filters1 != filters2);
+
+  /* Various forms of matched/mismatched filters. The correctness of this test
+   depends on the order; do not re-order these operations. */
+  filters1.Apply(
+      CollisionFilterDeclaration().ExcludeWithin(GeometrySet({id_A, id_B})),
+      this->get_extract_ids_functor());
+  EXPECT_FALSE(filters1 == filters2);
+  EXPECT_TRUE(filters1 != filters2);
+  filters2.Apply(
+      CollisionFilterDeclaration().ExcludeWithin(GeometrySet({id_A, id_B})),
+      this->get_extract_ids_functor());
+  EXPECT_TRUE(filters1 == filters2);
+  EXPECT_FALSE(filters1 != filters2);
+  filters1.Apply(
+      CollisionFilterDeclaration().ExcludeWithin(GeometrySet({id_A, id_C})),
+      this->get_extract_ids_functor());
+  EXPECT_FALSE(filters1 == filters2);
+  EXPECT_TRUE(filters1 != filters2);
+  filters2.Apply(
+      CollisionFilterDeclaration().ExcludeWithin(GeometrySet({id_B, id_C})),
+      this->get_extract_ids_functor());
+  EXPECT_FALSE(filters1 == filters2);
+  EXPECT_TRUE(filters1 != filters2);
+  filters1.Apply(
+      CollisionFilterDeclaration().ExcludeWithin(GeometrySet({id_B, id_C})),
+      this->get_extract_ids_functor());
+  filters2.Apply(
+      CollisionFilterDeclaration().ExcludeWithin(GeometrySet({id_A, id_C})),
+      this->get_extract_ids_functor());
+  EXPECT_TRUE(filters1 == filters2);
+  EXPECT_FALSE(filters1 != filters2);
+}
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/test/collision_filter_declaration_test.cc
+++ b/geometry/test/collision_filter_declaration_test.cc
@@ -1,0 +1,142 @@
+#include "drake/geometry/collision_filter_declaration.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/geometry/geometry_ids.h"
+
+namespace drake {
+namespace geometry {
+
+using std::vector;
+
+class CollisionFilterDeclTester {
+ public:
+  using Statement = CollisionFilterDeclaration::Statement;
+  using StatementOp = CollisionFilterDeclaration::StatementOp;
+
+  static const vector<Statement>& statements(
+      const CollisionFilterDeclaration& decl) {
+    return decl.statements();
+  }
+};
+
+class GeometrySetTester {
+ public:
+  static bool AreEqual(const GeometrySet& set_A, const GeometrySet& set_B) {
+    return set_A.geometry_ids_ == set_B.geometry_ids_ &&
+           set_A.frame_ids_ == set_B.frame_ids_;
+  }
+};
+
+namespace {
+
+using Tester = CollisionFilterDeclTester;
+
+GTEST_TEST(CollisionFilterDeclTest, DefaultConstructor) {
+  CollisionFilterDeclaration decl;
+  EXPECT_EQ(Tester::statements(decl).size(), 0);
+}
+
+// Confirms that the parameters of the ExcludeBetween method are properly
+// encoded in the last statement.
+GTEST_TEST(CollisionFilterDeclTest, ExcludeBetween) {
+  const GeometrySet set_A({GeometryId::get_new_id(), GeometryId::get_new_id()});
+  const GeometrySet set_B({FrameId::get_new_id(), FrameId::get_new_id()});
+
+  CollisionFilterDeclaration decl;
+  decl.ExcludeBetween(set_A, set_B);
+
+  const auto& statements = Tester::statements(decl);
+  EXPECT_EQ(statements.size(), 1);
+  EXPECT_EQ(statements[0].operation, Tester::StatementOp::kExcludeBetween);
+  EXPECT_TRUE(GeometrySetTester::AreEqual(statements[0].set_A, set_A));
+  EXPECT_TRUE(GeometrySetTester::AreEqual(statements[0].set_B, set_B));
+}
+
+// Confirms that the parameters of the ExcludeWithin method are properly encoded
+// in the last statement.
+GTEST_TEST(CollisionFilterDeclTest, ExcludeWithin) {
+  const GeometrySet set_1({GeometryId::get_new_id(), GeometryId::get_new_id()});
+  const GeometrySet set_2({FrameId::get_new_id(), FrameId::get_new_id()});
+
+  for (const auto& geo_set : {set_1, set_2}) {
+    CollisionFilterDeclaration decl;
+    decl.ExcludeWithin(geo_set);
+
+    const auto& statements = Tester::statements(decl);
+    EXPECT_EQ(statements.size(), 1);
+    EXPECT_EQ(statements[0].operation, Tester::StatementOp::kExcludeWithin);
+    EXPECT_TRUE(GeometrySetTester::AreEqual(statements[0].set_A, geo_set));
+    EXPECT_TRUE(
+        GeometrySetTester::AreEqual(statements[0].set_B, GeometrySet()));
+  }
+}
+
+// A simple test that confirms the *mechanism* for chaining; each statement
+// method returns a pointer to itself. This method should exercise *every*
+// statement method; as they get added to the class, they should be added here.
+GTEST_TEST(CollisionFilterDeclTest, ChainingStatements) {
+  const GeometrySet set_A({GeometryId::get_new_id(), GeometryId::get_new_id()});
+  CollisionFilterDeclaration decl;
+  EXPECT_EQ(&decl.ExcludeBetween(set_A, set_A), &decl);
+  EXPECT_EQ(&decl.ExcludeWithin(set_A), &decl);
+}
+
+// Confirms that the order of the statements given is preserved. We'll confirm
+// that each statement method appends the expected data to the sequence of
+// statements, leaving the previous statements untouched.
+GTEST_TEST(CollisionFilterDeclTest, StatementOrder) {
+  const GeometrySet set_1({GeometryId::get_new_id(), GeometryId::get_new_id()});
+  const GeometrySet set_2({GeometryId::get_new_id(), GeometryId::get_new_id()});
+
+  CollisionFilterDeclaration decl_original;
+  decl_original.ExcludeWithin(set_1);
+  // Validates the configuration of the *first* statement. It has the prereq
+  // that the declaration contains at least one statement.
+  auto validate_base = [&set_1](const CollisionFilterDeclaration& declaration) {
+    const auto& s = Tester::statements(declaration)[0];
+    EXPECT_EQ(s.operation, Tester::StatementOp::kExcludeWithin);
+    EXPECT_TRUE(GeometrySetTester::AreEqual(s.set_A, set_1));
+    EXPECT_TRUE(GeometrySetTester::AreEqual(s.set_B, GeometrySet{}));
+  };
+
+  // Confirm that the baseline declaration has the expected statement.
+  EXPECT_GE(Tester::statements(decl_original).size(), 1);
+  validate_base(decl_original);
+
+  // Confirm that there's a second statement, and its parameters are the given
+  // set of expectations (and the base statement is unchanged).
+  auto validate = [&validate_base](
+                      const Tester::Statement expected,
+                      const CollisionFilterDeclaration& declaration) {
+    validate_base(declaration);
+    const auto& statements = Tester::statements(declaration);
+    EXPECT_EQ(statements.size(), 2);
+    validate_base(declaration);
+    const auto& s = statements[1];
+    EXPECT_EQ(s.operation, expected.operation);
+    EXPECT_TRUE(GeometrySetTester::AreEqual(s.set_A, expected.set_A));
+    EXPECT_TRUE(GeometrySetTester::AreEqual(s.set_B, expected.set_B));
+  };
+
+  // Exercise each of the statement methods and confirm that it is appended to
+  // the end.
+
+  {
+    CollisionFilterDeclaration decl(decl_original);
+    decl.ExcludeBetween(set_2, set_1);
+    SCOPED_TRACE("ExcludeBetween");
+    validate({Tester::StatementOp::kExcludeBetween, set_2, set_1}, decl);
+  }
+
+  {
+    CollisionFilterDeclaration decl(decl_original);
+    decl.ExcludeWithin(set_2);
+    SCOPED_TRACE("ExcludeWithin");
+    validate({Tester::StatementOp::kExcludeWithin, set_2, GeometrySet()}, decl);
+  }
+}
+
+}  // namespace
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
The new collision filter differs in two ways:

1. The underlying implementation `CollisionFilter` is, essentially, an N^2 table (for a `SceneGraph` with N proximity geometries).
   - Each geometry pair is explicitly enumerated with its filtered state.
   - `CollisionFilterLegacy` made removing filters nearly impossible (it would consist of refactoring cliques.) This new representation allows for far simpler modifications. And, particularly, temporary modifications.
2. The state of the filters is modified via: `CollisionFilterDeclarations`.
   - It is comprised of one or more *statements* (e.g., exclude between *these* pairs. Allow between *those* pairs, etc.) The collision filter evaluates a declaration and makes the corresponding modifications.
   - One of the key aspects of this is that the declarations are expressed in terms of `GeometrySet`. `GeometrySet` can contain `FrameId`s (as a short-hand reference to all geometries rigidly affixed to the id'd Frame). `CollisionFilter` doesn't have the knowledge to map `FrameId` to the set of `GeometryId`s. It relies on a the caller to provide a callback.

Relates #15089.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15228)
<!-- Reviewable:end -->
