### PR TITLE
pydrake solvers: Add bindings for IbexSolver

### DIFF
--- a/bindings/pydrake/solvers/BUILD.bazel
+++ b/bindings/pydrake/solvers/BUILD.bazel
@@ -182,6 +182,18 @@ drake_pybind_library(
 )
 
 drake_pybind_library(
+    name = "ibex_py",
+    cc_deps = [
+        "//bindings/pydrake:documentation_pybind",
+    ],
+    cc_srcs = ["ibex_py.cc"],
+    package_info = PACKAGE_INFO,
+    py_deps = [
+        ":mathematicalprogram_py",
+    ],
+)
+
+drake_pybind_library(
     name = "ipopt_py",
     cc_deps = [
         "//bindings/pydrake:documentation_pybind",
@@ -284,6 +296,7 @@ PY_LIBRARIES_WITH_INSTALL = [
     ":csdp_py",
     ":dreal_py",
     ":gurobi_py",
+    ":ibex_py",
     ":ipopt_py",
     ":mathematicalprogram_py",
     ":mixed_integer_optimization_util_py",
@@ -361,6 +374,18 @@ drake_py_unittest(
     name = "gurobi_solver_test",
     tags = gurobi_test_tags(),
     deps = [":gurobi_py"],
+)
+
+drake_py_unittest(
+    name = "ibex_solver_test",
+    args = select({
+        "//tools:no_dreal": ["TestIbexSolver.unavailable"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        ":ibex_py",
+        "//bindings/pydrake/common/test_utilities:numpy_compare_py",
+    ],
 )
 
 drake_py_unittest(

--- a/bindings/pydrake/solvers/ibex_py.cc
+++ b/bindings/pydrake/solvers/ibex_py.cc
@@ -1,0 +1,26 @@
+#include "pybind11/eigen.h"
+#include "pybind11/pybind11.h"
+
+#include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/solvers/ibex_solver.h"
+
+namespace drake {
+namespace pydrake {
+
+PYBIND11_MODULE(ibex, m) {
+  // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
+  using namespace drake::solvers;
+  constexpr auto& doc = pydrake_doc.drake.solvers;
+
+  m.doc() = "IBEX solver bindings for MathematicalProgram";
+
+  py::module::import("pydrake.solvers.mathematicalprogram");
+
+  py::class_<IbexSolver, SolverInterface>(m, "IbexSolver", doc.IbexSolver.doc)
+      .def(py::init<>(), doc.IbexSolver.ctor.doc)
+      .def_static("id", &IbexSolver::id, doc.IbexSolver.id.doc);
+}
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -458,6 +458,7 @@ void BindSolverInterfaceAndFlags(py::module m) {
       .value("kEqualityConstrainedQP", SolverType::kEqualityConstrainedQP,
           doc.SolverType.kEqualityConstrainedQP.doc)
       .value("kGurobi", SolverType::kGurobi, doc.SolverType.kGurobi.doc)
+      .value("kIbex", SolverType::kIbex, doc.SolverType.kIbex.doc)
       .value("kIpopt", SolverType::kIpopt, doc.SolverType.kIpopt.doc)
       .value("kLinearSystem", SolverType::kLinearSystem,
           doc.SolverType.kLinearSystem.doc)

--- a/bindings/pydrake/solvers/test/ibex_solver_test.py
+++ b/bindings/pydrake/solvers/test/ibex_solver_test.py
@@ -1,0 +1,33 @@
+import unittest
+
+import numpy as np
+
+from pydrake.common.test_utilities import numpy_compare
+from pydrake.solvers import mathematicalprogram as mp
+from pydrake.solvers.ibex import IbexSolver
+
+
+class TestIbexSolver(unittest.TestCase):
+    def test_ibex_solver(self):
+        prog = mp.MathematicalProgram()
+        x = prog.NewContinuousVariables(2, "x")
+        prog.AddBoundingBoxConstraint(-1., 1., x[0])
+        prog.AddBoundingBoxConstraint(-1., 1., x[1])
+        prog.AddCost(x[0] - x[1])
+        solver = IbexSolver()
+        self.assertEqual(solver.solver_id(), IbexSolver.id())
+
+        self.assertTrue(solver.available())
+        self.assertEqual(solver.solver_id().name(), "IBEX")
+        self.assertEqual(solver.SolverName(), "IBEX")
+        self.assertEqual(solver.solver_type(), mp.SolverType.kIbex)
+
+        result = solver.Solve(prog, None, None)
+        self.assertTrue(result.is_success())
+        numpy_compare.assert_float_allclose(
+            result.GetSolution(x), [-1.0, 1.0], atol=1E-7)
+
+    def unavailable(self):
+        """Per the BUILD file, this test is only run when Ibex is disabled."""
+        solver = IbexSolver()
+        self.assertFalse(solver.available())

--- a/solvers/solver_type.h
+++ b/solvers/solver_type.h
@@ -11,6 +11,7 @@ enum class SolverType {
   kDReal,
   kEqualityConstrainedQP,
   kGurobi,
+  kIbex,
   kIpopt,
   kLinearSystem,
   kMobyLCP,

--- a/solvers/solver_type_converter.cc
+++ b/solvers/solver_type_converter.cc
@@ -6,6 +6,7 @@
 #include "drake/solvers/dreal_solver.h"
 #include "drake/solvers/equality_constrained_qp_solver.h"
 #include "drake/solvers/gurobi_solver.h"
+#include "drake/solvers/ibex_solver.h"
 #include "drake/solvers/ipopt_solver.h"
 #include "drake/solvers/linear_system_solver.h"
 #include "drake/solvers/moby_lcp_solver.h"
@@ -31,6 +32,8 @@ SolverId SolverTypeConverter::TypeToId(SolverType solver_type) {
       return EqualityConstrainedQPSolver::id();
     case SolverType::kGurobi:
       return GurobiSolver::id();
+    case SolverType::kIbex:
+      return IbexSolver::id();
     case SolverType::kIpopt:
       return IpoptSolver::id();
     case SolverType::kLinearSystem:
@@ -64,6 +67,8 @@ std::optional<SolverType> SolverTypeConverter::IdToType(SolverId solver_id) {
     return SolverType::kEqualityConstrainedQP;
   } else if (solver_id == GurobiSolver::id()) {
     return SolverType::kGurobi;
+  } else if (solver_id == IbexSolver::id()) {
+    return SolverType::kIbex;
   } else if (solver_id == IpoptSolver::id()) {
     return SolverType::kIpopt;
   } else if (solver_id == LinearSystemSolver::id()) {

--- a/solvers/test/solver_type_converter_test.cc
+++ b/solvers/test/solver_type_converter_test.cc
@@ -24,6 +24,8 @@ std::optional<SolverType> successor(std::optional<SolverType> solver_type) {
     case SolverType::kEqualityConstrainedQP:
       return SolverType::kGurobi;
     case SolverType::kGurobi:
+      return SolverType::kIbex;
+    case SolverType::kIbex:
       return SolverType::kIpopt;
     case SolverType::kIpopt:
       return SolverType::kLinearSystem;
@@ -67,7 +69,7 @@ GTEST_TEST(SolverId, RoundTrip) {
   }
 
   // This should track the number of SolverType values, if we add any.
-  EXPECT_EQ(iterations, 14);
+  EXPECT_EQ(iterations, 15);
 }
 
 }  // namespace


### PR DESCRIPTION
Adds bindings for IbexSolver as well as some other changes to make it a more fleshed out SolverInterface.  Ibex still doesn't set solver details in MathematicalProgramResult.

Toward #15573 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15793)
<!-- Reviewable:end -->
