### PR TITLE
robot_plan_interpolator_test: Use EXPECT_NEAR instead of EXPECT_FLOAT_EQ

### DIFF
--- a/manipulation/planner/test/robot_plan_interpolator_test.cc
+++ b/manipulation/planner/test/robot_plan_interpolator_test.cc
@@ -186,9 +186,9 @@ void DoTrajectoryTest(InterpolatorType interp_type) {
     const double accel =
         output->get_vector_data(dut.get_acceleration_output_port().get_index())
             ->GetAtIndex(0);
-    EXPECT_FLOAT_EQ(velocity, 0)
+    EXPECT_NEAR(velocity, 0, 1e-15)
               << "Failed at interpolator type: " << interp_str;
-    EXPECT_FLOAT_EQ(accel, 0)
+    EXPECT_NEAR(accel, 0, 1e-15)
               << "Failed at interpolator type: " << interp_str;
   }
 


### PR DESCRIPTION
Preparing for the release of Eigen 3.4, working towards #14968.

The `robot_plan_interlator_test` fails after updating to Eigen 3.4. Increase the tolerance of the failing comparisons.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15322)
<!-- Reviewable:end -->
