### PR TITLE
a fascinating compiler rathole

### DIFF
--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -163,7 +163,8 @@ void DoScalarDependentDefinitions(py::module m, T) {
             py::arg("b_A"), py::arg("axis_index"),
             cls_doc.MakeFromOneVector.doc)
         .def_static("Identity", &Class::Identity, cls_doc.Identity.doc)
-        .def("set", &Class::set, py::arg("R"), cls_doc.set.doc)
+        .def("set", py::overload_cast<const Matrix3<T>&>(&Class::set),
+            py::arg("R"), cls_doc.set.doc)
         .def("inverse", &Class::inverse, cls_doc.inverse.doc)
         .def("transpose", &Class::transpose, cls_doc.transpose.doc)
         .def("matrix", &Class::matrix, cls_doc.matrix.doc)

--- a/common/autodiffxd.h
+++ b/common/autodiffxd.h
@@ -18,6 +18,7 @@
 
 #include <cmath>
 #include <ostream>
+#include <utility>
 
 #include <Eigen/Dense>
 

--- a/examples/multibody/cassie_benchmark/test/cassie_bench.cc
+++ b/examples/multibody/cassie_benchmark/test/cassie_bench.cc
@@ -210,7 +210,7 @@ BENCHMARK_F(CassieAutodiffFixture, AutodiffMassMatrix)
 
   for (int k = 0; k < 3; k++) {
     // @see LimitMalloc note above.
-    LimitMalloc guard(LimitReleaseOnly(31426));
+    LimitMalloc guard(LimitReleaseOnly(31273));
 
     compute();
 
@@ -247,7 +247,7 @@ BENCHMARK_F(CassieAutodiffFixture, AutodiffInverseDynamics)
 
   for (int k = 0; k < 3; k++) {
     // @see LimitMalloc note above.
-    LimitMalloc guard(LimitReleaseOnly(38049));
+    LimitMalloc guard(LimitReleaseOnly(37698));
 
     compute();
 

--- a/math/rotation_matrix.h
+++ b/math/rotation_matrix.h
@@ -67,6 +67,7 @@ class RotationMatrix {
   /// @param[in] R an allegedly valid rotation matrix.
   /// @throws std::exception in debug builds if R fails IsValid(R).
   explicit RotationMatrix(const Matrix3<T>& R) { set(R); }
+  explicit RotationMatrix(Matrix3<T>&& R) { set(std::move(R)); }
 
   /// Constructs a %RotationMatrix from an Eigen::Quaternion.
   /// @param[in] quaternion a non-zero, finite quaternion which may or may not
@@ -357,6 +358,10 @@ class RotationMatrix {
   void set(const Matrix3<T>& R) {
     DRAKE_ASSERT_VOID(ThrowIfNotValid(R));
     SetUnchecked(R);
+  }
+  void set(Matrix3<T>&& R) {
+    DRAKE_ASSERT_VOID(ThrowIfNotValid(R));
+    SetUnchecked(std::move(R));
   }
 
   /// Returns the 3x3 identity %RotationMatrix.
@@ -736,6 +741,7 @@ class RotationMatrix {
   // test whether or not the parameter R is a valid rotation matrix.
   // @param[in] R an allegedly valid rotation matrix.
   void SetUnchecked(const Matrix3<T>& R) { R_AB_ = R; }
+  void SetUnchecked(Matrix3<T>&& R) { R_AB_ = std::move(R); }
 
   // Sets `this` %RotationMatrix `R_AB` from right-handed orthogonal unit
   // vectors `Bx`, `By`, `Bz` so that the columns of `this` are `[Bx, By, Bz]`.

--- a/math/rotation_matrix.h
+++ b/math/rotation_matrix.h
@@ -5,6 +5,7 @@
 #include <stdexcept>
 #include <string>
 #include <type_traits>
+#include <utility>
 
 #include <Eigen/Dense>
 
@@ -67,6 +68,7 @@ class RotationMatrix {
   /// @param[in] R an allegedly valid rotation matrix.
   /// @throws std::exception in debug builds if R fails IsValid(R).
   explicit RotationMatrix(const Matrix3<T>& R) { set(R); }
+  // @exclude_from_pydrake_mkdoc{Not bound in pydrake.}
   explicit RotationMatrix(Matrix3<T>&& R) { set(std::move(R)); }
 
   /// Constructs a %RotationMatrix from an Eigen::Quaternion.
@@ -359,6 +361,7 @@ class RotationMatrix {
     DRAKE_ASSERT_VOID(ThrowIfNotValid(R));
     SetUnchecked(R);
   }
+  // @exclude_from_pydrake_mkdoc{Not bound in pydrake.}
   void set(Matrix3<T>&& R) {
     DRAKE_ASSERT_VOID(ThrowIfNotValid(R));
     SetUnchecked(std::move(R));


### PR DESCRIPTION
This little bit of code polishes up a small improvement in autodiff heap metrics (less than 1%) that I found months ago, but could not merge. It turns out that defaulted move operators in AutoDiffXd's implementation could trigger gcc (only) release mode (only) "maybe-uninitialized" warnings (not sure what other conditions are necessary).

At the time, I suppressed the warnings by adding zeroing of m_value, which got shot down (without a great deal of evidence presented, but I digress).  Today's discovery is that manual implementations of the operators preserve the heap wins, and suppress the warnings.

I'm currently less interested in this as a performance win for autodiff (it may be -- haven't done the full assessment yet), than as a dusty and dangerous corner of modern c++ compilers. It is possible that getting past the warnings may open up a whole set of opportunities for heap optimization in the lower and middle layers of the MBP/Autodiff stack (spatial algebra, frames, etc.).

Presented here as a an object of discussion for the curious.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15722)
<!-- Reviewable:end -->
