### PR TITLE
[pydrake] Disable meshcat test_warnings_and_errors

### DIFF
--- a/bindings/pydrake/systems/test/meshcat_visualizer_test.py
+++ b/bindings/pydrake/systems/test/meshcat_visualizer_test.py
@@ -464,6 +464,7 @@ class TestMeshcat(unittest.TestCase):
         vis2.load(vis2.GetMyContextFromRoot(context))
         diagram.Publish(context)
 
+    @unittest.skip("TODO(#15702) Re-enable this test case.")
     def test_warnings_and_errors(self):
         builder = DiagramBuilder()
         sg = builder.AddSystem(SceneGraph())


### PR DESCRIPTION
The test case opens 2-3 webbrowser tabs in the user's browser anytime the test case is run. Disable the test case to mitigate this failure mode, until a real fix is in place.

#15702 is the tracking issue to re-enable it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15703)
<!-- Reviewable:end -->
