### PR TITLE
implement missing derivative overrides in bspline

### DIFF
--- a/common/trajectories/bspline_trajectory.cc
+++ b/common/trajectories/bspline_trajectory.cc
@@ -41,6 +41,52 @@ MatrixX<T> BsplineTrajectory<T>::value(const T& time) const {
 }
 
 template <typename T>
+bool BsplineTrajectory<T>::do_has_derivative() const {
+  return true;
+}
+
+
+template <typename T>
+MatrixX<T> BsplineTrajectory<T>::DoEvalDerivative(
+        const T& t, int derivative_order) const {
+  if (derivative_order == 0) {
+    return this->value(t);
+  } else if (derivative_order >= basis_.order()) {
+    return MatrixX<T>::Zero(rows(), cols());
+  } else if (derivative_order >= 1) {
+    // For a bspline trajectory of order n, the evaluation of k th derivative
+    // should take O(k^2) time by leveraging the sparsity of basis value.
+    // This differs from DoMakeDerivative, which takes O(nk) time.
+    std::vector<T> derivative_knots(basis_.knots().begin() + derivative_order,
+                                    basis_.knots().end() - derivative_order);
+    BsplineBasis<T> lower_order_basis = BsplineBasis<T>(
+        basis_.order() - derivative_order, derivative_knots);
+    std::vector<MatrixX<T>> coefficients(control_points());
+    std::vector<int> base_indices = basis_.ComputeActiveBasisFunctionIndices(t);
+    for (int j = 1; j <= derivative_order; ++j) {
+      for (int i = base_indices.front(); i <= base_indices.back() - j; ++i) {
+        coefficients.at(i) =
+            (basis_.order() - j) /
+            (basis_.knots()[i + basis_.order()] - basis_.knots()[i + j]) *
+            (coefficients[i + 1] - coefficients[i]);
+      }
+    }
+    std::vector<MatrixX<T>> derivative_control_points(
+        num_control_points() - derivative_order,
+        MatrixX<T>::Zero(rows(), cols()));
+    for (int i : lower_order_basis.ComputeActiveBasisFunctionIndices(t)) {
+      derivative_control_points.at(i) = coefficients.at(i);
+    }
+    return lower_order_basis.EvaluateCurve(derivative_control_points, t);
+  } else {
+    throw std::invalid_argument(
+        fmt::format("Invalid derivative order ({}). The derivative order must "
+                    "be greater than or equal to 0.",
+                    derivative_order));
+  }
+}
+
+template <typename T>
 std::unique_ptr<Trajectory<T>> BsplineTrajectory<T>::DoMakeDerivative(
     int derivative_order) const {
   if (derivative_order == 0) {

--- a/common/trajectories/bspline_trajectory.h
+++ b/common/trajectories/bspline_trajectory.h
@@ -132,6 +132,10 @@ class BsplineTrajectory final : public trajectories::Trajectory<T> {
   }
 
  private:
+  bool do_has_derivative() const override;
+
+  MatrixX<T> DoEvalDerivative(const T& t, int derivative_order) const override;
+
   std::unique_ptr<trajectories::Trajectory<T>> DoMakeDerivative(
       int derivative_order) const override;
 

--- a/common/trajectories/test/bspline_trajectory_test.cc
+++ b/common/trajectories/test/bspline_trajectory_test.cc
@@ -164,6 +164,27 @@ TYPED_TEST(BsplineTrajectoryTests, MakeDerivativeTest) {
   }
 }
 
+// Verifies that EvalDerivative() works as expected.
+TYPED_TEST(BsplineTrajectoryTests, EvalDerivativeTest) {
+  using T = TypeParam;
+  BsplineTrajectory<T> trajectory = MakeCircleTrajectory<T>();
+
+  // Verify that EvalDerivative() returns the consistent results.
+  const int num_times = 20;
+  VectorX<T> t = VectorX<T>::LinSpaced(num_times, trajectory.start_time(),
+                                       trajectory.end_time());
+  for (int o = 0; o < trajectory.basis().order(); ++o) {
+    std::unique_ptr<Trajectory<T>> derivative_trajectory =
+        trajectory.MakeDerivative(o);
+    for (int k = 0; k < num_times; ++k) {
+      MatrixX<T> derivative = trajectory.EvalDerivative(t(k), o);
+      MatrixX<T> expected_derivative = derivative_trajectory->value(t(k));
+      double tolerance = 1e-14;
+      EXPECT_TRUE(CompareMatrices(derivative, expected_derivative, tolerance));
+    }
+  }
+}
+
 // Verifies that CopyBlock() works as expected.
 TYPED_TEST(BsplineTrajectoryTests, CopyBlockTest) {
   using T = TypeParam;


### PR DESCRIPTION
Implement the missing method override `do_has_derivative` and `DoEvalDerivative` for bspline trajectory. The corresponding test is also added. This implementation exploits the sparsity of basis values at a point of interest and has O(k^2) time for k th derivative.

[Old PR](https://github.com/RobotLocomotion/drake/pull/15869) is closed to squash commits

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15895)
<!-- Reviewable:end -->
