### PR TITLE
[fem] Extract deformable contact solver results

### DIFF
--- a/multibody/fixed_fem/dev/deformable_rigid_manager.cc
+++ b/multibody/fixed_fem/dev/deformable_rigid_manager.cc
@@ -2,6 +2,7 @@
 
 #include "drake/multibody/contact_solvers/block_sparse_linear_operator.h"
 #include "drake/multibody/fixed_fem/dev/inverse_spd_operator.h"
+#include "drake/multibody/fixed_fem/dev/matrix_utilities.h"
 #include "drake/multibody/fixed_fem/dev/permute_block_sparse_matrix.h"
 #include "drake/multibody/plant/multibody_plant.h"
 
@@ -256,6 +257,16 @@ void DeformableRigidManager<T>::DeclareCacheEntries() {
           {systems::System<T>::all_sources_ticket()});
   two_way_coupled_contact_solver_results_cache_index_ =
       two_way_coupled_contact_solver_results_cache_entry.cache_index();
+
+  const auto& deformable_contact_solver_results_cache_entry =
+      this->DeclareCacheEntry(
+          "Contact solver results for participating deformable dofs",
+          systems::ValueProducer(
+              this,
+              &DeformableRigidManager<T>::CalcDeformableContactSolverResults),
+          {two_way_coupled_contact_solver_results_cache_entry.ticket()});
+  deformable_contact_solver_results_cache_index_ =
+      deformable_contact_solver_results_cache_entry.cache_index();
 }
 
 template <typename T>
