### PR TITLE
Fix bug in meshcat contact force visualization.

### DIFF
--- a/bindings/pydrake/systems/meshcat_visualizer.py
+++ b/bindings/pydrake/systems/meshcat_visualizer.py
@@ -617,9 +617,10 @@ class MeshcatContactVisualizer(LeafSystem):
                 f = contact_info.contact_force() / force_norm
                 axis = np.cross(y, f)
                 angle = np.arccos(y.dot(f))
-                if abs(angle) < 1e-3:
-                    # Practical guess for useful tolerance. Angles smaller than
-                    # 1e-3 rad should be invisible for visualization purposes.
+                # Practical guess for useful tolerance. Angles smaller than
+                # 1e-3 rad should be invisible for visualization purposes.
+                tol = 1e-3
+                if angle < 1e-3 or (np.pi - angle) < tol:
                     X_CGeom = np.eye(4)
                 else:
                     X_CGeom = tf.rotation_matrix(angle, axis)

--- a/bindings/pydrake/systems/meshcat_visualizer.py
+++ b/bindings/pydrake/systems/meshcat_visualizer.py
@@ -620,7 +620,7 @@ class MeshcatContactVisualizer(LeafSystem):
                 # Practical guess for useful tolerance. Angles smaller than
                 # 1e-3 rad should be invisible for visualization purposes.
                 tol = 1e-3
-                if angle < 1e-3 or (np.pi - angle) < tol:
+                if angle < tol or (np.pi - angle) < tol:
                     X_CGeom = np.eye(4)
                 else:
                     X_CGeom = tf.rotation_matrix(angle, axis)

--- a/bindings/pydrake/systems/meshcat_visualizer.py
+++ b/bindings/pydrake/systems/meshcat_visualizer.py
@@ -616,7 +616,7 @@ class MeshcatContactVisualizer(LeafSystem):
                 y = np.array([0, 1, 0])
                 f = contact_info.contact_force() / force_norm
                 axis = np.cross(y, f)
-                angle = np.arccos(y @ f)
+                angle = np.arccos(y.dot(f))
                 X_CGeom = tf.rotation_matrix(angle, axis)
             X_WC = tf.translation_matrix(contact_info.contact_point())
             cvis.set_transform(X_WC @ X_CGeom)

--- a/bindings/pydrake/systems/meshcat_visualizer.py
+++ b/bindings/pydrake/systems/meshcat_visualizer.py
@@ -613,10 +613,11 @@ class MeshcatContactVisualizer(LeafSystem):
                 X_CGeom = tf.identity_matrix()
             else:
                 # Rotates [0,1,0] to contact_force/force_norm.
-                angle_axis = np.cross(np.array([0, 1, 0]),
-                                      contact_info.contact_force()/force_norm)
-                X_CGeom = tf.rotation_matrix(
-                    np.arcsin(np.linalg.norm(angle_axis)), angle_axis)
+                y = np.array([0, 1, 0])
+                f = contact_info.contact_force() / force_norm
+                axis = np.cross(y, f)
+                angle = np.arccos(y @ f)
+                X_CGeom = tf.rotation_matrix(angle, axis)
             X_WC = tf.translation_matrix(contact_info.contact_point())
             cvis.set_transform(X_WC @ X_CGeom)
 

--- a/bindings/pydrake/systems/meshcat_visualizer.py
+++ b/bindings/pydrake/systems/meshcat_visualizer.py
@@ -618,6 +618,8 @@ class MeshcatContactVisualizer(LeafSystem):
                 axis = np.cross(y, f)
                 angle = np.arccos(y.dot(f))
                 if abs(angle) < 1e-3:
+                    # Practical guess for useful tolerance. Angles smaller than
+                    # 1e-3 rad should be invisible for visualization purposes.
                     X_CGeom = np.eye(4)
                 else:
                     X_CGeom = tf.rotation_matrix(angle, axis)

--- a/bindings/pydrake/systems/meshcat_visualizer.py
+++ b/bindings/pydrake/systems/meshcat_visualizer.py
@@ -617,7 +617,10 @@ class MeshcatContactVisualizer(LeafSystem):
                 f = contact_info.contact_force() / force_norm
                 axis = np.cross(y, f)
                 angle = np.arccos(y.dot(f))
-                X_CGeom = tf.rotation_matrix(angle, axis)
+                if abs(angle) < 1e-3:
+                    X_CGeom = np.eye(4)
+                else:
+                    X_CGeom = tf.rotation_matrix(angle, axis)
             X_WC = tf.translation_matrix(contact_info.contact_point())
             cvis.set_transform(X_WC @ X_CGeom)
 


### PR DESCRIPTION
The current implementation only rotates the force cylinder by up to pi/2, which leads to wrong contact force directions when the rotation needed is more than pi/2. The fix allows rotation up to pi.

@EricCousineau-TRI could you assign a reviewer for this PR? Thanks! 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15677)
<!-- Reviewable:end -->
