### PR TITLE
[geometry] Correct internal nomenclature for collision filtering

### DIFF
--- a/geometry/collision_filter_manager.h
+++ b/geometry/collision_filter_manager.h
@@ -93,8 +93,8 @@ class CollisionFilterManager {
    @throws std::exception if the `declaration` references invalid ids. */
   void Apply(const CollisionFilterDeclaration& declaration) {
     /* Modifications made via this API are by the user. Only the internals can
-     make "permanent" declarations. */
-    filter_->Apply(declaration, extract_ids_, false /* is_permanent */);
+     declare filters to be "invariant". */
+    filter_->Apply(declaration, extract_ids_, false /* is_invariant */);
   }
 
   // TODO(SeanCurtis-TRI) SceneGraphInspector includes the method

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -720,14 +720,14 @@ void GeometryState<T>::AssignRole(SourceId source_id, GeometryId geometry_id,
       }
 
       // Apply collision filter between geometry id and any geometries that have
-      // been identifiied. If none have been identified, this makes no changes.
+      // been identified. If none have been identified, this makes no changes.
       geometry_engine_->collision_filter().Apply(
           CollisionFilterDeclaration().ExcludeBetween(GeometrySet(geometry_id),
                                                       ids_for_filtering),
           [this](const GeometrySet& set) {
             return this->CollectIds(set, Role::kProximity);
           },
-          true /* is_permanent */);
+          true /* is_invariant */);
     } break;
     case RoleAssign::kReplace:
       // Give the engine a chance to compare properties before and after.

--- a/geometry/proximity/collision_filter.h
+++ b/geometry/proximity/collision_filter.h
@@ -42,12 +42,13 @@ class CollisionFilter {
    @param declaration       The declaration to apply.
    @param extract_ids       A callback to convert a GeometrySet into the
                             explicit set of geometry ids.
-   @param is_permanent      If `true` a filter added (via an Exclude* API) will
-                            be made permanent.
+   @param is_invariant      If `true` a filter added (via an Exclude* API) will
+                            be treated as a system invariant -- a filter that
+                            cannot be removed.
    @throws std::exception if any GeometryId referenced by the declaration has
                           not previously been added to `this` filter system. */
   void Apply(const CollisionFilterDeclaration& declaration,
-             const ExtractIds& extract_ids, bool is_permanent = false);
+             const ExtractIds& extract_ids, bool is_invariant = false);
 
   /* Adds a geometry to the filter system. When added, it will not be part of
    any filtered pairs.
@@ -82,10 +83,10 @@ class CollisionFilter {
  private:
   /* The collision filter state between a pair of geometries. */
   enum PairFilterState {
-    kUnfiltered,      // No filter has been declared.
-    kFiltered,        // A user-declared filter exists, the user can remove it.
-    kLockedFiltered,  // A system filter has been created and can't be removed
-                      // by the user.
+    kUnfiltered,       // No filter has been declared.
+    kFiltered,         // A user-declared filter exists, the user can remove it.
+    kInvariantFilter,  // The filter supports a SceneGraph filter invariant and
+                       // cannot be removed by the user.
   };
 
   /* The "filter state" is a 2d table. For N registered geometries, it is
@@ -121,18 +122,18 @@ class CollisionFilter {
    filtered. For each pair, if they are already filtered, no discernible change
    is made.
 
-   The filtered pair can be made "permanent" such that subsequent calls to
+   The filtered pair can be made "invariant" such that subsequent calls to
    RemoveFiltersBetween will not remove the filter. This is intended to support
    SceneGraph invariants that geometries affixed to the same frame are filtered
    or pairs of anchored geometries are likewise filtered. GeometryState is
-   responsible for determining permanence when adding filters.
+   responsible for determining invariance when adding filters.
 
    @pre All ids in `id_A` and `id_B` are part of this filter system.  */
   void AddFiltersBetween(const GeometrySet& set_A, const GeometrySet& set_B,
-                         const ExtractIds& extract_ids, bool is_permanent);
+                         const ExtractIds& extract_ids, bool is_invariant);
 
   /* Declares pairs (`id_A`, `id_B`) `∀ id_A ∈ set_A, id_B ∈ set_B` to be
-   unfiltered (if the filter isn't permanent). For each pair, if they are
+   unfiltered (if the filter isn't invariant). For each pair, if they are
    already unfiltered, no discernible change is made.
 
    @pre All ids in `id_A` and `id_B` are part of this filter system.  */
@@ -140,7 +141,7 @@ class CollisionFilter {
                             const CollisionFilter::ExtractIds& extract_ids);
 
   /* Atomic operation in support of AddFiltersBetween(). */
