### PR TITLE
Remove deprecated code 2021-09

### DIFF
--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -10,7 +10,6 @@
 #include "drake/bindings/pydrake/autodiff_types_pybind.h"
 #include "drake/bindings/pydrake/common/cpp_param_pybind.h"
 #include "drake/bindings/pydrake/common/cpp_template_pybind.h"
-#include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/symbolic_types_pybind.h"
@@ -1459,23 +1458,6 @@ for every column of ``prog_var_vals``. )""")
           doc.MathematicalProgram.RemoveCost.doc)
       .def("RemoveConstraint", &MathematicalProgram::RemoveConstraint,
           py::arg("constraint"), doc.MathematicalProgram.RemoveConstraint.doc);
-
-  {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    prog_cls.def("AddL2NormCost",
-        WrapDeprecated("Please use "
-                       "MathematicalProgram.Add2NormSquaredCost(A, b, vars),"
-                       " this variant will be "
-                       "removed after 2021-09-01",
-            overload_cast_explicit<Binding<QuadraticCost>,
-                const Eigen::Ref<const Eigen::MatrixXd>&,
-                const Eigen::Ref<const Eigen::VectorXd>&,
-                const Eigen::Ref<const VectorXDecisionVariable>&>(
-                &MathematicalProgram::Add2NormSquaredCost)),
-        py::arg("A"), py::arg("b"), py::arg("vars"));
-#pragma GCC diagnostic pop
-  }
 
   py::enum_<MathematicalProgram::NonnegativePolynomial>(prog_cls,
       "NonnegativePolynomial",

--- a/bindings/pydrake/systems/sensors_py.cc
+++ b/bindings/pydrake/systems/sensors_py.cc
@@ -167,19 +167,6 @@ PYBIND11_MODULE(sensors, m) {
     type_visit(instantiation_visitor, PixelTypeList{});
   }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  // Constants.
-  py::class_<InvalidDepth> invalid_depth(
-      m, "InvalidDepth", doc.InvalidDepth.doc_deprecated);
-  invalid_depth.attr("kTooFar") = InvalidDepth::kTooFar;
-  invalid_depth.attr("kTooClose") = InvalidDepth::kTooClose;
-
-  py::class_<Label> label(m, "Label", doc.Label.doc_deprecated);
-  label.attr("kNoBody") = Label::kNoBody;
-  label.attr("kFlatTerrain") = Label::kFlatTerrain;
-#pragma GCC diagnostic pop
-
   using T = double;
 
   // Systems.

--- a/bindings/pydrake/systems/test/sensors_test.py
+++ b/bindings/pydrake/systems/test/sensors_test.py
@@ -173,16 +173,6 @@ class TestSensors(unittest.TestCase):
             np.testing.assert_array_equal(data, channel_default)
             np.testing.assert_array_equal(mutable_data, channel_default)
 
-    def test_constants(self):
-        # Simply ensure we can access the constants.
-        values = [
-            mut.InvalidDepth.kTooFar,
-            mut.InvalidDepth.kTooClose,
-            mut.Label.kNoBody,
-            mut.Label.kFlatTerrain,
-        ]
-        self.assertTrue(values)
-
     def test_camera_info(self):
         width = 640
         height = 480

--- a/solvers/cost.h
+++ b/solvers/cost.h
@@ -10,7 +10,6 @@
 
 #include <Eigen/SparseCore>
 
-#include "drake/common/drake_deprecated.h"
 #include "drake/solvers/evaluator_base.h"
 
 namespace drake {
@@ -221,14 +220,6 @@ class QuadraticCost : public Cost {
 std::shared_ptr<QuadraticCost> MakeQuadraticErrorCost(
     const Eigen::Ref<const Eigen::MatrixXd>& Q,
     const Eigen::Ref<const Eigen::VectorXd>& x_desired);
-
-/**
- * Creates a cost term of the form | Ax - b |^2.
- */
-DRAKE_DEPRECATED("2021-09-01", "Use Make2NormSquaredCost instead")
-std::shared_ptr<QuadraticCost> MakeL2NormCost(
-    const Eigen::Ref<const Eigen::MatrixXd>& A,
-    const Eigen::Ref<const Eigen::VectorXd>& b);
 
 /**
  * Creates a quadratic cost of the form |Ax-b|²=(Ax-b)ᵀ(Ax-b)

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -22,7 +22,6 @@
 #include "drake/common/autodiff.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/polynomial.h"
 #include "drake/common/symbolic.h"
@@ -1105,33 +1104,6 @@ class MathematicalProgram {
       const Eigen::Ref<const Eigen::MatrixXd>& Q,
       const Eigen::Ref<const Eigen::VectorXd>& x_desired,
       const Eigen::Ref<const VectorXDecisionVariable>& vars);
-
-  /**
-   * Adds a cost term of the form | Ax - b |^2.
-   */
-  DRAKE_DEPRECATED("2021-09-01", "Please use Add2NormSquaredCost instead")
-  Binding<QuadraticCost> AddL2NormCost(
-      const Eigen::Ref<const Eigen::MatrixXd>& A,
-      const Eigen::Ref<const Eigen::VectorXd>& b, const VariableRefList& vars) {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    return AddL2NormCost(A, b, ConcatenateVariableRefList(vars));
-#pragma GCC diagnostic pop
-  }
-
-  /**
-   * Adds a cost term of the form | Ax - b |^2.
-   */
-  DRAKE_DEPRECATED("2021-09-01", "Please use Add2NormSquaredCost instead")
-  Binding<QuadraticCost> AddL2NormCost(
-      const Eigen::Ref<const Eigen::MatrixXd>& A,
-      const Eigen::Ref<const Eigen::VectorXd>& b,
-      const Eigen::Ref<const VectorXDecisionVariable>& vars) {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    return AddCost(MakeL2NormCost(A, b), vars);
-#pragma GCC diagnostic pop
-  }
 
   /**
    * Adds a quadratic cost of the form |Ax-b|²=(Ax-b)ᵀ(Ax-b)

--- a/systems/framework/event_collection.h
+++ b/systems/framework/event_collection.h
@@ -134,14 +134,6 @@ class EventCollection {
    * does not permit adding new events. Derived classes must implement this
    * method to add the specified event to the homogeneous event collection.
    */
-  DRAKE_DEPRECATED("2021-09-01", "Use AddEvent instead.")
-  virtual void add_event(std::unique_ptr<EventType> event) = 0;
-
-  /**
-   * Adds an event to this collection, or throws if the concrete collection
-   * does not permit adding new events. Derived classes must implement this
-   * method to add the specified event to the homogeneous event collection.
-   */
   virtual void AddEvent(EventType event) = 0;
 
  protected:
@@ -186,13 +178,6 @@ class DiagramEventCollection final : public EventCollection<EventType> {
       : EventCollection<EventType>(),
         subevent_collection_(num_subsystems),
         owned_subevent_collection_(num_subsystems) {}
-
-  /**
-   * Throws if called, because no events should be added at the Diagram level.
-   */
-  void add_event(std::unique_ptr<EventType>) final {
-    throw std::logic_error("DiagramEventCollection::add_event is not allowed");
-  }
 
   /**
    * Throws if called, because no events should be added at the Diagram level.
@@ -364,15 +349,6 @@ class LeafEventCollection final : public EventCollection<EventType> {
   }
 
   /**
-   * Add `event` to the existing collection. Ownership of `event` is
-   * transferred. Aborts if event is null.
-   */
-  void add_event(std::unique_ptr<EventType> event) final {
-    DRAKE_DEMAND(event != nullptr);
-    AddEvent(std::move(*event));
-  }
-
-  /**
    * Add `event` to the existing collection.
    */
   void AddEvent(EventType event) final {
@@ -520,18 +496,6 @@ class CompositeEventCollection {
    * transferred) to it.
    * @throws std::exception if the assumption is incorrect.
    */
-  DRAKE_DEPRECATED("2021-09-01", "Use AddPublishEvent instead.")
-  void add_publish_event(std::unique_ptr<PublishEvent<T>> event) {
-    DRAKE_DEMAND(event != nullptr);
-    AddPublishEvent(std::move(*event));
-  }
-
-  /**
-   * Assuming the internal publish event collection is an instance of
-   * LeafEventCollection, adds the publish event `event` (ownership is also
-   * transferred) to it.
-   * @throws std::exception if the assumption is incorrect.
-   */
   void AddPublishEvent(PublishEvent<T> event) {
     auto& events = dynamic_cast<LeafEventCollection<PublishEvent<T>>&>(
         this->get_mutable_publish_events());
@@ -544,36 +508,10 @@ class CompositeEventCollection {
    * also transferred) to it.
    * @throws std::exception if the assumption is incorrect.
    */
-  DRAKE_DEPRECATED("2021-09-01", "Use AddDiscreteUpdateEvent instead.")
-  void add_discrete_update_event(
-      std::unique_ptr<DiscreteUpdateEvent<T>> event) {
-    DRAKE_DEMAND(event != nullptr);
-    AddDiscreteUpdateEvent(std::move(*event));
-  }
-
-  /**
-   * Assuming the internal discrete update event collection is an instance of
-   * LeafEventCollection, adds the discrete update event `event` (ownership is
-   * also transferred) to it.
-   * @throws std::exception if the assumption is incorrect.
-   */
   void AddDiscreteUpdateEvent(DiscreteUpdateEvent<T> event) {
     auto& events = dynamic_cast<LeafEventCollection<DiscreteUpdateEvent<T>>&>(
         this->get_mutable_discrete_update_events());
     events.AddEvent(std::move(event));
-  }
-
-  /**
-   * Assuming the internal unrestricted update event collection is an instance
-   * of LeafEventCollection, adds the unrestricted update event `event`
-   * (ownership is also transferred) to it.
-   * @throws std::exception if the assumption is incorrect.
-   */
-  DRAKE_DEPRECATED("2021-09-01", "Use AddUnrestrictedUpdateEvent instead.")
-  void add_unrestricted_update_event(
-      std::unique_ptr<UnrestrictedUpdateEvent<T>> event) {
-    DRAKE_DEMAND(event != nullptr);
-    AddUnrestrictedUpdateEvent(std::move(*event));
   }
 
   /**

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -1693,13 +1693,6 @@ class System : public SystemBase {
     return system_scalar_converter_;
   }
 
-  template <template <typename> class Clazz>
-  DRAKE_DEPRECATED("2021-09-01",
-                   "Please use ValidateCreatedForThisSystem instead.")
-  void ValidateChildOfContext(const Clazz<T>* object) const {
-    ValidateCreatedForThisSystem(object);
-  }
-
  private:
   // For any T1 & T2, System<T1> considers System<T2> a friend, so that System
   // can safely and efficiently convert scalar types. See for example

--- a/systems/sensors/image.h
+++ b/systems/sensors/image.h
@@ -6,7 +6,6 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_deprecated.h"
 #include "drake/common/reset_after_move.h"
 #include "drake/systems/sensors/pixel_types.h"
 
@@ -154,37 +153,6 @@ class Image {
   reset_after_move<int> width_;
   reset_after_move<int> height_;
   std::vector<T> data_;
-};
-
-/// Set of constants used to represent invalid depth values.
-/// Note that in the case that a depth is not measurable, the constants defined
-/// here are not used. Instead we set the depth to NaN.
-class DRAKE_DEPRECATED("2021-09-01",
-    "Use ImageTraits<PixelType::kDepth32F> instead.")
-InvalidDepth {
- public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(InvalidDepth)
-
-  /// The depth value when the max sensing range is exceeded.
-  static constexpr float kTooFar =
-      ImageTraits<PixelType::kDepth32F>::kTooFar;
-
-  /// The depth value when the min sensing range is exceeded.
-  static constexpr float kTooClose =
-      ImageTraits<PixelType::kDepth32F>::kTooClose;
-};
-
-/// Set of labels used for label image.
-class DRAKE_DEPRECATED("2021-09-01",
-    "There is no replacement; these values are unused within Drake.")
-Label {
- public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Label)
-  /// The label used for pixels correspond to nothing.
-  static constexpr int16_t kNoBody{std::numeric_limits<int16_t>::max()};
-  /// The label used for pixels correspond to the flat terrain.
-  static constexpr int16_t kFlatTerrain{
-    std::numeric_limits<int16_t>::max() - 1};
 };
 
 }  // namespace sensors


### PR DESCRIPTION
(Note that the `RandomSource` is still marked as deprecated 2020-09-01; that will be changed in a different commit.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15701)
<!-- Reviewable:end -->
