### PR TITLE
Add Schur complement

### DIFF
--- a/multibody/fixed_fem/dev/BUILD.bazel
+++ b/multibody/fixed_fem/dev/BUILD.bazel
@@ -511,6 +511,20 @@ drake_cc_binary(
 )
 
 drake_cc_library(
+    name = "schur_complement",
+    srcs = [
+        "schur_complement.cc",
+    ],
+    hdrs = [
+        "schur_complement.h",
+    ],
+    deps = [
+        "//common:default_scalars",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
     name = "simplex_gaussian_quadrature",
     hdrs = [
         "simplex_gaussian_quadrature.h",
@@ -787,6 +801,14 @@ drake_cc_googletest(
     deps = [
         ":dummy_element",
         ":newmark_scheme",
+        "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "schur_complement_test",
+    deps = [
+        ":schur_complement",
         "//common/test_utilities:eigen_matrix_compare",
     ],
 )

--- a/multibody/fixed_fem/dev/schur_complement.cc
+++ b/multibody/fixed_fem/dev/schur_complement.cc
@@ -1,0 +1,55 @@
+#include "drake/multibody/fixed_fem/dev/schur_complement.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+namespace internal {
+
+template <typename T>
+SchurComplement<T>::SchurComplement(
+    const Eigen::Ref<const Eigen::SparseMatrix<T>>& A,
+    const Eigen::Ref<const Eigen::SparseMatrix<T>>& B_transpose,
+    const Eigen::Ref<const Eigen::SparseMatrix<T>>& D)
+    : p_(A.rows()), q_(D.rows()) {
+  DRAKE_DEMAND(A.cols() == p_);
+  DRAKE_DEMAND(D.cols() == q_);
+  DRAKE_DEMAND(B_transpose.rows() == q_);
+  DRAKE_DEMAND(B_transpose.cols() == p_);
+  /* Special treatment for M = A is needed because Eigen::LLT::solve() throws
+   exception if the matrix under decomposition is empty. */
+  if (q_ == 0) {
+    neg_Dinv_B_transpose_.resize(0, p_);
+    D_complement_ = A;
+  } else if (p_ == 0) {
+    neg_Dinv_B_transpose_.resize(q_, 0);
+    // D_complement is empty, same as default.
+  } else {
+    /* Note that since D is SPD, we could use a sparse Cholesky factorization
+     here. But we opt for SparseLU for now due to the license restriction on
+     Eigen's sparse Cholesky. */
+    const Eigen::SparseLU<Eigen::SparseMatrix<T>> D_factorization(D);
+    /* A column major rhs is required for the SparseLU solve, so we take
+     `B_transpose` instead of `B.transpose()`. */
+    neg_Dinv_B_transpose_ = D_factorization.solve(-B_transpose);
+    D_complement_ = A + B_transpose.transpose() * neg_Dinv_B_transpose_;
+  }
+}
+
+template <typename T>
+VectorX<T> SchurComplement<T>::SolveForY(
+    const Eigen::Ref<const VectorX<T>>& x) const {
+  /* If M = D, then the system reduces to Dy = 0. */
+  if (p_ == 0) {
+    return VectorX<T>::Zero(q_);
+  }
+  DRAKE_DEMAND(x.size() == p_);
+  return neg_Dinv_B_transpose_ * x;
+}
+
+}  // namespace internal
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fixed_fem::internal::SchurComplement)

--- a/multibody/fixed_fem/dev/schur_complement.h
+++ b/multibody/fixed_fem/dev/schur_complement.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+namespace internal {
+
+/* Computes the Schur complement of a matrix given its block components.
+
+Given a linear system of equations Mz = c that can be written in block form
+as:
+    Ax + By  =  a     (1)
+    Bᵀx + Dy =  0     (2)
+where M = [A B; Bᵀ D], zᵀ = [xᵀ yᵀ], cᵀ = [aᵀ 0ᵀ], and A(size p-by-p),
+D(size q-by-q) and M(size p+q-by-p+q) are positive definite, we may choose to
+solve the system using Schur complement. Specifically, using equation (2), we
+get
+    y = -D⁻¹Bᵀx       (3)
+Plugging (3) in (1), we get
+   (A - BD⁻¹Bᵀ)x = a.
+After a solution for x is obtained, we can use (3) to recover the solution for
+y. The matrix A - BD⁻¹Bᵀ is the Schur complement of the block D of the matrix M.
+Since M is positive definite, so is the Schur complement A - BD⁻¹Bᵀ.
+
+@tparam_nonsymbolic_scalar */
+template <typename T>
+class SchurComplement {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SchurComplement);
+
+  /* Creates an empty Schur complement. This allows SchurComplement to be
+   directly constructed in containers. */
+  SchurComplement() = default;
+
+  /* Calculates the Schur complement of the positive definite matrix M = [A B;
+  Bᵀ D] given its block components. We take Bᵀ in the constructor instead of B
+  for efficient calculation of the Schur complement of D.
+  @pre A, D, and M are symmetric positive definite. Note that this prerequisite
+       is not checked at construction as the check is expensive. Callers to the
+       constructor should take care to pass in valid arguments. One way of
+       making sure that this prerequisite is satisfied is by passing in
+       components of a matrix M that is known to be symmetric positive-definite.
+  @pre A.rows() == B_transpose.cols().
+  @pre B_transpose.rows() == D.cols(). */
+  SchurComplement(const Eigen::Ref<const Eigen::SparseMatrix<T>>& A,
+                  const Eigen::Ref<const Eigen::SparseMatrix<T>>& B_transpose,
+                  const Eigen::Ref<const Eigen::SparseMatrix<T>>& D);
+
+  /* Returns the Schur complement for the block D of the matrix M, A - BD⁻¹Bᵀ.
+   */
+  const MatrixX<T>& get_D_complement() const { return D_complement_; }
+
+  /* Solves for y given the solution for x assuming the right hand side takes
+  the form  [aᵀ 0ᵀ]x using the fact that y = -D⁻¹Bᵀx. See class documentation.
+  */
+  VectorX<T> SolveForY(const Eigen::Ref<const VectorX<T>>& x) const;
+
+ private:
+  int p_{0};  // Number of rows and columns for A.
+  int q_{0};  // Number of rows and columns for D.
+  // TODO(xuchenhan-tri): Investigate the sparsity pattern of D⁻¹Bᵀ with actual
+  //  meshes.
+  Eigen::SparseMatrix<T> neg_Dinv_B_transpose_{};  // -D⁻¹Bᵀ.
+  MatrixX<T> D_complement_{};                      // A - BD⁻¹Bᵀ.
+};
+
+}  // namespace internal
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fixed_fem::internal::SchurComplement)

