### PR TITLE
MosekSolver throws a runtime error when the solver option is not set correctly

### DIFF
--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -778,6 +778,7 @@ drake_cc_library(
     ] + select({
         "//tools:with_mosek": [
             "//common:scoped_singleton",
+            "//common:scope_exit",
             "//math:quadratic_form",
             "@mosek",
         ],
@@ -1373,6 +1374,7 @@ drake_cc_googletest(
         ":sos_examples",
         "//common:filesystem",
         "//common:temp_directory",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/solvers/mosek_solver.cc
+++ b/solvers/mosek_solver.cc
@@ -13,9 +13,11 @@
 
 #include <Eigen/Core>
 #include <Eigen/SparseCore>
+#include <fmt/format.h>
 #include <mosek.h>
 
 #include "drake/common/never_destroyed.h"
+#include "drake/common/scope_exit.h"
 #include "drake/common/scoped_singleton.h"
 #include "drake/common/text_logging.h"
 #include "drake/math/quadratic_form.h"
@@ -1602,6 +1604,27 @@ MSKrescodee SetDualSolution(
   return rescode;
 }
 
+// Throws a runtime error if the mosek option is set incorrectly.
+template <typename T>
+void ThrowForInvalidOption(MSKrescodee rescode, const std::string& option,
+                           const T& val) {
+  if (rescode != MSK_RES_OK) {
+    const std::string mosek_version =
+        fmt::format("{}.{}", MSK_VERSION_MAJOR, MSK_VERSION_MINOR);
+    throw std::runtime_error(fmt::format(
+        "MosekSolver(): cannot set Mosek option '{option}' to value '{value}', "
+        "response code {code}, check "
+        "https://docs.mosek.com/{version}/capi/response-codes.html for the "
+        "meaning of the response code, check "
+        "https://docs.mosek.com/{version}/capi/param-groups.html for allowable "
+        "values in C++, or "
+        "https://docs.mosek.com/{version}/pythonapi/param-groups.html "
+        "for allowable values in python.",
+        fmt::arg("option", option), fmt::arg("value", val),
+        fmt::arg("code", rescode), fmt::arg("version", mosek_version)));
+  }
+}
+
 }  // anonymous namespace
 
 /*
@@ -1675,7 +1698,6 @@ void MosekSolver::DoSolve(const MathematicalProgram& prog,
   // includes both the matrix variables (for psd matrix variables) and
   // non-matrix variables.
   const int num_decision_vars = prog.num_vars();
-  MSKtask_t task = nullptr;
   MSKrescodee rescode{MSK_RES_OK};
 
   if (!license_) {
@@ -1723,25 +1745,33 @@ void MosekSolver::DoSolve(const MathematicalProgram& prog,
       matrix_variable_entry_to_selection_matrix_id;
 
   // Create the optimization task.
+  // task is initialized as a null pointer, same as in Mosek's documentation
+  // https://docs.mosek.com/9.2/capi/design.html#hello-world-in-mosek
+  MSKtask_t task = nullptr;
   rescode = MSK_maketask(env, 0, num_nonmatrix_vars_in_prog, &task);
+  ScopeExit guard([&task]() { MSK_deletetask(&task); });
 
   // Set the options (parameters).
   for (const auto& double_options : merged_options.GetOptionsDouble(id())) {
     if (rescode == MSK_RES_OK) {
       rescode = MSK_putnadouparam(task, double_options.first.c_str(),
                                   double_options.second);
+      ThrowForInvalidOption(rescode, double_options.first,
+                            double_options.second);
     }
   }
   for (const auto& int_options : merged_options.GetOptionsInt(id())) {
     if (rescode == MSK_RES_OK) {
       rescode = MSK_putnaintparam(task, int_options.first.c_str(),
                                   int_options.second);
+      ThrowForInvalidOption(rescode, int_options.first, int_options.second);
     }
   }
   for (const auto& str_options : merged_options.GetOptionsStr(id())) {
     if (rescode == MSK_RES_OK) {
       rescode = MSK_putnastrparam(task, str_options.first.c_str(),
                                   str_options.second.c_str());
+      ThrowForInvalidOption(rescode, str_options.first, str_options.second);
     }
   }
 
@@ -2004,8 +2034,6 @@ void MosekSolver::DoSolve(const MathematicalProgram& prog,
   // is OK. But do not modify result->solution_result_ if rescode is not OK
   // after this line.
   unused(rescode);
-
-  MSK_deletetask(&task);
 }
 
 }  // namespace solvers

--- a/solvers/solver_interface.h
+++ b/solvers/solver_interface.h
@@ -62,6 +62,8 @@ class SolverInterface {
   /// If the @p prog has set an option for a solver, and @p solver_options
   /// contains a different value for the same option on the same solver, then @p
   /// solver_options takes priority.
+  /// Derived implementations of this interface may elect to throw
+  /// std::exception for badly formed programs.
   virtual void Solve(const MathematicalProgram& prog,
                      const std::optional<Eigen::VectorXd>& initial_guess,
                      const std::optional<SolverOptions>& solver_options,

--- a/solvers/test/mosek_solver_test.cc
+++ b/solvers/test/mosek_solver_test.cc
@@ -4,6 +4,7 @@
 
 #include "drake/common/filesystem.h"
 #include "drake/common/temp_directory.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/solvers/mathematical_program.h"
 #include "drake/solvers/mixed_integer_optimization_util.h"
 #include "drake/solvers/test/exponential_cone_program_examples.h"
@@ -261,18 +262,9 @@ GTEST_TEST(MosekSolver, SolverOptionsErrorTest) {
   MosekSolver mosek_solver;
   SolverOptions solver_options;
   solver_options.SetOption(MosekSolver::id(), "non-existing options", 42);
-  mosek_solver.Solve(prog, {}, solver_options, &result);
-  const auto& solver_details = result.get_solver_details<MosekSolver>();
-  // This response code is defined in
-  // https://docs.mosek.com/9.2/capi/response-codes.html#mosek.rescode
-  const int MSK_RES_ERR_PARAM_NAME_INT = 1207;
-  EXPECT_EQ(solver_details.rescode, MSK_RES_ERR_PARAM_NAME_INT);
-  // This problem status is defined in
-  // https://docs.mosek.com/9.2/capi/constants.html#mosek.prosta
-  const int MSK_PRO_STA_UNKNOWN = 0;
-  EXPECT_EQ(solver_details.solution_status, MSK_PRO_STA_UNKNOWN);
-
-  EXPECT_FALSE(result.is_success());
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      mosek_solver.Solve(prog, {}, solver_options, &result),
+      ".*cannot set Mosek option \'non-existing options\' to value \'42\'.*");
 }
 
 GTEST_TEST(MosekSolver, TestInitialGuess) {


### PR DESCRIPTION
As mentioned in the issue https://github.com/RobotLocomotion/drake/issues/15342#issuecomment-879038929

Fix MosekSolver first as several users are calling Mosek recently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15411)
<!-- Reviewable:end -->
