### PR TITLE
[common] Fix typo in an example usage of copyable_unique_ptr.

### DIFF
--- a/common/copyable_unique_ptr.h
+++ b/common/copyable_unique_ptr.h
@@ -74,7 +74,7 @@ namespace drake {
  @code
  copyable_unique_ptr<Base> cu_ptr = make_unique<Derived>();
  copyable_unique_ptr<Base> other_cu_ptr = cu_ptr;           // Triggers a copy.
- is_dynamic_castable<Derived>(cu_other_ptr.get());          // Should be true.
+ is_dynamic_castable<Derived>(other_cu_ptr.get());          // Should be true.
  @endcode
 
  This works for well-designed polymorphic classes.


### PR DESCRIPTION
This is a one-word fix of documentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15908)
<!-- Reviewable:end -->
