### PR TITLE
geometry:optimization Implements IsBounded and Hyperellipsoid Volumes

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -1318,9 +1318,9 @@ void def_geometry_optimization(py::module m) {
             cls_doc.ambient_dimension.doc)
         .def("PointInSet", &ConvexSet::PointInSet, py::arg("x"),
             py::arg("tol") = 1e-8, cls_doc.PointInSet.doc)
-        .def("AddPointInSetConstraint", &ConvexSet::AddPointInSetConstraint,
+        .def("AddPointInSetConstraints", &ConvexSet::AddPointInSetConstraints,
             py::arg("prog"), py::arg("vars"),
-            cls_doc.AddPointInSetConstraint.doc)
+            cls_doc.AddPointInSetConstraints.doc)
         .def("ToShapeWithPose", &ConvexSet::ToShapeWithPose,
             cls_doc.ToShapeWithPose.doc);
   }
@@ -1334,7 +1334,7 @@ void def_geometry_optimization(py::module m) {
         .def(py::init<const QueryObject<double>&, GeometryId,
                  std::optional<FrameId>>(),
             py::arg("query_object"), py::arg("geometry_id"),
-            py::arg("expressed_in") = std::nullopt, cls_doc.ctor.doc_3args)
+            py::arg("reference_frame") = std::nullopt, cls_doc.ctor.doc_3args)
         .def("A", &HPolyhedron::A, cls_doc.A.doc)
         .def("b", &HPolyhedron::b, cls_doc.b.doc)
         .def("MaximumVolumeInscribedEllipsoid",
@@ -1347,17 +1347,17 @@ void def_geometry_optimization(py::module m) {
   }
 
   {
-    const auto& cls_doc = doc.HyperEllipsoid;
-    py::class_<HyperEllipsoid, ConvexSet>(m, "HyperEllipsoid", cls_doc.doc)
+    const auto& cls_doc = doc.Hyperellipsoid;
+    py::class_<Hyperellipsoid, ConvexSet>(m, "Hyperellipsoid", cls_doc.doc)
         .def(py::init<const Eigen::Ref<const Eigen::MatrixXd>&,
                  const Eigen::Ref<const Eigen::VectorXd>&>(),
             py::arg("A"), py::arg("center"), cls_doc.ctor.doc_2args)
         .def(py::init<const QueryObject<double>&, GeometryId,
                  std::optional<FrameId>>(),
             py::arg("query_object"), py::arg("geometry_id"),
-            py::arg("expressed_in") = std::nullopt, cls_doc.ctor.doc_3args)
-        .def("A", &HyperEllipsoid::A, cls_doc.A.doc)
-        .def("center", &HyperEllipsoid::center, cls_doc.center.doc);
+            py::arg("reference_frame") = std::nullopt, cls_doc.ctor.doc_3args)
+        .def("A", &Hyperellipsoid::A, cls_doc.A.doc)
+        .def("center", &Hyperellipsoid::center, cls_doc.center.doc);
   }
 }
 

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -910,7 +910,7 @@ class TestGeometry(unittest.TestCase):
         np.testing.assert_array_equal(hpoly.A(), A)
         np.testing.assert_array_equal(hpoly.b(), b)
         self.assertTrue(hpoly.PointInSet(x=[0, 0, 0], tol=0.0))
-        hpoly.AddPointInSetConstraint(prog, x)
+        hpoly.AddPointInSetConstraints(prog, x)
         with self.assertRaisesRegex(
                 RuntimeError, ".*not implemented yet for HPolyhedron.*"):
             hpoly.ToShapeWithPose()
@@ -922,15 +922,15 @@ class TestGeometry(unittest.TestCase):
         np.testing.assert_array_equal(h_box.b(), h_unit_box.b())
         self.assertIsInstance(
             h_box.MaximumVolumeInscribedEllipsoid(),
-            mut.optimization.HyperEllipsoid)
+            mut.optimization.Hyperellipsoid)
 
-        # Test HyperEllipsoid.
-        ellipsoid = mut.optimization.HyperEllipsoid(A=A, center=b)
+        # Test Hyperellipsoid.
+        ellipsoid = mut.optimization.Hyperellipsoid(A=A, center=b)
         self.assertEqual(ellipsoid.ambient_dimension(), 3)
         np.testing.assert_array_equal(ellipsoid.A(), A)
         np.testing.assert_array_equal(ellipsoid.center(), b)
         self.assertTrue(ellipsoid.PointInSet(x=b, tol=0.0))
