### PR TITLE
[visualization] planar visualizer uses SceneGraph API to visualize

### DIFF
--- a/bindings/pydrake/examples/multibody/run_planar_scenegraph_visualizer.py
+++ b/bindings/pydrake/examples/multibody/run_planar_scenegraph_visualizer.py
@@ -14,7 +14,7 @@ from pydrake.multibody.plant import AddMultibodyPlantSceneGraph
 from pydrake.systems.analysis import Simulator
 from pydrake.systems.framework import DiagramBuilder
 from pydrake.systems.planar_scenegraph_visualizer import (
-    PlanarSceneGraphVisualizer)
+    ConnectPlanarSceneGraphVisualizer)
 
 
 def run_pendulum_example(args):
@@ -25,13 +25,11 @@ def run_pendulum_example(args):
         "drake/examples/pendulum/Pendulum.urdf"))
     plant.Finalize()
 
-    pose_bundle_output_port = scene_graph.get_pose_bundle_output_port()
     T_VW = np.array([[1., 0., 0., 0.],
                      [0., 0., 1., 0.],
                      [0., 0., 0., 1.]])
-    visualizer = builder.AddSystem(PlanarSceneGraphVisualizer(
-        scene_graph, T_VW=T_VW, xlim=[-1.2, 1.2], ylim=[-1.2, 1.2]))
-    builder.Connect(pose_bundle_output_port, visualizer.get_input_port(0))
+    visualizer = ConnectPlanarSceneGraphVisualizer(
+        builder, scene_graph, T_VW=T_VW, xlim=[-1.2, 1.2], ylim=[-1.2, 1.2])
 
     if args.playback:
         visualizer.start_recording()
@@ -64,16 +62,15 @@ def run_manipulation_example(args):
 
     plant = station.get_multibody_plant()
     scene_graph = station.get_scene_graph()
-    pose_bundle_output_port = station.GetOutputPort("pose_bundle")
+    query_object_output_port = station.GetOutputPort("geometry_query")
 
     # Side-on view of the station.
     T_VW = np.array([[1., 0., 0., 0.],
                      [0., 0., 1., 0.],
                      [0., 0., 0., 1.]])
-    visualizer = builder.AddSystem(PlanarSceneGraphVisualizer(
-        scene_graph, T_VW=T_VW, xlim=[-0.5, 1.0], ylim=[-1.2, 1.2],
-        draw_period=0.1))
-    builder.Connect(pose_bundle_output_port, visualizer.get_input_port(0))
+    ConnectPlanarSceneGraphVisualizer(
+        builder, scene_graph, query_object_output_port, T_VW=T_VW,
+        xlim=[-0.5, 1.0], ylim=[-1.2, 1.2], draw_period=0.1)
 
     if args.playback:
         visualizer.start_recording()

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -544,6 +544,7 @@ drake_py_unittest(
         ":framework_py",
         ":planar_scenegraph_visualizer_py",
         "//bindings/pydrake:geometry_py",
+        "//bindings/pydrake/common/test_utilities",
         "//bindings/pydrake/multibody",
     ],
 )

--- a/bindings/pydrake/systems/planar_scenegraph_visualizer.py
+++ b/bindings/pydrake/systems/planar_scenegraph_visualizer.py
@@ -15,12 +15,21 @@ with warnings.catch_warnings():  # noqa
     import scipy as sp
     from scipy import spatial
 
-from drake import lcmt_viewer_load_robot
-from pydrake.common.eigen_geometry import Quaternion
+from pydrake.common.deprecation import _warn_deprecated
 from pydrake.common.value import AbstractValue
-from pydrake.geometry import DrakeVisualizer, ReadObjToSurfaceMesh
-from pydrake.lcm import DrakeLcm, Subscriber
-from pydrake.math import RigidTransform, RotationMatrix
+from pydrake.geometry import (
+    Box,
+    Convex,
+    Cylinder,
+    HalfSpace,
+    Mesh,
+    QueryObject,
+    ReadObjToSurfaceMesh,
+    Rgba,
+    Role,
+    Sphere,
+)
+from pydrake.math import RigidTransform
 from pydrake.systems.pyplot_visualizer import PyPlotVisualizer
 from pydrake.systems.rendering import PoseBundle
 
@@ -40,7 +49,7 @@ class PlanarSceneGraphVisualizer(PyPlotVisualizer):
     drawn incorrectly, and geometry with many vertices will slow down the
     visualizer.
 
-     Specifics on view setup:
+    Specifics on view setup:
 
     T_VW specifies the 3x4 view projection matrix. For planar orthographic
     projection, use:
@@ -115,11 +124,15 @@ class PlanarSceneGraphVisualizer(PyPlotVisualizer):
         self._scene_graph = scene_graph
         self._T_VW = T_VW
 
+        # (2021-11-01) Remove at end of deprecation period.
         # Pose bundle (from SceneGraph) input port.
