### PR TITLE
[test_utilities] Default expected exception type to std::exception

### DIFF
--- a/common/schema/test/stochastic_test.cc
+++ b/common/schema/test/stochastic_test.cc
@@ -407,7 +407,6 @@ value: !Deterministic { value: 2.0 }
   FixedSize2 parsed;
   DRAKE_EXPECT_THROWS_MESSAGE(
       YamlReadArchive(YAML::Load(input)).Accept(&parsed),
-      std::exception,
       ".*unsupported type tag !Deterministic while selecting a variant<> entry"
       " for std::variant<.*> value.*");
 }

--- a/common/test/filesystem_test.cc
+++ b/common/test/filesystem_test.cc
@@ -23,7 +23,7 @@ GTEST_TEST(NamespaceAliasSmokeTest, ExistTest) {
   EXPECT_FALSE(filesystem::is_directory({"/no/such/path"}));
 
   DRAKE_EXPECT_THROWS_MESSAGE(
-      filesystem::read_symlink({"/no_such_readlink"}), std::exception,
+      filesystem::read_symlink({"/no_such_readlink"}),
       ".*(No such file or directory|Invalid argument).+/no_such_readlink.+");
 }
 

--- a/common/test/identifier_test.cc
+++ b/common/test/identifier_test.cc
@@ -217,25 +217,21 @@ TEST_F(IdentifierTests, InvalidGetValueCall) {
   AId invalid;
   DRAKE_EXPECT_THROWS_MESSAGE(
       unused(invalid.get_value()),
-      std::exception, ".*is_valid.*failed.*");
+      ".*is_valid.*failed.*");
 }
 
 // Comparison of invalid ids is an error.
 TEST_F(IdentifierTests, InvalidEqualityCompare) {
   if (kDrakeAssertIsDisarmed) { return; }
   AId invalid;
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      unused(invalid == a1_),
-      std::exception, ".*is_valid.*failed.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(unused(invalid == a1_), ".*is_valid.*failed.*");
 }
 
 // Comparison of invalid ids is an error.
 TEST_F(IdentifierTests, InvalidInequalityCompare) {
   if (kDrakeAssertIsDisarmed) { return; }
   AId invalid;
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      unused(invalid != a1_),
-      std::exception, ".*is_valid.*failed.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(unused(invalid != a1_), ".*is_valid.*failed.*");
 }
 
 // Hashing an invalid id is *not* an error.
@@ -253,9 +249,7 @@ TEST_F(IdentifierTests, InvalidStream) {
   if (kDrakeAssertIsDisarmed) { return; }
   AId invalid;
   std::stringstream ss;
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      unused(ss << invalid),
-      std::exception, ".*is_valid.*failed.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(unused(ss << invalid), ".*is_valid.*failed.*");
 }
 
 }  // namespace

--- a/common/yaml/test/yaml_write_archive_test.cc
+++ b/common/yaml/test/yaml_write_archive_test.cc
@@ -191,7 +191,6 @@ TEST_F(YamlWriteArchiveTest, Variant) {
   // does not yet support that output syntax.
   DRAKE_EXPECT_THROWS_MESSAGE(
       Save(VariantStruct{double{1.0}}),
-      std::exception,
       "Cannot YamlWriteArchive the variant type double with a non-zero index");
 }
 

--- a/geometry/proximity/test/characterization_utilities.cc
+++ b/geometry/proximity/test/characterization_utilities.cc
@@ -461,7 +461,6 @@ void CharacterizeResultTest<T>::RunCallback(
     case kThrows:
       DRAKE_ASSERT_THROWS_MESSAGE(
           callback_->Invoke(obj_A, obj_B, collision_filter, X_WGs),
-          std::exception,
           ".+ queries between shapes .+ and .+ are not supported.+");
       break;
   }

--- a/geometry/proximity/test/mesh_deformer_test.cc
+++ b/geometry/proximity/test/mesh_deformer_test.cc
@@ -76,12 +76,12 @@ class MeshDeformerTest : public ::testing::Test {
 
     const VectorX<T> too_small(q_size- 1);
     DRAKE_EXPECT_THROWS_MESSAGE(
-        deformer_.SetAllPositions(too_small), std::exception,
+        deformer_.SetAllPositions(too_small),
         ".+SetAllPositions.+ \\d+ vertices with data for \\d+ vertices");
 
     const VectorX<T> too_large(q_size + 1);
     DRAKE_EXPECT_THROWS_MESSAGE(
-        deformer_.SetAllPositions(too_large), std::exception,
+        deformer_.SetAllPositions(too_large),
         ".+SetAllPositions.+ \\d+ vertices with data for \\d+ vertices");
   }
 

--- a/geometry/proximity/test/obj_to_surface_mesh_test.cc
+++ b/geometry/proximity/test/obj_to_surface_mesh_test.cc
@@ -183,7 +183,6 @@ GTEST_TEST(ObjToSurfaceMeshTest, WarningCallback) {
     std::ifstream input(filename);
     DRAKE_EXPECT_THROWS_MESSAGE(
         ReadObjToSurfaceMesh(&input, 1.0, &FailOnWarning),
-        std::exception,
         "FailOnWarning: Warning parsing Wavefront obj file : "
         ".*CubeMaterial.*not found.*");
   }

--- a/geometry/test/drake_visualizer_test.cc
+++ b/geometry/test/drake_visualizer_test.cc
@@ -836,7 +836,7 @@ GTEST_TEST(DrakeVisualizerdTest, Transmogrify) {
   lcm::DrakeLcm lcm;
   DrakeVisualizerd vis_not_own_lcm_d(&lcm);
   DRAKE_EXPECT_THROWS_MESSAGE(
-      vis_not_own_lcm_d.ToAutoDiffXd(), std::exception,
+      vis_not_own_lcm_d.ToAutoDiffXd(),
       "DrakeVisualizer can only be scalar converted if it owns its "
       "DrakeLcmInterface instance.");
 }

