### PR TITLE
[acrobot] Remove spurious const

### DIFF
--- a/examples/acrobot/acrobot_plant.h
+++ b/examples/acrobot/acrobot_plant.h
@@ -91,8 +91,7 @@ class AcrobotPlant : public systems::LeafSystem<T> {
     return this->template GetNumericParameter<AcrobotParams>(context, 0);
   }
 
-  const AcrobotParams<T>& get_mutable_parameters(
-      systems::Context<T>* context) const {
+  AcrobotParams<T>& get_mutable_parameters(systems::Context<T>* context) const {
     return this->template GetMutableNumericParameter<AcrobotParams>(context, 0);
   }
 


### PR DESCRIPTION
There is already a pydrake unit test for this, it's just that pybind11 always discards "const" qualifiers so we never noticed.

Closes #15810.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15812)
<!-- Reviewable:end -->
