### PR TITLE
[py trajectories] support passing matrix coefficients to ZeroOrderHold

### DIFF
--- a/bindings/pydrake/test/trajectories_test.py
+++ b/bindings/pydrake/test/trajectories_test.py
@@ -74,7 +74,7 @@ class TestTrajectories(unittest.TestCase):
         p2 = Polynomial(2)
         pp = PiecewisePolynomial([p1, p2], [0, 1, 2])
 
-    def test_zero_order_hold(self):
+    def test_zero_order_hold_vector(self):
         x = np.array([[1., 2.], [3., 4.], [5., 6.]]).transpose()
         pp = PiecewisePolynomial.ZeroOrderHold([0., 1., 2.], x)
         pp_d = pp.derivative(derivative_order=1)
@@ -88,12 +88,26 @@ class TestTrajectories(unittest.TestCase):
         self.assertEqual(pp.get_number_of_segments(), 2)
         self.assertEqual(pp.start_time(), 0.)
         self.assertEqual(pp.end_time(), 2.)
+        self.assertEqual(pp.rows(), 2)
+        self.assertEqual(pp.cols(), 1)
         self.assertEqual(pp.start_time(segment_index=0), 0.)
         self.assertEqual(pp.end_time(segment_index=0), 1.)
         self.assertEqual(pp.duration(segment_index=0), 1.)
         self.assertTrue(pp.is_time_in_range(t=1.5))
         self.assertEqual(pp.get_segment_index(t=1.5), 1)
         self.assertEqual(pp.get_segment_times(), [0., 1., 2.])
+
+    def test_zero_order_hold_matrix(self):
+        A0 = np.array([[1, 2, 3], [4, 5, 6]])
+        A1 = np.array([[7, 8, 9], [10, 11, 12]])
+        A2 = np.array([[13, 14, 15], [16, 17, 18]])
+        pp = PiecewisePolynomial.ZeroOrderHold([0., 1., 2.], [A0, A1, A2])
+        self.assertEqual(pp.get_number_of_segments(), 2)
+        self.assertEqual(pp.start_time(), 0.)
+        self.assertEqual(pp.end_time(), 2.)
+        self.assertEqual(pp.rows(), 2)
+        self.assertEqual(pp.cols(), 3)
+        np.testing.assert_equal(A0, pp.value(.5))
 
     def test_first_order_hold(self):
         x = np.array([[1., 2.], [3., 4.], [5., 6.]]).transpose()

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -15,6 +15,30 @@
 namespace drake {
 namespace pydrake {
 
+namespace {
+// For bindings that want a `const vector<VectorX<T>>&` but are bound
+// via a `const vector<vector<T>>&` for overloading priority,
+// this function converts the input.  A numpy matrix is row-major, so a 2x3
+// samples numpy array (unfortunately) turns into a std::vector with 2 elements,
+// each a vector of 3 elements; we'll transpose that.
+template <typename T>
+std::vector<MatrixX<T>> MakeEigenFromRowMajorVectors(
+    const std::vector<std::vector<T>>& in) {
+  if (in.size() == 0) {
+    return std::vector<MatrixX<T>>();
+  }
+  std::vector<MatrixX<T>> vec(in[0].size(), Eigen::VectorXd(in.size()));
+  for (int row = 0; row < static_cast<int>(in.size()); ++row) {
+    DRAKE_THROW_UNLESS(in[row].size() == in[0].size());
+    for (int col = 0; col < static_cast<int>(in[row].size()); ++col) {
+      vec[col](row, 0) = in[row][col];
+    }
+  }
+  return vec;
+}
+
+}  // namespace
+
 PYBIND11_MODULE(trajectories, m) {
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
   using namespace drake::trajectories;
@@ -105,11 +129,24 @@ PYBIND11_MODULE(trajectories, m) {
       .def(py::init<std::vector<Polynomial<T>> const&,
                std::vector<double> const&>(),
           doc.PiecewisePolynomial.ctor.doc_2args_polynomials_breaks)
+      .def_static(
+          "ZeroOrderHold",
+          // This serves the same purpose as the C++ ZeroOrderHold(VectorX<T>,
+          // MatrixX<T>) method.  For 2d numpy arrays, pybind apparently matches
+          // vector<vector<T>> then vector<MatrixX<T>> then MatrixX<T>.
+          [](const std::vector<T>& breaks,
+              const std::vector<std::vector<T>>& samples) {
+            return PiecewisePolynomial<T>::ZeroOrderHold(
+                breaks, MakeEigenFromRowMajorVectors(samples));
+          },
+          py::arg("breaks"), py::arg("samples"),
+          doc.PiecewisePolynomial.ZeroOrderHold.doc_vector)
       .def_static("ZeroOrderHold",
-          py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
-              const Eigen::Ref<const MatrixX<T>>&>(
+          py::overload_cast<const std::vector<T>&,
+              const std::vector<MatrixX<T>>&>(
               &PiecewisePolynomial<T>::ZeroOrderHold),
-          doc.PiecewisePolynomial.ZeroOrderHold.doc)
+          py::arg("breaks"), py::arg("samples"),
+          doc.PiecewisePolynomial.ZeroOrderHold.doc_matrix)
       .def_static("FirstOrderHold",
           py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
               const Eigen::Ref<const MatrixX<T>>&>(

--- a/common/trajectories/piecewise_polynomial.h
+++ b/common/trajectories/piecewise_polynomial.h
@@ -211,7 +211,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    *
    * @throws std::exception under the conditions specified under
    *         @ref coefficient_construction_methods.
-   * @exclude_from_pydrake_mkdoc{This overload is not bound in pydrake.}
+   * @pydrake_mkdoc_identifier{matrix}
    */
   static PiecewisePolynomial<T> ZeroOrderHold(
       const std::vector<T>& breaks,
@@ -225,6 +225,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * @pre `samples.cols() == breaks.size()`
    * @throws std::exception under the conditions specified under
    *         @ref coefficient_construction_methods.
+   * @pydrake_mkdoc_identifier{vector}
    */
   static PiecewisePolynomial<T> ZeroOrderHold(
       const Eigen::Ref<const VectorX<T>>& breaks,


### PR DESCRIPTION
Related to #15427

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15433)
<!-- Reviewable:end -->
