### PR TITLE
[math] Add DARE overload that takes Q, R, and N cost matrices

### DIFF
--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -441,8 +441,22 @@ void DoScalarIndependentDefinitions(py::module m) {
       .def("RealContinuousLyapunovEquation", &RealContinuousLyapunovEquation,
           py::arg("A"), py::arg("Q"), doc.RealContinuousLyapunovEquation.doc)
       .def("DiscreteAlgebraicRiccatiEquation",
-          &DiscreteAlgebraicRiccatiEquation, py::arg("A"), py::arg("B"),
-          py::arg("Q"), py::arg("R"), doc.DiscreteAlgebraicRiccatiEquation.doc)
+          py::overload_cast<const Eigen::Ref<const Eigen::MatrixXd>&,
+              const Eigen::Ref<const Eigen::MatrixXd>&,
+              const Eigen::Ref<const Eigen::MatrixXd>&,
+              const Eigen::Ref<const Eigen::MatrixXd>&>(
+              &DiscreteAlgebraicRiccatiEquation),
+          py::arg("A"), py::arg("B"), py::arg("Q"), py::arg("R"),
+          doc.DiscreteAlgebraicRiccatiEquation.doc_4args)
+      .def("DiscreteAlgebraicRiccatiEquation",
+          py::overload_cast<const Eigen::Ref<const Eigen::MatrixXd>&,
+              const Eigen::Ref<const Eigen::MatrixXd>&,
+              const Eigen::Ref<const Eigen::MatrixXd>&,
+              const Eigen::Ref<const Eigen::MatrixXd>&,
+              const Eigen::Ref<const Eigen::MatrixXd>&>(
+              &DiscreteAlgebraicRiccatiEquation),
+          py::arg("A"), py::arg("B"), py::arg("Q"), py::arg("R"), py::arg("N"),
+          doc.DiscreteAlgebraicRiccatiEquation.doc_5args)
       .def("RealDiscreteLyapunovEquation", &RealDiscreteLyapunovEquation,
           py::arg("A"), py::arg("Q"), doc.RealDiscreteLyapunovEquation.doc);
 