--- a/lcm/test/drake_lcm_test.cc
+++ b/lcm/test/drake_lcm_test.cc
@@ -68,11 +68,11 @@ TEST_F(DrakeLcmTest, CustomUrlTest) {
 
 TEST_F(DrakeLcmTest, EmptyChannelTest) {
   auto noop = [](const void*, int) {};
-  DRAKE_EXPECT_THROWS_MESSAGE(dut_->Subscribe("", noop), std::exception,
+  DRAKE_EXPECT_THROWS_MESSAGE(dut_->Subscribe("", noop),
       ".*channel.empty.*");
 
   char data[1] = {};
-  DRAKE_EXPECT_THROWS_MESSAGE(dut_->Publish("", data, 1, {}), std::exception,
+  DRAKE_EXPECT_THROWS_MESSAGE(dut_->Publish("", data, 1, {}),
       ".*channel.empty.*");
 }
 

--- a/math/test/rotation_matrix_test.cc
+++ b/math/test/rotation_matrix_test.cc
@@ -1175,20 +1175,20 @@ GTEST_TEST(RotationMatrixTest, MakeFromOneUnitVectorExceptions) {
   if (kDrakeAssertIsArmed) {
     // Verify vector with NaN throws an exception.
     DRAKE_EXPECT_THROWS_MESSAGE(RotationMatrix<double>::MakeFromOneUnitVector(
-        Vector3<double>(NAN, 1, NAN), axis_index), std::exception,
+        Vector3<double>(NAN, 1, NAN), axis_index),
       "RotationMatrix::MakeFromOneUnitVector.* requires a unit-length vector"
       "[^]+ nan 1.* nan[^]+ is not less than or equal to .+");
 
     // Verify vector with infinity throws an exception.
     constexpr double kInfinity = std::numeric_limits<double>::infinity();
     DRAKE_EXPECT_THROWS_MESSAGE(RotationMatrix<double>::MakeFromOneUnitVector(
-        Vector3<double>(kInfinity, 1, 0), axis_index), std::exception,
+        Vector3<double>(kInfinity, 1, 0), axis_index),
       "RotationMatrix::MakeFromOneUnitVector.* requires a unit-length vector"
       "[^]+ inf 1.* 0[^]+ is not less than or equal to .+");
 
     // Verify non-unit vector throws an exception.
     DRAKE_EXPECT_THROWS_MESSAGE(RotationMatrix<double>::MakeFromOneUnitVector(
-        Vector3<double>(1, 2, 3), axis_index), std::exception,
+        Vector3<double>(1, 2, 3), axis_index),
       "RotationMatrix::MakeFromOneUnitVector.* requires a unit-length vector"
       "[^]+ 1.* 2.* 3.*[^]+ is not less than or equal to .+");
 
@@ -1201,7 +1201,7 @@ GTEST_TEST(RotationMatrixTest, MakeFromOneUnitVectorExceptions) {
     // We conservatively make tol_sqrt = 8 * √(kEpsilon) to ensure it throws.
     double tol_sqrt = 8 * std::sqrt(kEpsilon);  // Large enough to throw.
     DRAKE_EXPECT_THROWS_MESSAGE(RotationMatrix<double>::MakeFromOneUnitVector(
-         Vector3<double>(1, 0, tol_sqrt), axis_index), std::exception,
+         Vector3<double>(1, 0, tol_sqrt), axis_index),
       "RotationMatrix::MakeFromOneUnitVector.* requires a unit-length vector"
       "[^]+ is not less than or equal to .+");
 
@@ -1224,8 +1224,8 @@ GTEST_TEST(RotationMatrixTest, MakeFromOneUnitVectorExceptions) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       RotationMatrix<symbolic::Expression>::MakeFromOneVector(u_symbolic,
                                                               axis_index),
-      std::exception, "RotationMatrix::MakeFromOneUnitVector.* "
-                      "cannot be used with a symbolic type.");
+      "RotationMatrix::MakeFromOneUnitVector.* "
+      "cannot be used with a symbolic type.");
 }
 
 // Verify that the "basic" method MakeFromOneVector() throws an exception in
@@ -1237,7 +1237,7 @@ GTEST_TEST(RotationMatrixTest, MakeFromOneVectorExceptions) {
 
   // Verify vector with NaN throws an exception.
   DRAKE_EXPECT_THROWS_MESSAGE(RotationMatrix<double>::MakeFromOneVector(
-      Vector3<double>(NAN, 1, NAN), axis_index), std::exception,
+      Vector3<double>(NAN, 1, NAN), axis_index),
       "RotationMatrix::MakeFromOneVector.* cannot normalize the given vector"
       "[^]+ nan 1.* nan[^]+ If you are confident that v's direction is "
       "meaningful, pass v.normalized.. in place of v.");
@@ -1245,7 +1245,7 @@ GTEST_TEST(RotationMatrixTest, MakeFromOneVectorExceptions) {
   // Verify vector with infinity throws an exception.
   constexpr double kInfinity = std::numeric_limits<double>::infinity();
   DRAKE_EXPECT_THROWS_MESSAGE(RotationMatrix<double>::MakeFromOneVector(
-      Vector3<double>(kInfinity, 1, 0), axis_index), std::exception,
+      Vector3<double>(kInfinity, 1, 0), axis_index),
       "RotationMatrix::MakeFromOneVector.* cannot normalize the given vector"
       "[^]+ inf 1.* 0[^]+ If you are confident that v's direction is "
       "meaningful, pass v.normalized.. in place of v.");
@@ -1255,7 +1255,6 @@ GTEST_TEST(RotationMatrixTest, MakeFromOneVectorExceptions) {
   const Vector3<double> too_small_vector(1.0E-10 - kTolerance, 0, 0);
   DRAKE_EXPECT_THROWS_MESSAGE(
       RotationMatrix<double>::MakeFromOneVector(too_small_vector, axis_index),
-      std::exception,
       "RotationMatrix::MakeFromOneVector.* cannot normalize the given vector"
       "[^]+ If you are confident that v's direction is meaningful, pass "
       "v.normalized.. in place of v.");
@@ -1276,8 +1275,8 @@ GTEST_TEST(RotationMatrixTest, MakeFromOneVectorExceptions) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       RotationMatrix<symbolic::Expression>::MakeFromOneVector(v_symbolic,
                                                               axis_index),
-      std::exception, "RotationMatrix::MakeFromOneUnitVector.* "
-                      "cannot be used with a symbolic type.");
+      "RotationMatrix::MakeFromOneUnitVector.* "
+      "cannot be used with a symbolic type.");
 }
 
 }  // namespace

--- a/multibody/contact_solvers/test/block_sparse_matrix_test.cc
+++ b/multibody/contact_solvers/test/block_sparse_matrix_test.cc
@@ -100,7 +100,7 @@ TEST_F(BlockSparseMatrixTest, EmptyRow) {
   // builder.PushBlock(1, 2, J_.block(3, 3, 4, 2));  // 3rd block omitted.
   builder.PushBlock(2, 1, J_.block(7, 2, 3, 1));
   builder.PushBlock(2, 3, J_.block(7, 5, 3, 4));
-  DRAKE_EXPECT_THROWS_MESSAGE(builder.Build(), std::exception,
+  DRAKE_EXPECT_THROWS_MESSAGE(builder.Build(),
                               "No block was specified for row 1.");
 }
 
@@ -112,7 +112,7 @@ TEST_F(BlockSparseMatrixTest, EmptyColumn) {
   builder.PushBlock(1, 2, J_.block(3, 3, 4, 2));
   // builder.PushBlock(2, 1, J_.block(7, 2, 3, 1));  // 4th block omitted.
   builder.PushBlock(2, 3, J_.block(7, 5, 3, 4));
-  DRAKE_EXPECT_THROWS_MESSAGE(builder.Build(), std::exception,
+  DRAKE_EXPECT_THROWS_MESSAGE(builder.Build(),
                               "No block was specified for column 1.");
 }
 

--- a/multibody/fixed_fem/dev/test/collision_objects_test.cc
+++ b/multibody/fixed_fem/dev/test/collision_objects_test.cc
@@ -182,7 +182,6 @@ TEST_F(CollisionObjectsTest, AddHalfSpace) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       collision_objects_.AddCollisionObject(id, half_space,
                                             proximity_properties_),
-      std::exception,
       "Trying to make a rigid surface mesh for an unsupported type shape. The "
       "types supported are: Sphere, Box, Cylinder, Capsule, Ellipsoid, Mesh "
       "and Convex. The shape provided is drake::geometry::HalfSpace.");

--- a/multibody/fixed_fem/dev/test/deformable_model_test.cc
+++ b/multibody/fixed_fem/dev/test/deformable_model_test.cc
@@ -99,7 +99,6 @@ TEST_F(DeformableModelTest, RegisterDeformableBodyUniqueNameRequirement) {
             SoftBodyIndex(1));
   EXPECT_EQ(deformable_model_->num_bodies(), 2);
   DRAKE_EXPECT_THROWS_MESSAGE(AddDeformableBox(deformable_model_.get(), "box1"),
-                              std::exception,
                               "RegisterDeformableBody\\(\\): A body with name "
                               "'box1' already exists in the system.");
 }

