### PR TITLE
[lcm] SerializerInterface is now cloneable

### DIFF
--- a/bindings/pydrake/systems/_lcm_extra.py
+++ b/bindings/pydrake/systems/_lcm_extra.py
@@ -13,6 +13,9 @@ class PySerializer(SerializerInterface):
         SerializerInterface.__init__(self)
         self._lcm_type = lcm_type
 
+    def Clone(self):
+        return PySerializer(self._lcm_type)
+
     def CreateDefaultValue(self):
         return AbstractValue.Make(self._lcm_type())
 

--- a/bindings/pydrake/systems/lcm_py.cc
+++ b/bindings/pydrake/systems/lcm_py.cc
@@ -40,6 +40,11 @@ class PySerializerInterface : public py::wrapper<SerializerInterface> {
   // `PySerializerInterface`). C++ implementations will use the bindings on the
   // interface below.
 
+  std::unique_ptr<SerializerInterface> Clone() const override {
+    PYBIND11_OVERLOAD_PURE(
+        std::unique_ptr<SerializerInterface>, SerializerInterface, Clone);
+  }
+
   std::unique_ptr<AbstractValue> CreateDefaultValue() const override {
     PYBIND11_OVERLOAD_PURE(std::unique_ptr<AbstractValue>, SerializerInterface,
         CreateDefaultValue);
@@ -138,6 +143,7 @@ PYBIND11_MODULE(lcm, m) {
                   message_bytes.size());
             },
             py::arg("abstract_value"), cls_doc.Serialize.doc);
+    DefClone(&cls);
   }
 
   {

--- a/bindings/pydrake/systems/test/lcm_test.py
+++ b/bindings/pydrake/systems/test/lcm_test.py
@@ -74,6 +74,10 @@ class TestSystemsLcm(unittest.TestCase):
         raw = dut.Serialize(value)
         reconstruct = lcmt_quaternion.decode(raw)
         self.assert_lcm_equal(reconstruct, model_message)
+        # Check cloning.
+        cloned_dut = dut.Clone()
+        fresh_value = dut.CreateDefaultValue().get_value()
+        self.assertIsInstance(fresh_value, lcmt_quaternion)
 
     def test_serializer_cpp(self):
         # Tests relevant portions of API.
@@ -81,6 +85,10 @@ class TestSystemsLcm(unittest.TestCase):
         model_value = self._model_value_cpp()
         self.assert_lcm_equal(
             self._cpp_value_to_py_message(model_value), model_message)
+
+    def test_serializer_cpp_clone(self):
+        serializer = mut._Serializer_[lcmt_quaternion]()
+        serializer.Clone().CreateDefaultValue()
 
     def _process_event(self, dut):
         # Use a Simulator to invoke the update event on `dut`.  (Wouldn't it be

--- a/systems/lcm/serializer.h
+++ b/systems/lcm/serializer.h
@@ -25,6 +25,9 @@ class SerializerInterface {
 
   virtual ~SerializerInterface();
 
+  /** Creates a deep copy of this. */
+  virtual std::unique_ptr<SerializerInterface> Clone() const = 0;
+
   /**
    * Creates a value-initialized (zeroed) instance of the message object.
    * The result can be used as the output object filled in by Deserialize.
@@ -45,7 +48,7 @@ class SerializerInterface {
                          std::vector<uint8_t>* message_bytes) const = 0;
 
  protected:
-  SerializerInterface() {}
+  SerializerInterface() = default;
 };
 
 /**
@@ -59,8 +62,12 @@ class Serializer : public SerializerInterface {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Serializer)
 
-  Serializer() {}
-  ~Serializer() override {}
+  Serializer() = default;
+  ~Serializer() override = default;
+
+  std::unique_ptr<SerializerInterface> Clone() const override {
+    return std::make_unique<Serializer>();
+  }
 
   std::unique_ptr<AbstractValue> CreateDefaultValue() const override {
     // NOTE: We create the message using value-initialization ("{}") to ensure

--- a/systems/lcm/test/serializer_test.cc
+++ b/systems/lcm/test/serializer_test.cc
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/is_cloneable.h"
 #include "drake/lcm/lcmt_drake_signal_utils.h"
 #include "drake/lcmt_drake_signal.hpp"
 
@@ -42,6 +43,13 @@ GTEST_TEST(SerializerTest, BasicTest) {
                    abstract_value.get());
   EXPECT_TRUE(CompareLcmtDrakeSignalMessages(
       abstract_value->get_value<lcmt_drake_signal>(), sample_data));
+
+  // Cloning works.
+  EXPECT_TRUE(is_cloneable<SerializerInterface>::value);
+  auto fresh = dut->Clone();
+  ASSERT_NE(fresh, nullptr);
+  auto fresh_value = fresh->CreateDefaultValue();
+  EXPECT_EQ(fresh_value->get_value<lcmt_drake_signal>().dim, 0);
 }
 
 }  // namespace


### PR DESCRIPTION
Modernize "= default" boilerplate while we're here.

This is breaking change because we add a new pure-virtual method to the C++ SerializerInterface base class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15394)
<!-- Reviewable:end -->
