### PR TITLE
[geometry] Document AddPolygonToMeshDataAsOneTriangle for a polygon that is already a triangle.

### DIFF
--- a/geometry/proximity/contact_surface_utility.h
+++ b/geometry/proximity/contact_surface_utility.h
@@ -132,7 +132,8 @@ constexpr double kMinimumPolygonArea = 1e-13;
  introduced into `vertices`.
 
  The exact choice of the representative triangle is arbitrary subject to the
- constraints in the previous paragraph.
+ constraints in the previous paragraph. If the polygon is already a triangle,
+ we will add that original triangle in the output.
 
  In debug builds, this function will do _expensive_ validation of its
  parameters.

--- a/geometry/proximity/test/contact_surface_utility_test.cc
+++ b/geometry/proximity/test/contact_surface_utility_test.cc
@@ -575,6 +575,31 @@ GTEST_TEST(ContactSurfaceUtility, AddPolygonToMeshDataAsOneTriangle) {
   }
 }
 
+// Tests AddPolygonToMeshDataAsOneTriangle() for the special case of a
+// polygon that is already a triangle, i.e. a 3-gon. It should add that
+// triangle exactly without calculating a different representative triangle.
+GTEST_TEST(ContactSurfaceUtility, AddPolygonToMeshDataAsOneTriangle_3Gon) {
+  // A triangle is a special case of a polygon. Values of the coordinates
+  // are less relevant to this test.
+  const vector<Vector3d> polygon_F{Vector3d::Zero(), 2 * Vector3d::UnitX(),
+                                   3 * Vector3d::UnitY()};
+  const Vector3d nhat_F = Vector3d::UnitZ();
+
+  vector<SurfaceFace> faces;
+  vector<SurfaceVertex<double>> vertices_F;
+  AddPolygonToMeshDataAsOneTriangle<double>(polygon_F, nhat_F, &faces,
+                                            &vertices_F);
+  ASSERT_EQ(faces.size(), 1);
+  EXPECT_EQ(faces[0].vertex(0), SurfaceVertexIndex(0));
+  EXPECT_EQ(faces[0].vertex(1), SurfaceVertexIndex(1));
+  EXPECT_EQ(faces[0].vertex(2), SurfaceVertexIndex(2));
+
+  ASSERT_EQ(vertices_F.size(), 3);
+  EXPECT_EQ(vertices_F[0].r_MV(), polygon_F[0]);
+  EXPECT_EQ(vertices_F[1].r_MV(), polygon_F[1]);
+  EXPECT_EQ(vertices_F[2].r_MV(), polygon_F[2]);
+}
+
 // Tests AddPolygonToMeshDataAsOneTriangle() with AutoDiffXd. It's only a
 // smoke test. We only check that it compiles, and derivatives propagate to a
 // coordinate of a vertex.


### PR DESCRIPTION
Document AddPolygonToMeshDataAsOneTriangle, which is used in
hydroelastics, for the special case of the polygon that is already a
triangle. Add a unit test to confirm.
