### PR TITLE
Prototyping visualization for polygonal hydro. contact surfaces

### DIFF
--- a/geometry/query_results/BUILD.bazel
+++ b/geometry/query_results/BUILD.bazel
@@ -16,6 +16,7 @@ drake_cc_package_library(
     deps = [
         ":contact_surface",
         ":penetration_as_point_pair",
+        ":polygonal_contact_surface",
         ":signed_distance_pair",
         ":signed_distance_to_point",
     ],
@@ -64,6 +65,20 @@ drake_cc_library(
         "//geometry:geometry_ids",
         "//geometry/proximity:mesh_field",
         "//math:geometric_transform",
+    ],
+)
+
+drake_cc_library(
+    name = "polygonal_contact_surface",
+    srcs = [
+        "polygonal_contact_surface.cc",
+    ],
+    hdrs = [
+        "polygonal_contact_surface.h",
+    ],
+    deps = [
+        "//common",
+        "//geometry:geometry_ids",
     ],
 )
 

--- a/geometry/query_results/polygonal_contact_surface.cc
+++ b/geometry/query_results/polygonal_contact_surface.cc
@@ -1,0 +1,13 @@
+#include "drake/geometry/query_results/polygonal_contact_surface.h"
+
+#include "drake/common/default_scalars.h"
+
+namespace drake {
+namespace geometry {
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class PolygonalContactSurface);
+
+}  // namespace geometry
+}  // namespace drake
+

