### PR TITLE
Gives SortedPair compatibility with structured bindings

### DIFF
--- a/common/test/sorted_pair_test.cc
+++ b/common/test/sorted_pair_test.cc
@@ -128,5 +128,40 @@ GTEST_TEST(SortedPair, WriteToStream) {
   EXPECT_EQ(ss.str(), "(7, 8)");
 }
 
+GTEST_TEST(SortedPair, StructuredBinding) {
+  SortedPair<int> pair{8, 7};
+
+  // Copy access.
+  {
+    auto [a, b] = pair;
+    EXPECT_EQ(a, pair.first());
+    EXPECT_EQ(b, pair.second());
+  }
+
+  // Mutable reference access.
+  {
+    auto& [a, b] = pair;
+    a = 13;
+    b = 14;
+    EXPECT_EQ(a, pair.first());
+    EXPECT_EQ(b, pair.second());
+  }
+
+  // Const reference access.
+  {
+    auto& [a, b] = pair;
+    EXPECT_EQ(&a, &pair.first());
+    EXPECT_EQ(&b, &pair.second());
+  }
+
+  // Access via range iterators.
+  {
+    std::vector<SortedPair<int>> pairs({{1, 2}, {3, 6}});
+    for (const auto& [a, b] : pairs) {
+      EXPECT_EQ(2 * a, b);
+    }
+  }
+}
+
 }  // namespace
 }  // namespace drake


### PR DESCRIPTION
We can now do:

```c++
  SortedPair<Foo> pair{Foo(1), Foo(2)};
  const auto& [a, b] = pair;
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15551)
<!-- Reviewable:end -->
