### PR TITLE
[pydrake] Remove FakeId from geometry_test

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -1887,14 +1887,10 @@ bool PropertiesIndicateSoftHydro(const geometry::ProximityProperties& props) {
 }
 
 void def_testing_module(py::module m) {
-  class FakeTag;
-  using FakeId = Identifier<FakeTag>;
-
-  BindIdentifier<FakeId>(m, "FakeId", "Fake documentation.");
-  // Get a valid, constant FakeId to test hashing with new instances returned.
-  FakeId fake_id_constant{FakeId::get_new_id()};
-  m.def("get_fake_id_constant",
-      [fake_id_constant]() { return fake_id_constant; });
+  // The get_constant_id() returns a fresh object every time, but always with
+  // the same underlying get_value().
+  const auto constant_id = geometry::FilterId::get_new_id();
+  m.def("get_constant_id", [constant_id]() { return constant_id; });
 
   m.def("PropertiesIndicateSoftHydro", &PropertiesIndicateSoftHydro);
 

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -472,7 +472,6 @@ class TestGeometry(unittest.TestCase):
 
     def test_identifier_api(self):
         cls_list = [
-            mut_testing.FakeId,
             mut.FilterId,
             mut.SourceId,
             mut.FrameId,
@@ -488,14 +487,14 @@ class TestGeometry(unittest.TestCase):
             # N.B. Creation order does not imply value.
             self.assertTrue(a < b or b > a)
 
-        fake_id_1 = mut_testing.get_fake_id_constant()
-        fake_id_2 = mut_testing.get_fake_id_constant()
-        self.assertIsNot(fake_id_1, fake_id_2)
-        self.assertEqual(hash(fake_id_1), hash(fake_id_2))
+        id_1 = mut_testing.get_constant_id()
+        id_2 = mut_testing.get_constant_id()
+        self.assertIsNot(id_1, id_2)
+        self.assertEqual(hash(id_1), hash(id_2))
 
-        self.assertEqual(
-            repr(fake_id_1),
-            f"<FakeId value={fake_id_1.get_value()}>")
+        self.assertIn(
+            f"value={id_1.get_value()}",
+            repr(id_1))
 
     @numpy_compare.check_nonsymbolic_types
     def test_penetration_as_point_pair_api(self, T):


### PR DESCRIPTION
Creating a pydrake-only Identifier<> makes life difficult as we want to improve how identifiers are bound.  We can use an existing type without any loss of test specificity.

Pre-requisite for #15846.  See #15857 for the full branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15856)
<!-- Reviewable:end -->
