### PR TITLE
[tools] Fix config.cmake files broken in pycps removal

### DIFF
--- a/tools/install/libdrake/drake-config.cmake
+++ b/tools/install/libdrake/drake-config.cmake
@@ -52,10 +52,15 @@ unset(_targetsDefined)
 unset(_targetsNotDefined)
 unset(_expectedTargets)
 
+set(_apple_soname_prologue)
+if(APPLE)
+  set(_apple_soname_prologue "@rpath/")
+endif()
+
 add_library(drake::drake SHARED IMPORTED)
 set_target_properties(drake::drake PROPERTIES
   IMPORTED_LOCATION "${${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX}/lib/libdrake.so"
-  IMPORTED_SONAME "libdrake.so"
+  IMPORTED_SONAME "${_apple_soname_prologue}libdrake.so"
   INTERFACE_INCLUDE_DIRECTORIES "${${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX}/include"
   INTERFACE_LINK_LIBRARIES "drake::drake-lcmtypes-cpp;drake::drake-marker;Eigen3::Eigen;fmt::fmt-header-only;lcm::lcm;optitrack::optitrack-lcmtypes-cpp;spdlog::spdlog;tinyxml2::tinyxml2;${yaml-cpp_LIBRARIES}"
   INTERFACE_COMPILE_FEATURES "cxx_std_17"
@@ -78,8 +83,10 @@ set_target_properties(drake::drake-lcmtypes-java PROPERTIES
 add_library(drake::drake-marker SHARED IMPORTED)
 set_target_properties(drake::drake-marker PROPERTIES
   IMPORTED_LOCATION "${${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX}/lib/libdrake_marker.so"
-  IMPORTED_SONAME "libdrake_marker.so"
+  IMPORTED_SONAME "${_apple_soname_prologue}libdrake_marker.so"
 )
+
+unset(_apple_soname_prologue)
 
 set(drake_LIBRARIES "drake::drake")
 set(drake_INCLUDE_DIRS "")

--- a/tools/workspace/ignition_math/ignition-math6-config.cmake
+++ b/tools/workspace/ignition_math/ignition-math6-config.cmake
@@ -49,12 +49,17 @@ unset(_expectedTargets)
 
 set(ignition-math6_VERSION "6.8.0")
 
+set(_apple_soname_prologue)
+if(APPLE)
+  set(_apple_soname_prologue "@rpath/")
+endif()
 add_library(ignition-math6::ignition-math6 SHARED IMPORTED)
 set_target_properties(ignition-math6::ignition-math6 PROPERTIES
   IMPORTED_LOCATION "${${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX}/lib/libdrake_ignition_math.so"
-  IMPORTED_SONAME "libdrake_ignition_math.so"
+  IMPORTED_SONAME "${_apple_soname_prologue}libdrake_ignition_math.so"
   INTERFACE_INCLUDE_DIRECTORIES "${${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX}/include/ignition-math6"
 )
+unset(_apple_soname_prologue)
 
 set(ignition-math6_LIBRARIES "ignition-math6::ignition-math6")
 set(ignition-math6_INCLUDE_DIRS "")

--- a/tools/workspace/lcm/lcm-config.cmake
+++ b/tools/workspace/lcm/lcm-config.cmake
@@ -53,13 +53,18 @@ set_target_properties(lcm::lcm-coretypes PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES "${${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX}/include/lcm"
 )
 
+set(_apple_soname_prologue)
+if(APPLE)
+  set(_apple_soname_prologue "@rpath/")
+endif()
 add_library(lcm::lcm SHARED IMPORTED)
 set_target_properties(lcm::lcm PROPERTIES
   IMPORTED_LOCATION "${${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX}/lib/libdrake_lcm.so"
-  IMPORTED_SONAME "libdrake_lcm.so"
+  IMPORTED_SONAME "${_apple_soname_prologue}libdrake_lcm.so"
   INTERFACE_INCLUDE_DIRECTORIES "${${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX}/include/lcm"
   INTERFACE_LINK_LIBRARIES "lcm::lcm-coretypes"
 )
+unset(_apple_soname_prologue)
 
 add_executable(lcm::lcm-gen IMPORTED)
 set_target_properties(lcm::lcm-gen PROPERTIES

--- a/tools/workspace/spdlog/spdlog-config.cmake
+++ b/tools/workspace/spdlog/spdlog-config.cmake
@@ -50,14 +50,19 @@ unset(_expectedTargets)
 
 set(spdlog_VERSION "1.5.0")
 
+set(_apple_soname_prologue)
+if(APPLE)
+  set(_apple_soname_prologue "@rpath/")
+endif()
 add_library(spdlog::spdlog SHARED IMPORTED)
 set_target_properties(spdlog::spdlog PROPERTIES
   IMPORTED_LOCATION "${${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX}/lib/libdrake_spdlog.so"
-  IMPORTED_SONAME "libdrake_spdlog.so"
+  IMPORTED_SONAME "${_apple_soname_prologue}libdrake_spdlog.so"
   INTERFACE_INCLUDE_DIRECTORIES "${${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX}/include/spdlog"
   INTERFACE_LINK_LIBRARIES "fmt::fmt-header-only"
   INTERFACE_COMPILE_DEFINITIONS "HAVE_SPDLOG;SPDLOG_COMPILED_LIB;SPDLOG_FMT_EXTERNAL"
 )
+unset(_apple_soname_prologue)
 
 set(spdlog_LIBRARIES "spdlog::spdlog")
 set(spdlog_INCLUDE_DIRS "")


### PR DESCRIPTION
On macOS, we need some linker-specific mumbling for dynamic loading to operate correctly.

Hotfix for #15756.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15775)
<!-- Reviewable:end -->
