### PR TITLE
[geometry] Never call get_new_id from a header

### DIFF
--- a/common/identifier.h
+++ b/common/identifier.h
@@ -181,7 +181,8 @@ class Identifier {
    different from all previous identifiers created. This method does _not_
    make any guarantees about the values of ids from successive invocations.
    This method is guaranteed to be thread safe.
-   */
+   @note To avoid possible "one definition rule" violations, it's best to only
+   ever call this from from a *.cc file, not a header file.  */
   static Identifier get_new_id() {
     // Note that id 0 is reserved for uninitialized variable which is created
     // by the default constructor. As a result, we have an invariant that

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -142,7 +142,7 @@ drake_cc_library(
 
 drake_cc_library(
     name = "geometry_frame",
-    srcs = [],
+    srcs = ["geometry_frame.cc"],
     hdrs = ["geometry_frame.h"],
     deps = [
         ":geometry_ids",

--- a/geometry/geometry_frame.cc
+++ b/geometry/geometry_frame.cc
@@ -1,0 +1,21 @@
+#include "drake/geometry/geometry_frame.h"
+
+#include <stdexcept>
+
+namespace drake {
+namespace geometry {
+
+// N.B. This definition appears in the cc file because get_new_id should never
+// be called from a header file.
+GeometryFrame::GeometryFrame(const std::string& frame_name, int frame_group_id)
+    : id_(FrameId::get_new_id()),
+      name_(frame_name),
+      frame_group_(frame_group_id) {
+  if (frame_group_ < 0) {
+    throw std::logic_error(
+        "GeometryFrame requires a non-negative frame group");
+  }
+}
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/geometry_frame.h
+++ b/geometry/geometry_frame.h
@@ -1,11 +1,8 @@
 #pragma once
 
 #include <string>
-#include <type_traits>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/common/drake_deprecated.h"
-#include "drake/common/eigen_types.h"
 #include "drake/geometry/geometry_ids.h"
 
 namespace drake {
@@ -36,12 +33,7 @@ class GeometryFrame {
    @param frame_group_id    The optional frame group identifier. If unspecified,
                             defaults to the common, 0 group. Must be
                             non-negative.  */
-  explicit GeometryFrame(const std::string& frame_name, int frame_group_id = 0)
-      : id_(FrameId::get_new_id()),
-        name_(frame_name),
-        frame_group_(frame_group_id) {
-    ThrowIfInvalid();
-  }
+  explicit GeometryFrame(const std::string& frame_name, int frame_group_id = 0);
 
   /** Returns the globally unique id for this geometry specification. Every
    instantiation of %FrameInstance will contain a unique id value. The id
@@ -55,14 +47,6 @@ class GeometryFrame {
   int frame_group() const { return frame_group_; }
 
  private:
-  // Throws an exception if the GeometryFrame is ill configured.
-  void ThrowIfInvalid() const {
-    if (frame_group_ < 0) {
-      throw std::logic_error(
-          "GeometryFrame requires a non-negative frame group");
-    }
-  }
-
   // The *globally* unique identifier for this instance. It is functionally
   // const (i.e. defined in construction) but not marked const to allow for
   // default copying/assigning.

--- a/geometry/render/gl_renderer/shader_program.cc
+++ b/geometry/render/gl_renderer/shader_program.cc
@@ -47,6 +47,11 @@ GLuint CompileShader(GLuint shader_type, const std::string& shader_code) {
 
 }  // namespace
 
+// N.B. This definition appears in the cc file because get_new_id should never
+// be called from a header file.
+ShaderProgram::ShaderProgram()
+    : id_(ShaderId::get_new_id()) {}
+
 void ShaderProgram::LoadFromSources(const std::string& vertex_shader_source,
                                     const std::string& fragment_shader_source) {
   // Compile.

--- a/geometry/render/gl_renderer/shader_program.h
+++ b/geometry/render/gl_renderer/shader_program.h
@@ -58,7 +58,7 @@ namespace internal {
      to ℜ². */
 class ShaderProgram {
  public:
-  ShaderProgram() : id_(ShaderId::get_new_id()) {}
+  ShaderProgram();
 
   /* Note: we're using the default destructor and explicitly *not* cleaning up
    the OpenGl context. This is consistent with how we treat all OpenGl objects:


### PR DESCRIPTION
This avoids baiting the ODR demons.  It's best for mutable global storage to only ever be emitted into one object file.

Towards #15845 and #15846 (this is only half of the answer).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15854)
<!-- Reviewable:end -->
