### PR TITLE
[geometry] Clarify obj parse error messages for proximity geometry

### DIFF
--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -158,10 +158,16 @@ namespace {
       drake::log()->warn("Warning parsing file '{}' : {}", filename, warn);
     }
 
-    if (shapes.size() != 1) {
+    if (shapes.size() == 0) {
       throw std::runtime_error(
-          fmt::format("The OBJ contains multiple objects; only OBJs with a "
-                      "single object are supported: '{}'",
+          fmt::format("The file parsed contains no objects; only OBJs with "
+                      "a single object are supported. The file could be "
+                      "corrupt, empty, or not an OBJ file. File name: '{}'",
+                      filename));
+    } else if (shapes.size() > 1) {
+      throw std::runtime_error(
+          fmt::format("The OBJ file contains multiple objects; only OBJs with "
+                      "a single object are supported: File name: '{}'",
                       filename));
     }
 


### PR DESCRIPTION
Tweak the error messages when attempting to load objs for collision.

Previously, many possible failure modes were indirectly detected via tinyobjs result containing "zero" objects. This mechanism provided insufficient feedback to resolve disparate causes (e.g., not an OBJ at all). Now, we distinguish various error modes and give more specific error messages.

related to #14480

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15373)
<!-- Reviewable:end -->
