### PR TITLE
[workspace] Upgrade googlebenchmark to latest release 1.5.6

### DIFF
--- a/tools/workspace/googlebenchmark/repository.bzl
+++ b/tools/workspace/googlebenchmark/repository.bzl
@@ -8,7 +8,7 @@ def googlebenchmark_repository(
     github_archive(
         name = name,
         repository = "google/benchmark",
-        commit = "v1.5.5",
-        sha256 = "3bff5f237c317ddfd8d5a9b96b3eede7c0802e799db520d38ce756a2a46a18a0",  # noqa
+        commit = "v1.5.6",
+        sha256 = "789f85b4810d13ff803834ea75999e41b326405d83d6a538baf01499eda96102",  # noqa
         mirrors = mirrors,
     )


### PR DESCRIPTION
https://github.com/google/benchmark/releases/tag/v1.5.6

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15718)
<!-- Reviewable:end -->
