### PR TITLE
[solvers] MinimalDistanceFromSphereProblem is not assignable

### DIFF
--- a/solvers/test/second_order_cone_program_examples.h
+++ b/solvers/test/second_order_cone_program_examples.h
@@ -260,7 +260,7 @@ void SolveAndCheckSmallestEllipsoidCoveringProblems(
 template <int Dim>
 class MinimalDistanceFromSphereProblem {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(MinimalDistanceFromSphereProblem);
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MinimalDistanceFromSphereProblem);
 
   /** @param with_linear_cost If set to true, we add the quadratic cost as the
    * sum of a quadratic and a linear cost. Otherwise we add it as a single
@@ -317,7 +317,7 @@ class MinimalDistanceFromSphereProblem {
   Eigen::Matrix<symbolic::Variable, Dim, 1> x_;
   Eigen::Matrix<double, Dim, 1> pt_;
   Eigen::Matrix<double, Dim, 1> center_;
-  double radius_;
+  const double radius_;
 };
 
 void TestSocpDualSolution1(const SolverInterface& solver,


### PR DESCRIPTION
Relates #15884.

The `class MinimalDistanceFromSphereProblem` has a `MathematicalProgram` member, so has never been copyable, assignable, etc. Switch from `DRAKE_DEFAULT_COPY...` to `DRAKE_NO_COPY...` to make this clear. Also add missing `const` on POD member field.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15905)
<!-- Reviewable:end -->
