### PR TITLE
[multibody] An option for discrete hydroelastics to choose the type of contact surfaces.

### DIFF
--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1596,6 +1596,30 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   void set_contact_model(ContactModel model);
 
 #ifndef DRAKE_DOXYGEN_CXX
+  // (Experimental) For a discrete system, setting `true` instructs
+  // MultibodyPlant to use the low-resolution hydroelastic contact surfaces.
+  // This configuration defaults to `false`. When false, MultibodyPlant will use
+  // the high-resolution hydroelastic contact surfaces for the discrete system.
+  //
+  // For a continuous system, this setting has no effect because MultibodyPlant
+  // will always use the high-resolution contact surfaces.
+  //
+  // The low-resolution contact surfaces lead to a smaller contact problem with
+  // a significant reduction in the number of contact constraints, and thus
+  // you'll observe a speed up in your simulations. In this experimental state
+  // visualization does not show a continuous surface but rather a set of
+  // disconnected triangles only meant to visualize the location of discrete
+  // contact features. Once we provide the correct, continuous, visualization of
+  // the surface, this experimental method will be removed and the polygonal
+  // representation of the surfaces will be the default for discrete systems.
+  //
+  // @warning Setting this to `true` will change the underlying model and
+  // therefore simulation results won't match those obtained with
+  // `use_low_resolution`=false.
+  //
+  // @throws std::exception iff called post-finalize.
+  void set_low_resolution_contact_surface(bool use_low_resolution);
+
   // TODO(xuchenhan-tri): Remove SetContactSolver() once
   //  SetDiscreteUpdateManager() stabilizes.
   // (Experimental) SetContactSolver() should only be called by advanced
@@ -4749,6 +4773,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
 
   // The model used by the plant to compute contact forces.
   ContactModel contact_model_{ContactModel::kPointContactOnly};
+
+  bool use_low_resolution_contact_surface_{false};
 
   // Port handles for geometry:
   systems::InputPortIndex geometry_query_port_;

--- a/multibody/plant/test/multibody_plant_hydroelastic_contact_results_output_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_contact_results_output_test.cc
@@ -111,6 +111,7 @@ TEST_F(HydroelasticContactResultsOutputTester, ContactSurfaceEquivalent) {
           .template Eval<geometry::QueryObject<double>>(*plant_context_);
 
   // Compute the contact surface using the hydroelastic engine.
+  ASSERT_FALSE(plant_->is_discrete());
   std::vector<geometry::ContactSurface<double>> contact_surfaces =
       query_object.ComputeContactSurfaces();
 


### PR DESCRIPTION
This PR provides an option for a discrete system to choose between high-resolution contact surfaces and low-resolution contact surfaces for the hydroelastic contact model. The default is still the high resolution as before.

Replace #15436. 

Final step in the [implementation plan for 14579](https://github.com/RobotLocomotion/drake/issues/14579#issuecomment-843618123) in CY21Q3. This PR is after #15210 (QueryObject).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15487)
<!-- Reviewable:end -->
