### PR TITLE
Deprecate two unused autodiff utility functions

### DIFF
--- a/math/autodiff.h
+++ b/math/autodiff.h
@@ -11,6 +11,7 @@
 #include <Eigen/Dense>
 
 #include "drake/common/autodiff.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/unused.h"
 
 namespace drake {
@@ -169,6 +170,8 @@ AutoDiffMatrixType<Derived, Nq> initializeAutoDiff(
   return ret;
 }
 
+// TODO(sherm1) DRAKE_DEPRECATED("2021-12-01") Remove this internal:: block when
+//  resizeDerivativesToMatchScalar() below is removed.
 namespace internal {
 template <typename Derived, typename Scalar>
 struct ResizeDerivativesToMatchScalarImpl {
@@ -206,6 +209,8 @@ struct ResizeDerivativesToMatchScalarImpl<Derived,
  * \param scalar scalar to match the derivative size vector against.
  */
 template <typename Derived>
+DRAKE_DEPRECATED("2021-12-01",
+    "Apparently unused. File a Drake issue on GitHub if you need this method.")
 // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
 void resizeDerivativesToMatchScalar(Eigen::MatrixBase<Derived>& mat,
                                     const typename Derived::Scalar& scalar) {

--- a/math/autodiff_gradient.h
+++ b/math/autodiff_gradient.h
@@ -9,6 +9,7 @@
 #include <Eigen/Dense>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/unused.h"
 #include "drake/math/autodiff.h"
 #include "drake/math/gradient.h"
@@ -123,6 +124,8 @@ initializeAutoDiffGivenGradientMatrix(
 }
 
 template <typename DerivedGradient, typename DerivedAutoDiff>
+DRAKE_DEPRECATED("2021-12-01",
+    "Apparently unused. File a Drake issue on GitHub if you need this method.")
 void gradientMatrixToAutoDiff(
     const Eigen::MatrixBase<DerivedGradient>& gradient,
     // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).


### PR DESCRIPTION
Per discussion in issue #15604 this PR deprecates two unused AutoDiff utility functions:
- resizeDerivativesToMatchScalar() from autodiff.h
- gradientMatrixToAutoDiff() from autodiff_gradient.h

There are no other changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15658)
<!-- Reviewable:end -->
