### PR TITLE
[geometry] Hydroelastic contact vis uses "minimally unique names"

### DIFF
--- a/examples/scene_graph/simple_contact_surface_vis.cc
+++ b/examples/scene_graph/simple_contact_surface_vis.cc
@@ -57,6 +57,7 @@ using geometry::IllustrationProperties;
 using geometry::PenetrationAsPointPair;
 using geometry::ProximityProperties;
 using geometry::QueryObject;
+using geometry::Role;
 using geometry::SceneGraph;
 using geometry::SourceId;
 using geometry::Sphere;
@@ -84,6 +85,9 @@ DEFINE_bool(rigid_cylinders, true,
             "Set to true, the cylinders are given a rigid "
             "hydroelastic representation");
 DEFINE_bool(hybrid, false, "Set to true to run hybrid hydroelastic");
+DEFINE_bool(force_full_name, false,
+            "If true, the message will declare the body names are not unique, "
+            "forcing the visualizer to use the full model/body names.");
 
 /* To help simulate MultibodyPlant; we're going to assign frames "frame groups"
  that correlate with MbP's "model instance indices". We're defining the indices
@@ -246,6 +250,9 @@ class ContactResultMaker final : public LeafSystem<double> {
       surface_msg.model1_name =
           ModelInstanceName(inspector.GetFrameGroup(f_id1));
       surface_msg.geometry1_name = inspector.GetName(id1);
+      surface_msg.body1_unique = !FLAGS_force_full_name;
+      surface_msg.collision_count1 = inspector.NumGeometriesForFrameWithRole(
+          inspector.GetFrameId(id1), Role::kProximity);
 
       const GeometryId id2 = surfaces[i].id_N();
       const FrameId f_id2 = inspector.GetFrameId(id2);
@@ -253,6 +260,9 @@ class ContactResultMaker final : public LeafSystem<double> {
       surface_msg.model2_name =
           ModelInstanceName(inspector.GetFrameGroup(f_id2));
       surface_msg.geometry2_name = inspector.GetName(id2);
+      surface_msg.body2_unique = !FLAGS_force_full_name;
+      surface_msg.collision_count2 = inspector.NumGeometriesForFrameWithRole(
+          inspector.GetFrameId(id2), Role::kProximity);
 
       const SurfaceMesh<double>& mesh_W = surfaces[i].mesh_W();
       surface_msg.num_triangles = mesh_W.num_faces();

--- a/lcmtypes/lcmt_hydroelastic_contact_surface_for_viz.lcm
+++ b/lcmtypes/lcmt_hydroelastic_contact_surface_for_viz.lcm
@@ -7,13 +7,27 @@ struct lcmt_hydroelastic_contact_surface_for_viz {
   //   - name of the geometry affixed to the body which produced the surface.
   //   - name of the body.
   //   - name of the model instance to which the body belongs.
+  //   - uniqueness of the body name. If unique, the body can unambiguously be
+  //     represented by just its body name. Otherwise it must be combined with
+  //     its model instance name. The validity of this logic relies on
+  //     MultibodyPlant's requirement that model instance names must be unique.
+  //   - the number of collision geometries affixed to the body. If the
+  //     colliding bodies both have a single collision geometry each, there can
+  //     be only one contact surface between them and display can be
+  //     streamlined. Otherwise, the possibility of multiple contact surfaces
+  //     needs to be accounted for.
   //
   string geometry1_name;
   string body1_name;
   string model1_name;
+  boolean body1_unique;
+  int32_t collision_count1;
+
   string geometry2_name;
   string body2_name;
   string model2_name;
+  boolean body2_unique;
+  int32_t collision_count2;
 
   // The centroid of the contact surface, as an offset vector expressed in the
   // world frame.

--- a/multibody/plant/contact_results_to_lcm.h
+++ b/multibody/plant/contact_results_to_lcm.h
@@ -23,15 +23,28 @@ namespace multibody {
 namespace internal {
 
 /* Stores the "full" name of a body *in contact*: its model instance name, body
- name, and geometry name. This assumes that `model_name` is guaranteed to be
+ name, and geometry name. This assumes that `model` name is guaranteed to be
  unique within MBP. So, for two bodies which may be identically named (body
  name), they *must* differ by model name. For a body that has multiple collision
  geometries, we rely on the fact that every collision geometry for a single
- frame must be uniquely named. */
+ frame must be uniquely named.
+
+ This includes further information to allow visualizers to make streamlining
+ decisions. It reports if the body name is unique across the entire plant
+ (body_name_is_unique) and the number of collision geometries associated
+ with the body.
+
+ If the body name is unique, the visualizer can display only the body
+ name without fear of introducing ambiguity. Furthermore, with the number
+ collision geometries per body, the visualizer can draw conclusions about
+ the possible number of contact patches between bodies and streamline
+ accordingly. */
 struct FullBodyName {
   std::string model;
   std::string body;
   std::string geometry;
+  bool body_name_is_unique;
+  int geometry_count;
 };
 
 /* Facilitate unit testing. See ContactResultsToLcmSystem::Equals(). */

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3483,6 +3483,12 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     return internal_tree().HasBodyNamed(name);
   }
 
