### PR TITLE
[systems/framework] Sugar for setting/getting Eigen::VectorX data from DiscreteValues

### DIFF
--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -842,6 +842,10 @@ void DefineFrameworkPySemantics(py::module m) {
         .def("size", &DiscreteValues<T>::size, doc.DiscreteValues.size.doc)
         .def("get_data", &DiscreteValues<T>::get_data,
             py_rvp::reference_internal, doc.DiscreteValues.get_data.doc)
+        .def("set_value",
+            overload_cast_explicit<void, const Eigen::Ref<const VectorX<T>>&>(
+                &DiscreteValues<T>::set_value),
+            py::arg("value"), doc.DiscreteValues.set_value.doc_1args)
         .def("get_vector",
             overload_cast_explicit<const BasicVector<T>&, int>(
                 &DiscreteValues<T>::get_vector),
@@ -852,6 +856,22 @@ void DefineFrameworkPySemantics(py::module m) {
                 &DiscreteValues<T>::get_mutable_vector),
             py_rvp::reference_internal, py::arg("index") = 0,
             doc.DiscreteValues.get_mutable_vector.doc_1args)
+        .def("set_value",
+            overload_cast_explicit<void, int,
+                const Eigen::Ref<const VectorX<T>>&>(
+                &DiscreteValues<T>::set_value),
+            py::arg("index"), py::arg("value"),
+            doc.DiscreteValues.set_value.doc_2args)
+        .def("get_value",
+            overload_cast_explicit<Eigen::VectorBlock<const VectorX<T>>, int>(
+                &DiscreteValues<T>::get_value),
+            py_rvp::reference_internal, py::arg("index") = 0,
+            doc.DiscreteValues.get_value.doc_1args)
+        .def("get_mutable_value",
+            overload_cast_explicit<Eigen::VectorBlock<VectorX<T>>, int>(
+                &DiscreteValues<T>::get_mutable_value),
+            py_rvp::reference_internal, py::arg("index") = 0,
+            doc.DiscreteValues.get_mutable_value.doc_1args)
         .def(
             "SetFrom",
             [](DiscreteValues<T>* self, const DiscreteValues<double>& other) {

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -320,6 +320,12 @@ class TestGeneral(unittest.TestCase):
         self.assertEqual(DiscreteValues().num_groups(), 0)
         discrete_values = DiscreteValues(data=[BasicVector(1), BasicVector(2)])
         self.assertEqual(discrete_values.num_groups(), 2)
+        x = np.array([1.23, 4.56])
+        discrete_values.set_value(1, x)
+        np.testing.assert_array_equal(discrete_values.get_value(index=1), x)
+        np.testing.assert_array_equal(
+            discrete_values.get_mutable_value(index=1), x)
+
         discrete_values = DiscreteValues(datum=BasicVector(np.arange(3)))
         self.assertEqual(discrete_values.size(), 3)
         discrete_values_clone = discrete_values.Clone()
@@ -327,6 +333,10 @@ class TestGeneral(unittest.TestCase):
         self.assertEqual(len(discrete_values.get_data()), 1)
         self.assertEqual(discrete_values.get_vector(index=0).size(), 3)
         self.assertEqual(discrete_values.get_mutable_vector(index=0).size(), 3)
+        x = np.array([1., 3., 4.])
+        discrete_values.set_value(x)
+        np.testing.assert_array_equal(discrete_values.get_value(), x)
+        np.testing.assert_array_equal(discrete_values.get_mutable_value(), x)
         discrete_values[1] = 5.
         self.assertEqual(discrete_values[1], 5.)
         discrete_values.SetFrom(DiscreteValues(BasicVector(3)))

--- a/examples/mass_spring_cloth/cloth_spring_model.cc
+++ b/examples/mass_spring_cloth/cloth_spring_model.cc
@@ -241,7 +241,7 @@ void ClothSpringModel<T>::UpdateDiscreteState(
 
   // Write v_hat + dv into the velocity at the next time step.
   Eigen::VectorBlock<VectorX<T>> next_state_values =
-      next_states->get_mutable_vector().get_mutable_value();
+      next_states->get_mutable_value();
   auto next_q = next_state_values.head(3 * num_particles_);
   auto next_v = next_state_values.tail(3 * num_particles_);
   next_v = v_hat + dv;

--- a/examples/planar_gripper/planar_gripper_lcm.cc
+++ b/examples/planar_gripper/planar_gripper_lcm.cc
@@ -58,8 +58,7 @@ systems::EventStatus GripperCommandDecoder::UpdateDiscreteState(
 
   // If we're using a default constructed message (haven't received
   // a command yet), keep using the initial state.
-  BasicVector<double>& state = discrete_state->get_mutable_vector(0);
-  auto state_value = state.get_mutable_value();
+  auto state_value = discrete_state->get_mutable_value(0);
   auto positions = state_value.head(num_joints_);
   auto velocities = state_value.segment(num_joints_, num_joints_);
   auto torques = state_value.tail(num_joints_);
@@ -161,9 +160,7 @@ systems::EventStatus GripperStatusDecoder::UpdateDiscreteState(
   DRAKE_ASSERT(input != nullptr);
   const auto& status = input->get_value<lcmt_planar_gripper_status>();
 
-  BasicVector<double>& state = discrete_state->get_mutable_vector(0);
-
-  auto state_value = state.get_mutable_value();
+  auto state_value = discrete_state->get_mutable_value(0);
   auto positions = state_value.head(num_joints_);
   auto velocities = state_value.segment(num_joints_, num_joints_);
   auto tip_forces = state_value.tail(num_fingers_ * 2);

--- a/examples/planar_gripper/planar_manipuland_lcm.cc
+++ b/examples/planar_gripper/planar_manipuland_lcm.cc
@@ -26,8 +26,7 @@ systems::EventStatus PlanarManipulandStatusDecoder::UpdateDiscreteState(
   DRAKE_ASSERT(input != nullptr);
   const auto& status = input->get_value<lcmt_planar_manipuland_status>();
 
-  systems::BasicVector<double>& state = discrete_state->get_mutable_vector(0);
-  auto state_value = state.get_mutable_value();
+  auto state_value = discrete_state->get_mutable_value(0);
 
   state_value(0) = status.position[0];
   state_value(1) = status.position[1];

--- a/examples/rod2d/rod2d.cc
+++ b/examples/rod2d/rod2d.cc
@@ -596,9 +596,10 @@ void Rod2D<T>::DoCalcDiscreteVariableUpdates(
   VectorX<T> qplus = q + vplus * dt_;
 
   // Set the new discrete state.
-  systems::BasicVector<T>& new_state = discrete_state->get_mutable_vector(0);
-  new_state.get_mutable_value().segment(0, 3) = qplus;
-  new_state.get_mutable_value().segment(3, 3) = vplus;
+  Eigen::VectorBlock<VectorX<T>> new_state =
+      discrete_state->get_mutable_value(0);
+  new_state.segment(0, 3) = qplus;
+  new_state.segment(3, 3) = vplus;
 }
 
 // Computes the impulses such that the vertical velocity at the contact point

--- a/manipulation/kuka_iiwa/iiwa_command_receiver.cc
+++ b/manipulation/kuka_iiwa/iiwa_command_receiver.cc
@@ -72,7 +72,7 @@ void IiwaCommandReceiver::LatchInitialPosition(
     DiscreteValues<double>* result) const {
   const auto& bool_index = latched_position_measured_is_set_;
   const auto& value_index = latched_position_measured_;
-  result->get_mutable_vector(bool_index).get_mutable_value()[0] = 1.0;
+  result->get_mutable_value(bool_index)[0] = 1.0;
   result->get_mutable_vector(value_index).SetFrom(
       position_measured_or_zero_->Eval<BasicVector<double>>(context));
 }

--- a/manipulation/planner/differential_inverse_kinematics_integrator.cc
+++ b/manipulation/planner/differential_inverse_kinematics_integrator.cc
@@ -112,10 +112,10 @@ void DifferentialInverseKinematicsIntegrator::DoCalcDiscreteVariableUpdates(
           "Differential IK could not find a solution at time {}.",
           context.get_time());
     }
-    discrete_state->get_mutable_vector(0).SetFromVector(positions);
+    discrete_state->set_value(0, positions);
   } else {
-    discrete_state->get_mutable_vector(0).SetFromVector(
-        positions + time_step_ * result.joint_velocities.value());
+    discrete_state->set_value(
+        0, positions + time_step_ * result.joint_velocities.value());
   }
 
   if (this->num_discrete_state_groups() > 1) {

--- a/multibody/fixed_fem/dev/deformable_model.cc
+++ b/multibody/fixed_fem/dev/deformable_model.cc
@@ -140,9 +140,8 @@ void DeformableModel<T>::DoDeclareSystemResources(MultibodyPlant<T>* plant) {
         const systems::DiscreteValues<T>& all_discrete_states =
             context.get_discrete_state();
         for (int i = 0; i < num_bodies(); ++i) {
-          const systems::BasicVector<T>& discrete_state =
-              all_discrete_states.get_vector(discrete_state_indexes_[i]);
-          const auto& discrete_value = discrete_state.get_value();
+          const auto& discrete_value =
+              all_discrete_states.get_value(discrete_state_indexes_[i]);
           const int num_dofs = discrete_value.size() / 3;
           const auto& q = discrete_value.head(num_dofs);
           output_value[i] = q;

--- a/multibody/fixed_fem/dev/deformable_rigid_manager.cc
+++ b/multibody/fixed_fem/dev/deformable_rigid_manager.cc
@@ -328,8 +328,7 @@ void DeformableRigidManager<T>::DoCalcDiscreteValues(
 
   VectorX<T> x_next(this->plant().num_multibody_states());
   x_next << q_next, v_next;
-  updates->get_mutable_vector(this->multibody_state_index())
-      .SetFromVector(x_next);
+  updates->set_value(this->multibody_state_index(), x_next);
 
   /* Evaluates the deformable free-motion states. */
   const std::vector<systems::DiscreteStateIndex>& discrete_state_indexes =
@@ -343,10 +342,8 @@ void DeformableRigidManager<T>::DoCalcDiscreteValues(
     // TODO(xuchenhan-tri): This assumes no deformable-rigid contact exists.
     //  Modify this to include the effect of contact.
     /* Copy new state to output variable. */
-    systems::BasicVector<T>& next_discrete_state =
-        updates->get_mutable_vector(discrete_state_indexes[deformable_body_id]);
     Eigen::VectorBlock<VectorX<T>> next_discrete_value =
-        next_discrete_state.get_mutable_value();
+        updates->get_mutable_value(discrete_state_indexes[deformable_body_id]);
     next_discrete_value.head(num_dofs) = state_star.q();
     next_discrete_value.segment(num_dofs, num_dofs) = state_star.qdot();
     next_discrete_value.tail(num_dofs) = state_star.qddot();

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -2605,7 +2605,7 @@ void MultibodyPlant<T>::DoCalcDiscreteVariableUpdates(
 
   VectorX<T> x_next(this->num_multibody_states());
   x_next << q_next, v_next;
-  updates->get_mutable_vector(0).SetFromVector(x_next);
+  updates->set_value(0, x_next);
 }
 
 template<typename T>

--- a/multibody/plant/test/discrete_update_manager_test.cc
+++ b/multibody/plant/test/discrete_update_manager_test.cc
@@ -143,13 +143,11 @@ class DummyDiscreteUpdateManager : public DiscreteUpdateManager<T> {
   void DoCalcDiscreteValues(const Context<T>& context,
                             DiscreteValues<T>* updates) const final {
     auto multibody_data =
-        updates->get_mutable_vector(this->multibody_state_index())
-            .get_mutable_value();
+        updates->get_mutable_value(this->multibody_state_index());
     multibody_data += VectorX<T>::Ones(multibody_data.size());
     if (additional_state_index_.is_valid()) {
       auto additional_data =
-          updates->get_mutable_vector(additional_state_index_)
-              .get_mutable_value();
+          updates->get_mutable_value(additional_state_index_);
       additional_data += 2.0 * VectorX<T>::Ones(additional_data.size());
     }
   }

--- a/systems/analysis/test/simulator_test.cc
+++ b/systems/analysis/test/simulator_test.cc
@@ -1319,7 +1319,7 @@ class DiscreteInputAccumulator : public LeafSystem<double> {
         DiscreteUpdateEvent<double>([this](const Context<double>&,
                                            const DiscreteUpdateEvent<double>&,
                                            DiscreteValues<double>* x_0) {
-          x_0->get_mutable_vector()[0] = 0.;
+          (*x_0)[0] = 0.;
           result_.clear();
         }));
 
@@ -1341,7 +1341,7 @@ class DiscreteInputAccumulator : public LeafSystem<double> {
                                            DiscreteValues<double>* x_np1) {
           const double x_n = get_x(context);
           const double u = get_input_port(0).Eval(context)[0];
-          x_np1->get_mutable_vector()[0] = x_n + u;  // x_{n+1} = x_n + u(t)
+          (*x_np1)[0] = x_n + u;  // x_{n+1} = x_n + u(t)
         }));
   }
 

--- a/systems/controllers/test/linear_model_predictive_controller_test.cc
+++ b/systems/controllers/test/linear_model_predictive_controller_test.cc
@@ -114,8 +114,7 @@ class CubicPolynomialSystem final : public LeafSystem<T> {
     using std::pow;
     const T& x1 = context.get_discrete_state(0).get_value()[0];
     const T& u = this->get_input_port(0).Eval(context)[0];
-    next_state->get_mutable_vector(0).SetAtIndex(0, u);
-    next_state->get_mutable_vector(0).SetAtIndex(1, pow(x1, 3.));
+    next_state->set_value(0, Vector2<T>{u, pow(x1, 3.)});
   }
 
   void OutputState(const systems::Context<T>& context,

--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -818,6 +818,7 @@ drake_cc_googletest(
         ":diagram_discrete_values",
         ":discrete_values",
         "//common:essential",
+        "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
         "//common/test_utilities:is_dynamic_castable",
         "//systems/framework/test_utilities",

--- a/systems/framework/discrete_values.h
+++ b/systems/framework/discrete_values.h
@@ -128,6 +128,28 @@ class DiscreteValues {
     ThrowUnlessExactlyOneGroup();
     return get_mutable_vector(0);
   }
+
+  /// Sets the vector to the given value for the _only_ group.
+  void set_value(const Eigen::Ref<const VectorX<T>>& value) {
+    ThrowUnlessExactlyOneGroup();
+    get_mutable_vector(0).set_value(value);
+  }
+
+  /// Returns the entire vector as a const Eigen::VectorBlock for the _only_
+  /// group.
+  Eigen::VectorBlock<const VectorX<T>> get_value() const {
+    ThrowUnlessExactlyOneGroup();
+    return get_vector(0).get_value();
+  }
+
+  /// Returns the entire vector for the _only_ group as a mutable
+  /// Eigen::VectorBlock, which allows mutation of the values, but does not
+  /// allow resizing the vector itself.
+  Eigen::VectorBlock<VectorX<T>> get_mutable_value() {
+    ThrowUnlessExactlyOneGroup();
+    return get_mutable_vector(0).get_mutable_value();
+  }
+
   //@}
 
   /// Returns a const reference to the vector holding data for the indicated
@@ -142,6 +164,27 @@ class DiscreteValues {
   BasicVector<T>& get_mutable_vector(int index) {
     DRAKE_THROW_UNLESS(index >= 0 && index < num_groups());
     return *data_[index];
+  }
+
+  /// Returns the entire vector as a const Eigen::VectorBlock for the indicated
+  /// group.
+  Eigen::VectorBlock<const VectorX<T>> get_value(int index) const {
+    DRAKE_THROW_UNLESS(index >= 0 && index < num_groups());
+    return data_[index]->get_value();
+  }
+
+  /// Returns the entire vector for the indicated group as a mutable
+  /// Eigen::VectorBlock, which allows mutation of the values, but does not
+  /// allow resizing the vector itself.
+  Eigen::VectorBlock<VectorX<T>> get_mutable_value(int index) {
+    DRAKE_THROW_UNLESS(index >= 0 && index < num_groups());
+    return data_[index]->get_mutable_value();
+  }
+
+  /// Sets the vector to the given value for the indicated group.
+  void set_value(
+      int index, const Eigen::Ref<const VectorX<T>>& value) {
+    get_mutable_vector(index).set_value(value);
   }
 
   /// Resets the values in this DiscreteValues from the values in @p other,

--- a/systems/framework/discrete_values.h
+++ b/systems/framework/discrete_values.h
@@ -144,7 +144,7 @@ class DiscreteValues {
 
   /// Returns the entire vector for the _only_ group as a mutable
   /// Eigen::VectorBlock, which allows mutation of the values, but does not
-  /// allow resizing the vector itself.
+  /// allow resize() to be called on the vector.
   Eigen::VectorBlock<VectorX<T>> get_mutable_value() {
     ThrowUnlessExactlyOneGroup();
     return get_mutable_vector(0).get_mutable_value();
@@ -155,29 +155,29 @@ class DiscreteValues {
   /// Returns a const reference to the vector holding data for the indicated
   /// group.
   const BasicVector<T>& get_vector(int index) const {
-    DRAKE_THROW_UNLESS(index >= 0 && index < num_groups());
+    DRAKE_THROW_UNLESS(0 <= index && index < num_groups());
     return *data_[index];
   }
 
   /// Returns a mutable reference to the vector holding data for the indicated
   /// group.
   BasicVector<T>& get_mutable_vector(int index) {
-    DRAKE_THROW_UNLESS(index >= 0 && index < num_groups());
+    DRAKE_THROW_UNLESS(0 <= index && index < num_groups());
     return *data_[index];
   }
 
   /// Returns the entire vector as a const Eigen::VectorBlock for the indicated
   /// group.
   Eigen::VectorBlock<const VectorX<T>> get_value(int index) const {
-    DRAKE_THROW_UNLESS(index >= 0 && index < num_groups());
+    DRAKE_THROW_UNLESS(0 <= index && index < num_groups());
     return data_[index]->get_value();
   }
 
   /// Returns the entire vector for the indicated group as a mutable
   /// Eigen::VectorBlock, which allows mutation of the values, but does not
-  /// allow resizing the vector itself.
+  /// allow resize() to be called on the vector.
   Eigen::VectorBlock<VectorX<T>> get_mutable_value(int index) {
-    DRAKE_THROW_UNLESS(index >= 0 && index < num_groups());
+    DRAKE_THROW_UNLESS(0 <= index && index < num_groups());
     return data_[index]->get_mutable_value();
   }
 

--- a/systems/framework/test/discrete_values_test.cc
+++ b/systems/framework/test/discrete_values_test.cc
@@ -9,6 +9,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/autodiff.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/common/test_utilities/is_dynamic_castable.h"
 #include "drake/systems/framework/basic_vector.h"
@@ -163,6 +164,14 @@ GTEST_TEST(DiscreteValuesSingleGroupTest, ConvenienceSugar) {
   EXPECT_EQ(100.0, xd.get_vector()[0]);
   xd.get_mutable_vector()[1] = 1000.0;
   EXPECT_EQ(1000.0, xd[1]);
+
+  Eigen::Vector2d vec{44., 45.}, vec2{46., 47.};
+  xd.set_value(vec);
+  EXPECT_TRUE(CompareMatrices(xd.get_value(), vec));
+  xd.get_mutable_value() = vec2;
+  EXPECT_TRUE(CompareMatrices(xd.get_value(), vec2));
+
+  DRAKE_EXPECT_THROWS_MESSAGE(xd.set_value(Vector3d::Ones()), ".*size.*");
 }
 
 // Tests that the convenience accessors for a DiscreteValues that contains
@@ -176,6 +185,9 @@ GTEST_TEST(DiscreteValuesSingleGroupTest, ConvenienceSugarEmpty) {
                               expected_pattern);
   DRAKE_EXPECT_THROWS_MESSAGE(xd.get_mutable_vector(), std::logic_error,
                               expected_pattern);
+  DRAKE_EXPECT_THROWS_MESSAGE(xd.set_value(VectorXd()), expected_pattern);
+  DRAKE_EXPECT_THROWS_MESSAGE(xd.get_value(), expected_pattern);
+  DRAKE_EXPECT_THROWS_MESSAGE(xd.get_mutable_value(), expected_pattern);
 }
 
 // Tests that the convenience accessors for a DiscreteValues that contains
@@ -189,6 +201,14 @@ TEST_F(DiscreteValuesTest, ConvenienceSugarMultiple) {
                               expected_pattern);
   DRAKE_EXPECT_THROWS_MESSAGE(xd.get_mutable_vector(), std::logic_error,
                               expected_pattern);
+
+  Eigen::Vector2d vec{44., 45.}, vec2{46., 47.};
+  xd.set_value(1, vec);
+  EXPECT_TRUE(CompareMatrices(xd.get_value(1), vec));
+  xd.get_mutable_value(1) = vec2;
+  EXPECT_TRUE(CompareMatrices(xd.get_value(1), vec2));
+
+  DRAKE_EXPECT_THROWS_MESSAGE(xd.set_value(1, Vector3d::Ones()), ".*size.*");
 }
 
 // For DiagramDiscreteValues we want to check that we can build a tree of

--- a/systems/framework/test/system_symbolic_inspector_test.cc
+++ b/systems/framework/test/system_symbolic_inspector_test.cc
@@ -112,7 +112,7 @@ class SparseSystem : public LeafSystem<symbolic::Expression> {
     const Eigen::Vector2d f0(10.0, 11.0);
     const Vector2<symbolic::Expression> next_xd =
         A * xd + B1 * u0 + B2 * u1 + f0;
-    discrete_state->get_mutable_vector(0).SetFromVector(next_xd);
+    discrete_state->set_value(0, next_xd);
   }
 };
 

--- a/systems/framework/vector_system.h
+++ b/systems/framework/vector_system.h
@@ -181,10 +181,8 @@ class VectorSystem : public LeafSystem<T> {
 
     // Obtain the block form of xd after the update (i.e., the next state).
     DRAKE_ASSERT(discrete_state != nullptr);
-    BasicVector<T>& discrete_update_vector =
-        discrete_state->get_mutable_vector();
     Eigen::VectorBlock<VectorX<T>> discrete_update_block =
-        discrete_update_vector.get_mutable_value();
+        discrete_state->get_mutable_value();
 
     // Delegate to subclass.
     DoCalcVectorDiscreteVariableUpdates(context, input_block, state_block,

--- a/systems/primitives/affine_system.cc
+++ b/systems/primitives/affine_system.cc
@@ -188,7 +188,7 @@ void TimeVaryingAffineSystem<T>::DoCalcDiscreteVariableUpdates(
     DRAKE_DEMAND(Bt.rows() == num_states_ && Bt.cols() == num_inputs_);
     xn += Bt * u;
   }
-  updates->get_mutable_vector().SetFromVector(xn);
+  updates->set_value(xn);
 }
 
 template <typename T>
@@ -396,7 +396,7 @@ void AffineSystem<T>::DoCalcDiscreteVariableUpdates(
 
     xnext += B_ * u;
   }
-  updates->get_mutable_vector().SetFromVector(xnext);
+  updates->set_value(xnext);
 }
 
 DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS((

--- a/systems/primitives/discrete_derivative.cc
+++ b/systems/primitives/discrete_derivative.cc
@@ -63,8 +63,7 @@ void DiscreteDerivative<T>::DoCalcDiscreteVariableUpdates(
     const std::vector<const drake::systems::DiscreteUpdateEvent<T>*>&,
     drake::systems::DiscreteValues<T>* state) const {
   // x₀[n+1] = u[n].
-  state->get_mutable_vector(0).SetFromVector(
-      this->get_input_port().Eval(context));
+  state->set_value(0, this->get_input_port().Eval(context));
 
   // x₁[n+1] = x₀[n].
   state->get_mutable_vector(1).SetFrom(context.get_discrete_state(0));

--- a/systems/primitives/discrete_time_delay.cc
+++ b/systems/primitives/discrete_time_delay.cc
@@ -79,7 +79,7 @@ void DiscreteTimeDelay<T>::SaveInputVectorToBuffer(
   // copy operation.
   const auto& input = this->get_input_port().Eval(context);
   Eigen::VectorBlock<VectorX<T>> updated_state_value =
-      discrete_state->get_mutable_vector(0).get_mutable_value();
+      discrete_state->get_mutable_value(0);
   Eigen::VectorBlock<const VectorX<T>> old_state_value =
       context.get_discrete_state(0).get_value();
   updated_state_value.head((delay_buffer_size_ - 1) * vector_size_) =

--- a/systems/primitives/linear_system.cc
+++ b/systems/primitives/linear_system.cc
@@ -183,7 +183,7 @@ std::unique_ptr<AffineSystem<double>> DoFirstOrderTaylorApproximation(
           autodiff_system->AllocateDiscreteVariables();
       autodiff_system->CalcDiscreteVariableUpdates(*autodiff_context,
                                                    autodiff_x1.get());
-      auto autodiff_x1_vec = autodiff_x1->get_vector().CopyToVector();
+      auto autodiff_x1_vec = autodiff_x1->get_value();
 
       const Eigen::MatrixXd AB =
           math::autoDiffToGradientMatrix(autodiff_x1_vec);

--- a/systems/primitives/test/linear_system_test.cc
+++ b/systems/primitives/test/linear_system_test.cc
@@ -769,8 +769,7 @@ class MimoSystem final : public LeafSystem<T> {
     Vector3<T> u1 = this->get_input_port(1).Eval(context);
     Vector2<T> x = get_state_vector(context);
 
-    discrete_state->get_mutable_vector(0).SetFromVector(A_ * x + B0_ * u0 +
-                                                        B1_ * u1);
+    discrete_state->set_value(0, A_ * x + B0_ * u0 + B1_ * u1);
   }
 
   void CalcOutput0(const Context<T>& context, BasicVector<T>* output) const {

--- a/systems/primitives/zero_order_hold.cc
+++ b/systems/primitives/zero_order_hold.cc
@@ -48,8 +48,7 @@ void ZeroOrderHold<T>::LatchInputVectorToState(
     DiscreteValues<T>* discrete_state) const {
   DRAKE_ASSERT(!is_abstract());
   const auto& input = this->get_input_port().Eval(context);
-  BasicVector<T>& state_value = discrete_state->get_mutable_vector(0);
-  state_value.SetFromVector(input);
+  discrete_state->set_value(0, input);
 }
 
 template <typename T>

--- a/systems/trajectory_optimization/test/direct_transcription_test.cc
+++ b/systems/trajectory_optimization/test/direct_transcription_test.cc
@@ -58,8 +58,8 @@ class CubicPolynomialSystem final : public systems::LeafSystem<T> {
       const std::vector<const DiscreteUpdateEvent<T>*>&,
       DiscreteValues<T>* discrete_state) const final {
     using std::pow;
-    discrete_state->get_mutable_vector(0).SetAtIndex(
-        0, pow(context.get_discrete_state(0).GetAtIndex(0), 3.0));
+    (*discrete_state)[0] =
+        pow(context.get_discrete_state(0).GetAtIndex(0), 3.0);
   }
 
   const double timestep_{0.0};
@@ -89,9 +89,8 @@ class LinearSystemWParams final : public systems::LeafSystem<T> {
       const Context<T>& context,
       const std::vector<const DiscreteUpdateEvent<T>*>&,
       DiscreteValues<T>* discrete_state) const final {
-    discrete_state->get_mutable_vector(0).SetAtIndex(
-        0, context.get_numeric_parameter(0).GetAtIndex(0) *
-               context.get_discrete_state(0).GetAtIndex(0));
+    (*discrete_state)[0] = context.get_numeric_parameter(0).GetAtIndex(0) *
+                           context.get_discrete_state(0).GetAtIndex(0);
   }
 };
 


### PR DESCRIPTION
Related to #9171

Removes one level of indirection required in writing a discrete variable update method.  Now one can set/get the Eigen::VectorX directly, without having to use `discrete_values->get_vector()->set_value(...)`, etc. 

Importantly, this also makes it possible to do more things without having to ever think about `BasicVector`.

I've included a second commit applying this sugar throughout the codebase.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15539)
<!-- Reviewable:end -->
