### PR TITLE
detail_sdf_parser: Add 2021-12-01 removal date for unrecognized elements

### DIFF
--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -1274,8 +1274,8 @@ sdf::ParserConfig CreateNewSdfParserConfig(
   sdf::ParserConfig parser_config;
   parser_config.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   parser_config.SetDeprecatedElementsPolicy(sdf::EnforcementPolicy::WARN);
-  // TODO(#15018): Later, we should change unrecognized elements policy to
-  // become an error.
+  // TODO(#15018): Change unrecognized elements policy to become an error on
+  // or after 2021-12-01.
   parser_config.SetUnrecognizedElementsPolicy(sdf::EnforcementPolicy::WARN);
   parser_config.SetFindCallback(
     [=](const std::string &_input) {


### PR DESCRIPTION
Towards #15018
Follow-up for #15317

Applying deprecation date to landing of this PR.
If this does not merge in August, then date should be shifted back.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15672)
<!-- Reviewable:end -->
