### PR TITLE
Implement DeformableRigidManager::DoCalcDiscreteValues()

### DIFF
--- a/multibody/fixed_fem/dev/BUILD.bazel
+++ b/multibody/fixed_fem/dev/BUILD.bazel
@@ -201,6 +201,7 @@ drake_cc_library(
         ":inverse_spd_operator",
         ":matrix_utilities",
         ":schur_complement",
+        ":velocity_newmark_scheme",
         "//common:essential",
         "//multibody/contact_solvers:block_sparse_linear_operator",
         "//multibody/contact_solvers:block_sparse_matrix",
@@ -640,6 +641,18 @@ drake_cc_googletest(
     deps = [
         ":constitutive_model_test_utilities",
         ":corotated_model",
+    ],
+)
+
+drake_cc_googletest(
+    name = "deformable_box_test",
+    deps = [
+        ":deformable_rigid_manager",
+        ":deformable_visualizer",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//geometry:drake_visualizer",
+        "//multibody/contact_solvers:pgs_solver",
+        "//systems/analysis:simulator",
     ],
 )
 

--- a/multibody/fixed_fem/dev/deformable_rigid_manager.cc
+++ b/multibody/fixed_fem/dev/deformable_rigid_manager.cc
@@ -69,6 +69,13 @@ void DeformableRigidManager<T>::ExtractModelInfo() {
     throw std::logic_error(
         "The owning MultibodyPlant does not have any deformable model.");
   }
+  // TODO(xuchenhan-tri): We have to manually keep the integration schemes in
+  //  sync for free-motion solve and post-contact solve which is error prone.
+  //  See issue #15620.
+  /* We use the Newmark scheme with gamma = 1 and beta = 0.5 to advance states
+   for all deformable bodies. */
+  velocity_newmark_ = std::make_unique<internal::VelocityNewmarkScheme<T>>(
+      this->plant().time_step(), 1, 0.5);
 }
 
 template <typename T>
@@ -131,6 +138,21 @@ void DeformableRigidManager<T>::DeclareCacheEntries() {
         {fem_state_cache_entry.ticket()});
     free_motion_cache_indexes_.emplace_back(
         free_motion_cache_entry.cache_index());
+
+    const auto& next_fem_state_cache_entry = this->DeclareCacheEntry(
+        fmt::format("FEM state for {} at the next time step",
+                    deformable_body_id),
+        systems::ValueProducer(
+            *model_fem_state,
+            std::function<void(const systems::Context<T>&, FemStateBase<T>*)>{
+                [this, deformable_body_id](const systems::Context<T>& context,
+                                           FemStateBase<T>* next_state) {
+                  this->CalcNextFemStateBase(context, deformable_body_id,
+                                             next_state);
+                }}),
+        {systems::System<T>::all_sources_ticket()});
+    next_fem_state_cache_indexes_.emplace_back(
+        next_fem_state_cache_entry.cache_index());
 
     /* Allocates and calculates the free-motion tangent matrix for the
      deformable body. */
@@ -397,7 +419,7 @@ void DeformableRigidManager<T>::CalcDeformableContactSolverResults(
           v_star, body_contact_data.permuted_vertex_indexes());
       const int body_num_participating_dofs =
           3 * body_contact_data.num_vertices_in_contact();
-      /* Calculate the velocitiy changes for participating dofs and store them
+      /* Calculate the velocity changes for participating dofs and store them
        in `participating_delta_v`. */
       const auto participating_v_star =
           permuted_v_star.head(body_num_participating_dofs);
@@ -405,7 +427,7 @@ void DeformableRigidManager<T>::CalcDeformableContactSolverResults(
           participating_dofs_offset, body_num_participating_dofs);
       const VectorX<T> participating_delta_v =
           participating_v - participating_v_star;
