### PR TITLE
[fem] Add PermuteBlockVector()

### DIFF
--- a/multibody/fixed_fem/dev/permute_block_sparse_matrix.h
+++ b/multibody/fixed_fem/dev/permute_block_sparse_matrix.h
@@ -8,11 +8,11 @@ namespace drake {
 namespace multibody {
 namespace fem {
 namespace internal {
-
-/* Given an Eigen::SparseMatrix with block structure with 3x3 block entries Bᵢⱼ
-where i, j ∈ V = {0,...,num_vertices-1} and a permutation P on V, this method
-builds the permuted matrix with 3x3 block entries Cᵢⱼ such that Cᵢⱼ =
-B_{P(i),P(j)}.
+// TODO(xuchenhan-tri): Consider moving this method to matrix_utilities.h/cc.
+/* Given a 3N-by-3N Eigen::SparseMatrix with block structure with 3x3 block
+entries Bᵢⱼ where i, j ∈ V = {0, ..., N-1} and a permutation P on V, this method
+builds the permuted matrix with 3x3 block entries C's such that Cₚ₍ᵢ₎ₚ₍ⱼ₎ =
+Bᵢⱼ.
 
 For example, suppose the input `matrix` is given by
        a a a b b b
@@ -31,8 +31,8 @@ permutation will be:
        b b b a a a
 
 @param[in] matrix             The original block sparse matrix to be permuted.
-@param[in] block_permutation  block_permutation[i] gives the permuted index
-                              of the block whose original index is `i`.
+@param[in] block_permutation  block_permutation[i] gives the index of the
+                              permuted block whose original index is `i`.
 @pre matrix.rows() == matrix.cols().
 @pre matrix.rows() % 3 == 0.
 @pre block_permutation is a permutation of {0, 1, ..., matrix.rows()/3-1}. */

--- a/multibody/fixed_fem/dev/test/matrix_utilities_test.cc
+++ b/multibody/fixed_fem/dev/test/matrix_utilities_test.cc
@@ -105,6 +105,19 @@ GTEST_TEST(MatrixUtilitiesTest, AddScaledCofactorMatrixDerivative) {
     }
   }
 }
+
+GTEST_TEST(MatrixUtilitiesTest, PermuteBlockVector) {
+  constexpr int kNumBlocks = 3;
+  VectorX<double> v(3 * kNumBlocks);
+  v << 0, 1, 2, 3, 4, 5, 6, 7, 8;
+  const std::vector<int> block_permutation = {1, 2, 0};
+  const VectorX<double> permuted_v =
+      PermuteBlockVector<double>(v, block_permutation);
+  VectorX<double> expected_result(3 * kNumBlocks);
+  expected_result << 6, 7, 8, 0, 1, 2, 3, 4, 5;
+  EXPECT_TRUE(CompareMatrices(expected_result, permuted_v));
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace fem


### PR DESCRIPTION
This matrix utility method facilitates mapping velocities/contact forces
in the original order of the deformable vertices to the order where
all participating vertex quantities come first and vice versa.

Fix typo in documentation of PermuteBlockSparseMatrix().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15536)
<!-- Reviewable:end -->
