### PR TITLE
[geometry:meshcat] Adds SetAnimation

### DIFF
--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -1630,6 +1630,11 @@ void DoScalarIndependentDefinitions(py::module m) {
                 &Class::SetProperty),
             py::arg("path"), py::arg("property"), py::arg("value"),
             cls_doc.SetProperty.doc_double)
+        .def("SetProperty",
+            py::overload_cast<std::string_view, std::string,
+                const std::vector<double>&>(&Class::SetProperty),
+            py::arg("path"), py::arg("property"), py::arg("value"),
+            cls_doc.SetProperty.doc_vector_double)
         .def("AddButton", &Class::AddButton, py::arg("name"),
             cls_doc.AddButton.doc)
         .def("GetButtonClicks", &Class::GetButtonClicks, py::arg("name"),

--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -413,6 +413,8 @@ class TestGeometry(unittest.TestCase):
                             value=True)
         meshcat.SetProperty(path="/Lights/DirectionalLight/<object>",
                             property="intensity", value=1.0)
+        meshcat.SetProperty(path="/test/cloud",
+                            property="position", value=[1, 0, 0])
         meshcat.Set2dRenderMode(
             X_WC=RigidTransform(), xmin=-1, xmax=1, ymin=-1, ymax=1)
         meshcat.ResetRenderMode()

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -37,6 +37,7 @@ drake_cc_package_library(
         ":internal_frame",
         ":internal_geometry",
         ":meshcat",
+        ":meshcat_animation",
         ":meshcat_visualizer",
         ":meshcat_visualizer_params",
         ":proximity_engine",
@@ -375,6 +376,24 @@ install_files(
 )
 
 drake_cc_library(
+    name = "meshcat_animation",
+    srcs = ["meshcat_animation.cc"],
+    hdrs = ["meshcat_animation.h"],
+    deps = [
+        "//math:geometric_transform",
+    ],
+)
+
+drake_cc_googletest(
+    name = "meshcat_animation_test",
+    deps = [
+        ":meshcat_animation",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+drake_cc_library(
     name = "meshcat",
     srcs = ["meshcat.cc"],
     hdrs = [
@@ -384,6 +403,7 @@ drake_cc_library(
     data = [":meshcat_resources"],
     install_hdrs_exclude = ["meshcat_types.h"],
     deps = [
+        ":meshcat_animation",
         ":rgba",
         ":shape_specification",
         "//common:essential",

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -8,6 +8,7 @@
 #include <Eigen/Core>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/geometry/meshcat_animation.h"
 #include "drake/geometry/rgba.h"
 #include "drake/geometry/shape_specification.h"
 #include "drake/math/rigid_transform.h"
@@ -238,10 +239,28 @@ class Meshcat {
   */
   void SetProperty(std::string_view path, std::string property, double value);
 
+  /** Sets a single named property of the object at the given path. For example,
+  @verbatim
+  meshcat.SetProperty("box", "position", [1.0, 0.0, 0.0]);
+  @endverbatim
+  See @ref meshcat_path "Meshcat paths" for more details about these properties
+  and how to address them.
+
+  @param path a "/"-delimited string indicating the path in the scene tree.
+              See @ref meshcat_path for the semantics.
+  @param property the string name of the property to set
+  @param value the new value.
+
+  @pydrake_mkdoc_identifier{vector_double}
+  */
   void SetProperty(std::string_view path, std::string property,
                    const std::vector<double>& value);
 
-  // TODO(russt): Implement SetAnimation().
+  // TODO(russt): Support multiple animations, by name.  Currently "default" is
+  // hard-coded in the meshcat javascript.
+  /** Sets the MeshcatAnimation, which creates a slider interface element to
+  play/pause/rewind through a series of animation frames in the visualizer. */
+  void SetAnimation(const MeshcatAnimation& animation);
 
   /** @name Meshcat Controls
    Meshcat "Controls" are user interface elements in the browser.  These

--- a/geometry/meshcat_animation.cc
+++ b/geometry/meshcat_animation.cc
@@ -1,0 +1,65 @@
+#include "drake/geometry/meshcat_animation.h"
+
+namespace drake {
+namespace geometry {
+
+MeshcatAnimation::MeshcatAnimation(double frames_per_second)
+    : frames_per_second_(frames_per_second) {}
+
+MeshcatAnimation::~MeshcatAnimation() = default;
+
+void MeshcatAnimation::SetTransform(int frame, const std::string& path,
+                                    const math::RigidTransformd& X_ParentPath) {
+  std::vector<double> position(3);
+  Eigen::Vector3d::Map(&position[0]) = X_ParentPath.translation();
+  const auto q = X_ParentPath.rotation().ToQuaternion();
+  std::vector<double> quaternion{q.x(), q.y(), q.z(), q.w()};
+  DoSetProperty(frame, path, "position", "vector3", position);
+  DoSetProperty(frame, path, "quaternion", "quaternion", quaternion);
+}
+
+void MeshcatAnimation::SetProperty(int frame, const std::string& path,
+                  const std::string& property, bool value) {
+  DoSetProperty(frame, path, property, "boolean", value);
+}
+
+void MeshcatAnimation::SetProperty(int frame, const std::string& path,
+                  const std::string& property, double value) {
+  DoSetProperty(frame, path, property, "number", value);
+}
+
+void MeshcatAnimation::SetProperty(int frame, const std::string& path,
+                  const std::string& property,
+                  const std::vector<double>& value) {
+  DoSetProperty(frame, path, property, "vector", value);
+}
+
+std::string MeshcatAnimation::get_javascript_type(
+    const std::string& path, const std::string& property) const {
+  if (path_tracks_.find(path) == path_tracks_.end() ||
+      path_tracks_.at(path).find(property) == path_tracks_.at(path).end()) {
+    return "";
+  }
+  return path_tracks_.at(path).at(property).js_type;
+}
+
+template <typename T>
+void MeshcatAnimation::DoSetProperty(int frame, const std::string& path,
+                                     const std::string& property,
+                                     const std::string& js_type,
+                                     const T& value) {
+  TypedTrack& tt = path_tracks_[path][property];
+  if (std::holds_alternative<std::monostate>(tt.track)) {
+    tt.track = Track<T>();
+    tt.js_type = js_type;
+  } else if (tt.js_type != js_type) {
+    throw std::runtime_error(fmt::format(
+        "{} property {} already has a track with javascript type {} != {}",
+        path, property, tt.js_type, js_type));
+  }
+  // get<T> will also throw bad_variant_access if the types don't match.
+  std::get<Track<T>>(tt.track)[frame] = value;
+}
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/meshcat_animation.h
+++ b/geometry/meshcat_animation.h
@@ -1,0 +1,240 @@
+#pragma once
+
+#include <map>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include "drake/math/rigid_transform.h"
+
+namespace drake {
+namespace geometry {
+
+// Forward declaration.
+class Meshcat;
+
+/** An interface for recording/playback animations in Meshcat. Use
+Meshcat::SetAnimation to publish a MeshcatAnimation to the visualizer.
+
+NOTE: There is a significant bug in meshcat/three.js that limits the ability to
+set multiple property types in a single animation.  Your mileage with property
+animations may vary until we can resolve
+https://github.com/rdeits/meshcat/issues/105.
+
+Currently, an animation consists of (only) transforms and properties that get
+set at a particular integer frame number. Although we do not support calls to
+SetObject/Delete in an animation, you can consider using `SetProperty(frame,
+path, "visible", true/false)` in your animation to make the object appear or
+disappear at a particular frame.
+*/
+class MeshcatAnimation {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MeshcatAnimation)
+
+  /** Constructs the animation object.
+  @param frames_per_second a positive integer specifying the timing at which the
+  frames are played back. */
+  explicit MeshcatAnimation(double frames_per_second = 32.0);
+
+  ~MeshcatAnimation();
+
+  /** Returns the frame rate at which the animation will be played back. */
+  double frames_per_second() const { return frames_per_second_; }
+
+  /** Uses the frame rate to convert from time to the frame number, using
+   * std::round. `time_from_start` must be non-negative. */
+  int frame(double time_from_start) const {
+    DRAKE_DEMAND(time_from_start >= 0.0);
+    return static_cast<int>(std::round(time_from_start * frames_per_second_));
+  }
+
+  // The documentation is adapted from
+  // https://threejs.org/docs/index.html?q=Animation#api/en/animation/AnimationAction
+  // The values are from
+  // https://github.com/mrdoob/three.js/blob/dev/src/constants.js
+  enum LoopMode {
+    /** Plays the clip once. */
+    kLoopOnce = 2200,
+
+    /** Plays the clip with the chosen number of repetitions, each time jumping
+    from the end of the clip directly to its beginning. */
+    kLoopRepeat = 2201,
+
+    /** Plays the clip with the chosen number of repetitions, alternately
+    playing forward and backward. */
+    kLoopPingPong = 2202
+  };
+
+  // Accessors.
+  bool autoplay() const { return play_; }
+  LoopMode loop_mode() const { return loop_mode_; }
+  int repetitions() const { return repetitions_; }
+  bool clamp_when_finished() const { return clamp_when_finished_; }
+
+  /** Set the behavior when the animation is first sent to the visualizer.  The
+  animation will play immediately iff `play` is true.  The default is true.*/
+  void set_autoplay(bool play) { play_ = play; }
+
+  /** Sets the loop behavior on play.  @see LoopMode for details.  The default
+  is kLoopRepeat. */
+  void set_loop_mode(LoopMode mode) { loop_mode_ = mode; }
+
+  /** Sets the number of repetitions of the animation each time it is played.
+  This number has no effect when the loop mode is set to kLoopOnce.
+  `repetitions` must be a positive integer.  The default value is 1. */
+  void set_repetitions(int repetitions) {
+    DRAKE_DEMAND(repetitions >= 1);
+    repetitions_ = repetitions;
+  }
+
+  /** Sets the behavior at the end of the animation.  If true, then the
+  animation will automatically be paused on its last frame.  If false, the
+  scene will be reset to before the animation. The default is true.
+
+  Note: This setting has no impact if the action is interrupted (it has
+  only an effect if its last loop has really finished). */
+  void set_clamp_when_finished(bool clamp) { clamp_when_finished_ = clamp; }
+
+  /** Set the RigidTransform at `frame` in the animation for a given `path` in
+  the the scene tree.  @see Meshcat::SetTransform.
+  @param frame a non-negative integer indicating the frame at which this
+               transform is applied.
+  @param path a "/"-delimited string indicating the path in the scene tree.
+              See @ref meshcat_path "Meshcat paths" for the semantics.
+  @param X_ParentPath the relative transform from the path to its immediate
+  parent.
+  @throws std::exception if this the position or quaternion properties of this
+                         path have already been set to an incorrect type.
+
+  */
+  void SetTransform(int frame, const std::string& path,
+                    const math::RigidTransformd& X_ParentPath);
+
+  /** Sets a single named property of the object at the given `path` at the
+  specified `frame` in the animation. @see Meshcat::SetProperty.
+  @param frame a non-negative integer indicating the frame at which this
+               transform is applied.
+  @param path a "/"-delimited string indicating the path in the scene tree.
+              See @ref meshcat_path for the semantics.
+  @param property the string name of the property to set
+  @param value the new value.
+  @throws std::exception if this path/property has already been set with a
+                         different type.
+
+  @pydrake_mkdoc_identifier{bool}
+  */
+  void SetProperty(int frame, const std::string& path,
+                   const std::string& property, bool value);
+
+  /** Sets a single named property of the object at the given `path` at the
+  specified `frame` in the animation. @see Meshcat::SetProperty.
+  @param frame a non-negative integer indicating the frame at which this
+               transform is applied.
+  @param path a "/"-delimited string indicating the path in the scene tree.
+              See @ref meshcat_path for the semantics.
+  @param property the string name of the property to set
+  @param value the new value.
+  @throws std::exception if this path/property has already been set with a
+                         different type.
+
+  @pydrake_mkdoc_identifier{double}
+  */
+  void SetProperty(int frame, const std::string& path,
+                   const std::string& property, double value);
+
+  /** Sets a single named property of the object at the given `path` at the
+  specified `frame` in the animation. @see Meshcat::SetProperty.
+  @param frame a non-negative integer indicating the frame at which this
+               transform is applied.
+  @param path a "/"-delimited string indicating the path in the scene tree.
+              See @ref meshcat_path for the semantics.
+  @param property the string name of the property to set
+  @param value the new value.
+  @throws std::exception if this path/property has already been set with a
+                         different type.
+
+  @pydrake_mkdoc_identifier{double_vector}
+  */
+  void SetProperty(int frame, const std::string& path,
+                   const std::string& property,
+                   const std::vector<double>& value);
+
+  // TODO(russt): Consider ColorKeyframeTrack.js and/or StringKeyframeTrack.js
+
+  // TODO(russt): Possibly support interpolation modes and ending modes from
+  // https://threejs.org/docs/#api/en/constants/Animation.
+
+  // TODO(russt): Could implement a SetObject/Delete here that would effectively
+  // implement behind the scenes the work-around I've documented in the class
+  // documentation.  There would be some subtleties to make it robust (e.g.
+  // setting multiple objects at different frames on the same path, but still
+  // supporting properties, etc), but it could work.
+
+  /** Returns the value information for a particular path/property at a
+  particular frame if a value of type T has been set, otherwise returns
+  std::nullopt. This method is intended primarily for testing. */
+  template <typename T>
+  std::optional<T> get_key_frame(int frame, const std::string& path,
+                                 const std::string& property) const {
+    if (path_tracks_.find(path) == path_tracks_.end() ||
+        path_tracks_.at(path).find(property) == path_tracks_.at(path).end()) {
+      return std::nullopt;
+    }
+    const TypedTrack& tt = path_tracks_.at(path).at(property);
+    if (!std::holds_alternative<Track<T>>(tt.track)) {
+      return std::nullopt;
+    }
+    const Track<T>& t = std::get<Track<T>>(tt.track);
+    if (t.find(frame) == t.end()) {
+      return std::nullopt;
+    }
+    return t.at(frame);
+  }
+
+  /** Returns the javascript type for a particular path/property, or the empty
+   * string if nothing has been set. This method is intended primarily for
+   * testing. */
+  std::string get_javascript_type(const std::string& path,
+                                  const std::string& property) const;
+
+ private:
+  // Implements the SetProperty methods.
+  // js_type must match three.js getTrackTypeForValueTypeName implementation.
+  template <typename T>
+  void DoSetProperty(int frame, const std::string& path,
+                     const std::string& property, const std::string& js_type,
+                     const T& value);
+
+  // A map of frame => value.
+  template <typename T>
+  using Track = std::map<int, T>;
+
+  // All property values in a track must be the same type.
+  struct TypedTrack {
+    std::variant<std::monostate, Track<bool>, Track<double>,
+                 Track<std::vector<double>>>
+        track;
+    std::string js_type;
+  };
+
+  // A map of property name => tracks.
+  using PropertyTracks = std::map<std::string, TypedTrack>;
+
+  // A map of path => property tracks.
+  using PathTracks = std::map<std::string, PropertyTracks>;
+
+  friend class Meshcat;
+
+  // A map of path name => property tracks.
+  PathTracks path_tracks_{};
+
+  const double frames_per_second_;
+  bool play_{true};
+  LoopMode loop_mode_{kLoopRepeat};
+  int repetitions_{1};
+  bool clamp_when_finished_{true};
+};
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/meshcat_types.h
+++ b/geometry/meshcat_types.h
@@ -12,6 +12,7 @@
 
 #include "drake/common/nice_type_name.h"
 #include "drake/geometry/meshcat.h"
+#include "drake/geometry/meshcat_animation.h"
 #include "drake/geometry/rgba.h"
 #include "drake/math/rigid_transform.h"
 
@@ -423,6 +424,7 @@ struct UserInterfaceEvent {
 }  // namespace drake
 
 MSGPACK_ADD_ENUM(drake::geometry::internal::ThreeSide);
+MSGPACK_ADD_ENUM(drake::geometry::MeshcatAnimation::LoopMode);
 
 // We use the msgpack "non-intrusive" approach for packing types exposed in the
 // public interface. https://github.com/msgpack/msgpack-c/wiki/v2_0_cpp_adaptor

--- a/geometry/test/meshcat_animation_test.cc
+++ b/geometry/test/meshcat_animation_test.cc
@@ -1,0 +1,127 @@
+#include "drake/geometry/meshcat_animation.h"
+
+#include <cstdlib>
+
+#include <fmt/format.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+namespace drake {
+namespace geometry {
+namespace {
+
+using Eigen::Vector3d;
+using math::RigidTransformd;
+using math::RollPitchYawd;
+
+GTEST_TEST(MeshcatAnimationTest, FrameTest) {
+  const double kFramesPerSecond = 64;
+  MeshcatAnimation animation(kFramesPerSecond);
+
+  EXPECT_EQ(animation.frames_per_second(), kFramesPerSecond);
+  EXPECT_EQ(animation.frame(.5), 32);
+}
+
+GTEST_TEST(MeshcatAnimationTest, OptionsTest) {
+  MeshcatAnimation animation;
+
+  animation.set_autoplay(true);
+  EXPECT_TRUE(animation.autoplay());
+  animation.set_autoplay(false);
+  EXPECT_FALSE(animation.autoplay());
+
+  animation.set_loop_mode(MeshcatAnimation::kLoopOnce);
+  EXPECT_EQ(animation.loop_mode(), MeshcatAnimation::kLoopOnce);
+  animation.set_loop_mode(MeshcatAnimation::kLoopPingPong);
+  EXPECT_EQ(animation.loop_mode(), MeshcatAnimation::kLoopPingPong);
+
+  animation.set_repetitions(14);
+  EXPECT_EQ(animation.repetitions(), 14);
+
+  animation.set_clamp_when_finished(true);
+  EXPECT_TRUE(animation.clamp_when_finished());
+  animation.set_clamp_when_finished(false);
+  EXPECT_FALSE(animation.clamp_when_finished());
+}
+
+GTEST_TEST(MeshcatAnimationTest, SetTransformTest) {
+  MeshcatAnimation animation;
+  const int kFrame = 21;
+
+  EXPECT_FALSE(
+      animation.get_key_frame<std::vector<double>>(kFrame, "test", "position"));
+  EXPECT_FALSE(animation.get_key_frame<std::vector<double>>(kFrame, "test",
+                                                            "quaternion"));
+
+  Vector3d position(-2, .5, 8.7);
+  Eigen::Quaterniond quaternion(.3, 2, .7, .2);
+  quaternion.normalize();
+  animation.SetTransform(kFrame, "test", RigidTransformd(quaternion, position));
+  std::optional<std::vector<double>> p =
+      animation.get_key_frame<std::vector<double>>(kFrame, "test", "position");
+  EXPECT_TRUE(p);
+  EXPECT_TRUE(CompareMatrices(position, Vector3d::Map(&(*p)[0]), 1e-14));
+  std::optional<std::vector<double>> q =
+      animation.get_key_frame<std::vector<double>>(kFrame, "test",
+                                                   "quaternion");
+  EXPECT_TRUE(q);
+  Eigen::Quaterniond key_quaternion((*q)[3], (*q)[0], (*q)[1], (*q)[2]);
+  EXPECT_TRUE(quaternion.isApprox(key_quaternion, 1e-14));
+
+  EXPECT_EQ(animation.get_javascript_type("test", "position"), "vector3");
+  EXPECT_EQ(animation.get_javascript_type("test", "quaternion"), "quaternion");
+}
+
+GTEST_TEST(MeshcatAnimationTest, SetPropertyTest) {
+  MeshcatAnimation animation;
+  const int kFrame = 14;
+
+  // Boolean
+  EXPECT_FALSE(animation.get_key_frame<bool>(kFrame, "bool_test", "visible"));
+  animation.SetProperty(kFrame, "bool_test", "visible", true);
+  std::optional<bool> visible =
+      animation.get_key_frame<bool>(kFrame, "bool_test", "visible");
+  EXPECT_TRUE(visible);
+  EXPECT_TRUE(*visible);
+  EXPECT_EQ(animation.get_javascript_type("bool_test", "visible"), "boolean");
+
+  // Double
+  EXPECT_FALSE(animation.get_key_frame<double>(kFrame, "double_test",
+                                               "material.opacity"));
+  animation.SetProperty(kFrame, "double_test", "material.opacity", 0.5);
+  std::optional<double> opacity = animation.get_key_frame<double>(
+      kFrame, "double_test", "material.opacity");
+  EXPECT_TRUE(opacity);
+  EXPECT_EQ(*opacity, 0.5);
+  EXPECT_EQ(animation.get_javascript_type("double_test", "material.opacity"),
+            "number");
+
+  // Double vector
+  EXPECT_FALSE(animation.get_key_frame<std::vector<double>>(
+      kFrame, "vector_test", "position"));
+  animation.SetProperty(kFrame, "vector_test", "position", {0.1, 0.2});
+  std::optional<std::vector<double>> vec =
+      animation.get_key_frame<std::vector<double>>(kFrame, "vector_test",
+                                                   "position");
+  EXPECT_TRUE(vec);
+  EXPECT_EQ(vec->size(), 2);
+  EXPECT_EQ((*vec)[0], .1);
+  EXPECT_EQ((*vec)[1], .2);
+  EXPECT_EQ(animation.get_javascript_type("vector_test", "position"), "vector");
+
+  // Can't set a different type on a property that's already been set.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      animation.SetProperty(kFrame, "bool_test", "visible", 32.0),
+      ".*already has a track.*");
+  // ... even at a different frame.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      animation.SetProperty(kFrame + 1, "bool_test", "visible", 32.0),
+      ".*already has a track.*");
+}
+
+}  // namespace
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -1,9 +1,11 @@
 #include "drake/common/find_resource.h"
 #include "drake/geometry/meshcat.h"
+#include "drake/geometry/meshcat_animation.h"
 #include "drake/geometry/meshcat_visualizer.h"
 #include "drake/geometry/rgba.h"
 #include "drake/geometry/shape_specification.h"
 #include "drake/math/rigid_transform.h"
+#include "drake/math/rotation_matrix.h"
 #include "drake/multibody/parsing/parser.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/systems/analysis/simulator.h"
@@ -16,6 +18,7 @@ namespace geometry {
 
 using Eigen::Vector3d;
 using math::RigidTransformd;
+using math::RotationMatrixd;
 
 int do_main() {
   auto meshcat = std::make_shared<Meshcat>();
@@ -53,7 +56,6 @@ int do_main() {
   cloud.mutable_rgbs() = (255.0 * (m.array() + 1.0) / 2.0).cast<uint8_t>();
   meshcat->SetObject("point_cloud", cloud, 0.01);
   meshcat->SetTransform("point_cloud", RigidTransformd(Vector3d{3, 0, 0}));
-
   std::cout << R"""(
 Open up your browser to the URL above.
 
@@ -69,6 +71,52 @@ Open up your browser to the URL above.
 )""";
   std::cout << "[Press RETURN to continue]." << std::endl;
   std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+
+  std::cout << "Animations:\n";
+  MeshcatAnimation animation;
+  std::cout << "- the red sphere should move up and down in z.\n";
+  animation.SetTransform(0, "sphere", RigidTransformd(Vector3d{-3, 0, 0}));
+  animation.SetTransform(20, "sphere", RigidTransformd(Vector3d{-3, 0, 1}));
+  animation.SetTransform(40, "sphere", RigidTransformd(Vector3d{-3, 0, 0}));
+
+  std::cout << "- the blue box should spin about its long axis.\n";
+  animation.SetTransform(0, "box",
+                         RigidTransformd(RotationMatrixd::MakeZRotation(0)));
+  animation.SetTransform(20, "box",
+                         RigidTransformd(RotationMatrixd::MakeZRotation(M_PI)));
+  animation.SetTransform(
+      40, "box", RigidTransformd(RotationMatrixd::MakeZRotation(2 * M_PI)));
+  animation.set_repetitions(4);
+  meshcat->SetAnimation(animation);
+
+  // TODO(russt): Do all of these in a single animation pending resolution of
+  // https://github.com/rdeits/meshcat/issues/105
+  std::cout << "[Press RETURN to continue]." << std::endl;
+  std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+
+  MeshcatAnimation animation2;
+  animation2.SetProperty(0, "cylinder", "visible", true);
+  animation2.SetProperty(20, "cylinder", "visible", false);
+  animation2.SetProperty(40, "cylinder", "visible", true);
+  animation2.set_repetitions(4);
+  meshcat->SetAnimation(animation2);
+
+  std::cout << "- the green cylinder should appear and disappear.\n";
+  std::cout << "[Press RETURN to continue]." << std::endl;
+  std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+
+  MeshcatAnimation animation3;
+  animation3.SetProperty(0, "ellipsoid/<object>", "material.opacity", 1.0);
+  animation3.SetProperty(20, "ellipsoid/<object>", "material.opacity", 0.0);
+  animation3.SetProperty(40, "ellipsoid/<object>", "material.opacity", 1.0);
+  animation3.set_repetitions(4);
+  meshcat->SetAnimation(animation3);
+
+  std::cout
+      << "- the pink ellipsoid should get less and then more transparent.\n";
+  std::cout << "[Press RETURN to continue]." << std::endl;
+  std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+
 
   meshcat->Set2dRenderMode(math::RigidTransform(Eigen::Vector3d{0, -3, 0}), -4,
                            4, -2, 2);

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -413,6 +413,114 @@ GTEST_TEST(MeshcatTest, SetOrthographicCamera) {
     })""");
 }
 
+GTEST_TEST(MeshcatTest, SetAnimation) {
+  Meshcat meshcat;
+  MeshcatAnimation animation;
+
+  animation.SetTransform(0, "sphere", RigidTransformd(Vector3d{0, 0, 0}));
+  animation.SetTransform(20, "sphere", RigidTransformd(Vector3d{0, 0, 1}));
+  animation.SetTransform(40, "sphere", RigidTransformd(Vector3d{0, 0, 0}));
+
+  animation.SetProperty(0, "cylinder", "visible", true);
+  animation.SetProperty(20, "cylinder", "visible", false);
+  animation.SetProperty(40, "cylinder", "visible", true);
+
+  animation.SetProperty(0, "ellipsoid/<object>", "material.opacity", 0.0);
+  animation.SetProperty(20, "ellipsoid/<object>", "material.opacity", 1.0);
+  animation.SetProperty(40, "ellipsoid/<object>", "material.opacity", 0.0);
+
+  animation.set_loop_mode(MeshcatAnimation::kLoopRepeat);
+  animation.set_repetitions(4);
+  animation.set_autoplay(true);
+  animation.set_clamp_when_finished(true);
+
+  meshcat.SetAnimation(animation);
+
+  CheckWebsocketCommand(meshcat, 1, R"""({
+      "type": "set_animation",
+      "animations": [{
+          "path": "/drake/cylinder",
+          "clip": {
+              "fps": 32.0,
+              "name": "default",
+              "tracks": [{
+                  "name": ".visible",
+                  "type": "boolean",
+                  "keys": [{
+                      "time": 0,
+                      "value": true
+                    },{
+                      "time": 20,
+                      "value": false
+                    },{
+                      "time": 40,
+                      "value": true
+                  }]
+              }]
+          }
+      }, {
+          "path": "/drake/ellipsoid/<object>",
+          "clip": {
+              "fps": 32.0,
+              "name": "default",
+              "tracks": [{
+                  "name": ".material.opacity",
+                  "type": "number",
+                  "keys": [{
+                      "time": 0,
+                      "value": 0.0
+                    },{
+                      "time": 20,
+                      "value": 1.0
+                  },{
+                      "time": 40,
+                      "value": 0.0
+                  }]
+              }]
+          }
+      }, {
+          "path": "/drake/sphere",
+          "clip": {
+              "fps": 32.0,
+              "name": "default",
+              "tracks": [{
+                  "name": ".position",
+                  "type": "vector3",
+                  "keys": [{
+                      "time": 0,
+                      "value": [0.0, 0.0, 0.0]
+                    },{
+                      "time": 20,
+                      "value": [0.0, 0.0, 1.0]
+                    },{
+                      "time": 40,
+                      "value": [0.0, 0.0, 0.0]
+                  }]
+              }, {
+                  "name": ".quaternion",
+                  "type": "quaternion",
+                  "keys": [{
+                      "time": 0,
+                      "value": [0.0, 0.0, 0.0, 1.0]
+                    },{
+                      "time": 20,
+                      "value": [0.0, 0.0, 0.0, 1.0]
+                    },{
+                      "time": 40,
+                      "value": [0.0, 0.0, 0.0, 1.0]
+                  }]
+              }]
+          }
+      }],
+      "options": {
+          "play": true,
+          "loopMode": 2201,
+          "repetitions": 4,
+          "clampWhenFinished": true
+      }
+  })""");
+}
+
 GTEST_TEST(MeshcatTest, Set2dRenderMode) {
   Meshcat meshcat;
   meshcat.Set2dRenderMode();

--- a/geometry/test/meshcat_websocket_client.py
+++ b/geometry/test/meshcat_websocket_client.py
@@ -8,6 +8,32 @@ import umsgpack
 import websockets
 
 
+def recursive_compare(d1, d2, level='root'):
+    if isinstance(d1, dict) and isinstance(d2, dict):
+        if d1.keys() != d2.keys():
+            s1 = set(d1.keys())
+            s2 = set(d2.keys())
+            print('{:<20} + {} - {}'.format(level, s1-s2, s2-s1))
+            common_keys = s1 & s2
+        else:
+            common_keys = set(d1.keys())
+
+        for k in common_keys:
+            recursive_compare(d1[k], d2[k], level='{}.{}'.format(level, k))
+
+    elif isinstance(d1, list) and isinstance(d2, list):
+        if len(d1) != len(d2):
+            print('{:<20} len1={}; len2={}'.format(level, len(d1), len(d2)))
+        common_len = min(len(d1), len(d2))
+
+        for i in range(common_len):
+            recursive_compare(d1[i], d2[i], level='{}[{}]'.format(level, i))
+
+    else:
+        if d1 != d2:
+            print('{:<20} {} != {}'.format(level, d1, d2))
+
+
 async def check_command(ws_url, message_number, desired_command):
     async with websockets.connect(ws_url) as websocket:
         message = ''
@@ -18,6 +44,7 @@ async def check_command(ws_url, message_number, desired_command):
             print("FAILED")
             print(f"Expected: {desired_command}")
             print(f"Received: {command}")
+            recursive_compare(desired_command, command)
             sys.exit(1)
 
 


### PR DESCRIPTION
Provides a MeshcatAnimation class and Meshcat::SetAnimation.

Includes an upgrade to my test script which prints more narrow diffs;
this proved invaluable for debugging this complicated message type.

Resolves #15800.