### PR TITLE
[pydrake] Don't load native code upon 'import pydrake'

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -10,6 +10,7 @@ load(
     "@drake//tools/skylark:drake_py.bzl",
     "drake_py_binary",
     "drake_py_library",
+    "drake_py_test",
     "drake_py_unittest",
 )
 load(
@@ -525,6 +526,14 @@ drake_py_unittest(
         ":autodiffutils_py",
         ":math_py",
         ":symbolic_py",
+    ],
+)
+
+drake_py_test(
+    name = "minimal_import_test",
+    allow_import_unittest = True,
+    deps = [
+        "//bindings/pydrake",
     ],
 )
 

--- a/bindings/pydrake/__init__.py
+++ b/bindings/pydrake/__init__.py
@@ -34,20 +34,14 @@ try:
 except ImportError:
     pass
 
-# When running from python, turn DRAKE_ASSERT and DRAKE_DEMAND failures into
-# SystemExit, instead of process aborts.  See RobotLocomotion/drake#5268.
-# We specifically load `common` prior to loading any other pydrake modules,
-# in order to get assertion configuration done as early as possible.
-from . import common
-from .common.deprecation import ModuleShim
 
-__all__ = ['common', 'getDrakePath']
-common.set_assertion_failure_to_throw_exception()
+__all__ = ['getDrakePath']
 
 
 def getDrakePath():
     # Compatibility alias.
-    return os.path.abspath(common.GetDrakePath())
+    from . import common as _common
+    return os.path.abspath(_common.GetDrakePath())
 
 
 def _execute_extra_python_code(m):

