### PR TITLE
[geometry] Finish deprecation of "is gradient unique" from signed distance queries

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -799,7 +799,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
     auto cls = DefineTemplateClassWithDefault<Class>(
         m, "SignedDistancePair", param, doc.SignedDistancePair.doc);
     cls  // BR
-        .def(ParamInit<Class>(), doc.SignedDistancePair.ctor.doc_6args)
+        .def(ParamInit<Class>(), doc.SignedDistancePair.ctor.doc)
         .def_readwrite("id_A", &SignedDistancePair<T>::id_A,
             doc.SignedDistancePair.id_A.doc)
         .def_readwrite("id_B", &SignedDistancePair<T>::id_B,
@@ -815,21 +815,6 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def_readwrite("nhat_BA_W", &SignedDistancePair<T>::nhat_BA_W,
             return_value_policy_for_scalar_type<T>(),
             doc.SignedDistancePair.nhat_BA_W.doc);
-
-    constexpr char deprecated_unique_flag_doc[] =
-        "SignedDistancePair will no longer report uniqueness. If you require "
-        "knowledge of uniqueness, please contact the Drake team. This will be "
-        "removed on or after 2021-08-01.";
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    cls.def_property(
-        "is_nhat_BA_W_unique",
-        [](const Class* self) { return self->is_nhat_BA_W_unique; },
-        [](Class* self, int value) { self->is_nhat_BA_W_unique = value; },
-        deprecated_unique_flag_doc);
-#pragma GCC diagnostic pop
-
-    DeprecateAttribute(cls, "is_nhat_BA_W_unique", deprecated_unique_flag_doc);
   }
 
   // SignedDistanceToPoint
@@ -838,7 +823,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
     auto cls = DefineTemplateClassWithDefault<Class>(
         m, "SignedDistanceToPoint", param, doc.SignedDistanceToPoint.doc);
     cls  // BR
-        .def(ParamInit<Class>(), doc.SignedDistanceToPoint.ctor.doc_4args)
+        .def(ParamInit<Class>(), doc.SignedDistanceToPoint.ctor.doc)
         .def_readwrite("id_G", &SignedDistanceToPoint<T>::id_G,
             doc.SignedDistanceToPoint.id_G.doc)
         .def_readwrite("p_GN", &SignedDistanceToPoint<T>::p_GN,

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -1072,21 +1072,3 @@ class TestGeometry(unittest.TestCase):
             domain=mut.optimization.HPolyhedron.MakeBox(
                 lb=[-5, -5, -5], ub=[5, 5, 5]), options=options)
         self.assertIsInstance(region, mut.optimization.HPolyhedron)
-
-    def test_deprecated_struct_member(self):
-        """Tests successful deprecation of struct member"""
-        with catch_drake_warnings(expected_count=1):
-            # Initializing by referencing the deprecated field warns.
-            data = mut.SignedDistancePair(is_nhat_BA_W_unique=False)
-
-        data = mut.SignedDistancePair()
-        with catch_drake_warnings(expected_count=2):
-            # Setting the deprecated field warns.
-            data.is_nhat_BA_W_unique = False
-            _ = data.is_nhat_BA_W_unique
-
-        # Specifying all other members in constructor is fine.
-        data = mut.SignedDistancePair(id_A=mut.GeometryId.get_new_id(),
-                                      id_B=mut.GeometryId.get_new_id(),
-                                      p_ACa=[0, 0, 1], p_BCb=[1, 0, 0],
-                                      distance=13, nhat_BA_W=[0, 1, 0])

