### PR TITLE
detail_sdf_parser: Shift date (error on bad elements) back to 2022-01-01

### DIFF
--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -1275,7 +1275,7 @@ sdf::ParserConfig CreateNewSdfParserConfig(
   parser_config.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
   parser_config.SetDeprecatedElementsPolicy(sdf::EnforcementPolicy::WARN);
   // TODO(#15018): Change unrecognized elements policy to become an error on
-  // or after 2021-12-01.
+  // or after 2022-01-01.
   parser_config.SetUnrecognizedElementsPolicy(sdf::EnforcementPolicy::WARN);
   parser_config.SetFindCallback(
     [=](const std::string &_input) {


### PR DESCRIPTION
Follow-up to #15672, per Slack discussion: https://drakedevelopers.slack.com/archives/C0JNB2E3S/p1630161461003200?thread_ts=1630095607.003100&cid=C0JNB2E3S

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15680)
<!-- Reviewable:end -->
