### PR TITLE
Allow model_instances for MBP::CalcJacobianCenterOfMassTranslationalVelocity()

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -334,7 +334,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
             },
             py::arg("context"), py::arg("with_respect_to"), py::arg("frame_A"),
             py::arg("frame_E"),
-            cls_doc.CalcJacobianCenterOfMassTranslationalVelocity.doc)
+            cls_doc.CalcJacobianCenterOfMassTranslationalVelocity.doc_5args)
         .def("GetFreeBodyPose", &Class::GetFreeBodyPose, py::arg("context"),
             py::arg("body"), cls_doc.GetFreeBodyPose.doc)
         .def("SetFreeBodyPose",

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3227,8 +3227,6 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// are no massive bodies in MultibodyPlant (except world_body()).
   /// @throws std::exception if mₛ ≤ 0 (where mₛ is the mass of all non-world
   /// bodies contained in `this` MultibodyPlant).
-  /// @throws std::exception if composite_mass <= 0, where composite_mass is
-  /// the total mass of all bodies except world_body() in MultibodyPlant.
   void CalcJacobianCenterOfMassTranslationalVelocity(
       const systems::Context<T>& context,
       JacobianWrtVariable with_respect_to,

--- a/multibody/plant/test/multibody_plant_com_test.cc
+++ b/multibody/plant/test/multibody_plant_com_test.cc
@@ -277,7 +277,7 @@ TEST_F(MultibodyPlantCenterOfMassTest, CenterOfMassPosition) {
           frame_W, frame_W, &Js_v_WCcm_W),
       "CalcJacobianCenterOfMassTranslationalVelocity\\(\\): There must be at "
       "least one non-world body contained in model_instances.");
-  
+
   // Verify CalcCenterOfMassPositionInWorld() works for 1 instance in
   // model_instances.
   model_instances.push_back(triangle_instance_);

--- a/multibody/plant/test/multibody_plant_com_test.cc
+++ b/multibody/plant/test/multibody_plant_com_test.cc
@@ -236,6 +236,15 @@ TEST_F(MultibodyPlantCenterOfMassTest, CenterOfMassPosition) {
       "CalcCenterOfMassTranslationalVelocityInWorld\\(\\): There must be at "
       "least one non-world body contained in model_instances.");
 
+  Eigen::MatrixXd Js_v_WCcm_W(3, plant_.num_velocities());
+  const Frame<double>& frame_W = plant_.world_frame();
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      plant_.CalcJacobianCenterOfMassTranslationalVelocity(
+          *context_, model_instances, JacobianWrtVariable::kV,
+          frame_W, frame_W, &Js_v_WCcm_W),
+      "CalcJacobianCenterOfMassTranslationalVelocity\\(\\): There must be at "
+      "least one non-world body contained in model_instances.");
+
   // Ensure an exception is thrown when a model instance has one world body.
   const ModelInstanceIndex world_model_instance =
       multibody::world_model_instance();
@@ -247,6 +256,13 @@ TEST_F(MultibodyPlantCenterOfMassTest, CenterOfMassPosition) {
       "CalcCenterOfMassTranslationalVelocityInWorld\\(\\): There must be at "
       "least one non-world body contained in model_instances.");
 
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      plant_.CalcJacobianCenterOfMassTranslationalVelocity(
+          *context_, model_instances, JacobianWrtVariable::kV,
+          frame_W, frame_W, &Js_v_WCcm_W),
+      "CalcJacobianCenterOfMassTranslationalVelocity\\(\\): There must be at "
+      "least one non-world body contained in model_instances.");
+
   // Ensure an exception is thrown when a model instance has two world bodies.
   world_model_instance_array.push_back(world_model_instance);
   DRAKE_EXPECT_THROWS_MESSAGE(
@@ -255,7 +271,15 @@ TEST_F(MultibodyPlantCenterOfMassTest, CenterOfMassPosition) {
       "CalcCenterOfMassTranslationalVelocityInWorld\\(\\): There must be at "
       "least one non-world body contained in model_instances.");
 
-  // Try one instance in model_instances.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      plant_.CalcJacobianCenterOfMassTranslationalVelocity(
+          *context_, model_instances, JacobianWrtVariable::kV,
+          frame_W, frame_W, &Js_v_WCcm_W),
+      "CalcJacobianCenterOfMassTranslationalVelocity\\(\\): There must be at "
+      "least one non-world body contained in model_instances.");
+  
+  // Verify CalcCenterOfMassPositionInWorld() works for 1 instance in
+  // model_instances.
   model_instances.push_back(triangle_instance_);
   p_WCcm = plant_.CalcCenterOfMassPositionInWorld(*context_, model_instances);
   EXPECT_TRUE(CompareMatrices(p_WCcm, p_WTo_W + p_TTcm_T_, kTolerance));
