### PR TITLE
[manipulation_station] remove stray XML element from 061_foam_brick.sdf

### DIFF
--- a/examples/manipulation_station/models/061_foam_brick.sdf
+++ b/examples/manipulation_station/models/061_foam_brick.sdf
@@ -44,9 +44,6 @@
             <size>0.074 0.049 0.049</size>
           </box>
         </geometry>
-        <material>
-          <diffuse>0 1 0 1.0</diffuse>
-        </material>
       </collision>
       <collision name="point_collision1">
         <pose>0.0375 0.025 0 0 0 0</pose>


### PR DESCRIPTION
Now that the SDF parsing is quieter, I was able to turn my log_level back to the default.  And the only warning I got this time was real:
```
Warning [Utils.cc:128] [/sdf/model[@name="foam_brick"]/link[@name="base_link"]/collision[@name="box_collision"]/material:/opt/drake/lib/../share/drake/examples/manipulation_station/models/061_foam_brick.sdf:L47]: XML Element[material], child of element[collision], not defined in SDF. Copying[material] as children of [collision].
```
This PR removes the unintentional, unused XML element.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15590)
<!-- Reviewable:end -->
