### PR TITLE
Fix a comment in BasicVector

### DIFF
--- a/systems/framework/basic_vector.h
+++ b/systems/framework/basic_vector.h
@@ -79,7 +79,8 @@ class BasicVector : public VectorBase<T> {
   }
 
   /// Returns the entire vector as a mutable Eigen::VectorBlock, which allows
-  /// mutation of the values, but does not allow resizing the vector itself.
+  /// mutation of the values, but does not allow `resize()` to be invoked on
+  /// the returned object.
   Eigen::VectorBlock<VectorX<T>> get_mutable_value() {
     return values_.head(values_.rows());
   }


### PR DESCRIPTION
We recently noticed that we've been incorrectly saying that `VectorBlock<VectorX>` prevents resizing of the underlying Vector. Actually, while it does not permit `resize()` to be invoked, a determined user can get access to the underlying object and demolish it as they please. No, I'm not going to tell you how to do that!

This PR just fixes a comment about the above to be accurate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15588)
<!-- Reviewable:end -->
