### PR TITLE
[geometry] Support point-to-ellipsoid results in ComputeSignedDistanceToPoint query.

### DIFF
--- a/geometry/proximity/distance_to_point_callback.h
+++ b/geometry/proximity/distance_to_point_callback.h
@@ -155,20 +155,20 @@ class DistanceToPoint {
   // TODO(DamrongGuoy): Revisit computation over operator() overloads as per
   //  issue: https://github.com/RobotLocomotion/drake/issues/11227
 
-  /* Overload to compute distance to a sphere.  */
-  SignedDistanceToPoint<T> operator()(const fcl::Sphered& sphere);
-
-  /* Overload to compute distance to a halfspace.  */
-  SignedDistanceToPoint<T> operator()(const fcl::Halfspaced& halfspace);
+  /* Overload to compute distance to a box.  */
+  SignedDistanceToPoint<T> operator()(const fcl::Boxd& box);
 
   /* Overload to compute distance to a capsule.  */
   SignedDistanceToPoint<T> operator()(const fcl::Capsuled& capsule);
 
-  /* Overload to compute distance to a box.  */
-  SignedDistanceToPoint<T> operator()(const fcl::Boxd& box);
-
   /* Overload to compute distance to a cylinder.  */
   SignedDistanceToPoint<T> operator()(const fcl::Cylinderd& cylinder);
+
+  /* Overload to compute distance to a halfspace.  */
+  SignedDistanceToPoint<T> operator()(const fcl::Halfspaced& halfspace);
+
+  /* Overload to compute distance to a sphere.  */
+  SignedDistanceToPoint<T> operator()(const fcl::Sphered& sphere);
 
   /* Reports the "sign" of x with a small modification; Sign(0) --> 1.
    @tparam U  Templated to allow DistanceToPoint<AutoDiffXd> to still compute

--- a/geometry/proximity/distance_to_point_callback.h
+++ b/geometry/proximity/distance_to_point_callback.h
@@ -164,6 +164,9 @@ class DistanceToPoint {
   /* Overload to compute distance to a cylinder.  */
   SignedDistanceToPoint<T> operator()(const fcl::Cylinderd& cylinder);
 
+  /* Overload to compute distance to an ellipsoid.  */
+  SignedDistanceToPoint<T> operator()(const fcl::Ellipsoidd& ellipsoid);
+
   /* Overload to compute distance to a halfspace.  */
   SignedDistanceToPoint<T> operator()(const fcl::Halfspaced& halfspace);
 

--- a/geometry/proximity/test/distance_to_point_callback_test.cc
+++ b/geometry/proximity/test/distance_to_point_callback_test.cc
@@ -321,6 +321,90 @@ GTEST_TEST(DistanceToPoint, Capsule) {
   }
 }
 
