### PR TITLE
[geometry] Fix style guide nits in convex_set

### DIFF
--- a/geometry/optimization/convex_set.cc
+++ b/geometry/optimization/convex_set.cc
@@ -14,6 +14,8 @@ ConvexSet::ConvexSet(
   DRAKE_DEMAND(ambient_dimension >= 0);
 }
 
+ConvexSet::~ConvexSet() = default;
+
 std::unique_ptr<ConvexSet> ConvexSet::Clone() const { return cloner_(*this); }
 
 std::vector<solvers::Binding<solvers::Constraint>>

--- a/geometry/optimization/convex_set.h
+++ b/geometry/optimization/convex_set.h
@@ -61,7 +61,7 @@ The geometry::optimization tools support:
 */
 class ConvexSet : public ShapeReifier {
  public:
-  virtual ~ConvexSet() {}
+  virtual ~ConvexSet();
 
   /** Creates a unique deep copy of this set. */
   std::unique_ptr<ConvexSet> Clone() const;

--- a/geometry/optimization/hpolyhedron.cc
+++ b/geometry/optimization/hpolyhedron.cc
@@ -2,6 +2,7 @@
 
 #include <limits>
 #include <memory>
+#include <stdexcept>
 
 #include <Eigen/Eigenvalues>
 #include <fmt/format.h>
@@ -47,6 +48,8 @@ HPolyhedron::HPolyhedron(const QueryObject<double>& query_object,
   A_ = Ab_G.first * X_GE.rotation().matrix();
   b_ = Ab_G.second - Ab_G.first * X_GE.translation();
 }
+
+HPolyhedron::~HPolyhedron() = default;
 
 HyperEllipsoid HPolyhedron::MaximumVolumeInscribedEllipsoid() const {
   MathematicalProgram prog;
@@ -124,6 +127,14 @@ HPolyhedron::DoAddPointInNonnegativeScalingConstraints(
       Abar, VectorXd::Constant(m, -std::numeric_limits<double>::infinity()),
       VectorXd::Zero(m), {x, Vector1<Variable>(t)}));
   return constraints;
+}
+
+std::pair<std::unique_ptr<Shape>, math::RigidTransformd>
+HPolyhedron::DoToShapeWithPose() const {
+  throw std::runtime_error(
+      "ToShapeWithPose is not implemented yet for HPolyhedron.  Implementing "
+      "this will likely require additional support from the Convex shape "
+      "class (to support in-memory mesh data, or file I/O).");
 }
 
 void HPolyhedron::ImplementGeometry(const HalfSpace&, void* data) {

--- a/geometry/optimization/hpolyhedron.h
+++ b/geometry/optimization/hpolyhedron.h
@@ -37,7 +37,7 @@ class HPolyhedron final : public ConvexSet {
   // SceneGraph's AABB or OBB representation (for arbitrary objects) pending
   // #15121.
 
-  virtual ~HPolyhedron() {}
+  ~HPolyhedron() final;
 
   /** Returns the half-space representation matrix A. */
   const Eigen::MatrixXd& A() const { return A_; }
@@ -95,12 +95,7 @@ class HPolyhedron final : public ConvexSet {
   // add recommendation here that: "If ambient_dimension() != 3, then consider
   // using the AH polytope representation to project it to 3D."
   std::pair<std::unique_ptr<Shape>, math::RigidTransformd> DoToShapeWithPose()
-      const final {
-    throw std::runtime_error(
-        "ToShapeWithPose is not implemented yet for HPolyhedron.  Implementing "
-        "this will likely require additional support from the Convex shape "
-        "class (to support in-memory mesh data, or file I/O).");
-  }
+      const final;
 
   // Implement support shapes for the ShapeReifier interface.
   using ShapeReifier::ImplementGeometry;

--- a/geometry/optimization/hyperellipsoid.cc
+++ b/geometry/optimization/hyperellipsoid.cc
@@ -1,14 +1,11 @@
 #include "drake/geometry/optimization/hyperellipsoid.h"
 
-#include <limits>
 #include <memory>
 
 #include <Eigen/Eigenvalues>
-#include <fmt/format.h>
 
 #include "drake/math/matrix_util.h"
 #include "drake/math/rotation_matrix.h"
-#include "drake/solvers/solve.h"
 
 namespace drake {
 namespace geometry {
@@ -52,6 +49,8 @@ HyperEllipsoid::HyperEllipsoid(const QueryObject<double>& query_object,
   A_ = A_G * X_GE.rotation().matrix();
   center_ = X_GE.inverse().translation();
 }
+
+HyperEllipsoid::~HyperEllipsoid() = default;
 
 bool HyperEllipsoid::DoPointInSet(const Eigen::Ref<const VectorXd>& x,
                                   double tol) const {

--- a/geometry/optimization/hyperellipsoid.h
+++ b/geometry/optimization/hyperellipsoid.h
@@ -44,7 +44,7 @@ class HyperEllipsoid final : public ConvexSet {
                  GeometryId geometry_id,
                  std::optional<FrameId> expressed_in = std::nullopt);
 
-  virtual ~HyperEllipsoid() {}
+  ~HyperEllipsoid() final;
 
   /** Returns the quadratic form matrix A. */
   const Eigen::MatrixXd& A() const { return A_; }


### PR DESCRIPTION
Subclass constructors must be marked override or final.

Eschew inline functions except for tiny getters / forwarders.

Include what you use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15283)
<!-- Reviewable:end -->
