### PR TITLE
Deprecate the Transform specializations of Discard[Zero]Gradient()

### DIFF
--- a/math/autodiff.h
+++ b/math/autodiff.h
@@ -70,8 +70,10 @@ DiscardGradient(const Eigen::MatrixBase<Derived>& matrix) {
   return matrix;
 }
 
-/// @see DiscardGradient().
 template <typename _Scalar, int _Dim, int _Mode, int _Options>
+DRAKE_DEPRECATED("2021-12-01",
+    "Apparently unused. File a Drake issue on GitHub"
+    " if you need this specialization.")
 typename std::enable_if_t<
     !std::is_same_v<_Scalar, double>,
     Eigen::Transform<typename _Scalar::Scalar, _Dim, _Mode, _Options>>
@@ -81,8 +83,10 @@ DiscardGradient(const Eigen::Transform<_Scalar, _Dim, _Mode, _Options>&
       autoDiffToValueMatrix(auto_diff_transform.matrix()));
 }
 
-/// @see DiscardGradient().
 template <typename _Scalar, int _Dim, int _Mode, int _Options>
+DRAKE_DEPRECATED("2021-12-01",
+    "Apparently unused. File a Drake issue on GitHub"
+    " if you need this specialization.")
 typename std::enable_if_t<std::is_same_v<_Scalar, double>,
                           const Eigen::Transform<_Scalar, _Dim, _Mode,
     _Options>&>

--- a/math/autodiff_gradient.h
+++ b/math/autodiff_gradient.h
@@ -188,8 +188,10 @@ DiscardZeroGradient(const Eigen::MatrixBase<Derived>& matrix,
   return matrix;
 }
 
-/// @see DiscardZeroGradient().
 template <typename _Scalar, int _Dim, int _Mode, int _Options>
+DRAKE_DEPRECATED("2021-12-01",
+    "Apparently unused. File a Drake issue on GitHub"
+    " if you need this specialization.")
 typename std::enable_if_t<
     !std::is_same_v<_Scalar, double>,
     Eigen::Transform<typename _Scalar::Scalar, _Dim, _Mode, _Options>>
@@ -201,8 +203,10 @@ DiscardZeroGradient(
       DiscardZeroGradient(auto_diff_transform.matrix(), precision));
 }
 
-/// @see DiscardZeroGradient().
 template <typename _Scalar, int _Dim, int _Mode, int _Options>
+DRAKE_DEPRECATED("2021-12-01",
+    "Apparently unused. File a Drake issue on GitHub"
+    " if you need this specialization.")
 typename std::enable_if_t<
     std::is_same_v<_Scalar, double>,
     const Eigen::Transform<_Scalar, _Dim, _Mode, _Options>&>

--- a/math/test/autodiff_test.cc
+++ b/math/test/autodiff_test.cc
@@ -129,6 +129,8 @@ GTEST_TEST(AdditionalAutodiffTest, DiscardGradient) {
   Eigen::Vector3d test3out = DiscardGradient(test3);
   EXPECT_TRUE(CompareMatrices(test3out, test2));
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   Eigen::Isometry3d test5 = Eigen::Isometry3d::Identity();
   EXPECT_TRUE(CompareMatrices(DiscardGradient(test5).linear(), test5.linear()));
   EXPECT_TRUE(CompareMatrices(DiscardGradient(test5).translation(),
@@ -140,6 +142,7 @@ GTEST_TEST(AdditionalAutodiffTest, DiscardGradient) {
   EXPECT_TRUE(CompareMatrices(test6b.linear(), Eigen::Matrix3d::Identity()));
   EXPECT_TRUE(
       CompareMatrices(test6b.translation(), Eigen::Vector3d{3., 2., 1.}));
+#pragma GCC diagnostic pop
 }
 
 GTEST_TEST(AdditionalAutodiffTest, DiscardZeroGradient) {
@@ -171,6 +174,8 @@ GTEST_TEST(AdditionalAutodiffTest, DiscardZeroGradient) {
   EXPECT_THROW(DiscardZeroGradient(test3), std::runtime_error);
   DRAKE_EXPECT_NO_THROW(DiscardZeroGradient(test3, 2.));
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   Eigen::Isometry3d test5 = Eigen::Isometry3d::Identity();
   DRAKE_EXPECT_NO_THROW(DiscardZeroGradient(test5));
   EXPECT_TRUE(
@@ -190,6 +195,7 @@ GTEST_TEST(AdditionalAutodiffTest, DiscardZeroGradient) {
   test6.linear()(0, 0).derivatives() = Vector3d{1., 2., 3.};
 
   EXPECT_THROW(DiscardZeroGradient(test6), std::runtime_error);
+#pragma GCC diagnostic pop
 }
 
 // Make sure that casting to autodiff always results in zero gradients.


### PR DESCRIPTION
Deprecates `Eigen::Transform` specializations of autodiff utilities `DiscardGradient()` and `DiscardZeroGradient()`. These are not needed now since we switched (long ago) to `drake::RigidTransform`. See discussion in #15604 starting [here](https://github.com/RobotLocomotion/drake/issues/15604#issuecomment-908807843).