### PR TITLE
geometry_properties: Deprecate using Vector4d as a color

### DIFF
--- a/geometry/geometry_properties.h
+++ b/geometry/geometry_properties.h
@@ -11,6 +11,7 @@
 #include <Eigen/Dense>
 
 #include "drake/common/copyable_unique_ptr.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/never_destroyed.h"
 #include "drake/common/value.h"
 #include "drake/geometry/rgba.h"
@@ -483,16 +484,14 @@ class GeometryProperties {
     return *value;
   }
 
-  // TODO(eric.cousineau): Enable this.
-  // DRAKE_DEPRECATED(
-  //     "2022-01-01", "Use Rgba instead of Vector4d to define diffuse color.")
+  DRAKE_DEPRECATED(
+      "2022-01-01", "Use Rgba instead of Vector4d to define diffuse color.")
   static Eigen::Vector4d ToVector4d(const Rgba& color) {
     return Eigen::Vector4d(color.r(), color.g(), color.b(), color.a());
   }
 
-  // TODO(eric.cousineau): Enable this.
-  // DRAKE_DEPRECATED(
-  //     "2022-01-01", "Use Rgba instead of Vector4d to define diffuse color.")
+  DRAKE_DEPRECATED(
+      "2022-01-01", "Use Rgba instead of Vector4d to define diffuse color.")
   static Rgba ToRgba(const Eigen::Vector4d& value) {
     return Rgba(value(0), value(1), value(2), value(3));
   }

--- a/geometry/test/geometry_properties_test.cc
+++ b/geometry/test/geometry_properties_test.cc
@@ -1,4 +1,10 @@
+// N.B. Because we do not have a *direct* deprecation on the call site, but
+// instead indirectly via GeometryProperties::ToVector4d, ToRgba(), we must
+// suppress deprecations for the declaration of the file itself.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include "drake/geometry/geometry_properties.h"
+#pragma GCC diagnostic pop
 
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
@@ -488,6 +494,7 @@ GTEST_TEST(GeometryProperties, RgbaAndVector4) {
   properties.AddProperty(group_name, color_name, color);
   // - Get<Rgba>.
   EXPECT_EQ(color, properties.GetProperty<Rgba>(group_name, color_name));
+
   // - Get<Vector4d>.
   EXPECT_EQ(vector, properties.GetProperty<Vector4d>(group_name, color_name));
   EXPECT_EQ(vector, properties.GetPropertyOrDefault<Vector4d>(


### PR DESCRIPTION
Follow-up to #13456 and #15809

One such way to deprecate.

Suppressing deprecations seems rather dumb in this case. Other options:
- Use `logging::Warn` to defer to warning.
- Use SFINAE to make deprecation more direct (not worth the effort, IMO)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15811)
<!-- Reviewable:end -->
