### PR TITLE
[geometry] Remove PoseBundle allocation boilerplate

### DIFF
--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -89,7 +89,7 @@ SceneGraph<T>::SceneGraph()
       this->DeclareAbstractParameter(GeometryStateValue<T>());
 
   bundle_port_index_ = this->DeclareAbstractOutputPort(
-                               "lcm_visualization", &SceneGraph::MakePoseBundle,
+                               "lcm_visualization",
                                &SceneGraph::CalcPoseBundle)
                            .get_index();
 
@@ -385,13 +385,6 @@ void SceneGraph<T>::CalcQueryObject(const Context<T>& context,
   //
   // See the todo in the header for an alternate formulation.
   output->set(&context, this);
-}
-
-template <typename T>
-PoseBundle<T> SceneGraph<T>::MakePoseBundle() const {
-  vector<FrameId> dynamic_frames =
-      GetDynamicFrames(model_, Role::kIllustration);
-  return PoseBundle<T>(static_cast<int>(dynamic_frames.size()));
 }
 
 template <typename T>

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -909,10 +909,6 @@ class SceneGraph final : public systems::LeafSystem<T> {
   void CalcQueryObject(const systems::Context<T>& context,
                        QueryObject<T>* output) const;
 
-  // Constructs a PoseBundle of length equal to the concatenation of all inputs.
-  // This is the method used by the allocator for the output port.
-  systems::rendering::PoseBundle<T> MakePoseBundle() const;
-
   // Aggregates the input poses into the output PoseBundle, in the same order as
   // was used in allocation. Aborts if any inputs have a _different_ size than
   // expected.

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -74,11 +74,6 @@ class SceneGraphTester {
   }
 
   template <typename T>
-  static PoseBundle<T> MakePoseBundle(const SceneGraph<T>& scene_graph) {
-    return scene_graph.MakePoseBundle();
-  }
-
-  template <typename T>
   static void CalcPoseBundle(const SceneGraph<T>& scene_graph,
                              const systems::Context<T>& context,
                              PoseBundle<T>* bundle) {
@@ -598,11 +593,11 @@ GTEST_TEST(SceneGraphVisualizationTest, NoWorldInPoseVector) {
   // Case: No registered source, frames, or geometry --> empty pose vector.
   {
     SceneGraph<double> scene_graph;
-    PoseBundle<double> poses = SceneGraphTester::MakePoseBundle(scene_graph);
-    EXPECT_EQ(0, poses.get_num_poses());
+    PoseBundle<double> poses;
     auto context = scene_graph.CreateDefaultContext();
     DRAKE_EXPECT_NO_THROW(
         SceneGraphTester::CalcPoseBundle(scene_graph, *context, &poses));
+    EXPECT_EQ(0, poses.get_num_poses());
   }
 
   // Case: Calculating pose bundle with an input pose bundle the wrong size.
@@ -620,11 +615,11 @@ GTEST_TEST(SceneGraphVisualizationTest, NoWorldInPoseVector) {
   {
     SceneGraph<double> scene_graph;
     scene_graph.RegisterSource("dummy");
-    PoseBundle<double> poses = SceneGraphTester::MakePoseBundle(scene_graph);
-    EXPECT_EQ(0, poses.get_num_poses());
+    PoseBundle<double> poses;
     auto context = scene_graph.CreateDefaultContext();
     DRAKE_EXPECT_NO_THROW(
         SceneGraphTester::CalcPoseBundle(scene_graph, *context, &poses));
+    EXPECT_EQ(0, poses.get_num_poses());
   }
 
   // Case: Registered source with anchored geometry but no frames or dynamic
@@ -636,11 +631,11 @@ GTEST_TEST(SceneGraphVisualizationTest, NoWorldInPoseVector) {
         s_id, scene_graph.world_frame_id(),
         make_unique<GeometryInstance>(RigidTransformd::Identity(),
                                       make_unique<Sphere>(1.0), "sphere"));
-    PoseBundle<double> poses = SceneGraphTester::MakePoseBundle(scene_graph);
-    EXPECT_EQ(0, poses.get_num_poses());
+    PoseBundle<double> poses;
     auto context = scene_graph.CreateDefaultContext();
     DRAKE_EXPECT_NO_THROW(
         SceneGraphTester::CalcPoseBundle(scene_graph, *context, &poses));
+    EXPECT_EQ(0, poses.get_num_poses());
   }
 
   // Case: Registered source with anchored geometry and frame but no dynamic
@@ -654,16 +649,16 @@ GTEST_TEST(SceneGraphVisualizationTest, NoWorldInPoseVector) {
         make_unique<GeometryInstance>(RigidTransformd::Identity(),
                                       make_unique<Sphere>(1.0), "sphere"));
     FrameId f_id = scene_graph.RegisterFrame(s_id, GeometryFrame("f"));
-    PoseBundle<double> poses = SceneGraphTester::MakePoseBundle(scene_graph);
-    // The frame has no illustration geometry, so it is not part of the pose
-    // bundle.
-    EXPECT_EQ(0, poses.get_num_poses());
+    PoseBundle<double> poses;
     auto context = scene_graph.CreateDefaultContext();
     const FramePoseVector<double> pose_vector{
         {f_id, RigidTransformd::Identity()}};
     scene_graph.get_source_pose_port(s_id).FixValue(context.get(), pose_vector);
     DRAKE_EXPECT_NO_THROW(
         SceneGraphTester::CalcPoseBundle(scene_graph, *context, &poses));
+    // The frame has no illustration geometry, so it is not part of the pose
+    // bundle.
+    EXPECT_EQ(0, poses.get_num_poses());
   }
 
   // Case: Registered source with anchored geometry and frame with dynamic
@@ -680,16 +675,16 @@ GTEST_TEST(SceneGraphVisualizationTest, NoWorldInPoseVector) {
         s_id, f_id,
         make_unique<GeometryInstance>(RigidTransformd::Identity(),
                                       make_unique<Sphere>(1.0), "sphere"));
-    PoseBundle<double> poses = SceneGraphTester::MakePoseBundle(scene_graph);
-    // The dynamic geometry has no illustration role, so it doesn't lead the
-    // frame to be included in the bundle.
-    EXPECT_EQ(0, poses.get_num_poses());
+    PoseBundle<double> poses;
     auto context = scene_graph.CreateDefaultContext();
     const FramePoseVector<double> pose_vector{
         {f_id, RigidTransformd::Identity()}};
     scene_graph.get_source_pose_port(s_id).FixValue(context.get(), pose_vector);
     DRAKE_EXPECT_NO_THROW(
         SceneGraphTester::CalcPoseBundle(scene_graph, *context, &poses));
+    // The dynamic geometry has no illustration role, so it doesn't lead the
+    // frame to be included in the bundle.
+    EXPECT_EQ(0, poses.get_num_poses());
   }
 }
 

