### PR TITLE
[solvers] Fix assertion in AddPositiveSemidefiniteConstraint

### DIFF
--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -1089,8 +1089,7 @@ void BindMathematicalProgram(py::module m) {
               const Eigen::Ref<const MatrixX<Expression>>& e) {
             return self->AddPositiveSemidefiniteConstraint(e);
           },
-          doc.MathematicalProgram.AddPositiveSemidefiniteConstraint
-              .doc_1args_constEigenMatrixBase)
+          doc.MathematicalProgram.AddPositiveSemidefiniteConstraint.doc_1args_e)
       .def(
           "AddLinearMatrixInequalityConstraint",
           [](MathematicalProgram* self,


### PR DESCRIPTION
Closes #15579.

The symbolic transpose assertion was being incorrectly skipped, so we must rewrite the check to use `CheckStructualEquality` instead of `operator==`.

The `CheckStructualEquality` doesn't work well with `MatrixBase<Derived>`, so we must rewrite the function to take a Ref, instead. (This is an improvement in any case; we over-use `Derived` in the `MathematicalProgram` API.)

Also of note, with the Eigen 3.4 pre-release, the assertion was actually being compiled down to a `bool`, rather than skipped, leading to a type check error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15580)
<!-- Reviewable:end -->
