### PR TITLE
MBP SetPositions(.), SetVelocities(.) etc. take an Eigen::Ref rather than a VectorX

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -506,7 +506,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def(
             "CalcSpatialAccelerationsFromVdot",
             [](const Class* self, const Context<T>& context,
-                const VectorX<T>& known_vdot) {
+                const Eigen::Ref<const VectorX<T>>& known_vdot) {
               std::vector<SpatialAcceleration<T>> A_WB_array(
                   self->num_bodies());
               self->CalcSpatialAccelerationsFromVdot(
@@ -943,14 +943,16 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def(
             "SetPositions",
             [](const MultibodyPlant<T>* self, Context<T>* context,
-                const VectorX<T>& q) { self->SetPositions(context, q); },
+                const Eigen::Ref<const VectorX<T>>& q) {
+              self->SetPositions(context, q);
+            },
             py_rvp::reference, py::arg("context"), py::arg("q"),
             cls_doc.SetPositions.doc_2args)
         .def(
             "SetPositions",
             [](const MultibodyPlant<T>* self, Context<T>* context,
                 multibody::ModelInstanceIndex model_instance,
-                const VectorX<T>& q) {
+                const Eigen::Ref<const VectorX<T>>& q) {
               self->SetPositions(context, model_instance, q);
             },
             py_rvp::reference, py::arg("context"), py::arg("model_instance"),
@@ -972,13 +974,16 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def(
             "SetVelocities",
             [](const MultibodyPlant<T>* self, Context<T>* context,
-                const VectorX<T>& v) { self->SetVelocities(context, v); },
+                const Eigen::Ref<const VectorX<T>>& v) {
+              self->SetVelocities(context, v);
+            },
             py_rvp::reference, py::arg("context"), py::arg("v"),
             cls_doc.SetVelocities.doc_2args)
         .def(
             "SetVelocities",
             [](const MultibodyPlant<T>* self, Context<T>* context,
-                ModelInstanceIndex model_instance, const VectorX<T>& v) {
+                ModelInstanceIndex model_instance,
+                const Eigen::Ref<const VectorX<T>>& v) {
               self->SetVelocities(context, model_instance, v);
             },
             py_rvp::reference, py::arg("context"), py::arg("model_instance"),
@@ -1002,7 +1007,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def(
             "SetPositionsAndVelocities",
             [](const MultibodyPlant<T>* self, Context<T>* context,
-                const VectorX<T>& q_v) {
+                const Eigen::Ref<const VectorX<T>>& q_v) {
               self->SetPositionsAndVelocities(context, q_v);
             },
             py_rvp::reference, py::arg("context"), py::arg("q_v"),
@@ -1011,7 +1016,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
             "SetPositionsAndVelocities",
             [](const MultibodyPlant<T>* self, Context<T>* context,
                 multibody::ModelInstanceIndex model_instance,
-                const VectorX<T>& q_v) {
+                const Eigen::Ref<const VectorX<T>>& q_v) {
               self->SetPositionsAndVelocities(context, model_instance, q_v);
             },
             py_rvp::reference, py::arg("context"), py::arg("model_instance"),

--- a/geometry/optimization/iris.cc
+++ b/geometry/optimization/iris.cc
@@ -222,7 +222,7 @@ bool FindClosestCollision(const multibody::MultibodyPlant<Expression>& plant,
   setA.AddPointInSetConstraints(&prog, p_AA);
   setB.AddPointInSetConstraints(&prog, p_BB);
 
-  plant.SetPositions(context, q);
+  plant.SetPositions(context, q.cast<Expression>());
   const math::RigidTransform<Expression>& X_WA =
       plant.EvalBodyPoseInWorld(*context, bodyA);
   const math::RigidTransform<Expression>& X_WB =

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -608,10 +608,9 @@ void MultibodyPlant<T>::SetFreeBodyPoseInAnchoredFrame(
   SetFreeBodyPoseInWorldFrame(context, body, X_WB);
 }
 
-template<typename T>
+template <typename T>
 void MultibodyPlant<T>::CalcSpatialAccelerationsFromVdot(
-    const systems::Context<T>& context,
-    const VectorX<T>& known_vdot,
+    const systems::Context<T>& context, const VectorX<T>& known_vdot,
     std::vector<SpatialAcceleration<T>>* A_WB_array) const {
   this->ValidateContext(context);
   DRAKE_THROW_UNLESS(A_WB_array != nullptr);

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1831,7 +1831,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// not correspond to the context for a multibody model, or if the length of
   /// `q_v` is not equal to `num_positions() + num_velocities()`.
   void SetPositionsAndVelocities(
-      systems::Context<T>* context, const VectorX<T>& q_v) const {
+      systems::Context<T>* context,
+      const Eigen::Ref<const VectorX<T>>& q_v) const {
     this->ValidateContext(context);
     DRAKE_THROW_UNLESS(q_v.size() == (num_positions() + num_velocities()));
     internal_tree().GetMutablePositionsAndVelocities(context) = q_v;
@@ -1845,7 +1846,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// `num_positions(model_instance) + num_velocities(model_instance)`.
   void SetPositionsAndVelocities(
       systems::Context<T>* context, ModelInstanceIndex model_instance,
-      const VectorX<T>& q_v) const {
+      const Eigen::Ref<const VectorX<T>>& q_v) const {
     this->ValidateContext(context);
     DRAKE_THROW_UNLESS(
         q_v.size() ==
@@ -1914,7 +1915,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception if `context` is nullptr, if `context` does not
   /// correspond to the Context for a multibody model, or if the length of `q`
   /// is not equal to `num_positions()`.
-  void SetPositions(systems::Context<T>* context, const VectorX<T>& q) const {
+  void SetPositions(systems::Context<T>* context,
+                    const Eigen::Ref<const VectorX<T>>& q) const {
     this->ValidateContext(context);
     DRAKE_THROW_UNLESS(q.size() == num_positions());
     GetMutablePositions(context) = q;
@@ -1926,9 +1928,9 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// not correspond to the Context for a multibody model, if the model instance
   /// index is invalid, or if the length of `q_instance` is not equal to
   /// `num_positions(model_instance)`.
-  void SetPositions(
-      systems::Context<T>* context,
-      ModelInstanceIndex model_instance, const VectorX<T>& q_instance) const {
+  void SetPositions(systems::Context<T>* context,
+                    ModelInstanceIndex model_instance,
+                    const Eigen::Ref<const VectorX<T>>& q_instance) const {
     this->ValidateContext(context);
     DRAKE_THROW_UNLESS(q_instance.size() == num_positions(model_instance));
     Eigen::VectorBlock<VectorX<T>> q = GetMutablePositions(context);
@@ -1945,7 +1947,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @pre `state` comes from this MultibodyPlant.
   void SetPositions(const systems::Context<T>& context,
                     systems::State<T>* state, ModelInstanceIndex model_instance,
-                    const VectorX<T>& q_instance) const {
+                    const Eigen::Ref<const VectorX<T>>& q_instance) const {
     this->ValidateContext(context);
     DRAKE_THROW_UNLESS(q_instance.size() == num_positions(model_instance));
     CheckValidState(state);
@@ -2014,7 +2016,8 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception if the `context` is nullptr, if the context does
   /// not correspond to the context for a multibody model, or if the length of
   /// `v` is not equal to `num_velocities()`.
-  void SetVelocities(systems::Context<T>* context, const VectorX<T>& v) const {
+  void SetVelocities(systems::Context<T>* context,
+                     const Eigen::Ref<const VectorX<T>>& v) const {
     this->ValidateContext(context);
     DRAKE_THROW_UNLESS(v.size() == num_velocities());
     GetMutableVelocities(context) = v;
@@ -2026,9 +2029,9 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// not correspond to the Context for a multibody model, if the model instance
   /// index is invalid, or if the length of `v_instance` is not equal to
   /// `num_velocities(model_instance)`.
-  void SetVelocities(
-      systems::Context<T>* context,
-      ModelInstanceIndex model_instance, const VectorX<T>& v_instance) const {
+  void SetVelocities(systems::Context<T>* context,
+                     ModelInstanceIndex model_instance,
+                     const Eigen::Ref<const VectorX<T>>& v_instance) const {
     this->ValidateContext(context);
     DRAKE_THROW_UNLESS(v_instance.size() == num_velocities(model_instance));
     Eigen::VectorBlock<VectorX<T>> v = GetMutableVelocities(context);
@@ -2043,9 +2046,10 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// index is invalid, or if the length of `v_instance` is not equal to
   /// `num_velocities(model_instance)`.
   /// @pre `state` comes from this MultibodyPlant.
-  void SetVelocities(
-      const systems::Context<T>& context, systems::State<T>* state,
-      ModelInstanceIndex model_instance, const VectorX<T>& v_instance) const {
+  void SetVelocities(const systems::Context<T>& context,
+                     systems::State<T>* state,
+                     ModelInstanceIndex model_instance,
+                     const Eigen::Ref<const VectorX<T>>& v_instance) const {
     this->ValidateContext(context);
     DRAKE_THROW_UNLESS(v_instance.size() == num_velocities(model_instance));
     CheckValidState(state);
@@ -2698,8 +2702,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   ///   entries will be ordered by BodyIndex.
   /// @throws std::exception if A_WB_array is not of size `num_bodies()`.
   void CalcSpatialAccelerationsFromVdot(
-      const systems::Context<T>& context,
-      const VectorX<T>& known_vdot,
+      const systems::Context<T>& context, const VectorX<T>& known_vdot,
       std::vector<SpatialAcceleration<T>>* A_WB_array) const;
 
   /// Given the state of this model in `context` and a known vector


### PR DESCRIPTION
Resolves #13735

Note that `CalcInverseDynamics` still takes a `VectorX<T>`, but changing that trips up a number of LimitAlloc tests, so i've left it alone for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15561)
<!-- Reviewable:end -->
