### PR TITLE
Add python and pip to Dockerfile to support running notebooks on deepnote.com

### DIFF
--- a/tools/install/dockerhub/focal/Dockerfile
+++ b/tools/install/dockerhub/focal/Dockerfile
@@ -7,6 +7,9 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get update -qq \
   && apt-get install --no-install-recommends -o Dpkg::Use-Pty=0 -qy \
     $(cat /opt/drake/share/drake/setup/packages-focal.txt) \
+# Make python and pip available to meet the requirements for deepnote.com:
+# https://docs.deepnote.com/environment/custom-environments#custom-image-requirements
+    python3-pip python-is-python3 \
   && rm -rf /opt/drake/share/drake/setup /var/lib/apt/lists/* \
   && mv /opt/drake/bin/drake-visualizer /opt/drake/bin/drake-visualizer.image
 RUN printf '#!/bin/bash\n \


### PR DESCRIPTION
The current drake docker images will not run on deepnote.  Adding these lines fulfills the requirements, as specified here:
https://docs.deepnote.com/environment/custom-environments#custom-image-requirements , and seem a small price to pay for the increased capability.

To reproduce, I have uploaded the revised images to DockerHub as robotlocomotion/drake:pr15586-bionic and robotlocomotion/drake:pr15586-focal.  Visit https://deepnote.com/project/Drake-PR-15586-mPXpOqUZTqe8JBtfj5z4xQ/%2Fnotebook.ipynb .  You will need to create an account to proceed, I'm afraid.  Then
- On the left menu, click on the Environment toolbar, and then look at the "Environment" dropdown.
- I've connected 4 docker images: robotlocomotion/drake:bionic and robotlocomotion/drake:focal and the two revisions.
- Confirm that selecting the two existing images will spend some time "Loading image..." but then will fail with

`We failed to run the image you specified. Your image doesn’t exist, or we don’t have permissions to access it, or it doesn't fulfill the requirements to run.`

- Confirm that selecting the revised images result in the images loading successfully.
- For each of the revised images, run the first cell of the notebook, and see that pydrake loads successfully and prints the expected file path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15586)
<!-- Reviewable:end -->
