### PR TITLE
text_logging: Add set_log_pattern and --spdlog_pattern

### DIFF
--- a/common/add_text_logging_gflags.cc
+++ b/common/add_text_logging_gflags.cc
@@ -1,8 +1,9 @@
 // This is a Drake-internal utility for use only as a direct dependency
 // of executable (drake_cc_binary) targets.
 //
-// To add --spdlog_level to the gflags command line of any `drake_cc_binary`,
-// add "//common:add_text_logging_gflags" to the `deps` attribute in its BUILD.
+// To add --spdlog_level and --spdlog_pattern to the gflags command line of any
+// `drake_cc_binary`, add "//common:add_text_logging_gflags" to the `deps`
+// attribute in its BUILD.
 
 #include <string>
 
@@ -11,16 +12,23 @@
 #include "drake/common/text_logging.h"
 #include "drake/common/unused.h"
 
-// Declare the --spdlog_level gflags option.
+// Declare the gflags options.
 DEFINE_string(spdlog_level, drake::logging::kSetLogLevelUnchanged,
               drake::logging::kSetLogLevelHelpMessage);
+DEFINE_string(spdlog_pattern, "%+", drake::logging::kSetLogPatternHelpMessage);
 
-// Validate --spdlog_level and update Drake's configuration to match the flag.
+// Validate flags and update Drake's configuration to match their values.
 namespace {
 bool ValidateSpdlogLevel(const char* name, const std::string& value) {
   drake::unused(name);
   drake::logging::set_log_level(value);
   return true;
 }
+bool ValidateSpdlogPattern(const char* name, const std::string& value) {
+  drake::unused(name);
+  drake::logging::set_log_pattern(value);
+  return true;
+}
 }  // namespace
 DEFINE_validator(spdlog_level, &ValidateSpdlogLevel);
+DEFINE_validator(spdlog_pattern, &ValidateSpdlogPattern);

--- a/common/test/text_logging_test.cc
+++ b/common/test/text_logging_test.cc
@@ -160,6 +160,17 @@ GTEST_TEST(TextLoggingTest, SetLogLevel) {
   #endif
 }
 
+GTEST_TEST(TextLoggingTest, SetLogPattern) {
+  using drake::logging::set_log_pattern;
+
+  #if TEXT_LOGGING_TEST_SPDLOG
+    set_log_pattern("%v");
+    set_log_pattern("%+");
+  #else
+    set_log_pattern("anything really");
+  #endif
+}
+
 // We must run this test last because it changes the default configuration.
 GTEST_TEST(TextLoggingTest, ZZZ_ChangeDefaultSink) {
   // The getter should never return nullptr, even with spdlog disabled.

--- a/common/text_logging.cc
+++ b/common/text_logging.cc
@@ -106,6 +106,14 @@ const char* const logging::kSetLogLevelHelpMessage =
     "'critical', "
     "'off'";
 
+void logging::set_log_pattern(const std::string& pattern) {
+  drake::log()->set_pattern(pattern);
+}
+
+const char* const logging::kSetLogPatternHelpMessage =
+    "sets the spdlog pattern for formatting; for more information, see "
+    "https://github.com/gabime/spdlog/wiki/3.-Custom-formatting";
+
 #else  // HAVE_SPDLOG
 
 logging::logger::logger() {}
@@ -129,6 +137,11 @@ std::string logging::set_log_level(const std::string&) {
 }
 
 const char* const logging::kSetLogLevelHelpMessage =
+    "(Text logging is unavailable.)";
+
+void logging::set_log_pattern(const std::string&) {}
+
+const char* const logging::kSetLogPatternHelpMessage =
     "(Text logging is unavailable.)";
 
 #endif  // HAVE_SPDLOG

--- a/common/text_logging.h
+++ b/common/text_logging.h
@@ -213,5 +213,14 @@ extern const char* const kSetLogLevelUnchanged;
 /// An end-user help string suitable to describe the effects of set_log_level().
 extern const char* const kSetLogLevelHelpMessage;
 
+/// Invokes `drake::log()->set_pattern(pattern)`.
+/// @param pattern Formatting for message. For more information, see:
+/// https://github.com/gabime/spdlog/wiki/3.-Custom-formatting
+void set_log_pattern(const std::string& pattern);
+
+/// An end-user help string suitable to describe the effects of
+/// set_log_pattern().
+extern const char* const kSetLogPatternHelpMessage;
+
 }  // namespace logging
 }  // namespace drake


### PR DESCRIPTION
I find myself occasionally writing `drake::log()->set_pattern("%v")` in certain entry points.
Would be nice to have easily accessible configuration.

Can be talked down from this if it admits scope / feature creep.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15240)
<!-- Reviewable:end -->