--- a/math/discrete_algebraic_riccati_equation.cc
+++ b/math/discrete_algebraic_riccati_equation.cc
@@ -379,9 +379,8 @@ void reorder_eigen(Eigen::Ref<Eigen::MatrixXd> S, Eigen::Ref<Eigen::MatrixXd> T,
  * DiscreteAlgebraicRiccatiEquation function
  * computes the unique stabilizing solution X to the discrete-time algebraic
  * Riccati equation:
- * \f[
- * A'XA - X - A'XB(B'XB+R)^{-1}B'XA + Q = 0
- * \f]
+ *
+ * AᵀXA − X − AᵀXB(BᵀXB + R)⁻¹BᵀXA + Q = 0
  *
  * @throws std::exception if Q is not positive semi-definite.
  * @throws std::exception if R is not positive definite.
@@ -393,9 +392,9 @@ void reorder_eigen(Eigen::Ref<Eigen::MatrixXd> S, Eigen::Ref<Eigen::MatrixXd> T,
  *
  * Note: When, for example, n = 100, m = 80, and entries of A, B, Q_half,
  * R_half are sampled from standard normal distributions, where
- * Q = Q_half'*Q_half and similar for R, the absolute error of the solution
- * is 10^{-6}, while the absolute error of the solution computed by Matlab is
- * 10^{-8}.
+ * Q = Q_halfᵀ Q_half and similar for R, the absolute error of the solution
+ * is 10⁻⁶, while the absolute error of the solution computed by Matlab is
+ * 10⁻⁸.
  *
  * TODO(weiqiao.han): I may overwrite the RealQZ function to improve the
  * accuracy, together with more thorough tests.
@@ -451,6 +450,22 @@ Eigen::MatrixXd DiscreteAlgebraicRiccatiEquation(
   Eigen::MatrixXd X = U2 * U1.inverse();
   X = (X + X.adjoint().eval()) / 2.0;
   return X;
+}
+
+Eigen::MatrixXd DiscreteAlgebraicRiccatiEquation(
+    const Eigen::Ref<const Eigen::MatrixXd>& A,
+    const Eigen::Ref<const Eigen::MatrixXd>& B,
+    const Eigen::Ref<const Eigen::MatrixXd>& Q,
+    const Eigen::Ref<const Eigen::MatrixXd>& R,
+    const Eigen::Ref<const Eigen::MatrixXd>& N) {
+    DRAKE_DEMAND(N.rows() == B.rows() && N.cols() == B.cols());
+
+    // This is a change of variables to make the DARE that includes Q, R, and N
+    // cost matrices fit the form of the DARE that includes only Q and R cost
+    // matrices.
+    Eigen::MatrixXd A2 = A - B * R.llt().solve(N.transpose());
+    Eigen::MatrixXd Q2 = Q - N * R.llt().solve(N.transpose());
+    return DiscreteAlgebraicRiccatiEquation(A2, B, Q2, R);
 }
 
 }  // namespace math

--- a/math/discrete_algebraic_riccati_equation.h
+++ b/math/discrete_algebraic_riccati_equation.h
@@ -11,9 +11,7 @@ namespace math {
 /// Computes the unique stabilizing solution X to the discrete-time algebraic
 /// Riccati equation:
 ///
-/// @f[
-/// A'XA - X - A'XB(B'XB+R)^{-1}B'XA + Q = 0
-/// @f]
+/// AᵀXA − X − AᵀXB(BᵀXB + R)⁻¹BᵀXA + Q = 0
 ///
 /// @throws std::exception if Q is not positive semi-definite.
 /// @throws std::exception if R is not positive definite.
@@ -27,6 +25,56 @@ Eigen::MatrixXd DiscreteAlgebraicRiccatiEquation(
     const Eigen::Ref<const Eigen::MatrixXd>& B,
     const Eigen::Ref<const Eigen::MatrixXd>& Q,
     const Eigen::Ref<const Eigen::MatrixXd>& R);
+
+/// Computes the unique stabilizing solution X to the discrete-time algebraic
+/// Riccati equation:
+///
+/// AᵀXA − X − (AᵀXB + N)(BᵀXB + R)⁻¹(BᵀXA + Nᵀ) + Q = 0
+///
+/// This is equivalent to solving the original DARE:
+///
+/// A₂ᵀXA₂ − X − A₂ᵀXB(BᵀXB + R)⁻¹BᵀXA₂ + Q₂ = 0
+///
+/// where A₂ and Q₂ are a change of variables:
+///
+/// A₂ = A − BR⁻¹Nᵀ and Q₂ = Q − NR⁻¹Nᵀ
+///
+/// This overload of the DARE is useful for finding the control law uₖ that
+/// minimizes the following cost function subject to xₖ₊₁ = Axₖ + Buₖ.
+///
+/// @verbatim
+///     ∞ [xₖ]ᵀ[Q  N][xₖ]
+/// J = Σ [uₖ] [Nᵀ R][uₖ] ΔT
+///    k=0
+/// @endverbatim
+///
+/// This is a more general form of the following. The linear-quadratic regulator
+/// is the feedback control law uₖ that minimizes the following cost function
+/// subject to xₖ₊₁ = Axₖ + Buₖ:
+///
+/// @verbatim
+///     ∞
+/// J = Σ (xₖᵀQxₖ + uₖᵀRuₖ) ΔT
+///    k=0
+/// @endverbatim
+///
+/// This can be refactored as:
+///
+/// @verbatim
+///     ∞ [xₖ]ᵀ[Q 0][xₖ]
+/// J = Σ [uₖ] [0 R][uₖ] ΔT
+///    k=0
+/// @endverbatim
+///
+/// @throws std::runtime_error if Q − NR⁻¹Nᵀ is not positive semi-definite.
+/// @throws std::runtime_error if R is not positive definite.
+///
+Eigen::MatrixXd DiscreteAlgebraicRiccatiEquation(
+    const Eigen::Ref<const Eigen::MatrixXd>& A,
+    const Eigen::Ref<const Eigen::MatrixXd>& B,
+    const Eigen::Ref<const Eigen::MatrixXd>& Q,
+    const Eigen::Ref<const Eigen::MatrixXd>& R,
+    const Eigen::Ref<const Eigen::MatrixXd>& N);
 }  // namespace math
 }  // namespace drake
 

--- a/math/test/discrete_algebraic_riccati_equation_test.cc
+++ b/math/test/discrete_algebraic_riccati_equation_test.cc
@@ -24,10 +24,41 @@ void SolveDAREandVerify(const Eigen::Ref<const MatrixXd>& A,
     EXPECT_GE(es.eigenvalues()[i], 0);
   }
   // Check that X is the solution to the discrete time ARE.
-  MatrixXd Y = A.transpose() * X * A - X -
-               A.transpose() * X * B * (B.transpose() * X * B + R).inverse() *
-                   B.transpose() * X * A +
-               Q;
+  // clang-format off
+  MatrixXd Y =
+      A.transpose() * X * A
+      - X
+      - (A.transpose() * X * B * (B.transpose() * X * B + R).inverse()
+        * B.transpose() * X * A)
+      + Q;
+  // clang-format on
+  EXPECT_TRUE(CompareMatrices(Y, MatrixXd::Zero(n, n), 1E-10,
+                              MatrixCompareType::absolute));
+}
+
+void SolveDAREandVerify(const Eigen::Ref<const MatrixXd>& A,
+                        const Eigen::Ref<const MatrixXd>& B,
+                        const Eigen::Ref<const MatrixXd>& Q,
+                        const Eigen::Ref<const MatrixXd>& R,
+                        const Eigen::Ref<const MatrixXd>& N) {
+  MatrixXd X = DiscreteAlgebraicRiccatiEquation(A, B, Q, R, N);
+  // Check that X is positive semi-definite.
+  EXPECT_TRUE(
+      CompareMatrices(X, X.transpose(), 1E-10, MatrixCompareType::absolute));
+  int n = X.rows();
+  Eigen::SelfAdjointEigenSolver<MatrixXd> es(X);
+  for (int i = 0; i < n; i++) {
+    EXPECT_GE(es.eigenvalues()[i], 0);
+  }
+  // Check that X is the solution to the discrete time ARE.
+  // clang-format off
+  MatrixXd Y =
+      A.transpose() * X * A
+      - X
+      - ((A.transpose() * X * B + N) * (B.transpose() * X * B + R).inverse()
+        * (B.transpose() * X * A + N.transpose()))
+      + Q;
+  // clang-format on
   EXPECT_TRUE(CompareMatrices(Y, MatrixXd::Zero(n, n), 1E-10,
                               MatrixCompareType::absolute));
 }
