### PR TITLE
[libdrake] Add regression test for allowed header file dependencies

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -27,10 +27,12 @@ IncludeCategories:
     Priority: 35
   - Regex:    '^<clang-format-priority-45>$'
     Priority: 45
-  # C system headers.
+  # C system headers.  The header_dependency_test.py contains a copy of this
+  # list; be sure to update that test anytime this list changes.
   - Regex:    '^[<"](aio|arpa/inet|assert|complex|cpio|ctype|curses|dirent|dlfcn|errno|fcntl|fenv|float|fmtmsg|fnmatch|ftw|glob|grp|iconv|inttypes|iso646|langinfo|libgen|limits|locale|math|monetary|mqueue|ndbm|netdb|net/if|netinet/in|netinet/tcp|nl_types|poll|pthread|pwd|regex|sched|search|semaphore|setjmp|signal|spawn|stdalign|stdarg|stdatomic|stdbool|stddef|stdint|stdio|stdlib|stdnoreturn|string|strings|stropts|sys/ipc|syslog|sys/mman|sys/msg|sys/resource|sys/select|sys/sem|sys/shm|sys/socket|sys/stat|sys/statvfs|sys/time|sys/times|sys/types|sys/uio|sys/un|sys/utsname|sys/wait|tar|term|termios|tgmath|threads|time|trace|uchar|ulimit|uncntrl|unistd|utime|utmpx|wchar|wctype|wordexp)\.h[">]$'
     Priority: 20
-  # C++ system headers (as of C++17).
+  # C++ system headers (as of C++17).  The header_dependency_test.py contains a
+  # copy of this list; be sure to update that test anytime this list changes.
   - Regex:    '^[<"](algorithm|any|array|atomic|bitset|cassert|ccomplex|cctype|cerrno|cfenv|cfloat|charconv|chrono|cinttypes|ciso646|climits|clocale|cmath|codecvt|complex|condition_variable|csetjmp|csignal|cstdalign|cstdarg|cstdbool|cstddef|cstdint|cstdio|cstdlib|cstring|ctgmath|ctime|cuchar|cwchar|cwctype|deque|exception|execution|filesystem|forward_list|fstream|functional|future|initializer_list|iomanip|ios|iosfwd|iostream|istream|iterator|limits|list|locale|map|memory|memory_resource|mutex|new|numeric|optional|ostream|queue|random|ratio|regex|scoped_allocator|set|shared_mutex|sstream|stack|stdexcept|streambuf|string|string_view|strstream|system_error|thread|tuple|type_traits|typeindex|typeinfo|unordered_map|unordered_set|utility|valarray|variant|vector)[">]$'
     Priority: 30
   # Other libraries' h files (with angles).

--- a/bindings/pydrake/.clang-format
+++ b/bindings/pydrake/.clang-format
@@ -46,10 +46,12 @@ IncludeCategories:
     Priority: 35
   - Regex:    '^<clang-format-priority-45>$'
     Priority: 45
-  # C system headers.
+  # C system headers.  The header_dependency_test.py contains a copy of this
+  # list; be sure to update that test anytime this list changes.
   - Regex:    '^[<"](aio|arpa/inet|assert|complex|cpio|ctype|curses|dirent|dlfcn|errno|fcntl|fenv|float|fmtmsg|fnmatch|ftw|glob|grp|iconv|inttypes|iso646|langinfo|libgen|limits|locale|math|monetary|mqueue|ndbm|netdb|net/if|netinet/in|netinet/tcp|nl_types|poll|pthread|pwd|regex|sched|search|semaphore|setjmp|signal|spawn|stdalign|stdarg|stdatomic|stdbool|stddef|stdint|stdio|stdlib|stdnoreturn|string|strings|stropts|sys/ipc|syslog|sys/mman|sys/msg|sys/resource|sys/select|sys/sem|sys/shm|sys/socket|sys/stat|sys/statvfs|sys/time|sys/times|sys/types|sys/uio|sys/un|sys/utsname|sys/wait|tar|term|termios|tgmath|threads|time|trace|uchar|ulimit|uncntrl|unistd|utime|utmpx|wchar|wctype|wordexp)\.h[">]$'
     Priority: 20
-  # C++ system headers (as of C++17).
+  # C++ system headers (as of C++17).  The header_dependency_test.py contains a
+  # copy of this list; be sure to update that test anytime this list changes.
   - Regex:    '^[<"](algorithm|any|array|atomic|bitset|cassert|ccomplex|cctype|cerrno|cfenv|cfloat|charconv|chrono|cinttypes|ciso646|climits|clocale|cmath|codecvt|complex|condition_variable|csetjmp|csignal|cstdalign|cstdarg|cstdbool|cstddef|cstdint|cstdio|cstdlib|cstring|ctgmath|ctime|cuchar|cwchar|cwctype|deque|exception|execution|filesystem|forward_list|fstream|functional|future|initializer_list|iomanip|ios|iosfwd|iostream|istream|iterator|limits|list|locale|map|memory|memory_resource|mutex|new|numeric|optional|ostream|queue|random|ratio|regex|scoped_allocator|set|shared_mutex|sstream|stack|stdexcept|streambuf|string|string_view|strstream|system_error|thread|tuple|type_traits|typeindex|typeinfo|unordered_map|unordered_set|utility|valarray|variant|vector)[">]$'
     Priority: 30
   # Other libraries' h files (with angles).

--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -14,6 +14,10 @@ load(
     "drake_cc_test",
     "drake_transitive_installed_hdrs_filegroup",
 )
