### PR TITLE
[multibody] Fix error in ContactResultsToLcmSystem

### DIFF
--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -575,9 +575,6 @@ drake_cc_googletest(
     deps = [
         ":contact_results_to_lcm",
         "//common/test_utilities:eigen_geometry_compare",
-        "//geometry:drake_visualizer",
-        "//multibody/benchmarks/acrobot",
-        "//multibody/benchmarks/inclined_plane",
     ],
 )
 

--- a/multibody/plant/contact_results_to_lcm.cc
+++ b/multibody/plant/contact_results_to_lcm.cc
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "drake/common/unused.h"
 #include "drake/lcmt_contact_results_for_viz.hpp"
 
 namespace drake {
@@ -12,7 +13,7 @@ using systems::Context;
 template <typename T>
 ContactResultsToLcmSystem<T>::ContactResultsToLcmSystem(
     const MultibodyPlant<T>& plant)
-    : systems::LeafSystem<T>() {
+    : ContactResultsToLcmSystem<T>(true) {
   DRAKE_DEMAND(plant.is_finalized());
   const int body_count = plant.num_bodies();
 
@@ -25,14 +26,6 @@ ContactResultsToLcmSystem<T>::ContactResultsToLcmSystem(
     for (auto geometry_id : plant.GetCollisionGeometriesForBody(body))
       geometry_id_to_body_name_map_[geometry_id] = body.name();
   }
-
-  this->set_name("ContactResultsToLcmSystem");
-  contact_result_input_port_index_ = this->DeclareAbstractInputPort(
-      systems::kUseDefaultName,
-      Value<ContactResults<T>>()).get_index();
-  message_output_port_index_ = this->DeclareAbstractOutputPort(
-      systems::kUseDefaultName,
-      &ContactResultsToLcmSystem::CalcLcmContactOutput).get_index();
 }
 
 template <typename T>
@@ -45,6 +38,25 @@ template <typename T>
 const systems::OutputPort<T>&
 ContactResultsToLcmSystem<T>::get_lcm_message_output_port() const {
   return this->get_output_port(message_output_port_index_);
+}
+
+template <typename T>
+ContactResultsToLcmSystem<T>::ContactResultsToLcmSystem(bool dummy)
+    : systems::LeafSystem<T>(
+          systems::SystemTypeTag<ContactResultsToLcmSystem>{}) {
+  // Simply omitting the unused parameter `dummy` causes a linter error; cpplint
+  // thinks it is a C-style cast.
+  unused(dummy);
+  this->set_name("ContactResultsToLcmSystem");
+  contact_result_input_port_index_ =
+      this->DeclareAbstractInputPort(systems::kUseDefaultName,
+                                     Value<ContactResults<T>>())
+          .get_index();
+  message_output_port_index_ =
+      this->DeclareAbstractOutputPort(
+              systems::kUseDefaultName,
+              &ContactResultsToLcmSystem::CalcLcmContactOutput)
+          .get_index();
 }
 
 template <typename T>


### PR DESCRIPTION
The original implementation of `ContactResultsToLcmSystem` had a public scalar-converting copy constructor and a unit test called "Transmogrify". It clearly had the intention to be transmogrifiable. However, the copy constructor was broken -- an instance constructed via that copy constructor would have empty tables and no ports. It also wasn't properly transmogrifiable in the system scalar conversion sense. Finally, the unit test was insufficient to show these issues and invalid in its spelling.

More generally, the organization of the unit tests were haphazard, rendering extension of those unit tests (in subsequent PRs) largely intractible.

This PR provides the full infrastructure to realize the implied intent of being transmogrifiable.  The unit tests have been completely revisited to provide greater coverage with special attention paid to transmogrified systems and documenting the testing philosophy and strategy.

relates #15555

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15610)
<!-- Reviewable:end -->
