### PR TITLE
[workspace] Upgrade gtest to latest release 1.11.0

### DIFF
--- a/manipulation/models/jaco_description/urdf/test/jaco_arm_test.cc
+++ b/manipulation/models/jaco_description/urdf/test/jaco_arm_test.cc
@@ -1,3 +1,4 @@
+#include <ostream>
 #include <string>
 #include <vector>
 
@@ -16,6 +17,11 @@ struct TestCase {
   int num_actuators{};
   int num_bodies{};
 };
+
+std::ostream& operator<<(std::ostream& os, const TestCase& self) {
+  os << self.urdf << "," << self.num_actuators << "," << self.num_bodies;
+  return os;
+}
 
 class JacoArmParamsTest
     : public ::testing::TestWithParam<TestCase> {};

--- a/multibody/parsing/test/test_loaders.cc
+++ b/multibody/parsing/test/test_loaders.cc
@@ -31,6 +31,21 @@ void LoadFromUrdf(
   parser.AddModelFromFile(urdf_path, "");
 }
 
+std::ostream& operator<<(std::ostream& os, const ModelLoadFunction& func) {
+  const auto* const target = func.target<void(*)(
+      const std::string&,
+      MultibodyPlant<double>*,
+      geometry::SceneGraph<double>*)>();
+  if (target != nullptr && *target == LoadFromSdf) {
+    os << "LoadFromSdf()";
+  } else if (target != nullptr && *target == LoadFromUrdf) {
+    os << "LoadFromUrdf()";
+  } else {
+    os << "unknown ModelLoadFunction";
+  }
+  return os;
+}
+
 }  // namespace test
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/test/test_loaders.h
+++ b/multibody/parsing/test/test_loaders.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ostream>
 #include <functional>
 #include <string>
 
@@ -12,10 +13,13 @@ namespace test {
 
 /// This is a function signature used to parameterize unit tests by which
 /// loading mechanism they use.
-typedef std::function<void(
+class ModelLoadFunction final : public std::function<void(
     const std::string& base_name,
     MultibodyPlant<double>* plant,
-    geometry::SceneGraph<double>* scene_graph)> ModelLoadFunction;
+    geometry::SceneGraph<double>* scene_graph)> {
+  // Inherit the std::function constructors.
+  using function::function;
+};
 
 /// Load the model from an SDF with a resource path stem of @p base_name into
 /// @p plant.
@@ -30,6 +34,8 @@ void LoadFromUrdf(
     const std::string& base_name,
     MultibodyPlant<double>* plant,
     geometry::SceneGraph<double>* scene_graph);
+
+std::ostream& operator<<(std::ostream&, const ModelLoadFunction&);
 
 }  // namespace test
 }  // namespace multibody

--- a/multibody/parsing/test/test_loaders.h
+++ b/multibody/parsing/test/test_loaders.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <ostream>
 #include <functional>
+#include <ostream>
 #include <string>
 
 #include "drake/geometry/scene_graph.h"

--- a/tools/workspace/gtest/dont-define-test-f.patch
+++ b/tools/workspace/gtest/dont-define-test-f.patch
@@ -1,0 +1,23 @@
+Use GTEST_DONT_DEFINE_TEST_F to guard TEST_F
+
+Per the documentation, there should be one like-named toggle per macro,
+they should not share a toggle.
+
+--- googletest/include/gtest/gtest.h	2021-06-11 10:42:26.000000000 -0700
++++ googletest/include/gtest/gtest.h	2021-07-01 10:46:26.275471431 -0700
+@@ -2380,11 +2380,12 @@
+ //   }
+ //
+ // GOOGLETEST_CM0011 DO NOT DELETE
+-#if !GTEST_DONT_DEFINE_TEST
+-#define TEST_F(test_fixture, test_name)\
++#define GTEST_TEST_F(test_fixture, test_name)\
+   GTEST_TEST_(test_fixture, test_name, test_fixture, \
+               ::testing::internal::GetTypeId<test_fixture>())
+-#endif  // !GTEST_DONT_DEFINE_TEST
++#if !GTEST_DONT_DEFINE_TEST_F
++#define TEST_F(test_fixture, test_name) GTEST_TEST_F(test_fixture, test_name)
++#endif  // !GTEST_DONT_DEFINE_TEST_F
+ 
+ // Returns a path to temporary directory.
+ // Tries to determine an appropriate directory for the platform.

--- a/tools/workspace/gtest/dont-define-test-f.patch
+++ b/tools/workspace/gtest/dont-define-test-f.patch
@@ -3,6 +3,8 @@ Use GTEST_DONT_DEFINE_TEST_F to guard TEST_F
 Per the documentation, there should be one like-named toggle per macro,
 they should not share a toggle.
 
+https://github.com/google/googletest/pull/3472
+
 --- googletest/include/gtest/gtest.h	2021-06-11 10:42:26.000000000 -0700
 +++ googletest/include/gtest/gtest.h	2021-07-01 10:46:26.275471431 -0700
 @@ -2380,11 +2380,12 @@

--- a/tools/workspace/gtest/repository.bzl
+++ b/tools/workspace/gtest/repository.bzl
@@ -8,8 +8,11 @@ def gtest_repository(
     github_archive(
         name = name,
         repository = "google/googletest",
-        commit = "release-1.10.0",
-        sha256 = "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb",  # noqa
+        commit = "release-1.11.0",
+        sha256 = "b4870bf121ff7795ba20d20bcdd8627b8e088f2d1dab299a031c1034eddc93d5",  # noqa
         build_file = "@drake//tools/workspace/gtest:package.BUILD.bazel",
+        patches = [
+            "@drake//tools/workspace/gtest:dont-define-test-f.patch",
+        ],
         mirrors = mirrors,
     )


### PR DESCRIPTION
This re-applies #15291, which was previously reverted in #15306.

Fixes as of this new revision:

As of 1.11.0, googletest prints the values in for any value-parameterized test -- even if there is no printer defined, it will now print the raw bytes of the value.  This is a problem during memcheck when the default value contains uninitialized memory (e.g., the SBO buffer in a `std::string` or `std::function`).

We could tell valgrind to ignore gtest printers, but a better answer seems to be defining a proper printer so that `--gtest_list_tests` shows something useful, instead of hex dumps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15544)
<!-- Reviewable:end -->
