### PR TITLE
[drake_visualizer] Label spatial force on object in for hydro contact

### DIFF
--- a/tools/workspace/drake_visualizer/_drake_visualizer_builtin_scripts/show_hydroelastic_contact.py
+++ b/tools/workspace/drake_visualizer/_drake_visualizer_builtin_scripts/show_hydroelastic_contact.py
@@ -1083,6 +1083,8 @@ class HydroelasticContactVisualizer:
                 point = np.array([surface.centroid_W[0],
                                   surface.centroid_W[1],
                                   surface.centroid_W[2]])
+                # This is actually the force on body 1. It is documented as
+                # such in the lcm message.
                 force = np.array([surface.force_C_W[0],
                                   surface.force_C_W[1],
                                   surface.force_C_W[2]])
@@ -1119,8 +1121,13 @@ class HydroelasticContactVisualizer:
                         end=point + auto_moment_scale * moment * scale,
                         tubeRadius=0.002,
                         headRadius=0.004, color=[0, 0, 1])
+            # TODO See show_point_pair_contact.py. But if we ever had a single
+            # body represented with multiple contact geometries, we could end
+            # up with body pairs (A, B) and (B, A). This is less likely with
+            # hydro than with point pair contact, so resolving this is less
+            # urgent.
             self.visual_model.set_contact_debug_data(
-                surface, force_data, "Spatial force")
+                surface, force_data, f"Spatial force on {surface.body1_name}")
 
             # Iterate over all quadrature points, drawing traction and slip
             # velocity vectors.


### PR DESCRIPTION
For visualizing hydroelastic contact, the visualized quantities would label a pair of geometries and show various quantities. One was labeled simply "Spatial force" but didn't indicate which body in the pair the force was acting on. This adds the name of the body being acted on.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15416)
<!-- Reviewable:end -->
