### PR TITLE
Switch default eval_type of LorentzConeConstraint to ConvexSmooth.

### DIFF
--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -1529,7 +1529,7 @@ for every column of ``prog_var_vals``. )""")
         return std::make_unique<LorentzConeConstraint>(A, b, eval_type);
       }),
           py::arg("A"), py::arg("b"),
-          py::arg("eval_type") = LorentzConeConstraint::EvalType::kConvex,
+          py::arg("eval_type") = LorentzConeConstraint::EvalType::kConvexSmooth,
           doc.LorentzConeConstraint.ctor.doc)
       .def("A", &LorentzConeConstraint::A, doc.LorentzConeConstraint.A.doc)
       .def("b", &LorentzConeConstraint::b, doc.LorentzConeConstraint.b.doc);

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -1276,6 +1276,7 @@ drake_cc_googletest(
         ":mathematical_program_test_util",
         ":optimization_examples",
         ":quadratic_program_examples",
+        ":second_order_cone_program_examples",
         "//common/test_utilities:eigen_matrix_compare",
     ] + select({
         "//conditions:default": [
@@ -1567,6 +1568,7 @@ drake_cc_googletest(
         ":mathematical_program_test_util",
         ":optimization_examples",
         ":quadratic_program_examples",
+        ":second_order_cone_program_examples",
         "//common:filesystem",
         "//common:temp_directory",
         "//common/test_utilities:eigen_matrix_compare",

--- a/solvers/constraint.h
+++ b/solvers/constraint.h
@@ -304,14 +304,20 @@ class LorentzConeConstraint : public Constraint {
    * formulations, refer to LorentzConeConstraint documentation.
    */
   enum class EvalType {
-    kConvex,  ///< The constraint is g(z) = z₀ - sqrt(z₁² + ... + zₙ₋₁²) ≥ 0
-    kConvexSmooth,  ///< Same as kConvex1, but with approximated gradient.
-    kNonconvex  ///< Nonconvex constraint z₀²-(z₁²+...+zₙ₋₁²) ≥ 0 and z₀ ≥ 0
+    kConvex,  ///< The constraint is g(z) = z₀ - sqrt(z₁² + ... + zₙ₋₁²) ≥ 0.
+              ///< Note this formulation is non-differentiable at z₁= ...=
+              ///< zₙ₋₁=0
+    kConvexSmooth,  ///< Same as kConvex, but with approximated gradient that
+                    ///< exists everywhere..
+    kNonconvex  ///< Nonconvex constraint z₀²-(z₁²+...+zₙ₋₁²) ≥ 0 and z₀ ≥ 0.
+                ///< Note this formulation is differentiable, but at z₁= ...=
+                ///< zₙ₋₁=0 the gradient is also 0, so a gradient-based
+                ///< nonlinear solver can get stuck.
   };
 
   LorentzConeConstraint(const Eigen::Ref<const Eigen::MatrixXd>& A,
                         const Eigen::Ref<const Eigen::VectorXd>& b,
-                        EvalType eval_type = EvalType::kConvex);
+                        EvalType eval_type = EvalType::kConvexSmooth);
 
   ~LorentzConeConstraint() override {}
 

--- a/solvers/test/ipopt_solver_test.cc
+++ b/solvers/test/ipopt_solver_test.cc
@@ -6,6 +6,7 @@
 #include "drake/solvers/test/linear_program_examples.h"
 #include "drake/solvers/test/mathematical_program_test_util.h"
 #include "drake/solvers/test/quadratic_program_examples.h"
+#include "drake/solvers/test/second_order_cone_program_examples.h"
 
 #ifdef DRAKE_IPOPT_SOLVER_TEST_HAS_IPOPT
 
@@ -208,6 +209,63 @@ GTEST_TEST(IpoptSolverTest, TestNonconvexQP) {
   if (solver.available()) {
     TestNonconvexQP(solver, false);
   }
+}
+
+TEST_P(TestEllipsoidsSeparation, TestSOCP) {
+  IpoptSolver ipopt_solver;
+  if (ipopt_solver.available()) {
+    SolveAndCheckSolution(ipopt_solver, 1.E-8);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    IpoptSolverTest, TestEllipsoidsSeparation,
+    ::testing::ValuesIn({EllipsoidsSeparationProblem::kProblem0,
+                         EllipsoidsSeparationProblem::kProblem1,
+                         EllipsoidsSeparationProblem::kProblem3}));
+
+TEST_P(TestQPasSOCP, TestSOCP) {
+  IpoptSolver ipopt_solver;
+  if (ipopt_solver.available()) {
+    SolveAndCheckSolution(ipopt_solver);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(IpoptSolverTest, TestQPasSOCP,
+                         ::testing::ValuesIn(GetQPasSOCPProblems()));
+
+TEST_P(TestFindSpringEquilibrium, TestSOCP) {
+  IpoptSolver ipopt_solver;
+  if (ipopt_solver.available()) {
+    SolveAndCheckSolution(ipopt_solver, 2E-3);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    IpoptSolverTest, TestFindSpringEquilibrium,
+    ::testing::ValuesIn(GetFindSpringEquilibriumProblems()));
+
+GTEST_TEST(TestSOCP, MaximizeGeometricMeanTrivialProblem1) {
+  MaximizeGeometricMeanTrivialProblem1 prob;
+  IpoptSolver solver;
+  if (solver.available()) {
+    const auto result = solver.Solve(prob.prog(), {}, {});
+    prob.CheckSolution(result, 4E-6);
+  }
+}
+
+GTEST_TEST(TestSOCP, MaximizeGeometricMeanTrivialProblem2) {
+  MaximizeGeometricMeanTrivialProblem2 prob;
+  IpoptSolver solver;
+  if (solver.available()) {
+    const auto result = solver.Solve(prob.prog(), {}, {});
+    prob.CheckSolution(result, 1.E-6);
+  }
+}
+
+GTEST_TEST(TestSOCP, SmallestEllipsoidCoveringProblem) {
+  IpoptSolver solver;
+  SolveAndCheckSmallestEllipsoidCoveringProblems(solver, 1E-6);
 }
 }  // namespace test
 }  // namespace solvers

--- a/solvers/test/snopt_solver_test.cc
+++ b/solvers/test/snopt_solver_test.cc
@@ -17,6 +17,7 @@
 #include "drake/solvers/test/linear_program_examples.h"
 #include "drake/solvers/test/mathematical_program_test_util.h"
 #include "drake/solvers/test/quadratic_program_examples.h"
+#include "drake/solvers/test/second_order_cone_program_examples.h"
 
 namespace drake {
 namespace solvers {
@@ -531,6 +532,46 @@ GTEST_TEST(SnoptSolverTest, TestNonconvexQP) {
   }
 }
 
+TEST_P(TestEllipsoidsSeparation, TestSOCP) {
+  SnoptSolver snopt_solver;
+  if (snopt_solver.available()) {
+    SolveAndCheckSolution(snopt_solver, 1.E-8);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SnoptTest, TestEllipsoidsSeparation,
+    ::testing::ValuesIn(GetEllipsoidsSeparationProblems()));
+
+TEST_P(TestQPasSOCP, TestSOCP) {
+  SnoptSolver snopt_solver;
+  if (snopt_solver.available()) {
+    SolveAndCheckSolution(snopt_solver);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(SnoptTest, TestQPasSOCP,
+                         ::testing::ValuesIn(GetQPasSOCPProblems()));
+
+TEST_P(TestFindSpringEquilibrium, TestSOCP) {
+  SnoptSolver snopt_solver;
+  if (snopt_solver.available()) {
+    SolveAndCheckSolution(snopt_solver, 2E-3);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SnoptTest, TestFindSpringEquilibrium,
+    ::testing::ValuesIn(GetFindSpringEquilibriumProblems()));
+
+GTEST_TEST(TestSOCP, MaximizeGeometricMeanTrivialProblem1) {
+  MaximizeGeometricMeanTrivialProblem1 prob;
+  SnoptSolver solver;
+  if (solver.available()) {
+    const auto result = solver.Solve(prob.prog(), {}, {});
+    prob.CheckSolution(result, 4E-6);
+  }
+}
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake


### PR DESCRIPTION
Also add test for ipopt and snopt with Lorentz cone constraint

Resolves #15316

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15318)
<!-- Reviewable:end -->
