### PR TITLE
[pydrake] Breakout scene graph geometry elements

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -122,21 +122,20 @@ drake_pybind_library(
     name = "geometry_py",
     cc_deps = [
         "//bindings/pydrake:documentation_pybind",
-        "//bindings/pydrake/common:cpp_template_pybind",
         "//bindings/pydrake/common:default_scalars_pybind",
         "//bindings/pydrake/common:deprecation_pybind",
         "//bindings/pydrake/common:type_pack",
         "//bindings/pydrake/common:type_safe_index_pybind",
         "//bindings/pydrake/common:value_pybind",
-        "//lcmtypes:viewer",
     ],
     cc_srcs = [
-        "geometry_py_all.cc",
+        "geometry_py.cc",
         "geometry_py.h",
         "geometry_py_common.cc",
         "geometry_py_hydro.cc",
         "geometry_py_optimization.cc",
         "geometry_py_render.cc",
+        "geometry_py_scene_graph.cc",
         "geometry_py_visualizers.cc",
     ],
     package_info = PACKAGE_INFO,
@@ -484,15 +483,6 @@ drake_py_unittest(
 )
 
 drake_py_unittest(
-    name = "geometry_all_test",
-    deps = [
-        ":geometry_py",
-        "//bindings/pydrake/common/test_utilities",
-        "//bindings/pydrake/systems:sensors_py",
-    ],
-)
-
-drake_py_unittest(
     name = "frame_id_test",
     deps = [
         ":geometry_py",
@@ -547,6 +537,15 @@ drake_py_unittest(
 drake_py_unittest(
     name = "geometry_render_engine_subclass_test",
     flaky = True,
+    deps = [
+        ":geometry_py",
+        "//bindings/pydrake/common/test_utilities",
+        "//bindings/pydrake/systems:sensors_py",
+    ],
+)
+
+drake_py_unittest(
+    name = "geometry_scene_graph_test",
     deps = [
         ":geometry_py",
         "//bindings/pydrake/common/test_utilities",

--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -1,0 +1,37 @@
+#include "drake/bindings/pydrake/geometry_py.h"
+
+#include "pybind11/eval.h"
+
+#include "drake/bindings/pydrake/pydrake_pybind.h"
+
+namespace drake {
+namespace pydrake {
+namespace {
+
+void def_geometry_all(py::module m) {
+  py::dict vars = m.attr("__dict__");
+  py::exec(
+      "from pydrake.geometry import *\n"
+      "from pydrake.geometry.render import *\n"
+      "from pydrake.geometry.optimization import *\n",
+      py::globals(), vars);
+}
+}  // namespace
+
+PYBIND11_MODULE(geometry, m) {
+  PYDRAKE_PREVENT_PYTHON3_MODULE_REIMPORT(m);
+  py::module::import("pydrake.math");
+
+  /* The order of execution matters -- a module may rely on the definition
+   of bindings executed prior to it. */
+  DefineGeometryCommon(m);
+  DefineGeometryHydro(m);
+  DefineGeometryRender(m.def_submodule("render"));
+  DefineGeometrySceneGraph(m);
+  DefineGeometryOptimization(m.def_submodule("optimization"));
+  DefineGeometryVisualizers(m);
+  def_geometry_all(m.def_submodule("all"));
+}
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/geometry_py.h
+++ b/bindings/pydrake/geometry_py.h
@@ -26,6 +26,10 @@ void DefineGeometryOptimization(py::module m);
  See geometry_py_render.cc. */
 void DefineGeometryRender(py::module m);
 
+/** Binds SceneGraph and its query-related classes. See
+geometry_py_scene_graph.cc. */
+void DefineGeometrySceneGraph(py::module m);
+
 /** Binds the visualizers in drake::geometry. See geometry_py_visualizers.cc. */
 void DefineGeometryVisualizers(py::module m);
 

--- a/bindings/pydrake/geometry_py_scene_graph.cc
+++ b/bindings/pydrake/geometry_py_scene_graph.cc
@@ -1,23 +1,14 @@
-#include <sstream>
+/* @file This includes the SceneGraph class and the major components of its
+ API: SceneGraphInspector and QueryObject for examining its state and performing
+ queries, and the query result types as well. They can be found in the
+ pydrake.geometry module. */
 
-#include "pybind11/eigen.h"
-#include "pybind11/eval.h"
-#include "pybind11/operators.h"
-#include "pybind11/pybind11.h"
-#include "pybind11/stl.h"
-
-#include "drake/bindings/pydrake/common/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
 #include "drake/bindings/pydrake/common/deprecation_pybind.h"
 #include "drake/bindings/pydrake/common/type_pack.h"
-#include "drake/bindings/pydrake/common/type_safe_index_pybind.h"
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
-#include "drake/bindings/pydrake/geometry_py.h"
-#include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/geometry/geometry_frame.h"
-#include "drake/geometry/proximity_properties.h"
-#include "drake/geometry/query_results/penetration_as_point_pair.h"
 #include "drake/geometry/scene_graph.h"
 
 // TODO(SeanCurtis-TRI) When pybind issue 3019 gets resolved, we won't need to
@@ -43,16 +34,8 @@ namespace drake {
 namespace pydrake {
 namespace {
 
-using Eigen::Vector3d;
-using geometry::GeometryId;
-using geometry::PerceptionProperties;
-using geometry::Shape;
-using math::RigidTransformd;
 using systems::Context;
 using systems::LeafSystem;
-using systems::sensors::ImageDepth32F;
-using systems::sensors::ImageLabel16I;
-using systems::sensors::ImageRgba8U;
 
 template <typename T>
 void DoScalarDependentDefinitions(py::module m, T) {
@@ -566,40 +549,12 @@ void DoScalarDependentDefinitions(py::module m, T) {
         .def("id_N", &Class::id_N, doc.ContactSurface.id_N.doc)
         .def("mesh_W", &Class::mesh_W, doc.ContactSurface.mesh_W.doc);
   }
-}  // NOLINT(readability/fn_size)
+}
+}  // namespace
 
-void def_geometry(py::module m) {
+void DefineGeometrySceneGraph(py::module m) {
   type_visit([m](auto dummy) { DoScalarDependentDefinitions(m, dummy); },
       NonSymbolicScalarPack{});
 }
-
-void def_geometry_all(py::module m) {
-  py::dict vars = m.attr("__dict__");
-  py::exec(
-      "from pydrake.geometry import *\n"
-      "from pydrake.geometry.render import *\n"
-      "from pydrake.geometry.optimization import *\n",
-      py::globals(), vars);
-}
-
-PYBIND11_MODULE(geometry, m) {
-  PYDRAKE_PREVENT_PYTHON3_MODULE_REIMPORT(m);
-  py::module::import("pydrake.common");
-  py::module::import("pydrake.math");
-  py::module::import("pydrake.systems.framework");
-  py::module::import("pydrake.systems.lcm");
-
-  /* The order of execution matters -- a module may rely on the definition
-   of bindings executed prior to it. */
-  DefineGeometryCommon(m);
-  DefineGeometryHydro(m);
-  def_geometry(m);
-  DefineGeometryRender(m.def_submodule("render"));
-  DefineGeometryOptimization(m.def_submodule("optimization"));
-  DefineGeometryVisualizers(m);
-  def_geometry_all(m.def_submodule("all"));
-}
-
-}  // namespace
 }  // namespace pydrake
 }  // namespace drake

--- a/bindings/pydrake/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry_py_visualizers.cc
@@ -26,6 +26,7 @@ void DoScalarDependentDefinitions(py::module m, T) {
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
   using namespace drake::geometry;
   py::module::import("pydrake.systems.framework");
+  py::module::import("pydrake.systems.lcm");
 
   // DrakeVisualizer
   {

--- a/bindings/pydrake/test/geometry_scene_graph_test.py
+++ b/bindings/pydrake/test/geometry_scene_graph_test.py
@@ -7,10 +7,7 @@ from pydrake.common.test_utilities import numpy_compare
 from pydrake.common.test_utilities.deprecation import catch_drake_warnings
 from pydrake.common.value import Value
 from pydrake.math import RigidTransform_
-from pydrake.systems.framework import (
-    InputPort_,
-    OutputPort_,
-)
+from pydrake.systems.framework import InputPort_, OutputPort_
 from pydrake.systems.sensors import (
     CameraInfo,
     ImageRgba8U,
@@ -18,14 +15,8 @@ from pydrake.systems.sensors import (
     ImageLabel16I,
 )
 
-PROPERTY_CLS_LIST = [
-    mut.ProximityProperties,
-    mut.IllustrationProperties,
-    mut.PerceptionProperties,
-]
 
-
-class TestGeometry(unittest.TestCase):
+class TestGeometrySceneGraph(unittest.TestCase):
     @numpy_compare.check_nonsymbolic_types
     def test_scene_graph_api(self, T):
         SceneGraph = mut.SceneGraph_[T]
@@ -439,4 +430,3 @@ class TestGeometry(unittest.TestCase):
     def test_value_instantiations(self, T):
         Value[mut.FramePoseVector_[T]]
         Value[mut.QueryObject_[T]]
-        Value[mut.Rgba]


### PR DESCRIPTION
Moves the *final* portion of the bindings in geometry_py_all.cc into geometry_py_scene_graph.cc. The unit tests for those bindings move into a parallel test (geometry_scene_graph_test.py). This also renames `geometry_py_all.cc` back to `geometry_py.cc`. 

This includes:
  - SceneGraph
  - SceneGraphInspector
  - QueryObject
  - Proximity query result types

Relates #15858

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15925)
<!-- Reviewable:end -->
