### PR TITLE
[geometry/optimization] MinkowskiSum isa ConvexSet

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -22,6 +22,7 @@
 #include "drake/geometry/optimization/hpolyhedron.h"
 #include "drake/geometry/optimization/hyperellipsoid.h"
 #include "drake/geometry/optimization/iris.h"
+#include "drake/geometry/optimization/minkowski_sum.h"
 #include "drake/geometry/optimization/point.h"
 #include "drake/geometry/optimization/vpolytope.h"
 #include "drake/geometry/proximity/obj_to_surface_mesh.h"
@@ -1444,6 +1445,23 @@ void def_geometry_optimization(py::module m) {
             py::arg("dim"), cls_doc.MakeUnitBall.doc);
     py::implicitly_convertible<Hyperellipsoid,
         copyable_unique_ptr<ConvexSet>>();
+  }
+
+  {
+    const auto& cls_doc = doc.MinkowskiSum;
+    py::class_<MinkowskiSum, ConvexSet>(m, "MinkowskiSum", cls_doc.doc)
+        .def(py::init<const ConvexSets&>(), py::arg("sets"),
+            cls_doc.ctor.doc_1args)
+        .def(py::init<const ConvexSet&, const ConvexSet&>(), py::arg("setA"),
+            py::arg("setB"), cls_doc.ctor.doc_2args)
+        .def(py::init<const QueryObject<double>&, GeometryId,
+                 std::optional<FrameId>>(),
+            py::arg("query_object"), py::arg("geometry_id"),
+            py::arg("reference_frame") = std::nullopt, cls_doc.ctor.doc_3args)
+        .def("num_terms", &MinkowskiSum::num_terms, cls_doc.num_terms.doc)
+        .def("term", &MinkowskiSum::term, py_rvp::reference_internal,
+            py::arg("index"), cls_doc.term.doc);
+    py::implicitly_convertible<MinkowskiSum, copyable_unique_ptr<ConvexSet>>();
   }
 
   {

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -992,6 +992,15 @@ class TestGeometry(unittest.TestCase):
         np.testing.assert_array_equal(e_ball3.A(), A)
         np.testing.assert_array_equal(e_ball3.center(), [0, 0, 0])
 
+        # Test MinkowskiSum.
+        sum = mut.optimization.MinkowskiSum(setA=point, setB=hpoly)
+        self.assertEqual(sum.ambient_dimension(), 3)
+        self.assertEqual(sum.num_terms(), 2)
+        sum2 = mut.optimization.MinkowskiSum(sets=[point, hpoly])
+        self.assertEqual(sum2.ambient_dimension(), 3)
+        self.assertEqual(sum2.num_terms(), 2)
+        self.assertIsInstance(sum2.term(0), mut.optimization.Point)
+
         # Test VPolytope.
         vertices = np.array([[0.0, 1.0, 2.0], [3.0, 7.0, 5.0]])
         vpoly = mut.optimization.VPolytope(vertices=vertices)
@@ -1024,6 +1033,12 @@ class TestGeometry(unittest.TestCase):
             source_id=source_id, frame_id=frame_id,
             geometry=mut.GeometryInstance(X_PG=RigidTransform(),
                                           shape=mut.Sphere(1.), name="sphere"))
+        capsule_geometry_id = scene_graph.RegisterGeometry(
+            source_id=source_id,
+            frame_id=frame_id,
+            geometry=mut.GeometryInstance(X_PG=RigidTransform(),
+                                          shape=mut.Capsule(1., 1.0),
+                                          name="capsule"))
         context = scene_graph.CreateDefaultContext()
         pose_vector = mut.FramePoseVector()
         pose_vector.set_value(frame_id, RigidTransform())
@@ -1038,6 +1053,10 @@ class TestGeometry(unittest.TestCase):
             query_object=query_object, geometry_id=sphere_geometry_id,
             reference_frame=scene_graph.world_frame_id())
         self.assertEqual(E.ambient_dimension(), 3)
