### PR TITLE
[yaml] Minor tweaks to internal::Node API

### DIFF
--- a/common/yaml/yaml_write_archive.cc
+++ b/common/yaml/yaml_write_archive.cc
@@ -54,7 +54,7 @@ void RecursiveEmit(const internal::Node& node, YAML::EmitFromEvents* sink) {
       // If there are no children, then format this map onto a single line;
       // otherwise, format over multiple "key: value\n" lines.
       auto style = YAML::EmitterStyle::Block;
-      if (data.map.empty()) {
+      if (data.mapping.empty()) {
         style = YAML::EmitterStyle::Flow;
       }
       sink->OnMapStart(no_mark, node.GetTag(), no_anchor, style);
@@ -62,26 +62,26 @@ void RecursiveEmit(const internal::Node& node, YAML::EmitFromEvents* sink) {
       // member function in our header file), use it to specify output order;
       // otherwise, use alphabetical order.
       std::vector<std::string> key_order;
-      if (data.map.count(kKeyOrder)) {
-        const internal::Node& key_order_node = data.map.at(kKeyOrder);
+      if (data.mapping.count(kKeyOrder)) {
+        const internal::Node& key_order_node = data.mapping.at(kKeyOrder);
         // Use Accept()'s ordering.  (If EraseMatchingMaps has been called,
         // some of the keys may have disappeared.)
         for (const auto& item : key_order_node.GetSequence()) {
           const std::string& key = item.GetScalar();
-          if (data.map.count(key)) {
+          if (data.mapping.count(key)) {
             key_order.push_back(key);
           }
         }
       } else {
         // Use alphabetical ordering.
-        for (const auto& [key, value] : data.map) {
+        for (const auto& [key, value] : data.mapping) {
           unused(value);
           key_order.push_back(key);
         }
       }
       for (const auto& string_key : key_order) {
         RecursiveEmit(internal::Node::MakeScalar(string_key), sink);
-        RecursiveEmit(data.map.at(string_key), sink);
+        RecursiveEmit(data.mapping.at(string_key), sink);
       }
       sink->OnMapEnd();
     },

--- a/common/yaml/yaml_write_archive.h
+++ b/common/yaml/yaml_write_archive.h
@@ -249,16 +249,13 @@ class YamlWriteArchive final {
   void VisitScalar(const NVP& nvp) {
     using T = typename NVP::value_type;
     const T& value = *nvp.value();
-    internal::Node node;
-    if constexpr (std::is_floating_point_v<T>) {
-      // Different versions of fmt disagree on whether to omit the trailing
-      // ".0" when formatting integer-valued floating-point numbers.  Force
-      // the ".0" in all cases by using the "#" option.
-      node = internal::Node::MakeScalar(fmt::format("{:#}", value));
-    } else {
-      node = internal::Node::MakeScalar(fmt::format("{}", value));
-    }
-    root_.Add(nvp.name(), std::move(node));
+    // Different versions of fmt disagree on whether to omit the trailing
+    // ".0" when formatting integer-valued floating-point numbers.  Force
+    // the ".0" in all cases by using the "#" option for floats.
+    constexpr std::string_view pattern =
+        std::is_floating_point_v<T> ? "{:#}" : "{}";
+    root_.Add(nvp.name(), internal::Node::MakeScalar(
+        fmt::format(pattern, value)));
   }
 
   // This is used for std::optional or similar.


### PR DESCRIPTION
Amends #15865 in service of #15867 -- there, we will need to be very careful to distinguish null from empty, when parsing std::optional or std::variant.

* Remove default constructor.
* Add MakeNull constructor.
* Remove useless IsEmptyScalar.
* Add operator<< for debugging.
* Fix an overlooked rename of 'map' to 'mapping'.

Towards #15868.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15934)
<!-- Reviewable:end -->