--- a/systems/rendering/pose_aggregator.cc
+++ b/systems/rendering/pose_aggregator.cc
@@ -19,7 +19,6 @@ PoseAggregator<T>::PoseAggregator()
   // equal to the concatenation of all inputs. This can't be done with a model
   // value because we don't know at construction how big the output will be.
   this->DeclareAbstractOutputPort(kUseDefaultName,
-                                  &PoseAggregator::MakePoseBundle,
                                   &PoseAggregator::CalcPoseBundle);
 }
 
@@ -64,8 +63,13 @@ template <typename T>
 void PoseAggregator<T>::CalcPoseBundle(const Context<T>& context,
                                        PoseBundle<T>* output) const {
   PoseBundle<T>& bundle = *output;
-  int pose_index = 0;
 
+  const int total_num_poses = this->CountNumPoses();
+  if (bundle.get_num_poses() != total_num_poses) {
+    bundle = PoseBundle<T>(total_num_poses);
+  }
+
+  int pose_index = 0;
   const int num_ports = this->num_input_ports();
   for (int port_index = 0; port_index < num_ports; ++port_index) {
     const auto& port = this->get_input_port(port_index);
@@ -121,11 +125,7 @@ void PoseAggregator<T>::CalcPoseBundle(const Context<T>& context,
     }
     DRAKE_UNREACHABLE();
   }
-}
-
-template <typename T>
-PoseBundle<T> PoseAggregator<T>::MakePoseBundle() const {
-  return PoseBundle<T>(this->CountNumPoses());
+  DRAKE_DEMAND(pose_index == total_num_poses);
 }
 
 template <typename T>

--- a/systems/rendering/pose_aggregator.h
+++ b/systems/rendering/pose_aggregator.h
@@ -114,10 +114,6 @@ class PoseAggregator : public LeafSystem<T> {
   void CalcPoseBundle(const Context<T>& context,
                       PoseBundle<T>* output) const;
 
-  // Constructs a PoseBundle of length equal to the concatenation of all inputs.
-  // This is the method used by the allocator for the output port.
-  PoseBundle<T> MakePoseBundle() const;
-
   using InputRecord = internal::PoseAggregatorInputRecord;
 
   // Returns an InputRecord for a generic single pose input.


### PR DESCRIPTION
The output port allocation callbacks are intended for cases where cloned values are unsuitable.  PoseBundle has a default constructor, so there's no justification to use the allocation callback.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15259)
<!-- Reviewable:end -->
