### PR TITLE
[hydro] Remove SurfaceVertexIndex type

### DIFF
--- a/bindings/pydrake/geometry_py_hydro.cc
+++ b/bindings/pydrake/geometry_py_hydro.cc
@@ -66,8 +66,6 @@ void DoScalarIndependentDefinitions(py::module m) {
 
   // All the index types up front, so they'll be available to every other type.
   {
-    BindTypeSafeIndex<SurfaceVertexIndex>(
-        m, "SurfaceVertexIndex", doc.SurfaceVertexIndex.doc);
     BindTypeSafeIndex<SurfaceFaceIndex>(
         m, "SurfaceFaceIndex", doc.SurfaceFaceIndex.doc);
     BindTypeSafeIndex<VolumeVertexIndex>(
@@ -82,9 +80,8 @@ void DoScalarIndependentDefinitions(py::module m) {
     constexpr auto& cls_doc = doc.SurfaceFace;
     py::class_<Class> cls(m, "SurfaceFace", cls_doc.doc);
     cls  // BR
-        .def(py::init<SurfaceVertexIndex, SurfaceVertexIndex,
-                 SurfaceVertexIndex>(),
-            py::arg("v0"), py::arg("v1"), py::arg("v2"), cls_doc.ctor.doc_3args)
+        .def(py::init<int, int, int>(), py::arg("v0"), py::arg("v1"),
+            py::arg("v2"), cls_doc.ctor.doc_3args)
         // TODO(SeanCurtis-TRI): Bind constructor that takes array of ints.
         .def("vertex", &Class::vertex, py::arg("i"), cls_doc.vertex.doc);
     DefCopyAndDeepCopy(&cls);

--- a/bindings/pydrake/test/geometry_hydro_test.py
+++ b/bindings/pydrake/test/geometry_hydro_test.py
@@ -65,12 +65,8 @@ class TestGeometryHydro(unittest.TestCase):
         #      |/___|
         #     2      3
 
-        f_a = mut.SurfaceFace(v0=mut.SurfaceVertexIndex(3),
-                              v1=mut.SurfaceVertexIndex(1),
-                              v2=mut.SurfaceVertexIndex(2))
-        f_b = mut.SurfaceFace(v0=mut.SurfaceVertexIndex(2),
-                              v1=mut.SurfaceVertexIndex(1),
-                              v2=mut.SurfaceVertexIndex(0))
+        f_a = mut.SurfaceFace(v0=3, v1=1, v2=2)
+        f_b = mut.SurfaceFace(v0=2, v1=1, v2=0)
         self.assertEqual(f_a.vertex(0), 3)
         self.assertEqual(f_b.vertex(1), 1)
 

--- a/geometry/drake_visualizer.cc
+++ b/geometry/drake_visualizer.cc
@@ -119,7 +119,7 @@ lcmt_viewer_geometry_data MakeHydroMesh(GeometryId geometry_id,
   for (SurfaceFaceIndex f(0); f < surface_mesh.num_faces(); ++f) {
     const auto& face = surface_mesh.element(f);
     for (int fv = 0; fv < 3; ++fv) {
-      const SurfaceVertexIndex v_i = face.vertex(fv);
+      const int v_i = face.vertex(fv);
       const Vector3<float> p_MV =
           surface_mesh.vertex(v_i).template cast<float>();
       float_data[++v_index] = p_MV.x();

--- a/geometry/proximity/contact_surface_utility.h
+++ b/geometry/proximity/contact_surface_utility.h
@@ -23,7 +23,8 @@ namespace internal {
  In debug builds, this method will do _expensive_ validation of its parameters.
 
  @param polygon
-     The planar N-sided convex polygon.
+     The planar N-sided convex polygon defined by three or more ordered indices
+     into `vertices_F`.
  @param[in] n_F
      A vector that is perpendicular to the `polygon`'s plane, expressed in
      Frame F.
@@ -39,7 +40,7 @@ namespace internal {
  @tparam_nonsymbolic_scalar
  */
 template <typename T>
-Vector3<T> CalcPolygonCentroid(const std::vector<SurfaceVertexIndex>& polygon,
+Vector3<T> CalcPolygonCentroid(const std::vector<int>& polygon,
                                const Vector3<T>& n_F,
                                const std::vector<Vector3<T>>& vertices_F);
 
@@ -108,7 +109,7 @@ T CalcPolygonArea(const std::vector<Vector3<T>>& p_FVs,
  @pre `n_F` has non-trivial length.
  @tparam_nonsymbolic_scalar */
 template <typename T>
-void AddPolygonToMeshData(const std::vector<SurfaceVertexIndex>& polygon,
+void AddPolygonToMeshData(const std::vector<int>& polygon,
                           const Vector3<T>& n_F,
                           std::vector<SurfaceFace>* faces,
                           std::vector<Vector3<T>>* vertices_F);

--- a/geometry/proximity/mesh_half_space_intersection.h
+++ b/geometry/proximity/mesh_half_space_intersection.h
@@ -88,10 +88,8 @@ void ConstructTriangleHalfspaceIntersectionPolygon(
     ContactPolygonRepresentation representation,
     std::vector<Vector3<T>>* new_vertices_W,
     std::vector<SurfaceFace>* new_faces,
-    std::unordered_map<SurfaceVertexIndex, SurfaceVertexIndex>*
-        vertices_to_newly_created_vertices,
-    std::unordered_map<SortedPair<SurfaceVertexIndex>, SurfaceVertexIndex>*
-        edges_to_newly_created_vertices);
+    std::unordered_map<int, int>* vertices_to_newly_created_vertices,
+    std::unordered_map<SortedPair<int>, int>* edges_to_newly_created_vertices);
 
 /*
  Computes a triangular surface mesh by intersecting a half space with a set of

--- a/geometry/proximity/mesh_intersection.cc
+++ b/geometry/proximity/mesh_intersection.cc
@@ -203,7 +203,7 @@ SurfaceVolumeIntersector<T>::ClipTriangleByTetrahedron(
   // surface_N.
   polygon_M->clear();
   for (int i = 0; i < 3; ++i) {
-    SurfaceVertexIndex v = surface_N.element(face).vertex(i);
+    const int v = surface_N.element(face).vertex(i);
     const Vector3<T>& p_NV = surface_N.vertex(v).cast<T>();
     polygon_M->push_back(X_MN * p_NV);
   }
@@ -312,7 +312,7 @@ void SurfaceVolumeIntersector<T>::SampleVolumeFieldOnSurface(
   // We know that each contact polygon has at most 7 vertices because
   // each surface triangle is clipped by four half-spaces of the four
   // triangular faces of a tetrahedron.
-  std::vector<SurfaceVertexIndex> contact_polygon;
+  std::vector<int> contact_polygon;
   contact_polygon.reserve(7);
 
   const math::RigidTransform<double> X_MN_d = convert_to_double(X_MN);

--- a/geometry/proximity/mesh_plane_intersection.cc
+++ b/geometry/proximity/mesh_plane_intersection.cc
@@ -71,7 +71,7 @@ void SliceTetWithPlane(VolumeElementIndex tet_index,
                        std::vector<Vector3<T>>* vertices_W,
                        std::vector<T>* surface_e,
                        std::unordered_map<SortedPair<VolumeVertexIndex>,
-                                          SurfaceVertexIndex>* cut_edges) {
+                                          int>* cut_edges) {
   const VolumeMesh<double>& mesh_M = field_M.mesh();
 
   T distance[4];
@@ -93,7 +93,7 @@ void SliceTetWithPlane(VolumeElementIndex tet_index,
   // Indices of the new polygon's vertices in vertices_W. There can be, at
   // most, four due to the intersection with the plane.
   // Used for ContactPolygonRepresentation::kCentroidSubdivision.
-  std::vector<SurfaceVertexIndex> face_verts(4);
+  std::vector<int> face_verts(4);
   // Positions of the new polygon's vertices.
   // Used for ContactPolygonRepresentation::kSingleTriangle.
   std::vector<Vector3<T>> polygon_W(4);
@@ -131,7 +131,7 @@ void SliceTetWithPlane(VolumeElementIndex tet_index,
 
       switch (representation) {
         case ContactPolygonRepresentation::kCentroidSubdivision: {
-          SurfaceVertexIndex new_index{static_cast<int>(vertices_W->size())};
+          int new_index = static_cast<int>(vertices_W->size());
           vertices_W->emplace_back(p_WC);
           const double e0 = field_M.EvaluateAtVertex(v0);
           const double e1 = field_M.EvaluateAtVertex(v1);
@@ -183,8 +183,7 @@ std::unique_ptr<ContactSurface<T>> ComputeContactSurface(
   std::vector<SurfaceFace> faces;
   std::vector<Vector3<T>> vertices_W;
   std::vector<T> surface_e;
-  std::unordered_map<SortedPair<VolumeVertexIndex>, SurfaceVertexIndex>
-      cut_edges;
+  std::unordered_map<SortedPair<VolumeVertexIndex>, int> cut_edges;
 
   auto grad_eM_W = std::make_unique<std::vector<Vector3<T>>>();
   size_t old_face_count = 0;

--- a/geometry/proximity/mesh_plane_intersection.h
+++ b/geometry/proximity/mesh_plane_intersection.h
@@ -76,8 +76,9 @@ namespace internal {
  @param[in,out] surface_e   The per-vertex field values. Upon returning,
                             surface_e.size() == vertices_W.size() is true.
  @param[in,out] cut_edges   The cache of volume mesh edges that have already
-                            been cut and the surface mesh vertex associated
-                            with it.
+                            been cut and the index of the surface mesh vertex
+                            (indexing into vertices_W) that represents the cut
+                            point.
  @pre `tet_index` lies in the range `[0, field_M.mesh().num_elements())`.
  */
 template <typename T>
@@ -90,7 +91,7 @@ void SliceTetWithPlane(VolumeElementIndex tet_index,
                        std::vector<Vector3<T>>* vertices_W,
                        std::vector<T>* surface_e,
                        std::unordered_map<SortedPair<VolumeVertexIndex>,
-                                          SurfaceVertexIndex>* cut_edges);
+                                          int>* cut_edges);
 
 /* Computes a ContactSurface by intersecting a plane with a set of tetrahedra
  drawn from the given volume mesh (and its pressure field). The indicated

--- a/geometry/proximity/surface_mesh.h
+++ b/geometry/proximity/surface_mesh.h
@@ -16,14 +16,9 @@
 
 namespace drake {
 namespace geometry {
-
-/**
- Index used to identify a vertex in a surface mesh.
- */
-using SurfaceVertexIndex = TypeSafeIndex<class SurfaceVertexTag>;
-
-template <typename T>
-using SurfaceVertex = Vector3<T>;
+/** Index used to identify a vertex in a surface mesh. Use `int` instead; this
+ will disappear imminently. */
+using SurfaceVertexIndex = int;
 
 /**
  Index for identifying a triangular face in a surface mesh.
@@ -40,28 +35,22 @@ class SurfaceFace {
    @param v0 Index of the first vertex in SurfaceMesh.
    @param v1 Index of the second vertex in SurfaceMesh.
    @param v2 Index of the last vertex in SurfaceMesh.
-   */
-  SurfaceFace(SurfaceVertexIndex v0,
-              SurfaceVertexIndex v1,
-              SurfaceVertexIndex v2)
-      : vertex_({v0, v1, v2}) {}
+   @pre index values are non-negative. */
+  SurfaceFace(int v0, int v1, int v2) : vertex_({v0, v1, v2}) {
+    DRAKE_DEMAND(v0 >= 0 && v1 >= 0 && v2 >= 0);
+  }
 
   /** Constructs SurfaceFace.
    @param v  array of three integer indices of the vertices of the face in
              SurfaceMesh.
-   */
-  explicit SurfaceFace(const int v[3])
-      : vertex_({SurfaceVertexIndex(v[0]),
-                 SurfaceVertexIndex(v[1]),
-                 SurfaceVertexIndex(v[2])}) {}
+   @pre index values are non-negative. */
+  explicit SurfaceFace(const int v[3]) : SurfaceFace(v[0], v[1], v[2]) {}
 
   /** Returns the vertex index in SurfaceMesh of the i-th vertex of this face.
    @param i  The local index of the vertex in this face.
    @pre 0 <= i < 3
    */
-  SurfaceVertexIndex vertex(int i) const {
-    return vertex_.at(i);
-  }
+  int vertex(int i) const { return vertex_.at(i); }
 
   /** Reverses the order of the vertex indices -- this essentially flips the
    face normal based on the right-handed normal rule.
@@ -72,7 +61,7 @@ class SurfaceFace {
 
  private:
   // The vertices of this face.
-  std::array<SurfaceVertexIndex, 3> vertex_;
+  std::array<int, 3> vertex_;
 };
 
 namespace internal {
@@ -114,7 +103,7 @@ class SurfaceMesh {
   /**
    Index for identifying a vertex.
    */
-  using VertexIndex = SurfaceVertexIndex;
+  using VertexIndex = int;
 
   /**
    Index for identifying a triangular element.
@@ -165,7 +154,7 @@ class SurfaceMesh {
    @param v  The index of the vertex.
    @pre v ∈ {0, 1, 2,...,num_vertices()-1}.
    */
-  const Vector3<T>& vertex(VertexIndex v) const {
+  const Vector3<T>& vertex(int v) const {
     DRAKE_DEMAND(0 <= v && v < num_vertices());
     return vertices_[v];
   }
@@ -372,7 +361,7 @@ class SurfaceMesh {
         Vector3<T>::Constant(std::numeric_limits<double>::max());
     Vector3<T> max_extent =
         Vector3<T>::Constant(std::numeric_limits<double>::lowest());
-    for (SurfaceVertexIndex i(0); i < num_vertices(); ++i) {
+    for (int i = 0; i < num_vertices(); ++i) {
       Vector3<T> vertex = this->vertex(i);
       min_extent = min_extent.cwiseMin(vertex);
       max_extent = max_extent.cwiseMax(vertex);
@@ -403,7 +392,7 @@ class SurfaceMesh {
     }
 
     // Check vertices.
-    for (SurfaceVertexIndex i(0); i < this->num_vertices(); ++i) {
+    for (int i = 0; i < this->num_vertices(); ++i) {
       if (this->vertex(i) != mesh.vertex(i)) return false;
     }
 

--- a/geometry/proximity/test/aabb_test.cc
+++ b/geometry/proximity/test/aabb_test.cc
@@ -171,8 +171,6 @@ GTEST_TEST(AabbTest, TestEqual) {
  elements of the mesh will be garbage). Then we'll successively build Aabb
  instances from subsets of the vertices. */
 GTEST_TEST(AabbMakerTest, Compute) {
-  using VIndex = SurfaceVertexIndex;
-
   /* The vertices are all located at box corners.
 
         V₃--------------V₇
@@ -196,27 +194,23 @@ GTEST_TEST(AabbMakerTest, Compute) {
       }
     }
   }
-  vector<SurfaceFace> faces{{SurfaceFace{VIndex(0), VIndex(1), VIndex(2)}}};
+  vector<SurfaceFace> faces{{SurfaceFace{0, 1, 2}}};
   SurfaceMesh<double> mesh{std::move(faces), std::move(vertices)};
 
   ASSERT_EQ(mesh.num_vertices(), 8);
 
-  const VIndex v0(0);
-  const VIndex v3(3);
-  const VIndex v4(4);
-  const VIndex v7(7);
   {
     /* Case: single vertex. */
-    const set<VIndex> fit_vertices = {VIndex(0)};
+    const set<int> fit_vertices = {0};
     const Aabb::Maker<SurfaceMesh<double>> maker(mesh, fit_vertices);
     const Aabb aabb = maker.Compute();
-    EXPECT_TRUE(CompareMatrices(aabb.center(), mesh.vertex(VIndex(0))));
+    EXPECT_TRUE(CompareMatrices(aabb.center(), mesh.vertex(0)));
     EXPECT_TRUE(CompareMatrices(aabb.half_width(), Vector3d::Zero()));
   }
 
   {
     /* Case: Two vertices forming an axis-aligned edge. */
-    const set<VIndex> fit_vertices = {VIndex(3), VIndex(7)};
+    const set<int> fit_vertices = {3, 7};
     const Aabb::Maker<SurfaceMesh<double>> maker(mesh, fit_vertices);
     const Aabb aabb = maker.Compute();
     EXPECT_TRUE(CompareMatrices(aabb.center(),
@@ -227,7 +221,7 @@ GTEST_TEST(AabbMakerTest, Compute) {
 
   {
     /* Case: Two vertices lying completely on a plane. */
-    const set<VIndex> fit_vertices = {VIndex(4), VIndex(7)};
+    const set<int> fit_vertices = {4, 7};
     const Aabb::Maker<SurfaceMesh<double>> maker(mesh, fit_vertices);
     const Aabb aabb = maker.Compute();
     EXPECT_TRUE(CompareMatrices(aabb.center(),
@@ -238,7 +232,7 @@ GTEST_TEST(AabbMakerTest, Compute) {
 
   {
     /* Case: Two vertices lying diagonally across the box. */
-    const set<VIndex> fit_vertices = {VIndex(3), VIndex(4)};
+    const set<int> fit_vertices = {3, 4};
     const Aabb::Maker<SurfaceMesh<double>> maker(mesh, fit_vertices);
     const Aabb aabb = maker.Compute();
     EXPECT_TRUE(CompareMatrices(aabb.center(), Vector3d::Zero()));
@@ -248,10 +242,9 @@ GTEST_TEST(AabbMakerTest, Compute) {
   {
     /* Case: Once I have the minimum support for the full box (e.g., vertices
      3 and 4), adding other vertices will not change the outcome. */
-    const set<VIndex> base_set = {VIndex(3), VIndex(4)};
-    for (VIndex v :
-         {VIndex(0), VIndex(1), VIndex(2), VIndex(5), VIndex(6), VIndex(7)}) {
-      set<VIndex> fit_vertices(base_set);
+    const set<int> base_set = {3, 4};
+    for (int v : {0, 1, 2, 5, 6, 7}) {
+      set<int> fit_vertices(base_set);
       fit_vertices.emplace(v);
       const Aabb::Maker<SurfaceMesh<double>> maker(mesh, fit_vertices);
       const Aabb aabb = maker.Compute();

--- a/geometry/proximity/test/bvh_test.cc
+++ b/geometry/proximity/test/bvh_test.cc
@@ -178,10 +178,7 @@ TYPED_TEST(BvhTest, TestComputeBoundingVolume) {
   using BvType = TypeParam;
   // A mesh of two triangles that are well separated by X-Y plane.
   const SurfaceMesh<double> mesh(
-      {SurfaceFace(SurfaceVertexIndex(0), SurfaceVertexIndex(1),
-                   SurfaceVertexIndex(2)),
-       SurfaceFace(SurfaceVertexIndex(3), SurfaceVertexIndex(4),
-                   SurfaceVertexIndex(5))},
+      {SurfaceFace(0, 1, 2), SurfaceFace(3, 4, 5)},
       {Vector3d(0, 0, 1), Vector3d(1, 0, 1), Vector3d(0, 1, 1),
        Vector3d(0, 0, -1), Vector3d(1, 0, -1), Vector3d(0, 1, -1)});
 
@@ -400,13 +397,11 @@ TYPED_TEST(BvhTest, TestCollideSurfaceVolume) {
         (tet, tri2). */
 
   using STri = SurfaceFace;
-  using SVIndex = SurfaceVertexIndex;
   std::vector<Vector3d> vertices_S{{Vector3d(0, 0, 0),     // P
                                     Vector3d(1, 0, 1),     // Q
                                     Vector3d(2, 0, 0),     // R
                                     Vector3d(1, 0, -1)}};  // S
-  std::vector<STri> faces_S{{STri(SVIndex(0), SVIndex(3), SVIndex(1)),
-                             STri(SVIndex(3), SVIndex(2), SVIndex(1))}};
+  std::vector<STri> faces_S{{STri(0, 3, 1), STri(3, 2, 1)}};
   const SurfaceMesh<double> mesh_S(std::move(faces_S), std::move(vertices_S));
   const Bvh<BvType, SurfaceMesh<double>> bvh_S(mesh_S);
   // Confirm the expected topology (one leaf with two tris).

--- a/geometry/proximity/test/hydroelastic_callback_test.cc
+++ b/geometry/proximity/test/hydroelastic_callback_test.cc
@@ -271,14 +271,13 @@ class TestScene {
 // soft mesh.
 ::testing::AssertionResult ValidateDerivatives(
     const ContactSurface<AutoDiffXd>& surface) {
-  const SurfaceVertexIndex v0(0);
   const SurfaceFaceIndex f0(0);
   const auto& mesh_W = surface.mesh_W();
-  if (mesh_W.vertex(v0).x().derivatives().size() != 3) {
+  if (mesh_W.vertex(0).x().derivatives().size() != 3) {
     return ::testing::AssertionFailure() << "Vertex 0 is missing derivatives";
   }
 
-  if (surface.e_MN().EvaluateAtVertex(v0).derivatives().size() != 3) {
+  if (surface.e_MN().EvaluateAtVertex(0).derivatives().size() != 3) {
     return ::testing::AssertionFailure()
            << "Pressure field at vertex 0 is missing derivatives";
   }

--- a/geometry/proximity/test/hydroelastic_internal_test.cc
+++ b/geometry/proximity/test/hydroelastic_internal_test.cc
@@ -463,7 +463,7 @@ TEST_F(HydroelasticRigidGeometryTest, Sphere) {
   ASSERT_FALSE(sphere->is_half_space());
 
   const SurfaceMesh<double>& mesh = sphere->mesh();
-  for (SurfaceVertexIndex v(0); v < mesh.num_vertices(); ++v) {
+  for (int v = 0; v < mesh.num_vertices(); ++v) {
     ASSERT_NEAR(mesh.vertex(v).norm(), radius, 1e-15);
   }
 }
@@ -489,7 +489,7 @@ TEST_F(HydroelasticRigidGeometryTest, Box) {
   // Because it is a cube centered at the origin, the distance from the origin
   // to each vertex should be sqrt(3) * edge_len / 2.
   const double expected_dist = std::sqrt(3) * edge_len / 2;
-  for (SurfaceVertexIndex v(0); v < mesh.num_vertices(); ++v) {
+  for (int v = 0; v < mesh.num_vertices(); ++v) {
     ASSERT_NEAR(mesh.vertex(v).norm(), expected_dist, 1e-15);
   }
 }
@@ -518,7 +518,7 @@ TEST_F(HydroelasticRigidGeometryTest, Cylinder) {
   const SurfaceMesh<double>& mesh = cylinder->mesh();
   EXPECT_EQ(mesh.num_vertices(), 8);
   EXPECT_EQ(mesh.num_faces(), 12);
-  for (SurfaceVertexIndex v(0); v < mesh.num_vertices(); ++v) {
+  for (int v = 0; v < mesh.num_vertices(); ++v) {
     const auto [x, y, z] = unpack(mesh.vertex(v));
     // Only check that the vertex is within the cylinder. It does not check
     // that the vertex is near the surface of the cylinder.  We rely on the
@@ -592,7 +592,7 @@ TEST_F(HydroelasticRigidGeometryTest, Ellipsoid) {
   const SurfaceMesh<double>& mesh = ellipsoid->mesh();
   EXPECT_EQ(mesh.num_vertices(), 6);
   EXPECT_EQ(mesh.num_faces(), 8);
-  for (SurfaceVertexIndex v(0); v < mesh.num_vertices(); ++v) {
+  for (int v = 0; v < mesh.num_vertices(); ++v) {
     const auto [x, y, z] = unpack(mesh.vertex(v));
     ASSERT_NEAR(pow(x / a, 2) + pow(y / b, 2) + pow(z / c, 2), 1.0, 1e-15);
   }
@@ -627,7 +627,7 @@ void TestRigidMeshType() {
     // the expected distance of the vertex to the origin should be:
     // scale * sqrt(3) (because the original mesh was the unit sphere).
     const double expected_dist = std::sqrt(3) * scale;
-    for (SurfaceVertexIndex v(0); v < surface_mesh.num_vertices(); ++v) {
+    for (int v = 0; v < surface_mesh.num_vertices(); ++v) {
       const double dist = surface_mesh.vertex(v).norm();
       ASSERT_NEAR(dist, expected_dist, scale * kEps)
           << "for scale: " << scale << " at vertex " << v;

--- a/geometry/proximity/test/mesh_field_linear_test.cc
+++ b/geometry/proximity/test/mesh_field_linear_test.cc
@@ -52,17 +52,16 @@ std::unique_ptr<SurfaceMesh<T>> GenerateMesh() {
   return surface_mesh;
 }
 
-// Tests Evaluate(VertexIndex).
 GTEST_TEST(MeshFieldLinearTest, EvaluateAtVertex) {
   auto mesh = GenerateMesh<double>();
   std::vector<double> e_values = {0., 1., 2., 3.};
   auto mesh_field =
       std::make_unique<MeshFieldLinear<double, SurfaceMesh<double>>>(
           std::move(e_values), mesh.get());
-  EXPECT_EQ(mesh_field->EvaluateAtVertex(SurfaceVertexIndex(0)), 0);
-  EXPECT_EQ(mesh_field->EvaluateAtVertex(SurfaceVertexIndex(1)), 1);
-  EXPECT_EQ(mesh_field->EvaluateAtVertex(SurfaceVertexIndex(2)), 2);
-  EXPECT_EQ(mesh_field->EvaluateAtVertex(SurfaceVertexIndex(3)), 3);
+  EXPECT_EQ(mesh_field->EvaluateAtVertex(0), 0);
+  EXPECT_EQ(mesh_field->EvaluateAtVertex(1), 1);
+  EXPECT_EQ(mesh_field->EvaluateAtVertex(2), 2);
+  EXPECT_EQ(mesh_field->EvaluateAtVertex(3), 3);
 }
 
 #pragma GCC diagnostic push
@@ -339,7 +338,7 @@ class ScalarMixingTest : public ::testing::Test {
             std::move(e_ad), mesh_d_.get());
 
     p_WQ_d_ = Vector3d::Zero();
-    for (SurfaceVertexIndex v(0); v < 3; ++v) {
+    for (int v = 0; v < 3; ++v) {
       p_WQ_d_ += mesh_d_->vertex(v);
     }
     p_WQ_d_ /= 3;
@@ -349,7 +348,7 @@ class ScalarMixingTest : public ::testing::Test {
     b_ad_ = math::InitializeAutoDiff(b_d_);
 
     centroid_value_ = 0;
-    for (SurfaceVertexIndex v(0); v < 3; ++v) {
+    for (int v = 0; v < 3; ++v) {
       centroid_value_ += field_d_->EvaluateAtVertex(v);
     }
     centroid_value_ /= 3;

--- a/geometry/proximity/test/obb_test.cc
+++ b/geometry/proximity/test/obb_test.cc
@@ -237,14 +237,14 @@ class ObbMakerTestRectangularBox : public ::testing::Test {
 
   void SetUp() override {
     ASSERT_EQ(mesh_M_.num_vertices(), 8);
-    for (SurfaceVertexIndex i(0); i < mesh_M_.num_vertices(); ++i) {
+    for (int i = 0; i < mesh_M_.num_vertices(); ++i) {
       test_vertices_.insert(i);
     }
   }
 
  protected:
   SurfaceMesh<double> mesh_M_;
-  std::set<SurfaceVertexIndex> test_vertices_;
+  std::set<int> test_vertices_;
 };
 
 // Test the creation of obb orientation via PCA. We want to test the following:
@@ -344,15 +344,13 @@ class ObbMakerTestTriangle : public ::testing::Test {
  public:
   ObbMakerTestTriangle()
       : ::testing::Test(),
-        mesh_M_({SurfaceFace(SurfaceVertexIndex(0), SurfaceVertexIndex(1),
-                             SurfaceVertexIndex(2))},
+        mesh_M_({SurfaceFace(0, 1, 2)},
                 {Vector3d::UnitX(), Vector3d::UnitY(), Vector3d::UnitZ()}),
-        test_vertices_{SurfaceVertexIndex(0), SurfaceVertexIndex(1),
-                       SurfaceVertexIndex(2)} {}
+        test_vertices_{0, 1, 2} {}
 
  protected:
   SurfaceMesh<double> mesh_M_;
-  const std::set<SurfaceVertexIndex> test_vertices_;
+  const std::set<int> test_vertices_;
 };
 
 TEST_F(ObbMakerTestTriangle, CalcOrientationByPca) {
@@ -479,9 +477,7 @@ GTEST_TEST(ObbMakerTest, TestOptimizeObbVolume) {
   // Confirm that it is an octahedron.
   ASSERT_EQ(8, mesh_M.num_faces());
   ASSERT_EQ(6, mesh_M.num_vertices());
-  const std::set<SurfaceVertexIndex> test_vertices{
-      SurfaceVertexIndex(0), SurfaceVertexIndex(1), SurfaceVertexIndex(2),
-      SurfaceVertexIndex(3), SurfaceVertexIndex(4), SurfaceVertexIndex(5)};
+  const std::set<int> test_vertices{0, 1, 2, 3, 4, 5};
 
   // Initial obb is aligned with the three axes of the ellipsoid.
   const Obb initial_obb_M(X_ME, Vector3d(1., 2., 3.));
@@ -520,15 +516,13 @@ class ObbMakerTestOctahedron : public ::testing::Test {
       : ::testing::Test(),
         // Use a coarse sphere, i.e. an octahedron, as the underlying mesh.
         mesh_M_(MakeSphereSurfaceMesh<double>(Sphere(1.5), 3)),
-        test_vertices_{SurfaceVertexIndex(0), SurfaceVertexIndex(1),
-                       SurfaceVertexIndex(2), SurfaceVertexIndex(3),
-                       SurfaceVertexIndex(4), SurfaceVertexIndex(5)} {}
+        test_vertices_{0, 1, 2, 3, 4, 5} {}
 
   void SetUp() override { ASSERT_EQ(mesh_M_.num_vertices(), 6); }
 
  protected:
   SurfaceMesh<double> mesh_M_;
-  const std::set<SurfaceVertexIndex> test_vertices_;
+  const std::set<int> test_vertices_;
 };
 
 // Test PCA problem whose eigenvalue has triple multiplicity.
@@ -642,8 +636,8 @@ GTEST_TEST(ObbMakerTest, TestTruncatedBox) {
   auto surface_mesh = MakeBoxSurfaceMesh<double>(Box(6, 4, 2), 10);
   ASSERT_EQ(surface_mesh.num_vertices(), 8);
   ASSERT_EQ(surface_mesh.num_faces(), 12);
-  std::set<SurfaceVertexIndex> test_vertices;
-  for (SurfaceVertexIndex i(0); i < 8; ++i) {
+  std::set<int> test_vertices;
+  for (int i = 0; i < 8; ++i) {
     const Vector3d& p_MV = surface_mesh.vertex(i);
     // Omit vertices on a diagonal.
     if (CompareMatrices(p_MV, Vector3d(-3, -2, -1), 1e-5)) continue;
@@ -693,15 +687,11 @@ GTEST_TEST(ObbMakerTest, TestVolumeMesh) {
 GTEST_TEST(ObbMakerTestAPI, ObbMakerCompute) {
   const SurfaceMesh<double> mesh(
       // The triangles are not relevant to the test.
-      {SurfaceFace(SurfaceVertexIndex(0), SurfaceVertexIndex(1),
-                   SurfaceVertexIndex(2)),
-       SurfaceFace(SurfaceVertexIndex(0), SurfaceVertexIndex(3),
-                   SurfaceVertexIndex(1))},
+      {SurfaceFace(0, 1, 2), SurfaceFace(0, 3, 1)},
       {Vector3d::Zero(), Vector3d::UnitX(), 2. * Vector3d::UnitY(),
        3. * Vector3d::UnitZ()});
 
-  const std::set<SurfaceVertexIndex> test_vertices{SurfaceVertexIndex(0),
-                                                   SurfaceVertexIndex(1)};
+  const std::set<int> test_vertices{0, 1};
 
   const Obb obb = ObbMaker(mesh, test_vertices).Compute();
 
@@ -712,8 +702,7 @@ GTEST_TEST(ObbMakerTestAPI, ObbMakerCompute) {
   EXPECT_NEAR(obb.half_width().x(), 0.5, ObbTester::kTolerance);
   EXPECT_NEAR(obb.half_width().y(), 0., ObbTester::kTolerance);
   EXPECT_NEAR(obb.half_width().z(), 0., ObbTester::kTolerance);
-  const std::set<SurfaceVertexIndex> remaining_vertices{SurfaceVertexIndex(2),
-                                                        SurfaceVertexIndex(3)};
+  const std::set<int> remaining_vertices{2, 3};
   EXPECT_FALSE(Contain(obb, mesh, remaining_vertices));
 }
 

--- a/geometry/proximity/test/obj_to_surface_mesh_test.cc
+++ b/geometry/proximity/test/obj_to_surface_mesh_test.cc
@@ -98,7 +98,7 @@ GTEST_TEST(ObjToSurfaceMeshTest, ReadObjToSurfaceMesh) {
   // clang-format on
 
   for (int i = 0; i < 8; ++i) {
-    EXPECT_EQ(expect_vertices[i], surface.vertex(SurfaceVertexIndex(i)));
+    EXPECT_EQ(expect_vertices[i], surface.vertex(i));
   }
 
   // TODO(SeanCurtis-TRI) Devise a formulation of this that is less sensitive
@@ -230,7 +230,7 @@ f 1 2 3
     {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, { 0.0, 0.0, 1.0 }
   };
   for (int i = 0; i < 3; ++i) {
-    EXPECT_EQ(expect_vertices[i], surface.vertex(SurfaceVertexIndex(i)));
+    EXPECT_EQ(expect_vertices[i], surface.vertex(i));
   }
   ASSERT_EQ(1, surface.num_faces());
   int expect_face[3] = {0, 1, 2};
@@ -261,7 +261,7 @@ f 4 5 6
       {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0},
       {2.0, 0.0, 0.0}, {0.0, 2.0, 0.0}, {0.0, 0.0, 2.0}};
   for (int i = 0; i < 6; ++i) {
-    EXPECT_EQ(expect_vertices[i], surface.vertex(SurfaceVertexIndex(i)));
+    EXPECT_EQ(expect_vertices[i], surface.vertex(i));
   }
   ASSERT_EQ(2, surface.num_faces());
   int expect_faces[2][3]{{0, 1, 2}, {3, 4, 5}};

--- a/geometry/proximity/test/surface_mesh_test.cc
+++ b/geometry/proximity/test/surface_mesh_test.cc
@@ -54,10 +54,8 @@ std::unique_ptr<SurfaceMesh<T>> GenerateTwoTriangleMesh() {
   // Create the two triangles. Note that SurfaceMesh does not specify (or use) a
   // particular winding.
   std::vector<SurfaceFace> faces;
-  faces.emplace_back(
-      SurfaceVertexIndex(0), SurfaceVertexIndex(1), SurfaceVertexIndex(2));
-  faces.emplace_back(
-      SurfaceVertexIndex(2), SurfaceVertexIndex(3), SurfaceVertexIndex(0));
+  faces.emplace_back(0, 1, 2);
+  faces.emplace_back(2, 3, 0);
 
   return std::make_unique<SurfaceMesh<T>>(
       std::move(faces), std::move(vertices));
@@ -82,10 +80,8 @@ std::unique_ptr<SurfaceMesh<double>> GenerateZeroAreaMesh() {
 
   // Create the two triangles.
   std::vector<SurfaceFace> faces;
-  faces.emplace_back(
-      SurfaceVertexIndex(0), SurfaceVertexIndex(1), SurfaceVertexIndex(2));
-  faces.emplace_back(
-      SurfaceVertexIndex(2), SurfaceVertexIndex(3), SurfaceVertexIndex(0));
+  faces.emplace_back(0, 1, 2);
+  faces.emplace_back(2, 3, 0);
 
   return std::make_unique<SurfaceMesh<double>>(
       std::move(faces), std::move(vertices));
@@ -130,8 +126,7 @@ std::unique_ptr<SurfaceMesh<T>> TestSurfaceMesh(
   EXPECT_EQ(2, surface_mesh_W->num_faces());
   EXPECT_EQ(4, surface_mesh_W->num_vertices());
   for (int v = 0; v < 4; ++v)
-    EXPECT_EQ(X_WM * vertex_data_M[v],
-              surface_mesh_W->vertex(SurfaceVertexIndex(v)));
+    EXPECT_EQ(X_WM * vertex_data_M[v], surface_mesh_W->vertex(v));
   for (int f = 0; f < 2; ++f)
     for (int v = 0; v < 3; ++v)
       EXPECT_EQ(face_data[f][v],
@@ -483,7 +478,7 @@ GTEST_TEST(SurfaceMeshTest, TransformVertices) {
                        Vector3d{1, 2, 3}};
   test_mesh->TransformVertices(X_FM);
 
-  for (SurfaceVertexIndex v(0); v < test_mesh->num_vertices(); ++v) {
+  for (int v = 0; v < test_mesh->num_vertices(); ++v) {
     const Vector3d& p_FV_test = test_mesh->vertex(v);
     const Vector3d& p_MV_ref = ref_mesh->vertex(v);
     const Vector3d p_FV_ref = X_FM * p_MV_ref;
@@ -543,18 +538,17 @@ class ScalarMixingTest : public ::testing::Test {
     // only set the derivatives for vertex 1. That means, operations on
     // triangle 0 *must* have derivatives, but triangle 1 may not have them.
     std::vector<Vector3<AutoDiffXd>> vertices;
-    vertices.emplace_back(mesh_d_->vertex(SurfaceVertexIndex(0)));
-    vertices.emplace_back(math::InitializeAutoDiff(
-        mesh_d_->vertex(SurfaceVertexIndex(1))));
-    vertices.emplace_back(mesh_d_->vertex(SurfaceVertexIndex(2)));
-    vertices.emplace_back(mesh_d_->vertex(SurfaceVertexIndex(3)));
+    vertices.emplace_back(mesh_d_->vertex(0));
+    vertices.emplace_back(math::InitializeAutoDiff(mesh_d_->vertex(1)));
+    vertices.emplace_back(mesh_d_->vertex(2));
+    vertices.emplace_back(mesh_d_->vertex(3));
     std::vector<SurfaceFace> faces(mesh_d_->faces());
 
     mesh_ad_ = std::make_unique<SurfaceMesh<AutoDiffXd>>(std::move(faces),
                                                          std::move(vertices));
 
     p_WQ_d_ = Vector3d::Zero();
-    for (SurfaceVertexIndex v(0); v < 3; ++v) {
+    for (int v = 0; v < 3; ++v) {
       p_WQ_d_ += mesh_d_->vertex(v);
     }
     p_WQ_d_ /= 3;

--- a/geometry/proximity/volume_to_surface_mesh.cc
+++ b/geometry/proximity/volume_to_surface_mesh.cc
@@ -132,8 +132,8 @@ SurfaceMesh<T> ConvertVolumeToSurfaceMesh(const VolumeMesh<T>& volume) {
 
   std::vector<Vector3<T>> surface_vertices;
   surface_vertices.reserve(boundary_vertices.size());
-  std::unordered_map<VolumeVertexIndex, SurfaceVertexIndex> volume_to_surface;
-  for (SurfaceVertexIndex i(0); i < boundary_vertices.size(); ++i) {
+  std::unordered_map<VolumeVertexIndex, int> volume_to_surface;
+  for (int i(0); i < static_cast<int>(boundary_vertices.size()); ++i) {
     surface_vertices.emplace_back(volume.vertex(boundary_vertices[i]));
     volume_to_surface.emplace(boundary_vertices[i], i);
   }

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -292,13 +292,7 @@ GTEST_TEST(ProximityEngineTest, ComputeContactSurfacesAutodiffSupport) {
     // We'll poke *one* quantity of the surface mesh to confirm it has
     // derivatives. We won't consider the *value*, just the existence as proof
     // that it has been wired up to code that has already tested value.
-    EXPECT_EQ(surfaces[0]
-                  .mesh_W()
-                  .vertex(SurfaceVertexIndex(0))
-                  .x()
-                  .derivatives()
-                  .size(),
-              3);
+    EXPECT_EQ(surfaces[0].mesh_W().vertex(0).x().derivatives().size(), 3);
   }
 
   // Case: Rigid sphere and mesh with AutoDiffXd -- contact would be a point

--- a/multibody/fixed_fem/dev/deformable_contact.cc
+++ b/multibody/fixed_fem/dev/deformable_contact.cc
@@ -14,7 +14,6 @@ namespace fem {
 
 using geometry::SurfaceFaceIndex;
 using geometry::SurfaceMesh;
-using geometry::SurfaceVertexIndex;
 using geometry::VolumeElementIndex;
 using geometry::VolumeMesh;
 using geometry::VolumeVertexIndex;
@@ -403,7 +402,7 @@ class Intersector {
     // surface_R.
     polygon_D->clear();
     for (int i = 0; i < 3; ++i) {
-      const SurfaceVertexIndex v = surface_R.element(face).vertex(i);
+      const int v = surface_R.element(face).vertex(i);
       const Vector3<T> p_DV = X_DR * surface_R.vertex(v).cast<T>();
       polygon_D->push_back({p_DV, tet_mesh_D.CalcBarycentric(p_DV, tet_index)});
     }

--- a/multibody/plant/hydroelastic_traction_calculator.cc
+++ b/multibody/plant/hydroelastic_traction_calculator.cc
@@ -17,7 +17,6 @@ using geometry::SurfaceFace;
 using geometry::SurfaceFaceIndex;
 using geometry::SurfaceMesh;
 using geometry::SurfaceMeshFieldLinear;
-using geometry::SurfaceVertexIndex;
 using math::RigidTransform;
 
 namespace multibody {

--- a/multibody/plant/test/contact_results_to_lcm_test.cc
+++ b/multibody/plant/test/contact_results_to_lcm_test.cc
@@ -31,7 +31,6 @@ using geometry::Sphere;
 using geometry::SurfaceFace;
 using geometry::SurfaceFaceIndex;
 using geometry::SurfaceMesh;
-using geometry::SurfaceVertexIndex;
 using math::RigidTransform;
 using multibody::internal::FullBodyName;
 using std::function;
@@ -155,10 +154,8 @@ ContactSurface<T> MakeContactSurface(GeometryId id_M, GeometryId id_N,
   vertices.emplace_back(Vector3<double>(-0.5, 0.5, -0.5) + offset);
   vertices.emplace_back(Vector3<double>(-0.5, -0.5, -0.5) + offset);
   vertices.emplace_back(Vector3<double>(0.5, -0.5, -0.5) + offset);
-  faces.emplace_back(SurfaceVertexIndex(0), SurfaceVertexIndex(1),
-                     SurfaceVertexIndex(2));
-  faces.emplace_back(SurfaceVertexIndex(2), SurfaceVertexIndex(3),
-                     SurfaceVertexIndex(0));
+  faces.emplace_back(0, 1, 2);
+  faces.emplace_back(2, 3, 0);
   auto mesh = make_unique<SurfaceMesh<T>>(move(faces), move(vertices));
 
   /* Create the "e" field values (i.e., "hydroelastic pressure") - simply

--- a/multibody/plant/test/hydroelastic_traction_test.cc
+++ b/multibody/plant/test/hydroelastic_traction_test.cc
@@ -25,7 +25,6 @@ using geometry::SceneGraph;
 using geometry::SurfaceFaceIndex;
 using geometry::SurfaceFace;
 using geometry::SurfaceMesh;
-using geometry::SurfaceVertexIndex;
 using math::RigidTransform;
 using math::RigidTransformd;
 using systems::Context;
@@ -67,10 +66,8 @@ std::unique_ptr<SurfaceMesh<double>> CreateSurfaceMesh() {
   //       /     /|   /
   //   v2 /_____/_|__/ v3
   //           /  |
-  faces.emplace_back(
-      SurfaceVertexIndex(0), SurfaceVertexIndex(2), SurfaceVertexIndex(1));
-  faces.emplace_back(
-      SurfaceVertexIndex(2), SurfaceVertexIndex(0), SurfaceVertexIndex(3));
+  faces.emplace_back(0, 2, 1);
+  faces.emplace_back(2, 0, 3);
 
   auto mesh = std::make_unique<SurfaceMesh<double>>(
       std::move(faces), std::move(vertices));
@@ -107,7 +104,7 @@ std::unique_ptr<ContactSurface<double>> CreateContactSurface(
   // Create the "e" field values (i.e., "hydroelastic pressure") using
   // negated "z" values.
   std::vector<double> e_MN(mesh->num_vertices());
-  for (SurfaceVertexIndex i(0); i < mesh->num_vertices(); ++i)
+  for (int i = 0; i < mesh->num_vertices(); ++i)
     e_MN[i] = -mesh->vertex(i).z();
 
   // Now transform the mesh to the world frame, as ContactSurface specifies.
@@ -665,8 +662,7 @@ GTEST_TEST(HydroelasticTractionCalculatorTest,
       p_WC + Vector3<AutoDiffXd>(0, -0.5, -0.5),
   };
 
-  std::vector<SurfaceFace> faces({SurfaceFace{
-      SurfaceVertexIndex(0), SurfaceVertexIndex(1), SurfaceVertexIndex(2)}});
+  std::vector<SurfaceFace> faces({SurfaceFace{0, 1, 2}});
   auto mesh_W = std::make_unique<geometry::SurfaceMesh<AutoDiffXd>>(
       std::move(faces), std::move(vertices));
   // Note: these values are garbage. They merely allow us to instantiate the
@@ -795,7 +791,7 @@ class HydroelasticReportingTests
 
     // Create the e field values (i.e., "hydroelastic pressure").
     std::vector<double> e_MN(mesh->num_vertices());
-    for (SurfaceVertexIndex i(0); i < mesh->num_vertices(); ++i)
+    for (int i = 0; i < mesh->num_vertices(); ++i)
       e_MN[i] = pressure(mesh->vertex(i));
 
     SurfaceMesh<double>* mesh_pointer = mesh.get();

--- a/multibody/plant/test/multibody_plant_hydroelastic_contact_results_output_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_contact_results_output_test.cc
@@ -14,7 +14,6 @@ namespace drake {
 using geometry::ContactSurface;
 using geometry::SurfaceFace;
 using geometry::SurfaceFaceIndex;
-using geometry::SurfaceVertexIndex;
 using geometry::SurfaceMesh;
 
 namespace multibody {


### PR DESCRIPTION
There are four index types associated with the two mesh types. This removes the first of the four indices.

In this case "removal" means:
  1. Removing all usages of `SurfaceVertexIndex` in Drake C++ code.
  2. Removing the python bindings.
  3. Keep the type, but change it to be an alias to an int. This will allow us to defer updating Anzu until *all* index types have been removed. At that point, we'll remove the int aliases and update Anzu.
     - `TypeSafeIndex` allows for index vs unsigned int comparisions. This        alias will break this functionality. Where necessary, those signed-unsigned comparisons are also updated.

re: release notes. This is part of hydroelastic, so only the PR number should be referenced, no details.

Relates #15796.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15912)
<!-- Reviewable:end -->
