### PR TITLE
Work around Apple clang 13 optimizer

### DIFF
--- a/geometry/render/test/render_engine_vtk_test.cc
+++ b/geometry/render/test/render_engine_vtk_test.cc
@@ -1034,7 +1034,15 @@ TEST_F(RenderEngineVtkTest, RemoveVisual) {
 
   // Sets the expected values prior to calling PerformCenterShapeTest().
   auto set_expectations = [this](const RgbaColor& color, float depth,
-                                 RenderLabel label) {
+                                 RenderLabel label)
+// Optimizers on some platforms break code and cause test failures. Worse
+// still, there is no agreement on attribute spelling.
+#ifdef __clang__
+__attribute__((optnone))
+#else
+__attribute__((optimize("-O0")))
+#endif
+  {
     expected_color_ = color;
     expected_label_ = label;
     expected_object_depth_ = depth;


### PR DESCRIPTION
Relevant to: #15802

With -O2 optimization, the apple clang 13 optimizer damages the
unrelated variable expected_outlier_label_. Use conditional compilation
and compiler attributes to disable optimization at one location.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15840)
<!-- Reviewable:end -->
