### PR TITLE
Deprecating PoseBundle

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -513,13 +513,19 @@ void DoScalarDependentDefinitions(py::module m, T) {
     cls  // BR
         .def(py::init<>(), cls_doc.ctor.doc)
         .def("get_source_pose_port", &Class::get_source_pose_port,
-            py_rvp::reference_internal, cls_doc.get_source_pose_port.doc)
-        .def(
-            "get_pose_bundle_output_port",
-            [](Class* self) -> const systems::OutputPort<T>& {
-              return self->get_pose_bundle_output_port();
-            },
-            py_rvp::reference_internal, cls_doc.get_pose_bundle_output_port.doc)
+            py_rvp::reference_internal, cls_doc.get_source_pose_port.doc);
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls  // BR
+        .def("get_pose_bundle_output_port",
+            WrapDeprecated(cls_doc.get_pose_bundle_output_port.doc_deprecated,
+                &Class::get_pose_bundle_output_port),
+            py_rvp::reference_internal,
+            cls_doc.get_pose_bundle_output_port.doc_deprecated);
+#pragma GCC diagnostic pop
+
+    cls  // BR
         .def("get_query_output_port", &Class::get_query_output_port,
             py_rvp::reference_internal, cls_doc.get_query_output_port.doc)
         .def("model_inspector", &Class::model_inspector,

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -139,6 +139,7 @@ drake_pybind_library(
     name = "rendering_py",
     cc_deps = [
         "//bindings/pydrake:documentation_pybind",
+        "//bindings/pydrake/common:deprecation_pybind",
         "//bindings/pydrake/common:eigen_geometry_pybind",
         "//bindings/pydrake/common:value_pybind",
     ],
@@ -565,6 +566,7 @@ drake_py_unittest(
     data = ["//multibody/benchmarks/acrobot:models"],
     deps = [
         ":rendering_py",
+        "//bindings/pydrake/common/test_utilities:deprecation_py",
         "//bindings/pydrake/multibody:math_py",
         "//bindings/pydrake/multibody:parsing_py",
         "//bindings/pydrake/multibody:plant_py",

--- a/bindings/pydrake/systems/meshcat_visualizer.py
+++ b/bindings/pydrake/systems/meshcat_visualizer.py
@@ -22,7 +22,6 @@ from pydrake.geometry import (
 from pydrake.lcm import DrakeLcm, Subscriber
 from pydrake.math import RigidTransform, RotationMatrix
 from pydrake.systems.framework import LeafSystem, PublishEvent, TriggerType
-from pydrake.systems.rendering import PoseBundle
 from pydrake.multibody.plant import ContactResults
 import pydrake.perception as mut
 

--- a/bindings/pydrake/systems/planar_scenegraph_visualizer.py
+++ b/bindings/pydrake/systems/planar_scenegraph_visualizer.py
@@ -125,9 +125,13 @@ class PlanarSceneGraphVisualizer(PyPlotVisualizer):
         self._T_VW = T_VW
 
         # (2021-11-01) Remove at end of deprecation period.
-        # Pose bundle (from SceneGraph) input port.
-        self._pose_bundle_port = self.DeclareAbstractInputPort(
-            "lcm_visualization", AbstractValue.Make(PoseBundle(0)))
+        # Pose bundle (from SceneGraph).
+        # Note: we're suppressing the deprecation warning we'd get in
+        # instantiating a PoseBundle.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            self._pose_bundle_port = self.DeclareAbstractInputPort(
+                "lcm_visualization", AbstractValue.Make(PoseBundle(0)))
         self._warned_pose_bundle_input_port_connected = False
         # End of deprecation block.
 

--- a/bindings/pydrake/systems/rendering_py.cc
+++ b/bindings/pydrake/systems/rendering_py.cc
@@ -2,6 +2,7 @@
 #include "pybind11/pybind11.h"
 #include <Eigen/Dense>
 
+#include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/eigen_geometry_pybind.h"
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
@@ -28,14 +29,29 @@ PYBIND11_MODULE(rendering, m) {
 
   using T = double;
 
+  // Basically *all* of these classes/structs are deprecated, so we'll put the
+  // whole block of them inside the pragma.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+  // Because we've deprecated the *classes* and not the methods, applying
+  // deprecation to the constructors requires augmenting the doc string into
+  // something with an appropriately formatted deprecation warning.
+  const std::string deprecated_rendering(
+      " This class has been deprecated and will be removed on or after "
+      "2021-12-01.");
+
   py::class_<PoseVector<T>, BasicVector<T>> pose_vector(
-      m, "PoseVector", doc.PoseVector.doc);
+      m, "PoseVector", doc.PoseVector.doc_deprecated);
   pose_vector  // BR
-      .def(py::init(), doc.PoseVector.ctor.doc_0args)
-      .def(py::init<const Eigen::Quaternion<T>&,
-               const Eigen::Translation<T, 3>&>(),
+      .def(py_init_deprecated<PoseVector<T>>(
+               doc.PoseVector.ctor.doc_0args + deprecated_rendering),
+          (doc.PoseVector.ctor.doc_0args + deprecated_rendering).c_str())
+      .def(py_init_deprecated<PoseVector<T>, const Eigen::Quaternion<T>&,
+               const Eigen::Translation<T, 3>&>(
+               doc.PoseVector.ctor.doc_2args + deprecated_rendering),
           py::arg("rotation"), py::arg("translation"),
-          doc.PoseVector.ctor.doc_2args)
+          (doc.PoseVector.ctor.doc_2args + deprecated_rendering).c_str())
       .def("get_transform", &PoseVector<T>::get_transform,
           doc.PoseVector.get_transform.doc)
       .def("set_transform", &PoseVector<T>::set_transform,
@@ -52,11 +68,16 @@ PYBIND11_MODULE(rendering, m) {
   pose_vector.attr("kSize") = int{PoseVector<T>::kSize};
 
   py::class_<FrameVelocity<T>, BasicVector<T>> frame_velocity(
-      m, "FrameVelocity", doc.FrameVelocity.doc);
+      m, "FrameVelocity", doc.FrameVelocity.doc_deprecated);
   frame_velocity  // BR
-      .def(py::init(), doc.FrameVelocity.ctor.doc_0args)
-      .def(py::init<const multibody::SpatialVelocity<T>&>(),
-          py::arg("velocity"), doc.FrameVelocity.ctor.doc_1args)
+      .def(py_init_deprecated<FrameVelocity<T>>(
+               doc.FrameVelocity.ctor.doc_0args + deprecated_rendering),
+          (doc.FrameVelocity.ctor.doc_0args + deprecated_rendering).c_str())
+      .def(py_init_deprecated<FrameVelocity<T>,
+               const multibody::SpatialVelocity<T>&>(
+               doc.FrameVelocity.ctor.doc_1args + deprecated_rendering),
+          py::arg("velocity"),
+          (doc.FrameVelocity.ctor.doc_1args + deprecated_rendering).c_str())
       .def("get_velocity", &FrameVelocity<T>::get_velocity,
           doc.FrameVelocity.get_velocity.doc)
       .def("set_velocity", &FrameVelocity<T>::set_velocity, py::arg("velocity"),
@@ -64,9 +85,13 @@ PYBIND11_MODULE(rendering, m) {
 
   frame_velocity.attr("kSize") = int{FrameVelocity<T>::kSize};
 
-  py::class_<PoseBundle<T>> pose_bundle(m, "PoseBundle", doc.PoseBundle.doc);
+  py::class_<PoseBundle<T>> pose_bundle(
+      m, "PoseBundle", doc.PoseBundle.doc_deprecated);
   pose_bundle
-      .def(py::init<int>(), py::arg("num_poses"), doc.PoseBundle.ctor.doc)
+      .def(py_init_deprecated<PoseBundle<T>, int>(
+               doc.PoseBundle.ctor.doc + deprecated_rendering),
+          py::arg("num_poses"),
+          (doc.PoseBundle.ctor.doc + deprecated_rendering).c_str())
       .def("get_num_poses", &PoseBundle<T>::get_num_poses,
           doc.PoseBundle.get_num_poses.doc)
       .def("get_transform", &PoseBundle<T>::get_transform,
@@ -85,8 +110,9 @@ PYBIND11_MODULE(rendering, m) {
           doc.PoseBundle.set_model_instance_id.doc);
   AddValueInstantiation<PoseBundle<T>>(m);
 
-  py::class_<PoseVelocityInputPorts<T>>(
-      m, "PoseVelocityInputPorts", doc.PoseVelocityInputPorts.doc)
+  py::class_<PoseVelocityInputPorts<T>> pose_vel_input_port_cls(
+      m, "PoseVelocityInputPorts", doc.PoseVelocityInputPorts.doc_deprecated);
+  pose_vel_input_port_cls
       // N.B. We use lambdas below since we cannot use `def_readonly` with
       // reference members.
       .def_property_readonly(
@@ -101,10 +127,16 @@ PYBIND11_MODULE(rendering, m) {
             return self->velocity_input_port;
           },
           doc.PoseVelocityInputPorts.velocity_input_port.doc);
+  DeprecateAttribute(
+      pose_vel_input_port_cls, "pose_input_port", deprecated_rendering);
+  DeprecateAttribute(
+      pose_vel_input_port_cls, "velocity_input_port", deprecated_rendering);
 
   py::class_<PoseAggregator<T>, LeafSystem<T>>(
-      m, "PoseAggregator", doc.PoseAggregator.doc)
-      .def(py::init<>(), doc.PoseAggregator.ctor.doc)
+      m, "PoseAggregator", doc.PoseAggregator.doc_deprecated)
+      .def(py_init_deprecated<PoseAggregator<T>>(
+               doc.PoseAggregator.ctor.doc + deprecated_rendering),
+          (doc.PoseAggregator.ctor.doc + deprecated_rendering).c_str())
       .def("AddSingleInput", &PoseAggregator<T>::AddSingleInput,
           py_rvp::reference_internal, doc.PoseAggregator.AddSingleInput.doc)
       .def("AddSinglePoseAndVelocityInput",
@@ -113,6 +145,10 @@ PYBIND11_MODULE(rendering, m) {
       .def("AddBundleInput", &PoseAggregator<T>::AddBundleInput,
           py_rvp::reference_internal, doc.PoseAggregator.AddBundleInput.doc);
 
+#pragma GCC diagnostic pop
+
+  // See the todo in multibody_position_to_geometry_pose.h. This should
+  // ultimately move into a different module.
   py::class_<MultibodyPositionToGeometryPose<T>, LeafSystem<T>>(m,
       "MultibodyPositionToGeometryPose",
       doc.MultibodyPositionToGeometryPose.doc)
@@ -122,8 +158,6 @@ PYBIND11_MODULE(rendering, m) {
           py::keep_alive<1, 2>(),
           doc.MultibodyPositionToGeometryPose.ctor
               .doc_2args_plant_input_multibody_state);
-
-  // TODO(eric.cousineau): Add more systems as needed.
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/systems/sensors_py.cc
+++ b/bindings/pydrake/systems/sensors_py.cc
@@ -199,8 +199,17 @@ PYBIND11_MODULE(sensors, m) {
             py_rvp::reference_internal, cls_doc.depth_image_16U_output_port.doc)
         .def("label_image_output_port", &Class::label_image_output_port,
             py_rvp::reference_internal, cls_doc.label_image_output_port.doc)
-        .def("X_WB_output_port", &Class::X_WB_output_port,
-            py_rvp::reference_internal, cls_doc.X_WB_output_port.doc);
+        .def("body_pose_in_world_output_port",
+            &Class::body_pose_in_world_output_port, py_rvp::reference_internal,
+            cls_doc.body_pose_in_world_output_port.doc);
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    py_class.def("X_WB_output_port", &Class::X_WB_output_port,
+        py_rvp::reference_internal, cls_doc.X_WB_output_port.doc_deprecated);
+#pragma GCC diagnostic pop
+    DeprecateAttribute(
+        py_class, "X_WB_output_port", cls_doc.X_WB_output_port.doc_deprecated);
   };
 
   py::class_<RgbdSensor, LeafSystem<T>> rgbd_sensor(

--- a/bindings/pydrake/systems/test/planar_scenegraph_visualizer_test.py
+++ b/bindings/pydrake/systems/test/planar_scenegraph_visualizer_test.py
@@ -246,8 +246,10 @@ class TestPlanarSceneGraphVisualizerDeprecated(unittest.TestCase):
         self.assertTrue(cart_pole.geometry_source_is_registered())
 
         visualizer = builder.AddSystem(PlanarSceneGraphVisualizer(scene_graph))
-        builder.Connect(scene_graph.get_pose_bundle_output_port(),
-                        visualizer.get_input_port(0))
+        # scene_graph.get_pose_bundle_output_port() is deprecated.
+        with catch_drake_warnings(expected_count=1):
+            builder.Connect(scene_graph.get_pose_bundle_output_port(),
+                            visualizer.get_input_port(0))
 
         diagram = builder.Build()
 
@@ -288,8 +290,10 @@ class TestPlanarSceneGraphVisualizerDeprecated(unittest.TestCase):
         kuka.GetFrameByName("iiwa_link_6", iiwa)
 
         visualizer = builder.AddSystem(PlanarSceneGraphVisualizer(scene_graph))
-        builder.Connect(scene_graph.get_pose_bundle_output_port(),
-                        visualizer.get_input_port(0))
+        # scene_graph.get_pose_bundle_output_port() is deprecated.
+        with catch_drake_warnings(expected_count=1):
+            builder.Connect(scene_graph.get_pose_bundle_output_port(),
+                            visualizer.get_input_port(0))
 
         diagram = builder.Build()
 
@@ -338,8 +342,10 @@ class TestPlanarSceneGraphVisualizerDeprecated(unittest.TestCase):
         mbp.Finalize()
 
         visualizer = builder.AddSystem(PlanarSceneGraphVisualizer(scene_graph))
-        builder.Connect(scene_graph.get_pose_bundle_output_port(),
-                        visualizer.get_input_port(0))
+        # scene_graph.get_pose_bundle_output_port() is deprecated.
+        with catch_drake_warnings(expected_count=1):
+            builder.Connect(scene_graph.get_pose_bundle_output_port(),
+                            visualizer.get_input_port(0))
 
         diagram = builder.Build()
 
@@ -430,12 +436,14 @@ class TestPlanarSceneGraphVisualizerDeprecated(unittest.TestCase):
         # Confirm that arguments are passed through.
         self.assertEqual(vis_query_object.ax.get_xlim(), (0.3, 1.2))
 
-        # The visualizer will connect to the provided pose bundle port and
-        # calling draw will generate a warning.
-        vis_pose_bundle = ConnectPlanarSceneGraphVisualizer(
-            builder=builder,
-            scene_graph=scene_graph,
-            output_port=scene_graph.get_pose_bundle_output_port())
+        # scene_graph.get_pose_bundle_output_port() is deprecated.
+        with catch_drake_warnings(expected_count=1):
+            # The visualizer will connect to the provided pose bundle port and
+            # calling draw will generate a warning.
+            vis_pose_bundle = ConnectPlanarSceneGraphVisualizer(
+                builder=builder,
+                scene_graph=scene_graph,
+                output_port=scene_graph.get_pose_bundle_output_port())
         vis_pose_bundle.set_name("vis_pose_bundle")
         self.assertIsInstance(vis_pose_bundle, PlanarSceneGraphVisualizer)
 

--- a/bindings/pydrake/systems/test/rendering_test.py
+++ b/bindings/pydrake/systems/test/rendering_test.py
@@ -13,6 +13,7 @@ import unittest
 import numpy as np
 
 from pydrake.common import FindResourceOrThrow
+from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 from pydrake.common.value import AbstractValue
 from pydrake.geometry import SceneGraph
 from pydrake.math import RigidTransform
@@ -36,8 +37,10 @@ def normalized(x):
 
 
 class TestRendering(unittest.TestCase):
+    # 2021-12-01 deprecation. Remove the whole test.
     def test_pose_vector(self):
-        value = PoseVector()
+        with catch_drake_warnings(expected_count=1):
+            value = PoseVector()
         self.assertTrue(isinstance(value, BasicVector))
         self.assertTrue(isinstance(copy.copy(value), PoseVector))
         self.assertTrue(isinstance(value.Clone(), PoseVector))
@@ -64,7 +67,9 @@ class TestRendering(unittest.TestCase):
         vector_actual = value.get_value()
         self.assertTrue(np.allclose(vector_actual, vector_expected))
         # - Fully-parameterized constructor.
-        value1 = PoseVector(rotation=q, translation=p)
+
+        with catch_drake_warnings(expected_count=1):
+            value1 = PoseVector(rotation=q, translation=p)
         self.assertTrue(np.allclose(
             value1.get_transform().GetAsMatrix4(), X_expected.GetAsMatrix4()))
         # Test mutation via RigidTransform
@@ -75,8 +80,10 @@ class TestRendering(unittest.TestCase):
         self.assertTrue(np.allclose(
             value.get_transform().GetAsMatrix4(), X2_expected.GetAsMatrix4()))
 
+    # 2021-12-01 deprecation. Remove the whole test.
     def test_frame_velocity(self):
-        frame_velocity = FrameVelocity()
+        with catch_drake_warnings(expected_count=1):
+            frame_velocity = FrameVelocity()
         self.assertTrue(isinstance(frame_velocity, BasicVector))
         self.assertTrue(isinstance(copy.copy(frame_velocity), FrameVelocity))
         self.assertTrue(isinstance(frame_velocity.Clone(), FrameVelocity))
@@ -102,15 +109,18 @@ class TestRendering(unittest.TestCase):
         velocity_actual = frame_velocity.get_value()
         self.assertTrue(np.allclose(velocity_actual, velocity_expected))
         # - Fully-parameterized constructor.
-        frame_velocity1 = FrameVelocity(SpatialVelocity(w=w, v=v))
+        with catch_drake_warnings(expected_count=1):
+            frame_velocity1 = FrameVelocity(SpatialVelocity(w=w, v=v))
         self.assertTrue(np.allclose(
             frame_velocity1.get_velocity().rotational(), w))
         self.assertTrue(np.allclose(
             frame_velocity1.get_velocity().translational(), v))
 
+    # 2021-12-01 deprecation. Remove the whole test.
     def test_pose_bundle(self):
         num_poses = 7
-        bundle = PoseBundle(num_poses)
+        with catch_drake_warnings(expected_count=1):
+            bundle = PoseBundle(num_poses)
         # - Accessors.
         self.assertEqual(bundle.get_num_poses(), num_poses)
         self.assertTrue(isinstance(bundle.get_transform(0), RigidTransform))
@@ -125,7 +135,9 @@ class TestRendering(unittest.TestCase):
                          == pose.GetAsMatrix34()).all())
         w = [0.1, 0.3, 0.5]
         v = [0., 1., 2.]
-        frame_velocity = FrameVelocity(SpatialVelocity(w=w, v=v))
+
+        with catch_drake_warnings(expected_count=1):
+            frame_velocity = FrameVelocity(SpatialVelocity(w=w, v=v))
         bundle.set_velocity(kIndex, frame_velocity)
         vel_actual = bundle.get_velocity(kIndex).get_velocity()
         self.assertTrue(np.allclose(vel_actual.rotational(), w))
@@ -137,8 +149,10 @@ class TestRendering(unittest.TestCase):
         bundle.set_model_instance_id(kIndex, instance_id)
         self.assertEqual(bundle.get_model_instance_id(kIndex), instance_id)
 
+    # 2021-12-01 deprecation. Remove the whole test.
     def test_pose_aggregator(self):
-        aggregator = PoseAggregator()
+        with catch_drake_warnings(expected_count=1):
+            aggregator = PoseAggregator()
         # - Set-up.
         instance_id1 = 5  # Supply a random instance id.
         port1 = aggregator.AddSingleInput("pose_only", instance_id1)
@@ -147,13 +161,15 @@ class TestRendering(unittest.TestCase):
         instance_id2 = 42  # Supply another random, but unique, id.
         ports2 = aggregator.AddSinglePoseAndVelocityInput(
             "pose_and_velocity", instance_id2)
-        self.assertEqual(ports2.pose_input_port.get_data_type(),
-                         PortDataType.kVectorValued)
-        self.assertEqual(ports2.pose_input_port.size(), PoseVector.kSize)
-        self.assertEqual(ports2.velocity_input_port.get_data_type(),
-                         PortDataType.kVectorValued)
-        self.assertEqual(ports2.velocity_input_port.size(),
-                         FrameVelocity.kSize)
+
+        with catch_drake_warnings(expected_count=4):
+            self.assertEqual(ports2.pose_input_port.get_data_type(),
+                             PortDataType.kVectorValued)
+            self.assertEqual(ports2.pose_input_port.size(), PoseVector.kSize)
+            self.assertEqual(ports2.velocity_input_port.get_data_type(),
+                             PortDataType.kVectorValued)
+            self.assertEqual(ports2.velocity_input_port.size(),
+                             FrameVelocity.kSize)
         num_poses = 1
         port3 = aggregator.AddBundleInput("pose_bundle", num_poses)
         self.assertEqual(port3.get_data_type(), PortDataType.kAbstractValued)
@@ -165,18 +181,26 @@ class TestRendering(unittest.TestCase):
         output = aggregator.AllocateOutput()
 
         p1 = [0, 1, 2]
-        pose1 = PoseVector()
+
+        with catch_drake_warnings(expected_count=1):
+            pose1 = PoseVector()
         pose1.set_translation(p1)
         p2 = [5, 7, 9]
-        pose2 = PoseVector()
+
+        with catch_drake_warnings(expected_count=1):
+            pose2 = PoseVector()
         pose2.set_translation(p2)
         w = [0.3, 0.4, 0.5]
         v = [0.5, 0.6, 0.7]
-        velocity = FrameVelocity()
+
+        with catch_drake_warnings(expected_count=1):
+            velocity = FrameVelocity()
         velocity.set_velocity(SpatialVelocity(w=w, v=v))
         p3 = [50, 70, 90]
         q3 = Quaternion(wxyz=normalized([0.1, 0.3, 0.7, 0.9]))
-        bundle = PoseBundle(num_poses)
+
+        with catch_drake_warnings(expected_count=1):
+            bundle = PoseBundle(num_poses)
         bundle.set_transform(0, RigidTransform(quaternion=q3, p=p3))
         bundle_value = AbstractValue.Make(bundle)
 

--- a/bindings/pydrake/systems/test/sensors_test.py
+++ b/bindings/pydrake/systems/test/sensors_test.py
@@ -262,6 +262,10 @@ class TestSensors(unittest.TestCase):
             self.assertIsInstance(system.depth_image_16U_output_port(),
                                   OutputPort)
             self.assertIsInstance(system.label_image_output_port(), OutputPort)
+            self.assertIsInstance(system.body_pose_in_world_output_port(),
+                                  OutputPort)
+            with catch_drake_warnings(expected_count=1):
+                self.assertIsInstance(system.X_WB_output_port(), OutputPort)
 
         # Use HDTV size.
         width = 1280

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -65,8 +65,10 @@ class TestGeometry(unittest.TestCase):
                                           name="sphere3"))
         self.assertIsInstance(
             scene_graph.get_source_pose_port(global_source), InputPort)
-        self.assertIsInstance(
-            scene_graph.get_pose_bundle_output_port(), OutputPort)
+
+        with catch_drake_warnings(expected_count=1):
+            self.assertIsInstance(
+                scene_graph.get_pose_bundle_output_port(), OutputPort)
         self.assertIsInstance(
             scene_graph.get_query_output_port(), OutputPort)
 

--- a/examples/manipulation_station/manipulation_station.cc
+++ b/examples/manipulation_station/manipulation_station.cc
@@ -737,9 +737,11 @@ void ManipulationStation<T>::Finalize(
     }
   }
 
-  // TODO(#10482).  Deprecate the pose_bundle output port.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   builder.ExportOutput(scene_graph_->get_pose_bundle_output_port(),
                        "pose_bundle");
+#pragma GCC diagnostic pop
   builder.ExportOutput(scene_graph_->get_query_output_port(), "query_object");
 
   builder.ExportOutput(scene_graph_->get_query_output_port(),

--- a/examples/manipulation_station/manipulation_station.h
+++ b/examples/manipulation_station/manipulation_station.h
@@ -74,7 +74,7 @@ enum class Setup { kNone, kManipulationClass, kClutterClearing, kPlanarIiwa };
 /// - camera_[NAME]_depth_image
 /// - <b style="color:orange">camera_[NAME]_label_image</b>
 /// - <b style="color:orange">camera_[NAME]_point_cloud</b>
-/// - <b style="color:orange">pose_bundle</b>
+/// - <b style="color:orange">pose_bundle</b> (deprecated for 2021-12-01)
 /// - <b style="color:orange">query_object</b>
 /// - <b style="color:orange">contact_results</b>
 /// - <b style="color:orange">plant_continuous_state</b>

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -400,9 +400,15 @@ void SceneGraph<T>::CalcQueryObject(const Context<T>& context,
   output->set(&context, this);
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 template <typename T>
 void SceneGraph<T>::CalcPoseBundle(const Context<T>& context,
                                    PoseBundle<T>* output) const {
+  static const logging::Warn log_once(
+      "Do not use SceneGraph's PoseBundle-valued output port. It is deprecated "
+      "for removal after 2021-12-01. Instead use the QueryObject-valued port "
+      "and directly query for any information you need.");
   // Note: This functionality can potentially lead to strange visualization
   // artifacts. No invariant is maintained on what poses are being reported.
   // That means, when computing the output, *any* frame with illustration
@@ -429,6 +435,7 @@ void SceneGraph<T>::CalcPoseBundle(const Context<T>& context,
     // TODO(SeanCurtis-TRI): Handle velocity.
   }
 }
+#pragma GCC diagnostic pop
 
 template <typename T>
 std::vector<FrameId> SceneGraph<T>::GetDynamicFrames(

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -336,6 +336,9 @@ class SceneGraph final : public systems::LeafSystem<T> {
 
   /** Returns the output port which produces the PoseBundle for LCM
    communication to drake visualizer.  */
+  DRAKE_DEPRECATED("2021-12-01",
+                   "PoseBundle is no longer in use. Visualizers typically "
+                   "connect to SceneGraph's QueryObject port.")
   const systems::OutputPort<T>& get_pose_bundle_output_port() const {
     return systems::System<T>::get_output_port(bundle_port_index_);
   }
@@ -969,8 +972,11 @@ class SceneGraph final : public systems::LeafSystem<T> {
   // Aggregates the input poses into the output PoseBundle, in the same order as
   // was used in allocation. Aborts if any inputs have a _different_ size than
   // expected.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   void CalcPoseBundle(const systems::Context<T>& context,
                       systems::rendering::PoseBundle<T>* output) const;
+#pragma GCC diagnostic pop
 
   // Collects all of the *dynamic* frames that have geometries with the given
   // role.

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -73,12 +73,17 @@ class SceneGraphTester {
     scene_graph.CalcQueryObject(context, handle);
   }
 
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+// 2021-12-01 Delete this helper in completing the pose bundle removal.
   template <typename T>
   static void CalcPoseBundle(const SceneGraph<T>& scene_graph,
                              const systems::Context<T>& context,
                              PoseBundle<T>* bundle) {
     return scene_graph.CalcPoseBundle(context, bundle);
   }
+#pragma GCC diagnostic pop
 
   template <typename T>
   static const GeometryState<T>& GetGeometryState(
@@ -591,6 +596,9 @@ GTEST_TEST(SceneGraphAutoDiffTest, InstantiateAutoDiff) {
   SceneGraphTester::GetQueryObjectPortValue(scene_graph, *context, &handle);
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+// 2021-12-01 Delete this entire test in completing the pose bundle removal.
 // Tests the pose vector output port -- specifically, the pose vector should
 // *never* include the world frame.
 GTEST_TEST(SceneGraphVisualizationTest, NoWorldInPoseVector) {
@@ -691,6 +699,7 @@ GTEST_TEST(SceneGraphVisualizationTest, NoWorldInPoseVector) {
     EXPECT_EQ(0, poses.get_num_poses());
   }
 }
+#pragma GCC diagnostic pop
 
 // Tests that exercise the Context-modifying API
 

--- a/manipulation/perception/pose_smoother.cc
+++ b/manipulation/perception/pose_smoother.cc
@@ -64,7 +64,7 @@ VectorX<double> ComputeVelocities(const RigidTransform<double>& pose_1,
 }
 
 // TODO(naveenoid) : Replace the usage of these methods eventually with
-// PoseVector or a similar future variant.
+// some struct with clearer pose semantics.
 // Sets a pose from a 7-element array whose first 3 elements are position and
 // last 4 elements are a quaternion (w, x, y, z) with w >= 0 (canonical form).
 RigidTransform<double> PoseVector7ToRigidTransform(

--- a/systems/rendering/BUILD.bazel
+++ b/systems/rendering/BUILD.bazel
@@ -28,6 +28,8 @@ drake_cc_library(
     name = "pose_aggregator",
     srcs = ["pose_aggregator.cc"],
     hdrs = ["pose_aggregator.h"],
+    # Not necessary for gcc, but clang gets cranky without this.
+    copts = ["-Wno-deprecated-declarations"],
     deps = [
         ":pose_bundle",
         ":pose_vector",
@@ -99,6 +101,8 @@ drake_cc_library(
     name = "render_pose_to_geometry_pose",
     srcs = ["render_pose_to_geometry_pose.cc"],
     hdrs = ["render_pose_to_geometry_pose.h"],
+    # Not necessary for gcc, but clang gets cranky without this.
+    copts = ["-Wno-deprecated-declarations"],
     deps = [
         ":pose_vector",
         "//geometry:frame_kinematics",

--- a/systems/rendering/frame_velocity.cc
+++ b/systems/rendering/frame_velocity.cc
@@ -2,6 +2,9 @@
 
 #include "drake/common/default_scalars.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 namespace drake {
 namespace systems {
 namespace rendering {
@@ -70,3 +73,5 @@ FrameVelocity<T>* FrameVelocity<T>::DoClone() const {
 
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::rendering::FrameVelocity)
+
+#pragma GCC diagnostic pop

--- a/systems/rendering/frame_velocity.h
+++ b/systems/rendering/frame_velocity.h
@@ -2,6 +2,7 @@
 
 #include <Eigen/Dense>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/multibody/math/spatial_algebra.h"
 #include "drake/systems/framework/basic_vector.h"
 
@@ -18,7 +19,10 @@ namespace rendering {
 ///
 /// @tparam_default_scalar
 template <typename T>
-class FrameVelocity final : public BasicVector<T> {
+class DRAKE_DEPRECATED("2021-12-01",
+                       "FrameVelocity is no longer in use. Visualizers "
+                       "typically connect to SceneGraph's QueryObject port.")
+FrameVelocity final : public BasicVector<T> {
  public:
   /// Default constructor.
   FrameVelocity();
@@ -28,11 +32,14 @@ class FrameVelocity final : public BasicVector<T> {
   /// @param velocity the entire spatial velocity V_WA.
   explicit FrameVelocity(const multibody::SpatialVelocity<T>& velocity);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   // FrameVelocity is final, so we can implement copy and assignment without
   // fear of object slicing. This is useful for including FrameVelocity in an
   // AbstractValue, such as PoseBundle.
   FrameVelocity(const FrameVelocity<T>& other);
   FrameVelocity<T>& operator=(const FrameVelocity<T>& other);
+#pragma GCC diagnostic pop
 
   /// Returns the entire spatial velocity V_WA.
   multibody::SpatialVelocity<T> get_velocity() const;
@@ -42,7 +49,10 @@ class FrameVelocity final : public BasicVector<T> {
   static constexpr int kSize = 6;
 
  protected:
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   [[nodiscard]] FrameVelocity<T>* DoClone() const override;
+#pragma GCC diagnostic pop
 
  private:
   // Assigns the translational velocity p_WA.

--- a/systems/rendering/multibody_position_to_geometry_pose.h
+++ b/systems/rendering/multibody_position_to_geometry_pose.h
@@ -9,6 +9,12 @@ namespace drake {
 namespace systems {
 namespace rendering {
 
+// TODO(SeanCurtis-TRI) Move this out of systems/rendering into a more
+//  reasonable location so we can delete the rendering directory. It is used
+//  by applications that use sliders to control MBP positions and then directly
+//  input that to SceneGraph as poses. geometry_inspector.py and multibody
+//  examples (jupyter widgets). manipulation/util seems to be a reasonable
+//  location.
 /**
  * A direct-feedthrough system that converts a vector of joint positions
  * directly to a geometry::FramePoseVector<T> to behave like a

--- a/systems/rendering/pose_aggregator.cc
+++ b/systems/rendering/pose_aggregator.cc
@@ -8,6 +8,9 @@
 
 using std::to_string;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 namespace drake {
 namespace systems {
 namespace rendering {
@@ -194,3 +197,5 @@ PoseAggregator<T>::DeclareInput(const InputRecord& record) {
 
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::rendering::PoseAggregator)
+
+#pragma GCC diagnostic pop

--- a/systems/rendering/pose_aggregator.h
+++ b/systems/rendering/pose_aggregator.h
@@ -18,7 +18,10 @@ namespace internal { struct PoseAggregatorInputRecord; }
 /// A container with references to the input port for the pose input, and a
 /// reference to the input port for the velocity input.
 template <typename T>
-struct PoseVelocityInputPorts {
+struct DRAKE_DEPRECATED("2021-12-01",
+                       "PoseVelocityInputPorts is no longer in use. Visualizers"
+                       " typically connect to SceneGraph's QueryObject port.")
+PoseVelocityInputPorts {
   const InputPort<T>& pose_input_port;
   const InputPort<T>& velocity_input_port;
 };
@@ -74,16 +77,22 @@ struct PoseVelocityInputPorts {
 ///
 /// @tparam_default_scalar
 template <typename T>
-class PoseAggregator : public LeafSystem<T> {
+class DRAKE_DEPRECATED("2021-12-01",
+                       "PoseAggregator is no longer in use. Visualizers "
+                       "typically connect to SceneGraph's QueryObject port.")
+PoseAggregator : public LeafSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PoseAggregator)
 
   /// Constructs a default aggregator (with no inputs).
   PoseAggregator();
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   /// Scalar-converting copy constructor.  See @ref system_scalar_conversion.
   template <typename U>
   explicit PoseAggregator(const PoseAggregator<U>&);
+#pragma GCC diagnostic pop
 
   ~PoseAggregator() override;
 
@@ -97,8 +106,11 @@ class PoseAggregator : public LeafSystem<T> {
   /// @p model_instance_id.
   ///
   /// @return Input ports for pose and velocity.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   PoseVelocityInputPorts<T>
   AddSinglePoseAndVelocityInput(const std::string& name, int model_instance_id);
+#pragma GCC diagnostic pop
 
   /// Adds an input for a PoseBundle containing @p num_poses poses.
   const InputPort<T>& AddBundleInput(const std::string& bundle_name,
@@ -111,8 +123,11 @@ class PoseAggregator : public LeafSystem<T> {
   // Aggregates the input poses into the output PoseBundle, in the order
   // the input ports were added. Aborts if any inputs have an unexpected
   // dimension.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   void CalcPoseBundle(const Context<T>& context,
                       PoseBundle<T>* output) const;
+#pragma GCC diagnostic pop
 
   using InputRecord = internal::PoseAggregatorInputRecord;
 

--- a/systems/rendering/pose_bundle.cc
+++ b/systems/rendering/pose_bundle.cc
@@ -5,6 +5,9 @@
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 namespace drake {
 namespace systems {
 namespace rendering {
@@ -80,3 +83,5 @@ void PoseBundle<T>::set_model_instance_id(int index, int id) {
 
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::rendering::PoseBundle)
+
+#pragma GCC diagnostic pop

--- a/systems/rendering/pose_bundle.h
+++ b/systems/rendering/pose_bundle.h
@@ -8,6 +8,7 @@
 
 #include "drake/common/autodiff.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/symbolic.h"
 #include "drake/math/rigid_transform.h"
@@ -31,7 +32,10 @@ namespace rendering {
 ///
 /// @tparam_default_scalar
 template <typename T>
-class PoseBundle {
+class DRAKE_DEPRECATED("2021-12-01",
+                       "PoseBundle is no longer in use. Visualizers typically "
+                       "connect to SceneGraph's QueryObject port.")
+PoseBundle {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PoseBundle)
 
@@ -42,8 +46,11 @@ class PoseBundle {
   const math::RigidTransform<T>& get_transform(int index) const;
   void set_transform(int index, const math::RigidTransform<T>& pose);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   const FrameVelocity<T>& get_velocity(int index) const;
   void set_velocity(int index, const FrameVelocity<T>& velocity);
+#pragma GCC diagnostic pop
 
   const std::string& get_name(int index) const;
   void set_name(int index, const std::string& name);
@@ -53,7 +60,11 @@ class PoseBundle {
 
  private:
   std::vector<math::RigidTransform<T>> poses_;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   std::vector<FrameVelocity<T>> velocities_;
+#pragma GCC diagnostic pop
+
   std::vector<std::string> names_;
   std::vector<int> ids_;
 };

--- a/systems/rendering/pose_bundle_to_draw_message.cc
+++ b/systems/rendering/pose_bundle_to_draw_message.cc
@@ -9,6 +9,9 @@ namespace drake {
 namespace systems {
 namespace rendering {
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 PoseBundleToDrawMessage::PoseBundleToDrawMessage() {
   this->DeclareAbstractInputPort(
       kUseDefaultName, Value<PoseBundle<double>>());
@@ -54,6 +57,8 @@ void PoseBundleToDrawMessage::CalcViewerDrawMessage(
     message.quaternion[i][3] = q.z();
   }
 }
+
+#pragma GCC diagnostic pop
 
 }  // namespace rendering
 }  // namespace systems

--- a/systems/rendering/pose_bundle_to_draw_message.h
+++ b/systems/rendering/pose_bundle_to_draw_message.h
@@ -4,6 +4,7 @@
 
 #include <Eigen/Dense>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/lcmt_viewer_draw.hpp"
 #include "drake/systems/framework/leaf_system.h"
@@ -19,7 +20,11 @@ namespace rendering {
 /// The draw message will contain one link for each pose in the PoseBundle. The
 /// name of the link will be the name of the corresponding pose. The robot_num
 /// will be the corresponding model instance ID.
-class PoseBundleToDrawMessage : public LeafSystem<double> {
+class DRAKE_DEPRECATED("2021-12-01",
+                       "PoseBundleToDrawMessage is no longer in use. "
+                       "Visualizers typically connect to SceneGraph's "
+                       "QueryObject port.")
+PoseBundleToDrawMessage : public LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PoseBundleToDrawMessage)
 

--- a/systems/rendering/pose_vector.cc
+++ b/systems/rendering/pose_vector.cc
@@ -2,6 +2,9 @@
 
 #include "drake/common/default_scalars.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 namespace drake {
 namespace systems {
 namespace rendering {
@@ -71,3 +74,5 @@ PoseVector<T>* PoseVector<T>::DoClone() const {
 
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::rendering::PoseVector)
+
+#pragma GCC diagnostic pop

--- a/systems/rendering/pose_vector.h
+++ b/systems/rendering/pose_vector.h
@@ -17,18 +17,24 @@ namespace rendering {
 ///
 /// @tparam_default_scalar
 template <typename T>
-class PoseVector : public BasicVector<T> {
+class DRAKE_DEPRECATED("2021-12-01",
+                       "PoseVector is no longer in use. Visualizers typically "
+                       "connect to SceneGraph's QueryObject port.")
+PoseVector : public BasicVector<T> {
  public:
   /// Default constructor.
   PoseVector();
   ~PoseVector() override;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   /// Fully-parameterized constructor.
   /// @param rotation the orientation R_WA of frame A in the world frame W.
   /// @param translation the position vector p_WA giving A's origin measured
   /// from W's origin, expressed in W.
   PoseVector(const Eigen::Quaternion<T>& rotation,
              const Eigen::Translation<T, 3>& translation);
+#pragma GCC diagnostic pop
 
   /// Returns the transform X_WA.
   math::RigidTransform<T> get_transform() const;
@@ -48,7 +54,10 @@ class PoseVector : public BasicVector<T> {
   static constexpr int kSize = 7;
 
  protected:
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   [[nodiscard]] PoseVector<T>* DoClone() const override;
+#pragma GCC diagnostic pop
 };
 
 }  // namespace rendering

--- a/systems/rendering/render_pose_to_geometry_pose.cc
+++ b/systems/rendering/render_pose_to_geometry_pose.cc
@@ -9,6 +9,9 @@ using drake::geometry::FrameId;
 using drake::geometry::SourceId;
 using drake::math::RigidTransform;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 namespace drake {
 namespace systems {
 namespace rendering {
@@ -48,3 +51,5 @@ RenderPoseToGeometryPose<T>::~RenderPoseToGeometryPose() = default;
 
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::rendering::RenderPoseToGeometryPose)
+
+#pragma GCC diagnostic pop

--- a/systems/rendering/render_pose_to_geometry_pose.h
+++ b/systems/rendering/render_pose_to_geometry_pose.h
@@ -12,15 +12,22 @@ namespace rendering {
 /// rendering::PoseVector<T> on the input to geometry::FramePoseVector<T>
 /// on the output.
 template <typename T>
-class RenderPoseToGeometryPose final : public LeafSystem<T> {
+class DRAKE_DEPRECATED("2021-12-01",
+                       "RenderPoseToGeometryPose is no longer in use. "
+                       "Instead of passing through PoseVector, please output "
+                       "geometry::FramePoseVector directly.")
+RenderPoseToGeometryPose final : public LeafSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RenderPoseToGeometryPose)
 
   RenderPoseToGeometryPose(geometry::SourceId, geometry::FrameId);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   /// Scalar-converting copy constructor.  See @ref system_scalar_conversion.
   template <typename U>
   explicit RenderPoseToGeometryPose(const RenderPoseToGeometryPose<U>&);
+#pragma GCC diagnostic pop
 
   ~RenderPoseToGeometryPose() override;
 

--- a/systems/rendering/test/frame_velocity_test.cc
+++ b/systems/rendering/test/frame_velocity_test.cc
@@ -10,6 +10,9 @@ namespace systems {
 namespace rendering {
 namespace {
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 // Tests the fully-parameterized FrameVelocity.
 GTEST_TEST(FrameVelocity, FullyParameterizedCtor) {
   Vector6<double> data;
@@ -69,6 +72,8 @@ GTEST_TEST(FrameVelocityTest, Clone) {
   ASSERT_NE(nullptr, typed_clone);
   ASSERT_EQ(data, clone->get_value());
 }
+
+#pragma GCC diagnostic pop
 
 };  // namespace
 }  // namespace rendering

--- a/systems/rendering/test/pose_aggregator_test.cc
+++ b/systems/rendering/test/pose_aggregator_test.cc
@@ -27,6 +27,9 @@ namespace {
 const int kNumBundlePoses = 2;
 const int kNumSinglePoses = 2;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 class PoseAggregatorTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -222,6 +225,8 @@ GTEST_TEST(PoseBundleTest, Symbolic) {
   const symbolic::Expression& x = msv[0];
   EXPECT_TRUE(x.EqualTo(0.0));
 }
+
+#pragma GCC diagnostic pop
 
 }  // namespace
 }  // namespace rendering

--- a/systems/rendering/test/pose_bundle_to_draw_message_test.cc
+++ b/systems/rendering/test/pose_bundle_to_draw_message_test.cc
@@ -10,6 +10,9 @@ namespace systems {
 namespace rendering {
 namespace {
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 GTEST_TEST(PoseBundleToDrawMessageTest, Conversion) {
   PoseBundle<double> bundle(2);
   math::RigidTransformd foo_pose{Eigen::Vector3d{123, 0, 0}};
@@ -65,6 +68,8 @@ GTEST_TEST(PoseBundleToDrawMessageTest, Stateless) {
   auto context = converter.AllocateContext();
   EXPECT_TRUE(context->is_stateless());
 }
+
+#pragma GCC diagnostic pop
 
 }  // namespace
 }  // namespace rendering

--- a/systems/rendering/test/pose_vector_test.cc
+++ b/systems/rendering/test/pose_vector_test.cc
@@ -24,6 +24,9 @@ namespace systems {
 namespace rendering {
 namespace {
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 // Tests that the default PoseVector is initialized to identity.
 GTEST_TEST(PoseVector, InitiallyIdentity) {
   const PoseVector<double> vec;
@@ -191,6 +194,8 @@ GTEST_TEST(PoseVector, Autodiff) {
     }
   }
 }
+
+#pragma GCC diagnostic pop
 
 };  // namespace
 }  // namespace rendering

--- a/systems/rendering/test/render_pose_to_geometry_pose_test.cc
+++ b/systems/rendering/test/render_pose_to_geometry_pose_test.cc
@@ -3,6 +3,10 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 #include "drake/systems/framework/test_utilities/scalar_conversion.h"
 
 namespace drake {
@@ -50,6 +54,8 @@ GTEST_TEST(RenderPoseToGeometryPoseTest, ToSymbolic) {
     EXPECT_EQ(1, converted.num_output_ports());
   }));
 }
+
+#pragma GCC diagnostic pop
 
 }  // namespace
 }  // namespace rendering

--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -209,6 +209,7 @@ drake_cc_library(
     deps = [
         ":camera_info",
         ":image",
+        "//common:essential",
         "//geometry:geometry_ids",
         "//geometry:scene_graph",
         "//geometry/render:render_engine",

--- a/systems/sensors/test/rgbd_sensor_test.cc
+++ b/systems/sensors/test/rgbd_sensor_test.cc
@@ -303,7 +303,12 @@ TEST_F(RgbdSensorTest, PortNames) {
   EXPECT_EQ(sensor.depth_image_32F_output_port().get_name(), "depth_image_32f");
   EXPECT_EQ(sensor.depth_image_16U_output_port().get_name(), "depth_image_16u");
   EXPECT_EQ(sensor.label_image_output_port().get_name(), "label_image");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   EXPECT_EQ(sensor.X_WB_output_port().get_name(), "X_WB");
+#pragma GCC diagnostic pop
+  EXPECT_EQ(sensor.body_pose_in_world_output_port().get_name(),
+            "body_pose_in_world");
 }
 
 // Tests that the anchored camera reports the correct parent frame and has the
@@ -475,7 +480,12 @@ GTEST_TEST(RgbdSensorDiscrete, Construction) {
   EXPECT_EQ(sensor.depth_image_32F_output_port().get_name(), "depth_image_32f");
   EXPECT_EQ(sensor.depth_image_16U_output_port().get_name(), "depth_image_16u");
   EXPECT_EQ(sensor.label_image_output_port().get_name(), "label_image");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   EXPECT_EQ(sensor.X_WB_output_port().get_name(), "X_WB");
+#pragma GCC diagnostic pop
+  EXPECT_EQ(sensor.body_pose_in_world_output_port().get_name(),
+            "body_pose_in_world");
 
   // Confirm that the period was passed into the ZOH correctly. If the ZOH
   // reports the expected period, we rely on it to do the right thing.


### PR DESCRIPTION
This deprecates `PoseBundle` as well as closely affiliated classes: `PoseVector`, `PoseAggregator`, `PoseBundoeToDrawMessage`.

There are two systems that have `PoseBundle`-valued output ports and two diagrams that export those ports.

The systems had explicit getters for the ports; those getters have been deprecated.

The diagrams were mixed. One had a getter, one relied on `get_output_port(name)`. To generally aid the case where a leaf output port is exported, the calc methods of the two systems have been given a "log once" warning.

Bindings and unit tests have likewise been updated.

Resolves #10482
Resolves #13580

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15534)
<!-- Reviewable:end -->
