### PR TITLE
[geometry/optimization] Add GraphOfConvexSets

### DIFF
--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -15,6 +15,7 @@ drake_cc_package_library(
     visibility = ["//visibility:public"],
     deps = [
         ":convex_set",
+        ":graph_of_convex_sets",
         ":iris",
     ],
 )
@@ -43,12 +44,23 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "graph_of_convex_sets",
+    srcs = ["graph_of_convex_sets.cc"],
+    hdrs = ["graph_of_convex_sets.h"],
+    deps = [
+        ":convex_set",
+        "//common:symbolic",
+        "//solvers:create_cost",
+        "//solvers:mathematical_program_result",
+    ],
+)
+
+drake_cc_library(
     name = "iris",
     srcs = ["iris.cc"],
     hdrs = ["iris.h"],
     deps = [
         ":convex_set",
-        "//geometry:scene_graph",
     ],
 )
 
@@ -69,6 +81,15 @@ drake_cc_googletest(
     deps = [
         ":convex_set",
         "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "graph_of_convex_sets_test",
+    deps = [
+        ":graph_of_convex_sets",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -1,0 +1,142 @@
+#include "drake/geometry/optimization/graph_of_convex_sets.h"
+
+#include <limits>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <fmt/format.h>
+
+#include "drake/solvers/create_cost.h"
+
+namespace drake {
+namespace geometry {
+namespace optimization {
+
+using Edge = GraphOfConvexSets::Edge;
+using Vertex = GraphOfConvexSets::Vertex;
+using VertexId = GraphOfConvexSets::VertexId;
+
+using Eigen::MatrixXd;
+using Eigen::Ref;
+using Eigen::RowVectorXd;
+using Eigen::VectorXd;
+using solvers::Binding;
+using solvers::Constraint;
+using solvers::Cost;
+using solvers::L2NormCost;
+using solvers::LinearConstraint;
+using solvers::LinearCost;
+using solvers::LinearEqualityConstraint;
+using solvers::MathematicalProgram;
+using solvers::MathematicalProgramResult;
+using solvers::QuadraticCost;
+using solvers::VariableRefList;
+using solvers::VectorXDecisionVariable;
+using symbolic::Expression;
+using symbolic::Variable;
+using symbolic::Variables;
+
+GraphOfConvexSets::~GraphOfConvexSets() = default;
+
+Vertex::Vertex(const VertexId& id, const ConvexSet& set, std::string name)
+    : id_(id),
+      set_(set.Clone()),
+      name_(std::move(name)),
+      placeholder_x_(symbolic::MakeVectorContinuousVariable(
+          set_->ambient_dimension(), name_)) {}
+
+Vertex::~Vertex() = default;
+
+VectorXd Vertex::GetSolution(const MathematicalProgramResult& result) const {
+  return result.GetSolution(placeholder_x_);
+}
+
+Edge::Edge(const Vertex* u, const Vertex* v, std::string name)
+    : u_{u},
+      v_{v},
+      allowed_vars_{u_->x()},
+      phi_{"phi", symbolic::Variable::Type::BINARY},
+      name_(std::move(name)),
+      y_{symbolic::MakeVectorContinuousVariable(u_->ambient_dimension(), "y")},
+      z_{symbolic::MakeVectorContinuousVariable(v_->ambient_dimension(), "z")},
+      x_to_yz_(u_->ambient_dimension() + v_->ambient_dimension()) {
+  DRAKE_DEMAND(u_ != nullptr);
+  DRAKE_DEMAND(v_ != nullptr);
+  allowed_vars_.insert(Variables(v_->x()));
+  for (int i = 0; i < u_->ambient_dimension(); ++i) {
+    x_to_yz_.emplace(u_->x()[i], y_[i]);
+  }
+  for (int i = 0; i < v_->ambient_dimension(); ++i) {
+    x_to_yz_.emplace(v_->x()[i], z_[i]);
+  }
+}
+
+Edge::~Edge() = default;
+
+std::pair<Variable, Binding<Cost>> Edge::AddCost(
+    const symbolic::Expression& e) {
+  return AddCost(solvers::internal::ParseCost(e));
+}
+
+std::pair<Variable, Binding<Cost>> Edge::AddCost(const Binding<Cost>& binding) {
+  DRAKE_THROW_UNLESS(Variables(binding.variables()).IsSubsetOf(allowed_vars_));
+  const int n = ell_.size();
+  ell_.conservativeResize(n + 1);
+  ell_[n] = Variable(fmt::format("ell{}", n), Variable::Type::CONTINUOUS);
+  costs_.emplace_back(binding);
+  return std::pair<Variable, Binding<Cost>>(ell_[n], costs_.back());
+}
+
+Binding<Constraint> Edge::AddConstraint(const symbolic::Formula& f) {
+  return AddConstraint(solvers::internal::ParseConstraint(f));
+}
+
+Binding<Constraint> Edge::AddConstraint(const Binding<Constraint>& binding) {
+  DRAKE_THROW_UNLESS(Variables(binding.variables()).IsSubsetOf(allowed_vars_));
+  auto [iter, inserted] = constraints_.emplace(binding);
+  unused(inserted);
+  return *iter;
+}
+
+double Edge::GetSolutionCost(const MathematicalProgramResult& result) const {
+  return result.GetSolution(ell_).sum();
+}
+
+Vertex* GraphOfConvexSets::AddVertex(const ConvexSet& set, std::string name) {
+  if (name.empty()) {
+    name = fmt::format("v{}", vertices_.size());
+  }
+  VertexId id = VertexId::get_new_id();
+  auto [iter, success] =
+      vertices_.emplace(id, std::unique_ptr<Vertex>(new Vertex(id, set, name)));
+  DRAKE_DEMAND(success);
+  return iter->second.get();
+}
+
+Edge* GraphOfConvexSets::AddEdge(const VertexId& u_id, const VertexId& v_id,
+                                 std::string name) {
+  auto u_iter = vertices_.find(u_id);
+  DRAKE_DEMAND(u_iter != vertices_.end());
+  auto v_iter = vertices_.find(v_id);
+  DRAKE_DEMAND(v_iter != vertices_.end());
+
+  if (name.empty()) {
+    name = fmt::format("e{}", edges_.size());
+  }
+  auto [iter, success] = edges_.emplace(std::unique_ptr<Edge>(
+      new Edge(u_iter->second.get(), v_iter->second.get(), name)));
+  DRAKE_DEMAND(success);
+  return iter->get();
+}
+
+Edge* GraphOfConvexSets::AddEdge(const Vertex& u, const Vertex& v,
+                                 std::string name) {
+  return AddEdge(u.id(), v.id(), std::move(name));
+}
+
+}  // namespace optimization
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -1,0 +1,247 @@
+#pragma once
+
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/symbolic.h"
+#include "drake/geometry/optimization/convex_set.h"
+#include "drake/solvers/mathematical_program_result.h"
+
+namespace drake {
+namespace geometry {
+namespace optimization {
+
+/**
+(Experimental) -- This class is not yet fully functional, and the interface may
+change without deprecation.
+
+GraphOfConvexSets implements the design pattern and optimization problems first
+introduced in
+
+"Shortest Paths in Graphs of Convex Sets" by Tobia Marcucci, Jack Umenberger,
+Pablo A. Parrilo, Russ Tedrake. https://arxiv.org/abs/2101.11565
+
+Each vertex in the graph is associated with a convex set over continuous
+variables, edges in the graph contain convex costs and constraints on these
+continuous variables.  We can then formulate optimization problems over this
+graph, such as the shortest path problem where each visit to a vertex also
+corresponds to selecting an element from the convex set subject to the costs and
+constraints.  Behind the scenes, we construct efficient mixed-integer convex
+transcriptions of the graph problem using MathematicalProgram.
+
+Design note: This class avoids providing any direct access to the
+MathematicalProgram that it constructs nor to the decision variables /
+constraints.  The users should be able to write constraints against
+"placeholder" decision variables on the vertices and edges, but these get
+translated in non-trivial ways to the underlying program.
+
+@ingroup geometry_optimization
+*/
+class GraphOfConvexSets {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(GraphOfConvexSets)
+
+  /** Constructs an empty graph. */
+  GraphOfConvexSets() = default;
+
+  virtual ~GraphOfConvexSets();
+
+  class Edge;  // forward declaration.
+
+  using VertexId = Identifier<class VertexTag>;
+
+  /** Each vertex in the graph has a corresponding ConvexSet, and a std::string
+  name. */
+  class Vertex final {
+   public:
+    DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Vertex)
+
+    ~Vertex();
+
+    /** Returns the unique identifier associated with this Vertex. */
+    VertexId id() const { return id_; }
+
+    /** Returns the ambient dimension of the ConvexSet. */
+    int ambient_dimension() const { return set_->ambient_dimension(); }
+
+    /** Returns the name of the vertex. */
+    const std::string& name() const { return name_; }
+
+    /** Returns a decision variable corresponding to an element of the
+    ConvexSet, which can be used for constructing symbolic::Expression costs
+    and constraints. */
+    const VectorX<symbolic::Variable>& x() const { return placeholder_x_; }
+
+    /** Returns a const reference to the underlying ConvexSet. */
+    const ConvexSet& set() const { return *set_; }
+
+    /** Returns the solution of x() in a MathematicalProgramResult. */
+    Eigen::VectorXd GetSolution(
+        const solvers::MathematicalProgramResult& result) const;
+
+    // TODO(russt): Support AddCost/AddConstraint directly on the vertices.
+
+   private:
+    // Constructs a new vertex.
+    Vertex(const VertexId& id, const ConvexSet& set, std::string name);
+
+    const VertexId id_{};
+    const std::unique_ptr<const ConvexSet> set_;
+    const std::string name_{};
+    const VectorX<symbolic::Variable> placeholder_x_{};
+
+    friend class GraphOfConvexSets;
+  };
+
+  // Note: We think of this as a directed edge in the shortest path problem, but
+  // there is nothing specific to it being a directed edge here in this class.
+  /** An edge in the graph connects between vertex `u` and vertex `v`.  The
+  edge also holds a list of cost and constraints associated with the continuous
+  variables. */
+  class Edge final {
+   public:
+    DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Edge)
+
+    ~Edge();
+
+    /** Returns the string name associated with this edge. */
+    const std::string& name() const { return name_; }
+
+    /** Returns a const reference to the "left" Vertex that this edge connects
+    to. */
+    const Vertex& u() const { return *u_; }
+
+    /** Returns a const reference to the "right" Vertex that this edge connects
+     * to. */
+    const Vertex& v() const { return *v_; }
+
+    /** Returns the binary variable associated with this edge. It can be used
+    to determine whether this edge was active in the solution to an
+    optimization problem, by calling GetSolution(phi()) on a returned
+    MathematicalProgramResult. */
+    const symbolic::Variable& phi() const { return phi_; }
+
+    /** Returns the continuous decision variables associated with vertex `u`.
+    This can be used for constructing symbolic::Expression costs and
+    constraints.*/
+    const VectorX<symbolic::Variable>& xu() const { return u_->x(); }
+
+    /** Returns the continuous decision variables associated with vertex `v`.
+    This can be used for constructing symbolic::Expression costs and
+    constraints.*/
+    const VectorX<symbolic::Variable>& xv() const { return v_->x(); }
+
+    /** Adds a cost to this edge, described by a symbolic::Expression @p e
+    containing *only* elements of xu() and xv() as variables.  For technical
+    reasons relating to being able to "turn-off" the cost on inactive edges, all
+    costs are eventually implemented with a slack variable and a constraint:
+    @verbatim
+    min g(xu, xv) ⇒ min ℓ, s.t. ℓ ≥ g(xu,xv)
+    @endverbatim
+    @returns the pair <ℓ, Binding<Cost>>.
+    @throws std::exception if e.GetVariables() is not a subset of xu() ∪ xv().
+    */
+    std::pair<symbolic::Variable, solvers::Binding<solvers::Cost>> AddCost(
+        const symbolic::Expression& e);
+
+    /** Adds a cost to this edge.  @p binding must must contain *only*
+    elements of xu() and xv() as variables. For technical
+    reasons relating to being able to "turn-off" the cost on inactive edges, all
+    costs are eventually implemented with a slack variable and a constraint:
+    @verbatim
+    min g(xu, xv) ⇒ min ℓ, s.t. ℓ ≥ g(xu,xv)
+    @endverbatim
+    @returns the pair <ℓ, Binding<Cost>>.
+    @throws std::exception if binding.variables() is not a subset of xu() ∪
+    xv(). */
+    std::pair<symbolic::Variable, solvers::Binding<solvers::Cost>> AddCost(
+        const solvers::Binding<solvers::Cost>& binding);
+
+    /** Adds a cost to this edge, described by a symbolic::Formula @p f
+    containing *only* elements of xu() and xv() as variables.
+    @throws std::exception if f.GetFreeVariables() is not a subset of xu() ∪
+    xv().
+    */
+    solvers::Binding<solvers::Constraint> AddConstraint(
+        const symbolic::Formula& f);
+
+    /** Adds a constraint to this edge.  @p binding must must contain *only*
+    elements of xu() and xv() as variables.
+    @throws std::exception if binding.variables() is not a subset of xu() ∪
+    xv(). */
+    solvers::Binding<solvers::Constraint> AddConstraint(
+        const solvers::Binding<solvers::Constraint>& binding);
+
+    /** Returns the sum of the costs associated with this edge in a
+    MathematicalProgramResult. */
+    double GetSolutionCost(
+        const solvers::MathematicalProgramResult& result) const;
+
+   private:
+    // Constructs a new edge.
+    Edge(const Vertex* u, const Vertex* v, std::string name);
+
+    const Vertex* const u_{};
+    const Vertex* const v_{};
+    symbolic::Variables allowed_vars_{};
+    symbolic::Variable phi_{};
+    const std::string name_{};
+
+    // We construct placeholder variables for y and z here so that they can be
+    // accessed later from a MathematicalProgramResult.  We intentionally do
+    // *not* provide direct access to them for the user.
+    const VectorX<symbolic::Variable> y_{};
+    const VectorX<symbolic::Variable> z_{};
+
+    std::unordered_map<symbolic::Variable, symbolic::Variable> x_to_yz_{};
+    // Note: ell_[i] is associated with costs_[i].
+    solvers::VectorXDecisionVariable ell_{};
+    std::vector<solvers::Binding<solvers::Cost>> costs_{};
+    std::unordered_set<solvers::Binding<solvers::Constraint>> constraints_{};
+
+    friend class GraphOfConvexSets;
+  };
+
+  /** Adds a vertex to the graph.  A copy of @p set is cloned and stored inside
+  the graph. If @p name is empty then a default name will be provided. */
+  Vertex* AddVertex(const ConvexSet& set, std::string name = "");
+
+  // TODO(russt): Provide helper methods to add multiple vertices which share
+  // the same ConvexSet.
+
+  /** Adds an edge to the graph from VertexId @p u_id to VertexId @p v_id.  The
+  ids must refer to valid vertices in this graph. If @p name is empty then a
+  default name will be provided. */
+  Edge* AddEdge(const VertexId& u_id, const VertexId& v_id,
+                std::string name = "");
+
+  /** Adds an edge to the graph from Vertex @p u to Vertex @p v.  The
+  vertex references must refer to valid vertices in this graph. If @p name is
+  empty then a default name will be provided. */
+  Edge* AddEdge(const Vertex& u, const Vertex& v, std::string name = "");
+
+  // TODO(russt): std::string GetGraphvizString(const
+  // std::optional<solvers::MathematicalProgramResult>& = std::nullopt) const;
+
+  // TODO(russt): Most all of the interesting work will happen in this method.
+  // The only reason that it is not included in this initial PR is that we have
+  // separated it for code review.
+  //
+  // solvers::MathematicalProgramResult SolveShortestPath(const Vertex& source,
+  // const Vertex& target, bool convex_relaxation = false);
+
+ private:
+  std::unordered_map<VertexId, std::unique_ptr<Vertex>> vertices_{};
+  std::unordered_set<std::unique_ptr<Edge>> edges_{};
+};
+
+}  // namespace optimization
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -1,0 +1,174 @@
+#include "drake/geometry/optimization/graph_of_convex_sets.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/optimization/hpolyhedron.h"
+#include "drake/geometry/optimization/hyperellipsoid.h"
+#include "drake/geometry/optimization/point.h"
+#include "drake/geometry/optimization/vpolytope.h"
+
+namespace drake {
+namespace geometry {
+namespace optimization {
+
+using Eigen::Matrix2d;
+using Eigen::Vector2d;
+using Eigen::Vector3d;
+using solvers::Binding;
+using solvers::LinearConstraint;
+using solvers::LinearCost;
+using solvers::LinearEqualityConstraint;
+using solvers::MathematicalProgramResult;
+using solvers::QuadraticCost;
+using symbolic::Variables;
+typedef GraphOfConvexSets::Vertex Vertex;
+typedef GraphOfConvexSets::Edge Edge;
+
+GTEST_TEST(GraphOfConvexSetsTest, AddVertex) {
+  GraphOfConvexSets g;
+  Point p(Vector3d(1.0, 2.0, 3.0));
+  Vertex* v = g.AddVertex(p, "point");
+
+  EXPECT_EQ(v->ambient_dimension(), 3);
+  EXPECT_EQ(v->name(), "point");
+
+  EXPECT_EQ(v->x().size(), 3);
+  EXPECT_EQ(v->x()[0].get_name(), "point(0)");
+  EXPECT_TRUE(v->set().PointInSet(p.x()));
+
+  // Confirm that the vertex set does not refer to the original memory.
+  p.set_x(Vector3d(4., 5., 6));
+  EXPECT_FALSE(v->set().PointInSet(p.x()));
+}
+
+GTEST_TEST(GraphOfConvexSetsTest, GetVertexSolution) {
+  GraphOfConvexSets g;
+  Point p(Vector3d(1.0, 2.0, 3.0));
+  Vertex* v = g.AddVertex(p, "point");
+
+  MathematicalProgramResult result;
+  std::unordered_map<symbolic::Variable::Id, int> map;
+  for (int i = 0; i < 3; ++i) {
+    map.emplace(v->x()[i].get_id(), i);
+  }
+  result.set_decision_variable_index(map);
+  result.set_x_val(p.x());
+  EXPECT_TRUE(CompareMatrices(v->GetSolution(result), p.x()));
+}
+
+GTEST_TEST(GraphOfConvexSetsTest, AddEdge) {
+  GraphOfConvexSets g;
+  Point pu(Vector3d(1.0, 2.0, 3.0));
+  Point pv(Vector2d(4., 5.));
+  Vertex* u = g.AddVertex(pu, "u");
+  Vertex* v = g.AddVertex(pv, "v");
+  Edge* e = g.AddEdge(u->id(), v->id(), "e");
+
+  EXPECT_EQ(e->u().name(), u->name());
+  EXPECT_EQ(e->v().name(), v->name());
+
+  EXPECT_EQ(Variables(e->xu()), Variables(u->x()));
+  EXPECT_EQ(Variables(e->xv()), Variables(v->x()));
+}
+
+GTEST_TEST(GraphOfConvexSetsTest, AddEdge2) {
+  GraphOfConvexSets g;
+  Point pu(Vector3d(1.0, 2.0, 3.0));
+  Point pv(Vector2d(4., 5.));
+  Vertex* u = g.AddVertex(pu, "u");
+  Vertex* v = g.AddVertex(pv, "v");
+  Edge* e = g.AddEdge(*u, *v, "e");
+
+  EXPECT_EQ(e->u().name(), u->name());
+  EXPECT_EQ(e->v().name(), v->name());
+
+  EXPECT_EQ(Variables(e->xu()), Variables(u->x()));
+  EXPECT_EQ(Variables(e->xv()), Variables(v->x()));
+}
+
+
+/*
+┌───┐       ┌───┐
+│ u ├───e──►│ v │
+└───┘       └───┘
+*/
+class TwoPoints : public ::testing::Test {
+ protected:
+  TwoPoints()
+      : pu_{Vector2d(1., 2.)},
+        pv_{Vector3d(3., 4., 5.)} {
+    u_ = g_.AddVertex(pu_, "u");
+    v_ = g_.AddVertex(pv_, "v");
+    e_ = g_.AddEdge(*u_, *v_, "e");
+  }
+
+  GraphOfConvexSets g_{};
+  Point pu_;
+  Point pv_;
+  Vertex* u_;
+  Vertex* v_;
+  Edge* e_;
+};
+
+TEST_F(TwoPoints, Basic) {
+  EXPECT_EQ(e_->name(), "e");
+  EXPECT_EQ(e_->u().name(), u_->name());
+  EXPECT_EQ(e_->v().name(), v_->name());
+
+  EXPECT_EQ(Variables(e_->xu()), Variables(u_->x()));
+  EXPECT_EQ(Variables(e_->xv()), Variables(v_->x()));
+}
+
+// Confirms that I can add costs (both ways) and get the solution.
+// The correctness of the added costs will be established by the solution tests.
+TEST_F(TwoPoints, AddCost) {
+  auto [ell0, b0] = e_->AddCost((e_->xv().head<2>() - e_->xu()).squaredNorm());
+  auto cost = std::make_shared<LinearCost>(Vector2d{1.2, 3.4}, 0.1);
+  auto [ell1, b1] = e_->AddCost(Binding(cost, e_->xu()));
+
+  // Confirm that they are down-castable.
+  auto quadratic = dynamic_cast<QuadraticCost*>(b0.evaluator().get());
+  EXPECT_TRUE(quadratic != nullptr);
+  auto linear = dynamic_cast<LinearCost*>(b1.evaluator().get());
+  EXPECT_TRUE(linear != nullptr);
+
+  MathematicalProgramResult result;
+  std::unordered_map<symbolic::Variable::Id, int> map;
+  map.emplace(ell0.get_id(), 0);
+  map.emplace(ell1.get_id(), 1);
+  const Vector2d ell{1.2, 3.4};
+  result.set_decision_variable_index(map);
+  result.set_x_val(ell);
+
+  EXPECT_NEAR(e_->GetSolutionCost(result), ell.sum(), 1e-16);
+
+  symbolic::Variable other_var("x");
+  DRAKE_EXPECT_THROWS_MESSAGE(e_->AddCost(other_var), ".*IsSubsetOf.*");
+}
+
+// Confirms that I can add constraints (both ways).
+// The correctness of the added constraints will be established by the solution
+// tests.
+TEST_F(TwoPoints, AddConstraint) {
+  auto b0 = e_->AddConstraint(e_->xv().head<2>() == e_->xu());
+  auto constraint = std::make_shared<LinearConstraint>(
+      Matrix2d::Identity(), Vector2d::Zero(), Vector2d{1.2, 3.4});
+  auto b1 = e_->AddConstraint(Binding(constraint, e_->xu()));
+
+  // Confirm that they are down-castable.
+  auto linear_equality =
+      dynamic_cast<LinearEqualityConstraint*>(b0.evaluator().get());
+  EXPECT_TRUE(linear_equality != nullptr);
+  auto linear = dynamic_cast<LinearConstraint*>(b1.evaluator().get());
+  EXPECT_TRUE(linear != nullptr);
+
+  symbolic::Variable other_var("x");
+  DRAKE_EXPECT_THROWS_MESSAGE(e_->AddConstraint(other_var == 1),
+                              ".*IsSubsetOf.*");
+}
+
+}  // namespace optimization
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
This first PR adds the graph construction / maintenance logic only.  I've separated the actual mathematical programming part to follow-up PRs, so that they can be reviewed more carefully.

The additional correctness of the added costs/constraints on an edge will be established in the next PR, once the Solve method becomes available.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15413)
<!-- Reviewable:end -->
