### PR TITLE
[common] Deprecate DRAKE_THROW_UNLESS on a bare pointer

### DIFF
--- a/common/drake_throw.h
+++ b/common/drake_throw.h
@@ -14,17 +14,40 @@ namespace internal {
 // Throw an error message.
 [[noreturn]] void Throw(const char* condition, const char* func,
                         const char* file, int line);
+
+template <bool>
+constexpr void DrakeThrowUnlessWasUsedWithRawPointer() {}
+template<>
+[[deprecated("\nDRAKE DEPRECATED: When using DRAKE_THROW_UNLESS on a raw"
+" pointer, always write out DRAKE_THROW_UNLESS(foo != nullptr), do not write"
+" DRAKE_THROW_UNLESS(foo) and rely on implicit pointer-to-bool conversion."
+"\nThe deprecated code will be removed from Drake on or after 2021-12-01.")]]
+constexpr void DrakeThrowUnlessWasUsedWithRawPointer<true>() {}
+
 }  // namespace internal
 }  // namespace drake
 
 /// Evaluates @p condition and iff the value is false will throw an exception
 /// with a message showing at least the condition text, function name, file,
 /// and line.
+///
+/// The condition must not be a pointer, where we'd implicitly rely on its
+/// nullness. Instead, always write out "!= nullptr" to be precise.
+///
+/// Correct: `DRAKE_THROW_UNLESS(foo != nullptr);`
+/// Incorrect: `DRAKE_THROW_UNLESS(foo);`
+///
+/// Because this macro is intended to provide a useful exception message to
+/// users, we should err on the side of extra detail about the failure. The
+/// meaning of "foo" isolated within error message text does not make it
+/// clear that a null pointer is the proximate cause of the problem.
 #define DRAKE_THROW_UNLESS(condition)                                        \
   do {                                                                       \
     typedef ::drake::assert::ConditionTraits<                                \
         typename std::remove_cv_t<decltype(condition)>> Trait;               \
     static_assert(Trait::is_valid, "Condition should be bool-convertible."); \
+    ::drake::internal::DrakeThrowUnlessWasUsedWithRawPointer<                \
+        std::is_pointer_v<decltype(condition)>>();                           \
     if (!Trait::Evaluate(condition)) {                                       \
       ::drake::internal::Throw(#condition, __func__, __FILE__, __LINE__);    \
     }                                                                        \

--- a/common/test/drake_throw_test.cc
+++ b/common/test/drake_throw_test.cc
@@ -13,4 +13,13 @@ GTEST_TEST(DrakeThrowTest, BasicTest) {
   EXPECT_THROW(DRAKE_THROW_UNLESS(false), std::runtime_error);
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+GTEST_TEST(DrakeThrowTest, DeprecatedTest) {
+  int foo{};
+  int* foo_pointer = &foo;
+  DRAKE_EXPECT_NO_THROW(DRAKE_THROW_UNLESS(foo_pointer));
+}
+#pragma GCC diagnostic pop
+
 }  // namespace


### PR DESCRIPTION
For a raw pointer, when checking for null we'd like to insist on an explicit mention of `nullptr`:

Example function:
`void DoStuff(Foo* foo) { ... }`

Correct:
`DRAKE_THROW_UNLESS(foo != nullptr);`

Incorrect:
`DRAKE_THROW_UNLESS(foo);`

Because the macro is intended to provide a useful exception message to users, we should err on the side of extra detail about the failure condition.  The meaning of "foo" isolated within error message text does not make it clear that a null pointer is the proximate cause of the problem.

In the future, we could imagine even better macros or improved error messages, where even saying `!= nullptr` was an anachronism.  (For example, `DRAKE_NONNULL(foo);`.)  For now, though, just linting for some minimal cases at least captures and holds _some_ ground, and will make it easier to bulk-change to a better spelling if we find one later.

Relates to #15500.

- [x] Depends on #15512.
- [x] Depends on Anzu 7373.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15513)
<!-- Reviewable:end -->
