### PR TITLE
Python binding for CalcJacobianCenterOfMassTranslationalVelocity() with model_instances.

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -335,6 +335,22 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("context"), py::arg("with_respect_to"), py::arg("frame_A"),
             py::arg("frame_E"),
             cls_doc.CalcJacobianCenterOfMassTranslationalVelocity.doc_5args)
+        .def(
+            "CalcJacobianCenterOfMassTranslationalVelocity",
+            [](const Class* self, const Context<T>& context,
+                const std::vector<ModelInstanceIndex>& model_instances,
+                JacobianWrtVariable with_respect_to, const Frame<T>& frame_A,
+                const Frame<T>& frame_E) {
+              Matrix3X<T> Js_v_ACcm_E(
+                  3, GetVariableSize<T>(*self, with_respect_to));
+              self->CalcJacobianCenterOfMassTranslationalVelocity(context,
+                  model_instances, with_respect_to, frame_A, frame_E,
+                  &Js_v_ACcm_E);
+              return Js_v_ACcm_E;
+            },
+            py::arg("context"), py::arg("model_instances"),
+            py::arg("with_respect_to"), py::arg("frame_A"), py::arg("frame_E"),
+            cls_doc.CalcJacobianCenterOfMassTranslationalVelocity.doc_6args)
         .def("GetFreeBodyPose", &Class::GetFreeBodyPose, py::arg("context"),
             py::arg("body"), cls_doc.GetFreeBodyPose.doc)
         .def("SetFreeBodyPose",

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -808,6 +808,12 @@ class TestPlant(unittest.TestCase):
             self.assert_sane(Js_v_ACcm_E)
             self.assertEqual(Js_v_ACcm_E.shape, (3, nw))
 
+            Js_v_ACcm_E = plant.CalcJacobianCenterOfMassTranslationalVelocity(
+                context=context, model_instances=[instance],
+                with_respect_to=wrt, frame_A=base_frame, frame_E=world_frame)
+            self.assert_sane(Js_v_ACcm_E)
+            self.assertEqual(Js_v_ACcm_E.shape, (3, nw))
+
             Js_V_ABp_E = plant.CalcJacobianSpatialVelocity(
                 context=context, with_respect_to=wrt, frame_B=base_frame,
                 p_BP=np.zeros(3), frame_A=world_frame,


### PR DESCRIPTION
Resolves issue #14916 by adding Python binding for new variant of method
MultibodyPlant::CalcJacobianCenterOfMassTranslationalVelocity() which was merged with PR #15387.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15691)
<!-- Reviewable:end -->
