### PR TITLE
[manipulation/models] Fix warnings generated by sdf parsing of ycb objects

### DIFF
--- a/manipulation/models/ycb/sdf/003_cracker_box.sdf
+++ b/manipulation/models/ycb/sdf/003_cracker_box.sdf
@@ -51,9 +51,6 @@
             <size>0.158000 0.207400 0.065800</size>
           </box>
         </geometry>
-        <material>
-          <diffuse>0 1 0 1.0</diffuse>
-        </material>
       </collision>
       <collision name="point_collision1">
         <pose>0.079500 0.104200 0.033400 0 0 0 </pose>

--- a/manipulation/models/ycb/sdf/004_sugar_box.sdf
+++ b/manipulation/models/ycb/sdf/004_sugar_box.sdf
@@ -51,9 +51,6 @@
             <size>0.086700 0.170300 0.039100</size>
           </box>
         </geometry>
-        <material>
-          <diffuse>0 1 0 1.0</diffuse>
-        </material>
       </collision>
       <collision name="point_collision1">
         <pose>0.043850 0.085650 0.020050 0 0 0 </pose>

--- a/manipulation/models/ycb/sdf/005_tomato_soup_can.sdf
+++ b/manipulation/models/ycb/sdf/005_tomato_soup_can.sdf
@@ -53,9 +53,6 @@
             <length>0.099900</length>
           </cylinder>
         </geometry>
-        <material>
-          <diffuse>0 1 0 1.0</diffuse>
-        </material>
       </collision>
       <collision name="point_collision1">
         <pose>0.016425 0.050450 0.016425 0 0 0 </pose>

--- a/manipulation/models/ycb/sdf/006_mustard_bottle.sdf
+++ b/manipulation/models/ycb/sdf/006_mustard_bottle.sdf
@@ -54,9 +54,6 @@
             <size>0.090000 0.160300 0.052200</size>
           </box>
         </geometry>
-        <material>
-          <diffuse>0 1 0 1.0</diffuse>
-        </material>
       </collision>
       <collision name="point_collision1">
         <pose>0.045500 0.093150 0.026600 0 0 0 </pose>

--- a/manipulation/models/ycb/sdf/009_gelatin_box.sdf
+++ b/manipulation/models/ycb/sdf/009_gelatin_box.sdf
@@ -51,9 +51,6 @@
             <size>0.083200 0.067100 0.024000</size>
           </box>
         </geometry>
-        <material>
-          <diffuse>0 1 0 1.0</diffuse>
-        </material>
       </collision>
       <collision name="point_collision1">
         <pose>0.042100 0.034050 0.012500 0 0 0 </pose>

--- a/manipulation/models/ycb/sdf/010_potted_meat_can.sdf
+++ b/manipulation/models/ycb/sdf/010_potted_meat_can.sdf
@@ -51,9 +51,6 @@
             <size>0.095600 0.077500 0.051600</size>
           </box>
         </geometry>
-        <material>
-          <diffuse>0 1 0 1.0</diffuse>
-        </material>
       </collision>
       <collision name="point_collision1">
         <pose>0.048300 0.039250 0.026300 0 0 0 </pose>


### PR DESCRIPTION
Each of the ycb sdf tags had irrelevant material elements inside collision elements.  The updated sdf parser (correctly) spews sdplog warnings about them, so I have removed them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15648)
<!-- Reviewable:end -->
