### PR TITLE
[geometry:meshcat] Add UI controls to Meshcat

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -1594,7 +1594,24 @@ void DoScalarIndependentDefinitions(py::module m) {
             py::overload_cast<std::string_view, std::string, double>(
                 &Class::SetProperty),
             py::arg("path"), py::arg("property"), py::arg("value"),
-            cls_doc.SetProperty.doc_double);
+            cls_doc.SetProperty.doc_double)
+        .def("AddButton", &Class::AddButton, py::arg("name"),
+            cls_doc.AddButton.doc)
+        .def("GetButtonClicks", &Class::GetButtonClicks, py::arg("name"),
+            cls_doc.GetButtonClicks.doc)
+        .def("DeleteButton", &Class::DeleteButton, py::arg("name"),
+            cls_doc.DeleteButton.doc)
+        .def("AddSlider", &Class::AddSlider, py::arg("name"), py::arg("min"),
+            py::arg("max"), py::arg("step"), py::arg("value"),
+            cls_doc.AddSlider.doc)
+        .def("SetSliderValue", &Class::SetSliderValue, py::arg("name"),
+            py::arg("value"), cls_doc.SetSliderValue.doc)
+        .def("GetSliderValue", &Class::GetSliderValue, py::arg("name"),
+            cls_doc.GetSliderValue.doc)
+        .def("DeleteSlider", &Class::DeleteSlider, py::arg("name"),
+            cls_doc.DeleteSlider.doc)
+        .def("DeleteAddedControls", &Class::DeleteAddedControls,
+            cls_doc.DeleteAddedControls.doc);
     // Note: we intentionally do not bind the advanced methods (HasProperty and
     // GetPacked*) which were intended primarily for testing in C++.
   }
@@ -1614,9 +1631,9 @@ void DoScalarIndependentDefinitions(py::module m) {
             cls_doc.default_color.doc)
         .def_readwrite(
             "prefix", &MeshcatVisualizerParams::prefix, cls_doc.prefix.doc)
-        .def_readwrite("delete_on_intialization_event",
-            &MeshcatVisualizerParams::delete_on_intialization_event,
-            cls_doc.delete_on_intialization_event.doc);
+        .def_readwrite("delete_on_initialization_event",
+            &MeshcatVisualizerParams::delete_on_initialization_event,
+            cls_doc.delete_on_initialization_event.doc);
   }
 }  // NOLINT(readability/fn_size)
 

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -386,6 +386,15 @@ class TestGeometry(unittest.TestCase):
         meshcat.Set2dRenderMode(
             X_WC=RigidTransform(), xmin=-1, xmax=1, ymin=-1, ymax=1)
         meshcat.ResetRenderMode()
+        meshcat.AddButton(name="button")
+        self.assertEqual(meshcat.GetButtonClicks(name="button"), 0)
+        meshcat.DeleteButton(name="button")
+        meshcat.AddSlider(name="slider", min=0, max=1, step=0.01, value=0.5)
+        meshcat.SetSliderValue(name="slider", value=0.7)
+        self.assertAlmostEqual(meshcat.GetSliderValue(
+            name="slider"), 0.7, delta=1e-14)
+        meshcat.DeleteSlider(name="slider")
+        meshcat.DeleteAddedControls()
 
     @numpy_compare.check_nonsymbolic_types
     def test_meshcat_visualizer(self, T):
@@ -395,7 +404,7 @@ class TestGeometry(unittest.TestCase):
         params.role = mut.Role.kIllustration
         params.default_color = mut.Rgba(0.5, 0.5, 0.5)
         params.prefix = "py_visualizer"
-        params.delete_on_intialization_event = False
+        params.delete_on_initialization_event = False
         vis = mut.MeshcatVisualizerCpp_[T](meshcat=meshcat, params=params)
         vis.Delete()
         self.assertIsInstance(vis.query_object_input_port(), InputPort_[T])

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -221,8 +221,67 @@ class Meshcat {
                    const std::vector<double>& value);
 
   // TODO(russt): Implement SetAnimation().
