### PR TITLE
LorentzConeConstraint exposes eval_type

### DIFF
--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -1650,7 +1650,11 @@ void BindEvaluatorsAndBindings(py::module m) {
           py::arg("eval_type") = LorentzConeConstraint::EvalType::kConvexSmooth,
           doc.LorentzConeConstraint.ctor.doc)
       .def("A", &LorentzConeConstraint::A, doc.LorentzConeConstraint.A.doc)
-      .def("b", &LorentzConeConstraint::b, doc.LorentzConeConstraint.b.doc);
+      .def("b", &LorentzConeConstraint::b, doc.LorentzConeConstraint.b.doc)
+      .def("eval_type", &LorentzConeConstraint::eval_type,
+          doc.LorentzConeConstraint.eval_type.doc)
+      .def("set_eval_type", &LorentzConeConstraint::set_eval_type,
+          py::arg("eval_type"), doc.LorentzConeConstraint.set_eval_type.doc);
 
   py::class_<RotatedLorentzConeConstraint, Constraint,
       std::shared_ptr<RotatedLorentzConeConstraint>>(

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -1099,6 +1099,13 @@ class TestMathematicalProgram(unittest.TestCase):
             eval_type=mp.LorentzConeConstraint.EvalType.kConvexSmooth)
         np.testing.assert_array_equal(constraint.A().todense(), A)
         np.testing.assert_array_equal(constraint.b(), b)
+        self.assertEqual(
+            constraint.eval_type(),
+            mp.LorentzConeConstraint.EvalType.kConvexSmooth)
+        constraint.set_eval_type(
+            eval_type=mp.LorentzConeConstraint.EvalType.kConvex)
+        self.assertEqual(
+            constraint.eval_type(), mp.LorentzConeConstraint.EvalType.kConvex)
 
     def test_add_lorentz_cone_constraint(self):
         # Call AddLorentzConeConstraint, make sure no error is thrown.

--- a/solvers/constraint.h
+++ b/solvers/constraint.h
@@ -323,6 +323,10 @@ class LorentzConeConstraint : public Constraint {
 
   ~LorentzConeConstraint() override {}
 
+  EvalType eval_type() const { return eval_type_; }
+
+  void set_eval_type(EvalType eval_type) { eval_type_ = eval_type; }
+
   /** Getter for A. */
   const Eigen::SparseMatrix<double>& A() const { return A_; }
 
@@ -354,7 +358,7 @@ class LorentzConeConstraint : public Constraint {
   // using AutoDiffXd, and return the gradient as a dense matrix.
   const Eigen::MatrixXd A_dense_;
   const Eigen::VectorXd b_;
-  const EvalType eval_type_;
+  EvalType eval_type_;
 };
 
 /**

--- a/solvers/test/constraint_test.cc
+++ b/solvers/test/constraint_test.cc
@@ -144,6 +144,8 @@ void TestLorentzConeEvalConvex(const Eigen::Ref<const Eigen::MatrixXd>& A,
   LorentzConeConstraint cnstr1(A, b, LorentzConeConstraint::EvalType::kConvex);
   LorentzConeConstraint cnstr2(A, b,
                                LorentzConeConstraint::EvalType::kConvexSmooth);
+  EXPECT_EQ(cnstr1.eval_type(), LorentzConeConstraint::EvalType::kConvex);
+  EXPECT_EQ(cnstr2.eval_type(), LorentzConeConstraint::EvalType::kConvexSmooth);
   EXPECT_EQ(cnstr1.num_constraints(), 1);
   EXPECT_EQ(cnstr2.num_constraints(), 1);
   EXPECT_TRUE(CompareMatrices(cnstr1.lower_bound(), Vector1d(0)));
@@ -184,6 +186,9 @@ void TestLorentzConeEvalConvex(const Eigen::Ref<const Eigen::MatrixXd>& A,
   EXPECT_TRUE(CompareMatrices(math::autoDiffToGradientMatrix(y_autodiff1),
                               math::autoDiffToGradientMatrix(y_autodiff2),
                               2e-12));
+
+  cnstr1.set_eval_type(LorentzConeConstraint::EvalType::kNonconvex);
+  EXPECT_EQ(cnstr1.eval_type(), LorentzConeConstraint::EvalType::kNonconvex);
 }
 
 // Tests if the Lorentz Cone constraint (with non-convex eval) is imposed


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15550)
<!-- Reviewable:end -->