--- a/multibody/fixed_fem/dev/test/dirichlet_boundary_condition_test.cc
+++ b/multibody/fixed_fem/dev/test/dirichlet_boundary_condition_test.cc
@@ -100,15 +100,15 @@ TEST_F(DirichletBoundaryConditionTest, OutOfBound) {
   bc_.AddBoundaryCondition(DofIndex(4), Vector<double, kOdeOrder + 1>(3, 4));
   State state = MakeState();
   DRAKE_EXPECT_THROWS_MESSAGE(
-    state.ApplyBoundaryCondition(bc_), std::exception,
+    state.ApplyBoundaryCondition(bc_),
           "An index of the dirichlet boundary condition is out of the range.");
   VectorXd b = MakeResidual();
   DRAKE_EXPECT_THROWS_MESSAGE(
-  bc_.ApplyBcToResidual(&b), std::exception,
+  bc_.ApplyBcToResidual(&b),
           "An index of the dirichlet boundary condition is out of the range.");
   SparseMatrix A_sparse = MakeTangentMatrix();
   DRAKE_EXPECT_THROWS_MESSAGE(
-  bc_.ApplyBcToTangentMatrix(&A_sparse), std::exception,
+  bc_.ApplyBcToTangentMatrix(&A_sparse),
           "An index of the dirichlet boundary condition is out of the range.");
 }
 }  // namespace

--- a/multibody/fixed_fem/dev/test/fem_solver_test.cc
+++ b/multibody/fixed_fem/dev/test/fem_solver_test.cc
@@ -153,14 +153,13 @@ TEST_F(FemSolverTest, StaticForceEquilibrium) {
 TEST_F(FemSolverTest, IncompatibleState) {
   FemState<test::DummyElement<0>> dummy_state(Vector3<double>(1, 2, 3));
   DRAKE_EXPECT_THROWS_MESSAGE(
-      solver_.SolveStaticModelWithInitialGuess(&dummy_state), std::exception,
+      solver_.SolveStaticModelWithInitialGuess(&dummy_state),
       "SolveStaticModelWithInitialGuess\\(\\): The type of the FemState is "
       "incompatible "
       "with the type of the FemModel.");
   State state_with_wrong_size(Vector3<double>(1, 2, 3));
   DRAKE_EXPECT_THROWS_MESSAGE(
       solver_.SolveStaticModelWithInitialGuess(&state_with_wrong_size),
-      std::exception,
       "SolveStaticModelWithInitialGuess\\(\\): The size of the "
       "FemState \\(3\\) is incompatible "
       "with the size of the FemModel \\(24\\).");

--- a/multibody/fixed_fem/dev/test/fem_state_test.cc
+++ b/multibody/fixed_fem/dev/test/fem_state_test.cc
@@ -99,7 +99,7 @@ TEST_F(FemStateTest, MakeElementData) {
   std::vector<DummyElement<1>> invalid_ordered_elements;
   invalid_ordered_elements.emplace_back(ElementIndex(1), kNodeIndices);
   DRAKE_EXPECT_THROWS_MESSAGE(
-      state_.MakeElementData(invalid_ordered_elements), std::exception,
+      state_.MakeElementData(invalid_ordered_elements),
       "Input element entry at 0 has index 1 instead of 0. The entry with index "
       "i must be stored at position i.");
 }

--- a/multibody/fixed_fem/dev/test/isoparametric_element_test.cc
+++ b/multibody/fixed_fem/dev/test/isoparametric_element_test.cc
@@ -227,12 +227,12 @@ TEST_F(IsoparametricElementTest, DegenerateElementPseudoinverseJacobian) {
   /* Initialize a triangle in 3D that is degenerate. */
   Matrix3<double> xa;
   // clang-format off
-    xa << 1, 0, 0.5,
-          0, 1, 0.5,
-          0, 0, 0;
+  xa << 1, 0, 0.5,
+        0, 1, 0.5,
+        0, 0, 0;
   // clang-format on
   DRAKE_EXPECT_THROWS_MESSAGE(
-      tri_3d_.CalcJacobianPseudoinverse(xa), std::exception,
+      tri_3d_.CalcJacobianPseudoinverse(xa),
       "The element is degenerate and does not have a valid Jacobian "
       "pseudoinverse \\(the pseudoinverse is not the left inverse\\).");
 }

--- a/multibody/fixed_fem/dev/test/static_elasticity_element_test.cc
+++ b/multibody/fixed_fem/dev/test/static_elasticity_element_test.cc
@@ -148,7 +148,7 @@ TEST_F(StaticElasticityElementTest, StiffnessMatrixIsPositionDerivative) {
 TEST_F(StaticElasticityElementTest, NoDampingMatrix) {
   Eigen::Matrix<T, kNumDofs, kNumDofs> damping_matrix;
   DRAKE_EXPECT_THROWS_MESSAGE(
-      element().CalcDampingMatrix(*state_, &damping_matrix), std::exception,
+      element().CalcDampingMatrix(*state_, &damping_matrix),
       "Static elasticity forms a zero-th order ODE and does not provide a "
       "damping matrix.");
 }
@@ -156,7 +156,7 @@ TEST_F(StaticElasticityElementTest, NoDampingMatrix) {
 TEST_F(StaticElasticityElementTest, NoMassMatrix) {
   Eigen::Matrix<T, kNumDofs, kNumDofs> mass_matrix;
   DRAKE_EXPECT_THROWS_MESSAGE(
-      element().CalcMassMatrix(*state_, &mass_matrix), std::exception,
+      element().CalcMassMatrix(*state_, &mass_matrix),
       "Static elasticity forms a zero-th order ODE and does not provide a mass "
       "matrix.");
 }

--- a/multibody/fixed_fem/dev/test/zeroth_order_state_updater_test.cc
+++ b/multibody/fixed_fem/dev/test/zeroth_order_state_updater_test.cc
@@ -35,7 +35,7 @@ TEST_F(ZerothOrderStateUpdaterTest, AdvanceOneTimeStep) {
   FemState<DummyElement<0>> new_state(prev_state);
   DRAKE_EXPECT_THROWS_MESSAGE(
       state_updater.AdvanceOneTimeStep(prev_state, q, &new_state),
-      std::exception, "There is no notion of time in a zeroth order ODE.");
+      "There is no notion of time in a zeroth order ODE.");
 }
 }  // namespace
 }  // namespace test

--- a/multibody/parsing/test/parser_test.cc
+++ b/multibody/parsing/test/parser_test.cc
@@ -100,7 +100,7 @@ GTEST_TEST(FileParserTest, MultiModelTest) {
     MultibodyPlant<double> plant(0.0);
     DRAKE_EXPECT_THROWS_MESSAGE(
         Parser(&plant).AddModelFromFile(sdf_name),
-        std::exception, expected_error);
+        expected_error);
   }
 
   // Check the singular method with empty model_name.
