### PR TITLE
[geometry] Visualize at 32 Hz or 64 Hz by default

### DIFF
--- a/bindings/pydrake/systems/meshcat_visualizer.py
+++ b/bindings/pydrake/systems/meshcat_visualizer.py
@@ -44,7 +44,9 @@ import meshcat.geometry as g  # noqa
 import meshcat.transformations as tf  # noqa
 from meshcat.animation import Animation
 
-_DEFAULT_PUBLISH_PERIOD = 1 / 30.
+# To help avoid small simulation timesteps, we use a default period that has an
+# exact representation in binary floating point; see drake#15021 for details.
+_DEFAULT_PUBLISH_PERIOD = 1 / 32.
 
 
 def AddTriad(vis, name, prefix, length=1., radius=0.04, opacity=1.):

--- a/bindings/pydrake/systems/planar_scenegraph_visualizer.py
+++ b/bindings/pydrake/systems/planar_scenegraph_visualizer.py
@@ -76,7 +76,7 @@ class PlanarSceneGraphVisualizer(PyPlotVisualizer):
 
     def __init__(self,
                  scene_graph,
-                 draw_period=1./30,
+                 draw_period=None,
                  T_VW=np.array([[1., 0., 0., 0.],
                                 [0., 0., 1., 0.],
                                 [0., 0., 0., 1.]]),
@@ -91,7 +91,7 @@ class PlanarSceneGraphVisualizer(PyPlotVisualizer):
         Args:
             scene_graph: A SceneGraph object.
             draw_period: The rate at which this class publishes to the
-                visualizer.
+                visualizer.  When None, a suitable default will be used.
             T_VW: The view projection matrix from world to view coordinates.
             xlim: View limit into the scene.
             ylim: View limit into the scene.

--- a/bindings/pydrake/systems/pyplot_visualizer.py
+++ b/bindings/pydrake/systems/pyplot_visualizer.py
@@ -26,15 +26,20 @@ class PyPlotVisualizer(LeafSystem):
     appropriate state.
     """
 
-    def __init__(self, draw_period=1./30, facecolor=[1, 1, 1],
+    def __init__(self, draw_period=None, facecolor=[1, 1, 1],
                  figsize=None, ax=None, show=None):
         LeafSystem.__init__(self)
+
+        # To help avoid small simulation timesteps, we use a default period
+        # that has an exact representation in binary floating point; see
+        # drake#15021 for details.
+        default_draw_period = 1./32
 
         self._warned_signal_logger_deprecated = False  # Remove 2021-12-01.
 
         self.set_name('pyplot_visualization')
-        self.timestep = draw_period
-        self.DeclarePeriodicPublish(draw_period, 0.0)
+        self.timestep = draw_period or default_draw_period
+        self.DeclarePeriodicPublish(self.timestep, 0.0)
 
         if ax is None:
             self.fig = plt.figure(facecolor=facecolor, figsize=figsize)

--- a/bindings/pydrake/systems/test/meshcat_visualizer_test.py
+++ b/bindings/pydrake/systems/test/meshcat_visualizer_test.py
@@ -36,6 +36,7 @@ from pydrake.multibody.parsing import Parser
 from pydrake.systems.analysis import Simulator
 from pydrake.systems.framework import DiagramBuilder
 from pydrake.systems.meshcat_visualizer import (
+    _DEFAULT_PUBLISH_PERIOD,
     ConnectMeshcatVisualizer,
     MeshcatVisualizer,
     MeshcatContactVisualizer,
@@ -354,8 +355,7 @@ class TestMeshcat(unittest.TestCase):
     def test_point_cloud_visualization(self):
         """A small point cloud"""
 
-        draw_period = 1 / 30.
-        sim_time = draw_period * 3.
+        sim_time = _DEFAULT_PUBLISH_PERIOD * 3.
 
         def se3_from_xyz(xyz):
             return Isometry3(np.eye(3), xyz)

--- a/examples/scene_graph/simple_contact_surface_vis.cc
+++ b/examples/scene_graph/simple_contact_surface_vis.cc
@@ -408,7 +408,7 @@ int do_main() {
   // Visualize contacts.
   auto& contact_to_lcm =
       *builder.AddSystem(LcmPublisherSystem::Make<lcmt_contact_results_for_viz>(
-          "CONTACT_RESULTS", &lcm, 1.0 / 60));
+          "CONTACT_RESULTS", &lcm, 1.0 / 64));
   builder.Connect(contact_results, contact_to_lcm);
 
   auto diagram = builder.Build();

--- a/geometry/drake_visualizer_params.h
+++ b/geometry/drake_visualizer_params.h
@@ -9,8 +9,10 @@ namespace geometry {
 /** The set of parameters for configuring DrakeVisualizer.  */
 struct DrakeVisualizerParams {
   /** The duration (in seconds) between published LCM messages that update the
-   poses of the scene's geometry.  */
-  double publish_period{1 / 60.0};
+   poses of the scene's geometry. (To help avoid small simulation timesteps, we
+   use a default period that has an exact representation in binary floating
+   point; see drake#15021 for details.) */
+  double publish_period{1 / 64.0};
 
   /** The role of the geometries to be sent to the visualizer.  */
   Role role{Role::kIllustration};

--- a/geometry/meshcat_visualizer_params.h
+++ b/geometry/meshcat_visualizer_params.h
@@ -11,8 +11,10 @@ namespace geometry {
 /** The set of parameters for configuring MeshcatVisualizer. */
 struct MeshcatVisualizerParams {
   /** The duration (in simulation seconds) between attempts to update poses in
-   the visualizer. */
-  double publish_period{1 / 60.0};
+   the visualizer. (To help avoid small simulation timesteps, we use a default
+   period that has an exact representation in binary floating point; see
+   drake#15021 for details.) */
+  double publish_period{1 / 64.0};
 
   /** The role of the geometries to be sent to the visualizer. */
   Role role{Role::kIllustration};

--- a/geometry/test/drake_visualizer_test.cc
+++ b/geometry/test/drake_visualizer_test.cc
@@ -304,7 +304,7 @@ class DrakeVisualizerTest : public ::testing::Test {
     }
   }
 
-  static constexpr double kPublishPeriod = 1 / 60.0;
+  static constexpr double kPublishPeriod = 1 / 64.0;
   /* The LCM channel names. We are implicitly confirming that DrakeVisualizer
    broadcasts on the right channels via the subscribers. The reception of
    expected messages on those subscribers is proof.  */
@@ -340,7 +340,7 @@ TYPED_TEST_SUITE(DrakeVisualizerTest, ScalarTypes);
 
 TYPED_TEST(DrakeVisualizerTest, PublishPeriod) {
   using T = TypeParam;
-  for (double period : {1 / 30.0, 1 / 10.0}) {
+  for (double period : {1 / 32.0, 1 / 10.0}) {
     this->ConfigureDiagram({.publish_period = period});
     Simulator<T> simulator(*(this->diagram_));
     ASSERT_EQ(simulator.get_context().get_time(), 0.0);

--- a/multibody/fixed_fem/dev/run_scripted_deformable_motion.cc
+++ b/multibody/fixed_fem/dev/run_scripted_deformable_motion.cc
@@ -138,7 +138,7 @@ int DoMain() {
                                        {0, 0.6, 0});
 
   auto& visualizer = *builder.AddSystem<DeformableVisualizer>(
-      1.0 / 30.0, dummy_softsim_system->get_names(),
+      1.0 / 32.0, dummy_softsim_system->get_names(),
       dummy_softsim_system->get_meshes());
   builder.Connect(*dummy_softsim_system, visualizer);
   auto diagram = builder.Build();

--- a/multibody/fixed_fem/dev/run_simple_gripper.cc
+++ b/multibody/fixed_fem/dev/run_simple_gripper.cc
@@ -205,7 +205,7 @@ int DoMain() {
     reference_meshes.emplace_back(geometry.mesh());
   }
   auto& visualizer = *builder.AddSystem<DeformableVisualizer>(
-      1.0 / 60.0, deformable_model_raw->names(), reference_meshes);
+      1.0 / 64.0, deformable_model_raw->names(), reference_meshes);
   builder.Connect(deformable_model_raw->get_vertex_positions_output_port(),
                   visualizer.get_input_port());
   geometry::DrakeVisualizerd::AddToBuilder(&builder, scene_graph);

--- a/multibody/fixed_fem/dev/test/deformable_box_test.cc
+++ b/multibody/fixed_fem/dev/test/deformable_box_test.cc
@@ -108,7 +108,7 @@ class DeformableRigidContactSolverTest : public ::testing::Test {
       reference_meshes.emplace_back(geometry.mesh());
     }
     auto* visualizer = builder.AddSystem<DeformableVisualizer>(
-        1.0 / 60.0, deformable_model_ptr->names(), reference_meshes);
+        1.0 / 64.0, deformable_model_ptr->names(), reference_meshes);
     builder.Connect(deformable_model_ptr->get_vertex_positions_output_port(),
                     visualizer->get_input_port());
 

--- a/multibody/plant/contact_results_to_lcm.cc
+++ b/multibody/plant/contact_results_to_lcm.cc
@@ -284,9 +284,13 @@ systems::lcm::LcmPublisherSystem* ConnectWithNameLookup(
           new ContactResultsToLcmSystem<double>(multibody_plant, name_lookup)));
   contact_to_lcm->set_name("contact_to_lcm");
 
+  // To help avoid small timesteps, use a default period that has an exact
+  // representation in binary floating point (see drake#15021).
+  const double default_publish_period = 1.0 / 64;
   auto contact_results_publisher = builder->AddSystem(
       systems::lcm::LcmPublisherSystem::Make<lcmt_contact_results_for_viz>(
-          "CONTACT_RESULTS", lcm, publish_period.value_or(1.0 / 60)));
+          "CONTACT_RESULTS", lcm, publish_period.value_or(
+              default_publish_period)));
   contact_results_publisher->set_name("contact_results_publisher");
 
   builder->Connect(contact_results_port,

--- a/multibody/plant/contact_results_to_lcm.h
+++ b/multibody/plant/contact_results_to_lcm.h
@@ -193,7 +193,7 @@ class ContactResultsToLcmSystem final : public systems::LeafSystem<T> {
    the Diagram and connects the draw message output to the publisher input,
  - connects a ContactResults<double>-valued output port to the
    ContactResultsToLcmSystem system, and
- - sets the publishing rate to 1/60 of a second (simulated time).
+ - sets the publishing rate based on publish_period.
 
  The four variants differ in the following ways:
 

--- a/multibody/plant/test/contact_results_to_lcm_test.cc
+++ b/multibody/plant/test/contact_results_to_lcm_test.cc
@@ -874,12 +874,12 @@ class ConnectVisualizerTest : public ::testing::Test {
    with the given publication period.
 
    When no publication period is given, we check that the default value from the
-   cc file made it through.  We don't specifically care that this is 60 Hz, just
+   cc file made it through.  We don't specifically care that this is 64 Hz, just
    that it's some sensible default.  If the cc file changes, we should update
    the value here as well.
   */
   void ExpectValidPublisher(systems::lcm::LcmPublisherSystem* publisher,
-                            double expected_publish_period = 1.0 / 60) {
+                            double expected_publish_period = 1.0 / 64) {
     /* Confirm that we get a non-null result. */
     ASSERT_NE(publisher, nullptr);
 


### PR DESCRIPTION
Using a period that does not have an exact representation in binary floating point (e.g., our current defaults of 1/30 or 1/60) can lead to undesirably small timesteps due to the dithering of update rates.

Relates to #15021.  That issue is about fixing this kind of problem systemically; here, we just aim the shotgun slightly off to the side of our foot, in the meanwhile.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15850)
<!-- Reviewable:end -->
