### PR TITLE
Prepare for Eigen 3.4

### DIFF
--- a/common/type_safe_index.h
+++ b/common/type_safe_index.h
@@ -123,6 +123,19 @@ namespace drake {
 ///    for (MyIndex a(0); a < N; ++a) { ... }
 /// @endcode
 ///
+/// __Use with Eigen__
+///
+/// At the time of this writing when using the latest Eigen 3.4 preview branch,
+/// a TypeSafeIndex cannot be directly used to index into an Eigen::Matrix; the
+/// developer must explicitly introduce the `int` conversion:
+/// @code
+///    VectorXd some_vector = ...;
+///    FooIndex foo_index = ...;
+///    some_vector(foo_index) = 0.0;       // Fails to compile.
+///    some_vector(int{foo_index}) = 0.0;  // Compiles OK.
+/// @endcode
+/// TODO(#15354) We hope to fix this irregularity in the future.
+///
 /// @sa drake::geometry::Identifier
 ///
 /// @tparam Tag The name of the tag associated with a class type. The class

--- a/multibody/fixed_fem/dev/dirichlet_boundary_condition.h
+++ b/multibody/fixed_fem/dev/dirichlet_boundary_condition.h
@@ -108,7 +108,7 @@ class DirichletBoundaryCondition {
      */
     for (const auto& it : bcs_) {
       const DofIndex dof_index = it.first;
-      (*residual)(dof_index) = 0;
+      (*residual)(int{dof_index}) = 0;
     }
   }
 

--- a/multibody/fixed_fem/dev/fem_state_base.cc
+++ b/multibody/fixed_fem/dev/fem_state_base.cc
@@ -36,12 +36,12 @@ void FemStateBase<T>::ApplyBoundaryCondition(
   bc.VerifyBcIndexes(this->num_generalized_positions());
   /* Write the BC to the mutable state. */
   for (const auto& [dof_index, boundary_state] : bcs) {
-    q_(dof_index) = boundary_state(0);
+    q_(int{dof_index}) = boundary_state(0);
     if (ode_order() >= 1) {
-      qdot_(dof_index) = boundary_state(1);
+      qdot_(int{dof_index}) = boundary_state(1);
     }
     if (ode_order() == 2) {
-      qddot_(dof_index) = boundary_state(2);
+      qddot_(int{dof_index}) = boundary_state(2);
     }
   }
 }

--- a/multibody/fixed_fem/dev/test/stretch_test.cc
+++ b/multibody/fixed_fem/dev/test/stretch_test.cc
@@ -94,17 +94,18 @@ class StretchTest : public ::testing::Test {
       const DofIndex y_dof_index(kSolutionDimension * node + 1);
       const DofIndex z_dof_index(kSolutionDimension * node + 2);
       /* No translation in the xz-plane. */
-      if (std::abs(q(x_dof_index)) <= kTol) {
-        bc->AddBoundaryCondition(x_dof_index, Vector1<T>(q(x_dof_index)));
+      if (std::abs(q(int{x_dof_index})) <= kTol) {
+        bc->AddBoundaryCondition(x_dof_index, Vector1<T>(q(int{x_dof_index})));
       }
       /* Stretch the two ends of the bar in y-direction. */
-      if (std::abs(std::abs(q(y_dof_index)) - std::abs(kLy / 2)) <= kTol) {
+      if (std::abs(std::abs(q(int{y_dof_index})) - std::abs(kLy / 2)) <= kTol) {
         bc->AddBoundaryCondition(y_dof_index,
-                                 Vector1<T>(kStretchFactor * q(y_dof_index)));
+                                 Vector1<T>(
+                                     kStretchFactor * q(int{y_dof_index})));
       }
       /* No translation in the xz-plane. */
-      if (std::abs(q(z_dof_index)) <= kTol) {
-        bc->AddBoundaryCondition(z_dof_index, Vector1<T>(q(z_dof_index)));
+      if (std::abs(q(int{z_dof_index})) <= kTol) {
+        bc->AddBoundaryCondition(z_dof_index, Vector1<T>(q(int{z_dof_index})));
       }
     }
     return bc;

--- a/multibody/inverse_kinematics/test/global_inverse_kinematics_reachable_test.cc
+++ b/multibody/inverse_kinematics/test/global_inverse_kinematics_reachable_test.cc
@@ -77,12 +77,13 @@ TEST_F(KukaTest, ReachableTest) {
     EXPECT_TRUE(result.is_success());
     q_global_ik = global_ik_.ReconstructGeneralizedPositionSolution(result);
     // The reconstructed posture should be within the user specified bound.
-    EXPECT_NEAR(q_global_ik(plant_->GetJointByName("iiwa_joint_2").index()),
+    EXPECT_NEAR(q_global_ik(
+                    int{plant_->GetJointByName("iiwa_joint_2").index()}),
                 0.5, 1e-3);
     const JointIndex iiwa_joint_3_index =
         plant_->GetJointByName("iiwa_joint_3").index();
-    EXPECT_GE(q_global_ik(iiwa_joint_3_index), -0.5);
-    EXPECT_LE(q_global_ik(iiwa_joint_3_index), -0.4);
+    EXPECT_GE(q_global_ik(int{iiwa_joint_3_index}), -0.5);
+    EXPECT_LE(q_global_ik(int{iiwa_joint_3_index}), -0.4);
 
     // Now further tighten the joint limits, the problem should be infeasible
     global_ik_.AddJointLimitConstraint(

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -768,7 +768,7 @@ MatrixX<T> MultibodyPlant<T>::MakeActuationMatrix() const {
     // This method assumes actuators on single dof joints. Assert this
     // condition.
     DRAKE_DEMAND(actuator.joint().num_velocities() == 1);
-    B(actuator.joint().velocity_start(), actuator.index()) = 1;
+    B(actuator.joint().velocity_start(), int{actuator.index()}) = 1;
   }
   return B;
 }

--- a/multibody/plant/test/multibody_plant_reflected_inertia_test.cc
+++ b/multibody/plant/test/multibody_plant_reflected_inertia_test.cc
@@ -85,8 +85,8 @@ class MultibodyPlantReflectedInertiaTests : public ::testing::Test {
     for (JointActuatorIndex index(0); index < plant->num_actuators(); ++index) {
       JointActuator<double>& joint_actuator =
           plant->get_mutable_joint_actuator(index);
-      joint_actuator.set_default_rotor_inertia(rotor_inertias(index));
-      joint_actuator.set_default_gear_ratio(gear_ratios(index));
+      joint_actuator.set_default_rotor_inertia(rotor_inertias(int{index}));
+      joint_actuator.set_default_gear_ratio(gear_ratios(int{index}));
     }
   }
 

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -2936,7 +2936,7 @@ MatrixX<double> MultibodyTree<T>::MakeActuatorSelectorMatrix(
       MatrixX<double>::Zero(num_actuated_dofs(), num_selected_actuators);
   int user_index = 0;
   for (JointActuatorIndex actuator_index : user_to_actuator_index_map) {
-    Su(actuator_index, user_index) = 1.0;
+    Su(int{actuator_index}, user_index) = 1.0;
     ++user_index;
   }
 

--- a/solvers/csdp_solver.cc
+++ b/solvers/csdp_solver.cc
@@ -110,8 +110,8 @@ void SetProgramSolution(const SdpaFreeFormat& sdpa_free_format,
       (*prog_sol)(i) = std::get<double>(sdpa_free_format.prog_var_in_sdpa()[i]);
     } else if (std::holds_alternative<SdpaFreeFormat::FreeVariableIndex>(
                    sdpa_free_format.prog_var_in_sdpa()[i])) {
-      (*prog_sol)(i) = s_val(std::get<SdpaFreeFormat::FreeVariableIndex>(
-          sdpa_free_format.prog_var_in_sdpa()[i]));
+      (*prog_sol)(i) = s_val(int{std::get<SdpaFreeFormat::FreeVariableIndex>(
+          sdpa_free_format.prog_var_in_sdpa()[i])});
     }
   }
 }


### PR DESCRIPTION
In Eigen 3.4, implicit conversion from TypeSafeIndex to int may fail.
When needed, use the int constructor explicitly.

Working towards #14968

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15335)
<!-- Reviewable:end -->
