### PR TITLE
Removing VolumeVertex and SurfaceVertex

### DIFF
--- a/bindings/pydrake/geometry_py_hydro.cc
+++ b/bindings/pydrake/geometry_py_hydro.cc
@@ -25,26 +25,13 @@ void DoScalarDependentDefinitions(py::module m, T) {
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
   using namespace drake::geometry;
 
-  // SurfaceVertex
-  {
-    using Class = SurfaceVertex<T>;
-    auto cls = DefineTemplateClassWithDefault<Class>(
-        m, "SurfaceVertex", param, doc.SurfaceVertex.doc);
-    cls  // BR
-        .def(py::init<const Vector3<T>&>(), py::arg("r_MV"),
-            doc.SurfaceVertex.ctor.doc)
-        .def("r_MV", &Class::r_MV, py_rvp::reference_internal,
-            doc.SurfaceVertex.r_MV.doc);
-  }
-
   // SurfaceMesh
   {
     using Class = SurfaceMesh<T>;
     auto cls = DefineTemplateClassWithDefault<Class>(
         m, "SurfaceMesh", param, doc.SurfaceMesh.doc);
     cls  // BR
-        .def(
-            py::init<std::vector<SurfaceFace>, std::vector<SurfaceVertex<T>>>(),
+        .def(py::init<std::vector<SurfaceFace>, std::vector<Vector3<T>>>(),
             py::arg("faces"), py::arg("vertices"), doc.SurfaceMesh.ctor.doc)
         .def("faces", &Class::faces, doc.SurfaceMesh.faces.doc)
         .def("vertices", &Class::vertices, doc.SurfaceMesh.vertices.doc)
@@ -57,8 +44,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
     auto cls = DefineTemplateClassWithDefault<Class>(
         m, "VolumeMesh", param, doc.VolumeMesh.doc);
     cls  // BR
-        .def(py::init<std::vector<VolumeElement>,
-                 std::vector<VolumeVertex<T>>>(),
+        .def(py::init<std::vector<VolumeElement>, std::vector<Vector3<T>>>(),
             py::arg("elements"), py::arg("vertices"), doc.VolumeMesh.ctor.doc)
         .def("vertices", &Class::vertices, py_rvp::reference_internal,
             doc.VolumeMesh.vertices.doc)
@@ -67,18 +53,6 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("CalcTetrahedronVolume", &Class::CalcTetrahedronVolume,
             py::arg("e"), doc.VolumeMesh.CalcTetrahedronVolume.doc)
         .def("CalcVolume", &Class::CalcVolume, doc.VolumeMesh.CalcVolume.doc);
-  }
-
-  // VolumeVertex
-  {
-    using Class = VolumeVertex<T>;
-    auto cls = DefineTemplateClassWithDefault<Class>(
-        m, "VolumeVertex", param, doc.VolumeVertex.doc);
-    cls  // BR
-        .def(py::init<const Vector3<T>&>(), py::arg("r_MV"),
-            doc.VolumeVertex.ctor.doc_1args)
-        .def("r_MV", &Class::r_MV, py_rvp::reference_internal,
-            doc.VolumeVertex.r_MV.doc);
   }
 
   m.def("ConvertVolumeToSurfaceMesh", &ConvertVolumeToSurfaceMesh<T>,

--- a/bindings/pydrake/systems/meshcat_visualizer.py
+++ b/bindings/pydrake/systems/meshcat_visualizer.py
@@ -489,9 +489,9 @@ class MeshcatVisualizer(LeafSystem):
                     mesh_verts = surface_mesh.vertices()
                     v = 0
                     for face in surface_mesh.faces():
-                        p_MA = mesh_verts[int(face.vertex(0))].r_MV()
-                        p_MB = mesh_verts[int(face.vertex(1))].r_MV()
-                        p_MC = mesh_verts[int(face.vertex(2))].r_MV()
+                        p_MA = mesh_verts[int(face.vertex(0))]
+                        p_MB = mesh_verts[int(face.vertex(1))]
+                        p_MC = mesh_verts[int(face.vertex(2))]
                         vertices[v, :] = tuple(p_MA)
                         vertices[v + 1, :] = tuple(p_MB)
                         vertices[v + 2, :] = tuple(p_MC)

--- a/bindings/pydrake/systems/planar_scenegraph_visualizer.py
+++ b/bindings/pydrake/systems/planar_scenegraph_visualizer.py
@@ -283,7 +283,7 @@ class PlanarSceneGraphVisualizer(PyPlotVisualizer):
                     # Get mesh scaling.
                     scale = shape.scale()
                     mesh = ReadObjToSurfaceMesh(filename, scale)
-                    patch_G = np.vstack([v.r_MV() for v in mesh.vertices()])
+                    patch_G = np.vstack(mesh.vertices())
                     # Only store the vertices of the (3D) convex hull of the
                     # mesh, as any interior vertices will still be interior
                     # vertices after projection, and will therefore be removed

--- a/bindings/pydrake/test/geometry_hydro_test.py
+++ b/bindings/pydrake/test/geometry_hydro_test.py
@@ -74,12 +74,12 @@ class TestGeometryHydro(unittest.TestCase):
         self.assertEqual(f_a.vertex(0), 3)
         self.assertEqual(f_b.vertex(1), 1)
 
-        v0 = mut.SurfaceVertex((-1,  1, 0))
-        v1 = mut.SurfaceVertex((1,  1, 0))
-        v2 = mut.SurfaceVertex((-1, -1, 0))
-        v3 = mut.SurfaceVertex((1, -1, 0))
+        v0 = (-1,  1, 0)
+        v1 = (1,  1, 0)
+        v2 = (-1, -1, 0)
+        v3 = (1, -1, 0)
 
-        self.assertListEqual(list(v0.r_MV()), [-1, 1, 0])
+        self.assertListEqual(list(v0), [-1, 1, 0])
 
         mesh = mut.SurfaceMesh(faces=(f_a, f_b), vertices=(v0, v1, v2, v3))
         self.assertEqual(len(mesh.faces()), 2)
@@ -113,13 +113,13 @@ class TestGeometryHydro(unittest.TestCase):
         self.assertEqual(t_left.vertex(0), 2)
         self.assertEqual(t_right.vertex(1), 1)
 
-        v0 = mut.VolumeVertex((1, 0,  0))
-        v1 = mut.VolumeVertex((0, 0,  0))
-        v2 = mut.VolumeVertex((0, 1,  0))
-        v3 = mut.VolumeVertex((0, 0, 1))
-        v4 = mut.VolumeVertex((-1, 0,  0))
+        v0 = (1, 0,  0)
+        v1 = (0, 0,  0)
+        v2 = (0, 1,  0)
+        v3 = (0, 0, 1)
+        v4 = (-1, 0,  0)
 
-        self.assertListEqual(list(v0.r_MV()), [1, 0, 0])
+        self.assertListEqual(list(v0), [1, 0, 0])
 
         mesh = mut.VolumeMesh(elements=(t_left, t_right),
                               vertices=(v0, v1, v2, v3, v4))
@@ -127,7 +127,6 @@ class TestGeometryHydro(unittest.TestCase):
         self.assertEqual(len(mesh.tetrahedra()), 2)
         self.assertIsInstance(mesh.tetrahedra()[0], mut.VolumeElement)
         self.assertEqual(len(mesh.vertices()), 5)
-        self.assertIsInstance(mesh.vertices()[0], mut.VolumeVertex)
 
         self.assertAlmostEqual(
             mesh.CalcTetrahedronVolume(e=mut.VolumeElementIndex(1)),
@@ -146,11 +145,11 @@ class TestGeometryHydro(unittest.TestCase):
                                     v2=mut.VolumeVertexIndex(2),
                                     v3=mut.VolumeVertexIndex(0))
 
-        v0 = mut.VolumeVertex((1, 0,  0))
-        v1 = mut.VolumeVertex((0, 0,  0))
-        v2 = mut.VolumeVertex((0, 1,  0))
-        v3 = mut.VolumeVertex((0, 0, -1))
-        v4 = mut.VolumeVertex((-1, 0,  0))
+        v0 = (1, 0,  0)
+        v1 = (0, 0,  0)
+        v2 = (0, 1,  0)
+        v3 = (0, 0, -1)
+        v4 = (-1, 0,  0)
 
         volume_mesh = mut.VolumeMesh(elements=(t_left, t_right),
                                      vertices=(v0, v1, v2, v3, v4))
@@ -177,4 +176,4 @@ class TestGeometryHydro(unittest.TestCase):
             [-1.000000,  1.000000, -1.000000],
         ]
         for i, expected in enumerate(expected_vertices):
-            self.assertListEqual(list(vertices[i].r_MV()), expected)
+            self.assertListEqual(list(vertices[i]), expected)

--- a/examples/scene_graph/simple_contact_surface_vis.cc
+++ b/examples/scene_graph/simple_contact_surface_vis.cc
@@ -63,7 +63,6 @@ using geometry::SourceId;
 using geometry::Sphere;
 using geometry::SurfaceFaceIndex;
 using geometry::SurfaceMesh;
-using geometry::SurfaceVertex;
 using lcm::DrakeLcm;
 using math::RigidTransformd;
 using std::make_unique;
@@ -282,14 +281,14 @@ class ContactResultMaker final : public LeafSystem<double> {
 
         // Get the three vertices.
         const auto& face = mesh_W.element(j);
-        const SurfaceVertex<double>& vA = mesh_W.vertex(face.vertex(0));
-        const SurfaceVertex<double>& vB = mesh_W.vertex(face.vertex(1));
-        const SurfaceVertex<double>& vC = mesh_W.vertex(face.vertex(2));
+        const Vector3d& vA = mesh_W.vertex(face.vertex(0));
+        const Vector3d& vB = mesh_W.vertex(face.vertex(1));
+        const Vector3d& vC = mesh_W.vertex(face.vertex(2));
 
-        write_double3(vA.r_MV(), tri_msg.p_WA);
-        write_double3(vB.r_MV(), tri_msg.p_WB);
-        write_double3(vC.r_MV(), tri_msg.p_WC);
-        write_double3((vA.r_MV() + vB.r_MV() + vC.r_MV()) / 3.0, quad_msg.p_WQ);
+        write_double3(vA, tri_msg.p_WA);
+        write_double3(vB, tri_msg.p_WB);
+        write_double3(vC, tri_msg.p_WC);
+        write_double3((vA + vB + vC) / 3.0, quad_msg.p_WQ);
 
         tri_msg.pressure_A = field.EvaluateAtVertex(face.vertex(0));
         tri_msg.pressure_B = field.EvaluateAtVertex(face.vertex(1));

--- a/geometry/drake_visualizer.cc
+++ b/geometry/drake_visualizer.cc
@@ -121,7 +121,7 @@ lcmt_viewer_geometry_data MakeHydroMesh(GeometryId geometry_id,
     for (int fv = 0; fv < 3; ++fv) {
       const SurfaceVertexIndex v_i = face.vertex(fv);
       const Vector3<float> p_MV =
-          surface_mesh.vertex(v_i).r_MV().template cast<float>();
+          surface_mesh.vertex(v_i).template cast<float>();
       float_data[++v_index] = p_MV.x();
       float_data[++v_index] = p_MV.y();
       float_data[++v_index] = p_MV.z();

--- a/geometry/profiling/contact_surface_rigid_bowl_soft_ball.cc
+++ b/geometry/profiling/contact_surface_rigid_bowl_soft_ball.cc
@@ -70,7 +70,6 @@ using geometry::SourceId;
 using geometry::Sphere;
 using geometry::SurfaceMesh;
 using geometry::SurfaceFaceIndex;
-using geometry::SurfaceVertex;
 using lcm::DrakeLcm;
 using math::RigidTransformd;
 using std::make_unique;
@@ -291,13 +290,13 @@ class ContactResultMaker final : public LeafSystem<double> {
 
         // Get the three vertices.
         const auto& face = mesh_W.element(j);
-        const SurfaceVertex<double>& vA = mesh_W.vertex(face.vertex(0));
-        const SurfaceVertex<double>& vB = mesh_W.vertex(face.vertex(1));
-        const SurfaceVertex<double>& vC = mesh_W.vertex(face.vertex(2));
+        const Vector3d& vA = mesh_W.vertex(face.vertex(0));
+        const Vector3d& vB = mesh_W.vertex(face.vertex(1));
+        const Vector3d& vC = mesh_W.vertex(face.vertex(2));
 
-        write_double3(vA.r_MV(), tri_msg.p_WA);
-        write_double3(vB.r_MV(), tri_msg.p_WB);
-        write_double3(vC.r_MV(), tri_msg.p_WC);
+        write_double3(vA, tri_msg.p_WA);
+        write_double3(vB, tri_msg.p_WB);
+        write_double3(vC, tri_msg.p_WC);
 
         tri_msg.pressure_A = field.EvaluateAtVertex(face.vertex(0));
         tri_msg.pressure_B = field.EvaluateAtVertex(face.vertex(1));

--- a/geometry/proximity/aabb.cc
+++ b/geometry/proximity/aabb.cc
@@ -53,11 +53,11 @@ bool Aabb::HasOverlap(const Aabb& aabb_G, const Obb& obb_H,
 template <typename MeshType>
 Aabb AabbMaker<MeshType>::Compute() const {
   auto itr = vertices_.begin();
-  Vector3d max_bounds = convert_to_double(mesh_M_.vertex(*itr).r_MV());
+  Vector3d max_bounds = convert_to_double(mesh_M_.vertex(*itr));
   Vector3d min_bounds = max_bounds;
   ++itr;
   for (; itr != vertices_.end(); ++itr) {
-    const Vector3d& vertex = convert_to_double(mesh_M_.vertex(*itr).r_MV());
+    const Vector3d& vertex = convert_to_double(mesh_M_.vertex(*itr));
     // Compare its extent along each of the 3 axes.
     min_bounds = min_bounds.cwiseMin(vertex);
     max_bounds = max_bounds.cwiseMax(vertex);

--- a/geometry/proximity/bvh.cc
+++ b/geometry/proximity/bvh.cc
@@ -128,8 +128,7 @@ Vector3d Bvh<BvType, SourceMeshType>::ComputeCentroid(
   const auto& element = mesh.element(i);
   // Calculate average from all vertices.
   for (int v = 0; v < kElementVertexCount; ++v) {
-    const Vector3d& vertex =
-        convert_to_double(mesh.vertex(element.vertex(v)).r_MV());
+    const Vector3d& vertex = convert_to_double(mesh.vertex(element.vertex(v)));
     centroid += vertex;
   }
   centroid /= kElementVertexCount;

--- a/geometry/proximity/bvh_updater.h
+++ b/geometry/proximity/bvh_updater.h
@@ -64,31 +64,26 @@ class BvhUpdater {
   }
 
  private:
-  template <typename T>
-  using VertexType = typename MeshType::template VertexType<T>;
-
   // If the mesh type is already double-valued, simply return the mesh vertices.
-  static const std::vector<VertexType<double>>& GetMeshVertices(
-      const std::vector<VertexType<double>>& vertices) {
+  static const std::vector<Vector3<double>>& GetMeshVertices(
+      const std::vector<Vector3<double>>& vertices) {
     return vertices;
   }
 
   // If the mesh type is AutoDiffXd-valued, return double-valued vertices.
-  static const std::vector<VertexType<double>> GetMeshVertices(
-      const std::vector<VertexType<AutoDiffXd>>& vertices) {
-    std::vector<VertexType<double>> vertices_dbl;
+  static std::vector<Vector3<double>> GetMeshVertices(
+      const std::vector<Vector3<AutoDiffXd>>& vertices) {
+    std::vector<Vector3<double>> vertices_dbl;
     vertices_dbl.reserve(vertices.size());
     for (const auto& v : vertices) {
-      vertices_dbl.emplace_back(convert_to_double(v.r_MV()));
+      vertices_dbl.emplace_back(convert_to_double(v));
     }
     return vertices_dbl;
   }
 
   // Helper function to perform a bottom-up refit.
-  void UpdateRecursive(
-      typename Bvh<Aabb, MeshType>::NodeType* node,
-      const std::vector<typename MeshType::template VertexType<double>>&
-          vertices) {
+  void UpdateRecursive(typename Bvh<Aabb, MeshType>::NodeType* node,
+                       const std::vector<Vector3<double>>& vertices) {
     using Vector3d = Eigen::Vector3d;
     /* Intentionally uninitialized. */
     Vector3d lower, upper;
@@ -104,8 +99,7 @@ class BvhUpdater {
       for (int e = 0; e < num_elements; ++e) {
         const auto& element = mesh_.element(node->element_index(e));
         for (int i = 0; i < kElementVertexCount; ++i) {
-          const Vector3d& p_MV =
-              convert_to_double(vertices[element.vertex(i)].r_MV());
+          const Vector3d& p_MV = convert_to_double(vertices[element.vertex(i)]);
           lower = lower.cwiseMin(p_MV);
           upper = upper.cwiseMax(p_MV);
         }

--- a/geometry/proximity/contact_surface_utility.cc
+++ b/geometry/proximity/contact_surface_utility.cc
@@ -40,9 +40,9 @@ namespace {
   */
 template <typename T>
 void ThrowIfInvalidForCentroid(const char* prefix,
-                     const std::vector<SurfaceVertexIndex>& polygon,
-                     const Vector3<T>& n_F,
-                     const std::vector<SurfaceVertex<T>>& vertices_F) {
+                               const std::vector<SurfaceVertexIndex>& polygon,
+                               const Vector3<T>& n_F,
+                               const std::vector<Vector3<T>>& vertices_F) {
   // TODO(SeanCurtis-TRI): Consider also validating convexity.
 
   // First test for sufficient length.
@@ -79,7 +79,7 @@ void ThrowIfInvalidForCentroid(const char* prefix,
   const int v_count = static_cast<int>(polygon.size());
   A.resize(v_count, 4);
   for (int i = 0; i < v_count; ++i) {
-    const Vector3<T>& v = vertices_F[polygon[i]].r_MV();
+    const Vector3<T>& v = vertices_F[polygon[i]];
     A.block(i, 0, 1, 4) << v(0), v(1), v(2), 1;
   }
 
@@ -122,10 +122,9 @@ void ThrowIfInvalidForCentroid(const char* prefix,
 }  // namespace
 
 template <typename T>
-Vector3<T> CalcPolygonCentroid(
-    const std::vector<SurfaceVertexIndex>& polygon,
-    const Vector3<T>& n_F,
-    const std::vector<SurfaceVertex<T>>& vertices_F) {
+Vector3<T> CalcPolygonCentroid(const std::vector<SurfaceVertexIndex>& polygon,
+                               const Vector3<T>& n_F,
+                               const std::vector<Vector3<T>>& vertices_F) {
   // The position of the geometric centroid can be computed by decomposing the
   // polygon into triangles and performing an area-weighted average of each of
   // the triangle's centroids.
@@ -138,9 +137,7 @@ Vector3<T> CalcPolygonCentroid(
   using V = SurfaceVertexIndex;
 
   auto triangle_centroid = [&vertices_F](V v0, V v1, V v2) {
-    return (vertices_F[v0].r_MV() + vertices_F[v1].r_MV() +
-        vertices_F[v2].r_MV()) /
-        3;
+    return (vertices_F[v0] + vertices_F[v1] + vertices_F[v2]) / 3;
   };
 
   // Triangles get special treatment.
@@ -162,9 +159,9 @@ Vector3<T> CalcPolygonCentroid(
   // ∑(Aᵢ * centroidᵢ) / ∑Aᵢ = ∑(kAᵢ * centroidᵢ) / ∑kAᵢ, k != 0.
   // The value of k comes from the scale and orientation of n_F.
   auto triangle_weight = [&vertices_F, &n_F](V v0, V v1, V v2) {
-    const Vector3<T>& r_MV0 = vertices_F[v0].r_MV();
-    const Vector3<T>& r_MV1 = vertices_F[v1].r_MV();
-    const Vector3<T>& r_MV2 = vertices_F[v2].r_MV();
+    const Vector3<T>& r_MV0 = vertices_F[v0];
+    const Vector3<T>& r_MV1 = vertices_F[v1];
+    const Vector3<T>& r_MV2 = vertices_F[v2];
     return (r_MV1 - r_MV0).cross(r_MV2 - r_MV0).dot(n_F);
   };
 
@@ -188,7 +185,7 @@ Vector3<T> CalcPolygonCentroid(
     // could just *pick* one of the vertices.
     p_FC_accum = Vector3<T>::Zero();
     for (int i = 0; i < v_count; ++i) {
-      p_FC_accum += vertices_F[polygon[i]].r_MV();
+      p_FC_accum += vertices_F[polygon[i]];
     }
     total_weight = v_count;
   }
@@ -203,13 +200,7 @@ Vector3<T> CalcPolygonCentroid(const std::vector<Vector3<T>>& p_FVs,
   std::vector<SurfaceVertexIndex> polygon(num_vertices);
   std::iota(polygon.begin(), polygon.end(), SurfaceVertexIndex(0));
 
-  std::vector<SurfaceVertex<T>> vertices_F;
-  std::transform(p_FVs.begin(), p_FVs.end(), std::back_inserter(vertices_F),
-                 [](const Vector3<T>& p_FV) -> SurfaceVertex<T> {
-                   return SurfaceVertex(p_FV);
-                 });
-
-  return CalcPolygonCentroid(polygon, n_F, vertices_F);
+  return CalcPolygonCentroid(polygon, n_F, p_FVs);
 }
 
 template <typename T>
@@ -237,11 +228,10 @@ T CalcPolygonArea(const std::vector<Vector3<T>>& p_FVs,
 }
 
 template <typename T>
-void AddPolygonToMeshData(
-    const std::vector<SurfaceVertexIndex>& polygon,
-    const Vector3<T>& n_F,
-    std::vector<SurfaceFace>* faces,
-    std::vector<SurfaceVertex<T>>* vertices_F) {
+void AddPolygonToMeshData(const std::vector<SurfaceVertexIndex>& polygon,
+                          const Vector3<T>& n_F,
+                          std::vector<SurfaceFace>* faces,
+                          std::vector<Vector3<T>>* vertices_F) {
   DRAKE_DEMAND(faces != nullptr);
   DRAKE_DEMAND(vertices_F != nullptr);
   DRAKE_DEMAND(polygon.size() >= 3);
@@ -268,10 +258,10 @@ void AddPolygonToMeshData(
 }
 
 template <typename T>
-void AddPolygonToMeshDataAsOneTriangle(
-    const std::vector<Vector3<T>>& polygon_F, const Vector3<T>& nhat_F,
-    std::vector<SurfaceFace>* faces,
-    std::vector<SurfaceVertex<T>>* vertices_F) {
+void AddPolygonToMeshDataAsOneTriangle(const std::vector<Vector3<T>>& polygon_F,
+                                       const Vector3<T>& nhat_F,
+                                       std::vector<SurfaceFace>* faces,
+                                       std::vector<Vector3<T>>* vertices_F) {
   DRAKE_DEMAND(faces != nullptr);
   DRAKE_DEMAND(vertices_F != nullptr);
   DRAKE_DEMAND(polygon_F.size() >= 3);
@@ -362,7 +352,7 @@ DRAKE_DEFINE_FUNCTION_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS((
     static_cast<Vector3<T>(*)(
        const std::vector<SurfaceVertexIndex>&,
        const Vector3<T>&,
-       const std::vector<SurfaceVertex<T>>&)>(&CalcPolygonCentroid),
+       const std::vector<Vector3<T>>&)>(&CalcPolygonCentroid),
     /* Use static_cast to disambiguate the two different overloads. */
     static_cast<Vector3<T>(*)(
        const std::vector<Vector3<T>>&,

--- a/geometry/proximity/contact_surface_utility.h
+++ b/geometry/proximity/contact_surface_utility.h
@@ -39,10 +39,9 @@ namespace internal {
  @tparam_nonsymbolic_scalar
  */
 template <typename T>
-Vector3<T> CalcPolygonCentroid(
-    const std::vector<SurfaceVertexIndex>& polygon,
-    const Vector3<T>& n_F,
-    const std::vector<SurfaceVertex<T>>& vertices_F);
+Vector3<T> CalcPolygonCentroid(const std::vector<SurfaceVertexIndex>& polygon,
+                               const Vector3<T>& n_F,
+                               const std::vector<Vector3<T>>& vertices_F);
 
 // TODO(14579) This overload of CalcPolygonCentroid() is expected to simply go
 //  away when we implement the final support for discrete hydroelastics. If it
@@ -109,11 +108,10 @@ T CalcPolygonArea(const std::vector<Vector3<T>>& p_FVs,
  @pre `n_F` has non-trivial length.
  @tparam_nonsymbolic_scalar */
 template <typename T>
-void AddPolygonToMeshData(
-    const std::vector<SurfaceVertexIndex>& polygon,
-    const Vector3<T>& n_F,
-    std::vector<SurfaceFace>* faces,
-    std::vector<SurfaceVertex<T>>* vertices_F);
+void AddPolygonToMeshData(const std::vector<SurfaceVertexIndex>& polygon,
+                          const Vector3<T>& n_F,
+                          std::vector<SurfaceFace>* faces,
+                          std::vector<Vector3<T>>* vertices_F);
 
 // Any polygon with area less than this threshold is considered having
 // near-zero area in AddPolygonToMeshDataAsOneTriangle() below.
@@ -165,7 +163,7 @@ constexpr double kMinimumPolygonArea = 1e-13;
 template <typename T>
 void AddPolygonToMeshDataAsOneTriangle(
     const std::vector<Vector3<T>>& polygon_F, const Vector3<T>& nhat_F,
-    std::vector<SurfaceFace>* faces, std::vector<SurfaceVertex<T>>* vertices_F);
+    std::vector<SurfaceFace>* faces, std::vector<Vector3<T>>* vertices_F);
 
 enum class ContactPolygonRepresentation {
   // Each contact polygon is subdivided into triangles sharing the centroid

--- a/geometry/proximity/make_box_field.cc
+++ b/geometry/proximity/make_box_field.cc
@@ -35,9 +35,7 @@ VolumeMeshFieldLinear<T, T> MakeBoxPressureField(
 
   std::vector<T> pressure_values;
   pressure_values.reserve(mesh_B->num_vertices());
-  for (const VolumeVertex<T>& vertex : mesh_B->vertices()) {
-    // V is a vertex of the mesh of the box with frame B.
-    const Vector3<T>& r_BV = vertex.r_MV();
+  for (const Vector3<T>& r_BV : mesh_B->vertices()) {
     // N is for the nearest point of V on the boundary of the box,
     // and grad_B is the gradient vector of the signed distance function
     // of the box at V, expressed in frame B.

--- a/geometry/proximity/make_box_mesh.cc
+++ b/geometry/proximity/make_box_mesh.cc
@@ -194,7 +194,7 @@ VolumeMesh<T> MakeBoxVolumeMeshWithMa(const Box& box) {
   // The mesh vertices comprise the eight box vertices and up to four unique
   // MA's vertices inside the box. Later each virtual frustum will comprise
   // eight (possibly with duplication) indices into mesh_vertices.
-  std::vector<VolumeVertex<T>> mesh_vertices;
+  std::vector<Vector3<T>> mesh_vertices;
   mesh_vertices.reserve(12);
 
   // The eight mesh vertices of the box are indexed by the 2x2x2 array `v`,
@@ -340,7 +340,7 @@ int CalcSequentialIndex(int i, int j, int k, const Vector3<int>& num_vertices) {
 }
 
 template <typename T>
-std::vector<VolumeVertex<T>> GenerateVertices(
+std::vector<Vector3<T>> GenerateVertices(
     const Box& box, const Vector3<int>& num_vertices) {
   const T half_x = box.width() / T(2);
   const T half_y = box.depth() / T(2);
@@ -352,7 +352,7 @@ std::vector<VolumeVertex<T>> GenerateVertices(
   const auto z_coords =
       VectorX<T>::LinSpaced(num_vertices.z(), -half_z, half_z);
 
-  std::vector<VolumeVertex<T>> vertices;
+  std::vector<Vector3<T>> vertices;
   vertices.reserve(num_vertices.x() * num_vertices.y() * num_vertices.z());
   // The order of nested i-loop, j-loop, then k-loop makes the sequence of
   // vertices consistent with CalcSequentialIndex.
@@ -446,8 +446,7 @@ VolumeMesh<T> MakeBoxVolumeMesh(const Box& box, double resolution_hint) {
       1 + static_cast<int>(ceil(box.depth() / resolution_hint)),
       1 + static_cast<int>(ceil(box.height() / resolution_hint))};
 
-  std::vector<VolumeVertex<T>> vertices =
-      GenerateVertices<T>(box, num_vertices);
+  std::vector<Vector3<T>> vertices = GenerateVertices<T>(box, num_vertices);
 
   std::vector<VolumeElement> elements = GenerateElements(num_vertices);
 

--- a/geometry/proximity/make_box_mesh.h
+++ b/geometry/proximity/make_box_mesh.h
@@ -251,8 +251,8 @@ int CalcSequentialIndex(int i, int j, int k, const Vector3<int>& num_vertices);
      The linear sequence of vertices consistent with CalcSequentialIndex.
  */
 template <typename T>
-std::vector<VolumeVertex<T>> GenerateVertices(
-    const Box& box, const Vector3<int>& num_vertices);
+std::vector<Vector3<T>> GenerateVertices(const Box& box,
+                                         const Vector3<int>& num_vertices);
 
 /*
  Adds six tetrahedra of a given rectangular cell to the list of tetrahedral

--- a/geometry/proximity/make_capsule_field.h
+++ b/geometry/proximity/make_capsule_field.h
@@ -52,9 +52,9 @@ VolumeMeshFieldLinear<T, T> MakeCapsulePressureField(
   // We only partially check the precondition of the mesh (see @pre). The first
   // two vertices should always be the endpoints of the capsule's medial axis.
   // The first with positive z and the second with negative z.
-  DRAKE_DEMAND(mesh_C->vertex(VolumeVertexIndex(0)).r_MV() ==
+  DRAKE_DEMAND(mesh_C->vertex(VolumeVertexIndex(0)) ==
                Eigen::Vector3d(0, 0, capsule.length() / 2));
-  DRAKE_DEMAND(mesh_C->vertex(VolumeVertexIndex(1)).r_MV() ==
+  DRAKE_DEMAND(mesh_C->vertex(VolumeVertexIndex(1)) ==
                Eigen::Vector3d(0, 0, -capsule.length() / 2));
 
   std::vector<T> pressure_values(mesh_C->num_vertices(), 0.0);

--- a/geometry/proximity/make_capsule_mesh.cc
+++ b/geometry/proximity/make_capsule_mesh.cc
@@ -43,7 +43,7 @@ VolumeMesh<T> MakeCapsuleVolumeMesh(const Capsule& capsule,
   // to subdivide each cap into.
   const int num_circles_per_cap = num_vertices_per_circle / 2;
 
-  std::vector<VolumeVertex<T>> mesh_vertices;
+  std::vector<Vector3<T>> mesh_vertices;
   // 2 caps * number of circles per cap * number of verts per circle
   // + the two medial vertices and the two cap pole vertices.
   mesh_vertices.reserve(2 * num_circles_per_cap * num_vertices_per_circle + 4);

--- a/geometry/proximity/make_cylinder_field.cc
+++ b/geometry/proximity/make_cylinder_field.cc
@@ -46,9 +46,9 @@ VolumeMeshFieldLinear<T, T> MakeCylinderPressureField(
   const GeometryId unused_id;
   const auto identity = math::RigidTransform<T>::Identity();
   const fcl::Cylinderd fcl_cylinder(radius, length);
-  for (const VolumeVertex<T>& vertex : mesh_C->vertices()) {
+  for (const Vector3<T>& vertex : mesh_C->vertices()) {
     // V is a vertex of the cylinder mesh with frame C.
-    const Vector3<T>& r_CV = vertex.r_MV();
+    const Vector3<T>& r_CV = vertex;
     point_distance::DistanceToPoint<T> signed_distance_functor(
         unused_id, identity, r_CV);
     const T signed_distance = signed_distance_functor(fcl_cylinder).distance;

--- a/geometry/proximity/make_cylinder_mesh.cc
+++ b/geometry/proximity/make_cylinder_mesh.cc
@@ -44,7 +44,7 @@ std::vector<VolumeElement> CalcLongCylinderVolumeMeshWithMa(
     const std::vector<VolumeVertexIndex>& bottom,
     const VolumeVertexIndex top_center,
     const std::vector<VolumeVertexIndex>& top,
-    std::vector<VolumeVertex<T>>* mesh_vertices) {
+    std::vector<Vector3<T>>* mesh_vertices) {
   const double top_z = cylinder.length() / 2.;
   const double tolerance =
       DistanceToPointRelativeTolerance(std::min(top_z, cylinder.radius()));
@@ -154,7 +154,7 @@ std::vector<VolumeElement> CalcMediumCylinderVolumeMeshWithMa(
     const std::vector<VolumeVertexIndex>& bottom,
     const VolumeVertexIndex top_center,
     const std::vector<VolumeVertexIndex>& top,
-    std::vector<VolumeVertex<T>>* mesh_vertices) {
+    std::vector<Vector3<T>>* mesh_vertices) {
   const double top_z = cylinder.length() / 2.;
   const double tolerance =
       DistanceToPointRelativeTolerance(std::min(top_z, cylinder.radius()));
@@ -252,7 +252,7 @@ std::vector<VolumeElement> CalcShortCylinderVolumeMeshWithMa(
     const std::vector<VolumeVertexIndex>& bottom,
     const VolumeVertexIndex top_center,
     const std::vector<VolumeVertexIndex>& top,
-    std::vector<VolumeVertex<T>>* mesh_vertices) {
+    std::vector<Vector3<T>>* mesh_vertices) {
   const double top_z = cylinder.length() / 2.;
   const double tolerance =
       DistanceToPointRelativeTolerance(std::min(top_z, cylinder.radius()));
@@ -277,10 +277,10 @@ std::vector<VolumeElement> CalcShortCylinderVolumeMeshWithMa(
       medial_radius / cylinder.radius();
   for (int i = 0; i < num_vertices_per_circle; ++i) {
     const double x =
-        ExtractDoubleOrThrow(mesh_vertices->at(bottom[i]).r_MV().x()) *
+        ExtractDoubleOrThrow(mesh_vertices->at(bottom[i]).x()) *
         scale_cylinder_radius_to_medial_circle;
     const double y =
-        ExtractDoubleOrThrow(mesh_vertices->at(bottom[i]).r_MV().y()) *
+        ExtractDoubleOrThrow(mesh_vertices->at(bottom[i]).y()) *
         scale_cylinder_radius_to_medial_circle;
     medial[i] = VolumeVertexIndex(mesh_vertices->size());
     mesh_vertices->emplace_back(x, y, 0);
@@ -371,7 +371,7 @@ VolumeMesh<T> MakeCylinderVolumeMeshWithMa(const Cylinder& cylinder,
       3,
       static_cast<int>(ceil(2. * M_PI * cylinder.radius() / resolution_hint)));
 
-  std::vector<VolumeVertex<T>> mesh_vertices;
+  std::vector<Vector3<T>> mesh_vertices;
   switch (cylinder_class) {
     case CylinderClass::kLong:
       mesh_vertices.reserve(2 * num_vertices_per_circle + 4);

--- a/geometry/proximity/make_cylinder_mesh.h
+++ b/geometry/proximity/make_cylinder_mesh.h
@@ -245,7 +245,7 @@ Vector3<T> ProjectMidPoint(const Vector3<T>& x, const Vector3<T>& y,
 template <typename T>
 VolumeVertexIndex CreateNewVertex(
     VolumeVertexIndex a, VolumeVertexIndex b,
-    std::vector<VolumeVertex<T>>* split_mesh_vertices_ptr,
+    std::vector<Vector3<T>>* split_mesh_vertices_ptr,
     std::vector<CylinderVertexType>* split_vertex_type_ptr,
     std::unordered_map<SortedPair<VolumeVertexIndex>, VolumeVertexIndex>*
         vertex_map_ptr,
@@ -254,7 +254,7 @@ VolumeVertexIndex CreateNewVertex(
   DRAKE_DEMAND(split_vertex_type_ptr != nullptr);
   DRAKE_DEMAND(vertex_map_ptr != nullptr);
 
-  std::vector<VolumeVertex<T>>& split_mesh_vertices = *split_mesh_vertices_ptr;
+  std::vector<Vector3<T>>& split_mesh_vertices = *split_mesh_vertices_ptr;
   std::vector<CylinderVertexType>& split_vertex_type = *split_vertex_type_ptr;
   std::unordered_map<SortedPair<VolumeVertexIndex>, VolumeVertexIndex>&
       vertex_map = *vertex_map_ptr;
@@ -262,8 +262,8 @@ VolumeVertexIndex CreateNewVertex(
   const CylinderVertexType p_vertex_type =
       std::min(split_vertex_type[a], split_vertex_type[b]);
 
-  const Vector3<T>& A = split_mesh_vertices[a].r_MV();
-  const Vector3<T>& B = split_mesh_vertices[b].r_MV();
+  const Vector3<T>& A = split_mesh_vertices[a];
+  const Vector3<T>& B = split_mesh_vertices[b];
 
   const Vector3<T> p = ProjectMidPoint(A, B, p_vertex_type, radius);
 
@@ -294,7 +294,7 @@ VolumeVertexIndex CreateNewVertex(
 template <typename T>
 void RefineCylinderTetrahdron(
     const VolumeElement& tet,
-    std::vector<VolumeVertex<T>>* split_mesh_vertices_ptr,
+    std::vector<Vector3<T>>* split_mesh_vertices_ptr,
     std::vector<VolumeElement>* split_mesh_tetrahedra_ptr,
     std::vector<CylinderVertexType>* split_vertex_type_ptr,
     std::unordered_map<SortedPair<VolumeVertexIndex>, VolumeVertexIndex>*
@@ -305,7 +305,7 @@ void RefineCylinderTetrahdron(
   DRAKE_DEMAND(split_vertex_type_ptr != nullptr);
   DRAKE_DEMAND(vertex_map_ptr != nullptr);
 
-  std::vector<VolumeVertex<T>>& split_mesh_vertices = *split_mesh_vertices_ptr;
+  std::vector<Vector3<T>>& split_mesh_vertices = *split_mesh_vertices_ptr;
   std::vector<CylinderVertexType>& split_vertex_type = *split_vertex_type_ptr;
   std::vector<VolumeElement>& split_mesh_tetrahedra =
       *split_mesh_tetrahedra_ptr;
@@ -383,7 +383,7 @@ std::pair<VolumeMesh<T>, std::vector<CylinderVertexType>> RefineCylinderMesh(
     const std::vector<CylinderVertexType>& vertex_type, const double radius) {
   // Copy the vertex, and boundary information into the vectors for the
   // new subdivided mesh
-  std::vector<VolumeVertex<T>> split_mesh_vertices = mesh.vertices();
+  std::vector<Vector3<T>> split_mesh_vertices = mesh.vertices();
   std::vector<CylinderVertexType> split_vertex_type = vertex_type;
 
   // Original tets are all subdivied, so split_mesh_tetrahedra will only
@@ -413,7 +413,7 @@ template <typename T>
 std::pair<VolumeMesh<T>, std::vector<CylinderVertexType>>
 MakeCylinderMeshLevel0(const double& height, const double& radius) {
   std::vector<VolumeElement> tetrahedra;
-  std::vector<VolumeVertex<T>> vertices;
+  std::vector<Vector3<T>> vertices;
 
   // Initial subdivisions along the length of the cylinder are made based on
   // the aspect ratio so that, for a long cylinder, initial tetrahedra are

--- a/geometry/proximity/make_ellipsoid_field.h
+++ b/geometry/proximity/make_ellipsoid_field.h
@@ -66,9 +66,7 @@ VolumeMeshFieldLinear<T, T> MakeEllipsoidPressureField(
   // rounding errors. We will treat their near-zero extent as exactly zero
   // extent.
   const T kExtentEpsilon = 1e-14;
-  for (const VolumeVertex<T>& vertex : mesh_E->vertices()) {
-    // V is a vertex of the ellipsoid mesh with frame E.
-    const Vector3<T>& r_EV = vertex.r_MV();
+  for (const Vector3<T>& r_EV : mesh_E->vertices()) {
     // Scale V in the ellipsoid to U in the unit sphere.
     const Vector3<T> r_EU = scale.cwiseProduct(r_EV);
     T extent = T(1.0) - r_EU.norm();

--- a/geometry/proximity/make_ellipsoid_mesh.h
+++ b/geometry/proximity/make_ellipsoid_mesh.h
@@ -62,10 +62,10 @@ VolumeMesh<T> MakeEllipsoidVolumeMesh(const Ellipsoid& ellipsoid,
       MakeSphereVolumeMesh<T>(Sphere(1.0), unit_sphere_resolution, strategy);
 
   const Vector3<T> scale{a, b, c};
-  std::vector<VolumeVertex<T>> vertices;
+  std::vector<Vector3<T>> vertices;
   vertices.reserve(unit_sphere_mesh.num_vertices());
   for (const auto& sphere_vertex : unit_sphere_mesh.vertices()) {
-    vertices.emplace_back(scale.cwiseProduct(sphere_vertex.r_MV()));
+    vertices.emplace_back(scale.cwiseProduct(sphere_vertex));
   }
   std::vector<VolumeElement> tetrahedra = unit_sphere_mesh.tetrahedra();
 

--- a/geometry/proximity/make_sphere_field.h
+++ b/geometry/proximity/make_sphere_field.h
@@ -54,9 +54,7 @@ VolumeMeshFieldLinear<T, T> MakeSpherePressureField(const Sphere& sphere,
   // vertices do not lie exactly on the surface of the sphere due to rounding
   // errors. We will treat their near-zero extent as exactly zero extent.
   const T kExtentEpsilon = 1e-14;
-  for (const VolumeVertex<T>& vertex : mesh_S->vertices()) {
-    // V is a vertex of the mesh of the sphere with frame S.
-    const Vector3<T>& r_SV = vertex.r_MV();
+  for (const Vector3<T>& r_SV : mesh_S->vertices()) {
     T extent = T(1.0) - r_SV.norm() / radius;
     if (extent < kExtentEpsilon) {
       extent = T(0.0);

--- a/geometry/proximity/mesh_deformer.cc
+++ b/geometry/proximity/mesh_deformer.cc
@@ -19,8 +19,7 @@ void MeshDeformer<MeshType>::SetAllPositions(
         mesh_.num_vertices(), p_MVs.size()));
   }
   for (int v = 0, i = 0; v < mesh_.num_vertices(); ++v, i += 3) {
-    mesh_.vertices_[v] =
-        VertexType(Vector3<T>(p_MVs[i], p_MVs[i + 1], p_MVs[i + 2]));
+    mesh_.vertices_[v] = Vector3<T>(p_MVs[i], p_MVs[i + 1], p_MVs[i + 2]);
   }
 }
 

--- a/geometry/proximity/mesh_deformer.h
+++ b/geometry/proximity/mesh_deformer.h
@@ -57,8 +57,6 @@ class MeshDeformer {
   void SetAllPositions(const Eigen::Ref<const VectorX<T>>& p_MVs);
 
  private:
-  using VertexType = typename MeshType::template VertexType<T>;
-
   MeshType& mesh_;
 };
 

--- a/geometry/proximity/mesh_field_linear.h
+++ b/geometry/proximity/mesh_field_linear.h
@@ -323,7 +323,7 @@ class MeshFieldLinear {
   T CalcValueAtMeshOrigin(typename MeshType::ElementIndex e) const {
     DRAKE_DEMAND(e < gradients_.size());
     const typename MeshType::VertexIndex v0 = this->mesh().element(e).vertex(0);
-    const Vector3<T>& p_MV0 = this->mesh().vertex(v0).r_MV();
+    const Vector3<T>& p_MV0 = this->mesh().vertex(v0);
     // f(V₀) = ∇fᵉ⋅p_MV₀ + fᵉ(Mo)
     // fᵉ(Mo) = f(V₀) - ∇fᵉ⋅p_MV₀
     return values_[v0] - gradients_[e].dot(p_MV0);

--- a/geometry/proximity/mesh_half_space_intersection.h
+++ b/geometry/proximity/mesh_half_space_intersection.h
@@ -86,7 +86,7 @@ void ConstructTriangleHalfspaceIntersectionPolygon(
     const SurfaceMesh<double>& mesh_F, SurfaceFaceIndex tri_index,
     const PosedHalfSpace<T>& half_space_F, const math::RigidTransform<T>& X_WF,
     ContactPolygonRepresentation representation,
-    std::vector<SurfaceVertex<T>>* new_vertices_W,
+    std::vector<Vector3<T>>* new_vertices_W,
     std::vector<SurfaceFace>* new_faces,
     std::unordered_map<SurfaceVertexIndex, SurfaceVertexIndex>*
         vertices_to_newly_created_vertices,

--- a/geometry/proximity/mesh_intersection.cc
+++ b/geometry/proximity/mesh_intersection.cc
@@ -204,9 +204,7 @@ SurfaceVolumeIntersector<T>::ClipTriangleByTetrahedron(
   polygon_M->clear();
   for (int i = 0; i < 3; ++i) {
     SurfaceVertexIndex v = surface_N.element(face).vertex(i);
-    // TODO(SeanCurtis-TRI): The `M` in `r_MV()` is different from the M in this
-    //  function. More evidence that the `vertex(v).r_MV()` notation is *bad*.
-    const Vector3<T>& p_NV = surface_N.vertex(v).r_MV().cast<T>();
+    const Vector3<T>& p_NV = surface_N.vertex(v).cast<T>();
     polygon_M->push_back(X_MN * p_NV);
   }
   // Get the positions, in M's frame, of the four vertices of the tetrahedral
@@ -216,7 +214,7 @@ SurfaceVolumeIntersector<T>::ClipTriangleByTetrahedron(
   Vector3<double> p_MVs[4];
   for (int i = 0; i < 4; ++i) {
     VolumeVertexIndex v = volume_M.element(element).vertex(i);
-    p_MVs[i] = volume_M.vertex(v).r_MV();
+    p_MVs[i] = volume_M.vertex(v);
   }
   // Sets up the four half spaces associated with the four triangular faces of
   // the tetrahedron. Assume the tetrahedron has the fourth vertex seeing the
@@ -308,7 +306,7 @@ void SurfaceVolumeIntersector<T>::SampleVolumeFieldOnSurface(
   grad_eM_Ms->clear();
 
   std::vector<SurfaceFace> surface_faces;
-  std::vector<SurfaceVertex<T>> surface_vertices_M;
+  std::vector<Vector3<T>> surface_vertices_M;
   std::vector<T> surface_e;
   const VolumeMesh<double>& mesh_M = volume_field_M.mesh();
   // We know that each contact polygon has at most 7 vertices because
@@ -380,7 +378,7 @@ void SurfaceVolumeIntersector<T>::SampleVolumeFieldOnSurface(
     const int num_current_vertices = surface_vertices_M.size();
     // Calculate values of the pressure field at the new vertices.
     for (int v = num_previous_vertices; v < num_current_vertices; ++v) {
-      const Vector3<T>& r_MV = surface_vertices_M[v].r_MV();
+      const Vector3<T>& r_MV = surface_vertices_M[v];
       const T pressure = volume_field_M.EvaluateCartesian(tet_index, r_MV);
       surface_e.push_back(pressure);
     }

--- a/geometry/proximity/mesh_plane_intersection.cc
+++ b/geometry/proximity/mesh_plane_intersection.cc
@@ -68,7 +68,7 @@ void SliceTetWithPlane(VolumeElementIndex tet_index,
                        const math::RigidTransform<T>& X_WM,
                        ContactPolygonRepresentation representation,
                        std::vector<SurfaceFace>* faces,
-                       std::vector<SurfaceVertex<T>>* vertices_W,
+                       std::vector<Vector3<T>>* vertices_W,
                        std::vector<T>* surface_e,
                        std::unordered_map<SortedPair<VolumeVertexIndex>,
                                           SurfaceVertexIndex>* cut_edges) {
@@ -79,7 +79,7 @@ void SliceTetWithPlane(VolumeElementIndex tet_index,
   int intersection_code = 0;
   for (int i = 0; i < 4; ++i) {
     const VolumeVertexIndex v = mesh_M.element(tet_index).vertex(i);
-    distance[i] = plane_M.CalcHeight(mesh_M.vertex(v).r_MV());
+    distance[i] = plane_M.CalcHeight(mesh_M.vertex(v));
     if (distance[i] > T(0)) intersection_code |= 1 << i;
   }
 
@@ -117,8 +117,8 @@ void SliceTetWithPlane(VolumeElementIndex tet_index,
       // Need to compute the result; but we already know that this edge
       // intersects the plane based on the signed distances of its two
       // vertices.
-      const Vector3<double>& p_MV0 = mesh_M.vertex(v0).r_MV();
-      const Vector3<double>& p_MV1 = mesh_M.vertex(v1).r_MV();
+      const Vector3<double>& p_MV0 = mesh_M.vertex(v0);
+      const Vector3<double>& p_MV1 = mesh_M.vertex(v1);
       const T d_v0 = distance[tet_edge.first];
       const T d_v1 = distance[tet_edge.second];
       // Note: It should be impossible for the denominator to be zero. By
@@ -165,7 +165,7 @@ void SliceTetWithPlane(VolumeElementIndex tet_index,
     }
   }
   for (size_t v = before; v < vertices_W->size(); ++v) {
-    const Vector3<T> p_MV = X_WM.inverse() * vertices_W->at(v).r_MV();
+    const Vector3<T> p_MV = X_WM.inverse() * vertices_W->at(v);
     surface_e->emplace_back(field_M.EvaluateCartesian(tet_index, p_MV));
   }
 }
@@ -181,7 +181,7 @@ std::unique_ptr<ContactSurface<T>> ComputeContactSurface(
   if (tet_indices.size() == 0) return nullptr;
 
   std::vector<SurfaceFace> faces;
-  std::vector<SurfaceVertex<T>> vertices_W;
+  std::vector<Vector3<T>> vertices_W;
   std::vector<T> surface_e;
   std::unordered_map<SortedPair<VolumeVertexIndex>, SurfaceVertexIndex>
       cut_edges;

--- a/geometry/proximity/mesh_plane_intersection.h
+++ b/geometry/proximity/mesh_plane_intersection.h
@@ -87,7 +87,7 @@ void SliceTetWithPlane(VolumeElementIndex tet_index,
                        const math::RigidTransform<T>& X_WM,
                        ContactPolygonRepresentation representation,
                        std::vector<SurfaceFace>* faces,
-                       std::vector<SurfaceVertex<T>>* vertices_W,
+                       std::vector<Vector3<T>>* vertices_W,
                        std::vector<T>* surface_e,
                        std::unordered_map<SortedPair<VolumeVertexIndex>,
                                           SurfaceVertexIndex>* cut_edges);

--- a/geometry/proximity/mesh_to_vtk.cc
+++ b/geometry/proximity/mesh_to_vtk.cc
@@ -30,10 +30,9 @@ void WriteVtkUnstructuredGrid(std::ofstream& out, const Mesh& mesh) {
   const int num_points = mesh.num_vertices();
   out << "DATASET UNSTRUCTURED_GRID\n";
   out << "POINTS " << num_points << " double\n";
-  for (typename Mesh::VertexIndex i(0); i < num_points; ++i) {
-    const Vector3<double>& vertex = mesh.vertex(i).r_MV();
-    out << fmt::format("{:12.8f} {:12.8f} {:12.8f}\n", vertex[0], vertex[1],
-                       vertex[2]);
+  for (const Vector3<double> p_MV : mesh.vertices()) {
+    out << fmt::format("{:12.8f} {:12.8f} {:12.8f}\n", p_MV.x(), p_MV.y(),
+                       p_MV.z());
   }
   out << std::endl;
 

--- a/geometry/proximity/obb.cc
+++ b/geometry/proximity/obb.cc
@@ -169,13 +169,13 @@ RotationMatrixd ObbMaker<MeshType>::CalcOrientationByPca() const {
   // C is for centroid.
   Vector3d p_MC = Vector3d::Zero();
   for (typename MeshType::VertexIndex v : vertices_) {
-    p_MC += convert_to_double(mesh_M_.vertex(v).r_MV());
+    p_MC += convert_to_double(mesh_M_.vertex(v));
   }
   p_MC *= one_over_n;
 
   Matrix3d covariance_M = Matrix3d::Zero();
   for (typename MeshType::VertexIndex v : vertices_) {
-    const Vector3d& p_MV = convert_to_double(mesh_M_.vertex(v).r_MV());
+    const Vector3d& p_MV = convert_to_double(mesh_M_.vertex(v));
     const Vector3d p_CV_M = p_MV - p_MC;
     // covariance_M is a symmetric matrix because it's a sum of the
     // 3x3 symmetric matrices V*Vᵀ of column vectors V.
@@ -269,7 +269,7 @@ Obb ObbMaker<MeshType>::CalcOrientedBox(const RotationMatrixd& R_MB) const {
   for (typename MeshType::VertexIndex v : vertices_) {
     // Since frame F is a rotation of frame M with the same origin, we can use
     // the rotation R_FM for the transform X_FM.
-    const Vector3d p_FV = R_FM * convert_to_double(mesh_M_.vertex(v).r_MV());
+    const Vector3d p_FV = R_FM * convert_to_double(mesh_M_.vertex(v));
     p_FL = p_FL.cwiseMin(p_FV);
     p_FU = p_FU.cwiseMax(p_FV);
   }

--- a/geometry/proximity/obj_to_surface_mesh.cc
+++ b/geometry/proximity/obj_to_surface_mesh.cc
@@ -20,8 +20,9 @@
 
 namespace drake {
 namespace geometry {
-
 namespace {
+
+using Eigen::Vector3d;
 
 // TODO(DamrongGuoy): Refactor the tinyobj usage between here and
 //  ProximityEngine.
@@ -38,7 +39,7 @@ namespace {
  @pre
      The size of `tinyobj_vertices` is divisible by three.
  */
-std::vector<SurfaceVertex<double>> TinyObjToSurfaceVertices(
+std::vector<Vector3d> TinyObjToSurfaceVertices(
     const std::vector<tinyobj::real_t>& tinyobj_vertices, const double scale) {
   // Vertices from tinyobj are in a vector of floating-point numbers like this:
   //     tinyobj_vertices = {c₀,c₁,c₂, c₃,c₄,c₅, c₆,c₇,c₈,...}
@@ -48,7 +49,7 @@ std::vector<SurfaceVertex<double>> TinyObjToSurfaceVertices(
   //              = {    v0,         v1,         v2,...}
   const int num_coords = tinyobj_vertices.size();
   DRAKE_DEMAND(num_coords % 3 == 0);
-  std::vector<SurfaceVertex<double>> vertices;
+  std::vector<Vector3d> vertices;
   vertices.reserve(num_coords / 3);
 
   auto iter = tinyobj_vertices.begin();
@@ -145,7 +146,7 @@ SurfaceMesh<double> DoReadObjToSurfaceMesh(
   if (shapes.size() == 0) {
     throw std::runtime_error("The Wavefront obj file has no faces.");
   }
-  std::vector<SurfaceVertex<double>> vertices =
+  std::vector<Vector3d> vertices =
       TinyObjToSurfaceVertices(attrib.vertices, scale);
 
   // tinyobj stores vertices from all objects in attrib.vertices but stores

--- a/geometry/proximity/test/aabb_test.cc
+++ b/geometry/proximity/test/aabb_test.cc
@@ -171,7 +171,6 @@ GTEST_TEST(AabbTest, TestEqual) {
  elements of the mesh will be garbage). Then we'll successively build Aabb
  instances from subsets of the vertices. */
 GTEST_TEST(AabbMakerTest, Compute) {
-  using Vertex = SurfaceVertex<double>;
   using VIndex = SurfaceVertexIndex;
 
   /* The vertices are all located at box corners.
@@ -189,7 +188,7 @@ GTEST_TEST(AabbMakerTest, Compute) {
    V₀--------------V₄
    */
   const Vector3d half_size{0.5, 1.5, 1.25};
-  vector<Vertex> vertices;
+  vector<Vector3d> vertices;
   for (double x : {-1, 1}) {
     for (double y : {-1, 1}) {
       for (double z : {-1, 1}) {
@@ -211,7 +210,7 @@ GTEST_TEST(AabbMakerTest, Compute) {
     const set<VIndex> fit_vertices = {VIndex(0)};
     const Aabb::Maker<SurfaceMesh<double>> maker(mesh, fit_vertices);
     const Aabb aabb = maker.Compute();
-    EXPECT_TRUE(CompareMatrices(aabb.center(), mesh.vertex(VIndex(0)).r_MV()));
+    EXPECT_TRUE(CompareMatrices(aabb.center(), mesh.vertex(VIndex(0))));
     EXPECT_TRUE(CompareMatrices(aabb.half_width(), Vector3d::Zero()));
   }
 

--- a/geometry/proximity/test/bvh_updater_test.cc
+++ b/geometry/proximity/test/bvh_updater_test.cc
@@ -53,19 +53,18 @@ class BvhUpdaterTest : public ::testing::Test {
                  (i.e., vertices 6 and 7).  */
   static MeshType MakeMesh(double dist = 2) {
     using T = typename MeshType::ScalarType;
-    using V = typename MeshType::template VertexType<T>;
     using VI = typename MeshType::VertexIndex;
     const Vector3<T> offset{dist, 0, 0};
     // clang-format off
-    vector<V> vertices{
-        {V(Vector3<T>{0, -1, 0} + offset),
-         V(Vector3<T>{1, 0, 0} + offset),
-         V(Vector3<T>{0, 0, 1} + offset),
-         V(Vector3<T>{0, -1, 0} - offset),
-         V(Vector3<T>{-1, 0, 0} - offset),
-         V(Vector3<T>{0, 0, 1} - offset),
-         V(offset),
-         V(-offset)}};
+    vector<Vector3<T>> vertices{
+        {Vector3<T>{0, -1, 0} + offset,
+         Vector3<T>{1, 0, 0} + offset,
+         Vector3<T>{0, 0, 1} + offset,
+         Vector3<T>{0, -1, 0} - offset,
+         Vector3<T>{-1, 0, 0} - offset,
+         Vector3<T>{0, 0, 1} - offset,
+         offset,
+         -offset}};
     // clang-format on
     if constexpr (std::is_same_v<MeshType, SurfaceMesh<T>>) {
       /* The winding of the triangles don't matter. */
@@ -167,7 +166,7 @@ TYPED_TEST(BvhUpdaterTest, Update) {
   VectorX<T> p_MVs(3 * mesh.num_vertices());
   using VIndex = typename MeshType::VertexIndex;
   for (VIndex i(0); i < mesh.num_vertices(); ++i) {
-    p_MVs.segment(i * 3, 3) << R * mesh.vertex(i).r_MV();
+    p_MVs.segment(i * 3, 3) << R * mesh.vertex(i);
   }
   deformer.SetAllPositions(p_MVs);
   updater.Update();

--- a/geometry/proximity/test/contact_surface_test.cc
+++ b/geometry/proximity/test/contact_surface_test.cc
@@ -89,10 +89,8 @@ unique_ptr<SurfaceMesh<T>> GenerateMesh() {
   const int face_data[2][3] = {{0, 1, 2}, {2, 3, 0}};
   vector<SurfaceFace> faces;
   for (int f = 0; f < 2; ++f) faces.emplace_back(face_data[f]);
-  const Vector3<T> vertex_data[4] = {
+  vector<Vector3<T>> vertices = {
       {0., 0., 0.}, {1., 0., 0.}, {1., 1., 0.}, {0., 1., 0.}};
-  vector<SurfaceVertex<T>> vertices;
-  for (int v = 0; v < 4; ++v) vertices.emplace_back(vertex_data[v]);
   auto surface_mesh =
       make_unique<SurfaceMesh<T>>(move(faces), move(vertices));
   return surface_mesh;

--- a/geometry/proximity/test/deformable_volume_mesh_test.cc
+++ b/geometry/proximity/test/deformable_volume_mesh_test.cc
@@ -63,7 +63,7 @@ class DeformableVolumeMeshTest : public ::testing::Test {
     const auto& vertices = mesh.vertices();
     VectorX<T> q(num_vertices * 3);
     for (int v = 0, i = 0; v < num_vertices; ++v, i += 3) {
-      q.segment(i, 3) << vertices[v].r_MV();
+      q.segment(i, 3) << vertices[v];
     }
     return q;
   }

--- a/geometry/proximity/test/hydroelastic_callback_test.cc
+++ b/geometry/proximity/test/hydroelastic_callback_test.cc
@@ -274,7 +274,7 @@ class TestScene {
   const SurfaceVertexIndex v0(0);
   const SurfaceFaceIndex f0(0);
   const auto& mesh_W = surface.mesh_W();
-  if (mesh_W.vertex(v0).r_MV().x().derivatives().size() != 3) {
+  if (mesh_W.vertex(v0).x().derivatives().size() != 3) {
     return ::testing::AssertionFailure() << "Vertex 0 is missing derivatives";
   }
 

--- a/geometry/proximity/test/make_box_mesh_test.cc
+++ b/geometry/proximity/test/make_box_mesh_test.cc
@@ -51,7 +51,7 @@ bool IsTetrahedronRespectingMa(const VolumeElement& tetrahedron,
     for (const double face_bound : {-half_size[axis], half_size[axis]}) {
       bool closest_to_this_face = true;
       for (int i = 0; i < mesh.kVertexPerElement && closest_to_this_face; ++i) {
-        const Vector3d vertex = mesh.vertex(tetrahedron.vertex(i)).r_MV();
+        const Vector3d vertex = mesh.vertex(tetrahedron.vertex(i));
         const double distance_to_this_face = abs(vertex[axis] - face_bound);
         closest_to_this_face =
             tolerance >= distance_to_this_face - distance_to_boundary(vertex);
@@ -83,8 +83,7 @@ bool VerifyBoxMeshWithMa(const VolumeMesh<double>& mesh, const Box& box) {
   const int num_vertices = mesh.num_vertices();
   for (VolumeVertexIndex i(0); i < num_vertices; ++i) {
     for (VolumeVertexIndex j(i + 1); j < num_vertices; ++j) {
-      const bool vertex_is_unique =
-          mesh.vertex(i).r_MV() != mesh.vertex(j).r_MV();
+      const bool vertex_is_unique = mesh.vertex(i) != mesh.vertex(j);
       EXPECT_TRUE(vertex_is_unique) << "The mesh has duplicated vertices.";
       if (!vertex_is_unique) {
         return false;
@@ -110,12 +109,12 @@ bool VerifyBoxMeshWithMa(const VolumeMesh<double>& mesh, const Box& box) {
   for (const double x : {-half_size.x(), half_size.x()}) {
     for (const double y : {-half_size.y(), half_size.y()}) {
       for (const double z : {-half_size.z(), half_size.z()}) {
-        const VolumeVertex<double> corner(x, y, z);
+        const Vector3d corner(x, y, z);
         const bool corner_is_a_mesh_vertex =
             mesh.vertices().end() !=
             find_if(mesh.vertices().begin(), mesh.vertices().end(),
-                    [&corner](const VolumeVertex<double>& v) -> bool {
-                      return v.r_MV() == corner.r_MV();
+                    [&corner](const Vector3d& v) -> bool {
+                      return v == corner;
                     });
         EXPECT_TRUE(corner_is_a_mesh_vertex)
             << "A corner point of the box is missing from the mesh vertices.";
@@ -128,7 +127,7 @@ bool VerifyBoxMeshWithMa(const VolumeMesh<double>& mesh, const Box& box) {
   // B2. No mesh's vertex is outside the box.
   for (VolumeVertexIndex i(0); i < num_vertices; ++i) {
     const bool vertex_is_inside_or_on_boundary =
-        (mesh.vertex(i).r_MV().array().abs() <= half_size.array()).all();
+        (mesh.vertex(i).array().abs() <= half_size.array()).all();
     EXPECT_TRUE(vertex_is_inside_or_on_boundary)
         << "A mesh vertex is outside the box.";
     if (!vertex_is_inside_or_on_boundary) {
@@ -184,14 +183,14 @@ bool VerifyBoxMeshWithMa(const VolumeMesh<double>& mesh, const Box& box) {
       DistanceToPointRelativeTolerance(half_size.maxCoeff());
   for (const VolumeElement& tetrahedron : mesh.tetrahedra()) {
     const double distance_v0 =
-        distance_to_boundary(mesh.vertex(tetrahedron.vertex(0)).r_MV());
+        distance_to_boundary(mesh.vertex(tetrahedron.vertex(0)));
     bool different_distance_from_v0 = false;
     for (int i = 1; i < mesh.kVertexPerElement && !different_distance_from_v0;
          ++i) {
       different_distance_from_v0 =
           distance_tolerance <
           abs(distance_v0 -
-              distance_to_boundary(mesh.vertex(tetrahedron.vertex(i)).r_MV()));
+              distance_to_boundary(mesh.vertex(tetrahedron.vertex(i))));
     }
     EXPECT_TRUE(different_distance_from_v0)
         << "A tetrahedron has all vertices at the same distances to"
@@ -358,7 +357,7 @@ GTEST_TEST(MakeBoxVolumeMeshTest, GenerateVertices) {
       for (int k = 0; k < num_vertices.z(); ++k) {
         int sequential_index = CalcSequentialIndex(i, j, k, num_vertices);
         Vector3<double> expect_r_MV = Vector3<double>(i - 1, j - 2, k - 3);
-        Vector3<double> r_MV = vertices[sequential_index].r_MV();
+        Vector3<double> r_MV = vertices[sequential_index];
         EXPECT_TRUE(CompareMatrices(expect_r_MV, r_MV))
                     << "Incorrect vertex position.";
       }

--- a/geometry/proximity/test/make_capsule_mesh_test.cc
+++ b/geometry/proximity/test/make_capsule_mesh_test.cc
@@ -27,7 +27,7 @@ bool IsTetrahedronRespectingMa(const VolumeElement& tetrahedron,
   int num_medial = 0;
 
   for (int v = 0; v < mesh.kVertexPerElement; ++v) {
-    const Vector3d r_MV = mesh.vertex(tetrahedron.vertex(v)).r_MV();
+    const Vector3d r_MV = mesh.vertex(tetrahedron.vertex(v));
     const double dist = CalcDistanceToSurface(capsule, r_MV);
     if (capsule.radius() + dist < tolerance) {
       num_medial++;
@@ -59,8 +59,7 @@ void VerifyCapsuleMeshWithMa(const VolumeMesh<double>& mesh,
   const int num_vertices = mesh.num_vertices();
   for (VolumeVertexIndex i(0); i < num_vertices; ++i) {
     for (VolumeVertexIndex j(i + 1); j < num_vertices; ++j) {
-      const bool vertex_is_unique =
-          mesh.vertex(i).r_MV() != mesh.vertex(j).r_MV();
+      const bool vertex_is_unique = mesh.vertex(i) != mesh.vertex(j);
       ASSERT_TRUE(vertex_is_unique) << "The mesh has duplicated vertices.";
     }
   }
@@ -77,8 +76,8 @@ void VerifyCapsuleMeshWithMa(const VolumeMesh<double>& mesh,
   // B. The mesh conforms to the capsule.
   const double tolerance = DistanceToPointRelativeTolerance(
       std::max(capsule.length() / 2., capsule.radius()));
-  for (const VolumeVertex<double>& v : mesh.vertices()) {
-    ASSERT_TRUE(CalcDistanceToSurface(capsule, v.r_MV()) - tolerance <= 0)
+  for (const Vector3d& v : mesh.vertices()) {
+    ASSERT_TRUE(CalcDistanceToSurface(capsule, v) - tolerance <= 0)
         << "A mesh vertex is outside the capsule.";
   }
 

--- a/geometry/proximity/test/make_cylinder_field_test.cc
+++ b/geometry/proximity/test/make_cylinder_field_test.cc
@@ -55,15 +55,14 @@ void CheckMinMaxBoundaryValue(
   VolumeVertexIndex center_vertex{0};
   bool has_center_vertex = false;
   for (VolumeVertexIndex v{0}; v < pressure_field.mesh().num_vertices(); ++v) {
-    if (pressure_field.mesh().vertex(v).r_MV() == Vector3d::Zero()) {
+    if (pressure_field.mesh().vertex(v) == Vector3d::Zero()) {
       center_vertex = v;
       has_center_vertex = true;
       break;
     }
   }
   if (has_center_vertex) {
-    ASSERT_EQ(Vector3d::Zero(),
-              pressure_field.mesh().vertex(center_vertex).r_MV());
+    ASSERT_EQ(Vector3d::Zero(), pressure_field.mesh().vertex(center_vertex));
     EXPECT_NEAR(max_pressure, pressure_field.EvaluateAtVertex(center_vertex),
                 tolerance);
   }

--- a/geometry/proximity/test/make_cylinder_mesh_test.cc
+++ b/geometry/proximity/test/make_cylinder_mesh_test.cc
@@ -110,7 +110,7 @@ bool IsTetrahedronRespectingMa(const VolumeElement& tetrahedron,
   // medial axis.
   std::vector<int> closest_faces[mesh.kVertexPerElement];
   for (int v = 0; v < mesh.kVertexPerElement; ++v) {
-    const Vector3d r_MV = mesh.vertex(tetrahedron.vertex(v)).r_MV();
+    const Vector3d r_MV = mesh.vertex(tetrahedron.vertex(v));
     const double dist = distance_to_boundary(r_MV);
     for (int f = 0; f < kNumCylinderFaces; ++f) {
       if (distance_to_boundary_face(f, r_MV) - dist <= tolerance) {
@@ -151,8 +151,7 @@ void VerifyCylinderMeshWithMa(const VolumeMesh<double>& mesh,
   const int num_vertices = mesh.num_vertices();
   for (VolumeVertexIndex i(0); i < num_vertices; ++i) {
     for (VolumeVertexIndex j(i + 1); j < num_vertices; ++j) {
-      const bool vertex_is_unique =
-          mesh.vertex(i).r_MV() != mesh.vertex(j).r_MV();
+      const bool vertex_is_unique = mesh.vertex(i) != mesh.vertex(j);
       ASSERT_TRUE(vertex_is_unique) << "The mesh has duplicated vertices.";
     }
   }
@@ -172,10 +171,10 @@ void VerifyCylinderMeshWithMa(const VolumeMesh<double>& mesh,
   const double squared_radius = cylinder.radius() * cylinder.radius();
   const double distance_tolerance = DistanceToPointRelativeTolerance(
       std::max(half_length, cylinder.radius()));
-  for (const VolumeVertex<double>& v : mesh.vertices()) {
-    const double x = v.r_MV().x();
-    const double y = v.r_MV().y();
-    const double z = v.r_MV().z();
+  for (const Vector3d& v : mesh.vertices()) {
+    const double x = v.x();
+    const double y = v.y();
+    const double z = v.z();
     bool is_inside_or_on_boundary =
         abs(z) < half_length + distance_tolerance &&
         x * x + y * y < squared_radius + distance_tolerance;
@@ -217,14 +216,14 @@ void VerifyCylinderMeshWithMa(const VolumeMesh<double>& mesh,
   DistanceToCylinderBoundaryFromPointInside distance_to_boundary(cylinder);
   for (const VolumeElement& tetrahedron : mesh.tetrahedra()) {
     const double distance_v0 =
-        distance_to_boundary(mesh.vertex(tetrahedron.vertex(0)).r_MV());
+        distance_to_boundary(mesh.vertex(tetrahedron.vertex(0)));
     bool different_distance_from_v0 = false;
     for (int i = 1; i < mesh.kVertexPerElement && !different_distance_from_v0;
          ++i) {
       different_distance_from_v0 =
           distance_tolerance <
           abs(distance_v0 -
-              distance_to_boundary(mesh.vertex(tetrahedron.vertex(i)).r_MV()));
+              distance_to_boundary(mesh.vertex(tetrahedron.vertex(i))));
     }
     ASSERT_TRUE(different_distance_from_v0)
         << "A tetrahedron has all vertices at the same distances to"

--- a/geometry/proximity/test/make_ellipsoid_field_test.cc
+++ b/geometry/proximity/test/make_ellipsoid_field_test.cc
@@ -52,13 +52,12 @@ void CheckMinMaxBoundaryValue(
   // canonical frame.
   VolumeVertexIndex center_vertex{0};
   for (VolumeVertexIndex v{0}; v < pressure_field.mesh().num_vertices(); ++v) {
-    if (pressure_field.mesh().vertex(v).r_MV() == Vector3d::Zero()) {
+    if (pressure_field.mesh().vertex(v) == Vector3d::Zero()) {
       center_vertex = v;
       break;
     }
   }
-  ASSERT_EQ(Vector3d::Zero(),
-            pressure_field.mesh().vertex(center_vertex).r_MV());
+  ASSERT_EQ(Vector3d::Zero(), pressure_field.mesh().vertex(center_vertex));
   EXPECT_EQ(max_pressure, pressure_field.EvaluateAtVertex(center_vertex));
 }
 

--- a/geometry/proximity/test/make_sphere_field_test.cc
+++ b/geometry/proximity/test/make_sphere_field_test.cc
@@ -52,13 +52,12 @@ void CheckMinMaxBoundaryValue(
   // canonical frame.
   VolumeVertexIndex center_vertex{0};
   for (VolumeVertexIndex v{0}; v < pressure_field.mesh().num_vertices(); ++v) {
-    if (pressure_field.mesh().vertex(v).r_MV() == Vector3d::Zero()) {
+    if (pressure_field.mesh().vertex(v) == Vector3d::Zero()) {
       center_vertex = v;
       break;
     }
   }
-  ASSERT_EQ(Vector3d::Zero(),
-            pressure_field.mesh().vertex(center_vertex).r_MV());
+  ASSERT_EQ(Vector3d::Zero(), pressure_field.mesh().vertex(center_vertex));
   EXPECT_EQ(max_pressure, pressure_field.EvaluateAtVertex(center_vertex));
 }
 

--- a/geometry/proximity/test/make_sphere_mesh_test.cc
+++ b/geometry/proximity/test/make_sphere_mesh_test.cc
@@ -46,7 +46,7 @@ GTEST_TEST(MakeSphereMesh, InvariantsOfLevelZeroMesh) {
     }
   }
   EXPECT_EQ(count, 1);
-  EXPECT_EQ(mesh.vertex(center_index).r_MV(), Vector3d(0, 0, 0));
+  EXPECT_EQ(mesh.vertex(center_index), Vector3d(0, 0, 0));
 
   // Every vertex references the center index _and_ it is the fourth vertex
   // in each tet.
@@ -144,12 +144,12 @@ GTEST_TEST(MakeSphereMesh, SplitOctohedron) {
   // semantics of vertices e-j as defined in the make unit sphere
   // infrastructure.
   const int a(0), b(1), c(2), d(3);
-  const std::vector<VolumeVertex<double>> tet_vertices{
-      VolumeVertex<double>(1, -1, -1), VolumeVertex<double>(1, 1, 1),
-      VolumeVertex<double>(-1, 1, -1), VolumeVertex<double>(-1, -1, 1)};
+  const std::vector<Vector3d> tet_vertices{
+      Vector3d(1, -1, -1), Vector3d(1, 1, 1),
+      Vector3d(-1, 1, -1), Vector3d(-1, -1, 1)};
 
   auto mid_point = [&tet_vertices](int i, int j) -> Vector3d {
-    return (tet_vertices[i].r_MV() + tet_vertices[j].r_MV()) / 2;
+    return (tet_vertices[i] + tet_vertices[j]) / 2;
   };
 
   using VIndex = VolumeVertexIndex;
@@ -157,13 +157,13 @@ GTEST_TEST(MakeSphereMesh, SplitOctohedron) {
   // e-j.
   const VIndex e(0), f(1), g(2), h(3), i(4), j(5);
   const std::array<VIndex, 6> octo_vertices{e, f, g, h, i, j};
-  const std::vector<VolumeVertex<double>> unit_p_MVs{
-      VolumeVertex<double>(mid_point(a, b)),  // e = (a + b) / 2
-      VolumeVertex<double>(mid_point(a, c)),  // f = (a + c) / 2
-      VolumeVertex<double>(mid_point(a, d)),  // g = (a + d) / 2
-      VolumeVertex<double>(mid_point(b, c)),  // h = (b + c) / 2
-      VolumeVertex<double>(mid_point(b, d)),  // i = (b + d) / 2
-      VolumeVertex<double>(mid_point(c, d))};  // j = (c + d) / 2
+  const std::vector<Vector3d> unit_p_MVs{
+      Vector3d(mid_point(a, b)),  // e = (a + b) / 2
+      Vector3d(mid_point(a, c)),  // f = (a + c) / 2
+      Vector3d(mid_point(a, d)),  // g = (a + d) / 2
+      Vector3d(mid_point(b, c)),  // h = (b + c) / 2
+      Vector3d(mid_point(b, d)),  // i = (b + d) / 2
+      Vector3d(mid_point(c, d))};  // j = (c + d) / 2
 
   // Confirm the tetrahedron works as advertised; that the vertices at edge
   // midpoints live where we expect them to.
@@ -176,12 +176,12 @@ GTEST_TEST(MakeSphereMesh, SplitOctohedron) {
   //        e f
   //       /  |
   //     +X
-  ASSERT_TRUE(CompareMatrices(unit_p_MVs[e].r_MV(), Vector3d(1, 0, 0)));
-  ASSERT_TRUE(CompareMatrices(unit_p_MVs[f].r_MV(), Vector3d(0, 0, -1)));
-  ASSERT_TRUE(CompareMatrices(unit_p_MVs[g].r_MV(), Vector3d(0, -1, 0)));
-  ASSERT_TRUE(CompareMatrices(unit_p_MVs[h].r_MV(), Vector3d(0, 1, 0)));
-  ASSERT_TRUE(CompareMatrices(unit_p_MVs[i].r_MV(), Vector3d(0, 0, 1)));
-  ASSERT_TRUE(CompareMatrices(unit_p_MVs[j].r_MV(), Vector3d(-1, 0, 0)));
+  ASSERT_TRUE(CompareMatrices(unit_p_MVs[e], Vector3d(1, 0, 0)));
+  ASSERT_TRUE(CompareMatrices(unit_p_MVs[f], Vector3d(0, 0, -1)));
+  ASSERT_TRUE(CompareMatrices(unit_p_MVs[g], Vector3d(0, -1, 0)));
+  ASSERT_TRUE(CompareMatrices(unit_p_MVs[h], Vector3d(0, 1, 0)));
+  ASSERT_TRUE(CompareMatrices(unit_p_MVs[i], Vector3d(0, 0, 1)));
+  ASSERT_TRUE(CompareMatrices(unit_p_MVs[j], Vector3d(-1, 0, 0)));
 
   // We're going to implicitly scale the tetrahedron so that the octahedron
   // is no longer symmetric; we scale it along the three axes by a factor of
@@ -196,11 +196,11 @@ GTEST_TEST(MakeSphereMesh, SplitOctohedron) {
     Vector3d scale_factor{2, 2, 2};
     scale_factor(axis) = 1;
 
-    std::vector<VolumeVertex<double>> p_MVs;
+    std::vector<Vector3d> p_MVs;
     std::transform(
         unit_p_MVs.begin(), unit_p_MVs.end(), std::back_inserter(p_MVs),
-        [&scale_factor](const VolumeVertex<double>& v) {
-          return VolumeVertex<double>(v.r_MV().cwiseProduct(scale_factor));
+        [&scale_factor](const Vector3d& v) {
+          return Vector3d(v.cwiseProduct(scale_factor));
         });
     std::vector<VolumeElement> split_tetrahedra;
 
@@ -237,8 +237,7 @@ GTEST_TEST(MakeSphereVolumeMesh, ConfirmEdgeLength) {
     // We arbitrarily pick the z = 0 equator (although x = 0 or y = 0 would work
     // equally well).
     std::vector<Vector3d> equator_vertices;
-    for (const auto& vertex : mesh.vertices()) {
-      const Vector3d& p_MV = vertex.r_MV();
+    for (const auto& p_MV : mesh.vertices()) {
       const double d_squared = p_MV(0) * p_MV(0) + p_MV(1) * p_MV(1);
       if (p_MV(2) == 0.0 && d_squared >= r_squared - 1e-14) {
         equator_vertices.push_back(p_MV);
@@ -357,7 +356,7 @@ int CountSurfaceVertices(const VolumeMesh<double>& mesh, double radius = 1.0) {
   const double kEps = std::numeric_limits<double>::epsilon() * radius;
   int count = 0;
   for (VolumeVertexIndex v(0); v < mesh.num_vertices(); ++v) {
-    const double r = mesh.vertex(v).r_MV().norm();
+    const double r = mesh.vertex(v).norm();
     // This is a very tight tolerance. That's good. We want to know that the
     // surface vertices are as close to the surface of the sphere as can
     // possibly be represented by doubles. If changes in the algorithm cause

--- a/geometry/proximity/test/mesh_field_linear_test.cc
+++ b/geometry/proximity/test/mesh_field_linear_test.cc
@@ -45,7 +45,7 @@ std::unique_ptr<SurfaceMesh<T>> GenerateMesh() {
   for (int f = 0; f < 2; ++f) faces.emplace_back(face_data[f]);
   const Vector3<T> vertex_data[4] = {
       {0., 0., 0.}, {1., 0., 0.}, {1., 1., 0.}, {0., 1., 0.}};
-  std::vector<SurfaceVertex<T>> vertices;
+  std::vector<Vector3<T>> vertices;
   for (int v = 0; v < 4; ++v) vertices.emplace_back(vertex_data[v]);
   auto surface_mesh =
       std::make_unique<SurfaceMesh<T>>(move(faces), std::move(vertices));
@@ -203,7 +203,7 @@ GTEST_TEST(MeshFieldLinearTest, EvaluateCartesianWithAndWithoutGradient) {
     int num_positive_or_zero = 0;
     int num_negative_or_zero = 0;
     for (int i = 0; i < 4; ++i) {
-      const Vector3d p_MV = mesh_M.vertex(mesh_M.element(e).vertex(i)).r_MV();
+      const Vector3d p_MV = mesh_M.vertex(mesh_M.element(e).vertex(i));
       if (p_MV.x() >= 0) ++num_positive_or_zero;
       if (p_MV.x() <= 0) ++num_negative_or_zero;
     }
@@ -242,8 +242,8 @@ GTEST_TEST(MeshFieldLinearTest, EvaluateCartesianWithAndWithoutGradient) {
   };
 
   std::vector<double> values;
-  for (const VolumeVertex<double>& v : mesh_M.vertices()) {
-    values.push_back(f(v.r_MV()));
+  for (const Vector3d& p_MV : mesh_M.vertices()) {
+    values.push_back(f(p_MV));
   }
   std::vector<double> values_copy = values;
 
@@ -269,7 +269,7 @@ GTEST_TEST(MeshFieldLinearTest, EvaluateCartesianWithAndWithoutGradient) {
       for (VolumeElementIndex e(0); e < mesh_M.num_elements(); ++e) {
         Vector3d p_MQ{0, 0, 0};
         for (int i = 0; i < 4; ++i) {
-          p_MQ += mesh_M.vertex(mesh_M.element(e).vertex(i)).r_MV() * b_Q(i);
+          p_MQ += mesh_M.vertex(mesh_M.element(e).vertex(i)) * b_Q(i);
         }
         const double expect = f(p_MQ);
         constexpr double tolerance = 2e-15;
@@ -340,7 +340,7 @@ class ScalarMixingTest : public ::testing::Test {
 
     p_WQ_d_ = Vector3d::Zero();
     for (SurfaceVertexIndex v(0); v < 3; ++v) {
-      p_WQ_d_ += mesh_d_->vertex(v).r_MV();
+      p_WQ_d_ += mesh_d_->vertex(v);
     }
     p_WQ_d_ /= 3;
     p_WQ_ad_ = math::InitializeAutoDiff(p_WQ_d_);

--- a/geometry/proximity/test/obb_test.cc
+++ b/geometry/proximity/test/obb_test.cc
@@ -346,9 +346,7 @@ class ObbMakerTestTriangle : public ::testing::Test {
       : ::testing::Test(),
         mesh_M_({SurfaceFace(SurfaceVertexIndex(0), SurfaceVertexIndex(1),
                              SurfaceVertexIndex(2))},
-                {SurfaceVertex<double>(Vector3d::UnitX()),
-                 SurfaceVertex<double>(Vector3d::UnitY()),
-                 SurfaceVertex<double>(Vector3d::UnitZ())}),
+                {Vector3d::UnitX(), Vector3d::UnitY(), Vector3d::UnitZ()}),
         test_vertices_{SurfaceVertexIndex(0), SurfaceVertexIndex(1),
                        SurfaceVertexIndex(2)} {}
 
@@ -452,7 +450,7 @@ bool Contain(const Obb& obb_M, const MeshType& mesh_M,
   const RigidTransformd& X_MB = obb_M.pose();
   const RigidTransformd X_BM = X_MB.inverse();
   for (const typename MeshType::VertexIndex& v : vertices) {
-    Vector3d p_MV = mesh_M.vertex(v).r_MV();
+    Vector3d p_MV = mesh_M.vertex(v);
     Vector3d p_BV = X_BM * p_MV;
     if ((p_BV.array() > obb_M.half_width().array()).any()) {
       return false;
@@ -646,7 +644,7 @@ GTEST_TEST(ObbMakerTest, TestTruncatedBox) {
   ASSERT_EQ(surface_mesh.num_faces(), 12);
   std::set<SurfaceVertexIndex> test_vertices;
   for (SurfaceVertexIndex i(0); i < 8; ++i) {
-    const Vector3d& p_MV = surface_mesh.vertex(i).r_MV();
+    const Vector3d& p_MV = surface_mesh.vertex(i);
     // Omit vertices on a diagonal.
     if (CompareMatrices(p_MV, Vector3d(-3, -2, -1), 1e-5)) continue;
     if (CompareMatrices(p_MV, Vector3d(3, 2, 1), 1e-5)) continue;
@@ -699,10 +697,8 @@ GTEST_TEST(ObbMakerTestAPI, ObbMakerCompute) {
                    SurfaceVertexIndex(2)),
        SurfaceFace(SurfaceVertexIndex(0), SurfaceVertexIndex(3),
                    SurfaceVertexIndex(1))},
-      {SurfaceVertex<double>(Vector3d::Zero()),
-       SurfaceVertex<double>(Vector3d::UnitX()),
-       SurfaceVertex<double>(2. * Vector3d::UnitY()),
-       SurfaceVertex<double>(3. * Vector3d::UnitZ())});
+      {Vector3d::Zero(), Vector3d::UnitX(), 2. * Vector3d::UnitY(),
+       3. * Vector3d::UnitZ()});
 
   const std::set<SurfaceVertexIndex> test_vertices{SurfaceVertexIndex(0),
                                                    SurfaceVertexIndex(1)};

--- a/geometry/proximity/test/obj_to_surface_mesh_test.cc
+++ b/geometry/proximity/test/obj_to_surface_mesh_test.cc
@@ -30,7 +30,7 @@ GTEST_TEST(ObjToSurfaceMeshTest, TinyObjToSurfaceVertices) {
     // Seek to the beginning of the stream in each iteration.
     test_stream.seekg(0, test_stream.beg);
 
-    const std::vector<SurfaceVertex<double>> surface_vertices(
+    const std::vector<Vector3<double>> surface_vertices(
         ReadObjToSurfaceMesh(&test_stream, scale).vertices());
 
     EXPECT_EQ(3, surface_vertices.size());
@@ -41,7 +41,7 @@ GTEST_TEST(ObjToSurfaceMeshTest, TinyObjToSurfaceVertices) {
     };
 
     for (int i = 0; i < 3; ++i) {
-      EXPECT_EQ(expect_vertices[i], surface_vertices[i].r_MV());
+      EXPECT_EQ(expect_vertices[i], surface_vertices[i]);
     }
   }
 }
@@ -98,7 +98,7 @@ GTEST_TEST(ObjToSurfaceMeshTest, ReadObjToSurfaceMesh) {
   // clang-format on
 
   for (int i = 0; i < 8; ++i) {
-    EXPECT_EQ(expect_vertices[i], surface.vertex(SurfaceVertexIndex(i)).r_MV());
+    EXPECT_EQ(expect_vertices[i], surface.vertex(SurfaceVertexIndex(i)));
   }
 
   // TODO(SeanCurtis-TRI) Devise a formulation of this that is less sensitive
@@ -230,7 +230,7 @@ f 1 2 3
     {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, { 0.0, 0.0, 1.0 }
   };
   for (int i = 0; i < 3; ++i) {
-    EXPECT_EQ(expect_vertices[i], surface.vertex(SurfaceVertexIndex(i)).r_MV());
+    EXPECT_EQ(expect_vertices[i], surface.vertex(SurfaceVertexIndex(i)));
   }
   ASSERT_EQ(1, surface.num_faces());
   int expect_face[3] = {0, 1, 2};
@@ -261,7 +261,7 @@ f 4 5 6
       {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0},
       {2.0, 0.0, 0.0}, {0.0, 2.0, 0.0}, {0.0, 0.0, 2.0}};
   for (int i = 0; i < 6; ++i) {
-    EXPECT_EQ(expect_vertices[i], surface.vertex(SurfaceVertexIndex(i)).r_MV());
+    EXPECT_EQ(expect_vertices[i], surface.vertex(SurfaceVertexIndex(i)));
   }
   ASSERT_EQ(2, surface.num_faces());
   int expect_faces[2][3]{{0, 1, 2}, {3, 4, 5}};

--- a/geometry/proximity/test/proximity_utilities_test.cc
+++ b/geometry/proximity/test/proximity_utilities_test.cc
@@ -87,7 +87,7 @@ class VolumeMeshUtilities : public ::testing::Test {
         Vector3<double>::Zero(), Vector3<double>::UnitX(),
         Vector3<double>::UnitY(), Vector3<double>::UnitZ(),
         -Vector3<double>::UnitZ()};
-    std::vector<VolumeVertex<double>> vertices;
+    std::vector<Vector3d> vertices;
     for (int v = 0; v < 5; ++v) vertices.emplace_back(vertex_data[v]);
     volume_mesh = std::make_unique<VolumeMesh<double>>(std::move(elements),
                                                        std::move(vertices));

--- a/geometry/proximity/test/volume_mesh_test.cc
+++ b/geometry/proximity/test/volume_mesh_test.cc
@@ -65,7 +65,7 @@ std::unique_ptr<VolumeMesh<T>> TestVolumeMesh(
   const Vector3<T> vertex_data[5] = {Vector3<T>::Zero(), Vector3<T>::UnitX(),
                                      Vector3<T>::UnitY(), Vector3<T>::UnitZ(),
                                      -Vector3<T>::UnitZ()};
-  std::vector<VolumeVertex<T>> vertices_W;
+  std::vector<Vector3<T>> vertices_W;
   for (int v = 0; v < 5; ++v) vertices_W.emplace_back(X_WM * vertex_data[v]);
   auto volume_mesh_W = std::make_unique<VolumeMesh<T>>(std::move(elements),
                                                        std::move(vertices_W));
@@ -73,7 +73,7 @@ std::unique_ptr<VolumeMesh<T>> TestVolumeMesh(
   EXPECT_EQ(5, volume_mesh_W->num_vertices());
   for (int v = 0; v < 5; ++v)
     EXPECT_EQ(X_WM * vertex_data[v],
-              volume_mesh_W->vertex(VolumeVertexIndex(v)).r_MV());
+              volume_mesh_W->vertex(VolumeVertexIndex(v)));
   for (int e = 0; e < 2; ++e)
     for (int v = 0; v < 4; ++v)
       EXPECT_EQ(element_data[e][v],
@@ -116,7 +116,7 @@ void TestVolumeMeshEqual() {
 
   // Different tetrahedral connectivity.
   {
-    std::vector<VolumeVertex<T>> vertices_copy = mesh->vertices();
+    std::vector<Vector3<T>> vertices_copy = mesh->vertices();
     std::vector<VolumeElement> tetrahedra = mesh->tetrahedra();
     // Re-order vertices of the first tetrahedron.
     tetrahedra[0] = VolumeElement(tetrahedra[0].vertex(1),
@@ -130,7 +130,7 @@ void TestVolumeMeshEqual() {
 
   // Different number of vertices.
   {
-    std::vector<VolumeVertex<T>> vertices = mesh->vertices();
+    std::vector<Vector3<T>> vertices = mesh->vertices();
     vertices.emplace_back(1.2, 3.7, 0.15);
     std::vector<VolumeElement> tetrahedra = mesh->tetrahedra();
     VolumeMesh<T> another_mesh(std::move(tetrahedra), std::move(vertices));
@@ -139,7 +139,7 @@ void TestVolumeMeshEqual() {
 
   // Different number of tetrahedra.
   {
-    std::vector<VolumeVertex<T>> vertices = mesh->vertices();
+    std::vector<Vector3<T>> vertices = mesh->vertices();
     std::vector<VolumeElement> tetrahedra = mesh->tetrahedra();
     tetrahedra.pop_back();
     VolumeMesh<T> another_mesh(std::move(tetrahedra), std::move(vertices));
@@ -293,8 +293,8 @@ void TestCalcGradBarycentric() {
   // the test more realistic.
   const VolumeMesh<T> mesh_W(
       {VolumeElement(tetrahedron)},
-      {VolumeVertex<T>(X_WM * v0_M), VolumeVertex<T>(X_WM * v1_M),
-       VolumeVertex<T>(X_WM * v2_M), VolumeVertex<T>(X_WM * v3_M)});
+      {Vector3<T>(X_WM * v0_M), Vector3<T>(X_WM * v1_M),
+       Vector3<T>(X_WM * v2_M), Vector3<T>(X_WM * v3_M)});
 
   const VolumeMeshTester<T> tester(mesh_W);
   const auto gradb0_W = tester.CalcGradBarycentric(VolumeElementIndex(0), 0);
@@ -451,13 +451,13 @@ class ScalarMixingTest : public ::testing::Test {
     // We construct an AutoDiffXd-valued mesh from the double-valued mesh. We
     // only set the derivatives for vertex 3. That means, operations on
     // test 0 *must* have derivatives, but tet 1 may not have them.
-    std::vector<VolumeVertex<AutoDiffXd>> vertices;
-    vertices.emplace_back(mesh_d_->vertex(VolumeVertexIndex(0)).r_MV());
-    vertices.emplace_back(mesh_d_->vertex(VolumeVertexIndex(1)).r_MV());
-    vertices.emplace_back(mesh_d_->vertex(VolumeVertexIndex(2)).r_MV());
+    std::vector<Vector3<AutoDiffXd>> vertices;
+    vertices.emplace_back(mesh_d_->vertex(VolumeVertexIndex(0)));
+    vertices.emplace_back(mesh_d_->vertex(VolumeVertexIndex(1)));
+    vertices.emplace_back(mesh_d_->vertex(VolumeVertexIndex(2)));
     vertices.emplace_back(math::InitializeAutoDiff(
-        mesh_d_->vertex(VolumeVertexIndex(3)).r_MV()));
-    vertices.emplace_back(mesh_d_->vertex(VolumeVertexIndex(4)).r_MV());
+        mesh_d_->vertex(VolumeVertexIndex(3))));
+    vertices.emplace_back(mesh_d_->vertex(VolumeVertexIndex(4)));
     std::vector<VolumeElement> elements(mesh_d_->tetrahedra());
 
     mesh_ad_ = std::make_unique<VolumeMesh<AutoDiffXd>>(std::move(elements),
@@ -475,7 +475,7 @@ TEST_F(ScalarMixingTest, CalcBarycentric) {
   constexpr double kEps = std::numeric_limits<double>::epsilon();
   Vector3<double> p_WQ_d = Vector3<double>::Zero();
   for (VolumeVertexIndex v(0); v < 4; ++v) {
-    p_WQ_d += mesh_d_->vertex(v).r_MV();
+    p_WQ_d += mesh_d_->vertex(v);
   }
   p_WQ_d /= 4;
   const Vector3<AutoDiffXd> p_WQ_ad = math::InitializeAutoDiff(p_WQ_d);

--- a/geometry/proximity/test/volume_to_surface_mesh_test.cc
+++ b/geometry/proximity/test/volume_to_surface_mesh_test.cc
@@ -25,9 +25,9 @@ Vector3<T> CalcFaceNormal(const SurfaceMesh<T>& surface,
 //  will update `normal_M_` when TransformVertices() and ReverseFaceWinding()
 //  of SurfaceMesh are called.
   const SurfaceFace& face = surface.element(face_index);
-  const Vector3<T>& r_MA = surface.vertex(face.vertex(0)).r_MV();
-  const Vector3<T>& r_MB = surface.vertex(face.vertex(1)).r_MV();
-  const Vector3<T>& r_MC = surface.vertex(face.vertex(2)).r_MV();
+  const Vector3<T>& r_MA = surface.vertex(face.vertex(0));
+  const Vector3<T>& r_MB = surface.vertex(face.vertex(1));
+  const Vector3<T>& r_MC = surface.vertex(face.vertex(2));
   const auto r_AB_M = r_MB - r_MA;
   const auto r_AC_M = r_MC - r_MA;
   const auto rhat_AB_M = r_AB_M.normalized();
@@ -118,8 +118,7 @@ void TestVolumeToSurfaceMesh() {
   // so we can use `set`.
   using Coords = std::tuple<T, T, T>;
   std::set<Coords> boundary_vertex_coords;
-  for (const VolumeVertex<T>& vertex : volume.vertices()) {
-    const Vector3<T>& r_MV = vertex.r_MV();
+  for (const Vector3<T>& r_MV : volume.vertices()) {
     // A vertex is on the boundary of a box when one of its coordinates
     // matches an extremal value.
     using std::abs;
@@ -135,8 +134,7 @@ void TestVolumeToSurfaceMesh() {
   // check that they are the same as vertices on the boundary of the
   // volume mesh.
   std::set<Coords> surface_vertex_coords;
-  for (SurfaceVertexIndex i(0); i < surface.num_vertices(); ++i) {
-    const Vector3<T>& r_MV = surface.vertex(i).r_MV();
+  for (const Vector3<T>& r_MV : surface.vertices()) {
     surface_vertex_coords.insert(Coords(r_MV.x(), r_MV.y(), r_MV.z()));
   }
   EXPECT_EQ(boundary_vertex_coords, surface_vertex_coords);
@@ -149,7 +147,7 @@ void TestVolumeToSurfaceMesh() {
     const Vector3<T> normal_M = internal::CalcFaceNormal(surface, f);
     // Position vector of the first vertex V of the face.
     const Vector3<T> r_MV =
-        surface.vertex(surface.element(f).vertex(0)).r_MV();
+        surface.vertex(surface.element(f).vertex(0));
     EXPECT_GT(normal_M.dot(r_MV), T(0.0));
   }
 }

--- a/geometry/proximity/volume_to_surface_mesh.cc
+++ b/geometry/proximity/volume_to_surface_mesh.cc
@@ -130,11 +130,11 @@ SurfaceMesh<T> ConvertVolumeToSurfaceMesh(const VolumeMesh<T>& volume) {
   const std::vector<VolumeVertexIndex> boundary_vertices =
       internal::CollectUniqueVertices(boundary_faces);
 
-  std::vector<SurfaceVertex<T>> surface_vertices;
+  std::vector<Vector3<T>> surface_vertices;
   surface_vertices.reserve(boundary_vertices.size());
   std::unordered_map<VolumeVertexIndex, SurfaceVertexIndex> volume_to_surface;
   for (SurfaceVertexIndex i(0); i < boundary_vertices.size(); ++i) {
-    surface_vertices.emplace_back(volume.vertex(boundary_vertices[i]).r_MV());
+    surface_vertices.emplace_back(volume.vertex(boundary_vertices[i]));
     volume_to_surface.emplace(boundary_vertices[i], i);
   }
 

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -295,7 +295,6 @@ GTEST_TEST(ProximityEngineTest, ComputeContactSurfacesAutodiffSupport) {
     EXPECT_EQ(surfaces[0]
                   .mesh_W()
                   .vertex(SurfaceVertexIndex(0))
-                  .r_MV()
                   .x()
                   .derivatives()
                   .size(),

--- a/multibody/fixed_fem/dev/deformable_contact.cc
+++ b/multibody/fixed_fem/dev/deformable_contact.cc
@@ -404,14 +404,14 @@ class Intersector {
     polygon_D->clear();
     for (int i = 0; i < 3; ++i) {
       const SurfaceVertexIndex v = surface_R.element(face).vertex(i);
-      const Vector3<T> p_DV = X_DR * surface_R.vertex(v).r_MV().cast<T>();
+      const Vector3<T> p_DV = X_DR * surface_R.vertex(v).cast<T>();
       polygon_D->push_back({p_DV, tet_mesh_D.CalcBarycentric(p_DV, tet_index)});
     }
     // Get the positions, in Frame D, of the four vertices of the tet.
     Vector3<T> p_DVs[4];
     for (int i = 0; i < 4; ++i) {
       const VolumeVertexIndex v = tet_mesh_D.element(tet_index).vertex(i);
-      p_DVs[i] = tet_mesh_D.vertex(v).r_MV();
+      p_DVs[i] = tet_mesh_D.vertex(v);
     }
 
     /* Sets up the four half spaces associated with the four triangular faces of

--- a/multibody/fixed_fem/dev/elasticity_model.h
+++ b/multibody/fixed_fem/dev/elasticity_model.h
@@ -146,7 +146,7 @@ class ElasticityModel : public FemModel<Element> {
     const NodeIndex node_index_offset = NodeIndex(this->num_nodes());
     for (VolumeVertexIndex i(0); i < num_new_vertices; ++i) {
       reference_positions_.template segment<kDim>(
-          kDim * (i + node_index_offset)) = mesh.vertex(i).r_MV();
+          kDim * (i + node_index_offset)) = mesh.vertex(i);
     }
     /* Record the number of vertices *before* the input mesh is parsed. */
     const int num_vertices = this->num_nodes();

--- a/multibody/fixed_fem/dev/run_scripted_deformable_motion.cc
+++ b/multibody/fixed_fem/dev/run_scripted_deformable_motion.cc
@@ -62,12 +62,12 @@ class DummySoftsimSystem final : public systems::LeafSystem<double> {
   void RegisterBody(const geometry::VolumeMesh<double>& mesh, std::string name,
                     double amplitude, double velocity,
                     const Vector3<double>& p_WM) {
-    const std::vector<geometry::VolumeVertex<double>>& verts = mesh.vertices();
+    const std::vector<Vector3<double>>& verts = mesh.vertices();
     std::vector<geometry::VolumeElement> elements = mesh.tetrahedra();
-    std::vector<geometry::VolumeVertex<double>> verts_W;
+    std::vector<Vector3<double>> verts_W;
     /* Shift the vertices to world frame. */
     for (const auto& v : verts) {
-      verts_W.emplace_back(v.r_MV() + p_WM);
+      verts_W.emplace_back(v + p_WM);
     }
     meshes_.emplace_back(std::move(elements), std::move(verts_W));
     names_.emplace_back(std::move(name));
@@ -98,14 +98,13 @@ class DummySoftsimSystem final : public systems::LeafSystem<double> {
     output->resize(num_geometries());
     const double t = context.get_time();
     for (int i = 0; i < num_geometries(); ++i) {
-      const std::vector<geometry::VolumeVertex<double>> vertices =
-          meshes_[i].vertices();
+      const std::vector<Vector3<double>> vertices = meshes_[i].vertices();
       const int num_vertices = meshes_[i].num_vertices();
       VectorX<double> q(num_vertices * 3);
       const double v = velocities_[i];
       const double h = amplitudes_[i];
       for (int j = 0; j < num_vertices; ++j) {
-        Vector3<double> r_MV = vertices[j].r_MV();
+        Vector3<double> r_MV = vertices[j];
         r_MV(2) += h * std::sin(frequency_ * (r_MV(0) + v * t));
         q.template segment<3>(3 * j) = r_MV;
       }

--- a/multibody/fixed_fem/dev/test/deformable_contact_test.cc
+++ b/multibody/fixed_fem/dev/test/deformable_contact_test.cc
@@ -27,7 +27,6 @@ using geometry::VolumeElement;
 using geometry::VolumeElementIndex;
 using geometry::VolumeMesh;
 using geometry::VolumeMeshFieldLinear;
-using geometry::VolumeVertex;
 using geometry::internal::Bvh;
 using geometry::internal::DeformableVolumeMesh;
 using geometry::internal::Obb;
@@ -67,7 +66,7 @@ SurfaceMesh<T> MakePyramidSurface() {
     faces.emplace_back(face);
   }
   // clang-format off
-  const Vector3<T> vertex_data[6] = {
+  vector<Vector3<T>> vertices = {
       { 0,  0, 0},
       { 1,  0, 0},
       { 0,  1, 0},
@@ -76,10 +75,6 @@ SurfaceMesh<T> MakePyramidSurface() {
       { 0,  0, 1}
   };
   // clang-format on
-  vector<geometry::SurfaceVertex<T>> vertices;
-  for (auto& vertex : vertex_data) {
-    vertices.emplace_back(vertex);
-  }
   return SurfaceMesh<T>(std::move(faces), std::move(vertices));
 }
 
@@ -191,7 +186,7 @@ void TestComputeTetMeshTriMeshContact() {
     /* Calculate the centroid in cartesian coordinate by interpolating the
      positions of the tet vertices with the barycentric weights. */
     for (int j = 0; j < 4; ++j) {
-      centroid_D += b_centroid(j) * volume_D.vertex(tet.vertex(j)).r_MV();
+      centroid_D += b_centroid(j) * volume_D.vertex(tet.vertex(j));
     }
     calculated_centroids_D.push_back(centroid_D);
   }
@@ -215,12 +210,7 @@ GTEST_TEST(DeformableContactTest, NonTriangleContactPolygon) {
   int face[3] = {0, 1, 2};
   vector<geometry::SurfaceFace> faces;
   faces.emplace_back(face);
-  const Vector3<double> tri_vertex_data[3] = {
-      {10, 0, 0}, {-5, 5, 0}, {-5, -5, 0}};
-  vector<geometry::SurfaceVertex<double>> tri_vertices;
-  for (auto& vertex : tri_vertex_data) {
-    tri_vertices.emplace_back(vertex);
-  }
+  vector<Vector3<double>> tri_vertices = {{10, 0, 0}, {-5, 5, 0}, {-5, -5, 0}};
   const SurfaceMesh<double> surface_R(std::move(faces),
                                       std::move(tri_vertices));
   const Bvh<Obb, SurfaceMesh<double>> bvh_R(surface_R);
@@ -236,7 +226,7 @@ GTEST_TEST(DeformableContactTest, NonTriangleContactPolygon) {
   tets.emplace_back(tet);
   const Vector3<double> tet_vertex_data[4] = {
       {1, 0, -1}, {-1, 0, -1}, {0, -1, 1}, {0, 1, 1}};
-  vector<VolumeVertex<double>> tet_vertices;
+  vector<Vector3d> tet_vertices;
   for (const auto& vertex : tet_vertex_data) {
     tet_vertices.emplace_back(vertex);
   }

--- a/multibody/fixed_fem/dev/test/deformable_model_test.cc
+++ b/multibody/fixed_fem/dev/test/deformable_model_test.cc
@@ -131,7 +131,7 @@ TEST_F(DeformableModelTest, VertexPositionsOutputPort) {
   const auto& expected_mesh = MakeBoxTetMesh();
   for (int i = 0; i < kNumVertices; ++i) {
     EXPECT_TRUE(CompareMatrices(
-        expected_mesh.vertex(geometry::VolumeVertexIndex(i)).r_MV(),
+        expected_mesh.vertex(geometry::VolumeVertexIndex(i)),
         vertex_positions.segment<3>(3 * i)));
   }
 }

--- a/multibody/fixed_fem/dev/test/deformable_rigid_manager_test.cc
+++ b/multibody/fixed_fem/dev/test/deformable_rigid_manager_test.cc
@@ -64,9 +64,9 @@ VolumeMesh<double> MakeUnitCubeTetMesh(
   DRAKE_DEMAND(mesh.num_vertices() == kNumVertices);
 
   std::vector<geometry::VolumeElement> elements = mesh.tetrahedra();
-  std::vector<geometry::VolumeVertex<double>> vertices;
+  std::vector<Vector3d> vertices;
   for (const auto& v : mesh.vertices()) {
-    vertices.emplace_back(pose * v.r_MV());
+    vertices.emplace_back(pose * v);
   }
   return {std::move(elements), std::move(vertices)};
 }
@@ -294,7 +294,7 @@ TEST_F(DeformableRigidManagerTest, UpdateDeformableVertexPositions) {
        i < deformed_meshes[0].mesh().num_vertices(); ++i) {
     const Vector3<double> p_WV = current_positions[0].segment<3>(3 * i);
     EXPECT_TRUE(
-        CompareMatrices(p_WV, deformed_meshes[0].mesh().vertex(i).r_MV()));
+        CompareMatrices(p_WV, deformed_meshes[0].mesh().vertex(i)));
   }
 }
 

--- a/multibody/plant/contact_results_to_lcm.cc
+++ b/multibody/plant/contact_results_to_lcm.cc
@@ -249,13 +249,13 @@ void ContactResultsToLcmSystem<T>::CalcLcmContactOutput(
 
       // Get the three vertices.
       const auto& face = mesh_W.element(j);
-      const geometry::SurfaceVertex<T>& vA = mesh_W.vertex(face.vertex(0));
-      const geometry::SurfaceVertex<T>& vB = mesh_W.vertex(face.vertex(1));
-      const geometry::SurfaceVertex<T>& vC = mesh_W.vertex(face.vertex(2));
+      const Vector3<T>& vA = mesh_W.vertex(face.vertex(0));
+      const Vector3<T>& vB = mesh_W.vertex(face.vertex(1));
+      const Vector3<T>& vC = mesh_W.vertex(face.vertex(2));
 
-      write_double3(vA.r_MV(), tri_msg.p_WA);
-      write_double3(vB.r_MV(), tri_msg.p_WB);
-      write_double3(vC.r_MV(), tri_msg.p_WC);
+      write_double3(vA, tri_msg.p_WA);
+      write_double3(vB, tri_msg.p_WB);
+      write_double3(vC, tri_msg.p_WC);
 
       // Record the pressures.
       tri_msg.pressure_A =

--- a/multibody/plant/test/contact_results_to_lcm_test.cc
+++ b/multibody/plant/test/contact_results_to_lcm_test.cc
@@ -31,7 +31,6 @@ using geometry::Sphere;
 using geometry::SurfaceFace;
 using geometry::SurfaceFaceIndex;
 using geometry::SurfaceMesh;
-using geometry::SurfaceVertex;
 using geometry::SurfaceVertexIndex;
 using math::RigidTransform;
 using multibody::internal::FullBodyName;
@@ -150,8 +149,8 @@ ContactSurface<T> MakeContactSurface(GeometryId id_M, GeometryId id_N,
    looping through elements). The position of the vertices is offset by offset.
    The position of the vertices is irrelevant -- the mesh is just a collection
    of doubles that get copied. */
-  vector<SurfaceVertex<T>> vertices;
   vector<SurfaceFace> faces;
+  vector<Vector3<T>> vertices;
   vertices.emplace_back(Vector3<double>(0.5, 0.5, -0.5) + offset);
   vertices.emplace_back(Vector3<double>(-0.5, 0.5, -0.5) + offset);
   vertices.emplace_back(Vector3<double>(-0.5, -0.5, -0.5) + offset);
@@ -690,13 +689,13 @@ TYPED_TEST(ContactResultsToLcmTest, HydroContactOnly) {
       // clang-format off
       EXPECT_TRUE(CompareMatrices(
           Vector3<double>(tri_message.p_WA),
-          ExtractDoubleOrThrow(mesh.vertex(tri_data.vertex(0)).r_MV())));
+          ExtractDoubleOrThrow(mesh.vertex(tri_data.vertex(0)))));
       EXPECT_TRUE(CompareMatrices(
           Vector3<double>(tri_message.p_WB),
-          ExtractDoubleOrThrow(mesh.vertex(tri_data.vertex(1)).r_MV())));
+          ExtractDoubleOrThrow(mesh.vertex(tri_data.vertex(1)))));
       EXPECT_TRUE(CompareMatrices(
           Vector3<double>(tri_message.p_WC),
-          ExtractDoubleOrThrow(mesh.vertex(tri_data.vertex(2)).r_MV())));
+          ExtractDoubleOrThrow(mesh.vertex(tri_data.vertex(2)))));
       // clang-format on
       EXPECT_EQ(
           tri_message.pressure_A,

--- a/multibody/plant/test/multibody_plant_hydroelastic_contact_results_output_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_contact_results_output_test.cc
@@ -14,7 +14,6 @@ namespace drake {
 using geometry::ContactSurface;
 using geometry::SurfaceFace;
 using geometry::SurfaceFaceIndex;
-using geometry::SurfaceVertex;
 using geometry::SurfaceVertexIndex;
 using geometry::SurfaceMesh;
 


### PR DESCRIPTION
This removes the impoverished vertex types: `SurfaceVertex` and `VolumeVertex`.

These types were thin wrappers of `Vector3d` and the wrapping provided little value but made constructing meshes cumbersome. Furthermore, to get the actual position of the vertex, the `.r_MV()` method had to be called on it. This led to code bloat and introduced frame and point symbols into calling code that served as spurious noise.

This simply removes all vertex types straight across the board without deprecation.

Relates #15796

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15903)
<!-- Reviewable:end -->