-        ellipsoid.AddPointInSetConstraint(prog, x)
+        ellipsoid.AddPointInSetConstraints(prog, x)
         shape, pose = ellipsoid.ToShapeWithPose()
         self.assertIsInstance(shape, mut.Ellipsoid)
         self.assertIsInstance(pose, RigidTransform)
@@ -957,11 +957,11 @@ class TestGeometry(unittest.TestCase):
         query_object = scene_graph.get_query_output_port().Eval(context)
         H = mut.optimization.HPolyhedron(
             query_object=query_object, geometry_id=box_geometry_id,
-            expressed_in=scene_graph.world_frame_id())
+            reference_frame=scene_graph.world_frame_id())
         self.assertEqual(H.ambient_dimension(), 3)
-        E = mut.optimization.HyperEllipsoid(
+        E = mut.optimization.Hyperellipsoid(
             query_object=query_object, geometry_id=sphere_geometry_id,
-            expressed_in=scene_graph.world_frame_id())
+            reference_frame=scene_graph.world_frame_id())
         self.assertEqual(E.ambient_dimension(), 3)
 
     def test_deprecated_struct_member(self):

--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -54,6 +54,14 @@ drake_cc_library(
 )
 
 drake_cc_googletest(
+    name = "convex_set_test",
+    deps = [
+        ":convex_set",
+        "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
     name = "hpolyhedron_test",
     deps = [
         ":convex_set",

--- a/geometry/optimization/convex_set.cc
+++ b/geometry/optimization/convex_set.cc
@@ -1,5 +1,6 @@
 #include "drake/geometry/optimization/convex_set.h"
 
+#include <algorithm>
 #include <limits>
 #include <memory>
 
@@ -29,6 +30,20 @@ ConvexSet::AddPointInNonnegativeScalingConstraints(
   constraints.emplace_back(prog->AddBoundingBoxConstraint(
       0, std::numeric_limits<double>::infinity(), t));
   return constraints;
+}
+
+ConvexSets::ConvexSets() = default;
+
+ConvexSets::~ConvexSets() = default;
+
+ConvexSet& ConvexSets::emplace_back(const ConvexSet& set) {
+  sets_.emplace_back(set.Clone());
+  return *sets_.back();
+}
+
+ConvexSet& ConvexSets::emplace_back(std::unique_ptr<ConvexSet> set) {
+  sets_.emplace_back(std::move(set));
+  return *sets_.back();
 }
 
 }  // namespace optimization

--- a/geometry/optimization/hyperellipsoid.cc
+++ b/geometry/optimization/hyperellipsoid.cc
@@ -1,11 +1,14 @@
 #include "drake/geometry/optimization/hyperellipsoid.h"
 
+#include <limits>
 #include <memory>
 
 #include <Eigen/Eigenvalues>
+#include <fmt/format.h>
 
 #include "drake/math/matrix_util.h"
 #include "drake/math/rotation_matrix.h"
+#include "drake/solvers/solve.h"
 
 namespace drake {
 namespace geometry {
@@ -22,25 +25,26 @@ using solvers::VectorXDecisionVariable;
 using std::sqrt;
 using symbolic::Variable;
 
-HyperEllipsoid::HyperEllipsoid(const Eigen::Ref<const MatrixXd>& A,
+Hyperellipsoid::Hyperellipsoid(const Eigen::Ref<const MatrixXd>& A,
                                const Eigen::Ref<const VectorXd>& center)
-    : ConvexSet(&ConvexSetCloner<HyperEllipsoid>, center.size()),
+    : ConvexSet(&ConvexSetCloner<Hyperellipsoid>, center.size()),
       A_{A},
       center_{center} {
-  DRAKE_DEMAND(A.rows() == center.size());
+  DRAKE_DEMAND(A.cols() == center.size());
+  DRAKE_DEMAND(A.allFinite());  // to ensure the set is non-empty.
 }
 
-HyperEllipsoid::HyperEllipsoid(const QueryObject<double>& query_object,
+Hyperellipsoid::Hyperellipsoid(const QueryObject<double>& query_object,
                                GeometryId geometry_id,
-                               std::optional<FrameId> expressed_in)
-    : ConvexSet(&ConvexSetCloner<HyperEllipsoid>, 3) {
+                               std::optional<FrameId> reference_frame)
+    : ConvexSet(&ConvexSetCloner<Hyperellipsoid>, 3) {
   Eigen::Matrix3d A_G;
   query_object.inspector().GetShape(geometry_id).Reify(this, &A_G);
   // p_GG_varᵀ * A_Gᵀ * A_G * p_GG_var ≤ 1
 
-  const RigidTransformd X_WE = expressed_in
-                                   ? query_object.GetPoseInWorld(*expressed_in)
-                                   : RigidTransformd::Identity();
+  const RigidTransformd X_WE =
+      reference_frame ? query_object.GetPoseInWorld(*reference_frame)
+                      : RigidTransformd::Identity();
   const RigidTransformd& X_WG = query_object.GetPoseInWorld(geometry_id);
   const RigidTransformd X_GE = X_WG.InvertAndCompose(X_WE);
 
@@ -50,16 +54,117 @@ HyperEllipsoid::HyperEllipsoid(const QueryObject<double>& query_object,
   center_ = X_GE.inverse().translation();
 }
 
-HyperEllipsoid::~HyperEllipsoid() = default;
+Hyperellipsoid::~Hyperellipsoid() = default;
 
-bool HyperEllipsoid::DoPointInSet(const Eigen::Ref<const VectorXd>& x,
+namespace {
+
+double volume_of_unit_sphere(int dim) {
+  // Formula from https://en.wikipedia.org/wiki/Volume_of_an_n-ball .
+  // Note: special case n≤3 only because they are common and simple.
+  switch (dim) {
+    case 0:
+      return 1.0;
+    case 1:
+      return 2.0;
+    case 2:
+      return M_PI;
+    case 3:
+      return 4.0 * M_PI / 3.0;
+    default:
+      return std::pow(M_PI, dim / 2.0) / std::tgamma(dim / 2.0 + 1);
+  }
+}
+
+}  // namespace
+
+double Hyperellipsoid::Volume() const {
+  if (A_.rows() < A_.cols()) {
+    return std::numeric_limits<double>::infinity();
+  }
+  // Note: this will (correctly) return infinity if the determinant is zero.
+  return volume_of_unit_sphere(ambient_dimension()) / A_.determinant();
+}
+
+std::pair<double, VectorXd> Hyperellipsoid::MinimumUniformScalingToTouch(
+    const ConvexSet& other) const {
+  DRAKE_DEMAND(other.ambient_dimension() == ambient_dimension());
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables(ambient_dimension());
+  other.AddPointInSetConstraints(&prog, x);
+
+  // If we have only linear constraints, then add a quadratic cost and solve the
+  // QP.  Otherwise add a slack variable and solve the SOCP.
+  bool has_only_linear_constraints = true;
+  for (const auto& attribute : prog.required_capabilities()) {
+    if (attribute != solvers::ProgramAttribute::kLinearConstraint &&
+        attribute != solvers::ProgramAttribute::kLinearEqualityConstraint) {
+      has_only_linear_constraints = false;
+    }
+  }
+  if (has_only_linear_constraints) {
+    prog.AddQuadraticErrorCost(A_.transpose() * A_, center_, x);
+  } else {
+    auto slack = prog.NewContinuousVariables<1>("slack");
+    prog.AddLinearCost(slack[0]);
+    // z₀ = slack, z₁ = 1, z₂...ₙ = A_*(x-center)
+    // z₀z₁ ≥ z₂² + ... + zₙ²
+    MatrixXd A = MatrixXd::Zero(A_.rows()+2, A_.cols()+1);
+    VectorXd b(A_.rows()+2);
+    A(0, 0) = 1;
+    A.bottomRightCorner(A_.rows(), A_.cols()) = A_;
+    b[0] = 0;
+    b[1] = 1;
+    b.tail(A_.rows()) = -A_*center_;
+    prog.AddRotatedLorentzConeConstraint(A, b, {slack, x});
+  }
+  auto result = solvers::Solve(prog);
+  if (!result.is_success()) {
+    throw std::runtime_error(fmt::format(
+        "Solver {} failed to solve the `minimum uniform scaling to touch' "
+        "problem; it terminated with SolutionResult {}). This should not "
+        "happen.",
+        result.get_solver_id().name(), result.get_solution_result()));
+  }
+  return std::pair<double, VectorXd>(std::sqrt(result.get_optimal_cost()),
+                                     result.GetSolution(x));
+}
+
+Hyperellipsoid Hyperellipsoid::MakeAxisAligned(
+    const Eigen::Ref<const VectorXd>& radius,
+    const Eigen::Ref<const VectorXd>& center) {
+  DRAKE_DEMAND(radius.size() == center.size());
+  DRAKE_DEMAND((radius.array() > 0).all());
+  return Hyperellipsoid(MatrixXd(radius.cwiseInverse().asDiagonal()), center);
+}
+
+Hyperellipsoid Hyperellipsoid::MakeHypersphere(
+    double radius, const Eigen::Ref<const VectorXd>& center) {
+  DRAKE_DEMAND(radius > 0);
+  const int dim = center.size();
+  return Hyperellipsoid(MatrixXd::Identity(dim, dim) / radius, center);
+}
+
+Hyperellipsoid Hyperellipsoid::MakeUnitBall(int dim) {
+  DRAKE_DEMAND(dim > 0);
+  return Hyperellipsoid(MatrixXd::Identity(dim, dim), VectorXd::Zero(dim));
+}
+
+bool Hyperellipsoid::DoIsBounded() const {
+  if (A_.rows() < A_.cols()) {
+    return false;
+  }
+  Eigen::ColPivHouseholderQR<MatrixXd> qr(A_);
+  return qr.dimensionOfKernel() == 0;
+}
+
+bool Hyperellipsoid::DoPointInSet(const Eigen::Ref<const VectorXd>& x,
                                   double tol) const {
   DRAKE_DEMAND(A_.cols() == x.size());
   const VectorXd v = A_ * (x - center_);
   return v.dot(v) <= 1.0 + tol;
 }
 
-void HyperEllipsoid::DoAddPointInSetConstraint(
+void Hyperellipsoid::DoAddPointInSetConstraints(
     MathematicalProgram* prog,
     const Eigen::Ref<const VectorXDecisionVariable>& x) const {
   // 1.0 ≥ |A * (x - center)|_2, written as
@@ -74,7 +179,7 @@ void HyperEllipsoid::DoAddPointInSetConstraint(
 }
 
 std::vector<Binding<Constraint>>
-HyperEllipsoid::DoAddPointInNonnegativeScalingConstraints(
+Hyperellipsoid::DoAddPointInNonnegativeScalingConstraints(
     MathematicalProgram* prog,
     const Eigen::Ref<const VectorXDecisionVariable>& x,
     const Variable& t) const {
@@ -94,7 +199,7 @@ HyperEllipsoid::DoAddPointInNonnegativeScalingConstraints(
 }
 
 std::pair<std::unique_ptr<Shape>, RigidTransformd>
-HyperEllipsoid::DoToShapeWithPose() const {
+Hyperellipsoid::DoToShapeWithPose() const {
   // Use {R*D*u + center | |u|₂ ≤ 1} representation, but where R is an
   // orthonormal matrix representing a pure rotation and D is a positive
   // diagonal matrix representing a pure scaling. We obtain this via the
@@ -121,16 +226,12 @@ HyperEllipsoid::DoToShapeWithPose() const {
   return std::make_pair(std::move(shape), X_WG);
 }
 
-HyperEllipsoid HyperEllipsoid::MakeUnitBall(int dim) {
-  return HyperEllipsoid(MatrixXd::Identity(dim, dim), VectorXd::Zero(dim));
-}
-
-void HyperEllipsoid::ImplementGeometry(const Sphere& sphere, void* data) {
+void Hyperellipsoid::ImplementGeometry(const Sphere& sphere, void* data) {
   auto* A = static_cast<Eigen::Matrix3d*>(data);
   *A = Eigen::Matrix3d::Identity() / sphere.radius();
 }
 
-void HyperEllipsoid::ImplementGeometry(const Ellipsoid& ellipsoid, void* data) {
+void Hyperellipsoid::ImplementGeometry(const Ellipsoid& ellipsoid, void* data) {
   // x²/a² + y²/b² + z²/c² = 1 in quadratic form is
   // xᵀ * diag(1/a^2, 1/b^2, 1/c^2) * x = 1 and A is the square root.
   auto* A = static_cast<Eigen::Matrix3d*>(data);

--- a/geometry/optimization/point.cc
+++ b/geometry/optimization/point.cc
@@ -24,7 +24,7 @@ Point::Point(const Eigen::Ref<const Eigen::VectorXd>& x)
     : ConvexSet(&ConvexSetCloner<Point>, x.size()), x_{x} {}
 
 Point::Point(const QueryObject<double>& query_object, GeometryId geometry_id,
-             std::optional<FrameId> expressed_in,
+             std::optional<FrameId> reference_frame,
              double maximum_allowable_radius)
     : ConvexSet(&ConvexSetCloner<Point>, 3) {
   double radius = -1.0;
@@ -36,9 +36,9 @@ Point::Point(const QueryObject<double>& query_object, GeometryId geometry_id,
                     geometry_id, radius, maximum_allowable_radius));
   }
 
-  const RigidTransformd X_WE = expressed_in
-                                   ? query_object.GetPoseInWorld(*expressed_in)
-                                   : RigidTransformd::Identity();
+  const RigidTransformd X_WE =
+      reference_frame ? query_object.GetPoseInWorld(*reference_frame)
+                      : RigidTransformd::Identity();
   const RigidTransformd& X_WG = query_object.GetPoseInWorld(geometry_id);
   const RigidTransformd X_EG = X_WE.InvertAndCompose(X_WG);
   x_ = X_EG.translation();
@@ -51,7 +51,7 @@ bool Point::DoPointInSet(const Eigen::Ref<const Eigen::VectorXd>& x,
   return is_approx_equal_abstol(x, x_, tol);
 }
 
-void Point::DoAddPointInSetConstraint(
+void Point::DoAddPointInSetConstraints(
     MathematicalProgram* prog,
     const Eigen::Ref<const VectorXDecisionVariable>& x) const {
   prog->AddBoundingBoxConstraint(x_, x_, x);

--- a/geometry/optimization/point.h
+++ b/geometry/optimization/point.h
@@ -12,7 +12,10 @@ namespace geometry {
 namespace optimization {
 
 /** A convex set that contains exactly one element.  Also known as a
-singleton or unit set. */
+singleton or unit set.
+
+@ingroup geometry_optimization
+*/
 class Point final : public ConvexSet {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Point)
@@ -21,13 +24,14 @@ class Point final : public ConvexSet {
   explicit Point(const Eigen::Ref<const Eigen::VectorXd>& x);
 
   /** Constructs a Point from a SceneGraph geometry and pose in
-  the @p expressed_in frame, obtained via the QueryObject. If @p expressed_in
-  frame is std::nullopt, then it will be expressed in the world frame.
+  the @p reference_frame frame, obtained via the QueryObject. If @p
+  reference_frame frame is std::nullopt, then it will be expressed in the world
+  frame.
 
   @throws std::exception if geometry_id does not correspond to a Sphere or if
   the Sphere has radius greater than @p maximum_allowable_radius. */
   Point(const QueryObject<double>& query_object, GeometryId geometry_id,
-        std::optional<FrameId> expressed_in = std::nullopt,
+        std::optional<FrameId> reference_frame = std::nullopt,
         double maximum_allowable_radius = 0.0);
 
   ~Point() final;
@@ -39,10 +43,12 @@ class Point final : public ConvexSet {
   const Eigen::VectorXd& x() const { return x_; }
 
  private:
+  bool DoIsBounded() const final { return true; }
+
   bool DoPointInSet(const Eigen::Ref<const Eigen::VectorXd>& x,
                     double tol) const final;
 
-  void DoAddPointInSetConstraint(
+  void DoAddPointInSetConstraints(
       solvers::MathematicalProgram*,
       const Eigen::Ref<const solvers::VectorXDecisionVariable>&) const final;
 

--- a/geometry/optimization/test/convex_set_test.cc
+++ b/geometry/optimization/test/convex_set_test.cc
@@ -1,0 +1,90 @@
+#include "drake/geometry/optimization/convex_set.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/is_approx_equal_abstol.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+
+namespace drake {
+namespace geometry {
+namespace optimization {
+namespace {
+
+using Eigen::Vector2d;
+using Eigen::Vector3d;
+
+class MutablePoint final : public ConvexSet {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(MutablePoint)
+
+  explicit MutablePoint(const Eigen::Ref<const Eigen::VectorXd>& x)
+      : ConvexSet(&ConvexSetCloner<MutablePoint>, x.size()), x_{x} {}
+  ~MutablePoint() final {}
+
+  const Eigen::VectorXd& x() const { return x_; }
+  Eigen::VectorXd& x() { return x_; }
+
+ private:
+  // These are unused, and (effectively) unimplemented.
+  bool DoIsBounded() const final { return true; }
+
+  bool DoPointInSet(const Eigen::Ref<const Eigen::VectorXd>& x,
+                    double tol) const final {
+      return is_approx_equal_abstol(x, x_, tol);
+  }
+
+  void DoAddPointInSetConstraints(
+      solvers::MathematicalProgram*,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>&) const final {
+    throw std::runtime_error("Not implemented");
+  }
+
+  std::vector<solvers::Binding<solvers::Constraint>>
+  DoAddPointInNonnegativeScalingConstraints(
+      solvers::MathematicalProgram* prog,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>& x,
+      const symbolic::Variable& t) const final {
+    throw std::runtime_error("Not implemented");
+  }
+
+  std::pair<std::unique_ptr<Shape>, math::RigidTransformd> DoToShapeWithPose()
+      const final {
+    throw std::runtime_error("Not implemented");
+  }
+
+  Eigen::VectorXd x_;
+};
+
+GTEST_TEST(ConvexSetsTest, BasicTest) {
+  ConvexSets sets;
+
+  const ConvexSet& a = sets.emplace_back(MutablePoint(Vector2d{1., 2.}));
+  const Vector3d b_point{3., 4., 5.};
+  std::unique_ptr<MutablePoint> b_original =
+      std::make_unique<MutablePoint>(b_point);
+  MutablePoint* b_pointer = b_original.get();
+  const ConvexSet& b = sets.emplace_back(std::move(b_original));
+
+  EXPECT_EQ(a.ambient_dimension(), 2);
+  EXPECT_EQ(b.ambient_dimension(), 3);
+
+  EXPECT_EQ(sets.size(), 2);
+  EXPECT_EQ(sets[0].ambient_dimension(), 2);
+  EXPECT_EQ(sets[1].ambient_dimension(), 3);
+
+  // Confirm that I can move without copying the underlying data.
+  ConvexSets moved = std::move(sets);
+  EXPECT_EQ(moved.size(), 2);
+  EXPECT_EQ(moved[0].ambient_dimension(), 2);
+  EXPECT_EQ(moved[1].ambient_dimension(), 3);
+  EXPECT_TRUE(moved[1].PointInSet(b_point));
+  const Vector3d new_point{6., 7., 8.};
+  EXPECT_FALSE(moved[1].PointInSet(new_point));
+  b_pointer->x() = new_point;
+  EXPECT_TRUE(moved[1].PointInSet(new_point));
+}
+}  // namespace
+
+}  // namespace optimization
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/optimization/test/point_test.cc
+++ b/geometry/optimization/test/point_test.cc
@@ -16,8 +16,9 @@ namespace drake {
 namespace geometry {
 namespace optimization {
 
+using Eigen::Vector2d;
 using Eigen::Vector3d;
-using internal::CheckAddPointInSetConstraint;
+using internal::CheckAddPointInSetConstraints;
 using internal::MakeSceneGraphWithShape;
 using math::RigidTransformd;
 using math::RotationMatrixd;
@@ -37,8 +38,9 @@ GTEST_TEST(PointTest, BasicTest) {
   EXPECT_FALSE(P.PointInSet(p_W + Vector3d::Constant(0.01)));
   EXPECT_TRUE(P.PointInSet(p_W + Vector3d::Constant(0.01), 0.01 + 1e-16));
 
-  EXPECT_TRUE(CheckAddPointInSetConstraint(P, p_W));
-  EXPECT_FALSE(CheckAddPointInSetConstraint(P, p_W + Vector3d::Constant(0.01)));
+  EXPECT_TRUE(CheckAddPointInSetConstraints(P, p_W));
+  EXPECT_FALSE(
+      CheckAddPointInSetConstraints(P, p_W + Vector3d::Constant(0.01)));
 
   // Test ToShapeWithPose.
   auto [shape, X_WG] = P.ToShapeWithPose();
@@ -46,6 +48,9 @@ GTEST_TEST(PointTest, BasicTest) {
   EXPECT_TRUE(sphere != NULL);
   EXPECT_NEAR(sphere->radius(), 0.0, 0.0);
   EXPECT_TRUE(CompareMatrices(X_WG.translation(), p_W, 1e-16));
+
+  // Test IsBounded (which is trivially true for Point).
+  EXPECT_TRUE(P.IsBounded());
 }
 
 GTEST_TEST(PointTest, FromSceneGraphTest) {
@@ -70,7 +75,7 @@ GTEST_TEST(PointTest, FromSceneGraphTest) {
   EXPECT_THROW(Point(query, geom_id, std::nullopt, kRadius / 2.0),
                std::exception);
 
-  // Test expressed_in frame.
+  // Test reference_frame frame.
   SourceId source_id = scene_graph->RegisterSource("F");
   FrameId frame_id = scene_graph->RegisterFrame(source_id, GeometryFrame("F"));
   auto context2 = scene_graph->CreateDefaultContext();

--- a/geometry/optimization/test/vpolytope_test.cc
+++ b/geometry/optimization/test/vpolytope_test.cc
@@ -19,7 +19,7 @@ namespace geometry {
 namespace optimization {
 
 using Eigen::Vector3d;
-using internal::CheckAddPointInSetConstraint;
+using internal::CheckAddPointInSetConstraints;
 using internal::MakeSceneGraphWithShape;
 using math::RigidTransformd;
 using math::RotationMatrixd;
@@ -38,6 +38,9 @@ GTEST_TEST(VPolytopeTest, TriangleTest) {
   EXPECT_EQ(V.ambient_dimension(), 2);
   EXPECT_TRUE(CompareMatrices(V.vertices(), triangle));
 
+  // Check IsBounded (which is trivially true for V Polytopes).
+  EXPECT_TRUE(V.IsBounded());
+
   const Eigen::Vector2d center = triangle.rowwise().mean();
   // Mosek worked with 1e-15.
   // Gurobi worked with 1e-15 (see the note about alpha_sol in the method).
@@ -48,8 +51,8 @@ GTEST_TEST(VPolytopeTest, TriangleTest) {
     const Eigen::Vector2d v = triangle.col(i);
     const Eigen::Vector2d at_tol =
         v + kTol * (v - center) / ((v - center).lpNorm<Eigen::Infinity>());
-    EXPECT_TRUE(CompareMatrices(v, at_tol, 2.0*kTol));
-    EXPECT_FALSE(CompareMatrices(v, at_tol, .5*kTol));
+    EXPECT_TRUE(CompareMatrices(v, at_tol, 2.0 * kTol));
+    EXPECT_FALSE(CompareMatrices(v, at_tol, .5 * kTol));
 
     EXPECT_TRUE(V.PointInSet(v, kTol));
     EXPECT_TRUE(V.PointInSet(at_tol, 2.0 * kTol));
@@ -71,10 +74,10 @@ GTEST_TEST(VPolytopeTest, UnitBoxTest) {
   EXPECT_TRUE(V.PointInSet(in2_W, kTol));
   EXPECT_FALSE(V.PointInSet(out_W, kTol));
 
-  // Test AddPointInSetConstraint.
-  EXPECT_TRUE(CheckAddPointInSetConstraint(V, in1_W));
-  EXPECT_TRUE(CheckAddPointInSetConstraint(V, in2_W));
-  EXPECT_FALSE(CheckAddPointInSetConstraint(V, out_W));
+  // Test AddPointInSetConstraints.
+  EXPECT_TRUE(CheckAddPointInSetConstraints(V, in1_W));
+  EXPECT_TRUE(CheckAddPointInSetConstraints(V, in2_W));
+  EXPECT_FALSE(CheckAddPointInSetConstraints(V, out_W));
 
   // Test SceneGraph constructor.
   auto [scene_graph, geom_id] =
@@ -115,11 +118,11 @@ GTEST_TEST(VPolytopeTest, ArbitraryBoxTest) {
   EXPECT_TRUE(V.PointInSet(in2_W, kTol));
   EXPECT_FALSE(V.PointInSet(out_W, kTol));
 
-  EXPECT_TRUE(CheckAddPointInSetConstraint(V, in1_W));
-  EXPECT_TRUE(CheckAddPointInSetConstraint(V, in2_W));
-  EXPECT_FALSE(CheckAddPointInSetConstraint(V, out_W));
+  EXPECT_TRUE(CheckAddPointInSetConstraints(V, in1_W));
+  EXPECT_TRUE(CheckAddPointInSetConstraints(V, in2_W));
+  EXPECT_FALSE(CheckAddPointInSetConstraints(V, out_W));
 
-  // Test expressed_in frame.
+  // Test reference_frame frame.
   SourceId source_id = scene_graph->RegisterSource("F");
   FrameId frame_id = scene_graph->RegisterFrame(source_id, GeometryFrame("F"));
   auto context2 = scene_graph->CreateDefaultContext();

--- a/geometry/optimization/test_utilities.cc
+++ b/geometry/optimization/test_utilities.cc
@@ -28,11 +28,11 @@ MakeSceneGraphWithShape(const Shape& shape, const RigidTransformd& X_WG) {
 }
 
 // Returns true iff the convex optimization can make the `point` be in the set.
-bool CheckAddPointInSetConstraint(
+bool CheckAddPointInSetConstraints(
     const ConvexSet& set, const Eigen::Ref<const Eigen::VectorXd>& point) {
   solvers::MathematicalProgram prog;
   auto x = prog.NewContinuousVariables(point.size());
-  set.AddPointInSetConstraint(&prog, x);
+  set.AddPointInSetConstraints(&prog, x);
   // x = point.
   prog.AddBoundingBoxConstraint(point, point, x);
   return solvers::Solve(prog).is_success();

--- a/geometry/optimization/test_utilities.h
+++ b/geometry/optimization/test_utilities.h
@@ -19,7 +19,7 @@ std::tuple<std::unique_ptr<SceneGraph<double>>, GeometryId>
 MakeSceneGraphWithShape(const Shape& shape, const math::RigidTransformd& X_WG);
 
 // Returns true iff the convex optimization can make the `point` be in the set.
-bool CheckAddPointInSetConstraint(
+bool CheckAddPointInSetConstraints(
     const ConvexSet& set, const Eigen::Ref<const Eigen::VectorXd>& point);
 
 }  // namespace internal

--- a/geometry/optimization/vpolytope.h
+++ b/geometry/optimization/vpolytope.h
@@ -18,7 +18,10 @@ namespace optimization {
 
  Note: Unlike the half-space representation, this
  definition means the set is always bounded (hence the name polytope, instead of
- polyhedron). */
+ polyhedron).
+ 
+@ingroup geometry_optimization
+*/
 class VPolytope final : public ConvexSet {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(VPolytope)
@@ -30,7 +33,7 @@ class VPolytope final : public ConvexSet {
 
   /** Construct the polytope from a SceneGraph geometry. */
   VPolytope(const QueryObject<double>& query_object, GeometryId geometry_id,
-            std::optional<FrameId> expressed_in = std::nullopt);
+            std::optional<FrameId> reference_frame = std::nullopt);
 
   ~VPolytope() final;
 
@@ -55,10 +58,12 @@ class VPolytope final : public ConvexSet {
   static VPolytope MakeUnitBox(int dim);
 
  private:
+  bool DoIsBounded() const { return true; }
+
   bool DoPointInSet(const Eigen::Ref<const Eigen::VectorXd>& x,
                     double tol) const final;
 
-  void DoAddPointInSetConstraint(
+  void DoAddPointInSetConstraints(
       solvers::MathematicalProgram*,
       const Eigen::Ref<const solvers::VectorXDecisionVariable>&) const final;
 


### PR DESCRIPTION
Also includes a ConvexSets (plural) container as my proposed solution to memory management for workflows like this:
```
ConvexSets MakeIrisObstacles(
    const QueryObject<double>& query_object,
    std::optional<FrameId> reference_frame = std::nullopt);
HPolyhedron Iris(const ConvexSets& obstacles,
                 const Eigen::Ref<const Eigen::VectorXd>& sample,
                 const HPolyhedron& domain,
                 const IrisOptions& options = IrisOptions());
```

Also includes a number of small fix-ups and style updates:
- HyperEllipsoid => Hyperellipsoid (per discussion with Sean)
- AddPointInSetConstraint => AddPointInSetConstraints
- expressed_in => reference_frame
This are API breaking changes, but we marked the classes as Experimental so that we could do this in the early stages.

This is not chopped up quite as finely as I've been trying to do so far.  But it's the last batch of changes, which had been piling up, before I land the IRIS algorithm in the next PR.  I hope it's ok(better?) this way for my reviewers!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15314)
<!-- Reviewable:end -->
