### PR TITLE
Add HPolyhedron::CartesianProduct

### DIFF
--- a/geometry/optimization/hpolyhedron.cc
+++ b/geometry/optimization/hpolyhedron.cc
@@ -117,6 +117,16 @@ VectorXd HPolyhedron::ChebyshevCenter() const {
   return result.GetSolution(x);
 }
 
+HPolyhedron HPolyhedron::CartesianProduct(const HPolyhedron& other) const {
+  MatrixXd A_product = MatrixXd::Zero(A_.rows() + other.A().rows(),
+                                      A_.cols() + other.A().cols());
+  A_product.topLeftCorner(A_.rows(), A_.cols()) = A_;
+  A_product.bottomRightCorner(other.A().rows(), other.A().cols()) = other.A();
+  VectorXd b_product(b_.size() + other.b().size());
+  b_product << b_, other.b();
+  return {A_product, b_product};
+}
+
 HPolyhedron HPolyhedron::CartesianPower(int n) const {
   MatrixXd A_power = MatrixXd::Zero(n * A_.rows(), n * A_.cols());
   for (int i{0}; i < n; ++i) {

--- a/geometry/optimization/hpolyhedron.h
+++ b/geometry/optimization/hpolyhedron.h
@@ -92,6 +92,9 @@ class HPolyhedron final : public ConvexSet {
   */
   Eigen::VectorXd ChebyshevCenter() const;
 
+  /** Returns the Cartesian product of `this` and `other`. */
+  HPolyhedron CartesianProduct(const HPolyhedron& other) const;
+
   /** Returns the `n`-ary Cartesian power of `this`.
   The n-ary Cartesian power of a set H is the set H ⨉ H ⨉ ... ⨉ H, where H is
   repeated n times. */

--- a/geometry/optimization/test/hpolyhedron_test.cc
+++ b/geometry/optimization/test/hpolyhedron_test.cc
@@ -360,6 +360,21 @@ GTEST_TEST(HPolyhedronTest, CartesianPowerTest) {
   EXPECT_TRUE(CompareMatrices(H_3.b(), b_3));
 }
 
+GTEST_TEST(HPolyhedronTest, CartesianProductTest) {
+  HPolyhedron H_A = HPolyhedron::MakeUnitBox(2);
+  VectorXd x_A = VectorXd::Zero(2);
+  EXPECT_TRUE(H_A.PointInSet(x_A));
+
+  HPolyhedron H_B = HPolyhedron::MakeBox(Vector2d(2, 2), Vector2d(4, 4));
+  VectorXd x_B = 3 * VectorXd::Ones(2);
+  EXPECT_TRUE(H_B.PointInSet(x_B));
+
+  HPolyhedron H_C = H_A.CartesianProduct(H_B);
+  VectorXd x_C{x_A.size() + x_B.size()};
+  x_C << x_A, x_B;
+  EXPECT_TRUE(H_C.PointInSet(x_C));
+}
+
 
 }  // namespace optimization
 }  // namespace geometry


### PR DESCRIPTION
This implements the special case in which the Cartesian product of two HPolyhedra is another HPolyhedron.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15608)
<!-- Reviewable:end -->
