### PR TITLE
[framework] Fix deprecated AddIfSupported scalar conversion helper

### DIFF
--- a/systems/framework/system_scalar_converter.h
+++ b/systems/framework/system_scalar_converter.h
@@ -135,7 +135,7 @@ class SystemScalarConverter {
   DRAKE_DEPRECATED("2021-10-01",
       "User-defined scalar types cannot be added.")
   void AddIfSupported() {
-    AddIfSupported<S, T, U>(GuaranteedSubtypePreservation::kEnabled);
+    MaybeAddConstructor<true, S, T, U>();
   }
 
   /// Removes from this converter all pairs where `other.IsConvertible<T, U>`

--- a/systems/framework/test/system_scalar_converter_test.cc
+++ b/systems/framework/test/system_scalar_converter_test.cc
@@ -339,6 +339,18 @@ GTEST_TEST(SystemScalarConverterTest, Remove) {
       dut.Convert<AutoDiffXd, double>(system)));
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+GTEST_TEST(SystemScalarConverterTest, DeprecatedAddIfSupported) {
+  // The deprecated function AddIfSupported no longer serves any useful purpose,
+  // because there are no public functions that allow us to observe its effects,
+  // but we should ensure that it at least _compiles_ if someone does try to use
+  // it.
+  SystemScalarConverter dut(SystemTypeTag<FromDoubleSystem>{});
+  dut.AddIfSupported<FromDoubleSystem, double, float>();
+}
+#pragma GCC diagnostic pop
+
 }  // namespace
 }  // namespace systems
 }  // namespace drake


### PR DESCRIPTION
The prior implementation of this template function contained broken code, but was never compiled so we never noticed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15657)
<!-- Reviewable:end -->
