### PR TITLE
Add explicit nullptr checks to assertions

### DIFF
--- a/common/polynomial.cc
+++ b/common/polynomial.cc
@@ -627,7 +627,7 @@ Polynomial<T>::VariableNameToId(const string name,
   VarType name_part = 0;
   for (int i = static_cast<int>(name.size()) - 1; i >= 0; i--) {
     const char* const character_match = strchr(kNameChars, name[i]);
-    DRAKE_ASSERT(character_match);
+    DRAKE_ASSERT(character_match != nullptr);
     VarType offset = static_cast<VarType>(character_match - kNameChars);
     name_part += (offset + 1) * multiplier;
     multiplier *= kNumNameChars + 1;

--- a/common/symbolic_expression_cell.cc
+++ b/common/symbolic_expression_cell.cc
@@ -233,7 +233,7 @@ UnaryExpressionCell::UnaryExpressionCell(const ExpressionKind k, Expression e,
     : ExpressionCell{k, is_poly, is_expanded}, e_{std::move(e)} {}
 
 void UnaryExpressionCell::HashAppendDetail(DelegatingHasher* hasher) const {
-  DRAKE_ASSERT(hasher);
+  DRAKE_ASSERT(hasher != nullptr);
   using drake::hash_append;
   hash_append(*hasher, e_);
 }
@@ -270,7 +270,7 @@ BinaryExpressionCell::BinaryExpressionCell(const ExpressionKind k,
       e2_{std::move(e2)} {}
 
 void BinaryExpressionCell::HashAppendDetail(DelegatingHasher* hasher) const {
-  DRAKE_ASSERT(hasher);
+  DRAKE_ASSERT(hasher != nullptr);
   using drake::hash_append;
   hash_append(*hasher, e1_);
   hash_append(*hasher, e2_);
@@ -320,7 +320,7 @@ ExpressionVar::ExpressionVar(Variable v)
 }
 
 void ExpressionVar::HashAppendDetail(DelegatingHasher* hasher) const {
-  DRAKE_ASSERT(hasher);
+  DRAKE_ASSERT(hasher != nullptr);
   using drake::hash_append;
   hash_append(*hasher, var_);
 }

--- a/common/symbolic_formula_cell.cc
+++ b/common/symbolic_formula_cell.cc
@@ -33,7 +33,7 @@ RelationalFormulaCell::RelationalFormulaCell(const FormulaKind k,
     : FormulaCell{k}, e_lhs_{std::move(lhs)}, e_rhs_{std::move(rhs)} {}
 
 void RelationalFormulaCell::HashAppendDetail(DelegatingHasher* hasher) const {
-  DRAKE_ASSERT(hasher);
+  DRAKE_ASSERT(hasher != nullptr);
   using drake::hash_append;
   hash_append(*hasher, e_lhs_);
   hash_append(*hasher, e_rhs_);
@@ -69,7 +69,7 @@ NaryFormulaCell::NaryFormulaCell(const FormulaKind k, set<Formula> formulas)
     : FormulaCell{k}, formulas_{std::move(formulas)} {}
 
 void NaryFormulaCell::HashAppendDetail(DelegatingHasher* hasher) const {
-  DRAKE_ASSERT(hasher);
+  DRAKE_ASSERT(hasher != nullptr);
   using drake::hash_append;
   hash_append(*hasher, formulas_);
 }
@@ -180,7 +180,7 @@ FormulaVar::FormulaVar(Variable v)
 }
 
 void FormulaVar::HashAppendDetail(DelegatingHasher* hasher) const {
-  DRAKE_ASSERT(hasher);
+  DRAKE_ASSERT(hasher != nullptr);
   using drake::hash_append;
   hash_append(*hasher, var_);
 }
@@ -403,7 +403,7 @@ FormulaNot::FormulaNot(Formula f)
     : FormulaCell{FormulaKind::Not}, f_{std::move(f)} {}
 
 void FormulaNot::HashAppendDetail(DelegatingHasher* hasher) const {
-  DRAKE_ASSERT(hasher);
+  DRAKE_ASSERT(hasher != nullptr);
   using drake::hash_append;
   hash_append(*hasher, f_);
 }
@@ -442,7 +442,7 @@ FormulaForall::FormulaForall(Variables vars, Formula f)
       f_{std::move(f)} {}
 
 void FormulaForall::HashAppendDetail(DelegatingHasher* hasher) const {
-  DRAKE_ASSERT(hasher);
+  DRAKE_ASSERT(hasher != nullptr);
   using drake::hash_append;
   hash_append(*hasher, vars_);
   hash_append(*hasher, f_);
@@ -499,7 +499,7 @@ FormulaIsnan::FormulaIsnan(Expression e)
     : FormulaCell{FormulaKind::Isnan}, e_{std::move(e)} {}
 
 void FormulaIsnan::HashAppendDetail(DelegatingHasher* hasher) const {
-  DRAKE_ASSERT(hasher);
+  DRAKE_ASSERT(hasher != nullptr);
   using drake::hash_append;
   hash_append(*hasher, e_);
 }
@@ -584,7 +584,7 @@ struct VariablesCollector {
 
 void FormulaPositiveSemidefinite::HashAppendDetail(
     DelegatingHasher* hasher) const {
-  DRAKE_ASSERT(hasher);
+  DRAKE_ASSERT(hasher != nullptr);
   using drake::hash_append;
   // Computes a hash of a matrix only using its lower-triangular part.
   for (int i = 0; i < m_.rows(); ++i) {

--- a/common/symbolic_polynomial_basis_element.cc
+++ b/common/symbolic_polynomial_basis_element.cc
@@ -152,8 +152,8 @@ symbolic::Expression PolynomialBasisElement::ToExpression() const {
 void PolynomialBasisElement::DoEvaluatePartial(
     const Environment& env, double* coeff,
     std::map<Variable, int>* new_basis_element) const {
-  DRAKE_ASSERT(coeff);
-  DRAKE_ASSERT(new_basis_element);
+  DRAKE_ASSERT(coeff != nullptr);
+  DRAKE_ASSERT(new_basis_element != nullptr);
   DRAKE_ASSERT(new_basis_element->empty());
   *coeff = 1;
   for (const auto& [var, degree] : var_to_degree_map_) {

--- a/common/yaml/yaml_read_archive.cc
+++ b/common/yaml/yaml_read_archive.cc
@@ -149,7 +149,7 @@ void YamlReadArchive::ReportError(const std::string& note) const {
   for (auto* archive = parent_; archive; archive = archive->parent_) {
     fmt::print(e, " while accepting ");
     archive->PrintNodeSummary(e);
-    if (archive->debug_visit_name_) {
+    if (archive->debug_visit_name_ != nullptr) {
       fmt::print(e, " while visiting ");
       archive->PrintVisitNameType(e);
     }
@@ -201,12 +201,12 @@ void YamlReadArchive::PrintNodeSummary(std::ostream& s) const {
 }
 
 void YamlReadArchive::PrintVisitNameType(std::ostream& s) const {
-  if (!debug_visit_name_) {
+  if (debug_visit_name_ == nullptr) {
     s << "<root>";
     return;
   }
-  DRAKE_DEMAND(debug_visit_name_);
-  DRAKE_DEMAND(debug_visit_type_);
+  DRAKE_DEMAND(debug_visit_name_ != nullptr);
+  DRAKE_DEMAND(debug_visit_type_ != nullptr);
   fmt::print(s, "{} {}",
              drake::NiceTypeName::Get(*debug_visit_type_),
              debug_visit_name_);

--- a/examples/kuka_iiwa_arm/kuka_simulation.cc
+++ b/examples/kuka_iiwa_arm/kuka_simulation.cc
@@ -160,7 +160,7 @@ int DoMain() {
   if (FLAGS_torque_control) {
     KukaTorqueController<double>* torque_controller =
         dynamic_cast<KukaTorqueController<double>*>(controller);
-    DRAKE_DEMAND(torque_controller);
+    DRAKE_DEMAND(torque_controller != nullptr);
     builder.Connect(command_receiver->get_commanded_torque_output_port(),
                     torque_controller->get_input_port_commanded_torque());
   }

--- a/examples/rod2d/rod2d.cc
+++ b/examples/rod2d/rod2d.cc
@@ -161,7 +161,7 @@ void Rod2D<T>::GetContactPoints(const systems::Context<T>& context,
   using std::cos;
   using std::sin;
 
-  DRAKE_DEMAND(points);
+  DRAKE_DEMAND(points != nullptr);
   DRAKE_DEMAND(points->empty());
 
   const Vector3<T> q = GetRodConfig(context);
@@ -185,7 +185,7 @@ template <class T>
 void Rod2D<T>::GetContactPointsTangentVelocities(
     const systems::Context<T>& context,
     const std::vector<Vector2<T>>& points, std::vector<T>* vels) const {
-  DRAKE_DEMAND(vels);
+  DRAKE_DEMAND(vels != nullptr);
   const Vector3<T> q = GetRodConfig(context);
   const Vector3<T> v = GetRodVelocity(context);
 
@@ -305,7 +305,7 @@ void Rod2D<T>::CalcConstraintProblemData(
     multibody::constraint::ConstraintAccelProblemData<T>* data)
     const {
   using std::abs;
-  DRAKE_DEMAND(data);
+  DRAKE_DEMAND(data != nullptr);
   DRAKE_DEMAND(points.size() == tangent_vels.size());
 
   // Set the inertia solver.
@@ -413,7 +413,7 @@ void Rod2D<T>::CalcImpactProblemData(
     const std::vector<Vector2<T>>& points,
     multibody::constraint::ConstraintVelProblemData<T>* data) const {
   using std::abs;
-  DRAKE_DEMAND(data);
+  DRAKE_DEMAND(data != nullptr);
 
   // Setup the generalized inertia matrix.
   Matrix3<T> M;

--- a/examples/scene_graph/solar_system.cc
+++ b/examples/scene_graph/solar_system.cc
@@ -58,7 +58,7 @@ unique_ptr<GeometryInstance> MakeShape(const RigidTransformd& pose,
 
 template <typename T>
 SolarSystem<T>::SolarSystem(SceneGraph<T>* scene_graph) {
-  DRAKE_DEMAND(scene_graph);
+  DRAKE_DEMAND(scene_graph != nullptr);
   source_id_ = scene_graph->RegisterSource("solar_system");
 
   this->DeclareContinuousState(kBodyCount /* num_q */, kBodyCount /* num_v */,

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -407,8 +407,8 @@ class GeometryState {
   void ComputeContactSurfacesWithFallback(
       std::vector<ContactSurface<T>>* surfaces,
       std::vector<PenetrationAsPointPair<T>>* point_pairs) const {
-    DRAKE_DEMAND(surfaces);
-    DRAKE_DEMAND(point_pairs);
+    DRAKE_DEMAND(surfaces != nullptr);
+    DRAKE_DEMAND(point_pairs != nullptr);
     return geometry_engine_->ComputeContactSurfacesWithFallback(
         X_WGs_, surfaces, point_pairs);
   }
@@ -418,8 +418,8 @@ class GeometryState {
   void ComputePolygonalContactSurfacesWithFallback(
       std::vector<ContactSurface<T>>* surfaces,
       std::vector<PenetrationAsPointPair<T>>* point_pairs) const {
-    DRAKE_DEMAND(surfaces);
-    DRAKE_DEMAND(point_pairs);
+    DRAKE_DEMAND(surfaces != nullptr);
+    DRAKE_DEMAND(point_pairs != nullptr);
     return geometry_engine_->ComputePolygonalContactSurfacesWithFallback(
         X_WGs_, surfaces, point_pairs);
   }

--- a/geometry/proximity/collisions_exist_callback.cc
+++ b/geometry/proximity/collisions_exist_callback.cc
@@ -9,7 +9,7 @@ namespace has_collisions {
 
 CallbackData::CallbackData(const CollisionFilter* collision_filter_in)
     : collision_filter(*collision_filter_in) {
-  DRAKE_DEMAND(collision_filter_in);
+  DRAKE_DEMAND(collision_filter_in != nullptr);
   request.num_max_contacts = 1;
   request.enable_contact = false;
   // NOTE: As of 5/1/2018 the GJK implementation of Libccd appears to be

--- a/geometry/proximity/distance_to_point_callback.h
+++ b/geometry/proximity/distance_to_point_callback.h
@@ -55,9 +55,9 @@ struct CallbackData {
         p_WQ_W(p_WQ_W_in),
         X_WGs(*X_WGs_in),
         distances(*distances_in) {
-    DRAKE_DEMAND(query_in);
-    DRAKE_DEMAND(X_WGs_in);
-    DRAKE_DEMAND(distances_in);
+    DRAKE_DEMAND(query_in != nullptr);
+    DRAKE_DEMAND(X_WGs_in != nullptr);
+    DRAKE_DEMAND(distances_in != nullptr);
   }
 
   /* The query fcl object.  */

--- a/geometry/proximity/distance_to_shape_callback.h
+++ b/geometry/proximity/distance_to_shape_callback.h
@@ -52,9 +52,9 @@ struct CallbackData {
         X_WGs(*X_WGs_in),
         max_distance(max_distance_in),
         nearest_pairs(*nearest_pairs_in) {
-    DRAKE_DEMAND(collision_filter_in);
-    DRAKE_DEMAND(X_WGs_in);
-    DRAKE_DEMAND(nearest_pairs_in);
+    DRAKE_DEMAND(collision_filter_in != nullptr);
+    DRAKE_DEMAND(X_WGs_in != nullptr);
+    DRAKE_DEMAND(nearest_pairs_in != nullptr);
   }
 
   /* The collision filter system.  */
@@ -95,7 +95,7 @@ class DistancePairGeometry {
                        const math::RigidTransform<T>& X_WB,
                        SignedDistancePair<T>* result)
       : id_A_(id_A), id_B_(id_B), X_WA_(X_WA), X_WB_(X_WB), result_(result) {
-    DRAKE_ASSERT(result);
+    DRAKE_ASSERT(result != nullptr);
   }
 
   /* @name  Overloads in support of sphere-shape computation

--- a/geometry/proximity/find_collision_candidates_callback.cc
+++ b/geometry/proximity/find_collision_candidates_callback.cc
@@ -11,8 +11,8 @@ CallbackData::CallbackData(const CollisionFilter* collision_filter_in,
                            std::vector<SortedPair<GeometryId>>* pairs_in)
     : collision_filter(*collision_filter_in),
       pairs(*pairs_in) {
-  DRAKE_DEMAND(collision_filter_in);
-  DRAKE_DEMAND(pairs_in);
+  DRAKE_DEMAND(collision_filter_in != nullptr);
+  DRAKE_DEMAND(pairs_in != nullptr);
 }
 
 bool Callback(fcl::CollisionObjectd* object_A_ptr,

--- a/geometry/proximity/hydroelastic_callback.h
+++ b/geometry/proximity/hydroelastic_callback.h
@@ -65,10 +65,10 @@ struct CallbackData {
         geometries(*geometries_in),
         polygon_representation(polygon_representation_in),
         surfaces(*surfaces_in) {
-    DRAKE_DEMAND(collision_filter_in);
-    DRAKE_DEMAND(X_WGs_in);
-    DRAKE_DEMAND(geometries_in);
-    DRAKE_DEMAND(surfaces_in);
+    DRAKE_DEMAND(collision_filter_in != nullptr);
+    DRAKE_DEMAND(X_WGs_in != nullptr);
+    DRAKE_DEMAND(geometries_in != nullptr);
+    DRAKE_DEMAND(surfaces_in != nullptr);
   }
 
   /* The collision filter system.  */

--- a/geometry/proximity/mesh_half_space_intersection.cc
+++ b/geometry/proximity/mesh_half_space_intersection.cc
@@ -129,10 +129,10 @@ void ConstructTriangleHalfspaceIntersectionPolygon(
   // TODO(SeanCurtis-TRI): This needs to support the "backface" culling that is
   //  implemented in mesh-mesh intersection. See the
   //  IsFaceNormalAlongPressureGradient() function in mesh_intersection.h.
-  DRAKE_DEMAND(new_vertices_W);
-  DRAKE_DEMAND(new_faces);
-  DRAKE_DEMAND(vertices_to_newly_created_vertices);
-  DRAKE_DEMAND(edges_to_newly_created_vertices);
+  DRAKE_DEMAND(new_vertices_W != nullptr);
+  DRAKE_DEMAND(new_faces != nullptr);
+  DRAKE_DEMAND(vertices_to_newly_created_vertices != nullptr);
+  DRAKE_DEMAND(edges_to_newly_created_vertices != nullptr);
 
   const std::vector<SurfaceVertex<double>>& vertices_F = mesh_F.vertices();
   const SurfaceFace& triangle = mesh_F.element(tri_index);

--- a/geometry/proximity/mesh_intersection.cc
+++ b/geometry/proximity/mesh_intersection.cc
@@ -302,9 +302,9 @@ void SurfaceVolumeIntersector<T>::SampleVolumeFieldOnSurface(
     std::unique_ptr<SurfaceMesh<T>>* surface_MN_M,
     std::unique_ptr<SurfaceMeshFieldLinear<T, T>>* e_MN,
     std::vector<Vector3<T>>* grad_eM_Ms) {
-  DRAKE_DEMAND(surface_MN_M);
-  DRAKE_DEMAND(e_MN);
-  DRAKE_DEMAND(grad_eM_Ms);
+  DRAKE_DEMAND(surface_MN_M != nullptr);
+  DRAKE_DEMAND(e_MN != nullptr);
+  DRAKE_DEMAND(grad_eM_Ms != nullptr);
   grad_eM_Ms->clear();
 
   std::vector<SurfaceFace> surface_faces;

--- a/geometry/proximity/penetration_as_point_pair_callback.h
+++ b/geometry/proximity/penetration_as_point_pair_callback.h
@@ -31,9 +31,9 @@ struct CallbackData {
       : collision_filter(*collision_filter_in),
         X_WGs(*X_WGs_in),
         point_pairs(*point_pairs_in) {
-    DRAKE_DEMAND(collision_filter_in);
-    DRAKE_DEMAND(X_WGs_in);
-    DRAKE_DEMAND(point_pairs_in);
+    DRAKE_DEMAND(collision_filter_in != nullptr);
+    DRAKE_DEMAND(X_WGs_in != nullptr);
+    DRAKE_DEMAND(point_pairs_in != nullptr);
     request.num_max_contacts = 1;
     request.enable_contact = true;
     // NOTE: As of 5/1/2018 the GJK implementation of Libccd appears to be

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -760,8 +760,8 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
       ContactPolygonRepresentation representation,
       std::vector<ContactSurface<T>>* surfaces,
       std::vector<PenetrationAsPointPair<T>>* point_pairs) const {
-    DRAKE_DEMAND(surfaces);
-    DRAKE_DEMAND(point_pairs);
+    DRAKE_DEMAND(surfaces != nullptr);
+    DRAKE_DEMAND(point_pairs != nullptr);
 
     // All these quantities, except `representation`, are aliased in the
     // callback data.
@@ -787,8 +787,8 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
       const std::unordered_map<GeometryId, RigidTransform<T>>& X_WGs,
       std::vector<ContactSurface<T>>* surfaces,
       std::vector<PenetrationAsPointPair<T>>* point_pairs) const {
-    DRAKE_DEMAND(surfaces);
-    DRAKE_DEMAND(point_pairs);
+    DRAKE_DEMAND(surfaces != nullptr);
+    DRAKE_DEMAND(point_pairs != nullptr);
     ComputeContactSurfacesWithFallbackImpl(
         X_WGs, ContactPolygonRepresentation::kCentroidSubdivision, surfaces,
         point_pairs);
@@ -798,8 +798,8 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
       const std::unordered_map<GeometryId, RigidTransform<T>>& X_WGs,
       std::vector<ContactSurface<T>>* surfaces,
       std::vector<PenetrationAsPointPair<T>>* point_pairs) const {
-    DRAKE_DEMAND(surfaces);
-    DRAKE_DEMAND(point_pairs);
+    DRAKE_DEMAND(surfaces != nullptr);
+    DRAKE_DEMAND(point_pairs != nullptr);
     // TODO(14579): Change kSingleTriangle to the future polygon representation.
     ComputeContactSurfacesWithFallbackImpl(
         X_WGs, ContactPolygonRepresentation::kSingleTriangle, surfaces,

--- a/geometry/proximity_properties.cc
+++ b/geometry/proximity_properties.cc
@@ -86,14 +86,14 @@ void AddContactMaterial(
 
 void AddRigidHydroelasticProperties(double resolution_hint,
                                     ProximityProperties* properties) {
-  DRAKE_DEMAND(properties);
+  DRAKE_DEMAND(properties != nullptr);
   properties->AddProperty(internal::kHydroGroup, internal::kRezHint,
                           resolution_hint);
   AddRigidHydroelasticProperties(properties);
 }
 
 void AddRigidHydroelasticProperties(ProximityProperties* properties) {
-  DRAKE_DEMAND(properties);
+  DRAKE_DEMAND(properties != nullptr);
   // The bare minimum of defining a rigid geometry is to declare its compliance
   // type. Downstream consumers (ProximityEngine) will determine if this is
   // sufficient.
@@ -103,14 +103,14 @@ void AddRigidHydroelasticProperties(ProximityProperties* properties) {
 
 void AddSoftHydroelasticProperties(double resolution_hint,
                                    ProximityProperties* properties) {
-  DRAKE_DEMAND(properties);
+  DRAKE_DEMAND(properties != nullptr);
   properties->AddProperty(internal::kHydroGroup, internal::kRezHint,
                           resolution_hint);
   AddSoftHydroelasticProperties(properties);
 }
 
 void AddSoftHydroelasticProperties(ProximityProperties* properties) {
-  DRAKE_DEMAND(properties);
+  DRAKE_DEMAND(properties != nullptr);
   // The bare minimum of defining a soft geometry is to declare its compliance
   // type. Downstream consumers (ProximityEngine) will determine if this is
   // sufficient.
@@ -120,7 +120,7 @@ void AddSoftHydroelasticProperties(ProximityProperties* properties) {
 
 void AddSoftHydroelasticPropertiesForHalfSpace(
     double slab_thickness, ProximityProperties* properties) {
-  DRAKE_DEMAND(properties);
+  DRAKE_DEMAND(properties != nullptr);
   properties->AddProperty(internal::kHydroGroup, internal::kSlabThickness,
                           slab_thickness);
   AddSoftHydroelasticProperties(properties);

--- a/geometry/query_object.cc
+++ b/geometry/query_object.cc
@@ -127,8 +127,8 @@ template <typename T>
 void QueryObject<T>::ComputeContactSurfacesWithFallback(
     std::vector<ContactSurface<T>>* surfaces,
     std::vector<PenetrationAsPointPair<T>>* point_pairs) const {
-  DRAKE_DEMAND(surfaces);
-  DRAKE_DEMAND(point_pairs);
+  DRAKE_DEMAND(surfaces != nullptr);
+  DRAKE_DEMAND(point_pairs != nullptr);
 
   ThrowIfNotCallable();
 
@@ -141,8 +141,8 @@ template <typename T>
 void QueryObject<T>::ComputePolygonalContactSurfacesWithFallback(
     std::vector<ContactSurface<T>>* surfaces,
     std::vector<PenetrationAsPointPair<T>>* point_pairs) const {
-  DRAKE_DEMAND(surfaces);
-  DRAKE_DEMAND(point_pairs);
+  DRAKE_DEMAND(surfaces != nullptr);
+  DRAKE_DEMAND(point_pairs != nullptr);
 
   ThrowIfNotCallable();
 

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -742,8 +742,8 @@ class QueryObject {
   // `scene_graph` cannot be null.
   void set(const systems::Context<T>* context,
            const SceneGraph<T>* scene_graph) {
-    DRAKE_DEMAND(context);
-    DRAKE_DEMAND(scene_graph);
+    DRAKE_DEMAND(context != nullptr);
+    DRAKE_DEMAND(scene_graph != nullptr);
     state_.reset();
     context_ = context;
     scene_graph_ = scene_graph;

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -629,7 +629,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
    @code
    const ProximityProperties* old_props =
        scene_graph.model_inspector().GetProximityProperties(geometry_id);
-   DRAKE_DEMAND(old_props);
+   DRAKE_DEMAND(old_props != nullptr);
    ProximityProperties new_props(*old_props);
    // Add a new property.
    new_props.AddProperty("group", "new_prop_name", some_value);

--- a/geometry/utilities.h
+++ b/geometry/utilities.h
@@ -62,7 +62,7 @@ class MapKeyRange {
   };
 
   explicit MapKeyRange(const std::unordered_map<K, V>* map) : map_(map) {
-    DRAKE_DEMAND(map);
+    DRAKE_DEMAND(map != nullptr);
   }
   ConstIterator begin() const { return ConstIterator(map_->cbegin()); }
   ConstIterator end() const { return ConstIterator(map_->cend()); }

--- a/manipulation/planner/constraint_relaxing_ik.cc
+++ b/manipulation/planner/constraint_relaxing_ik.cc
@@ -40,7 +40,7 @@ bool ConstraintRelaxingIk::PlanSequentialTrajectory(
     const std::vector<IkCartesianWaypoint>& waypoints,
     const VectorX<double>& q_current,
     std::vector<Eigen::VectorXd>* q_sol_out) {
-  DRAKE_DEMAND(q_sol_out);
+  DRAKE_DEMAND(q_sol_out != nullptr);
   int num_steps = static_cast<int>(waypoints.size());
 
   VectorX<double> q0 = q_current;
@@ -154,7 +154,7 @@ bool ConstraintRelaxingIk::SolveIk(
     const VectorX<double>& q0,
     const Vector3<double>& pos_tol, double rot_tol,
     VectorX<double>* q_res) {
-  DRAKE_DEMAND(q_res);
+  DRAKE_DEMAND(q_res != nullptr);
 
   multibody::InverseKinematics ik(plant_);
 

--- a/manipulation/planner/differential_inverse_kinematics_integrator.cc
+++ b/manipulation/planner/differential_inverse_kinematics_integrator.cc
@@ -90,7 +90,7 @@ void DifferentialInverseKinematicsIntegrator::DoCalcDiscreteVariableUpdates(
     systems::DiscreteValues<double>* discrete_state) const {
   unused(events);
   const AbstractValue* input = this->EvalAbstractInput(context, 0);
-  DRAKE_DEMAND(input);
+  DRAKE_DEMAND(input != nullptr);
   const math::RigidTransformd& X_WE_desired =
       input->get_value<math::RigidTransformd>();
   const math::RigidTransform<double> X_WE = ForwardKinematics(context);

--- a/multibody/constraint/constraint_solver.h
+++ b/multibody/constraint/constraint_solver.h
@@ -816,7 +816,7 @@ ProblemData* ConstraintSolver<T>::UpdateProblemDataForUnilateralConstraints(
     int gv_dim,
     ProblemData* modified_problem_data) {
   // Verify that the modified problem data points to something.
-  DRAKE_DEMAND(modified_problem_data);
+  DRAKE_DEMAND(modified_problem_data != nullptr);
 
   // Get the number of equality constraints.
   const int num_eq_constraints = problem_data.kG.size();
@@ -882,7 +882,7 @@ void ConstraintSolver<T>::FormAndSolveConstraintLinearSystem(
   using std::max;
   using std::abs;
 
-  DRAKE_DEMAND(cf);
+  DRAKE_DEMAND(cf != nullptr);
 
   // Alias problem data.
   const std::vector<int>& sliding_contacts = problem_data.sliding_contacts;
@@ -944,7 +944,7 @@ void ConstraintSolver<T>::FormAndSolveConstraintLcp(
   using std::max;
   using std::abs;
 
-  DRAKE_DEMAND(cf);
+  DRAKE_DEMAND(cf != nullptr);
 
   // Alias problem data.
   const std::vector<int>& sliding_contacts = problem_data.sliding_contacts;
@@ -1528,9 +1528,9 @@ void ConstraintSolver<T>::UpdateDiscretizedTimeLcp(
     VectorX<T>* a,
     MatrixX<T>* MM,
     VectorX<T>* qq) {
-  DRAKE_DEMAND(MM);
-  DRAKE_DEMAND(qq);
-  DRAKE_DEMAND(a);
+  DRAKE_DEMAND(MM != nullptr);
+  DRAKE_DEMAND(qq != nullptr);
+  DRAKE_DEMAND(a != nullptr);
 
   // Look for early exit.
   if (qq->rows() == 0)
@@ -1620,9 +1620,9 @@ void ConstraintSolver<T>::ConstructBaseDiscretizedTimeLcp(
     MlcpToLcpData* mlcp_to_lcp_data,
     MatrixX<T>* MM,
     VectorX<T>* qq) {
-  DRAKE_DEMAND(MM);
-  DRAKE_DEMAND(qq);
-  DRAKE_DEMAND(mlcp_to_lcp_data);
+  DRAKE_DEMAND(MM != nullptr);
+  DRAKE_DEMAND(qq != nullptr);
+  DRAKE_DEMAND(mlcp_to_lcp_data != nullptr);
 
   // Get number of contacts and limits.
   const int num_contacts = problem_data.mu.size();
@@ -1704,7 +1704,7 @@ void ConstraintSolver<T>::ComputeInverseInertiaTimesGT(
     std::function<VectorX<T>(const VectorX<T>&)> G_transpose_mult,
     int m,
     MatrixX<T>* iM_GT) {
-  DRAKE_DEMAND(iM_GT);
+  DRAKE_DEMAND(iM_GT != nullptr);
   DRAKE_DEMAND(iM_GT->cols() == m);
 
   VectorX<T> basis(m);  // Basis vector.
@@ -1774,8 +1774,8 @@ void ConstraintSolver<T>::FormSustainedConstraintLinearSystem(
     const ConstraintAccelProblemData<T>& problem_data,
     const VectorX<T>& trunc_neg_invA_a,
     MatrixX<T>* MM, VectorX<T>* qq) {
-  DRAKE_DEMAND(MM);
-  DRAKE_DEMAND(qq);
+  DRAKE_DEMAND(MM != nullptr);
+  DRAKE_DEMAND(qq != nullptr);
 
   // Get numbers of types of contacts.
   const int num_sliding = problem_data.sliding_contacts.size();
@@ -1862,8 +1862,8 @@ void ConstraintSolver<T>::FormSustainedConstraintLcp(
     const ConstraintAccelProblemData<T>& problem_data,
     const VectorX<T>& trunc_neg_invA_a,
     MatrixX<T>* MM, VectorX<T>* qq) {
-  DRAKE_DEMAND(MM);
-  DRAKE_DEMAND(qq);
+  DRAKE_DEMAND(MM != nullptr);
+  DRAKE_DEMAND(qq != nullptr);
 
   // Get numbers of types of contacts.
   const int num_sliding = problem_data.sliding_contacts.size();
@@ -2069,8 +2069,8 @@ void ConstraintSolver<T>::FormImpactingConstraintLcp(
     const ConstraintVelProblemData<T>& problem_data,
     const VectorX<T>& trunc_neg_invA_a,
     MatrixX<T>* MM, VectorX<T>* qq) {
-  DRAKE_DEMAND(MM);
-  DRAKE_DEMAND(qq);
+  DRAKE_DEMAND(MM != nullptr);
+  DRAKE_DEMAND(qq != nullptr);
 
   // Get numbers of contacts.
   const int num_contacts = problem_data.mu.size();

--- a/multibody/constraint/test/constraint_solver_test.cc
+++ b/multibody/constraint/test/constraint_solver_test.cc
@@ -279,7 +279,7 @@ class Constraint2DSolverTest : public ::testing::Test {
   void SolveDiscretizationProblem(
       const ConstraintVelProblemData<double>& problem_data, double dt,
       VectorX<double>* cf) {
-    DRAKE_DEMAND(cf);
+    DRAKE_DEMAND(cf != nullptr);
 
     VectorX<double> qq, a;
     MatrixX<double> MM;

--- a/multibody/contact_solvers/test/multibody_sim_driver.cc
+++ b/multibody/contact_solvers/test/multibody_sim_driver.cc
@@ -70,7 +70,7 @@ void MultibodySimDriver::SetPointContactParameters(const Body<double>& body,
   for (const auto& id : geometries) {
     const geometry::ProximityProperties* old_props =
         inspector.GetProximityProperties(id);
-    DRAKE_DEMAND(old_props);
+    DRAKE_DEMAND(old_props != nullptr);
     geometry::ProximityProperties new_props(*old_props);
     // Update to a new property. If not existent, UpdateProperty() behaves as
     // AddProperty.
@@ -97,7 +97,7 @@ std::vector<double> MultibodySimDriver::GetDynamicFrictionCoefficients(
   for (const auto& id : geometries) {
     const geometry::ProximityProperties* props =
         inspector.GetProximityProperties(id);
-    DRAKE_DEMAND(props);
+    DRAKE_DEMAND(props != nullptr);
     const auto& friction = props->GetProperty<CoulombFriction<double>>(
         geometry::internal::kMaterialGroup, geometry::internal::kFriction);
     params.push_back(friction.dynamic_friction());

--- a/multibody/contact_solvers/test/multibody_sim_driver.h
+++ b/multibody/contact_solvers/test/multibody_sim_driver.h
@@ -45,13 +45,13 @@ class MultibodySimDriver {
 
   // @pre BuildModel() must have been called.
   const MultibodyPlant<double>& plant() const {
-    DRAKE_DEMAND(plant_);
+    DRAKE_DEMAND(plant_ != nullptr);
     return *plant_;
   }
 
   // @pre BuildModel() must have been called.
   MultibodyPlant<double>& mutable_plant() {
-    DRAKE_DEMAND(plant_);
+    DRAKE_DEMAND(plant_ != nullptr);
     return *plant_;
   }
 

--- a/multibody/inverse_kinematics/inverse_kinematics.cc
+++ b/multibody/inverse_kinematics/inverse_kinematics.cc
@@ -35,7 +35,7 @@ InverseKinematics::InverseKinematics(const MultibodyPlant<double>& plant,
       owned_context_(nullptr),
       context_(plant_context),
       q_(prog_->NewContinuousVariables(plant.num_positions(), "q")) {
-  DRAKE_DEMAND(plant_context);
+  DRAKE_DEMAND(plant_context != nullptr);
   if (with_joint_limits) {
     prog_->AddBoundingBoxConstraint(plant.GetPositionLowerLimits(),
                                     plant.GetPositionUpperLimits(), q_);

--- a/multibody/inverse_kinematics/kinematic_constraint_utilities.cc
+++ b/multibody/inverse_kinematics/kinematic_constraint_utilities.cc
@@ -23,7 +23,7 @@ bool AreAutoDiffVecXdEqual(const Eigen::Ref<const VectorX<AutoDiffXd>>& a,
 void UpdateContextConfiguration(drake::systems::Context<double>* context,
                                 const MultibodyPlant<double>& plant,
                                 const Eigen::Ref<const VectorX<double>>& q) {
-  DRAKE_ASSERT(context);
+  DRAKE_ASSERT(context != nullptr);
   if (q != plant.GetPositions(*context)) {
     plant.SetPositions(context, q);
   }
@@ -39,7 +39,7 @@ void UpdateContextConfiguration(drake::systems::Context<double>* context,
 void UpdateContextConfiguration(systems::Context<AutoDiffXd>* context,
                                 const MultibodyPlant<AutoDiffXd>& plant,
                                 const Eigen::Ref<const AutoDiffVecXd>& q) {
-  DRAKE_ASSERT(context);
+  DRAKE_ASSERT(context != nullptr);
   if (!AreAutoDiffVecXdEqual(q, plant.GetPositions(*context))) {
     plant.SetPositions(context, q);
   }
@@ -48,7 +48,7 @@ void UpdateContextConfiguration(systems::Context<AutoDiffXd>* context,
 void UpdateContextPositionsAndVelocities(
     systems::Context<double>* context, const MultibodyPlant<double>& plant,
     const Eigen::Ref<const Eigen::VectorXd>& q_v) {
-  DRAKE_ASSERT(context);
+  DRAKE_ASSERT(context != nullptr);
   if (q_v != plant.GetPositionsAndVelocities(*context)) {
     plant.SetPositionsAndVelocities(context, q_v);
   }
@@ -65,7 +65,7 @@ void UpdateContextPositionsAndVelocities(
     systems::Context<AutoDiffXd>* context,
     const MultibodyPlant<AutoDiffXd>& plant,
     const Eigen::Ref<const AutoDiffVecXd>& q_v) {
-  DRAKE_ASSERT(context);
+  DRAKE_ASSERT(context != nullptr);
   if (!AreAutoDiffVecXdEqual(q_v, plant.GetPositionsAndVelocities(*context))) {
     plant.SetPositionsAndVelocities(context, q_v);
   }

--- a/multibody/optimization/contact_wrench_evaluator.h
+++ b/multibody/optimization/contact_wrench_evaluator.h
@@ -110,8 +110,8 @@ class ContactWrenchEvaluator : public solvers::EvaluatorBase {
         context_(context),
         geometry_id_pair_{geometry_id_pair},
         num_lambda_{num_lambda} {
-    DRAKE_DEMAND(plant);
-    DRAKE_DEMAND(context);
+    DRAKE_DEMAND(plant != nullptr);
+    DRAKE_DEMAND(context != nullptr);
     DRAKE_DEMAND(num_lambda >= 0);
   }
 

--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -587,7 +587,7 @@ std::string LoadSdf(
       root_dir = ".";
     }
   } else {
-    DRAKE_DEMAND(data_source.file_contents);
+    DRAKE_DEMAND(data_source.file_contents != nullptr);
     ThrowAnyErrors(root->LoadSdfString(*data_source.file_contents,
                                        parser_config));
   }

--- a/multibody/parsing/detail_urdf_geometry.cc
+++ b/multibody/parsing/detail_urdf_geometry.cc
@@ -31,7 +31,7 @@ UrdfMaterial AddMaterialToMaterialMap(const std::string& material_name,
                                       UrdfMaterial material,
                                       bool abort_if_name_clash,
                                       MaterialMap* materials) {
-  DRAKE_DEMAND(materials);
+  DRAKE_DEMAND(materials != nullptr);
   // Determines if the material is already in the map.
   auto material_iter = materials->find(material_name);
   if (material_iter != materials->end()) {

--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -152,7 +152,7 @@ void ParseBody(const multibody::PackageMap& package_map,
          collision_node = collision_node->NextSiblingElement("collision")) {
       geometry::GeometryInstance geometry_instance =
           ParseCollision(body_name, package_map, root_dir, collision_node);
-      DRAKE_DEMAND(geometry_instance.proximity_properties());
+      DRAKE_DEMAND(geometry_instance.proximity_properties() != nullptr);
       plant->RegisterCollisionGeometry(
           body, geometry_instance.pose(), geometry_instance.shape(),
           geometry_instance.name(),
@@ -818,7 +818,7 @@ ModelInstanceIndex AddModelFromUrdf(
           full_path, xml_doc.ErrorName()));
     }
   } else {
-    DRAKE_DEMAND(data_source.file_contents);
+    DRAKE_DEMAND(data_source.file_contents != nullptr);
     xml_doc.Parse(data_source.file_contents->c_str());
     if (xml_doc.ErrorID()) {
       throw std::runtime_error(fmt::format(

--- a/multibody/plant/hydroelastic_contact_info.h
+++ b/multibody/plant/hydroelastic_contact_info.h
@@ -75,7 +75,7 @@ class HydroelasticContactInfo {
       : contact_surface_(contact_surface),
         F_Ac_W_(F_Ac_W),
         quadrature_point_data_(std::move(quadrature_point_data)) {
-    DRAKE_DEMAND(contact_surface);
+    DRAKE_DEMAND(contact_surface != nullptr);
   }
 
   /** This constructor takes ownership of `contact_surface` via a
@@ -91,8 +91,7 @@ class HydroelasticContactInfo {
         F_Ac_W_(F_Ac_W),
         quadrature_point_data_(std::move(quadrature_point_data)) {
     DRAKE_DEMAND(std::get<std::unique_ptr<geometry::ContactSurface<T>>>(
-                     contact_surface_)
-                     .get());
+                     contact_surface_) != nullptr);
   }
   // @}
 

--- a/multibody/plant/hydroelastic_traction_calculator.cc
+++ b/multibody/plant/hydroelastic_traction_calculator.cc
@@ -30,8 +30,8 @@ void HydroelasticTractionCalculator<T>::
         std::vector<HydroelasticQuadraturePointData<T>>*
             traction_at_quadrature_points,
         SpatialForce<T>* F_Ac_W) const {
-  DRAKE_DEMAND(traction_at_quadrature_points);
-  DRAKE_DEMAND(F_Ac_W);
+  DRAKE_DEMAND(traction_at_quadrature_points != nullptr);
+  DRAKE_DEMAND(F_Ac_W != nullptr);
 
   // Use a second-order Gaussian quadrature rule. For linear pressure fields,
   // the second-order rule allows exact computation (to floating point error)

--- a/multibody/plant/hydroelastic_traction_calculator.h
+++ b/multibody/plant/hydroelastic_traction_calculator.h
@@ -44,7 +44,7 @@ class HydroelasticTractionCalculator {
             X_WA(X_WA_in), X_WB(X_WB_in), V_WA(V_WA_in), V_WB(V_WB_in),
             surface(*surface_in),
             p_WC(surface_in->mesh_W().centroid()) {
-      DRAKE_DEMAND(surface_in);
+      DRAKE_DEMAND(surface_in != nullptr);
     }
 
     // The pose of Body A (the body that Geometry `surface.M_id()` in the

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1900,7 +1900,7 @@ void MultibodyPlant<T>::CalcContactSurfaces(
     const drake::systems::Context<T>& context,
     std::vector<ContactSurface<T>>* contact_surfaces) const {
   this->ValidateContext(context);
-  DRAKE_DEMAND(contact_surfaces);
+  DRAKE_DEMAND(contact_surfaces != nullptr);
 
   const auto& query_object = EvalGeometryQueryInput(context);
 
@@ -2420,7 +2420,7 @@ template <typename T>
 void MultibodyPlant<T>::CalcGeneralizedContactForcesContinuous(
     const Context<T>& context, VectorX<T>* tau_contact) const {
   this->ValidateContext(context);
-  DRAKE_DEMAND(tau_contact);
+  DRAKE_DEMAND(tau_contact != nullptr);
   DRAKE_DEMAND(tau_contact->size() == num_velocities());
   DRAKE_DEMAND(!is_discrete());
   const int nv = this->num_velocities();
@@ -2461,7 +2461,7 @@ void MultibodyPlant<T>::CalcSpatialContactForcesContinuous(
       const drake::systems::Context<T>& context,
       std::vector<SpatialForce<T>>* F_BBo_W_array) const {
   this->ValidateContext(context);
-  DRAKE_DEMAND(F_BBo_W_array);
+  DRAKE_DEMAND(F_BBo_W_array != nullptr);
   DRAKE_DEMAND(static_cast<int>(F_BBo_W_array->size()) == num_bodies());
   DRAKE_DEMAND(!is_discrete());
 

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -725,13 +725,13 @@ class MultibodyTree {
 
   // An accessor to the current gravity field.
   const UniformGravityFieldElement<T>& gravity_field() const {
-    DRAKE_ASSERT(gravity_field_);
+    DRAKE_ASSERT(gravity_field_ != nullptr);
     return *gravity_field_;
   }
 
   // A mutable accessor to the current gravity field.
   UniformGravityFieldElement<T>& mutable_gravity_field() {
-    DRAKE_ASSERT(gravity_field_);
+    DRAKE_ASSERT(gravity_field_ != nullptr);
     return *gravity_field_;
   }
 
@@ -2137,7 +2137,7 @@ class MultibodyTree {
     tree_clone->gravity_field_ =
         dynamic_cast<UniformGravityFieldElement<ToScalar>*>(
             tree_clone->owned_force_elements_[0].get());
-    DRAKE_DEMAND(tree_clone->gravity_field_);
+    DRAKE_DEMAND(tree_clone->gravity_field_ != nullptr);
 
     // Since Joint<T> objects are implemented from basic element objects like
     // Body, Mobilizer, ForceElement and Constraint, they are cloned last so

--- a/multibody/tree/test/ball_rpy_joint_test.cc
+++ b/multibody/tree/test/ball_rpy_joint_test.cc
@@ -46,7 +46,7 @@ class BallRpyJointTest : public ::testing::Test {
                                             kDamping);
     mutable_joint_ = dynamic_cast<BallRpyJoint<double>*>(
         &model->get_mutable_joint(joint_->index()));
-    DRAKE_DEMAND(mutable_joint_);
+    DRAKE_DEMAND(mutable_joint_ != nullptr);
     mutable_joint_->set_position_limits(
         Vector3d::Constant(kPositionLowerLimit),
         Vector3d::Constant(kPositionUpperLimit));

--- a/multibody/tree/test/planar_joint_test.cc
+++ b/multibody/tree/test/planar_joint_test.cc
@@ -48,7 +48,7 @@ class PlanarJointTest : public ::testing::Test {
                                            Vector3d::Constant(kDamping));
     mutable_joint_ = dynamic_cast<PlanarJoint<double>*>(
         &model->get_mutable_joint(joint_->index()));
-    DRAKE_DEMAND(mutable_joint_);
+    DRAKE_DEMAND(mutable_joint_ != nullptr);
     mutable_joint_->set_position_limits(
         Vector3d::Constant(kPositionLowerLimit),
         Vector3d::Constant(kPositionUpperLimit));

--- a/multibody/tree/test/revolute_joint_test.cc
+++ b/multibody/tree/test/revolute_joint_test.cc
@@ -47,7 +47,7 @@ class RevoluteJointTest : public ::testing::Test {
         Vector3d::UnitZ(), kPositionLowerLimit, kPositionUpperLimit, kDamping);
     mutable_joint1_ = dynamic_cast<RevoluteJoint<double>*>(
         &model->get_mutable_joint(joint1_->index()));
-    DRAKE_DEMAND(mutable_joint1_);
+    DRAKE_DEMAND(mutable_joint1_ != nullptr);
     mutable_joint1_->set_velocity_limits(
         Vector1<double>::Constant(kVelocityLowerLimit),
         Vector1<double>::Constant(kVelocityUpperLimit));

--- a/multibody/tree/test/screw_joint_test.cc
+++ b/multibody/tree/test/screw_joint_test.cc
@@ -40,7 +40,7 @@ class ScrewJointTest : public ::testing::Test {
                                           kScrewPitch, kDamping);
     mutable_joint_ = dynamic_cast<ScrewJoint<double>*>(
         &model->get_mutable_joint(joint_->index()));
-    DRAKE_DEMAND(mutable_joint_);
+    DRAKE_DEMAND(mutable_joint_ != nullptr);
     mutable_joint_->set_position_limits(
         Vector1d::Constant(kPositionLowerLimit),
         Vector1d::Constant(kPositionUpperLimit));

--- a/multibody/tree/test/universal_joint_test.cc
+++ b/multibody/tree/test/universal_joint_test.cc
@@ -46,7 +46,7 @@ class UniversalJointTest : public ::testing::Test {
                                               std::nullopt, kDamping);
     mutable_joint_ = dynamic_cast<UniversalJoint<double>*>(
         &model->get_mutable_joint(joint_->index()));
-    DRAKE_DEMAND(mutable_joint_);
+    DRAKE_DEMAND(mutable_joint_ != nullptr);
     mutable_joint_->set_position_limits(
         Vector2d::Constant(kPositionLowerLimit),
         Vector2d::Constant(kPositionUpperLimit));

--- a/solvers/branch_and_bound.cc
+++ b/solvers/branch_and_bound.cc
@@ -95,7 +95,7 @@ SolutionResult SolveProgramWithSolver(const MathematicalProgram& prog,
                                       const SolverId& solver_id,
                                       MathematicalProgramResult* result) {
   std::unique_ptr<SolverInterface> solver = MakeSolver(solver_id);
-  DRAKE_ASSERT(solver.get());
+  DRAKE_ASSERT(solver != nullptr);
   solver->Solve(prog, {}, {}, result);
   return result->get_solution_result();
 }

--- a/solvers/create_constraint.cc
+++ b/solvers/create_constraint.cc
@@ -233,8 +233,8 @@ namespace {
 //
 void FindBound(const Expression& e1, const Expression& e2, Expression* const e,
                double* const c) {
-  DRAKE_ASSERT(e);
-  DRAKE_ASSERT(c);
+  DRAKE_ASSERT(e != nullptr);
+  DRAKE_ASSERT(c != nullptr);
   double c1 = 0;
   double c2 = 0;
   const Expression e1_expanded{e1.Expand()};

--- a/solvers/gurobi_solver.cc
+++ b/solvers/gurobi_solver.cc
@@ -1036,7 +1036,7 @@ void GurobiSolver::DoSolve(
   // Note that it is not necessary to free this environment; rather,
   // we just have to call GRBfreemodel(model).
   GRBenv* model_env = GRBgetenv(model);
-  DRAKE_DEMAND(model_env);
+  DRAKE_DEMAND(model_env != nullptr);
 
   // Handle common solver options before gurobi-specific options stored in
   // merged_options, so that gurobi-specific options can overwrite common solver

--- a/solvers/integer_inequality_solver.cc
+++ b/solvers/integer_inequality_solver.cc
@@ -59,7 +59,7 @@ IntegerVectorList BuildAlphabetFromBounds(const Eigen::VectorXi& lower_bound,
 enum class ColumnType { Nonnegative, Nonpositive, Indefinite };
 std::vector<ColumnType> ProcessInputs(const Eigen::MatrixXi& A,
                                       IntegerVectorList* alphabet) {
-  DRAKE_ASSERT(alphabet);
+  DRAKE_ASSERT(alphabet != nullptr);
   int cnt = 0;
   std::vector<ColumnType> column_type(A.cols(), ColumnType::Indefinite);
 

--- a/solvers/unrevised_lemke_solver.cc
+++ b/solvers/unrevised_lemke_solver.cc
@@ -392,7 +392,7 @@ bool UnrevisedLemkeSolver<T>::LemkePivot(
     T zero_tol,
     VectorX<T>* M_prime_col,
     VectorX<T>* q_prime) const {
-  DRAKE_DEMAND(q_prime);
+  DRAKE_DEMAND(q_prime != nullptr);
 
   const int kArtificial = M.rows();
   DRAKE_DEMAND(driving_index >= 0 && driving_index <= kArtificial);
@@ -404,7 +404,7 @@ bool UnrevisedLemkeSolver<T>::LemkePivot(
   // If the driving index does not correspond to the artificial variable,
   // M_prime_col must be non-null.
   if (!IsArtificial(indep_variables_[driving_index]))
-    DRAKE_DEMAND(M_prime_col);
+    DRAKE_DEMAND(M_prime_col != nullptr);
 
   // Determine the sets.
   DetermineIndexSets();
@@ -555,7 +555,7 @@ bool UnrevisedLemkeSolver<T>::ConstructLemkeSolution(
     int artificial_index,
     T zero_tol,
     VectorX<T>* z) const {
-  DRAKE_DEMAND(z);
+  DRAKE_DEMAND(z != nullptr);
   const int n = q.rows();
 
   // Compute the solution by pivoting the artificial variable, which was just
@@ -581,7 +581,7 @@ template <typename T>
 bool UnrevisedLemkeSolver<T>::FindBlockingIndex(
     const T& zero_tol, const VectorX<T>& matrix_col, const VectorX<T>& ratios,
     int* blocking_index) const {
-  DRAKE_DEMAND(blocking_index);
+  DRAKE_DEMAND(blocking_index != nullptr);
   DRAKE_DEMAND(ratios.size() == matrix_col.size());
   DRAKE_DEMAND(zero_tol > 0);
 
@@ -670,7 +670,7 @@ bool UnrevisedLemkeSolver<T>::SolveLcpLemke(const MatrixX<T>& M,
                                      const T& zero_tol) const {
   using std::max;
   using std::abs;
-  DRAKE_DEMAND(num_pivots);
+  DRAKE_DEMAND(num_pivots != nullptr);
 
   DRAKE_LOGGER_DEBUG(
       "UnrevisedLemkeSolver::SolveLcpLemke() entered, M: {}, "

--- a/systems/analysis/implicit_euler_integrator.cc
+++ b/systems/analysis/implicit_euler_integrator.cc
@@ -390,8 +390,8 @@ template <class T>
 bool ImplicitEulerIntegrator<T>::AttemptStepPaired(const T& t0, const T& h,
     const VectorX<T>& xt0, VectorX<T>* xtplus_ie, VectorX<T>* xtplus_hie) {
   using std::abs;
-  DRAKE_ASSERT(xtplus_ie);
-  DRAKE_ASSERT(xtplus_hie);
+  DRAKE_ASSERT(xtplus_ie != nullptr);
+  DRAKE_ASSERT(xtplus_hie != nullptr);
 
   // Compute the derivative at time and state (t0, x(t0)). NOTE: the derivative
   // is calculated at this point (early on in the integration process) in order

--- a/systems/analysis/implicit_integrator.cc
+++ b/systems/analysis/implicit_integrator.cc
@@ -339,7 +339,7 @@ void ImplicitIntegrator<T>::FreshenMatricesIfFullNewton(
         typename ImplicitIntegrator<T>::IterationMatrix*)>&
         compute_and_factor_iteration_matrix,
     typename ImplicitIntegrator<T>::IterationMatrix* iteration_matrix) {
-  DRAKE_DEMAND(iteration_matrix);
+  DRAKE_DEMAND(iteration_matrix != nullptr);
 
   // Return immediately if full-Newton is not in use.
   if (!get_use_full_newton()) return;

--- a/systems/analysis/initial_value_problem.h
+++ b/systems/analysis/initial_value_problem.h
@@ -195,13 +195,13 @@ class InitialValueProblem {
 
   /// Gets a reference to the internal integrator instance.
   const IntegratorBase<T>& get_integrator() const {
-    DRAKE_DEMAND(integrator_.get());
+    DRAKE_DEMAND(integrator_ != nullptr);
     return *integrator_.get();
   }
 
   /// Gets a mutable reference to the internal integrator instance.
   IntegratorBase<T>& get_mutable_integrator() {
-    DRAKE_DEMAND(integrator_.get());
+    DRAKE_DEMAND(integrator_ != nullptr);
     return *integrator_.get();
   }
 

--- a/systems/analysis/radau_integrator.cc
+++ b/systems/analysis/radau_integrator.cc
@@ -456,8 +456,8 @@ template <typename T, int num_stages>
 bool RadauIntegrator<T, num_stages>::AttemptStepPaired(const T& t0, const T& h,
     const VectorX<T>& xt0, VectorX<T>* xtplus_radau, VectorX<T>* xtplus_itr) {
   using std::abs;
-  DRAKE_ASSERT(xtplus_radau);
-  DRAKE_ASSERT(xtplus_itr);
+  DRAKE_ASSERT(xtplus_radau != nullptr);
+  DRAKE_ASSERT(xtplus_itr != nullptr);
   DRAKE_ASSERT(xtplus_radau->size() == xt0.size());
   DRAKE_ASSERT(xtplus_itr->size() == xt0.size());
 

--- a/systems/analysis/simulator.cc
+++ b/systems/analysis/simulator.cc
@@ -399,7 +399,7 @@ void Simulator<T>::IsolateWitnessTriggers(
     std::vector<const WitnessFunction<T>*>* triggered_witnesses) {
 
   // Verify that the vector of triggered witnesses is non-null.
-  DRAKE_DEMAND(triggered_witnesses);
+  DRAKE_DEMAND(triggered_witnesses != nullptr);
 
   // TODO(edrumwri): Speed this process using interpolation between states,
   // more powerful root finding methods, and/or introducing the concept of
@@ -567,7 +567,7 @@ Simulator<T>::IntegrateContinuousState(
   using std::abs;
 
   // Clear the composite event collection.
-  DRAKE_ASSERT(witnessed_events);
+  DRAKE_ASSERT(witnessed_events != nullptr);
   witnessed_events->Clear();
 
   // Save the time and current state.

--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -710,7 +710,7 @@ class Simulator {
   // TODO(sherm1) Add an option where the Simulator returns failed status
   // rather than throwing.
   void CallMonitorUpdateStatusAndMaybeThrow(SimulatorStatus* status) {
-    DRAKE_DEMAND(status);
+    DRAKE_DEMAND(status != nullptr);
     if (!get_monitor()) return;
     const EventStatus monitor_status = get_monitor()(*context_);
     if (monitor_status.severity() == EventStatus::kReachedTermination) {

--- a/systems/controllers/inverse_dynamics.cc
+++ b/systems/controllers/inverse_dynamics.cc
@@ -16,7 +16,7 @@ InverseDynamics<T>::InverseDynamics(const MultibodyPlant<T>* plant,
       mode_(mode),
       q_dim_(plant->num_positions()),
       v_dim_(plant->num_velocities()) {
-  DRAKE_DEMAND(multibody_plant_);
+  DRAKE_DEMAND(multibody_plant_ != nullptr);
   DRAKE_DEMAND(plant->is_finalized());
 
   input_port_index_state_ =

--- a/systems/estimators/luenberger_observer.cc
+++ b/systems/estimators/luenberger_observer.cc
@@ -16,7 +16,7 @@ LuenbergerObserver<T>::LuenbergerObserver(
     : owned_system_(std::move(owned_system)),
       observed_system_(owned_system_ ? owned_system_.get() : system),
       observer_gain_(observer_gain) {
-  DRAKE_DEMAND(observed_system_);
+  DRAKE_DEMAND(observed_system_ != nullptr);
   observed_system_->ValidateContext(observed_system_context);
 
   // Note: Could potentially extend this to MIMO systems.

--- a/systems/framework/cache_entry.cc
+++ b/systems/framework/cache_entry.cc
@@ -21,7 +21,7 @@ CacheEntry::CacheEntry(
       description_(std::move(description)),
       value_producer_(std::move(value_producer)),
       prerequisites_of_calc_(std::move(prerequisites_of_calc)) {
-  DRAKE_DEMAND(owning_system);
+  DRAKE_DEMAND(owning_system != nullptr);
   DRAKE_DEMAND(index.is_valid() && ticket.is_valid());
   DRAKE_DEMAND(value_producer_.is_valid());
 

--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -735,7 +735,7 @@ class Context : public ContextBase {
   /// invalidation notifications. Use get_mutable_parameters() instead for
   /// normal access.
   static Parameters<T>& access_mutable_parameters(Context<T>* context) {
-    DRAKE_ASSERT(context);
+    DRAKE_ASSERT(context != nullptr);
     return *context->parameters_;
   }
 
@@ -743,7 +743,7 @@ class Context : public ContextBase {
   /// invalidation notifications. Use get_mutable_state() instead for normal
   /// access.
   static State<T>& access_mutable_state(Context<T>* context) {
-    DRAKE_ASSERT(context);
+    DRAKE_ASSERT(context != nullptr);
     return context->do_access_mutable_state();
   }
 

--- a/systems/framework/context_base.h
+++ b/systems/framework/context_base.h
@@ -740,7 +740,7 @@ class SystemBaseContextBaseAttorney {
   // SystemBase should invoke this when ContextBase has been successfully
   // initialized.
   static void mark_context_base_initialized(ContextBase* context) {
-    DRAKE_DEMAND(context);
+    DRAKE_DEMAND(context != nullptr);
     DRAKE_DEMAND(!context->is_context_base_initialized_);
     context->is_context_base_initialized_ = true;
   }

--- a/systems/framework/dependency_tracker.h
+++ b/systems/framework/dependency_tracker.h
@@ -169,7 +169,7 @@ class DependencyTracker {
   // This is for validating that this tracker is associated with the right
   // cache entry. Don't use this during runtime invalidation.
   const CacheEntryValue* cache_entry_value() const {
-    DRAKE_DEMAND(cache_value_);
+    DRAKE_DEMAND(cache_value_ != nullptr);
     if (!has_associated_cache_entry_)
       return nullptr;  // cache_value_ actually points to a dummy entry.
     return cache_value_;

--- a/systems/framework/diagram.cc
+++ b/systems/framework/diagram.cc
@@ -29,7 +29,7 @@ std::vector<const systems::System<T>*> Diagram<T>::GetSystems() const {
 
 template <typename T>
 void Diagram<T>::Accept(SystemVisitor<T>* v) const {
-  DRAKE_DEMAND(v);
+  DRAKE_DEMAND(v != nullptr);
   v->VisitDiagram(*this);
 }
 
@@ -623,14 +623,14 @@ template <typename T>
 void Diagram<T>::AddTriggeredWitnessFunctionToCompositeEventCollection(
     Event<T>* event,
     CompositeEventCollection<T>* events) const {
-  DRAKE_DEMAND(events);
-  DRAKE_DEMAND(event);
-  DRAKE_DEMAND(event->get_event_data());
+  DRAKE_DEMAND(events != nullptr);
+  DRAKE_DEMAND(event != nullptr);
+  DRAKE_DEMAND(event->get_event_data() != nullptr);
 
   // Get the event data- it will need to be modified.
   auto data = dynamic_cast<WitnessTriggeredEventData<T>*>(
       event->get_mutable_event_data());
-  DRAKE_DEMAND(data);
+  DRAKE_DEMAND(data != nullptr);
 
   // Get the vector of events corresponding to the subsystem.
   const System<T>& subsystem = data->triggered_witness()->get_system();
@@ -1124,7 +1124,7 @@ void Diagram<T>::DispatchPublishHandler(
     const Context<T>& context,
     const EventCollection<PublishEvent<T>>& event_info) const {
   auto diagram_context = dynamic_cast<const DiagramContext<T>*>(&context);
-  DRAKE_DEMAND(diagram_context);
+  DRAKE_DEMAND(diagram_context != nullptr);
   const DiagramEventCollection<PublishEvent<T>>& info =
       dynamic_cast<const DiagramEventCollection<PublishEvent<T>>&>(
           event_info);
@@ -1146,10 +1146,10 @@ void Diagram<T>::DispatchDiscreteVariableUpdateHandler(
     const EventCollection<DiscreteUpdateEvent<T>>& events,
     DiscreteValues<T>* discrete_state) const {
   auto diagram_context = dynamic_cast<const DiagramContext<T>*>(&context);
-  DRAKE_DEMAND(diagram_context);
+  DRAKE_DEMAND(diagram_context != nullptr);
   auto diagram_discrete =
       dynamic_cast<DiagramDiscreteValues<T>*>(discrete_state);
-  DRAKE_DEMAND(diagram_discrete);
+  DRAKE_DEMAND(diagram_discrete != nullptr);
 
   const DiagramEventCollection<DiscreteUpdateEvent<T>>& diagram_events =
       dynamic_cast<const DiagramEventCollection<DiscreteUpdateEvent<T>>&>(
@@ -1203,7 +1203,7 @@ void Diagram<T>::DispatchUnrestrictedUpdateHandler(
     const EventCollection<UnrestrictedUpdateEvent<T>>& events,
     State<T>* state) const {
   auto diagram_context = dynamic_cast<const DiagramContext<T>*>(&context);
-  DRAKE_DEMAND(diagram_context);
+  DRAKE_DEMAND(diagram_context != nullptr);
   auto diagram_state = dynamic_cast<DiagramState<T>*>(state);
   DRAKE_DEMAND(diagram_state != nullptr);
 

--- a/systems/framework/leaf_system.cc
+++ b/systems/framework/leaf_system.cc
@@ -355,11 +355,11 @@ template <typename T>
 void LeafSystem<T>::AddTriggeredWitnessFunctionToCompositeEventCollection(
     Event<T>* event,
     CompositeEventCollection<T>* events) const {
-  DRAKE_DEMAND(event);
-  DRAKE_DEMAND(event->get_event_data());
+  DRAKE_DEMAND(event != nullptr);
+  DRAKE_DEMAND(event->get_event_data() != nullptr);
   DRAKE_DEMAND(dynamic_cast<const WitnessTriggeredEventData<T>*>(
-      event->get_event_data()));
-  DRAKE_DEMAND(events);
+      event->get_event_data()) != nullptr);
+  DRAKE_DEMAND(events != nullptr);
   event->AddToComposite(events);
 }
 

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -1725,7 +1725,7 @@ class LeafSystem : public System<T> {
     auto fn = [this, publish_callback](
         const Context<T>& context, const PublishEvent<T>& publish_event) {
       auto system_ptr = dynamic_cast<const MySystem*>(this);
-      DRAKE_DEMAND(system_ptr);
+      DRAKE_DEMAND(system_ptr != nullptr);
       return (system_ptr->*publish_callback)(context, publish_event);
     };
     PublishEvent<T> publish_event(fn);
@@ -1753,7 +1753,7 @@ class LeafSystem : public System<T> {
     auto fn = [this, du_callback](const Context<T>& context,
         const DiscreteUpdateEvent<T>& du_event, DiscreteValues<T>* values) {
       auto system_ptr = dynamic_cast<const MySystem*>(this);
-      DRAKE_DEMAND(system_ptr);
+      DRAKE_DEMAND(system_ptr != nullptr);
       return (system_ptr->*du_callback)(context, du_event, values);
     };
     DiscreteUpdateEvent<T> du_event(fn);
@@ -1781,7 +1781,7 @@ class LeafSystem : public System<T> {
     auto fn = [this, uu_callback](const Context<T>& context,
         const UnrestrictedUpdateEvent<T>& uu_event, State<T>* state) {
       auto system_ptr = dynamic_cast<const MySystem*>(this);
-      DRAKE_DEMAND(system_ptr);
+      DRAKE_DEMAND(system_ptr != nullptr);
       return (system_ptr->*uu_callback)(context, uu_event, state);
     };
     UnrestrictedUpdateEvent<T> uu_event(fn);

--- a/systems/framework/system.cc
+++ b/systems/framework/system.cc
@@ -16,7 +16,7 @@ System<T>::~System() {}
 
 template <typename T>
 void System<T>::Accept(SystemVisitor<T>* v) const {
-  DRAKE_DEMAND(v);
+  DRAKE_DEMAND(v != nullptr);
   v->VisitSystem(*this);
 }
 
@@ -871,7 +871,7 @@ template <typename T>
 void System<T>::GetWitnessFunctions(
     const Context<T>& context,
     std::vector<const WitnessFunction<T>*>* w) const {
-  DRAKE_DEMAND(w);
+  DRAKE_DEMAND(w != nullptr);
   DRAKE_DEMAND(w->empty());
   ValidateContext(context);
   DoGetWitnessFunctions(context, w);

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -1639,37 +1639,37 @@ class System : public SystemBase {
   }
 
   EventCollection<PublishEvent<T>>& get_mutable_forced_publish_events() {
-    DRAKE_DEMAND(forced_publish_events_.get());
+    DRAKE_DEMAND(forced_publish_events_ != nullptr);
     return *forced_publish_events_;
   }
 
   EventCollection<DiscreteUpdateEvent<T>>&
   get_mutable_forced_discrete_update_events() {
-    DRAKE_DEMAND(forced_discrete_update_events_.get());
+    DRAKE_DEMAND(forced_discrete_update_events_ != nullptr);
     return *forced_discrete_update_events_;
   }
 
   EventCollection<UnrestrictedUpdateEvent<T>>&
   get_mutable_forced_unrestricted_update_events() {
-    DRAKE_DEMAND(forced_unrestricted_update_events_.get());
+    DRAKE_DEMAND(forced_unrestricted_update_events_ != nullptr);
     return *forced_unrestricted_update_events_;
   }
 
   const EventCollection<PublishEvent<T>>&
   get_forced_publish_events() const {
-    DRAKE_DEMAND(forced_publish_events_.get());
+    DRAKE_DEMAND(forced_publish_events_ != nullptr);
     return *forced_publish_events_;
   }
 
   const EventCollection<DiscreteUpdateEvent<T>>&
   get_forced_discrete_update_events() const {
-    DRAKE_DEMAND(forced_discrete_update_events_.get());
+    DRAKE_DEMAND(forced_discrete_update_events_ != nullptr);
     return *forced_discrete_update_events_;
   }
 
   const EventCollection<UnrestrictedUpdateEvent<T>>&
   get_forced_unrestricted_update_events() const {
-    DRAKE_DEMAND(forced_unrestricted_update_events_.get());
+    DRAKE_DEMAND(forced_unrestricted_update_events_ != nullptr);
     return *forced_unrestricted_update_events_;
   }
 

--- a/systems/framework/system_scalar_converter.h
+++ b/systems/framework/system_scalar_converter.h
@@ -220,7 +220,7 @@ void SystemScalarConverter::Add(const ConverterFunction<T, U>& func) {
   // is typed as `void* => void*` in order to have a non-templated signature
   // and thus fit into a homogeneously-typed std::unordered_map.
   Insert(typeid(T), typeid(U), [func](const void* const bare_u) {
-    DRAKE_ASSERT(bare_u);
+    DRAKE_ASSERT(bare_u != nullptr);
     const System<U>& other = *static_cast<const System<U>*>(bare_u);
     return func(other).release();
   });

--- a/systems/lcm/lcm_publisher_system.cc
+++ b/systems/lcm/lcm_publisher_system.cc
@@ -27,7 +27,7 @@ LcmPublisherSystem::LcmPublisherSystem(
       lcm_(lcm ? lcm : owned_lcm_.get()),
       publish_period_(publish_period) {
   DRAKE_DEMAND(serializer_ != nullptr);
-  DRAKE_DEMAND(lcm_);
+  DRAKE_DEMAND(lcm_ != nullptr);
   DRAKE_DEMAND(publish_period >= 0.0);
   DRAKE_DEMAND(!publish_triggers.empty());
 

--- a/systems/lcm/lcm_subscriber_system.cc
+++ b/systems/lcm/lcm_subscriber_system.cc
@@ -29,7 +29,7 @@ LcmSubscriberSystem::LcmSubscriberSystem(
       serializer_(std::move(serializer)),
       magic_number_{kMagic} {
   DRAKE_DEMAND(serializer_ != nullptr);
-  DRAKE_DEMAND(lcm);
+  DRAKE_DEMAND(lcm != nullptr);
 
   subscription_ = lcm->Subscribe(
       channel_, [this](const void* buffer, int size) {

--- a/systems/optimization/system_constraint_adapter.cc
+++ b/systems/optimization/system_constraint_adapter.cc
@@ -14,7 +14,7 @@ SystemConstraintAdapter::SystemConstraintAdapter(
       // TODO(hongkai.dai): use system_symbolic_ to parse the constraint in the
       // symbolic form.
       system_symbolic_{system_double_->ToSymbolicMaybe()} {
-  DRAKE_DEMAND(system);
+  DRAKE_DEMAND(system != nullptr);
 }
 
 std::optional<std::vector<solvers::Binding<solvers::Constraint>>>

--- a/systems/sensors/lcm_image_array_to_images.cc
+++ b/systems/sensors/lcm_image_array_to_images.cc
@@ -55,10 +55,10 @@ struct PngDecodeData {
 };
 
 void CopyNextPngBytes(png_structp png_ptr, png_bytep data, size_t length) {
-  DRAKE_DEMAND(png_ptr);
+  DRAKE_DEMAND(png_ptr != nullptr);
   PngDecodeData* decode_data = reinterpret_cast<PngDecodeData*>(
       png_get_io_ptr(png_ptr));
-  DRAKE_DEMAND(decode_data);
+  DRAKE_DEMAND(decode_data != nullptr);
 
   if (decode_data->pos + static_cast<int>(length) > decode_data->size) {
     png_error(png_ptr, "Attempt to read past end of PNG input buffer");
@@ -76,10 +76,10 @@ bool DecompressPng(const lcmt_image* lcm_image, Image<kPixelType>* image) {
 
   png_structp png_ptr = png_create_read_struct(
       PNG_LIBPNG_VER_STRING, 0, 0, 0);
-  DRAKE_DEMAND(png_ptr);
+  DRAKE_DEMAND(png_ptr != nullptr);
 
   png_infop info_ptr = png_create_info_struct(png_ptr);
-  DRAKE_DEMAND(info_ptr);
+  DRAKE_DEMAND(info_ptr != nullptr);
 
   if (setjmp(png_jmpbuf(png_ptr)) == 0) {
     png_set_read_fn(png_ptr, &decode_data, CopyNextPngBytes);

--- a/systems/trajectory_optimization/direct_collocation.cc
+++ b/systems/trajectory_optimization/direct_collocation.cc
@@ -210,7 +210,7 @@ void DirectCollocation::DoAddRunningCost(const symbolic::Expression& g) {
 
 PiecewisePolynomial<double> DirectCollocation::ReconstructInputTrajectory(
     const solvers::MathematicalProgramResult& result) const {
-  DRAKE_DEMAND(input_port_);
+  DRAKE_DEMAND(input_port_ != nullptr);
   Eigen::VectorXd times = GetSampleTimes(result);
   std::vector<double> times_vec(N());
   std::vector<Eigen::MatrixXd> inputs(N());


### PR DESCRIPTION
Refer to #15513 for the motivations.  While "throw" vs "abort" are slightly different semantics in terms of error message, I think the reasoning shown there applies sufficiently well to ASSERT and DEMAND.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15574)
<!-- Reviewable:end -->
