### PR TITLE
Revert "MosekSolver sets logging using CommonSolverOption"

### DIFF
--- a/bindings/pydrake/solvers/mosek_py.cc
+++ b/bindings/pydrake/solvers/mosek_py.cc
@@ -23,15 +23,10 @@ PYBIND11_MODULE(mosek, m) {
   py::class_<MosekSolver, SolverInterface> cls(
       m, "MosekSolver", doc.MosekSolver.doc);
   cls.def(py::init<>(), doc.MosekSolver.ctor.doc)
-      .def_static("id", &MosekSolver::id, doc.MosekSolver.id.doc);
-
-  {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    cls.def("set_stream_logging", &MosekSolver::set_stream_logging,
-        py::arg("flag"), py::arg("log_file"));
-#pragma GCC diagnostic pop
-  }
+      .def_static("id", &MosekSolver::id, doc.MosekSolver.id.doc)
+      .def("set_stream_logging", &MosekSolver::set_stream_logging,
+          py::arg("flag"), py::arg("log_file"),
+          doc.MosekSolver.set_stream_logging.doc);
   pysolvers::BindAcquireLicense(&cls, doc.MosekSolver);
 
   py::class_<MosekSolverDetails>(

--- a/bindings/pydrake/solvers/test/mosek_solver_test.py
+++ b/bindings/pydrake/solvers/test/mosek_solver_test.py
@@ -14,11 +14,10 @@ class TestMathematicalProgram(unittest.TestCase):
         solver = MosekSolver()
         self.assertEqual(solver.solver_id(), MosekSolver.id())
         # Mosek prints output to the terminal.
-        solver_options = mp.SolverOptions()
-        solver_options.SetOption(mp.CommonSolverOption.kPrintToConsole, 1)
+        solver.set_stream_logging(True, "")
         self.assertTrue(solver.available())
         self.assertEqual(solver.solver_type(), mp.SolverType.kMosek)
-        result = solver.Solve(prog, None, solver_options)
+        result = solver.Solve(prog, None, None)
         self.assertTrue(result.is_success())
         x_expected = np.array([1, 1])
         self.assertTrue(np.allclose(result.GetSolution(x), x_expected))

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -1373,7 +1373,6 @@ drake_cc_googletest(
         ":sos_examples",
         "//common:filesystem",
         "//common:temp_directory",
-        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/solvers/mosek_solver.cc
+++ b/solvers/mosek_solver.cc
@@ -1853,46 +1853,14 @@ void MosekSolver::DoSolve(const MathematicalProgram& prog,
   }
 
   // log file.
-  bool print_to_console = false;
-  bool print_to_file = false;
-  // Refer to https://docs.mosek.com/9.2/capi/solver-io.html#stream-logging
-  // for Mosek stream logging.
-  if (rescode == MSK_RES_OK) {
-    auto it_kPrintToConsole = merged_options.common_solver_options().find(
-        CommonSolverOption::kPrintToConsole);
-    if (it_kPrintToConsole != merged_options.common_solver_options().end()) {
-      if (std::get<int>(it_kPrintToConsole->second) == 1) {
-        rescode =
-            MSK_linkfunctotaskstream(task, MSK_STREAM_LOG, nullptr, printstr);
-        print_to_console = true;
-      }
-    }
-    auto it_kPrintFileName = merged_options.common_solver_options().find(
-        CommonSolverOption::kPrintFileName);
-    if (it_kPrintFileName != merged_options.common_solver_options().end()) {
-      rescode = MSK_linkfiletotaskstream(
-          task, MSK_STREAM_LOG,
-          std::get<std::string>(it_kPrintFileName->second).c_str(), 0);
-      print_to_file = true;
-    }
-  }
-  // TODO(hongkai.dai) remove stream_logging_ and log_file_ once
-  // set_stream_logging() is deprecated on 2021-11-01.
   if (rescode == MSK_RES_OK && stream_logging_) {
     if (log_file_.empty()) {
       rescode =
           MSK_linkfunctotaskstream(task, MSK_STREAM_LOG, nullptr, printstr);
-      print_to_console = true;
     } else {
       rescode =
           MSK_linkfiletotaskstream(task, MSK_STREAM_LOG, log_file_.c_str(), 0);
-      print_to_file = true;
     }
-  }
-  if (print_to_console && print_to_file) {
-    throw std::runtime_error(
-        "MosekSolver::Solve(): cannot print to both the console and the log "
-        "file.");
   }
 
   // Mosek can accept the initial guess on its integer/binary variables, but

--- a/solvers/mosek_solver.h
+++ b/solvers/mosek_solver.h
@@ -71,9 +71,6 @@ class MosekSolver final : public SolverBase {
    * set @p log_file to the name of that file. If the user wants to output the
    * logging to the console, then set log_file to empty string.
    */
-  DRAKE_DEPRECATED("2021-11-01",
-                   "Please set CommonSolverOption::kPrintFileName or "
-                   "CommonSolverOption::kPrintToConsole in SolverOptions")
   void set_stream_logging(bool flag, const std::string& log_file) {
     stream_logging_ = flag;
     log_file_ = log_file;

--- a/solvers/test/mosek_solver_test.cc
+++ b/solvers/test/mosek_solver_test.cc
@@ -4,7 +4,6 @@
 
 #include "drake/common/filesystem.h"
 #include "drake/common/temp_directory.h"
-#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/solvers/mathematical_program.h"
 #include "drake/solvers/mixed_integer_optimization_util.h"
 #include "drake/solvers/test/exponential_cone_program_examples.h"
@@ -217,46 +216,13 @@ GTEST_TEST(MosekTest, TestLogFile) {
   // By default, no logging file.
   EXPECT_FALSE(filesystem::exists({log_file}));
   // Output the logging to the console
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   solver.set_stream_logging(true, "");
   solver.Solve(prog, {}, {}, &result);
   EXPECT_FALSE(filesystem::exists({log_file}));
   // Output the logging to the file.
   solver.set_stream_logging(true, log_file);
-#pragma GCC diagnostic pop
   solver.Solve(prog, {}, {}, &result);
   EXPECT_TRUE(filesystem::exists({log_file}));
-}
-
-GTEST_TEST(MosekTest, TestLogging) {
-  // Test if we can print the logging info to a log file.
-  MathematicalProgram prog;
-  const auto x = prog.NewContinuousVariables<2>();
-  prog.AddLinearConstraint(x(0) + x(1) == 1);
-
-  const std::string log_file = temp_directory() + "/mosek_logging.log";
-  EXPECT_FALSE(filesystem::exists({log_file}));
-  MosekSolver solver;
-  MathematicalProgramResult result;
-  solver.Solve(prog, {}, {}, &result);
-  // By default, no logging file.
-  EXPECT_FALSE(filesystem::exists({log_file}));
-  // Print to console. We can only test this doesn't cause any runtime error. We
-  // can't test if the logging message is actually printed to the console.
-  SolverOptions solver_options;
-  solver_options.SetOption(CommonSolverOption::kPrintToConsole, 1);
-  solver.Solve(prog, {}, solver_options, &result);
-  solver_options.SetOption(CommonSolverOption::kPrintToConsole, 0);
-  // Output the logging to the console
-  solver_options.SetOption(CommonSolverOption::kPrintFileName, log_file);
-  solver.Solve(prog, {}, solver_options, &result);
-  EXPECT_TRUE(filesystem::exists({log_file}));
-  // Now set both print to console and the log file. This will cause an error.
-  solver_options.SetOption(CommonSolverOption::kPrintToConsole, 1);
-  DRAKE_EXPECT_THROWS_MESSAGE(
-      solver.Solve(prog, {}, solver_options, &result), std::runtime_error,
-      ".* cannot print to both the console and the log file.");
 }
 
 GTEST_TEST(MosekTest, SolverOptionsTest) {


### PR DESCRIPTION
Dear @hongkai-dai,

 The on-call build cop, @BetsyMcPhail , believes that your PR #15360 may have
 broken one or more of Drake's continuous integration builds [1]. It is
 possible to break a build even if your PR passed continuous integration
 pre-merge because additional platforms are tested post-merge.

 The specific build failures under investigation are:
 https://drake-jenkins.csail.mit.edu/job/linux-bionic-clang-bazel-continuous-everything-leak-sanitizer/340/
https://drake-jenkins.csail.mit.edu/job/linux-bionic-clang-bazel-continuous-everything-address-sanitizer/3628/

 Therefore, the build cop has created this revert PR and started a complete
 post-merge build to determine whether your PR was in fact the cause of the
 problem. If that build passes, this revert PR will be merged 60 minutes from
 now. You can then fix the problem at your leisure, and send a new PR to
 reinstate your change.

 If you believe your original PR did not actually break the build, please
 explain on this thread.

 If you believe you can fix the break promptly in lieu of a revert, please
 explain on this thread, and send a PR to the build cop for review ASAP.

 If you believe your original PR definitely did break the build and should be
 reverted, please review and LGTM this PR. This allows the build cop to merge
 without waiting for CI results.

 For advice on how to handle a build cop revert, see [2].

 Thanks!
 Your Friendly On-call Build Cop

 [1] CI Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Production/
 [2] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15375)
<!-- Reviewable:end -->
