### PR TITLE
Ensure we're using drake::all not Eigen::all

### DIFF
--- a/common/drake_bool.h
+++ b/common/drake_bool.h
@@ -49,7 +49,7 @@ boolean<typename Derived::Scalar> all_of(
     const Eigen::MatrixBase<Derived>& m,
     const std::function<boolean<typename Derived::Scalar>(
         const typename Derived::Scalar&)>& pred) {
-  return all(m.unaryExpr(pred));
+  return drake::all(m.unaryExpr(pred));
 }
 
 /// Checks truth for at least one element in matrix @p m.  This is identical to
@@ -81,7 +81,7 @@ template <typename Derived>
 typename Derived::Scalar none(const Eigen::MatrixBase<Derived>& m) {
   using Boolish = typename Derived::Scalar;
   const auto negate = [](const Boolish& v) -> Boolish { return !v; };
-  return all(m.unaryExpr(negate));
+  return drake::all(m.unaryExpr(negate));
 }
 
 /// Checks if unary predicate @p pred holds for no elements in the matrix @p m.

--- a/common/test/drake_bool_test.cc
+++ b/common/test/drake_bool_test.cc
@@ -45,12 +45,12 @@ TEST_F(BoolTestDouble, TypeCheck) {
 
 TEST_F(BoolTestDouble, All) {
   auto bools = Eigen::Matrix<bool, 3, 3>::Constant(true).eval();
-  EXPECT_TRUE(all(bools));
+  EXPECT_TRUE(drake::all(bools));
   bools(0, 0) = false;
-  EXPECT_FALSE(all(bools));
+  EXPECT_FALSE(drake::all(bools));
 
   // Vacuously true.
-  EXPECT_TRUE(all(Eigen::Matrix<bool, 0, 0>::Constant(false)));
+  EXPECT_TRUE(drake::all(Eigen::Matrix<bool, 0, 0>::Constant(false)));
 }
 
 TEST_F(BoolTestDouble, AllOf) {
@@ -210,7 +210,7 @@ TEST_F(BoolTestSymbolic, All) {
                isnan(x_) && isnan(y_) && isnan(z_) && isnan(w_));
 
   // Vacuously true.
-  EXPECT_TRUE(all(MatrixX<Formula>::Constant(0, 0, Formula::False())));
+  EXPECT_TRUE(drake::all(MatrixX<Formula>::Constant(0, 0, Formula::False())));
 }
 
 TEST_F(BoolTestSymbolic, AllOf) {

--- a/common/trajectories/bspline_trajectory.cc
+++ b/common/trajectories/bspline_trajectory.cc
@@ -170,7 +170,7 @@ boolean<T> BsplineTrajectory<T>::operator==(
       this->cols() == other.cols()) {
     boolean<T> result{true};
     for (int i = 0; i < this->num_control_points(); ++i) {
-      result = result && all(this->control_points()[i].array() ==
+      result = result && drake::all(this->control_points()[i].array() ==
                              other.control_points()[i].array());
       if (std::equal_to<boolean<T>>{}(result, boolean<T>{false})) {
         break;


### PR DESCRIPTION
Preparing for the release of Eigen 3.4, working towards #14968.

The 'all' function was introduced to `Eigen/src/Core/util/Macros.h` at [af96018b](https://gitlab.com/libeigen/eigen/-/commit/af96018b499be64ff0b262cafc7b31f1a907b4c8)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15323)
<!-- Reviewable:end -->
