### PR TITLE
[skylark] Remove TODO about -Wmissing-field-initializers

### DIFF
--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -58,7 +58,7 @@ GCC_FLAGS = CXX_FLAGS + [
     "-Werror=non-virtual-dtor",
     "-Werror=return-local-addr",
     "-Werror=unused-but-set-parameter",
-    # TODO(jwnimmer-tri) Fix these warnings and remove this suppression.
+    # This was turned on via -Wextra, but is too strict to have as an error.
     "-Wno-missing-field-initializers",
 ]
 


### PR DESCRIPTION
Using missing-field-initializers has a poor true/false positive ratio.  Resolve the TODO in favor of no action.

For reference, these are the (only) three complaints that we'd see if we were to turn this on today:
```console
geometry/render/render_engine_vtk.cc:193:45: error: missing initializer for member 'drake::geometry::render::{anonymous}::RegistrationData::mesh_filename' [-Werror=missing-field-initializers]
   RegistrationData data{properties, X_WG, id};

manipulation/perception/test/optitrack_pose_extractor_test.cc:168:39: error: missing initializer for member 'optitrack::optitrack_rigid_body_description_t::parent_id' [-Werror=missing-field-initializers]
   message.rigid_bodies = {{"test", 10}};

solvers/scs_solver.cc:755:21: error: missing initializer for member 'SCS_INFO::status' [-Werror=missing-field-initializers]
   ScsInfo scs_info{0};
```

The first two are perhaps a nice one-time "reminder", but the code is plenty correct and readable as-is, so the Werror is too harsh.

The final one _is_ helpfully highlightling an awkward (but not defective) idiom.  The `{0}` is mimicing the C-ism to zero-initialize a struct (which would be `ScsInfo scs_info = {0}`, in the case of idomatic C).  The idomatic C++ convention would just be say `{}` without the zero, but overall, it's a big _shrug_ from me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15441)
<!-- Reviewable:end -->
