### PR TITLE
Deprecate various unused bits of code

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -820,6 +820,7 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "eigen_stl_types_test",
+    copts = ["-Wno-cpp"],
     deps = [
         ":essential",
     ],

--- a/common/eigen_stl_types.h
+++ b/common/eigen_stl_types.h
@@ -14,6 +14,9 @@
 #include <Eigen/Core>
 #include <Eigen/StdVector>
 
+// NOLINTNEXTLINE(whitespace/line_length)
+#warning "DRAKE DEPRECATED: This header file and all of its helper types are deprecated.  With Drake's supported C++ compilers, there are no special rules required when using the the standard library's collections.  This header will be removed from Drake on or after 2021-12-01."
+
 namespace drake {
 
 /// A std::map that uses Eigen::aligned_allocator so that the

--- a/manipulation/schunk_wsg/schunk_buttons.py
+++ b/manipulation/schunk_wsg/schunk_buttons.py
@@ -20,6 +20,8 @@ from director import lcmUtils
 
 import drake as lcmdrake
 
+print("DRAKE DEPRECATED: This script will be removed from Drake on or after 2021-12-01.")
+
 def sendGripperCommand(targetPositionMM, force):
     msg = lcmdrake.lcmt_schunk_wsg_command()
     msg.utime = int(time.time()*1e6)

--- a/multibody/tree/position_kinematics_cache.h
+++ b/multibody/tree/position_kinematics_cache.h
@@ -6,7 +6,6 @@
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/eigen_stl_types.h"
 #include "drake/common/eigen_types.h"
 #include "drake/math/rigid_transform.h"
 #include "drake/math/rotation_matrix.h"

--- a/tools/workspace/jsoncpp/BUILD.bazel
+++ b/tools/workspace/jsoncpp/BUILD.bazel
@@ -5,4 +5,8 @@
 
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
+# TODO(jwnimmer-tri) Once the deprecation date of 2021-12-01 is reached
+# and this whole package is removed, also remove jsoncpp from the list
+# of operating system packages under drake/setup.
+
 add_lint_tests()

--- a/tools/workspace/jsoncpp/repository.bzl
+++ b/tools/workspace/jsoncpp/repository.bzl
@@ -19,5 +19,6 @@ def jsoncpp_repository(
         licenses = licenses,
         modname = modname,
         pkg_config_paths = pkg_config_paths,
+        extra_deprecation = "DRAKE DEPRECATED: The @jsoncpp external will be removed from Drake on or after 2021-12-01.",  # noqa
         **kwargs
     )


### PR DESCRIPTION
* The eigen_stl_types.h header (closes #15578).
* The schunk_buttons.py helper script (closes #15583).
* The `@jsoncpp` external (closes #15623).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15639)
<!-- Reviewable:end -->
