### PR TITLE
[parsing] Allow assigning geometries to "world" in URDF

### DIFF
--- a/multibody/parsing/parser.h
+++ b/multibody/parsing/parser.h
@@ -39,7 +39,7 @@ class Parser final {
   /// SDFormat files may contain multiple `<model>` elements.  New model
   /// instances will be added to @p plant for each `<model>` tag in the file.
   ///
-  /// @note Adding multiple root-level models, i.e, `<model>`s direclty under
+  /// @note Adding multiple root-level models, i.e, `<model>`s directly under
   /// `<sdf>`, is deprecated. If you need multiple models in a single file,
   /// please use an SDFormat world file.
   ///


### PR DESCRIPTION
In a URDF file, we now allow the declaration of a link named "world". We also allow the assignment of geometry to that link (which registers geometry to `MultibodyPlant`'s world body and as "anchored" geometry in `SceneGraph`).

(Opportunistically cleans up a related typo in parser.h.)

Relates #14727 (We're deferring closure until we have decided whether we can do the same thing in SDF.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15763)
<!-- Reviewable:end -->
