### PR TITLE
[tree] Fix screw_mobilizer_test vs Eigen 3.4

### DIFF
--- a/multibody/tree/test/screw_mobilizer_test.cc
+++ b/multibody/tree/test/screw_mobilizer_test.cc
@@ -281,12 +281,12 @@ TEST_F(ScrewMobilizerTest, KinematicMapping) {
   // Compute N.
   MatrixX<double> N(1, 1);
   mobilizer_->CalcNMatrix(*context_, &N);
-  EXPECT_EQ(N, Matrix1d::Identity());
+  EXPECT_EQ(N, Matrix1d::Identity().eval());
 
   // Compute Nplus.
   MatrixX<double> Nplus(1, 1);
   mobilizer_->CalcNplusMatrix(*context_, &Nplus);
-  EXPECT_EQ(Nplus, Matrix1d::Identity());
+  EXPECT_EQ(Nplus, Matrix1d::Identity().eval());
 }
 
 }  // namespace


### PR DESCRIPTION
With Eigen 3.4, gtest was trying to print an Eigen expression tree using it's stl compatibility iterators, which violates an Eigen static assert related to matrixes with non-trivial layouts.

Force it to a concrete Matrix type so that printing compiles again (when using Eigen 3.4).

Towards #15142.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15445)
<!-- Reviewable:end -->
