### PR TITLE
Narrow Apple clang fixup by version

### DIFF
--- a/common/test/value_test.cc
+++ b/common/test/value_test.cc
@@ -429,16 +429,19 @@ class NiceAnonEnumTemplate {
 
 }  // namespace
 
-#ifdef __APPLE__
-constexpr bool kApple = true;
+// Apple clang prior to version 13 needs a fixup for inline namespaces.
+#if defined(__APPLE__) && defined(__clang__) && __clang_major__ < 13
+constexpr bool kAppleInlineNamespace = true;
 #else
-constexpr bool kApple = false;
+constexpr bool kAppleInlineNamespace = false;
 #endif
+
 #ifdef __clang__
 constexpr bool kClang = true;
 #else
 constexpr bool kClang = false;
 #endif
+
 #if __GNUC__ >= 9
 constexpr bool kGcc9 = true;
 #else
@@ -457,7 +460,7 @@ GTEST_TEST(TypeHashTest, WellKnownValues) {
   CheckHash<AnonEnum>("drake::test::{anonymous}::AnonEnum");
 
   // Templated containers without default template arguments.
-  const std::string stdcc = kApple ? "std::__1" : "std";
+  const std::string stdcc = kAppleInlineNamespace ? "std::__1" : "std";
   CheckHash<std::shared_ptr<double>>(fmt::format(
       "{std}::shared_ptr<double>",
       fmt::arg("std", stdcc)));


### PR DESCRIPTION
Relevant to: #15802

Prior versions of apple clang leaked an inline namespace token into
names; version 13 no longer needs it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15839)
<!-- Reviewable:end -->
