### PR TITLE
Prevent underlinking

### DIFF
--- a/tools/cc_toolchain/bazel.rc
+++ b/tools/cc_toolchain/bazel.rc
@@ -4,6 +4,8 @@ build --action_env=CCACHE_DISABLE=1
 # Add C++17 compiler flags.
 build --cxxopt=-std=c++17
 build --host_cxxopt=-std=c++17
+build --linkopt=-Wl,--no-undefined
+build --host_linkopt=-Wl,--no-undefined
 
 # When compiling with Drake as the main WORKSPACE (i.e., if and only if this
 # rcfile is loaded), we enable -Werror by default for Drake's *own* targets,


### PR DESCRIPTION
Build with `--no-undefined` to prevent underlinking. This prevents generating a shared library with unresolved externals which can result in being unable to use the library later. This is particularly a problem with the Python bindings, as errors don't show up until trying to load the module.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15891)
<!-- Reviewable:end -->
