### PR TITLE
[hydro] Remove SurfacFaceIndex type

### DIFF
--- a/bindings/pydrake/geometry_py_hydro.cc
+++ b/bindings/pydrake/geometry_py_hydro.cc
@@ -64,12 +64,6 @@ void DoScalarIndependentDefinitions(py::module m) {
   using namespace drake::geometry;
   constexpr auto& doc = pydrake_doc.drake.geometry;
 
-  // All the index types up front, so they'll be available to every other type.
-  {
-    BindTypeSafeIndex<SurfaceFaceIndex>(
-        m, "SurfaceFaceIndex", doc.SurfaceFaceIndex.doc);
-  }
-
   // SurfaceFace
   {
     using Class = SurfaceFace;

--- a/examples/scene_graph/simple_contact_surface_vis.cc
+++ b/examples/scene_graph/simple_contact_surface_vis.cc
@@ -61,7 +61,6 @@ using geometry::Role;
 using geometry::SceneGraph;
 using geometry::SourceId;
 using geometry::Sphere;
-using geometry::SurfaceFaceIndex;
 using geometry::SurfaceMesh;
 using lcm::DrakeLcm;
 using math::RigidTransformd;
@@ -273,7 +272,7 @@ class ContactResultMaker final : public LeafSystem<double> {
 
       // Loop through each contact triangle on the contact surface.
       const auto& field = surfaces[i].e_MN();
-      for (SurfaceFaceIndex j(0); j < surface_msg.num_triangles; ++j) {
+      for (int j = 0; j < surface_msg.num_triangles; ++j) {
         lcmt_hydroelastic_contact_surface_tri_for_viz& tri_msg =
             surface_msg.triangles[j];
         lcmt_hydroelastic_quadrature_per_point_data_for_viz& quad_msg =

--- a/geometry/drake_visualizer.cc
+++ b/geometry/drake_visualizer.cc
@@ -116,7 +116,7 @@ lcmt_viewer_geometry_data MakeHydroMesh(GeometryId geometry_id,
   // The index of the most recently added vertex (whose position measures are
   // written at v_index, v_index + 1, and v_index + 2 in float_data).
   int newest_vertex_index = -1;
-  for (SurfaceFaceIndex f(0); f < surface_mesh.num_faces(); ++f) {
+  for (int f = 0; f < surface_mesh.num_faces(); ++f) {
     const auto& face = surface_mesh.element(f);
     for (int fv = 0; fv < 3; ++fv) {
       const int v_i = face.vertex(fv);

--- a/geometry/profiling/contact_surface_rigid_bowl_soft_ball.cc
+++ b/geometry/profiling/contact_surface_rigid_bowl_soft_ball.cc
@@ -69,7 +69,6 @@ using geometry::SceneGraph;
 using geometry::SourceId;
 using geometry::Sphere;
 using geometry::SurfaceMesh;
-using geometry::SurfaceFaceIndex;
 using lcm::DrakeLcm;
 using math::RigidTransformd;
 using std::make_unique;
@@ -284,7 +283,7 @@ class ContactResultMaker final : public LeafSystem<double> {
 
       // Loop through each contact triangle on the contact surface.
       const auto& field = contacts[i].e_MN();
-      for (SurfaceFaceIndex j(0); j < surface_msg.num_triangles; ++j) {
+      for (int j = 0; j < surface_msg.num_triangles; ++j) {
         lcmt_hydroelastic_contact_surface_tri_for_viz& tri_msg =
             surface_msg.triangles[j];
 

--- a/geometry/proximity/contact_surface_utility.cc
+++ b/geometry/proximity/contact_surface_utility.cc
@@ -323,7 +323,7 @@ void AddPolygonToMeshDataAsOneTriangle(const std::vector<Vector3<T>>& polygon_F,
 template <typename T>
 bool IsFaceNormalInNormalDirection(const Vector3<T>& normal_F,
                                    const SurfaceMesh<T>& surface_M,
-                                   SurfaceFaceIndex tri_index,
+                                   int tri_index,
                                    const math::RotationMatrix<T>& R_FM) {
   const Vector3<T>& face_normal_F = R_FM * surface_M.face_normal(tri_index);
   // Given the rotation, we're re-normalizing the face normal to guard against

--- a/geometry/proximity/contact_surface_utility.h
+++ b/geometry/proximity/contact_surface_utility.h
@@ -195,7 +195,7 @@ enum class ContactPolygonRepresentation {
 template <typename T>
 bool IsFaceNormalInNormalDirection(const Vector3<T>& normal_F,
                                    const SurfaceMesh<T>& surface_M,
-                                   SurfaceFaceIndex tri_index,
+                                   int tri_index,
                                    const math::RotationMatrix<T>& R_FM);
 
 }  // namespace internal

--- a/geometry/proximity/mesh_half_space_intersection.cc
+++ b/geometry/proximity/mesh_half_space_intersection.cc
@@ -114,7 +114,7 @@ int GetVertexAddIfNeeded(
 
 template <typename T>
 void ConstructTriangleHalfspaceIntersectionPolygon(
-    const SurfaceMesh<double>& mesh_F, SurfaceFaceIndex tri_index,
+    const SurfaceMesh<double>& mesh_F, int tri_index,
     const PosedHalfSpace<T>& half_space_F, const math::RigidTransform<T>& X_WF,
     ContactPolygonRepresentation representation,
     std::vector<Vector3<T>>* new_vertices_W,
@@ -364,7 +364,7 @@ std::unique_ptr<SurfaceMesh<T>>
 ConstructSurfaceMeshFromMeshHalfspaceIntersection(
     const SurfaceMesh<double>& input_mesh_F,
     const PosedHalfSpace<T>& half_space_F,
-    const std::vector<SurfaceFaceIndex>& tri_indices,
+    const std::vector<int>& tri_indices,
     const math::RigidTransform<T>& X_WF,
     ContactPolygonRepresentation representation) {
   std::vector<Vector3<T>> new_vertices_W;
@@ -398,12 +398,12 @@ ComputeContactSurfaceFromSoftHalfSpaceRigidMesh(
     const Bvh<Obb, SurfaceMesh<double>>& bvh_R,
     const math::RigidTransform<T>& X_WR,
     ContactPolygonRepresentation representation) {
-  std::vector<SurfaceFaceIndex> tri_indices;
+  std::vector<int> tri_indices;
   tri_indices.reserve(mesh_R.num_elements());
   auto bvh_callback = [&tri_indices, &mesh_R,
                        R_WS = convert_to_double(X_WS).rotation(),
-                       R_WR = convert_to_double(X_WR).rotation()](
-                          SurfaceFaceIndex tri_index) {
+                       R_WR =
+                           convert_to_double(X_WR).rotation()](int tri_index) {
     // The gradient of the half space pressure field lies in the _opposite_
     // direction as its normal. Its normal is Sz. So, unit_grad_p_W = -Sz_W.
     const Eigen::Vector3d& unit_grad_p_W = -R_WS.col(2);

--- a/geometry/proximity/mesh_half_space_intersection.h
+++ b/geometry/proximity/mesh_half_space_intersection.h
@@ -83,7 +83,7 @@ namespace internal {
 */
 template <typename T>
 void ConstructTriangleHalfspaceIntersectionPolygon(
-    const SurfaceMesh<double>& mesh_F, SurfaceFaceIndex tri_index,
+    const SurfaceMesh<double>& mesh_F, int tri_index,
     const PosedHalfSpace<T>& half_space_F, const math::RigidTransform<T>& X_WF,
     ContactPolygonRepresentation representation,
     std::vector<Vector3<T>>* new_vertices_W,
@@ -124,8 +124,7 @@ template <typename T>
 std::unique_ptr<SurfaceMesh<T>>
 ConstructSurfaceMeshFromMeshHalfspaceIntersection(
     const SurfaceMesh<double>& input_mesh_F,
-    const PosedHalfSpace<T>& half_space_F,
-    const std::vector<SurfaceFaceIndex>& tri_indices,
+    const PosedHalfSpace<T>& half_space_F, const std::vector<int>& tri_indices,
     const math::RigidTransform<T>& X_WF,
     ContactPolygonRepresentation representation);
 

--- a/geometry/proximity/mesh_intersection.cc
+++ b/geometry/proximity/mesh_intersection.cc
@@ -193,9 +193,8 @@ void SurfaceVolumeIntersector<T>::RemoveDuplicateVertices(
 template <typename T>
 const std::vector<Vector3<T>>&
 SurfaceVolumeIntersector<T>::ClipTriangleByTetrahedron(
-    int element, const VolumeMesh<double>& volume_M,
-    SurfaceFaceIndex face, const SurfaceMesh<double>& surface_N,
-    const math::RigidTransform<T>& X_MN) {
+    int element, const VolumeMesh<double>& volume_M, int face,
+    const SurfaceMesh<double>& surface_N, const math::RigidTransform<T>& X_MN) {
   // Although polygon_M starts out pointing to polygon_[0] that is not an
   // invariant in this function.
   std::vector<Vector3<T>>* polygon_M = &(polygon_[0]);
@@ -283,7 +282,7 @@ bool SurfaceVolumeIntersector<T>::IsFaceNormalAlongPressureGradient(
     const VolumeMeshFieldLinear<double, double>& volume_field_M,
     const SurfaceMesh<double>& surface_N,
     const math::RigidTransform<double>& X_MN,
-    int tet_index, const SurfaceFaceIndex& tri_index) {
+    int tet_index, int tri_index) {
   const Vector3<double> grad_p_M = volume_field_M.EvaluateGradient(tet_index);
   return IsFaceNormalInNormalDirection(grad_p_M.normalized(), surface_N,
                                        tri_index, X_MN.rotation());
@@ -319,8 +318,7 @@ void SurfaceVolumeIntersector<T>::SampleVolumeFieldOnSurface(
   auto callback = [&volume_field_M, &surface_N, &surface_faces,
                    &surface_vertices_M, &surface_e, &mesh_M, &X_MN_d, &X_MN,
                    &contact_polygon, grad_eM_Ms, representation,
-                   this](int tet_index,
-                         SurfaceFaceIndex tri_index) -> BvttCallbackResult {
+                   this](int tet_index, int tri_index) -> BvttCallbackResult {
     if (!this->IsFaceNormalAlongPressureGradient(
             volume_field_M, surface_N, X_MN_d, tet_index, tri_index)) {
       return BvttCallbackResult::Continue;

--- a/geometry/proximity/mesh_intersection.h
+++ b/geometry/proximity/mesh_intersection.h
@@ -212,8 +212,8 @@ class SurfaceVolumeIntersector {
           tetrahedron (non-zero area restriction still applies).
    */
   const std::vector<Vector3<T>>& ClipTriangleByTetrahedron(
-      int element, const VolumeMesh<double>& volume_M,
-      SurfaceFaceIndex face, const SurfaceMesh<double>& surface_N,
+      int element, const VolumeMesh<double>& volume_M, int face,
+      const SurfaceMesh<double>& surface_N,
       const math::RigidTransform<T>& X_MN);
 
   /* Determines whether a triangle of a rigid surface N and a tetrahedron of a
@@ -297,8 +297,7 @@ class SurfaceVolumeIntersector {
   static bool IsFaceNormalAlongPressureGradient(
       const VolumeMeshFieldLinear<double, double>& volume_field_M,
       const SurfaceMesh<double>& surface_N,
-      const math::RigidTransform<double>& X_MN,
-      int tet_index, const SurfaceFaceIndex& tri_index);
+      const math::RigidTransform<double>& X_MN, int tet_index, int tri_index);
 
   // To avoid heap allocation by std::vector in low-level functions, we use
   // these member variables instead of local variables in the functions.

--- a/geometry/proximity/test/contact_surface_test.cc
+++ b/geometry/proximity/test/contact_surface_test.cc
@@ -128,7 +128,7 @@ ContactSurface<T> TestContactSurface() {
   EXPECT_EQ(4, contact_surface.mesh_W().num_vertices());
   // Tests evaluation of `e` on face f0 {0, 1, 2}.
   {
-    const SurfaceFaceIndex f0(0);
+    const int f0{0};
     const typename SurfaceMesh<T>::template Barycentric<double> b{0.2, 0.3,
                                                                   0.5};
     const T expect_e = b(0) * e0 + b(1) * e1 + b(2) * e2;
@@ -136,8 +136,8 @@ ContactSurface<T> TestContactSurface() {
   }
   // Tests area() of triangular faces.
   {
-    EXPECT_EQ(T(0.5), contact_surface.mesh_W().area(SurfaceFaceIndex(0)));
-    EXPECT_EQ(T(0.5), contact_surface.mesh_W().area(SurfaceFaceIndex(1)));
+    EXPECT_EQ(T(0.5), contact_surface.mesh_W().area(0));
+    EXPECT_EQ(T(0.5), contact_surface.mesh_W().area(1));
   }
 
   return contact_surface;
@@ -279,7 +279,7 @@ GTEST_TEST(ContactSurfaceTest, TestCopy) {
   EXPECT_EQ(original.mesh_W().num_faces(), copy.mesh_W().num_faces());
 
   // We check evaluation of field values only at one position.
-  const SurfaceFaceIndex f(0);
+  const int f{0};
   const typename SurfaceMesh<double>::Barycentric<double> b{0.2, 0.3, 0.5};
   EXPECT_EQ(original.e_MN().Evaluate(f, b), copy.e_MN().Evaluate(f, b));
 }
@@ -348,7 +348,7 @@ GTEST_TEST(ContactSurfaceTest, TestSwapMAndN) {
            f1.vertex(2) == f2.vertex(2);
   };
   // Face winding is changed.
-  for (SurfaceFaceIndex f(0); f < original.mesh_W().num_faces(); ++f) {
+  for (int f = 0; f < original.mesh_W().num_faces(); ++f) {
     EXPECT_FALSE(
         are_identical(dut.mesh_W().element(f), original.mesh_W().element(f)));
   }
@@ -356,7 +356,7 @@ GTEST_TEST(ContactSurfaceTest, TestSwapMAndN) {
   // Evaluate the mesh field, once per face for an arbitrary point Q on the
   // interior of the triangle. We expect e_MN function hasn't changed.
   const SurfaceMesh<double>::Barycentric<double> b_Q{0.25, 0.25, 0.5};
-  for (SurfaceFaceIndex f(0); f < original.mesh_W().num_faces(); ++f) {
+  for (int f = 0; f < original.mesh_W().num_faces(); ++f) {
     EXPECT_EQ(dut.e_MN().Evaluate(f, b_Q), original.e_MN().Evaluate(f, b_Q));
   }
 }

--- a/geometry/proximity/test/contact_surface_utility_test.cc
+++ b/geometry/proximity/test/contact_surface_utility_test.cc
@@ -467,7 +467,7 @@ TEST_F(ContactSurfaceUtilityTest, AddPolygonToMeshData) {
 //     The unit normal vector of the polygon, expressed in frame F. We assume
 //     the winding of the polygon vertices is consistent with this normal
 //     vector.
-void VerifyRepresentativeTriangle(SurfaceFaceIndex triangle_index,
+void VerifyRepresentativeTriangle(int triangle_index,
                                   const vector<SurfaceFace>& faces,
                                   const vector<Vector3d>& vertices_F,
                                   const vector<Vector3d>& polygon_F,
@@ -545,8 +545,8 @@ GTEST_TEST(ContactSurfaceUtility, AddPolygonToMeshDataAsOneTriangle) {
                                               &vertices_F);
     EXPECT_EQ(faces.size(), i + 1);
     EXPECT_EQ(vertices_F.size(), 3 * (i + 1));
-    VerifyRepresentativeTriangle(SurfaceFaceIndex(i), faces, vertices_F,
-                                 polygons_F[i], nhats_F[i]);
+    VerifyRepresentativeTriangle(i, faces, vertices_F, polygons_F[i],
+                                 nhats_F[i]);
   }
 }
 

--- a/geometry/proximity/test/hydroelastic_callback_test.cc
+++ b/geometry/proximity/test/hydroelastic_callback_test.cc
@@ -271,7 +271,6 @@ class TestScene {
 // soft mesh.
 ::testing::AssertionResult ValidateDerivatives(
     const ContactSurface<AutoDiffXd>& surface) {
-  const SurfaceFaceIndex f0(0);
   const auto& mesh_W = surface.mesh_W();
   if (mesh_W.vertex(0).x().derivatives().size() != 3) {
     return ::testing::AssertionFailure() << "Vertex 0 is missing derivatives";
@@ -283,13 +282,13 @@ class TestScene {
   }
 
   if (surface.HasGradE_M()) {
-    if (surface.EvaluateGradE_M_W(f0).x().derivatives().size() != 3) {
+    if (surface.EvaluateGradE_M_W(0).x().derivatives().size() != 3) {
       return ::testing::AssertionFailure()
              << "Face 0's grad eM is missing derivatives";
     }
   }
   if (surface.HasGradE_N()) {
-    if (surface.EvaluateGradE_N_W(f0).x().derivatives().size() != 3) {
+    if (surface.EvaluateGradE_N_W(0).x().derivatives().size() != 3) {
       return ::testing::AssertionFailure()
              << "Face 0's grad eN is missing derivatives";
     }

--- a/geometry/proximity/test/mesh_field_linear_test.cc
+++ b/geometry/proximity/test/mesh_field_linear_test.cc
@@ -135,7 +135,7 @@ GTEST_TEST(MeshFieldLinearTest, TestEvaluateGradient) {
       std::make_unique<MeshFieldLinear<double, SurfaceMesh<double>>>(
           std::move(e_values), mesh.get());
 
-  Vector3d gradient = mesh_field->EvaluateGradient(SurfaceFaceIndex(0));
+  Vector3d gradient = mesh_field->EvaluateGradient(0);
 
   Vector3d expect_gradient(1., 1., 0.);
   EXPECT_TRUE(CompareMatrices(expect_gradient, gradient, 1e-14));
@@ -151,7 +151,7 @@ GTEST_TEST(MeshFieldLinearTest, TestEvaluateGradientThrow) {
       std::make_unique<MeshFieldLinear<double, SurfaceMesh<double>>>(
           std::move(e_values), mesh.get(), calculate_gradient);
 
-  EXPECT_THROW(mesh_field->EvaluateGradient(SurfaceFaceIndex(0)),
+  EXPECT_THROW(mesh_field->EvaluateGradient(0),
                std::runtime_error);
 }
 
@@ -166,7 +166,7 @@ GTEST_TEST(MeshFieldLinearTest, TestTransformGradients) {
 
   // We will not check all gradient vectors. Instead we will use the gradient
   // vector of the first triangle as a representative.
-  Vector3d gradient_M = mesh_field->EvaluateGradient(SurfaceFaceIndex(0));
+  Vector3d gradient_M = mesh_field->EvaluateGradient(0);
 
   // Confirm the gradient vector before rigid transform.
   Vector3d expect_gradient_M(1., 1., 0.);
@@ -177,7 +177,7 @@ GTEST_TEST(MeshFieldLinearTest, TestTransformGradients) {
   mesh->TransformVertices(X_MN);
   mesh_field->TransformGradients(X_MN);
 
-  Vector3d gradient_N = mesh_field->EvaluateGradient(SurfaceFaceIndex(0));
+  Vector3d gradient_N = mesh_field->EvaluateGradient(0);
   Vector3d expect_gradient_N = X_MN.rotation() * expect_gradient_M;
 
   EXPECT_TRUE(CompareMatrices(expect_gradient_N, gradient_N, 1e-14));
@@ -357,8 +357,8 @@ class ScalarMixingTest : public ::testing::Test {
   std::unique_ptr<MeshFieldLinear<double, SurfaceMesh<double>>> field_d_;
   std::unique_ptr<MeshFieldLinear<AutoDiffXd, SurfaceMesh<double>>> field_ad_;
 
-  SurfaceFaceIndex e0_{0};
-  SurfaceFaceIndex e1_{1};
+  int e0_{0};
+  int e1_{1};
   // The centroid of triangle 0.
   Vector3<double> p_WQ_d_;
   Vector3<AutoDiffXd> p_WQ_ad_;

--- a/geometry/proximity/test/mesh_plane_intersection_test.cc
+++ b/geometry/proximity/test/mesh_plane_intersection_test.cc
@@ -1342,7 +1342,7 @@ TEST_F(ComputeContactSurfaceTest, NormalsInPlaneDirection) {
       {ContactPolygonRepresentation::kCentroidSubdivision,
        ContactPolygonRepresentation::kSingleTriangle}) {
     SCOPED_TRACE(fmt::format("representation = {}", representation));
-    for (const auto&[id_A, id_B] : ids) {
+    for (const auto& [id_A, id_B] : ids) {
       SCOPED_TRACE(fmt::format("[id_A, id_B] = [{}, {}]", id_A, id_B));
       unique_ptr<ContactSurface<double>> contact =
           ComputeContactSurface<double>(id_A, *field_F_, id_B, plane_F,
@@ -1354,8 +1354,8 @@ TEST_F(ComputeContactSurfaceTest, NormalsInPlaneDirection) {
       // will improve.
       constexpr double kEps = 64 * std::numeric_limits<double>::epsilon();
       const SurfaceMesh<double>& mesh_W = contact->mesh_W();
-      for (SurfaceFaceIndex f{0}; f < mesh_W.num_faces(); ++f) {
-        SCOPED_TRACE(fmt::format("SurfaceFaceIndex f = {}", f));
+      for (int f = 0; f < mesh_W.num_faces(); ++f) {
+        SCOPED_TRACE(fmt::format("Face index f = {}", f));
         EXPECT_TRUE(CompareMatrices(mesh_W.face_normal(f), nhat_W, kEps));
       }
     }
@@ -1403,13 +1403,13 @@ TEST_F(ComputeContactSurfaceTest, GradientConstituentPressure) {
     EXPECT_TRUE(contact_surface->HasGradE_M());
     EXPECT_FALSE(contact_surface->HasGradE_N());
     int num_triangles = contact_surface->mesh_W().num_elements();
-    for (SurfaceFaceIndex f(0); f < num_triangles / 2; ++f) {
-      SCOPED_TRACE(fmt::format("SurfaceFaceIndex f = {}", f));
+    for (int f = 0; f < num_triangles / 2; ++f) {
+      SCOPED_TRACE(fmt::format("Face index f = {}", f));
       EXPECT_TRUE(CompareMatrices(contact_surface->EvaluateGradE_M_W(f),
                                   grad_eMesh_W_expected0));
     }
-    for (SurfaceFaceIndex f(num_triangles / 2); f < num_triangles; ++f) {
-      SCOPED_TRACE(fmt::format("SurfaceFaceIndex f = {}", f));
+    for (int f = num_triangles / 2; f < num_triangles; ++f) {
+      SCOPED_TRACE(fmt::format("Face index f = {}", f));
       EXPECT_TRUE(CompareMatrices(contact_surface->EvaluateGradE_M_W(f),
                                   grad_eMesh_W_expected1));
     }
@@ -1437,13 +1437,13 @@ TEST_F(ComputeContactSurfaceTest, GradientConstituentPressure) {
     EXPECT_FALSE(contact_surface->HasGradE_M());
     EXPECT_TRUE(contact_surface->HasGradE_N());
     int num_triangles = contact_surface->mesh_W().num_elements();
-    for (SurfaceFaceIndex f(0); f < num_triangles / 2; ++f) {
-      SCOPED_TRACE(fmt::format("SurfaceFaceIndex f = {}", f));
+    for (int f = 0; f < num_triangles / 2; ++f) {
+      SCOPED_TRACE(fmt::format("Face index f = {}", f));
       EXPECT_TRUE(CompareMatrices(contact_surface->EvaluateGradE_N_W(f),
                                   grad_eMesh_W_expected0));
     }
-    for (SurfaceFaceIndex f(num_triangles / 2); f < num_triangles; ++f) {
-      SCOPED_TRACE(fmt::format("SurfaceFaceIndex f = {}", f));
+    for (int f = num_triangles / 2; f < num_triangles; ++f) {
+      SCOPED_TRACE(fmt::format("Face index f = {}", f));
       EXPECT_TRUE(CompareMatrices(contact_surface->EvaluateGradE_N_W(f),
                                   grad_eMesh_W_expected1));
     }
@@ -1507,7 +1507,7 @@ void MeshPlaneIntersectionTestSoftVolumeRigidHalfSpace(
     }
     // Sample the face normals.
     const Vector3d& norm_W =
-        contact_surface->mesh_W().face_normal(SurfaceFaceIndex{0});
+        contact_surface->mesh_W().face_normal(0);
     const Vector3d& Sx_W = X_WS.rotation().col(0);
     EXPECT_TRUE(CompareMatrices(norm_W, Sx_W, kEps));
     // Sample the vertex positions: in the S frame they should all have x = 0.5.
@@ -1546,7 +1546,7 @@ void MeshPlaneIntersectionTestSoftVolumeRigidHalfSpace(
     // The effect of reversing the labels reverses the normals, so repeat the
     // normal test, but in the opposite direction.
     const Vector3d& norm_W =
-        contact_surface->mesh_W().face_normal(SurfaceFaceIndex{0});
+        contact_surface->mesh_W().face_normal(0);
     const Vector3d& Sx_W = X_WS.rotation().col(0);
     EXPECT_TRUE(CompareMatrices(norm_W, -Sx_W, kEps));
   }
@@ -2038,7 +2038,7 @@ TEST_F(MeshPlaneDerivativesTest, FaceNormalsWrtPosition) {
     const auto& mesh_W = surface.mesh_W();
     const Vector3d plane_n_W = X_WR.rotation().col(2);
     const Matrix3<double> zeros = Matrix3<double>::Zero();
-    for (SurfaceFaceIndex f(0); f < mesh_W.num_elements(); ++f) {
+    for (int f = 0; f < mesh_W.num_elements(); ++f) {
       const Vector3<AutoDiffXd>& tri_n_W = mesh_W.face_normal(f);
       EXPECT_TRUE(
           CompareMatrices(math::ExtractValue(tri_n_W), plane_n_W, 2 * kEps));
@@ -2091,7 +2091,7 @@ TEST_F(MeshPlaneDerivativesTest, FaceNormalsWrtOrientation) {
     ASSERT_GT(mesh_W.num_elements(), 0);
 
     constexpr double kEps = std::numeric_limits<double>::epsilon();
-    for (SurfaceFaceIndex f(0); f < mesh_W.num_elements(); ++f) {
+    for (int f = 0; f < mesh_W.num_elements(); ++f) {
       const Vector3<AutoDiffXd>& tri_n_W = mesh_W.face_normal(f);
       /* Confirm the normal direction. */
       EXPECT_TRUE(

--- a/geometry/proximity/test/obj_to_surface_mesh_test.cc
+++ b/geometry/proximity/test/obj_to_surface_mesh_test.cc
@@ -142,8 +142,7 @@ GTEST_TEST(ObjToSurfaceMeshTest, ReadObjToSurfaceMesh) {
   };
 
   for (int i = 0; i < 12; ++i) {
-    EXPECT_TRUE(face_equal(SurfaceFace(expect_faces[i]),
-                           surface.element(SurfaceFaceIndex(i))));
+    EXPECT_TRUE(face_equal(SurfaceFace(expect_faces[i]), surface.element(i)));
   }
 }
 
@@ -235,8 +234,7 @@ f 1 2 3
   ASSERT_EQ(1, surface.num_faces());
   int expect_face[3] = {0, 1, 2};
   for (int v = 0; v < 3; ++v) {
-    EXPECT_EQ(expect_face[v],
-              surface.element(SurfaceFaceIndex(0)).vertex(v));
+    EXPECT_EQ(expect_face[v], surface.element(0).vertex(v));
   }
 }
 
@@ -267,8 +265,7 @@ f 4 5 6
   int expect_faces[2][3]{{0, 1, 2}, {3, 4, 5}};
   for (int f = 0; f < 2; ++f) {
     for (int v = 0; v < 3; ++v) {
-      EXPECT_EQ(expect_faces[f][v],
-                surface.element(SurfaceFaceIndex(f)).vertex(v));
+      EXPECT_EQ(expect_faces[f][v], surface.element(f).vertex(v));
     }
   }
 }

--- a/geometry/proximity/test/surface_mesh_test.cc
+++ b/geometry/proximity/test/surface_mesh_test.cc
@@ -20,7 +20,7 @@ template <typename T>
 class SurfaceMeshTester {
  public:
   explicit SurfaceMeshTester(const SurfaceMesh<T>& mesh) : mesh_(mesh) {}
-  Vector3<T> CalcGradBarycentric(SurfaceFaceIndex f, int i) const {
+  Vector3<T> CalcGradBarycentric(int f, int i) const {
     return mesh_.CalcGradBarycentric(f, i);
   }
  private:
@@ -129,8 +129,7 @@ std::unique_ptr<SurfaceMesh<T>> TestSurfaceMesh(
     EXPECT_EQ(X_WM * vertex_data_M[v], surface_mesh_W->vertex(v));
   for (int f = 0; f < 2; ++f)
     for (int v = 0; v < 3; ++v)
-      EXPECT_EQ(face_data[f][v],
-                surface_mesh_W->element(SurfaceFaceIndex(f)).vertex(v));
+      EXPECT_EQ(face_data[f][v], surface_mesh_W->element(f).vertex(v));
   return surface_mesh_W;
 }
 
@@ -158,8 +157,8 @@ GTEST_TEST(SurfaceMeshTest, GenerateTwoTriangleMeshAutoDiffXd) {
 GTEST_TEST(SurfaceMeshTest, TestArea) {
   const double tol = 10 * std::numeric_limits<double>::epsilon();
   auto surface_mesh = GenerateTwoTriangleMesh<double>();
-  EXPECT_NEAR(surface_mesh->area(SurfaceFaceIndex(0)), 0.5, tol);
-  EXPECT_NEAR(surface_mesh->area(SurfaceFaceIndex(1)), 1.0, tol);
+  EXPECT_NEAR(surface_mesh->area(0), 0.5, tol);
+  EXPECT_NEAR(surface_mesh->area(1), 1.0, tol);
   EXPECT_NEAR(surface_mesh->total_area(), 1.5, tol);
 
   // Verify that the zero area mesh gives zero area.
@@ -177,16 +176,16 @@ GTEST_TEST(SurfaceMeshTest, TestFaceNormal) {
   const auto surface_mesh = TestSurfaceMesh<double>(X_WM);
   const Vector3<double> expect_normal =
       X_WM.rotation() * Vector3<double>::UnitZ();
-  EXPECT_TRUE(CompareMatrices(
-      expect_normal, surface_mesh->face_normal(SurfaceFaceIndex(0)), tol));
-  EXPECT_TRUE(CompareMatrices(
-      expect_normal, surface_mesh->face_normal(SurfaceFaceIndex(1)), tol));
+  EXPECT_TRUE(
+      CompareMatrices(expect_normal, surface_mesh->face_normal(0), tol));
+  EXPECT_TRUE(
+      CompareMatrices(expect_normal, surface_mesh->face_normal(1), tol));
 
   // Verify that the zero-area mesh has zero-vector face normal.
   const auto zero_mesh = GenerateZeroAreaMesh();
   const Vector3<double> zero_normal = Vector3<double>::Zero();
-  EXPECT_EQ(zero_normal, zero_mesh->face_normal(SurfaceFaceIndex(0)));
-  EXPECT_EQ(zero_normal, zero_mesh->face_normal(SurfaceFaceIndex(1)));
+  EXPECT_EQ(zero_normal, zero_mesh->face_normal(0));
+  EXPECT_EQ(zero_normal, zero_mesh->face_normal(1));
 }
 
 // Checks the centroid calculations.
@@ -216,7 +215,7 @@ void TestCalcBarycentric() {
   // Empirically the std::numeric_limits<double>::epsilon() is too small to
   // account for the pose.
   const T kTolerance(1e-14);
-  const SurfaceFaceIndex f0(0);
+  const int f0 = 0;
   using Barycentric = typename SurfaceMesh<T>::template Barycentric<T>;
 
   // At v1.
@@ -308,9 +307,9 @@ void TestCalcGradBarycentric() {
                                Vector3<T>(X_WM * v2_M)});
 
   const SurfaceMeshTester<T> tester(mesh_W);
-  const auto gradb0_W = tester.CalcGradBarycentric(SurfaceFaceIndex(0), 0);
-  const auto gradb1_W = tester.CalcGradBarycentric(SurfaceFaceIndex(0), 1);
-  const auto gradb2_W = tester.CalcGradBarycentric(SurfaceFaceIndex(0), 2);
+  const auto gradb0_W = tester.CalcGradBarycentric(0, 0);
+  const auto gradb1_W = tester.CalcGradBarycentric(0, 1);
+  const auto gradb2_W = tester.CalcGradBarycentric(0, 2);
 
   // In this example, we have these equations, expressed in M's frame:
   //      b₀(x,y,z) = -x - y/2 + 1,
@@ -345,7 +344,7 @@ GTEST_TEST(SurfaceMeshTest, TestCalcGradBarycentricAutoDiffXd) {
 GTEST_TEST(SurfaceMeshTest, TestCalcGradBarycentricZeroAreaTriangle) {
   std::unique_ptr<SurfaceMesh<double>> mesh = GenerateZeroAreaMesh();
   const SurfaceMeshTester<double> tester(*mesh);
-  EXPECT_THROW(tester.CalcGradBarycentric(SurfaceFaceIndex(0), 0),
+  EXPECT_THROW(tester.CalcGradBarycentric(0, 0),
                std::runtime_error);
 }
 
@@ -382,7 +381,7 @@ void TestCalcGradientVectorOfLinearField() {
   const std::array<T, 3> f{2., 3., 4.};
 
   const Vector3<T> gradf_M =
-      mesh_M.CalcGradientVectorOfLinearField(f, SurfaceFaceIndex(0));
+      mesh_M.CalcGradientVectorOfLinearField(f, 0);
 
   // This function
   //       f(x,y,z) = -x + z + 3
@@ -424,8 +423,7 @@ GTEST_TEST(SurfaceMeshTest, ReverseFaceWinding) {
     return true;
   };
 
-  for (int value : {0, 1}) {
-    SurfaceFaceIndex i(value);
+  for (int i : {0, 1}) {
     EXPECT_TRUE(faces_match(ref_mesh->element(i), test_mesh->element(i)));
   }
 
@@ -457,13 +455,11 @@ GTEST_TEST(SurfaceMeshTest, ReverseFaceWinding) {
     return winding_is_valid;
   };
 
-  for (int value : {0, 1}) {
-    SurfaceFaceIndex i(value);
+  for (int i : {0, 1}) {
     EXPECT_TRUE(winding_reversed(ref_mesh->element(i), test_mesh->element(i)));
   }
 
-  for (int value : {0, 1}) {
-    SurfaceFaceIndex i(value);
+  for (int i : {0, 1}) {
     EXPECT_EQ(ref_mesh->face_normal(i), - test_mesh->face_normal(i));
   }
 }
@@ -485,7 +481,7 @@ GTEST_TEST(SurfaceMeshTest, TransformVertices) {
     EXPECT_TRUE(CompareMatrices(p_FV_test, p_FV_ref));
   }
 
-  for (SurfaceFaceIndex f(0); f < test_mesh->num_faces(); ++f) {
+  for (int f = 0; f < test_mesh->num_faces(); ++f) {
     const Vector3d& nhat_F_test = test_mesh->face_normal(f);
     const Vector3d& nhat_M_ref = ref_mesh->face_normal(f);
     const Vector3d nhat_F_ref = X_FM.rotation() * nhat_M_ref;
@@ -561,8 +557,8 @@ class ScalarMixingTest : public ::testing::Test {
   std::unique_ptr<SurfaceMesh<double>> mesh_d_;
   std::unique_ptr<SurfaceMesh<AutoDiffXd>> mesh_ad_;
 
-  SurfaceFaceIndex e0_{0};
-  SurfaceFaceIndex e1_{1};
+  int e0_{0};
+  int e1_{1};
   // The centroid of triangle 0.
   Vector3<double> p_WQ_d_;
   Vector3<AutoDiffXd> p_WQ_ad_;

--- a/geometry/proximity/test/volume_to_surface_mesh_test.cc
+++ b/geometry/proximity/test/volume_to_surface_mesh_test.cc
@@ -18,8 +18,7 @@ namespace {
 // Calculates unit normal vector to a triangular face of a surface mesh. The
 // direction of the vector depends on the winding of the face.
 template <typename T>
-Vector3<T> CalcFaceNormal(const SurfaceMesh<T>& surface,
-                          SurfaceFaceIndex face_index) {
+Vector3<T> CalcFaceNormal(const SurfaceMesh<T>& surface, int face_index) {
 // TODO(DamrongGuoy): Consider moving this function into SurfaceMesh by
 //  adding a member variable `normal_M_` similar to `area_`. Consequently we
 //  will update `normal_M_` when TransformVertices() and ReverseFaceWinding()
@@ -133,7 +132,7 @@ void TestVolumeToSurfaceMesh() {
   EXPECT_EQ(surface_vertex_coords.size(), surface.num_vertices());
 
   // Check that the face normal vectors are in the outward direction.
-  for (SurfaceFaceIndex f(0); f < surface.num_faces(); ++f) {
+  for (int f = 0; f < surface.num_faces(); ++f) {
     const Vector3<T> normal_M = internal::CalcFaceNormal(surface, f);
     // Position vector of the first vertex V of the face.
     const Vector3<T> r_MV =

--- a/geometry/query_results/contact_surface.h
+++ b/geometry/query_results/contact_surface.h
@@ -251,8 +251,9 @@ class ContactSurface {
   bool HasGradE_N() const { return grad_eN_W_ != nullptr; }
 
   /** Returns the value of ∇eₘ for the triangle with index `index`.
-   @throws std::exception if HasGradE_M() returns false.  */
-  const Vector3<T>& EvaluateGradE_M_W(SurfaceFaceIndex index) const {
+   @throws std::exception if HasGradE_M() returns false.
+   @pre `index ∈ [0, mesh().num_faces())`.  */
+  const Vector3<T>& EvaluateGradE_M_W(int index) const {
     if (grad_eM_W_ == nullptr) {
       throw std::runtime_error(
           "ContactSurface::EvaluateGradE_M_W() invalid; no gradient values "
@@ -263,8 +264,9 @@ class ContactSurface {
   }
 
   /** Returns the value of ∇eₙ for the triangle with index `index`.
-   @throws std::exception if HasGradE_N() returns false.  */
-  const Vector3<T>& EvaluateGradE_N_W(SurfaceFaceIndex index) const {
+   @throws std::exception if HasGradE_N() returns false.
+   @pre `index ∈ [0, mesh().num_faces())`.  */
+  const Vector3<T>& EvaluateGradE_N_W(int index) const {
     if (grad_eN_W_ == nullptr) {
       throw std::runtime_error(
           "ContactSurface::EvaluateGradE_N_W() invalid; no gradient values "

--- a/multibody/fixed_fem/dev/deformable_contact.cc
+++ b/multibody/fixed_fem/dev/deformable_contact.cc
@@ -12,7 +12,6 @@ namespace drake {
 namespace multibody {
 namespace fem {
 
-using geometry::SurfaceFaceIndex;
 using geometry::SurfaceMesh;
 using geometry::VolumeMesh;
 using geometry::internal::Aabb;
@@ -390,8 +389,8 @@ class Intersector {
           tetrahedron (non-zero area restriction still applies).
    */
   const std::vector<IntersectionVertex<T>>& ClipTriangleByTetrahedron(
-      int tet_index, const VolumeMesh<T>& tet_mesh_D,
-      SurfaceFaceIndex face, const SurfaceMesh<double>& surface_R,
+      int tet_index, const VolumeMesh<T>& tet_mesh_D, int face,
+      const SurfaceMesh<double>& surface_R,
       const math::RigidTransform<T>& X_DR) {
     // Although polygon_D starts out pointing to polygon_[0], that is not an
     // invariant in this function.

--- a/multibody/plant/contact_results_to_lcm.cc
+++ b/multibody/plant/contact_results_to_lcm.cc
@@ -243,7 +243,7 @@ void ContactResultsToLcmSystem<T>::CalcLcmContactOutput(
 
     // Loop through each contact triangle on the contact surface.
     const auto& field = contact_surface.e_MN();
-    for (geometry::SurfaceFaceIndex j(0); j < surface_msg.num_triangles; ++j) {
+    for (int j = 0; j < surface_msg.num_triangles; ++j) {
       lcmt_hydroelastic_contact_surface_tri_for_viz& tri_msg =
           surface_msg.triangles[j];
 

--- a/multibody/plant/hydroelastic_quadrature_point_data.h
+++ b/multibody/plant/hydroelastic_quadrature_point_data.h
@@ -18,7 +18,7 @@ struct HydroelasticQuadraturePointData {
   Vector3<T> p_WQ;
 
   /// The triangle on the ContactSurface that contains Q.
-  geometry::SurfaceFaceIndex face_index;
+  int face_index{};
 
   /// Denoting Point Aq as the point of Body A coincident with Q and Point Bq as
   /// the point of Body B coincident with Q, calculates vr (the velocity

--- a/multibody/plant/hydroelastic_traction_calculator.cc
+++ b/multibody/plant/hydroelastic_traction_calculator.cc
@@ -14,7 +14,6 @@ namespace drake {
 
 using geometry::ContactSurface;
 using geometry::SurfaceFace;
-using geometry::SurfaceFaceIndex;
 using geometry::SurfaceMesh;
 using geometry::SurfaceMeshFieldLinear;
 using math::RigidTransform;
@@ -52,7 +51,7 @@ void HydroelasticTractionCalculator<T>::
   traction_at_quadrature_points->reserve(data.surface.mesh_W().num_faces());
 
   // Integrate the tractions over all triangles in the contact surface.
-  for (SurfaceFaceIndex i(0); i < data.surface.mesh_W().num_faces(); ++i) {
+  for (int i = 0; i < data.surface.mesh_W().num_faces(); ++i) {
     // Construct the function to be integrated over triangle i.
     // TODO(sherm1) Pull functor creation out of the loop (not a good idea to
     //              create a new functor for every i).
@@ -130,7 +129,7 @@ SpatialForce<T> HydroelasticTractionCalculator<T>::
 template <typename T>
 HydroelasticQuadraturePointData<T>
 HydroelasticTractionCalculator<T>::CalcTractionAtPoint(
-    const Data& data, SurfaceFaceIndex face_index,
+    const Data& data, int face_index,
     // NOLINTNEXTLINE(runtime/references): "template Bar..." confuses cpplint.
     const typename SurfaceMesh<T>::template Barycentric<T>& Q_barycentric,
     double dissipation, double mu_coulomb) const {
@@ -170,9 +169,8 @@ HydroelasticTractionCalculator<T>::CalcTractionAtPoint(
 template <typename T>
 HydroelasticQuadraturePointData<T>
 HydroelasticTractionCalculator<T>::CalcTractionAtQHelper(
-    const Data& data, SurfaceFaceIndex face_index, const T& e,
-    const Vector3<T>& nhat_W, double dissipation, double mu_coulomb,
-    const Vector3<T>& p_WQ) const {
+    const Data& data, int face_index, const T& e, const Vector3<T>& nhat_W,
+    double dissipation, double mu_coulomb, const Vector3<T>& p_WQ) const {
   HydroelasticQuadraturePointData<T> traction_data;
 
   // Set entries that do not require computation first.

--- a/multibody/plant/hydroelastic_traction_calculator.h
+++ b/multibody/plant/hydroelastic_traction_calculator.h
@@ -142,15 +142,14 @@ class HydroelasticTractionCalculator {
   friend class HydroelasticReportingTests_LinearSlipVelocity_Test;
 
   HydroelasticQuadraturePointData<T> CalcTractionAtPoint(
-      const Data& data, geometry::SurfaceFaceIndex face_index,
+      const Data& data, int face_index,
       const typename geometry::SurfaceMesh<T>::template Barycentric<T>&
           Q_barycentric,
       double dissipation, double mu_coulomb) const;
 
   HydroelasticQuadraturePointData<T> CalcTractionAtQHelper(
-      const Data& data, geometry::SurfaceFaceIndex face_index, const T& e,
-      const Vector3<T>& nhat_W, double dissipation, double mu_coulomb,
-      const Vector3<T>& p_WQ) const;
+      const Data& data, int face_index, const T& e, const Vector3<T>& nhat_W,
+      double dissipation, double mu_coulomb, const Vector3<T>& p_WQ) const;
 
   multibody::SpatialForce<T> ComputeSpatialTractionAtAcFromTractionAtAq(
       const Data& data, const Vector3<T>& p_WQ,

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -2124,8 +2124,7 @@ void MultibodyPlant<T>::CalcDiscreteContactPairs(
         const T dissipation = hydroelastics_engine_.CalcCombinedDissipation(
             s.id_M(), s.id_N(), inspector);
 
-        for (geometry::SurfaceFaceIndex face(0); face < mesh_W.num_faces();
-             ++face) {
+        for (int face = 0; face < mesh_W.num_faces(); ++face) {
           const T& Ae = mesh_W.area(face);  // Face element area.
 
           // We found out that the hydroelastic query might report

--- a/multibody/plant/test/contact_results_to_lcm_test.cc
+++ b/multibody/plant/test/contact_results_to_lcm_test.cc
@@ -29,7 +29,6 @@ using geometry::PenetrationAsPointPair;
 using geometry::SceneGraph;
 using geometry::Sphere;
 using geometry::SurfaceFace;
-using geometry::SurfaceFaceIndex;
 using geometry::SurfaceMesh;
 using math::RigidTransform;
 using multibody::internal::FullBodyName;
@@ -184,14 +183,14 @@ vector<HydroelasticQuadraturePointData<T>> MakeQuadratureData(
   quadrature_point_data[0].p_WQ = Vector3<double>(1, 3, 5) + offset;
   quadrature_point_data[0].vt_BqAq_W = Vector3<double>(7, 11, 13) + offset;
   quadrature_point_data[0].traction_Aq_W = Vector3<double>(17, 19, 23) + offset;
-  quadrature_point_data[0].face_index = SurfaceFaceIndex(0);
+  quadrature_point_data[0].face_index = 0;
   for (int i = 1; i < kNumPoints; ++i) {
     quadrature_point_data[i].p_WQ = quadrature_point_data[i - 1].p_WQ + offset;
     quadrature_point_data[i].vt_BqAq_W =
         quadrature_point_data[i - 1].vt_BqAq_W + offset;
     quadrature_point_data[i].traction_Aq_W =
         quadrature_point_data[i - 1].traction_Aq_W + offset;
-    quadrature_point_data[i].face_index = SurfaceFaceIndex(i / kNumPointPerTri);
+    quadrature_point_data[i].face_index = i / kNumPointPerTri;
   }
   return quadrature_point_data;
 }
@@ -680,7 +679,7 @@ TYPED_TEST(ContactResultsToLcmTest, HydroContactOnly) {
     EXPECT_EQ(pair_message.num_triangles, mesh.num_faces());
     EXPECT_EQ(pair_message.triangles.size(), mesh.num_faces());
     const auto& field = surface.e_MN();
-    for (SurfaceFaceIndex f(0); f < mesh.num_faces(); ++f) {
+    for (int f = 0; f < mesh.num_faces(); ++f) {
       const auto& tri_message = pair_message.triangles[f];
       const auto& tri_data = mesh.element(f);
       // clang-format off

--- a/multibody/plant/test/hydroelastic_traction_test.cc
+++ b/multibody/plant/test/hydroelastic_traction_test.cc
@@ -22,7 +22,6 @@ using geometry::ContactSurface;
 using geometry::GeometryId;
 using geometry::MeshFieldLinear;
 using geometry::SceneGraph;
-using geometry::SurfaceFaceIndex;
 using geometry::SurfaceFace;
 using geometry::SurfaceMesh;
 using math::RigidTransform;
@@ -72,7 +71,7 @@ std::unique_ptr<SurfaceMesh<double>> CreateSurfaceMesh() {
   auto mesh = std::make_unique<SurfaceMesh<double>>(
       std::move(faces), std::move(vertices));
 
-  for (SurfaceFaceIndex f(0); f < mesh->num_faces(); ++f) {
+  for (int f = 0; f < mesh->num_faces(); ++f) {
     // Can't use an ASSERT_TRUE here because it interferes with the return
     // value.
     if (!CompareMatrices(mesh->face_normal(f), -Vector3<double>::UnitZ(),
@@ -170,7 +169,7 @@ public ::testing::TestWithParam<RigidTransform<double>> {
     // world frame.
     HydroelasticQuadraturePointData<double> output =
         traction_calculator().CalcTractionAtPoint(
-            calculator_data(), SurfaceFaceIndex(0),
+            calculator_data(), 0 /* tri_index */,
             SurfaceMesh<double>::Barycentric<double>(1.0, 0.0, 0.0),
             dissipation, mu_coulomb);
 
@@ -566,9 +565,8 @@ class HydroelasticTractionCalculatorTester {
   static HydroelasticQuadraturePointData<T> CalcTractionAtQHelper(
       const HydroelasticTractionCalculator<T>& calculator,
       const typename HydroelasticTractionCalculator<T>::Data& data,
-      geometry::SurfaceFaceIndex face_index, const T& e,
-      const Vector3<T>& nhat_W, double dissipation, double mu_coulomb,
-      const Vector3<T>& p_WQ) {
+      int face_index, const T& e, const Vector3<T>& nhat_W, double dissipation,
+      double mu_coulomb, const Vector3<T>& p_WQ) {
     return calculator.CalcTractionAtQHelper(data, face_index, e, nhat_W,
                                             dissipation, mu_coulomb, p_WQ);
   }
@@ -684,7 +682,7 @@ GTEST_TEST(HydroelasticTractionCalculatorTest,
                                                std::move(field));
 
   // Parameters for CalcTractionAtQHelper().
-  const geometry::SurfaceFaceIndex f0(0);
+  const int f0 = 0;
   // N.B. From documentation for CalcTractionAtQHelper(), nhat_W points from B
   // into A. Since the right-hand rule on the triangle above dictates the
   // direction of the normal to be in the +z axis, body A is situated above body
@@ -855,10 +853,10 @@ SpatialForce<double> MakeSpatialForce() {
 std::vector<HydroelasticQuadraturePointData<double>> GetQuadraturePointData() {
   HydroelasticQuadraturePointData<double> data;
   data.p_WQ = Vector3<double>(3.0, 5.0, 7.0);
-  data.face_index = SurfaceFaceIndex(1);
+  data.face_index = 1;
   data.vt_BqAq_W = Vector3<double>(11.0, 13.0, 17.0);
   data.traction_Aq_W = Vector3<double>(19.0, 23.0, 29.0);
-  return { data };
+  return {data};
 }
 
 HydroelasticContactInfo<double> CreateContactInfo(

--- a/multibody/plant/test/multibody_plant_hydroelastic_contact_results_output_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_contact_results_output_test.cc
@@ -13,7 +13,6 @@ namespace drake {
 
 using geometry::ContactSurface;
 using geometry::SurfaceFace;
-using geometry::SurfaceFaceIndex;
 using geometry::SurfaceMesh;
 
 namespace multibody {


### PR DESCRIPTION
There are four index types associated with the two mesh types. This removes the third of the four indices.

In this case "removal" means:
  1. Removing all usages of `SurfacFaceIndex` in Drake C++ code.
  2. Removing the python bindings.
  3. Keep the type, but change it to be an alias to an int. This will allow us to defer updating Anzu until *all* index types have been removed. At that point, we'll remove the int aliases and update Anzu.
     - `TypeSafeIndex` allows for index vs unsigned int comparisions. This alias will break this functionality. Where necessary, those signed-unsigned comparisons are also updated.

Note: There are three instances where the removal of the index type represents, in some sense, a loss:

  - mesh_intersection.cc, IsFaceNoramlAlongPressureGradient()
  - surface_mesh.h: SurfaceMesh::CalcGradBarycentric
  - bvh.h: BvttCallback

However, the loss is considered acceptable. In the first two cases, the API is internal or private, we can rely on developer discipline and unit tests to make sure that the internal code is using the correct interpretation of index types.

In `BvttCallback`, there would *ostensibly* be value in distinguishing the index types of the two meshes being collided. However, that distinction only exists if the mesh types themselves are different. If they are the same (e.g., for compliant-compliant contact), the types provide no distinguishing power. So, the code has to be properly tested for correct
ordering, regardless of types. So, the constraint of the typed indices provides more cost than benefit.

re: release notes. This is part of hydroelastic, so only the PR number should be referenced, no details.

Relates #15796.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15932)
<!-- Reviewable:end -->
