### PR TITLE
multibody plant: Fix TAMSI threading hazard

### DIFF
--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -1757,17 +1757,6 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   /// @throws std::exception if `v_stiction` is non-positive.
   void set_stiction_tolerance(double v_stiction = 0.001) {
     friction_model_.set_stiction_tolerance(v_stiction);
-    // We allow calling this method post-finalize. Therefore, if the plant is
-    // modeled as a discrete system, we must update the solver's stiction
-    // parameter. Pre-Finalize the solver is not yet created and therefore we
-    // check for nullptr.
-    if (is_discrete() && tamsi_solver_ != nullptr) {
-      TamsiSolverParameters solver_parameters =
-          tamsi_solver_->get_solver_parameters();
-      solver_parameters.stiction_tolerance =
-          friction_model_.stiction_tolerance();
-      tamsi_solver_->set_solver_parameters(solver_parameters);
-    }
   }
   /// @} <!-- Contact modeling -->
 
@@ -4026,6 +4015,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     systems::CacheIndex point_pairs;
     systems::CacheIndex spatial_contact_forces_continuous;
     systems::CacheIndex contact_solver_results;
+    systems::CacheIndex contact_solver_scratch;
     systems::CacheIndex discrete_contact_pairs;
     systems::CacheIndex joint_locking_data;
   };
