### PR TITLE
Modify hydro contact vis to provide more information (names)

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -1149,8 +1149,7 @@ PYBIND11_MODULE(plant, m) {
     py::class_<Class, systems::LeafSystem<T>>(
         m, "ContactResultsToLcmSystem", cls_doc.doc)
         .def(py::init<const MultibodyPlant<T>&>(), py::arg("plant"),
-            // Keep alive, reference: `self` keeps `plant` alive.
-            py::keep_alive<1, 2>(), cls_doc.ctor.doc)
+            cls_doc.ctor.doc)
         .def("get_contact_result_input_port",
             &Class::get_contact_result_input_port, py_rvp::reference_internal,
             cls_doc.get_contact_result_input_port.doc)
@@ -1174,7 +1173,29 @@ PYBIND11_MODULE(plant, m) {
       py::keep_alive<2, 1>(),
       // Keep alive, transitive: `lcm` keeps `builder` alive.
       py::keep_alive<3, 1>(),
-      doc.ConnectContactResultsToDrakeVisualizer.doc_3args);
+      doc.ConnectContactResultsToDrakeVisualizer.doc_3args_builder_plant_lcm);
+
+  m.def(
+      "ConnectContactResultsToDrakeVisualizer",
+      [](systems::DiagramBuilder<double>* builder,
+          const MultibodyPlant<double>& plant,
+          const geometry::SceneGraph<double>& scene_graph,
+          lcm::DrakeLcmInterface* lcm) {
+        return drake::multibody::ConnectContactResultsToDrakeVisualizer(
+            builder, plant, scene_graph, lcm);
+      },
+      py::arg("builder"), py::arg("plant"), py::arg("scene_graph"),
+      py::arg("lcm") = nullptr, py_rvp::reference,
+      // Keep alive, ownership: `return` keeps `builder` alive.
+      py::keep_alive<0, 1>(),
+      // Keep alive, transitive: `plant` keeps `builder` alive.
+      py::keep_alive<2, 1>(),
+      // Keep alive, transitive: `scene_graph` keeps `builder` alive.
+      py::keep_alive<3, 1>(),
+      // Keep alive, transitive: `lcm` keeps `builder` alive.
+      py::keep_alive<4, 1>(),
+      doc.ConnectContactResultsToDrakeVisualizer
+          .doc_4args_builder_plant_scene_graph_lcm);
 
   {
     using Class = PropellerInfo;

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from pydrake.autodiffutils import AutoDiffXd
 from pydrake.symbolic import Expression, Variable
+from pydrake.lcm import DrakeLcm
 from pydrake.math import RigidTransform
 from pydrake.multibody.tree import (
     BallRpyJoint_,
@@ -1924,13 +1925,14 @@ class TestPlant(unittest.TestCase):
         file_name = FindResourceOrThrow(
             "drake/multibody/benchmarks/acrobot/acrobot.sdf")
         plant = MultibodyPlant_[float](0.0)
+
         Parser(plant).AddModelFromFile(file_name)
         plant.Finalize()
         plant.set_penetration_allowance(penetration_allowance=0.0001)
         plant.set_stiction_tolerance(v_stiction=0.001)
         self.assertIsInstance(
             plant.get_contact_penalty_method_time_scale(), float)
-        contact_results_to_lcm = ContactResultsToLcmSystem(plant)
+        contact_results_to_lcm = ContactResultsToLcmSystem(plant=plant)
         context = contact_results_to_lcm.CreateDefaultContext()
         contact_results_to_lcm.get_input_port(0).FixValue(
             context, ContactResults_[float]())
@@ -1940,18 +1942,32 @@ class TestPlant(unittest.TestCase):
         self.assertIsInstance(result, AbstractValue)
 
     def test_connect_contact_results(self):
-        DiagramBuilder = DiagramBuilder_[float]
-        MultibodyPlant = MultibodyPlant_[float]
-
+        # For this test to be meaningful, the sdf file must contain collision
+        # geometries. We'll do a reality check after instantiating.
         file_name = FindResourceOrThrow(
-            "drake/multibody/benchmarks/acrobot/acrobot.sdf")
-        builder = DiagramBuilder()
-        plant = builder.AddSystem(MultibodyPlant(0.001))
-        Parser(plant).AddModelFromFile(file_name)
-        plant.Finalize()
+            "drake/bindings/pydrake/multibody/test/double_pendulum.sdf")
+        # Test for owning and non-owning lcm.
+        for lcm in (None, DrakeLcm()):
+            # There are two versions of the function; one takes a SceneGraph,
+            # one does not. Test both.
+            for use_custom_names in (True, False):
+                builder = DiagramBuilder_[float]()
+                plant, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.0)
+                Parser(plant).AddModelFromFile(file_name)
+                plant.Finalize()
+                self.assertGreater(
+                    len(plant.GetCollisionGeometriesForBody(
+                        plant.GetBodyByName("base"))),
+                    0)
 
-        publisher = ConnectContactResultsToDrakeVisualizer(builder, plant)
-        self.assertIsInstance(publisher, LcmPublisherSystem)
+                if use_custom_names:
+                    publisher = ConnectContactResultsToDrakeVisualizer(
+                        builder=builder, plant=plant, scene_graph=scene_graph,
+                        lcm=lcm)
+                else:
+                    publisher = ConnectContactResultsToDrakeVisualizer(
+                        builder=builder, plant=plant, lcm=lcm)
+                self.assertIsInstance(publisher, LcmPublisherSystem)
 
     def test_collision_filter(self):
         builder_f = DiagramBuilder_[float]()

