### PR TITLE
[geometry] Update clipping range documentation

### DIFF
--- a/geometry/render/render_camera.h
+++ b/geometry/render/render_camera.h
@@ -11,8 +11,57 @@ namespace drake {
 namespace geometry {
 namespace render {
 
-/** Defines the near and far clipping planes for frustum-based (e.g. OpenGL)
- RenderEngine cameras.  */
+/** Defines the near and far clipping planes for frustum-based (OpenGL)
+ RenderEngine cameras.
+
+ <h3>Guidance on selecting clipping plane values</h3>
+
+ This documentation is targeted toward those who are unfamiliar with
+ the OpenGL rasterization pipeline. For in-depth explanations about how the
+ clipping range defines the viewing volume, see
+ <a href="https://www.glprogramming.com/red/chapter03.html#name3">
+ the discussion on projective transforms</a>. For more detail on its effect on
+ determining occlusion (which geometries are in front), try
+ <a href="https://www.glprogramming.com/red/chapter05.html#name1">
+ "A Hidden-Surface Removal Survival Kit"</a>.
+
+ <h4>The short summary</h4>
+  - The clipping range defines the distance of the *closest* and *farthest*
+    things that *can* appear in the rendering.
+  - Objects that cross the planes placed at those distances get clipped.
+  - Make the range as small as reasonably possible to get the best occlusion
+    (a.k.a. z-buffer) results.
+  - For depth cameras, make sure your clipping range always includes your valid
+    depth range.
+
+ <h4>The longer discussion</h4>
+
+ Given that the clipping range defines what you can/can't see in the camera, it
+ _might_ be tempting to just put an arbitrarily large range in (e.g., starting
+ 1 micrometer away and going up to 1 million kilometers away). By doing so, you
+ know everything you put into your scene will appear. If making sure things are
+ visible were the only factor, this would be fine.
+
+ Rasterization pipelines render objects in arbitrary order but have to be able
+ to determine which objects are in front of other objects as they go. They
+ achieve this by creating a "z-buffer". It is a measure of the depth of the
+ triangle that rendered to a particular "pixel". When two triangles both want to
+ color the same pixel, the triangle with the smallest z-value is typically
+ selected.
+
+ The z-buffer has fixed precision. That fixed precision is spread over the
+ entire available depth range (as defined by the clipping range). The greater
+ the range, the less precision the z-buffer has per meter of depth. A small
+ range may have the ability to distinguish objects separated by 1 mm. But a
+ large range may only be able to distinuish objects separated by 1 m. Two
+ objects with measurably different depths relative to the camera, can become
+ indistinguishable in the z-buffer due to these precision issues; the object
+ that ends up in front is due to random chance. This will lead to artifacts
+ where two objects near the same depth will flicker back and forth in front of
+ each other (sometimes called "z fighting").
+
+ So, it is best to define the smallest clipping range that will include the
+ objects of the scene that you care about most. */
 class ClippingRange {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ClippingRange);


### PR DESCRIPTION
Provide more guidance and information for selecting clipping planes well. Also corrected a hidden bug that phrases like "e.g." or "i.e." in the first sentence of doxygen messes up our "auto-summary" functionality.

Closes #14487

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15750)
<!-- Reviewable:end -->
