### PR TITLE
[drake_visualizer] Use drake's native lcmtypes for drawing

### DIFF
--- a/tools/workspace/drake_visualizer/package.BUILD.bazel
+++ b/tools/workspace/drake_visualizer/package.BUILD.bazel
@@ -23,14 +23,6 @@ py_library(
     name = "drake_visualizer_python_deps",
     deps = [
         "@lcm//:lcm-python",
-        # TODO(jwnimmer-tri): The visualizer binary should incorporate its own
-        # build of whatever LCM messages it needs -- we should not need to
-        # supply it with extra dependencies.  For now, we'll use deprecated
-        # Drake targets for these messages.  If this problem is not fixed
-        # prior to the deprecation removal date, we'll have to keep the
-        # dependency around for a little while longer until it is fixed.
-        "@lcmtypes_bot2_core//:lcmtypes_bot2_core_py_nondeprecated",
-        "@lcmtypes_robotlocomotion//:lcmtypes_robotlocomotion_py_nondeprecated",  # noqa
         # TODO(eric.cousineau): Expose VTK Python libraries here for Linux.
     ],
     visibility = ["//visibility:public"],

--- a/tools/workspace/drake_visualizer/repository.bzl
+++ b/tools/workspace/drake_visualizer/repository.bzl
@@ -29,6 +29,7 @@ Argument:
     name: A unique name for this rule.
 """
 
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "patch")
 load("@drake//tools/workspace:os.bzl", "determine_os")
 
 def _impl(repository_ctx):
@@ -39,12 +40,15 @@ def _impl(repository_ctx):
     if os_result.is_macos:
         archive = "dv-0.1.0-406-g4c3e570a-python-3.9.2-qt-5.15.2-vtk-8.2.0-mac-x86_64.tar.gz"  # noqa
         sha256 = "8a13ffa117167fada851acef8535a42d613b71be2200ea3c7139e9fea05782b8"  # noqa
+        python_version = "3.9"
     elif os_result.ubuntu_release == "18.04":
         archive = "dv-0.1.0-406-g4c3e570a-python-3.6.9-qt-5.9.5-vtk-8.2.0-bionic-x86_64-1.tar.gz"  # noqa
         sha256 = "2c477c2f1186cd151710af9a6f50bd3720034ced3c5ed21d977b0a822ac56237"  # noqa
+        python_version = "3.6"
     elif os_result.ubuntu_release == "20.04":
         archive = "dv-0.1.0-406-g4c3e570a-python-3.8.2-qt-5.12.8-vtk-8.2.0-focal-x86_64-1.tar.gz"  # noqa
         sha256 = "282438d7fabd72dddc8a9f5b3b7481b6b6ea53e4355f79f5bda1dae6e258d6be"  # noqa
+        python_version = "3.8"
     else:
         fail("Operating system is NOT supported", attr = os_result)
 
@@ -59,6 +63,18 @@ def _impl(repository_ctx):
         output = root_path,
         sha256 = sha256,
         type = "tar.gz",
+    )
+
+    patch(
+        repository_ctx,
+        patches = [
+            Label("@drake//tools/workspace/drake_visualizer:use_drake_lcmtypes.patch"),  # noqa
+        ],
+        patch_args = [
+            "--directory=lib/python{}/site-packages/director".format(
+                python_version,
+            ),
+        ],
     )
 
     repository_ctx.symlink(

--- a/tools/workspace/drake_visualizer/use_drake_lcmtypes.patch
+++ b/tools/workspace/drake_visualizer/use_drake_lcmtypes.patch
@@ -1,0 +1,110 @@
+Respell the imported lcmtypes to match Drake's build system.
+
+--- drakevisualizer.py	2020-07-15 08:51:01.000000000 -0700
++++ drakevisualizer.py	2021-06-30 21:52:04.169503858 -0700
+@@ -15,22 +15,8 @@
+ from director import packagepath
+ from director.fieldcontainer import FieldContainer
+ 
+-import bot_core as lcmbot
+-
+-# Currently, viewer lcm message types are in bot_core_lcmtypes and
+-# robotlocomotion-lcmtypes, but drake only builds bot_core_lcmtypes.
+-# When drake starts using robotlocomotion-lcmtypes, then the following
+-# import can be used instead of getting viewer messages from bot_core_lcmtypes.
+-#import robotlocomotion as lcmrl
+-lcmrl = lcmbot
+-
+-# pydrake is only used to provide an additional source of mesh package lookup
+-# paths, so failing to find it should not be fatal
+-try:
+-    import pydrake
+-    HAVE_PYDRAKE = True
+-except ImportError:
+-    HAVE_PYDRAKE = False
++import drake
++import pydrake
+ 
+ from PythonQt import QtGui
+ 
+@@ -44,22 +30,22 @@
+     @staticmethod
+     def createPolyDataFromPrimitive(geom):
+ 
+-        if geom.type == lcmrl.viewer_geometry_data_t.BOX:
++        if geom.type == drake.lcmt_viewer_geometry_data.BOX:
+             d = DebugData()
+             d.addCube(dimensions=geom.float_data[0:3], center=[0,0,0])
+             return d.getPolyData()
+ 
+-        elif geom.type == lcmrl.viewer_geometry_data_t.SPHERE:
++        elif geom.type == drake.lcmt_viewer_geometry_data.SPHERE:
+             d = DebugData()
+             d.addSphere(center=(0,0,0), radius=geom.float_data[0])
+             return d.getPolyData()
+ 
+-        elif geom.type == lcmrl.viewer_geometry_data_t.CYLINDER:
++        elif geom.type == drake.lcmt_viewer_geometry_data.CYLINDER:
+             d = DebugData()
+             d.addCylinder(center=(0,0,0), axis=(0,0,1), radius=geom.float_data[0], length=geom.float_data[1])
+             return d.getPolyData()
+ 
+-        elif geom.type == lcmrl.viewer_geometry_data_t.CAPSULE:
++        elif geom.type == drake.lcmt_viewer_geometry_data.CAPSULE:
+             d = DebugData()
+             radius = geom.float_data[0]
+             length = geom.float_data[1]
+@@ -68,7 +54,7 @@
+             d.addSphere(center=(0,0,-length/2.0), radius=radius)
+             return d.getPolyData()
+ 
+-        elif hasattr(lcmrl.viewer_geometry_data_t, "ELLIPSOID") and geom.type == lcmrl.viewer_geometry_data_t.ELLIPSOID:
++        elif hasattr(drake.lcmt_viewer_geometry_data, "ELLIPSOID") and geom.type == drake.lcmt_viewer_geometry_data.ELLIPSOID:
+             d = DebugData()
+             radii = geom.float_data[0:3]
+             d.addEllipsoid(center=(0,0,0), radii=radii)
+@@ -191,8 +177,7 @@
+ 
+         if Geometry.PackageMap is None:
+             m = packagepath.PackageMap()
+-            if HAVE_PYDRAKE:
+-                m.populateFromSearchPaths([pydrake.getDrakePath()])
++            m.populateFromSearchPaths([pydrake.getDrakePath()])
+             m.populateFromEnvironment(['DRAKE_PACKAGE_PATH', 'ROS_PACKAGE_PATH'])
+             Geometry.PackageMap = m
+ 
+@@ -264,7 +249,7 @@
+ 
+         visInfo = None
+ 
+-        if geom.type != lcmrl.viewer_geometry_data_t.MESH:
++        if geom.type != drake.lcmt_viewer_geometry_data.MESH:
+             polyDataList = [Geometry.createPolyDataFromPrimitive(geom)]
+         elif not geom.string_data:
+             polyDataList = [Geometry.createPolyDataFromMeshMessage(geom)]
+@@ -321,11 +306,9 @@
+         self.sendStatusMessage('loaded')
+ 
+     def _addSubscribers(self):
+-        self.subscribers.append(lcmUtils.addSubscriber('DRAKE_VIEWER_LOAD_ROBOT', lcmrl.viewer_load_robot_t, self.onViewerLoadRobot))
+-        self.subscribers.append(lcmUtils.addSubscriber('DRAKE_VIEWER_ADD_ROBOT', lcmrl.viewer_load_robot_t, self.onViewerAddRobot))
+-        self.subscribers.append(lcmUtils.addSubscriber('DRAKE_VIEWER_DRAW', lcmrl.viewer_draw_t, self.onViewerDraw))
+-        self.subscribers.append(lcmUtils.addSubscriber('DRAKE_PLANAR_LIDAR_.*', lcmbot.planar_lidar_t, self.onPlanarLidar, callbackNeedsChannel=True))
+-        self.subscribers.append(lcmUtils.addSubscriber('DRAKE_POINTCLOUD_.*', lcmbot.pointcloud_t, self.onPointCloud, callbackNeedsChannel=True))
++        self.subscribers.append(lcmUtils.addSubscriber('DRAKE_VIEWER_LOAD_ROBOT', drake.lcmt_viewer_load_robot, self.onViewerLoadRobot))
++        self.subscribers.append(lcmUtils.addSubscriber('DRAKE_VIEWER_ADD_ROBOT', drake.lcmt_viewer_load_robot, self.onViewerAddRobot))
++        self.subscribers.append(lcmUtils.addSubscriber('DRAKE_VIEWER_DRAW', drake.lcmt_viewer_draw, self.onViewerDraw))
+ 
+     def _removeSubscribers(self):
+         for sub in self.subscribers:
+@@ -408,8 +391,8 @@
+             del self.robots[robotNum]
+ 
+     def sendStatusMessage(self, message):
+-        msg = lcmrl.viewer_command_t()
+-        msg.command_type = lcmrl.viewer_command_t.STATUS
++        msg = drake.lcmt_viewer_command()
++        msg.command_type = drake.lcmt_viewer_command.STATUS
+         msg.command_data = message
+         lcmUtils.publish('DRAKE_VIEWER_STATUS', msg)
+ 

--- a/tools/workspace/lcmtypes_bot2_core/package.BUILD.bazel
+++ b/tools/workspace/lcmtypes_bot2_core/package.BUILD.bazel
@@ -70,10 +70,7 @@ lcm_py_library(
 py_library(
     name = "lcmtypes_bot2_core_py_nondeprecated",
     deps = ["lcmtypes_bot2_core_py"],
-    visibility = [
-        "@drake_visualizer//:__pkg__",
-        "@lcmtypes_robotlocomotion//:__pkg__",
-    ],
+    visibility = ["@lcmtypes_robotlocomotion//:__pkg__"],
 )
 
 CMAKE_PACKAGE = "bot2-core-lcmtypes"

--- a/tools/workspace/lcmtypes_robotlocomotion/package.BUILD.bazel
+++ b/tools/workspace/lcmtypes_robotlocomotion/package.BUILD.bazel
@@ -51,12 +51,6 @@ lcm_py_library(
     deps = ["@lcmtypes_bot2_core//:lcmtypes_bot2_core_py"],
 )
 
-py_library(
-    name = "lcmtypes_robotlocomotion_py_nondeprecated",
-    deps = ["lcmtypes_robotlocomotion_py"],
-    visibility = ["@drake_visualizer//:__pkg__"],
-)
-
 CMAKE_PACKAGE = "robotlocomotion-lcmtypes"
 
 cmake_config(


### PR DESCRIPTION
Remove support for bot_core based visualization of pointcloud and lidar.

Towards #14362 as the final step of removing use of bot_core lcmtypes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15284)
<!-- Reviewable:end -->
