### PR TITLE
Tweak simple contact surface vis example

### DIFF
--- a/examples/scene_graph/simple_contact_surface_vis.cc
+++ b/examples/scene_graph/simple_contact_surface_vis.cc
@@ -252,13 +252,23 @@ class ContactResultMaker final : public LeafSystem<double> {
         tri_msg.pressure_B = field.EvaluateAtVertex(face.vertex(1));
         tri_msg.pressure_C = field.EvaluateAtVertex(face.vertex(2));
 
-        // Face contact *traction* and *slip velocity* data.
-        write_double3(Vector3<double>(0, 0.2, 0), quad_msg.vt_BqAq_W);
-        write_double3(Vector3<double>(0, -0.2, 0), quad_msg.traction_Aq_W);
+        // Fake contact *traction* and *slip velocity* data, with some
+        // variations across different data instances. The variation allows one
+        // to appreciate the differences among the vector scaling models for
+        // hydroelastics (fixed-length, scaled, and auto-scale). Without the
+        // variation, there's no visible difference between the fixed-length
+        // mode and the auto-scale mode.
+        write_double3(Vector3<double>(0, 0.2 + (j * 0.005), 0),
+                      quad_msg.vt_BqAq_W);
+        write_double3(Vector3<double>(0, -0.2 - (j * 0.005), 0),
+                      quad_msg.traction_Aq_W);
       }
-      // Fake contact *force* and *moment* data.
-      write_double3(Vector3<double>(1, 0, 0), surface_msg.force_C_W);
-      write_double3(Vector3<double>(0, 0, 1), surface_msg.moment_C_W);
+      // Fake contact *force* and *moment* data, with some variations across
+      // different data instances to facilitate visualizer testing (see above).
+      write_double3(Vector3<double>(1.2 * (i + 1), 0, 0),
+                    surface_msg.force_C_W);
+      write_double3(Vector3<double>(0, 0, 0.5 * (i + 1)),
+                    surface_msg.moment_C_W);
     }
 
     // Point pairs.


### PR DESCRIPTION
Introduce some variations in the fake contact data to make testing easier. Without the variations, there is no visual difference
between the fixed-length mode and the auto-scale mode when visualizing vector quantities for hydroelastics contact.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15299)
<!-- Reviewable:end -->
