### PR TITLE
py mp: Fix docstring spelling for forwarded module

### DIFF
--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -1844,6 +1844,9 @@ Bindings for MathematicalProgram
 If you are formulating constraints using symbolic formulas, please review the
 top-level documentation for :py:mod:`pydrake.math`.
 )""";
+  // N.B. Only necessary for forwarding module for deprecation, to ensure
+  // docstrings from pybind11 use the corerct module spelling.
+  m.attr("__name__") = "pydrake.solvers.mathematicalprogram";
 
   py::module::import("pydrake.autodiffutils");
   py::module::import("pydrake.symbolic");

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -1,5 +1,5 @@
 from pydrake.solvers import mathematicalprogram as mp
-import pydrake.solvers._mathematicalprogram._testing as mp_testing
+import pydrake.solvers.mathematicalprogram._testing as mp_testing
 from pydrake.solvers.gurobi import GurobiSolver
 from pydrake.solvers.snopt import SnoptSolver
 from pydrake.solvers.scs import ScsSolver


### PR DESCRIPTION
Follow-up fix to #15409

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15457)
<!-- Reviewable:end -->