-        # TODO(tehbelinda): Rename the `lcm_visualization` port to match
-        # SceneGraph once its output port has been updated. See #12214.
         self._pose_bundle_port = self.DeclareAbstractInputPort(
             "lcm_visualization", AbstractValue.Make(PoseBundle(0)))
+        self._warned_pose_bundle_input_port_connected = False
+        # End of deprecation block.
+
+        self._geometry_query_input_port = self.DeclareAbstractInputPort(
+            "geometry_query", AbstractValue.Make(QueryObject()))
 
         self.ax.axis('equal')
         self.ax.axis('off')
@@ -132,7 +145,8 @@ class PlanarSceneGraphVisualizer(PyPlotVisualizer):
 
         # Populate body patches.
         self._build_body_patches(use_random_colors,
-                                 substitute_collocated_mesh_files)
+                                 substitute_collocated_mesh_files,
+                                 scene_graph.model_inspector())
 
         # Populate the body fill list -- which requires doing most of a draw
         # pass, but with an ax.fill() command to initialize the draw patches.
@@ -159,8 +173,24 @@ class PlanarSceneGraphVisualizer(PyPlotVisualizer):
                 # Then update the vertices for a more accurate initial draw.
                 self._update_body_fill_verts(body_fill, patch_V)
 
+    def get_geometry_query_input_port(self):
+        return self._geometry_query_input_port
+
+    @staticmethod
+    def frame_name(frame_id, inspector):
+        """Produces a visualizer name for a frame."""
+        # (2021-11-01) During the deprecation period it is *critical* that the
+        # name here matches the name produced by DrakeVisualizer. After this
+        # system ceases to use the PoseBundle to define frame poses, the name
+        # can change to whatever this visualizer would like.
+        if frame_id == inspector.world_frame_id():
+            return "world"
+        return "{}::{}".format(
+            inspector.GetOwningSourceName(frame_id),
+            inspector.GetName(frame_id))
+
     def _build_body_patches(self, use_random_colors,
-                            substitute_collocated_mesh_files):
+                            substitute_collocated_mesh_files, inspector):
         """
         Generates body patches. self._patch_Blist stores a list of patches for
         each body (starting at body id 1). A body patch is a list of all 3D
@@ -169,64 +199,37 @@ class PlanarSceneGraphVisualizer(PyPlotVisualizer):
         self._patch_Blist = {}
         self._patch_Blist_colors = {}
 
-        memq_lcm = DrakeLcm("memq://")
-        memq_lcm_subscriber = Subscriber(lcm=memq_lcm,
-                                         channel="DRAKE_VIEWER_LOAD_ROBOT",
-                                         lcm_type=lcmt_viewer_load_robot)
-        # TODO(SeanCurtis-TRI): Use SceneGraph inspection instead of mocking
-        # LCM and inspecting the generated message.
-        DrakeVisualizer.DispatchLoadMessage(self._scene_graph, memq_lcm)
-        memq_lcm.HandleSubscriptions(0)
-        assert memq_lcm_subscriber.count > 0
-        load_robot_msg = memq_lcm_subscriber.message
+        for frame_id in inspector.all_frame_ids():
+            count = inspector.NumGeometriesForFrameWithRole(frame_id,
+                                                            Role.kIllustration)
+            if count == 0:
+                continue
 
-        # Spawn a random color generator, in case we need to pick random colors
-        # for some bodies. Each body will be given a unique color when using
-        # this random generator, with each visual element of the body colored
-        # the same.
-        color = iter(plt.cm.rainbow(np.linspace(0, 1,
-                                                load_robot_msg.num_links)))
-
-        for i in range(load_robot_msg.num_links):
-            link = load_robot_msg.link[i]
+            frame_name = self.frame_name(frame_id, inspector)
 
             this_body_patches = []
             this_body_colors = []
-            this_color = next(color)
 
-            for j in range(link.num_geom):
-                geom = link.geom[j]
-                # MultibodyPlant currently sets alpha=0 to make collision
-                # geometry "invisible".  Ignore those geometries here.
-                if geom.color[3] == 0:
-                    continue
+            for g_id in inspector.GetGeometries(frame_id, Role.kIllustration):
+                X_BG = inspector.GetPoseInFrame(g_id)
+                shape = inspector.GetShape(g_id)
 
-                # Short-circuit if the geometry scale is invalid.
-                # (All uses of float data should be strictly positive:
-                # edge lengths for boxes, radius and length for
-                # spheres and cylinders, and scaling for meshes.)
-                if not all([x > 0 for x in geom.float_data]):
-                    continue
-
-                X_BG = RigidTransform(
-                    RotationMatrix(Quaternion(geom.quaternion)),
-                    geom.position)
-
-                if geom.type == geom.BOX:
-                    assert geom.num_float_data == 3
-
+                if isinstance(shape, Box):
                     # Draw a bounding box.
                     patch_G = np.vstack((
-                        geom.float_data[0]/2.*np.array(
+                        shape.width()/2.*np.array(
                             [-1, -1, 1, 1, -1, -1, 1, 1]),
-                        geom.float_data[1]/2.*np.array(
+                        shape.depth()/2.*np.array(
                             [-1, 1, -1, 1, -1, 1, -1, 1]),
-                        geom.float_data[2]/2.*np.array(
+                        shape.height()/2.*np.array(
                             [-1, -1, -1, -1, 1, 1, 1, 1])))
 
-                elif geom.type == geom.SPHERE:
-                    assert geom.num_float_data == 1
-                    radius = geom.float_data[0]
+                elif isinstance(shape, Sphere):
+                    # Sphere is the only shape that allows a zero-measure. A
+                    # zero-radius sphere is a point, and we skip it.
+                    if shape.radius() == 0:
+                        continue
+
                     lati, longi = np.meshgrid(np.arange(0., 2.*math.pi, 0.5),
                                               np.arange(0., 2.*math.pi, 0.5))
                     lati = lati.ravel()
@@ -235,12 +238,11 @@ class PlanarSceneGraphVisualizer(PyPlotVisualizer):
                         np.sin(lati)*np.cos(longi),
                         np.sin(lati)*np.sin(longi),
                         np.cos(lati)])
-                    patch_G *= radius
+                    patch_G *= shape.radius()
 
-                elif geom.type == geom.CYLINDER:
-                    assert geom.num_float_data == 2
-                    radius = geom.float_data[0]
-                    length = geom.float_data[1]
+                elif isinstance(shape, Cylinder):
+                    radius = shape.radius()
+                    length = shape.length()
 
                     # In the lcm geometry, cylinders are along +z
                     # https://github.com/RobotLocomotion/drake/blob/last_sha_with_original_matlab/drake/matlab/systems/plants/RigidBodyCylinder.m
@@ -256,8 +258,8 @@ class PlanarSceneGraphVisualizer(PyPlotVisualizer):
                              length/2.]]).T
                          for pt in sample_pts])
 
-                elif geom.type == geom.MESH:
-                    filename = geom.string_data
+                elif isinstance(shape, (Mesh, Convex)):
+                    filename = shape.filename()
                     base, ext = os.path.splitext(filename)
                     if (ext.lower() != ".obj"
                             and substitute_collocated_mesh_files):
@@ -275,7 +277,7 @@ class PlanarSceneGraphVisualizer(PyPlotVisualizer):
                         raise FileNotFoundError(errno.ENOENT, os.strerror(
                             errno.ENOENT), filename)
                     # Get mesh scaling.
-                    scale = geom.float_data[0]
+                    scale = shape.scale()
                     mesh = ReadObjToSurfaceMesh(filename, scale)
                     patch_G = np.vstack([v.r_MV() for v in mesh.vertices()])
                     # Only store the vertices of the (3D) convex hull of the
@@ -286,9 +288,23 @@ class PlanarSceneGraphVisualizer(PyPlotVisualizer):
                     patch_G = np.vstack(
                         [patch_G[v, :] for v in hull.vertices]).T
 
+                elif isinstance(shape, HalfSpace):
+                    # For a half space, we'll simply create a large box with
+                    # the top face at z = 0, the bottom face at z = -1 and the
+                    # far corners at +/- 50 in the x- and y- directions.
+                    x = 50
+                    y = 50
+                    z = -1
+                    patch_G = np.vstack((
+                        x * np.array([-1, -1,  1,  1, -1, -1,  1, 1]),
+                        y * np.array([-1,  1, -1,  1, -1,  1, -1, 1]),
+                        z * np.array([-1, -1, -1, -1,  0,  0,  0, 0])))
+
+                # TODO(SeanCurtis-TRI): Provide support for capsule and
+                # ellipsoid.
                 else:
                     print("UNSUPPORTED GEOMETRY TYPE {} IGNORED".format(
-                        geom.type))
+                        type(shape)))
                     continue
 
                 # Compute pose in body.
@@ -299,13 +315,29 @@ class PlanarSceneGraphVisualizer(PyPlotVisualizer):
                     patch_B = np.hstack((patch_B, patch_B[:, 0][np.newaxis].T))
 
                 this_body_patches.append(patch_B)
-                if use_random_colors:
-                    this_body_colors.append(this_color)
-                else:
-                    this_body_colors.append(geom.color)
+                if not use_random_colors:
+                    # If we need to use random colors, we apply them after the
+                    # fact. See below.
+                    props = inspector.GetIllustrationProperties(g_id)
+                    assert props is not None
+                    rgba = props.GetPropertyOrDefault(
+                        "phong", "diffuse",  Rgba(0.9, 0.9, 0.9, 1.0))
+                    color = np.array((rgba.r(), rgba.g(), rgba.b(), rgba.a()))
+                    this_body_colors.append(color)
 
-            self._patch_Blist[link.name] = this_body_patches
-            self._patch_Blist_colors[link.name] = this_body_colors
+            self._patch_Blist[frame_name] = this_body_patches
+            self._patch_Blist_colors[frame_name] = this_body_colors
+
+        # Spawn a random color generator. Each body will be given a unique
+        # color when using this random generator, with each visual element of
+        # the body colored the same.
+        if use_random_colors:
+            color = iter(plt.cm.rainbow(
+                np.linspace(0, 1, len(self._patch_Blist_colors))))
+            for name in self._patch_Blist_colors.keys():
+                this_color = next(color)
+                patch_count = len(self._patch_Blist[name])
+                self._patch_Blist_colors[name] = [this_color] * patch_count
 
     def _get_view_patches(self, full_name, X_WB):
         """
