### PR TITLE
draft (do not merge) [multibody] Experiment with user-control parameter to select geometric queries for hydroelastics.

### DIFF
--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -93,6 +93,11 @@ enum class ContactModel {
   kHydroelasticWithFallback
 };
 
+enum class ContactSurfaceChoice {
+  kContinuous,
+  kDiscrete
+};
+
 /// @cond
 // Helper macro to throw an exception within methods that should not be called
 // post-finalize.
@@ -1594,6 +1599,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// The default contact model is ContactModel::kPointContactOnly.
   /// @throws std::exception iff called post-finalize.
   void set_contact_model(ContactModel model);
+
+  void set_contact_surface_choice(ContactSurfaceChoice choice);
 
 #ifndef DRAKE_DOXYGEN_CXX
   // TODO(xuchenhan-tri): Remove SetContactSolver() once
@@ -3917,6 +3924,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// Returns the model used for contact. See documentation for ContactModel.
   ContactModel get_contact_model() const;
 
+  ContactSurfaceChoice get_contact_surface_choice() const;
+
   /// Returns the number of geometries registered for visualization.
   /// This method can be called at any time during the lifetime of `this` plant,
   /// either pre- or post-finalize, see Finalize().
@@ -4749,6 +4758,9 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   // The model used by the plant to compute contact forces.
   ContactModel contact_model_{ContactModel::kPointContactOnly};
+
+  ContactSurfaceChoice contact_surface_choice_{
+      ContactSurfaceChoice::kContinuous};
 
   // Port handles for geometry:
   systems::InputPortIndex geometry_query_port_;

--- a/multibody/plant/test/multibody_plant_hydroelastic_contact_results_output_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_contact_results_output_test.cc
@@ -111,8 +111,12 @@ TEST_F(HydroelasticContactResultsOutputTester, ContactSurfaceEquivalent) {
           .template Eval<geometry::QueryObject<double>>(*plant_context_);
 
   // Compute the contact surface using the hydroelastic engine.
-  std::vector<geometry::ContactSurface<double>> contact_surfaces =
-      query_object.ComputeContactSurfaces();
+  std::vector<geometry::ContactSurface<double>> contact_surfaces;
+  if (plant_->is_discrete()) {
+    contact_surfaces = query_object.ComputePolygonalContactSurfaces();
+  } else {
+    contact_surfaces = query_object.ComputeContactSurfaces();
+  }
 
   // Check that the two contact surfaces are equivalent.
   ASSERT_EQ(contact_surfaces.size(), 1);


### PR DESCRIPTION
Final step in the [implementation plan for 14579](https://github.com/RobotLocomotion/drake/issues/14579#issuecomment-843618123) in CY21Q3. This draft PR #15436 is after #15210 (QueryObject).

This draft PR is replaced by #15487.  The main difference between the two PRs is that this PR experimented with allowing users to choose between the old and new geometric queries for each of the continuous and discrete systems, while the other PR uses the new query for the discrete system and uses the old query for the continuous system.

After r2, we merged the prequel PR #15210 (QueryObject) into master, so the file matrix now shows only `multibody/plant` files like this:
![image](https://user-images.githubusercontent.com/42557859/126735602-2b3846fc-ea57-4820-a624-ee6b01e98bfd.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15436)
<!-- Reviewable:end -->
