### PR TITLE
fix DoMakeDerivative for derivative of order higher than basis degree

### DIFF
--- a/common/trajectories/bspline_trajectory.cc
+++ b/common/trajectories/bspline_trajectory.cc
@@ -91,6 +91,13 @@ std::unique_ptr<Trajectory<T>> BsplineTrajectory<T>::DoMakeDerivative(
     int derivative_order) const {
   if (derivative_order == 0) {
     return this->Clone();
+  } else if (derivative_order > basis_.degree()) {
+    std::vector<T> derivative_knots;
+    derivative_knots.push_back(basis_.knots().front());
+    derivative_knots.push_back(basis_.knots().back());
+    std::vector<MatrixX<T>> control_points(1, MatrixX<T>::Zero(rows(), cols()));
+    return std::make_unique<BsplineTrajectory<T>>(
+        BsplineBasis<T>(1, derivative_knots), control_points);
   } else if (derivative_order > 1) {
     return this->MakeDerivative(1)->MakeDerivative(derivative_order - 1);
   } else if (derivative_order == 1) {

--- a/common/trajectories/test/bspline_trajectory_test.cc
+++ b/common/trajectories/test/bspline_trajectory_test.cc
@@ -162,6 +162,16 @@ TYPED_TEST(BsplineTrajectoryTests, MakeDerivativeTest) {
         calc_value, Vector1<T>{t(k)}, NumericalGradientOption{method});
     EXPECT_TRUE(CompareMatrices(derivative, expected_derivative, tolerance));
   }
+
+  // Verify that MakeDerivative() returns 0 matrix for derivative of order
+  // higher than basis degree
+  derivative_trajectory = trajectory.MakeDerivative(trajectory.basis().order());
+  MatrixX<T> expected_derivative = MatrixX<T>::Zero(trajectory.rows(),
+                                                    trajectory.cols());
+  for (int k = 0; k < num_times; ++k) {
+    MatrixX<T> derivative = derivative_trajectory->value(t(k));
+    EXPECT_TRUE(CompareMatrices(derivative, expected_derivative, 0.0));
+  }
 }
 
 // Verifies that EvalDerivative() works as expected.


### PR DESCRIPTION
In bspline_trajectory, the current recursive implementation of DoMakeDerivative will lead to an error when the input order of derivative is higher than the degree of basis due to negative memory reservation at this [line](https://github.com/RobotLocomotion/drake/blob/0bafc0979b426e3a7f85a4ce9a78e9af5ca4715a/common/trajectories/bspline_trajectory.cc#L99). 

Mathematically, we should return a zero-trajectory in such situations. This PR implements the correct behaviour.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15939)
<!-- Reviewable:end -->
