### PR TITLE
Fix #15569 By adding SubscribeAllChannels and get_lcm_url

### DIFF
--- a/lcm/drake_lcm.cc
+++ b/lcm/drake_lcm.cc
@@ -48,6 +48,15 @@ class DrakeLcm::Impl {
     }
   }
 
+  // Housekeeping: scrub any deallocated subscriptions.
+  void CleanUpOldSubscriptions() {
+    subscriptions_.erase(std::remove_if(
+        subscriptions_.begin(), subscriptions_.end(),
+        [](const auto& weak_subscription) {
+          return weak_subscription.expired();
+        }), subscriptions_.end());
+  }
+
   std::string requested_lcm_url_;
   std::string lcm_url_;
   bool deferred_initialization_{};
@@ -95,16 +104,35 @@ class DrakeSubscription final : public DrakeSubscriptionInterface {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DrakeSubscription)
 
   using HandlerFunction = DrakeLcmInterface::HandlerFunction;
+  using MultichannelHandlerFunction =
+      DrakeLcmInterface::MultichannelHandlerFunction;
 
-  static std::shared_ptr<DrakeSubscription> Create(
+  static std::shared_ptr<DrakeSubscription> CreateSingleChannel(
       ::lcm::LCM* native_instance, const std::string& channel,
-      HandlerFunction handler) {
-    DRAKE_DEMAND(native_instance != nullptr);
-
+      HandlerFunction single_channel_handler) {
     // The argument to subscribeFunction is regex (not a string literal), so
     // we'll need to escape the channel name before calling subscribeFunction.
     char* const channel_regex = g_regex_escape_string(channel.c_str(), -1);
     ScopeExit guard([channel_regex](){ g_free(channel_regex); });
+
+    return Create(native_instance, channel_regex,
+                  [handler = std::move(single_channel_handler)](
+                      std::string_view, const void* data, int size) {
+                    handler(data, size);
+                  });
+  }
+
+  static std::shared_ptr<DrakeSubscription> CreateMultichannel(
+      ::lcm::LCM* native_instance,
+      MultichannelHandlerFunction multichannel_handler) {
+    return Create(native_instance, ".*", std::move(multichannel_handler));
+  }
+
+  static std::shared_ptr<DrakeSubscription> Create(
+      ::lcm::LCM* native_instance, std::string_view channel_regex,
+      MultichannelHandlerFunction handler) {
+    DRAKE_DEMAND(native_instance != nullptr);
+    DRAKE_DEMAND(handler != nullptr);
 
     // Create the result.
     auto result = std::make_shared<DrakeSubscription>();
@@ -179,11 +207,11 @@ class DrakeSubscription final : public DrakeSubscriptionInterface {
   // The native LCM stack calls into here.
   static void NativeCallback(
       const ::lcm::ReceiveBuffer* buffer,
-      const std::string& /* channel */ ,
+      const std::string& channel,
       DrakeSubscription* self) {
     DRAKE_DEMAND(buffer != nullptr);
     DRAKE_DEMAND(self != nullptr);
-    self->InstanceCallback(buffer);
+    self->InstanceCallback(channel, buffer);
   }
 
  private:
@@ -195,10 +223,11 @@ class DrakeSubscription final : public DrakeSubscriptionInterface {
   explicit DrakeSubscription(AsIfPrivateConstructor = {}) {}
 
  private:
-  void InstanceCallback(const ::lcm::ReceiveBuffer* buffer) {
+  void InstanceCallback(const std::string& channel,
+                        const ::lcm::ReceiveBuffer* buffer) {
     DRAKE_DEMAND(!weak_self_reference_.expired());
     if (user_callback_ != nullptr) {
-      user_callback_(buffer->data, buffer->data_size);
+      user_callback_(channel, buffer->data, buffer->data_size);
     }
   }
 
@@ -209,8 +238,7 @@ class DrakeSubscription final : public DrakeSubscriptionInterface {
   ::lcm::Subscription* native_subscription_{};
   int queue_capacity_{1};
 
-  // The user's function that handles raw message data.
-  DrakeLcmInterface::HandlerFunction user_callback_;
+  DrakeLcmInterface::MultichannelHandlerFunction user_callback_;
 
   // We can use "strong" to pretend a subscriber is still active.
   std::weak_ptr<DrakeSubscriptionInterface> weak_self_reference_;
@@ -223,23 +251,32 @@ std::shared_ptr<DrakeSubscriptionInterface> DrakeLcm::Subscribe(
     const std::string& channel, HandlerFunction handler) {
   DRAKE_THROW_UNLESS(!channel.empty());
   DRAKE_THROW_UNLESS(handler != nullptr);
-
-  // Some housekeeping: scrub any deallocated subscribers.
-  auto& subs = impl_->subscriptions_;
-  subs.erase(std::remove_if(
-      subs.begin(), subs.end(),
-      [](const auto& weak_subscription) {
-        return weak_subscription.expired();
-      }), subs.end());
+  impl_->CleanUpOldSubscriptions();
 
   // Add the new subscriber.
-  auto result = DrakeSubscription::Create(
+  auto result = DrakeSubscription::CreateSingleChannel(
       &(impl_->lcm_), channel, std::move(handler));
   if (!impl_->deferred_initialization_) {
     result->AttachIfNeeded();
   }
-  subs.push_back(result);
-  DRAKE_DEMAND(!subs.back().expired());
+  impl_->subscriptions_.push_back(result);
+  DRAKE_DEMAND(!impl_->subscriptions_.back().expired());
+  return result;
+}
+
+std::shared_ptr<DrakeSubscriptionInterface> DrakeLcm::SubscribeAllChannels(
+    MultichannelHandlerFunction handler) {
+  DRAKE_THROW_UNLESS(handler != nullptr);
+  impl_->CleanUpOldSubscriptions();
+
+  // Add the new subscriber.
+  auto result = DrakeSubscription::CreateMultichannel(
+      &(impl_->lcm_), std::move(handler));
+  if (!impl_->deferred_initialization_) {
+    result->AttachIfNeeded();
+  }
+  impl_->subscriptions_.push_back(result);
+  DRAKE_DEMAND(!impl_->subscriptions_.back().expired());
   return result;
 }
 

--- a/lcm/drake_lcm.h
+++ b/lcm/drake_lcm.h
@@ -44,7 +44,6 @@ class DrakeLcm : public DrakeLcmInterface {
    */
   DrakeLcm(std::string lcm_url, bool defer_initialization);
 
-
   /**
    * A destructor that forces the receive thread to be stopped.
    */
@@ -57,15 +56,14 @@ class DrakeLcm : public DrakeLcmInterface {
    */
   ::lcm::LCM* get_lcm_instance();
 
-  /**
-   * Returns the LCM URL.
-   */
-  std::string get_lcm_url() const;
 
   void Publish(const std::string&, const void*, int,
                std::optional<double>) override;
+  std::string get_lcm_url() const override;
   std::shared_ptr<DrakeSubscriptionInterface> Subscribe(
       const std::string&, HandlerFunction) override;
+  std::shared_ptr<DrakeSubscriptionInterface> SubscribeAllChannels(
+      MultichannelHandlerFunction) override;
   int HandleSubscriptions(int) override;
 
  private:

--- a/lcm/drake_lcm_interface.h
+++ b/lcm/drake_lcm_interface.h
@@ -55,6 +55,26 @@ class DrakeLcmInterface {
   using HandlerFunction = std::function<void(const void*, int)>;
 
   /**
+   * A callback used by DrakeLcmInterface::SubscribeMultipleChannels (which
+   * therefore needs the receiving channel passed in).
+   */
+  using MultichannelHandlerFunction =
+      std::function<void(std::string_view, const void*, int)>;
+
+  /**
+   * Returns a URL describing the transport of this LCM interface.
+   *
+   * When the URL refers to a transport offered by LCM itself (e.g., memq or
+   * udpm), then this function must return the conventional URL spelling.  If
+   * the implementation of DrakeLcmInterface is using a non-standard back end,
+   * the result implementation-defined.
+   *
+   * In either case, it is always formatted using URI syntax rules per the
+   * RFC(s).
+   */
+  virtual std::string get_lcm_url() const = 0;
+
+  /**
    * Most users should use the drake::lcm::Publish() free function, instead of
    * this interface method.
    *
@@ -97,6 +117,13 @@ class DrakeLcmInterface {
    */
   virtual std::shared_ptr<DrakeSubscriptionInterface> Subscribe(
       const std::string& channel, HandlerFunction) = 0;
+
+  /**
+   * Subscribe to all channels; this is useful for logging and redirecting LCM
+   * traffic without regard to its content.
+   */
+  virtual std::shared_ptr<DrakeSubscriptionInterface> SubscribeAllChannels(
+      MultichannelHandlerFunction) = 0;
 
   /**
    * Invokes the HandlerFunction callbacks for all subscriptions' pending

--- a/lcm/test/drake_mock_lcm_test.cc
+++ b/lcm/test/drake_mock_lcm_test.cc
@@ -19,11 +19,27 @@ GTEST_TEST(DrakeMockLcmTest, AcceptanceTest) {
   const std::string channel_name = "DrakeMockLcmTest.AcceptanceTest";
   lcmt_drake_signal message{};
   message.timestamp = 10;
-  Subscriber<lcmt_drake_signal> subscriber(&dut, channel_name);
-  Publish(&dut, channel_name, message);
-  dut.HandleSubscriptions(0);
-  EXPECT_EQ(subscriber.count(), 1);
-  EXPECT_EQ(subscriber.message().timestamp, 10);
+
+  {
+    Subscriber<lcmt_drake_signal> subscriber(&dut, channel_name);
+    Publish(&dut, channel_name, message);
+    dut.HandleSubscriptions(0);
+    EXPECT_EQ(subscriber.count(), 1);
+    EXPECT_EQ(subscriber.message().timestamp, 10);
+  }
+
+  {
+    int received = 0;
+    dut.SubscribeAllChannels(
+        [&received, &channel_name](
+            std::string_view channel, const void*, int) {
+          EXPECT_EQ(channel, channel_name);
+          received++;
+        });
+    Publish(&dut, channel_name, message);
+    dut.HandleSubscriptions(0);
+    EXPECT_EQ(received, 1);
+  }
 }
 
 }  // namespace

--- a/systems/lcm/lcm_interface_system.cc
+++ b/systems/lcm/lcm_interface_system.cc
@@ -3,6 +3,8 @@
 #include <limits>
 #include <utility>
 
+#include "fmt/format.h"
+
 #include "drake/lcm/drake_lcm.h"
 
 namespace drake {
@@ -24,9 +26,15 @@ LcmInterfaceSystem::LcmInterfaceSystem(std::unique_ptr<DrakeLcmInterface> owned)
 LcmInterfaceSystem::LcmInterfaceSystem(DrakeLcmInterface* lcm)
     : lcm_(lcm) {
   DRAKE_THROW_UNLESS(lcm != nullptr);
+  this->set_name(fmt::format(
+      "LcmInterfaceSystem(lcm_url={})", lcm_->get_lcm_url()));
 }
 
 LcmInterfaceSystem::~LcmInterfaceSystem() = default;
+
+std::string LcmInterfaceSystem::get_lcm_url() const {
+  return lcm_->get_lcm_url();
+}
 
 void LcmInterfaceSystem::Publish(
     const std::string& channel, const void* data, int data_size,
@@ -37,6 +45,11 @@ void LcmInterfaceSystem::Publish(
 std::shared_ptr<DrakeSubscriptionInterface> LcmInterfaceSystem::Subscribe(
     const std::string& channel, HandlerFunction handler) {
   return lcm_->Subscribe(channel, std::move(handler));
+}
+
+std::shared_ptr<DrakeSubscriptionInterface>
+LcmInterfaceSystem::SubscribeAllChannels(MultichannelHandlerFunction handler) {
+  return lcm_->SubscribeAllChannels(std::move(handler));
 }
 
 int LcmInterfaceSystem::HandleSubscriptions(int timeout_millis) {

--- a/systems/lcm/lcm_interface_system.h
+++ b/systems/lcm/lcm_interface_system.h
@@ -57,10 +57,13 @@ class LcmInterfaceSystem final
   ~LcmInterfaceSystem() final;
 
   // DrakeLcmInterface overrides.
+  std::string get_lcm_url() const override;
   void Publish(const std::string&, const void*, int,
                std::optional<double>) final;
   std::shared_ptr<drake::lcm::DrakeSubscriptionInterface>
       Subscribe(const std::string&, HandlerFunction) final;
+  std::shared_ptr<drake::lcm::DrakeSubscriptionInterface>
+      SubscribeAllChannels(MultichannelHandlerFunction) final;
   int HandleSubscriptions(int) final;
 
  private:


### PR DESCRIPTION
* This provides mechanisms that downstream projects have gotten
  by directly accessing the native LCM rather than via the interface:
  * This captures the use of a `.*` regex on the native lcm, which
    was being abused downstream, behind a proper function.
    * No support of more general regexps at this time, but the API
      change to support that is pretty clear so we can come back to
      that in the future.
  * Provides a URL-like string for logging
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15575)
<!-- Reviewable:end -->
