### PR TITLE
[py/trajectories] bind matrix versions of PiecewisePolynomial

### DIFF
--- a/bindings/pydrake/test/trajectories_test.py
+++ b/bindings/pydrake/test/trajectories_test.py
@@ -97,19 +97,7 @@ class TestTrajectories(unittest.TestCase):
         self.assertEqual(pp.get_segment_index(t=1.5), 1)
         self.assertEqual(pp.get_segment_times(), [0., 1., 2.])
 
-    def test_zero_order_hold_matrix(self):
-        A0 = np.array([[1, 2, 3], [4, 5, 6]])
-        A1 = np.array([[7, 8, 9], [10, 11, 12]])
-        A2 = np.array([[13, 14, 15], [16, 17, 18]])
-        pp = PiecewisePolynomial.ZeroOrderHold([0., 1., 2.], [A0, A1, A2])
-        self.assertEqual(pp.get_number_of_segments(), 2)
-        self.assertEqual(pp.start_time(), 0.)
-        self.assertEqual(pp.end_time(), 2.)
-        self.assertEqual(pp.rows(), 2)
-        self.assertEqual(pp.cols(), 3)
-        np.testing.assert_equal(A0, pp.value(.5))
-
-    def test_first_order_hold(self):
+    def test_first_order_hold_vector(self):
         x = np.array([[1., 2.], [3., 4.], [5., 6.]]).transpose()
         pp = PiecewisePolynomial.FirstOrderHold([0., 1., 2.], x)
         np.testing.assert_equal(np.array([[2.], [3.]]), pp.value(.5))
@@ -118,7 +106,7 @@ class TestTrajectories(unittest.TestCase):
         np.testing.assert_equal(np.array([[2.], [2.]]), deriv.value(.5))
         pp.AppendFirstOrderSegment(time=3., sample=[-0.4, .57])
 
-    def test_hermite(self):
+    def test_hermite_vector(self):
         t = [0., 1., 2.]
         x = np.array([[0, 1, 1]])
         pp = PiecewisePolynomial.CubicShapePreserving(
@@ -126,7 +114,7 @@ class TestTrajectories(unittest.TestCase):
         pp.AppendCubicHermiteSegment(time=3., sample=[2], sample_dot=[2])
         pp.RemoveFinalSegment()
 
-    def test_cubic(self):
+    def test_cubic_vector(self):
         t = [0., 1., 2.]
         x = np.diag([4., 5., 6.])
         periodic_end = False
@@ -139,13 +127,48 @@ class TestTrajectories(unittest.TestCase):
             breaks=t, samples=x, sample_dot_at_start=[0., 0., 0.],
             sample_dot_at_end=[0., 0., 0.])
 
-    def test_lagrange_interpolating_polynomial(self):
+    def test_lagrange_interpolating_polynomial_vector(self):
         t = [0., 1., 2.]
         x = np.diag([4., 5., 6.])
         pp = PiecewisePolynomial.LagrangeInterpolatingPolynomial(times=t,
                                                                  samples=x)
         self.assertEqual(pp.get_number_of_segments(), 1)
         np.testing.assert_array_almost_equal(x[:, [1]], pp.value(1.), 1e-12)
+
+    def test_matrix_trajectories(self):
+        A0 = np.array([[1, 2, 3], [4, 5, 6]])
+        A1 = np.array([[7, 8, 9], [10, 11, 12]])
+        A2 = np.array([[13, 14, 15], [16, 17, 18]])
+        t = [0., 1., 2.]
+        pp = dict()
+        pp["zoh"] = PiecewisePolynomial.ZeroOrderHold(
+            breaks=t, samples=[A0, A1, A2])
+        pp["foh"] = PiecewisePolynomial.FirstOrderHold(
+            breaks=t, samples=[A0, A1, A2])
+        pp["hermite"] = PiecewisePolynomial.CubicShapePreserving(
+            breaks=t, samples=[A0, A1, A2], zero_end_point_derivatives=False)
+        pp["c1"] = PiecewisePolynomial.CubicWithContinuousSecondDerivatives(
+            breaks=t, samples=[A0, A1, A2], periodic_end=False)
+        pp["c2"] = PiecewisePolynomial.CubicHermite(
+            breaks=t, samples=[A0, A1, A2], samples_dot=[0*A0, 0*A1, 0*A2])
+        pp["c3"] = PiecewisePolynomial.CubicWithContinuousSecondDerivatives(
+            breaks=t, samples=[A0, A1, A2], sample_dot_at_start=0*A0,
+            sample_dot_at_end=0*A0)
+        pp["lagrange"] = PiecewisePolynomial.LagrangeInterpolatingPolynomial(
+            times=t, samples=[A0, A1, A2])
+        for name, traj in pp.items():
+            if name == "lagrange":
+                self.assertEqual(traj.get_number_of_segments(), 1)
+            else:
+                self.assertEqual(traj.get_number_of_segments(), 2)
+            self.assertEqual(traj.start_time(), 0.)
+            self.assertEqual(traj.end_time(), 2.)
+            self.assertEqual(traj.rows(), 2)
+            self.assertEqual(traj.cols(), 3)
+        # Check the values for the easy cases:
+        np.testing.assert_equal(A0, pp["zoh"].value(.5))
+        np.testing.assert_allclose(
+            0.5*A0 + 0.5*A1, pp["foh"].value(.5), 1e-15)
 
     def test_reverse_and_scale_time(self):
         x = np.array([[10.], [20.], [30.]]).transpose()

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -147,48 +147,115 @@ PYBIND11_MODULE(trajectories, m) {
               &PiecewisePolynomial<T>::ZeroOrderHold),
           py::arg("breaks"), py::arg("samples"),
           doc.PiecewisePolynomial.ZeroOrderHold.doc_matrix)
