### PR TITLE
[geometry] Deprecate old collision filter API; use CollisionFilterManager

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -560,27 +560,44 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("collision_filter_manager",
             overload_cast_explicit<CollisionFilterManager>(
                 &Class::collision_filter_manager),
-            cls_doc.collision_filter_manager.doc_0args)
+            cls_doc.collision_filter_manager.doc_0args);
+
+// TODO(2021-11-01) Remove these bindings with deprecated code. We can also
+//  eliminate the breaking "cls //BR" below and put it all together in a stream
+//  of .defs.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
         .def("ExcludeCollisionsBetween",
-            py::overload_cast<const GeometrySet&, const GeometrySet&>(
-                &Class::ExcludeCollisionsBetween),
+            WrapDeprecated(
+                cls_doc.ExcludeCollisionsBetween.doc_deprecated_2args,
+                py::overload_cast<const GeometrySet&, const GeometrySet&>(
+                    &Class::ExcludeCollisionsBetween)),
             py_rvp::reference_internal, py::arg("setA"), py::arg("setB"),
-            cls_doc.ExcludeCollisionsBetween.doc_2args)
+            cls_doc.ExcludeCollisionsBetween.doc_deprecated_2args)
         .def("ExcludeCollisionsBetween",
-            overload_cast_explicit<void, Context<T>*, const GeometrySet&,
-                const GeometrySet&>(&Class::ExcludeCollisionsBetween),
+            WrapDeprecated(
+                cls_doc.ExcludeCollisionsBetween.doc_deprecated_3args,
+                overload_cast_explicit<void, Context<T>*, const GeometrySet&,
+                    const GeometrySet&>(&Class::ExcludeCollisionsBetween)),
             py_rvp::reference_internal, py::arg("context"), py::arg("setA"),
-            py::arg("setB"), cls_doc.ExcludeCollisionsBetween.doc_3args)
+            py::arg("setB"),
+            cls_doc.ExcludeCollisionsBetween.doc_deprecated_3args)
         .def("ExcludeCollisionsWithin",
-            py::overload_cast<const GeometrySet&>(
-                &Class::ExcludeCollisionsWithin),
+            WrapDeprecated(cls_doc.ExcludeCollisionsWithin.doc_deprecated_1args,
+                py::overload_cast<const GeometrySet&>(
+                    &Class::ExcludeCollisionsWithin)),
             py_rvp::reference_internal, py::arg("set"),
-            cls_doc.ExcludeCollisionsWithin.doc_1args)
+            cls_doc.ExcludeCollisionsWithin.doc_deprecated_1args)
         .def("ExcludeCollisionsWithin",
-            overload_cast_explicit<void, Context<T>*, const GeometrySet&>(
-                &Class::ExcludeCollisionsWithin),
+            WrapDeprecated(cls_doc.ExcludeCollisionsWithin.doc_deprecated_2args,
+                overload_cast_explicit<void, Context<T>*, const GeometrySet&>(
+                    &Class::ExcludeCollisionsWithin)),
             py_rvp::reference_internal, py::arg("context"), py::arg("set"),
-            cls_doc.ExcludeCollisionsWithin.doc_2args)
+            cls_doc.ExcludeCollisionsWithin.doc_deprecated_2args);
+#pragma GCC diagnostic pop
+
+    cls  // BR
         .def("AddRenderer", &Class::AddRenderer, py::arg("name"),
             py::arg("renderer"), cls_doc.AddRenderer.doc)
         .def("HasRenderer", &Class::HasRenderer, py::arg("name"),

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -773,11 +773,13 @@ class TestGeometry(unittest.TestCase):
         dut.Apply(
             mut.CollisionFilterDeclaration().ExcludeWithin(geometries))
 
+        # TODO(2021-11-01) Remove these with deprecation resolution.
         # Legacy API
-        sg.ExcludeCollisionsBetween(geometries, geometries)
-        sg.ExcludeCollisionsBetween(sg_context, geometries, geometries)
-        sg.ExcludeCollisionsWithin(geometries)
-        sg.ExcludeCollisionsWithin(sg_context, geometries)
+        with catch_drake_warnings(expected_count=4):
+            sg.ExcludeCollisionsBetween(geometries, geometries)
+            sg.ExcludeCollisionsBetween(sg_context, geometries, geometries)
+            sg.ExcludeCollisionsWithin(geometries)
+            sg.ExcludeCollisionsWithin(sg_context, geometries)
 
     @numpy_compare.check_nonsymbolic_types
     def test_value_instantiations(self, T):

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -835,7 +835,9 @@ class SceneGraph final : public systems::LeafSystem<T> {
       systems::Context<T>* context) const;
   //@}
 
-  /** @name         Collision filtering (Legacy)
+  // TODO(2021-11-01) Remove this entire group when completing deprecation of
+  //  the methods below.
+  /** @name         Collision filtering (Deprecated)
    @anchor scene_graph_collision_filtering
    The *legacy* interface for limiting the scope of penetration queries (i.e.,
    "filtering collisions").
@@ -892,11 +894,19 @@ class SceneGraph final : public systems::LeafSystem<T> {
 
    @throws std::exception if the set includes ids that don't exist in the
                           scene graph.  */
+  DRAKE_DEPRECATED(
+      "2021-11-01",
+      "Please call collision_filter_manager().Apply() "
+      "instead")
   void ExcludeCollisionsWithin(const GeometrySet& set);
 
   /** systems::Context-modifying variant of ExcludeCollisionsWithin(). Rather
    than modifying %SceneGraph's model, it modifies the copy of the model stored
    in the provided context.  */
+  DRAKE_DEPRECATED(
+      "2021-11-01",
+      "Please call collision_filter_manager(context).Apply() "
+      "instead")
   void ExcludeCollisionsWithin(systems::Context<T>* context,
                                const GeometrySet& set) const;
 
@@ -912,12 +922,20 @@ class SceneGraph final : public systems::LeafSystem<T> {
 
    @throws std::exception if the groups include ids that don't exist in the
                           scene graph.  */
+  DRAKE_DEPRECATED(
+      "2021-11-01",
+      "Please call collision_filter_manager().Apply() "
+      "instead")
   void ExcludeCollisionsBetween(const GeometrySet& setA,
                                 const GeometrySet& setB);
 
   /** systems::Context-modifying variant of ExcludeCollisionsBetween(). Rather
    than modifying %SceneGraph's model, it modifies the copy of the model stored
    in the provided context.  */
+  DRAKE_DEPRECATED(
+      "2021-11-01",
+      "Please call collision_filter_manager(context).Apply()"
+      " instead")
   void ExcludeCollisionsBetween(systems::Context<T>* context,
                                 const GeometrySet& setA,
                                 const GeometrySet& setB) const;

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -359,19 +359,23 @@ TEST_F(SceneGraphTest, TransmogrifyContext) {
   DRAKE_EXPECT_NO_THROW(context_ad->SetTimeStateAndParametersFrom(*context));
 }
 
+// TODO(2021-11-01) Remove this test entirely when resolving deprecation.
 // Tests that exercising the collision filtering logic *after* allocation is
 // allowed.
-TEST_F(SceneGraphTest, PostAllocationCollisionFilteringLegacy) {
+TEST_F(SceneGraphTest, PostAllocationCollisionFilteringDeprecated) {
   SourceId source_id = scene_graph_.RegisterSource("filter_after_allocation");
   FrameId frame_id =
       scene_graph_.RegisterFrame(source_id, GeometryFrame("dummy"));
   CreateDefaultContext();
 
   GeometrySet geometry_set{frame_id};
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   DRAKE_EXPECT_NO_THROW(scene_graph_.ExcludeCollisionsWithin(geometry_set));
 
   DRAKE_EXPECT_NO_THROW(
       scene_graph_.ExcludeCollisionsBetween(geometry_set, geometry_set));
+#pragma GCC diagnostic pop
 }
 
 // Tests the model inspector. Exercises a token piece of functionality. The
@@ -731,7 +735,8 @@ GTEST_TEST(SceneGraphContextModifier, RegisterGeometry) {
       "Referenced geometry \\d+ has not been registered.");
 }
 
-GTEST_TEST(SceneGraphContextModifier, CollisionFiltersLegacy) {
+// TODO(2021-11-01) Remove this test entirely when resolving deprecation.
+GTEST_TEST(SceneGraphContextModifier, CollisionFiltersDeprecated) {
   // Initializes the scene graph and context.
   SceneGraph<double> scene_graph;
   // Simple scene with three frames, each with a sphere which, by default
@@ -773,6 +778,8 @@ GTEST_TEST(SceneGraphContextModifier, CollisionFiltersLegacy) {
   EXPECT_FALSE(inspector.CollisionFiltered(g_id1, g_id3));
   EXPECT_FALSE(inspector.CollisionFiltered(g_id2, g_id3));
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   scene_graph.ExcludeCollisionsWithin(context.get(),
                                       GeometrySet({g_id1, g_id2}));
   EXPECT_TRUE(inspector.CollisionFiltered(g_id1, g_id2));
@@ -782,6 +789,7 @@ GTEST_TEST(SceneGraphContextModifier, CollisionFiltersLegacy) {
   scene_graph.ExcludeCollisionsBetween(context.get(),
                                        GeometrySet({g_id1, g_id2}),
                                        GeometrySet({g_id3}));
+#pragma GCC diagnostic pop
   EXPECT_TRUE(inspector.CollisionFiltered(g_id1, g_id2));
   EXPECT_TRUE(inspector.CollisionFiltered(g_id1, g_id3));
   EXPECT_TRUE(inspector.CollisionFiltered(g_id2, g_id3));

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -38,6 +38,7 @@ namespace multibody {
 // pre-finalize.
 #define DRAKE_MBP_THROW_IF_NOT_FINALIZED() ThrowIfNotFinalized(__func__)
 
+using geometry::CollisionFilterDeclaration;
 using geometry::ContactSurface;
 using geometry::FrameId;
 using geometry::FramePoseVector;
@@ -786,6 +787,12 @@ struct MultibodyPlant<T>::SceneGraphStub {
     }
   };
 
+  struct StubCollisionFilterManager {
+    void Apply(const geometry::CollisionFilterDeclaration&) {
+      return;
+    }
+  };
+
   static void Throw(const char* operation_name) {
     throw std::logic_error(fmt::format(
         "Cannot {} on a SceneGraph<symbolic::Expression>", operation_name));
@@ -800,14 +807,16 @@ struct MultibodyPlant<T>::SceneGraphStub {
   Ret Name(Args...) const { Throw(#Name); return Ret(); }
 
   DRAKE_STUB(void, AssignRole)
-  DRAKE_STUB(void, ExcludeCollisionsBetween)
-  DRAKE_STUB(void, ExcludeCollisionsWithin)
   DRAKE_STUB(FrameId, RegisterFrame)
   DRAKE_STUB(GeometryId, RegisterGeometry)
   DRAKE_STUB(SourceId, RegisterSource)
   const StubSceneGraphInspector model_inspector() const {
     Throw("model_inspector");
     return StubSceneGraphInspector();
+  }
+  StubCollisionFilterManager collision_filter_manager() {
+    Throw("collision_filter_manager");
+    return StubCollisionFilterManager();
   }
 
 #undef DRAKE_STUB
@@ -850,16 +859,18 @@ void MultibodyPlant<T>::FilterAdjacentBodies() {
     std::optional<FrameId> parent_id = GetBodyFrameIdIfExists(parent.index());
 
     if (child_id && parent_id) {
-      member_scene_graph().ExcludeCollisionsBetween(
+      member_scene_graph().collision_filter_manager().Apply(
+        CollisionFilterDeclaration().ExcludeBetween(
           geometry::GeometrySet(*child_id),
-          geometry::GeometrySet(*parent_id));
+          geometry::GeometrySet(*parent_id)));
     }
   }
   // We must explicitly exclude collisions between all geometries registered
   // against the world.
   // TODO(eric.cousineau): Do this in a better fashion (#11117).
   auto g_world = CollectRegisteredGeometries(GetBodiesWeldedTo(world_body()));
-  member_scene_graph().ExcludeCollisionsWithin(g_world);
+  member_scene_graph().collision_filter_manager().Apply(
+      CollisionFilterDeclaration().ExcludeWithin(g_world));
 }
 
 template <typename T>
@@ -873,8 +884,12 @@ void MultibodyPlant<T>::ExcludeCollisionsWithVisualGeometry() {
   for (const auto& body_geometries : collision_geometries_) {
     collision.Add(body_geometries);
   }
-  member_scene_graph().ExcludeCollisionsWithin(visual);
-  member_scene_graph().ExcludeCollisionsBetween(visual, collision);
+  // clang-format off
+  member_scene_graph().collision_filter_manager().Apply(
+      CollisionFilterDeclaration()
+          .ExcludeWithin(visual)
+          .ExcludeBetween(visual, collision));
+  // clang-format on
 }
 
 template <typename T>
@@ -887,15 +902,17 @@ void MultibodyPlant<T>::ExcludeCollisionGeometriesWithCollisionFilterGroupPair(
   DRAKE_DEMAND(geometry_source_is_registered());
 
   if (collision_filter_group_a.first == collision_filter_group_b.first) {
-    member_scene_graph().ExcludeCollisionsWithin(
-        collision_filter_group_a.second);
+    member_scene_graph().collision_filter_manager().Apply(
+        CollisionFilterDeclaration().ExcludeWithin(
+            collision_filter_group_a.second));
   } else {
-    member_scene_graph().ExcludeCollisionsBetween(
-        collision_filter_group_a.second, collision_filter_group_b.second);
+    member_scene_graph().collision_filter_manager().Apply(
+        CollisionFilterDeclaration().ExcludeBetween(
+            collision_filter_group_a.second, collision_filter_group_b.second));
   }
 }
 
-template<typename T>
+template <typename T>
 void MultibodyPlant<T>::CalcNormalAndTangentContactJacobians(
     const systems::Context<T>& context,
     const std::vector<internal::DiscreteContactPair<T>>& contact_pairs,

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1351,8 +1351,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   /// For each of the provided `bodies`, collects up all geometries that have
   /// been registered to that body. Intended to be used in conjunction with
-  /// SceneGraph::ExcludeCollisionsWithin() and
-  /// SceneGraph::ExcludeCollisionsBetween() to filter collisions between the
+  /// CollisionFilterDeclaration and
+  /// CollisionFilterManager::Apply() to filter collisions between the
   /// geometries registered to the bodies.
   ///
   /// For example:
@@ -1361,7 +1361,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// // `body2`, or `body3`.
   /// std::vector<const RigidBody<T>*> bodies{&body1, &body2, &body3};
   /// geometry::GeometrySet set = plant.CollectRegisteredGeometries(bodies);
-  /// scene_graph.ExcludeCollisionsWithin(set);
+  /// scene_graph.collision_filter_manager().Apply(
+  ///     CollisionFilterDeclaration().ExcludeWithin(set));
   /// ```
   ///
   /// @note There is a *very* specific order of operations:


### PR DESCRIPTION
The only meaningful invocation of the old API (outsdie of tests) was in `MultibodyPlant`. Using the new API required modifying the `symbolic::Expression` stub to include a stub `CollisionFilterManager`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15396)
<!-- Reviewable:end -->
