### PR TITLE
[pydrake:math] Add bindings for RigidTransform comparison methods

### DIFF
--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -101,8 +101,12 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("GetAsIsometry3", &Class::GetAsIsometry3,
             cls_doc.GetAsIsometry3.doc)
         .def("SetIdentity", &Class::SetIdentity, cls_doc.SetIdentity.doc)
-        // .def("IsExactlyIdentity", ...)
-        // .def("IsIdentityToEpsilon", ...)
+        .def("IsExactlyIdentity", &Class::IsExactlyIdentity,
+            cls_doc.IsExactlyIdentity.doc)
+        .def("IsIdentityToEpsilon", &Class::IsIdentityToEpsilon,
+            py::arg("translation_tolerance"), cls_doc.IsIdentityToEpsilon.doc)
+        .def("IsNearlyEqualTo", &Class::IsNearlyEqualTo, py::arg("other"),
+            py::arg("tolerance"), cls_doc.IsNearlyEqualTo.doc)
         .def("inverse", &Class::inverse, cls_doc.inverse.doc)
         .def(
             "multiply",

--- a/bindings/pydrake/test/math_test.py
+++ b/bindings/pydrake/test/math_test.py
@@ -162,6 +162,10 @@ class TestMath(unittest.TestCase):
             X.multiply(other=RigidTransform()), RigidTransform)
         self.assertIsInstance(X @ RigidTransform(), RigidTransform)
         self.assertIsInstance(X @ [0, 0, 0], np.ndarray)
+        if T != Expression:
+            self.assertTrue(X.IsExactlyIdentity())
+            self.assertTrue(X.IsIdentityToEpsilon(translation_tolerance=0))
+            self.assertTrue(X.IsNearlyEqualTo(other=X, tolerance=0))
         # - Test shaping (#13885).
         v = np.array([0., 0., 0.])
         vs = np.array([[1., 2., 3.], [4., 5., 6.]]).T


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15785)
<!-- Reviewable:end -->
