### PR TITLE
[trajectories] Update exception unit tests to match current guide

### DIFF
--- a/common/trajectories/test/bspline_trajectory_test.cc
+++ b/common/trajectories/test/bspline_trajectory_test.cc
@@ -346,7 +346,6 @@ GTEST_TEST(BsplineTrajectorySerializeTests, NotEnoughControlPointsTest) {
   BsplineTrajectory<double> dut{};
     DRAKE_EXPECT_THROWS_MESSAGE(
       YamlReadArchive(YAML::Load(not_enough_control_points)).Accept(&dut),
-      std::runtime_error,
       ".*CheckInvariants.*");
 }
 

--- a/common/trajectories/test/discrete_time_trajectory_test.cc
+++ b/common/trajectories/test/discrete_time_trajectory_test.cc
@@ -50,13 +50,13 @@ GTEST_TEST(DiscreteTimeTrajectoryTest, ValueThrowsTest) {
   DiscreteTimeTrajectory<double> traj(times, values);
 
   DRAKE_EXPECT_THROWS_MESSAGE(
-      traj.value(-1), std::runtime_error,
+      traj.value(-1),
       "Value requested at time -1(\\.0)? does not match .*");
   DRAKE_EXPECT_THROWS_MESSAGE(
-      traj.value(0.4), std::runtime_error,
+      traj.value(0.4),
       "Value requested at time 0.4 does not match .*");
   DRAKE_EXPECT_THROWS_MESSAGE(
-      traj.value(1), std::runtime_error,
+      traj.value(1),
       "Value requested at time 1(\\.0)? does not match .*");
 
   const double kLooseTolerance = 0.1;
@@ -106,13 +106,13 @@ GTEST_TEST(DicreteTimeTrajectoryTest, SymbolicTimes) {
   values << 6, 5, 67, 5, -4, 1, 34, 16, -23;
 
   DRAKE_EXPECT_THROWS_MESSAGE(
-      DiscreteTimeTrajectory<Expression>(times, values), std::runtime_error,
+      DiscreteTimeTrajectory<Expression>(times, values),
       ".*environment does not have an entry for the variable t.*\n*");
 
   times[1] = 0.4;
   DiscreteTimeTrajectory<Expression> traj(times, values);
   DRAKE_EXPECT_THROWS_MESSAGE(
-      traj.value(t), std::runtime_error,
+      traj.value(t),
       ".*environment does not have an entry for the variable t.*\n*");
 }
 

--- a/common/trajectories/test/piecewise_polynomial_test.cc
+++ b/common/trajectories/test/piecewise_polynomial_test.cc
@@ -265,7 +265,7 @@ GTEST_TEST(testPiecewisePolynomial, ExceptionsTest) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(
           breaks, samples, true),
-      std::runtime_error, "Times must be in increasing order.");
+      "Times must be in increasing order.");
 }
 
 GTEST_TEST(testPiecewisePolynomial, AllTests) {
@@ -300,7 +300,7 @@ GTEST_TEST(testPiecewisePolynomial, VectorValueTest) {
 
   PiecewisePolynomial<double> mat(Eigen::Matrix3d::Identity());
   DRAKE_EXPECT_THROWS_MESSAGE(
-      mat.vector_values(times), std::runtime_error,
+      mat.vector_values(times),
       "This method only supports vector-valued trajectories.");
 }
 

--- a/common/trajectories/test/trajectory_test.cc
+++ b/common/trajectories/test/trajectory_test.cc
@@ -40,13 +40,13 @@ GTEST_TEST(TrajectoryTest, EvalDerivativesTest) {
   EXPECT_TRUE(traj_yes_deriv.has_derivative());
   DRAKE_EXPECT_THROWS_MESSAGE(
       traj_yes_deriv.EvalDerivative(traj_yes_deriv.start_time()),
-      std::logic_error, ".* must implement .*");
+      ".* must implement .*");
 
   TrajectoryTester traj_no_deriv(false);
   EXPECT_FALSE(traj_no_deriv.has_derivative());
   DRAKE_EXPECT_THROWS_MESSAGE(
       traj_no_deriv.EvalDerivative(traj_no_deriv.start_time()),
-      std::logic_error, ".* does not support .*");
+      ".* does not support .*");
 }
 
 GTEST_TEST(TrajectoryTest, MakeDerivativesTest) {
@@ -54,13 +54,13 @@ GTEST_TEST(TrajectoryTest, MakeDerivativesTest) {
   EXPECT_TRUE(traj_yes_deriv.has_derivative());
   DRAKE_EXPECT_THROWS_MESSAGE(
       traj_yes_deriv.MakeDerivative(),
-      std::logic_error, ".* must implement .*");
+      ".* must implement .*");
 
   TrajectoryTester traj_no_deriv(false);
   EXPECT_FALSE(traj_no_deriv.has_derivative());
   DRAKE_EXPECT_THROWS_MESSAGE(
       traj_no_deriv.MakeDerivative(),
-      std::logic_error, ".* does not support .*");
+      ".* does not support .*");
 }
 
 template <typename T>