@@ -290,8 +314,13 @@ TEST_F(MultibodyPlantCenterOfMassTest, CenterOfMassPosition) {
       "CalcCenterOfMassTranslationalVelocityInWorld\\(\\): The "
       "system's total mass must be greater than zero.");
 
-  Eigen::MatrixXd Js_v_WCcm_W(3, plant_.num_velocities());
-  const Frame<double>& frame_W = plant_.world_frame();
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      plant_.CalcJacobianCenterOfMassTranslationalVelocity(
+          *context_, model_instances, JacobianWrtVariable::kV,
+          frame_W, frame_W, &Js_v_WCcm_W),
+      "CalcJacobianCenterOfMassTranslationalVelocity\\(\\): The "
+      "system's total mass must be greater than zero.");
+
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant_.CalcJacobianCenterOfMassTranslationalVelocity(
       *context_, JacobianWrtVariable::kV, frame_W, frame_W, &Js_v_WCcm_W),
@@ -313,6 +342,10 @@ TEST_F(MultibodyPlantCenterOfMassTest, CenterOfMassPosition) {
   EXPECT_THROW(plant_.CalcCenterOfMassTranslationalVelocityInWorld(
                    *context_, model_instances),
                        std::exception);
+  EXPECT_THROW(plant_.CalcJacobianCenterOfMassTranslationalVelocity(
+          *context_, model_instances, JacobianWrtVariable::kV,
+          frame_W, frame_W, &Js_v_WCcm_W),
+              std::exception);
 }
 
 }  // namespace

