### PR TITLE
documentation_instructions: Fix incorrect build target

### DIFF
--- a/doc/_pages/documentation_instructions.md
+++ b/doc/_pages/documentation_instructions.md
@@ -96,7 +96,7 @@ There are in fact five available commands:
 
 ```sh
 $ bazel run //doc:build               # Entire website (i.e., all of the below).
-$ bazel run //doc:pages_build         # Main site only.
+$ bazel run //doc:pages               # Main site only.
 $ bazel run //doc/doxygen_cxx:build   # C++ API reference subdir only.
 $ bazel run //doc/pydrake:build       # Python API reference subdir only.
 $ bazel run //doc/styleguide:build    # Style Guide subdir only.


### PR DESCRIPTION
`//doc:pages_build` does not exist; `//doc:pages` does

As part of #15236, while doing #15207

\cc @jwnimmer-tri

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15237)
<!-- Reviewable:end -->
