### PR TITLE
[common] Avoid std::filesystem with GCC 8

### DIFF
--- a/common/filesystem.cc
+++ b/common/filesystem.cc
@@ -3,7 +3,9 @@
 // library implements separate compilation.  So, we have to NOLINT it below.
 
 // Keep this sequence in sync with drake/common/filesystem.h.
-#if __has_include(<filesystem>) && !defined(__APPLE__)
+#if __has_include(<filesystem>) && !( \
+  defined(__APPLE__) || \
+  (!defined(__clang__) && defined(__GNUC__) && (__GNUC__ < 9)))
 
 // No compilation required for std::filesystem.
 

--- a/common/filesystem.h
+++ b/common/filesystem.h
@@ -6,11 +6,14 @@
 // files -- it is not a public dependency of Drake; do not include this file
 // from Drake header files.
 //
-// Note that until apple ships a working std::filesystem implementation, we
-// need to force-disable it.
+// Note that until Apple ships a working std::filesystem implementation, we
+// need to force-disable it. Similarly, GCC prior to 9 requires arcane linker
+// flags, so we need to exclude it as well.
 //
 // Keep this if-sequence in sync with drake/common/filesystem.cc.
-#if __has_include(<filesystem>) && !defined(__APPLE__)
+#if __has_include(<filesystem>) && !( \
+  defined(__APPLE__) || \
+  (!defined(__clang__) && defined(__GNUC__) && (__GNUC__ < 9)))
 
 #include <filesystem>
 namespace drake { namespace filesystem = std::filesystem; }


### PR DESCRIPTION
While we don't officially support GCC 8, sometimes users will still try it and need to work around this.

https://stackoverflow.com/questions/64762679/building-python-bindings-linking-of-rule-failed/64779015#64779015
https://stackoverflow.com/questions/68173726/declarevectorinputport-function-runs-with-error

Tested locally with `env CC=gcc-8 CXX=g++-8 bazel test //common:*` on Bionic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15265)
<!-- Reviewable:end -->
