### PR TITLE
[common] Change Expression to use nanboxing

### DIFF
--- a/bindings/pydrake/symbolic_py.cc
+++ b/bindings/pydrake/symbolic_py.cc
@@ -292,7 +292,7 @@ PYBIND11_MODULE(symbolic, m) {
   // TODO(m-chaturvedi) Add Pybind11 documentation for operator overloads, etc.
   py::class_<Expression> expr_cls(m, "Expression", doc.Expression.doc);
   expr_cls.def(py::init<>(), doc.Expression.ctor.doc_0args)
-      .def(py::init<double>(), doc.Expression.ctor.doc_1args_d)
+      .def(py::init<double>(), doc.Expression.ctor.doc_1args_value)
       .def(py::init<const Variable&>(), doc.Expression.ctor.doc_1args_var)
       .def("__str__", &Expression::to_string)
       .def("__repr__",

--- a/common/test/symbolic_expression_cell_test.cc
+++ b/common/test/symbolic_expression_cell_test.cc
@@ -54,8 +54,6 @@ class SymbolicExpressionCellTest : public ::testing::Test {
 };
 
 TEST_F(SymbolicExpressionCellTest, CastFunctionsConst) {
-  EXPECT_EQ(to_constant(e_constant_).get_value(),
-            get_constant_value(e_constant_));
   EXPECT_EQ(to_variable(e_var_).get_variable(), get_variable(e_var_));
 
   EXPECT_EQ(to_addition(e_add_).get_constant(),
@@ -123,8 +121,6 @@ TEST_F(SymbolicExpressionCellTest, CastFunctionsConst) {
 }
 
 TEST_F(SymbolicExpressionCellTest, CastFunctionsNonConst) {
-  EXPECT_EQ(to_constant(Expression{e_constant_}).get_value(),
-            get_constant_value(e_constant_));
   EXPECT_EQ(to_variable(Expression{e_var_}).get_variable(),
             get_variable(e_var_));
 


### PR DESCRIPTION
I was curious to learn about how nanboxing worked, so I tried it out on `symbolic::Expression`.

This reduces the size of the class from 16 bytes to 8 bytes, allows inline construction for constants (and so, allows zero pages to serve as valid matrices), and provides speed-ups when doing operations on constants.  It might even improve speed when dealing with cells, by avoiding some of the complexities of `shared_ptr` (weak pointers, non-virtual subtypes, and aliased sub-objects).

I'm curious to hear any suggestions on throughput and/or latency benchmarks that I could try with the revised Expression implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15369)
<!-- Reviewable:end -->
