### PR TITLE
[geometry] Visualizing hydro with DrakeVisualizer

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -1146,13 +1146,18 @@ void DoScalarIndependentDefinitions(py::module m) {
         .def_readwrite("role", &DrakeVisualizerParams::role, cls_doc.role.doc)
         .def_readwrite("default_color", &DrakeVisualizerParams::default_color,
             cls_doc.default_color.doc)
+        .def_readwrite("show_hydroelastic",
+            &DrakeVisualizerParams::show_hydroelastic,
+            cls_doc.show_hydroelastic.doc)
         .def("__repr__", [](const Class& self) {
           return py::str(
               "DrakeVisualizerParams("
               "publish_period={}, "
               "role={}, "
-              "default_color={})")
-              .format(self.publish_period, self.role, self.default_color);
+              "default_color={}, "
+              "show_hydroelastic={})")
+              .format(self.publish_period, self.role, self.default_color,
+                  self.show_hydroelastic);
         });
   }
 

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -308,12 +308,14 @@ class TestGeometry(unittest.TestCase):
         role = mut.Role.kIllustration
         params = mut.DrakeVisualizerParams(
             publish_period=0.1, role=mut.Role.kIllustration,
-            default_color=mut.Rgba(0.1, 0.2, 0.3, 0.4))
+            default_color=mut.Rgba(0.1, 0.2, 0.3, 0.4),
+            show_hydroelastic=False)
         self.assertEqual(repr(params), "".join([
             "DrakeVisualizerParams("
             "publish_period=0.1, "
             "role=Role.kIllustration, "
-            "default_color=Rgba(r=0.1, g=0.2, b=0.3, a=0.4))"]))
+            "default_color=Rgba(r=0.1, g=0.2, b=0.3, a=0.4), "
+            "show_hydroelastic=False)"]))
 
         # Add some subscribers to detect message broadcast.
         load_channel = "DRAKE_VIEWER_LOAD_ROBOT"

