### PR TITLE
Initialize the AutoDiffXd value field to NaN

### DIFF
--- a/math/test/autodiff_test.cc
+++ b/math/test/autodiff_test.cc
@@ -113,6 +113,14 @@ TEST_F(AutodiffTest, ToGradientMatrix) {
       << gradients;
 }
 
+// See note in class documentation for our AutoDiffXd specialization in
+// common/autodiffxd.h for why we initialize the value field even though
+// that is not part of the Eigen::AutoDiffScalar contract.
+GTEST_TEST(AdditionalAutodiffTest, ValueIsInitializedToNaN) {
+  AutoDiffXd autodiff;
+  EXPECT_TRUE(std::isnan(autodiff.value()));
+}
+
 GTEST_TEST(AdditionalAutodiffTest, DiscardGradient) {
   // Test the double case:
   Eigen::Matrix2d test = Eigen::Matrix2d::Identity();


### PR DESCRIPTION
Previously the `m_value` field in Drake's AutoDiffXd specialization was left intentionally uninitialized. However this has caused difficult to remove maybe-uninitialized warnings from gcc (see #15699 and #15722).

There should be little performance cost to initializing this field, because it is adjacent to a VectorXd field (`m_derivatives`) that requires initialization already (to a null pointer and a zero length). Here are before and after cassie_bench AutoDiff performance numbers (run on my Puget, best of 18 runs, times in μs):

 _ |  Mass Matrix | Inverse Dynamics | Forward Dynamics
-----|---------------|---------------------|--------
Uninitialized | 2532 | 3719 | 5267
NaN-initialized |  2543 | 3713 | 5270
Cost | 0.4% | -0.2% | 0.06%

These numbers are the same to within measurement noise.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15792)
<!-- Reviewable:end -->
