### PR TITLE
[lcm] added missing <stdexcept> include 

### DIFF
--- a/lcm/lcm_messages.h
+++ b/lcm/lcm_messages.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <cstdint>
-#include <vector>
 #include <stdexcept>
+#include <vector>
 
 #include "drake/common/drake_throw.h"
 #include "drake/common/nice_type_name.h"


### PR DESCRIPTION
resulting in error: 'runtime_error' is not a member of 'std' (seen on WSL ubuntu 18.04 g++10.3)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15668)
<!-- Reviewable:end -->
