### PR TITLE
[multibody] Add new enumerator names for ContactModel

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -1199,12 +1199,16 @@ PYBIND11_MODULE(plant, m) {
     using Class = ContactModel;
     constexpr auto& cls_doc = doc.ContactModel;
     py::enum_<Class>(m, "ContactModel", cls_doc.doc)
+        .value("kHydroelastic", Class::kHydroelastic, cls_doc.kHydroelastic.doc)
+        .value("kPoint", Class::kPoint, cls_doc.kPoint.doc)
+        .value("kHydroelasticWithFallback", Class::kHydroelasticWithFallback,
+            cls_doc.kHydroelasticWithFallback.doc)
+        // Legacy alias. TODO(jwnimmer-tri) Deprecate this constant.
         .value("kHydroelasticsOnly", Class::kHydroelasticsOnly,
             cls_doc.kHydroelasticsOnly.doc)
+        // Legacy alias. TODO(jwnimmer-tri) Deprecate this constant.
         .value("kPointContactOnly", Class::kPointContactOnly,
-            cls_doc.kPointContactOnly.doc)
-        .value("kHydroelasticWithFallback", Class::kHydroelasticWithFallback,
-            cls_doc.kHydroelasticWithFallback.doc);
+            cls_doc.kPointContactOnly.doc);
   }
 }  // NOLINT(readability/fn_size)
 

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -1907,9 +1907,12 @@ class TestPlant(unittest.TestCase):
     def test_contact_model(self):
         plant = MultibodyPlant_[float](0.1)
         models = [
+            ContactModel.kHydroelastic,
+            ContactModel.kPoint,
+            ContactModel.kHydroelasticWithFallback,
+            # Also test the legacy aliases.
             ContactModel.kHydroelasticsOnly,
             ContactModel.kPointContactOnly,
-            ContactModel.kHydroelasticWithFallback,
         ]
         for model in models:
             plant.set_contact_model(model)
@@ -2082,7 +2085,7 @@ class TestPlant(unittest.TestCase):
         Parser(plant).AddModelFromFile(
             FindResourceOrThrow(
                 "drake/bindings/pydrake/multibody/test/hydroelastic.sdf"))
-        plant.set_contact_model(ContactModel.kHydroelasticsOnly)
+        plant.set_contact_model(ContactModel.kHydroelastic)
         plant.Finalize()
 
         diagram = builder.Build()

