### PR TITLE
[framework] Use static_cast (not dynamic_cast) in hot path

### DIFF
--- a/systems/framework/diagram.cc
+++ b/systems/framework/diagram.cc
@@ -995,10 +995,20 @@ template <typename T>
 const AbstractValue* Diagram<T>::EvalConnectedSubsystemInputPort(
     const ContextBase& context_base,
     const InputPortBase& input_port_base) const {
+  // Profiling revealed that it is too expensive to do a dynamic_cast here.
+  // A static_cast is safe as long we validate the SystemId, so that we know
+  // this Context is ours. Proving that our caller would have already checked
+  // the SystemId is too complicated, so we'll always just check ourselves.
+  this->ValidateContext(context_base);
   auto& diagram_context =
-      dynamic_cast<const DiagramContext<T>&>(context_base);
+      static_cast<const DiagramContext<T>&>(context_base);
+
+  // Profiling revealed that it is too expensive to do a dynamic_cast here.
+  // A static_cast is safe as long as the given input_port_base was actually
+  // an InputPort<T>, and since our sole caller is SystemBase which always
+  // retrieves the input_port_base from `this`, the <T> must be correct.
   auto& system =
-      dynamic_cast<const System<T>&>(input_port_base.get_system_interface());
+      static_cast<const System<T>&>(input_port_base.get_system_interface());
   const InputPortLocator id{&system, input_port_base.get_index()};
 
   // Find if this input port is exported (connected to an input port of this

--- a/systems/framework/framework_common.h
+++ b/systems/framework/framework_common.h
@@ -224,16 +224,6 @@ class SystemParentServiceInterface {
  public:
   virtual ~SystemParentServiceInterface() = default;
 
-  // This method is invoked when we need to evaluate a connected input port of
-  // a child subsystem of this System. This need arises only if this System
-  // contains subsystems, and the framework promises only to invoke this method
-  // under that circumstance. Hence Diagram must implement this to evaluate the
-  // connected-to output port (likely belonging to a different child subsystem)
-  // and returning its value as the value for the given input port.
-  virtual const AbstractValue* EvalConnectedSubsystemInputPort(
-      const ContextBase& context,
-      const InputPortBase& input_port) const = 0;
-
   // Generates and returns the full path name of the parent subsystem, starting
   // at the root of the containing Diagram, with path name separators between
   // segments. The returned string must be what would be returned by invoking
@@ -248,6 +238,20 @@ class SystemParentServiceInterface {
  protected:
   SystemParentServiceInterface() = default;
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SystemParentServiceInterface);
+
+ private:
+  friend class ::drake::systems::SystemBase;
+
+  // This method is invoked when we need to evaluate a connected input port of
+  // a child subsystem of this System. This need arises only if this System
+  // contains subsystems, and the framework promises only to invoke this method
+  // under that circumstance. Hence Diagram must implement this to evaluate the
+  // connected-to output port (likely belonging to a different child subsystem)
+  // and returning its value as the value for the given input port.
+  // @pre The given `input_port` must use same scalar type `T` as `this`.
+  virtual const AbstractValue* EvalConnectedSubsystemInputPort(
+      const ContextBase& context,
+      const InputPortBase& input_port) const = 0;
 };
 
 // These dependency ticket numbers are common to all systems and contexts so


### PR DESCRIPTION
Towards #15421.  (This is the last of the hot spots that I've found to date.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15470)
<!-- Reviewable:end -->
