### PR TITLE
Replace an expensive dynamic_cast with a cheap static_cast

### DIFF
--- a/multibody/parsing/test/acrobot_parser_test.cc
+++ b/multibody/parsing/test/acrobot_parser_test.cc
@@ -43,11 +43,11 @@ class AcrobotModelTests :
 
     // Create a benchmark model for verification of the parsed model.
     // The benchmark model is created programmatically through Drake's API.
-    benchmark_plant_ =
-        benchmarks::acrobot::MakeAcrobotPlant(parameters_, true);
+    benchmark_plant_ = benchmarks::acrobot::MakeAcrobotPlant(parameters_, true);
     benchmark_shoulder_ =
-        &plant_->GetJointByName<RevoluteJoint>("ShoulderJoint");
-    benchmark_elbow_ = &plant_->GetJointByName<RevoluteJoint>("ElbowJoint");
+        &benchmark_plant_->GetJointByName<RevoluteJoint>("ShoulderJoint");
+    benchmark_elbow_ =
+        &benchmark_plant_->GetJointByName<RevoluteJoint>("ElbowJoint");
     benchmark_context_ = benchmark_plant_->CreateDefaultContext();
   }
 

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -2327,7 +2327,7 @@ class MultibodyTree {
   // Returns the MultibodyTreeSystem that owns this MultibodyTree.
   // @pre There is an owning MultibodyTreeSystem.
   const MultibodyTreeSystem<T>& tree_system() const {
-    DRAKE_DEMAND(tree_system_ != nullptr);
+    DRAKE_ASSERT(tree_system_ != nullptr);
     return *tree_system_;
   }
 
@@ -2389,9 +2389,11 @@ class MultibodyTree {
   Eigen::VectorBlock<VectorX<T>> get_mutable_discrete_state_vector(
       systems::State<T>* state) const;
 
+  // @pre the VectorBase is a BasicVector.
   Eigen::VectorBlock<const VectorX<T>> extract_qv_from_continuous(
       const systems::VectorBase<T>& continuous_qvz) const;
 
+  // @pre the VectorBase is non-null and is a BasicVector.
   Eigen::VectorBlock<VectorX<T>> extract_mutable_qv_from_continuous(
       systems::VectorBase<T>* continuous_qvz) const;
 


### PR DESCRIPTION
Profiling revealed that a dynamic_cast used in MBTree for basic continuous state vector access was expensive (about 2% of total forward dynamics time). Fortunately it was also unnecessary.

This PR replaces it with a static_cast and an argument about its safety.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15489)
<!-- Reviewable:end -->
