### PR TITLE
[framework] Respell SFINAE for Apple Clang

### DIFF
--- a/systems/framework/value_producer.h
+++ b/systems/framework/value_producer.h
@@ -354,11 +354,12 @@ class ValueProducer final {
 
   /** Overload (5b). Refer to the
   @ref ValueProducer_constructors "Constructor overloads" for details. */
-  template <typename SomeOutput>
+  template <typename SomeOutput,
+      typename = std::enable_if_t<!std::is_convertible_v<
+          SomeOutput, AllocateCallback>>>
   ValueProducer(
-      const SomeOutput& model_value, CalcCallback calc,
-      std::enable_if_t<!std::is_convertible_v<
-          SomeOutput, AllocateCallback>>* = 0)
+      const SomeOutput& model_value,
+      CalcCallback calc)
       : ValueProducer(make_allocate_mode_b(model_value),
                       std::move(calc)) {}
 


### PR DESCRIPTION
When using Eigen 3.4 pre-release, the prior spelling ends up with inexplicable compilation errors when using Apple Clang; this new spelling seems to work better.

Closes #15498.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15517)
<!-- Reviewable:end -->
