### PR TITLE
[framework] Move SystemScalarConverter error message to cc file

### DIFF
--- a/systems/framework/system_scalar_converter.cc
+++ b/systems/framework/system_scalar_converter.cc
@@ -1,7 +1,12 @@
 #include "drake/systems/framework/system_scalar_converter.h"
 
+#include <stdexcept>
+
+#include <fmt/format.h>
+
 #include "drake/common/default_scalars.h"
 #include "drake/common/hash.h"
+#include "drake/common/nice_type_name.h"
 
 using std::pair;
 using std::type_index;
@@ -61,6 +66,20 @@ void SystemScalarConverter::RemoveUnlessAlsoSupportedBy(
     }
   }
 }
+
+namespace system_scalar_converter_internal {
+
+void ThrowConversionMismatch(
+    const type_info& s_t_info, const type_info& s_u_info,
+    const type_info& other_info) {
+  throw std::runtime_error(fmt::format(
+      "SystemScalarConverter was configured to convert a {} into a {}"
+      " but was called with a {} at runtime",
+      NiceTypeName::Get(s_u_info), NiceTypeName::Get(s_t_info),
+      NiceTypeName::Get(other_info)));
+}
+
+}  // namespace system_scalar_converter_internal
 
 DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((
     &SystemScalarConverter::Remove<T, U>

--- a/systems/framework/test/system_scalar_converter_test.cc
+++ b/systems/framework/test/system_scalar_converter_test.cc
@@ -243,7 +243,7 @@ GTEST_TEST(SystemScalarConverterTest, SubclassMismatch) {
         EXPECT_THAT(
             std::string(e.what()),
             testing::MatchesRegex(
-                "SystemScalarConverter::Convert was configured to convert a "
+                "SystemScalarConverter was configured to convert a "
                 ".*::AnyToAnySystem<double> into a "
                 ".*::AnyToAnySystem<drake::AutoDiffXd> but was called with a "
                 ".*::SubclassOfAnyToAnySystem<double> at runtime"));


### PR DESCRIPTION
Creating ostream output in headers leads to object code bloat, in this case about 0.5% (208 KiB) of libdrake.so was for generating this one error message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15328)
<!-- Reviewable:end -->
