### PR TITLE
[solvers] Disable ClpSolver console printing by default

### DIFF
--- a/solvers/clp_solver.cc
+++ b/solvers/clp_solver.cc
@@ -293,6 +293,20 @@ void ParseModelExceptLinearConstraints(
         it.value();
   }
 }
+
+int ChooseLogLevel(const SolverOptions& options) {
+  const auto& common_options = options.common_solver_options();
+  auto iter = common_options.find(CommonSolverOption::kPrintToConsole);
+  if (iter != common_options.end()) {
+    const int option_value = std::get<int>(iter->second);
+    DRAKE_DEMAND((option_value == 0) || (option_value == 1));
+    if (option_value) {
+      // Documented as "factorizations plus a bit more" in ClpModel.hpp.
+      return 3;
+    }
+  }
+  return 0;
+}
 }  // namespace
 
 bool ClpSolver::is_available() { return true; }
@@ -301,10 +315,10 @@ void ClpSolver::DoSolve(const MathematicalProgram& prog,
                         const Eigen::VectorXd& initial_guess,
                         const SolverOptions& merged_options,
                         MathematicalProgramResult* result) const {
-  // TODO(hongkai.dai): use initial guess and merged options.
+  // TODO(hongkai.dai): use initial guess and more of the merged options.
   unused(initial_guess);
-  unused(merged_options);
   ClpSimplex model;
+  model.setLogLevel(ChooseLogLevel(merged_options));
   Eigen::VectorXd xlow(prog.num_vars());
   Eigen::VectorXd xupp(prog.num_vars());
   Eigen::VectorXd objective_coeff = Eigen::VectorXd::Zero(prog.num_vars());

--- a/solvers/test/clp_solver_test.cc
+++ b/solvers/test/clp_solver_test.cc
@@ -184,6 +184,24 @@ GTEST_TEST(ClpSolverTest, TestNonconvexQP) {
     TestNonconvexQP(solver, true);
   }
 }
+
+// This is a code coverage test, not a functional test.  If the code that
+// handles verbosity options has a segfault or always throws an exception,
+// then this would catch it.
+GTEST_TEST(ClpSolverTest, TestVerbosity) {
+  LinearProgram0 example(CostForm::kSymbolic, ConstraintForm::kSymbolic);
+  const MathematicalProgram& prog = *example.prog();
+
+  SolverOptions options;
+  options.SetOption(CommonSolverOption::kPrintToConsole, 1);
+
+  ClpSolver solver;
+  if (solver.available()) {
+    // This will print stuff to the console, but we don't have any
+    // easy way to check that.
+    solver.Solve(prog, {}, options);
+  }
+}
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake


### PR DESCRIPTION
Users can use kPrintToConsole to opt-in.

```
[ RUN      ] ClpSolverTest.TestVerbosity
Clp1001I Initial range of elements is 1 to 2
Clp1004I Not bothering to scale as good enough
Clp0022I Absolute values of scaled rhs range from 1 to 4, minimum gap 1e+100
Clp0020I Absolute values of scaled objective range from 1 to 2
Clp0021I Absolute values of scaled bounds range from 2 to 2, minimum gap 1e+100
Clp0006I 0  Obj 6 Primal inf 0.9999999 (1) Dual inf 1e+10 (1)
Clp0006I 1  Obj 8
Clp0017I Looking optimal with tolerance of 1e-07
Clp0000I Optimal - objective value 8
[       OK ] ClpSolverTest.TestVerbosity (1 ms)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15254)
<!-- Reviewable:end -->
