### PR TITLE
Fix Doxygen throws clauses to only mention std::exception

### DIFF
--- a/bindings/pydrake/common/cpp_param_pybind.h
+++ b/bindings/pydrake/common/cpp_param_pybind.h
@@ -93,7 +93,7 @@ struct wrapper_pydrake_object {
 py::object GetParamAliases();
 
 // Gets Python type object given `std::type_info`.
-// @throws std::runtime_error if type is neither aliased nor registered in
+// @throws std::exception if type is neither aliased nor registered in
 // `pybind11`.
 py::object GetPyParamScalarImpl(const std::type_info& tinfo);
 
@@ -130,7 +130,7 @@ inline py::object GetPyParamScalarImpl(type_pack<std::vector<T>> = {}) {
 
 /// Gets the canonical Python parameters for each C++ type.
 /// @returns Python tuple of canonical parameters.
-/// @throws std::runtime_error on the first type it encounters that is neither
+/// @throws std::exception on the first type it encounters that is neither
 /// aliased nor registered in `pybind11`.
 /// @tparam Ts The types to get C++ types for.
 /// @pre Ts must be public symbols.

--- a/common/find_resource.h
+++ b/common/find_resource.h
@@ -26,7 +26,7 @@ class FindResourceResult {
   std::optional<std::string> get_absolute_path() const;
 
   /// Either returns the get_absolute_path() iff the resource was found,
-  /// or else throws std::runtime_error.
+  /// or else throws std::exception.
   std::string get_absolute_path_or_throw() const;
 
   /// Returns the error message, iff the resource was not found.

--- a/common/pointer_cast.h
+++ b/common/pointer_cast.h
@@ -43,13 +43,13 @@ std::unique_ptr<T> dynamic_pointer_cast(std::unique_ptr<U>&& other) noexcept {
 }
 
 /// Casts the object owned by the std::unique_ptr `other` from type `U` to `T`;
-/// if `other` is nullptr or the cast fails, throws a std::logic_error.
+/// if `other` is nullptr or the cast fails, throws a std::exception.
 /// Casting is performed using `dynamic_cast` on the managed value (i.e., the
 /// result of `other.get()`).  On success, `other`'s managed value is
 /// transferred to the result and `other` is empty; on failure, `other` will
 /// retain its original managed value.
 ///
-/// @throws std::logic_error if the cast fails.
+/// @throws std::exception if the cast fails.
 ///
 /// Note that this function only supports default deleters.
 template <class T, class U>

--- a/common/polynomial.h
+++ b/common/polynomial.h
@@ -189,7 +189,7 @@ class Polynomial {
   /** Evaluate a univariate Polynomial at a specific point.
    *
    * Evaluates a univariate Polynomial at the given x.
-   * @throws std::runtime_error if this Polynomial is not univariate.
+   * @throws std::exception if this Polynomial is not univariate.
    *
    * @p x may be of any type supporting the ** and + operations (which can be
    * different from both CoefficientsType and RealScalar).
@@ -239,7 +239,7 @@ class Polynomial {
   /** Evaluate a multivariate Polynomial at a specific point.
    *
    * Evaluates a Polynomial with the given values for each variable.
-   * @throws std::out_of_range if the Polynomial contains variables for which
+   * @throws std::exception if the Polynomial contains variables for which
    * values were not provided.
    *
    * The provided values may be of any type which is std::is_arithmetic
@@ -406,7 +406,7 @@ class Polynomial {
   /** Constructs a Polynomial representing the symbolic expression `e`.
    * Note that the ID of a variable is preserved in this translation.
    *
-   * @throw std::runtime_error if `e` is not polynomial-convertible.
+   * @throws std::exception if `e` is not polynomial-convertible.
    * @pre e.is_polynomial() is true.
    */
   static Polynomial<T> FromExpression(const drake::symbolic::Expression& e);

--- a/common/proto/call_python.h
+++ b/common/proto/call_python.h
@@ -17,7 +17,7 @@ namespace common {
 
 /// Initializes `CallPython` for a given file.  If this function is not called,
 /// then the filename defaults to `/tmp/python_rpc`.
-/// @throws std::runtime_error If either this function or `CallPython` have
+/// @throws std::exception If either this function or `CallPython` have
 /// already been called.
 void CallPythonInit(const std::string& filename);
 

--- a/common/proto/rpc_pipe_temp_directory.h
+++ b/common/proto/rpc_pipe_temp_directory.h
@@ -9,7 +9,7 @@ namespace common {
 /// clients and libraries.
 /// @return The value of the environment variable TEST_TMPDIR if defined or
 /// otherwise /tmp. Any trailing / will be stripped from the output.
-/// @throws std::runtime_error If the path referred to by TEST_TMPDIR or /tmp
+/// @throws std::exception If the path referred to by TEST_TMPDIR or /tmp
 /// does not exist or is not a directory.
 std::string GetRpcPipeTempDirectory();
 

--- a/common/schema/rotation.h
+++ b/common/schema/rotation.h
@@ -86,7 +86,7 @@ class Rotation {
   bool IsDeterministic() const;
 
   /// If this is deterministic, retrieves its value.
-  /// @throws exception if this is not fully deterministic.
+  /// @throws std::exception if this is not fully deterministic.
   math::RotationMatrixd GetDeterministicValue() const;
 
   /// Returns the symbolic form of this rotation.  If this is deterministic,

--- a/common/schema/stochastic.h
+++ b/common/schema/stochastic.h
@@ -338,7 +338,7 @@ drake::VectorX<drake::symbolic::Expression> ToSymbolic(
 bool IsDeterministic(const DistributionVariant& var);
 
 /// If `var` is deterministic, retrieves its value.
-/// @throws exception if `var` is not deterministic.
+/// @throws std::exception if `var` is not deterministic.
 double GetDeterministicValue(const DistributionVariant& var);
 
 // ---------------------------------------------------------------------------
@@ -494,7 +494,7 @@ template <int Size>
 bool IsDeterministic(const DistributionVectorVariant<Size>& vec);
 
 /// If `vec` is deterministic, retrieves its value.
-/// @throws exception if `vec` is not deterministic.
+/// @throws std::exception if `vec` is not deterministic.
 /// @tparam Size rows at compile time (max 6) or else Eigen::Dynamic.
 template <int Size>
 Eigen::VectorXd GetDeterministicValue(

--- a/common/schema/transform.h
+++ b/common/schema/transform.h
@@ -168,7 +168,7 @@ class Transform {
   bool IsDeterministic() const;
 
   /// If this is deterministic, retrieves its value.
-  /// @throws exception if this is not fully deterministic.
+  /// @throws std::exception if this is not fully deterministic.
   math::RigidTransformd GetDeterministicValue() const;
 
   /// Returns the symbolic form of this rotation.  If this is deterministic,

--- a/common/symbolic_codegen.h
+++ b/common/symbolic_codegen.h
@@ -242,7 +242,7 @@ std::string CodeGen(const std::string& function_name,
 ///  - `.m.outer_indices`: the length of the outer_indices.
 ///  - `.m.inner_indices`: the length of the inner_indices.
 ///
-/// @throw std::runtime_error if @p M is not compressed.
+/// @throws std::exception if @p M is not compressed.
 // TODO(soonho-tri): Support row-major sparse matrices.
 ///
 /// Please consider the following example which generates code for a 3x6

--- a/common/symbolic_decompose.h
+++ b/common/symbolic_decompose.h
@@ -16,7 +16,7 @@ namespace symbolic {
 
 /** Decomposes @p expressions into @p M * @p vars.
 
-@throws std::runtime_error if @p expressions is not linear in @p vars.
+@throws std::exception if @p expressions is not linear in @p vars.
 @pre M.rows() == expressions.rows() && M.cols() == vars.rows(). */
 void DecomposeLinearExpressions(
     const Eigen::Ref<const VectorX<Expression>>& expressions,
@@ -25,7 +25,7 @@ void DecomposeLinearExpressions(
 
 /** Decomposes @p expressions into @p M * @p vars + @p v.
 
-@throws std::runtime_error if @p expressions is not affine in @p vars.
+@throws std::exception if @p expressions is not affine in @p vars.
 @pre M.rows() == expressions.rows() && M.cols() == vars.rows().
 @pre v.rows() == expressions.rows(). */
 void DecomposeAffineExpressions(

--- a/common/symbolic_environment.h
+++ b/common/symbolic_environment.h
@@ -39,18 +39,18 @@ namespace symbolic {
  * \endcode
  *
  * Note that it is not allowed to have a dummy variable in an environment. It
- * throws std::runtime_error for the attempts to create an environment with a
+ * throws std::exception for the attempts to create an environment with a
  * dummy variable, to insert a dummy variable to an existing environment, or to
  * take a reference to a value mapped to a dummy variable. See the following
  * examples.
  *
  * \code{.cpp}
  *   Variable    var_dummy{};           // OK to have a dummy variable
- *   Environment e1{var_dummy};         // throws std::runtime_error exception
- *   Environment e2{{var_dummy, 1.0}};  // throws std::runtime_error exception
+ *   Environment e1{var_dummy};         // throws exception
+ *   Environment e2{{var_dummy, 1.0}};  // throws exception
  *   Environment e{};
- *   e.insert(var_dummy, 1.0);          // throws std::runtime_error exception
- *   e[var_dummy] = 3.0;                // throws std::runtime_error exception
+ *   e.insert(var_dummy, 1.0);          // throws exception
+ *   e[var_dummy] = 3.0;                // throws exception
  * \endcode
  *
  */
@@ -72,7 +72,7 @@ class Environment {
   /** List constructor. Constructs an environment from a list of (Variable *
    * double).
    *
-   * @throws std::runtime_error if @p init include a dummy variable or a NaN
+   * @throws std::exception if @p init include a dummy variable or a NaN
    * value.
    */
   Environment(std::initializer_list<value_type> init);
@@ -80,14 +80,14 @@ class Environment {
   /** List constructor. Constructs an environment from a list of
    * Variable. Initializes the variables with 0.0.
    *
-   * @throws std::runtime_error if @p vars include a dummy variable.
+   * @throws std::exception if @p vars include a dummy variable.
    */
   Environment(std::initializer_list<key_type> vars);
 
   /** Constructs an environment from @p m (of `map` type, which is
    * `std::unordered_map`).
    *
-   * @throws std::runtime_error if @p m include a dummy variable or a NaN value.
+   * @throws std::exception if @p m include a dummy variable or a NaN value.
    */
   explicit Environment(map m);
 
@@ -111,7 +111,7 @@ class Environment {
    * elements, inserts each pair (keys(i, j), elements(i, j)) into the
    * environment.
    *
-   * @throw std::runtime_error if the size of @p keys is different from the size
+   * @throws std::exception if the size of @p keys is different from the size
    * of @p elements.
    */
   void insert(const Eigen::Ref<const MatrixX<key_type>>& keys,

--- a/common/symbolic_expression.h
+++ b/common/symbolic_expression.h
@@ -255,12 +255,12 @@ class Expression {
    * sample a value and use the value to substitute all occurrences of the
    * variable in this expression.
    *
-   * @throws std::runtime_error if there exists a non-random variable in this
-   *                            expression whose assignment is not provided by
-   *                            @p env.
-   * @throws std::runtime_error if an unassigned random variable is detected
-   *                            while @p random_generator is `nullptr`.
-   * @throws std::runtime_error if NaN is detected during evaluation.
+   * @throws std::exception if there exists a non-random variable in this
+   *                        expression whose assignment is not provided by
+   *                        @p env.
+   * @throws std::exception if an unassigned random variable is detected
+   *                        while @p random_generator is `nullptr`.
+   * @throws std::exception if NaN is detected during evaluation.
    */
   double Evaluate(const Environment& env = Environment{},
                   RandomGenerator* random_generator = nullptr) const;
@@ -277,7 +277,7 @@ class Expression {
    * env. Internally, this method promotes @p env into a substitution
    * (Variable → Expression) and call Evaluate::Substitute with it.
    *
-   * @throws std::runtime_error if NaN is detected during evaluation.
+   * @throws std::exception if NaN is detected during evaluation.
    */
   [[nodiscard]] Expression EvaluatePartial(const Environment& env) const;
 
@@ -299,13 +299,13 @@ class Expression {
    * 2y)`. It also simplifies "division by constant" cases. See
    * "drake/common/test/symbolic_expansion_test.cc" to find the examples.
    *
-   * @throws std::runtime_error if NaN is detected during expansion.
+   * @throws std::exception if NaN is detected during expansion.
    */
   [[nodiscard]] Expression Expand() const;
 
   /** Returns a copy of this expression replacing all occurrences of @p var
    * with @p e.
-   * @throws std::runtime_error if NaN is detected during substitution.
+   * @throws std::exception if NaN is detected during substitution.
    */
   [[nodiscard]] Expression Substitute(const Variable& var,
                                       const Expression& e) const;
@@ -314,13 +314,13 @@ class Expression {
    * variables in @p s with corresponding expressions in @p s. Note that the
    * substitutions occur simultaneously. For example, (x / y).Substitute({{x,
    * y}, {y, x}}) gets (y / x).
-   * @throws std::runtime_error if NaN is detected during substitution.
+   * @throws std::exception if NaN is detected during substitution.
    */
   [[nodiscard]] Expression Substitute(const Substitution& s) const;
 
   /** Differentiates this symbolic expression with respect to the variable @p
    * var.
-   * @throws std::runtime_error if it is not differentiable.
+   * @throws std::exception if it is not differentiable.
    */
   [[nodiscard]] Expression Differentiate(const Variable& x) const;
 
@@ -830,7 +830,7 @@ class uniform_real_distribution<drake::symbolic::Expression> {
   /// Constructs a new distribution object with a minimum value @p a and a
   /// maximum value @p b.
   ///
-  /// @throw std::runtime_error if a and b are constant expressions but a > b.
+  /// @throws std::exception if a and b are constant expressions but a > b.
   explicit uniform_real_distribution(RealType a, RealType b = 1.0)
       : a_{std::move(a)},
         b_{std::move(b)},
@@ -966,7 +966,7 @@ class normal_distribution<drake::symbolic::Expression> {
 
   /// Constructs a new distribution object with @p mean and @p stddev.
   ///
-  /// @throw std::runtime_error if stddev is a non-positive constant expression.
+  /// @throws std::exception if stddev is a non-positive constant expression.
   explicit normal_distribution(RealType mean, RealType stddev = 1.0)
       : mean_{std::move(mean)},
         stddev_{std::move(stddev)},
@@ -1072,7 +1072,7 @@ class exponential_distribution<drake::symbolic::Expression> {
 
   /// Constructs a new distribution object with @p lambda.
   ///
-  /// @throw std::runtime_error if lambda is a non-positive constant expression.
+  /// @throws std::exception if lambda is a non-positive constant expression.
   explicit exponential_distribution(RealType lambda)
       : lambda_{std::move(lambda)},
         random_variables_{std::make_shared<std::vector<Variable>>()} {
@@ -1324,9 +1324,9 @@ auto operator*(
 /// substitute all occurrences of the random variable in @p m.
 ///
 /// @returns a matrix of double whose size is the size of @p m.
-/// @throws std::runtime_error if NaN is detected during evaluation.
-/// @throws std::runtime_error if @p m includes unassigned random variables but
-///                               @p random_generator is `nullptr`.
+/// @throws std::exception if NaN is detected during evaluation.
+/// @throws std::exception if @p m includes unassigned random variables but
+///                           @p random_generator is `nullptr`.
 /// @pydrake_mkdoc_identifier{expression}
 template <typename Derived>
 std::enable_if_t<
@@ -1355,9 +1355,9 @@ Evaluate(const Eigen::MatrixBase<Derived>& m,
 
 /** Evaluates @p m using a given environment (by default, an empty environment).
  *
- * @throws std::runtime_error if there exists a variable in @p m whose value is
- *                            not provided by @p env.
- * @throws std::runtime_error if NaN is detected during evaluation.
+ * @throws std::exception if there exists a variable in @p m whose value is
+ *                        not provided by @p env.
+ * @throws std::exception if NaN is detected during evaluation.
  */
 Eigen::SparseMatrix<double> Evaluate(
     const Eigen::Ref<const Eigen::SparseMatrix<Expression>>& m,
@@ -1366,7 +1366,7 @@ Eigen::SparseMatrix<double> Evaluate(
 /// Substitutes a symbolic matrix @p m using a given substitution @p subst.
 ///
 /// @returns a matrix of symbolic expressions whose size is the size of @p m.
-/// @throws std::runtime_error if NaN is detected during substitution.
+/// @throws std::exception if NaN is detected during substitution.
 template <typename Derived>
 Eigen::Matrix<Expression, Derived::RowsAtCompileTime,
               Derived::ColsAtCompileTime, 0, Derived::MaxRowsAtCompileTime,
@@ -1383,7 +1383,7 @@ Substitute(const Eigen::MatrixBase<Derived>& m, const Substitution& subst) {
 /// Substitutes @p var with @p e in a symbolic matrix @p m.
 ///
 /// @returns a matrix of symbolic expressions whose size is the size of @p m.
-/// @throws std::runtime_error if NaN is detected during substitution.
+/// @throws std::exception if NaN is detected during substitution.
 template <typename Derived>
 Eigen::Matrix<Expression, Derived::RowsAtCompileTime,
               Derived::ColsAtCompileTime, 0, Derived::MaxRowsAtCompileTime,
@@ -1398,7 +1398,7 @@ Substitute(const Eigen::MatrixBase<Derived>& m, const Variable& var,
 }
 
 /// Constructs a vector of variables from the vector of variable expressions.
-/// @throws std::logic_error if there is an expression in @p vec which is not a
+/// @throws std::exception if there is an expression in @p vec which is not a
 /// variable.
 VectorX<Variable> GetVariableVector(
     const Eigen::Ref<const VectorX<Expression>>& expressions);

--- a/common/symbolic_expression_cell.h
+++ b/common/symbolic_expression_cell.h
@@ -73,25 +73,25 @@ class ExpressionCell {
   void set_expanded() { is_expanded_ = true; }
 
   /** Evaluates under a given environment (by default, an empty environment).
-   *  @throws std::runtime_error if NaN is detected during evaluation.
+   *  @throws std::exception if NaN is detected during evaluation.
    */
   [[nodiscard]] virtual double Evaluate(const Environment& env) const = 0;
 
   /** Expands out products and positive integer powers in expression.
-   * @throws std::runtime_error if NaN is detected during expansion.
+   * @throws std::exception if NaN is detected during expansion.
    */
   [[nodiscard]] virtual Expression Expand() const = 0;
 
   /** Returns an Expression obtained by replacing all occurrences of the
    * variables in @p s in the current expression cell with the corresponding
    * expressions in @p s.
-   * @throws std::runtime_error if NaN is detected during substitution.
+   * @throws std::exception if NaN is detected during substitution.
    */
   [[nodiscard]] virtual Expression Substitute(const Substitution& s) const = 0;
 
   /** Differentiates this symbolic expression with respect to the variable @p
    * var.
-   * @throws std::runtime_error if it is not differentiable.
+   * @throws std::exception if it is not differentiable.
    */
   [[nodiscard]] virtual Expression Differentiate(const Variable& x) const = 0;
 
@@ -490,7 +490,7 @@ class ExpressionLog : public UnaryExpressionCell {
   friend Expression log(const Expression& e);
 
  private:
-  /* Throws std::domain_error if v ∉ [0, +oo). */
+  /* Throws std::exception if v ∉ [0, +oo). */
   static void check_domain(double v);
   [[nodiscard]] double DoEvaluate(double v) const override;
 };
@@ -536,7 +536,7 @@ class ExpressionSqrt : public UnaryExpressionCell {
   friend Expression sqrt(const Expression& e);
 
  private:
-  /* Throws std::domain_error if v ∉ [0, +oo). */
+  /* Throws std::exception if v ∉ [0, +oo). */
   static void check_domain(double v);
   [[nodiscard]] double DoEvaluate(double v) const override;
 };
@@ -553,7 +553,7 @@ class ExpressionPow : public BinaryExpressionCell {
   friend Expression pow(const Expression& e1, const Expression& e2);
 
  private:
-  /* Throws std::domain_error if v1 is finite negative and v2 is finite
+  /* Throws std::exception if v1 is finite negative and v2 is finite
      non-integer. */
   static void check_domain(double v1, double v2);
   [[nodiscard]] double DoEvaluate(double v1, double v2) const override;
@@ -610,7 +610,7 @@ class ExpressionAsin : public UnaryExpressionCell {
   friend Expression asin(const Expression& e);
 
  private:
-  /* Throws std::domain_error if v ∉ [-1.0, +1.0]. */
+  /* Throws std::exception if v ∉ [-1.0, +1.0]. */
   static void check_domain(double v);
   [[nodiscard]] double DoEvaluate(double v) const override;
 };
@@ -627,7 +627,7 @@ class ExpressionAcos : public UnaryExpressionCell {
   friend Expression acos(const Expression& e);
 
  private:
-  /* Throws std::domain_error if v ∉ [-1.0, +1.0]. */
+  /* Throws std::exception if v ∉ [-1.0, +1.0]. */
   static void check_domain(double v);
   [[nodiscard]] double DoEvaluate(double v) const override;
 };

--- a/common/symbolic_expression_visitor.h
+++ b/common/symbolic_expression_visitor.h
@@ -18,7 +18,7 @@ namespace symbolic {
 /// methods which take @p f and @p args: `VisitConstant`, `VisitVariable`,
 /// `VisitAddition`, `VisitMultiplication`, `VisitDivision`, `VisitPow`.
 ///
-/// @throws std::runtime_error if NaN is detected during a visit.
+/// @throws std::exception if NaN is detected during a visit.
 ///
 /// See the implementation of @c DegreeVisitor class and @c Degree function in
 /// drake/common/symbolic_monomial.cc as an example usage.
@@ -86,7 +86,7 @@ Result VisitPolynomial(Visitor* v, const Expression& e, Args&&... args) {
 /// `VisitMin`, `VisitMax`, `VisitCeil`, `VisitFloor`, `VisitIfThenElse`,
 /// `VisitUninterpretedFunction.
 ///
-/// @throws std::runtime_error if NaN is detected during a visit.
+/// @throws std::exception if NaN is detected during a visit.
 template <typename Result, typename Visitor, typename... Args>
 Result VisitExpression(Visitor* v, const Expression& e, Args&&... args) {
   switch (e.get_kind()) {

--- a/common/symbolic_formula.h
+++ b/common/symbolic_formula.h
@@ -167,10 +167,10 @@ class Formula {
    * value and use it to substitute all occurrences of the random variable in
    * this formula.
    *
-   * @throws std::runtime_error if a variable `v` is needed for an evaluation
-   *                            but not provided by @p env.
-   * @throws std::runtime_error if an unassigned random variable is detected
-   *                            while @p random_generator is `nullptr`.
+   * @throws std::exception if a variable `v` is needed for an evaluation
+   *                        but not provided by @p env.
+   * @throws std::exception if an unassigned random variable is detected
+   *                        while @p random_generator is `nullptr`.
    */
   bool Evaluate(const Environment& env = Environment{},
                 RandomGenerator* random_generator = nullptr) const;
@@ -183,7 +183,7 @@ class Formula {
 
   /** Returns a copy of this formula replacing all occurrences of @p var
    * with @p e.
-   * @throws std::runtime_error if NaN is detected during substitution.
+   * @throws std::exception if NaN is detected during substitution.
    */
   [[nodiscard]] Formula Substitute(const Variable& var,
                                    const Expression& e) const;
@@ -192,7 +192,7 @@ class Formula {
    * variables in @p s with corresponding expressions in @p s. Note that the
    * substitutions occur simultaneously. For example, (x / y >
    * 0).Substitute({{x, y}, {y, x}}) gets (y / x > 0).
-   * @throws std::runtime_error if NaN is detected during substitution.
+   * @throws std::exception if NaN is detected during substitution.
    */
   [[nodiscard]] Formula Substitute(const Substitution& s) const;
 
@@ -317,20 +317,20 @@ Formula operator>=(const Expression& e1, const Expression& e2);
  *
  * When this formula is evaluated, there are two possible outcomes:
  * - Returns false if the e.Evaluate() is not NaN.
- * - Throws std::runtime_error if NaN is detected during evaluation.
+ * - Throws std::exception if NaN is detected during evaluation.
  * Note that the evaluation of `isnan(e)` never returns true.
  */
 Formula isnan(const Expression& e);
 
 /** Returns a Formula determining if the given expression @p e is a
  * positive or negative infinity.
- * @throws std::runtime_error if NaN is detected during evaluation.
+ * @throws std::exception if NaN is detected during evaluation.
  */
 Formula isinf(const Expression& e);
 
 /** Returns a Formula determining if the given expression @p e has a finite
  * value.
- * @throws std::runtime_error if NaN is detected during evaluation.
+ * @throws std::exception if NaN is detected during evaluation.
  */
 Formula isfinite(const Expression& e);
 
@@ -338,7 +338,7 @@ Formula isfinite(const Expression& e);
  * matrix. By definition, a symmetric matrix @p m is positive-semidefinte if xᵀ
  * m x ≥ 0 for all vector x ∈ ℝⁿ.
  *
- * @throws std::runtime_error if @p m is not symmetric.
+ * @throws std::exception if @p m is not symmetric.
  *
  * @note This method checks if @p m is symmetric, which can be costly. If you
  * want to avoid it, please consider using
@@ -351,7 +351,7 @@ Formula positive_semidefinite(const Eigen::Ref<const MatrixX<Expression>>& m);
 /** Constructs and returns a symbolic positive-semidefinite formula from @p
  * m. If @p mode is Eigen::Lower, it's using the lower-triangular part of @p m
  * to construct a positive-semidefinite formula. If @p mode is Eigen::Upper, the
- * upper-triangular part of @p m is used. It throws std::runtime_error if @p has
+ * upper-triangular part of @p m is used. It throws std::exception if @p has
  * other values. See the following code snippet.
  *
  * @code

--- a/common/symbolic_formula_cell.h
+++ b/common/symbolic_formula_cell.h
@@ -342,7 +342,7 @@ class FormulaPositiveSemidefinite : public FormulaCell {
  public:
   /** Constructs a positive-semidefinite formula from a symmetric matrix @p m.
    *
-   * @throws std::runtime_error if @p m is not symmetric.
+   * @throws std::exception if @p m is not symmetric.
    *
    * @note This constructor checks if @p m is symmetric, which can be costly.
    */

--- a/common/symbolic_generic_polynomial.h
+++ b/common/symbolic_generic_polynomial.h
@@ -73,7 +73,7 @@ class GenericPolynomial {
   /** Constructs a polynomial from an expression @p e. Note that all variables
    * in `e` are considered as indeterminates.
    *
-   * @throws std::runtime_error if @p e is not a polynomial.
+   * @throws std::exception if @p e is not a polynomial.
    */
   explicit GenericPolynomial(const Expression& e);
 
@@ -85,7 +85,7 @@ class GenericPolynomial {
    * still registered as an indeterminate in this polynomial, as
    * this->indeterminates() be the same as @p indeterminates.
    *
-   * @throws std::runtime_error if @p e is not a polynomial in @p
+   * @throws std::exception if @p e is not a polynomial in @p
    * indeterminates.
    */
   GenericPolynomial(const Expression& e, Variables indeterminates);
@@ -171,14 +171,14 @@ class GenericPolynomial {
   /**
    * Evaluates this generic polynomial under a given environment @p env.
    *
-   * @throws std::invalid_argument if there is a variable in this generic
+   * @throws std::exception if there is a variable in this generic
    * polynomial whose assignment is not provided by @p env.
    */
   [[nodiscard]] double Evaluate(const Environment& env) const;
 
   /** Partially evaluates this generic polynomial using an environment @p env.
    *
-   * @throws std::runtime_error if NaN is detected during evaluation.
+   * @throws std::exception if NaN is detected during evaluation.
    */
   [[nodiscard]] GenericPolynomial<BasisElement> EvaluatePartial(
       const Environment& env) const;
@@ -186,7 +186,7 @@ class GenericPolynomial {
   /** Partially evaluates this generic polynomial by substituting @p var with @p
    * c.
 
-   * @throws std::runtime_error if NaN is detected at any point during
+   * @throws std::exception if NaN is detected at any point during
    * evaluation.
    */
   [[nodiscard]] GenericPolynomial<BasisElement> EvaluatePartial(
@@ -268,7 +268,7 @@ class GenericPolynomial {
   }
 
  private:
-  // Throws std::runtime_error if there is a variable appeared in both of
+  // Throws std::exception if there is a variable appeared in both of
   // decision_variables() and indeterminates().
   void CheckInvariant() const;
 

--- a/common/symbolic_monomial.h
+++ b/common/symbolic_monomial.h
@@ -36,7 +36,7 @@ class Monomial {
   explicit Monomial(std::nullptr_t) : Monomial() {}
 
   /** Constructs a Monomial from @p powers.
-   * @throws std::logic_error if `powers` includes a negative exponent.
+   * @throws std::exception if `powers` includes a negative exponent.
    */
   explicit Monomial(const std::map<Variable, int>& powers);
 
@@ -45,7 +45,7 @@ class Monomial {
    * For example, `Monomial([x, y, z], [2, 0, 1])` constructs a Monomial `x²z`.
    *
    * @pre The size of `vars` should be the same as the size of `exponents`.
-   * @throws std::logic_error if `exponents` includes a negative integer.
+   * @throws std::exception if `exponents` includes a negative integer.
    */
   Monomial(const Eigen::Ref<const VectorX<Variable>>& vars,
            const Eigen::Ref<const Eigen::VectorXi>& exponents);
@@ -78,7 +78,7 @@ class Monomial {
 
   /** Evaluates under a given environment @p env.
    *
-   * @throws std::out_of_range exception if there is a variable in this monomial
+   * @throws std::exception if there is a variable in this monomial
    * whose assignment is not provided by @p env.
    */
   double Evaluate(const Environment& env) const;
@@ -113,7 +113,7 @@ class Monomial {
   Monomial& operator*=(const Monomial& m);
 
   /** Returns this monomial raised to @p p.
-   * @throws std::runtime_error if @p p is negative.
+   * @throws std::exception if @p p is negative.
    */
   Monomial& pow_in_place(int p);
 
@@ -139,7 +139,7 @@ std::ostream& operator<<(std::ostream& out, const Monomial& m);
 Monomial operator*(Monomial m1, const Monomial& m2);
 
 /** Returns @p m1 raised to @p p.
- * @throws std::runtime_error if @p p is negative.
+ * @throws std::exception if @p p is negative.
  */
 Monomial pow(Monomial m, int p);
 }  // namespace symbolic

--- a/common/symbolic_monomial_basis_element.h
+++ b/common/symbolic_monomial_basis_element.h
@@ -56,7 +56,7 @@ class MonomialBasisElement : public PolynomialBasisElement {
    * MonomialBasisElement `x²z`.
    *
    * @pre The size of `vars` should be the same as the size of `degrees`.
-   * @throws std::logic_error if `degrees` includes a negative integer.
+   * @throws std::exception if `degrees` includes a negative integer.
    */
   MonomialBasisElement(const Eigen::Ref<const VectorX<Variable>>& vars,
                        const Eigen::Ref<const Eigen::VectorXi>& degrees);
@@ -91,7 +91,7 @@ class MonomialBasisElement : public PolynomialBasisElement {
       const Environment& env) const;
 
   /** Returns this monomial raised to @p p.
-   * @throws std::runtime_error if @p p is negative.
+   * @throws std::exception if @p p is negative.
    */
   MonomialBasisElement& pow_in_place(int p);
 
@@ -203,7 +203,7 @@ std::map<MonomialBasisElement, double> operator*(
  * return signature as other PolynomialBasisElement. For example, the power
  * of a ChebyshevBasisElement object is a weighted sum of ChebyshevBasisElement
  * objects.
- * @throws std::runtime_error if @p p is negative.
+ * @throws std::exception if @p p is negative.
  */
 std::map<MonomialBasisElement, double> pow(MonomialBasisElement m, int p);
 }  // namespace symbolic

--- a/common/symbolic_polynomial.h
+++ b/common/symbolic_polynomial.h
@@ -94,7 +94,7 @@ class Polynomial {
   /// Constructs a polynomial from an expression @p e. Note that all variables
   /// in `e` are considered as indeterminates.
   ///
-  /// @throws std::runtime_error if @p e is not a polynomial.
+  /// @throws std::exception if @p e is not a polynomial.
   explicit Polynomial(const Expression& e);
 
   /// Constructs a polynomial from an expression @p e by decomposing it with
@@ -103,7 +103,7 @@ class Polynomial {
   /// @note It collects the intersection of the variables appeared in `e` and
   /// the provided @p indeterminates.
   ///
-  /// @throws std::runtime_error if @p e is not a polynomial in @p
+  /// @throws std::exception if @p e is not a polynomial in @p
   /// indeterminates.
   Polynomial(const Expression& e, Variables indeterminates);
 
@@ -183,18 +183,18 @@ class Polynomial {
 
   /// Evaluates this polynomial under a given environment @p env.
   ///
-  /// @throws std::out_of_range if there is a variable in this polynomial whose
+  /// @throws std::exception if there is a variable in this polynomial whose
   /// assignment is not provided by @p env.
   double Evaluate(const Environment& env) const;
 
   /// Partially evaluates this polynomial using an environment @p env.
   ///
-  /// @throws std::runtime_error if NaN is detected during evaluation.
+  /// @throws std::exception if NaN is detected during evaluation.
   Polynomial EvaluatePartial(const Environment& env) const;
 
   /// Partially evaluates this polynomial by substituting @p var with @p c.
   ///
-  /// @throws std::runtime_error if NaN is detected at any point during
+  /// @throws std::exception if NaN is detected at any point during
   /// evaluation.
   Polynomial EvaluatePartial(const Variable& var, double c) const;
 
@@ -259,7 +259,7 @@ class Polynomial {
   friend Polynomial operator/(Polynomial p, double v);
 
  private:
-  // Throws std::runtime_error if there is a variable appeared in both of
+  // Throws std::exception if there is a variable appeared in both of
   // decision_variables() and indeterminates().
   void CheckInvariant() const;
 
@@ -476,7 +476,7 @@ namespace symbolic {
 /// Evaluates a matrix `m` of symbolic polynomials using `env`.
 ///
 /// @returns a matrix of double whose size is the size of @p m.
-/// @throws std::runtime_error if NaN is detected during evaluation.
+/// @throws std::exception if NaN is detected during evaluation.
 /// @pydrake_mkdoc_identifier{polynomial}
 template <typename Derived>
 std::enable_if_t<

--- a/common/symbolic_polynomial_basis_element.h
+++ b/common/symbolic_polynomial_basis_element.h
@@ -56,7 +56,7 @@ class PolynomialBasisElement {
   /**
    * Constructs a polynomial basis given the variable and the degree of that
    * variable.
-   * @throw std::logic_error if any of the degree is negative.
+   * @throws std::exception if any of the degree is negative.
    * @note we will ignore the variable with degree 0.
    */
   explicit PolynomialBasisElement(
@@ -65,8 +65,8 @@ class PolynomialBasisElement {
   /**
    * Constructs a polynomial basis, such that it contains the variable-to-degree
    * map vars(i)→degrees(i).
-   * @throws invalid_argument if @p vars contains repeated variables.
-   * @throws logic_error if any degree is negative.
+   * @throws std::exception if @p vars contains repeated variables.
+   * @throws std::exception if any degree is negative.
    */
   PolynomialBasisElement(const Eigen::Ref<const VectorX<Variable>>& vars,
                          const Eigen::Ref<const Eigen::VectorXi>& degrees);
@@ -99,7 +99,7 @@ class PolynomialBasisElement {
 
   /** Evaluates under a given environment @p env.
    *
-   * @throws std::invalid_argument exception if there is a variable in this
+   * @throws std::exception exception if there is a variable in this
    * monomial whose assignment is not provided by @p env.
    */
   [[nodiscard]] double Evaluate(const Environment& env) const;

--- a/common/symbolic_rational_function.h
+++ b/common/symbolic_rational_function.h
@@ -41,7 +41,7 @@ class RationalFunction {
    * @pre None of the indeterminates in the numerator can be decision variables
    * in the denominator; similarly none of the indeterminates in the denominator
    * can be decision variables in the numerator.
-   * @throws std::logic_error if the precondition is not satisfied.
+   * @throws std::exception if the precondition is not satisfied.
    */
   RationalFunction(Polynomial numerator, Polynomial denominator);
 
@@ -110,7 +110,7 @@ class RationalFunction {
   friend std::ostream& operator<<(std::ostream&, const RationalFunction& f);
 
  private:
-  // Throws std::logic_error if an indeterminate of the denominator (numerator,
+  // Throws std::exception if an indeterminate of the denominator (numerator,
   // respectively) is a decision variable of the numerator (denominator).
   void CheckIndeterminates() const;
   Polynomial numerator_;

--- a/common/temp_directory.h
+++ b/common/temp_directory.h
@@ -9,7 +9,7 @@ namespace drake {
 /// otherwise ${TMPDIR:-/tmp}/robotlocomotion_drake_XXXXXX where each X is
 /// replaced by a character from the portable filename character set. Any
 /// trailing / will be stripped from the output.
-/// @throws std::runtime_error If the path referred to by TEST_TMPDIR or
+/// @throws std::exception If the path referred to by TEST_TMPDIR or
 /// ${TMPDIR:-/tmp}/robotlocomotion_drake_XXXXXX cannot be created, does not
 /// exist, or is not a directory.
 std::string temp_directory();

--- a/common/trajectories/discrete_time_trajectory.h
+++ b/common/trajectories/discrete_time_trajectory.h
@@ -106,8 +106,8 @@ class DiscreteTimeTrajectory final : public Trajectory<T> {
   std::unique_ptr<Trajectory<T>> Clone() const override;
 
   /** Returns the value of the trajectory at @p t.
-  @throws runtime_error if t is not within tolerance of one of the sample times.
-  */
+  @throws std::exception if t is not within tolerance of one of the sample
+  times. */
   MatrixX<T> value(const T& t) const override;
 
   /** Returns the number of rows in the MatrixX<T> returned by value().

--- a/common/trajectories/piecewise_polynomial.h
+++ b/common/trajectories/piecewise_polynomial.h
@@ -194,7 +194,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * `const std::vector<MatrixX<T>>&`) or a column vector (versions
    * taking `const Eigen::Ref<const MatrixX<T>>&`).
    *
-   * These methods will throw `std::runtime_error` if:
+   * These methods will throw `std::exception` if:
    *  - the breaks and samples have different length,
    *  - the breaks are not strictly increasing,
    *  - the samples have inconsistent dimensions (i.e., the matrices do not all
@@ -209,7 +209,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * points, although in this case, the second sample point's value is ignored,
    * and only its break time is used.
    *
-   * @throws std::runtime_error under the conditions specified under
+   * @throws std::exception under the conditions specified under
    *         @ref coefficient_construction_methods.
    * @exclude_from_pydrake_mkdoc{This overload is not bound in pydrake.}
    */
@@ -223,7 +223,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * sample point.
    *
    * @pre `samples.cols() == breaks.size()`
-   * @throws std::runtime_error under the conditions specified under
+   * @throws std::exception under the conditions specified under
    *         @ref coefficient_construction_methods.
    */
   static PiecewisePolynomial<T> ZeroOrderHold(
@@ -233,7 +233,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
   /**
    * Constructs a piecewise linear %PiecewisePolynomial using matrix samples.
    *
-   * @throws std::runtime_error under the conditions specified under
+   * @throws std::exception under the conditions specified under
    *         @ref coefficient_construction_methods.
    * @exclude_from_pydrake_mkdoc{This overload is not bound in pydrake.}
    */
@@ -247,7 +247,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * a sample point.
    *
    * @pre `samples.cols() == breaks.size()`
-   * @throws std::runtime_error under the conditions specified under
+   * @throws std::exception under the conditions specified under
    *         @ref coefficient_construction_methods.
    */
   static PiecewisePolynomial<T> FirstOrderHold(
@@ -286,13 +286,13 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * computing a cubic polynomial whose values are given by `samples`, and
    * derivatives set to zero.
    *
-   * @throws std::runtime_error if:
+   * @throws std::exception if:
    *  - `breaks` has length smaller than 3 and `zero_end_point_derivatives` is
    *    `false`,
    *  - `breaks` has length smaller than 2 and `zero_end_point_derivatives` is
    *    true.
    *
-   * @throws std::runtime_error under the conditions specified under
+   * @throws std::exception under the conditions specified under
    *         @ref coefficient_construction_methods.
    * @exclude_from_pydrake_mkdoc{This overload is not bound in pydrake.}
    */
@@ -307,7 +307,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * MatrixX<T> arguments. Each column of `samples` represents a sample point.
    *
    * @pre `samples.cols() == breaks.size()`.
-   * @throws std::runtime_error under the conditions specified under
+   * @throws std::exception under the conditions specified under
    *         @ref coefficient_construction_methods.
    */
   static PiecewisePolynomial<T> CubicShapePreserving(
@@ -322,9 +322,9 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * `sample_dot_at_start` and `sample_dot_at_end` are used for the first and
    * last first derivatives.
    *
-   * @throws std::runtime_error if `sample_dot_at_start` or `sample_dot_at_end`
+   * @throws std::exception if `sample_dot_at_start` or `sample_dot_at_end`
    * and `samples` have inconsistent dimensions.
-   * @throws std::runtime_error under the conditions specified under
+   * @throws std::exception under the conditions specified under
    *         @ref coefficient_construction_methods.
    * @exclude_from_pydrake_mkdoc{This overload is not bound in pydrake.}
    */
@@ -340,7 +340,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * `samples` represents a sample point.
    *
    * @pre `samples.cols() == breaks.size()`.
-   * @throws std::runtime_error under the conditions specified under
+   * @throws std::exception under the conditions specified under
    *         @ref coefficient_construction_methods.
    */
   static PiecewisePolynomial<T> CubicWithContinuousSecondDerivatives(
@@ -547,13 +547,13 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
 
   /**
    * Returns the row count of the output matrices.
-   * @throws std::runtime_error if empty().
+   * @throws std::exception if empty().
    */
   Eigen::Index rows() const override;
 
   /**
    * Returns the column count of the output matrices.
-   * @throws std::runtime_error if empty().
+   * @throws std::exception if empty().
    */
   Eigen::Index cols() const override;
 
@@ -580,7 +580,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * corresponding Polynomial in the PolynomialMatrix of `this`, storing the
    * result in `this`. If `this` corresponds to t² and `other` corresponds to
    * t³, `this += other` will correspond to t³ + t².
-   * @throws std::runtime_error if every element of `other.get_segment_times()`
+   * @throws std::exception if every element of `other.get_segment_times()`
    * is not within PiecewiseTrajectory::kEpsilonTime from
    * `this->get_segment_times().
    */
@@ -591,7 +591,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * corresponding Polynomial in the PolynomialMatrix of `this`, storing the
    * result in `this`. If `this` corresponds to t² and `other` corresponds to
    * t³, `this -= other` will correspond to t² - t³.
-   * @throws std::runtime_error if every element of `other.get_segment_times()`
+   * @throws std::exception if every element of `other.get_segment_times()`
    * is not within PiecewiseTrajectory::kEpsilonTime from
    * `this->get_segment_times().
    */
@@ -603,7 +603,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * coefficient-wise multiplication), storing the result in `this`. If `this`
    * corresponds to t² and `other` corresponds to t³, `this *= other` will
    * correspond to t⁵.
-   * @throws std::runtime_error if every element of `other.get_segment_times()`
+   * @throws std::exception if every element of `other.get_segment_times()`
    * is not within PiecewiseTrajectory::kEpsilonTime from
    * `this->get_segment_times().
    */
@@ -618,7 +618,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * corresponding Polynomial in the PolynomialMatrix of `this`.
    * If `this` corresponds to t² and `other` corresponds to
    * t³, `this + other` will correspond to t³ + t².
-   * @throws std::runtime_error if every element of `other.get_segment_times()`
+   * @throws std::exception if every element of `other.get_segment_times()`
    * is not within PiecewiseTrajectory::kEpsilonTime from
    * `this->get_segment_times().
    */
@@ -629,7 +629,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * corresponding Polynomial in the PolynomialMatrix of `this`.
    * If `this` corresponds to t² and `other` corresponds to
    * t³, `this - other` will correspond to t² - t³.
-   * @throws std::runtime_error if every element of `other.get_segment_times()`
+   * @throws std::exception if every element of `other.get_segment_times()`
    * is not within PiecewiseTrajectory::kEpsilonTime from
    * `this->get_segment_times().
    */
@@ -646,7 +646,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * corresponding Polynomial in the PolynomialMatrix of `this` (i.e., a
    * coefficient-wise multiplication). If `this` corresponds to t² and `other`
    * corresponds to t³, `this *= other` will correspond to t⁵.
-   * @throws std::runtime_error if every element of `other.get_segment_times()`
+   * @throws std::exception if every element of `other.get_segment_times()`
    * is not within PiecewiseTrajectory::kEpsilonTime from
    * `this->get_segment_times()1.
    */
@@ -677,13 +677,13 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    *          the last Polynomial of `this`. See warning about evaluating
    *          discontinuous derivatives at breaks in derivative().
    * @param other %PiecewisePolynomial instance to concatenate.
-   * @throws std::runtime_error if trajectories' dimensions do not match
-   *                            each other (either rows() or cols() does
-   *                            not match between this and `other`).
-   * @throws std::runtime_error if `this->end_time()` and `other->start_time()`
-   *                            are not within
-   *                            PiecewiseTrajectory<T>::kEpsilonTime from
-   *                            each other.
+   * @throws std::exception if trajectories' dimensions do not match
+   *                        each other (either rows() or cols() does
+   *                        not match between this and `other`).
+   * @throws std::exception if `this->end_time()` and `other->start_time()`
+   *                        are not within
+   *                        PiecewiseTrajectory<T>::kEpsilonTime from
+   *                        each other.
    */
   void ConcatenateInTime(const PiecewisePolynomial& other);
 
@@ -789,7 +789,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
 
   // Computes coeffecients for a cubic spline given the value and first
   // derivatives at the end points.
-  // Throws `std::runtime_error` if `dt < PiecewiseTrajectory::kEpsilonTime`.
+  // Throws `std::exception` if `dt < PiecewiseTrajectory::kEpsilonTime`.
   static Eigen::Matrix<T, 4, 1> ComputeCubicSplineCoeffs(const T& dt, T y0,
                                                          T y1, T yd0, T yd1);
 
@@ -833,7 +833,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
       const std::vector<MatrixX<T>>& samples, int row, int col,
       std::vector<Eigen::Triplet<T>>* triplet_list, VectorX<T>* b);
 
-  // Throws std::runtime_error if
+  // Throws std::exception if
   // `breaks` and `samples` have different length,
   // `breaks` is not strictly increasing,
   // `samples` has inconsistent dimensions,

--- a/common/trajectories/piecewise_quaternion.h
+++ b/common/trajectories/piecewise_quaternion.h
@@ -41,7 +41,7 @@ class PiecewiseQuaternionSlerp final : public PiecewiseTrajectory<T> {
 
   /**
    * Builds a PiecewiseQuaternionSlerp.
-   * @throws std::logic_error if breaks and quaternions have different length,
+   * @throws std::exception if breaks and quaternions have different length,
    * or breaks have length < 2.
    */
   PiecewiseQuaternionSlerp(
@@ -50,7 +50,7 @@ class PiecewiseQuaternionSlerp final : public PiecewiseTrajectory<T> {
 
   /**
    * Builds a PiecewiseQuaternionSlerp.
-   * @throws std::logic_error if breaks and rot_matrices have different length,
+   * @throws std::exception if breaks and rot_matrices have different length,
    * or breaks have length < 2.
    */
   PiecewiseQuaternionSlerp(
@@ -59,7 +59,7 @@ class PiecewiseQuaternionSlerp final : public PiecewiseTrajectory<T> {
 
   /**
    * Builds a PiecewiseQuaternionSlerp.
-   * @throws std::logic_error if breaks and rot_matrices have different length,
+   * @throws std::exception if breaks and rot_matrices have different length,
    * or breaks have length < 2.
    */
   PiecewiseQuaternionSlerp(
@@ -68,7 +68,7 @@ class PiecewiseQuaternionSlerp final : public PiecewiseTrajectory<T> {
 
   /**
    * Builds a PiecewiseQuaternionSlerp.
-   * @throws std::logic_error if breaks and ang_axes have different length,
+   * @throws std::exception if breaks and ang_axes have different length,
    * or breaks have length < 2.
    */
   PiecewiseQuaternionSlerp(

--- a/common/trajectories/trajectory.h
+++ b/common/trajectories/trajectory.h
@@ -41,7 +41,7 @@ class Trajectory {
   * Otherwise, if rows()==1, then evaluates the trajectory at each time @p t,
   * and returns the results as a Matrix with the ith row corresponding to
   * the ith time.
-  * @throws std::runtime_error if both cols and rows are not equal to 1.
+  * @throws std::exception if both cols and rows are not equal to 1.
   */
   MatrixX<T> vector_values(const std::vector<T>& t) const;
 

--- a/examples/bead_on_a_wire/bead_on_a_wire.h
+++ b/examples/bead_on_a_wire/bead_on_a_wire.h
@@ -123,7 +123,7 @@ class BeadOnAWire : public systems::LeafSystem<T> {
   ///          (scalar `s`) as input and outputs a point in 3D as output.
   /// @param inv_f The pointer to a function that takes a point in 3D as input
   ///              and outputs a floating point scalar as output.
-  /// @throws std::logic_error if f or inv_f is a nullptr (the functions must
+  /// @throws std::exception if f or inv_f is a nullptr (the functions must
   ///         always be set).
   void reset_wire_parameter_functions(
         std::function<Eigen::Matrix<ArcLength, 3, 1>(const ArcLength&)> f,

--- a/examples/manipulation_station/manipulation_station.h
+++ b/examples/manipulation_station/manipulation_station.h
@@ -445,25 +445,25 @@ class ManipulationStation : public systems::Diagram<T> {
   std::vector<std::string> get_camera_names() const;
 
   /// Set the gains for the WSG controller.
-  /// @throws exception if Finalize() has been called.
+  /// @throws std::exception if Finalize() has been called.
   void SetWsgGains(double kp, double kd);
 
   /// Set the position gains for the IIWA controller.
-  /// @throws exception if Finalize() has been called.
+  /// @throws std::exception if Finalize() has been called.
   void SetIiwaPositionGains(const VectorX<double>& kp) {
     DRAKE_THROW_UNLESS(!plant_->is_finalized());
     iiwa_kp_ = kp;
   }
 
   /// Set the velocity gains for the IIWA controller.
-  /// @throws exception if Finalize() has been called.
+  /// @throws std::exception if Finalize() has been called.
   void SetIiwaVelocityGains(const VectorX<double>& kd) {
     DRAKE_THROW_UNLESS(!plant_->is_finalized());
     iiwa_kd_ = kd;
   }
 
   /// Set the integral gains for the IIWA controller.
-  /// @throws exception if Finalize() has been called.
+  /// @throws std::exception if Finalize() has been called.
   void SetIiwaIntegralGains(const VectorX<double>& ki) {
     DRAKE_THROW_UNLESS(!plant_->is_finalized());
     iiwa_ki_ = ki;

--- a/examples/mass_spring_cloth/cloth_spring_model_geometry.h
+++ b/examples/mass_spring_cloth/cloth_spring_model_geometry.h
@@ -39,7 +39,7 @@ class ClothSpringModelGeometry final : public systems::LeafSystem<double> {
    system. The return value pointer is an alias of the new
    %ClothSpringModelGeometry system that is owned by the `builder`.
 
-   @throws std::logic_error if @p cloth_spring_model or @p scene_graph is not
+   @throws std::exception if @p cloth_spring_model or @p scene_graph is not
    already added to the given @p builder.
    */
   static const ClothSpringModelGeometry& AddToBuilder(

--- a/examples/rod2d/rod2d.cc
+++ b/examples/rod2d/rod2d.cc
@@ -83,7 +83,7 @@ int Rod2D<T>::DetermineNumWitnessFunctions(
 
 /// Gets the integer variable 'k' used to determine the point of contact
 /// indicated by the current mode.
-/// @throws std::logic_error if this is a discretized system (implying that
+/// @throws std::exception if this is a discretized system (implying that
 ///         modes are unused).
 /// @returns the value -1 to indicate the bottom of the rod (when theta = pi/2),
 ///          +1 to indicate the top of the rod (when theta = pi/2), or 0 to

--- a/examples/rod2d/rod2d.h
+++ b/examples/rod2d/rod2d.h
@@ -173,7 +173,7 @@ class Rod2D : public systems::LeafSystem<T> {
   /// continuous ordinary differential equation based approach.
   /// @param dt The integration step size. This step size cannot be reset
   ///           after construction.
-  /// @throws std::logic_error if @p dt is not positive and system_type is
+  /// @throws std::exception if @p dt is not positive and system_type is
   ///         kDiscretized or @p dt is not zero and system_type is
   ///         kPiecewiseDAE or kContinuous.
   explicit Rod2D(SystemType system_type, double dt);

--- a/geometry/frame_kinematics_vector.h
+++ b/geometry/frame_kinematics_vector.h
@@ -120,7 +120,7 @@ class FrameKinematicsVector {
   }
 
   /** Returns the value associated with the given `id`.
-   @throws std::runtime_error if `id` is not in the specified set of ids.  */
+   @throws std::exception if `id` is not in the specified set of ids.  */
   const KinematicsValue& value(FrameId id) const;
 
   /** Reports true if the given id is a member of this data. */

--- a/geometry/geometry_instance.h
+++ b/geometry/geometry_instance.h
@@ -86,7 +86,7 @@ class GeometryInstance {
    @param X_PG   The pose of this geometry (`G`) in its parent's frame (`P`).
    @param shape  The underlying shape for this geometry instance.
    @param name   The name of the geometry (must satisfy the name requirements).
-   @throws std::logic_error if the canonicalized version of `name` is empty.
+   @throws std::exception if the canonicalized version of `name` is empty.
    */
   GeometryInstance(const math::RigidTransform<double>& X_PG,
       std::unique_ptr<Shape> shape, const std::string& name);

--- a/geometry/geometry_properties.h
+++ b/geometry/geometry_properties.h
@@ -240,7 +240,7 @@ class GeometryProperties {
 
   /** Retrieves the indicated property group. The returned group is valid for
    as long as this instance.
-   @throws std::logic_error if there is no group with the given name.  */
+   @throws std::exception if there is no group with the given name.  */
   const Group& GetPropertiesInGroup(const std::string& group_name) const;
 
   /** Returns all of the defined group names.  */
@@ -252,7 +252,7 @@ class GeometryProperties {
    @param group_name   The group name.
    @param name         The name of the property -- must be unique in the group.
    @param value        The value to assign to the property.
-   @throws std::logic_error if the property already exists.
+   @throws std::exception if the property already exists.
    @tparam ValueType   The type of data to store with the attribute -- must be
                        copy constructible or cloneable (see Value).  */
   template <typename ValueType>
@@ -273,7 +273,7 @@ class GeometryProperties {
    @param group_name   The group name.
    @param name         The name of the property -- must be unique in the group.
    @param value        The value to assign to the property.
-   @throws std::logic_error if the property exists with a different type.
+   @throws std::exception if the property exists with a different type.
    @tparam ValueType   The type of data to store with the attribute -- must be
                        copy constructible or cloneable (see Value).  */
   template <typename ValueType>
@@ -288,7 +288,7 @@ class GeometryProperties {
    @param group_name   The group name.
    @param name         The name of the property -- must be unique in the group.
    @param value        The value to assign to the property.
-   @throws std::logic_error if the property already exists.  */
+   @throws std::exception if the property already exists.  */
   void AddPropertyAbstract(const std::string& group_name,
                            const std::string& name, const AbstractValue& value);
 
@@ -300,7 +300,7 @@ class GeometryProperties {
    @param group_name   The group name.
    @param name         The name of the property -- must be unique in the group.
    @param value        The value to assign to the property.
-   @throws std::logic_error if the property exists with a different type.  */
+   @throws std::exception if the property exists with a different type.  */
   void UpdatePropertyAbstract(const std::string& group_name,
                               const std::string& name,
                               const AbstractValue& value);
@@ -320,9 +320,9 @@ class GeometryProperties {
 
    @param group_name  The name of the group to which the property belongs.
    @param name        The name of the desired property.
-   @throws std::logic_error if a) the group name is invalid,
-                            b) the property name is invalid, or
-                            c) the property type is not that specified.
+   @throws std::exception if a) the group name is invalid,
+                          b) the property name is invalid, or
+                          c) the property type is not that specified.
    @tparam ValueType  The expected type of the desired property.
    @returns const ValueType& of stored value.
             If ValueType is Eigen::Vector4d, the return type will be a copy
@@ -348,8 +348,8 @@ class GeometryProperties {
 
    @param group_name  The name of the group to which the property belongs.
    @param name        The name of the desired property.
-   @throws std::logic_error if a) the group name is invalid, or
-                            b) the property name is invalid. */
+   @throws std::exception if a) the group name is invalid, or
+                          b) the property name is invalid. */
   const AbstractValue& GetPropertyAbstract(const std::string& group_name,
                                            const std::string& name) const;
 
@@ -375,8 +375,8 @@ class GeometryProperties {
    @param name           The name of the desired property.
    @param default_value  The alternate value to return if the property cannot
                          be acquired.
-   @throws std::logic_error if a property of the given name exists but is not
-                            of `ValueType`.  */
+   @throws std::exception if a property of the given name exists but is not
+                          of `ValueType`.  */
   template <typename ValueType>
   ValueType GetPropertyOrDefault(const std::string& group_name,
                                  const std::string& name,

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -189,7 +189,7 @@ class GeometryState {
   /** Reports the number of child geometries for this frame that have the
    indicated role assigned. This only includes the immediate child geometries of
    *this* frame, and not those of child frames.
-   @throws std::logic_error if the `frame_id` does not map to a valid frame.  */
+   @throws std::exception if the `frame_id` does not map to a valid frame.  */
   int NumGeometriesWithRole(FrameId frame_id, Role role) const;
 
   /** Implementation of SceneGraphInspector::GetGeometryIdByName().  */
@@ -359,24 +359,24 @@ class GeometryState {
    `frame_id`, if it has been added to the renderer with the given
    `renderer_name` it is removed from that renderer.
    @return The number of geometries affected by the removal.
-   @throws std::logic_error if a) `source_id` does not map to a registered
-                            source,
-                            b) `frame_id` does not map to a registered frame,
-                            c) `frame_id` does not belong to `source_id` (unless
-                            `frame_id` is the world frame id), or
-                            d) the context has already been allocated.  */
+   @throws std::exception if a) `source_id` does not map to a registered
+                          source,
+                          b) `frame_id` does not map to a registered frame,
+                          c) `frame_id` does not belong to `source_id` (unless
+                          `frame_id` is the world frame id), or
+                          d) the context has already been allocated.  */
   int RemoveFromRenderer(const std::string& renderer_name, SourceId source_id,
                          FrameId frame_id);
 
   /** Removes the geometry with the given `geometry_id` from the renderer with
    the given `renderer_name`, _if_ it has previously been added.
    @return The number of geometries affected by the removal (0 or 1).
-   @throws std::logic_error if a) `source_id` does not map to a registered
-                            source,
-                            b) `geometry_id` does not map to a registered
-                            geometry,
-                            c) `geometry_id` does not belong to `source_id`, or
-                            d) the context has already been allocated.  */
+   @throws std::exception if a) `source_id` does not map to a registered
+                          source,
+                          b) `geometry_id` does not map to a registered
+                          geometry,
+                          c) `geometry_id` does not belong to `source_id`, or
+                          d) the context has already been allocated.  */
   int RemoveFromRenderer(const std::string& renderer_name, SourceId source_id,
                          GeometryId geometry_id);
   //@}
@@ -598,7 +598,7 @@ class GeometryState {
   // Sets the kinematic poses for the frames indicated by the given ids.
   // @param poses The frame id and pose values.
   // @pre source_id is a registered source.
-  // @throws std::logic_error  If the ids are invalid as defined by
+  // @throws std::exception  If the ids are invalid as defined by
   // ValidateFrameIds().
   void SetFramePoses(SourceId source_id, const FramePoseVector<T>& poses);
 
@@ -606,7 +606,7 @@ class GeometryState {
   // registered to the set's source id and that no extra frames are included.
   // @param values The kinematics values (ids and values) to validate.
   // @pre source_id is a registered source.
-  // @throws std::runtime_error if the set is inconsistent with known topology.
+  // @throws std::exception if the set is inconsistent with known topology.
   template <typename ValueType>
   void ValidateFrameIds(SourceId source_id,
                         const FrameKinematicsVector<ValueType>& values) const;
@@ -615,11 +615,11 @@ class GeometryState {
   // _all_ of the state's frames have had their poses updated.
   void FinalizePoseUpdate();
 
-  // Gets the source id for the given frame id. Throws std::logic_error if the
+  // Gets the source id for the given frame id. Throws std::exception if the
   // frame belongs to no registered source.
   SourceId get_source_id(FrameId frame_id) const;
 
-  // Gets the source id for the given frame id. Throws std::logic_error if the
+  // Gets the source id for the given frame id. Throws std::exception if the
   // geometry belongs to no registered source.
   SourceId get_source_id(GeometryId frame_id) const;
 
@@ -642,7 +642,7 @@ class GeometryState {
   //    frame and, if it exists, its parent geometry.
   //   - RemoveGeometryUnchecked(): This is the recursive call; it's parent
   //    is already slated for removal, so parent references can be left alone.
-  // @throws std::logic_error if `geometry_id` is not in `geometries_`.
+  // @throws std::exception if `geometry_id` is not in `geometries_`.
   void RemoveGeometryUnchecked(GeometryId geometry_id,
                                RemoveGeometryOrigin caller);
 

--- a/geometry/proximity/hydroelastic_internal.h
+++ b/geometry/proximity/hydroelastic_internal.h
@@ -309,8 +309,8 @@ class Geometries final : public ShapeReifier {
    @param id            The unique identifier for the geometry.
    @param properties    The proximity properties which will determine if a
                         hydroelastic representation is requested.
-   @throws std::logic_error if the shape is a supported type but the properties
-                            are malformed.
+   @throws std::exception if the shape is a supported type but the properties
+                          are malformed.
    @pre There is no previous representation associated with id.  */
   void MaybeAddGeometry(const Shape& shape, GeometryId id,
                         const ProximityProperties& properties);

--- a/geometry/proximity/mesh_field_linear.h
+++ b/geometry/proximity/mesh_field_linear.h
@@ -220,7 +220,7 @@ class MeshFieldLinear {
   /** Evaluates the gradient in the domain of the element indicated by `e`.
   The gradient is a vector in R³ expressed in frame M. For surface meshes, it
   will particularly lie parallel to the plane of the corresponding triangle.
-  @throw std::runtime_error if the gradient vector was not calculated.
+  @throws std::exception if the gradient vector was not calculated.
   */
   Vector3<T> EvaluateGradient(typename MeshType::ElementIndex e) const {
     if (gradients_.size() == 0) {

--- a/geometry/proximity/mesh_to_vtk.h
+++ b/geometry/proximity/mesh_to_vtk.h
@@ -25,7 +25,7 @@ namespace internal {
  @param mesh       A tetrahedral volume mesh.
  @param title      Name of the data set will be written on the second line of
                    the VTK file.
- @throws std::runtime_error if unable to create the file.
+ @throws std::exception if unable to create the file.
  */
 void WriteVolumeMeshToVtk(const std::string& file_name,
                           const VolumeMesh<double>& mesh,
@@ -37,7 +37,7 @@ void WriteVolumeMeshToVtk(const std::string& file_name,
  @param mesh       A triangulated surface mesh.
  @param title      Name of the data set will be written on the second line of
                    the VTK file.
- @throws std::runtime_error if unable to create the file.
+ @throws std::exception if unable to create the file.
  */
 void WriteSurfaceMeshToVtk(const std::string& file_name,
                            const SurfaceMesh<double>& mesh,
@@ -51,7 +51,7 @@ void WriteSurfaceMeshToVtk(const std::string& file_name,
                    the VTK file.
  @note `field.name()` will be written to VTK file with space ' ' replaced by
        underscore '_' on the "SCALARS field.name()" line.
- @throws std::runtime_error if unable to create the file.
+ @throws std::exception if unable to create the file.
  */
 void WriteVolumeMeshFieldLinearToVtk(
     const std::string& file_name,
@@ -66,7 +66,7 @@ void WriteVolumeMeshFieldLinearToVtk(
                    the VTK file.
  @note `field.name()` will be written to VTK file with space ' ' replaced by
        underscore '_' on the "SCALARS field.name()" line.
- @throws std::runtime_error if unable to create the file.
+ @throws std::exception if unable to create the file.
  */
 void WriteSurfaceMeshFieldLinearToVtk(
     const std::string& file_name,

--- a/geometry/proximity/obj_to_surface_mesh.h
+++ b/geometry/proximity/obj_to_surface_mesh.h
@@ -24,7 +24,7 @@ namespace geometry {
  @param on_warning
      An optional callback that will receive warning message(s) encountered
      while reading the mesh.  When not provided, drake::log() will be used.
- @throws std::runtime_error if `filename` doesn't have a valid file path, or the
+ @throws std::exception if `filename` doesn't have a valid file path, or the
      file has no faces.
  @return surface mesh
  */

--- a/geometry/proximity/volume_mesh.h
+++ b/geometry/proximity/volume_mesh.h
@@ -442,7 +442,7 @@ Vector3<T> VolumeMesh<T>::CalcGradBarycentric(VolumeElementIndex e,
   // near the spanning line of an edge of ABC, or anywhere on the spanning plane
   // of ABC), the signed volume calculation ((AB x AC)⋅AV) may become a
   // near-zero number with the wrong sign. In these degenerate cases, we
-  // throw std::runtime_error.
+  // throw std::exception.
   //
   const Vector3<T> area_vector_M = p_AB_M.cross(p_AC_M);  // AB x AC
   const T signed_volume = area_vector_M.dot(p_AV_M);      // (AB x AC)⋅AV

--- a/geometry/proximity_engine.h
+++ b/geometry/proximity_engine.h
@@ -113,10 +113,10 @@ class ProximityEngine {
 
    @param geometry          The geometry to update.
    @param new_properties    The properties to associate with the given geometry.
-   @throws std::logic_error   if `geometry` doesn't map to a known geometry in
-                              the engine or if the new properties trigger work
-                              that can't meaningfully be completed because of
-                              incomplete or inconsistent property definitions.
+   @throws std::exception   if `geometry` doesn't map to a known geometry in
+                            the engine or if the new properties trigger work
+                            that can't meaningfully be completed because of
+                            incomplete or inconsistent property definitions.
    @pre `geometry` still has a copy of the original proximity properties that
          are to be replaced.  */
   void UpdateRepresentationForNewProperties(
@@ -128,7 +128,7 @@ class ProximityEngine {
   /* Removes the given geometry indicated by `id` from the engine.
    @param id          The id of the geometry to be removed.
    @param is_dynamic  True if the geometry is dynamic, false if anchored.
-   @throws std::logic_error if `id` does not refer to a geometry in this engine.
+   @throws std::exception if `id` does not refer to a geometry in this engine.
   */
   void RemoveGeometry(GeometryId id, bool is_dynamic);
 

--- a/geometry/proximity_properties.h
+++ b/geometry/proximity_properties.h
@@ -112,9 +112,9 @@ std::ostream& operator<<(std::ostream& out, const HydroelasticType& type);
  */
 ///@{
 /**
- * @throws std::logic_error if any parameter doesn't satisfy the requirements
- *                          listed in @ref contact_material_utility_functions
- *                          "Contact Material Utility Functions".
+ * @throws std::exception if any parameter doesn't satisfy the requirements
+ *                        listed in @ref contact_material_utility_functions
+ *                        "Contact Material Utility Functions".
  */
 void AddContactMaterial(
     const std::optional<double>& elastic_modulus,
@@ -143,7 +143,7 @@ void AddContactMaterial(
                               will be ignored for geometry types that don't
                               require tessellation.
  @param[in,out] properties    The properties will be added to this property set.
- @throws std::logic_error     If `properties` already has properties with the
+ @throws std::exception       If `properties` already has properties with the
                               names that this function would need to add.
  @pre 0 < `resolution_hint` < ∞ and `properties` is not nullptr.  */
 void AddRigidHydroelasticProperties(double resolution_hint,
@@ -166,7 +166,7 @@ void AddRigidHydroelasticProperties(ProximityProperties* properties);
                               refinement. This will be ignored for geometry
                               types that don't require tessellation.
  @param[in,out] properties    The properties will be added to this property set.
- @throws std::logic_error     If `properties` already has properties with the
+ @throws std::exception       If `properties` already has properties with the
                               names that this function would need to add.
  @pre 0 < `resolution_hint` < ∞, `properties` is not nullptr, and `properties`
       contains a valid elastic modulus value. */
@@ -186,8 +186,8 @@ void AddSoftHydroelasticProperties(ProximityProperties* properties);
                             rigid core (this helps define the extent field of
                             the half space).
  @param[out] properties     The properties will be added to this property set.
- @throws std::logic_error If `properties` already has properties with the names
-                          that this function would need to add.
+ @throws std::exception If `properties` already has properties with the names
+                        that this function would need to add.
  @pre 0 < `slab_thickness` < ∞ . */
 void AddSoftHydroelasticPropertiesForHalfSpace(double slab_thickness,
                                                ProximityProperties* properties);

--- a/geometry/render/gl_renderer/opengl_context.h
+++ b/geometry/render/gl_renderer/opengl_context.h
@@ -26,7 +26,7 @@ class OpenGlContext {
   ~OpenGlContext();
 
   /* Makes this context current.
-   @throw std::runtime_error if not successful.  */
+   @throws std::exception if not successful.  */
   void MakeCurrent() const;
 
   /* Displays the window at the given dimensions. Calling this redundantly (on
@@ -42,7 +42,7 @@ class OpenGlContext {
    Being "viewable" is not necessarily the same as visible to the user. The
    window might be occluded. But, at the very least, there is a window to view.
 
-   @throws std::runtime_error if the visibility status cannot be determined. */
+   @throws std::exception if the visibility status cannot be determined. */
   bool IsWindowViewable() const;
 
   /* Updates the window contents by drawing the back GL buffer into the window.

--- a/geometry/render/gl_renderer/shader_program.h
+++ b/geometry/render/gl_renderer/shader_program.h
@@ -75,8 +75,8 @@ class ShaderProgram {
                                   shader.
    @param fragment_shader_source  The valid GLSL source code for a fragment
                                   shader.
-   @throws std::runtime_error if either shader source doesn't compile or the
-                              resulting program has errors.
+   @throws std::exception if either shader source doesn't compile or the
+                          resulting program has errors.
    */
   void LoadFromSources(const std::string& vertex_shader_source,
                        const std::string& fragment_shader_source);
@@ -87,9 +87,9 @@ class ShaderProgram {
                                 code for a vertex shader.
    @param fragment_shader_file  The path to a file containing valid GLSL source
                                 code for a fragment shader.
-   @throws std::runtime_error if there is an error in reading the files, either
-                              shader source doesn't compile, or the resulting
-                              program has errors.
+   @throws std::exception if there is an error in reading the files, either
+                          shader source doesn't compile, or the resulting
+                          program has errors.
    */
   void LoadFromFiles(const std::string& vertex_shader_file,
                      const std::string& fragment_shader_file);
@@ -147,7 +147,7 @@ class ShaderProgram {
                           const Eigen::Vector3d& scale) const;
 
   /* Provides the location of the named shader uniform parameter.
-   @throws std::runtime_error if the named uniform isn't part of the program. */
+   @throws std::exception if the named uniform isn't part of the program. */
   GLint GetUniformLocation(const std::string& uniform_name) const;
 
   /* Binds the program for usage.  */

--- a/geometry/render/gl_renderer/shape_meshes.h
+++ b/geometry/render/gl_renderer/shape_meshes.h
@@ -48,9 +48,9 @@ struct MeshData {
  If no texture coordinates are specified by the file, it will be indicated in
  the returned MeshData. See MeshData::has_tex_coord for more detail.
 
- @throws std::runtime_error if a) there are no normals, b) faces fail to
-                               reference normals, or c) faces fail to reference
-                               the texture coordinates if they are present.  */
+ @throws std::exception if a) there are no normals, b) faces fail to
+                           reference normals, or c) faces fail to reference
+                           the texture coordinates if they are present.  */
 MeshData LoadMeshFromObj(std::istream* input_stream,
                          const std::string& filename = "from_string");
 

--- a/geometry/render/render_camera.h
+++ b/geometry/render/render_camera.h
@@ -18,8 +18,8 @@ class ClippingRange {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ClippingRange);
 
   /** Constructs the %ClippingRange.
-   @throws std::runtime_error if either value isn't positive, or if
-                              `near >= far`.  */
+   @throws std::exception if either value isn't positive, or if
+                          `near >= far`.  */
   ClippingRange(double near, double far);
 
   double near() const { return near_; }
@@ -133,8 +133,8 @@ class DepthRange {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DepthRange);
 
   /** Constructs the %DepthRange.
-   @throws std::runtime_error if either value isn't positive, or if
-                              `min_in >= max_in`.  */
+   @throws std::exception if either value isn't positive, or if
+                          `min_in >= max_in`.  */
   DepthRange(double min_in, double max_in);
 
   double min_depth() const { return min_depth_; }
@@ -154,8 +154,8 @@ class DepthRenderCamera {
   /** Fully-specified constructor. See the documentation on the member getter
    methods for documentation of parameters.
 
-   @throws std::runtime_error if the depth_range is not fully contained within
-                              the clipping range.  */
+   @throws std::exception if the depth_range is not fully contained within
+                          the clipping range.  */
   DepthRenderCamera(RenderCameraCore core, DepthRange depth_range);
 
   /** This camera's core render properties.  */

--- a/geometry/render/render_engine.h
+++ b/geometry/render/render_engine.h
@@ -89,8 +89,8 @@ class RenderEngine : public ShapeReifier {
    RenderLabel::kUnspecified or RenderLabel::kDontCare. (See
    @ref render_engine_default_label "this section" for more details.)
 
-   @throws std::logic_error if the default render label is not one of the two
-                            allowed labels.  */
+   @throws std::exception if the default render label is not one of the two
+                          allowed labels.  */
   explicit RenderEngine(
       const RenderLabel& default_label = RenderLabel::kUnspecified)
       : default_render_label_(default_label) {
@@ -126,11 +126,11 @@ class RenderEngine : public ShapeReifier {
                          UpdatePoses().
    @returns True if the %RenderEngine implementation accepted the shape for
             registration.
-   @throws std::runtime_error if the shape is an unsupported type, the
-                              shape's RenderLabel value is
-                              RenderLabel::kUnspecified or RenderLabel::kEmpty,
-                              or a geometry has already been registered with the
-                              given `id`.
+   @throws std::exception if the shape is an unsupported type, the
+                          shape's RenderLabel value is
+                          RenderLabel::kUnspecified or RenderLabel::kEmpty,
+                          or a geometry has already been registered with the
+                          given `id`.
   */
   bool RegisterVisual(
       GeometryId id,
@@ -182,9 +182,9 @@ class RenderEngine : public ShapeReifier {
 
    @param camera                The _render engine_ camera properties.
    @param[out] color_image_out  The rendered color image.
-   @throws std::logic_error if `color_image_out` is `nullptr` or the size of the
-                            given input image doesn't match the size declared in
-                            `camera`.  */
+   @throws std::exception if `color_image_out` is `nullptr` or the size of the
+                          given input image doesn't match the size declared in
+                          `camera`.  */
   void RenderColorImage(const ColorRenderCamera& camera,
                         systems::sensors::ImageRgba8U* color_image_out) const {
     ThrowIfInvalid(camera.core().intrinsics(), color_image_out, "color");
@@ -198,9 +198,9 @@ class RenderEngine : public ShapeReifier {
 
    @param camera                The _render engine_ camera properties.
    @param[out] depth_image_out  The rendered depth image.
-   @throws std::logic_error if `depth_image_out` is `nullptr` or the size of the
-                            given input image doesn't match the size declared in
-                            `camera`.  */
+   @throws std::exception if `depth_image_out` is `nullptr` or the size of the
+                          given input image doesn't match the size declared in
+                          `camera`.  */
   void RenderDepthImage(
       const DepthRenderCamera& camera,
       systems::sensors::ImageDepth32F* depth_image_out) const {
@@ -216,9 +216,9 @@ class RenderEngine : public ShapeReifier {
 
    @param camera                The _render engine_ camera properties.
    @param[out] label_image_out  The rendered label image.
-   @throws std::logic_error if `label_image_out` is `nullptr` or the size of the
-                            given input image doesn't match the size declared in
-                            `camera`.  */
+   @throws std::exception if `label_image_out` is `nullptr` or the size of the
+                          given input image doesn't match the size declared in
+                          `camera`.  */
   void RenderLabelImage(
       const ColorRenderCamera& camera,
       systems::sensors::ImageLabel16I* label_image_out) const {
@@ -312,7 +312,7 @@ class RenderEngine : public ShapeReifier {
   /** Extracts the `(label, id)` RenderLabel property from the given
    `properties` and validates it (or the configured default if no such
    property is defined).
-   @throws std::logic_error If the tested render label value is deemed invalid.
+   @throws std::exception If the tested render label value is deemed invalid.
    */
   RenderLabel GetRenderLabelOrThrow(
       const PerceptionProperties& properties) const;

--- a/geometry/render/render_label.h
+++ b/geometry/render/render_label.h
@@ -80,8 +80,8 @@ class RenderLabel {
   RenderLabel() = default;
 
   /** Constructs a label with the given `value`.
-   @throws std::logic_error if a) is negative, or b) the `value` is one of the
-                               reserved values.  */
+   @throws std::exception if a) is negative, or b) the `value` is one of the
+                             reserved values.  */
   explicit RenderLabel(int value) : RenderLabel(value, true) {}
 
   /** Compares this label with the `other` label. Reports true if they have the

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -317,7 +317,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
    @param name          The optional name of the source. If none is provided
                         (or the empty string) a default name will be defined by
                         SceneGraph's logic.
-   @throws std::logic_error if the name is not unique.  */
+   @throws std::exception if the name is not unique.  */
   SourceId RegisterSource(const std::string& name = "");
 
   /** Reports if the given source id is registered.
@@ -327,7 +327,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
   /** Given a valid source `id`, returns a _pose_ input port associated
    with that `id`. This port is used to communicate _pose_ data for registered
    frames.
-   @throws std::logic_error if the source_id is _not_ recognized.  */
+   @throws std::exception if the source_id is _not_ recognized.  */
   const systems::InputPort<T>& get_source_pose_port(SourceId id) const;
 
   /** Returns the output port which produces the PoseBundle for LCM
@@ -393,10 +393,10 @@ class SceneGraph final : public systems::LeafSystem<T> {
    @param source_id     The id for the source registering the frame.
    @param frame         The frame to register.
    @returns A unique identifier for the added frame.
-   @throws std::logic_error  if a) the `source_id` does _not_ map to a
-                             registered source, or
-                             b) `frame` has an id that has already been
-                             registered.  */
+   @throws std::exception  if a) the `source_id` does _not_ map to a
+                           registered source, or
+                           b) `frame` has an id that has already been
+                           registered.  */
   FrameId RegisterFrame(SourceId source_id, const GeometryFrame& frame);
 
   /** Registers a new frame F for this source. This hangs frame F on another
@@ -411,12 +411,12 @@ class SceneGraph final : public systems::LeafSystem<T> {
    @param parent_id    The id of the parent frame P.
    @param frame        The frame to register.
    @returns A unique identifier for the added frame.
-   @throws std::logic_error  if a) the `source_id` does _not_ map to a
-                             registered source,
-                             b) the `parent_id` does _not_ map to a known
-                             frame or does not belong to the source, or
-                             c) `frame` has an id that has already been
-                             registered.  */
+   @throws std::exception  if a) the `source_id` does _not_ map to a
+                           registered source,
+                           b) the `parent_id` does _not_ map to a known
+                           frame or does not belong to the source, or
+                           c) `frame` has an id that has already been
+                           registered.  */
   FrameId RegisterFrame(SourceId source_id, FrameId parent_id,
                         const GeometryFrame& frame);
 
@@ -437,12 +437,12 @@ class SceneGraph final : public systems::LeafSystem<T> {
    @param frame_id    The id for the frame F to hang the geometry on.
    @param geometry    The geometry G to affix to frame F.
    @return A unique identifier for the added geometry.
-   @throws std::logic_error  if a) the `source_id` does _not_ map to a
-                             registered source,
-                             b) the `frame_id` doesn't belong to the source,
-                             c) the `geometry` is equal to `nullptr`, or
-                             d) the geometry's name doesn't satisfy the
-                             requirements outlined in GeometryInstance.  */
+   @throws std::exception  if a) the `source_id` does _not_ map to a
+                           registered source,
+                           b) the `frame_id` doesn't belong to the source,
+                           c) the `geometry` is equal to `nullptr`, or
+                           d) the geometry's name doesn't satisfy the
+                           requirements outlined in GeometryInstance.  */
   GeometryId RegisterGeometry(SourceId source_id, FrameId frame_id,
                               std::unique_ptr<GeometryInstance> geometry);
 
@@ -471,12 +471,12 @@ class SceneGraph final : public systems::LeafSystem<T> {
    @param geometry_id  The id for the parent geometry P.
    @param geometry     The geometry G to add.
    @return A unique identifier for the added geometry.
-   @throws std::logic_error if a) the `source_id` does _not_ map to a registered
-                            source,
-                            b) the `geometry_id` doesn't belong to the source,
-                            c) the `geometry` is equal to `nullptr`, or
-                            d) the geometry's name doesn't satisfy the
-                            requirements outlined in GeometryInstance.  */
+   @throws std::exception if a) the `source_id` does _not_ map to a registered
+                          source,
+                          b) the `geometry_id` doesn't belong to the source,
+                          c) the `geometry` is equal to `nullptr`, or
+                          d) the geometry's name doesn't satisfy the
+                          requirements outlined in GeometryInstance.  */
   GeometryId RegisterGeometry(SourceId source_id, GeometryId geometry_id,
                               std::unique_ptr<GeometryInstance> geometry);
 
@@ -502,10 +502,10 @@ class SceneGraph final : public systems::LeafSystem<T> {
    @param source_id     The id for the source registering the frame.
    @param geometry      The anchored geometry G to add to the world.
    @return A unique identifier for the added geometry.
-   @throws std::logic_error  if a) the `source_id` does _not_ map to a
-                             registered source or
-                             b) the geometry's name doesn't satisfy the
-                             requirements outlined in GeometryInstance.  */
+   @throws std::exception  if a) the `source_id` does _not_ map to a
+                           registered source or
+                           b) the geometry's name doesn't satisfy the
+                           requirements outlined in GeometryInstance.  */
   GeometryId RegisterAnchoredGeometry(
       SourceId source_id, std::unique_ptr<GeometryInstance> geometry);
 
@@ -521,12 +521,12 @@ class SceneGraph final : public systems::LeafSystem<T> {
    @param source_id   The identifier for the owner geometry source.
    @param geometry_id The identifier of the geometry to remove (can be dynamic
                       or anchored).
-   @throws std::logic_error  if a) the `source_id` does _not_ map to a
-                             registered source,
-                             b) the `geometry_id` does not map to a valid
-                             geometry, or
-                             c) the `geometry_id` maps to a geometry that does
-                             not belong to the indicated source.  */
+   @throws std::exception  if a) the `source_id` does _not_ map to a
+                           registered source,
+                           b) the `geometry_id` does not map to a valid
+                           geometry, or
+                           c) the `geometry_id` maps to a geometry that does
+                           not belong to the indicated source.  */
   void RemoveGeometry(SourceId source_id, GeometryId geometry_id);
 
   /** systems::Context-modifying variant of RemoveGeometry(). Rather than
@@ -566,7 +566,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
 
    @param name      The unique name of the renderer.
    @param renderer  The `renderer` to add.
-   @throws std::logic_error if the name is not unique.  */
+   @throws std::exception if the name is not unique.  */
   void AddRenderer(std::string name,
                    std::unique_ptr<render::RenderEngine> renderer);
 
@@ -751,12 +751,12 @@ class SceneGraph final : public systems::LeafSystem<T> {
    on the role being removed from the geometry (see @ref
    scene_graph_versioning).
    @returns The number of geometries affected by the removed role.
-   @throws std::logic_error if a) `source_id` does not map to a registered
-                            source,
-                            b) `frame_id` does not map to a registered frame,
-                            c) `frame_id` does not belong to `source_id`
-                            (unless `frame_id` is the world frame id), or
-                            d) the context has already been allocated.  */
+   @throws std::exception if a) `source_id` does not map to a registered
+                          source,
+                          b) `frame_id` does not map to a registered frame,
+                          c) `frame_id` does not belong to `source_id`
+                          (unless `frame_id` is the world frame id), or
+                          d) the context has already been allocated.  */
   int RemoveRole(SourceId source_id, FrameId frame_id, Role role);
 
   /** systems::Context-modifying variant of
@@ -772,12 +772,12 @@ class SceneGraph final : public systems::LeafSystem<T> {
    scene_graph_versioning).
    @returns One if the geometry had the role removed and zero if the geometry
             did not have the role assigned in the first place.
-   @throws std::logic_error if a) `source_id` does not map to a registered
-                            source,
-                            b) `geometry_id` does not map to a registered
-                            geometry,
-                            c) `geometry_id` does not belong to `source_id`, or
-                            d) the context has already been allocated.
+   @throws std::exception if a) `source_id` does not map to a registered
+                          source,
+                          b) `geometry_id` does not map to a registered
+                          geometry,
+                          c) `geometry_id` does not belong to `source_id`, or
+                          d) the context has already been allocated.
    @pydrake_mkdoc_identifier{geometry_direct}  */
   int RemoveRole(SourceId source_id, GeometryId geometry_id, Role role);
 
@@ -851,8 +851,8 @@ class SceneGraph final : public systems::LeafSystem<T> {
    @sa @ref scene_graph_collision_filtering for requirements and how collision
    filtering works.
 
-   @throws std::logic_error if the set includes ids that don't exist in the
-                            scene graph.  */
+   @throws std::exception if the set includes ids that don't exist in the
+                          scene graph.  */
   void ExcludeCollisionsWithin(const GeometrySet& set);
 
   /** systems::Context-modifying variant of ExcludeCollisionsWithin(). Rather
@@ -871,8 +871,8 @@ class SceneGraph final : public systems::LeafSystem<T> {
    @sa @ref scene_graph_collision_filtering for requirements and how collision
    filtering works.
 
-   @throws std::logic_error if the groups include ids that don't exist in the
-                            scene graph.  */
+   @throws std::exception if the groups include ids that don't exist in the
+                          scene graph.  */
   void ExcludeCollisionsBetween(const GeometrySet& setA,
                                 const GeometrySet& setB);
 

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -197,7 +197,7 @@ class SceneGraphInspector {
 
   /** Reports the number of frames registered to the source with the given
    `source_id`.
-   @throws std::logic_error if `source_id` does not map to a registered source.
+   @throws std::exception if `source_id` does not map to a registered source.
    */
   int NumFramesForSource(SourceId source_id) const {
     DRAKE_DEMAND(state_ != nullptr);
@@ -206,7 +206,7 @@ class SceneGraphInspector {
 
   /** Reports the ids of all of the frames registered to the source with the
    given source `source_id`.
-   @throws std::logic_error if `source_id` does not map to a registered source.
+   @throws std::exception if `source_id` does not map to a registered source.
    */
   const std::unordered_set<FrameId>& FramesForSource(SourceId source_id) const {
     DRAKE_DEMAND(state_ != nullptr);
@@ -223,8 +223,8 @@ class SceneGraphInspector {
    @param frame_id      The query frame id.
    @param source_id     The query source id.
    @returns True if `frame_id` was registered on `source_id`.
-   @throws std::logic_error  If `frame_id` does not map to a registered frame
-                             or `source_id` does not map to a registered source.
+   @throws std::exception  If `frame_id` does not map to a registered frame
+                           or `source_id` does not map to a registered source.
    */
   bool BelongsToSource(FrameId frame_id, SourceId source_id) const {
     DRAKE_DEMAND(state_ != nullptr);
@@ -233,7 +233,7 @@ class SceneGraphInspector {
 
   /** Reports the _name_ of the geometry source that registered the frame with
    the given `frame_id`.
-   @throws std::logic_error  If `frame_id` does not map to a registered frame.
+   @throws std::exception  If `frame_id` does not map to a registered frame.
    */
   const std::string& GetOwningSourceName(FrameId frame_id) const {
     DRAKE_DEMAND(state_ != nullptr);
@@ -241,7 +241,7 @@ class SceneGraphInspector {
   }
 
   /** Reports the name of the frame with the given `frame_id`.
-   @throws std::logic_error if `frame_id` does not map to a registered frame.
+   @throws std::exception if `frame_id` does not map to a registered frame.
    */
   const std::string& GetName(FrameId frame_id) const {
     DRAKE_DEMAND(state_ != nullptr);
@@ -249,7 +249,7 @@ class SceneGraphInspector {
   }
 
   /** Reports the frame group for the frame with the given `frame_id`.
-   @throws  std::logic_error if `frame_id` does not map to a registered frame.
+   @throws std::exception if `frame_id` does not map to a registered frame.
    @internal This value is equivalent to the old "model instance id".  */
   int GetFrameGroup(FrameId frame_id) const {
     DRAKE_DEMAND(state_ != nullptr);
@@ -259,7 +259,7 @@ class SceneGraphInspector {
   /** Reports the number of geometries affixed to the frame with the given
    `frame_id`. This count does _not_ include geometries attached to frames that
    are descendants of this frame.
-   @throws std::logic_error if `frame_id` does not map to a registered frame.
+   @throws std::exception if `frame_id` does not map to a registered frame.
    */
   int NumGeometriesForFrame(FrameId frame_id) const {
     DRAKE_DEMAND(state_ != nullptr);
@@ -269,7 +269,7 @@ class SceneGraphInspector {
   /** Reports the total number of geometries with the given `role` directly
    registered to the frame with the given `frame_id`. This count does _not_
    include geometries attached to frames that are descendants of this frame.
-   @throws std::logic_error if `frame_id` does not map to a registered frame.
+   @throws std::exception if `frame_id` does not map to a registered frame.
    */
   int NumGeometriesForFrameWithRole(FrameId frame_id, Role role) const {
     DRAKE_DEMAND(state_ != nullptr);
@@ -283,7 +283,7 @@ class SceneGraphInspector {
    @param role  The requested role; if omitted, all geometries registered to the
                 frame are returned.
    @returns The requested unique geometry ids in a consistent order.
-   @throws std::logic_error if `id` does not map to a registered frame.  */
+   @throws std::exception if `id` does not map to a registered frame.  */
   std::vector<GeometryId> GetGeometries(
       FrameId frame_id, const std::optional<Role>& role = std::nullopt) const {
     DRAKE_DEMAND(state_ != nullptr);
@@ -300,9 +300,9 @@ class SceneGraphInspector {
                     @ref canonicalized_geometry_names "GeometryInstance" for
                     details).
    @return The id of the queried geometry.
-   @throws std::logic_error if no such geometry exists, multiple geometries have
-                            that name, or if the `frame_id` does not map to a
-                            registered frame.  */
+   @throws std::exception if no such geometry exists, multiple geometries have
+                          that name, or if the `frame_id` does not map to a
+                          registered frame.  */
   GeometryId GetGeometryIdByName(FrameId frame_id, Role role,
                                  const std::string& name) const {
     DRAKE_DEMAND(state_ != nullptr);
@@ -319,9 +319,9 @@ class SceneGraphInspector {
    @param geometry_id   The query geometry id.
    @param source_id     The query source id.
    @returns True if `geometry_id` was registered on `source_id`.
-   @throws std::logic_error  If `geometry_id` does not map to a registered
-                             geometry or `source_id` does not map to a
-                             registered source.  */
+   @throws std::exception  If `geometry_id` does not map to a registered
+                           geometry or `source_id` does not map to a
+                           registered source.  */
   bool BelongsToSource(GeometryId geometry_id, SourceId source_id) const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->BelongsToSource(geometry_id, source_id);
@@ -329,7 +329,7 @@ class SceneGraphInspector {
 
   /** Reports the _name_ of the geometry source that registered the geometry
    with the given `geometry_id`.
-   @throws std::logic_error  If `geometry_id` does not map to a registered
+   @throws std::exception  If `geometry_id` does not map to a registered
    geometry. */
   const std::string& GetOwningSourceName(GeometryId geometry_id) const {
     DRAKE_DEMAND(state_ != nullptr);
@@ -338,7 +338,7 @@ class SceneGraphInspector {
 
   /** Reports the id of the frame to which the given geometry with the given
    `geometry_id` is registered.
-   @throws std::logic_error if `geometry_id` does not map to a registered
+   @throws std::exception if `geometry_id` does not map to a registered
    geometry.  */
   FrameId GetFrameId(GeometryId geometry_id) const {
     DRAKE_DEMAND(state_ != nullptr);
@@ -348,7 +348,7 @@ class SceneGraphInspector {
   /** Reports the stored, canonical name of the geometry with the given
    `geometry_id` (see  @ref canonicalized_geometry_names "GeometryInstance" for
    details).
-   @throws std::logic_error if `geometry_id` does not map to a registered
+   @throws std::exception if `geometry_id` does not map to a registered
    geometry.  */
   const std::string& GetName(GeometryId geometry_id) const {
     DRAKE_DEMAND(state_ != nullptr);
@@ -368,7 +368,7 @@ class SceneGraphInspector {
    frame F or another geometry. If the geometry was registered directly to F,
    then `X_PG = X_FG`.
    @sa GetPoseInFrame()
-   @throws std::logic_error if `geometry_id` does not map to a registered
+   @throws std::exception if `geometry_id` does not map to a registered
    geometry.  */
   const math::RigidTransform<double>& GetPoseInParent(
       GeometryId geometry_id) const {
@@ -381,7 +381,7 @@ class SceneGraphInspector {
    geometry P or not). If the geometry was registered directly to the frame F,
    then `X_PG = X_FG`.
    @sa GetPoseInParent()
-   @throws std::logic_error if `geometry_id` does not map to a registered
+   @throws std::exception if `geometry_id` does not map to a registered
    geometry.  */
   const math::RigidTransform<double>& GetPoseInFrame(
       GeometryId geometry_id) const {
@@ -454,9 +454,9 @@ class SceneGraphInspector {
 
   /** Reports true if the two geometries with given ids `geometry_id1` and
    `geometry_id2`, define a collision pair that has been filtered out.
-   @throws std::logic_error if either id does not map to a registered geometry
-                            or if any of the geometries do not have a proximity
-                            role.  */
+   @throws std::exception if either id does not map to a registered geometry
+                          or if any of the geometries do not have a proximity
+                          role.  */
   bool CollisionFiltered(GeometryId geometry_id1,
                          GeometryId geometry_id2) const {
     DRAKE_DEMAND(state_ != nullptr);
@@ -467,7 +467,7 @@ class SceneGraphInspector {
    geometry will be passed into the provided `reifier`. This is the mechanism by
    which external code can discover and respond to the different types of
    geometries stored in SceneGraph. See ShapeToString as an example.
-   @throws std::logic_error if the `geometry_id` does not refer to a valid
+   @throws std::exception if the `geometry_id` does not refer to a valid
    geometry.  */
   void Reify(GeometryId geometry_id, ShapeReifier* reifier) const {
     DRAKE_DEMAND(state_ != nullptr);
@@ -479,7 +479,7 @@ class SceneGraphInspector {
    @return A new GeometryInstance that is ready to be added as a new geometry.
            All roles/properties will be copied, the shape will be cloned based
            off of the original, but the returned id() will completely unique.
-   @throws std::logic_error if the `geometry_id` does not refer to a valid
+   @throws std::exception if the `geometry_id` does not refer to a valid
    geometry.  */
   std::unique_ptr<GeometryInstance>
   CloneGeometryInstance(GeometryId geometry_id) const;

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -106,7 +106,7 @@ class Sphere final : public Shape {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Sphere)
 
   /** Constructs a sphere with the given `radius`.
-   @throws std::logic_error if `radius` is negative. Note that a zero radius is
+   @throws std::exception if `radius` is negative. Note that a zero radius is
    is considered valid. */
   explicit Sphere(double radius);
 
@@ -123,7 +123,7 @@ class Cylinder final : public Shape {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Cylinder)
 
   /** Constructs a cylinder with the given `radius` and `length`.
-   @throws std::logic_error if `radius` or `length` are not strictly positive.
+   @throws std::exception if `radius` or `length` are not strictly positive.
    */
   Cylinder(double radius, double length);
 
@@ -145,7 +145,7 @@ class Box final : public Shape {
   /** Constructs a box with the given `width`, `depth`, and `height`, which
    specify the box's dimension along the canonical x-, y-, and z-axes,
    respectively.
-   @throws std::logic_error if `width`, `depth` or `height` are not strictly
+   @throws std::exception if `width`, `depth` or `height` are not strictly
    positive. */
   Box(double width, double depth, double height);
 
@@ -181,7 +181,7 @@ class Capsule final : public Shape {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Capsule)
 
   /** Constructs a capsule with the given `radius` and `length`.
-   @throws std::logic_error if `radius` or `length` are not strictly positive.
+   @throws std::exception if `radius` or `length` are not strictly positive.
    */
   Capsule(double radius, double length);
 
@@ -207,7 +207,7 @@ class Ellipsoid final : public Shape {
 
   /** Constructs an ellipsoid with the given lengths of its principal
    semi-axes.
-   @throws std::logic_error if `a`, `b`, or `c` are not strictly positive.
+   @throws std::exception if `a`, `b`, or `c` are not strictly positive.
    */
   Ellipsoid(double a, double b, double c);
 
@@ -243,8 +243,8 @@ class HalfSpace final : public Shape {
    @param p_FB      A point B lying on the half space's boundary measured
                     and expressed in frame F.
    @retval X_FH     The pose of the canonical half-space in frame F.
-   @throws std::logic_error if the normal is _close_ to a zero-vector (e.g.,
-                            ‖normal_F‖₂ < ε). */
+   @throws std::exception if the normal is _close_ to a zero-vector (e.g.,
+                          ‖normal_F‖₂ < ε). */
   static math::RigidTransform<double> MakePose(const Vector3<double>& Hz_dir_F,
                                                const Vector3<double>& p_FB);
 };
@@ -261,7 +261,7 @@ class Mesh final : public Shape {
 
   /** Constructs a mesh specification from the mesh file located at the given
    _absolute_ file path. Optionally uniformly scaled by the given scale factor.
-   @throws std::logic_error if |scale| < 1e-8. Note that a negative scale is
+   @throws std::exception if |scale| < 1e-8. Note that a negative scale is
    considered valid. We want to preclude scales near zero but recognise that
    scale is a convenience tool for "tweaking" models. 8 orders of magnitude
    should be plenty without considering revisiting the model itself. */
@@ -289,12 +289,12 @@ class Convex final : public Shape {
                                 We assume that the polyhedron is convex.
    @param scale                 An optional scale to coordinates.
 
-   @throws std::runtime_error   if the .obj file doesn't define a single object.
+   @throws std::exception       if the .obj file doesn't define a single object.
                                 This can happen if it is empty, if there are
                                 multiple object-name statements (e.g.,
                                 "o object_name"), or if there are faces defined
                                 outside a single object-name statement.
-   @throws std::logic_error     if |scale| < 1e-8. Note that a negative scale is
+   @throws std::exception       if |scale| < 1e-8. Note that a negative scale is
                                 considered valid. We want to preclude scales
                                 near zero but recognise that scale is a
                                 convenience tool for "tweaking" models. 8 orders

--- a/lcm/drake_lcm_log.h
+++ b/lcm/drake_lcm_log.h
@@ -41,7 +41,7 @@ class DrakeLcmLog : public DrakeLcmInterface {
    * lcm-logger's behavior. It also implicitly records how fast the messages
    * are generated in real time.
    *
-   * @throws std::runtime_error if unable to open file.
+   * @throws std::exception if unable to open file.
    */
   DrakeLcmLog(const std::string& file_name, bool is_write,
               bool overwrite_publish_time_with_system_clock = false);
@@ -58,7 +58,7 @@ class DrakeLcmLog : public DrakeLcmInterface {
    * this parameter can be overwritten by the host system's clock if
    * `overwrite_publish_time_with_system_clock` is true at construction time.
    *
-   * @throws std::logic_error if this instance is not constructed in write-only
+   * @throws std::exception if this instance is not constructed in write-only
    * mode.
    */
   void Publish(const std::string& channel, const void* data, int data_size,
@@ -68,7 +68,7 @@ class DrakeLcmLog : public DrakeLcmInterface {
    * Subscribes @p handler to @p channel. Multiple handlers can subscribe to the
    * same channel.
    *
-   * @throws std::logic_error if this instance is not constructed in read-only
+   * @throws std::exception if this instance is not constructed in read-only
    * mode.
    *
    * @return nullptr because this implementation does not support unsubscribe.
@@ -85,7 +85,7 @@ class DrakeLcmLog : public DrakeLcmInterface {
    * Returns the time in seconds for the next logged message's occurrence time
    * or infinity if there are no more messages in the current log.
    *
-   * @throws std::logic_error if this instance is not constructed in read-only
+   * @throws std::exception if this instance is not constructed in read-only
    * mode.
    */
   double GetNextMessageTime() const;
@@ -98,7 +98,7 @@ class DrakeLcmLog : public DrakeLcmInterface {
    * nothing if `MSG` is null (end of log) or @p current_time does not match
    * `MSG`'s timestamp.
    *
-   * @throws std::logic_error if this instance is not constructed in read-only
+   * @throws std::exception if this instance is not constructed in read-only
    * mode.
    */
   void DispatchMessageAndAdvanceLog(double current_time);

--- a/lcm/lcm_messages.h
+++ b/lcm/lcm_messages.h
@@ -24,7 +24,7 @@ std::vector<uint8_t> EncodeLcmMessage(const Message& message) {
 
 /**
  Decodes an LCM message from a series of bytes.
- @throws std::runtime_error if decoding fails.
+ @throws std::exception if decoding fails.
  */
 template <typename Message>
 Message DecodeLcmMessage(const std::vector<uint8_t>& bytes) {

--- a/manipulation/planner/differential_inverse_kinematics.h
+++ b/manipulation/planner/differential_inverse_kinematics.h
@@ -201,7 +201,7 @@ class DifferentialInverseKinematicsParameters {
   /**
    * Adds a linear velocity constraint.
    * @param linear_velocity_constraint A linear constraint on joint velocities.
-   * @throws std::invalid_argument if `constraint->num_vars !=
+   * @throws std::exception if `constraint->num_vars !=
    * this->get_num_velocities()`.
    */
   void AddLinearVelocityConstraint(

--- a/manipulation/util/moving_average_filter.h
+++ b/manipulation/util/moving_average_filter.h
@@ -36,7 +36,7 @@ class MovingAverageFilter {
   /**
    * Constructs the filter with the specified `window_size`.
    * @param window_size The size of the window.
-   * @throws std::runtime_error when window_size <= 0.
+   * @throws std::exception when window_size <= 0.
    */
   explicit MovingAverageFilter(int window_size);
 

--- a/math/autodiff_gradient.h
+++ b/math/autodiff_gradient.h
@@ -152,7 +152,7 @@ void gradientMatrixToAutoDiff(
  *
  * @param precision is passed to Eigen's isZero(precision) to evaluate whether
  * the gradients are zero.
- * @throws std::runtime_error if the gradients were not empty nor zero.
+ * @throws std::exception if the gradients were not empty nor zero.
  *
  * @see DiscardGradient
  */

--- a/math/bspline_basis.h
+++ b/math/bspline_basis.h
@@ -39,13 +39,13 @@ class BsplineBasis final {
 
   /** Constructs a B-spline basis with the specified `order` and `knots`.
   @pre `knots` is sorted in non-descending order.
-  @throws std::invalid_argument if knots.size() < 2 * order. */
+  @throws std::exception if knots.size() < 2 * order. */
   BsplineBasis(int order, std::vector<T> knots);
 
   /** Constructs a B-spline basis with the specified `order`,
   `num_basis_functions`, `initial_parameter_value`, `final_parameter_value`,
   and an auto-generated knot vector of the specified `type`.
-  @throws std::invalid_argument if num_basis_functions < order
+  @throws std::exception if num_basis_functions < order
   @pre initial_parameter_value ≤ final_parameter_value */
   BsplineBasis(int order, int num_basis_functions,
                KnotVectorType type = KnotVectorType::kClampedUniform,

--- a/math/continuous_algebraic_riccati_equation.h
+++ b/math/continuous_algebraic_riccati_equation.h
@@ -12,7 +12,7 @@ namespace math {
 /// S A + A' S - S B R^{-1} B' S + Q = 0
 /// @f]
 ///
-/// @throws std::runtime_error if R is not positive definite.
+/// @throws std::exception if R is not positive definite.
 ///
 /// Based on the Matrix Sign Function method outlined in this paper:
 /// http://www.engr.iupui.edu/~skoskie/ECE684/Riccati_algorithms.pdf

--- a/math/continuous_lyapunov_equation.h
+++ b/math/continuous_lyapunov_equation.h
@@ -20,13 +20,13 @@ namespace math {
  * Computes a unique solution X to the continuous Lyapunov equation: `AᵀX + XA +
  * Q = 0`, where A is real and square, and Q is real, symmetric and of equal
  * size as A.
- * @throws std::runtime_error if A or Q are not square matrices or do not
+ * @throws std::exception if A or Q are not square matrices or do not
  * have the same size.
  *
  * Limitations: Given the Eigenvalues of A as λ₁, ..., λₙ, there exists
  * a unique solution if and only if λᵢ + λ̅ⱼ ≠ 0 ∀ i,j, where λ̅ⱼ is
  * the complex conjugate of λⱼ.
- * @throws std::runtime_error if the solution is not unique.
+ * @throws std::exception if the solution is not unique.
  *
  * There are no further limitations on the eigenvalues of A.
  * Further, if all λᵢ have negative real parts, and if Q is positive
@@ -38,7 +38,7 @@ namespace math {
  * The implementation is based on SLICOT routine SB03MD [2]. Note the
  * transformation Q = -C. The complexity of this routine is O(n³).
  * If A is larger than 2-by-2, then a Schur factorization is performed.
- * @throw std::runtime_error if Schur factorization failed.
+ * @throws std::exception if Schur factorization failed.
  *
  * A tolerance of ε is used to check if a double variable is equal to zero,
  * where the default value for ε is 1e-10. It has been used to check (1) if λᵢ +

--- a/math/discrete_algebraic_riccati_equation.cc
+++ b/math/discrete_algebraic_riccati_equation.cc
@@ -383,8 +383,8 @@ void reorder_eigen(Eigen::Ref<Eigen::MatrixXd> S, Eigen::Ref<Eigen::MatrixXd> T,
  * A'XA - X - A'XB(B'XB+R)^{-1}B'XA + Q = 0
  * \f]
  *
- * @throws std::runtime_error if Q is not positive semi-definite.
- * @throws std::runtime_error if R is not positive definite.
+ * @throws std::exception if Q is not positive semi-definite.
+ * @throws std::exception if R is not positive definite.
  *
  * Based on the Schur Vector approach outlined in this paper:
  * "On the Numerical Solution of the Discrete-Time Algebraic Riccati Equation"

--- a/math/discrete_algebraic_riccati_equation.h
+++ b/math/discrete_algebraic_riccati_equation.h
@@ -15,8 +15,8 @@ namespace math {
 /// A'XA - X - A'XB(B'XB+R)^{-1}B'XA + Q = 0
 /// @f]
 ///
-/// @throws std::runtime_error if Q is not positive semi-definite.
-/// @throws std::runtime_error if R is not positive definite.
+/// @throws std::exception if Q is not positive semi-definite.
+/// @throws std::exception if R is not positive definite.
 ///
 /// Based on the Schur Vector approach outlined in this paper:
 /// "On the Numerical Solution of the Discrete-Time Algebraic Riccati Equation"

--- a/math/discrete_lyapunov_equation.h
+++ b/math/discrete_lyapunov_equation.h
@@ -20,12 +20,12 @@ namespace math {
  * Computes the unique solution X to the discrete Lyapunov equation: `AᵀXA - X +
  * Q = 0`, where A is real and square, and Q is real, symmetric and of equal
  * size as A.
- * @throws std::runtime_error if A or Q are not square matrices or do not
+ * @throws std::exception if A or Q are not square matrices or do not
  * have the same size.
  *
  * Limitations: Given the Eigenvalues of A as λ₁, ..., λₙ, there exists
  * a unique solution if and only if λᵢ * λⱼ ≠ 1 ∀ i,j and λᵢ ≠ ±1, ∀ i [1].
- * @throws std::runtime_error if the solution is not unique.[3]
+ * @throws std::exception if the solution is not unique.[3]
  *
  * There are no further limitations on the eigenvalues of A.
  * Further, if |λᵢ|<1, ∀ i, and if Q is
@@ -38,7 +38,7 @@ namespace math {
  * The implementation is based on SLICOT routine SB03MD [2]. Note the
  * transformation Q = -C. The complexity of this routine is O(n³).
  * If A is larger than 2-by-2, then a Schur factorization is performed.
- * @throws std::runtime_error if Schur factorization fails.
+ * @throws std::exception if Schur factorization fails.
  *
  * A tolerance of ε is used to check if a double variable is equal to zero,
  * where the default value for ε is 1e-10. It has been used to check (1) if λᵢ =

--- a/math/evenly_distributed_pts_on_sphere.h
+++ b/math/evenly_distributed_pts_on_sphere.h
@@ -12,7 +12,7 @@ namespace math {
  * points.
  * @param num_points The number of points we want on the unit sphere.
  * @return The generated points.
- * @pre num_samples >= 1. Throw std::runtime_error if num_points < 1
+ * @pre num_samples >= 1. Throw std::exception if num_points < 1
  */
 Eigen::Matrix3Xd UniformPtsOnSphereFibonacci(int num_points);
 }  // namespace math

--- a/math/orthonormal_basis.h
+++ b/math/orthonormal_basis.h
@@ -20,7 +20,7 @@ namespace math {
 ///                     in frame W. The vector need not be a unit vector: this
 ///                     routine will normalize it.
 /// @retval R_WL        The computed basis.
-/// @throws std::logic_error if the norm of @p axis_W is within 1e-10 to zero or
+/// @throws std::exception if the norm of @p axis_W is within 1e-10 to zero or
 ///         @p axis_index does not lie in the range [0,2].
 template <class T>
 DRAKE_DEPRECATED("2021-10-01", "Use RotationMatrix::MakeFromOneVector().")

--- a/math/quadratic_form.h
+++ b/math/quadratic_form.h
@@ -19,7 +19,7 @@ namespace math {
  * @retval X. The matrix X satisfies XᵀX = Y and X.rows() = rank(Y).
  * @pre 1. Y is positive semidefinite.
  *      2. zero_tol is non-negative.
- * @throws std::runtime_error when the pre-conditions are not satisfied.
+ * @throws std::exception when the pre-conditions are not satisfied.
  * @note We only use the lower triangular part of Y.
  */
 Eigen::MatrixXd DecomposePSDmatrixIntoXtransposeTimesX(
@@ -58,7 +58,7 @@ Eigen::MatrixXd DecomposePSDmatrixIntoXtransposeTimesX(
  *         is positive semidefinite.
  *      2. `Q` and `b` are of the correct size.
  *      3. `tol` is non-negative.
- * @throws std::runtime_error if the precondition is not satisfied.
+ * @throws std::exception if the precondition is not satisfied.
  */
 std::pair<Eigen::MatrixXd, Eigen::MatrixXd>
 DecomposePositiveQuadraticForm(const Eigen::Ref<const Eigen::MatrixXd>& Q,

--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -102,7 +102,7 @@ class RigidTransform {
   /// have unit length [i.e., `quaternion.norm()` does not have to be 1].
   /// @param[in] p position vector from frame A's origin to frame B's origin,
   /// expressed in frame A.  In monogram notation p is denoted `p_AoBo_A`.
-  /// @throws std::logic_error in debug builds if the rotation matrix
+  /// @throws std::exception in debug builds if the rotation matrix
   /// that is built from `quaternion` is invalid.
   /// @see RotationMatrix::RotationMatrix(const Eigen::Quaternion<T>&)
   RigidTransform(const Eigen::Quaternion<T>& quaternion, const Vector3<T>& p)
@@ -114,7 +114,7 @@ class RigidTransform {
   /// may not have unit length [i.e., `lambda.norm()` does not have to be 1].
   /// @param[in] p position vector from frame A's origin to frame B's origin,
   /// expressed in frame A.  In monogram notation p is denoted `p_AoBo_A
-  /// @throws std::logic_error in debug builds if the rotation matrix
+  /// @throws std::exception in debug builds if the rotation matrix
   /// that is built from `theta_lambda` is invalid.
   /// @see RotationMatrix::RotationMatrix(const Eigen::AngleAxis<T>&)
   RigidTransform(const Eigen::AngleAxis<T>& theta_lambda, const Vector3<T>& p)
@@ -151,7 +151,7 @@ class RigidTransform {
   /// @param[in] pose Isometry3 that contains an allegedly valid rotation matrix
   /// `R_AB` and also contains a position vector `p_AoBo_A` from frame A's
   /// origin to frame B's origin.  `p_AoBo_A` must be expressed in frame A.
-  /// @throws std::logic_error in debug builds if R_AB is not a proper
+  /// @throws std::exception in debug builds if R_AB is not a proper
   /// orthonormal 3x3 rotation matrix.
   /// @note No attempt is made to orthogonalize the 3x3 rotation matrix part of
   /// `pose`.  As needed, use RotationMatrix::ProjectToRotationMatrix().
@@ -166,7 +166,7 @@ class RigidTransform {
   ///  │ R_AB  p_AoBo_A │
   ///  └                ┘
   /// </pre>
-  /// @throws std::logic_error in debug builds if the `R_AB` part of `pose` is
+  /// @throws std::exception in debug builds if the `R_AB` part of `pose` is
   /// not a proper orthonormal 3x3 rotation matrix.
   /// @note No attempt is made to orthogonalize the 3x3 rotation matrix part of
   /// `pose`.  As needed, use RotationMatrix::ProjectToRotationMatrix().
@@ -187,7 +187,7 @@ class RigidTransform {
   ///  │   0      1     │
   ///  └                ┘
   /// </pre>
-  /// @throws std::logic_error in debug builds if the `R_AB` part of `pose`
+  /// @throws std::exception in debug builds if the `R_AB` part of `pose`
   /// is not a proper orthonormal 3x3 rotation matrix or if `pose` is a 4x4
   /// matrix whose final row is not `[0, 0, 0, 1]`.
   /// @note No attempt is made to orthogonalize the 3x3 rotation matrix part of
@@ -201,7 +201,7 @@ class RigidTransform {
 
   /// Constructs a %RigidTransform from an appropriate Eigen <b>expression</b>.
   /// @param[in] pose Generic Eigen matrix <b>expression</b>.
-  /// @throws std::logic_error if the Eigen <b>expression</b> in pose does not
+  /// @throws std::exception if the Eigen <b>expression</b> in pose does not
   /// resolve to a Vector3 or 3x4 matrix or 4x4 matrix or if the rotational part
   /// of `pose` is not a proper orthonormal 3x3 rotation matrix or if `pose` is
   /// a 4x4 matrix whose final row is not `[0, 0, 0, 1]`.
@@ -263,7 +263,7 @@ class RigidTransform {
   /// @param[in] pose Isometry3 that contains an allegedly valid rotation matrix
   /// `R_AB` and also contains a position vector `p_AoBo_A` from frame A's
   /// origin to frame B's origin.  `p_AoBo_A` must be expressed in frame A.
-  /// @throws std::logic_error in debug builds if R_AB is not a proper
+  /// @throws std::exception in debug builds if R_AB is not a proper
   /// orthonormal 3x3 rotation matrix.
   /// @note No attempt is made to orthogonalize the 3x3 rotation matrix part of
   /// `pose`.  As needed, use RotationMatrix::ProjectToRotationMatrix().

--- a/math/rotation_matrix.h
+++ b/math/rotation_matrix.h
@@ -1049,7 +1049,7 @@ using RotationMatrixd = RotationMatrix<double>;
 /// @param[in] angle_lb the lower bound of the rotation angle θ.
 /// @param[in] angle_ub the upper bound of the rotation angle θ.
 /// @return Rotation angle θ of the projected matrix, angle_lb <= θ <= angle_ub
-/// @throws std::runtime_error if axis is the zero vector or
+/// @throws std::exception if axis is the zero vector or
 ///         if angle_lb > angle_ub.
 /// @note This method is useful for reconstructing a rotation matrix for a
 /// revolute joint with joint limits.

--- a/multibody/constraint/constraint_solver.h
+++ b/multibody/constraint/constraint_solver.h
@@ -341,11 +341,11 @@ class ConstraintSolver {
   ///           CalcContactForcesInContactFrames(). `cf` will be resized as
   ///           necessary.
   /// @pre Constraint data has been computed.
-  /// @throws std::runtime_error if the constraint forces cannot be computed
+  /// @throws std::exception if the constraint forces cannot be computed
   ///         (due to, e.g., the effects of roundoff error in attempting to
   ///         solve a complementarity problem); in such cases, it is
   ///         recommended to increase regularization and attempt again.
-  /// @throws std::logic_error if `cf` is null.
+  /// @throws std::exception if `cf` is null.
   void SolveImpactProblem(const ConstraintVelProblemData<T>& problem_data,
                           VectorX<T>* cf) const;
 
@@ -402,9 +402,9 @@ class ConstraintSolver {
   ///           CalcContactForcesInContactFrames(). `cf` will be resized as
   ///           necessary.
   /// @pre Constraint data has been computed.
-  /// @throws std::runtime_error if the constraint forces cannot be computed
+  /// @throws std::exception if the constraint forces cannot be computed
   ///         (due to, e.g., an "inconsistent" rigid contact configuration).
-  /// @throws std::logic_error if `cf` is null.
+  /// @throws std::exception if `cf` is null.
   void SolveConstraintProblem(const ConstraintAccelProblemData<T>& problem_data,
                               VectorX<T>* cf) const;
 
@@ -418,7 +418,7 @@ class ConstraintSolver {
   ///             This method will resize `generalized_force` as necessary. The
   ///             indices of `generalized_force` will exactly match the indices
   ///             of `problem_data.f`.
-  /// @throws std::logic_error if `generalized_force` is null or `cf`
+  /// @throws std::exception if `generalized_force` is null or `cf`
   ///         vector is incorrectly sized.
   static void ComputeGeneralizedForceFromConstraintForces(
       const ConstraintAccelProblemData<T>& problem_data,
@@ -436,7 +436,7 @@ class ConstraintSolver {
   ///             This method will resize `generalized_force` as necessary. The
   ///             indices of `generalized_force` will exactly match the indices
   ///             of `problem_data.f`.
-  /// @throws std::logic_error if `generalized_force` is null or `cf`
+  /// @throws std::exception if `generalized_force` is null or `cf`
   ///         vector is incorrectly sized.
   static void ComputeGeneralizedForceFromConstraintForces(
       const ConstraintVelProblemData<T>& problem_data,
@@ -450,7 +450,7 @@ class ConstraintSolver {
   ///           format described in documentation for SolveConstraintProblem.
   /// @param[out] generalized_acceleration The generalized acceleration, on
   ///             return.
-  /// @throws std::logic_error if @p generalized_acceleration is null or
+  /// @throws std::exception if @p generalized_acceleration is null or
   ///         @p cf vector is incorrectly sized.
   static void ComputeGeneralizedAcceleration(
       const ConstraintAccelProblemData<T>& problem_data,
@@ -477,7 +477,7 @@ class ConstraintSolver {
   /// @warning This method uses the method `problem_data.solve_inertia()` in
   ///          order to compute `v(t+dt)`, so the computational demands may
   ///          be significant.
-  /// @throws std::logic_error if `generalized_acceleration` is null or
+  /// @throws std::exception if `generalized_acceleration` is null or
   ///         `cf` vector is incorrectly sized.
   /// @pre `dt` is positive.
   static void ComputeGeneralizedAcceleration(
@@ -491,7 +491,7 @@ class ConstraintSolver {
   /// forces.
   /// @param cf The computed constraint forces, in the packed storage
   ///           format described in documentation for SolveConstraintProblem.
-  /// @throws std::logic_error if @p generalized_acceleration is null or
+  /// @throws std::exception if @p generalized_acceleration is null or
   ///         @p cf vector is incorrectly sized.
   static void ComputeGeneralizedAccelerationFromConstraintForces(
       const ConstraintAccelProblemData<T>& problem_data,
@@ -502,7 +502,7 @@ class ConstraintSolver {
   /// forces.
   /// @param cf The computed constraint forces, in the packed storage
   ///           format described in documentation for SolveConstraintProblem.
-  /// @throws std::logic_error if @p generalized_acceleration is null or
+  /// @throws std::exception if @p generalized_acceleration is null or
   ///         @p cf vector is incorrectly sized.
   static void ComputeGeneralizedAccelerationFromConstraintForces(
     const ConstraintVelProblemData<T>& problem_data,
@@ -513,7 +513,7 @@ class ConstraintSolver {
   /// impulses.
   /// @param cf The computed constraint impulses, in the packed storage
   ///           format described in documentation for SolveImpactProblem.
-  /// @throws std::logic_error if `generalized_delta_v` is null or
+  /// @throws std::exception if `generalized_delta_v` is null or
   ///         `cf` vector is incorrectly sized.
   static void ComputeGeneralizedVelocityChange(
       const ConstraintVelProblemData<T>& problem_data,
@@ -534,7 +534,7 @@ class ConstraintSolver {
   /// @param[out] contact_forces a non-null vector of a doublet of values, where
   ///             the iᵗʰ element represents the force along each basis
   ///             vector in the iᵗʰ contact frame.
-  /// @throws std::logic_error if `contact_forces` is null, if
+  /// @throws std::exception if `contact_forces` is null, if
   ///         `contact_forces` is not empty, if `cf` is not the
   ///         proper size, if the number of tangent directions is not one per
   ///         non-sliding contact (indicating that the contact problem might not
@@ -565,7 +565,7 @@ class ConstraintSolver {
   /// @param[out] contact_forces a non-null vector of a doublet of values,
   ///             where the iᵗʰ element represents the force along
   ///             each basis vector in the iᵗʰ contact frame.
-  /// @throws std::logic_error if `contact_forces` is null, if
+  /// @throws std::exception if `contact_forces` is null, if
   ///         `contact_forces` is not empty, if `cf` is not the
   ///         proper size, if the number of tangent directions is not one per
   ///         contact (indicating that the contact problem might not be 2D), if

--- a/multibody/contact_solvers/linear_operator.h
+++ b/multibody/contact_solvers/linear_operator.h
@@ -69,7 +69,7 @@ class LinearOperator {
   }
 
   // For `this` operator A, performs y = Aᵀ⋅x.
-  // The default implementation throws a std::runtime_error exception.
+  // The default implementation throws a std::exception.
   // Derived classes can provide an implementation through the virtual
   // interface DoMultiplyByTranspose().
   // @throws if y is nullptr.
@@ -125,7 +125,7 @@ class LinearOperator {
                           VectorX<T>* y) const = 0;
 
   // For `this` operator A, performs y = Aᵀ⋅x.
-  // The default implementation throws a std::runtime_error exception.
+  // The default implementation throws a std::exception.
   // Its NVI already performed checks for valid arguments.
   virtual void DoMultiplyByTranspose(const Eigen::SparseVector<T>& x,
                                      Eigen::SparseVector<T>* y) const;
@@ -135,7 +135,7 @@ class LinearOperator {
   virtual void DoMultiplyByTranspose(const VectorX<T>& x, VectorX<T>* y) const;
 
   // Assembles `this` operator into a sparse matrix A.
-  // The default implementation throws a std::runtime_error exception.
+  // The default implementation throws a std::exception.
   // Its NVI already performed checks for a valid non-null pointer to a matrix
   // of the proper size.
   // TODO(amcastro-tri): A default implementation for this method based on

--- a/multibody/fixed_fem/dev/fem_model_base.h
+++ b/multibody/fixed_fem/dev/fem_model_base.h
@@ -145,7 +145,7 @@ class FemModelBase {
     dirichlet_bc_ = std::move(dirichlet_bc);
   }
 
-  /** (Internal use only) Throws std::logic_error to report a mismatch between
+  /** (Internal use only) Throws std::exception to report a mismatch between
   the concrete types of `this` FemModelBase and the FemStateBase that was
   passed to API method `func`. */
   virtual void ThrowIfModelStateIncompatible(

--- a/multibody/inverse_kinematics/angle_between_vectors_constraint.h
+++ b/multibody/inverse_kinematics/angle_between_vectors_constraint.h
@@ -38,12 +38,12 @@ class AngleBetweenVectorsConstraint : public solvers::Constraint {
    *   `plant`.  We will update the context when evaluating the constraint.
    *   `plant_context` should be alive during the lifetime of this constraint.
    * @pre `frameA` and `frameB` must belong to `plant`.
-   * @throws std::invalid_argument if `plant` is nullptr.
-   * @throws std::invalid_argument if `a_A` is close to zero.
-   * @throws std::invalid_argument if `b_B` is close to zero.
-   * @throws std::invalid_argument if `angle_lower` is negative.
-   * @throws std::invalid_argument if `angle_upper` ∉ [`angle_lower`, π].
-   * @throws std::invalid_argument if `plant_context` is nullptr.
+   * @throws std::exception if `plant` is nullptr.
+   * @throws std::exception if `a_A` is close to zero.
+   * @throws std::exception if `b_B` is close to zero.
+   * @throws std::exception if `angle_lower` is negative.
+   * @throws std::exception if `angle_upper` ∉ [`angle_lower`, π].
+   * @throws std::exception if `plant_context` is nullptr.
    */
   AngleBetweenVectorsConstraint(const MultibodyPlant<double>* plant,
                                 const Frame<double>& frameA,

--- a/multibody/inverse_kinematics/com_position_constraint.h
+++ b/multibody/inverse_kinematics/com_position_constraint.h
@@ -33,7 +33,7 @@ class ComPositionConstraint final : public solvers::Constraint {
    * @param plant_context The Context that has been allocated for this
    *   `plant`. We will update the context when evaluating the constraint.
    *   `plant_context` should be alive during the lifetime of this constraint.
-   * @throws std::invalid_argument if `plant` or `plant_context` is nullptr.
+   * @throws std::exception if `plant` or `plant_context` is nullptr.
    * @pydrake_mkdoc_identifier{ctor_double}
    */
   ComPositionConstraint(

--- a/multibody/inverse_kinematics/gaze_target_constraint.h
+++ b/multibody/inverse_kinematics/gaze_target_constraint.h
@@ -45,10 +45,10 @@ class GazeTargetConstraint : public solvers::Constraint {
    *   `plant`.  We will update the context when evaluating the constraint.
    *   `plant_context` should be alive during the lifetime of this constraint.
    * @pre `frameA` and `frameB` must belong to `plant`.
-   * @throws std::invalid_argument if `plant` is nullptr.
-   * @throws std::invalid_argument if `n_A` is close to zero.
-   * @throws std::invalid_argument if `cone_half_angle` ∉ [0, π/2].
-   * @throws std::invalid_argument if `plant_context` is nullptr.
+   * @throws std::exception if `plant` is nullptr.
+   * @throws std::exception if `n_A` is close to zero.
+   * @throws std::exception if `cone_half_angle` ∉ [0, π/2].
+   * @throws std::exception if `plant_context` is nullptr.
    */
   GazeTargetConstraint(const MultibodyPlant<double>* plant,
                        const Frame<double>& frameA,

--- a/multibody/inverse_kinematics/global_inverse_kinematics.h
+++ b/multibody/inverse_kinematics/global_inverse_kinematics.h
@@ -73,7 +73,7 @@ class GlobalInverseKinematics {
    * measured and expressed in the world frame.
    * @param body_index  The index of the queried body. Notice that body 0 is
    * the world, and thus not a decision variable.
-   * @throws std::runtime_error if the index is smaller than 1, or greater
+   * @throws std::exception if the index is smaller than 1, or greater
    * than or equal to the total number of bodies in the robot.
    */
   const solvers::MatrixDecisionVariable<3, 3>& body_rotation_matrix(
@@ -83,7 +83,7 @@ class GlobalInverseKinematics {
    * origin measured and expressed in the world frame.
    * @param body_index The index of the queried body. Notice that body 0 is
    * the world, and thus not a decision variable.
-   * @throws std::runtime_error if the index is smaller than 1, or greater than
+   * @throws std::exception if the index is smaller than 1, or greater than
    * or equal to the total number of bodies in the robot.
    */
   const solvers::VectorDecisionVariable<3>& body_position(
@@ -206,13 +206,13 @@ class GlobalInverseKinematics {
    * 1. body_position_cost.rows() == plant.num_bodies(), where `plant`
    *    is the input argument in the constructor of the class.
    * 2. body_position_cost(i) is non-negative.
-   * @throws std::runtime_error if the precondition is not satisfied.
+   * @throws std::exception if the precondition is not satisfied.
    * @param body_orientation_cost The cost for each body's orientation error.
    * @pre
    * 1. body_orientation_cost.rows() == plant.num_bodies() , where
    *    `plant` is the input argument in the constructor of the class.
    * 2. body_position_cost(i) is non-negative.
-   * @throws std::runtime_error if the precondition is not satisfied.
+   * @throws std::exception if the precondition is not satisfied.
    */
   void AddPostureCost(
       const Eigen::Ref<const Eigen::VectorXd>& q_desired,

--- a/multibody/inverse_kinematics/inverse_kinematics.h
+++ b/multibody/inverse_kinematics/inverse_kinematics.h
@@ -149,14 +149,14 @@ class InverseKinematics {
    * @param n_A The directional vector representing the center ray of the
    * cone, expressed in frame A.
    * @pre @p n_A cannot be a zero vector.
-   * @throws std::invalid_argument is n_A is close to a zero vector.
+   * @throws std::exception is n_A is close to a zero vector.
    * @param frameB The frame where the target point T is fixed to.
    * @param p_BT The position of the target point T, measured and expressed in
    * frame B.
    * @param cone_half_angle The half angle of the cone. We denote it as θ in the
    * documentation. @p cone_half_angle is in radians.
    * @pre @p 0 <= cone_half_angle <= pi.
-   * @throws std::invalid_argument if cone_half_angle is outside of the bound.
+   * @throws std::exception if cone_half_angle is outside of the bound.
    */
   solvers::Binding<solvers::Constraint> AddGazeTargetConstraint(
       const Frame<double>& frameA,
@@ -177,20 +177,20 @@ class InverseKinematics {
    * @param frameA The frame to which na is fixed.
    * @param na_A The vector na fixed to frame A, expressed in frame A.
    * @pre na_A should be a non-zero vector.
-   * @throws std::invalid_argument if na_A is close to zero.
+   * @throws std::exception if na_A is close to zero.
    * @param frameB The frame to which nb is fixed.
    * @param nb_B The vector nb fixed to frame B, expressed in frame B.
    * @pre nb_B should be a non-zero vector.
-   * @throws std::invalid_argument if nb_B is close to zero.
+   * @throws std::exception if nb_B is close to zero.
    * @param angle_lower The lower bound on the angle between na and nb. It is
    * denoted as θ_lower in the documentation. @p angle_lower is in radians.
    * @pre angle_lower >= 0.
-   * @throws std::invalid_argument if angle_lower is negative.
+   * @throws std::exception if angle_lower is negative.
    * @param angle_upper The upper bound on the angle between na and nb. it is
    * denoted as θ_upper in the class documentation. @p angle_upper is in
    * radians.
    * @pre angle_lower <= angle_upper <= pi.
-   * @throws std::invalid_argument if angle_upper is outside the bounds.
+   * @throws std::exception if angle_upper is outside the bounds.
    */
   solvers::Binding<solvers::Constraint> AddAngleBetweenVectorsConstraint(
       const Frame<double>& frameA,

--- a/multibody/inverse_kinematics/kinematic_constraint_utilities.h
+++ b/multibody/inverse_kinematics/kinematic_constraint_utilities.h
@@ -58,7 +58,7 @@ void UpdateContextPositionsAndVelocities(
 /*
  * Normalize an Eigen vector of doubles. This function is used in the
  * constructor of some kinematic constraints.
- * @throws std::invalid_argument if the vector is close to zero.
+ * @throws std::exception if the vector is close to zero.
  */
 template <typename DerivedA>
 typename std::enable_if_t<
@@ -75,7 +75,7 @@ NormalizeVector(const Eigen::MatrixBase<DerivedA>& a) {
 /*
  * If `plant` is not nullptr, return a reference to the MultibodyPlant to which
  * it points.
- * @throws std::invalid_argument if `plant` is nullptr.
+ * @throws std::exception if `plant` is nullptr.
  */
 template <typename T>
 const MultibodyPlant<T>& RefFromPtrOrThrow(

--- a/multibody/inverse_kinematics/minimum_distance_constraint.h
+++ b/multibody/inverse_kinematics/minimum_distance_constraint.h
@@ -82,10 +82,10 @@ class MinimumDistanceConstraint final : public solvers::Constraint {
   to scale the signed distances between pairs of geometries. Smaller values may
   improve performance, as fewer pairs of geometries need to be considered in
   each constraint evaluation. @default 1 meter
-  @throws std::invalid_argument if `plant` has not registered its geometry with
+  @throws std::exception if `plant` has not registered its geometry with
   a SceneGraph object.
-  @throws std::invalid_argument if influence_distance_offset = ∞.
-  @throws std::invalid_argument if influence_distance_offset ≤ 0.
+  @throws std::exception if influence_distance_offset = ∞.
+  @throws std::exception if influence_distance_offset ≤ 0.
   */
   MinimumDistanceConstraint(
       const multibody::MultibodyPlant<double>* const plant,

--- a/multibody/inverse_kinematics/orientation_constraint.h
+++ b/multibody/inverse_kinematics/orientation_constraint.h
@@ -52,11 +52,11 @@ class OrientationConstraint : public solvers::Constraint {
    * @param plant_context The Context that has been allocated for this
    *   `plant`. We will update the context when evaluating the constraint.
    *   `plant_context` should be alive during the lifetime of this constraint.
-   * @throws std::invalid_argument if `plant` is nullptr.
-   * @throws std::logic_error if `frameAbar` or `frameBbar` does not belong to
+   * @throws std::exception if `plant` is nullptr.
+   * @throws std::exception if `frameAbar` or `frameBbar` does not belong to
    *   `plant`.
-   * @throws std::invalid_argument if angle_bound < 0.
-   * @throws std::invalid_argument if `plant_context` is nullptr.
+   * @throws std::exception if angle_bound < 0.
+   * @throws std::exception if `plant_context` is nullptr.
    */
   OrientationConstraint(
       const MultibodyPlant<double>* const plant,

--- a/multibody/inverse_kinematics/position_constraint.h
+++ b/multibody/inverse_kinematics/position_constraint.h
@@ -36,8 +36,8 @@ class PositionConstraint : public solvers::Constraint {
    *   `plant_context` should be alive during the lifetime of this constraint.
    * @pre `frameA` and `frameB` must belong to `plant`.
    * @pre p_AQ_lower(i) <= p_AQ_upper(i) for i = 1, 2, 3.
-   * @throws std::invalid_argument if `plant` is nullptr.
-   * @throws std::invalid_argument if `plant_context` is nullptr.
+   * @throws std::exception if `plant` is nullptr.
+   * @throws std::exception if `plant_context` is nullptr.
    */
   PositionConstraint(const MultibodyPlant<double>* plant,
                      const Frame<double>& frameA,

--- a/multibody/parsing/detail_path_utils.h
+++ b/multibody/parsing/detail_path_utils.h
@@ -13,7 +13,7 @@ namespace internal {
 // If @p file_name is a relative path, this method converts it into
 // an absolute path based on the current working directory.
 //
-// @throws std::runtime_error if the file does not exist or if @p
+// @throws std::exception if the file does not exist or if @p
 // file_name is empty.
 std::string GetFullPath(const std::string& file_name);
 

--- a/multibody/parsing/detail_sdf_parser.h
+++ b/multibody/parsing/detail_sdf_parser.h
@@ -18,10 +18,10 @@ namespace internal {
 // element. `<world>` elements (used for instance to specify gravity) are
 // ignored by this method.  A new model instance will be added to @p plant.
 //
-// @throws std::runtime_error if the file is not in accordance with the SDF
+// @throws std::exception if the file is not in accordance with the SDF
 // specification containing a message with a list of errors encountered while
 // parsing the file.
-// @throws std::runtime_error if there is more than one `<model>` element or
+// @throws std::exception if there is more than one `<model>` element or
 // zero of them.
 // @throws std::exception if plant is nullptr or if MultibodyPlant::Finalize()
 // was already called on `plant`.
@@ -52,10 +52,10 @@ ModelInstanceIndex AddModelFromSdf(
 // elements. New model instances will be added to @p plant for each
 // `<model>` tag in the SDF file.
 //
-// @throws std::runtime_error if the file is not in accordance with the SDF
+// @throws std::exception if the file is not in accordance with the SDF
 // specification containing a message with a list of errors encountered while
 // parsing the file.
-// @throws std::runtime_error if the file contains no models.
+// @throws std::exception if the file contains no models.
 // @throws std::exception if plant is nullptr or if MultibodyPlant::Finalize()
 // was already called on `plant`.
 //

--- a/multibody/parsing/detail_tinyxml.h
+++ b/multibody/parsing/detail_tinyxml.h
@@ -22,7 +22,7 @@ bool ParseStringAttribute(const tinyxml2::XMLElement* node,
 //
 // @returns false if the attribute is not present
 //
-// @throws std::invalid_argument if the attribute doesn't contain a
+// @throws std::exception if the attribute doesn't contain a
 // single numeric value.
 bool ParseScalarAttribute(const tinyxml2::XMLElement* node,
                           const char* attribute_name, double* val);
@@ -32,7 +32,7 @@ bool ParseScalarAttribute(const tinyxml2::XMLElement* node,
 //
 // @returns false if the attribute is not present
 //
-// @throws std::invalid_argument if the attribute doesn't contain
+// @throws std::exception if the attribute doesn't contain
 // three numeric values.
 bool ParseVectorAttribute(const tinyxml2::XMLElement* node,
                           const char* attribute_name,
@@ -43,7 +43,7 @@ bool ParseVectorAttribute(const tinyxml2::XMLElement* node,
 //
 // @returns false if the attribute is not present
 //
-// @throws std::invalid_argument if the attribute doesn't contain
+// @throws std::exception if the attribute doesn't contain
 // four numeric values.
 bool ParseVectorAttribute(const tinyxml2::XMLElement* node,
                           const char* attribute_name,
@@ -53,7 +53,7 @@ bool ParseVectorAttribute(const tinyxml2::XMLElement* node,
 // RigidTransformd created from them.  If either the "xyz" or "rpy"
 // attributes are omitted they will be initialized with zero values.
 //
-// @throws std::invalid_argument if the "xyz" or "rpy" attributes are
+// @throws std::exception if the "xyz" or "rpy" attributes are
 // malformed.
 math::RigidTransformd OriginAttributesToTransform(
     const tinyxml2::XMLElement* node);
@@ -73,7 +73,7 @@ math::RigidTransformd OriginAttributesToTransform(
 //
 // @returns false if the attribute is not present
 //
-// @throws std::invalid_argument If any problem is encountered parsing the
+// @throws std::exception If any problem is encountered parsing the
 // three vector value.
 bool ParseThreeVectorAttribute(const tinyxml2::XMLElement* node,
                                const char* attribute_name,

--- a/multibody/parsing/detail_urdf_parser.h
+++ b/multibody/parsing/detail_urdf_parser.h
@@ -15,7 +15,7 @@ namespace internal {
 // Parses a `<robot>` element from the URDF file specified by @p file_name and
 // adds it to @p plant.  A new model instance will be added to @p plant.
 //
-// @throws std::runtime_error if the file is not in accordance with the URDF
+// @throws std::exception if the file is not in accordance with the URDF
 // specification.  The exception contains a message with a list of errors
 // encountered while parsing the file.
 //

--- a/multibody/plant/coulomb_friction.h
+++ b/multibody/plant/coulomb_friction.h
@@ -69,7 +69,7 @@ class CoulombFriction {
 
   /// Specifies both the static and dynamic friction coefficients for a given
   /// surface.
-  /// @throws std::logic_error if any of the friction coefficients are
+  /// @throws std::exception if any of the friction coefficients are
   /// negative or if `dynamic_friction > static_friction` (they can be equal.)
   CoulombFriction(const T& static_friction, const T& dynamic_friction);
 
@@ -86,7 +86,7 @@ class CoulombFriction {
   // Confirms two properties on the friction coefficient pair:
   //  1. Both values non-negative.
   //  2. static_friction >= dynamic_friction.
-  // Throws std::logic_error on failure of these tests.
+  // Throws std::exception on failure of these tests.
   static void ThrowForBadFriction(const T& static_friction,
                                   const T& dynamic_friction);
 

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -903,8 +903,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   ///   in the body frame B.
   /// @returns A constant reference to the new RigidBody just added, which will
   ///          remain valid for the lifetime of `this` %MultibodyPlant.
-  /// @throws std::logic_error if additional model instances have been created
-  ///                          beyond the world and default instances.
+  /// @throws std::exception if additional model instances have been created
+  ///                        beyond the world and default instances.
   const RigidBody<T>& AddRigidBody(
       const std::string& name, const SpatialInertia<double>& M_BBo_B) {
     if (num_model_instances() != 2) {
@@ -1155,7 +1155,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   ///
   /// @see is_finalized().
   ///
-  /// @throws std::logic_error if the %MultibodyPlant has already been
+  /// @throws std::exception if the %MultibodyPlant has already been
   /// finalized.
   void Finalize();
   /// @}
@@ -1661,7 +1661,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// section @ref mbp_penalty_method "Contact by penalty method" for further
   /// details.
   ///
-  /// @throws std::logic_error if penetration_allowance is not positive.
+  /// @throws std::exception if penetration_allowance is not positive.
   void set_penetration_allowance(double penetration_allowance = 0.001);
 
   /// Returns a time-scale estimate `tc` based on the requested penetration
@@ -2297,7 +2297,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// would involve a complex inverse kinematics problem. This method allows us
   /// to simplify this process when we know the body is free in space.
   /// @throws std::exception if `body` is not a free body in the model.
-  /// @throws std::logic_error if called pre-finalize.
+  /// @throws std::exception if called pre-finalize.
   void SetFreeBodyPoseInWorldFrame(
       systems::Context<T>* context,
       const Body<T>& body, const math::RigidTransform<T>& X_WB) const;
@@ -2307,8 +2307,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// Frame F must be anchored, meaning that it is either directly welded to the
   /// world frame W or, more generally, that there is a kinematic path between
   /// frame F and the world frame W that only includes weld joints.
-  /// @throws std::logic_error if called pre-finalize.
-  /// @throws std::logic_error if frame F is not anchored to the world.
+  /// @throws std::exception if called pre-finalize.
+  /// @throws std::exception if frame F is not anchored to the world.
   void SetFreeBodyPoseInAnchoredFrame(
       systems::Context<T>* context,
       const Frame<T>& frame_F, const Body<T>& body,
@@ -2356,7 +2356,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   ///   The body B for which the pose is requested.
   /// @retval X_WB
   ///   The pose of body frame B in the world frame W.
-  /// @throws std::logic_error if Finalize() was not called on `this` model or
+  /// @throws std::exception if Finalize() was not called on `this` model or
   ///   if `body_B` does not belong to this model.
   const math::RigidTransform<T>& EvalBodyPoseInWorld(
       const systems::Context<T>& context,
@@ -2370,7 +2370,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @param[in] body_B  The body B for which the spatial velocity is requested.
   /// @retval V_WB_W Body B's spatial velocity in the world frame W,
   ///   expressed in W (for point Bo, the body's origin).
-  /// @throws std::logic_error if Finalize() was not called on `this` model or
+  /// @throws std::exception if Finalize() was not called on `this` model or
   ///   if `body_B` does not belong to this model.
   const SpatialVelocity<T>& EvalBodySpatialVelocityInWorld(
       const systems::Context<T>& context,
@@ -2384,7 +2384,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @param[in] body_B  The body for which spatial acceleration is requested.
   /// @retval A_WB_W Body B's spatial acceleration in the world frame W,
   ///   expressed in W (for point Bo, the body's origin).
-  /// @throws std::logic_error if Finalize() was not called on `this` model or
+  /// @throws std::exception if Finalize() was not called on `this` model or
   ///   if `body_B` does not belong to this model.
   /// @note When cached values are out of sync with the state stored in context,
   /// this method performs an expensive forward dynamics computation, whereas
@@ -2488,8 +2488,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   ///   **must** be in `ℝ³ˣⁿᵖ`.
   ///
   /// @note Both `p_BQi` and `p_AQi` must have three rows. Otherwise this
-  /// method will throw a std::runtime_error exception. This method also throws
-  /// a std::runtime_error exception if `p_BQi` and `p_AQi` differ in the number
+  /// method will throw a std::exception. This method also throws
+  /// a std::exception if `p_BQi` and `p_AQi` differ in the number
   /// of columns.
   void CalcPointsPositions(
       const systems::Context<T>& context,
@@ -3224,7 +3224,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// J𝑠_v_ACcm_E is a 3 x n matrix, where n is the number of elements in 𝑠.
   /// The Jacobian is a function of only generalized positions q (which are
   /// pulled from the context).
-  /// @throws std::runtime_error if CCm does not exist, which occurs if there
+  /// @throws std::exception if CCm does not exist, which occurs if there
   /// are no massive bodies in MultibodyPlant (except world_body()).
   /// @throws std::exception if composite_mass <= 0, where composite_mass is
   /// the total mass of all bodies except world_body() in MultibodyPlant.
@@ -3257,7 +3257,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @param[in] frame_E The frame in which abias_ACcm is expressed on output.
   /// @retval abias_ACcm_E Point Ccm's translational "bias" acceleration term
   /// in frame A with respect to "speeds" 𝑠, expressed in frame E.
-  /// @throws std::runtime_error if Ccm does not exist, which occurs if there
+  /// @throws std::exception if Ccm does not exist, which occurs if there
   /// are no massive bodies in MultibodyPlant (except world_body()).
   /// @throws std::exception if composite_mass <= 0, where composite_mass is
   /// the total mass of all bodies except world_body() in MultibodyPlant.
@@ -3291,7 +3291,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// positions for `user_to_joint_index_map[1]`, etc. Similarly for the
   /// selected velocities vₛ.
   ///
-  /// @throws std::logic_error if there are repeated indexes in
+  /// @throws std::exception if there are repeated indexes in
   /// `user_to_joint_index_map`.
   MatrixX<double> MakeStateSelectorMatrix(
       const std::vector<JointIndex>& user_to_joint_index_map) const {
@@ -3345,7 +3345,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// `user_to_joint_index_map` are actuated.
   /// See MakeActuatorSelectorMatrix(const std::vector<JointActuatorIndex>&) for
   /// details.
-  /// @throws std::logic_error if any of the joints in
+  /// @throws std::exception if any of the joints in
   /// `user_to_joint_index_map` does not have an actuator.
   MatrixX<double> MakeActuatorSelectorMatrix(
       const std::vector<JointIndex>& user_to_joint_index_map) const {
@@ -3417,7 +3417,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @returns `true` if a body named `name` was added to the %MultibodyPlant.
   /// @see AddRigidBody().
   ///
-  /// @throws std::logic_error if the body name occurs in multiple model
+  /// @throws std::exception if the body name occurs in multiple model
   /// instances.
   bool HasBodyNamed(std::string_view name) const {
     return internal_tree().HasBodyNamed(name);
@@ -3435,8 +3435,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   /// Returns a constant reference to a body that is identified
   /// by the string `name` in `this` %MultibodyPlant.
-  /// @throws std::logic_error if there is no body with the requested name.
-  /// @throws std::logic_error if the body name occurs in multiple model
+  /// @throws std::exception if there is no body with the requested name.
+  /// @throws std::exception if the body name occurs in multiple model
   /// instances.
   /// @see HasBodyNamed() to query if there exists a body in `this`
   /// %MultibodyPlant with a given specified name.
@@ -3446,7 +3446,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   /// Returns a constant reference to the body that is uniquely identified
   /// by the string `name` and @p model_instance in `this` %MultibodyPlant.
-  /// @throws std::logic_error if there is no body with the requested name.
+  /// @throws std::exception if there is no body with the requested name.
   /// @see HasBodyNamed() to query if there exists a body in `this`
   /// %MultibodyPlant with a given specified name.
   const Body<T>& GetBodyByName(
@@ -3462,10 +3462,10 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   /// Returns a constant reference to a rigid body that is identified
   /// by the string `name` in `this` model.
-  /// @throws std::logic_error if there is no body with the requested name.
-  /// @throws std::logic_error if the body name occurs in multiple model
+  /// @throws std::exception if there is no body with the requested name.
+  /// @throws std::exception if the body name occurs in multiple model
   /// instances.
-  /// @throws std::logic_error if the requested body is not a RigidBody.
+  /// @throws std::exception if the requested body is not a RigidBody.
   /// @see HasBodyNamed() to query if there exists a body in `this` model with a
   /// given specified name.
   const RigidBody<T>& GetRigidBodyByName(std::string_view name) const {
@@ -3474,9 +3474,9 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   /// Returns a constant reference to the rigid body that is uniquely identified
   /// by the string `name` in @p model_instance.
-  /// @throws std::logic_error if there is no body with the requested name.
-  /// @throws std::logic_error if the requested body is not a RigidBody.
-  /// @throws std::runtime_error if @p model_instance is not valid for this
+  /// @throws std::exception if there is no body with the requested name.
+  /// @throws std::exception if the requested body is not a RigidBody.
+  /// @throws std::exception if @p model_instance is not valid for this
   ///         model.
   /// @see HasBodyNamed() to query if there exists a body in `this` model with a
   /// given specified name.
@@ -3524,7 +3524,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   }
 
   /// Returns a constant reference to the joint with unique index `joint_index`.
-  /// @throws std::runtime_error when `joint_index` does not correspond to a
+  /// @throws std::exception when `joint_index` does not correspond to a
   /// joint in this model.
   const Joint<T>& get_joint(JointIndex joint_index) const {
     return internal_tree().get_joint(joint_index);
@@ -3532,7 +3532,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   /// @returns `true` if a joint named `name` was added to this model.
   /// @see AddJoint().
-  /// @throws std::logic_error if the joint name occurs in multiple model
+  /// @throws std::exception if the joint name occurs in multiple model
   /// instances.
   bool HasJointNamed(std::string_view name) const {
     return internal_tree().HasJointNamed(name);
@@ -3547,7 +3547,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   }
 
   /// Returns a mutable reference to the joint with unique index `joint_index`.
-  /// @throws std::runtime_error when `joint_index` does not correspond to a
+  /// @throws std::exception when `joint_index` does not correspond to a
   /// joint in this model.
   Joint<T>& get_mutable_joint(JointIndex joint_index) {
     return this->mutable_tree().get_mutable_joint(joint_index);
@@ -3565,7 +3565,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// the specified `JointType`.
   /// @tparam JointType The specific type of the Joint to be retrieved. It must
   /// be a subclass of Joint.
-  /// @throws std::logic_error if the named joint is not of type `JointType` or
+  /// @throws std::exception if the named joint is not of type `JointType` or
   /// if there is no Joint with that name.
   /// @throws std::exception if @p model_instance is not valid for this model.
   /// @see HasJointNamed() to query if there exists a joint in `this`
@@ -3605,7 +3605,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   /// @returns `true` if a frame named `name` was added to the model.
   /// @see AddFrame().
-  /// @throws std::logic_error if the frame name occurs in multiple model
+  /// @throws std::exception if the frame name occurs in multiple model
   /// instances.
   bool HasFrameNamed(std::string_view name) const {
     return internal_tree().HasFrameNamed(name);
@@ -3621,8 +3621,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   /// Returns a constant reference to a frame that is identified by the
   /// string `name` in `this` model.
-  /// @throws std::logic_error if there is no frame with the requested name.
-  /// @throws std::logic_error if the frame name occurs in multiple model
+  /// @throws std::exception if there is no frame with the requested name.
+  /// @throws std::exception if the frame name occurs in multiple model
   /// instances.
   /// @see HasFrameNamed() to query if there exists a frame in `this` model with
   /// a given specified name.
@@ -3632,8 +3632,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   /// Returns a constant reference to the frame that is uniquely identified
   /// by the string `name` in @p model_instance.
-  /// @throws std::logic_error if there is no frame with the requested name.
-  /// @throws std::runtime_error if @p model_instance is not valid for this
+  /// @throws std::exception if there is no frame with the requested name.
+  /// @throws std::exception if @p model_instance is not valid for this
   ///         model.
   /// @see HasFrameNamed() to query if there exists a frame in `this` model with
   /// a given specified name.
@@ -3680,7 +3680,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   /// @returns `true` if an actuator named `name` was added to this model.
   /// @see AddJointActuator().
-  /// @throws std::logic_error if the actuator name occurs in multiple model
+  /// @throws std::exception if the actuator name occurs in multiple model
   /// instances.
   bool HasJointActuatorNamed(std::string_view name) const {
     return internal_tree().HasJointActuatorNamed(name);
@@ -3697,8 +3697,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   /// Returns a constant reference to an actuator that is identified
   /// by the string `name` in `this` %MultibodyPlant.
-  /// @throws std::logic_error if there is no actuator with the requested name.
-  /// @throws std::logic_error if the actuator name occurs in multiple model
+  /// @throws std::exception if there is no actuator with the requested name.
+  /// @throws std::exception if the actuator name occurs in multiple model
   /// instances.
   /// @see HasJointActuatorNamed() to query if there exists an actuator in
   /// `this` %MultibodyPlant with a given specified name.
@@ -3709,7 +3709,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   /// Returns a constant reference to the actuator that is uniquely identified
   /// by the string `name` and @p model_instance in `this` %MultibodyPlant.
-  /// @throws std::logic_error if there is no actuator with the requested name.
+  /// @throws std::exception if there is no actuator with the requested name.
   /// @throws std::exception if @p model_instance is not valid for this model.
   /// @see HasJointActuatorNamed() to query if there exists an actuator in
   /// `this` %MultibodyPlant with a given specified name.
@@ -3726,7 +3726,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   /// Returns a constant reference to the force element with unique index
   /// `force_element_index`.
-  /// @throws std::runtime_error when `force_element_index` does not correspond
+  /// @throws std::exception when `force_element_index` does not correspond
   /// to a force element in this model.
   const ForceElement<T>& get_force_element(
       ForceElementIndex force_element_index) const {
@@ -3739,7 +3739,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// `ForceElementType`.
   /// @tparam ForceElementType The specific type of the ForceElement to be
   /// retrieved. It must be a subclass of ForceElement.
-  /// @throws std::logic_error if the force element is not of type
+  /// @throws std::exception if the force element is not of type
   /// `ForceElementType` or if there is no ForceElement with that index.
   template <template <typename> class ForceElementType = ForceElement>
   const ForceElementType<T>& GetForceElement(
@@ -3765,7 +3765,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   }
 
   /// Returns the name of a `model_instance`.
-  /// @throws std::logic_error when `model_instance` does not correspond to a
+  /// @throws std::exception when `model_instance` does not correspond to a
   /// model in this model.
   const std::string& GetModelInstanceName(
       ModelInstanceIndex model_instance) const {
@@ -3780,7 +3780,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   /// Returns the index to the model instance that is uniquely identified
   /// by the string `name` in `this` %MultibodyPlant.
-  /// @throws std::logic_error if there is no instance with the requested name.
+  /// @throws std::exception if there is no instance with the requested name.
   /// @see HasModelInstanceNamed() to query if there exists an instance in
   /// `this` %MultibodyPlant with a given specified name.
   ModelInstanceIndex GetModelInstanceByName(std::string_view name) const {
@@ -3830,7 +3830,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// limits for every generalized position coordinate. These include joint and
   /// free body coordinates. Any unbounded or unspecified limits will be
   /// -infinity.
-  /// @throws std::logic_error if called pre-finalize.
+  /// @throws std::exception if called pre-finalize.
   VectorX<double> GetPositionLowerLimits() const {
     return internal_tree().GetPositionLowerLimits();
   }
@@ -3846,7 +3846,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// limits for every generalized velocity coordinate. These include joint and
   /// free body coordinates. Any unbounded or unspecified limits will be
   /// -infinity.
-  /// @throws std::logic_error if called pre-finalize.
+  /// @throws std::exception if called pre-finalize.
   VectorX<double> GetVelocityLowerLimits() const {
     return internal_tree().GetVelocityLowerLimits();
   }
@@ -3862,7 +3862,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// acceleration limits for every generalized velocity coordinate. These
   /// include joint and free body coordinates. Any unbounded or unspecified
   /// limits will be -infinity.
-  /// @throws std::logic_error if called pre-finalize.
+  /// @throws std::exception if called pre-finalize.
   VectorX<double> GetAccelerationLowerLimits() const {
     return internal_tree().GetAccelerationLowerLimits();
   }

--- a/multibody/plant/tamsi_solver.h
+++ b/multibody/plant/tamsi_solver.h
@@ -624,7 +624,7 @@ class TamsiSolver {
   /// @param[in] v_guess The initial guess used in by the Newton-Raphson
   /// iteration. Typically, the previous time step velocities.
   ///
-  /// @throws std::logic_error if `v_guess` is not of size `nv`, the number of
+  /// @throws std::exception if `v_guess` is not of size `nv`, the number of
   /// generalized velocities specified at construction.
   TamsiSolverResult SolveWithGuess(
       double dt, const VectorX<T>& v_guess) const;

--- a/multibody/topology/multibody_graph.h
+++ b/multibody/topology/multibody_graph.h
@@ -65,10 +65,10 @@ class MultibodyGraph {
     AddBody(), or it must be the designated index for the world body
     (world_index()).
   @returns The unique JointIndex for the added joint in the graph.
-  @throws std::runtime_error iff `name` is duplicated within `model_instance`.
-  @throws std::runtime_error iff `type` has not been registered with
+  @throws std::exception iff `name` is duplicated within `model_instance`.
+  @throws std::exception iff `type` has not been registered with
   RegisterJointType().
-  @throws std::runtime_error iff `parent_body_index` or `child_body_index` are
+  @throws std::exception iff `parent_body_index` or `child_body_index` are
   not valide body indexes for `this` graph. */
   JointIndex AddJoint(const std::string& name,
                       ModelInstanceIndex model_instance,
@@ -77,13 +77,13 @@ class MultibodyGraph {
 
   /* Returns the body that corresponds to the world. This body added via the
   first call to AddBody().
-  @throws std::runtime_error iff AddBody() was not called even once yet. */
+  @throws std::exception iff AddBody() was not called even once yet. */
   const Body& world_body() const;
 
   /* Returns the name we recognize as the World (or Ground) body. This is
   the name that was provided in the first AddBody() call.
   In Drake, MultibodyPlant names it the "WorldBody".
-  @throws std::runtime_error iff AddBody() was not called even once yet. */
+  @throws std::exception iff AddBody() was not called even once yet. */
   const std::string& world_body_name() const;
 
   /* Returns the unique index that identifies the "weld" joint type (always
@@ -100,7 +100,7 @@ class MultibodyGraph {
   to identify weld joints. "weld" joint type has index `weld_type_index()`.
   @param[in] joint_type_name
     A unique string identifying a joint type, such as "pin" or "prismatic".
-  @throws std::runtime_error if `joint_type_name` already identifies a
+  @throws std::exception if `joint_type_name` already identifies a
   previously registered joint type.
   @retval JointTypeIndex Index uniquely identifying the new joint type. */
   JointTypeIndex RegisterJointType(const std::string& joint_type_name);

--- a/multibody/tree/body_node.h
+++ b/multibody/tree/body_node.h
@@ -1417,14 +1417,14 @@ class BodyNode : public MultibodyElement<BodyNode, T, BodyNodeIndex> {
 
  protected:
   // Returns the inboard frame F of this node's mobilizer.
-  // @throws std::runtime_error if called on the root node corresponding to
+  // @throws std::exception if called on the root node corresponding to
   // the _world_ body.
   const Frame<T>& inboard_frame() const {
     return get_mobilizer().inboard_frame();
   }
 
   // Returns the outboard frame M of this node's mobilizer.
-  // @throws std::runtime_error if called on the root node corresponding to
+  // @throws std::exception if called on the root node corresponding to
   // the _world_ body.
   const Frame<T>& outboard_frame() const {
     return get_mobilizer().outboard_frame();

--- a/multibody/tree/frame.h
+++ b/multibody/tree/frame.h
@@ -81,7 +81,7 @@ class Frame : public FrameBase<T> {
 
   /// Variant of CalcPoseInBodyFrame() that returns the fixed pose `X_BF` of
   /// `this` frame F in the body frame B associated with this frame.
-  /// @throws std::logic_error if called on a %Frame that does not have a
+  /// @throws std::exception if called on a %Frame that does not have a
   /// fixed offset in the body frame.
   // %Frame sub-classes that can represent the fixed pose of `this` frame F in
   // a body frame B, must override this method.
@@ -97,7 +97,7 @@ class Frame : public FrameBase<T> {
 
   /// Returns the rotation matrix `R_BF` that relates body frame B to `this`
   /// frame F (B is the body frame to which `this` frame F is attached).
-  /// @throws std::logic_error if `this` frame F is a %Frame that does not have
+  /// @throws std::exception if `this` frame F is a %Frame that does not have
   /// a fixed offset in the body frame B (i.e., `R_BF` is not constant).
   /// %Frame sub-classes that have a constant `R_BF` must override this method.
   /// An example of a frame sub-class not implementing this method would be that
@@ -139,7 +139,7 @@ class Frame : public FrameBase<T> {
   /// Variant of CalcOffsetPoseInBody() that given the offset pose `X_FQ` of a
   /// frame Q in `this` frame F, returns the pose `X_BQ` of frame Q in the body
   /// frame B to which this frame is attached.
-  /// @throws std::logic_error if called on a %Frame that does not have a
+  /// @throws std::exception if called on a %Frame that does not have a
   /// fixed offset in the body frame.
   virtual math::RigidTransform<T> GetFixedOffsetPoseInBody(
       const math::RigidTransform<T>& X_FQ) const {
@@ -150,7 +150,7 @@ class Frame : public FrameBase<T> {
   /// B to frame Q via `this` intermediate frame F, i.e., `R_BQ = R_BF * R_FQ`
   /// (B is the body frame to which `this` frame F is attached).
   /// @param[in] R_FQ rotation matrix that relates frame F to frame Q.
-  /// @throws std::logic_error if `this` frame F is a %Frame that does not have
+  /// @throws std::exception if `this` frame F is a %Frame that does not have
   /// a fixed offset in the body frame B (i.e., `R_BF` is not constant).
   virtual math::RotationMatrix<T> GetFixedRotationMatrixInBody(
       const math::RotationMatrix<T>& R_FQ) const {

--- a/multibody/tree/linear_spring_damper.h
+++ b/multibody/tree/linear_spring_damper.h
@@ -128,7 +128,7 @@ class LinearSpringDamper final : public ForceElement<T> {
   // effect of δ is negligible for non-zero x.
   // This spring model does not allow the length of the spring to approach zero
   // since that would incur in a non-physical situation. Therefore this "safe"
-  // norm will throw a std::runtime_error when ‖x‖ < δ.
+  // norm will throw a std::exception when ‖x‖ < δ.
   T SafeSoftNorm(const Vector3<T> &x) const;
 
   // Helper method to compute the rate of change of the separation length

--- a/multibody/tree/mobilizer.h
+++ b/multibody/tree/mobilizer.h
@@ -216,7 +216,7 @@ class Mobilizer : public MultibodyElement<Mobilizer, T, MobilizerIndex> {
   // the knowledge of the inboard and outboard frames it connects.
   // Subclasses of %Mobilizer are therefore required to provide this
   // information in their respective constructors.
-  // @throws std::runtime_error if `inboard_frame` and `outboard_frame`
+  // @throws std::exception if `inboard_frame` and `outboard_frame`
   // reference the same frame object.
   Mobilizer(const Frame<T>& inboard_frame,
             const Frame<T>& outboard_frame) :

--- a/multibody/tree/model_instance.h
+++ b/multibody/tree/model_instance.h
@@ -81,7 +81,7 @@ class ModelInstance :
 
   // Returns an Eigen vector of the actuation for `this` model instance from a
   // vector `u` of actuator forces for the entire model.
-  // @throws std::logic_error if `u` is not of size
+  // @throws std::exception if `u` is not of size
   //         MultibodyTree::num_actuators().
   VectorX<T> GetActuationFromArray(
       const Eigen::Ref<const VectorX<T>>& u) const;
@@ -98,7 +98,7 @@ class ModelInstance :
   //   model to which `this` actuator belongs to. It must be of size equal to
   //   the number of degrees of freedom of all of the actuated joints in the
   //   entire MultibodyTree model.
-  // @throws std::logic_error if `u_instance` is not of size equal to the
+  // @throws std::exception if `u_instance` is not of size equal to the
   //         number of degrees of freedom of all of the actuated joints in this
   //         model or `u` is not of size equal to the number of degrees of
   //         freedom of all of the actuated joints in the entire MultibodyTree
@@ -110,7 +110,7 @@ class ModelInstance :
   // Returns an Eigen vector of the generalized positions
   // for `this` model instance from a vector `q` of generalized
   // positions for the entire MultibodyTree model.
-  // @throws std::logic_error if `q` is not of size
+  // @throws std::exception if `q` is not of size
   //         MultibodyTree::num_positions().
   VectorX<T> GetPositionsFromArray(
       const Eigen::Ref<const VectorX<T>>& q) const;
@@ -121,7 +121,7 @@ class ModelInstance :
   // correspond to `this` are not altered. Note that calling
   // `SetPositionsInArray(q_instance, q)` causes
   // `GetPositionsFromArray(q)` to yield `q_instance`.
-  // @throws std::logic_error if `q` is not of size
+  // @throws std::exception if `q` is not of size
   //         MultibodyTree::num_positions() or `q_instance` is not of size
   //         num_positions().
   void SetPositionsInArray(
@@ -131,7 +131,7 @@ class ModelInstance :
   // Returns an Eigen vector of the generalized velocities
   // for `this` mobilizer from a vector `v` of generalized velocities for
   // the entire MultibodyTree model.
-  // @throws std::logic_error if `v` is not of size
+  // @throws std::exception if `v` is not of size
   //         MultibodyTree::num_velocities().
   VectorX<T> GetVelocitiesFromArray(
       const Eigen::Ref<const VectorX<T>>& v) const;
@@ -142,7 +142,7 @@ class ModelInstance :
   // correspond to `this` are not altered. Note that calling
   // `SetVelocitiesInArray(v_instance, v)` causes
   // `GetVelocitiesFromArray(v)` to yield `v_instance`.
-  // @throws std::logic_error if `v` is not of size
+  // @throws std::exception if `v` is not of size
   //         MultibodyTree::num_velocities() or `v_instance` is not of size
   //         num_velocities().
   void SetVelocitiesInArray(

--- a/multibody/tree/multibody_element.h
+++ b/multibody/tree/multibody_element.h
@@ -69,7 +69,7 @@ class MultibodyElement {
   /// `drake/multibody/plant/multibody_plant.h` in the translation unit that
   /// invokes this method; multibody_element.h cannot do that for you.
   ///
-  /// @throws std::logic_error if there is no %MultibodyPlant owner.
+  /// @throws std::exception if there is no %MultibodyPlant owner.
   template <typename MultibodyPlantDeferred = MultibodyPlant<T>>
   const MultibodyPlantDeferred& GetParentPlant() const {
     HasParentTreeOrThrow();
@@ -167,7 +167,7 @@ class MultibodyElement {
 
   // Checks whether this MultibodyElement has been registered into
   // a MultibodyTree and throws an exception if not.
-  // @throws std::logic_error if the element is not in a MultibodyTree.
+  // @throws std::exception if the element is not in a MultibodyTree.
   void HasParentTreeOrThrow() const {
     if (!has_parent_tree()) {
       throw std::logic_error(
@@ -177,7 +177,7 @@ class MultibodyElement {
 
   // Checks whether this MultibodyElement belongs to the provided
   // MultibodyTree `tree` and throws an exception if not.
-  // @throws std::logic_error if `this` element is not in the given `tree`.
+  // @throws std::exception if `this` element is not in the given `tree`.
   void HasThisParentTreeOrThrow(const internal::MultibodyTree<T>* tree) const {
     DRAKE_ASSERT(tree != nullptr);
     if (parent_tree_ != tree) {

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -109,8 +109,8 @@ class MultibodyTree {
   //       model.AddBody(std::make_unique<RigidBody<T>>(spatial_inertia));
   // @endcode
   //
-  // @throws std::logic_error if `body` is a nullptr.
-  // @throws std::logic_error if Finalize() was already called on `this` tree.
+  // @throws std::exception if `body` is a nullptr.
+  // @throws std::exception if Finalize() was already called on `this` tree.
   //
   // @param[in] body A unique pointer to a body to add to `this`
   //                 %MultibodyTree. The body class must be specialized on the
@@ -145,7 +145,7 @@ class MultibodyTree {
   //   auto body = model.template AddBody<RigidBody>(Args...);
   // @endcode
   //
-  // @throws std::logic_error if Finalize() was already called on `this` tree.
+  // @throws std::exception if Finalize() was already called on `this` tree.
   //
   // @param[in] args The arguments needed to construct a valid Body of type
   //                 `BodyType`. `BodyType` must provide a public constructor
@@ -185,9 +185,9 @@ class MultibodyTree {
   //   frame B.
   // @returns A constant reference to the new RigidBody just added, which will
   //          remain valid for the lifetime of `this` %MultibodyTree.
-  // @throws std::logic_error if a body named `name` already exists in this
+  // @throws std::exception if a body named `name` already exists in this
   //         model instance.
-  // @throws std::logic_error if the model instance does not exist.
+  // @throws std::exception if the model instance does not exist.
   const RigidBody<T>& AddRigidBody(
       const std::string& name, ModelInstanceIndex model_instance,
       const SpatialInertia<double>& M_BBo_B);
@@ -216,9 +216,9 @@ class MultibodyTree {
   //   frame B.
   // @returns A constant reference to the new RigidBody just added, which will
   //          remain valid for the lifetime of `this` %MultibodyTree.
-  // @throws std::logic_error if a body named `name` already exists.
-  // @throws std::logic_error if additional model instances have been created
-  //                          beyond the world and default instances.
+  // @throws std::exception if a body named `name` already exists.
+  // @throws std::exception if additional model instances have been created
+  //                        beyond the world and default instances.
   const RigidBody<T>& AddRigidBody(
       const std::string& name, const SpatialInertia<double>& M_BBo_B);
 
@@ -234,8 +234,8 @@ class MultibodyTree {
   //       model.AddFrame(std::make_unique<FixedOffsetFrame<T>>(body, X_BF));
   // @endcode
   //
-  // @throws std::logic_error if `frame` is a nullptr.
-  // @throws std::logic_error if Finalize() was already called on `this` tree.
+  // @throws std::exception if `frame` is a nullptr.
+  // @throws std::exception if Finalize() was already called on `this` tree.
   //
   // @param[in] frame A unique pointer to a frame to be added to `this`
   //                  %MultibodyTree. The frame class must be specialized on
@@ -273,7 +273,7 @@ class MultibodyTree {
   //       model.template AddFrame<FixedOffsetFrame>(body, X_BF);
   // @endcode
   //
-  // @throws std::logic_error if Finalize() was already called on `this` tree.
+  // @throws std::exception if Finalize() was already called on `this` tree.
   //
   // @param[in] args The arguments needed to construct a valid Frame of type
   //                 `FrameType`. `FrameType` must provide a public constructor
@@ -306,11 +306,11 @@ class MultibodyTree {
   // A %Mobilizer effectively connects the two bodies to which the inboard and
   // outboard frames belong.
   //
-  // @throws std::logic_error if `mobilizer` is a nullptr.
-  // @throws std::logic_error if Finalize() was already called on `this` tree.
-  // @throws std::runtime_error if the new mobilizer attempts to connect a
+  // @throws std::exception if `mobilizer` is a nullptr.
+  // @throws std::exception if Finalize() was already called on `this` tree.
+  // @throws std::exception if the new mobilizer attempts to connect a
   // frame with itself.
-  // @throws std::runtime_error if attempting to connect two bodies with more
+  // @throws std::exception if attempting to connect two bodies with more
   // than one mobilizer between them.
   //
   // @param[in] mobilizer A unique pointer to a mobilizer to add to `this`
@@ -352,10 +352,10 @@ class MultibodyTree {
   // (say for instance you have a MultibodyTree<T> member within your custom
   // class).
   //
-  // @throws std::logic_error if Finalize() was already called on `this` tree.
-  // @throws std::runtime_error if the new mobilizer attempts to connect a
+  // @throws std::exception if Finalize() was already called on `this` tree.
+  // @throws std::exception if the new mobilizer attempts to connect a
   // frame with itself.
-  // @throws std::runtime_error if attempting to connect two bodies with more
+  // @throws std::exception if attempting to connect two bodies with more
   // than one mobilizer between them.
   //
   // @param[in] args The arguments needed to construct a valid Mobilizer of
@@ -527,7 +527,7 @@ class MultibodyTree {
   //   A string that uniquely identifies the new instance to be added to `this`
   //   model. An exception is thrown if an instance with the same name
   //   already exists in the model. See HasModelInstanceNamed().
-  // @throws std::logic_error if Finalize() was already called on `this` tree.
+  // @throws std::exception if Finalize() was already called on `this` tree.
   ModelInstanceIndex AddModelInstance(const std::string& name);
 
   // @}
@@ -758,7 +758,7 @@ class MultibodyTree {
   // @returns `true` if a body named `name` was added to the model.
   // @see AddRigidBody().
   //
-  // @throws std::logic_error if the body name occurs in multiple model
+  // @throws std::exception if the body name occurs in multiple model
   // instances.
   bool HasBodyNamed(std::string_view name) const;
 
@@ -953,7 +953,7 @@ class MultibodyTree {
   // (Advanced) Allocates a new context for this %MultibodyTree uniquely
   // identifying the state of the multibody system.
   //
-  // @throws std::runtime_error if this is not owned by a MultibodyPlant /
+  // @throws std::exception if this is not owned by a MultibodyPlant /
   // MultibodyTreeSystem.
   std::unique_ptr<systems::LeafContext<T>> CreateDefaultContext() const;
 
@@ -1929,8 +1929,8 @@ class MultibodyTree {
   // `selected_joints[0]` are first, followed by the positions for
   // `selected_joints[1]`, etc. Similarly for the selected velocities vₛ.
   //
-  // @throws std::logic_error if there are any duplicates in `selected_joints`.
-  // @throws std::logic_error if there is no joint in the model with a name
+  // @throws std::exception if there are any duplicates in `selected_joints`.
+  // @throws std::exception if there is no joint in the model with a name
   // specified in `selected_joints`.
   MatrixX<double> MakeStateSelectorMatrixFromJointNames(
       const std::vector<std::string>& selected_joints) const;
@@ -2394,7 +2394,7 @@ class MultibodyTree {
   // At Finalize(), this method performs all other finalization that is not
   // topological (i.e. performed by FinalizeTopology()). This includes for
   // instance the creation of BodyNode objects.
-  // This method will throw a std::logic_error if FinalizeTopology() was not
+  // This method will throw a std::exception if FinalizeTopology() was not
   // previously called on this tree.
   void FinalizeInternals();
 

--- a/multibody/tree/multibody_tree_system.h
+++ b/multibody/tree/multibody_tree_system.h
@@ -78,7 +78,7 @@ class MultibodyTreeSystem : public systems::LeafSystem<T> {
   @param[in] is_discrete Whether to allocate discrete state variables for the
       MultibodyTree kinematics. Otherwise allocates continuous state variables.
 
-  @throws std::logic_error if `tree` is null. */
+  @throws std::exception if `tree` is null. */
   explicit MultibodyTreeSystem(std::unique_ptr<MultibodyTree<T>> tree,
                                bool is_discrete = false);
 

--- a/multibody/tree/multibody_tree_topology.h
+++ b/multibody/tree/multibody_tree_topology.h
@@ -544,7 +544,7 @@ class MultibodyTreeTopology {
   // The BodyTopology will be assigned a new, unique BodyIndex and FrameIndex
   // values.
   //
-  // @throws std::logic_error if Finalize() was already called on `this`
+  // @throws std::exception if Finalize() was already called on `this`
   // topology.
   //
   // @returns a std::pair<BodyIndex, FrameIndex> containing the indexes
@@ -564,7 +564,7 @@ class MultibodyTreeTopology {
   // Creates and adds a new FrameTopology, associated with the given
   // body_index, to this MultibodyTreeTopology.
   //
-  // @throws std::logic_error if Finalize() was already called on `this`
+  // @throws std::exception if Finalize() was already called on `this`
   // topology.
   //
   // @returns The FrameIndex assigned to the new FrameTopology.
@@ -584,13 +584,13 @@ class MultibodyTreeTopology {
   // `out_frame`, respectively. The created topology will correspond to that of
   // a Mobilizer with `num_positions` and `num_velocities`.
   //
-  // @throws std::runtime_error if either `in_frame` or `out_frame` do not
+  // @throws std::exception if either `in_frame` or `out_frame` do not
   // index frame topologies in `this` %MultibodyTreeTopology.
-  // @throws std::runtime_error if `in_frame == out_frame`.
-  // @throws std::runtime_error if `in_frame` and `out_frame` already are
+  // @throws std::exception if `in_frame == out_frame`.
+  // @throws std::exception if `in_frame` and `out_frame` already are
   // connected by another mobilizer. More than one mobilizer between two frames
   // is not allowed.
-  // @throws std::logic_error if Finalize() was already called on `this`
+  // @throws std::exception if Finalize() was already called on `this`
   // topology.
   //
   // @returns The MobilizerIndex assigned to the new MobilizerTopology.
@@ -664,7 +664,7 @@ class MultibodyTreeTopology {
   // Creates and adds a new ForceElementTopology, associated with the given
   // force_index, to this MultibodyTreeTopology.
   //
-  // @throws std::logic_error if Finalize() was already called on `this`
+  // @throws std::exception if Finalize() was already called on `this`
   // topology.
   //
   // @returns The ForceElementIndex assigned to the new ForceElementTopology.
@@ -685,7 +685,7 @@ class MultibodyTreeTopology {
   // @param[in] num_dofs
   //   The number of joint dofs actuated by this actuator.
   //
-  // @throws std::logic_error if Finalize() was already called on `this`
+  // @throws std::exception if Finalize() was already called on `this`
   // topology.
   //
   // @returns The JointActuatorIndex assigned to the new JointActuatorTopology.
@@ -723,7 +723,7 @@ class MultibodyTreeTopology {
   // meaning it is up-to-date after this call.
   // No more multibody tree elements can be added after a call to Finalize().
   //
-  // @throws std::logic_error If users attempt to call this method on an
+  // @throws std::exception If users attempt to call this method on an
   //         already finalized topology.
   // @see is_valid()
   void Finalize() {

--- a/multibody/tree/rigid_body.h
+++ b/multibody/tree/rigid_body.h
@@ -134,7 +134,7 @@ class RigidBody : public Body<T> {
   }
 
   /// Gets the mass stored in @p context
-  /// @throw std::logic_error if `this` RigidBody is not owned by a
+  /// @throws std::exception if `this` RigidBody is not owned by a
   /// MultibodyPlant
   const T& get_mass(const systems::Context<T>& context) const final {
     const systems::BasicVector<T>& spatial_inertia_parameter =
@@ -143,7 +143,7 @@ class RigidBody : public Body<T> {
   }
 
   /// Gets the center of mass stored in @p context
-  /// @throw std::logic_error if `this` RigidBody is not owned by a
+  /// @throws std::exception if `this` RigidBody is not owned by a
   /// MultibodyPlant
   const Vector3<T> CalcCenterOfMassInBodyFrame(
       const systems::Context<T>& context) const final {
@@ -179,7 +179,7 @@ class RigidBody : public Body<T> {
   // SpatialInertia<T> as an abstract parameter.
 
   /// Gets the spatial inertia stored in @p context
-  /// @throw std::logic_error if `this` RigidBody is not owned by a
+  /// @throws std::exception if `this` RigidBody is not owned by a
   /// MultibodyPlant.
   SpatialInertia<T> CalcSpatialInertiaInBodyFrame(
       const systems::Context<T>& context) const override {
@@ -190,7 +190,7 @@ class RigidBody : public Body<T> {
   }
 
   /// Sets the mass stored in @p context to @p mass
-  /// @throw std::logic_error if `this` RigidBody is not owned by a
+  /// @throws std::exception if `this` RigidBody is not owned by a
   /// MultibodyPlant
   void SetMass(systems::Context<T>* context, const T& mass) const {
     systems::BasicVector<T>& spatial_inertia_parameter =
@@ -201,7 +201,7 @@ class RigidBody : public Body<T> {
   }
 
   /// Sets the center of mass stored in @p context to @p center_of_mass
-  /// @throw std::logic_error if `this` RigidBody is not owned by a
+  /// @throws std::exception if `this` RigidBody is not owned by a
   /// MultibodyPlant
   void SetCenterOfMassInBodyFrame(systems::Context<T>* context,
                                   const Vector3<T>& com) const {
@@ -217,7 +217,7 @@ class RigidBody : public Body<T> {
   }
 
   /// Sets the spatial inertia stored in @p context to @p M_Bo_B
-  /// @throw std::logic_error if `this` RigidBody is not owned by a
+  /// @throws std::exception if `this` RigidBody is not owned by a
   /// MultibodyPlant
   void SetSpatialInertiaInBodyFrame(systems::Context<T>* context,
                                     const SpatialInertia<T>& M_Bo_B) const {

--- a/multibody/tree/rotational_inertia.h
+++ b/multibody/tree/rotational_inertia.h
@@ -171,13 +171,13 @@ class RotationalInertia {
 
   /// Creates a rotational inertia with moments of inertia `Ixx`, `Iyy`, `Izz`,
   /// and with each product of inertia set to zero.
-  /// @throws std::logic_error for Debug builds if not CouldBePhysicallyValid().
+  /// @throws std::exception for Debug builds if not CouldBePhysicallyValid().
   RotationalInertia(const T& Ixx, const T& Iyy, const T& Izz)
       : RotationalInertia(Ixx, Iyy, Izz, 0.0, 0.0, 0.0) {}
 
   /// Creates a rotational inertia with moments of inertia `Ixx`, `Iyy`, `Izz`,
   /// and with products of inertia `Ixy`, `Ixz`, `Iyz`.
-  /// @throws std::logic_error for Debug builds if not CouldBePhysicallyValid().
+  /// @throws std::exception for Debug builds if not CouldBePhysicallyValid().
   RotationalInertia(const T& Ixx, const T& Iyy, const T& Izz,
                     const T& Ixy, const T& Ixz, const T& Iyz) {
     set_moments_and_products_no_validity_check(Ixx, Iyy, Izz,
@@ -192,14 +192,14 @@ class RotationalInertia {
   /// @param p_PQ_E Position from about-point P to Q, expressed-in frame E.
   /// @retval I_QP_E, Q's rotational inertia about-point P expressed-in frame E.
   /// @remark Negating the position vector p_PQ_E has no affect on the result.
-  /// @throws std::logic_error for Debug builds if not CouldBePhysicallyValid().
+  /// @throws std::exception for Debug builds if not CouldBePhysicallyValid().
   RotationalInertia(const T& mass, const Vector3<T>& p_PQ_E)
       : RotationalInertia(mass * p_PQ_E, p_PQ_E) {}
 
   /// Constructs a rotational inertia with equal moments of inertia along its
   /// diagonal and with each product of inertia set to zero. This factory
   /// is useful for the rotational inertia of a uniform-density sphere or cube.
-  /// In debug builds, throws std::logic_error if I_triaxial is negative/NaN.
+  /// In debug builds, throws std::exception if I_triaxial is negative/NaN.
   // TODO(mitiguy) Per issue #6139  Update to ConstructTriaxiallySymmetric.
   static RotationalInertia<T> TriaxiallySymmetric(const T& I_triaxial) {
     return RotationalInertia(I_triaxial, I_triaxial, I_triaxial, 0.0, 0.0, 0.0);
@@ -326,7 +326,7 @@ class RotationalInertia {
   ///        must have the same about-point P and expressed-in frame E.
   /// @return A reference to `this` rotational inertia. `this` changes
   ///         since rotational inertia `I_BP_E` has been subtracted from it.
-  /// @throws std::logic_error for Debug builds if not CouldBePhysicallyValid().
+  /// @throws std::exception for Debug builds if not CouldBePhysicallyValid().
   /// @see operator-().
   /// @note This subtract operator is useful for computing rotational inertia
   /// of a body with a hole.  First the rotational inertia of a fully solid
@@ -347,7 +347,7 @@ class RotationalInertia {
   ///        be subtracted from `this` rotational inertia. `I_BP_E` and `this`
   ///        must have the same about-point P and expressed-in frame E.
   /// @return The subtraction of `I_BP_E` from `this` rotational inertia.
-  /// @throws std::logic_error for Debug builds if not CouldBePhysicallyValid().
+  /// @throws std::exception for Debug builds if not CouldBePhysicallyValid().
   /// @see operator-=().
   /// @warning See warning and documentation for operator-=().
   RotationalInertia<T> operator-(const RotationalInertia<T>& I_BP_E) const {
@@ -368,7 +368,7 @@ class RotationalInertia {
   }
 
   /// Multiplies `this` rotational inertia by a nonnegative scalar (>= 0).
-  /// In debug builds, throws std::logic_error if `nonnegative_scalar` < 0.
+  /// In debug builds, throws std::exception if `nonnegative_scalar` < 0.
   /// @param nonnegative_scalar Nonnegative scalar which multiplies `this`.
   /// @return `this` rotational inertia multiplied by `nonnegative_scalar`.
   /// @see operator*=(), operator*(const T&, const RotationalInertia<T>&)
@@ -377,7 +377,7 @@ class RotationalInertia {
   }
 
   /// Multiplies a nonnegative scalar (>= 0) by the rotational inertia `I_BP_E`.
-  /// In debug builds, throws std::logic_error if `nonnegative_scalar` < 0.
+  /// In debug builds, throws std::exception if `nonnegative_scalar` < 0.
   /// @param nonnegative_scalar Nonnegative scalar which multiplies `I_BP_E`.
   /// @return `nonnegative_scalar` multiplied by rotational inertia `I_BP_E`.
   /// @see operator*=(), operator*()
@@ -411,7 +411,7 @@ class RotationalInertia {
   }
 
   /// Divides `this` rotational inertia by a positive scalar(> 0).
-  /// In debug builds, throws std::logic_error if `positive_scalar` <= 0.
+  /// In debug builds, throws std::exception if `positive_scalar` <= 0.
   /// @param positive_scalar Positive scalar (> 0) which divides `this`.
   /// @return `this` rotational inertia divided by `positive_scalar`.
   /// @see operator/=().
@@ -482,7 +482,7 @@ class RotationalInertia {
   ///
   /// @retval principal_moments The vector of principal moments of inertia
   ///                           `[Ixx Iyy Izz]` sorted in ascending order.
-  /// @throws std::runtime_error if eigenvalue solver fails or if scalar type T
+  /// @throws std::exception if eigenvalue solver fails or if scalar type T
   ///         cannot be converted to a double.
   Vector3<double> CalcPrincipalMomentsOfInertia() const {
     // Notes:
@@ -541,7 +541,7 @@ class RotationalInertia {
   ///
   /// @return `true` for a plausible rotational inertia passing the above
   ///          necessary but insufficient checks and `false` otherwise.
-  /// @throws std::runtime_error if principal moments of inertia cannot be
+  /// @throws std::exception if principal moments of inertia cannot be
   ///         calculated (eigenvalue solver) or if scalar type T cannot be
   ///         converted to a double.
   boolean<T> CouldBePhysicallyValid() const {
@@ -576,7 +576,7 @@ class RotationalInertia {
   /// @param[in] R_AE RotationMatrix relating frames A and E.
   /// @return A reference to `this` rotational inertia about-point P, but
   ///         with `this` now expressed in frame A (instead of frame E).
-  /// @throws std::logic_error for Debug builds if the rotational inertia that
+  /// @throws std::exception for Debug builds if the rotational inertia that
   /// is re-expressed-in frame A violates CouldBePhysicallyValid().
   /// @see ReExpress().
   RotationalInertia<T>& ReExpressInPlace(const math::RotationMatrix<T>& R_AE);
@@ -585,7 +585,7 @@ class RotationalInertia {
   /// i.e., re-expresses body B's rotational inertia from frame E to frame A.
   /// @param[in] R_AE RotationMatrix relating frames A and E.
   /// @retval I_BP_A Rotational inertia of B about-point P expressed-in frame A.
-  /// @throws std::logic_error for Debug builds if the rotational inertia that
+  /// @throws std::exception for Debug builds if the rotational inertia that
   /// is re-expressed-in frame A violates CouldBePhysicallyValid().
   /// @see ReExpressInPlace()
   RotationalInertia<T> ReExpress(const math::RotationMatrix<T>& R_AE) const
@@ -613,7 +613,7 @@ class RotationalInertia {
   ///         but with `this` shifted from about-point Bcm to about-point Q.
   ///         i.e., returns I_BQ_E,  B's rotational inertia about-point Bcm
   ///         expressed-in frame E.
-  /// @throws std::logic_error for Debug builds if the rotational inertia that
+  /// @throws std::exception for Debug builds if the rotational inertia that
   /// is shifted to about-point Q violates CouldBePhysicallyValid().
   /// @remark Negating the position vector p_BcmQ_E has no affect on the result.
   RotationalInertia<T>& ShiftFromCenterOfMassInPlace(
@@ -630,7 +630,7 @@ class RotationalInertia {
   /// @param mass The mass of body (or composite body) B.
   /// @param p_BcmQ_E Position vector from Bcm to Q, expressed-in frame E.
   /// @retval I_BQ_E B's rotational inertia about-point Q expressed-in frame E.
-  /// @throws std::logic_error for Debug builds if the rotational inertia that
+  /// @throws std::exception for Debug builds if the rotational inertia that
   /// is shifted to about-point Q violates CouldBePhysicallyValid().
   /// @remark Negating the position vector p_BcmQ_E has no affect on the result.
   RotationalInertia<T> ShiftFromCenterOfMass(const T& mass,
@@ -649,7 +649,7 @@ class RotationalInertia {
   ///         but with `this` shifted from about-point Q to about-point `Bcm`,
   ///         i.e., returns `I_BBcm_E`, B's rotational inertia about-point `Bcm`
   ///         expressed-in frame E.
-  /// @throws std::logic_error for Debug builds if the rotational inertia that
+  /// @throws std::exception for Debug builds if the rotational inertia that
   /// is shifted to about-point `Bcm` violates CouldBePhysicallyValid().
   /// @remark Negating the position vector `p_QBcm_E` has no affect on the
   /// result.
@@ -667,7 +667,7 @@ class RotationalInertia {
   /// @param p_QBcm_E Position vector from Q to `Bcm`, expressed-in frame E.
   /// @retval I_BBcm_E B's rotational inertia about-point `Bcm` expressed-in
   /// frame E.
-  /// @throws std::logic_error for Debug builds if the rotational inertia that
+  /// @throws std::exception for Debug builds if the rotational inertia that
   /// is shifted to about-point `Bcm` violates CouldBePhysicallyValid().
   /// @remark Negating the position vector `p_QBcm_E` has no affect on the
   /// result.
@@ -687,7 +687,7 @@ class RotationalInertia {
   ///         but with `this` shifted from about-point P to about-point Q,
   ///         i.e., returns I_BQ_E, B's rotational inertia about-point Q
   ///         expressed-in frame E.
-  /// @throws std::logic_error for Debug builds if the rotational inertia that
+  /// @throws std::exception for Debug builds if the rotational inertia that
   /// is shifted to about-point Q violates CouldBePhysicallyValid().
   /// @remark Negating either (or both) position vectors p_PBcm_E and p_QBcm_E
   ///         has no affect on the result.
@@ -711,7 +711,7 @@ class RotationalInertia {
   /// @param p_PBcm_E Position vector from P to Bcm, expressed-in frame E.
   /// @param p_QBcm_E Position vector from Q to Bcm, expressed-in frame E.
   /// @retval I_BQ_E, B's rotational inertia about-point Q expressed-in frame E.
-  /// @throws std::logic_error for Debug builds if the rotational inertia that
+  /// @throws std::exception for Debug builds if the rotational inertia that
   /// is shifted to about-point Q violates CouldBePhysicallyValid().
   /// @remark Negating either (or both) position vectors p_PBcm_E and p_QBcm_E
   ///         has no affect on the result.
@@ -763,7 +763,7 @@ class RotationalInertia {
   // from about-point P is p_PQ_E = xx̂ + yŷ + zẑ = [x, y, z]_E, where E is the
   // expressed-in frame.  Particle Q's mass (or unit mass) is included in the
   // first argument.  This constructor is private as it is a "helper" function.
-  // In debug builds, throws std::logic_error if rotational inertia that is
+  // In debug builds, throws std::exception if rotational inertia that is
   // constructed from these arguments violates CouldBePhysicallyValid().
   // @param p_PQ_E Position from about-point P to Q, expressed-in frame E.
   // @param mass_p_PQ_E The mass of particle Q multiplied by `p_PQ_E`.
@@ -823,7 +823,7 @@ class RotationalInertia {
   // shifting the rotational inertia for a unit-mass body (or composite body) B
   // from about-point P to about-point Q via Bcm (B's center of mass).  In
   // other words, shifts `I_BP_E` to `I_BQ_E` (both are expressed-in frame E).
-  // In debug builds, throws std::logic_error if rotational inertia that is
+  // In debug builds, throws std::exception if rotational inertia that is
   // shifted to about-point Bcm or Q violates CouldBePhysicallyValid().
   // @param p_PBcm_E Position vector from P to Bcm, expressed-in frame E.
   // @param p_QBcm_E Position vector from Q to Bcm, expressed-in frame E.

--- a/multibody/tree/unit_inertia.h
+++ b/multibody/tree/unit_inertia.h
@@ -46,14 +46,14 @@ class UnitInertia : public RotationalInertia<T> {
 
   /// Creates a unit inertia with moments of inertia `Ixx`, `Iyy`, `Izz`,
   /// and with each product of inertia set to zero.
-  /// In debug builds, throws std::logic_error if unit inertia constructed from
+  /// In debug builds, throws std::exception if unit inertia constructed from
   /// these arguments violates RotationalInertia::CouldBePhysicallyValid().
   UnitInertia(const T& Ixx, const T& Iyy, const T& Izz)
       : RotationalInertia<T>(Ixx, Iyy, Izz) {}
 
   /// Creates a unit inertia with moments of inertia `Ixx`, `Iyy`, `Izz`,
   /// and with products of inertia `Ixy`, `Ixz`, `Iyz`.
-  /// In debug builds, throws std::logic_error if unit inertia constructed from
+  /// In debug builds, throws std::exception if unit inertia constructed from
   /// these arguments violates RotationalInertia::CouldBePhysicallyValid().
   UnitInertia(const T& Ixx, const T& Iyy, const T& Izz,
               const T& Ixy, const T& Ixz, const T& Iyz)
@@ -281,7 +281,7 @@ class UnitInertia : public RotationalInertia<T> {
   ///   `Bcm`, and expressed in the same frame E as the input axis of rotation
   ///   `b_E`.
   ///
-  /// @throws std::runtime_error
+  /// @throws std::exception
   ///   - Radius r is negative.
   ///   - Length L is negative.
   ///   - `b_E` is the zero vector. That is if `‖b_E‖₂ ≤ ε`, where ε is the
@@ -323,7 +323,7 @@ class UnitInertia : public RotationalInertia<T> {
   /// where `Id` is the identity matrix and ⊗ denotes the tensor product
   /// operator. See Mitiguy, P., 2016. Advanced Dynamics & Motion Simulation.
   ///
-  /// @throws std::runtime_error
+  /// @throws std::exception
   ///   - J is negative. J can be zero.
   ///   - K is negative. K can be zero.
   ///   - J ≤ 2 * K, this corresponds to the triangle inequality, see
@@ -413,7 +413,7 @@ class UnitInertia : public RotationalInertia<T> {
   /// Constructs a unit inertia with equal moments of inertia along its
   /// diagonal and with each product of inertia set to zero. This factory
   /// is useful for the unit inertia of a uniform-density sphere or cube.
-  /// In debug builds, throws std::logic_error if I_triaxial is negative/NaN.
+  /// In debug builds, throws std::exception if I_triaxial is negative/NaN.
   /// @see UnitInertia::SolidSphere() and UnitInertia::SolidCube() for examples.
   // TODO(mitiguy) Per issue #6139  Update to ConstructTriaxiallySymmetric.
   static UnitInertia<T> TriaxiallySymmetric(const T& I_triaxial) {

--- a/perception/point_cloud.h
+++ b/perception/point_cloud.h
@@ -284,7 +284,7 @@ class PointCloud final {
 
   /// Requires a given set of fields.
   /// @see HasFields for preconditions.
-  /// @throws std::runtime_error if this point cloud does not have these
+  /// @throws std::exception if this point cloud does not have these
   /// fields.
   void RequireFields(pc_flags::Fields fields_in) const;
 
@@ -294,7 +294,7 @@ class PointCloud final {
 
   /// Requires the exact given set of fields.
   /// @see HasFields for preconditions.
-  /// @throws std::runtime_error if this point cloud does not have exactly
+  /// @throws std::exception if this point cloud does not have exactly
   /// these fields.
   void RequireExactFields(pc_flags::Fields field_set) const;
 

--- a/perception/point_cloud_flags.h
+++ b/perception/point_cloud_flags.h
@@ -84,13 +84,13 @@ class Fields {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Fields)
 
-  /// @throws std::runtime_error if `base_fields` is not composed of valid
+  /// @throws std::exception if `base_fields` is not composed of valid
   /// `BaseField`s.
   Fields(BaseFieldT base_fields, DescriptorType descriptor_type)
       : base_fields_(base_fields),
         descriptor_type_(descriptor_type) {}
 
-  /// @throws std::runtime_error if `base_fields` is not composed of valid
+  /// @throws std::exception if `base_fields` is not composed of valid
   /// `BaseField`s.
   Fields(BaseFieldT base_fields)  // NOLINT(runtime/explicit)
       : base_fields_(base_fields) {
@@ -119,7 +119,7 @@ class Fields {
   }
 
   /// Provides in-place union.
-  /// @throws std::runtime_error if multiple non-None `DescriptorType`s are
+  /// @throws std::exception if multiple non-None `DescriptorType`s are
   /// specified.
   Fields& operator|=(const Fields& rhs) {
     base_fields_ = base_fields_ | rhs.base_fields_;

--- a/solvers/bilinear_product_util.h
+++ b/solvers/bilinear_product_util.h
@@ -18,14 +18,14 @@ namespace solvers {
  * y.
  * @param x The bilinear product between `x` and `y` will be replaced by the
  * corresponding term in `W`.
- * @throws std::runtime_error if `x` contains duplicate entries.
+ * @throws std::exception if `x` contains duplicate entries.
  * @param y The bilinear product between `x` and `y` will be replaced by the
  * corresponding term in `W.
- * @throws std::runtime_error if `y` contains duplicate entries.
+ * @throws std::exception if `y` contains duplicate entries.
  * @param W Bilinear product term x(i) * y(j) will be replaced by W(i, j). If
  * W(i,j) is not a single variable, but an expression, then this expression
  * cannot contain a variable in either x or y.
- * @throws std::runtime_error, if W(i, j) is not a single variable, and also
+ * @throws std::exception, if W(i, j) is not a single variable, and also
  * contains a variable in x or y.
  * @return The symbolic expression after replacing x(i) * y(j) with W(i, j).
  */

--- a/solvers/branch_and_bound.h
+++ b/solvers/branch_and_bound.h
@@ -62,7 +62,7 @@ class MixedIntegerBranchAndBoundNode {
    * the map from the old variables to the new variables.
    * @pre prog should contain binary variables.
    * @pre solver_id can be either Gurobi or Scs.
-   * @throws std::runtime_error if the preconditions are not met.
+   * @throws std::exception if the preconditions are not met.
    */
   static std::pair<
       std::unique_ptr<MixedIntegerBranchAndBoundNode>,
@@ -77,7 +77,7 @@ class MixedIntegerBranchAndBoundNode {
    * @param binary_variable This binary variable is fixed to either 0 or 1 in
    * the child node.
    * @pre binary_variable is in remaining_binary_variables_;
-   * @throws std::runtime_error if the preconditions are not met.
+   * @throws std::exception if the preconditions are not met.
    */
   void Branch(const symbolic::Variable& binary_variable);
 
@@ -156,7 +156,7 @@ class MixedIntegerBranchAndBoundNode {
   /**
    * Getter for optimal_solution_is_integral.
    * @pre The optimization problem is solved successfully.
-   * @throws std::runtime_error if the precondition is not satisfied.
+   * @throws std::exception if the precondition is not satisfied.
    */
   bool optimal_solution_is_integral() const;
 
@@ -315,7 +315,7 @@ class MixedIntegerBranchAndBound {
    * include the optimal cost.
    * @param nth_suboptimal_cost The n'th sub-optimal cost.
    * @pre `nth_suboptimal_cost` is between 0 and solutions().size() - 1.
-   * @throws std::runtime_error if the precondition is not satisfied.
+   * @throws std::exception if the precondition is not satisfied.
    */
   double GetSubOptimalCost(int nth_suboptimal_cost) const;
 
@@ -328,7 +328,7 @@ class MixedIntegerBranchAndBound {
    * @param nth_best_solution. The index of the best integral solution.
    * @pre `mip_var` is a variable in the original MIP.
    * @pre `nth_best_solution` is between 0 and solutions().size().
-   * @throws std::runtime_error if the preconditions are not satisfied.
+   * @throws std::exception if the preconditions are not satisfied.
    */
   double GetSolution(const symbolic::Variable& mip_var,
                      int nth_best_solution = 0) const;
@@ -341,7 +341,7 @@ class MixedIntegerBranchAndBound {
    * @param nth_best_solution. The index of the best integral solution.
    * @pre `mip_vars` are variables in the original MIP.
    * @pre `nth_best_solution` is between 0 and solutions().size().
-   * @throws std::runtime_error if the preconditions are not satisfied.
+   * @throws std::exception if the preconditions are not satisfied.
    */
   template <typename Derived>
   typename std::enable_if_t<
@@ -369,7 +369,7 @@ class MixedIntegerBranchAndBound {
    * procedure.
    * @pre old_variable is a variable in the mixed-integer program, passed in the
    * constructor of this MixedIntegerBranchAndBound.
-   * @throws std::runtime_error if the pre-condition fails.
+   * @throws std::exception if the pre-condition fails.
    */
   const symbolic::Variable& GetNewVariable(
       const symbolic::Variable& old_variable) const;
@@ -439,7 +439,7 @@ class MixedIntegerBranchAndBound {
    * in TestSetUserDefinedNodeSelectionFunction.
    * @note The user defined function should pick an un-fathomed leaf node for
    * branching.
-   * @throws std::_runtime error if the node is not a leaf node, or it is
+   * @throws std::exception if the node is not a leaf node, or it is
    * fathomed.
    */
   void SetUserDefinedNodeSelectionFunction(NodeSelectFun fun) {
@@ -518,7 +518,7 @@ class MixedIntegerBranchAndBound {
    *
    * @param leaf_node A leaf node to check if it is fathomed.
    * @pre The node should be a leaf node.
-   * @throws std::runtime_error if the precondition is not satisfied.
+   * @throws std::exception if the precondition is not satisfied.
    */
   bool IsLeafNodeFathomed(
       const MixedIntegerBranchAndBoundNode& leaf_node) const;

--- a/solvers/choose_best_solver.h
+++ b/solvers/choose_best_solver.h
@@ -14,7 +14,7 @@ namespace solvers {
 /**
  * Choose the best solver given the formulation in the optimization program and
  * the availability of the solvers.
- * @throw invalid_argument if there is no available solver for @p prog.
+ * @throws std::exception if there is no available solver for @p prog.
  */
 SolverId ChooseBestSolver(const MathematicalProgram& prog);
 
@@ -25,7 +25,7 @@ const std::set<SolverId>& GetKnownSolvers();
 
 /**
  * Given the solver ID, create the solver with the matching ID.
- * @throw invalid_argument if there is no matching solver.
+ * @throws std::exception if there is no matching solver.
  */
 std::unique_ptr<SolverInterface> MakeSolver(const SolverId& id);
 

--- a/solvers/csdp_solver_internal.h
+++ b/solvers/csdp_solver_internal.h
@@ -44,7 +44,7 @@ void ConvertSparseMatrixFormatToCsdpProblemData(
 
 /**
  * Converts to a CSDP problem data if `sdpa_free_format` has no free variables.
- * @throw a runtime error if sdpa_free_format has free variables.
+ * @throws std::exception if sdpa_free_format has free variables.
  */
 void GenerateCsdpProblemDataWithoutFreeVariables(
     const SdpaFreeFormat& sdpa_free_format, csdp::blockmatrix* C, double** b,

--- a/solvers/dreal_solver.cc
+++ b/solvers/dreal_solver.cc
@@ -495,7 +495,7 @@ symbolic::Formula ExtractLinearComplementarityConstraints(
 // Extracts generic constraints in @p prog into a symbolic formula. This is a
 // helper function used in DrealSolver::Solve.
 //
-// @throws std::logic_error if there is a generic-constraint which does not
+// @throws std::exception if there is a generic-constraint which does not
 // provide symbolic evaluation.
 symbolic::Formula ExtractGenericConstraints(const MathematicalProgram& prog) {
   return ExtractConstraints(prog.generic_constraints());

--- a/solvers/fbstab/components/dense_feasibility.h
+++ b/solvers/fbstab/components/dense_feasibility.h
@@ -25,7 +25,7 @@ class DenseFeasibility {
    * @param[in] nz number of decision variables
    * @param[in] nv number of inequality constraints
    *
-   * Throws a runtime_error is any inputs are non-positive.
+   * Throws an exception is any inputs are non-positive.
    */
   DenseFeasibility(int nz, int nv);
 
@@ -39,7 +39,7 @@ class DenseFeasibility {
    * @param[in] x   Variable to check
    * @param[in] tol Numerical tolerance
    *
-   * Throws a runtime_error if tol isn't positive.
+   * Throws an exception if tol isn't positive.
    */
   void ComputeFeasibility(const DenseVariable& x, double tol);
 

--- a/solvers/fbstab/components/dense_linear_solver.h
+++ b/solvers/fbstab/components/dense_linear_solver.h
@@ -63,7 +63,7 @@ class DenseLinearSolver {
    * @param[in]  sigma   Regularization strength
    * @return             true if factorization succeeds false otherwise.
    *
-   * Throws a runtime_error if x and xbar aren't the correct size,
+   * Throws an exception if x and xbar aren't the correct size,
    * sigma is negative or the problem data isn't linked.
    */
   bool Initialize(const DenseVariable& x, const DenseVariable& xbar,
@@ -78,7 +78,7 @@ class DenseLinearSolver {
    * @param[out]  x   Overwritten with the solution
    * @return true if successful, false otherwise
    *
-   * Throws a runtime_error if x and r aren't the correct sizes,
+   * Throws an exception if x and r aren't the correct sizes,
    * if x is null or if the problem data isn't linked.
    */
   bool Solve(const DenseResidual& r, DenseVariable* x) const;

--- a/solvers/fbstab/components/dense_residual.h
+++ b/solvers/fbstab/components/dense_residual.h
@@ -55,7 +55,7 @@ class DenseResidual {
    * @param[in] xbar   Outer loop variable
    * @param[in] sigma  Regularization strength > 0
    *
-   * Throws a runtime_error if problem data isn't linked, sigma isn't positive,
+   * Throws an exception if problem data isn't linked, sigma isn't positive,
    * or if x and xbar aren't the same size.
    */
   void InnerResidual(const DenseVariable& x, const DenseVariable& xbar,
@@ -69,7 +69,7 @@ class DenseResidual {
    *
    * @param[in] x Evaluation point.
    *
-   * Throws a runtime_error if problem data isn't linked.
+   * Throws an exception if problem data isn't linked.
    */
   void NaturalResidual(const DenseVariable& x);
 
@@ -81,7 +81,7 @@ class DenseResidual {
    *
    * @param[in] x Evaluation point.
    *
-   * Throws a runtime_error if problem data isn't linked.
+   * Throws an exception if problem data isn't linked.
    */
   void PenalizedNaturalResidual(const DenseVariable& x);
 

--- a/solvers/fbstab/components/mpc_data.h
+++ b/solvers/fbstab/components/mpc_data.h
@@ -75,7 +75,7 @@ class MpcData {
    * @param[in] b Scaling
    * @param[in,out] y Output vector, length(y) = (nx+nu)*(N+1)
    *
-   * Throws a runtime_error if sizes aren't consistent or y is null.
+   * Throws an exception if sizes aren't consistent or y is null.
    */
   void gemvH(const Eigen::VectorXd& x, double a, double b,
              Eigen::VectorXd* y) const;
@@ -89,7 +89,7 @@ class MpcData {
    * @param[in] b Scaling
    * @param[in,out] y Output vector, length(y) = nc*(N+1)
    *
-   * Throws a runtime_error if sizes aren't consistent or y is null.
+   * Throws an exception if sizes aren't consistent or y is null.
    */
   void gemvA(const Eigen::VectorXd& x, double a, double b,
              Eigen::VectorXd* y) const;
@@ -103,7 +103,7 @@ class MpcData {
    * @param[in] b Scaling
    * @param[in,out] y Output vector, length(y) = nx*(N+1)
    *
-   * Throws a runtime_error if sizes aren't consistent or y is null.
+   * Throws an exception if sizes aren't consistent or y is null.
    */
   void gemvG(const Eigen::VectorXd& x, double a, double b,
              Eigen::VectorXd* y) const;
@@ -117,7 +117,7 @@ class MpcData {
    * @param[in] b Scaling
    * @param[in,out] y Output vector, length(y) = (nx+nu)*(N+1)
    *
-   * Throws a runtime_error if sizes aren't consistent or y is null.
+   * Throws an exception if sizes aren't consistent or y is null.
    */
   void gemvAT(const Eigen::VectorXd& x, double a, double b,
               Eigen::VectorXd* y) const;
@@ -131,7 +131,7 @@ class MpcData {
    * @param[in] b Scaling
    * @param[in,out] y Output vector, length(y) = (nx+nu)*(N+1)
    *
-   * Throws a runtime_error if sizes aren't consistent or y is null.
+   * Throws an exception if sizes aren't consistent or y is null.
    */
   void gemvGT(const Eigen::VectorXd& x, double a, double b,
               Eigen::VectorXd* y) const;
@@ -143,7 +143,7 @@ class MpcData {
    * @param[in] a Scaling factor
    * @param[in,out] y Output vector, length(y) = (nx+nu)*(N+1)
    *
-   * Throws a runtime_error if sizes aren't consistent or y is null.
+   * Throws an exception if sizes aren't consistent or y is null.
    */
   void axpyf(double a, Eigen::VectorXd* y) const;
 
@@ -154,7 +154,7 @@ class MpcData {
    * @param[in] a Scaling factor
    * @param[in,out] y Output vector, length(y) = nx*(N+1)
    *
-   * Throws a runtime_error if sizes aren't consistent or y is null.
+   * Throws an exception if sizes aren't consistent or y is null.
    */
   void axpyh(double a, Eigen::VectorXd* y) const;
 
@@ -165,7 +165,7 @@ class MpcData {
    * @param[in] a Scaling factor
    * @param[in,out] y Output vector, length(y) = nc*(N+1)
    *
-   * Throws a runtime_error if sizes aren't consistent or y is null.
+   * Throws an exception if sizes aren't consistent or y is null.
    */
   void axpyb(double a, Eigen::VectorXd* y) const;
 

--- a/solvers/fbstab/components/mpc_feasibility.h
+++ b/solvers/fbstab/components/mpc_feasibility.h
@@ -29,7 +29,7 @@ class MpcFeasibility {
    * @param[in] nu number of control input
    * @param[in] nc number of constraints per stage
    *
-   * Throws a runtime_error if any inputs are non-positive.
+   * Throws an exception if any inputs are non-positive.
    */
   MpcFeasibility(int N, int nx, int nu, int nc);
 
@@ -39,7 +39,7 @@ class MpcFeasibility {
    * @param[in] x   infeasibility certificate candidate
    * @param[in] tol numerical tolerance
    *
-   * Throws a runtime_error if x and *this aren't the same size
+   * Throws an exception if x and *this aren't the same size
    * or if the problem data hasn't been linked.
    */
   void ComputeFeasibility(const MpcVariable& x, double tol);

--- a/solvers/fbstab/components/mpc_residual.h
+++ b/solvers/fbstab/components/mpc_residual.h
@@ -35,7 +35,7 @@ class MpcResidual {
    * @param[in] nu number of control input
    * @param[in] nc number of constraints per stage
    *
-   * Throws a runtime_error if any of the inputs
+   * Throws an exception if any of the inputs
    * are non-positive.
    */
   MpcResidual(int N, int nx, int nu, int nc);
@@ -81,7 +81,7 @@ class MpcResidual {
    * @param[in] xbar   Outer loop variable
    * @param[in] sigma  Regularization strength > 0
    *
-   * Throws a runtime_error if sigma isn't positive,
+   * Throws an exception if sigma isn't positive,
    * or if x and xbar aren't the same size.
    */
   void InnerResidual(const MpcVariable& x, const MpcVariable& xbar,

--- a/solvers/fbstab/components/mpc_variable.h
+++ b/solvers/fbstab/components/mpc_variable.h
@@ -43,7 +43,7 @@ class MpcVariable {
    * @param[in] nu number of control input
    * @param[in] nc number of constraints per stage
    *
-   * Throws a runtime_error if any of the inputs are non-positive.
+   * Throws an exception if any of the inputs are non-positive.
    */
   MpcVariable(int N, int nx, int nu, int nc);
 
@@ -55,7 +55,7 @@ class MpcVariable {
    * @param[in] v    A vector to store the dual variables.
    * @param[in] y    A vector to store the inequality margin.
    *
-   * Throws a runtime_error if sizes are mismatched or if any of the inputs are
+   * Throws an exception if sizes are mismatched or if any of the inputs are
    * null.
    */
   MpcVariable(Eigen::VectorXd* z, Eigen::VectorXd* l, Eigen::VectorXd* v,
@@ -76,7 +76,7 @@ class MpcVariable {
 
   /**
    * Sets the constraint margin to y = b - Az.
-   * Throws a runtime_error if problem data hasn't been provided.
+   * Throws an exception if problem data hasn't been provided.
    */
   void InitializeConstraintMargin();
 
@@ -91,7 +91,7 @@ class MpcVariable {
    * Note that this handles the constraint margin correctly, i.e., after the
    * operation u.y = b - A*(u.z + a*x.z).
    *
-   * Throws a runtime_error if problem data hasn't been provided.
+   * Throws an exception if problem data hasn't been provided.
    */
   void axpy(double a, const MpcVariable& x);
 

--- a/solvers/fbstab/components/riccati_linear_solver.h
+++ b/solvers/fbstab/components/riccati_linear_solver.h
@@ -60,7 +60,7 @@ class RiccatiLinearSolver {
    * @param[in] nu number of control input
    * @param[in] nc number of constraints per stage
    *
-   * Throws a runtime_error if any of the inputs are non-positive.
+   * Throws an exception if any of the inputs are non-positive.
    */
   RiccatiLinearSolver(int N, int nx, int nu, int nc);
 
@@ -83,7 +83,7 @@ class RiccatiLinearSolver {
    * @param[in]  sigma   Regularization strength
    * @return             true if factorization succeeds false otherwise.
    *
-   * Throws a runtime_error if x and xbar aren't the correct size,
+   * Throws an exception if x and xbar aren't the correct size,
    * sigma is negative or the problem data isn't linked.
    */
   bool Initialize(const MpcVariable& x, const MpcVariable& xbar, double sigma);
@@ -97,7 +97,7 @@ class RiccatiLinearSolver {
    * @param[out]  x   Overwritten with the solution
    * @return        true if the solve succeeds, false otherwise
    *
-   * Throws a runtime_error if x and r aren't the correct sizes,
+   * Throws an exception if x and r aren't the correct sizes,
    * if x is null or if the problem data isn't linked.
    */
   bool Solve(const MpcResidual& r, MpcVariable* dx) const;

--- a/solvers/fbstab/fbstab_dense.h
+++ b/solvers/fbstab/fbstab_dense.h
@@ -104,7 +104,7 @@ class FBstabDense {
   };
   /**
    * Allocates needed workspace given the dimensions of the QPs to
-   * be solved. Throws a runtime_error if any inputs are non-positive.
+   * be solved. Throws an exception if any inputs are non-positive.
    *
    * @param[in] num_variables
    * @param[in] num_constraints

--- a/solvers/fbstab/fbstab_mpc.h
+++ b/solvers/fbstab/fbstab_mpc.h
@@ -117,7 +117,7 @@ class FBstabMpc {
    * @param[in] nu number of control input
    * @param[in] nc number of constraints per timestep
    *
-   * Throws a runtime_error if any inputs are nonpositive.
+   * Throws an exception if any inputs are nonpositive.
    */
   FBstabMpc(int N, int nx, int nu, int nc);
 

--- a/solvers/fbstab/test/ocp_generator.h
+++ b/solvers/fbstab/test/ocp_generator.h
@@ -45,7 +45,7 @@ class OcpGenerator {
    * Returns problem data in the form accepted by FBstab.
    * @return problem data
    *
-   * Throws a runtime_error if one of the problem creator methods hasn't been
+   * Throws an exception if one of the problem creator methods hasn't been
    * called first.
    */
   FBstabMpc::QPData GetFBstabInput() const;
@@ -56,7 +56,7 @@ class OcpGenerator {
    *
    * @return simulation inputs
    *
-   * Throws a runtime_error if one of the problem creator methods hasn't been
+   * Throws an exception if one of the problem creator methods hasn't been
    * called first.
    */
   SimulationInputs GetSimulationInputs() const;
@@ -90,7 +90,7 @@ class OcpGenerator {
    *
    * @parm[in] N prediction horizon length
    *
-   * Throws a runtime_error if N <= 0.
+   * Throws an exception if N <= 0.
    */
   void ServoMotor(int N = 20);
 
@@ -107,7 +107,7 @@ class OcpGenerator {
    *
    * @param[in] N prediction horizon length
    *
-   * Throws a runtime_error if N <= 0.
+   * Throws an exception if N <= 0.
    */
   void SpacecraftRelativeMotion(int N = 40);
 
@@ -117,7 +117,7 @@ class OcpGenerator {
    *
    * @param[in] N prediction horizon length
    *
-   * Throws a runtime_error if N <= 0.
+   * Throws an exception if N <= 0.
    */
   void DoubleIntegrator(int N = 10);
 

--- a/solvers/gurobi_solver.h
+++ b/solvers/gurobi_solver.h
@@ -153,7 +153,7 @@ class GurobiSolver final : public SolverBase {
    * @return A shared pointer to a license environment that will stay valid
    * as long as any shared_ptr returned by this function is alive. If Gurobi
    * not available in your build, this will return a null (empty) shared_ptr.
-   * @throws std::runtime_error if Gurobi is available but a license cannot be
+   * @throws std::exception if Gurobi is available but a license cannot be
    * obtained.
    */
   static std::shared_ptr<License> AcquireLicense();

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -397,7 +397,7 @@ class MathematicalProgram {
    * @pre `decision_variables` should not intersect with the existing variables
    * or indeterminates in the optimization program.
    * @pre Each entry in `decision_variables` should not be a dummy variable.
-   * @throws std::runtime_error if the preconditions are not satisfied.
+   * @throws std::exception if the preconditions are not satisfied.
    */
   void AddDecisionVariables(
       const Eigen::Ref<const VectorXDecisionVariable>& decision_variables);
@@ -531,7 +531,7 @@ class MathematicalProgram {
    *   p = Q₍₀,₀₎x⁴ + 2Q₍₁,₀₎ x³ + (2Q₍₂,₀₎ + Q₍₁,₁₎)x² + 2Q₍₂,₁₎x + Q₍₂,₂₎
    * and Q.
    *
-   * @throws std::runtime_error if @p degree is not a positive even integer.
+   * @throws std::exception if @p degree is not a positive even integer.
    * @see MonomialBasis.
    */
   std::pair<symbolic::Polynomial, MatrixXDecisionVariable> NewSosPolynomial(
@@ -1007,7 +1007,7 @@ class MathematicalProgram {
    * is_convex=nullopt (the default), then Drake will determine if `e` is a
    * convex quadratic cost or not. To improve the computation speed, the user
    * can set is_convex if the user knows whether the cost is convex or not.
-   * @throws std::runtime error if the expression is not quadratic.
+   * @throws std::exception if the expression is not quadratic.
    * @return The newly added cost together with the bound variables.
    */
   Binding<QuadraticCost> AddQuadraticCost(
@@ -1904,7 +1904,7 @@ class MathematicalProgram {
    *    Also the quadratic expression has to be convex, namely Q is a
    *    positive semidefinite matrix, and the quadratic expression needs
    *    to be non-negative for any x.
-   * @throws std::runtime_error if the preconditions are not satisfied.
+   * @throws std::exception if the preconditions are not satisfied.
    *
    * Notice this constraint is equivalent to the vector [z;y] is within a
    * Lorentz cone, where
@@ -2068,7 +2068,7 @@ class MathematicalProgram {
    *    Also the quadratic expression has to be convex, namely Q is a
    *    positive semidefinite matrix, and the quadratic expression needs
    *    to be non-negative for any x.
-   * @throws std::runtime_error if the preconditions are not satisfied.
+   * @throws std::exception if the preconditions are not satisfied.
    *
    * For example, to add the rotated Lorentz cone constraint
    *
@@ -2279,7 +2279,7 @@ class MathematicalProgram {
   /**
    * Adds a positive semidefinite constraint on a symmetric matrix.
    *
-   * @throws std::runtime_error in Debug mode if @p symmetric_matrix_var is not
+   * @throws std::exception in Debug mode if @p symmetric_matrix_var is not
    * symmetric.
    * @param symmetric_matrix_var A symmetric MatrixDecisionVariable object.
    */
@@ -2557,7 +2557,7 @@ class MathematicalProgram {
   /**
    * Gets the initial guess for a single variable.
    * @pre @p decision_variable has been registered in the optimization program.
-   * @throws std::runtime_error if the pre condition is not satisfied.
+   * @throws std::exception if the pre condition is not satisfied.
    */
   double GetInitialGuess(const symbolic::Variable& decision_variable) const;
 
@@ -2565,7 +2565,7 @@ class MathematicalProgram {
    * Gets the initial guess for some variables.
    * @pre Each variable in @p decision_variable_mat has been registered in the
    * optimization program.
-   * @throws std::runtime_error if the pre condition is not satisfied.
+   * @throws std::exception if the pre condition is not satisfied.
    */
   template <typename Derived>
   typename std::enable_if_t<
@@ -2591,7 +2591,7 @@ class MathematicalProgram {
    * Sets the initial guess for a single variable @p decision_variable.
    * The guess is stored as part of this program.
    * @pre decision_variable is a registered decision variable in the program.
-   * @throws std::runtime_error if precondition is not satisfied.
+   * @throws std::exception if precondition is not satisfied.
    */
   void SetInitialGuess(const symbolic::Variable& decision_variable,
                        double variable_guess_value);
@@ -2874,7 +2874,7 @@ class MathematicalProgram {
    * program.
    * @param prog_var_vals The value of all the decision variables in this
    * program.
-   * @throws std::logic_error if the size of `prog_var_vals` is invalid.
+   * @throws std::exception if the size of `prog_var_vals` is invalid.
    */
   template <typename C, typename DerivedX>
   typename std::enable_if_t<is_eigen_vector<DerivedX>::value,
@@ -2906,7 +2906,7 @@ class MathematicalProgram {
    * @param prog_var_vals The value of all the decision variables in this
    * program.
    * @return All binding values, concatenated into a single vector.
-   * @throws std::logic_error if the size of `prog_var_vals` is invalid.
+   * @throws std::exception if the size of `prog_var_vals` is invalid.
    */
   template <typename C, typename DerivedX>
   typename std::enable_if_t<is_eigen_vector<DerivedX>::value,
@@ -2962,7 +2962,7 @@ class MathematicalProgram {
    *
    * @param prog_var_vals The value of all the decision variables in this
    * program.
-   * @throws std::logic_error if the size does not match.
+   * @throws std::exception if the size does not match.
    */
   void EvalVisualizationCallbacks(
       const Eigen::Ref<const Eigen::VectorXd>& prog_var_vals) const;
@@ -3258,7 +3258,7 @@ class MathematicalProgram {
    * Ensure a binding is valid *before* adding it to the program.
    * @pre The binding has not yet been registered.
    * @pre The decision variables have been registered.
-   * @throws std::runtime_error if the binding is invalid.
+   * @throws std::exception if the binding is invalid.
    */
   template <typename C>
   void CheckBinding(const Binding<C>& binding) const {

--- a/solvers/mathematical_program_result.h
+++ b/solvers/mathematical_program_result.h
@@ -30,7 +30,7 @@ namespace solvers {
  * @param variable_values The values of all variables.
  * @return variable_values(variable_index[var.get_id()]) if
  * var.get_id() is a valid key of @p variable_index.
- * @throws an invalid_argument error if var.get_id() is not a valid key of @p
+ * @throws std::exception if var.get_id() is not a valid key of @p
  * variable_index.
  * @pre All the mapped value in variable_index is in the range [0,
  * variable_values.rows())
@@ -194,7 +194,7 @@ class MathematicalProgramResult final {
    * Gets the solution of a single decision variable.
    * @param var The decision variable.
    * @return The value of the decision variable after solving the problem.
-   * @throws invalid_argument if `var` is not captured in the mapping @p
+   * @throws std::exception if `var` is not captured in the mapping @p
    * decision_variable_index, as the input argument of
    * set_decision_variable_index().
    */

--- a/solvers/minimum_value_constraint.h
+++ b/solvers/minimum_value_constraint.h
@@ -93,8 +93,8 @@ class MinimumValueConstraint final : public solvers::Constraint {
   @pre `value_function_double(math::autoDiffToValueMatrix(x), v_influence) ==
   math::autoDiffToValueMatrix(value_function(x, v_influence))` for all x.
   @pre `value_function(x).size() <= max_num_values` for all x.
-  @throws std::invalid_argument if influence_value_offset = ∞.
-  @throws std::invalid_argument if influence_value_offset ≤ 0.
+  @throws std::exception if influence_value_offset = ∞.
+  @throws std::exception if influence_value_offset ≤ 0.
   */
   MinimumValueConstraint(
       int num_vars, double minimum_value, double influence_value_offset,

--- a/solvers/mixed_integer_optimization_util.h
+++ b/solvers/mixed_integer_optimization_util.h
@@ -129,7 +129,7 @@ void AddSos2Constraint(
  * (y(0), ..., y(⌈log₂(n)⌉) equals to binary_encoding.row(M), then λ(M) = 1
  * @param binary_encoding A n x ⌈log₂(n)⌉ matrix. binary_encoding.row(i)
  * represents integer i. No two rows of `binary_encoding` can be the same.
- * @throws std::runtime_error if @p binary_encoding has a non-binary entry (0,
+ * @throws std::exception if @p binary_encoding has a non-binary entry (0,
  * 1).
  */
 void AddLogarithmicSos1Constraint(

--- a/solvers/moby_lcp_solver.h
+++ b/solvers/moby_lcp_solver.h
@@ -113,7 +113,7 @@ class MobyLCPSolver final : public SolverBase {
   /// @param[in] zero_tol The tolerance for testing against zero. If the
   ///            tolerance is negative (default) the solver will determine a
   ///            generally reasonable tolerance.
-  /// @throws std::logic_error if M is non-square or M's dimensions do not
+  /// @throws std::exception if M is non-square or M's dimensions do not
   ///         equal q's dimension.
   /// @returns `true` if the solver succeeded and `false` otherwise.
   ///
@@ -168,7 +168,7 @@ class MobyLCPSolver final : public SolverBase {
   /// @param[in] zero_tol The tolerance for testing against zero. If the
   ///            tolerance is negative (default) the solver will determine a
   ///            generally reasonable tolerance.
-  /// @throws std::logic_error if M is non-square or M's dimensions do not
+  /// @throws std::exception if M is non-square or M's dimensions do not
   ///         equal q's dimension.
   /// @returns `true` if the solver succeeded and `false` if the solver did not
   ///          find a solution for α = 10ᵞ.
@@ -217,7 +217,7 @@ class MobyLCPSolver final : public SolverBase {
   ///          "artificial" variable (see [Cottle 1992]) and `false` otherwise.
   /// @warning The caller should verify that the algorithm has solved the LCP to
   ///          the desired tolerances on returns indicating success.
-  /// @throws std::logic_error if M is not square or the dimensions of M do not
+  /// @throws std::exception if M is not square or the dimensions of M do not
   ///         match the length of q.
   ///
   /// * [Cottle 1992]      R. Cottle, J.-S. Pang, and R. Stone. The Linear

--- a/solvers/mosek_solver.h
+++ b/solvers/mosek_solver.h
@@ -92,7 +92,7 @@ class MosekSolver final : public SolverBase {
    * @return A shared pointer to a license environment that will stay valid
    * as long as any shared_ptr returned by this function is alive. If MOSEK is
    * not available in your build, this will return a null (empty) shared_ptr.
-   * @throws std::runtime_error if MOSEK is available but a license cannot be
+   * @throws std::exception if MOSEK is available but a license cannot be
    * obtained.
    */
   static std::shared_ptr<License> AcquireLicense();

--- a/solvers/non_convex_optimization_util.h
+++ b/solvers/non_convex_optimization_util.h
@@ -37,7 +37,7 @@ namespace solvers {
  *     By A. A. Ahmadi and G. Hall
  *     Mathematical Programming, 2015
  * @param Q A square matrix.
- * @throws std::runtime_error if Q is not square.
+ * @throws std::exception if Q is not square.
  * @return The optimal decomposition (Q₁, Q₂)
  */
 std::pair<Eigen::MatrixXd, Eigen::MatrixXd> DecomposeNonConvexQuadraticForm(
@@ -105,7 +105,7 @@ std::pair<Eigen::MatrixXd, Eigen::MatrixXd> DecomposeNonConvexQuadraticForm(
  *    If ub = +∞, then the original constraint is the convex rotated Lorentz
  *    cone constraint xᵀQ₂x ≤ pᵀy - lb. The user should not call this function
  *    to relax this convex constraint.
- *    @throws std::runtime_error if Q₁ = 0 and ub = +∞.
+ *    @throws std::exception if Q₁ = 0 and ub = +∞.
  *    If ub < +∞, then we introduce a new variable z, with the constraints
  *    lb ≤ -z + pᵀy ≤ ub
  *    z ≥ xᵀQ₂x
@@ -115,7 +115,7 @@ std::pair<Eigen::MatrixXd, Eigen::MatrixXd> DecomposeNonConvexQuadraticForm(
  *    If lb = -∞, then the original constraint is the convex rotated Lorentz
  *    cone constraint xᵀQ₁x ≤ ub - pᵀy. The user should not call this function
  *    to relax this convex constraint.
- *    @throws std::runtime_error if Q₂ = 0 and lb = -∞.
+ *    @throws std::exception if Q₂ = 0 and lb = -∞.
  *    If lb > -∞, then we introduce a new variable z, with the constraints
  *    lb ≤ z + pᵀy ≤ ub
  *    z ≥ xᵀQ₁x
@@ -148,7 +148,7 @@ std::pair<Eigen::MatrixXd, Eigen::MatrixXd> DecomposeNonConvexQuadraticForm(
  *      3. Q1, Q2, x, x₀ are all of the consistent size.
  *      4. p and y are of the consistent size.
  *      5. lower_bound ≤ upper_bound.
- *      @throws std::runtime_error when the precondition is not satisfied.
+ *      @throws std::exception when the precondition is not satisfied.
  * @ingroup solver_evaluators
  */
 std::tuple<Binding<LinearConstraint>,

--- a/solvers/solver_options.h
+++ b/solvers/solver_options.h
@@ -140,7 +140,7 @@ class SolverOptions {
    * @param double_keys The set of allowable keys for double options.
    * @param int_keys The set of allowable keys for int options.
    * @param str_keys The set of allowable keys for string options.
-   * @throw invalid_argument if the solver contains un-allowed options.
+   * @throws std::exception if the solver contains un-allowed options.
    */
   void CheckOptionKeysForSolver(
       const SolverId& solver_id,

--- a/solvers/unrevised_lemke_solver.h
+++ b/solvers/unrevised_lemke_solver.h
@@ -80,7 +80,7 @@ class UnrevisedLemkeSolver final : public SolverBase {
   /// @returns `true` if the solver computes a solution to floating point
   ///           tolerances (i.e., if IsSolution() returns `true` on the problem)
   ///           and `false` otherwise.
-  /// @throws std::logic_error if M is not square or the dimensions of M do not
+  /// @throws std::exception if M is not square or the dimensions of M do not
   ///         match the length of q.
   ///
   /// * [Cottle 1992]      R. Cottle, J.-S. Pang, and R. Stone. The Linear

--- a/systems/analysis/antiderivative_function.h
+++ b/systems/analysis/antiderivative_function.h
@@ -127,7 +127,7 @@ class AntiderivativeFunction {
   /// @pre If given, the dimension of the parameter vector @p values.k
   ///      must match that of the parameter vector 𝐤 in the default specified
   ///      values given on construction.
-  /// @throws std::logic_error if any of the preconditions is not met.
+  /// @throws std::exception if any of the preconditions is not met.
   T Evaluate(const T& u, const IntegrableFunctionContext& values = {}) const {
     typename ScalarInitialValueProblem<T>::ScalarOdeContext scalar_ivp_values(
         values.v, {}, values.k);
@@ -161,7 +161,7 @@ class AntiderivativeFunction {
   /// @pre If given, the dimension of the parameter vector @p values.k
   ///      must match that of the parameter vector 𝐤 in the default specified
   ///      values given on construction.
-  /// @throws std::logic_error if any of the preconditions is not met.
+  /// @throws std::exception if any of the preconditions is not met.
   std::unique_ptr<ScalarDenseOutput<T>> MakeDenseEvalFunction(
       const T& w, const IntegrableFunctionContext& values = {}) const {
     // Delegates request to the scalar IVP used for computations, by putting

--- a/systems/analysis/bogacki_shampine3_integrator.cc
+++ b/systems/analysis/bogacki_shampine3_integrator.cc
@@ -11,7 +11,7 @@ namespace systems {
 
 /*
  * Bogacki-Shampine-specific initialization function.
- * @throws std::logic_error if *neither* the initial step size target nor the
+ * @throws std::exception if *neither* the initial step size target nor the
  *           maximum step size have been set before calling.
  */
 template <class T>

--- a/systems/analysis/dense_output.h
+++ b/systems/analysis/dense_output.h
@@ -53,9 +53,9 @@ class DenseOutput {
   /// @param t Time at which to evaluate output.
   /// @returns Output vector value.
   /// @pre Output is not empty i.e. is_empty() equals false.
-  /// @throws std::logic_error if any of the preconditions are not met.
-  /// @throws std::runtime_error if given @p t is not within output's domain
-  ///                            i.e. @p t ∉ [start_time(), end_time()].
+  /// @throws std::exception if any of the preconditions are not met.
+  /// @throws std::exception if given @p t is not within output's domain
+  ///                        i.e. @p t ∉ [start_time(), end_time()].
   VectorX<T> Evaluate(const T& t) const {
     ThrowIfOutputIsEmpty(__func__);
     ThrowIfTimeIsInvalid(__func__, t);
@@ -73,11 +73,11 @@ class DenseOutput {
   ///          value to evaluate.
   /// @returns Output value's `n`th scalar element (0-indexed).
   /// @pre Output is not empty i.e. is_empty() equals false.
-  /// @throws std::logic_error if any of the preconditions are not met.
-  /// @throws std::runtime_error if given @p t is not within output's domain
-  ///                            i.e. @p t ∉ [start_time(), end_time()].
-  /// @throws std::runtime_error if given @p n does not refer to a valid
-  ///                            output dimension i.e. @p n ∉ [0, size()).
+  /// @throws std::exception if any of the preconditions are not met.
+  /// @throws std::exception if given @p t is not within output's domain
+  ///                        i.e. @p t ∉ [start_time(), end_time()].
+  /// @throws std::exception if given @p n does not refer to a valid
+  ///                        output dimension i.e. @p n ∉ [0, size()).
   T EvaluateNth(const T& t, int n) const {
     ThrowIfOutputIsEmpty(__func__);
     ThrowIfNthElementIsInvalid(__func__, n);
@@ -88,7 +88,7 @@ class DenseOutput {
   /// Returns the output size (i.e. the number of elements in an
   /// output value).
   /// @pre Output is not empty i.e. is_empty() equals false.
-  /// @throws std::logic_error if any of the preconditions is not met.
+  /// @throws std::exception if any of the preconditions is not met.
   int size() const {
     ThrowIfOutputIsEmpty(__func__);
     return this->do_size();
@@ -100,7 +100,7 @@ class DenseOutput {
   /// Returns output's start time, or in other words, the oldest time
   /// `t` that it can be evaluated at e.g. via Evaluate().
   /// @pre Output is not empty i.e. is_empty() equals false.
-  /// @throws std::logic_error if any of the preconditions is not met.
+  /// @throws std::exception if any of the preconditions is not met.
   const T& start_time() const {
     ThrowIfOutputIsEmpty(__func__);
     return this->do_start_time();
@@ -109,7 +109,7 @@ class DenseOutput {
   /// Returns output's end time, or in other words, the newest time
   /// `t` that it can be evaluated at e.g. via Evaluate().
   /// @pre Output is not empty i.e. is_empty() equals false.
-  /// @throws std::logic_error if any of the preconditions is not met.
+  /// @throws std::exception if any of the preconditions is not met.
   const T& end_time() const {
     ThrowIfOutputIsEmpty(__func__);
     return this->do_end_time();
@@ -143,7 +143,7 @@ class DenseOutput {
 
   // Asserts that this dense output is not empty.
   // @param func_name Call site name for error message clarity (i.e. __func__).
-  // @throws std::logic_error if output is empty i.e. is_empty() equals false.
+  // @throws std::exception if output is empty i.e. is_empty() equals false.
   void ThrowIfOutputIsEmpty(const char* func_name) const {
     if (is_empty()) {
       throw std::logic_error(fmt::format(
@@ -154,8 +154,8 @@ class DenseOutput {
   // Asserts that the given element index @p n is valid for this dense output.
   // @param func_name Call site name for error message clarity (i.e. __func__).
   // @param n The nth scalar element (0-indexed) to be checked.
-  // @throws std::runtime_error if given @p n does not refer to a valid
-  //                            output dimension i.e. @p n ∉ [0, size()).
+  // @throws std::exception if given @p n does not refer to a valid
+  //                        output dimension i.e. @p n ∉ [0, size()).
   void ThrowIfNthElementIsInvalid(const char* func_name, int n) const {
     if (n < 0 || this->do_size() <= n) {
       throw std::runtime_error(fmt::format(
@@ -167,8 +167,8 @@ class DenseOutput {
   // Asserts that the given given time @p t is valid for this dense output.
   // @param func_name Call site name for error message clarity (i.e. __func__).
   // @param t Time to be checked.
-  // @throws std::runtime_error if given @p t is not within output's domain
-  //                            i.e. @p t ∉ [start_time(), end_time()].
+  // @throws std::exception if given @p t is not within output's domain
+  //                        i.e. @p t ∉ [start_time(), end_time()].
   void ThrowIfTimeIsInvalid(const char* func_name, const T& t) const {
     if (t < this->do_start_time() || t > this->do_end_time()) {
       throw std::runtime_error(fmt::format(

--- a/systems/analysis/hermitian_dense_output.h
+++ b/systems/analysis/hermitian_dense_output.h
@@ -125,7 +125,7 @@ class HermitianDenseOutput final : public StepwiseDenseOutput<T> {
     /// @param initial_state_derivative Initial state derivative vector
     ///                                 d𝐱/dt₀ at @p initial_time as a
     ///                                 column matrix.
-    /// @throws std::runtime_error
+    /// @throws std::exception
     ///   if given @p initial_state 𝐱₀ is not a column matrix.<br>
     ///   if given @p initial_state_derivative d𝐱/t₀ is not a column
     ///   matrix.<br>
@@ -149,7 +149,7 @@ class HermitianDenseOutput final : public StepwiseDenseOutput<T> {
     /// @param state State vector 𝐱ᵢ at @p time tᵢ as a column matrix.
     /// @param state_derivative State derivative vector d𝐱/dtᵢ at @p time tᵢ
     ///                         as a column matrix.
-    /// @throws std::runtime_error
+    /// @throws std::exception
     ///   if given @p state 𝐱ᵢ is not a column matrix.<br>
     ///   if given @p state_derivative d𝐱/dtᵢ is not a column matrix.<br>
     ///   if given @p time tᵢ is not greater than the previous time
@@ -274,7 +274,7 @@ class HermitianDenseOutput final : public StepwiseDenseOutput<T> {
   /// StepwiseDenseOutput class documentation).
   ///
   /// @param step Integration step to update this output with.
-  /// @throws std::runtime_error
+  /// @throws std::exception
   ///   if given @p step has zero length.<br>
   ///   if given @p step does not ensure C1 continuity at the end of
   ///   this dense output.<br>
@@ -355,7 +355,7 @@ class HermitianDenseOutput final : public StepwiseDenseOutput<T> {
   // @param next_step Integration step to be taken.
   // @param prev_step Last integration step consolidated or to be
   //                  consolidated into dense output.
-  // @throws std::runtime_error
+  // @throws std::exception
   //   if given @p next_step does not ensure C1 continuity at the
   //   end of the given @p prev_step.<br>
   //   if given @p next_step dimensions does not match @p prev_step

--- a/systems/analysis/initial_value_problem.h
+++ b/systems/analysis/initial_value_problem.h
@@ -117,7 +117,7 @@ class InitialValueProblem {
   /// @pre An initial time @p default_values.t0 is given.
   /// @pre An initial state vector @p default_values.x0 is given.
   /// @pre A parameter vector @p default_values.k is given.
-  /// @throws std::logic_error if preconditions are not met.
+  /// @throws std::exception if preconditions are not met.
   InitialValueProblem(const OdeFunction& ode_function,
                       const OdeContext& default_values);
 
@@ -136,7 +136,7 @@ class InitialValueProblem {
   /// @pre If given, the dimension of the parameter vector @p values.k
   ///      must match that of the parameter vector in the default specified
   ///      values given on construction.
-  /// @throws std::logic_error if preconditions are not met.
+  /// @throws std::exception if preconditions are not met.
   VectorX<T> Solve(const T& tf, const OdeContext& values = {}) const;
 
   /// Solves and yields an approximation of the IVP solution x(t; 𝐤) for
@@ -165,7 +165,7 @@ class InitialValueProblem {
   /// @pre If given, the dimension of the parameter vector @p values.k
   ///      must match that of the parameter vector in the default specified
   ///      values given on construction.
-  /// @throws std::logic_error if any of the preconditions is not met.
+  /// @throws std::exception if any of the preconditions is not met.
   std::unique_ptr<DenseOutput<T>> DenseSolve(
       const T& tf, const OdeContext& values = {}) const;
 
@@ -214,10 +214,10 @@ class InitialValueProblem {
   // @param tf The IVP will be solved for this time.
   // @param values IVP initial conditions and parameters.
   // @returns Sanitized values.
-  // @throws std::logic_error If preconditions specified for
-  //                          InitialValueProblem::Solve() and
-  //                          InitialValueProblem::DenseSolve()
-  //                          do not hold.
+  // @throws std::exception If preconditions specified for
+  //                        InitialValueProblem::Solve() and
+  //                        InitialValueProblem::DenseSolve()
+  //                        do not hold.
   OdeContext SanitizeValuesOrThrow(const T& tf, const OdeContext& values) const;
 
   // IVP values specified by default.

--- a/systems/analysis/integrator_base.h
+++ b/systems/analysis/integrator_base.h
@@ -212,7 +212,7 @@ class IntegratorBase {
    integrator supports this capability before calling this function; if
    the integrator does not support it, this method will throw an exception.
 
-   @throws std::logic_error if integrator does not support error
+   @throws std::exception if integrator does not support error
            estimation.
    */
   // TODO(edrumwri): complain if integrator with error estimation wants to drop
@@ -318,7 +318,7 @@ class IntegratorBase {
             get_error_estimate() will still return a correct result), meaning
             that the additional (typically, but not necessarily small)
             computation required for error estimation will still be performed.
-   @throws std::logic_error if integrator does not support error
+   @throws std::exception if integrator does not support error
            estimation and @p flag is set to `false`.
    */
   void set_fixed_step_mode(bool flag) {
@@ -644,13 +644,13 @@ class IntegratorBase {
    Request that the first attempted integration step have a particular size.
    If no request is made, the integrator will estimate a suitable size
    for the initial step attempt. *If the integrator does not support error
-   control*, this method will throw a std::logic_error (call
+   control*, this method will throw a std::exception (call
    supports_error_estimation() to verify before calling this method). For
    variable-step integration, the initial target will be treated as a maximum
    step size subject to accuracy requirements and event occurrences. You can
    find out what size *actually* worked with
    `get_actual_initial_step_size_taken()`.
-   @throws std::logic_error If the integrator does not support error
+   @throws std::exception If the integrator does not support error
        estimation.
    */
   void request_initial_step_size_target(const T& step_size) {
@@ -807,7 +807,7 @@ class IntegratorBase {
     return req_min_step_size_; }
 
   /**
-   Sets whether the integrator should throw a std::runtime_error exception
+   Sets whether the integrator should throw a std::exception
    when the integrator's step size selection algorithm determines that it
    must take a step smaller than the minimum step size (for, e.g., purposes
    of error control). Default is `true`. If `false`, the integrator will
@@ -884,11 +884,11 @@ class IntegratorBase {
 
   /**
    An integrator must be initialized before being used. The pointer to the
-   context must be set before Initialize() is called (or an std::logic_error
+   context must be set before Initialize() is called (or an std::exception
    will be thrown). If Initialize() is not called, an exception will be
    thrown when attempting to call IntegrateNoFurtherThanTime(). To reinitialize
    the integrator, Reset() should be called followed by Initialize().
-   @throws std::logic_error If the context has not been set or a user-set
+   @throws std::exception If the context has not been set or a user-set
            parameter has been set illogically (i.e., one of the
            weighting matrix coefficients is set to a negative value- this
            check is only performed for integrators that support error
@@ -958,9 +958,9 @@ class IntegratorBase {
    @param boundary_time The present or future time (exception will be thrown
           if this is not the case) marking the end of the user-designated
           simulated interval.
-   @throws std::logic_error If the integrator has not been initialized or one
-                            of publish_time, update_time, or boundary_time is
-                            in the past.
+   @throws std::exception If the integrator has not been initialized or one
+                          of publish_time, update_time, or boundary_time is
+                          in the past.
    @return The reason for the integration step ending.
    @post The time in the context will be no greater than
          `min(publish_time, update_time, boundary_time)`.
@@ -990,8 +990,8 @@ class IntegratorBase {
             place of this function (which was created for off-simulation
             purposes), generally.
    @param t_final The current or future time to integrate to.
-   @throws std::logic_error If the integrator has not been initialized or
-                            t_final is in the past.
+   @throws std::exception If the integrator has not been initialized or
+                          t_final is in the past.
    @sa IntegrateNoFurtherThanTime(), which is designed to be operated by
        Simulator and accounts for publishing and state reinitialization.
    @sa IntegrateWithSingleFixedStepToTime(), which is also designed to be
@@ -1032,9 +1032,9 @@ class IntegratorBase {
             place of this function (which was created for off-simulation
             purposes), generally.
    @param t_target The current or future time to integrate to.
-   @throws std::logic_error If the integrator has not been initialized or
-                            `t_target` is in the past or the integrator
-                            is not operating in fixed step mode.
+   @throws std::exception If the integrator has not been initialized or
+                          `t_target` is in the past or the integrator
+                          is not operating in fixed step mode.
    @sa IntegrateNoFurtherThanTime(), which is designed to be operated by
        Simulator and accounts for publishing and state reinitialization.
    @sa IntegrateWithMultipleStepsToTime(), which is also designed to be
@@ -1235,7 +1235,7 @@ class IntegratorBase {
    @pre The system being integrated has continuous state.
    @pre No dense integration is in progress (no dense output is held by the
         integrator)
-   @throws std::logic_error if any of the preconditions is not met.
+   @throws std::exception if any of the preconditions is not met.
    @warning Dense integration may incur significant overhead.
    */
   void StartDenseIntegration() {
@@ -1277,7 +1277,7 @@ class IntegratorBase {
         integrator, after a call to StartDenseIntegration()).
    @post Previously held dense output is not updated nor referenced by
          the integrator anymore.
-   @throws std::logic_error if any of the preconditions is not met.
+   @throws std::exception if any of the preconditions is not met.
    */
   std::unique_ptr<trajectories::PiecewisePolynomial<T>> StopDenseIntegration() {
     if (!dense_output_) {
@@ -1364,8 +1364,8 @@ class IntegratorBase {
                  take a smaller step than specified to satisfy accuracy
                  requirements, to resolve integrator convergence problems, or
                  to respect the integrator's maximum step size.
-   @throws std::logic_error if integrator does not support error
-                            estimation.
+   @throws std::exception if integrator does not support error
+                          estimation.
    @note This function will shrink the integration step as necessary whenever
          the integrator's DoStep() fails to take the requested step
          e.g., due to integrator convergence failure.

--- a/systems/analysis/runge_kutta3_integrator.cc
+++ b/systems/analysis/runge_kutta3_integrator.cc
@@ -5,7 +5,7 @@ namespace systems {
 
 /*
  * RK3-specific initialization function.
- * @throws std::logic_error if *neither* the initial step size target nor the
+ * @throws std::exception if *neither* the initial step size target nor the
  *           maximum step size have been set before calling.
  */
 template <class T>

--- a/systems/analysis/runge_kutta5_integrator.cc
+++ b/systems/analysis/runge_kutta5_integrator.cc
@@ -5,7 +5,7 @@ namespace systems {
 
 /*
  * RK5-specific initialization function.
- * @throws std::logic_error if *neither* the initial step size target nor the
+ * @throws std::exception if *neither* the initial step size target nor the
  *           maximum step size has been set before calling.
  */
 template <typename T>

--- a/systems/analysis/scalar_dense_output.h
+++ b/systems/analysis/scalar_dense_output.h
@@ -25,9 +25,9 @@ class ScalarDenseOutput : public DenseOutput<T> {
   /// @param t Time at which to evaluate output.
   /// @returns Output scalar value.
   /// @pre Output is not empty i.e. is_empty() is false.
-  /// @throws std::logic_error if any of the preconditions is not met.
-  /// @throws std::runtime_error if given @p t is not within output's domain
-  ///                            i.e. @p t ∉ [start_time(), end_time()].
+  /// @throws std::exception if any of the preconditions is not met.
+  /// @throws std::exception if given @p t is not within output's domain
+  ///                        i.e. @p t ∉ [start_time(), end_time()].
   T EvaluateScalar(const T& t) const {
     this->ThrowIfOutputIsEmpty(__func__);
     this->ThrowIfTimeIsInvalid(__func__, t);

--- a/systems/analysis/scalar_initial_value_problem.h
+++ b/systems/analysis/scalar_initial_value_problem.h
@@ -95,7 +95,7 @@ class ScalarInitialValueProblem {
   /// @pre An initial time @p default_values.t0 is provided.
   /// @pre An initial state @p default_values.x0 is provided.
   /// @pre An parameter vector @p default_values.k is provided.
-  /// @throws std::logic_error if preconditions are not met.
+  /// @throws std::exception if preconditions are not met.
   ScalarInitialValueProblem(const ScalarOdeFunction& scalar_ode_function,
                             const ScalarOdeContext& default_values) {
     // Wraps the given scalar ODE function as a vector ODE function.
@@ -121,7 +121,7 @@ class ScalarInitialValueProblem {
   /// @pre If given, the dimension of the parameter vector @p values.k
   ///      must match that of the parameter vector in the default specified
   ///      values given on construction.
-  /// @throws std::logic_error if any of the preconditions is not met.
+  /// @throws std::exception if any of the preconditions is not met.
   T Solve(const T& tf, const ScalarOdeContext& values = {}) const {
     return this->vector_ivp_->Solve(tf, ToVectorIVPOdeContext(values))[0];
   }
@@ -153,7 +153,7 @@ class ScalarInitialValueProblem {
   /// @pre If given, the dimension of the parameter vector @p values.k
   ///      must match that of the parameter vector in the default specified
   ///      values given on construction.
-  /// @throws std::logic_error if any of the preconditions is not met.
+  /// @throws std::exception if any of the preconditions is not met.
   std::unique_ptr<ScalarDenseOutput<T>> DenseSolve(
       const T& tf, const ScalarOdeContext& values = {}) const {
     // Delegates request to the vector form of this IVP by putting

--- a/systems/analysis/scalar_view_dense_output.h
+++ b/systems/analysis/scalar_view_dense_output.h
@@ -27,10 +27,10 @@ class ScalarViewDenseOutput : public ScalarDenseOutput<T> {
   /// @param base_output Base dense output to operate with.
   /// @param n The nth scalar element (0-indexed) of the output value
   ///          to view.
-  /// @throws std::runtime_error if @p base_output is nullptr.
-  /// @throws std::runtime_error if given @p n does not refer to a valid
-  ///                            base output dimension
-  ///                            i.e. @p n ∉ [0, `base_output`->size()).
+  /// @throws std::exception if @p base_output is nullptr.
+  /// @throws std::exception if given @p n does not refer to a valid
+  ///                        base output dimension
+  ///                        i.e. @p n ∉ [0, `base_output`->size()).
   explicit ScalarViewDenseOutput(
       std::unique_ptr<DenseOutput<T>> base_output, int n)
       : base_output_(std::move(base_output)), n_(n) {

--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -282,7 +282,7 @@ class Simulator {
   /// constraints -- it is up to you to make sure that constraints are
   /// satisfied by the initial conditions.
   ///
-  /// This method will throw `std::logic_error` if the combination of options
+  /// This method will throw `std::exception` if the combination of options
   /// doesn't make sense. Other failures are possible from the System and
   /// integrator in use.
   ///
@@ -673,7 +673,7 @@ class Simulator {
   ///          (indicating that any witness-triggered events should trigger
   ///          at the end of a time interval over which continuous state is
   ///          integrated).
-  /// @throws std::logic_error if the accuracy is not set in the Context and
+  /// @throws std::exception if the accuracy is not set in the Context and
   ///         the integrator is not operating in fixed step mode (see
   ///         IntegratorBase::get_fixed_step_mode().
   std::optional<T> GetCurrentWitnessTimeIsolation() const;

--- a/systems/analysis/stepwise_dense_output.h
+++ b/systems/analysis/stepwise_dense_output.h
@@ -33,7 +33,7 @@ class StepwiseDenseOutput : public DenseOutput<T> {
   /// @remarks This process is irreversible.
   /// @pre Updates have taken place since instantiation or last
   ///      consolidation (via Consolidate()).
-  /// @throws std::logic_error if any of the preconditions is not met.
+  /// @throws std::exception if any of the preconditions is not met.
   virtual void Rollback() = 0;
 
   /// Consolidates latest updates.
@@ -48,7 +48,7 @@ class StepwiseDenseOutput : public DenseOutput<T> {
   ///       last consolidation can be evaluated (via Evaluate()).
   /// @post Time extents covered by updates can be evaluated
   ///       (via start_time()/end_time()).
-  /// @throws std::logic_error if any of the preconditions is not met.
+  /// @throws std::exception if any of the preconditions is not met.
   virtual void Consolidate() = 0;
 
  protected:

--- a/systems/analysis/test_utilities/spring_mass_damper_system.h
+++ b/systems/analysis/test_utilities/spring_mass_damper_system.h
@@ -53,7 +53,7 @@ class SpringMassDamperSystem : public SpringMassSystem<T> {
   /// @param tf the time at which to return the position and velocity.
   /// @param[out] xf the position of the spring at time tf, on return.
   /// @param[out] vf the velocity of the spring at time tf, on return.
-  /// @throws std::logic_error if xf or vf is nullptr or the system is
+  /// @throws std::exception if xf or vf is nullptr or the system is
   ///         damped, yet underdamped.
   void GetClosedFormSolution(const T& x0, const T& v0, const T& tf,
                              T* xf, T* vf) const {

--- a/systems/analysis/test_utilities/spring_mass_system.h
+++ b/systems/analysis/test_utilities/spring_mass_system.h
@@ -196,7 +196,7 @@ class SpringMassSystem : public LeafSystem<T> {
   /// @param tf the time at which to return the position and velocity.
   /// @param[out] xf the position of the spring at time tf, on return.
   /// @param[out] vf the velocity of the spring at time tf, on return.
-  /// @throws std::logic_error if xf or vf is nullptr or if the system is
+  /// @throws std::exception if xf or vf is nullptr or if the system is
   ///         forced.
   void GetClosedFormSolution(const T& x0, const T& v0, const T& tf,
                              T* xf, T* vf) const {

--- a/systems/controllers/linear_quadratic_regulator.h
+++ b/systems/controllers/linear_quadratic_regulator.h
@@ -30,7 +30,7 @@ struct LinearQuadraticRegulatorResult {
 /// @returns A structure that contains the optimal feedback gain K and the
 /// quadratic cost term S. The optimal feedback control is u = -Kx;
 ///
-/// @throws std::runtime_error if R is not positive definite.
+/// @throws std::exception if R is not positive definite.
 /// @ingroup control
 ///
 LinearQuadraticRegulatorResult LinearQuadraticRegulator(
@@ -58,7 +58,7 @@ LinearQuadraticRegulatorResult LinearQuadraticRegulator(
 /// @returns A structure that contains the optimal feedback gain K and the
 /// quadratic cost term S. The optimal feedback control is u = -Kx;
 ///
-/// @throws std::runtime_error if R is not positive definite.
+/// @throws std::exception if R is not positive definite.
 /// @ingroup control
 LinearQuadraticRegulatorResult DiscreteTimeLinearQuadraticRegulator(
     const Eigen::Ref<const Eigen::MatrixXd>& A,
@@ -86,7 +86,7 @@ LinearQuadraticRegulatorResult DiscreteTimeLinearQuadraticRegulator(
 /// @returns A system implementing the optimal controller in the original system
 /// coordinates.
 ///
-/// @throws std::runtime_error if R is not positive definite.
+/// @throws std::exception if R is not positive definite.
 /// @ingroup control_systems
 ///
 std::unique_ptr<LinearSystem<double>> LinearQuadraticRegulator(
@@ -127,7 +127,7 @@ std::unique_ptr<LinearSystem<double>> LinearQuadraticRegulator(
 /// @returns A system implementing the optimal controller in the original system
 /// coordinates.
 ///
-/// @throws std::runtime_error if R is not positive definite.
+/// @throws std::exception if R is not positive definite.
 /// @ingroup control_systems
 /// @see drake::systems::Linearize()
 ///

--- a/systems/controllers/pid_controller.h
+++ b/systems/controllers/pid_controller.h
@@ -59,7 +59,7 @@ class PidController : public LeafSystem<T>,
    * @param ki I gain.
    * @param kd D gain.
    *
-   * @throws std::logic_error if @p kp, @p ki and @p kd have different
+   * @throws std::exception if @p kp, @p ki and @p kd have different
    * dimensions.
    */
   PidController(const Eigen::VectorXd& kp, const Eigen::VectorXd& ki,
@@ -73,7 +73,7 @@ class PidController : public LeafSystem<T>,
    * @param ki I gain.
    * @param kd D gain.
    *
-   * @throws std::logic_error if @p kp, @p ki and @p kd have different
+   * @throws std::exception if @p kp, @p ki and @p kd have different
    * dimensions or `P_x.row() != 2 * |kp|'.
    */
   PidController(const MatrixX<double>& state_projection,
@@ -96,7 +96,7 @@ class PidController : public LeafSystem<T>,
    * @param ki I gain.
    * @param kd V gain.
    *
-   * @throws std::logic_error if any assumption is violated.
+   * @throws std::exception if any assumption is violated.
    */
   PidController(const MatrixX<double>& state_projection,
                 const MatrixX<double>& output_projection,

--- a/systems/estimators/kalman_filter.h
+++ b/systems/estimators/kalman_filter.h
@@ -31,7 +31,7 @@ namespace estimators {
 /// @returns The steady-state observer gain matrix of size num_states x
 /// num_outputs.
 ///
-/// @throws std::runtime_error if V is not positive definite.
+/// @throws std::exception if V is not positive definite.
 /// @ingroup estimator_systems
 ///
 Eigen::MatrixXd SteadyStateKalmanFilter(
@@ -51,7 +51,7 @@ Eigen::MatrixXd SteadyStateKalmanFilter(
 /// @param V The measurement noise covariance matrix, E[vv'], of size num_.
 /// @returns A unique_ptr to the constructed observer system.
 ///
-/// @throws std::runtime_error if V is not positive definite.
+/// @throws std::exception if V is not positive definite.
 /// @ingroup estimator_systems
 std::unique_ptr<LuenbergerObserver<double>> SteadyStateKalmanFilter(
     std::unique_ptr<LinearSystem<double>> system,
@@ -83,7 +83,7 @@ std::unique_ptr<LuenbergerObserver<double>> SteadyStateKalmanFilter(
 /// @param V The measurement noise covariance matrix, E[vv'], of size num_.
 /// @returns A unique_ptr to the constructed observer system.
 ///
-/// @throws std::runtime_error if V is not positive definite.
+/// @throws std::exception if V is not positive definite.
 /// @ingroup estimator_systems
 std::unique_ptr<LuenbergerObserver<double>> SteadyStateKalmanFilter(
     std::unique_ptr<System<double>> system,

--- a/systems/framework/cache.h
+++ b/systems/framework/cache.h
@@ -92,9 +92,9 @@ class CacheEntryValue {
   frozen. However, the corresponding value won't be accessible while the cache
   remains frozen (since it is out of date).
 
-  @throws std::logic_error if the given value is null or if there is already a
-                           value, or if this %CacheEntryValue is malformed in
-                           some detectable way. */
+  @throws std::exception if the given value is null or if there is already a
+                         value, or if this %CacheEntryValue is malformed in
+                         some detectable way. */
   void SetInitialValue(std::unique_ptr<AbstractValue> init_value) {
     if (init_value == nullptr) {
       throw std::logic_error(FormatName(__func__) +
@@ -123,7 +123,7 @@ class CacheEntryValue {
   not be out of date with respect to any of its prerequisites. It is
   an error to call this if there is no stored value object, or if the value is
   out of date.
-  @throws std::logic_error if there is no value or it is out of date.
+  @throws std::exception if there is no value or it is out of date.
   @see get_abstract_value() */
   const AbstractValue& GetAbstractValueOrThrow() const {
     return GetAbstractValueOrThrowHelper(__func__);
@@ -132,8 +132,8 @@ class CacheEntryValue {
   /** Returns a const reference to the contained value of known type V. It is
   an error to call this if there is no stored value, or the value is out of
   date, or the value doesn't actually have type V.
-  @throws std::logic_error if there is no stored value, or if it is out of
-                           date, or it doesn't actually have type V.
+  @throws std::exception if there is no stored value, or if it is out of
+                         date, or it doesn't actually have type V.
   @see get_value() */
   template <typename V>
   const V& GetValueOrThrow() const {
@@ -156,9 +156,9 @@ class CacheEntryValue {
   large ones. You can alternatively obtain a mutable reference to the value
   already contained in the cache entry and update it in place via
   GetMutableValueOrThrow().
-  @throws std::logic_error if there is no value, or the value is already up
-                           to date, of it doesn't actually have type V.
-  @throws std::logic_error if the cache is frozen.
+  @throws std::exception if there is no value, or the value is already up
+                         to date, of it doesn't actually have type V.
+  @throws std::exception if the cache is frozen.
   @see set_value(), GetMutableValueOrThrow() */
   template <typename V>
   void SetValueOrThrow(const V& new_value) {
@@ -179,9 +179,9 @@ class CacheEntryValue {
   perform, use set_value() instead. If your computation completes successfully,
   you must mark the entry up to date yourself using mark_up_to_date() if you
   want anyone to be able to use the new value.
-  @throws std::logic_error if there is no value, or if the value is already
-                           up to date.
-  @throws std::logic_error if the cache is frozen.
+  @throws std::exception if there is no value, or if the value is already
+                         up to date.
+  @throws std::exception if the cache is frozen.
   @see SetValueOrThrow(), set_value(), mark_up_to_date() */
   AbstractValue& GetMutableAbstractValueOrThrow() {
     return GetMutableAbstractValueOrThrowHelper(__func__);
@@ -192,9 +192,9 @@ class CacheEntryValue {
   the contained value does not have the indicated concrete type. Note that you
   must call mark_up_to_date() after modifying the value through the returned
   reference. See GetMutableAbstractValueOrThrow() above for more information.
-  @throws std::logic_error if there is no value, or if the value is already
-                           up to date, of it doesn't actually have type V.
-  @throws std::logic_error if the cache is frozen.
+  @throws std::exception if there is no value, or if the value is already
+                         up to date, of it doesn't actually have type V.
+  @throws std::exception if the cache is frozen.
   @see SetValueOrThrow(), set_value(), mark_up_to_date()
   @tparam V The known actual value type. */
   template <typename V>
@@ -207,7 +207,7 @@ class CacheEntryValue {
   whether the value is out of date. This can be used to check type and size
   information but should not be used to look at the value unless you _really_
   know what you're doing.
-  @throws std::logic_error if there is no contained value. */
+  @throws std::exception if there is no contained value. */
   const AbstractValue& PeekAbstractValueOrThrow() const {
     ThrowIfNoValuePresent(__func__);
     return *value_;
@@ -217,8 +217,8 @@ class CacheEntryValue {
   downcast to its known concrete type, _without_ checking whether the value is
   out of date. This can be used to check type and size information but should
   not be used to look at the value unless you _really_ know what you're doing.
-  @throws std::logic_error if there is no contained value, or if the contained
-                           value does not actually have type V.
+  @throws std::exception if there is no contained value, or if the contained
+                         value does not actually have type V.
   @tparam V The known actual value type. */
   template <typename V>
   const V& PeekValueOrThrow() const {
@@ -277,7 +277,7 @@ class CacheEntryValue {
   this value went out of date. The serial number is incremented. If you are not
   in a performance-critical situation (and you probably are not!), use
   `SetValueOrThrow<V>()` instead.
-  @throws std::logic_error if the cache is frozen.
+  @throws std::exception if the cache is frozen.
   @tparam V The known actual value type. */
   template <typename V>
   void set_value(const V& new_value) {
@@ -296,7 +296,7 @@ class CacheEntryValue {
   This is useful for discrete updates of abstract state variables that contain
   large objects. Both values must be non-null and of the same concrete type but
   we won't check for errors except in Debug builds.
-  @throws std::logic_error if the cache is frozen.
+  @throws std::exception if the cache is frozen.
   */
   void swap_value(std::unique_ptr<AbstractValue>* other_value) {
     DRAKE_ASSERT_VOID(ThrowIfNoValuePresent(__func__));
@@ -411,12 +411,12 @@ class CacheEntryValue {
   can disable just a single entry if necessary. */
   //@{
 
-  /** Throws an std::logic_error if there is something clearly wrong with this
+  /** Throws an std::exception if there is something clearly wrong with this
   %CacheEntryValue object. If the owning subcontext is known, provide a pointer
   to it here and we'll check that this cache entry agrees. In addition we check
   for other internal inconsistencies.
-  @throws std::logic_error for anything that goes wrong, with an appropriate
-                           explanatory message. */
+  @throws std::exception for anything that goes wrong, with an appropriate
+                         explanatory message. */
   // These invariants hold for all CacheEntryValues except the dummy one.
   void ThrowIfBadCacheEntryValue(const internal::ContextMessageInterface*
                                      owning_subcontext = nullptr) const;

--- a/systems/framework/cache_entry.h
+++ b/systems/framework/cache_entry.h
@@ -86,7 +86,7 @@ class CacheEntry {
   and the cache index and ticket must be valid. The description is an arbitrary
   string not interpreted in any way by Drake.
 
-  @throws std::logic_error if the prerequisite list is empty.
+  @throws std::exception if the prerequisite list is empty.
 
   @see drake::systems::SystemBase::DeclareCacheEntry() */
   CacheEntry(const internal::SystemMessageInterface* owning_system,
@@ -132,7 +132,7 @@ class CacheEntry {
   /** Invokes this cache entry's allocator function to allocate a concrete
   object suitable for holding the value to be held in this cache entry, and
   returns that as an AbstractValue. The returned object will never be null.
-  @throws std::logic_error if the allocator function returned null. */
+  @throws std::exception if the allocator function returned null. */
   std::unique_ptr<AbstractValue> Allocate() const;
 
   /** Unconditionally computes the value this cache entry should have given a
@@ -153,7 +153,7 @@ class CacheEntry {
   to date already, you may use the GetKnownUpToDate() method instead.
   @pre `context` is a subcontext that is compatible with the subsystem that owns
        this cache entry.
-  @throws std::logic_error if the value doesn't actually have type V. */
+  @throws std::exception if the value doesn't actually have type V. */
   template <typename ValueType>
   const ValueType& Eval(const ContextBase& context) const {
     const AbstractValue& abstract_value = EvalAbstract(context);
@@ -186,8 +186,8 @@ class CacheEntry {
   is disabled. This method is constant time and _very_ fast if it succeeds.
   @pre `context` is a subcontext that is compatible with the subsystem that owns
        this cache entry.
-  @throws std::logic_error if the value is out of date or if it does not
-                           actually have type `ValueType`. */
+  @throws std::exception if the value is out of date or if it does not
+                         actually have type `ValueType`. */
   // Keep this method as small as possible to encourage inlining; it gets
   // called *a lot*.
   template <typename ValueType>
@@ -203,7 +203,7 @@ class CacheEntry {
   information.
   @pre `context` is a subcontext that is compatible with the subsystem that owns
        this cache entry.
-  @throws std::logic_error if the value is not up to date. */
+  @throws std::exception if the value is not up to date. */
   // Keep this method as small as possible to encourage inlining; it gets
   // called *a lot*.
   const AbstractValue& GetKnownUpToDateAbstract(

--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -95,7 +95,7 @@ class Context : public ContextBase {
 
   /// Returns the total dimension of all of the basic vector states (as if they
   /// were muxed).
-  /// @throws std::runtime_error if the system contains any abstract state.
+  /// @throws std::exception if the system contains any abstract state.
   int num_total_states() const {
     DRAKE_THROW_UNLESS(num_abstract_states() == 0);
     int count = num_continuous_states();
@@ -331,7 +331,7 @@ class Context : public ContextBase {
   /// time-dependent computations (at least if the time has actually changed).
   /// Time must have the same value in every subcontext within the same Diagram
   /// context tree so may only be modified at the root context of the tree.
-  /// @throws std::logic_error if this is not the root context.
+  /// @throws std::exception if this is not the root context.
   void SetTime(const T& time_sec);
 
   // TODO(sherm1) Add more-specific state "set" methods for smaller
@@ -350,7 +350,7 @@ class Context : public ContextBase {
   /// Sets time to @p time_sec and continuous state to @p xc. Performs a single
   /// notification sweep to avoid duplicate notifications for computations that
   /// depend on both time and state.
-  /// @throws std::logic_error if this is not the root context.
+  /// @throws std::exception if this is not the root context.
   void SetTimeAndContinuousState(const T& time_sec,
                                  const Eigen::Ref<const VectorX<T>>& xc) {
     VectorBase<T>& xc_vector =
@@ -498,7 +498,7 @@ class Context : public ContextBase {
   /// - it allows us to notify accuracy-dependent cached results that they are
   ///   out of date when the accuracy setting changes.
   ///
-  /// @throws std::logic_error if this is not the root context.
+  /// @throws std::exception if this is not the root context.
   void SetAccuracy(const std::optional<double>& accuracy);
 
   //@}
@@ -617,7 +617,7 @@ class Context : public ContextBase {
   /// state xc (including q, v, z) as a VectorBase. Performs a single
   /// notification sweep to avoid duplicate notifications for computations that
   /// depend on both time and state.
-  /// @throws std::logic_error if this is not the root context.
+  /// @throws std::exception if this is not the root context.
   /// @see SetTimeAndNoteContinuousStateChange()
   /// @see SetTimeAndGetMutableContinuousState()
   VectorBase<T>& SetTimeAndGetMutableContinuousStateVector(const T& time_sec) {
@@ -629,7 +629,7 @@ class Context : public ContextBase {
   /// continuous state partition q from xc. Performs a single notification sweep
   /// to avoid duplicate notifications for computations that depend on both time
   /// and q.
-  /// @throws std::logic_error if this is not the root context.
+  /// @throws std::exception if this is not the root context.
   /// @see GetMutableVZVectors()
   /// @see SetTimeAndGetMutableContinuousStateVector()
   VectorBase<T>& SetTimeAndGetMutableQVector(const T& time_sec);
@@ -647,7 +647,7 @@ class Context : public ContextBase {
   /// mutable reference to xc which they are going to modify. Performs a single
   /// notification sweep to avoid duplicate notifications for computations that
   /// depend on both time and state.
-  /// @throws std::logic_error if this is not the root context.
+  /// @throws std::exception if this is not the root context.
   /// @see SetTimeAndGetMutableContinuousStateVector()
   void SetTimeAndNoteContinuousStateChange(const T& time_sec) {
     SetTimeAndNoteContinuousStateChangeHelper(__func__, time_sec);
@@ -672,7 +672,7 @@ class Context : public ContextBase {
   //@{
 
   /// Returns a deep copy of this Context.
-  /// @throws std::logic_error if this is not the root context.
+  /// @throws std::exception if this is not the root context.
   // This is just an intentional shadowing of the base class method to return
   // a more convenient type.
   std::unique_ptr<Context<T>> Clone() const;

--- a/systems/framework/context_base.h
+++ b/systems/framework/context_base.h
@@ -48,7 +48,7 @@ class ContextBase : public internal::ContextMessageInterface {
   /** @} */
 
   /** Creates an identical copy of the concrete context object.
-  @throws std::logic_error if this is not the root context. */
+  @throws std::exception if this is not the root context. */
   std::unique_ptr<ContextBase> Clone() const;
 
   ~ContextBase() override;

--- a/systems/framework/dependency_tracker.h
+++ b/systems/framework/dependency_tracker.h
@@ -292,15 +292,15 @@ class DependencyTracker {
   Methods used in test cases or for debugging. */
   //@{
 
-  /** Throws an std::logic_error if there is something clearly wrong with this
+  /** Throws an std::exception if there is something clearly wrong with this
   %DependencyTracker object. If the owning subcontext is known, provide a
   pointer to it here and we'll check that this tracker agrees. If you know which
   cache entry is supposed to be associated with this tracker, supply a pointer
   to that and we'll check it (trackers that are not associated with a real cache
   entry are still associated with the CacheEntryValue::dummy()). In addition we
   check for other internal inconsistencies.
-  @throws std::logic_error for anything that goes wrong, with an appropriate
-                           explanatory message. */
+  @throws std::exception for anything that goes wrong, with an appropriate
+                         explanatory message. */
   void ThrowIfBadDependencyTracker(
       const internal::ContextMessageInterface* owning_subcontext = nullptr,
       const CacheEntryValue* cache_value = nullptr) const;

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -135,7 +135,7 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
 
   /// Retrieves a reference to the subsystem with name @p name returned by
   /// get_name().
-  /// @throws std::logic_error if a match cannot be found.
+  /// @throws std::exception if a match cannot be found.
   /// @see System<T>::get_name()
   const System<T>& GetSubsystemByName(const std::string& name) const;
 

--- a/systems/framework/diagram_builder.h
+++ b/systems/framework/diagram_builder.h
@@ -276,12 +276,12 @@ class DiagramBuilder {
 
   /// Builds the Diagram that has been described by the calls to Connect,
   /// ExportInput, and ExportOutput.
-  /// @throws std::logic_error if the graph is not buildable.
+  /// @throws std::exception if the graph is not buildable.
   std::unique_ptr<Diagram<T>> Build();
 
   /// Configures @p target to have the topology that has been described by
   /// the calls to Connect, ExportInput, and ExportOutput.
-  /// @throws std::logic_error if the graph is not buildable.
+  /// @throws std::exception if the graph is not buildable.
   ///
   /// Only Diagram subclasses should call this method. The target must not
   /// already be initialized.
@@ -318,7 +318,7 @@ class DiagramBuilder {
   void ThrowIfAlgebraicLoopsExist() const;
 
   // Produces the Blueprint that has been described by the calls to
-  // Connect, ExportInput, and ExportOutput. Throws std::logic_error if the
+  // Connect, ExportInput, and ExportOutput. Throws std::exception if the
   // graph is empty or contains algebraic loops.
   // The DiagramBuilder passes ownership of the registered systems to the
   // blueprint.

--- a/systems/framework/event_collection.h
+++ b/systems/framework/event_collection.h
@@ -285,7 +285,7 @@ class DiagramEventCollection final : public EventCollection<EventType> {
    * `other_collection`. In addition, this method assumes that `this` and
    * `other_collection` have the exact same topology (i.e. both are created for
    * the same Diagram.)
-   * @throws std::bad_cast if `other_collection` is not an instance of
+   * @throws std::exception if `other_collection` is not an instance of
    * DiagramEventCollection.
    */
   void DoAddToEnd(
@@ -420,7 +420,7 @@ class LeafEventCollection final : public EventCollection<EventType> {
    *   EventType: {event1, event2, event3, event4}
    * </pre>
    *
-   * @throws std::bad_cast if `other_collection` is not an instance of
+   * @throws std::exception if `other_collection` is not an instance of
    * LeafEventCollection.
    */
   void DoAddToEnd(const EventCollection<EventType>& other_collection) final {
@@ -518,7 +518,7 @@ class CompositeEventCollection {
    * Assuming the internal publish event collection is an instance of
    * LeafEventCollection, adds the publish event `event` (ownership is also
    * transferred) to it.
-   * @throws std::bad_cast if the assumption is incorrect.
+   * @throws std::exception if the assumption is incorrect.
    */
   DRAKE_DEPRECATED("2021-09-01", "Use AddPublishEvent instead.")
   void add_publish_event(std::unique_ptr<PublishEvent<T>> event) {
@@ -530,7 +530,7 @@ class CompositeEventCollection {
    * Assuming the internal publish event collection is an instance of
    * LeafEventCollection, adds the publish event `event` (ownership is also
    * transferred) to it.
-   * @throws std::bad_cast if the assumption is incorrect.
+   * @throws std::exception if the assumption is incorrect.
    */
   void AddPublishEvent(PublishEvent<T> event) {
     auto& events = dynamic_cast<LeafEventCollection<PublishEvent<T>>&>(
@@ -542,7 +542,7 @@ class CompositeEventCollection {
    * Assuming the internal discrete update event collection is an instance of
    * LeafEventCollection, adds the discrete update event `event` (ownership is
    * also transferred) to it.
-   * @throws std::bad_cast if the assumption is incorrect.
+   * @throws std::exception if the assumption is incorrect.
    */
   DRAKE_DEPRECATED("2021-09-01", "Use AddDiscreteUpdateEvent instead.")
   void add_discrete_update_event(
@@ -555,7 +555,7 @@ class CompositeEventCollection {
    * Assuming the internal discrete update event collection is an instance of
    * LeafEventCollection, adds the discrete update event `event` (ownership is
    * also transferred) to it.
-   * @throws std::bad_cast if the assumption is incorrect.
+   * @throws std::exception if the assumption is incorrect.
    */
   void AddDiscreteUpdateEvent(DiscreteUpdateEvent<T> event) {
     auto& events = dynamic_cast<LeafEventCollection<DiscreteUpdateEvent<T>>&>(
@@ -567,7 +567,7 @@ class CompositeEventCollection {
    * Assuming the internal unrestricted update event collection is an instance
    * of LeafEventCollection, adds the unrestricted update event `event`
    * (ownership is also transferred) to it.
-   * @throws std::bad_cast if the assumption is incorrect.
+   * @throws std::exception if the assumption is incorrect.
    */
   DRAKE_DEPRECATED("2021-09-01", "Use AddUnrestrictedUpdateEvent instead.")
   void add_unrestricted_update_event(
@@ -580,7 +580,7 @@ class CompositeEventCollection {
    * Assuming the internal unrestricted update event collection is an instance
    * of LeafEventCollection, adds the unrestricted update event `event`
    * (ownership is also transferred) to it.
-   * @throws std::bad_cast if the assumption is incorrect.
+   * @throws std::exception if the assumption is incorrect.
    */
   void AddUnrestrictedUpdateEvent(UnrestrictedUpdateEvent<T> event) {
     auto& events =

--- a/systems/framework/fixed_input_port_value.h
+++ b/systems/framework/fixed_input_port_value.h
@@ -73,7 +73,7 @@ class FixedInputPortValue {
   /** Returns a pointer to the data inside this %FixedInputPortValue, and
   notifies the dependent input port that the value has changed, invalidating
   downstream computations.
-  @throws std::bad_cast if the data is not vector data.
+  @throws std::exception if the data is not vector data.
 
   To ensure invalidation notifications are delivered, callers should call this
   method every time they wish to update the stored value. In particular, callers

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -1157,7 +1157,7 @@ class LeafSystem : public System<T> {
 
   You should normally provide a meaningful name for any input port you
   create. Names must be unique for this system (passing in a duplicate
-  name will throw std::logic_error). However, if you specify
+  name will throw std::exception). However, if you specify
   kUseDefaultName as the name, then a default name of e.g. "u2", where 2
   is the input port number will be provided. An empty name is not
   permitted. */

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -570,7 +570,7 @@ class System : public SystemBase {
   of the state variables to change. See the documentation for
   DispatchUnrestrictedUpdateHandler() for more details.
 
-  @throws std::logic_error if the dimensionality of the state variables
+  @throws std::exception if the dimensionality of the state variables
           changes in the callback. */
   void CalcUnrestrictedUpdate(
       const Context<T>& context,
@@ -796,14 +796,14 @@ class System : public SystemBase {
 
   /** Returns a const reference to the subcontext that corresponds to the
   contained %System `subsystem`.
-  @throws std::logic_error if `subsystem` not contained in `this` %System.
+  @throws std::exception if `subsystem` not contained in `this` %System.
   @pre The given `context` is valid for use with `this` %System. */
   const Context<T>& GetSubsystemContext(const System<T>& subsystem,
                                         const Context<T>& context) const;
 
   /** Returns a mutable reference to the subcontext that corresponds to the
   contained %System `subsystem`.
-  @throws std::logic_error if `subsystem` not contained in `this` %System.
+  @throws std::exception if `subsystem` not contained in `this` %System.
   @pre The given `context` is valid for use with `this` %System. */
   Context<T>& GetMutableSubsystemContext(const System<T>& subsystem,
                                          Context<T>* context) const;
@@ -812,7 +812,7 @@ class System : public SystemBase {
   `this` %System is already the top level (root) %System, just returns
   `root_context`. (A root Context is one that does not have a parent
   Context.)
-  @throws std::logic_error if the given `root_context` is not actually
+  @throws std::exception if the given `root_context` is not actually
       a root context.
   @see GetSubsystemContext() */
   const Context<T>& GetMyContextFromRoot(const Context<T>& root_context) const;
@@ -931,7 +931,7 @@ class System : public SystemBase {
   /** Returns the typed input port with the unique name @p port_name.
   The current implementation performs a linear search over strings; prefer
   get_input_port() when performance is a concern.
-  @throws std::logic_error if port_name is not found. */
+  @throws std::exception if port_name is not found. */
   const InputPort<T>& GetInputPort(const std::string& port_name) const;
 
   /** Returns true iff the system has an InputPort of the given @p
@@ -966,7 +966,7 @@ class System : public SystemBase {
   /** Returns the typed output port with the unique name @p port_name.
   The current implementation performs a linear search over strings; prefer
   get_output_port() when performance is a concern.
-  @throws std::logic_error if port_name is not found. */
+  @throws std::exception if port_name is not found. */
   const OutputPort<T>& GetOutputPort(const std::string& port_name) const;
 
   /** Returns true iff the system has an OutputPort of the given @p
@@ -978,7 +978,7 @@ class System : public SystemBase {
   int num_constraints() const;
 
   /** Returns the constraint at index @p constraint_index.
-  @throws std::out_of_range for an invalid constraint_index. */
+  @throws std::exception for an invalid constraint_index. */
   const SystemConstraint<T>& get_constraint(
       SystemConstraintIndex constraint_index) const;
 
@@ -1364,7 +1364,7 @@ class System : public SystemBase {
   /** Adds a port with the specified @p type and @p size to the input topology.
 
   Input port names must be unique for this system (passing in a duplicate
-  @p name will throw std::logic_error). If @p name is given as
+  @p name will throw std::exception). If @p name is given as
   kUseDefaultName, then a default value of e.g. "u2", where 2
   is the input number will be provided. An empty @p name is not permitted.
 
@@ -1374,7 +1374,7 @@ class System : public SystemBase {
   reason explicitly about randomness at the system level.  All random input
   ports are assumed to be statistically independent.
   @pre @p name must not be empty.
-  @throws std::logic_error for a duplicate port name.
+  @throws std::exception for a duplicate port name.
   @returns the declared port. */
   InputPort<T>& DeclareInputPort(
       std::variant<std::string, UseDefaultName> name, PortDataType type,
@@ -1557,7 +1557,7 @@ class System : public SystemBase {
 
   The default implementation uses the identity mapping, and correctly does
   nothing if the %System does not have second-order state variables. It
-  throws std::runtime_error if the `generalized_velocity` and
+  throws std::exception if the `generalized_velocity` and
   `qdot` are not the same size, but that is not enough to guarantee that
   the default implementation is adequate. Child classes must
   override this function if qdot != v (even if they are the same size).
@@ -1579,7 +1579,7 @@ class System : public SystemBase {
 
   The default implementation uses the identity mapping, and correctly does
   nothing if the %System does not have second-order state variables. It
-  throws std::runtime_error if the `generalized_velocity` (`v`) and
+  throws std::exception if the `generalized_velocity` (`v`) and
   `qdot` are not the same size, but that is not enough to guarantee that
   the default implementation is adequate. Child classes must
   override this function if `qdot != v` (even if they are the same size).

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -359,7 +359,7 @@ class SystemBase : public internal::SystemMessageInterface {
     is truly independent of the Context (rare!) say so explicitly by providing
     the list `{nothing_ticket()}`; an explicitly empty list `{}` is forbidden.
   @returns a reference to the newly-created %CacheEntry.
-  @throws std::logic_error if given an explicitly empty prerequisite list. */
+  @throws std::exception if given an explicitly empty prerequisite list. */
   CacheEntry& DeclareCacheEntry(
       std::string description, ValueProducer value_producer,
       std::set<DependencyTicket> prerequisites_of_calc = {
@@ -866,7 +866,7 @@ class SystemBase : public internal::SystemMessageInterface {
   System. Insists that the port already contains a reference to this System, and
   that the port's index is already set to the next available output port index
   for this System, and that the name of the port is unique.
-  @throws std::logic_error if the name of the output port is not unique. */
+  @throws std::exception if the name of the output port is not unique. */
   // TODO(sherm1) Add check on suitability of `size` parameter for the port's
   // data type.
   void AddOutputPort(std::unique_ptr<OutputPortBase> port) {
@@ -1019,7 +1019,7 @@ class SystemBase : public internal::SystemMessageInterface {
                                              const ContextBase& context,
                                              InputPortIndex port_index) const;
 
-  /** Throws std::out_of_range to report a negative `port_index` that was
+  /** Throws std::exception to report a negative `port_index` that was
   passed to API method `func`. Caller must ensure that the function name
   makes it clear what kind of port we're complaining about. */
   // We're taking an int here for the index; InputPortIndex and OutputPortIndex
@@ -1027,23 +1027,23 @@ class SystemBase : public internal::SystemMessageInterface {
   [[noreturn]] void ThrowNegativePortIndex(const char* func,
                                            int port_index) const;
 
-  /** Throws std::out_of_range to report bad input `port_index` that was passed
+  /** Throws std::exception to report bad input `port_index` that was passed
   to API method `func`. */
   [[noreturn]] void ThrowInputPortIndexOutOfRange(
       const char* func, InputPortIndex port_index) const;
 
-  /** Throws std::out_of_range to report bad output `port_index` that was passed
+  /** Throws std::exception to report bad output `port_index` that was passed
   to API method `func`. */
   [[noreturn]] void ThrowOutputPortIndexOutOfRange(
       const char* func, OutputPortIndex port_index) const;
 
-  /** Throws std::logic_error because someone misused API method `func`, that is
+  /** Throws std::exception because someone misused API method `func`, that is
   only allowed for declared-vector input ports, on an abstract port whose
   index is given here. */
   [[noreturn]] void ThrowNotAVectorInputPort(const char* func,
                                              InputPortIndex port_index) const;
 
-  /** Throws std::logic_error because someone called API method `func` claiming
+  /** Throws std::exception because someone called API method `func` claiming
   the input port had some value type that was wrong. */
   [[noreturn]] void ThrowInputPortHasWrongType(
       const char* func, InputPortIndex port_index,
@@ -1051,21 +1051,21 @@ class SystemBase : public internal::SystemMessageInterface {
 
   // This method is static for use from outside the System hierarchy but where
   // the problematic System is clear.
-  /** Throws std::logic_error because someone called API method `func` claiming
+  /** Throws std::exception because someone called API method `func` claiming
   the input port had some value type that was wrong. */
   [[noreturn]] static void ThrowInputPortHasWrongType(
       const char* func, const std::string& system_pathname, InputPortIndex,
       const std::string& port_name, const std::string& expected_type,
       const std::string& actual_type);
 
-  /** Throws std::logic_error because someone called API method `func`, that
+  /** Throws std::exception because someone called API method `func`, that
   requires this input port to be evaluatable, but the port was neither
   fixed nor connected. */
   [[noreturn]] void ThrowCantEvaluateInputPort(const char* func,
                                                InputPortIndex port_index) const;
 
   /** (Internal use only) Returns the InputPortBase at index `port_index`,
-  throwing std::out_of_range we don't like the port index. The name of the
+  throwing std::exception we don't like the port index. The name of the
   public API method that received the bad index is provided in `func` and is
   included in the error message. */
   const InputPortBase& GetInputPortBaseOrThrow(const char* func,
@@ -1079,7 +1079,7 @@ class SystemBase : public internal::SystemMessageInterface {
   }
 
   /** (Internal use only) Returns the OutputPortBase at index `port_index`,
-  throwing std::out_of_range if we don't like the port index. The name of the
+  throwing std::exception if we don't like the port index. The name of the
   public API method that received the bad index is provided in `func` and is
   included in the error message. */
   const OutputPortBase& GetOutputPortBaseOrThrow(const char* func,

--- a/systems/framework/system_output.h
+++ b/systems/framework/system_output.h
@@ -52,7 +52,7 @@ class SystemOutput {
 
   /** Returns the last-saved value of output port `index` as a `BasicVector<T>`,
   although the actual concrete type is preserved from the actual output port.
-  @throws std::bad_cast if the port is not vector-valued. */
+  @throws std::exception if the port is not vector-valued. */
   const BasicVector<T>* get_vector_data(int index) const {
     DRAKE_ASSERT(0 <= index && index < num_ports());
     return &port_values_[index]->template get_value<BasicVector<T>>();
@@ -73,7 +73,7 @@ class SystemOutput {
   System. The object's concrete type is preserved from the output port. Most
   users should just call `System<T>::CalcOutputs()` to get all the output
   port values at once.
-  @throws std::bad_cast if the port is not vector-valued. */
+  @throws std::exception if the port is not vector-valued. */
   BasicVector<T>* GetMutableVectorData(int index) {
     DRAKE_ASSERT(0 <= index && index < num_ports());
     return &port_values_[index]->template get_mutable_value<BasicVector<T>>();

--- a/systems/lcm/lcm_publisher_system.h
+++ b/systems/lcm/lcm_publisher_system.h
@@ -196,7 +196,7 @@ class LcmPublisherSystem : public LeafSystem<double> {
    * will be created.
    *
    * You can only call this method once.
-   * @throws std::logic_error if called a second time.
+   * @throws std::exception if called a second time.
    *
    * @pre The publisher function may not be null.
    */

--- a/systems/optimization/system_constraint_adapter.h
+++ b/systems/optimization/system_constraint_adapter.h
@@ -100,7 +100,7 @@ class SystemConstraintAdapter {
    * SystemConstraint. If the SystemConstraint cannot be parsed to the generic
    * constraint using @p context instantiated with symbolic::Expression, then
    * constraint.has_value() = false.
-   * @throw invalid_argument if the system contains abstract state or abstract
+   * @throws std::exception if the system contains abstract state or abstract
    * parameters.
    */
   std::optional<solvers::Binding<solvers::Constraint>>

--- a/systems/primitives/affine_system.h
+++ b/systems/primitives/affine_system.h
@@ -218,7 +218,7 @@ class AffineSystem : public TimeVaryingAffineSystem<T> {
   /// Creates a unique pointer to AffineSystem<T> by decomposing @p dynamics and
   /// @p outputs using @p state_vars and @p input_vars.
   ///
-  /// @throws std::runtime_error if either @p dynamics or @p outputs is not
+  /// @throws std::exception if either @p dynamics or @p outputs is not
   /// affine in @p state_vars and @p input_vars.
   static std::unique_ptr<AffineSystem<T>> MakeAffineSystem(
       const Eigen::Ref<const VectorX<symbolic::Expression>>& dynamics,

--- a/systems/primitives/demultiplexer.h
+++ b/systems/primitives/demultiplexer.h
@@ -26,8 +26,8 @@ class Demultiplexer final : public LeafSystem<T> {
   /// is the length of this vector. The size of each output port is the value of
   /// the corresponding element of the vector @p output_ports_sizes.
   ///
-  /// @throws std::logic_error if @p output_ports_sizes is a zero length vector.
-  /// @throws std::logic_error if any element of the @p output_ports_sizes is
+  /// @throws std::exception if @p output_ports_sizes is a zero length vector.
+  /// @throws std::exception if any element of the @p output_ports_sizes is
   /// zero. Therefore, the Demultiplexer does not allow zero size output ports.
   ///
   /// @param output_ports_sizes Contains the sizes of each output port. The
@@ -39,7 +39,7 @@ class Demultiplexer final : public LeafSystem<T> {
   /// Constructs %Demultiplexer with one vector valued input port of size
   /// @p size and vector valued output ports of size @p output_ports_size.
   ///
-  /// @throws std::logic_error if output_ports_sizes can not exactly divide @p
+  /// @throws std::exception if output_ports_sizes can not exactly divide @p
   /// size. The number of output ports is therefore `size / output_ports_size`.
   ///
   /// @param size is the size of the input signal to be demultiplexed into its

--- a/systems/primitives/linear_system.h
+++ b/systems/primitives/linear_system.h
@@ -61,7 +61,7 @@ class LinearSystem : public AffineSystem<T> {
   /// Creates a unique pointer to LinearSystem<T> by decomposing @p dynamics and
   /// @p outputs using @p state_vars and @p input_vars.
   ///
-  /// @throws std::runtime_error if either @p dynamics or @p outputs is not
+  /// @throws std::exception if either @p dynamics or @p outputs is not
   /// linear in @p state_vars and @p input_vars.
   static std::unique_ptr<LinearSystem<T>> MakeLinearSystem(
       const Eigen::Ref<const VectorX<symbolic::Expression>>& dynamics,
@@ -152,9 +152,9 @@ class TimeVaryingLinearSystem : public TimeVaryingAffineSystem<T> {
 /// the derivative vector isZero at the nominal operating point.  @default 1e-6.
 /// @returns A LinearSystem that approximates the original system in the
 /// vicinity of the operating point.  See note below.
-/// @throws std::runtime_error if the operating point is not an
+/// @throws std::exception if the operating point is not an
 /// equilibrium point of the system (within the specified tolerance)
-/// @throws std::runtime_error if the system is not (only)
+/// @throws std::exception if the system is not (only)
 /// continuous or (only) discrete time with a single periodic update.
 ///
 /// @note All _vector_ inputs in the system must be connected, either to the

--- a/systems/primitives/signal_logger.h
+++ b/systems/primitives/signal_logger.h
@@ -78,7 +78,7 @@ class SignalLogger final : public LeafSystem<T> {
   /// Sets the publishing period of this system to specify periodic sampling
   /// and disables the default per-step sampling. This method can only be called
   /// once and only if set_forced_publish_only() hasn't been called.
-  /// @throws std::logic_error if called more than once, or if
+  /// @throws std::exception if called more than once, or if
   ///   set_forced_publish_only() has been called.
   /// @pre `period` must be greater than zero.
   void set_publish_period(double period);
@@ -87,7 +87,7 @@ class SignalLogger final : public LeafSystem<T> {
   /// to System::Publish() issued directly or by the Simulator and disables the
   /// default per-step sampling. This method cannot be called if
   /// set_publish_period() has been called.
-  /// @throws std::logic_error if set_publish_period() has been called.
+  /// @throws std::exception if set_publish_period() has been called.
   void set_forced_publish_only();
 
   /// Returns the number of samples taken since construction or last reset().

--- a/systems/primitives/symbolic_vector_system.h
+++ b/systems/primitives/symbolic_vector_system.h
@@ -147,7 +147,7 @@ class SymbolicVectorSystem final : public LeafSystem<T> {
   /// scalar expression corresponding to either `\dot{var}` (continuous case) or
   /// `var[n+1]` (discrete case).
   ///
-  /// @throw std::out_of_range if this system has no corresponding dynamics for
+  /// @throws std::exception if this system has no corresponding dynamics for
   /// the variable @p var.
   const symbolic::Expression& dynamics_for_variable(
       const symbolic::Variable& var) const {
@@ -382,7 +382,7 @@ class SymbolicVectorSystemBuilder {
   /// scalar expression corresponding to either `\dot{var}` (continuous case) or
   /// `var[n+1]` (discrete case).
   ///
-  /// @throw std::out_of_range if this builder has no corresponding dynamics for
+  /// @throws std::exception if this builder has no corresponding dynamics for
   /// the variable @p var.
   const symbolic::Expression& dynamics_for_variable(
       const symbolic::Variable& var) const {

--- a/systems/sensors/camera_info.h
+++ b/systems/sensors/camera_info.h
@@ -158,7 +158,7 @@ class CameraInfo final {
    Constructs this instance by extracting focal_x, focal_y, center_x, and
    center_y from the provided intrinsic_matrix.
 
-   @throws std::runtime_error if intrinsic_matrix is not of the form indicated
+   @throws std::exception if intrinsic_matrix is not of the form indicated
    above for the pinhole camera model (representing an affine / homogeneous
    transform).
   */

--- a/systems/sensors/color_palette.h
+++ b/systems/sensors/color_palette.h
@@ -91,7 +91,7 @@ class ColorPalette {
   /// @param no_body_id The id to express pixels that have no body. This will be
   ///  used in the label image.
   ///
-  /// @throws std::logic_error When @p num_colors exceeds the maximum limit,
+  /// @throws std::exception When @p num_colors exceeds the maximum limit,
   /// which is 1535.
   ColorPalette(int num_colors, IdType terrain_id, IdType no_body_id)
       : terrain_id_(terrain_id), empty_id_(no_body_id) {

--- a/systems/sensors/image_writer.h
+++ b/systems/sensors/image_writer.h
@@ -189,7 +189,7 @@ class ImageWriter : public LeafSystem<double> {
                             PixelType). Must be one of {PixelType::kRgba8U,
                             PixelType::kDepth32F, PixelType::kLabel16I,
                             PixelType::kDepth16U, or PixelType::kGrey8U}.
-   @throws std::logic_error if (1) the directory encoded in the
+   @throws std::exception   if (1) the directory encoded in the
                             `file_name_format` is not "valid" (see
                             documentation above for definition),
                             (2) `publish_period` is not positive, or

--- a/systems/trajectory_optimization/multiple_shooting.h
+++ b/systems/trajectory_optimization/multiple_shooting.h
@@ -46,7 +46,7 @@ class MultipleShooting : public solvers::MathematicalProgram {
 
   /// Returns the decision variable associated with the timestep, h, at time
   /// index @p index.
-  /// @throws std::runtime_error if timesteps are not declared as decision
+  /// @throws std::exception if timesteps are not declared as decision
   /// variables.
   const solvers::VectorDecisionVariable<1> timestep(int index) const {
     DRAKE_THROW_UNLESS(timesteps_are_decision_variables_);
@@ -178,14 +178,14 @@ class MultipleShooting : public solvers::MathematicalProgram {
   /// @param lower_bound  A scalar double lower bound.
   /// @param upper_bound  A scalar double upper bound.
   /// @return The bounding box constraint enforcing time interval bounds.
-  /// @throws std::runtime_error if timesteps are not declared as decision
+  /// @throws std::exception if timesteps are not declared as decision
   /// variables.
   solvers::Binding<solvers::BoundingBoxConstraint> AddTimeIntervalBounds(
       double lower_bound, double upper_bound);
 
   /// Adds constraints to enforce that all timesteps have equal duration.
   /// @return A vector of constraints enforcing all time intervals are equal.
-  /// @throws std::runtime_error if timesteps are not declared as decision
+  /// @throws std::exception if timesteps are not declared as decision
   /// variables.
   std::vector<solvers::Binding<solvers::LinearConstraint>>
   AddEqualTimeIntervalsConstraints();
@@ -194,7 +194,7 @@ class MultipleShooting : public solvers::MathematicalProgram {
   /// @param lower_bound  A scalar double lower bound.
   /// @param upper_bound  A scalar double upper bound.
   /// @return The constraint enforcing the duration bounds.
-  /// @throws std::runtime_error if timesteps are not declared as decision
+  /// @throws std::exception if timesteps are not declared as decision
   /// variables.
   solvers::Binding<solvers::LinearConstraint> AddDurationBounds(
       double lower_bound, double upper_bound);
@@ -302,7 +302,7 @@ class MultipleShooting : public solvers::MathematicalProgram {
   /// If time steps are decision variables, then the initial guess for
   /// the time steps are evenly distributed to match the duration of the
   /// @p traj_init_u and @p traj_init_x.
-  /// @throws std::runtime_error if @p traj_init_u and @p traj_init_x are both
+  /// @throws std::exception if @p traj_init_u and @p traj_init_x are both
   /// empty, or if @p traj_init_u and @p traj_init_x are both non-empty, and
   /// have different start and end times.
   // TODO(russt): Consider taking the actual breakpoints from

--- a/systems/trajectory_optimization/sequential_expression_manager.h
+++ b/systems/trajectory_optimization/sequential_expression_manager.h
@@ -62,12 +62,12 @@ class SequentialExpressionManager {
    *                               sequential_expressions(i, j) is the value of
    *                               the i-th expression at the j-th index.
    * @param name Name for the newly registered sequential expression vector.
-   * @throw std::runtime_error unless `sequential_expressions` has
-   *                           `placeholders.size()` rows.
-   * @throw std::runtime_error unless `sequential_expressions` has num_samples()
-   *                           columns.
-   * @throw std::runtime_error if it has an existing registration under the
-   *                           `name`.
+   * @throws std::exception unless `sequential_expressions` has
+   *                        `placeholders.size()` rows.
+   * @throws std::exception unless `sequential_expressions` has num_samples()
+   *                        columns.
+   * @throws std::exception if it has an existing registration under the
+   *                        `name`.
    */
   void RegisterSequentialExpressions(
       const VectorX<symbolic::Variable>& placeholders,


### PR DESCRIPTION
This brings approximately all legacy code up to the current style guide standard (at least, everything findable via a bunch of grepping).

This keeps intact any reverse-indentation conventions within Doxygen comments, but does **not** attempt to reflow the paragraphs to take advantage of the extra characters now available on the `@throws std::exception ...` comment lines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15336)
<!-- Reviewable:end -->
