### PR TITLE
geometry:optimization: AddPointInNonnegativeScalingConstraints

### DIFF
--- a/geometry/optimization/convex_set.cc
+++ b/geometry/optimization/convex_set.cc
@@ -1,5 +1,6 @@
 #include "drake/geometry/optimization/convex_set.h"
 
+#include <limits>
 #include <memory>
 
 namespace drake {
@@ -14,6 +15,19 @@ ConvexSet::ConvexSet(
 }
 
 std::unique_ptr<ConvexSet> ConvexSet::Clone() const { return cloner_(*this); }
+
+std::vector<solvers::Binding<solvers::Constraint>>
+ConvexSet::AddPointInNonnegativeScalingConstraints(
+    solvers::MathematicalProgram* prog,
+    const Eigen::Ref<const solvers::VectorXDecisionVariable>& x,
+    const symbolic::Variable& t) const {
+  DRAKE_DEMAND(x.size() == ambient_dimension());
+  std::vector<solvers::Binding<solvers::Constraint>> constraints =
+      DoAddPointInNonnegativeScalingConstraints(prog, x, t);
+  constraints.emplace_back(prog->AddBoundingBoxConstraint(
+      0, std::numeric_limits<double>::infinity(), t));
+  return constraints;
+}
 
 }  // namespace optimization
 }  // namespace geometry

--- a/geometry/optimization/hpolyhedron.h
+++ b/geometry/optimization/hpolyhedron.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <optional>
 #include <utility>
+#include <vector>
 
 #include "drake/geometry/optimization/convex_set.h"
 #include "drake/geometry/optimization/hyperellipsoid.h"
@@ -77,6 +78,12 @@ class HPolyhedron final : public ConvexSet {
       solvers::MathematicalProgram* prog,
       const Eigen::Ref<const solvers::VectorXDecisionVariable>& vars)
       const final;
+
+  std::vector<solvers::Binding<solvers::Constraint>>
+  DoAddPointInNonnegativeScalingConstraints(
+      solvers::MathematicalProgram* prog,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>& x,
+      const symbolic::Variable& t) const final;
 
   // TODO(russt): Implement DoToShapeWithPose.  Currently we don't have a Shape
   // that can consume this output.  The obvious candidate is Convex, that class

--- a/geometry/optimization/hyperellipsoid.h
+++ b/geometry/optimization/hyperellipsoid.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <optional>
 #include <utility>
+#include <vector>
 
 #include "drake/geometry/optimization/convex_set.h"
 
@@ -64,6 +65,10 @@ class HyperEllipsoid final : public ConvexSet {
   but how does that translate into a numerical precision? */
   using ConvexSet::ToShapeWithPose;
 
+  /** Constructs the L₂-norm unit ball in @p dim dimensions, {x | |x|₂ <= 1 }.
+   */
+  static HyperEllipsoid MakeUnitBall(int dim);
+
  private:
   bool DoPointInSet(const Eigen::Ref<const Eigen::VectorXd>& x,
                     double tol) const final;
@@ -72,6 +77,12 @@ class HyperEllipsoid final : public ConvexSet {
       solvers::MathematicalProgram* prog,
       const Eigen::Ref<const solvers::VectorXDecisionVariable>& vars)
       const final;
+
+  std::vector<solvers::Binding<solvers::Constraint>>
+  DoAddPointInNonnegativeScalingConstraints(
+      solvers::MathematicalProgram* prog,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>& x,
+      const symbolic::Variable& t) const final;
 
   std::pair<std::unique_ptr<Shape>, math::RigidTransformd> DoToShapeWithPose()
       const final;


### PR DESCRIPTION
This is another well-defined operation on convex sets, and it is the workhorse for the MIP formulation of the shortest-path problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15286)
<!-- Reviewable:end -->
