### PR TITLE
[geometry] Add declaration to *remove* collision filters

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -992,6 +992,10 @@ void DoScalarIndependentDefinitions(py::module m) {
 
     py::class_<Class>(m, "CollisionFilterDeclaration", cls_doc.doc)
         .def(py::init(), cls_doc.ctor.doc)
+        .def("AllowBetween", &Class::AllowBetween, py::arg("set_A"),
+            py::arg("set_B"), py_rvp::reference, cls_doc.AllowBetween.doc)
+        .def("AllowWithin", &Class::AllowWithin, py::arg("geometry_set"),
+            py_rvp::reference, cls_doc.AllowWithin.doc)
         .def("ExcludeBetween", &Class::ExcludeBetween, py::arg("set_A"),
             py::arg("set_B"), py_rvp::reference, cls_doc.ExcludeBetween.doc)
         .def("ExcludeWithin", &Class::ExcludeWithin, py::arg("geometry_set"),

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -764,6 +764,12 @@ class TestGeometry(unittest.TestCase):
                 geometries, geometries))
         dut.Apply(
             mut.CollisionFilterDeclaration().ExcludeWithin(geometries))
+        dut.Apply(
+            mut.CollisionFilterDeclaration().AllowBetween(
+                set_A=geometries, set_B=geometries))
+        dut.Apply(
+            mut.CollisionFilterDeclaration().AllowWithin(
+                geometry_set=geometries))
 
         # Mutate context data
         dut = sg.collision_filter_manager(sg_context)
@@ -772,6 +778,12 @@ class TestGeometry(unittest.TestCase):
                 geometries, geometries))
         dut.Apply(
             mut.CollisionFilterDeclaration().ExcludeWithin(geometries))
+        dut.Apply(
+            mut.CollisionFilterDeclaration().AllowBetween(
+                set_A=geometries, set_B=geometries))
+        dut.Apply(
+            mut.CollisionFilterDeclaration().AllowWithin(
+                geometry_set=geometries))
 
         # TODO(2021-11-01) Remove these with deprecation resolution.
         # Legacy API