--- a/multibody/fixed_fem/dev/test/schur_complement_test.cc
+++ b/multibody/fixed_fem/dev/test/schur_complement_test.cc
@@ -1,0 +1,97 @@
+#include "drake/multibody/fixed_fem/dev/schur_complement.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+
+namespace drake {
+namespace multibody {
+namespace fixed_fem {
+namespace internal {
+namespace {
+
+using Eigen::Matrix2d;
+using Eigen::MatrixXd;
+using Eigen::Vector2d;
+using Eigen::VectorXd;
+/* Verify that SchurComplement provides the same answer as hand-calculated
+solution on a small problem. */
+GTEST_TEST(SchurComplementTest, AnalyticTest) {
+  Matrix2d A, B, D;
+  // clang-format off
+  A << 3, 0,
+       0, 2;
+  B << 1, 1,
+      -1, 0;
+  D << 4, 1,
+       1, 4;
+  // clang-format on
+  /* The matrix M is given by
+     3 0  | 1  1
+     0 2  | -1 0
+     -----------
+     1 -1 | 4  1
+     1 0  | 1  4
+  It is clearly symmetric and diagonally dominant and thus positive definite.
+  The Schur complement for the bottom right block is given by
+  A - BD⁻¹Bᵀ, which is equal to [13/5, 1/5; 1/5, 26/15] after simple
+  calculation. */
+  const SchurComplement<double> s(A.sparseView(), B.transpose().sparseView(),
+                                  D.sparseView());
+  Matrix2d expected_D_complement;
+  // clang-format off
+  expected_D_complement << 13./5., 1./5.,
+                           1./5., 26./15.;
+  // clang-format on
+  EXPECT_TRUE(CompareMatrices(s.get_D_complement(), expected_D_complement,
+                              std::numeric_limits<double>::epsilon()));
+
+  /* Verify that y = -D⁻¹Bᵀx. */
+  const Vector2d x(1, 2);
+  const Vector2d expected_y(1. / 3., -1. / 3.);
+  EXPECT_TRUE(CompareMatrices(s.SolveForY(x), expected_y,
+                              std::numeric_limits<double>::epsilon()));
+}
+
+/* Verify that when M = D, the Schur complement is a zero-sized matrix and the
+ solution to the y variable is zero. */
+GTEST_TEST(SchurComplementTest, MisD) {
+  const MatrixXd A(0, 0);
+  const MatrixXd B(0, 2);
+  Matrix2d D;
+  // clang-format off
+  D << 4, 1,
+       1, 4;
+  // clang-format on
+  const SchurComplement<double> s(A.sparseView(), B.transpose().sparseView(),
+                                  D.sparseView());
+  EXPECT_EQ(s.get_D_complement().rows(), 0);
+  EXPECT_EQ(s.get_D_complement().cols(), 0);
+  /* Verify that y = 0. */
+  const VectorXd x(0);
+  EXPECT_TRUE(CompareMatrices(s.SolveForY(x), Vector2d::Zero()));
+}
+
+/* Verify that when M = A, the Schur complement is equal to A. */
+GTEST_TEST(SchurComplementTest, MisA) {
+  Matrix2d A;
+  // clang-format off
+  A << 4, 1,
+       1, 4;
+  // clang-format on
+  const MatrixXd B(2, 0);
+  const MatrixXd D(0, 0);
+  const SchurComplement<double> s(A.sparseView(), B.transpose().sparseView(),
+                                  D.sparseView());
+  EXPECT_TRUE(CompareMatrices(s.get_D_complement(), A));
+  /* Verify that the y variable is empty. */
+  const VectorXd expected_y(0);
+  const Vector2d x(1, 2);
+  EXPECT_TRUE(CompareMatrices(s.SolveForY(x), expected_y));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace fixed_fem
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Support deformable rigid contact by providing the functionality to
calculate the Schur complement of a symmetric positive definite matrix.
With Schur complement, the deformable dynamics tangent matrix can be made
into a smaller matrix involving only the dofs in contact. The velocity of
the dofs not in contact can also be solved using Schur complement  after
the contact solve.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15252)
<!-- Reviewable:end -->
