### PR TITLE
[pydrake] Disable memory_maps acceptance test on macOS

### DIFF
--- a/bindings/pydrake/test/minimal_import_test.py
+++ b/bindings/pydrake/test/minimal_import_test.py
@@ -1,11 +1,17 @@
+"""Checks that simple 'import pydrake' does not load Drake's C++ native
+library.
+
+Note that we can't use Drake's unittest framework for this test case,
+because it loads native code as part of its deprecation testing probes.
+
+On macOS, we aren't able to access the psutil.memory_maps(), so we can't
+actually run this test. We'll assume that testing on Ubuntu is sufficient.
+"""
 import sys
 
+if "darwin" in sys.platform:
+    sys.exit(0)
 import psutil
-
-# Checks that simple 'import pydrake' does not load Drake's C++ native library.
-#
-# Note that we can't use Drake's unittest framework for this test case, because
-# it loads native code as part of its deprecation testing probes.
 
 
 def _error(message):


### PR DESCRIPTION
The psutil library does not offer memory_maps() on macOS, so we can't easily inspect the list of loaded libraries.

Hotfix for #15585.  Tested locally on macOS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15589)
<!-- Reviewable:end -->
