### PR TITLE
[geometry] Select output format from mesh_plane_intersection in hydroelastics.

### DIFF
--- a/geometry/proximity/hydroelastic_callback.h
+++ b/geometry/proximity/hydroelastic_callback.h
@@ -123,11 +123,8 @@ std::unique_ptr<ContactSurface<T>> DispatchRigidSoftCalculation(
           dynamic_cast<const VolumeMeshFieldLinear<double, double>&>(
               soft.pressure_field());
       const Bvh<Obb, VolumeMesh<double>>& bvh_S = soft.bvh();
-      // TODO(DamrongGuoy): Pass `representation` parameter (the choice of
-      //  contact polygons) when
-      //  ComputeContactSurfaceFromSoftVolumeRigidHalfSpace supports it.
       return ComputeContactSurfaceFromSoftVolumeRigidHalfSpace(
-          id_S, field_S, bvh_S, X_WS, id_R, X_WR);
+          id_S, field_S, bvh_S, X_WS, id_R, X_WR, representation);
     }
   } else {
     // soft cannot be a half space; so this must be mesh-mesh.


### PR DESCRIPTION
Support Part II of the [development plan for 14579](https://github.com/RobotLocomotion/drake/issues/14579#issuecomment-843618123). This PR for mesh_plane_intersection is similar to PR #15131 for mesh_intersection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15310)
<!-- Reviewable:end -->