--- a/multibody/plant/test/multibody_plant_jacobians_test.cc
+++ b/multibody/plant/test/multibody_plant_jacobians_test.cc
@@ -309,8 +309,6 @@ class TwoDOFPlanarPendulumTest : public ::testing::Test {
     bodyB_instance_ = plant_->AddModelInstance("bodyBInstanceName");
     bodyA_ = &plant_->AddRigidBody("bodyA", bodyA_instance_, M_Bcm);
     bodyB_ = &plant_->AddRigidBody("bodyB", bodyB_instance_, M_Bcm);
-    // bodyA_ = &plant_->AddRigidBody("BodyA", M_Bcm);
-    // bodyB_ = &plant_->AddRigidBody("BodyB", M_Bcm);
 
     // Create a revolute joint that connects point Wo of the world frame to a
     // unnamed point of link A that is a distance of link_length/2 from link A's

--- a/multibody/plant/test/multibody_plant_jacobians_test.cc
+++ b/multibody/plant/test/multibody_plant_jacobians_test.cc
@@ -305,8 +305,12 @@ class TwoDOFPlanarPendulumTest : public ::testing::Test {
 
     // Create an empty MultibodyPlant and then add the two links.
     plant_ = std::make_unique<MultibodyPlant<double>>(0.0);
-    bodyA_ = &plant_->AddRigidBody("BodyA", M_Bcm);
-    bodyB_ = &plant_->AddRigidBody("BodyB", M_Bcm);
+    bodyA_instance_ = plant_->AddModelInstance("bodyAInstanceName");
+    bodyB_instance_ = plant_->AddModelInstance("bodyBInstanceName");
+    bodyA_ = &plant_->AddRigidBody("bodyA", bodyA_instance_, M_Bcm);
+    bodyB_ = &plant_->AddRigidBody("bodyB", bodyB_instance_, M_Bcm);
+    // bodyA_ = &plant_->AddRigidBody("BodyA", M_Bcm);
+    // bodyB_ = &plant_->AddRigidBody("BodyB", M_Bcm);
 
     // Create a revolute joint that connects point Wo of the world frame to a
     // unnamed point of link A that is a distance of link_length/2 from link A's
@@ -357,6 +361,8 @@ class TwoDOFPlanarPendulumTest : public ::testing::Test {
   const RigidBody<double>* bodyB_{nullptr};
   const RevoluteJoint<double>* joint1_{nullptr};
   const RevoluteJoint<double>* joint2_{nullptr};
+  ModelInstanceIndex bodyA_instance_;
+  ModelInstanceIndex bodyB_instance_;
 };
 
 TEST_F(TwoDOFPlanarPendulumTest, CalcBiasAccelerations) {
@@ -457,40 +463,6 @@ TEST_F(TwoDOFPlanarPendulumTest,
   joint1_->set_angular_rate(context_.get(), state[2]);
   joint2_->set_angular_rate(context_.get(), state[3]);
 
-  // Test for CalcJacobianCenterOfMassTranslationalVelocity().
-  const Frame<double>& frame_W = plant_->world_frame();
-  Eigen::MatrixXd Js_v_WScm_W(3, plant_->num_velocities());
-  plant_->CalcJacobianCenterOfMassTranslationalVelocity(
-      *context_, JacobianWrtVariable::kV, frame_W, frame_W, &Js_v_WScm_W);
-
-  Eigen::MatrixXd Js_v_WScm_W_expected(3, plant_->num_velocities());
-  // Denoting Scm as the center of mass of the system formed by links A and B,
-  // Scm's velocity in world W is expected to be (L wAz_ + 0.25 L wBz_) Wy,
-  // hence Scm's translational Jacobian with respect to {wAz_ , wBz_} is
-  // { L Wy, 0.25 L Wy } = { [0, L, 0] [0, 0.25 L, 0] }
-  Js_v_WScm_W_expected << 0.0, 0.0,
-                          link_length_, 0.25 * link_length_,
-                          0.0, 0.0;
-  const Vector3d v_WScm_W_expected =
-      (wAz_ * link_length_ + wBz_ * 0.25 * link_length_) * Vector3d::UnitY();
-  EXPECT_TRUE(CompareMatrices(Js_v_WScm_W, Js_v_WScm_W_expected, kTolerance));
-  EXPECT_TRUE(
-      CompareMatrices(Js_v_WScm_W * state.tail(plant_->num_velocities()),
-                      v_WScm_W_expected, kTolerance));
-
-  // Test for CalcBiasCenterOfMassTranslationalAcceleration()
-  const Vector3<double>& abias_WScm_W =
-      plant_->CalcBiasCenterOfMassTranslationalAcceleration(
-          *context_, JacobianWrtVariable::kV, plant_->world_frame(),
-          plant_->world_frame());
-
-  // Scm's bias translational in world W is expected to be
-  // abias_WScm = -L (wAz_² + 0.5 wAz_ wBz_ + 0.25 wBz_²) 𝐖𝐱
-  Vector3d abias_WScm_W_expected =
-      -link_length_ * (wAz_ * wAz_ + 0.5 * wAz_ * wBz_ + 0.25 * wBz_ * wBz_) *
-      Vector3d::UnitX();
-  EXPECT_TRUE(CompareMatrices(abias_WScm_W, abias_WScm_W_expected, kTolerance));
-
   // Shortcuts to rigid bodies.
   const RigidBody<double>& body_A = rigid_bodyA();
   const RigidBody<double>& body_B = rigid_bodyB();
@@ -512,11 +484,76 @@ TEST_F(TwoDOFPlanarPendulumTest,
   // Verify MultibodyPlant::CalcCenterOfMassTranslationalVelocityInWorld().
   const Vector3d v_WScm_W =
       plant_->CalcCenterOfMassTranslationalVelocityInWorld(*context_);
+  const Vector3d v_WScm_W_expected =
+      (wAz_ * link_length_ + wBz_ * 0.25 * link_length_) * Vector3d::UnitY();
   EXPECT_TRUE(CompareMatrices(v_WScm_W, v_WScm_W_expected, kTolerance));
   const Vector3d v_WScm_W_alternate = (mass_link_ * v_WAcm_W_expected
                                     +  mass_link_ * v_WBcm_W_expected)
                                     / (2 * mass_link_);
   EXPECT_TRUE(CompareMatrices(v_WScm_W, v_WScm_W_alternate, kTolerance));
+
+  // Test CalcJacobianCenterOfMassTranslationalVelocity() for full MBP.
+  const int num_velocities = plant_->num_velocities();
+  const Frame<double>& frame_W = plant_->world_frame();
+  Eigen::MatrixXd Js_v_WScm_W(3, num_velocities);
+  plant_->CalcJacobianCenterOfMassTranslationalVelocity(
+      *context_, JacobianWrtVariable::kV, frame_W, frame_W, &Js_v_WScm_W);
+
+  Eigen::MatrixXd Js_v_WScm_W_expected(3, num_velocities);
+  // Denoting Scm as the center of mass of the system formed by links A and B,
+  // Scm's velocity in world W is expected to be (L wAz_ + 0.25 L wBz_) Wy,
+  // hence Scm's translational Jacobian with respect to {wAz_ , wBz_} is
+  // { L Wy, 0.25 L Wy } = { [0, L, 0] [0, 0.25 L, 0] }
+  Js_v_WScm_W_expected << 0.0, 0.0,
+                          link_length_, 0.25 * link_length_,
+                          0.0, 0.0;
+  EXPECT_TRUE(CompareMatrices(Js_v_WScm_W, Js_v_WScm_W_expected, kTolerance));
+  EXPECT_TRUE(
+      CompareMatrices(Js_v_WScm_W * state.tail(num_velocities),
+                      v_WScm_W_expected, kTolerance));
+
+  // Test CalcJacobianCenterOfMassTranslationalVelocity() for 1 model instance.
+  std::vector<ModelInstanceIndex> model_instances;
+  const ModelInstanceIndex bodyA_instance_index =
+      plant_->GetModelInstanceByName("bodyAInstanceName");
+  model_instances.push_back(bodyA_instance_index);
+  Eigen::MatrixXd Js_v_WAcm_W(3, num_velocities);
+  plant_->CalcJacobianCenterOfMassTranslationalVelocity(*context_,
+      model_instances, JacobianWrtVariable::kV, frame_W, frame_W, &Js_v_WAcm_W);
+
+  // Acm's velocity in world W is expected to be 0.5 L wAz_ Wy,
+  // hence Acm's translational Jacobian with respect to {wAz_ , wBz_} is
+  // { 0.5 L Wy, 0 } = { [0, 0.5 L, 0] [0, 0, 0] }
+  Eigen::MatrixXd Js_v_WAcm_W_expected(3, num_velocities);
+  Js_v_WAcm_W_expected << 0.0, 0.0,
+                          0.5 * link_length_, 0.0,
+                          0.0, 0.0;
+  EXPECT_TRUE(CompareMatrices(Js_v_WAcm_W, Js_v_WAcm_W_expected, kTolerance));
+  EXPECT_TRUE(
+      CompareMatrices(Js_v_WAcm_W * state.tail(num_velocities),
+                      v_WAcm_W_expected, kTolerance));
+
+  // Test CalcJacobianCenterOfMassTranslationalVelocity() for 2 model instances.
+  // This should produce the same results as Scm (system center of mass).
+  const ModelInstanceIndex bodyB_instance_index =
+      plant_->GetModelInstanceByName("bodyBInstanceName");
+  model_instances.push_back(bodyB_instance_index);
+  plant_->CalcJacobianCenterOfMassTranslationalVelocity(*context_,
+      model_instances, JacobianWrtVariable::kV, frame_W, frame_W, &Js_v_WScm_W);
+  EXPECT_TRUE(CompareMatrices(Js_v_WAcm_W, Js_v_WAcm_W_expected, kTolerance));
+
+  // Test for CalcBiasCenterOfMassTranslationalAcceleration().
+  const Vector3<double>& abias_WScm_W =
+      plant_->CalcBiasCenterOfMassTranslationalAcceleration(
+          *context_, JacobianWrtVariable::kV, plant_->world_frame(),
+          plant_->world_frame());
+
+  // Scm's bias translational in world W is expected to be
+  // abias_WScm = -L (wAz_² + 0.5 wAz_ wBz_ + 0.25 wBz_²) 𝐖𝐱
+  Vector3d abias_WScm_W_expected =
+      -link_length_ * (wAz_ * wAz_ + 0.5 * wAz_ * wBz_ + 0.25 * wBz_ * wBz_) *
+      Vector3d::UnitX();
+  EXPECT_TRUE(CompareMatrices(abias_WScm_W, abias_WScm_W_expected, kTolerance));
 }
 
 // Fixture for two degree-of-freedom 3D satellite tracker with bodies A and B.

--- a/multibody/plant/test/multibody_plant_jacobians_test.cc
+++ b/multibody/plant/test/multibody_plant_jacobians_test.cc
@@ -463,10 +463,6 @@ TEST_F(TwoDOFPlanarPendulumTest,
   plant_->CalcJacobianCenterOfMassTranslationalVelocity(
       *context_, JacobianWrtVariable::kV, frame_W, frame_W, &Js_v_WScm_W);
 
-  // Test for CalcJacobianCenterOfMassTranslationalVelocity().
-  plant_->CalcJacobianCenterOfMassTranslationalVelocity(
-      *context_, JacobianWrtVariable::kV, frame_W, frame_W, &Js_v_WScm_W);
-
   Eigen::MatrixXd Js_v_WScm_W_expected(3, plant_->num_velocities());
   // Denoting Scm as the center of mass of the system formed by links A and B,
   // Scm's velocity in world W is expected to be (L wAz_ + 0.25 L wBz_) Wy,

--- a/multibody/plant/test/multibody_plant_jacobians_test.cc
+++ b/multibody/plant/test/multibody_plant_jacobians_test.cc
@@ -463,6 +463,10 @@ TEST_F(TwoDOFPlanarPendulumTest,
   plant_->CalcJacobianCenterOfMassTranslationalVelocity(
       *context_, JacobianWrtVariable::kV, frame_W, frame_W, &Js_v_WScm_W);
 
+  // Test for CalcJacobianCenterOfMassTranslationalVelocity().
+  plant_->CalcJacobianCenterOfMassTranslationalVelocity(
+      *context_, JacobianWrtVariable::kV, frame_W, frame_W, &Js_v_WScm_W);
+
   Eigen::MatrixXd Js_v_WScm_W_expected(3, plant_->num_velocities());
   // Denoting Scm as the center of mass of the system formed by links A and B,
   // Scm's velocity in world W is expected to be (L wAz_ + 0.25 L wBz_) Wy,

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -2608,11 +2608,11 @@ void MultibodyTree<T>::CalcJacobianCenterOfMassTranslationalVelocity(
 
 template<typename T>
 void MultibodyTree<T>::CalcJacobianCenterOfMassTranslationalVelocity(
-    const systems::Context<T> &context,
-    const std::vector<ModelInstanceIndex> &model_instances,
+    const systems::Context<T>& context,
+    const std::vector<ModelInstanceIndex>& model_instances,
     JacobianWrtVariable with_respect_to,
-    const Frame<T> &frame_A,
-    const Frame<T> &frame_E,
+    const Frame<T>& frame_A,
+    const Frame<T>& frame_E,
     EigenPtr<Matrix3X<T>> Js_v_ACcm_E) const {
   const int num_columns = (with_respect_to == JacobianWrtVariable::kQDot) ?
                           num_positions() : num_velocities();
@@ -2641,11 +2641,11 @@ void MultibodyTree<T>::CalcJacobianCenterOfMassTranslationalVelocity(
   // model_instances in std::vector are considered an upstream user error.
   int number_of_non_world_bodies_processed = 0;
   for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
-    const Body<T> &body = get_body(body_index);
+    const Body<T>& body = get_body(body_index);
     if (std::find(model_instances.begin(), model_instances.end(),
                   body.model_instance()) != model_instances.end()) {
       // total mass = ∑ mᵢ.
-      const T &body_mass = body.get_mass(context);
+      const T& body_mass = body.get_mass(context);
       total_mass += body_mass;
       ++number_of_non_world_bodies_processed;
 

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -1240,8 +1240,19 @@ class MultibodyTree {
 
   // See MultibodyPlant method.
   void CalcJacobianCenterOfMassTranslationalVelocity(
-      const systems::Context<T>& context, JacobianWrtVariable with_respect_to,
-      const Frame<T>& frame_A, const Frame<T>& frame_E,
+      const systems::Context<T>& context,
+      JacobianWrtVariable with_respect_to,
+      const Frame<T>& frame_A,
+      const Frame<T>& frame_E,
+      EigenPtr<Matrix3X<T>> Js_v_ACcm_E) const;
+
+  // See MultibodyPlant method.
+  void CalcJacobianCenterOfMassTranslationalVelocity(
+      const systems::Context<T>& context,
+      const std::vector<ModelInstanceIndex>& model_instances,
+      JacobianWrtVariable with_respect_to,
+      const Frame<T>& frame_A,
+      const Frame<T>& frame_E,
       EigenPtr<Matrix3X<T>> Js_v_ACcm_E) const;
 
   // See MultibodyPlant method.


### PR DESCRIPTION
New overload for MultibodyPlant::CalcJacobianCenterOfMassTranslationalVelocity() to allow for model_instances 
to resolve issue #14916.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15387)
<!-- Reviewable:end -->
