### PR TITLE
[common] Fine tune {not_,}equal_strict<Expression> for Eigen 3.4

### DIFF
--- a/common/test/symbolic_expression_test.cc
+++ b/common/test/symbolic_expression_test.cc
@@ -881,6 +881,8 @@ TEST_F(SymbolicExpressionTest, UnaryPlus) {
   EXPECT_PRED2(ExprEqual, Expression(var_x_), +var_x_);
 }
 
+// TODO(jwnimmer-tri) These tests should probably live in symbolic_formula_test.
+//
 // Confirm that Eigen::numext::{not_,}equal_strict are appropriately
 // specialized for Expression.
 // We only need a limited set of cases because if the specialization doesn't
@@ -891,11 +893,27 @@ TEST_F(SymbolicExpressionTest, UnaryPlus) {
 TEST_F(SymbolicExpressionTest, EigenEqualStrict) {
   EXPECT_TRUE(Eigen::numext::equal_strict(c3_, c3_));
   EXPECT_FALSE(Eigen::numext::equal_strict(c3_, c4_));
+
+  // Check our special-case zero handling.
+  EXPECT_TRUE(Eigen::numext::equal_strict(zero_, zero_));
+  EXPECT_FALSE(Eigen::numext::equal_strict(zero_, one_));
+  EXPECT_FALSE(Eigen::numext::equal_strict(one_, zero_));
+  EXPECT_FALSE(Eigen::numext::equal_strict(zero_, x_));
+  EXPECT_FALSE(Eigen::numext::equal_strict(x_, zero_));
+  EXPECT_THROW(Eigen::numext::equal_strict(x_, y_), std::exception);
 }
 
 TEST_F(SymbolicExpressionTest, EigenNotEqualStrict) {
   EXPECT_TRUE(Eigen::numext::not_equal_strict(c3_, c4_));
   EXPECT_FALSE(Eigen::numext::not_equal_strict(c3_, c3_));
+
+  // Check our special-case zero handling.
+  EXPECT_FALSE(Eigen::numext::not_equal_strict(zero_, zero_));
+  EXPECT_TRUE(Eigen::numext::not_equal_strict(zero_, one_));
+  EXPECT_TRUE(Eigen::numext::not_equal_strict(one_, zero_));
+  EXPECT_TRUE(Eigen::numext::not_equal_strict(zero_, x_));
+  EXPECT_TRUE(Eigen::numext::not_equal_strict(x_, zero_));
+  EXPECT_THROW(Eigen::numext::not_equal_strict(x_, y_), std::exception);
 }
 #endif
 


### PR DESCRIPTION
In various Eigen algorithms ([ec323b7](https://gitlab.com/libeigen/eigen/-/commit/ec323b7e6643d9da3d9cda86570cc7724e0a8d3c)), it uses "short-circuit when zero" guards to skip computationally expensive steps in cases where knows the end result will remain unchanged.

When we have Expressions filled with only constants, this works fine. However, when we have Expressions filled with Variables, trying to check for zero throws an exception because the resulting Formula cannot convert to back to a bool -- and in any case, we want the full expression tree anyway, without any short-circuits, for doing symbolic evaluation later.

Therefore, we tweak `Eigen::numext::not_equal_strict` to special-case its results if either of the operands is a literal zero, with no throwing even if the other operand has unbound variables.

Closes #15444.
Towards #15142.

Note that all of our CI configurations _other than Bionic_ cover the `Eigen >= 3.3.5` case.  Only Bionic is disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15453)
<!-- Reviewable:end -->
