### PR TITLE
[geometry] Select output format from mesh_half_space_intersection in hydroelastics.

### DIFF
--- a/geometry/proximity/hydroelastic_callback.h
+++ b/geometry/proximity/hydroelastic_callback.h
@@ -110,18 +110,13 @@ std::unique_ptr<ContactSurface<T>> DispatchRigidSoftCalculation(
       // Soft half space with rigid mesh.
       const SurfaceMesh<double>& mesh_R = rigid.mesh();
       const Bvh<Obb, SurfaceMesh<double>>& bvh_R = rigid.bvh();
-
-      // TODO(DamrongGuoy): Pass `representation` parameter (the choice of
-      //  contact polygons) when ComputeContactSurfaceFromSoftHalfSpaceRigidMesh
-      //  supports it.
       return ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
-          id_S, X_WS, soft.pressure_scale(), id_R, mesh_R, bvh_R, X_WR);
+          id_S, X_WS, soft.pressure_scale(), id_R, mesh_R, bvh_R, X_WR,
+          representation);
     } else {
-      // Soft volume vs rigid half space. The half space-mesh intersection
-      // requires the mesh field to be a linear mesh field.
-      const auto& field_S =
-          dynamic_cast<const VolumeMeshFieldLinear<double, double>&>(
-              soft.pressure_field());
+      // Soft volume vs rigid half space.
+      const VolumeMeshFieldLinear<double, double>& field_S =
+          soft.pressure_field();
       const Bvh<Obb, VolumeMesh<double>>& bvh_S = soft.bvh();
       return ComputeContactSurfaceFromSoftVolumeRigidHalfSpace(
           id_S, field_S, bvh_S, X_WS, id_R, X_WR, representation);

--- a/geometry/proximity/mesh_half_space_intersection.h
+++ b/geometry/proximity/mesh_half_space_intersection.h
@@ -8,6 +8,7 @@
 #include "drake/common/sorted_pair.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/proximity/bvh.h"
+#include "drake/geometry/proximity/contact_surface_utility.h"
 #include "drake/geometry/proximity/posed_half_space.h"
 #include "drake/geometry/proximity/surface_mesh.h"
 #include "drake/geometry/query_results/contact_surface.h"
@@ -24,13 +25,21 @@ namespace internal {
  unimportant (see note below).
 
  This function is a component of the larger operation of clipping a
- SurfaceMesh by a half space. When doing that, we don't want to introduce any
- duplicate vertices (beyond those already in the input mesh). This function
- uses bookkeeping to prevent the addition of such duplicate vertices, which can
- be created when either a vertex lies inside/on the half space or when an edge
- intersects the half space. The method tracks these resultant vertices using
- `vertices_to_newly_created_vertices` and `edges_to_newly_created_vertices`,
- respectively.
+ SurfaceMesh by a half space.
+
+ For `representation` = ContactPolygonRepresentation::kCentroidSubdivision,
+ we do not introduce any duplicate vertices (beyond those already in the input
+ mesh). This function uses bookkeeping to prevent the addition of such
+ duplicate vertices, which can be created when either a vertex lies inside/on
+ the half space or when an edge intersects the half space. The method tracks
+ these resultant vertices using `vertices_to_newly_created_vertices` and
+ `edges_to_newly_created_vertices`, respectively.
+
+ For `representation` = ContactPolygonRepresentation::kSingleTriangle, it
+ creates 3 or 4 times fewer triangles than the other choice by representing
+ the intersected polygon (triangle or quadrilateral) as one triangle. However,
+ it allows duplicate vertices and ignores `vertices_to_newly_created_vertices`
+ and `edges_to_newly_created_vertices`.
 
  @param mesh_F
      The surface mesh to intersect, measured and expressed in Frame F.
@@ -41,6 +50,8 @@ namespace internal {
      The half space measured and expressed in Frame F.
  @param X_WF
      The relative pose between Frame F and Frame W.
+ @param[in] representation
+     The preferred representation of the intersected polygon.
  @param[in,out] new_vertices_W
      The accumulator for all of the vertices in the intersecting mesh. It should
      be empty for the first call and will gradually accumulate all of the
@@ -51,13 +62,14 @@ namespace internal {
      empty for the first call and will gradually accumulate all of the faces
      with each subsequent call to this method.
  @param[in,out] vertices_to_newly_created_vertices
-     The accumulated mapping from indices in `vertices_F` to indices in
+     The accumulated mapping from indices in `mesh_F.vertices()` to indices in
      `new_vertices_W`. It should be empty for the first call and will gradually
      accumulate elements with each subsequent call to this method.
  @param[in,out] edges_to_newly_created_vertices
-     The accumulated mapping from pairs of indices in `vertices_F` to indices in
-     `new_vertices_W`. It should be empty for the first call and will gradually
-     accumulate elements with each subsequent call to this method.
+     The accumulated mapping from pairs of indices in `mesh_F.vertices()` to
+     indices in `new_vertices_W`. It should be empty for the first call and
+     will gradually accumulate elements with each subsequent call to this
+     method.
 
  @note Unlike most geometric intersection routines, this method does not
        require the user to provide (or the algorithm to compute) a reasonable
@@ -73,6 +85,7 @@ template <typename T>
 void ConstructTriangleHalfspaceIntersectionPolygon(
     const SurfaceMesh<double>& mesh_F, SurfaceFaceIndex tri_index,
     const PosedHalfSpace<T>& half_space_F, const math::RigidTransform<T>& X_WF,
+    ContactPolygonRepresentation representation,
     std::vector<SurfaceVertex<T>>* new_vertices_W,
     std::vector<SurfaceFace>* new_faces,
     std::unordered_map<SurfaceVertexIndex, SurfaceVertexIndex>*
@@ -85,10 +98,15 @@ void ConstructTriangleHalfspaceIntersectionPolygon(
  triangles drawn from the given surface mesh. The indicated triangles would
  typically be the result of broadphase culling.
 
- Each triangle in `mesh_W` is a proper subset of one triangle in `input_mesh_F`
+ For `representation` = ContactPolygonRepresentation::kCentroidSubdivision,
+ each triangle in `mesh_W` is a proper subset of one triangle in `input_mesh_F`
  (i.e., fully contained within the triangle in `input_mesh_F`). As such,
  the face normal for each triangle in `mesh_W` will point in the same direction
  as its containing triangle in `input_mesh_F`.
+
+ For `representation` = ContactPolygonRepresentation::kSingleTriangle, each
+ triangle in `mesh_W` corresponds to one triangle in `input_mesh_F` that
+ intersects the half space. Their face normals will point in the same direction.
 
  @param input_mesh_F
      The mesh with vertices measured and expressed in some frame, F.
@@ -98,6 +116,8 @@ void ConstructTriangleHalfspaceIntersectionPolygon(
      A collection of triangle indices in `input_mesh_F`.
  @param X_WF
      The relative pose of Frame F with the world frame W.
+ @param[in] representation
+     The preferred representation of each intersected polygon.
  @retval `mesh_W`, the SurfaceMesh corresponding to the intersection between
          the mesh and the half space; the vertices are measured and expressed in
          Frame W. `nullptr` if there is no intersection.
@@ -108,7 +128,8 @@ ConstructSurfaceMeshFromMeshHalfspaceIntersection(
     const SurfaceMesh<double>& input_mesh_F,
     const PosedHalfSpace<T>& half_space_F,
     const std::vector<SurfaceFaceIndex>& tri_indices,
-    const math::RigidTransform<T>& X_WF);
+    const math::RigidTransform<T>& X_WF,
+    ContactPolygonRepresentation representation);
 
 /*
  Computes the ContactSurface formed by a soft half space and the given rigid
@@ -116,7 +137,7 @@ ConstructSurfaceMeshFromMeshHalfspaceIntersection(
 
  The definition of the half space is implicit in the call -- it is the type
  defined by the HalfSpace class, thus, only its id, its pose in a common frame
- (the world frame), and the thickness of the compliant volume is necessary.
+ (the world frame), and the `pressure_scale` is necessary.
 
  @param[in] id_S            The id of the soft half space.
  @param[in] X_WS            The relative pose of Frame S (the soft half space's
@@ -131,6 +152,8 @@ ConstructSurfaceMeshFromMeshHalfspaceIntersection(
                             mesh measured and expressed in Frame R.
  @param[in] X_WR            The relative pose between Frame R -- the frame the
                             mesh is defined in -- and the world frame W.
+ @param[in] representation  The preferred representation of each contact
+                            polygon.
  @returns `nullptr` if there is no collision, otherwise the ContactSurface
           between geometries S and R. Each triangle in the contact surface is a
           piece of a triangle in the input `mesh_R`; the normals of the former
@@ -144,7 +167,8 @@ ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
     GeometryId id_S, const math::RigidTransform<T>& X_WS, double pressure_scale,
     GeometryId id_R, const SurfaceMesh<double>& mesh_R,
     const Bvh<Obb, SurfaceMesh<double>>& bvh_R,
-    const math::RigidTransform<T>& X_WR);
+    const math::RigidTransform<T>& X_WR,
+    ContactPolygonRepresentation representation);
 
 }  // namespace internal
 }  // namespace geometry


### PR DESCRIPTION
Support the [development plan for 14579](https://github.com/RobotLocomotion/drake/issues/14579#issuecomment-843618123). This PR for mesh_half_space_intersection is similar to PR #15310 for mesh_plane_intersection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15358)
<!-- Reviewable:end -->
