### PR TITLE
Enable copy/deepcopy for SpatialInertia

### DIFF
--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -571,6 +571,7 @@ class TestPlant(unittest.TestCase):
             mass=2.5, p_PScm_E=[0.1, -0.2, 0.3],
             G_SP_E=UnitInertia(Ixx=2.0, Iyy=2.3, Izz=2.4))
         numpy_compare.assert_float_equal(spatial_inertia.get_mass(), 2.5)
+        copied_inertia = copy.deepcopy(spatial_inertia)
         self.assertIsInstance(spatial_inertia.get_com(), np.ndarray)
         self.assertIsInstance(spatial_inertia.CalcComMoment(), np.ndarray)
         self.assertIsInstance(spatial_inertia.get_unit_inertia(), UnitInertia)

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -995,6 +995,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def(py::self += py::self)
         .def(py::self * SpatialAcceleration<T>())
         .def(py::self * SpatialVelocity<T>());
+    DefCopyAndDeepCopy(&cls);
   }
   // NOLINTNEXTLINE(readability/fn_size)
 }


### PR DESCRIPTION
@EricCousineau-TRI or @jwnimmer-tri (or other interested parties)  I think this is a trivial addition, but maybe there's a deeper story I don't know about? Would either of you mind taking a look?

Edit: (The objective here is to be able to deepcopy an object containing a SpatialInertia. My original version of this wanted to get pickling too, but I think that's an additional set of bindings that are less standard and I don't really need to add.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15676)
<!-- Reviewable:end -->
