### PR TITLE
[setup] Upgrade bazel to latest release 4.2.1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,4 +19,4 @@ load("@bazel_skylib//lib:versions.bzl", "versions")
 # This needs to be in WORKSPACE or a repository rule for native.bazel_version
 # to actually be defined. The minimum_bazel_version value should match the
 # version passed to the find_package(Bazel) call in the root CMakeLists.txt.
-versions.check(minimum_bazel_version = "3.0")
+versions.check(minimum_bazel_version = "4.0")

--- a/doc/_pages/developers.md
+++ b/doc/_pages/developers.md
@@ -68,10 +68,10 @@ Drake requires a compiler running in C++17 mode.
 
 | Operating System                 | Bazel | CMake | C/C++ Compiler                 | Java                          | Python |
 |----------------------------------|-------|-------|--------------------------------|-------------------------------|--------|
-| Ubuntu 18.04 LTS (Bionic Beaver) | 4.1   | 3.10  | GCC 7.5 (default) or Clang 9   | OpenJDK 11                    | 3.6    |
-| Ubuntu 20.04 LTS (Focal Fossa)   | 4.1   | 3.16  | GCC 9.3 (default) or Clang 9   | OpenJDK 11                    | 3.8    |
-| macOS Catalina (10.15)           | 4.1   | 3.19  | Apple LLVM 12.0.0 (Xcode 12.4) | AdoptOpenJDK 15 (HotSpot JVM) | 3.9    |
-| macOS Big Sur (11)               | 4.1   | 3.19  | Apple LLVM 12.0.0 (Xcode 12.4) | AdoptOpenJDK 15 (HotSpot JVM) | 3.9    |
+| Ubuntu 18.04 LTS (Bionic Beaver) | 4.2   | 3.10  | GCC 7.5 (default) or Clang 9   | OpenJDK 11                    | 3.6    |
+| Ubuntu 20.04 LTS (Focal Fossa)   | 4.2   | 3.16  | GCC 9.3 (default) or Clang 9   | OpenJDK 11                    | 3.8    |
+| macOS Catalina (10.15)           | 4.2   | 3.19  | Apple LLVM 12.0.0 (Xcode 12.4) | AdoptOpenJDK 15 (HotSpot JVM) | 3.9    |
+| macOS Big Sur (11)               | 4.2   | 3.19  | Apple LLVM 12.0.0 (Xcode 12.4) | AdoptOpenJDK 15 (HotSpot JVM) | 3.9    |
 
 CPython is the only Python implementation supported. On Ubuntu, amd64
 (i.e., x86_64) is the only supported architecture. On macOS, x86_64 is the only

--- a/doc/_release-notes/v0.32.0.md
+++ b/doc/_release-notes/v0.32.0.md
@@ -165,6 +165,7 @@ Newly bound
 * Upgrade meshcat_python to latest commit ([#15296][_#15296])
 * Upgrade rules_python to latest release 0.3.0 ([#15289][_#15289])
 * Upgrade tinyobjloader to latest commit ([#15278][_#15278])
+* Drake now requires Bazel version 4.0 or greater ([#15289][_#15289])
 
 ## Newly-deprecated APIs
 

--- a/setup/ubuntu/source_distribution/install_prereqs.sh
+++ b/setup/ubuntu/source_distribution/install_prereqs.sh
@@ -168,6 +168,6 @@ EOF
 )
 
 dpkg_install_from_wget \
-  bazel 4.1.0 \
-  https://releases.bazel.build/4.1.0/release/bazel_4.1.0-linux-x86_64.deb \
-  ce403656e027d0099187908c272c612fcebd1c5cca1b074357f0088beb15cd9c
+  bazel 4.2.1 \
+  https://releases.bazel.build/4.2.1/release/bazel_4.2.1-linux-x86_64.deb \
+  67447658b8313316295cd98323dfda2a27683456a237f7a3226b68c9c6c81b3a


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/releases/tag/4.2.1

Set our minimum supported bazel version to `>= 4.0`.  We have not been compatible with the bazel `3.x` series since we upgraded `rules_python` on July 1st (#15289) and `rules_pkg` on August 2nd (#15548).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15711)
<!-- Reviewable:end -->
