### PR TITLE
[geometry] ConvertVolumeToSurfaceMesh moves out of internal namespace

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -31,6 +31,7 @@
 #include "drake/geometry/proximity/obj_to_surface_mesh.h"
 #include "drake/geometry/proximity/surface_mesh.h"
 #include "drake/geometry/proximity/volume_mesh.h"
+#include "drake/geometry/proximity/volume_to_surface_mesh.h"
 #include "drake/geometry/proximity_properties.h"
 #include "drake/geometry/query_results/penetration_as_point_pair.h"
 #include "drake/geometry/render/gl_renderer/render_engine_gl_factory.h"
@@ -1030,6 +1031,9 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("r_MV", &Class::r_MV, py_rvp::reference_internal,
             doc.VolumeVertex.r_MV.doc);
   }
+
+  m.def("ConvertVolumeToSurfaceMesh", &ConvertVolumeToSurfaceMesh<T>,
+      py::arg("volume"), doc.ConvertVolumeToSurfaceMesh.doc);
 }  // NOLINT(readability/fn_size)
 
 void DoScalarIndependentDefinitions(py::module m) {

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -975,6 +975,30 @@ class TestGeometry(unittest.TestCase):
             delta=1e-15)
         self.assertAlmostEqual(mesh.CalcVolume(), 1/3.0, delta=1e-15)
 
+    def test_convert_volume_to_surface_mesh(self):
+        # Use the volume mesh from `test_volume_mesh()`.
+        t_left = mut.VolumeElement(v0=mut.VolumeVertexIndex(1),
+                                   v1=mut.VolumeVertexIndex(2),
+                                   v2=mut.VolumeVertexIndex(3),
+                                   v3=mut.VolumeVertexIndex(4))
+        t_right = mut.VolumeElement(v0=mut.VolumeVertexIndex(1),
+                                    v1=mut.VolumeVertexIndex(3),
+                                    v2=mut.VolumeVertexIndex(2),
+                                    v3=mut.VolumeVertexIndex(0))
+
+        v0 = mut.VolumeVertex((1, 0,  0))
+        v1 = mut.VolumeVertex((0, 0,  0))
+        v2 = mut.VolumeVertex((0, 1,  0))
+        v3 = mut.VolumeVertex((0, 0, -1))
+        v4 = mut.VolumeVertex((-1, 0,  0))
+
+        volume_mesh = mut.VolumeMesh(elements=(t_left, t_right),
+                                     vertices=(v0, v1, v2, v3, v4))
+
+        surface_mesh = mut.ConvertVolumeToSurfaceMesh(volume_mesh)
+
+        self.assertIsInstance(surface_mesh, mut.SurfaceMesh)
+
     def test_read_obj_to_surface_mesh(self):
         mesh_path = FindResourceOrThrow("drake/geometry/test/quad_cube.obj")
         mesh = mut.ReadObjToSurfaceMesh(mesh_path)

--- a/geometry/proximity/test/volume_to_surface_mesh_test.cc
+++ b/geometry/proximity/test/volume_to_surface_mesh_test.cc
@@ -102,11 +102,15 @@ GTEST_TEST(VolumeToSurfaceMeshTest, CollectUniqueVertices) {
   EXPECT_EQ(expect_vertex_set, vertex_set);
 }
 
