### PR TITLE
[fem] Make fem indexes follow TypeSafeIndex convention

### DIFF
--- a/multibody/fixed_fem/dev/fem_indexes.h
+++ b/multibody/fixed_fem/dev/fem_indexes.h
@@ -15,7 +15,7 @@ using NodeIndex = TypeSafeIndex<class NodeTag>;
 using DofIndex = TypeSafeIndex<class DofTag>;
 
 /** Index into a vector of deformable bodies. */
-using DeformableBodyIndex = TypeSafeIndex<class BodyTag>;
+using DeformableBodyIndex = TypeSafeIndex<class DeformableBodyTag>;
 }  // namespace fem
 }  // namespace multibody
 }  // namespace drake


### PR DESCRIPTION
Fix the bug that the index aliased by `DeformableBodyIndex` doesn't follow the convention and the resulting index has the same type as the one aliased by "multibody::internal::BodyIndex".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15542)
<!-- Reviewable:end -->
