### PR TITLE
Clean up handling of multibody state sub-blocks

### DIFF
--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1749,30 +1749,34 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @ref systems::Context "Context" that is supplied
   /// as the first argument to every method.
   ///
+  /// @note State vectors for the full system are returned as live references
+  /// into the Context, not independent copies. In contrast, state vectors
+  /// for individual model instances are returned as copies because the state
+  /// associated with a model instance is generally not contiguous in a Context.
+  ///
   /// There are also utilities for accessing and mutating portions of state
   /// or actuation arrays corresponding to just a single model instance.
   /// @{
 
-  /// Returns a const vector reference containing the vector
-  /// `[q; v]` with `q` the vector of generalized positions and
-  /// `v` the vector of generalized velocities.
+  /// Returns a const vector reference `[q; v]` to the generalized positions q
+  /// and generalized velocities v in a given Context.
   /// @note This method returns a reference to existing data, exhibits constant
   ///       i.e., O(1) time complexity, and runs very quickly.
-  /// @throws std::exception if the `context` does not
-  /// correspond to the context for a multibody model.
+  /// @throws std::exception if `context` does not correspond to the Context
+  /// for a multibody model.
   Eigen::VectorBlock<const VectorX<T>> GetPositionsAndVelocities(
       const systems::Context<T>& context) const {
     this->ValidateContext(context);
-    return internal_tree().GetPositionsAndVelocities(context);
+    return internal_tree().get_positions_and_velocities(context);
   }
 
-  /// Returns the vector `[q; v]`
-  /// of the model with `q` the vector of generalized positions and `v` the
-  /// vector of generalized velocities for model instance `model_instance`.
-  /// @throws std::exception if the `context` does not correspond to the context
+  /// Returns a vector `[q; v]` containing the generalized positions q and
+  /// generalized velocities v of a specified model instance in a given Context.
+  /// @note Returns a dense vector of dimension
+  ///       `num_positions(model_instance) + num_velocities(model_instance)`
+  ///       associated with `model_instance` by copying from `context`.
+  /// @throws std::exception if `context` does not correspond to the Context
   /// for a multibody model or `model_instance` is invalid.
-  /// @note returns a dense vector of dimension `q.size() + v.size()` associated
-  ///          with `model_instance` in O(`q.size()`) time.
   VectorX<T> GetPositionsAndVelocities(
       const systems::Context<T>& context,
       ModelInstanceIndex model_instance) const {
@@ -1780,13 +1784,15 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     return internal_tree().GetPositionsAndVelocities(context, model_instance);
   }
 
-  /// (Advanced) Returns a mutable vector containing the vector `[q; v]`
-  /// of the model with `q` the vector of generalized positions and `v` the
-  /// vector of generalized velocities (**see warning**).
-  /// @warning You should use SetPositionsAndVelocities() instead of this method
-  ///          unless you are fully aware of the interactions with the caching
-  ///          mechanism (see @ref dangerous_get_mutable).
-  /// @throws std::exception if the `context` is nullptr or if it does not
+  /// (Advanced -- **see warning**) Returns a mutable vector reference `[q; v]`
+  /// to the generalized positions q and generalized velocities v in a given
+  /// Context.
+  /// @warning Cache invalidation will occur when this is called but not if you
+  ///          subsequently write through the returned object. You should use
+  ///          SetPositionsAndVelocities() instead unless you are
+  ///          fully aware of the interactions with the caching mechanism (see
+  ///          @ref dangerous_get_mutable).
+  /// @throws std::exception if `context` is nullptr or if it does not
   /// correspond to the context for a multibody model.
   Eigen::VectorBlock<VectorX<T>> GetMutablePositionsAndVelocities(
       systems::Context<T>* context) const {
@@ -1794,9 +1800,10 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     return internal_tree().GetMutablePositionsAndVelocities(context);
   }
 
-  /// Sets all generalized positions and velocities from the given vector
-  /// [q; v].
-  /// @throws std::exception if the `context` is nullptr, if the context does
+  /// Sets generalized positions q and generalized velocities v in a given
+  /// Context from a given vector [q; v]. Prefer this method over
+  /// GetMutablePositionsAndVelocities().
+  /// @throws std::exception if `context` is nullptr, if `context` does
   /// not correspond to the context for a multibody model, or if the length of
   /// `q_v` is not equal to `num_positions() + num_velocities()`.
   void SetPositionsAndVelocities(
@@ -1806,10 +1813,10 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     internal_tree().GetMutablePositionsAndVelocities(context) = q_v;
   }
 
-  /// Sets generalized positions and velocities from the given vector
-  /// [q; v] for the specified model instance.
-  /// @throws std::exception if the `context` is nullptr, if the context does
-  /// not correspond to the context for a multibody model, if the model instance
+  /// Sets generalized positions q and generalized velocities v from a given
+  /// vector [q; v] for a specified model instance in a given Context.
+  /// @throws std::exception if `context` is nullptr, if `context` does
+  /// not correspond to the Context for a multibody model, if the model instance
   /// index is invalid, or if the length of `q_v` is not equal to
   /// `num_positions(model_instance) + num_velocities(model_instance)`.
   void SetPositionsAndVelocities(
@@ -1822,91 +1829,77 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     internal_tree().SetPositionsAndVelocities(model_instance, q_v, context);
   }
 
-  /// Returns a const vector reference containing the vector of
-  /// generalized positions.
+  /// Returns a const vector reference to the vector of generalized positions
+  /// q in a given Context.
   /// @note This method returns a reference to existing data, exhibits constant
   ///       i.e., O(1) time complexity, and runs very quickly.
-  /// @throws std::exception if the `context` does not
-  /// correspond to the context for a multibody model.
+  /// @throws std::exception if `context` does not correspond to the Context for
+  /// a multibody model.
   Eigen::VectorBlock<const VectorX<T>> GetPositions(
       const systems::Context<T>& context) const {
-    // Note: the nestedExpression() is necessary to treat the VectorBlock<T>
-    // returned from GetPositionsAndVelocities() as a VectorX<T> so that we can
-    // call head() on it.
     this->ValidateContext(context);
-    return GetPositionsAndVelocities(context).nestedExpression().head(
-        num_positions());
+    return internal_tree().get_positions(context);
   }
 
-  /// Returns an vector containing the generalized positions (`q`) for the
-  /// given model instance.
-  /// @throws std::exception if the `context` does not
-  /// correspond to the context for a multibody model.
-  /// @note returns a dense vector of dimension `q.size()` associated with
-  ///          `model_instance` in O(`q.size()`) time.
+  /// Returns a vector containing the generalized positions q of a specified
+  /// model instance in a given Context.
+  /// @note Returns a dense vector of dimension `num_positions(model_instance)`
+  ///       associated with `model_instance` by copying from `context`.
+  /// @throws std::exception if `context` does not correspond to the Context
+  /// for a multibody model or `model_instance` is invalid.
   VectorX<T> GetPositions(
       const systems::Context<T>& context,
       ModelInstanceIndex model_instance) const {
     this->ValidateContext(context);
     return internal_tree().GetPositionsFromArray(
-        model_instance, GetPositions(context));
+        model_instance, internal_tree().get_positions(context));
   }
 
