### PR TITLE
[geometry/optimization] Adds IrisInConfigurationSpace

### DIFF
--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -61,6 +61,10 @@ drake_cc_library(
     hdrs = ["iris.h"],
     deps = [
         ":convex_set",
+        "//geometry:scene_graph",
+        "//multibody/plant",
+        "//solvers:ipopt_solver",
+        "//solvers:snopt_solver",
     ],
 )
 
@@ -116,6 +120,8 @@ drake_cc_googletest(
     deps = [
         ":iris",
         "//common/test_utilities:eigen_matrix_compare",
+        "//multibody/parsing:parser",
+        "//systems/framework:diagram_builder",
     ],
 )
 

--- a/geometry/optimization/iris.cc
+++ b/geometry/optimization/iris.cc
@@ -1,12 +1,18 @@
 #include "drake/geometry/optimization/iris.h"
 
 #include <algorithm>
+#include <limits>
 #include <optional>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
 
 #include "drake/geometry/optimization/convex_set.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/solvers/choose_best_solver.h"
+#include "drake/solvers/ipopt_solver.h"
+#include "drake/solvers/snopt_solver.h"
 
 namespace drake {
 namespace geometry {
@@ -14,7 +20,9 @@ namespace optimization {
 
 using Eigen::MatrixXd;
 using Eigen::Ref;
+using Eigen::Vector3d;
 using Eigen::VectorXd;
+using symbolic::Expression;
 
 HPolyhedron Iris(const ConvexSets& obstacles, const Ref<const VectorXd>& sample,
                  const HPolyhedron& domain, const IrisOptions& options) {
@@ -106,43 +114,47 @@ class IrisConvexSetMaker final : public ShapeReifier {
                      std::optional<FrameId> reference_frame)
       : query_{query}, reference_frame_{reference_frame} {};
 
+  void set_reference_frame(const FrameId& reference_frame) {
+    DRAKE_DEMAND(reference_frame.is_valid());
+    *reference_frame_ = reference_frame;
+  }
+
+  void set_geometry_id(const GeometryId& geom_id) { geom_id_ = geom_id; }
+
   using ShapeReifier::ImplementGeometry;
 
   void ImplementGeometry(const Sphere&, void* data) {
-    GeometryId& geom_id = *static_cast<GeometryId*>(data);
-    sets_.emplace_back(
-        std::make_unique<Hyperellipsoid>(query_, geom_id, reference_frame_));
+    DRAKE_DEMAND(geom_id_.is_valid());
+    auto& set = *static_cast<copyable_unique_ptr<ConvexSet>*>(data);
+    set = std::make_unique<Hyperellipsoid>(query_, geom_id_, reference_frame_);
   }
 
   void ImplementGeometry(const HalfSpace&, void* data) {
-    GeometryId& geom_id = *static_cast<GeometryId*>(data);
-    sets_.emplace_back(
-        std::make_unique<HPolyhedron>(query_, geom_id, reference_frame_));
+    DRAKE_DEMAND(geom_id_.is_valid());
+    auto& set = *static_cast<copyable_unique_ptr<ConvexSet>*>(data);
+    set = std::make_unique<HPolyhedron>(query_, geom_id_, reference_frame_);
   }
 
   void ImplementGeometry(const Box&, void* data) {
-    GeometryId& geom_id = *static_cast<GeometryId*>(data);
+    DRAKE_DEMAND(geom_id_.is_valid());
+    auto& set = *static_cast<copyable_unique_ptr<ConvexSet>*>(data);
     // Note: We choose HPolyhedron over VPolytope here, but the IRIS paper
     // discusses a significant performance improvement using a "least-distance
     // programming" instance from CVXGEN that exploited the VPolytope
     // representation.  So we may wish to revisit this.
-    sets_.emplace_back(
-        std::make_unique<HPolyhedron>(query_, geom_id, reference_frame_));
+    set = std::make_unique<HPolyhedron>(query_, geom_id_, reference_frame_);
   }
 
   void ImplementGeometry(const Ellipsoid&, void* data) {
-    GeometryId& geom_id = *static_cast<GeometryId*>(data);
-    sets_.emplace_back(
-        std::make_unique<Hyperellipsoid>(query_, geom_id, reference_frame_));
+    DRAKE_DEMAND(geom_id_.is_valid());
+    auto& set = *static_cast<copyable_unique_ptr<ConvexSet>*>(data);
+    set = std::make_unique<Hyperellipsoid>(query_, geom_id_, reference_frame_);
   }
-
-  // This must be called last; it transfers ownership.
-  ConvexSets claim_sets() { return std::move(sets_); }
 
  private:
   const QueryObject<double>& query_{};
   std::optional<FrameId> reference_frame_{};
-  ConvexSets sets_{};
+  GeometryId geom_id_{};
 };
 
 }  // namespace
@@ -153,12 +165,205 @@ ConvexSets MakeIrisObstacles(const QueryObject<double>& query_object,
   const GeometrySet all_ids(inspector.GetAllGeometryIds());
   const std::unordered_set<GeometryId> geom_ids =
       inspector.GetGeometryIds(all_ids, Role::kProximity);
+  ConvexSets sets(geom_ids.size());
 
   IrisConvexSetMaker maker(query_object, reference_frame);
+  int count = 0;
   for (GeometryId geom_id : geom_ids) {
-    inspector.GetShape(geom_id).Reify(&maker, &geom_id);
+    maker.set_geometry_id(geom_id);
+    inspector.GetShape(geom_id).Reify(&maker, &sets[count++]);
   }
-  return maker.claim_sets();
+  return sets;
+}
+
+namespace {
+
+// Solves the optimization
+// min_q (q-d)*CᵀC(q-d)
+// s.t. setA on bodyA and setB on bodyB are in collision in q.
+//      Aq ≤ b.
+// where C, d are the center and matrix from the hyperellipsoid E.
+// Returns true iff a collision is found.
+// Sets `closest` to an optimizing solution q*, if a solution is found.
+bool FindClosestCollision(const multibody::MultibodyPlant<Expression>& plant,
+                          const multibody::Body<Expression>& bodyA,
+                          const multibody::Body<Expression>& bodyB,
+                          const ConvexSet& setA, const ConvexSet& setB,
+                          const Hyperellipsoid& E,
+                          const Eigen::Ref<const Eigen::MatrixXd>& A,
+                          const Eigen::Ref<const Eigen::VectorXd>& b,
+                          const solvers::SolverInterface& solver,
+                          systems::Context<Expression>* context,
+                          const Eigen::Ref<const Eigen::VectorXd>& q_guess,
+                          VectorXd* closest) {
+  solvers::MathematicalProgram prog;
+  auto q = prog.NewContinuousVariables(plant.num_positions(), "q");
+
+  prog.AddLinearConstraint(
+      A, VectorXd::Constant(b.size(), -std::numeric_limits<double>::infinity()),
+      b, q);
+  // Scale the objective so the eigenvalues are close to 1, using
+  // scale*lambda_min = 1/scale*lambda_max.
+  const MatrixXd Asq = E.A().transpose() * E.A();
+  Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> es(Asq);
+  const double scale = 1.0 / std::sqrt(es.eigenvalues().maxCoeff() *
+                                       es.eigenvalues().minCoeff());
+  prog.AddQuadraticErrorCost(scale * Asq, E.center(), q);
+
+  auto p_AA = prog.NewContinuousVariables<3>("p_AA");
+  auto p_BB = prog.NewContinuousVariables<3>("p_BB");
+  setA.AddPointInSetConstraints(&prog, p_AA);
+  setB.AddPointInSetConstraints(&prog, p_BB);
+
+  plant.SetPositions(context, q);
+  const math::RigidTransform<Expression>& X_WA =
+      plant.EvalBodyPoseInWorld(*context, bodyA);
+  const math::RigidTransform<Expression>& X_WB =
+      plant.EvalBodyPoseInWorld(*context, bodyB);
+  prog.AddConstraint(X_WA * p_AA.cast<Expression>() ==
+                     X_WB * p_BB.cast<Expression>());
+
+  // Help nonlinear optimizers (e.g. SNOPT) avoid trivial local minima at the
+  // origin.
+  prog.SetInitialGuess(q, q_guess);
+  prog.SetInitialGuess(p_AA, Vector3d::Constant(.01));
+  prog.SetInitialGuess(p_BB, Vector3d::Constant(.01));
+
+  solvers::MathematicalProgramResult result;
+  solver.Solve(prog, std::nullopt, std::nullopt, &result);
+  if (result.is_success()) {
+    *closest = result.GetSolution(q);
+    return true;
+  }
+  return false;
+}
+
+}  // namespace
+
+HPolyhedron IrisInConfigurationSpace(
+    const multibody::MultibodyPlant<double>& plant,
+    const systems::Context<double>& context,
+    const Eigen::Ref<const Eigen::VectorXd>& sample,
+    const IrisOptions& options) {
+  plant.ValidateContext(context);
+  const int nq = plant.num_positions();
+  DRAKE_DEMAND(sample.size() == nq);
+
+  // Note: We require finite joint limits to define the bounding box for the
+  // IRIS algorithm.
+  DRAKE_DEMAND(plant.GetPositionLowerLimits().array().isFinite().all());
+  DRAKE_DEMAND(plant.GetPositionUpperLimits().array().isFinite().all());
+  HPolyhedron P = HPolyhedron::MakeBox(plant.GetPositionLowerLimits(),
+                                       plant.GetPositionUpperLimits());
+  DRAKE_DEMAND(P.A().rows() == 2 * nq);
+
+  const double kEpsilonEllipsoid = 1e-2;
+  Hyperellipsoid E = Hyperellipsoid::MakeHypersphere(kEpsilonEllipsoid, sample);
+
+  std::unique_ptr<multibody::MultibodyPlant<symbolic::Expression>>
+      symbolic_plant = systems::System<double>::ToSymbolic(plant);
+
+  auto query_object =
+      plant.get_geometry_query_input_port().Eval<QueryObject<double>>(context);
+  const SceneGraphInspector<double>& inspector = query_object.inspector();
+
+  // Make all of the convex sets.
+  // TODO(russt): Consider factoring this out so that I don't have to redo the
+  // work for every new region.
+  IrisConvexSetMaker maker(query_object, inspector.world_frame_id());
+  std::unordered_map<GeometryId, copyable_unique_ptr<ConvexSet>> sets{};
+  std::unordered_map<GeometryId, const multibody::Body<Expression>&> bodies{};
+  const std::unordered_set<GeometryId> geom_ids = inspector.GetGeometryIds(
+      GeometrySet(inspector.GetAllGeometryIds()), Role::kProximity);
+  copyable_unique_ptr<ConvexSet> temp_set;
+  for (GeometryId geom_id : geom_ids) {
+    // Make all sets in the local geometry frame.
+    FrameId frame_id = inspector.GetFrameId(geom_id);
+    maker.set_reference_frame(frame_id);
+    maker.set_geometry_id(geom_id);
+    inspector.GetShape(geom_id).Reify(&maker, &temp_set);
+    sets.emplace(geom_id, std::move(temp_set));
+    bodies.emplace(geom_id, *symbolic_plant->GetBodyFromFrameId(frame_id));
+  }
+
+  // TODO(russt): As a surrogate for the true objective, we could use convex
+  // optimization to compute the (squared?) distance between each collision pair
+  // from the sample point configuration, then sort the pairs by that distance.
+  // This could improve computation times in Ibex here and produce regions with
+  // less faces.
+  auto pairs = inspector.GetCollisionCandidates();
+  const int N = static_cast<int>(pairs.size());
+
+  // On each iteration, we will build the collision-free polytope represented as
+  // {x | A * x <= b}.  Here we pre-allocate matrices with a generous maximum
+  // size.
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> A(
+      P.A().rows() + 2 * N, nq);
+  VectorXd b(P.A().rows() + 2 * N);
+  A.topRows(P.A().rows()) = P.A();
+  b.head(P.A().rows()) = P.b();
+
+  double best_volume = E.Volume();
+  int iteration = 0;
+  MatrixXd tangent_matrix;
+
+  auto solver = solvers::MakeFirstAvailableSolver(
+      {solvers::SnoptSolver::id(), solvers::IpoptSolver::id()});
+  auto symbolic_context = symbolic_plant->CreateDefaultContext();
+  VectorXd closest(nq);
+
+  while (true) {
+    tangent_matrix = 2.0 * E.A().transpose() * E.A();
+    int num_constraints = 2 * nq;  // Start with just the joint limits.
+    // Find separating hyperplanes
+    for (const auto [geomA, geomB] : pairs) {
+      while (true) {
+        const bool collision = FindClosestCollision(
+            *symbolic_plant, bodies.at(geomA), bodies.at(geomB),
+            *sets.at(geomA), *sets.at(geomB), E, A.topRows(num_constraints),
+            b.head(num_constraints), *solver, symbolic_context.get(), sample,
+            &closest);
+        if (collision) {
+          // Add the tangent to the (scaled) ellipsoid at this point as a
+          // constraint.
+          if (num_constraints >= A.rows()) {
+            // Increase pre-allocated polytope size.
+            A.conservativeResize(A.rows() + N, nq);
+            b.conservativeResize(b.rows() + N);
+          }
+
+          A.row(num_constraints) =
+              (tangent_matrix * (closest - E.center())).normalized();
+          b[num_constraints] = A.row(num_constraints) * closest -
+                               options.configuration_space_margin;
+          num_constraints++;
+        } else {
+          break;
+        }
+      }
+    }
+
+    if (options.require_sample_point_is_contained &&
+        ((A.topRows(num_constraints) * sample).array() >=
+         b.head(num_constraints).array())
+            .any()) {
+      break;
+    }
+    P = HPolyhedron(A.topRows(num_constraints), b.head(num_constraints));
+
+    iteration++;
+    if (iteration >= options.iteration_limit) {
+      break;
+    }
+
+    E = P.MaximumVolumeInscribedEllipsoid();
+    const double volume = E.Volume();
+    if (volume - best_volume <= options.termination_threshold) {
+      break;
+    }
+    best_volume = volume;
+  }
+  return P;
 }
 
 }  // namespace optimization

--- a/geometry/optimization/test/iris_test.cc
+++ b/geometry/optimization/test/iris_test.cc
@@ -7,6 +7,8 @@
 #include "drake/geometry/optimization/vpolytope.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/math/rigid_transform.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/systems/framework/diagram_builder.h"
 
 namespace drake {
 namespace geometry {
@@ -110,8 +112,7 @@ GTEST_TEST(IrisTest, BallInBox) {
 └─────┴─┴─────┘ */
 GTEST_TEST(IrisTest, MultipleBoxes) {
   ConvexSets obstacles;
-  obstacles.emplace_back(
-      VPolytope::MakeBox(Vector2d(.1, .5), Vector2d(1, 1)));
+  obstacles.emplace_back(VPolytope::MakeBox(Vector2d(.1, .5), Vector2d(1, 1)));
   obstacles.emplace_back(
       VPolytope::MakeBox(Vector2d(-1, -1), Vector2d(-.1, -.5)));
   obstacles.emplace_back(
@@ -230,6 +231,346 @@ TEST_F(SceneGraphTester, MultipleBoxes) {
   // We also expect it to elongate in z.
   EXPECT_TRUE(region.PointInSet(Vector3d(0.0, 0.0, 0.99)));
   EXPECT_TRUE(region.PointInSet(Vector3d(0.0, 0.0, -0.99)));
+}
+
+namespace {
+
+// Helper method for testing IrisInConfigurationSpace from a urdf string.
+HPolyhedron IrisFromUrdf(const std::string urdf,
+                         const Eigen::Ref<const Eigen::VectorXd>& sample,
+                         const IrisOptions& options) {
+  systems::DiagramBuilder<double> builder;
+  multibody::MultibodyPlant<double>& plant =
+      multibody::AddMultibodyPlantSceneGraph(&builder, 0.0);
+  multibody::Parser(&plant).AddModelFromString(urdf, "urdf");
+  plant.Finalize();
+  auto diagram = builder.Build();
+
+  auto context = diagram->CreateDefaultContext();
+  return IrisInConfigurationSpace(plant, plant.GetMyContextFromRoot(*context),
+                                  sample, options);
+}
+
+}  // namespace
+
+// One prismatic link with joint limits.  Iris should return the joint limits.
+GTEST_TEST(IrisInConfigurationSpaceTest, JointLimits) {
+  const std::string limits_urdf = R"(
+<robot name="limits">
+  <link name="movable">
+    <collision>
+      <geometry><box size="1 1 1"/></geometry>
+    </collision>
+  </link>
+  <joint name="movable" type="prismatic">
+    <axis xyz="1 0 0"/>
+    <limit lower="-2" upper="2"/>
+    <parent link="world"/>
+    <child link="movable"/>
+  </joint>
+</robot>
+)";
+
+  const Vector1d sample = Vector1d::Zero();
+  IrisOptions options;
+  HPolyhedron region = IrisFromUrdf(limits_urdf, sample, options);
+
+  EXPECT_EQ(region.ambient_dimension(), 1);
+
+  const double kTol = 1e-5;
+  const double qmin = -2.0, qmax = 2.0;
+  EXPECT_TRUE(region.PointInSet(Vector1d{qmin + kTol}));
+  EXPECT_TRUE(region.PointInSet(Vector1d{qmax - kTol}));
+  EXPECT_FALSE(region.PointInSet(Vector1d{qmin - kTol}));
+  EXPECT_FALSE(region.PointInSet(Vector1d{qmax + kTol}));
+}
+
+// Three boxes.  Two on the outside are fixed.  One in the middle on a prismatic
+// joint.  The configuration space is a (convex) line segment q ∈ (−1,1).
+GTEST_TEST(IrisInConfigurationSpaceTest, BoxesPrismatic) {
+  const std::string boxes_urdf = R"(
+<robot name="boxes">
+  <link name="fixed">
+    <collision name="right">
+      <origin rpy="0 0 0" xyz="2 0 0"/>
+      <geometry><box size="1 1 1"/></geometry>
+    </collision>
+    <collision name="left">
+      <origin rpy="0 0 0" xyz="-2 0 0"/>
+      <geometry><box size="1 1 1"/></geometry>
+    </collision>
+  </link>
+  <joint name="fixed_link_weld" type="fixed">
+    <parent link="world"/>
+    <child link="fixed"/>
+  </joint>
+  <link name="movable">
+    <collision name="center">
+      <geometry><box size="1 1 1"/></geometry>
+    </collision>
+  </link>
+  <joint name="movable" type="prismatic">
+    <axis xyz="1 0 0"/>
+    <limit lower="-2" upper="2"/>
+    <parent link="world"/>
+    <child link="movable"/>
+  </joint>
+</robot>
+)";
+
+  const Vector1d sample = Vector1d::Zero();
+  IrisOptions options;
+  HPolyhedron region = IrisFromUrdf(boxes_urdf, sample, options);
+
+  EXPECT_EQ(region.ambient_dimension(), 1);
+
+  const double kTol = 1e-5;
+  const double qmin = -1.0 + options.configuration_space_margin,
+               qmax = 1.0 - options.configuration_space_margin;
+  EXPECT_TRUE(region.PointInSet(Vector1d{qmin + kTol}));
+  EXPECT_TRUE(region.PointInSet(Vector1d{qmax - kTol}));
+  EXPECT_FALSE(region.PointInSet(Vector1d{qmin - kTol}));
+  EXPECT_FALSE(region.PointInSet(Vector1d{qmax + kTol}));
+}
+
+// Three spheres.  Two on the outside are fixed.  One in the middle on a
+// prismatic joint.  The configuration space is a (convex) line segment q ∈
+// (−1,1).
+GTEST_TEST(IrisInConfigurationSpaceTest, SpheresPrismatic) {
+  const std::string spheres_urdf = R"(
+<robot name="spheres">
+  <link name="fixed">
+    <collision name="right">
+      <origin rpy="0 0 0" xyz="2 0 0"/>
+      <geometry><sphere radius=".5"/></geometry>
+    </collision>
+    <collision name="left">
+      <origin rpy="0 0 0" xyz="-2 0 0"/>
+      <geometry><sphere radius=".5"/></geometry>
+    </collision>
+  </link>
+  <joint name="fixed_link_weld" type="fixed">
+    <parent link="world"/>
+    <child link="fixed"/>
+  </joint>
+  <link name="movable">
+    <collision name="center">
+      <geometry><sphere radius=".5"/></geometry>
+    </collision>
+  </link>
+  <joint name="movable" type="prismatic">
+    <axis xyz="1 0 0"/>
+    <limit lower="-2" upper="2"/>
+    <parent link="world"/>
+    <child link="movable"/>
+  </joint>
+</robot>
+)";
+
+  const Vector1d sample = Vector1d::Zero();
+  IrisOptions options;
+  HPolyhedron region = IrisFromUrdf(spheres_urdf, sample, options);
+
+  EXPECT_EQ(region.ambient_dimension(), 1);
+
+  const double kTol = 1e-5;
+  const double qmin = -1.0 + options.configuration_space_margin,
+               qmax = 1.0 - options.configuration_space_margin;
+  EXPECT_TRUE(region.PointInSet(Vector1d{qmin + kTol}));
+  EXPECT_TRUE(region.PointInSet(Vector1d{qmax - kTol}));
+  EXPECT_FALSE(region.PointInSet(Vector1d{qmin - kTol}));
+  EXPECT_FALSE(region.PointInSet(Vector1d{qmax + kTol}));
+}
+
+// A simple pendulum of length `l` with a sphere at the tip of radius `r`
+// between two (fixed) walls at `w` from the origin.  The configuration space
+// is a (convex) line segment q ∈ (sin⁻¹((-w+r)/l), sin((w-r)/l)).
+GTEST_TEST(IrisInConfigurationSpaceTest, SinglePendulum) {
+  const double l = 2.0;
+  const double r = .5;
+  const double w = 1.0;
+  const std::string pendulum_urdf = fmt::format(
+      R"(
+<robot name="pendulum">
+  <link name="fixed">
+    <collision name="right">
+      <origin rpy="0 0 0" xyz="{w_plus_one_half} 0 0"/>
+      <geometry><box size="1 1 10"/></geometry>
+    </collision>
+    <collision name="left">
+      <origin rpy="0 0 0" xyz="-{w_plus_one_half} 0 0"/>
+      <geometry><box size="1 1 10"/></geometry>
+    </collision>
+  </link>
+  <joint name="fixed_link_weld" type="fixed">
+    <parent link="world"/>
+    <child link="fixed"/>
+  </joint>
+  <link name="pendulum">
+    <collision name="ball">
+      <origin rpy="0 0 0" xyz="0 0 -{l}"/>
+      <geometry><sphere radius="{r}"/></geometry>
+    </collision>
+  </link>
+  <joint name="pendulum" type="revolute">
+    <axis xyz="0 1 0"/>
+    <limit lower="-1.57" upper="1.57"/>
+    <parent link="world"/>
+    <child link="pendulum"/>
+  </joint>
+</robot>
+)",
+      fmt::arg("w_plus_one_half", w + .5), fmt::arg("l", l), fmt::arg("r", r));
+
+  const Vector1d sample = Vector1d::Zero();
+  IrisOptions options;
+  HPolyhedron region = IrisFromUrdf(pendulum_urdf, sample, options);
+
+  EXPECT_EQ(region.ambient_dimension(), 1);
+
+  const double kTol = 1e-5;
+  const double qmin =
+                   std::asin((-w + r) / l) + options.configuration_space_margin,
+               qmax =
+                   std::asin((w - r) / l) - options.configuration_space_margin;
+  EXPECT_TRUE(region.PointInSet(Vector1d{qmin + kTol}));
+  EXPECT_TRUE(region.PointInSet(Vector1d{qmax - kTol}));
+  EXPECT_FALSE(region.PointInSet(Vector1d{qmin - kTol}));
+  EXPECT_FALSE(region.PointInSet(Vector1d{qmax + kTol}));
+}
+
+// A simple double pendulum with link lengths `l1` and `l2` with a sphere at the
+// tip of radius `r` between two (fixed) walls at `w` from the origin.  The
+// true configuration space is - w + r ≤ l₁s₁ + l₂s₁₊₂ ≤ w - r.  These regions
+// are visualized at https://www.desmos.com/calculator/ff0hbnkqhm.
+GTEST_TEST(IrisInConfigurationSpaceTest, DoublePendulum) {
+  const double l1 = 2.0;
+  const double l2 = 1.0;
+  const double r = .5;
+  const double w = 1.83;
+  const std::string double_pendulum_urdf = fmt::format(
+      R"(
+<robot name="double_pendulum">
+  <link name="fixed">
+    <collision name="right">
+      <origin rpy="0 0 0" xyz="{w_plus_one_half} 0 0"/>
+      <geometry><box size="1 1 10"/></geometry>
+    </collision>
+    <collision name="left">
+      <origin rpy="0 0 0" xyz="-{w_plus_one_half} 0 0"/>
+      <geometry><box size="1 1 10"/></geometry>
+    </collision>
+  </link>
+  <joint name="fixed_link_weld" type="fixed">
+    <parent link="world"/>
+    <child link="fixed"/>
+  </joint>
+  <link name="link1"/>
+  <joint name="joint1" type="revolute">
+    <axis xyz="0 1 0"/>
+    <limit lower="-1.57" upper="1.57"/>
+    <parent link="world"/>
+    <child link="link1"/>
+  </joint>
+  <link name="link2">
+    <collision name="ball">
+      <origin rpy="0 0 0" xyz="0 0 -{l2}"/>
+      <geometry><sphere radius="{r}"/></geometry>
+    </collision>
+  </link>
+  <joint name="joint2" type="revolute">
+    <origin rpy="0 0 0" xyz="0 0 -{l1}"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-1.57" upper="1.57"/>
+    <parent link="link1"/>
+    <child link="link2"/>
+  </joint>
+</robot>
+)",
+      fmt::arg("w_plus_one_half", w + .5), fmt::arg("l1", l1),
+      fmt::arg("l2", l2), fmt::arg("r", r));
+
+  const Vector2d sample = Vector2d::Zero();
+  IrisOptions options;
+  HPolyhedron region = IrisFromUrdf(double_pendulum_urdf, sample, options);
+
+  // Note: You may use this to plot the solution in the desmos graphing
+  // calculator link above.  Just copy each equation in the printed formula into
+  // a desmos cell.  The intersection is the computed region.
+  // const Vector2<symbolic::Expression> xy{symbolic::Variable("x"),
+  //                                       symbolic::Variable("y")};
+  // std::cout << (region.A()*xy <= region.b()) << std::endl;
+
+  EXPECT_EQ(region.ambient_dimension(), 2);
+  // Confirm that we've found a substantial region.
+  EXPECT_GE(region.MaximumVolumeInscribedEllipsoid().Volume(), 2.0);
+
+  EXPECT_TRUE(region.PointInSet(Vector2d{.4, 0.0}));
+  EXPECT_FALSE(region.PointInSet(Vector2d{.5, 0.0}));
+  EXPECT_TRUE(region.PointInSet(Vector2d{.3, .3}));
+  EXPECT_FALSE(region.PointInSet(Vector2d{.4, .3}));
+  EXPECT_TRUE(region.PointInSet(Vector2d{-.4, 0.0}));
+  EXPECT_FALSE(region.PointInSet(Vector2d{-.5, 0.0}));
+  EXPECT_TRUE(region.PointInSet(Vector2d{-.3, -.3}));
+  EXPECT_FALSE(region.PointInSet(Vector2d{-.4, -.3}));
+}
+
+// A block on a vertical track, free to rotate (in the plane) with width `w` and
+// height `h`, plus a ground plane at z=0.  The true configuration space is
+// min(q₀ ± .5w sin(q₁) ± .5h cos(q₁)) ≥ 0, where the min is over the ±.  These
+// regions are visualized at https://www.desmos.com/calculator/ok5ckpa1kp.
+GTEST_TEST(IrisInConfigurationSpaceTest, BlockOnGround) {
+  const double w = 2.0;
+  const double h = 1.0;
+  const std::string block_urdf = fmt::format(
+      R"(
+<robot name="block">
+  <link name="fixed">
+    <collision name="ground">
+      <origin rpy="0 0 0" xyz="0 0 -1"/>
+      <geometry><box size="10 10 2"/></geometry>
+    </collision>
+  </link>
+  <joint name="fixed_link_weld" type="fixed">
+    <parent link="world"/>
+    <child link="fixed"/>
+  </joint>
+  <link name="link1"/>
+  <joint name="joint1" type="prismatic">
+    <axis xyz="0 0 1"/>
+    <limit lower="0" upper="3.0"/>
+    <parent link="world"/>
+    <child link="link1"/>
+  </joint>
+  <link name="link2">
+    <collision name="block">
+      <geometry><box size="{w} 1 {h}"/></geometry>
+    </collision>
+  </link>
+  <joint name="joint2" type="revolute">
+    <axis xyz="0 1 0"/>
+    <limit lower="-1.57" upper="1.57"/>
+    <parent link="link1"/>
+    <child link="link2"/>
+  </joint>
+</robot>
+)",
+      fmt::arg("w", w), fmt::arg("h", h));
+
+  const Vector2d sample{1.0, 0.0};
+  IrisOptions options;
+  HPolyhedron region = IrisFromUrdf(block_urdf, sample, options);
+
+  // Note: You may use this to plot the solution in the desmos graphing
+  // calculator link above.  Just copy each equation in the printed formula into
+  // a desmos cell.  The intersection is the computed region.
+  // const Vector2<symbolic::Expression> xy{symbolic::Variable("x"),
+  //                                        symbolic::Variable("y")};
+  // std::cout << (region.A()*xy <= region.b()) << std::endl;
+
+  EXPECT_EQ(region.ambient_dimension(), 2);
+  // Confirm that we've found a substantial region.
+  EXPECT_GE(region.MaximumVolumeInscribedEllipsoid().Volume(), 2.0);
 }
 
 }  // namespace


### PR DESCRIPTION
This is a first pass at the algorithm, using Snopt/Ipopt but not (yet) backed by Ibex/dReal.  That will come in the next PR.

There is still an open question about whether we can use ONLY Ibex/dReal, instead of Snopt.  But based on python experiments, I believe we can use Snopt first and then follow with Ibex/dReal to confirm that our sets are collision free. Furthermore, this Snopt version is useful immediately, and including Ibex/dReal will not change the interface, only the backend.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15476)
<!-- Reviewable:end -->
