### PR TITLE
Fix "liblzma" (i.e. xz) license

### DIFF
--- a/tools/workspace/liblzma/repository.bzl
+++ b/tools/workspace/liblzma/repository.bzl
@@ -7,7 +7,7 @@ load(
 
 def liblzma_repository(
         name,
-        licenses = ["restricted"],  # LGPL-2.1-only
+        licenses = ["unencumbered"],  # Public-Domain
         modname = "liblzma",
         pkg_config_paths = ["/usr/local/opt/xz/lib/pkgconfig"],
         **kwargs):


### PR DESCRIPTION
The [license](https://git.tukaani.org/?p=xz.git;a=blob;f=COPYING) of liblzma (which is part of [the xz project](https://tukaani.org/xz/)) is actually Public Domain. (The tools, which we aren't using, are [L]GPL. The build system, which we also don't use, as we expect the library to already be present, are GPL.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15844)
<!-- Reviewable:end -->