--- a/geometry/query_results/polygonal_contact_surface.h
+++ b/geometry/query_results/polygonal_contact_surface.h
@@ -1,0 +1,352 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/geometry/geometry_ids.h"
+
+namespace drake {
+namespace geometry {
+
+/** The %PolygonalContactSurface characterizes the intersection of two
+  geometries M and N as a contact surface with a scalar field and a vector
+  field, whose purpose is to support the hydroelastic pressure field contact
+  model as described in:
+
+      R. Elandt, E. Drumwright, M. Sherman, and Andy Ruina. A pressure
+      field model for fast, robust approximation of net contact force
+      and moment between nominally rigid objects. IROS 2019: 8238-8245.
+
+  <h2> Mathematical Concepts </h2>
+
+  In this section, we give motivation for the concept of contact surface from
+  the hydroelastic pressure field contact model. Here the mathematical
+  discussion is coordinate-free (treatment of the topic without reference to
+  any particular coordinate system); however, our implementation heavily
+  relies on coordinate frames. We borrow terminology from differential
+  geometry.
+
+  In this section, the mathematical term _compact set_ (a subset of Euclidean
+  space that is closed and bounded) corresponds to the term _geometry_ (or the
+  space occupied by the geometry) in SceneGraph.
+
+  We describe the contact surface 𝕊ₘₙ between two intersecting compact subsets
+  𝕄 and ℕ of ℝ³ with the scalar fields eₘ and eₙ defined on 𝕄 ⊂ ℝ³ and ℕ ⊂ ℝ³
+  respectively:
+
+                 eₘ : 𝕄 → ℝ,
+                 eₙ : ℕ → ℝ.
+
+  The _contact surface_ 𝕊ₘₙ is the surface of equilibrium eₘ = eₙ. It is the
+  locus of points Q where eₘ(Q) equals eₙ(Q):
+
+               𝕊ₘₙ = { Q ∈ 𝕄 ∩ ℕ : eₘ(Q) = eₙ(Q) }.
+
+  We can define the scalar field eₘₙ on the surface 𝕊ₘₙ as a scalar function
+  that assigns Q ∈ 𝕊ₘₙ the value of eₘ(Q), which is the same as eₙ(Q):
+
+               eₘₙ : 𝕊ₘₙ → ℝ,
+               eₘₙ(Q) = eₘ(Q) = eₙ(Q).
+
+  We can also define the scalar field hₘₙ on 𝕄 ∩ ℕ as the difference between
+  eₘ and eₙ:
+
+               hₘₙ : 𝕄 ∩ ℕ → ℝ,
+               hₘₙ(Q) = eₘ(Q) - eₙ(Q).
+
+  It follows that the gradient vector field ∇hₘₙ on 𝕄 ∩ ℕ equals the difference
+  between the gradient vector fields ∇eₘ and ∇eₙ:
+
+               ∇hₘₙ : 𝕄 ∩ ℕ → ℝ³,
+               ∇hₘₙ(Q) = ∇eₘ(Q) - ∇eₙ(Q).
+
+  By construction, Q ∈ 𝕊ₘₙ if and only if hₘₙ(Q) = 0. In other words, 𝕊ₘₙ is
+  the zero level set of hₘₙ. It follows that, for Q ∈ 𝕊ₘₙ, ∇hₘₙ(Q) is
+  orthogonal to the surface 𝕊ₘₙ at Q in the direction of increasing eₘ - eₙ.
+  <!-- Note from PR discussion
+    1. `∇hₘₙ` *is* a well-behaved vector (subject to some assumptions -- see
+        below).
+    2. The contact surface "clips" intersecting geometries M and N into disjoint
+       geometries M' and N'. `∇hₘₙ` points *out* of M' and *into* N'.
+    Assumptions:
+    - `∇e` is differentiable and "points outward"
+
+   TODO(DamrongGuoy):
+   1. Document the above listed properties of `∇hₘₙ`.
+   2. Add a todo indicating M' and N' should be illustrated in the docs.
+   3. Explicitly add the assumptions on `e` that make this interpretation valid.
+  -->
+
+  Notice that the domain of eₘₙ is the two-dimensional surface 𝕊ₘₙ, while the
+  domain of ∇hₘₙ is the three-dimensional compact set 𝕄 ∩ ℕ.
+  Even though eₘₙ and ∇hₘₙ are defined on different domains (𝕊ₘₙ and 𝕄 ∩ ℕ),
+  our implementation only represents them on their common domain, i.e., 𝕊ₘₙ.
+
+  <h2> Discrete Representation </h2>
+
+  In practice, the contact surface is approximated with a discrete triangle
+  mesh. The triangle mesh's normals are defined *per face*. The normal of each
+  face is guaranteed to point "out of" N and "into" M. They can be accessed via
+  `mesh_W().face_normal(face_index)`.
+
+  The pressure values on the contact surface are represented as a continuous,
+  piecewise-linear function, accessed via e_MN().
+
+  The normals of the mesh are discontinuous at triangle boundaries, but the
+  pressure can be meaningfully evaluated over the entire domain of the mesh.
+
+  When available, the values of ∇eₘ and ∇eₙ are represented as a discontinuous,
+  piecewise-constant function over the triangles -- one vector per triangle.
+  These quantities are accessed via EvaluateGradE_M_W() and EvaluateGradE_N_W(),
+  respectively.
+
+  <h2> Barycentric Coordinates </h2>
+
+  For Point Q on the surface mesh of the contact surface between Geometry M and
+  Geometry N, r_WQ = (x,y,z) is the displacement vector from the origin of the
+  world frame to Q expressed in the coordinate frame of W. We also have the
+  _barycentric coordinates_ (b0, b1, b2) on a triangle of the surface mesh that
+  contains Q. With vertices of the triangle labeled as v₀, v₁, v₂, we can
+  map (b0, b1, b2) to r_WQ by:
+
+               r_WQ = b0 * r_Wv₀ + b1 * r_Wv₁ + b2 * r_Wv₂,
+               b0 + b1 + b2 = 1, bᵢ ∈ [0,1],
+
+  where r_Wvᵢ is the displacement vector of the vertex labeled as vᵢ from the
+  origin of the world frame, expressed in the world frame.
+
+  We use the barycentric coordinates to evaluate the field values.
+
+  @tparam_nonsymbolic_scalar */
+template <typename T>
+class PolygonalContactSurface {
+ public:
+  PolygonalContactSurface(const PolygonalContactSurface& surface) {
+    *this = surface;
+  }
+
+  PolygonalContactSurface& operator=(const PolygonalContactSurface& surface) {
+    if (&surface == this) return *this;
+
+    id_M_ = surface.id_M_;
+    id_N_ = surface.id_N_;
+#if 0
+    mesh_W_ = std::make_unique<SurfaceMesh<T>>(*surface.mesh_W_);
+
+    // We can't simply copy the mesh fields; the copies must contain pointers
+    // to the new mesh. So, we use CloneAndSetMesh() instead.
+    e_MN_.reset(static_cast<SurfaceMeshFieldLinear<T, T>*>(
+        surface.e_MN_->CloneAndSetMesh(mesh_W_.get()).release()));
+
+    if (surface.grad_eM_W_) {
+      grad_eM_W_ =
+          std::make_unique<std::vector<Vector3<T>>>(*surface.grad_eM_W_);
+    }
+    if (surface.grad_eN_W_) {
+      grad_eN_W_ =
+          std::make_unique<std::vector<Vector3<T>>>(*surface.grad_eN_W_);
+    }
+#endif
+    return *this;
+  }
+
+  PolygonalContactSurface(PolygonalContactSurface&&) = default;
+  PolygonalContactSurface& operator=(PolygonalContactSurface&&) = default;
+  PolygonalContactSurface(GeometryId id_M, GeometryId id_N)
+      : id_M_(id_M), id_N_(id_N) {}
+#if 0
+  /** Constructs a PolygonalContactSurface.
+   @param id_M         The id of the first geometry M.
+   @param id_N         The id of the second geometry N.
+   @param mesh_W       The surface mesh of the contact surface 𝕊ₘₙ between M
+                       and N. The mesh vertices are defined in the world frame.
+   @param e_MN         Represents the scalar field eₘₙ on the surface mesh.
+   @pre The face normals in `mesh_W` point *out of* geometry N and *into* M.
+   @note If `id_M > id_N`, the labels will be swapped and the normals of the
+         mesh reversed (to maintain the documented invariants). Comparing the
+         input parameters with the members of the resulting
+         %PolygonalContactSurface will reveal if such a swap has occurred. */
+  PolygonalContactSurface(GeometryId id_M, GeometryId id_N,
+                 std::unique_ptr<SurfaceMesh<T>> mesh_W,
+                 std::unique_ptr<SurfaceMeshFieldLinear<T, T>> e_MN)
+      : PolygonalContactSurface(id_M, id_N, std::move(mesh_W), std::move(e_MN),
+                                nullptr, nullptr) {}
+
+  /** Constructs a PolygonalContactSurface with the optional gradients of the
+   constituent scalar fields.
+   @param id_M         The id of the first geometry M.
+   @param id_N         The id of the second geometry N.
+   @param mesh_W       The surface mesh of the contact surface 𝕊ₘₙ between M
+                       and N. The mesh vertices are defined in the world frame.
+   @param e_MN         Represents the scalar field eₘₙ on the surface mesh.
+   @param grad_eM_W    ∇eₘ sampled once per face, expressed in the world frame.
+   @param grad_eN_W    ∇eₙ sampled once per face, expressed in the world frame.
+   @pre The face normals in `mesh_W` point *out of* geometry N and *into* M.
+   @pre If given, `grad_eM_W` and `grad_eN_W` must have as many entries as
+        `mesh_W` has faces and the ith entry in each should correspond to the
+        ith face in `mesh_W`.
+   @note If `id_M > id_N`, the labels will be swapped and the normals of the
+         mesh reversed (to maintain the documented invariants). Comparing the
+         input parameters with the members of the resulting
+         %PolygonalContactSurface will reveal if such a swap has occurred. */
+  PolygonalContactSurface(GeometryId id_M, GeometryId id_N,
+                 std::unique_ptr<SurfaceMesh<T>> mesh_W,
+                 std::unique_ptr<SurfaceMeshFieldLinear<T, T>> e_MN,
+                 std::unique_ptr<std::vector<Vector3<T>>> grad_eM_W,
+                 std::unique_ptr<std::vector<Vector3<T>>> grad_eN_W)
+      : id_M_(id_M),
+        id_N_(id_N),
+        mesh_W_(std::move(mesh_W)),
+        e_MN_(std::move(e_MN)),
+        grad_eM_W_(std::move(grad_eM_W)),
+        grad_eN_W_(std::move(grad_eN_W)) {
+    // If defined the gradient values must map 1-to-1 onto elements.
+    DRAKE_THROW_UNLESS(grad_eM_W_ == nullptr ||
+                       static_cast<int>(grad_eM_W_->size()) ==
+                           mesh_W_->num_elements());
+    DRAKE_THROW_UNLESS(grad_eN_W_ == nullptr ||
+                       static_cast<int>(grad_eN_W_->size()) ==
+                           mesh_W_->num_elements());
+    if (id_N_ < id_M_) SwapMAndN();
+  }
+#endif
+  /** Returns the geometry id of Geometry M. */
+  GeometryId id_M() const { return id_M_; }
+
+  /** Returns the geometry id of Geometry N. */
+  GeometryId id_N() const { return id_N_; }
+#if 0
+  /** @name  Evaluation of constituent pressure fields
+
+   The %PolygonalContactSurface *provisionally* includes the gradients of the
+   constituent pressure fields (∇eₘ and ∇eₙ) sampled on the contact surface. In
+   order for these values to be included in an instance, the gradient for the
+   corresponding mesh must be well defined. For example a rigid mesh will not
+   have a well-defined pressure gradient; as stiffness goes to infinity, the
+   geometry becomes rigid and the gradient _direction_ converges to the
+   direction of the rigid mesh's surface normals, but the magnitude goes to
+   infinity, producing a pressure gradient that would be some variant of
+   `<∞, ∞, ∞>`.
+
+   Accessing the gradient values must be pre-conditioned on a test that the
+   particular instance of %PolygonalContactSurface actually contains the
+   gradient data. The presence of gradient data for each geometry must be
+   confirmed separately.
+
+   The values ∇eₘ and ∇eₘ are piecewise constant over the
+   %PolygonalContactSurface and can only be evaluate on a per-triangle basis. */
+  //@{
+
+  /** @returns `true` if `this` contains values for ∇eₘ.  */
+  bool HasGradE_M() const { return grad_eM_W_ != nullptr; }
+
+  /** @returns `true` if `this` contains values for ∇eₙ.  */
+  bool HasGradE_N() const { return grad_eN_W_ != nullptr; }
+
+  /** Returns the value of ∇eₘ for the triangle with index `index`.
+   @throws std::exception if HasGradE_M() returns false.  */
+  const Vector3<T>& EvaluateGradE_M_W(SurfaceFaceIndex index) const {
+    if (grad_eM_W_ == nullptr) {
+      throw std::runtime_error(
+          "PolygonalContactSurface::EvaluateGradE_M_W() invalid; no gradient "
+          "values stored. Mesh M may be rigid, or the constituent gradients "
+          "weren't requested.");
+    }
+    return (*grad_eM_W_)[index];
+  }
+
+  /** Returns the value of ∇eₙ for the triangle with index `index`.
+   @throws std::exception if HasGradE_N() returns false.  */
+  const Vector3<T>& EvaluateGradE_N_W(SurfaceFaceIndex index) const {
+    if (grad_eN_W_ == nullptr) {
+      throw std::runtime_error(
+          "PolygonalContactSurface::EvaluateGradE_N_W() invalid; no gradient "
+          "values stored. Mesh N may be rigid, or the constituent gradients "
+          "weren't requested.");
+    }
+    return (*grad_eN_W_)[index];
+  }
+
+  //@}
+
+  /** Returns a reference to the surface mesh whose vertex
+   positions are measured and expressed in the world frame.
+   */
+  const SurfaceMesh<T>& mesh_W() const {
+    DRAKE_DEMAND(mesh_W_ != nullptr);
+    return *mesh_W_;
+  }
+
+  /** Returns a reference to the scalar field eₘₙ. */
+  const SurfaceMeshFieldLinear<T, T>& e_MN() const { return *e_MN_; }
+#endif
+  // TODO(#12173): Consider NaN==NaN to be true in equality tests.
+  /** Checks to see whether the given PolygonalContactSurface object is equal
+   via deep exact comparison. NaNs are treated as not equal as per the IEEE
+   standard.
+
+   @param surface The contact surface for comparison.
+   @returns `true` if the given contact surface is equal.
+   */
+  bool Equal(const PolygonalContactSurface<T>& surface) const {
+#if 0
+    // First check the meshes.
+    if (!this->mesh_W().Equal(surface.mesh_W())) return false;
+
+    // Now examine the pressure field.
+    if (!this->e_MN().Equal(surface.e_MN())) return false;
+
+    // TODO(SeanCurtis-TRI) This isn't testing the following quantities:
+    //  1. Geometry ids
+    //  2. Gradients.
+#endif
+    if (id_M_ != surface.id_M_ || id_N_ != surface.id_N_) return false;
+    // All checks passed.
+    return true;
+  }
+
+ private:
+  // Swaps M and N (modifying the data in place to reflect the change).
+  void SwapMAndN() {
+    std::swap(id_M_, id_N_);
+#if 0
+    // TODO(SeanCurtis-TRI): Determine if this work is necessary. It is neither
+    // documented nor tested that the face winding is guaranteed to be one way
+    // or the other. Alternatively, this should be documented and tested.
+    mesh_W_->ReverseFaceWinding();
+
+    // Note: the scalar field does not depend on the order of M and N.
+    std::swap(grad_eM_W_, grad_eN_W_);
+#endif
+  }
+
+  // The id of the first geometry M.
+  GeometryId id_M_;
+  // The id of the second geometry N.
+  GeometryId id_N_;
+#if 0
+  // The surface mesh of the contact surface 𝕊ₘₙ between M and N.
+  std::unique_ptr<SurfaceMesh<T>> mesh_W_;
+  // TODO(SeanCurtis-TRI): We can only construct from a linear field, so store
+  //  it as such for now. This can be promoted once there's a construction that
+  //  uses a different derivation.
+  // Represents the scalar field eₘₙ on the surface mesh.
+  std::unique_ptr<SurfaceMeshFieldLinear<T, T>> e_MN_;
+
+  // The gradients of the pressure fields eₘ and eₙ sampled on the contact
+  // surface. There is one gradient value *per contact surface triangle*.
+  // These quantities may not be defined if the gradient is not well-defined.
+  // See class documentation for elaboration.
+  std::unique_ptr<std::vector<Vector3<T>>> grad_eM_W_;
+  std::unique_ptr<std::vector<Vector3<T>>> grad_eN_W_;
+#endif
+  // TODO(DamrongGuoy): Remove this when we allow direct access to e_MN.
+  template <typename U>
+  friend class PolyPolygonalContactSurfaceTester;
+};
+
+}  // namespace geometry
+}  // namespace drake

