### PR TITLE
[systems/framework] FixInputPortsFrom does not support type-dependent abstract ports

### DIFF
--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -1143,7 +1143,10 @@ class System : public SystemBase {
   in @p other_context, as evaluated by @p other_system.
   @throws std::exception unless `other_context` and `target_context` both
   have the same shape as this System, and the `other_system`. Ignores
-  disconnected inputs. */
+  disconnected inputs.
+  @throws std::exception if `this` system's scalar type T != double and
+  `other_system` has any abstract input ports whose contained type depends on
+  scalar type. */
   void FixInputPortsFrom(const System<double>& other_system,
                          const Context<double>& other_context,
                          Context<T>* target_context) const;


### PR DESCRIPTION
This PR adds a docstring and some tests confirming the behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15437)
<!-- Reviewable:end -->
