### PR TITLE
[pydrake] Various fixes in prep for pydrake.lcmtypes

### DIFF
--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -259,7 +259,6 @@ drake_py_library(
         "//bindings/pydrake:lcm_py",
         "//bindings/pydrake:math_py",
         "//bindings/pydrake/common:eigen_geometry_py",
-        "//lcmtypes:lcmtypes_drake_py",
         "@meshcat_python//:meshcat",
         "@meshcat_python//:meshcat-server",
     ],

--- a/bindings/pydrake/systems/meshcat_visualizer.py
+++ b/bindings/pydrake/systems/meshcat_visualizer.py
@@ -11,7 +11,6 @@ import webbrowser
 
 import numpy as np
 
-from drake import lcmt_viewer_load_robot
 from pydrake.common.deprecation import _warn_deprecated
 from pydrake.common.eigen_geometry import Quaternion, Isometry3
 from pydrake.common.value import AbstractValue

--- a/bindings/pydrake/test/all_each_import_test.py
+++ b/bindings/pydrake/test/all_each_import_test.py
@@ -16,8 +16,6 @@ class TestAllEachImport(unittest.TestCase):
         self._expected_non_native_modules = [
             # A standalone 'import pydrake' should not trigger native code.
             "pydrake",
-            # This module has no native dependencies.
-            "pydrake.visualization",
             # Another example of a module we'd want to be non-native would be
             # pydrake.lcmtypes, but we don't have such a module (yet).
         ]

--- a/bindings/pydrake/visualization/__init__.py
+++ b/bindings/pydrake/visualization/__init__.py
@@ -1,1 +1,2 @@
-# Blank Python module.
+# Bootstrap our native code.
+import pydrake.common as _common

--- a/tools/workspace/lcm/example/BUILD.bazel
+++ b/tools/workspace/lcm/example/BUILD.bazel
@@ -1,0 +1,69 @@
+# -*- python -*-
+
+load(
+    "@drake//tools/workspace/lcm:lcm.bzl",
+    "lcm_cc_library",
+    "lcm_java_library",
+    "lcm_py_library",
+)
+load("@drake//tools/skylark:py.bzl", "py_library")
+load("@drake//tools/skylark:drake_py.bzl", "drake_py_unittest")
+load("@drake//tools/skylark:drake_cc.bzl", "drake_cc_googletest")
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+package(default_visibility = ["//visibility:private"])
+
+_LCM_PACKAGE = "package1.package2"
+
+_LCM_SRCS = [
+    "lcmt_foo.lcm",
+    "lcmt_bar.lcm",
+]
+
+lcm_cc_library(
+    name = "cc_lib",
+    aggregate_hdr = "package1/package2/package2.hpp",
+    lcm_package = _LCM_PACKAGE,
+    lcm_srcs = _LCM_SRCS,
+    # Disable Drake's add_lint_tests() for this library.
+    # This line would not typically be required for non-Drake projects.
+    tags = ["nolint"],
+)
+
+lcm_java_library(
+    name = "java_lib",
+    lcm_package = _LCM_PACKAGE,
+    lcm_srcs = _LCM_SRCS,
+    # Disable Drake's add_lint_tests() for this library.
+    # This line would not typically be required for non-Drake projects.
+    tags = ["nolint"],
+)
+
+lcm_py_library(
+    name = "py_lib",
+    lcm_package = _LCM_PACKAGE,
+    lcm_srcs = _LCM_SRCS,
+    # Disable Drake's add_lint_tests() for this library.
+    # This line would not typically be required for non-Drake projects.
+    tags = ["nolint"],
+)
+
+drake_cc_googletest(
+    name = "cc_lib_test",
+    deps = [
+        ":cc_lib",
+    ],
+)
+
+drake_py_unittest(
+    name = "py_lib_test",
+    deps = [
+        ":py_lib",
+    ],
+)
+
+# N.B. Our java messages are only ever used by lcm-spy, so traditionally we
+# don't write tests for them. (In practice, we've never seen any regressions
+# escape due to that lack of testing.)
+
+add_lint_tests()

--- a/tools/workspace/lcm/example/README.md
+++ b/tools/workspace/lcm/example/README.md
@@ -1,0 +1,3 @@
+
+This directory serves and both an example of how to use the lcm.bzl macros,
+as well an acceptance test that the macros are operating correctly.

--- a/tools/workspace/lcm/example/lcmt_bar.lcm
+++ b/tools/workspace/lcm/example/lcmt_bar.lcm
@@ -1,0 +1,7 @@
+package package1.package2;
+
+struct lcmt_bar
+{
+  int64_t utime;
+  double value;
+}

--- a/tools/workspace/lcm/example/lcmt_foo.lcm
+++ b/tools/workspace/lcm/example/lcmt_foo.lcm
@@ -1,0 +1,7 @@
+package package1.package2;
+
+struct lcmt_foo
+{
+  int64_t utime;
+  package1.package2.lcmt_bar bar;
+}

--- a/tools/workspace/lcm/example/test/cc_lib_test.cc
+++ b/tools/workspace/lcm/example/test/cc_lib_test.cc
@@ -1,0 +1,12 @@
+#include "package1/package2/package2.hpp"
+#include <gtest/gtest.h>
+
+namespace {
+
+GTEST_TEST(Foo, Foo) {
+  package1::package2::lcmt_foo foo{};
+  foo.bar.value = 5;
+  EXPECT_GT(foo.getEncodedSize(), 0);
+}
+
+}  // namespace

--- a/tools/workspace/lcm/example/test/py_lib_test.py
+++ b/tools/workspace/lcm/example/test/py_lib_test.py
@@ -1,0 +1,11 @@
+import unittest
+
+from package1.package2 import lcmt_foo
+
+
+class TestFoo(unittest.TestCase):
+
+    def test_foo(self):
+        foo = lcmt_foo()
+        foo.bar.value = 5
+        self.assertIsNotNone(foo.encode())


### PR DESCRIPTION
Add native code bootstrapping to `pydrake.visualization`; missed in #15585.  (The sub-modules indirectly loaded native code, so this should not have been allow-listed as an expected pure-python module.)

Enhance `lcm.bzl` to understand dots within `lcm_package` names; these need to turn into forward-slashes when used in filenames.  Add direct local acceptance testing for this macro.

Remove stray lcmtypes import from `meshcat_visualizer` (and its `BUILD.bazel` stanza).

Towards #15577 towards #1183.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15591)
<!-- Reviewable:end -->