+// Test the evaluation of signed distance to Ellipsoid. This explicitly spells
+// out a double-valued test because AutoDiffXd is not yet supported. We hand
+// construct a few points (and corresponding normals) on the surface of the
+// ellipsoid and construct query points relative to those surface points.
+// The surface points should report as the witness point, the normal is the
+// gradient, etc.
+//
+// For each sample, we try a different distance and confirm all the fields of
+// the returned type.
+GTEST_TEST(DistanceToPoint, Ellipsoid) {
+  // Provide some arbitrary pose of the ellipsoid G in the world.
+  // const RotationMatrix<double> R_WG(
+  //     AngleAxis<double>(M_PI / 5, Vector3d{1, 2, 3}.normalized()));
+  // const Vector3d p_WG{0.5, 1.25, -2};
+  // const RigidTransform<double> X_WG(R_WG, p_WG);
+  const RigidTransform<double> X_WG;
+  // Note: the more eccentric the ellipsoid becomes (with higher curvature), the
+  // more error there will be near the regions with high curvature. This is
+  // because we're using GJK/EPA to compute distance. So, to avoid highly
+  // variable error across the point samples, we'll keep the ellipsoid "close"
+  // to a sphere. If we stretch it out, we need either a) a larger tolerance
+  // value for the vectors or b) a per-sample tolerance values.
+  const fcl::Ellipsoidd ellipsoid(1.5, 0.75, 1.25);
+
+  // TODO(SeanCurtis-TRI): When point-to-ellipsoid supports AutoDiffXd, modify
+  //  this to exercise PointShapeAutoDiffSignedDistanceTester.
+
+  auto get_sample = [&ellipsoid](double theta, double phi) {
+    // Compute a point on the surface of the ellipsoid and the normal at
+    // that point. For the point, we use the parametric equation of the
+    // ellipsoid (on two periodic parameters):
+    //    E = [a⋅cos(θ)⋅sin(ϕ), b⋅sin(θ)⋅sin(ϕ), c⋅cos(ϕ)].
+    // For the normal, we normalize the gradient of
+    //    f = x² / a² + y² / b² + z² / c²
+    //    ∇f = <2x / a², 2y / b², 2z / c²>
+    //    n = ∇f / |∇f|
+    const double a = ellipsoid.radii.x();
+    const double b = ellipsoid.radii.y();
+    const double c = ellipsoid.radii.z();
+    const double x = a * std::cos(theta) * std::sin(phi);
+    const double y = b * std::sin(theta) * std::sin(phi);
+    const double z = c * std::cos(phi);
+    // Because we're normalizing the gradient, we simply omit the redundant
+    // scale factor of 2.
+    return std::make_pair(
+        Vector3d{x, y, z},
+        Vector3d{x / a / a, y / b / b, z / c / c}.normalized());
+  };
+
+  struct EllipseCoord {
+    double theta{};
+    double phi{};
+  };
+
+  std::vector<EllipseCoord> coords{
+      EllipseCoord{0, 0},                       // Bottom pole.
+      EllipseCoord{7 * M_PI / 5, M_PI / 6},     // Lower half.
+      EllipseCoord{3 * M_PI / 7, 4 * M_PI / 5}  // Upper half.
+  };
+
+  constexpr double kDistTolerance = 5e-5;
+  constexpr double kVectorTolerance = 5e-4;
+  const GeometryId id = GeometryId::get_new_id();
+
+  for (const auto& coord : coords) {
+    const auto& [p_GN, n_G] = get_sample(coord.theta, coord.phi);
+    for (const double distance : {-0.125, 0.0, 0.2}) {
+      const Vector3d p_GQ = p_GN + n_G * distance;
+      const Vector3d p_WQ = X_WG * p_GQ;
+      DistanceToPoint<double> distance_to_point(id, X_WG, p_WQ);
+      const SignedDistanceToPoint<double> result = distance_to_point(ellipsoid);
+
+      SCOPED_TRACE(fmt::format(
+          "theta = {}, phi = {}, distance = {}\n  p_GQ: {} {} {}", coord.theta,
+          coord.phi, distance, p_GQ.x(), p_GQ.y(), p_GQ.z()));
+      EXPECT_EQ(result.id_G, id);
+      EXPECT_NEAR(result.distance, distance, kDistTolerance);
+      EXPECT_TRUE(CompareMatrices(result.p_GN, p_GN, kVectorTolerance));
+      EXPECT_TRUE(CompareMatrices(result.grad_W, X_WG.rotation() * n_G,
+                                  kVectorTolerance));
+    }
+  }
+}
+
 // Simple smoke test for signed distance to Halfspace. It does the following:
 //   Perform test of three different points w.r.t. a halfspace: outside, on
 //     surface, and inside.
@@ -514,6 +598,18 @@ int ExpectedCylinderResult<AutoDiffXd>() {
   return 0;
 }
 