--- a/bindings/pydrake/autodiffutils_py.cc
+++ b/bindings/pydrake/autodiffutils_py.cc
@@ -25,6 +25,8 @@ PYBIND11_MODULE(autodiffutils, m) {
   using namespace drake::math;
   constexpr auto& doc = pydrake_doc.drake.math;
 
+  py::module::import("pydrake.common");
+
   // Install NumPy warning filtres.
   // N.B. This may interfere with other code, but until that is a confirmed
   // issue, we should aggressively try to avoid these warnings.

--- a/bindings/pydrake/common/__init__.py
+++ b/bindings/pydrake/common/__init__.py
@@ -6,6 +6,10 @@ import numpy as np
 
 from ._module_py import *
 
+# When running from python, turn DRAKE_ASSERT and DRAKE_DEMAND failures into
+# SystemExit, instead of process aborts.  See RobotLocomotion/drake#5268.
+set_assertion_failure_to_throw_exception()
+
 
 def _wrap_to_match_input_shape(f):
     # See docstring for `WrapToMatchInputShape` in `eigen_pybind.h` for more

--- a/bindings/pydrake/examples/__init__.py
+++ b/bindings/pydrake/examples/__init__.py
@@ -1,3 +1,6 @@
 """Provides both bindings of existing C++ example library code and pure Python
 examples.
 """
+
+# Bootstrap our native code.
+import pydrake.common as _common

--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -1535,6 +1535,7 @@ void def_geometry_all(py::module m) {
 
 PYBIND11_MODULE(geometry, m) {
   PYDRAKE_PREVENT_PYTHON3_MODULE_REIMPORT(m);
+  py::module::import("pydrake.common");
   py::module::import("pydrake.systems.framework");
   py::module::import("pydrake.systems.lcm");
 

--- a/bindings/pydrake/lcm_py.cc
+++ b/bindings/pydrake/lcm_py.cc
@@ -18,6 +18,8 @@ PYBIND11_MODULE(lcm, m) {
   using namespace drake::lcm;
   constexpr auto& doc = pydrake_doc.drake.lcm;
 
+  py::module::import("pydrake.common");
+
   // Use `py::bytes` as a mid-point between C++ LCM (`void* + int` /
   // `vector<uint8_t>`) and Python LCM (`str`).
   using PyHandlerFunction = std::function<void(py::bytes)>;

--- a/bindings/pydrake/manipulation/__init__.py
+++ b/bindings/pydrake/manipulation/__init__.py
@@ -1,1 +1,2 @@
-# Empty Python module.
+# Bootstrap our native code.
+import pydrake.common as _common

--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -504,6 +504,7 @@ void DoScalarIndependentDefinitions(py::module m) {
 PYBIND11_MODULE(math, m) {
   // N.B. Docstring contained in `_math_extra.py`.
 
+  py::module::import("pydrake.common");
   py::module::import("pydrake.autodiffutils");
   py::module::import("pydrake.common.eigen_geometry");
   py::module::import("pydrake.symbolic");

--- a/bindings/pydrake/multibody/__init__.py
+++ b/bindings/pydrake/multibody/__init__.py
@@ -1,1 +1,2 @@
-# Empty Python module.
+# Bootstrap our native code.
+import pydrake.common as _common

--- a/bindings/pydrake/perception_py.cc
+++ b/bindings/pydrake/perception_py.cc
@@ -152,12 +152,14 @@ void init_perception(py::module m) {
 }
 
 PYBIND11_MODULE(perception, m) {
+  m.doc() = "Python bindings for //perception";
+
+  py::module::import("pydrake.common");
+
   // N.B. To stick to directory structure, we do not define this in a
   // `pc_flags` submodule.
   init_pc_flags(m);
   init_perception(m);
-
-  m.doc() = "Python bindings for //perception";
 }
 
 }  // namespace

--- a/bindings/pydrake/solvers/__init__.py
+++ b/bindings/pydrake/solvers/__init__.py
@@ -1,1 +1,2 @@
-# Blank Python module.
+# Bootstrap our native code.
+import pydrake.common as _common

--- a/bindings/pydrake/symbolic_py.cc
+++ b/bindings/pydrake/symbolic_py.cc
@@ -39,6 +39,8 @@ PYBIND11_MODULE(symbolic, m) {
   using namespace drake::symbolic;
   constexpr auto& doc = pydrake_doc.drake.symbolic;
 
+  py::module::import("pydrake.common");
+
   // Install NumPy warning filtres.
   // N.B. This may interfere with other code, but until that is a confirmed
   // issue, we should aggressively try to avoid these warnings.

--- a/bindings/pydrake/systems/__init__.py
+++ b/bindings/pydrake/systems/__init__.py
@@ -1,1 +1,2 @@
-# Blank Python module.
+# Bootstrap our native code.
+import pydrake.common as _common

--- a/bindings/pydrake/test/all_each_import_test.py
+++ b/bindings/pydrake/test/all_each_import_test.py
@@ -1,26 +1,85 @@
+import pickle
 import subprocess
+from subprocess import PIPE
 import sys
+import tempfile
+import textwrap
 import unittest
 
 import pydrake.all
+from pydrake.common import temp_directory
 
 
-def check_module(name):
-    # Run a new interpreter and ensure we can import the module in isolation.
-    print(name)
-    subprocess.run([sys.executable, "-c", f"import {name}"], check=True)
+class TestAllEachImport(unittest.TestCase):
 
+    def setUp(self):
+        self._expected_non_native_modules = [
+            # A standalone 'import pydrake' should not trigger native code.
+            "pydrake",
+            # This module has no native dependencies.
+            "pydrake.visualization",
+            # Another example of a module we'd want to be non-native would be
+            # pydrake.lcmtypes, but we don't have such a module (yet).
+        ]
+        self._temp_dir = temp_directory()
 
-class Test(unittest.TestCase):
     def test_each_import(self):
+        """For all known pydrake modules, checks that they can be imported on
+        their own, one by one.
+        """
         names = []
         for name in sys.modules.keys():
-            if not name.startswith("pydrake.") or "._" in name:
+            if "._" in name:
+                # Private module.
                 continue
             if name == "pydrake.all":
+                # Already tested via this process's import statement.
                 continue
-            names.append(name)
+            if name == "pydrake" or name.startswith("pydrake."):
+                names.append(name)
         self.assertGreater(len(names), 0)
 
         for name in sorted(names):
-            check_module(name)
+            with self.subTest(name=name):
+                self._check_module(name)
+
+        for name in self._expected_non_native_modules:
+            self.assertIn(name, names)
+
+    def _check_module(self, name):
+        """Runs a new interpreter to prove that we can import the module in
+        isolation. Modulo a few allowed corner-cases, also checks that the
+        pydrake.common module has also been imported by side-effect (and so,
+        that it's important native-code bootstrapping logic is in effect).
+        """
+        temp_filename = f"{self._temp_dir}/has_common_{name}"
+        script = textwrap.dedent(f"""\
+            import {name}
+            import pickle, sys
+            has_common = bool("pydrake.common" in sys.modules)
+            with open("{temp_filename}", "wb") as f:
+                pickle.dump(has_common, f)
+        """)
+        subprocess.run([sys.executable, "-c", script], check=True)
+
+        # Parse the output.
+        with open(temp_filename, "rb") as f:
+            has_common = pickle.load(f)
+        self.assertIsNotNone(has_common)
+
+        # Check for required presence / absence of native code.
+        if name in self._expected_non_native_modules:
+            self.assertFalse(
+                has_common,
+                f"The module {name} is not supposed to induce a load-time"
+                " dependency on pydrake.common, but somehow it did.")
+        else:
+            self.assertTrue(
+                has_common,
+                f"The module {name} was expected to 'import pydrake.common'"
+                " to force native code bootstrapping, but it did not. If"
+                " the module does not contain native code, then add it to"
+                " list of expected_non_native_modules. If the module does"
+                " contain native code, then add this line near the start of"
+                " the PYBIND11_MODULE stanza in its cc file: "
+                " py::module::import(\"pydrake.common\");")

--- a/bindings/pydrake/test/minimal_import_test.py
+++ b/bindings/pydrake/test/minimal_import_test.py
@@ -1,0 +1,43 @@
+import sys
+
+import psutil
+
+# Checks that simple 'import pydrake' does not load Drake's C++ native library.
+#
+# Note that we can't use Drake's unittest framework for this test case, because
+# it loads native code as part of its deprecation testing probes.
+
+
+def _error(message):
+    print("error: " + message, file=sys.stderr, flush=True)
+    sys.exit(1)
+
+
+def _is_native_code_loaded():
+    """Returns True iff libdrake.so has been loaded yet."""
+    this_process = psutil.Process()
+    for item in this_process.memory_maps():
+        if item.path.endswith("/libdrake.so"):
+            return True
+    return False
+
+
+def main():
+    # Sanity check: native code is not loaded by the testing framework.
+    if _is_native_code_loaded():
+        _error("The test framework loaded native code?!")
+
+    # Native code is not loaded after 'import pydrake'.
+    import pydrake
+    if _is_native_code_loaded():
+        _error("An 'import pydrake' native code")
+
+    # Once we import a C++ module, we have native code.
+    from pydrake.common import RandomDistribution
+    if not _is_native_code_loaded():
+        _error("Native code was not loaded?"
+               " The _is_native_code_loaded function is probably broken.")
+
+
+if __name__ == '__main__':
+    main()

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -43,6 +43,8 @@ PYBIND11_MODULE(trajectories, m) {
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
   using namespace drake::trajectories;
   constexpr auto& doc = pydrake_doc.drake.trajectories;
+
+  py::module::import("pydrake.common");
   py::module::import("pydrake.polynomial");
 
   using T = double;

--- a/doc/_pages/python_bindings.md
+++ b/doc/_pages/python_bindings.md
@@ -154,7 +154,7 @@ After following the above install steps, check to ensure you can import
 ``pydrake``.
 
 ```bash
-python3 -c 'import pydrake; print(pydrake.__file__)'
+python3 -c 'import pydrake.all; print(pydrake.__file__)'
 ```
 
 <div class="note" markdown="1">


### PR DESCRIPTION
Wait until a native module is loaded (or a native function is called) before loading our shared libraries. This will make the forthcoming `pydrake.lcmtypes` more convenient to use without forcing a dependency on native code.

Closes #7912.

Towards #15577 towards #1183.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15585)
<!-- Reviewable:end -->
