### PR TITLE
parsing: Encapsulate (make private) all detail_* libraries

### DIFF
--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -60,6 +60,10 @@ drake_cc_library(
     ],
 )
 
+# For simplicity in dependency management (e.g., prevent exposing `sdformat`),
+# we make all `detail_*` headers and libraries private. For more info, see
+# #7451.
+
 drake_cc_library(
     name = "detail_misc",
     srcs = [
@@ -75,9 +79,13 @@ drake_cc_library(
         "detail_tinyxml.h",
     ],
     install_hdrs_exclude = [
-        # This header includes `ignition` directly, which we do not
-        # want to expose externally.
+        "detail_common.h",
         "detail_ignition.h",
+        "detail_path_utils.h",
+        "detail_tinyxml.h",
+    ],
+    visibility = [
+        "//visibility:private",
     ],
     deps = [
         ":package_map",
@@ -99,8 +107,6 @@ drake_cc_library(
         "detail_scene_graph.h",
     ],
     install_hdrs_exclude = [
-        # This header includes `sdformat` directly, which we do not want to
-        # expose externally.
         "detail_scene_graph.h",
     ],
     visibility = [
@@ -124,6 +130,9 @@ drake_cc_library(
     hdrs = [
         "detail_sdf_parser.h",
     ],
+    install_hdrs_exclude = [
+        "detail_sdf_parser.h",
+    ],
     visibility = [
         "//visibility:private",
     ],
@@ -144,6 +153,10 @@ drake_cc_library(
         "detail_urdf_parser.cc",
     ],
     hdrs = [
+        "detail_urdf_geometry.h",
+        "detail_urdf_parser.h",
+    ],
+    install_hdrs_exclude = [
         "detail_urdf_geometry.h",
         "detail_urdf_parser.h",
     ],


### PR DESCRIPTION
I'm not sure why we had these partially public, so this just completely seals things.

Could possibly help for #15477, but IMO this is a standalone improvement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15535)
<!-- Reviewable:end -->
