### PR TITLE
py mp: Use template Binding[{Type}]; deprecate old Binding_{Type}

### DIFF
--- a/bindings/pydrake/__init__.py
+++ b/bindings/pydrake/__init__.py
@@ -66,8 +66,14 @@ def _execute_extra_python_code(m):
             ).format(m.__name__))
     top_module_name = module_path[0]
     top_module_dir = os.path.dirname(sys.modules[top_module_name].__file__)
-    extra_path = [top_module_dir] + module_path[1:-1] + [
-        "_{}_extra.py".format(module_path[-1])]
+    mid_module_names = module_path[1:-1]
+    base_module_name = module_path[-1]
+    if base_module_name.startswith("_"):
+        # Do not repeat leading `_`.
+        extra_module_name = f"{base_module_name}_extra.py"
+    else:
+        extra_module_name = f"_{base_module_name}_extra.py"
+    extra_path = [top_module_dir] + mid_module_names + [extra_module_name]
     extra_filename = os.path.join(*extra_path)
     with open(extra_filename) as f:
         _code = compile(f.read(), extra_filename, 'exec')
@@ -80,7 +86,12 @@ def _setattr_kwargs(obj, kwargs):
         setattr(obj, name, value)
 
 
-def _import_cc_module_vars(cc_module, py_module_name):
+def _import_cc_module_vars(
+    cc_module,
+    py_module_name,
+    *,
+    include_private=False,
+):
     # Imports the cc_module's public symbols into the named py module
     # (py_module_name), resetting their __module__ to be the py module in the
     # process.
@@ -88,7 +99,9 @@ def _import_cc_module_vars(cc_module, py_module_name):
     py_module = sys.modules[py_module_name]
     var_list = []
     for name, value in cc_module.__dict__.items():
-        if name.startswith("_"):
+        if name.startswith("_") and not include_private:
+            continue
+        if name.startswith("__"):
             continue
         if getattr(value, "__module__", None) == cc_module.__name__:
             value.__module__ = py_module_name

--- a/bindings/pydrake/solvers/BUILD.bazel
+++ b/bindings/pydrake/solvers/BUILD.bazel
@@ -56,15 +56,24 @@ drake_pybind_library(
         "//bindings/pydrake:documentation_pybind",
         "//bindings/pydrake:symbolic_types_pybind",
         "//bindings/pydrake/common:cpp_param_pybind",
+        "//bindings/pydrake/common:cpp_template_pybind",
         "//bindings/pydrake/common:deprecation_pybind",
     ],
+    # N.B. Leading `_` is only for deprecation.
+    cc_so_name = "_mathematicalprogram",
     cc_srcs = ["mathematicalprogram_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
         "//bindings/pydrake:autodiffutils_py",
         "//bindings/pydrake:symbolic_py",
+        "//bindings/pydrake/common:cpp_param_py",
+        "//bindings/pydrake/common:cpp_template_py",
     ],
-    py_srcs = ["_mathematicalprogram_extra.py"],
+    py_srcs = [
+        "_mathematicalprogram_extra.py",
+        # N.B. This file is only for deprecation.
+        "mathematicalprogram.py",
+    ],
 )
 
 drake_pybind_library(

--- a/bindings/pydrake/solvers/mathematicalprogram.py
+++ b/bindings/pydrake/solvers/mathematicalprogram.py
@@ -1,0 +1,38 @@
+"""
+Bindings for MathematicalProgram
+
+If you are formulating constraints using symbolic formulas, please review the
+top-level documentation for :py:mod:`pydrake.math`.
+"""
+
+# This module only exists to handle deprecation; CPython C extensions cannot
+# easily be swapped during construction (e.g. if calling `ModuleShim._install`
+# in `_{base}_extra.py`), so we must have a forwarding module.
+
+# The above docstring is copied from the `*_py.cc` file because (for whatever
+# reason), Sphinx seems to pick up the source version (as written above), not
+# the variable version (as would be assigned to `__doc__`).
+
+from pydrake import _import_cc_module_vars
+import pydrake.solvers._mathematicalprogram as _cc
+from pydrake.common.deprecation import ModuleShim, _warn_deprecated
+
+_import_cc_module_vars(_cc, __name__, include_private=True)
+
+
+def _deprecation_handler(name):
+    binding_prefix = "Binding_"
+    if name.startswith(binding_prefix):
+        cls_name = name[len(binding_prefix):]
+        new_name = f"Binding[{cls_name}]"
+        _warn_deprecated(
+            f"{name} is deprecated; please use {new_name} instead.",
+            date="2021-11-01",
+        )
+        cls = globals()[cls_name]
+        return Binding[cls]
+    else:
+        raise AttributeError()
+
+
+ModuleShim._install(__name__, _deprecation_handler, auto_all=True)


### PR DESCRIPTION
`pydrake/__init__.py`:
- Do not repeat leading `_` for ExecuteExtraPythonCode
- Allow forwarding of private `_` variables from cc modules

deprecation:
- Fix (Py 2 -> Py 3) for empty `AttributeError` messages
- Add `ModuleShim._install(*, auto_all)`

Resolves #15406

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15409)
<!-- Reviewable:end -->
