### PR TITLE
[fem] Reconcile unknown variable and highest order state

### DIFF
--- a/multibody/fixed_fem/dev/BUILD.bazel
+++ b/multibody/fixed_fem/dev/BUILD.bazel
@@ -314,7 +314,6 @@ drake_cc_library(
         ":fem_indexes",
         ":fem_model_base",
         ":fem_state",
-        ":state_updater",
         "//common:essential",
         "//common:unused",
     ],
@@ -331,6 +330,7 @@ drake_cc_library(
     deps = [
         ":dirichlet_boundary_condition",
         ":fem_state_base",
+        ":state_updater",
         "//common:default_scalars",
         "//common:essential",
     ],

--- a/multibody/fixed_fem/dev/dynamic_elasticity_model.h
+++ b/multibody/fixed_fem/dev/dynamic_elasticity_model.h
@@ -34,8 +34,7 @@ class DynamicElasticityModel : public ElasticityModel<Element> {
    */
   explicit DynamicElasticityModel(double dt)
       : ElasticityModel<Element>(
-            std::make_unique<NewmarkScheme<FemState<Element>>>(dt, 0.5, 0.25)) {
-  }
+            std::make_unique<internal::NewmarkScheme<T>>(dt, 0.5, 0.25)) {}
 
   ~DynamicElasticityModel() = default;
 

--- a/multibody/fixed_fem/dev/elasticity_model.h
+++ b/multibody/fixed_fem/dev/elasticity_model.h
@@ -119,7 +119,7 @@ class ElasticityModel : public FemModel<Element> {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ElasticityModel);
 
   explicit ElasticityModel(
-      std::unique_ptr<StateUpdater<FemState<Element>>> state_updater)
+      std::unique_ptr<internal::StateUpdater<T>> state_updater)
       : FemModel<Element>(std::move(state_updater)) {}
 
   virtual ~ElasticityModel() = default;

--- a/multibody/fixed_fem/dev/fem_model.h
+++ b/multibody/fixed_fem/dev/fem_model.h
@@ -15,7 +15,6 @@
 #include "drake/multibody/fixed_fem/dev/fem_indexes.h"
 #include "drake/multibody/fixed_fem/dev/fem_model_base.h"
 #include "drake/multibody/fixed_fem/dev/fem_state.h"
