### PR TITLE
Retire many more duplicated-word typos

### DIFF
--- a/bindings/pydrake/systems/system_sliders.py
+++ b/bindings/pydrake/systems/system_sliders.py
@@ -141,7 +141,7 @@ class SystemSliders(VectorSystem):
     # context, which is why we can get away with it. However, it would
     # be better to add a discrete state vector that gets updated values
     # from the sliders (and handles the slider update at that time) and
-    # update that in in a DiscreteUpdate.
+    # update that in a DiscreteUpdate.
     def _update_window(self, context, event):
         # GUI functionality is not automatically tested
         # Must manually test this function to ensure updates run properly

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -67,7 +67,7 @@ from pydrake.systems.primitives import (
     ZeroOrderHold,
     )
 
-# TODO(eric.cousineau): The scope of this test file and and `custom_test.py`
+# TODO(eric.cousineau): The scope of this test file and `custom_test.py`
 # is poor. Move these tests into `framework_test` and `analysis_test`, and
 # ensure that the tests reflect this, even if there is some coupling.
 

--- a/common/symbolic_expression_cell.h
+++ b/common/symbolic_expression_cell.h
@@ -296,8 +296,8 @@ class ExpressionAddFactory {
   [[nodiscard]] Expression GetExpression() const;
 
  private:
-  /* Adds constant to this factory.
-   * Adding constant constant into an add factory representing
+  /* Adds a constant @p constant to this factory.
+   * Adding constant into an add factory representing
    *
    *     c0 + c1 * t1 + ... + cn * tn
    *

--- a/common/test/reset_after_move_test.cc
+++ b/common/test/reset_after_move_test.cc
@@ -157,7 +157,7 @@ GTEST_TEST(DefaultValueTest, Move) {
   EXPECT_EQ(w, 3);
 }
 
-// Make sure that our wrapper is is sufficiently nothrow, e.g., so that it can
+// Make sure that our wrapper is sufficiently nothrow, e.g., so that it can
 // be moved (not copied) when an STL container is resized.
 GTEST_TEST(DefaultValueTest, Nothrow) {
   // Default constructor.

--- a/common/test/symbolic_simplification_test.cc
+++ b/common/test/symbolic_simplification_test.cc
@@ -68,7 +68,7 @@ TEST_F(SymbolicUnificationTest, ConstantFailure) {
   // Rule: 3 => 5.
   const RewritingRule rule{3, 5};
   const Rewriter rewriter = MakeRuleRewriter(rule);
-  // Fails to match 4 with with the above rule.
+  // Fails to match 4 with the above rule.
   const Expression e{4};
   EXPECT_PRED2(ExprEqual, rewriter(e), e /* no change */);
 }