@@ -108,7 +108,7 @@ GTEST_TEST(FileParserTest, MultiModelTest) {
     MultibodyPlant<double> plant(0.0);
     DRAKE_EXPECT_THROWS_MESSAGE(
         Parser(&plant).AddModelFromFile(sdf_name, ""),
-        std::exception, expected_error);
+        expected_error);
   }
 
   // Check the singular method with non-empty model_name.
@@ -116,7 +116,7 @@ GTEST_TEST(FileParserTest, MultiModelTest) {
     MultibodyPlant<double> plant(0.0);
     DRAKE_EXPECT_THROWS_MESSAGE(
         Parser(&plant).AddModelFromFile(sdf_name, "foo"),
-        std::exception, expected_error);
+        expected_error);
   }
 }
 
@@ -153,22 +153,18 @@ GTEST_TEST(FileParserTest, ExtensionMatchTest) {
   MultibodyPlant<double> plant(0.0);
   DRAKE_EXPECT_THROWS_MESSAGE(
       Parser(&plant).AddModelFromFile("acrobot.foo"),
-      std::exception,
       ".*file type '\\.foo' is not supported .*");
   DRAKE_EXPECT_THROWS_MESSAGE(
       Parser(&plant).AddAllModelsFromFile("acrobot.foo"),
-      std::exception,
       ".*file type '\\.foo' is not supported .*");
 
   // Uppercase extensions are accepted (i.e., still call the underlying SDF or
   // URDF parser, shown here by it generating a different exception message).
   DRAKE_EXPECT_THROWS_MESSAGE(
       Parser(&plant).AddModelFromFile("acrobot.SDF"),
-      std::exception,
       ".*does not exist.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
       Parser(&plant).AddModelFromFile("acrobot.URDF"),
-      std::exception,
       ".*does not exist.*");
 }
 
@@ -177,19 +173,16 @@ GTEST_TEST(FileParserTest, BadStringTest) {
   MultibodyPlant<double> plant(0.0);
   DRAKE_EXPECT_THROWS_MESSAGE(
       Parser(&plant).AddModelFromString("bad", "sdf"),
-      std::exception,
       ".*\n.*Unable to read SDF string.*");
 
   // Malformed URDF string is an error.
   DRAKE_EXPECT_THROWS_MESSAGE(
       Parser(&plant).AddModelFromString("bad", "urdf"),
-      std::exception,
       "Failed to parse XML string: XML_ERROR_PARSING_TEXT");
 
   // Unknown extension is an error.
   DRAKE_EXPECT_THROWS_MESSAGE(
       Parser(&plant).AddModelFromString("<bad/>", "weird-ext"),
-      std::exception,
       ".*file type '\\.weird-ext' is not supported .*");
 }
 

--- a/multibody/parsing/test/process_model_directives_test.cc
+++ b/multibody/parsing/test/process_model_directives_test.cc
@@ -158,7 +158,7 @@ GTEST_TEST(ProcessModelDirectivesTest, ErrorMessages) {
   // When the user gives a bogus filename, at minimum we must echo it back to
   // them so they know what failed.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      LoadModelDirectives("no-such-file.yaml"), std::exception,
+      LoadModelDirectives("no-such-file.yaml"),
       ".*no-such-file.yaml.*");
 }
 

--- a/multibody/plant/test/multibody_plant_com_test.cc
+++ b/multibody/plant/test/multibody_plant_com_test.cc
@@ -23,13 +23,11 @@ GTEST_TEST(EmptyMultibodyPlantCenterOfMassTest, CalcCenterOfMassPosition) {
   auto context_ = plant.CreateDefaultContext();
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant.CalcCenterOfMassPositionInWorld(*context_),
-      std::exception,
       "CalcCenterOfMassPositionInWorld\\(\\): This MultibodyPlant "
       "only contains the world_body\\(\\) so its center of mass is undefined.");
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant.CalcCenterOfMassTranslationalVelocityInWorld(*context_),
-      std::exception,
       "CalcCenterOfMassTranslationalVelocityInWorld\\(\\): This MultibodyPlant "
       "only contains the world_body\\(\\) so its center of mass is undefined.");
   }
@@ -229,14 +227,12 @@ TEST_F(MultibodyPlantCenterOfMassTest, CenterOfMassPosition) {
   std::vector<ModelInstanceIndex> model_instances;
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant_.CalcCenterOfMassPositionInWorld(*context_, model_instances),
-      std::exception,
       "CalcCenterOfMassPositionInWorld\\(\\): There must be at "
       "least one non-world body contained in model_instances.");
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant_.CalcCenterOfMassTranslationalVelocityInWorld(*context_,
                                                           model_instances),
-      std::exception,
       "CalcCenterOfMassTranslationalVelocityInWorld\\(\\): There must be at "
       "least one non-world body contained in model_instances.");
 
@@ -248,7 +244,6 @@ TEST_F(MultibodyPlantCenterOfMassTest, CenterOfMassPosition) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant_.CalcCenterOfMassTranslationalVelocityInWorld(*context_,
           world_model_instance_array),
-      std::exception,
       "CalcCenterOfMassTranslationalVelocityInWorld\\(\\): There must be at "
       "least one non-world body contained in model_instances.");
 
@@ -257,7 +252,6 @@ TEST_F(MultibodyPlantCenterOfMassTest, CenterOfMassPosition) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant_.CalcCenterOfMassTranslationalVelocityInWorld(*context_,
           world_model_instance_array),
-      std::exception,
       "CalcCenterOfMassTranslationalVelocityInWorld\\(\\): There must be at "
       "least one non-world body contained in model_instances.");
 
@@ -287,14 +281,12 @@ TEST_F(MultibodyPlantCenterOfMassTest, CenterOfMassPosition) {
   set_mass_triangle(0.0);
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant_.CalcCenterOfMassPositionInWorld(*context_, model_instances),
-      std::exception,
       "CalcCenterOfMassPositionInWorld\\(\\): The "
       "system's total mass must be greater than zero.");
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant_.CalcCenterOfMassTranslationalVelocityInWorld(*context_,
                                                           model_instances),
-      std::exception,
       "CalcCenterOfMassTranslationalVelocityInWorld\\(\\): The "
       "system's total mass must be greater than zero.");
 
@@ -303,14 +295,12 @@ TEST_F(MultibodyPlantCenterOfMassTest, CenterOfMassPosition) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant_.CalcJacobianCenterOfMassTranslationalVelocity(
       *context_, JacobianWrtVariable::kV, frame_W, frame_W, &Js_v_WCcm_W),
-      std::exception,
       "CalcJacobianCenterOfMassTranslationalVelocity\\(\\): The "
       "system's total mass must be greater than zero.");
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant_.CalcBiasCenterOfMassTranslationalAcceleration(
       *context_, JacobianWrtVariable::kV, frame_W, frame_W),
-      std::exception,
       "CalcBiasCenterOfMassTranslationalAcceleration\\(\\): The "
       "system's total mass must be greater than zero.");
 

