### PR TITLE
platform review checklist: don't nag draft PRs

### DIFF
--- a/doc/_pages/platform_reviewer_checklist.md
+++ b/doc/_pages/platform_reviewer_checklist.md
@@ -13,7 +13,7 @@ Search for [issues without an assigned individual](https://github.com/RobotLocom
 and assign an owner.  When in doubt, assign [the lead](/issues.html#team)
 associated with the issue's ``team`` label.
 
-Search for [pull requests that need review](https://github.com/RobotLocomotion/drake/pulls?q=is%3Aopen+is%3Apr+no%3Aassignee+-label%3A%22status%3A+do+not+review%22)
+Search for [pull requests that need review](https://github.com/RobotLocomotion/drake/pulls?q=is%3Aopen+is%3Apr+no%3Aassignee+-label%3A%22status%3A+do+not+review%22+draft%3Afalse)
 and (probably) assign a feature reviewer.  This is intended to make sure that
 requests from outside developers receive timely attention.  For a pull request
 by a core Drake Developer, leaving it unassigned may be acceptable when it is


### PR DESCRIPTION
This patch excludes PRs explicitly marked draft from the daily platform
reviewer search for PRs that need review. This allows authors to use the draft
status in a way similar to the "do not review" label.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15602)
<!-- Reviewable:end -->