--- a/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
+++ b/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
@@ -131,7 +131,7 @@ int do_main() {
 
   // Set contact model and parameters.
   if (FLAGS_contact_model == "hydroelastic") {
-    plant.set_contact_model(ContactModel::kHydroelasticsOnly);
+    plant.set_contact_model(ContactModel::kHydroelastic);
     plant.Finalize();
   } else if (FLAGS_contact_model == "point") {
     // Plant must be finalized before setting the penetration allowance.

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1239,11 +1239,11 @@ void MultibodyPlant<T>::CalcContactResultsContinuous(
   if (num_collision_geometries() == 0) return;
 
   switch (contact_model_) {
-    case ContactModel::kPointContactOnly:
+    case ContactModel::kPoint:
       CalcContactResultsContinuousPointPair(context, contact_results);
       break;
 
-    case ContactModel::kHydroelasticsOnly:
+    case ContactModel::kHydroelastic:
       AppendContactResultsContinuousHydroelastic(context, contact_results);
       break;
 
@@ -1403,11 +1403,11 @@ void MultibodyPlant<T>::CalcContactResultsDiscrete(
   if (num_collision_geometries() == 0) return;
 
   switch (contact_model_) {
-    case ContactModel::kPointContactOnly:
+    case ContactModel::kPoint:
       CalcContactResultsDiscretePointPair(context, contact_results);
       break;
 
-    case ContactModel::kHydroelasticsOnly:
+    case ContactModel::kHydroelastic:
       // N.B. We are simply computing the hydro force as function of the state,
       // not the actual discrete approximation used by the contact solver.
       AppendContactResultsContinuousHydroelastic(context, contact_results);
@@ -1978,13 +1978,13 @@ void MultibodyPlant<T>::CalcDiscreteContactPairs(
     // We guard for case (2) since EvalPointPairPenetrations() cannot be called
     // when point contact is not used and would otherwise throw an exception.
     int num_point_pairs = 0;  // The number of point contact pairs.
-    if (contact_model_ == ContactModel::kPointContactOnly ||
+    if (contact_model_ == ContactModel::kPoint ||
         contact_model_ == ContactModel::kHydroelasticWithFallback) {
       num_point_pairs = EvalPointPairPenetrations(context).size();
     }
 
     int num_quadrature_pairs = 0;
-    if (contact_model_ == ContactModel::kHydroelasticsOnly ||
+    if (contact_model_ == ContactModel::kHydroelastic ||
         contact_model_ == ContactModel::kHydroelasticWithFallback) {
       const std::vector<geometry::ContactSurface<T>>& surfaces =
           EvalContactSurfaces(context);
@@ -2471,14 +2471,14 @@ void MultibodyPlant<T>::CalcSpatialContactForcesContinuous(
 
   // Compute the spatial forces on each body from contact.
   switch (contact_model_) {
-    case ContactModel::kPointContactOnly:
+    case ContactModel::kPoint:
       // Note: consider caching the results from the following method (in which
       // case we would also want to introduce the Eval... naming convention for
       // the method).
       CalcAndAddContactForcesByPenaltyMethod(context, &(*F_BBo_W_array));
       break;
 
-    case ContactModel::kHydroelasticsOnly:
+    case ContactModel::kHydroelastic:
       *F_BBo_W_array = EvalHydroelasticContactForces(context).F_BBo_W_array;
       break;
 
@@ -2893,7 +2893,7 @@ void MultibodyPlant<T>::DeclareCacheEntries() {
   // Cache entry for spatial forces and contact info due to hydroelastic
   // contact.
   const bool use_hydroelastic =
-      contact_model_ == ContactModel::kHydroelasticsOnly ||
+      contact_model_ == ContactModel::kHydroelastic ||
       contact_model_ == ContactModel::kHydroelasticWithFallback;
   if (use_hydroelastic) {
     auto& contact_info_and_body_spatial_forces_cache_entry =

--- a/multibody/plant/test/multibody_plant_hydroelastic_contact_results_output_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_contact_results_output_test.cc
@@ -53,7 +53,7 @@ class HydroelasticContactResultsOutputTester : public ::testing::Test {
             0.0 /* mbp_dt */, radius, mass, elastic_modulus, dissipation,
             friction, gravity_W, false /* rigid_sphere */,
             false /* soft_ground */, &scene_graph));
-    plant_->set_contact_model(ContactModel::kHydroelasticsOnly);
+    plant_->set_contact_model(ContactModel::kHydroelastic);
     plant_->Finalize();
 
     // Sanity check on the availability of the optional source id before using

--- a/multibody/plant/test/multibody_plant_hydroelastic_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_test.cc
@@ -63,11 +63,11 @@ class HydroelasticModelTests : public ::testing::Test {
                        kFrictionCoefficient);
 
     // The default contact model today is point contact.
-    EXPECT_EQ(plant_->get_contact_model(), ContactModel::kPointContactOnly);
+    EXPECT_EQ(plant_->get_contact_model(), ContactModel::kPoint);
 
     // Tell the plant to use the hydroelastic model.
-    plant_->set_contact_model(ContactModel::kHydroelasticsOnly);
-    ASSERT_EQ(plant_->get_contact_model(), ContactModel::kHydroelasticsOnly);
+    plant_->set_contact_model(ContactModel::kHydroelastic);
+    ASSERT_EQ(plant_->get_contact_model(), ContactModel::kHydroelastic);
 
     plant_->Finalize();
 
@@ -499,7 +499,7 @@ class ContactModelTest : public ::testing::Test {
 };
 
 TEST_F(ContactModelTest, PointPairContact) {
-  this->Configure(ContactModel::kPointContactOnly);
+  this->Configure(ContactModel::kPoint);
   const ContactResults<double>& contact_results = GetContactResults();
   ASSERT_EQ(contact_results.num_point_pair_contacts(), 2);
   ASSERT_EQ(contact_results.num_hydroelastic_contacts(), 0);
@@ -523,7 +523,7 @@ TEST_F(ContactModelTest, PointPairContact) {
 }
 
 TEST_F(ContactModelTest, HydroelasticOnly) {
-  this->Configure(ContactModel::kHydroelasticsOnly);
+  this->Configure(ContactModel::kHydroelastic);
   // Rigid-rigid contact precludes successful evaluation.
   DRAKE_EXPECT_THROWS_MESSAGE(GetContactResults(), std::logic_error,
                               "Requested contact between two rigid objects .+");
@@ -572,7 +572,7 @@ TEST_F(ContactModelTest, HydroelasticWithFallbackDisconnectedPorts) {
 //  inheritance and consider using parameter-value tests.
 
 // Tests MultibodyPlant::CalcContactSurfaces() which is used in
-// kHydroelasticsOnly contact model for both continuous systems and discrete
+// kHydroelastic contact model for both continuous systems and discrete
 // systems. Tests the experimental option to request low-resolution
 // contact surfaces too.
 //
@@ -587,7 +587,7 @@ class CalcContactSurfacesTest : public ContactModelTest {
     const bool connect_scene_graph = true;
     // No rigid-rigid contact. Only the rigid-compliant contact.
     bool are_rigid_spheres_in_contact = false;
-    ContactModelTest::Configure(ContactModel::kHydroelasticsOnly,
+    ContactModelTest::Configure(ContactModel::kHydroelastic,
                                 connect_scene_graph, time_step,
                                 are_rigid_spheres_in_contact,
                                 use_low_resolution_contact_surface);


### PR DESCRIPTION
Retain the old names for now, to avoid immediately disrupting existing users; eventually, we should deprecated the legacy names.

Towards #15565.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15656)
<!-- Reviewable:end -->