--- a/lcmtypes/BUILD.bazel
+++ b/lcmtypes/BUILD.bazel
@@ -87,6 +87,7 @@ drake_lcm_cc_library(
     lcm_srcs = ["lcmt_contact_results_for_viz.lcm"],
     deps = [
         ":hydroelastic_contact_surface_for_viz",
+        ":hydroelastic_poly_contact_surface_for_viz",
         ":point_pair_contact_info_for_viz",
     ],
 )
@@ -117,6 +118,15 @@ drake_lcm_cc_library(
         ":hydroelastic_contact_surface_tri_for_viz",
         ":hydroelastic_quadrature_per_point_data_for_viz",
     ],
+)
+
+drake_lcm_cc_library(
+    name = "hydroelastic_poly_contact_surface_for_viz",
+    lcm_package = "drake",
+    lcm_srcs = ["lcmt_hydroelastic_poly_contact_surface_for_viz.lcm"],
+    deps = [
+        ":point",
+    ]
 )
 
 drake_lcm_cc_library(

--- a/lcmtypes/defs.bzl
+++ b/lcmtypes/defs.bzl
@@ -20,6 +20,7 @@ ALL_LCM_SRCS = [
     "lcmt_force_torque.lcm",
     "lcmt_header.lcm",
     "lcmt_hydroelastic_contact_surface_for_viz.lcm",
+    "lcmt_hydroelastic_poly_contact_surface_for_viz.lcm",
     "lcmt_hydroelastic_contact_surface_tri_for_viz.lcm",
     "lcmt_hydroelastic_quadrature_per_point_data_for_viz.lcm",
     "lcmt_iiwa_command.lcm",

--- a/lcmtypes/lcmt_contact_results_for_viz.lcm
+++ b/lcmtypes/lcmt_contact_results_for_viz.lcm
@@ -11,4 +11,8 @@ struct lcmt_contact_results_for_viz {
   int32_t num_hydroelastic_contacts;
   lcmt_hydroelastic_contact_surface_for_viz hydroelastic_contacts[
       num_hydroelastic_contacts];
+
+  int32_t num_hydroelastic_poly_contacts;
+  lcmt_hydroelastic_poly_contact_surface_for_viz hydroelastic_poly_contacts[
+      num_hydroelastic_poly_contacts];
 }

--- a/lcmtypes/lcmt_hydroelastic_poly_contact_surface_for_viz.lcm
+++ b/lcmtypes/lcmt_hydroelastic_poly_contact_surface_for_viz.lcm
@@ -1,0 +1,41 @@
+package drake;
+
+struct lcmt_hydroelastic_poly_contact_surface_for_viz {
+  // TODO: As the changes to ContactResultsToLcmSystem hit master, rebase on
+  //  that and modify this message to benefit from model and geometry names.
+
+  // Names of the colliding bodies.
+  string body1_name;
+  string body2_name;
+
+  // The net force acting on the body due to this contact: a force and moment
+  // applied at a point (which happens to be the centroid).
+
+  // The centroid of the contact surface, as an offset vector expressed in the
+  // world frame.
+  double centroid_W[3];
+
+  // The force, expressed in the world frame, that is applied to `body1_name`
+  // at the centroid of the contact surface.
+  double force_C_W[3];
+
+  // The moment, expressed in the world frame, that is applied to `body1_name`
+  // at the centroid of the contact surface.
+  double moment_C_W[3];
+
+  // The vertices.
+  int32_t num_vertices;
+  // TODO: It would be nice to have a simple Vector3 type here.
+  lcmt_point p_WV[num_vertices];
+
+  // Pressure values at each vertex.
+  double pressure[num_vertices];
+
+  // The polygons are encoded in one long stream as
+  // c0, v00, v01, ..., c1, v10, v11, ...
+  // Such that each polygon has a count of vertices ci, followed by ci number
+  // of 0-indexed indices into the vertex set. The total number of integer
+  // values is recorded here.
+  int32_t poly_data_int_count;
+  int32_t poly_data[poly_data_int_count];
+}

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -25,6 +25,7 @@ drake_cc_package_library(
         ":discrete_contact_pair",
         ":externally_applied_spatial_force",
         ":hydroelastic_contact_info",
+        ":hydroelastic_poly_contact_info",
         ":hydroelastic_quadrature_point_data",
         ":hydroelastic_traction",
         ":multibody_plant_core",
@@ -150,6 +151,21 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "hydroelastic_poly_contact_info",
+    srcs = [
+        "hydroelastic_poly_contact_info.cc",
+    ],
+    hdrs = [
+        "hydroelastic_poly_contact_info.h",
+    ],
+    deps = [
+        "//common:default_scalars",
+        "//geometry/query_results:polygonal_contact_surface",
+        "//multibody/math",
+    ],
+)
+
+drake_cc_library(
     name = "hydroelastic_quadrature_point_data",
     srcs = [],
     hdrs = [
@@ -170,6 +186,7 @@ drake_cc_library(
     ],
     deps = [
         ":hydroelastic_contact_info",
+        ":hydroelastic_poly_contact_info",
         ":point_pair_contact_info",
         "//common:default_scalars",
     ],
@@ -279,6 +296,13 @@ drake_cc_library(
     hdrs = ["contact_permutation.h"],
     deps = [
         "//multibody/tree:multibody_tree_topology",
+    ],
+)
+
+drake_cc_googletest(
+    name = "contact_results_test",
+    deps = [
+        ":contact_results",
     ],
 )
 

--- a/multibody/plant/contact_results.cc
+++ b/multibody/plant/contact_results.cc
@@ -6,59 +6,10 @@ namespace drake {
 namespace multibody {
 
 template <typename T>
-ContactResults<T>::ContactResults() {
-  // Make this hold pointers at first (see comment on
-  // hydroelastic_contact_info_).
-  hydroelastic_contact_info_ =
-      std::vector<const HydroelasticContactInfo<T>*>();
-}
-
-template <typename T>
-ContactResults<T>::ContactResults(const ContactResults<T>& contact_results) {
-  *this = contact_results;
-}
-
-template <typename T>
-ContactResults<T>& ContactResults<T>::operator=(
-    const ContactResults<T>& contact_results) {
-  // Make the type a vector of const pointers if we can.
-  if (contact_results.num_hydroelastic_contacts() == 0) {
-    hydroelastic_contact_info_ =
-        std::vector<const HydroelasticContactInfo<T>*>();
-  } else {
-    // If this currently holds pointers, we need to change the type.
-    if (hydroelastic_contact_vector_ownership_mode() == kAliasedPointers) {
-      hydroelastic_contact_info_ =
-          std::vector<std::unique_ptr<HydroelasticContactInfo<T>>>();
-    }
-
-    // Copy the HydroelasticContactInfo data.
-    std::vector<std::unique_ptr<HydroelasticContactInfo<T>>>&
-        hydroelastic_contact_vector =
-            hydroelastic_contact_vector_of_unique_ptrs();
-    hydroelastic_contact_vector.resize(
-        contact_results.num_hydroelastic_contacts());
-    for (int i = 0; i < contact_results.num_hydroelastic_contacts(); ++i) {
-      const HydroelasticContactInfo<T>& contact_info =
-          contact_results.hydroelastic_contact_info(i);
-      hydroelastic_contact_vector[i] =
-          std::make_unique<HydroelasticContactInfo<T>>(contact_info);
-    }
-  }
-
-  point_pairs_info_ = contact_results.point_pairs_info_;
-
-  return *this;
-}
-
-template <typename T>
 void ContactResults<T>::Clear() {
   point_pairs_info_.clear();
-  if (hydroelastic_contact_vector_ownership_mode() == kAliasedPointers) {
-    hydroelastic_contact_vector_of_pointers().clear();
-  } else {
-    hydroelastic_contact_vector_of_unique_ptrs().clear();
-  }
+  hydroelastic_contact_info_.clear();
+  hydroelastic_poly_contact_info_.clear();
 }
 
 template <typename T>
@@ -71,31 +22,15 @@ ContactResults<T>::point_pair_contact_info(int i) const {
 template <typename T>
 const HydroelasticContactInfo<T>&
 ContactResults<T>::hydroelastic_contact_info(int i) const {
-  DRAKE_DEMAND(i >= 0 && i < num_hydroelastic_contacts());
-  if (hydroelastic_contact_vector_ownership_mode() == kAliasedPointers) {
-    return *hydroelastic_contact_vector_of_pointers()[i];
-  } else {
-    return *hydroelastic_contact_vector_of_unique_ptrs()[i];
-  }
+  DRAKE_DEMAND(i >= 0 && i < hydroelastic_contact_info_.size());
+  return hydroelastic_contact_info_.get(i);
 }
 
 template <typename T>
-void ContactResults<T>::AddContactInfo(
-    const HydroelasticContactInfo<T>* hydroelastic_contact_info) {
-  DRAKE_DEMAND(hydroelastic_contact_vector_ownership_mode() ==
-               kAliasedPointers);
-  hydroelastic_contact_vector_of_pointers().push_back(
-      hydroelastic_contact_info);
-}
-
-template <typename T>
-int ContactResults<T>::num_hydroelastic_contacts() const {
-  if (hydroelastic_contact_vector_ownership_mode() == kAliasedPointers) {
-    return static_cast<int>(hydroelastic_contact_vector_of_pointers().size());
-  } else {
-    return static_cast<int>(
-        hydroelastic_contact_vector_of_unique_ptrs().size());
-  }
+const HydroelasticPolyContactInfo<T>&
+ContactResults<T>::hydroelastic_poly_contact_info(int i) const {
+  DRAKE_DEMAND(i >= 0 && i < hydroelastic_poly_contact_info_.size());
+  return hydroelastic_poly_contact_info_.get(i);
 }
 
 }  // namespace multibody

--- a/multibody/plant/hydroelastic_poly_contact_info.cc
+++ b/multibody/plant/hydroelastic_poly_contact_info.cc
@@ -1,0 +1,4 @@
+#include "drake/multibody/plant/hydroelastic_poly_contact_info.h"
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::HydroelasticPolyContactInfo)

--- a/multibody/plant/hydroelastic_poly_contact_info.h
+++ b/multibody/plant/hydroelastic_poly_contact_info.h
@@ -1,0 +1,199 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/geometry/query_results/polygonal_contact_surface.h"
+#include "drake/multibody/math/spatial_algebra.h"
+#ifdef DRAKE_POLY_QUADRATURE_DATA
+#include "drake/multibody/plant/hydroelastic_quadrature_point_data.h"
+#endif
+
+namespace drake {
+namespace multibody {
+
+/**
+ A class containing information regarding contact and contact response between
+ two geometries attached to a pair of bodies. This class provides the output
+ from the Hydroelastic contact model and includes:
+
+    - The shared polygonal contact surface between the two geometries, which
+      includes
+      the virtual pressures acting at every point on the contact surface.
+    - The tractions acting at the quadrature points on the contact surface.
+    - The slip speeds at the quadrature points on the contact surface.
+    - The spatial force from the integrated tractions that is applied at the
+      centroid of the contact surface.
+
+ The two geometries, denoted M and N (and obtainable via
+ `contact_surface().id_M()` and `contact_surface().id_N()`) are attached to
+ bodies A and B, respectively.
+
+ @tparam_default_scalar
+ */
+template <typename T>
+class HydroelasticPolyContactInfo {
+ public:
+  /** @name                 Construction
+   The constructors below adhere to a number of invariants. The
+   geometry::PolygonalontactSurface defines contact between two geometries M and
+   N (via contact_surface().id_M() and contact_surface().id_N(), respectively).
+   %HydroelasticPolyContactInfo further associates geometries M and N with the
+   bodies to which they are rigidly fixed, A and B, respectively. It is the
+   responsibility of the caller of these constructors to ensure that the
+   parameters satisfy the documented invariants, see below. Similarly, the
+   spatial force `F_Ac_W` must be provided as indicated by the monogram notation
+   in use, that is, it is the spatial force on body A, at the contact surface's
+   centroid C, and expressed in the world frame. Quadrature points data must be
+   provided in accordance to the conventions and monogram notation documented in
+   HydroelasticQuadraturePointData. */
+  // @{
+
+  /**
+   @anchor hydro_contact_info_non_owning_ctor
+   Constructs this structure using the given contact surface, traction field,
+   and slip field. This constructor does not own the PolygonalContactSurface; it
+   points to a PolygonalContactSurface that another owns, see contact_surface().
+
+   @param[in] contact_surface Contact surface between two geometries M and N,
+     see geometry::PolygonalContactSurface::id_M() and
+     geometry::PolygonalContactSurface::id_N().
+   @param[in] F_Ac_W Spatial force applied on body A, at contact surface
+     centroid C, and expressed in the world frame W. The position `p_WC` of C in
+     the world frame W can be obtained with
+     `PolygonalContactSurface::mesh_W().centroid()`.
+   @param[in] quadrature_point_data Hydroelastic field data at each quadrature
+     point. Data must be provided in accordance to the convention that geometry
+     M and N are attached to bodies A and B, respectively. Refer to
+     HydroelasticQuadraturePointData for further details.
+   */
+  HydroelasticPolyContactInfo(
+      const geometry::PolygonalContactSurface<T>* contact_surface,
+      const SpatialForce<T>& F_Ac_W
+#ifdef DRAKE_POLY_QUADRATURE_DATA
+      ,
+      std::vector<HydroelasticQuadraturePointData<T>>&& quadrature_point_data
+#endif
+      )
+      : contact_surface_(contact_surface),
+        F_Ac_W_(F_Ac_W)
+#ifdef DRAKE_POLY_QUADRATURE_DATA
+        ,
+        quadrature_point_data_(std::move(quadrature_point_data))
+#endif
+  {
+    DRAKE_DEMAND(contact_surface != nullptr);
+  }
+
+  /** This constructor takes ownership of `contact_surface` via a
+   std::unique_ptr, instead of aliasing a pre-existing contact surface. In all
+   other respects, it is identical to the @ref
+   hydro_contact_info_non_owning_ctor "other overload" that takes
+   `contact_surface` by raw pointer.  */
+  HydroelasticPolyContactInfo(
+      std::unique_ptr<geometry::PolygonalContactSurface<T>> contact_surface,
+      const SpatialForce<T>& F_Ac_W
+#ifdef DRAKE_POLY_QUADRATURE_DATA
+      ,
+      std::vector<HydroelasticQuadraturePointData<T>>&& quadrature_point_data
+#endif
+      )
+      : contact_surface_(std::move(contact_surface)),
+        F_Ac_W_(F_Ac_W)
+#ifdef DRAKE_POLY_QUADRATURE_DATA
+        ,
+        quadrature_point_data_(std::move(quadrature_point_data))
+#endif
+  {
+    DRAKE_DEMAND(
+        std::get<std::unique_ptr<geometry::PolygonalContactSurface<T>>>(
+            contact_surface_) != nullptr);
+  }
+  // @}
+
+  /// @name Implements CopyConstructible, CopyAssignable, MoveConstructible,
+  /// MoveAssignable.
+  //@{
+
+  /** Clones this data structure, making deep copies of all underlying data.
+   @note The new object will contain a cloned PolygonalContactSurface even if
+         the original was constructed using a raw pointer referencing an
+         existing PolygonalContactSurface.
+   */
+  HydroelasticPolyContactInfo(const HydroelasticPolyContactInfo& info) {
+    *this = info;
+  }
+
+  /** Clones this object in the same manner as the copy constructor.
+   @see HydroelasticPolyContactInfo(const HydroelasticPolyContactInfo&)
+   */
+  HydroelasticPolyContactInfo& operator=(
+      const HydroelasticPolyContactInfo& info) {
+    contact_surface_ = std::make_unique<geometry::PolygonalContactSurface<T>>(
+        info.contact_surface());
+    F_Ac_W_ = info.F_Ac_W_;
+#ifdef DRAKE_POLY_QUADRATURE_DATA
+    quadrature_point_data_ = info.quadrature_point_data_;
+#endif
+    return *this;
+  }
+
+  HydroelasticPolyContactInfo(HydroelasticPolyContactInfo&&) = default;
+  HydroelasticPolyContactInfo& operator=(HydroelasticPolyContactInfo&&) =
+      default;
+
+  //@}
+
+  /* Returns a reference to the PolygonalContactSurface data structure. Note
+   that the mesh and gradient vector fields are expressed in the world frame. */
+  const geometry::PolygonalContactSurface<T>& contact_surface() const {
+    if (std::holds_alternative<const geometry::PolygonalContactSurface<T>*>(
+            contact_surface_)) {
+      return *std::get<const geometry::PolygonalContactSurface<T>*>(
+          contact_surface_);
+    } else {
+      return *std::get<std::unique_ptr<geometry::PolygonalContactSurface<T>>>(
+          contact_surface_);
+    }
+  }
+#ifdef DRAKE_POLY_QUADRATURE_DATA
+  /// Gets the intermediate data, including tractions, computed by the
+  /// quadrature process.
+  const std::vector<HydroelasticQuadraturePointData<T>>& quadrature_point_data()
+      const {
+    return quadrature_point_data_;
+  }
+#endif
+  /// Gets the spatial force applied on body A, at the centroid point C of the
+  /// surface mesh M, and expressed in the world frame W. The position `p_WC` of
+  /// the centroid point C in the world frame W can be obtained with
+  /// `contact_surface().mesh_W().centroid()`.
+  const SpatialForce<T>& F_Ac_W() const { return F_Ac_W_; }
+
+ private:
+  // TODO(SeanCurtis-TRI): I suspect this should be cleaned up -- I don't think
+  //  this class *ever* owns the underlying contact surface.
+  // Note that the mesh of the contact surface is defined in the world frame.
+  std::variant<const geometry::PolygonalContactSurface<T>*,
+               std::unique_ptr<geometry::PolygonalContactSurface<T>>>
+      contact_surface_;
+
+  // The spatial force applied at the centroid (Point C) of the surface mesh.
+  SpatialForce<T> F_Ac_W_;
+#ifdef DRAKE_POLY_QUADRATURE_DATA
+  // The traction and slip velocity evaluated at each quadrature point.
+  std::vector<HydroelasticQuadraturePointData<T>>
+      quadrature_point_data_;
+#endif
+};
+
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::HydroelasticPolyContactInfo)

--- a/multibody/plant/test/contact_results_test.cc
+++ b/multibody/plant/test/contact_results_test.cc
@@ -1,0 +1,180 @@
+#include "drake/multibody/plant/contact_results.h"
+
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/drake_copyable.h"
+
+namespace drake {
+namespace multibody {
+
+using std::move;
+using std::vector;
+
+namespace internal {
+namespace {
+
+/* The class we provide must a) be default constructible and b) default
+ constructible in order to use with OwnershipVector. */
+class CopyConstructible {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CopyConstructible)
+
+  CopyConstructible() = default;
+  explicit CopyConstructible(int value) : value_(value) {}
+
+  int value() const { return value_; }
+
+ private:
+  int value_{};
+};
+
+bool operator==(const CopyConstructible& a, const CopyConstructible& b) {
+  return a.value() == b.value();
+}
+
+std::ostream& operator<<(std::ostream& out, const CopyConstructible& c) {
+    out << c.value();
+    return out;
+}
+
+// TODO(SeanCurtis-TRI) Refactor this more intelligibly. As is, there is a
+//  great deal to slog through in a single test.
+GTEST_TEST(OwnershipVectorTest, EverythingUnderTheSun) {
+  const vector<CopyConstructible> source_data{
+      CopyConstructible(10), CopyConstructible(20), CopyConstructible(30)};
+  const CopyConstructible extra(40);
+
+  /* Create a new copy of OwnershipVector with unowned references to all of the
+   entries in source_data. */
+  auto make_fresh = [&source_data]() {
+    OwnershipVector<CopyConstructible> instances;
+    for (const auto& instance : source_data) {
+      instances.AddUnowned(&instance);
+    }
+    return instances;
+  };
+
+  /* Confirms that the given OwnershipVector has all of the data in source_data,
+   but it doesn't own anything. */
+  auto confirm_unowned =
+      [&source_data](const OwnershipVector<CopyConstructible>& dut) {
+        EXPECT_EQ(dut.size(), static_cast<int>(source_data.size()));
+        /* The data is still at the source_data address.. */
+        for (int i = 0; i < dut.size(); ++i) {
+          EXPECT_EQ(&dut.get(i), &source_data[i]);
+        }
+      };
+
+  /* Confirms that the OwnershipVector is a unique copy of `source_data`. */
+  auto confirm_owned_copy = [&source_data,
+                             &extra](OwnershipVector<CopyConstructible>* dut) {
+    EXPECT_EQ(dut->size(), static_cast<int>(source_data.size()));
+    /* The copy has the same values but different addresses. */
+    for (int i = 0; i < dut->size(); ++i) {
+      EXPECT_EQ(dut->get(i), source_data[i]);
+      EXPECT_NE(&dut->get(i), &source_data[i]);
+    }
+    /* It can't add any more fields. */
+    EXPECT_THROW(dut->AddUnowned(&extra), std::exception);
+  };
+
+  auto confirm_unique_copy = [](const OwnershipVector<CopyConstructible>& a,
+                                const OwnershipVector<CopyConstructible>& b) {
+    EXPECT_EQ(a.size(), b.size());
+    /* The copies have the same values but different addresses. */
+    for (int i = 0; i < a.size(); ++i) {
+      EXPECT_EQ(a.get(i), b.get(i));
+      EXPECT_NE(&a.get(i), &b.get(i));
+    }
+  };
+
+  /* Construct and add unowned instances. */
+  OwnershipVector<CopyConstructible> instances = make_fresh();
+  confirm_unowned(instances);
+
+  /* Copy construction -- creates unique copy which cannot be extended. */
+  OwnershipVector<CopyConstructible> copy_constructed(instances);
+  confirm_owned_copy(&copy_constructed);
+
+  OwnershipVector<CopyConstructible> copy_constructed_from_copy(
+      copy_constructed);
+  confirm_owned_copy(&copy_constructed_from_copy);
+  confirm_unique_copy(copy_constructed_from_copy, copy_constructed);
+
+  /* Copy assignment -- old values are lost, creates a unique copy which
+   cannot be extended. */
+  OwnershipVector<CopyConstructible> copy_assigned;
+  copy_assigned.AddUnowned(&extra);
+  EXPECT_EQ(copy_assigned.size(), 1);
+  EXPECT_EQ(&copy_assigned.get(0), &extra);
+
+  copy_assigned = instances;
+  confirm_owned_copy(&copy_assigned);
+
+  OwnershipVector<CopyConstructible> copy_assigned_from_copy;
+  copy_assigned_from_copy = copy_constructed;
+  confirm_owned_copy(&copy_assigned_from_copy);
+  confirm_unique_copy(copy_assigned_from_copy, copy_constructed);
+
+  /* Move construction -- the result has the same semantics as the original. */
+
+  OwnershipVector<CopyConstructible> move_constructed(make_fresh());
+  confirm_unowned(move_constructed);
+  EXPECT_NO_THROW(move_constructed.AddUnowned(&extra));
+  EXPECT_EQ(move_constructed.size(), static_cast<int>(source_data.size()) + 1);
+
+  OwnershipVector<CopyConstructible> move_constructed_from_copy(
+      move(copy_constructed));
+  confirm_owned_copy(&move_constructed_from_copy);
+
+  /* Move assignment. */
+  OwnershipVector<CopyConstructible> move_assigned;
+  move_assigned.AddUnowned(&extra);
+  EXPECT_EQ(move_assigned.size(), 1);
+  EXPECT_EQ(&move_assigned.get(0), &extra);
+
+  move_assigned = make_fresh();
+
+  confirm_unowned(move_assigned);
+  EXPECT_NO_THROW(move_assigned.AddUnowned(&extra));
+  EXPECT_EQ(move_assigned.size(), static_cast<int>(source_data.size()) + 1);
+
+  OwnershipVector<CopyConstructible> move_assigned_from_copy;
+  move_assigned_from_copy.AddUnowned(&extra);
+  EXPECT_EQ(move_assigned_from_copy.size(), 1);
+  EXPECT_EQ(&move_assigned_from_copy.get(0), &extra);
+
+  move_assigned_from_copy = move(copy_assigned);
+
+  confirm_owned_copy(&move_assigned_from_copy);
+
+  /* Clear - restores it to zero size and addable. */
+  OwnershipVector<CopyConstructible> non_owner(make_fresh());
+  EXPECT_NO_THROW(non_owner.AddUnowned(&extra));  // Proof it doesn't own.
+  EXPECT_GT(non_owner.size(), 0);
+  non_owner.clear();
+  EXPECT_EQ(non_owner.size(), 0);
+  EXPECT_NO_THROW(non_owner.AddUnowned(&extra));  // Proof it doesn't own.
+
+  OwnershipVector<CopyConstructible> owner(copy_assigned_from_copy);
+  EXPECT_THROW(owner.AddUnowned(&extra), std::exception);  // Proof is owner.
+  EXPECT_GT(owner.size(), 0);
+  owner.clear();
+  EXPECT_EQ(owner.size(), 0);
+  EXPECT_NO_THROW(owner.AddUnowned(&extra));  // Proof it doesn't own.
+}
+
+}  // namespace
+}  // namespace internal
+namespace {
+
+// TODO(SeanCurtis-TRI) We need to test the following:
+//  - It initially doesn't own any of the hydroelastic components.
+//  - Copies work and are proper, stand-alone copies.
+GTEST_TEST(ContactResultsTest, Construction) {}
+}  // namespace
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION

Very draft PR. Status: do not review.
----------------------------------------------------------------------------------------
From @SeanCurtis-TRI . (Sorry for my limited git knowhow.  I don't know how to push to @SeanCurtis-TRI  fork, so I push to RobotLocomotion for now.)

----------------------------------------------------------------------------------------
(Sean)

Core infrastructure:

- Introduce new lcm message for polygonal contact surface
  - I'm omitting slip velocities and traction vectors.
  - I'm using lcmt_point to serve as a Vector3.
  - The new data type is added to lcmt_contact_results_for_viz.lcm
  - See documentation for mesh encoding.
- Introduce *fake* PolygonalContactSurface. This should be replaced with
  the actual thing.
  - Current version only has ids -- no mesh geometry yet.
- Introduce HydroelasticPolyContactInfo
  - The polygonal version of HydroelasticContactInfo
  - It doesn't (currently) include quadrature data.
  - It swaps ContactSurface for PolygonalContactSurface.
- ContactResults modified
  - Streamline the whole "owned vs unowned" data thing.
  - Add HydroelasticPolyContactInfo into the class.
- Extending visualizer to handle this new data type.
  - Polygonal contact surfaces handle drawing the edges differently.
    Rather than generating a second mesh, it tweaks the visualization of
    the mesh: "Surface with edges" while playing with edge colors and
    widths.
    - That means it doesn't *quite* work with the current infrastructure.
    - Turning off edges and changing color maps works perfectly well.
    - Turning off surface (leaving edges on) produces various artifacts
      that need to be resolved.

Secondary:

- Modify simple_contact_surface_vis to produce a fixed polygonal mesh.
  - Exercise the logic of the visualizer.

TODO (to make functional)
 - Replace this `polygonal_contact_surface.h` with the real thing.
 - Given PolygonalContactSurface
  - update ContactResultsToLcm to populate the lcm message.

TODO (to polish -- not a complete list)
 - Refine OwnershipVector (in contact_results.h)
   - Better name, document requirejments on template parameter Foo, get a
     better name that "Foo".
 - Fix the problem where edges are visible but not pressure patch in
   visualizer.
 - ContactResults itself needs unit tests to show that it copies
   correctly.
----------------------------------------------------------------------------------------
(Damrong)
Minor clean up. Make sure all `bazel test geometry/multibody` passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15749)
<!-- Reviewable:end -->
