### PR TITLE
[multibody] Add internal cross-check for default contact model

### DIFF
--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -356,7 +356,11 @@ VectorX<T> ExpandRows(const VectorX<T>& v, int rows_out,
 
 template <typename T>
 MultibodyPlant<T>::MultibodyPlant(double time_step)
-    : MultibodyPlant(nullptr, time_step) {}
+    : MultibodyPlant(nullptr, time_step) {
+  // Cross-check that the Config default matches our header file default.
+  DRAKE_DEMAND(contact_model_ == ContactModel::kPoint);
+  DRAKE_DEMAND(MultibodyPlantConfig{}.contact_model == "point");
+}
 
 template <typename T>
 MultibodyPlant<T>::MultibodyPlant(

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -4797,11 +4797,9 @@ class MultibodyPlant : public internal::MultibodyTreeSystem<T> {
   // See geometry_id_to_collision_index_.
   std::vector<CoulombFriction<double>> default_coulomb_friction_;
 
-  // The model used by the plant to compute contact forces.
-  // Keep this in sync with the default value in multibody_plant_config.h.
-  // TODO(jwnimmer-tri) The best way to keep in sync would be to initialize
-  // this value from a default-constructed MultibodyPlantConfig.  We'll need
-  // to refactor the code a little bit before we can do that, though.
+  // The model used by the plant to compute contact forces. Keep this in sync
+  // with the default value in multibody_plant_config.h; there are already
+  // assertions in the cc file that enforce this.
   ContactModel contact_model_{ContactModel::kPoint};
 
   bool use_low_resolution_contact_surface_{false};


### PR DESCRIPTION
This resolves a TODO related to software upkeep, from #15826.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15861)
<!-- Reviewable:end -->
