### PR TITLE
[pydrake] Bindings of Identifier types are not necessarily unique

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -490,6 +490,13 @@ drake_py_unittest(
 )
 
 drake_py_unittest(
+    name = "sg_fid_test",
+    deps = [
+        ":geometry_py",
+    ],
+)
+
+drake_py_unittest(
     name = "geometry_render_engine_gl_test",
     deps = [
         ":geometry_py",

--- a/bindings/pydrake/test/sg_fid_test.py
+++ b/bindings/pydrake/test/sg_fid_test.py
@@ -1,0 +1,51 @@
+import pydrake.geometry as mut
+
+import unittest
+
+
+class TestFoo(unittest.TestCase):
+    def test_one(self):
+        """
+        Every acquired FrameId must be unique. If this test executes first, it
+        will fail. scene_graph's world_frame_id() will match the id of the
+        newly added geometry frame. If, however, test_two executes first, this
+        test will pass.
+
+        This is because both SceneGraph and GeometryFrame call
+        FrameId::get_new_id(), but they are somehow accessing *different*
+        FrameId classes -- they are drawing from different static sources.
+        """
+        scene_graph = mut.SceneGraph()
+        f = mut.GeometryFrame("frame")
+        f_id = mut.FrameId.get_new_id()
+        self.assertNotEqual(scene_graph.world_frame_id().get_value(),
+                            f.id().get_value())
+        self.assertNotEqual(scene_graph.world_frame_id().get_value(), f_id)
+        self.assertNotEqual(f.id().get_value(), f_id)
+
+
+    def test_two(self):
+        """
+        Same exact test as test_one, fails if executed first, passes if
+        executed second.
+        """
+        scene_graph = mut.SceneGraph()
+        f = mut.GeometryFrame("frame")
+        f_id = mut.FrameId.get_new_id()
+        self.assertNotEqual(scene_graph.world_frame_id().get_value(),
+                            f.id().get_value())
+        self.assertNotEqual(scene_graph.world_frame_id().get_value(), f_id)
+        self.assertNotEqual(f.id().get_value(), f_id)
+
+    def test_three(self):
+        """
+        This test also fails under the conditions and the reasons outlined
+        above.
+        """
+        scene_graph = mut.SceneGraph_[float]()
+        f = mut.GeometryFrame("frame")
+        f_id = mut.FrameId.get_new_id()
+        self.assertNotEqual(scene_graph.world_frame_id().get_value(),
+                            f.id().get_value())
+        self.assertNotEqual(scene_graph.world_frame_id().get_value(), f_id)
+        self.assertNotEqual(f.id().get_value(), f_id)

--- a/bindings/pydrake/test/sg_fid_test.py
+++ b/bindings/pydrake/test/sg_fid_test.py
@@ -23,7 +23,6 @@ class TestFoo(unittest.TestCase):
         self.assertNotEqual(scene_graph.world_frame_id().get_value(), f_id)
         self.assertNotEqual(f.id().get_value(), f_id)
 
-
     def test_two(self):
         """
         Same exact test as test_one, fails if executed first, passes if

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -278,6 +278,7 @@ drake_cc_library(
     deps = [
         ":essential",
         ":hash",
+        ":nice_type_name",
     ],
 )
 

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -274,6 +274,7 @@ drake_cc_library(
 
 drake_cc_library(
     name = "identifier",
+    srcs = ["identifier.cc"],
     hdrs = ["identifier.h"],
     deps = [
         ":essential",

--- a/common/identifier.cc
+++ b/common/identifier.cc
@@ -1,0 +1,25 @@
+#include "drake/common/identifier.h"
+
+#include <mutex>
+#include <typeindex>
+#include <unordered_map>
+
+#include "drake/common/never_destroyed.h"
+
+namespace drake {
+namespace internal {
+int64_t new_id_value_from_type(const std::type_info& t) {
+  std::type_index i{t};
+  static never_destroyed<std::unordered_map<std::type_index, int64_t>>
+      static_ids;
+  static never_destroyed<std::mutex> map_mutex;
+  std::lock_guard<std::mutex> lock(map_mutex.access());
+  std::unordered_map<std::type_index, int64_t>& ids = static_ids.access();
+  if (ids.count(i) == 0) {
+    ids.emplace(i, 1);
+  }
+  return ids[i]++;
+}
+
+}  // namespace internal
+}  // namespace drake

--- a/common/identifier.h
+++ b/common/identifier.h
@@ -1,17 +1,23 @@
 #pragma once
 
-#include <atomic>
 #include <cstdint>
 #include <functional>
 #include <string>
+#include <typeinfo>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/hash.h"
-#include "drake/common/never_destroyed.h"
 #include "drake/common/nice_type_name.h"
 
 namespace drake {
+namespace internal {
+
+/* This function serves as the support for all identifier types. It guarantees
+ that the static memory is well isolated within a single compilation unit. */
+int64_t new_id_value_from_type(const std::type_info& t);
+
+}
 
 /**
  A simple identifier class.
@@ -184,14 +190,7 @@ class Identifier {
    This method is guaranteed to be thread safe.
    */
   static Identifier get_new_id() {
-    // Note that id 0 is reserved for uninitialized variable which is created
-    // by the default constructor. As a result, we have an invariant that
-    // get_new_id() > 0.
-    static never_destroyed<std::atomic<int64_t>> next_index(1);
-    std::cerr << NiceTypeName::Get<Identifier>() << "::get_new_id() at "
-              << static_cast<void*>(&next_index) << "\n";
-
-    return Identifier(next_index.access()++);
+    return Identifier(internal::new_id_value_from_type(typeid(Identifier)));
   }
 
   /** Implements the @ref hash_append concept. And invalid id will successfully

--- a/common/identifier.h
+++ b/common/identifier.h
@@ -9,6 +9,7 @@
 #include "drake/common/drake_throw.h"
 #include "drake/common/hash.h"
 #include "drake/common/never_destroyed.h"
+#include "drake/common/nice_type_name.h"
 
 namespace drake {
 
@@ -187,6 +188,9 @@ class Identifier {
     // by the default constructor. As a result, we have an invariant that
     // get_new_id() > 0.
     static never_destroyed<std::atomic<int64_t>> next_index(1);
+    std::cerr << NiceTypeName::Get<Identifier>() << "::get_new_id() at "
+              << static_cast<void*>(&next_index) << "\n";
+
     return Identifier(next_index.access()++);
   }
 


### PR DESCRIPTION
This draft PR serves the purpose to reproduce an existing bug and provide some insight.

The `Identifier` type has a static method `get_new_id()` that guarantees over the lifespan of the process that every invocation of that method returns a unique identifier that cannot be returned by any other invocation. This provides a process-global, typed unique identifier. This contract is backed up by a function-local static variable (the counter of ids produced which gets incremented and returned on each invocation).

The problem observed is that the python bindings have access to multiple instances of the same identifier type. This is illustrated by using two different public APIs that should draw from a common identifier pool, but, nevertheless draw from unique pools.

This PR introduces a throwaway unit test that exactly exposes this issue. It also includes some additional decoration of the `Identifier` type to clarify the issue.

Commit 1: Adds a print out on the invocation of each `Identifier::get_new_id()` which helps identify which identifier type is being queried.
Commit 2: Adds a documented unit test (and the commit message explains how to exercise it).

Running:

    bazel test //bindings/pydrake:py/sg_fid_test

will show failure on test_one (but test_two and test_three will pass). However, if you run either of those later tests individually, they will fail with the same error:

    bazel test bindings/pydrake:py/sg_fid_test --test_arg=TestFoo.test_two

or

    bazel test bindings/pydrake:py/sg_fid_test --test_arg=TestFoo.test_three


Relates #15846.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15845)
<!-- Reviewable:end -->
