### PR TITLE
[framework] Never dynamic_cast an AbstractValue

### DIFF
--- a/systems/framework/leaf_system.cc
+++ b/systems/framework/leaf_system.cc
@@ -963,7 +963,7 @@ LeafOutputPort<T>& LeafSystem<T>::CreateVectorLeafOutputPort(
 
     // The abstract value must be a Value<BasicVector<T>>, even if the
     // underlying object is a more-derived vector type.
-    auto value = dynamic_cast<Value<BasicVector<T>>*>(abstract);
+    auto* value = abstract->maybe_get_mutable_value<BasicVector<T>>();
 
     // TODO(sherm1) Make this error message more informative by capturing
     // system and port index info.
@@ -974,7 +974,7 @@ LeafOutputPort<T>& LeafSystem<T>::CreateVectorLeafOutputPort(
           NiceTypeName::Get<Value<BasicVector<T>>>(),
           abstract->GetNiceTypeName()));
     }
-    vector_calculator(context, &value->get_mutable_value());
+    vector_calculator(context, value);
   };
 
   // The allocator function is identical between output port and cache.

--- a/systems/framework/output_port.cc
+++ b/systems/framework/output_port.cc
@@ -7,7 +7,7 @@ void OutputPort<T>::CheckValidAllocation(const AbstractValue& proposed) const {
   if (this->get_data_type() != kVectorValued)
     return;  // Nothing we can check for an abstract port.
 
-  auto proposed_vec = dynamic_cast<const Value<BasicVector<T>>*>(&proposed);
+  const auto* const proposed_vec = proposed.maybe_get_value<BasicVector<T>>();
   if (proposed_vec == nullptr) {
     throw std::logic_error(
         fmt::format("OutputPort::Allocate(): expected BasicVector output type "

--- a/systems/framework/test_utilities/pack_value.h
+++ b/systems/framework/test_utilities/pack_value.h
@@ -14,13 +14,11 @@ std::unique_ptr<AbstractValue> PackValue(T value) {
   return std::make_unique<Value<T>>(value);
 }
 
-/// Extracts data of type T from the given @p value, or aborts if the
+/// Extracts data of type T from the given @p value, or throws if the
 /// @p value does not contain type T.
 template <typename T>
 T UnpackValue(const AbstractValue& value) {
-  const Value<T>* unpacked = dynamic_cast<const Value<T>*>(&value);
-  DRAKE_DEMAND(unpacked != nullptr);
-  return unpacked->get_value();
+  return value.get_value<T>();
 }
 
 /// Extracts an integer from the given @p value, or aborts if the

--- a/systems/framework/value_checker.h
+++ b/systems/framework/value_checker.h
@@ -58,12 +58,11 @@ void CheckBasicVectorInvariants(const BasicVector<T>* basic_vector) {
 template <typename T>
 void CheckVectorValueInvariants(const AbstractValue* abstract_value) {
   DRAKE_THROW_UNLESS(abstract_value != nullptr);
-  const Value<BasicVector<T>>* const vector_value =
-      dynamic_cast<const Value<BasicVector<T>>*>(abstract_value);
-  if (vector_value != nullptr) {
+  const auto* const basic_vector =
+      abstract_value->maybe_get_value<BasicVector<T>>();
+  if (basic_vector != nullptr) {
     // We are a Value<BasicVector<T>>, so check the invariants.
-    const BasicVector<T>& basic_vector = vector_value->get_value();
-    CheckBasicVectorInvariants<T>(&basic_vector);
+    CheckBasicVectorInvariants<T>(basic_vector);
   }
 }
 


### PR DESCRIPTION
The AbstractValue implementation goes to great lengths to avoid dynamic_cast, because RTTI checking is exceedingly slow, relative to what we expect during an inner loop. We should use its built-in type checking functions, instead of casting ourselves.

The leaf_system.cc vector cast was showing up as a profiling hot spot, but even without that we should make this change, even in test code. Trying to directly cast sets a bad example for others to imitate.

This provides a minor (~5%) speed-up on the forthcoming PassThrough3 benchmark (where three vector-valued pass through systems are cascaded within a diagram) at #15422.

- [x] Depends on #15418.

Towards #15421.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15419)
<!-- Reviewable:end -->
