### PR TITLE
[fem] Calculate tangent matrix for contact

### DIFF
--- a/multibody/fixed_fem/dev/BUILD.bazel
+++ b/multibody/fixed_fem/dev/BUILD.bazel
@@ -186,6 +186,8 @@ drake_cc_library(
         ":deformable_model",
         ":deformable_rigid_contact_pair",
         ":fem_solver",
+        ":permute_block_sparse_matrix",
+        ":schur_complement",
         "//common:essential",
         "//multibody/contact_solvers:block_sparse_matrix",
         "//multibody/plant",
@@ -492,6 +494,20 @@ drake_cc_library(
     ],
 )
 
+drake_cc_library(
+    name = "permute_block_sparse_matrix",
+    srcs = [
+        "permute_block_sparse_matrix.cc",
+    ],
+    hdrs = [
+        "permute_block_sparse_matrix.h",
+    ],
+    deps = [
+        "//common:default_scalars",
+        "//common:essential",
+    ],
+)
+
 drake_cc_binary(
     name = "run_scripted_deformable_motion",
     srcs = [
@@ -605,6 +621,7 @@ drake_cc_googletest(
     deps = [
         ":deformable_contact",
         ":deformable_contact_data",
+        ":mesh_utilities",
         "//common/test_utilities:eigen_matrix_compare",
         "//geometry/proximity:surface_mesh",
         "//geometry/proximity:volume_mesh",
@@ -804,6 +821,14 @@ drake_cc_googletest(
     deps = [
         ":dummy_element",
         ":newmark_scheme",
+        "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "permute_block_sparse_matrix_test",
+    deps = [
+        ":permute_block_sparse_matrix",
         "//common/test_utilities:eigen_matrix_compare",
     ],
 )

--- a/multibody/fixed_fem/dev/deformable_rigid_manager.cc
+++ b/multibody/fixed_fem/dev/deformable_rigid_manager.cc
@@ -1,7 +1,7 @@
 #include "drake/multibody/fixed_fem/dev/deformable_rigid_manager.h"
 
+#include "drake/multibody/fixed_fem/dev/permute_block_sparse_matrix.h"
 #include "drake/multibody/plant/multibody_plant.h"
-
 namespace drake {
 namespace multibody {
 namespace fem {
@@ -92,11 +92,13 @@ void DeformableRigidManager<T>::DeclareCacheEntries() {
   for (SoftBodyIndex deformable_body_id(0);
        deformable_body_id < deformable_model_->num_bodies();
        ++deformable_body_id) {
+    const FemModelBase<T>& fem_model =
+        deformable_model_->fem_model(deformable_body_id);
     const std::unique_ptr<const FemStateBase<T>> model_fem_state =
-        deformable_model_->fem_model(deformable_body_id).MakeFemStateBase();
+        fem_model.MakeFemStateBase();
 
-    // Extracts the q, qdot, and qddot from the given context and copies them
-    // to the cached fem state.
+    /* Extracts the q, qdot, and qddot from the given context and copies them
+     to the cached fem state. */
     const auto& fem_state_cache_entry = this->DeclareCacheEntry(
         fmt::format("FEM state {}", deformable_body_id),
         systems::ValueProducer(
@@ -108,7 +110,7 @@ void DeformableRigidManager<T>::DeclareCacheEntries() {
         {systems::System<T>::xd_ticket()});
     fem_state_cache_indexes_.emplace_back(fem_state_cache_entry.cache_index());
 
-    // Calculates the free-motion velocity for the deformable body.
+    /* Calculates the free-motion velocity for the deformable body. */
     const auto& free_motion_cache_entry = this->DeclareCacheEntry(
         fmt::format("Free motion FEM state {}", deformable_body_id),
         systems::ValueProducer(
@@ -121,9 +123,48 @@ void DeformableRigidManager<T>::DeclareCacheEntries() {
         {fem_state_cache_entry.ticket()});
     free_motion_cache_indexes_.emplace_back(
         free_motion_cache_entry.cache_index());
+
+    /* Allocates and calculates the free-motion tangent matrix for the
+     deformable body. */
+    Eigen::SparseMatrix<T> model_tangent_matrix(fem_model.num_dofs(),
+                                                fem_model.num_dofs());
+    fem_model.SetTangentMatrixSparsityPattern(&model_tangent_matrix);
+    const auto& tangent_matrix_cache_entry = this->DeclareCacheEntry(
+        fmt::format("Free motion FEM tangent matrix {}", deformable_body_id),
+        systems::ValueProducer(model_tangent_matrix,
+                               std::function<void(const systems::Context<T>&,
+                                                  Eigen::SparseMatrix<T>*)>{
+                                   [this, deformable_body_id](
+                                       const systems::Context<T>& context,
+                                       Eigen::SparseMatrix<T>* tangent_matrix) {
+                                     this->CalcFreeMotionTangentMatrix(
+                                         context, deformable_body_id,
+                                         tangent_matrix);
+                                   }}),
+        {free_motion_cache_entry.ticket()});
+    tangent_matrix_cache_indexes_.emplace_back(
+        tangent_matrix_cache_entry.cache_index());
+
+    /* Calculates the Schur complement of the free-motion tangent matrix for the
+     deformable body. */
+    const auto& tangent_matrix_schur_complement_cache_entry =
+        this->DeclareCacheEntry(
+            fmt::format("Free motion FEM tangent matrix Schur complement {}",
+                        deformable_body_id),
+            systems::ValueProducer(std::function{
+                [this, deformable_body_id](
+                    const systems::Context<T>& context,
+                    internal::SchurComplement<T>* schur_complement) {
+                  this->CalcFreeMotionTangentMatrixSchurComplement(
+                      context, deformable_body_id, schur_complement);
+                }}),
+            {free_motion_cache_entry.ticket(),
+             tangent_matrix_cache_entry.ticket()});
+    tangent_matrix_schur_complement_cache_indexes_.emplace_back(
+        tangent_matrix_schur_complement_cache_entry.cache_index());
   }
 
-  // Calculates the contact data for all deformable bodies.
+  /* Calculates the contact data for all deformable bodies. */
   const auto& deformable_contact_data_cache_entry = this->DeclareCacheEntry(
       "Deformable contact data",
       systems::ValueProducer(
@@ -131,51 +172,15 @@ void DeformableRigidManager<T>::DeclareCacheEntries() {
       {systems::System<T>::xd_ticket()});
   deformable_contact_data_cache_index_ =
       deformable_contact_data_cache_entry.cache_index();
-}
 
-template <typename T>
-void DeformableRigidManager<T>::CalcFemStateBase(
-    const systems::Context<T>& context, SoftBodyIndex id,
-    FemStateBase<T>* fem_state) const {
-  const systems::BasicVector<T>& discrete_state =
-      context.get_discrete_state().get_vector(
-          deformable_model_->discrete_state_indexes()[id]);
-  const auto& discrete_value = discrete_state.get_value();
-  DRAKE_DEMAND(discrete_value.size() % 3 == 0);
-  const int num_dofs = discrete_value.size() / 3;
-  const auto& q = discrete_value.head(num_dofs);
-  const auto& qdot = discrete_value.segment(num_dofs, num_dofs);
-  const auto& qddot = discrete_value.tail(num_dofs);
-  fem_state->SetQ(q);
-  fem_state->SetQdot(qdot);
-  fem_state->SetQddot(qddot);
-}
-
-template <typename T>
-void DeformableRigidManager<T>::CalcFreeMotionFemStateBase(
-    const systems::Context<T>& context, SoftBodyIndex id,
-    FemStateBase<T>* fem_state_star) const {
-  const FemStateBase<T>& fem_state = EvalFemStateBase(context, id);
-  // TODO(xuchenhan-tri): FemState needs a SetFrom() method.
-  fem_state_star->SetQ(fem_state.q());
-  fem_state_star->SetQdot(fem_state.qdot());
-  fem_state_star->SetQddot(fem_state.qddot());
-  /* Obtain the contact-free state for the deformable body. */
-  fem_solvers_[id]->AdvanceOneTimeStep(fem_state, fem_state_star);
-}
-
-template <typename T>
-void DeformableRigidManager<T>::CalcDeformableRigidContact(
-    const systems::Context<T>& context,
-    std::vector<internal::DeformableContactData<T>>* result) const {
-  result->clear();
-  UpdateCollisionObjectPoses(context);
-  UpdateDeformableVertexPositions(context);
-  const int num_bodies = deformable_model_->num_bodies();
-  result->reserve(num_bodies);
-  for (SoftBodyIndex i(0); i < num_bodies; ++i) {
-    result->emplace_back(CalcDeformableContactData(i));
-  }
+  /* Calculates the tangent matrix for the contact solver. */
+  const auto& contact_tangent_matrix_cache_entry = this->DeclareCacheEntry(
+      "Tangent matrix for contact",
+      systems::ValueProducer(
+          this, &DeformableRigidManager<T>::CalcContactTangentMatrix),
+      {systems::System<T>::xd_ticket()});
+  contact_tangent_matrix_cache_index_ =
+      contact_tangent_matrix_cache_entry.cache_index();
 }
 
 template <typename T>
@@ -349,6 +354,74 @@ void DeformableRigidManager<T>::DoCalcDiscreteValues(
 }
 
 template <typename T>
+void DeformableRigidManager<T>::CalcFemStateBase(
+    const systems::Context<T>& context, SoftBodyIndex id,
+    FemStateBase<T>* fem_state) const {
+  const systems::BasicVector<T>& discrete_state =
+      context.get_discrete_state().get_vector(
+          deformable_model_->discrete_state_indexes()[id]);
+  const auto& discrete_value = discrete_state.get_value();
+  DRAKE_DEMAND(discrete_value.size() % 3 == 0);
+  const int num_dofs = discrete_value.size() / 3;
+  const auto& q = discrete_value.head(num_dofs);
+  const auto& qdot = discrete_value.segment(num_dofs, num_dofs);
+  const auto& qddot = discrete_value.tail(num_dofs);
+  fem_state->SetQ(q);
+  fem_state->SetQdot(qdot);
+  fem_state->SetQddot(qddot);
+}
+
+template <typename T>
+void DeformableRigidManager<T>::CalcFreeMotionFemStateBase(
+    const systems::Context<T>& context, SoftBodyIndex id,
+    FemStateBase<T>* fem_state_star) const {
+  const FemStateBase<T>& fem_state = EvalFemStateBase(context, id);
+  // TODO(xuchenhan-tri): FemState needs a SetFrom() method.
+  fem_state_star->SetQ(fem_state.q());
+  fem_state_star->SetQdot(fem_state.qdot());
+  fem_state_star->SetQddot(fem_state.qddot());
+  /* Obtain the contact-free state for the deformable body. */
+  fem_solvers_[id]->AdvanceOneTimeStep(fem_state, fem_state_star);
+}
+
+template <typename T>
+void DeformableRigidManager<T>::CalcFreeMotionTangentMatrix(
+    const systems::Context<T>& context, SoftBodyIndex index,
+    Eigen::SparseMatrix<T>* tangent_matrix) const {
+  const FemStateBase<T>& free_motion_fem_state =
+      EvalFreeMotionFemStateBase(context, index);
+  const FemModelBase<T>& fem_model = deformable_model_->fem_model(index);
+  fem_model.CalcTangentMatrix(free_motion_fem_state, tangent_matrix);
+}
+
+template <typename T>
+void DeformableRigidManager<T>::CalcFreeMotionTangentMatrixSchurComplement(
+    const systems::Context<T>& context, SoftBodyIndex index,
+    internal::SchurComplement<T>* schur_complement) const {
+  const Eigen::SparseMatrix<T>& free_motion_tangent_matrix =
+      EvalFreeMotionTangentMatrix(context, index);
+  const std::vector<internal::DeformableContactData<T>>&
+      deformable_contact_data = EvalDeformableRigidContact(context);
+  /* Reindex the deformable dofs so that the tangent matrix assumes a block
+   structure associated with the contact pattern that facilitates subsequent
+   computations. */
+  const Eigen::SparseMatrix<T> permuted_tangent_matrix =
+      internal::PermuteBlockSparseMatrix(
+          free_motion_tangent_matrix,
+          deformable_contact_data[index].permuted_vertex_indexes());
+  constexpr int kDimension = 3;
+  const int dofs_in_contact =
+      deformable_contact_data[index].num_vertices_in_contact() * kDimension;
+  const int total_dofs = free_motion_tangent_matrix.rows();
+  *schur_complement = internal::SchurComplement<T>(
+      permuted_tangent_matrix.topLeftCorner(dofs_in_contact, dofs_in_contact),
+      permuted_tangent_matrix.bottomLeftCorner(total_dofs - dofs_in_contact,
+                                               dofs_in_contact),
+      permuted_tangent_matrix.bottomRightCorner(total_dofs - dofs_in_contact,
+                                                total_dofs - dofs_in_contact));
+}
+
+template <typename T>
 void DeformableRigidManager<T>::UpdateCollisionObjectPoses(
     const systems::Context<T>& context) const {
   const geometry::QueryObject<T>& query_object =
@@ -450,6 +523,20 @@ DeformableRigidManager<T>::CalcDeformableContactData(
   return {
       std::move(deformable_rigid_contact_pairs),
       deformable_model_->reference_configuration_geometries()[deformable_id]};
+}
+
+template <typename T>
+void DeformableRigidManager<T>::CalcDeformableRigidContact(
+    const systems::Context<T>& context,
+    std::vector<internal::DeformableContactData<T>>* result) const {
+  result->clear();
+  UpdateCollisionObjectPoses(context);
+  UpdateDeformableVertexPositions(context);
+  const int num_bodies = deformable_model_->num_bodies();
+  result->reserve(num_bodies);
+  for (SoftBodyIndex i(0); i < num_bodies; ++i) {
+    result->emplace_back(CalcDeformableContactData(i));
+  }
 }
 
 template <typename T>
@@ -694,6 +781,58 @@ void DeformableRigidManager<T>::CalcContactPointData(
       contact_offset += nc_in_pair;
     }
   }
+}
+
+template <typename T>
+BlockSparseMatrix<T> DeformableRigidManager<T>::CalcContactTangentMatrix(
+    const systems::Context<T>& context) const {
+  const std::vector<internal::DeformableContactData<T>>&
+      deformable_contact_data = EvalDeformableRigidContact(context);
+
+  int num_deformable_body_in_contact = 0;
+  for (const auto& contact_data : deformable_contact_data) {
+    if (contact_data.num_contact_points() > 0) {
+      ++num_deformable_body_in_contact;
+    }
+  }
+
+  const std::vector<DiscreteContactPair<T>>& rigid_contact_pairs =
+      this->EvalDiscreteContactPairs(context);
+
+  /* Return an empty tangent matrix if there is no contact. */
+  if (rigid_contact_pairs.empty() && num_deformable_body_in_contact == 0) {
+    return BlockSparseMatrix<T>();
+  }
+
+  // TODO(xuchenhan-tri): The mass matrix of the rigid dofs is treated as a
+  //  single block. Exploit its branch-induced sparsity in the future.
+  const int num_rigid_blocks = 1;
+  const int num_deformable_blocks = num_deformable_body_in_contact;
+  const int num_blocks = num_rigid_blocks + num_deformable_blocks;
+  BlockSparseMatrixBuilder<T> builder(num_blocks, num_blocks, num_blocks);
+
+  const int num_rigid_dofs = this->plant().num_velocities();
+  MatrixX<T> M(num_rigid_dofs, num_rigid_dofs);
+  this->plant().CalcMassMatrix(context, &M);
+  /* The rigid dofs come before the deformable dofs in the contact formulation,
+   so we put the rigid block on the top-left corner. */
+  builder.PushBlock(0, 0, M);
+
+  /* Now start building the deformable blocks. */
+  int block_index = 1;
+  DRAKE_DEMAND(deformable_model_ != nullptr);
+  for (SoftBodyIndex i(0); i < deformable_model_->num_bodies(); ++i) {
+    /* Skip deformable bodies not in contact. */
+    if (deformable_contact_data[i].num_contact_points() == 0) {
+      continue;
+    }
+    const internal::SchurComplement<T>& tangent_matrix_schur_complement =
+        EvalFreeMotionTangentMatrixSchurComplement(context, i);
+    builder.PushBlock(block_index, block_index,
+                      tangent_matrix_schur_complement.get_D_complement());
+    ++block_index;
+  }
+  return builder.Build();
 }
 
 }  // namespace fem

--- a/multibody/fixed_fem/dev/mesh_utilities.cc
+++ b/multibody/fixed_fem/dev/mesh_utilities.cc
@@ -14,6 +14,7 @@ namespace fem {
 using geometry::Box;
 using geometry::VolumeElement;
 using geometry::VolumeMesh;
+using geometry::VolumeMeshFieldLinear;
 using geometry::VolumeVertex;
 using geometry::VolumeVertexIndex;
 /* Generates connectivity for the tetrahedral elements of the mesh by splitting
@@ -135,14 +136,65 @@ internal::ReferenceDeformableGeometry<T> MakeDiamondCubicBoxDeformableGeometry(
       GenerateDiamondCubicElements(num_vertices);
   auto mesh =
       std::make_unique<VolumeMesh<T>>(std::move(elements), std::move(vertices));
-  auto mesh_field = std::make_unique<geometry::VolumeMeshFieldLinear<T, T>>(
+  auto mesh_field = std::make_unique<VolumeMeshFieldLinear<T, T>>(
+      "Approximated signed distance", std::move(signed_distances), mesh.get(),
+      false);
+  return {std::move(mesh), std::move(mesh_field)};
+}
+
+template <typename T>
+VolumeMesh<T> MakeOctahedronVolumeMesh() {
+  // Eight tetrahedra in the octahedron mesh. Order the vertices to follow the
+  // convention in geometry::VolumeMesh. See geometry::VolumeMesh for more
+  // details.
+  const int element_data[8][4] = {
+      // The top four tetrahedrons share the top vertex v5.
+      {0, 1, 2, 5},
+      {0, 2, 3, 5},
+      {0, 3, 4, 5},
+      {0, 4, 1, 5},
+      // The bottom four tetrahedrons share the bottom vertex v6.
+      {0, 2, 1, 6},
+      {0, 3, 2, 6},
+      {0, 4, 3, 6},
+      {0, 1, 4, 6}};
+  std::vector<VolumeElement> elements;
+  for (const auto& element : element_data) {
+    elements.emplace_back(element);
+  }
+  // clang-format off
+  const Vector3<T> vertex_data[7] = {
+      { 0,  0,  0},
+      { 1,  0,  0},
+      { 0,  1,  0},
+      {-1,  0,  0},
+      { 0, -1,  0},
+      { 0,  0,  1},
+      { 0,  0, -1}};
+  // clang-format on
+  std::vector<VolumeVertex<T>> vertices;
+  for (const auto& vertex : vertex_data) {
+    vertices.emplace_back(vertex);
+  }
+  return VolumeMesh<T>(std::move(elements), std::move(vertices));
+}
+
+template <typename T>
+internal::ReferenceDeformableGeometry<T> MakeOctahedronDeformableGeometry() {
+  auto mesh = std::make_unique<VolumeMesh<T>>(MakeOctahedronVolumeMesh<T>());
+  /* The distance to surface of the octahedron is zero for all vertices except
+   for v0 that has signed distance to the surface of -1/√3. */
+  std::vector<T> signed_distances(7, 0.0);
+  signed_distances[0] = -1.0 / std::sqrt(3);
+  auto mesh_field = std::make_unique<VolumeMeshFieldLinear<T, T>>(
       "Approximated signed distance", std::move(signed_distances), mesh.get(),
       false);
   return {std::move(mesh), std::move(mesh_field)};
 }
 
 DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
-    (&MakeDiamondCubicBoxDeformableGeometry<T>))
+    (&MakeDiamondCubicBoxDeformableGeometry<T>, &MakeOctahedronVolumeMesh<T>,
+     &MakeOctahedronDeformableGeometry<T>))
 
 }  // namespace fem
 }  // namespace multibody

--- a/multibody/fixed_fem/dev/mesh_utilities.h
+++ b/multibody/fixed_fem/dev/mesh_utilities.h
@@ -43,12 +43,38 @@ namespace fem {
      providing a resolution hint at least as large as the box's largest
      dimension.
  @param[in] X_WB
-     The pose of the rectanglur volume mesh in the world frame.
+     The pose of the rectangular volume mesh in the world frame.
  @tparam_nonsymbolic_scalar */
 template <typename T>
 internal::ReferenceDeformableGeometry<T> MakeDiamondCubicBoxDeformableGeometry(
     const geometry::Box& box, double resolution_hint,
     const math::RigidTransform<T>& X_WB);
+
+/* Generates a volume mesh of an octahedron comprising of eight tetrahedral
+ elements with vertices on the coordinate axes and the origin like this:
+
+                +Z   -X
+                 |   /
+              v5 ●  ● v3
+                 | /
+       v4     v0 |/
+  -Y----●--------●------●----+Y
+                /|      v2
+               / |
+           v1 ●  ● v6
+             /   |
+           +X    |
+                -Z
+ @tparam_nonsymbolic_scalar */
+template <typename T>
+geometry::VolumeMesh<T> MakeOctahedronVolumeMesh();
+
+/* Generates a ReferenceDeformableGeometry whose underlying mesh is given by
+ MakeOctahedronVolumeMesh().
+ @tparam_nonsymbolic_scalar */
+template <typename T>
+internal::ReferenceDeformableGeometry<T> MakeOctahedronDeformableGeometry();
+
 }  // namespace fem
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/fixed_fem/dev/permute_block_sparse_matrix.cc
+++ b/multibody/fixed_fem/dev/permute_block_sparse_matrix.cc
@@ -1,0 +1,48 @@
+#include "drake/multibody/fixed_fem/dev/permute_block_sparse_matrix.h"
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_assert.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+template <typename T>
+Eigen::SparseMatrix<T> PermuteBlockSparseMatrix(
+    const Eigen::SparseMatrix<T>& matrix,
+    const std::vector<int>& block_permutation) {
+  DRAKE_ASSERT(matrix.rows() == matrix.cols());
+  DRAKE_ASSERT(static_cast<int>(block_permutation.size()) * 3 == matrix.cols());
+  const int nv = matrix.rows();
+  Eigen::SparseMatrix<T> permuted_matrix(nv, nv);
+  std::vector<Eigen::Triplet<T>> triplets;
+  triplets.reserve(matrix.nonZeros());
+  using InnerIterator = typename Eigen::SparseMatrix<T>::InnerIterator;
+  for (int i = 0; i < matrix.outerSize(); ++i) {
+    for (InnerIterator it(matrix, i); it; ++it) {
+      const int block_row = it.row() % 3;
+      const int block_col = it.col() % 3;
+      const int block_row_offset = it.row() / 3;
+      const int block_col_offset = it.col() / 3;
+      const int permuted_row_block = block_permutation[block_row_offset];
+      const int permuted_col_block = block_permutation[block_col_offset];
+      const int permuted_row = permuted_row_block * 3 + block_row;
+      const int permuted_col = permuted_col_block * 3 + block_col;
+      triplets.emplace_back(permuted_row, permuted_col, it.value());
+    }
+  }
+  /* The permuted matrix should have the exact same number of non-zero entries
+   as the old matrix. */
+  DRAKE_DEMAND(static_cast<int>(triplets.size()) == matrix.nonZeros());
+  permuted_matrix.setFromTriplets(triplets.begin(), triplets.end());
+  return permuted_matrix;
+}
+
+DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    (&PermuteBlockSparseMatrix<T>))
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/permute_block_sparse_matrix.h
+++ b/multibody/fixed_fem/dev/permute_block_sparse_matrix.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <vector>
+
+#include <Eigen/SparseCore>
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+/* Given an Eigen::SparseMatrix with block structure with 3x3 block entries Bᵢⱼ
+where i, j ∈ V = {0,...,num_vertices-1} and a permutation P on V, this method
+builds the permuted matrix with 3x3 block entries Cᵢⱼ such that Cᵢⱼ =
+B_{P(i),P(j)}.
+
+For example, suppose the input `matrix` is given by
+       a a a b b b
+       a a a b b b
+       a a a b b b
+       c c c d d d
+       c c c d d d
+       c c c d d d
+and the input `block_permutation` is {1, 0}, then the result of the
+permutation will be:
+       d d d c c c
+       d d d c c c
+       d d d c c c
+       b b b a a a
+       b b b a a a
+       b b b a a a
+
+@param[in] matrix             The original block sparse matrix to be permuted.
+@param[in] block_permutation  block_permutation[i] gives the permuted index
+                              of the block whose original index is `i`.
+@pre matrix.rows() == matrix.cols().
+@pre matrix.rows() % 3 == 0.
+@pre block_permutation is a permutation of {0, 1, ..., matrix.rows()/3-1}. */
+template <typename T>
+Eigen::SparseMatrix<T> PermuteBlockSparseMatrix(
+    const Eigen::SparseMatrix<T>& matrix,
+    const std::vector<int>& block_permutation);
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/test/deformable_contact_test.cc
+++ b/multibody/fixed_fem/dev/test/deformable_contact_test.cc
@@ -13,6 +13,7 @@
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/fixed_fem/dev/deformable_contact_data.h"
 #include "drake/multibody/fixed_fem/dev/deformable_rigid_contact_pair.h"
+#include "drake/multibody/fixed_fem/dev/mesh_utilities.h"
 
 namespace drake {
 namespace multibody {
@@ -31,71 +32,7 @@ using geometry::internal::DeformableVolumeMesh;
 using geometry::internal::Obb;
 using std::vector;
 
-/* The OctahedronVolume() and MakePyramidSurface() methods are stolen from
- mesh_intersection_test.cc. */
-
-/* Generates a volume mesh of an octahedron comprising of eight tetrahedral
- elements with vertices on the coordinate axes and the origin like this:
-
-                +Z   -X
-                 |   /
-              v5 ●  ● v3
-                 | /
-       v4     v0 |/
-  -Y----●--------●------●----+Y
-                /|      v2
-               / |
-           v1 ●  ● v6
-             /   |
-           +X    |
-                -Z
-*/
-template <typename T>
-VolumeMesh<T> OctahedronVolume() {
-  const int element_data[8][4] = {
-      // The top four tetrahedrons share the top vertex v5.
-      {0, 1, 2, 5},
-      {0, 2, 3, 5},
-      {0, 3, 4, 5},
-      {0, 4, 1, 5},
-      // The bottom four tetrahedrons share the bottom vertex v6.
-      {0, 2, 1, 6},
-      {0, 3, 2, 6},
-      {0, 4, 3, 6},
-      {0, 1, 4, 6}};
-  vector<VolumeElement> elements;
-  for (const auto& element : element_data) {
-    elements.emplace_back(element);
-  }
-  // clang-format off
-  const Vector3<T> vertex_data[7] = {
-      { 0,  0,  0},
-      { 1,  0,  0},
-      { 0,  1,  0},
-      {-1,  0,  0},
-      { 0, -1,  0},
-      { 0,  0,  1},
-      { 0,  0, -1}};
-  // clang-format on
-  vector<VolumeVertex<T>> vertices;
-  for (const auto& vertex : vertex_data) {
-    vertices.emplace_back(vertex);
-  }
-  return VolumeMesh<T>(std::move(elements), std::move(vertices));
-}
-
-template <typename T>
-internal::ReferenceDeformableGeometry<T> OctahedronDeformableGeometry() {
-  auto mesh = std::make_unique<VolumeMesh<T>>(OctahedronVolume<T>());
-  /* The distance to surface of the octahedron is zero for all vertices except
-   for v0 that has signed distance to the surface of -1/√3. */
-  std::vector<T> signed_distances(7, 0.0);
-  signed_distances[0] = -1.0 / std::sqrt(3);
-  auto mesh_field = std::make_unique<VolumeMeshFieldLinear<T, T>>(
-      "Approximated signed distance", std::move(signed_distances), mesh.get(),
-      false);
-  return {std::move(mesh), std::move(mesh_field)};
-}
+/* The MakePyramidSurface() method is stolen from mesh_intersection_test.cc. */
 
 /* Generates a simple surface mesh of a pyramid with vertices on the
  coordinate axes and the origin like this:
@@ -162,12 +99,12 @@ bool CompareSetOfVector3s(const std::vector<Vector3<T>>& A,
 
 /* Returns the contact surface between the rigid pyramid surface (see
  MakePyramidSurface()) and the deforamble octahedron volume (see
- OctahedronVolume()) where the pose of the rigid mesh in the deformable mesh's
- frame is given by X_DR. */
+ MakeOctahedronVolumeMesh()) where the pose of the rigid mesh in the deformable
+ mesh's frame is given by X_DR. */
 template <typename T>
 DeformableContactSurface<T> MakeDeformableContactSurface(
     const math::RigidTransform<T>& X_DR) {
-  const DeformableVolumeMesh<T> volume_D(OctahedronVolume<T>());
+  const DeformableVolumeMesh<T> volume_D(MakeOctahedronVolumeMesh<T>());
   /* Deformable contact assumes the rigid surface is double-valued, regardless
    of the scalar value for the volume mesh.  */
   const SurfaceMesh<double> surface_R = MakePyramidSurface<double>();
@@ -243,7 +180,7 @@ void TestComputeTetMeshTriMeshContact() {
       CompareSetOfVector3s(calculated_centroids_D, expected_centroids_D, kEps));
 
   /* Verify the centroids in barycentric coordinates are as expected. */
-  const VolumeMesh<T> volume_D = OctahedronVolume<T>();
+  const VolumeMesh<T> volume_D = MakeOctahedronVolumeMesh<T>();
   calculated_centroids_D.clear();
   for (int i = 0; i < kNumPolys; ++i) {
     const Vector4<T> b_centroid = contact_data[i].b_centroid;
@@ -343,7 +280,7 @@ GTEST_TEST(DeformableContactTest, DeformableContactData) {
       MakeDeformableContactSurface<double>(X_DR);
   const internal::DeformableContactData<double> contact_data =
       MakeDeformableContactData(std::move(contact_surface),
-                                OctahedronDeformableGeometry<double>());
+                                MakeOctahedronDeformableGeometry<double>());
 
   EXPECT_EQ(contact_data.num_contact_pairs(), 1);
   /* v0, v1, v2, v3, v4, v6 are participating in contact so they get new indexes
@@ -368,7 +305,7 @@ GTEST_TEST(DeformableContactTest, EmptyDeformableContactData) {
       MakeDeformableContactSurface<double>(X_DR);
   const internal::DeformableContactData<double> contact_data =
       MakeDeformableContactData(std::move(contact_surface),
-                                OctahedronDeformableGeometry<double>());
+                                MakeOctahedronDeformableGeometry<double>());
 
   EXPECT_EQ(contact_data.num_contact_pairs(), 1);
   EXPECT_EQ(contact_data.num_vertices_in_contact(), 0);

--- a/multibody/fixed_fem/dev/test/deformable_rigid_manager_test.cc
+++ b/multibody/fixed_fem/dev/test/deformable_rigid_manager_test.cc
@@ -9,6 +9,7 @@
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/contact_solvers/pgs_solver.h"
 #include "drake/multibody/fixed_fem/dev/deformable_model.h"
+#include "drake/multibody/fixed_fem/dev/mesh_utilities.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/systems/analysis/simulator.h"
 
@@ -45,23 +46,33 @@ using geometry::SceneGraph;
 using geometry::SurfaceMesh;
 using geometry::VolumeMesh;
 using geometry::VolumeMeshFieldLinear;
+using math::RigidTransformd;
 using multibody::contact_solvers::internal::BlockSparseMatrix;
 using multibody::internal::DiscreteContactPair;
 using systems::Context;
 
 geometry::Box MakeUnitCube() { return geometry::Box(1.0, 1.0, 1.0); }
 
-/* Makes a unit cube and subdivide it into 6 tetrahedra. */
-VolumeMesh<double> MakeUnitCubeTetMesh() {
+/* Makes a unit cube with the given `pose` in world and subdivide it into 6
+ tetrahedra. */
+VolumeMesh<double> MakeUnitCubeTetMesh(
+    RigidTransformd pose = RigidTransformd()) {
   VolumeMesh<double> mesh =
       geometry::internal::MakeBoxVolumeMesh<double>(MakeUnitCube(), 1.0);
   DRAKE_DEMAND(mesh.num_elements() == 6);
   DRAKE_DEMAND(mesh.num_vertices() == kNumVertices);
-  return mesh;
+
+  std::vector<geometry::VolumeElement> elements = mesh.tetrahedra();
+  std::vector<geometry::VolumeVertex<double>> vertices;
+  for (const auto& v : mesh.vertices()) {
+    vertices.emplace_back(pose * v.r_MV());
+  }
+  return {std::move(elements), std::move(vertices)};
 }
 
-internal::ReferenceDeformableGeometry<double> MakeUnitCubeDeformableGeometry() {
-  auto mesh = std::make_unique<VolumeMesh<double>>(MakeUnitCubeTetMesh());
+internal::ReferenceDeformableGeometry<double> MakeUnitCubeDeformableGeometry(
+    RigidTransformd pose = RigidTransformd()) {
+  auto mesh = std::make_unique<VolumeMesh<double>>(MakeUnitCubeTetMesh(pose));
   /* This doesn't satisfy the requirement of the approximated signed-distance
    field. In particular, it doesn't evaluate to zero on the boundary of the
    mesh. But we are using our clear-box knowledge here to test interpolation of
@@ -497,6 +508,8 @@ const CoulombFriction kFrictionB = {0.24, 0.23};
 const CoulombFriction kFrictionC = {0.34, 0.33};
 const CoulombFriction kFrictionD = {0.44, 0.43};
 
+/* Unit test for contact data from DeformableRigidManager fed to the contact
+ solver. */
 class DeformableRigidContactDataTest : public ::testing::Test {
  protected:
   /* Set up a scene with three rigid boxes and one deforamble cube.
@@ -851,7 +864,6 @@ TEST_F(DeformableRigidContactDataTest, ContactData) {
   }
   EXPECT_TRUE(CompareMatrices(mu_rigid_rigid, mu_rigid_rigid_expected));
 
-  std::cout << mu.transpose() << std::endl;
   /* A vs. B friction. */
   const auto& mu_AB = mu.segment(nc_rigid_rigid, nc_AB);
   const VectorXd mu_AB_expected =
@@ -974,6 +986,199 @@ TEST_F(DeformableRigidContactDataTest, NoContact) {
   EXPECT_EQ(contact_point_data.phi0.size(), 0);
   EXPECT_EQ(contact_point_data.stiffness.size(), 0);
   EXPECT_EQ(contact_point_data.damping.size(), 0);
+}
+
+}  // namespace
+
+/* Unit test for dynamics data from DeformableRigidManager fed to the contact
+ solver. */
+class DeformableRigidDynamicsDataTest : public ::testing::Test {
+ protected:
+  /* Set up a scene with two deforamble bodies and one rigid cube.
+   In particular, unit cube A and octahedron B are deformable and unit cube
+   C is rigid. */
+  void SetUp() override {
+    systems::DiagramBuilder<double> builder;
+    std::tie(plant_, scene_graph_) = AddMultibodyPlantSceneGraph(&builder, kDt);
+    /* Add two deformable bodies. */
+    auto deformable_model = std::make_unique<DeformableModel<double>>(plant_);
+    A_ = deformable_model->RegisterDeformableBody(
+        MakeUnitCubeDeformableGeometry(RigidTransformd(Vector3d(0, 2, 0))),
+        "cube_A", MakeDeformableBodyConfig(),
+        MakeProximityProperties(kStiffnessA, kDampingA, kFrictionA));
+    B_ = deformable_model->RegisterDeformableBody(
+        MakeOctahedronDeformableGeometry<double>(), "octahedron_B",
+        MakeDeformableBodyConfig(),
+        MakeProximityProperties(kStiffnessB, kDampingB, kFrictionB));
+    plant_->AddPhysicalModel(std::move(deformable_model));
+    /* Add the rigid cube. */
+    C_ = plant_->AddRigidBody("cube_C", MakeSpatialInertiaForBox()).index();
+    collision_geometry_C_ = plant_->RegisterCollisionGeometry(
+        plant_->get_body(C_), math::RigidTransform<double>(),
+        geometry::Box(1.0, 1.0, 1.0), "C",
+        MakeProximityProperties(kStiffnessC, kDampingC, kFrictionC));
+    plant_->Finalize();
+
+    auto owned_deformable_rigid_manager =
+        std::make_unique<DeformableRigidManager<double>>();
+    deformable_rigid_manager_ = owned_deformable_rigid_manager.get();
+    plant_->SetDiscreteUpdateManager(std::move(owned_deformable_rigid_manager));
+    deformable_rigid_manager_->RegisterCollisionObjects(*scene_graph_);
+
+    diagram_ = builder.Build();
+    diagram_context_ = diagram_->CreateDefaultContext();
+  }
+
+  static SpatialInertia<double> MakeSpatialInertiaForBox() {
+    const UnitInertia<double> G_Rcm =
+        UnitInertia<double>::SolidBox(1.0, 1.0, 1.0);
+    return SpatialInertia<double>(1.0, Vector3d::Zero(), G_Rcm);
+  }
+
+  /* Calls DeformableRigidManager::EvalContactTangentMatrix() and returns the
+   tangent matrix for contact as a dense matrix. */
+  MatrixXd CalcContactTangentMatrix(const Context<double>& context) const {
+    const BlockSparseMatrix<double> A =
+        deformable_rigid_manager_->EvalContactTangentMatrix(context);
+    return A.MakeDenseMatrix();
+  }
+
+  /* Calls DeformableRigidManager::EvalFreeMotionTangentMatrix() and returns the
+   free motion tangent matrix of the deformable body with the given `index` as a
+   dense matrix. */
+  MatrixXd CalcFreeMotionTangentMatrix(const Context<double>& context,
+                                       SoftBodyIndex index) const {
+    const Eigen::SparseMatrix<double> tangent_matrix_sparse =
+        deformable_rigid_manager_->EvalFreeMotionTangentMatrix(context, index);
+    return MatrixXd(tangent_matrix_sparse);
+  }
+
+  /* Calls DeformableRigidManager::EvalFreeMotionTangentMatrixSchurComplement()
+   and returns the Schur complement of the tangent matrix of the deformable body
+   with the given `index` as a dense matrix. */
+  const MatrixXd& EvalFreeMotionTangentMatrixSchurComplement(
+      const systems::Context<double>& context, SoftBodyIndex index) const {
+    const internal::SchurComplement<double>& schur_complement =
+        deformable_rigid_manager_->EvalFreeMotionTangentMatrixSchurComplement(
+            context, index);
+    return schur_complement.get_D_complement();
+  }
+
+  SceneGraph<double>* scene_graph_{nullptr};
+  MultibodyPlant<double>* plant_{nullptr};
+  const DeformableRigidManager<double>* deformable_rigid_manager_{nullptr};
+  SoftBodyIndex A_;
+  SoftBodyIndex B_;
+  BodyIndex C_;
+  GeometryId collision_geometry_C_;
+  std::unique_ptr<systems::Diagram<double>> diagram_{nullptr};
+  std::unique_ptr<Context<double>> diagram_context_{nullptr};
+};
+
+namespace {
+
+/* Verifies that the Schur complement of the deformable free motion tangent
+ matrix is as expected in a simple scenario where we know what the contact
+ looks like. */
+TEST_F(DeformableRigidDynamicsDataTest,
+       FreeMotionTangentMatrixSchurComplement) {
+  Context<double>& plant_context =
+      plant_->GetMyMutableContextFromRoot(diagram_context_.get());
+  /* Move the rigid cube up so that it intersects the octahedron in the upper
+  prism. Recall that the octahedron looks like:
+                +Z   -X
+                 |   /
+              v5 ●  ● v3
+                 | /
+       v4     v0 |/
+  -Y----●--------●------●----+Y
+                /|      v2
+               / |
+           v1 ●  ● v6
+             /   |
+           +X    |
+                -Z
+  Therefore, all vertices except v6 are participating in contact. */
+  const Vector3d p_WC(0, 0, 1);
+  const math::RigidTransformd X_WC(p_WC);
+  plant_->SetFreeBodyPose(&plant_context, plant_->get_body(C_), X_WC);
+  const MatrixXd tangent_matrix_schur_complement =
+      EvalFreeMotionTangentMatrixSchurComplement(plant_context, B_);
+  constexpr int num_participating_vertices = 6;
+  EXPECT_EQ(tangent_matrix_schur_complement.rows(),
+            3 * num_participating_vertices);
+  EXPECT_EQ(tangent_matrix_schur_complement.cols(),
+            3 * num_participating_vertices);
+  /* Construct the Schur complement by hand and verify that it matches the
+   calculated result. Note that here we rely on the fact that the permutation in
+   the deformable dofs is identity since it so happens that v6 is the
+   non-participating vertex. */
+  const MatrixXd tangent_matrix =
+      CalcFreeMotionTangentMatrix(plant_context, B_);
+  const Eigen::SparseMatrix<double> participating_block =
+      tangent_matrix
+          .topLeftCorner<3 * num_participating_vertices,
+                         3 * num_participating_vertices>()
+          .sparseView();
+  const Eigen::SparseMatrix<double> non_participating_block =
+      tangent_matrix.bottomRightCorner<3, 3>().sparseView();
+  const Eigen::SparseMatrix<double> off_diagonal_block =
+      tangent_matrix.bottomLeftCorner<3, 3 * num_participating_vertices>()
+          .sparseView();
+  const internal::SchurComplement<double> expected_schur_complement =
+      internal::SchurComplement<double>(participating_block, off_diagonal_block,
+                                        non_participating_block);
+  EXPECT_TRUE(CompareMatrices(expected_schur_complement.get_D_complement(),
+                              tangent_matrix_schur_complement,
+                              std::numeric_limits<double>::epsilon()));
+}
+
+/* Verifies that the contact tangent matrix is empty when there is no contact.
+ */
+TEST_F(DeformableRigidDynamicsDataTest, NoContact) {
+  Context<double>& plant_context =
+      plant_->GetMyMutableContextFromRoot(diagram_context_.get());
+  /* Move the bodies far away from each other so that there is no contact at
+   all. */
+  const Vector3d p_WC(0, -5, 0);
+  const math::RigidTransformd X_WC(p_WC);
+  plant_->SetFreeBodyPose(&plant_context, plant_->get_body(C_), X_WC);
+  const MatrixXd tangent_matrix = CalcContactTangentMatrix(plant_context);
+  EXPECT_EQ(tangent_matrix.rows(), 0);
+  EXPECT_EQ(tangent_matrix.cols(), 0);
+}
+
+/* Verifies that the contact tangent matrix matches expectation. */
+TEST_F(DeformableRigidDynamicsDataTest, TangentMatrix) {
+  Context<double>& plant_context =
+      plant_->GetMyMutableContextFromRoot(diagram_context_.get());
+  /* Move the rigid body so that A and C are in contact but B and C are not.
+   */
+  const Vector3d p_WC(0, 2.5, 0);
+  const math::RigidTransformd X_WC(p_WC);
+  plant_->SetFreeBodyPose(&plant_context, plant_->get_body(C_), X_WC);
+  const MatrixXd tangent_matrix = CalcContactTangentMatrix(plant_context);
+  /* Since only A and C are in contact and all vertices of A are participating
+   in contact, the dimension of the tangent matrix should be 6 (rigid dofs) +
+   the number of dofs in A (3 * kNumVertices). B does not show up in the
+   tangent matrix. */
+  EXPECT_EQ(tangent_matrix.rows(), 6 + 3 * kNumVertices);
+  EXPECT_EQ(tangent_matrix.cols(), 6 + 3 * kNumVertices);
+  SpatialInertia<double> M = MakeSpatialInertiaForBox();
+  EXPECT_TRUE(CompareMatrices(tangent_matrix.topLeftCorner(6, 6),
+                              M.CopyToFullMatrix6()));
+  EXPECT_TRUE(
+      CompareMatrices(tangent_matrix.topRightCorner(6, 3 * kNumVertices),
+                      MatrixXd::Zero(6, 3 * kNumVertices)));
+  EXPECT_TRUE(
+      CompareMatrices(tangent_matrix.bottomLeftCorner(3 * kNumVertices, 6),
+                      MatrixXd::Zero(3 * kNumVertices, 6)));
+  /* Since *all* vertices in A are participating in contact, the Schur
+   complement of the free motion tangent matrix of A is the free motion
+   tangent matrix itself. */
+  EXPECT_TRUE(CompareMatrices(
+      tangent_matrix.bottomRightCorner(3 * kNumVertices, 3 * kNumVertices),
+      CalcFreeMotionTangentMatrix(plant_context, A_)));
 }
 
 }  // namespace

--- a/multibody/fixed_fem/dev/test/permute_block_sparse_matrix_test.cc
+++ b/multibody/fixed_fem/dev/test/permute_block_sparse_matrix_test.cc
@@ -1,0 +1,55 @@
+#include "drake/multibody/fixed_fem/dev/permute_block_sparse_matrix.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+namespace {
+
+using Eigen::MatrixXd;
+constexpr int kNumBlocks = 2;
+constexpr int kSize = kNumBlocks * 3;
+/* Returns an arbitrary matrix for testing purpose. */
+MatrixXd MakeMatrix() {
+  const int rows = kSize;
+  const int cols = kSize;
+  MatrixXd A(rows, cols);
+  for (int i = 0; i < rows; ++i) {
+    for (int j = 0; j < cols; ++j) {
+      A(i, j) = cols * i + j;
+    }
+  }
+  return A;
+}
+
+/* Verify that PermuteBlockSparseMatrix provides the expected answer as
+hand-calculated solution on a small problem. The problem consists of 2 blocks
+permuted such that 0->1, 1->0. */
+GTEST_TEST(PermuteBlockSparseMatrix, AnalyticTest) {
+  const MatrixXd A = MakeMatrix();
+  const Eigen::SparseMatrix<double> A_sparse = A.sparseView();
+  const std::vector<int> block_permutation = {1, 0};
+  const Eigen::SparseMatrix<double> permuted_A =
+      PermuteBlockSparseMatrix(A_sparse, block_permutation);
+  const MatrixXd permuted_A_dense = permuted_A;
+
+  MatrixXd expected_result(kSize, kSize);
+  /* The new 0-0 block is the same as the old 1-1 block. */
+  expected_result.topLeftCorner<3, 3>() = A.bottomRightCorner<3, 3>();
+  /* The new 0-1 block is the same as the old 1-0 block. */
+  expected_result.topRightCorner<3, 3>() = A.bottomLeftCorner<3, 3>();
+  /* The new 1-0 block is the same as the old 0-1 block. */
+  expected_result.bottomLeftCorner<3, 3>() = A.topRightCorner<3, 3>();
+  /* The new 1-1 block is the same as the old 0-0 block. */
+  expected_result.bottomRightCorner<3, 3>() = A.topLeftCorner<3, 3>();
+  EXPECT_TRUE(CompareMatrices(expected_result, permuted_A_dense));
+}
+}  // namespace
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
* Calculate the free motion tangent matrix for all deformable bodies in
DeformableRigidManager.
* Permute the free motion tangent matrix to group dofs in contact.
* Calculate the Schur complement of the free motion tangent matrix based
on contact participation.
* Assemble the tangent matrix for contact with full mass matrix for
rigid dofs and the Schur complements of the free motion tangent matrices
for participating deformable bodies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15417)
<!-- Reviewable:end -->