@@ -331,6 +342,109 @@ void DeformableRigidManager<T>::CalcTwoWayCoupledContactSolverResults(
   const VectorX<T>& v0 = EvalParticipatingVelocities(context);
   contact_solver_->SolveWithGuess(this->plant().time_step(), dynamics_data,
                                   contact_data, v0, results);
+}
+
+template <typename T>
+void DeformableRigidManager<T>::CalcDeformableContactSolverResults(
+    const systems::Context<T>& context,
+    ContactSolverResults<T>* deformable_results) const {
+  DRAKE_DEMAND(deformable_results != nullptr);
+  /* Extract the results related to the deformable dofs from the full two-way
+   coupled deformable-rigid results. */
+  const ContactSolverResults<T>& two_way_coupled_results =
+      EvalTwoWayCoupledContactSolverResults(context);
+  const std::vector<internal::DeformableContactData<T>>&
+      deformable_contact_data = EvalDeformableRigidContact(context);
+
+  /* Find the total number of deformable contacts and the number of deformable
+   participating dofs. */
+  int nc = 0;
+  int nv_participating = 0;
+  for (const auto& data : deformable_contact_data) {
+    nc += data.num_contact_points();
+    nv_participating += 3 * data.num_vertices_in_contact();
+  }
+  deformable_results->Resize(deformable_model_->NumDofs(), nc);
+  /* Write to all per contact point results. The deformable-rigid contact point
+   results are stored at the end of the two-way coupled results. */
+  deformable_results->fn = two_way_coupled_results.fn.tail(nc);
+  deformable_results->ft = two_way_coupled_results.ft.tail(2 * nc);
+  deformable_results->vn = two_way_coupled_results.vn.tail(nc);
+  deformable_results->vt = two_way_coupled_results.vt.tail(2 * nc);
+
+  /* Calculate post-contact velocity and contact impulse for *all* deformable
+   dofs from participating deformable dofs. */
+  const auto participating_deformable_velocities =
+      two_way_coupled_results.v_next.tail(nv_participating);
+  const auto participating_deformable_tau =
+      two_way_coupled_results.tau_contact.tail(nv_participating);
+  int dof_offset = 0;
+  int participating_dof_offset = 0;
+  for (DeformableBodyIndex i(0); i < deformable_model_->num_bodies(); ++i) {
+    const FemStateBase<T>& fem_state_star =
+        EvalFreeMotionFemStateBase(context, i);
+    const VectorX<T>& v_star = fem_state_star.qdot();
+    const int num_dofs_i = v_star.size();
+    const auto& contact_data_i = deformable_contact_data[i];
+    if (contact_data_i.num_contact_points() == 0) {
+      /* If the deformable body is not in contact, then the free motion velocity
+      is the final velocity. */
+      deformable_results->v_next.segment(dof_offset, num_dofs_i) = v_star;
+      deformable_results->tau_contact.segment(dof_offset, num_dofs_i).setZero();
+    } else {
+      VectorX<T> permuted_v_star = internal::PermuteBlockVector<T>(
+          v_star, contact_data_i.permuted_vertex_indexes());
+      const int num_participating_dofs_i =
+          3 * contact_data_i.num_vertices_in_contact();
+      /* Calculate the velocitiy changes for participating dofs and store them
+       in `participating_delta_v`. */
+      const auto participating_v_star =
+          permuted_v_star.head(num_participating_dofs_i);
+      const auto participating_v = participating_deformable_velocities.segment(
+          participating_dof_offset, num_participating_dofs_i);
+      const VectorX<T> participating_delta_v =
+          participating_v - participating_v_star;
+      /* Use Schur complement to calculate the velocitiy changes for
+        non-participating dofs and store them in `nonparticipating_delta_v`. */
+      const internal::SchurComplement<T>& schur_complement =
+          EvalFreeMotionTangentMatrixSchurComplement(context, i);
+      const VectorX<T> nonparticipating_delta_v =
+          schur_complement.SolveForY(participating_delta_v);
+      /* Calculate v = v* + dv for nonparticipating dofs. */
+      const auto nonparticipating_v_star =
+          permuted_v_star.tail(num_dofs_i - num_participating_dofs_i);
+      const VectorX<T> nonparticipating_v =
+          nonparticipating_v_star + nonparticipating_delta_v;
+      /* We use `permuted_v` to store the velocity of the body i in permuted
+       order at the next time step. */
+      VectorX<T> permuted_v(num_dofs_i);
+      permuted_v << participating_v, nonparticipating_v;
+      /* Restore the velocities to their original order and write to
+       `deformable_results`. */
+      deformable_results->v_next.segment(dof_offset, num_dofs_i) =
+          internal::PermuteBlockVector<T>(
+              permuted_v, contact_data_i.permuted_to_original_indexes());
+      /* We use `permuted_tau` to store the contact impulse of the body i in
+       permuted order at the next time step. */
+      VectorX<T> permuted_tau = VectorX<T>::Zero(num_dofs_i);
+      /* Extract `tau` for participating dofs. Non-participating dofs have zero
+       `tau`. */
+      permuted_tau.head(num_participating_dofs_i) =
+          participating_deformable_tau.segment(participating_dof_offset,
+                                               num_participating_dofs_i);
+      /* Restore the contact impulses to their original order and write to
+       `deformable_results`. */
+      deformable_results->tau_contact.segment(dof_offset, num_dofs_i) =
+          internal::PermuteBlockVector<T>(
+              permuted_tau, contact_data_i.permuted_to_original_indexes());
+
+      participating_dof_offset += num_participating_dofs_i;
+    }
+    dof_offset += num_dofs_i;
+  }
+  /* Sanity check that all dofs and participating dofs are accounted for. */
+  DRAKE_DEMAND(dof_offset == deformable_model_->NumDofs());
+  DRAKE_DEMAND(participating_dof_offset == nv_participating);
 }
 
 template <typename T>

--- a/multibody/fixed_fem/dev/deformable_rigid_manager.h
+++ b/multibody/fixed_fem/dev/deformable_rigid_manager.h
@@ -154,6 +154,21 @@ class DeformableRigidManager final
       const systems::Context<T>& context,
       contact_solvers::internal::ContactSolverResults<T>* results) const;
 
