### PR TITLE
implement missing derivative overrides in bspline

### DIFF
--- a/common/trajectories/bspline_trajectory.cc
+++ b/common/trajectories/bspline_trajectory.cc
@@ -46,7 +46,8 @@ bool BsplineTrajectory<T>::do_has_derivative() const {
 }
 
 template <typename T>
-MatrixX<T> BsplineTrajectory<T>::DoEvalDerivative(const T& t, int derivative_order) const {
+MatrixX<T> BsplineTrajectory<T>::DoEvalDerivative(
+    const T& t, int derivative_order) const {
   return this->MakeDerivative(derivative_order)->value(t);
 }
 

--- a/common/trajectories/bspline_trajectory.cc
+++ b/common/trajectories/bspline_trajectory.cc
@@ -41,6 +41,16 @@ MatrixX<T> BsplineTrajectory<T>::value(const T& time) const {
 }
 
 template <typename T>
+bool BsplineTrajectory<T>::do_has_derivative() const {
+  return true;
+}
+
+template <typename T>
+MatrixX<T> BsplineTrajectory<T>::DoEvalDerivative(const T& t, int derivative_order) const {
+  return this->MakeDerivative(derivative_order)->value(t);
+}
+
+template <typename T>
 std::unique_ptr<Trajectory<T>> BsplineTrajectory<T>::DoMakeDerivative(
     int derivative_order) const {
   if (derivative_order == 0) {

--- a/common/trajectories/bspline_trajectory.h
+++ b/common/trajectories/bspline_trajectory.h
@@ -131,7 +131,7 @@ class BsplineTrajectory final : public trajectories::Trajectory<T> {
     DRAKE_THROW_UNLESS(CheckInvariants());
   }
 
-  private:
+ private:
   bool do_has_derivative() const override;
 
   MatrixX<T> DoEvalDerivative(const T& t, int derivative_order) const override;

--- a/common/trajectories/bspline_trajectory.h
+++ b/common/trajectories/bspline_trajectory.h
@@ -131,7 +131,11 @@ class BsplineTrajectory final : public trajectories::Trajectory<T> {
     DRAKE_THROW_UNLESS(CheckInvariants());
   }
 
- private:
+  private:
+  bool do_has_derivative() const override;
+
+  MatrixX<T> DoEvalDerivative(const T& t, int derivative_order) const override;
+
   std::unique_ptr<trajectories::Trajectory<T>> DoMakeDerivative(
       int derivative_order) const override;
 


### PR DESCRIPTION
Implement the missing method override `do_has_derivative` and `DoEvalDerivative` for bspline trajectory. 

I think the implementation of  `DoEvalDerivative` should be the same for all trajectory subclasses. Should I move its implementation to replace [this line](https://github.com/RobotLocomotion/drake/blob/2f16f87df02d7c6ef436fb87437e59a3df840bb5/common/trajectories/trajectory.cc#L51) in trajectory.cc?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15855)
<!-- Reviewable:end -->