-  /// (Advanced) Returns a mutable vector reference containing the vector
-  /// of generalized positions (**see warning**).
-  /// @note This method returns a reference to existing data, exhibits constant
-  ///       i.e., O(1) time complexity, and runs very quickly.
-  /// @warning You should use SetPositions() instead of this method
-  ///          unless you are fully aware of the possible interactions with the
-  ///          caching mechanism (see @ref dangerous_get_mutable).
+  /// (Advanced -- **see warning**) Returns a mutable vector reference to the
+  /// generalized positions q in a given Context.
+  /// @warning Cache invalidation will occur when this is called but not
+  ///          if you subsequently write through the returned object. You
+  ///          should use SetPositions() instead unless you are fully aware
+  ///          of the possible interactions with the caching mechanism (see
+  ///          @ref dangerous_get_mutable).
   /// @throws std::exception if the `context` is nullptr or if it does not
-  /// correspond to the context for a multibody model.
+  /// correspond to the Context for a multibody model.
   Eigen::VectorBlock<VectorX<T>> GetMutablePositions(
       systems::Context<T>* context) const {
-    // Note: the nestedExpression() is necessary to treat the VectorBlock<T>
-    // returned from GetMutablePositionsAndVelocities() as a VectorX<T> so that
-    // we can call head() on it.
     this->ValidateContext(context);
-    return internal_tree().GetMutablePositionsAndVelocities(context)
-        .nestedExpression().head(num_positions());
+    return internal_tree().GetMutablePositions(context);
   }
 
-  /// (Advanced) Returns a mutable vector reference containing the vector
-  /// of generalized positions (**see warning**).
+  /// (Advanced) Returns a mutable vector reference to the generalized positions
+  /// q in a given State.
   /// @note This method returns a reference to existing data, exhibits constant
-  ///       i.e., O(1) time complexity, and runs very quickly.
-  /// @warning You should use SetPositions() instead of this method
-  ///          unless you are fully aware of the possible interactions with the
-  ///          caching mechanism (see @ref dangerous_get_mutable).
-  /// @throws std::exception if the `state` is nullptr or if the context does
-  ///         not correspond to the context for a multibody model.
-  /// @pre `state` comes from this MultibodyPlant.
+  ///       i.e., O(1) time complexity, and runs very quickly. No cache
+  ///       invalidation occurs.
+  /// @throws std::exception if the `state` is nullptr or if `context` does
+  ///         not correspond to the Context for a multibody model.
+  /// @pre `state` comes from this multibody model.
   Eigen::VectorBlock<VectorX<T>> GetMutablePositions(
       const systems::Context<T>& context, systems::State<T>* state) const {
     this->ValidateContext(context);
     DRAKE_ASSERT_VOID(CheckValidState(state));
-    // Note: the nestedExpression() is necessary to treat the VectorBlock<T>
-    // returned from GetMutablePositionsAndVelocities() as a VectorX<T> so that
-    // we can call head() on it.
-    return internal_tree()
-        .GetMutablePositionsAndVelocities(context, state)
-        .nestedExpression()
-        .head(num_positions());
+    return internal_tree().get_mutable_positions(state);
   }
 
-  /// Sets all generalized positions from the given vector.
-  /// @throws std::exception if the `context` is nullptr, if the context does
-  /// not correspond to the context for a multibody model, or if the length of
-  /// `q` is not equal to `num_positions()`.
+  /// Sets the generalized positions q in a given Context from a given vector.
+  /// Prefer this method over GetMutablePositions().
+  /// @throws std::exception if `context` is nullptr, if `context` does not
+  /// correspond to the Context for a multibody model, or if the length of `q`
+  /// is not equal to `num_positions()`.
   void SetPositions(systems::Context<T>* context, const VectorX<T>& q) const {
     this->ValidateContext(context);
     DRAKE_THROW_UNLESS(q.size() == num_positions());
     GetMutablePositions(context) = q;
   }
 
-  /// Sets the positions for a particular model instance from the given vector.
-  /// @throws std::exception if the `context` is nullptr, if the context does
-  /// not correspond to the context for a multibody model, if the model instance
+  /// Sets the generalized positions q for a particular model instance in a
+  /// given Context from a given vector.
+  /// @throws std::exception if the `context` is nullptr, if `context` does
+  /// not correspond to the Context for a multibody model, if the model instance
   /// index is invalid, or if the length of `q_instance` is not equal to
   /// `num_positions(model_instance)`.
   void SetPositions(
@@ -1918,9 +1911,11 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     internal_tree().SetPositionsInArray(model_instance, q_instance, &q);
   }
 
-  /// Sets the positions for a particular model instance from the given vector.
-  /// @throws std::exception if the `state` is nullptr, if the context does
-  /// not correspond to the context for a multibody model, if the model instance
+  /// (Advanced) Sets the generalized positions q for a particular model
+  /// instance in a given State from a given vector.
+  /// @note No cache invalidation occurs.
+  /// @throws std::exception if the `context` is nullptr, if `context` does
+  /// not correspond to the Context for a multibody model, if the model instance
   /// index is invalid, or if the length of `q_instance` is not equal to
   /// `num_positions(model_instance)`.
   /// @pre `state` comes from this MultibodyPlant.
@@ -1934,64 +1929,64 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     internal_tree().SetPositionsInArray(model_instance, q_instance, &q);
   }
 
-  /// Returns a const vector reference containing the generalized velocities.
+  /// Returns a const vector reference to the generalized velocities v in a
+  /// given Context.
   /// @note This method returns a reference to existing data, exhibits constant
   ///       i.e., O(1) time complexity, and runs very quickly.
+  /// @throws std::exception if `context` does not correspond to the Context
+  /// for a multibody model.
   Eigen::VectorBlock<const VectorX<T>> GetVelocities(
       const systems::Context<T>& context) const {
-    // Note: the nestedExpression() is necessary to treat the VectorBlock<T>
-    // returned from GetPositionsAndVelocities() as a VectorX<T> so that we can
-    // call tail() on it.
     this->ValidateContext(context);
-    return GetPositionsAndVelocities(context).nestedExpression().tail(
-        num_velocities());
+    return internal_tree().get_velocities(context);
   }
 
