### PR TITLE
[fem] Move DeformationGradientData out of dev

### DIFF
--- a/multibody/fem/BUILD.bazel
+++ b/multibody/fem/BUILD.bazel
@@ -15,10 +15,25 @@ drake_cc_package_library(
     name = "fem",
     visibility = ["//multibody/fixed_fem:__subpackages__"],
     deps = [
+        ":deformation_gradient_data",
         ":isoparametric_element",
         ":linear_simplex_element",
         ":quadrature",
         ":simplex_gaussian_quadrature",
+    ],
+)
+
+drake_cc_library(
+    name = "deformation_gradient_data",
+    srcs = [
+        "deformation_gradient_data.cc",
+    ],
+    hdrs = [
+        "deformation_gradient_data.h",
+    ],
+    deps = [
+        "//common:essential",
+        "//common:nice_type_name",
     ],
 )
 
@@ -73,6 +88,15 @@ drake_cc_library(
     ],
     deps = [
         ":quadrature",
+    ],
+)
+
+drake_cc_googletest(
+    name = "deformation_gradient_data_test",
+    deps = [
+        ":deformation_gradient_data",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/multibody/fem/deformation_gradient_data.cc
+++ b/multibody/fem/deformation_gradient_data.cc
@@ -1,0 +1,1 @@
+#include "drake/multibody/fem/deformation_gradient_data.h"

--- a/multibody/fem/deformation_gradient_data.h
+++ b/multibody/fem/deformation_gradient_data.h
@@ -25,8 +25,8 @@ class DeformationGradientData;
  It stores the deformation gradients calculated at the prescribed "locations"
  (the number of which could depend on varying criteria, e.g., quadrature points,
  etc.). A derived class will further store derived quantities which solely
- depend on the stored deformation gradients that facilitates calculations of
- energy density, stress, and stress derivatives (e.g., strain).
+ depend on the stored deformation gradients (e.g., strain) that facilitate
+ calculations of energy density, stress, and stress derivatives.
 
  As part of a derivation, the child `FooData` class must implement the method:
 
@@ -50,11 +50,12 @@ class DeformationGradientData<
   static constexpr int num_locations = num_locations_at_compile_time;
 
   /* Updates the data with the given deformation gradients. The deformation
-   gradient dependent quantities are also updated with the given `F`.
-   @param F The up-to-date deformation gradients evaluated at the prescribed
-   locations. */
-  void UpdateData(std::array<Matrix3<T>, num_locations> F) {
-    deformation_gradient_ = std::move(F);
+   gradient dependent quantities are also updated with the given
+   `deformation_gradient`.
+   @param deformation_gradient The up-to-date deformation gradients evaluated at
+   the prescribed locations. */
+  void UpdateData(std::array<Matrix3<T>, num_locations> deformation_gradient) {
+    deformation_gradient_ = std::move(deformation_gradient);
     static_cast<Derived*>(this)->UpdateFromDeformationGradient();
   }
 
@@ -63,6 +64,14 @@ class DeformationGradientData<
   }
 
  protected:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DeformationGradientData);
+
+  /* Constructs a DeformationGradientData with identity deformation gradients.
+   */
+  DeformationGradientData() {
+    deformation_gradient_.fill(Matrix3<T>::Identity());
+  }
+
   /* Derived classes *must* shadow this method to compute quantities derived
    from deformation gradients. `deformation_gradient()` will be up to date
    before any call to this method. */
@@ -71,14 +80,6 @@ class DeformationGradientData<
         fmt::format("The derived class {} must provide a shadow definition of "
                     "UpdateFromDeformationGradient() to be correct.",
                     NiceTypeName::Get(*static_cast<Derived*>(this))));
-  }
-
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DeformationGradientData);
-
-  /* Constructs a DeformationGradientData with identity deformation gradients.
-   */
-  DeformationGradientData() {
-    deformation_gradient_.fill(Matrix3<T>::Identity());
   }
 
  private:

--- a/multibody/fem/test/deformation_gradient_data_test.cc
+++ b/multibody/fem/test/deformation_gradient_data_test.cc
@@ -1,4 +1,4 @@
-#include "drake/multibody/fixed_fem/dev/deformation_gradient_data.h"
+#include "drake/multibody/fem/deformation_gradient_data.h"
 
 #include <gtest/gtest.h>
 
@@ -15,8 +15,7 @@ constexpr int kNumLocations = 1;
 using Eigen::Matrix3d;
 
 /* A dummy DeformationGradientData for testing the behaviors of
- DeformationGradientData::UpdateData(). See
- DeformationGradientDataTest::UpdateData below. It holds a single deformation
+ DeformationGradientData::UpdateData(). It holds a single deformation
  gradient dependent data which simply doubles the deformation gradient. */
 template <typename T, int num_locations_at_compile_time>
 class DummyData : public DeformationGradientData<