+// Helper functions to indicate expectation on whether I get a distance result
+// with a ellipsoid based on scalar type.
+template <typename T>
+int ExpectedEllipsoidResult() {
+  return 1;
+}
+
+template <>
+int ExpectedEllipsoidResult<AutoDiffXd>() {
+  return 0;
+}
+
 template <typename T>
 void TestScalarShapeSupport() {
   // Configure the basic query.
@@ -563,6 +659,11 @@ void TestScalarShapeSupport() {
   {
     run_callback(make_shared<fcl::Cylinderd>(1.0, 2.0));
     EXPECT_EQ(distances.size(), ExpectedCylinderResult<T>());
+  }
+
+  // Ellipsoid
+  { run_callback(make_shared<fcl::Ellipsoidd>(1.5, 0.7, 3));
+    EXPECT_EQ(distances.size(), ExpectedEllipsoidResult<T>());
   }
 
   // HalfSpace

--- a/geometry/proximity/test/distance_to_point_characterize_test.cc
+++ b/geometry/proximity/test/distance_to_point_characterize_test.cc
@@ -118,7 +118,7 @@ INSTANTIATE_TEST_SUITE_P(
         QueryInstance(kPoint, kCapsule, 4e-15),
         QueryInstance(kPoint, kConvex, kIgnores),
         QueryInstance(kPoint, kCylinder, 3e-15),
-        QueryInstance(kPoint, kEllipsoid, kIgnores),
+        QueryInstance(kPoint, kEllipsoid, 3e-6),
         QueryInstance(kPoint, kHalfSpace, 5e-15),
         QueryInstance(kPoint, kSphere, 4e-15)),
     QueryInstanceName);

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -502,10 +502,6 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
   }
 
   void ImplementGeometry(const Ellipsoid& ellipsoid, void* user_data) override {
-    static const logging::Warn log_once(
-        "Ellipsoid is primarily for ComputeContactSurfaces in hydroelastic "
-        "contact model. The accuracy of other collision queries and signed "
-        "distance queries are not guaranteed.");
     // Note: Using `shared_ptr` because of FCL API requirements.
     auto fcl_ellipsoid = make_shared<fcl::Ellipsoidd>(
         ellipsoid.a(), ellipsoid.b(), ellipsoid.c());

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -556,13 +556,15 @@ class QueryObject {
 
    | Scalar |   %Box  | %Capsule | %Convex | %Cylinder | %Ellipsoid | %HalfSpace |  %Mesh  | %Sphere |
    | :----: | :-----: | :------: | :-----: | :-------: | :--------: | :--------: | :-----: | :-----: |
-   | double |  2e-15  |   4e-15  |    ᵃ    |   3e-15   |      ᵃ     |    5e-15   |    ᵃ    |  4e-15  |
+   | double |  2e-15  |   4e-15  |    ᵃ    |   3e-15   |    3e-6ᵇ   |    5e-15   |    ᵃ    |  4e-15  |
    | ADXd   |  1e-15  |   4e-15  |    ᵃ    |     ᵃ     |      ᵃ     |    5e-15   |    ᵃ    |  3e-15  |
    __*Table 5*__: Worst observed error (in m) for 2mm penetration/separation
    between geometry approximately 20cm in size and a point.
 
    - ᵃ Unsupported geometry/scalar combinations are simply ignored; no results
        are reported for that geometry.
+   - ᵇ As the eccentricity of the ellipsoid increases, this error will get
+       worse.
 
    @note For a sphere G, the signed distance function φᵢ(p) has an undefined
    gradient vector at the center of the sphere--every point on the sphere's


### PR DESCRIPTION
Add point-to-ellipsoid support

This extends the `ComputeSignedDistanceToPoint()` method to support `Ellipsoid` primitives. Previously, they were simply ignored. The support is partial -- `double` only.

1. Add to `DistanceToPointCallback` to exercise `fcl` in order to produce *some* answer (albeit a sloppy one).
   - Test it.
2. Modify the characterization test for the callback to reflect the new support and the corresponding documentation.
3. This also removes the former warning about `Ellipsoid`s. The distance-to-point query was the only outlier; its support is now clearly documented across all of the proximity queries.

Closes #15227.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15231)
<!-- Reviewable:end -->