-  /// Returns a vector containing the generalized velocities (`v`) for
-  /// the given model instance.
-  /// @throws std::exception if the `context` does not
-  /// correspond to the context for a multibody model.
-  /// @note returns a dense vector of dimension `v.size()` associated with
-  ///          `model_instance` in O(`v.size()`) time.
+  /// Returns a vector containing the generalized velocities v of a specified
+  /// model instance in a given Context.
+  /// @note returns a dense vector of dimension `num_velocities(model_instance)`
+  ///       associated with `model_instance` by copying from `context`.
+  /// @throws std::exception if `context` does not correspond to the Context
+  /// for a multibody model or `model_instance` is invalid.
   VectorX<T> GetVelocities(
       const systems::Context<T>& context,
       ModelInstanceIndex model_instance) const {
     this->ValidateContext(context);
     return internal_tree().GetVelocitiesFromArray(
-        model_instance, GetVelocities(context));
+        model_instance, internal_tree().get_velocities(context));
   }
 
-  /// (Advanced) Returns a mutable vector reference containing the vector
-  /// of generalized velocities (**see warning**).
+  /// (Advanced -- **see warning**) Returns a mutable vector reference to the
+  /// generalized velocities v in a given Context.
+  /// @warning Cache invalidation will occur when this is called but not
+  ///          if you subsequently write through the returned object. You
+  ///          should use SetVelocities() instead unless you are fully aware
+  ///          of the possible interactions with the caching mechanism (see
+  ///          @ref dangerous_get_mutable).
+  /// @throws std::exception if the `context` is nullptr or if it does not
+  /// correspond to the Context for a multibody model.
+  Eigen::VectorBlock<VectorX<T>> GetMutableVelocities(
+      systems::Context<T>* context) const {
+    this->ValidateContext(context);
+    return internal_tree().GetMutableVelocities(context);
+  }
+
+  /// (Advanced) Returns a mutable vector reference to the generalized
+  /// velocities v in a given State.
   /// @note This method returns a reference to existing data, exhibits constant
-  ///       i.e., O(1) time complexity, and runs very quickly.
-  /// @warning You should use SetVelocities() instead of this method
-  ///          unless you are fully aware of the possible interactions with the
-  ///          caching mechanism (see @ref dangerous_get_mutable).
-  /// @throws std::exception if the `context` is nullptr or the context does
-  /// not correspond to the context for a multibody model.
-  /// @pre `state` comes from this MultibodyPlant.
+  ///       i.e., O(1) time complexity, and runs very quickly. No cache
+  ///       invalidation occurs.
+  /// @throws std::exception if the `state` is nullptr or if `context` does
+  ///         not correspond to the Context for a multibody model.
+  /// @pre `state` comes from this multibody model.
   Eigen::VectorBlock<VectorX<T>> GetMutableVelocities(
       const systems::Context<T>& context, systems::State<T>* state) const {
     this->ValidateContext(context);
     DRAKE_ASSERT_VOID(CheckValidState(state));
-    // Note: the nestedExpression() is necessary to treat the VectorBlock<T>
-    // returned from GetMutablePositionsAndVelocities() as a VectorX<T> so that
-    // we can call tail() on it.
-    return internal_tree()
-        .GetMutablePositionsAndVelocities(context, state)
-        .nestedExpression()
-        .tail(num_velocities());
+    return internal_tree().get_mutable_velocities(state);
   }
 
-  /// See GetMutableVelocities() method above.
-  Eigen::VectorBlock<VectorX<T>> GetMutableVelocities(
-      systems::Context<T>* context) const {
-    this->ValidateContext(context);
-    return GetMutableVelocities(*context, &context->get_mutable_state());
-  }
-
-  /// Sets all generalized velocities from the given vector.
+  /// Sets the generalized velocities v in a given Context from a given
+  /// vector. Prefer this method over GetMutableVelocities().
   /// @throws std::exception if the `context` is nullptr, if the context does
   /// not correspond to the context for a multibody model, or if the length of
   /// `v` is not equal to `num_velocities()`.
@@ -2001,10 +1996,26 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     GetMutableVelocities(context) = v;
   }
 
-  /// Sets the generalized velocities for a particular model instance from the
-  /// given vector.
-  /// @throws std::exception if the `context` is nullptr, if the context does
-  /// not correspond to the context for a multibody model, if the model instance
+  /// Sets the generalized velocities v for a particular model instance in a
+  /// given Context from a given vector.
+  /// @throws std::exception if the `context` is nullptr, if `context` does
+  /// not correspond to the Context for a multibody model, if the model instance
+  /// index is invalid, or if the length of `v_instance` is not equal to
+  /// `num_velocities(model_instance)`.
+  void SetVelocities(
+      systems::Context<T>* context,
+      ModelInstanceIndex model_instance, const VectorX<T>& v_instance) const {
+    this->ValidateContext(context);
+    DRAKE_THROW_UNLESS(v_instance.size() == num_velocities(model_instance));
+    Eigen::VectorBlock<VectorX<T>> v = GetMutableVelocities(context);
+    internal_tree().SetVelocitiesInArray(model_instance, v_instance, &v);
+  }
+
+  /// (Advanced) Sets the generalized velocities v for a particular model
+  /// instance in a given State from a given vector.
+  /// @note No cache invalidation occurs.
+  /// @throws std::exception if the `context` is nullptr, if `context` does
+  /// not correspond to the Context for a multibody model, if the model instance
   /// index is invalid, or if the length of `v_instance` is not equal to
   /// `num_velocities(model_instance)`.
   /// @pre `state` comes from this MultibodyPlant.
@@ -2015,21 +2026,6 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     DRAKE_THROW_UNLESS(v_instance.size() == num_velocities(model_instance));
     CheckValidState(state);
     Eigen::VectorBlock<VectorX<T>> v = GetMutableVelocities(context, state);
-    internal_tree().SetVelocitiesInArray(model_instance, v_instance, &v);
-  }
-
-  /// Sets the generalized velocities for a particular model instance from the
-  /// given vector.
-  /// @throws std::exception if the `context` is nullptr, if the context does
-  /// not correspond to the context for a multibody model, if the model instance
-  /// index is invalid, or if the length of `v_instance` is not equal to
-  /// `num_velocities(model_instance)`.
-  void SetVelocities(
-      systems::Context<T>* context,
-      ModelInstanceIndex model_instance, const VectorX<T>& v_instance) const {
-    this->ValidateContext(context);
-    DRAKE_THROW_UNLESS(v_instance.size() == num_velocities(model_instance));
-    Eigen::VectorBlock<VectorX<T>> v = GetMutableVelocities(context);
     internal_tree().SetVelocitiesInArray(model_instance, v_instance, &v);
   }
 

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -737,18 +737,11 @@ void MultibodyTree<T>::SetRandomState(const systems::Context<T>& context,
 }
 
 template <typename T>