@@ -38,8 +37,9 @@ class DummyData : public DeformationGradientData<
 
  private:
   /* Using `Base` as the alias for the base class is a preferred pattern that
-   usually provides more readability. Here, it that doesn't provide specific
-   value in this dummy class because of the simplicity of the dummy class. */
+   usually provides more readability. It doesn't provide any value in this
+   simple dummy class but we're defining it anyway to set a good example for how
+   to structure real classes. */
   using Base =
       DeformationGradientData<DummyData<T, num_locations_at_compile_time>>;
 
@@ -80,7 +80,12 @@ GTEST_TEST(DeformationGradientDataTest, UpdateData) {
                               2.0 * Matrix3d::Identity()));
 
   /* Arbitrary deformation gradient. */
-  const Matrix3d F = 2.8 * Matrix3d::Identity();
+  Matrix3d F;
+  // clang-format off
+  F << 4, 9, 2,
+       3, 5, 7,
+       8, 1, 6;
+  // clang-format on
   dummy_data.UpdateData({F});
 
   EXPECT_TRUE(CompareMatrices(dummy_data.deformation_gradient()[0], F));

--- a/multibody/fixed_fem/dev/BUILD.bazel
+++ b/multibody/fixed_fem/dev/BUILD.bazel
@@ -40,9 +40,9 @@ drake_cc_library(
         "constitutive_model.h",
     ],
     deps = [
-        ":deformation_gradient_data",
         ":fem_indexes",
         "//common:essential",
+        "//multibody/fem:deformation_gradient_data",
     ],
 )
 
@@ -74,10 +74,10 @@ drake_cc_library(
         "corotated_model_data.h",
     ],
     deps = [
-        ":deformation_gradient_data",
         ":matrix_utilities",
         "//common:default_scalars",
         "//common:essential",
+        "//multibody/fem:deformation_gradient_data",
     ],
 )
 
@@ -118,20 +118,6 @@ drake_cc_library(
     deps = [
         ":deformable_rigid_contact_pair",
         ":reference_deformable_geometry",
-    ],
-)
-
-drake_cc_library(
-    name = "deformation_gradient_data",
-    srcs = [
-        "deformation_gradient_data.cc",
-    ],
-    hdrs = [
-        "deformation_gradient_data.h",
-    ],
-    deps = [
-        "//common:essential",
-        "//common:nice_type_name",
     ],
 )
 
@@ -425,8 +411,8 @@ drake_cc_library(
         "linear_constitutive_model_data.h",
     ],
     deps = [
-        ":deformation_gradient_data",
         "//common:essential",
+        "//multibody/fem:deformation_gradient_data",
     ],
 )
 
@@ -634,15 +620,6 @@ drake_cc_googletest(
         "//geometry/proximity:make_box_mesh",
         "//multibody/contact_solvers:pgs_solver",
         "//systems/analysis:simulator",
-    ],
-)
-
-drake_cc_googletest(
-    name = "deformation_gradient_data_test",
-    deps = [
-        ":deformation_gradient_data",
-        "//common/test_utilities:eigen_matrix_compare",
-        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/multibody/fixed_fem/dev/constitutive_model.h
+++ b/multibody/fixed_fem/dev/constitutive_model.h
@@ -3,7 +3,7 @@
 #include <array>
 
 #include "drake/common/eigen_types.h"
-#include "drake/multibody/fixed_fem/dev/deformation_gradient_data.h"
+#include "drake/multibody/fem/deformation_gradient_data.h"
 #include "drake/multibody/fixed_fem/dev/fem_indexes.h"
 
 namespace drake {

--- a/multibody/fixed_fem/dev/corotated_model_data.h
+++ b/multibody/fixed_fem/dev/corotated_model_data.h
@@ -3,7 +3,7 @@
 #include <array>
 
 #include "drake/common/eigen_types.h"
-#include "drake/multibody/fixed_fem/dev/deformation_gradient_data.h"
+#include "drake/multibody/fem/deformation_gradient_data.h"
 #include "drake/multibody/fixed_fem/dev/fem_indexes.h"
 #include "drake/multibody/fixed_fem/dev/matrix_utilities.h"
 

--- a/multibody/fixed_fem/dev/deformation_gradient_data.cc
+++ b/multibody/fixed_fem/dev/deformation_gradient_data.cc
@@ -1,1 +1,0 @@
-#include "drake/multibody/fixed_fem/dev/deformation_gradient_data.h"

--- a/multibody/fixed_fem/dev/linear_constitutive_model_data.h
+++ b/multibody/fixed_fem/dev/linear_constitutive_model_data.h
@@ -3,7 +3,7 @@
 #include <array>
 
 #include "drake/common/eigen_types.h"
-#include "drake/multibody/fixed_fem/dev/deformation_gradient_data.h"
+#include "drake/multibody/fem/deformation_gradient_data.h"
 
 namespace drake {
 namespace multibody {


### PR DESCRIPTION
Also move a concrete derived class of DeformationGradientData,
LinearConstitutiveModelData out of dev.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15526)
<!-- Reviewable:end -->
