### PR TITLE
[parsing] Require exactly one model or world

### DIFF
--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -1304,21 +1304,18 @@ std::vector<ModelInstanceIndex> AddModelsFromSdf(
 
   std::string root_dir = LoadSdf(&root, data_source, parser_config);
 
-  // Throw an error if there are no models or worlds.
-  if (root.Model() == nullptr && root.WorldCount() == 0) {
-    throw std::runtime_error(
-        "File must have at least one <model>, or <world> with one "
-        "child <model> element.");
-  }
-
-  // Only one world in an SDF file is allowed.
-  if (root.WorldCount() > 1) {
-    throw std::runtime_error("File must contain only one <world>.");
-  }
-
-  // Do not allow a <world> to have a <model> sibling.
-  if (root.Model() != nullptr && root.WorldCount() > 0) {
-    throw std::runtime_error("A <world> and <model> cannot be siblings.");
+  // There either must be exactly one model, or exactly one world.
+  // TODO(jwnimmer-tri) When we upgrade to a version of libsdformat that no
+  // longer offers ModelCount(), use 'Model() != nullptr ? 1 : 0' here.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  const uint64_t model_count = root.ModelCount();
+#pragma GCC diagnostic pop
+  const uint64_t world_count = root.WorldCount();
+  if ((model_count + world_count) != 1) {
+    throw std::runtime_error(fmt::format(
+        "File must have exactly one <model> or exactly one <world>, but"
+        " instead has {} models and {} worlds", model_count, world_count));
   }
 
   if (scene_graph != nullptr && !plant->geometry_source_is_registered()) {
@@ -1329,41 +1326,26 @@ std::vector<ModelInstanceIndex> AddModelsFromSdf(
 
   // At this point there should be only Models or a single World at the Root
   // level.
-  if (root.Model() != nullptr) {
-    // Load all the models at the root level.
-    // TODO(jwnimmer-tri) When we upgrade to a version of libsdformat that no
-    // longer offers ModelCount(), we should simplify this entire block by
-    // removing the for-each-model loop, instead just using the root.Model().
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    const uint64_t model_count = root.ModelCount();
-#pragma GCC diagnostic pop
-    if (model_count != 1) {
-      static const logging::Warn log_once(
-        "The feature to load multiple models from a single SDFormat model file "
-        "in Drake is deprecated, and will be removed on or around 2021-08-01. "
-        "If you need multiple root-level models, please use an SDFormat world "
-        "file.");
-    }
-    for (uint64_t i = 0; i < model_count; ++i) {
-      // Get the model.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-      const sdf::Model& model = *root.ModelByIndex(i);
-#pragma GCC diagnostic pop
-      // //sdf/model/pose/@relative_to is invalid. Note, libsdformat should emit
-      // an error during Load, but currently doesn't. See sdformat#567
-      ThrowIfPoseFrameSpecified(model.Element());
+  if (model_count > 0) {
+    DRAKE_DEMAND(model_count == 1);
+    DRAKE_DEMAND(world_count == 0);
+    DRAKE_DEMAND(root.Model() != nullptr);
+    const sdf::Model& model = *root.Model();
 
-      std::vector<ModelInstanceIndex> added_model_instances =
-          AddModelsFromSpecification(model, model.Name(), {}, plant,
-                                     package_map, root_dir);
-      model_instances.insert(model_instances.end(),
-                             added_model_instances.begin(),
-                             added_model_instances.end());
-    }
+    // //sdf/model/pose/@relative_to is invalid. Note, libsdformat should emit
+    // an error during Load, but currently doesn't. See sdformat#567
+    ThrowIfPoseFrameSpecified(model.Element());
+
+    std::vector<ModelInstanceIndex> added_model_instances =
+        AddModelsFromSpecification(model, model.Name(), {}, plant,
+                                   package_map, root_dir);
+    model_instances.insert(model_instances.end(),
+                           added_model_instances.begin(),
+                           added_model_instances.end());
   } else {
-    // Load the world and all the models in the world.
+    DRAKE_DEMAND(model_count == 0);
+    DRAKE_DEMAND(world_count == 1);
+    DRAKE_DEMAND(root.WorldByIndex(0) != nullptr);
     const sdf::World& world = *root.WorldByIndex(0);
 
     // TODO(eric.cousineau): Either support or explicitly prevent adding joints

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -1109,17 +1109,16 @@ GTEST_TEST(SdfParser, TestSdformatParserPolicies) {
       R"([\s\S]*XML Attribute\[bad_attribute\] in element\[model\] not )"
       R"(defined in SDF.[\s\S]*)");
 
-  // TODO(#15018): This currently only emits a Drake-log deprecation warning.
-  // We should handle this more directly in the future, ideally via
-  // libsdformat's policies.
-  ParseTestString(R"""(
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      ParseTestString(R"""(
 <model name='model_with_too_many_top_level_elements'>
   <link name='a'/>
 </model>
 <model name='two_models_too_many'>
   <link name='b'/>
 </model>
-)""");
+)"""),
+    ".*has 2 models and 0 worlds.*");
 
   // TODO(#15018): Have this be a printed warning, and then make this an error.
   ParseTestString(R"""(

--- a/multibody/parsing/test/parser_test.cc
+++ b/multibody/parsing/test/parser_test.cc
@@ -81,14 +81,19 @@ GTEST_TEST(FileParserTest, BasicStringTest) {
   }
 }
 
-GTEST_TEST(FileParserTest, MultiModelTest) {
+// Try loading a file with two <model> elements, but without a <world>.
+// This should always result in an error. For an example of a valid <world>
+// with two <model> elements, refer to MultiModelViaWorldIncludesTest.
+GTEST_TEST(FileParserTest, MultiModelErrorsTest) {
   const std::string sdf_name = FindResourceOrThrow(
       "drake/multibody/parsing/test/sdf_parser_test/two_models.sdf");
 
-  // Check that the plural method loads two models.
+  // Check the plural method.
   {
     MultibodyPlant<double> plant(0.0);
-    EXPECT_EQ(Parser(&plant).AddAllModelsFromFile(sdf_name).size(), 2);
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        Parser(&plant).AddAllModelsFromFile(sdf_name),
+        ".*has 2 models and 0 worlds.*");
   }
 
   // The singular method cannot load a two-model file.


### PR DESCRIPTION
The previous behavior of allowing for multiple models was deprecated, and is now removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15540)
<!-- Reviewable:end -->
