### PR TITLE
[meshcat] Adds recording methods to MeshcatVisualizerCpp

### DIFF
--- a/bindings/pydrake/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry_py_visualizers.cc
@@ -91,6 +91,15 @@ MeshcatVisualizer.  See #13038.)""")
             // `meshcat` is a shared_ptr, so does not need a keep_alive.
             cls_doc.ctor.doc)
         .def("Delete", &Class::Delete, cls_doc.Delete.doc)
+        .def("StartRecording", &Class::StartRecording,
+            cls_doc.StartRecording.doc)
+        .def("StopRecording", &Class::StopRecording, cls_doc.StopRecording.doc)
+        .def("PublishRecording", &Class::PublishRecording,
+            cls_doc.PublishRecording.doc)
+        .def("DeleteRecording", &Class::DeleteRecording,
+            cls_doc.DeleteRecording.doc)
+        .def("get_mutable_recording", &Class::get_mutable_recording,
+            cls_doc.get_mutable_recording.doc)
         .def("query_object_input_port", &Class::query_object_input_port,
             py_rvp::reference_internal, cls_doc.query_object_input_port.doc)
         .def_static("AddToBuilder",

--- a/bindings/pydrake/test/geometry_visualizers_test.py
+++ b/bindings/pydrake/test/geometry_visualizers_test.py
@@ -160,6 +160,12 @@ class TestGeometryVisualizers(unittest.TestCase):
         vis = mut.MeshcatVisualizerCpp_[T](meshcat=meshcat, params=params)
         vis.Delete()
         self.assertIsInstance(vis.query_object_input_port(), InputPort_[T])
+        animation = vis.StartRecording()
+        self.assertIsInstance(animation, mut.MeshcatAnimation)
+        self.assertEqual(animation, vis.get_mutable_recording())
+        vis.StopRecording()
+        vis.PublishRecording()
+        vis.DeleteRecording()
 
         builder = DiagramBuilder_[T]()
         scene_graph = builder.AddSystem(mut.SceneGraph_[T]())

--- a/geometry/meshcat_animation.h
+++ b/geometry/meshcat_animation.h
@@ -43,10 +43,13 @@ class MeshcatAnimation {
   double frames_per_second() const { return frames_per_second_; }
 
   /** Uses the frame rate to convert from time to the frame number, using
-   * std::round. `time_from_start` must be non-negative. */
-  int frame(double time_from_start) const {
-    DRAKE_DEMAND(time_from_start >= 0.0);
-    return static_cast<int>(std::round(time_from_start * frames_per_second_));
+  std::floor.
+  @pre `time` ≥ start_time().
+  */
+  int frame(double time) const {
+    DRAKE_DEMAND(time >= start_time_);
+    return static_cast<int>(
+        std::floor((time - start_time_) * frames_per_second_));
   }
 
   // The documentation is adapted from
@@ -67,10 +70,18 @@ class MeshcatAnimation {
   };
 
   // Accessors.
+  double start_time() const { return start_time_; }
   bool autoplay() const { return play_; }
   LoopMode loop_mode() const { return loop_mode_; }
   int repetitions() const { return repetitions_; }
   bool clamp_when_finished() const { return clamp_when_finished_; }
+
+  /** Set the start time of the animation.  This is only for convenience; it is
+  used in the frame() method to allow callers to look up the frame number based
+  on the current time, the start time, and the frame rate.  It is not passed to
+  Meshcat. It does not change any frames that have previously been set.  The
+  default is zero.*/
+  void set_start_time(double time) { start_time_ = time; }
 
   /** Set the behavior when the animation is first sent to the visualizer.  The
   animation will play immediately iff `play` is true.  The default is true.*/
@@ -231,6 +242,7 @@ class MeshcatAnimation {
   PathTracks path_tracks_{};
 
   const double frames_per_second_;
+  double start_time_{0.0};
   bool play_{true};
   LoopMode loop_mode_{kLoopRepeat};
   int repetitions_{1};

--- a/geometry/meshcat_visualizer.h
+++ b/geometry/meshcat_visualizer.h
@@ -6,6 +6,7 @@
 
 #include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/meshcat.h"
+#include "drake/geometry/meshcat_animation.h"
 #include "drake/geometry/meshcat_visualizer_params.h"
 #include "drake/geometry/rgba.h"
 #include "drake/geometry/scene_graph.h"
@@ -70,6 +71,47 @@ class MeshcatVisualizer final : public systems::LeafSystem<T> {
    to determine whether this should be called on initialization. */
   void Delete() const;
 
+  /** Sets a flag indicating that subsequent publish events should also be
+  "recorded" into a MeshcatAnimation.  The data in these events will be
+  combined with any frames previously added to the animation; if the same
+  transform/property is set at the same time, then it will overwrite the
+  existing frame in the animation.  Frames are added at the index
+  MeshcatAnimation::frame(context.get_time()).
+
+  @returns a mutable pointer to the current recording.  See
+  get_mutable_recording().
+  */
+  MeshcatAnimation* StartRecording() {
+    recording_ = true;
+    return get_mutable_recording();
+  }
+
+  /** Sets a flag to pause/stop recording.  When stopped, publish events will
+  not add frames to the animation. */
+  void StopRecording() { recording_ = false; }
+
+  /** Sends the recording to Meshcat as an animation. The published animation
+  only includes transforms and properties; the objects that they modify must be
+  sent to the visualizer separately (e.g. by calling Publish()). */
+  void PublishRecording() const;
+
+  /** Deletes the current animation holding the recorded frames.  Animation
+  options (autoplay, repetitions, etc) will also be reset, and any pointers
+  obtained from get_mutable_recording() will be rendered invalid. This does
+  *not* currently remove the animation from Meshcat. */
+  void DeleteRecording();
+
+  /** Returns a mutable pointer to this MeshcatVisualizer's unique
+  MeshcatAnimation object in which the frames will be recorded. This pointer
+  can be used to set animation properties (like autoplay, the loop mode, number
+  of repetitions, etc), and can be passed to supporting visualizers (e.g.
+  MeshcatPointCloudVisualizer and MeshcatContactVisualizer) so that they record
+  into the same animation.
+
+  The MeshcatAnimation object will only remain valid for the lifetime of `this`
+  or until DeleteRecording() is called. */
+  MeshcatAnimation* get_mutable_recording() { return animation_.get(); }
+
   /** Returns the QueryObject-valued input port. It should be connected to
    SceneGraph's QueryObject-valued output port. Failure to do so will cause a
    runtime error when attempting to broadcast messages. */
@@ -77,23 +119,21 @@ class MeshcatVisualizer final : public systems::LeafSystem<T> {
     return this->get_input_port(query_object_input_port_);
   }
 
-  /** Adds a MescatVisualizer and connects it to the given SceneGraph's
+  /** Adds a MeshcatVisualizer and connects it to the given SceneGraph's
    QueryObject-valued output port. See
    MeshcatVisualizer::MeshcatVisualizer(MeshcatVisualizer*,
    MeshcatVisualizerParams) for details. */
-  static const MeshcatVisualizer<T>& AddToBuilder(
+  static MeshcatVisualizer<T>& AddToBuilder(
       systems::DiagramBuilder<T>* builder, const SceneGraph<T>& scene_graph,
-      std::shared_ptr<Meshcat> meshcat,
-      MeshcatVisualizerParams params = {});
+      std::shared_ptr<Meshcat> meshcat, MeshcatVisualizerParams params = {});
 
   /** Adds a MescatVisualizer and connects it to the given QueryObject-valued
    output port. See MeshcatVisualizer::MeshcatVisualizer(MeshcatVisualizer*,
    MeshcatVisualizerParams) for details. */
-  static const MeshcatVisualizer<T>& AddToBuilder(
+  static MeshcatVisualizer<T>& AddToBuilder(
       systems::DiagramBuilder<T>* builder,
       const systems::OutputPort<T>& query_object_port,
-      std::shared_ptr<Meshcat> meshcat,
-      MeshcatVisualizerParams params = {});
+      std::shared_ptr<Meshcat> meshcat, MeshcatVisualizerParams params = {});
   //@}
 
  private:
@@ -111,7 +151,8 @@ class MeshcatVisualizer final : public systems::LeafSystem<T> {
 
   /* Makes calls to Meshcat::SetTransform to update the poses from SceneGraph.
    */
-  void SetTransforms(const QueryObject<T>& query_object) const;
+  void SetTransforms(const systems::Context<T>& context,
+                     const QueryObject<T>& query_object) const;
 
   /* Handles the initialization event. */
   systems::EventStatus OnInitialization(const systems::Context<T>&) const;
@@ -146,6 +187,24 @@ class MeshcatVisualizer final : public systems::LeafSystem<T> {
 
   /* The parameters for the visualizer.  */
   MeshcatVisualizerParams params_;
+
+  /* TODO(russt): Consider moving the MeshcatAnimation into the Context.
+  Full-fledged support for multi-threaded recording requires some additional
+  design thinking and may require either moving the prefix into the Context as
+  well (e.g. multiple copies of the MeshcatVisualizer publish to the same
+  Meshcat, but on different prefixes) or support for SetObject in
+  MeshcatAnimation (each animation keeps track of the objects, instead of the
+  shared Meshcat instance keeping track).  We may also want to allow users to
+  disable the default publishing behavior (to record without visualizing
+  immediately). */
+
+  /* MeshcatAnimation object for recording. It must be mutable so that frames
+   * can be added to it during Publish events. */
+  mutable std::unique_ptr<MeshcatAnimation> animation_;
+
+  /* Recording status.  True means that each new Publish event will record a
+  frame in the animation. */
+  bool recording_{false};
 };
 
 /** A convenient alias for the MeshcatVisualizer class when using the `double`

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -174,7 +174,8 @@ Open up your browser to the URL above.
   builder.ExportInput(plant.get_actuation_input_port(), "actuation_input");
   MeshcatVisualizerParams params;
   params.delete_on_initialization_event = false;
-  MeshcatVisualizerd::AddToBuilder(&builder, scene_graph, meshcat, params);
+  auto& visualizer =
+      MeshcatVisualizerd::AddToBuilder(&builder, scene_graph, meshcat, params);
 
   auto diagram = builder.Build();
   auto context = diagram->CreateDefaultContext();
@@ -194,7 +195,16 @@ Open up your browser to the URL above.
 
   systems::Simulator<double> simulator(*diagram, std::move(context));
   simulator.set_target_realtime_rate(1.0);
+  visualizer.StartRecording();
   simulator.AdvanceTo(4.0);
+  visualizer.PublishRecording();
+
+  std::cout << "The recorded simulation results should now be available as an "
+               "animation.  Use the animation GUI to confirm."
+            << std::endl;
+
+  std::cout << "[Press RETURN to continue]." << std::endl;
+  std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
 
   meshcat->AddButton("ButtonTest");
   meshcat->AddSlider("SliderTest", 0, 1, 0.01, 0.5);


### PR DESCRIPTION
Based on the model used in MeshcatVisualizer python, but with more
thorough documentation.

This is a follow-up to #15800.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15937)
<!-- Reviewable:end -->