--- a/math/test/bspline_basis_test.cc
+++ b/math/test/bspline_basis_test.cc
@@ -104,12 +104,12 @@ TYPED_TEST(BsplineBasisTests, ConstructorErrors) {
       "The number of basis functions (.*) should be greater than or equal to "
       "the order (.*).";
   DRAKE_EXPECT_THROWS_MESSAGE(BsplineBasis<double>(order, 3),
-                              std::invalid_argument, expected_message_0);
+                              expected_message_0);
   const char* expected_message_1 =
       "The number of knots (.*) should be greater than or equal to twice the "
       "order (.*).";
   DRAKE_EXPECT_THROWS_MESSAGE(BsplineBasis<T>(order, {0, 1, 2, 3, 4, 5, 6}),
-                              std::invalid_argument, expected_message_1);
+                              expected_message_1);
 }
 
 // Verifies that ComputeActiveBasisFunctionIndices() returns the correct values
@@ -332,7 +332,6 @@ GTEST_TEST(BsplineBasisSerializeTests, NotEnoughKnotsTest) {
   BsplineBasis<double> dut{};
   DRAKE_EXPECT_THROWS_MESSAGE(
       YamlReadArchive(YAML::Load(not_enough_knots)).Accept(&dut),
-      std::runtime_error,
       ".*CheckInvariants.*");
 }
 
@@ -344,7 +343,6 @@ GTEST_TEST(BsplineBasisSerializeTests, UnsortedKnotsTest) {
   BsplineBasis<double> dut{};
   DRAKE_EXPECT_THROWS_MESSAGE(
       YamlReadArchive(YAML::Load(unsorted_knots)).Accept(&dut),
-      std::runtime_error,
       ".*CheckInvariants.*");
 }
 

--- a/math/test/quadratic_form_test.cc
+++ b/math/test/quadratic_form_test.cc
@@ -81,7 +81,6 @@ GTEST_TEST(TestDecomposePSDmatrixIntoXtransposeTimesX, negativeY) {
   // Y is a negative definite matrix.
   DRAKE_EXPECT_THROWS_MESSAGE(
       DecomposePSDmatrixIntoXtransposeTimesX(-Eigen::Matrix3d::Identity(), 0),
-      std::runtime_error,
       "Y is not positive definite. It has an eigenvalue -1.* that is more "
       "negative than the tolerance 0.*.");
 }


### PR DESCRIPTION
_"Only test for a specific subtype of `std::exception` when the subtype is **necessary** to determine whether the code behaved correctly."_

-- per https://github.com/RobotLocomotion/styleguide/pull/45/commits/c68a09ad882b81c825cf824062d3abb62487f51a which has been merged, but hasn't percolated to reach our GSG website hosting yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15377)
<!-- Reviewable:end -->