@@ -43,6 +74,12 @@ GTEST_TEST(DARE, SolveDAREandVerify) {
   Q1 << 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
   R1 << 0.25;
   SolveDAREandVerify(A1, B1, Q1, R1);
+
+  MatrixXd Aref1(n1, n1);
+  Aref1 << 0.25, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0;
+  SolveDAREandVerify(A1, B1, (A1 - Aref1).transpose() * Q1 * (A1 - Aref1),
+      B1.transpose() * Q1 * B1 + R1, (A1 - Aref1).transpose() * Q1 * B1);
+
   // Test 2: invertible A
   int n2 = 2, m2 = 1;
   MatrixXd A2(n2, n2), B2(n2, m2), Q2(n2, n2), R2(m2, m2);
@@ -51,6 +88,12 @@ GTEST_TEST(DARE, SolveDAREandVerify) {
   Q2 << 1, 0, 0, 0;
   R2 << 0.3;
   SolveDAREandVerify(A2, B2, Q2, R2);
+
+  MatrixXd Aref2(n2, n2);
+  Aref2 << 0.5, 1, 0, 1;
+  SolveDAREandVerify(A2, B2, (A2 - Aref2).transpose() * Q2 * (A2 - Aref2),
+      B2.transpose() * Q2 * B2 + R2, (A2 - Aref2).transpose() * Q2 * B2);
+
   // Test 3: the first generalized eigenvalue of (S,T) is stable
   int n3 = 2, m3 = 1;
   MatrixXd A3(n3, n3), B3(n3, m3), Q3(n3, n3), R3(m3, m3);
@@ -59,12 +102,21 @@ GTEST_TEST(DARE, SolveDAREandVerify) {
   Q3 << 1, 0, 0, 1;
   R3 << 1;
   SolveDAREandVerify(A3, B3, Q3, R3);
+
+  MatrixXd Aref3(n3, n3);
+  Aref3 << 0, 0.5, 0, 0;
+  SolveDAREandVerify(A3, B3, (A3 - Aref3).transpose() * Q3 * (A3 - Aref3),
+      B3.transpose() * Q3 * B3 + R3, (A3 - Aref3).transpose() * Q3 * B3);
+
   // Test 4: A = B = Q = R = I_2 (2-by-2 identity matrix)
   const Eigen::MatrixXd A4{Eigen::Matrix2d::Identity()};
   const Eigen::MatrixXd B4{Eigen::Matrix2d::Identity()};
   const Eigen::MatrixXd Q4{Eigen::Matrix2d::Identity()};
   const Eigen::MatrixXd R4{Eigen::Matrix2d::Identity()};
   SolveDAREandVerify(A4, B4, Q4, R4);
+
+  const Eigen::MatrixXd N4{Eigen::Matrix2d::Identity()};
+  SolveDAREandVerify(A4, B4, Q4, R4, N4);
 }
 }  // namespace
 }  // namespace math


### PR DESCRIPTION
I've been using this overload to compute the LQR gains for implicit model following (using feedback to make one model behave like another, but without extra states hence "implicit").

The relations `Q_new = (A - A_ref)^T Q (A - A_ref)`, `R_new = B^T Q B + R`, and `N_new = (A - A_ref)^T QB` I used in the tests came from equation (C.9) in appendix C of https://file.tavsys.net/control/controls-engineering-in-frc.pdf. This should probably be documented in the test itself, but I'm not sure what your guidelines are for referencing external works, or if there's some other way you'd like me to do this.

I'm also open to a simpler way of defining the cost matrices, but this was the easiest way I was able to create a set of matrices that led to a positive semidefinite DARE solution; naively choosing N = 1 for some of the tests with the original A, B, Q, and R violated that invariant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15352)
<!-- Reviewable:end -->
