### PR TITLE
MBP: added get frames function

### DIFF
--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -3669,6 +3669,11 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
     return internal_tree().get_frame(frame_index);
   }
 
+  /// Returns a list of all frames in this plant ordered by their FrameIndex.
+  const std::vector<Frame<T>*>& get_frames() const {
+    return internal_tree().get_frames();
+  }
+
   /// @returns `true` if a frame named `name` was added to the model.
   /// @see AddFrame().
   /// @throws std::exception if the frame name occurs in multiple model

--- a/multibody/tree/multibody_tree.h
+++ b/multibody/tree/multibody_tree.h
@@ -683,6 +683,11 @@ class MultibodyTree {
     return *frames_[frame_index];
   }
 
+  // See MultibodyPant method.
+  const std::vector<Frame<T>*>& get_frames() const {
+    return frames_;
+  }
+
   // See MultibodyPlant method.
   const Mobilizer<T>& get_mobilizer(MobilizerIndex mobilizer_index) const {
     DRAKE_THROW_UNLESS(mobilizer_index < num_mobilizers());


### PR DESCRIPTION
Adds `get_frames` function to `MultibodyPlant` that returns a list of all the frames in the plant.

Part of https://github.com/RobotLocomotion/drake/issues/15026

\cc @EricCousineau-TRI 