--- a/geometry/proximity/distance_to_point_callback.h
+++ b/geometry/proximity/distance_to_point_callback.h
@@ -94,8 +94,7 @@ struct CallbackData {
                               is expressed in the world frame. Where grad_W is
                               not unique, then an arbitrary value is
                               assigned (as documented in
-                              QueryObject::ComputeSignedDistanceToPoint().
- @param is_grad_w_unique[out] True if the value in `grad_W` is unique.  */
+                              QueryObject::ComputeSignedDistanceToPoint().  */
 //@{
 
 /* Computes distance from point to sphere with the understanding that all
@@ -104,32 +103,28 @@ struct CallbackData {
 template <typename T>
 void SphereDistanceInSphereFrame(const fcl::Sphered& sphere,
                                  const Vector3<T>& p_SQ, Vector3<T>* p_SN,
-                                 T* distance, Vector3<T>* grad_S,
-                                 bool* is_grad_W_unique);
+                                 T* distance, Vector3<T>* grad_S);
 
 /* Overload of ComputeDistanceToPrimitive() for sphere primitive. */
 template <typename T>
 void ComputeDistanceToPrimitive(const fcl::Sphered& sphere,
                                 const math::RigidTransform<T>& X_WG,
                                 const Vector3<T>& p_WQ, Vector3<T>* p_GN,
-                                T* distance, Vector3<T>* grad_W,
-                                bool* is_grad_W_unique);
+                                T* distance, Vector3<T>* grad_W);
 
 /* Overload of ComputeDistanceToPrimitive() for halfspace primitive. */
 template <typename T>
 void ComputeDistanceToPrimitive(const fcl::Halfspaced& halfspace,
                                 const math::RigidTransform<T>& X_WG,
                                 const Vector3<T>& p_WQ, Vector3<T>* p_GN,
-                                T* distance, Vector3<T>* grad_W,
-                                bool* is_grad_W_unique);
+                                T* distance, Vector3<T>* grad_W);
 
 /* Overload of ComputeDistanceToPrimitive() for capsule primitive. */
 template <typename T>
 void ComputeDistanceToPrimitive(const fcl::Capsuled& capsule,
                                 const math::RigidTransform<T>& X_WG,
                                 const Vector3<T>& p_WQ, Vector3<T>* p_GN,
-                                T* distance, Vector3<T>* grad_W,
-                                bool* is_grad_W_unique);
+                                T* distance, Vector3<T>* grad_W);
 
 // TODO(DamrongGuoy): Add overloads for all supported geometries.
 