+        S = mut.optimization.MinkowskiSum(
+            query_object=query_object, geometry_id=capsule_geometry_id,
+            reference_frame=scene_graph.world_frame_id())
+        self.assertEqual(S.ambient_dimension(), 3)
         P = mut.optimization.Point(
             query_object=query_object, geometry_id=sphere_geometry_id,
             reference_frame=scene_graph.world_frame_id(),

--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -26,6 +26,7 @@ drake_cc_library(
         "convex_set.cc",
         "hpolyhedron.cc",
         "hyperellipsoid.cc",
+        "minkowski_sum.cc",
         "point.cc",
         "vpolytope.cc",
     ],
@@ -33,6 +34,7 @@ drake_cc_library(
         "convex_set.h",
         "hpolyhedron.h",
         "hyperellipsoid.h",
+        "minkowski_sum.h",
         "point.h",
         "vpolytope.h",
     ],
@@ -122,6 +124,15 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//multibody/parsing:parser",
         "//systems/framework:diagram_builder",
+    ],
+)
+
+drake_cc_googletest(
+    name = "minkowski_sum_test",
+    deps = [
+        ":convex_set",
+        ":test_utilities",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/geometry/optimization/iris.cc
+++ b/geometry/optimization/iris.cc
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "drake/geometry/optimization/convex_set.h"
+#include "drake/geometry/optimization/minkowski_sum.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/solvers/choose_best_solver.h"
 #include "drake/solvers/ipopt_solver.h"
@@ -143,6 +144,12 @@ class IrisConvexSetMaker final : public ShapeReifier {
     // programming" instance from CVXGEN that exploited the VPolytope
     // representation.  So we may wish to revisit this.
     set = std::make_unique<HPolyhedron>(query_, geom_id_, reference_frame_);
+  }
+
+  void ImplementGeometry(const Capsule&, void* data) {
+    DRAKE_DEMAND(geom_id_.is_valid());
+    auto& set = *static_cast<copyable_unique_ptr<ConvexSet>*>(data);
+    set = std::make_unique<MinkowskiSum>(query_, geom_id_, reference_frame_);
   }
 
   void ImplementGeometry(const Ellipsoid&, void* data) {

--- a/geometry/optimization/minkowski_sum.cc
+++ b/geometry/optimization/minkowski_sum.cc
@@ -1,0 +1,167 @@
+#include "drake/geometry/optimization/minkowski_sum.h"
+
+#include <memory>
+
+#include <fmt/format.h>
+
+#include "drake/common/copyable_unique_ptr.h"
+#include "drake/geometry/optimization/hpolyhedron.h"
+#include "drake/geometry/optimization/hyperellipsoid.h"
+#include "drake/solvers/mathematical_program.h"
+#include "drake/solvers/solve.h"
+
+namespace drake {
+namespace geometry {
+namespace optimization {
+
+using Eigen::RowVectorXd;
+using Eigen::Vector3d;
+using Eigen::VectorXd;
+using math::RigidTransformd;
+using solvers::Binding;
+using solvers::Constraint;
+using solvers::MathematicalProgram;
+using solvers::Solve;
+using solvers::VectorXDecisionVariable;
+using symbolic::Variable;
+
+MinkowskiSum::MinkowskiSum(const ConvexSets& sets)
+    : ConvexSet(&ConvexSetCloner<MinkowskiSum>,
+                sets.size() > 0 ? sets[0]->ambient_dimension() : 0),
+      sets_(sets) {
+  for (int i = 1; i < static_cast<int>(sets_.size()); ++i) {
+    DRAKE_DEMAND(sets_[i]->ambient_dimension() ==
+                 sets_[0]->ambient_dimension());
+  }
+}
+
+MinkowskiSum::MinkowskiSum(const ConvexSet& setA, const ConvexSet& setB)
+    : ConvexSet(&ConvexSetCloner<MinkowskiSum>, setA.ambient_dimension()) {
+  DRAKE_DEMAND(setB.ambient_dimension() == setA.ambient_dimension());
+  sets_.emplace_back(setA.Clone());
+  sets_.emplace_back(setB.Clone());
+}
+
+MinkowskiSum::MinkowskiSum(const QueryObject<double>& query_object,
+                           GeometryId geometry_id,
+                           std::optional<FrameId> reference_frame)
+    : ConvexSet(&ConvexSetCloner<MinkowskiSum>, 3) {
+  Capsule capsule(1., 1.);
+  query_object.inspector().GetShape(geometry_id).Reify(this, &capsule);
+
+  // Sphere at zero.
+  sets_.emplace_back(
+      Hyperellipsoid::MakeHypersphere(capsule.radius(), Vector3d::Zero())
+          .Clone());
+
+  const RigidTransformd X_WF =
+      reference_frame ? query_object.GetPoseInWorld(*reference_frame)
+                      : RigidTransformd::Identity();
+  const RigidTransformd& X_WG = query_object.GetPoseInWorld(geometry_id);
+  const RigidTransformd X_GF = X_WG.InvertAndCompose(X_WF);
+
+  // Line segment as a HPolyhedron (the VPolytope would be easier here, but
+  // HPolyhedron is nicer for most of the computations).
+  HPolyhedron H_G =
+      HPolyhedron::MakeBox(Vector3d{0, 0, -capsule.length() / 2.0},
+                           Vector3d{0, 0, capsule.length() / 2.0});
+  // A_G*(p_GF + R_GF*p_FF_var) ≤ b_G
+  sets_.emplace_back(
+      std::make_unique<HPolyhedron>(H_G.A() * X_GF.rotation().matrix(),
+                                    H_G.b() - H_G.A() * X_GF.translation()));
+}
+
+MinkowskiSum::~MinkowskiSum() = default;
+
+const ConvexSet& MinkowskiSum::term(int index) const {
+  DRAKE_DEMAND(0 <= index && index < static_cast<int>(sets_.size()));
+  return *sets_[index];
+}
+
+bool MinkowskiSum::DoIsBounded() const {
+  for (const auto& s : sets_) {
+    if (!s->IsBounded()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool MinkowskiSum::DoPointInSet(const Eigen::Ref<const Eigen::VectorXd>& x,
+                                double) const {
+  // TODO(russt): Figure out if there is a general way to communicate tol
+  // to/through the solver.
+  MathematicalProgram prog;
+  auto X = prog.NewContinuousVariables(ambient_dimension(), num_terms(), "x");
+  const VectorXd ones = VectorXd::Ones(num_terms());
+  for (int i = 0; i < ambient_dimension(); ++i) {
+    // ∑ⱼ xⱼ[i] = x[i]
+    prog.AddLinearEqualityConstraint(ones, x[i], X.row(i).transpose());
+  }
+  for (int j = 0; j < num_terms(); ++j) {
+    sets_[j]->AddPointInSetConstraints(&prog, X.col(j));
+  }
+  auto result = Solve(prog);
+  return result.is_success();
+}
+
+void MinkowskiSum::DoAddPointInSetConstraints(
+    MathematicalProgram* prog,
+    const Eigen::Ref<const VectorXDecisionVariable>& x) const {
+  auto X = prog->NewContinuousVariables(ambient_dimension(), num_terms(), "x");
+  RowVectorXd a = RowVectorXd::Ones(num_terms() + 1);
+  a[0] = -1;
+  for (int i = 0; i < ambient_dimension(); ++i) {
+    // ∑ⱼ xⱼ[i] = x[i]
+    prog->AddLinearEqualityConstraint(
+        a, 0.0, {Vector1<Variable>(x[i]), X.row(i).transpose()});
+  }
+  for (int j = 0; j < num_terms(); ++j) {
+    sets_[j]->AddPointInSetConstraints(prog, X.col(j));
+  }
+}
+
+std::vector<Binding<Constraint>>
+MinkowskiSum::DoAddPointInNonnegativeScalingConstraints(
+    MathematicalProgram* prog,
+    const Eigen::Ref<const VectorXDecisionVariable>& x,
+    const symbolic::Variable& t) const {
+  // We add the constraint
+  //   x in t (S1 ⨁ ... ⨁ Sn)
+  // by enforcing
+  //   x in t S1 ⨁ ... ⨁ t Sn.
+  // This can be done because t is nonnegative and S1,..., Sn are convex.
+  std::vector<Binding<Constraint>> constraints;
+  auto X = prog->NewContinuousVariables(ambient_dimension(), num_terms(), "x");
+  RowVectorXd a = RowVectorXd::Ones(num_terms() + 1);
+  a[0] = -1;
+  for (int i = 0; i < ambient_dimension(); ++i) {
+    // ∑ⱼ xⱼ[i] = x[i]
+    constraints.emplace_back(prog->AddLinearEqualityConstraint(
+        a, 0.0, {Vector1<Variable>(x[i]), X.row(i).transpose()}));
+  }
+  for (int j = 0; j < num_terms(); ++j) {
+    auto new_constraints =
+        sets_[j]->AddPointInNonnegativeScalingConstraints(prog, X.col(j), t);
+    constraints.insert(constraints.end(),
+                       std::make_move_iterator(new_constraints.begin()),
+                       std::make_move_iterator(new_constraints.end()));
+  }
+  return constraints;
+}
+
+std::pair<std::unique_ptr<Shape>, math::RigidTransformd>
+MinkowskiSum::DoToShapeWithPose() const {
+  // TODO(russt): Consider handling Capsule as a (very) special case.
+  throw std::runtime_error(
+      "ToShapeWithPose is not implemented yet for MinkowskiSum.");
+}
+
+void MinkowskiSum::ImplementGeometry(const Capsule& capsule, void* data) {
+  Capsule* c = static_cast<Capsule*>(data);
+  *c = capsule;
+}
+
+}  // namespace optimization
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/optimization/minkowski_sum.h
+++ b/geometry/optimization/minkowski_sum.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "drake/geometry/optimization/convex_set.h"
+#include "drake/geometry/optimization/point.h"
+
+namespace drake {
+namespace geometry {
+namespace optimization {
+
+/** A convex set that represents the Minkowski sum of multiple sets:
+S = X₁ ⨁ X₂ ⨁ ... ⨁ Xₙ =
+    {x₁ + x₂ + ... + xₙ | x₁ ∈ X₁, x₂ ∈ X, ..., xₙ ∈ Xₙ}
+
+@ingroup geometry_optimization
+*/
+class MinkowskiSum final : public ConvexSet {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(MinkowskiSum)
+
+  /** Constructs the sum from a vector of convex sets. */
+  explicit MinkowskiSum(const ConvexSets& sets);
+
+  /** Constructs the sum from a pair of convex sets. */
+  MinkowskiSum(const ConvexSet& setA, const ConvexSet& setB);
+
+  /** Constructs a MinkowskiSum from a SceneGraph geometry and pose in
+  the @p reference_frame frame, obtained via the QueryObject. If @p
+  reference_frame frame is std::nullopt, then it will be expressed in the world
+  frame.
+
+  Although in principle a MinkowskiSum can represent any ConvexSet as the sum of
+  a single set, here we only support Capsule geometry, which will be represented
+  as the (non-trivial) Minkowski sum of a sphere with a line segment.  Most
+  SceneGraph geometry types are supported by at least one of the ConvexSet class
+  constructors.
+
+  @throws std::exception if geometry_id does not correspond to a Capsule. */
+  MinkowskiSum(const QueryObject<double>& query_object, GeometryId geometry_id,
+               std::optional<FrameId> reference_frame = std::nullopt);
+
+  ~MinkowskiSum() final;
+
+  /** The number of terms (or sets) used in the sum. */
+  int num_terms() const { return sets_.size(); }
+
+  /** Returns a reference to the ConvexSet defining the @p index term in the
+  sum. */
+  const ConvexSet& term(int index) const;
+
+  /** Returns true if the point is in the set.
+
+  Note: This requires the solution of a convex program; the @p tol parameter is
+  currently ignored, and the solver tolerance is used instead.
+  @see ConvexSet::set_solver
+  */
+  using ConvexSet::PointInSet;
+
+ private:
+  bool DoIsBounded() const final;
+
+  bool DoPointInSet(const Eigen::Ref<const Eigen::VectorXd>& x,
+                    double tol) const final;
+
+  void DoAddPointInSetConstraints(
+      solvers::MathematicalProgram*,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>&) const final;
+
+  std::vector<solvers::Binding<solvers::Constraint>>
+  DoAddPointInNonnegativeScalingConstraints(
+      solvers::MathematicalProgram* prog,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>& x,
+      const symbolic::Variable& t) const final;
+
+  std::pair<std::unique_ptr<Shape>, math::RigidTransformd> DoToShapeWithPose()
+      const final;
+
+  // Implement support shapes for the ShapeReifier interface.
+  using ShapeReifier::ImplementGeometry;
+  void ImplementGeometry(const Capsule& capsule, void* data) final;
+
+  ConvexSets sets_{};  // Not marked const to support move semantics.
+};
+
+}  // namespace optimization
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/optimization/test/minkowski_sum_test.cc
+++ b/geometry/optimization/test/minkowski_sum_test.cc
@@ -1,0 +1,170 @@
+#include "drake/geometry/optimization/minkowski_sum.h"
+
+#include <limits>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/copyable_unique_ptr.h"
+#include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/geometry/geometry_frame.h"
+#include "drake/geometry/optimization/hpolyhedron.h"
+#include "drake/geometry/optimization/point.h"
+#include "drake/geometry/optimization/test_utilities.h"
+#include "drake/geometry/optimization/vpolytope.h"
+#include "drake/geometry/scene_graph.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/solvers/solve.h"
+
+namespace drake {
+namespace geometry {
+namespace optimization {
+
+using Eigen::Matrix;
+using Eigen::Vector2d;
+using Eigen::Vector3d;
+using math::RigidTransformd;
+
+GTEST_TEST(MinkowskiSumTest, BasicTest) {
+  const Point P1(Vector2d{1.2, 3.4}), P2(Vector2d{5.6, 7.8});
+  const MinkowskiSum S(P1, P2);
+  EXPECT_EQ(S.num_terms(), 2);
+  EXPECT_EQ(S.ambient_dimension(), 2);
+
+  // Test PointInSet.
+  Vector2d in{P1.x() + P2.x()}, out{P1.x() + P2.x() + Vector2d::Constant(0.01)};
+  EXPECT_TRUE(S.PointInSet(in));
+  EXPECT_FALSE(S.PointInSet(out));
+
+  EXPECT_TRUE(internal::CheckAddPointInSetConstraints(S, in));
+  EXPECT_FALSE(internal::CheckAddPointInSetConstraints(S, out));
+
+  // Test IsBounded.
+  EXPECT_TRUE(S.IsBounded());
+
+  // Test ConvexSets constructor.
+  ConvexSets sets;
+  sets.emplace_back(P1);
+  sets.emplace_back(P2);
+  const MinkowskiSum S2(sets);
+  EXPECT_EQ(S2.num_terms(), 2);
+  EXPECT_EQ(S2.ambient_dimension(), 2);
+  EXPECT_TRUE(S2.PointInSet(in));
+  EXPECT_FALSE(S2.PointInSet(out));
+}
+
+GTEST_TEST(MinkowskiSumTest, FromSceneGraph) {
+  const RigidTransformd X_WG{math::RollPitchYawd(.1, .2, 3),
+                             Vector3d{.5, .87, .1}};
+
+  // Test SceneGraph constructor.
+  const double kRadius = 0.2;
+  const double kLength = 0.5;
+  auto [scene_graph, geom_id] =
+      internal::MakeSceneGraphWithShape(Capsule(kRadius, kLength), X_WG);
+  auto context = scene_graph->CreateDefaultContext();
+  auto query =
+      scene_graph->get_query_output_port().Eval<QueryObject<double>>(*context);
+
+  MinkowskiSum S(query, geom_id, std::nullopt);
+  Matrix<double, 3, 4> in_G, out_G;
+  // clang-format off
+  in_G << 0, 0,                    kRadius,     kRadius/std::sqrt(2.0),
+          0, 0,                    0,           kRadius/std::sqrt(2.0),
+          0, kRadius+kLength/2.0, -kLength/2.0, kLength/2.0;
+  out_G << kRadius+.01, 0,          kRadius,     kRadius/std::sqrt(2.0),
+           0, 0,                    0,           kRadius/std::sqrt(2.0),
+           0, kRadius+kLength/2.0+.01, -kLength/2.0-.01, kLength/2.0+.01;
+  // clang-format on
+  const Matrix<double, 3, 4> in_W = X_WG * in_G, out_W = X_WG * out_G;
+  const double kTol = 1e-14;
+  for (int i = 0; i < 4; ++i) {
+    EXPECT_LE(query.ComputeSignedDistanceToPoint(in_W.col(i))[0].distance,
+              kTol);
+    EXPECT_GE(query.ComputeSignedDistanceToPoint(out_W.col(i))[0].distance,
+              -kTol);
+
+    EXPECT_TRUE(S.PointInSet(in_W.col(i)));
+    EXPECT_FALSE(S.PointInSet(out_W.col(i)));
+  }
+
+  // Test reference_frame frame.
+  SourceId source_id = scene_graph->RegisterSource("F");
+  FrameId frame_id = scene_graph->RegisterFrame(source_id, GeometryFrame("F"));
+  auto context2 = scene_graph->CreateDefaultContext();
+  const RigidTransformd X_WF{math::RollPitchYawd(.5, .26, -3),
+                             Vector3d{.9, -2., .12}};
+  const FramePoseVector<double> pose_vector{{frame_id, X_WF}};
+  scene_graph->get_source_pose_port(source_id).FixValue(context2.get(),
+                                                        pose_vector);
+  auto query2 =
+      scene_graph->get_query_output_port().Eval<QueryObject<double>>(*context2);
+  MinkowskiSum S2(query2, geom_id, frame_id);
+
+  const RigidTransformd X_FW = X_WF.inverse();
+  const Matrix<double, 3, 4> in_F = X_FW * in_W, out_F = X_FW * out_W;
+  for (int i = 0; i < 4; ++i) {
+    EXPECT_TRUE(S2.PointInSet(in_F.col(i)));
+    EXPECT_FALSE(S2.PointInSet(out_F.col(i)));
+  }
+}
+
+GTEST_TEST(MinkowskiSumTest, TwoBoxes) {
+  HPolyhedron H = HPolyhedron::MakeBox(Vector2d{1, 1}, Vector2d{2, 2});
+  VPolytope V = VPolytope::MakeBox(Vector2d{-2, 2}, Vector2d{0, 4});
+  MinkowskiSum S(H, V);
+  EXPECT_TRUE(S.PointInSet(Vector2d{-1, 3}));
+  EXPECT_FALSE(S.PointInSet(Vector2d{-1, 2.9}));
+  EXPECT_FALSE(S.PointInSet(Vector2d{-1.01, 3}));
+}
+
+GTEST_TEST(MinkowskiSumTest, CloneTest) {
+  const Point P1(Vector2d{1.2, 3.4}), P2(Vector2d{5.6, 7.8});
+  const MinkowskiSum S(P1, P2);
+  std::unique_ptr<ConvexSet> clone = S.Clone();
+  EXPECT_EQ(clone->ambient_dimension(), 2);
+
+  MinkowskiSum* s = dynamic_cast<MinkowskiSum*>(clone.get());
+  ASSERT_NE(s, nullptr);
+  ASSERT_EQ(s->num_terms(), 2);
+  const Point* p = dynamic_cast<const Point*>(&s->term(0));
+  ASSERT_NE(p, nullptr);
+  EXPECT_TRUE(CompareMatrices(P1.x(), p->x()));
+}
+
+bool PointInScaledSet(const solvers::VectorXDecisionVariable& x_vars,
+                      const symbolic::Variable& t_var, const Vector2d& x,
+                      double t, solvers::MathematicalProgram* prog) {
+  auto b1 = prog->AddBoundingBoxConstraint(x, x, x_vars);
+  auto b2 = prog->AddBoundingBoxConstraint(t, t, t_var);
+  auto result = solvers::Solve(*prog);
+  prog->RemoveConstraint(b1);
+  prog->RemoveConstraint(b2);
+  return result.is_success();
+}
+
+GTEST_TEST(MinkowskiSumTest, NonnegativeScalingTest) {
+  const Point P1(Vector2d{1.2, 3.4}), P2(Vector2d{5.6, 7.8});
+  const MinkowskiSum S(P1, P2);
+
+  solvers::MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables(2, "x");
+  auto t = prog.NewContinuousVariables(1, "t")[0];
+
+  std::vector<solvers::Binding<solvers::Constraint>> constraints =
+      S.AddPointInNonnegativeScalingConstraints(&prog, x, t);
+
+  // 1 from P1, 1 from P2, 2 to from S, and t>=0 3 times.
+  EXPECT_EQ(constraints.size(), 7);
+
+  const Vector2d p = P1.x() + P2.x();
+  for (const double scale : {0.5, 1.0, 2.0}) {
+    EXPECT_TRUE(PointInScaledSet(x, t, scale * p, scale, &prog));
+    EXPECT_FALSE(PointInScaledSet(x, t, 0.99 * scale * p, scale, &prog));
+  }
+  EXPECT_FALSE(PointInScaledSet(x, t, p, -1.0, &prog));
+}
+
+}  // namespace optimization
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
Adds the concept of a Minkowski sum of convex sets, which enables geoemtry optimization support for the Capsule geometry in SceneGraph.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15543)
<!-- Reviewable:end -->
