### PR TITLE
Add missing pybinding for CalcMassMatrix()

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -542,7 +542,17 @@ void DoScalarDependentDefinitions(py::module m, T) {
               self->CalcMassMatrixViaInverseDynamics(context, &H);
               return H;
             },
-            py::arg("context"))
+            py::arg("context"), cls_doc.CalcMassMatrixViaInverseDynamics.doc)
+        .def(
+            "CalcMassMatrix",
+            [](const Class* self, const Context<T>& context) {
+              MatrixX<T> H;
+              const int n = self->num_velocities();
+              H.resize(n, n);
+              self->CalcMassMatrix(context, &H);
+              return H;
+            },
+            py::arg("context"), cls_doc.CalcMassMatrix.doc)
         .def(
             "CalcBiasSpatialAcceleration",
             [](const Class* self, const systems::Context<T>& context,

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -1802,6 +1802,7 @@ class TestPlant(unittest.TestCase):
         plant.SetPositions(context, [0.1, 0.2])
 
         M = plant.CalcMassMatrixViaInverseDynamics(context)
+        M = plant.CalcMassMatrix(context)
         Cv = plant.CalcBiasTerm(context)
 
         self.assertTrue(M.shape == (2, 2))


### PR DESCRIPTION
@wualbert pointed out on Slack that this binding was missing, while the considerably less efficient CalcMassMatrixViaInverseDynamics() was available.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15520)
<!-- Reviewable:end -->
