### PR TITLE
[cassie_bench] Add Expression support

### DIFF
--- a/examples/multibody/cassie_benchmark/BUILD.bazel
+++ b/examples/multibody/cassie_benchmark/BUILD.bazel
@@ -28,6 +28,7 @@ drake_cc_test(
 sh_test(
     name = "record_results",
     size = "small",
+    timeout = "moderate",
     srcs = ["record_results.sh"],
     data = [
         ":cassie_bench",

--- a/examples/multibody/cassie_benchmark/test/cassie_bench.cc
+++ b/examples/multibody/cassie_benchmark/test/cassie_bench.cc
@@ -8,6 +8,7 @@
 #include "drake/multibody/plant/multibody_plant.h"
 
 using drake::multibody::MultibodyPlant;
+using drake::symbolic::Expression;
 using drake::systems::Context;
 using drake::test::LimitMalloc;
 
@@ -297,6 +298,67 @@ BENCHMARK_F(CassieAutodiffFixture, AutodiffForwardDynamics)
     compute();
   }
   tracker_.Report(&state);
+}
+
+// Fixture that holds a Cassie robot model in a MultibodyPlant<Expression>. It
+// also holds a default context for Expression.
+class CassieExpressionFixture : public CassieDoubleFixture {
+ public:
+  using CassieDoubleFixture::SetUp;
+  void SetUp(benchmark::State& state) override {
+    CassieDoubleFixture::SetUp(state);
+    plant_expression_ = systems::System<double>::ToSymbolic(*plant_);
+    context_expression_ = plant_expression_->CreateDefaultContext();
+  }
+
+  // @see CassieDoubleFixture::InvalidateState(). This method invalidates the
+  // expression version of state.
+  void InvalidateState() override {
+    context_expression_->NoteContinuousStateChange();
+  }
+
+ protected:
+  std::unique_ptr<MultibodyPlant<Expression>> plant_expression_;
+  std::unique_ptr<Context<Expression>> context_expression_;
+};
+
+// This uses T=Expression, but all values are still constants (not variables).
+BENCHMARK_F(CassieExpressionFixture, ExpressionMassMatrix)
+    // NOLINTNEXTLINE(runtime/references) cpplint disapproves of gbench choices.
+    (benchmark::State& state) {
+  MatrixX<Expression> M(nv_, nv_);
+  for (auto _ : state) {
+    InvalidateState();
+    plant_expression_->CalcMassMatrix(*context_expression_, &M);
+  }
+}
+
+// This uses T=Expression, but all values are still constants (not variables).
+BENCHMARK_F(CassieExpressionFixture, ExpressionInverseDynamics)
+    // NOLINTNEXTLINE(runtime/references) cpplint disapproves of gbench choices.
+    (benchmark::State& state) {
+  VectorX<Expression> desired_vdot = VectorXd::Zero(nv_);
+  multibody::MultibodyForces<Expression> external_forces(*plant_expression_);
+  for (auto _ : state) {
+    InvalidateState();
+    plant_expression_->CalcInverseDynamics(
+        *context_expression_, desired_vdot, external_forces);
+  }
+}
+
+// This uses T=Expression, but all values are still constants (not variables).
+BENCHMARK_F(CassieExpressionFixture, ExpressionForwardDynamics)
+    // NOLINTNEXTLINE(runtime/references) cpplint disapproves of gbench choices.
+    (benchmark::State& state) {
+  auto derivatives = plant_expression_->AllocateTimeDerivatives();
+  auto& port_value = plant_expression_->get_actuation_input_port().FixValue(
+      context_expression_.get(), u_.cast<Expression>().eval());
+  for (auto _ : state) {
+    InvalidateState();
+    port_value.GetMutableData();  // Invalidates caching of inputs.
+    plant_expression_->CalcTimeDerivatives(
+        *context_expression_, derivatives.get());
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
This only tests Expression when using constants (not variables), but still serves as a proxy for the overhead of Expression vs double in cases where not all C++ variables are necessarily symbolic variables.

I found this useful when experimenting with various simplifications of Expression's constant cells.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15379)
<!-- Reviewable:end -->
