### PR TITLE
common: provides ExtractDoubleOrThrow for Eigen::MatrixBase

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -871,6 +871,7 @@ drake_cc_googletest(
     deps = [
         ":essential",
         ":extract_double",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -1091,6 +1092,7 @@ drake_cc_googletest(
         ":essential",
         ":polynomial",
         ":symbolic",
+        "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:is_memcpy_movable",
         "//common/test_utilities:symbolic_test_util",
     ],

--- a/common/autodiff_overloads.h
+++ b/common/autodiff_overloads.h
@@ -160,6 +160,22 @@ double ExtractDoubleOrThrow(const Eigen::AutoDiffScalar<DerType>& scalar) {
   return static_cast<double>(scalar.value());
 }
 
+/// Returns @p matrix as an Eigen::Matrix<double, ...> with the same size
+/// allocation as @p matrix.  Calls ExtractDoubleOrThrow on each element of the
+/// matrix, and therefore throws if any one of the extractions fail.
+template <typename DerType, int RowsAtCompileTime, int ColsAtCompileTime,
+          int Options, int MaxRowsAtCompileTime, int MaxColsAtCompileTime>
+auto ExtractDoubleOrThrow(
+    const Eigen::MatrixBase<Eigen::Matrix<
+        Eigen::AutoDiffScalar<DerType>, RowsAtCompileTime, ColsAtCompileTime,
+        Options, MaxRowsAtCompileTime, MaxColsAtCompileTime>>& matrix) {
+  return matrix
+      .unaryExpr([](const typename Eigen::AutoDiffScalar<DerType>& value) {
+        return ExtractDoubleOrThrow(value);
+      })
+      .eval();
+}
+
 /// Specializes common/dummy_value.h.
 template <typename DerType>
 struct dummy_value<Eigen::AutoDiffScalar<DerType>> {

--- a/common/symbolic_expression.h
+++ b/common/symbolic_expression.h
@@ -1478,6 +1478,23 @@ struct dummy_value<symbolic::Expression> {
 /// expression with an empty environment.
 double ExtractDoubleOrThrow(const symbolic::Expression& e);
 
+/// Returns @p matrix as an Eigen::Matrix<double, ...> with the same size
+/// allocation as @p matrix.  Calls ExtractDoubleOrThrow on each element of the
+/// matrix, and therefore throws if any one of the extractions fail.
+template <typename Derived>
+typename std::enable_if_t<
+    std::is_same_v<typename Derived::Scalar, symbolic::Expression>,
+    Eigen::Matrix<double, Derived::RowsAtCompileTime,
+                  Derived::ColsAtCompileTime, Derived::Options,
+                  Derived::MaxRowsAtCompileTime, Derived::MaxColsAtCompileTime>>
+ExtractDoubleOrThrow(const Eigen::MatrixBase<Derived>& matrix) {
+  return matrix
+      .unaryExpr([](const typename Derived::Scalar& value) {
+        return ExtractDoubleOrThrow(value);
+      })
+      .eval();
+}
+
 /*
  * Determine if two EigenBase<> types are matrices (non-column-vectors) of
  * Expressions and doubles, to then form an implicit formulas.

--- a/common/test/autodiff_overloads_test.cc
+++ b/common/test/autodiff_overloads_test.cc
@@ -70,6 +70,11 @@ GTEST_TEST(AutodiffOverloadsTest, ExtractDouble) {
   // A double still works, too.
   double y = 1.0;
   EXPECT_EQ(ExtractDoubleOrThrow(y), 1.0);
+
+  // Eigen variant.
+  Vector2<Eigen::AutoDiffScalar<Eigen::Vector2d>> v{9.0, 7.0};
+  EXPECT_TRUE(
+      CompareMatrices(ExtractDoubleOrThrow(v), Eigen::Vector2d{9.0, 7.0}));
 }
 
 // Tests correctness of nexttoward.

--- a/common/test/extract_double_test.cc
+++ b/common/test/extract_double_test.cc
@@ -5,6 +5,8 @@
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+
 // A non-numeric ScalarType for testing.
 namespace { struct NonNumericScalar { }; }
 
@@ -20,9 +22,24 @@ GTEST_TEST(ExtractDoubleTest, BasicTest) {
   const double y = 2.0;
   EXPECT_EQ(ExtractDoubleOrThrow(y), 2.0);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   // A non-numeric throws.
   NonNumericScalar non_numeric;
   EXPECT_THROW(ExtractDoubleOrThrow(non_numeric), std::exception);
+#pragma GCC diagnostic pop
+}
+
+GTEST_TEST(ExtractDoubleTest, MatrixTest) {
+  // Fixed size matrices work.
+  Eigen::Matrix2d x;
+  x << 1.0, 2.0, 3.0, 4.0;
+  EXPECT_TRUE(CompareMatrices(ExtractDoubleOrThrow(x), x));
+
+  // Dynamically-sized matrices work.
+  Eigen::MatrixXd y(1, 5);
+  y << 1, 2, 3, 4, 5;
+  EXPECT_TRUE(CompareMatrices(ExtractDoubleOrThrow(y), y));
 }
 
 }  // namespace

--- a/common/test/symbolic_expression_test.cc
+++ b/common/test/symbolic_expression_test.cc
@@ -18,6 +18,7 @@
 #include "drake/common/hash.h"
 #include "drake/common/polynomial.h"
 #include "drake/common/symbolic.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/is_memcpy_movable.h"
 #include "drake/common/test_utilities/symbolic_test_util.h"
 
@@ -1940,6 +1941,15 @@ TEST_F(SymbolicExpressionTest, ExtractDoubleTest) {
   // Computed NaN should still throw.
   const Expression bogus = zero_ / e_nan_;
   EXPECT_THROW(ExtractDoubleOrThrow(bogus), std::exception);
+
+  // Eigen variant.
+  const Vector2<Expression> v1{12.0, 13.0};
+  EXPECT_TRUE(
+      CompareMatrices(ExtractDoubleOrThrow(v1), Eigen::Vector2d{12.0, 13.0}));
+
+  // Computed NaN should still throw through the Eigen variant.
+  const Vector2<Expression> v2{12.0, bogus};
+  EXPECT_THROW(ExtractDoubleOrThrow(v2), std::exception);
 }
 
 TEST_F(SymbolicExpressionTest, Jacobian) {


### PR DESCRIPTION
Revives and completes #13003.

I needed this method again, and my c++ foo has grown, so I decided to slay the old dragon.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15518)
<!-- Reviewable:end -->
