### PR TITLE
Switch to per-context dummy CacheEntryValue for thread safety

### DIFF
--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -1088,4 +1088,12 @@ drake_cc_googletest(
     ],
 )
 
+drake_cc_googletest(
+    name = "thread_sanitizer_test",
+    deps = [
+        ":vector_system",
+        "//common/test_utilities",
+    ],
+)
+
 add_lint_tests()

--- a/systems/framework/context_base.h
+++ b/systems/framework/context_base.h
@@ -585,6 +585,12 @@ class ContextBase : public internal::ContextMessageInterface {
     notify_set_system_id(id);
   }
 
+  // Returns a mutable dummy CacheEntryValue that can
+  // serve as a /dev/null-like destination for throw-away writes.
+  CacheEntryValue& dummy_cache_entry_value() const final {
+    return get_mutable_cache().dummy_cache_entry_value();
+  }
+
   // Notifies interested subclasses of the id of the subsystem that created
   // this context.
   virtual void notify_set_system_id(internal::SystemId) {}

--- a/systems/framework/dependency_tracker.cc
+++ b/systems/framework/dependency_tracker.cc
@@ -218,7 +218,8 @@ void DependencyTracker::RepairTrackerPointers(
   DRAKE_DEMAND(cache != nullptr);
   owning_subcontext_ = owning_subcontext;
 
-  // Set the cache entry pointer.
+  // Set the cache entry pointer to refer to the new cache, either to a real
+  // CacheEntryValue or the cache's dummy value.
   DRAKE_DEMAND(has_associated_cache_entry_ ==
                source.has_associated_cache_entry_);
   if (has_associated_cache_entry_) {
@@ -228,6 +229,8 @@ void DependencyTracker::RepairTrackerPointers(
         "Cloned tracker '{}' repairing cache entry {} invalidation to {:#x}.",
         GetPathDescription(), source.cache_value_->cache_index(),
         size_t(cache_value_));
+  } else {
+    cache_value_ = &cache->dummy_cache_entry_value();
   }
 
   // Set the subscriber pointers.

--- a/systems/framework/framework_common.h
+++ b/systems/framework/framework_common.h
@@ -105,6 +105,7 @@ enum class OutputPortSelection { kNoOutput = -1, kUseFirstOutputIfItExists =
     -2 };
 
 #ifndef DRAKE_DOXYGEN_CXX
+class CacheEntryValue;
 class ContextBase;
 class InputPortBase;
 class SystemBase;
@@ -210,6 +211,10 @@ class ContextMessageInterface {
 
   // Returns true if the cache in this subcontext has been frozen.
   virtual bool is_cache_frozen() const = 0;
+
+  // Returns a mutable reference to the Context's (mutable) Cache's dummy
+  // CacheEntryValue.
+  virtual CacheEntryValue& dummy_cache_entry_value() const = 0;
 
  protected:
   ContextMessageInterface() = default;

--- a/systems/framework/test/thread_sanitizer_test.cc
+++ b/systems/framework/test/thread_sanitizer_test.cc
@@ -1,0 +1,104 @@
+#include <future>
+#include <memory>
+
+#include "gtest/gtest.h"
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/test_utilities/expect_no_throw.h"
+#include "drake/systems/framework/context.h"
+#include "drake/systems/framework/vector_system.h"
+
+// The purpose of this test is to provide TSan (ThreadSanitizer) some material
+// to study. The test cases exercise legitimate ways to use Drake with multiple
+// threads and should pass TSan cleanly. One of these tests was shown
+// to fail prior to removing the shared mutable static in PR #15564.
+
+namespace drake {
+namespace systems {
+namespace {
+
+// Simple system to use in thread-safety testing.
+class TestVectorSystem : public VectorSystem<double> {
+ public:
+  TestVectorSystem() : VectorSystem(0, 1) {
+    // Discrete state is initialized to zero.
+    this->DeclareDiscreteState(1);
+  }
+
+ private:
+  void DoCalcVectorOutput(
+      const Context<double>& context,
+      const Eigen::VectorBlock<const VectorX<double>>& input,
+      const Eigen::VectorBlock<const VectorX<double>>& state,
+      Eigen::VectorBlock<VectorX<double>>* output) const override {
+    *output = state;
+  }
+};
+
+// Test that exercises read and write use of per-thread contexts.
+// Failed prior to PR #15564.
+GTEST_TEST(ThreadSanitizerTest, PerThreadContextTest) {
+  // Make test system.
+  auto system = std::make_unique<TestVectorSystem>();
+
+  // Make two contexts.
+  auto context_A = system->CreateDefaultContext();
+  auto context_B = system->CreateDefaultContext();
+
+  // Define read & write operation on a context.
+  const auto context_rw_operation = [](Context<double>* system_context) {
+    Eigen::VectorXd state_vector =
+        system_context->get_discrete_state_vector().get_value();
+    // Ensure that we are actually making a change here so the write can't
+    // be elided.
+    DRAKE_DEMAND(state_vector[0] == 0.0);
+    state_vector[0] = 1.0;
+    system_context->SetDiscreteState(state_vector);
+  };
+
+  // Dispatch parallel read & write operations on separate contexts.
+  std::future<void> context_A_rw_operation = std::async(
+      std::launch::async, context_rw_operation, context_A.get());
+  std::future<void> context_B_rw_operation = std::async(
+      std::launch::async, context_rw_operation, context_B.get());
+
+  // Wait for operations to complete, and ensure they don't throw.
+  DRAKE_EXPECT_NO_THROW(context_A_rw_operation.get());
+  DRAKE_EXPECT_NO_THROW(context_B_rw_operation.get());
+}
+
+// Test that exercises read-only use of a shared context between threads.
+GTEST_TEST(ThreadSanitizerTest, SharedFrozenContextTest) {
+  // Make test system.
+  auto system = std::make_unique<TestVectorSystem>();
+
+  // Make a context.
+  auto context = system->CreateDefaultContext();
+
+  // Define a read-only operation on a context.
+  const auto context_ro_operation = [](Context<double>* system_context) {
+    const Eigen::VectorXd state_vector =
+        system_context->get_discrete_state_vector().get_value();
+    return state_vector;
+  };
+
+  // Freeze context.
+  context->FreezeCache();
+
+  // Dispatch parallel read operations on the same context.
+  std::future<Eigen::VectorXd> context_ro_operation_1 = std::async(
+      std::launch::async, context_ro_operation, context.get());
+  std::future<Eigen::VectorXd> context_ro_operation_2 = std::async(
+      std::launch::async, context_ro_operation, context.get());
+
+  // Wait for operations to complete, and ensure they don't throw.
+  DRAKE_EXPECT_NO_THROW(context_ro_operation_1.get());
+  DRAKE_EXPECT_NO_THROW(context_ro_operation_2.get());
+
+  // Thaw context.
+  context->UnfreezeCache();
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
Previously we used a singleton "dummy" CacheEntryValue as a /dev/null-like destination for throw-away writes. This caused trouble with Tsan in multithreaded PR #15537.

This PR switches to using a per-Context dummy rather than a singleton. This is mildly tricky due to the need to switch dummy destinations during Context cloning.

This is a prerequisite for #15537 to merge hence high priority.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15564)
<!-- Reviewable:end -->
