### PR TITLE
Calculate contact jacobian

### DIFF
--- a/multibody/fixed_fem/dev/BUILD.bazel
+++ b/multibody/fixed_fem/dev/BUILD.bazel
@@ -166,6 +166,7 @@ drake_cc_library(
         ":deformable_rigid_contact_pair",
         ":fem_solver",
         "//common:essential",
+        "//multibody/contact_solvers:block_sparse_matrix",
         "//multibody/plant",
     ],
 )

--- a/multibody/fixed_fem/dev/deformable_contact_data.h
+++ b/multibody/fixed_fem/dev/deformable_contact_data.h
@@ -74,7 +74,9 @@ class DeformableContactData {
   int num_vertices_in_contact() const { return num_vertices_in_contact_; }
 
   /* Returns the total number of contact points that have the deformable body as
-   one of the bodies in contact. */
+   one of the bodies in contact. In the illustrating example above, suppose each
+   face of the rigid box R consists of exactly one surface mesh element, then
+   the total number of contact points is 2. */
   int num_contact_points() const { return num_contact_points_; }
 
   /* Returns the number of deformable rigid contact pairs that involve this

--- a/multibody/fixed_fem/dev/deformable_rigid_manager.h
+++ b/multibody/fixed_fem/dev/deformable_rigid_manager.h
@@ -2,11 +2,13 @@
 
 #include <algorithm>
 #include <memory>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/scene_graph.h"
+#include "drake/multibody/contact_solvers/block_sparse_matrix.h"
 #include "drake/multibody/contact_solvers/contact_solver.h"
 #include "drake/multibody/fixed_fem/dev/collision_objects.h"
 #include "drake/multibody/fixed_fem/dev/deformable_contact_data.h"
@@ -76,10 +78,12 @@ class DeformableRigidManager final
    MultibodyPlant::SetDiscreteUpdateManager().
    @pre The owning MultibodyPlant is registered as a source of the given
    `scene_graph`. */
-  void RegisterCollisionObjects(const geometry::SceneGraph<T>& scene_graph);
+  void RegisterCollisionObjects(
+      const geometry::SceneGraph<T>& scene_graph) const;
 
  private:
   friend class DeformableRigidManagerTest;
+  friend class DeformableRigidContactJacobianTest;
 
   // TODO(xuchenhan-tri): Implement CloneToDouble() and CloneToAutoDiffXd() and
   //  the corresponding is_cloneable methods.
@@ -166,6 +170,8 @@ class DeformableRigidManager final
   void UpdateDeformableVertexPositions(
       const systems::Context<T>& context) const;
 
+  // TODO(xuchenhan-tri): Make proper distinction between id and index in
+  //  variable names.
   /* Calculates the contact information for the contact pair consisting of the
    rigid body identified by `rigid_id` and the deformable body identified by
    `deformable_id`. */
@@ -178,17 +184,101 @@ class DeformableRigidManager final
   internal::DeformableContactData<T> CalcDeformableContactData(
       SoftBodyIndex deformable_id) const;
 
+  // TODO(xuchenhan-tri): Skip empty contact data altogether.
   /* Calculates all deforamble-rigid contacts and returns a vector of
    DeformableContactData in which the i-th entry contains contact information
-   about the i-th deformable body against all rigid bodies. */
+   about the i-th deformable body against all rigid bodies. If the i-th
+   deformable body is not in contact with any rigid body, then the i-th entry
+   (data[i]) in the return value will have `data[i].num_contact_points() == 0`.
+  */
   std::vector<internal::DeformableContactData<T>> CalcDeformableRigidContact(
       const systems::Context<T>& context) const;
+
+  /* Eval version of the method CalcDeformableRigidContact(). */
+  const std::vector<internal::DeformableContactData<T>>&
+  EvalDeformableRigidContact(const systems::Context<T>& context) const {
+    return this->plant()
+        .get_cache_entry(deformable_contact_data_cache_index_)
+        .template Eval<std::vector<internal::DeformableContactData<T>>>(
+            context);
+  }
+
+  // TODO(xuchenhan-tri): Modify the description of the contact jacobian when
+  //  sparsity for rigid dofs are exploited.
+  /* Calculates and returns the contact jacobian as a block sparse matrix.
+   As an illustrating example, consider a scene with n rigid bodies and m
+   deformable bodies. Four of those deformable bodies are in contact with rigid
+   geometries. Then the sparsity pattern of the contact jacobian looks like:
+                                | RR               |
+                                | RD0  D0          |
+                                | RD1     D1       |
+                                | RD2        D2    |
+                                | RD3           D3 |
+   where "RR" represents the rigid-rigid block, "RDi" represents the the
+   rigid-deformable block with respect to the rigid dofs for the i-th deformable
+   body, and "Di" represents the rigid-deformable block with respect to the
+   deformable dofs for the i-th deformable body.
+
+   More specifically, the contact jacobian is ordered in the following way:
+    1. The contact jacobian has 3 * (ncr + ncd) rows, where ncr is the number of
+       contact points among rigid objects, and ncd is the number of contact
+       points between deformable bodies and rigid bodies, i.e, the sum of
+       DeformableContactData::num_contact_points() for all deformable bodies in
+       contact.
+    2. Rows 3*i, 3*i+1, and 3*i+2 correspond to the i-th rigid-rigid
+       contact point for i = 0, ..., ncr-1. These contact points are ordered as
+       given by the result of `EvalDiscreteContactPairs()`. Rows 3*(i+ncr),
+       3*(i+ncr)+1, and 3*(i+ncr)+2 correspond to the i-th rigid-deformable
+       contact points for i = 0, ..., ncd-1. These contact points are ordered as
+       given by the result of `CalcDeformableRigidContact()`.
+    3. The contact jacobian has nvr + 3 * nvd columns, where nvr is the number
+       of rigid velocity degrees of freedom and nvd is the number of deformable
+       vertices participating in contact. A vertex of a deformable body is said
+       to be participating in contact if it is incident to a tetrahedron that
+       contains a contact point.
+    4. The first nvr columns of the contact jacobian correspond to the rigid
+       velocity degrees of freedom. The last 3 * nvd columns correspond to the
+       participating deformable velocity degrees of freedom. The participating
+       deformable velocity dofs come in blocks. The i-th block corresponds to
+       i-th deformable body and has number of dofs equal to 3 * number of
+       participating vertices for deformable body i (see
+       DeformableContactData::num_vertices_in_contact()). Within the i-th block,
+       the 3*j, 3*j+1, and 3*j+2 velocity dofs belong to the j-th permuted
+       vertex. (see DeformableContactData::permuted_vertex_indexes()). */
+  multibody::contact_solvers::internal::BlockSparseMatrix<T>
+  CalcContactJacobian(const systems::Context<T>& context) const;
+
+  /* Given the contact data for a deformable body, calculates the contact
+   jacobian for the contact points associated with that deformable body with
+   respect to the deformable degrees of freedom participating in the contact. */
+  MatrixX<T> CalcContactJacobianDeformableBlock(
+      const internal::DeformableContactData<T>& contact_data) const;
+
+  /* Given the contact data for a deformable body, calculates the contact
+   jacobian for the contact points associated with that deformable body with
+   respect to all rigid degrees of freedom. */
+  MatrixX<T> CalcContactJacobianRigidBlock(
+      const systems::Context<T>& context,
+      const internal::DeformableContactData<T>& contact_data) const;
+
+  /* Given the GeometryId of a rigid collision geometry, returns the body frame
+   of the collision geometry.
+   @pre The collision geometry with the given `id` is already registered with
+   `this` DeformableRigidManager. */
+  const Frame<T>& GetBodyFrameFromCollisionGeometry(
+      geometry::GeometryId id) const {
+    BodyIndex body_index = this->geometry_id_to_body_index().at(id);
+    const Body<T>& body = this->plant().get_body(body_index);
+    return body.body_frame();
+  }
 
   /* The deformable models being solved by `this` manager. */
   const DeformableModel<T>* deformable_model_{nullptr};
   /* Cached FEM state quantities. */
   std::vector<systems::CacheIndex> fem_state_cache_indexes_;
   std::vector<systems::CacheIndex> free_motion_cache_indexes_;
+  /* Cached contact query results. */
+  systems::CacheIndex deformable_contact_data_cache_index_;
   /* Solvers for all deformable bodies. */
   std::vector<std::unique_ptr<FemSolver<T>>> fem_solvers_{};
   std::unique_ptr<multibody::contact_solvers::internal::ContactSolver<T>>

--- a/multibody/plant/discrete_update_manager.cc
+++ b/multibody/plant/discrete_update_manager.cc
@@ -142,6 +142,13 @@ double DiscreteUpdateManager<T>::default_contact_dissipation() const {
   return MultibodyPlantDiscreteUpdateManagerAttorney<
       T>::default_contact_dissipation(plant());
 }
+
+template <typename T>
+const std::unordered_map<geometry::GeometryId, BodyIndex>&
+DiscreteUpdateManager<T>::geometry_id_to_body_index() const {
+  return MultibodyPlantDiscreteUpdateManagerAttorney<
+      T>::geometry_id_to_body_index(*plant_);
+}
 }  // namespace internal
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/plant/discrete_update_manager.h
+++ b/multibody/plant/discrete_update_manager.h
@@ -1,7 +1,9 @@
 #pragma once