-Eigen::VectorBlock<const VectorX<T>>
-MultibodyTree<T>::GetPositionsAndVelocities(
-    const systems::Context<T>& context) const {
-  return get_state_vector(context);
-}
-
-template <typename T>
 VectorX<T> MultibodyTree<T>::GetPositionsAndVelocities(
     const systems::Context<T>& context,
     ModelInstanceIndex model_instance) const {
   Eigen::VectorBlock<const VectorX<T>> state_vector =
-      get_state_vector(context);
+      get_positions_and_velocities(context);
 
   VectorX<T> instance_state_vector(num_states(model_instance));
   instance_state_vector.head(num_positions(model_instance)) =
@@ -762,24 +755,16 @@ VectorX<T> MultibodyTree<T>::GetPositionsAndVelocities(
 }
 
 template <typename T>
-Eigen::VectorBlock<VectorX<T>>
-MultibodyTree<T>::GetMutablePositionsAndVelocities(
-    const systems::Context<T>&, systems::State<T>* state) const {
-  DRAKE_DEMAND(state != nullptr);
-  return get_mutable_state_vector(state);
-}
-
-template <typename T>
 void MultibodyTree<T>::SetPositionsAndVelocities(
     ModelInstanceIndex model_instance,
     const Eigen::Ref<const VectorX<T>>& instance_state,
     systems::Context<T>* context) const {
   Eigen::VectorBlock<VectorX<T>> state_vector =
       GetMutablePositionsAndVelocities(context);
-  Eigen::VectorBlock<VectorX<T>> q = state_vector.nestedExpression().head(
-      num_positions());
-  Eigen::VectorBlock<VectorX<T>> v = state_vector.nestedExpression().tail(
-      num_velocities());
+  Eigen::VectorBlock<VectorX<T>> q = make_mutable_block_segment(&state_vector,
+      0, num_positions());
+  Eigen::VectorBlock<VectorX<T>> v = make_mutable_block_segment(&state_vector,
+      num_positions(), num_velocities());
   SetPositionsInArray(model_instance,
                       instance_state.head(num_positions(model_instance)), &q);
   SetVelocitiesInArray(model_instance,
@@ -2750,8 +2735,7 @@ T MultibodyTree<T>::CalcKineticEnergy(
 
   // Account for reflected inertia.
   // See JointActuator::reflected_inertia().
-  const Eigen::VectorBlock<const VectorX<T>> v =
-      get_state_vector(context).nestedExpression().tail(num_velocities());
+  const Eigen::VectorBlock<const VectorX<T>> v = get_velocities(context);
 
   twice_kinetic_energy_W +=
       (v.array() * reflected_inertia.array() * v.array()).sum();

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -971,9 +971,8 @@ class MultibodyTree {
   // `v` the vector of generalized velocities.
   // @note This method returns a reference to existing data, exhibits constant
   //       i.e., O(1) time complexity, and runs very quickly.
-  // @throws std::exception if the `context` does not correspond to the context
-  // for a multibody model.
-  Eigen::VectorBlock<const VectorX<T>> GetPositionsAndVelocities(
+  // @pre `context` is a valid multibody system Context.
+  Eigen::VectorBlock<const VectorX<T>> get_positions_and_velocities(
       const systems::Context<T>& context) const;
 
   // Returns a Eigen vector containing the multibody state `x = [q; v]`
@@ -983,27 +982,27 @@ class MultibodyTree {
   // for a multibody model or `model_instance` is invalid.
   // @note returns a dense vector of dimension `q.size() + v.size()` associated
   //          with `model_instance` in O(`q.size()`) time.
+  // @pre `context` is a valid multibody system Context.
   VectorX<T> GetPositionsAndVelocities(
       const systems::Context<T>& context,
       ModelInstanceIndex model_instance) const;
 
-  // Returns a mutable Eigen vector containing the vector `[q; v]`
-  // of the model with `q` the vector of generalized positions and `v` the
-  // vector of generalized velocities.
-  // @throws std::exception if the `context` is nullptr or if it does not
-  // correspond to the context for a multibody model.
+  // From a mutable State, returns a mutable Eigen vector containing the vector
+  // `[q; v]` of the model with `q` the vector of generalized positions and `v`
+  // the vector of generalized velocities.
   // @note This method returns a reference to existing data, exhibits constant
-  //       i.e., O(1) time complexity, and runs very quickly.
-  // @pre `state` must be the systems::State<T> owned by the `context`.
-  Eigen::VectorBlock<VectorX<T>> GetMutablePositionsAndVelocities(
-  const systems::Context<T>& context, systems::State<T>* state) const;
+  //       i.e., O(1) time complexity, and runs very quickly. It does not cause
+  //       cache invalidation so be careful!
+  // @pre `state` is a valid multibody system State.
+  Eigen::VectorBlock<VectorX<T>> get_mutable_positions_and_velocities(
+      systems::State<T>* state) const;
 
-  // See GetMutablePositionsAndVelocities(context, state) above.
+  // This is a mutable-Context version of
+  // `get_mutable_positions_and_velocities()`; see above.
+  // @note Invalidates all q- or v-dependent cache entries.
+  // @pre `context` is a valid multibody system Context.
   Eigen::VectorBlock<VectorX<T>> GetMutablePositionsAndVelocities(
-  systems::Context<T>* context) const {
-    return GetMutablePositionsAndVelocities(*context,
-                                            &context->get_mutable_state());
-  }
+      systems::Context<T>* context) const;
 
   // Sets `context` to store the vector `[q; v]`
   // with `q` the vector of generalized positions and `v` the vector
@@ -1012,6 +1011,7 @@ class MultibodyTree {
   // for a multibody model, `context` is nullptr, `model_instance` is invalid,
   // or `instance_state.size()` does not equal `num_positions(model_instance)`
   // + `num_velocities(model_instance)`.
+  // @pre `context` is a valid multibody system Context.
   void SetPositionsAndVelocities(
       ModelInstanceIndex model_instance,
       const Eigen::Ref<const VectorX<T>>& instance_state,
@@ -2215,114 +2215,112 @@ class MultibodyTree {
     return tree_system_->is_discrete();
   }
 
-  // Returns a const reference to the kinematic state vector stored in the
-  // given Context as an `Eigen::VectorBlock<const VectorX<T>>`. This will
-  // consist only of q and v partitions in that order.
-  Eigen::VectorBlock<const VectorX<T>> get_state_vector(
-      const systems::Context<T>& context) const;
-
-  // This is a mutable-Context version of `get_state_vector()`.
-  // @note Invalidates all q- or v-dependent cache entries.
-  Eigen::VectorBlock<VectorX<T>> get_mutable_state_vector(
-      systems::Context<T>* context) const;
-
-  // This is a mutable-State version of `get_state_vector()`.
-  // @note This does not cause cache invalidation.
-  Eigen::VectorBlock<VectorX<T>> get_mutable_state_vector(
-      systems::State<T>* state) const;
-
   // Returns a const reference to the position state vector q stored in the
   // given Context as an `Eigen::VectorBlock<const VectorX<T>>`.
+  // @pre `context` is a valid multibody system Context.
   Eigen::VectorBlock<const VectorX<T>> get_positions(
       const systems::Context<T>& context) const;
 
   // This is a mutable-Context version of `get_positions()`.
   // @note Invalidates all q-dependent cache entries. (May also invalidate
   //       v-dependent cache entries.)
-  Eigen::VectorBlock<VectorX<T>> get_mutable_positions(
+  // @pre `context` is a valid multibody system Context.
+  Eigen::VectorBlock<VectorX<T>> GetMutablePositions(
       systems::Context<T>* context) const;
 
   // This is a mutable-State version of `get_positions()`.
-  // @note This does not cause cache invalidation.
+  // @note This does not cause cache invalidation so it is very fast.
+  // @pre `state` is a valid multibody system State.
   Eigen::VectorBlock<VectorX<T>> get_mutable_positions(
       systems::State<T>* state) const;
 
-  // Returns a const reference to the velcoity state vector v stored in the
+  // Returns a const reference to the velocity state vector v stored in the
   // given Context as an `Eigen::VectorBlock<const VectorX<T>>`.
+  // @pre `context` is a valid multibody system Context.
   Eigen::VectorBlock<const VectorX<T>> get_velocities(
       const systems::Context<T>& context) const;
 
   // This is a mutable-Context version of `get_velocities()`.
   // @note Invalidates all v-dependent cache entries. (May also invalidate
   //       q-dependent cache entries.)
-  Eigen::VectorBlock<VectorX<T>> get_mutable_velocities(
+  // @pre `context` is a valid multibody system Context.
+  Eigen::VectorBlock<VectorX<T>> GetMutableVelocities(
       systems::Context<T>* context) const;
 
   // This is a mutable-State version of `get_velocities()`.
-  // @note This does not cause cache invalidation.
+  // @note This does not cause cache invalidation so it is very fast.
+  // @pre `state` is a valid multibody system State.
   Eigen::VectorBlock<VectorX<T>> get_mutable_velocities(
       systems::State<T>* state) const;
 
-  // Returns a const fixed-size Eigen::VectorBlock of `count` elements
+  // Returns a const fixed-size Eigen::VectorBlock of `length` elements
   // referencing a segment in the state vector with its first element
   // at `start`.
-  template <int count>
-  Eigen::VectorBlock<const VectorX<T>, count> get_state_segment(
+  // @pre `context` is a valid multibody system Context.
+  // @pre start, length >= 0 and start+length is in-bounds for qv state.
+  template <int length>
+  Eigen::VectorBlock<const VectorX<T>, length> get_state_segment(
       const systems::Context<T>& context, int start) const {
-    // (Comments here apply to similar methods below too.)
-    // We know that context is a LeafContext and therefore the
-    // continuous state vector must be a BasicVector.
-    // TODO(amcastro-tri): make use of VectorBase::get_contiguous_vector() once
-    // PR #6049 gets merged.
-    Eigen::VectorBlock<const VectorX<T>> x = get_state_vector(context);
-    // xc.nestedExpression() resolves to "VectorX<T>&" since the continuous
-    // state is a BasicVector.
-    // If we do return xc.segment() directly, we would instead get a
-    // Block<Block<VectorX>>, which is very different from Block<VectorX>.
-    return x.nestedExpression().template segment<count>(start);
+    Eigen::VectorBlock<const VectorX<T>> qv =
+        get_positions_and_velocities(context);
+    return make_block_segment<length>(qv, start);
   }
 
   // This is a mutable-Context version of `get_state_segment<count>(start)`.
   // @note Invalidates all q- or v-dependent cache entries.
-  template <int count>
-  Eigen::VectorBlock<VectorX<T>, count> get_mutable_state_segment(
+  // @pre `context` is a valid multibody system Context.
+  // @pre start, length >= 0 and start+length is in-bounds for qv state.
+  template <int length>
+  Eigen::VectorBlock<VectorX<T>, length> GetMutableStateSegment(
       systems::Context<T>* context, int start) const {
-    Eigen::VectorBlock<VectorX<T>> x = get_mutable_state_vector(context);
-    return x.nestedExpression().template segment<count>(start);
+    Eigen::VectorBlock<VectorX<T>> qv =
+        GetMutablePositionsAndVelocities(context);
+    return make_mutable_block_segment<length>(&qv, start);
   }
 
   // This is a mutable-State version of `get_state_segment<count>(start)`.
-  // @note This does not cause cache invalidation.
-  template <int count>
-  Eigen::VectorBlock<VectorX<T>, count> get_mutable_state_segment(
+  // @note This does not cause cache invalidation so it is very fast.
+  // @pre `state` is a valid multibody system State.
+  // @pre start, length >= 0 and start+length is in-bounds for qv state.
+  template <int length>
+  Eigen::VectorBlock<VectorX<T>, length> get_mutable_state_segment(
       systems::State<T>* state, int start) const {
-    Eigen::VectorBlock<VectorX<T>> x = get_mutable_state_vector(&*state);
-    return x.nestedExpression().template segment<count>(start);
+    Eigen::VectorBlock<VectorX<T>> qv =
+        get_mutable_positions_and_velocities(state);
+    return make_mutable_block_segment<length>(&qv, start);
   }
 
-  // Returns a const fixed-size Eigen::VectorBlock of `count` elements
-  // referencing a segment in the Context's state vector with its first element
-  // at `start`.
+  // Returns a const Eigen::VectorBlock of `length` elements referencing a
+  // segment in the Context's state vector with its first element at `start`.
+  // @pre `context` is a valid multibody system Context.
+  // @pre start, length >= 0 and start+length is in-bounds for qv state.
   Eigen::VectorBlock<const VectorX<T>> get_state_segment(
-      const systems::Context<T>& context, int start, int count) const {
-    Eigen::VectorBlock<const VectorX<T>> x = get_state_vector(context);
-    return x.nestedExpression().segment(start, count);
+      const systems::Context<T>& context, int start, int length) const {
+    Eigen::VectorBlock<const VectorX<T>> qv =
+        get_positions_and_velocities(context);
+    return make_block_segment(qv, start, length);
   }
 
-  // This is a mutable-Context version of `get_state_segment(start, count)`.
+  // This is a mutable-Context version of `get_state_segment(start, length)`.
   // @note Invalidates all q- or v-dependent cache entries.
-  Eigen::VectorBlock<VectorX<T>> get_mutable_state_segment(
-      systems::Context<T>* context, int start, int count) const {
-    Eigen::VectorBlock<VectorX<T>> x = get_mutable_state_vector(context);
-    return x.nestedExpression().segment(start, count);
+  // @pre `context` is a valid multibody system Context.
+  // @pre start, length >= 0 and start+length is in-bounds for qv state.
+  Eigen::VectorBlock<VectorX<T>> GetMutableStateSegment(
+      systems::Context<T>* context, int start, int length) const {
+    Eigen::VectorBlock<VectorX<T>> qv =
+        GetMutablePositionsAndVelocities(context);
+    return make_mutable_block_segment(&qv, start, length);
   }
 
-  // This is a mutable-State version of `get_state_segment(start, count)`.
+  // This is a mutable-State version of `get_state_segment(start, length)`.
   // @note This does not cause cache invalidation.
+  // @pre `state` is a valid multibody system State.
+  // @pre start, length >= 0 and start+length is in-bounds for qv state.
   Eigen::VectorBlock<VectorX<T>> get_mutable_state_segment(
-      systems::State<T>* state, int start, int count) const {
-    Eigen::VectorBlock<VectorX<T>> x = get_mutable_state_vector(&*state);
-    return x.nestedExpression().segment(start, count);
+      systems::State<T>* state, int start, int length) const {
+    Eigen::VectorBlock<VectorX<T>> qv =
+        get_mutable_positions_and_velocities(state);
+    return make_mutable_block_segment(&qv, start, length);
   }
   //@}
 
@@ -2391,11 +2389,60 @@ class MultibodyTree {
   Eigen::VectorBlock<VectorX<T>> get_mutable_discrete_state_vector(
       systems::State<T>* state) const;
 
-  Eigen::VectorBlock<VectorX<T>> extract_qv_from_continuous(
+  Eigen::VectorBlock<const VectorX<T>> extract_qv_from_continuous(
+      const systems::VectorBase<T>& continuous_qvz) const;
+
+  Eigen::VectorBlock<VectorX<T>> extract_mutable_qv_from_continuous(
       systems::VectorBase<T>* continuous_qvz) const;
+
+  // Given a VectorBlock and (start, length) segment specification relative
+  // to that block, return a new block representing that segment relative to
+  // the original nested expression.
+  static Eigen::VectorBlock<const VectorX<T>> make_block_segment(
+      const Eigen::VectorBlock<const VectorX<T>>& block, int start,
+      int length) {
+    DRAKE_ASSERT(start >= 0 && length >= 0);
+    DRAKE_ASSERT(start + length <= block.rows());
+    return block.nestedExpression().segment(block.startRow() + start, length);
+  }
+
+  // The mutable version of make_block_segment().
+  static Eigen::VectorBlock<VectorX<T>> make_mutable_block_segment(
+      Eigen::VectorBlock<VectorX<T>>* block, int start, int length) {
+    DRAKE_ASSERT(block != nullptr);
+    DRAKE_ASSERT(start >= 0 && length >= 0);
+    DRAKE_ASSERT(start + length <= block->rows());
+    return block->nestedExpression().segment(block->startRow() + start, length);
+  }
+
+  // Templatized versions of the above where the return type is a fixed-length
+  // VectorBlock of the given VectorX.
+  template <int length>
+  static Eigen::VectorBlock<const VectorX<T>, length> make_block_segment(
+      const Eigen::VectorBlock<const VectorX<T>>& block, int start) {
+    static_assert(length >= 0,
+                  "make_block_segment(): length must be non-negative");
+    DRAKE_ASSERT(start >= 0);
+    DRAKE_ASSERT(start + length <= block.rows());
+    return block.nestedExpression().template segment<length>(block.startRow() +
+                                                             start);
+  }
+
+  template <int length>
+  static Eigen::VectorBlock<VectorX<T>, length> make_mutable_block_segment(
+      Eigen::VectorBlock<VectorX<T>>* block, int start) {
+    static_assert(length >= 0,
+                  "make_mutable_block_segment(): length must be non-negative");
+    DRAKE_ASSERT(block != nullptr);
+    DRAKE_ASSERT(start >= 0);
+    DRAKE_ASSERT(start + length <= block->rows());
+    return block->nestedExpression().template segment<length>(
+        block->startRow() + start);
+  }
 
   const Joint<T>& GetJointByNameImpl(
       std::string_view, std::optional<ModelInstanceIndex>) const;
+
   [[noreturn]] void ThrowJointSubtypeMismatch(
       const Joint<T>&, std::string_view) const;
 

--- a/multibody/tree/multibody_tree_system.cc
+++ b/multibody/tree/multibody_tree_system.cc
@@ -344,12 +344,8 @@ void MultibodyTreeSystem<T>::DoCalcImplicitTimeDerivativesResidual(
 
   auto qdot_residual = residual->head(nq);
   // N(q)⋅v
-  internal_tree().MapVelocityToQDot(context,
-                                    internal_tree()
-                                        .GetPositionsAndVelocities(context)
-                                        .nestedExpression()
-                                        .tail(nv),
-                                    &qdot_residual);
+  internal_tree().MapVelocityToQDot(
+      context, internal_tree().get_velocities(context), &qdot_residual);
   // q̇_proposed - N(q)⋅v
   qdot_residual = qvdot_proposed.head(nq) - qdot_residual;
   // InverseDynamics(context, v_proposed)

--- a/multibody/tree/planar_mobilizer.cc
+++ b/multibody/tree/planar_mobilizer.cc
@@ -22,7 +22,7 @@ template <typename T>
 const PlanarMobilizer<T>& PlanarMobilizer<T>::set_translations(
     systems::Context<T>* context,
     const Eigen::Ref<const Vector2<T>>& translations) const {
-  auto q = this->get_mutable_positions(&*context);
+  auto q = this->GetMutablePositions(context);
   DRAKE_ASSERT(q.size() == kNq);
   q.head(2) = translations;
   return *this;
@@ -39,7 +39,7 @@ const T& PlanarMobilizer<T>::get_angle(
 template <typename T>
 const PlanarMobilizer<T>& PlanarMobilizer<T>::set_angle(
     systems::Context<T>* context, const T& angle) const {
-  auto q = this->get_mutable_positions(&*context);
+  auto q = this->GetMutablePositions(context);
   DRAKE_ASSERT(q.size() == kNq);
   q[2] = angle;
   return *this;
@@ -57,7 +57,7 @@ template <typename T>
 const PlanarMobilizer<T>& PlanarMobilizer<T>::set_translation_rates(
     systems::Context<T>* context,
     const Eigen::Ref<const Vector2<T>>& v_FM_F) const {
-  auto v = this->get_mutable_velocities(&*context);
+  auto v = this->GetMutableVelocities(context);
   DRAKE_ASSERT(v.size() == kNv);
   v.head(2) = v_FM_F;
   return *this;
@@ -74,7 +74,7 @@ const T& PlanarMobilizer<T>::get_angular_rate(
 template <typename T>
 const PlanarMobilizer<T>& PlanarMobilizer<T>::set_angular_rate(
     systems::Context<T>* context, const T& theta_dot) const {
-  auto v = this->get_mutable_velocities(&*context);
+  auto v = this->GetMutableVelocities(context);
   DRAKE_ASSERT(v.size() == kNv);
   v[2] = theta_dot;
   return *this;

--- a/multibody/tree/prismatic_mobilizer.cc
+++ b/multibody/tree/prismatic_mobilizer.cc
@@ -21,7 +21,7 @@ const T& PrismaticMobilizer<T>::get_translation(
 template <typename T>
 const PrismaticMobilizer<T>& PrismaticMobilizer<T>::set_translation(
     systems::Context<T>* context, const T& translation) const {
-  auto q = this->get_mutable_positions(&*context);
+  auto q = this->GetMutablePositions(context);
   DRAKE_ASSERT(q.size() == kNq);
   q[0] = translation;
   return *this;
@@ -38,7 +38,7 @@ const T& PrismaticMobilizer<T>::get_translation_rate(
 template <typename T>
 const PrismaticMobilizer<T>& PrismaticMobilizer<T>::set_translation_rate(
     systems::Context<T>* context, const T& translation_dot) const {
-  auto v = this->get_mutable_velocities(&*context);
+  auto v = this->GetMutableVelocities(context);
   DRAKE_ASSERT(v.size() == kNv);
   v[0] = translation_dot;
   return *this;

--- a/multibody/tree/revolute_mobilizer.cc
+++ b/multibody/tree/revolute_mobilizer.cc
@@ -20,7 +20,7 @@ const T& RevoluteMobilizer<T>::get_angle(
 template <typename T>
 const RevoluteMobilizer<T>& RevoluteMobilizer<T>::set_angle(
     systems::Context<T>* context, const T& angle) const {
-  auto q = this->get_mutable_positions(&*context);
+  auto q = this->GetMutablePositions(context);
   DRAKE_ASSERT(q.size() == kNq);
   q[0] = angle;
   return *this;
@@ -28,7 +28,7 @@ const RevoluteMobilizer<T>& RevoluteMobilizer<T>::set_angle(
 
 template <typename T>
 const T& RevoluteMobilizer<T>::get_angular_rate(
-    const systems::Context<T> &context) const {
+    const systems::Context<T>& context) const {
   const auto& v = this->get_velocities(context);
   DRAKE_ASSERT(v.size() == kNv);
   return v.coeffRef(0);
@@ -37,7 +37,7 @@ const T& RevoluteMobilizer<T>::get_angular_rate(
 template <typename T>
 const RevoluteMobilizer<T>& RevoluteMobilizer<T>::set_angular_rate(
     systems::Context<T>* context, const T& theta_dot) const {
-  auto v = this->get_mutable_velocities(&*context);
+  auto v = this->GetMutableVelocities(context);
   DRAKE_ASSERT(v.size() == kNv);
   v[0] = theta_dot;
   return *this;

--- a/multibody/tree/screw_mobilizer.cc
+++ b/multibody/tree/screw_mobilizer.cc
@@ -28,7 +28,7 @@ const ScrewMobilizer<T>& ScrewMobilizer<T>::set_translation(
   using std::abs;
   DRAKE_THROW_UNLESS(abs(screw_pitch_) > kEpsilon ||
                      abs(translation) < kEpsilon);
-  auto q = this->get_mutable_positions(&*context);
+  auto q = this->GetMutablePositions(context);
   DRAKE_ASSERT(q.size() == kNq);
   q[0] = get_screw_rotation_from_translation(translation, screw_pitch_);
   return *this;
@@ -45,7 +45,7 @@ T ScrewMobilizer<T>::get_angle(
 template <typename T>
 const ScrewMobilizer<T>& ScrewMobilizer<T>::set_angle(
     systems::Context<T>* context, const T& angle) const {
-  auto q = this->get_mutable_positions(&*context);
+  auto q = this->GetMutablePositions(context);
   DRAKE_ASSERT(q.size() == kNq);
   q[0] = angle;
   return *this;
@@ -67,7 +67,7 @@ const ScrewMobilizer<T>& ScrewMobilizer<T>::set_translation_rate(
   using std::abs;
   DRAKE_THROW_UNLESS(abs(screw_pitch_) > kEpsilon || abs(vz) < kEpsilon);
 
-  auto v = this->get_mutable_velocities(&*context);
+  auto v = this->GetMutableVelocities(context);
   DRAKE_ASSERT(v.size() == kNv);
   v[0] = get_screw_rotation_from_translation(vz, screw_pitch_);
   return *this;
@@ -84,7 +84,7 @@ T ScrewMobilizer<T>::get_angular_rate(
 template <typename T>
 const ScrewMobilizer<T>& ScrewMobilizer<T>::set_angular_rate(
     systems::Context<T>* context, const T& theta_dot) const {
-  auto v = this->get_mutable_velocities(&*context);
+  auto v = this->GetMutableVelocities(context);
   DRAKE_ASSERT(v.size() == kNv);
   v[0] = theta_dot;
   return *this;

--- a/multibody/tree/space_xyz_floating_mobilizer.cc
+++ b/multibody/tree/space_xyz_floating_mobilizer.cc
@@ -52,7 +52,7 @@ Vector3<T> SpaceXYZFloatingMobilizer<T>::get_translational_velocity(
 template <typename T>
 const SpaceXYZFloatingMobilizer<T>& SpaceXYZFloatingMobilizer<T>::set_angles(
     systems::Context<T>* context, const Vector3<T>& angles) const {
-  auto q = this->get_mutable_positions(context).template head<3>();
+  auto q = this->GetMutablePositions(context).template head<3>();
   q = angles;
   return *this;
 }
@@ -61,7 +61,7 @@ template <typename T>
 const SpaceXYZFloatingMobilizer<T>&
 SpaceXYZFloatingMobilizer<T>::set_translation(systems::Context<T>* context,
                                               const Vector3<T>& p_FM) const {
-  auto q = this->get_mutable_positions(context).template tail<3>();
+  auto q = this->GetMutablePositions(context).template tail<3>();
   q = p_FM;
   return *this;
 }
@@ -70,7 +70,7 @@ template <typename T>
 const SpaceXYZFloatingMobilizer<T>&
 SpaceXYZFloatingMobilizer<T>::set_angular_velocity(
     systems::Context<T>* context, const Vector3<T>& w_FM) const {
-  auto v = this->get_mutable_velocities(context).template head<3>();
+  auto v = this->GetMutableVelocities(context).template head<3>();
   v = w_FM;
   return *this;
 }
@@ -79,7 +79,7 @@ template <typename T>
 const SpaceXYZFloatingMobilizer<T>&
 SpaceXYZFloatingMobilizer<T>::set_translational_velocity(
     systems::Context<T>* context, const Vector3<T>& v_FM) const {
-  auto v = this->get_mutable_velocities(context).template tail<3>();
+  auto v = this->GetMutableVelocities(context).template tail<3>();
   v = v_FM;
   return *this;
 }

--- a/multibody/tree/space_xyz_mobilizer.cc
+++ b/multibody/tree/space_xyz_mobilizer.cc
@@ -21,7 +21,7 @@ Vector3<T> SpaceXYZMobilizer<T>::get_angles(
 template <typename T>
 const SpaceXYZMobilizer<T>& SpaceXYZMobilizer<T>::set_angles(
     systems::Context<T>* context, const Vector3<T>& angles) const {
-  auto q = this->get_mutable_positions(&*context);
+  auto q = this->GetMutablePositions(context);
   q = angles;
   return *this;
 }
@@ -29,7 +29,7 @@ const SpaceXYZMobilizer<T>& SpaceXYZMobilizer<T>::set_angles(
 template <typename T>
 const SpaceXYZMobilizer<T>& SpaceXYZMobilizer<T>::SetFromRotationMatrix(
     systems::Context<T>* context, const math::RotationMatrix<T>& R_FM) const {
-  auto q = this->get_mutable_positions(&*context);
+  auto q = this->GetMutablePositions(context);
   DRAKE_ASSERT(q.size() == kNq);
   q = math::RollPitchYaw<T>(R_FM).vector();
   return *this;

--- a/multibody/tree/test/articulated_body_algorithm_test.cc
+++ b/multibody/tree/test/articulated_body_algorithm_test.cc
@@ -42,10 +42,10 @@ class FeatherstoneMobilizer final : public MobilizerImpl<T, 2, 2> {
              0, 0;
   }
 
-  const FeatherstoneMobilizer<T>& set_angles(
+  const FeatherstoneMobilizer<T>& SetAngles(
       systems::Context<T>* context,
       const Vector2<T>& angles) const {
-    auto q = this->get_mutable_positions(&*context);
+    auto q = this->GetMutablePositions(context);
     DRAKE_ASSERT(q.size() == kNq);
     q = angles;
     return *this;
@@ -306,7 +306,7 @@ GTEST_TEST(ArticulatedBodyInertiaAlgorithm, ModifiedFeatherstoneExample) {
   // State of the mobilizer connecting the box and cylinder.
   Vector2<double> q_BC;
   q_BC << M_PI_4, 0.2;
-  BC_mobilizer.set_angles(context.get(), q_BC);
+  BC_mobilizer.SetAngles(context.get(), q_BC);
 
   // Update cache.
   PositionKinematicsCache<double> pc(tree.get_topology());

--- a/multibody/tree/test/model_instance_test.cc
+++ b/multibody/tree/test/model_instance_test.cc
@@ -122,7 +122,7 @@ GTEST_TEST(ModelInstance, ModelInstanceTest) {
   // Clear the entire multibody state vector so that we can check the effect
   // of setting one instance at a time.
   tree.GetMutablePositionsAndVelocities(context.get()).setZero();
-  EXPECT_EQ(tree.GetPositionsAndVelocities(*context).norm(), 0);
+  EXPECT_EQ(tree.get_positions_and_velocities(*context).norm(), 0);
 
   // Validate setting the position and velocity through the multibody state
   // vector for an instance.

--- a/multibody/tree/test/tree_from_mobilizers_test.cc
+++ b/multibody/tree/test/tree_from_mobilizers_test.cc
@@ -490,13 +490,13 @@ TEST_F(PendulumTests, CreateContext) {
 
   // Verifies the correct number of generalized positions and velocities.
   EXPECT_EQ(tree.get_positions(*context).size(), 2);
-  EXPECT_EQ(tree.get_mutable_positions(&*context).size(), 2);
+  EXPECT_EQ(tree.GetMutablePositions(&*context).size(), 2);
   EXPECT_EQ(tree.get_velocities(*context).size(), 2);
-  EXPECT_EQ(tree.get_mutable_velocities(&*context).size(), 2);
+  EXPECT_EQ(tree.GetMutableVelocities(&*context).size(), 2);
 
   // Verifies methods to retrieve fixed-sized segments of the state.
   EXPECT_EQ(tree.get_state_segment<1>(*context, 1).size(), 1);
-  EXPECT_EQ(tree.get_mutable_state_segment<1>(&*context, 1).size(), 1);
+  EXPECT_EQ(tree.GetMutableStateSegment<1>(&*context, 1).size(), 1);
 
   // Set the poses of each body in the position kinematics cache to have an
   // arbitrary value that we can use for unit testing. In practice the poses in

--- a/multibody/tree/universal_mobilizer.cc
+++ b/multibody/tree/universal_mobilizer.cc
@@ -25,7 +25,7 @@ Vector2<T> UniversalMobilizer<T>::get_angles(
 template <typename T>
 const UniversalMobilizer<T>& UniversalMobilizer<T>::set_angles(
     systems::Context<T>* context, const Vector2<T>& angles) const {
-  auto q = this->get_mutable_positions(&*context);
+  auto q = this->GetMutablePositions(context);
   DRAKE_ASSERT(q.size() == kNq);
   q = angles;
   return *this;
@@ -42,7 +42,7 @@ Vector2<T> UniversalMobilizer<T>::get_angular_rates(
 template <typename T>
 const UniversalMobilizer<T>& UniversalMobilizer<T>::set_angular_rates(
     systems::Context<T>* context, const Vector2<T>& angles_dot) const {
-  auto v = this->get_mutable_velocities(&*context);
+  auto v = this->GetMutableVelocities(context);
   DRAKE_ASSERT(v.size() == kNv);
   v = angles_dot;
   return *this;


### PR DESCRIPTION
This PR cleans up handling of state sub-blocks in MultibodyTree and MultibodyPlant. 
- Localizes building of sub-blocks to four private methods in MBTree that know how to create sub-VectorBlocks from large VectorBlocks without ending up with double indirection.
- Modifies all methods that need sub-blocks to use the new methods.
- Removes any assumption that the velocities are at the tail of the full state, replacing that with only the assumption that they follow the positions. Currently it is not possible to add z variables to MBTree but this avoids a potential landmine if z's are added later.
- Renames MBTree methods for consistency and to make it clear which ones are expensive (those are internal so don't require deprecation).
- Eliminates redundant state access methods in MBTree.
- Adds missing unit tests for the MBTree state-access methods.
- Modifies some comments and makes minor style fixes.

The organization of state access methods in MBTree is somewhat scattered and could use re-arranging. I'm not doing that here because it would make the changes too hard to review.

This is a prerequisite for PR #15489.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15528)
<!-- Reviewable:end -->