--- a/geometry/proximity/distance_to_shape_callback.cc
+++ b/geometry/proximity/distance_to_shape_callback.cc
@@ -56,10 +56,6 @@ void DistancePairGeometry<T>::SphereShapeDistance(const fcl::Sphered& sphere_A,
   // p_BCb is the witness point on ∂B measured and expressed in B.
   result_->p_BCb = shape_B_to_point_Ao.p_GN;
   result_->nhat_BA_W = shape_B_to_point_Ao.grad_W;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  result_->is_nhat_BA_W_unique = shape_B_to_point_Ao.is_grad_W_unique;
-#pragma GCC diagnostic pop
   // p_ACa is the witness point on ∂A measured and expressed in A.
   const math::RotationMatrix<T> R_AW = X_WA_.rotation().transpose();
   result_->p_ACa = -sphere_A.radius * (R_AW * shape_B_to_point_Ao.grad_W);
@@ -93,20 +89,11 @@ void CalcDistanceFallback<double>(const fcl::CollisionObjectd& a,
 
   // Returns NaN in nhat when min_distance is 0 or almost 0.
   // TODO(DamrongGuoy): In the future, we should return nhat_BA_W as the
-  //  outward face normal when the two objects are touching and set
-  //  is_nhat_BA_W_unique to true.
+  //  outward face normal when the two objects are touching.
   if (std::abs(result.min_distance) < kEps) {
     pair_data->nhat_BA_W = Eigen::Vector3d(kNan, kNan, kNan);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    pair_data->is_nhat_BA_W_unique = false;
-#pragma GCC diagnostic pop
   } else {
     pair_data->nhat_BA_W = (p_WCa - p_WCb) / result.min_distance;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    pair_data->is_nhat_BA_W_unique = true;
-#pragma GCC diagnostic pop
   }
 }
 

--- a/geometry/proximity/test/distance_sphere_to_shape_test.cc
+++ b/geometry/proximity/test/distance_sphere_to_shape_test.cc
@@ -467,47 +467,6 @@ GTEST_TEST(ComputeNarrowPhaseDistance, sphere_touches_shape) {
   EXPECT_EQ(Vector3d(1, 0, 0), result.nhat_BA_W);
 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-// Confirms that `is_nhat_BA_W_unique` is passed from point_distance to
-// shape_distance correctly. It is a pass through from DistanceToPoint() to
-// SphereShapeDistance(). We use Sphere-Box as a representative sample and
-// test two cases when `is_nhat_BA_W_unique` is true and is false.
-GTEST_TEST(ComputeNarrowPhaseDistance, is_nhat_BA_W_well_defined) {
-  // Sphere
-  CollisionObjectd sphere(make_shared<Sphered>(1));
-  const GeometryId sphere_id = GeometryId::get_new_id();
-  EncodedData(sphere_id, true).write_to(&sphere);
-
-  // Box [-1,1]x[-1,1]x[-1,1].
-  CollisionObjectd box(make_shared<Boxd>(2, 2, 2));
-  const GeometryId box_id = GeometryId::get_new_id();
-  EncodedData(box_id, true).write_to(&box);
-  const RigidTransformd X_WB(RigidTransformd::Identity());
-
-  const fcl::DistanceRequestd request{};
-
-  // Tests when `is_nhat_BA_W_unique` is true.
-  {
-    // The center of the sphere is outside the box.
-    const RigidTransformd X_WS(Vector3d{3, 3, 3});
-    SignedDistancePair<double> result;
-    ComputeNarrowPhaseDistance<double>(sphere, X_WS, box, X_WB, request,
-                                       &result);
-    EXPECT_EQ(true, result.is_nhat_BA_W_unique);
-  }
-  // Tests when `is_nhat_BA_W_unique` is false.
-  {
-    // The center of the sphere is at a corner of the box.
-    const RigidTransformd X_WS(Vector3d{1, 1, 1});
-    SignedDistancePair<double> result;
-    ComputeNarrowPhaseDistance<double>(sphere, X_WS, box, X_WB, request,
-                                       &result);
-    EXPECT_EQ(false, result.is_nhat_BA_W_unique);
-  }
-}
-#pragma GCC diagnostic pop
-
 template <typename T>
 class CallbackScalarSupport : public ::testing::Test {
  public:

--- a/geometry/proximity/test/distance_to_point_callback_test.cc
+++ b/geometry/proximity/test/distance_to_point_callback_test.cc
@@ -81,10 +81,6 @@ class PointShapeAutoDiffSignedDistanceTester {
         GeometryId::get_new_id(), X_WG_.cast<AutoDiffXd>(), p_WQ_ad);
 
     SignedDistanceToPoint<AutoDiffXd> result = distance_to_point(shape_);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    EXPECT_EQ(result.is_grad_W_unique, is_grad_W_unique);
-#pragma GCC diagnostic pop
     if (std::abs(result.distance.value() - expected_distance) > tolerance_) {
       error = true;
       failure << "The difference between expected distance and tested distance "
@@ -203,7 +199,7 @@ GTEST_TEST(DistanceToPoint, Box) {
           // The query point lies on the vertex of the box.
           EXPECT_TRUE(tester.Test(p_GN_G, Vector3d::Zero(),
                                   false /* not inside the box */,
-                                  false /* not well defined */));
+                                  false /* gradient ill defined */));
         }
       }
     }
@@ -227,7 +223,7 @@ GTEST_TEST(DistanceToPoint, Box) {
         // The query point lies on the edge of the box.
         EXPECT_TRUE(tester.Test(p_GN_G, Vector3d::Zero(),
                                 false /* not inside the box */,
-                                false /* not well defined */));
+                                false /* gradient ill defined */));
 
         // A query point *inside* the box would not be nearest the edge.
       }
@@ -316,7 +312,7 @@ GTEST_TEST(DistanceToPoint, Capsule) {
     {
       const Vector3d p_NQ_G = -capsule.radius * vhat_NQ_G;
       EXPECT_TRUE(tester.Test(p_GN_G, p_NQ_G, true /* is inside */,
-                              false /* ill defined */));
+                              false /* gradient ill defined */));
     }
   }
 }
