### PR TITLE
[workspace] Upgrade lcm to latest commit

### DIFF
--- a/tools/workspace/lcm/repository.bzl
+++ b/tools/workspace/lcm/repository.bzl
@@ -8,8 +8,8 @@ def lcm_repository(
     github_archive(
         name = name,
         repository = "lcm-proj/lcm",
-        commit = "98893d8cb34cc86203235f2e41b740bf216b97c3",
-        sha256 = "5c9beb7e4d6f2aef4f6a51dc9c7ee687ba3a2c9a25f8228d9a0b126980db4477",  # noqa
+        commit = "e83d2d0810c7f1751123383ab7c3dc4da1b53602",
+        sha256 = "13f478db7002165e9987b6e6cbcc8e42e2c103c882b360236b83c9ba5355f539",  # noqa
         build_file = "@drake//tools/workspace/lcm:package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
Note that this upgrade contains a fix to mutex locking (https://github.com/lcm-proj/lcm/pull/354), so might warrant additional caution when monitoring for regressions after the upgrade.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15717)
<!-- Reviewable:end -->
