### PR TITLE
[lcm] Give DrakeLcm the ability to defer launching its thread

### DIFF
--- a/bindings/pydrake/lcm_py.cc
+++ b/bindings/pydrake/lcm_py.cc
@@ -50,6 +50,8 @@ PYBIND11_MODULE(lcm, m) {
         .def(py::init<>(), cls_doc.ctor.doc_0args)
         .def(
             py::init<std::string>(), py::arg("lcm_url"), cls_doc.ctor.doc_1args)
+        .def(py::init<std::string, bool>(), py::arg("lcm_url"),
+            py::arg("defer_initialization"), cls_doc.ctor.doc_2args)
         .def(
             "Subscribe",
             [](Class* self, const std::string& channel,

--- a/bindings/pydrake/test/lcm_test.py
+++ b/bindings/pydrake/test/lcm_test.py
@@ -17,6 +17,8 @@ class TestLcm(unittest.TestCase):
     def test_lcm(self):
         dut = DrakeLcm()
         self.assertIsInstance(dut, DrakeLcmInterface)
+        DrakeLcm(lcm_url="")
+        DrakeLcm(lcm_url="", defer_initialization=True)
         # Test virtual function names.
         dut.Publish
         dut.HandleSubscriptions

--- a/lcm/BUILD.bazel
+++ b/lcm/BUILD.bazel
@@ -2,11 +2,16 @@
 
 load(
     "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_binary",
     "drake_cc_googletest",
     "drake_cc_library",
     "drake_cc_package_library",
 )
-load("@drake//tools/skylark:drake_py.bzl", "drake_py_test")
+load(
+    "@drake//tools/skylark:drake_py.bzl",
+    "drake_py_test",
+    "drake_py_unittest",
+)
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 package(default_visibility = ["//visibility:public"])
@@ -133,6 +138,28 @@ drake_cc_googletest(
     deps = [
         ":drake_lcm",
         ":lcmt_drake_signal_utils",
+    ],
+)
+
+drake_cc_binary(
+    name = "initialization_sequence_test_stub",
+    testonly = True,
+    srcs = ["test/initialization_sequence_test_stub.cc"],
+    deps = [
+        ":drake_lcm",
+        "//common:add_text_logging_gflags",
+        "//lcmtypes:drake_signal",
+        "@gflags",
+    ],
+)
+
+drake_py_unittest(
+    name = "initialization_sequence_test",
+    data = [
+        ":initialization_sequence_test_stub",
+    ],
+    deps = [
+        "@bazel_tools//tools/python/runfiles",
     ],
 )
 

--- a/lcm/drake_lcm.h
+++ b/lcm/drake_lcm.h
@@ -32,6 +32,21 @@ class DrakeLcm : public DrakeLcmInterface {
   explicit DrakeLcm(std::string lcm_url);
 
   /**
+   * (Advanced) Constructs using the given URL, but with the ability to defer
+   * launching the receive thread.
+   *
+   * @param defer_initialization controls whether or not LCM's background
+   * receive thread will be launched immediately during the constructor
+   * (when false) or deferred until the first time it's needed (when true).
+   * This can be useful if the scheduling configuration for new threads varies
+   * between the construction time and and first use.  For other constructor
+   * overloads, this setting defaults to `false` -- the thread is launched
+   * immediately.
+   */
+  DrakeLcm(std::string lcm_url, bool defer_initialization);
+
+
+  /**
    * A destructor that forces the receive thread to be stopped.
    */
   ~DrakeLcm() override;

--- a/lcm/test/drake_lcm_test.cc
+++ b/lcm/test/drake_lcm_test.cc
@@ -66,6 +66,13 @@ TEST_F(DrakeLcmTest, CustomUrlTest) {
   EXPECT_EQ(dut_->get_lcm_url(), kUdpmUrl);
 }
 
+TEST_F(DrakeLcmTest, DeferThreadTest) {
+  dut_ = std::make_unique<DrakeLcm>(kUdpmUrl, false);
+  EXPECT_EQ(dut_->get_lcm_url(), kUdpmUrl);
+  // There's no easy way to check whether the thread is running.  For now,
+  // we'll satisfy ourselves that the test compiles and preserves the URL.
+}
+
 TEST_F(DrakeLcmTest, EmptyChannelTest) {
   auto noop = [](const void*, int) {};
   DRAKE_EXPECT_THROWS_MESSAGE(dut_->Subscribe("", noop),

--- a/lcm/test/initialization_sequence_test.py
+++ b/lcm/test/initialization_sequence_test.py
@@ -1,0 +1,67 @@
+from subprocess import PIPE, STDOUT
+import sys
+import time
+import unittest
+
+from bazel_tools.tools.python.runfiles import runfiles
+
+# On macOS, we don't want to support this (somewhat tricky) test case on an
+# ongoing basis, we'll skip it.  (Thus, we also don't try to install psutil
+# as a dependency on macOS.)
+_SKIP = False
+if "darwin" in sys.platform:
+    _SKIP = True
+else:
+    import psutil
+
+
+class InitializationSequenceTest(unittest.TestCase):
+    """Checks for proper behavior of the `defer_initialization = true` argument
+    to the DrakeLcm constructor.  Reliably testing this is a bit tricky, so
+    we dedicate this entire test program for that purpose, distinct from all
+    of the other functional tests.
+    """
+
+    def setUp(self):
+        manifest = runfiles.Create()
+        self._stub_path = manifest.Rlocation(
+            "drake/lcm/initialization_sequence_test_stub")
+
+        # We need a non-memq URL for this test to be meaningful.  (By default,
+        # our configuration for the "bazel test" environment uses "memq://".)
+        self._lcm_url = "udpm://239.255.76.67:7671"
+
+    @unittest.skipIf(_SKIP, "Not supported on macOS")
+    def test_worker_threads(self):
+        # Launch the C++ stub.
+        dut = psutil.Popen(
+            [self._stub_path, f"--lcm_url={self._lcm_url}"],
+            stdin=PIPE, stdout=PIPE, stderr=STDOUT)
+
+        # Wait for it to complete constructing it's LCM instance and subscribe
+        # to a channel.
+        for line in dut.stdout:
+            line = line.decode("utf-8").strip()
+            print(f"dut says: {line}", flush=True)
+            if "recv_parts_test_stub: construction is complete" in line:
+                break
+            time.sleep(0.1)
+
+        # Check that it has not launched any threads, nor opened any sockets.
+        self.assertEqual(dut.num_threads(), 1)
+        self.assertListEqual(dut.connections(), [])
+
+        # Prompt it to active the recv parts on the LCM instance and wait until
+        # that is complete.
+        dut.stdin.write("dummy\n".encode("utf-8"))
+        dut.stdin.flush()
+        for line in dut.stdout:
+            line = line.decode("utf-8").strip()
+            print(f"dut says: {line}", flush=True)
+            if "recv_parts_test_stub: activation is complete" in line:
+                break
+            time.sleep(0.1)
+
+        # Check that it has launched a thread and opened sockets.
+        self.assertGreater(dut.num_threads(), 1)
+        self.assertGreater(len(dut.connections()), 1)

--- a/lcm/test/initialization_sequence_test_stub.cc
+++ b/lcm/test/initialization_sequence_test_stub.cc
@@ -1,0 +1,47 @@
+#include <iostream>
+#include <thread>
+
+#include <gflags/gflags.h>
+
+#include "drake/common/text_logging.h"
+#include "drake/lcm/drake_lcm.h"
+#include "drake/lcmt_drake_signal.hpp"
+
+// This program is a helper stub for initialization_sequence_test.py.
+
+DEFINE_string(lcm_url, "", "");
+
+namespace drake {
+namespace lcm {
+namespace test {
+namespace {
+
+void PauseForInput() {
+  std::string dummy;
+  std::getline(std::cin, dummy);
+}
+
+int main() {
+  const bool defer_initialization = true;
+  DrakeLcm dut(FLAGS_lcm_url, defer_initialization);
+  Subscriber<lcmt_drake_signal> subscriber(&dut, "CHANNEL_NAME");
+
+  log()->info("recv_parts_test_stub: construction is complete");
+  PauseForInput();
+
+  dut.HandleSubscriptions(0);
+  log()->info("recv_parts_test_stub: activation is complete");
+  PauseForInput();
+
+  return 0;
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace lcm
+}  // namespace drake
+
+int main(int argc, char* argv[]) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  return drake::lcm::test::main();
+}


### PR DESCRIPTION
This can be useful if the scheduling configuration for new threads varies between the construction time and and first use.

- [x] Requires #15392.
- [x] Requires #15395.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15390)
<!-- Reviewable:end -->