@@ -4229,6 +4219,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // During the time span dt the problem data M, Jn, Jt and minus_tau, are
   // approximated to be constant, a first order approximation.
   TamsiSolverResult SolveUsingSubStepping(
+      TamsiSolver<T>* tamsi_solver,
       int num_substeps, const MatrixX<T>& M0, const MatrixX<T>& Jn,
       const MatrixX<T>& Jt, const VectorX<T>& minus_tau,
       const VectorX<T>& stiffness, const VectorX<T>& damping,
@@ -4633,6 +4624,7 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // Helper to invoke our TamsiSolver. This method and `CallContactSolver()` are
   // disjoint methods. One should only use one or the other, but not both.
   void CallTamsiSolver(
+      TamsiSolver<T>* tamsi_solver,
       const T& time0, const VectorX<T>& v0, const MatrixX<T>& M0,
       const VectorX<T>& minus_tau, const VectorX<T>& fn0, const MatrixX<T>& Jn,
       const MatrixX<T>& Jt, const VectorX<T>& stiffness,
@@ -4869,9 +4861,6 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // time_step_ corresponds to the period of those updates. Otherwise, if the
   // plant is modeled as a continuous system, it is exactly zero.
   double time_step_{0};
-
-  // The solver used when the plant is modeled as a discrete system.
-  std::unique_ptr<TamsiSolver<T>> tamsi_solver_;
 
   // TODO(xuchenhan-tri): Entirely remove the contact_solver_ back door by the
   // newer design using DiscreteUpdateManager. When not the nullptr, this is the

--- a/multibody/plant/tamsi_solver.h
+++ b/multibody/plant/tamsi_solver.h
@@ -514,8 +514,6 @@ class TamsiSolver {
   /// Change the working size of the solver to use `nv` generalized
   /// velocities. This can be used to either shrink or grow the workspaces.
   /// @throws std::exception if nv is non-positive.
-  // TODO(#15674): this method is a stop-gap until proper thread-safe handling
-  // of workspaces is implemented.
   void ResizeIfNeeded(int nv) const {
     DRAKE_THROW_UNLESS(nv > 0);
     if (nv != nv_) {
@@ -523,6 +521,22 @@ class TamsiSolver {
       fixed_size_workspace_ = FixedSizeWorkspace(nv);
       variable_size_workspace_ = VariableSizeWorkspace(128, nv);
     }
+  }
+
+  /// @returns a deep copy of this, with the problem data invalidated, i.e., one
+  /// of the Set*ProblemData() methods must be called on the clone before it
+  /// can be used to solve.
+  std::unique_ptr<TamsiSolver<T>> Clone() const {
+    auto result = std::make_unique<TamsiSolver<T>>(nv_);
+    // Don't copy the aliases; just wipe them.
+    result->problem_data_aliases_.Invalidate();
+    result->nc_ = nc_;
+    result->parameters_ = parameters_;
+    result->fixed_size_workspace_ = fixed_size_workspace_;
+    result->variable_size_workspace_ = variable_size_workspace_;
+    result->cos_theta_max_ = cos_theta_max_;
+    result->statistics_ = statistics_;
+    return result;
   }
 
   // TODO(amcastro-tri): submit a separate reformat PR changing /// by /**.
@@ -786,16 +800,44 @@ class TamsiSolver {
       mu_ptr_ = mu;
     }
 
+    // Clears references to any problem-defining data. One of the Set*Data()
+    // methods must be called to provide new references before any of the
+    // problem data accessors can be used again.
+    void Invalidate() {
+      coupling_scheme_ = kInvalidScheme;
+      M_ptr_ = nullptr;
+      Jn_ptr_ = nullptr;
+      Jt_ptr_ = nullptr;
+      p_star_ptr_ = nullptr;
+      fn_ptr_ = nullptr;
+      fn0_ptr_ = nullptr;
+      stiffness_ptr_ = nullptr;
+      dissipation_ptr_ = nullptr;
+      mu_ptr_ = nullptr;
+    }
+
     // Returns true if this class contains the data for a two-way coupled
     // problem.
     bool has_two_way_coupling_data() const {
       return coupling_scheme_ == kTwoWayCoupled;
     }
 
-    Eigen::Ref<const MatrixX<T>> M() const { return *M_ptr_; }
-    Eigen::Ref<const MatrixX<T>> Jn() const { return *Jn_ptr_; }
-    Eigen::Ref<const MatrixX<T>> Jt() const { return *Jt_ptr_; }
-    Eigen::Ref<const VectorX<T>> p_star() const { return *p_star_ptr_; }
+    Eigen::Ref<const MatrixX<T>> M() const {
+      DRAKE_ASSERT_VOID(DemandValid());
+      return *M_ptr_;
+    }
+    Eigen::Ref<const MatrixX<T>> Jn() const {
+      DRAKE_ASSERT_VOID(DemandValid());
+      return *Jn_ptr_;
+    }
+    Eigen::Ref<const MatrixX<T>> Jt() const {
+      DRAKE_ASSERT_VOID(DemandValid());
+      return *Jt_ptr_;
+    }
+    Eigen::Ref<const VectorX<T>> p_star() const {
+      DRAKE_ASSERT_VOID(DemandValid());
+      return *p_star_ptr_;
+    }
 
     // For the one-way coupled scheme, it returns a constant reference to the
     // data for the normal forces. It aborts if called on data for the two-way
@@ -830,6 +872,7 @@ class TamsiSolver {
     }
 
     Eigen::Ref<const VectorX<T>> mu() const {
+      DRAKE_ASSERT_VOID(DemandValid());
       return *mu_ptr_;
     }
 
@@ -839,6 +882,10 @@ class TamsiSolver {
       kOneWayCoupled,
       kTwoWayCoupled
     } coupling_scheme_{kInvalidScheme};
+
+    void DemandValid() const {
+      DRAKE_DEMAND(coupling_scheme_ != kInvalidScheme);
+    }
 
     // The mass matrix of the system.
     EigenPtr<const MatrixX<T>> M_ptr_{nullptr};


### PR DESCRIPTION
Closes: #15674

The storage of the TamsiSolver as member data created a thread-race hazard for
context-per-thread usage. Instead, store the solver (via shared_ptr) in a
scratch cache entry. Reorganize transmission of stiction_tolerance to be
maximally lazy, in part to avoid the absence of context access where it used to
be transmitted.

The patch also adds some minimal test coverage for context-per-thread usage in
both discrete and continuous modes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15690)
<!-- Reviewable:end -->
