### PR TITLE
[solver] IpOptSolver respects CommonSolverOptions::kPrintToConsole

### DIFF
--- a/solvers/ipopt_solver.cc
+++ b/solvers/ipopt_solver.cc
@@ -748,8 +748,12 @@ void SetIpoptOptions(const MathematicalProgram& prog,
   SetIpoptOptionsHelper<std::string>("hessian_approximation", "limited-memory",
                                      &merged_solver_options);
   // Note: 0<= print_level <= 12, with higher numbers more verbose.  4 is very
-  // useful for debugging.
-  SetIpoptOptionsHelper<int>("print_level", 2, &merged_solver_options);
+  // useful for debugging. Otherwise, we default to printing nothing. The user
+  // can always select an arbitrary print level, by setting the ipopt value
+  // directly in the solver options.
+  int common_print_level = merged_solver_options.get_print_to_console() ? 4 : 0;
+  SetIpoptOptionsHelper<int>("print_level", common_print_level,
+                             &merged_solver_options);
 
   const auto& ipopt_options_double =
       merged_solver_options.GetOptionsDouble(IpoptSolver::id());

--- a/solvers/test/ipopt_solver_test.cc
+++ b/solvers/test/ipopt_solver_test.cc
@@ -211,6 +211,52 @@ GTEST_TEST(IpoptSolverTest, TestNonconvexQP) {
   }
 }
 
+/* Tests the solver's processing of the verbosity options. With multiple ways
+ to request verbosity (common options and solver-specific options), we simply
+ apply a smoke test that none of the means causes runtime errors. Note, we
+ don't test the case where we configure the mathematical program itself; that
+ is resolved in SolverBase. We only need to test the options passed into
+ Solve(). The possible configurations are:
+    - No verbosity set at all (this is implicitly tested in all other tests).
+    - Common option explicitly set (on & off)
+    - Solver option explicitly set (on & off)
+    - Both options explicitly set (with all permutations of (on, on), etc.) */
+GTEST_TEST(IpoptSolverTest, SolverOptionsVerbosity) {
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables(1);
+  prog.AddLinearConstraint(x(0) <= 3);
+  prog.AddLinearConstraint(x(0) >= -3);
+  prog.AddLinearCost(x(0));
+
+  IpoptSolver solver;
+
+  if (solver.is_available()) {
+    // Setting common options.
+    for (int print_to_console : {0, 1}) {
+      SolverOptions options;
+      options.SetOption(CommonSolverOption::kPrintToConsole, print_to_console);
+      solver.Solve(prog, {}, options);
+    }
+    // Setting solver options.
+    for (int print_to_console : {0, 2}) {
+      SolverOptions options;
+      options.SetOption(IpoptSolver::id(), "print_level", print_to_console);
+      solver.Solve(prog, {}, options);
+    }
+    // Setting both.
+    for (int common_print_to_console : {0, 1}) {
+      for (int solver_print_to_console : {0, 2}) {
+        SolverOptions options;
+        options.SetOption(CommonSolverOption::kPrintToConsole,
+                          common_print_to_console);
+        options.SetOption(IpoptSolver::id(), "print_level",
+                          solver_print_to_console);
+        solver.Solve(prog, {}, options);
+      }
+    }
+  }
+}
+
 TEST_P(TestEllipsoidsSeparation, TestSOCP) {
   IpoptSolver ipopt_solver;
   if (ipopt_solver.available()) {


### PR DESCRIPTION
Verbosity can now be controlled by either the solver-specific "print_level" flag, or the Drake common property `kPrintToConsole`.

Relates #12867

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15502)
<!-- Reviewable:end -->
