### PR TITLE
[common] SortedPair is consistent with the wrapper type's operators

### DIFF
--- a/common/test/sorted_pair_test.cc
+++ b/common/test/sorted_pair_test.cc
@@ -9,6 +9,16 @@
 namespace drake {
 namespace {
 
+struct NoDefaultCtor {
+  explicit NoDefaultCtor(int value_in) : value(value_in) {}
+
+  bool operator<(const NoDefaultCtor& other) const {
+    return value < other.value;
+  }
+
+  int value{};
+};
+
 // Verifies behavior of the default constructor.
 GTEST_TEST(SortedPair, Default) {
   SortedPair<int> x;
@@ -18,6 +28,15 @@ GTEST_TEST(SortedPair, Default) {
   SortedPair<double> y;
   EXPECT_EQ(y.first(), 0.0);
   EXPECT_EQ(y.second(), 0.0);
+}
+
+// Usable even with non-default-constructible types
+GTEST_TEST(SortedPair, WithoutDefaultCtor) {
+  NoDefaultCtor a(2);
+  NoDefaultCtor b(1);
+  SortedPair<NoDefaultCtor> x(a, b);
+  EXPECT_EQ(x.first().value, 1);
+  EXPECT_EQ(x.second().value, 2);
 }
 
 // Verifies sorting occurs.


### PR DESCRIPTION
Instead of insisting that the wrapped type is default constructible, copy constructible, copy assignable, move constructible, and move assignable, just let the compiler do its thing.

Relates #15884.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15907)
<!-- Reviewable:end -->
