### PR TITLE
[solvers] Remove redundant free in MosekSolver

### DIFF
--- a/solvers/mosek_solver.cc
+++ b/solvers/mosek_solver.cc
@@ -1920,7 +1920,6 @@ void MosekSolver::DoSolve(const MathematicalProgram& prog,
   // MSK_linkfiletotaskstream. Otherwise we might create the log file but cannot
   // close it.
   if (print_to_console && print_to_file) {
-    MSK_deletetask(&task);
     throw std::runtime_error(
         "MosekSolver::Solve(): cannot print to both the console and the log "
         "file.");


### PR DESCRIPTION
We should only call MSK_deletetask once. The second time is a no-op, which misleads to the reader.