### PR TITLE
[geometry] Introduce "transient" collision filter modifications

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -982,9 +982,11 @@ void DoScalarIndependentDefinitions(py::module m) {
     AddValueInstantiation<Rgba>(m);
   }
 
+  BindIdentifier<FilterId>(m, "FilterId", doc.FilterId.doc);
   BindIdentifier<SourceId>(m, "SourceId", doc.SourceId.doc);
   BindIdentifier<FrameId>(m, "FrameId", doc.FrameId.doc);
   BindIdentifier<GeometryId>(m, "GeometryId", doc.GeometryId.doc);
+
   // CollisionFilterDeclaration.
   {
     using Class = CollisionFilterDeclaration;
@@ -1007,7 +1009,15 @@ void DoScalarIndependentDefinitions(py::module m) {
     using Class = CollisionFilterManager;
     constexpr auto& cls_doc = doc.CollisionFilterManager;
     py::class_<Class>(m, "CollisionFilterManager", cls_doc.doc)
-        .def("Apply", &Class::Apply, py::arg("declaration"), cls_doc.Apply.doc);
+        .def("Apply", &Class::Apply, py::arg("declaration"), cls_doc.Apply.doc)
+        .def("ApplyTransient", &Class::ApplyTransient, py::arg("declaration"),
+            cls_doc.ApplyTransient.doc)
+        .def("RemoveDeclaration", &Class::RemoveDeclaration,
+            py::arg("filter_id"), cls_doc.RemoveDeclaration.doc)
+        .def("has_transient_history", &Class::has_transient_history,
+            cls_doc.has_transient_history.doc)
+        .def("IsActive", &Class::IsActive, py::arg("filter_id"),
+            cls_doc.IsActive.doc);
   }
 
   // Role enumeration

--- a/geometry/collision_filter_manager.h
+++ b/geometry/collision_filter_manager.h
@@ -73,7 +73,97 @@ class GeometryState;
    If a proximity role is subsequently assigned, those geometries will _still_
    not be part of any user-declared collision filters.
  - In general, adding collisions and assigning proximity roles should
-   happen prior to collision filter configuration. */
+   happen prior to collision filter configuration.
+
+ <h3>Transient vs Persistent changes</h3>
+
+ Collision filtering is all about defining which geometry pairs are in the set
+ C. The simplest way to modify the set C is through *persistent* modifications
+ to a "base configuration" (via calls to Apply()). However, declarations can
+ also be applied in a *transient* manner. Transient declarations form a history.
+ The current definition of the set C is the result of applying the history
+ of collision filter declarations to the persistent base configuration in order.
+ That history can be modified:
+
+   - New transient declarations can be appended.
+   - Arbitrary transient declarations can be removed from the sequence.
+   - The current configuration (based on a history with an arbitrary number
+     of transient declarations) can be "flattened" into the persistent base
+     (with no history).
+
+ The table below illustrates a sequence of operations and their effect on C. We
+ define C's initial configuration as `C = {P₁, P₂, ..., Pₙ}` (for `n` geometry
+ pairs). Each action is described as either persistent or transient.
+
+  | Line |  C                  |  Action |
+  | :--: | :------------------ | :-------------------------------------------------- |
+  |  1   | `{P₁, P₂, ..., Pₙ}` | Initial condition of the persistent base            |
+  |  2   | `{P₂, ..., Pₙ}`     | Remove P₁ from the persistent base                  |
+  |  3   | `{P₂, ..., Pₙ₋₁}`   | Remove Pₙ from the persistent base                  |
+  |  4   | `{P₂}`              | Remove all pairs except P₂ from the persistent base |
+  |  5   | `{P₂, P₄, P₅}`      | Transient declaration #1 puts P₄ and P₅ into C      |
+  |  6   | `{P₂, P₃, P₄, P₅}`  | Transient declaration #2 puts P₃ and P₄ into C      |
+  |  7   | `{P₂, P₃, P₄}`      | Remove declaration #1.                              |
+  |  8   | `{P₂, P₃, P₄}`      | Configuration flattened; #2 no longer exists        |
+  __Table 1__: An example sequence of operations on collision filters.
+
+ Notes:
+   - lines 2 - 4 represent a series of *persistent* operations, filtering pairs
+     of geometry (aka removing them from C by calling Apply()).
+   - line 5: the first transient filter declaration which is assigned the id
+     value #1 (via a call to ApplyTransient()).
+   - line 6: Adds a new transient filter declaration to the sequence (assigned
+     id #2). Note, that it redundantly declares that P₄ is a member of C just
+     as declaration #1 did. This redundancy is fine. In fact, it may be very
+     important (see below).
+   - line 7: We remove declaration #1. Although #1 added both P₄ and P₅ to C,
+     the result of removing this declaration from the sequence is that P₅ is no
+     longer a member of C but P₄ *is*. This is because #2's declaration that P₄
+     *is* in C preserves its membership.
+   - line 8: the current configuration is "flattened" into the persistent base.
+     All history is thrown out and any filter identifiers are rendered invalid.
+
+ This example workflow above illustrates some key ideas in using transient
+ declarations.
+
+   - __The persistent configuration can only be modified when there is no
+     transient history.__ Applying a filter declaration should have the effect
+     of realizing that declaration. If a pair is *declared* to be in C, the
+     result of the declaration is that the pair is in C (assuming that the pair
+     *can* be in C). If we allowed modifying the persistent configuration with
+     an active transient history, there might be no discernable change in the
+     resultant configuration state because a subsequent transient declaration
+     may supplant it. This would lead to inscrutable bugs. Therefore, it's
+     simply not allowed.
+   - __When defining a transient declaration, the declaration should include all
+     critical pairs *explicitly*.__ This includes those pairs that should and
+     should not be in C. Any pair *not* explicitly accounted for should be one
+     whose filter status is immaterial.
+     It *might* seems desirable (from an optimization perspective) to examine
+     the *current* configuration of C and apply the minimum change to put it
+     into a desired state (i.e., if a pair I need filtered is already filtered,
+     I would omit it from the declaration). This approach is fraught with peril.
+     If the current configuration is the result of previous transient
+     declarations, the removal of any of those declarations could invalidate the
+     attempted difference calculation and my declaration would no longer be
+     sufficient to guarantee the set C required.
+   - __Anyone at any time can add to the history.__ Some code can modify C to
+     suit its needs. However, it can also make subsequent calls into code that
+     also modifies C with no guarantees that the called code will undo those
+     changes. Code that modifies collision filters configuration should document
+     that it does so. It should also have a clear protocol for cleaning up its
+     own changes. Finally, code that applies declarations should not take for
+     granted that its transient declarations are necessarily the last
+     declarations in the history.
+
+ <h4>Making transient filter declarations</h4>
+
+ There is a custom API for applying a filter declaration as a *transient*
+ declaration. It returns the id for the transient API (used to remove the
+ declaration from the history sequence).
+
+ Attempting to change the persistent configuration when there are active
+ transient declarations in the history will throw an exception.   */
 class CollisionFilterManager {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CollisionFilterManager)
@@ -90,7 +180,8 @@ class CollisionFilterManager {
      - Attempts to "allow" collision between a pair that is strictly excluded
        (e.g., between two anchored geometries) will be ignored.
 
-   @throws std::exception if the `declaration` references invalid ids. */
+   @throws std::exception if the `declaration` references invalid ids or there
+                          is an active history. */
   void Apply(const CollisionFilterDeclaration& declaration) {
     /* Modifications made via this API are by the user. Only the internals can
      declare filters to be "invariant". */
@@ -110,6 +201,34 @@ class CollisionFilterManager {
   //  If those can be resolved, it would make more sense to make the
   //  CollisionFilterManager the one-stop shop for all things collision filter
   //  rather than having it split over two classes.
+
+  /** Applies the declaration as the newest *transient* modification to the
+   collision filter configuration. The declaration must be considered "valid",
+   as defined for Apply(). */
+  FilterId ApplyTransient(const CollisionFilterDeclaration& declaration) {
+    return filter_->ApplyTransient(declaration, extract_ids_);
+  }
+
+  /** Attempts to remove the transient declaration from the history for the
+   declaration associated with the given `filter_id`.
+   @param filter_id   The id of the filter declaration to remove.
+   @returns `true` iff `is_active(filter_id)` returns `true` before calling this
+            method (i.e., `filter_id` refers to an existent filter that has
+            successfully been removed). */
+  bool RemoveDeclaration(FilterId filter_id) {
+    return filter_->RemoveDeclaration(filter_id);
+  }
+
+  /** Reports if there are any active transient filter declarations. */
+  bool has_transient_history() const {
+    return filter_->has_transient_history();
+  }
+
+  /** Reports if the transient collision filter declaration indicated by the
+   given `filter_id` is part of the history. */
+  bool IsActive(FilterId filter_id) const {
+    return filter_->IsActive(filter_id);
+  }
 
  private:
   /* Only GeometryState can construct a collision filter manager. */

--- a/geometry/geometry_ids.h
+++ b/geometry/geometry_ids.h
@@ -10,6 +10,10 @@ namespace internal {
 class EncodedData;
 }  // namespace internal
 
+/** Type used to identify transient collision filter declarations in SceneGraph.
+ */
+using FilterId = drake::Identifier<class FilterTag>;
+
 /** Type used to identify geometry sources in SceneGraph. */
 using SourceId = drake::Identifier<class SourceTag>;
 

--- a/geometry/geometry_set.h
+++ b/geometry/geometry_set.h
@@ -269,14 +269,14 @@ class GeometrySet {
   friend class GeometryState;
 
   // Returns the frame ids in the set.
-  const std::unordered_set<FrameId> frames() const { return frame_ids_; }
+  const std::unordered_set<FrameId>& frames() const { return frame_ids_; }
 
   // Reports the number of frames in the set.
   int num_frames() const { return static_cast<int>(frame_ids_.size()); }
 
   // Returns the geometry ids in the set -- these are only the geometry ids
   // explicitly added to the set and _not_ those implied by added frames.
-  const std::unordered_set<GeometryId> geometries() const {
+  const std::unordered_set<GeometryId>& geometries() const {
     return geometry_ids_;
   }
 

--- a/geometry/proximity/collision_filter.cc
+++ b/geometry/proximity/collision_filter.cc
@@ -9,60 +9,135 @@ namespace internal {
 
 using std::unordered_set;
 
+CollisionFilter::CollisionFilter() {
+  /* The filter history always has at least one entry -- entry[0] is the
+   persistent base. We associate it with a filter id that can never be
+   accessed via ApplyTransient() so that it can't accidentally be removed. */
+  filter_history_.emplace_back(FilterState{}, FilterId::get_new_id());
+}
+
+// TODO(SeanCurtis-TRI): Multiple calls to Apply will lead to multiple
+//  constructions of std::unordered_set from GeometrySet (as opposed to
+//  re-using a single set). If this is a performance issue, revisit this so
+//  that I can operate on multiple filter states *per statement*.
 void CollisionFilter::Apply(const CollisionFilterDeclaration& declaration,
                             const CollisionFilter::ExtractIds& extract_ids,
                             bool is_invariant) {
-  using Operation = CollisionFilterDeclaration::StatementOp;
-  for (const auto& statement : declaration.statements()) {
-    switch (statement.operation) {
-      case Operation::kAllowBetween:
-        RemoveFiltersBetween(statement.set_A, statement.set_B, extract_ids);
-        break;
-      case Operation::kAllowWithin:
-        RemoveFiltersBetween(statement.set_A, statement.set_A, extract_ids);
-        break;
-      case Operation::kExcludeWithin:
-        AddFiltersBetween(statement.set_A, statement.set_A, extract_ids,
-                          is_invariant);
-        break;
-      case Operation::kExcludeBetween:
-        AddFiltersBetween(statement.set_A, statement.set_B, extract_ids,
-                          is_invariant);
-        break;
+  if (has_transient_history()) {
+    throw std::runtime_error(
+        "You cannot attempt to modify the persistent collision filter "
+        "configuration when there are active, transient filter declarations");
+  }
+  // TODO(SeanCurtis-TRI): We're using a brute-force approach to update the
+  //  cached composite state and the persistent state. We assume it's cheaper
+  //  to "apply" the declaration twice than to apply once and copy. If this
+  //  introduces too much cost during configuration, we have a couple of options
+  //    - Find out if copying is faster.
+  //    - In the case where there is *only* persistent state, don't use the
+  //      copy as the persistent state *is* its own composite state.
+  /* Keep current configuration and persistent base in sync. */
+  Apply(declaration, extract_ids, is_invariant, &filter_state_);
+  Apply(declaration, extract_ids, is_invariant,
+        &filter_history_[0].filter_state);
+}
+
+FilterId CollisionFilter::ApplyTransient(
+    const CollisionFilterDeclaration& declaration,
+    const CollisionFilter::ExtractIds& extract_ids) {
+  /* By its very definition, transient declarations *cannot* be invariant. They
+   are never used by the system to implement invariants and users cannot declare
+   a filter to be invariant. */
+  const bool is_invariant = false;
+
+  /* Using the same brute-force approach as in Apply(), we need to apply the
+   declaration to our cached, composite result (filter_state_). Then we need
+   to add it to the history by:
+
+     1. Creating a new FilterState instance (with all the registered geometry
+        in final_state_).
+     2. Apply the declaration to that new state in the history. */
+  // TODO(SeanCurtis-TRI): The brute force approach introduces several costs.
+  //  In addition to the cost of converting GeometrySet --> set<GeometryId>
+  //  twice, we are instantiating a full FilterState for what might be a small
+  //  declaration and applying the declaration twice. If this cost is too high,
+  //  even for out-of-the-loop configuration, revisit how we represent the
+  //  history and maintain the composite copy.
+  Apply(declaration, extract_ids, is_invariant, &filter_state_);
+  filter_history_.emplace_back(
+      InitializeTransientState(filter_state_, kUndefined),
+      FilterId::get_new_id());
+  Apply(declaration, extract_ids, is_invariant,
+        &filter_history_.back().filter_state);
+  return filter_history_.back().id;
+}
+
+bool CollisionFilter::IsActive(FilterId id) const {
+  for (const auto& delta : filter_history_) {
+    if (id == delta.id) return true;
+  }
+  return false;
+}
+
+bool CollisionFilter::RemoveDeclaration(FilterId id) {
+  /* We skip the first entry, that is always the persistent base and can't be
+   removed. */
+  for (auto it = filter_history_.begin() + 1; it != filter_history_.end();
+       ++it) {
+    if (it->id != id) continue;
+
+    /* We found a declaration to remove. We simply pop it out, relying on the
+     std::vector to use move semantics to slide the subsequent entries down.
+     Then we just copy the persistent base and "replay" the transient
+     declarations. */
+    filter_history_.erase(it);
+    filter_state_ = filter_history_[0].filter_state;
+    for (size_t i = 1; i < filter_history_.size(); ++i) {
+      const FilterState& state = filter_history_[i].filter_state;
+      /* Note: If the filtered state in transient declarations was sparse, this
+       application algorithm would directly benefit. It only requires that the
+       persistent state has all of the required pairs. See the TODO in
+       AddGeometry() for more discussion. */
+      for (const auto& [source_id, source_map] : state) {
+        for (const auto& [pair_id, pair_relation] : source_map) {
+          if (pair_relation != kUndefined) {
+            if (filter_state_[source_id][pair_id] != kInvariantFilter) {
+              filter_state_[source_id][pair_id] = pair_relation;
+            }
+          }
+        }
+      }
     }
+    return true;
+  }
+  return false;
+}
+
+void CollisionFilter::Flatten() {
+  if (filter_history_.size() > 1) {
+    filter_history_.resize(1);
+    filter_history_[0].filter_state = filter_state_;
   }
 }
 
 void CollisionFilter::AddGeometry(GeometryId new_id) {
-  DRAKE_DEMAND(filter_state_.count(new_id) == 0);
-  GeometryMap& new_map = filter_state_[new_id] = {};
-  for (auto& [other_id, other_map] : filter_state_) {
-    /* Whichever id is *smaller* tracks the relationship with the other.
-     That relationship defaults to unfiltered (i.e., "can collide").
-
-     Note: we're iterating over filter_state_ and assigning to either new_map
-     or other_map. This doesn't invalidate the implicit iterator of the range
-     operator. We never change the *keys* of filter_state_ in this loop, only
-     its values. And we don't do any iteration in the new_map or other_map
-     so don't depend on their iterators. */
-    if (other_id < new_id) {
-      other_map[new_id] = kUnfiltered;
-    } else {
-      new_map[other_id] = kUnfiltered;
-    }
+  /* Current and persistent configurations should simply add the id with
+   unfiltered status. */
+  AddGeometry(new_id, &filter_state_, kUnfiltered);
+  AddGeometry(new_id, &filter_history_[0].filter_state, kUnfiltered);
+  // TODO(SeanCurtis): Can I skip this work by allowing delta filter state to be
+  //  incomplete? If each transient delta *only* contains explicitly declared
+  //  changes, iterating through it would be faster. More complex, but faster.
+  /* Active transient history should add the id with undefined status. */
+  for (size_t i = 1; i < filter_history_.size(); ++i) {
+    AddGeometry(new_id, &filter_history_[i].filter_state, kUndefined);
   }
 }
 
 void CollisionFilter::RemoveGeometry(GeometryId remove_id) {
-  DRAKE_DEMAND(filter_state_.count(remove_id) == 1);
-  filter_state_.erase(remove_id);
-  for (auto& [other_id, other_map] : filter_state_) {
-    /* remove_id will only be found in maps belonging to geometries with ids
-     that are smaller than remove_id. Those that are larger were deleted when we
-     removed remove_id's entry. */
-    if (other_id < remove_id) {
-      other_map.erase(remove_id);
-    }
+  /* Simply remove the geometry from everything. */
+  RemoveGeometry(remove_id, &filter_state_);
+  for (auto& delta : filter_history_) {
+    RemoveGeometry(remove_id, &delta.filter_state);
   }
 }
 
@@ -77,50 +152,55 @@ bool CollisionFilter::CanCollideWith(GeometryId id_A, GeometryId id_B) const {
 
 void CollisionFilter::AddFiltersBetween(
     const GeometrySet& set_A, const GeometrySet& set_B,
-    const CollisionFilter::ExtractIds& extract_ids, bool is_invariant) {
+    const CollisionFilter::ExtractIds& extract_ids, bool is_invariant,
+    FilterState* state_out) {
   const std::unordered_set<GeometryId> ids_A = extract_ids(set_A);
   const std::unordered_set<GeometryId>& ids_B =
       &set_A == &set_B ? ids_A : extract_ids(set_B);
   for (GeometryId id_A : ids_A) {
     for (GeometryId id_B : ids_B) {
-      AddFilteredPair(id_A, id_B, is_invariant);
+      AddFilteredPair(id_A, id_B, is_invariant, state_out);
     }
   }
 }
 
 void CollisionFilter::RemoveFiltersBetween(
     const GeometrySet& set_A, const GeometrySet& set_B,
-    const CollisionFilter::ExtractIds& extract_ids) {
-  const unordered_set<GeometryId> ids_A = extract_ids(set_A);
-  const unordered_set<GeometryId>& ids_B =
+    const CollisionFilter::ExtractIds& extract_ids, FilterState* state_out) {
+  const std::unordered_set<GeometryId> ids_A = extract_ids(set_A);
+  const std::unordered_set<GeometryId>& ids_B =
       &set_A == &set_B ? ids_A : extract_ids(set_B);
   for (GeometryId id_A : ids_A) {
     for (GeometryId id_B : ids_B) {
-      RemoveFilteredPair(id_A, id_B);
+      RemoveFilteredPair(id_A, id_B, state_out);
     }
   }
 }
 
 void CollisionFilter::AddFilteredPair(GeometryId id_A, GeometryId id_B,
-                                      bool is_invariant) {
-  DRAKE_ASSERT(filter_state_.count(id_A) == 1 &&
-               filter_state_.count(id_B) == 1);
+                                      bool is_invariant,
+                                      FilterState* state_out) {
+  FilterState& filter_state = *state_out;
+  DRAKE_DEMAND(filter_state.count(id_A) == 1 &&
+               filter_state.count(id_B) == 1);
 
   if (id_A == id_B) return;
-  PairFilterState& pair_state =
-      id_A < id_B ? filter_state_[id_A][id_B] : filter_state_[id_B][id_A];
-  if (pair_state == kInvariantFilter) return;
-  pair_state = is_invariant ? kInvariantFilter : kFiltered;
+  PairRelationship& pair_relation =
+      id_A < id_B ? filter_state[id_A][id_B] : filter_state[id_B][id_A];
+  if (pair_relation == kInvariantFilter) return;
+  pair_relation = is_invariant ? kInvariantFilter : kFiltered;
 }
 
-void CollisionFilter::RemoveFilteredPair(GeometryId id_A, GeometryId id_B) {
-  DRAKE_ASSERT(filter_state_.count(id_A) == 1 &&
-               filter_state_.count(id_B) == 1);
+void CollisionFilter::RemoveFilteredPair(GeometryId id_A, GeometryId id_B,
+                                         FilterState* state_out) {
+  FilterState& filter_state = *state_out;
+  DRAKE_DEMAND(filter_state.count(id_A) == 1 &&
+               filter_state.count(id_B) == 1);
   if (id_A == id_B) return;
-  PairFilterState& pair_state =
-      id_A < id_B ? filter_state_[id_A][id_B] : filter_state_[id_B][id_A];
-  if (pair_state == kInvariantFilter) return;
-  pair_state = kUnfiltered;
+  PairRelationship& pair_relation =
+      id_A < id_B ? filter_state[id_A][id_B] : filter_state[id_B][id_A];
+  if (pair_relation == kInvariantFilter) return;
+  pair_relation = kUnfiltered;
 }
 
 bool CollisionFilter::operator==(const CollisionFilter& other) const {
@@ -140,6 +220,92 @@ bool CollisionFilter::operator==(const CollisionFilter& other) const {
   return true;
 }
 
+CollisionFilter CollisionFilter::MakeClearCopy() const {
+  auto clear_state = CollisionFilter::InitializeTransientState(
+      filter_state_, CollisionFilter::kUnfiltered);
+  CollisionFilter new_filter;
+  new_filter.filter_state_ = clear_state;
+  new_filter.filter_history_[0].filter_state = clear_state;
+  return new_filter;
+}
+
+void CollisionFilter::Apply(const CollisionFilterDeclaration& declaration,
+                            const CollisionFilter::ExtractIds& extract_ids,
+                            bool is_invariant, FilterState* filter_state) {
+  using Operation = CollisionFilterDeclaration::StatementOp;
+  for (const auto& statement : declaration.statements()) {
+    switch (statement.operation) {
+      case Operation::kAllowBetween:
+        // Note: GeometryState should never be declaring is_invariant is true
+        // while removing collision filters.
+        DRAKE_DEMAND(!is_invariant);
+        RemoveFiltersBetween(statement.set_A, statement.set_B, extract_ids,
+                             filter_state);
+        break;
+      case Operation::kAllowWithin:
+        DRAKE_DEMAND(!is_invariant);
+        RemoveFiltersBetween(statement.set_A, statement.set_A, extract_ids,
+                             filter_state);
+        break;
+      case Operation::kExcludeWithin:
+        AddFiltersBetween(statement.set_A, statement.set_A, extract_ids,
+                          is_invariant, filter_state);
+        break;
+      case Operation::kExcludeBetween:
+        AddFiltersBetween(statement.set_A, statement.set_B, extract_ids,
+                          is_invariant, filter_state);
+        break;
+    }
+  }
+}
+
+void CollisionFilter::AddGeometry(GeometryId new_id,
+                                  FilterState* filter_state_out,
+                                  PairRelationship relationship) {
+  FilterState& filter_state = *filter_state_out;
+  DRAKE_DEMAND(filter_state.count(new_id) == 0);
+  GeometryMap& new_map = filter_state[new_id] = {};
+  for (auto& [other_id, other_map] : filter_state) {
+    /* Whichever id is *smaller* tracks the relationship with the other.
+     That relationship defaults to unfiltered (i.e., "can collide").
+
+     Note: we're iterating over filter_state_ and assigning to either new_map
+     or other_map. This doesn't invalidate the implicit iterator of the range
+     operator. We never change the *keys* of filter_state_ in this loop, only
+     its values. And we don't do any iteration in the new_map or other_map
+     so don't depend on their iterators. */
+    if (other_id < new_id) {
+      other_map[new_id] = relationship;
+    } else {
+      new_map[other_id] = relationship;
+    }
+  }
+}
+
+void CollisionFilter::RemoveGeometry(GeometryId remove_id,
+                                     FilterState* filter_state_out) {
+  FilterState& filter_state = *filter_state_out;
+  DRAKE_DEMAND(filter_state.count(remove_id) == 1);
+  filter_state.erase(remove_id);
+  for (auto& [other_id, other_map] : filter_state) {
+    /* remove_id will only be found in maps belonging to geometries with ids
+     that are smaller than remove_id. Those that are larger were deleted when we
+     removed remove_id's entry. */
+    if (other_id < remove_id) {
+      other_map.erase(remove_id);
+    }
+  }
+}
+
+CollisionFilter::FilterState CollisionFilter::InitializeTransientState(
+    const FilterState& reference, PairRelationship default_relationship) {
+  FilterState new_state;
+  for (const auto& [id, _] : reference) {
+    unused(_);
+    AddGeometry(id, &new_state, default_relationship);
+  }
+  return new_state;
+}
 }  // namespace internal
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/proximity/collision_filter.h
+++ b/geometry/proximity/collision_filter.h
@@ -3,6 +3,7 @@
 #include <functional>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "drake/geometry/collision_filter_declaration.h"
@@ -24,7 +25,7 @@ class CollisionFilter {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CollisionFilter)
 
-  CollisionFilter() = default;
+  CollisionFilter();
 
   /* The callback function type for resolving a GeometrySet in a declaration
    into an explicitly enumerated set of GeometryIds. All ids in the resultant
@@ -35,9 +36,19 @@ class CollisionFilter {
   using ExtractIds =
       std::function<std::unordered_set<GeometryId>(const GeometrySet&)>;
 
-  /* Applies the collision filter declaration. The callback `extract_ids`
-   provides a means to convert the GeometrySet into an explicit, unique set of
-   GeometryIds for each GeometrySet defined in the given `declaration`.
+  /* Applies the collision filter declaration to the persistent state. The
+   callback `extract_ids` provides a means to convert the GeometrySet into an
+   explicit, unique set of GeometryIds for each GeometrySet defined in the
+   given `declaration`. The callback is *not* stored. It is used to process
+   the given `declaration` and then forgotten. The persistent configuration can
+   only be modified if there are no transient declarations active.
+
+   Note that adding invariant filters is a very explicit act. It is the
+   expectation that SceneGraph (and related classes) will never attempt to add
+   invariant filters at the same time as removing filters -- the only time a
+   statement adds and removes filters should be from a user. As such,
+   `is_invariant` should be `true` iff the declaration consists solely of
+   `Exclude*()` statements.
 
    @param declaration       The declaration to apply.
    @param extract_ids       A callback to convert a GeometrySet into the
@@ -46,9 +57,46 @@ class CollisionFilter {
                             be treated as a system invariant -- a filter that
                             cannot be removed.
    @throws std::exception if any GeometryId referenced by the declaration has
-                          not previously been added to `this` filter system. */
+                          not previously been added to `this` filter system.
+   @throws std::exception if there are any transient declarations active.
+   @pre If `is_invariant` is `true`, declaration contains no `Allow*()`
+        statements. */
   void Apply(const CollisionFilterDeclaration& declaration,
              const ExtractIds& extract_ids, bool is_invariant = false);
+
+  /* Applies the collision filter declaration as a transient declaration. The
+   callback `extract_ids` provides a means to convert the GeometrySet into an
+   explicit, unique set of GeometryIds for each Geometry set defined in the
+   given `declaration`. The callback is *not* stored. It is used to process
+   the given `declaration` and then forgotten.
+
+   @param declaration       The declaration to apply.
+   @param extract_ids       A callback to convert a GeometrySet into the
+                            explicit set of geometry ids.
+   @returns A unique FilterId for this transient declaration.
+   @throws std::exception if any GeometryId referenced by the declaration has
+                          not previously been added to the system. */
+  FilterId ApplyTransient(const CollisionFilterDeclaration& declaration,
+                          const ExtractIds& extract_ids);
+
+  /* Reports true if there are any active transient declarations.  */
+  bool has_transient_history() const {
+    /* Remember: filter_history_[0] is the persistent state. */
+    return filter_history_.size() > 1;
+  }
+
+  /* Reports if the given filter id is part of the active, transient history. */
+  bool IsActive(FilterId id) const;
+
+  /* Attempts to remove the transient declaration associated with the given id.
+   If the id isn't valid, no action is taken.
+
+   @returns true if a declaration is actually removed. */
+  bool RemoveDeclaration(FilterId id);
+
+  /* Flattens the history. The current configuration becomes the persistent
+   base configuration and all transient history is removed. */
+  void Flatten();
 
   /* Adds a geometry to the filter system. When added, it will not be part of
    any filtered pairs.
@@ -81,8 +129,16 @@ class CollisionFilter {
   bool HasGeometry(GeometryId id) const { return filter_state_.count(id) > 0; }
 
  private:
+  friend class CollisionFilterTest;
+
+  /* Test utility so that the unit tests can create a CollisionFilter with all
+   of the registered geometry but no collision filters. */
+  CollisionFilter MakeClearCopy() const;
+
   /* The collision filter state between a pair of geometries. */
-  enum PairFilterState {
+  enum PairRelationship {
+    kUndefined,        // No relationship has been defined; used for transient
+                       // declarations.
     kUnfiltered,       // No filter has been declared.
     kFiltered,         // A user-declared filter exists, the user can remove it.
     kInvariantFilter,  // The filter supports a SceneGraph filter invariant and
@@ -110,13 +166,27 @@ class CollisionFilter {
    As a concrete example, if we've registered GeometryId values 10, 20, 30, 40,
    the filter state would have keys {10, 20, 30, 40} which each maps to a
    corresponding GeometryMap as illustrated below.
-     10 -> {(20, PairFilterState), (30, PairFilterState), (40, PairFilterState)}
-     20 -> {(30, PairFilterState), (40, PairFilterState)}
-     30 -> {(40, PairFilterState)}
+     10 -> {(20, PairRelationship), (30, PairRelationship),
+            (40, PairRelationship)}
+     20 -> {(30, PairRelationship), (40, PairRelationship)}
+     30 -> {(40, PairRelationship)}
      40 -> {} */
-  using GeometryMap = std::unordered_map<GeometryId, PairFilterState>;
+  using GeometryMap = std::unordered_map<GeometryId, PairRelationship>;
 
   using FilterState = std::unordered_map<GeometryId, GeometryMap>;
+
+  /* Applies the given declaration to an arbitrary `filter_state`. */
+  static void Apply(const CollisionFilterDeclaration& declaration,
+                    const ExtractIds& extract_ids, bool is_invariant,
+                    FilterState* filter_state);
+
+  /* Adds the geometry with the given `id` to the given filter state with the
+   given initial_state for all pairs including the new id. */
+  static void AddGeometry(GeometryId id, FilterState* filter_state_out,
+                          PairRelationship relationship);
+
+  /* Removes the geometry with the given `id` from the given filter state. */
+  static void RemoveGeometry(GeometryId id, FilterState* filter_state_out);
 
   /* Declares pairs (`id_A`, `id_B`) `∀ id_A ∈ set_A, id_B ∈ set_B` to be
    filtered. For each pair, if they are already filtered, no discernible change
@@ -129,25 +199,61 @@ class CollisionFilter {
    responsible for determining invariance when adding filters.
 
    @pre All ids in `id_A` and `id_B` are part of this filter system.  */
-  void AddFiltersBetween(const GeometrySet& set_A, const GeometrySet& set_B,
-                         const ExtractIds& extract_ids, bool is_invariant);
+  static void AddFiltersBetween(const GeometrySet& set_A,
+                                const GeometrySet& set_B,
+                                const ExtractIds& extract_ids,
+                                bool is_invariant, FilterState* state_out);
 
   /* Declares pairs (`id_A`, `id_B`) `∀ id_A ∈ set_A, id_B ∈ set_B` to be
    unfiltered (if the filter isn't invariant). For each pair, if they are
    already unfiltered, no discernible change is made.
 
-   @pre All ids in `id_A` and `id_B` are part of this filter system.  */
-  void RemoveFiltersBetween(const GeometrySet& set_A, const GeometrySet& set_B,
-                            const CollisionFilter::ExtractIds& extract_ids);
+   @pre All ids `id_A` and `id_B` are part of the system.  */
+  static void RemoveFiltersBetween(const GeometrySet& set_A,
+                                   const GeometrySet& set_B,
+                                   const ExtractIds& extract_ids,
+                                   FilterState* state_out);
 
-  /* Atomic operation in support of AddFiltersBetween(). */
-  void AddFilteredPair(GeometryId id_A, GeometryId id_B, bool is_invariant);
+  /* Atomic operation in support of AddFiltersBetween().  */
+  static void AddFilteredPair(GeometryId id_A, GeometryId id_B,
+                              bool is_invariant, FilterState* state_out);
 
-  /* Atomic operation in support of RemoveFiltersBetween(). */
-  void RemoveFilteredPair(GeometryId id_A, GeometryId id_B);
+  /* Atomic operation in support of RemoveFilterBetween().  */
+  static void RemoveFilteredPair(GeometryId id_A, GeometryId id_B,
+                                 FilterState* state_out);
 
-  /* The filter state of all pairs of geometry. */
+  /* Instantiates a FilterState such that all known pairs have given
+   default relationship. */
+  static FilterState InitializeTransientState(
+      const FilterState& reference, PairRelationship default_relationship);
+
+  /* The filter state of all pairs of geometry.
+
+   This is neither the persistent base configuration nor the history. It is
+   the cached result of the base with all transient declarations applied. We
+   store this composite result in order to make collision filter lookups as
+   fast as possible. The implication is that when we update the history, we
+   must *also* update this so that it always reflects the final configuration.
+   */
   FilterState filter_state_;
+
+  /* The underlying data for transient history: the assigned filter id and
+   the filter state instance which represents the applied transient declaration.
+   The filter state has been initialized with all registered geometry and
+   *no* collision filters and has the transient declaration applied directly
+   to it. In other words, any geometry pair that isn't explicitly accounted
+   for in the declaration is marked with PairRelationship::kUndefined. */
+  struct StateDelta {
+    /* Default constructor to support resize of vector<StateDelta>. */
+    StateDelta() = default;
+
+    StateDelta(FilterState state, FilterId id_in)
+        : filter_state(std::move(state)), id(id_in) {}
+
+    FilterState filter_state;
+    FilterId id{};
+  };
+  std::vector<StateDelta> filter_history_;
 };
 
 }  // namespace internal

--- a/geometry/proximity/test/collision_filter_test.cc
+++ b/geometry/proximity/test/collision_filter_test.cc
@@ -19,6 +19,7 @@ class GeometrySetTester {
 
 namespace internal {
 
+using std::make_pair;
 using std::vector;
 
 constexpr bool kCanCollide = true;
@@ -79,6 +80,10 @@ class CollisionFilterTest : public ::testing::Test {
   /* Returns a value for the collision filter id extraction functor. */
   static CollisionFilter::ExtractIds get_extract_ids_functor() {
     return &GeometrySetTester::geometries;
+  }
+
+  static CollisionFilter ClearCopy(const CollisionFilter& filter) {
+    return filter.MakeClearCopy();
   }
 };
 
@@ -187,6 +192,224 @@ TEST_F(CollisionFilterTest, NoSelfCollision) {
 
   // TODO(SeanCurtis-TRI): When we add filter *removal* confirm that attempts to
   // add pair (A, A) back into candidate set C doesn't work.
+}
+
+/* Exercise transient declaration API. This entails five different methods that
+ are all deeply entangled, so we'll have to test them together. For each
+ function, we want to test certain properties (as listed below):
+  A ApplyTransient()
+    1 Can't remove invariant filters.
+    2 Can add filters.
+    3 Can remove filters.
+  B has_transient_history()
+    1 No history reports false.
+    2 History reports true.
+  C IsActive()
+    1 No active history implies no ids report as active.
+    2 Ids in active set report true.
+    3 Ids not in active set report false.
+  D RemoveDeclaration()
+    1 Removing an invalid id is a no-op.
+    2 Removing the last declaration returns us to the previous state.
+    3 Removing an intermediate declaration has playback.
+  E Flatten()
+    1 Flattening an "only-persitent" filter state makes no difference.
+    2 Any previous ids given are no longer valid.
+    3 Reports no active history.
+    4 Flatten preserves resultant filter state (i.e., the set of filtered
+      pairs is same before and after flattening).
+
+  In addition, to those *specific* methods, there are aspects of the other
+  methods that interact with transient history:
+
+   F Add geometry to system with transient history.
+   G Remove geometry from system with transient history.
+   H Two collision filters with the same *end* result are equal, even if their
+     history is different.
+
+  The testing methodology is a sequence of operations that will give us the
+  chance to test all of the properties above. Comments will reference which
+  property is under test. */
+TEST_F(CollisionFilterTest, TransientDeclarations) {
+  CollisionFilter filter;
+
+  /* Prop. C.1: No history -> not active. */
+  EXPECT_FALSE(filter.IsActive(FilterId::get_new_id()));
+  /* Prop. B.1: No history -> reports false. */
+  EXPECT_FALSE(filter.has_transient_history());
+
+  /* Five geometry ids give us ten possible pairs to play with. */
+  auto new_id = [&filter]() {
+    const GeometryId id = GeometryId::get_new_id();
+    filter.AddGeometry(id);
+    return id;
+  };
+  const GeometryId A = new_id();
+  const GeometryId B = new_id();
+  const GeometryId C = new_id();
+  const GeometryId D = new_id();
+  const GeometryId E = new_id();
+
+  const bool invariant = true;
+
+  /* We'll track the expected pairs by adding them and removing them from this
+   collection. */
+  using Pair = std::pair<GeometryId, GeometryId>;
+  using Decl = CollisionFilterDeclaration;
+
+  /* Prop. H: This test encodes expected filters into persistent base
+   configuration and compares it against a filter with arbitrary history.
+   The parameter `expected` should be *all* the geometry pairs that the filter
+   `f` would report as filtered. */
+  auto is_expected =
+      [this](const CollisionFilter& f,
+             const std::set<Pair>& expected) -> ::testing::AssertionResult {
+    CollisionFilter temp_filter = this->ClearCopy(f);
+    for (const auto& pair : expected) {
+      temp_filter.Apply(
+          Decl().ExcludeWithin(GeometrySet({pair.first, pair.second})),
+          this->get_extract_ids_functor(), !invariant);
+    }
+    if (temp_filter != f) return ::testing::AssertionFailure();
+    return ::testing::AssertionSuccess();
+  };
+
+  std::set<Pair> expected_filter_pairs;
+  const CollisionFilter::ExtractIds& extract = this->get_extract_ids_functor();
+
+  /* Set up the persistent base with pairs
+    P(D, E), (B, C), (B, D), (B, E)
+    * P(i, j) denotes an *invariant* pair between i and j. */
+  filter.Apply(Decl().ExcludeWithin(GeometrySet{D, E}), extract, invariant);
+  filter.Apply(Decl().ExcludeBetween(GeometrySet{B}, GeometrySet{C, D, E}),
+               extract, !invariant);
+  expected_filter_pairs.emplace(make_pair(D, E));
+  expected_filter_pairs.emplace(make_pair(B, C));
+  expected_filter_pairs.emplace(make_pair(B, D));
+  expected_filter_pairs.emplace(make_pair(B, E));
+  ASSERT_TRUE(is_expected(filter, expected_filter_pairs));
+
+  /* Prop. H: Add a redundant declaration, so now we *know* we're testing a
+   filter *with* history against one without. Filtered pairs are still:
+    P(D, E), (B, C), (B, D), (B, E) */
+  const FilterId id0 =
+      filter.ApplyTransient(CollisionFilterDeclaration().ExcludeBetween(
+                                GeometrySet{B}, GeometrySet{{C, D, E}}),
+                            this->get_extract_ids_functor());
+  EXPECT_TRUE(is_expected(filter, expected_filter_pairs));
+  /* Prop. B.2.: history -> true */
+  EXPECT_TRUE(filter.has_transient_history());
+  /* Prop. C.2: Has history, query valid id -> active. */
+  EXPECT_TRUE(filter.IsActive(id0));
+  /* Prop. C.3: Has history, query invalid id -> not active. */
+  EXPECT_FALSE(filter.IsActive(FilterId::get_new_id()));
+
+  /* Prop. A.2 and A.3: Add new filter (C, D), remove old, non-invariant
+   filter (B, D). Filtered pairs become:
+    P(D, E), (B, C), (B, E), (C, D) */
+  const FilterId id1 = filter.ApplyTransient(
+      Decl().ExcludeWithin(GeometrySet{C, D}).AllowWithin(GeometrySet{B, D}),
+      extract);
+  /* The new declaration is active. */
+  EXPECT_TRUE(filter.IsActive(id1));
+  /* The old declaration, although supplanted, is also active. */
+  EXPECT_TRUE(filter.IsActive(id0));
+  expected_filter_pairs.emplace(make_pair(C, D));
+  expected_filter_pairs.erase(expected_filter_pairs.find(make_pair(B, D)));
+  ASSERT_TRUE(is_expected(filter, expected_filter_pairs));
+
+  /* This declaration will be used twice. We'll add and then remove it (with
+   this as the last declaration to test D.2), and then use it again to test D.3.
+   */
+  /* We'll save the state at id 1 as we'll be returning to it. */
+  const CollisionFilter filter_as_of_id1(filter);
+  Decl add_2_clear_2;
+  add_2_clear_2.ExcludeBetween(GeometrySet(A), GeometrySet{B, C})
+      .AllowBetween(GeometrySet(B), GeometrySet{C, E});
+
+  /* Prop. C.2 and C.3 again: adding and removing filters. More complex. The
+   state becomes:
+    P(D, E), (A, B), (A, C), (C, D) */
+  const FilterId id2 = filter.ApplyTransient(add_2_clear_2, extract);
+  EXPECT_TRUE(filter.IsActive(id2));
+  expected_filter_pairs.emplace(make_pair(A, B));
+  expected_filter_pairs.emplace(make_pair(A, C));
+  expected_filter_pairs.erase(expected_filter_pairs.find(make_pair(B, C)));
+  expected_filter_pairs.erase(expected_filter_pairs.find(make_pair(B, E)));
+  ASSERT_TRUE(is_expected(filter, expected_filter_pairs));
+
+  /* Prop. D.1: Removing invalid id does nothing. */
+  EXPECT_FALSE(filter.RemoveDeclaration(FilterId::get_new_id()));
+  ASSERT_TRUE(is_expected(filter, expected_filter_pairs));
+
+  /* Prop. D.2: Removing last declaration returns to previous state:
+    P(D, E), (B, C), (B, E), (C, D) */
+  EXPECT_TRUE(filter.RemoveDeclaration(id2));
+  ASSERT_TRUE(filter == filter_as_of_id1);
+
+  /* Re-apply the declaration (add_2_clear_2) to become:
+    P(D, E), (A, B), (A, C), (C, D) */
+  const FilterId id3 = filter.ApplyTransient(add_2_clear_2, extract);
+  EXPECT_TRUE(filter.IsActive(id3));
+  ASSERT_TRUE(is_expected(filter, expected_filter_pairs));
+
+  /* Add a further declaration that is *partially* redundant w.r.t. the previous
+   declaration. We'll continue to filter (A, B) and continue to allow (B, E):
+    P(D, E), (A, B), (A, C), (C, D) */
+  const FilterId id4 = filter.ApplyTransient(
+      Decl().ExcludeWithin(GeometrySet{A, B}).AllowWithin(GeometrySet{B, E}),
+      extract);
+  EXPECT_TRUE(filter.IsActive(id4));
+  ASSERT_TRUE(is_expected(filter, expected_filter_pairs));
+
+  /* Prop. D.3: Removing id 3 will only half undo its work. id 4 keeps one
+   filter and one removal:
+    P(D, E), (A, B), (B, C), (C, D) */
+  EXPECT_TRUE(filter.RemoveDeclaration(id3));
+  expected_filter_pairs.erase(expected_filter_pairs.find(make_pair(A, C)));
+  expected_filter_pairs.emplace(make_pair(B, C));
+  ASSERT_TRUE(is_expected(filter, expected_filter_pairs));
+
+  /* Prop. A.1: Attempting to remove invariant filter makes no difference:
+    P(D, E), (A, B), (B, C), (C, D) */
+  const FilterId id5 =
+      filter.ApplyTransient(Decl().AllowWithin(GeometrySet{D, E}), extract);
+  EXPECT_TRUE(filter.IsActive(id5));
+  ASSERT_TRUE(is_expected(filter, expected_filter_pairs));
+
+  /* Prop. F: Adding a geometry to filter with history is allowed and preserves
+   filters:
+    P(D, E), (A, B), (B, C), (C, D) */
+  const GeometryId F = GeometryId::get_new_id();
+  filter.AddGeometry(F);
+  ASSERT_TRUE(is_expected(filter, expected_filter_pairs));
+
+  /* Prop. G: Removing a geometry does the right thing. We'll remove a geometry
+   with filters to see the impact:
+    P(D, E), (B, C), (C, D) */
+  filter.RemoveGeometry(A);
+  expected_filter_pairs.erase(expected_filter_pairs.find(make_pair(A, B)));
+  ASSERT_TRUE(is_expected(filter, expected_filter_pairs));
+
+  /* Prop E: flattening history. Before flattening, we'll confirm valid filter
+   ids and active history. */
+  ASSERT_TRUE(filter.has_transient_history());
+  for (FilterId id : {id0, id1, id4, id5}) ASSERT_TRUE(filter.IsActive(id));
+
+  filter.Flatten();
+
+  /* Prop. E.1: Flatten -> unchanged resultant filter state. */
+  ASSERT_TRUE(is_expected(filter, expected_filter_pairs));
+
+  /* Prop. E.2: Flatten -> reports no active history. */
+  EXPECT_FALSE(filter.has_transient_history());
+
+  /* Prop. E.3: Flatten -> Invalid ids. */
+  for (FilterId id : {id0, id1, id4, id5}) EXPECT_FALSE(filter.IsActive(id));
+
+  /* Prop. E.4: Flatten flat history makes no difference. */
+  EXPECT_NO_THROW(filter.Flatten());
+  ASSERT_TRUE(is_expected(filter, expected_filter_pairs));
 }
 
 /* In this test, we're confirming the logic of operator== and operator!=. As

--- a/geometry/test/collision_filter_manager_test.cc
+++ b/geometry/test/collision_filter_manager_test.cc
@@ -95,6 +95,22 @@ GTEST_TEST(CollisionFilterManagerTest, Apply) {
   EXPECT_FALSE(inspector.CollisionFiltered(g_id1, g_id3));
   EXPECT_FALSE(inspector.CollisionFiltered(g_id2, g_id3));
 
+  EXPECT_FALSE(filter_manager.has_transient_history());
+
+  const FilterId filter_id =
+      filter_manager.ApplyTransient(CollisionFilterDeclaration().ExcludeBetween(
+          GeometrySet({g_id1, g_id2}), GeometrySet({g_id3})));
+  EXPECT_TRUE(inspector.CollisionFiltered(g_id1, g_id2));
+  EXPECT_TRUE(inspector.CollisionFiltered(g_id1, g_id3));
+  EXPECT_TRUE(inspector.CollisionFiltered(g_id2, g_id3));
+
+  EXPECT_TRUE(filter_manager.has_transient_history());
+  EXPECT_TRUE(filter_manager.IsActive(filter_id));
+  EXPECT_TRUE(filter_manager.RemoveDeclaration(filter_id));
+  EXPECT_TRUE(inspector.CollisionFiltered(g_id1, g_id2));
+  EXPECT_FALSE(inspector.CollisionFiltered(g_id1, g_id3));
+  EXPECT_FALSE(inspector.CollisionFiltered(g_id2, g_id3));
+
   // Note that the underlying model *didn't* change.
   const auto& model_inspector = scene_graph.model_inspector();
   EXPECT_FALSE(model_inspector.CollisionFiltered(g_id1, g_id2));


### PR DESCRIPTION
This introduces the concept of a history of collision filter modifications and the ability to edit that history.

 - Introduce new id type: `FilterId`.
 - `CollisionFilterManager` introduces the concept and provides an API for exercising it.
 - `CollisionFilter` implements the plumbing.
 - Python bindings

resolves #15089

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15492)
<!-- Reviewable:end -->
