### PR TITLE
[fem] Upgrading rigid-deformable contact to use Bvhs

### DIFF
--- a/multibody/fixed_fem/dev/BUILD.bazel
+++ b/multibody/fixed_fem/dev/BUILD.bazel
@@ -23,6 +23,7 @@ drake_cc_library(
         "//geometry:geometry_ids",
         "//geometry:proximity_properties",
         "//geometry:shape_specification",
+        "//geometry/proximity:bvh",
         "//geometry/proximity:make_box_mesh",
         "//geometry/proximity:make_capsule_mesh",
         "//geometry/proximity:make_cylinder_mesh",
@@ -102,9 +103,10 @@ drake_cc_library(
     hdrs = ["deformable_contact.h"],
     deps = [
         "//common:default_scalars",
+        "//geometry/proximity:bvh",
+        "//geometry/proximity:deformable_volume_mesh",
         "//geometry/proximity:posed_half_space",
         "//geometry/proximity:surface_mesh",
-        "//geometry/proximity:volume_mesh",
     ],
 )
 

--- a/multibody/fixed_fem/dev/collision_objects.cc
+++ b/multibody/fixed_fem/dev/collision_objects.cc
@@ -123,9 +123,16 @@ template <typename T>
 template <typename ShapeType>
 void CollisionObjects<T>::MakeRigidRepresentation(const ShapeType& shape,
                                                   const ReifyData& data) {
+  // This ("fem/dev", "resolution_hint") property is a stopgap. We don't want
+  // to use hydro's resolution hint as that would needlessly entangle this
+  // functionality with that. This property name isn't the *final* name, but,
+  // while in dev, it gives us some power to articulate resolution.
+  // TODO(SeanCurtis-TRI) Define a final name for this property and document it
+  // appropriately.
   rigid_representations_[data.id] = {
-      std::make_unique<SurfaceMesh<double>>(
-          MakeRigidSurfaceMesh(shape, kDefaultResolutionHint)),
+      std::make_unique<SurfaceMesh<double>>(MakeRigidSurfaceMesh(
+          shape, data.properties.GetPropertyOrDefault(
+                     "fem/dev", "resolution_hint", kDefaultResolutionHint))),
       data.properties};
   geometry_ids_.emplace_back(data.id);
 }

--- a/multibody/fixed_fem/dev/deformable_contact.h
+++ b/multibody/fixed_fem/dev/deformable_contact.h
@@ -6,8 +6,9 @@
 #include <Eigen/Dense>
 
 #include "drake/common/eigen_types.h"
+#include "drake/geometry/proximity/bvh.h"
+#include "drake/geometry/proximity/deformable_volume_mesh.h"
 #include "drake/geometry/proximity/surface_mesh.h"
-#include "drake/geometry/proximity/volume_mesh.h"
 #include "drake/math/rigid_transform.h"
 
 namespace drake {
@@ -87,10 +88,12 @@ class DeformableContactSurface {
 
  If there is no contact, the result will be empty.
 
- @param tet_mesh_D   The tetrahedral mesh, with vertex positions measured and
-                     expressed in the *deformable* mesh's frame D.
+ @param tet_mesh_D   The deformable tetrahedral mesh, with vertex positions
+                     measured and expressed in the *deformable* mesh's frame D.
  @param tri_mesh_R   The triangle mesh, with vertex positions measured and
                      expressed in the *rigid* mesh's frame R.
+ @param bvh_R        The bounding volume hierarchy for the triangle mesh,
+                     measured and expressed in the *rigid* mesh's frame R.
  @param X_DR         The pose of the triangle mesh in the volume mesh's frame.
  @returns The collection of contact data associated with an implicit contact
           surface formed by the intersection of the volume and surface meshes.
@@ -98,8 +101,10 @@ class DeformableContactSurface {
           "empty".  */
 template <typename T>
 DeformableContactSurface<T> ComputeTetMeshTriMeshContact(
-    const geometry::VolumeMesh<T>& tet_mesh_D,
+    const geometry::internal::DeformableVolumeMesh<T>& tet_mesh_D,
     const geometry::SurfaceMesh<double>& tri_mesh_R,
+    const geometry::internal::Bvh<geometry::internal::Obb,
+                                  geometry::SurfaceMesh<double>>& bvh_R,
     const math::RigidTransform<T>& X_DR);
 }  // namespace fixed_fem
 }  // namespace multibody

--- a/multibody/fixed_fem/dev/deformable_rigid_manager.h
+++ b/multibody/fixed_fem/dev/deformable_rigid_manager.h
@@ -310,7 +310,8 @@ class DeformableRigidManager final
 
   /* Geometries temporarily managed by DeformableRigidManager. In the future,
    SceneGraph will manage all the geometries. */
-  mutable std::vector<geometry::VolumeMesh<T>> deformable_meshes_{};
+  mutable std::vector<geometry::internal::DeformableVolumeMesh<T>>
+      deformable_meshes_;
   mutable internal::CollisionObjects<T> collision_objects_;
 };
 }  // namespace fixed_fem

