### PR TITLE
[tools] Restore build_components_refresh to idempotency

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -37,6 +37,7 @@ drake_cc_package_library(
         ":internal_frame",
         ":internal_geometry",
         ":meshcat",
+        ":meshcat_types",
         ":meshcat_visualizer",
         ":meshcat_visualizer_params",
         ":proximity_engine",
@@ -349,10 +350,6 @@ drake_cc_library(
     name = "meshcat_types",
     hdrs = ["meshcat_types.h"],
     install_hdrs_exclude = ["meshcat_types.h"],
-    tags = [
-        "exclude_from_libdrake",
-        "exclude_from_package",
-    ],
     deps = ["@msgpack"],
 )
 

--- a/tools/install/libdrake/build_components_refresh.py
+++ b/tools/install/libdrake/build_components_refresh.py
@@ -50,6 +50,7 @@ kind("cc_library", visible("//tools/install/libdrake:libdrake.so", "//..."))
     )
     except("//lcmtypes/...")
     except("//tools/install/...")
+    except("//tools/performance/...")
     except(attr(tags, "exclude_from_libdrake", //...))
 """
     # First, find the drake_cc_package_library targets within that query.


### PR DESCRIPTION
Exclude tools/performance.  The helpers for googlebenchmark should never be part of libdrake, because libdrake does not depend on googlebenchmark.

Unflag meshcat_types as excluded form libdrake.  It was always transitively included anyway, so the extra tags served no purpose.  The only important attribute was "install_hdrs_exclude", which we leave intact.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15709)
<!-- Reviewable:end -->
