### PR TITLE
[kuka_iiwa] Clean and adjust for better parity with Anzu

### DIFF
--- a/manipulation/kuka_iiwa/iiwa_command_receiver.cc
+++ b/manipulation/kuka_iiwa/iiwa_command_receiver.cc
@@ -1,8 +1,6 @@
 #include "drake/manipulation/kuka_iiwa/iiwa_command_receiver.h"
 
-#include "drake/common/drake_assert.h"
 #include "drake/common/drake_throw.h"
-#include "drake/common/text_logging.h"
 #include "drake/lcm/lcm_messages.h"
 
 namespace drake {
@@ -10,11 +8,14 @@ namespace manipulation {
 namespace kuka_iiwa {
 
 using Eigen::VectorXd;
+using lcm::AreLcmMessagesEqual;
 using systems::BasicVector;
+using systems::CompositeEventCollection;
 using systems::Context;
 using systems::DiscreteValues;
 using systems::DiscreteUpdateEvent;
 using systems::NumericParameterIndex;
+using systems::kVectorValued;
 
 IiwaCommandReceiver::IiwaCommandReceiver(int num_joints)
     : num_joints_(num_joints) {
@@ -23,7 +24,7 @@ IiwaCommandReceiver::IiwaCommandReceiver(int num_joints)
   message_input_ = &DeclareAbstractInputPort(
       "lcmt_iiwa_command", Value<lcmt_iiwa_command>());
   position_measured_input_ = &DeclareInputPort(
-      "position_measured", systems::kVectorValued, num_joints);
+      "position_measured", kVectorValued, num_joints);
 
   // This cache entry provides either the input (iff connected) or else zero.
   position_measured_or_zero_ = &DeclareCacheEntry(
@@ -54,9 +55,11 @@ IiwaCommandReceiver::IiwaCommandReceiver(int num_joints)
       {defaulted_command_->ticket()});
 }
 
+IiwaCommandReceiver::~IiwaCommandReceiver() = default;
+
 void IiwaCommandReceiver::CalcPositionMeasuredOrZero(
-    const systems::Context<double>& context,
-    systems::BasicVector<double>* result) const {
+    const Context<double>& context,
+    BasicVector<double>* result) const {
   if (position_measured_input_->HasValue(context)) {
     result->SetFromVector(position_measured_input_->Eval(context));
   } else {
@@ -75,7 +78,7 @@ void IiwaCommandReceiver::LatchInitialPosition(
 }
 
 void IiwaCommandReceiver::LatchInitialPosition(
-    systems::Context<double>* context) const {
+    Context<double>* context) const {
   DRAKE_THROW_UNLESS(context != nullptr);
   LatchInitialPosition(*context, &context->get_mutable_discrete_state());
 }
@@ -84,8 +87,8 @@ void IiwaCommandReceiver::LatchInitialPosition(
 // "now" event.  We should try to consolidate it with other similar uses within
 // the source tree.  Relates to #11403 somewhat.
 void IiwaCommandReceiver::DoCalcNextUpdateTime(
-    const systems::Context<double>& context,
-    systems::CompositeEventCollection<double>* events, double* time) const {
+    const Context<double>& context,
+    CompositeEventCollection<double>* events, double* time) const {
   // We do not support events other than our own message timing events.
   LeafSystem<double>::DoCalcNextUpdateTime(context, events, time);
   DRAKE_THROW_UNLESS(events->HasEvents() == false);
@@ -108,13 +111,13 @@ void IiwaCommandReceiver::DoCalcNextUpdateTime(
 }
 
 void IiwaCommandReceiver::CalcDefaultedCommand(
-    const systems::Context<double>& context, lcmt_iiwa_command* result) const {
+    const Context<double>& context, lcmt_iiwa_command* result) const {
   // Copy the input value into our tentative result.
   *result = message_input_->Eval<lcmt_iiwa_command>(context);
 
   // If we haven't received a message yet, then fall back to the default
   // position.
-  if (lcm::AreLcmMessagesEqual(*result, lcmt_iiwa_command{})) {
+  if (AreLcmMessagesEqual(*result, lcmt_iiwa_command{})) {
     const BasicVector<double>& latch_is_set = context.get_discrete_state(
         latched_position_measured_is_set_);
     const BasicVector<double>& default_position =

--- a/manipulation/kuka_iiwa/iiwa_command_receiver.h
+++ b/manipulation/kuka_iiwa/iiwa_command_receiver.h
@@ -1,15 +1,9 @@
 #pragma once
 
-#include <memory>
-#include <string>
-#include <vector>
-
 #include "drake/common/drake_copyable.h"
-#include "drake/common/eigen_types.h"
 #include "drake/lcmt_iiwa_command.hpp"
 #include "drake/manipulation/kuka_iiwa/iiwa_constants.h"
 #include "drake/systems/framework/leaf_system.h"
-#include "drake/systems/lcm/lcm_subscriber_system.h"
 
 namespace drake {
 namespace manipulation {
@@ -46,11 +40,12 @@ namespace kuka_iiwa {
 /// available to achieve the same effect without using events.
 /// @par
 /// The "torque" output will always be a vector of zeros.
-class IiwaCommandReceiver : public systems::LeafSystem<double> {
+class IiwaCommandReceiver final : public systems::LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(IiwaCommandReceiver)
 
   explicit IiwaCommandReceiver(int num_joints = kIiwaArmNumJoints);
+  ~IiwaCommandReceiver() final;
 
   /// (Advanced.) Copies the current "position_measured" input (or zero if not
   /// connected) into Context state, and changes the behavior of the "position"
@@ -80,8 +75,7 @@ class IiwaCommandReceiver : public systems::LeafSystem<double> {
  private:
   void DoCalcNextUpdateTime(
       const systems::Context<double>&,
-      systems::CompositeEventCollection<double>*, double*) const override;
-
+      systems::CompositeEventCollection<double>*, double*) const final;
   void CalcPositionMeasuredOrZero(
       const systems::Context<double>&, systems::BasicVector<double>*) const;
   void LatchInitialPosition(

--- a/manipulation/kuka_iiwa/iiwa_command_sender.cc
+++ b/manipulation/kuka_iiwa/iiwa_command_sender.cc
@@ -14,6 +14,8 @@ IiwaCommandSender::IiwaCommandSender(int num_joints)
       "lcmt_iiwa_command", &IiwaCommandSender::CalcOutput);
 }
 
+IiwaCommandSender::~IiwaCommandSender() = default;
+
 using InPort = systems::InputPort<double>;
 const InPort& IiwaCommandSender::get_position_input_port() const {
   return LeafSystem<double>::get_input_port(0);

--- a/manipulation/kuka_iiwa/iiwa_command_sender.h
+++ b/manipulation/kuka_iiwa/iiwa_command_sender.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_deprecated.h"
 #include "drake/lcmt_iiwa_command.hpp"
 #include "drake/manipulation/kuka_iiwa/iiwa_constants.h"
 #include "drake/systems/framework/leaf_system.h"
@@ -33,11 +32,12 @@ namespace kuka_iiwa {
 /// @endsystem
 ///
 /// @see `lcmt_iiwa_command.lcm` for additional documentation.
-class IiwaCommandSender : public systems::LeafSystem<double> {
+class IiwaCommandSender final : public systems::LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(IiwaCommandSender)
 
   explicit IiwaCommandSender(int num_joints = kIiwaArmNumJoints);
+  ~IiwaCommandSender() final;
 
   /// @name Named accessors for this System's input and output ports.
   //@{

--- a/manipulation/kuka_iiwa/iiwa_status_receiver.cc
+++ b/manipulation/kuka_iiwa/iiwa_status_receiver.cc
@@ -1,6 +1,6 @@
 #include "drake/manipulation/kuka_iiwa/iiwa_status_receiver.h"
 
-#include "drake/common/drake_assert.h"
+#include "drake/common/drake_throw.h"
 
 namespace drake {
 namespace manipulation {
@@ -38,6 +38,8 @@ IiwaStatusReceiver::IiwaStatusReceiver(int num_joints)
       &IiwaStatusReceiver::CalcLcmOutput<
         &lcmt_iiwa_status::joint_torque_external>);
 }
+
+IiwaStatusReceiver::~IiwaStatusReceiver() = default;
 
 using OutPort = systems::OutputPort<double>;
 const OutPort& IiwaStatusReceiver::get_position_commanded_output_port() const {

--- a/manipulation/kuka_iiwa/iiwa_status_receiver.h
+++ b/manipulation/kuka_iiwa/iiwa_status_receiver.h
@@ -3,7 +3,6 @@
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_deprecated.h"
 #include "drake/lcmt_iiwa_status.hpp"
 #include "drake/manipulation/kuka_iiwa/iiwa_constants.h"
 #include "drake/systems/framework/leaf_system.h"
@@ -38,11 +37,12 @@ namespace kuka_iiwa {
 /// @endsystem
 ///
 /// @see `lcmt_iiwa_status.lcm` for additional documentation.
-class IiwaStatusReceiver : public systems::LeafSystem<double> {
+class IiwaStatusReceiver final : public systems::LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(IiwaStatusReceiver)
 
   explicit IiwaStatusReceiver(int num_joints = kIiwaArmNumJoints);
+  ~IiwaStatusReceiver() final;
 
   /// @name Named accessors for this System's input and output ports.
   //@{

--- a/manipulation/kuka_iiwa/iiwa_status_sender.cc
+++ b/manipulation/kuka_iiwa/iiwa_status_sender.cc
@@ -4,24 +4,22 @@ namespace drake {
 namespace manipulation {
 namespace kuka_iiwa {
 
+using drake::systems::Context;
+using drake::systems::kVectorValued;
+
 IiwaStatusSender::IiwaStatusSender(int num_joints)
     : num_joints_(num_joints),
       zero_vector_(Eigen::VectorXd::Zero(num_joints)) {
-  this->DeclareInputPort(
-      "position_commanded", systems::kVectorValued, num_joints_);
-  this->DeclareInputPort(
-      "position_measured", systems::kVectorValued, num_joints_);
-  this->DeclareInputPort(
-      "velocity_estimated", systems::kVectorValued, num_joints_);
-  this->DeclareInputPort(
-      "torque_commanded", systems::kVectorValued, num_joints_);
-  this->DeclareInputPort(
-      "torque_measured", systems::kVectorValued, num_joints_);
-  this->DeclareInputPort(
-      "torque_external", systems::kVectorValued, num_joints_);
-  this->DeclareAbstractOutputPort(
-      "lcmt_iiwa_status", &IiwaStatusSender::CalcOutput);
+  DeclareInputPort("position_commanded", kVectorValued, num_joints_);
+  DeclareInputPort("position_measured", kVectorValued, num_joints_);
+  DeclareInputPort("velocity_estimated", kVectorValued, num_joints_);
+  DeclareInputPort("torque_commanded", kVectorValued, num_joints_);
+  DeclareInputPort("torque_measured", kVectorValued, num_joints_);
+  DeclareInputPort("torque_external", kVectorValued, num_joints_);
+  DeclareAbstractOutputPort("lcmt_iiwa_status", &IiwaStatusSender::CalcOutput);
 }
+
+IiwaStatusSender::~IiwaStatusSender() = default;
 
 using InPort = systems::InputPort<double>;
 const InPort& IiwaStatusSender::get_position_commanded_input_port() const {
@@ -50,10 +48,10 @@ namespace {
 // If more than max_num_connected of (port1,port2) are connected, throws.
 // If port2_tail is provided, a suffix of port2's value is returned.
 Eigen::Ref<const Eigen::VectorXd> EvalFirstConnected(
-    const systems::Context<double>& context,
+    const Context<double>& context,
     int min_num_connected, int max_num_connected, const Eigen::VectorXd& zeros,
     const InPort& port1, const InPort& port2,
-    int port2_tail = -1) {
+    const int port2_tail = -1) {
   const int total_connected =
       (port1.HasValue(context) ? 1 : 0) +
       (port2.HasValue(context) ? 1 : 0);
@@ -80,11 +78,10 @@ Eigen::Ref<const Eigen::VectorXd> EvalFirstConnected(
   }
   return zeros;
 }
-
 }  // namespace
 
 void IiwaStatusSender::CalcOutput(
-    const systems::Context<double>& context, lcmt_iiwa_status* output) const {
+    const Context<double>& context, lcmt_iiwa_status* output) const {
   const auto& position_commanded =
       get_position_commanded_input_port().Eval(context);
   const auto& position_measured =

--- a/manipulation/kuka_iiwa/iiwa_status_sender.h
+++ b/manipulation/kuka_iiwa/iiwa_status_sender.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_deprecated.h"
 #include "drake/lcmt_iiwa_status.hpp"
 #include "drake/manipulation/kuka_iiwa/iiwa_constants.h"
 #include "drake/systems/framework/leaf_system.h"
@@ -50,11 +49,12 @@ namespace kuka_iiwa {
 /// @endsystem
 ///
 /// @see `lcmt_iiwa_status.lcm` for additional documentation.
-class IiwaStatusSender : public systems::LeafSystem<double> {
+class IiwaStatusSender final : public systems::LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(IiwaStatusSender)
 
   explicit IiwaStatusSender(int num_joints = kIiwaArmNumJoints);
+  ~IiwaStatusSender() final;
 
   /// @name Named accessors for this System's input and output ports.
   //@{


### PR DESCRIPTION
Adjust includes to remove extra / add missing.
Add using-statements so names don't flap while syncing this to Anzu.
Stop inlining the destructors (GSG) and mark classes as final.
Remove superfluous this-> and whitespace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15403)
<!-- Reviewable:end -->
