### PR TITLE
Parse deprecation information from package manifests

### DIFF
--- a/multibody/parsing/package_map.h
+++ b/multibody/parsing/package_map.h
@@ -2,6 +2,7 @@
 
 #include <initializer_list>
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -40,8 +41,20 @@ class PackageMap final {
   /// Throws if @p package_name is not present in this PackageMap.
   void Remove(const std::string& package_name);
 
+  /// Sets or clears the deprecation message for package @p package_name. A
+  /// @p deprecated_message value of std::nullopt implies no deprecation. Aborts
+  /// if no package named @p package_name exists in this PackageMap.
+  void SetDeprecated(const std::string& package_name,
+      std::optional<std::string> deprecated_message);
+
   /// Returns the number of entries in this PackageMap.
   int size() const;
+
+  /// Returns the deprecation message for package @p package_name if it has
+  /// been set as deprecated. A value of std::nullopt implies no deprecation.
+  /// Aborts if no package named @p package_name exists in this PackageMap.
+  std::optional<std::string> GetDeprecated(
+      const std::string& package_name) const;
 
   /// Returns the package names in this PackageMap. The order of package names
   /// returned is unspecified.
@@ -93,6 +106,14 @@ class PackageMap final {
                                   const PackageMap& package_map);
 
  private:
+  // Information about a package.
+  struct PackageData {
+    // Directory in which the manifest resides.
+    std::string path;
+    // Optional message declaring deprecation of the package.
+    std::optional<std::string> deprecated_message;
+  };
+
   // A constructor that initializes a map by parsing a list of package.xml
   // file paths.
   PackageMap(std::initializer_list<std::string> manifest_paths);
@@ -119,9 +140,9 @@ class PackageMap final {
       const std::string& directory,
       const std::string& stop_at_directory);
 
-  // The key is the name of a ROS package and the value is the package's
-  // directory.
-  std::map<std::string, std::string> map_;
+  // The key is the name of a ROS package and the value is a struct containing
+  // information about that package.
+  std::map<std::string, struct PackageData> map_;
 };
 
 }  // namespace multibody

--- a/multibody/parsing/test/package_map_test.cc
+++ b/multibody/parsing/test/package_map_test.cc
@@ -291,6 +291,31 @@ GTEST_TEST(PackageMapTest, TestStreamingToString) {
             3);
 }
 
+// Tests that PackageMap is parsing deprecation messages
+GTEST_TEST(PackageMapTest, TestDeprecation) {
+  const
+  std::map<std::string, std::optional<std::string>> expected_deprecations = {
+    {
+      "package_map_test_package_b",
+      "package_map_test_package_b is deprecated, and will be removed on or "
+          "around 2038-01-19. Please use the 'drake' package instead."
+    },
+    {"package_map_test_package_d", ""},
+  };
+  const string root_path = GetTestDataRoot();
+  PackageMap package_map;
+  package_map.PopulateFromFolder(root_path);
+  for (const auto& package_name : package_map.GetPackageNames()) {
+    const auto expected_message = expected_deprecations.find(package_name);
+    if (expected_message != expected_deprecations.end()) {
+      EXPECT_EQ(package_map.GetDeprecated(package_name),
+                expected_message->second);
+    } else {
+      EXPECT_FALSE(package_map.GetDeprecated(package_name).has_value());
+    }
+  }
+}
+
 }  // namespace
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/parsing/test/package_map_test_packages/package_map_test_package_b/package.xml
+++ b/multibody/parsing/test/package_map_test_packages/package_map_test_package_b/package.xml
@@ -8,4 +8,10 @@
   <maintainer email="user@example.com">John Doe</maintainer>
   <author>Jane Doe</author>
   <license>N/A</license>
+  <export>
+    <deprecated>
+      package_map_test_package_b is deprecated, and will be removed on
+      or around 2038-01-19. Please use the 'drake' package instead.
+    </deprecated>
+  </export>
 </package>

--- a/multibody/parsing/test/package_map_test_packages/package_map_test_package_set/package_map_test_package_c/package.xml
+++ b/multibody/parsing/test/package_map_test_packages/package_map_test_package_set/package_map_test_package_c/package.xml
@@ -8,4 +8,5 @@
   <maintainer email="user@example.com">John Doe</maintainer>
   <author>Jane Doe</author>
   <license>N/A</license>
+  <export/>
 </package>

--- a/multibody/parsing/test/package_map_test_packages/package_map_test_package_set/package_map_test_package_d/package.xml
+++ b/multibody/parsing/test/package_map_test_packages/package_map_test_package_set/package_map_test_package_d/package.xml
@@ -8,4 +8,12 @@
   <maintainer email="user@example.com">John Doe</maintainer>
   <author>Jane Doe</author>
   <license>N/A</license>
+  <export>
+    <!--
+    Test empty tag to ensure we conform with REP 149.
+    Drake Developers should conform to normal deprecation messages.
+    See package_map_test_package_b for an example.
+    -->
+    <deprecated/>
+  </export>
 </package>


### PR DESCRIPTION
This change adds deprecation information to the package.xml manifests parsed in a `PackageMap`. In addition to adding the `IsDeprecated` function, the `GetPath` function now logs a warning when a deprecated manifest is used.

The motivation for this change is to deprecate many of the existing manifests throughout the source tree in favor of the top-level drake manifest. Rather than curating a static list of which manifests are deprecated, the manifests should now be able to express that they themselves are deprecated.

[REP 149](https://www.ros.org/reps/rep-0149.html#deprecated) describes the `deprecated` element details.

Towards #10531

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15896)
<!-- Reviewable:end -->
