### PR TITLE
[geometry] SceneGraphInspector can report hydro representation

### DIFF
--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -15,6 +15,7 @@
 #include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/proximity_engine.h"
+#include "drake/geometry/proximity_properties.h"
 #include "drake/geometry/render/render_engine.h"
 #include "drake/geometry/utilities.h"
 
@@ -22,6 +23,7 @@ namespace drake {
 namespace geometry {
 
 using internal::convert_to_double;
+using internal::HydroelasticType;
 using internal::InternalFrame;
 using internal::InternalGeometry;
 using internal::ProximityEngine;
@@ -386,6 +388,32 @@ const math::RigidTransform<double>& GeometryState<T>::GetPoseInParent(
     GeometryId geometry_id) const {
   const auto& geometry = GetValueOrThrow(geometry_id, geometries_);
   return geometry.X_PG();
+}
+
+template <typename T>
+std::variant<std::monostate, const SurfaceMesh<double>*,
+             const VolumeMesh<double>*>
+GeometryState<T>::maybe_get_hydroelastic_mesh(GeometryId geometry_id) const {
+  const auto& hydro_geometries = geometry_engine_->hydroelastic_geometries();
+  switch (hydro_geometries.hydroelastic_type(geometry_id)) {
+    case HydroelasticType::kUndefined:
+      break;
+    case HydroelasticType::kRigid: {
+      const auto& rigid = hydro_geometries.rigid_geometry(geometry_id);
+      if (!rigid.is_half_space()) {
+        return &rigid.mesh();
+      }
+      break;
+    }
+    case HydroelasticType::kSoft: {
+      const auto& soft = hydro_geometries.soft_geometry(geometry_id);
+      if (!soft.is_half_space()) {
+        return &soft.mesh();
+      }
+      break;
+    }
+  }
+  return {};
 }
 
 template <typename T>

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -7,6 +7,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "drake/common/autodiff.h"
@@ -227,6 +228,12 @@ class GeometryState {
   /** Implementation of SceneGraphInspector::X_PG().  */
   const math::RigidTransform<double>& GetPoseInParent(
       GeometryId geometry_id) const;
+
+  /** Implementation of
+   SceneGraphInspector::maybe_get_hydroelastic_mesh().  */
+  std::variant<std::monostate, const SurfaceMesh<double>*,
+               const VolumeMesh<double>*>
+  maybe_get_hydroelastic_mesh(GeometryId geometry_id) const;
 
   /** Implementation of SceneGraphInspector::GetProximityProperties().  */
   const ProximityProperties* GetProximityProperties(GeometryId id) const;

--- a/geometry/proximity_engine.h
+++ b/geometry/proximity_engine.h
@@ -258,6 +258,10 @@ class ProximityEngine {
 
   //@}
 
+  /* The representation of every geometry that was successfully requested for
+   use for hydroelastic contact surface computation. */
+  const hydroelastic::Geometries& hydroelastic_geometries() const;
+
  private:
   // Testing utilities:
   // These functions facilitate *limited* introspection into the engine state.
@@ -270,10 +274,6 @@ class ProximityEngine {
   // Reports the pose (X_WG) of the geometry with the given id.
   const math::RigidTransform<double> GetX_WG(GeometryId id,
                                              bool is_dynamic) const;
-
-  // The representation of every geometry that was successfully requested for
-  // use for hydroelastic contact surface computation.
-  const hydroelastic::Geometries& hydroelastic_geometries() const;
 
   ////////////////////////////////////////////////////////////////////////////
 

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <unordered_set>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "drake/common/drake_deprecated.h"
@@ -405,6 +406,37 @@ class SceneGraphInspector {
       GeometryId geometry_id) const {
     DRAKE_DEMAND(state_ != nullptr);
     return state_->GetPoseInFrame(geometry_id);
+  }
+
+  /** Returns the *mesh* used to represent this geometry in hydroelastic contact
+   calculations, if it exists. Most primitives (sphere, cylinder, etc.) are
+   actually represented by discrete approximations (i.e., the mesh). If there is
+   no mesh, the returned variant will hold neither the SurfaceMesh<double> nor
+   the VolumeMesh<double> alternatives. If either alternative is present, the
+   pointer is guaranteed to be non-null.
+
+   Just because hydroelastic properties have been assigned to a geometry does
+   *not* mean there is necessarily a mesh associated with it. Some shape types
+   (e.g., half space) have non-mesh representations.
+
+   The result can be tested as follows:
+
+   @code
+     auto maybe_mesh = inspector.maybe_get_hydroelastic_mesh(id);
+
+     // These two methods are equivalent, although testing index is more
+     // brittle.
+     const bool no_mesh1 = maybe_mesh.index() == 0;
+     const bool no_mesh2 = std::holds_alternative<std::monostate>(maybe_mesh);
+   @endcode
+
+   @param geometry_id  The id of the geometry to query.
+   @returns The associated mesh, if it exists. */
+  std::variant<std::monostate, const SurfaceMesh<double>*,
+               const VolumeMesh<double>*>
+  maybe_get_hydroelastic_mesh(GeometryId geometry_id) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->maybe_get_hydroelastic_mesh(geometry_id);
   }
 
   /** Return a pointer to the const properties indicated by `role` of the

--- a/geometry/test/scene_graph_inspector_test.cc
+++ b/geometry/test/scene_graph_inspector_test.cc
@@ -93,6 +93,7 @@ GTEST_TEST(SceneGraphInspector, ExerciseEverything) {
   inspector.GetShape(geometry_id);
   inspector.GetPoseInParent(geometry_id);
   inspector.GetPoseInFrame(geometry_id);
+  inspector.maybe_get_hydroelastic_mesh(geometry_id);
   inspector.GetProximityProperties(geometry_id);
   inspector.GetIllustrationProperties(geometry_id);
   inspector.GetPerceptionProperties(geometry_id);


### PR DESCRIPTION
We've introduced two new methods:
  - `has_hydroelastic_representation()`
  - `get_hydroelastic_mesh_representation()`

Between the two, anyone will be able to determine if a geometry *has* a hydro representation and, if it is a mesh, get the mesh data.

Relates #15738

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15739)
<!-- Reviewable:end -->
