### PR TITLE
[fem] Remove redundant default destructor definitions

### DIFF
--- a/multibody/fixed_fem/dev/constitutive_model.h
+++ b/multibody/fixed_fem/dev/constitutive_model.h
@@ -40,8 +40,6 @@ class ConstitutiveModel {
   using Traits = DerivedTraits;
   using T = typename Traits::Scalar;
 
-  ~ConstitutiveModel() = default;
-
   /* The number of locations at which the constitutive relationship is
    evaluated. */
   static constexpr int num_locations() { return DerivedTraits::kNumLocations; }

--- a/multibody/fixed_fem/dev/corotated_model.h
+++ b/multibody/fixed_fem/dev/corotated_model.h
@@ -59,8 +59,6 @@ class CorotatedModel final
     std::tie(lambda_, mu_) = CalcLameParameters(E_, nu_);
   }
 
-  ~CorotatedModel() = default;
-
   const T& youngs_modulus() const { return E_; }
 
   const T& poisson_ratio() const { return nu_; }

--- a/multibody/fixed_fem/dev/corotated_model_data.h
+++ b/multibody/fixed_fem/dev/corotated_model_data.h
@@ -28,8 +28,6 @@ class CorotatedModelData
 
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CorotatedModelData);
 
-  ~CorotatedModelData() = default;
-
   /* Constructs a CorotatedModelData with no deformation. */
   CorotatedModelData() {
     std::fill(R_.begin(), R_.end(), Matrix3<T>::Identity());

--- a/multibody/fixed_fem/dev/deformation_gradient_data.h
+++ b/multibody/fixed_fem/dev/deformation_gradient_data.h
@@ -49,8 +49,6 @@ class DeformationGradientData<
   /* The number of locations at which the data needs to be evaluated. */
   static constexpr int num_locations = num_locations_at_compile_time;
 
-  ~DeformationGradientData() = default;
-
   /* Updates the data with the given deformation gradients. The deformation
    gradient dependent quantities are also updated with the given `F`.
    @param F The up-to-date deformation gradients evaluated at the prescribed

--- a/multibody/fixed_fem/dev/element_cache_entry.h
+++ b/multibody/fixed_fem/dev/element_cache_entry.h
@@ -25,8 +25,6 @@ class ElementCacheEntry {
   /* Constructs a new %ElementCacheEntry with default initialized data. */
   ElementCacheEntry() {}
 
-  ~ElementCacheEntry() = default;
-
   ElementData& mutable_element_data() { return element_data_; }
 
   const ElementData& element_data() const { return element_data_; }

--- a/multibody/fixed_fem/dev/linear_constitutive_model.h
+++ b/multibody/fixed_fem/dev/linear_constitutive_model.h
@@ -86,8 +86,6 @@ class LinearConstitutiveModel final
     }
   }
 
-  ~LinearConstitutiveModel() = default;
-
   const T& youngs_modulus() const { return E_; }
 
   const T& poisson_ratio() const { return nu_; }

--- a/multibody/fixed_fem/dev/linear_constitutive_model_data.h
+++ b/multibody/fixed_fem/dev/linear_constitutive_model_data.h
@@ -26,8 +26,6 @@ class LinearConstitutiveModelData
 
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(LinearConstitutiveModelData);
 
-  ~LinearConstitutiveModelData() = default;
-
   /* Constructs a LinearConstitutiveModelData with zero strain. */
   LinearConstitutiveModelData() {
     strain_.fill(Matrix3<T>::Zero());


### PR DESCRIPTION
Explicitly defining default destructors for non-polymorphic classes
may misleadingly suggest that the class is polymorphic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15527)
<!-- Reviewable:end -->
