### PR TITLE
[geometry,multibody] Rename variable to hydroelastic_modulus.

### DIFF
--- a/bindings/pydrake/geometry_py_common.cc
+++ b/bindings/pydrake/geometry_py_common.cc
@@ -482,7 +482,7 @@ void DoScalarIndependentDefinitions(py::module m) {
           const std::optional<double>&, const std::optional<double>&,
           const std::optional<multibody::CoulombFriction<double>>&,
           ProximityProperties*>(&AddContactMaterial),
-      py::arg("elastic_modulus") = std::nullopt,
+      py::arg("hydroelastic_modulus") = std::nullopt,
       py::arg("dissipation") = std::nullopt,
       py::arg("point_stiffness") = std::nullopt,
       py::arg("friction") = std::nullopt, py::arg("properties"),

--- a/bindings/pydrake/multibody/test/hydroelastic.sdf
+++ b/bindings/pydrake/multibody/test/hydroelastic.sdf
@@ -27,7 +27,7 @@
           <drake:mu_dynamic>0.5</drake:mu_dynamic>
           <drake:mu_static>0.5</drake:mu_static>
           <drake:mesh_resolution_hint>0.1</drake:mesh_resolution_hint>
-          <drake:elastic_modulus>0.5e9</drake:elastic_modulus>
+          <drake:hydroelastic_modulus>0.5e9</drake:hydroelastic_modulus>
           <drake:hunt_crossley_dissipation>1.25</drake:hunt_crossley_dissipation>
           <drake:rigid_hydroelastic/>
         </drake:proximity_properties>
@@ -55,7 +55,7 @@
           <drake:mu_dynamic>0.5</drake:mu_dynamic>
           <drake:mu_static>0.5</drake:mu_static>
           <drake:mesh_resolution_hint>0.2</drake:mesh_resolution_hint>
-          <drake:elastic_modulus>180.0e9</drake:elastic_modulus>
+          <drake:hydroelastic_modulus>180.0e9</drake:hydroelastic_modulus>
           <drake:hunt_crossley_dissipation>1.25</drake:hunt_crossley_dissipation>
           <drake:soft_hydroelastic/>
         </drake:proximity_properties>

--- a/bindings/pydrake/test/geometry_common_test.py
+++ b/bindings/pydrake/test/geometry_common_test.py
@@ -239,13 +239,15 @@ class TestGeometryCore(unittest.TestCase):
         """
         props = mut.ProximityProperties()
         reference_friction = CoulombFriction(0.25, 0.125)
-        mut.AddContactMaterial(elastic_modulus=1.5,
+        mut.AddContactMaterial(hydroelastic_modulus=1.5,
                                dissipation=2.7,
                                point_stiffness=3.9,
                                friction=reference_friction,
                                properties=props)
-        self.assertTrue(props.HasProperty("material", "elastic_modulus"))
-        self.assertEqual(props.GetProperty("material", "elastic_modulus"), 1.5)
+        self.assertTrue(
+            props.HasProperty("material", "hydroelastic_modulus"))
+        self.assertEqual(
+            props.GetProperty("material", "hydroelastic_modulus"), 1.5)
         self.assertTrue(
             props.HasProperty("material", "hunt_crossley_dissipation"))
         self.assertEqual(

--- a/bindings/pydrake/test/geometry_scene_graph_test.py
+++ b/bindings/pydrake/test/geometry_scene_graph_test.py
@@ -52,7 +52,7 @@ class TestGeometrySceneGraph(unittest.TestCase):
                                           shape=mut.Sphere(1.),
                                           name="sphere3"))
         props = mut.ProximityProperties()
-        mut.AddContactMaterial(elastic_modulus=1e8, properties=props)
+        mut.AddContactMaterial(hydroelastic_modulus=1e8, properties=props)
         mut.AddSoftHydroelasticProperties(resolution_hint=1, properties=props)
         scene_graph.AssignRole(source_id=global_source, geometry_id=sphere_3,
                                properties=props)

--- a/examples/multibody/rolling_sphere/make_rolling_sphere_plant.cc
+++ b/examples/multibody/rolling_sphere/make_rolling_sphere_plant.cc
@@ -25,7 +25,7 @@ using drake::multibody::UnitInertia;
 using drake::math::RigidTransformd;
 
 std::unique_ptr<drake::multibody::MultibodyPlant<double>> MakeBouncingBallPlant(
-    double mbp_dt, double radius, double mass, double elastic_modulus,
+    double mbp_dt, double radius, double mass, double hydroelastic_modulus,
     double dissipation, const CoulombFriction<double>& surface_friction,
     const Vector3<double>& gravity_W, bool rigid_sphere, bool soft_ground,
     SceneGraph<double>* scene_graph) {
@@ -46,7 +46,7 @@ std::unique_ptr<drake::multibody::MultibodyPlant<double>> MakeBouncingBallPlant(
     } else {
       AddRigidHydroelasticProperties(&ground_props);
     }
-    AddContactMaterial(elastic_modulus, dissipation, surface_friction,
+    AddContactMaterial(hydroelastic_modulus, dissipation, surface_friction,
                        &ground_props);
     plant->RegisterCollisionGeometry(plant->world_body(), X_WG,
                                      geometry::HalfSpace{}, "collision",
@@ -60,7 +60,7 @@ std::unique_ptr<drake::multibody::MultibodyPlant<double>> MakeBouncingBallPlant(
     const RigidTransformd X_BS = RigidTransformd::Identity();
     // Set material properties for hydroelastics.
     ProximityProperties ball_props;
-    AddContactMaterial(elastic_modulus, dissipation, surface_friction,
+    AddContactMaterial(hydroelastic_modulus, dissipation, surface_friction,
                        &ball_props);
     if (rigid_sphere) {
       AddRigidHydroelasticProperties(radius, &ball_props);

--- a/examples/multibody/rolling_sphere/make_rolling_sphere_plant.h
+++ b/examples/multibody/rolling_sphere/make_rolling_sphere_plant.h
@@ -29,7 +29,7 @@ namespace bouncing_ball {
 ///   The radius of the ball.
 /// @param[in] mass
 ///   The mass of the ball.
-/// @param[in] elastic_modulus
+/// @param[in] hydroelastic_modulus
 ///   The modulus of elasticity for the ball. Only used when modeled with the
 ///   hydroelastic model. See @ref mbp_hydroelastic_materials_properties
 ///   "Hydroelastic contact" documentation for details.
@@ -58,7 +58,7 @@ std::unique_ptr<drake::multibody::MultibodyPlant<double>>
 MakeBouncingBallPlant(
     double mbp_dt,
     double radius, double mass,
-    double elastic_modulus, double dissipation,
+    double hydroelastic_modulus, double dissipation,
     const drake::multibody::CoulombFriction<double>& surface_friction,
     const Vector3<double>& gravity_W, bool rigid_sphere, bool soft_ground,
     geometry::SceneGraph<double>* scene_graph = nullptr);

--- a/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
+++ b/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
@@ -24,8 +24,9 @@ DEFINE_double(simulation_time, 2.0,
 // Contact model parameters.
 DEFINE_string(contact_model, "point",
               "Contact model. Options are: 'point', 'hydroelastic', 'hybrid'.");
-DEFINE_double(elastic_modulus, 5.0e4,
-              "For hydroelastic (and hybrid) contact, elastic modulus, [Pa].");
+DEFINE_double(hydroelastic_modulus, 5.0e4,
+              "For hydroelastic (and hybrid) contact, "
+              "hydroelastic modulus, [Pa].");
 DEFINE_double(dissipation, 5.0,
               "For hydroelastic (and hybrid) contact, Hunt & Crossley "
               "dissipation, [s/m].");
@@ -112,7 +113,7 @@ int do_main() {
       FLAGS_friction_coefficient /* dynamic friction */);
 
   MultibodyPlant<double>& plant = *builder.AddSystem(MakeBouncingBallPlant(
-      FLAGS_mbp_dt, radius, mass, FLAGS_elastic_modulus, FLAGS_dissipation,
+      FLAGS_mbp_dt, radius, mass, FLAGS_hydroelastic_modulus, FLAGS_dissipation,
       coulomb_friction, -g * Vector3d::UnitZ(), FLAGS_rigid_ball,
       FLAGS_soft_ground, &scene_graph));
 

--- a/geometry/proximity/hydroelastic_internal.cc
+++ b/geometry/proximity/hydroelastic_internal.cc
@@ -273,11 +273,11 @@ std::optional<SoftGeometry> MakeSoftRepresentation(
   auto mesh = make_unique<VolumeMesh<double>>(
       MakeSphereVolumeMesh<double>(sphere, edge_length, strategy));
 
-  const double elastic_modulus =
+  const double hydroelastic_modulus =
       validator.Extract(props, kMaterialGroup, kElastic);
 
   auto pressure = make_unique<VolumeMeshFieldLinear<double, double>>(
-      MakeSpherePressureField(sphere, mesh.get(), elastic_modulus));
+      MakeSpherePressureField(sphere, mesh.get(), hydroelastic_modulus));
 
   return SoftGeometry(SoftMesh(move(mesh), move(pressure)));
 }
@@ -289,11 +289,11 @@ std::optional<SoftGeometry> MakeSoftRepresentation(
   auto mesh =
       make_unique<VolumeMesh<double>>(MakeBoxVolumeMeshWithMa<double>(box));
 
-  const double elastic_modulus =
+  const double hydroelastic_modulus =
       validator.Extract(props, kMaterialGroup, kElastic);
 
   auto pressure = make_unique<VolumeMeshFieldLinear<double, double>>(
-      MakeBoxPressureField(box, mesh.get(), elastic_modulus));
+      MakeBoxPressureField(box, mesh.get(), hydroelastic_modulus));
 
   return SoftGeometry(SoftMesh(move(mesh), move(pressure)));
 }
@@ -306,11 +306,11 @@ std::optional<SoftGeometry> MakeSoftRepresentation(
   auto mesh = make_unique<VolumeMesh<double>>(
       MakeCylinderVolumeMeshWithMa<double>(cylinder, edge_length));
 
-  const double elastic_modulus =
+  const double hydroelastic_modulus =
       validator.Extract(props, kMaterialGroup, kElastic);
 
   auto pressure = make_unique<VolumeMeshFieldLinear<double, double>>(
-      MakeCylinderPressureField(cylinder, mesh.get(), elastic_modulus));
+      MakeCylinderPressureField(cylinder, mesh.get(), hydroelastic_modulus));
 
   return SoftGeometry(SoftMesh(move(mesh), move(pressure)));
 }
@@ -323,11 +323,11 @@ std::optional<SoftGeometry> MakeSoftRepresentation(
   auto mesh = make_unique<VolumeMesh<double>>(
       MakeCapsuleVolumeMesh<double>(capsule, edge_length));
 
-  const double elastic_modulus =
+  const double hydroelastic_modulus =
       validator.Extract(props, kMaterialGroup, kElastic);
 
   auto pressure = make_unique<VolumeMeshFieldLinear<double, double>>(
-      MakeCapsulePressureField(capsule, mesh.get(), elastic_modulus));
+      MakeCapsulePressureField(capsule, mesh.get(), hydroelastic_modulus));
 
   return SoftGeometry(SoftMesh(move(mesh), move(pressure)));
 }
@@ -344,11 +344,11 @@ std::optional<SoftGeometry> MakeSoftRepresentation(
   auto mesh = make_unique<VolumeMesh<double>>(
       MakeEllipsoidVolumeMesh<double>(ellipsoid, edge_length, strategy));
 
-  const double elastic_modulus =
+  const double hydroelastic_modulus =
       validator.Extract(props, kMaterialGroup, kElastic);
 
   auto pressure = make_unique<VolumeMeshFieldLinear<double, double>>(
-      MakeEllipsoidPressureField(ellipsoid, mesh.get(), elastic_modulus));
+      MakeEllipsoidPressureField(ellipsoid, mesh.get(), hydroelastic_modulus));
 
   return SoftGeometry(SoftMesh(move(mesh), move(pressure)));
 }
@@ -360,10 +360,10 @@ std::optional<SoftGeometry> MakeSoftRepresentation(
   const double thickness =
       validator.Extract(props, kHydroGroup, kSlabThickness);
 
-  const double elastic_modulus =
+  const double hydroelastic_modulus =
       validator.Extract(props, kMaterialGroup, kElastic);
 
-  return SoftGeometry(SoftHalfSpace{elastic_modulus / thickness});
+  return SoftGeometry(SoftHalfSpace{hydroelastic_modulus / thickness});
 }
 
 }  // namespace hydroelastic

--- a/geometry/proximity/hydroelastic_internal.h
+++ b/geometry/proximity/hydroelastic_internal.h
@@ -432,36 +432,36 @@ std::optional<SoftGeometry> MakeSoftRepresentation(const Shape& shape,
 
 /* Creates a soft sphere (assuming the proximity properties have sufficient
  information). Requires the ('hydroelastic', 'resolution_hint') and
- ('material', 'elastic_modulus') properties.  */
+ ('material', 'hydroelastic_modulus') properties.  */
 std::optional<SoftGeometry> MakeSoftRepresentation(
     const Sphere& sphere, const ProximityProperties& props);
 
 /* Creates a soft box (assuming the proximity properties have sufficient
- information). Requires the ('material', 'elastic_modulus') properties.  */
+ information). Requires the ('material', 'hydroelastic_modulus') properties.  */
 std::optional<SoftGeometry> MakeSoftRepresentation(
     const Box& box, const ProximityProperties& props);
 
 /* Creates a soft cylinder (assuming the proximity properties have sufficient
  information). Requires the ('hydroelastic', 'resolution_hint') and
- ('material', 'elastic_modulus') properties.  */
+ ('material', 'hydroelastic_modulus') properties.  */
 std::optional<SoftGeometry> MakeSoftRepresentation(
     const Cylinder& cylinder, const ProximityProperties& props);
 
 /* Creates a soft capsule (assuming the proximity properties have sufficient
  information). Requires the ('hydroelastic', 'resolution_hint') and
- ('material', 'elastic_modulus') properties.  */
+ ('material', 'hydroelastic_modulus') properties.  */
 std::optional<SoftGeometry> MakeSoftRepresentation(
     const Capsule& capsule, const ProximityProperties& props);
 
 /* Creates a soft ellipsoid (assuming the proximity properties have sufficient
  information). Requires the ('hydroelastic', 'resolution_hint') and
- ('material', 'elastic_modulus') properties.  */
+ ('material', 'hydroelastic_modulus') properties.  */
 std::optional<SoftGeometry> MakeSoftRepresentation(
     const Ellipsoid& ellipsoid, const ProximityProperties& props);
 
 /* Creates a compliant half space (assuming the proximity properties have
  sufficient information). Requires the ('hydroelastic', 'slab_thickness') and
- ('material', 'elastic_modulus') properties.  */
+ ('material', 'hydroelastic_modulus') properties.  */
 std::optional<SoftGeometry> MakeSoftRepresentation(
     const HalfSpace& half_space, const ProximityProperties& props);
 

--- a/geometry/proximity/make_box_field.cc
+++ b/geometry/proximity/make_box_field.cc
@@ -15,8 +15,8 @@ namespace internal {
 template <typename T>
 VolumeMeshFieldLinear<T, T> MakeBoxPressureField(
     const Box& box, const VolumeMesh<T>* mesh_B,
-    const T elastic_modulus) {
-  DRAKE_DEMAND(elastic_modulus > T(0));
+    const T hydroelastic_modulus) {
+  DRAKE_DEMAND(hydroelastic_modulus > T(0));
   const Vector3<double> half_size = box.size() / 2.0;
   const double min_half_size = half_size.minCoeff();
 
@@ -47,7 +47,7 @@ VolumeMeshFieldLinear<T, T> MakeBoxPressureField(
     // Map signed_distance ∈ [-min_half_size, 0] to extent e ∈ [0, 1],
     // -min_half_size ⇝ 1, 0 ⇝ 0.
     T extent = -signed_distance / T(min_half_size);
-    pressure_values.push_back(elastic_modulus * extent);
+    pressure_values.push_back(hydroelastic_modulus * extent);
   }
 
   return VolumeMeshFieldLinear<T, T>(std::move(pressure_values), mesh_B);

--- a/geometry/proximity/make_box_field.h
+++ b/geometry/proximity/make_box_field.h
@@ -12,16 +12,16 @@ namespace internal {
  Generates a linear approximation of a pressure field inside the given box as
  represented by the given volume mesh. The pressure at a point is defined
  as E * e(x) where e ∈ [0,1] is the extent -- a measure of penetration into
- the volume, and E is the given `elastic_modulus`. The pressure is zero on the
- boundary with maximum E in the interior.
+ the volume, and E is the given `hydroelastic_modulus`. The pressure is zero on
+ the boundary with maximum E in the interior.
  @param box              The box with its canonical frame B.
  @param mesh_B           A pointer to a tetrahedral mesh of the box. It is
                          aliased in the returned pressure field and must remain
                          alive as long as the field. The position vectors of
                          mesh vertices are expressed in the box's frame B.
- @param elastic_modulus  Scale extent to pressure.
+ @param hydroelastic_modulus  Scale extent to pressure.
  @return                 The pressure field defined on the tetrahedral mesh.
- @pre                    `elastic_modulus` is strictly positive.
+ @pre                    `hydroelastic_modulus` is strictly positive.
                          `mesh_B` represents the box well (the space enclosed
                          by the mesh should be exactly the same space as the
                          box specification). `mesh_B` has enough resolution
@@ -31,7 +31,7 @@ namespace internal {
 template <typename T>
 VolumeMeshFieldLinear<T, T> MakeBoxPressureField(const Box& box,
                                                  const VolumeMesh<T>* mesh_B,
-                                                 const T elastic_modulus);
+                                                 const T hydroelastic_modulus);
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/make_capsule_field.h
+++ b/geometry/proximity/make_capsule_field.h
@@ -36,9 +36,9 @@ namespace internal {
                          remain alive as long as the field. The position
                          vectors of mesh vertices are expressed in the
                          capsule's frame C.
- @param[in] elastic_modulus  Scale extent to pressure.
+ @param[in] hydroelastic_modulus  Scale extent to pressure.
  @return                 The pressure field defined on the tetrahedral mesh.
- @pre                    `elastic_modulus` is strictly positive.
+ @pre                    `hydroelastic_modulus` is strictly positive.
                          `mesh_C` is non-null.
  @tparam T               The scalar type for representing the mesh vertex
                          positions and the pressure value.
@@ -46,8 +46,8 @@ namespace internal {
 template <typename T>
 VolumeMeshFieldLinear<T, T> MakeCapsulePressureField(
     const Capsule& capsule, const VolumeMesh<T>* mesh_C,
-    const T elastic_modulus) {
-  DRAKE_DEMAND(elastic_modulus > T(0));
+    const T hydroelastic_modulus) {
+  DRAKE_DEMAND(hydroelastic_modulus > T(0));
   DRAKE_DEMAND(mesh_C != nullptr);
   // We only partially check the precondition of the mesh (see @pre). The first
   // two vertices should always be the endpoints of the capsule's medial axis.
@@ -61,7 +61,7 @@ VolumeMeshFieldLinear<T, T> MakeCapsulePressureField(
 
   // Only the inner vertices lying on the medial axis (vertex 0 and 1) have
   // non-zero pressure values.
-  pressure_values[0] = pressure_values[1] = elastic_modulus;
+  pressure_values[0] = pressure_values[1] = hydroelastic_modulus;
 
   return VolumeMeshFieldLinear<T, T>(std::move(pressure_values), mesh_C);
 }

--- a/geometry/proximity/make_cylinder_field.cc
+++ b/geometry/proximity/make_cylinder_field.cc
@@ -16,8 +16,8 @@ namespace internal {
 template <typename T>
 VolumeMeshFieldLinear<T, T> MakeCylinderPressureField(
     const Cylinder& cylinder, const VolumeMesh<T>* mesh_C,
-    const T elastic_modulus) {
-  DRAKE_DEMAND(elastic_modulus > T(0));
+    const T hydroelastic_modulus) {
+  DRAKE_DEMAND(hydroelastic_modulus > T(0));
   const double radius = cylinder.radius();
   const double length = cylinder.length();
   const double min_half_size = std::min(radius, length / 2.0);
@@ -57,7 +57,8 @@ VolumeMeshFieldLinear<T, T> MakeCylinderPressureField(
     const T extent = -signed_distance / T(min_half_size);
     using std::min;
     // Bound the pressure values in [0, E], where E is the elastic modulus.
-    pressure_values.push_back(min(elastic_modulus * extent, elastic_modulus));
+    pressure_values.push_back(
+        min(hydroelastic_modulus * extent, hydroelastic_modulus));
   }
 
   // Make sure the boundary vertices have zero pressure. Numerical rounding

--- a/geometry/proximity/make_cylinder_field.h
+++ b/geometry/proximity/make_cylinder_field.h
@@ -12,8 +12,8 @@ namespace internal {
  Generates a piecewise-linear pressure field inside the given cylinder as
  represented by the given volume mesh. The pressure at a point is defined
  as E * e(x) where e ∈ [0,1] is the extent -- a measure of penetration into
- the volume, and E is the given `elastic_modulus`. The pressure is zero on the
- boundary with maximum E in the interior.
+ the volume, and E is the given `hydroelastic_modulus`. The pressure is zero on
+ the boundary with maximum E in the interior.
 
  For hydroelastics, a desirable mesh (`mesh_C` parameter) for this field can
  be created by MakeCylinderMeshWithMa(), which has these properties:
@@ -39,9 +39,9 @@ namespace internal {
                          remain alive as long as the field. The position
                          vectors of mesh vertices are expressed in the
                          cylinder's frame C.
- @param[in] elastic_modulus  Scale extent to pressure.
+ @param[in] hydroelastic_modulus  Scale extent to pressure.
  @return                 The pressure field defined on the tetrahedral mesh.
- @pre                    `elastic_modulus` is strictly positive.
+ @pre                    `hydroelastic_modulus` is strictly positive.
                          `mesh_C` represents the cylinder and has enough
                          resolution to represent the pressure field.
  @tparam_nonsymbolic_scalar
@@ -49,7 +49,7 @@ namespace internal {
 template <typename T>
 VolumeMeshFieldLinear<T, T> MakeCylinderPressureField(
     const Cylinder& cylinder, const VolumeMesh<T>* mesh_C,
-    const T elastic_modulus);
+    const T hydroelastic_modulus);
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/make_ellipsoid_field.h
+++ b/geometry/proximity/make_ellipsoid_field.h
@@ -16,17 +16,17 @@ namespace internal {
  Generates a piecewise-linear pressure field inside the given ellipsoid as
  represented by the given volume mesh. The pressure at a point is defined
  as E * e(x) where e ∈ [0,1] is the extent -- a measure of penetration into
- the volume, and E is the given `elastic_modulus`. The pressure is zero on the
- boundary with maximum E in the interior.
+ the volume, and E is the given `hydroelastic_modulus`. The pressure is zero on
+ the boundary with maximum E in the interior.
  @param ellipsoid        The ellipsoid with its canonical frame E.
  @param mesh_E           A pointer to a tetrahedral mesh of the ellipsoid. It
                          is aliased in the returned pressure field and must
                          remain alive as long as the field. The position
                          vectors of mesh vertices are expressed in the
                          ellipsoid's frame E.
- @param elastic_modulus  Scale extent to pressure.
+ @param hydroelastic_modulus  Scale extent to pressure.
  @return                 The pressure field defined on the tetrahedral mesh.
- @pre                    `elastic_modulus` is strictly positive.
+ @pre                    `hydroelastic_modulus` is strictly positive.
                          `mesh_E` represents the ellipsoid and has enough
                          resolution to represent the pressure field.
  @tparam T               The scalar type for representing the mesh
@@ -35,7 +35,7 @@ namespace internal {
 template <typename T>
 VolumeMeshFieldLinear<T, T> MakeEllipsoidPressureField(
     const Ellipsoid& ellipsoid, const VolumeMesh<T>* mesh_E,
-    const T elastic_modulus) {
+    const T hydroelastic_modulus) {
   // TODO(DamrongGuoy): Switch to a better implementation in the future.
   //  The current implementation uses a simple map from the ellipsoid to the
   //  unit sphere and assigns extent on the ellipsoid from the extent on the
@@ -53,7 +53,7 @@ VolumeMeshFieldLinear<T, T> MakeEllipsoidPressureField(
   //     functions.  One possibility is to generate the mesh in offset
   //     layers, and define linear pressure fields in each offset with
   //     different elastic modulus.
-  DRAKE_DEMAND(elastic_modulus > T(0));
+  DRAKE_DEMAND(hydroelastic_modulus > T(0));
   const T a = ellipsoid.a();
   const T b = ellipsoid.b();
   const T c = ellipsoid.c();
@@ -73,7 +73,7 @@ VolumeMeshFieldLinear<T, T> MakeEllipsoidPressureField(
     if (extent < kExtentEpsilon) {
       extent = T(0.0);
     }
-    pressure_values.push_back(elastic_modulus * extent);
+    pressure_values.push_back(hydroelastic_modulus * extent);
   }
   return VolumeMeshFieldLinear<T, T>(std::move(pressure_values), mesh_E);
 }

--- a/geometry/proximity/make_sphere_field.h
+++ b/geometry/proximity/make_sphere_field.h
@@ -16,25 +16,25 @@ namespace internal {
  Generates a piecewise-linear pressure field inside the given sphere as
  represented by the given volume mesh. The pressure at a point is defined
  as E * e(x) where e ∈ [0,1] is the extent -- a measure of penetration into
- the volume, and E is the given `elastic_modulus`. The pressure is zero on the
- boundary with maximum E in the interior.
+ the volume, and E is the given `hydroelastic_modulus`. The pressure is zero on
+ the boundary with maximum E in the interior.
  @param sphere           The sphere with its canonical frame S.
  @param mesh_S           A pointer to a tetrahedral mesh of the sphere. It is
                          aliased in the returned pressure field and must remain
                          alive as long as the field. The position vectors of
                          mesh vertices are expressed in the sphere's frame S.
- @param elastic_modulus  Scale extent to pressure.
+ @param hydroelastic_modulus  Scale extent to pressure.
  @return                 The pressure field defined on the tetrahedral mesh.
- @pre                    `elastic_modulus` is strictly positive.
+ @pre                    `hydroelastic_modulus` is strictly positive.
                          `mesh_S` represents the sphere and has enough
                          resolution to represent the pressure field.
  @tparam T               The scalar type for representing the mesh
                          vertex positions and the pressure value.
 */
 template <typename T>
-VolumeMeshFieldLinear<T, T> MakeSpherePressureField(const Sphere& sphere,
-                                                    const VolumeMesh<T>* mesh_S,
-                                                    const T elastic_modulus) {
+VolumeMeshFieldLinear<T, T> MakeSpherePressureField(
+    const Sphere& sphere, const VolumeMesh<T>* mesh_S,
+    const T hydroelastic_modulus) {
   // TODO(DamrongGuoy): Switch to a better implementation in the future. The
   //  current implementation has a number of limitations:
   //  1. For simplicity, we use a scaling of distance to boundary, which is
@@ -46,7 +46,7 @@ VolumeMeshFieldLinear<T, T> MakeSpherePressureField(const Sphere& sphere,
   //     functions.  One possibility is to generate the mesh in offset
   //     layers, and define linear pressure fields in each offset with
   //     different elastic modulus.
-  DRAKE_DEMAND(elastic_modulus > T(0));
+  DRAKE_DEMAND(hydroelastic_modulus > T(0));
   const T radius = sphere.radius();
   std::vector<T> pressure_values;
   pressure_values.reserve(mesh_S->num_vertices());
@@ -59,7 +59,7 @@ VolumeMeshFieldLinear<T, T> MakeSpherePressureField(const Sphere& sphere,
     if (extent < kExtentEpsilon) {
       extent = T(0.0);
     }
-    pressure_values.push_back(elastic_modulus * extent);
+    pressure_values.push_back(hydroelastic_modulus * extent);
   }
   return VolumeMeshFieldLinear<T, T>(std::move(pressure_values), mesh_S);
 }

--- a/geometry/proximity/mesh_half_space_intersection.h
+++ b/geometry/proximity/mesh_half_space_intersection.h
@@ -142,7 +142,7 @@ ConstructSurfaceMeshFromMeshHalfspaceIntersection(
                             canonical frame) and the world frame W.
  @param[in] pressure_scale  A linear scale factor that transforms penetration
                             depth into pressure values. Generally,
-                            `pressure_scale = elastic_modulus / thickness`.
+                            `pressure_scale = hydroelastic_modulus / thickness`.
  @param[in] id_R            The id of the rigid mesh.
  @param[in] mesh_R          The rigid mesh. The field mesh vertices are measured
                             and expressed in Frame R.

--- a/geometry/proximity/test/hydroelastic_internal_test.cc
+++ b/geometry/proximity/test/hydroelastic_internal_test.cc
@@ -32,9 +32,9 @@ GTEST_TEST(SoftMeshTest, TestCopyMoveAssignConstruct) {
   const double resolution_hint = 0.5;
   auto mesh = make_unique<VolumeMesh<double>>(MakeSphereVolumeMesh<double>(
       sphere, resolution_hint, TessellationStrategy::kSingleInteriorVertex));
-  const double elastic_modulus = 1e+7;
+  const double hydroelastic_modulus = 1e+7;
   auto pressure = make_unique<VolumeMeshFieldLinear<double, double>>(
-      MakeSpherePressureField(sphere, mesh.get(), elastic_modulus));
+      MakeSpherePressureField(sphere, mesh.get(), hydroelastic_modulus));
 
   const SoftMesh original(std::move(mesh), std::move(pressure));
 
@@ -125,9 +125,9 @@ GTEST_TEST(SoftGeometryTest, TestCopyMoveAssignConstruct) {
   const double resolution_hint = 0.5;
   auto mesh = make_unique<VolumeMesh<double>>(MakeSphereVolumeMesh<double>(
       sphere, resolution_hint, TessellationStrategy::kSingleInteriorVertex));
-  const double elastic_modulus = 1e+7;
+  const double hydroelastic_modulus = 1e+7;
   auto pressure = make_unique<VolumeMeshFieldLinear<double, double>>(
-      MakeSpherePressureField(sphere, mesh.get(), elastic_modulus));
+      MakeSpherePressureField(sphere, mesh.get(), hydroelastic_modulus));
 
   const SoftGeometry original(SoftMesh(std::move(mesh), std::move(pressure)));
 

--- a/geometry/proximity/test/make_capsule_field_test.cc
+++ b/geometry/proximity/test/make_capsule_field_test.cc
@@ -18,20 +18,20 @@ using Eigen::Vector3d;
 // make_`shape`_field_test.cc for box, sphere, ellipsoid, etc.
 
 // Checks that the pressure values evaluated at each vertex of the underlying
-// mesh of `pressure_field` are within the range [0, elastic_modulus]. Also
+// mesh of `pressure_field` are within the range [0, hydroelastic_modulus]. Also
 // checks that the pressure values evaluate at boundary vertices are 0.
 void CheckMinMaxBoundaryValue(
     const VolumeMeshFieldLinear<double, double>& pressure_field,
-    double elastic_modulus_in) {
-  const double elastic_modulus = elastic_modulus_in;
+    double hydroelastic_modulus_in) {
+  const double hydroelastic_modulus = hydroelastic_modulus_in;
   // Check that all vertices have their pressure values within the range of
-  // zero to elastic_modulus, and their minimum and maximum values are indeed
-  // zero and elastic_modulus respectively.
+  // zero to hydroelastic_modulus, and their minimum and maximum values are
+  // indeed zero and hydroelastic_modulus respectively.
   double max_pressure = std::numeric_limits<double>::lowest();
   double min_pressure = std::numeric_limits<double>::max();
   for (int v = 0; v < pressure_field.mesh().num_vertices(); ++v) {
     const double pressure = pressure_field.EvaluateAtVertex(v);
-    ASSERT_LE(pressure, elastic_modulus);
+    ASSERT_LE(pressure, hydroelastic_modulus);
     ASSERT_GE(pressure, 0.0);
     if (pressure > max_pressure) {
       max_pressure = pressure;
@@ -41,7 +41,7 @@ void CheckMinMaxBoundaryValue(
     }
   }
   EXPECT_EQ(min_pressure, 0.0);
-  EXPECT_EQ(max_pressure, elastic_modulus);
+  EXPECT_EQ(max_pressure, hydroelastic_modulus);
 
   // TODO(joemasterjohn): Rather than searching for boundary vertices, use
   // type traits to access vertices with a particular property using a priori

--- a/geometry/proximity/test/make_cylinder_field_test.cc
+++ b/geometry/proximity/test/make_cylinder_field_test.cc
@@ -18,17 +18,17 @@ using Eigen::Vector3d;
 //  make_`shape`_field_test.cc for box, sphere, ellipsoid, etc.
 void CheckMinMaxBoundaryValue(
     const VolumeMeshFieldLinear<double, double>& pressure_field,
-    const double elastic_modulus) {
+    const double hydroelastic_modulus) {
   // We pick the relative error 1e-14 of the elastic modulus empirically.
-  const double tolerance = 1e-14 * elastic_modulus;
+  const double tolerance = 1e-14 * hydroelastic_modulus;
   // Check that all vertices have their pressure values within the range of
-  // zero to elastic_modulus, and their minimum and maximum values are indeed
-  // zero and elastic_modulus respectively.
+  // zero to hydroelastic_modulus, and their minimum and maximum values are
+  // indeed zero and hydroelastic_modulus respectively.
   double max_pressure = std::numeric_limits<double>::lowest();
   double min_pressure = std::numeric_limits<double>::max();
   for (int v = 0; v < pressure_field.mesh().num_vertices(); ++v) {
     double pressure = pressure_field.EvaluateAtVertex(v);
-    ASSERT_LE(pressure, elastic_modulus + tolerance);
+    ASSERT_LE(pressure, hydroelastic_modulus + tolerance);
     ASSERT_GE(pressure, 0.0);
     if (pressure > max_pressure) {
       max_pressure = pressure;
@@ -38,7 +38,7 @@ void CheckMinMaxBoundaryValue(
     }
   }
   EXPECT_EQ(min_pressure, 0.0);
-  EXPECT_NEAR(max_pressure, elastic_modulus, tolerance);
+  EXPECT_NEAR(max_pressure, hydroelastic_modulus, tolerance);
 
   // Check that all boundary vertices have zero pressure.
   std::vector<int> boundary_vertex_indices =

--- a/geometry/proximity/test/make_ellipsoid_field_test.cc
+++ b/geometry/proximity/test/make_ellipsoid_field_test.cc
@@ -18,15 +18,15 @@ using Eigen::Vector3d;
 //  make_`shape`_field_test.cc for box, sphere, ellipsoid, etc.
 void CheckMinMaxBoundaryValue(
     const VolumeMeshFieldLinear<double, double>& pressure_field,
-    const double elastic_modulus) {
+    const double hydroelastic_modulus) {
   // Check that all vertices have their pressure values within the range of
-  // zero to elastic_modulus, and their minimum and maximum values are indeed
-  // zero and elastic_modulus respectively.
+  // zero to hydroelastic_modulus, and their minimum and maximum values are
+  // indeed zero and hydroelastic_modulus respectively.
   double max_pressure = std::numeric_limits<double>::lowest();
   double min_pressure = std::numeric_limits<double>::max();
   for (int v = 0; v < pressure_field.mesh().num_vertices(); ++v) {
     double pressure = pressure_field.EvaluateAtVertex(v);
-    EXPECT_LE(pressure, elastic_modulus);
+    EXPECT_LE(pressure, hydroelastic_modulus);
     EXPECT_GE(pressure, 0.0);
     if (pressure > max_pressure) {
       max_pressure = pressure;
@@ -36,7 +36,7 @@ void CheckMinMaxBoundaryValue(
     }
   }
   EXPECT_EQ(min_pressure, 0.0);
-  EXPECT_EQ(max_pressure, elastic_modulus);
+  EXPECT_EQ(max_pressure, hydroelastic_modulus);
 
   // Check that all boundary vertices have zero pressure.
   std::vector<int> boundary_vertex_indices =

--- a/geometry/proximity/test/make_sphere_field_test.cc
+++ b/geometry/proximity/test/make_sphere_field_test.cc
@@ -18,15 +18,15 @@ using Eigen::Vector3d;
 //  make_`shape`_field_test.cc for box, sphere, ellipsoid, etc.
 void CheckMinMaxBoundaryValue(
     const VolumeMeshFieldLinear<double, double>& pressure_field,
-    const double elastic_modulus) {
+    const double hydroelastic_modulus) {
   // Check that all vertices have their pressure values within the range of
-  // zero to elastic_modulus, and their minimum and maximum values are indeed
-  // zero and elastic_modulus respectively.
+  // zero to hydroelastic_modulus, and their minimum and maximum values are
+  // indeed zero and hydroelastic_modulus respectively.
   double max_pressure = std::numeric_limits<double>::lowest();
   double min_pressure = std::numeric_limits<double>::max();
   for (int v = 0; v < pressure_field.mesh().num_vertices(); ++v) {
     double pressure = pressure_field.EvaluateAtVertex(v);
-    EXPECT_LE(pressure, elastic_modulus);
+    EXPECT_LE(pressure, hydroelastic_modulus);
     EXPECT_GE(pressure, 0.0);
     if (pressure > max_pressure) {
       max_pressure = pressure;
@@ -36,7 +36,7 @@ void CheckMinMaxBoundaryValue(
     }
   }
   EXPECT_EQ(min_pressure, 0.0);
-  EXPECT_EQ(max_pressure, elastic_modulus);
+  EXPECT_EQ(max_pressure, hydroelastic_modulus);
 
   // Check that all boundary vertices have zero pressure.
   std::vector<int> boundary_vertex_indices =

--- a/geometry/proximity_properties.cc
+++ b/geometry/proximity_properties.cc
@@ -5,7 +5,7 @@ namespace geometry {
 namespace internal {
 
 const char* const kMaterialGroup = "material";
-const char* const kElastic = "elastic_modulus";
+const char* const kElastic = "hydroelastic_modulus";
 const char* const kFriction = "coulomb_friction";
 const char* const kHcDissipation = "hunt_crossley_dissipation";
 const char* const kPointStiffness = "point_contact_stiffness";
@@ -35,26 +35,28 @@ std::ostream& operator<<(std::ostream& out, const HydroelasticType& type) {
 }  // namespace internal
 
 void AddContactMaterial(
-    const std::optional<double>& elastic_modulus,
+    const std::optional<double>& hydroelastic_modulus,
     const std::optional<double>& dissipation,
     const std::optional<multibody::CoulombFriction<double>>& friction,
     ProximityProperties* properties) {
-  AddContactMaterial(elastic_modulus, dissipation, {}, friction, properties);
+  AddContactMaterial(hydroelastic_modulus, dissipation, {}, friction,
+                     properties);
 }
 
 void AddContactMaterial(
-    const std::optional<double>& elastic_modulus,
+    const std::optional<double>& hydroelastic_modulus,
     const std::optional<double>& dissipation,
     const std::optional<double>& point_stiffness,
     const std::optional<multibody::CoulombFriction<double>>& friction,
     ProximityProperties* properties) {
-  if (elastic_modulus.has_value()) {
-    if (*elastic_modulus <= 0) {
-      throw std::logic_error(fmt::format(
-          "The elastic modulus must be positive; given {}", *elastic_modulus));
+  if (hydroelastic_modulus.has_value()) {
+    if (*hydroelastic_modulus <= 0) {
+      throw std::logic_error(
+          fmt::format("The hydroelastic modulus must be positive; given {}",
+                      *hydroelastic_modulus));
     }
     properties->AddProperty(internal::kMaterialGroup, internal::kElastic,
-                            *elastic_modulus);
+                            *hydroelastic_modulus);
   }
   if (dissipation.has_value()) {
     if (*dissipation < 0) {

--- a/geometry/proximity_properties.h
+++ b/geometry/proximity_properties.h
@@ -31,7 +31,8 @@ namespace internal {
 //@{
 
 extern const char* const kMaterialGroup;   ///< The contact material group name.
-extern const char* const kElastic;         ///< Elastic modulus property name.
+extern const char* const kElastic;         ///< Hydroelastic modulus property
+                                           ///< name.
 extern const char* const kFriction;        ///< Friction coefficients property
                                            ///< name.
 extern const char* const kHcDissipation;   ///< Hunt-Crossley dissipation
@@ -104,7 +105,7 @@ std::ostream& operator<<(std::ostream& out, const HydroelasticType& type);
  * `point_stiffness`.
  *
  * These functions will throw an error if:
- * - `elastic_modulus` is not positive
+ * - `hydroelastic_modulus` is not positive
  * - `dissipation` is negative
  * - `point_stiffness` is not positive
  * - Any of the contact material properties have already been defined in
@@ -117,7 +118,7 @@ std::ostream& operator<<(std::ostream& out, const HydroelasticType& type);
  *                        "Contact Material Utility Functions".
  */
 void AddContactMaterial(
-    const std::optional<double>& elastic_modulus,
+    const std::optional<double>& hydroelastic_modulus,
     const std::optional<double>& dissipation,
     const std::optional<double>& point_stiffness,
     const std::optional<multibody::CoulombFriction<double>>& friction,
@@ -128,7 +129,7 @@ void AddContactMaterial(
  * argument for `point_stiffness` rather than this one.
  */
 void AddContactMaterial(
-    const std::optional<double>& elastic_modulus,
+    const std::optional<double>& hydroelastic_modulus,
     const std::optional<double>& dissipation,
     const std::optional<multibody::CoulombFriction<double>>& friction,
     ProximityProperties* properties);

--- a/geometry/test/proximity_properties_test.cc
+++ b/geometry/test/proximity_properties_test.cc
@@ -40,7 +40,7 @@ GTEST_TEST(ProximityPropertiesTest, AddContactMaterial) {
     EXPECT_EQ(mu_stored.dynamic_friction(), mu.dynamic_friction());
   }
 
-  // Error case: Already has elastic_modulus.
+  // Error case: Already has hydroelastic_modulus.
   {
     ProximityProperties p;
     p.AddProperty(kMaterialGroup, kElastic, E);

--- a/multibody/hydroelastics/hydroelastic_engine.cc
+++ b/multibody/hydroelastics/hydroelastic_engine.cc
@@ -20,7 +20,7 @@ using geometry::ProximityProperties;
 using geometry::SceneGraphInspector;
 
 struct MaterialProperties {
-  double elastic_modulus{-1};
+  double hydroelastic_modulus{-1};
   double dissipation{-1};
 };
 
@@ -31,11 +31,11 @@ MaterialProperties GetMaterials(GeometryId id,
   MaterialProperties material;
   if (const ProximityProperties* properties =
           inspector.GetProximityProperties(id)) {
-    material.elastic_modulus =
-        properties->GetPropertyOrDefault("material", "elastic_modulus", kInf);
+    material.hydroelastic_modulus = properties->GetPropertyOrDefault(
+        "material", "hydroelastic_modulus", kInf);
     material.dissipation = properties->GetPropertyOrDefault(
         "material", "hunt_crossley_dissipation", 0.0);
-    DRAKE_DEMAND(material.elastic_modulus > 0);
+    DRAKE_DEMAND(material.hydroelastic_modulus > 0);
     DRAKE_DEMAND(material.dissipation >= 0);
   } else {
     throw std::runtime_error(fmt::format(
@@ -55,8 +55,8 @@ double HydroelasticEngine<T>::CalcCombinedElasticModulus(
   const MaterialProperties material_A = GetMaterials(id_A, inspector);
   const MaterialProperties material_B = GetMaterials(id_B, inspector);
 
-  const double E_A = material_A.elastic_modulus;
-  const double E_B = material_B.elastic_modulus;
+  const double E_A = material_A.hydroelastic_modulus;
+  const double E_B = material_B.hydroelastic_modulus;
   if (E_A == kInf) return E_B;
   if (E_B == kInf) return E_A;
   return E_A * E_B / (E_A + E_B);
@@ -73,8 +73,8 @@ double HydroelasticEngine<T>::CalcCombinedDissipation(
   const MaterialProperties material_A = GetMaterials(id_A, inspector);
   const MaterialProperties material_B = GetMaterials(id_B, inspector);
 
-  const double E_A = material_A.elastic_modulus;
-  const double E_B = material_B.elastic_modulus;
+  const double E_A = material_A.hydroelastic_modulus;
+  const double E_B = material_B.hydroelastic_modulus;
   const double d_A = material_A.dissipation;
   const double d_B = material_B.dissipation;
   const double Estar = CalcCombinedElasticModulus(id_A, id_B, inspector);

--- a/multibody/hydroelastics/test/hydroelastic_engine_test.cc
+++ b/multibody/hydroelastics/test/hydroelastic_engine_test.cc
@@ -48,11 +48,11 @@ class HydroelasticEngineTest : public ::testing::Test {
 
   /** Adds a geometry with the given name and assigns soft hydroelastic geometry
    properties.  */
-  GeometryId AddSoftGeometry(const std::string& name, double elastic_modulus,
-                             double dissipation) {
+  GeometryId AddSoftGeometry(const std::string& name,
+                             double hydroelastic_modulus, double dissipation) {
     GeometryId id = AddGeometry(name);
     ProximityProperties props;
-    props.AddProperty("material", "elastic_modulus", elastic_modulus);
+    props.AddProperty("material", "hydroelastic_modulus", hydroelastic_modulus);
     props.AddProperty("material", "hunt_crossley_dissipation", dissipation);
     scene_graph_.AssignRole(source_id_, id, props);
     return id;

--- a/multibody/parsing/detail_common.cc
+++ b/multibody/parsing/detail_common.cc
@@ -34,7 +34,21 @@ geometry::ProximityProperties ParseProximityProperties(
     }
   }
 
-  std::optional<double> elastic_modulus = read_double("drake:elastic_modulus");
+  std::optional<double> hydroelastic_modulus =
+      read_double("drake:hydroelastic_modulus");
+  {
+    std::optional<double> elastic_modulus =
+        read_double("drake:elastic_modulus");
+    if (elastic_modulus.has_value()) {
+      static const logging::Warn log_once(
+          "The tag drake:elastic_modulus is deprecated, and will be removed on"
+          " or around 2022-02-01. Please use drake:hydroelastic_modulus"
+          " instead.");
+    }
+    if (!hydroelastic_modulus.has_value()) {
+      hydroelastic_modulus = elastic_modulus;
+    }
+  }
 
   std::optional<double> dissipation =
       read_double("drake:hunt_crossley_dissipation");
@@ -55,7 +69,7 @@ geometry::ProximityProperties ParseProximityProperties(
     friction = CoulombFriction<double>(*mu_static, *mu_static);
   }
 
-  geometry::AddContactMaterial(elastic_modulus, dissipation, stiffness,
+  geometry::AddContactMaterial(hydroelastic_modulus, dissipation, stiffness,
                                friction, &properties);
 
   return properties;

--- a/multibody/parsing/detail_scene_graph.h
+++ b/multibody/parsing/detail_scene_graph.h
@@ -146,13 +146,13 @@ math::RigidTransformd MakeGeometryPoseFromSdfCollision(
  of these properties.
  | Tag                              | Group        | Property                  | Notes                                                                                                                            |
  | :------------------------------: | :----------: | :-----------------------: | :------------------------------------------------------------------------------------------------------------------------------: |
- | drake:mesh_resolution_hint       | hydroelastic | resolution_hint           | Required for shapes that require tessellation to support hydroelastic contact.                                                    |
- | drake:elastic_modulus            | material     | elastic_modulus           | Finite positive value. Required for soft hydroelastic representations.                                                           |
+ | drake:mesh_resolution_hint       | hydroelastic | resolution_hint           | Required for shapes that require tessellation to support hydroelastic contact.                                                   |
+ | drake:hydroelastic_modulus       | material     | hydroelastic_modulus      | Finite positive value. Required for soft hydroelastic representations.                                                           |
  | drake:hunt_crossley_dissipation  | material     | hunt_crossley_dissipation |                                                                                                                                  |
  | drake:mu_dynamic                 | material     | coulomb_friction          | See note below on friction.                                                                                                      |
  | drake:mu_static                  | material     | coulomb_friction          | See note below on friction.                                                                                                      |
  | drake:rigid_hydroelastic         | hydroelastic | compliance_type           | Requests a rigid hydroelastic representation. Cannot be combined *with* soft_hydroelastic.                                       |
- | drake:soft_hydroelastic          | hydroelastic | compliance_type           | Requests a soft hydroelastic representation. Cannot be combined *with* rigid_hydroelastic. Requires a value for elastic_modulus. |
+ | drake:soft_hydroelastic          | hydroelastic | compliance_type           | Requests a soft hydroelastic representation. Cannot be combined *with* rigid_hydroelastic. Requires a value for hydroelastic_modulus. |
 
  <h3>Coefficients of friction</h3>
 

--- a/multibody/parsing/detail_urdf_geometry.h
+++ b/multibody/parsing/detail_urdf_geometry.h
@@ -159,13 +159,13 @@ geometry::GeometryInstance ParseVisual(
  of these properties.
  | Tag                              | Group        | Property                  | Notes                                                                                                                            |
  | :------------------------------: | :----------: | :-----------------------: | :------------------------------------------------------------------------------------------------------------------------------: |
- | drake:mesh_resolution_hint       | hydroelastic | resolution_hint           | Required for shapes that require tessellation to support hydroelastic contact.                                                    |
- | drake:elastic_modulus            | material     | elastic_modulus           | Finite positive value. Required for soft hydroelastic representations.                                                           |
+ | drake:mesh_resolution_hint       | hydroelastic | resolution_hint           | Required for shapes that require tessellation to support hydroelastic contact.                                                   |
+ | drake:hydroelastic_modulus       | material     | hydroelastic_modulus      | Finite positive value. Required for soft hydroelastic representations.                                                           |
  | drake:hunt_crossley_dissipation  | material     | hunt_crossley_dissipation |                                                                                                                                  |
  | drake:mu_dynamic                 | material     | coulomb_friction          | See note below on friction.                                                                                                      |
  | drake:mu_static                  | material     | coulomb_friction          | See note below on friction.                                                                                                      |
  | drake:rigid_hydroelastic         | hydroelastic | compliance_type           | Requests a rigid hydroelastic representation. Cannot be combined *with* soft_hydroelastic.                                       |
- | drake:soft_hydroelastic          | hydroelastic | compliance_type           | Requests a soft hydroelastic representation. Cannot be combined *with* rigid_hydroelastic. Requires a value for elastic_modulus. |
+ | drake:soft_hydroelastic          | hydroelastic | compliance_type           | Requests a soft hydroelastic representation. Cannot be combined *with* rigid_hydroelastic. Requires a value for hydroelastic_modulus. |
 
  <h3>Coefficients of friction</h3>
 

--- a/multibody/parsing/test/detail_common_test.cc
+++ b/multibody/parsing/test/detail_common_test.cc
@@ -149,13 +149,28 @@ GTEST_TEST(ParseProximityPropertiesTest, HydroelasticProperties) {
   }
 }
 
-// Confirms successful parsing of elastic modulus.
-GTEST_TEST(ParseProximityPropertiesTest, ElasticModulus) {
+// Confirms successful parsing of hydroelastic modulus.
+GTEST_TEST(ParseProximityPropertiesTest, HydroelasticModulus) {
+  const double kValue = 1.75;
+  ProximityProperties properties = ParseProximityProperties(
+      param_read_double("drake:hydroelastic_modulus", kValue), !rigid, !soft);
+  EXPECT_TRUE(ExpectScalar(kMaterialGroup, kElastic, kValue, properties));
+  // Hydroelastic modulus is the only property.
+  EXPECT_EQ(properties.GetPropertiesInGroup(kMaterialGroup).size(), 1u);
+  EXPECT_EQ(properties.num_groups(), 2);  // Material and default groups.
+}
+
+// TODO(DamrongGuoy): Remove this test when we remove the support of the tag
+//  drake:elastic_modulus. See ParseProximityProperties().
+
+// Confirms the tag drake:elastic_modulus is still working.
+// The tag drake:elastic_modulus is deprecated, and will be removed on or
+// around 2022-02-01.
+GTEST_TEST(ParseProximityPropertiesTest, DeprecateElasticModulus) {
   const double kValue = 1.75;
   ProximityProperties properties = ParseProximityProperties(
       param_read_double("drake:elastic_modulus", kValue), !rigid, !soft);
   EXPECT_TRUE(ExpectScalar(kMaterialGroup, kElastic, kValue, properties));
-  // Elastic modulus is the only property.
   EXPECT_EQ(properties.GetPropertiesInGroup(kMaterialGroup).size(), 1u);
   EXPECT_EQ(properties.num_groups(), 2);  // Material and default groups.
 }

--- a/multibody/parsing/test/detail_scene_graph_test.cc
+++ b/multibody/parsing/test/detail_scene_graph_test.cc
@@ -1078,7 +1078,7 @@ GTEST_TEST(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
     unique_ptr<sdf::Collision> sdf_collision = make_sdf_collision(R"""(
   <drake:proximity_properties>
     <drake:mesh_resolution_hint>2.5</drake:mesh_resolution_hint>
-    <drake:elastic_modulus>3.5</drake:elastic_modulus>
+    <drake:hydroelastic_modulus>3.5</drake:hydroelastic_modulus>
     <drake:hunt_crossley_dissipation>4.5</drake:hunt_crossley_dissipation>
     <drake:mu_dynamic>4.5</drake:mu_dynamic>
     <drake:mu_static>4.75</drake:mu_static>

--- a/multibody/parsing/test/detail_urdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_urdf_geometry_test.cc
@@ -558,7 +558,7 @@ TEST_F(UrdfGeometryTests, CollisionProperties) {
     unique_ptr<XMLDocument> doc = MakeCollisionDocFromString(R"""(
   <drake:proximity_properties>
     <drake:mesh_resolution_hint value="2.5"/>
-    <drake:elastic_modulus value="3.5" />
+    <drake:hydroelastic_modulus value="3.5" />
     <drake:hunt_crossley_dissipation value="3.5" />
     <drake:mu_dynamic value="3.25" />
     <drake:mu_static value="3.5" />

--- a/multibody/plant/test/multibody_plant_hydroelastic_contact_results_output_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_contact_results_output_test.cc
@@ -36,7 +36,7 @@ class HydroelasticContactResultsOutputTester : public ::testing::Test {
     // Set some reasonable, but arbitrary, parameters: none of these will
     // affect the test results.
     const double mass = 2.0;                           // kg.
-    const double elastic_modulus = 1e7;                // Pascals.
+    const double hydroelastic_modulus = 1e7;           // Pascals.
     const Vector3<double> gravity_W(0, 0, -9.8);       // m/s^2.
 
     // Create the plant.
@@ -48,7 +48,7 @@ class HydroelasticContactResultsOutputTester : public ::testing::Test {
     //  directory. Examples code shouldn't feed back into other code.
     plant_ = builder.AddSystem(
         examples::multibody::bouncing_ball::MakeBouncingBallPlant(
-            0.0 /* mbp_dt */, radius, mass, elastic_modulus, dissipation,
+            0.0 /* mbp_dt */, radius, mass, hydroelastic_modulus, dissipation,
             friction, gravity_W, false /* rigid_sphere */,
             false /* soft_ground */, &scene_graph));
     plant_->set_contact_model(ContactModel::kHydroelastic);

--- a/multibody/plant/test/multibody_plant_hydroelastic_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_test.cc
@@ -102,7 +102,7 @@ class HydroelasticModelTests : public ::testing::Test {
   }
 
   const RigidBody<double>& AddObject(MultibodyPlant<double>* plant,
-                                     double radius, double elastic_modulus,
+                                     double radius, double hydroelastic_modulus,
                                      double dissipation,
                                      double friction_coefficient) {
     // Inertial properties are only needed when verifying accelerations since
@@ -126,7 +126,7 @@ class HydroelasticModelTests : public ::testing::Test {
     // This should produce a level-2 refinement (two steps beyond octahedron).
     geometry::AddSoftHydroelasticProperties(radius / 2, &props);
     geometry::AddContactMaterial(
-        elastic_modulus, dissipation,
+        hydroelastic_modulus, dissipation,
         CoulombFriction<double>(friction_coefficient, friction_coefficient),
         &props);
     plant->RegisterCollisionGeometry(body, X_BG, shape, "BodyCollisionGeometry",


### PR DESCRIPTION
Replace the generic name of the variable elastic_modulus with the
more specific name hydroelastic_modulus for hydroelastic contact
models.

It deprecates SDF/URDF tag drake:elastic_modulus, but it breaks the named argument elastic_modulus in pydrake (see #15931).

The MbP's Doxygen about (hydro)elastic modulus ([contact modeling](https://drake.mit.edu/doxygen_cxx/classdrake_1_1multibody_1_1_multibody_plant.html#mbp_contact_modeling)) will belong to PR #15924.

Relate to #15796.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15911)
<!-- Reviewable:end -->
