### PR TITLE
[systems/lcm] Narrow the subscriber output port dependencies

### DIFF
--- a/systems/lcm/lcm_subscriber_system.cc
+++ b/systems/lcm/lcm_subscriber_system.cc
@@ -39,22 +39,15 @@ LcmSubscriberSystem::LcmSubscriberSystem(
     subscription_->set_unsubscribe_on_delete(true);
   }
 
-  // Use the "advanced" method to construct explicit non-member functors to
-  // deal with the unusual methods we have available.
-  DeclareAbstractOutputPort(
-      kUseDefaultName,
-      [this]() {
-        return this->AllocateSerializerOutputValue();
-      },
-      [this](const Context<double>& context, AbstractValue* out) {
-        this->CalcSerializerOutputValue(context, out);
-      });
-
   // Declare our two states (message_value, message_count).
   static_assert(kStateIndexMessage == 0, "");
-  this->DeclareAbstractState(*AllocateSerializerOutputValue());
+  auto message_state_index =
+      this->DeclareAbstractState(*serializer_->CreateDefaultValue());
   static_assert(kStateIndexMessageCount == 1, "");
   this->DeclareAbstractState(Value<int>(0));
+
+  // Our sole output is the message state.
+  this->DeclareStateOutputPort(kUseDefaultName, message_state_index);
 
   // Declare an unrestricted forced update handler that is invoked when a
   // "forced" trigger occurs. This gives the user flexibility to force update
@@ -140,17 +133,6 @@ std::string LcmSubscriberSystem::make_name(const std::string& channel) {
 
 const std::string& LcmSubscriberSystem::get_channel_name() const {
   return channel_;
-}
-
-std::unique_ptr<AbstractValue>
-LcmSubscriberSystem::AllocateSerializerOutputValue() const {
-  return serializer_->CreateDefaultValue();
-}
-
-void LcmSubscriberSystem::CalcSerializerOutputValue(
-    const Context<double>& context, AbstractValue* output_value) const {
-  output_value->SetFrom(
-      context.get_abstract_state().get_value(kStateIndexMessage));
 }
 
 void LcmSubscriberSystem::HandleMessage(const void* buffer, int size) {

--- a/systems/lcm/lcm_subscriber_system.h
+++ b/systems/lcm/lcm_subscriber_system.h
@@ -120,10 +120,6 @@ class LcmSubscriberSystem : public LeafSystem<double> {
                             systems::CompositeEventCollection<double>* events,
                             double* time) const final;
 
-  std::unique_ptr<AbstractValue> AllocateSerializerOutputValue() const;
-  void CalcSerializerOutputValue(const Context<double>& context,
-                                 AbstractValue* output_value) const;
-
   systems::EventStatus ProcessMessageAndStoreToAbstractState(
       const Context<double>&, State<double>* state) const;
 


### PR DESCRIPTION
This is likely to reduce unnecessary downstream re-calculations, e.g., when only the context time changes.

Fixes #15562.