### PR TITLE
[workspace] Link common_robotics_utilities and vtkCapsuleSource statically

### DIFF
--- a/third_party/com_github_finetjul_bender/BUILD.bazel
+++ b/third_party/com_github_finetjul_bender/BUILD.bazel
@@ -12,6 +12,7 @@ cc_library(
     ],
     hdrs = ["vtkCapsuleSource.h"],
     licenses = ["notice"],  # Apache-2.0
+    linkstatic = True,
     tags = ["nolint"],
     visibility = ["//geometry:__subpackages__"],
     deps = [

--- a/tools/workspace/common_robotics_utilities/package.BUILD.bazel
+++ b/tools/workspace/common_robotics_utilities/package.BUILD.bazel
@@ -47,6 +47,7 @@ cc_library(
         "include/common_robotics_utilities/zlib_helpers.hpp",
     ],
     includes = ["include"],
+    linkstatic = True,
     deps = [
         "@eigen",
         "@zlib",

--- a/tools/workspace/voxelized_geometry_tools/package.BUILD.bazel
+++ b/tools/workspace/voxelized_geometry_tools/package.BUILD.bazel
@@ -11,6 +11,7 @@ cc_library(
     name = "cl_hpp",
     hdrs = ["include/voxelized_geometry_tools/cl.hpp"],
     includes = ["include"],
+    linkstatic = True,
     deps = ["@opencl"],
 )
 
@@ -30,6 +31,7 @@ cc_library(
         "include/voxelized_geometry_tools/topology_computation.hpp",
     ],
     includes = ["include"],
+    linkstatic = True,
     deps = [
         "@common_robotics_utilities",
         "@eigen",
@@ -47,6 +49,7 @@ cc_library(
         "include/voxelized_geometry_tools/device_voxelization_interface.hpp",
     ],
     includes = ["include"],
+    linkstatic = True,
     deps = [
         "@common_robotics_utilities",
         "@eigen",
@@ -63,6 +66,7 @@ cc_library(
         "include/voxelized_geometry_tools/opencl_voxelization_helpers.h",
     ],
     includes = ["include"],
+    linkstatic = True,
     deps = [
         ":cl_hpp",
         "@common_robotics_utilities",
@@ -87,6 +91,7 @@ cc_library(
         "include/voxelized_geometry_tools/pointcloud_voxelization_interface.hpp",  # noqa
     ],
     includes = ["include"],
+    linkstatic = True,
     deps = [
         ":voxelized_geometry_tools",
         ":cuda_voxelization_helpers",


### PR DESCRIPTION
Ditto for voxelized_geometry_tools (though it doesn't matter yet, because we're not using it outside of its unit test).

We always want our private dependencies to be statically linked.

Prereq for #15891.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15893)
<!-- Reviewable:end -->
