### PR TITLE
Add pybind for SolverId == and !=

### DIFF
--- a/bindings/pydrake/solvers/BUILD.bazel
+++ b/bindings/pydrake/solvers/BUILD.bazel
@@ -402,6 +402,8 @@ drake_py_unittest(
     deps = [
         ":gurobi_py",
         ":mathematicalprogram_py",
+        ":osqp_py",
+        ":scs_py",
         ":snopt_py",
         "//bindings/pydrake:math_py",
         "//bindings/pydrake/common/test_utilities",

--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -3,6 +3,7 @@
 
 #include "pybind11/eigen.h"
 #include "pybind11/functional.h"
+#include "pybind11/operators.h"
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 
@@ -363,7 +364,21 @@ top-level documentation for :py:mod:`pydrake.math`.
 
   py::class_<SolverId>(m, "SolverId", doc.SolverId.doc)
       .def(py::init<std::string>(), py::arg("name"), doc.SolverId.ctor.doc)
-      .def("name", &SolverId::name, doc.SolverId.name.doc);
+      .def("name", &SolverId::name, doc.SolverId.name.doc)
+      .def("__hash__",
+          [](const SolverId& self) { return std::hash<SolverId>{}(self); })
+      .def(
+          "__eq__",
+          [](const SolverId& self, const SolverId& other) {
+            return self == other;
+          },
+          py::is_operator())
+      .def(
+          "__ne__",
+          [](const SolverId& self, const SolverId& other) {
+            return self != other;
+          },
+          py::is_operator());
 
   py::enum_<SolverType>(m, "SolverType", doc.SolverType.doc)
       .value("kClp", SolverType::kClp, doc.SolverType.kClp.doc)

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -1,6 +1,8 @@
 from pydrake.solvers import mathematicalprogram as mp
 from pydrake.solvers.gurobi import GurobiSolver
 from pydrake.solvers.snopt import SnoptSolver
+from pydrake.solvers.scs import ScsSolver
+from pydrake.solvers.osqp import OsqpSolver
 from pydrake.solvers.mathematicalprogram import (
     LinearConstraint,
     MathematicalProgramResult,
@@ -1027,6 +1029,15 @@ class TestMathematicalProgram(unittest.TestCase):
         np.testing.assert_array_equal(cnstr.evaluator().F()[0], F[0])
         np.testing.assert_array_equal(cnstr.evaluator().F()[1], F[1])
         self.assertEqual(len(prog.linear_matrix_inequality_constraints()), 1)
+
+    def test_solver_id(self):
+        self.assertEqual(ScsSolver().solver_id(), ScsSolver().solver_id())
+        self.assertNotEqual(ScsSolver().solver_id(), OsqpSolver().solver_id())
+        # Test the hash function, by checking the set size.
+        self.assertEqual(
+            len({ScsSolver().solver_id(), ScsSolver().solver_id()}), 1)
+        self.assertEqual(
+            len({ScsSolver().solver_id(), OsqpSolver().solver_id()}), 2)
 
     def test_solver_options(self):
         prog = mp.MathematicalProgram()


### PR DESCRIPTION
Previously `ScsSolver().solver_id() == ScsSolver().solver_id()` would return False in Pydrake.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15276)
<!-- Reviewable:end -->
