### PR TITLE
[fem] Un-nest ContactPointData

### DIFF
--- a/multibody/fixed_fem/dev/deformable_rigid_manager.cc
+++ b/multibody/fixed_fem/dev/deformable_rigid_manager.cc
@@ -338,7 +338,8 @@ void DeformableRigidManager<T>::CalcTwoWayCoupledContactSolverResults(
   /* Point contact data. */
   const BlockSparseMatrix<T> Jc = CalcContactJacobian(context);
   const BlockSparseLinearOperator<T> Jc_op("Contact Jacobian", &Jc);
-  const ContactPointData& point_data = EvalContactPointData(context);
+  const internal::ContactPointData<T>& point_data =
+      EvalContactPointData(context);
 
   /* System dynamics data.*/
   const VectorX<T>& v_star = EvalFreeMotionParticipatingVelocities(context);
@@ -900,7 +901,7 @@ MatrixX<T> DeformableRigidManager<T>::CalcContactJacobianRigidBlock(
 template <typename T>
 void DeformableRigidManager<T>::CalcContactPointData(
     const systems::Context<T>& context,
-    ContactPointData* contact_point_data) const {
+    internal::ContactPointData<T>* contact_point_data) const {
   DRAKE_DEMAND(contact_point_data != nullptr);
 
   /* Get the rigid-rigid and deformable-rigid contact info. */

--- a/multibody/fixed_fem/dev/test/deformable_rigid_manager_test.cc
+++ b/multibody/fixed_fem/dev/test/deformable_rigid_manager_test.cc
@@ -464,9 +464,9 @@ class DeformableRigidContactDataTest : public ::testing::Test {
 
   /* Forwards the call to DeformableRigidManager::CalcContactPointData() and
    returns the result as a return value. */
-  DeformableRigidManager<double>::ContactPointData CalcContactPointData(
+  internal::ContactPointData<double> CalcContactPointData(
       const Context<double>& context) const {
-    DeformableRigidManager<double>::ContactPointData data;
+    internal::ContactPointData<double> data;
     deformable_rigid_manager_->CalcContactPointData(context, &data);
     return data;
   }
@@ -737,7 +737,8 @@ TEST_F(DeformableRigidContactDataTest, ContactData) {
   ASSERT_GT(nc_rigid_deformable, 0);
 
   /* Verifies that the contact point data is as expected. */
-  const auto contact_point_data = CalcContactPointData(plant_context);
+  const internal::ContactPointData<double> contact_point_data =
+      CalcContactPointData(plant_context);
   const VectorXd& mu = contact_point_data.mu;
   const VectorXd& phi0 = contact_point_data.phi0;
   const VectorXd& stiffness = contact_point_data.stiffness;
@@ -874,7 +875,8 @@ TEST_F(DeformableRigidContactDataTest, NoContact) {
   EXPECT_EQ(Jc.cols(), 0);
 
   /* Verify that the contact point data is empty. */
-  const auto contact_point_data = CalcContactPointData(plant_context);
+  const internal::ContactPointData<double> contact_point_data =
+      CalcContactPointData(plant_context);
   EXPECT_EQ(contact_point_data.mu.size(), 0);
   EXPECT_EQ(contact_point_data.phi0.size(), 0);
   EXPECT_EQ(contact_point_data.stiffness.size(), 0);


### PR DESCRIPTION
Move `ContactPointData` from nested in DeformableRigidManager to outside
of DeformableRigidManager but internal namespace. This prevents typename
hasher from spewing warning messages to the console as in #15761.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15779)
<!-- Reviewable:end -->