--- a/multibody/plant/test/multibody_plant_introspection_test.cc
+++ b/multibody/plant/test/multibody_plant_introspection_test.cc
@@ -72,7 +72,7 @@ GTEST_TEST(MultibodyPlantIntrospection, FloatingBodies) {
       plant.GetFloatingBaseBodies(), std::logic_error,
       "Pre-finalize calls to 'GetFloatingBaseBodies\\(\\)' are not allowed.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
-      plant.GetUniqueFreeBaseBodyOrThrow(robot_table_model), std::exception,
+      plant.GetUniqueFreeBaseBodyOrThrow(robot_table_model),
       "Pre-finalize calls to 'GetUniqueFreeBaseBodyOrThrow\\(\\)' are not "
       "allowed.*");
 
@@ -109,7 +109,7 @@ GTEST_TEST(MultibodyPlantIntrospection, FloatingBodies) {
   EXPECT_FALSE(plant.GetBodyByName("link", robot_table_model).is_floating());
   EXPECT_FALSE(plant.HasUniqueFreeBaseBody(robot_table_model));
   DRAKE_EXPECT_THROWS_MESSAGE(
-      plant.GetUniqueFreeBaseBodyOrThrow(robot_table_model), std::exception,
+      plant.GetUniqueFreeBaseBodyOrThrow(robot_table_model),
       "Model " + plant.GetModelInstanceName(robot_table_model) +
           " has a unique base body, but it is not free.");
 
@@ -149,7 +149,6 @@ GTEST_TEST(MultibodyPlantIntrospection, NonUniqueBaseBody) {
   EXPECT_FALSE(plant.HasUniqueFreeBaseBody(default_model_instance()));
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant.GetUniqueFreeBaseBodyOrThrow(default_model_instance()),
-      std::exception,
       "Model " + plant.GetModelInstanceName(default_model_instance()) +
           " does not have a unique base body.");
 }

--- a/multibody/plant/test/multibody_plant_momentum_energy_test.cc
+++ b/multibody/plant/test/multibody_plant_momentum_energy_test.cc
@@ -163,7 +163,6 @@ TEST_F(TwoDofPlanarPendulumTest, CalcSpatialMomentumNonsenseSet) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant_.CalcSpatialMomentumInWorldAboutPoint(*context_, model_instances,
                                                   p_WoWo_W),
-      std::exception,
       "CalcSpatialMomentumInWorldAboutPoint\\(\\): This MultibodyPlant method"
       " contains an invalid model_instance.");
 }

--- a/multibody/plant/test/physical_model_test.cc
+++ b/multibody/plant/test/physical_model_test.cc
@@ -60,7 +60,7 @@ TEST_F(PhysicalModelTest, DiscreteStateAndOutputPorts) {
 // Tests that adding new state after Finalize is not allowed.
 TEST_F(PhysicalModelTest, PostFinalizeStateAdditionNotAllowed) {
   DRAKE_EXPECT_THROWS_MESSAGE(
-      dummy_model_->AppendDiscreteState(dummy_state1()), std::exception,
+      dummy_model_->AppendDiscreteState(dummy_state1()),
       "Calls to 'AppendDiscreteState\\(\\)' after system resources have been "
       "declared are not allowed.");
 }

--- a/multibody/topology/test/multibody_graph_test.cc
+++ b/multibody/topology/test/multibody_graph_test.cc
@@ -111,9 +111,9 @@ GTEST_TEST(MultibodyGraph, SerialChain) {
   // Verify we can get bodies/joints.
   EXPECT_EQ(graph.get_body(BodyIndex(3)).name(), "body3");
   EXPECT_EQ(graph.get_joint(JointIndex(3)).name(), "pin4");
-  DRAKE_EXPECT_THROWS_MESSAGE(graph.get_body(BodyIndex(9)), std::exception,
+  DRAKE_EXPECT_THROWS_MESSAGE(graph.get_body(BodyIndex(9)),
                               ".*index < num_bodies\\(\\).*");
-  DRAKE_EXPECT_THROWS_MESSAGE(graph.get_joint(JointIndex(9)), std::exception,
+  DRAKE_EXPECT_THROWS_MESSAGE(graph.get_joint(JointIndex(9)),
                               ".*index < num_joints\\(\\).*");
 
   // Verify we can query if a body/joint is in the graph.

--- a/multibody/tree/test/linear_spring_damper_test.cc
+++ b/multibody/tree/test/linear_spring_damper_test.cc
@@ -112,18 +112,16 @@ GTEST_TEST(LinearSpringDamper, BadParameters) {
       plant.AddForceElement<LinearSpringDamper>(bodyA, p_AP, bodyB, p_BQ,
                                                 -1.0 /* negative rest length */,
                                                 stiffness, damping),
-      std::exception, ".*condition 'free_length > 0' failed.*");
+      ".*condition 'free_length > 0' failed.*");
 
   DRAKE_EXPECT_THROWS_MESSAGE(plant.AddForceElement<LinearSpringDamper>(
                                   bodyA, p_AP, bodyB, p_BQ, free_length,
                                   -1.0 /* negative stiffness */, damping),
-                              std::exception,
                               ".*condition 'stiffness >= 0' failed.*");
 
   DRAKE_EXPECT_THROWS_MESSAGE(plant.AddForceElement<LinearSpringDamper>(
                                   bodyA, p_AP, bodyB, p_BQ, free_length,
                                   stiffness, -1.0 /* negative damping */),
-                              std::exception,
                               ".*condition 'damping >= 0' failed.*");
 }
 

--- a/multibody/tree/test/multibody_tree_test.cc
+++ b/multibody/tree/test/multibody_tree_test.cc
@@ -915,7 +915,6 @@ TEST_F(KukaIiwaModelTests, CalcBiasForJacobianTranslationalVelocity) {
       tree().CalcBiasForJacobianTranslationalVelocity(
           *context_, JacobianWrtVariable::kV, *frame_H_, p_HQi,
           world_frame, world_frame),
-      std::exception,
       ".* condition '.*.rows\\(\\) == 3' failed.");
 
   // Verify CalcBiasForJacobianTranslationalVelocity() throws an exception if
@@ -1368,7 +1367,7 @@ TEST_F(KukaIiwaModelTests, CalcJacobianSpatialVelocityC) {
       tree().CalcJacobianSpatialVelocity(
           *context_, JacobianWrtVariable::kV, link7.body_frame(), p_L7Q,
           link3.body_frame(), link5.body_frame(), nullptr),
-      std::exception, ".*'Js_V_ABp_E != nullptr'.*");
+      ".*'Js_V_ABp_E != nullptr'.*");
 
   // Unit test that CalcJacobianSpatialVelocity throws an exception when
   // the input Jacobian has the wrong number of rows.
@@ -1378,7 +1377,7 @@ TEST_F(KukaIiwaModelTests, CalcJacobianSpatialVelocityC) {
       tree().CalcJacobianSpatialVelocity(
           *context_, JacobianWrtVariable::kV, link7.body_frame(), p_L7Q,
           link3.body_frame(), link5.body_frame(), &Jv_wrong_size),
-      std::exception, ".*'Js_V_ABp_E->rows\\(\\) == 6'.*");
+      ".*'Js_V_ABp_E->rows\\(\\) == 6'.*");
 
   // Unit test that CalcJacobianSpatialVelocity throws an exception when
   // the input Jacobian has the wrong number of columns.
