### PR TITLE
multibody, examples: Remove unnecessary calls to EnableCaching()

### DIFF
--- a/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
+++ b/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
@@ -107,7 +107,6 @@ int do_main() {
   // Create a context for this system:
   std::unique_ptr<systems::Context<double>> diagram_context =
       diagram->CreateDefaultContext();
-  diagram_context->EnableCaching();
   systems::Context<double>& plant_context =
       diagram->GetMutableSubsystemContext(plant, diagram_context.get());
 

--- a/examples/simple_gripper/simple_gripper.cc
+++ b/examples/simple_gripper/simple_gripper.cc
@@ -291,7 +291,6 @@ int do_main() {
   // Create a context for this system:
   std::unique_ptr<systems::Context<double>> diagram_context =
       diagram->CreateDefaultContext();
-  diagram_context->EnableCaching();
   diagram->SetDefaultContext(diagram_context.get());
   systems::Context<double>& plant_context =
       diagram->GetMutableSubsystemContext(plant, diagram_context.get());

--- a/multibody/plant/test/box_test.cc
+++ b/multibody/plant/test/box_test.cc
@@ -55,7 +55,6 @@ class SlidingBoxTest : public ::testing::Test {
     // Create a context for this system:
     std::unique_ptr<Context<double>> diagram_context =
         diagram->CreateDefaultContext();
-    diagram_context->EnableCaching();
     diagram->SetDefaultContext(diagram_context.get());
     Context<double>& plant_context =
         diagram->GetMutableSubsystemContext(plant, diagram_context.get());
@@ -149,7 +148,6 @@ class SlidingBoxTest : public ::testing::Test {
         diagram2->GetSubsystemByName("plant"));
     std::unique_ptr<Context<double>> diagram_context2 =
         diagram2->CreateDefaultContext();
-    diagram_context2->EnableCaching();
     Context<double>& plant_context2 =
         diagram2->GetMutableSubsystemContext(plant2, diagram_context2.get());
     plant2.get_actuation_input_port().FixValue(&plant_context2, applied_force_);

--- a/multibody/plant/test/floating_body_test.cc
+++ b/multibody/plant/test/floating_body_test.cc
@@ -72,7 +72,6 @@ GTEST_TEST(QuaternionFloatingMobilizer, Simulation) {
   // call to this system's SetDefaultState().
   systems::Simulator<double> simulator(free_body_plant);
   systems::Context<double>& context = simulator.get_mutable_context();
-  context.EnableCaching();
 
   // The expected initial velocities with non-zero components in all three
   // axes, where B is the free body frame and W is the world frame.

--- a/multibody/tree/test/revolute_spring_test.cc
+++ b/multibody/tree/test/revolute_spring_test.cc
@@ -56,8 +56,6 @@ class SpringTester : public ::testing::Test {
     system_ = std::make_unique<MultibodyTreeSystem<double>>(std::move(model));
     context_ = system_->CreateDefaultContext();
 
-    context_->EnableCaching();
-
     forces_ = std::make_unique<MultibodyForces<double>>(tree());
   }
 


### PR DESCRIPTION
This should be enabled by default; ideally, we don't show this to users in examples unless it's explicitly for debugging caching / computation issues.

Relates #15478

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15479)
<!-- Reviewable:end -->
