### PR TITLE
[geometry] Bvh uses default copy/move/assign operations

### DIFF
--- a/common/copyable_unique_ptr.h
+++ b/common/copyable_unique_ptr.h
@@ -84,15 +84,8 @@ namespace drake {
  instead of `Derived`. Some mistakes that would lead to this degenerate
  behavior:
 
-   - The `Base` class has a public copy constructor.
    - The `Base` class's Clone() implementation does not invoke the `Derived`
    class's implementation of a suitable virtual method.
-
- @warning One important difference between unique_ptr and %copyable_unique_ptr
- is that a unique_ptr can be declared on a forward-declared class type. The
- %copyable_unique_ptr _cannot_. The class must be fully defined so that the
- %copyable_unique_ptr is able to determine if the type meets the requirements
- (i.e., public copy constructible or cloneable).
 
  <!--
  For future developers:
@@ -119,9 +112,9 @@ class copyable_unique_ptr : public std::unique_ptr<T> {
    %copyable_unique_ptr. */
   copyable_unique_ptr() noexcept : std::unique_ptr<T>() {}
 
-  /** Given a pointer to a writable heap-allocated object, take over
+  /** Given a raw pointer to a writable heap-allocated object, take over
    ownership of that object. No copying occurs. */
-  explicit copyable_unique_ptr(T* ptr) noexcept : std::unique_ptr<T>(ptr) {}
+  explicit copyable_unique_ptr(T* raw) noexcept : std::unique_ptr<T>(raw) {}
 
   /** Constructs a unique instance of T as a copy of the provided model value.
    */
@@ -173,8 +166,8 @@ class copyable_unique_ptr : public std::unique_ptr<T> {
   /** This form of assignment replaces the currently-held object by
    the given source object and takes over ownership of the source object. The
    currently-held object (if any) is deleted. */
-  copyable_unique_ptr& operator=(T* ptr) noexcept {
-    std::unique_ptr<T>::reset(ptr);
+  copyable_unique_ptr& operator=(T* raw) noexcept {
+    std::unique_ptr<T>::reset(raw);
     return *this;
   }
 
@@ -369,9 +362,7 @@ class copyable_unique_ptr : public std::unique_ptr<T> {
 
   // True iff type T provides a copy constructor that is accessible from
   // %copyable_unique_ptr<T>. Invoke with `can_copy(1)`; the argument is used
-  // to select the right method. Note that if both `can_copy()` and
-  // `can_clone()` return true, we will prefer the copy constructor over the
-  // Clone() method.
+  // to select the right method.
   static constexpr bool can_copy(...) { return false; }
 
   // If this instantiates successfully it will be the preferred method called
@@ -401,31 +392,26 @@ class copyable_unique_ptr : public std::unique_ptr<T> {
     return true;
   }
 
-  static_assert(
-      can_copy(1) || can_clone(1),
-      "copyable_unique_ptr<T> can only be used with a 'copyable' class T, "
-      "requiring either a copy constructor or a Clone method of the form "
-      "'unique_ptr<T> Clone() const', accessible to copyable_unique_ptr<T>. "
-      "You may need to friend copyable_unique_ptr<T>.");
-
-  // Selects Clone iff there is no copy constructor and the Clone method is of
-  // the expected form.
-  template <typename U = T>
-  static typename std::enable_if_t<!can_copy(1) && can_clone(1), U*>
-  CopyOrNullHelper(const U* ptr, int) {
-    return ptr->Clone().release();
-  }
-
-  // Default to copy constructor if present.
-  template <typename U>
-  static
-  U* CopyOrNullHelper(const U* ptr, ...) {
-    return new U(*ptr);
-  }
-
   // If src is non-null, clone it; otherwise return nullptr.
-  static T* CopyOrNull(const T *ptr) {
-    return ptr ? CopyOrNullHelper(ptr, 1) : nullptr;
+  // If both can_copy() and can_clone() return true, we will prefer the Clone()
+  // function over the copy constructor.
+  // The caller has ownership over the return value.
+  static T* CopyOrNull(const T* raw) {
+    constexpr bool check_can_clone = can_clone(1);
+    constexpr bool check_can_copy = can_copy(1);
+    static_assert(
+        check_can_clone || check_can_copy,
+        "copyable_unique_ptr<T> can only be used with a 'copyable' class T, "
+        "requiring either a copy constructor or a Clone method of the form "
+        "'unique_ptr<T> Clone() const'.");
+    if (raw == nullptr) {
+      return nullptr;
+    }
+    if constexpr (check_can_clone) {
+      return raw->Clone().release();
+    } else {
+      return new T(*raw);
+    }
   }
 };
 

--- a/common/test/copyable_unique_ptr_test.cc
+++ b/common/test/copyable_unique_ptr_test.cc
@@ -121,7 +121,7 @@ GTEST_TEST(CopyableUniquePtrTest, FriendsWithBenefits) {
 }
 
 // A fully copyable class (has both copy constructor and Clone). Confirms that
-// in the presence of both, the copy constructor is preferred.
+// in the presence of both, the clone function is preferred.
 struct FullyCopyable : Base {
   explicit FullyCopyable(int v, Origin org = Origin::CONSTRUCT)
       : Base(v, org) {}
@@ -131,12 +131,12 @@ struct FullyCopyable : Base {
   }
 };
 
-// Confirms that the copy constructor is preferred when both exist.
+// Confirms that Clone is preferred when both exist.
 GTEST_TEST(CopyableUniquePtrTest, FullyCopyableSuccess) {
   cup<FullyCopyable> ptr(new FullyCopyable(1));
   EXPECT_EQ(ptr->origin, Origin::CONSTRUCT);
   cup<FullyCopyable> copy(ptr);
-  EXPECT_EQ(copy->origin, Origin::COPY);
+  EXPECT_EQ(copy->origin, Origin::CLONE);
   EXPECT_EQ(copy->value, ptr->value);
   ++copy->value;
   EXPECT_NE(copy->value, ptr->value);


### PR DESCRIPTION
Fix `copyable_unique_ptr` to be usable on a forward-declared type, ala `unique_ptr`.  In support of that, we can't put a static_assert on T at class scope.

Change `copyable_unique_ptr` to prefer `Clone` over copying.  Ruling our protected-access copy constructors on forward-declared types is a big headache.  If the user went to the trouble of writing a Clone function, surely they want us to use it.

Relates #15884.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15906)
<!-- Reviewable:end -->
