### PR TITLE
[solvers] Add bindings for MathematicalProgram::AddCost(shared_ptr, vars)

### DIFF
--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -54,7 +54,6 @@ using solvers::SolverInterface;
 using solvers::SolverOptions;
 using solvers::SolverType;
 using solvers::SolverTypeConverter;
-using solvers::VariableRefList;
 using solvers::VectorXDecisionVariable;
 using solvers::VectorXIndeterminate;
 using solvers::VisualizationCallback;
@@ -718,13 +717,21 @@ top-level documentation for :py:mod:`pydrake.math`.
           py::arg("func"), py::arg("vars"), py::arg("description") = "",
           // N.B. There is no corresponding C++ method, so the docstring here
           // is a literal, not a reference to documentation_pybind.h
-          "Adds a cost function")
+          "Adds a cost function.")
       .def("AddCost",
           static_cast<Binding<Cost> (MathematicalProgram::*)(
               const Expression&)>(&MathematicalProgram::AddCost),
           // N.B. There is no corresponding C++ method, so the docstring here
           // is a literal, not a reference to documentation_pybind.h
-          "Adds a cost expression")
+          "Adds a cost expression.")
+      .def(
+          "AddCost",
+          [](MathematicalProgram* self, const std::shared_ptr<Cost>& obj,
+              const Eigen::Ref<const VectorXDecisionVariable>& vars) {
+            return self->AddCost(obj, vars);
+          },
+          py::arg("obj"), py::arg("vars"),
+          doc.MathematicalProgram.AddCost.doc_2args_obj_vars)
       .def("AddLinearCost",
           static_cast<Binding<LinearCost> (MathematicalProgram::*)(
               const Expression&)>(&MathematicalProgram::AddLinearCost),

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -883,6 +883,8 @@ class MathematicalProgram {
 
   /**
    * Adds a generic cost to the optimization program.
+   *
+   * @exclude_from_pydrake_mkdoc{Not bound in pydrake.}
    */
   Binding<Cost> AddCost(const Binding<Cost>& binding);
 
@@ -890,6 +892,8 @@ class MathematicalProgram {
    * Adds a cost type to the optimization program.
    * @param obj The added objective.
    * @param vars The decision variables on which the cost depend.
+   *
+   * @pydrake_mkdoc_identifier{2args_obj_vars}
    */
   template <typename C>
   auto AddCost(const std::shared_ptr<C>& obj,
@@ -903,6 +907,8 @@ class MathematicalProgram {
    * Adds a generic cost to the optimization program.
    * @param obj The added objective.
    * @param vars The decision variables on which the cost depend.
+   *
+   * @exclude_from_pydrake_mkdoc{Not bound in pydrake.}
    */
   template <typename C>
   auto AddCost(const std::shared_ptr<C>& obj, const VariableRefList& vars) {
@@ -922,6 +928,8 @@ class MathematicalProgram {
   /**
    * Adds a cost to the optimization program on a list of variables.
    * @tparam F it should define functions numInputs, numOutputs and eval. Check
+   *
+   * @exclude_from_pydrake_mkdoc{Not bound in pydrake.}
    */
   template <typename F>
   typename std::enable_if_t<internal::is_cost_functor_candidate<F>::value,
@@ -934,6 +942,8 @@ class MathematicalProgram {
    * Adds a cost to the optimization program on an Eigen::Vector containing
    * decision variables.
    * @tparam F Type that defines functions numInputs, numOutputs and eval.
+   *
+   * @exclude_from_pydrake_mkdoc{Not bound in pydrake.}
    */
   template <typename F>
   typename std::enable_if_t<internal::is_cost_functor_candidate<F>::value,
@@ -947,6 +957,8 @@ class MathematicalProgram {
    * Statically assert if a user inadvertently passes a
    * binding-compatible Constraint.
    * @tparam F The type to check.
+   *
+   * @exclude_from_pydrake_mkdoc{Not bound in pydrake.}
    */
   template <typename F, typename Vars>
   typename std::enable_if_t<internal::assert_if_is_constraint<F>::value,
@@ -959,6 +971,8 @@ class MathematicalProgram {
    * Adds a cost term of the form c'*x.
    * Applied to a subset of the variables and pushes onto
    * the linear cost data structure.
+   *
+   * @exclude_from_pydrake_mkdoc{Not bound in pydrake.}
    */
   Binding<LinearCost> AddCost(const Binding<LinearCost>& binding);
 
@@ -1007,6 +1021,8 @@ class MathematicalProgram {
    * Adds a cost term of the form 0.5*x'*Q*x + b'x.
    * Applied to subset of the variables and pushes onto
    * the quadratic cost data structure.
+   *
+   * @exclude_from_pydrake_mkdoc{Not bound in pydrake.}
    */
   Binding<QuadraticCost> AddCost(const Binding<QuadraticCost>& binding);
 
@@ -1151,6 +1167,8 @@ class MathematicalProgram {
    * @param e The linear or quadratic expression of the cost.
    * @pre `e` is linear or `e` is quadratic. Otherwise throws a runtime error.
    * @return The newly created cost, together with the bound variables.
+   *
+   * @exclude_from_pydrake_mkdoc{Not bound in pydrake.}
    */
   Binding<Cost> AddCost(const symbolic::Expression& e);
 


### PR DESCRIPTION
There are a number of very similar entry points for adding costs to mathematical program.  We only binding a subset of them so far.  I elected to bind this variant because we don't currently binding the constructor for the `Binding_*` classes (although I've confirmed that this is also easy to do).

This also follows the current pattern in `AddConstraint`.  The `AddConstraint((shared_ptr)` variant was already bound, but `AddConstraint(Binding<Constraint>)` is not (yet).

For most cases, we've avoided needing this because `MathematicalProgram` provides enough sugar methods to construct and add all of the variants of costs and constraints that user have been asking for.  But `L2NormCost` is a new case (until we outwait the deprecation period) where we cannot offer the right sugar.

Related to #15366.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15400)
<!-- Reviewable:end -->
