### PR TITLE
[geometry] Binding proximty_properties.h

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -480,6 +480,7 @@ drake_py_unittest(
     deps = [
         ":geometry_py",
         "//bindings/pydrake/common/test_utilities",
+        "//bindings/pydrake/multibody:plant_py",
         "//bindings/pydrake/solvers:mathematicalprogram_py",
         "//bindings/pydrake/systems:analysis_py",
         "//bindings/pydrake/systems:sensors_py",

--- a/geometry/proximity_properties.cc
+++ b/geometry/proximity_properties.cc
@@ -13,7 +13,7 @@ const char* const kPointStiffness = "point_contact_stiffness";
 const char* const kHydroGroup = "hydroelastic";
 const char* const kRezHint = "resolution_hint";
 const char* const kComplianceType = "compliance_type";
-const char* const  kSlabThickness = "slab_thickness";
+const char* const kSlabThickness = "slab_thickness";
 
 std::ostream& operator<<(std::ostream& out, const HydroelasticType& type) {
   switch (type) {


### PR DESCRIPTION
A number of useful utility functions for setting proximity properties had been omitted from binding. This adds them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15689)
<!-- Reviewable:end -->