+
 #include <memory>
 #include <set>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "drake/geometry/geometry_ids.h"
@@ -213,6 +215,9 @@ class DiscreteUpdateManager : public ScalarConvertibleComponent<T> {
 
   double default_contact_stiffness() const;
   double default_contact_dissipation() const;
+
+  const std::unordered_map<geometry::GeometryId, BodyIndex>&
+  geometry_id_to_body_index() const;
   /* @} */
 
   /* Concrete DiscreteUpdateManagers must override these NVI Calc methods to

--- a/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
+++ b/multibody/plant/multibody_plant_discrete_update_manager_attorney.h
@@ -1,6 +1,8 @@
 #pragma once
+
 #include <set>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -102,6 +104,11 @@ class MultibodyPlantDiscreteUpdateManagerAttorney {
 
   static double default_contact_dissipation(const MultibodyPlant<T>& plant) {
     return plant.penalty_method_contact_parameters_.dissipation;
+  }
+
+  static const std::unordered_map<geometry::GeometryId, BodyIndex>&
+  geometry_id_to_body_index(const MultibodyPlant<T>& plant) {
+    return plant.geometry_id_to_body_index_;
   }
 };
 }  // namespace internal


### PR DESCRIPTION
Add DeformableRigidManager::CalcContactJacobian() that calculates the contact jacobian for a system with rigid and deformable bodies. The way that the contact jacobian is ordered also implies an order for all deformable and rigid degrees of freedom; i.e. the order of the dofs should be compatible with that laid out in the contact jacobian.

To facilitate this effort:
* Cache deformable rigid contact query results.
* Add DeformableRigidManager::GetBodyFrameFromCollisionGeometry().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15238)
<!-- Reviewable:end -->