+      .def_static(
+          "FirstOrderHold",
+          [](const std::vector<T>& breaks,
+              const std::vector<std::vector<T>>& samples) {
+            return PiecewisePolynomial<T>::FirstOrderHold(
+                breaks, MakeEigenFromRowMajorVectors(samples));
+          },
+          py::arg("breaks"), py::arg("samples"),
+          doc.PiecewisePolynomial.FirstOrderHold.doc_vector)
       .def_static("FirstOrderHold",
-          py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
-              const Eigen::Ref<const MatrixX<T>>&>(
+          py::overload_cast<const std::vector<T>&,
+              const std::vector<MatrixX<T>>&>(
               &PiecewisePolynomial<T>::FirstOrderHold),
-          doc.PiecewisePolynomial.FirstOrderHold.doc)
+          py::arg("breaks"), py::arg("samples"),
+          doc.PiecewisePolynomial.FirstOrderHold.doc_matrix)
+      .def_static(
+          "CubicShapePreserving",
+          [](const std::vector<T>& breaks,
+              const std::vector<std::vector<T>>& samples,
+              bool zero_end_point_derivatives) {
+            return PiecewisePolynomial<T>::CubicShapePreserving(breaks,
+                MakeEigenFromRowMajorVectors(samples),
+                zero_end_point_derivatives);
+          },
+          py::arg("breaks"), py::arg("samples"),
+          py::arg("zero_end_point_derivatives") = false,
+          doc.PiecewisePolynomial.CubicShapePreserving.doc_vector)
       .def_static("CubicShapePreserving",
-          py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
-              const Eigen::Ref<const MatrixX<T>>&, bool>(
+          py::overload_cast<const std::vector<T>&,
+              const std::vector<MatrixX<T>>&, bool>(
               &PiecewisePolynomial<T>::CubicShapePreserving),
           py::arg("breaks"), py::arg("samples"),
           py::arg("zero_end_point_derivatives") = false,
-          doc.PiecewisePolynomial.CubicShapePreserving.doc)
+          doc.PiecewisePolynomial.CubicShapePreserving.doc_matrix)
+      .def_static(
+          "CubicWithContinuousSecondDerivatives",
+          [](const std::vector<T>& breaks,
+              const std::vector<std::vector<T>>& samples,
+              const MatrixX<T>& sample_dot_at_start,
+              const MatrixX<T>& sample_dot_at_end) {
+            return PiecewisePolynomial<T>::CubicWithContinuousSecondDerivatives(
+                breaks, MakeEigenFromRowMajorVectors(samples),
+                sample_dot_at_start, sample_dot_at_end);
+          },
+          py::arg("breaks"), py::arg("samples"), py::arg("sample_dot_at_start"),
+          py::arg("sample_dot_at_end"),
+          doc.PiecewisePolynomial.CubicWithContinuousSecondDerivatives
+              .doc_4args_vector)
       .def_static("CubicWithContinuousSecondDerivatives",
-          py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
-              const Eigen::Ref<const MatrixX<T>>&,
-              const Eigen::Ref<const VectorX<T>>&,
-              const Eigen::Ref<const VectorX<T>>&>(
+          py::overload_cast<const std::vector<T>&,
+              const std::vector<MatrixX<T>>&, const MatrixX<T>&,
+              const MatrixX<T>&>(
               &PiecewisePolynomial<T>::CubicWithContinuousSecondDerivatives),
           py::arg("breaks"), py::arg("samples"), py::arg("sample_dot_at_start"),
           py::arg("sample_dot_at_end"),
           doc.PiecewisePolynomial.CubicWithContinuousSecondDerivatives
-              .doc_4args)
+              .doc_4args_matrix)
+      .def_static(
+          "CubicHermite",
+          [](const std::vector<T>& breaks,
+              const std::vector<std::vector<T>>& samples,
+              const std::vector<std::vector<T>>& samples_dot) {
+            return PiecewisePolynomial<T>::CubicHermite(breaks,
+                MakeEigenFromRowMajorVectors(samples),
+                MakeEigenFromRowMajorVectors(samples_dot));
+          },
+          py::arg("breaks"), py::arg("samples"), py::arg("samples_dot"),
+          doc.PiecewisePolynomial.CubicHermite.doc_vector)
       .def_static("CubicHermite",
-          py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
-              const Eigen::Ref<const MatrixX<T>>&,
-              const Eigen::Ref<const MatrixX<T>>&>(
+          py::overload_cast<const std::vector<T>&,
+              const std::vector<MatrixX<T>>&, const std::vector<MatrixX<T>>&>(
               &PiecewisePolynomial<T>::CubicHermite),
           py::arg("breaks"), py::arg("samples"), py::arg("samples_dot"),
-          doc.PiecewisePolynomial.CubicHermite.doc)
+          doc.PiecewisePolynomial.CubicHermite.doc_matrix)
+      .def_static(
+          "CubicWithContinuousSecondDerivatives",
+          [](const std::vector<T>& breaks,
+              const std::vector<std::vector<T>>& samples,
+              bool periodic_end_condition) {
+            return PiecewisePolynomial<T>::CubicWithContinuousSecondDerivatives(
+                breaks, MakeEigenFromRowMajorVectors(samples),
+                periodic_end_condition);
+          },
+          py::arg("breaks"), py::arg("samples"),
+          py::arg("periodic_end_condition") = false,
+          doc.PiecewisePolynomial.CubicWithContinuousSecondDerivatives
+              .doc_3args_vector)
       .def_static("CubicWithContinuousSecondDerivatives",
-          py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
-              const Eigen::Ref<const MatrixX<T>>&, bool>(
+          py::overload_cast<const std::vector<T>&,
+              const std::vector<MatrixX<T>>&, bool>(
               &PiecewisePolynomial<T>::CubicWithContinuousSecondDerivatives),
           py::arg("breaks"), py::arg("samples"), py::arg("periodic_end"),
           doc.PiecewisePolynomial.CubicWithContinuousSecondDerivatives
-              .doc_3args)
+              .doc_3args_matrix)
+      .def_static(
+          "LagrangeInterpolatingPolynomial",
+          [](const std::vector<T>& breaks,
+              const std::vector<std::vector<T>>& samples) {
+            return PiecewisePolynomial<T>::LagrangeInterpolatingPolynomial(
+                breaks, MakeEigenFromRowMajorVectors(samples));
+          },
+          py::arg("times"), py::arg("samples"),
+          doc.PiecewisePolynomial.LagrangeInterpolatingPolynomial.doc_vector)
       .def_static("LagrangeInterpolatingPolynomial",
-          py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
-              const Eigen::Ref<const MatrixX<T>>&>(
+          py::overload_cast<const std::vector<T>&,
+              const std::vector<MatrixX<T>>&>(
               &PiecewisePolynomial<T>::LagrangeInterpolatingPolynomial),
           py::arg("times"), py::arg("samples"),
-          doc.PiecewisePolynomial.LagrangeInterpolatingPolynomial.doc)
+          doc.PiecewisePolynomial.LagrangeInterpolatingPolynomial.doc_matrix)
       .def("derivative", &PiecewisePolynomial<T>::derivative,
           py::arg("derivative_order") = 1,
           doc.PiecewisePolynomial.derivative.doc)