+  /* Eval version of CalcDeformableContactSolverResults(). */
+  const contact_solvers::internal::ContactSolverResults<T>&
+  EvalDeformableContactSolverResults(const systems::Context<T>& context) const {
+    return this->plant()
+        .get_cache_entry(deformable_contact_solver_results_cache_index_)
+        .template Eval<contact_solvers::internal::ContactSolverResults<T>>(
+            context);
+  }
+
+  /* Calculates the contact solver results for the deformable dofs only. */
+  void CalcDeformableContactSolverResults(
+      const systems::Context<T>& context,
+      contact_solvers::internal::ContactSolverResults<T>* deformable_results)
+      const;
+
   // TODO(xuchenhan-tri): Implement this once AccelerationKinematicsCache
   //  also caches acceleration for deformable dofs.
   void DoCalcAccelerationKinematicsCache(
@@ -480,6 +495,9 @@ class DeformableRigidManager final
   systems::CacheIndex participating_free_motion_velocities_cache_index_;
   /* Cached two-way coupled contact solver results. */
   systems::CacheIndex two_way_coupled_contact_solver_results_cache_index_;
+  /* Cached contact solver results for deformable dofs only. */
+  systems::CacheIndex deformable_contact_solver_results_cache_index_;
+
   /* Solvers for all deformable bodies. */
   std::vector<std::unique_ptr<FemSolver<T>>> fem_solvers_{};
   std::unique_ptr<multibody::contact_solvers::internal::ContactSolver<T>>

--- a/multibody/fixed_fem/dev/test/deformable_rigid_contact_solver_test.cc
+++ b/multibody/fixed_fem/dev/test/deformable_rigid_contact_solver_test.cc
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/geometry/proximity/make_box_mesh.h"
 #include "drake/multibody/contact_solvers/contact_solver_utils.h"
 #include "drake/multibody/contact_solvers/pgs_solver.h"
 #include "drake/multibody/fixed_fem/dev/deformable_model.h"
@@ -29,6 +30,8 @@ const CoulombFriction kFriction{0.3, 0.2};
 constexpr double kTolerance = 1e-6;
 constexpr int kMaxIterations = 100;
 constexpr double kRelaxationFactor = 1.0;
+constexpr int kNumCubeVertices = 8;
+constexpr int kNumOctahedronVertices = 7;
 
 using Eigen::MatrixXd;
 using Eigen::Vector3d;
@@ -36,6 +39,8 @@ using Eigen::VectorXd;
 using geometry::GeometryId;
 using geometry::ProximityProperties;
 using geometry::SceneGraph;
+using geometry::VolumeMesh;
+using geometry::VolumeMeshFieldLinear;
 using math::RigidTransformd;
 using multibody::contact_solvers::internal::BlockSparseMatrix;
 using multibody::contact_solvers::internal::ContactSolverResults;
@@ -81,6 +86,17 @@ DeformableBodyConfig<double> MakeDeformableBodyConfig() {
   return config;
 }
 
+internal::ReferenceDeformableGeometry<double> MakeUnitCubeDeformableGeometry() {
+  auto mesh = std::make_unique<VolumeMesh<double>>(
+      geometry::internal::MakeBoxVolumeMesh<double>(
+          geometry::Box(1.0, 1.0, 1.0), 1.0));
+  std::vector<double> dummy_signed_distances(kNumCubeVertices, 0.0);
+  auto mesh_field = std::make_unique<VolumeMeshFieldLinear<double, double>>(
+      "Dummy signed distances", std::move(dummy_signed_distances), mesh.get(),
+      false);
+  return {std::move(mesh), std::move(mesh_field)};
+}
+
 // TODO(xuchenhan-tri): This test can be strengthened by adding a case where a
 //  deformable object is in contact with a fixed collision geometry and no rigid
 //  dofs exist.
@@ -94,7 +110,10 @@ class DeformableRigidContactSolverTest : public ::testing::Test {
     std::tie(plant_, scene_graph_) = AddMultibodyPlantSceneGraph(&builder, kDt);
     /* Add a deformable octahedron. */
     auto deformable_model = std::make_unique<DeformableModel<double>>(plant_);
-    deformable_index_ = deformable_model->RegisterDeformableBody(
+    deformable_cube_ = deformable_model->RegisterDeformableBody(
+        MakeUnitCubeDeformableGeometry(), "deformable unit cube",
+        MakeDeformableBodyConfig(), MakeDefaultProximityProperties());
+    deformable_octahedron_ = deformable_model->RegisterDeformableBody(
         MakeOctahedronDeformableGeometry<double>(), "deformable octahedron",
         MakeDeformableBodyConfig(), MakeDefaultProximityProperties());
     plant_->AddPhysicalModel(std::move(deformable_model));
@@ -157,10 +176,34 @@ class DeformableRigidContactSolverTest : public ::testing::Test {
         context);
   }
 
+  /* Calls DeformableRigidManager::EvalFreeMotionTangentMatrix(). */
+  const Eigen::SparseMatrix<double>& EvalFreeMotionTangentMatrix(
+      const Context<double>& context, DeformableBodyIndex index) const {
+    return deformable_rigid_manager_->EvalFreeMotionTangentMatrix(context,
+                                                                  index);
+  }
+
+  /* Calls DeformableRigidManager::EvalDeformableContactSolverResults(). */
+  const ContactSolverResults<double>& EvalDeformableContactSolverResults(
+      const Context<double>& context) const {
+    return deformable_rigid_manager_->EvalDeformableContactSolverResults(
+        context);
+  }
+
+  /* Calls DiscreteUpdateManager::CalcContactSolverResults() and returns the
+   output. */
+  const ContactSolverResults<double> CalcContactSolverResults(
+      const Context<double>& context) const {
+    ContactSolverResults<double> results;
+    deformable_rigid_manager_->CalcContactSolverResults(context, &results);
+    return results;
+  }
+
   SceneGraph<double>* scene_graph_{nullptr};
   MultibodyPlant<double>* plant_{nullptr};
   const DeformableRigidManager<double>* deformable_rigid_manager_{nullptr};
-  DeformableBodyIndex deformable_index_;
+  DeformableBodyIndex deformable_octahedron_;
+  DeformableBodyIndex deformable_cube_;
   BodyIndex rigid_index_;
   GeometryId rigid_geometry_index_;
   std::unique_ptr<systems::Diagram<double>> diagram_{nullptr};
@@ -198,13 +241,14 @@ TEST_F(DeformableRigidContactSolverTest, NoContact) {
                   |
                   ●
                 ⁄  | ＼  deformable
-              ⁄    |   ＼  octahedron
-            ⁄      |     ＼
-   -Y-----●-------●-------●----+Y
-            \     |      ⁄
+              ⁄----+---＼  octahedron/cube
+            ⁄  |   |   | ＼
+   -Y-----●---+---●---+---●----+Y
+            \ |   |   |  ⁄
               \---|----⁄
-              | \ |  ⁄ |
+              --\-|--⁄--
               |   ●   |
+              |   |   |
               |   |   |
               ----|---- rigid cube
                   |
@@ -212,7 +256,7 @@ TEST_F(DeformableRigidContactSolverTest, NoContact) {
 TEST_F(DeformableRigidContactSolverTest, InContact) {
   Context<double>& plant_context =
       plant_->GetMyMutableContextFromRoot(diagram_context_.get());
-  const Vector3d p_WB(0, 0, -1);
+  const Vector3d p_WB(0, 0, -1.25);
   const math::RigidTransformd X_WB(p_WB);
   plant_->SetFreeBodyPose(&plant_context, plant_->get_body(rigid_index_), X_WB);
   /* Introduce some arbitrary spatial velocity for the rigid cube to make the
@@ -276,6 +320,82 @@ TEST_F(DeformableRigidContactSolverTest, InContact) {
   EXPECT_TRUE((results.fn.array() >= 0).all());
   EXPECT_TRUE(CompareMatrices(results.vn.cwiseProduct(results.fn),
                               VectorXd::Zero(nc), kTolerance));
+}
+
+/* Verifies that the deformable contact solver results obtained through the
+ Schur complement matches expectation. In particular,
+ 1. the results at the contact points (i.e. contact forces and contact
+    velocities) match their rigid counterparts, and
+ 2. the equation A⋅Δv = Jcᵀ⋅γ is satisfied for *all* (not just participating)
+    deformable dofs. */
+TEST_F(DeformableRigidContactSolverTest, DeformableResults) {
+  Context<double>& plant_context =
+      plant_->GetMyMutableContextFromRoot(diagram_context_.get());
+  /* Move the rigid cube down so that it intersects the octahedron in the lower
+   prism. The test setup looks like the following in the yz-plane:
+                 +Z
+                  |
+                  ●
+                ⁄  | ＼  deformable
+              ⁄----+---＼  octahedron/cube
+            ⁄  |   |   | ＼
+   -Y-----●---+---●---+---●----+Y
+            \ |   |   |  ⁄
+              \---|----⁄
+              --\-|--⁄--
+              |   ●   |
+              |   |   |
+              |   |   |
+              ----|---- rigid cube
+                  |
+                 -Z                    */
+  const Vector3d p_WB(0, 0, -1.25);
+  const math::RigidTransformd X_WB(p_WB);
+  plant_->SetFreeBodyPose(&plant_context, plant_->get_body(rigid_index_), X_WB);
+  const Vector3d w_WB(0.1, 0.2, 0.3);
+  const Vector3d v_WB(0.4, 0.5, 0.6);
+  const SpatialVelocity<double> V_WB(w_WB, v_WB);
+  plant_->SetFreeBodySpatialVelocity(&plant_context,
+                                     plant_->get_body(rigid_index_), V_WB);
+  const ContactSolverResults<double>& deformable_results =
+      EvalDeformableContactSolverResults(plant_context);
+  const ContactSolverResults<double> rigid_results =
+      CalcContactSolverResults(plant_context);
+
+  /* Verifies the first documented test. Since there are only deformable-rigid
+   contact and no rigid-rigid contact, the contact forces are velocities
+   should be the same for the rigid results and the deformable results. */
+  EXPECT_TRUE(CompareMatrices(deformable_results.fn, rigid_results.fn));
+  EXPECT_TRUE(CompareMatrices(deformable_results.ft, rigid_results.ft));
+  EXPECT_TRUE(CompareMatrices(deformable_results.vn, rigid_results.vn));
+  EXPECT_TRUE(CompareMatrices(deformable_results.vt, rigid_results.vt));
+
+  /* Verifies the second documented test. */
+  /* The cube is not in contact, so v = v* (dv = 0) and tau = 0. */
+  const FemStateBase<double>& cube_state_star =
+      EvalFreeMotionFemStateBase(plant_context, deformable_cube_);
+  const VectorXd& cube_v_star = cube_state_star.qdot();
+  const VectorXd& cube_v = deformable_results.v_next.head(3 * kNumCubeVertices);
+  EXPECT_TRUE(CompareMatrices(cube_v, cube_v_star));
+  const VectorXd cube_tau =
+      deformable_results.tau_contact.head(3 * kNumCubeVertices);
+  EXPECT_TRUE(CompareMatrices(cube_tau, VectorXd::Zero(3 * kNumCubeVertices)));
+
+  /* The octahedron is in contact, and we verify that A⋅Δv = Jcᵀ⋅γ. */
+  const FemStateBase<double>& octahedron_state_star =
+      EvalFreeMotionFemStateBase(plant_context, deformable_octahedron_);
+  const VectorXd& octahedron_v_star = octahedron_state_star.qdot();
+  const VectorXd& octahedron_v =
+      deformable_results.v_next.tail(3 * kNumOctahedronVertices);
+  const VectorXd dv = octahedron_v - octahedron_v_star;
+  const MatrixXd A(
+      EvalFreeMotionTangentMatrix(plant_context, deformable_octahedron_));
+  const VectorXd Adv = A * dv;
+  /* This `tau` is given by Jcᵀ⋅γ. */
+  const VectorXd octahedron_tau =
+      deformable_results.tau_contact.tail(3 * kNumOctahedronVertices);
+  /* Verify that A⋅Δv = Jcᵀ⋅γ. */
+  EXPECT_TRUE(CompareMatrices(Adv, octahedron_tau, 1e-13));
 }
 
 }  // namespace


### PR DESCRIPTION
This is the penultimate PR to integrate deformable solver with contact solver.

In addition to the new methods `CalcDeformableContactSolverResults()` and `EvalDeforambleContactSolverResults()`, strengthen the `DeformableRigidContactSolverTest` by adding a second deformable *not* in contact for additional converage.