### PR TITLE
[systems] Add one elementary benchmark

### DIFF
--- a/examples/acrobot/BUILD.bazel
+++ b/examples/acrobot/BUILD.bazel
@@ -18,6 +18,10 @@ load(
     "@drake//tools/vector_gen:vector_gen.bzl",
     "drake_cc_vector_gen_library",
 )
+load(
+    "@drake//tools/performance:defs.bzl",
+    "drake_cc_googlebench_binary",
+)
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 package(default_visibility = ["//visibility:private"])
@@ -424,7 +428,7 @@ drake_py_test(
     ],
 )
 
-drake_cc_binary(
+drake_cc_googlebench_binary(
     name = "benchmark_autodiff",
     srcs = ["benchmark_autodiff.cc"],
     deps = [
@@ -435,7 +439,7 @@ drake_cc_binary(
         "//math:gradient",
         "//multibody/benchmarks/acrobot:make_acrobot_plant",
         "//multibody/parsing",
-        "@googlebenchmark//:benchmark",
+        "//tools/performance:fixture_common",
     ],
 )
 

--- a/examples/acrobot/benchmark_autodiff.cc
+++ b/examples/acrobot/benchmark_autodiff.cc
@@ -13,6 +13,7 @@
 #include "drake/math/autodiff_gradient.h"
 #include "drake/multibody/benchmarks/acrobot/make_acrobot_plant.h"
 #include "drake/multibody/parsing/parser.h"
+#include "drake/tools/performance/fixture_common.h"
 
 using Eigen::MatrixXd;
 using drake::multibody::MultibodyPlant;
@@ -28,12 +29,7 @@ template <typename T>
 class FixtureBase : public benchmark::Fixture {
  public:
   FixtureBase() {
-    ComputeStatistics("min", [](const std::vector<double>& v) -> double {
-        return *(std::min_element(std::begin(v), std::end(v)));
-      });
-    ComputeStatistics("max", [](const std::vector<double>& v) -> double {
-        return *(std::max_element(std::begin(v), std::end(v)));
-      });
+    tools::performance::AddMinMaxStatistics(this);
   }
 
   void Populate(const System<T>& plant) {

--- a/examples/multibody/cassie_benchmark/BUILD.bazel
+++ b/examples/multibody/cassie_benchmark/BUILD.bazel
@@ -2,26 +2,24 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load(
-    "@drake//tools/skylark:drake_cc.bzl",
-    "drake_cc_library",
-    "drake_cc_test",
+    "@drake//tools/performance:defs.bzl",
+    "drake_cc_googlebench_binary",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 package(default_visibility = ["//visibility:public"])
 
-drake_cc_test(
+drake_cc_googlebench_binary(
     name = "cassie_bench",
     srcs = ["test/cassie_bench.cc"],
     data = ["cassie_v2.urdf"],
-    linkstatic = True,
     deps = [
         "//common:essential",
         "//common:find_resource",
         "//common/test_utilities:limit_malloc",
         "//math:gradient",
         "//multibody/parsing:parser",
-        "@googlebenchmark//:benchmark",
+        "//tools/performance:fixture_common",
     ],
 )
 

--- a/examples/multibody/cassie_benchmark/test/cassie_bench.cc
+++ b/examples/multibody/cassie_benchmark/test/cassie_bench.cc
@@ -6,6 +6,7 @@
 #include "drake/math/autodiff_gradient.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/multibody/plant/multibody_plant.h"
+#include "drake/tools/performance/fixture_common.h"
 
 using drake::multibody::MultibodyPlant;
 using drake::symbolic::Expression;
@@ -73,12 +74,7 @@ class AllocationTracker {
 class CassieDoubleFixture : public benchmark::Fixture {
  public:
   CassieDoubleFixture() {
-    ComputeStatistics("min", [](const std::vector<double>& v) -> double {
-        return *(std::min_element(std::begin(v), std::end(v)));
-      });
-    ComputeStatistics("max", [](const std::vector<double>& v) -> double {
-        return *(std::max_element(std::begin(v), std::end(v)));
-      });
+    tools::performance::AddMinMaxStatistics(this);
   }
 
   // This apparently futile using statement works around "overloaded virtual"

--- a/geometry/benchmarking/BUILD.bazel
+++ b/geometry/benchmarking/BUILD.bazel
@@ -1,11 +1,16 @@
 # -*- python -*-
 
 load("@drake//tools/skylark:drake_cc.bzl", "drake_cc_binary")
+load(
+    "@drake//tools/performance:defs.bzl",
+    "drake_cc_googlebench_binary",
+)
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
-drake_cc_binary(
+drake_cc_googlebench_binary(
     name = "mesh_intersection_benchmark",
     srcs = ["mesh_intersection_benchmark.cc"],
+    test_timeout = "moderate",
     deps = [
         "//common:essential",
         "//geometry/proximity:make_ellipsoid_field",
@@ -13,10 +18,11 @@ drake_cc_binary(
         "//geometry/proximity:make_sphere_mesh",
         "//geometry/proximity:mesh_intersection",
         "//math",
-        "@googlebenchmark//:benchmark",
     ],
 )
 
+# TODO(jwnimmer-tri) Change this to a drake_cc_googlebench_binary (i.e., add
+# a unit test here) once we figure out how to mate googlebench with gflags.
 drake_cc_binary(
     name = "render_benchmark",
     srcs = ["render_benchmark.cc"],

--- a/systems/benchmarking/BUILD.bazel
+++ b/systems/benchmarking/BUILD.bazel
@@ -1,0 +1,21 @@
+# -*- python -*-
+
+load(
+    "@drake//tools/performance:defs.bzl",
+    "drake_cc_googlebench_binary",
+)
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+package(default_visibility = ["//visibility:private"])
+
+drake_cc_googlebench_binary(
+    name = "framework_benchmarks",
+    srcs = ["framework_benchmarks.cc"],
+    deps = [
+        "//systems/framework:diagram_builder",
+        "//systems/primitives:pass_through",
+        "//tools/performance:fixture_common",
+    ],
+)
+
+add_lint_tests()

--- a/systems/benchmarking/README.md
+++ b/systems/benchmarking/README.md
@@ -1,0 +1,12 @@
+Runtime Performance Benchmarks for Dynamical Systems
+----------------------------------------------------
+
+## Supported experiments
+
+TODO(jwnimmer-tri) As of now, the benchmark suite is fairly minimal.
+Check back later for additional details and instructions.
+
+## Additional information
+
+Documentation for command line arguments is here:
+https://github.com/google/benchmark#command-line

--- a/systems/benchmarking/framework_benchmarks.cc
+++ b/systems/benchmarking/framework_benchmarks.cc
@@ -1,0 +1,69 @@
+#include <benchmark/benchmark.h>
+
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/primitives/pass_through.h"
+#include "drake/tools/performance/fixture_common.h"
+
+/* A collection of scenarios to benchmark, scoped to cover all code within the
+drake/systems/framework package. */
+
+namespace drake {
+namespace systems {
+namespace {
+
+class BasicFixture : public benchmark::Fixture {
+ public:
+  BasicFixture() {
+    tools::performance::AddMinMaxStatistics(this);
+  }
+
+  // This apparently futile using statement works around "overloaded virtual"
+  // errors in g++. All of this is a consequence of the weird deprecation of
+  // const-ref State versions of SetUp() and TearDown() in benchmark.h.
+  using benchmark::Fixture::SetUp;
+  void SetUp(benchmark::State&) override {
+    builder_ = std::make_unique<DiagramBuilder<double>>();
+  }
+
+  void Build() {
+    diagram_ = builder_->Build();
+    context_ = diagram_->CreateDefaultContext();
+    builder_.reset();
+  }
+
+ protected:
+  std::unique_ptr<DiagramBuilder<double>> builder_;
+  std::unique_ptr<Diagram<double>> diagram_;
+  std::unique_ptr<Context<double>> context_;
+};
+
+// NOLINTNEXTLINE(runtime/references) cpplint disapproves of gbench choices.
+BENCHMARK_F(BasicFixture, PassThrough3)(benchmark::State& state) {
+  const int n = 7;
+  auto* alpha = builder_->AddSystem<PassThrough<double>>(n);
+  auto* bravo = builder_->AddSystem<PassThrough<double>>(n);
+  auto* charlie = builder_->AddSystem<PassThrough<double>>(n);
+  builder_->ExportInput(alpha->get_input_port());
+  builder_->Cascade(*alpha, *bravo);
+  builder_->Cascade(*bravo, *charlie);
+  builder_->ExportOutput(charlie->get_output_port());
+  Build();
+
+  Eigen::VectorXd value = Eigen::VectorXd::Constant(n, 22.2);
+  auto& input = diagram_->get_input_port().FixValue(context_.get(), value);
+  auto& output = diagram_->get_output_port();
+
+  for (auto _ : state) {
+    // Invalidate the furthest upstream CacheEntry, in order to force
+    // re-computation of all downstream values.  This also mimics a common
+    // scenario of interest, where the inputs change on every tick.
+    input.GetMutableData();
+    output.Eval(*context_);
+  }
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake
+
+BENCHMARK_MAIN();

--- a/tools/performance/BUILD.bazel
+++ b/tools/performance/BUILD.bazel
@@ -1,9 +1,25 @@
 # -*- python -*-
 
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_library",
+)
+load(
+    "@drake//tools/skylark:py.bzl",
+    "py_binary",
+)
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("//tools/skylark:py.bzl", "py_binary")
 
 package(default_visibility = ["//visibility:public"])
+
+drake_cc_library(
+    name = "fixture_common",
+    srcs = ["fixture_common.cc"],
+    hdrs = ["fixture_common.h"],
+    deps = [
+        "@googlebenchmark//:benchmark",
+    ],
+)
 
 py_binary(
     name = "record_results",

--- a/tools/performance/defs.bzl
+++ b/tools/performance/defs.bzl
@@ -1,0 +1,38 @@
+# -*- python -*-
+
+load("@drake//tools/skylark:drake_cc.bzl", "drake_cc_test")
+
+# This file provides build system sugar for crafting benchmarking programs.
+
+def drake_cc_googlebench_binary(
+        name,
+        *,
+        srcs,
+        deps,
+        test_timeout = None,
+        **kwargs):
+    """Declares a testonly binary that uses google benchmark.  Automatically
+    adds appropriate deps and ensures it has an automated smoke test.
+    """
+    if not srcs:
+        fail("Missing srcs")
+
+    # Even though this program is more like a cc_binary than a cc_test, we
+    # still declare it as a test here so that when run in CI the ASan, TSan,
+    # Memcheck, etc. tools will all be in full effect. (In CI, tests declared
+    # as python or shell wrappers are excluded from the santizers.)
+    drake_cc_test(
+        name = name,
+        srcs = srcs,
+        args = [
+            # When running as a unit test, run each function only once to save
+            # time. (Once is sufficient to prove lack of runtime errors.)
+            "--benchmark_min_time=0",
+        ],
+        timeout = test_timeout,
+        linkstatic = True,
+        deps = (deps or []) + [
+            "@googlebenchmark//:benchmark",
+        ],
+        **kwargs
+    )

--- a/tools/performance/fixture_common.cc
+++ b/tools/performance/fixture_common.cc
@@ -1,0 +1,21 @@
+#include "drake/tools/performance/fixture_common.h"
+
+#include <algorithm>
+#include <vector>
+
+namespace drake {
+namespace tools {
+namespace performance {
+
+void AddMinMaxStatistics(benchmark::Fixture* fixture) {
+  fixture->ComputeStatistics("min", [](const std::vector<double>& v) -> double {
+    return *(std::min_element(std::begin(v), std::end(v)));
+  });
+  fixture->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
+    return *(std::max_element(std::begin(v), std::end(v)));
+  });
+}
+
+}  // namespace performance
+}  // namespace tools
+}  // namespace drake

--- a/tools/performance/fixture_common.h
+++ b/tools/performance/fixture_common.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <benchmark/benchmark.h>
+
+namespace drake {
+namespace tools {
+namespace performance {
+
+/** Adds "min" and "max" statistics to the fixture's reports. */
+void AddMinMaxStatistics(benchmark::Fixture* fixture);
+
+}  // namespace performance
+}  // namespace tools
+}  // namespace drake


### PR DESCRIPTION
This first benchmark only measures the throughput of PassThroughSystem and Diagram when used with vector-valued ports.  Even so, it is enough to highlight unnecessary spending on dynamic casts.

Factor out a common cc_binary rule between the existing cassie_benchmark and the newly-added systems/benchmarking.

Towards #15421.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15422)
<!-- Reviewable:end -->
