### PR TITLE
[geometry/optimization] IrisInConfigurationSpace with Ibex

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -495,6 +495,7 @@ drake_py_unittest(
     deps = [
         ":geometry_py",
         "//bindings/pydrake/common/test_utilities",
+        "//bindings/pydrake/multibody:parsing_py",
         "//bindings/pydrake/multibody:plant_py",
     ],
 )
@@ -514,6 +515,8 @@ drake_py_unittest(
     deps = [
         ":geometry_py",
         ":math_py",
+        "//bindings/pydrake/multibody:parsing_py",
+        "//bindings/pydrake/multibody:plant_py",
         "//bindings/pydrake/solvers:mathematicalprogram_py",
     ],
 )

--- a/bindings/pydrake/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry_py_optimization.cc
@@ -205,17 +205,20 @@ void DefineGeometryOptimization(py::module m) {
       .def_readwrite("configuration_space_margin",
           &IrisOptions::configuration_space_margin,
           doc.IrisOptions.configuration_space_margin.doc)
+      .def_readwrite("enable_ibex", &IrisOptions::enable_ibex,
+          doc.IrisOptions.enable_ibex.doc)
       .def("__repr__", [](const IrisOptions& self) {
         return py::str(
             "IrisOptions("
             "require_sample_point_is_contained={}, "
             "iteration_limit={}, "
             "termination_threshold={}, "
-            "configuration_space_margin={}"
+            "configuration_space_margin={}, "
+            "enable_ibex={}"
             ")")
             .format(self.require_sample_point_is_contained,
                 self.iteration_limit, self.termination_threshold,
-                self.configuration_space_margin);
+                self.configuration_space_margin, self.enable_ibex);
       });
 
   m.def("Iris", &Iris, py::arg("obstacles"), py::arg("sample"),
@@ -223,6 +226,10 @@ void DefineGeometryOptimization(py::module m) {
 
   m.def("MakeIrisObstacles", &MakeIrisObstacles, py::arg("query_object"),
       py::arg("reference_frame") = std::nullopt, doc.MakeIrisObstacles.doc);
+
+  m.def("IrisInConfigurationSpace", &IrisInConfigurationSpace, py::arg("plant"),
+      py::arg("context"), py::arg("sample"), py::arg("options") = IrisOptions(),
+      doc.IrisInConfigurationSpace.doc);
 
   // GraphOfConvexSets
   {

--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -67,6 +67,7 @@ drake_cc_library(
         ":convex_set",
         "//geometry:scene_graph",
         "//multibody/plant",
+        "//solvers:ibex_solver",
         "//solvers:ipopt_solver",
         "//solvers:snopt_solver",
     ],

--- a/geometry/optimization/iris.h
+++ b/geometry/optimization/iris.h
@@ -42,6 +42,12 @@ struct IrisOptions {
   number of faces to approximate a curved boundary.
   */
   double configuration_space_margin{1e-2};
+
+  /** For IRIS in configuration space, we use IbexSolver to rigorously confirm
+  that regions are collision-free. This step may be computationally
+  demanding, so we allow it to be disabled for a faster algorithm for obtaining
+  regions without the rigorous guarantee. */
+  bool enable_ibex = true;
 };
 
 /** The IRIS (Iterative Region Inflation by Semidefinite programming) algorithm,
@@ -108,11 +114,9 @@ connected to a SceneGraph in a systems::Diagram.
 @param context is a context of the @p plant.
 @param sample is a vector of size plant.num_positions() representing the initial
 IRIS seed configuration.
-@param options provides additional configuration options.
-
-Note: This initial implementation **does not** yet provide a rigorous guarantee
-that the returned region is collision free.  The certification step will be
-contributed in a follow-up PR.
+@param options provides additional configuration options.  In particular,
+`options.enabled_ibex` may have a significant impact on the runtime of the
+algorithm.
 
 @ingroup geometry_optimization
 */


### PR DESCRIPTION
- Adds enable_ibex option to IrisOptions
- Refactors nonlinear programming code path to use MultibodyPlant
double instead of autodiff.
- Adds Ibex as an additional check to certify the cspace iris regions
- Adds a test for which snopt misses some counter-examples and Ibex succeeds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15789)
<!-- Reviewable:end -->