--- a/geometry/collision_filter_declaration.h
+++ b/geometry/collision_filter_declaration.h
@@ -50,6 +50,54 @@ class CollisionFilterDeclaration {
 
   CollisionFilterDeclaration() = default;
 
+  /** @name  Allowing pairs in consideration (removing collision filters)
+
+   These methods provide mechanisms which implicitly define a set of pairs and
+   add each pair into the set of proximity query candidates C (see the
+   documentation for CollisionFilterManager for definition of set C). Each
+   method provides the definition for the set of pairs.
+
+   SceneGraph maintains some invariants about pairs which will never be
+   considered in proximity queries (the sets `Aₚ × Aₚ`, `Fₚ`, or `Iₚ` -- again
+   see CollisionFilterManager for explanation of those sets). If any pair in
+   those sets are included in declarations which allow collisions, those pairs
+   will simply be ignored.
+
+   The *declared* pairs can be invalid (e.g., containing GeometryId values that
+   aren't part of the SceneGraph data). This will only be detected when applying
+   the declaration (see CollisionFilterManager::Apply()).  */
+  //@{
+
+  /** Allows geometry pairs in proximity evaluation by updating the
+   candidate pair set `C ← C ⋃ P*`, where `P = {(a, b)}, ∀ a ∈ A, b ∈ B, a ≠ b`
+   and `A = {a₀, a₁, ..., aₘ}` and `B = {b₀, b₁, ..., bₙ}` are the input sets of
+   geometries `set_A` and `set_B`, respectively. Where
+   `P* = P - (Aₚ × Aₚ) - Fₚ - Iₚ`, the set of pairs after we remove the
+   SceneGraph-mandated invariants (see CollisionFilterManager for details on
+   those invariants).
+
+   To be explicit, in contrast to AllowWithin, this does _not_ clear filters
+   between members of the _same_ set (e.g., `(aᵢ, aⱼ)` or `(bᵢ, bⱼ)`). */
+  CollisionFilterDeclaration& AllowBetween(const GeometrySet& set_A,
+                                           const GeometrySet& set_B) {
+    statements_.emplace_back(kAllowBetween, std::move(set_A), std::move(set_B));
+    return *this;
+  }
+
+  /** Allows geometry pairs in proximity evaluation by updating the candidate
+   pair set `C ← C ⋃ P*`, where `P = {(gᵢ, gⱼ)}, ∀ gᵢ, gⱼ ∈ G, i ≠ j` and
+   `G = {g₀, g₁, ..., gₘ}` is the input `geometry_set` of geometries. Where
+   `P* = P - (Aₚ × Aₚ) - Fₚ - Iₚ`, the set of pairs after we remove the
+   SceneGraph-mandated invariants (see CollisionFilterManager for details on
+   those invariants). */
+  CollisionFilterDeclaration& AllowWithin(const GeometrySet& geometry_set) {
+    statements_.emplace_back(kAllowWithin, std::move(geometry_set),
+                             GeometrySet{});
+    return *this;
+  }
+
+  //@}
+
   /** @name  Excluding pairs from consideration (adding collision filters)
 
    These methods provide mechanisms which implicitly define a set of pairs and
@@ -91,14 +139,16 @@ class CollisionFilterDeclaration {
 
   // The various kinds of statements that can be made.
   enum StatementOp {
+    kAllowBetween,
+    kAllowWithin,
     kExcludeBetween,
     kExcludeWithin
   };
 
   // The record of a single statement.
   struct Statement {
-    Statement(StatementOp op_in, GeometrySet A_in, GeometrySet B_in) :
-      operation(op_in), set_A(std::move(A_in)), set_B(std::move(B_in)) {}
+    Statement(StatementOp op_in, GeometrySet A_in, GeometrySet B_in)
+        : operation(op_in), set_A(std::move(A_in)), set_B(std::move(B_in)) {}
     StatementOp operation;
     GeometrySet set_A;
     GeometrySet set_B;  // May be unused for unary statements.

--- a/geometry/collision_filter_manager.h
+++ b/geometry/collision_filter_manager.h
@@ -48,6 +48,8 @@ class GeometryState;
 
    - `∀ (gᵢ, gⱼ) ∈ C`, both gᵢ and gⱼ must be registered with SceneGraph; you
      can't inject arbitrary ids. Attempting to do so will result in an error.
+   - No pairs in `Aₚ × Aₚ`, `Fₚ`, or `Iₚ` can ever be added to C. Excluding
+     those pairs is a SceneGraph invariant. Attempts to do so will be ignored.
 
  The current configuration of C depends on the sequence of filter declarations
  that have been applied in the manager. Changing the order can change the end
@@ -85,10 +87,14 @@ class CollisionFilterManager {
      - Referencing an invalid id (FrameId or GeometryId): throws.
      - Declaring a filtered pair that is already filtered: no discernible
        change.
+     - Attempts to "allow" collision between a pair that is strictly excluded
+       (e.g., between two anchored geometries) will be ignored.
 
    @throws std::exception if the `declaration` references invalid ids. */
   void Apply(const CollisionFilterDeclaration& declaration) {
-    filter_->Apply(declaration, extract_ids_);
+    /* Modifications made via this API are by the user. Only the internals can
+     make "permanent" declarations. */
+    filter_->Apply(declaration, extract_ids_, false /* is_permanent */);
   }
 
   // TODO(SeanCurtis-TRI) SceneGraphInspector includes the method

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -726,7 +726,8 @@ void GeometryState<T>::AssignRole(SourceId source_id, GeometryId geometry_id,
                                                       ids_for_filtering),
           [this](const GeometrySet& set) {
             return this->CollectIds(set, Role::kProximity);
-          });
+          },
+          true /* is_permanent */);
     } break;
     case RoleAssign::kReplace:
       // Give the engine a chance to compare properties before and after.

--- a/geometry/proximity/test/collisions_exist_callback_test.cc
+++ b/geometry/proximity/test/collisions_exist_callback_test.cc
@@ -111,7 +111,7 @@ GTEST_TEST(CollisionsExistCallback, RespectsCollisionFilter) {
   };
   collision_filter.Apply(CollisionFilterDeclaration().ExcludeWithin(
                              GeometrySet{data_A.id(), data_B.id()}),
-                         extract);
+                         extract, false /* is_permanent */);
 
   // Make sure the pair no longer collides.
   CallbackData data_after(&collision_filter);

