### PR TITLE
[geometry] Moves DrakeVisualizerParams into dedicated header

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -93,6 +93,7 @@ drake_cc_library(
     srcs = ["drake_visualizer.cc"],
     hdrs = ["drake_visualizer.h"],
     deps = [
+        ":drake_visualizer_params",
         ":geometry_roles",
         ":geometry_version",
         ":scene_graph",
@@ -101,6 +102,15 @@ drake_cc_library(
         "//lcmtypes:viewer",
         "//systems/framework:context",
         "//systems/framework:leaf_system",
+    ],
+)
+
+drake_cc_library(
+    name = "drake_visualizer_params",
+    hdrs = ["drake_visualizer_params.h"],
+    deps = [
+        ":geometry_roles",
+        ":rgba",
     ],
 )
 

--- a/geometry/drake_visualizer.h
+++ b/geometry/drake_visualizer.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/geometry/drake_visualizer_params.h"
 #include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/geometry_version.h"
 #include "drake/geometry/query_object.h"
@@ -21,19 +22,6 @@ namespace geometry {
 // Forward declare a tester class used as a friend of DrakeVisualizer.
 template <typename T>
 class DrakeVisualizerTest;
-
-/** The set of parameters for configuring DrakeVisualizer.  */
-struct DrakeVisualizerParams {
-  /** The duration (in seconds) between published LCM messages that update the
-   poses of the scene's geometry.  */
-  double publish_period{1 / 60.0};
-
-  /* The role of the geometries to be sent to the visualizer.  */
-  Role role{Role::kIllustration};
-
-  /** The color to apply to any geometry that hasn't defined one.  */
-  Rgba default_color{0.9, 0.9, 0.9, 1.0};
-};
 
 namespace internal {
 /* Data stored in the cache; populated when we transmit a load message and

--- a/geometry/drake_visualizer_params.h
+++ b/geometry/drake_visualizer_params.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "drake/geometry/geometry_roles.h"
+#include "drake/geometry/rgba.h"
+
+namespace drake {
+namespace geometry {
+
+/** The set of parameters for configuring DrakeVisualizer.  */
+struct DrakeVisualizerParams {
+  /** The duration (in seconds) between published LCM messages that update the
+   poses of the scene's geometry.  */
+  double publish_period{1 / 60.0};
+
+  /* The role of the geometries to be sent to the visualizer.  */
+  Role role{Role::kIllustration};
+
+  /** The color to apply to any geometry that hasn't defined one.  */
+  Rgba default_color{0.9, 0.9, 0.9, 1.0};
+};
+
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
This allows downstream code to make decisions about parameters without dragging all of `SceneGraph` into their headers.