### PR TITLE
[trajectories] Fix uninitialized data in unit test

### DIFF
--- a/common/trajectories/test/piecewise_polynomial_generation_test.cc
+++ b/common/trajectories/test/piecewise_polynomial_generation_test.cc
@@ -658,6 +658,8 @@ GTEST_TEST(SplineTests, TestException) {
   Y = std::vector<MatrixX<double>>(T.size(), MatrixX<double>::Zero(rows, cols));
   MatrixX<double> Ydot0(rows, cols);
   MatrixX<double> Ydot1(rows, cols);
+  Ydot0.setZero();
+  Ydot1.setZero();
   DRAKE_EXPECT_NO_THROW(
       PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(
           T, Y, Ydot0, Ydot1));


### PR DESCRIPTION
Caught by memcheck when running against Eigen 3.4

Towards #15142.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15499)
<!-- Reviewable:end -->