--- a/geometry/proximity/test/distance_sphere_to_shape_test.cc
+++ b/geometry/proximity/test/distance_sphere_to_shape_test.cc
@@ -674,7 +674,7 @@ GTEST_TEST(Callback, ScalarSupportWithFilters) {
   };
   collision_filter.Apply(CollisionFilterDeclaration().ExcludeWithin(
                              GeometrySet{data_A.id(), data_B.id()}),
-                         extract);
+                         extract, false /* is_permanent */);
 
   const std::unordered_map<GeometryId, RigidTransform<T>> X_WGs{
       {id_A, RigidTransform<T>::Identity()},
@@ -727,7 +727,7 @@ GTEST_TEST(Callback, RespectCollisionFiltering) {
   };
   collision_filter.Apply(CollisionFilterDeclaration().ExcludeWithin(
                              GeometrySet{data_A.id(), data_B.id()}),
-                         extract);
+                         extract, false /* is_permanent */);
   results.clear();
   threshold = std::numeric_limits<double>::max();
   Callback<double>(&sphere_A, &sphere_B, &data, threshold);

--- a/geometry/proximity/test/find_collision_candidates_callback_test.cc
+++ b/geometry/proximity/test/find_collision_candidates_callback_test.cc
@@ -67,7 +67,7 @@ GTEST_TEST(Callback, RespectsCollisionFilter) {
   };
   collision_filter.Apply(CollisionFilterDeclaration().ExcludeWithin(
                              GeometrySet{data_A.id(), data_B.id()}),
-                         extract);
+                         extract, false /* is_permanent */);
 
   CollisionObjectd box_A(make_shared<Boxd>(0.25, 0.3, 0.4));
   data_A.write_to(&box_A);

--- a/geometry/proximity/test/hydroelastic_callback_test.cc
+++ b/geometry/proximity/test/hydroelastic_callback_test.cc
@@ -217,7 +217,7 @@ class TestScene {
     };
     collision_filter_.Apply(CollisionFilterDeclaration().ExcludeWithin(
                                 GeometrySet{data_A.id(), data_B.id()}),
-                            extract);
+                            extract, false /* is_permanent */);
   }
 
   // Note: these are non const because the callback takes non-const pointers

--- a/geometry/proximity/test/penetration_as_point_pair_callback_test.cc
+++ b/geometry/proximity/test/penetration_as_point_pair_callback_test.cc
@@ -183,7 +183,7 @@ class PenetrationAsPointPairCallbackTest : public ::testing::Test {
     };
     collision_filter_.Apply(
         CollisionFilterDeclaration().ExcludeWithin(GeometrySet{id_A_, id_B_}),
-        extract);
+        extract, false /* is_permanent */);
 
     EXPECT_FALSE(Callback<T>(&sphere_A_, &sphere_B_, &callback_data));
     EXPECT_EQ(point_pairs.size(), 0u);

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -867,7 +867,7 @@ GTEST_TEST(ProximityEngineTests, SignedDistancePairClosestPoint) {
     };
     engine.collision_filter().Apply(
         CollisionFilterDeclaration().ExcludeWithin(GeometrySet{id_A, id_B}),
-        extract_ids);
+        extract_ids, false /* is_permanent */);
     DRAKE_EXPECT_THROWS_MESSAGE(
         engine.ComputeSignedDistancePairClosestPoints(id_A, id_B, X_WGs),
         std::runtime_error,
@@ -2407,7 +2407,7 @@ TEST_F(SimplePenetrationTest, WithCollisionFilters) {
   };
   engine_.collision_filter().Apply(CollisionFilterDeclaration().ExcludeWithin(
                                        GeometrySet{origin_id, collide_id}),
-                                   extract_ids);
+                                   extract_ids, false /* is_permanent */);
 
   EXPECT_FALSE(
       engine_.collision_filter().CanCollideWith(origin_id, collide_id));


### PR DESCRIPTION
Previous API only allowed for *adding* filters on geometry pairs. This introduces the API that can allow (generally) the removal of a filter from a geometry pair.

This introduces the concept of the "permanent" filter. It supports scene graph invariants (e.g., geometries affixed to the same frame are always filtered, etc.) This concept is purely internal -- it doesn't affect the public API.

The code changes include:

  - `CollisionFilterDeclaration` gets new statement methods.
  - `CollisionFilter` learns how to apply them.
  - `CollisionFilterManager` documents the "invariant" filters.
  - Touch numerous tests that depend on having a collision filter.
  - Python bindings for new API.

Relates #15089.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15415)
<!-- Reviewable:end -->
