### PR TITLE
[common] Add Value::maybe_get_mutable_value

### DIFF
--- a/common/test/value_test.cc
+++ b/common/test/value_test.cc
@@ -198,11 +198,38 @@ GTEST_TEST(ValueTest, MaybeGetValue) {
   EXPECT_EQ(double_value->maybe_get_value<std::string>(), nullptr);
   EXPECT_EQ(string_value->maybe_get_value<double>(), nullptr);
 
-  ASSERT_NE(double_value->maybe_get_value<double>(), nullptr);
-  EXPECT_EQ(*double_value->maybe_get_value<double>(), 3.);
+  const double* const double_pointer =
+      double_value->maybe_get_value<double>();
+  const std::string* const string_pointer =
+      string_value->maybe_get_value<std::string>();
 
-  ASSERT_NE(string_value->maybe_get_value<std::string>(), nullptr);
-  EXPECT_EQ(*string_value->maybe_get_value<std::string>(), "hello");
+  ASSERT_NE(double_pointer, nullptr);
+  ASSERT_NE(string_pointer, nullptr);
+  EXPECT_EQ(*double_pointer, 3.);
+  EXPECT_EQ(*string_pointer, "hello");
+}
+
+// Check that maybe_get_mutable_value() returns nullptr for wrong-type
+// requests, and returns the correct value for right-type requests.
+GTEST_TEST(ValueTest, MaybeGetMutableValue) {
+  auto double_value = AbstractValue::Make<double>(3.);
+  auto string_value = AbstractValue::Make<std::string>("hello");
+
+  EXPECT_EQ(double_value->maybe_get_mutable_value<std::string>(), nullptr);
+  EXPECT_EQ(string_value->maybe_get_mutable_value<double>(), nullptr);
+
+  double* const double_pointer =
+      double_value->maybe_get_mutable_value<double>();
+  std::string* const string_pointer =
+      string_value->maybe_get_mutable_value<std::string>();
+
+  ASSERT_NE(double_pointer, nullptr);
+  ASSERT_NE(string_pointer, nullptr);
+  EXPECT_EQ(*double_pointer, 3.);
+  EXPECT_EQ(*string_pointer, "hello");
+
+  *string_pointer = "goodbye";
+  EXPECT_EQ(string_value->get_value<std::string>(), "goodbye");
 }
 
 TYPED_TEST(TypedValueTest, Access) {

--- a/common/value.h
+++ b/common/value.h
@@ -114,6 +114,14 @@ class AbstractValue {
   template <typename T>
   const T* maybe_get_value() const;
 
+  /// Returns the mutable value wrapped in this AbstractValue, if T matches the
+  /// originally declared type of this AbstractValue.
+  /// @tparam T The originally declared type of this AbstractValue, e.g., from
+  /// AbstractValue::Make<T>() or Value<T>::Value().  If T does not match,
+  /// returns nullptr.
+  template <typename T>
+  T* maybe_get_mutable_value();
+
   /// Returns a copy of this AbstractValue.
   virtual std::unique_ptr<AbstractValue> Clone() const = 0;
 
@@ -664,6 +672,13 @@ const T* AbstractValue::maybe_get_value() const {
   if (!is_maybe_matched<T>()) { return nullptr; }
   auto& self = static_cast<const Value<T>&>(*this);
   return &self.get_value();
+}
+
+template <typename T>
+T* AbstractValue::maybe_get_mutable_value() {
+  if (!is_maybe_matched<T>()) { return nullptr; }
+  auto& self = static_cast<Value<T>&>(*this);
+  return &self.get_mutable_value();
 }
 
 // In Debug mode, returns true iff `this` is-a `Value<T>`.  In Release mode, a


### PR DESCRIPTION
Note that we don't need to bind this in pydrake; with dynamic typing, there is no need for a "maybe" flavor of the getters.

This new function will be used by a forthcoming `framework` optimization, to supplant a `dynamic_cast` (#15419).

Towards #15421.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15418)
<!-- Reviewable:end -->
