### PR TITLE
[manipulation] In show_model only read the top-level package_path

### DIFF
--- a/manipulation/util/show_model.py
+++ b/manipulation/util/show_model.py
@@ -97,11 +97,12 @@ def parse_filename_and_parser(args_parser, args):
         if args.package_path:
             # Verify that package.xml is found in the designated path.
             package_path = os.path.abspath(args.package_path)
-            if not os.path.isfile(os.path.join(package_path, "package.xml")):
+            package_xml = os.path.join(package_path, "package.xml")
+            if not os.path.isfile(package_xml):
                 args_parser.error(f"package.xml not found at: {package_path}")
 
             # Get the package map and populate it using the package path.
-            parser.package_map().PopulateFromFolder(package_path)
+            parser.package_map().AddPackageXml(package_xml)
         return parser
 
     if args.find_resource:


### PR DESCRIPTION
When given a directory with a package.xml file to load, read only that one file; do not crawl through all of its subfolders recursively trying to find other xml files lying around to read in.

Going back through git history and code reviews, this seems to have always been the design intent, but somehow was botched from the get-go in #10156.

Crawling through all folders leads to problems when loading `runfiles/anzu/package.xml` also tries to load `runfiles/anzu/external/drake/package.xml` and its friends.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15801)
<!-- Reviewable:end -->
