### PR TITLE
[kuka_iiwa] Add unit tests to lock in heap-less operation

### DIFF
--- a/manipulation/kuka_iiwa/BUILD.bazel
+++ b/manipulation/kuka_iiwa/BUILD.bazel
@@ -97,6 +97,7 @@ drake_cc_googletest(
     deps = [
         ":iiwa_command_sender",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:limit_malloc",
     ],
 )
 
@@ -105,6 +106,7 @@ drake_cc_googletest(
     deps = [
         ":iiwa_status_receiver",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:limit_malloc",
     ],
 )
 

--- a/manipulation/kuka_iiwa/test/iiwa_command_sender_test.cc
+++ b/manipulation/kuka_iiwa/test/iiwa_command_sender_test.cc
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/limit_malloc.h"
 
 namespace drake {
 namespace manipulation {
@@ -11,6 +12,8 @@ namespace kuka_iiwa {
 namespace {
 
 using Eigen::VectorXd;
+using drake::test::LimitMalloc;
+
 constexpr int N = kIiwaArmNumJoints;
 
 class IiwaCommandSenderTest : public testing::Test {
@@ -28,23 +31,51 @@ class IiwaCommandSenderTest : public testing::Test {
   IiwaCommandSender dut_;
   std::unique_ptr<systems::Context<double>> context_ptr_;
   systems::Context<double>& context_;
+
+  const VectorXd q0_{VectorXd::LinSpaced(N, 0.1, 0.2)};
+  const std::vector<double> std_q0_{q0_.data(), q0_.data() + q0_.size()};
+
+  const VectorXd t0_{VectorXd::LinSpaced(N, 0.3, 0.4)};
+  const std::vector<double> std_t0_{t0_.data(), t0_.data() + t0_.size()};
 };
 
 TEST_F(IiwaCommandSenderTest, AcceptanceTest) {
-  const VectorXd q0 = VectorXd::LinSpaced(N, 0.1, 0.2);
-  const std::vector<double> std_q0 = {q0.data(), q0.data() + q0.size()};
-  dut_.get_position_input_port().FixValue(&context_, q0);
+  dut_.get_position_input_port().FixValue(&context_, q0_);
   EXPECT_EQ(output().num_joints, N);
-  EXPECT_EQ(output().joint_position, std_q0);
+  EXPECT_EQ(output().joint_position, std_q0_);
   EXPECT_EQ(output().num_torques, 0);
 
-  const VectorXd t0 = VectorXd::LinSpaced(N, 0.3, 0.4);
-  const std::vector<double> std_t0 = {t0.data(), t0.data() + t0.size()};
-  dut_.get_torque_input_port().FixValue(&context_, t0);
+  dut_.get_torque_input_port().FixValue(&context_, t0_);
   EXPECT_EQ(output().num_joints, N);
-  EXPECT_EQ(output().joint_position, std_q0);
+  EXPECT_EQ(output().joint_position, std_q0_);
   EXPECT_EQ(output().num_torques, N);
-  EXPECT_EQ(output().joint_torque, std_t0);
+  EXPECT_EQ(output().joint_torque, std_t0_);
+}
+
+// This class is likely to be used on the critical path for robot control, so
+// we insist that it must not perform heap operations while in steady-state.
+TEST_F(IiwaCommandSenderTest, MallocTest) {
+  // Initialize and then invalidate the cached output.
+  auto& q = dut_.get_position_input_port().FixValue(&context_, q0_);
+  output();
+  q.GetMutableVectorData<double>();
+
+  // Recompute the output. No heap changes are allowed.
+  {
+    LimitMalloc guard;
+    output();
+  }
+
+  // Add torques, re-initialize, and then invalidate the cached output.
+  auto& tau = dut_.get_torque_input_port().FixValue(&context_, t0_);
+  output();
+  tau.GetMutableVectorData<double>();
+
+  // Recompute the output. No heap changes are allowed.
+  {
+    LimitMalloc guard;
+    output();
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
These classes are likely to be used on the critical path for robot control, so we insist they must not perform heap operations while in steady-state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15389)
<!-- Reviewable:end -->
