### PR TITLE
[framework] Clarify SystemScalarConverter only supports default scalars

### DIFF
--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -853,13 +853,24 @@ void DoScalarIndependentDefinitions(py::module m) {
             });
     // Bind templated instantiations.
     auto converter_methods = [converter](auto pack) {
+      constexpr auto& cls_doc = pydrake_doc.drake.systems.SystemScalarConverter;
       using Pack = decltype(pack);
       using T = typename Pack::template type_at<0>;
       using U = typename Pack::template type_at<1>;
-      AddTemplateMethod(converter, "Add",
-          WrapCallbacks(&SystemScalarConverter::Add<T, U>), GetPyParam<T, U>());
       AddTemplateMethod(converter, "IsConvertible",
           &SystemScalarConverter::IsConvertible<T, U>, GetPyParam<T, U>());
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+      AddTemplateMethod(converter, "Add",
+          WrapDeprecated(cls_doc.Add.doc_deprecated,
+              WrapCallbacks(&SystemScalarConverter::Add<T, U>)),
+          GetPyParam<T, U>());
+      // N.B. When the deprecation date happens, the C++ member function Add()
+      // should become internal or private, to be used only by pydrake here
+      // via this method with a leading underscore.
+      AddTemplateMethod(converter, "_Add",
+          WrapCallbacks(&SystemScalarConverter::Add<T, U>), GetPyParam<T, U>());
+#pragma GCC diagnostic pop
     };
     // N.B. When changing the pairs of supported types below, ensure that these
     // reflect the stanzas for the advanced constructor of

--- a/bindings/pydrake/systems/scalar_conversion.py
+++ b/bindings/pydrake/systems/scalar_conversion.py
@@ -219,5 +219,5 @@ class TemplateSystem(TemplateClass):
         # to when the conversion is called.
         for (T, U) in self._T_pairs:
             conversion = partial(self._make, T, U)
-            converter.Add[T, U](conversion)
+            converter._Add[T, U](conversion)
         return converter

--- a/systems/framework/system_scalar_conversion_doxygen.h
+++ b/systems/framework/system_scalar_conversion_doxygen.h
@@ -222,7 +222,7 @@ class Foo {
 };
 @endcode
 
-Here, `U` is the donor scalar type (to convert from), and `T` the resulting
+Here, `U` is the source scalar type (to convert from), and `T` the resulting
 scalar type (to convert into).  For example, in the second line of
 @code
 Foo<double> foo;

--- a/systems/framework/test/system_scalar_converter_test.cc
+++ b/systems/framework/test/system_scalar_converter_test.cc
@@ -154,7 +154,7 @@ GTEST_TEST(SystemScalarConverterTest, Empty) {
 }
 
 GTEST_TEST(SystemScalarConverterTest, DefaualtConstructor) {
-  // With the default ctor, nothing is convertible ...
+  // With the default ctor, nothing is convertible.
   const SystemScalarConverter dut;
   EXPECT_FALSE((dut.IsConvertible<double,     double>()));
   EXPECT_FALSE((dut.IsConvertible<double,     AutoDiffXd>()));
@@ -165,11 +165,6 @@ GTEST_TEST(SystemScalarConverterTest, DefaualtConstructor) {
   EXPECT_FALSE((dut.IsConvertible<Expression, double>()));
   EXPECT_FALSE((dut.IsConvertible<Expression, AutoDiffXd>()));
   EXPECT_FALSE((dut.IsConvertible<Expression, Expression>()));
-
-  // ... including non-standard scalar types.
-  using AD2 = Eigen::AutoDiffScalar<Eigen::Vector2d>;
-  EXPECT_FALSE((dut.IsConvertible<AD2, double>()));
-  EXPECT_FALSE((dut.IsConvertible<double, AD2>()));
 }
 
 GTEST_TEST(SystemScalarConverterTest, TestAnyToAnySystem) {


### PR DESCRIPTION
In its original incarnation, we imagined supporting user-defined scalars but that never came to pass (#12814).  Here, we improve the documentation to be clear about exactly what is supported and deprecate methods that were only useful for uses beyond the defaults.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15255)
<!-- Reviewable:end -->
