### PR TITLE
Add bindings for VolumeMesh and extend SurfaceMesh bindings

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -125,6 +125,7 @@ drake_pybind_library(
         "//bindings/pydrake/common:default_scalars_pybind",
         "//bindings/pydrake/common:deprecation_pybind",
         "//bindings/pydrake/common:type_pack",
+        "//bindings/pydrake/common:type_safe_index_pybind",
         "//bindings/pydrake/common:value_pybind",
         "//lcmtypes:viewer",
     ],

--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -10,6 +10,7 @@
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/type_pack.h"
+#include "drake/bindings/pydrake/common/type_safe_index_pybind.h"
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
@@ -29,6 +30,7 @@
 #include "drake/geometry/optimization/vpolytope.h"
 #include "drake/geometry/proximity/obj_to_surface_mesh.h"
 #include "drake/geometry/proximity/surface_mesh.h"
+#include "drake/geometry/proximity/volume_mesh.h"
 #include "drake/geometry/proximity_properties.h"
 #include "drake/geometry/query_results/penetration_as_point_pair.h"
 #include "drake/geometry/render/gl_renderer/render_engine_gl_factory.h"
@@ -883,7 +885,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
     cls  // BR
         .def(py::init<const Vector3<T>&>(), py::arg("r_MV"),
             doc.SurfaceVertex.ctor.doc)
-        .def("r_MV", &Class::r_MV, doc.SurfaceVertex.r_MV.doc);
+        .def("r_MV", &Class::r_MV, py_rvp::reference_internal,
+            doc.SurfaceVertex.r_MV.doc);
   }
 
   // SurfaceMesh
@@ -997,6 +1000,36 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.AddToBuilder
                 .doc_4args_builder_query_object_port_meshcat_params);
   }
+
+  // VolumeMesh
+  {
+    using Class = VolumeMesh<T>;
+    auto cls = DefineTemplateClassWithDefault<Class>(
+        m, "VolumeMesh", param, doc.VolumeMesh.doc);
+    cls  // BR
+        .def(py::init<std::vector<VolumeElement>,
+                 std::vector<VolumeVertex<T>>>(),
+            py::arg("elements"), py::arg("vertices"), doc.VolumeMesh.ctor.doc)
+        .def("vertices", &Class::vertices, py_rvp::reference_internal,
+            doc.VolumeMesh.vertices.doc)
+        .def("tetrahedra", &Class::tetrahedra, py_rvp::reference_internal,
+            doc.VolumeMesh.tetrahedra.doc)
+        .def("CalcTetrahedronVolume", &Class::CalcTetrahedronVolume,
+            py::arg("e"), doc.VolumeMesh.CalcTetrahedronVolume.doc)
+        .def("CalcVolume", &Class::CalcVolume, doc.VolumeMesh.CalcVolume.doc);
+  }
+
+  // VolumeVertex
+  {
+    using Class = VolumeVertex<T>;
+    auto cls = DefineTemplateClassWithDefault<Class>(
+        m, "VolumeVertex", param, doc.VolumeVertex.doc);
+    cls  // BR
+        .def(py::init<const Vector3<T>&>(), py::arg("r_MV"),
+            doc.VolumeVertex.ctor.doc_1args)
+        .def("r_MV", &Class::r_MV, py_rvp::reference_internal,
+            doc.VolumeVertex.r_MV.doc);
+  }
 }  // NOLINT(readability/fn_size)
 
 void DoScalarIndependentDefinitions(py::module m) {
@@ -1004,6 +1037,19 @@ void DoScalarIndependentDefinitions(py::module m) {
   using namespace drake::geometry;
   constexpr auto& doc = pydrake_doc.drake.geometry;
 
+  // All the index types up front, so they'll be available to every other type.
+  {
+    BindTypeSafeIndex<SurfaceVertexIndex>(
+        m, "SurfaceVertexIndex", doc.SurfaceVertexIndex.doc);
+    BindTypeSafeIndex<SurfaceFaceIndex>(
+        m, "SurfaceFaceIndex", doc.SurfaceFaceIndex.doc);
+    BindTypeSafeIndex<VolumeVertexIndex>(
+        m, "VolumeVertexIndex", doc.VolumeVertexIndex.doc);
+    BindTypeSafeIndex<VolumeElementIndex>(
+        m, "VolumeElementIndex", doc.VolumeElementIndex.doc);
+  }
+
+  // Rgba
   {
     using Class = Rgba;
     constexpr auto& cls_doc = doc.Rgba;
@@ -1392,6 +1438,35 @@ void DoScalarIndependentDefinitions(py::module m) {
     DefCopyAndDeepCopy(&cls);
   }
 
+  // SurfaceFace
+  {
+    using Class = SurfaceFace;
+    constexpr auto& cls_doc = doc.SurfaceFace;
+    py::class_<Class> cls(m, "SurfaceFace", cls_doc.doc);
+    cls  // BR
+        .def(py::init<SurfaceVertexIndex, SurfaceVertexIndex,
+                 SurfaceVertexIndex>(),
+            py::arg("v0"), py::arg("v1"), py::arg("v2"), cls_doc.ctor.doc_3args)
+        // TODO(SeanCurtis-TRI): Bind constructor that takes array of ints.
+        .def("vertex", &Class::vertex, py::arg("i"), cls_doc.vertex.doc);
+    DefCopyAndDeepCopy(&cls);
+  }
+
+  // VolumeElement
+  {
+    using Class = VolumeElement;
+    constexpr auto& cls_doc = doc.VolumeElement;
+    py::class_<Class> cls(m, "VolumeElement", cls_doc.doc);
+    cls  // BR
+        .def(py::init<VolumeVertexIndex, VolumeVertexIndex, VolumeVertexIndex,
+                 VolumeVertexIndex>(),
+            py::arg("v0"), py::arg("v1"), py::arg("v2"), py::arg("v3"),
+            cls_doc.ctor.doc_4args)
+        // TODO(SeanCurtis-TRI): Bind constructor that takes array of ints.
+        .def("vertex", &Class::vertex, py::arg("i"), cls_doc.vertex.doc);
+    DefCopyAndDeepCopy(&cls);
+  }
+
   m.def("MakePhongIllustrationProperties", &MakePhongIllustrationProperties,
       py_rvp::reference_internal, py::arg("diffuse"),
       doc.MakePhongIllustrationProperties.doc);
@@ -1487,7 +1562,7 @@ void DoScalarIndependentDefinitions(py::module m) {
             &MeshcatVisualizerParams::delete_on_intialization_event,
             cls_doc.delete_on_intialization_event.doc);
   }
-}
+}  // NOLINT(readability/fn_size)
 
 void def_geometry(py::module m) {
   DoScalarIndependentDefinitions(m);

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -880,6 +880,86 @@ class TestGeometry(unittest.TestCase):
             X_PC=RigidTransform())
         self.assertIsInstance(image, ImageLabel16I)
 
