### PR TITLE
wrap_function: Preserve return type for mutable and const class methods

### DIFF
--- a/bindings/pydrake/common/test/wrap_function_test.cc
+++ b/bindings/pydrake/common/test/wrap_function_test.cc
@@ -5,6 +5,8 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/drake_copyable.h"
+
 // @note Some of these statements violate style guide. That is intended, as
 // this should test references for use in `pybind`.
 
@@ -392,6 +394,26 @@ GTEST_TEST(WrapFunction, ChangeCallbackOnly) {
       // Arguments.
       double*, CallbackWrapped, CallbackWrapped>;
   check_expected::run(wrapped);
+}
+
+// Testing for #15505.
+struct ArgNoCopyNoMove {
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ArgNoCopyNoMove)
+  ArgNoCopyNoMove() {}
+};
+
+class ArgNoCopyNoMoveContainer {
+ public:
+  const ArgNoCopyNoMove& get_const() const { return noncopyable_; }
+  const ArgNoCopyNoMove& get_mutable() { return noncopyable_; }
+
+ private:
+  ArgNoCopyNoMove noncopyable_;
+};
+
+GTEST_TEST(WrapFunction, InferForArgNoCopyNoMove) {
+  WrapIdentity(&ArgNoCopyNoMoveContainer::get_const);
+  WrapIdentity(&ArgNoCopyNoMoveContainer::get_mutable);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/common/wrap_function.h
+++ b/bindings/pydrake/common/wrap_function.h
@@ -40,7 +40,7 @@ auto infer_function_info(Return (*func)(Args...)) {
 // Infers `function_info<>` from a mutable method pointer.
 template <typename Return, typename Class, typename... Args>
 auto infer_function_info(Return (Class::*method)(Args...)) {
-  auto func = [method](Class* self, Args... args) {
+  auto func = [method](Class* self, Args... args) -> Return {
     return (self->*method)(std::forward<Args>(args)...);
   };
   return make_function_info<Return, Class*, Args...>(func);
@@ -49,7 +49,7 @@ auto infer_function_info(Return (Class::*method)(Args...)) {
 // Infers `function_info<>` from a const method pointer.
 template <typename Return, typename Class, typename... Args>
 auto infer_function_info(Return (Class::*method)(Args...) const) {
-  auto func = [method](const Class* self, Args... args) {
+  auto func = [method](const Class* self, Args... args) -> Return {
     return (self->*method)(std::forward<Args>(args)...);
   };
   return make_function_info<Return, const Class*, Args...>(func);


### PR DESCRIPTION
Resolves #15505

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15507)
<!-- Reviewable:end -->