--- a/multibody/fixed_fem/dev/test/collision_objects_test.cc
+++ b/multibody/fixed_fem/dev/test/collision_objects_test.cc
@@ -38,6 +38,12 @@ using geometry::internal::MakeSphereSurfaceMesh;
 const char* const dummy_group_name = "group";
 const char* const dummy_property_name = "property";
 const double dummy_property_value = 3.14;
+// We use a large resolution hint for this test to keep the meshes coarse and
+// the test cheap.
+constexpr double kTestResolutionHint = 0.75;
+
+using DutBvh = geometry::internal::Bvh<geometry::internal::Obb,
+                                       geometry::SurfaceMesh<double>>;
 
 class CollisionObjectsTest : public ::testing::Test {
  protected:
@@ -45,6 +51,9 @@ class CollisionObjectsTest : public ::testing::Test {
     // Make some dummy proximity properties.
     proximity_properties_.AddProperty(dummy_group_name, dummy_property_name,
                                       dummy_property_value);
+
+    proximity_properties_.AddProperty("fem/dev", "resolution_hint",
+                                      kTestResolutionHint);
   }
 
   void VerifyProximityProperties(GeometryId id) const {
@@ -68,9 +77,11 @@ TEST_F(CollisionObjectsTest, AddSphere) {
   VerifyProximityProperties(id);
 
   const SurfaceMesh<double> expected_surface_mesh =
-      MakeSphereSurfaceMesh<double>(
-          sphere, CollisionObjects<double>::kDefaultResolutionHint);
+      MakeSphereSurfaceMesh<double>(sphere, kTestResolutionHint);
   EXPECT_TRUE(expected_surface_mesh.Equal(collision_objects_.mesh(id)));
+
+  const DutBvh expected_bvh(expected_surface_mesh);
+  EXPECT_TRUE(expected_bvh.Equal(collision_objects_.bvh(id)));
 }
 
 TEST_F(CollisionObjectsTest, AddBox) {
@@ -84,6 +95,9 @@ TEST_F(CollisionObjectsTest, AddBox) {
   const SurfaceMesh<double> expected_surface_mesh =
       MakeBoxSurfaceMesh<double>(box, 1e10);
   EXPECT_TRUE(expected_surface_mesh.Equal(collision_objects_.mesh(id)));
+
+  const DutBvh expected_bvh(expected_surface_mesh);
+  EXPECT_TRUE(expected_bvh.Equal(collision_objects_.bvh(id)));
 }
 
 TEST_F(CollisionObjectsTest, AddCylinder) {
@@ -94,9 +108,11 @@ TEST_F(CollisionObjectsTest, AddCylinder) {
   VerifyProximityProperties(id);
 
   const SurfaceMesh<double> expected_surface_mesh =
-      MakeCylinderSurfaceMesh<double>(
-          cylinder, CollisionObjects<double>::kDefaultResolutionHint);
+      MakeCylinderSurfaceMesh<double>(cylinder, kTestResolutionHint);
   EXPECT_TRUE(expected_surface_mesh.Equal(collision_objects_.mesh(id)));
+
+  const DutBvh expected_bvh(expected_surface_mesh);
+  EXPECT_TRUE(expected_bvh.Equal(collision_objects_.bvh(id)));
 }
 
 TEST_F(CollisionObjectsTest, AddCapsule) {
@@ -107,22 +123,25 @@ TEST_F(CollisionObjectsTest, AddCapsule) {
   VerifyProximityProperties(id);
 
   const SurfaceMesh<double> expected_surface_mesh =
-      MakeCapsuleSurfaceMesh<double>(
-          capsule, CollisionObjects<double>::kDefaultResolutionHint);
+      MakeCapsuleSurfaceMesh<double>(capsule, kTestResolutionHint);
   EXPECT_TRUE(expected_surface_mesh.Equal(collision_objects_.mesh(id)));
+
+  const DutBvh expected_bvh(expected_surface_mesh);
+  EXPECT_TRUE(expected_bvh.Equal(collision_objects_.bvh(id)));
 }
 
 TEST_F(CollisionObjectsTest, AddEllipsoid) {
   const GeometryId id = GeometryId::get_new_id();
   const Ellipsoid ellipsoid(0.123, 0.456, 0.789);
   collision_objects_.AddCollisionObject(id, ellipsoid, proximity_properties_);
-
   VerifyProximityProperties(id);
 
   const SurfaceMesh<double> expected_surface_mesh =
-      MakeEllipsoidSurfaceMesh<double>(
-          ellipsoid, CollisionObjects<double>::kDefaultResolutionHint);
+      MakeEllipsoidSurfaceMesh<double>(ellipsoid, kTestResolutionHint);
   EXPECT_TRUE(expected_surface_mesh.Equal(collision_objects_.mesh(id)));
+
+  const DutBvh expected_bvh(expected_surface_mesh);
+  EXPECT_TRUE(expected_bvh.Equal(collision_objects_.bvh(id)));
 }
 
 TEST_F(CollisionObjectsTest, AddConvex) {
@@ -136,6 +155,9 @@ TEST_F(CollisionObjectsTest, AddConvex) {
   const SurfaceMesh<double> expected_surface_mesh =
       ReadObjToSurfaceMesh(convex.filename(), convex.scale());
   EXPECT_TRUE(expected_surface_mesh.Equal(collision_objects_.mesh(id)));
+
+  const DutBvh expected_bvh(expected_surface_mesh);
+  EXPECT_TRUE(expected_bvh.Equal(collision_objects_.bvh(id)));
 }
 
 TEST_F(CollisionObjectsTest, AddMesh) {
@@ -149,6 +171,9 @@ TEST_F(CollisionObjectsTest, AddMesh) {
   const SurfaceMesh<double> expected_surface_mesh =
       ReadObjToSurfaceMesh(mesh.filename(), mesh.scale());
   EXPECT_TRUE(expected_surface_mesh.Equal(collision_objects_.mesh(id)));
+
+  const DutBvh expected_bvh(expected_surface_mesh);
+  EXPECT_TRUE(expected_bvh.Equal(collision_objects_.bvh(id)));
 }
 
 TEST_F(CollisionObjectsTest, AddHalfSpace) {


### PR DESCRIPTION
This improves the performance of deformable-rigid contact computation by making use of Bvh.

 - Upgraded `deformable_contact.*` API
     - it consumes a `DeformableVolumeMesh` and a `Bvh` for the rigid collision object.
 - `CollisionObjects` now include bvh for the surface mesh.
 - `DeformableRigidManager` tracks `DeformableVolumeMesh` instead of `VolumeMesh`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15287)
<!-- Reviewable:end -->