-  void AddFilteredPair(GeometryId id_A, GeometryId id_B, bool is_permanent);
+  void AddFilteredPair(GeometryId id_A, GeometryId id_B, bool is_invariant);
 
   /* Atomic operation in support of RemoveFiltersBetween(). */
   void RemoveFilteredPair(GeometryId id_A, GeometryId id_B);

--- a/geometry/proximity/test/collision_filter_test.cc
+++ b/geometry/proximity/test/collision_filter_test.cc
@@ -65,9 +65,9 @@ class CollisionFilterTest : public ::testing::Test {
   /* Apply collision filters between geometries in the list. */
   static void FilterAllPairs(CollisionFilter* filter,
                              std::initializer_list<GeometryId> ids,
-                             bool is_permanent) {
+                             bool is_invariant) {
     filter->Apply(CollisionFilterDeclaration().ExcludeWithin(GeometrySet(ids)),
-                  get_extract_ids_functor(), is_permanent);
+                  get_extract_ids_functor(), is_invariant);
 
     for (GeometryId id_A : ids) {
       for (GeometryId id_B : ids) {
@@ -85,20 +85,20 @@ class CollisionFilterTest : public ::testing::Test {
 /* Tests that declaration statements that allow collisions between geometries
  in different sets are properly handled. */
 TEST_F(CollisionFilterTest, AllowBetween) {
-  for (bool is_permanent : {true, false}) {
+  for (bool is_invariant : {true, false}) {
     CollisionFilter filters;
     auto [id_A, id_B, id_C] = this->InitIds(&filters);
 
     /* To test Allowing, we have to start with filters. Filter everything. */
-    this->FilterAllPairs(&filters, {id_A, id_B, id_C}, is_permanent);
+    this->FilterAllPairs(&filters, {id_A, id_B, id_C}, is_invariant);
 
     filters.Apply(CollisionFilterDeclaration().AllowBetween(
                       GeometrySet(id_A), GeometrySet({id_B, id_C})),
                   this->get_extract_ids_functor());
-    /* Our ability to remove the filter depends on whether it was permanent when
+    /* Our ability to remove the filter depends on whether it was invariant when
      added. */
-    EXPECT_EQ(filters.CanCollideWith(id_A, id_B), !is_permanent);
-    EXPECT_EQ(filters.CanCollideWith(id_A, id_C), !is_permanent);
+    EXPECT_EQ(filters.CanCollideWith(id_A, id_B), !is_invariant);
+    EXPECT_EQ(filters.CanCollideWith(id_A, id_C), !is_invariant);
     EXPECT_FALSE(filters.CanCollideWith(id_B, id_C));
   }
 }
@@ -106,21 +106,21 @@ TEST_F(CollisionFilterTest, AllowBetween) {
 /* Tests that declaration statements that allow collisions between geometries
  in a single set are properly handled. */
 TEST_F(CollisionFilterTest, AllowWithin) {
-  for (bool is_permanent : {true, false}) {
+  for (bool is_invariant : {true, false}) {
     CollisionFilter filters;
     auto [id_A, id_B, id_C] = this->InitIds(&filters);
 
     /* To test Allowing, we have to start with filters. Filter everything. */
-    this->FilterAllPairs(&filters, {id_A, id_B, id_C}, is_permanent);
+    this->FilterAllPairs(&filters, {id_A, id_B, id_C}, is_invariant);
 
     filters.Apply(CollisionFilterDeclaration()
                       .AllowWithin(GeometrySet({id_A, id_B}))
                       .AllowWithin(GeometrySet({id_A, id_C})),
                   this->get_extract_ids_functor());
-    /* Our ability to remove the filter depends on whether it was permanent when
+    /* Our ability to remove the filter depends on whether it was invariant when
      added. */
-    EXPECT_EQ(filters.CanCollideWith(id_A, id_B), !is_permanent);
-    EXPECT_EQ(filters.CanCollideWith(id_A, id_C), !is_permanent);
+    EXPECT_EQ(filters.CanCollideWith(id_A, id_B), !is_invariant);
+    EXPECT_EQ(filters.CanCollideWith(id_A, id_C), !is_invariant);
     EXPECT_FALSE(filters.CanCollideWith(id_B, id_C));
   }
 }

--- a/geometry/proximity/test/collisions_exist_callback_test.cc
+++ b/geometry/proximity/test/collisions_exist_callback_test.cc
@@ -111,7 +111,7 @@ GTEST_TEST(CollisionsExistCallback, RespectsCollisionFilter) {
   };
   collision_filter.Apply(CollisionFilterDeclaration().ExcludeWithin(
                              GeometrySet{data_A.id(), data_B.id()}),
-                         extract, false /* is_permanent */);
+                         extract, false /* is_invariant */);
 
   // Make sure the pair no longer collides.
   CallbackData data_after(&collision_filter);

--- a/geometry/proximity/test/distance_sphere_to_shape_test.cc
+++ b/geometry/proximity/test/distance_sphere_to_shape_test.cc
@@ -633,7 +633,7 @@ GTEST_TEST(Callback, ScalarSupportWithFilters) {
   };
   collision_filter.Apply(CollisionFilterDeclaration().ExcludeWithin(
                              GeometrySet{data_A.id(), data_B.id()}),
-                         extract, false /* is_permanent */);
+                         extract, false /* is_invariant */);
 
   const std::unordered_map<GeometryId, RigidTransform<T>> X_WGs{
       {id_A, RigidTransform<T>::Identity()},
@@ -686,7 +686,7 @@ GTEST_TEST(Callback, RespectCollisionFiltering) {
   };
   collision_filter.Apply(CollisionFilterDeclaration().ExcludeWithin(
                              GeometrySet{data_A.id(), data_B.id()}),
-                         extract, false /* is_permanent */);
+                         extract, false /* is_invariant */);
   results.clear();
   threshold = std::numeric_limits<double>::max();
   Callback<double>(&sphere_A, &sphere_B, &data, threshold);

--- a/geometry/proximity/test/find_collision_candidates_callback_test.cc
+++ b/geometry/proximity/test/find_collision_candidates_callback_test.cc
@@ -67,7 +67,7 @@ GTEST_TEST(Callback, RespectsCollisionFilter) {
   };
   collision_filter.Apply(CollisionFilterDeclaration().ExcludeWithin(
                              GeometrySet{data_A.id(), data_B.id()}),
-                         extract, false /* is_permanent */);
+                         extract, false /* is_invariant */);
 
   CollisionObjectd box_A(make_shared<Boxd>(0.25, 0.3, 0.4));
   data_A.write_to(&box_A);

--- a/geometry/proximity/test/hydroelastic_callback_test.cc
+++ b/geometry/proximity/test/hydroelastic_callback_test.cc
@@ -217,7 +217,7 @@ class TestScene {
     };
     collision_filter_.Apply(CollisionFilterDeclaration().ExcludeWithin(
                                 GeometrySet{data_A.id(), data_B.id()}),
-                            extract, false /* is_permanent */);
+                            extract, false /* is_invariant */);
   }
 
   // Note: these are non const because the callback takes non-const pointers

--- a/geometry/proximity/test/penetration_as_point_pair_callback_test.cc
+++ b/geometry/proximity/test/penetration_as_point_pair_callback_test.cc
@@ -183,7 +183,7 @@ class PenetrationAsPointPairCallbackTest : public ::testing::Test {
     };
     collision_filter_.Apply(
         CollisionFilterDeclaration().ExcludeWithin(GeometrySet{id_A_, id_B_}),
-        extract, false /* is_permanent */);
+        extract, false /* is_invariant */);
 
     EXPECT_FALSE(Callback<T>(&sphere_A_, &sphere_B_, &callback_data));
     EXPECT_EQ(point_pairs.size(), 0u);

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -867,7 +867,7 @@ GTEST_TEST(ProximityEngineTests, SignedDistancePairClosestPoint) {
     };
     engine.collision_filter().Apply(
         CollisionFilterDeclaration().ExcludeWithin(GeometrySet{id_A, id_B}),
-        extract_ids, false /* is_permanent */);
+        extract_ids, false /* is_invariant */);
     DRAKE_EXPECT_THROWS_MESSAGE(
         engine.ComputeSignedDistancePairClosestPoints(id_A, id_B, X_WGs),
         std::runtime_error,
@@ -2407,7 +2407,7 @@ TEST_F(SimplePenetrationTest, WithCollisionFilters) {
   };
   engine_.collision_filter().Apply(CollisionFilterDeclaration().ExcludeWithin(
                                        GeometrySet{origin_id, collide_id}),
-                                   extract_ids, false /* is_permanent */);
+                                   extract_ids, false /* is_invariant */);
 
   EXPECT_FALSE(
       engine_.collision_filter().CanCollideWith(origin_id, collide_id));


### PR DESCRIPTION
The public documentation refers to sets of "invariant" collision filters (e.g., geometries fixed to a common frame are always filtered). Internally, it was referred to as a "permanent" filter. This changes the internal implementation to refer to them as "invariant" filters.

(This also paves the way for adding "transient" modifications to collision filters as that uses the term "persistent". The confusion between "permanent" and "persistent" is much higher than that with "invariant"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15617)
<!-- Reviewable:end -->
