### PR TITLE
py deprecation: Add example for deprecating kwarg for C++ binding

### DIFF
--- a/bindings/pydrake/common/test/deprecation_example/cc_module_py.cc
+++ b/bindings/pydrake/common/test/deprecation_example/cc_module_py.cc
@@ -89,6 +89,25 @@ PYBIND11_MODULE(cc_module, m) {
         py::arg("x"), cls_doc.overload.doc_deprecated);
 #pragma GCC diagnostic pop
 
+    // Example: A C++ function with an argument name that has been renamed.
+    // In C++, we simply change the function signature name with no ill effect
+    // on the public API. However, in Python, the argument name is part of the
+    // function signature, so we should deprecate the old spelling.
+    // - Bind the *undeprecated* spelling *first*. This way, a user calling this
+    // function without specifying the argument name will not come across the
+    // deprecation.
+    cls.def("FunctionWithArgumentName", &Class::FunctionWithArgumentName,
+        py::arg("new_name"), cls_doc.FunctionWithArgumentName.doc);
+    // - Now bind the deprecated spelling.
+    constexpr char doc_FunctionWithArgumentName_deprecated[] =
+        "FunctionWithArgumentName(old_name) is deprecated, and will be "
+        "removed on or around 2038-01-18. Please use "
+        "FunctionWithArgumentName(new_name) instead.";
+    cls.def("FunctionWithArgumentName",
+        WrapDeprecated(doc_FunctionWithArgumentName_deprecated,
+            &Class::FunctionWithArgumentName),
+        py::arg("old_name"), doc_FunctionWithArgumentName_deprecated);
+
     // Example: A C++ method with multiple overloads, where we wish to
     // deprecate all of the overloads in the bindings. One option is to
     // deprecate each overload, but instead we instead deprecate all overloads

--- a/bindings/pydrake/common/test/deprecation_example/example_class.h
+++ b/bindings/pydrake/common/test/deprecation_example/example_class.h
@@ -54,6 +54,11 @@ class ExampleCppClass {
     unused(x);
   }
 
+  // This will be bound with two spellings in Python:
+  // - FunctionWithArgumentName(new_name) - not deprecated
+  // - FunctionWithArgumentName(old_name) - deprecated
+  int FunctionWithArgumentName(int new_name) { return new_name + 1; }
+
   /// Good property.
   int prop{};
 };

--- a/bindings/pydrake/common/test/deprecation_utility_test.py
+++ b/bindings/pydrake/common/test/deprecation_utility_test.py
@@ -55,3 +55,15 @@ class TestDeprecationExample(unittest.TestCase):
         with catch_drake_warnings(expected_count=1) as w:
             obj.overload(0)
             self.assertIn("Do not use overload(int)", str(w[0].message))
+
+    def test_cc_wrap_deprecated_for_old_kwarg(self):
+        obj = mut_cc.ExampleCppClass()
+
+        # Not deprecated.
+        obj.FunctionWithArgumentName(1)
+        obj.FunctionWithArgumentName(new_name=1)
+
+        with catch_drake_warnings(expected_count=1) as w:
+            obj.FunctionWithArgumentName(old_name=1)
+            self.assertIn(
+                "FunctionWithArgumentName(old_name)", str(w[0].message))


### PR DESCRIPTION
Motivated by #15911

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15923)
<!-- Reviewable:end -->
