### PR TITLE
[workspace] Upgrade meshcat and meshcat_python to latest commit

### DIFF
--- a/tools/workspace/meshcat/package.BUILD.bazel
+++ b/tools/workspace/meshcat/package.BUILD.bazel
@@ -4,10 +4,6 @@ load("@drake//tools/install:install.bzl", "install", "install_files")
 
 licenses(["notice"])  # MIT
 
-# TODO(jwnimmer-tri) The main.min.js embeds Three.js and possible other third-
-# party dependencies as well.  We probably need to install the transitive
-# licenses for those dependencies, since we are a derivative work.
-
 VIEWER_FILES = [
     "dist/index.html",
     "dist/main.min.js",
@@ -27,7 +23,11 @@ install_files(
 
 install(
     name = "install",
-    docs = ["LICENSE"],
+    docs = [
+        "LICENSE",
+        "dist/main.min.js.THIRD_PARTY_LICENSES.json",
+    ],
+    doc_strip_prefix = ["dist"],
     visibility = ["//visibility:public"],
     deps = [":install_viewer"],
 )

--- a/tools/workspace/meshcat/repository.bzl
+++ b/tools/workspace/meshcat/repository.bzl
@@ -11,8 +11,8 @@ def meshcat_repository(
         repository = "rdeits/meshcat",
         # Updating this commit requires local testing; see
         # drake/tools/workspace/meshcat/README.md for details.
-        commit = "06c6342adc4e7e69caa88125ba6a924a1507f9e5",
-        sha256 = "04d00ba8a8f9a8d457fba53c417bade53db9b02c7c7a4b13c518556b4abb34ff",  # noqa
+        commit = "675a312a2e91921d786fe83c49b492f02c1fc6c3",
+        sha256 = "ea05fad66d761284026c2396e79922164dc4ae28817705316783eeacbf345a08",  # noqa
         build_file = "@drake//tools/workspace/meshcat:package.BUILD.bazel",  # noqa
         mirrors = mirrors,
     )

--- a/tools/workspace/meshcat_python/repository.bzl
+++ b/tools/workspace/meshcat_python/repository.bzl
@@ -41,12 +41,12 @@ def _impl(repository_ctx):
 
     github_download_and_extract(
         repository_ctx,
-        "rdeits/meshcat-python",
+        repository = "rdeits/meshcat-python",
         # Updating this commit requires local testing; see
         # drake/tools/workspace/meshcat/README.md for details.
-        "17939622629d99b913e7c2a231ef6e414b84f528",
-        repository_ctx.attr.mirrors,
-        sha256 = "476e7543af4857aceb6d0508d942a5fba1a914caaa04ae5ccf5154c842e979e3",  # noqa
+        commit = "7f03547d68976004f721c320b17c7c2204b172e9",
+        mirrors = repository_ctx.attr.mirrors,
+        sha256 = "ed4c16265fbd437241d78a541b54ee60b0c1dfae1f4391dfe879595a43549f1a",  # noqa
     )
 
     repository_ctx.symlink(


### PR DESCRIPTION
Add install rule for meshcat webpack license notice that is newly available as of this commit.

In Bazel files always use kwargs (not positional args) so that `tools/workspace/new_release` can perform automatic upgrades.

Closes #15755.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15898)
<!-- Reviewable:end -->
