### PR TITLE
Add rotation constraint python bindings to solvers.all

### DIFF
--- a/bindings/pydrake/solvers/all.py
+++ b/bindings/pydrake/solvers/all.py
@@ -9,6 +9,7 @@ from .dreal import *
 from .gurobi import *  # noqa
 from .ipopt import *  # noqa
 from .mixed_integer_optimization_util import *  # noqa
+from .mixed_integer_rotation_constraint import *  # noqa
 from .mosek import *  # noqa
 from .osqp import *  # noqa
 from .sdpa_free_format import *  # noqa


### PR DESCRIPTION
Forgot to include this little bit in #15678.