@@ -499,7 +495,8 @@ GTEST_TEST(DistanceToPoint, Sphere) {
 
   // Case: point lies at origin of the sphere.
   EXPECT_TRUE(tester.Test(p_GN_G, -sphere.radius * vhat_NQ,
-                          true /* is inside */, false /* ill defined */));
+                          true /* is inside */,
+                          false /* gradient ill defined */));
 }
 
 // TODO(SeanCurtis-TRI): Point-to-cylinder with AutoDiff has been "disabled".

--- a/geometry/query_results/signed_distance_pair.h
+++ b/geometry/query_results/signed_distance_pair.h
@@ -20,7 +20,6 @@ namespace geometry {
  - When A and B are touching or penetrating, distance <= 0.
  - By definition, nhat_AB_W must be in the opposite direction of nhat_BA_W.
  - (p_WCa - p_Wcb) = distance · nhat_BA_W.
- - In some cases, nhat_BA_W is not unique, and is_nhat_BA_W_unique is false.
  @warning For two geometries that are just touching (i.e., distance = 0), the
           underlying code can guarantee a correct value for nhat_BA_W only
           when one geometry is a sphere, and the other geometry is a sphere, a
@@ -31,37 +30,14 @@ namespace geometry {
  */
 template <typename T>
 struct SignedDistancePair{
-  // 2021-08-01 deprecation note: While deprecating the is_grad_W_unique, we
-  // cannot use the standard Drake mechanism for declaring copy and move
-  // semantics. The default implementations insist on writing to the deprecated
-  // member and the macro rebels against being enclosed in the
-  // deprecation-suppressing pragma. Once deprecation is complete restore the
-  // standard boilerplate:
-  //
-  //  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SignedDistancePair)
-  //  SignedDistancePair() = default;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SignedDistancePair)
   SignedDistancePair() = default;
-  /** @name Implements CopyConstructible, CopyAssignable, MoveConstructible,
-   MoveAssignable */
-  //@{
-  SignedDistancePair(const SignedDistancePair& other) = default;
-  SignedDistancePair(SignedDistancePair&& other) = default;
-  SignedDistancePair& operator=(const SignedDistancePair& other) =
-      default;
-  SignedDistancePair& operator=(SignedDistancePair&& other) =
-      default;
-  //@}
-#pragma GCC diagnostic pop
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-/* 2021-08-01 deprecation note: This constructor is wrapped in a deprecation
- silencer because gcc will implicitly try to write to the deprecated member and
- throw a build error. When the deprecated member is removed, we *keep* this
- constructor, but lose the pragma manipulations (in contrast to the other
- constructors which will just be deleted as noted). */
+
+  // TODO(DamrongGuoy): When we have a full implementation of computing
+  //  nhat_BA_W in ComputeSignedDistancePairwiseClosestPoints, check a
+  //  condition like this (within epsilon):
+  //      DRAKE_DEMAND(nhat_BA_W.norm() == T(1.));
   /** Constructor
    @param a             The id of the first geometry (A).
    @param b             The id of the second geometry (B).
@@ -79,61 +55,10 @@ struct SignedDistancePair{
         p_BCb(p_BCb_in),
         distance(dist),
         nhat_BA_W(nhat_BA_W_in) {}
-#pragma GCC diagnostic pop
-
-  /** Constructor
-   @param a             The id of the first geometry (A).
-   @param b             The id of the second geometry (B).
-   @param p_ACa_in      The witness point on geometry A's surface, in A's frame.
-   @param p_BCb_in      The witness point on geometry B's surface, in B's frame.
-   @param dist          The signed distance between p_A and p_B.
-   @param nhat_BA_W_in  A direction of fastest increasing distance.
-   @param is_nhat_BA_W_unique_in  True if nhat_BA_W is unique.
-   @pre nhat_BA_W_in is unit-length. */
-  DRAKE_DEPRECATED("2021-08-01",
-                   "SignedDistancePair will no longer report uniqueness. "
-                   "If you require knowledge of uniqueness, please contact the "
-                   "Drake team.")
-  SignedDistancePair(GeometryId a, GeometryId b, const Vector3<T>& p_ACa_in,
-                     const Vector3<T>& p_BCb_in, const T& dist,
-                     const Vector3<T>& nhat_BA_W_in,
-                     bool is_nhat_BA_W_unique_in)
-      : id_A(a),
-        id_B(b),
-        p_ACa(p_ACa_in),
-        p_BCb(p_BCb_in),
-        distance(dist),
-        nhat_BA_W(nhat_BA_W_in),
-        is_nhat_BA_W_unique(is_nhat_BA_W_unique_in)
-  // TODO(DamrongGuoy): When we have a full implementation of computing
-  //  nhat_BA_W in ComputeSignedDistancePairwiseClosestPoints, check a
-  //  condition like this (within epsilon):
-  //      DRAKE_DEMAND(nhat_BA_W.norm() == T(1.));
-  {}
-
-  /** Constructor.
-   We keep this constructor temporarily for backward compatibility.
-   @param a         The id of the first geometry (A).
-   @param b         The id of the second geometry (B).
-   @param p_ACa_in  The witness point on geometry A's surface, in A's frame.
-   @param p_BCb_in  The witness point on geometry B's surface, in B's frame.
-   @param dist      The signed distance between p_A and p_B. */
-  DRAKE_DEPRECATED("2021-08-01",
-                   "Please use default or full constructor instead.")
-  SignedDistancePair(GeometryId a, GeometryId b, const Vector3<T>& p_ACa_in,
-                     const Vector3<T>& p_BCb_in, const T& dist)
-      : id_A(a),
-        id_B(b),
-        p_ACa(p_ACa_in),
-        p_BCb(p_BCb_in),
-        distance(dist),
-        nhat_BA_W(Vector3<T>::Zero()),
-        is_nhat_BA_W_unique(false) {}
 
   /** Swaps the interpretation of geometries A and B. */
   void SwapAAndB() {
-    // Leave distance and is_nhat_BA_W_unique alone; swapping A and B
-    // doesn't change them.
+    // Leave distance alone; swapping A and B doesn't change it.
     std::swap(id_A, id_B);
     std::swap(p_ACa, p_BCb);
     nhat_BA_W = -nhat_BA_W;
@@ -159,11 +84,6 @@ struct SignedDistancePair{
   T distance{};
   /** A direction of fastest increasing distance. */
   Vector3<T> nhat_BA_W;
-  DRAKE_DEPRECATED("2021-08-01",
-                   "SignedDistancePair will no longer report uniqueness. "
-                   "If you require knowledge of uniqueness, please contact the "
-                   "Drake team.")
-  bool is_nhat_BA_W_unique{false};
 };
 
 }  // namespace geometry

--- a/geometry/query_results/signed_distance_to_point.h
+++ b/geometry/query_results/signed_distance_to_point.h
@@ -23,37 +23,9 @@ namespace geometry {
  */
 template <typename T>
 struct SignedDistanceToPoint{
-  // 2021-08-01 deprecation note: While deprecating the is_grad_W_unique, we
-  // cannot use the standard Drake mechanism for declaring copy and move
-  // semantics. The default implementations insist on writing to the deprecated
-  // member and the macro rebels against being enclosed in the
-  // deprecation-suppressing pragma. Once deprecation is complete restore the
-  // standard boilerplate:
-  //
-  //  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SignedDistanceToPoint)
-  //  SignedDistanceToPoint() = default;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SignedDistanceToPoint)
   SignedDistanceToPoint() = default;
-  /** @name Implements CopyConstructible, CopyAssignable, MoveConstructible,
-   MoveAssignable */
-  //@{
-  SignedDistanceToPoint(const SignedDistanceToPoint& other) = default;
-  SignedDistanceToPoint(SignedDistanceToPoint&& other) = default;
-  SignedDistanceToPoint& operator=(const SignedDistanceToPoint& other) =
-      default;
-  SignedDistanceToPoint& operator=(SignedDistanceToPoint&& other) =
-      default;
-  //@}
-#pragma GCC diagnostic pop
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-/* 2021-08-01 deprecation note: This constructor is wrapped in a deprecation
- silencer because gcc will implicitly try to write to the deprecated member and
- throw a build error. When the deprecated member is removed, we *keep* this
- constructor, but lose the pragma manipulations (in contrast to the other
- constructors which will just be deleted as noted). */
   /** Constructs SignedDistanceToPoint struct from calculated results.
    @param id_G_in     The id of the geometry G to which we measure distance from
                       the query point Q.
@@ -85,49 +57,6 @@ struct SignedDistanceToPoint{
     using std::isnan;
     DRAKE_ASSERT(!(isnan(grad_W(0)) || isnan(grad_W(1)) || isnan(grad_W(2))));
   }
-#pragma GCC diagnostic pop
-
-  /** Constructs SignedDistanceToPoint struct from calculated results.
-   @param id_G_in     The id of the geometry G to which we measure distance from
-                      the query point Q.
-   @param p_GN_in     The position of the nearest point N on G's surface from
-                      the query point Q, expressed in G's frame.
-   @param distance_in The signed distance from the query point Q to the nearest
-                      point N on the surface of geometry G. It is positive if
-                      Q is outside G. It is negative if Q is inside G. It is
-                      zero if Q is on the boundary of G.
-   @param grad_W_in   The gradient vector of the distance function with respect
-                      to the query point Q, expressed in world frame W.
-   @param is_grad_W_unique_in  True if grad_W is unique, false otherwise.
-
-   @note grad_W is not well defined everywhere. For example, when computing the
-         distance from a point to a sphere, and the point coincides with the
-         center of the sphere, grad_W is not well defined (as it can be computed
-         as p_GQ / |p_GQ|, but the denominator is 0). When grad_W is not
-         well defined, and we instantiate SignedDistanceToPoint<T> with T being
-         an AutoDiffScalar (like AutoDiffXd), the gradient of the query result
-         is not well defined either, so the user should use the gradient in
-         p_GN, distance and grad_W with caution.
-   @pre grad_W_in must not contain NaN.
-   */
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  DRAKE_DEPRECATED("2021-08-01",
-                   "SignedDistanceToPoint will no longer report uniqueness. "
-                   "If you require knowledge of uniqueness, please contact the "
-                   "Drake team.")
-  SignedDistanceToPoint(GeometryId id_G_in, const Vector3<T>& p_GN_in,
-                        T distance_in, const Vector3<T>& grad_W_in,
-                        bool is_grad_W_unique_in)
-      : id_G(id_G_in),
-        p_GN(p_GN_in),
-        distance(distance_in),
-        grad_W(grad_W_in),
-        is_grad_W_unique(is_grad_W_unique_in) {
-    using std::isnan;
-    DRAKE_ASSERT(!(isnan(grad_W(0)) || isnan(grad_W(1)) || isnan(grad_W(2))));
-  }
-#pragma GCC diagnostic pop
 
   /** The id of the geometry G to which we measure distance from the query
       point Q. */
@@ -142,19 +71,6 @@ struct SignedDistanceToPoint{
   /** The gradient vector of the distance function with respect to the query
       point Q, expressed in world frame W. */
   Vector3<T> grad_W;
-
-  // TODO(SeanCurtis-TRI) When it comes time to deprecate (2021-08-01), ping the
-  //  listed author. Deprecation in this case entails more than simply removing
-  //  this field; it includes changing code in distance_to_point_callback.h,
-  //  its unit tests, and in distance_to_shape_callback.h.
-  /** Whether grad_W is well defined.
-   * Ref to the constructor SignedDistanceToPoint() for an explanation.
-   */
-  DRAKE_DEPRECATED("2021-08-01",
-                   "SignedDistanceToPoint will no longer report uniqueness. "
-                   "If you require knowledge of uniqueness, please contact the "
-                   "Drake team.")
-  bool is_grad_W_unique{false};
 };
 
 }  // namespace geometry


### PR DESCRIPTION
This removes the deprecated member indicating whether the gradient of a signed distance query is "unique".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15532)
<!-- Reviewable:end -->
