### PR TITLE
[install] Add --help and test filtering to install_test

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -73,7 +73,9 @@ install(
 
 install_test(
     name = "install_test",
-    args = ["$(location :" + _INSTALL_TEST_COMMANDS + ")"],
+    args = ["--install_tests_filename=$(location :{})".format(
+        _INSTALL_TEST_COMMANDS,
+    )],
     data = [
         ":install",
         _INSTALL_TEST_COMMANDS,

--- a/tools/install/install_test.py
+++ b/tools/install/install_test.py
@@ -1,42 +1,78 @@
+import argparse
+import functools
 import os
+import re
 import sys
-import install_test_helper
 import unittest
 
+import install_test_helper
 
-class TestInstall(unittest.TestCase):
-    def test_install(self):
-        # Fail (on purpose) if not given exactly one command line argument.
-        self.assertEqual(len(sys.argv), 2)
-        with open(sys.argv[1], 'r') as f:
-            lines = f.readlines()
 
-        # Install into bazel read-only temporary directory. The temporary
-        # directory does not need to be removed as bazel tests are run in a
-        # scratch space.
+class InstallTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        # Install into bazel read-only temporary directory.  We expect this
+        # method to be called exactly once, so we assert that the install
+        # directory must not exist beforehand, but must exist afterward.
+        cls._installation_folder = install_test_helper.get_install_dir()
+        assert not os.path.exists(cls._installation_folder)
         install_test_helper.install()
-        installation_folder = install_test_helper.get_install_dir()
-        self.assertTrue(os.path.isdir(installation_folder))
+        assert os.path.isdir(cls._installation_folder)
 
+    def test_basic_paths(self):
         # Verify install directory content.
-        content = set(os.listdir(installation_folder))
+        content = set(os.listdir(self._installation_folder))
         self.assertSetEqual(set(['bin', 'include', 'lib', 'share']), content)
 
+    def _run_one_command(self, test_command):
         # Our launched processes should be independent, not inherit their
         # runfiles from the install_test.py runner.
-        cmd_env = dict(os.environ)
+        env = dict(os.environ)
         for key in ["RUNFILES_MANIFEST_FILE", "RUNFILES_DIR", "TEST_SRCDIR"]:
-            if key in cmd_env:
-                del cmd_env[key]
+            if key in env:
+                del env[key]
 
-        # Execute the install actions.
-        for cmd in lines:
-            cmd = cmd.strip()
-            print("+ {}".format(cmd))
-            install_test_helper.check_call(
-                [os.path.join(os.getcwd(), cmd)],
-                env=cmd_env)
+        # Execute the test_command.
+        print("+ {}".format(test_command), file=sys.stderr)
+        install_test_helper.check_call(
+            [os.path.join(os.getcwd(), test_command)],
+            env=env)
+
+
+def _convert_test_command_to_test_case_name(test_command):
+    program = test_command.split()[0]
+    basename = os.path.basename(program)
+    bare_name = os.path.splitext(basename)[0]
+    identifier = re.sub("[^0-9a-zA-Z]+", "_", bare_name)
+    if identifier.startswith("test_"):
+        test_case_name = identifier
+    else:
+        test_case_name = "test_" + identifier
+    return test_case_name
+
+
+def main():
+    # Locate the command-line argument that provides the list of test commands.
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument('--install_tests_filename', required=True)
+    args, unparsed = parser.parse_known_args()
+    new_argv = ["install_test"] + unparsed
+
+    # Read the list of tests.
+    with open(args.install_tests_filename, 'r') as f:
+        lines = f.readlines()
+
+    # Add them as individual tests.
+    for one_line in lines:
+        test_command = one_line.strip()
+        test_case_name = _convert_test_command_to_test_case_name(test_command)
+        setattr(InstallTest, test_case_name, functools.partialmethod(
+            InstallTest._run_one_command, test_command=test_command))
+
+    # Delegate to unittest.
+    unittest.main(argv=new_argv)
 
 
 if __name__ == '__main__':
-    unittest.main(argv=["TestInstall"])
+    main()


### PR DESCRIPTION
Closes #15710.

Example use:

```
bazel test //:py/install_test \
  --test_output=streamed --nocache_test_results \
  --test_arg=InstallTest.test_resource_tool_installed_test
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15758)
<!-- Reviewable:end -->
