### PR TITLE
[examples/pendulum] Include weld joint in Pendulum.urdf

### DIFF
--- a/bindings/pydrake/examples/multibody/pendulum_lqr_monte_carlo_analysis.py
+++ b/bindings/pydrake/examples/multibody/pendulum_lqr_monte_carlo_analysis.py
@@ -58,8 +58,6 @@ def main():
     file_name = FindResourceOrThrow(
         "drake/examples/pendulum/Pendulum.urdf")
     Parser(pendulum).AddModelFromFile(file_name)
-    pendulum.WeldFrames(pendulum.world_frame(),
-                        pendulum.GetFrameByName("base"))
     pendulum.Finalize()
 
     # Set the pendulum to start at uniformly random

--- a/bindings/pydrake/examples/multibody/run_planar_scenegraph_visualizer.py
+++ b/bindings/pydrake/examples/multibody/run_planar_scenegraph_visualizer.py
@@ -23,7 +23,6 @@ def run_pendulum_example(args):
     parser = Parser(plant)
     parser.AddModelFromFile(FindResourceOrThrow(
         "drake/examples/pendulum/Pendulum.urdf"))
-    plant.WeldFrames(plant.world_frame(), plant.GetFrameByName("base"))
     plant.Finalize()
 
     pose_bundle_output_port = scene_graph.get_pose_bundle_output_port()

--- a/examples/pendulum/Pendulum.urdf
+++ b/examples/pendulum/Pendulum.urdf
@@ -31,7 +31,7 @@
       <material name="green"/>
     </visual>
   </link>
-  <joint drake_ignore="true" name="base_weld" type="fixed">
+  <joint name="base_weld" type="fixed">
     <parent link="world"/>
     <child link="base"/>
     <origin xyz="0 0 1"/>

--- a/examples/pendulum/print_symbolic_dynamics.cc
+++ b/examples/pendulum/print_symbolic_dynamics.cc
@@ -45,7 +45,6 @@ VectorX<Expression> MultibodyPlantDynamics() {
   MultibodyPlant<double> plant(0.0);
   Parser parser(&plant);
   parser.AddModelFromFile(FindResourceOrThrow(urdf_path));
-  plant.WeldFrames(plant.world_frame(), plant.GetFrameByName("base"));
   plant.Finalize();
   auto symbolic_plant_ptr = System<double>::ToSymbolic(plant);
   const MultibodyPlant<Expression>& symbolic_plant = *symbolic_plant_ptr;

--- a/examples/pendulum/test/urdf_dynamics_test.cc
+++ b/examples/pendulum/test/urdf_dynamics_test.cc
@@ -17,7 +17,6 @@ GTEST_TEST(UrdfDynamicsTest, AllTests) {
   multibody::MultibodyPlant<double> mbp(0.0);
   multibody::Parser(&mbp).AddModelFromFile(FindResourceOrThrow(
       "drake/examples/pendulum/Pendulum.urdf"));
-  mbp.WeldFrames(mbp.world_frame(), mbp.GetFrameByName("base"));
   mbp.Finalize();
   PendulumPlant<double> p;
 

--- a/systems/controllers/test/dynamic_programming_test.cc
+++ b/systems/controllers/test/dynamic_programming_test.cc
@@ -215,7 +215,6 @@ GTEST_TEST(FittedValueIteration, MultibodyPlant) {
   multibody::Parser(mbp, scene_graph)
       .AddModelFromFile(
           FindResourceOrThrow("drake/examples/pendulum/Pendulum.urdf"));
-  mbp->WeldFrames(mbp->world_frame(), mbp->GetFrameByName("base"));
   mbp->Finalize();
 
   // Export an input that we don't need, and export it first, just to test the

--- a/systems/sensors/test/accelerometer_test.cc
+++ b/systems/sensors/test/accelerometer_test.cc
@@ -26,7 +26,6 @@ class AccelerometerTest : public ::testing::Test {
         FindResourceOrThrow("drake/examples/pendulum/Pendulum.urdf");
     multibody::Parser parser(plant_);
     parser.AddModelFromFile(urdf_name);
-    plant_->WeldFrames(plant_->world_frame(), plant_->GetFrameByName("base"));
     plant_->Finalize();
 
     // Connect a pendulum to the accelerometer.

--- a/systems/sensors/test/gyroscope_test.cc
+++ b/systems/sensors/test/gyroscope_test.cc
@@ -26,7 +26,6 @@ class GyroscopeTest : public ::testing::Test {
         FindResourceOrThrow("drake/examples/pendulum/Pendulum.urdf");
     multibody::Parser parser(plant_);
     parser.AddModelFromFile(urdf_name);
-    plant_->WeldFrames(plant_->world_frame(), plant_->GetFrameByName("base"));
     plant_->Finalize();
 
     const multibody::Body<double>& arm_body = plant_->GetBodyByName("arm");

--- a/systems/trajectory_optimization/test/direct_transcription_test.cc
+++ b/systems/trajectory_optimization/test/direct_transcription_test.cc
@@ -292,8 +292,6 @@ void SolvePendulumTrajectory(bool continuous_time) {
       std::make_unique<multibody::MultibodyPlant<double>>(kTimeStep);
   multibody::Parser parser(pendulum.get());
   parser.AddModelFromFile(FindResourceOrThrow(urdf_path));
-  pendulum->WeldFrames(pendulum->world_frame(),
-                       pendulum->GetFrameByName("base"));
   pendulum->Finalize();
 
   // Create the DirectTranscription object, and specify which input port

--- a/tutorials/pyplot_animation_multibody_plant.ipynb
+++ b/tutorials/pyplot_animation_multibody_plant.ipynb
@@ -125,7 +125,6 @@
     "    parser = Parser(plant)\n",
     "    parser.AddModelFromFile(FindResourceOrThrow(\n",
     "        \"drake/examples/pendulum/Pendulum.urdf\"))\n",
-    "    plant.WeldFrames(plant.world_frame(), plant.GetFrameByName(\"base\"))\n",
     "    plant.Finalize()\n",
     "\n",
     "    pose_bundle_output_port = scene_graph.get_pose_bundle_output_port()\n",


### PR DESCRIPTION
The pendulum urdf should *not* be floating by default.  This tripped me up quickly when I was testing something, and I'd like to resolve it now.

This is in some sense an API-breaking change without deprecation.  I don't know how to deprecate the urdf.

Code using the old workflow does get a quite clear error message:
```
RuntimeError: This MultibodyGraph already has a joint 'base_weld' connecting 'WorldBody' to 'base'. Therefore adding joint 'WorldBody_welds_to_base' connecting 'WorldBody' to 'base' is not allowed.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15426)
<!-- Reviewable:end -->
