### PR TITLE
[performance] Add .py suffix to benchmark_tool

### DIFF
--- a/examples/multibody/cassie_benchmark/conduct_experiment
+++ b/examples/multibody/cassie_benchmark/conduct_experiment
@@ -12,5 +12,5 @@ shift
 
 cd "$HERE"/../../..
 
-./tools/performance/benchmark_tool conduct_experiment \
+python3 -B tools/performance/benchmark_tool.py conduct_experiment \
     $TARGET "$OUTPUT_DIR" -- "$@"

--- a/examples/multibody/cassie_benchmark/copy_results_to
+++ b/examples/multibody/cassie_benchmark/copy_results_to
@@ -9,4 +9,4 @@ HERE=$(dirname $ME)
 
 cd "$HERE"/../../..
 
-./tools/performance/benchmark_tool copy_results $TARGET "$1"
+python3 -B tools/performance/benchmark_tool.py copy_results $TARGET "$1"

--- a/tools/performance/BUILD.bazel
+++ b/tools/performance/BUILD.bazel
@@ -13,4 +13,4 @@ py_binary(
     ],
 )
 
-add_lint_tests(python_lint_extra_srcs = ["benchmark_tool"])
+add_lint_tests(python_lint_extra_srcs = ["benchmark_tool.py"])

--- a/tools/performance/README.md
+++ b/tools/performance/README.md
@@ -8,7 +8,7 @@ analysis of Drake programs.
 Included here are two tools to help with well-controlled benchmark experiments:
 
  * `record_results.py` -- run benchmark under bazel, record context and results
- * `benchmark_tool` -- outside-bazel tool for experiments and data handling
+ * `benchmark_tool.py` -- outside-bazel tool for experiments and data handling
 
 A fully worked example that integrates these two tools is available at
 `drake/examples/multibody/cassie_benchmark`. Some of the history of attempts to

--- a/tools/performance/benchmark_tool.py
+++ b/tools/performance/benchmark_tool.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Tool to help with controlled benchmark experiments.
 
 Subcommands:
@@ -19,7 +18,7 @@ conduct_experiment:
   It is possible to customize the bazel build and run steps by using
   "--extra-build-args=" (a.k.a. "-b=") options:
 
-    benchmark_tool conduct_experiment \\
+    python3 -B benchmark_tool.py conduct_experiment \\
       -b=--copt=-mtune=haswell \\
       -b=--copt=-g \\
       [TARGET] [OUTPUT-DIR]


### PR DESCRIPTION
Change its invocations to match.

This is in preparation for changing it into a bazel py_binary, while preserving git history.

Towards #15421.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15420)
<!-- Reviewable:end -->