--- a/common/trajectories/piecewise_polynomial.h
+++ b/common/trajectories/piecewise_polynomial.h
@@ -236,7 +236,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    *
    * @throws std::exception under the conditions specified under
    *         @ref coefficient_construction_methods.
-   * @exclude_from_pydrake_mkdoc{This overload is not bound in pydrake.}
+   * @pydrake_mkdoc_identifier{matrix}
    */
   static PiecewisePolynomial<T> FirstOrderHold(
       const std::vector<T>& breaks,
@@ -250,6 +250,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * @pre `samples.cols() == breaks.size()`
    * @throws std::exception under the conditions specified under
    *         @ref coefficient_construction_methods.
+   * @pydrake_mkdoc_identifier{vector}
    */
   static PiecewisePolynomial<T> FirstOrderHold(
       const Eigen::Ref<const VectorX<T>>& breaks,
@@ -295,7 +296,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    *
    * @throws std::exception under the conditions specified under
    *         @ref coefficient_construction_methods.
-   * @exclude_from_pydrake_mkdoc{This overload is not bound in pydrake.}
+   * @pydrake_mkdoc_identifier{matrix}
    */
   static PiecewisePolynomial<T> CubicShapePreserving(
       const std::vector<T>& breaks,
@@ -310,6 +311,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * @pre `samples.cols() == breaks.size()`.
    * @throws std::exception under the conditions specified under
    *         @ref coefficient_construction_methods.
+   * @pydrake_mkdoc_identifier{vector}
    */
   static PiecewisePolynomial<T> CubicShapePreserving(
       const Eigen::Ref<const VectorX<T>>& breaks,
@@ -327,7 +329,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * and `samples` have inconsistent dimensions.
    * @throws std::exception under the conditions specified under
    *         @ref coefficient_construction_methods.
-   * @exclude_from_pydrake_mkdoc{This overload is not bound in pydrake.}
+   * @pydrake_mkdoc_identifier{4args_matrix}
    */
   static PiecewisePolynomial<T> CubicWithContinuousSecondDerivatives(
       const std::vector<T>& breaks,
@@ -343,6 +345,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * @pre `samples.cols() == breaks.size()`.
    * @throws std::exception under the conditions specified under
    *         @ref coefficient_construction_methods.
+   * @pydrake_mkdoc_identifier{4args_vector}
    */
   static PiecewisePolynomial<T> CubicWithContinuousSecondDerivatives(
       const Eigen::Ref<const VectorX<T>>& breaks,
@@ -358,7 +361,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * `samples`. Each segment is fully specified by `samples` and `sample_dot` at
    * both ends. Second derivatives are not continuous.
    *
-   * @exclude_from_pydrake_mkdoc{This overload is not bound in pydrake.}
+   * @pydrake_mkdoc_identifier{matrix}
    */
   static PiecewisePolynomial<T> CubicHermite(
       const std::vector<T>& breaks,
@@ -372,6 +375,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * variable derivative, respectively.
    *
    * @pre `samples.cols() == samples_dot.cols() == breaks.size()`.
+   * @pydrake_mkdoc_identifier{vector}
    */
   static PiecewisePolynomial<T> CubicHermite(
       const Eigen::Ref<const VectorX<T>>& breaks,
@@ -401,7 +405,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * `periodic_end_condition` is `true`, then for two samples, it would
    * produce a straight line (use `FirstOrderHold` for this instead), and if
    * `periodic_end_condition` is `false` the problem is ill-defined.
-   * @exclude_from_pydrake_mkdoc{This overload is not bound in pydrake.}
+   * @pydrake_mkdoc_identifier{3args_matrix}
    */
   static PiecewisePolynomial<T> CubicWithContinuousSecondDerivatives(
       const std::vector<T>& breaks,
@@ -414,6 +418,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * of `samples` represents a sample point.
    *
    * @pre `samples.cols() == breaks.size()`.
+   * @pydrake_mkdoc_identifier{3args_vector}
    */
   static PiecewisePolynomial<T> CubicWithContinuousSecondDerivatives(
       const Eigen::Ref<const VectorX<T>>& breaks,
@@ -435,7 +440,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * information.
    * @pre `times` must be monotonically increasing.
    * @pre `samples.size() == times.size()`.
-   * @exclude_from_pydrake_mkdoc{This overload is not bound in pydrake.}
+   * @pydrake_mkdoc_identifier{matrix}
    */
   static PiecewisePolynomial LagrangeInterpolatingPolynomial(
       const std::vector<T>& times, const std::vector<MatrixX<T>>& samples);
@@ -446,6 +451,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * of `samples` represents a sample point.
    *
    * @pre `samples.cols() == times.size()`.
+   * @pydrake_mkdoc_identifier{vector}
    */
   static PiecewisePolynomial<T> LagrangeInterpolatingPolynomial(
       const Eigen::Ref<const VectorX<T>>& times,


### PR DESCRIPTION
Takes the pattern established in #15433, and implements it for the remaining construction methods.

Resolves #15427.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15442)
<!-- Reviewable:end -->
