### PR TITLE
[common] Always allow caller clean up directory from temp_directory()

### DIFF
--- a/bindings/pydrake/common/test/module_test.py
+++ b/bindings/pydrake/common/test/module_test.py
@@ -33,9 +33,13 @@ class TestCommon(unittest.TestCase):
             'drake/examples/atlas/urdf/atlas_convex_hull.urdf'
             )
 
-    def test_temp_directory(self):
-        self.assertEqual(os.environ.get('TEST_TMPDIR'),
-                         mut.temp_directory())
+    def test_test_temp_directory(self):
+        temp_dir = mut.temp_directory()
+        # We'll simply confirm that the path *starts* with the TEST_TMPDIR and
+        # that it exists. We'll assume that it otherwise has the documented
+        # properties.
+        self.assertTrue(temp_dir.startswith(os.environ.get('TEST_TMPDIR')))
+        self.assertTrue(os.path.exists(temp_dir))
 
     def test_tolerance_type(self):
         # Simply test the spelling

--- a/common/temp_directory.cc
+++ b/common/temp_directory.cc
@@ -12,32 +12,24 @@ namespace drake {
 std::string temp_directory() {
   filesystem::path path;
 
-  const char* test_tmpdir = std::getenv("TEST_TMPDIR");
+  const char* tmpdir = nullptr;
+  (tmpdir = std::getenv("TEST_TMPDIR")) || (tmpdir = std::getenv("TMPDIR")) ||
+      (tmpdir = "/tmp");
 
-  if (test_tmpdir == nullptr) {
-    const char* tmpdir = nullptr;
-    (tmpdir = std::getenv("TMPDIR")) || (tmpdir = "/tmp");
+  filesystem::path path_template(tmpdir);
+  path_template.append("robotlocomotion_drake_XXXXXX");
 
-    filesystem::path path_template(tmpdir);
-    path_template.append("robotlocomotion_drake_XXXXXX");
+  std::string path_template_str = path_template.string();
+  const char* dtemp = ::mkdtemp(&path_template_str[0]);
+  DRAKE_THROW_UNLESS(dtemp != nullptr);
 
-    std::string path_template_str = path_template.string();
-    const char* dtemp = ::mkdtemp(&path_template_str[0]);
-    DRAKE_THROW_UNLESS(dtemp != nullptr);
-
-    path = dtemp;
-  } else {
-    path = test_tmpdir;
-  }
+  path = dtemp;
 
   DRAKE_THROW_UNLESS(filesystem::is_directory(path));
+  std::string path_string = path.string();
+  DRAKE_DEMAND(path_string.back() != '/');
 
-  // Strip any trailing /.
-  std::string result = path.string();
-  if (result.back() == '/') {
-    result.pop_back();
-  }
-  return result;
+  return path_string;
 }
 
 }  // namespace drake

--- a/common/temp_directory.h
+++ b/common/temp_directory.h
@@ -5,13 +5,23 @@
 namespace drake {
 
 /// Returns a directory location suitable for temporary files.
-/// @return The value of the environment variable TEST_TMPDIR if defined or
-/// otherwise ${TMPDIR:-/tmp}/robotlocomotion_drake_XXXXXX where each X is
-/// replaced by a character from the portable filename character set. Any
-/// trailing / will be stripped from the output.
-/// @throws std::exception If the path referred to by TEST_TMPDIR or
-/// ${TMPDIR:-/tmp}/robotlocomotion_drake_XXXXXX cannot be created, does not
-/// exist, or is not a directory.
+/// The directory will be called ${parent}/robotlocomotion_drake_XXXXXX where
+/// each X is replaced by a character from the portable filename character set.
+/// The path ${parent} is defined as one of the following (in decreasing
+/// priority):
+///
+///    - ${TEST_TMPDIR}
+///    - ${TMPDIR}
+///    - /tmp
+///
+/// If successful, this will always create a new directory. While the caller is
+/// not obliged to delete the directory, it has full power to do so based on
+/// specific context and need.
+///
+/// @return The path representing a newly created directory There will be no
+///         trailing `/`.
+/// @throws if the directory ${parent}/robotlocomotion_drake_XXXXXX cannot be
+///         created, or is not a directory.
 std::string temp_directory();
 
 }  // namespace drake

--- a/common/test/temp_directory_test.cc
+++ b/common/test/temp_directory_test.cc
@@ -18,7 +18,10 @@ GTEST_TEST(TempDirectoryTest, TestTmpdirSet) {
 
   const std::string temp_directory_with_test_tmpdir_set = temp_directory();
   EXPECT_NE('/', temp_directory_with_test_tmpdir_set.back());
-  EXPECT_EQ(std::string(test_tmpdir), temp_directory_with_test_tmpdir_set);
+  filesystem::path temp_path(temp_directory_with_test_tmpdir_set);
+  EXPECT_EQ(std::string(test_tmpdir), temp_path.parent_path().string());
+  EXPECT_THAT(temp_path.filename().string(),
+              testing::MatchesRegex("robotlocomotion_drake_[^/]{6}$"));
 }
 
 GTEST_TEST(TempDirectoryTest, TestTmpdirUnset) {


### PR DESCRIPTION
Modify temp_directory so the caller can always clean up.

For code that creates a temporary working directory, this cleans up the ambiguity of whether or not it is able to delete that directory. Now it can *always* clean up (modulo catastrophic system failures).

Updates the tests that confirm the behavior when `TEST_TMPDIR` is set.

resolves #15696

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15698)
<!-- Reviewable:end -->
