### PR TITLE
[render] Respect (renderer, accepting) for post-hoc renderers

### DIFF
--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -905,13 +905,22 @@ void GeometryState<T>::AddRenderer(
   bool accepted = false;
   for (auto& id_geo_pair : geometries_) {
     InternalGeometry& geometry = id_geo_pair.second;
+    // To add this geometry to the renderer, it must:
+    //   1. Have perception role and
+    //   2. Be an acceptable renderer -- it is acceptable if the geometry hasn't
+    //      declared *any* acceptable renderers or if this renderer's name has
+    //      been explicitly included in its acceptable set.
     if (geometry.has_perception_role()) {
-      const GeometryId id = id_geo_pair.first;
       const PerceptionProperties* properties = geometry.perception_properties();
       DRAKE_DEMAND(properties != nullptr);
-      accepted |= render_engine->RegisterVisual(
-                     id, geometry.shape(), *properties,
-                     RigidTransformd(geometry.X_FG()), geometry.is_dynamic());
+      auto accepting_renderers = properties->GetPropertyOrDefault(
+          "renderer", "accepting", set<string>{});
+      if (accepting_renderers.empty() || accepting_renderers.count(name) > 0) {
+        const GeometryId id = id_geo_pair.first;
+        accepted |= render_engine->RegisterVisual(
+            id, geometry.shape(), *properties, RigidTransformd(geometry.X_FG()),
+            geometry.is_dynamic());
+      }
     }
   }
   // Increment version number if any geometry is registered to the new


### PR DESCRIPTION
When a renderer is added to 1SceneGraph1 *after* geometry was registered, the (renderer, accepting) property wasn't respected. That led, in rare cases where the property was used, that geometries would end up in the
wrong render engines.

This makes sure that the property is respected.

Resolves #14198

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15448)
<!-- Reviewable:end -->
