### PR TITLE
Add GraphOfConvexSets::LockEdge()

### DIFF
--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -110,6 +110,10 @@ void Edge::AddPhiConstraint(bool phi_value) {
   phi_value_ = phi_value;
 }
 
+void Edge::ClearPhiConstraints() {
+  phi_value_ = std::nullopt;
+}
+
 double Edge::GetSolutionCost(const MathematicalProgramResult& result) const {
   return result.GetSolution(ell_).sum();
 }

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -129,10 +129,9 @@ Edge* GraphOfConvexSets::AddEdge(const VertexId& u_id, const VertexId& v_id,
   if (name.empty()) {
     name = fmt::format("e{}", edges_.size());
   }
-  auto [iter, success] = edges_.emplace(std::unique_ptr<Edge>(
+  edges_.emplace_back(std::unique_ptr<Edge>(
       new Edge(u_iter->second.get(), v_iter->second.get(), name)));
-  DRAKE_DEMAND(success);
-  return iter->get();
+  return edges_.back().get();
 }
 
 Edge* GraphOfConvexSets::AddEdge(const Vertex& u, const Vertex& v,

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -140,6 +140,10 @@ Edge* GraphOfConvexSets::AddEdge(const Vertex& u, const Vertex& v,
   return AddEdge(u.id(), v.id(), std::move(name));
 }
 
+void GraphOfConvexSets::LockEdge(const Edge& edge, bool active) {
+  locked_edges_[&edge] = active;
+}
+
 std::unordered_set<VertexId> GraphOfConvexSets::VertexIds() const {
   std::unordered_set<VertexId> ids(vertices_.size());
   for (const auto& v : vertices_) {
@@ -185,6 +189,11 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
     } else {
       phi = e->phi_;
       prog.AddDecisionVariables(Vector1<Variable>(phi));
+    }
+    const auto locked_edge = locked_edges_.find(e.get());
+    if (locked_edge != locked_edges_.end()) {
+      double phi_value = locked_edge->second ? 1.0 : 0.0;
+      prog.AddBoundingBoxConstraint(phi_value, phi_value, phi);
     }
     prog.AddDecisionVariables(e->y_);
     prog.AddDecisionVariables(e->z_);

--- a/geometry/optimization/graph_of_convex_sets.cc
+++ b/geometry/optimization/graph_of_convex_sets.cc
@@ -106,6 +106,10 @@ Binding<Constraint> Edge::AddConstraint(const Binding<Constraint>& binding) {
   return *iter;
 }
 
+void Edge::AddPhiConstraint(bool phi_value) {
+  phi_value_ = phi_value;
+}
+
 double Edge::GetSolutionCost(const MathematicalProgramResult& result) const {
   return result.GetSolution(ell_).sum();
 }
@@ -140,10 +144,6 @@ Edge* GraphOfConvexSets::AddEdge(const VertexId& u_id, const VertexId& v_id,
 Edge* GraphOfConvexSets::AddEdge(const Vertex& u, const Vertex& v,
                                  std::string name) {
   return AddEdge(u.id(), v.id(), std::move(name));
-}
-
-void GraphOfConvexSets::LockEdge(const Edge& edge, bool active) {
-  locked_edges_[&edge] = active;
 }
 
 std::unordered_set<VertexId> GraphOfConvexSets::VertexIds() const {
@@ -194,9 +194,8 @@ MathematicalProgramResult GraphOfConvexSets::SolveShortestPath(
       phi = e->phi_;
       prog.AddDecisionVariables(Vector1<Variable>(phi));
     }
-    const auto locked_edge = locked_edges_.find(e.get());
-    if (locked_edge != locked_edges_.end()) {
-      double phi_value = locked_edge->second ? 1.0 : 0.0;
+    if (e->phi_value_.has_value()) {
+      double phi_value = *e->phi_value_ ? 1.0 : 0.0;
       prog.AddBoundingBoxConstraint(phi_value, phi_value, phi);
     }
     prog.AddDecisionVariables(e->y_);

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -227,6 +227,8 @@ class GraphOfConvexSets {
   empty then a default name will be provided. */
   Edge* AddEdge(const Vertex& u, const Vertex& v, std::string name = "");
 
+  void LockEdge(const Edge& edge, bool active);
+
   /** Returns the VertexIds of the vertices stored in the graph.  Note that the
   order of the elements is not guaranteed. */
   std::unordered_set<VertexId> VertexIds() const;
@@ -272,6 +274,7 @@ class GraphOfConvexSets {
  private:
   std::unordered_map<VertexId, std::unique_ptr<Vertex>> vertices_{};
   std::unordered_set<std::unique_ptr<Edge>> edges_{};
+  std::unordered_map<const Edge*, bool> locked_edges_{};
 };
 
 }  // namespace optimization

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -185,7 +185,10 @@ class GraphOfConvexSets {
     solvers::Binding<solvers::Constraint> AddConstraint(
         const solvers::Binding<solvers::Constraint>& binding);
 
-    /** Adds a constraint on the binary variable associated with this edge. */
+    /** Adds a constraint on the binary variable associated with this edge.
+    @note We intentionally do not return a binding to the constraint created by
+    this call, as that would allow the caller to make nonsensical modifications
+    to its bounds (i.e. requiring phi == 0.5). */
     void AddPhiConstraint(bool phi_value);
 
     /** Removes any constraints added with AddPhiConstraint. */

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -279,14 +279,9 @@ class GraphOfConvexSets {
       const Vertex& source, const Vertex& target,
       bool convex_relaxation = false) const;
 
-  /** Custom comparator for sorting edges based on their identifiers. */
-  static bool CompareEdges(const std::unique_ptr<Edge>& a,
-                           const std::unique_ptr<Edge>& b);
-
  private:
   std::map<VertexId, std::unique_ptr<Vertex>> vertices_{};
-  std::set<std::unique_ptr<Edge>, decltype(&GraphOfConvexSets::CompareEdges)>
-      edges_{&GraphOfConvexSets::CompareEdges};
+  std::map<EdgeId, std::unique_ptr<Edge>> edges_{};
   std::map<const Edge*, bool> locked_edges_{};
 };
 

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -272,9 +272,9 @@ class GraphOfConvexSets {
       bool convex_relaxation = false) const;
 
  private:
-  std::unordered_map<VertexId, std::unique_ptr<Vertex>> vertices_{};
-  std::unordered_set<std::unique_ptr<Edge>> edges_{};
-  std::unordered_map<const Edge*, bool> locked_edges_{};
+  std::map<VertexId, std::unique_ptr<Vertex>> vertices_{};
+  std::vector<std::unique_ptr<Edge>> edges_{};
+  std::map<const Edge*, bool> locked_edges_{};
 };
 
 }  // namespace optimization

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -185,6 +185,9 @@ class GraphOfConvexSets {
     solvers::Binding<solvers::Constraint> AddConstraint(
         const solvers::Binding<solvers::Constraint>& binding);
 
+    /** Adds a constraint on the binary variable associated with this edge. */
+    void AddPhiConstraint(bool phi_value);
+
     /** Returns the sum of the costs associated with this edge in a
     MathematicalProgramResult. */
     double GetSolutionCost(
@@ -212,6 +215,7 @@ class GraphOfConvexSets {
     solvers::VectorXDecisionVariable ell_{};
     std::vector<solvers::Binding<solvers::Cost>> costs_{};
     std::unordered_set<solvers::Binding<solvers::Constraint>> constraints_{};
+    std::optional<bool> phi_value_{};
 
     friend class GraphOfConvexSets;
   };
@@ -233,9 +237,6 @@ class GraphOfConvexSets {
   vertex references must refer to valid vertices in this graph. If @p name is
   empty then a default name will be provided. */
   Edge* AddEdge(const Vertex& u, const Vertex& v, std::string name = "");
-
-  /** Requires that @p edge be active (phi == 1) or inactive (phi == 0). */
-  void LockEdge(const Edge& edge, bool active);
 
   /** Returns the VertexIds of the vertices stored in the graph.  Note that the
   order of the elements is not guaranteed. */
@@ -282,7 +283,6 @@ class GraphOfConvexSets {
  private:
   std::map<VertexId, std::unique_ptr<Vertex>> vertices_{};
   std::map<EdgeId, std::unique_ptr<Edge>> edges_{};
-  std::map<const Edge*, bool> locked_edges_{};
 };
 
 }  // namespace optimization

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -188,6 +188,9 @@ class GraphOfConvexSets {
     /** Adds a constraint on the binary variable associated with this edge. */
     void AddPhiConstraint(bool phi_value);
 
+    /** Removes any constraints added with AddPhiConstraint. */
+    void ClearPhiConstraints();
+
     /** Returns the sum of the costs associated with this edge in a
     MathematicalProgramResult. */
     double GetSolutionCost(

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -227,6 +227,7 @@ class GraphOfConvexSets {
   empty then a default name will be provided. */
   Edge* AddEdge(const Vertex& u, const Vertex& v, std::string name = "");
 
+  /** Requires that @p edge be active (phi == 1) or inactive (phi == 0). */
   void LockEdge(const Edge& edge, bool active);
 
   /** Returns the VertexIds of the vertices stored in the graph.  Note that the

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -697,12 +697,12 @@ GTEST_TEST(ShortestPathTest, TobiasToyExample) {
   for (const auto& e : spp.Edges()) {
     auto iter =
         std::find(new_shortest_path.begin(), new_shortest_path.end(), &e->u());
+    // All costs should be non-negative.
+    EXPECT_GE(e->GetSolutionCost(new_result), 0.0);
     if (iter != new_shortest_path.end() && &e->v() == *(++iter)) {
       // Then it's on the shortest path; phi should be 1.
       EXPECT_NEAR(new_result.GetSolution(e->phi()), 1.0, 1e-5);
     } else {
-      drake::log()->debug("{} -> {}: phi = {:e}", e->u().name(), e->v().name(),
-                          new_result.GetSolution(e->phi()));
       EXPECT_NEAR(new_result.GetSolution(e->phi()), 0.0, 1e-5);
     }
   }

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -689,7 +689,7 @@ GTEST_TEST(ShortestPathTest, TobiasToyExample) {
 
   // Test that forcing an edge not on the shortest path to be active yields a
   // higher cost.
-  spp.LockEdge(*source_to_p2, true);
+  source_to_p2->AddPhiConstraint(true);
   auto new_result = spp.SolveShortestPath(source->id(), target->id(), false);
   ASSERT_TRUE(new_result.is_success());
 

--- a/geometry/optimization/test/graph_of_convex_sets_test.cc
+++ b/geometry/optimization/test/graph_of_convex_sets_test.cc
@@ -698,10 +698,12 @@ GTEST_TEST(ShortestPathTest, TobiasToyExample) {
     auto iter =
         std::find(new_shortest_path.begin(), new_shortest_path.end(), &e->u());
     if (iter != new_shortest_path.end() && &e->v() == *(++iter)) {
-      // Then it's on the shortest path; cost should be non-zero.
-      EXPECT_GE(e->GetSolutionCost(new_result), 1.0);
+      // Then it's on the shortest path; phi should be 1.
+      EXPECT_NEAR(new_result.GetSolution(e->phi()), 1.0, 1e-5);
     } else {
-      EXPECT_NEAR(e->GetSolutionCost(new_result), 0.0, 1e-5);
+      drake::log()->debug("{} -> {}: phi = {:e}", e->u().name(), e->v().name(),
+                          new_result.GetSolution(e->phi()));
+      EXPECT_NEAR(new_result.GetSolution(e->phi()), 0.0, 1e-5);
     }
   }
   EXPECT_GT(new_result.get_optimal_cost(), result.get_optimal_cost());


### PR DESCRIPTION
This allows the user to specify that particular edges of the graph ought to be active/inactive.

This PR also makes the order of constraints deterministic in `GraphOfConvexSets::Solve()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15572)
<!-- Reviewable:end -->