-  // TODO(russt): Implement SetButton() and SetSlider() as wrappers on
-  // set_control.
+
+  /** @name Meshcat Controls
+   Meshcat "Controls" are user interface elements in the browser.  These
+   currently include buttons and sliders.
+   - Controls appear in the browser under the "Open Controls" dropdown menu,
+     and are appended to the root node of the tree (they do not have a path in
+     the "scene tree"), in the order in which they are added.
+   - Controls must have unique names.  Adding a control with a name that was
+     already in use will overwrite the existing control.  If you add a slider
+     with a name that was previous used for a button, then the button will be
+     replaced by the slider, etc.
+   - Users of this Meshcat instance are responsible for polling the GUI to
+     retrieve the user interface events.
+   - Controls can be added/deleted/accessed anytime during the lifetime of this
+     Meshcat instance.
+  */
+  //@{
+
+  /** Adds a button with the label `name` to the meshcat browser controls GUI.
+   */
+  void AddButton(std::string name);
+
+  /** Returns the number of times the button `name` has been clicked in the
+   GUI, from the time that it was added to `this`.  If multiple browsers are
+   open, then this number is the cumulative number of clicks in all browsers.
+   @throws std::exception if `name` is not a registered button. */
+  int GetButtonClicks(std::string_view name);
+
+  /** Removes the button `name` from the GUI.
+   @throws std::exception if `name` is not a registered button. */
+  void DeleteButton(std::string name);
+
+  /** Adds a slider with the label `name` to the meshcat browser controls GUI.
+   The slider range is given by [`min`, `max`]. `step` is the smallest
+   increment by which the slider can change values (and therefore send updates
+   back to this Meshcat instance). `value` specifies the initial value; it will
+   be truncated to the slider range and rounded to the nearest increment. */
+  void AddSlider(std::string name, double min, double max, double step,
+                 double value);
+
+  /** Sets the current `value` of the slider `name`. `value` will be truncated
+   to the slider range and rounded to the nearest increment specified by the
+   slider `step`. This will update the slider element in all connected meshcat
+   browsers.
+   @throws std::exception if `name` is not a registered slider. */
+  void SetSliderValue(std::string name, double value);
+
+  /** Gets the current `value` of the slider `name`.
+   @throws std::exception if `name` is not a registered slider. */
+  double GetSliderValue(std::string_view name);
+
+  /** Removes the slider `name` from the GUI.
+   @throws std::exception if `name` is not a registered slider. */
+  void DeleteSlider(std::string name);
+
+  /** Removes all buttons and sliders from the GUI that have been registered by
+   this Meshcat instance. It does *not* clear the default GUI elements set in
+   the meshcat browser (e.g. for cameras and lights). */
+  void DeleteAddedControls();
+
+  //@}
 
   /* These remaining public methods are intended to primarily for testing. These
   calls must safely acquire the data from the websocket thread and will block

--- a/geometry/meshcat_types.h
+++ b/geometry/meshcat_types.h
@@ -201,6 +201,50 @@ struct SetPropertyData {
   MSGPACK_DEFINE_MAP(type, path, property, value);
 };
 
+struct SetButtonControl {
+  std::string type{"set_control"};
+  int num_clicks{0};
+  std::string name;
+  std::string callback;
+  MSGPACK_DEFINE_MAP(type, name, callback);
+};
+
+struct SetSliderControl {
+  std::string type{"set_control"};
+  std::string name;
+  std::string callback;
+  double value;
+  double min;
+  double max;
+  double step;
+  MSGPACK_DEFINE_MAP(type, name, callback, value, min, max, step);
+};
+
+struct SetSliderValue {
+  std::string type{"set_control_value"};
+  std::string name;
+  double value;
+  // Note: If invoke_callback is true, then we will receive a message back from
+  // the slider whose value it being set.  This can lead to mysterious loopy
+  // behavior when multiple browsers are connected.
+  // TODO(russt): Make it impossible to set this to true.
+  bool invoke_callback{false};
+  MSGPACK_DEFINE_MAP(type, name, value, invoke_callback);
+};
+
+struct DeleteControl {
+  std::string type{"delete_control"};
+  std::string name;
+  MSGPACK_DEFINE_MAP(type, name);
+};
+
+struct UserInterfaceEvent {
+  std::string type;
+  std::string name;
+  std::optional<double> value;
+  MSGPACK_DEFINE_MAP(type, name, value);
+};
+
 }  // namespace internal
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/meshcat_visualizer.cc
+++ b/geometry/meshcat_visualizer.cc
@@ -30,7 +30,7 @@ MeshcatVisualizer<T>::MeshcatVisualizer(std::shared_ptr<Meshcat> meshcat,
                                     &MeshcatVisualizer<T>::UpdateMeshcat);
   this->DeclareForcedPublishEvent(&MeshcatVisualizer<T>::UpdateMeshcat);
 
-  if (params_.delete_on_intialization_event) {
+  if (params_.delete_on_initialization_event) {
     this->DeclareInitializationPublishEvent(
         &MeshcatVisualizer<T>::OnInitialization);
   }

--- a/geometry/meshcat_visualizer.h
+++ b/geometry/meshcat_visualizer.h
@@ -66,7 +66,7 @@ class MeshcatVisualizer final : public systems::LeafSystem<T> {
    MeshcatVisualizerParams::prefix.  Since this visualizer will only ever add
    geometry under this prefix, this will remove all geometry/transforms added
    by the visualizer, or by a previous instance of this visualizer using the
-   same prefix.  Use MeshcatVisualizer::delete_on_intialization_event
+   same prefix.  Use MeshcatVisualizer::delete_on_initialization_event
    to determine whether this should be called on initialization. */
   void Delete() const;
 

