### PR TITLE
Parse frames with model instance when adding bushings

### DIFF
--- a/multibody/parsing/detail_urdf_parser.cc
+++ b/multibody/parsing/detail_urdf_parser.cc
@@ -607,7 +607,9 @@ void ParseFrame(ModelInstanceIndex model_instance,
       name, body.body_frame(), X_BF));
 }
 
-void ParseBushing(XMLElement* node, MultibodyPlant<double>* plant) {
+void ParseBushing(ModelInstanceIndex model_instance,
+                  XMLElement* node,
+                  MultibodyPlant<double>* plant) {
   // Functor to read a child element with a vector valued `value` attribute
   // Throws an error if unable to find the tag or if the value attribute is
   // improperly formed.
@@ -634,19 +636,20 @@ void ParseBushing(XMLElement* node, MultibodyPlant<double>* plant) {
   // Functor to read a child element with a string valued `name` attribute.
   // Throws an error if unable to find the tag of if the name attribute is
   // improperly formed.
-  auto read_frame = [node,
+  auto read_frame = [model_instance,
+                     node,
                      plant](const char* element_name) -> const Frame<double>& {
     XMLElement* value_node = node->FirstChildElement(element_name);
 
     if (value_node != nullptr) {
       std::string frame_name;
       if (ParseStringAttribute(value_node, "name", &frame_name)) {
-        if (!plant->HasFrameNamed(frame_name)) {
+        if (!plant->HasFrameNamed(frame_name, model_instance)) {
           throw std::runtime_error(fmt::format(
               "Frame: {} specified for <{}> does not exist in the model.",
               frame_name, element_name));
         }
-        return plant->GetFrameByName(frame_name);
+        return plant->GetFrameByName(frame_name, model_instance);
 
       } else {
         throw std::runtime_error(
@@ -757,7 +760,7 @@ ModelInstanceIndex ParseUrdf(
            node->FirstChildElement("drake:linear_bushing_rpy");
        bushing_node; bushing_node = bushing_node->NextSiblingElement(
                          "drake:linear_bushing_rpy")) {
-    ParseBushing(bushing_node, plant);
+    ParseBushing(model_instance, bushing_node, plant);
   }
 
   return model_instance;

--- a/multibody/parsing/test/sdf_parser_test/joint_parsing_test.sdf
+++ b/multibody/parsing/test/sdf_parser_test/joint_parsing_test.sdf
@@ -3,173 +3,210 @@
 Defines an SDF model with various types of joints used for testing the parser.
 -->
 <sdf version="1.7">
-  <model name="joint_parsing_test">
-    <link name="link1">
-      <inertial>
-        <mass>1</mass>
-        <inertia>
-          <ixx>0.1</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>0.1</iyy>
-          <iyz>0</iyz>
-          <izz>0.1</izz>
-        </inertia>
-      </inertial>
-    </link>
-    <link name="link2">
-      <inertial>
-        <mass>1</mass>
-        <inertia>
-          <ixx>0.1</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>0.1</iyy>
-          <iyz>0</iyz>
-          <izz>0.1</izz>
-        </inertia>
-      </inertial>
-    </link>
-    <joint name="revolute_joint" type="revolute">
-      <child>link2</child>
-      <parent>link1</parent>
-      <axis>
-        <xyz expressed_in="__model__">0 0 1</xyz>
-        <limit>
-          <lower>-1</lower>
-          <upper>2</upper>
-          <effort>100</effort>
-          <velocity>100</velocity>
-          <drake:acceleration>200</drake:acceleration>
-        </limit>
-        <dynamics>
-          <damping>0.2</damping>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
-    <link name="link3">
-      <inertial>
-        <mass>1</mass>
-        <inertia>
-          <ixx>0.1</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>0.1</iyy>
-          <iyz>0</iyz>
-          <izz>0.1</izz>
-        </inertia>
-      </inertial>
-    </link>
-    <joint name="prismatic_joint" type="prismatic">
-      <child>link3</child>
-      <parent>link2</parent>
-      <axis>
-        <xyz expressed_in="__model__">0 0 1</xyz>
-        <limit>
-          <lower>-2</lower>
-          <upper>1</upper>
-          <effort>100</effort>
-          <velocity>5</velocity>
-          <drake:acceleration>10</drake:acceleration>
-        </limit>
-        <dynamics>
-          <damping>0.3</damping>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
-    <link name="link4">
-      <inertial>
-        <mass>1</mass>
-        <inertia>
-          <ixx>0.1</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>0.1</iyy>
-          <iyz>0</iyz>
-          <izz>0.1</izz>
-        </inertia>
-      </inertial>
-    </link>
-    <joint name="revolute_joint_no_limits" type="revolute">
-      <child>link4</child>
-      <parent>link3</parent>
-      <axis>
-        <xyz expressed_in="__model__">0 0 1</xyz>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
-    <link name="link5">
-      <inertial>
-        <mass>1</mass>
-        <inertia>
-          <ixx>0.1</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>0.1</iyy>
-          <iyz>0</iyz>
-          <izz>0.1</izz>
-        </inertia>
-      </inertial>
-    </link>
-    <joint name="ball_joint" type="ball">
-      <child>link5</child>
-      <parent>link4</parent>
-      <axis>
-        <dynamics>
-          <damping>0.1</damping>
-        </dynamics>
-        <xyz expressed_in="__model__">0 0 1</xyz>
-      </axis>
-    </joint>
-    <link name="link6">
-      <inertial>
-        <mass>1</mass>
-        <inertia>
-          <ixx>0.1</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>0.1</iyy>
-          <iyz>0</iyz>
-          <izz>0.1</izz>
-        </inertia>
-      </inertial>
-    </link>
-    <joint name="universal_joint" type="universal">
-      <child>link6</child>
-      <parent>link5</parent>
-      <axis>
-        <dynamics>
-          <damping>0.1</damping>
-        </dynamics>
-        <xyz expressed_in="__model__">0 0 1</xyz>
-      </axis>
-    </joint>
-    <link name="link7">
-      <inertial>
-        <mass>1</mass>
-        <inertia>
-          <ixx>0.1</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>0.1</iyy>
-          <iyz>0</iyz>
-          <izz>0.1</izz>
-        </inertia>
-      </inertial>
-    </link>
-    <frame name='frame6' attached_to='link6'/>
-    <frame name='frame7' attached_to='link7'/>
-    <drake:joint name="planar_joint" type="planar">
-      <drake:child>frame7</drake:child>
-      <drake:parent>frame6</drake:parent>
-      <drake:damping>0.1 0.1 0.1</drake:damping>
-    </drake:joint>
-  </model>
+  <world name="joint_parsing_test_world">
+    <model name="joint_parsing_test">
+      <link name="link1">
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.1</iyy>
+            <iyz>0</iyz>
+            <izz>0.1</izz>
+          </inertia>
+        </inertial>
+      </link>
+      <link name="link2">
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.1</iyy>
+            <iyz>0</iyz>
+            <izz>0.1</izz>
+          </inertia>
+        </inertial>
+      </link>
+      <joint name="revolute_joint" type="revolute">
+        <child>link2</child>
+        <parent>link1</parent>
+        <axis>
+          <xyz expressed_in="__model__">0 0 1</xyz>
+          <limit>
+            <lower>-1</lower>
+            <upper>2</upper>
+            <effort>100</effort>
+            <velocity>100</velocity>
+            <drake:acceleration>200</drake:acceleration>
+          </limit>
+          <dynamics>
+            <damping>0.2</damping>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name="link3">
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.1</iyy>
+            <iyz>0</iyz>
+            <izz>0.1</izz>
+          </inertia>
+        </inertial>
+      </link>
+      <joint name="prismatic_joint" type="prismatic">
+        <child>link3</child>
+        <parent>link2</parent>
+        <axis>
+          <xyz expressed_in="__model__">0 0 1</xyz>
+          <limit>
+            <lower>-2</lower>
+            <upper>1</upper>
+            <effort>100</effort>
+            <velocity>5</velocity>
+            <drake:acceleration>10</drake:acceleration>
+          </limit>
+          <dynamics>
+            <damping>0.3</damping>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name="link4">
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.1</iyy>
+            <iyz>0</iyz>
+            <izz>0.1</izz>
+          </inertia>
+        </inertial>
+      </link>
+      <joint name="revolute_joint_no_limits" type="revolute">
+        <child>link4</child>
+        <parent>link3</parent>
+        <axis>
+          <xyz expressed_in="__model__">0 0 1</xyz>
+          <dynamics>
+            <spring_reference>0</spring_reference>
+            <spring_stiffness>0</spring_stiffness>
+          </dynamics>
+        </axis>
+      </joint>
+      <link name="link5">
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.1</iyy>
+            <iyz>0</iyz>
+            <izz>0.1</izz>
+          </inertia>
+        </inertial>
+      </link>
+      <joint name="ball_joint" type="ball">
+        <child>link5</child>
+        <parent>link4</parent>
+        <axis>
+          <dynamics>
+            <damping>0.1</damping>
+          </dynamics>
+          <xyz expressed_in="__model__">0 0 1</xyz>
+        </axis>
+      </joint>
+      <link name="link6">
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.1</iyy>
+            <iyz>0</iyz>
+            <izz>0.1</izz>
+          </inertia>
+        </inertial>
+      </link>
+      <joint name="universal_joint" type="universal">
+        <child>link6</child>
+        <parent>link5</parent>
+        <axis>
+          <dynamics>
+            <damping>0.1</damping>
+          </dynamics>
+          <xyz expressed_in="__model__">0 0 1</xyz>
+        </axis>
+      </joint>
+      <link name="link7">
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.1</iyy>
+            <iyz>0</iyz>
+            <izz>0.1</izz>
+          </inertia>
+        </inertial>
+      </link>
+      <frame name='frame6' attached_to='link6'/>
+      <frame name='frame7' attached_to='link7'/>
+      <drake:joint name="planar_joint" type="planar">
+        <drake:child>frame7</drake:child>
+        <drake:parent>frame6</drake:parent>
+        <drake:damping>0.1 0.1 0.1</drake:damping>
+      </drake:joint>
+    </model>
+    <model name="joint_parsing_test2">
+      <link name="link6">
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.1</iyy>
+            <iyz>0</iyz>
+            <izz>0.1</izz>
+          </inertia>
+        </inertial>
+      </link>
+      <link name="link7">
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.1</iyy>
+            <iyz>0</iyz>
+            <izz>0.1</izz>
+          </inertia>
+        </inertial>
+      </link>
+      <frame name='frame6' attached_to='link6'/>
+      <frame name='frame7' attached_to='link7'/>
+      <drake:joint name="planar_joint" type="planar">
+        <drake:child>frame7</drake:child>
+        <drake:parent>frame6</drake:parent>
+        <drake:damping>0.2 0.2 0.2</drake:damping>
+      </drake:joint>
+    </model>
+  </world>
 </sdf>


### PR DESCRIPTION
Also fixes an issue in the SDF parser where drake: custom joint types
were missing model instance information during parsing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15941)
<!-- Reviewable:end -->
