### PR TITLE
[atlas] Use a smaller time step to avoid discrete solver errors

### DIFF
--- a/examples/atlas/atlas_run_dynamics.cc
+++ b/examples/atlas/atlas_run_dynamics.cc
@@ -18,7 +18,7 @@ DEFINE_double(stiction_tolerance, 1.0E-3,
               "Allowable drift speed during stiction (m/s).");
 
 DEFINE_double(
-    mbp_discrete_update_period, 1.0E-3,
+    mbp_discrete_update_period, 5.0E-4,
     "The fixed-time step period (in seconds) of discrete updates for the "
     "multibody plant modeled as a discrete system. Strictly positive. "
     "Set to zero for a continuous plant model.");


### PR DESCRIPTION
The error happens at time ~0.5s, which is not caught by CI.  We can't run the full-length test in CI, because in Debug builds it takes well over two minutes.

Relates to #15782.

Task failed successfully:

https://user-images.githubusercontent.com/17596505/134714161-d9bdb9bc-6f4d-4c1e-a4d2-312c7c732e2c.mp4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15814)
<!-- Reviewable:end -->
