### PR TITLE
[framework] Deprecate dispreferred DeclareCacheEntry overloads

### DIFF
--- a/systems/framework/system.cc
+++ b/systems/framework/system.cc
@@ -909,19 +909,19 @@ System<T>::System(SystemScalarConverter converter)
       accuracy_ticket(), all_state_ticket(), all_parameters_ticket()};
   potential_energy_cache_index_ =
       DeclareCacheEntry("potential energy",
-          &System<T>::CalcPotentialEnergy,
+          ValueProducer(this, &System<T>::CalcPotentialEnergy),
           energy_prereqs_for_9171)  // After #9171: configuration + mass.
           .cache_index();
 
   kinetic_energy_cache_index_ =
       DeclareCacheEntry("kinetic energy",
-          &System<T>::CalcKineticEnergy,
+          ValueProducer(this, &System<T>::CalcKineticEnergy),
           energy_prereqs_for_9171)  // After #9171: kinematics + mass.
           .cache_index();
 
   conservative_power_cache_index_ =
       DeclareCacheEntry("conservative power",
-          &System<T>::CalcConservativePower,
+          ValueProducer(this, &System<T>::CalcConservativePower),
           energy_prereqs_for_9171)  // After #9171: kinematics + mass.
           .cache_index();
 
@@ -930,8 +930,8 @@ System<T>::System(SystemScalarConverter converter)
   // EvalNonConservativePower() to see why.
   nonconservative_power_cache_index_ =
       DeclareCacheEntry("non-conservative power",
-                        &System<T>::CalcNonConservativePower,
-                        {all_sources_ticket()})  // This is correct.
+          ValueProducer(this, &System<T>::CalcNonConservativePower),
+          {all_sources_ticket()})  // This is correct.
           .cache_index();
 
   // We must assume that time derivatives can depend on *any* context source.

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -377,21 +377,18 @@ class SystemBase : public internal::SystemMessageInterface {
       std::set<DependencyTicket> prerequisites_of_calc = {
           all_sources_ticket()});
 
-  /** Declares a cache entry by specifying member functions to use both for the
-  allocator and calculator. The signatures are: @code
-    ValueType MySystem::MakeValueType() const;
-    void MySystem::CalcCacheValue(const MyContext&, ValueType*) const;
-  @endcode
-  where `MySystem` is a class derived from `SystemBase`, `MyContext` is a class
-  derived from `ContextBase`, and `ValueType` is any concrete type such that
-  `Value<ValueType>` is permitted. (The method names are arbitrary.) Template
-  arguments will be deduced and do not need to be specified. See the
-  @ref DeclareCacheEntry_primary "primary DeclareCacheEntry() signature"
-  for more information about the parameters and behavior.
-  @see drake::Value
-  @warning This method is currently specified as `public` access, but will be
-  demoted to `protected` access on or after 2021-10-01. */
+  // Declares a cache entry via two member function pointers.
+  // This will be demoted to `protected` access on or after 2021-10-01, and then
+  // removed entirely on 2021-11-01.
   template <class MySystem, class MyContext, typename ValueType>
