### PR TITLE
Add SpheresOuterApproximation

### DIFF
--- a/geometry/optimization/BUILD.bazel
+++ b/geometry/optimization/BUILD.bazel
@@ -7,6 +7,10 @@ load(
     "drake_cc_package_library",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
+load(
+    "@drake//tools/skylark:test_tags.bzl",
+    "gurobi_test_tags",
+)
 
 package(default_visibility = ["//visibility:public"])
 
@@ -17,6 +21,7 @@ drake_cc_package_library(
         ":convex_set",
         ":graph_of_convex_sets",
         ":iris",
+        ":spheres_cover",
     ],
 )
 
@@ -69,6 +74,15 @@ drake_cc_library(
         "//multibody/plant",
         "//solvers:ipopt_solver",
         "//solvers:snopt_solver",
+    ],
+)
+
+drake_cc_library(
+    name = "spheres_cover",
+    srcs = ["spheres_cover.cc"],
+    hdrs = ["spheres_cover.h"],
+    deps = [
+        "//solvers:mathematical_program",
     ],
 )
 
@@ -153,6 +167,16 @@ drake_cc_googletest(
         ":convex_set",
         ":test_utilities",
         "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "spheres_cover_test",
+    tags = gurobi_test_tags(),
+    deps = [
+        ":spheres_cover",
+        "//solvers:gurobi_solver",
+        "//solvers:solve",
     ],
 )
 

