### PR TITLE
Provide GSG-compatible signatures for autodiff utilities

### DIFF
--- a/bindings/pydrake/_autodiffutils_extra.py
+++ b/bindings/pydrake/_autodiffutils_extra.py
@@ -4,7 +4,7 @@
 import numpy as np
 
 
-def initializeAutoDiffTuple(*args):
+def InitializeAutoDiffTuple(*args):
     """Given a series of array_like input arguments, create a tuple of
     corresponding AutoDiff matrices with values equal to the input matrices
     and properly initialized derivative vectors.
@@ -19,7 +19,7 @@ def initializeAutoDiffTuple(*args):
     elements of the first input argument (traversed first by row, then by
     column), and so on for subsequent arguments.
 
-    This is a pythonic implementation of drake::math::initializeAutoDiffTuple
+    This is a pythonic implementation of drake::math::InitializeAutoDiffTuple
     in C++.
     """
 
@@ -30,12 +30,16 @@ def initializeAutoDiffTuple(*args):
     autodiff_tuple = []
     deriv_num_start = 0
     for arg in args:
-        autodiff_tuple.append(initializeAutoDiff(arg,
+        autodiff_tuple.append(InitializeAutoDiff(arg,
                                                  num_derivatives,
                                                  deriv_num_start))
         deriv_num_start += np.asarray(arg).size
 
     return tuple(autodiff_tuple)
+
+
+# TODO(sherm1) To be deprecated asap.
+initializeAutoDiffTuple = InitializeAutoDiffTuple
 
 
 @np.vectorize

--- a/bindings/pydrake/autodiffutils_py.cc
+++ b/bindings/pydrake/autodiffutils_py.cc
@@ -107,13 +107,46 @@ PYBIND11_MODULE(autodiffutils, m) {
   autodiff.attr("arctan2") = autodiff.attr("atan2");
 
   m.def(
+      "InitializeAutoDiff",
+      [](const Eigen::MatrixXd& value, Eigen::DenseIndex num_derivatives,
+          Eigen::DenseIndex deriv_num_start) {
+        return InitializeAutoDiff(value, num_derivatives, deriv_num_start);
+      },
+      py::arg("value"), py::arg("num_derivatives") = std::nullopt,
+      py::arg("deriv_num_start") = std::nullopt,
+      doc.InitializeAutoDiff.doc_just_value);
+
+  m.def(
+      "ExtractValue",
+      [](const MatrixX<AutoDiffXd>& auto_diff_matrix) {
+        return ExtractValue(auto_diff_matrix);
+      },
+      py::arg("auto_diff_matrix"), doc.ExtractValue.doc);
+
+  m.def(
+      "ExtractGradient",
+      [](const MatrixX<AutoDiffXd>& auto_diff_matrix) {
+        return ExtractGradient(auto_diff_matrix);
+      },
+      py::arg("auto_diff_matrix"), doc.ExtractGradient.doc);
+
+  m.def(
+      "InitializeAutoDiff",
+      [](const Eigen::VectorXd& value, const Eigen::MatrixXd& gradient) {
+        return InitializeAutoDiff(value, gradient);
+      },
+      py::arg("value"), py::arg("gradient"),
+      doc.InitializeAutoDiff.doc_value_and_gradient);
+
+  // TODO(sherm1) To be deprecated asap.
+  m.def(
       "initializeAutoDiff",
       [](const Eigen::MatrixXd& mat, Eigen::DenseIndex num_derivatives,
           Eigen::DenseIndex deriv_num_start) {
         return initializeAutoDiff(mat, num_derivatives, deriv_num_start);
       },
       py::arg("mat"), py::arg("num_derivatives") = -1,
-      py::arg("deriv_num_start") = 0, doc.initializeAutoDiff.doc_3args);
+      py::arg("deriv_num_start") = 0, doc.initializeAutoDiff.doc);
 
   m.def(
       "autoDiffToValueMatrix",
@@ -135,7 +168,7 @@ PYBIND11_MODULE(autodiffutils, m) {
         return initializeAutoDiffGivenGradientMatrix(val, gradient);
       },
       py::arg("val"), py::arg("gradient"),
-      doc.initializeAutoDiffGivenGradientMatrix.doc_2args);
+      doc.initializeAutoDiffGivenGradientMatrix.doc);
 
   ExecuteExtraPythonCode(m);
 }

--- a/bindings/pydrake/test/autodiffutils_test.py
+++ b/bindings/pydrake/test/autodiffutils_test.py
@@ -1,8 +1,17 @@
 import pydrake.autodiffutils as mut