--- a/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
+++ b/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
@@ -53,6 +53,9 @@ DEFINE_double(
 DEFINE_bool(visualize, true,
             "If true, the simulation will publish messages for Drake "
             "visualizer. Useful to turn off during profiling sessions.");
+DEFINE_bool(vis_hydro, false,
+            "If true, visualize collision geometries as their hydroelastic "
+            "meshes, where possible.");
 
 // Sphere's spatial velocity.
 DEFINE_double(vx, 1.5,
@@ -161,7 +164,13 @@ int do_main() {
       scene_graph.get_source_pose_port(plant.get_source_id().value()));
 
   if (FLAGS_visualize) {
-    geometry::DrakeVisualizerd::AddToBuilder(&builder, scene_graph);
+    geometry::DrakeVisualizerParams params;
+    if (FLAGS_vis_hydro) {
+      params.role = geometry::Role::kProximity;
+      params.show_hydroelastic = true;
+    }
+    geometry::DrakeVisualizerd::AddToBuilder(&builder, scene_graph, nullptr,
+                                             params);
     ConnectContactResultsToDrakeVisualizer(&builder, plant);
   }
   auto diagram = builder.Build();

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -517,6 +517,7 @@ drake_cc_googletest(
     name = "drake_visualizer_test",
     deps = [
         ":drake_visualizer",
+        "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
         "//lcm:mock",
         "//systems/analysis:simulator",

--- a/geometry/drake_visualizer.cc
+++ b/geometry/drake_visualizer.cc
@@ -6,6 +6,7 @@
 #include "drake/common/default_scalars.h"
 #include "drake/common/extract_double.h"
 #include "drake/common/value.h"
+#include "drake/geometry/proximity/volume_to_surface_mesh.h"
 #include "drake/geometry/query_object.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/geometry/shape_specification.h"
@@ -29,6 +30,113 @@ using systems::EventStatus;
 using systems::SystemTypeTag;
 
 namespace {
+
+/* Create an lcm message for a hydroelastic mesh representation of the geometry
+ indicated by `geometry_id`.
+
+ The geometry data message is marked as a MESH, but rather than having a
+ path to a parseable file stored in it, the actual mesh data is stored.
+
+ This function shares implementation details with the ShapeToLcm reifier (in
+ terms of handling pose and color). Ultimately, when the Mesh shape
+ specification supports in-memory mesh definitions, this can be rolled into
+ ShapeToLcm and it will more fully share that class's code for handling pose
+ and color.
+
+ @param geometry_id   The id of the geometry to draw.
+ @param inspector     The SceneGraphInspector from which the mesh will be drawn.
+ @param X_PG          The pose of the geometry in the parent frame.
+ @param in_color      The color to apply to the mesh.
+ @pre The geometry actually has a hydroelastic mesh. */
+template <typename T>
+lcmt_viewer_geometry_data MakeHydroMesh(GeometryId geometry_id,
+                                        const SceneGraphInspector<T>& inspector,
+                                        const RigidTransformd& X_PG,
+                                        const Rgba& in_color) {
+  auto hydro_mesh = inspector.maybe_get_hydroelastic_mesh(geometry_id);
+  DRAKE_DEMAND(!std::holds_alternative<std::monostate>(hydro_mesh));
+  // SceneGraphInspector guarantees whichever pointer is "held" in the variant
+  // is non-null.
+  const SurfaceMesh<double>& surface_mesh =
+      std::holds_alternative<const SurfaceMesh<double>*>(hydro_mesh)
+          ? *std::get<const SurfaceMesh<double>*>(hydro_mesh)
+          : ConvertVolumeToSurfaceMesh(
+                *std::get<const VolumeMesh<double>*>(hydro_mesh));
+
+  lcmt_viewer_geometry_data geometry_data;
+
+  // Saves the location and orientation of the visualization geometry in the
+  // `lcmt_viewer_geometry_data` object. The location and orientation are
+  // specified in the body's frame.
+  Eigen::Map<Eigen::Vector3f> position(geometry_data.position);
+  position = X_PG.translation().template cast<float>();
+  // LCM quaternion must be w, x, y, z.
+  Quaterniond q(X_PG.rotation().ToQuaternion());
+  geometry_data.quaternion[0] = q.w();
+  geometry_data.quaternion[1] = q.x();
+  geometry_data.quaternion[2] = q.y();
+  geometry_data.quaternion[3] = q.z();
+
+  Eigen::Map<Eigen::Vector4f> color(geometry_data.color);
+  Eigen::Vector4d color_vec(in_color.r(), in_color.g(), in_color.b(),
+                            in_color.a());
+  color = color_vec.cast<float>();
+
+  // There are *two* ways to use the MESH geometry type. One is to set the
+  // string value with a path to a parseable mesh file (see
+  // ImplementGeometry(Mesh) below). The other is to leave the string empty and
+  // define the mesh in the float data as:
+  // V | T | v0 | v1 | ... vN | t0 | t1 | ... | tM
+  // where
+  //   V: The number of vertices.
+  //   T: The number of triangles.
+  //   N: 3V, the number of floating point values for the V vertices.
+  //   M: 3T, the number of vertex indices for the T triangles.
+  geometry_data.type = geometry_data.MESH;
+
+  // We want a *faceted* mesh. We can achieve this by duplicating the vertices
+  // so DrakeVisualizer can't smooth over vertices. So, that means for T
+  // triangles we have 3T vertices. Experimentation suggests this redundancy
+  // is the simplest way to get a faceted mesh.
+  const int num_tris = surface_mesh.num_faces();
+  const int num_verts = 3 * num_tris;
+  const int header_floats = 2;
+  geometry_data.num_float_data = header_floats + 3 * num_tris + 3 * num_verts;
+  geometry_data.float_data.resize(geometry_data.num_float_data);
+  auto& float_data = geometry_data.float_data;
+
+  float_data[0] = num_verts;
+  float_data[1] = num_tris;
+
+  // We simply want to pre-increment before using this index; so we'll decrement
+  // it to be just before where we want to write.
+  int v_index = header_floats - 1;
+  int t_index = v_index + 3 * num_verts;
+
+  // The index of the most recently added vertex (whose position measures are
+  // written at v_index, v_index + 1, and v_index + 2 in float_data).
+  int newest_vertex_index = -1;
+  for (SurfaceFaceIndex f(0); f < surface_mesh.num_faces(); ++f) {
+    const auto& face = surface_mesh.element(f);
+    for (int fv = 0; fv < 3; ++fv) {
+      const SurfaceVertexIndex v_i = face.vertex(fv);
+      const Vector3<float> p_MV =
+          surface_mesh.vertex(v_i).r_MV().template cast<float>();
+      float_data[++v_index] = p_MV.x();
+      float_data[++v_index] = p_MV.y();
+      float_data[++v_index] = p_MV.z();
+      float_data[++t_index] = ++newest_vertex_index;
+    }
+  }
+
+  // v_index and t_index end with the index of the last element added, so one
+  // less than the expected number, hence the "+ 1". So, the vertex index should
+  // have walked up to the starting index for triangles and the triangle index
+  // should have walked up to the total number of floats.
+  DRAKE_DEMAND(header_floats + 3 * num_verts == (v_index + 1));
+  DRAKE_DEMAND(geometry_data.num_float_data == (t_index + 1));
+  return geometry_data;
+}
 
 // Simple class for converting shape specifications into LCM-compatible shapes.
 class ShapeToLcm : public ShapeReifier {
@@ -306,6 +414,15 @@ void DrakeVisualizer<T>::SendLoadMessage(
     }
     const Rgba& color =
         props->GetPropertyOrDefault("phong", "diffuse", default_color);
+    if (params.role == Role::kProximity && params.show_hydroelastic) {
+      auto hydro_mesh = inspector.maybe_get_hydroelastic_mesh(g_id);
+      if (!std::holds_alternative<std::monostate>(hydro_mesh)) {
+        // This Shape *definitely* has a mesh associated with it. Replace the
+        // primitive with the mesh hydroelastic mesh.
+        return MakeHydroMesh(g_id, inspector, inspector.GetPoseInFrame(g_id),
+                             color);
+      }
+    }
     return ShapeToLcm().Convert(shape, inspector.GetPoseInFrame(g_id), color);
   };
 

--- a/geometry/drake_visualizer_params.h
+++ b/geometry/drake_visualizer_params.h
@@ -17,6 +17,22 @@ struct DrakeVisualizerParams {
 
   /** The color to apply to any geometry that hasn't defined one.  */
   Rgba default_color{0.9, 0.9, 0.9, 1.0};
+
+  /** When using the hydroelastic contact model, collision geometries that are
+   _declared_ as geometric primitives are frequently represented by some
+   discretely tessellated mesh when computing contact. It can be quite helpful
+   in assessing contact behavior to visualize these discrete meshes (in place of
+   the idealized primitives).
+
+   To visualize these representations it is necessary to request visualization
+   of geometries with the Role::kProximity role (see the role field). It is
+   further necessary to explicitly request the hydroelastic meshes where
+   available (setting show_hydroelastic to `true`).
+
+   Setting this `show_hydroelastic` to `true` will have no apparent effect if
+   none of the collision meshes have a hydroelastic mesh associated with them.
+   */
+  bool show_hydroelastic{false};
 };
 
 }  // namespace geometry

--- a/geometry/rgba.h
+++ b/geometry/rgba.h
@@ -50,6 +50,16 @@ class Rgba {
     a_ = a;
   }
 
+  /* Reports if two %Rgba values are equal within a given absolute `tolerance`.
+   They are "equal" so long as the difference in no single channel is larger
+   than the specified `tolerance`. */
+  bool AlmostEqual(const Rgba& other, double tolerance = 0.0) const {
+    return std::abs(r_ - other.r_) <= tolerance &&
+           std::abs(g_ - other.g_) <= tolerance &&
+           std::abs(b_ - other.b_) <= tolerance &&
+           std::abs(a_ - other.a_) <= tolerance;
+  }
+
   bool operator==(const Rgba& other) const {
     return
         r_ == other.r_ && g_ == other.g_ && b_ == other.b_ && a_ == other.a_;

--- a/geometry/test/rgba_test.cc
+++ b/geometry/test/rgba_test.cc
@@ -19,6 +19,11 @@ GTEST_TEST(RgbaTest, Basic) {
   EXPECT_EQ(color.a(), a);
   EXPECT_TRUE(color == Rgba(r, g, b, a));
   EXPECT_TRUE(color != Rgba(r, g, b, 0.));
+  const double kEps = 1e-8;
+  const Rgba color_delta(color.r() + kEps, color.g() - kEps, color.b() + kEps,
+                         color.a() - kEps);
+  EXPECT_TRUE(color.AlmostEqual(color_delta, 1.001 * kEps));
+  EXPECT_FALSE(color.AlmostEqual(color_delta, 0.999 * kEps));
   color.set(1., 1., 1., 0.);
   EXPECT_EQ(color, Rgba(1., 1., 1., 0.));
 }

--- a/tools/workspace/drake_visualizer/draw_lcm_mesh.patch
+++ b/tools/workspace/drake_visualizer/draw_lcm_mesh.patch
@@ -1,0 +1,14 @@
+Correct integer division used in range to draw lcm-defined mesh.
+
+--- a/drakevisualizer.py
++++ b/drakevisualizer.py
+@@ -90,7 +90,7 @@ class Geometry(object):
+
+         assert len(faces) % 3 == 0
+         cells = vtk.vtkCellArray()
+-        for i in range(len(faces)/3):
++        for i in range(len(faces) // 3):
+             tri = vtk.vtkTriangle()
+             tri.GetPointIds().SetId(0, faces[i*3 + 0])
+             tri.GetPointIds().SetId(1, faces[i*3 + 1])
+

--- a/tools/workspace/drake_visualizer/repository.bzl
+++ b/tools/workspace/drake_visualizer/repository.bzl
@@ -69,6 +69,7 @@ def _impl(repository_ctx):
         repository_ctx,
         patches = [
             Label("@drake//tools/workspace/drake_visualizer:use_drake_lcmtypes.patch"),  # noqa
+            Label("@drake//tools/workspace/drake_visualizer:draw_lcm_mesh.patch"),  # noqa
         ],
         patch_args = [
             "--directory=lib/python{}/site-packages/director".format(


### PR DESCRIPTION
Visualizing hydro with DrakeVisualizer

This streams the meshes for hydro geometries via a previously unused lcm mechanism. That mechanism requires a patch to `drakevisualizer.py` (it hasn't been kept up to date w.r.t. python versions).

We also expand `rolling_sphere_run_dynamics` to include a flag to exercise
this new functionality.

To see the visualization at work, run:

```
bazel run //examples/multibody/rolling_sphere:rolling_sphere_run_dynamics \
  -- --vis_hydro
```

relates #15738

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15772)
<!-- Reviewable:end -->
