### PR TITLE
[setup] Adjust removal date further into the future

### DIFF
--- a/setup/mac/binary_distribution/install_prereqs.sh
+++ b/setup/mac/binary_distribution/install_prereqs.sh
@@ -51,7 +51,7 @@ export HOMEBREW_NO_INSTALL_CLEANUP=1
 binary_distribution_called_update=0
 
 if [[ "${with_update}" -eq 1 ]]; then
-  # TODO(jamiesnape): Remove the below brew tap commands on or after 2021-09-01.
+  # TODO(jamiesnape): Remove the below brew tap commands on or after 2021-11-01.
   brew tap robotlocomotion/director
   brew tap --repair robotlocomotion/director
 

--- a/setup/mac/source_distribution/install_prereqs.sh
+++ b/setup/mac/source_distribution/install_prereqs.sh
@@ -46,7 +46,7 @@ if ! command -v brew &>/dev/null; then
 fi
 
 if [[ "${with_update}" -eq 1 && "${binary_distribution_called_update:-0}" -ne 1 ]]; then
-  # TODO(jamiesnape): Remove the below brew tap commands on or after 2021-09-01.
+  # TODO(jamiesnape): Remove the below brew tap commands on or after 2021-11-01.
   brew tap robotlocomotion/director
   brew tap --repair robotlocomotion/director
 


### PR DESCRIPTION
There is no great rush to tidy up the setup scripts, and if a user happened to pause their Drake upgrades during the summer, they would be bitten by this, with a difficult recovery.  Push the date out an extra two months to allow for more time for the transition.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15700)
<!-- Reviewable:end -->
