### PR TITLE
Adapt uses of reset_after_move vs Eigen 3.4 prerelease

### DIFF
--- a/systems/primitives/vector_log.cc
+++ b/systems/primitives/vector_log.cc
@@ -34,8 +34,8 @@ void VectorLog<T>::AddData(const T& time, const VectorX<T>& sample) {
   }
 
   // Record time and input to the num_samples position.
-  sample_times_(num_samples_) = time;
-  data_.col(num_samples_) = sample;
+  sample_times_(int64_t{num_samples_}) = time;
+  data_.col(int64_t{num_samples_}) = sample;
 
   // Update the count.
   ++num_samples_;


### PR DESCRIPTION
In Eigen 3.4, implicit conversion from reset_after_move to int may fail.  When needed, use the int constructor explicitly.

This is like f0cdd44674c6c4c4f05ae1b3a4e4bfc935ba0a31, but for new code written after that fix was made.

Towards #15142.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15556)
<!-- Reviewable:end -->
