### PR TITLE
[common] Do not use line breaks within DRAKE_DEPRECATED

### DIFF
--- a/common/drake_deprecated.h
+++ b/common/drake_deprecated.h
@@ -27,11 +27,10 @@ three months by default, often rounded up to the next first of the month.  So
 for code announced as deprecated on 2018-01-22 the removal_date would nominally
 be set to 2018-05-01.
 
-Try to keep the date string immediately after the DRAKE_DEPRECATED macro name,
-even if the message itself must be wrapped to a new line:
+Do not use line breaks within the DRAKE_DEPRECATED macro; long lines should use
+a NOLINT marker instead:
 @code
-  DRAKE_DEPRECATED("2038-01-19",
-      "foo is being replaced with a safer, const-method named bar().")
+  DRAKE_DEPRECATED("2038-01-19", "foo is being replaced with a safer, const-method named bar().")  // NOLINT
   int foo();
 @endcode
 

--- a/common/extract_double.h
+++ b/common/extract_double.h
@@ -23,10 +23,7 @@ namespace drake {
 /// See autodiff_overloads.h to use this with Eigen's AutoDiffScalar.
 /// See symbolic_expression.h to use this with symbolic::Expression.
 template <typename T>
-DRAKE_DEPRECATED("2021-11-01",
-                 "Provide a specific overload of ExtractDoubleOrThrow for any "
-                 "type that really is sensible at compile time and should "
-                 "defer failure to runtime; this version was too generic.")
+DRAKE_DEPRECATED("2021-11-01", "Provide a specific overload of ExtractDoubleOrThrow for any type that really is sensible at compile time and should defer failure to runtime; this version was too generic.")  // NOLINT
 typename std::enable_if_t<!is_eigen_type<T>::value, double>
 ExtractDoubleOrThrow(const T&) {
   throw std::runtime_error(NiceTypeName::Get<T>() +

--- a/common/test/drake_deprecated_test.cc
+++ b/common/test/drake_deprecated_test.cc
@@ -13,8 +13,7 @@ class DRAKE_DEPRECATED("2038-01-19", "Use MyNewClass instead.") MyClass {
 class MyNewClass {
 };
 
-DRAKE_DEPRECATED("2038-01-19",
-    "Don't use this function; use NewMethod() instead.")
+DRAKE_DEPRECATED("2038-01-19", "Don't use this function; use NewMethod() instead.")  // NOLINT
 int OldMethod(int arg) { return arg; }
 
 int NewMethod(int arg) { return arg; }

--- a/common/trajectories/piecewise_pose.h
+++ b/common/trajectories/piecewise_pose.h
@@ -85,8 +85,7 @@ class PiecewisePose final : public PiecewiseTrajectory<T> {
     return GetPose(t).GetAsMatrix4();
   }
 
-  DRAKE_DEPRECATED("2022-01-01",
-                   "get_velocity() has been renamed to GetVelocity().")
+  DRAKE_DEPRECATED("2022-01-01", "get_velocity() has been renamed to GetVelocity().")  // NOLINT
   Vector6<T> get_velocity(const T& time) const {
     return GetVelocity(time);
   }
@@ -97,8 +96,7 @@ class PiecewisePose final : public PiecewiseTrajectory<T> {
    */
   Vector6<T> GetVelocity(const T& time) const;
 
-  DRAKE_DEPRECATED("2022-01-01",
-                   "get_acceleration() has been renamed to GetAcceleration().")
+  DRAKE_DEPRECATED("2022-01-01", "get_acceleration() has been renamed to GetAcceleration().")  // NOLINT
   Vector6<T> get_acceleration(const T& time) const {
     return GetAcceleration(time);
   }
@@ -109,8 +107,7 @@ class PiecewisePose final : public PiecewiseTrajectory<T> {
    */
   Vector6<T> GetAcceleration(const T& time) const;
 
-  DRAKE_DEPRECATED("2022-01-01",
-                   "is_approx() has been renamed to IsApprox().")
+  DRAKE_DEPRECATED("2022-01-01", "is_approx() has been renamed to IsApprox().")
   bool is_approx(const PiecewisePose<T>& other, double tol) const {
     return IsApprox(other, tol);
   }

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -336,9 +336,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
 
   /** Returns the output port which produces the PoseBundle for LCM
    communication to drake visualizer.  */
-  DRAKE_DEPRECATED("2021-12-01",
-                   "PoseBundle is no longer in use. Visualizers typically "
-                   "connect to SceneGraph's QueryObject port.")
+  DRAKE_DEPRECATED("2021-12-01", "PoseBundle is no longer in use. Visualizers typically connect to SceneGraph's QueryObject port.")  // NOLINT
   const systems::OutputPort<T>& get_pose_bundle_output_port() const {
     return systems::System<T>::get_output_port(bundle_port_index_);
   }
@@ -897,19 +895,13 @@ class SceneGraph final : public systems::LeafSystem<T> {
 
    @throws std::exception if the set includes ids that don't exist in the
                           scene graph.  */
-  DRAKE_DEPRECATED(
-      "2021-11-01",
-      "Please call collision_filter_manager().Apply() "
-      "instead")
+  DRAKE_DEPRECATED("2021-11-01", "Please call collision_filter_manager().Apply() instead")  // NOLINT
   void ExcludeCollisionsWithin(const GeometrySet& set);
 
   /** systems::Context-modifying variant of ExcludeCollisionsWithin(). Rather
    than modifying %SceneGraph's model, it modifies the copy of the model stored
    in the provided context.  */
-  DRAKE_DEPRECATED(
-      "2021-11-01",
-      "Please call collision_filter_manager(context).Apply() "
-      "instead")
+  DRAKE_DEPRECATED("2021-11-01", "Please call collision_filter_manager(context).Apply() instead")  // NOLINT
   void ExcludeCollisionsWithin(systems::Context<T>* context,
                                const GeometrySet& set) const;
 
@@ -925,20 +917,14 @@ class SceneGraph final : public systems::LeafSystem<T> {
 
    @throws std::exception if the groups include ids that don't exist in the
                           scene graph.  */
-  DRAKE_DEPRECATED(
-      "2021-11-01",
-      "Please call collision_filter_manager().Apply() "
-      "instead")
+  DRAKE_DEPRECATED("2021-11-01", "Please call collision_filter_manager().Apply() instead")  // NOLINT
   void ExcludeCollisionsBetween(const GeometrySet& setA,
                                 const GeometrySet& setB);
 
   /** systems::Context-modifying variant of ExcludeCollisionsBetween(). Rather
    than modifying %SceneGraph's model, it modifies the copy of the model stored
    in the provided context.  */
-  DRAKE_DEPRECATED(
-      "2021-11-01",
-      "Please call collision_filter_manager(context).Apply()"
-      " instead")
+  DRAKE_DEPRECATED("2021-11-01", "Please call collision_filter_manager(context).Apply() instead")  // NOLINT
   void ExcludeCollisionsBetween(systems::Context<T>* context,
                                 const GeometrySet& setA,
                                 const GeometrySet& setB) const;

--- a/math/autodiff.h
+++ b/math/autodiff.h
@@ -106,9 +106,7 @@ DiscardGradient(const Eigen::MatrixBase<Derived>& matrix) {
 }
 
 template <typename _Scalar, int _Dim, int _Mode, int _Options>
-DRAKE_DEPRECATED("2021-12-01",
-    "Apparently unused. File a Drake issue on GitHub"
-    " if you need this specialization.")
+DRAKE_DEPRECATED("2021-12-01", "Apparently unused. File a Drake issue on GitHub if you need this specialization.")  // NOLINT
 typename std::enable_if_t<
     !std::is_same_v<_Scalar, double>,
     Eigen::Transform<typename _Scalar::Scalar, _Dim, _Mode, _Options>>
@@ -119,9 +117,7 @@ DiscardGradient(const Eigen::Transform<_Scalar, _Dim, _Mode, _Options>&
 }
 
 template <typename _Scalar, int _Dim, int _Mode, int _Options>
-DRAKE_DEPRECATED("2021-12-01",
-    "Apparently unused. File a Drake issue on GitHub"
-    " if you need this specialization.")
+DRAKE_DEPRECATED("2021-12-01", "Apparently unused. File a Drake issue on GitHub if you need this specialization.")  // NOLINT
 typename std::enable_if_t<std::is_same_v<_Scalar, double>,
                           const Eigen::Transform<_Scalar, _Dim, _Mode,
     _Options>&>
@@ -288,8 +284,7 @@ struct ResizeDerivativesToMatchScalarImpl<Derived,
  * \param scalar scalar to match the derivative size vector against.
  */
 template <typename Derived>
-DRAKE_DEPRECATED("2021-12-01",
-    "Apparently unused. File a Drake issue on GitHub if you need this method.")
+DRAKE_DEPRECATED("2021-12-01", "Apparently unused. File a Drake issue on GitHub if you need this method.")  // NOLINT
 // NOLINTNEXTLINE(runtime/references).
 void resizeDerivativesToMatchScalar(Eigen::MatrixBase<Derived>& matrix,
                                     const typename Derived::Scalar& scalar) {

--- a/math/autodiff_gradient.h
+++ b/math/autodiff_gradient.h
@@ -212,8 +212,7 @@ initializeAutoDiffGivenGradientMatrix(
 }
 
 template <typename DerivedGradient, typename DerivedAutoDiff>
-DRAKE_DEPRECATED("2021-12-01",
-    "Apparently unused. File a Drake issue on GitHub if you need this method.")
+DRAKE_DEPRECATED("2021-12-01", "Apparently unused. File a Drake issue on GitHub if you need this method.")  // NOLINT
 void gradientMatrixToAutoDiff(
     const Eigen::MatrixBase<DerivedGradient>& gradient,
     // NOLINTNEXTLINE(runtime/references).
@@ -277,9 +276,7 @@ DiscardZeroGradient(const Eigen::MatrixBase<Derived>& matrix,
 }
 
 template <typename _Scalar, int _Dim, int _Mode, int _Options>
-DRAKE_DEPRECATED("2021-12-01",
-    "Apparently unused. File a Drake issue on GitHub"
-    " if you need this specialization.")
+DRAKE_DEPRECATED("2021-12-01", "Apparently unused. File a Drake issue on GitHub if you need this specialization.")  // NOLINT
 typename std::enable_if_t<
     !std::is_same_v<_Scalar, double>,
     Eigen::Transform<typename _Scalar::Scalar, _Dim, _Mode, _Options>>
@@ -292,9 +289,7 @@ DiscardZeroGradient(
 }
 
 template <typename _Scalar, int _Dim, int _Mode, int _Options>
-DRAKE_DEPRECATED("2021-12-01",
-    "Apparently unused. File a Drake issue on GitHub"
-    " if you need this specialization.")
+DRAKE_DEPRECATED("2021-12-01", "Apparently unused. File a Drake issue on GitHub if you need this specialization.")  // NOLINT
 typename std::enable_if_t<
     std::is_same_v<_Scalar, double>,
     const Eigen::Transform<_Scalar, _Dim, _Mode, _Options>&>

--- a/math/linear_solve.h
+++ b/math/linear_solve.h
@@ -106,8 +106,7 @@ SolveLinearSystem(const LinearSolver& linear_solver,
 }
 
 template <typename LinearSolver, typename DerivedA, typename DerivedB>
-DRAKE_DEPRECATED("2022-01-01",
-                 "Please use SolveLinearSystem() instead of LinearSolve()")
+DRAKE_DEPRECATED("2022-01-01", "Please use SolveLinearSystem() instead of LinearSolve()")  // NOLINT
 typename std::enable_if<
     internal::is_double_or_symbolic_v<typename DerivedA::Scalar> &&
         internal::is_double_or_symbolic_v<typename DerivedB::Scalar> &&
@@ -164,8 +163,7 @@ SolveLinearSystem(const LinearSolver& linear_solver,
 }
 
 template <typename LinearSolver, typename DerivedA, typename DerivedB>
-DRAKE_DEPRECATED("2022-01-01",
-                 "Please use SolveLinearSystem() instead of LinearSolve()")
+DRAKE_DEPRECATED("2022-01-01", "Please use SolveLinearSystem() instead of LinearSolve()")  // NOLINT
 typename std::enable_if<
     std::is_same_v<typename DerivedA::Scalar, double> &&
         !internal::is_double_or_symbolic_v<typename DerivedB::Scalar>,
@@ -290,8 +288,7 @@ SolveLinearSystem(const LinearSolver& linear_solver,
 }
 
 template <typename LinearSolver, typename DerivedA, typename DerivedB>
-DRAKE_DEPRECATED("2022-01-01",
-                 "Please use SolveLinearSystem() instead of LinearSolve()")
+DRAKE_DEPRECATED("2022-01-01", "Please use SolveLinearSystem() instead of LinearSolve()")  // NOLINT
 typename std::enable_if<
     !internal::is_double_or_symbolic_v<typename DerivedA::Scalar>,
     Eigen::Matrix<typename DerivedA::Scalar, DerivedA::RowsAtCompileTime,
@@ -491,8 +488,7 @@ SolveLinearSystem(const Eigen::MatrixBase<DerivedA>& A,
 
 template <template <typename, int...> typename LinearSolverType,
           typename DerivedA, typename DerivedB>
-DRAKE_DEPRECATED("2022-01-01",
-                 "Please use SolveLinearSystem() instead of LinearSolve()")
+DRAKE_DEPRECATED("2022-01-01", "Please use SolveLinearSystem() instead of LinearSolve()")  // NOLINT
 typename std::enable_if<
     internal::is_double_or_symbolic_v<typename DerivedA::Scalar> &&
         internal::is_double_or_symbolic_v<typename DerivedB::Scalar> &&
@@ -523,8 +519,7 @@ SolveLinearSystem(const Eigen::MatrixBase<DerivedA>& A,
 
 template <template <typename, int...> typename LinearSolverType,
           typename DerivedA, typename DerivedB>
-DRAKE_DEPRECATED("2022-01-01",
-                 "Please use SolveLinearSystem() instead of LinearSolve()")
+DRAKE_DEPRECATED("2022-01-01", "Please use SolveLinearSystem() instead of LinearSolve()")  // NOLINT
 typename std::enable_if<
     std::is_same_v<typename DerivedA::Scalar, double> &&
         !internal::is_double_or_symbolic_v<typename DerivedB::Scalar>,
@@ -553,8 +548,7 @@ SolveLinearSystem(const Eigen::MatrixBase<DerivedA>& A,
 
 template <template <typename, int...> typename LinearSolverType,
           typename DerivedA, typename DerivedB>
-DRAKE_DEPRECATED("2022-01-01",
-                 "Please use SolveLinearSystem() instead of LinearSolve()")
+DRAKE_DEPRECATED("2022-01-01", "Please use SolveLinearSystem() instead of LinearSolve()")  // NOLINT
 typename std::enable_if<
     !internal::is_double_or_symbolic_v<typename DerivedA::Scalar>,
     Eigen::Matrix<typename DerivedA::Scalar, DerivedA::RowsAtCompileTime,

--- a/solvers/mosek_solver.h
+++ b/solvers/mosek_solver.h
@@ -83,9 +83,7 @@ class MosekSolver final : public SolverBase {
    * set @p log_file to the name of that file. If the user wants to output the
    * logging to the console, then set log_file to empty string.
    */
-  DRAKE_DEPRECATED("2021-11-01",
-                   "Please set CommonSolverOption::kPrintFileName or "
-                   "CommonSolverOption::kPrintToConsole in SolverOptions")
+  DRAKE_DEPRECATED("2021-11-01", "Please set CommonSolverOption::kPrintFileName or CommonSolverOption::kPrintToConsole in SolverOptions")  // NOLINT
   void set_stream_logging(bool flag, const std::string& log_file) {
     stream_logging_ = flag;
     log_file_ = log_file;

--- a/systems/framework/cache_entry.h
+++ b/systems/framework/cache_entry.h
@@ -48,15 +48,13 @@ class CacheEntry {
   a value of a particular cache entry. The result is always returned as an
   AbstractValue but must contain the correct concrete type. */
   using AllocCallback
-      DRAKE_DEPRECATED("2021-10-01",
-          "Use ValueProducer::AllocateCallback instead.")
+      DRAKE_DEPRECATED("2021-10-01", "Use ValueProducer::AllocateCallback instead.")  // NOLINT
       = ValueProducer::AllocateCallback;
 
   /** Signature of a function suitable for calculating a value of a particular
   cache entry, given a place to put the value. */
   using CalcCallback
-      DRAKE_DEPRECATED("2021-10-01",
-          "Use ValueProducer::CalcCallback instead.")
+      DRAKE_DEPRECATED("2021-10-01", "Use ValueProducer::CalcCallback instead.")
       = ValueProducer::CalcCallback;
 
   // All the nontrivial parameters here are moved to the CacheEntry which is

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -1521,12 +1521,7 @@ class LeafSystem : public System<T> {
   // Declares an output port by specifying an allocator function pointer that
   // returns by-value, and a calc function pointer.
   template <class MySystem, typename OutputType>
-  DRAKE_DEPRECATED("2021-11-01",
-      "This overload for DeclareAbstractOutputPort is rarely the best choice;"
-      " it is unusual for a boutique allocation to return an abstract type by"
-      " value rather than provide a model_value. If the default constructor"
-      " or a model value cannot be used, use the overload that accepts an"
-      " AllocCallback alloc_function instead.")
+  DRAKE_DEPRECATED("2021-11-01", "This overload for DeclareAbstractOutputPort is rarely the best choice; it is unusual for a boutique allocation to return an abstract type by value rather than provide a model_value. If the default constructor or a model value cannot be used, use the overload that accepts an AllocCallback alloc_function instead.")  // NOLINT
   LeafOutputPort<T>& DeclareAbstractOutputPort(
       std::variant<std::string, UseDefaultName> name,
       OutputType (MySystem::*make)() const,

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -381,14 +381,7 @@ class SystemBase : public internal::SystemMessageInterface {
   // This will be demoted to `protected` access on or after 2021-10-01, and then
   // removed entirely on 2021-11-01.
   template <class MySystem, class MyContext, typename ValueType>
-  DRAKE_DEPRECATED("2021-11-01",
-      "This overload for DeclareCacheEntry is rarely the best choice; it is"
-      " unusual for allocation to actually require a boutique callback rather"
-      " than just a Clone of a model_value. We found that most uses of this"
-      " overload hindered readability, because other overloads would often do"
-      " the job more directly. If no existing overload works, you may wrap a"
-      " ValueProducer around your existing make method and call the primary"
-      " DeclareCacheEntry overload that takes a ValueProducer, instead.")
+  DRAKE_DEPRECATED("2021-11-01", "This overload for DeclareCacheEntry is rarely the best choice; it is unusual for allocation to actually require a boutique callback rather than just a Clone of a model_value. We found that most uses of this overload hindered readability, because other overloads would often do the job more directly. If no existing overload works, you may wrap a ValueProducer around your existing make method and call the primary DeclareCacheEntry overload that takes a ValueProducer, instead.")  // NOLINT
   CacheEntry& DeclareCacheEntry(
       std::string description,
       ValueType (MySystem::*make)() const,
@@ -422,14 +415,7 @@ class SystemBase : public internal::SystemMessageInterface {
   // This will be demoted to `protected` access on or after 2021-10-01, and then
   // removed entirely on 2021-11-01.
   template <class MySystem, class MyContext, typename ValueType>
-  DRAKE_DEPRECATED("2021-11-01",
-      "This overload for DeclareCacheEntry is dispreferred because it might"
-      " not reuse heap storage from one calculation to the next, and so is"
-      " typically less efficient than the other overloads. A better option"
-      " is to change the ValueType returned by-value to be an output pointer"
-      " instead, and return void. If that is not possible, you may wrap a"
-      " ValueProducer around your existing method and call the primary"
-      " DeclareCacheEntry overload that takes a ValueProducer, instead.")
+  DRAKE_DEPRECATED("2021-11-01", "This overload for DeclareCacheEntry is dispreferred because it might not reuse heap storage from one calculation to the next, and so is typically less efficient than the other overloads. A better option is to change the ValueType returned by-value to be an output pointer instead, and return void. If that is not possible, you may wrap a ValueProducer around your existing method and call the primary DeclareCacheEntry overload that takes a ValueProducer, instead.")  // NOLINT
   CacheEntry& DeclareCacheEntry(
       std::string description, const ValueType& model_value,
       ValueType (MySystem::*calc)(const MyContext&) const,
@@ -471,14 +457,7 @@ class SystemBase : public internal::SystemMessageInterface {
   // This will be demoted to `protected` access on or after 2021-10-01, and then
   // removed entirely on 2021-11-01.
   template <class MySystem, class MyContext, typename ValueType>
-  DRAKE_DEPRECATED("2021-11-01",
-      "This overload for DeclareCacheEntry is dispreferred because it might"
-      " not reuse heap storage from one calculation to the next, and so is"
-      " typically less efficient than the other overloads. A better option"
-      " is to change the ValueType returned by-value to be an output pointer"
-      " instead, and return void. If that is not possible, you may wrap a"
-      " ValueProducer around your existing method and call the primary"
-      " DeclareCacheEntry overload that takes a ValueProducer, instead.")
+  DRAKE_DEPRECATED("2021-11-01", "This overload for DeclareCacheEntry is dispreferred because it might not reuse heap storage from one calculation to the next, and so is typically less efficient than the other overloads. A better option is to change the ValueType returned by-value to be an output pointer instead, and return void. If that is not possible, you may wrap a ValueProducer around your existing method and call the primary DeclareCacheEntry overload that takes a ValueProducer, instead.")  // NOLINT
   CacheEntry& DeclareCacheEntry(
       std::string description,
       ValueType (MySystem::*calc)(const MyContext&) const,

--- a/systems/framework/system_scalar_converter.h
+++ b/systems/framework/system_scalar_converter.h
@@ -91,8 +91,7 @@ class SystemScalarConverter {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   template <template <typename> class S>
-  DRAKE_DEPRECATED("2021-11-01",
-      "Use MakeWithoutSubtypeChecking instead of kDisabled.")
+  DRAKE_DEPRECATED("2021-11-01", "Use MakeWithoutSubtypeChecking instead of kDisabled.")  // NOLINT
   SystemScalarConverter(SystemTypeTag<S>, GuaranteedSubtypePreservation sub) {
     if (sub == GuaranteedSubtypePreservation::kEnabled) {
       AddConstructors<true, S>();
@@ -119,21 +118,18 @@ class SystemScalarConverter {
 
   template <typename T, typename U>
   using ConverterFunction
-      DRAKE_DEPRECATED("2021-10-01",
-      "Only scalar-converting copy constructors are supported.")
+      DRAKE_DEPRECATED("2021-10-01", "Only scalar-converting copy constructors are supported.")  // NOLINT
       = std::function<std::unique_ptr<System<T>>(const System<U>&)>;
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   template <typename T, typename U>
-  DRAKE_DEPRECATED("2021-10-01",
-      "Only scalar-converting copy constructors are supported.")
+  DRAKE_DEPRECATED("2021-10-01", "Only scalar-converting copy constructors are supported.")  // NOLINT
   void Add(const ConverterFunction<T, U>&);
 #pragma GCC diagnostic pop
 
   template <template <typename> class S, typename T, typename U>
-  DRAKE_DEPRECATED("2021-10-01",
-      "User-defined scalar types cannot be added.")
+  DRAKE_DEPRECATED("2021-10-01", "User-defined scalar types cannot be added.")
   void AddIfSupported() {
     MaybeAddConstructor<true, S, T, U>();
   }

--- a/systems/lcm/connect_lcm_scope.h
+++ b/systems/lcm/connect_lcm_scope.h
@@ -9,9 +9,7 @@ namespace drake {
 namespace systems {
 namespace lcm {
 
-DRAKE_DEPRECATED("2021-11-01",
-    "Prefer to use LcmScopeSystem::AddToBuilder instead of this function;"
-    " the LcmScopeSystem provides more detailed timestamps.")
+DRAKE_DEPRECATED("2021-11-01", "Prefer to use LcmScopeSystem::AddToBuilder instead of this function; the LcmScopeSystem provides more detailed timestamps.")  // NOLINT
 LcmPublisherSystem* ConnectLcmScope(const OutputPort<double>& src,
                                     const std::string& channel,
                                     systems::DiagramBuilder<double>* builder,

--- a/systems/sensors/rgbd_sensor.h
+++ b/systems/sensors/rgbd_sensor.h
@@ -174,9 +174,7 @@ class RgbdSensor final : public LeafSystem<double> {
 
   /** Returns the abstract-valued output port that contains a
    rendering::PoseVector for `X_WB`. */
-  DRAKE_DEPRECATED("2021-12-01",
-                   "Please use the body_pose_in_world_output_port() for a "
-                   "RigidTransform-valued pose.")
+  DRAKE_DEPRECATED("2021-12-01", "Please use the body_pose_in_world_output_port() for a RigidTransform-valued pose.")  // NOLINT
   const OutputPort<double>& X_WB_output_port() const;
 
   /** Returns the abstract-valued output port (containing a RigidTransform)
@@ -299,9 +297,7 @@ class RgbdSensorDiscrete final : public systems::Diagram<double> {
   }
 
   /** @see RgbdSensor::base_pose_output_port().  */
-  DRAKE_DEPRECATED("2021-12-01",
-                   "Please use the body_pose_in_world_output_port() for a "
-                   "RigidTransform-valued pose.")
+  DRAKE_DEPRECATED("2021-12-01", "Please use the body_pose_in_world_output_port() for a RigidTransform-valued pose.")  // NOLINT
   const systems::OutputPort<double>& X_WB_output_port() const {
     return get_output_port(X_WB_output_port_);
   }

--- a/tools/workspace/pybind11/test/sample_header.h
+++ b/tools/workspace/pybind11/test/sample_header.h
@@ -260,13 +260,13 @@ enum {
 class DRAKE_DEPRECATED("2038-01-19", "Use MyNewClass instead.")
 DrakeDeprecatedClass {
  public:
-  DRAKE_DEPRECATED("2038-01-19",
-    "f() is slow; use g() instead. "
-    "Also, I like hats.")
+  // (This is a filler line to avoid disturbing line numbers.)
+  // (This is a filler line to avoid disturbing line numbers.)
+  DRAKE_DEPRECATED("2038-01-19", "f() is slow; use g() instead. Also, I like hats.")  // NOLINT
   int f(int arg);
 
-  DRAKE_DEPRECATED("2038-01-19",
-    "f() now requires an int.")
+  // (This is a filler line to avoid disturbing line numbers.)
+  DRAKE_DEPRECATED("2038-01-19", "f() now requires an int.")
   int f();
 
   /// Ideally this overview would still appear, but it does not yet.


### PR DESCRIPTION
When we break a the deprecation message onto multiple lines, the extra quotes remain intact in the generated Doxygen, which could be a bit confusing for users.

Closes #15619.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15808)
<!-- Reviewable:end -->