-#include "drake/multibody/fixed_fem/dev/state_updater.h"
 
 namespace drake {
 namespace multibody {
@@ -62,9 +61,8 @@ class FemModel : public FemModelBase<typename Element::Traits::T> {
  protected:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FemModel);
 
-  explicit FemModel(
-      std::unique_ptr<StateUpdater<FemState<Element>>> state_updater)
-      : state_updater_(std::move(state_updater)) {}
+  explicit FemModel(std::unique_ptr<internal::StateUpdater<T>> state_updater)
+      : FemModelBase<T>(std::move(state_updater)) {}
 
   virtual ~FemModel() = default;
 
@@ -167,7 +165,7 @@ class FemModel : public FemModelBase<typename Element::Traits::T> {
     /* Scratch space to store the contribution to the tangent matrix from each
      element. */
     Eigen::Matrix<T, kNumDofs, kNumDofs> element_tangent_matrix;
-    const Vector3<T>& weights = state_updater_->weights();
+    const Vector3<T>& weights = this->state_updater().weights();
     for (ElementIndex e(0); e < num_elements(); ++e) {
       element_tangent_matrix = CalcElementTangentMatrix(state, weights, e);
       const std::array<NodeIndex, kNumNodes>& element_node_indices =
@@ -272,27 +270,6 @@ class FemModel : public FemModelBase<typename Element::Traits::T> {
            weights[2] * mass_matrix;
   }
 
-  /* Implements FemModelBase::DoUpdateStateFromChangeInUnknowns(). */
-  void DoUpdateStateFromChangeInUnknowns(const VectorX<T>& dz,
-                                         FemStateBase<T>* state) const final {
-    FemState<Element>& mutable_concrete_state =
-        cast_to_mutable_concrete_state(state);
-    state_updater_->UpdateStateFromChangeInUnknowns(dz,
-                                                    &mutable_concrete_state);
-  }
-
-  /* Implements FemModelBase::DoAdvanceOneTimeStep(). */
-  void DoAdvanceOneTimeStep(const FemStateBase<T>& prev_state,
-                            const VectorX<T>& highest_order_state,
-                            FemStateBase<T>* next_state) const final {
-    FemState<Element>& next_state_concrete =
-        cast_to_mutable_concrete_state(next_state);
-    const FemState<Element>& prev_state_concrete =
-        cast_to_concrete_state(prev_state);
-    state_updater_->AdvanceOneTimeStep(prev_state_concrete, highest_order_state,
-                                       &next_state_concrete);
-  }
-
   /* Statically cast the given FemStateBase to the FemState compatible
    with `this` FemModel.
    @pre The given `abstract_state` is compatible with the `this` FemModel. */
@@ -333,8 +310,6 @@ class FemModel : public FemModelBase<typename Element::Traits::T> {
 
   /* FemElements owned by this model. */
   std::vector<Element> elements_{};
-  /* The StateUpdater that updates the states for this model. */
-  std::unique_ptr<StateUpdater<FemState<Element>>> state_updater_;
 };
 }  // namespace fem
 }  // namespace multibody

--- a/multibody/fixed_fem/dev/fem_model_base.cc
+++ b/multibody/fixed_fem/dev/fem_model_base.cc
@@ -41,25 +41,32 @@ void FemModelBase<T>::SetTangentMatrixSparsityPattern(
 }
 
 template <typename T>
+const VectorX<T>& FemModelBase<T>::GetUnknowns(
+    const FemStateBase<T>& state) const {
+  ThrowIfModelStateIncompatible(__func__, state);
+  return state_updater_->GetUnknowns(state);
+}
+
+template <typename T>
 void FemModelBase<T>::UpdateStateFromChangeInUnknowns(
     const VectorX<T>& dz, FemStateBase<T>* state) const {
   DRAKE_DEMAND(state != nullptr);
   DRAKE_DEMAND(dz.size() == state->num_generalized_positions());
   ThrowIfModelStateIncompatible(__func__, *state);
-  DoUpdateStateFromChangeInUnknowns(dz, state);
+  state_updater_->UpdateStateFromChangeInUnknowns(dz, state);
 }
 
 template <typename T>
 void FemModelBase<T>::AdvanceOneTimeStep(const FemStateBase<T>& prev_state,
-                                         const VectorX<T>& highest_order_state,
+                                         const VectorX<T>& unknown_variable,
                                          FemStateBase<T>* next_state) const {
   DRAKE_DEMAND(next_state != nullptr);
-  DRAKE_DEMAND(highest_order_state.size() ==
+  DRAKE_DEMAND(unknown_variable.size() ==
                next_state->num_generalized_positions());
   DRAKE_THROW_UNLESS(ode_order() > 0);
   ThrowIfModelStateIncompatible(__func__, prev_state);
   ThrowIfModelStateIncompatible(__func__, *next_state);
-  DoAdvanceOneTimeStep(prev_state, highest_order_state, next_state);
+  state_updater_->AdvanceOneTimeStep(prev_state, unknown_variable, next_state);
 }
 
 template <typename T>

--- a/multibody/fixed_fem/dev/fem_model_base.h
+++ b/multibody/fixed_fem/dev/fem_model_base.h
@@ -10,12 +10,13 @@
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/fixed_fem/dev/dirichlet_boundary_condition.h"
 #include "drake/multibody/fixed_fem/dev/fem_state_base.h"
+#include "drake/multibody/fixed_fem/dev/state_updater.h"
 
 namespace drake {
 namespace multibody {
 namespace fem {
 
-/** %FemModel calculates the components of the discretized FEM equations.
+/** %FemModelBase calculates the components of the discretized FEM equations.
  Suppose the PDE at hand is of the form
 
      F(z, ∇z, ...) = 0.
@@ -42,16 +43,15 @@ namespace fem {
  z₂, ..., zₙ are solved for with a linear or nonlinear solver, and the solution
  z is interpolated from these nodal values.
 
- %FemModel calculates various components of the system of linear or nonlinear
- equations that supports solving the system. For example, CalcResidual()
- calculates the value of G evaluated at the current state and
- CalcTangentMatrix() calculates ∇G at the current state.
- @tparam_nonsymbolic_scalar T. */
+ %FemModelBase calculates various components of the system of linear or
+ nonlinear equations that supports solving the system. For example,
+ CalcResidual() calculates the value of G evaluated at the given state and
+ CalcTangentMatrix() calculates ∇G at the given state.
+ @tparam_nonsymbolic_scalar. */
 template <typename T>
 class FemModelBase {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FemModelBase);
-  FemModelBase() = default;
   virtual ~FemModelBase() = default;
 
   /** The order of the ODE problem associated with `this` %FemModel. */
@@ -98,13 +98,18 @@ class FemModelBase {
   void CalcTangentMatrix(const FemStateBase<T>& state,
                          Eigen::SparseMatrix<T>* tangent_matrix) const;
 
-  /** Sets the sparsity pattern for the tangent matrix of this %FemModel.
-   @param[out] tangent_matrix    The tangent matrix of this %FemModel. Its size
-   and sparsity pattern will be set so that it will be ready to be passed into
-   CalcTangentMatrix().
+  /** Sets the sparsity pattern for the tangent matrix of this %FemModelBase.
+   @param[out] tangent_matrix    The tangent matrix of this %FemModelBase. Its
+   size and sparsity pattern will be set so that it will be ready to be passed
+   into CalcTangentMatrix().
    @pre `tangent_matrix` must not be the null pointer. */
   void SetTangentMatrixSparsityPattern(
       Eigen::SparseMatrix<T>* tangent_matrix) const;
+
+  /** Extracts the unknown variable from the given FEM `state`.
+   @throw std::exception if the type of concrete FemState for `state` is not
+   compatible with the concrete FemModel for `this` model. */
+  const VectorX<T>& GetUnknowns(const FemStateBase<T>& state) const;
 
   /** Updates the FemStateBase `state` given the change in the unknown variable
    `dz`.
@@ -115,26 +120,26 @@ class FemModelBase {
   void UpdateStateFromChangeInUnknowns(const VectorX<T>& dz,
                                        FemStateBase<T>* state) const;
 
-  /** For a dynamic FEM model, calculates the state at the next time step given
-   the state at the previous time step and the highest order state at the next
-   time step. If `this` %FemModel is static (ode_order() == 0), throw an
-   exception.
+  /** For a dynamic FEM model, calculates the state at the next time step
+   given the state at the previous time step and the unknown variable. If
+   `this` %FemModelBase is static (ode_order() == 0), throw an exception.
    @param[in] prev_state The state at the previous time step.
-   @param[in] highest_order_state The highest order state at the next time step.
+   @param[in] unknown_variable The unknown variable of the FEM model.
    @param[out] next_state The state at the next time step.
    @pre next_state != nullptr.
    @pre next_state->num_generalized_positions() ==
    prev_state.num_generalized_positions().
-   @pre next_state->num_generalized_positions() == highest_order_state.size().
+   @pre next_state->num_generalized_positions() == unknown_variable.size().
    @throw std::exception if the type of concrete FemState in `prev_state` or
-   `next_state` is not compatible with the concrete FemModel in `this` model.
+   `next_state` is not compatible with the concrete FemModel in `this`
+   model.
    @throw std::exception if ode_order() == 0. */
   void AdvanceOneTimeStep(const FemStateBase<T>& prev_state,
-                          const VectorX<T>& highest_order_state,
+                          const VectorX<T>& unknown_variable,
                           FemStateBase<T>* next_state) const;
 
-  /* Apply boundary condition set for this %FemModel to the input `state`. No-op
-   if no boundary condition is set.
+  /* Apply boundary condition set for this %FemModelBase to the input `state`.
+   No-op if no boundary condition is set.
    @pre state != nullptr. */
   void ApplyBoundaryCondition(FemStateBase<T>* state) const;
 
@@ -152,6 +157,10 @@ class FemModelBase {
       const char* func, const FemStateBase<T>& state_base) const = 0;
 
  protected:
+  explicit FemModelBase(
+      std::unique_ptr<internal::StateUpdater<T>> state_updater)
+      : state_updater_(std::move(state_updater)) {}
+
   /** Derived classes must override this method to provide an implementation for
     the NVI MakeFemStateBase(). */
   virtual std::unique_ptr<FemStateBase<T>> DoMakeFemStateBase() const = 0;
@@ -174,27 +183,21 @@ class FemModelBase {
   virtual void DoSetTangentMatrixSparsityPattern(
       Eigen::SparseMatrix<T>* tangent_matrix) const = 0;
 
-  /** Derived classes must override this method to provide an implementation for
-   the NVI UpdateStateFromChangeInUnknowns(). The input `state` is
-   guaranteed to be compatible with `this` FEM model. */
-  virtual void DoUpdateStateFromChangeInUnknowns(
-      const VectorX<T>& dz, FemStateBase<T>* state) const = 0;
-
-  /** Derived classes must override this method to provide an implementation for
-   the NVI AdvanceOneTimeStep(). The input `prev_state` and `next_state` are
-   guaranteed to be compatible with `this` FEM model. The size of `prev_state`,
-   `highest_order_state`, and `next_state` are guaranteed to be compatible. */
-  virtual void DoAdvanceOneTimeStep(const FemStateBase<T>& prev_state,
-                                    const VectorX<T>& highest_order_state,
-                                    FemStateBase<T>* next_state) const = 0;
-
+  /** Derived classes must invoke this method to update the number of nodes in
+   the model when they add more nodes to the FEM model. */
   void increment_num_nodes(int num_new_nodes) { num_nodes_ += num_new_nodes; }
+
+  const internal::StateUpdater<T>& state_updater() const {
+    return *state_updater_;
+  }
 
  private:
   /* The total number of nodes in the system. */
   int num_nodes_{0};
   /* The Dirichlet boundary condition imposed on the model. */
   std::unique_ptr<DirichletBoundaryCondition<T>> dirichlet_bc_;
+  /* The StateUpdater that updates the states for this model. */
+  std::unique_ptr<internal::StateUpdater<T>> state_updater_;
 };
 }  // namespace fem
 }  // namespace multibody

--- a/multibody/fixed_fem/dev/fem_solver.h
+++ b/multibody/fixed_fem/dev/fem_solver.h
@@ -14,14 +14,13 @@ namespace drake {
 namespace multibody {
 namespace fem {
 // TODO(xuchenhan-tri): Move the implementation of this class to a .cc file.
-/** %FemSolver solves for the state of a given FemModel at which residual of the
- model is sufficiently close to zero. %FemSolver uses a simple Newton-Raphson
- solver to solve for the zero residual state. A common workflow for solving a
- static FEM model looks like:
+/** %FemSolver solves for the state of a given FemModel at which the residual of
+ the model is sufficiently close to zero. %FemSolver uses a simple
+ Newton-Raphson solver to solve for the zero residual state. A common workflow
+ for solving a static FEM model looks like:
  ```
- // Creates a solver for a given FemModel and sets the LinearSystemSolver used
- // in the Newton-Raphson iterations.
- FemSolver solver(&model));
+ // Creates a solver for the given FemModel.
+ FemSolver<double> solver(&model));
  // Optionally, sets the tolerances under which we deem the residual is
  // effectively zero.
  solver.set_absolute_tolerance(kAbsoluteTolereance);
@@ -38,7 +37,8 @@ class FemSolver {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FemSolver);
 
   // TODO(xuchenhan-tri): Consider allowing users to configure the linear
-  //  solver.
+  //  solver or at the very least, note that solver will not converge if the
+  //  tangent matrices that show up in the Newton iterations are not SPD.
   /** Constructs a new %FemSolver with the given FemModelBase and an Eigen
    Conjugate Gradient solver as the linear solver. The `model` pointer persists
    in `this` %FemSolver and thus the FemModelBase object must outlive `this`
@@ -51,8 +51,8 @@ class FemSolver {
         std::make_unique<internal::EigenConjugateGradientSolver<T>>(&A_op_);
   }
 
-  /** For dynamic models, advance the given FEM state from the previous time
-   step to the next time step. If the FEM model owned by `this` solver is
+  /** For dynamic models, advances the given FEM state from the previous time
+   step to the next time step. If the FEM model associated with `this` solver is
    static, throw an exception.
    @param[in] prev_state The state of the FEM model evaluated at the previous
    time step.
@@ -64,7 +64,7 @@ class FemSolver {
    next_state->num_generalized_positions().
    @throw std::exception if the input `prev_state` or `next_state` is
    incompatible with the FEM model associated with `this` %FemSolver, or if the
-   model is not dynamic (see is_dynamic()). */
+   model is not dynamic (see is_model_dynamic()). */
   void AdvanceOneTimeStep(const FemStateBase<T>& prev_state,
                           FemStateBase<T>* next_state) const {
     DRAKE_DEMAND(next_state != nullptr);
@@ -74,21 +74,23 @@ class FemSolver {
     }
     model_->ThrowIfModelStateIncompatible(__func__, prev_state);
     model_->ThrowIfModelStateIncompatible(__func__, *next_state);
-    /* Grab the initial guess for the highest order state. */
-    const VectorX<T>& highest_order_state =
-        next_state->get_highest_order_state();
-    /* Since `highest_order_state` is only an initial guess, this only produces
-     an *initial guess* that is compatible with the previous time step. */
-    model_->AdvanceOneTimeStep(prev_state, highest_order_state, next_state);
+    /* Grab the initial guess for the unknown variable. */
+    const VectorX<T>& unknown_variable = model_->GetUnknowns(*next_state);
+    model_->AdvanceOneTimeStep(prev_state, unknown_variable, next_state);
     SolveWithInitialGuess(next_state);
   }
 
-  /** For static models, solve for the state at equilibrium given the initial
-   guess. If the FEM model owned by the solver is dynamic, throw an exception.
+  // TODO(xuchenhan-tri): Consider making FemSolver only a Newton-Raphson
+  //  solver. In other words, make it ignorant of what kind of model it is
+  //  solving for and provide a single method that takes an initial guess and
+  //  returns the zero-residual state.
+  /** For static models, solves for the state at equilibrium given the initial
+   guess. If the FEM model associated with `this` solver is dynamic, throw an
+   exception.
    @pre next_state != nullptr.
    @throw std::exception if the input `state` is incompatible with the FEM model
    associated with `this` %FemSolver, or if the model is dynamic (see
-   is_dynamic()). */
+   is_model_dynamic()). */
   void SolveStaticModelWithInitialGuess(FemStateBase<T>* state) const {
     DRAKE_DEMAND(state != nullptr);
     if (is_model_dynamic()) {
@@ -96,7 +98,6 @@ class FemSolver {
           fmt::format("{}() can only be called on a static model!", __func__));
     }
     model_->ThrowIfModelStateIncompatible(__func__, *state);
-    /* Throw if mode is *not* static. */
     SolveWithInitialGuess(state);
   }
 
@@ -104,7 +105,7 @@ class FemSolver {
    than 0. Returns false otherwise. */
   bool is_model_dynamic() const { return model_->ode_order() > 0; }
 
-  /** Returns the FemModel that this solver owns. */
+  /** Returns the FemModel that this solver is solving. */
   const FemModelBase<T>& model() const { return *model_; }
 
   /** Sets the relative tolerance, unitless. The Newton-Raphson iterations are
@@ -158,9 +159,9 @@ class FemSolver {
       model_->UpdateStateFromChangeInUnknowns(dz_, state);
       model_->CalcResidual(*state, &b_);
       ++iter;
-    } while (dz_.norm() >
-                 std::max(relative_tolerance_ * state->HighestOrderStateNorm(),
-                          absolute_tolerance_) &&
+    } while (dz_.norm() > std::max(relative_tolerance_ *
+                                       model_->GetUnknowns(*state).norm(),
+                                   absolute_tolerance_) &&
              iter < kMaxIterations_);
     if (iter == kMaxIterations_) {
       // TODO(xuchenhan-tri): Provide some advice on how to get a "better
@@ -199,7 +200,7 @@ class FemSolver {
    solver, unitless. */
   T relative_tolerance_{1e-6};
   /* The absolute tolerance for determining the convergence of the Newton
-   solver. It has the same unit as the highest order state. */
+   solver. It has the same unit as the unknown variable z. */
   T absolute_tolerance_{1e-6};
   // TODO(xuchenhan-tri): Consider making `kMaxIterations_` configurable.
   /* Any reasonable Newton solve should converge within 20 iterations. If it

--- a/multibody/fixed_fem/dev/fem_state_base.h
+++ b/multibody/fixed_fem/dev/fem_state_base.h
@@ -50,20 +50,6 @@ class FemStateBase {
   void SetQddot(const Eigen::Ref<const VectorX<T>>& value);
   /** @} */
 
-  // TODO(xuchenhan-tri): Change the API to calculate the norm of the unknown
-  //  instead.
-  /** Calculates the norm of the state with the highest order. */
-  T HighestOrderStateNorm() const { return get_highest_order_state().norm(); }
-
-  // TODO(xuchenhan-tri): Change the API to get the the unknown state
-  //  instead.
-  const VectorX<T>& get_highest_order_state() const {
-    if (ode_order() == 0) return q_;
-    if (ode_order() == 1) return qdot_;
-    if (ode_order() == 2) return qddot_;
-    DRAKE_UNREACHABLE();
-  }
-
   int num_generalized_positions() const { return q_.size(); }
 
   /** The order of the ODE problem after FEM spatial discretization. */

--- a/multibody/fixed_fem/dev/newmark_scheme.h
+++ b/multibody/fixed_fem/dev/newmark_scheme.h
@@ -5,7 +5,8 @@
 namespace drake {
 namespace multibody {
 namespace fem {
-/** Implements the interface StateUpdater with Newmark-beta time integration
+namespace internal {
+/* Implements the interface StateUpdater with Newmark-beta time integration
  scheme. Given the value for the current time step acceleration `a`, the states
  are calculated from states from the previous time step according to the
  following equations:
@@ -17,19 +18,13 @@ namespace fem {
 
  [Newmark, 1959] Newmark, Nathan M. "A method of computation for structural
  dynamics." Journal of the engineering mechanics division 85.3 (1959): 67-94.
-
- @tparam State    The type of FemState to be updated by the %NewmarkScheme. The
- template parameter State must be an instantiation of FemState.
- @pre State::ode_order() == 2. */
-template <class State>
-class NewmarkScheme final : public StateUpdater<State> {
+ @tparam_nonsymbolic_scalar */
+template <typename T>
+class NewmarkScheme final : public StateUpdater<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(NewmarkScheme);
 
-  static_assert(State::ode_order() == 2);
-  using T = typename State::T;
-
-  /** Construct a Newmark scheme with the provided timestep, `gamma` and `beta`.
+  /* Constructs a Newmark scheme with the provided timestep, `gamma` and `beta`.
    @pre dt > 0.
    @pre 0 <= gamma <= 1.
    @pre 0 <= beta <= 0.5. */
@@ -43,14 +38,16 @@ class NewmarkScheme final : public StateUpdater<State> {
   ~NewmarkScheme() = default;
 
  private:
-  /* Implements StateUpdater::weights(). */
   Vector3<T> do_get_weights() const final {
     return {beta_ * dt_ * dt_, gamma_ * dt_, 1.0};
   }
 
-  /* Implements StateUpdater::DoUpdateStateFromChangeInUnknowns(). */
+  const VectorX<T>& DoGetUnknowns(const FemStateBase<T>& state) const final {
+    return state.qddot();
+  }
+
   void DoUpdateStateFromChangeInUnknowns(const VectorX<T>& dz,
-                                                  State* state) const final {
+                                         FemStateBase<T>* state) const final {
     const VectorX<T>& a = state->qddot();
     const VectorX<T>& v = state->qdot();
     const VectorX<T>& x = state->q();
@@ -59,14 +56,13 @@ class NewmarkScheme final : public StateUpdater<State> {
     state->SetQ(x + dt_ * dt_ * beta_ * dz);
   }
 
-  /* Implements StateUpdater::DoAdvanceOneTimeStep(). */
-  void DoAdvanceOneTimeStep(const State& prev_state,
-                            const VectorX<T>& highest_order_state,
-                            State* state) const final {
+  void DoAdvanceOneTimeStep(const FemStateBase<T>& prev_state,
+                            const VectorX<T>& unknown_variable,
+                            FemStateBase<T>* state) const final {
     const VectorX<T>& an = prev_state.qddot();
     const VectorX<T>& vn = prev_state.qdot();
     const VectorX<T>& xn = prev_state.q();
-    const VectorX<T>& a = highest_order_state;
+    const VectorX<T>& a = unknown_variable;
     state->SetQddot(a);
     state->SetQdot(vn + dt_ * (gamma_ * a + (1.0 - gamma_) * an));
     state->SetQ(xn + dt_ * vn + dt_ * dt_ * (beta_ * a + (0.5 - beta_) * an));
@@ -76,6 +72,7 @@ class NewmarkScheme final : public StateUpdater<State> {
   double gamma_{0.5};
   double beta_{0.25};
 };
+}  // namespace internal
 }  // namespace fem
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/fixed_fem/dev/state_updater.h
+++ b/multibody/fixed_fem/dev/state_updater.h
@@ -6,15 +6,17 @@
 namespace drake {
 namespace multibody {
 namespace fem {
-// TODO(xuchenhan-tri): Template this class on scalar type only so that
-//  FemModelBase can own it.
-/** %StateUpdater provides the interface to update FemState in NewtonSolver.
+namespace internal {
+// TODO(xuchenhan-tri): Try to come up with a better name for this class. It
+//  does more than updating the states. It also defines the discretized equation
+//  that FEM solver solves.
+/* StateUpdater provides the interface to update FemStateBase in FemModelBase.
  In each Newton-Raphson iteration of the FEM solver, we are solving for an
  equation in the form of
 
         G(q, q̇, q̈) = 0.
 
- For different FemModels, G takes different forms. For dynamic elasticity,
+ For different models, G takes different forms. For dynamic elasticity,
 
         G(q, q̇, q̈) = Mq̈ - fₑ(q) - fᵥ(q, q̇) - fₑₓₜ,
 
@@ -28,7 +30,13 @@ namespace fem {
         G(q, q̇, q̈) = G(q) = Kq − f.
 
  With time discretization, one can express `q`, `q̇,` `q̈` in terms of a
- single variable, which we dub the name "key variable" and denote it with `z`.
+ single variable, which we dub the name "unknown" and denote it with `z`.
+ The mapping from `z` to the states takes the affine form
+
+        q̈ = αₐ z + bₐ
+        q̇ = αᵥ z + bᵥ
+        q = αₚ z + bₚ
+
  For example, for dynamic elasticity with Newmark scheme,
 
         q̈ = z;
@@ -44,93 +52,85 @@ namespace fem {
 
         ∇G(z) ⋅ dz = -G(z),
 
- where ∇G = ∂G/∂z. StateUpdater is responsible for updating the FemState given
- the solution of the linear solve, `dz`. In addition, %StateUpdater also
- provides the derivatives of the states with respect to the key variable `z`,
- namely, `∂q/∂z`,  `∂q̇/∂z`, and `∂q̈/∂z`, that are needed for building ∇G.
- @tparam State    The type of FemState to be updated by this %StateUpdater. The
- template parameter State must be an instantiation of FemState. */
-template <class State>
+ where ∇G = ∂G/∂z. StateUpdater is responsible for updating the FEM state given
+ the solution of the linear solve, `dz`, which is also the change in the unknown
+ variables. In addition, StateUpdater also provides the derivatives of the
+ states with respect to the unknown variable `z`, namely, `∂q/∂z`,  `∂q̇/∂z`, and
+ `∂q̈/∂z`, that are needed for building ∇G.
+ @tparam_non_symbolic. */
+template <typename T>
 class StateUpdater {
  public:
-  using T = typename State::T;
-
   virtual ~StateUpdater() = default;
 
-  /** For a representative degree of freedom i, returns the derivative of the
-   state with respect to the key variable `zᵢ`, [∂qᵢ/∂zᵢ, ∂q̇ᵢ/∂zᵢ, ∂q̈ᵢ/∂zᵢ].
-   The choice of i is arbitrary as these derivatives are the same for all
-   degrees of freedom in the same model. These derivatives can be used as
-   weights to combine stiffness, damping and mass matrices to form the tangent
-   matrix. If q̇ or q̈ are not a part of the state, their derivatives are set to
-   0. */
+  /* Returns (αₚ, αᵥ, αₐ) (See class documentation). These weights can be
+   used to combine stiffness, damping and mass matrices (see FemElement) to form
+   the tangent matrix (see FemModelBase). */
   Vector3<T> weights() const { return do_get_weights(); }
 
-  /** Updates the FemState `state` given the change in the unknown variable
-   `dz`.
+  /* Extracts the unknown variable from the given FEM `state`.
+   @throw std::exception if the unknowns variable does not exist in the given
+   `state`. */
+  const VectorX<T>& GetUnknowns(const FemStateBase<T>& state) const {
+    return DoGetUnknowns(state);
+  }
+
+  /* Updates the FemStateBase `state` given the change in the unknown variables.
    @pre state != nullptr.
-   @pre dz.size() == state.num_generalized_positions(). */
+   @pre dz.size() == state->num_generalized_positions(). */
   void UpdateStateFromChangeInUnknowns(const VectorX<T>& dz,
-                                       State* state) const {
+                                       FemStateBase<T>* state) const {
     DRAKE_DEMAND(state != nullptr);
     DRAKE_DEMAND(dz.size() == state->num_generalized_positions());
     DoUpdateStateFromChangeInUnknowns(dz, state);
   }
 
-  // TODO(xuchenhan-tri): Consider passing in more than one previous state when
-  //  we implement multi-step methods. */
-  /** Advance the given `state` by one time step.
-   More specifically, if State::ode_order() > 0, then advance `state` in time
-   using the discrete time stepping scheme by a time step of size `dt` which is
-   stored in the time stepping scheme.
-   If State::ode_order() == 0, throw an exception.
-   @param[in] prev_state The state at the previous time step.
-   @param[in, out] state The state at the current time step. The highest order
-   state will be used as input (and will not be modified by this method). For
-   example, if State::ode_order() == 2, then `state->qddot()` will be used as
-   input (and will not be modified) and `state->q()` and `state->qdot()` will be
-   modified by numerically integrating in time.
-   @pre state != nullptr. */
-  void AdvanceOneTimeStep(const State& prev_state,
-                          const VectorX<T>& highest_order_state,
-                          State* state) const {
-    DRAKE_DEMAND(state != nullptr);
-    DoAdvanceOneTimeStep(prev_state, highest_order_state, state);
+  /* Advances the given `prev_state` by one time step to the `next_state` if the
+   states have nonzero ODE order. No-op otherwise.
+   @param[in]  prev_state        The state at the previous time step.
+   @param[in]  unknown_variable  The unknown variable z.
+   @param[out] next_state        The state at the new time step.
+   @pre next_state != nullptr.
+   @pre The sizes of `prev_state`, `unknown_variable`, and `next_state` are
+   compatible. */
+  void AdvanceOneTimeStep(const FemStateBase<T>& prev_state,
+                          const VectorX<T>& unknown_variable,
+                          FemStateBase<T>* next_state) const {
+    DRAKE_DEMAND(next_state != nullptr);
+    DRAKE_DEMAND(prev_state.num_generalized_positions() ==
+                 next_state->num_generalized_positions());
+    DRAKE_DEMAND(prev_state.num_generalized_positions() ==
+                 unknown_variable.size());
+    DoAdvanceOneTimeStep(prev_state, unknown_variable, next_state);
   }
 
  protected:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(StateUpdater);
   StateUpdater() = default;
 
-  /** Derived classes must override this method to provide an implementation to
-   the method weights(). */
+  /* Derived classes must override this method to provide an implementation. */
   virtual Vector3<T> do_get_weights() const = 0;
 
-  /** Derived classes must override this method to udpate the FemState `state`
-   given the change in the unknown variable `dz` based on the time-stepping
-   scheme of the derived class. The `dz` provided here has compatible size with
-   the number of generalized positions in `state` and does not need to be
-   checked again.  */
-  virtual void DoUpdateStateFromChangeInUnknowns(const VectorX<T>& dz,
-                                                 State* state) const = 0;
+  /* Derived classes must override this method to implement the NVI
+   GetUnknowns(). Refer to GetUnknowns for details. */
+  virtual const VectorX<T>& DoGetUnknowns(
+      const FemStateBase<T>& state) const = 0;
 
-  /** Derived classes templated on FemState whose ode_order() is greater than 0
-   must override this method to advance a single time step according to the
-   specific time stepping scheme. */
-  virtual void DoAdvanceOneTimeStep(const State& prev_state,
-                                    const VectorX<T>& highest_order_state,
-                                    State* state) const {
-    unused(prev_state, highest_order_state, state);
-    if constexpr (State::ode_order() == 0) {
-      throw std::logic_error(
-          "There is no notion of time in a zeroth order ODE.");
-    }
-    throw std::logic_error(
-        "AdvanceOneTimeStep() should be implemented for this StateUpdater but "
-        "is "
-        "not implemented.");
+  /* Derived classes must override this method to implement the NVI
+   UpdateStateFromChangeInUnknowns(). Refer UpdateStateFromChangeInUnknowns()
+   for details. */
+  virtual void DoUpdateStateFromChangeInUnknowns(
+      const VectorX<T>& dz, FemStateBase<T>* state) const = 0;
+
+  /* Implements the NVI AdvanceOneTimeStep(). Refer AdvanceOneTimeStep() for
+   details. */
+  virtual void DoAdvanceOneTimeStep(const FemStateBase<T>& prev_state,
+                                    const VectorX<T>& unknowns,
+                                    FemStateBase<T>* next_state) const {
+    unused(prev_state, unknowns, next_state);
   }
 };
+}  // namespace internal
 }  // namespace fem
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/fixed_fem/dev/static_elasticity_model.h
+++ b/multibody/fixed_fem/dev/static_elasticity_model.h
@@ -27,7 +27,7 @@ class StaticElasticityModel : public ElasticityModel<Element> {
 
   StaticElasticityModel()
       : ElasticityModel<Element>(
-            std::make_unique<ZerothOrderStateUpdater<FemState<Element>>>()) {}
+            std::make_unique<internal::ZerothOrderStateUpdater<T>>()) {}
 
   ~StaticElasticityModel() = default;
 

--- a/multibody/fixed_fem/dev/test/fem_solver_test.cc
+++ b/multibody/fixed_fem/dev/test/fem_solver_test.cc
@@ -14,7 +14,6 @@
 #include "drake/multibody/fixed_fem/dev/static_elasticity_element.h"
 #include "drake/multibody/fixed_fem/dev/static_elasticity_model.h"
 #include "drake/multibody/fixed_fem/dev/test/dummy_element.h"
-#include "drake/multibody/fixed_fem/dev/zeroth_order_state_updater.h"
 
 namespace drake {
 namespace multibody {
@@ -140,7 +139,6 @@ TEST_F(FemSolverTest, StaticForceEquilibrium) {
   const T initial_error = nodal_force.norm();
   model_.SetExplicitExternalForce(nodal_force);
   State state = MakeReferenceState();
-  const ZerothOrderStateUpdater<State> state_updater;
   solver_.SolveStaticModelWithInitialGuess(&state);
   EXPECT_TRUE(CompareMatrices(state.q(), prescribed_state.q(),
                               std::max(kTol, kTol * initial_error)));

--- a/multibody/fixed_fem/dev/test/newmark_scheme_test.cc
+++ b/multibody/fixed_fem/dev/test/newmark_scheme_test.cc
@@ -8,8 +8,9 @@
 namespace drake {
 namespace multibody {
 namespace fem {
-namespace test {
+namespace internal {
 namespace {
+using fem::test::DummyElement;
 const double kDt = 1e-4;
 const double kGamma = 0.2;
 const double kBeta = 0.3;
@@ -28,7 +29,7 @@ class NewmarkSchemeTest : public ::testing::Test {
     return Vector4<double>(0.1011, 0.1112, 0.1213, 0.1314);
   }
 
-  NewmarkScheme<FemState<DummyElement<2>>> newmark_scheme_{kDt, kGamma, kBeta};
+  NewmarkScheme<double> newmark_scheme_{kDt, kGamma, kBeta};
 };
 
 TEST_F(NewmarkSchemeTest, Weights) {
@@ -75,7 +76,7 @@ TEST_F(NewmarkSchemeTest, AdvanceOneTimeStep) {
                       kTimeSteps * kTol));
 }
 }  // namespace
-}  // namespace test
+}  // namespace internal
 }  // namespace fem
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/fixed_fem/dev/test/zeroth_order_state_updater_test.cc
+++ b/multibody/fixed_fem/dev/test/zeroth_order_state_updater_test.cc
@@ -9,11 +9,12 @@
 namespace drake {
 namespace multibody {
 namespace fem {
-namespace test {
+namespace internal {
 namespace {
+using fem::test::DummyElement;
 class ZerothOrderStateUpdaterTest : public ::testing::Test {
  protected:
-  ZerothOrderStateUpdater<FemState<DummyElement<0>>> state_updater;
+  ZerothOrderStateUpdater<double> state_updater;
 };
 
 TEST_F(ZerothOrderStateUpdaterTest, Weights) {
@@ -28,17 +29,8 @@ TEST_F(ZerothOrderStateUpdaterTest, UpdateStateFromChangeInUnknowns) {
   state_updater.UpdateStateFromChangeInUnknowns(dq, &state);
   EXPECT_TRUE(CompareMatrices(state.q(), q + dq, 0));
 }
-
-TEST_F(ZerothOrderStateUpdaterTest, AdvanceOneTimeStep) {
-  const VectorX<double> q = Vector4<double>(1.23, 2.34, 3.45, 4.56);
-  FemState<DummyElement<0>> prev_state(q);
-  FemState<DummyElement<0>> new_state(prev_state);
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      state_updater.AdvanceOneTimeStep(prev_state, q, &new_state),
-      "There is no notion of time in a zeroth order ODE.");
-}
 }  // namespace
-}  // namespace test
+}  // namespace internal
 }  // namespace fem
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/fixed_fem/dev/zeroth_order_state_updater.h
+++ b/multibody/fixed_fem/dev/zeroth_order_state_updater.h
@@ -5,32 +5,31 @@
 namespace drake {
 namespace multibody {
 namespace fem {
-/** Implements the interface StateUpdater with the zeroth-order state updater.
+namespace internal {
+/* Implements the interface StateUpdater with the zeroth-order state updater.
  Namely, q = z and dq = dz.
- @tparam State    The type of FemState to be updated by this %StateUpdater. The
- template parameter State must be an instantiation of FemState.
- @pre State::ode_order() == 0. */
-template <class State>
-class ZerothOrderStateUpdater final : public StateUpdater<State> {
+ @tparam_nonsymbolic_scalar */
+template <typename T>
+class ZerothOrderStateUpdater final : public StateUpdater<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ZerothOrderStateUpdater);
-
-  static_assert(State::ode_order() == 0);
-  using T = typename State::T;
 
   ZerothOrderStateUpdater() = default;
   ~ZerothOrderStateUpdater() = default;
 
  private:
-  /* Implements StateUpdater::weights(). */
   Vector3<T> do_get_weights() const final { return {1, 0, 0}; }
 
-  /* Implements StateUpdater::DoUpdateStateFromChangeInUnknowns(). */
+  const VectorX<T>& DoGetUnknowns(const FemStateBase<T>& state) const final {
+    return state.q();
+  }
+
   void DoUpdateStateFromChangeInUnknowns(const VectorX<T>& dz,
-                                                  State* state) const final {
+                                         FemStateBase<T>* state) const final {
     state->SetQ(state->q() + dz);
   }
 };
+}  // namespace internal
 }  // namespace fem
 }  // namespace multibody
 }  // namespace drake


### PR DESCRIPTION
* Remove all occurance of "highest order state" in favor of "unknown variable" because the unknown variable being solved for in FEM is *not* necessarily the highest order state. Relate RobotLocomotion#15349.
* Template StateUpdater on the scalar type instead of the State type and move it from state-templated FemModel to type-templated FemModelBase.
* Move the method State::get_highest_order_state() to StateUpdater::GetUnknowns() as the FemState by itself cannot determine which variable is the "unknown". That information is held by StateUpdater.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15357)
<!-- Reviewable:end -->
