### PR TITLE
[planner] Remove useless assertion in test

### DIFF
--- a/manipulation/planner/test/differential_inverse_kinematics_test.cc
+++ b/manipulation/planner/test/differential_inverse_kinematics_test.cc
@@ -50,7 +50,6 @@ class DifferentialInverseKinematicsTest : public ::testing::Test {
     plant_->Finalize();
     owned_context_ = plant_->CreateDefaultContext();
     context_ = owned_context_.get();
-    DRAKE_THROW_UNLESS(context_);
 
     // Configure the Diff IK.
     params_ = std::make_unique<DifferentialInverseKinematicsParameters>(


### PR DESCRIPTION
The likelihood that `MultibodyPlant::CreateDefaultContext()` returns null is very small.

(This is the only place within Drake where we `DRAKE_THROW_UNLESS` on a bare pointer without any explicit comparison to nullptr.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15512)
<!-- Reviewable:end -->
