### PR TITLE
[trajectories] Cleanup PiecewisePose and add python bindings

### DIFF
--- a/bindings/pydrake/test/trajectories_test.py
+++ b/bindings/pydrake/test/trajectories_test.py
@@ -4,11 +4,11 @@ import unittest
 from pydrake.common import ToleranceType
 from pydrake.common.eigen_geometry import AngleAxis, Quaternion
 from pydrake.common.test_utilities import numpy_compare
-from pydrake.math import BsplineBasis, RotationMatrix
+from pydrake.math import BsplineBasis, RigidTransform, RotationMatrix
 from pydrake.polynomial import Polynomial
 from pydrake.trajectories import (
-    BsplineTrajectory, PiecewisePolynomial, PiecewiseQuaternionSlerp,
-    Trajectory
+    BsplineTrajectory, PiecewisePolynomial, PiecewisePose,
+    PiecewiseQuaternionSlerp, Trajectory
 )
 
 
@@ -291,3 +291,35 @@ class TestTrajectories(unittest.TestCase):
         np.testing.assert_equal(
             np.zeros(3), pq.angular_acceleration(time=1)
         )
+
+    def test_piecewise_pose(self):
+        # Test empty constructor.
+        ppose = PiecewisePose()
+        self.assertEqual(ppose.rows(), 4)
+        self.assertEqual(ppose.cols(), 4)
+        self.assertEqual(ppose.get_number_of_segments(), 0)
+
+        t = [0., 1., 2.]
+        q = Quaternion()
+        pp = PiecewisePolynomial.FirstOrderHold(t, np.zeros((3, 3)))
+        pq = PiecewiseQuaternionSlerp(t, [q, q, q])
+        ppose = PiecewisePose(position_trajectory=pp,
+                              orientation_trajectory=pq)
+        self.assertEqual(ppose.get_number_of_segments(), 2)
+
+        np.testing.assert_equal(ppose.GetPose(
+            time=0).GetAsMatrix4(), np.eye(4))
+        np.testing.assert_equal(ppose.GetVelocity(time=0), np.zeros((6,)))
+        np.testing.assert_equal(
+            ppose.GetAcceleration(time=0), np.zeros((6,)))
+        self.assertTrue(ppose.IsApprox(other=ppose, tol=0.0))
+        self.assertIsInstance(
+            ppose.get_position_trajectory(), PiecewisePolynomial)
+        self.assertIsInstance(
+            ppose.get_orientation_trajectory(), PiecewiseQuaternionSlerp)
+
+        X = RigidTransform()
+        ppose = PiecewisePose.MakeCubicLinearWithEndLinearVelocity(
+            times=t, poses=[X, X, X], start_vel=np.zeros((3, 1)),
+            end_vel=np.zeros((3, 1)))
+        self.assertEqual(ppose.get_number_of_segments(), 2)

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -9,6 +9,7 @@
 #include "drake/common/polynomial.h"
 #include "drake/common/trajectories/bspline_trajectory.h"
 #include "drake/common/trajectories/piecewise_polynomial.h"
+#include "drake/common/trajectories/piecewise_pose.h"
 #include "drake/common/trajectories/piecewise_quaternion.h"
 #include "drake/common/trajectories/trajectory.h"
 
