### PR TITLE
[framework] Use static_cast (not dynamic_cast) in hot paths

### DIFF
--- a/systems/framework/diagram_output_port.h
+++ b/systems/framework/diagram_output_port.h
@@ -101,7 +101,7 @@ class DiagramOutputPort final : public OutputPort<T> {
     return source_output_port_->Calc(subcontext, value);
   }
 
-  // Given he whole Diagram context, extracts the appropriate subcontext and
+  // Given the whole Diagram context, extracts the appropriate subcontext and
   // delegates to the source output port.
   const AbstractValue& DoEval(const Context<T>& diagram_context) const final {
     const Context<T>& subcontext = get_subcontext(diagram_context);
@@ -125,8 +125,13 @@ class DiagramOutputPort final : public OutputPort<T> {
 
   // Digs out the right subcontext for delegation.
   const Context<T>& get_subcontext(const Context<T>& diagram_context) const {
+    // Profiling revealed that it is too expensive to do a dynamic_cast here.
+    // A static_cast is safe as long as this is invoked only by methods that
+    // validate the SystemId, so that we know this Context is ours. As of this
+    // writing, only OutputPort::Eval and OutputPort::Calc invoke this and
+    // they do so safely.
     const DiagramContext<T>* diagram_context_downcast =
-        dynamic_cast<const DiagramContext<T>*>(&diagram_context);
+        static_cast<const DiagramContext<T>*>(&diagram_context);
     DRAKE_DEMAND(diagram_context_downcast != nullptr);
     return diagram_context_downcast->GetSubsystemContext(
         source_subsystem_index_);

--- a/systems/framework/leaf_system.cc
+++ b/systems/framework/leaf_system.cc
@@ -959,7 +959,12 @@ LeafOutputPort<T>& LeafSystem<T>::CreateVectorLeafOutputPort(
   // BasicVector<T> calculator function.
   auto cache_calc_function = [vector_calculator](
       const ContextBase& context_base, AbstractValue* abstract) {
-    auto& context = dynamic_cast<const Context<T>&>(context_base);
+    // Profiling revealed that it is too expensive to do a dynamic_cast here.
+    // A static_cast is safe as long as this is invoked only by methods that
+    // validate the SystemId, so that we know this Context is ours. As of this
+    // writing, only OutputPort::Eval and OutputPort::Calc invoke this and
+    // they do so safely.
+    auto& context = static_cast<const Context<T>&>(context_base);
 
     // The abstract value must be a Value<BasicVector<T>>, even if the
     // underlying object is a more-derived vector type.

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -906,7 +906,13 @@ class System : public SystemBase {
   // TODO(sherm1) Make this an InputPortIndex.
   /** Returns the typed input port at index @p port_index. */
   const InputPort<T>& get_input_port(int port_index) const {
-    return dynamic_cast<const InputPort<T>&>(
+    // Profiling revealed that it is too expensive to do a dynamic_cast here.
+    // A static_cast is safe as long as GetInputPortBaseOrThrow always returns
+    // a satisfactory type. As of this writing, it only ever returns values
+    // supplied via SystemBase::AddInputPort, which atop its implementation
+    // has a check that port.get_system_interface() matches `this` which is a
+    // System<T>, so we are safe.
+    return static_cast<const InputPort<T>&>(
         this->GetInputPortBaseOrThrow(__func__, port_index));
   }
 
@@ -941,7 +947,13 @@ class System : public SystemBase {
   // TODO(sherm1) Make this an OutputPortIndex.
   /** Returns the typed output port at index @p port_index. */
   const OutputPort<T>& get_output_port(int port_index) const {
-    return dynamic_cast<const OutputPort<T>&>(
+    // Profiling revealed that it is too expensive to do a dynamic_cast here.
+    // A static_cast is safe as long as GetInputPortBaseOrThrow always returns
+    // a satisfactory type. As of this writing, it only ever returns values
+    // supplied via SystemBase::AddInputPort, which atop its implementation
+    // has a check that port.get_system_interface() matches `this` which is a
+    // System<T>, so we are safe.
+    return static_cast<const OutputPort<T>&>(
         this->GetOutputPortBaseOrThrow(__func__, port_index));
   }
 


### PR DESCRIPTION
Note that this leaves a couple more hot-path dynamic_casts still in place (currently shown in #15421 as a WIP), because they are more complicated to reason about.

The baseline performance (with #15419 already applied):
```
---------------------------------------------------------------------------
Benchmark                                 Time             CPU   Iterations
---------------------------------------------------------------------------
BasicFixture/PassThrough3_mean         1233 ns         1233 ns            9
BasicFixture/PassThrough3_median       1224 ns         1224 ns            9
BasicFixture/PassThrough3_stddev       30.7 ns         30.7 ns            9
BasicFixture/PassThrough3_min          1209 ns         1209 ns            9
BasicFixture/PassThrough3_max          1308 ns         1308 ns            9
```

The performance as of this PR at r1:
```
BasicFixture/PassThrough3_mean          871 ns          871 ns            9
BasicFixture/PassThrough3_median        870 ns          870 ns            9
BasicFixture/PassThrough3_stddev       6.83 ns         6.83 ns            9
BasicFixture/PassThrough3_min           863 ns          863 ns            9
BasicFixture/PassThrough3_max           886 ns          886 ns            9
```

So chopping about 29% off the compute time, or about 41% greater throughput.

Towards #15421.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15431)
<!-- Reviewable:end -->