+  DRAKE_DEPRECATED("2021-11-01",
+      "This overload for DeclareCacheEntry is rarely the best choice; it is"
+      " unusual for allocation to actually require a boutique callback rather"
+      " than just a Clone of a model_value. We found that most uses of this"
+      " overload hindered readability, because other overloads would often do"
+      " the job more directly. If no existing overload works, you may wrap a"
+      " ValueProducer around your existing make method and call the primary"
+      " DeclareCacheEntry overload that takes a ValueProducer, instead.")
   CacheEntry& DeclareCacheEntry(
       std::string description,
       ValueType (MySystem::*make)() const,
@@ -421,17 +418,18 @@ class SystemBase : public internal::SystemMessageInterface {
       std::set<DependencyTicket> prerequisites_of_calc = {
           all_sources_ticket()});
 
-  /** Declares a cache entry by specifying a model value of concrete type
-  `ValueType` and a calculator function that is a class member function (method)
-  with signature: @code
-    ValueType MySystem::CalcCacheValue(const MyContext&) const;
-  @endcode
-  Other than the calculator signature, this is identical to the other
-  @ref DeclareCacheEntry_model_and_calc "model and calculator signature",
-  please look there for more information.
-  @warning This method is currently specified as `public` access, but will be
-  demoted to `protected` access on or after 2021-10-01. */
+  // Declares a cache entry via a model value and calc member function pointer.
+  // This will be demoted to `protected` access on or after 2021-10-01, and then
+  // removed entirely on 2021-11-01.
   template <class MySystem, class MyContext, typename ValueType>
+  DRAKE_DEPRECATED("2021-11-01",
+      "This overload for DeclareCacheEntry is dispreferred because it might"
+      " not reuse heap storage from one calculation to the next, and so is"
+      " typically less efficient than the other overloads. A better option"
+      " is to change the ValueType returned by-value to be an output pointer"
+      " instead, and return void. If that is not possible, you may wrap a"
+      " ValueProducer around your existing method and call the primary"
+      " DeclareCacheEntry overload that takes a ValueProducer, instead.")
   CacheEntry& DeclareCacheEntry(
       std::string description, const ValueType& model_value,
       ValueType (MySystem::*calc)(const MyContext&) const,
@@ -469,17 +467,18 @@ class SystemBase : public internal::SystemMessageInterface {
       std::set<DependencyTicket> prerequisites_of_calc = {
           all_sources_ticket()});
 
-  /** Declares a cache entry by specifying only a calculator function that is a
-  class member function (method) with signature:
-  @code
-    ValueType MySystem::CalcCacheValue(const MyContext&) const;
-  @endcode
-  Other than the calculator method's signature, this is identical to the other
-  @ref DeclareCacheEntry_calc_only "calculator-only signature";
-  please look there for more information.
-  @warning This method is currently specified as `public` access, but will be
-  demoted to `protected` access on or after 2021-10-01. */
+  // Declares a cache entry via a calculator member function pointer only.
+  // This will be demoted to `protected` access on or after 2021-10-01, and then
+  // removed entirely on 2021-11-01.
   template <class MySystem, class MyContext, typename ValueType>
+  DRAKE_DEPRECATED("2021-11-01",
+      "This overload for DeclareCacheEntry is dispreferred because it might"
+      " not reuse heap storage from one calculation to the next, and so is"
+      " typically less efficient than the other overloads. A better option"
+      " is to change the ValueType returned by-value to be an output pointer"
+      " instead, and return void. If that is not possible, you may wrap a"
+      " ValueProducer around your existing method and call the primary"
+      " DeclareCacheEntry overload that takes a ValueProducer, instead.")
   CacheEntry& DeclareCacheEntry(
       std::string description,
       ValueType (MySystem::*calc)(const MyContext&) const,
@@ -1259,6 +1258,7 @@ class SystemBase : public internal::SystemMessageInterface {
 
 // Implementations of templatized DeclareCacheEntry() methods.
 
+// (This overload is deprecated.)
 // Takes make() and calc() member functions.
 template <class MySystem, class MyContext, typename ValueType>
 CacheEntry& SystemBase::DeclareCacheEntry(
@@ -1306,10 +1306,9 @@ CacheEntry& SystemBase::DeclareCacheEntry(
   return entry;
 }
 
+// (This overload is deprecated.)
 // Takes an initial value and value-returning calc() member function.
 // See the above output-argument signature for an explanation of the code.
-// TODO(sherm1) Consider whether common code in this and the previous method
-// can be factored out and shared rather than repeated.
 template <class MySystem, class MyContext, typename ValueType>
 CacheEntry& SystemBase::DeclareCacheEntry(
     std::string description, const ValueType& model_value,
@@ -1352,6 +1351,7 @@ CacheEntry& SystemBase::DeclareCacheEntry(
                            std::move(prerequisites_of_calc));
 }
 
+// (This overload is deprecated.)
 // Takes just a value-returning calc() member function, and
 // value-initializes the entry. See previous method for more information.
 template <class MySystem, class MyContext, typename ValueType>
@@ -1363,8 +1363,11 @@ CacheEntry& SystemBase::DeclareCacheEntry(
       std::is_default_constructible_v<ValueType>,
       "SystemBase::DeclareCacheEntry(calc): the calc-only overloads of "
       "this method requires that the output type has a default constructor");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   return DeclareCacheEntry(std::move(description), ValueType{}, calc,
                            std::move(prerequisites_of_calc));
+#pragma GCC diagnostic pop
 }
 
 }  // namespace systems

--- a/systems/framework/test/cache_entry_test.cc
+++ b/systems/framework/test/cache_entry_test.cc
@@ -88,61 +88,78 @@ class MyContextBase : public ContextBase {
 class MySystemBase final : public SystemBase {
  public:
   // Use at least one of each of the six DeclareCacheEntry() variants.
-  MySystemBase()
-        // 1. Use the most general method, taking free functions. Unspecified
-        //    prerequisites should default to all_sources_ticket().
-      : entry0_(DeclareCacheEntry("entry0", ValueProducer(Alloc3, Calc99))),
-        // 2. Use the method that takes two member functions.
-        entry1_(DeclareCacheEntry("entry1", &MySystemBase::MakeInt1,
-                                  &MySystemBase::CalcInt98,
-                                  {entry0_.ticket()})),
-        // 3a. Use the method that takes a model value and member calculator.
-        entry2_(DeclareCacheEntry("entry2", 2, &MySystemBase::CalcInt98,
-                                  {entry0_.ticket(), entry1_.ticket()})),
-        // 4. Use the method that takes a model value and member calculator that
-        // uses function return for its value.
-        entry3_(DeclareCacheEntry("entry3", 17, &MySystemBase::CalcReturnInt11,
-                                  {entry0_.ticket(), entry1_.ticket()})),
-        // 5. Use the method that takes just a member calculator that uses
-        // an output argument. (Entry will be value-initialized.)
-        entry4_(DeclareCacheEntry("entry4",
-                                  &MySystemBase::CalcInt98,
-                                  {entry0_.ticket(), entry1_.ticket()})),
-        // 6. Use the method that takes just a member calculator that uses
-        // function return for its value. (Entry will be value-initialized.)
-        entry5_(DeclareCacheEntry("entry5",
-                                  &MySystemBase::CalcReturnInt11,
-                                  {entry0_.ticket(), entry1_.ticket()})),
-        // 6b. Use the method that takes just a member calculator with output
-        // argument (value-initializes the cache entry).
-        string_entry_(DeclareCacheEntry("string thing",
-                                        &MySystemBase::CalcString,
-                                        {time_ticket()})),
-        // 3b. Also a model value and member calculator.
-        vector_entry_(
-            DeclareCacheEntry("vector thing", MyVector3d(Vector3d(1., 2., 3.)),
-                              &MySystemBase::CalcMyVector3,
-                              {xc_ticket(), string_entry_.ticket()})) {
+  MySystemBase() {
+    // 1. Use the most general method, taking free functions. Unspecified
+    //    prerequisites should default to all_sources_ticket().
+    entry0_ = &DeclareCacheEntry("entry0", ValueProducer(Alloc3, Calc99));
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    // 2. Use the method that takes two member functions.
+    entry1_ = &DeclareCacheEntry("entry1", &MySystemBase::MakeInt1,
+                                 &MySystemBase::CalcInt98,
+                                 {entry0_->ticket()});
+#pragma GCC diagnostic pop
+
+    // 3a. Use the method that takes a model value and member calculator.
+    entry2_ = &DeclareCacheEntry("entry2", 2, &MySystemBase::CalcInt98,
+                                 {entry0_->ticket(), entry1_->ticket()});
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    // 4. Use the method that takes a model value and member calculator that
+    // uses function return for its value.
+    entry3_ = &DeclareCacheEntry("entry3", 17, &MySystemBase::CalcReturnInt11,
+                                 {entry0_->ticket(), entry1_->ticket()});
+#pragma GCC diagnostic pop
+
+    // 5. Use the method that takes just a member calculator that uses
+    // an output argument. (Entry will be value-initialized.)
+    entry4_ = &DeclareCacheEntry("entry4",
+                                 &MySystemBase::CalcInt98,
+                                 {entry0_->ticket(), entry1_->ticket()});
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    // 6. Use the method that takes just a member calculator that uses
+    // function return for its value. (Entry will be value-initialized.)
+    entry5_ = &DeclareCacheEntry("entry5",
+                                 &MySystemBase::CalcReturnInt11,
+                                 {entry0_->ticket(), entry1_->ticket()});
+#pragma GCC diagnostic pop
+
+    // 6b. Use the method that takes just a member calculator with output
+    // argument (value-initializes the cache entry).
+    string_entry_ = &DeclareCacheEntry("string thing",
+                                       &MySystemBase::CalcString,
+                                       {time_ticket()});
+
+    // 3b. Also a model value and member calculator.
+    vector_entry_ =
+        &DeclareCacheEntry("vector thing", MyVector3d(Vector3d(1., 2., 3.)),
+                           &MySystemBase::CalcMyVector3,
+                           {xc_ticket(), string_entry_->ticket()});
+
     set_name("cache_entry_test_system");
 
     // We'll make entry4 disabled by default; everything else is enabled.
-    entry4_.disable_caching_by_default();
+    entry4_->disable_caching_by_default();
 
     EXPECT_EQ(num_cache_entries(), 8);
     EXPECT_EQ(GetSystemName(), "cache_entry_test_system");
 
-    EXPECT_FALSE(entry3_.is_disabled_by_default());
-    EXPECT_TRUE(entry4_.is_disabled_by_default());
+    EXPECT_FALSE(entry3_->is_disabled_by_default());
+    EXPECT_TRUE(entry4_->is_disabled_by_default());
   }
 
-  const CacheEntry& entry0() const { return entry0_; }
-  const CacheEntry& entry1() const { return entry1_; }
-  const CacheEntry& entry2() const { return entry2_; }
-  const CacheEntry& entry3() const { return entry3_; }
-  const CacheEntry& entry4() const { return entry4_; }
-  const CacheEntry& entry5() const { return entry5_; }
-  const CacheEntry& string_entry() const { return string_entry_; }
-  const CacheEntry& vector_entry() const { return vector_entry_; }
+  const CacheEntry& entry0() const { return *entry0_; }
+  const CacheEntry& entry1() const { return *entry1_; }
+  const CacheEntry& entry2() const { return *entry2_; }
+  const CacheEntry& entry3() const { return *entry3_; }
+  const CacheEntry& entry4() const { return *entry4_; }
+  const CacheEntry& entry5() const { return *entry5_; }
+  const CacheEntry& string_entry() const { return *string_entry_; }
+  const CacheEntry& vector_entry() const { return *vector_entry_; }
 
   // For use as an allocator.
   int MakeInt1() const { return 1; }
@@ -178,14 +195,14 @@ class MySystemBase final : public SystemBase {
     throw std::logic_error("GetDirectFeedthroughs is not implemented");
   }
 
-  CacheEntry& entry0_;
-  CacheEntry& entry1_;
-  CacheEntry& entry2_;
-  CacheEntry& entry3_;
-  CacheEntry& entry4_;
-  CacheEntry& entry5_;
-  CacheEntry& string_entry_;
-  CacheEntry& vector_entry_;
+  CacheEntry* entry0_{};
+  CacheEntry* entry1_{};
+  CacheEntry* entry2_{};
+  CacheEntry* entry3_{};
+  CacheEntry* entry4_{};
+  CacheEntry* entry5_{};
+  CacheEntry* string_entry_{};
+  CacheEntry* vector_entry_{};
 };
 
 // An allocator is not permitted to return null. That should be caught when


### PR DESCRIPTION
These overloads are not commonly necessary, so tend to clutter up the documentation and lead users to either add unnecessary boilerplate or fail to reuse context storage efficiently.

Refer to #15174, #15175, #15176, and #15190 for the kinds of boilerplate that we'll now discourage.

In cases where these signatures were important, users can fall back to using the full set of ValueProducer constructor overloads for maximum flexibility.

Towards #15161.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15443)
<!-- Reviewable:end -->
