### PR TITLE
py math: Add patch for rich comparison operators; test combinatorics

### DIFF
--- a/bindings/pydrake/common/deprecation.py
+++ b/bindings/pydrake/common/deprecation.py
@@ -225,6 +225,9 @@ def install_numpy_warning_filters(force=False):
     warnings.filterwarnings(
         "error", category=DeprecationWarning,
         message="elementwise == comparison failed")
+    warnings.filterwarnings(
+        "error", category=DeprecationWarning,
+        message="elementwise != comparison failed")
     # Error changed in 1.16.0
     warnings.filterwarnings(
         "error", category=DeprecationWarning,

--- a/bindings/pydrake/test/symbolic_test.py
+++ b/bindings/pydrake/test/symbolic_test.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
 
 import copy
+import itertools
 import unittest
 
 import numpy as np
 
 import pydrake.symbolic as sym
 import pydrake.common
+import pydrake.math as drake_math
 from pydrake.test.algebra_test_util import ScalarAlgebra, VectorizedAlgebra
 from pydrake.common.containers import EqualToDict
 from pydrake.common.deprecation import install_numpy_warning_filters
@@ -521,6 +523,84 @@ class TestSymbolicExpression(unittest.TestCase):
         self.assertIsInstance(xv[0], sym.Variable)
         self.assertEqual(e_xv.shape, (2,))
         self.assertIsInstance(e_xv[0], sym.Expression)
+
+    def test_vectorized_binary_operator_type_combinatorics(self):
+        """
+        Tests vectorized binary operator via brute-force combinatorics per
+        #15549.
+
+        This complements test with the same name in ``autodiffutils_test.py``.
+        """
+
+        def expand_values(value):
+            return (
+                # Scalar.
+                value,
+                # Scalar array.
+                np.array(value),
+                # Size-1 array.
+                np.array([value]),
+                # Size-2 array.
+                np.array([value, value]),
+            )
+
+        operators = drake_math._OPERATORS
+        operators_reverse = drake_math._OPERATORS_REVERSE
+
+        T_operands_x = (
+            # Variable.
+            expand_values(x)
+            # Expression.
+            + expand_values(e_x)
+        )
+        T_operands_y = (
+            # Variable.
+            expand_values(y)
+            # Expression.
+            + expand_values(e_y)
+        )
+        numeric_operands = (
+            # Float.
+            # - Native.
+            expand_values(1.0)
+            # - np.generic
+            + expand_values(np.float64(1.0))
+            # Int.
+            # - Native.
+            + expand_values(1)
+            # - np.generic
+            + expand_values(np.int64(1.0))
+        )
+
+        @np.vectorize
+        def assert_nontrivial_formula(value):
+            self.assertIsInstance(value, sym.Formula)
+            self.assertNotEqual(value, sym.Formula.True_())
+            self.assertNotEqual(value, sym.Formula.False_())
+
+        def check_operands(op, lhs_operands, rhs_operands):
+            operand_combinatorics_iter = itertools.product(
+                lhs_operands, rhs_operands
+            )
+            op_reverse = operators_reverse[op]
+            for lhs, rhs in operand_combinatorics_iter:
+                hint_for_error = f"{op.__doc__}: {repr(lhs)}, {repr(rhs)}"
+                with numpy_compare.soft_sub_test(hint_for_error):
+                    value = op(lhs, rhs)
+                    assert_nontrivial_formula(value)
+                    reverse_value = op_reverse(rhs, lhs)
+                    assert_nontrivial_formula(reverse_value)
+                    numpy_compare.assert_equal(value, reverse_value)
+
+        # Combinations (unordered) that we're interested in.
+        operand_combinations = (
+            (T_operands_x, T_operands_y),
+            (T_operands_x, numeric_operands),
+        )
+        for op in operators:
+            for (op_a, op_b) in operand_combinations:
+                check_operands(op, op_a, op_b)
+                check_operands(op, op_b, op_a)
 
     def test_equalto(self):
         self.assertTrue((x + y).EqualTo(x + y))


### PR DESCRIPTION
Tests both symbolic types and AutoDiffXd
numpy_compare: Add soft_sub_test workaround
deprecation: Catch old-style deprecation elementwise != comparison

Resolves #15549

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15659)
<!-- Reviewable:end -->
