### PR TITLE
Deformable body distance field

### DIFF
--- a/multibody/fixed_fem/dev/BUILD.bazel
+++ b/multibody/fixed_fem/dev/BUILD.bazel
@@ -116,6 +116,23 @@ drake_cc_library(
     hdrs = ["deformable_contact_data.h"],
     deps = [
         ":deformable_rigid_contact_pair",
+        ":reference_deformable_geometry",
+    ],
+)
+
+drake_cc_library(
+    name = "reference_deformable_geometry",
+    srcs = [
+        "reference_deformable_geometry.cc",
+    ],
+    hdrs = [
+        "reference_deformable_geometry.h",
+    ],
+    deps = [
+        "//common:default_scalars",
+        "//common:essential",
+        "//geometry/proximity:mesh_field",
+        "//geometry/proximity:volume_mesh",
     ],
 )
 
@@ -136,6 +153,7 @@ drake_cc_library(
         ":fem_model_base",
         ":linear_constitutive_model",
         ":linear_simplex_element",
+        ":mesh_utilities",
         "//common:essential",
         "//geometry/proximity:volume_mesh",
         "//multibody/fem:simplex_gaussian_quadrature",
@@ -179,6 +197,7 @@ drake_cc_library(
     srcs = ["deformable_visualizer.cc"],
     hdrs = ["deformable_visualizer.h"],
     deps = [
+        ":reference_deformable_geometry",
         "//common:essential",
         "//geometry/proximity:sorted_triplet",
         "//geometry/proximity:volume_mesh",
@@ -453,8 +472,10 @@ drake_cc_library(
         "mesh_utilities.h",
     ],
     deps = [
+        ":reference_deformable_geometry",
         "//common:default_scalars",
         "//common:essential",
+        "//geometry:scene_graph",
         "//geometry/proximity:make_box_mesh",
         "//geometry/proximity:volume_mesh",
         "//math:geometric_transform",

--- a/multibody/fixed_fem/dev/deformable_model.cc
+++ b/multibody/fixed_fem/dev/deformable_model.cc
@@ -15,7 +15,7 @@ namespace fem {
 
 template <typename T>
 SoftBodyIndex DeformableModel<T>::RegisterDeformableBody(
-    const geometry::VolumeMesh<T>& mesh, std::string name,
+    internal::ReferenceDeformableGeometry<T> geometry, std::string name,
     const DeformableBodyConfig<T>& config,
     geometry::ProximityProperties proximity_props) {
   /* Throw if name is not unique. */
@@ -30,14 +30,15 @@ SoftBodyIndex DeformableModel<T>::RegisterDeformableBody(
   switch (config.material_model()) {
     case MaterialModel::kLinear:
       RegisterDeformableBodyHelper<LinearConstitutiveModel>(
-          mesh, std::move(name), config);
+          geometry.mesh(), std::move(name), config);
       break;
     case MaterialModel::kCorotated:
-      RegisterDeformableBodyHelper<CorotatedModel>(mesh, std::move(name),
-                                                   config);
+      RegisterDeformableBodyHelper<CorotatedModel>(geometry.mesh(),
+                                                   std::move(name), config);
       break;
   }
   proximity_properties_.emplace_back(std::move(proximity_props));
+  reference_configuration_geometries_.emplace_back(std::move(geometry));
   return body_index;
 }
 
@@ -119,7 +120,6 @@ void DeformableModel<T>::RegisterDeformableBodyHelper(
   model_discrete_states_.emplace_back(discrete_state);
 
   fem_models_.emplace_back(std::move(fem_model));
-  reference_configuration_meshes_.emplace_back(mesh);
   names_.emplace_back(std::move(name));
 }
 

--- a/multibody/fixed_fem/dev/deformable_model.h
+++ b/multibody/fixed_fem/dev/deformable_model.h
@@ -10,6 +10,7 @@
 #include "drake/geometry/proximity/volume_mesh.h"
 #include "drake/multibody/fixed_fem/dev/deformable_body_config.h"
 #include "drake/multibody/fixed_fem/dev/fem_model_base.h"
+#include "drake/multibody/fixed_fem/dev/mesh_utilities.h"
 #include "drake/multibody/plant/physical_model.h"
 
 namespace drake {
@@ -19,7 +20,8 @@ namespace fem {
 /** %DeformableModel implements the interface in PhysicalModel and provides the
  functionalities to specify deformable bodies. Unlike rigid bodies, the shape of
  deformable bodies can change in a simulation. Each deformable body is modeled
- as a volumetric mesh with persisting topology and changing vertex positions.
+ as a volumetric mesh with persisting topology, changing vertex positions, and
+ an approximated signed distance field.
 
  Deformable bodies can only be added, but not deleted. Each deformable body is
  uniquely identified by its index, which is equal to the number of deformable
@@ -35,10 +37,11 @@ namespace fem {
  and 3j + 2 in the i-th VectorX from the output port.
 
  The connectivity of the meshes representing the deformable bodies and their
- initial positions can be queried via `reference_configuration_meshes()` which
- returns an std::vector of volume meshes. The i-th mesh stores the connectivity
- for body i, which does not change throughout the simulation, as well as the
- initial positions of the vertices of the i-th body.
+ initial positions can be queried via `reference_configuration_geometries()`
+ which returns the geometries of the deformable bodies at the reference
+ configuration. The i-th mesh stores the connectivity for body i, which does not
+ change throughout the simulation, as well as the initial positions of the
+ vertices of the i-th body.
 
  Simple zero DirichletBoundaryCondition can be configured via
  `SetRegisteredBodyInWall()`.
@@ -69,7 +72,7 @@ class DeformableModel final : public multibody::internal::PhysicalModel<T> {
    @throw std::exception if `name` is not distinct from names of all previously
    registered bodies. */
   SoftBodyIndex RegisterDeformableBody(
-      const geometry::VolumeMesh<T>& mesh, std::string name,
+      internal::ReferenceDeformableGeometry<T> geometry, std::string name,
       const DeformableBodyConfig<T>& config,
       geometry::ProximityProperties proximity_props);
 
@@ -84,7 +87,7 @@ class DeformableModel final : public multibody::internal::PhysicalModel<T> {
                                 double distance_tolerance = 1e-6);
 
   /** Returns the number of deformable bodies registered. */
-  int num_bodies() const { return reference_configuration_meshes_.size(); }
+  int num_bodies() const { return reference_configuration_geometries_.size(); }
 
   /** Returns the FEM model of the selected deformable body. Each deformable
    body is modeled as an individual FEM model. */
@@ -101,12 +104,12 @@ class DeformableModel final : public multibody::internal::PhysicalModel<T> {
     return discrete_state_indexes_;
   }
 
-  /** Returns the volume meshes of the deformable bodies at reference
-   configuration. The meshes have the same order as the registration of their
-   corresponding deformable bodies. */
-  const std::vector<geometry::VolumeMesh<T>>& reference_configuration_meshes()
-      const {
-    return reference_configuration_meshes_;
+  /** Returns the geometries of the deformable bodies at reference
+   configuration. The geometries have the same order as the registration of
+   their corresponding deformable bodies. */
+  const std::vector<internal::ReferenceDeformableGeometry<T>>&
+  reference_configuration_geometries() const {
+    return reference_configuration_geometries_;
   }
 
   /* Returns the proximity properties of the registered deformable bodies in the
@@ -154,12 +157,13 @@ class DeformableModel final : public multibody::internal::PhysicalModel<T> {
   const MultibodyPlant<T>* plant_{nullptr};
   /* The FemModels owned by this DeformableModel. One per deformable body. */
   std::vector<std::unique_ptr<FemModelBase<T>>> fem_models_{};
-  /* Initial meshes for all deformable bodies at time of registration. */
-  std::vector<geometry::VolumeMesh<T>> reference_configuration_meshes_{};
+  /* The geometries of the deformable bodies at reference configuration. */
+  std::vector<internal::ReferenceDeformableGeometry<T>>
+      reference_configuration_geometries_{};
   /* The state of each deformable body at reference configuration. This contains
    the same information as the vertex positions in
-   reference_configuration_meshes_, but is stored in a more convenient format.
-  */
+   reference_configuration_geometries_, but is stored in a more convenient
+   format. */
   std::vector<VectorX<T>> model_discrete_states_;
   /* Proximity properties for all registered deformable bodies. */
   std::vector<geometry::ProximityProperties> proximity_properties_{};

--- a/multibody/fixed_fem/dev/mesh_utilities.cc
+++ b/multibody/fixed_fem/dev/mesh_utilities.cc
@@ -1,9 +1,12 @@
 #include "drake/multibody/fixed_fem/dev/mesh_utilities.h"
 
+#include <memory>
 #include <utility>
 #include <vector>
 
 #include "drake/geometry/proximity/make_box_mesh.h"
+#include "drake/geometry/query_object.h"
+#include "drake/geometry/scene_graph.h"
 
 namespace drake {
 namespace multibody {
@@ -85,7 +88,7 @@ std::vector<VolumeElement> GenerateDiamondCubicElements(
 }
 
 template <typename T>
-VolumeMesh<T> MakeDiamondCubicBoxVolumeMesh(
+internal::ReferenceDeformableGeometry<T> MakeDiamondCubicBoxDeformableGeometry(
     const Box& box, double resolution_hint,
     const math::RigidTransform<T>& X_WB) {
   DRAKE_DEMAND(resolution_hint > 0.);
@@ -96,9 +99,33 @@ VolumeMesh<T> MakeDiamondCubicBoxVolumeMesh(
       1 + static_cast<int>(ceil(box.depth() / resolution_hint)),
       1 + static_cast<int>(ceil(box.height() / resolution_hint))};
 
-  // Initially generate vertices in box's frame B.
+  /* Initially generate vertices in box's frame B. */
   std::vector<VolumeVertex<T>> vertices =
       geometry::internal::GenerateVertices<T>(box, num_vertices);
+
+  // TODO(xuchenhan-tri): This is an expedient but expensive way to calculate
+  //  the signed distance of the vertices. When moving out of dev/, come up with
+  //  a better solution.
+  /* Generate the vertex distances to the shape. */
+  geometry::SceneGraph<T> scene_graph;
+  const auto& source_id = scene_graph.RegisterSource();
+  const auto& geometry_id = scene_graph.RegisterGeometry(
+      source_id, scene_graph.world_frame_id(),
+      std::make_unique<geometry::GeometryInstance>(math::RigidTransformd(),
+                                                   box.Clone(), "box"));
+  scene_graph.AssignRole(source_id, geometry_id,
+                         geometry::ProximityProperties());
+  const auto& context = scene_graph.CreateDefaultContext();
+  const auto& query_object =
+      scene_graph.get_query_output_port()
+          .template Eval<geometry::QueryObject<T>>(*context);
+  std::vector<T> signed_distances;
+  for (const VolumeVertex<T>& vertex : vertices) {
+    const auto& d = query_object.ComputeSignedDistanceToPoint(vertex.r_MV());
+    DRAKE_DEMAND(d.size() == 1);
+    signed_distances.emplace_back(d[0].distance);
+  }
+
   for (VolumeVertex<T>& vertex : vertices) {
     // Transform to World frame.
     vertex = VolumeVertex<T>(X_WB * vertex.r_MV());
@@ -106,12 +133,16 @@ VolumeMesh<T> MakeDiamondCubicBoxVolumeMesh(
 
   std::vector<VolumeElement> elements =
       GenerateDiamondCubicElements(num_vertices);
-  return VolumeMesh<T>(std::move(elements), std::move(vertices));
+  auto mesh =
+      std::make_unique<VolumeMesh<T>>(std::move(elements), std::move(vertices));
+  auto mesh_field = std::make_unique<geometry::VolumeMeshFieldLinear<T, T>>(
+      "Approximated signed distance", std::move(signed_distances), mesh.get(),
+      false);
+  return {std::move(mesh), std::move(mesh_field)};
 }
 
-DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS((
-    &MakeDiamondCubicBoxVolumeMesh<T>
-))
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    (&MakeDiamondCubicBoxDeformableGeometry<T>))
 
 }  // namespace fem
 }  // namespace multibody

--- a/multibody/fixed_fem/dev/mesh_utilities.h
+++ b/multibody/fixed_fem/dev/mesh_utilities.h
@@ -1,21 +1,26 @@
 #pragma once
 
+#include <utility>
+#include <vector>
+
 #include "drake/geometry/proximity/volume_mesh.h"
+#include "drake/geometry/proximity/volume_mesh_field.h"
 #include "drake/geometry/shape_specification.h"
 #include "drake/math/rigid_transform.h"
+#include "drake/multibody/fixed_fem/dev/reference_deformable_geometry.h"
 
 namespace drake {
 namespace multibody {
 namespace fem {
-/** Generates a tetrahedral volume mesh of a given box by subdividing the box
+/** Generates a deformable geometry from a given box by subdividing the box
  into _rectangular cells_ (volume bounded by six axis-aligned faces) and
  subdividing each rectangular cell into five tetrahedra. Two adjacent
-rectangular cells (sharing a rectangular face) are subdivided in the patterns
-that are mirrored of each other so that the mesh is conforming.
+ rectangular cells (sharing a rectangular face) are subdivided in the patterns
+ that are mirrored of each other so that the mesh is conforming.
 
-The following picture file shows example of the diamond cubic box volume mesh
-and demonstrates the mirrored subdivision pattern in adjacent cells. The file is
-distributed with the source code.
+ The following picture file shows example of the diamond cubic box volume mesh
+ and demonstrates the mirrored subdivision pattern in adjacent cells. The file
+ is distributed with the source code.
 
  | multibody/fixed_fem/dev/images/diamond_cubic_box_volume_mesh.png  |
  | (Top) A diamond cubic box volume mesh. (Center and bottom) mirrored
@@ -41,7 +46,7 @@ distributed with the source code.
      The pose of the rectanglur volume mesh in the world frame.
  @tparam_nonsymbolic_scalar */
 template <typename T>
-geometry::VolumeMesh<T> MakeDiamondCubicBoxVolumeMesh(
+internal::ReferenceDeformableGeometry<T> MakeDiamondCubicBoxDeformableGeometry(
     const geometry::Box& box, double resolution_hint,
     const math::RigidTransform<T>& X_WB);
 }  // namespace fem

--- a/multibody/fixed_fem/dev/reference_deformable_geometry.cc
+++ b/multibody/fixed_fem/dev/reference_deformable_geometry.cc
@@ -1,0 +1,44 @@
+#include "drake/multibody/fixed_fem/dev/reference_deformable_geometry.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+template <typename T>
+ReferenceDeformableGeometry<T>::ReferenceDeformableGeometry(
+    std::unique_ptr<geometry::VolumeMesh<T>> mesh,
+    std::unique_ptr<geometry::VolumeMeshFieldLinear<T, T>> signed_distance)
+    : mesh_(std::move(mesh)), signed_distance_(std::move(signed_distance)) {
+  DRAKE_DEMAND(mesh_.get() == &signed_distance_->mesh());
+  const std::vector<T>& vertex_values = signed_distance_->values();
+  for (const T& value : vertex_values) {
+    DRAKE_ASSERT(value <= 0.0);
+  }
+}
+
+template <typename T>
+ReferenceDeformableGeometry<T>::ReferenceDeformableGeometry(
+    const ReferenceDeformableGeometry<T>& s) {
+  *this = s;
+}
+
+template <typename T>
+ReferenceDeformableGeometry<T>& ReferenceDeformableGeometry<T>::operator=(
+    const ReferenceDeformableGeometry<T>& s) {
+  if (this == &s) return *this;
+
+  mesh_ = std::make_unique<geometry::VolumeMesh<T>>(s.mesh());
+  /* We can't simply copy the mesh field; the copy must contain a pointer to
+   the new mesh. So, we use CloneAndSetMesh() instead. */
+  signed_distance_ = s.signed_distance().CloneAndSetMesh(mesh_.get());
+
+  return *this;
+}
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fem::internal::ReferenceDeformableGeometry);

--- a/multibody/fixed_fem/dev/reference_deformable_geometry.h
+++ b/multibody/fixed_fem/dev/reference_deformable_geometry.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "drake/common/default_scalars.h"
+#include "drake/geometry/proximity/volume_mesh.h"
+#include "drake/geometry/proximity/volume_mesh_field.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+/* Definition of a deformable body's geometry at the reference configuration.
+ It includes a volume mesh and a scalar field approximating the signed distance
+ to the surface of the mesh defined on the interior of the geometry.
+ @tparam_nonsymbolic_scalar. */
+template <typename T>
+class ReferenceDeformableGeometry {
+  /* This class is similar to geometry::internal::hydroelastic::SoftMesh
+   with a few differences:
+    1. This class allows AutoDiffXd as a scalar type.
+    2. This class doesn't provide a bounding volume hierarchy. */
+ public:
+  /* Constructs a deformable geometry at reference configuration with the
+   provided mesh and piece-wise linear approximation of the signed distance
+   field within the volume mesh.
+   @pre The signed_distance approximation is exact at mesh vertices, evaluates
+   to zero on the boundary vertices, and evaluates to non-positive values on all
+   vertices. */
+  ReferenceDeformableGeometry(
+      std::unique_ptr<geometry::VolumeMesh<T>> mesh,
+      std::unique_ptr<geometry::VolumeMeshFieldLinear<T, T>> signed_distance);
+
+  /* Custom copy assign and construct. */
+  ReferenceDeformableGeometry<T>& operator=(
+      const ReferenceDeformableGeometry<T>& s);
+  ReferenceDeformableGeometry(const ReferenceDeformableGeometry<T>& s);
+
+  ReferenceDeformableGeometry(ReferenceDeformableGeometry<T>&&) = default;
+  ReferenceDeformableGeometry<T>& operator=(ReferenceDeformableGeometry<T>&&) =
+      default;
+
+  /* Returns the volume mesh representation of the deformable geometry at
+   reference configuration. */
+  const geometry::VolumeMesh<T>& mesh() const { return *mesh_; }
+
+  /* Returns the approximate signed distance field with which `this` is
+   constructed. */
+  const geometry::VolumeMeshFieldLinear<T, T>& signed_distance() const {
+    return *signed_distance_;
+  }
+
+ private:
+  std::unique_ptr<geometry::VolumeMesh<T>> mesh_;
+  std::unique_ptr<geometry::VolumeMeshFieldLinear<T, T>> signed_distance_;
+};
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::fem::internal::ReferenceDeformableGeometry);

--- a/multibody/fixed_fem/dev/test/mesh_utilities_test.cc
+++ b/multibody/fixed_fem/dev/test/mesh_utilities_test.cc
@@ -15,6 +15,7 @@ using Eigen::Vector3d;
 using geometry::Box;
 using geometry::VolumeElement;
 using geometry::VolumeMesh;
+using geometry::VolumeMeshFieldLinear;
 using geometry::VolumeVertex;
 using geometry::VolumeVertexIndex;
 using geometry::internal::ComputeEulerCharacteristic;
@@ -114,13 +115,14 @@ bool VerifyDiamondCubicBoxMesh(const VolumeMesh<double>& mesh, const Box& box,
   return true;
 }
 
-GTEST_TEST(MeshUtilitiesTest, MakeDiamondCubicBoxVolumeMesh) {
+GTEST_TEST(MeshUtilitiesTest, DiamondCubicBoxVolumeMesh) {
   const double dx = 0.1;
   const RigidTransform<double> X_WB(Eigen::Quaternion<double>(1, 2, 3, 4),
                                     Vector3d(1, 2, 3));
   const Box cube(Box::MakeCube(2 * dx));
-  const VolumeMesh<double> cube_mesh =
-      MakeDiamondCubicBoxVolumeMesh<double>(cube, dx, X_WB);
+  const internal::ReferenceDeformableGeometry<double> cube_geometry =
+      MakeDiamondCubicBoxDeformableGeometry<double>(cube, dx, X_WB);
+  const VolumeMesh<double>& cube_mesh = cube_geometry.mesh();
   /* 2 x 2 x 2 = 8 cubes. Each cube is split into 5 tetrahedrons. */
   EXPECT_EQ(cube_mesh.num_elements(), 8 * 5);
   /* 3 x 3 x 3 = 27 vertices. From the cubes. No additional vertex is introduced
@@ -130,8 +132,9 @@ GTEST_TEST(MeshUtilitiesTest, MakeDiamondCubicBoxVolumeMesh) {
   EXPECT_TRUE(VerifyDiamondCubicBoxMesh(cube_mesh, cube, X_WB));
 
   const Box rectangle(1.2 * dx, 2.3 * dx, 3.5 * dx);
-  const VolumeMesh<double> rectangle_mesh =
-      MakeDiamondCubicBoxVolumeMesh<double>(rectangle, dx, X_WB);
+  const internal::ReferenceDeformableGeometry<double> rectangle_geometry =
+      MakeDiamondCubicBoxDeformableGeometry<double>(rectangle, dx, X_WB);
+  const VolumeMesh<double>& rectangle_mesh = rectangle_geometry.mesh();
   /* 2 x 3 x 4 = 24 cubes. Each cube is split into 5 tetrahedrons. */
   EXPECT_EQ(rectangle_mesh.num_elements(), 120);
   /* 3 x 4 x 5 = 60 vertices. From the cubes. No additional vertex is introduced
@@ -139,6 +142,35 @@ GTEST_TEST(MeshUtilitiesTest, MakeDiamondCubicBoxVolumeMesh) {
   EXPECT_EQ(rectangle_mesh.num_vertices(), 60);
   /* Verify that the mesh is conforming and conforms to the box. */
   EXPECT_TRUE(VerifyDiamondCubicBoxMesh(rectangle_mesh, rectangle, X_WB));
+}
+
+/* Verifies that the signed distance field is correct at all vertex locations.
+ */
+GTEST_TEST(MeshUtilitiesTest, SignedDistanceField) {
+  constexpr double dx = 0.1;
+  constexpr double half_Lx = 1.1 * dx;
+  constexpr double half_Ly = 1.2 * dx;
+  constexpr double half_Lz = 2.3 * dx;
+  const Box box(2.0 * half_Lx, 2.0 * half_Ly, 2.0 * half_Lz);
+  const internal::ReferenceDeformableGeometry<double> box_geometry =
+      MakeDiamondCubicBoxDeformableGeometry<double>(box, dx,
+                                                    math::RigidTransformd());
+  const VolumeMesh<double>& mesh = box_geometry.mesh();
+  const VolumeMeshFieldLinear<double, double>& mesh_field =
+      box_geometry.signed_distance();
+  for (VolumeVertexIndex i(0); i < mesh.num_vertices(); ++i) {
+    const double signed_distance = mesh_field.EvaluateAtVertex(i);
+    const Vector3d& r_WV = mesh.vertex(i).r_MV();
+    // clang-format off
+    const std::array<double, 6> distance_to_box_faces = {
+        half_Lx - r_WV(0), r_WV(0) + half_Lx,
+        half_Ly - r_WV(1), r_WV(1) + half_Ly,
+        half_Lz - r_WV(2), r_WV(2) + half_Lz };
+    // clang-format on
+    const double distance_to_surface = *std::min_element(
+        std::begin(distance_to_box_faces), std::end(distance_to_box_faces));
+    EXPECT_DOUBLE_EQ(-distance_to_surface, signed_distance);
+  }
 }
 }  // namespace
 }  // namespace fem

--- a/multibody/fixed_fem/dev/test/stretch_test.cc
+++ b/multibody/fixed_fem/dev/test/stretch_test.cc
@@ -51,10 +51,11 @@ class StretchTest : public ::testing::Test {
    into a tetrahedral mesh. */
   static VolumeMesh<T> MakeBoxTetMesh() {
     geometry::Box box(kLx / 2.0, kLy, kLz / 2.0);
-    const VolumeMesh<T> mesh = MakeDiamondCubicBoxVolumeMesh(
-        box, kDx,
-        math::RigidTransform(Vector3<double>(kLx / 4.0, 0, kLz / 4.0)));
-    return mesh;
+    const internal::ReferenceDeformableGeometry<T> geometry =
+        MakeDiamondCubicBoxDeformableGeometry(
+            box, kDx,
+            math::RigidTransform(Vector3<double>(kLx / 4.0, 0, kLz / 4.0)));
+    return geometry.mesh();
   }
 
   /* The rest positions of the vertices of the bar. */


### PR DESCRIPTION
Approximate signed distance field for deformable bodies

* Augment reference configuration deformable geometry with an approximate signed distance field. We precompute the signed distance at each vertex of the deformable mesh at *reference* configuration and approximate the signed distance at the contact point in the *deformed* configuration by linearly interpolating the precomputed values at the vertices.
* The domain of the approximated signed distance field is strictly in the interior of the deformable mesh and the value is non-positive.
* Collect this approximated signed distance information with DeformableContactData.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15300)
<!-- Reviewable:end -->
