### PR TITLE
[analysis] Support fixed input ports in RegionOfAttraction

### DIFF
--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -569,6 +569,8 @@ drake_cc_googletest(
     deps = [
         ":region_of_attraction",
         "//solvers:mosek_solver",
+        "//systems/framework:diagram_builder",
+        "//systems/primitives:constant_vector_source",
         "//systems/primitives:symbolic_vector_system",
     ],
 )

--- a/systems/analysis/region_of_attraction.cc
+++ b/systems/analysis/region_of_attraction.cc
@@ -127,9 +127,8 @@ Expression RegionOfAttraction(const System<double>& system,
 
   const auto symbolic_system = system.ToSymbolic();
   const auto symbolic_context = symbolic_system->CreateDefaultContext();
-  // Time and parameters should just be doubles (not Variables).
-  symbolic_context->SetTime(0.0);
-  symbolic_context->get_mutable_parameters().SetFrom(context.get_parameters());
+  symbolic_context->SetTimeStateAndParametersFrom(context);
+  symbolic_system->FixInputPortsFrom(system, context, symbolic_context.get());
 
   // Subroutines should create their own programs to avoid incidental
   // sharing of costs or constraints.  However, we pass x and expect that

--- a/systems/analysis/region_of_attraction.h
+++ b/systems/analysis/region_of_attraction.h
@@ -54,9 +54,16 @@ struct RegionOfAttractionOptions {
  * {x | V(x)<=1} containing the fixed-point in @p context represents the region
  * of attraction.
  *
- * Note: There are more numerical techniques that we know how to apply here.
- * Do report an issue if you discover a system for which this code does not
- * perform well.
+ * @pre For the given @p system and @p context, any required input ports on @p
+ * system must be "defined", i.e., connected to other systems in a larger
+ * diagram or holding fixed values; see System::FixInputPortsFrom for possible
+ * caveats. Analyzing a closed-loop system would typically be accomplished by
+ * having both the plant and the controller in a diagram (which then has no
+ * input ports), and passing the diagram into this method as @p system.
+ *
+ * Note: There are more numerical recipes for region of attraction analysis that
+ * could extend the current implementation. Do report an issue if you discover a
+ * system for which this code does not perform well.
  *
  * @ingroup analysis
  */


### PR DESCRIPTION
In response to https://stackoverflow.com/questions/68344096/is-regionofattraction-available-for-multibody-plants-from-pydrake

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15425)
<!-- Reviewable:end -->
