### PR TITLE
[pydrake] Correct geometry render bindings to correct warning

### DIFF
--- a/bindings/pydrake/geometry_py_render.cc
+++ b/bindings/pydrake/geometry_py_render.cc
@@ -32,6 +32,8 @@ using systems::sensors::ImageLabel16I;
 using systems::sensors::ImageRgba8U;
 using systems::sensors::PixelType;
 
+namespace {
+
 class PyRenderEngine : public py::wrapper<RenderEngine> {
  public:
   using Base = RenderEngine;
@@ -99,14 +101,13 @@ class PyRenderEngine : public py::wrapper<RenderEngine> {
   }
 };
 
-void DefineGeometryRender(py::module m) {
+void DoScalarIndependentDefinitions(py::module m) {
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
   using namespace drake;
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
   using namespace drake::geometry;
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
   using namespace drake::geometry::render;
-  m.doc() = "Local bindings for `drake::geometry::render`";
   constexpr auto& doc = pydrake_doc.drake.geometry.render;
 
   {
@@ -326,6 +327,12 @@ void DefineGeometryRender(py::module m) {
   }
 
   AddValueInstantiation<RenderLabel>(m);
+}
+}  // namespace
+
+void DefineGeometryRender(py::module m) {
+  m.doc() = "Local bindings for `drake::geometry::render`";
+  DoScalarIndependentDefinitions(m);
 }
 
 }  // namespace pydrake


### PR DESCRIPTION
When render elements were moved out of `geometry_py_all.cc` into `geometry_py_render.cc`, the components for the render engine were not kept in an anonymous namespace. This led to a gcc warning complaining about inconsistent visibility between a class and its components. This moves the definitions into a consistent, anonymous namespace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15927)
<!-- Reviewable:end -->
