### PR TITLE
[common] Clean up ExpressionCell const-ness

### DIFF
--- a/common/symbolic_expression.h
+++ b/common/symbolic_expression.h
@@ -483,81 +483,69 @@ class Expression {
   // and not exposed to the user of drake/common/symbolic_expression.h
   // header. These functions are declared in
   // drake/common/symbolic_expression_cell.h header.
-  friend std::shared_ptr<const ExpressionConstant> to_constant(
-      const Expression& e);
-  friend std::shared_ptr<const ExpressionVar> to_variable(const Expression& e);
-  friend std::shared_ptr<const UnaryExpressionCell> to_unary(
-      const Expression& e);
-  friend std::shared_ptr<const BinaryExpressionCell> to_binary(
-      const Expression& e);
-  friend std::shared_ptr<const ExpressionAdd> to_addition(const Expression& e);
-  friend std::shared_ptr<const ExpressionMul> to_multiplication(
-      const Expression& e);
-  friend std::shared_ptr<const ExpressionDiv> to_division(const Expression& e);
-  friend std::shared_ptr<const ExpressionLog> to_log(const Expression& e);
-  friend std::shared_ptr<const ExpressionAbs> to_abs(const Expression& e);
-  friend std::shared_ptr<const ExpressionExp> to_exp(const Expression& e);
-  friend std::shared_ptr<const ExpressionSqrt> to_sqrt(const Expression& e);
-  friend std::shared_ptr<const ExpressionPow> to_pow(const Expression& e);
-  friend std::shared_ptr<const ExpressionSin> to_sin(const Expression& e);
-  friend std::shared_ptr<const ExpressionCos> to_cos(const Expression& e);
-  friend std::shared_ptr<const ExpressionTan> to_tan(const Expression& e);
-  friend std::shared_ptr<const ExpressionAsin> to_asin(const Expression& e);
-  friend std::shared_ptr<const ExpressionAcos> to_acos(const Expression& e);
-  friend std::shared_ptr<const ExpressionAtan> to_atan(const Expression& e);
-  friend std::shared_ptr<const ExpressionAtan2> to_atan2(const Expression& e);
-  friend std::shared_ptr<const ExpressionSinh> to_sinh(const Expression& e);
-  friend std::shared_ptr<const ExpressionCosh> to_cosh(const Expression& e);
-  friend std::shared_ptr<const ExpressionTanh> to_tanh(const Expression& e);
-  friend std::shared_ptr<const ExpressionMin> to_min(const Expression& e);
-  friend std::shared_ptr<const ExpressionMax> to_max(const Expression& e);
-  friend std::shared_ptr<const ExpressionCeiling> to_ceil(const Expression& e);
-  friend std::shared_ptr<const ExpressionFloor> to_floor(const Expression& e);
-  friend std::shared_ptr<const ExpressionIfThenElse> to_if_then_else(
-      const Expression& e);
-  friend std::shared_ptr<const ExpressionUninterpretedFunction>
+  friend const ExpressionConstant& to_constant(const Expression& e);
+  friend const ExpressionVar& to_variable(const Expression& e);
+  friend const UnaryExpressionCell& to_unary(const Expression& e);
+  friend const BinaryExpressionCell& to_binary(const Expression& e);
+  friend const ExpressionAdd& to_addition(const Expression& e);
+  friend const ExpressionMul& to_multiplication(const Expression& e);
+  friend const ExpressionDiv& to_division(const Expression& e);
+  friend const ExpressionLog& to_log(const Expression& e);
+  friend const ExpressionAbs& to_abs(const Expression& e);
+  friend const ExpressionExp& to_exp(const Expression& e);
+  friend const ExpressionSqrt& to_sqrt(const Expression& e);
+  friend const ExpressionPow& to_pow(const Expression& e);
+  friend const ExpressionSin& to_sin(const Expression& e);
+  friend const ExpressionCos& to_cos(const Expression& e);
+  friend const ExpressionTan& to_tan(const Expression& e);
+  friend const ExpressionAsin& to_asin(const Expression& e);
+  friend const ExpressionAcos& to_acos(const Expression& e);
+  friend const ExpressionAtan& to_atan(const Expression& e);
+  friend const ExpressionAtan2& to_atan2(const Expression& e);
+  friend const ExpressionSinh& to_sinh(const Expression& e);
+  friend const ExpressionCosh& to_cosh(const Expression& e);
+  friend const ExpressionTanh& to_tanh(const Expression& e);
+  friend const ExpressionMin& to_min(const Expression& e);
+  friend const ExpressionMax& to_max(const Expression& e);
+  friend const ExpressionCeiling& to_ceil(const Expression& e);
+  friend const ExpressionFloor& to_floor(const Expression& e);
+  friend const ExpressionIfThenElse& to_if_then_else(const Expression& e);
+  friend const ExpressionUninterpretedFunction&
   to_uninterpreted_function(const Expression& e);
 
   // Cast functions which takes a pointer to a non-const Expression.
-  friend std::shared_ptr<ExpressionConstant> to_constant(Expression* e);
-  friend std::shared_ptr<ExpressionVar> to_variable(Expression* e);
-  friend std::shared_ptr<UnaryExpressionCell> to_unary(Expression* e);
-  friend std::shared_ptr<BinaryExpressionCell> to_binary(Expression* e);
-  friend std::shared_ptr<ExpressionAdd> to_addition(Expression* e);
-  friend std::shared_ptr<ExpressionMul> to_multiplication(Expression* e);
-  friend std::shared_ptr<ExpressionDiv> to_division(Expression* e);
-  friend std::shared_ptr<ExpressionLog> to_log(Expression* e);
-  friend std::shared_ptr<ExpressionAbs> to_abs(Expression* e);
-  friend std::shared_ptr<ExpressionExp> to_exp(Expression* e);
-  friend std::shared_ptr<ExpressionSqrt> to_sqrt(Expression* e);
-  friend std::shared_ptr<ExpressionPow> to_pow(Expression* e);
-  friend std::shared_ptr<ExpressionSin> to_sin(Expression* e);
-  friend std::shared_ptr<ExpressionCos> to_cos(Expression* e);
-  friend std::shared_ptr<ExpressionTan> to_tan(Expression* e);
-  friend std::shared_ptr<ExpressionAsin> to_asin(Expression* e);
-  friend std::shared_ptr<ExpressionAcos> to_acos(Expression* e);
-  friend std::shared_ptr<ExpressionAtan> to_atan(Expression* e);
-  friend std::shared_ptr<ExpressionAtan2> to_atan2(Expression* e);
-  friend std::shared_ptr<ExpressionSinh> to_sinh(Expression* e);
-  friend std::shared_ptr<ExpressionCosh> to_cosh(Expression* e);
-  friend std::shared_ptr<ExpressionTanh> to_tanh(Expression* e);
-  friend std::shared_ptr<ExpressionMin> to_min(Expression* e);
-  friend std::shared_ptr<ExpressionMax> to_max(Expression* e);
-  friend std::shared_ptr<ExpressionCeiling> to_ceil(Expression* e);
-  friend std::shared_ptr<ExpressionFloor> to_floor(Expression* e);
-  friend std::shared_ptr<ExpressionIfThenElse> to_if_then_else(Expression* e);
-  friend std::shared_ptr<ExpressionUninterpretedFunction>
+  friend ExpressionConstant& to_constant(Expression* e);
+  friend ExpressionVar& to_variable(Expression* e);
+  friend UnaryExpressionCell& to_unary(Expression* e);
+  friend BinaryExpressionCell& to_binary(Expression* e);
+  friend ExpressionAdd& to_addition(Expression* e);
+  friend ExpressionMul& to_multiplication(Expression* e);
+  friend ExpressionDiv& to_division(Expression* e);
+  friend ExpressionLog& to_log(Expression* e);
+  friend ExpressionAbs& to_abs(Expression* e);
+  friend ExpressionExp& to_exp(Expression* e);
+  friend ExpressionSqrt& to_sqrt(Expression* e);
+  friend ExpressionPow& to_pow(Expression* e);
+  friend ExpressionSin& to_sin(Expression* e);
+  friend ExpressionCos& to_cos(Expression* e);
+  friend ExpressionTan& to_tan(Expression* e);
+  friend ExpressionAsin& to_asin(Expression* e);
+  friend ExpressionAcos& to_acos(Expression* e);
+  friend ExpressionAtan& to_atan(Expression* e);
+  friend ExpressionAtan2& to_atan2(Expression* e);
+  friend ExpressionSinh& to_sinh(Expression* e);
+  friend ExpressionCosh& to_cosh(Expression* e);
+  friend ExpressionTanh& to_tanh(Expression* e);
+  friend ExpressionMin& to_min(Expression* e);
+  friend ExpressionMax& to_max(Expression* e);
+  friend ExpressionCeiling& to_ceil(Expression* e);
+  friend ExpressionFloor& to_floor(Expression* e);
+  friend ExpressionIfThenElse& to_if_then_else(Expression* e);
+  friend ExpressionUninterpretedFunction&
   to_uninterpreted_function(Expression* e);
 
   friend class ExpressionAddFactory;
   friend class ExpressionMulFactory;
-
-  // The following classes call the private method `set_expand()` and need to be
-  // friends of this class.
-  friend class ExpressionAdd;
-  friend class ExpressionMul;
-  friend class ExpressionDiv;
-  friend class ExpressionPow;
 
  private:
   // This is a helper function used to handle `Expression(double)` constructor.
@@ -567,13 +555,22 @@ class Expression {
 
   void HashAppend(DelegatingHasher* hasher) const;
 
+  // Returns a const reference to the owned cell.
+  const ExpressionCell& cell() const {
+    DRAKE_ASSERT(ptr_ != nullptr);
+    return *ptr_;
+  }
+
+  // Returns a mutable reference to the owned cell. This function may only be
+  // called when this object is the sole owner of the cell.
+  ExpressionCell& mutable_cell();
+
   // Note: We use "non-const" ExpressionCell type. This allows us to perform
   // destructive updates on the pointed cell if the cell is not shared with
-  // other Expressions (that is, ptr_.use_count() == 1).
+  // other Expressions (that is, ptr_.use_count() == 1). However, because that
+  // pattern needs careful attention, our library code should never access
+  // ptr_ directly, it should always use cell() or mutable_cell().
   std::shared_ptr<ExpressionCell> ptr_;
-
-  /** Sets this symbolic expression as already expanded. */
-  Expression& set_expanded();
 };
 
 Expression operator+(Expression lhs, const Expression& rhs);

--- a/common/symbolic_expression_cell.h
+++ b/common/symbolic_expression_cell.h
@@ -14,7 +14,6 @@
 #include <algorithm>  // for cpplint only
 #include <cstddef>
 #include <map>
-#include <memory>
 #include <ostream>
 #include <string>
 #include <vector>
@@ -313,17 +312,15 @@ class ExpressionAddFactory {
   ExpressionAddFactory(double constant,
                        std::map<Expression, double> expr_to_coeff_map);
 
-  /** Constructs ExpressionAddFactory from @p ptr. */
-  explicit ExpressionAddFactory(
-      const std::shared_ptr<const ExpressionAdd>& ptr);
+  /** Constructs ExpressionAddFactory from @p add. */
+  explicit ExpressionAddFactory(const ExpressionAdd& add);
 
   /** Adds @p e to this factory. */
   void AddExpression(const Expression& e);
   /** Adds ExpressionAdd pointed by @p ptr to this factory. */
-  void Add(const std::shared_ptr<const ExpressionAdd>& ptr);
-  /** Assigns a factory from a shared pointer to ExpressionAdd.  */
-  ExpressionAddFactory& operator=(
-      const std::shared_ptr<const ExpressionAdd>& ptr);
+  void Add(const ExpressionAdd& add);
+  /** Assigns a factory from a an ExpressionAdd.  */
+  ExpressionAddFactory& operator=(const ExpressionAdd& ptr);
 
   /** Negates the expressions in factory.
    * If it represents c0 + c1 * t1 + ... + * cn * tn,
@@ -417,17 +414,15 @@ class ExpressionMulFactory {
   ExpressionMulFactory(double constant,
                        std::map<Expression, Expression> base_to_exponent_map);
 
-  /** Constructs ExpressionMulFactory from @p ptr. */
-  explicit ExpressionMulFactory(
-      const std::shared_ptr<const ExpressionMul>& ptr);
+  /** Constructs ExpressionMulFactory from @p mul. */
+  explicit ExpressionMulFactory(const ExpressionMul& mul);
 
   /** Adds @p e to this factory. */
   void AddExpression(const Expression& e);
   /** Adds ExpressionMul pointed by @p ptr to this factory. */
-  void Add(const std::shared_ptr<const ExpressionMul>& ptr);
-  /** Assigns a factory from a shared pointer to ExpressionMul.  */
-  ExpressionMulFactory& operator=(
-      const std::shared_ptr<const ExpressionMul>& ptr);
+  void Add(const ExpressionMul& ptr);
+  /** Assigns a factory from an ExpressionMul.  */
+  ExpressionMulFactory& operator=(const ExpressionMul& ptr);
   /** Negates the expressions in factory.
    * If it represents c0 * p1 * ... * pn,
    * this method flips it into -c0 * p1 * ... * pn.
@@ -820,6 +815,10 @@ class ExpressionUninterpretedFunction : public ExpressionCell {
 bool is_constant(const ExpressionCell& c);
 /** Checks if @p c is a variable expression. */
 bool is_variable(const ExpressionCell& c);
+/** Checks if @p c is a unary expression. */
+bool is_unary(const ExpressionCell& c);
+/** Checks if @p c is a binary expression. */
+bool is_binary(const ExpressionCell& c);
 /** Checks if @p c is an addition expression. */
 bool is_addition(const ExpressionCell& c);
 /** Checks if @p c is an multiplication expression. */
@@ -868,174 +867,6 @@ bool is_floor(const ExpressionCell& c);
 bool is_if_then_else(const ExpressionCell& c);
 /** Checks if @p c is an uninterpreted-function expression. */
 bool is_uninterpreted_function(const ExpressionCell& c);
-
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionConstant>.
- *  @pre @p *expr_ptr is of @c ExpressionConstant.
- */
-std::shared_ptr<ExpressionConstant> to_constant(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionVar>.
- *  @pre @p *expr_ptr is of @c ExpressionVar.
- */
-std::shared_ptr<ExpressionVar> to_variable(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-
-/** Casts @p expr_ptr to @c shared_ptr<UnaryExpressionCell>.
- *  @pre @c *expr_ptr is of @c UnaryExpressionCell.
- */
-std::shared_ptr<UnaryExpressionCell> to_unary(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-
-/** Casts @p expr_ptr to @c shared_ptr<BinaryExpressionCell>.
- *  @pre @c *expr_ptr is of @c BinaryExpressionCell.
- */
-std::shared_ptr<BinaryExpressionCell> to_binary(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionAdd>.
- *  @pre @c *expr_ptr is of @c ExpressionAdd.
- */
-std::shared_ptr<ExpressionAdd> to_addition(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionMul>.
- *  @pre @c *expr_ptr is of @c ExpressionMul.
- */
-std::shared_ptr<ExpressionMul> to_multiplication(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionDiv>.
- *  @pre @c *expr_ptr is of @c ExpressionDiv.
- */
-std::shared_ptr<ExpressionDiv> to_division(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionLog>.
- *  @pre @c *expr_ptr is of @c ExpressionLog.
- */
-std::shared_ptr<ExpressionLog> to_log(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionExp>.
- *  @pre @c *expr_ptr is of @c ExpressionExp.
- */
-std::shared_ptr<ExpressionExp> to_exp(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionAbs>.
- *  @pre @c *expr_ptr is of @c ExpressionAbs.
- */
-std::shared_ptr<ExpressionAbs> to_abs(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionSqrt>.
- *  @pre @c *expr_ptr is of @c ExpressionSqrt.
- */
-std::shared_ptr<ExpressionSqrt> to_sqrt(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionPow>.
- *  @pre @c *expr_ptr is of @c ExpressionPow.
- */
-std::shared_ptr<ExpressionPow> to_pow(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionSin>.
- *  @pre @c *expr_ptr is of @c ExpressionSin.
- */
-std::shared_ptr<ExpressionSin> to_sin(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionCos>.
- *  @pre @c *expr_ptr is of @c ExpressionCos.
- */
-std::shared_ptr<ExpressionCos> to_cos(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionTan>.
- *  @pre @c *expr_ptr is of @c ExpressionTan.
- */
-std::shared_ptr<ExpressionTan> to_tan(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionAsin>.
- *  @pre @c *expr_ptr is of @c ExpressionAsin.
- */
-std::shared_ptr<ExpressionAsin> to_asin(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionAcos>.
- *  @pre @c *expr_ptr is of @c ExpressionAcos.
- */
-std::shared_ptr<ExpressionAcos> to_acos(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionAtan>.
- *  @pre @c *expr_ptr is of @c ExpressionAtan.
- */
-std::shared_ptr<ExpressionAtan> to_atan(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionAtan2>.
- *  @pre @c *expr_ptr is of @c ExpressionAtan2.
- */
-std::shared_ptr<ExpressionAtan2> to_atan2(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionSinh>.
- *  @pre @c *expr_ptr is of @c ExpressionSinh.
- */
-std::shared_ptr<ExpressionSinh> to_sinh(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionCosh>.
- *  @pre @c *expr_ptr is of @c ExpressionCosh.
- */
-std::shared_ptr<ExpressionCosh> to_cosh(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionTanh>.
- *  @pre @c *expr_ptr is of @c ExpressionTanh.
- */
-std::shared_ptr<ExpressionTanh> to_tanh(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionMin>.
- *  @pre @c *expr_ptr is of @c ExpressionMin.
- */
-std::shared_ptr<ExpressionMin> to_min(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionMax>.
- *  @pre @c *expr_ptr is of @c ExpressionMax.
- */
-std::shared_ptr<ExpressionMax> to_max(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionCeiling>.
- *  @pre @c *expr_ptr is of @c ExpressionCeiling.
- */
-std::shared_ptr<ExpressionCeiling> to_ceil(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionFloor>.
- *  @pre @c *expr_ptr is of @c ExpressionFloor.
- */
-std::shared_ptr<ExpressionFloor> to_floor(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionIfThenElse>.
- *  @pre @c *expr_ptr is of @c ExpressionIfThenElse.
- */
-std::shared_ptr<ExpressionIfThenElse> to_if_then_else(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
-
-/** Casts @p expr_ptr to @c shared_ptr<ExpressionUninterpretedFunction>.
- *  @pre @c *expr_ptr is of @c ExpressionUninterpretedFunction.
- */
-std::shared_ptr<ExpressionUninterpretedFunction> to_uninterpreted_function(
-    const std::shared_ptr<ExpressionCell>& expr_ptr);
 
 }  // namespace symbolic
 }  // namespace drake

--- a/common/test/symbolic_expression_cell_test.cc
+++ b/common/test/symbolic_expression_cell_test.cc
@@ -54,168 +54,168 @@ class SymbolicExpressionCellTest : public ::testing::Test {
 };
 
 TEST_F(SymbolicExpressionCellTest, CastFunctionsConst) {
-  EXPECT_EQ(to_constant(e_constant_)->get_value(),
+  EXPECT_EQ(to_constant(e_constant_).get_value(),
             get_constant_value(e_constant_));
-  EXPECT_EQ(to_variable(e_var_)->get_variable(), get_variable(e_var_));
+  EXPECT_EQ(to_variable(e_var_).get_variable(), get_variable(e_var_));
 
-  EXPECT_EQ(to_addition(e_add_)->get_constant(),
+  EXPECT_EQ(to_addition(e_add_).get_constant(),
             get_constant_in_addition(e_add_));
-  EXPECT_EQ(to_addition(e_add_)->get_expr_to_coeff_map(),
+  EXPECT_EQ(to_addition(e_add_).get_expr_to_coeff_map(),
             get_expr_to_coeff_map_in_addition(e_add_));
 
-  EXPECT_EQ(to_multiplication(e_mul_)->get_constant(),
+  EXPECT_EQ(to_multiplication(e_mul_).get_constant(),
             get_constant_in_multiplication(e_mul_));
-  EXPECT_EQ(to_multiplication(e_mul_)->get_base_to_exponent_map().size(),
+  EXPECT_EQ(to_multiplication(e_mul_).get_base_to_exponent_map().size(),
             get_base_to_exponent_map_in_multiplication(e_mul_).size());
-  EXPECT_EQ(to_multiplication(e_mul_)->get_base_to_exponent_map().size(), 2);
+  EXPECT_EQ(to_multiplication(e_mul_).get_base_to_exponent_map().size(), 2);
   EXPECT_PRED2(ExprEqual,
-               to_multiplication(e_mul_)->get_base_to_exponent_map().at(var_x_),
+               to_multiplication(e_mul_).get_base_to_exponent_map().at(var_x_),
                get_base_to_exponent_map_in_multiplication(e_mul_).at(var_x_));
   EXPECT_PRED2(ExprEqual,
-               to_multiplication(e_mul_)->get_base_to_exponent_map().at(var_y_),
+               to_multiplication(e_mul_).get_base_to_exponent_map().at(var_y_),
                get_base_to_exponent_map_in_multiplication(e_mul_).at(var_y_));
 
-  EXPECT_EQ(to_division(e_div_)->get_second_argument(),
+  EXPECT_EQ(to_division(e_div_).get_second_argument(),
             get_second_argument(e_div_));
-  EXPECT_EQ(to_division(e_div_)->get_second_argument(),
+  EXPECT_EQ(to_division(e_div_).get_second_argument(),
             get_second_argument(e_div_));
 
-  EXPECT_EQ(to_log(e_log_)->get_argument(), get_argument(e_log_));
-  EXPECT_EQ(to_abs(e_abs_)->get_argument(), get_argument(e_abs_));
-  EXPECT_EQ(to_exp(e_exp_)->get_argument(), get_argument(e_exp_));
-  EXPECT_EQ(to_sqrt(e_sqrt_)->get_argument(), get_argument(e_sqrt_));
-  EXPECT_EQ(to_pow(e_pow_)->get_first_argument(), get_first_argument(e_pow_));
-  EXPECT_EQ(to_pow(e_pow_)->get_second_argument(), get_second_argument(e_pow_));
-  EXPECT_EQ(to_sin(e_sin_)->get_argument(), get_argument(e_sin_));
-  EXPECT_EQ(to_cos(e_cos_)->get_argument(), get_argument(e_cos_));
-  EXPECT_EQ(to_tan(e_tan_)->get_argument(), get_argument(e_tan_));
-  EXPECT_EQ(to_asin(e_asin_)->get_argument(), get_argument(e_asin_));
-  EXPECT_EQ(to_acos(e_acos_)->get_argument(), get_argument(e_acos_));
-  EXPECT_EQ(to_atan(e_atan_)->get_argument(), get_argument(e_atan_));
-  EXPECT_EQ(to_atan2(e_atan2_)->get_first_argument(),
+  EXPECT_EQ(to_log(e_log_).get_argument(), get_argument(e_log_));
+  EXPECT_EQ(to_abs(e_abs_).get_argument(), get_argument(e_abs_));
+  EXPECT_EQ(to_exp(e_exp_).get_argument(), get_argument(e_exp_));
+  EXPECT_EQ(to_sqrt(e_sqrt_).get_argument(), get_argument(e_sqrt_));
+  EXPECT_EQ(to_pow(e_pow_).get_first_argument(), get_first_argument(e_pow_));
+  EXPECT_EQ(to_pow(e_pow_).get_second_argument(), get_second_argument(e_pow_));
+  EXPECT_EQ(to_sin(e_sin_).get_argument(), get_argument(e_sin_));
+  EXPECT_EQ(to_cos(e_cos_).get_argument(), get_argument(e_cos_));
+  EXPECT_EQ(to_tan(e_tan_).get_argument(), get_argument(e_tan_));
+  EXPECT_EQ(to_asin(e_asin_).get_argument(), get_argument(e_asin_));
+  EXPECT_EQ(to_acos(e_acos_).get_argument(), get_argument(e_acos_));
+  EXPECT_EQ(to_atan(e_atan_).get_argument(), get_argument(e_atan_));
+  EXPECT_EQ(to_atan2(e_atan2_).get_first_argument(),
             get_first_argument(e_atan2_));
-  EXPECT_EQ(to_atan2(e_atan2_)->get_second_argument(),
+  EXPECT_EQ(to_atan2(e_atan2_).get_second_argument(),
             get_second_argument(e_atan2_));
-  EXPECT_EQ(to_sinh(e_sinh_)->get_argument(), get_argument(e_sinh_));
-  EXPECT_EQ(to_cosh(e_cosh_)->get_argument(), get_argument(e_cosh_));
-  EXPECT_EQ(to_tanh(e_tanh_)->get_argument(), get_argument(e_tanh_));
-  EXPECT_EQ(to_min(e_min_)->get_first_argument(), get_first_argument(e_min_));
-  EXPECT_EQ(to_min(e_min_)->get_second_argument(), get_second_argument(e_min_));
-  EXPECT_EQ(to_max(e_max_)->get_first_argument(), get_first_argument(e_max_));
-  EXPECT_EQ(to_max(e_max_)->get_second_argument(), get_second_argument(e_max_));
-  EXPECT_EQ(to_ceil(e_ceil_)->get_argument(), get_argument(e_ceil_));
-  EXPECT_EQ(to_floor(e_floor_)->get_argument(), get_argument(e_floor_));
-  EXPECT_PRED2(FormulaEqual, to_if_then_else(e_ite_)->get_conditional_formula(),
+  EXPECT_EQ(to_sinh(e_sinh_).get_argument(), get_argument(e_sinh_));
+  EXPECT_EQ(to_cosh(e_cosh_).get_argument(), get_argument(e_cosh_));
+  EXPECT_EQ(to_tanh(e_tanh_).get_argument(), get_argument(e_tanh_));
+  EXPECT_EQ(to_min(e_min_).get_first_argument(), get_first_argument(e_min_));
+  EXPECT_EQ(to_min(e_min_).get_second_argument(), get_second_argument(e_min_));
+  EXPECT_EQ(to_max(e_max_).get_first_argument(), get_first_argument(e_max_));
+  EXPECT_EQ(to_max(e_max_).get_second_argument(), get_second_argument(e_max_));
+  EXPECT_EQ(to_ceil(e_ceil_).get_argument(), get_argument(e_ceil_));
+  EXPECT_EQ(to_floor(e_floor_).get_argument(), get_argument(e_floor_));
+  EXPECT_PRED2(FormulaEqual, to_if_then_else(e_ite_).get_conditional_formula(),
                get_conditional_formula(e_ite_));
-  EXPECT_PRED2(ExprEqual, to_if_then_else(e_ite_)->get_then_expression(),
+  EXPECT_PRED2(ExprEqual, to_if_then_else(e_ite_).get_then_expression(),
                get_then_expression(e_ite_));
-  EXPECT_PRED2(ExprEqual, to_if_then_else(e_ite_)->get_else_expression(),
+  EXPECT_PRED2(ExprEqual, to_if_then_else(e_ite_).get_else_expression(),
                get_else_expression(e_ite_));
-  EXPECT_EQ(to_uninterpreted_function(e_uf_)->get_name(),
+  EXPECT_EQ(to_uninterpreted_function(e_uf_).get_name(),
             get_uninterpreted_function_name(e_uf_));
-  EXPECT_EQ(to_uninterpreted_function(e_uf_)->get_arguments().size(), 2);
-  EXPECT_EQ(to_uninterpreted_function(e_uf_)->get_arguments().size(),
+  EXPECT_EQ(to_uninterpreted_function(e_uf_).get_arguments().size(), 2);
+  EXPECT_EQ(to_uninterpreted_function(e_uf_).get_arguments().size(),
             get_uninterpreted_function_arguments(e_uf_).size());
-  EXPECT_EQ(to_uninterpreted_function(e_uf_)->get_arguments()[0],
+  EXPECT_EQ(to_uninterpreted_function(e_uf_).get_arguments()[0],
             get_uninterpreted_function_arguments(e_uf_)[0]);
-  EXPECT_EQ(to_uninterpreted_function(e_uf_)->get_arguments()[1],
+  EXPECT_EQ(to_uninterpreted_function(e_uf_).get_arguments()[1],
             get_uninterpreted_function_arguments(e_uf_)[1]);
 }
 
 TEST_F(SymbolicExpressionCellTest, CastFunctionsNonConst) {
-  EXPECT_EQ(to_constant(Expression{e_constant_})->get_value(),
+  EXPECT_EQ(to_constant(Expression{e_constant_}).get_value(),
             get_constant_value(e_constant_));
-  EXPECT_EQ(to_variable(Expression{e_var_})->get_variable(),
+  EXPECT_EQ(to_variable(Expression{e_var_}).get_variable(),
             get_variable(e_var_));
 
-  EXPECT_EQ(to_addition(Expression{e_add_})->get_constant(),
+  EXPECT_EQ(to_addition(Expression{e_add_}).get_constant(),
             get_constant_in_addition(e_add_));
-  EXPECT_EQ(to_addition(Expression{e_add_})->get_expr_to_coeff_map(),
+  EXPECT_EQ(to_addition(Expression{e_add_}).get_expr_to_coeff_map(),
             get_expr_to_coeff_map_in_addition(e_add_));
 
-  EXPECT_EQ(to_multiplication(Expression{e_mul_})->get_constant(),
+  EXPECT_EQ(to_multiplication(Expression{e_mul_}).get_constant(),
             get_constant_in_multiplication(e_mul_));
   EXPECT_EQ(
-      to_multiplication(Expression{e_mul_})->get_base_to_exponent_map().size(),
+      to_multiplication(Expression{e_mul_}).get_base_to_exponent_map().size(),
       get_base_to_exponent_map_in_multiplication(e_mul_).size());
   EXPECT_EQ(
-      to_multiplication(Expression{e_mul_})->get_base_to_exponent_map().size(),
+      to_multiplication(Expression{e_mul_}).get_base_to_exponent_map().size(),
       2);
   EXPECT_PRED2(ExprEqual,
                to_multiplication(Expression{e_mul_})
-                   ->get_base_to_exponent_map()
+                   .get_base_to_exponent_map()
                    .at(var_x_),
                get_base_to_exponent_map_in_multiplication(e_mul_).at(var_x_));
   EXPECT_PRED2(ExprEqual,
                to_multiplication(Expression{e_mul_})
-                   ->get_base_to_exponent_map()
+                   .get_base_to_exponent_map()
                    .at(var_y_),
                get_base_to_exponent_map_in_multiplication(e_mul_).at(var_y_));
 
-  EXPECT_EQ(to_division(Expression{e_div_})->get_second_argument(),
+  EXPECT_EQ(to_division(Expression{e_div_}).get_second_argument(),
             get_second_argument(e_div_));
-  EXPECT_EQ(to_division(Expression{e_div_})->get_second_argument(),
+  EXPECT_EQ(to_division(Expression{e_div_}).get_second_argument(),
             get_second_argument(e_div_));
 
-  EXPECT_EQ(to_log(Expression{e_log_})->get_argument(), get_argument(e_log_));
-  EXPECT_EQ(to_abs(Expression{e_abs_})->get_argument(), get_argument(e_abs_));
-  EXPECT_EQ(to_exp(Expression{e_exp_})->get_argument(), get_argument(e_exp_));
-  EXPECT_EQ(to_sqrt(Expression{e_sqrt_})->get_argument(),
+  EXPECT_EQ(to_log(Expression{e_log_}).get_argument(), get_argument(e_log_));
+  EXPECT_EQ(to_abs(Expression{e_abs_}).get_argument(), get_argument(e_abs_));
+  EXPECT_EQ(to_exp(Expression{e_exp_}).get_argument(), get_argument(e_exp_));
+  EXPECT_EQ(to_sqrt(Expression{e_sqrt_}).get_argument(),
             get_argument(e_sqrt_));
-  EXPECT_EQ(to_pow(Expression{e_pow_})->get_first_argument(),
+  EXPECT_EQ(to_pow(Expression{e_pow_}).get_first_argument(),
             get_first_argument(e_pow_));
-  EXPECT_EQ(to_pow(Expression{e_pow_})->get_second_argument(),
+  EXPECT_EQ(to_pow(Expression{e_pow_}).get_second_argument(),
             get_second_argument(e_pow_));
-  EXPECT_EQ(to_sin(Expression{e_sin_})->get_argument(), get_argument(e_sin_));
-  EXPECT_EQ(to_cos(Expression{e_cos_})->get_argument(), get_argument(e_cos_));
-  EXPECT_EQ(to_tan(Expression{e_tan_})->get_argument(), get_argument(e_tan_));
-  EXPECT_EQ(to_asin(Expression{e_asin_})->get_argument(),
+  EXPECT_EQ(to_sin(Expression{e_sin_}).get_argument(), get_argument(e_sin_));
+  EXPECT_EQ(to_cos(Expression{e_cos_}).get_argument(), get_argument(e_cos_));
+  EXPECT_EQ(to_tan(Expression{e_tan_}).get_argument(), get_argument(e_tan_));
+  EXPECT_EQ(to_asin(Expression{e_asin_}).get_argument(),
             get_argument(e_asin_));
-  EXPECT_EQ(to_acos(Expression{e_acos_})->get_argument(),
+  EXPECT_EQ(to_acos(Expression{e_acos_}).get_argument(),
             get_argument(e_acos_));
-  EXPECT_EQ(to_atan(Expression{e_atan_})->get_argument(),
+  EXPECT_EQ(to_atan(Expression{e_atan_}).get_argument(),
             get_argument(e_atan_));
-  EXPECT_EQ(to_atan2(Expression{e_atan2_})->get_first_argument(),
+  EXPECT_EQ(to_atan2(Expression{e_atan2_}).get_first_argument(),
             get_first_argument(e_atan2_));
-  EXPECT_EQ(to_atan2(Expression{e_atan2_})->get_second_argument(),
+  EXPECT_EQ(to_atan2(Expression{e_atan2_}).get_second_argument(),
             get_second_argument(e_atan2_));
-  EXPECT_EQ(to_sinh(Expression{e_sinh_})->get_argument(),
+  EXPECT_EQ(to_sinh(Expression{e_sinh_}).get_argument(),
             get_argument(e_sinh_));
-  EXPECT_EQ(to_cosh(Expression{e_cosh_})->get_argument(),
+  EXPECT_EQ(to_cosh(Expression{e_cosh_}).get_argument(),
             get_argument(e_cosh_));
-  EXPECT_EQ(to_tanh(Expression{e_tanh_})->get_argument(),
+  EXPECT_EQ(to_tanh(Expression{e_tanh_}).get_argument(),
             get_argument(e_tanh_));
-  EXPECT_EQ(to_min(Expression{e_min_})->get_first_argument(),
+  EXPECT_EQ(to_min(Expression{e_min_}).get_first_argument(),
             get_first_argument(e_min_));
-  EXPECT_EQ(to_min(Expression{e_min_})->get_second_argument(),
+  EXPECT_EQ(to_min(Expression{e_min_}).get_second_argument(),
             get_second_argument(e_min_));
-  EXPECT_EQ(to_max(Expression{e_max_})->get_first_argument(),
+  EXPECT_EQ(to_max(Expression{e_max_}).get_first_argument(),
             get_first_argument(e_max_));
-  EXPECT_EQ(to_max(Expression{e_max_})->get_second_argument(),
+  EXPECT_EQ(to_max(Expression{e_max_}).get_second_argument(),
             get_second_argument(e_max_));
-  EXPECT_EQ(to_ceil(Expression{e_ceil_})->get_argument(),
+  EXPECT_EQ(to_ceil(Expression{e_ceil_}).get_argument(),
             get_argument(e_ceil_));
-  EXPECT_EQ(to_floor(Expression{e_floor_})->get_argument(),
+  EXPECT_EQ(to_floor(Expression{e_floor_}).get_argument(),
             get_argument(e_floor_));
   EXPECT_PRED2(FormulaEqual,
-               to_if_then_else(Expression{e_ite_})->get_conditional_formula(),
+               to_if_then_else(Expression{e_ite_}).get_conditional_formula(),
                get_conditional_formula(e_ite_));
   EXPECT_PRED2(ExprEqual,
-               to_if_then_else(Expression{e_ite_})->get_then_expression(),
+               to_if_then_else(Expression{e_ite_}).get_then_expression(),
                get_then_expression(e_ite_));
   EXPECT_PRED2(ExprEqual,
-               to_if_then_else(Expression{e_ite_})->get_else_expression(),
+               to_if_then_else(Expression{e_ite_}).get_else_expression(),
                get_else_expression(e_ite_));
-  EXPECT_EQ(to_uninterpreted_function(Expression{e_uf_})->get_name(),
+  EXPECT_EQ(to_uninterpreted_function(Expression{e_uf_}).get_name(),
             get_uninterpreted_function_name(e_uf_));
   EXPECT_EQ(
-      to_uninterpreted_function(Expression{e_uf_})->get_arguments().size(), 2);
+      to_uninterpreted_function(Expression{e_uf_}).get_arguments().size(), 2);
   EXPECT_EQ(
-      to_uninterpreted_function(Expression{e_uf_})->get_arguments().size(),
+      to_uninterpreted_function(Expression{e_uf_}).get_arguments().size(),
       get_uninterpreted_function_arguments(e_uf_).size());
-  EXPECT_EQ(to_uninterpreted_function(Expression{e_uf_})->get_arguments()[0],
+  EXPECT_EQ(to_uninterpreted_function(Expression{e_uf_}).get_arguments()[0],
             get_uninterpreted_function_arguments(e_uf_)[0]);
-  EXPECT_EQ(to_uninterpreted_function(Expression{e_uf_})->get_arguments()[1],
+  EXPECT_EQ(to_uninterpreted_function(Expression{e_uf_}).get_arguments()[1],
             get_uninterpreted_function_arguments(e_uf_)[1]);
 }
 


### PR DESCRIPTION
The prior change to remove const from the shared_ptr (#11756) left open the const propagation hole when directly accessing the member field.

Here, we introduce getters for the cell so that constness is preserved, and switch the downcasters to return direct cell references (instead of shared_ptr references) because none of the callers actually need to indirectly increment the shared_ptr count.

This is a breaking change insofar as some `ExpressionCell` signatures have changed.  We consider `ExpressionCell` to be an internal implementation detail, though we have not moved it to the `internal` namespace yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15364)
<!-- Reviewable:end -->