+    def test_surface_mesh(self):
+        # Create a mesh out of two triangles forming a quad.
+        #
+        #     0______1
+        #      |b  /|      Two faces: a and b.
+        #      |  / |      Four vertices: 0, 1, 2, and 3.
+        #      | /a |
+        #      |/___|
+        #     2      3
+
+        f_a = mut.SurfaceFace(v0=mut.SurfaceVertexIndex(3),
+                              v1=mut.SurfaceVertexIndex(1),
+                              v2=mut.SurfaceVertexIndex(2))
+        f_b = mut.SurfaceFace(v0=mut.SurfaceVertexIndex(2),
+                              v1=mut.SurfaceVertexIndex(1),
+                              v2=mut.SurfaceVertexIndex(0))
+        self.assertEqual(f_a.vertex(0), 3)
+        self.assertEqual(f_b.vertex(1), 1)
+
+        v0 = mut.SurfaceVertex((-1,  1, 0))
+        v1 = mut.SurfaceVertex((1,  1, 0))
+        v2 = mut.SurfaceVertex((-1, -1, 0))
+        v3 = mut.SurfaceVertex((1, -1, 0))
+
+        self.assertListEqual(list(v0.r_MV()), [-1, 1, 0])
+
+        mesh = mut.SurfaceMesh(faces=(f_a, f_b), vertices=(v0, v1, v2, v3))
+        self.assertEqual(len(mesh.faces()), 2)
+        self.assertEqual(len(mesh.vertices()), 4)
+        self.assertListEqual(list(mesh.centroid()), [0, 0, 0])
+
+    def test_volume_mesh(self):
+        # Create a mesh out of two tetrahedra with a single, shared face
+        # (1, 2, 3).
+        #
+        #            +y
+        #            |
+        #            o v2
+        #            |
+        #       v4   | v1   v0
+        #    ───o────o─────o──  +x
+        #           /
+        #          /
+        #         o v3
+        #        /
+        #      +z
+
+        t_left = mut.VolumeElement(v0=mut.VolumeVertexIndex(2),
+                                   v1=mut.VolumeVertexIndex(1),
+                                   v2=mut.VolumeVertexIndex(3),
+                                   v3=mut.VolumeVertexIndex(4))
+        t_right = mut.VolumeElement(v0=mut.VolumeVertexIndex(3),
+                                    v1=mut.VolumeVertexIndex(1),
+                                    v2=mut.VolumeVertexIndex(2),
+                                    v3=mut.VolumeVertexIndex(0))
+        self.assertEqual(t_left.vertex(0), 2)
+        self.assertEqual(t_right.vertex(1), 1)
+
+        v0 = mut.VolumeVertex((1, 0,  0))
+        v1 = mut.VolumeVertex((0, 0,  0))
+        v2 = mut.VolumeVertex((0, 1,  0))
+        v3 = mut.VolumeVertex((0, 0, 1))
+        v4 = mut.VolumeVertex((-1, 0,  0))
+
+        self.assertListEqual(list(v0.r_MV()), [1, 0, 0])
+
+        mesh = mut.VolumeMesh(elements=(t_left, t_right),
+                              vertices=(v0, v1, v2, v3, v4))
+
+        self.assertEqual(len(mesh.tetrahedra()), 2)
+        self.assertIsInstance(mesh.tetrahedra()[0], mut.VolumeElement)
+        self.assertEqual(len(mesh.vertices()), 5)
+        self.assertIsInstance(mesh.vertices()[0], mut.VolumeVertex)
+
+        self.assertAlmostEqual(
+            mesh.CalcTetrahedronVolume(e=mut.VolumeElementIndex(1)),
+            1/6.0,
+            delta=1e-15)
+        self.assertAlmostEqual(mesh.CalcVolume(), 1/3.0, delta=1e-15)
+
     def test_read_obj_to_surface_mesh(self):
         mesh_path = FindResourceOrThrow("drake/geometry/test/quad_cube.obj")
         mesh = mut.ReadObjToSurfaceMesh(mesh_path)


### PR DESCRIPTION
Some preliminary bindings already exists for `SurfaceMesh`. This beefs them up (bindings on index types and defining the `SurfaceFace`) so that a `SurfaceMesh` can actually be constructed in python.

It completely creates the `VolumeMesh` binding to the same level of support.

Both are tested.

Relates #15738

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15707)
<!-- Reviewable:end -->