+  /// @returns The total number of bodies (across all model instances) with the
+  /// given name.
+  int NumBodiesWithName(std::string_view name) const {
+    return internal_tree().NumBodiesWithName(name);
+  }
+
   /// @returns `true` if a body named `name` was added to the %MultibodyPlant
   /// in @p model_instance.
   /// @see AddRigidBody().

--- a/multibody/plant/test/multibody_plant_test.cc
+++ b/multibody/plant/test/multibody_plant_test.cc
@@ -220,6 +220,9 @@ GTEST_TEST(MultibodyPlant, SimpleModelCreation) {
   EXPECT_TRUE(plant->HasBodyNamed(parameters.link1_name()));
   EXPECT_TRUE(plant->HasBodyNamed(parameters.link2_name()));
   EXPECT_FALSE(plant->HasBodyNamed(kInvalidName));
+  // Indicator that the plant is calling the tree's method correctly.
+  EXPECT_EQ(plant->NumBodiesWithName(parameters.link1_name()), 1);
+  EXPECT_EQ(plant->NumBodiesWithName(kInvalidName), 0);
 
   EXPECT_TRUE(plant->HasJointNamed(parameters.shoulder_joint_name()));
   EXPECT_TRUE(plant->HasJointNamed(parameters.elbow_joint_name()));

--- a/multibody/tree/multibody_tree.cc
+++ b/multibody/tree/multibody_tree.cc
@@ -303,6 +303,11 @@ const auto& GetElementByName(
 }  // namespace
 
 template <typename T>
+int MultibodyTree<T>::NumBodiesWithName(std::string_view name) const {
+  return static_cast<int>(body_name_to_index_.count(name));
+}
+
+template <typename T>
 bool MultibodyTree<T>::HasBodyNamed(std::string_view name) const {
   return HasElementNamed(*this, name, std::nullopt, body_name_to_index_);
 }

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -755,6 +755,9 @@ class MultibodyTree {
   // the model.
   // @{
 
+  // See MultibodyPlant method.
+  int NumBodiesWithName(std::string_view name) const;
+
   // @returns `true` if a body named `name` was added to the model.
   // @see AddRigidBody().
   //

--- a/multibody/tree/test/multibody_tree_test.cc
+++ b/multibody/tree/test/multibody_tree_test.cc
@@ -100,8 +100,10 @@ void VerifyModelBasics(const MultibodyTree<T>& model) {
   // Query if elements exist in the model.
   for (const std::string& link_name : kLinkNames) {
     EXPECT_TRUE(model.HasBodyNamed(link_name));
+    EXPECT_EQ(model.NumBodiesWithName(link_name), 1);
   }
   EXPECT_FALSE(model.HasBodyNamed(kInvalidName));
+  EXPECT_EQ(model.NumBodiesWithName(kInvalidName), 0);
 
   for (const std::string& frame_name : kFrameNames) {
     EXPECT_TRUE(model.HasFrameNamed(frame_name));
@@ -268,6 +270,9 @@ GTEST_TEST(MultibodyTree, RetrievingAmbiguousNames) {
       model->AddRigidBody(link_name, world_model_instance(),
                           SpatialInertia<double>()));
   EXPECT_NO_THROW(model->Finalize());
+
+  // Link name is ambiguous, there are more than one bodies that use the name.
+  EXPECT_GT(model->NumBodiesWithName(link_name), 1);
 
   // Checking if the name exists throws (unfortunately), unless we specify the
   // intended model instance.


### PR DESCRIPTION
The "minimally unique name" is predicated on whether a body has a unique name across *all* model instances. If it does, it can be displayed simply as "body" in visualization. Otherwise, it must be displayed as "model/body".

Furthermore, on a per-contact surface resolution, it determines if displaying geometry names is *necessary* or not. It is necessary if either body in contact has multiple collision geometries.

This extends the lcm message to give the visualizer sufficient information to make the display decision.

 - `MultibodyPlant` provides the API to report how many bodies share a name.
 - LCM message is extended to include uniqueness data.
 - Visualization removes the option to toggle "full names" and just always uses the minimal names.

This has *one* regrettable artifact.
 - geometry names registered by `MultibodyPlant` are defined as "model name/geometry name". This comes from using `MultibodPlant.GetScopedName()` on *geometry* names when registering. It is not clear that applying scoped names to geometry has any value.

(Related to #15706, the final step in the fix. This is the polish.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15741)
<!-- Reviewable:end -->
