### PR TITLE
[hydro] Remove VolumeElementIndex type

### DIFF
--- a/bindings/pydrake/geometry_py_hydro.cc
+++ b/bindings/pydrake/geometry_py_hydro.cc
@@ -68,8 +68,6 @@ void DoScalarIndependentDefinitions(py::module m) {
   {
     BindTypeSafeIndex<SurfaceFaceIndex>(
         m, "SurfaceFaceIndex", doc.SurfaceFaceIndex.doc);
-    BindTypeSafeIndex<VolumeElementIndex>(
-        m, "VolumeElementIndex", doc.VolumeElementIndex.doc);
   }
 
   // SurfaceFace

--- a/bindings/pydrake/test/geometry_hydro_test.py
+++ b/bindings/pydrake/test/geometry_hydro_test.py
@@ -119,7 +119,7 @@ class TestGeometryHydro(unittest.TestCase):
         self.assertEqual(len(mesh.vertices()), 5)
 
         self.assertAlmostEqual(
-            mesh.CalcTetrahedronVolume(e=mut.VolumeElementIndex(1)),
+            mesh.CalcTetrahedronVolume(e=1),
             1/6.0,
             delta=1e-15)
         self.assertAlmostEqual(mesh.CalcVolume(), 1/3.0, delta=1e-15)

--- a/geometry/proximity/mesh_field_linear.h
+++ b/geometry/proximity/mesh_field_linear.h
@@ -217,8 +217,8 @@ class MeshFieldLinear {
     if (gradients_.size() == 0) {
       return Evaluate(e, this->mesh().CalcBarycentric(p_MQ, e));
     } else {
-      DRAKE_ASSERT(e < gradients_.size());
-      DRAKE_ASSERT(e < values_at_Mo_.size());
+      DRAKE_ASSERT(e < static_cast<int>(gradients_.size()));
+      DRAKE_ASSERT(e < static_cast<int>(values_at_Mo_.size()));
       return gradients_[e].dot(p_MQ) + values_at_Mo_[e];
     }
   }
@@ -321,7 +321,7 @@ class MeshFieldLinear {
   }
 
   T CalcValueAtMeshOrigin(typename MeshType::ElementIndex e) const {
-    DRAKE_DEMAND(e < gradients_.size());
+    DRAKE_DEMAND(e < static_cast<int>(gradients_.size()));
     const typename MeshType::VertexIndex v0 = this->mesh().element(e).vertex(0);
     const Vector3<T>& p_MV0 = this->mesh().vertex(v0);
     // f(V₀) = ∇fᵉ⋅p_MV₀ + fᵉ(Mo)

--- a/geometry/proximity/mesh_intersection.cc
+++ b/geometry/proximity/mesh_intersection.cc
@@ -193,7 +193,7 @@ void SurfaceVolumeIntersector<T>::RemoveDuplicateVertices(
 template <typename T>
 const std::vector<Vector3<T>>&
 SurfaceVolumeIntersector<T>::ClipTriangleByTetrahedron(
-    VolumeElementIndex element, const VolumeMesh<double>& volume_M,
+    int element, const VolumeMesh<double>& volume_M,
     SurfaceFaceIndex face, const SurfaceMesh<double>& surface_N,
     const math::RigidTransform<T>& X_MN) {
   // Although polygon_M starts out pointing to polygon_[0] that is not an
@@ -283,7 +283,7 @@ bool SurfaceVolumeIntersector<T>::IsFaceNormalAlongPressureGradient(
     const VolumeMeshFieldLinear<double, double>& volume_field_M,
     const SurfaceMesh<double>& surface_N,
     const math::RigidTransform<double>& X_MN,
-    const VolumeElementIndex& tet_index, const SurfaceFaceIndex& tri_index) {
+    int tet_index, const SurfaceFaceIndex& tri_index) {
   const Vector3<double> grad_p_M = volume_field_M.EvaluateGradient(tet_index);
   return IsFaceNormalInNormalDirection(grad_p_M.normalized(), surface_N,
                                        tri_index, X_MN.rotation());
@@ -319,7 +319,7 @@ void SurfaceVolumeIntersector<T>::SampleVolumeFieldOnSurface(
   auto callback = [&volume_field_M, &surface_N, &surface_faces,
                    &surface_vertices_M, &surface_e, &mesh_M, &X_MN_d, &X_MN,
                    &contact_polygon, grad_eM_Ms, representation,
-                   this](VolumeElementIndex tet_index,
+                   this](int tet_index,
                          SurfaceFaceIndex tri_index) -> BvttCallbackResult {
     if (!this->IsFaceNormalAlongPressureGradient(
             volume_field_M, surface_N, X_MN_d, tet_index, tri_index)) {

--- a/geometry/proximity/mesh_intersection.h
+++ b/geometry/proximity/mesh_intersection.h
@@ -212,7 +212,7 @@ class SurfaceVolumeIntersector {
           tetrahedron (non-zero area restriction still applies).
    */
   const std::vector<Vector3<T>>& ClipTriangleByTetrahedron(
-      VolumeElementIndex element, const VolumeMesh<double>& volume_M,
+      int element, const VolumeMesh<double>& volume_M,
       SurfaceFaceIndex face, const SurfaceMesh<double>& surface_N,
       const math::RigidTransform<T>& X_MN);
 
@@ -298,7 +298,7 @@ class SurfaceVolumeIntersector {
       const VolumeMeshFieldLinear<double, double>& volume_field_M,
       const SurfaceMesh<double>& surface_N,
       const math::RigidTransform<double>& X_MN,
-      const VolumeElementIndex& tet_index, const SurfaceFaceIndex& tri_index);
+      int tet_index, const SurfaceFaceIndex& tri_index);
 
   // To avoid heap allocation by std::vector in low-level functions, we use
   // these member variables instead of local variables in the functions.

--- a/geometry/proximity/mesh_plane_intersection.cc
+++ b/geometry/proximity/mesh_plane_intersection.cc
@@ -62,7 +62,7 @@ constexpr std::array<std::array<int, 4>, 16> kMarchingTetsTable = {
 }  // namespace
 
 template <typename T>
-void SliceTetWithPlane(VolumeElementIndex tet_index,
+void SliceTetWithPlane(int tet_index,
                        const VolumeMeshFieldLinear<double, double>& field_M,
                        const Plane<T>& plane_M,
                        const math::RigidTransform<T>& X_WM,
@@ -172,7 +172,7 @@ std::unique_ptr<ContactSurface<T>> ComputeContactSurface(
     GeometryId mesh_id,
     const VolumeMeshFieldLinear<double, double>& mesh_field_M,
     GeometryId plane_id, const Plane<T>& plane_M,
-    const std::vector<VolumeElementIndex>& tet_indices,
+    const std::vector<int>& tet_indices,
     const math::RigidTransform<T>& X_WM,
     ContactPolygonRepresentation representation) {
   if (tet_indices.size() == 0) return nullptr;
@@ -220,9 +220,9 @@ ComputeContactSurfaceFromSoftVolumeRigidHalfSpace(
     const math::RigidTransform<T>& X_WS, const GeometryId id_R,
     const math::RigidTransform<T>& X_WR,
     ContactPolygonRepresentation representation) {
-  std::vector<VolumeElementIndex> tet_indices;
+  std::vector<int> tet_indices;
   tet_indices.reserve(field_S.mesh().num_elements());
-  auto callback = [&tet_indices](VolumeElementIndex tet_index) {
+  auto callback = [&tet_indices](int tet_index) {
     tet_indices.push_back(tet_index);
     return BvttCallbackResult::Continue;
   };

--- a/geometry/proximity/mesh_plane_intersection.h
+++ b/geometry/proximity/mesh_plane_intersection.h
@@ -82,7 +82,7 @@ namespace internal {
  @pre `tet_index` lies in the range `[0, field_M.mesh().num_elements())`.
  */
 template <typename T>
-void SliceTetWithPlane(VolumeElementIndex tet_index,
+void SliceTetWithPlane(int tet_index,
                        const VolumeMeshFieldLinear<double, double>& field_M,
                        const Plane<T>& plane_M,
                        const math::RigidTransform<T>& X_WM,
@@ -125,7 +125,7 @@ std::unique_ptr<ContactSurface<T>> ComputeContactSurface(
     GeometryId mesh_id,
     const VolumeMeshFieldLinear<double, double>& mesh_field_M,
     GeometryId plane_id, const Plane<T>& plane_M,
-    const std::vector<VolumeElementIndex>& tet_indices,
+    const std::vector<int>& tet_indices,
     const math::RigidTransform<T>& X_WM,
     ContactPolygonRepresentation representation);
 

--- a/geometry/proximity/test/bvh_test.cc
+++ b/geometry/proximity/test/bvh_test.cc
@@ -428,7 +428,7 @@ TYPED_TEST(BvhTest, TestCollideSurfaceVolume) {
    the candidates and the total number of candidates we get. */
   bool intersecting_included = false;
   int total_count = 0;
-  auto callback = [&intersecting_included, &total_count](VolumeElementIndex v,
+  auto callback = [&intersecting_included, &total_count](int v,
                                                          SurfaceFaceIndex s) {
     ++total_count;
     if (v == 0 && s == 0) intersecting_included = true;
@@ -516,7 +516,7 @@ TYPED_TEST(BvhTest, TestComputeCentroid) {
   auto volume_mesh = MakeEllipsoidVolumeMesh<double>(
       Ellipsoid(1., 2., 3.), 6, TessellationStrategy::kSingleInteriorVertex);
   centroid = BvhTester::ComputeCentroid<BvType, VolumeMesh<double>>(
-      volume_mesh, VolumeElementIndex(0));
+      volume_mesh, 0 /* tet_index */);
   // The first face of our octahedron is a tet with vertices at 1, 2, and 3
   // along each respective axis and the origin 0, so its centroid should
   // average out to 1/4, 2/4, and 3/4.

--- a/geometry/proximity/test/make_box_field_test.cc
+++ b/geometry/proximity/test/make_box_field_test.cc
@@ -91,7 +91,7 @@ GTEST_TEST(MakeBoxFieldTest, MakeBoxPressureFieldInMeshWithMedialAxis) {
   // Check that there is no constant-pressure tetrahedron.
   const double kPressureTolerance =
       kElasticModulus * std::numeric_limits<double>::epsilon();
-  for (VolumeElementIndex e(0); e < mesh.num_elements(); ++e) {
+  for (int e = 0; e < mesh.num_elements(); ++e) {
     const double pressure_v0 =
         pressure_field.EvaluateAtVertex(mesh.element(e).vertex(0));
     bool same_pressure = true;

--- a/geometry/proximity/test/make_box_mesh_test.cc
+++ b/geometry/proximity/test/make_box_mesh_test.cc
@@ -450,7 +450,7 @@ GTEST_TEST(MakeBoxVolumeMeshTest, GenerateMesh) {
   double volume = 0.0;
   for (int e = 0; e < box_mesh.num_elements(); ++e) {
     double tetrahedron_volume =
-        box_mesh.CalcTetrahedronVolume(VolumeElementIndex(e));
+        box_mesh.CalcTetrahedronVolume(e);
     EXPECT_GT(tetrahedron_volume, 0.0);
     volume += tetrahedron_volume;
   }

--- a/geometry/proximity/test/make_sphere_mesh_test.cc
+++ b/geometry/proximity/test/make_sphere_mesh_test.cc
@@ -51,7 +51,7 @@ GTEST_TEST(MakeSphereMesh, InvariantsOfLevelZeroMesh) {
 
   // Every vertex references the center index _and_ it is the fourth vertex
   // in each tet.
-  for (VolumeElementIndex t(0); t < mesh.num_elements(); ++t) {
+  for (int t = 0; t < mesh.num_elements(); ++t) {
     const VolumeElement& tet = mesh.element(t);
     EXPECT_EQ(tet.vertex(3), center_index);
   }
@@ -62,7 +62,7 @@ GTEST_TEST(MakeSphereMesh, InvariantsOfLevelZeroMesh) {
 double CalcTetrahedronMeshVolume(const VolumeMesh<double>& mesh) {
   double volume = 0.0;
   for (int e = 0; e < mesh.num_elements(); ++e) {
-    volume += mesh.CalcTetrahedronVolume(VolumeElementIndex(e));
+    volume += mesh.CalcTetrahedronVolume(e);
   }
   return volume;
 }

--- a/geometry/proximity/test/mesh_field_linear_test.cc
+++ b/geometry/proximity/test/mesh_field_linear_test.cc
@@ -197,8 +197,8 @@ GTEST_TEST(MeshFieldLinearTest, EvaluateCartesianWithAndWithoutGradient) {
   // "positive tetrahedron" and the latter "negative tetrahedron".
   // No tetrahedron crosses the x=0 plane in frame M. Obviously we assume
   // the tetrahedra fill the volume of the box.
-  std::set<VolumeElementIndex> positive_set;  // set of positive tetrahedra.
-  for (VolumeElementIndex e(0); e < mesh_M.num_elements(); ++e) {
+  std::set<int> positive_set;  // set of positive tetrahedra.
+  for (int e = 0; e < mesh_M.num_elements(); ++e) {
     int num_positive_or_zero = 0;
     int num_negative_or_zero = 0;
     for (int i = 0; i < 4; ++i) {
@@ -251,9 +251,8 @@ GTEST_TEST(MeshFieldLinearTest, EvaluateCartesianWithAndWithoutGradient) {
   const MeshFieldLinear<double, VolumeMesh<double>> field_with_gradient(
       std::move(values), &mesh_M, true);
 
-  ASSERT_THROW(field_without_gradient.EvaluateGradient(VolumeElementIndex(0)),
-               std::runtime_error);
-  ASSERT_NO_THROW(field_with_gradient.EvaluateGradient(VolumeElementIndex(0)));
+  ASSERT_THROW(field_without_gradient.EvaluateGradient(0), std::runtime_error);
+  ASSERT_NO_THROW(field_with_gradient.EvaluateGradient(0));
 
   {
     // Evaluating the field for points within tetrahedra.  The tolerance
@@ -265,7 +264,7 @@ GTEST_TEST(MeshFieldLinearTest, EvaluateCartesianWithAndWithoutGradient) {
           Barycentric{0.49999, 0.49999, 1e-5, 1e-5} /* near edge */}) {
       // TODO(SeanCurtis-TRI): it's ridiculous that we don't have a mesh method
       //  that turns (element index, barycentric) --> cartesian.
-      for (VolumeElementIndex e(0); e < mesh_M.num_elements(); ++e) {
+      for (int e = 0; e < mesh_M.num_elements(); ++e) {
         Vector3d p_MQ{0, 0, 0};
         for (int i = 0; i < 4; ++i) {
           p_MQ += mesh_M.vertex(mesh_M.element(e).vertex(i)) * b_Q(i);
@@ -285,7 +284,7 @@ GTEST_TEST(MeshFieldLinearTest, EvaluateCartesianWithAndWithoutGradient) {
   for (const Vector3d& p_MQ :
        {Vector3d{1e-15, 1e-15, 1e-15}, Vector3d{0.1, 0.2, 0.3},
         Vector3d{-10.23, 27, 77}, Vector3d{321.3, -843.2, 202.02}}) {
-    for (VolumeElementIndex e(0); e < mesh_M.num_elements(); ++e) {
+    for (int e = 0; e < mesh_M.num_elements(); ++e) {
       if (positive_set.count(e) == 1) {
         // f⁺(x,y,z) =  3.5x - 2.7y + 0.7z + 1.23
         const double expect = f_p(p_MQ);

--- a/geometry/proximity/volume_mesh.h
+++ b/geometry/proximity/volume_mesh.h
@@ -21,10 +21,9 @@ namespace geometry {
  will disappear imminently. */
 using VolumeVertexIndex = int;
 
-/**
- Index for identifying a tetrahedral element in a volume mesh.
- */
-using VolumeElementIndex = TypeSafeIndex<class VolumeElementTag>;
+/** Index used to identify a tetrahedral element in a volume mesh. Use `int`
+ instead; this will disappear imminently. */
+using VolumeElementIndex = int;
 
 /** %VolumeElement represents a tetrahedral element in a VolumeMesh. It is a
  topological entity in the sense that it only knows the indices of its vertices
@@ -129,7 +128,7 @@ class VolumeMesh {
 
   /** Index for identifying a tetrahedral element.
    */
-  using ElementIndex = VolumeElementIndex;
+  using ElementIndex = int;
 
   // TODO(SeanCurtis-TRI) This is very dissatisfying. The alias contained in a
   //  templated class doesn't depend on the class template parameter, but
@@ -192,10 +191,11 @@ class VolumeMesh {
   int num_vertices() const { return vertices_.size(); }
 
   /** Calculates volume of a tetrahedral element.
+   @pre `f ∈ [0, num_elements())`.
    */
-  T CalcTetrahedronVolume(VolumeElementIndex e) const {
+  T CalcTetrahedronVolume(int e) const {
     // TODO(DamrongGuoy): Refactor this function out of VolumeMesh when we need
-    //  it. CalcTetrahedronVolume(VolumeElementIndex) will call
+    //  it. CalcTetrahedronVolume(index) will call
     //  CalcTetrahedronVolume(Vector3, Vector3, Vector3, Vector3).
     const Vector3<T>& a = vertices_[elements_[e].vertex(0)];
     const Vector3<T>& b = vertices_[elements_[e].vertex(1)];
@@ -217,7 +217,7 @@ class VolumeMesh {
   T CalcVolume() const {
     T volume(0.0);
     for (int e = 0; e < num_elements(); ++e) {
-      volume += CalcTetrahedronVolume(VolumeElementIndex(e));
+      volume += CalcTetrahedronVolume(e);
     }
     return volume;
   }
@@ -281,7 +281,7 @@ class VolumeMesh {
     if (this->num_vertices() != mesh.num_vertices()) return false;
 
     // Check tetrahedral elements.
-    for (VolumeElementIndex i(0); i < this->num_elements(); ++i) {
+    for (int i = 0; i < this->num_elements(); ++i) {
       if (!this->element(i).Equal(mesh.element(i))) return false;
     }
     // Check vertices.
@@ -306,8 +306,7 @@ class VolumeMesh {
    */
   template <typename FieldValue>
   Vector3<promoted_numerical_t<T, FieldValue>> CalcGradientVectorOfLinearField(
-      const std::array<FieldValue, 4>& field_value,
-      VolumeElementIndex e) const {
+      const std::array<FieldValue, 4>& field_value, int e) const {
     using ReturnType = promoted_numerical_t<T, FieldValue>;
     Vector3<ReturnType> gradu_M = field_value[0] * CalcGradBarycentric(e, 0);
     for (int i = 1; i < 4; ++i) {
@@ -324,7 +323,7 @@ class VolumeMesh {
   // function bᵢ of the i-th vertex of the tetrahedron `e`. The gradient
   // vector ∇bᵢ is expressed in the coordinates frame of this mesh M.
   // @pre  0 ≤ i < 4.
-  Vector3<T> CalcGradBarycentric(VolumeElementIndex e, int i) const;
+  Vector3<T> CalcGradBarycentric(int e, int i) const;
 
   // The tetrahedral elements that comprise the volume.
   std::vector<VolumeElement> elements_;
@@ -335,8 +334,7 @@ class VolumeMesh {
 };
 
 template <typename T>
-Vector3<T> VolumeMesh<T>::CalcGradBarycentric(VolumeElementIndex e,
-                                              int i) const {
+Vector3<T> VolumeMesh<T>::CalcGradBarycentric(int e, int i) const {
   DRAKE_DEMAND(0 <= i && i < 4);
   // Vertex V corresponds to bᵢ in the barycentric coordinate in the
   // tetrahedron indexed by `e`.  A, B, and C are the remaining vertices of

--- a/multibody/fixed_fem/dev/deformable_contact.cc
+++ b/multibody/fixed_fem/dev/deformable_contact.cc
@@ -14,7 +14,6 @@ namespace fem {
 
 using geometry::SurfaceFaceIndex;
 using geometry::SurfaceMesh;
-using geometry::VolumeElementIndex;
 using geometry::VolumeMesh;
 using geometry::internal::Aabb;
 using geometry::internal::Bvh;
@@ -391,7 +390,7 @@ class Intersector {
           tetrahedron (non-zero area restriction still applies).
    */
   const std::vector<IntersectionVertex<T>>& ClipTriangleByTetrahedron(
-      VolumeElementIndex tet_index, const VolumeMesh<T>& tet_mesh_D,
+      int tet_index, const VolumeMesh<T>& tet_mesh_D,
       SurfaceFaceIndex face, const SurfaceMesh<double>& surface_R,
       const math::RigidTransform<T>& X_DR) {
     // Although polygon_D starts out pointing to polygon_[0], that is not an

--- a/multibody/fixed_fem/dev/deformable_contact.h
+++ b/multibody/fixed_fem/dev/deformable_contact.h
@@ -42,7 +42,7 @@ struct ContactPolygonData {
   Vector4<T> b_centroid;
   /** The index of the tetrahedron element in the intersecting tet-mesh in which
    this data's polygon is completely contained.  */
-  geometry::VolumeElementIndex tet_index;
+  int tet_index{};
 };
 
 /** Characterization of the contact surface between a deformable volume (tet)

--- a/multibody/fixed_fem/dev/deformable_contact_data.cc
+++ b/multibody/fixed_fem/dev/deformable_contact_data.cc
@@ -65,8 +65,7 @@ void DeformableContactData<T>::CalcParticipatingVertices(
     const DeformableContactSurface<T>& contact_surface =
         contact_pairs_[i].contact_surface;
     for (int j = 0; j < contact_surface.num_polygons(); ++j) {
-      const geometry::VolumeElementIndex tet_in_contact =
-          contact_surface.polygon_data(j).tet_index;
+      const int tet_in_contact = contact_surface.polygon_data(j).tet_index;
       for (int k = 0; k < kNumVerticesInTetrahedron; ++k) {
         const int v = deformable_mesh.element(tet_in_contact).vertex(k);
         if (permuted_vertex_indexes_[v] == -1) {

--- a/multibody/fixed_fem/dev/dynamic_elasticity_model.h
+++ b/multibody/fixed_fem/dev/dynamic_elasticity_model.h
@@ -63,7 +63,6 @@ class DynamicElasticityModel : public ElasticityModel<Element> {
     constexpr int kNumDofs = kDim * kNumNodes;
     DRAKE_THROW_UNLESS(kNumNodes == 4);
 
-    using geometry::VolumeElementIndex;
     /* Record the reference positions of the input mesh. The returned offset is
      from before the new tets are added. */
     const NodeIndex node_index_offset(this->ParseTetMesh(mesh));
@@ -71,7 +70,7 @@ class DynamicElasticityModel : public ElasticityModel<Element> {
     /* Builds and adds new elements. */
     const VectorX<T>& X = this->reference_positions();
     std::array<NodeIndex, kNumNodes> element_node_indices;
-    for (VolumeElementIndex i(0); i < mesh.num_elements(); ++i) {
+    for (int i = 0; i < mesh.num_elements(); ++i) {
       for (int j = 0; j < kNumNodes; ++j) {
         /* To obtain the global node index, offset the local index of the nodes
          in the mesh (starting from 0) by the existing number of nodes

--- a/multibody/fixed_fem/dev/static_elasticity_model.h
+++ b/multibody/fixed_fem/dev/static_elasticity_model.h
@@ -51,7 +51,6 @@ class StaticElasticityModel : public ElasticityModel<Element> {
     constexpr int kNumNodes = Element::Traits::kNumNodes;
     DRAKE_THROW_UNLESS(kNumNodes == 4);
 
-    using geometry::VolumeElementIndex;
     /* Record the reference positions of the input mesh. The returned offset is
      from before the new tets are added. */
     const NodeIndex node_index_offset(this->ParseTetMesh(mesh));
@@ -59,7 +58,7 @@ class StaticElasticityModel : public ElasticityModel<Element> {
     /* Builds and adds new elements. */
     std::array<NodeIndex, kNumNodes> element_node_indices;
     const VectorX<T>& X = this->reference_positions();
-    for (VolumeElementIndex i(0); i < mesh.num_elements(); ++i) {
+    for (int i = 0; i < mesh.num_elements(); ++i) {
       for (int j = 0; j < kNumNodes; ++j) {
         /* To obtain the global node index, offset the local index of the nodes
          in the mesh (starting from 0) by the existing number of nodes

--- a/multibody/fixed_fem/dev/test/deformable_contact_test.cc
+++ b/multibody/fixed_fem/dev/test/deformable_contact_test.cc
@@ -24,7 +24,6 @@ namespace {
 using Eigen::Vector3d;
 using geometry::SurfaceMesh;
 using geometry::VolumeElement;
-using geometry::VolumeElementIndex;
 using geometry::VolumeMesh;
 using geometry::VolumeMeshFieldLinear;
 using geometry::internal::Bvh;
@@ -180,7 +179,7 @@ void TestComputeTetMeshTriMeshContact() {
   calculated_centroids_D.clear();
   for (int i = 0; i < kNumPolys; ++i) {
     const Vector4<T> b_centroid = contact_data[i].b_centroid;
-    const VolumeElementIndex tet_index = contact_data[i].tet_index;
+    const int tet_index = contact_data[i].tet_index;
     const VolumeElement& tet = volume_D.element(tet_index);
     Vector3<T> centroid_D(0, 0, 0);
     /* Calculate the centroid in cartesian coordinate by interpolating the

--- a/multibody/fixed_fem/dev/test/deformable_rigid_manager_test.cc
+++ b/multibody/fixed_fem/dev/test/deformable_rigid_manager_test.cc
@@ -277,8 +277,7 @@ TEST_F(DeformableRigidManagerTest, UpdateDeformableVertexPositions) {
                reference_configuration_geometries[0].mesh().num_elements());
   /* Verify that the elements of the deformed mesh is the same as the elements
    of the initial mesh. */
-  for (geometry::VolumeElementIndex i(0);
-       i < deformed_meshes[0].mesh().num_elements(); ++i) {
+  for (int i = 0; i < deformed_meshes[0].mesh().num_elements(); ++i) {
     EXPECT_EQ(deformed_meshes[0].mesh().element(i),
               reference_configuration_geometries[0].mesh().element(i));
   }


### PR DESCRIPTION
There are four index types associated with the two mesh types. This removes the fourth of the four indices.

In this case "removal" means:
  1. Removing all usages of `VolumeElementIndex` in Drake C++ code.
  2. Removing the python bindings.
  3. Keep the type, but change it to be an alias to an int. This will allow us to defer updating Anzu until *all* index types have been removed. At that point, we'll remove the int aliases and update Anzu.
     - `TypeSafeIndex` allows for index vs unsigned int comparisons. This alias will break this functionality. Where necessary, those signed-unsigned comparisons are also updated.

re: release notes. This is part of hydroelastic, so only the PR number should be referenced, no details.

Relates #15796.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15933)
<!-- Reviewable:end -->
