### PR TITLE
[hydro] Remove VolumeVertexIndex type

### DIFF
--- a/bindings/pydrake/geometry_py_hydro.cc
+++ b/bindings/pydrake/geometry_py_hydro.cc
@@ -68,8 +68,6 @@ void DoScalarIndependentDefinitions(py::module m) {
   {
     BindTypeSafeIndex<SurfaceFaceIndex>(
         m, "SurfaceFaceIndex", doc.SurfaceFaceIndex.doc);
-    BindTypeSafeIndex<VolumeVertexIndex>(
-        m, "VolumeVertexIndex", doc.VolumeVertexIndex.doc);
     BindTypeSafeIndex<VolumeElementIndex>(
         m, "VolumeElementIndex", doc.VolumeElementIndex.doc);
   }
@@ -93,10 +91,8 @@ void DoScalarIndependentDefinitions(py::module m) {
     constexpr auto& cls_doc = doc.VolumeElement;
     py::class_<Class> cls(m, "VolumeElement", cls_doc.doc);
     cls  // BR
-        .def(py::init<VolumeVertexIndex, VolumeVertexIndex, VolumeVertexIndex,
-                 VolumeVertexIndex>(),
-            py::arg("v0"), py::arg("v1"), py::arg("v2"), py::arg("v3"),
-            cls_doc.ctor.doc_4args)
+        .def(py::init<int, int, int, int>(), py::arg("v0"), py::arg("v1"),
+            py::arg("v2"), py::arg("v3"), cls_doc.ctor.doc_4args)
         // TODO(SeanCurtis-TRI): Bind constructor that takes array of ints.
         .def("vertex", &Class::vertex, py::arg("i"), cls_doc.vertex.doc);
     DefCopyAndDeepCopy(&cls);

--- a/bindings/pydrake/test/geometry_hydro_test.py
+++ b/bindings/pydrake/test/geometry_hydro_test.py
@@ -98,14 +98,8 @@ class TestGeometryHydro(unittest.TestCase):
         #        /
         #      +z
 
-        t_left = mut.VolumeElement(v0=mut.VolumeVertexIndex(2),
-                                   v1=mut.VolumeVertexIndex(1),
-                                   v2=mut.VolumeVertexIndex(3),
-                                   v3=mut.VolumeVertexIndex(4))
-        t_right = mut.VolumeElement(v0=mut.VolumeVertexIndex(3),
-                                    v1=mut.VolumeVertexIndex(1),
-                                    v2=mut.VolumeVertexIndex(2),
-                                    v3=mut.VolumeVertexIndex(0))
+        t_left = mut.VolumeElement(v0=2, v1=1, v2=3, v3=4)
+        t_right = mut.VolumeElement(v0=3, v1=1, v2=2, v3=0)
         self.assertEqual(t_left.vertex(0), 2)
         self.assertEqual(t_right.vertex(1), 1)
 
@@ -132,14 +126,8 @@ class TestGeometryHydro(unittest.TestCase):
 
     def test_convert_volume_to_surface_mesh(self):
         # Use the volume mesh from `test_volume_mesh()`.
-        t_left = mut.VolumeElement(v0=mut.VolumeVertexIndex(1),
-                                   v1=mut.VolumeVertexIndex(2),
-                                   v2=mut.VolumeVertexIndex(3),
-                                   v3=mut.VolumeVertexIndex(4))
-        t_right = mut.VolumeElement(v0=mut.VolumeVertexIndex(1),
-                                    v1=mut.VolumeVertexIndex(3),
-                                    v2=mut.VolumeVertexIndex(2),
-                                    v3=mut.VolumeVertexIndex(0))
+        t_left = mut.VolumeElement(v0=1, v1=2, v2=3, v3=4)
+        t_right = mut.VolumeElement(v0=1, v1=3, v2=2, v3=0)
 
         v0 = (1, 0,  0)
         v1 = (0, 0,  0)

--- a/geometry/proximity/make_box_mesh.cc
+++ b/geometry/proximity/make_box_mesh.cc
@@ -18,8 +18,7 @@ using std::unordered_set;
  share the diagonal v0v6 (see ordering below). We allow repeated vertices in
  the virtual cube and will skip tetrahedra with repeated vertices.
 
- We assume the input vertex indices (represented as VolumeVertexIndex) are in
- this ordering:
+ We assume the input vertex indices are in this ordering:
    1. Four vertices v0,v1,v2,v3 of the "bottom" face in counterclockwise
       order when look from "above" the cube.
    2. Four vertices v4,v5,v6,v7 of the "top" face matching v0,v1,v2,v3,
@@ -46,20 +45,16 @@ using std::unordered_set;
    get 2 tetrahedra instead of 6 tetrahedra.
 
  @note   This function is purely topological because it takes only
- VolumeVertexIndex into account without attempting to access coordinates of
- the vertices.
+ indices into account without attempting to access coordinates of the vertices.
  */
-std::vector<VolumeElement> SplitToTetrahedra(
-    VolumeVertexIndex v0, VolumeVertexIndex v1, VolumeVertexIndex v2,
-    VolumeVertexIndex v3, VolumeVertexIndex v4, VolumeVertexIndex v5,
-    VolumeVertexIndex v6, VolumeVertexIndex v7) {
+std::vector<VolumeElement> SplitToTetrahedra(int v0, int v1, int v2, int v3,
+                                             int v4, int v5, int v6, int v7) {
   std::vector<VolumeElement> elements;
   elements.reserve(6);
-  VolumeVertexIndex previous = v1;
-  for (const VolumeVertexIndex& next : {v2, v3, v7, v4, v5, v1}) {
+  int previous = v1;
+  for (int next : {v2, v3, v7, v4, v5, v1}) {
     // Allow distinct vertex indices only.
-    if (unordered_set<VolumeVertexIndex>({previous, next, v0, v6}).size() ==
-        4) {
+    if (unordered_set<int>({previous, next, v0, v6}).size() == 4) {
       elements.emplace_back(previous, next, v0, v6);
     }
     previous = next;
@@ -212,7 +207,7 @@ VolumeMesh<T> MakeBoxVolumeMeshWithMa(const Box& box) {
   //   |/        |/
   //   v100------v110
   //
-  VolumeVertexIndex v[2][2][2];
+  int v[2][2][2];
   const Vector3d half_box = box.size() / 2.;
   for (const int i : {0, 1}) {
     const double x(i == 0 ? -half_box.x() : half_box.x());
@@ -220,7 +215,7 @@ VolumeMesh<T> MakeBoxVolumeMeshWithMa(const Box& box) {
       const double y(j == 0 ? -half_box.y() : half_box.y());
       for (const int k : {0, 1}) {
         const double z(k == 0 ? -half_box.z() : half_box.z());
-        v[i][j][k] = VolumeVertexIndex(mesh_vertices.size());
+        v[i][j][k] = static_cast<int>(mesh_vertices.size());
         mesh_vertices.emplace_back(x, y, z);
       }
     }
@@ -231,7 +226,7 @@ VolumeMesh<T> MakeBoxVolumeMeshWithMa(const Box& box) {
   // virtual MA's vertices are represented by the 2x2x2 array `m`, where the
   // virtual MA's vertex m[i][j][k] corresponds to the box's vertex
   // v[i][j][k]. Some of the m[i][j][k]'s are duplicated by design.
-  VolumeVertexIndex m[2][2][2];
+  int m[2][2][2];
   const double min_half_box = half_box.minCoeff();
   // Similar to half_box describing the half dimensions of the box,
   // half_central_Ma describes the half dimensions of the central piece of MA.
@@ -269,7 +264,7 @@ VolumeMesh<T> MakeBoxVolumeMeshWithMa(const Box& box) {
                                ? m[i][0][k]
                                : duplicate_in_k
                                      ? m[i][j][0]
-                                     : VolumeVertexIndex(mesh_vertices.size());
+                                     : static_cast<int>(mesh_vertices.size());
         if (!duplicate_in_i && !duplicate_in_j && !duplicate_in_k) {
           mesh_vertices.emplace_back(x, y, z);
         }

--- a/geometry/proximity/make_capsule_field.h
+++ b/geometry/proximity/make_capsule_field.h
@@ -52,9 +52,9 @@ VolumeMeshFieldLinear<T, T> MakeCapsulePressureField(
   // We only partially check the precondition of the mesh (see @pre). The first
   // two vertices should always be the endpoints of the capsule's medial axis.
   // The first with positive z and the second with negative z.
-  DRAKE_DEMAND(mesh_C->vertex(VolumeVertexIndex(0)) ==
+  DRAKE_DEMAND(mesh_C->vertex(0) ==
                Eigen::Vector3d(0, 0, capsule.length() / 2));
-  DRAKE_DEMAND(mesh_C->vertex(VolumeVertexIndex(1)) ==
+  DRAKE_DEMAND(mesh_C->vertex(1) ==
                Eigen::Vector3d(0, 0, -capsule.length() / 2));
 
   std::vector<T> pressure_values(mesh_C->num_vertices(), 0.0);

--- a/geometry/proximity/make_capsule_mesh.cc
+++ b/geometry/proximity/make_capsule_mesh.cc
@@ -49,20 +49,18 @@ VolumeMesh<T> MakeCapsuleVolumeMesh(const Capsule& capsule,
   mesh_vertices.reserve(2 * num_circles_per_cap * num_vertices_per_circle + 4);
 
   // Add the cap pole vertices and the medial vertices.
-  VolumeVertexIndex medial_top(mesh_vertices.size());
+  int medial_top = static_cast<int>(mesh_vertices.size());
   mesh_vertices.emplace_back(0, 0, medial_top_z);
-  VolumeVertexIndex medial_bottom(mesh_vertices.size());
+  int medial_bottom = static_cast<int>(mesh_vertices.size());
   mesh_vertices.emplace_back(0, 0, medial_bottom_z);
-  VolumeVertexIndex top(mesh_vertices.size());
+  int top = static_cast<int>(mesh_vertices.size());
   mesh_vertices.emplace_back(0, 0, top_z);
-  VolumeVertexIndex bottom(mesh_vertices.size());
+  int bottom = static_cast<int>(mesh_vertices.size());
   mesh_vertices.emplace_back(0, 0, bottom_z);
 
   // Storage for the vertex indices of each cap.
-  std::vector<VolumeVertexIndex> top_cap(num_circles_per_cap *
-                                         num_vertices_per_circle);
-  std::vector<VolumeVertexIndex> bottom_cap(num_circles_per_cap *
-                                            num_vertices_per_circle);
+  std::vector<int> top_cap(num_circles_per_cap * num_vertices_per_circle);
+  std::vector<int> bottom_cap(num_circles_per_cap * num_vertices_per_circle);
 
   // The vertices of the caps are spaced in an equal subdivision of the sphere
   // with spherical coordinates. Vertex (i, j) will have spherical coordinates:
@@ -93,10 +91,10 @@ VolumeMesh<T> MakeCapsuleVolumeMesh(const Capsule& capsule,
       const double y = capsule.radius() * s * sin(phi);
 
       top_cap[num_vertices_per_circle * i + j] =
-          VolumeVertexIndex(mesh_vertices.size());
+          static_cast<int>(mesh_vertices.size());
       mesh_vertices.emplace_back(x, y, top_circle_z);
       bottom_cap[num_vertices_per_circle * i + j] =
-          VolumeVertexIndex(mesh_vertices.size());
+          static_cast<int>(mesh_vertices.size());
       mesh_vertices.emplace_back(x, y, bottom_circle_z);
     }
   }

--- a/geometry/proximity/make_cylinder_field.cc
+++ b/geometry/proximity/make_cylinder_field.cc
@@ -63,9 +63,9 @@ VolumeMeshFieldLinear<T, T> MakeCylinderPressureField(
   // Make sure the boundary vertices have zero pressure. Numerical rounding
   // can cause the boundary vertices to be slightly off the boundary surface
   // of the cylinder.
-  std::vector<VolumeVertexIndex> boundary_vertices =
+  std::vector<int> boundary_vertices =
       CollectUniqueVertices(IdentifyBoundaryFaces(mesh_C->tetrahedra()));
-  for (VolumeVertexIndex bv : boundary_vertices) {
+  for (int bv : boundary_vertices) {
     pressure_values[bv] = T(0.);
   }
 

--- a/geometry/proximity/make_cylinder_mesh.cc
+++ b/geometry/proximity/make_cylinder_mesh.cc
@@ -40,10 +40,8 @@ namespace {
 template <typename T>
 std::vector<VolumeElement> CalcLongCylinderVolumeMeshWithMa(
     const Cylinder& cylinder, const int num_vertices_per_circle,
-    const VolumeVertexIndex bottom_center,
-    const std::vector<VolumeVertexIndex>& bottom,
-    const VolumeVertexIndex top_center,
-    const std::vector<VolumeVertexIndex>& top,
+    const int bottom_center, const std::vector<int>& bottom,
+    const int top_center, const std::vector<int>& top,
     std::vector<Vector3<T>>* mesh_vertices) {
   const double top_z = cylinder.length() / 2.;
   const double tolerance =
@@ -54,13 +52,13 @@ std::vector<VolumeElement> CalcLongCylinderVolumeMeshWithMa(
 
   // These two mesh vertices will be at the two end points of the central
   // medial line segment.
-  VolumeVertexIndex medial[2];
+  int medial[2];
   const double offset_distance = cylinder.radius();
   const double offset_top_z = top_z - offset_distance;
   const double offset_bottom_z = -offset_top_z;
-  medial[0] = VolumeVertexIndex(mesh_vertices->size());
+  medial[0] = static_cast<int>(mesh_vertices->size());
   mesh_vertices->emplace_back(0, 0, offset_bottom_z);
-  medial[1] = VolumeVertexIndex(mesh_vertices->size());
+  medial[1] = static_cast<int>(mesh_vertices->size());
   mesh_vertices->emplace_back(0, 0, offset_top_z);
 
   std::vector<VolumeElement> mesh_elements;
@@ -150,10 +148,8 @@ std::vector<VolumeElement> CalcLongCylinderVolumeMeshWithMa(
 template <typename T>
 std::vector<VolumeElement> CalcMediumCylinderVolumeMeshWithMa(
     const Cylinder& cylinder, const int num_vertices_per_circle,
-    const VolumeVertexIndex bottom_center,
-    const std::vector<VolumeVertexIndex>& bottom,
-    const VolumeVertexIndex top_center,
-    const std::vector<VolumeVertexIndex>& top,
+    const int bottom_center, const std::vector<int>& bottom,
+    const int top_center, const std::vector<int>& top,
     std::vector<Vector3<T>>* mesh_vertices) {
   const double top_z = cylinder.length() / 2.;
   const double tolerance =
@@ -163,7 +159,7 @@ std::vector<VolumeElement> CalcMediumCylinderVolumeMeshWithMa(
   DRAKE_DEMAND(num_vertices_per_circle == static_cast<int>(top.size()));
 
   // The central medial vertex is at the center of the medium cylinder.
-  VolumeVertexIndex medial = VolumeVertexIndex(mesh_vertices->size());
+  int medial = static_cast<int>(mesh_vertices->size());
   mesh_vertices->emplace_back(0, 0, 0);
 
   std::vector<VolumeElement> mesh_elements;
@@ -248,10 +244,8 @@ std::vector<VolumeElement> CalcMediumCylinderVolumeMeshWithMa(
 template <typename T>
 std::vector<VolumeElement> CalcShortCylinderVolumeMeshWithMa(
     const Cylinder& cylinder, const int num_vertices_per_circle,
-    const VolumeVertexIndex bottom_center,
-    const std::vector<VolumeVertexIndex>& bottom,
-    const VolumeVertexIndex top_center,
-    const std::vector<VolumeVertexIndex>& top,
+    const int bottom_center, const std::vector<int>& bottom,
+    const int top_center, const std::vector<int>& top,
     std::vector<Vector3<T>>* mesh_vertices) {
   const double top_z = cylinder.length() / 2.;
   const double tolerance =
@@ -267,11 +261,11 @@ std::vector<VolumeElement> CalcShortCylinderVolumeMeshWithMa(
   // will decrease the number of vertices and tetrahedra slightly, but the
   // mesh will not be symmetric around the rotation axis, and the code will
   // become more complicated.
-  VolumeVertexIndex center = VolumeVertexIndex(mesh_vertices->size());
+  int center = static_cast<int>(mesh_vertices->size());
   mesh_vertices->emplace_back(0, 0, 0);
 
   // Vertices along the medial circle.
-  std::vector<VolumeVertexIndex> medial(num_vertices_per_circle);
+  std::vector<int> medial(num_vertices_per_circle);
   const double medial_radius = cylinder.radius() - cylinder.length() / 2.;
   const double scale_cylinder_radius_to_medial_circle =
       medial_radius / cylinder.radius();
@@ -282,7 +276,7 @@ std::vector<VolumeElement> CalcShortCylinderVolumeMeshWithMa(
     const double y =
         ExtractDoubleOrThrow(mesh_vertices->at(bottom[i]).y()) *
         scale_cylinder_radius_to_medial_circle;
-    medial[i] = VolumeVertexIndex(mesh_vertices->size());
+    medial[i] = static_cast<int>(mesh_vertices->size());
     mesh_vertices->emplace_back(x, y, 0);
   }
 
@@ -391,21 +385,21 @@ VolumeMesh<T> MakeCylinderVolumeMeshWithMa(const Cylinder& cylinder,
   // will decrease the number of vertices and tetrahedra slightly, but the
   // mesh will not be symmetric around the rotation axis, and the code will
   // become more complicated.
-  VolumeVertexIndex bottom_center(mesh_vertices.size());
+  int bottom_center = static_cast<int>(mesh_vertices.size());
   mesh_vertices.emplace_back(0, 0, bottom_z);
-  VolumeVertexIndex top_center(mesh_vertices.size());
+  int top_center = static_cast<int>(mesh_vertices.size());
   mesh_vertices.emplace_back(0, 0, top_z);
 
   // Vertices on the two circular rims of the cylinder.
-  std::vector<VolumeVertexIndex> bottom(num_vertices_per_circle);
-  std::vector<VolumeVertexIndex> top(num_vertices_per_circle);
+  std::vector<int> bottom(num_vertices_per_circle);
+  std::vector<int> top(num_vertices_per_circle);
   const double angle_step = 2. * M_PI / num_vertices_per_circle;
   for (int i = 0; i < num_vertices_per_circle; ++i) {
     const double x = cylinder.radius() * cos(angle_step * i);
     const double y = cylinder.radius() * sin(angle_step * i);
-    bottom[i] = VolumeVertexIndex(mesh_vertices.size());
+    bottom[i] = static_cast<int>(mesh_vertices.size());
     mesh_vertices.emplace_back(x, y, bottom_z);
-    top[i] = VolumeVertexIndex(mesh_vertices.size());
+    top[i] = static_cast<int>(mesh_vertices.size());
     mesh_vertices.emplace_back(x, y, top_z);
   }
 

--- a/geometry/proximity/mesh_intersection.cc
+++ b/geometry/proximity/mesh_intersection.cc
@@ -213,7 +213,7 @@ SurfaceVolumeIntersector<T>::ClipTriangleByTetrahedron(
   // as we do transformed computations below.
   Vector3<double> p_MVs[4];
   for (int i = 0; i < 4; ++i) {
-    VolumeVertexIndex v = volume_M.element(element).vertex(i);
+    int v = volume_M.element(element).vertex(i);
     p_MVs[i] = volume_M.vertex(v);
   }
   // Sets up the four half spaces associated with the four triangular faces of

--- a/geometry/proximity/mesh_plane_intersection.cc
+++ b/geometry/proximity/mesh_plane_intersection.cc
@@ -70,15 +70,14 @@ void SliceTetWithPlane(VolumeElementIndex tet_index,
                        std::vector<SurfaceFace>* faces,
                        std::vector<Vector3<T>>* vertices_W,
                        std::vector<T>* surface_e,
-                       std::unordered_map<SortedPair<VolumeVertexIndex>,
-                                          int>* cut_edges) {
+                       std::unordered_map<SortedPair<int>, int>* cut_edges) {
   const VolumeMesh<double>& mesh_M = field_M.mesh();
 
   T distance[4];
   // Bit encoding of the sign of signed-distance: v0, v1, v2, v3.
   int intersection_code = 0;
   for (int i = 0; i < 4; ++i) {
-    const VolumeVertexIndex v = mesh_M.element(tet_index).vertex(i);
+    const int v = mesh_M.element(tet_index).vertex(i);
     distance[i] = plane_M.CalcHeight(mesh_M.vertex(v));
     if (distance[i] > T(0)) intersection_code |= 1 << i;
   }
@@ -102,11 +101,9 @@ void SliceTetWithPlane(VolumeElementIndex tet_index,
     if (edge_index == -1) break;
     ++num_intersections;
     const TetrahedronEdge& tet_edge = kTetEdges[edge_index];
-    const VolumeVertexIndex v0 =
-        mesh_M.element(tet_index).vertex(tet_edge.first);
-    const VolumeVertexIndex v1 =
-        mesh_M.element(tet_index).vertex(tet_edge.second);
-    const SortedPair<VolumeVertexIndex> mesh_edge{v0, v1};
+    const int v0 = mesh_M.element(tet_index).vertex(tet_edge.first);
+    const int v1 = mesh_M.element(tet_index).vertex(tet_edge.second);
+    const SortedPair<int> mesh_edge{v0, v1};
 
     auto iter = cut_edges->find(mesh_edge);
     if (representation == ContactPolygonRepresentation::kCentroidSubdivision &&
@@ -183,7 +180,7 @@ std::unique_ptr<ContactSurface<T>> ComputeContactSurface(
   std::vector<SurfaceFace> faces;
   std::vector<Vector3<T>> vertices_W;
   std::vector<T> surface_e;
-  std::unordered_map<SortedPair<VolumeVertexIndex>, int> cut_edges;
+  std::unordered_map<SortedPair<int>, int> cut_edges;
 
   auto grad_eM_W = std::make_unique<std::vector<Vector3<T>>>();
   size_t old_face_count = 0;

--- a/geometry/proximity/mesh_plane_intersection.h
+++ b/geometry/proximity/mesh_plane_intersection.h
@@ -90,8 +90,7 @@ void SliceTetWithPlane(VolumeElementIndex tet_index,
                        std::vector<SurfaceFace>* faces,
                        std::vector<Vector3<T>>* vertices_W,
                        std::vector<T>* surface_e,
-                       std::unordered_map<SortedPair<VolumeVertexIndex>,
-                                          int>* cut_edges);
+                       std::unordered_map<SortedPair<int>, int>* cut_edges);
 
 /* Computes a ContactSurface by intersecting a plane with a set of tetrahedra
  drawn from the given volume mesh (and its pressure field). The indicated

--- a/geometry/proximity/meshing_utilities.cc
+++ b/geometry/proximity/meshing_utilities.cc
@@ -14,28 +14,25 @@ void Append(const std::vector<VolumeElement>& new_elements,
 
 using std::unordered_set;
 
-std::vector<VolumeElement> SplitTriangularPrismToTetrahedra(
-    const VolumeVertexIndex v0, const VolumeVertexIndex v1,
-    const VolumeVertexIndex v2, const VolumeVertexIndex v3,
-    const VolumeVertexIndex v4, const VolumeVertexIndex v5) {
+std::vector<VolumeElement> SplitTriangularPrismToTetrahedra(int v0, int v1,
+                                                            int v2, int v3,
+                                                            int v4, int v5) {
   std::vector<VolumeElement> elements;
   elements.reserve(3);
-  VolumeVertexIndex previous = v3;
-  for (const VolumeVertexIndex& next : {v4, v1, v2}) {
+  int previous = v3;
+  for (int next : {v4, v1, v2}) {
     elements.emplace_back(previous, next, v0, v5);
     previous = next;
   }
   return elements;
 }
 
-std::vector<VolumeElement> SplitPyramidToTetrahedra(
-    const VolumeVertexIndex v0, const VolumeVertexIndex v1,
-    const VolumeVertexIndex v2, const VolumeVertexIndex v3,
-    const VolumeVertexIndex v4) {
+std::vector<VolumeElement> SplitPyramidToTetrahedra(int v0, int v1, int v2,
+                                                    int v3, int v4) {
   std::vector<VolumeElement> elements;
   elements.reserve(2);
-  VolumeVertexIndex previous = v3;
-  for (const VolumeVertexIndex& next : {v4, v1}) {
+  int previous = v3;
+  for (int next : {v4, v1}) {
     elements.emplace_back(previous, next, v0, v2);
     previous = next;
   }

--- a/geometry/proximity/meshing_utilities.h
+++ b/geometry/proximity/meshing_utilities.h
@@ -16,8 +16,7 @@ void Append(const std::vector<VolumeElement>& new_elements,
  diagonal v0,v5 (see ordering below) of the rectangular face v0,v2,v5,v3. The
  other two face diagonals are v0,v4 and v1,v5.
 
- We assume the input vertex indices (represented as VolumeVertexIndex) are in
- this ordering:
+ We assume the input vertex indices are in this ordering:
    1. Three vertices v0,v1,v2 of the "bottom" face are in counterclockwise
       order when look from "above" the prism.
    2. Three vertices v3,v4,v5 of the "top" face match v0,v1,v2, respectively.
@@ -36,9 +35,9 @@ void Append(const std::vector<VolumeElement>& new_elements,
                 |/          \|
                 v1-----------v2
  */
-std::vector<VolumeElement> SplitTriangularPrismToTetrahedra(
-    VolumeVertexIndex v0, VolumeVertexIndex v1, VolumeVertexIndex v2,
-    VolumeVertexIndex v3, VolumeVertexIndex v4, VolumeVertexIndex v5);
+std::vector<VolumeElement> SplitTriangularPrismToTetrahedra(int v0, int v1,
+                                                            int v2, int v3,
+                                                            int v4, int v5);
 
 /* Subdivide a pyramid into two tetrahedra sharing the diagonal v0,v2.
 
@@ -51,11 +50,8 @@ std::vector<VolumeElement> SplitTriangularPrismToTetrahedra(
                 |/          \|
                 v3-----------v2
  */
-std::vector<VolumeElement> SplitPyramidToTetrahedra(VolumeVertexIndex v0,
-                                                    VolumeVertexIndex v1,
-                                                    VolumeVertexIndex v2,
-                                                    VolumeVertexIndex v3,
-                                                    VolumeVertexIndex v4);
+std::vector<VolumeElement> SplitPyramidToTetrahedra(int v0, int v1, int v2,
+                                                    int v3, int v4);
 
 }  // namespace internal
 }  // namespace geometry

--- a/geometry/proximity/proximity_utilities.cc
+++ b/geometry/proximity/proximity_utilities.cc
@@ -51,7 +51,7 @@ std::string GetGeometryName(const fcl::CollisionObjectd& object) {
 }
 
 int CountEdges(const VolumeMesh<double>& mesh) {
-  std::unordered_set<SortedPair<VolumeVertexIndex>> edges;
+  std::unordered_set<SortedPair<int>> edges;
 
   for (auto& t : mesh.tetrahedra()) {
     // 6 edges of a tetrahedron
@@ -66,7 +66,7 @@ int CountEdges(const VolumeMesh<double>& mesh) {
 }
 
 int CountFaces(const VolumeMesh<double>& mesh) {
-  std::set<SortedTriplet<VolumeVertexIndex>> faces;
+  std::set<SortedTriplet<int>> faces;
 
   for (const auto& t : mesh.tetrahedra()) {
     // 4 faces of a tetrahedron, all facing in

--- a/geometry/proximity/test/bvh_test.cc
+++ b/geometry/proximity/test/bvh_test.cc
@@ -408,7 +408,6 @@ TYPED_TEST(BvhTest, TestCollideSurfaceVolume) {
   ASSERT_EQ(CountLeafNodes(bvh_S.root_node()), 1);
 
   using VTet = VolumeElement;
-  using VVindex = VolumeVertexIndex;
   std::vector<Vector3d> vertices_V{
       {Vector3d(1, 0, 1),     // A
        Vector3d(1, 0, -1),    // B
@@ -417,9 +416,7 @@ TYPED_TEST(BvhTest, TestCollideSurfaceVolume) {
        Vector3d(-1, 0, 1),    // E
        Vector3d(-1, 0, -1),   // F
        Vector3d(-1, 1, 0)}};  // G
-  std::vector<VTet> tets_V{
-      {VTet(VVindex(0), VVindex(2), VVindex(1), VVindex(3)),
-       VTet(VVindex(4), VVindex(5), VVindex(6), VVindex(3))}};
+  std::vector<VTet> tets_V{{VTet(0, 2, 1, 3), VTet(4, 5, 6, 3)}};
   const VolumeMesh<double> mesh_V(std::move(tets_V), std::move(vertices_V));
   const Bvh<BvType, VolumeMesh<double>> bvh_V(mesh_V);
   // Confirm the expected topology (two leaves, one per tet).
@@ -532,16 +529,12 @@ TYPED_TEST(BvhTest, TestEqual) {
   // bounding volumes are not equal. Each tree has only one node.
   {
     const VolumeMesh<double> smaller_tetrahedron(
-        std::vector<VolumeElement>{
-            VolumeElement(VolumeVertexIndex(0), VolumeVertexIndex(1),
-                          VolumeVertexIndex(2), VolumeVertexIndex(3))},
+        std::vector<VolumeElement>{VolumeElement(0, 1, 2, 3)},
         std::vector<Vector3<double>>{Vector3d::Zero(), Vector3d::UnitX(),
                                      Vector3d::UnitY(), Vector3d::UnitZ()});
     const Bvh<BvType, VolumeMesh<double>> smaller(smaller_tetrahedron);
     const VolumeMesh<double> bigger_tetrahedron(
-        std::vector<VolumeElement>{
-            VolumeElement(VolumeVertexIndex(0), VolumeVertexIndex(1),
-                          VolumeVertexIndex(2), VolumeVertexIndex(3))},
+        std::vector<VolumeElement>{VolumeElement(0, 1, 2, 3)},
         std::vector<Vector3<double>>{Vector3d::Zero(), 2. * Vector3d::UnitX(),
                                      2. * Vector3d::UnitY(),
                                      2. * Vector3d::UnitZ()});
@@ -564,8 +557,7 @@ TYPED_TEST(BvhTest, TestEqual) {
     const std::vector<Vector3<double>> vertices{
         Vector3d::Zero(), Vector3d::UnitX(), Vector3d::UnitY(),
         Vector3d::UnitZ()};
-    const VolumeElement element(VolumeVertexIndex(0), VolumeVertexIndex(1),
-                                VolumeVertexIndex(2), VolumeVertexIndex(3));
+    const VolumeElement element(0, 1, 2, 3);
     const VolumeMesh<double> one_tetrahedron(
         std::vector<VolumeElement>{element},
         std::vector<Vector3d>(vertices));

--- a/geometry/proximity/test/hydroelastic_internal_test.cc
+++ b/geometry/proximity/test/hydroelastic_internal_test.cc
@@ -885,7 +885,7 @@ TEST_F(HydroelasticSoftGeometryTest, Sphere) {
   double max_distance = -1.0;
   for (const auto& soft_geometry : {*sphere1, *sphere2}) {
     const VolumeMesh<double>& mesh = soft_geometry.mesh();
-    for (VolumeVertexIndex v(0); v < mesh.num_vertices(); ++v) {
+    for (int v = 0; v < mesh.num_vertices(); ++v) {
       const double dist = mesh.vertex(v).norm();
       max_distance = std::max(max_distance, dist);
       ASSERT_LE(dist, kRadius);
@@ -903,7 +903,7 @@ TEST_F(HydroelasticSoftGeometryTest, Sphere) {
   };
   const double kEps = std::numeric_limits<double>::epsilon();
   const VolumeMesh<double>& mesh = sphere1->mesh();
-  for (VolumeVertexIndex v(0); v < mesh.num_vertices(); ++v) {
+  for (int v = 0; v < mesh.num_vertices(); ++v) {
     const Vector3d& vertex = mesh.vertex(v);
     // Zero on outside, 1 on inside.
     const double expected_p = pressure(vertex);
@@ -979,7 +979,7 @@ TEST_F(HydroelasticSoftGeometryTest, Box) {
   EXPECT_EQ(box->mesh().num_vertices(), expected_num_vertices);
   const double E =
       properties.GetPropertyOrDefault(kMaterialGroup, kElastic, 1e8);
-  for (VolumeVertexIndex v(0); v < box->mesh().num_vertices(); ++v) {
+  for (int v = 0; v < box->mesh().num_vertices(); ++v) {
     const double pressure = box->pressure_field().EvaluateAtVertex(v);
     EXPECT_GE(pressure, 0);
     EXPECT_LE(pressure, E);
@@ -1005,7 +1005,7 @@ TEST_F(HydroelasticSoftGeometryTest, Cylinder) {
   EXPECT_EQ(cylinder->mesh().num_vertices(), expected_num_vertices);
   const double E =
       properties.GetPropertyOrDefault(kMaterialGroup, kElastic, 1e8);
-  for (VolumeVertexIndex v(0); v < cylinder->mesh().num_vertices(); ++v) {
+  for (int v = 0; v < cylinder->mesh().num_vertices(); ++v) {
     const double pressure = cylinder->pressure_field().EvaluateAtVertex(v);
     EXPECT_GE(pressure, 0);
     EXPECT_LE(pressure, E);
@@ -1033,7 +1033,7 @@ TEST_F(HydroelasticSoftGeometryTest, Capsule) {
   // `GetProperty` variant.
   const double E =
       properties.GetPropertyOrDefault(kMaterialGroup, kElastic, 1e8);
-  for (VolumeVertexIndex v(0); v < capsule->mesh().num_vertices(); ++v) {
+  for (int v = 0; v < capsule->mesh().num_vertices(); ++v) {
     const double pressure = capsule->pressure_field().EvaluateAtVertex(v);
     EXPECT_GE(pressure, 0);
     EXPECT_LE(pressure, E);
@@ -1062,7 +1062,7 @@ TEST_F(HydroelasticSoftGeometryTest, Ellipsoid) {
   EXPECT_EQ(ellipsoid->mesh().num_vertices(), expected_num_vertices);
   const double E =
       properties.GetPropertyOrDefault(kMaterialGroup, kElastic, 1e8);
-  for (VolumeVertexIndex v(0); v < ellipsoid->mesh().num_vertices(); ++v) {
+  for (int v = 0; v < ellipsoid->mesh().num_vertices(); ++v) {
     const double pressure = ellipsoid->pressure_field().EvaluateAtVertex(v);
     EXPECT_GE(pressure, 0);
     EXPECT_LE(pressure, E);

--- a/geometry/proximity/test/make_box_field_test.cc
+++ b/geometry/proximity/test/make_box_field_test.cc
@@ -28,7 +28,7 @@ GTEST_TEST(MakeBoxFieldTest, MakeBoxPressureField) {
   // zero and kElasticModulus respectively.
   double max_pressure = std::numeric_limits<double>::lowest();
   double min_pressure = std::numeric_limits<double>::max();
-  for (VolumeVertexIndex v(0); v < mesh.num_vertices(); ++v) {
+  for (int v = 0; v < mesh.num_vertices(); ++v) {
     double pressure = pressure_field.EvaluateAtVertex(v);
     EXPECT_LE(pressure, kElasticModulus);
     EXPECT_GE(pressure, 0.0);
@@ -43,9 +43,9 @@ GTEST_TEST(MakeBoxFieldTest, MakeBoxPressureField) {
   EXPECT_EQ(max_pressure, kElasticModulus);
 
   // Check that all boundary vertices have zero pressure.
-  std::vector<VolumeVertexIndex> boundary_vertex_indices =
+  std::vector<int> boundary_vertex_indices =
       CollectUniqueVertices(IdentifyBoundaryFaces(mesh.tetrahedra()));
-  for (const VolumeVertexIndex& v : boundary_vertex_indices) {
+  for (int v : boundary_vertex_indices) {
     double pressure = pressure_field.EvaluateAtVertex(v);
     EXPECT_EQ(pressure, 0.0);
   }
@@ -66,7 +66,7 @@ GTEST_TEST(MakeBoxFieldTest, MakeBoxPressureFieldInMeshWithMedialAxis) {
   // zero and kElasticModulus respectively.
   double max_pressure = std::numeric_limits<double>::lowest();
   double min_pressure = std::numeric_limits<double>::max();
-  for (VolumeVertexIndex v(0); v < mesh.num_vertices(); ++v) {
+  for (int v = 0; v < mesh.num_vertices(); ++v) {
     double pressure = pressure_field.EvaluateAtVertex(v);
     EXPECT_LE(pressure, kElasticModulus);
     EXPECT_GE(pressure, 0.0);
@@ -81,9 +81,9 @@ GTEST_TEST(MakeBoxFieldTest, MakeBoxPressureFieldInMeshWithMedialAxis) {
   EXPECT_EQ(max_pressure, kElasticModulus);
 
   // Check that all boundary vertices have zero pressure.
-  std::vector<VolumeVertexIndex> boundary_vertex_indices =
+  std::vector<int> boundary_vertex_indices =
       CollectUniqueVertices(IdentifyBoundaryFaces(mesh.tetrahedra()));
-  for (const VolumeVertexIndex& v : boundary_vertex_indices) {
+  for (int v : boundary_vertex_indices) {
     double pressure = pressure_field.EvaluateAtVertex(v);
     EXPECT_EQ(pressure, 0.0);
   }

--- a/geometry/proximity/test/make_box_mesh_test.cc
+++ b/geometry/proximity/test/make_box_mesh_test.cc
@@ -81,8 +81,8 @@ bool VerifyBoxMeshWithMa(const VolumeMesh<double>& mesh, const Box& box) {
   // A. The mesh is conforming.
   // A1. The mesh has unique vertices.
   const int num_vertices = mesh.num_vertices();
-  for (VolumeVertexIndex i(0); i < num_vertices; ++i) {
-    for (VolumeVertexIndex j(i + 1); j < num_vertices; ++j) {
+  for (int i = 0; i < num_vertices; ++i) {
+    for (int j = i + 1; j < num_vertices; ++j) {
       const bool vertex_is_unique = mesh.vertex(i) != mesh.vertex(j);
       EXPECT_TRUE(vertex_is_unique) << "The mesh has duplicated vertices.";
       if (!vertex_is_unique) {
@@ -125,7 +125,7 @@ bool VerifyBoxMeshWithMa(const VolumeMesh<double>& mesh, const Box& box) {
     }
   }
   // B2. No mesh's vertex is outside the box.
-  for (VolumeVertexIndex i(0); i < num_vertices; ++i) {
+  for (int i = 0; i < num_vertices; ++i) {
     const bool vertex_is_inside_or_on_boundary =
         (mesh.vertex(i).array().abs() <= half_size.array()).all();
     EXPECT_TRUE(vertex_is_inside_or_on_boundary)
@@ -152,7 +152,7 @@ bool VerifyBoxMeshWithMa(const VolumeMesh<double>& mesh, const Box& box) {
   // C. The mesh conforms to the box's medial axis.
   // C1. No tetrahedron has all four vertices on the box's boundary, i.e.,
   //     each tetrahedron has at least one interior vertex.
-  std::vector<VolumeVertexIndex> boundary_vertices =
+  std::vector<int> boundary_vertices =
       CollectUniqueVertices(IdentifyBoundaryFaces(mesh.tetrahedra()));
   for (const VolumeElement& tetrahedron : mesh.tetrahedra()) {
     bool tetrahedron_has_an_interior_vertex = false;

--- a/geometry/proximity/test/make_capsule_field_test.cc
+++ b/geometry/proximity/test/make_capsule_field_test.cc
@@ -29,7 +29,7 @@ void CheckMinMaxBoundaryValue(
   // zero and elastic_modulus respectively.
   double max_pressure = std::numeric_limits<double>::lowest();
   double min_pressure = std::numeric_limits<double>::max();
-  for (VolumeVertexIndex v(0); v < pressure_field.mesh().num_vertices(); ++v) {
+  for (int v = 0; v < pressure_field.mesh().num_vertices(); ++v) {
     const double pressure = pressure_field.EvaluateAtVertex(v);
     ASSERT_LE(pressure, elastic_modulus);
     ASSERT_GE(pressure, 0.0);
@@ -48,10 +48,10 @@ void CheckMinMaxBoundaryValue(
   // knowledge of the mesh structure. This goes for medial axis vertices also.
 
   // Check that all boundary vertices have zero pressure.
-  std::vector<VolumeVertexIndex> boundary_vertex_indices =
+  std::vector<int> boundary_vertex_indices =
       CollectUniqueVertices(
           IdentifyBoundaryFaces(pressure_field.mesh().tetrahedra()));
-  for (const VolumeVertexIndex& v : boundary_vertex_indices) {
+  for (int v : boundary_vertex_indices) {
     ASSERT_EQ(pressure_field.EvaluateAtVertex(v), 0.0);
   }
 }

--- a/geometry/proximity/test/make_capsule_mesh_test.cc
+++ b/geometry/proximity/test/make_capsule_mesh_test.cc
@@ -57,8 +57,8 @@ void VerifyCapsuleMeshWithMa(const VolumeMesh<double>& mesh,
   // A. The mesh is conforming.
   // A1. The mesh has unique vertices.
   const int num_vertices = mesh.num_vertices();
-  for (VolumeVertexIndex i(0); i < num_vertices; ++i) {
-    for (VolumeVertexIndex j(i + 1); j < num_vertices; ++j) {
+  for (int i = 0; i < num_vertices; ++i) {
+    for (int j = i + 1; j < num_vertices; ++j) {
       const bool vertex_is_unique = mesh.vertex(i) != mesh.vertex(j);
       ASSERT_TRUE(vertex_is_unique) << "The mesh has duplicated vertices.";
     }
@@ -84,7 +84,7 @@ void VerifyCapsuleMeshWithMa(const VolumeMesh<double>& mesh,
   // C. The mesh conforms to the capsule's medial axis.
   // C1. No tetrahedron has all four vertices on the capsule's boundary, i.e.,
   //     each tetrahedron has at least one interior vertex.
-  const std::vector<VolumeVertexIndex> boundary_vertices =
+  const std::vector<int> boundary_vertices =
       CollectUniqueVertices(IdentifyBoundaryFaces(mesh.tetrahedra()));
   for (const VolumeElement& tetrahedron : mesh.tetrahedra()) {
     bool tetrahedron_has_an_interior_vertex = false;

--- a/geometry/proximity/test/make_cylinder_field_test.cc
+++ b/geometry/proximity/test/make_cylinder_field_test.cc
@@ -26,7 +26,7 @@ void CheckMinMaxBoundaryValue(
   // zero and elastic_modulus respectively.
   double max_pressure = std::numeric_limits<double>::lowest();
   double min_pressure = std::numeric_limits<double>::max();
-  for (VolumeVertexIndex v(0); v < pressure_field.mesh().num_vertices(); ++v) {
+  for (int v = 0; v < pressure_field.mesh().num_vertices(); ++v) {
     double pressure = pressure_field.EvaluateAtVertex(v);
     ASSERT_LE(pressure, elastic_modulus + tolerance);
     ASSERT_GE(pressure, 0.0);
@@ -41,10 +41,10 @@ void CheckMinMaxBoundaryValue(
   EXPECT_NEAR(max_pressure, elastic_modulus, tolerance);
 
   // Check that all boundary vertices have zero pressure.
-  std::vector<VolumeVertexIndex> boundary_vertex_indices =
+  std::vector<int> boundary_vertex_indices =
       CollectUniqueVertices(
           IdentifyBoundaryFaces(pressure_field.mesh().tetrahedra()));
-  for (const VolumeVertexIndex& v : boundary_vertex_indices) {
+  for (int v : boundary_vertex_indices) {
     double pressure = pressure_field.EvaluateAtVertex(v);
     ASSERT_EQ(pressure, 0.0);
   }
@@ -52,9 +52,9 @@ void CheckMinMaxBoundaryValue(
   // This test only applies to a mesh that has a vertex at the center of
   // the geometric shape, where we check that the center vertex has the
   // max_pressure.
-  VolumeVertexIndex center_vertex{0};
+  int center_vertex = 0;
   bool has_center_vertex = false;
-  for (VolumeVertexIndex v{0}; v < pressure_field.mesh().num_vertices(); ++v) {
+  for (int v = 0; v < pressure_field.mesh().num_vertices(); ++v) {
     if (pressure_field.mesh().vertex(v) == Vector3d::Zero()) {
       center_vertex = v;
       has_center_vertex = true;

--- a/geometry/proximity/test/make_cylinder_mesh_test.cc
+++ b/geometry/proximity/test/make_cylinder_mesh_test.cc
@@ -149,8 +149,8 @@ void VerifyCylinderMeshWithMa(const VolumeMesh<double>& mesh,
   // A. The mesh is conforming.
   // A1. The mesh has unique vertices.
   const int num_vertices = mesh.num_vertices();
-  for (VolumeVertexIndex i(0); i < num_vertices; ++i) {
-    for (VolumeVertexIndex j(i + 1); j < num_vertices; ++j) {
+  for (int i = 0; i < num_vertices; ++i) {
+    for (int j = i + 1; j < num_vertices; ++j) {
       const bool vertex_is_unique = mesh.vertex(i) != mesh.vertex(j);
       ASSERT_TRUE(vertex_is_unique) << "The mesh has duplicated vertices.";
     }
@@ -195,7 +195,7 @@ void VerifyCylinderMeshWithMa(const VolumeMesh<double>& mesh,
   // C. The mesh conforms to the cylinder's medial axis.
   // C1. No tetrahedron has all four vertices on the cylinder's boundary, i.e.,
   //     each tetrahedron has at least one interior vertex.
-  std::vector<VolumeVertexIndex> boundary_vertices =
+  std::vector<int> boundary_vertices =
       CollectUniqueVertices(IdentifyBoundaryFaces(mesh.tetrahedra()));
   for (const VolumeElement& tetrahedron : mesh.tetrahedra()) {
     bool tetrahedron_has_an_interior_vertex = false;

--- a/geometry/proximity/test/make_ellipsoid_field_test.cc
+++ b/geometry/proximity/test/make_ellipsoid_field_test.cc
@@ -24,7 +24,7 @@ void CheckMinMaxBoundaryValue(
   // zero and elastic_modulus respectively.
   double max_pressure = std::numeric_limits<double>::lowest();
   double min_pressure = std::numeric_limits<double>::max();
-  for (VolumeVertexIndex v(0); v < pressure_field.mesh().num_vertices(); ++v) {
+  for (int v = 0; v < pressure_field.mesh().num_vertices(); ++v) {
     double pressure = pressure_field.EvaluateAtVertex(v);
     EXPECT_LE(pressure, elastic_modulus);
     EXPECT_GE(pressure, 0.0);
@@ -39,10 +39,10 @@ void CheckMinMaxBoundaryValue(
   EXPECT_EQ(max_pressure, elastic_modulus);
 
   // Check that all boundary vertices have zero pressure.
-  std::vector<VolumeVertexIndex> boundary_vertex_indices =
+  std::vector<int> boundary_vertex_indices =
       CollectUniqueVertices(
           IdentifyBoundaryFaces(pressure_field.mesh().tetrahedra()));
-  for (const VolumeVertexIndex& v : boundary_vertex_indices) {
+  for (int v : boundary_vertex_indices) {
     double pressure = pressure_field.EvaluateAtVertex(v);
     EXPECT_EQ(pressure, 0.0);
   }
@@ -50,8 +50,8 @@ void CheckMinMaxBoundaryValue(
   // Check that the center (0,0,0) of the shape has the max_pressure.
   // This test assumes that the mesh has a vertex at the origin of its
   // canonical frame.
-  VolumeVertexIndex center_vertex{0};
-  for (VolumeVertexIndex v{0}; v < pressure_field.mesh().num_vertices(); ++v) {
+  int center_vertex = 0;
+  for (int v = 0; v < pressure_field.mesh().num_vertices(); ++v) {
     if (pressure_field.mesh().vertex(v) == Vector3d::Zero()) {
       center_vertex = v;
       break;

--- a/geometry/proximity/test/make_sphere_field_test.cc
+++ b/geometry/proximity/test/make_sphere_field_test.cc
@@ -24,7 +24,7 @@ void CheckMinMaxBoundaryValue(
   // zero and elastic_modulus respectively.
   double max_pressure = std::numeric_limits<double>::lowest();
   double min_pressure = std::numeric_limits<double>::max();
-  for (VolumeVertexIndex v(0); v < pressure_field.mesh().num_vertices(); ++v) {
+  for (int v = 0; v < pressure_field.mesh().num_vertices(); ++v) {
     double pressure = pressure_field.EvaluateAtVertex(v);
     EXPECT_LE(pressure, elastic_modulus);
     EXPECT_GE(pressure, 0.0);
@@ -39,10 +39,10 @@ void CheckMinMaxBoundaryValue(
   EXPECT_EQ(max_pressure, elastic_modulus);
 
   // Check that all boundary vertices have zero pressure.
-  std::vector<VolumeVertexIndex> boundary_vertex_indices =
+  std::vector<int> boundary_vertex_indices =
       CollectUniqueVertices(
           IdentifyBoundaryFaces(pressure_field.mesh().tetrahedra()));
-  for (const VolumeVertexIndex& v : boundary_vertex_indices) {
+  for (int v : boundary_vertex_indices) {
     double pressure = pressure_field.EvaluateAtVertex(v);
     EXPECT_EQ(pressure, 0.0);
   }
@@ -50,8 +50,8 @@ void CheckMinMaxBoundaryValue(
   // Check that the center (0,0,0) of the shape has the max_pressure.
   // This test assumes that the mesh has a vertex at the origin of its
   // canonical frame.
-  VolumeVertexIndex center_vertex{0};
-  for (VolumeVertexIndex v{0}; v < pressure_field.mesh().num_vertices(); ++v) {
+  int center_vertex = 0;
+  for (int v = 0; v < pressure_field.mesh().num_vertices(); ++v) {
     if (pressure_field.mesh().vertex(v) == Vector3d::Zero()) {
       center_vertex = v;
       break;

--- a/geometry/proximity/test/make_sphere_mesh_test.cc
+++ b/geometry/proximity/test/make_sphere_mesh_test.cc
@@ -38,13 +38,14 @@ GTEST_TEST(MakeSphereMesh, InvariantsOfLevelZeroMesh) {
   // There is only one vertex marked `false` in is_boundary -- the vertex at
   // (0, 0, 0).
   int count = 0;
-  VolumeVertexIndex center_index;
-  for (VolumeVertexIndex i(0); i < static_cast<int>(is_boundary.size()); ++i) {
+  int center_index = -1;
+  for (int i = 0; i < static_cast<int>(is_boundary.size()); ++i) {
     if (is_boundary[i] == false) {
       ++count;
       center_index = i;
     }
   }
+  ASSERT_GT(center_index, -1);
   EXPECT_EQ(count, 1);
   EXPECT_EQ(mesh.vertex(center_index), Vector3d(0, 0, 0));
 
@@ -152,11 +153,10 @@ GTEST_TEST(MakeSphereMesh, SplitOctohedron) {
     return (tet_vertices[i] + tet_vertices[j]) / 2;
   };
 
-  using VIndex = VolumeVertexIndex;
   // We don't need the vertices for a, b, c, and d in the test; we just need
   // e-j.
-  const VIndex e(0), f(1), g(2), h(3), i(4), j(5);
-  const std::array<VIndex, 6> octo_vertices{e, f, g, h, i, j};
+  const int e(0), f(1), g(2), h(3), i(4), j(5);
+  const std::array<int, 6> octo_vertices{e, f, g, h, i, j};
   const std::vector<Vector3d> unit_p_MVs{
       Vector3d(mid_point(a, b)),  // e = (a + b) / 2
       Vector3d(mid_point(a, c)),  // f = (a + c) / 2
@@ -189,9 +189,8 @@ GTEST_TEST(MakeSphereMesh, SplitOctohedron) {
   // SplitOctohedron() will favor splitting along the shortest axis. In the
   // tests above, it's clear that EJ is aligned with the x-axis, GH with the y,
   // and FI with the z.
-  const std::vector<SortedPair<VIndex>> split_edges{SortedPair<VIndex>{e, j},
-                                                    SortedPair<VIndex>{g, h},
-                                                    SortedPair<VIndex>{f, i}};
+  const std::vector<SortedPair<int>> split_edges{
+      SortedPair<int>{e, j}, SortedPair<int>{g, h}, SortedPair<int>{f, i}};
   for (int axis = 0; axis < 3; ++axis) {
     Vector3d scale_factor{2, 2, 2};
     scale_factor(axis) = 1;
@@ -213,7 +212,7 @@ GTEST_TEST(MakeSphereMesh, SplitOctohedron) {
     for (const auto& tet : split_tetrahedra) {
       for (int v = 0; v < 3; ++v) {
         for (int u = v + 1; u < 4; ++u) {
-          SortedPair<VIndex> test_edge(tet.vertex(v), tet.vertex(u));
+          SortedPair<int> test_edge(tet.vertex(v), tet.vertex(u));
           for (int ax = 0; ax < 3; ++ax) {
             if (test_edge == split_edges[ax]) ++split_count[ax];
           }
@@ -355,7 +354,7 @@ GTEST_TEST(SparseSphereTest, SurfaceMatchesDenseMesh) {
 int CountSurfaceVertices(const VolumeMesh<double>& mesh, double radius = 1.0) {
   const double kEps = std::numeric_limits<double>::epsilon() * radius;
   int count = 0;
-  for (VolumeVertexIndex v(0); v < mesh.num_vertices(); ++v) {
+  for (int v = 0; v < mesh.num_vertices(); ++v) {
     const double r = mesh.vertex(v).norm();
     // This is a very tight tolerance. That's good. We want to know that the
     // surface vertices are as close to the surface of the sphere as can

--- a/geometry/proximity/test/mesh_intersection_test.cc
+++ b/geometry/proximity/test/mesh_intersection_test.cc
@@ -1069,8 +1069,7 @@ class MeshMeshDerivativesTest : public ::testing::Test {
     /* The pressure field is arbitrary, but
       1. its orientation doesn't lead to culling of intersection polygons, and
       2. validation is expressed in terms of that gradient. */
-    using VI = VolumeVertexIndex;
-    vector<VolumeElement> elements({VolumeElement(VI(0), VI(1), VI(2), VI(3))});
+    vector<VolumeElement> elements({VolumeElement(0, 1, 2, 3)});
     vector<Vector3d> vertices_S({Vector3d::Zero(), Vector3d::UnitX(),
                                  Vector3d::UnitY(), Vector3d::UnitZ()});
     tet_mesh_S_ = make_unique<VolumeMesh<double>>(std::move(elements),
@@ -1194,10 +1193,10 @@ class MeshMeshDerivativesTest : public ::testing::Test {
       /* Reality check: confirm the edges *are* parallel with the triangle. */
       const RotationMatrixd R_WR_d = convert_to_double(X_WR_).rotation();
       const RotationMatrixd R_WS_d = R_WR_d * R_RS_d;
-      const Vector3d& v0_S = tet_mesh_S_->vertex(VolumeVertexIndex(0));
-      const Vector3d& v1_S = tet_mesh_S_->vertex(VolumeVertexIndex(1));
-      const Vector3d& v2_S = tet_mesh_S_->vertex(VolumeVertexIndex(2));
-      const Vector3d& v3_S = tet_mesh_S_->vertex(VolumeVertexIndex(3));
+      const Vector3d& v0_S = tet_mesh_S_->vertex(0);
+      const Vector3d& v1_S = tet_mesh_S_->vertex(1);
+      const Vector3d& v2_S = tet_mesh_S_->vertex(2);
+      const Vector3d& v3_S = tet_mesh_S_->vertex(3);
       const Vector3d e03_S = v3_S - v0_S;
       const Vector3d e12_S = v2_S - v1_S;
       const Vector3d e03_W = R_WS_d * e03_S;

--- a/geometry/proximity/test/mesh_plane_intersection_test.cc
+++ b/geometry/proximity/test/mesh_plane_intersection_test.cc
@@ -342,7 +342,7 @@ class SliceTetWithPlaneTest : public ::testing::Test {
    position of the volume vertex with index v.  */
   struct EdgeVertex {
     int slice_vertex;
-    SortedPair<VolumeVertexIndex> edge;
+    SortedPair<int> edge;
     double weight{};
   };
 
@@ -377,8 +377,8 @@ class SliceTetWithPlaneTest : public ::testing::Test {
         // The slice polygon vertex S in the mesh frame F.
         const Vector3d p_FS = X_FW * slice_vertices_W[v];
         for (int e = 0; e < 6; ++e) {
-          const VolumeVertexIndex V0 = tet.vertex(tet_edges[e][0]);
-          const VolumeVertexIndex V1 = tet.vertex(tet_edges[e][1]);
+          const int V0 = tet.vertex(tet_edges[e][0]);
+          const int V1 = tet.vertex(tet_edges[e][1]);
           const Vector3d p_FV0 = mesh_F.vertex(V0);
           const Vector3d p_FV1 = mesh_F.vertex(V1);
           const Vector3d p_V0V1_F = p_FV1 - p_FV0;
@@ -419,7 +419,7 @@ class SliceTetWithPlaneTest : public ::testing::Test {
     // Every edge I've identified should be located in the clipping algorithm's
     // cache: cut_edges_. Make sure they line up.
     for (const auto& edge_vertex : edge_vertices) {
-      const SortedPair<VolumeVertexIndex>& computed_edge = edge_vertex.edge;
+      const SortedPair<int>& computed_edge = edge_vertex.edge;
       if (cut_edges_.count(computed_edge) == 0) {
         return {{},
                 ::testing::AssertionFailure()
@@ -599,7 +599,7 @@ class SliceTetWithPlaneTest : public ::testing::Test {
   vector<SurfaceFace> faces_;
   vector<Vector3d> vertices_W_;
   vector<double> surface_pressure_;
-  unordered_map<SortedPair<VolumeVertexIndex>, int> cut_edges_;
+  unordered_map<SortedPair<int>, int> cut_edges_;
 };
 
 /* This tests the *boundaries* of intersection. Confirms that a tet lying
@@ -934,7 +934,7 @@ TEST_F(SliceTetWithPlaneTest, DuplicateOutputFromDuplicateInput) {
   vector<SurfaceFace> min_faces;
   vector<Vector3d> min_vertices_F;
   vector<double> min_surface_pressure;
-  unordered_map<SortedPair<VolumeVertexIndex>, int> min_cut_edges;
+  unordered_map<SortedPair<int>, int> min_cut_edges;
 
   // The infrastructure for the mesh with duplicate vertices.
   VolumeMesh<double> dupe_mesh_F =
@@ -944,7 +944,7 @@ TEST_F(SliceTetWithPlaneTest, DuplicateOutputFromDuplicateInput) {
   vector<SurfaceFace> dupe_faces;
   vector<Vector3d> dupe_vertices_F;
   vector<double> dupe_surface_pressure;
-  unordered_map<SortedPair<VolumeVertexIndex>, int> dupe_cut_edges;
+  unordered_map<SortedPair<int>, int> dupe_cut_edges;
 
   // The common slicing plane.
   Plane<double> plane_F{Vector3d::UnitX(), Vector3d{0.5, 0, 0}};
@@ -1011,7 +1011,7 @@ TEST_F(SliceTetWithPlaneTest, NoDoubleCounting) {
     vector<SurfaceFace> faces;
     vector<Vector3d> vertices_W;
     vector<double> surface_pressure;
-    unordered_map<SortedPair<VolumeVertexIndex>, int> cut_edges;
+    unordered_map<SortedPair<int>, int> cut_edges;
     VolumeElementIndex tet_index{0};
     SliceTetWithPlane(tet_index, field_M, plane_M, I, representation, &faces,
                       &vertices_W, &surface_pressure, &cut_edges);
@@ -1031,7 +1031,7 @@ TEST_F(SliceTetWithPlaneTest, NoDoubleCounting) {
     vector<SurfaceFace> faces;
     vector<Vector3d> vertices_W;
     vector<double> surface_pressure;
-    unordered_map<SortedPair<VolumeVertexIndex>, int> cut_edges;
+    unordered_map<SortedPair<int>, int> cut_edges;
     VolumeElementIndex tet_index{1};
     SliceTetWithPlane(tet_index, field_M, plane_M, I, representation,
                       &faces, &vertices_W, &surface_pressure, &cut_edges);
@@ -1606,8 +1606,7 @@ class MeshPlaneDerivativesTest : public ::testing::Test {
     /* The pressure field is arbitrary, but
       1. its orientation doesn't lead to culling of intersection polygons, and
       2. validation is expressed in terms of that gradient. */
-    using VI = VolumeVertexIndex;
-    vector<VolumeElement> elements({VolumeElement(VI(0), VI(1), VI(2), VI(3))});
+    vector<VolumeElement> elements({VolumeElement(0, 1, 2, 3)});
     vector<Vector3d> vertices_S({Vector3d::Zero(), Vector3d::UnitX(),
                                  Vector3d::UnitY(), Vector3d::UnitZ()});
     mesh_S_ = make_unique<VolumeMesh<double>>(std::move(elements),
@@ -1724,10 +1723,10 @@ class MeshPlaneDerivativesTest : public ::testing::Test {
       /* Reality check: confirm the edges *are* parallel with the plane. */
       const RotationMatrixd R_WR_d = convert_to_double(X_WR_).rotation();
       const RotationMatrixd R_WS_d = R_WR_d * R_RS_d;
-      const Vector3d& v0_S = mesh_S_->vertex(VolumeVertexIndex(0));
-      const Vector3d& v1_S = mesh_S_->vertex(VolumeVertexIndex(1));
-      const Vector3d& v2_S = mesh_S_->vertex(VolumeVertexIndex(2));
-      const Vector3d& v3_S = mesh_S_->vertex(VolumeVertexIndex(3));
+      const Vector3d& v0_S = mesh_S_->vertex(0);
+      const Vector3d& v1_S = mesh_S_->vertex(1);
+      const Vector3d& v2_S = mesh_S_->vertex(2);
+      const Vector3d& v3_S = mesh_S_->vertex(3);
       const Vector3d e03_S = v3_S - v0_S;
       const Vector3d e12_S = v2_S - v1_S;
       const Vector3d e03_W = R_WS_d * e03_S;

--- a/geometry/proximity/test/meshing_utilities_test.cc
+++ b/geometry/proximity/test/meshing_utilities_test.cc
@@ -10,20 +10,13 @@ namespace internal {
 namespace {
 
 GTEST_TEST(SplitTriangularPrismToTetrahedraTest, SimpleTest) {
-  const VolumeVertexIndex v0(0);
-  const VolumeVertexIndex v1(1);
-  const VolumeVertexIndex v2(2);
-  const VolumeVertexIndex v3(3);
-  const VolumeVertexIndex v4(4);
-  const VolumeVertexIndex v5(5);
-
   std::vector<VolumeElement> tetrahedra =
-      SplitTriangularPrismToTetrahedra(v0, v1, v2, v3, v4, v5);
+      SplitTriangularPrismToTetrahedra(0, 1, 2, 3, 4, 5);
 
   EXPECT_EQ(tetrahedra.size(), 3);
 
   // The following statements check each of the three tetrahedra and also the
-  // three face diagonals (v0,v5), (v0,v4), and (v1,v5) that we promised in the
+  // three face diagonals (0,5), (0,4), and (1,5) that we promised in the
   // API contract. A tetrahedron always connect its four vertices into all
   // possible pairs of vertices to make six edges (4 choose 2 = 6). Therefore,
   // checking for existence of tetrahedron *,u,*,v,* implies the diagonal u,v
@@ -35,32 +28,26 @@ GTEST_TEST(SplitTriangularPrismToTetrahedraTest, SimpleTest) {
   // need to change too.
   EXPECT_TRUE(tetrahedra.end() != std::find(tetrahedra.begin(),
                                             tetrahedra.end(),
-                                            VolumeElement(v3, v4, v0, v5)));
+                                            VolumeElement(3, 4, 0, 5)));
   EXPECT_TRUE(tetrahedra.end() != std::find(tetrahedra.begin(),
                                             tetrahedra.end(),
-                                            VolumeElement(v4, v1, v0, v5)));
+                                            VolumeElement(4, 1, 0, 5)));
   EXPECT_TRUE(tetrahedra.end() != std::find(tetrahedra.begin(),
                                             tetrahedra.end(),
-                                            VolumeElement(v1, v2, v0, v5)));
+                                            VolumeElement(1, 2, 0, 5)));
 }
 
 GTEST_TEST(SplitPyramidToTetrahedraTest, SimpleTest) {
-  const VolumeVertexIndex v0(0);
-  const VolumeVertexIndex v1(1);
-  const VolumeVertexIndex v2(2);
-  const VolumeVertexIndex v3(3);
-  const VolumeVertexIndex v4(4);
-
   std::vector<VolumeElement> tetrahedra =
-      SplitPyramidToTetrahedra(v0, v1, v2, v3, v4);
+      SplitPyramidToTetrahedra(0, 1, 2, 3, 4);
 
   EXPECT_EQ(tetrahedra.size(), 2);
   EXPECT_TRUE(tetrahedra.end() != std::find(tetrahedra.begin(),
                                             tetrahedra.end(),
-                                            VolumeElement(v3, v4, v0, v2)));
+                                            VolumeElement(3, 4, 0, 2)));
   EXPECT_TRUE(tetrahedra.end() != std::find(tetrahedra.begin(),
                                             tetrahedra.end(),
-                                            VolumeElement(v4, v1, v0, v2)));
+                                            VolumeElement(4, 1, 0, 2)));
 }
 
 }  // namespace

--- a/geometry/proximity/test/obb_test.cc
+++ b/geometry/proximity/test/obb_test.cc
@@ -670,8 +670,8 @@ GTEST_TEST(ObbMakerTest, TestVolumeMesh) {
   // Use a very coarse mesh.
   const VolumeMesh<double> volume_mesh = MakeEllipsoidVolumeMesh<double>(
       Ellipsoid(1., 2., 3.), 6, TessellationStrategy::kSingleInteriorVertex);
-  std::set<VolumeVertexIndex> test_vertices;
-  for (VolumeVertexIndex i(0); i < volume_mesh.num_vertices(); ++i) {
+  std::set<int> test_vertices;
+  for (int i = 0; i < volume_mesh.num_vertices(); ++i) {
     test_vertices.insert(i);
   }
   Obb obb = ObbMaker(volume_mesh, test_vertices).Compute();

--- a/geometry/proximity/test/volume_mesh_test.cc
+++ b/geometry/proximity/test/volume_mesh_test.cc
@@ -72,8 +72,7 @@ std::unique_ptr<VolumeMesh<T>> TestVolumeMesh(
   EXPECT_EQ(2, volume_mesh_W->num_elements());
   EXPECT_EQ(5, volume_mesh_W->num_vertices());
   for (int v = 0; v < 5; ++v)
-    EXPECT_EQ(X_WM * vertex_data[v],
-              volume_mesh_W->vertex(VolumeVertexIndex(v)));
+    EXPECT_EQ(X_WM * vertex_data[v], volume_mesh_W->vertex(v));
   for (int e = 0; e < 2; ++e)
     for (int v = 0; v < 4; ++v)
       EXPECT_EQ(element_data[e][v],
@@ -452,12 +451,11 @@ class ScalarMixingTest : public ::testing::Test {
     // only set the derivatives for vertex 3. That means, operations on
     // test 0 *must* have derivatives, but tet 1 may not have them.
     std::vector<Vector3<AutoDiffXd>> vertices;
-    vertices.emplace_back(mesh_d_->vertex(VolumeVertexIndex(0)));
-    vertices.emplace_back(mesh_d_->vertex(VolumeVertexIndex(1)));
-    vertices.emplace_back(mesh_d_->vertex(VolumeVertexIndex(2)));
-    vertices.emplace_back(math::InitializeAutoDiff(
-        mesh_d_->vertex(VolumeVertexIndex(3))));
-    vertices.emplace_back(mesh_d_->vertex(VolumeVertexIndex(4)));
+    vertices.emplace_back(mesh_d_->vertex(0));
+    vertices.emplace_back(mesh_d_->vertex(1));
+    vertices.emplace_back(mesh_d_->vertex(2));
+    vertices.emplace_back(math::InitializeAutoDiff(mesh_d_->vertex(3)));
+    vertices.emplace_back(mesh_d_->vertex(4));
     std::vector<VolumeElement> elements(mesh_d_->tetrahedra());
 
     mesh_ad_ = std::make_unique<VolumeMesh<AutoDiffXd>>(std::move(elements),
@@ -474,7 +472,7 @@ class ScalarMixingTest : public ::testing::Test {
 TEST_F(ScalarMixingTest, CalcBarycentric) {
   constexpr double kEps = std::numeric_limits<double>::epsilon();
   Vector3<double> p_WQ_d = Vector3<double>::Zero();
-  for (VolumeVertexIndex v(0); v < 4; ++v) {
+  for (int v = 0; v < 4; ++v) {
     p_WQ_d += mesh_d_->vertex(v);
   }
   p_WQ_d /= 4;

--- a/geometry/proximity/test/volume_to_surface_mesh_test.cc
+++ b/geometry/proximity/test/volume_to_surface_mesh_test.cc
@@ -72,33 +72,23 @@ GTEST_TEST(VolumeToSurfaceMeshTest, IdentifyBoundaryFaces) {
   // ordering of the vertices within each triangle are exactly as expected.
   // Changes to the ordering in the code that otherwise defines the same set
   // of triangles would fail.
-  const std::vector<std::array<VolumeVertexIndex, 3>> expect_faces{
-      {VolumeVertexIndex(1), VolumeVertexIndex(3), VolumeVertexIndex(0)},
-      {VolumeVertexIndex(4), VolumeVertexIndex(1), VolumeVertexIndex(0)},
-      {VolumeVertexIndex(3), VolumeVertexIndex(2), VolumeVertexIndex(0)},
-      {VolumeVertexIndex(2), VolumeVertexIndex(4), VolumeVertexIndex(0)},
-      {VolumeVertexIndex(1), VolumeVertexIndex(2), VolumeVertexIndex(3)},
-      {VolumeVertexIndex(2), VolumeVertexIndex(1), VolumeVertexIndex(4)}};
+  const std::vector<std::array<int, 3>> expect_faces{
+      {1, 3, 0}, {4, 1, 0}, {3, 2, 0}, {2, 4, 0}, {1, 2, 3}, {2, 1, 4}};
   EXPECT_EQ(expect_faces, boundary_faces);
 }
 
 GTEST_TEST(VolumeToSurfaceMeshTest, CollectUniqueVertices) {
-  const std::vector<std::array<VolumeVertexIndex, 3>> faces{
-      {VolumeVertexIndex(1), VolumeVertexIndex(2), VolumeVertexIndex(3)},
-      {VolumeVertexIndex(2), VolumeVertexIndex(3), VolumeVertexIndex(4)}};
+  const std::vector<std::array<int, 3>> faces{{1, 2, 3}, {2, 3, 4}};
 
-  const std::vector<VolumeVertexIndex> unique_vertices =
-      CollectUniqueVertices(faces);
+  const std::vector<int> unique_vertices = CollectUniqueVertices(faces);
 
   // We copy the result into a `set` so that the test is independent of the
   // ordering of vertices in `unique_vertices`.
-  const std::set<VolumeVertexIndex> vertex_set(unique_vertices.begin(),
-                                               unique_vertices.end());
+  const std::set<int> vertex_set(unique_vertices.begin(),
+                                 unique_vertices.end());
   // Check that there are no repeated vertices in `unique_vertices`.
   EXPECT_EQ(vertex_set.size(), unique_vertices.size());
-  const std::set<VolumeVertexIndex> expect_vertex_set{
-      VolumeVertexIndex(1), VolumeVertexIndex(2), VolumeVertexIndex(3),
-      VolumeVertexIndex(4)};
+  const std::set<int> expect_vertex_set{1, 2, 3, 4};
   EXPECT_EQ(expect_vertex_set, vertex_set);
 }
 

--- a/geometry/proximity/volume_mesh.h
+++ b/geometry/proximity/volume_mesh.h
@@ -17,14 +17,9 @@
 
 namespace drake {
 namespace geometry {
-
-/**
- Index used to identify a vertex in a volume mesh.
- */
-using VolumeVertexIndex = TypeSafeIndex<class VolumeVertexTag>;
-
-template <typename T>
-using VolumeVertex = Vector3<T>;
+/** Index used to identify a vertex in a volume mesh. Use `int` instead; this
+ will disappear imminently. */
+using VolumeVertexIndex = int;
 
 /**
  Index for identifying a tetrahedral element in a volume mesh.
@@ -49,33 +44,32 @@ class VolumeElement {
    @param v1 Index of the second vertex in VolumeMesh.
    @param v2 Index of the third vertex in VolumeMesh.
    @param v3 Index of the last vertex in VolumeMesh.
+   @pre All indices are non-negative.
    */
-  VolumeElement(VolumeVertexIndex v0, VolumeVertexIndex v1,
-                VolumeVertexIndex v2, VolumeVertexIndex v3)
-      : vertex_({v0, v1, v2, v3}) {}
+  VolumeElement(int v0, int v1, int v2, int v3) : vertex_({v0, v1, v2, v3}) {
+    DRAKE_DEMAND(v0 >= 0 && v1 >= 0 && v2 >= 0 && v3 >= 0);
+  }
 
   /** Constructs VolumeElement.
    @param v  Array of four integer indices of the vertices of the element in
              VolumeMesh.
+   @pre All indices are non-negative.
    */
   explicit VolumeElement(const int v[4])
-      : vertex_({VolumeVertexIndex(v[0]), VolumeVertexIndex(v[1]),
-                 VolumeVertexIndex(v[2]), VolumeVertexIndex(v[3])}) {}
+      : VolumeElement(v[0], v[1], v[2], v[3]) {}
 
   /** Returns the vertex index in VolumeMesh of the i-th vertex of this
    element.
    @param i  The local index of the vertex in this element.
    @pre 0 <= i < 4
    */
-  VolumeVertexIndex vertex(int i) const {
-    return vertex_.at(i);
-  }
+  int vertex(int i) const { return vertex_.at(i); }
 
-  /** Checks to see whether the given VolumeElement use the same four
-   VolumeVertexIndex's in the same order. We check for equality to the last
-   bit consistently with VolumeMesh::Equal(). Two permutations of
-   the four vertex indices of a tetrahedron are considered different
-   tetrahedra even though they span the same space.
+  /** Checks to see whether the given VolumeElement use the same four indices in
+   the same order. We check for equality to the last bit consistently with
+   VolumeMesh::Equal(). Two permutations of the four vertex indices of a
+   tetrahedron are considered different tetrahedra even though they span the
+   same space.
    */
   bool Equal(const VolumeElement& e) const {
     return this->vertex_ == e.vertex_;
@@ -83,7 +77,7 @@ class VolumeElement {
 
  private:
   // The vertices of this element.
-  std::array<VolumeVertexIndex, 4> vertex_;
+  std::array<int, 4> vertex_;
 };
 
 inline bool operator==(const VolumeElement& e1, const VolumeElement& e2) {
@@ -131,7 +125,7 @@ class VolumeMesh {
 
   /** Index for identifying a vertex.
    */
-  using VertexIndex = VolumeVertexIndex;
+  using VertexIndex = int;
 
   /** Index for identifying a tetrahedral element.
    */
@@ -180,7 +174,7 @@ class VolumeMesh {
    @param v  The index of the vertex.
    @pre v ∈ {0, 1, 2,...,num_vertices()-1}.
    */
-  const Vector3<T>& vertex(VertexIndex v) const {
+  const Vector3<T>& vertex(int v) const {
     DRAKE_DEMAND(0 <= v && v < num_vertices());
     return vertices_[v];
   }
@@ -291,9 +285,8 @@ class VolumeMesh {
       if (!this->element(i).Equal(mesh.element(i))) return false;
     }
     // Check vertices.
-    for (VolumeVertexIndex i(0); i < this->num_vertices(); ++i) {
-      if ((this->vertex(i) - mesh.vertex(i)).norm() >
-          vertex_tolerance) {
+    for (int i = 0; i < this->num_vertices(); ++i) {
+      if ((this->vertex(i) - mesh.vertex(i)).norm() > vertex_tolerance) {
         return false;
       }
     }

--- a/geometry/proximity/volume_to_surface_mesh.cc
+++ b/geometry/proximity/volume_to_surface_mesh.cc
@@ -16,7 +16,7 @@ namespace internal {
 
 using geometry::internal::SortedTriplet;
 
-std::vector<std::array<VolumeVertexIndex, 3>> IdentifyBoundaryFaces(
+std::vector<std::array<int, 3>> IdentifyBoundaryFaces(
     const std::vector<VolumeElement>& tetrahedra) {
   // We want to identify a triangle ABC from all six permutations of A,B,C
   // (i.e., ABC, ACB, BAC, BCA, CAB, CBA), so we use SortedTriplet(A,B,C)
@@ -39,19 +39,15 @@ std::vector<std::array<VolumeVertexIndex, 3>> IdentifyBoundaryFaces(
   // The canonical order of the entries in the map is also useful in
   // debugging. However, `map` is slower, and we may change to
   // `unordered_map` later if `map` is too slow.
-  std::map<SortedTriplet<VolumeVertexIndex>, std::array<VolumeVertexIndex, 3>>
-      face_map;
+  std::map<SortedTriplet<int>, std::array<int, 3>> face_map;
 
-  auto insert_or_erase = [&face_map](VolumeVertexIndex v0,
-                                     VolumeVertexIndex v1,
-                                     VolumeVertexIndex v2) {
-    SortedTriplet<VolumeVertexIndex> sorted(v0, v1, v2);
+  auto insert_or_erase = [&face_map](int v0, int v1, int v2) {
+    SortedTriplet<int> sorted(v0, v1, v2);
     auto find = face_map.find(sorted);
     if (find != face_map.end()) {
       face_map.erase(find);
     } else {
-      face_map.emplace(sorted,
-                       std::array<VolumeVertexIndex, 3>{v0, v1, v2});
+      face_map.emplace(sorted, std::array<int, 3>{v0, v1, v2});
     }
   };
 
@@ -94,7 +90,7 @@ std::vector<std::array<VolumeVertexIndex, 3>> IdentifyBoundaryFaces(
     }
   }
 
-  std::vector<std::array<VolumeVertexIndex, 3>> boundary;
+  std::vector<std::array<int, 3>> boundary;
   boundary.reserve(face_map.size());
   for (const auto& pair : face_map) {
     boundary.emplace_back(pair.second);
@@ -103,37 +99,40 @@ std::vector<std::array<VolumeVertexIndex, 3>> IdentifyBoundaryFaces(
   return boundary;
 }
 
-std::vector<VolumeVertexIndex> CollectUniqueVertices(
-    const std::vector<std::array<VolumeVertexIndex, 3>>& faces) {
+std::vector<int> CollectUniqueVertices(
+    const std::vector<std::array<int, 3>>& faces) {
   // We use `set` instead of `unordered_set` so that we get the same
   // result on different computers, operating systems, or compilers. It will
   // help with repeatability between different users on different platforms.
   // The canonical order of the vertices is also useful in debugging.
   // However, `set` is slower, and we may change to `unordered_set` later if
   // `set` is too slow.
-  std::set<VolumeVertexIndex> vertex_set;
+  std::set<int> vertex_set;
   for (const auto& face : faces) {
     for (const auto& vertex : face) {
       vertex_set.insert(vertex);
     }
   }
-  return std::vector<VolumeVertexIndex>(vertex_set.begin(), vertex_set.end());
+  return std::vector<int>(vertex_set.begin(), vertex_set.end());
 }
 
 }  // namespace internal
 
 template <class T>
 SurfaceMesh<T> ConvertVolumeToSurfaceMesh(const VolumeMesh<T>& volume) {
-  const std::vector<std::array<VolumeVertexIndex, 3>> boundary_faces =
+  const std::vector<std::array<int, 3>> boundary_faces =
       internal::IdentifyBoundaryFaces(volume.tetrahedra());
 
-  const std::vector<VolumeVertexIndex> boundary_vertices =
+  const std::vector<int> boundary_vertices =
       internal::CollectUniqueVertices(boundary_faces);
 
   std::vector<Vector3<T>> surface_vertices;
   surface_vertices.reserve(boundary_vertices.size());
-  std::unordered_map<VolumeVertexIndex, int> volume_to_surface;
-  for (int i(0); i < static_cast<int>(boundary_vertices.size()); ++i) {
+
+  // Map from an index into the volume mesh's vertices to the resulting
+  // surface mesh's vertices.
+  std::unordered_map<int, int> volume_to_surface;
+  for (int i = 0; i < static_cast<int>(boundary_vertices.size()); ++i) {
     surface_vertices.emplace_back(volume.vertex(boundary_vertices[i]));
     volume_to_surface.emplace(boundary_vertices[i], i);
   }

--- a/geometry/proximity/volume_to_surface_mesh.h
+++ b/geometry/proximity/volume_to_surface_mesh.h
@@ -22,7 +22,7 @@ namespace internal {
           duplicate vertices.
        2. Any given face is shared by one or two tetrahedra only.
  */
-std::vector<std::array<VolumeVertexIndex, 3>> IdentifyBoundaryFaces(
+std::vector<std::array<int, 3>> IdentifyBoundaryFaces(
     const std::vector<VolumeElement>& tetrahedra);
 
 /*
@@ -32,8 +32,8 @@ std::vector<std::array<VolumeVertexIndex, 3>> IdentifyBoundaryFaces(
  @param[in] faces
  @return    vertices used by the faces.
  */
-std::vector<VolumeVertexIndex> CollectUniqueVertices(
-    const std::vector<std::array<VolumeVertexIndex, 3>>& faces);
+std::vector<int> CollectUniqueVertices(
+    const std::vector<std::array<int, 3>>& faces);
 
 }  // namespace internal
 

--- a/multibody/fixed_fem/dev/deformable_contact.cc
+++ b/multibody/fixed_fem/dev/deformable_contact.cc
@@ -16,7 +16,6 @@ using geometry::SurfaceFaceIndex;
 using geometry::SurfaceMesh;
 using geometry::VolumeElementIndex;
 using geometry::VolumeMesh;
-using geometry::VolumeVertexIndex;
 using geometry::internal::Aabb;
 using geometry::internal::Bvh;
 using geometry::internal::BvttCallbackResult;
@@ -409,7 +408,7 @@ class Intersector {
     // Get the positions, in Frame D, of the four vertices of the tet.
     Vector3<T> p_DVs[4];
     for (int i = 0; i < 4; ++i) {
-      const VolumeVertexIndex v = tet_mesh_D.element(tet_index).vertex(i);
+      const int v = tet_mesh_D.element(tet_index).vertex(i);
       p_DVs[i] = tet_mesh_D.vertex(v);
     }
 

--- a/multibody/fixed_fem/dev/elasticity_model.h
+++ b/multibody/fixed_fem/dev/elasticity_model.h
@@ -138,13 +138,12 @@ class ElasticityModel : public FemModel<Element> {
     constexpr int kNumNodes = Element::Traits::kNumNodes;
     DRAKE_THROW_UNLESS(kNumNodes == 4);
 
-    using geometry::VolumeVertexIndex;
     /* Record the reference positions of the input mesh. */
     const int num_new_vertices = mesh.num_vertices();
     reference_positions_.conservativeResize(reference_positions_.size() +
                                             kDim * num_new_vertices);
     const NodeIndex node_index_offset = NodeIndex(this->num_nodes());
-    for (VolumeVertexIndex i(0); i < num_new_vertices; ++i) {
+    for (int i = 0; i < num_new_vertices; ++i) {
       reference_positions_.template segment<kDim>(
           kDim * (i + node_index_offset)) = mesh.vertex(i);
     }

--- a/multibody/fixed_fem/dev/mesh_utilities.cc
+++ b/multibody/fixed_fem/dev/mesh_utilities.cc
@@ -19,7 +19,6 @@ using geometry::internal::IdentifyBoundaryFaces;
 using geometry::VolumeElement;
 using geometry::VolumeMesh;
 using geometry::VolumeMeshFieldLinear;
-using geometry::VolumeVertexIndex;
 
 namespace {
 
@@ -28,7 +27,7 @@ namespace {
  */
 bool IsBoundaryTetrahedron(
     const VolumeElement& tetrahedron,
-    const std::unordered_set<VolumeVertexIndex>& boundary_vertex_set) {
+    const std::unordered_set<int>& boundary_vertex_set) {
   for (int j = 0; j < 4; ++j) {
     if (boundary_vertex_set.count(tetrahedron.vertex(j)) == 0) {
       // The trahedron has a non-boundary vertex.
@@ -51,10 +50,10 @@ void StarRefineTetrahedron(int e, std::vector<VolumeElement>* elements,
   DRAKE_DEMAND(e < num_elements_before);
 
   VolumeElement& tetrahedron = (*elements)[e];
-  VolumeVertexIndex v0 = tetrahedron.vertex(0);
-  VolumeVertexIndex v1 = tetrahedron.vertex(1);
-  VolumeVertexIndex v2 = tetrahedron.vertex(2);
-  VolumeVertexIndex v3 = tetrahedron.vertex(3);
+  int v0 = tetrahedron.vertex(0);
+  int v1 = tetrahedron.vertex(1);
+  int v2 = tetrahedron.vertex(2);
+  int v3 = tetrahedron.vertex(3);
 
   const int num_vertices_before = vertices->size();
   DRAKE_DEMAND(v0 < num_vertices_before);
@@ -66,7 +65,7 @@ void StarRefineTetrahedron(int e, std::vector<VolumeElement>* elements,
       ((*vertices)[v0] + (*vertices)[v1] + (*vertices)[v2] + (*vertices)[v3]) /
       4.};
   vertices->push_back(std::move(star));
-  VolumeVertexIndex star_vertex(num_vertices_before);
+  int star_vertex(num_vertices_before);
 
   //
   // You can use this picture to verify the connectivity with your
@@ -96,9 +95,9 @@ VolumeMesh<T> StarRefineBoundaryTetrahedra(
   std::vector<Vector3<T>> out_vertices(in.vertices());
   std::vector<VolumeElement> out_elements(in.tetrahedra());
 
-  const std::vector<VolumeVertexIndex> boundary_vertices =
+  const std::vector<int> boundary_vertices =
       CollectUniqueVertices(IdentifyBoundaryFaces(out_elements));
-  const std::unordered_set<VolumeVertexIndex> boundary_vertex_set(
+  const std::unordered_set<int> boundary_vertex_set(
       boundary_vertices.begin(), boundary_vertices.end());
 
   const int num_input_tetrahedra = in.num_elements();
@@ -145,14 +144,13 @@ std::vector<VolumeElement> GenerateDiamondCubicElements(
             /
            /
          +I                                                        */
-        VolumeVertexIndex v[8];
+        int v[8];
         int s = 0;
         for (int l = 0; l < 2; ++l) {
           for (int m = 0; m < 2; ++m) {
             for (int n = 0; n < 2; ++n) {
-              v[s++] =
-                  VolumeVertexIndex(geometry::internal::CalcSequentialIndex(
-                      i + l, j + m, k + n, num_vertices));
+              v[s++] = geometry::internal::CalcSequentialIndex(
+                  i + l, j + m, k + n, num_vertices);
             }
           }
         }

--- a/multibody/fixed_fem/dev/test/deformable_model_test.cc
+++ b/multibody/fixed_fem/dev/test/deformable_model_test.cc
@@ -130,9 +130,8 @@ TEST_F(DeformableModelTest, VertexPositionsOutputPort) {
   EXPECT_EQ(vertex_positions.size(), 3 * kNumVertices);
   const auto& expected_mesh = MakeBoxTetMesh();
   for (int i = 0; i < kNumVertices; ++i) {
-    EXPECT_TRUE(CompareMatrices(
-        expected_mesh.vertex(geometry::VolumeVertexIndex(i)),
-        vertex_positions.segment<3>(3 * i)));
+    EXPECT_TRUE(CompareMatrices(expected_mesh.vertex(i),
+                                vertex_positions.segment<3>(3 * i)));
   }
 }
 }  // namespace

--- a/multibody/fixed_fem/dev/test/deformable_rigid_manager_test.cc
+++ b/multibody/fixed_fem/dev/test/deformable_rigid_manager_test.cc
@@ -290,8 +290,7 @@ TEST_F(DeformableRigidManagerTest, UpdateDeformableVertexPositions) {
   EXPECT_EQ(current_positions.size(), 1);
   EXPECT_EQ(current_positions[0].size(),
             deformed_meshes[0].mesh().num_vertices() * 3);
-  for (geometry::VolumeVertexIndex i(0);
-       i < deformed_meshes[0].mesh().num_vertices(); ++i) {
+  for (int i = 0; i < deformed_meshes[0].mesh().num_vertices(); ++i) {
     const Vector3<double> p_WV = current_positions[0].segment<3>(3 * i);
     EXPECT_TRUE(
         CompareMatrices(p_WV, deformed_meshes[0].mesh().vertex(i)));

--- a/multibody/fixed_fem/dev/test/mesh_utilities_test.cc
+++ b/multibody/fixed_fem/dev/test/mesh_utilities_test.cc
@@ -19,7 +19,6 @@ using geometry::Box;
 using geometry::VolumeElement;
 using geometry::VolumeMesh;
 using geometry::VolumeMeshFieldLinear;
-using geometry::VolumeVertexIndex;
 using geometry::internal::ComputeEulerCharacteristic;
 using math::RigidTransform;
 using std::abs;
@@ -41,8 +40,8 @@ bool VerifyDiamondCubicBoxMesh(const VolumeMesh<double>& mesh, const Box& box,
   // A. The mesh is conforming.
   // A1. The mesh has unique vertices.
   const int num_vertices = mesh.num_vertices();
-  for (VolumeVertexIndex i(0); i < num_vertices; ++i) {
-    for (VolumeVertexIndex j(i + 1); j < num_vertices; ++j) {
+  for (int i = 0; i < num_vertices; ++i) {
+    for (int j = i + 1; j < num_vertices; ++j) {
       const bool vertex_is_unique = mesh.vertex(i) != mesh.vertex(j);
       EXPECT_TRUE(vertex_is_unique) << "The mesh has duplicated vertices.";
       if (!vertex_is_unique) {
@@ -88,7 +87,7 @@ bool VerifyDiamondCubicBoxMesh(const VolumeMesh<double>& mesh, const Box& box,
   // TODO(xuchenhan-tri): The epsilon here should be tuned to the condition
   // number of the rigid transform.
   const double epsilon = 1e-14;
-  for (VolumeVertexIndex i(0); i < num_vertices; ++i) {
+  for (int i = 0; i < num_vertices; ++i) {
     const bool vertex_is_inside_or_on_boundary =
         ((X_WB.inverse() * mesh.vertex(i)).array().abs() <=
          (1 + epsilon) * half_size.array())
@@ -159,7 +158,7 @@ GTEST_TEST(MeshUtilitiesTest, SignedDistanceField) {
   const VolumeMesh<double>& mesh = box_geometry.mesh();
   const VolumeMeshFieldLinear<double, double>& mesh_field =
       box_geometry.signed_distance();
-  for (VolumeVertexIndex i(0); i < mesh.num_vertices(); ++i) {
+  for (int i = 0; i < mesh.num_vertices(); ++i) {
     const double signed_distance = mesh_field.EvaluateAtVertex(i);
     const Vector3d& r_WV = mesh.vertex(i);
     // clang-format off
@@ -177,9 +176,8 @@ GTEST_TEST(MeshUtilitiesTest, SignedDistanceField) {
 GTEST_TEST(MeshUtilitiesTest, StarRefineBoundaryTetrahedra) {
   // Refine one tetrahedron into four tetrahedra.
   {
-    using VIx = VolumeVertexIndex;
     const VolumeMesh<double> one_element_mesh(
-        std::vector<VolumeElement>{{VIx(0), VIx(1), VIx(2), VIx(3)}},
+        std::vector<VolumeElement>{{0, 1, 2, 3}},
         std::vector<Vector3d>{Vector3d::Zero(), Vector3d::UnitX(),
                               Vector3d::UnitY(), Vector3d::UnitZ()});
     ASSERT_EQ(one_element_mesh.num_elements(), 1);


### PR DESCRIPTION
There are four index types associated with the two mesh types. This removes the second of the four indices.

In this case "removal" means:
  1. Removing all usages of `VolumeVertexIndex` in Drake C++ code.
  2. Removing the python bindings.
  3. Keep the type, but change it to be an alias to an int. This will allow us to defer updating Anzu until *all* index types have been removed. At that point, we'll remove the int aliases and update Anzu.
     - `TypeSafeIndex` allows for index vs unsigned int comparisons. This alias will break this functionality. Where necessary, those signed- unsigned comparisons are also updated.

re: release notes. This is part of hydroelastic, so only the PR number should be referenced, no details.

Relates #15796.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15913)
<!-- Reviewable:end -->