+
+from pydrake.autodiffutils import (
+    AutoDiffXd,
+    ExtractGradient,
+    ExtractValue,
+    InitializeAutoDiff,
+    InitializeAutoDiffTuple,
+)
+
+# TODO(sherm1) To be deprecated asap.
 from pydrake.autodiffutils import (
     autoDiffToGradientMatrix,
     autoDiffToValueMatrix,
-    AutoDiffXd,
     initializeAutoDiff,
     initializeAutoDiffGivenGradientMatrix,
     initializeAutoDiffTuple,
@@ -237,6 +246,32 @@ class TestAutoDiffXd(unittest.TestCase):
         np.testing.assert_equal(numpy_compare.to_float(Xinv), Xinv_float)
 
     def test_math_utils(self):
+        a = InitializeAutoDiff(value=[1, 2, 3], num_derivatives=3,
+                               deriv_num_start=0)
+        np.testing.assert_array_equal(ExtractValue(auto_diff_matrix=a),
+                                      np.array([[1, 2, 3]]).T)
+        np.testing.assert_array_equal(ExtractGradient(auto_diff_matrix=a),
+                                      np.eye(3))
+
+        a, b = InitializeAutoDiffTuple([1], [2, 3])
+        np.testing.assert_array_equal(ExtractValue(a),
+                                      np.array([[1]]))
+        np.testing.assert_array_equal(ExtractValue(b),
+                                      np.array([[2, 3]]).T)
+        np.testing.assert_array_equal(ExtractGradient(a),
+                                      np.eye(1, 3))
+        np.testing.assert_array_equal(ExtractGradient(b),
+                                      np.hstack((np.zeros((2, 1)), np.eye(2))))
+
+        c_grad = [[2, 4, 5], [1, -1, 0]]
+        c = InitializeAutoDiff(value=[2, 3], gradient=c_grad)
+        np.testing.assert_array_equal(ExtractValue(c),
+                                      np.array([2, 3]).reshape((2, 1)))
+        np.testing.assert_array_equal(ExtractGradient(c),
+                                      np.array(c_grad))
+
+    # TODO(sherm1) To be deprecated asap.
+    def test_deprecated_math_utils(self):
         a = initializeAutoDiff([1, 2, 3])
         np.testing.assert_array_equal(autoDiffToValueMatrix(a),
                                       np.array([[1, 2, 3]]).T)

--- a/common/autodiff_overloads.h
+++ b/common/autodiff_overloads.h
@@ -155,6 +155,7 @@ namespace drake {
 
 /// Returns the autodiff scalar's value() as a double.  Never throws.
 /// Overloads ExtractDoubleOrThrow from common/extract_double.h.
+/// @see math::ExtractValue(), math::DiscardGradient()
 template <typename DerType>
 double ExtractDoubleOrThrow(const Eigen::AutoDiffScalar<DerType>& scalar) {
   return static_cast<double>(scalar.value());
@@ -163,6 +164,7 @@ double ExtractDoubleOrThrow(const Eigen::AutoDiffScalar<DerType>& scalar) {
 /// Returns @p matrix as an Eigen::Matrix<double, ...> with the same size
 /// allocation as @p matrix.  Calls ExtractDoubleOrThrow on each element of the
 /// matrix, and therefore throws if any one of the extractions fail.
+/// @see math::ExtractValue(), math::DiscardGradient()
 template <typename DerType, int RowsAtCompileTime, int ColsAtCompileTime,
           int Options, int MaxRowsAtCompileTime, int MaxColsAtCompileTime>
 auto ExtractDoubleOrThrow(

--- a/math/autodiff.h
+++ b/math/autodiff.h
@@ -1,11 +1,10 @@
-/// @file
-/// Utilities for arithmetic on AutoDiffScalar.
-
-// TODO(russt): rename methods to be GSG compliant.
+/** @file
+Utilities for arithmetic on AutoDiffScalar. */
 
 #pragma once
 
 #include <cmath>
+#include <optional>
 #include <tuple>
 
 #include <Eigen/Dense>
@@ -17,6 +16,47 @@
 namespace drake {
 namespace math {
 
+
+/** Extracts the `value()` portion from a matrix of AutoDiffScalar entries.
+(Each entry contains a value and some derivatives.)
+
+@param auto_diff_matrix An object whose Eigen type represents a matrix of
+    AutoDiffScalar entries.
+@retval value An Eigen::Matrix of the same dimensions as the input
+    matrix, but containing only the value portion of each entry, without the
+    derivatives.
+@tparam Derived An Eigen type representing a matrix with AutoDiffScalar
+    entries. The type will be inferred from the type of the `auto_diff_matrix`
+    parameter at the call site.
+
+<!-- Don't remove this note without fixing cross references to it in
+     Discard[Zero]Gradient(). -->
+@note Drake provides several similar functions: DiscardGradient() is specialized
+so that it can be applied to a `Matrix<T>` where T could be an AutoDiffScalar
+or an ordinary double, in which case it returns the original matrix at no cost.
+DiscardZeroGradient() is similar but requires that the discarded gradient was
+zero. drake::ExtractDoubleOrThrow() has many specializations, including one for
+`Matrix<AutoDiffScalar>` that behaves identically to ExtractValue().
+
+@see DiscardGradient(), drake::ExtractDoubleOrThrow() */
+template <typename Derived>
+Eigen::Matrix<typename Derived::Scalar::Scalar,
+              Derived::RowsAtCompileTime, Derived::ColsAtCompileTime>
+ExtractValue(const Eigen::MatrixBase<Derived>& auto_diff_matrix) {
+  Eigen::Matrix<typename Derived::Scalar::Scalar,
+                Derived::RowsAtCompileTime, Derived::ColsAtCompileTime>
+      value(auto_diff_matrix.rows(), auto_diff_matrix.cols());
+
+  for (int i = 0; i < auto_diff_matrix.rows(); ++i) {
+    for (int j = 0; j < auto_diff_matrix.cols(); ++j) {
+      value(i, j) = auto_diff_matrix(i, j).value();
+    }
+  }
+  return value;
+}
+
+// TODO(sherm1) DRAKE_DEPRECATED("2022-01-01",
+//    "Used only in deprecated functions.")
 template <typename Derived>
 struct AutoDiffToValueMatrix {
   typedef typename Eigen::Matrix<typename Derived::Scalar::Scalar,
@@ -25,32 +65,27 @@ struct AutoDiffToValueMatrix {
 };
 
 template <typename Derived>
-typename AutoDiffToValueMatrix<Derived>::type autoDiffToValueMatrix(
-    const Eigen::MatrixBase<Derived>& auto_diff_matrix) {
-  typename AutoDiffToValueMatrix<Derived>::type ret(auto_diff_matrix.rows(),
-                                                    auto_diff_matrix.cols());
-  for (int i = 0; i < auto_diff_matrix.rows(); i++) {
-    for (int j = 0; j < auto_diff_matrix.cols(); ++j) {
-      ret(i, j) = auto_diff_matrix(i, j).value();
-    }
-  }
-  return ret;
+// TODO(sherm1) DRAKE_DEPRECATED("2022-01-01", "Use ExtractValue() instead")
+typename AutoDiffToValueMatrix<Derived>::type
+    autoDiffToValueMatrix(const Eigen::MatrixBase<Derived>& autodiff_matrix) {
+  return ExtractValue(autodiff_matrix);
 }
 
 /** `B = DiscardGradient(A)` enables casting from a matrix of AutoDiffScalars
- * to AutoDiffScalar::Scalar type, explicitly throwing away any gradient
- * information. For a matrix of type, e.g. `MatrixX<AutoDiffXd> A`, the
- * comparable operation
- *   `B = A.cast<double>()`
- * should (and does) fail to compile.  Use `DiscardGradient(A)` if you want to
- * force the cast (and explicitly declare that information is lost).
- *
- * This method is overloaded to permit the user to call it for double types and
- * AutoDiffScalar types (to avoid the calling function having to handle the
- * two cases differently).
- *
- * @see DiscardZeroGradient
- */
+to AutoDiffScalar::Scalar type, explicitly throwing away any gradient
+information. For a matrix of type, e.g. `MatrixX<AutoDiffXd> A`, the
+comparable operation
+  `B = A.cast<double>()`
+should (and does) fail to compile.  Use `DiscardGradient(A)` if you want to
+force the cast (and explicitly declare that information is lost).
+
+This method is overloaded to permit the user to call it for double types and
+AutoDiffScalar types (to avoid the calling function having to handle the
+two cases differently).
+
+See ExtractValue() for a note on similar Drake functions.
+
+@see ExtractValue(), DiscardZeroGradient() */
 template <typename Derived>
 typename std::enable_if_t<
     !std::is_same_v<typename Derived::Scalar, double>,
@@ -58,10 +93,10 @@ typename std::enable_if_t<
                   Derived::ColsAtCompileTime, 0, Derived::MaxRowsAtCompileTime,
                   Derived::MaxColsAtCompileTime>>
 DiscardGradient(const Eigen::MatrixBase<Derived>& auto_diff_matrix) {
-  return autoDiffToValueMatrix(auto_diff_matrix);
+  return ExtractValue(auto_diff_matrix);
 }
 
-/// @see DiscardGradient().
+/** @see DiscardGradient(). */
 template <typename Derived>
 typename std::enable_if_t<
     std::is_same_v<typename Derived::Scalar, double>,
@@ -80,7 +115,7 @@ typename std::enable_if_t<
 DiscardGradient(const Eigen::Transform<_Scalar, _Dim, _Mode, _Options>&
                     auto_diff_transform) {
   return Eigen::Transform<typename _Scalar::Scalar, _Dim, _Mode, _Options>(
-      autoDiffToValueMatrix(auto_diff_transform.matrix()));
+      ExtractValue(auto_diff_transform.matrix()));
 }
 
 template <typename _Scalar, int _Dim, int _Mode, int _Options>
@@ -95,31 +130,32 @@ DiscardGradient(
   return transform;
 }
 
+/** Initializes a single AutoDiff matrix given the corresponding value matrix.
 
-/** \brief Initialize a single autodiff matrix given the corresponding value
- *matrix.
- *
- * Set the values of \p auto_diff_matrix to be equal to \p val, and for each
- *element i of \p auto_diff_matrix,
- * resize the derivatives vector to \p num_derivatives, and set derivative
- *number \p deriv_num_start + i to one (all other elements of the derivative
- *vector set to zero).
- *
- * \param[in] mat 'regular' matrix of values
- * \param[out] ret AutoDiff matrix
- * \param[in] num_derivatives the size of the derivatives vector @default the
- *size of mat
- * \param[in] deriv_num_start starting index into derivative vector (i.e.
- *element deriv_num_start in derivative vector corresponds to mat(0, 0)).
- *@default 0
- */
+Sets the values of `auto_diff_matrix` (after resizing if necessary) to be equal
+to `value`, and for each element i of `auto_diff_matrix`, resizes the
+derivatives vector to `num_derivatives` and sets derivative number
+`deriv_num_start` + i to one (all other elements of the derivative vector set
+to zero).
+
+@param[in] value a 'regular' matrix of values
+@param[in] num_derivatives (Optional) size of the derivatives vector
+    @default total size of the value matrix
+@param[in] deriv_num_start (Optional) starting index into derivative vector
+    (i.e. element deriv_num_start in derivative vector corresponds to
+    value(0, 0)).
+    @default 0
+@param[out] auto_diff_matrix AutoDiff matrix set as described above
+
+@exclude_from_pydrake_mkdoc{Not bound in pydrake.} */
 template <typename Derived, typename DerivedAutoDiff>
-void initializeAutoDiff(const Eigen::MatrixBase<Derived>& val,
-                        // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-                        Eigen::MatrixBase<DerivedAutoDiff>& auto_diff_matrix,
-                        Eigen::DenseIndex num_derivatives = Eigen::Dynamic,
-                        Eigen::DenseIndex deriv_num_start = 0) {
-  using ADScalar = typename DerivedAutoDiff::Scalar;
+void InitializeAutoDiff(const Eigen::MatrixBase<Derived>& value,
+                        std::optional<int> num_derivatives,
+                        std::optional<int> deriv_num_start,
+                        Eigen::MatrixBase<DerivedAutoDiff>* auto_diff_matrix) {
+  // Any fixed-size dimension of auto_diff_matrix must match the
+  // corresponding fixed-size dimension of value. Any dynamic-size
+  // dimension must be dynamic in both matrices.
   static_assert(static_cast<int>(Derived::RowsAtCompileTime) ==
                     static_cast<int>(DerivedAutoDiff::RowsAtCompileTime),
                 "auto diff matrix has wrong number of rows at compile time");
@@ -127,51 +163,92 @@ void initializeAutoDiff(const Eigen::MatrixBase<Derived>& val,
                     static_cast<int>(DerivedAutoDiff::ColsAtCompileTime),
                 "auto diff matrix has wrong number of columns at compile time");
 
-  if (num_derivatives == Eigen::Dynamic) num_derivatives = val.size();
+  DRAKE_DEMAND(auto_diff_matrix != nullptr);
+  if (!num_derivatives.has_value()) num_derivatives = value.size();
 
-  auto_diff_matrix.resize(val.rows(), val.cols());
-  Eigen::DenseIndex deriv_num = deriv_num_start;
-  for (Eigen::DenseIndex i = 0; i < val.size(); i++) {
-    auto_diff_matrix(i) = ADScalar(val(i), num_derivatives, deriv_num++);
+  using ADScalar = typename DerivedAutoDiff::Scalar;
+  auto_diff_matrix->resize(value.rows(), value.cols());
+  int deriv_num = deriv_num_start.value_or(0);
+  for (int i = 0; i < value.size(); ++i) {
+    (*auto_diff_matrix)(i) = ADScalar(value(i), *num_derivatives, deriv_num++);
   }
 }
 
-/** \brief The appropriate AutoDiffScalar gradient type given the value type and
- * the number of derivatives at compile time
- */
-template <typename Derived, int Nq>
+/** Alternate signature provides default values for the number of derivatives
+(dynamic, determined at run time) and the starting index (0).
+
+@exclude_from_pydrake_mkdoc{Not bound in pydrake.} */
+template <typename Derived, typename DerivedAutoDiff>
+void InitializeAutoDiff(
+    const Eigen::MatrixBase<Derived>& value,
+    Eigen::MatrixBase<DerivedAutoDiff>* auto_diff_matrix) {
+  InitializeAutoDiff(value, {}, {}, auto_diff_matrix);
+}
+
+template <typename Derived, typename DerivedAutoDiff>
+// TODO(sherm1) DRAKE_DEPRECATED("2022-01-01",
+//     "Use InitializeAutoDiff() instead")
+void initializeAutoDiff(const Eigen::MatrixBase<Derived>& value,
+                        // NOLINTNEXTLINE(runtime/references).
+                        Eigen::MatrixBase<DerivedAutoDiff>& auto_diff_matrix,
+                        Eigen::DenseIndex num_derivatives = Eigen::Dynamic,
+                        Eigen::DenseIndex deriv_num_start = 0) {
+  InitializeAutoDiff(value,
+                     num_derivatives == Eigen::Dynamic
+                         ? std::nullopt
+                         : std::optional<int>(num_derivatives),
+                     static_cast<int>(deriv_num_start), &auto_diff_matrix);
+}
+
+/** The appropriate AutoDiffScalar matrix type given the value type and the
+number of derivatives at compile time. */
+template <typename Derived, int nq>
 using AutoDiffMatrixType = Eigen::Matrix<
-    Eigen::AutoDiffScalar<Eigen::Matrix<typename Derived::Scalar, Nq, 1>>,
+    Eigen::AutoDiffScalar<Eigen::Matrix<typename Derived::Scalar, nq, 1>>,
     Derived::RowsAtCompileTime, Derived::ColsAtCompileTime, 0,
     Derived::MaxRowsAtCompileTime, Derived::MaxColsAtCompileTime>;
 
-/** \brief Initialize a single autodiff matrix given the corresponding value
- *matrix.
- *
- * Create autodiff matrix that matches \p mat in size with derivatives of
- *compile time size \p Nq and runtime size \p num_derivatives.
- * Set its values to be equal to \p val, and for each element i of \p
- *auto_diff_matrix, set derivative number \p deriv_num_start + i to one (all
- *other derivatives set to zero).
- *
- * \param[in] mat 'regular' matrix of values
- * \param[in] num_derivatives the size of the derivatives vector @default the
- *size of mat
- * \param[in] deriv_num_start starting index into derivative vector (i.e.
- *element deriv_num_start in derivative vector corresponds to mat(0, 0)).
- *@default 0
- * \return AutoDiff matrix
- */
-template <int Nq = Eigen::Dynamic, typename Derived>
-AutoDiffMatrixType<Derived, Nq> initializeAutoDiff(
+/** Initializes a single AutoDiff matrix given the corresponding value matrix.
+
+Creates an AutoDiff matrix that matches `value` in size with derivative
+of compile time size `nq` and runtime size `num_derivatives`. Sets its values to
+be equal to `value`, and for each element i of `auto_diff_matrix`, sets
+derivative number `deriv_num_start` + i to one (all other derivatives set to
+zero).
+
+@param[in] value 'regular' matrix of values
+@param[in] num_derivatives (Optional) size of the derivatives vector
+    @default total size of the value matrix
+@param[in] deriv_num_start (Optional) starting index into derivative vector
+    (i.e. element deriv_num_start in derivative vector corresponds to
+    matrix(0, 0)).
+    @default 0
+@retval auto_diff_matrix The result as described above.
+
+@pydrake_mkdoc_identifier{just_value} */
+template <int nq = Eigen::Dynamic, typename Derived>
+AutoDiffMatrixType<Derived, nq> InitializeAutoDiff(
+    const Eigen::MatrixBase<Derived>& value,
+    std::optional<int> num_derivatives = {},
+    std::optional<int> deriv_num_start = {}) {
+  AutoDiffMatrixType<Derived, nq> auto_diff_matrix(value.rows(), value.cols());
+  InitializeAutoDiff(value, num_derivatives.value_or(value.size()),
+                     deriv_num_start.value_or(0), &auto_diff_matrix);
+  return auto_diff_matrix;
+}
+
+template <int nq = Eigen::Dynamic, typename Derived>
+// TODO(sherm1) DRAKE_DEPRECATED("2022-01-01",
+//     "Use InitializeAutoDiff() instead")
+AutoDiffMatrixType<Derived, nq> initializeAutoDiff(
     const Eigen::MatrixBase<Derived>& mat,
     Eigen::DenseIndex num_derivatives = -1,
     Eigen::DenseIndex deriv_num_start = 0) {
-  if (num_derivatives == -1) num_derivatives = mat.size();
-
-  AutoDiffMatrixType<Derived, Nq> ret(mat.rows(), mat.cols());
-  initializeAutoDiff(mat, ret, num_derivatives, deriv_num_start);
-  return ret;
+  return InitializeAutoDiff<nq, Derived>(
+      mat,
+      num_derivatives == -1 ? std::nullopt
+                            : std::optional<int>(num_derivatives),
+      static_cast<int>(deriv_num_start));
 }
 
 // TODO(sherm1) DRAKE_DEPRECATED("2021-12-01") Remove this internal:: block when
@@ -179,18 +256,16 @@ AutoDiffMatrixType<Derived, Nq> initializeAutoDiff(
 namespace internal {
 template <typename Derived, typename Scalar>
 struct ResizeDerivativesToMatchScalarImpl {
-  // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-  static void run(Eigen::MatrixBase<Derived>&, const Scalar&) {}
+  static void run(const Scalar&, Eigen::MatrixBase<Derived>*) {}
 };
 
 template <typename Derived, typename DerivType>
 struct ResizeDerivativesToMatchScalarImpl<Derived,
                                           Eigen::AutoDiffScalar<DerivType>> {
   using Scalar = Eigen::AutoDiffScalar<DerivType>;
-  // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-  static void run(Eigen::MatrixBase<Derived>& mat, const Scalar& scalar) {
-    for (int i = 0; i < mat.size(); i++) {
-      auto& derivs = mat(i).derivatives();
+  static void run(const Scalar& scalar, Eigen::MatrixBase<Derived>* mat) {
+    for (int i = 0; i < mat->size(); ++i) {
+      auto& derivs = (*mat)(i).derivatives();
       if (derivs.size() == 0) {
         derivs.resize(scalar.derivatives().size());
         derivs.setZero();
@@ -215,122 +290,128 @@ struct ResizeDerivativesToMatchScalarImpl<Derived,
 template <typename Derived>
 DRAKE_DEPRECATED("2021-12-01",
     "Apparently unused. File a Drake issue on GitHub if you need this method.")
-// TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-void resizeDerivativesToMatchScalar(Eigen::MatrixBase<Derived>& mat,
+// NOLINTNEXTLINE(runtime/references).
+void resizeDerivativesToMatchScalar(Eigen::MatrixBase<Derived>& matrix,
                                     const typename Derived::Scalar& scalar) {
   internal::ResizeDerivativesToMatchScalarImpl<
-      Derived, typename Derived::Scalar>::run(mat, scalar);
+      Derived, typename Derived::Scalar>::run(scalar, &matrix);
 }
 
 namespace internal {
-/* Helper for totalSizeAtCompileTime function (recursive) */
+/* Helper for total_size_at_compile_time() (recursive). */
 template <typename Head, typename... Tail>
-struct TotalSizeAtCompileTime {
+struct TotalSizeAtCompileTimeHelper {
   static constexpr int eval() {
     return Head::SizeAtCompileTime == Eigen::Dynamic ||
-                   TotalSizeAtCompileTime<Tail...>::eval() == Eigen::Dynamic
+                   TotalSizeAtCompileTimeHelper<Tail...>::eval() ==
+                       Eigen::Dynamic
                ? Eigen::Dynamic
                : Head::SizeAtCompileTime +
-                     TotalSizeAtCompileTime<Tail...>::eval();
+                     TotalSizeAtCompileTimeHelper<Tail...>::eval();
   }
 };
 
-/* Helper for totalSizeAtCompileTime function (base case) */
+/* Helper for total_size_at_compile_time() (base case). */
 template <typename Head>
-struct TotalSizeAtCompileTime<Head> {
+struct TotalSizeAtCompileTimeHelper<Head> {
   static constexpr int eval() { return Head::SizeAtCompileTime; }
 };
 
-/* Determine the total size at compile time of a number of arguments
- * based on their SizeAtCompileTime static members
- */
+/* Determines the total size at compile time of a number of arguments
+based on their SizeAtCompileTime static members. Returns Eigen::Dynamic if
+total size can't be determined at compile time. */
 template <typename... Args>
-constexpr int totalSizeAtCompileTime() {
-  return TotalSizeAtCompileTime<Args...>::eval();
+constexpr int total_size_at_compile_time() {
+  return TotalSizeAtCompileTimeHelper<Args...>::eval();
 }
 
-/* Determine the total size at runtime of a number of arguments using
- * their size() methods (base case).
- */
-constexpr Eigen::DenseIndex totalSizeAtRunTime() { return 0; }
+/* Determines the total size at runtime of a number of arguments using
+their size() methods (base case). */
+constexpr Eigen::DenseIndex total_size_at_run_time() { return 0; }
 
-/* Determine the total size at runtime of a number of arguments using
- * their size() methods (recursive)
- */
+/* Determines the total size at runtime of a number of arguments using
+their size() methods (recursive). */
 template <typename Head, typename... Tail>
-Eigen::DenseIndex totalSizeAtRunTime(const Eigen::MatrixBase<Head>& head,
-                                     const Tail&... tail) {
-  return head.size() + totalSizeAtRunTime(tail...);
+Eigen::DenseIndex total_size_at_run_time(const Eigen::MatrixBase<Head>& head,
+                                         const Tail&... tail) {
+  return head.size() + total_size_at_run_time(tail...);
 }
 
-/* Helper for initializeAutoDiffTuple function (recursive) */
-template <size_t Index>
+/* Helper for InitializeAutoDiffTuple() (recursive). */
+template <size_t index>
 struct InitializeAutoDiffTupleHelper {
   template <typename... ValueTypes, typename... AutoDiffTypes>
   static void run(const std::tuple<ValueTypes...>& values,
-                  // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-                  std::tuple<AutoDiffTypes...>& auto_diffs,
                   Eigen::DenseIndex num_derivatives,
-                  Eigen::DenseIndex deriv_num_start) {
-    constexpr size_t tuple_index = sizeof...(AutoDiffTypes)-Index;
+                  Eigen::DenseIndex deriv_num_start,
+                  std::tuple<AutoDiffTypes...>* auto_diffs) {
+    DRAKE_DEMAND(auto_diffs != nullptr);
+    constexpr size_t tuple_index = sizeof...(AutoDiffTypes) - index;
     const auto& value = std::get<tuple_index>(values);
-    auto& auto_diff = std::get<tuple_index>(auto_diffs);
+    auto& auto_diff = std::get<tuple_index>(*auto_diffs);
     auto_diff.resize(value.rows(), value.cols());
-    initializeAutoDiff(value, auto_diff, num_derivatives, deriv_num_start);
-    InitializeAutoDiffTupleHelper<Index - 1>::run(
-        values, auto_diffs, num_derivatives, deriv_num_start + value.size());
+    InitializeAutoDiff(value, num_derivatives, deriv_num_start, &auto_diff);
+    InitializeAutoDiffTupleHelper<index - 1>::run(
+        values, num_derivatives, deriv_num_start + value.size(), auto_diffs);
   }
 };
 
-/* Helper for initializeAutoDiffTuple function (base case) */
+/* Helper for InitializeAutoDiffTuple() (base case). */
 template <>
 struct InitializeAutoDiffTupleHelper<0> {
   template <typename... ValueTypes, typename... AutoDiffTypes>
   static void run(const std::tuple<ValueTypes...>& values,
-                  const std::tuple<AutoDiffTypes...>& auto_diffs,
                   Eigen::DenseIndex num_derivatives,
-                  Eigen::DenseIndex deriv_num_start) {
-    unused(values, auto_diffs, num_derivatives, deriv_num_start);
+                  Eigen::DenseIndex deriv_num_start,
+                  const std::tuple<AutoDiffTypes...>* auto_diffs) {
+    unused(values, num_derivatives, deriv_num_start, auto_diffs);
   }
 };
 }  // namespace internal
 
-/** \brief Given a series of Eigen matrices, create a tuple of corresponding
- *AutoDiff matrices with values equal to the input matrices and properly
- *initialized derivative vectors.
- *
- * The size of the derivative vector of each element of the matrices in the
- *output tuple will be the same, and will equal the sum of the number of
- *elements of the matrices in \p args.
- * If all of the matrices in \p args have fixed size, then the derivative
- *vectors will also have fixed size (being the sum of the sizes at compile time
- *of all of the input arguments),
- * otherwise the derivative vectors will have dynamic size.
- * The 0th element of the derivative vectors will correspond to the derivative
- *with respect to the 0th element of the first argument.
- * Subsequent derivative vector elements correspond first to subsequent elements
- *of the first input argument (traversed first by row, then by column), and so
- *on for subsequent arguments.
- *
- * \param args a series of Eigen matrices
- * \return a tuple of properly initialized AutoDiff matrices corresponding to \p
- *args
- *
- */
+/* Given a series of Eigen matrices, creates a tuple of corresponding
+AutoDiff matrices with values equal to the input matrices and properly
+initialized derivative vectors.
+
+The size of the derivative vector of each element of the matrices in the
+output tuple will be the same, and will equal the sum of the number of
+elements of the matrices in `args`. If all of the matrices in `args` have fixed
+size, then the derivative vectors will also have fixed size (being the sum of
+the sizes at compile time of all of the input arguments), otherwise the
+derivative vectors will have dynamic size. The 0th element of the derivative
+vectors will correspond to the derivative with respect to the 0th element of the
+first argument. Subsequent derivative vector elements correspond first to
+subsequent elements of the first input argument (traversed first by row, then by
+column), and so on for subsequent arguments.
+
+@param args a series of Eigen matrices
+@returns a tuple of properly initialized AutoDiff matrices corresponding to
+    `args` */
 template <typename... Deriveds>
 std::tuple<AutoDiffMatrixType<
-    Deriveds, internal::totalSizeAtCompileTime<Deriveds...>()>...>
-initializeAutoDiffTuple(const Eigen::MatrixBase<Deriveds>&... args) {
-  Eigen::DenseIndex dynamic_num_derivs = internal::totalSizeAtRunTime(args...);
-  std::tuple<AutoDiffMatrixType<
-      Deriveds, internal::totalSizeAtCompileTime<Deriveds...>()>...>
-      ret(AutoDiffMatrixType<Deriveds,
-                             internal::totalSizeAtCompileTime<Deriveds...>()>(
-          args.rows(), args.cols())...);
+    Deriveds, internal::total_size_at_compile_time<Deriveds...>()>...>
+InitializeAutoDiffTuple(const Eigen::MatrixBase<Deriveds>&... args) {
+  constexpr int compile_num_derivs =
+      internal::total_size_at_compile_time<Deriveds...>();
+  const Eigen::DenseIndex dynamic_num_derivs =
+      internal::total_size_at_run_time(args...);
+
+  std::tuple<AutoDiffMatrixType<Deriveds, compile_num_derivs>...> result(
+      AutoDiffMatrixType<Deriveds, compile_num_derivs>(args.rows(),
+                                                       args.cols())...);
   auto values = std::forward_as_tuple(args...);
   internal::InitializeAutoDiffTupleHelper<sizeof...(args)>::run(
-      values, ret, dynamic_num_derivs, 0);
-  return ret;
+      values, dynamic_num_derivs, 0, &result);
+  return result;
+}
+
+template <typename... Deriveds>
+// TODO(sherm1) DRAKE_DEPRECATED("2022-01-01",
+//     "Use InitializeAutoDiffTuple() instead")
+std::tuple<AutoDiffMatrixType<
+    Deriveds, internal::total_size_at_compile_time<Deriveds...>()>...>
+initializeAutoDiffTuple(const Eigen::MatrixBase<Deriveds>&... args) {
+  return InitializeAutoDiffTuple(args...);
 }
 
 }  // namespace math

--- a/math/gradient.h
+++ b/math/gradient.h
@@ -1,5 +1,5 @@
-/// @file
-/// Utilities for arithmetic on gradients.
+/** @file
+Utilities for arithmetic on gradients. */
 
 #pragma once
 
@@ -8,28 +8,25 @@
 namespace drake {
 namespace math {
 
-/*
- * Recursively defined template specifying a matrix type of the correct size for
- * a gradient of a matrix function with respect to Nq variables, of any order.
- */
-template <typename Derived, int Nq, int DerivativeOrder = 1>
+/** Recursively defined template specifying a matrix type of the correct size
+for a gradient of a matrix function with respect to `nq` variables, of any
+order. */
+template <typename Derived, int nq, int derivative_order = 1>
 struct Gradient {
   typedef typename Eigen::Matrix<
       typename Derived::Scalar,
-      ((Derived::SizeAtCompileTime == Eigen::Dynamic || Nq == Eigen::Dynamic)
+      ((Derived::SizeAtCompileTime == Eigen::Dynamic || nq == Eigen::Dynamic)
            ? Eigen::Dynamic
-           : Gradient<Derived, Nq,
-                      DerivativeOrder - 1>::type::SizeAtCompileTime),
-      Nq> type;
+           : Gradient<Derived, nq,
+                      derivative_order - 1>::type::SizeAtCompileTime),
+      nq> type;
 };
 
-/*
- * Base case for recursively defined gradient template.
- */
-template <typename Derived, int Nq>
-struct Gradient<Derived, Nq, 1> {
+/** Base case for recursively defined gradient template. */
+template <typename Derived, int nq>
+struct Gradient<Derived, nq, 1> {
   typedef typename Eigen::Matrix<typename Derived::Scalar,
-                                 Derived::SizeAtCompileTime, Nq> type;
+                                 Derived::SizeAtCompileTime, nq> type;
 };
 
 }  // namespace math


### PR DESCRIPTION
In preparation to deprecate the old non-compliant functions in math/autodiff.h and math/autodiff_gradient.h this PR introduces GSG-compliant signatures. Also updates the comments and code in the headers to bring them up to current Drake standards.

For reviewability, this is split out from draft PR #15615 which also modifies the hundreds of call sites. Refer to that PR to see what the call sites look like; this one retains the original call sites. 

Addresses part of #15604. The remaining steps (in separate PRs) are:
- update the call sites in Drake to use the new signatures (the remainder of #15615).
- update the call sites in Anzu
- uncomment the "TODO DEPRECATE" lines here for the old signatures
- (three months later) remove the deprecated methods (C++ & python)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15699)
<!-- Reviewable:end -->