@@ -348,6 +349,34 @@ PYBIND11_MODULE(trajectories, m) {
       .def("angular_acceleration",
           &PiecewiseQuaternionSlerp<T>::angular_acceleration, py::arg("time"),
           doc.PiecewiseQuaternionSlerp.angular_acceleration.doc);
+
+  py::class_<PiecewisePose<T>, PiecewiseTrajectory<T>>(
+      m, "PiecewisePose", doc.PiecewisePose.doc)
+      .def(py::init<>(), doc.PiecewisePose.ctor.doc_0args)
+      .def(py::init<const PiecewisePolynomial<T>&,
+               const PiecewiseQuaternionSlerp<T>&>(),
+          py::arg("position_trajectory"), py::arg("orientation_trajectory"),
+          doc.PiecewisePose.ctor.doc_2args)
+      .def_static("MakeCubicLinearWithEndLinearVelocity",
+          &PiecewisePose<T>::MakeCubicLinearWithEndLinearVelocity,
+          py::arg("times"), py::arg("poses"),
+          py::arg("start_vel") = Vector3<T>::Zero(),
+          py::arg("end_vel") = Vector3<T>::Zero(),
+          doc.PiecewisePose.MakeCubicLinearWithEndLinearVelocity.doc)
+      .def("GetPose", &PiecewisePose<T>::GetPose, py::arg("time"),
+          doc.PiecewisePose.GetPose.doc)
+      .def("GetVelocity", &PiecewisePose<T>::GetVelocity, py::arg("time"),
+          doc.PiecewisePose.GetVelocity.doc)
+      .def("GetAcceleration", &PiecewisePose<T>::GetAcceleration,
+          py::arg("time"), doc.PiecewisePose.GetAcceleration.doc)
+      .def("IsApprox", &PiecewisePose<T>::IsApprox, py::arg("other"),
+          py::arg("tol"), doc.PiecewisePose.IsApprox.doc)
+      .def("get_position_trajectory",
+          &PiecewisePose<T>::get_position_trajectory,
+          doc.PiecewisePose.get_position_trajectory.doc)
+      .def("get_orientation_trajectory",
+          &PiecewisePose<T>::get_orientation_trajectory,
+          doc.PiecewisePose.get_orientation_trajectory.doc);
 }
 
 }  // namespace pydrake