--- a/geometry/meshcat_visualizer_params.h
+++ b/geometry/meshcat_visualizer_params.h
@@ -31,7 +31,7 @@ struct MeshcatVisualizerParams {
    initialization event to remove any visualizations e.g. from a previous
    simulation. See @ref declare_initialization_events "Declare initialization
    events" for more information. */
-  bool delete_on_intialization_event{true};
+  bool delete_on_initialization_event{true};
 };
 
 }  // namespace geometry

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -8,7 +8,7 @@
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/systems/analysis/simulator.h"
 
-/**  To test, you must manually run `bazel run //geometry:meshcat_manual_test`,
+/* To test, you must manually run `bazel run //geometry:meshcat_manual_test`,
 then follow the instructions on your console. */
 
 namespace drake {
@@ -107,7 +107,7 @@ Open up your browser to the URL above.
 
   builder.ExportInput(plant.get_actuation_input_port(), "actuation_input");
   MeshcatVisualizerParams params;
-  params.delete_on_intialization_event = false;
+  params.delete_on_initialization_event = false;
   MeshcatVisualizerd::AddToBuilder(&builder, scene_graph, meshcat, params);
 
   auto diagram = builder.Build();
@@ -122,13 +122,31 @@ Open up your browser to the URL above.
   std::cout << "[Press RETURN to continue]." << std::endl;
   std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
 
-  std::cout << "Finally we'll run the simulation (you should see the robot "
-               "fall down) and exit."
-            << std::endl;
+  std::cout
+      << "Now we'll run the simulation (you should see the robot fall down)."
+      << std::endl;
 
   systems::Simulator<double> simulator(*diagram, std::move(context));
   simulator.set_target_realtime_rate(1.0);
   simulator.AdvanceTo(4.0);
+
+  meshcat->AddButton("ButtonTest");
+  meshcat->AddSlider("SliderTest", 0, 1, 0.01, 0.5);
+
+  std::cout << "I've added a button and a slider to the controls menu.\n";
+  std::cout << "- Click the ButtonTest button a few times.\n";
+  std::cout << "- Move SliderTest slider.\n";
+  std::cout << "- Open a second browser (" << meshcat->web_url()
+            << ") and confirm that moving the slider in one updates the slider "
+               "in the other.\n";
+
+  std::cout << "[Press RETURN to continue]." << std::endl;
+  std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+
+  std::cout << "Got " << meshcat->GetButtonClicks("ButtonTest")
+            << " clicks on ButtonTest.\n"
+            << "Got " << meshcat->GetSliderValue("SliderTest")
+            << " value for SliderTest." << std::endl;
 
   std::cout << "Exiting..." << std::endl;
   return 0;

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -241,6 +241,67 @@ GTEST_TEST(MeshcatTest, SetPropertyDouble) {
   EXPECT_EQ(data.value, 2.0);
 }
 
+GTEST_TEST(MeshcatTest, Buttons) {
+  Meshcat meshcat;
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      meshcat.GetButtonClicks("button"),
+      "Meshcat does not have any button named button.");
+
+  meshcat.AddButton("button");
+  EXPECT_EQ(meshcat.GetButtonClicks("button"), 0);
+  meshcat.DeleteButton("button");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      meshcat.GetButtonClicks("button"),
+      "Meshcat does not have any button named button.");
+
+  meshcat.AddButton("button1");
+  meshcat.AddButton("button2");
+  meshcat.DeleteAddedControls();
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      meshcat.GetButtonClicks("button1"),
+      "Meshcat does not have any button named button1.");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      meshcat.GetButtonClicks("button2"),
+      "Meshcat does not have any button named button2.");
+}
+
+GTEST_TEST(MeshcatTest, Sliders) {
+  Meshcat meshcat;
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      meshcat.GetSliderValue("slider"),
+      "Meshcat does not have any slider named slider.");
+
+  meshcat.AddSlider("slider", 0.2, 1.5, 0.1, 0.5);
+  EXPECT_NEAR(meshcat.GetSliderValue("slider"), 0.5, 1e-14);
+  meshcat.SetSliderValue("slider", 0.7);
+  EXPECT_NEAR(meshcat.GetSliderValue("slider"), 0.7, 1e-14);
+  meshcat.SetSliderValue("slider", -2.0);
+  EXPECT_NEAR(meshcat.GetSliderValue("slider"), .2, 1e-14);
+  meshcat.SetSliderValue("slider", 2.0);
+  EXPECT_NEAR(meshcat.GetSliderValue("slider"), 1.5, 1e-14);
+  meshcat.SetSliderValue("slider", 1.245);
+  EXPECT_NEAR(meshcat.GetSliderValue("slider"), 1.2, 1e-14);
+
+  meshcat.DeleteSlider("slider");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      meshcat.GetSliderValue("slider"),
+      "Meshcat does not have any slider named slider.");
+
+  meshcat.AddSlider("slider1", 2, 3, 0.01, 2.35);
+  meshcat.AddSlider("slider2", 4, 5, 0.01, 4.56);
+  meshcat.DeleteAddedControls();
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      meshcat.GetSliderValue("slider1"),
+      "Meshcat does not have any slider named slider1.");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      meshcat.GetSliderValue("slider2"),
+      "Meshcat does not have any slider named slider2.");
+}
+
 void CheckWebsocketCommand(const drake::geometry::Meshcat& meshcat,
                            int message_num,
                            const std::string& desired_command_json) {

--- a/geometry/test/meshcat_visualizer_test.cc
+++ b/geometry/test/meshcat_visualizer_test.cc
@@ -147,7 +147,7 @@ TEST_F(MeshcatVisualizerWithIiwaTest, Prefix) {
 
 TEST_F(MeshcatVisualizerWithIiwaTest, DeletePrefixOnInitialization) {
   MeshcatVisualizerParams params;
-  params.delete_on_intialization_event = true;
+  params.delete_on_initialization_event = true;
   SetUpDiagram(params);
   // Scribble a transform onto the scene tree beneath the visualizer prefix.
   meshcat_->SetTransform("/drake/visualizer/my_random_path",
@@ -163,7 +163,7 @@ TEST_F(MeshcatVisualizerWithIiwaTest, DeletePrefixOnInitialization) {
   EXPECT_FALSE(meshcat_->HasPath("/drake/visualizer/my_random_path"));
 
   // Repeat, but this time with delete prefix disabled.
-  params.delete_on_intialization_event = false;
+  params.delete_on_initialization_event = false;
   SetUpDiagram(params);
   meshcat_->SetTransform("/drake/visualizer/my_random_path",
                         math::RigidTransformd());

--- a/tools/workspace/meshcat/repository.bzl
+++ b/tools/workspace/meshcat/repository.bzl
@@ -11,8 +11,8 @@ def meshcat_repository(
         repository = "rdeits/meshcat",
         # Updating this commit requires local testing; see
         # drake/tools/workspace/meshcat/README.md for details.
-        commit = "a03d1abf636c059166132a6d9434a164a155ecbe",
-        sha256 = "b23fcc5152c0eafc51a2255928a93568151f93e0f812fbc7e7fc3548f2e9c49a",  # noqa
+        commit = "06c6342adc4e7e69caa88125ba6a924a1507f9e5",
+        sha256 = "04d00ba8a8f9a8d457fba53c417bade53db9b02c7c7a4b13c518556b4abb34ff",  # noqa
         build_file = "@drake//tools/workspace/meshcat:package.BUILD.bazel",  # noqa
         mirrors = mirrors,
     )


### PR DESCRIPTION
Adds support for buttons and sliders inside the meshcat browser.  This is also the first instance of a bidirectional communication (the new direction being browser => c++).  I've been using it for class for a week or so, and it's been working well under that stress test.

Note: This contains the commits from #15727 and #15728, which are both ready to merge (I believe).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15768)
<!-- Reviewable:end -->