@@ -1387,7 +1386,7 @@ TEST_F(KukaIiwaModelTests, CalcJacobianSpatialVelocityC) {
       tree().CalcJacobianSpatialVelocity(
           *context_, JacobianWrtVariable::kV, link7.body_frame(), p_L7Q,
           link3.body_frame(), link5.body_frame(), &Jv_wrong_size),
-      std::exception, ".*'Js_V_ABp_E->cols\\(\\) == num_columns'.*");
+      ".*'Js_V_ABp_E->cols\\(\\) == num_columns'.*");
 }
 
 // Fixture to setup a simple MBT model with weld mobilizers. The model is in

--- a/solvers/test/gurobi_solver_grb_license_file_test.cc
+++ b/solvers/test/gurobi_solver_grb_license_file_test.cc
@@ -64,7 +64,7 @@ TEST_F(GrbLicenseFileTest, GrbLicenseFileUnset) {
   EXPECT_EQ(solver_.enabled(), false);
 
   DRAKE_EXPECT_THROWS_MESSAGE(
-      solver_.Solve(prog_), std::exception,
+      solver_.Solve(prog_),
       ".*GurobiSolver has not been properly configured.*");
 }
 

--- a/solvers/test/linear_system_solver_test.cc
+++ b/solvers/test/linear_system_solver_test.cc
@@ -47,7 +47,7 @@ GTEST_TEST(testLinearSystemSolver, EmptyProblem) {
 
   LinearSystemSolver solver;
   DRAKE_EXPECT_THROWS_MESSAGE(
-      solver.Solve(prog), std::exception,
+      solver.Solve(prog),
       ".*LinearEqualityConstraint is required.*");
 }
 
@@ -62,7 +62,7 @@ GTEST_TEST(testLinearSystemSolver, QuadraticProblem) {
 
   LinearSystemSolver solver;
   DRAKE_EXPECT_THROWS_MESSAGE(
-      solver.Solve(prog), std::exception,
+      solver.Solve(prog),
       ".*QuadraticCost was declared.*");
 }
 

--- a/solvers/test/mosek_solver_moseklm_license_file_test.cc
+++ b/solvers/test/mosek_solver_moseklm_license_file_test.cc
@@ -64,7 +64,7 @@ TEST_F(MoseklmLicenseFileTest, MoseklmLicenseFileUnset) {
   EXPECT_EQ(solver_.enabled(), false);
 
   DRAKE_EXPECT_THROWS_MESSAGE(
-      solver_.Solve(prog_), std::exception,
+      solver_.Solve(prog_),
       ".*MosekSolver has not been properly configured.*");
 }
 

--- a/solvers/test/snopt_solver_test.cc
+++ b/solvers/test/snopt_solver_test.cc
@@ -502,7 +502,6 @@ GTEST_TEST(SnoptSolverTest, BadIntegerParameter) {
   MathematicalProgram prog;
   prog.SetSolverOption(solver.solver_id(), "not an option", 15);
   DRAKE_EXPECT_THROWS_MESSAGE(solver.Solve(prog),
-      std::exception,
       "Error setting Snopt integer parameter not an option");
 }
 
@@ -511,7 +510,6 @@ GTEST_TEST(SnoptSolverTest, BadDoubleParameter) {
   MathematicalProgram prog;
   prog.SetSolverOption(solver.solver_id(), "not an option", 15.0);
   DRAKE_EXPECT_THROWS_MESSAGE(solver.Solve(prog),
-      std::exception,
       "Error setting Snopt double parameter not an option");
 }
 
@@ -520,7 +518,6 @@ GTEST_TEST(SnoptSolverTest, BadStringParameter) {
   MathematicalProgram prog;
   prog.SetSolverOption(solver.solver_id(), "not an option", "test");
   DRAKE_EXPECT_THROWS_MESSAGE(solver.Solve(prog),
-      std::exception,
       "Error setting Snopt string parameter not an option");
 }
 

--- a/solvers/test/solver_base_test.cc
+++ b/solvers/test/solver_base_test.cc
@@ -158,7 +158,7 @@ GTEST_TEST(SolverBaseTest, AvailableError) {
   StubSolverBase dut;
   dut.available_ = false;
   DRAKE_EXPECT_THROWS_MESSAGE(
-      dut.Solve(prog, {}, {}), std::exception,
+      dut.Solve(prog, {}, {}),
       ".*StubSolverBase has not been compiled.*");
 }
 
@@ -168,7 +168,7 @@ GTEST_TEST(SolverBaseTest, ProgramAttributesError) {
   StubSolverBase dut;
   dut.satisfied_ = false;
   DRAKE_EXPECT_THROWS_MESSAGE(
-      dut.Solve(prog, {}, {}), std::exception,
+      dut.Solve(prog, {}, {}),
       ".*StubSolverBase is unable to solve.*");
 }
 

--- a/systems/framework/test/basic_vector_test.cc
+++ b/systems/framework/test/basic_vector_test.cc
@@ -293,13 +293,13 @@ GTEST_TEST(BasicVectorTest, ValuesAccess) {
 GTEST_TEST(BasicVectorTest, ExceptionMessages) {
   BasicVector<double> pair{1.0, 2.0};
   DRAKE_EXPECT_THROWS_MESSAGE(
-      pair.GetAtIndex(-1), std::exception,
+      pair.GetAtIndex(-1),
       "Index -1 is not within \\[0, 2\\) while accessing .*BasicVector.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
-      pair.GetAtIndex(10), std::exception,
+      pair.GetAtIndex(10),
       "Index 10 is not within \\[0, 2\\) while accessing .*BasicVector.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
-      pair.SetFromVector(Eigen::Vector3d::Zero()), std::exception,
+      pair.SetFromVector(Eigen::Vector3d::Zero()),
       "Operand vector size 3 does not match this .*BasicVector.* size 2");
 }
 

--- a/systems/framework/test/continuous_state_test.cc
+++ b/systems/framework/test/continuous_state_test.cc
@@ -155,7 +155,7 @@ TEST_F(ContinuousStateTest, SetFrom) {
   unbound_symbolic->get_mutable_vector()[0] = symbolic::Variable("q");
   DRAKE_EXPECT_THROWS_MESSAGE(
       actual_double->SetFrom(*unbound_symbolic),
-      std::exception, ".*variable q.*\n*");
+      ".*variable q.*\n*");
 
   // Check ContinuousState<AutoDiff>::SetFrom<U> for U=double and U=Expression.
   actual_autodiff = MakeNanState<AutoDiffXd>();

--- a/systems/framework/test/diagram_context_test.cc
+++ b/systems/framework/test/diagram_context_test.cc
@@ -795,7 +795,6 @@ TEST_F(DiagramContextTest, SubcontextSetTimeStateAndParametersFromIsError) {
   auto& dest_subcontext = clone->GetMutableSubsystemContext(SubsystemIndex{0});
   DRAKE_EXPECT_THROWS_MESSAGE(
       dest_subcontext.SetTimeStateAndParametersFrom(source_subcontext),
-      std::exception,
       "SetTimeStateAndParametersFrom\\(\\): Time change allowed only in the "
       "root Context.");
 }

--- a/systems/framework/test/discrete_values_test.cc
+++ b/systems/framework/test/discrete_values_test.cc
@@ -149,7 +149,7 @@ TEST_F(DiscreteValuesTest, SetFrom) {
   dut_symbolic.get_mutable_vector(0)[0] = symbolic::Variable("x");
   DRAKE_EXPECT_THROWS_MESSAGE(
       dut_double.SetFrom(dut_symbolic),
-      std::exception, ".*variable x.*\n*");
+      ".*variable x.*\n*");
 }
 
 // Tests that the convenience accessors for a DiscreteValues that contains

