### PR TITLE
[geometry] Adds new public API for manipulating collision filters

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -553,6 +553,14 @@ void DoScalarDependentDefinitions(py::module m, T) {
                 &Class::RegisterAnchoredGeometry),
             py::arg("source_id"), py::arg("geometry"),
             cls_doc.RegisterAnchoredGeometry.doc)
+        .def("collision_filter_manager",
+            overload_cast_explicit<CollisionFilterManager, Context<T>*>(
+                &Class::collision_filter_manager),
+            py::arg("context"), cls_doc.collision_filter_manager.doc_1args)
+        .def("collision_filter_manager",
+            overload_cast_explicit<CollisionFilterManager>(
+                &Class::collision_filter_manager),
+            cls_doc.collision_filter_manager.doc_0args)
         .def("ExcludeCollisionsBetween",
             py::overload_cast<const GeometrySet&, const GeometrySet&>(
                 &Class::ExcludeCollisionsBetween),
@@ -960,7 +968,28 @@ void DoScalarIndependentDefinitions(py::module m) {
   BindIdentifier<SourceId>(m, "SourceId", doc.SourceId.doc);
   BindIdentifier<FrameId>(m, "FrameId", doc.FrameId.doc);
   BindIdentifier<GeometryId>(m, "GeometryId", doc.GeometryId.doc);
+  // CollisionFilterDeclaration.
+  {
+    using Class = CollisionFilterDeclaration;
+    constexpr auto& cls_doc = doc.CollisionFilterDeclaration;
 
+    py::class_<Class>(m, "CollisionFilterDeclaration", cls_doc.doc)
+        .def(py::init(), cls_doc.ctor.doc)
+        .def("ExcludeBetween", &Class::ExcludeBetween, py::arg("set_A"),
+            py::arg("set_B"), py_rvp::reference, cls_doc.ExcludeBetween.doc)
+        .def("ExcludeWithin", &Class::ExcludeWithin, py::arg("geometry_set"),
+            py_rvp::reference, cls_doc.ExcludeWithin.doc);
+  }
+
+  //  CollisionFilterManager
+  {
+    using Class = CollisionFilterManager;
+    constexpr auto& cls_doc = doc.CollisionFilterManager;
+    py::class_<Class>(m, "CollisionFilterManager", cls_doc.doc)
+        .def("Apply", &Class::Apply, py::arg("declaration"), cls_doc.Apply.doc);
+  }
+
+  // Role enumeration
   {
     constexpr auto& cls_doc = doc.Role;
     py::enum_<Role>(m, "Role", py::arithmetic(), cls_doc.doc)
@@ -970,6 +999,7 @@ void DoScalarIndependentDefinitions(py::module m) {
         .value("kPerception", Role::kPerception, cls_doc.kPerception.doc);
   }
 
+  // RoleAssign enumeration
   {
     constexpr auto& cls_doc = doc.RoleAssign;
     using Class = RoleAssign;
@@ -978,6 +1008,7 @@ void DoScalarIndependentDefinitions(py::module m) {
         .value("kReplace", Class::kReplace, cls_doc.kReplace.doc);
   }
 
+  // DrakeVisualizerParams
   {
     using Class = DrakeVisualizerParams;
     constexpr auto& cls_doc = doc.DrakeVisualizerParams;
@@ -1102,6 +1133,7 @@ void DoScalarIndependentDefinitions(py::module m) {
     DefCopyAndDeepCopy(&cls);
   }
 
+  // GeometryProperties
   {
     using Class = GeometryProperties;
     constexpr auto& cls_doc = doc.GeometryProperties;

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -757,6 +757,23 @@ class TestGeometry(unittest.TestCase):
         sg_context = sg.CreateDefaultContext()
         geometries = mut.GeometrySet()
 
+        # Mutate SceneGraph model
+        dut = sg.collision_filter_manager()
+        dut.Apply(
+            mut.CollisionFilterDeclaration().ExcludeBetween(
+                geometries, geometries))
+        dut.Apply(
+            mut.CollisionFilterDeclaration().ExcludeWithin(geometries))
+
+        # Mutate context data
+        dut = sg.collision_filter_manager(sg_context)
+        dut.Apply(
+            mut.CollisionFilterDeclaration().ExcludeBetween(
+                geometries, geometries))
+        dut.Apply(
+            mut.CollisionFilterDeclaration().ExcludeWithin(geometries))
+
+        # Legacy API
         sg.ExcludeCollisionsBetween(geometries, geometries)
         sg.ExcludeCollisionsBetween(sg_context, geometries, geometries)
         sg.ExcludeCollisionsWithin(geometries)

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -15,6 +15,7 @@ drake_cc_package_library(
     visibility = ["//visibility:public"],
     deps = [
         ":collision_filter_declaration",
+        ":collision_filter_manager",
         ":drake_visualizer",
         ":frame_kinematics",
         ":geometry_frame",
@@ -72,6 +73,18 @@ drake_cc_library(
     deps = [
         ":geometry_set",
         "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "collision_filter_manager",
+    srcs = ["collision_filter_manager.cc"],
+    hdrs = ["collision_filter_manager.h"],
+    deps = [
+        ":collision_filter_declaration",
+        ":geometry_ids",
+        ":geometry_set",
+        "//geometry/proximity:collision_filter",
     ],
 )
 
@@ -190,6 +203,7 @@ drake_cc_library(
     srcs = ["geometry_state.cc"],
     hdrs = ["geometry_state.h"],
     deps = [
+        ":collision_filter_manager",
         ":frame_kinematics",
         ":geometry_frame",
         ":geometry_ids",
@@ -330,6 +344,15 @@ drake_cc_googletest(
     deps = [
         ":collision_filter_declaration",
         ":geometry_ids",
+    ],
+)
+
+drake_cc_googletest(
+    name = "collision_filter_manager_test",
+    deps = [
+        ":collision_filter_manager",
+        ":scene_graph",
+        "//common/test_utilities:expect_no_throw",
     ],
 )
 

--- a/geometry/collision_filter_declaration.h
+++ b/geometry/collision_filter_declaration.h
@@ -20,29 +20,9 @@ class CollisionFilter;
  "collision filters"; collision filters limit the scope of various proximity
  queries.
 
- A SceneGraph instance contains the set of geometry
- `G = D ⋃ A = {g₀, g₁, ..., gₙ}`, where D is the set of dynamic geometries and
- A is the set of anchored geometries (by definition `D ⋂ A = ∅`). `Gₚ ⊂ G` is
- the subset of geometries that have a proximity role (with an analogous
- interpretation of `Dₚ` and `Aₚ`). Many proximity queries operate on pairs of
- geometries (e.g., (gᵢ, gⱼ)). The set of proximity candidate pairs for such
- queries is initially defined as `C = (Gₚ × Gₚ) - (Aₚ × Aₚ) - Fₚ - Iₚ`, where:
-
-  - `Gₚ × Gₚ = {(gᵢ, gⱼ)}, ∀ gᵢ, gⱼ ∈ Gₚ` is the Cartesian product of the set
-    of SceneGraph proximity geometries.
-  - `Aₚ × Aₚ` represents all pairs consisting only of anchored geometries;
-    an anchored geometry is never tested against another anchored geometry.
-  - `Fₚ = {(gᵢ, gⱼ)} ∀ i, j`, such that `gᵢ, gⱼ ∈ Dₚ` and
-    `frame(gᵢ) == frame(gⱼ)`; the pairs where both geometries are rigidly
-    affixed to the same frame.
-  - `Iₚ = {(g, g)}, ∀ g ∈ Gₚ` is the set of all pairs consisting of a
-    geometry with itself; there is no meaningful proximity query on a
-    geometry with itself.
-
- Only pairs contained in C will be included in pairwise proximity operations.
-
- This class provides the basis for *declaring* what pairs should not be included
- in the set C.
+ This class provides the basis for *declaring* what pairs should or should not
+ be included in the set of proximity query candidates C (see documentation for
+ CollisionFilterManager for details on the set C).
 
  A declaration consists of zero or more *statements*. Each statement can
  declare, for example, that the pair (g₁, g₂) should be excluded from C (also
@@ -62,7 +42,8 @@ class CollisionFilter;
 
  It's worth noting, that the statements are evaluated in *invocation* order such
  that a later statement can partially or completely undo the effect of an
- earlier statement. */
+ earlier statement. The full declaration is evaluated by
+ CollisionFilterManager::Apply(). */
 class CollisionFilterDeclaration {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CollisionFilterDeclaration)
@@ -72,13 +53,14 @@ class CollisionFilterDeclaration {
   /** @name  Excluding pairs from consideration (adding collision filters)
 
    These methods provide mechanisms which implicitly define a set of pairs and
-   subtracts each implied pair from the set C. The documentation of each method
-   explains the relationship between the input parameters and the set of implied
-   geometry pairs.
+   subtracts each implied pair from the set of proximity query candidates C (see
+   the documentation for CollisionFilterManager for definition of set C). The
+   documentation of each method explains the relationship between the input
+   parameters and the set of implied geometry pairs.
 
-   The *declared* pairs may be invalid (e.g., containing GeometryId values that
+   The *declared* pairs can be invalid (e.g., containing GeometryId values that
    aren't part of the SceneGraph data). This will only be detected when applying
-   the declaration. */
+   the declaration (see CollisionFilterManager::Apply()). */
   //@{
 
   /** Excludes geometry pairs from proximity evaluation by updating the

--- a/geometry/collision_filter_manager.cc
+++ b/geometry/collision_filter_manager.cc
@@ -1,0 +1,17 @@
+#include "drake/geometry/collision_filter_manager.h"
+
+#include <utility>
+
+namespace drake {
+namespace geometry {
+
+using internal::CollisionFilter;
+
+CollisionFilterManager::CollisionFilterManager(
+    CollisionFilter* filter, CollisionFilter::ExtractIds extract_ids)
+    : filter_(filter), extract_ids_(std::move(extract_ids)) {
+  DRAKE_DEMAND(filter != nullptr);
+}
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/collision_filter_manager.h
+++ b/geometry/collision_filter_manager.h
@@ -1,0 +1,124 @@
+#pragma once
+
+#include "drake/common/drake_copyable.h"
+#include "drake/geometry/collision_filter_declaration.h"
+#include "drake/geometry/geometry_set.h"
+#include "drake/geometry/proximity/collision_filter.h"
+
+namespace drake {
+namespace geometry {
+
+// Forward declarations.
+template <typename T>
+class GeometryState;
+
+/** Class for configuring "collision filters"; collision filters limit the scope
+ of various proximity queries.
+
+ The sole source of %CollisionFilterManager instances is SceneGraph. See
+ @ref scene_graph_collision_filter_manager "SceneGraph's documentation" for
+ details on acquiring an instance.
+
+ A SceneGraph instance contains the set of geometry
+ `G = D ⋃ A = {g₀, g₁, ..., gₙ}`, where D is the set of dynamic geometries and
+ A is the set of anchored geometries (by definition `D ⋂ A = ∅`). `Gₚ ⊂ G` is
+ the subset of geometries that have a proximity role (with an analogous
+ interpretation of `Dₚ` and `Aₚ`). Many proximity queries operate on pairs of
+ geometries (e.g., (gᵢ, gⱼ)). The set of proximity candidate pairs for such
+ queries is initially defined as `C = (Gₚ × Gₚ) - (Aₚ × Aₚ) - Fₚ - Iₚ`, where:
+
+  - `Gₚ × Gₚ = {(gᵢ, gⱼ)}, ∀ gᵢ, gⱼ ∈ Gₚ` is the Cartesian product of the set
+    of SceneGraph proximity geometries.
+  - `Aₚ × Aₚ` represents all pairs consisting only of anchored geometries;
+    an anchored geometry is never tested against another anchored geometry.
+  - `Fₚ = {(gᵢ, gⱼ)} ∀ i, j`, such that `gᵢ, gⱼ ∈ Dₚ` and
+    `frame(gᵢ) == frame(gⱼ)`; the pairs where both geometries are rigidly
+    affixed to the same frame.
+  - `Iₚ = {(g, g)}, ∀ g ∈ Gₚ` is the set of all pairs consisting of a
+    geometry with itself; there is no meaningful proximity query on a
+    geometry with itself.
+
+ Only pairs contained in C will be included in pairwise proximity operations.
+
+ The manager provides an interface to modify the set C. Changes to C are
+ articulated with CollisionFilterDeclaration. Once a change has been *declared*
+ it is applied via the manager's API to change the configuration of C.
+
+ There are limits to how C can be modified.
+
+   - `∀ (gᵢ, gⱼ) ∈ C`, both gᵢ and gⱼ must be registered with SceneGraph; you
+     can't inject arbitrary ids. Attempting to do so will result in an error.
+
+ The current configuration of C depends on the sequence of filter declarations
+ that have been applied in the manager. Changing the order can change the end
+ result.
+
+ A %CollisionFilterManager is a view into geometry data (either that owned by
+ a SceneGraph instance or a SceneGraph context). The manager instance can be
+ copied or moved and the resulting instance is a view into the same data. For
+ both the original and the copy (or just the target when moving the manager),
+ the source data must stay alive for at least as long as the manager instance.
+
+ @warning The effect of applying a declaration is based on the state of
+ SceneGraph's geometry data at the time of application. More concretely:
+ - For a particular FrameId in a GeometrySet instance, only those geometries
+   attached to the identified frame with the proximity role assigned at the
+   time of the call will be included in the filter. If geometries are
+   subsequently added or assigned the proximity role, they will not be
+   retroactively added to the user-declared filter.
+ - If the geometry set in a declaration statement includes geometries which
+   have _not_ been assigned a proximity role, those geometries will be ignored.
+   If a proximity role is subsequently assigned, those geometries will _still_
+   not be part of any user-declared collision filters.
+ - In general, adding collisions and assigning proximity roles should
+   happen prior to collision filter configuration. */
+class CollisionFilterManager {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CollisionFilterManager)
+
+  /** Applies the given `declaration` to the geometry state managed by `this`
+   instance.
+
+   The process of *applying* the collision filter data also validates it. The
+   following polices are implemented during application:
+
+     - Referencing an invalid id (FrameId or GeometryId): throws.
+     - Declaring a filtered pair that is already filtered: no discernible
+       change.
+
+   @throws std::exception if the `declaration` references invalid ids. */
+  void Apply(const CollisionFilterDeclaration& declaration) {
+    filter_->Apply(declaration, extract_ids_);
+  }
+
+  // TODO(SeanCurtis-TRI) SceneGraphInspector includes the method
+  //  CollisionFiltered. It reports whether two geometries are filtered. It
+  //  would be logical to include that here with *two* caveats.
+  //  1. The SceneGraphInspector relies on GeometryState to provide detailed
+  //     error message in case of failure (e.g., id is valid, but has no
+  //     proximity) role. This class lacks that intelligence.
+  //  2. The SceneGraphInspector can be acquired via an input port (from a
+  //     QueryObject instance). CollisionFilterManager cannot. However, the
+  //     QueryObject class can be extended to return a manager just like an
+  //     inspector.
+  //  If those can be resolved, it would make more sense to make the
+  //  CollisionFilterManager the one-stop shop for all things collision filter
+  //  rather than having it split over two classes.
+
+ private:
+  /* Only GeometryState can construct a collision filter manager. */
+  template <typename>
+  friend class GeometryState;
+
+  /* Constructs the manager for a `filter` with the appropriate callback for
+   resolving GeometrySet into set of GeometryIds. */
+  explicit CollisionFilterManager(
+      internal::CollisionFilter* filter,
+      internal::CollisionFilter::ExtractIds extract_ids);
+
+  internal::CollisionFilter* filter_{};
+  internal::CollisionFilter::ExtractIds extract_ids_;
+};
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/geometry_set.h
+++ b/geometry/geometry_set.h
@@ -20,8 +20,8 @@ class GeometryState;
  frame to which the geometries are rigidly affixed.
 
  This class does no validation; it is a simple collection. Ultimately, it serves
- as the operand of SceneGraph operations (e.g.,
- SceneGraph::ExcludeCollisionsWithin()). If the _operation_ has a particular
+ as the operand of various geometry operations (e.g., CollisionFilterDeclaration
+ and CollisionFilterManager::Apply(). If the _operation_ has a particular
  prerequisite on the members of a %GeometrySet, it is the operation's
  responsibility to enforce that requirement.
 

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -894,27 +894,6 @@ int GeometryState<T>::RemoveFromRenderer(const std::string& renderer_name,
 }
 
 template <typename T>
-void GeometryState<T>::ExcludeCollisionsWithin(const GeometrySet& set) {
-  geometry_version_.modify_proximity();
-  geometry_engine_->collision_filter().Apply(
-      CollisionFilterDeclaration().ExcludeWithin(set),
-      [this](const GeometrySet& set_in) {
-        return this->CollectIds(set_in, Role::kProximity);
-      });
-}
-
-template <typename T>
-void GeometryState<T>::ExcludeCollisionsBetween(const GeometrySet& setA,
-                                                const GeometrySet& setB) {
-  geometry_version_.modify_proximity();
-  geometry_engine_->collision_filter().Apply(
-      CollisionFilterDeclaration().ExcludeBetween(setA, setB),
-      [this](const GeometrySet& set_in) {
-        return this->CollectIds(set_in, Role::kProximity);
-      });
-}
-
-template <typename T>
 void GeometryState<T>::AddRenderer(
     std::string name, std::unique_ptr<render::RenderEngine> renderer) {
   if (render_engines_.count(name) > 0) {

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -11,6 +11,7 @@
 
 #include "drake/common/autodiff.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/geometry/collision_filter_manager.h"
 #include "drake/geometry/frame_kinematics_vector.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/geometry_index.h"
@@ -138,6 +139,7 @@ class GeometryState {
   const GeometryVersion& geometry_version() const {
       return geometry_version_;
   }
+
   //@}
 
   /** @name          Sources and source-related data  */
@@ -418,27 +420,16 @@ class GeometryState {
 
   //@}
 
-  /** @name               Proximity filters
+  /** @name        Collision filtering    */
 
-   This interface allows control over which pairs of geometries can even be
-   considered for proximity queries. This affects all queries that depend on
-   geometries with a proximity role.
-
-   See @ref scene_graph_collision_filtering "Scene Graph Collision Filtering"
-   for more details.   */
-  //@{
-
-  // TODO(SeanCurtis-TRI): Rename these functions to reflect the larger role
-  // in proximity queries _or_ change the scope of the filters.
-
-  /** Implementation of SceneGraph::ExcludeCollisionsWithin().  */
-  void ExcludeCollisionsWithin(const GeometrySet& set);
-
-  /** Implementation of SceneGraph::ExcludeCollisionsBetween().  */
-  void ExcludeCollisionsBetween(const GeometrySet& setA,
-                                const GeometrySet& setB);
-
-  //@}
+  /** Implementation of SceneGraph::collision_filter_manager(). */
+  CollisionFilterManager collision_filter_manager() {
+    geometry_version_.modify_proximity();
+    return CollisionFilterManager(
+        &geometry_engine_->collision_filter(), [this](const GeometrySet& set) {
+          return this->CollectIds(set, Role::kProximity);
+        });
+  }
 
   //---------------------------------------------------------------------------
   /** @name                Signed Distance Queries

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -325,29 +325,42 @@ const SceneGraphInspector<T>& SceneGraph<T>::model_inspector() const {
 }
 
 template <typename T>
+CollisionFilterManager SceneGraph<T>::collision_filter_manager() {
+  return model_.collision_filter_manager();;
+}
+
+template <typename T>
+CollisionFilterManager SceneGraph<T>::collision_filter_manager(
+    Context<T>* context) const {
+  return mutable_geometry_state(context).collision_filter_manager();
+}
+
+template <typename T>
 void SceneGraph<T>::ExcludeCollisionsWithin(const GeometrySet& geometry_set) {
-  model_.ExcludeCollisionsWithin(geometry_set);
+  collision_filter_manager().Apply(
+      CollisionFilterDeclaration().ExcludeWithin(geometry_set));
 }
 
 template <typename T>
 void SceneGraph<T>::ExcludeCollisionsWithin(
     Context<T>* context, const GeometrySet& geometry_set) const {
-  auto& g_state = mutable_geometry_state(context);
-  g_state.ExcludeCollisionsWithin(geometry_set);
+  collision_filter_manager(context).Apply(
+      CollisionFilterDeclaration().ExcludeWithin(geometry_set));
 }
 
 template <typename T>
 void SceneGraph<T>::ExcludeCollisionsBetween(const GeometrySet& setA,
                                              const GeometrySet& setB) {
-  model_.ExcludeCollisionsBetween(setA, setB);
+  collision_filter_manager().Apply(
+      CollisionFilterDeclaration().ExcludeBetween(setA, setB));
 }
 
 template <typename T>
 void SceneGraph<T>::ExcludeCollisionsBetween(Context<T>* context,
                                              const GeometrySet& setA,
                                              const GeometrySet& setB) const {
-  auto& g_state = mutable_geometry_state(context);
-  g_state.ExcludeCollisionsBetween(setA, setB);
+  collision_filter_manager(context).Apply(
+      CollisionFilterDeclaration().ExcludeBetween(setA, setB));
 }
 
 template <typename T>

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "drake/common/drake_deprecated.h"
+#include "drake/geometry/collision_filter_manager.h"
 #include "drake/geometry/geometry_set.h"
 #include "drake/geometry/geometry_state.h"
 #include "drake/geometry/query_object.h"
@@ -214,6 +215,9 @@ class QueryObject;
  <!-- TODO(SeanCurtis-TRI): Add context-modifying variants of all methods. -->
 
 @section  scene_graph_versioning Detecting changes
+
+ <!-- TODO(SeanCurtis-TRI) All references to APIs that modify versions should
+  have cross links back to this section.  -->
 
  The geometry data associated with %SceneGraph is coarsely versioned. Consumers
  of the geometry can query for the version of the data and recognize if the
@@ -799,9 +803,44 @@ class SceneGraph final : public systems::LeafSystem<T> {
   const SceneGraphInspector<T>& model_inspector() const;
 
   /** @name         Collision filtering
+   @anchor scene_graph_collision_filter_manager
+
+   Control over "collision filtering" is handled by the CollisionFilterManager.
+   %SceneGraph provides access to the manager. As with other geometry data,
+   collision filters can be configured in %SceneGraph's *model* or in the copy
+   stored in a particular Context. These methods provide access to the manager
+   for the data stored in either location.
+
+   Generally, it should be considered a bad practice to hang onto the instance
+   of CollisionFilterManager returned by collision_filter_manager(). It is not
+   immediately clear whether a particular CollisionFilterManager instance
+   refers to the %SceneGraph model or the Context data and persisting the
+   reference may lead to confusion. Keeping the reference for the duration of
+   a function is appropriate, but allowing it to persist outside of the scope
+   of acquisition is dangerous. Acquiring a new CollisionFilterManager is *very*
+   cheap, so feel free to discard and reacquire.
+
+   Simply acquiring an instance of CollisionFilterManager will advance the
+   @ref scene_graph_versioning "proximity version" for the related geometry
+   data (model or context).  */
+  //@{
+
+  /** Returns the collision filter manager for this %SceneGraph instance's
+   *model*. */
+  CollisionFilterManager collision_filter_manager();
+
+  /** Returns the collision filter manager for data stored in `context`. The
+   context must remain alive for at least as long as the returned manager.  */
+  CollisionFilterManager collision_filter_manager(
+      systems::Context<T>* context) const;
+  //@}
+
+  /** @name         Collision filtering (Legacy)
    @anchor scene_graph_collision_filtering
-   The interface for limiting the scope of penetration queries (i.e., "filtering
-   collisions").
+   The *legacy* interface for limiting the scope of penetration queries (i.e.,
+   "filtering collisions").
+
+   Please use the @ref scene_graph_collision_filter_manager "new API" instead.
 
    The scene graph consists of the set of geometry
    `G = D ⋃ A = {g₀, g₁, ..., gₙ}`, where D is the set of dynamic geometry and

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -165,11 +165,13 @@ class SceneGraphInspector {
   }
 
   /** Returns all pairs of geometries that are candidates for collision (in no
-   particular order). See SceneGraph::ExcludeCollisionsBetween() or
-   SceneGraph::ExcludeCollisionsWithin() for information on why a particular
-   pair may _not_ be a candidate. For candidate pair (A, B), the candidate is
-   always guaranteed to be reported in a fixed order (i.e., always (A, B) and
-   _never_ (B, A)). This is the same ordering as would be returned by, e.g.,
+   particular order). See CollisionFilterDeclaration and
+   CollisionFilterManager::Apply() for information on why a particular pair may
+   _not_ be a candidate.
+
+   For candidate pair (A, B), the candidate is always guaranteed to be reported
+   in a fixed order (i.e., always (A, B) and _never_ (B, A)). This is the same
+   ordering as would be returned by, e.g.,
    QueryObject::ComputePointPairPenetration().  */
   std::set<std::pair<GeometryId, GeometryId>> GetCollisionCandidates()
       const {

--- a/geometry/test/collision_filter_manager_test.cc
+++ b/geometry/test/collision_filter_manager_test.cc
@@ -1,0 +1,182 @@
+#include "drake/geometry/collision_filter_manager.h"
+
+#include <array>
+#include <memory>
+#include <utility>
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_no_throw.h"
+#include "drake/geometry/geometry_frame.h"
+#include "drake/geometry/geometry_instance.h"
+#include "drake/geometry/geometry_properties.h"
+#include "drake/geometry/query_object.h"
+#include "drake/geometry/scene_graph.h"
+#include "drake/geometry/scene_graph_inspector.h"
+#include "drake/geometry/shape_specification.h"
+#include "drake/math/rigid_transform.h"
+
+namespace drake {
+namespace geometry {
+namespace {
+
+using math::RigidTransformd;
+using std::array;
+using std::make_unique;
+using std::move;
+using std::unique_ptr;
+
+// Convenience function for making a geometry instance.
+unique_ptr<GeometryInstance> make_sphere_instance(double radius = 1.0) {
+  return make_unique<GeometryInstance>(RigidTransformd::Identity(),
+                                       make_unique<Sphere>(radius), "sphere");
+}
+
+/* Populates the given SceneGraph with three spheres with the proximity role
+ assigned. Their poses are undefined. Each sphere is affixed to a unique dynamic
+ frame. No collision filters are added.
+
+ @returns An array of GeometryIds, one for each added sphere. */
+array<GeometryId, 3> PopulateSceneGraph(SceneGraph<double>* scene_graph_ptr) {
+  DRAKE_DEMAND(scene_graph_ptr != nullptr);
+  SceneGraph<double>& scene_graph = *scene_graph_ptr;
+
+  array<GeometryId, 3> ids;
+
+  SourceId source_id = scene_graph.RegisterSource("source");
+  for (int i = 0; i < 3; ++i) {
+    const FrameId f_id = scene_graph.RegisterFrame(
+        source_id, GeometryFrame(fmt::format("frame_{}", i)));
+    const GeometryId g_id =
+        scene_graph.RegisterGeometry(source_id, f_id, make_sphere_instance());
+    scene_graph.AssignRole(source_id, g_id, ProximityProperties());
+    ids[i] = g_id;
+  }
+
+  // Confirm that the model reports no filtered pairs.
+  const auto& model_inspector = scene_graph.model_inspector();
+  if (model_inspector.CollisionFiltered(ids[0], ids[1]) ||
+      model_inspector.CollisionFiltered(ids[0], ids[2]) ||
+      model_inspector.CollisionFiltered(ids[1], ids[2])) {
+    throw std::runtime_error(
+        "Initial conditions erroneously has filtered pairs");
+  }
+  return ids;
+}
+
+/* In this test we simply apply a single declaration. We don't worry about the
+ various declaration statement types, because that is the responsibility of
+ the CollisionFilter class. This just makes sure it gets exercised. */
+GTEST_TEST(CollisionFilterManagerTest, Apply) {
+  // Initializes the scene graph and context with three geometries and no
+  // filtered pairs.
+  SceneGraph<double> scene_graph;
+  const auto [g_id1, g_id2, g_id3] = PopulateSceneGraph(&scene_graph);
+  auto context = scene_graph.CreateDefaultContext();
+
+  // Acquire an inspector for the context geometry data. It has a "live"
+  // connection to the data. So, as we change the data below, we can use the
+  // same inspector to view the changes.
+  const QueryObject<double>& query_object =
+      scene_graph.get_query_output_port().Eval<QueryObject<double>>(*context);
+  const auto& inspector = query_object.inspector();
+
+  // Confirm unfiltered state was copied into the context..
+  EXPECT_FALSE(inspector.CollisionFiltered(g_id1, g_id2));
+  EXPECT_FALSE(inspector.CollisionFiltered(g_id1, g_id3));
+  EXPECT_FALSE(inspector.CollisionFiltered(g_id2, g_id3));
+
+  auto filter_manager = scene_graph.collision_filter_manager(context.get());
+
+  filter_manager.Apply(
+      CollisionFilterDeclaration().ExcludeWithin(GeometrySet({g_id1, g_id2})));
+  EXPECT_TRUE(inspector.CollisionFiltered(g_id1, g_id2));
+  EXPECT_FALSE(inspector.CollisionFiltered(g_id1, g_id3));
+  EXPECT_FALSE(inspector.CollisionFiltered(g_id2, g_id3));
+
+  // Note that the underlying model *didn't* change.
+  const auto& model_inspector = scene_graph.model_inspector();
+  EXPECT_FALSE(model_inspector.CollisionFiltered(g_id1, g_id2));
+  EXPECT_FALSE(model_inspector.CollisionFiltered(g_id1, g_id3));
+  EXPECT_FALSE(model_inspector.CollisionFiltered(g_id2, g_id3));
+}
+
+/* Confirm that the CollisionFilterManager can be copy constructed and assigned
+ as expected. A copied CollisionFilterManager has the same *live* access as the
+ source. */
+GTEST_TEST(CollisionFilterManagerTest, CopySemantics) {
+  // Initializes the scene graph and context with three geometries and no
+  // filtered pairs.
+  SceneGraph<double> scene_graph;
+  const auto [g_id1, g_id2, g_id3] = PopulateSceneGraph(&scene_graph);
+  auto context = scene_graph.CreateDefaultContext();
+
+  // We get inspectors into SceneGraph's model and context's data.
+  const auto& model_inspector = scene_graph.model_inspector();
+  const QueryObject<double>& query_object =
+      scene_graph.get_query_output_port().Eval<QueryObject<double>>(*context);
+  const auto& context_inspector = query_object.inspector();
+  // We're assuming that the model has no collision filters and the context has
+  // successfully copied that trait -- that is explicitly tested in the Apply
+  // test.
+
+  // Copy construct a filter from the model. A modification to the copy should
+  // be visible in the original model_filter but not the context.
+  CollisionFilterManager copy_filter(scene_graph.collision_filter_manager());
+  copy_filter.Apply(
+      CollisionFilterDeclaration().ExcludeWithin(GeometrySet{g_id1, g_id2}));
+  EXPECT_TRUE(model_inspector.CollisionFiltered(g_id1, g_id2));
+  EXPECT_FALSE(context_inspector.CollisionFiltered(g_id1, g_id2));
+
+  // Copy assign the context filter on top of the copy_filter. Now changes will
+  // be visible to the context inspector but not model inspector.
+  copy_filter = scene_graph.collision_filter_manager(context.get());
+  copy_filter.Apply(
+      CollisionFilterDeclaration().ExcludeWithin(GeometrySet{g_id1, g_id3}));
+  EXPECT_FALSE(model_inspector.CollisionFiltered(g_id1, g_id3));
+  EXPECT_TRUE(context_inspector.CollisionFiltered(g_id1, g_id3));
+}
+
+/* Confirm that the CollisionFilterManager can be move constructed and assigned
+ as expected. A moved CollisionFilterManager has the same *live* access as the
+ source. */
+GTEST_TEST(CollisionFilterManagerTest, MoveSemantics) {
+  // Initializes the scene graph and context with three geometries and no
+  // filtered pairs.
+  SceneGraph<double> scene_graph;
+  const auto [g_id1, g_id2, g_id3] = PopulateSceneGraph(&scene_graph);
+  auto context = scene_graph.CreateDefaultContext();
+
+  // We get inspectors into SceneGraph's model and context's data.
+  const auto& model_inspector = scene_graph.model_inspector();
+  const QueryObject<double>& query_object =
+      scene_graph.get_query_output_port().Eval<QueryObject<double>>(*context);
+  const auto& context_inspector = query_object.inspector();
+  // We're assuming that the model has no collision filters and the context has
+  // successfully copied that trait -- that is explicitly tested in the Apply
+  // test.
+
+  // Move construct a filter from the model. A modification to the copy should
+  // be visible in the original model_filter but not the context.
+  CollisionFilterManager model_filter = scene_graph.collision_filter_manager();
+  CollisionFilterManager copy_filter(move(model_filter));
+  copy_filter.Apply(
+      CollisionFilterDeclaration().ExcludeWithin(GeometrySet{g_id1, g_id2}));
+  EXPECT_TRUE(model_inspector.CollisionFiltered(g_id1, g_id2));
+  EXPECT_FALSE(context_inspector.CollisionFiltered(g_id1, g_id2));
+
+  // Move assign the context filter on top of the copy_filter. Now changes will
+  // be visible to the context inspector but not model inspector.
+  CollisionFilterManager context_filter =
+      scene_graph.collision_filter_manager(context.get());
+  copy_filter = move(context_filter);
+  copy_filter.Apply(
+      CollisionFilterDeclaration().ExcludeWithin(GeometrySet{g_id1, g_id3}));
+  EXPECT_FALSE(model_inspector.CollisionFiltered(g_id1, g_id3));
+  EXPECT_TRUE(context_inspector.CollisionFiltered(g_id1, g_id3));
+}
+
+}  // namespace
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -361,7 +361,7 @@ TEST_F(SceneGraphTest, TransmogrifyContext) {
 
 // Tests that exercising the collision filtering logic *after* allocation is
 // allowed.
-TEST_F(SceneGraphTest, PostAllocationCollisionFiltering) {
+TEST_F(SceneGraphTest, PostAllocationCollisionFilteringLegacy) {
   SourceId source_id = scene_graph_.RegisterSource("filter_after_allocation");
   FrameId frame_id =
       scene_graph_.RegisterFrame(source_id, GeometryFrame("dummy"));
@@ -731,7 +731,7 @@ GTEST_TEST(SceneGraphContextModifier, RegisterGeometry) {
       "Referenced geometry \\d+ has not been registered.");
 }
 
-GTEST_TEST(SceneGraphContextModifier, CollisionFilters) {
+GTEST_TEST(SceneGraphContextModifier, CollisionFiltersLegacy) {
   // Initializes the scene graph and context.
   SceneGraph<double> scene_graph;
   // Simple scene with three frames, each with a sphere which, by default


### PR DESCRIPTION
Provides a public-facing API to access the new `CollisionFilter` mechanism.

 - Adds the `CollisionFilterManager` class
   - including python bindings
 - Binds the previously unbound `CollisionFilterDeclaration` (now that there is a public API to consume it).
 - Move some documentation from `CollisionFilterDeclaration` to `CollisionFilterManager`
 - `GeometryState` completely loses its legacy API (`ExcludeCollisionsWithin`and `ExcludeCollisionBetween`). This is *technically* breaking because `GeometryState` is erroneously in the `geometry` namespace. But no one actually accesses the class.
 - `SceneGraph` offers API access to the `CollisionFilterManager`
   - Labels the old API as "legacy".
   - old API expressed in terms of collision filter manager.
 - Documentation that referenced legacy API updated.
   - `SceneGraphInspector`

Relates #15089.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15348)
<!-- Reviewable:end -->
