### PR TITLE
[solvers] Add L2NormCost isa Cost

### DIFF
--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -33,6 +33,7 @@ using solvers::Constraint;
 using solvers::Cost;
 using solvers::EvaluatorBase;
 using solvers::ExponentialConeConstraint;
+using solvers::L2NormCost;
 using solvers::LinearComplementarityConstraint;
 using solvers::LinearConstraint;
 using solvers::LinearCost;
@@ -1715,9 +1716,27 @@ for every column of ``prog_var_vals``. )""")
           py::arg("is_convex") = py::none(),
           doc.QuadraticCost.UpdateCoefficients.doc);
 
+  py::class_<L2NormCost, Cost, std::shared_ptr<L2NormCost>>(
+      m, "L2NormCost", doc.L2NormCost.doc)
+      .def(py::init([](const Eigen::MatrixXd& A, const Eigen::VectorXd& b) {
+        return std::make_unique<L2NormCost>(A, b);
+      }),
+          py::arg("A"), py::arg("b"), doc.L2NormCost.ctor.doc)
+      .def("A", &L2NormCost::A, doc.L2NormCost.A.doc)
+      .def("b", &L2NormCost::b, doc.L2NormCost.b.doc)
+      .def(
+          "UpdateCoefficients",
+          [](L2NormCost& self, const Eigen::MatrixXd& new_A,
+              const Eigen::VectorXd& new_b) {
+            self.UpdateCoefficients(new_A, new_b);
+          },
+          py::arg("new_A"), py::arg("new_b") = 0,
+          doc.L2NormCost.UpdateCoefficients.doc);
+
   RegisterBinding<Cost>(&m, "Cost");
   RegisterBinding<LinearCost>(&m, "LinearCost");
   RegisterBinding<QuadraticCost>(&m, "QuadraticCost");
+  RegisterBinding<L2NormCost>(&m, "L2NormCost");
 
   py::class_<VisualizationCallback, EvaluatorBase,
       std::shared_ptr<VisualizationCallback>>(

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -58,6 +58,16 @@ class TestCost(unittest.TestCase):
         cost = mp.QuadraticCost(np.array([[1., 2.], [2., 6.]]), b, c)
         self.assertTrue(cost.is_convex())
 
+    def test_l2norm_cost(self):
+        A = np.array([[1., 2.], [-.4, .7]])
+        b = np.array([0.5, -.4])
+        cost = mp.L2NormCost(A=A, b=b)
+        np.testing.assert_allclose(cost.A(), A)
+        np.testing.assert_allclose(cost.b(), b)
+        cost.UpdateCoefficients(new_A=2*A, new_b=2*b)
+        np.testing.assert_allclose(cost.A(), 2*A)
+        np.testing.assert_allclose(cost.b(), 2*b)
+
 
 class TestQP:
     def __init__(self):

--- a/solvers/cost.cc
+++ b/solvers/cost.cc
@@ -11,26 +11,6 @@ using std::shared_ptr;
 
 namespace drake {
 namespace solvers {
-template <typename DerivedX, typename U>
-void LinearCost::DoEvalGeneric(const Eigen::MatrixBase<DerivedX>& x,
-                               VectorX<U>* y) const {
-  y->resize(1);
-  (*y)(0) = a_.dot(x) + b_;
-}
-
-void LinearCost::DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
-                        Eigen::VectorXd* y) const {
-  DoEvalGeneric(x, y);
-}
-void LinearCost::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
-                        AutoDiffVecXd* y) const {
-  DoEvalGeneric(x, y);
-}
-
-void LinearCost::DoEval(const Eigen::Ref<const VectorX<symbolic::Variable>>& x,
-                        VectorX<symbolic::Expression>* y) const {
-  DoEvalGeneric(x, y);
-}
 
 namespace {
 std::ostream& DisplayCost(const Cost& cost, std::ostream& os,
@@ -52,6 +32,27 @@ std::ostream& DisplayCost(const Cost& cost, std::ostream& os,
   return os;
 }
 }  // namespace
+
+template <typename DerivedX, typename U>
+void LinearCost::DoEvalGeneric(const Eigen::MatrixBase<DerivedX>& x,
+                               VectorX<U>* y) const {
+  y->resize(1);
+  (*y)(0) = a_.dot(x) + b_;
+}
+
+void LinearCost::DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
+                        Eigen::VectorXd* y) const {
+  DoEvalGeneric(x, y);
+}
+void LinearCost::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
+                        AutoDiffVecXd* y) const {
+  DoEvalGeneric(x, y);
+}
+
+void LinearCost::DoEval(const Eigen::Ref<const VectorX<symbolic::Variable>>& x,
+                        VectorX<symbolic::Expression>* y) const {
+  DoEvalGeneric(x, y);
+}
 
 std::ostream& LinearCost::DoDisplay(
     std::ostream& os, const VectorX<symbolic::Variable>& vars) const {
@@ -128,6 +129,49 @@ shared_ptr<QuadraticCost> Make2NormSquaredCost(
   const double c = b.dot(b);
   return make_shared<QuadraticCost>(2 * A.transpose() * A,
                                     -2 * A.transpose() * b, c);
+}
+
+L2NormCost::L2NormCost(const Eigen::Ref<const Eigen::MatrixXd>& A,
+                       const Eigen::Ref<const Eigen::VectorXd>& b)
+    : Cost(A.cols()), A_(A), b_(b) {
+  DRAKE_DEMAND(A_.rows() == b_.rows());
+}
+
+void L2NormCost::UpdateCoefficients(
+    const Eigen::Ref<const Eigen::MatrixXd>& new_A,
+    const Eigen::Ref<const Eigen::VectorXd>& new_b) {
+  if (new_A.cols() != A_.cols()) {
+    throw std::runtime_error("Can't change the number of decision variables");
+  }
+  if (new_A.rows() != new_b.rows()) {
+    throw std::runtime_error("A and b must have the same number of rows.");
+  }
+
+  A_ = new_A;
+  b_ = new_b;
+}
+
+void L2NormCost::DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
+                        Eigen::VectorXd* y) const {
+  y->resize(1);
+  (*y)(0) = (A_ * x + b_).norm();
+}
+
+void L2NormCost::DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
+                        AutoDiffVecXd* y) const {
+  y->resize(1);
+  (*y)(0) = (A_ * x + b_).norm();
+}
+
+void L2NormCost::DoEval(const Eigen::Ref<const VectorX<symbolic::Variable>>& x,
+                        VectorX<symbolic::Expression>* y) const {
+  y->resize(1);
+  (*y)(0) = sqrt((A_ * x + b_).squaredNorm());
+}
+
+std::ostream& L2NormCost::DoDisplay(
+    std::ostream& os, const VectorX<symbolic::Variable>& vars) const {
+  return DisplayCost(*this, os, "L2NormCost", vars);
 }
 
 }  // namespace solvers


### PR DESCRIPTION
Toward #15366.

Note: I've added the python binding for the class, but we currently don't have any `AddCost` variants that will support adding it to a `MathematicalProgram` (in python).  I looked at that, but it's more than I want to bite off now.  As is, this binding will still work for my shortest path problem code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15367)
<!-- Reviewable:end -->