--- a/systems/framework/test/input_port_test.cc
+++ b/systems/framework/test/input_port_test.cc
@@ -74,12 +74,12 @@ GTEST_TEST(InputPortTest, VectorTest) {
 
   // Check error messages.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      dut->Eval<std::string>(context), std::exception,
+      dut->Eval<std::string>(context),
       "InputPort::Eval..: wrong value type std::string specified; "
       "actual type was drake::systems::MyVector<double,3> "
       "for InputPort.*2.*of.*dummy.*DummySystem.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
-      dut->Eval<MyVector2d>(context), std::exception,
+      dut->Eval<MyVector2d>(context),
       "InputPort::Eval..: wrong value type .*MyVector<double,2> specified; "
       "actual type was .*MyVector<double,3> "
       "for InputPort.*2.*of.*dummy.*DummySystem.*");
@@ -129,22 +129,22 @@ GTEST_TEST(InputPortTest, AbstractTest) {
   EXPECT_EQ(eval_abs.get_value<std::string>(), data);
 
   DRAKE_EXPECT_THROWS_MESSAGE(
-      dut->Eval(context), std::exception,
+      dut->Eval(context),
       "InputPort::Eval..: wrong value type .*BasicVector<double> specified; "
       "actual type was std::string "
       "for InputPort.*2.*of.*dummy.*DummySystem.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
-      dut->Eval<BasicVector<T>>(context), std::exception,
+      dut->Eval<BasicVector<T>>(context),
       "InputPort::Eval..: wrong value type .*BasicVector<double> specified; "
       "actual type was std::string "
       "for InputPort.*2.*of.*dummy.*DummySystem.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
-      dut->Eval<MyVector3d>(context), std::exception,
+      dut->Eval<MyVector3d>(context),
       "InputPort::Eval..: wrong value type .*BasicVector<double> specified; "
       "actual type was std::string "
       "for InputPort.*2.*of.*dummy.*DummySystem.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
-      dut->Eval<int>(context), std::exception,
+      dut->Eval<int>(context),
       "InputPort::Eval..: wrong value type int specified; "
       "actual type was std::string "
       "for InputPort.*2.*of.*dummy.*DummySystem.*");
@@ -347,10 +347,10 @@ GTEST_TEST(InputPortTest, ContextForEmbeddedSystem) {
   // When given an inapproprate context, we fail-fast.
   auto diagram_context = diagram->CreateDefaultContext();
   DRAKE_EXPECT_THROWS_MESSAGE(
-      system->int_port.HasValue(*diagram_context), std::exception,
+      system->int_port.HasValue(*diagram_context),
       ".*Context.*was not created for this InputPort.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
-      system->int_port.Eval<int>(*diagram_context), std::exception,
+      system->int_port.Eval<int>(*diagram_context),
       ".*Context.*was not created for this InputPort.*");
 }
 

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -1147,7 +1147,6 @@ GTEST_TEST(ModelLeafSystemTest, MissingModelAbstractInput) {
   dut.set_name("dut");
   DRAKE_EXPECT_THROWS_MESSAGE(
       dut.AllocateInputAbstract(dut.get_input_port(0)),
-      std::exception,
       "System::AllocateInputAbstract\\(\\): a System with abstract input "
       "ports must pass a model_value to DeclareAbstractInputPort; the "
       "port\\[0\\] named 'no_model_input' did not do so \\(System ::dut\\)");
@@ -1172,7 +1171,6 @@ GTEST_TEST(ModelLeafSystemTest, ModelInputGovernsFixedInput) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       context->FixInputPort(0, Value<BasicVector<double>>(
                                    VectorXd::Constant(2, 0.0))),
-      std::exception,
       "System::FixInputPortTypeCheck\\(\\): expected value of type "
       "drake::systems::BasicVector<double> with size=1 "
       "for input port 'input' \\(index 0\\) but the actual type was "
@@ -1180,7 +1178,6 @@ GTEST_TEST(ModelLeafSystemTest, ModelInputGovernsFixedInput) {
       "\\(System ::dut\\)");
   DRAKE_EXPECT_THROWS_MESSAGE(
       context->FixInputPort(0, Value<std::string>()),
-      std::exception,
       "System::FixInputPortTypeCheck\\(\\): expected value of type "
       "drake::Value<drake::systems::BasicVector<double>> "
       "for input port 'input' \\(index 0\\) but the actual type was "
@@ -1191,7 +1188,6 @@ GTEST_TEST(ModelLeafSystemTest, ModelInputGovernsFixedInput) {
   context->FixInputPort(2, Value<int>(11));
   DRAKE_EXPECT_THROWS_MESSAGE(
       context->FixInputPort(2, Value<std::string>()),
-      std::exception,
       "System::FixInputPortTypeCheck\\(\\): expected value of type "
       "int "
       "for input port 'abstract_input' \\(index 2\\) but the actual type was "
@@ -3197,7 +3193,7 @@ GTEST_TEST(SystemTest, MissedEventIssue12620) {
   auto events = nan_system.AllocateCompositeEventCollection();
   nan_context->SetTime(0.25);
   DRAKE_EXPECT_THROWS_MESSAGE(
-      nan_system.CalcNextUpdateTime(*nan_context, events.get()), std::exception,
+      nan_system.CalcNextUpdateTime(*nan_context, events.get()),
       ".*CalcNextUpdateTime.*TriggerTimeButNoEventSystem.*MyTriggerSystem.*"
       "time=0.25.*no update time.*NaN.*Return infinity.*");
 
@@ -3208,7 +3204,6 @@ GTEST_TEST(SystemTest, MissedEventIssue12620) {
   trigger_context->SetTime(0.25);
   DRAKE_EXPECT_THROWS_MESSAGE(
       trigger_system.CalcNextUpdateTime(*trigger_context, events.get()),
-      std::exception,
       ".*CalcNextUpdateTime.*TriggerTimeButNoEventSystem.*MyTriggerSystem.*"
       "time=0.25.*update time 0.375.*empty Event collection.*"
       "at least one Event object must be provided.*");
@@ -3236,7 +3231,6 @@ GTEST_TEST(SystemTest, ForgotToSetTheUpdateTime) {
   forgot_context->SetTime(0.25);
   DRAKE_EXPECT_THROWS_MESSAGE(
       forgot_system.CalcNextUpdateTime(*forgot_context, events.get()),
-      std::exception,
       ".*CalcNextUpdateTime.*ForgotToSetTimeSystem.*MyForgetfulSystem.*"
       "time=0.25.*no update time.*NaN.*Return infinity.*");
 }

--- a/systems/framework/test/output_port_test.cc
+++ b/systems/framework/test/output_port_test.cc
@@ -437,7 +437,7 @@ GTEST_TEST(DiagramOutputPortTest, OneLevel) {
   const auto& sys1_context = diagram_context.GetSubsystemContext(
       SubsystemIndex{0});
   DRAKE_EXPECT_THROWS_MESSAGE(
-      out0.Eval<int>(sys1_context), std::exception,
+      out0.Eval<int>(sys1_context),
       ".*Context.*was not created for this OutputPort.*");
 }
 

--- a/systems/framework/test/system_base_test.cc
+++ b/systems/framework/test/system_base_test.cc
@@ -77,7 +77,6 @@ GTEST_TEST(SystemBaseTest, NameAndMessageSupport) {
   MySystemBase other_system;
   auto other_context = other_system.AllocateContext();
   DRAKE_EXPECT_THROWS_MESSAGE(system.ValidateContext(*other_context),
-                              std::exception,
                               ".*Context.*was not created for.*");
 }
 

--- a/systems/framework/test/system_constraint_test.cc
+++ b/systems/framework/test/system_constraint_test.cc
@@ -159,7 +159,7 @@ class WrongOrderSystem final : public LeafSystem<double> {
 // We should fail-fast if constraints are added in the wrong order.
 GTEST_TEST(SystemConstraintTest, WrongOrder) {
   DRAKE_EXPECT_THROWS_MESSAGE(
-      WrongOrderSystem{}, std::exception,
+      WrongOrderSystem{},
       "System _ cannot add an internal constraint \\(named dummy2\\) after "
       "an external constraint \\(named empty\\) has already been added");
 }

--- a/systems/framework/test/value_producer_test.cc
+++ b/systems/framework/test/value_producer_test.cc
@@ -49,19 +49,19 @@ TEST_F(ValueProducerTest, DefaultCtor) {
   const ValueProducer empty;
   EXPECT_FALSE(empty.is_valid());
   DRAKE_EXPECT_THROWS_MESSAGE(
-      empty.Allocate(), std::exception,
+      empty.Allocate(),
       ".* null Allocate.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
-      empty.Calc(context_, storage.get()), std::exception,
+      empty.Calc(context_, storage.get()),
       ".* null Calc.*");
 
   const ValueProducer empty_copy(empty);
   EXPECT_FALSE(empty_copy.is_valid());
   DRAKE_EXPECT_THROWS_MESSAGE(
-      empty_copy.Allocate(), std::exception,
+      empty_copy.Allocate(),
       ".* null Allocate.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
-      empty_copy.Calc(context_, storage.get()), std::exception,
+      empty_copy.Calc(context_, storage.get()),
       ".* null Calc.*");
 }
 
@@ -73,13 +73,13 @@ TEST_F(ValueProducerTest, InvalidCallbacks) {
   const CalcCallback bad_calc;
   EXPECT_NO_THROW(ValueProducer(good_allocate, good_calc));
   DRAKE_EXPECT_THROWS_MESSAGE(
-      ValueProducer(bad_allocate, good_calc), std::exception,
+      ValueProducer(bad_allocate, good_calc),
       ".* null Allocate.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
-      ValueProducer(good_allocate, bad_calc), std::exception,
+      ValueProducer(good_allocate, bad_calc),
       ".* null Calc.*");
   DRAKE_EXPECT_THROWS_MESSAGE(
-      ValueProducer(bad_allocate, bad_calc), std::exception,
+      ValueProducer(bad_allocate, bad_calc),
       ".* null .*");
 }
 

--- a/systems/framework/test/vector_system_test.cc
+++ b/systems/framework/test/vector_system_test.cc
@@ -533,12 +533,12 @@ TEST_F(VectorSystemTest, MissingMethodsContinuousTimeSystemTest) {
   std::unique_ptr<ContinuousState<double>> derivatives =
       dut.AllocateTimeDerivatives();
   DRAKE_EXPECT_THROWS_MESSAGE(
-      dut.CalcTimeDerivatives(*context, derivatives.get()), std::exception,
+      dut.CalcTimeDerivatives(*context, derivatives.get()),
       ".*TimeDerivatives.*derivatives->size.. == 0.*failed.*");
 
   const auto& output = dut.get_output_port();
   DRAKE_EXPECT_THROWS_MESSAGE(
-      output.Eval(*context), std::exception,
+      output.Eval(*context),
       ".*Output.*'output->size.. == 0.*failed.*");
 }
 
@@ -561,12 +561,11 @@ TEST_F(VectorSystemTest, MissingMethodsDiscreteTimeSystemTest) {
   auto discrete_updates = dut.AllocateDiscreteVariables();
   DRAKE_EXPECT_THROWS_MESSAGE(
       dut.CalcDiscreteVariableUpdates(*context, discrete_updates.get()),
-      std::exception,
       ".*DiscreteVariableUpdates.*next_state->size.. == 0.*failed.*");
 
   const auto& output = dut.get_output_port();
   DRAKE_EXPECT_THROWS_MESSAGE(
-      output.Eval(*context), std::exception,
+      output.Eval(*context),
       ".*Output.*'output->size.. == 0.*failed.*");
 }
 

--- a/systems/framework/test_utilities/test/my_vector_test.cc
+++ b/systems/framework/test_utilities/test/my_vector_test.cc
@@ -38,7 +38,7 @@ GTEST_TEST(MyVectorTest, BadSize) {
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       MyVector3d(VectorX<double>(fixed_size4)),
-      std::exception, ".*size.*fail.*");
+      ".*size.*fail.*");
 
   // This won't compile since there is no constructor with mismatched sizes.
   // MyVector3d from_4(fixed_size4);

--- a/systems/primitives/test/affine_system_test.cc
+++ b/systems/primitives/test/affine_system_test.cc
@@ -428,7 +428,7 @@ GTEST_TEST(IllegalTimeVaryingAffineSystemTest, BadSizeTest) {
   auto derivatives = sys.AllocateTimeDerivatives();
   DRAKE_EXPECT_THROWS_MESSAGE(
       sys.CalcTimeDerivatives(*context, derivatives.get()),
-      std::exception, ".*rows.*");
+      ".*rows.*");
 }
 
 class AffineSystemSymbolicTest : public ::testing::Test {

--- a/systems/primitives/test/sine_test.cc
+++ b/systems/primitives/test/sine_test.cc
@@ -235,7 +235,7 @@ GTEST_TEST(SineTest, BadSizeTest) {
   Eigen::Vector3d kPhase(1.9, 2.0, 2.1);
   DRAKE_EXPECT_THROWS_MESSAGE(
       Sine<double>(kAmp, kFreq, kPhase, true),
-      std::exception, ".*amplitudes.*==.*phases.*");
+      ".*amplitudes.*==.*phases.*");
 }
 
 GTEST_TEST(SineTest, SineAccessorTest) {


### PR DESCRIPTION
Specifying that we expect to catch a `std::exception` is useless boilerplate.

In fact, checking for specific subtypes _at all_ is verboten via https://drake.mit.edu/styleguide/cppguide.html#Exceptions.  Over time, we should port all of the existing tests to remove their specified subtypes, but that will require a more careful review than this mindless bulk change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15331)
<!-- Reviewable:end -->
