### PR TITLE
[solvers] Implement Display for ExpressionConstraint

### DIFF
--- a/solvers/constraint.cc
+++ b/solvers/constraint.cc
@@ -509,6 +509,11 @@ void ExpressionConstraint::DoEval(
   }
 }
 
+std::ostream& ExpressionConstraint::DoDisplay(
+    std::ostream& os, const VectorX<symbolic::Variable>& vars) const {
+  return DisplayConstraint(*this, os, "ExpressionConstraint", vars, false);
+}
+
 ExponentialConeConstraint::ExponentialConeConstraint(
     const Eigen::Ref<const Eigen::SparseMatrix<double>>& A,
     const Eigen::Ref<const Eigen::Vector3d>& b)

--- a/solvers/constraint.h
+++ b/solvers/constraint.h
@@ -962,6 +962,9 @@ class ExpressionConstraint : public Constraint {
   void DoEval(const Eigen::Ref<const VectorX<symbolic::Variable>>& x,
               VectorX<symbolic::Expression>* y) const override;
 
+  std::ostream& DoDisplay(std::ostream&,
+                          const VectorX<symbolic::Variable>&) const override;
+
  private:
   VectorX<symbolic::Expression> expressions_{0};
   MatrixX<symbolic::Expression> derivatives_{0, 0};

--- a/solvers/test/constraint_test.cc
+++ b/solvers/test/constraint_test.cc
@@ -102,7 +102,7 @@ GTEST_TEST(testConstraint, testQuadraticConstraintHessian) {
   EXPECT_TRUE(CompareMatrices(constraint1.b(), b));
   std::ostringstream os;
   constraint1.Display(os, symbolic::MakeVectorContinuousVariable(2, "x"));
-  EXPECT_EQ(fmt::format("{}", os.str()),
+  EXPECT_EQ(os.str(),
             "QuadraticConstraint\n"
             "0 <= (x(0) + 2 * x(1) + 0.5 * pow(x(0), 2) + 0.5 * pow(x(1), 2)) "
             "<= 1\n");
@@ -438,6 +438,13 @@ GTEST_TEST(testConstraint, testExpressionConstraint) {
   ASSERT_EQ(expressions.size(), 2);
   EXPECT_TRUE(e[0].EqualTo(expressions[0]));
   EXPECT_TRUE(e[1].EqualTo(expressions[1]));
+
+  std::ostringstream os;
+  constraint.Display(os, vars);
+  EXPECT_EQ(os.str(),
+            "ExpressionConstraint\n"
+            "0 <= (1 + pow(x0, 2)) <= 2\n"
+            "0 <= (x2 + pow(x1, 2)) <= 2\n");
 
   const Vector3d x{.2, .4, .6};
   VectorXd y;


### PR DESCRIPTION
Before Display(ExpressionConstraint) would output
```
ExpressionConstraint with 3 decision variables x0 x1 x2
```

Now we can get beautiful output like:
```
ExpressionConstraint
0 <= (1 + pow(x0, 2)) <= 2
0 <= (x2 + pow(x1, 2)) <= 2
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15472)
<!-- Reviewable:end -->