@@ -359,6 +391,44 @@ class PlanarSceneGraphVisualizer(PyPlotVisualizer):
 
     def draw(self, context):
         """Overrides base with the implementation."""
+        if self._pose_bundle_port.HasValue(context):
+            self._draw_deprecated(context)
+        else:
+            self._draw(context)
+
+    def _draw(self, context):
+        query_object = self._geometry_query_input_port.Eval(context)
+        inspector = query_object.inspector()
+
+        view_dir = np.cross(self._T_VW[0, :3], self._T_VW[1, :3])
+        for frame_id in inspector.all_frame_ids():
+            frame_name = self.frame_name(frame_id, inspector)
+            if frame_name not in self._patch_Blist:
+                continue
+            X_WB = query_object.GetPoseInWorld(frame_id)
+
+            patch_Wlist, _ = self._get_view_patches(frame_name, X_WB)
+            for i, patch_W in enumerate(patch_Wlist):
+                # Project the object vertices from 3d in world frame W to 2d in
+                # view frame V (keeps homogeneous portion, removing it later).
+                patch_V = self._project_patch(patch_W)
+                body_fill = self._body_fill_dict[frame_name][i]
+                # Use the latest vertices to update the body_fill.
+                self._update_body_fill_verts(body_fill, patch_V)
+                body_fill.zorder = X_WB.translation() @ view_dir
+        self.ax.set_title('t = {:.1f}'.format(context.get_time()))
+
+    # (2021-11-01) Deprecated.
+    def _draw_deprecated(self, context):
+        """Drawing via the deprecated PoseBundle mechanism"""
+        if not self._warned_pose_bundle_input_port_connected:
+            _warn_deprecated(
+                "The pose_bundle input port is deprecated.  Use e.g.\n"
+                "builder.Connect("
+                "scene_graph.get_query_output_port(), "
+                "visualizer.get_geometry_query_input_port())\n"
+                "instead.", date="2021-11-01")
+            self._warned_pose_bundle_input_port_connected = True
 
         pose_bundle = self._pose_bundle_port.Eval(context)
         view_dir = np.cross(self._T_VW[0, :3], self._T_VW[1, :3])
