### PR TITLE
Work around #15828 by turning off asan on affected test

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -471,6 +471,9 @@ drake_cc_googletest(
     data = [
         "//manipulation/models/iiwa_description:models",
     ],
+    tags = [
+        "no_asan",  # TODO(#15828) This is a workaround and should be removed.
+    ],
     deps = [
         ":meshcat_visualizer",
         "//common/test_utilities:expect_throws_message",


### PR DESCRIPTION
//geometry:meshcat_visualizer_test was failing asan+mac due to a timeout.
This PR adds no_asan to that test as a workaround.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15829)
<!-- Reviewable:end -->
