### PR TITLE
[geometry] To debug hydroelastics, use the field name from the source.

### DIFF
--- a/geometry/proximity/mesh_intersection.cc
+++ b/geometry/proximity/mesh_intersection.cc
@@ -395,7 +395,8 @@ void SurfaceVolumeIntersector<T>::SampleVolumeFieldOnSurface(
       std::move(surface_faces), std::move(surface_vertices_M));
   const bool calculate_gradient = false;
   *e_MN = std::make_unique<SurfaceMeshFieldLinear<T, T>>(
-      "e", std::move(surface_e), surface_MN_M->get(), calculate_gradient);
+      volume_field_M.name(), std::move(surface_e), surface_MN_M->get(),
+      calculate_gradient);
 }
 
 template <typename T>

--- a/geometry/proximity/mesh_plane_intersection.cc
+++ b/geometry/proximity/mesh_plane_intersection.cc
@@ -208,7 +208,7 @@ std::unique_ptr<ContactSurface<T>> ComputeContactSurface(
   auto mesh_W =
       std::make_unique<SurfaceMesh<T>>(std::move(faces), std::move(vertices_W));
   auto field_W = std::make_unique<SurfaceMeshFieldLinear<T, T>>(
-      "pressure", std::move(surface_e), mesh_W.get(),
+      mesh_field_M.name(), std::move(surface_e), mesh_W.get(),
       false /* calculate_gradient */);
   // SliceTetWithPlane promises to make the surface normals point in the plane
   // normal direction (i.e., out of the plane and into the mesh).


### PR DESCRIPTION
This is just to demonstrate an idea, not intended for reviewing or merging.

To debug hydroelastics, use the name of the field variable from the source mesh field in mesh-mesh intersection and mesh-plane intersection.

Related to issue #15616.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15582)
<!-- Reviewable:end -->
