### PR TITLE
pydrake: Add guidance that types should be bound before use in functions

### DIFF
--- a/bindings/pydrake/pydrake_doxygen.h
+++ b/bindings/pydrake/pydrake_doxygen.h
@@ -200,7 +200,8 @@ anonymous namespaces. Avoid `using namespace` directives otherwise.
 - Any symbol referenced in a module binding (even as function/method parameters)
 must either be *bound* in that compilation unit (with the binding evaluated
 before to the reference), or the module must import the pydrake module in which
-it is bound (e.g., `py::module::import("pydrake.foo"))`). Failure to do so will
+it is bound (e.g., `py::module::import("pydrake.foo"))`). Failure to do so can
+cause errors (unable to cast unregistered types from Python to C++) and can
 cause the generated docstring from pybind11 to render these types by their C++
 `typeid` rather than the Python type name.
 - If a module depends on the *bindings* for another module, then you should do

--- a/bindings/pydrake/pydrake_doxygen.h
+++ b/bindings/pydrake/pydrake_doxygen.h
@@ -197,10 +197,12 @@ modules should not re-define this alias at global scope.
 - If a certain namespace is being bound (e.g. `drake::systems::sensors`), you
 may use `using namespace drake::systems::sensors` within functions or
 anonymous namespaces. Avoid `using namespace` directives otherwise.
-- For function / method docstrings, please ensure that any types used in your
-function signature have already had their binding code executed. Otherwise, the
-generated docstring from pybind11 may use the raw C++ `typeid` rather than the
-Python type name.
+- Any symbol referenced in a module binding (even as function/method parameters)
+must either be *bound* in that compilation unit (with the binding evaluated
+before to the reference), or the module must import the pydrake module in which
+it is bound (e.g., `py::module::import("pydrake.foo"))`). Failure to do so will
+cause the generated docstring from pybind11 to render these types by their C++
+`typeid` rather than the Python type name.
 - If a module depends on the *bindings* for another module, then you should do
 the following:
   - Ensure that the dependent bindings module is listed in the `py_deps`

--- a/bindings/pydrake/pydrake_doxygen.h
+++ b/bindings/pydrake/pydrake_doxygen.h
@@ -197,6 +197,10 @@ modules should not re-define this alias at global scope.
 - If a certain namespace is being bound (e.g. `drake::systems::sensors`), you
 may use `using namespace drake::systems::sensors` within functions or
 anonymous namespaces. Avoid `using namespace` directives otherwise.
+- For function / method docstrings, please ensure that any types used in your
+function signature have already had their binding code executed. Otherwise, the
+generated docstring from pybind11 may use the raw C++ `typeid` rather than the
+Python type name.
 - If a module depends on the *bindings* for another module, then you should do
 the following:
   - Ensure that the dependent bindings module is listed in the `py_deps`


### PR DESCRIPTION
Follow-up from #15410

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15429)
<!-- Reviewable:end -->
