### PR TITLE
Adjust deprecation dates that still cite last year (2020)

### DIFF
--- a/common/extract_double.h
+++ b/common/extract_double.h
@@ -23,7 +23,7 @@ namespace drake {
 /// See autodiff_overloads.h to use this with Eigen's AutoDiffScalar.
 /// See symbolic_expression.h to use this with symbolic::Expression.
 template <typename T>
-DRAKE_DEPRECATED("2020-08-01",
+DRAKE_DEPRECATED("2021-11-01",
                  "Provide a specific overload of ExtractDoubleOrThrow for any "
                  "type that really is sensible at compile time and should "
                  "defer failure to runtime; this version was too generic.")

--- a/geometry/geometry_properties.h
+++ b/geometry/geometry_properties.h
@@ -485,14 +485,14 @@ class GeometryProperties {
 
   // TODO(eric.cousineau): Enable this.
   // DRAKE_DEPRECATED(
-  //     "2020-10-01", "Use Rgba instead of Vector4d to define diffuse color.")
+  //     "2022-01-01", "Use Rgba instead of Vector4d to define diffuse color.")
   static Eigen::Vector4d ToVector4d(const Rgba& color) {
     return Eigen::Vector4d(color.r(), color.g(), color.b(), color.a());
   }
 
   // TODO(eric.cousineau): Enable this.
   // DRAKE_DEPRECATED(
-  //     "2020-10-01", "Use Rgba instead of Vector4d to define diffuse color.")
+  //     "2022-01-01", "Use Rgba instead of Vector4d to define diffuse color.")
   static Rgba ToRgba(const Eigen::Vector4d& value) {
     return Rgba(value(0), value(1), value(2), value(3));
   }


### PR DESCRIPTION
In the case of ExtractDouble, it was flagged on 2021-07-29 and announced in v0.33.0 release notes, so should have said 2021-11-01 from the get-go.

In the case of Rgba, the call to deprecate is still disarmed in a comment, so should be at least T+3 months from now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15809)
<!-- Reviewable:end -->