--- a/common/trajectories/piecewise_pose.cc
+++ b/common/trajectories/piecewise_pose.cc
@@ -8,14 +8,17 @@ namespace drake {
 namespace trajectories {
 
 template <typename T>
-PiecewisePose<T>::PiecewisePose(const PiecewisePolynomial<T>& pos_traj,
-                                const PiecewiseQuaternionSlerp<T>& rot_traj) {
-  DRAKE_DEMAND(pos_traj.rows() == 3);
-  DRAKE_DEMAND(pos_traj.cols() == 1);
-  position_ = pos_traj;
+PiecewisePose<T>::PiecewisePose(
+    const PiecewisePolynomial<T>& position_trajectory,
+    const PiecewiseQuaternionSlerp<T>& orientation_trajectory)
+    : PiecewiseTrajectory<T>(position_trajectory.get_segment_times()) {
+  DRAKE_DEMAND(position_trajectory.rows() == 3);
+  DRAKE_DEMAND(position_trajectory.cols() == 1);
+  DRAKE_DEMAND(this->SegmentTimesEqual(orientation_trajectory, 0));
+  position_ = position_trajectory;
   velocity_ = position_.derivative();
   acceleration_ = velocity_.derivative();
-  orientation_ = rot_traj;
+  orientation_ = orientation_trajectory;
 }
 
 template <typename T>
@@ -42,13 +45,13 @@ std::unique_ptr<Trajectory<T>> PiecewisePose<T>::Clone() const {
 }
 
 template <typename T>
-math::RigidTransform<T> PiecewisePose<T>::get_pose(const T& time) const {
+math::RigidTransform<T> PiecewisePose<T>::GetPose(const T& time) const {
   return math::RigidTransform<T>(orientation_.orientation(time),
                                  position_.value(time));
 }
 
 template <typename T>
-Vector6<T> PiecewisePose<T>::get_velocity(const T& time) const {
+Vector6<T> PiecewisePose<T>::GetVelocity(const T& time) const {
   Vector6<T> velocity;
   if (orientation_.is_time_in_range(time)) {
     velocity.template head<3>() = orientation_.angular_velocity(time);
@@ -64,7 +67,7 @@ Vector6<T> PiecewisePose<T>::get_velocity(const T& time) const {
 }
 
 template <typename T>
-Vector6<T> PiecewisePose<T>::get_acceleration(const T& time) const {
+Vector6<T> PiecewisePose<T>::GetAcceleration(const T& time) const {
   Vector6<T> acceleration;
   if (orientation_.is_time_in_range(time)) {
     acceleration.template head<3>() = orientation_.angular_acceleration(time);
@@ -80,7 +83,7 @@ Vector6<T> PiecewisePose<T>::get_acceleration(const T& time) const {
 }
 
 template <typename T>
-bool PiecewisePose<T>::is_approx(const PiecewisePose<T>& other,
+bool PiecewisePose<T>::IsApprox(const PiecewisePose<T>& other,
                                  double tol) const {
   bool ret = position_.isApprox(other.position_, tol);
   ret &= orientation_.is_approx(other.orientation_, tol);

--- a/common/trajectories/piecewise_pose.h
+++ b/common/trajectories/piecewise_pose.h
@@ -34,8 +34,8 @@ class PiecewisePose final : public PiecewiseTrajectory<T> {
    * @param pos_traj Position trajectory.
    * @param rot_traj Orientation trajectory.
    */
-  PiecewisePose(const PiecewisePolynomial<T>& pos_traj,
-                const PiecewiseQuaternionSlerp<T>& rot_traj);
+  PiecewisePose(const PiecewisePolynomial<T>& position_trajectory,
+                const PiecewiseQuaternionSlerp<T>& orientation_trajectory);
 
   /**
    * Constructs a PiecewisePose from given @p time and @p poses.
@@ -59,32 +59,55 @@ class PiecewisePose final : public PiecewiseTrajectory<T> {
 
   Eigen::Index cols() const override { return 4; }
 
+  DRAKE_DEPRECATED("2022-01-01", "get_pose() has been renamed to GetPose().")
+  math::RigidTransform<T> get_pose(const T& time) const {
+    return GetPose(time);
+  }
+
   /**
    * Returns the interpolated pose at @p time.
    */
-  math::RigidTransform<T> get_pose(const T& time) const;
+  math::RigidTransform<T> GetPose(const T& time) const;
 
   MatrixX<T> value(const T& t) const override {
-    return get_pose(t).GetAsMatrix4();
+    return GetPose(t).GetAsMatrix4();
+  }
+
+  DRAKE_DEPRECATED("2022-01-01",
+                   "get_velocity() has been renamed to GetVelocity().")
+  Vector6<T> get_velocity(const T& time) const {
+    return GetVelocity(time);
   }
 
   /**
    * Returns the interpolated velocity at @p time or zero if @p time is before
    * this trajectory's start time or after its end time.
    */
-  Vector6<T> get_velocity(const T& time) const;
+  Vector6<T> GetVelocity(const T& time) const;
+
+  DRAKE_DEPRECATED("2022-01-01",
+                   "get_acceleration() has been renamed to GetAcceleration().")
+  Vector6<T> get_acceleration(const T& time) const {
+    return GetAcceleration(time);
+  }
 
   /**
    * Returns the interpolated acceleration at @p time or zero if @p time is
    * before this trajectory's start time or after its end time.
    */
-  Vector6<T> get_acceleration(const T& time) const;
+  Vector6<T> GetAcceleration(const T& time) const;
+
+  DRAKE_DEPRECATED("2022-01-01",
+                   "is_approx() has been renamed to IsApprox().")
+  bool is_approx(const PiecewisePose<T>& other, double tol) const {
+    return IsApprox(other, tol);
+  }
 
   /**
    * Returns true if the position and orientation trajectories are both
    * within @p tol from the other's.
    */
-  bool is_approx(const PiecewisePose<T>& other, double tol) const;
+  bool IsApprox(const PiecewisePose<T>& other, double tol) const;
 
   /**
    * Returns the position trajectory.

--- a/common/trajectories/test/piecewise_pose_test.cc
+++ b/common/trajectories/test/piecewise_pose_test.cc
@@ -54,16 +54,21 @@ class PiecewisePoseTest : public ::testing::Test {
   PiecewiseQuaternionSlerp<double> orientation_;
 };
 
+TEST_F(PiecewisePoseTest, TestConstructor) {
+  EXPECT_EQ(dut_.get_number_of_segments(), 1);
+  EXPECT_EQ(dut_.get_segment_times()[1], 2);
+}
+
 // Tests linear velocity starts and ends at zero.
 TEST_F(PiecewisePoseTest, TestEndLinearVelocity) {
   double t0 = dut_.get_position_trajectory().start_time();
   double t1 = dut_.get_position_trajectory().end_time();
 
-  EXPECT_TRUE(drake::CompareMatrices(dut_.get_velocity(t0).tail<3>(),
+  EXPECT_TRUE(drake::CompareMatrices(dut_.GetVelocity(t0).tail<3>(),
                                      Vector3<double>::Zero(), 1e-12,
                                      drake::MatrixCompareType::absolute));
 
-  EXPECT_TRUE(drake::CompareMatrices(dut_.get_velocity(t1).tail<3>(),
+  EXPECT_TRUE(drake::CompareMatrices(dut_.GetVelocity(t1).tail<3>(),
                                      Vector3<double>::Zero(), 1e-12,
                                      drake::MatrixCompareType::absolute));
 }
@@ -74,9 +79,15 @@ TEST_F(PiecewisePoseTest, TestPose) {
   for (double time : test_times_) {
     math::RigidTransform<double> expected(orientation_.orientation(time),
                                           position_.value(time));
+    EXPECT_TRUE(drake::CompareMatrices(dut_.GetPose(time).GetAsMatrix4(),
+                                       expected.GetAsMatrix4(), 1e-12,
+                                       drake::MatrixCompareType::absolute));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     EXPECT_TRUE(drake::CompareMatrices(dut_.get_pose(time).GetAsMatrix4(),
                                        expected.GetAsMatrix4(), 1e-12,
                                        drake::MatrixCompareType::absolute));
+#pragma GCC diagnostic pop
     EXPECT_TRUE(drake::CompareMatrices(dut_.value(time),
                                        expected.GetAsMatrix4(), 1e-12,
                                        drake::MatrixCompareType::absolute));
@@ -94,15 +105,20 @@ TEST_F(PiecewisePoseTest, TestVelocity) {
     if (!orientation_.is_time_in_range(time)) expected.head<3>().setZero();
     if (!position_.is_time_in_range(time)) expected.tail<3>().setZero();
 
+    EXPECT_TRUE(drake::CompareMatrices(dut_.GetVelocity(time), expected, 1e-12,
+                                       drake::MatrixCompareType::absolute));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     EXPECT_TRUE(drake::CompareMatrices(dut_.get_velocity(time), expected, 1e-12,
                                        drake::MatrixCompareType::absolute));
+#pragma GCC diagnostic pop
   }
 }
 
 // Tests angular acceleration is always zero because of linear interpolation,
 // and linear acceleration matches that interpolated from
 // PiecewisePolynomial.
-TEST_F(PiecewisePoseTest, TestAccelertaion) {
+TEST_F(PiecewisePoseTest, TestAcceleration) {
   for (double time : test_times_) {
     Vector6<double> expected;
     expected.head<3>() = Vector3<double>::Zero();
@@ -110,9 +126,15 @@ TEST_F(PiecewisePoseTest, TestAccelertaion) {
 
     if (!position_.is_time_in_range(time)) expected.tail<3>().setZero();
 
+    EXPECT_TRUE(drake::CompareMatrices(dut_.GetAcceleration(time), expected,
+                                       1e-12,
+                                       drake::MatrixCompareType::absolute));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     EXPECT_TRUE(drake::CompareMatrices(dut_.get_acceleration(time), expected,
                                        1e-12,
                                        drake::MatrixCompareType::absolute));
+#pragma GCC diagnostic pop
   }
 }
 
@@ -124,31 +146,36 @@ TEST_F(PiecewisePoseTest, TestGetTrajectory) {
 
 // Tests is_approx().
 TEST_F(PiecewisePoseTest, TestIsApprox) {
-  std::vector<double> times = {1, 2, 3};
+  std::vector<double> times = {1, 2};
   std::vector<AngleAxis<double>> rot_samples(times.size());
   std::vector<MatrixX<double>> pos_samples(times.size(), MatrixX<double>(3, 1));
   pos_samples[0] << -3, 1, 0;
   pos_samples[1] << -2, -1, 5;
-  pos_samples[2] << -2, -1, 5;
 
   rot_samples[0] = AngleAxis<double>(0.3, Vector3<double>::UnitX());
-  rot_samples[1] = AngleAxis<double>(-1, Vector3<double>::UnitY());
-  rot_samples[2] = AngleAxis<double>(-0.44, Vector3<double>::UnitZ());
+  rot_samples[1] = AngleAxis<double>(-1.2, Vector3<double>::UnitY());
+
+  Vector3<double> start_vel(Vector3<double>::Zero());
+  Vector3<double> end_vel(Vector3<double>::Zero());
 
   PiecewisePolynomial<double> new_pos_traj =
       PiecewisePolynomial<double>::CubicWithContinuousSecondDerivatives(
-          times, pos_samples);
+          times, pos_samples, start_vel, end_vel);
   PiecewiseQuaternionSlerp<double> new_rot_traj(times, rot_samples);
 
-  {
-    PiecewisePose<double> diff_position(new_pos_traj, orientation_);
-    EXPECT_TRUE(!diff_position.is_approx(dut_, 1e-12));
-  }
+  PiecewisePose<double> diff_position(new_pos_traj, orientation_);
+  EXPECT_TRUE(!diff_position.IsApprox(dut_, 1e-12));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  EXPECT_TRUE(!diff_position.is_approx(dut_, 1e-12));
+#pragma GCC diagnostic pop
 
-  {
-    PiecewisePose<double> diff_orientation(position_, new_rot_traj);
-    EXPECT_TRUE(!diff_orientation.is_approx(dut_, 1e-12));
-  }
+  PiecewisePose<double> diff_orientation(position_, new_rot_traj);
+  EXPECT_TRUE(!diff_orientation.IsApprox(dut_, 1e-12));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  EXPECT_TRUE(!diff_orientation.is_approx(dut_, 1e-12));
+#pragma GCC diagnostic pop
 }
 
 // Tests getters.
@@ -172,17 +199,17 @@ TEST_F(PiecewisePoseTest, TestTrajectoryOverrides) {
                                        dut_.EvalDerivative(time, 0), 1e-12,
                                        drake::MatrixCompareType::absolute));
 
-    EXPECT_TRUE(drake::CompareMatrices(dut_.get_velocity(time),
+    EXPECT_TRUE(drake::CompareMatrices(dut_.GetVelocity(time),
                                        first_derivative->value(time), 1e-12,
                                        drake::MatrixCompareType::absolute));
-    EXPECT_TRUE(drake::CompareMatrices(dut_.get_velocity(time),
+    EXPECT_TRUE(drake::CompareMatrices(dut_.GetVelocity(time),
                                        dut_.EvalDerivative(time, 1), 1e-12,
                                        drake::MatrixCompareType::absolute));
 
-    EXPECT_TRUE(drake::CompareMatrices(dut_.get_acceleration(time),
+    EXPECT_TRUE(drake::CompareMatrices(dut_.GetAcceleration(time),
                                        second_derivative->value(time), 1e-12,
                                        drake::MatrixCompareType::absolute));
-    EXPECT_TRUE(drake::CompareMatrices(dut_.get_acceleration(time),
+    EXPECT_TRUE(drake::CompareMatrices(dut_.GetAcceleration(time),
                                        dut_.EvalDerivative(time, 2), 1e-12,
                                        drake::MatrixCompareType::absolute));
   }


### PR DESCRIPTION
- Fix: PiecewisePose was not properly initializing its base class.
- Updates the non-virtual public methods to be style-guide compliant (and deprecates the old names).
- Adds python bindings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15786)
<!-- Reviewable:end -->
