### PR TITLE
geometry: remove stale documentation line.

### DIFF
--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -58,7 +58,7 @@ class Shape {
    Provides optional user-data (cast as a void*) for the reifier to consume. */
   void Reify(ShapeReifier* reifier, void* user_data = nullptr) const;
 
-  /** Creates a unique copy of this shape. Invokes the protected DoClone(). */
+  /** Creates a unique copy of this shape. */
   std::unique_ptr<Shape> Clone() const;
 
  protected:


### PR DESCRIPTION
Clone does not call an NVI DoClone anymore; it uses the fancy ShapeTag functor trick.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15247)
<!-- Reviewable:end -->