+}  // namespace
+}  // namespace internal
+
+namespace {
 template <typename T>
 void TestVolumeToSurfaceMesh() {
   const Box box(0.2, 0.4, 0.6);
   const double target_edge_length = 0.1;
-  const auto volume = MakeBoxVolumeMesh<T>(box, target_edge_length);
+  const auto volume = internal::MakeBoxVolumeMesh<T>(box, target_edge_length);
 
   // Go through the vertices on the boundary of the volume mesh. Keep their
   // coordinates in a `set` for comparison with vertices of the surface
@@ -142,7 +146,7 @@ void TestVolumeToSurfaceMesh() {
 
   // Check that the face normal vectors are in the outward direction.
   for (SurfaceFaceIndex f(0); f < surface.num_faces(); ++f) {
-    const Vector3<T> normal_M = CalcFaceNormal(surface, f);
+    const Vector3<T> normal_M = internal::CalcFaceNormal(surface, f);
     // Position vector of the first vertex V of the face.
     const Vector3<T> r_MV =
         surface.vertex(surface.element(f).vertex(0)).r_MV();
@@ -159,6 +163,5 @@ GTEST_TEST(VolumeToSurfaceMeshTest, TestAutoDiffXd) {
 }
 
 }  // namespace
-}  // namespace internal
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/proximity/volume_to_surface_mesh.h
+++ b/geometry/proximity/volume_to_surface_mesh.h
@@ -1,8 +1,6 @@
 #pragma once
 
 #include <array>
-#include <unordered_map>
-#include <utility>
 #include <vector>
 
 #include "drake/geometry/proximity/surface_mesh.h"
@@ -37,8 +35,9 @@ std::vector<std::array<VolumeVertexIndex, 3>> IdentifyBoundaryFaces(
 std::vector<VolumeVertexIndex> CollectUniqueVertices(
     const std::vector<std::array<VolumeVertexIndex, 3>>& faces);
 
-/*
- Converts a tetrahedral volume mesh to a triangulated surface mesh of the
+}  // namespace internal
+
+/** Converts a tetrahedral volume mesh to a triangulated surface mesh of the
  boundary surface of the volume.
  @param volume  The tetrahedral volume mesh, whose vertex positions are
                 measured and expressed in some frame E.
@@ -49,36 +48,9 @@ std::vector<VolumeVertexIndex> CollectUniqueVertices(
                 vertices with the same coordinates. Otherwise, the returned
                 surface mesh will have extra triangles in addition to the
                 boundary triangles of the volume.
- @tparam T      The underlying scalar type for coordinates, e.g., double
-                or AutoDiffXd. Must be a valid Eigen scalar.
- */
+ @tparam_nonsymbolic_scalar */
 template <class T>
-SurfaceMesh<T> ConvertVolumeToSurfaceMesh(const VolumeMesh<T>& volume) {
-  const std::vector<std::array<VolumeVertexIndex, 3>> boundary_faces =
-      IdentifyBoundaryFaces(volume.tetrahedra());
+SurfaceMesh<T> ConvertVolumeToSurfaceMesh(const VolumeMesh<T>& volume);
 
-  const std::vector<VolumeVertexIndex> boundary_vertices =
-      CollectUniqueVertices(boundary_faces);
-
-  std::vector<SurfaceVertex<T>> surface_vertices;
-  surface_vertices.reserve(boundary_vertices.size());
-  std::unordered_map<VolumeVertexIndex, SurfaceVertexIndex> volume_to_surface;
-  for (SurfaceVertexIndex i(0); i < boundary_vertices.size(); ++i) {
-    surface_vertices.emplace_back(volume.vertex(boundary_vertices[i]).r_MV());
-    volume_to_surface.emplace(boundary_vertices[i], i);
-  }
-
-  std::vector<SurfaceFace> surface_faces;
-  surface_faces.reserve(boundary_faces.size());
-  for (const auto& face_vertices : boundary_faces) {
-    surface_faces.emplace_back(volume_to_surface.at(face_vertices[0]),
-                               volume_to_surface.at(face_vertices[1]),
-                               volume_to_surface.at(face_vertices[2]));
-  }
-
-  return SurfaceMesh<T>(std::move(surface_faces), std::move(surface_vertices));
-}
-
-}  // namespace internal
 }  // namespace geometry
 }  // namespace drake

--- a/multibody/fixed_fem/dev/test/deformable_rigid_manager_test.cc
+++ b/multibody/fixed_fem/dev/test/deformable_rigid_manager_test.cc
@@ -245,7 +245,7 @@ TEST_F(DeformableRigidManagerTest, RegisterCollisionGeometry) {
   get_collision_geometry(&id);
   /* Verify the surface mesh is as expected. */
   const SurfaceMesh<double> expected_surface_mesh =
-      geometry::internal::ConvertVolumeToSurfaceMesh(MakeUnitCubeTetMesh());
+      geometry::ConvertVolumeToSurfaceMesh(MakeUnitCubeTetMesh());
   EXPECT_TRUE(expected_surface_mesh.Equal(collision_objects.mesh(id)));
   /* Verify proximity property is as expected. */
   const CoulombFriction<double> mu = collision_objects.proximity_properties(id)


### PR DESCRIPTION
We're putting this in the public API so that visualizers can use this method to map `VolumeMesh` to a `SurfaceMesh` of the mesh boundary. This also includes bindings and tests on those bindings.

As part of this, we move the implementation into the .cc file and explicitly define it on the supported scalar types (with appropriate modification of doxygen to bring it up to current practices).

Relates #15738.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15762)
<!-- Reviewable:end -->
