### PR TITLE
[framework] Deprecate dispreferred DeclareOutputPort overload

### DIFF
--- a/systems/framework/leaf_system.cc
+++ b/systems/framework/leaf_system.cc
@@ -747,6 +747,8 @@ LeafOutputPort<T>& LeafSystem<T>::DeclareStateOutputPort(
 }
 
 // (This function is deprecated.)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 template <typename T>
 LeafOutputPort<T>& LeafSystem<T>::DeclareVectorOutputPort(
     const BasicVector<T>& model_vector,
@@ -756,8 +758,11 @@ LeafOutputPort<T>& LeafSystem<T>::DeclareVectorOutputPort(
                                  std::move(vector_calc_function),
                                  std::move(prerequisites_of_calc));
 }
+#pragma GCC diagnostic pop
 
 // (This function is deprecated.)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 template <typename T>
 LeafOutputPort<T>& LeafSystem<T>::DeclareAbstractOutputPort(
     typename LeafOutputPort<T>::AllocCallback alloc_function,
@@ -767,6 +772,7 @@ LeafOutputPort<T>& LeafSystem<T>::DeclareAbstractOutputPort(
                                    std::move(calc_function),
                                    std::move(prerequisites_of_calc));
 }
+#pragma GCC diagnostic pop
 
 template <typename T>
 std::unique_ptr<WitnessFunction<T>> LeafSystem<T>::MakeWitnessFunction(

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -1463,18 +1463,15 @@ class LeafSystem : public System<T> {
                                      std::move(prerequisites_of_calc));
   }
 
-  /** Declares an abstract-valued output port by specifying member functions to
-  use both for the allocator and calculator. The signatures are:
-  @code
-  OutputType MySystem::MakeOutputValue() const;
-  void MySystem::CalcOutputValue(const Context<T>&, OutputType*) const;
-  @endcode
-  where `MySystem` is a class derived from `LeafSystem<T>` and `OutputType`
-  may be any concrete type such that `Value<OutputType>` is permitted.
-  See alternate signature if your allocator method needs a Context.
-  Template arguments will be deduced and do not need to be specified.
-  @see drake::Value */
+  // Declares an output port by specifying an allocator function pointer that
+  // returns by-value, and a calc function pointer.
   template <class MySystem, typename OutputType>
+  DRAKE_DEPRECATED("2021-11-01",
+      "This overload for DeclareAbstractOutputPort is rarely the best choice;"
+      " it is unusual for a boutique allocation to return an abstract type by"
+      " value rather than provide a model_value. If the default constructor"
+      " or a model value cannot be used, use the overload that accepts an"
+      " AllocCallback alloc_function instead.")
   LeafOutputPort<T>& DeclareAbstractOutputPort(
       std::variant<std::string, UseDefaultName> name,
       OutputType (MySystem::*make)() const,
@@ -1592,8 +1589,11 @@ class LeafSystem : public System<T> {
       void (MySystem::*calc)(const Context<T>&, OutputType*) const,
       std::set<DependencyTicket> prerequisites_of_calc = {
           all_sources_ticket()}) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     return DeclareAbstractOutputPort(kUseDefaultName, make, calc,
                                      std::move(prerequisites_of_calc));
+#pragma GCC diagnostic pop
   }
 
   DRAKE_DEPRECATED("2021-10-01", "Pass a port name as the first argument.")

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -1516,12 +1516,15 @@ class DeclaredNonModelOutputSystem : public LeafSystem<double> {
         });
     unused(port);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     // Output port 3 is declared with a commonly-used signature taking
     // methods for both allocator and calculator for an abstract port.
     port = &DeclareAbstractOutputPort(
         kUseDefaultName, &DeclaredNonModelOutputSystem::MakeString,
         &DeclaredNonModelOutputSystem::CalcString);
     unused(port);
+#pragma GCC diagnostic pop
 
     // Output port 4 uses a default-constructed bare struct which should be
     // value-initialized.


### PR DESCRIPTION
This overload was not commonly necessary, so tended to clutter up the documentation and lead users to add unnecessary boilerplate.  In cases where this signature was important, users can fall back to using the most generic form of allocator callback.

Towards #15161.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15485)
<!-- Reviewable:end -->
