### PR TITLE
[common] Change NiceTypeName's internal caching to be opt-in

### DIFF
--- a/common/nice_type_name.h
+++ b/common/nice_type_name.h
@@ -43,17 +43,23 @@ This class exists only to group type name-related static methods; don't try
 to construct an object of this type. */
 class NiceTypeName {
  public:
-  /** Attempts to return a nicely demangled and canonicalized type name that is
-  the same on all platforms, using Canonicalize(). This is an expensive
-  operation but is only done once per instantiation of NiceTypeName::Get<T>()
-  for a given type `T`. The returned reference will not be deleted even at
-  program termination, so feel free to use it in error messages even in
-  destructors that may be invoked during program tear-down. */
+  /** Returns a nicely demangled and canonicalized type name that is the same
+  on all platforms, using Canonicalize(). This is calculated on the fly so is
+  expensive whenever called, though very reasonable for use in error messages.
+  For repeated or performance-sensitive uses, see GetFromStorage(). */
   template <typename T>
-  static const std::string& Get() {
-    static const never_destroyed<std::string> canonical(
-        NiceTypeName::Get(typeid(T)));
-    return canonical.access();
+  static std::string Get() {
+    return NiceTypeName::Get(typeid(T));
+  }
+
+  /** Like Get<T>() but only computed once per process for a given type `T`.
+  The returned reference will not be deleted even at program termination, so
+  feel free to use it in error messages even in destructors that may be
+  invoked during program tear-down. */
+  template <typename T>
+  static const std::string& GetFromStorage() {
+    static const never_destroyed<std::string> result(NiceTypeName::Get<T>());
+    return result.access();
   }
 
   /** Returns the type name of the most-derived type of an object of type T,

--- a/common/yaml/yaml_read_archive.h
+++ b/common/yaml/yaml_read_archive.h
@@ -344,7 +344,7 @@ class YamlReadArchive final {
   void VariantHelperImpl(
       const std::string& tag, const char* name, Variant* storage) {
     if (((I == 0) && (tag.empty() || (tag == "?"))) ||
-        IsTagMatch(drake::NiceTypeName::Get<T>(), tag)) {
+        IsTagMatch(drake::NiceTypeName::GetFromStorage<T>(), tag)) {
       T typed_storage{};
       this->Visit(drake::MakeNameValue(name, &typed_storage));
       storage->template emplace<I>(std::move(typed_storage));

--- a/common/yaml/yaml_write_archive.h
+++ b/common/yaml/yaml_write_archive.h
@@ -306,7 +306,7 @@ class YamlWriteArchive final {
 
   template <typename T>
   static std::string GetVariantTag() {
-    const std::string full_name = NiceTypeName::Get<T>();
+    const std::string full_name = NiceTypeName::GetFromStorage<T>();
     if ((full_name == "std::string")
         || (full_name == "double")
         || (full_name == "int")) {

--- a/geometry/geometry_properties.h
+++ b/geometry/geometry_properties.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <typeinfo>
 #include <unordered_map>
 
 #include "fmt/ostream.h"
@@ -334,7 +335,7 @@ class GeometryProperties {
     if constexpr (std::is_same_v<ValueType, Eigen::Vector4d>) {
       const Rgba color =
           GetValueOrThrow<Rgba>("GetProperty", group_name, name, abstract,
-                                NiceTypeName::Get<Eigen::Vector4d>());
+                                typeid(Eigen::Vector4d));
       return ToVector4d(color);
     } else {
       return GetValueOrThrow<ValueType>("GetProperty", group_name, name,
@@ -388,7 +389,7 @@ class GeometryProperties {
       if constexpr (std::is_same_v<ValueType, Eigen::Vector4d>) {
         const Rgba color = GetValueOrThrow<Rgba>(
             "GetPropertyOrDefault", group_name, name, *abstract,
-            NiceTypeName::Get<Eigen::Vector4d>());
+            typeid(Eigen::Vector4d));
         return ToVector4d(color);
       } else {
         // This incurs the cost of copying a stored value.
@@ -470,13 +471,13 @@ class GeometryProperties {
   static const ValueType& GetValueOrThrow(
       const std::string& method, const std::string& group_name,
       const std::string& name, const AbstractValue& abstract,
-      const std::string& nice_type_name = NiceTypeName::Get<ValueType>()) {
+      const std::type_info& requested_type = typeid(ValueType)) {
     const ValueType* value = abstract.maybe_get_value<ValueType>();
     if (value == nullptr) {
       throw std::logic_error(fmt::format(
           "{}(): The property ('{}', '{}') exists, but is of a different type. "
           "Requested '{}', but found '{}'",
-          method, group_name, name, nice_type_name,
+          method, group_name, name, NiceTypeName::Get(requested_type),
           abstract.GetNiceTypeName()));
     }
     return *value;

--- a/solvers/mathematical_program_result.cc
+++ b/solvers/mathematical_program_result.cc
@@ -2,6 +2,8 @@
 
 #include <fmt/format.h>
 
+#include "drake/common/never_destroyed.h"
+
 namespace drake {
 namespace solvers {
 namespace {


### PR DESCRIPTION
Approximately 0.9% of libdrake.so object code in Release builds was due to this caching, but in general practice we don't care about the cost of repeatedly naming the same type.

Code that does care about caching can still opt-in to memoization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15269)
<!-- Reviewable:end -->
