### PR TITLE
[framework] Add sugar for declaring state output ports

### DIFF
--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -76,6 +76,7 @@ void DefineFrameworkPySemantics(py::module m) {
   BindTypeSafeIndex<SubsystemIndex>(m, "SubsystemIndex");
   BindTypeSafeIndex<InputPortIndex>(m, "InputPortIndex");
   BindTypeSafeIndex<OutputPortIndex>(m, "OutputPortIndex");
+  BindTypeSafeIndex<ContinuousStateIndex>(m, "ContinuousStateIndex");
   BindTypeSafeIndex<DiscreteStateIndex>(m, "DiscreteStateIndex");
   BindTypeSafeIndex<AbstractStateIndex>(m, "AbstractStateIndex");
   BindTypeSafeIndex<NumericParameterIndex>(m, "NumericParameterIndex");

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -85,6 +85,7 @@ struct Impl {
     using Base::DeclarePeriodicEvent;
     using Base::DeclarePeriodicPublish;
     using Base::DeclarePerStepEvent;
+    using Base::DeclareStateOutputPort;
     using Base::DeclareVectorInputPort;
     using Base::DeclareVectorOutputPort;
     using Base::MakeWitnessFunction;
@@ -607,6 +608,22 @@ Note: The above is for the C++ documentation. For Python, use
                 .doc_deprecated_deprecated_3args_constBasicVectorSubtype_voidMySystemconstContextBasicVectorSubtypeconst_stdset);
 #pragma GCC diagnostic pop
     leaf_system_cls  // BR
+        .def("DeclareStateOutputPort",
+            py::overload_cast<std::variant<std::string, UseDefaultName>,
+                ContinuousStateIndex>(
+                &LeafSystemPublic::DeclareStateOutputPort),
+            py::arg("name"), py::arg("state_index"), py_rvp::reference_internal,
+            doc.LeafSystem.DeclareStateOutputPort.doc_continuous)
+        .def("DeclareStateOutputPort",
+            py::overload_cast<std::variant<std::string, UseDefaultName>,
+                DiscreteStateIndex>(&LeafSystemPublic::DeclareStateOutputPort),
+            py::arg("name"), py::arg("state_index"), py_rvp::reference_internal,
+            doc.LeafSystem.DeclareStateOutputPort.doc_discrete)
+        .def("DeclareStateOutputPort",
+            py::overload_cast<std::variant<std::string, UseDefaultName>,
+                AbstractStateIndex>(&LeafSystemPublic::DeclareStateOutputPort),
+            py::arg("name"), py::arg("state_index"), py_rvp::reference_internal,
+            doc.LeafSystem.DeclareStateOutputPort.doc_abstract)
         .def(
             "DeclareInitializationEvent",
             [](PyLeafSystem* self, const Event<T>& event) {

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -18,6 +18,7 @@ from pydrake.systems.framework import (
     BasicVector, BasicVector_,
     CacheIndex,
     Context,
+    ContinuousStateIndex,
     DependencyTicket,
     Diagram,
     DiagramBuilder,
@@ -442,6 +443,22 @@ class TestCustom(unittest.TestCase):
         input_port.get_index()
         vector_output_port.Eval(context)
         abstract_output_port.Eval(context)
+
+    def test_state_output_port_declarations(self):
+        """Checks that DeclareStateOutputPort is bound."""
+        dut = LeafSystem()
+
+        xc_index = dut.DeclareContinuousState(2)
+        xc_port = dut.DeclareStateOutputPort(name="xc", state_index=xc_index)
+        self.assertEqual(xc_port.size(), 2)
+
+        xd_index = dut.DeclareDiscreteState(3)
+        xd_port = dut.DeclareStateOutputPort(name="xd", state_index=xd_index)
+        self.assertEqual(xd_port.size(), 3)
+
+        xa_index = dut.DeclareAbstractState(AbstractValue.Make(1))
+        xa_port = dut.DeclareStateOutputPort(name="xa", state_index=xa_index)
+        self.assertEqual(xa_port.get_name(), "xa")
 
     def test_vector_system_overrides(self):
         dt = 0.5

--- a/examples/acrobot/acrobot_plant.cc
+++ b/examples/acrobot/acrobot_plant.cc
@@ -20,12 +20,11 @@ namespace acrobot {
 template <typename T>
 AcrobotPlant<T>::AcrobotPlant()
     : systems::LeafSystem<T>(systems::SystemTypeTag<AcrobotPlant>{}) {
-  this->DeclareVectorInputPort("elbow_torque", AcrobotInput<T>());
-  this->DeclareVectorOutputPort("acrobot_state", AcrobotState<T>(),
-                                &AcrobotPlant::CopyStateOut);
-  this->DeclareContinuousState(AcrobotState<T>(), 2 /* num_q */, 2 /* num_v */,
-                               0 /* num_z */);
   this->DeclareNumericParameter(AcrobotParams<T>());
+  this->DeclareVectorInputPort("elbow_torque", AcrobotInput<T>());
+  auto state_index = this->DeclareContinuousState(
+      AcrobotState<T>(), 2 /* num_q */, 2 /* num_v */, 0 /* num_z */);
+  this->DeclareStateOutputPort("acrobot_state", state_index);
 }
 
 template <typename T>
@@ -50,14 +49,6 @@ parameters) const {
   // current (Amps), in order to simplify the implementation of torque
   // constraint on motors. Therefore, some of the numbers here have incorrect
   // units.
-}
-
-template <typename T>
-void AcrobotPlant<T>::CopyStateOut(const systems::Context<T>& context,
-                                  AcrobotState<T>* output) const {
-  output->set_value(dynamic_cast<const AcrobotState<T>&>(
-                        context.get_continuous_state_vector())
-                        .get_value());
 }
 
 template <typename T>

--- a/examples/acrobot/acrobot_plant.h
+++ b/examples/acrobot/acrobot_plant.h
@@ -97,9 +97,6 @@ class AcrobotPlant : public systems::LeafSystem<T> {
   }
 
  private:
-  void CopyStateOut(const systems::Context<T>& context,
-                    AcrobotState<T>* output) const;
-
   T DoCalcKineticEnergy(const systems::Context<T>& context) const override;
 
   T DoCalcPotentialEnergy(const systems::Context<T>& context) const override;

--- a/examples/bead_on_a_wire/bead_on_a_wire.cc
+++ b/examples/bead_on_a_wire/bead_on_a_wire.cc
@@ -10,21 +10,12 @@ namespace examples {
 namespace bead_on_a_wire {
 
 template <typename T>
-BeadOnAWire<T>::BeadOnAWire(BeadOnAWire<T>::CoordinateType type) {
-  if (type == BeadOnAWire<T>::kMinimalCoordinates) {
-    this->DeclareContinuousState(1, 1, 0);
-    this->DeclareInputPort(systems::kUseDefaultName, systems::kVectorValued, 1);
-    this->DeclareVectorOutputPort(systems::kUseDefaultName,
-                                  systems::BasicVector<T>(2),
-                                  &BeadOnAWire::CopyStateOut);
-  } else {
-    this->DeclareContinuousState(3, 3, 0);
-    this->DeclareInputPort(systems::kUseDefaultName, systems::kVectorValued, 3);
-    this->DeclareVectorOutputPort(systems::kUseDefaultName,
-                                  systems::BasicVector<T>(6),
-                                  &BeadOnAWire::CopyStateOut);
-  }
-  coordinate_type_ = type;
+BeadOnAWire<T>::BeadOnAWire(BeadOnAWire<T>::CoordinateType type)
+    : coordinate_type_(type) {
+  const int n = (type == BeadOnAWire<T>::kMinimalCoordinates) ? 1 : 3;
+  auto state_index = this->DeclareContinuousState(n, n, 0);
+  this->DeclareInputPort(systems::kUseDefaultName, systems::kVectorValued, n);
+  this->DeclareStateOutputPort(systems::kUseDefaultName, state_index);
 }
 
 template <class T>
@@ -128,13 +119,6 @@ Eigen::VectorXd BeadOnAWire<T>::EvalConstraintEquationsDot(
   Eigen::VectorXd result = get_pfunction_first_derivative(fprime)*dinvf_dt - v;
 
   return result;
-}
-
-template <typename T>
-void BeadOnAWire<T>::CopyStateOut(const systems::Context<T>& context,
-                                  systems::BasicVector<T>* output) const {
-  output->get_mutable_value() =
-      context.get_continuous_state().CopyToVector();
 }
 
 template <class T>

--- a/examples/bead_on_a_wire/bead_on_a_wire.h
+++ b/examples/bead_on_a_wire/bead_on_a_wire.h
@@ -203,9 +203,6 @@ class BeadOnAWire : public systems::LeafSystem<T> {
       const Eigen::VectorXd& lambda) const;
 
  protected:
-  void CopyStateOut(const systems::Context<T>& context,
-                    systems::BasicVector<T>* output) const;
-
   void DoCalcTimeDerivatives(
       const systems::Context<T>& context,
       systems::ContinuousState<T>* derivatives) const override;

--- a/examples/bouncing_ball/bouncing_ball.h
+++ b/examples/bouncing_ball/bouncing_ball.h
@@ -29,12 +29,10 @@ class BouncingBall final : public systems::LeafSystem<T> {
   BouncingBall() : systems::LeafSystem<T>(
       systems::SystemTypeTag<BouncingBall>{}) {
     // Two state variables: q and v.
-    this->DeclareContinuousState(1, 1, 0);
+    auto state_index = this->DeclareContinuousState(1, 1, 0);
 
     // The state of the system is output.
-    this->DeclareVectorOutputPort(systems::kUseDefaultName,
-                                  systems::BasicVector<T>(2),
-                                  &BouncingBall::CopyStateOut);
+    this->DeclareStateOutputPort(systems::kUseDefaultName, state_index);
 
     // Declare the witness function.
     signed_distance_witness_ = this->MakeWitnessFunction(
@@ -65,12 +63,6 @@ class BouncingBall final : public systems::LeafSystem<T> {
   T CalcSignedDistance(const systems::Context<T>& context) const {
     const systems::VectorBase<T>& xc = context.get_continuous_state_vector();
     return xc.GetAtIndex(0);
-  }
-
-  void CopyStateOut(const systems::Context<T>& context,
-                    systems::BasicVector<T>* output) const {
-    output->get_mutable_value() =
-        context.get_continuous_state().CopyToVector();
   }
 
   void DoCalcTimeDerivatives(

--- a/examples/particles/particle.cc
+++ b/examples/particles/particle.cc
@@ -9,22 +9,9 @@ Particle<T>::Particle() {
   // A 1D input vector for acceleration.
   this->DeclareInputPort(systems::kUseDefaultName, systems::kVectorValued, 1);
   // Adding one generalized position and one generalized velocity.
-  this->DeclareContinuousState(1, 1, 0);
+  auto state_index = this->DeclareContinuousState(1, 1, 0);
   // A 2D output vector for position and velocity.
-  this->DeclareVectorOutputPort(systems::kUseDefaultName,
-                                systems::BasicVector<T>(2),
-                                &Particle::CopyStateOut);
-}
-
-template <typename T>
-void Particle<T>::CopyStateOut(
-    const systems::Context<T>& context,
-    systems::BasicVector<T>* output) const {
-  // Get current state from context.
-  const systems::VectorBase<T>& continuous_state_vector =
-      context.get_continuous_state_vector();
-  // Write system output.
-  output->set_value(continuous_state_vector.CopyToVector());
+  this->DeclareStateOutputPort(systems::kUseDefaultName, state_index);
 }
 
 template <typename T>

--- a/examples/particles/particle.h
+++ b/examples/particles/particle.h
@@ -27,9 +27,6 @@ class Particle final : public systems::LeafSystem<T> {
   Particle();
 
  protected:
-  void CopyStateOut(const systems::Context<T>& context,
-                    systems::BasicVector<T>* output) const;
-
   void DoCalcTimeDerivatives(const systems::Context<T>& context,
       systems::ContinuousState<T>* derivatives) const override;
 };

--- a/examples/pendulum/pendulum_plant.cc
+++ b/examples/pendulum/pendulum_plant.cc
@@ -11,12 +11,11 @@ namespace pendulum {
 template <typename T>
 PendulumPlant<T>::PendulumPlant()
     : systems::LeafSystem<T>(systems::SystemTypeTag<PendulumPlant>{}) {
-  this->DeclareVectorInputPort("tau", PendulumInput<T>());
-  this->DeclareVectorOutputPort("state", &PendulumPlant::CopyStateOut,
-                                {this->all_state_ticket()});
-  this->DeclareContinuousState(PendulumState<T>(), 1 /* num_q */, 1 /* num_v */,
-                               0 /* num_z */);
   this->DeclareNumericParameter(PendulumParams<T>());
+  this->DeclareVectorInputPort("tau", PendulumInput<T>());
+  auto state_index = this->DeclareContinuousState(
+      PendulumState<T>(), 1 /* num_q */, 1 /* num_v */, 0 /* num_z */);
+  this->DeclareStateOutputPort("state", state_index);
 }
 
 template <typename T>
@@ -30,12 +29,6 @@ template <typename T>
 const systems::OutputPort<T>& PendulumPlant<T>::get_state_output_port() const {
   DRAKE_DEMAND(systems::LeafSystem<T>::num_output_ports() == 1);
   return systems::LeafSystem<T>::get_output_port(0);
-}
-
-template <typename T>
-void PendulumPlant<T>::CopyStateOut(const systems::Context<T>& context,
-                                    PendulumState<T>* output) const {
-  *output = get_state(context);
 }
 
 template <typename T>

--- a/examples/pendulum/pendulum_plant.h
+++ b/examples/pendulum/pendulum_plant.h
@@ -77,9 +77,6 @@ class PendulumPlant final : public systems::LeafSystem<T> {
   }
 
  private:
-  void CopyStateOut(const systems::Context<T>& context,
-                    PendulumState<T>* output) const;
-
   void DoCalcTimeDerivatives(
       const systems::Context<T>& context,
       systems::ContinuousState<T>* derivatives) const final;

--- a/examples/quadrotor/quadrotor_plant.cc
+++ b/examples/quadrotor/quadrotor_plant.cc
@@ -37,10 +37,8 @@ QuadrotorPlant<T>::QuadrotorPlant(double m_arg, double L_arg,
   // Four inputs -- one for each propellor.
   this->DeclareInputPort("propellor_force", systems::kVectorValued, 4);
   // State is x ,y , z, roll, pitch, yaw + velocities.
-  this->DeclareContinuousState(12);
-  this->DeclareVectorOutputPort("state", systems::BasicVector<T>(12),
-                                &QuadrotorPlant::CopyStateOut,
-                                {this->all_state_ticket()});
+  auto state_index = this->DeclareContinuousState(12);
+  this->DeclareStateOutputPort("state", state_index);
   // TODO(russt): Declare input limits.  R2 has @ 2:1 thrust to weight ratio.
 }
 
@@ -51,13 +49,6 @@ QuadrotorPlant<T>:: QuadrotorPlant(const QuadrotorPlant<U>& other)
 
 template <typename T>
 QuadrotorPlant<T>::~QuadrotorPlant() {}
-
-template <typename T>
-void QuadrotorPlant<T>::CopyStateOut(const systems::Context<T> &context,
-                                     systems::BasicVector<T> *output) const {
-  output->set_value(
-      context.get_continuous_state_vector().CopyToVector());
-}
 
 // TODO(russt): Generalize this to support the rotor locations on the Skydio R2.
 template <typename T>

--- a/examples/quadrotor/quadrotor_plant.h
+++ b/examples/quadrotor/quadrotor_plant.h
@@ -46,9 +46,6 @@ class QuadrotorPlant final : public systems::LeafSystem<T> {
       const systems::Context<T>& context,
       systems::ContinuousState<T>* derivatives) const override;
 
-  void CopyStateOut(const systems::Context<T>& context,
-                    systems::BasicVector<T>* output) const;
-
   // Allow different specializations to access each other's private data.
   template <typename> friend class QuadrotorPlant;
 

--- a/examples/rod2d/rod2d.cc
+++ b/examples/rod2d/rod2d.cc
@@ -31,7 +31,9 @@ Rod2D<T>::Rod2D(SystemType system_type, double dt)
     // Discretization approach requires three position variables and
     // three velocity variables, all discrete, and periodic update.
     this->DeclarePeriodicDiscreteUpdate(dt);
-    this->DeclareDiscreteState(6);
+    auto state_index = this->DeclareDiscreteState(6);
+    state_output_port_ = &this->DeclareStateOutputPort(
+        "state_output", state_index);
   } else {
     if (dt != 0)
       throw std::logic_error(
@@ -40,14 +42,15 @@ Rod2D<T>::Rod2D(SystemType system_type, double dt)
 
     // Both piecewise DAE and compliant approach require six continuous
     // variables.
-    this->DeclareContinuousState(Rod2dStateVector<T>(), 3, 3, 0);  // q, v, z
+    auto state_index = this->DeclareContinuousState(
+        Rod2dStateVector<T>(), 3, 3, 0);  // q, v, z
+    state_output_port_ = &this->DeclareStateOutputPort(
+        "state_output", state_index);
   }
   // TODO(edrumwri): When type is SystemType::kPiecewiseDAE, allocate the
   // abstract mode variables.
 
   this->DeclareInputPort(systems::kUseDefaultName, systems::kVectorValued, 3);
-  state_output_port_ = &this->DeclareVectorOutputPort(
-      "state_output", systems::BasicVector<T>(6), &Rod2D::CopyStateOut);
 }
 
 // Computes the external forces on the rod.
@@ -473,16 +476,6 @@ void Rod2D<T>::CalcImpactProblemData(
 
   data->kL.resize(0);
   data->gammaL.resize(0);
-}
-
-template <typename T>
-void Rod2D<T>::CopyStateOut(const systems::Context<T>& context,
-                            systems::BasicVector<T>* state_port_value) const {
-  // Output port value is just the continuous or discrete state.
-  const VectorX<T> state = (system_type_ == SystemType::kDiscretized)
-                               ? context.get_discrete_state(0).CopyToVector()
-                               : context.get_continuous_state().CopyToVector();
-  state_port_value->SetFromVector(state);
 }
 
 /// Integrates the Rod 2D example forward in time using a

--- a/examples/rod2d/rod2d.h
+++ b/examples/rod2d/rod2d.h
@@ -493,8 +493,6 @@ class Rod2D : public systems::LeafSystem<T> {
   T GetSlidingVelocityTolerance() const;
   MatrixX<T> solve_inertia(const MatrixX<T>& B) const;
   int get_k(const systems::Context<T>& context) const;
-  void CopyStateOut(const systems::Context<T>& context,
-                    systems::BasicVector<T>* output) const;
   void DoCalcTimeDerivatives(const systems::Context<T>& context,
                              systems::ContinuousState<T>* derivatives)
                                const override;

--- a/examples/scene_graph/bouncing_ball_plant.cc
+++ b/examples/scene_graph/bouncing_ball_plant.cc
@@ -43,15 +43,11 @@ BouncingBallPlant<T>::BouncingBallPlant(SourceId source_id,
   geometry_query_port_ = this->DeclareAbstractInputPort(
       systems::kUseDefaultName, Value<geometry::QueryObject<T>>{})
           .get_index();
+  auto state_index = this->DeclareContinuousState(
+      BouncingBallVector<T>(), 1 /* num_q */, 1 /* num_v */, 0 /* num_z */);
   state_port_ =
-      this->DeclareVectorOutputPort(systems::kUseDefaultName,
-                                    BouncingBallVector<T>(),
-                                    &BouncingBallPlant::CopyStateToOutput,
-                                    {this->all_state_ticket()})
+      this->DeclareStateOutputPort(systems::kUseDefaultName, state_index)
           .get_index();
-
-  this->DeclareContinuousState(BouncingBallVector<T>(), 1 /* num_q */,
-                               1 /* num_v */, 0 /* num_z */);
   static_assert(BouncingBallVectorIndices::kNumCoordinates == 1 + 1, "");
 
   ball_frame_id_ = scene_graph->RegisterFrame(
@@ -98,14 +94,6 @@ template <typename T>
 const systems::OutputPort<T>&
 BouncingBallPlant<T>::get_geometry_pose_output_port() const {
   return systems::System<T>::get_output_port(geometry_pose_port_);
-}
-
-// Updates the state output port.
-template <typename T>
-void BouncingBallPlant<T>::CopyStateToOutput(
-    const Context<T>& context,
-    BouncingBallVector<T>* state_output_vector) const {
-  state_output_vector->set_value(get_state(context).get_value());
 }
 
 template <typename T>

--- a/examples/scene_graph/bouncing_ball_plant.h
+++ b/examples/scene_graph/bouncing_ball_plant.h
@@ -66,10 +66,6 @@ class BouncingBallPlant : public systems::LeafSystem<T> {
   double g() const { return g_; }
 
  private:
-  // Callback for writing the state vector to an output.
-  void CopyStateToOutput(const systems::Context<T>& context,
-                         BouncingBallVector<T>* state_output_vector) const;
-
   // Calculate the frame pose set output port value.
   void CalcFramePoseOutput(const systems::Context<T>& context,
                            geometry::FramePoseVector<T>* poses) const;

--- a/examples/van_der_pol/van_der_pol.cc
+++ b/examples/van_der_pol/van_der_pol.cc
@@ -15,7 +15,7 @@ template <typename T>
 VanDerPolOscillator<T>::VanDerPolOscillator()
     : systems::LeafSystem<T>(systems::SystemTypeTag<VanDerPolOscillator>{}) {
   // State is (q,q̇).
-  this->DeclareContinuousState(1, 1, 0);
+  auto state_index = this->DeclareContinuousState(1, 1, 0);
 
   // First output, y₁ = q, for interesting estimation problems.
   this->DeclareVectorOutputPort(systems::kUseDefaultName,
@@ -23,9 +23,7 @@ VanDerPolOscillator<T>::VanDerPolOscillator()
                                 &VanDerPolOscillator::CopyPositionToOutput);
 
   // Second output, y₂ = [q,q̇]', for e.g. visualizing the full state.
-  this->DeclareVectorOutputPort(systems::kUseDefaultName,
-                                systems::BasicVector<T>(2),
-                                &VanDerPolOscillator::CopyFullStateToOutput);
+  this->DeclareStateOutputPort(systems::kUseDefaultName, state_index);
 
   // Single parameter, μ, with default μ=1.
   this->DeclareNumericParameter(systems::BasicVector<T>(Vector1<T>(1.0)));
@@ -86,12 +84,6 @@ void VanDerPolOscillator<T>::CopyPositionToOutput(
   output->SetAtIndex(
       0,
       context.get_continuous_state().get_generalized_position().GetAtIndex(0));
-}
-
-template <typename T>
-void VanDerPolOscillator<T>::CopyFullStateToOutput(
-    const systems::Context<T>& context, systems::BasicVector<T>* output) const {
-  output->SetFromVector(context.get_continuous_state_vector().CopyToVector());
 }
 
 }  // namespace van_der_pol

--- a/examples/van_der_pol/van_der_pol.h
+++ b/examples/van_der_pol/van_der_pol.h
@@ -60,9 +60,6 @@ class VanDerPolOscillator final : public systems::LeafSystem<T> {
 
   void CopyPositionToOutput(const systems::Context<T>& context,
                             systems::BasicVector<T>* output) const;
-
-  void CopyFullStateToOutput(const systems::Context<T>& context,
-                             systems::BasicVector<T>* output) const;
 };
 
 }  // namespace van_der_pol

--- a/systems/framework/framework_common.h
+++ b/systems/framework/framework_common.h
@@ -49,6 +49,9 @@ using InputPortIndex = TypeSafeIndex<class InputPortTag>;
 indexes used by a subsystem and its corresponding subcontext are the same. */
 using OutputPortIndex = TypeSafeIndex<class OutputPortTag>;
 
+/** Placeholder for future use. Currently, the only valid value is zero. */
+using ContinuousStateIndex = TypeSafeIndex<class ContinuousStateTag>;
+
 /** Serves as the local index for discrete state groups within a given System
 and its corresponding Context. */
 using DiscreteStateIndex = TypeSafeIndex<class DiscreteStateTag>;

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -1055,18 +1055,22 @@ class LeafSystem : public System<T> {
 
   /** Declares that this System should reserve continuous state with
   @p num_state_variables state variables, which have no second-order
-  structure. */
-  void DeclareContinuousState(int num_state_variables);
+  structure.
+  @return index of the declared state (currently always zero). */
+  ContinuousStateIndex DeclareContinuousState(int num_state_variables);
 
   /** Declares that this System should reserve continuous state with @p num_q
   generalized positions, @p num_v generalized velocities, and @p num_z
-  miscellaneous state variables. */
-  void DeclareContinuousState(int num_q, int num_v, int num_z);
+  miscellaneous state variables.
+  @return index of the declared state (currently always zero). */
+  ContinuousStateIndex DeclareContinuousState(int num_q, int num_v, int num_z);
 
   /** Declares that this System should reserve continuous state with
   @p model_vector.size() miscellaneous state variables, stored in a
-  vector cloned from @p model_vector. */
-  void DeclareContinuousState(const BasicVector<T>& model_vector);
+  vector cloned from @p model_vector.
+  @return index of the declared state (currently always zero). */
+  ContinuousStateIndex DeclareContinuousState(
+      const BasicVector<T>& model_vector);
 
   /** Declares that this System should reserve continuous state with @p num_q
   generalized positions, @p num_v generalized velocities, and @p num_z
@@ -1074,9 +1078,10 @@ class LeafSystem : public System<T> {
   @p model_vector. Aborts if @p model_vector has the wrong size. If the
   @p model_vector declares any VectorBase::GetElementBounds()
   constraints, they will be re-declared as inequality constraints on this
-  system (see DeclareInequalityConstraint()). */
-  void DeclareContinuousState(const BasicVector<T>& model_vector, int num_q,
-                              int num_v, int num_z);
+  system (see DeclareInequalityConstraint()).
+  @return index of the declared state (currently always zero). */
+  ContinuousStateIndex DeclareContinuousState(
+      const BasicVector<T>& model_vector, int num_q, int num_v, int num_z);
   //@}
 
   /** @name            Declare discrete state variables
@@ -1506,6 +1511,29 @@ class LeafSystem : public System<T> {
       typename LeafOutputPort<T>::CalcCallback calc_function,
       std::set<DependencyTicket> prerequisites_of_calc = {
           all_sources_ticket()});
+
+  /** Declares a vector-valued output port whose value is the continuous state
+  of this system.
+  @param state_index must be ContinuousStateIndex(0) for now, since LeafSystem
+  only supports a single continuous state group at the moment.
+  @pydrake_mkdoc_identifier{continuous} */
+  LeafOutputPort<T>& DeclareStateOutputPort(
+      std::variant<std::string, UseDefaultName> name,
+      ContinuousStateIndex state_index);
+
+  /** Declares a vector-valued output port whose value is the given discrete
+  state group of this system.
+  @pydrake_mkdoc_identifier{discrete} */
+  LeafOutputPort<T>& DeclareStateOutputPort(
+      std::variant<std::string, UseDefaultName> name,
+      DiscreteStateIndex state_index);
+
+  /** Declares an abstract-valued output port whose value is the given abstract
+  state of this system.
+  @pydrake_mkdoc_identifier{abstract} */
+  LeafOutputPort<T>& DeclareStateOutputPort(
+      std::variant<std::string, UseDefaultName> name,
+      AbstractStateIndex state_index);
   //@}
 
   // =========================================================================

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -134,6 +134,7 @@ class TestSystem : public LeafSystem<T> {
 
   using LeafSystem<T>::DeclareContinuousState;
   using LeafSystem<T>::DeclareDiscreteState;
+  using LeafSystem<T>::DeclareStateOutputPort;
   using LeafSystem<T>::DeclareNumericParameter;
   using LeafSystem<T>::DeclareVectorInputPort;
   using LeafSystem<T>::DeclareAbstractInputPort;
@@ -883,7 +884,7 @@ TEST_F(LeafSystemTest, DeclareVanillaContinuousState) {
 // second-order structure of interesting custom type.
 TEST_F(LeafSystemTest, DeclareTypedContinuousState) {
   using MyVector9d = MyVector<double, 4 + 3 + 2>;
-  system_.DeclareContinuousState(MyVector9d(), 4, 3, 2);
+  auto state_index = system_.DeclareContinuousState(MyVector9d(), 4, 3, 2);
 
   // Tests num_continuous_states without a context.
   EXPECT_EQ(4 + 3 + 2, system_.num_continuous_states());
@@ -898,6 +899,14 @@ TEST_F(LeafSystemTest, DeclareTypedContinuousState) {
   EXPECT_EQ(4, xc.get_generalized_position().size());
   EXPECT_EQ(3, xc.get_generalized_velocity().size());
   EXPECT_EQ(2, xc.get_misc_continuous_state().size());
+
+  // Check that the state retains its type when placed on an output port.
+  const auto& state_output_port = system_.DeclareStateOutputPort(
+      "state", state_index);
+  context = system_.CreateDefaultContext();
+  const Eigen::VectorXd ones = VectorXd::Ones(9);
+  context->SetContinuousState(ones);
+  EXPECT_EQ(state_output_port.Eval<MyVector9d>(*context).get_value(), ones);
 }
 
 TEST_F(LeafSystemTest, ContinuousStateBelongsWithSystem) {
@@ -1356,6 +1365,7 @@ GTEST_TEST(ModelLeafSystemTest, ModelDiscreteState) {
       // Takes a BasicVector.
       indexes_.push_back(
           DeclareDiscreteState(MyVector2d(Vector2d(1., 2.))));
+      DeclareStateOutputPort("state", indexes_.back());
       // Takes an Eigen vector.
       indexes_.push_back(DeclareDiscreteState(Vector3d(3., 4., 5.)));
       // Four state variables, initialized to zero.
@@ -1377,6 +1387,8 @@ GTEST_TEST(ModelLeafSystemTest, ModelDiscreteState) {
   BasicVector<double>& xd0 = xd.get_mutable_vector(0);
   EXPECT_TRUE(is_dynamic_castable<const MyVector2d>(&xd0));
   EXPECT_EQ(xd0.get_value(), Vector2d(1., 2.));
+  EXPECT_EQ(dut.get_output_port().Eval<MyVector2d>(*context).get_value(),
+            Vector2d(1., 2.));
 
   // Eigen vector should have been stored in a BasicVector-type object.
   BasicVector<double>& xd1 = xd.get_mutable_vector(1);
@@ -1393,11 +1405,15 @@ GTEST_TEST(ModelLeafSystemTest, ModelDiscreteState) {
   xd0.SetFromVector(Vector2d(9., 10.));
   xd1.SetFromVector(Vector3d(11., 12., 13.));
   xd2.SetFromVector(Vector4d(1., 2., 3., 4.));
+  // Ensure that the cache knows that the values have changed.
+  context->get_mutable_discrete_state();
 
   // Of course that had to work, but let's just prove it ...
   EXPECT_EQ(xd0.get_value(), Vector2d(9., 10.));
   EXPECT_EQ(xd1.get_value(), Vector3d(11., 12., 13.));
   EXPECT_EQ(xd2.get_value(), Vector4d(1., 2., 3., 4.));
+  EXPECT_EQ(dut.get_output_port().Eval<MyVector2d>(*context).get_value(),
+            Vector2d(9., 10.));
 
   dut.SetDefaultContext(&*context);
   EXPECT_EQ(xd0.get_value(), Vector2d(1., 2.));
@@ -1412,6 +1428,7 @@ GTEST_TEST(ModelLeafSystemTest, ModelAbstractState) {
     DeclaredModelAbstractStateSystem() {
       DeclareAbstractState(Value<int>(1));
       DeclareAbstractState(Value<std::string>("wow"));
+      DeclareStateOutputPort("state", AbstractStateIndex{1});
     }
   };
 
@@ -1423,12 +1440,14 @@ GTEST_TEST(ModelLeafSystemTest, ModelAbstractState) {
   // Check that the allocations were made and with the correct type
   DRAKE_EXPECT_NO_THROW(context->get_abstract_state<int>(0));
   DRAKE_EXPECT_NO_THROW(context->get_abstract_state<std::string>(1));
+  EXPECT_EQ(dut.get_output_port().Eval<std::string>(*context), "wow");
 
   // Mess with the abstract values on the context.
   AbstractValues& values = context->get_mutable_abstract_state();
   AbstractValue& value = values.get_mutable_value(1);
   DRAKE_EXPECT_NO_THROW(value.set_value<std::string>("whoops"));
   EXPECT_EQ(context->get_abstract_state<std::string>(1), "whoops");
+  EXPECT_EQ(dut.get_output_port().Eval<std::string>(*context), "whoops");
 
   // Ask it to reset to the defaults specified on system construction.
   dut.SetDefaultContext(context.get());

--- a/systems/primitives/random_source.cc
+++ b/systems/primitives/random_source.cc
@@ -82,16 +82,11 @@ RandomSourceT<T>::RandomSourceT(RandomDistribution distribution,
       distribution_(distribution),
       sampling_interval_sec_{sampling_interval_sec},
       instance_seed_{get_next_seed()} {
-  this->DeclareDiscreteState(num_outputs);
+  auto discrete_state_index = this->DeclareDiscreteState(num_outputs);
   this->DeclareAbstractState(Value<SampleGenerator>());
   this->DeclarePeriodicUnrestrictedUpdateEvent(
       sampling_interval_sec, 0., &RandomSourceT<T>::UpdateSamples);
-  this->DeclareVectorOutputPort(
-      "output", BasicVector<T>(num_outputs),
-      [](const Context<T>& context, BasicVector<T>* output) {
-        const auto& values = context.get_discrete_state(0);
-        output->SetFrom(values);
-      });
+  this->DeclareStateOutputPort("output", discrete_state_index);
 }
 
 template <typename T>

--- a/systems/primitives/zero_order_hold.h
+++ b/systems/primitives/zero_order_hold.h
@@ -93,22 +93,10 @@ class ZeroOrderHold final : public LeafSystem<T> {
   ZeroOrderHold(double period_sec, int vector_size,
                 std::unique_ptr<const AbstractValue> model_value);
 
-  // Sets the output port value to the vector value that is currently
-  // latched in the zero-order hold.
-  void CopyLatchedVector(
-      const Context<T>& context,
-      BasicVector<T>* output) const;
-
   // Latches the input port into the discrete vector-valued state.
   void LatchInputVectorToState(
       const Context<T>& context,
       DiscreteValues<T>* discrete_state) const;
-
-  // Sets the output port value to the abstract value that is currently
-  // latched in the zero-order hold.
-  void CopyLatchedAbstractValue(
-      const Context<T>& context,
-      AbstractValue* output) const;
 
   // Latches the abstract input port into the abstract-valued state.
   void LatchInputAbstractValueToState(


### PR DESCRIPTION
Even with pydrake bindings and new tests, this is still net-LOC negative.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15256)
<!-- Reviewable:end -->
