### PR TITLE
[solvers] Disable CsdpSolver console printing by default 

### DIFF
--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -989,6 +989,8 @@ drake_cc_library(
         ":mathematical_program",
         ":solver_base",
         ":sdpa_free_format",
+        "//common:filesystem",
+        "//common:scope_exit",
     ] + select({
         "//conditions:default": [
             "@csdp",

--- a/solvers/csdp_solver.cc
+++ b/solvers/csdp_solver.cc
@@ -1,8 +1,12 @@
 #include "drake/solvers/csdp_solver.h"
 
+#include <unistd.h>
+
 #include <algorithm>
+#include <cstdlib>
 #include <limits>
 #include <stdexcept>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -10,8 +14,15 @@
 #include <Eigen/Sparse>
 #include <Eigen/SparseQR>
 
+#include "drake/common/filesystem.h"
+#include "drake/common/scope_exit.h"
 #include "drake/common/text_logging.h"
 #include "drake/solvers/csdp_solver_internal.h"
+
+// Note that in the below, the first argument to csdp::easy_sdp is a params
+// filename, but that feature is a Drake-specific patch added to the CSDP
+// headers and source; refer to drake/tools/workspace/csdp/repository.bzl
+// for details.
 
 namespace drake {
 namespace solvers {
@@ -108,6 +119,7 @@ void SetProgramSolution(const SdpaFreeFormat& sdpa_free_format,
 void SolveProgramWithNoFreeVariables(
     const MathematicalProgram& prog,
     const SdpaFreeFormat& sdpa_free_format,
+    const std::string& csdp_params_pathname,
     MathematicalProgramResult* result) {
   DRAKE_ASSERT(sdpa_free_format.num_free_variables() == 0);
 
@@ -123,6 +135,7 @@ void SolveProgramWithNoFreeVariables(
                  rhs, constraints, &X, &y, &Z);
   double pobj, dobj;
   const int ret = csdp::easy_sdp(
+      csdp_params_pathname.c_str(),
       sdpa_free_format.num_X_rows(), sdpa_free_format.g().rows(), C, rhs,
       constraints, -sdpa_free_format.constant_min_cost_term(), &X, &y, &Z,
       &pobj, &dobj);
@@ -151,6 +164,7 @@ void SolveProgramWithNoFreeVariables(
 
 void SolveProgramThroughNullspaceApproach(
     const MathematicalProgram& prog, const SdpaFreeFormat& sdpa_free_format,
+    const std::string& csdp_params_pathname,
     MathematicalProgramResult* result) {
   static const logging::Warn log_once(
       "The problem has free variables, and CSDP removes the free "
@@ -177,11 +191,12 @@ void SolveProgramThroughNullspaceApproach(
                  rhs_csdp, constraints_csdp, &X_csdp, &y, &Z);
   double pobj{0};
   double dobj{0};
-  const int ret = csdp::easy_sdp(sdpa_free_format.num_X_rows(), rhs_hat.rows(),
-                                 C_csdp, rhs_csdp, constraints_csdp,
-                                 -sdpa_free_format.constant_min_cost_term() +
-                                     sdpa_free_format.g().dot(y_hat),
-                                 &X_csdp, &y, &Z, &pobj, &dobj);
+  const int ret = csdp::easy_sdp(
+      csdp_params_pathname.c_str(),
+      sdpa_free_format.num_X_rows(), rhs_hat.rows(), C_csdp, rhs_csdp,
+      constraints_csdp, -sdpa_free_format.constant_min_cost_term()
+          + sdpa_free_format.g().dot(y_hat),
+      &X_csdp, &y, &Z, &pobj, &dobj);
   Eigen::SparseMatrix<double> X_hat(sdpa_free_format.num_X_rows(),
                                     sdpa_free_format.num_X_rows());
   ConvertCsdpBlockMatrixtoEigen(X_csdp, &X_hat);
@@ -232,6 +247,7 @@ void SolveProgramThroughNullspaceApproach(
  */
 void SolveProgramThroughTwoSlackVariablesApproach(
     const MathematicalProgram& prog, const SdpaFreeFormat& sdpa_free_format,
+    const std::string& csdp_params_pathname,
     MathematicalProgramResult* result) {
   static const logging::Warn log_once(
       "The problem has free variables, and CSDP removes the free "
@@ -260,10 +276,11 @@ void SolveProgramThroughTwoSlackVariablesApproach(
                  constraints_csdp, &X_csdp, &y, &Z);
   double pobj{0};
   double dobj{0};
-  const int ret = csdp::easy_sdp(num_X_hat_rows, sdpa_free_format.g().rows(),
-                                 C_csdp, rhs_csdp, constraints_csdp,
-                                 -sdpa_free_format.constant_min_cost_term(),
-                                 &X_csdp, &y, &Z, &pobj, &dobj);
+  const int ret = csdp::easy_sdp(
+      csdp_params_pathname.c_str(),
+      num_X_hat_rows, sdpa_free_format.g().rows(), C_csdp, rhs_csdp,
+      constraints_csdp, -sdpa_free_format.constant_min_cost_term(),
+      &X_csdp, &y, &Z, &pobj, &dobj);
   Eigen::SparseMatrix<double> X_hat(num_X_hat_rows, num_X_hat_rows);
   ConvertCsdpBlockMatrixtoEigen(X_csdp, &X_hat);
   // Now retrieve the value for the free variable s as y⁺ - y⁻.
@@ -322,6 +339,7 @@ void SolveProgramThroughTwoSlackVariablesApproach(
  */
 void SolveProgramThroughLorentzConeSlackApproach(
     const MathematicalProgram& prog, const SdpaFreeFormat& sdpa_free_format,
+    const std::string& csdp_params_pathname,
     MathematicalProgramResult* result) {
   static const logging::Warn log_once(
       "The problem has free variables, and CSDP removes the free "
@@ -351,10 +369,11 @@ void SolveProgramThroughLorentzConeSlackApproach(
                  constraints_csdp, &X_csdp, &y, &Z);
   double pobj{0};
   double dobj{0};
-  const int ret = csdp::easy_sdp(num_X_hat_rows, rhs_hat.rows(), C_csdp,
-                                 rhs_csdp, constraints_csdp,
-                                 -sdpa_free_format.constant_min_cost_term(),
-                                 &X_csdp, &y, &Z, &pobj, &dobj);
+  const int ret = csdp::easy_sdp(
+      csdp_params_pathname.c_str(),
+      num_X_hat_rows, rhs_hat.rows(), C_csdp, rhs_csdp, constraints_csdp,
+      -sdpa_free_format.constant_min_cost_term(),
+      &X_csdp, &y, &Z, &pobj, &dobj);
   Eigen::SparseMatrix<double> X_hat(num_X_hat_rows, num_X_hat_rows);
   ConvertCsdpBlockMatrixtoEigen(X_csdp, &X_hat);
   // Now retrieve the value for the free variable s from Y.
@@ -390,34 +409,89 @@ void SolveProgramThroughLorentzConeSlackApproach(
   csdp::free_prob(num_X_hat_rows, rhs_hat.rows(), C_csdp, rhs_csdp,
                   constraints_csdp, X_csdp, y, Z);
 }
+
+std::string MaybeWriteCsdpParams(const SolverOptions& options) {
+  // We'll consolidate options into this config string to pass to CSDP.
+  std::string all_csdp_params;
+
+  // Map the common options into CSDP's conventions.
+  const auto& common_options = options.common_solver_options();
+  auto iter = common_options.find(CommonSolverOption::kPrintToConsole);
+  if (iter != common_options.end()) {
+    const int option_value = std::get<int>(iter->second);
+    DRAKE_DEMAND((option_value == 0) || (option_value == 1));
+    if (option_value) {
+      all_csdp_params += "printlevel=1\n";
+    }
+  }
+
+  // TODO(jwnimmer-tri) We could pass through the other named options here,
+  // if we wanted to.
+
+  if (all_csdp_params.empty()) {
+    // No need to write a temporary file.
+    return {};
+  }
+
+  // Choose a temporary filename.
+  const char* dir = std::getenv("TEST_TMPDIR");
+  if (!dir) { dir = std::getenv("TMPDIR"); }
+  if (!dir) { dir = "/tmp"; }
+  filesystem::path path_template(dir);
+  path_template.append("robotlocomotion_drake_XXXXXX");
+  std::string result = path_template;
+  int fd = ::mkstemp(result.data());
+  DRAKE_THROW_UNLESS(fd != -1);
+  const size_t total = all_csdp_params.size();
+  ssize_t written = ::write(fd, all_csdp_params.data(), total);
+  DRAKE_THROW_UNLESS(written != -1);
+  DRAKE_THROW_UNLESS(written == static_cast<ssize_t>(total));
+  ::close(fd);
+
+  return result;
+}
+
 }  // namespace
 
 void CsdpSolver::DoSolve(const MathematicalProgram& prog,
-                         const Eigen::VectorXd&, const SolverOptions&,
+                         const Eigen::VectorXd&,
+                         const SolverOptions& merged_options,
                          MathematicalProgramResult* result) const {
   if (!prog.GetVariableScaling().empty()) {
     static const logging::Warn log_once(
         "CsdpSolver doesn't support the feature of variable scaling.");
   }
 
+  // If necessary, write the custom CSDP parameters to a temporary file, which
+  // we should remove when this function returns.
+  const std::string csdp_params_pathname =
+      MaybeWriteCsdpParams(merged_options);
+  ScopeExit guard([&csdp_params_pathname]() {
+    if (!csdp_params_pathname.empty()) {
+      ::unlink(csdp_params_pathname.c_str());
+    }
+  });
+
   result->set_solver_id(CsdpSolver::id());
   const SdpaFreeFormat sdpa_free_format(prog);
   if (sdpa_free_format.num_free_variables() == 0) {
-    SolveProgramWithNoFreeVariables(prog, sdpa_free_format, result);
+    SolveProgramWithNoFreeVariables(
+        prog, sdpa_free_format, csdp_params_pathname, result);
   } else {
     switch (method_) {
       case RemoveFreeVariableMethod::kNullspace: {
-        SolveProgramThroughNullspaceApproach(prog, sdpa_free_format, result);
+        SolveProgramThroughNullspaceApproach(
+            prog, sdpa_free_format, csdp_params_pathname, result);
         break;
       }
       case RemoveFreeVariableMethod::kTwoSlackVariables: {
-        SolveProgramThroughTwoSlackVariablesApproach(prog, sdpa_free_format,
-                                                     result);
+        SolveProgramThroughTwoSlackVariablesApproach(
+            prog, sdpa_free_format, csdp_params_pathname, result);
         break;
       }
       case RemoveFreeVariableMethod::kLorentzConeSlack: {
-        SolveProgramThroughLorentzConeSlackApproach(prog, sdpa_free_format,
-                                                    result);
+        SolveProgramThroughLorentzConeSlackApproach(
+            prog, sdpa_free_format, csdp_params_pathname, result);
         break;
       }
     }

--- a/solvers/test/csdp_solver_internal_test.cc
+++ b/solvers/test/csdp_solver_internal_test.cc
@@ -243,7 +243,8 @@ TEST_F(SDPwithOverlappingVariables1, Solve) {
                  &Z);
   double pobj, dobj;
   const int ret =
-      csdp::easy_sdp(dut.num_X_rows(), dut.g().rows(), C, rhs, constraints,
+      csdp::easy_sdp(nullptr,
+                     dut.num_X_rows(), dut.g().rows(), C, rhs, constraints,
                      -dut.constant_min_cost_term(), &X, &y, &Z, &pobj, &dobj);
   EXPECT_EQ(ret, 0 /* 0 is for success */);
   const double tol = 1E-7;
@@ -272,7 +273,8 @@ TEST_F(SDPwithOverlappingVariables2, Solve) {
                  &Z);
   double pobj, dobj;
   const int ret =
-      csdp::easy_sdp(dut.num_X_rows(), dut.g().rows(), C, rhs, constraints,
+      csdp::easy_sdp(nullptr,
+                     dut.num_X_rows(), dut.g().rows(), C, rhs, constraints,
                      -dut.constant_min_cost_term(), &X, &y, &Z, &pobj, &dobj);
   EXPECT_EQ(ret, 0 /* 0 is for success */);
   const double tol = 1E-7;
@@ -300,7 +302,8 @@ TEST_F(CsdpDocExample, Solve) {
                  &Z);
   double pobj, dobj;
   const int ret =
-      csdp::easy_sdp(dut.num_X_rows(), dut.g().rows(), C, rhs, constraints,
+      csdp::easy_sdp(nullptr,
+                     dut.num_X_rows(), dut.g().rows(), C, rhs, constraints,
                      -dut.constant_min_cost_term(), &X, &y, &Z, &pobj, &dobj);
   EXPECT_EQ(ret, 0 /* 0 is for success */);
 
@@ -340,7 +343,8 @@ TEST_F(TrivialSDP1, Solve) {
                  &Z);
   double pobj, dobj;
   const int ret =
-      csdp::easy_sdp(dut.num_X_rows(), dut.g().rows(), C, rhs, constraints,
+      csdp::easy_sdp(nullptr,
+                     dut.num_X_rows(), dut.g().rows(), C, rhs, constraints,
                      -dut.constant_min_cost_term(), &X, &y, &Z, &pobj, &dobj);
   EXPECT_EQ(ret, 0 /* 0 is for success */);
 

--- a/solvers/test/csdp_solver_test.cc
+++ b/solvers/test/csdp_solver_test.cc
@@ -350,6 +350,18 @@ GTEST_TEST(TestSOS, UnivariateNonnegative1) {
     }
   }
 }
+
+// This is a code coverage test, not a functional test. If the code that
+// handles verbosity options has a segfault or always throws an exception,
+// then this would catch it.
+TEST_F(TrivialSDP1, SolveVerbose) {
+  SolverOptions options;
+  options.SetOption(CommonSolverOption::kPrintToConsole, 1);
+  CsdpSolver solver;
+  if (solver.available()) {
+    solver.Solve(*prog_, {}, options);
+  }
+}
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/sdpa_free_format_test.cc
+++ b/solvers/test/sdpa_free_format_test.cc
@@ -846,6 +846,7 @@ TEST_F(LinearProgramBoundingBox1, RemoveFreeVariableByNullspaceApproach) {
   double pobj{0};
   double dobj{0};
   const int ret = csdp::easy_sdp(
+      nullptr,
       dut.num_X_rows(), rhs_hat.rows(), C_csdp, rhs_csdp, constraints_csdp,
       -dut.constant_min_cost_term() + dut.g().dot(y_hat), &X_csdp, &y, &Z,
       &pobj, &dobj);

--- a/tools/workspace/csdp/params_pathname.patch
+++ b/tools/workspace/csdp/params_pathname.patch
@@ -1,0 +1,64 @@
+Add option to specify a filename to parse for CSDP parameters.
+
+--- include/declarations.h	2017-07-25 11:44:57.000000000 -0700
++++ include/declarations.h	2021-06-30 16:17:10.855119121 -0700
+@@ -132,7 +132,7 @@
+ 
+ void free_mat(struct blockmatrix A);
+ 
+-void initparams(struct paramstruc *params, int *pprintlevel);
++void initparams(const char *pathname, struct paramstruc *params, int *pprintlevel);
+ 
+ void initsoln(int n, int k, struct blockmatrix C, double *a, 
+ 	      struct constraintmatrix *constraints, struct blockmatrix *pX0,
+@@ -184,7 +184,7 @@
+ 	double *dy, double *dy1, double *Fp, int printlevel, 
+ 	struct paramstruc parameters);
+ 
+-int easy_sdp(int n, int k, struct blockmatrix C, double *a, 
++int easy_sdp(const char* params_pathname, int n, int k, struct blockmatrix C, double *a, 
+ 	     struct constraintmatrix *constraints, double constant_offset,
+ 	     struct blockmatrix *pX, double **py, struct blockmatrix *pZ,
+ 	     double *ppobj, double *pdobj);
+--- lib/initparams.c	2021-06-30 16:16:49.222803365 -0700
++++ lib/initparams.c	2021-06-30 16:16:08.046220044 -0700
+@@ -6,7 +6,8 @@
+ #include <strings.h>
+ #include "declarations.h"
+ 
+-void initparams(params,pprintlevel)
++void initparams(pathname,params,pprintlevel)
++     const char *pathname;
+      struct paramstruc *params;
+      int *pprintlevel;
+ {
+@@ -42,7 +43,7 @@
+    * the default values.
+    */
+ 
+-  paramfile=fopen("param.csdp","r");
++  paramfile=fopen(pathname,"r");
+ 
+   if (paramfile != NULL)
+     {
+--- lib/easysdp.c	2017-07-25 11:44:57.000000000 -0700
++++ lib/easysdp.c	2021-06-30 16:18:42.336451557 -0700
+@@ -12,7 +12,8 @@
+ #include <math.h>
+ #include "declarations.h"
+ 
+-int easy_sdp(n,k,C,a,constraints,constant_offset,pX,py,pZ,ppobj,pdobj)
++int easy_sdp(params_pathname,n,k,C,a,constraints,constant_offset,pX,py,pZ,ppobj,pdobj)
++     const char *params_pathname;
+      int n;
+      int k;
+      struct blockmatrix C;
+@@ -72,7 +73,7 @@
+     *  Initialize the parameters.
+     */
+ 
+-   initparams(&params,&printlevel);
++   initparams(params_pathname,&params,&printlevel);
+ 
+ 
+   /*

--- a/tools/workspace/csdp/params_pathname.patch
+++ b/tools/workspace/csdp/params_pathname.patch
@@ -32,12 +32,15 @@ Add option to specify a filename to parse for CSDP parameters.
       struct paramstruc *params;
       int *pprintlevel;
  {
-@@ -42,7 +43,7 @@
+@@ -42,7 +43,10 @@
     * the default values.
     */
  
 -  paramfile=fopen("param.csdp","r");
-+  paramfile=fopen(pathname,"r");
++  if (pathname)
++    paramfile=fopen(pathname,"r");
++  else
++    paramfile=NULL;
  
    if (paramfile != NULL)
      {

--- a/tools/workspace/csdp/printlevel.patch
+++ b/tools/workspace/csdp/printlevel.patch
@@ -1,0 +1,13 @@
+When no parameters file is in use, do not console print by default.
+
+--- lib/initparams.c	2017-07-25 11:44:57.000000000 -0700
++++ lib/initparams.c	2021-06-30 15:50:10.984899788 -0700
+@@ -35,7 +35,7 @@
+   params->affine=0;
+   params->perturbobj=1;
+   params->fastmode=0;
+-  *pprintlevel=1;
++  *pprintlevel=0;
+ 
+   /*
+    * Attempt to open param.csdp.  If it doesn't open, then just use 

--- a/tools/workspace/csdp/repository.bzl
+++ b/tools/workspace/csdp/repository.bzl
@@ -11,5 +11,9 @@ def csdp_repository(
         commit = "releases/6.2.0",
         sha256 = "3d341974af1f8ed70e1a37cc896e7ae4a513375875e5b46db8e8f38b7680b32f",  # noqa
         build_file = "@drake//tools/workspace/csdp:package.BUILD.bazel",
+        patches = [
+            "@drake//tools/workspace/csdp:printlevel.patch",
+            "@drake//tools/workspace/csdp:params_pathname.patch",
+        ],
         mirrors = mirrors,
     )


### PR DESCRIPTION
This re-applies #15281, with a change to avoid calling `fopen()` on a NULL pathname.

For easier review, the original commit vs fixup commit are kept separate.  They will be squashed when merging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15307)
<!-- Reviewable:end -->
