### PR TITLE
[trajectories] Add PiecewisePose::MakeLinear

### DIFF
--- a/bindings/pydrake/test/trajectories_test.py
+++ b/bindings/pydrake/test/trajectories_test.py
@@ -319,6 +319,9 @@ class TestTrajectories(unittest.TestCase):
             ppose.get_orientation_trajectory(), PiecewiseQuaternionSlerp)
 
         X = RigidTransform()
+        ppose = PiecewisePose.MakeLinear(times=t, poses=[X, X, X])
+        self.assertEqual(ppose.get_number_of_segments(), 2)
+
         ppose = PiecewisePose.MakeCubicLinearWithEndLinearVelocity(
             times=t, poses=[X, X, X], start_vel=np.zeros((3, 1)),
             end_vel=np.zeros((3, 1)))

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -357,6 +357,8 @@ PYBIND11_MODULE(trajectories, m) {
                const PiecewiseQuaternionSlerp<T>&>(),
           py::arg("position_trajectory"), py::arg("orientation_trajectory"),
           doc.PiecewisePose.ctor.doc_2args)
+      .def_static("MakeLinear", &PiecewisePose<T>::MakeLinear, py::arg("times"),
+          py::arg("poses"), doc.PiecewisePose.MakeLinear.doc)
       .def_static("MakeCubicLinearWithEndLinearVelocity",
           &PiecewisePose<T>::MakeCubicLinearWithEndLinearVelocity,
           py::arg("times"), py::arg("poses"),

--- a/common/trajectories/piecewise_pose.cc
+++ b/common/trajectories/piecewise_pose.cc
@@ -22,6 +22,22 @@ PiecewisePose<T>::PiecewisePose(
 }
 
 template <typename T>
+PiecewisePose<T> PiecewisePose<T>::MakeLinear(
+    const std::vector<T>& times,
+    const std::vector<math::RigidTransform<T>>& poses) {
+  std::vector<MatrixX<T>> pos_knots(poses.size());
+  std::vector<math::RotationMatrix<T>> rot_knots(poses.size());
+  for (size_t i = 0; i < poses.size(); ++i) {
+    pos_knots[i] = poses[i].translation();
+    rot_knots[i] = poses[i].rotation();
+  }
+
+  return PiecewisePose<T>(
+      PiecewisePolynomial<T>::FirstOrderHold(times, pos_knots),
+      PiecewiseQuaternionSlerp<T>(times, rot_knots));
+}
+
+template <typename T>
 PiecewisePose<T> PiecewisePose<T>::MakeCubicLinearWithEndLinearVelocity(
     const std::vector<T>& times,
     const std::vector<math::RigidTransform<T>>& poses,

--- a/common/trajectories/piecewise_pose.h
+++ b/common/trajectories/piecewise_pose.h
@@ -38,7 +38,19 @@ class PiecewisePose final : public PiecewiseTrajectory<T> {
                 const PiecewiseQuaternionSlerp<T>& orientation_trajectory);
 
   /**
-   * Constructs a PiecewisePose from given @p time and @p poses.
+   * Constructs a PiecewisePose from given @p times and @p poses. The positions
+   * trajectory is constructed as a first-order hold. The orientation is
+   * constructed using the quaternion slerp.  There must be at least two
+   * elements in @p times and @p poses.
+   * @param times     Breaks used to build the splines.
+   * @param poses     Knots used to build the splines.
+   */
+  static PiecewisePose<T> MakeLinear(
+      const std::vector<T>& times,
+      const std::vector<math::RigidTransform<T>>& poses);
+
+  /**
+   * Constructs a PiecewisePose from given @p times and @p poses.
    * A cubic polynomial with given end velocities is used to construct the
    * position part. The rotational part is represented by a piecewise quaterion
    * trajectory.  There must be at least two elements in @p times and @p poses.


### PR DESCRIPTION
Helper method when the goal is to have a first-order position trajectory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15803)
<!-- Reviewable:end -->
