### PR TITLE
[examples] Always connect a SceneGraph for contact visualization

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -1181,14 +1181,17 @@ PYBIND11_MODULE(plant, m) {
             cls_doc.get_lcm_message_output_port.doc);
   }
 
-  m.def(
-      "ConnectContactResultsToDrakeVisualizer",
-      [](systems::DiagramBuilder<double>* builder,
-          const MultibodyPlant<double>& plant, lcm::DrakeLcmInterface* lcm,
-          std::optional<double> publish_period) {
-        return drake::multibody::ConnectContactResultsToDrakeVisualizer(
-            builder, plant, lcm, publish_period);
-      },
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  m.def("ConnectContactResultsToDrakeVisualizer",
+      WrapDeprecated(doc.ConnectContactResultsToDrakeVisualizer
+                         .doc_4args_builder_plant_lcm_publish_period,
+          [](systems::DiagramBuilder<double>* builder,
+              const MultibodyPlant<double>& plant, lcm::DrakeLcmInterface* lcm,
+              std::optional<double> publish_period) {
+            return drake::multibody::ConnectContactResultsToDrakeVisualizer(
+                builder, plant, lcm, publish_period);
+          }),
       py::arg("builder"), py::arg("plant"), py::arg("lcm") = nullptr,
       py::arg("publish_period") = std::nullopt, py_rvp::reference,
       // Keep alive, ownership: `return` keeps `builder` alive.
@@ -1199,6 +1202,7 @@ PYBIND11_MODULE(plant, m) {
       py::keep_alive<3, 1>(),
       doc.ConnectContactResultsToDrakeVisualizer
           .doc_4args_builder_plant_lcm_publish_period);
+#pragma GCC diagnostic pop
 
   m.def(
       "ConnectContactResultsToDrakeVisualizer",

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -1999,8 +1999,10 @@ class TestPlant(unittest.TestCase):
                 [{}, {"publish_period": None}, {"publish_period": 1.0/32}]):
             kwargs = collections.ChainMap(*optional_args)
             with self.subTest(num_optional_args=len(kwargs), **kwargs):
-                publisher = ConnectContactResultsToDrakeVisualizer(
-                    builder=builder, plant=plant, **kwargs)
+                is_deprecated = 0 if "scene_graph" in kwargs else 1
+                with catch_drake_warnings(expected_count=is_deprecated) as w:
+                    publisher = ConnectContactResultsToDrakeVisualizer(
+                        builder=builder, plant=plant, **kwargs)
                 self.assertIsInstance(publisher, LcmPublisherSystem)
 
     def test_collision_filter(self):

--- a/examples/atlas/atlas_run_dynamics.cc
+++ b/examples/atlas/atlas_run_dynamics.cc
@@ -41,11 +41,10 @@ int do_main() {
 
   // Build a generic multibody plant.
   systems::DiagramBuilder<double> builder;
-  auto pair = AddMultibodyPlantSceneGraph(
+  auto [plant, scene_graph] = AddMultibodyPlantSceneGraph(
       &builder,
       std::make_unique<MultibodyPlant<double>>(
           FLAGS_mbp_discrete_update_period));
-  MultibodyPlant<double>& plant = pair.plant;
 
   const std::string full_name =
       FindResourceOrThrow("drake/examples/atlas/urdf/atlas_convex_hull.urdf");
@@ -90,9 +89,9 @@ int do_main() {
   DRAKE_DEMAND(pelvis.floating_velocities_start() == plant.num_positions());
 
   // Publish contact results for visualization.
-  ConnectContactResultsToDrakeVisualizer(&builder, plant);
+  ConnectContactResultsToDrakeVisualizer(&builder, plant, scene_graph);
 
-  geometry::DrakeVisualizerd::AddToBuilder(&builder, pair.scene_graph);
+  geometry::DrakeVisualizerd::AddToBuilder(&builder, scene_graph);
   auto diagram = builder.Build();
 
   // Create a context for this system:

--- a/examples/manipulation_station/proof_of_life.cc
+++ b/examples/manipulation_station/proof_of_life.cc
@@ -70,7 +70,7 @@ int do_main(int argc, char* argv[]) {
       &builder, station->GetOutputPort("query_object"));
   multibody::ConnectContactResultsToDrakeVisualizer(
       &builder, station->get_mutable_multibody_plant(),
-      station->GetOutputPort("contact_results"));
+      station->get_scene_graph(), station->GetOutputPort("contact_results"));
 
   auto image_to_lcm_image_array =
       builder.template AddSystem<systems::sensors::ImageToLcmImageArrayT>();

--- a/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
+++ b/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
@@ -100,7 +100,7 @@ int do_main() {
       scene_graph.get_source_pose_port(plant.get_source_id().value()));
 
   // Publish contact results for visualization.
-  ConnectContactResultsToDrakeVisualizer(&builder, plant, &lcm);
+  ConnectContactResultsToDrakeVisualizer(&builder, plant, scene_graph, &lcm);
 
   auto diagram = builder.Build();
 

--- a/examples/multibody/inclined_plane_with_body/inclined_plane_with_body.cc
+++ b/examples/multibody/inclined_plane_with_body/inclined_plane_with_body.cc
@@ -63,9 +63,8 @@ using drake::multibody::MultibodyPlant;
 int do_main() {
   // Build a generic multibody plant.
   systems::DiagramBuilder<double> builder;
-  auto pair = AddMultibodyPlantSceneGraph(
+  auto [plant, scene_graph] = AddMultibodyPlantSceneGraph(
       &builder, std::make_unique<MultibodyPlant<double>>(FLAGS_time_step));
-  MultibodyPlant<double>& plant = pair.plant;
 
   // Set constants that are relevant whether body B is a sphere or block.
   const double massB = 0.1;       // Body B's mass (kg).
@@ -137,9 +136,9 @@ int do_main() {
   // Publish contact results for visualization.
   // TODO(Mitiguy) Ensure contact forces can be displayed when time_step = 0.
   if (FLAGS_time_step > 0)
-    ConnectContactResultsToDrakeVisualizer(&builder, plant);
+    ConnectContactResultsToDrakeVisualizer(&builder, plant, scene_graph);
 
-  geometry::DrakeVisualizerd::AddToBuilder(&builder, pair.scene_graph);
+  geometry::DrakeVisualizerd::AddToBuilder(&builder, scene_graph);
   auto diagram = builder.Build();
 
   // Create a context for this system:

--- a/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
+++ b/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
@@ -171,7 +171,7 @@ int do_main() {
     }
     geometry::DrakeVisualizerd::AddToBuilder(&builder, scene_graph, nullptr,
                                              params);
-    ConnectContactResultsToDrakeVisualizer(&builder, plant);
+    ConnectContactResultsToDrakeVisualizer(&builder, plant, scene_graph);
   }
   auto diagram = builder.Build();
 

--- a/examples/multibody/strandbeest/run_with_motor.cc
+++ b/examples/multibody/strandbeest/run_with_motor.cc
@@ -140,7 +140,7 @@ int do_main() {
   strandbeest.set_stiction_tolerance(FLAGS_stiction_tolerance);
 
   geometry::DrakeVisualizerd::AddToBuilder(&builder, scene_graph);
-  ConnectContactResultsToDrakeVisualizer(&builder, strandbeest);
+  ConnectContactResultsToDrakeVisualizer(&builder, strandbeest, scene_graph);
 
   // Create a DesiredVelocityMotor where the proportional term is directly
   // proportional to the mass of the model.

--- a/examples/planar_gripper/planar_gripper_simulation.cc
+++ b/examples/planar_gripper/planar_gripper_simulation.cc
@@ -351,7 +351,7 @@ int DoMain() {
 
   // Publish contact results for visualization.
   if (FLAGS_visualize_contacts) {
-    ConnectContactResultsToDrakeVisualizer(&builder, plant, lcm);
+    ConnectContactResultsToDrakeVisualizer(&builder, plant, scene_graph, lcm);
   }
 
   // Publish planar gripper status via LCM.

--- a/examples/simple_gripper/simple_gripper.cc
+++ b/examples/simple_gripper/simple_gripper.cc
@@ -251,7 +251,7 @@ int do_main() {
       scene_graph.get_source_pose_port(plant.get_source_id().value()));
 
   // Publish contact results for visualization.
-  ConnectContactResultsToDrakeVisualizer(&builder, plant, &lcm);
+  ConnectContactResultsToDrakeVisualizer(&builder, plant, scene_graph, &lcm);
 
   // Sinusoidal force input. We want the gripper to follow a trajectory of the
   // form x(t) = X0 * sin(ω⋅t). By differentiating once, we can compute the

--- a/multibody/plant/contact_results_to_lcm.h
+++ b/multibody/plant/contact_results_to_lcm.h
@@ -199,8 +199,7 @@ class ContactResultsToLcmSystem final : public systems::LeafSystem<T> {
 
   - Two overloads take a SceneGraph and two don't. Those that do will ensure
     that the geometry names communicated in the lcm messages match the names
-    used in SceneGraph. Those that don't default to the naming convention
-    documented in ContactResultsToLcmSystem.
+    used in SceneGraph. Those that don't are deprecated.
   - Two overloads take an OutputPort and two don't. This determines what is
     connected to the ContactResultsToLcmSystem input port. The overloads that
     specify an OutputPort will attempt to connect that port. Those that don't
@@ -236,6 +235,7 @@ class ContactResultsToLcmSystem final : public systems::LeafSystem<T> {
 
 /** MultibodyPlant-connecting, default-named geometry overload.
  @ingroup visualization */
+DRAKE_DEPRECATED("2022-01-01", "Provide a SceneGraph as the third argument.")
 systems::lcm::LcmPublisherSystem* ConnectContactResultsToDrakeVisualizer(
     systems::DiagramBuilder<double>* builder,
     const MultibodyPlant<double>& plant,
@@ -253,6 +253,7 @@ systems::lcm::LcmPublisherSystem* ConnectContactResultsToDrakeVisualizer(
 
 /** OutputPort-connecting, default-named geometry overload.
  @ingroup visualization */
+DRAKE_DEPRECATED("2022-01-01", "Provide a SceneGraph as the third argument.")
 systems::lcm::LcmPublisherSystem* ConnectContactResultsToDrakeVisualizer(
     systems::DiagramBuilder<double>* builder,
     const MultibodyPlant<double>& plant,

--- a/multibody/plant/test/contact_results_to_lcm_test.cc
+++ b/multibody/plant/test/contact_results_to_lcm_test.cc
@@ -920,12 +920,15 @@ class ConnectVisualizerTest : public ::testing::Test {
   static constexpr char kGeoName[] = "test_sphere";
 };
 
-TEST_F(ConnectVisualizerTest, ConnectToPlantDefaultNames) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+TEST_F(ConnectVisualizerTest, DeprecatedConnectToPlantDefaultNames) {
   ConfigureDiagram(false /* is_nested */);
   auto* publisher = ConnectContactResultsToDrakeVisualizer(&builder_, *plant_);
   ExpectValidPublisher(publisher);
   ExpectGeometryNameSemantics(true /* expect_default_names */);
 }
+#pragma GCC diagnostic push
 
 TEST_F(ConnectVisualizerTest, ConnectToPlantSceneGraphNames) {
   ConfigureDiagram(false /* is_nested */);
@@ -935,13 +938,16 @@ TEST_F(ConnectVisualizerTest, ConnectToPlantSceneGraphNames) {
   ExpectGeometryNameSemantics(false /* expect_default_names */);
 }
 
-TEST_F(ConnectVisualizerTest, ConnectToPortDefaultNames) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+TEST_F(ConnectVisualizerTest, DeprecatedConnectToPortDefaultNames) {
   ConfigureDiagram(true /* is_nested */);
   auto* publisher = ConnectContactResultsToDrakeVisualizer(
       &builder_, *plant_, *contact_results_port_);
   ExpectValidPublisher(publisher);
   ExpectGeometryNameSemantics(true /* expect_default_names */);
 }
+#pragma GCC diagnostic pop
 
 TEST_F(ConnectVisualizerTest, ConnectToPortSceneGraphNames) {
   ConfigureDiagram(true /* is_nested */);
@@ -951,13 +957,16 @@ TEST_F(ConnectVisualizerTest, ConnectToPortSceneGraphNames) {
   ExpectGeometryNameSemantics(false /* expect_default_names */);
 }
 
-TEST_F(ConnectVisualizerTest, ConnectToPlantDefaultNamesWithPeriod) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+TEST_F(ConnectVisualizerTest, DeprecatedConnectToPlantDefaultNamesWithPeriod) {
   ConfigureDiagram(false /* is_nested */);
   auto* publisher = ConnectContactResultsToDrakeVisualizer(
       &builder_, *plant_, nullptr, 0.5);
   ExpectValidPublisher(publisher, 0.5);
   ExpectGeometryNameSemantics(true /* expect_default_names */);
 }
+#pragma GCC diagnostic pop
 
 TEST_F(ConnectVisualizerTest, ConnectToPlantSceneGraphNamesWithPeriod) {
   ConfigureDiagram(false /* is_nested */);
@@ -967,13 +976,16 @@ TEST_F(ConnectVisualizerTest, ConnectToPlantSceneGraphNamesWithPeriod) {
   ExpectGeometryNameSemantics(false /* expect_default_names */);
 }
 
-TEST_F(ConnectVisualizerTest, ConnectToPortDefaultNamesWithPeriod) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+TEST_F(ConnectVisualizerTest, DeprecatedConnectToPortDefaultNamesWithPeriod) {
   ConfigureDiagram(true /* is_nested */);
   auto* publisher = ConnectContactResultsToDrakeVisualizer(
       &builder_, *plant_, *contact_results_port_, nullptr, 0.5);
   ExpectValidPublisher(publisher, 0.5);
   ExpectGeometryNameSemantics(true /* expect_default_names */);
 }
+#pragma GCC diagnostic pop
 
 TEST_F(ConnectVisualizerTest, ConnectToPortSceneGraphNamesWithPeriod) {
   ConfigureDiagram(true /* is_nested */);

--- a/multibody/plant/test/multibody_plant_hydroelastic_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_test.cc
@@ -73,7 +73,7 @@ class HydroelasticModelTests : public ::testing::Test {
 
     // Connect visualizer. Useful for when this test is used for debugging.
     drake::geometry::DrakeVisualizerd::AddToBuilder(&builder, *scene_graph_);
-    ConnectContactResultsToDrakeVisualizer(&builder, *plant_);
+    ConnectContactResultsToDrakeVisualizer(&builder, *plant_, *scene_graph_);
 
     diagram_ = builder.Build();
 

--- a/multibody/plant/test/multibody_plant_reaction_forces_test.cc
+++ b/multibody/plant/test/multibody_plant_reaction_forces_test.cc
@@ -79,7 +79,8 @@ class LadderTest : public ::testing::Test {
     // Add visualization for verification of the results when we have the
     // visualizer running.
     geometry::DrakeVisualizerd::AddToBuilder(&builder, *scene_graph_, &lcm_);
-    ConnectContactResultsToDrakeVisualizer(&builder, *plant_, &lcm_);
+    ConnectContactResultsToDrakeVisualizer(
+        &builder, *plant_, *scene_graph_, &lcm_);
 
     diagram_ = builder.Build();
   }


### PR DESCRIPTION
Otherwise, we spew console warnings about non-unique contact names.

For that same reason, document that the overload without a scene_graph is dis-preferred.

Also incorporates ancillary changes for improved uniformity in examples.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15849)
<!-- Reviewable:end -->
