### PR TITLE
Turn off kcov on a test that hit kcov#339

### DIFF
--- a/systems/controllers/BUILD.bazel
+++ b/systems/controllers/BUILD.bazel
@@ -275,6 +275,8 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "setpoint_test",
     srcs = ["test/setpoint_test.cc"],
+    # TODO(ggould-tri) This test hit kcov#339; untag when we have kcov>=40.
+    tags = ["no_kcov"],
     deps = [
         ":setpoint",
         "//common/test_utilities:eigen_matrix_compare",


### PR DESCRIPTION
Our current version of kcov on bionic has a bug
https://github.com/SimonKagstrom/kcov/issues/339
that generatues spurious failures based on the bitwise contents of
target binaries.  Temporarily deactivate kcov testing of this test to avoid
one such spurious failure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15650)
<!-- Reviewable:end -->