@@ -108,28 +108,28 @@ TEST_F(SymbolicUnificationTest, AdditionFailureNonZeroCoeff) {
   const RewritingRule rule{2 + sin(x_) + cos(y_), 3 + 4 * x_ + 5 * y_};
   const Rewriter rewriter = MakeRuleRewriter(rule);
 
-  // Fails to match the following with with the above rule (constant
+  // Fails to match the following with the above rule (constant
   // mismatched).
   // Example of Case 4 in UnificationVisitor::VisitAddition.
   const Expression e1{5 + sin(a_) + cos(b_)};
   EXPECT_PRED2(ExprEqual, rewriter(e1), e1 /* no change */);
 
-  // Fails to match the following with with the above rule (length).
+  // Fails to match the following with the above rule (length).
   // Example of Case 4 in UnificationVisitor::VisitAddition.
   const Expression e2{2 + sin(a_)};
   EXPECT_PRED2(ExprEqual, rewriter(e2), e2 /* no change */);
 
-  // Fails to match the following with with the above rule (sin != cos).
+  // Fails to match the following with the above rule (sin != cos).
   // Example of Case 4 in UnificationVisitor::VisitAddition.
   const Expression e3{2 + cos(a_) + cos(b_)};
   EXPECT_PRED2(ExprEqual, rewriter(e3), e3 /* no change */);
 
-  // Fails to match the following with with the above rule (cos != tan).
+  // Fails to match the following with the above rule (cos != tan).
   // Example of Case 4 in UnificationVisitor::VisitAddition.
   const Expression e4{2 + sin(a_) + tan(b_)};
   EXPECT_PRED2(ExprEqual, rewriter(e4), e4 /* no change */);
 
-  // Fails to match the following with with the above rule (coefficient
+  // Fails to match the following with the above rule (coefficient
   // mismatched).
   // Example of Case 3 in UnificationVisitor::VisitAddition.
   const Expression e5{sin(a_) + cos(b_)};
@@ -141,21 +141,21 @@ TEST_F(SymbolicUnificationTest, AdditionFailureZeroCoeff) {
   const RewritingRule rule{sin(x_) + cos(y_) + sin(z_), x_ + y_ + z_};
   const Rewriter rewriter = MakeRuleRewriter(rule);
 
-  // Fails to match the following with with the above rule (not addition).
+  // Fails to match the following with the above rule (not addition).
   const Expression e1{cos(a_)};
   EXPECT_PRED2(ExprEqual, rewriter(e1), e1 /* no change */);
 
-  // Fails to match the following with with the above rule (length).
+  // Fails to match the following with the above rule (length).
   // Example of Case 2 in UnificationVisitor::VisitAddition.
   const Expression e2{3 + cos(a_)};
   EXPECT_PRED2(ExprEqual, rewriter(e2), e2 /* no change */);
 
-  // Fails to match the following with with the above rule (sin(x) vs 1).
+  // Fails to match the following with the above rule (sin(x) vs 1).
   // Example of Case 2 in UnificationVisitor::VisitAddition.
   const Expression e3{1 + log(a_) + abs(b_)};
   EXPECT_PRED2(ExprEqual, rewriter(e3), e3 /* no change */);
 
-  // Fails to match the following with with the above rule (sin != tan).
+  // Fails to match the following with the above rule (sin != tan).
   // Example of Case 1 in UnificationVisitor::VisitAddition.
   const Expression e4{sin(b_) + cos(a_) + tan(c_)};
   EXPECT_PRED2(ExprEqual, rewriter(e4), e4 /* no change */);
@@ -216,7 +216,7 @@ TEST_F(SymbolicUnificationTest, MultiplicationFailure1) {
                            4 * pow(x_, y_) * pow(2, z_)};
   const Rewriter rewriter = MakeRuleRewriter(rule);
 
-  // Fails to match the following with with the above rule.
+  // Fails to match the following with the above rule.
   // Example of Case 3 in UnificationVisitor::VisitMultiplication.
   const Expression e{pow(cos(a_), c_) * cos(b_)};
   EXPECT_PRED2(ExprEqual, rewriter(e), e /* no change */);
@@ -227,19 +227,19 @@ TEST_F(SymbolicUnificationTest, MultiplicationFailure2) {
   //    => x + y + z
   const RewritingRule rule{sin(x_) * cos(y_) * tan(z_), x_ + y_ + z_};
   const Rewriter rewriter = MakeRuleRewriter(rule);
-  // Fails to match the following with with the above rule.
+  // Fails to match the following with the above rule.
   // Example of Case 1 in UnificationVisitor::VisitMultiplication.
   const Expression e1{sin(a_) * acos(b_) * tan(c_)};
   EXPECT_PRED2(ExprEqual, rewriter(e1), e1 /* no change */);
-  // Fails to match the following with with the above rule.
+  // Fails to match the following with the above rule.
   // Example of Case 1 in UnificationVisitor::VisitMultiplication.
   const Expression e2{a_ * sin(b_)};
   EXPECT_PRED2(ExprEqual, rewriter(e2), e2 /* no change */);
-  // Fails to match the following with with the above rule.
+  // Fails to match the following with the above rule.
   // Example of Case 2 in UnificationVisitor::VisitMultiplication.
   const Expression e3{5 * cos(b_) * tan(z_)};
   EXPECT_PRED2(ExprEqual, rewriter(e3), e3 /* no change */);
-  // Fails to match the following with with the above rule.
+  // Fails to match the following with the above rule.
   const Expression e4{5};
   EXPECT_PRED2(ExprEqual, rewriter(e4), e4 /* no change */);
 }
@@ -248,11 +248,11 @@ TEST_F(SymbolicUnificationTest, MultiplicationFailure3) {
   // Rule: 2 * x * y * z => x + y + z.
   const RewritingRule rule{2 * x_ * y_ * z_, x_ + y_ + z_};
   const Rewriter rewriter = MakeRuleRewriter(rule);
-  // Fails to match the following with with the above rule (coefficients).
+  // Fails to match the following with the above rule (coefficients).
   // Example of Case 4 in UnificationVisitor::VisitMultiplication.
   const Expression e1{3 * a_ * b_ * c_};
   EXPECT_PRED2(ExprEqual, rewriter(e1), e1 /* no change */);
-  // Fails to match the following with with the above rule (length).
+  // Fails to match the following with the above rule (length).
   // Example of Case 4 in UnificationVisitor::VisitMultiplication.
   const Expression e2{3 * a_ * b_};
   EXPECT_PRED2(ExprEqual, rewriter(e2), e2 /* no change */);
@@ -262,7 +262,7 @@ TEST_F(SymbolicUnificationTest, MultiplicationFailure4) {
   // Rule: x * y * z => x + y + z.
   const RewritingRule rule{x_ * y_ * z_, x_ + y_ + z_};
   const Rewriter rewriter = MakeRuleRewriter(rule);
-  // Fails to match the following with with the above rule.
+  // Fails to match the following with the above rule.
   // Example of Case 2 in UnificationVisitor::VisitMultiplication.
   const Expression e{3 * a_};
   EXPECT_PRED2(ExprEqual, rewriter(e), e /* no change */);

--- a/common/test_utilities/expect_throws_message.h
+++ b/common/test_utilities/expect_throws_message.h
@@ -19,7 +19,7 @@ Usage example: @code
 @endcode
 The regular expression must match the entire error message. If there is
 boilerplate you don't care to match at the beginning and end, surround with
-with `.*` to ignore in single-line messages or `[\s\S]*` for multiline
+`.*` to ignore in single-line messages or `[\s\S]*` for multiline
 messages.
 
 The "exception" argument is optional and defaults to "std::exception" when

--- a/common/test_utilities/test/limit_malloc_test.cc
+++ b/common/test_utilities/test/limit_malloc_test.cc
@@ -159,7 +159,7 @@ TEST_P(LimitMallocDeathTest, MaxLimitTest) {
 }
 
 TEST_P(LimitMallocDeathTest, ObservationTest) {
-  // Though not actually a death test, this is is a convenient place to test
+  // Though not actually a death test, this is a convenient place to test
   // that the getter returns a correct count.  We must check within a unit test
   // that is known to be disabled via the BUILD file for platforms without a
   // working implementation.

--- a/common/type_safe_index.h
+++ b/common/type_safe_index.h
@@ -421,7 +421,7 @@ class TypeSafeIndex {
     return index_ <= other.index_;
   }
 
-  /// Allow less than or equals test test with unsigned integers.
+  /// Allow less than or equals test with unsigned integers.
   template <typename U>
   typename std::enable_if_t<
       std::is_integral_v<U> && std::is_unsigned_v<U>, bool>

--- a/common/yaml/yaml_read_archive.h
+++ b/common/yaml/yaml_read_archive.h
@@ -114,8 +114,8 @@ class YamlReadArchive final {
   }
 
   /// (Advanced.)  Sets the value pointed to by `nvp.value()` based on the YAML
-  /// file associated with this archive.  Most users should should call Accept,
-  /// not Visit.
+  /// file associated with this archive.  Most users should call Accept, not
+  /// Visit.
   template <typename NameValuePair>
   void Visit(const NameValuePair& nvp) {
     this->Visit(nvp, VisitShouldMemorizeType::kYes);

--- a/common/yaml/yaml_write_archive.h
+++ b/common/yaml/yaml_write_archive.h
@@ -118,7 +118,7 @@ class YamlWriteArchive final {
   void EraseMatchingMaps(const YamlWriteArchive& other);
 
   /// (Advanced.)  Copies the value pointed to by `nvp.value()` into the YAML
-  /// object.  Most users should should call Accept, not Visit.
+  /// object.  Most users should call Accept, not Visit.
   template <typename NameValuePair>
   void Visit(const NameValuePair& nvp) {
     // Use int32_t for the final argument to prefer the specialized overload.

--- a/doc/_pages/developers.md
+++ b/doc/_pages/developers.md
@@ -247,7 +247,7 @@ Please subscribe to the ``drake`` tag by following these instructions:
 Please also monitor for [unanswered StackOverflow posts](https://stackoverflow.com/unanswered/tagged/drake?tab=noanswers)
 once per day. If there are unanswered questions that you are unsure of the
 answer, consider posting on the Slack ``#onramp`` channel to see if someone
-can can look into the question.
+can look into the question.
 
 # Continuous Integration Notes
 

--- a/geometry/drake_visualizer.cc
+++ b/geometry/drake_visualizer.cc
@@ -221,7 +221,7 @@ DrakeVisualizer<T>::DrakeVisualizer(lcm::DrakeLcmInterface* lcm,
   }
   if (params_.role == Role::kUnassigned) {
     throw std::runtime_error(
-        "DrakeVisualizer cannot be be used for geometries with the "
+        "DrakeVisualizer cannot be used for geometries with the "
         "Role::kUnassigned value. Please choose proximity, perception, or "
         "illustration");
   }

--- a/geometry/drake_visualizer.h
+++ b/geometry/drake_visualizer.h
@@ -76,7 +76,7 @@ struct DynamicFrameData {
  specified.
 
  The appearance of the geometry in the visualizer is typically defined by the
- the geometry's properties for the visualized role.
+ geometry's properties for the visualized role.
 
    - For the visualized role, if a geometry has the ("phong", "diffuse")
      property described in the table below, that value is used.

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -151,10 +151,10 @@ class GraphOfConvexSets {
     std::pair<symbolic::Variable, solvers::Binding<solvers::Cost>> AddCost(
         const symbolic::Expression& e);
 
-    /** Adds a cost to this edge.  @p binding must must contain *only*
-    elements of xu() and xv() as variables. For technical
-    reasons relating to being able to "turn-off" the cost on inactive edges, all
-    costs are eventually implemented with a slack variable and a constraint:
+    /** Adds a cost to this edge.  @p binding must contain *only* elements of
+    xu() and xv() as variables. For technical reasons relating to being able to
+    "turn-off" the cost on inactive edges, all costs are eventually implemented
+    with a slack variable and a constraint:
     @verbatim
     min g(xu, xv) ⇒ min ℓ, s.t. ℓ ≥ g(xu,xv)
     @endverbatim
@@ -172,7 +172,7 @@ class GraphOfConvexSets {
     solvers::Binding<solvers::Constraint> AddConstraint(
         const symbolic::Formula& f);
 
-    /** Adds a constraint to this edge.  @p binding must must contain *only*
+    /** Adds a constraint to this edge.  @p binding must contain *only*
     elements of xu() and xv() as variables.
     @throws std::exception if binding.variables() is not a subset of xu() ∪
     xv(). */

--- a/geometry/proximity/test/mesh_plane_intersection_test.cc
+++ b/geometry/proximity/test/mesh_plane_intersection_test.cc
@@ -1052,7 +1052,7 @@ TEST_F(SliceTetWithPlaneTest, NoDoubleCounting) {
   1. No intersection returns nullptr.
   2. The resulting contact surface is a function of the tets provided; they
      are all considered and only those that actually intersect contribute to
-     to the final output.
+     the final output.
   3. Duplicates handled correctly; if the input mesh has no duplicates, the
      result has none. Alternatively, if the input has duplicates, the output
      does as well.

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -635,7 +635,7 @@ class QueryObject {
    box if it lies within a certain tolerance from them.
 
    @note For a box B, if a point p is inside the box, and it is equidistant to
-   to multiple nearest faces, the signed distance function φᵢ(p) at p will have
+   multiple nearest faces, the signed distance function φᵢ(p) at p will have
    an undefined gradient vector. There is a nearest point candidate associated
    with each nearest face. In this case, we arbitrarily pick the point Nᵢ
    associated with one of the nearest faces.  Please note that, due to the

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -107,7 +107,7 @@ class Sphere final : public Shape {
 
   /** Constructs a sphere with the given `radius`.
    @throws std::exception if `radius` is negative. Note that a zero radius is
-   is considered valid. */
+   considered valid. */
   explicit Sphere(double radius);
 
   double radius() const { return radius_; }

--- a/lcm/drake_lcm.h
+++ b/lcm/drake_lcm.h
@@ -36,12 +36,11 @@ class DrakeLcm : public DrakeLcmInterface {
    * launching the receive thread.
    *
    * @param defer_initialization controls whether or not LCM's background
-   * receive thread will be launched immediately during the constructor
-   * (when false) or deferred until the first time it's needed (when true).
-   * This can be useful if the scheduling configuration for new threads varies
-   * between the construction time and and first use.  For other constructor
-   * overloads, this setting defaults to `false` -- the thread is launched
-   * immediately.
+   * receive thread will be launched immediately during the constructor (when
+   * false) or deferred until the first time it's needed (when true).  This can
+   * be useful if the scheduling configuration for new threads varies between
+   * the construction time and first use.  For other constructor overloads,
+   * this setting defaults to `false` -- the thread is launched immediately.
    */
   DrakeLcm(std::string lcm_url, bool defer_initialization);
 

--- a/manipulation/kinova_jaco/jaco_command_receiver.cc
+++ b/manipulation/kinova_jaco/jaco_command_receiver.cc
@@ -54,7 +54,7 @@ void JacoCommandReceiver::set_initial_position(
 
 // Returns (in "result") the command message input, or if a message has not
 // been received yet returns the initial command (as optionally set by the
-// user).  The result will always have have num_joints_ positions and torques.
+// user).  The result will always have num_joints_ positions and torques.
 void JacoCommandReceiver::CalcInput(
   const Context<double>& context, lcmt_jaco_command* result) const {
   if (!get_input_port().HasValue(context)) {

--- a/math/autodiff.h
+++ b/math/autodiff.h
@@ -193,7 +193,7 @@ struct ResizeDerivativesToMatchScalarImpl<Derived,
 };
 }  // namespace internal
 
-/** Resize derivatives vector of each element of a matrix to to match the size
+/** Resize derivatives vector of each element of a matrix to match the size
  * of the derivatives vector of a given scalar.
  * \brief If the mat and scalar inputs are AutoDiffScalars, resize the
  * derivatives vector of each element of the matrix mat to match

--- a/math/roll_pitch_yaw.h
+++ b/math/roll_pitch_yaw.h
@@ -221,8 +221,8 @@ class RollPitchYaw {
   /// More specifically, returns true if `abs(cos_pitch_angle)` is less than an
   /// internally-defined tolerance of gimbal-lock.
   /// @param[in] cos_pitch_angle cosine of the pitch angle, i.e., `cos(p)`.
-  /// @note Pitch-angles close to gimbal-lock can can cause problems with
-  /// numerical precision and numerical integration.
+  /// @note Pitch-angles close to gimbal-lock can cause problems with numerical
+  /// precision and numerical integration.
   static boolean<T> DoesCosPitchAngleViolateGimbalLockTolerance(
       const T& cos_pitch_angle) {
     using std::abs;

--- a/math/rotation_matrix.h
+++ b/math/rotation_matrix.h
@@ -515,7 +515,7 @@ class RotationMatrix {
     return matrix() * v_B;
   }
 
-  /// Returns how close the matrix R is to to being a 3x3 orthonormal matrix by
+  /// Returns how close the matrix R is to being a 3x3 orthonormal matrix by
   /// computing `‖R ⋅ Rᵀ - I‖∞` (i.e., the maximum absolute value of the
   /// difference between the elements of R ⋅ Rᵀ and the 3x3 identity matrix).
   /// @param[in] R matrix being checked for orthonormality.

--- a/multibody/constraint/constraint_doxygen.h
+++ b/multibody/constraint/constraint_doxygen.h
@@ -127,7 +127,7 @@ Algebraic Equation or Differential Complementarity Problem index
 <pre>
 d/dt gₚ(t; q) = ġₚ(t, q; v)
 </pre>
-vs. equations that **must** be posed at at the velocity-level
+vs. equations that **must** be posed at the velocity-level
 (i.e., nonholonomic constraints):<pre>
 gᵥ(t, q; v).
 </pre>

--- a/multibody/constraint/constraint_problem_data.h
+++ b/multibody/constraint/constraint_problem_data.h
@@ -413,7 +413,7 @@ struct ConstraintVelProblemData {
   /// along the nr vectors that span the contact tangents at the nc
   /// point contacts (these nc * nr vectors are denoted nnr for brevity). For
   /// contact problems in two dimensions, nr will be one and nnr would equal nc.
-  /// For a friction pyramid at each point contact in in three dimensions, nr
+  /// For a friction pyramid at each point contact in three dimensions, nr
   /// would be two and nnr would equation 2nc. While the definition of the
   /// dimension of the Jacobian matrix above indicates that every one of the nc
   /// contacts uses the same "nr", the code imposes no such requirement.

--- a/multibody/plant/hydroelastic_traction_calculator.cc
+++ b/multibody/plant/hydroelastic_traction_calculator.cc
@@ -231,8 +231,8 @@ HydroelasticTractionCalculator<T>::CalcTractionAtQHelper(
   // We now divide the numerator and denominator of Eq. (3) by vₛ (that is, we
   // effectively multiply by 1) to write:
   //   fₜ = −μ 2/π atan(‖vₜ‖/vₛ)(vₜ/vₛ)/(‖vₜ‖/vₛ)fₙ                          (4)
-  // Finally we make make the substitution x = ‖vₜ‖/vₛ and group together the
-  // terms in x to get:
+  // Finally we make the substitution x = ‖vₜ‖/vₛ and group together the terms
+  // in x to get:
   //   fₜ =−μ 2/π vₜ/vₛ fₙ (atan(x)/x)
   // We then make the observation that the function atan(x)/x is continuosly
   // differentiable (that is the limits from both sides are exist and are

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -2814,7 +2814,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @param[in] context
   ///   The context containing the state of the model.
   /// @param[in] v
-  ///   A vector of of generalized velocities for this model.
+  ///   A vector of generalized velocities for this model.
   ///   This method aborts if v is not of size num_velocities().
   /// @param[out] qdot
   ///   A valid (non-null) pointer to a vector in `ℝⁿ` with n being the number

--- a/multibody/tree/articulated_body_inertia.h
+++ b/multibody/tree/articulated_body_inertia.h
@@ -285,7 +285,7 @@ class ArticulatedBodyInertia {
   ///                   about point R, expressed in the same frame E `this`
   ///                   articulated body inertia is expressed in.
   /// @retval P_AR_E This same articulated body inertia for articulated body
-  ///         A but now computed about about a new point R.
+  ///         A but now computed about a new point R.
   ArticulatedBodyInertia<T> Shift(const Vector3<T>& p_QR_E) const {
     return ArticulatedBodyInertia<T>(*this).ShiftInPlace(p_QR_E);
   }

--- a/multibody/tree/body.h
+++ b/multibody/tree/body.h
@@ -328,7 +328,7 @@ class Body : public MultibodyElement<Body, T, BodyIndex> {
   }
 
   /// Gets the sptatial force on `this` body B from `forces` as F_BBo_W:
-  /// applied at body B's origin Bo and expressed in world world frame W.
+  /// applied at body B's origin Bo and expressed in world frame W.
   const SpatialForce<T>& GetForceInWorld(
       const systems::Context<T>&, const MultibodyForces<T>& forces) const {
     DRAKE_THROW_UNLESS(

--- a/multibody/tree/spatial_inertia.h
+++ b/multibody/tree/spatial_inertia.h
@@ -334,7 +334,7 @@ class SpatialInertia {
   ///                   about point Q, expressed in the same frame E `this`
   ///                   spatial inertia is expressed in.
   /// @returns A reference to `this` spatial inertia for body or composite body
-  ///          S but now computed about about a new point Q.
+  ///          S but now computed about a new point Q.
   SpatialInertia& ShiftInPlace(const Vector3<T>& p_PQ_E) {
     const Vector3<T> p_QScm_E = p_PScm_E_ - p_PQ_E;
     // The following two lines apply the parallel axis theorem (in place) so
@@ -360,7 +360,7 @@ class SpatialInertia {
   ///                   about point Q, expressed in the same frame E `this`
   ///                   spatial inertia is expressed in.
   /// @retval M_SQ_E    This same spatial inertia for body or composite body S
-  ///                   but computed about about a new point Q.
+  ///                   but computed about a new point Q.
   SpatialInertia Shift(const Vector3<T>& p_PQ_E) const {
     return SpatialInertia(*this).ShiftInPlace(p_PQ_E);
   }
@@ -385,7 +385,7 @@ class SpatialInertia {
   /// center of mass), read as: <pre>
   ///   Ftot_BBo = M_Bo_W * A_WB + b_Bo
   /// </pre>
-  /// where `Ftot_BBo` is the total spatial force applied on body B at at `Bo`
+  /// where `Ftot_BBo` is the total spatial force applied on body B at `Bo`
   /// that corresponds to the body spatial acceleration `A_WB` and `b_Bo`
   /// contains the velocity dependent gyroscopic terms (see Eq. 2.26, p. 27,
   /// in A. Jain's book).

--- a/multibody/tree/test/multibody_tree_creation_test.cc
+++ b/multibody/tree/test/multibody_tree_creation_test.cc
@@ -491,7 +491,7 @@ TEST_F(TreeTopologyTests, SizesAndIndexing) {
 }
 
 // Verifies that the clone of a given MultibodyTree model created with
-// MultibodyTree::Clone() has has exactly the same topology as the original
+// MultibodyTree::Clone() has exactly the same topology as the original
 // model.
 TEST_F(TreeTopologyTests, Clone) {
   model_->Finalize();

--- a/solvers/mosek_solver.cc
+++ b/solvers/mosek_solver.cc
@@ -272,7 +272,7 @@ MSKrescodee AddLinearConstraintToMosek(
   // newly added linear constraint.
   // mosek_matrix_variable_entries[j] contains all the entries in that matrix
   // variable X̅ⱼ that show up in this new linear constraint.
-  // This map is used to compute the symmetric matrix A̅ᵢⱼ in the term term
+  // This map is used to compute the symmetric matrix A̅ᵢⱼ in the term
   // <A̅ᵢⱼ, X̅ⱼ>.
   std::unordered_map<MSKint64t, std::vector<MatrixVariableEntry>>
       mosek_matrix_variable_entries;

--- a/systems/analysis/dense_output.h
+++ b/systems/analysis/dense_output.h
@@ -164,7 +164,7 @@ class DenseOutput {
     }
   }
 
-  // Asserts that the given given time @p t is valid for this dense output.
+  // Asserts that the given time @p t is valid for this dense output.
   // @param func_name Call site name for error message clarity (i.e. __func__).
   // @param t Time to be checked.
   // @throws std::exception if given @p t is not within output's domain

--- a/systems/framework/context_base.h
+++ b/systems/framework/context_base.h
@@ -324,7 +324,7 @@ class ContextBase : public internal::ContextMessageInterface {
   change notifications that propagate down from a DiagramContext (where the
   change is initiated) through all its subcontexts, recursively. Such
   notification sweeps result in the "out of date" flag being set in each of
-  the affected cache entry values. Each of these "Note" methods methods affects
+  the affected cache entry values. Each of these "Note" methods affects
   only the local context, but all have identical signatures so can be passed
   down the context tree to operate on every subcontext. The `change_event`
   argument should be the result of the start_new_change_event() method. */

--- a/systems/framework/event.h
+++ b/systems/framework/event.h
@@ -496,7 +496,7 @@ class Event {
    * Adds a clone of `this` event to the event collection `events`, with
    * the given trigger type. If `this` event has an unknown trigger type, then
    * any trigger type is acceptable. Otherwise the given trigger type must
-   * match match the trigger type stored in `this` event.
+   * match the trigger type stored in `this` event.
    * @pre `trigger_type` must match the current trigger type unless that is
    *      unknown.
    * @pre `events` must not be null.

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -1460,7 +1460,7 @@ class System : public SystemBase {
 
   @note The public method has already verified that `proposed_derivatives`
   is compatible with this System and that `residual` is non-null and of the
-  the declared size (as reported by
+  declared size (as reported by
   SystemBase::implicit_time_derivatives_residual_size()). You do not have to
   check those two conditions in your implementation, but if you have additional
   restrictions you should validate that they are also met. */

--- a/systems/systems.h
+++ b/systems/systems.h
@@ -79,7 +79,7 @@
 
 /// @addtogroup manipulation_systems
 /// @{
-/// @brief Systems implementations and related functions that specifically 
+/// @brief Systems implementations and related functions that specifically
 /// support dexterous manipulation capabilities in robotics.
 /// @}
 
@@ -118,7 +118,7 @@
 ///        A matplotlib visualization for planar rigid body systems</a>.</li>
 /// </ul>
 /// @}
-// TODO(russt): Add pointers to / support for for RViz.
+// TODO(russt): Add pointers to / support for RViz.
 
 /// @addtogroup example_systems
 /// @{

--- a/tools/clion/bazel_wrapper
+++ b/tools/clion/bazel_wrapper
@@ -15,7 +15,7 @@ def _write_stderr(data):
 
 def gdb_compatible_strings(args):
     """Examine the args and conditionally inject the compiler argument for the
-    benefit of non-GCC compilers to to compile gdb-friendly STL symbols.
+    benefit of non-GCC compilers to compile gdb-friendly STL symbols.
     Modifies the args in place."""
     if 'dbg' in args:
         # Place the compiler argument after the dbg command.

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -151,7 +151,7 @@ def installed_headers_for_dep(dep):
     `dep` for a cc_library, such as would be found in the `deps = []` of
     some cc_library, returns the corresponding label for the matching DrakeCc
     provider associated with that library.  The returned label is appropriate
-    to use in the deps of of a `drake_installed_headers()` rule.
+    to use in the deps of a `drake_installed_headers()` rule.
 
     Once our rules are better able to call native rules like native.cc_binary,
     instead of having two labels we would prefer to tack a DrakeCc provider

--- a/tools/vector_gen/test/sample_test.cc
+++ b/tools/vector_gen/test/sample_test.cc
@@ -125,7 +125,7 @@ GTEST_TEST(SampleTest, Move) {
   const int nominal_size = SampleIndices::kNumCoordinates;
   const double* const original_storage = &first.x();
 
-  // Note than we we move-construct or move-assign from a prvalue, the size of
+  // Note that when we move-construct or move-assign from a prvalue, the size of
   // the donor object goes to zero, even though it is still a Sample object.
   // That means that methods such as get_x etc. will throw if we call them.
 

--- a/tools/workspace/buildifier/repository.bzl
+++ b/tools/workspace/buildifier/repository.bzl
@@ -65,7 +65,7 @@ def _impl(repository_ctx):
         "BUILD.bazel",
     )
 
-    # Create a summary file for for Drake maintainers.  We need to list all
+    # Create a summary file for Drake maintainers.  We need to list all
     # possible binaries so Drake's mirroring scripts will fetch everything.
     generate_repository_metadata(
         repository_ctx,

--- a/tools/workspace/github.bzl
+++ b/tools/workspace/github.bzl
@@ -211,7 +211,7 @@ def github_download_and_extract(
         stripPrefix = _strip_prefix(repository, commit, extra_strip_prefix),
     )
 
-    # Create a summary file for for Drake maintainers.
+    # Create a summary file for Drake maintainers.
     generate_repository_metadata(
         repository_ctx,
         repository_rule_type = "github",

--- a/tools/workspace/libblas/repository.bzl
+++ b/tools/workspace/libblas/repository.bzl
@@ -13,9 +13,9 @@ def _impl(repo_ctx):
     # TLDR: Use @blas instead of this repository (@libblas) in the deps of your
     # target.
     #
-    # On Ubuntu, we will use use pkg-config to find libblas.so (the vendor of
-    # which is typically chosen by the Ubuntu alternatives system). On macOS,
-    # no targets should depend on @libblas. However, on both macOS and Ubuntu,
+    # On Ubuntu, we will use pkg-config to find libblas.so (the vendor of which
+    # is typically chosen by the Ubuntu alternatives system). On macOS, no
+    # targets should depend on @libblas. However, on both macOS and Ubuntu,
     # targets should normally depend on the alias @blas instead of @libblas (or
     # @openblas) to install an operating-system-specific BLAS implementation.
     os_result = determine_os(repo_ctx)

--- a/tools/workspace/liblapack/repository.bzl
+++ b/tools/workspace/liblapack/repository.bzl
@@ -13,7 +13,7 @@ def _impl(repo_ctx):
     # TLDR: Use @lapack instead of this repository (@liblapack) in the deps of
     # your target.
     #
-    # On Ubuntu, we will use use pkg-config to find liblapack.so (the vendor of
+    # On Ubuntu, we will use pkg-config to find liblapack.so (the vendor of
     # which is typically chosen by the Ubuntu alternatives system). On macOS,
     # no targets should depend on @liblapack. However, on both macOS and
     # Ubuntu, targets should normally depend on the alias @lapack instead of

--- a/tools/workspace/openblas/repository.bzl
+++ b/tools/workspace/openblas/repository.bzl
@@ -13,10 +13,10 @@ def _impl(repo_ctx):
     # TLDR: Use @blas and/or @lapack instead of this repository (@openblas) in
     # the deps of your target.
     #
-    # On macOS, we will use use pkg-config to find libopenblas.dylib. On
-    # Ubuntu, no targets should depend on @openblas. However, on both macOS and
-    # Ubuntu, targets should normally depend on the aliases @blas and/or
-    # @lapack instead of @openblas (or @libblas and/or @libpack) to install an
+    # On macOS, we will use pkg-config to find libopenblas.dylib. On Ubuntu, no
+    # targets should depend on @openblas. However, on both macOS and Ubuntu,
+    # targets should normally depend on the aliases @blas and/or @lapack
+    # instead of @openblas (or @libblas and/or @libpack) to install an
     # operating-system-specific BLAS and/or LAPACK implementation.
     os_result = determine_os(repo_ctx)
     if os_result.error != None:


### PR DESCRIPTION
These were harvested with `pcregrep`, which has perl-compatible regular
expressions. This command gives some raw data:

    $ git ls-files | egrep -v '\.(obj|mtl|sdf|urdf)' \
      | xargs pcregrep -Min --color=auto '\b([a-z][a-z]+)[[:space:]]+\1\b'

Results were curated by hand and many were left untouched, since the regex
filter was insensitive to transitions between comments and text, various
documentation conventions, etc. In some cases, word wrap was updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15533)
<!-- Reviewable:end -->
