### PR TITLE
[fem] Improve IsoparametricElement

### DIFF
--- a/multibody/fixed_fem/dev/BUILD.bazel
+++ b/multibody/fixed_fem/dev/BUILD.bazel
@@ -398,6 +398,9 @@ drake_cc_library(
 
 drake_cc_library(
     name = "isoparametric_element",
+    srcs = [
+        "isoparametric_element.cc",
+    ],
     hdrs = [
         "isoparametric_element.h",
     ],
@@ -434,11 +437,15 @@ drake_cc_library(
 
 drake_cc_library(
     name = "linear_simplex_element",
+    srcs = [
+        "linear_simplex_element.cc",
+    ],
     hdrs = [
         "linear_simplex_element.h",
     ],
     deps = [
         ":isoparametric_element",
+        "//common:default_scalars",
     ],
 )
 
@@ -776,6 +783,7 @@ drake_cc_googletest(
     name = "linear_simplex_element_test",
     deps = [
         ":linear_simplex_element",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/multibody/fixed_fem/dev/deformable_model.cc
+++ b/multibody/fixed_fem/dev/deformable_model.cc
@@ -86,7 +86,8 @@ void DeformableModel<T>::RegisterDeformableBodyHelper(
       internal::SimplexGaussianQuadrature<kNaturalDimension, kQuadratureOrder>;
   constexpr int kNumQuads = QuadratureType::num_quadrature_points;
   using IsoparametricElementType =
-      LinearSimplexElement<T, kNaturalDimension, kSpatialDimension, kNumQuads>;
+      internal::LinearSimplexElement<T, kNaturalDimension, kSpatialDimension,
+                                     kNumQuads>;
   using ConstitutiveModelType = Model<T, kNumQuads>;
   static_assert(std::is_base_of_v<
                     ConstitutiveModel<ConstitutiveModelType,

--- a/multibody/fixed_fem/dev/isoparametric_element.cc
+++ b/multibody/fixed_fem/dev/isoparametric_element.cc
@@ -1,0 +1,1 @@
+#include "drake/multibody/fixed_fem/dev/isoparametric_element.h"

--- a/multibody/fixed_fem/dev/isoparametric_element.h
+++ b/multibody/fixed_fem/dev/isoparametric_element.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include <array>
 #include <utility>
 
@@ -7,28 +8,28 @@
 namespace drake {
 namespace multibody {
 namespace fem {
-/** IsoparametricElement is a class that evaluates shape functions
+namespace internal {
+
+/* IsoparametricElement is a class that evaluates shape functions
  and their derivatives at prescribed locations. The shape function
  `S` located at a vertex `a` maps the parent domain to a scalar. The reference
  position `X` as well as `u(X)`, an arbitrary function on the reference domain,
  can be interpolated from nodal values `Xₐ` and `uₐ` to any location in the
  parent domain using the shape function, i.e.:
 
- <pre>
      X(ξ) = Sₐ(ξ)Xₐ, and
      u(X(ξ)) = Sₐ(ξ)uₐ,
- </pre>
 
- where ξ ∈ ℝᵈ is in the parent domain and d is its dimension (and we call it the
- natural dimension), which may be different from the dimension of X, which we
- call the spatial dimension (e.g. 2D membrane or shell element in 3D dynamics
- simulation has natural dimension 2 and spatial dimension 3). The constructor
- for this class takes in an array of locations at which we may evaluate and/or
+ where ξ ∈ ℝᵈ is in the parent domain and d is its dimension (the natural
+ dimension), which may be different from the dimension of X (the spatial
+ dimension). For example 2D membrane or shell element in 3D dynamics simulation
+ has natural dimension 2 and spatial dimension 3. The constructor for this
+ class takes in an std::array of locations at which we may evaluate and/or
  interpolate various quantities. If you need to evaluate and/or interpolate at
- other locations, construct another instance of %IsoparametricElement and pass
+ other locations, construct another instance of IsoparametricElement and pass
  the new locations into the constructor.
 
- %IsoparametricElement serves as the interface base class. Since shape
+ IsoparametricElement serves as the interface base class. Since shape
  functions are usually evaluated in computationally intensive inner loops of the
  simulation, the overhead caused by virtual methods may be significant.
  Therefore, this class uses CRTP to achieve compile-time polymorphism
@@ -39,175 +40,142 @@ namespace fem {
  quantities and type declarations that this base class requires. One cannot
  combine the derived class and the traits class because the derived class is
  incomplete at the time when the traits is needed.
- @tparam DerivedElement The concrete isoparametric element that inherits
- from %IsoparametricElement through CRTP.
- @tparam DerivedTraits The traits class associated with the DerivedElement. */
+ @tparam DerivedElement  The concrete isoparametric element that inherits
+                         from IsoparametricElement through CRTP.
+ @tparam DerivedTraits   The traits class associated with the DerivedElement.
+                         See LinearSimplexElementTraits for an example. */
 template <class DerivedElement, class DerivedTraits>
 class IsoparametricElement {
  public:
-  /** The number of locations to evaluate various quantities in the
+  /* The number of locations to evaluate various quantities in the
    element. */
-  static constexpr int num_sample_locations() {
-    return DerivedTraits::kNumSampleLocations;
-  }
+  static constexpr int num_sample_locations =
+      DerivedTraits::num_sample_locations;
 
-  /** The dimension of the parent domain. */
-  static constexpr int natural_dimension() {
-    return DerivedTraits::kNaturalDimension;
-  }
+  /* The dimension of the parent domain. */
+  static constexpr int natural_dimension = DerivedTraits::natural_dimension;
 
-  /** The dimension of the spatial domain. */
-  static constexpr int spatial_dimension() {
-    return DerivedTraits::kSpatialDimension;
-  }
+  /* The dimension of the spatial domain. */
+  static constexpr int spatial_dimension = DerivedTraits::spatial_dimension;
 
-  /** The number of nodes in the element. E.g. 3 for linear triangles, 9 for
+  /* The number of nodes in the element. E.g. 3 for linear triangles, 9 for
    quadratic quadrilaterals and 4 for linear tetrahedrons. */
-  static constexpr int num_nodes() { return DerivedTraits::kNumNodes; }
+  static constexpr int num_nodes = DerivedTraits::num_nodes;
 
-  /** std::array of size `num_sample_locations()`. */
   template <typename U>
-  using ArrayType = std::array<U, num_sample_locations()>;
+  using ArrayNumSamples = std::array<U, num_sample_locations>;
 
   using T = typename DerivedTraits::Scalar;
 
-  /** Type of locations at which to evaluate and/or interpolate numerical
-   quantities from nodes. */
-  using LocationsType = ArrayType<Vector<double, natural_dimension()>>;
+  /* Fixed size vector type to store shape functions evaluated at a sample
+   location. */
+  using VectorNumNodes = Vector<T, num_nodes>;
 
-  /** Fixed size matrix type to store the Jacobian matrix. */
-  using JacobianMatrix =
-      Eigen::Matrix<T, spatial_dimension(), natural_dimension()>;
+  /* Fixed size matrix type to store gradient in parent coordinates at a sample
+   locations. */
+  using GradientInParentCoordinates =
+      Eigen::Matrix<T, num_nodes, natural_dimension>;
 
-  /** Fixed size matrix type to store the pseudoinverse Jacobian matrix. */
+  /* Fixed size matrix type to store gradient in spatial coordinates at a sample
+   location. */
+  using GradientInSpatialCoordinates =
+      Eigen::Matrix<T, num_nodes, spatial_dimension>;
+
+  /* Fixed size matrix type to store the Jacobian matrix at a sample location.
+   */
+  using JacobianMatrix = Eigen::Matrix<T, spatial_dimension, natural_dimension>;
+
+  /* Fixed size matrix type to store the pseudoinverse Jacobian matrix at a
+   sample location. */
   using PseudoinverseJacobianMatrix =
-      Eigen::Matrix<T, natural_dimension(), spatial_dimension()>;
+      Eigen::Matrix<T, natural_dimension, spatial_dimension>;
 
-  /** Returns the array of sample locations in the parent domain at which the
-   isoparametric element evaluates elemental quantities, as provided at
+  /* Returns the std::array of sample locations in the parent domain at which
+   the isoparametric element evaluates elemental quantities, as provided at
    construction. */
-  const LocationsType& locations() const { return locations_; }
-
-  /** Obtains the shape function array
-     <pre>
-          S(ξ) = [S₀(ξ); S₁(ξ); ... Sₐ(ξ); ...; Sₙ₋₁(ξ)]
-     </pre>
-   at each location in the parent domain provided at construction.
-   @returns an array of size equal to `num_sample_locations()`. The q-th entry
-   contains the vector S(ξ), of size num_nodes(), evaluated at the
-   q-th sample location in the parent domain provided at construction.
-   The a-th component of S(ξ) corresponds to the shape function Sₐ(ξ) for node
-   a. */
-  const ArrayType<Vector<T, num_nodes()>>& GetShapeFunctions() const {
-    const DerivedElement& derived = static_cast<const DerivedElement&>(*this);
-    return derived.GetShapeFunctions();
+  const ArrayNumSamples<Vector<double, natural_dimension>>& locations() const {
+    return locations_;
   }
 
-  /** Obtains the gradient of the shape functions in parent coordinates, dS/dξ,
-   evaluated at each location in the parent domain provided at construction.
-   @returns an array of size `num_sample_locations()`. The q-th entry contains
-   the matrix dS/dξ, of size `num_nodes()`-by-`natural_dimension()`, evaluated
-   at the q-th sample location in the parent domain provided at construction.
-   The a-th row of the matrix gives the derivatives dSₐ/dξ for node a. */
-  const ArrayType<Eigen::Matrix<T, num_nodes(), natural_dimension()>>&
+  /* Obtains the shape function array
+       S(ξ) = [S₀(ξ); S₁(ξ); ... Sₐ(ξ); ...; Sₙ₋₁(ξ)]
+   at each sample location in the parent domain provided at construction.
+   @returns an std::array of size equal to `num_sample_locations`. The q-th
+   entry contains the vector S(ξ), of size `num_nodes`, evaluated at the q-th
+   sample location in the parent domain provided at construction. The a-th
+   component of S(ξ) corresponds to the shape function Sₐ(ξ) for node `a`. */
+  const ArrayNumSamples<VectorNumNodes>& GetShapeFunctions() const {
+    return S_;
+  }
+
+  /* Obtains the gradient of the shape functions in parent coordinates, dS/dξ,
+   evaluated at each sample location in the parent domain provided at
+   construction.
+   @returns an std::array of size `num_sample_locations`. The q-th entry
+   contains the matrix dS/dξ, of size `num_nodes`-by-`natural_dimension`,
+   evaluated at the q-th sample location in the parent domain provided at
+   construction. The a-th row of the matrix gives the derivatives dSₐ/dξ for
+   node `a`. */
+  const ArrayNumSamples<GradientInParentCoordinates>&
   GetGradientInParentCoordinates() const {
-    const DerivedElement& derived = static_cast<const DerivedElement&>(*this);
-    return derived.GetGradientInParentCoordinates();
+    return dSdxi_;
   }
 
-  // TODO(xuchenhan-tri): Implement CalcGradientInSpatialCoordinates().
-
-  /** Computes the Jacobian matrix, dx/dξ, at each location in the parent domain
-   provided at construction.
-   @param xa Spatial coordinates for each element node stored column-wise.
-   @returns an array of size 'num_sample_locations()`. The q-th entry contains
-   the Jacobian matrix dx/dξ, of size
-   `spatial_dimension()`-by-`natural_dimension()`, evaluated at the q-th sample
-   location in the parent domain provided at construction. */
-  ArrayType<JacobianMatrix> CalcJacobian(
-      const Eigen::Ref<
-          const Eigen::Matrix<T, spatial_dimension(), num_nodes()>>& xa) const {
-    ArrayType<JacobianMatrix> dxdxi;
-    const ArrayType<Eigen::Matrix<T, num_nodes(), natural_dimension()>>& dSdxi =
-        GetGradientInParentCoordinates();
-    for (int q = 0; q < num_sample_locations(); ++q) {
-      dxdxi[q] = xa * dSdxi[q];
-    }
-    return dxdxi;
+  /* Calculates the gradient of the shape functions in spatial coordinates,
+   dS/dX, evaluated at each sample location in the parent domain provided at
+   construction.
+   @param xa  Spatial coordinates for each element node stored column-wise.
+   @returns an std::array of size `num_sample_locations`. The q-th entry
+   contains the matrix dS/dX, of size `num_nodes`-by-`spatial_dimension`,
+   evaluated at the q-th sample location in the parent domain provided at
+   construction. The a-th row of the matrix gives the derivatives dSₐ/dX for
+   node `a`.
+   @pre the element with node positions `xa` is not degenerate. */
+  ArrayNumSamples<GradientInSpatialCoordinates>
+  CalcGradientInSpatialCoordinates(
+      const Eigen::Ref<const Eigen::Matrix<T, spatial_dimension, num_nodes>>&
+          xa) const {
+    return derived().CalcGradientInSpatialCoordinates(xa);
   }
 
-  /** Computes dξ/dx, the pseudoinverse Jacobian matrix, at each sample location
-   in the parent domain provided at construction.
-   @param xa Spatial coordinates for each element node stored column-wise.
-   @returns an array of size `num_sample_locations()`. The q-th entry contains
-   the pseudoinverse Jacobian dξ/dx, of size
-   `natural_dimension()`-by-`spatial_dimension()`, evaluated at the q-th sample
-   location in the parent domain provided at construction.
-   @pre the element with node positions `xa` must not be degenerate.
-   @see CalcJacobian().  */
-  ArrayType<PseudoinverseJacobianMatrix> CalcJacobianPseudoinverse(
-      const Eigen::Ref<
-          const Eigen::Matrix<T, spatial_dimension(), num_nodes()>>& xa) const {
-    ArrayType<JacobianMatrix> dxdxi = CalcJacobian(xa);
-    return CalcJacobianPseudoinverse(dxdxi);
-  }
-
-  /** Preferred signature for computing dξ/dx when the Jacobian matrices are
-   available so as to avoid recomputing the Jacobian matrices.
-   @param jacobian An array of size `num_sample_locations()`. The q-th entry
+  /* Computes the Jacobian matrix, dx/dξ, at each sample location in the parent
+   domain provided at construction.
+   @param xa  Spatial coordinates for each element node stored column-wise.
+   @returns an std::array of size 'num_sample_locations`. The q-th entry
    contains the Jacobian matrix dx/dξ, of size
-   `spatial_dimension()`-by-`natural_dimension()`, evaluated at the q-th sample
-   location in the parent domain provided at construction.
-   @pre Each entry in `jacobian` must be full rank.
-   @see CalcJacobian(). */
-  /* Suppose the Jacobian matrix J = dx/dξ is m×n where m >= n. We are looking
-   for a n×m matrix A = dξ/dx. By the chain rule, AJ = I. In fact A is the
-   pseudoinverse of J. To see that, observe that AJA = A, JAJ = J, (AJ)ᵀ = AJ.
-   The only nontrivial fact is that (JA)ᵀ = JA. To see that, QR decompose J so
-   that J = QR where Q is orthogonal and R is upper triangular, and define B =
-   AQ. Here R and B are the dx/dξ and dξ/dx in the Q bases, and thus the m-n
-   right-most columns of B are zero. Restricting B and R to their top-left n×n
-   corners (call them B̂ and R̂̂), we get R̂B̂ = B̂ᵀR̂̂ᵀ = Iₙₓₙ. Padding zeros in the
-   correct places, we see that BᵀRᵀ = RB. Therefore, QBᵀRᵀQᵀ = QRBQᵀ which
-   implies AᵀJᵀ = JA. */
-  // TODO(xuchenhan-tri): The rank revealing Eigen::JacobiSVD is used instead of
-  //  Eigen::HouseholderQR to guard against rank-deficiency. This is fine for
-  //  now as this function is only invoked in precomputes at the moment.
-  //  Consider the more performant alternative when we need this in an inner
-  //  loop.
-  ArrayType<PseudoinverseJacobianMatrix> CalcJacobianPseudoinverse(
-      const ArrayType<JacobianMatrix>& jacobian) const {
-    ArrayType<PseudoinverseJacobianMatrix> dxidx;
-    for (int q = 0; q < num_sample_locations(); ++q) {
-      /* Thin unitaries are enough but Eigen does not allow them for fixed size
-       matrix. */
-      Eigen::JacobiSVD<JacobianMatrix> svd(
-          jacobian[q], Eigen::ComputeFullU | Eigen::ComputeFullV);
-      if (svd.rank() != natural_dimension()) {
-        throw std::runtime_error(
-            "The element is degenerate and does not have a valid Jacobian "
-            "pseudoinverse (the pseudoinverse is not the left inverse).");
-      }
-      /* Use SVD to solve for the least square system which gives the
-       pseudoinverse. */
-      dxidx[q] = svd.solve(Eigen::Matrix<T, spatial_dimension(),
-                                         spatial_dimension()>::Identity());
-    }
-    return dxidx;
+   `spatial_dimension`-by-`natural_dimension`, evaluated at the q-th sample
+   location in the parent domain provided at construction. */
+  ArrayNumSamples<JacobianMatrix> CalcJacobian(
+      const Eigen::Ref<const Eigen::Matrix<T, spatial_dimension, num_nodes>>&
+          xa) const {
+    return derived().CalcJacobian(xa);
   }
 
-  /** Interpolates nodal values `ua` into u(ξ) at each sample location
+  /* Computes dξ/dx, the pseudoinverse Jacobian matrix, at each sample location
+   in the parent domain provided at construction.
+   @param jacobian An array of size `num_sample_locations`. The q-th entry
+   contains the Jacobian matrix dx/dξ, of size
+   `spatial_dimension`-by-`natural_dimension`, evaluated at the q-th sample
+   location in the parent domain provided at construction.
+   @pre Each entry in `jacobian` is full rank.
+   @see CalcJacobian(). */
+  ArrayNumSamples<PseudoinverseJacobianMatrix> CalcJacobianPseudoinverse(
+      const ArrayNumSamples<JacobianMatrix>& jacobian) const {
+    return derived().CalcJacobianPseudoinverse(jacobian);
+  }
+
+  /* Interpolates nodal values `ua` into u(ξ) at each sample location
    in the parent domain provided at construction.
    @param ua The value of function u at each element node stored column-wise.
-   @returns an array of size `num_sample_locations()` of the interpolated
+   @returns an std::array of size `num_sample_locations` of the interpolated
    values of u.
    @tparam dim The dimension of the value of u. */
   template <int dim>
-  ArrayType<Vector<T, dim>> InterpolateNodalValues(
-      const Eigen::Ref<const Eigen::Matrix<T, dim, num_nodes()>>& ua) const {
-    const ArrayType<Vector<T, num_nodes()>>& S = GetShapeFunctions();
-    ArrayType<Vector<T, dim>> interpolated_value;
-    for (int q = 0; q < num_sample_locations(); ++q) {
+  ArrayNumSamples<Vector<T, dim>> InterpolateNodalValues(
+      const Eigen::Ref<const Eigen::Matrix<T, dim, num_nodes>>& ua) const {
+    const ArrayNumSamples<Vector<T, num_nodes>>& S = GetShapeFunctions();
+    ArrayNumSamples<Vector<T, dim>> interpolated_value;
+    for (int q = 0; q < num_sample_locations; ++q) {
       interpolated_value[q] = ua * S[q];
     }
     return interpolated_value;
@@ -216,14 +184,93 @@ class IsoparametricElement {
  protected:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(IsoparametricElement);
 
-  /** Constructs an isoparametric element that performs calculations at the
-   locations specified by the input `locations`. */
-  explicit IsoparametricElement(LocationsType locations)
-      : locations_(std::move(locations)) {}
+  /* Constructs an isoparametric element that performs calculations at the
+   prescribed input `locations`. */
+  IsoparametricElement(
+      ArrayNumSamples<Vector<double, natural_dimension>> locations,
+      ArrayNumSamples<Vector<T, num_nodes>> S,
+      ArrayNumSamples<GradientInParentCoordinates> dSdxi)
+      : locations_(std::move(locations)),
+        S_(std::move(S)),
+        dSdxi_(std::move(dSdxi)) {}
+
+  /* Default implementations of "Calc" methods. Derived concrete elements should
+   call these "DefaultCalc" methods unless they can provide an optimization.
+   @{ */
+  ArrayNumSamples<GradientInSpatialCoordinates>
+  DefaultCalcGradientInSpatialCoordinates(
+      const Eigen::Ref<const Eigen::Matrix<T, spatial_dimension, num_nodes>>&
+          xa) const {
+    ArrayNumSamples<GradientInSpatialCoordinates> dSdX;
+    const auto& dSdxi = GetGradientInParentCoordinates();
+    const auto dxidX = CalcJacobianPseudoinverse(CalcJacobian(xa));
+    for (int q = 0; q < num_sample_locations; ++q) {
+      dSdX[q] = dSdxi[q] * dxidX[q];
+    }
+    return dSdX;
+  }
+
+  ArrayNumSamples<JacobianMatrix> DefaultCalcJacobian(
+      const Eigen::Ref<const Eigen::Matrix<T, spatial_dimension, num_nodes>>&
+          xa) const {
+    ArrayNumSamples<JacobianMatrix> dxdxi;
+    const ArrayNumSamples<Eigen::Matrix<T, num_nodes, natural_dimension>>&
+        dSdxi = GetGradientInParentCoordinates();
+    for (int q = 0; q < num_sample_locations; ++q) {
+      dxdxi[q] = xa * dSdxi[q];
+    }
+    return dxdxi;
+  }
+
+  ArrayNumSamples<PseudoinverseJacobianMatrix> DefaultCalcJacobianPseudoinverse(
+      const ArrayNumSamples<JacobianMatrix>& jacobian) const {
+    /* Suppose the Jacobian matrix J = dx/dξ is m×n where m >= n. We are looking
+     for a n×m matrix A = dξ/dx. By the chain rule, AJ = I. In fact A is the
+     pseudoinverse of J. To see that, observe that AJA = A, JAJ = J, (AJ)ᵀ = AJ.
+     The only nontrivial fact is that (JA)ᵀ = JA. To see that, QR decompose J so
+     that J = QR where Q is orthogonal and R is upper triangular, and define B =
+     AQ. Here R and B are the dx/dξ and dξ/dx in the Q bases, and thus the m-n
+     right-most columns of B are zero. Restricting B and R to their top-left n×n
+     corners (call them B̂ and R̂̂), we get R̂B̂ = B̂ᵀR̂̂ᵀ = Iₙₓₙ. Padding zeros in the
+     correct places, we see that BᵀRᵀ = RB. Therefore, QBᵀRᵀQᵀ = QRBQᵀ which
+     implies AᵀJᵀ = JA. */
+    ArrayNumSamples<PseudoinverseJacobianMatrix> dxidx;
+    for (int q = 0; q < num_sample_locations; ++q) {
+      // TODO(xuchenhan-tri): The rank revealing Eigen::JacobiSVD is used
+      //  instead of Eigen::HouseholderQR to guard against rank-deficiency. This
+      //  is fine for now as this function is only invoked in precomputes at the
+      //  moment. Consider the more performant alternative when we need this in
+      //  an inner loop.
+      /* Thin unitaries are enough but Eigen does not allow them for fixed size
+       matrix. */
+      Eigen::JacobiSVD<JacobianMatrix> svd(
+          jacobian[q], Eigen::ComputeFullU | Eigen::ComputeFullV);
+      if (svd.rank() != natural_dimension) {
+        throw std::runtime_error(
+            "The element is degenerate and does not have a valid Jacobian "
+            "pseudoinverse (the pseudoinverse is not the left inverse).");
+      }
+      /* Use SVD to solve for the least square system which gives the
+       pseudoinverse. */
+      dxidx[q] = svd.solve(
+          Eigen::Matrix<T, spatial_dimension, spatial_dimension>::Identity());
+    }
+    return dxidx;
+  }
+  /* @} */
 
  private:
+  const DerivedElement& derived() const {
+    return static_cast<const DerivedElement&>(*this);
+  }
+
   /* The locations at which to evaluate various quantities of this element. */
-  LocationsType locations_;
+  ArrayNumSamples<Vector<double, natural_dimension>> locations_;
+  /* Shape functions evaluated at points specified at construction. */
+  ArrayNumSamples<Vector<T, num_nodes>> S_;
+  /* Shape function derivatives evaluated at points specified at construction.
+   */
+  ArrayNumSamples<GradientInParentCoordinates> dSdxi_;
 };
 
 template <class Element>
@@ -232,6 +279,7 @@ struct is_isoparametric_element {
       std::is_base_of_v<IsoparametricElement<Element, typename Element::Traits>,
                         Element>;
 };
+}  // namespace internal
 }  // namespace fem
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/fixed_fem/dev/linear_simplex_element.cc
+++ b/multibody/fixed_fem/dev/linear_simplex_element.cc
@@ -1,0 +1,146 @@
+#include "drake/multibody/fixed_fem/dev/linear_simplex_element.h"
+
+#include "drake/common/default_scalars.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+namespace internal {
+
+template <typename T, int natural_dimension_at_compile_time,
+          int spatial_dimension_at_compile_time,
+          int num_sample_locations_at_compile_time>
+typename LinearSimplexElement<T, natural_dimension_at_compile_time,
+                              spatial_dimension_at_compile_time,
+                              num_sample_locations_at_compile_time>::
+    template ArrayNumSamples<typename IsoparametricElement<
+        LinearSimplexElement<T, natural_dimension_at_compile_time,
+                             spatial_dimension_at_compile_time,
+                             num_sample_locations_at_compile_time>,
+        LinearSimplexElementTraits<T, natural_dimension_at_compile_time,
+                                   spatial_dimension_at_compile_time,
+                                   num_sample_locations_at_compile_time>>::
+                                 GradientInSpatialCoordinates>
+    LinearSimplexElement<T, natural_dimension_at_compile_time,
+                         spatial_dimension_at_compile_time,
+                         num_sample_locations_at_compile_time>::
+        CalcGradientInSpatialCoordinates(
+            const Eigen::Ref<const Eigen::Matrix<T, spatial_dimension,
+                                                 num_nodes>>& xa) const {
+  return this->DefaultCalcGradientInSpatialCoordinates(xa);
+}
+
+template <typename T, int natural_dimension_at_compile_time,
+          int spatial_dimension_at_compile_time,
+          int num_sample_locations_at_compile_time>
+typename LinearSimplexElement<T, natural_dimension_at_compile_time,
+                              spatial_dimension_at_compile_time,
+                              num_sample_locations_at_compile_time>::
+    template ArrayNumSamples<typename IsoparametricElement<
+        LinearSimplexElement<T, natural_dimension_at_compile_time,
+                             spatial_dimension_at_compile_time,
+                             num_sample_locations_at_compile_time>,
+        LinearSimplexElementTraits<T, natural_dimension_at_compile_time,
+                                   spatial_dimension_at_compile_time,
+                                   num_sample_locations_at_compile_time>>::
+                                 JacobianMatrix>
+    LinearSimplexElement<T, natural_dimension_at_compile_time,
+                         spatial_dimension_at_compile_time,
+                         num_sample_locations_at_compile_time>::
+        CalcJacobian(const Eigen::Ref<
+                     const Eigen::Matrix<T, spatial_dimension, num_nodes>>& xa)
+            const {
+  return this->DefaultCalcJacobian(xa);
+}
+
+template <typename T, int natural_dimension_at_compile_time,
+          int spatial_dimension_at_compile_time,
+          int num_sample_locations_at_compile_time>
+typename LinearSimplexElement<T, natural_dimension_at_compile_time,
+                              spatial_dimension_at_compile_time,
+                              num_sample_locations_at_compile_time>::
+    template ArrayNumSamples<typename IsoparametricElement<
+        LinearSimplexElement<T, natural_dimension_at_compile_time,
+                             spatial_dimension_at_compile_time,
+                             num_sample_locations_at_compile_time>,
+        LinearSimplexElementTraits<T, natural_dimension_at_compile_time,
+                                   spatial_dimension_at_compile_time,
+                                   num_sample_locations_at_compile_time>>::
+                                 PseudoinverseJacobianMatrix>
+    LinearSimplexElement<T, natural_dimension_at_compile_time,
+                         spatial_dimension_at_compile_time,
+                         num_sample_locations_at_compile_time>::
+        CalcJacobianPseudoinverse(
+            const ArrayNumSamples<JacobianMatrix>& jacobian) const {
+  return this->DefaultCalcJacobianPseudoinverse(jacobian);
+}
+
+template <typename T, int natural_dimension_at_compile_time,
+          int spatial_dimension_at_compile_time,
+          int num_sample_locations_at_compile_time>
+typename LinearSimplexElement<T, natural_dimension_at_compile_time,
+                              spatial_dimension_at_compile_time,
+                              num_sample_locations_at_compile_time>::
+    template ArrayNumSamples<typename LinearSimplexElement<
+        T, natural_dimension_at_compile_time, spatial_dimension_at_compile_time,
+        num_sample_locations_at_compile_time>::VectorNumNodes>
+    LinearSimplexElement<T, natural_dimension_at_compile_time,
+                         spatial_dimension_at_compile_time,
+                         num_sample_locations_at_compile_time>::
+        CalcShapeFunctions(
+            const ArrayNumSamples<Vector<double, natural_dimension>>& locations)
+            const {
+  ArrayNumSamples<VectorNumNodes> S;
+  for (int q = 0; q < num_sample_locations; ++q) {
+    VectorNumNodes Sq;
+    /* Sₐ = ξₐ₋₁ for a = 1, ..., num_nodes - 1. */
+    for (int a = 1; a < num_nodes; ++a) {
+      Sq(a) = locations[q](a - 1);
+    }
+    /* S₀ = 1−ξ₀ − ... − ξₙ₋₂. */
+    Sq(0) = 0;
+    Sq(0) = 1 - Sq.sum();
+    S[q] = std::move(Sq);
+  }
+  return S;
+}
+
+template <typename T, int natural_dimension_at_compile_time,
+          int spatial_dimension_at_compile_time,
+          int num_sample_locations_at_compile_time>
+const typename LinearSimplexElement<T, natural_dimension_at_compile_time,
+                                    spatial_dimension_at_compile_time,
+                                    num_sample_locations_at_compile_time>::
+    template ArrayNumSamples<typename LinearSimplexElement<
+        T, natural_dimension_at_compile_time, spatial_dimension_at_compile_time,
+        num_sample_locations_at_compile_time>::GradientInParentCoordinates>
+    LinearSimplexElement<T, natural_dimension_at_compile_time,
+                         spatial_dimension_at_compile_time,
+                         num_sample_locations_at_compile_time>::
+        CalcGradientInParentCoordinates() {
+  GradientInParentCoordinates dSdxi_q;
+  dSdxi_q.template topRows<1>() = -1.0 * Vector<T, natural_dimension>::Ones();
+  dSdxi_q.template bottomRows<natural_dimension>() =
+      Eigen::Matrix<T, natural_dimension, natural_dimension>::Identity();
+  ArrayNumSamples<GradientInParentCoordinates> dSdxi;
+  dSdxi.fill(dSdxi_q);
+  return dSdxi;
+}
+
+template class LinearSimplexElement<double, 2, 2, 2>;
+template class LinearSimplexElement<double, 2, 2, 4>;
+template class LinearSimplexElement<double, 2, 3, 4>;
+template class LinearSimplexElement<double, 3, 3, 1>;
+template class LinearSimplexElement<double, 3, 3, 2>;
+template class LinearSimplexElement<double, 3, 3, 5>;
+template class LinearSimplexElement<AutoDiffXd, 2, 2, 2>;
+template class LinearSimplexElement<AutoDiffXd, 2, 2, 4>;
+template class LinearSimplexElement<AutoDiffXd, 2, 3, 4>;
+template class LinearSimplexElement<AutoDiffXd, 3, 3, 1>;
+template class LinearSimplexElement<AutoDiffXd, 3, 3, 2>;
+template class LinearSimplexElement<AutoDiffXd, 3, 3, 5>;
+
+}  // namespace internal
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/fixed_fem/dev/test/dynamic_elasticity_element_test.cc
+++ b/multibody/fixed_fem/dev/test/dynamic_elasticity_element_test.cc
@@ -24,7 +24,8 @@ class DynamicElasticityElementTest : public ::testing::Test {
       internal::SimplexGaussianQuadrature<kNaturalDimension, kQuadratureOrder>;
   static constexpr int kNumQuads = QuadratureType::num_quadrature_points;
   using IsoparametricElementType =
-      LinearSimplexElement<T, kNaturalDimension, kSpatialDimension, kNumQuads>;
+      internal::LinearSimplexElement<T, kNaturalDimension, kSpatialDimension,
+                                     kNumQuads>;
   using ConstitutiveModelType = LinearConstitutiveModel<T, kNumQuads>;
   using ElementType =
       DynamicElasticityElement<IsoparametricElementType, QuadratureType,

--- a/multibody/fixed_fem/dev/test/dynamic_elasticity_model_test.cc
+++ b/multibody/fixed_fem/dev/test/dynamic_elasticity_model_test.cc
@@ -24,7 +24,8 @@ using QuadratureType =
     internal::SimplexGaussianQuadrature<kNaturalDimension, kQuadratureOrder>;
 constexpr int kNumQuads = QuadratureType::num_quadrature_points;
 using IsoparametricElementType =
-    LinearSimplexElement<T, kNaturalDimension, kSpatialDimension, kNumQuads>;
+    internal::LinearSimplexElement<T, kNaturalDimension, kSpatialDimension,
+                                   kNumQuads>;
 using ConstitutiveModelType = LinearConstitutiveModel<T, kNumQuads>;
 using ElementType =
     DynamicElasticityElement<IsoparametricElementType, QuadratureType,

--- a/multibody/fixed_fem/dev/test/elasticity_element_test.cc
+++ b/multibody/fixed_fem/dev/test/elasticity_element_test.cc
@@ -21,8 +21,8 @@ using QuadratureType =
     internal::SimplexGaussianQuadrature<kNaturalDimension, kQuadratureOrder>;
 static constexpr int kNumQuads = QuadratureType::num_quadrature_points;
 using IsoparametricElementType =
-    LinearSimplexElement<AutoDiffXd, kNaturalDimension, kSpatialDimension,
-                         kNumQuads>;
+    internal::LinearSimplexElement<AutoDiffXd, kNaturalDimension,
+                                   kSpatialDimension, kNumQuads>;
 using ConstitutiveModelType = LinearConstitutiveModel<AutoDiffXd, kNumQuads>;
 
 /* The traits for the DummyElasticityElement. `kOdeOrder` is set to zero to

--- a/multibody/fixed_fem/dev/test/fem_solver_test.cc
+++ b/multibody/fixed_fem/dev/test/fem_solver_test.cc
@@ -32,7 +32,8 @@ using QuadratureType =
     internal::SimplexGaussianQuadrature<kNaturalDimension, kQuadratureOrder>;
 constexpr int kNumQuads = QuadratureType::num_quadrature_points;
 using IsoparametricElementType =
-    LinearSimplexElement<T, kNaturalDimension, kSpatialDimension, kNumQuads>;
+    internal::LinearSimplexElement<T, kNaturalDimension, kSpatialDimension,
+                                   kNumQuads>;
 using ConstitutiveModelType = LinearConstitutiveModel<T, kNumQuads>;
 using ElementType =
     StaticElasticityElement<IsoparametricElementType, QuadratureType,

--- a/multibody/fixed_fem/dev/test/linear_simplex_element_test.cc
+++ b/multibody/fixed_fem/dev/test/linear_simplex_element_test.cc
@@ -4,9 +4,12 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+
 namespace drake {
 namespace multibody {
 namespace fem {
+namespace internal {
 namespace {
 
 constexpr int kNumQuads = 2;
@@ -76,6 +79,19 @@ TEST_F(LinearSimplexElementTest, ShapeFunctionDerivative2D) {
     EXPECT_EQ(dSdxi[q].col(0), x_deriv);
     EXPECT_EQ(dSdxi[q].col(1), y_deriv);
   }
+  // Verify that when the mapping from the parent domain to the spatial domain
+  // is the identity, the gradient in spatial coordinates is the same as the
+  // gradient in parent coordinates.
+  Eigen::Matrix<double, 2, 3> xa;
+  // clang-format off
+  xa << 0, 1, 0,
+        0, 0, 1;
+  // clang-format on
+  const auto dSdX = tri_.CalcGradientInSpatialCoordinates(xa);
+  for (int q = 0; q < kNumQuads; ++q) {
+    EXPECT_TRUE(CompareMatrices(dSdX[q], dSdxi[q],
+                                std::numeric_limits<double>::epsilon()));
+  }
 }
 
 TEST_F(LinearSimplexElementTest, ShapeFunctionDerivative3D) {
@@ -97,9 +113,24 @@ TEST_F(LinearSimplexElementTest, ShapeFunctionDerivative3D) {
     EXPECT_EQ(dSdxi[q].col(1), y_deriv);
     EXPECT_EQ(dSdxi[q].col(2), z_deriv);
   }
+  // Verify that when the mapping from the parent domain to the spatial domain
+  // is the identity, the gradient in spatial coordinates is the same as the
+  // gradient in parent coordinates.
+  Eigen::Matrix<double, 3, 4> xa;
+  // clang-format off
+  xa << 0, 1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1;
+  // clang-format on
+  const auto dSdX = tet_.CalcGradientInSpatialCoordinates(xa);
+  for (int q = 0; q < kNumQuads; ++q) {
+    EXPECT_TRUE(CompareMatrices(dSdX[q], dSdxi[q],
+                                std::numeric_limits<double>::epsilon()));
+  }
 }
 
 }  // namespace
+}  // namespace internal
 }  // namespace fem
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/fixed_fem/dev/test/static_elasticity_element_test.cc
+++ b/multibody/fixed_fem/dev/test/static_elasticity_element_test.cc
@@ -24,7 +24,8 @@ class StaticElasticityElementTest : public ::testing::Test {
       internal::SimplexGaussianQuadrature<kNaturalDimension, kQuadratureOrder>;
   static constexpr int kNumQuads = QuadratureType::num_quadrature_points;
   using IsoparametricElementType =
-      LinearSimplexElement<T, kNaturalDimension, kSpatialDimension, kNumQuads>;
+      internal::LinearSimplexElement<T, kNaturalDimension, kSpatialDimension,
+                                     kNumQuads>;
   using ConstitutiveModelType = LinearConstitutiveModel<T, kNumQuads>;
   using ElementType =
       StaticElasticityElement<IsoparametricElementType, QuadratureType,

--- a/multibody/fixed_fem/dev/test/static_elasticity_model_test.cc
+++ b/multibody/fixed_fem/dev/test/static_elasticity_model_test.cc
@@ -24,7 +24,8 @@ using QuadratureType =
     internal::SimplexGaussianQuadrature<kNaturalDimension, kQuadratureOrder>;
 constexpr int kNumQuads = QuadratureType::num_quadrature_points;
 using IsoparametricElementType =
-    LinearSimplexElement<T, kNaturalDimension, kSpatialDimension, kNumQuads>;
+    internal::LinearSimplexElement<T, kNaturalDimension, kSpatialDimension,
+                                   kNumQuads>;
 using ConstitutiveModelType = LinearConstitutiveModel<T, kNumQuads>;
 using ElementType =
     StaticElasticityElement<IsoparametricElementType, QuadratureType,

--- a/multibody/fixed_fem/dev/test/stretch_test.cc
+++ b/multibody/fixed_fem/dev/test/stretch_test.cc
@@ -23,7 +23,8 @@ using QuadratureType =
     internal::SimplexGaussianQuadrature<kNaturalDimension, kQuadratureOrder>;
 constexpr int kNumQuads = QuadratureType::num_quadrature_points;
 using IsoparametricElementType =
-    LinearSimplexElement<T, kNaturalDimension, kSpatialDimension, kNumQuads>;
+    internal::LinearSimplexElement<T, kNaturalDimension, kSpatialDimension,
+                                   kNumQuads>;
 using ConstitutiveModelType = LinearConstitutiveModel<T, kNumQuads>;
 using ElementType =
     StaticElasticityElement<IsoparametricElementType, QuadratureType,
@@ -100,9 +101,8 @@ class StretchTest : public ::testing::Test {
       }
       /* Stretch the two ends of the bar in y-direction. */
       if (std::abs(std::abs(q(int{y_dof_index})) - std::abs(kLy / 2)) <= kTol) {
-        bc->AddBoundaryCondition(y_dof_index,
-                                 Vector1<T>(
-                                     kStretchFactor * q(int{y_dof_index})));
+        bc->AddBoundaryCondition(
+            y_dof_index, Vector1<T>(kStretchFactor * q(int{y_dof_index})));
       }
       /* No translation in the xz-plane. */
       if (std::abs(q(int{z_dof_index})) <= kTol) {


### PR DESCRIPTION
Misc improvements:
* Move IsoparametricElement and LinearSimplexElement into internal::
namespace.
* Add CalcGradientInSpatialCoordinates() method.
* Move implementations to .cc file and use protected DoFoo() methods in
the CRTP base class to comply with style guide rules on inline methods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15440)
<!-- Reviewable:end -->
