### PR TITLE
[geometry] Establish Meshcat in C++ (step 3)

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -343,6 +343,17 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "meshcat_types",
+    hdrs = ["meshcat_types.h"],
+    install_hdrs_exclude = ["meshcat_types.h"],
+    tags = [
+        "exclude_from_libdrake",
+        "exclude_from_package",
+    ],
+    deps = ["@msgpack"],
+)
+
+drake_cc_library(
     name = "meshcat",
     srcs = ["meshcat.cc"],
     hdrs = ["meshcat.h"],
@@ -352,10 +363,15 @@ drake_cc_library(
         "@meshcat//:dist/main.min.js",
     ],
     deps = [
+        ":meshcat_types",
+        ":rgba",
+        ":shape_specification",
         "//common:essential",
         "//common:find_resource",
         "//common:unused",
+        "//math:geometric_transform",
         "@msgpack",
+        "@stduuid",
         "@uwebsockets",
     ],
 )
@@ -364,6 +380,7 @@ drake_cc_binary(
     name = "meshcat_manual_test",
     testonly = True,
     srcs = ["test/meshcat_manual_test.cc"],
+    data = ["//systems/sensors:test_models"],
     visibility = ["//visibility:private"],
     deps = [":meshcat"],
 )
@@ -377,11 +394,17 @@ drake_py_binary(
 
 drake_cc_googletest(
     name = "meshcat_test",
-    data = [":meshcat_websocket_client"],
+    data = [
+        ":meshcat_websocket_client",
+        "//systems/sensors:test_models",
+    ],
     # Disable valgrind because it currently fails on the system call to python.
     # TODO(russt): Make it possible to pass --trace-children=no to valgrind.sh.
     tags = ["no_memcheck"],
-    deps = [":meshcat"],
+    deps = [
+        ":meshcat",
+        "//common/test_utilities:eigen_matrix_compare",
+    ],
 )
 
 # -----------------------------------------------------

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -3,6 +3,7 @@
 #include <fstream>
 #include <future>
 #include <map>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <thread>
@@ -12,11 +13,13 @@
 #include <App.h>
 #include <fmt/format.h>
 #include <msgpack.hpp>
+#include <uuid.h>
 
 #include "drake/common/find_resource.h"
 #include "drake/common/never_destroyed.h"
 #include "drake/common/text_logging.h"
 #include "drake/common/unused.h"
+#include "drake/geometry/meshcat_types.h"
 
 namespace {
 std::string LoadResource(const std::string& resource_name) {
@@ -35,6 +38,7 @@ const std::string& GetUrlContent(std::string_view url_path) {
       LoadResource("drake/external/meshcat/dist/main.min.js"));
   static const drake::never_destroyed<std::string> favicon_ico(
       LoadResource("drake/doc/favicon.ico"));
+  // TODO(russt): Set the different default background color for Drake.
   static const drake::never_destroyed<std::string> index_html(
       LoadResource("drake/external/meshcat/dist/index.html"));
   if (url_path == "/main.min.js") {
@@ -53,12 +57,266 @@ namespace geometry {
 
 namespace {
 
+using math::RigidTransformd;
+using math::RotationMatrixd;
+
 constexpr static bool kSsl = false;
 constexpr static bool kIsServer = true;
 struct PerSocketData {
   // Intentionally left empty.
 };
 using WebSocket = uWS::WebSocket<kSsl, kIsServer, PerSocketData>;
+using MsgPackMap = std::map<std::string, msgpack::object>;
+
+class SceneTreeElement {
+ public:
+  // Member access methods (object_, transform_, and properties_ should be
+  // effectively public).
+  const std::optional<std::string>& object() const { return object_; }
+  std::optional<std::string>& object() { return object_; }
+  const std::optional<std::string>& transform() const { return transform_; }
+  std::optional<std::string>& transform() { return transform_; }
+  const std::map<std::string, std::string>& properties() const {
+    return properties_;
+  }
+  std::map<std::string, std::string>& properties() { return properties_; }
+
+  // Returns this element or a descendant, based on a recursive evaluation of
+  // the `path`.  Adds new elements if they do not exist.  Comparable to
+  // std::map::operator[].
+  SceneTreeElement& operator[](std::string_view path) {
+    while (!path.empty() && path.front() == '/') {
+      path.remove_prefix(1);
+    }
+    if (path.empty()) {
+      return *this;
+    }
+    auto loc = path.find_first_of("/");
+    std::string name(path.substr(0, loc));
+    auto child = children_.find(name);
+    // Create the child if it doesn't exist.
+    if (child == children_.end()) {
+      child =
+          children_.emplace(name, std::make_unique<SceneTreeElement>()).first;
+    }
+    if (loc == std::string_view::npos) {
+      return *child->second;
+    } else {
+      return (*child->second)[path.substr(loc + 1)];
+    }
+  }
+
+  // Returns a pointer to `this` element or a descendant, based on a recursive
+  // evaluation of the `path`, or nullptr if `path` does not exist.
+  const SceneTreeElement* Find(std::string_view path) const {
+    while (!path.empty() && path.front() == '/') {
+      path.remove_prefix(1);
+    }
+    if (path.empty()) {
+      return this;
+    }
+    auto loc = path.find_first_of("/");
+    std::string name(path.substr(0, loc));
+    auto child = children_.find(name);
+    if (child == children_.end()) {
+      return nullptr;
+    }
+    if (loc == std::string_view::npos) {
+      return child->second.get();
+    } else {
+      return child->second->Find(path.substr(loc + 1));
+    }
+  }
+
+  // Deletes `path` from the tree.  See Meshcat::Delete.
+  void Delete(std::string_view path) {
+    while (!path.empty() && path.front() == '/') {
+      path.remove_prefix(1);
+    }
+    if (path.empty()) {
+      // To match javascript, we don't delete the empty path.
+      return;
+    }
+
+    auto loc = path.find_first_of("/");
+    auto child = children_.find(std::string(path.substr(0, loc)));
+    if (child == children_.end()) {
+      return;
+    }
+    if (loc == std::string_view::npos) {
+      children_.erase(child);
+      return;
+    }
+    child->second->Delete(path.substr(loc + 1));
+  }
+
+  // Sends the entire tree on `ws`.
+  void Send(WebSocket* ws) {
+    if (object_) {
+      ws->send(*object_);
+    }
+    if (transform_) {
+      ws->send(*transform_);
+    }
+    for (const auto& [property, msg] : properties_) {
+      unused(property);
+      ws->send(msg);
+    }
+
+    for (const auto& [name, child] : children_) {
+      unused(name);
+      child->Send(ws);
+    }
+  }
+
+ private:
+  // Note: We use std::optional here to clearly denote the variables that have
+  // not been set, and therefore need not be sent over the websocket.
+
+  // The msgpack'd set_object command.
+  std::optional<std::string> object_{std::nullopt};
+  // The msgpack'd set_transform command.
+  std::optional<std::string> transform_{std::nullopt};
+  // The msgpack'd set_property command(s).
+  std::map<std::string, std::string> properties_{};
+  // Children, with the key value denoting their (relative) path name.
+  std::map<std::string, std::unique_ptr<SceneTreeElement>> children_{};
+};
+
+class MeshcatShapeReifier : public ShapeReifier {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MeshcatShapeReifier);
+
+  explicit MeshcatShapeReifier(std::string uuid) : uuid_(std::move(uuid)) {}
+
+  ~MeshcatShapeReifier() = default;
+
+  const std::string& uuid() const { return uuid_; }
+
+  using ShapeReifier::ImplementGeometry;
+
+  void ImplementGeometry(const Sphere& sphere, void* data) override {
+    DRAKE_ASSERT(data != nullptr);
+    auto& lumped = *static_cast<internal::LumpedObjectData*>(data);
+    internal::GeometryData& geometry = lumped.geometries[0];
+
+    geometry.uuid = uuid_;
+    geometry.type = "SphereGeometry";
+    geometry.radius = sphere.radius();
+    geometry.widthSegments = 20;
+    geometry.heightSegments = 20;
+  }
+
+  void ImplementGeometry(const Cylinder& cylinder, void* data) override {
+    DRAKE_ASSERT(data != nullptr);
+    auto& lumped = *static_cast<internal::LumpedObjectData*>(data);
+    internal::GeometryData& geometry = lumped.geometries[0];
+
+    geometry.uuid = uuid_;
+    geometry.type = "CylinderGeometry";
+    geometry.radiusBottom = cylinder.radius();
+    geometry.radiusTop = cylinder.radius();
+    geometry.height = cylinder.length();
+    geometry.radialSegments = 50;
+
+    Eigen::Map<Eigen::Matrix4d>(lumped.object.matrix) =
+        RigidTransformd(RotationMatrixd::MakeXRotation(M_PI / 2.0))
+            .GetAsMatrix4();
+  }
+
+  void ImplementGeometry(const HalfSpace&, void*) override {
+    drake::log()->warn("Meshcat does not display HalfSpace geometry (yet).");
+  }
+
+  void ImplementGeometry(const Box& box, void* data) override {
+    DRAKE_ASSERT(data != nullptr);
+    auto& lumped = *static_cast<internal::LumpedObjectData*>(data);
+    internal::GeometryData& geometry = lumped.geometries[0];
+
+    geometry.uuid = uuid_;
+    geometry.type = "BoxGeometry";
+    geometry.width = box.width();
+    // Three.js uses height for the y axis; Drake uses depth.
+    geometry.height = box.depth();
+    geometry.depth = box.height();
+  }
+
+  void ImplementGeometry(const Capsule&, void*) override {
+    drake::log()->warn("Meshcat does not display Capsule geometry (yet).");
+  }
+
+  void ImplementGeometry(const Ellipsoid& ellipsoid, void* data) override {
+    // Implemented as a Sphere stretched by a diagonal transform.
+    DRAKE_ASSERT(data != nullptr);
+    auto& lumped = *static_cast<internal::LumpedObjectData*>(data);
+    internal::GeometryData& geometry = lumped.geometries[0];
+
+    geometry.uuid = uuid_;
+    geometry.type = "SphereGeometry";
+    geometry.radius = 1;
+    geometry.widthSegments = 20;
+    geometry.heightSegments = 20;
+
+    Eigen::Map<Eigen::Matrix4d> matrix(lumped.object.matrix);
+    matrix(0, 0) = ellipsoid.a();
+    matrix(1, 1) = ellipsoid.b();
+    matrix(2, 2) = ellipsoid.c();
+  }
+
+  template <typename T>
+  void ImplementMesh(const T& mesh, void* data) {
+    DRAKE_ASSERT(data != nullptr);
+    auto& lumped = *static_cast<internal::LumpedObjectData*>(data);
+    internal::GeometryData& geometry = lumped.geometries[0];
+
+    // TODO(russt): Use file contents to generate the uuid, and avoid resending
+    // meshes unless necessary.  Using the filename is tempting, but that leads
+    // to problems when the file contents change on disk.
+
+    size_t pos = mesh.filename().find_last_of('.');
+    if (pos == std::string::npos) {
+      drake::log()->warn("Meshcat: Unsupported extension for mesh filename {}",
+                         mesh.filename());
+      return;
+    }
+    geometry.uuid = uuid_;
+    geometry.format = mesh.filename().substr(pos + 1);
+
+    std::ifstream input(mesh.filename(), std::ios::binary | std::ios::ate);
+    if (!input.is_open()) {
+      drake::log()->warn("Meshcat: Could not open mesh filename {}",
+                         mesh.filename());
+      return;
+    }
+
+    // We simply dump the binary contents of the file into the data field of the
+    // message.  The javascript meshcat takes care of the rest.
+    int size = input.tellg();
+    input.seekg(0, std::ios::beg);
+    geometry.data.resize(size);
+    input.read(geometry.data.data(), size);
+
+    // TODO(russt): Implement textures.  Need to add LumpedData.textures,
+    // LumpedData.images, etc.
+    geometry.type = "_meshfile_geometry";
+
+    Eigen::Map<Eigen::Matrix4d> matrix(lumped.object.matrix);
+    matrix(0, 0) = mesh.scale();
+    matrix(1, 1) = mesh.scale();
+    matrix(2, 2) = mesh.scale();
+  }
+
+  void ImplementGeometry(const Mesh& mesh, void* data) override {
+    ImplementMesh(mesh, data);
+  }
+
+  void ImplementGeometry(const Convex& mesh, void* data) override {
+    ImplementMesh(mesh, data);
+  }
+
+ private:
+  std::string uuid_;
+};
 
 }  // namespace
 
@@ -66,11 +324,12 @@ class Meshcat::WebSocketPublisher {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(WebSocketPublisher);
 
-  WebSocketPublisher() : main_thread_id_(std::this_thread::get_id()) {
+  WebSocketPublisher()
+      : prefix_("/drake"), main_thread_id_(std::this_thread::get_id()) {
     std::promise<std::tuple<uWS::App*, uWS::Loop*, int, us_listen_socket_t*>>
-          app_promise;
+        app_promise;
     std::future<std::tuple<uWS::App*, uWS::Loop*, int, us_listen_socket_t*>>
-          app_future = app_promise.get_future();
+        app_future = app_promise.get_future();
     websocket_thread_ = std::thread(&WebSocketPublisher::WebSocketMain, this,
                                     std::move(app_promise));
     std::tie(app_, loop_, port_, listen_socket_) = app_future.get();
@@ -78,9 +337,8 @@ class Meshcat::WebSocketPublisher {
 
   ~WebSocketPublisher() {
     DRAKE_DEMAND(std::this_thread::get_id() == main_thread_id_);
-    loop_->defer([socket = listen_socket_]() {
-      us_listen_socket_close(0, socket);
-    });
+    loop_->defer(
+        [socket = listen_socket_]() { us_listen_socket_close(0, socket); });
     websocket_thread_.join();
   }
 
@@ -89,28 +347,195 @@ class Meshcat::WebSocketPublisher {
     return port_;
   }
 
+  void SetObject(std::string_view path, const Shape& shape,
+                        const Rgba& rgba) {
+    DRAKE_DEMAND(std::this_thread::get_id() == main_thread_id_);
+    DRAKE_DEMAND(app_ != nullptr);
+    DRAKE_DEMAND(loop_ != nullptr);
+
+    uuids::uuid_random_generator uuid_generator{generator_};
+    internal::SetObjectData data;
+    data.path = FullPath(path);
+
+    // TODO(russt): This current meshcat set_object interface couples geometry,
+    // material, and object for convenience, but we might consider decoupling
+    // them again for efficiency. We don't want to send meshes over the network
+    // (which could be from the cloud to a local browser) more than necessary.
+
+    internal::MaterialData& material = data.object.materials[0];
+    material.uuid = uuids::to_string(uuid_generator());
+    material.type = "MeshPhongMaterial";
+    material.color = (static_cast<int>(255 * rgba.r()) << 16) +
+                     (static_cast<int>(255 * rgba.g()) << 8) +
+                     static_cast<int>(255 * rgba.b());
+    // From meshcat-python: Three.js allows a material to have an opacity
+    // which is != 1, but to still be non - transparent, in which case the
+    // opacity only serves to desaturate the material's color. That's a
+    // pretty odd combination of things to want, so by default we just use
+    // the opacity value to decide whether to set transparent to True or
+    // False.
+    material.transparent = (rgba.a() != 1.0);
+    material.opacity = rgba.a();
+
+    internal::Object3dData& object3d = data.object.object;
+    object3d.uuid = uuids::to_string(uuid_generator());
+    object3d.type = "Mesh";
+    object3d.material = material.uuid;
+
+    MeshcatShapeReifier reifier(uuids::to_string(uuid_generator()));
+    shape.Reify(&reifier, &data.object);
+    if (data.object.geometries[0].type.empty()) {
+      // Then this shape is not supported, and I should not send the message,
+      // nor add the object to the tree.
+      return;
+    }
+    object3d.geometry = reifier.uuid();
+
+    // Note: pass all temporaries by value.
+    loop_->defer([this, data = std::move(data)]() {
+      std::stringstream message_stream;
+      msgpack::pack(message_stream, data);
+      std::string message = message_stream.str();
+      app_->publish("all", message, uWS::OpCode::BINARY, false);
+      SceneTreeElement& e = scene_tree_root_[data.path];
+      e.object() = std::move(message);
+    });
+  }
+
+  void SetTransform(std::string_view path,
+                    const RigidTransformd& X_ParentPath) {
+    DRAKE_DEMAND(std::this_thread::get_id() == main_thread_id_);
+    DRAKE_DEMAND(app_ != nullptr);
+    DRAKE_DEMAND(loop_ != nullptr);
+
+    internal::SetTransformData data;
+    data.path = FullPath(path);
+    Eigen::Map<Eigen::Matrix4d>(data.matrix) = X_ParentPath.GetAsMatrix4();
+
+    // Note: pass all temporaries by value.
+    loop_->defer([this, data = std::move(data)]() {
+      std::stringstream message_stream;
+      msgpack::pack(message_stream, data);
+      std::string message = message_stream.str();
+      app_->publish("all", message, uWS::OpCode::BINARY, false);
+      SceneTreeElement& e = scene_tree_root_[data.path];
+      e.transform() = std::move(message);
+    });
+  }
+
+  void Delete(std::string_view path) {
+    DRAKE_DEMAND(std::this_thread::get_id() == main_thread_id_);
+    DRAKE_DEMAND(app_ != nullptr);
+    DRAKE_DEMAND(loop_ != nullptr);
+
+    internal::DeleteData data;
+    data.path = FullPath(path);
+
+    // Note: pass all temporaries by value.
+    loop_->defer([this, data = std::move(data)]() {
+      std::stringstream message_stream;
+      msgpack::pack(message_stream, data);
+      std::string message = message_stream.str();
+      app_->publish("all", message, uWS::OpCode::BINARY, false);
+      scene_tree_root_.Delete(data.path);
+    });
+  }
+
   template <typename T>
-  void SetProperty(std::string_view path, std::string_view property,
+  void SetProperty(std::string_view path, std::string property,
                    const T& value) {
     DRAKE_DEMAND(std::this_thread::get_id() == main_thread_id_);
     DRAKE_DEMAND(app_ != nullptr);
     DRAKE_DEMAND(loop_ != nullptr);
 
-    std::stringstream message;
+    internal::SetPropertyData<T> data;
+    data.path = FullPath(path);
+    data.property = std::move(property);
+    data.value = value;
 
-    msgpack::zone z;
-    msgpack::pack(message, std::map<std::string, msgpack::object>(
-                               {{"type", msgpack::object("set_property", z)},
-                                {"path", msgpack::object(path, z)},
-                                {"property", msgpack::object(property, z)},
-                                {"value", msgpack::object(value, z)}}));
-
-    // Note: Must pass path and property by value because they will go out of
-    // scope.
-    loop_->defer([this, app = app_, path, property, msg = message.str()]() {
-      app->publish("all", msg, uWS::OpCode::BINARY, false);
-      set_properties_[fmt::format("{}/{}", path, property)] = msg;
+    // Note: pass all temporaries by value.
+    loop_->defer([this, data = std::move(data)]() {
+      std::stringstream message_stream;
+      msgpack::pack(message_stream, data);
+      std::string message = message_stream.str();
+      app_->publish("all", message, uWS::OpCode::BINARY, false);
+      SceneTreeElement& e = scene_tree_root_[data.path];
+      e.properties()[data.property] = std::move(message);
     });
+  }
+
+  bool HasPath(std::string_view path) const {
+    DRAKE_DEMAND(std::this_thread::get_id() == main_thread_id_);
+    DRAKE_DEMAND(loop_ != nullptr);
+
+    std::promise<bool> p;
+    std::future<bool> f = p.get_future();
+    // Note: pass all temporaries by value.
+    loop_->defer([this, path = FullPath(path), p = std::move(p)]() mutable {
+      p.set_value(scene_tree_root_.Find(path) != nullptr);
+    });
+    return f.get();
+  }
+
+  std::string GetPackedObject(std::string_view path) const {
+    DRAKE_DEMAND(std::this_thread::get_id() == main_thread_id_);
+    DRAKE_DEMAND(loop_ != nullptr);
+
+    std::promise<std::string> p;
+    std::future<std::string> f = p.get_future();
+    // Note: pass all temporaries by value.
+    loop_->defer([this, path = FullPath(path), p = std::move(p)]() mutable {
+      const SceneTreeElement* e = scene_tree_root_.Find(path);
+      if (!e || !e->object()) {
+        p.set_value("");
+      } else {
+        p.set_value(*e->object());
+      }
+    });
+    return f.get();
+  }
+
+  std::string GetPackedTransform(std::string_view path) const {
+    DRAKE_DEMAND(std::this_thread::get_id() == main_thread_id_);
+    DRAKE_DEMAND(loop_ != nullptr);
+
+    std::promise<std::string> p;
+    std::future<std::string> f = p.get_future();
+    // Note: pass all temporaries by value.
+    loop_->defer([this, path = FullPath(path), p = std::move(p)]() mutable {
+      const SceneTreeElement* e = scene_tree_root_.Find(path);
+      if (!e || !e->transform()) {
+        p.set_value("");
+      } else {
+        p.set_value(*e->transform());
+      }
+    });
+    return f.get();
+  }
+
+  std::string GetPackedProperty(std::string_view path,
+                                std::string property) const {
+    DRAKE_DEMAND(std::this_thread::get_id() == main_thread_id_);
+    DRAKE_DEMAND(loop_ != nullptr);
+
+    std::promise<std::string> p;
+    std::future<std::string> f = p.get_future();
+    // Note: pass all temporaries by value.
+    loop_->defer([this, path = FullPath(path), property = std::move(property),
+                  p = std::move(p)]() mutable {
+      const SceneTreeElement* e = scene_tree_root_.Find(path);
+      if (!e) {
+        p.set_value("");
+      } else {
+        auto prop = e->properties().find(property);
+        if (prop == e->properties().end()) {
+          p.set_value("");
+        } else {
+          p.set_value(prop->second);
+        }
+      }
+    });
+    return f.get();
   }
 
  private:
@@ -163,22 +588,34 @@ class Meshcat::WebSocketPublisher {
 
   void SendTree(WebSocket* ws) {
     DRAKE_DEMAND(std::this_thread::get_id() == websocket_thread_id_);
-    // TODO(russt): Generalize this to publishing the entire scene tree.
-    for (const auto& [key, msg] : set_properties_) {
-      unused(key);
-      ws->send(msg);
+    scene_tree_root_.Send(ws);
+  }
+
+  std::string FullPath(std::string_view path) const {
+    while (path.size() > 1 && path.back() == '/') {
+      path.remove_suffix(1);
     }
+    if (path.empty()) {
+      return prefix_;
+    }
+    if (path.front() == '/') {
+      return std::string(path);
+    }
+    return fmt::format("{}/{}", prefix_, path);
   }
 
   std::thread websocket_thread_{};
+  const std::string prefix_{};
 
-  // These variables should only be accessed in the main thread.
+  // These variables should only be accessed in the main thread, where "main
+  // thread" is the thread in which this class was constructed.
   std::thread::id main_thread_id_{};
   int port_{};
+  std::mt19937 generator_{};
 
   // These variables should only be accessed in the websocket thread.
   std::thread::id websocket_thread_id_{};
-  std::map<std::string, std::string> set_properties_{};
+  SceneTreeElement scene_tree_root_{};
 
   // These pointers should only be accessed in the main thread, but the objects
   // they are pointing to should be only used in the websocket thread.
@@ -210,9 +647,43 @@ std::string Meshcat::ws_url() const {
   return fmt::format("ws://localhost:{}", publisher_->port());
 }
 
-void Meshcat::SetProperty(std::string_view path, std::string_view property,
+void Meshcat::SetObject(std::string_view path, const Shape& shape,
+                        const Rgba& rgba) {
+  publisher_->SetObject(path, shape, rgba);
+}
+
+void Meshcat::SetTransform(std::string_view path,
+                           const RigidTransformd& X_ParentPath) {
+  publisher_->SetTransform(path, X_ParentPath);
+}
+
+void Meshcat::Delete(std::string_view path) { publisher_->Delete(path); }
+
+void Meshcat::SetProperty(std::string_view path, std::string property,
                           bool value) {
-  publisher_->SetProperty(path, property, value);
+  publisher_->SetProperty(path, std::move(property), value);
+}
+
+void Meshcat::SetProperty(std::string_view path, std::string property,
+                          double value) {
+  publisher_->SetProperty(path, std::move(property), value);
+}
+
+bool Meshcat::HasPath(std::string_view path) const {
+  return publisher_->HasPath(path);
+}
+
+std::string Meshcat::GetPackedObject(std::string_view path) const {
+  return publisher_->GetPackedObject(path);
+}
+
+std::string Meshcat::GetPackedTransform(std::string_view path) const {
+  return publisher_->GetPackedTransform(path);
+}
+
+std::string Meshcat::GetPackedProperty(std::string_view path,
+                                       std::string property) const {
+  return publisher_->GetPackedProperty(path, std::move(property));
 }
 
 }  // namespace geometry

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -4,21 +4,76 @@
 #include <string>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/geometry/rgba.h"
+#include "drake/geometry/shape_specification.h"
+#include "drake/math/rigid_transform.h"
 
 namespace drake {
 namespace geometry {
 
-/** Provides an interface to https://github.com/rdeits/meshcat.
+/** Provides an interface to %Meshcat (https://github.com/rdeits/meshcat).
 
 Each instance of this class spawns a thread which runs an http/websocket server.
 Users can navigate their browser to the hosted URL to visualize the Meshcat
 scene.  Note that, unlike many visualizers, one cannot open the visualizer until
 this server is running.
 
-Note: This code is currently a skeleton implementation; it only allows you to
-set (boolean) properties as a minimal demonstration of sending data from C++ to
-the viewer.  It is the result of the second PR in a train of PRs that will
-establish the full Meshcat functionality. See #13038.
+In the current implementation, Meshcat methods must be called from the same
+thread where the class instance was constructed.  For example, running multiple
+simulations in parallel using the same Meshcat instance is not yet supported. We
+may generalize this in the future.
+
+@section meshcat_path Meshcat paths and the scene tree
+
+https://github.com/rdeits/meshcat#api provides a nice introduction to the
+websocket API that we wrap with this class.  One of the core concepts is the
+"scene tree" -- a directory-like structure of objects, transforms, and
+properties. The scene tree is viewable in the browser by clicking on "Open
+Controls" in the top right corner.
+
+Elements of the tree are referenced programmatically by a "/"-delimited string
+indicating the object's **path** in the scene tree. An object at path "/foo/bar"
+is a child of an object at path "/foo", so setting the transform of (or
+deleting) "/foo" will also affect its children.
+
+The string path arguments to the methods in this class use the following
+semantics:
+- A path that begins with "/" is treated as an absolute path, and is used
+without modification.
+- A path that *does not* begin with "/" is treated as a relative path to the
+default working directory.
+- The "working directory" is fixed to be "/drake" in the current implementation.
+So any relative path "foo" will be treated as "/drake/foo".
+- Delete("/foo") will remove all objects, transforms, and properties in "/foo"
+and its children from the scene tree.
+- Delete() is equivalent to Delete("") or Delete("/drake/").
+- SetObject("/foo", ...) places the object at "/foo/<object>", where "<object>"
+is a hard-coded suffix used for all objects.  You can use the
+Delete("/foo/<object>") to delete the object only (and not the children of
+"/foo") and must use SetProperty("/foo/<object>", ...) to change object-specific
+properties.
+
+The root directory contains a number of elements that are set up automatically
+in the browser.  These include "/Background", "/Lights", "/Grid", and
+"/Cameras".  To find more details please see the @link
+https://github.com/rdeits/meshcat#api meshcat documentation @endlink and the
+@link https://threejs.org/docs/index.html three.js documentation @endlink.
+- You can modify these elements, create new lights/cameras, and even delete
+these elements (one at a time).
+- Delete("/") is not allowed.  It will be silently ignored.
+
+@section meshcat_recommended_workflow Recommended workflow
+
+For convenience, Meshcat fosters a work flow in which all user-created objects
+created in Drake are contained in the "/drake" folder. Objects added with a
+relative path are placed in the "/drake" folder for you. The benefits are:
+- It's simple to distinguish between user objects and "infrastructure" objects
+in the visualizer.
+- All user objects can easily be cleared by a single, parameter-free call to
+Delete(). You are welcome to use absolute paths to organize your data, but the
+burden on tracking and cleaning them up lie on you.
+
+
 */
 class Meshcat {
  public:
@@ -37,13 +92,94 @@ class Meshcat {
   interface.  Most users should connect via a browser opened to web_url(). */
   std::string ws_url() const;
 
-  /** Forwards a set_property(...) message to the meshcat viewers. For example,
+  /** Sets the 3D object at a given `path` in the scene tree.  Note that
+  `path`="/foo" will always set an object in the tree at "/foo/<object>".  See
+  @ref meshcat_path.  Any objects previously set at this `path` will be
+  replaced.
+  @param path a "/"-delimited string indicating the path in the scene tree.
+              See @ref meshcat_path for the semantics.
+  @param shape a Shape that specifies the geometry of the object.
+  @param rgba an Rgba that specifies the (solid) color of the object.
+  */
+  void SetObject(std::string_view path, const Shape& shape,
+                 const Rgba& rgba = Rgba(.9, .9, .9, 1.));
+
+  // TODO(russt): SetObject with texture map.
+
+  /** Set the RigidTransform for a given path in the scene tree. An object's
+  pose is the concatenation of all of the transforms along its path, so setting
+  the transform of "/foo" will move the objects at "/foo/box1" and
+  "/foo/robots/HAL9000".
+  @param path a "/"-delimited string indicating the path in the scene tree.
+              See @ref meshcat_path for the semantics.
+  @param X_ParentPath the relative transform from the path to its immediate
+  parent.
+  */
+  void SetTransform(std::string_view path,
+                    const math::RigidTransformd& X_ParentPath);
+
+  /** Deletes the object at the given `path` as well as all of its children.
+  See @ref meshcat_path for the detailed semantics of deletion. */
+  void Delete(std::string_view path = "");
+
+  /** Sets a single named property of the object at the given path. For example,
   @verbatim
   meshcat.SetProperty("/Background", "visible", false);
   @endverbatim
-  will turn off the background. */
-  void SetProperty(std::string_view path, std::string_view property,
-                   bool value);
+  will turn off the background. See @ref meshcat_path for more details about
+  these properties and how to address them.
+
+  @param path a "/"-delimited string indicating the path in the scene tree.
+              See @ref meshcat_path for the semantics.
+  @param property the string name of the property to set
+  @param value the new value.
+  */
+  void SetProperty(std::string_view path, std::string property, bool value);
+
+  /** Sets a single named property of the object at the given path. For example,
+  @verbatim
+  meshcat.SetProperty("/Cameras/default/rotated/<object>", "zoom", 2.0);
+  meshcat.SetProperty("/Lights/DirectionalLight/<object>", "intensity", 1.0);
+  @endverbatim
+  See @ref meshcat_path for more details about these properties and how to
+  address them.
+
+  @param path a "/"-delimited string indicating the path in the scene tree.
+              See @ref meshcat_path for the semantics.
+  @param property the string name of the property to set
+  @param value the new value.
+  */
+  void SetProperty(std::string_view path, std::string property, double value);
+
+  // TODO(russt): Implement SetAnimation().
+  // TODO(russt): Implement SetButton() and SetSlider() as wrappers on
+  // set_control.
+
+  /* These remaining public methods are intended to primarily for testing. These
+  calls must safely acquire the data from the websocket thread and will block
+  execution waiting for that data to be acquired. They are intentionally
+  excluded from doxygen. */
+
+  /* Returns true iff `path` exists in the current internal (server) tree.
+  Note that the javascript client maintains its own tree, which may contain
+  elements that are not in the server tree. */
+  bool HasPath(std::string_view path) const;
+
+  /* Returns the msgpack representation of the object stored in the internal
+  (server) tree at `path`, or the empty string if `path` does not exist or no
+  object has been set at `path`. */
+  std::string GetPackedObject(std::string_view path) const;
+
+  /* Returns the msgpack representation of the transform stored in the internal
+  (server) tree at `path`, or the empty string if `path` does not exist or no
+  transform has been set at `path`. */
+  std::string GetPackedTransform(std::string_view path) const;
+
+  /* Returns the msgpack representation of the `property` stored in the
+  internal (server) tree at `path`, or the empty string if `path` does not
+  exist or `property` has not been set at `path`. */
+  std::string GetPackedProperty(std::string_view path,
+                                std::string property) const;
 
  private:
   // Provides PIMPL encapsulation of websocket types.

--- a/geometry/meshcat_types.h
+++ b/geometry/meshcat_types.h
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <msgpack.hpp>
+
+#include "drake/geometry/rgba.h"
+#include "drake/math/rigid_transform.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+// Note: These types lack many of the standard const qualifiers in order to be
+// compatible with msgpack, which wants to be able to unpack into the same
+// structure.
+
+// TODO(russt): Can we teach msgpack for std::optional to only add the key if
+// has_value() == true?  This would only be for efficiency, but it would allow
+// us to support more options without any cost.
+
+// TODO(russt): These are taken verbatim from meshcat-python.  We should
+// expose them to the user, but not until we can properly document them.
+// Many are documented here: https://threejs.org/docs/#api/en/materials/Material
+struct MaterialData {
+  std::string uuid{};
+  std::string type{};
+  int color{(229 << 16) + (229 << 8) + 229};
+  // TODO(russt): Make many of these std::optional.
+  double reflectivity{0.5};
+  int side{2};
+  bool transparent{false};
+  double opacity{1.0};
+  double linewidth{1.0};
+  bool wireframe{false};
+  double wireframeLineWidth{1.0};
+  bool vertexColors{false};
+  MSGPACK_DEFINE_MAP(uuid, type, color, reflectivity, side, transparent,
+                     opacity, linewidth, wireframe, wireframeLineWidth,
+                     vertexColors);
+};
+
+// Note: This contains the fields required for all geometry types.  Getting
+// msgpack to work with runtime derived types proved to be very complicated.
+struct GeometryData {
+  std::string uuid;
+  std::string type;
+  std::optional<double> width;
+  std::optional<double> height;
+  std::optional<double> depth;
+  std::optional<double> radius;
+  std::optional<double> widthSegments;
+  std::optional<double> heightSegments;
+  std::optional<double> radiusTop;
+  std::optional<double> radiusBottom;
+  std::optional<double> radialSegments;
+  std::optional<std::string> format;
+  std::vector<char> data;
+  MSGPACK_DEFINE_MAP(uuid, type, width, height, depth, radius, widthSegments,
+                     heightSegments, radiusTop, radiusBottom, radialSegments,
+                     format, data);
+};
+
+struct ObjectMetaData {
+  std::string type{"Object"};
+  double version{4.5};
+  MSGPACK_DEFINE_MAP(type, version);
+};
+
+struct Object3dData {
+  std::string uuid;
+  std::string type;
+  std::string geometry;
+  std::string material;
+  double matrix[16] = {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
+  MSGPACK_DEFINE_MAP(uuid, type, geometry, material, matrix);
+};
+
+struct LumpedObjectData {
+  ObjectMetaData metadata{};
+  GeometryData geometries[1];
+  MaterialData materials[1];
+  Object3dData object;
+  MSGPACK_DEFINE_MAP(metadata, geometries, materials, object);
+};
+
+struct SetObjectData {
+  std::string type{"set_object"};
+  std::string path;
+  LumpedObjectData object;
+  MSGPACK_DEFINE_MAP(type, path, object);
+};
+
+struct SetTransformData {
+  std::string type{"set_transform"};
+  std::string path;
+  double matrix[16];
+  MSGPACK_DEFINE_MAP(type, path, matrix);
+};
+
+struct DeleteData {
+  std::string type{"delete"};
+  std::string path;
+  MSGPACK_DEFINE_MAP(type, path);
+};
+
+template <typename T>
+struct SetPropertyData {
+  std::string type{"set_property"};
+  std::string path;
+  std::string property;
+  T value;
+  MSGPACK_DEFINE_MAP(type, path, property, value);
+};
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -355,7 +355,7 @@ class Convex final : public Shape {
    }
    ...
    void ImplementGeometry(const Sphere& sphere, void* data) override {
-     DRAKE_ASSERT(data);
+     DRAKE_ASSERT(data != nullptr);
      ImportantData& data = *static_cast<ImportantData*>(data);
      // Do work to create a sphere using the provided user data.
    }

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -1,29 +1,76 @@
-#include <future>
-
+#include "drake/common/find_resource.h"
 #include "drake/geometry/meshcat.h"
+#include "drake/geometry/rgba.h"
+#include "drake/geometry/shape_specification.h"
+#include "drake/math/rigid_transform.h"
 
-/**  To test, you must manually run `bazel run //geometry:meshcat_manual_test`.
-It will print two URLs to console.  Navigating your browser to the first, you
-should see that the normally blue meshcat background is not visible (the
-background will look white).  In the second URL, you should see the default
-meshcat view, but the grid that normally shows the ground plane is not visible.
-*/
+/**  To test, you must manually run `bazel run //geometry:meshcat_manual_test`,
+then follow the instructions on your console. */
 
-int main() {
-  drake::geometry::Meshcat meshcat;
+namespace drake {
+namespace geometry {
 
-  // Note: this will only send one message to any new server.
+using Eigen::Vector3d;
+using math::RigidTransformd;
+
+int do_main() {
+  Meshcat meshcat;
+
+  // Turn off the background (it will appear white).
   meshcat.SetProperty("/Background", "visible", false);
-  meshcat.SetProperty("/Background", "visible", true);
-  meshcat.SetProperty("/Background", "visible", false);
 
-  // Demonstrate that we can construct multiple meshcats (and they will serve on
-  // different ports).
-  drake::geometry::Meshcat meshcat2;
-  meshcat2.SetProperty("/Grid", "visible", false);
+  meshcat.SetObject("sphere", Sphere(.25), Rgba(1.0, 0, 0, 1));
+  meshcat.SetTransform("sphere", RigidTransformd(Vector3d{-2.0, 0, 0}));
 
-  // Sleep forever (we require the user to SIGINT to end the program).
-  std::promise<void>().get_future().wait();
+  meshcat.SetObject("cylinder", Cylinder(.25, .5), Rgba(0.0, 1.0, 0, 1));
+  meshcat.SetTransform("cylinder", RigidTransformd(Vector3d{-1.0, 0, 0}));
+
+  meshcat.SetObject("ellipsoid", Ellipsoid(.25, .25, .5), Rgba(1., 0, 1, .5));
+  meshcat.SetTransform("ellipsoid", RigidTransformd(Vector3d{0.0, 0, 0}));
+
+  meshcat.SetObject("box", Box(.25, .25, .5), Rgba(0, 0, 1, 1));
+  meshcat.SetTransform("box", RigidTransformd(Vector3d{1.0, 0, 0}));
+
+  meshcat.SetObject(
+      "obj", Mesh(FindResourceOrThrow(
+                      "drake/systems/sensors/test/models/meshes/box.obj"),
+                  .25));
+  meshcat.SetTransform("obj", RigidTransformd(Vector3d{2.0, 0, 0}));
+
+  std::cout << R"""(
+Open up your browser to the URL above.
+
+- The background should be off (it will appear white).\n";
+- From back to front along the x axis, you should see:
+  - a red sphere
+  - a green cylinder (with the long axis in z)
+  - a pink semi-transparent ellipsoid (long axis in z)
+  - a blue box (long axis in z)
+  - a gray cube (which will be textured once we add texture support)
+)""";
+  std::cout << "[Press RETURN to continue]." << std::endl;
+  std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+
+  meshcat.Delete("box");
+  meshcat.SetProperty("/Lights/AmbientLight/<object>", "intensity", 0.1);
+
+  std::cout << "- The blue box should have disappeared and the lights should "
+               "have dimmed."
+            << std::endl;
+  std::cout << "[Press RETURN to continue]." << std::endl;
+  std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+
+  meshcat.Delete();
+  std::cout << "- Everything else should have disappeared." << std::endl;
+
+  std::cout << "[Press RETURN to continue]." << std::endl;
+  std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+  std::cout << "All done." << std::endl;
 
   return 0;
 }
+
+}  // namespace geometry
+}  // namespace drake
+
+int main() { return drake::geometry::do_main(); }

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -5,13 +5,18 @@
 #include <fmt/format.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <msgpack.hpp>
 
 #include "drake/common/find_resource.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/geometry/meshcat_types.h"
 
 namespace drake {
 namespace geometry {
 namespace {
 
+using Eigen::Vector3d;
+using math::RigidTransformd;
 using ::testing::HasSubstr;
 
 // A small wrapper around std::system to ensure correct argument passing.
@@ -26,7 +31,7 @@ int SystemCall(const std::vector<std::string>& argv) {
 }
 
 GTEST_TEST(MeshcatTest, TestHttp) {
-  drake::geometry::Meshcat meshcat;
+  Meshcat meshcat;
   // Note: The server doesn't respect all requests; unfortunately we can't use
   // curl --head and wget --spider nor curl --range to avoid downloading the
   // full file.
@@ -42,8 +47,8 @@ GTEST_TEST(MeshcatTest, TestHttp) {
 }
 
 GTEST_TEST(MeshcatTest, ConstructMultiple) {
-  drake::geometry::Meshcat meshcat;
-  drake::geometry::Meshcat meshcat2;
+  Meshcat meshcat;
+  Meshcat meshcat2;
 
   EXPECT_THAT(meshcat.web_url(), HasSubstr("http://localhost:"));
   EXPECT_THAT(meshcat.ws_url(), HasSubstr("ws://localhost:"));
@@ -52,8 +57,178 @@ GTEST_TEST(MeshcatTest, ConstructMultiple) {
   EXPECT_NE(meshcat.web_url(), meshcat2.web_url());
 }
 
-void CheckCommand(const drake::geometry::Meshcat& meshcat, int message_num,
-                  const std::string& desired_command_json) {
+// The correctness of this is established with meshcat_manual_test.  Here we
+// simply aim to provide code coverage for CI (e.g., no segfaults).
+GTEST_TEST(MeshcatTest, SetObjectWithShape) {
+  Meshcat meshcat;
+  EXPECT_TRUE(meshcat.GetPackedObject("sphere").empty());
+  meshcat.SetObject("sphere", Sphere(.25), Rgba(1.0, 0, 0, 1));
+  EXPECT_FALSE(meshcat.GetPackedObject("sphere").empty());
+  meshcat.SetObject("cylinder", Cylinder(.25, .5), Rgba(0.0, 1.0, 0, 1));
+  EXPECT_FALSE(meshcat.GetPackedObject("cylinder").empty());
+  // HalfSpaces are not supported yet; this should only log a warning.
+  meshcat.SetObject("halfspace", HalfSpace());
+  EXPECT_TRUE(meshcat.GetPackedObject("halfspace").empty());
+  meshcat.SetObject("box", Box(.25, .25, .5), Rgba(0, 0, 1, 1));
+  EXPECT_FALSE(meshcat.GetPackedObject("box").empty());
+  meshcat.SetObject("ellipsoid", Ellipsoid(.25, .25, .5), Rgba(1., 0, 1, 1));
+  EXPECT_FALSE(meshcat.GetPackedObject("ellipsoid").empty());
+  // Capsules are not supported yet; this should only log a warning.
+  meshcat.SetObject("capsule", Capsule(.25, .5));
+  EXPECT_TRUE(meshcat.GetPackedObject("capsule").empty());
+  meshcat.SetObject(
+      "mesh", Mesh(FindResourceOrThrow(
+                       "drake/systems/sensors/test/models/meshes/box.obj"),
+                   .25));
+  EXPECT_FALSE(meshcat.GetPackedObject("mesh").empty());
+  meshcat.SetObject(
+      "convex", Convex(FindResourceOrThrow(
+                           "drake/systems/sensors/test/models/meshes/box.obj"),
+                       .25));
+  EXPECT_FALSE(meshcat.GetPackedObject("convex").empty());
+  // Bad filename (no extension).  Should only log a warning.
+  meshcat.SetObject("bad", Mesh("test"));
+  EXPECT_TRUE(meshcat.GetPackedObject("bad").empty());
+  // Bad filename (file doesn't exist).  Should only log a warning.
+  meshcat.SetObject("bad", Mesh("test.obj"));
+  EXPECT_TRUE(meshcat.GetPackedObject("bad").empty());
+}
+
+GTEST_TEST(MeshcatTest, SetTransform) {
+  Meshcat meshcat;
+  EXPECT_FALSE(meshcat.HasPath("frame"));
+  EXPECT_TRUE(meshcat.GetPackedTransform("frame").empty());
+  const RigidTransformd X_ParentPath{math::RollPitchYawd(.5, .26, -3),
+                                     Vector3d{.9, -2., .12}};
+  meshcat.SetTransform("frame", X_ParentPath);
+
+  std::string transform = meshcat.GetPackedTransform("frame");
+  msgpack::object_handle oh =
+      msgpack::unpack(transform.data(), transform.size());
+  auto data = oh.get().as<internal::SetTransformData>();
+  EXPECT_EQ(data.type, "set_transform");
+  EXPECT_EQ(data.path, "/drake/frame");
+  Eigen::Map<Eigen::Matrix4d> matrix(data.matrix);
+  EXPECT_TRUE(CompareMatrices(matrix, X_ParentPath.GetAsMatrix4()));
+}
+
+GTEST_TEST(MeshcatTest, Delete) {
+  Meshcat meshcat;
+  // Ok to delete an empty tree.
+  meshcat.Delete();
+  EXPECT_FALSE(meshcat.HasPath(""));
+  EXPECT_FALSE(meshcat.HasPath("frame"));
+  meshcat.SetTransform("frame", RigidTransformd{});
+  EXPECT_TRUE(meshcat.HasPath(""));
+  EXPECT_TRUE(meshcat.HasPath("frame"));
+  EXPECT_TRUE(meshcat.HasPath("/drake/frame"));
+  // Deleting a random string does nothing.
+  meshcat.Delete("bad");
+  EXPECT_TRUE(meshcat.HasPath("frame"));
+  meshcat.Delete("frame");
+  EXPECT_FALSE(meshcat.HasPath("frame"));
+
+  // Deleting a parent directory deletes all children.
+  meshcat.SetTransform("test/frame", RigidTransformd{});
+  meshcat.SetTransform("test/frame2", RigidTransformd{});
+  meshcat.SetTransform("test/another/frame", RigidTransformd{});
+  EXPECT_TRUE(meshcat.HasPath("test/frame"));
+  EXPECT_TRUE(meshcat.HasPath("test/frame2"));
+  EXPECT_TRUE(meshcat.HasPath("test/another/frame"));
+  meshcat.Delete("test");
+  EXPECT_FALSE(meshcat.HasPath("test/frame"));
+  EXPECT_FALSE(meshcat.HasPath("test/frame2"));
+  EXPECT_FALSE(meshcat.HasPath("test/another/frame"));
+  EXPECT_TRUE(meshcat.HasPath("/drake"));
+
+  // Deleting the empty string deletes the prefix.
+  meshcat.SetTransform("test/frame", RigidTransformd{});
+  meshcat.SetTransform("test/frame2", RigidTransformd{});
+  meshcat.SetTransform("test/another/frame", RigidTransformd{});
+  EXPECT_TRUE(meshcat.HasPath("test/frame"));
+  EXPECT_TRUE(meshcat.HasPath("test/frame2"));
+  EXPECT_TRUE(meshcat.HasPath("test/another/frame"));
+  meshcat.Delete();
+  EXPECT_FALSE(meshcat.HasPath("test/frame"));
+  EXPECT_FALSE(meshcat.HasPath("test/frame2"));
+  EXPECT_FALSE(meshcat.HasPath("test/another/frame"));
+  EXPECT_FALSE(meshcat.HasPath("/drake"));
+}
+
+// Tests three methods of SceneTreeElement:
+// - SceneTreeElement::operator[]() is used in Meshcat::Set*().  We'll use
+// SetTransform() here.
+// - SceneTreeElement::Find() is used in Meshcat::HasPath() and
+// Meshcat::GetPacked*().  We'll use HasPath() to test.
+// - SceneTreeElement::Delete() is used in Meshat::Delete().
+// All of them also run through WebSocketPublisher::FullPath().
+GTEST_TEST(MeshcatTest, Paths) {
+  Meshcat meshcat;
+  // Absolute paths.
+  meshcat.SetTransform("/foo/frame", RigidTransformd{});
+  EXPECT_TRUE(meshcat.HasPath("/foo/frame"));
+  meshcat.Delete("/foo/frame");
+  EXPECT_FALSE(meshcat.HasPath("/foo/frame"));
+
+  // Absolute paths with strange spellings.
+  meshcat.SetTransform("///bar///frame///", RigidTransformd{});
+  EXPECT_TRUE(meshcat.HasPath("//bar//frame//"));
+  EXPECT_TRUE(meshcat.HasPath("/bar/frame"));
+  meshcat.Delete("////bar//frame///");
+  EXPECT_FALSE(meshcat.HasPath("/bar/frame"));
+
+  // Relative paths.
+  meshcat.SetTransform("frame", RigidTransformd{});
+  EXPECT_TRUE(meshcat.HasPath("frame"));
+  EXPECT_TRUE(meshcat.HasPath("/drake/frame"));
+
+  // Relative paths with strange spellings.
+  meshcat.SetTransform("bar///frame///", RigidTransformd{});
+  EXPECT_TRUE(meshcat.HasPath("bar//frame//"));
+  EXPECT_TRUE(meshcat.HasPath("/drake/bar/frame"));
+  meshcat.Delete("bar//frame//");
+  EXPECT_FALSE(meshcat.HasPath("bar/frame"));
+  EXPECT_FALSE(meshcat.HasPath("/drake/bar/frame"));
+}
+
+GTEST_TEST(MeshcatTest, SetPropertyBool) {
+  Meshcat meshcat;
+  EXPECT_FALSE(meshcat.HasPath("/Grid"));
+  EXPECT_TRUE(meshcat.GetPackedProperty("/Grid", "visible").empty());
+  meshcat.SetProperty("/Grid", "visible", false);
+  EXPECT_TRUE(meshcat.HasPath("/Grid"));
+
+  std::string property = meshcat.GetPackedProperty("/Grid", "visible");
+  msgpack::object_handle oh = msgpack::unpack(property.data(), property.size());
+  auto data = oh.get().as<internal::SetPropertyData<bool>>();
+  EXPECT_EQ(data.type, "set_property");
+  EXPECT_EQ(data.path, "/Grid");
+  EXPECT_EQ(data.property, "visible");
+  EXPECT_FALSE(data.value);
+}
+
+GTEST_TEST(MeshcatTest, SetPropertyDouble) {
+  Meshcat meshcat;
+  EXPECT_FALSE(meshcat.HasPath("/Cameras/default/rotated/<object>"));
+  EXPECT_TRUE(
+      meshcat.GetPackedProperty("/Cameras/default/rotated/<object>", "zoom")
+          .empty());
+  meshcat.SetProperty("/Cameras/default/rotated/<object>", "zoom", 2.0);
+  EXPECT_TRUE(meshcat.HasPath("/Cameras/default/rotated/<object>"));
+
+  std::string property =
+      meshcat.GetPackedProperty("/Cameras/default/rotated/<object>", "zoom");
+  msgpack::object_handle oh = msgpack::unpack(property.data(), property.size());
+  auto data = oh.get().as<internal::SetPropertyData<double>>();
+  EXPECT_EQ(data.type, "set_property");
+  EXPECT_EQ(data.path, "/Cameras/default/rotated/<object>");
+  EXPECT_EQ(data.property, "zoom");
+  EXPECT_EQ(data.value, 2.0);
+}
+
+void CheckWebsocketCommand(const drake::geometry::Meshcat& meshcat,
+                           int message_num,
+                           const std::string& desired_command_json) {
   EXPECT_EQ(SystemCall(
                 {FindResourceOrThrow("drake/geometry/meshcat_websocket_client"),
                  meshcat.ws_url(), std::to_string(message_num),
@@ -61,30 +236,30 @@ void CheckCommand(const drake::geometry::Meshcat& meshcat, int message_num,
             0);
 }
 
-GTEST_TEST(MeshcatTest, SetProperty) {
-  drake::geometry::Meshcat meshcat;
+GTEST_TEST(MeshcatTest, SetPropertyWebSocket) {
+  Meshcat meshcat;
   meshcat.SetProperty("/Background", "visible", false);
-  CheckCommand(meshcat, 1, R"""({
-              "property": "visible",
-              "value": false,
-              "path": "/Background",
-              "type": "set_property"
-              })""");
+  CheckWebsocketCommand(meshcat, 1, R"""({
+      "type": "set_property",
+      "path": "/Background",
+      "property": "visible",
+      "value": false
+    })""");
   meshcat.SetProperty("/Grid", "visible", false);
   // Note: The order of the messages is due to "/Background" < "/Grid" in the
   // std::map, not due to the order that SetProperty was called.
-  CheckCommand(meshcat, 1, R"""({
-              "property": "visible",
-              "value": false,
-              "path": "/Background",
-              "type": "set_property"
-              })""");
-  CheckCommand(meshcat, 2, R"""({
-              "property": "visible",
-              "value": false,
-              "path": "/Grid",
-              "type": "set_property"
-              })""");
+  CheckWebsocketCommand(meshcat, 1, R"""({
+      "type": "set_property",
+      "path": "/Background",
+      "property": "visible",
+      "value": false
+    })""");
+  CheckWebsocketCommand(meshcat, 2, R"""({
+      "type": "set_property",
+      "path": "/Grid",
+      "property": "visible",
+      "value": false
+    })""");
 }
 
 }  // namespace

--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -75,6 +75,7 @@ load("@drake//tools/workspace/scs:repository.bzl", "scs_repository")
 load("@drake//tools/workspace/sdformat:repository.bzl", "sdformat_repository")
 load("@drake//tools/workspace/snopt:repository.bzl", "snopt_repository")
 load("@drake//tools/workspace/spdlog:repository.bzl", "spdlog_repository")
+load("@drake//tools/workspace/stduuid:repository.bzl", "stduuid_repository")
 load("@drake//tools/workspace/styleguide:repository.bzl", "styleguide_repository")  # noqa
 load("@drake//tools/workspace/suitesparse:repository.bzl", "suitesparse_repository")  # noqa
 load("@drake//tools/workspace/tinyobjloader:repository.bzl", "tinyobjloader_repository")  # noqa
@@ -247,6 +248,8 @@ def add_default_repositories(excludes = [], mirrors = DEFAULT_MIRRORS):
         snopt_repository(name = "snopt")
     if "spdlog" not in excludes:
         spdlog_repository(name = "spdlog", mirrors = mirrors)
+    if "stduuid" not in excludes:
+        stduuid_repository(name = "stduuid", mirrors = mirrors)
     if "styleguide" not in excludes:
         styleguide_repository(name = "styleguide", mirrors = mirrors)
     if "suitesparse" not in excludes:

--- a/tools/workspace/stduuid/BUILD.bazel
+++ b/tools/workspace/stduuid/BUILD.bazel
@@ -1,0 +1,8 @@
+# -*- python -*-
+
+# This file exists to make our directory into a Bazel package, so that our
+# neighboring *.bzl file can be loaded elsewhere.
+
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+add_lint_tests()

--- a/tools/workspace/stduuid/package.BUILD.bazel
+++ b/tools/workspace/stduuid/package.BUILD.bazel
@@ -1,0 +1,23 @@
+# -*- python -*-
+
+load(
+    "@drake//tools/install:install.bzl",
+    "install",
+)
+
+licenses(["notice"])  # MIT
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "stduuid",
+    hdrs = glob(["include/uuid.h", "gsl/*"]),
+    includes = ["include", "gsl"],
+    linkstatic = 1,
+)
+
+# Install the license file.
+install(
+    name = "install",
+    docs = ["LICENSE"],
+)

--- a/tools/workspace/stduuid/repository.bzl
+++ b/tools/workspace/stduuid/repository.bzl
@@ -1,0 +1,16 @@
+# -*- mode: python -*-
+# vi: set ft=python :
+
+load("@drake//tools/workspace:github.bzl", "github_archive")
+
+def stduuid_repository(
+        name,
+        mirrors = None):
+    github_archive(
+        name = name,
+        repository = "mariusbancila/stduuid",
+        commit = "4959d46eb494f8eddd4a37a1c8c6434b41d56ca8",
+        sha256 = "011514f3c4ef831d26fa11ef897c6d0b92a491987f3b15a5b21cd872cf9153b4",  # noqa
+        build_file = "@drake//tools/workspace/stduuid:package.BUILD.bazel",
+        mirrors = mirrors,
+    )


### PR DESCRIPTION
Implements the most essential elements of the Meshcat API:
- Added SceneTree data structure.
- Added stduuid
- Added SetObject from Shape, Rgba
  - Supports all shapes that meshcat_visualizer.py supports (more, in fact)
  - Does not support texture maps yet.
- Added SetTransform
- Added Delete
- Added SetProperty<double>
- Added HasPath, GetPacked* methods, primarily for testing.

This PR is > 500 lines, but a significant portion of this commit is relatively boilerplate management of the msgpack data structures used to communicate with the javascript client.

Updated the meshcat_manual_test to step the user through the checks.
Updated meschat_test to hammer on the new API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15647)
<!-- Reviewable:end -->