@@ -366,7 +436,6 @@ class PlanarSceneGraphVisualizer(PyPlotVisualizer):
             # SceneGraph currently sets the name in PoseBundle as
             #    "get_source_name::frame_name".
             full_name = pose_bundle.get_name(frame_i)
-            model_id = pose_bundle.get_model_instance_id(frame_i)
 
             X_WB = pose_bundle.get_transform(frame_i)
             patch_Wlist, _ = self._get_view_patches(full_name, X_WB)
@@ -396,7 +465,7 @@ def ConnectPlanarSceneGraphVisualizer(builder,
             visualized.
         output_port: (optional) If not None, then output_port will be connected
             to the visualizer input port instead of the scene_graph.
-            get_pose_bundle_output_port().  This is required, for instance,
+            get_query_output_port().  This is required, for instance,
             when the SceneGraph is inside a Diagram, and we must connect the
             exposed port to the visualizer instead of the original SceneGraph
             port.
@@ -407,9 +476,18 @@ def ConnectPlanarSceneGraphVisualizer(builder,
     Returns:
         The newly created PlanarSceneGraphVisualizer object.
     """
-    if output_port is None:
-        output_port = scene_graph.get_pose_bundle_output_port()
     visualizer = builder.AddSystem(
         PlanarSceneGraphVisualizer(scene_graph, **kwargs))
-    builder.Connect(output_port, visualizer.get_input_port(0))
+
+    if output_port and isinstance(output_port.Allocate().get_value(),
+                                  PoseBundle):
+        # (2021-11-01): Remove this code path on deprecation of the pose_bundle
+        # api.
+        builder.Connect(output_port, visualizer.get_input_port(0))
+        return visualizer
+
+    if output_port is None:
+        output_port = scene_graph.get_query_output_port()
+
+    builder.Connect(output_port, visualizer.get_geometry_query_input_port())
     return visualizer

--- a/bindings/pydrake/systems/test/planar_scenegraph_visualizer_test.py
+++ b/bindings/pydrake/systems/test/planar_scenegraph_visualizer_test.py
@@ -4,6 +4,7 @@ import numpy as np
 import os
 
 from pydrake.common import FindResourceOrThrow
+from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 from pydrake.geometry import Box, Mesh
 from pydrake.math import RigidTransform
 from pydrake.multibody.parsing import Parser
@@ -28,8 +29,8 @@ class TestPlanarSceneGraphVisualizer(unittest.TestCase):
         self.assertTrue(cart_pole.geometry_source_is_registered())
 
         visualizer = builder.AddSystem(PlanarSceneGraphVisualizer(scene_graph))
-        builder.Connect(scene_graph.get_pose_bundle_output_port(),
-                        visualizer.get_input_port(0))
+        builder.Connect(scene_graph.get_query_output_port(),
+                        visualizer.get_geometry_query_input_port())
 
         diagram = builder.Build()
 
@@ -69,8 +70,8 @@ class TestPlanarSceneGraphVisualizer(unittest.TestCase):
         kuka.GetFrameByName("iiwa_link_6", iiwa)
 
         visualizer = builder.AddSystem(PlanarSceneGraphVisualizer(scene_graph))
-        builder.Connect(scene_graph.get_pose_bundle_output_port(),
-                        visualizer.get_input_port(0))
+        builder.Connect(scene_graph.get_query_output_port(),
+                        visualizer.get_geometry_query_input_port())
 
         diagram = builder.Build()
 
@@ -118,8 +119,8 @@ class TestPlanarSceneGraphVisualizer(unittest.TestCase):
         mbp.Finalize()
 
         visualizer = builder.AddSystem(PlanarSceneGraphVisualizer(scene_graph))
-        builder.Connect(scene_graph.get_pose_bundle_output_port(),
-                        visualizer.get_input_port(0))
+        builder.Connect(scene_graph.get_query_output_port(),
+                        visualizer.get_geometry_query_input_port())
 
         diagram = builder.Build()
 
@@ -201,19 +202,253 @@ class TestPlanarSceneGraphVisualizer(unittest.TestCase):
         Parser(plant=cart_pole).AddModelFromFile(file_name)
         cart_pole.Finalize()
 
-        visualizer = ConnectPlanarSceneGraphVisualizer(
+        # The function auto connects to the scene graph query object port.
+        vis_auto_connect = ConnectPlanarSceneGraphVisualizer(
             builder=builder, scene_graph=scene_graph, xlim=[0.3, 1.2])
-        self.assertIsInstance(visualizer, PlanarSceneGraphVisualizer)
+        self.assertIsInstance(vis_auto_connect, PlanarSceneGraphVisualizer)
         # Confirm that arguments are passed through.
-        self.assertEqual(visualizer.ax.get_xlim(), (0.3, 1.2))
+        self.assertEqual(vis_auto_connect.ax.get_xlim(), (0.3, 1.2))
 
-        vis2 = ConnectPlanarSceneGraphVisualizer(
+        # The function connects visualizer to provided query object port.
+        vis_port_connect = ConnectPlanarSceneGraphVisualizer(
+            builder=builder,
+            scene_graph=scene_graph,
+            output_port=scene_graph.get_query_output_port())
+        vis_port_connect.set_name("vis_port_connect")
+        self.assertIsInstance(vis_port_connect, PlanarSceneGraphVisualizer)
+
+        diagram = builder.Build()
+        diagram_context = diagram.CreateDefaultContext()
+        vis_auto_connect_context = diagram.GetMutableSubsystemContext(
+            vis_auto_connect, diagram_context)
+        vis_port_connect_context = diagram.GetMutableSubsystemContext(
+            vis_port_connect, diagram_context)
+
+        # Note: we can't simply call diagram.Publish(diagram_context) because
+        # the visualizer isn't set to be visible; as such, no drawing work
+        # will be done.
+        vis_auto_connect.draw(vis_auto_connect_context)
+        vis_port_connect.draw(vis_port_connect_context)
+
+
+# (2021-11-01) The simple copy of the tests which make use of the pose bundle
+# port. Simply delete this entire test fixture at the end of the deprecation
+# period.
+class TestPlanarSceneGraphVisualizerDeprecated(unittest.TestCase):
+    def test_cart_pole(self):
+        """Cart-Pole with simple geometry."""
+        file_name = FindResourceOrThrow(
+            "drake/examples/multibody/cart_pole/cart_pole.sdf")
+        builder = DiagramBuilder()
+        cart_pole, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.0)
+        Parser(plant=cart_pole).AddModelFromFile(file_name)
+        cart_pole.Finalize()
+        self.assertTrue(cart_pole.geometry_source_is_registered())
+
+        visualizer = builder.AddSystem(PlanarSceneGraphVisualizer(scene_graph))
+        builder.Connect(scene_graph.get_pose_bundle_output_port(),
+                        visualizer.get_input_port(0))
+
+        diagram = builder.Build()
+
+        diagram_context = diagram.CreateDefaultContext()
+        cart_pole_context = diagram.GetMutableSubsystemContext(
+            cart_pole, diagram_context)
+        vis_context = diagram.GetMutableSubsystemContext(
+            visualizer, diagram_context)
+
+        cart_pole.get_actuation_input_port().FixValue(cart_pole_context, 0)
+
+        cart_slider = cart_pole.GetJointByName("CartSlider")
+        pole_pin = cart_pole.GetJointByName("PolePin")
+        cart_slider.set_translation(context=cart_pole_context, translation=0.)
+        pole_pin.set_angle(context=cart_pole_context, angle=2.)
+
+        simulator = Simulator(diagram, diagram_context)
+        simulator.set_publish_every_time_step(False)
+        with catch_drake_warnings(expected_count=1):
+            simulator.AdvanceTo(.1)
+
+            visualizer.draw(vis_context)
+        self.assertEqual(visualizer.ax.get_title(), "t = 0.1",)
+
+    def test_kuka(self):
+        """Kuka IIWA with mesh geometry."""
+        file_name = FindResourceOrThrow(
+            "drake/manipulation/models/iiwa_description/sdf/"
+            "iiwa14_no_collision.sdf")
+        builder = DiagramBuilder()
+        kuka, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.0)
+        Parser(plant=kuka).AddModelFromFile(file_name)
+        kuka.Finalize()
+
+        # Make sure that the frames to visualize exist.
+        iiwa = kuka.GetModelInstanceByName("iiwa14")
+        kuka.GetFrameByName("iiwa_link_7", iiwa)
+        kuka.GetFrameByName("iiwa_link_6", iiwa)
+
+        visualizer = builder.AddSystem(PlanarSceneGraphVisualizer(scene_graph))
+        builder.Connect(scene_graph.get_pose_bundle_output_port(),
+                        visualizer.get_input_port(0))
+
+        diagram = builder.Build()
+
+        diagram_context = diagram.CreateDefaultContext()
+        kuka_context = diagram.GetMutableSubsystemContext(
+            kuka, diagram_context)
+        vis_context = diagram.GetMutableSubsystemContext(
+            visualizer, diagram_context)
+
+        kuka_actuation_port = kuka.get_actuation_input_port()
+        kuka_actuation_port.FixValue(kuka_context,
+                                     np.zeros(kuka_actuation_port.size()))
+
+        simulator = Simulator(diagram, diagram_context)
+        simulator.set_publish_every_time_step(False)
+        with catch_drake_warnings(expected_count=1):
+            simulator.AdvanceTo(.1)
+
+            visualizer.draw(vis_context)
+        self.assertEqual(visualizer.ax.get_title(), "t = 0.1",)
+
+    def test_procedural_geometry(self):
+        """
+        This test ensures we can draw procedurally added primitive
+        geometry that is added to the world model instance (which has
+        a slightly different naming scheme than geometry with a
+        non-default / non-world model instance).
+        """
+        builder = DiagramBuilder()
+        mbp, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.0)
+        world_body = mbp.world_body()
+        box_shape = Box(1., 2., 3.)
+        # This rigid body will be added to the world model instance since
+        # the model instance is not specified.
+        box_body = mbp.AddRigidBody("box", SpatialInertia(
+            mass=1.0, p_PScm_E=np.array([0., 0., 0.]),
+            G_SP_E=UnitInertia(1.0, 1.0, 1.0)))
+        mbp.WeldFrames(world_body.body_frame(), box_body.body_frame(),
+                       RigidTransform())
+        mbp.RegisterVisualGeometry(
+            box_body, RigidTransform.Identity(), box_shape, "ground_vis",
+            np.array([0.5, 0.5, 0.5, 1.]))
+        mbp.RegisterCollisionGeometry(
+            box_body, RigidTransform.Identity(), box_shape, "ground_col",
+            CoulombFriction(0.9, 0.8))
+        mbp.Finalize()
+
+        visualizer = builder.AddSystem(PlanarSceneGraphVisualizer(scene_graph))
+        builder.Connect(scene_graph.get_pose_bundle_output_port(),
+                        visualizer.get_input_port(0))
+
+        diagram = builder.Build()
+
+        diagram_context = diagram.CreateDefaultContext()
+        vis_context = diagram.GetMutableSubsystemContext(
+            visualizer, diagram_context)
+
+        simulator = Simulator(diagram, diagram_context)
+        simulator.set_publish_every_time_step(False)
+        with catch_drake_warnings(expected_count=1):
+            simulator.AdvanceTo(.1)
+
+            visualizer.draw(vis_context)
+        self.assertEqual(visualizer.ax.get_title(), "t = 0.1",)
+
+    def test_mesh_file_parsing(self):
+        """
+        This test ensures we can load obj files or provide a reasonable error
+        message.
+        """
+        def scene_graph_with_mesh(filename, scale=1.0):
+            builder = DiagramBuilder()
+            mbp, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.0)
+            world_body = mbp.world_body()
+
+            mesh_shape = Mesh(filename, scale=scale)
+            mesh_body = mbp.AddRigidBody("mesh", SpatialInertia(
+                mass=1.0, p_PScm_E=np.array([0., 0., 0.]),
+                G_SP_E=UnitInertia(1.0, 1.0, 1.0)))
+            mbp.WeldFrames(world_body.body_frame(), mesh_body.body_frame(),
+                           RigidTransform())
+            mbp.RegisterVisualGeometry(
+                mesh_body, RigidTransform.Identity(), mesh_shape, "mesh_vis",
+                np.array([0.5, 0.5, 0.5, 1.]))
+            mbp.Finalize()
+
+            return scene_graph
+
+        # This mesh should load correctly.
+        mesh_name = FindResourceOrThrow(
+            "drake/manipulation/models/iiwa_description/meshes/visual/"
+            "link_0.obj")
+        scene_graph = scene_graph_with_mesh(mesh_name)
+        PlanarSceneGraphVisualizer(scene_graph)
+
+        # This should load correctly, too, by substituting the .obj.
+        mesh_name_wrong_ext = os.path.splitext(mesh_name)[0] + ".STL"
+        scene_graph = scene_graph_with_mesh(mesh_name_wrong_ext)
+        PlanarSceneGraphVisualizer(scene_graph)
+
+        # This should report that the file does not exist:
+        with self.assertRaises(FileNotFoundError):
+            PlanarSceneGraphVisualizer(
+                scene_graph, substitute_collocated_mesh_files=False)
+
+        # This should report that the file does not exist.
+        scene_graph = scene_graph_with_mesh("garbage.obj")
+        with self.assertRaises(FileNotFoundError):
+            PlanarSceneGraphVisualizer(scene_graph)
+
+        # This should report that the extension was wrong and no .obj was
+        # found.
+        scene_graph = scene_graph_with_mesh("garbage.STL")
+        with self.assertRaises(RuntimeError):
+            PlanarSceneGraphVisualizer(scene_graph)
+
+        # This should load correctly and yield a very large patch.
+        scene_graph = scene_graph_with_mesh(mesh_name, 1e3)
+        visualizer = PlanarSceneGraphVisualizer(scene_graph)
+        _, _, width, height = visualizer.ax.dataLim.bounds
+        self.assertTrue(width > 10.0)
+        self.assertTrue(height > 10.0)
+
+    def testConnectPlanarSceneGraphVisualizer(self):
+        """Cart-Pole with simple geometry."""
+        file_name = FindResourceOrThrow(
+            "drake/examples/multibody/cart_pole/cart_pole.sdf")
+        builder = DiagramBuilder()
+        cart_pole, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.0)
+        Parser(plant=cart_pole).AddModelFromFile(file_name)
+        cart_pole.Finalize()
+
+        # The visualizer will connect to query object and calling draw will not
+        # spawn any deprecation warnings.
+        vis_query_object = ConnectPlanarSceneGraphVisualizer(
+            builder=builder, scene_graph=scene_graph, xlim=[0.3, 1.2])
+        self.assertIsInstance(vis_query_object, PlanarSceneGraphVisualizer)
+        # Confirm that arguments are passed through.
+        self.assertEqual(vis_query_object.ax.get_xlim(), (0.3, 1.2))
+
+        # The visualizer will connect to the provided pose bundle port and
+        # calling draw will generate a warning.
+        vis_pose_bundle = ConnectPlanarSceneGraphVisualizer(
             builder=builder,
             scene_graph=scene_graph,
             output_port=scene_graph.get_pose_bundle_output_port())
-        vis2.set_name("vis2")
-        self.assertIsInstance(vis2, PlanarSceneGraphVisualizer)
+        vis_pose_bundle.set_name("vis_pose_bundle")
+        self.assertIsInstance(vis_pose_bundle, PlanarSceneGraphVisualizer)
 
         diagram = builder.Build()
-        context = diagram.CreateDefaultContext()
-        diagram.Publish(context)
+        diagram_context = diagram.CreateDefaultContext()
+        vis_query_object_context = diagram.GetMutableSubsystemContext(
+            vis_query_object, diagram_context)
+        vis_pose_bundle_context = diagram.GetMutableSubsystemContext(
+            vis_pose_bundle, diagram_context)
+
+        # Note: we can't simply call diagram.Publish(diagram_context) because
+        # the visualizer isn't set to be visible; as such, no drawing work
+        # will be done.
+        vis_query_object.draw(vis_query_object_context)
+        with catch_drake_warnings(expected_count=1):
+            vis_pose_bundle.draw(vis_pose_bundle_context)

--- a/examples/manipulation_station/joint_teleop.py
+++ b/examples/manipulation_station/joint_teleop.py
@@ -19,7 +19,7 @@ from pydrake.systems.analysis import Simulator
 from pydrake.systems.meshcat_visualizer import MeshcatVisualizer
 from pydrake.systems.primitives import FirstOrderLowPassFilter, SignalLogger
 from pydrake.systems.planar_scenegraph_visualizer import \
-    PlanarSceneGraphVisualizer
+    ConnectPlanarSceneGraphVisualizer
 
 
 def main():
@@ -78,19 +78,17 @@ def main():
 
         station.Finalize()
 
-        DrakeVisualizer.AddToBuilder(builder,
-                                     station.GetOutputPort("query_object"))
+        geometry_query_port = station.GetOutputPort("geometry_query")
+        DrakeVisualizer.AddToBuilder(builder, geometry_query_port)
         if args.meshcat:
             meshcat = ConnectMeshcatVisualizer(
-                builder, output_port=station.GetOutputPort("geometry_query"),
+                builder, output_port=geometry_query_port,
                 zmq_url=args.meshcat, open_browser=args.open_browser)
             if args.setup == 'planar':
                 meshcat.set_planar_viewpoint()
         if args.setup == 'planar':
-            pyplot_visualizer = builder.AddSystem(PlanarSceneGraphVisualizer(
-                station.get_scene_graph()))
-            builder.Connect(station.GetOutputPort("pose_bundle"),
-                            pyplot_visualizer.get_input_port(0))
+            pyplot_visualizer = ConnectPlanarSceneGraphVisualizer(
+                builder, station.get_scene_graph(), geometry_query_port)
 
     teleop = builder.AddSystem(JointSliders(station.get_controller_plant(),
                                             length=800))

--- a/manipulation/util/show_model.py
+++ b/manipulation/util/show_model.py
@@ -62,7 +62,7 @@ from pydrake.systems.framework import DiagramBuilder
 from pydrake.systems.meshcat_visualizer import (
     ConnectMeshcatVisualizer, MeshcatVisualizer)
 from pydrake.systems.planar_scenegraph_visualizer import (
-    PlanarSceneGraphVisualizer,
+    ConnectPlanarSceneGraphVisualizer,
 )
 
 
@@ -136,7 +136,7 @@ def add_visualizers_argparse_arguments(args_parser):
 
 def parse_visualizers(args_parser, args):
     """
-    Parses argparse arguments for visualizers, returning update_visulization
+    Parses argparse arguments for visualizers, returning update_visualization
     and connect_visualizers.
     """
 
@@ -166,9 +166,7 @@ def parse_visualizers(args_parser, args):
 
         # Connect to PyPlot.
         if args.pyplot:
-            pyplot = builder.AddSystem(PlanarSceneGraphVisualizer(scene_graph))
-            builder.Connect(scene_graph.get_pose_bundle_output_port(),
-                            pyplot.get_input_port(0))
+            pyplot = ConnectPlanarSceneGraphVisualizer(builder, scene_graph)
 
     return update_visualization, connect_visualizers
 

--- a/tutorials/pyplot_animation_multibody_plant.ipynb
+++ b/tutorials/pyplot_animation_multibody_plant.ipynb
@@ -94,7 +94,7 @@
     "from pydrake.systems.analysis import Simulator\n",
     "from pydrake.systems.framework import DiagramBuilder\n",
     "from pydrake.systems.planar_scenegraph_visualizer import (\n",
-    "    PlanarSceneGraphVisualizer)"
+    "    ConnectPlanarSceneGraphVisualizer)"
    ]
   },
   {
@@ -127,14 +127,12 @@
     "        \"drake/examples/pendulum/Pendulum.urdf\"))\n",
     "    plant.Finalize()\n",
     "\n",
-    "    pose_bundle_output_port = scene_graph.get_pose_bundle_output_port()\n",
     "    T_VW = np.array([[1., 0., 0., 0.],\n",
     "                     [0., 0., 1., 0.],\n",
     "                     [0., 0., 0., 1.]])\n",
-    "    visualizer = builder.AddSystem(PlanarSceneGraphVisualizer(\n",
-    "        scene_graph, T_VW=T_VW,\n",
-    "        xlim=[-1.2, 1.2], ylim=[-1.2, 1.2], show=show))\n",
-    "    builder.Connect(pose_bundle_output_port, visualizer.get_input_port(0))\n",
+    "    visualizer = ConnectPlanarSceneGraphVisualizer(\n",
+    "        builder, scene_graph, T_VW=T_VW, xlim=[-1.2, 1.2],\n",
+    "        ylim=[-1.2, 1.2], show=show)\n",
     "    if playback:\n",
     "        visualizer.start_recording()\n",
     "\n",


### PR DESCRIPTION
The planar visualizer had previously used a hackneyed approach to visualize. It would generate a `DrakeVisualizer` lcm message for loading and consume pose bundle for updating poses. This updates it to make use of the `SceneGraphInspector` and `QueryObject` for those tasks (akin to what meshcat visualizer does).

This is done in a deprecated, backwards-compatible way. The old spelling will still work, but if the visualizer is connected to a `PoseBundle`-valued port, the first call to `draw()` will dispatch a deprecation warning.

This lead to the following ancillary changes:
  - All uses of `PlanarSceneGraphVisualizer` in Drake have been updated to use the new API (in fact, they've been updated to prefer using `ConnectPlanarSceneGraphVisualizer`).
  - The old unit tests have simply been copied wholesale. One test fixture is based on the new implementation, the other, labeled "Deprecated" on the old.
    - This also led to a change in the test for `ConnectPlanar...` The old test called `diagram.Publish(context)` on a diagram containing visualizers. However, those visualizers had their `_show` flag set to `False`, so no drawing work was actually being done. The test has been reformulated to really test the drawing logic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15456)
<!-- Reviewable:end -->