-      /* Use Schur complement to calculate the velocitiy changes for
+      /* Use Schur complement to calculate the velocity changes for
         non-participating dofs and store them in `nonparticipating_delta_v`. */
       const internal::SchurComplement<T>& schur_complement =
           EvalFreeMotionTangentMatrixSchurComplement(context, body);
@@ -452,7 +474,7 @@ template <typename T>
 void DeformableRigidManager<T>::DoCalcDiscreteValues(
     const systems::Context<T>& context,
     systems::DiscreteValues<T>* updates) const {
-  /* Get the rigid dofs from context. */
+  /* Calculate the discrete state values for the rigid dofs. */
   auto x =
       context.get_discrete_state(this->multibody_state_index()).get_value();
   const auto& q = x.topRows(this->plant().num_positions());
@@ -470,23 +492,19 @@ void DeformableRigidManager<T>::DoCalcDiscreteValues(
   x_next << q_next, v_next;
   updates->set_value(this->multibody_state_index(), x_next);
 
-  /* Evaluates the deformable free-motion states. */
+  /* Calculate the discrete state values for the deformable dofs. */
   const std::vector<systems::DiscreteStateIndex>& discrete_state_indexes =
       deformable_model_->discrete_state_indexes();
-  for (DeformableBodyIndex deformable_body_id(0);
-       deformable_body_id < free_motion_cache_indexes_.size();
-       ++deformable_body_id) {
-    const FemStateBase<T>& state_star =
-        EvalFreeMotionFemStateBase(context, deformable_body_id);
-    const int num_dofs = state_star.num_generalized_positions();
-    // TODO(xuchenhan-tri): This assumes no deformable-rigid contact exists.
-    //  Modify this to include the effect of contact.
-    /* Copy new state to output variable. */
+  for (DeformableBodyIndex body(0); body < discrete_state_indexes.size();
+       ++body) {
     Eigen::VectorBlock<VectorX<T>> next_discrete_value =
-        updates->get_mutable_value(discrete_state_indexes[deformable_body_id]);
-    next_discrete_value.head(num_dofs) = state_star.q();
-    next_discrete_value.segment(num_dofs, num_dofs) = state_star.qdot();
-    next_discrete_value.tail(num_dofs) = state_star.qddot();
+        updates->get_mutable_value(discrete_state_indexes[body]);
+    const int body_num_dofs = next_discrete_value.size() / 3;
+    const FemStateBase<T>& next_state = EvalNextFemStateBase(context, body);
+    next_discrete_value.head(body_num_dofs) = next_state.q();
+    next_discrete_value.segment(body_num_dofs, body_num_dofs) =
+        next_state.qdot();
+    next_discrete_value.tail(body_num_dofs) = next_state.qddot();
   }
 }
 
@@ -519,6 +537,30 @@ void DeformableRigidManager<T>::CalcFreeMotionFemStateBase(
   fem_state_star->SetQddot(fem_state.qddot());
   /* Obtain the contact-free state for the deformable body. */
   fem_solvers_[id]->AdvanceOneTimeStep(fem_state, fem_state_star);
+}
+
+template <typename T>
+void DeformableRigidManager<T>::CalcNextFemStateBase(
+    const systems::Context<T>& context, DeformableBodyIndex body_index,
+    FemStateBase<T>* fem_state) const {
+  DRAKE_DEMAND(deformable_model_ != nullptr);
+  /* Calculate the discrete state values for the deformable dofs. */
+  const auto& deformable_contact_solver_results =
+      EvalDeformableContactSolverResults(context);
+  const VectorX<T>& deformable_velocities =
+      deformable_contact_solver_results.v_next;
+  // TODO(xuchenhan-tri): The dofs offset for a certain deformable body is
+  // required throughout multiple methods in this class and should be
+  // precomputed.
+  int dofs_offset = 0;
+  for (DeformableBodyIndex b(0); b < body_index; ++b) {
+    dofs_offset += deformable_model_->fem_model(b).num_dofs();
+  }
+  const int body_num_dofs = deformable_model_->fem_model(body_index).num_dofs();
+  const VectorX<T>& body_velocity =
+      deformable_velocities.segment(dofs_offset, body_num_dofs);
+  const FemStateBase<T>& state0 = EvalFemStateBase(context, body_index);
+  velocity_newmark_->AdvanceOneTimeStep(state0, body_velocity, fem_state);
 }
 
 template <typename T>

--- a/multibody/fixed_fem/dev/dynamic_elasticity_model.h
+++ b/multibody/fixed_fem/dev/dynamic_elasticity_model.h
@@ -28,14 +28,14 @@ class DynamicElasticityModel : public ElasticityModel<Element> {
   using ConstitutiveModel = typename Element::Traits::ConstitutiveModel;
 
   // TODO(xuchenhan-tri): Currently the time stepping scheme is hard coded to
-  // the mid-point rule. Consider letting the user configure the time stepping
-  // scheme.
+  //  gamma = 1.0 and beta = 0.5. Consider letting the user configure the time
+  //  stepping scheme.
   /** Creates a new %DynamicElasticityModel with the given discrete time step.
    */
   explicit DynamicElasticityModel(double dt)
       : ElasticityModel<Element>(
-            std::make_unique<internal::AccelerationNewmarkScheme<T>>(dt, 0.5,
-                                                                     0.25)) {}
+            std::make_unique<internal::AccelerationNewmarkScheme<T>>(dt, 1.0,
+                                                                     0.5)) {}
 
   ~DynamicElasticityModel() = default;
 

--- a/multibody/fixed_fem/dev/test/deformable_box_test.cc
+++ b/multibody/fixed_fem/dev/test/deformable_box_test.cc
@@ -1,0 +1,188 @@
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/geometry/drake_visualizer.h"
+#include "drake/multibody/contact_solvers/pgs_solver.h"
+#include "drake/multibody/fixed_fem/dev/deformable_model.h"
+#include "drake/multibody/fixed_fem/dev/deformable_rigid_manager.h"
+#include "drake/multibody/fixed_fem/dev/deformable_visualizer.h"
+#include "drake/multibody/fixed_fem/dev/mesh_utilities.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/systems/analysis/simulator.h"
+
+namespace drake {
+namespace multibody {
+namespace fem {
+
+/* Deformable body parameters.  */
+constexpr double kYoungsModulus = 1e5;      // unit: N/m²
+constexpr double kPoissonRatio = 0.4;       // unitless.
+constexpr double kDensity = 1e3;            // unit: kg/m³
+constexpr double kMassDamping = 0;          // unit: 1/s
+constexpr double kStiffnessDamping = 0.01;  // unit: s
+constexpr double kSideLength = 0.1;         // unit: m
+/* Time step (seconds). */
+constexpr double kDt = 5e-3;
+/* Contact parameters. */
+const CoulombFriction kFriction{1.0, 1.0};
+/* PGS solver parameters. */
+/* Absolute tolerance (m/s) *and* relative tolerance (unitless). */
+constexpr double kTolerance = 1e-6;
+constexpr int kMaxIterations = 100;
+constexpr double kRelaxationFactor = 0.8;
+
+using drake::systems::Simulator;
+using Eigen::Vector3d;
+using Eigen::Vector4d;
+using Eigen::VectorXd;
+using geometry::Box;
+using geometry::ProximityProperties;
+using geometry::SceneGraph;
+using math::RigidTransformd;
+using multibody::contact_solvers::internal::ContactSolverResults;
+using multibody::contact_solvers::internal::PgsSolver;
+using systems::Context;
+
+class DeformableRigidContactSolverTest : public ::testing::Test {
+ protected:
+  /* Set up a scene with a deformable cube sitting on the ground. */
+  void SetUp() override {
+    systems::DiagramBuilder<double> builder;
+    std::tie(plant_, scene_graph_) = AddMultibodyPlantSceneGraph(&builder, kDt);
+
+    /* Size of the deformable box. */
+    const Box box = Box::MakeCube(kSideLength);
+
+    /* We set both the deformable box and the ground to be axis-aligned and
+     change gravity to *simulate* a tilted plane. */
+    const Vector3d kGravity(-9.81 * std::sin(M_PI / 6.0), 0,
+                            -9.81 * std::cos(M_PI / 6.0));
+    plant_->mutable_gravity_field().set_gravity_vector(kGravity);
+
+    /* Set up the deformable box. */
+    /* Set the position of the box so that the bottom face aligns with the
+     xy-plane. */
+    const RigidTransformd X_WB(Vector3d(0, 0, kSideLength / 2.0));
+    DeformableBodyConfig<double> box_config;
+    box_config.set_youngs_modulus(kYoungsModulus);
+    box_config.set_poisson_ratio(kPoissonRatio);
+    box_config.set_mass_damping_coefficient(kMassDamping);
+    box_config.set_stiffness_damping_coefficient(kStiffnessDamping);
+    box_config.set_mass_density(kDensity);
+    box_config.set_material_model(MaterialModel::kCorotated);
+    /* Discretize the box into 1x1x1 grid of boxes (2x2x2 vertices). */
+    constexpr int kNumBlocks = 1;
+    const internal::ReferenceDeformableGeometry<double> deformable_box =
+        MakeDiamondCubicBoxDeformableGeometry<double>(
+            box, kSideLength / kNumBlocks, X_WB);
+    geometry::ProximityProperties proximity_props;
+    /* Use default stiffness and dissipation. */
+    geometry::AddContactMaterial({}, {}, {}, kFriction, &proximity_props);
+    /* Use the Corotated constitutive model. */
+    auto deformable_model = std::make_unique<DeformableModel<double>>(plant_);
+    const auto* deformable_model_ptr = deformable_model.get();
+    deformable_index_ = deformable_model->RegisterDeformableBody(
+        deformable_box, "deformable_box", box_config, proximity_props);
+    deformable_model.get();
+    plant_->AddPhysicalModel(std::move(deformable_model));
+
+    constexpr double kRigidSize = 0.5;
+    const RigidTransformd X_WG(Vector3d(0, 0, -kRigidSize / 2));
+    plant_->RegisterCollisionGeometry(plant_->world_body(), X_WG,
+                                      Box::MakeCube(kRigidSize), "ground",
+                                      proximity_props);
+    geometry::IllustrationProperties illustration_props;
+    illustration_props.AddProperty("phong", "diffuse",
+                                   Vector4d(0.1, 0.8, 0.1, 0.25));
+
+    plant_->RegisterVisualGeometry(plant_->world_body(), X_WG,
+                                   Box::MakeCube(kRigidSize), "ground_visual",
+                                   illustration_props);
+    plant_->Finalize();
+
+    /* Connect visualizer. Useful for when this test is used for debugging. */
+    geometry::DrakeVisualizerd::AddToBuilder(&builder, *scene_graph_);
+    std::vector<geometry::VolumeMesh<double>> reference_meshes;
+    for (const internal::ReferenceDeformableGeometry<double>& geometry :
+         deformable_model_ptr->reference_configuration_geometries()) {
+      reference_meshes.emplace_back(geometry.mesh());
+    }
+    auto* visualizer = builder.AddSystem<DeformableVisualizer>(
+        1.0 / 60.0, deformable_model_ptr->names(), reference_meshes);
+    builder.Connect(deformable_model_ptr->get_vertex_positions_output_port(),
+                    visualizer->get_input_port());
+
+    auto pgs_solver = std::make_unique<PgsSolver<double>>();
+    pgs_solver->set_parameters(
+        {kRelaxationFactor, kTolerance, kTolerance, kMaxIterations});
+    auto owned_deformable_rigid_manager =
+        std::make_unique<DeformableRigidManager<double>>(std::move(pgs_solver));
+    deformable_rigid_manager_ = owned_deformable_rigid_manager.get();
+    plant_->SetDiscreteUpdateManager(std::move(owned_deformable_rigid_manager));
+    deformable_rigid_manager_->RegisterCollisionObjects(*scene_graph_);
+
+    diagram_ = builder.Build();
+  }
+
+  /* Calls DeformableRigidManager::EvalFemStateBase(). */
+  const FemStateBase<double>& EvalFemStateBase(
+      const Context<double>& context, DeformableBodyIndex index) const {
+    return deformable_rigid_manager_->EvalFemStateBase(context, index);
+  }
+
+  /* Calls DeformableRigidManager::EvalDeformableContactSolverResults(). */
+  const ContactSolverResults<double>& EvalDeformableContactSolverResults(
+      const Context<double>& context) const {
+    return deformable_rigid_manager_->EvalDeformableContactSolverResults(
+        context);
+  }
+
+  SceneGraph<double>* scene_graph_{nullptr};
+  MultibodyPlant<double>* plant_{nullptr};
+  const DeformableRigidManager<double>* deformable_rigid_manager_{nullptr};
+  DeformableBodyIndex deformable_index_;
+  std::unique_ptr<systems::Diagram<double>> diagram_{nullptr};
+};
+
+namespace {
+
+/* Verify the contact impulse applied by the ground to the deformable box is as
+ expected at steady state. */
+TEST_F(DeformableRigidContactSolverTest, SteadyState) {
+  Simulator<double> simulator(*diagram_);
+  const auto& diagram_context = simulator.get_context();
+  const auto& plant_context = plant_->GetMyContextFromRoot(diagram_context);
+  /* Run simulation for long enough to reach steady state. */
+  simulator.AdvanceTo(0.8);
+
+  /* Verify the system has reached steady state. */
+  const FemStateBase<double>& fem_state =
+      EvalFemStateBase(plant_context, deformable_index_);
+  constexpr double kSteadyStateThreshold = 2e-4;  // unit: m/s.
+  const VectorXd& v = fem_state.qdot();
+  EXPECT_TRUE(
+      CompareMatrices(v, VectorXd::Zero(v.size()), kSteadyStateThreshold));
+  const VectorXd& a = fem_state.qddot();
+  EXPECT_TRUE(CompareMatrices(a, VectorXd::Zero(a.size()),
+                              kSteadyStateThreshold / kDt));
+
+  /* Verify the contact impulse is equal to the contact force times the time
+   step and that the contact force counterbalances gravity. */
+  const ContactSolverResults<double>& deformable_contact_solver_results =
+      EvalDeformableContactSolverResults(plant_context);
+  const VectorXd& tau_contact = deformable_contact_solver_results.tau_contact;
+  Vector3d contact_impulse = Vector3d::Zero();
+  for (int i = 0; i < tau_contact.size() / 3; ++i) {
+    contact_impulse += tau_contact.segment<3>(3 * i);
+  }
+  constexpr double kVolume = kSideLength * kSideLength * kSideLength;
+  const Vector3d expected_contact_force =
+      kVolume * kDensity * (-plant_->gravity_field().gravity_vector());
+  const Vector3d expected_contact_impulse = expected_contact_force * kDt;
+  EXPECT_TRUE(CompareMatrices(expected_contact_impulse, contact_impulse, 1e-5));
+}
+
+}  // namespace
+}  // namespace fem
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
This is the final PR to enable deformable body simulation with two-way coupled rigid contacts in `dev/`.

Update implementation for DeformableRigidManager::DoCalcDiscreteValues() to account for deformable bodies that are in contact. In addition, add an integration test that tests the integration of the deformable solver and the contact solver.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15661)
<!-- Reviewable:end -->
