### PR TITLE
[geometry] Deprecate geometry::FrameIndex

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -60,7 +60,6 @@ drake_cc_library(
     ],
     deps = [
         ":geometry_ids",
-        ":geometry_index",
         ":geometry_roles",
         ":internal_geometry",
         ":shape_specification",
@@ -285,7 +284,6 @@ drake_cc_library(
     hdrs = ["internal_frame.h"],
     deps = [
         ":geometry_ids",
-        ":geometry_index",
         "//common:essential",
     ],
 )
@@ -296,7 +294,6 @@ drake_cc_library(
     hdrs = ["internal_geometry.h"],
     deps = [
         ":geometry_ids",
-        ":geometry_index",
         ":geometry_roles",
         ":internal_frame",
         ":shape_specification",

--- a/geometry/geometry_index.h
+++ b/geometry/geometry_index.h
@@ -1,14 +1,16 @@
 #pragma once
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/type_safe_index.h"
 
 namespace drake {
 namespace geometry {
 
-// TODO(SeanCurtis-TRI): Remove FrameIndex.
+// TODO(2022-01-01): Remove this header when removing the deprecated type.
 /** Index into the ordered vector of all registered frames -- by convention,
  the world frame's index is always zero.  */
-using FrameIndex = TypeSafeIndex<class GeometryTag>;
+using FrameIndex DRAKE_DEPRECATED("2022-01-01", "This is an unused type.") =
+    TypeSafeIndex<class GeometryTag>;
 
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -124,7 +124,7 @@ GeometryState<T>::GeometryState()
   // As an arbitrary design choice, we'll say the world frame is its own parent.
   frames_[world] = InternalFrame(self_source_, world, "world",
                                  InternalFrame::world_frame_group(),
-                                 FrameIndex(0), world);
+                                 0, world);
   frame_index_to_id_map_.push_back(world);
   X_WF_.push_back(RigidTransform<T>::Identity());
   X_PF_.push_back(RigidTransform<T>::Identity());
@@ -556,7 +556,7 @@ FrameId GeometryState<T>::RegisterFrame(SourceId source_id, FrameId parent_id,
   }
 
   DRAKE_ASSERT(X_PF_.size() == frame_index_to_id_map_.size());
-  FrameIndex index(X_PF_.size());
+  int index(static_cast<int>(X_PF_.size()));
   X_PF_.emplace_back(RigidTransform<T>::Identity());
   X_WF_.emplace_back(RigidTransform<T>::Identity());
   frame_index_to_id_map_.push_back(frame_id);

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -15,7 +15,6 @@
 #include "drake/geometry/collision_filter_manager.h"
 #include "drake/geometry/frame_kinematics_vector.h"
 #include "drake/geometry/geometry_ids.h"
-#include "drake/geometry/geometry_index.h"
 #include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/geometry_set.h"
 #include "drake/geometry/geometry_version.h"

--- a/geometry/internal_frame.cc
+++ b/geometry/internal_frame.cc
@@ -10,13 +10,14 @@ InternalFrame::InternalFrame() {}
 
 InternalFrame::InternalFrame(SourceId source_id, FrameId frame_id,
                              const std::string& name, int frame_group,
-                             FrameIndex index, FrameId parent_id)
+                             int index, FrameId parent_id)
     : source_id_(source_id),
       id_(frame_id),
       name_(name),
       frame_group_(frame_group),
       index_(index),
       parent_id_(parent_id) {
+  DRAKE_DEMAND(index >= 0);
   DRAKE_DEMAND(frame_group >= 0 || frame_group == world_frame_group());
 }
 

--- a/geometry/internal_frame.h
+++ b/geometry/internal_frame.h
@@ -5,7 +5,6 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/geometry/geometry_ids.h"
-#include "drake/geometry/geometry_index.h"
 
 namespace drake {
 namespace geometry {
@@ -43,7 +42,7 @@ class InternalFrame {
    @param index         The index of this frame in the SceneGraph.
    @param parent_id     The id of the parent frame.  */
   InternalFrame(SourceId source_id, FrameId frame_id, const std::string& name,
-                int frame_group, FrameIndex index, FrameId parent_id);
+                int frame_group, int index, FrameId parent_id);
 
   /* Compares two %InternalFrame instances for "equality". Two internal frames
    are considered equal if they have the same frame identifier.  */
@@ -71,7 +70,7 @@ class InternalFrame {
   int frame_group() const { return frame_group_; }
 
   /* Returns the index of this frame in the full scene graph.  */
-  FrameIndex index() const { return index_; }
+  int index() const { return index_; }
 
   //@}
 
@@ -173,7 +172,7 @@ class InternalFrame {
   int frame_group_{0};
 
   // The index of this frame in the full SceneGraph.
-  FrameIndex index_;
+  int index_{};
 
   // The identifier of this frame's parent frame.
   FrameId parent_id_;

--- a/geometry/internal_geometry.h
+++ b/geometry/internal_geometry.h
@@ -10,7 +10,6 @@
 #include "drake/common/copyable_unique_ptr.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/geometry/geometry_ids.h"
-#include "drake/geometry/geometry_index.h"
 #include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/internal_frame.h"
 #include "drake/geometry/shape_specification.h"

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -568,7 +568,6 @@ drake_cc_library(
         ":volume_mesh",
         "//common:sorted_pair",
         "//geometry:geometry_ids",
-        "//geometry:geometry_index",
         "//geometry:shape_specification",
         "@fcl",
         "@fmt",

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -974,8 +974,8 @@ TEST_F(GeometryStateTest, ValidateSingleSourceTree) {
     // The world frame + the frames added by s_id.
     EXPECT_EQ(internal_frames.size(), kFrameCount + 1);
 
-    auto test_frame = [internal_frames, this, s_id](
-        FrameIndex i, FrameId parent_id, int num_child_frames) {
+    auto test_frame = [internal_frames, this, s_id](int i, FrameId parent_id,
+                                                    int num_child_frames) {
       const auto& frame = internal_frames.at(frames_[i]);
       EXPECT_EQ(frame.source_id(), s_id);
       EXPECT_EQ(frame.id(), frames_[i]);
@@ -1013,9 +1013,9 @@ TEST_F(GeometryStateTest, ValidateSingleSourceTree) {
     gs_tester_.SetFramePoses(s_id, poses);
     gs_tester_.FinalizePoseUpdate();
 
-    test_frame(FrameIndex(0), gs_tester_.get_world_frame(), 0);
-    test_frame(FrameIndex(1), gs_tester_.get_world_frame(), 1);
-    test_frame(FrameIndex(2), frames_[1], 0);
+    test_frame(0, gs_tester_.get_world_frame(), 0);
+    test_frame(1, gs_tester_.get_world_frame(), 1);
+    test_frame(2, frames_[1], 0);
   }
 
   // The internal geometries are what and where they should be.


### PR DESCRIPTION
`geometry::FrameIndex` is another ancient relic in the `SceneGraph` ecosystem. It should not have been in the `geometry::` namespace. At best, it should have been in `geometry::internal`. However, upon further inspection, it provides very little value. So, we're deprecating the type entirely. Technically, this is a breaking change, but as no public API consumed or returned these indices, simply removing it should not cause difficulties.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15778)
<!-- Reviewable:end -->
