### PR TITLE
[fem] Wrap around Eigen::SparseMatrix to avoid non-type template parameters

### DIFF
--- a/multibody/fixed_fem/dev/deformable_rigid_manager.cc
+++ b/multibody/fixed_fem/dev/deformable_rigid_manager.cc
@@ -156,17 +156,17 @@ void DeformableRigidManager<T>::DeclareCacheEntries() {
 
     /* Allocates and calculates the free-motion tangent matrix for the
      deformable body. */
-    Eigen::SparseMatrix<T> model_tangent_matrix(fem_model.num_dofs(),
-                                                fem_model.num_dofs());
-    fem_model.SetTangentMatrixSparsityPattern(&model_tangent_matrix);
+    EigenSparseMatrix<T> model_tangent_matrix = {
+        Eigen::SparseMatrix<T>(fem_model.num_dofs(), fem_model.num_dofs())};
+    fem_model.SetTangentMatrixSparsityPattern(&(model_tangent_matrix.data));
     const auto& tangent_matrix_cache_entry = this->DeclareCacheEntry(
         fmt::format("Free motion FEM tangent matrix {}", deformable_body_id),
         systems::ValueProducer(model_tangent_matrix,
                                std::function<void(const systems::Context<T>&,
-                                                  Eigen::SparseMatrix<T>*)>{
+                                                  EigenSparseMatrix<T>*)>{
                                    [this, deformable_body_id](
                                        const systems::Context<T>& context,
-                                       Eigen::SparseMatrix<T>* tangent_matrix) {
+                                       EigenSparseMatrix<T>* tangent_matrix) {
                                      this->CalcFreeMotionTangentMatrix(
                                          context, deformable_body_id,
                                          tangent_matrix);
@@ -566,11 +566,11 @@ void DeformableRigidManager<T>::CalcNextFemStateBase(
 template <typename T>
 void DeformableRigidManager<T>::CalcFreeMotionTangentMatrix(
     const systems::Context<T>& context, DeformableBodyIndex index,
-    Eigen::SparseMatrix<T>* tangent_matrix) const {
+    EigenSparseMatrix<T>* tangent_matrix) const {
   const FemStateBase<T>& free_motion_fem_state =
       EvalFreeMotionFemStateBase(context, index);
   const FemModelBase<T>& fem_model = deformable_model_->fem_model(index);
-  fem_model.CalcTangentMatrix(free_motion_fem_state, tangent_matrix);
+  fem_model.CalcTangentMatrix(free_motion_fem_state, &(tangent_matrix->data));
 }
 
 template <typename T>

--- a/multibody/fixed_fem/dev/deformable_rigid_manager.h
+++ b/multibody/fixed_fem/dev/deformable_rigid_manager.h
@@ -109,6 +109,15 @@ class DeformableRigidManager final
     }
   };
 
+  template <typename Scalar, int Options = 0, typename StorageIndex = int>
+  /* Wrapper around Eigen::SparseMatrix to avoid non-type template parameters
+   that trigger typename hasher to spew warning messages to the console in a
+   simulation. */
+  struct EigenSparseMatrix {
+    using NonTypeTemplateParameter = std::integral_constant<int, Options>;
+    Eigen::SparseMatrix<Scalar, Options, StorageIndex> data;
+  };
+
   friend class DeformableRigidManagerTest;
   friend class DeformableRigidContactDataTest;
   friend class DeformableRigidDynamicsDataTest;
@@ -230,14 +239,15 @@ class DeformableRigidManager final
       const systems::Context<T>& context, DeformableBodyIndex index) const {
     return this->plant()
         .get_cache_entry(tangent_matrix_cache_indexes_[index])
-        .template Eval<Eigen::SparseMatrix<T>>(context);
+        .template Eval<EigenSparseMatrix<T>>(context)
+        .data;
   }
 
   /* Calculates the tangent matrix of the deformable body with the given `index`
    at free motion state. */
-  void CalcFreeMotionTangentMatrix(
-      const systems::Context<T>& context, DeformableBodyIndex index,
-      Eigen::SparseMatrix<T>* tangent_matrix) const;
+  void CalcFreeMotionTangentMatrix(const systems::Context<T>& context,
+                                   DeformableBodyIndex index,
+                                   EigenSparseMatrix<T>* tangent_matrix) const;
 
   /* Eval version of CalcFreeMotionTangentMatrixSchurComplement(). */
   const internal::SchurComplement<T>&


### PR DESCRIPTION
This prevents typename hasher from spewing warning messages to the console.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15761)
<!-- Reviewable:end -->
