### PR TITLE
draft experimental [geometry] Make pictures of triangle-tetrahedron intersection into a heptagon with pressure field.

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -925,6 +925,7 @@ drake_cc_googletest(
     name = "mesh_intersection_test",
     deps = [
         ":mesh_intersection",
+        ":mesh_to_vtk",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
         "//math:autodiff",

--- a/geometry/proximity/mesh_intersection.cc
+++ b/geometry/proximity/mesh_intersection.cc
@@ -395,7 +395,8 @@ void SurfaceVolumeIntersector<T>::SampleVolumeFieldOnSurface(
       std::move(surface_faces), std::move(surface_vertices_M));
   const bool calculate_gradient = false;
   *e_MN = std::make_unique<SurfaceMeshFieldLinear<T, T>>(
-      "e", std::move(surface_e), surface_MN_M->get(), calculate_gradient);
+      volume_field_M.name(), std::move(surface_e), surface_MN_M->get(),
+      calculate_gradient);
 }
 
 template <typename T>

--- a/geometry/proximity/mesh_plane_intersection.cc
+++ b/geometry/proximity/mesh_plane_intersection.cc
@@ -208,7 +208,7 @@ std::unique_ptr<ContactSurface<T>> ComputeContactSurface(
   auto mesh_W =
       std::make_unique<SurfaceMesh<T>>(std::move(faces), std::move(vertices_W));
   auto field_W = std::make_unique<SurfaceMeshFieldLinear<T, T>>(
-      "pressure", std::move(surface_e), mesh_W.get(),
+      mesh_field_M.name(), std::move(surface_e), mesh_W.get(),
       false /* calculate_gradient */);
   // SliceTetWithPlane promises to make the surface normals point in the plane
   // normal direction (i.e., out of the plane and into the mesh).


### PR DESCRIPTION
This is an experimental work to create pictures of rigid-compliant contact surfaces for discrete hydroelastics paper.

There is no intention to merge into master.

Remove this PR after we finish writing the discrete hydroelastics paper.

![image](https://user-images.githubusercontent.com/42557859/127911397-c754fcbe-721d-4bd3-ad20-b3491499856e.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15546)
<!-- Reviewable:end -->
