### PR TITLE
[common] Use [[noreturn]] instead of __attribute__((noreturn))

### DIFF
--- a/common/drake_assert.h
+++ b/common/drake_assert.h
@@ -83,12 +83,11 @@
 namespace drake {
 namespace internal {
 // Abort the program with an error message.
-__attribute__((noreturn)) /* gcc is ok with [[noreturn]]; clang is not. */
-void Abort(const char* condition, const char* func, const char* file, int line);
+[[noreturn]] void Abort(const char* condition, const char* func,
+                        const char* file, int line);
 // Report an assertion failure; will either Abort(...) or throw.
-__attribute__((noreturn)) /* gcc is ok with [[noreturn]]; clang is not. */
-void AssertionFailed(
-    const char* condition, const char* func, const char* file, int line);
+[[noreturn]] void AssertionFailed(const char* condition, const char* func,
+                                  const char* file, int line);
 }  // namespace internal
 namespace assert {
 // Allows for specialization of how to bool-convert Conditions used in

--- a/common/drake_throw.h
+++ b/common/drake_throw.h
@@ -12,8 +12,8 @@
 namespace drake {
 namespace internal {
 // Throw an error message.
-__attribute__((noreturn)) /* gcc is ok with [[noreturn]]; clang is not. */
-void Throw(const char* condition, const char* func, const char* file, int line);
+[[noreturn]] void Throw(const char* condition, const char* func,
+                        const char* file, int line);
 }  // namespace internal
 }  // namespace drake
 


### PR DESCRIPTION
This attribute is already used elsewhere, and it fixes compilation of
these files with MSVC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15351)
<!-- Reviewable:end -->
