### PR TITLE
VectorLogSink API for mutable access requires mutable Context

### DIFF
--- a/systems/primitives/test/vector_log_sink_test.cc
+++ b/systems/primitives/test/vector_log_sink_test.cc
@@ -22,7 +22,7 @@ namespace {
 GTEST_TEST(TestVectorLogSink, LogGetters) {
   VectorLogSink<double> dut(11);
   auto context = dut.CreateDefaultContext();
-  EXPECT_EQ(&(dut.GetLog(*context)), &(dut.GetMutableLog(*context)));
+  EXPECT_EQ(&(dut.GetLog(*context)), &(dut.GetMutableLog(context.get())));
 }
 
 GTEST_TEST(TestVectorLogSink, LogFinders) {
@@ -31,12 +31,13 @@ GTEST_TEST(TestVectorLogSink, LogFinders) {
   auto dut = builder.AddSystem<VectorLogSink<double>>(1);
   auto diagram = builder.Build();
   auto diagram_context = diagram->CreateDefaultContext();
-  auto& logger_context = dut->GetMyContextFromRoot(*diagram_context);
+  auto& logger_context =
+      dut->GetMyMutableContextFromRoot(diagram_context.get());
 
   EXPECT_EQ(&(dut->GetLog(logger_context)),
             &(dut->FindLog(*diagram_context)));
   EXPECT_EQ(&(dut->FindLog(*diagram_context)),
-            &(dut->FindMutableLog(*diagram_context)));
+            &(dut->FindMutableLog(diagram_context.get())));
 
   DRAKE_EXPECT_THROWS_MESSAGE(dut->GetLog(*diagram_context),
                               ".*Context was not created for.*");
@@ -122,7 +123,7 @@ GTEST_TEST(TestVectorLogSink, LinearSystemTest) {
   EXPECT_TRUE(CompareMatrices(log.data(), log2.data()));
 
   // Test that Clear makes everything empty.
-  logger->FindMutableLog(context).Clear();
+  logger->FindMutableLog(&context).Clear();
   EXPECT_EQ(log.num_samples(), 0);
   EXPECT_EQ(log.sample_times().size(), 0);
   EXPECT_EQ(log.data().cols(), 0);

--- a/systems/primitives/vector_log_sink.cc
+++ b/systems/primitives/vector_log_sink.cc
@@ -82,12 +82,30 @@ const VectorLog<T>&
 VectorLogSink<T>::GetLog(const Context<T>& context) const {
   // Relying on the mutable implementation here avoids pointless out-of-date
   // checks.
-  return GetMutableLog(context);
+  return GetLogFromCache(context);
 }
 
 template <typename T>
 VectorLog<T>&
-VectorLogSink<T>::GetMutableLog(const Context<T>& context) const {
+VectorLogSink<T>::GetMutableLog(Context<T>* context) const {
+  return GetLogFromCache(*context);
+}
+
+template <typename T>
+const VectorLog<T>&
+VectorLogSink<T>::FindLog(const Context<T>& root_context) const {
+  return GetLogFromCache(this->GetMyContextFromRoot(root_context));
+}
+
+template <typename T>
+VectorLog<T>&
+VectorLogSink<T>::FindMutableLog(Context<T>* root_context) const {
+  return GetLogFromCache(this->GetMyMutableContextFromRoot(root_context));
+}
+
+template <typename T>
+VectorLog<T>&
+VectorLogSink<T>::GetLogFromCache(const Context<T>& context) const {
   this->ValidateContext(context);
   CacheEntryValue& value =
       this->get_cache_entry(log_cache_index_)
@@ -96,20 +114,8 @@ VectorLogSink<T>::GetMutableLog(const Context<T>& context) const {
 }
 
 template <typename T>
-const VectorLog<T>&
-VectorLogSink<T>::FindLog(const Context<T>& root_context) const {
-  return FindMutableLog(root_context);
-}
-
-template <typename T>
-VectorLog<T>&
-VectorLogSink<T>::FindMutableLog(const Context<T>& root_context) const {
-  return GetMutableLog(this->GetMyContextFromRoot(root_context));
-}
-
-template <typename T>
 EventStatus VectorLogSink<T>::WriteToLog(const Context<T>& context) const {
-  GetMutableLog(context).AddData(
+  GetLogFromCache(context).AddData(
       context.get_time(), this->get_input_port().Eval(context));
   return EventStatus::Succeeded();
 }

--- a/systems/primitives/vector_log_sink.h
+++ b/systems/primitives/vector_log_sink.h
@@ -111,7 +111,7 @@ class VectorLogSink final : public LeafSystem<T> {
 
   /// Access the log as a mutable object within this component's context.
   /// @throws std::exception if context was not created for this system.
-  VectorLog<T>& GetMutableLog(const Context<T>& context) const;
+  VectorLog<T>& GetMutableLog(Context<T>* context) const;
 
   /// Access the log within a containing root context.
   /// @throws std::exception if supplied context is not a root context, or was
@@ -121,10 +121,14 @@ class VectorLogSink final : public LeafSystem<T> {
   /// Access the log as a mutable object within a containing root context.
   /// @throws std::exception if supplied context is not a root context, or was
   /// not created for the containing diagram.
-  VectorLog<T>& FindMutableLog(const Context<T>& root_context) const;
+  VectorLog<T>& FindMutableLog(Context<T>* root_context) const;
 
  private:
   template <typename> friend class VectorLogSink;
+
+  // Access the mutable vector log stored in the given `context`'s cache entry.
+  // @throws std::exception if context was not created for this system.
+  VectorLog<T>& GetLogFromCache(const Context<T>& context) const;
 
   // Remember trigger details for use in scalar conversion.
   TriggerTypeSet publish_triggers_;


### PR DESCRIPTION
The APIs (`GetMutableLog()` and `FindMutableLog()`) now require a mutable context to provide mutable access to the stored log (via `Context*` parameter).

This is technically a breaking change. However, it considered harmless because it tweaks an API that was introduced six days ago in #15523. It really hasn't gotten out in the wild yet.

Tests have been updated accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15592)
<!-- Reviewable:end -->