--- a/lcmtypes/lcmt_hydroelastic_contact_surface_for_viz.lcm
+++ b/lcmtypes/lcmt_hydroelastic_contact_surface_for_viz.lcm
@@ -1,9 +1,19 @@
 package drake;
 
 struct lcmt_hydroelastic_contact_surface_for_viz {
-  // Names of the colliding bodies.
+  // The contact is between two bodies, but we track multiple names per body
+  // so that visualizers can fully disambiguate contacts:
+  //
+  //   - name of the geometry affixed to the body which produced the surface.
+  //   - name of the body.
+  //   - name of the model instance to which the body belongs.
+  //
+  string geometry1_name;
   string body1_name;
+  string model1_name;
+  string geometry2_name;
   string body2_name;
+  string model2_name;
 
   // The centroid of the contact surface, as an offset vector expressed in the
   // world frame.

--- a/multibody/plant/contact_results_to_lcm.cc
+++ b/multibody/plant/contact_results_to_lcm.cc
@@ -2,31 +2,70 @@
 
 #include <memory>
 
+#include "drake/common/text_logging.h"
 #include "drake/common/unused.h"
 #include "drake/lcmt_contact_results_for_viz.hpp"
 
 namespace drake {
 namespace multibody {
 
+using geometry::GeometryId;
+using internal::FullBodyName;
 using systems::Context;
+
+namespace internal {
+
+bool operator==(const FullBodyName& n1, const FullBodyName& n2) {
+  return n1.model == n2.model && n1.body == n2.body &&
+         n1.geometry == n2.geometry;
+}
+
+}  // namespace internal
+
+namespace {
+
+/* Wrapper for plant.GetCollisionGeometriesForBody() that can provide a
+ warning that visualization would be improved by providing a geometry name
+ generator. */
+template <typename T>
+const std::vector<GeometryId>& GetCollisionGeometriesForBody(
+    const MultibodyPlant<T>& plant, const Body<T>& body,
+    bool warn_for_multi_geometry_body) {
+  const std::vector<GeometryId>& geometries =
+      plant.GetCollisionGeometriesForBody(body);
+  if (warn_for_multi_geometry_body && geometries.size() > 1) {
+    static const logging::Warn log_once(
+        "MultibodyPlant has at least one body '{}/{}' with multiple contact "
+        "geometries. Contacts with this body may be unclear in the visualizer "
+        "if contact is made with multiple geometries simultaneously. To "
+        "clarify the visualization, pass in a geometry naming functor to the "
+        "constructor. See the documentation for ContactResultsToLcmSystem for "
+        "details.",
+        plant.GetModelInstanceName(body.model_instance()), body.name());
+    unused(log_once);
+  }
+  return geometries;
+}
+
+/* The default functor that converts GeometryId to a simple stringified version.
+ */
+std::string id_as_label(GeometryId id) {
+  return fmt::format("Id({})", id);
+}
+
+std::function<std::string(GeometryId)> make_geometry_name_lookup(
+    const geometry::SceneGraph<double>& scene_graph) {
+  return [&inspector = scene_graph.model_inspector()](GeometryId id) {
+    return inspector.GetName(id);
+  };
+}
+
+}  // namespace
 
 template <typename T>
 ContactResultsToLcmSystem<T>::ContactResultsToLcmSystem(
     const MultibodyPlant<T>& plant)
-    : ContactResultsToLcmSystem<T>(true) {
-  DRAKE_DEMAND(plant.is_finalized());
-  const int body_count = plant.num_bodies();
-
-  body_names_.reserve(body_count);
-  using std::to_string;
-  for (BodyIndex i{0}; i < body_count; ++i) {
-    const Body<T>& body = plant.get_body(i);
-    body_names_.push_back(body.name() + "(" + to_string(body.model_instance()) +
-                          ")");
-    for (auto geometry_id : plant.GetCollisionGeometriesForBody(body))
-      geometry_id_to_body_name_map_[geometry_id] = body.name();
-  }
-}
+    : ContactResultsToLcmSystem<T>(plant, nullptr) {}
 
 template <typename T>
 const systems::InputPort<T>&
@@ -38,6 +77,33 @@ template <typename T>
 const systems::OutputPort<T>&
 ContactResultsToLcmSystem<T>::get_lcm_message_output_port() const {
   return this->get_output_port(message_output_port_index_);
+}
+
+template <typename T>
+ContactResultsToLcmSystem<T>::ContactResultsToLcmSystem(
+    const MultibodyPlant<T>& plant,
+    const std::function<std::string(GeometryId)>& geometry_name_lookup)
+    : ContactResultsToLcmSystem<T>(true) {
+  DRAKE_DEMAND(plant.is_finalized());
+  const int body_count = plant.num_bodies();
+
+  body_names_.reserve(body_count);
+  const bool use_default_namer = geometry_name_lookup == nullptr;
+  const std::function<std::string(GeometryId)>& namer =
+      use_default_namer ? &id_as_label : geometry_name_lookup;
+  for (BodyIndex i{0}; i < body_count; ++i) {
+    const Body<T>& body = plant.get_body(i);
+    using std::to_string;
+    body_names_.push_back(body.name() + "(" + to_string(body.model_instance()) +
+                          ")");
+    for (auto geometry_id :
+         GetCollisionGeometriesForBody(plant, body, use_default_namer)) {
+      const std::string& model_name =
+          plant.GetModelInstanceName(body.model_instance());
+      geometry_id_to_body_name_map_[geometry_id] = {model_name, body.name(),
+                                                    namer(geometry_id)};
+    }
+  }
 }
 
 template <typename T>
@@ -63,13 +129,15 @@ template <typename T>
 void ContactResultsToLcmSystem<T>::CalcLcmContactOutput(
     const Context<T>& context, lcmt_contact_results_for_viz* output) const {
   // Get input / output.
-  const auto& contact_results = get_contact_result_input_port().
-      template Eval<ContactResults<T>>(context);
+  const auto& contact_results =
+      get_contact_result_input_port().template Eval<ContactResults<T>>(context);
+  // TODO(SeanCurtis-TRI): Here, and below, the abbreviation "msg" is not
+  //  style guide-compliant.
   auto& msg = *output;
 
   // Time in microseconds.
-  msg.timestamp = static_cast<int64_t>(
-      ExtractDoubleOrThrow(context.get_time()) * 1e6);
+  msg.timestamp =
+      static_cast<int64_t>(ExtractDoubleOrThrow(context.get_time()) * 1e6);
   msg.num_point_pair_contacts = contact_results.num_point_pair_contacts();
   msg.point_pair_contact_info.resize(msg.num_point_pair_contacts);
   msg.num_hydroelastic_contacts = contact_results.num_hydroelastic_contacts();
@@ -108,10 +176,16 @@ void ContactResultsToLcmSystem<T>::CalcLcmContactOutput(
             hydroelastic_contact_info.quadrature_point_data();
 
     // Get the two body names.
-    surface_msg.body1_name = geometry_id_to_body_name_map_.at(
-            hydroelastic_contact_info.contact_surface().id_M());
-    surface_msg.body2_name = geometry_id_to_body_name_map_.at(
-            hydroelastic_contact_info.contact_surface().id_N());
+    const FullBodyName& name1 = geometry_id_to_body_name_map_.at(
+        hydroelastic_contact_info.contact_surface().id_M());
+    surface_msg.body1_name = name1.body;
+    surface_msg.model1_name = name1.model;
+    surface_msg.geometry1_name = name1.geometry;
+    const FullBodyName& name2 = geometry_id_to_body_name_map_.at(
+        hydroelastic_contact_info.contact_surface().id_N());
+    surface_msg.body2_name = name2.body;
+    surface_msg.model2_name = name2.model;
+    surface_msg.geometry2_name = name2.geometry;
 
     const geometry::ContactSurface<T>& contact_surface =
         hydroelastic_contact_info.contact_surface();
@@ -171,25 +245,19 @@ void ContactResultsToLcmSystem<T>::CalcLcmContactOutput(
   }
 }
 
-systems::lcm::LcmPublisherSystem* ConnectContactResultsToDrakeVisualizer(
-    systems::DiagramBuilder<double>* builder,
-    const MultibodyPlant<double>& multibody_plant,
-    lcm::DrakeLcmInterface* lcm) {
-  return ConnectContactResultsToDrakeVisualizer(
-      builder, multibody_plant,
-      multibody_plant.get_contact_results_output_port(), lcm);
-}
-
-systems::lcm::LcmPublisherSystem* ConnectContactResultsToDrakeVisualizer(
+systems::lcm::LcmPublisherSystem* ConnectWithNameLookup(
     systems::DiagramBuilder<double>* builder,
     const MultibodyPlant<double>& multibody_plant,
     const systems::OutputPort<double>& contact_results_port,
+    const std::function<std::string(GeometryId)>& name_lookup,
     lcm::DrakeLcmInterface* lcm) {
   DRAKE_DEMAND(builder != nullptr);
 
-  auto contact_to_lcm =
-      builder->template AddSystem<ContactResultsToLcmSystem<double>>(
-          multibody_plant);
+  // Note: Can't use AddSystem<System> or make_unique<System> because neither
+  // of those have access to the private constructor.
+  ContactResultsToLcmSystem<double>* contact_to_lcm =
+      builder->AddSystem(std::unique_ptr<ContactResultsToLcmSystem<double>>(
+          new ContactResultsToLcmSystem<double>(multibody_plant, name_lookup)));
   contact_to_lcm->set_name("contact_to_lcm");
 
   auto contact_results_publisher = builder->AddSystem(
@@ -202,6 +270,47 @@ systems::lcm::LcmPublisherSystem* ConnectContactResultsToDrakeVisualizer(
   builder->Connect(*contact_to_lcm, *contact_results_publisher);
 
   return contact_results_publisher;
+}
+
+systems::lcm::LcmPublisherSystem* ConnectContactResultsToDrakeVisualizer(
+    systems::DiagramBuilder<double>* builder,
+    const MultibodyPlant<double>& multibody_plant,
+    lcm::DrakeLcmInterface* lcm) {
+  return ConnectWithNameLookup(
+      builder, multibody_plant,
+      multibody_plant.get_contact_results_output_port(), nullptr, lcm);
+}
+
+systems::lcm::LcmPublisherSystem* ConnectContactResultsToDrakeVisualizer(
+    systems::DiagramBuilder<double>* builder,
+    const MultibodyPlant<double>& multibody_plant,
+    const geometry::SceneGraph<double>& scene_graph,
+    lcm::DrakeLcmInterface* lcm) {
+  return ConnectWithNameLookup(
+      builder, multibody_plant,
+      multibody_plant.get_contact_results_output_port(),
+      make_geometry_name_lookup(scene_graph), lcm);
+}
+
+systems::lcm::LcmPublisherSystem* ConnectContactResultsToDrakeVisualizer(
+    systems::DiagramBuilder<double>* builder,
+    const MultibodyPlant<double>& multibody_plant,
+    const systems::OutputPort<double>& contact_results_port,
+    lcm::DrakeLcmInterface* lcm) {
+  return ConnectWithNameLookup(
+      builder, multibody_plant, contact_results_port, nullptr, lcm);
+}
+
+systems::lcm::LcmPublisherSystem* ConnectContactResultsToDrakeVisualizer(
+    systems::DiagramBuilder<double>* builder,
+    const MultibodyPlant<double>& multibody_plant,
+    const geometry::SceneGraph<double>& scene_graph,
+    const systems::OutputPort<double>& contact_results_port,
+    lcm::DrakeLcmInterface* lcm) {
+  return ConnectWithNameLookup(
+      builder, multibody_plant,
+      contact_results_port,
+      make_geometry_name_lookup(scene_graph), lcm);
 }
 
 }  // namespace multibody

--- a/multibody/plant/contact_results_to_lcm.h
+++ b/multibody/plant/contact_results_to_lcm.h
@@ -3,12 +3,14 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 #include <vector>
 
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/scene_graph.h"
 #include "drake/lcmt_contact_results_for_viz.hpp"
 #include "drake/multibody/plant/contact_results.h"
 #include "drake/multibody/plant/multibody_plant.h"
@@ -18,6 +20,24 @@
 
 namespace drake {
 namespace multibody {
+namespace internal {
+
+/* Stores the "full" name of a body *in contact*: its model instance name, body
+ name, and geometry name. This assumes that `model_name` is guaranteed to be
+ unique within MBP. So, for two bodies which may be identically named (body
+ name), they *must* differ by model name. For a body that has multiple collision
+ geometries, we rely on the fact that every collision geometry for a single
+ frame must be uniquely named. */
+struct FullBodyName {
+  std::string model;
+  std::string body;
+  std::string geometry;
+};
+
+/* Facilitate unit testing. See ContactResultsToLcmSystem::Equals(). */
+bool operator==(const FullBodyName& n1, const FullBodyName& n2);
+
+}  // namespace internal
 
 /** A System that encodes ContactResults into a lcmt_contact_results_for_viz
  message. It has a single input port with type ContactResults<T> and a single
@@ -25,27 +45,56 @@ namespace multibody {
 
  Although this class can be instantiated on all default scalars, its
  functionality will be limited for `T` = symbolic::Expression. If there are any
- `symbolic::Variable`s in the expression, attempting to evaluate the output port
- will throw an exception. The support is sufficient that a systems::Diagram with
- a %ContactResultsToLcmSystem can be scalar converted to symbolic::Expression
- without error, but not necessarily evaluated.
+ symbolic::Variable instances in the expression, attempting to evaluate the
+ output port will throw an exception. The support is sufficient that a
+ systems::Diagram with a %ContactResultsToLcmSystem can be scalar converted to
+ symbolic::Expression without error, but not necessarily evaluated.
+
+ <h3>Constructing instances</h3>
+
+ Generally, you shouldn't construct %ContactResultsToLcmSystem instances
+ directly. We recommend using one of the overloaded
+ @ref contact_result_vis_creation "ConnectContactResultsToDrakeVisualizer()"
+ methods to add contact visualization to your diagram.
+
+ <h3>How contacts are described in visualization</h3>
+
+ In the visualizer, each contact between two bodies is uniquely characterized
+ by two triples of names: (model instance name, body name, geometry name).
+ These triples help distinguish contacts which might otherwise be ambiguous
+ (e.g., contact with two bodies, both called "box" but part of different model
+ instances).
+
+ %ContactResultsToLcmSystem gets the model instance and body names from an
+ instance of MultibodyPlant, but *geometry* names are not available from the
+ plant. By default, %ContactResultsToLcmSystem will *generate* a unique name
+ based on a geometry's unique id (e.g., "Id(7)"). For many applications
+ (those cases where each body has only a single collision geometry), this is
+ perfectly acceptable. However, in cases where a body has multiple collision
+ geometries, those default names may not be helpful when viewing the visualized
+ results. Instead, %ContactResultsToLcmSystem can use the names associated with
+ the id in a geometry::SceneGraph instance. The only method for doing this is
+ via the @ref contact_result_vis_creation
+ "ConnectContactResultsToDrakeVisualizer()" methods and requires the diagram
+ to be instantiated as double valued. If a diagram with a different scalar
+ type is required, it should subsequently be scalar converted.
 
  @tparam_default_scalar
- */
+ @ingroup visualization */
 template <typename T>
 class ContactResultsToLcmSystem final : public systems::LeafSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ContactResultsToLcmSystem)
 
-  /** Constructs a ContactResultsToLcmSystem.
-   @param plant The MultibodyPlant that the ContactResults are generated from.
-   @pre The `plant` must be finalized already. The input port of this system
-        must be connected to the corresponding output port of `plant`
-        (either directly or from an exported port in a Diagram).
-  */
+  /** Constructs an instance with *default* geometry names (e.g., "Id(7)").
+
+   @param plant   The MultibodyPlant that the ContactResults are generated from.
+   @pre The `plant` parameter (or a fully equivalent plant) connects to `this`
+        system's input port.
+   @pre The `plant` parameter is finalized. */
   explicit ContactResultsToLcmSystem(const MultibodyPlant<T>& plant);
 
-  /** Scalar-converting copy constructor.  */
+  /** Scalar-converting copy constructor. */
   template <typename U>
   explicit ContactResultsToLcmSystem(const ContactResultsToLcmSystem<U>& other)
       : ContactResultsToLcmSystem<T>(true) {
@@ -58,6 +107,13 @@ class ContactResultsToLcmSystem final : public systems::LeafSystem<T> {
 
  private:
   friend class ContactResultsToLcmTester;
+  // The connection function gets friend access so it can call the "name lookup
+  // functor" constructor.
+  friend systems::lcm::LcmPublisherSystem* ConnectWithNameLookup(
+      systems::DiagramBuilder<double>*, const MultibodyPlant<double>&,
+      const systems::OutputPort<double>&,
+      const std::function<std::string(geometry::GeometryId)>&,
+      lcm::DrakeLcmInterface*);
 
   // Allow different specializations to access each other's private data for
   // scalar conversion.
@@ -66,6 +122,13 @@ class ContactResultsToLcmSystem final : public systems::LeafSystem<T> {
   // Special constructor that handles configuring ports. Used by both public
   // constructor and scalar-converting copy constructor.
   explicit ContactResultsToLcmSystem(bool);
+
+  // Constructs the system using a "name lookup functor" (mapping geometry ids
+  // to geometry names).
+  ContactResultsToLcmSystem(
+      const MultibodyPlant<T>& plant,
+      const std::function<std::string(geometry::GeometryId)>&
+          geometry_name_lookup);
 
   void CalcLcmContactOutput(const systems::Context<T>& context,
                             lcmt_contact_results_for_viz* output) const;
@@ -88,65 +151,105 @@ class ContactResultsToLcmSystem final : public systems::LeafSystem<T> {
   systems::InputPortIndex contact_result_input_port_index_;
   systems::OutputPortIndex message_output_port_index_;
 
-  // A mapping from geometry IDs to body indices.
-  std::unordered_map<geometry::GeometryId, std::string>
+  // TODO(SeanCurtis-TRI): There is some incoherence in how body names are
+  //  stored based on contact type (point vs hydro).
+  //  geometry_id_to_body_name_map_ is exclusively used by hydro, and
+  //  body_names_ is exclusively used for point contact. They should be
+  //  reconciled.
+
+  // A mapping from geometry IDs to per-body name data.
+  std::unordered_map<geometry::GeometryId, internal::FullBodyName>
       geometry_id_to_body_name_map_;
 
   // A mapping from body index values to body names.
   std::vector<std::string> body_names_;
 };
 
-/** Extends a Diagram with the required components to publish contact results
- to drake_visualizer. This must be called _during_ Diagram building and
- uses the given `builder` to add relevant subsystems and connections.
+/** @name Visualizing contact results
+ @anchor contact_result_vis_creation
 
- This is a convenience method to simplify some common boilerplate for adding
- contact results visualization capability to a Diagram. What it does is:
+ These methods extend a Diagram with the required components to publish contact
+ results (as reported by MultibodyPlant) to drake_visualizer. We recommend
+ using these methods instead of assembling the requisite components by hand.
 
- - adds systems ContactResultsToLcmSystem and LcmPublisherSystem to
+ These must be called _during_ Diagram building. Each method makes modifications
+ to the diagram being constructed by `builder` including the following changes:
+
+ - adds systems multibody::ContactResultsToLcmSystem and LcmPublisherSystem to
    the Diagram and connects the draw message output to the publisher input,
- - connects the `multibody_plant` contact results output to the
+ - connects a ContactResults<double>-valued output port to the
    ContactResultsToLcmSystem system, and
  - sets the publishing rate to 1/60 of a second (simulated time).
 
- @param builder          The diagram builder being used to construct the
-                         Diagram.
- @param multibody_plant  The System in `builder` containing the plant whose
-                         contact results are to be visualized.
- @param lcm              An optional lcm interface through which lcm messages
-                         will be dispatched. Will be allocated internally if
-                         none is supplied.
+ The four variants differ in the following ways:
 
- @pre The given `multibody_plant` must be contained within the supplied
-      DiagramBuilder.
+  - Two overloads take a SceneGraph and two don't. Those that do will ensure
+    that the geometry names communicated in the lcm messages match the names
+    used in SceneGraph. Those that don't default to the naming convention
+    documented in ContactResultsToLcmSystem.
+  - Two overloads take an OutputPort and two don't. This determines what is
+    connected to the ContactResultsToLcmSystem input port. The overloads that
+    specify an OutputPort will attempt to connect that port. Those that don't
+    will connect the given plant's contact results output port.
 
- @returns the LcmPublisherSystem (in case callers, e.g., need to change the
- default publishing rate).
+ The parameters have the following semantics:
 
- @ingroup visualization
- */
+ @param builder                The diagram builder being used to construct the
+                               Diagram. Systems will be added to this builder.
+ @param plant                  The System in `builder` containing the plant
+                               whose contact results are to be visualized.
+ @param scene_graph            The SceneGraph that will determine how the
+                               geometry names will appear in the lcm message.
+ @param lcm                    An optional lcm interface through which lcm
+                               messages will be dispatched. Will be allocated
+                               internally if none is supplied. If one is given,
+                               it must remain alive at least as long as the
+                               diagram built from `builder`.
+ @param contact_results_port   The optional port that will be connected to the
+                               ContactResultsToLcmSystem (as documented above).
+
+ @returns (for all overloads) the LcmPublisherSystem (in case callers, e.g.,
+          need to change the default publishing rate).
+
+ @pre `plant` is contained within the supplied `builder`.
+ @pre `scene_graph` (if given) is contained with the supplied `builder`.
+ @pre `contact_results_port` (if given) belongs to a system that is an immediate
+      child of `builder`. */
+//@{
+
+/** MultibodyPlant-connecting, default-named geometry overload.
+ @ingroup visualization */
 systems::lcm::LcmPublisherSystem* ConnectContactResultsToDrakeVisualizer(
     systems::DiagramBuilder<double>* builder,
-    const MultibodyPlant<double>& multibody_plant,
+    const MultibodyPlant<double>& plant,
     lcm::DrakeLcmInterface* lcm = nullptr);
 
-/** Implements ConnectContactResultsToDrakeVisualizer, but using
- explicitly specified `contact_results_port` and `geometry_input_port`
- arguments.  This call is required, for instance, when the MultibodyPlant is
- inside a Diagram, and the Diagram exports the pose bundle port.
-
- @pre contact_results_port must be connected to the contact_results_port of
- @p multibody_plant.
-
- @see ConnectContactResultsToDrakeVisualizer().
-
- @ingroup visualization
- */
+/** MultibodyPlant-connecting, SceneGraph-named geometry overload.
+ @ingroup visualization */
 systems::lcm::LcmPublisherSystem* ConnectContactResultsToDrakeVisualizer(
     systems::DiagramBuilder<double>* builder,
-    const MultibodyPlant<double>& multibody_plant,
+    const MultibodyPlant<double>& plant,
+    const geometry::SceneGraph<double>& scene_graph,
+    lcm::DrakeLcmInterface* lcm = nullptr);
+
+/** OutputPort-connecting, default-named geometry overload.
+ @ingroup visualization */
+systems::lcm::LcmPublisherSystem* ConnectContactResultsToDrakeVisualizer(
+    systems::DiagramBuilder<double>* builder,
+    const MultibodyPlant<double>& plant,
     const systems::OutputPort<double>& contact_results_port,
     lcm::DrakeLcmInterface* lcm = nullptr);
+
+/** OutputPort-connecting, SceneGraph-named geometry overload.
+ @ingroup visualization */
+systems::lcm::LcmPublisherSystem* ConnectContactResultsToDrakeVisualizer(
+    systems::DiagramBuilder<double>* builder,
+    const MultibodyPlant<double>& plant,
+    const geometry::SceneGraph<double>& scene_graph,
+    const systems::OutputPort<double>& contact_results_port,
+    lcm::DrakeLcmInterface* lcm = nullptr);
+
+//@}
 
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/plant/test/contact_results_to_lcm_test.cc
+++ b/multibody/plant/test/contact_results_to_lcm_test.cc
@@ -33,6 +33,8 @@ using geometry::SurfaceMesh;
 using geometry::SurfaceVertex;
 using geometry::SurfaceVertexIndex;
 using math::RigidTransform;
+using multibody::internal::FullBodyName;
+using std::function;
 using std::make_unique;
 using std::move;
 using std::nullopt;
@@ -52,8 +54,24 @@ class ContactResultsToLcmTester {
  public:
   ContactResultsToLcmTester() = delete;
 
+  /* Provide access to the hidden constructor that allows control over the
+   naming method -- so we can directly test that it works. */
   template <typename T>
-  static unordered_map<GeometryId, string>& get_geometry_id_to_body_map(
+  static unique_ptr<ContactResultsToLcmSystem<T>> Make(
+      const MultibodyPlant<T>& plant,
+      const function<string(GeometryId)>& namer = nullptr) {
+    /* We want to make sure we explicitly exercise both constructors. */
+    if (namer == nullptr) {
+      return unique_ptr<ContactResultsToLcmSystem<T>>(
+          new ContactResultsToLcmSystem<T>(plant));
+    } else {
+      return unique_ptr<ContactResultsToLcmSystem<T>>(
+          new ContactResultsToLcmSystem<T>(plant, namer));
+    }
+  }
+
+  template <typename T>
+  static unordered_map<GeometryId, FullBodyName>& get_geometry_id_to_body_map(
       ContactResultsToLcmSystem<T>* system) {
     return system->geometry_id_to_body_name_map_;
   }
@@ -61,7 +79,7 @@ class ContactResultsToLcmTester {
   template <typename T>
   static void AddToGeometryBodyMap(
       ContactResultsToLcmSystem<T>* system,
-      std::initializer_list<unordered_map<GeometryId, string>::value_type>
+      std::initializer_list<unordered_map<GeometryId, FullBodyName>::value_type>
           items) {
     system->geometry_id_to_body_name_map_.insert(items);
   }
@@ -83,6 +101,33 @@ class ContactResultsToLcmTester {
     return system_T.Equals(system_U);
   }
 };
+
+/* Friend class to the plant. We're going to use this to artificially associate
+ GeometryIds (for mythical collision geometries) with bodies. This removes the
+ need for these tests to directly depend on SceneGraph. */
+class MultibodyPlantTester {
+ public:
+  /* Adds the given geometry `id` to the given `body` as one of its collision
+   geometries. */
+  template <typename T>
+  static void AddCollisionGeometryToBody(GeometryId id, const Body<T>& body,
+                                         MultibodyPlant<T>* plant) {
+    DRAKE_DEMAND(body.index() < plant->num_bodies());
+    plant->collision_geometries_[body.index()].push_back(id);
+  }
+};
+
+namespace internal {
+
+/* For the purpose of this test, enable writing FullBodyName to string so that
+ failure messages include human readable output (rather than bytestrings). */
+std::ostream& operator<<(std::ostream& out, const FullBodyName& name) {
+  out << "Model: '" << name.model << "', Body = '" << name.body << "', Geo: '"
+      << name.geometry << "'";
+  return out;
+}
+
+}  // namespace internal
 
 namespace {
 
@@ -199,40 +244,44 @@ const std::array<GeometryId, N>& GetGeometryIds() {
 template <typename T>
 class ContactResultsToLcmTest : public ::testing::Test {
  protected:
-  void SetUp() {
-    if constexpr (std::is_same_v<T, Expression>) {
-      /* SceneGraph<symbolic::Expression> is *not* supported. */
-      plant_ = builder_.template AddSystem<MultibodyPlant<T>>(0.0);
-    } else {
-      SceneGraph<T>* scene_graph;
-      std::tie(plant_, scene_graph) =
-          AddMultibodyPlantSceneGraph(&builder_, 0.0);
-    }
-    test_model_index_ = plant_->AddModelInstance("TestInstance");
-  }
+  /* Adds a body with the given `name` to the given `plant` as part of the given
+   model instance. In order to test the tables that ContactResultsToLcmSystem
+   builds during construction, this method builds the expected tables based
+   on the body added to the plant. The entries are added to the given
+   `id_to_body_map` and `body_names` output parameters.
 
-  void AddBody(const std::string& name, MultibodyPlant<T>* plant,
-               unordered_map<GeometryId, string>* id_to_body_map,
-               vector<string>* body_names,
-               optional<ModelInstanceIndex> opt_model_index = nullopt) {
-    const ModelInstanceIndex model_index =
-        opt_model_index.has_value() ? *opt_model_index : test_model_index_;
+   @param body_name         The name of the body to add.
+   @param model_index       The model instance to which this body will be
+                            added.
+   @param namer             A functor that turns GeometryId into strings.
+   @param plant             The plant to add the body to.
+   @param id_to_body_map    The ContactResultsToLcmSystem table that maps
+                            GeometryId to FullBodyName.
+   @param body_names        The ContactResultsToLcmSystem table that maps body
+                            index to body name.
+   @pre `model_index` is a valid model instance index. */
+  void AddBody(const std::string& body_name, ModelInstanceIndex model_index,
+               const function<string(GeometryId)>& namer,
+               MultibodyPlant<T>* plant,
+               unordered_map<GeometryId, FullBodyName>* id_to_body_map,
+               vector<string>* body_names) {
     const auto& body =
-        plant->AddRigidBody(name, model_index, SpatialInertia<double>());
-    body_names->push_back(fmt::format("{}({})", name, model_index));
-    if constexpr (!std::is_same_v<T, Expression>) {
-      // We can only register geometry for T != Expression.
-      const GeometryId id = plant->RegisterCollisionGeometry(
-          body, RigidTransform<double>{}, Sphere(0.5), name + "_sphere",
-          CoulombFriction<double>());
-      id_to_body_map->insert({id, name});
-    }
-  }
+        plant->AddRigidBody(body_name, model_index, SpatialInertia<double>());
+    /* The expected format based on knowledge of the ContactResultToLcmSystem's
+     implementation. */
+    body_names->push_back(fmt::format("{}({})", body_name, model_index));
 
-  MultibodyPlant<T>& get_plant(bool finalize = false) {
-    DRAKE_DEMAND(plant_ != nullptr);
-    if (finalize) plant_->Finalize();
-    return *plant_;
+    /* We will *simulate* registering a collision geometry with MBP. Rather than
+     instantiating SceneGraph<T> (which we can't even do for symbolic), we'll
+     use friend access to shove a GeometryId into MBP's table of known,
+     per-body collision geometries. That is sufficient for
+     ContactResultsToLcmSystem to add entries to its tables. */
+    const GeometryId fake_id = GeometryId::get_new_id();
+    MultibodyPlantTester::AddCollisionGeometryToBody(fake_id, body, plant);
+    /* And, now, populate the table. */
+    const string& model_name = plant->GetModelInstanceName(model_index);
+    const string geometry_name = namer(fake_id);
+    id_to_body_map->insert({fake_id, {model_name, body_name, geometry_name}});
   }
 
   /* Adds fake point-pair contact results to the given set of contact `results`.
@@ -290,11 +339,11 @@ class ContactResultsToLcmTest : public ::testing::Test {
 
     if (lcm_system != nullptr) {
       ContactResultsToLcmTester::AddToGeometryBodyMap(
-          lcm_system, {{ids[0], "G0's body"},
-                       {ids[1], "G1's body"},
-                       {ids[2], "G2's body"},
-                       {ids[3], "G3's body"},
-                       {GeometryId::get_new_id(), "Unreferenced body"}});
+          lcm_system, {{ids[0], {"Model0", "Body0", "Geo0"}},
+                       {ids[1], {"Model1", "Body1", "Geo1"}},
+                       {ids[2], {"Model2", "Body2", "Geo2"}},
+                       {ids[3], {"Model3", "Body3", "Geo3"}},
+                       {GeometryId::get_new_id(), {"M", "B", "G"}}});
     }
 
     /* In creating this fake contact data, what matters *most* is that the body
@@ -318,53 +367,80 @@ class ContactResultsToLcmTest : public ::testing::Test {
         MakeQuadratureData<U>(Vector3<U>{-3, -1, -2}));
     results->AddContactInfo(&pair2.access());
   }
-
-  DiagramBuilder<T> builder_;
-  MultibodyPlant<T>* plant_{};
-  ModelInstanceIndex test_model_index_{};
 };
 
 using ScalarTypes = ::testing::Types<double, AutoDiffXd, Expression>;
 TYPED_TEST_SUITE(ContactResultsToLcmTest, ScalarTypes);
 
-/* We construct a plant with known contents, instantiate an
+/* We construct a plant with known contents, instantiate an instance of
  ContactResultsToLcmSystem on it and confirm the internal tables are populated
- as we expect them to be. */
+ as we expect them to be.
+
+ We're exercising the private constructor that takes the geometry-naming
+ functor. Accessing that functionality is only *really* available by calling
+ ConnectContactResultsToDrakeVisualizer(), but by testing the functor flavor
+ of the constructor *here*, we leverage this code for both modes of construction
+ and simplify the tests on those functions to simply look for evidence that
+ the proper constructor was called (having already shown the constructor to be
+ correct). */
 TYPED_TEST(ContactResultsToLcmTest, Constructor) {
   using T = TypeParam;
 
-  /* These mirror the internal data tables in ContactResultsToLcmSystem. We'll
-   populate them as we populate MBP and confirm that the resulting tables match
-   the tables we build by hand. */
-  unordered_map<GeometryId, string> expected_geo_body_map;
-  /* The world body will always be the first listed. */
-  vector<string> expected_body_names{{"WorldBody(0)"}};
+  for (bool use_custom_names : {true, false}) {
+    /* These mirror the internal data tables in ContactResultsToLcmSystem. We'll
+     populate them as we populate MBP and confirm that the resulting tables
+     match the tables we build by hand. */
+    unordered_map<GeometryId, FullBodyName> expected_geo_body_map;
+    /* The world body will always be the first listed. */
+    vector<string> expected_body_names{{"WorldBody(0)"}};
 
-  MultibodyPlant<T>& plant = this->get_plant();
-  /* Body 1 and 2 go to the same model instance (the "default" for this test).
-   */
-  this->AddBody("body1", &plant, &expected_geo_body_map, &expected_body_names);
-  this->AddBody("body2", &plant, &expected_geo_body_map, &expected_body_names);
-  const ModelInstanceIndex model3 = plant.AddModelInstance("JustForBody3");
-  this->AddBody("body3", &plant, &expected_geo_body_map, &expected_body_names,
-                model3);
-  plant.Finalize();
+    auto namer = [use_custom_names](GeometryId id) {
+      if (use_custom_names) {
+        /* Create an arbitrary name unique to this test. */
+        return fmt::format("CustomTestId({})", id);
+      }
+      /* Reproduce the expected default name for ContactResultsToLcmSystem. */
+      return fmt::format("Id({})", id);
+    };
 
-  /* Construction should populate tables about bodies. */
-  ContactResultsToLcmSystem<T> lcm(plant);
+    MultibodyPlant<T> plant(0.0);
+    /* Body 1 and 2 go to the same model instance. Body 3 goes to its own. */
+    const ModelInstanceIndex model12 = plant.AddModelInstance("JustForBody12");
+    this->AddBody("body1", model12, namer, &plant, &expected_geo_body_map,
+                  &expected_body_names);
+    this->AddBody("body2", model12, namer, &plant, &expected_geo_body_map,
+                  &expected_body_names);
+    const ModelInstanceIndex model3 = plant.AddModelInstance("JustForBody3");
+    this->AddBody("body3", model3, namer, &plant, &expected_geo_body_map,
+                  &expected_body_names);
+    plant.Finalize();
 
-  /* Examine the constructed tables. */
-  const auto& body_names = ContactResultsToLcmTester::get_body_names(&lcm);
-  const auto& id_to_body_map =
-      ContactResultsToLcmTester::get_geometry_id_to_body_map(&lcm);
-  EXPECT_EQ(body_names, expected_body_names);
-  EXPECT_EQ(id_to_body_map, expected_geo_body_map);
+    SCOPED_TRACE(use_custom_names ? "Using custom names"
+                                  : "Using default names");
+    /* Construction should populate tables about bodies. */
+    unique_ptr<ContactResultsToLcmSystem<T>> lcm{};
+    if (use_custom_names) {
+      lcm = ContactResultsToLcmTester::Make(plant, namer);
+    } else {
+      /* Rather than simply passing in `nullptr`, we want to test the default-
+       value spelling of the constructor. */
+      lcm = ContactResultsToLcmTester::Make(plant);
+    }
 
-  /* We'll further confirm that the system has its default name and ports
-   available. */
-  EXPECT_EQ(lcm.get_name(), "ContactResultsToLcmSystem");
-  EXPECT_NO_THROW(lcm.get_contact_result_input_port());
-  EXPECT_NO_THROW(lcm.get_lcm_message_output_port());
+    /* Examine the constructed tables. */
+    const auto& body_names =
+        ContactResultsToLcmTester::get_body_names(lcm.get());
+    const auto& id_to_body_map =
+        ContactResultsToLcmTester::get_geometry_id_to_body_map(lcm.get());
+    EXPECT_EQ(body_names, expected_body_names);
+    EXPECT_EQ(id_to_body_map, expected_geo_body_map);
+
+    /* We'll further confirm that the system has its default name and ports
+     available. */
+    EXPECT_EQ(lcm->get_name(), "ContactResultsToLcmSystem");
+    EXPECT_NO_THROW(lcm->get_contact_result_input_port());
+    EXPECT_NO_THROW(lcm->get_lcm_message_output_port());
+  }
 }
 
 /* Confirms that empty ContactResults produces an empty message. */
@@ -373,7 +449,8 @@ TYPED_TEST(ContactResultsToLcmTest, EmptyContactResults) {
 
   /* We're not going to populate the plant, because we're going to set the
    internal tables by hand and fix the input for the context. */
-  MultibodyPlant<T>& plant = this->get_plant(true /* finalize */);
+  MultibodyPlant<T> plant(0.0);
+  plant.Finalize();
   ContactResultsToLcmSystem<T> lcm(plant);
   const unique_ptr<Context<T>> context = lcm.AllocateContext();
 
@@ -410,9 +487,8 @@ TYPED_TEST(ContactResultsToLcmTest, EmptyContactResults) {
     ContactResultsToLcmTester::AddToBodyNames(
         &lcm, {"A body", "Another body", "and more"});
     ContactResultsToLcmTester::AddToGeometryBodyMap(
-        &lcm,
-        {{GeometryId::get_new_id(), "A body"},
-         {GeometryId::get_new_id(), "The names don't even have to match"}});
+        &lcm, {{GeometryId::get_new_id(), {"A model", "A body", "A geometry"}},
+               {GeometryId::get_new_id(), {"names", "don't", "matter"}}});
     SCOPED_TRACE("With populated tables");
     confirm_empty();
   }
@@ -439,7 +515,8 @@ TYPED_TEST(ContactResultsToLcmTest, PointPairContactOnly) {
 
   /* We're not going to populate the plant, because we're going to set the
    internal tables by hand and fix the input for the context. */
-  MultibodyPlant<T>& plant = this->get_plant(true /* finalize */);
+  MultibodyPlant<T> plant(0.0);
+  plant.Finalize();
   ContactResultsToLcmSystem<T> lcm(plant);
   const unique_ptr<Context<T>> context = lcm.AllocateContext();
 
@@ -515,7 +592,8 @@ TYPED_TEST(ContactResultsToLcmTest, HydroContactOnly) {
 
   /* We're not going to populate the plant, because we're going to set the
    internal tables by hand and fix the input for the context. */
-  MultibodyPlant<T>& plant = this->get_plant(true /* finalize */);
+  MultibodyPlant<T> plant(0.0);
+  plant.Finalize();
   ContactResultsToLcmSystem<T> lcm(plant);
   const unique_ptr<Context<T>> context = lcm.AllocateContext();
 
@@ -544,8 +622,15 @@ TYPED_TEST(ContactResultsToLcmTest, HydroContactOnly) {
     const auto& surface = pair_data.contact_surface();
     const auto& mesh = surface.mesh_W();
 
-    EXPECT_EQ(pair_message.body1_name, geo_to_body_map.at(surface.id_M()));
-    EXPECT_EQ(pair_message.body2_name, geo_to_body_map.at(surface.id_N()));
+    const auto& name1 = geo_to_body_map.at(surface.id_M());
+    EXPECT_EQ(pair_message.body1_name, name1.body);
+    EXPECT_EQ(pair_message.model1_name, name1.model);
+    EXPECT_EQ(pair_message.geometry1_name, name1.geometry);
+
+    const auto& name2 = geo_to_body_map.at(surface.id_N());
+    EXPECT_EQ(pair_message.body2_name, name2.body);
+    EXPECT_EQ(pair_message.model2_name, name2.model);
+    EXPECT_EQ(pair_message.geometry2_name, name2.geometry);
 
     /* Mesh aggregate results: centroid, force, moment. */
     // clang-format off
@@ -626,7 +711,8 @@ TYPED_TEST(ContactResultsToLcmTest, MixedContactData) {
 
   /* We're not going to populate the plant, because we're going to set the
    internal tables by hand and fix the input for the context. */
-  MultibodyPlant<T>& plant = this->get_plant(true /* finalize */);
+  MultibodyPlant<T> plant(0.0);
+  plant.Finalize();
   ContactResultsToLcmSystem<T> lcm(plant);
   const unique_ptr<Context<T>> context = lcm.AllocateContext();
 
@@ -664,29 +750,33 @@ TYPED_TEST(ContactResultsToLcmTest, Transmogrifcation) {
 
   MultibodyPlant<double> plant(0.0);
   plant.Finalize();
-  ContactResultsToLcmSystem<double> lcm_double(plant);
+  auto custom_names = [](GeometryId id) {
+    return fmt::format("String that must be copied to match {}", id);
+  };
+  auto lcm_double = ContactResultsToLcmTester::Make(plant, custom_names);
+  lcm_double->set_name("Ad hoc name");
 
   /* We don't care about double-valued results, we're just using it to
-    populate the tables in lcm_double. These will get copied over. */
+   populate the tables in lcm_double. These will get copied over. */
   ContactResults<double> contacts_double;
-  this->AddFakePointPairContact(&lcm_double, &contacts_double);
-  this->AddFakeHydroContact(&lcm_double, &contacts_double);
+  this->AddFakePointPairContact(lcm_double.get(), &contacts_double);
+  this->AddFakeHydroContact(lcm_double.get(), &contacts_double);
 
-  auto system_T = [&lcm_double]() {
+  auto system_T = [&double_source = *lcm_double]() {
     if constexpr (std::is_same_v<T, double>) {
       /* We support AutoDiffXd -> double. So, when T is double, we'll convert to
        AutoDiffXd and *back*. Obviously if double -> AutoDiffXd is broken both
        that specific test and this test will fail. */
-      return lcm_double.ToAutoDiffXd()->ToScalarType<double>();
+      return double_source.ToAutoDiffXd()->template ToScalarType<double>();
     } else {
-      return lcm_double.ToScalarType<T>();
+      return double_source.template ToScalarType<T>();
     }
   }();
   ContactResultsToLcmSystem<T>* lcm_T =
       dynamic_cast<ContactResultsToLcmSystem<T>*>(system_T.get());
   ASSERT_NE(lcm_T, nullptr);
 
-  EXPECT_TRUE(ContactResultsToLcmTester::Equals(lcm_double, *lcm_T));
+  EXPECT_TRUE(ContactResultsToLcmTester::Equals(*lcm_double, *lcm_T));
 
   ContactResults<T> contacts;
   this->template AddFakePointPairContact<T>(nullptr, &contacts);
@@ -704,50 +794,121 @@ TYPED_TEST(ContactResultsToLcmTest, Transmogrifcation) {
   EXPECT_EQ(message.hydroelastic_contacts.size(), 2);
 }
 
-GTEST_TEST(ConnectContactResultsToDrakeVisualizer, BasicTest) {
-  systems::DiagramBuilder<double> builder;
+/* There are four overloads of ConnectContactResultsToDrakeVisualizer(). They
+ differ along two axes:
 
-  // Make a trivial plant with at least one body.
-  auto plant = builder.AddSystem<MultibodyPlant>(0.0);
-  plant->AddRigidBody("link", SpatialInertia<double>());
-  plant->Finalize();
+   - Does the ContactResultsToLcmSystem instance connect directly to the plant
+     or to some arbitrary passed OutputPort?
+   - Does ContactResultsToLcmSystem use default geometry names or does it get
+     geometry names from a given SceneGraph instance.
 
-  auto publisher = ConnectContactResultsToDrakeVisualizer(&builder, *plant);
+ The test fixture is built to facilitate tests structured along those axes. Each
+ test comprises four parts:
 
-  // Confirm that we get a non-null result.
-  EXPECT_NE(publisher, nullptr);
+   1. Construct a diagram (see ConfigureDiagram()).
+   2. Invoke a particular overload (found in each TEST_F).
+   3. Confirm the returned value is of expected type with documented properties
+      (see ExpectValidPublisher()).
+   4. Confirm geometry names are as expected (see ExpectGeometryNameSemantics().
+ */
+class ConnectVisualizerTest : public ::testing::Test {
+ protected:
+  void ConfigureDiagram(bool is_nested) {
+    auto system_pair = AddMultibodyPlantSceneGraph(&builder_, 0.0);
+    plant_ = &system_pair.plant;
+    scene_graph_ = &system_pair.scene_graph;
 
-  // Check that the publishing event was set as documented.
-  auto periodic_events = publisher->GetPeriodicEvents();
-  EXPECT_EQ(periodic_events.size(), 1);
-  EXPECT_EQ(periodic_events.begin()->first.period_sec(), 1 / 60.0);
+    const auto& body = plant_->AddRigidBody("link", SpatialInertia<double>());
+    plant_->RegisterCollisionGeometry(body, {}, Sphere(1.0), kGeoName,
+                                      CoulombFriction<double>{});
+    plant_->Finalize();
+
+    if (is_nested) {
+      /* We'll treat the MBP-SG pair as a nested diagram so we can test all
+       overloads of the DUT. This means, exporting the contact port out of the
+       diagram. */
+      builder_.ExportOutput(plant_->get_contact_results_output_port(),
+                            "contact_results");
+
+      auto diagram = builder_.AddSystem(builder_.Build());
+      contact_results_port_ = &diagram->GetOutputPort("contact_results");
+    }
+  }
+
+  /* Confirms that the publisher pointer is non-null and has been configured to
+   60Hz periodic publication. */
+  void ExpectValidPublisher(systems::lcm::LcmPublisherSystem* publisher) {
+    /* Confirm that we get a non-null result. */
+    ASSERT_NE(publisher, nullptr);
+
+    /* Check that the publishing event was set as documented. */
+    auto periodic_events = publisher->GetPeriodicEvents();
+    ASSERT_EQ(periodic_events.size(), 1);
+    EXPECT_EQ(periodic_events.begin()->first.period_sec(), 1 / 60.0);
+  }
+
+  /* Confirms that the names for geometries stored in the
+   ContactResultsToLcmSystem are as expepcted (default or scene_graph as
+   indicated). */
+  void ExpectGeometryNameSemantics(bool expect_default_names) {
+    /* Grab the contact results to lcm system and confirm the namer has
+     correctly handled. The name should either be the tester constant (kGeoName)
+     or Id(\d+). */
+    for (auto* system : builder_.GetMutableSystems()) {
+      auto* lcm = dynamic_cast<ContactResultsToLcmSystem<double>*>(system);
+      if (lcm != nullptr) {
+        const auto& id_to_body_map =
+            ContactResultsToLcmTester::get_geometry_id_to_body_map(lcm);
+        ASSERT_EQ(id_to_body_map.size(), 1);
+        const auto& [id, name] = *id_to_body_map.begin();
+        if (expect_default_names) {
+          EXPECT_EQ(name.geometry, fmt::format("Id({})", id));
+        } else {
+          EXPECT_EQ(name.geometry, kGeoName);
+        }
+        return;
+      }
+    }
+    GTEST_FAIL() << "The diagram builder did not have an instance of "
+                    "ContactResultsToLcmSystem.";
+  }
+
+  DiagramBuilder<double> builder_;
+  MultibodyPlant<double>* plant_{};
+  SceneGraph<double>* scene_graph_{};
+  const systems::OutputPort<double>* contact_results_port_{};
+  static constexpr char kGeoName[] = "test_sphere";
+};
+
+TEST_F(ConnectVisualizerTest, ConnectToPlantDefaultNames) {
+  ConfigureDiagram(false /* is_nested */);
+  auto* publisher = ConnectContactResultsToDrakeVisualizer(&builder_, *plant_);
+  ExpectValidPublisher(publisher);
+  ExpectGeometryNameSemantics(true /* expect_default_names */);
 }
 
-GTEST_TEST(ConnectContactResultsToDrakeVisualizer, NestedDiagramTest) {
-  systems::DiagramBuilder<double> builder;
+TEST_F(ConnectVisualizerTest, ConnectToPlantSceneGraphNames) {
+  ConfigureDiagram(false /* is_nested */);
+  auto* publisher =
+      ConnectContactResultsToDrakeVisualizer(&builder_, *plant_, *scene_graph_);
+  ExpectValidPublisher(publisher);
+  ExpectGeometryNameSemantics(false /* expect_default_names */);
+}
 
-  // Make a trivial plant with at least one body.
-  MultibodyPlant<double>* plant;
-  SceneGraph<double>* scene_graph;
-  std::tie(plant, scene_graph) = AddMultibodyPlantSceneGraph(&builder, 0.0);
-  plant->AddRigidBody("link", SpatialInertia<double>());
-  plant->Finalize();
+TEST_F(ConnectVisualizerTest, ConnectToPortDefaultNames) {
+  ConfigureDiagram(true /* is_nested */);
+  auto* publisher = ConnectContactResultsToDrakeVisualizer(
+      &builder_, *plant_, *contact_results_port_);
+  ExpectValidPublisher(publisher);
+  ExpectGeometryNameSemantics(true /* expect_default_names */);
+}
 
-  builder.ExportOutput(plant->get_contact_results_output_port(),
-                       "contact_results");
-
-  auto diagram = builder.AddSystem(builder.Build());
-
-  auto publisher = ConnectContactResultsToDrakeVisualizer(
-      &builder, *plant, diagram->GetOutputPort("contact_results"));
-
-  // Confirm that we get a non-null result.
-  EXPECT_NE(publisher, nullptr);
-
-  // Check that the publishing event was set as documented.
-  auto periodic_events = publisher->GetPeriodicEvents();
-  EXPECT_EQ(periodic_events.size(), 1);
-  EXPECT_EQ(periodic_events.begin()->first.period_sec(), 1 / 60.0);
+TEST_F(ConnectVisualizerTest, ConnectToPortSceneGraphNames) {
+  ConfigureDiagram(true /* is_nested */);
+  auto* publisher = ConnectContactResultsToDrakeVisualizer(
+      &builder_, *plant_, *scene_graph_, *contact_results_port_);
+  ExpectValidPublisher(publisher);
+  ExpectGeometryNameSemantics(false /* expect_default_names */);
 }
 
 }  // namespace


### PR DESCRIPTION
tl;dr We *now* include geometry and model instance names with the previously broadcast body names in the hydroelastic contact visualization lcm message.

This fixes *two* bugs in hydroelastic visualization contact:

1. Information provided in LCM was insufficient to distinguish contact between two identically named bodies which belong to different model instances.
    - Solution:
      - Extend the lcm message to include model instance names.
      - `ContactResultsToLcmSystem` populates model instance names the new fields.
2. Multiple independent contacts between the *same* bodies aren't handled correctly.
   - Solution:
      - Also provide a "name" for the *geometry*.
      - Legacy constructor for ContactResultToLcmSystem takes only a MBP instance. As such, it can't resolve collision geometry *names*.
          - Constructed with the old API, we use stringified geometry ids.
     - The `ConnectContactResultsToDrakeVisualizer` methods have been overloaded to also accept a SceneGraph instance. When given, the geometry names will be acquired from that instance.
      - Add bindings for new API.

This does *not* include changes to the visualizer itself. The data produced here is a strict superset of the old data. The visualizer will be updated in a follow-up PR.

To see the *full* impact of this PR when taken with the subsequent changes to the visualization, take a look at [this branch](https://github.com/SeanCurtis-TRI/drake/tree/PR_body_pair_multiple_hydro_contacts)

relates #15555

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15642)
<!-- Reviewable:end -->
