### PR TITLE
primitives: Introduce VectorLog

### DIFF
--- a/systems/primitives/BUILD.bazel
+++ b/systems/primitives/BUILD.bazel
@@ -40,6 +40,7 @@ drake_cc_package_library(
         ":trajectory_affine_system",
         ":trajectory_linear_system",
         ":trajectory_source",
+        ":vector_log",
         ":wrap_to_system",
         ":zero_order_hold",
     ],
@@ -308,6 +309,17 @@ drake_cc_library(
     deps = [
         "//common/trajectories:trajectory",
         "//systems/framework",
+    ],
+)
+
+drake_cc_library(
+    name = "vector_log",
+    srcs = ["vector_log.cc"],
+    hdrs = ["vector_log.h"],
+    deps = [
+        "//common:default_scalars",
+        "//common:essential",
+        "//common:reset_after_move",
     ],
 )
 
@@ -641,6 +653,21 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//common/trajectories:piecewise_polynomial",
         "//systems/framework",
+    ],
+)
+
+drake_cc_googletest(
+    name = "vector_log_limit_malloc_test",
+    deps = [
+        ":vector_log",
+        "//common/test_utilities:limit_malloc",
+    ],
+)
+
+drake_cc_googletest(
+    name = "vector_log_test",
+    deps = [
+        ":vector_log",
     ],
 )
 

