### PR TITLE
parsing: Fix joint pose computation when using frames as joint parent or child

### DIFF
--- a/multibody/parsing/test/sdf_parser_test/frames_as_joint_parent_or_child.sdf
+++ b/multibody/parsing/test/sdf_parser_test/frames_as_joint_parent_or_child.sdf
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<sdf version="1.8">
+  <model name="parent_model">
+    <!-- Testing frames attached to links in the same model -->
+    <link name="L1"/>
+    <link name="L2"/>
+
+    <frame name="L1_offset" attached_to="L1">
+      <pose>1 2 3   0 0 0</pose>
+    </frame>
+    <frame name="L2_offset" attached_to="L2">
+      <pose>4 5 6   0 0 0</pose>
+    </frame>
+
+    <joint name="J1" type="fixed">
+      <parent>L1_offset</parent>
+      <child>L2_offset</child>
+    </joint>
+
+    <!-- Testing frames attached to links in the other (nested) models -->
+    <model name="M1">
+      <link name="base_link"/>
+    </model>
+    <model name="M2">
+      <link name="base_link"/>
+    </model>
+
+    <frame name="M1_base_link_offset" attached_to="M1::base_link">
+      <pose>1 2 3   0 0 0</pose>
+    </frame>
+    <frame name="M2_base_link_offset" attached_to="M2::base_link">
+      <pose>4 5 6   0 0 0</pose>
+    </frame>
+
+    <joint name="J2" type="fixed">
+      <parent>M1_base_link_offset</parent>
+      <child>M2_base_link_offset</child>
+    </joint>
+  </model>
+</sdf>


### PR DESCRIPTION
This fixes the case where  `//joint/parent` or `//joint/child` is a frame instead of a link and that frame has a non-identity pose. The poses of the frames were being ignored because we incorrectly computing `X_PJ` and `X_CJ`. Instead of resolving these poses relative to the parent or child **bodies**, we were resolving them relative to the names in `//joint/parent` or `//joint/child`, which may  reference frames instead of bodies.

/cc @EricCousineau-TRI

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15290)
<!-- Reviewable:end -->
