### PR TITLE
[geometry:meshcat] fix #15828

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -471,9 +471,6 @@ drake_cc_googletest(
     data = [
         "//manipulation/models/iiwa_description:models",
     ],
-    tags = [
-        "no_asan",  # TODO(#15828) This is a workaround and should be removed.
-    ],
     deps = [
         ":meshcat_visualizer",
         "//common/test_utilities:expect_throws_message",


### PR DESCRIPTION
Resolves #15828

The regex that I was doing on the obj file contents was tragically
slow, especially on mac debug builds.  I have replaced it with a find,
then a more narrow regex.

Before this PR, running
```
bazel run --config=apple_debug //geometry:meshcat_visualizer_test
```
would execute in ~195 seconds.  After this PR, it executes in ~4 seconds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15842)
<!-- Reviewable:end -->
