### PR TITLE
parsing: Fix how parent bodies are resolved for frames attached to joints

### DIFF
--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -686,7 +686,31 @@ const Frame<double>& AddFrameFromSpecification(
       const auto [parent_model_instance, local_name] =
           GetResolvedModelInstanceAndLocalName(frame_spec.AttachedTo(),
                                                model_instance, *plant);
-      parent_frame = &plant->GetFrameByName(local_name, parent_model_instance);
+      if (plant->HasFrameNamed(local_name, parent_model_instance)) {
+        parent_frame =
+            &plant->GetFrameByName(local_name, parent_model_instance);
+      } else {
+        // If there is no frame named `local_name`, the `attached_to` attribute
+        // must be pointing to something we don't create implicit frames for in
+        // Drake. Currently these are models and joints. Models are handled in
+        // the first `if` block, so we're dealing with joints here. Since joints
+        // may end up in a model instance different from the model in which they
+        // were defined, we don't bother to find the joint and use its child
+        // frame. Instead we ask libsdformat to resolve the body associated with
+        // whatever is referenced by the `attached_to` attribute. Since this is
+        // a body, we're assured that its implicit frame exists in the plant.
+        std::string resolved_attached_to_body_name;
+        ThrowAnyErrors(
+            frame_spec.ResolveAttachedToBody(resolved_attached_to_body_name));
+
+        const std::string resolved_attached_to_body_absolute_name =
+            parsing::PrefixName(
+                parsing::GetInstanceScopeName(*plant, model_instance),
+                resolved_attached_to_body_name);
+        parent_frame = parsing::GetScopedFrameByNameMaybe(
+            *plant, resolved_attached_to_body_absolute_name);
+        DRAKE_DEMAND(nullptr != parent_frame);
+      }
     }
   }
   const Frame<double>& frame =


### PR DESCRIPTION
Drake does not create implicit frames for joints, so an error occurs if a joint name is referenced in `//frame/@attached_to`. The fix here is to use libsdformat to resolve for the parent body instead of searching for the frame in the plant.

This also changes uses of `node_index` to `index` as the latter is the preferred API.

/cc @EricCousineau-TRI

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15279)
<!-- Reviewable:end -->