+load(
+    "@drake//tools/skylark:drake_py.bzl",
+    "drake_py_unittest",
+)
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load(":build_components.bzl", "LIBDRAKE_COMPONENTS")
 load(
@@ -260,6 +264,19 @@ drake_cc_googletest(
     tags = ["no_kcov"],  # See #10788.
     deps = [
         "//:drake_shared_library",
+    ],
+)
+
+drake_py_unittest(
+    name = "header_dependency_test",
+    args = [
+        "$(rootpaths :libdrake_headers)",
+    ],
+    data = [
+        ":libdrake_headers",
+    ],
+    tags = [
+        "lint",
     ],
 )
 

--- a/tools/install/libdrake/test/header_dependency_test.py
+++ b/tools/install/libdrake/test/header_dependency_test.py
@@ -1,0 +1,68 @@
+import re
+import sys
+import unittest
+
+
+class HeaderDependencyTest(unittest.TestCase):
+
+    def setUp(self):
+        # Matches C/C++ #include statment.
+        self._include = re.compile(r'^\s*#\s*include\s*["<](.*?)[>"].*$')
+
+        # C system headers; copied from drake/.clang-format.
+        re_c = re.compile(r'^(aio|arpa/inet|assert|complex|cpio|ctype|curses|dirent|dlfcn|errno|fcntl|fenv|float|fmtmsg|fnmatch|ftw|glob|grp|iconv|inttypes|iso646|langinfo|libgen|limits|locale|math|monetary|mqueue|ndbm|netdb|net/if|netinet/in|netinet/tcp|nl_types|poll|pthread|pwd|regex|sched|search|semaphore|setjmp|signal|spawn|stdalign|stdarg|stdatomic|stdbool|stddef|stdint|stdio|stdlib|stdnoreturn|string|strings|stropts|sys/ipc|syslog|sys/mman|sys/msg|sys/resource|sys/select|sys/sem|sys/shm|sys/socket|sys/stat|sys/statvfs|sys/time|sys/times|sys/types|sys/uio|sys/un|sys/utsname|sys/wait|tar|term|termios|tgmath|threads|time|trace|uchar|ulimit|uncntrl|unistd|utime|utmpx|wchar|wctype|wordexp)\.h$')  # noqa
+
+        # C++ system headers; copied from drake/.clang-format.
+        re_cpp = re.compile(r'^(algorithm|any|array|atomic|bitset|cassert|ccomplex|cctype|cerrno|cfenv|cfloat|charconv|chrono|cinttypes|ciso646|climits|clocale|cmath|codecvt|complex|condition_variable|csetjmp|csignal|cstdalign|cstdarg|cstdbool|cstddef|cstdint|cstdio|cstdlib|cstring|ctgmath|ctime|cuchar|cwchar|cwctype|deque|exception|execution|filesystem|forward_list|fstream|functional|future|initializer_list|iomanip|ios|iosfwd|iostream|istream|iterator|limits|list|locale|map|memory|memory_resource|mutex|new|numeric|optional|ostream|queue|random|ratio|regex|scoped_allocator|set|shared_mutex|sstream|stack|stdexcept|streambuf|string|string_view|strstream|system_error|thread|tuple|type_traits|typeindex|typeinfo|unordered_map|unordered_set|utility|valarray|variant|vector)$')  # noqa
+
+        # Drake's first-party headers.
+        re_drake = re.compile(r'^drake/.*$')
+
+        # Drake's allowed list of third-party libraries.  Do not add new
+        # entries here without consulting Drake's build system maintainers.
+        #  https://github.com/RobotLocomotion/drake/issues/7451
+        re_thirds = [
+            re.compile(r'^(Eigen|unsupported/Eigen)/.*$'),
+            re.compile(r'^(fmt|spdlog)/.*$'),
+            re.compile(r'^lcm/.*$'),
+            re.compile(r'^optitrack/.*$'),
+            re.compile(r'^yaml-cpp/yaml\.h$'),
+        ]
+
+        # The full list of matchers to measure filename validity.
+        self._valid_filenames = [re_drake, re_c, re_cpp] + re_thirds
+
+    def _is_valid_line(self, line):
+        """Returns False iff the line contains an invalid include statement."""
+
+        # Find the include statement, if any.
+        match = self._include.match(line)
+        if not match:
+            return True
+        (target,) = match.groups()
+
+        # Check for allowed patterns.
+        for matcher in self._valid_filenames:
+            if matcher.match(target):
+                return True
+
+        return False
+
+    def test_installed_drake_header_include_paths(self):
+        """Confirms that Drake's installed headers mention only an allowed set
+        of acceptable choices.
+        """
+        header_filenames = sys.argv[1:]
+        self.assertGreater(len(header_filenames), 100)
+        for filename in header_filenames:
+            with open(filename, "r", encoding="utf-8") as f:
+                lines = f.read().splitlines()
+            for i, line in enumerate(lines):
+                # If this test reports an error, you will either need to remove
+                # the include statement from the Drake header (possibly moving
+                # it to the *.cc file), or else exclude the Drake header from
+                # being installed by using installed_hdrs_exclude.
+                if not self._is_valid_line(line):
+                    self.fail("This #include statement is not allowed\n"
+                              "ERROR: {}:{}: {}".format(
+                                  filename, i+1, line))


### PR DESCRIPTION
Relates to #7451.  Needs #15817 to merge first.

This guards against #15535 regressing and re-introducing a header dependency on `libxml2` or `sdformat`.

This would have diagnosed the include path errors in `linear_solve.h` that were fixed #15790 but still crept into the v0.34.0 release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15816)
<!-- Reviewable:end -->
