### PR TITLE
Fix Python InitializeAutoDiff() signature

### DIFF
--- a/bindings/pydrake/autodiffutils_py.cc
+++ b/bindings/pydrake/autodiffutils_py.cc
@@ -108,13 +108,21 @@ PYBIND11_MODULE(autodiffutils, m) {
 
   m.def(
       "InitializeAutoDiff",
-      [](const Eigen::MatrixXd& value, Eigen::DenseIndex num_derivatives,
-          Eigen::DenseIndex deriv_num_start) {
+      [](const Eigen::MatrixXd& value, std::optional<int> num_derivatives,
+          std::optional<int> deriv_num_start) {
         return InitializeAutoDiff(value, num_derivatives, deriv_num_start);
       },
       py::arg("value"), py::arg("num_derivatives") = std::nullopt,
       py::arg("deriv_num_start") = std::nullopt,
       doc.InitializeAutoDiff.doc_just_value);
+
+  m.def(
+      "InitializeAutoDiff",
+      [](const Eigen::MatrixXd& value, const Eigen::MatrixXd& gradient) {
+        return InitializeAutoDiff(value, gradient);
+      },
+      py::arg("value"), py::arg("gradient"),
+      doc.InitializeAutoDiff.doc_value_and_gradient);
 
   m.def(
       "ExtractValue",
@@ -129,14 +137,6 @@ PYBIND11_MODULE(autodiffutils, m) {
         return ExtractGradient(auto_diff_matrix);
       },
       py::arg("auto_diff_matrix"), doc.ExtractGradient.doc);
-
-  m.def(
-      "InitializeAutoDiff",
-      [](const Eigen::VectorXd& value, const Eigen::MatrixXd& gradient) {
-        return InitializeAutoDiff(value, gradient);
-      },
-      py::arg("value"), py::arg("gradient"),
-      doc.InitializeAutoDiff.doc_value_and_gradient);
 
   // TODO(sherm1) To be deprecated asap.
   m.def(


### PR DESCRIPTION
PR #15699 renamed both initializeAutoDiff() and initializeAutoDiffGivenGradientMatrix() to overloads of InitializeAutoDiff(). One of the new signatures was incorrect and caused an overload ambiguity in Python.

This PR:
- fixes the erroneous signature to match C++ properly
- moves the gradient signature to be adjacent to the other overload to make it easier to see what's what
- corrects the gradient signature's first argument type (was VectorXd rather than MatrixXd).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15831)
<!-- Reviewable:end -->
