### PR TITLE
[fem] Fix bug in DeformableRigidContactData

### DIFF
--- a/multibody/fixed_fem/dev/deformable_contact_data.h
+++ b/multibody/fixed_fem/dev/deformable_contact_data.h
@@ -67,7 +67,7 @@ class DeformableContactData {
   /* Returns the inverse mapping of `permuted_vertex_indexes()`. For the example
    above, the returned vector would be {1, 2, 5, 0, 3, 4}. */
   const std::vector<int>& permuted_to_original_indexes() const {
-    return permuted_vertex_indexes_;
+    return permuted_to_original_indexes_;
   }
 
   /* Returns a vector of *approximations* of signed distances at all contact


### PR DESCRIPTION
The bug is an obvious typo in a getter method, but hard to detect out of
context.
Update the unit test that fails to catch the bug because the index
mapping happen to be self-inverse.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15622)
<!-- Reviewable:end -->
