### PR TITLE
[fixed_fem] DirichletBoundaryCondition is not assignable

### DIFF
--- a/multibody/fixed_fem/dev/dirichlet_boundary_condition.h
+++ b/multibody/fixed_fem/dev/dirichlet_boundary_condition.h
@@ -24,7 +24,7 @@ namespace fem {
 template <class T>
 class DirichletBoundaryCondition {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DirichletBoundaryCondition);
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DirichletBoundaryCondition);
 
   /* Constructs a new %DirichletBoundaryCondition that applies to an FEM model
    that has the given `ode_order`. */


### PR DESCRIPTION
Relates #15884.

The `class DirichletBoundaryCondition` has a `const int ode_order_;` so is not assignable.  Switch from `DRAKE_DEFAULT_COPY...` to `DRAKE_NO_COPY...` to make this clear.  (Since it appears to be pass-by-unique_ptr, the intention always seems to have been for it to be non-copyable in the first place.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15904)
<!-- Reviewable:end -->
