### PR TITLE
Remove rare typos "this this" and "that that".

### DIFF
--- a/bindings/pydrake/common/test/cpp_template_test.py
+++ b/bindings/pydrake/common/test/cpp_template_test.py
@@ -147,7 +147,7 @@ class TestCppTemplate(unittest.TestCase):
                     self.mangled_result = self.__mangled_method()
 
                 def __mangled_method(self):
-                    # Ensure that that mangled methods are usable.
+                    # Ensure that mangled methods are usable.
                     return (T, 10)
 
             return Impl

--- a/common/drake_copyable.h
+++ b/common/drake_copyable.h
@@ -19,8 +19,8 @@ Code that needs custom copy or move functions should not use these macros.
 /** DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN deletes the special member functions for
 copy-construction, copy-assignment, move-construction, and move-assignment.
 Drake's Doxygen is customized to render the deletions in detail, with
-appropriate comments.  Invoke this this macro in the public section of the
-class declaration, e.g.:
+appropriate comments.  Invoke this macro in the public section of the class
+declaration, e.g.:
 <pre>
 class Foo {
  public:
@@ -43,8 +43,8 @@ copy-assignment defaults are well-formed.  Note that the defaulted move
 functions could conceivably still be ill-formed, in which case they will
 effectively not be declared or used -- but because the copy constructor exists
 the type will still be MoveConstructible.  Drake's Doxygen is customized to
-render the functions in detail, with appropriate comments.  Invoke this this
-macro in the public section of the class declaration, e.g.:
+render the functions in detail, with appropriate comments.  Invoke this macro
+in the public section of the class declaration, e.g.:
 <pre>
 class Foo {
  public:

--- a/multibody/tree/mobilizer_impl.h
+++ b/multibody/tree/mobilizer_impl.h
@@ -102,10 +102,10 @@ class MobilizerImpl : public Mobilizer<T> {
     if (!random_state_distribution_) {
       random_state_distribution_.emplace(
           Vector<symbolic::Expression, kNx>::Zero());
-      // Note that that there is no `get_zero_velocity()`, since the zero
-      // velocity is simply zero for all mobilizers.  Setting the velocity
-      // elements of the distribution to zero here therefore maintains the
-      // default behavior for velocity.
+      // Note that there is no `get_zero_velocity()`, since the zero velocity
+      // is simply zero for all mobilizers.  Setting the velocity elements of
+      // the distribution to zero here therefore maintains the default behavior
+      // for velocity.
     }
 
     random_state_distribution_->template head<kNq>() = position;


### PR DESCRIPTION
Fun fact, not all uses of "that that" are typos.

In some cases, update word wrap.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15511)
<!-- Reviewable:end -->