--- a/geometry/optimization/spheres_cover.cc
+++ b/geometry/optimization/spheres_cover.cc
@@ -1,0 +1,304 @@
+#include "drake/geometry/optimization/spheres_cover.h"
+
+#include <algorithm>
+#include <limits>
+#include <utility>
+
+#include "drake/solvers/decision_variable.h"
+
+namespace drake {
+namespace geometry {
+namespace optimization {
+constexpr double kInf = std::numeric_limits<double>::infinity();
+
+SpheresOuterApproximator::SpheresOuterApproximator(
+    int num_spheres, std::vector<Eigen::MatrixXd> polytopes,
+    const Eigen::Ref<const Eigen::MatrixXd>& outliers,
+    std::optional<double> max_sphere_radius)
+    : prog_{},
+      dim_{static_cast<int>(outliers.rows())},
+      polytopes_{std::move(polytopes)},
+      outliers_{outliers} {
+  spheres_.reserve(num_spheres);
+  for (int i = 0; i < num_spheres; ++i) {
+    auto a_i = prog_.NewContinuousVariables(dim_, "a");
+    auto b_i = prog_.NewContinuousVariables<1>("b")[0];
+    spheres_.push_back(SpheresOuterApproximator::Sphere{.a = a_i, .b = b_i});
+  }
+  const int num_polytopes = static_cast<int>(polytopes_.size());
+  const int num_outliers = static_cast<int>(outliers_.cols());
+  phi_ = prog_.NewBinaryVariables(num_polytopes, num_spheres, "phi");
+  zeta_ = prog_.NewBinaryVariables(num_outliers, num_spheres, "zeta");
+
+  // Each polytope is contained in at least one sphere.
+  for (int i = 0; i < num_polytopes; ++i) {
+    prog_.AddLinearConstraint(Eigen::VectorXd::Ones(num_spheres), 1, kInf,
+                              phi_.row(i));
+  }
+  outlier_covered_ = prog_.NewBinaryVariables(num_outliers, "outlier_covered");
+  // outlier_covered[i] = logical_or(zeta_(i, 0), zeta_(i, 1), ...,
+  // zeta_(i, num_spheres-1)). We can write this logical_or operation with
+  // linear constraints
+  // outlier_covered_[i] >= zeta_(i, j) for all j
+  // outlier_covered_[i] <= ∑ⱼ zeta_(i, j)
+  Eigen::MatrixXd A_outlier_or =
+      Eigen::MatrixXd::Zero(num_spheres + 1, num_spheres + 1);
+  A_outlier_or.col(0) = Eigen::VectorXd::Ones(num_spheres + 1);
+  A_outlier_or.topRightCorner(num_spheres, num_spheres) =
+      -Eigen::MatrixXd::Identity(num_spheres, num_spheres);
+  A_outlier_or.bottomRightCorner(1, num_spheres) =
+      -Eigen::RowVectorXd::Ones(num_spheres);
+  Eigen::VectorXd lb_outlier_or = Eigen::VectorXd::Zero(num_spheres + 1);
+  lb_outlier_or(num_spheres) = -kInf;
+  Eigen::VectorXd ub_outlier_or =
+      Eigen::VectorXd::Constant(num_spheres + 1, kInf);
+  ub_outlier_or(num_spheres) = 0;
+  for (int i = 0; i < num_outliers; ++i) {
+    solvers::VectorXDecisionVariable vars_outlier_or(num_spheres + 1);
+    vars_outlier_or(0) = outlier_covered_(i);
+    vars_outlier_or.tail(num_spheres) = zeta_.row(i);
+    prog_.AddLinearConstraint(A_outlier_or, lb_outlier_or, ub_outlier_or,
+                              vars_outlier_or);
+  }
+
+  // Add the cost to minimize the summation of outlier_covered_
+  prog_.AddLinearCost(Eigen::VectorXd::Ones(num_outliers), 0, outlier_covered_);
+
+  polytope_vertex_square_max_ = -kInf;
+  for (const auto& polytope : polytopes_) {
+    polytope_vertex_square_max_ =
+        std::max(polytope_vertex_square_max_,
+                 polytope.array().square().colwise().sum().maxCoeff());
+  }
+  AddPolytopeInSphereConstraint();
+
+  const double vertex_pairwise_dist_squared_max =
+      ComputePolytopePairwiseDistanceSquaredMaximal();
+  // When the sphere center is within the convex hull of the polytopes, the
+  // best sphere must have its radius smaller than the maximal pairwise
+  // distance of the polytope vertices.
+  const double max_sphere_radius_squared =
+      max_sphere_radius.has_value()
+          ? std::min(vertex_pairwise_dist_squared_max,
+                     max_sphere_radius.value() * max_sphere_radius.value())
+          : vertex_pairwise_dist_squared_max;
+
+  for (int i = 0; i < num_spheres; ++i) {
+    for (int j = 0; j < num_outliers; ++j) {
+      AddOutlierNotInSphereConstraint(j, i, max_sphere_radius_squared);
+    }
+  }
+
+  AddSphereCenterInPolytopeConvexHull();
+
+  // Add constraint that the sphere radius should be less than
+  // max_sphere_radius.
+  // For a sphere xᵀx + aᵢᵀx + bᵢ ≤ 0, the radius square is
+  // aᵢᵀaᵢ/4 − bᵢ
+  // So we impose the second-order cone constraint 4(bᵢ + rₘₐₓ²) ≥ aᵢᵀaᵢ
+  if (max_sphere_radius.has_value()) {
+    const auto r_max_squared = AddSphereRadiusUpperBound();
+    prog_.AddBoundingBoxConstraint(
+        0, max_sphere_radius.value() * max_sphere_radius.value(),
+        r_max_squared);
+  }
+}
+
+void SpheresOuterApproximator::AddPolytopeInSphereConstraint() {
+  const int num_spheres = static_cast<int>(spheres_.size());
+  const int num_polytopes = static_cast<int>(polytopes_.size());
+  for (int i = 0; i < num_spheres; ++i) {
+    for (int j = 0; j < num_polytopes; ++j) {
+      for (int vert_idx = 0; vert_idx < polytopes_[j].cols(); ++vert_idx) {
+        AddPointInSphereConstraint(polytopes_[j].col(vert_idx), i, phi_(j, i));
+      }
+    }
+  }
+  // Add the constraint that at least one of phi_(j, :) is 1, namely the
+  // polytope has to be contained in at least one box.
+  for (int j = 0; j < num_polytopes; ++j) {
+    prog_.AddLinearConstraint(Eigen::RowVectorXd::Ones(num_spheres), 1, kInf,
+                              phi_.row(j));
+  }
+}
+
+void SpheresOuterApproximator::AddOutlierNotInSphereConstraint(
+    int outlier_idx, int sphere_idx, double max_sphere_radius_squared) {
+  // We add the constraint
+  // oⱼᵀqⱼ + aᵢᵀoⱼ + bᵢ ≥ -M₁*ζ(j, i)
+  // First we need to compute the big-M constant M₁, as a lower bound of the
+  // left hand side. If the sphere is parameterized as (x-c)ᵀ(x-c) ≤ r², then we
+  // know that aᵢ=−2c, bᵢ=cᵀc−r² where c is the center of the sphere and r is
+  // the radius of the sphere. We can compute min aᵢᵀoⱼ = min -2cᵀoⱼ over c in
+  // ConvexHull(polytopes). This minimization is obtained at one of the polytope
+  // vertices. bᵢ is lower-bounded by −r².
+  double a_dot_o_min = kInf;
+  const auto& o = outliers_.col(outlier_idx);
+
+  for (const auto& polytope : polytopes_) {
+    a_dot_o_min = std::min(a_dot_o_min,
+                           (-2 * o.transpose() * polytope).array().minCoeff());
+  }
+  const double M1 =
+      std::max(-(o.squaredNorm() + a_dot_o_min - max_sphere_radius_squared),
+
+               0.);
+  // add the constraint oⱼᵀoⱼ + aᵢᵀoⱼ + bᵢ ≥ −M1 * ζ(j, i)
+  Eigen::RowVectorXd coeff(dim_ + 2);
+  coeff.head(dim_) = o.transpose();
+  coeff(dim_) = 1;
+  coeff(dim_ + 1) = M1;
+  solvers::VectorXDecisionVariable vars(dim_ + 2);
+  vars.head(dim_) = spheres_[sphere_idx].a;
+  vars(dim_) = spheres_[sphere_idx].b;
+  vars(dim_ + 1) = zeta_(outlier_idx, sphere_idx);
+  prog_.AddLinearConstraint(coeff, -o.squaredNorm(), kInf, vars);
+
+  // Add the constraint zeta = 1 => outlier is inside the sphere.
+  AddPointInSphereConstraint(o, sphere_idx, zeta_(outlier_idx, sphere_idx));
+}
+
+void SpheresOuterApproximator::AddPointInSphereConstraint(
+    const Eigen::Ref<const Eigen::VectorXd>& pt, int sphere_idx,
+    const symbolic::Variable& binary_var) {
+  // We add the constraint pᵀp + aᵀp + b ≤ M * (1-z)
+  // First we need to compute the big constant M. To do so, we compute an upper
+  // bound of the left hand side. If the sphere is parameterized as (x-c)ᵀ(x-c)
+  // ≤ r², then we know that a=−2c, b=cᵀc−r² where c is the center of the
+  // sphere and r is the radius of the sphere.
+  // We know that the sphere center c should be in the convex hull of all the
+  // polytopes, so max aᵀp is upper bounded by max -2cᵀp subject to c in
+  // ConvexHull(P), and the maximal occurs at one of vertices of P. The maximal
+  // of b is upper bounded by cᵀc, equal to polytope_vertex_square_max_.
+
+  // Compute max aᵀp
+  double a_dot_p_max = -kInf;
+  for (const auto& polytope : polytopes_) {
+    a_dot_p_max = std::max(a_dot_p_max,
+                           (-2 * pt.transpose() * polytope).array().maxCoeff());
+  }
+  const double M = std::max(
+      pt.squaredNorm() + a_dot_p_max + polytope_vertex_square_max_, 0.);
+  // We add the constraint vᵀv + aᵀv + b ≤ M * (1-z)
+  Eigen::RowVectorXd coeff(dim_ + 2);
+  coeff.head(dim_) = pt.transpose();
+  coeff(dim_) = 1;
+  coeff(dim_ + 1) = M;
+  solvers::VectorXDecisionVariable vars(dim_ + 2);
+  vars.head(dim_) = spheres_[sphere_idx].a;
+  vars(dim_) = spheres_[sphere_idx].b;
+  vars(dim_ + 1) = binary_var;
+
+  prog_.AddLinearConstraint(coeff, -kInf, M - pt.squaredNorm(), vars);
+}
+
+double SpheresOuterApproximator::ComputePolytopePairwiseDistanceSquaredMaximal()
+    const {
+  double squared_dist = 0;
+  for (int i = 0; i < static_cast<int>(polytopes_.size()); ++i) {
+    for (int j = 0; j < polytopes_[i].cols(); ++j) {
+      if (j != polytopes_[i].cols() - 1) {
+        // Compute the squared distance between polytopes_[i].col(j) and
+        // polytopes_[i][:, j+1:]
+        squared_dist = std::max(
+            squared_dist,
+            (polytopes_[i].rightCols(polytopes_[i].cols() - j - 1) -
+             polytopes_[i].col(j).replicate(1, polytopes_[i].cols() - j - 1))
+                .array()
+                .square()
+                .colwise()
+                .sum()
+                .maxCoeff());
+      }
+      for (int k = i + 1; k < static_cast<int>(polytopes_.size()); ++k) {
+        // Compute the squared distance between polytopes_[i].col(j) and
+        // polytopes_[k]
+        squared_dist = std::max(squared_dist,
+                                (polytopes_[k] - polytopes_[i].col(j).replicate(
+                                                     1, polytopes_[k].cols()))
+                                    .array()
+                                    .square()
+                                    .colwise()
+                                    .sum()
+                                    .maxCoeff());
+      }
+    }
+  }
+  return squared_dist;
+}
+
+void SpheresOuterApproximator::AddSphereCenterInPolytopeConvexHull() {
+  // First get all the unique vertices of all polytopes.
+  Eigen::MatrixXd vertices = polytopes_[0];
+  for (int i = 1; i < static_cast<int>(polytopes_.size()); ++i) {
+    for (int j = 0; j < polytopes_[i].cols(); ++j) {
+      if (((vertices - polytopes_[i].col(j).replicate(1, vertices.cols()))
+               .array()
+               .colwise()
+               .sum() < 1E-6)
+              .any()) {
+        // Find a duplicated vertex.
+        continue;
+      } else {
+        vertices.conservativeResize(dim_, vertices.cols() + 1);
+        vertices.rightCols<1>() = polytopes_[i].col(j);
+      }
+    }
+  }
+  // We need to impose the linear equality constraint that c = wᵀv where c is
+  // the sphere center and v is the polytope vertices. Since c = −aᵢ/2, the
+  // linear equality constraint coefficient is [v  0.5 * 𝟏].
+  Eigen::MatrixXd linear_eq_coeff(dim_, vertices.cols() + 1);
+  linear_eq_coeff.leftCols(vertices.cols()) = vertices;
+  linear_eq_coeff.rightCols<1>() = 0.5 * Eigen::VectorXd::Ones(dim_);
+  for (const auto& sphere : spheres_) {
+    // Add the constraints that the sphere center is in the convex hull of
+    // vertices.
+    // TODO(hongkai.dai): compute the H-representation of the convex hull
+    // instead of the V-representation.
+    auto weights = prog_.NewContinuousVariables(vertices.cols(), "w");
+    prog_.AddBoundingBoxConstraint(0, 1, weights);
+    prog_.AddLinearEqualityConstraint(Eigen::RowVectorXd::Ones(vertices.cols()),
+                                      Vector1d(1), weights);
+    solvers::VectorXDecisionVariable linear_eq_vars(vertices.cols() + 1);
+    linear_eq_vars.head(vertices.cols()) = weights;
+    for (int i = 0; i < dim_; ++i) {
+      linear_eq_vars(vertices.cols()) = sphere.a(i);
+      prog_.AddLinearEqualityConstraint(linear_eq_coeff.row(i), 0.,
+                                        linear_eq_vars);
+    }
+  }
+}
+
+solvers::VectorXDecisionVariable
+SpheresOuterApproximator::AddSphereRadiusUpperBound() {
+  // Add constraint that the sphere radius should be less than
+  // max_sphere_radius.
+  // For a sphere xᵀx + aᵢᵀx + bᵢ ≤ 0, the radius square is
+  // aᵢᵀaᵢ/4 − bᵢ
+  // So we impose the second-order cone constraint 4(bᵢ + rₘₐₓ²) ≥ aᵢᵀaᵢ
+  const int num_spheres = static_cast<int>(spheres_.size());
+  solvers::VectorXDecisionVariable r_max_squared =
+      prog_.NewContinuousVariables(num_spheres, "r_max_squared");
+  for (int i = 0; i < num_spheres; ++i) {
+    Eigen::MatrixXd A_rotated_lorentz =
+        Eigen::MatrixXd::Zero(2 + dim_, dim_ + 2);
+    A_rotated_lorentz(0, 0) = 1;
+    A_rotated_lorentz(0, 1) = 1;
+    A_rotated_lorentz.bottomRightCorner(dim_, dim_) =
+        Eigen::MatrixXd::Identity(dim_, dim_);
+    Eigen::VectorXd b_rotated_lorentz = Eigen::VectorXd::Zero(2 + dim_);
+    b_rotated_lorentz(1) = 4;
+    VectorX<symbolic::Variable> vars_rotated_lorentz(dim_ + 2);
+    vars_rotated_lorentz(0) = spheres_[i].b;
+    vars_rotated_lorentz(1) = r_max_squared(i);
+    vars_rotated_lorentz.tail(dim_) = spheres_[i].a;
+
+    prog_.AddRotatedLorentzConeConstraint(A_rotated_lorentz, b_rotated_lorentz,
+                                          vars_rotated_lorentz);
+  }
+  return r_max_squared;
+}
+}  // namespace optimization
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/optimization/spheres_cover.h
+++ b/geometry/optimization/spheres_cover.h
@@ -1,0 +1,218 @@
+#pragma once
+#include <optional>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/solvers/decision_variable.h"
+#include "drake/solvers/mathematical_program.h"
+
+namespace drake {
+namespace geometry {
+namespace optimization {
+/**
+ * Given many polytopes Pᵢ, i=1, ..., N. We want to find spheres such that
+ * each polytope Pᵢ is covered by at least one of the spheres, and we want the
+ * union of the spheres to be a tight approximation of the union of Pᵢ. We
+ * measure the tightness by putting many sampled points outside of the
+ * polytopes Pᵢ, and our goal is to minimize the number of sample points being
+ * covered by the union of spheres. If possible, also minimize the size of the
+ * spheres.
+ *
+ * @note We assume that the center of each sphere is in the convex hull of the
+ * polytopes.
+ *
+ * Mathematically we solve this problem as
+ *
+ * Step 1:
+ * min ∑ⱼ1(oⱼ ∈ (S₁∪ S₂ ∪...∪ Sₘ))
+ * s.t Pᵢ ⊂ Sₖ for at least one k
+ *
+ * where oⱼ is a sampled point outside of the union of geometries Pᵢ. 1(oⱼ ∈
+ * (S₁∪ S₂ ∪...∪ Sₘ)) is the indicator variable that qⱼ is inside any
+ * spheres. Sₖ is the k'th sphere. This optimization will be a mixed-integer
+ * program.
+ *
+ * Step 1 finds the spheres that cover all polytopes, and minimize the outliers
+ * being covered by any sphere. Note that it is possible to use less number of
+ * spheres, while still cover the polytopes and obtain the same optimal cost as
+ * in step 1. Ideally we would prefer using less number of spheres. Hence we
+ * solve another optimization problem
+ *
+ * Step 2:
+ * min m
+ * s.t Pᵢ ⊂ Sₖ for at least one k
+ *     ∑ⱼ1(oⱼ ∈ (S₁∪ S₂ ∪...∪ Sₘ)) = optimal_cost_in_step_1.
+ *
+ * where m is the number of active spheres. It equals to the sum of some
+ * binary variables.
+ *
+ * Note that we can still scale the size of the
+ * spheres such that they obtain the same optimal cost (one example is that
+ * given a box and many outliers far away from the box, we can cover this box
+ * while avoiding the outliers using one sphere of different radius). When this
+ * happens, ideally we want to minimize the size of the spheres. We do this in
+ * step 3.
+ *
+ * Step 3:
+ * min radius²(S₁) + radius²(S₂) + ... + radius²(Sₘ)
+ * s.t Pᵢ ⊂ Sₖ for at least one k
+ *     ∑ⱼ1(oⱼ ∈ (S₁∪ S₂ ∪...∪ Sₘ)) = optimal_cost_in_step_2.
+ *
+ */
+class SpheresOuterApproximator {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SpheresOuterApproximator)
+
+  /**
+   * We parameterize a sphere as
+   * xᵀx + aᵀx + b ≤ 0
+   * where a and b are decision variables.
+   */
+  struct Sphere {
+    solvers::VectorXDecisionVariable a;
+    symbolic::Variable b;
+  };
+
+  /** Constructor
+   * @param num_spheres. Number of spheres we use to cover the geometries.
+   * @param polytopes. The polytopes we want to cover with spheres. polytopes[i]
+   * contains the vertices of the i'th polytope, each column of polytopes[i] is
+   * one vertex.
+   * @param outliers The points outside of each polytopes that we want to cover
+   * as few as possible. The i'th column is the location of the i'th outlier
+   * point.
+   * @param max_sphere_radius The maximal value of the sphere radius. If this
+   * value is set, then we add the second-order cone constraint aᵢᵀaᵢ  ≤ 4(rₘₐₓ²
+   * + bᵢ) which constrains the sphere radius to be less than rₘₐₓ
+   */
+  SpheresOuterApproximator(
+      int num_spheres, std::vector<Eigen::MatrixXd> polytopes,
+      const Eigen::Ref<const Eigen::MatrixXd>& outliers,
+      std::optional<double> max_sphere_radius = std::nullopt);
+
+  const solvers::MathematicalProgram& prog() const { return prog_; }
+
+  solvers::MathematicalProgram& mutable_prog() { return prog_; }
+
+  const std::vector<Sphere>& spheres() const { return spheres_; }
+
+  /** Getter for the binary variable phi.
+   * ϕ has size num_polytopes * num_spheres.
+   * ϕ(i, j) = 1 => the i'th polytope is covered by the j'th sphere.
+   * ϕ(i, j) = 0 => nothing. (Note that ϕ(i, j) = 0 DOESN'T imply the i'th
+   * polytope isn't covered by the j'th sphere).
+   * We require that ∑ⱼ ϕ(i, j) = 1. (Note that actually each polytope can be
+   * covered by multiple spheres, but we only assign one of these spheres as the
+   * covering sphere for that polytope).
+   *
+   * Note that if we swap two spheres, then we still get a valid covering. To
+   * break this symmetry, we impose an ordering on the spheres. If we denote the
+   * first polytope covered by the j'th sphere as sⱼ, i.e., ϕ(sⱼ, j) = 1 and
+   * ϕ(i, j) = 0 if i < sⱼ, then we require sⱼ < sₖ if j < k. If we look at the
+   * matrix ϕ, it means the index of the leading non-zero entry along each row
+   * increases row by row. The following assignment of ϕ is valid
+   * \verbatim
+   * 1 0 0 0 0
+   * 0 1 1 0 1
+   * 0 0 0 1 0
+   * \endverbatim
+   * The following assignment of ϕ is not valid
+   * \verbatim
+   * 1 0 0 1 0
+   * 0 0 1 0 1
+   * 0 1 0 0 0
+   * \endverbatim
+   * since the leading non-zero entry in the third row comes before the leading
+   * non-zero entry in the second row.
+   */
+  // TODO(hongkai.dai): impose this total ordering on phi.
+  const solvers::MatrixXDecisionVariable& phi() const { return phi_; }
+
+  /** Getter for the binary variable zeta.
+   * zeta_ has size size num_outliers * num_spheres.
+   * zeta_(i, j) = 1 => the i'th outlier is outside the j'th sphere.
+   */
+  const solvers::MatrixXDecisionVariable& zeta() const { return zeta_; }
+
+ private:
+  /**
+   * Adds the constraint that each polytope has to be in one of the spheres.
+   */
+  void AddPolytopeInSphereConstraint();
+
+  /**
+   * Adds the constraint that
+   * if zeta_(outlier_idx, sphere_idx) = 0 => outlier_[outlier_idx] is outside
+   * spheres_[sphere_idx]
+   * if zeta_(outlier_idx, sphere_idx) = 1 => outlier_[outlier_idx] is inside
+   * spheres_[sphere_idx].
+   * Mathematically the constraint is
+   * oⱼᵀoⱼ + aᵢᵀoⱼ + bᵢ ≥ -M₁ζ(j, i)
+   * oⱼᵀoⱼ + aᵢᵀoⱼ + bᵢ ≤ M₂(1-ζ(j, i))
+   * where oⱼ = outlier_[outlier_idx], i = sphere_idx. M₁, M₂ are positive big
+   * constants.
+   * @param max_sphere_radius_squared. The maximal value of r² with r being the
+   * radius of the sphere. This is used to compute the big-M constant M₁.
+   */
+  void AddOutlierNotInSphereConstraint(int outlier_idx, int sphere_idx,
+                                       double max_sphere_radius_squared);
+
+  /**
+   * Adds the constraint that a point is inside a sphere when the binary
+   * variable is active. Namely z = 1 => a point p is inside the sphere {x | xᵀx
+   * + aᵀx+b ≤ 0}. We impose the constraint pᵀp + aᵀx + b ≤ M(1−z) where M is a
+   * big constant.
+   */
+  void AddPointInSphereConstraint(const Eigen::Ref<const Eigen::VectorXd>& pt,
+                                  int sphere_idx,
+                                  const symbolic::Variable& binary_var);
+
+  /**
+   * Computes the maximal of the squared distance between polytope vertices.
+   */
+  double ComputePolytopePairwiseDistanceSquaredMaximal() const;
+
+  /**
+   * Add the linear constraint that center of each sphere is within the convex
+   * hull of the polytopes.
+   */
+  void AddSphereCenterInPolytopeConvexHull();
+
+  /**
+   * Add constraints on the upper bound of sphere radius.
+   * For a sphere xᵀx + aᵢᵀx + bᵢ ≤ 0, the radius square is
+   * aᵢᵀaᵢ/4 − bᵢ
+   * So we impose the second-order cone constraint 4(bᵢ + rₘₐₓ²) ≥ aᵢᵀaᵢ
+   * @return rₘₐₓ² The vector of variables whose i'th entry represent the upper
+   * bound of the radius square for the i'th sphere.
+   */
+  solvers::VectorXDecisionVariable AddSphereRadiusUpperBound();
+
+  solvers::MathematicalProgram prog_;
+  std::vector<Sphere> spheres_;
+  int dim_;
+
+  std::vector<Eigen::MatrixXd> polytopes_;
+  Eigen::MatrixXd outliers_;
+
+  // phi_ has size num_polytopes * num_spheres.
+  // phi_(i, j) = 1 => the i'th polytope is covered by the j'th sphere.
+  solvers::MatrixXDecisionVariable phi_;
+
+  // zeta_ has size size num_outliers * num_spheres.
+  // zeta_(i, j) = 0 => the i'th outlier is outside the j'th sphere.
+  // zeta_(i, j) = 1 => the i'th outlier is inside the j'th sphere.
+  solvers::MatrixXDecisionVariable zeta_;
+
+  // outlier_covered_[i] = 1 if outliers_.col(i) is covered by any of
+  // the spheres.
+  solvers::VectorXDecisionVariable outlier_covered_;
+
+  // polytope_vertex_square_max is the maximal of vᵀv among all polytope
+  // vertices v. This quantity will be used for computing big-M in
+  // AddPolytopeInSphereConstraint.
+  double polytope_vertex_square_max_{NAN};
+};
+}  // namespace optimization
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/optimization/test/spheres_cover_test.cc
+++ b/geometry/optimization/test/spheres_cover_test.cc
@@ -1,0 +1,104 @@
+#include "drake/geometry/optimization/spheres_cover.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/solvers/gurobi_solver.h"
+#include "drake/solvers/solve.h"
+
+namespace drake {
+namespace geometry {
+namespace optimization {
+GTEST_TEST(SpheresOuterApproximatorTest, SingleBox1) {
+  // Test covering a single box with spheres. The sphere can avoid all outliers.
+  Eigen::Matrix<double, 2, 4> box;
+  // clang-format off
+  box << 0.5, 0.5, -0.5, -0.5,
+         0.5, -0.5, -0.5, 0.5;
+  // clang-format on
+  // The outliers are just outside the corners of the box.
+  Eigen::Matrix<double, 2, 4> outliers = 1.5 * box;
+
+  // Test without setting max_sphere_radius.
+  SpheresOuterApproximator dut1(1, {box}, outliers);
+
+  auto result = solvers::Solve(dut1.prog());
+  EXPECT_TRUE(result.is_success());
+  // The optimal cost should be 0, that none of the outliers is covered by the
+  // sphere.
+  EXPECT_NEAR(result.get_optimal_cost(), 0, 1E-7);
+  // Make sure the sphere contains all vertices of the box, but no outliers.
+  Eigen::Vector2d a_val = result.GetSolution(dut1.spheres()[0].a);
+  double b_val = result.GetSolution(dut1.spheres()[0].b);
+  for (int i = 0; i < 4; ++i) {
+    EXPECT_LE(box.col(i).dot(box.col(i)) + box.col(i).dot(a_val) + b_val, 0);
+  }
+  for (int i = 0; i < 4; ++i) {
+    EXPECT_GE(outliers.col(i).dot(outliers.col(i)) +
+                  outliers.col(i).dot(a_val) + b_val,
+              0);
+  }
+  // Now add the sphere radius constraint. Check the sphere radius constraint
+  double max_sphere_radius = 0.8;
+  SpheresOuterApproximator dut2(1, {box}, outliers, max_sphere_radius);
+  result = solvers::Solve(dut2.prog());
+  EXPECT_TRUE(result.is_success());
+  a_val = result.GetSolution(dut2.spheres()[0].a);
+  b_val = result.GetSolution(dut2.spheres()[0].b);
+  EXPECT_LE((a_val / 2).dot(a_val / 2) - b_val,
+            max_sphere_radius * max_sphere_radius);
+
+  // Now further tighten the max sphere radius. The problem should be
+  // infeasible.
+  max_sphere_radius = 0.7;
+  SpheresOuterApproximator dut3(1, {box}, outliers, max_sphere_radius);
+  result = solvers::Solve(dut3.prog());
+  EXPECT_FALSE(result.is_success());
+}
+
+GTEST_TEST(SpheresOuterApproximatorTest, SingleBox2) {
+  // Test covering a single box with spheres. The sphere has to contain some
+  // outliers.
+  Eigen::Matrix<double, 2, 4> box;
+  // clang-format off
+  box << 0.5, 0.5, -0.5, -0.5,
+         0.5, -0.5, -0.5, 0.5;
+  // clang-format on
+  Eigen::Matrix<double, 2, 3> outliers;
+  // clang-format off
+  outliers << 0,  1, 0,
+              0.6, 1, -0.6;
+  // clang-format on
+
+  SpheresOuterApproximator dut1(1, {box}, outliers);
+
+  auto result = solvers::Solve(dut1.prog());
+  EXPECT_TRUE(result.is_success());
+  // The optimal cost should be 2, that two outliers are covered by the
+  // sphere.
+  EXPECT_EQ(result.get_optimal_cost(), 2);
+  // Make sure the sphere contains all vertices of the box
+  Eigen::Vector2d a_val = result.GetSolution(dut1.spheres()[0].a);
+  double b_val = result.GetSolution(dut1.spheres()[0].b);
+  for (int i = 0; i < 4; ++i) {
+    EXPECT_LE(box.col(i).dot(box.col(i)) + box.col(i).dot(a_val) + b_val, 0);
+  }
+  const auto zeta_sol = result.GetSolution(dut1.zeta());
+  for (int i = 0; i < outliers.cols(); ++i) {
+    if (std::abs(zeta_sol(i)) < 1E-6) {
+      // zeta_sol(i) = 0, the outlier is not inside the sphere.
+      EXPECT_GE(outliers.col(i).dot(outliers.col(i)) +
+                    outliers.col(i).dot(a_val) + b_val,
+                0);
+    } else {
+      EXPECT_LE(outliers.col(i).dot(outliers.col(i)) +
+                    outliers.col(i).dot(a_val) + b_val,
+                0);
+    }
+    EXPECT_GE(outliers.col(1).dot(outliers.col(1)) +
+                  outliers.col(1).dot(a_val) + b_val,
+              0);
+  }
+}
+}  // namespace optimization
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
As we discussed on slack and through meetings, we want to outer-approximate some geometry with spheres. I think one approach is to first voxelize the geometry, and then outer-approximate the voxelized volume with spheres. This PR is the first step to solve this problem, that given a list of polytopes (voxel grid), how to cover these polytopes with a given number of spheres.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15935)
<!-- Reviewable:end -->
