### PR TITLE
[geometry:meshcat] Add support for ports and public_urls

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -1567,8 +1567,10 @@ void DoScalarIndependentDefinitions(py::module m) {
     constexpr auto& cls_doc = doc.Meshcat;
     py::class_<Class, std::shared_ptr<Class>> cls(m, "Meshcat", cls_doc.doc);
     cls  // BR
-        .def(py::init<>(), cls_doc.ctor.doc)
+        .def(py::init<const std::optional<int>&>(),
+            py::arg("port") = std::nullopt, cls_doc.ctor.doc)
         .def("web_url", &Class::web_url, cls_doc.web_url.doc)
+        .def("port", &Class::port, cls_doc.port.doc)
         .def("ws_url", &Class::ws_url, cls_doc.ws_url.doc)
         .def("SetObject", &Class::SetObject, py::arg("path"), py::arg("shape"),
             py::arg("rgba") = Rgba(.9, .9, .9, 1.), cls_doc.SetObject.doc)

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -368,7 +368,10 @@ class TestGeometry(unittest.TestCase):
         draw_subscriber.clear()
 
     def test_meshcat(self):
-        meshcat = mut.Meshcat()
+        meshcat = mut.Meshcat(port=7051)
+        self.assertEqual(meshcat.port(), 7051)
+        with self.assertRaises(RuntimeError):
+            meshcat2 = mut.Meshcat(port=7051)
         self.assertIn("http", meshcat.web_url())
         self.assertIn("ws", meshcat.ws_url())
         meshcat.SetObject(path="/test/box",

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -441,6 +441,7 @@ drake_cc_googletest(
     deps = [
         ":meshcat",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "drake/common/drake_copyable.h"
@@ -77,14 +78,19 @@ class Meshcat {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Meshcat)
 
-  /** Constructs the Meshcat instance. It will listen on the first available
-  port starting at 7001 (up to 7099). */
-  Meshcat();
+  /** Constructs the Meshcat instance on `port`. If no port is specified, the it
+  will listen on the first available port starting at 7000 (up to 7099).
+  @pre We require `port` >= 1024.
+  @throws std::exception if no requested `port` is available. */
+  explicit Meshcat(const std::optional<int>& port = std::nullopt);
 
   ~Meshcat();
 
   /** Returns the hosted http URL. */
   std::string web_url() const;
+
+  /** Returns the port on localhost listening for http connections. */
+  int port() const;
 
   /** (Advanced) Returns the ws:// URL for direct connection to the websocket
   interface.  Most users should connect via a browser opened to web_url(). */

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -9,6 +9,7 @@
 
 #include "drake/common/find_resource.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/meshcat_types.h"
 
 namespace drake {
@@ -55,6 +56,20 @@ GTEST_TEST(MeshcatTest, ConstructMultiple) {
   EXPECT_THAT(meshcat2.web_url(), HasSubstr("http://localhost:"));
   EXPECT_THAT(meshcat2.ws_url(), HasSubstr("ws://localhost:"));
   EXPECT_NE(meshcat.web_url(), meshcat2.web_url());
+}
+
+GTEST_TEST(MeshcatTest, Ports) {
+  Meshcat meshcat(7050);
+  EXPECT_EQ(meshcat.port(), 7050);
+
+  // Can't open the same port twice.
+  DRAKE_EXPECT_THROWS_MESSAGE(Meshcat m2(7050),
+                              "Meshcat failed to open a websocket port.");
+
+  // The default constructor gets a default port.
+  Meshcat m3;
+  EXPECT_GE(m3.port(), 7000);
+  EXPECT_LE(m3.port(), 7099);
 }
 
 // The correctness of this is established with meshcat_manual_test.  Here we


### PR DESCRIPTION
- Adds an option for taking the port in the Meshcat constructor
- Adds an option for setting the web_url (e.g. to be the web or proxy server address).
- Moves the `throw std::runtime_error` from the websocket thread to the main thread so that one can catch failures to open a requested port.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15727)
<!-- Reviewable:end -->
