### PR TITLE
[workspace] Upgrade gtest to latest release 1.11.0

### DIFF
--- a/tools/workspace/gtest/dont-define-test-f.patch
+++ b/tools/workspace/gtest/dont-define-test-f.patch
@@ -1,0 +1,23 @@
+Use GTEST_DONT_DEFINE_TEST_F to guard TEST_F
+
+Per the documentation, there should be one like-named toggle per macro,
+they should not share a toggle.
+
+--- googletest/include/gtest/gtest.h	2021-06-11 10:42:26.000000000 -0700
++++ googletest/include/gtest/gtest.h	2021-07-01 10:46:26.275471431 -0700
+@@ -2380,11 +2380,12 @@
+ //   }
+ //
+ // GOOGLETEST_CM0011 DO NOT DELETE
+-#if !GTEST_DONT_DEFINE_TEST
+-#define TEST_F(test_fixture, test_name)\
++#define GTEST_TEST_F(test_fixture, test_name)\
+   GTEST_TEST_(test_fixture, test_name, test_fixture, \
+               ::testing::internal::GetTypeId<test_fixture>())
+-#endif  // !GTEST_DONT_DEFINE_TEST
++#if !GTEST_DONT_DEFINE_TEST_F
++#define TEST_F(test_fixture, test_name) GTEST_TEST_F(test_fixture, test_name)
++#endif  // !GTEST_DONT_DEFINE_TEST_F
+ 
+ // Returns a path to temporary directory.
+ // Tries to determine an appropriate directory for the platform.

--- a/tools/workspace/gtest/repository.bzl
+++ b/tools/workspace/gtest/repository.bzl
@@ -8,8 +8,11 @@ def gtest_repository(
     github_archive(
         name = name,
         repository = "google/googletest",
-        commit = "release-1.10.0",
-        sha256 = "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb",  # noqa
+        commit = "release-1.11.0",
+        sha256 = "b4870bf121ff7795ba20d20bcdd8627b8e088f2d1dab299a031c1034eddc93d5",  # noqa
         build_file = "@drake//tools/workspace/gtest:package.BUILD.bazel",
+        patches = [
+            "@drake//tools/workspace/gtest:dont-define-test-f.patch",
+        ],
         mirrors = mirrors,
     )


### PR DESCRIPTION
I've filed the patch upstream at https://github.com/google/googletest/pull/3472.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15291)
<!-- Reviewable:end -->
