### PR TITLE
[geometry:meshcat] Adds visualization for Point Clouds

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -485,6 +485,7 @@ drake_py_unittest(
     ],
     deps = [
         ":geometry_py",
+        "//bindings/pydrake:perception_py",
         "//bindings/pydrake/common/test_utilities",
         "//bindings/pydrake/multibody:plant_py",
         "//bindings/pydrake/systems:analysis_py",

--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -1599,8 +1599,16 @@ void DoScalarIndependentDefinitions(py::module m) {
         .def("web_url", &Class::web_url, cls_doc.web_url.doc)
         .def("port", &Class::port, cls_doc.port.doc)
         .def("ws_url", &Class::ws_url, cls_doc.ws_url.doc)
-        .def("SetObject", &Class::SetObject, py::arg("path"), py::arg("shape"),
-            py::arg("rgba") = Rgba(.9, .9, .9, 1.), cls_doc.SetObject.doc)
+        .def("SetObject",
+            py::overload_cast<std::string_view, const Shape&, const Rgba&>(
+                &Class::SetObject),
+            py::arg("path"), py::arg("shape"),
+            py::arg("rgba") = Rgba(.9, .9, .9, 1.), cls_doc.SetObject.doc_shape)
+        .def("SetObject",
+            py::overload_cast<std::string_view, const perception::PointCloud&,
+                double, const Rgba&>(&Class::SetObject),
+            py::arg("path"), py::arg("cloud"), py::arg("point_size") = 0.001,
+            py::arg("rgba") = Rgba(.9, .9, .9, 1.), cls_doc.SetObject.doc_cloud)
         // TODO(russt): Bind SetCamera.
         .def("Set2dRenderMode", &Class::Set2dRenderMode,
             py::arg("X_WC") = RigidTransformd{Eigen::Vector3d{0, -1, 0}},

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -17,6 +17,7 @@ from pydrake.common.value import AbstractValue, Value
 from pydrake.lcm import DrakeLcm, Subscriber
 from pydrake.math import RigidTransform, RigidTransform_
 from pydrake.multibody.plant import CoulombFriction
+from pydrake.perception import PointCloud
 from pydrake.systems.analysis import (
     Simulator_,
 )
@@ -403,6 +404,10 @@ class TestGeometry(unittest.TestCase):
                           shape=mut.Box(1, 1, 1),
                           rgba=mut.Rgba(.5, .5, .5))
         meshcat.SetTransform(path="/test/box", X_ParentPath=RigidTransform())
+        cloud = PointCloud(4)
+        cloud.mutable_xyzs()[:] = np.zeros((3, 4))
+        meshcat.SetObject(path="/test/cloud", cloud=cloud,
+                          point_size=0.01, rgba=mut.Rgba(.5, .5, .5))
         meshcat.SetProperty(path="/Background",
                             property="visible",
                             value=True)

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -390,6 +390,7 @@ drake_cc_library(
         "//common:find_resource",
         "//common:unused",
         "//math:geometric_transform",
+        "//perception:point_cloud",
         "@common_robotics_utilities",
         "@msgpack",
         "@stduuid",

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -11,6 +11,8 @@
 #include "drake/geometry/rgba.h"
 #include "drake/geometry/shape_specification.h"
 #include "drake/math/rigid_transform.h"
+// TODO(russt): Move point_cloud.h to a more central location.
+#include "drake/perception/point_cloud.h"
 
 namespace drake {
 namespace geometry {
@@ -107,11 +109,30 @@ class Meshcat {
               See @ref meshcat_path "Meshcat paths" for the semantics.
   @param shape a Shape that specifies the geometry of the object.
   @param rgba an Rgba that specifies the (solid) color of the object.
+  @pydrake_mkdoc_identifier{shape}
   */
   void SetObject(std::string_view path, const Shape& shape,
                  const Rgba& rgba = Rgba(.9, .9, .9, 1.));
 
   // TODO(russt): SetObject with texture map.
+
+  /** Sets the "object" at a given `path` in the scene tree to be
+  `point_cloud`.  Note that `path`="/foo" will always set an object in the tree
+  at "/foo/<object>".  See @ref meshcat_path.  Any objects previously set at
+  this `path` will be replaced.
+  @param path a "/"-delimited string indicating the path in the scene tree. See
+              @ref meshcat_path "Meshcat paths" for the semantics.
+  @param point_cloud a perception::PointCloud; if `point_cloud.has_rgbs()` is
+                     true, then meshcat will render the colored points.
+  @param point_size is the size of each rendered point.
+  @param rgba is the default color, which is only used if
+              `point_cloud.has_rgbs() == false`.
+  @pydrake_mkdoc_identifier{cloud}
+  */
+  void SetObject(std::string_view path,
+                 const perception::PointCloud& point_cloud,
+                 double point_size = 0.001,
+                 const Rgba& rgba = Rgba(.9, .9, .9, 1.));
 
   // TODO(russt): Provide a more general SetObject(std::string_view path,
   // msgpack::object object) that would allow users to pass through anything

--- a/geometry/meshcat_types.h
+++ b/geometry/meshcat_types.h
@@ -10,6 +10,7 @@
 
 #include <msgpack.hpp>
 
+#include "drake/common/nice_type_name.h"
 #include "drake/geometry/meshcat.h"
 #include "drake/geometry/rgba.h"
 #include "drake/math/rigid_transform.h"
@@ -17,6 +18,12 @@
 namespace drake {
 namespace geometry {
 namespace internal {
+
+// This macro not only makes the code shorter, but it also helps avoid spelling
+// mistakes by ensuring that the string name matches the variable name.
+#define PACK_MAP_VAR(packer, var) \
+  packer.pack(#var);           \
+  packer.pack(var);
 
 // The fields in these structures are chosen to match the serialized names in
 // the meshcat messages. This simplifies msgpack operations and provides parity
@@ -30,119 +37,231 @@ namespace internal {
 // compatible with msgpack, which wants to be able to unpack into the same
 // structure.
 
-// TODO(russt): These are taken verbatim from meshcat-python.  We should
-// expose them to the user, but not until we can properly document them.
-// Many are documented here: https://threejs.org/docs/#api/en/materials/Material
+// From https://github.com/mrdoob/three.js/blob/dev/src/constants.js
+enum ThreeSide { kFrontSide = 0, kBackSide = 1, kDoubleSide = 2 };
+
+// TODO(russt): We should expose these options to the user.
+// The documentation of the fields is adapted from
+// https://threejs.org/docs/#api/en/materials/Material and its derived classes.
 struct MaterialData {
-  std::string uuid{};
-  std::string type{};
+  // UUID of this material instance.
+  std::string uuid;
+
+  // The three.js material type (e.g. PointsMaterial, LineBasicMaterial,
+  // MeshBasicMaterial, MeshPhongMaterial...)
+  std::string type;
+
+  // Default color is a light gray.
   int color{(229 << 16) + (229 << 8) + 229};
-  // TODO(russt): Make many of these std::optional.
-  double reflectivity{0.5};
-  int side{2};
-  bool transparent{false};
-  double opacity{1.0};
-  double linewidth{1.0};
-  bool wireframe{false};
-  double wireframeLineWidth{1.0};
+
+  // For LineBasicMaterial, controls line thickness. The three.js default is 1.
+  // Due to limitations of the OpenGL Core Profile with the WebGL renderer on
+  // most platforms linewidth will always be 1 regardless of the set value.
+  std::optional<double> linewidth;
+
+  // Double in the range of 0.0 - 1.0 indicating how transparent the material
+  // is. A value of 0.0 indicates fully transparent, 1.0 is fully opaque. If the
+  // material's transparent property is not set to true, the material will
+  // remain fully opaque and this value will only affect its color. The three.js
+  // default is 1.0.
+  std::optional<double> opacity;
+
+  // For MeshBasicMaterial, specifies how much the environment map affects the
+  // surface. The three.js default value is 1 and the valid range is between 0
+  // (no reflections) and 1 (full reflections).
+  std::optional<double> reflectivity;
+
+  // Defines which side of faces will be rendered - front, back or both. Default
+  // is kFrontSide. Other options are kBackSide and kDoubleSide.
+  std::optional<ThreeSide> side;
+
+  // For PointsMaterial, sets the size of the points. The three.js default
+  // is 1.0. Will be capped if it exceeds the hardware dependent parameter
+  // gl.ALIASED_POINT_SIZE_RANGE.
+  std::optional<double> size;
+
+  // Defines whether this material is transparent. This has an effect on
+  // rendering as transparent objects need special treatment and are rendered
+  // after non-transparent objects.  When set to true, the extent to which the
+  // material is transparent is controlled by setting its opacity
+  // property.  The three.js default is false.
+  std::optional<bool> transparent;
+
+  // Defines whether vertex coloring is used.  @default false.
   bool vertexColors{false};
 
-  MSGPACK_DEFINE_MAP(uuid, type, color, reflectivity, side, transparent,
-                     opacity, linewidth, wireframe, wireframeLineWidth,
-                     vertexColors);
-};
+  // For MeshBasicMaterial, render geometry as wireframe. The three.js default
+  // is false (i.e. render as flat polygons).
+  std::optional<bool> wireframe;
 
-// Note: This contains the fields required for all geometry types.  Getting
-// msgpack to work with runtime derived types proved to be very complicated.
-struct GeometryData {
-  std::string uuid;
-  std::string type;
-  std::optional<double> width;
-  std::optional<double> height;
-  std::optional<double> depth;
-  std::optional<double> radius;
-  std::optional<double> widthSegments;
-  std::optional<double> heightSegments;
-  std::optional<double> radiusTop;
-  std::optional<double> radiusBottom;
-  std::optional<double> radialSegments;
-  std::string format;
-  std::string data;
+  // For MeshBasicMateiral, controls wireframe thickness. The three.js default
+  // is 1.
+  std::optional<double> wireframeLineWidth;
 
-  // MSGPACK_DEFINE_MAP sends e.g. 'heightSegments':nil when the optional values
-  // are not set.  This defeats the defaults in three.js.  We have to implement
-  // a custom packer in order to avoid it.
-  // TODO(russt): Could make this fancier with e.g. the template parameter packs
-  // in msgpack-c/include/msgpack/v1/adaptor/detail/cpp11_define_map.hpp
   template <typename Packer>
   // NOLINTNEXTLINE(runtime/references) cpplint disapproves of msgpack choices.
   void msgpack_pack(Packer& o) const {
-    int size = 2;  // uuid and type are always sent.
-    if (width) ++size;
-    if (height) ++size;
-    if (depth) ++size;
-    if (radius) ++size;
-    if (widthSegments) ++size;
-    if (heightSegments) ++size;
-    if (radiusTop) ++size;
-    if (radiusBottom) ++size;
-    if (radialSegments) ++size;
-    if (!format.empty()) ++size;
-    if (!data.empty()) ++size;
-    o.pack_map(size);
-    o.pack("uuid");
-    o.pack(uuid);
-    o.pack("type");
-    o.pack(type);
-    if (width) {
-      o.pack("width");
-      o.pack(*width);
+    int n = 4;
+    if (linewidth) ++n;
+    if (opacity) ++n;
+    if (reflectivity) ++n;
+    if (side) ++n;
+    if (size) ++n;
+    if (transparent) ++n;
+    if (wireframe) ++n;
+    if (wireframeLineWidth) ++n;
+    o.pack_map(n);
+    PACK_MAP_VAR(o, uuid);
+    PACK_MAP_VAR(o, type);
+    PACK_MAP_VAR(o, color);
+    PACK_MAP_VAR(o, vertexColors);
+    if (linewidth) {
+      o.pack("linewidth");
+      o.pack(*linewidth);
     }
-    if (height) {
-      o.pack("height");
-      o.pack(*height);
+    if (opacity) {
+      o.pack("opacity");
+      o.pack(*opacity);
     }
-    if (depth) {
-      o.pack("depth");
-      o.pack(*depth);
+    if (reflectivity) {
+      o.pack("reflectivity");
+      o.pack(*reflectivity);
     }
-    if (radius) {
-      o.pack("radius");
-      o.pack(*radius);
+    if (side) {
+      o.pack("side");
+      o.pack(*side);
     }
-    if (widthSegments) {
-      o.pack("widthSegments");
-      o.pack(*widthSegments);
+    if (size) {
+      o.pack("size");
+      o.pack(*size);
     }
-    if (heightSegments) {
-      o.pack("heightSegments");
-      o.pack(*heightSegments);
+    if (transparent) {
+      o.pack("transparent");
+      o.pack(*transparent);
     }
-    if (radiusTop) {
-      o.pack("radiusTop");
-      o.pack(*radiusTop);
+    if (wireframe) {
+      o.pack("wireframe");
+      o.pack(*wireframe);
     }
-    if (radiusBottom) {
-      o.pack("radiusBottom");
-      o.pack(*radiusBottom);
-    }
-    if (radialSegments) {
-      o.pack("radialSegments");
-      o.pack(*radialSegments);
-    }
-    if (!format.empty()) {
-      o.pack("format");
-      o.pack(format);
-    }
-    if (!data.empty()) {
-      o.pack("data");
-      o.pack(data);
+    if (wireframeLineWidth) {
+      o.pack("wireframeLineWidth");
+      o.pack(*wireframeLineWidth);
     }
   }
+
   // This method must be defined, but the implementation is not needed in the
   // current workflows.
   void msgpack_unpack(msgpack::object const&) {
-    throw std::runtime_error("unpack is not implemented for GeometryData.");
+    throw std::runtime_error(
+        "unpack is not implemented for MaterialData.");
+  }
+};
+
+struct GeometryData {
+  virtual ~GeometryData() = default;
+  std::string uuid;
+
+  // NOLINTNEXTLINE(runtime/references) cpplint disapproves of msgpack choices.
+  virtual void msgpack_pack(msgpack::packer<std::stringstream>& o) const = 0;
+
+  // This method must be defined, but the implementation is not needed in the
+  // current workflows.
+  void msgpack_unpack(msgpack::object const&) {
+    throw std::runtime_error(
+        "unpack is not implemented for BufferGeometryData.");
+  }
+};
+
+struct SphereGeometryData : public GeometryData {
+  double radius{};
+  double widthSegments{20};
+  double heightSegments{20};
+
+  // NOLINTNEXTLINE(runtime/references) cpplint disapproves of msgpack choices.
+  void msgpack_pack(msgpack::packer<std::stringstream>& o) const override {
+    o.pack_map(5);
+    o.pack("type");
+    o.pack("SphereGeometry");
+    PACK_MAP_VAR(o, uuid);
+    PACK_MAP_VAR(o, radius);
+    PACK_MAP_VAR(o, widthSegments);
+    PACK_MAP_VAR(o, heightSegments);
+  }
+};
+
+struct CylinderGeometryData : public GeometryData {
+  double radiusBottom{};
+  double radiusTop{};
+  double height{};
+  double radialSegments{50};
+
+  // NOLINTNEXTLINE(runtime/references) cpplint disapproves of msgpack choices.
+  void msgpack_pack(msgpack::packer<std::stringstream>& o) const override {
+    o.pack_map(6);
+    o.pack("type");
+    o.pack("CylinderGeometry");
+    PACK_MAP_VAR(o, uuid);
+    PACK_MAP_VAR(o, radiusBottom);
+    PACK_MAP_VAR(o, radiusTop);
+    PACK_MAP_VAR(o, height);
+    PACK_MAP_VAR(o, radialSegments);
+  }
+};
+
+struct BoxGeometryData : public GeometryData {
+  double width{};
+  double height{};
+  double depth{};
+
+  // NOLINTNEXTLINE(runtime/references) cpplint disapproves of msgpack choices.
+  void msgpack_pack(msgpack::packer<std::stringstream>& o) const override {
+    o.pack_map(5);
+    o.pack("type");
+    o.pack("BoxGeometry");
+    PACK_MAP_VAR(o, uuid);
+    PACK_MAP_VAR(o, width);
+    PACK_MAP_VAR(o, height);
+    PACK_MAP_VAR(o, depth);
+  }
+};
+
+struct MeshFileGeometryData : public GeometryData {
+  std::string format;
+  std::string data;
+
+  // NOLINTNEXTLINE(runtime/references) cpplint disapproves of msgpack choices.
+  void msgpack_pack(msgpack::packer<std::stringstream>& o) const override {
+    o.pack_map(4);
+    o.pack("type");
+    o.pack("_meshfile_geometry");
+    PACK_MAP_VAR(o, uuid);
+    PACK_MAP_VAR(o, format);
+    PACK_MAP_VAR(o, data);
+  }
+};
+
+struct BufferGeometryData : public GeometryData {
+  // We deviate from the meshcat data structure, since it is an unnecessarily
+  // deep hierarchy of dictionaries, and simply implement the packer manually.
+  Eigen::Matrix3Xf position;
+  Eigen::Matrix3Xf color;
+
+  // NOLINTNEXTLINE(runtime/references) cpplint disapproves of msgpack choices.
+  void msgpack_pack(msgpack::packer<std::stringstream>& o) const override {
+    o.pack_map(3);
+    o.pack("type");
+    o.pack("BufferGeometry");
+    PACK_MAP_VAR(o, uuid);
+    o.pack("data");
+    o.pack_map(1);
+    o.pack("attributes");
+    if (color.cols() > 0) {
+      o.pack_map(2);
+      PACK_MAP_VAR(o, color);
+    } else {
+      o.pack_map(1);
+    }
+    PACK_MAP_VAR(o, position);
   }
 };
 
@@ -174,24 +293,30 @@ struct MeshFileObjectData {
 
 struct LumpedObjectData {
   ObjectData metadata{};
-  // We use std::vector here for geometries and materials, even though our
-  // current usage only ever sends zero or one of each.  This is because the
-  // msgpack serialization needs to use msgpack::Array; using std::vector
-  // allows us to use the msgpack default Packer.
-  std::vector<GeometryData> geometries;
-  std::vector<MaterialData> materials;
+  // We deviate from the msgpack names (geometries, materials) here since we
+  // currently only support zero or one geometry/material.
+  std::unique_ptr<GeometryData> geometry;
+  std::unique_ptr<MaterialData> material;
   std::variant<std::monostate, MeshData, MeshFileObjectData> object;
 
   template <typename Packer>
   // NOLINTNEXTLINE(runtime/references) cpplint disapproves of msgpack choices.
   void msgpack_pack(Packer& o) const {
-    o.pack_map(4);
-    o.pack("metadata");
-    o.pack(metadata);
-    o.pack("geometries");
-    o.pack(geometries);
-    o.pack("materials");
-    o.pack(materials);
+    int size = 2;
+    if (geometry) ++size;
+    if (material) ++size;
+    o.pack_map(size);
+    PACK_MAP_VAR(o, metadata);
+    if (geometry) {
+      o.pack("geometries");
+      o.pack_array(1);
+      o.pack(*geometry);
+    }
+    if (material) {
+      o.pack("materials");
+      o.pack_array(1);
+      o.pack(*material);
+    }
     o.pack("object");
     if (std::holds_alternative<MeshData>(object)) {
       o.pack(std::get<MeshData>(object));
@@ -230,7 +355,7 @@ struct SetCameraData {
 struct SetTransformData {
   std::string type{"set_transform"};
   std::string path;
-  double matrix[16];
+  double matrix[16]{};
   MSGPACK_DEFINE_MAP(type, path, matrix);
 };
 
@@ -261,17 +386,17 @@ struct SetSliderControl {
   std::string type{"set_control"};
   std::string name;
   std::string callback;
-  double value;
-  double min;
-  double max;
-  double step;
+  double value{};
+  double min{};
+  double max{};
+  double step{};
   MSGPACK_DEFINE_MAP(type, name, callback, value, min, max, step);
 };
 
 struct SetSliderValue {
   std::string type{"set_control_value"};
   std::string name;
-  double value;
+  double value{};
   // Note: If invoke_callback is true, then we will receive a message back from
   // the slider whose value it being set.  This can lead to mysterious loopy
   // behavior when multiple browsers are connected.
@@ -297,6 +422,7 @@ struct UserInterfaceEvent {
 }  // namespace geometry
 }  // namespace drake
 
+MSGPACK_ADD_ENUM(drake::geometry::internal::ThreeSide);
 
 // We use the msgpack "non-intrusive" approach for packing types exposed in the
 // public interface. https://github.com/msgpack/msgpack-c/wiki/v2_0_cpp_adaptor
@@ -304,11 +430,59 @@ namespace msgpack {
 MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS) {
 namespace adaptor {
 
-template<>
+
+template <typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime,
+          int Options, int MaxRowsAtCompileTime, int MaxColsAtCompileTime>
+struct pack<Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options,
+                          MaxRowsAtCompileTime, MaxColsAtCompileTime> > {
+  template <typename Stream>
+  packer<Stream>& operator()(
+      // NOLINTNEXTLINE(runtime/references) cpplint disapproves of msgpack.
+      msgpack::packer<Stream>& o,
+      const Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options,
+                          MaxRowsAtCompileTime, MaxColsAtCompileTime>& mat)
+      const {
+    o.pack_map(4);
+    o.pack("itemSize");
+    o.pack(mat.rows());
+    o.pack("type");
+    int8_t ext;
+    // Based on pack_numpy_array method in meshcat-python geometry.py. See also
+    // https://github.com/msgpack/msgpack/blob/master/spec.md#extension-types
+    if (std::is_floating_point_v<Scalar>) {
+      o.pack("Float32Array");
+      ext = 0x17;
+    } else if (std::is_same_v<Scalar, uint8_t>) {
+      o.pack("Uint8Array");
+      ext = 0x12;
+    } else {
+      throw std::runtime_error("Unsupported Scalar " +
+                               drake::NiceTypeName::Get(typeid(Scalar)));
+    }
+    o.pack("array");
+    if (std::is_same_v<std::remove_cv<Scalar>, double>) {
+      // Three.js only uses float, and meshcat only parses Float32Array (not
+      // doubles).
+      size_t s = mat.size() * sizeof(float);
+      o.pack_ext(s, ext);
+      auto mat_float = mat.template cast<float>().eval();
+      o.pack_ext_body(reinterpret_cast<const char*>(mat_float.data()), s);
+    } else {
+      size_t s = mat.size() * sizeof(Scalar);
+      o.pack_ext(s, ext);
+      o.pack_ext_body(reinterpret_cast<const char*>(mat.data()), s);
+    }
+    o.pack("normalized");
+    o.pack(false);
+    return o;
+  }
+};
+
+template <>
 struct pack<drake::geometry::Meshcat::OrthographicCamera> {
   template <typename Stream>
   packer<Stream>& operator()(
-  // NOLINTNEXTLINE(runtime/references) cpplint disapproves of msgpack choices.
+      // NOLINTNEXTLINE(runtime/references) cpplint disapproves of msgpack.
       msgpack::packer<Stream>& o,
       const drake::geometry::Meshcat::OrthographicCamera& v) const {
     o.pack_map(8);

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -21,29 +21,38 @@ int do_main() {
   auto meshcat = std::make_shared<Meshcat>();
 
   meshcat->SetObject("sphere", Sphere(.25), Rgba(1.0, 0, 0, 1));
-  meshcat->SetTransform("sphere", RigidTransformd(Vector3d{-2.5, 0, 0}));
+  meshcat->SetTransform("sphere", RigidTransformd(Vector3d{-3, 0, 0}));
 
   meshcat->SetObject("cylinder", Cylinder(.25, .5), Rgba(0.0, 1.0, 0, 1));
-  meshcat->SetTransform("cylinder", RigidTransformd(Vector3d{-1.5, 0, 0}));
+  meshcat->SetTransform("cylinder", RigidTransformd(Vector3d{-2, 0, 0}));
 
   meshcat->SetObject("ellipsoid", Ellipsoid(.25, .25, .5), Rgba(1., 0, 1, .5));
-  meshcat->SetTransform("ellipsoid", RigidTransformd(Vector3d{-0.5, 0, 0}));
+  meshcat->SetTransform("ellipsoid", RigidTransformd(Vector3d{-1, 0, 0}));
 
   meshcat->SetObject("box", Box(.25, .25, .5), Rgba(0, 0, 1, 1));
-  meshcat->SetTransform("box", RigidTransformd(Vector3d{.5, 0, 0}));
+  meshcat->SetTransform("box", RigidTransformd(Vector3d{0, 0, 0}));
 
   // The green color of this cube comes from the texture map.
   meshcat->SetObject(
       "obj", Mesh(FindResourceOrThrow(
                       "drake/systems/sensors/test/models/meshes/box.obj"),
                   .25));
-  meshcat->SetTransform("obj", RigidTransformd(Vector3d{1.5, 0, 0}));
+  meshcat->SetTransform("obj", RigidTransformd(Vector3d{1, 0, 0}));
 
   meshcat->SetObject(
       "mustard",
       Mesh(FindResourceOrThrow("drake/manipulation/models/ycb/meshes/"
                                "006_mustard_bottle_textured.obj"), 3.0));
-  meshcat->SetTransform("mustard", RigidTransformd(Vector3d{2.5, 0, 0}));
+  meshcat->SetTransform("mustard", RigidTransformd(Vector3d{2, 0, 0}));
+
+  const int kPoints = 100000;
+  perception::PointCloud cloud(
+      kPoints, perception::pc_flags::kXYZs | perception::pc_flags::kRGBs);
+  Eigen::Matrix3Xf m = Eigen::Matrix3Xf::Random(3, kPoints);
+  cloud.mutable_xyzs() = Eigen::DiagonalMatrix<float, 3>{.25, .25, .5} * m;
+  cloud.mutable_rgbs() = (255.0 * (m.array() + 1.0) / 2.0).cast<uint8_t>();
+  meshcat->SetObject("point_cloud", cloud, 0.01);
+  meshcat->SetTransform("point_cloud", RigidTransformd(Vector3d{3, 0, 0}));
 
   std::cout << R"""(
 Open up your browser to the URL above.
@@ -56,12 +65,13 @@ Open up your browser to the URL above.
   - a blue box (long axis in z)
   - a bright green cube (the green comes from a texture map)
   - a yellow mustard bottle w/ label
+  - a dense rainbow point cloud in a box (long axis in z)
 )""";
   std::cout << "[Press RETURN to continue]." << std::endl;
   std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
 
-  meshcat->Set2dRenderMode(math::RigidTransform(Eigen::Vector3d{0, -3, 0}), -3,
-                           3, -2, 2);
+  meshcat->Set2dRenderMode(math::RigidTransform(Eigen::Vector3d{0, -3, 0}), -4,
+                           4, -2, 2);
 
   std::cout << "- The scene should have switched to 2D rendering mode.\n";
   std::cout << "[Press RETURN to continue]." << std::endl;

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -109,6 +109,36 @@ GTEST_TEST(MeshcatTest, SetObjectWithShape) {
   EXPECT_TRUE(meshcat.GetPackedObject("bad").empty());
 }
 
+GTEST_TEST(MeshcatTest, SetObjectWithPointCloud) {
+  Meshcat meshcat;
+
+  perception::PointCloud cloud(5);
+  // clang-format off
+  cloud.mutable_xyzs().transpose() <<
+    1, 2, 3,
+    10, 20, 30,
+    100, 200, 300,
+    4, 5, 6,
+    40, 50, 60;
+  // clang-format on
+  meshcat.SetObject("cloud", cloud);
+  EXPECT_FALSE(meshcat.GetPackedObject("cloud").empty());
+
+  perception::PointCloud rgb_cloud(
+      5, perception::pc_flags::kXYZs | perception::pc_flags::kRGBs);
+  rgb_cloud.mutable_xyzs() = cloud.xyzs();
+  // clang-format off
+  rgb_cloud.mutable_rgbs() <<
+    1, 2, 3,
+    10, 20, 30,
+    100, 200, 255,
+    4, 5, 6,
+    40, 50, 60;
+  // clang-format on
+  meshcat.SetObject("rgb_cloud", rgb_cloud);
+  EXPECT_FALSE(meshcat.GetPackedObject("rgb_cloud").empty());
+}
+
 GTEST_TEST(MeshcatTest, SetTransform) {
   Meshcat meshcat;
   EXPECT_FALSE(meshcat.HasPath("frame"));


### PR DESCRIPTION
Includes a refactoring of the GeometryData msgpack type, because
adding yet another geometry type was becoming unwieldy.

Implements the TODO making many MaterialData fields optional, because
the point clouds needed to not have spurious mesh material properties
in their message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15851)
<!-- Reviewable:end -->
