### PR TITLE
[tools] Do our best to avoid downloading a remote JDK during build

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -133,4 +133,7 @@ config_setting(
     values = {"define": "NO_SCS=ON"},
 )
 
+# A stub for disabling coverage tools.
+filegroup(name = "dummy_filegroup")
+
 add_lint_tests()

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -14,6 +14,15 @@ build --force_pic
 build --strip=never
 build --strict_system_includes
 
+# Disable coverage tools, to reduce our downloaded dependencies.
+build --coverage_report_generator=//tools:dummy_filegroup
+build --coverage_support=//tools:dummy_filegroup
+
+# Always use the local JDK, not a remote JDK, even for host tools.
+# (Note that this is the spelling as of Bazel 4.x; as of Bazel 5.x, it
+# will be something more like --tool_java_runtime_version=local_jdk.)
+build --host_javabase=@bazel_tools//tools/jdk:jdk
+
 # Default test options.
 test --test_output=errors
 test --test_summary=terse

--- a/tools/install/bazel/test/drake_bazel_installed_test.py
+++ b/tools/install/bazel/test/drake_bazel_installed_test.py
@@ -104,9 +104,13 @@ import pydrake.all
         "--announce_rc",
         # Use "release engineering" options for hermeticity.
         "--nokeep_state_after_build",
-        # Nerf the coverage reporter to avoid downloading the entire JDK afresh
-        # from the internet every time we run this test.
+        # Avoid downloading an entire JDK afresh from the internet every time
+        # we run this test (N.B. these are copied from drake/tools/bazel.rc):
+        #  Use the local JDK.
+        "--host_javabase=@bazel_tools//tools/jdk:jdk",
+        #  Disable coverage tools.
         "--coverage_report_generator=//:dummy_filegroup",
+        "--coverage_support=//:dummy_filegroup",
         ])
 
 


### PR DESCRIPTION
The JDK mirror has become flaky, so we should try not to use it.

Closes #15740.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15742)
<!-- Reviewable:end -->