--- a/systems/primitives/test/vector_log_limit_malloc_test.cc
+++ b/systems/primitives/test/vector_log_limit_malloc_test.cc
@@ -1,0 +1,51 @@
+#include <gtest/gtest.h>
+
+#include "drake/common/autodiff.h"
+#include "drake/common/symbolic.h"
+#include "drake/common/test_utilities/limit_malloc.h"
+#include "drake/systems/primitives/vector_log.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+template <typename T>
+class VectorLogLimitMallocFixture : public testing::Test {
+ protected:
+  int max_num_allocations() const {
+    if constexpr (std::is_same_v<T, symbolic::Expression>) {
+      // symbolic:: generates heap traffic on its own. The specific limit here
+      // is not very important, as long as it doesn't grow without bound.
+      return 2999;
+    } else {
+      return 0;
+    }
+    DRAKE_UNREACHABLE();
+  }
+
+  static constexpr int64_t kBigCapacity_ = 3 * VectorLog<T>::kDefaultCapacity;
+  VectorLog<T> log_{3};
+  VectorX<T> record_{Vector3<T>{1.1, 2.2, 3.3}};
+};
+
+using ScalarTypes = ::testing::Types<double, AutoDiffXd, symbolic::Expression>;
+
+TYPED_TEST_SUITE(VectorLogLimitMallocFixture, ScalarTypes);
+
+// Ensure that reserving log storage can avoid heap operations when adding
+// data. See #10228.
+TYPED_TEST(VectorLogLimitMallocFixture, Reserve) {
+  // Reserve more than the default capacity.
+  this->log_.Reserve(this->kBigCapacity_);
+
+  // Store records to the full capacity, allowing allocations as determined by
+  // scalar type.
+  test::LimitMalloc guard({.max_num_allocations = this->max_num_allocations()});
+  for (int k = 0; k < this->kBigCapacity_; k++) {
+    this->log_.AddData(0.01 * k, this->record_);
+  }
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake

--- a/systems/primitives/test/vector_log_test.cc
+++ b/systems/primitives/test/vector_log_test.cc
@@ -1,0 +1,70 @@
+#include "drake/systems/primitives/vector_log.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/autodiff.h"
+#include "drake/common/symbolic.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+template <typename T>
+class VectorLogFixture : public testing::Test {
+ protected:
+  static constexpr int64_t kDefaultCapacity = VectorLog<T>::kDefaultCapacity;
+  VectorLog<T> log_{3};
+  VectorX<T> record_{Vector3<T>{1.1, 2.2, 3.3}};
+};
+
+using ScalarTypes = ::testing::Types<double, AutoDiffXd, symbolic::Expression>;
+
+TYPED_TEST_SUITE(VectorLogFixture, ScalarTypes);
+
+TYPED_TEST(VectorLogFixture, Basics) {
+  auto& log = this->log_;
+  auto& record = this->record_;
+  EXPECT_EQ(log.get_input_size(), 3);
+  EXPECT_EQ(log.num_samples(), 0);
+
+  log.AddData(0.001, record);
+  EXPECT_EQ(log.num_samples(), 1);
+  EXPECT_EQ(log.sample_times()[0], 0.001);
+  EXPECT_EQ(log.data()(0, 0), 1.1);
+  EXPECT_EQ(log.data()(1, 0), 2.2);
+  EXPECT_EQ(log.data()(2, 0), 3.3);
+
+  log.Clear();
+  EXPECT_EQ(log.num_samples(), 0);
+}
+
+TYPED_TEST(VectorLogFixture, Move) {
+  auto& log = this->log_;
+  auto& record = this->record_;
+  log.AddData(0.001, record);
+  EXPECT_EQ(log.num_samples(), 1);
+
+  auto other_log = std::move(log);
+  EXPECT_EQ(other_log.num_samples(), 1);
+  // The moved-from log becomes empty.
+  EXPECT_EQ(log.num_samples(), 0);
+}
+
+TYPED_TEST(VectorLogFixture, GrowLog) {
+  auto& log = this->log_;
+  auto& record = this->record_;
+  auto goal_size = 1 + this->kDefaultCapacity;
+
+  for (int k = 0; k < goal_size; k++) {
+    log.AddData(0.001 + k, record);
+  }
+  EXPECT_EQ(log.num_samples(), goal_size);
+  EXPECT_EQ(log.sample_times()[goal_size - 1], 0.001 + goal_size - 1);
+  EXPECT_EQ(log.data()(0, goal_size - 1), 1.1);
+  EXPECT_EQ(log.data()(1, goal_size - 1), 2.2);
+  EXPECT_EQ(log.data()(2, goal_size - 1), 3.3);
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake

--- a/systems/primitives/vector_log.cc
+++ b/systems/primitives/vector_log.cc
@@ -1,0 +1,55 @@
+#include "drake/systems/primitives/vector_log.h"
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_assert.h"
+
+namespace drake {
+namespace systems {
+
+template <typename T>
+VectorLog<T>::VectorLog(int input_size)
+    : sample_times_(kDefaultCapacity),
+      data_(input_size, kDefaultCapacity) {
+  DRAKE_ASSERT_VOID(CheckInvariants());
+}
+
+template <typename T>
+void VectorLog<T>::Reserve(int64_t capacity) {
+  DRAKE_ASSERT_VOID(CheckInvariants());
+  if (capacity > sample_times_.size()) {
+    sample_times_.conservativeResize(capacity);
+    data_.conservativeResize(Eigen::NoChange, capacity);
+  }
+  DRAKE_ASSERT_VOID(CheckInvariants());
+}
+
+template <typename T>
+void VectorLog<T>::AddData(const T& time, const VectorX<T>& sample) {
+  DRAKE_ASSERT_VOID(CheckInvariants());
+  // If the new size exceeds the current allocation, then do a conservative
+  // resize (ouch!). Clients can avoid this if necessary by calling Reserve()
+  // ahead of time.
+  if (num_samples_ + 1 > sample_times_.size()) {
+    Reserve(sample_times_.size() * 2);
+  }
+
+  // Record time and input to the num_samples position.
+  sample_times_(num_samples_) = time;
+  data_.col(num_samples_) = sample;
+
+  // Update the count.
+  ++num_samples_;
+  DRAKE_ASSERT_VOID(CheckInvariants());
+}
+
+template <typename T>
+void VectorLog<T>::CheckInvariants() const {
+  DRAKE_DEMAND(sample_times_.size() == data_.cols());
+  DRAKE_DEMAND(num_samples_ <= sample_times_.size());
+}
+
+}  // namespace systems
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::VectorLog)

--- a/systems/primitives/vector_log.h
+++ b/systems/primitives/vector_log.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/common/reset_after_move.h"
+
+namespace drake {
+namespace systems {
+
+/**
+ This utility class serves as an in-memory cache of time-dependent vector
+ values. Note that this is a standalone class, not a Drake System. It is
+ primarily intended to support the Drake System primitive VectorLogSink, but
+ can be used independently.
+
+ When the log becomes full, adding more data will cause the allocated space to
+ double in size. If avoiding memory allocation during some performance-critical
+ phase is desired, clients can call Reserve() to pre-allocate log storage.
+
+ This object imposes no constraints on the stored data. For example, times
+ passed to AddData() need not be increasing in order of insertion, values are
+ allowed to be infinite, NaN, etc.
+
+ @tparam_default_scalar
+ */
+template <typename T>
+class VectorLog {
+ public:
+  /**
+   The default capacity of vector log allocation, expressed as a number of
+   samples. Chosen to be large enough that most systems won't need to allocate
+   during simulation advance steps.
+   */
+  static constexpr int64_t kDefaultCapacity = 1000;
+
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(VectorLog)
+
+  /** Constructs the vector log.
+   @param input_size                Dimension of the per-time step data set.
+   */
+  explicit VectorLog(int input_size);
+
+  /** Reports the size of the log's input vector. */
+  int64_t get_input_size() const { return data_.rows(); }
+
+  /** Returns the number of samples taken since construction or last Clear(). */
+  int num_samples() const { return num_samples_; }
+
+  /** Accesses the logged time stamps. */
+  Eigen::VectorBlock<const VectorX<T>> sample_times() const {
+    return const_cast<const VectorX<T>&>(sample_times_).head(num_samples_);
+  }
+
+  /** Accesses the logged data.
+
+   The InnerPanel parameter of the return type indicates that the compiler can
+   assume aligned access to the data.
+   */
+  Eigen::Block<const MatrixX<T>, Eigen::Dynamic, Eigen::Dynamic,
+               true /* InnerPanel */>
+  data() const {
+    return data_.leftCols(num_samples_);
+  }
+
+  /**
+   Reserve storage for at least `capacity` samples. At construction, there will
+   be at least `kDefaultCapacity`; use this method to reserve more.
+   */
+  void Reserve(int64_t capacity);
+
+  /** Clears the logged data. */
+  void Clear() {
+    DRAKE_ASSERT_VOID(CheckInvariants());
+    // Resetting num_samples_ is sufficient to have all future writes and
+    // reads re-initialized to the beginning of the data.
+    num_samples_ = 0;
+    DRAKE_ASSERT_VOID(CheckInvariants());
+  }
+
+  /** Adds a `sample` to the data set with the associated `time` value. The new
+   * sample and time are added to the end of the log. No constraints are
+   * imposed on the values of`time` or `sample`.
+
+   @param time      The time value for this sample.
+   @param sample    A vector of data of the declared size for this log.
+   */
+  void AddData(const T& time, const VectorX<T>& sample);
+
+ private:
+  void CheckInvariants() const;
+
+  reset_after_move<int64_t> num_samples_{0};
+  VectorX<T> sample_times_;
+  MatrixX<T> data_;
+};
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
Relevant to: #10228

This is step 1 of 4 to deprecate and replace SignalLogger and SignalLog
with a logging system that avoids threading hazards (SignalLogger) and
slow memory management (SignalLog).

VectorLog will eventually replace SignalLog. Improvements include
doubling reallocation on growth (similar to std::vector), a Reserve()
method to pre-allocate log space ahead of time, and adjustment of the
AddData() signature to avoid unnecessary object copying and memory
allocations.

New unit tests demonstrate basic functionality, log storage growth, and
avoidance of run-time dynamic allocations via Reserve().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15484)
<!-- Reviewable:end -->
