### PR TITLE
pydrake: Add binding for PackageMap.Remove

### DIFF
--- a/bindings/pydrake/multibody/parsing_py.cc
+++ b/bindings/pydrake/multibody/parsing_py.cc
@@ -34,6 +34,8 @@ PYBIND11_MODULE(parsing, m) {
         .def("AddMap", &Class::AddMap, py::arg("other_map"), cls_doc.AddMap.doc)
         .def("Contains", &Class::Contains, py::arg("package_name"),
             cls_doc.Contains.doc)
+        .def("Remove", &Class::Remove, py::arg("package_name"),
+            cls_doc.Remove.doc)
         .def("size", &Class::size, cls_doc.size.doc)
         .def("GetPackageNames", &Class::GetPackageNames,
             cls_doc.GetPackageNames.doc)

--- a/bindings/pydrake/multibody/test/parsing_test.py
+++ b/bindings/pydrake/multibody/test/parsing_test.py
@@ -43,7 +43,7 @@ class TestParsing(unittest.TestCase):
         self.assertEqual(dut.GetPath(package_name="root"), tmpdir)
         dut.AddPackageXml(filename=FindResourceOrThrow(
             "drake/multibody/parsing/test/box_package/package.xml"))
-        dut2.Remove('root')
+        dut2.Remove(package_name="root")
         self.assertEqual(dut2.size(), 0)
 
         # Simple coverage test for Drake paths.

--- a/bindings/pydrake/multibody/test/parsing_test.py
+++ b/bindings/pydrake/multibody/test/parsing_test.py
@@ -33,7 +33,7 @@ class TestParsing(unittest.TestCase):
             "drake/examples/atlas/urdf/atlas_minimal_contact.urdf")
 
         # Simple coverage test for Add, AddMap, Contains, size,
-        # GetPackageNames, GetPath, AddPackageXml.
+        # GetPackageNames, GetPath, AddPackageXml, Remove.
         dut.Add(package_name="root", package_path=tmpdir)
         dut2.Add(package_name="root", package_path=tmpdir)
         dut.AddMap(dut2)
@@ -43,6 +43,8 @@ class TestParsing(unittest.TestCase):
         self.assertEqual(dut.GetPath(package_name="root"), tmpdir)
         dut.AddPackageXml(filename=FindResourceOrThrow(
             "drake/multibody/parsing/test/box_package/package.xml"))
+        dut2.Remove('root')
+        self.assertEqual(dut2.size(), 0)
 
         # Simple coverage test for Drake paths.
         dut.PopulateUpstreamToDrake(model_file=model)


### PR DESCRIPTION
As part of the effort to introduce a top-level package.xml for Drake (see #10531), the `PackageMap` will be updated to include the top-level package reference during initialization. This binding will be used in tests which currently assume that the `PackageMap` is initialized empty.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15430)
<!-- Reviewable:end -->
