### PR TITLE
[hydro] Remove final vestiges of mesh feature index types

### DIFF
--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -590,7 +590,6 @@ drake_cc_library(
     hdrs = ["surface_mesh.h"],
     deps = [
         ":mesh_traits",
-        "//common:type_safe_index",
         "//math:geometric_transform",
     ],
 )
@@ -612,7 +611,6 @@ drake_cc_library(
     deps = [
         ":mesh_traits",
         "//common:default_scalars",
-        "//common:type_safe_index",
         "//geometry:geometry_ids",
     ],
 )

--- a/geometry/proximity/aabb.h
+++ b/geometry/proximity/aabb.h
@@ -170,8 +170,7 @@ class AabbMaker {
    @param vertices   The subset of vertices to fit.
    @pre `vertices` is not empty, and each of its entry is in the
         range [0, mesh_M.num_vertices()).  */
-  AabbMaker(const MeshType& mesh_M,
-            const std::set<typename MeshType::VertexIndex>& vertices)
+  AabbMaker(const MeshType& mesh_M, const std::set<int>& vertices)
       : mesh_M_(mesh_M), vertices_(vertices) {
     DRAKE_DEMAND(vertices_.size() > 0);
   }
@@ -182,7 +181,7 @@ class AabbMaker {
 
  private:
   const MeshType& mesh_M_;
-  const std::set<typename MeshType::VertexIndex>& vertices_;
+  const std::set<int>& vertices_;
 };
 
 }  // namespace internal

--- a/geometry/proximity/bvh.cc
+++ b/geometry/proximity/bvh.cc
@@ -21,7 +21,7 @@ Bvh<BvType, SourceMeshType>::Bvh(const SourceMeshType& mesh) {
   // for calculating the split point of the volumes.
   const int num_elements = mesh.num_elements();
   std::vector<CentroidPair> element_centroids;
-  for (IndexType i(0); i < num_elements; ++i) {
+  for (int i = 0; i < num_elements; ++i) {
     element_centroids.emplace_back(i, ComputeCentroid(mesh, i));
   }
 
@@ -108,7 +108,7 @@ BvType Bvh<BvType, SourceMeshType>::ComputeBoundingVolume(
     const SourceMeshType& mesh,
     const typename std::vector<CentroidPair>::iterator& start,
     const typename std::vector<CentroidPair>::iterator& end) {
-  std::set<typename SourceMeshType::VertexIndex> vertices;
+  std::set<int> vertices;
   // Check each mesh element in the given range.
   for (auto pair = start; pair < end; ++pair) {
     const auto& element = mesh.element(pair->first);
@@ -123,7 +123,7 @@ BvType Bvh<BvType, SourceMeshType>::ComputeBoundingVolume(
 
 template <class BvType, class SourceMeshType>
 Vector3d Bvh<BvType, SourceMeshType>::ComputeCentroid(
-    const SourceMeshType& mesh, const IndexType i) {
+    const SourceMeshType& mesh, int i) {
   Vector3d centroid{0, 0, 0};
   const auto& element = mesh.element(i);
   // Calculate average from all vertices.

--- a/geometry/proximity/bvh.h
+++ b/geometry/proximity/bvh.h
@@ -51,7 +51,7 @@ class BvNode {
    The actual number of stored element indices is `num_index`. */
   struct LeafData {
     int num_index;
-    std::array<typename MeshType::ElementIndex, kMaxElementPerLeaf> indices;
+    std::array<int, kMaxElementPerLeaf> indices;
   };
 
   /* Constructor for leaf nodes consisting of multiple elements.
@@ -82,7 +82,7 @@ class BvNode {
   /* Returns the i-th element index in the leaf data.
    @pre is_leaf() returns true.
    @pre `i` is less than LeafData::num_index, and i >= 0. */
-  typename MeshType::ElementIndex element_index(int i) const {
+  int element_index(int i) const {
     DRAKE_ASSERT(0 <= i && i < std::get<LeafData>(child_).num_index);
     return std::get<LeafData>(child_).indices[i];
   }
@@ -180,10 +180,10 @@ enum BvttCallbackResult {
 };
 
 /* Bounding volume tree traversal (BVTT) callback. Returns a BvttCallbackResult
- for further action, e.g. deciding whether to exit early.  */
-template <class MeshType, class OtherMeshType>
-using BvttCallback = std::function<BvttCallbackResult(
-    typename MeshType::ElementIndex, typename OtherMeshType::ElementIndex)>;
+ for further action, e.g. deciding whether to exit early. The parameters are
+ an index into the elements of the *first* mesh followed by the index into
+ the elements of the *second* mesh. */
+using BvttCallback = std::function<BvttCallbackResult(int, int)>;
 
 /* %Bvh is an acceleration structure for performing spatial queries against a
  collection of objects (in this case, triangles or tetrahedra). Specifically,
@@ -206,7 +206,6 @@ class Bvh {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Bvh)
 
   using MeshType = SourceMeshType;
-  using IndexType = typename MeshType::ElementIndex;
   using NodeType = BvNode<BvType, MeshType>;
 
   explicit Bvh(const MeshType& mesh);
@@ -226,7 +225,7 @@ class Bvh {
   template <class OtherBvhType>
   void Collide(
       const OtherBvhType& bvh_B, const math::RigidTransformd& X_AB,
-      BvttCallback<MeshType, typename OtherBvhType::MeshType> callback) const {
+      BvttCallback callback) const {
     using NodePair =
         std::pair<const NodeType&, const typename OtherBvhType::NodeType&>;
     std::stack<NodePair, std::vector<NodePair>> node_pairs;
@@ -289,10 +288,9 @@ class Bvh {
    @note This method can be only used for a primitive type that has an overload
    for BvType::HasOverlap() defined.  */
   template <typename PrimitiveType>
-  void Collide(
-      const PrimitiveType& primitive_P, const math::RigidTransformd& X_PH,
-      std::function<BvttCallbackResult(typename MeshType::ElementIndex)>
-          callback) const {
+  void Collide(const PrimitiveType& primitive_P,
+               const math::RigidTransformd& X_PH,
+               std::function<BvttCallbackResult(int)> callback) const {
     std::stack<const NodeType*> nodes;
     nodes.emplace(&root_node());
     while (!nodes.empty()) {
@@ -319,16 +317,13 @@ class Bvh {
   /* Wrapper around `Collide` with a callback that accumulates each pair of
    collision candidates and returns them all.
    @return Vector of element index pairs whose elements are candidates for
-   collision.  */
+   collision (index into *this* mesh's elements, index into bvh_B's mesh's
+   elements).  */
   template <class OtherBvhType>
-  std::vector<
-      std::pair<IndexType, typename OtherBvhType::MeshType::ElementIndex>>
-  GetCollisionCandidates(const OtherBvhType& bvh_B,
-                         const math::RigidTransformd& X_AB) const {
-    using OtherIndexType = typename OtherBvhType::MeshType::ElementIndex;
-    std::vector<std::pair<IndexType, OtherIndexType>> result;
-    auto callback = [&result](IndexType a,
-                              OtherIndexType b) -> BvttCallbackResult {
+  std::vector<std::pair<int, int>> GetCollisionCandidates(
+      const OtherBvhType& bvh_B, const math::RigidTransformd& X_AB) const {
+    std::vector<std::pair<int, int>> result;
+    BvttCallback callback = [&result](int a, int b) -> BvttCallbackResult {
       result.emplace_back(a, b);
       return BvttCallbackResult::Continue;
     };
@@ -354,7 +349,7 @@ class Bvh {
 
   NodeType& mutable_root_node() { return *root_node_; }
 
-  using CentroidPair = std::pair<IndexType, Vector3<double>>;
+  using CentroidPair = std::pair<int, Vector3<double>>;
 
   static std::unique_ptr<NodeType> BuildBvTree(
       const MeshType& mesh,
@@ -367,9 +362,9 @@ class Bvh {
       const typename std::vector<CentroidPair>::iterator& end);
 
   // TODO(tehbelinda): Move this function into SurfaceMesh/VolumeMesh directly
-  // and rename to CalcElementCentroid(ElementIndex).
-  static Vector3<double> ComputeCentroid(const MeshType& mesh,
-                                         IndexType i);
+  // and rename to CalcElementCentroid(int element_index).
+  // Computes the centroid of the ith element of the given mesh.
+  static Vector3<double> ComputeCentroid(const MeshType& mesh, int i);
 
   // Tests that two trees, rooted at nodes a and b, respectively, are equal
   // in the sense that they have identical node structure and equal bounding

--- a/geometry/proximity/mesh_deformer.h
+++ b/geometry/proximity/mesh_deformer.h
@@ -25,9 +25,6 @@ class MeshDeformer {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MeshDeformer);
 
-  /* The type of index used for referencing vertices in `MeshType`. */
-  using VertexIndexType = typename MeshType::VertexIndex;
-
   /* The scalar type the mesh uses to report vertex positions. */
   using T = typename MeshType::ScalarType;
 

--- a/geometry/proximity/mesh_to_vtk.cc
+++ b/geometry/proximity/mesh_to_vtk.cc
@@ -44,7 +44,7 @@ void WriteVtkUnstructuredGrid(std::ofstream& out, const Mesh& mesh) {
   const int num_vertices_per_element = Mesh::kVertexPerElement;
   const int num_integers = num_elements * (num_vertices_per_element + 1);
   out << "CELLS " << num_elements << " " << num_integers << std::endl;
-  for (typename Mesh::ElementIndex i(0); i < num_elements; ++i) {
+  for (int i = 0; i < num_elements; ++i) {
     const auto& element = mesh.element(i);
     out << fmt::format("{}", num_vertices_per_element);
     for (int v = 0; v < num_vertices_per_element; ++v) {

--- a/geometry/proximity/obb.cc
+++ b/geometry/proximity/obb.cc
@@ -168,13 +168,13 @@ RotationMatrixd ObbMaker<MeshType>::CalcOrientationByPca() const {
 
   // C is for centroid.
   Vector3d p_MC = Vector3d::Zero();
-  for (typename MeshType::VertexIndex v : vertices_) {
+  for (int v : vertices_) {
     p_MC += convert_to_double(mesh_M_.vertex(v));
   }
   p_MC *= one_over_n;
 
   Matrix3d covariance_M = Matrix3d::Zero();
-  for (typename MeshType::VertexIndex v : vertices_) {
+  for (int v : vertices_) {
     const Vector3d& p_MV = convert_to_double(mesh_M_.vertex(v));
     const Vector3d p_CV_M = p_MV - p_MC;
     // covariance_M is a symmetric matrix because it's a sum of the
@@ -266,7 +266,7 @@ Obb ObbMaker<MeshType>::CalcOrientedBox(const RotationMatrixd& R_MB) const {
   Vector3d p_FL = Vector3d::Constant(std::numeric_limits<double>::infinity());
   Vector3d p_FU = -Vector3d::Constant(std::numeric_limits<double>::infinity());
   const RotationMatrixd R_FM = R_MF.inverse();
-  for (typename MeshType::VertexIndex v : vertices_) {
+  for (int v : vertices_) {
     // Since frame F is a rotation of frame M with the same origin, we can use
     // the rotation R_FM for the transform X_FM.
     const Vector3d p_FV = R_FM * convert_to_double(mesh_M_.vertex(v));

--- a/geometry/proximity/obb.h
+++ b/geometry/proximity/obb.h
@@ -188,8 +188,7 @@ class ObbMaker {
    @param vertices The vertices to fit.
    @pre `vertices` is not empty, and each of its entry is in the
         range [0, V), where V is mesh_M.num_vertices().  */
-  ObbMaker(const MeshType& mesh_M,
-           const std::set<typename MeshType::VertexIndex>& vertices)
+  ObbMaker(const MeshType& mesh_M, const std::set<int>& vertices)
       : mesh_M_(mesh_M), vertices_(vertices) {
     DRAKE_DEMAND(vertices_.size() > 0);
   }
@@ -237,7 +236,7 @@ class ObbMaker {
   Obb OptimizeObbVolume(const Obb& box) const;
 
   const MeshType& mesh_M_;
-  const std::set<typename MeshType::VertexIndex>& vertices_;
+  const std::set<int>& vertices_;
 
   friend class ObbMakerTester<MeshType>;
 };

--- a/geometry/proximity/surface_mesh.h
+++ b/geometry/proximity/surface_mesh.h
@@ -10,20 +10,11 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
-#include "drake/common/type_safe_index.h"
 #include "drake/geometry/proximity/mesh_traits.h"
 #include "drake/math/rigid_transform.h"
 
 namespace drake {
 namespace geometry {
-/** Index used to identify a vertex in a surface mesh. Use `int` instead; this
- will disappear imminently. */
-using SurfaceVertexIndex = int;
-
-/** Index used to identify a triangular face in a surface mesh. Use `int`
- instead; this will disappear imminently. */
-using SurfaceFaceIndex = int;
-
 /** %SurfaceFace represents a triangular face in a SurfaceMesh.
  */
 class SurfaceFace {
@@ -98,16 +89,6 @@ class SurfaceMesh {
    Number of vertices per element. A triangle has 3 vertices.
    */
   static constexpr int kVertexPerElement = 3;
-
-  /**
-   Index for identifying a vertex.
-   */
-  using VertexIndex = int;
-
-  /**
-   Index for identifying a triangular element.
-   */
-  using ElementIndex = int;
 
   // TODO(SeanCurtis-TRI) This is very dissatisfying. The alias contained in a
   //  templated class doesn't depend on the class template parameter, but

--- a/geometry/proximity/test/bvh_test.cc
+++ b/geometry/proximity/test/bvh_test.cc
@@ -27,8 +27,7 @@ class BvhTester {
   BvhTester() = delete;
 
   template <class BvType, class MeshType>
-  static Vector3d ComputeCentroid(const MeshType& mesh,
-                                  const typename MeshType::ElementIndex i) {
+  static Vector3d ComputeCentroid(const MeshType& mesh, int i) {
     return Bvh<BvType, MeshType>::ComputeCentroid(mesh, i);
   }
 

--- a/geometry/proximity/test/bvh_updater_test.cc
+++ b/geometry/proximity/test/bvh_updater_test.cc
@@ -53,7 +53,6 @@ class BvhUpdaterTest : public ::testing::Test {
                  (i.e., vertices 6 and 7).  */
   static MeshType MakeMesh(double dist = 2) {
     using T = typename MeshType::ScalarType;
-    using VI = typename MeshType::VertexIndex;
     const Vector3<T> offset{dist, 0, 0};
     // clang-format off
     vector<Vector3<T>> vertices{
@@ -70,8 +69,8 @@ class BvhUpdaterTest : public ::testing::Test {
       /* The winding of the triangles don't matter. */
       vector<SurfaceFace> triangles;
       for (int i = 0; i < MeshTraits<MeshType>::kMaxElementPerBvhLeaf; ++i) {
-        triangles.push_back(SurfaceFace(VI(0), VI(1), VI(2)));
-        triangles.push_back(SurfaceFace(VI(3), VI(4), VI(5)));
+        triangles.push_back(SurfaceFace(0, 1, 2));
+        triangles.push_back(SurfaceFace(3, 4, 5));
       }
       return MeshType(std::move(triangles), std::move(vertices));
     } else {
@@ -79,8 +78,8 @@ class BvhUpdaterTest : public ::testing::Test {
        (the 3D version of "winding"). */
       vector<VolumeElement> tets;
       for (int i = 0; i < MeshTraits<MeshType>::kMaxElementPerBvhLeaf; ++i) {
-        tets.emplace_back(VI(0), VI(1), VI(2), VI(6));
-        tets.emplace_back(VI(3), VI(4), VI(5), VI(7));
+        tets.emplace_back(0, 1, 2, 6);
+        tets.emplace_back(3, 4, 5, 7);
       }
       return MeshType(std::move(tets), std::move(vertices));
     }
@@ -164,8 +163,7 @@ TYPED_TEST(BvhUpdaterTest, Update) {
 
   /* 3 doubles for each of M vertices */
   VectorX<T> p_MVs(3 * mesh.num_vertices());
-  using VIndex = typename MeshType::VertexIndex;
-  for (VIndex i(0); i < mesh.num_vertices(); ++i) {
+  for (int i = 0; i < mesh.num_vertices(); ++i) {
     p_MVs.segment(i * 3, 3) << R * mesh.vertex(i);
   }
   deformer.SetAllPositions(p_MVs);

--- a/geometry/proximity/test/contact_surface_test.cc
+++ b/geometry/proximity/test/contact_surface_test.cc
@@ -146,8 +146,6 @@ ContactSurface<T> TestContactSurface() {
 // Tests the ContactSurface with constituent gradients: construction, successful
 // reversal, access, etc.
 GTEST_TEST(ContactSurfaceTest, ConstituentGradients) {
-  using Index = SurfaceMesh<double>::ElementIndex;
-
   // Define two ids: A and B. When we create a ContactSurface with A and B in
   // that order, then the data is taken as is (i.e., A --> M, B --> N). When
   // we reverse the order, ContactSurface will swap/reverse the data so that
@@ -173,9 +171,9 @@ GTEST_TEST(ContactSurfaceTest, ConstituentGradients) {
         id_A, id_B, make_unique<SurfaceMesh<double>>(*surface_mesh),
         make_e_field(surface_mesh.get()), nullptr, nullptr);
     EXPECT_FALSE(surface.HasGradE_M());
-    EXPECT_THROW(surface.EvaluateGradE_M_W(Index(1)), std::runtime_error);
+    EXPECT_THROW(surface.EvaluateGradE_M_W(1), std::runtime_error);
     EXPECT_FALSE(surface.HasGradE_N());
-    EXPECT_THROW(surface.EvaluateGradE_N_W(Index(1)), std::runtime_error);
+    EXPECT_THROW(surface.EvaluateGradE_N_W(1), std::runtime_error);
   }
 
   {
@@ -186,9 +184,9 @@ GTEST_TEST(ContactSurfaceTest, ConstituentGradients) {
         make_e_field(surface_mesh.get()), make_unique<vector<Vector3d>>(grad_e),
         nullptr);
     EXPECT_TRUE(surface.HasGradE_M());
-    EXPECT_EQ(surface.EvaluateGradE_M_W(Index(1)), grad_e[1]);
+    EXPECT_EQ(surface.EvaluateGradE_M_W(1), grad_e[1]);
     EXPECT_FALSE(surface.HasGradE_N());
-    EXPECT_THROW(surface.EvaluateGradE_N_W(Index(1)), std::runtime_error);
+    EXPECT_THROW(surface.EvaluateGradE_N_W(1), std::runtime_error);
   }
 
   {
@@ -199,9 +197,9 @@ GTEST_TEST(ContactSurfaceTest, ConstituentGradients) {
         make_e_field(surface_mesh.get()), make_unique<vector<Vector3d>>(grad_e),
         nullptr);
     EXPECT_FALSE(surface.HasGradE_M());
-    EXPECT_THROW(surface.EvaluateGradE_M_W(Index(1)), std::runtime_error);
+    EXPECT_THROW(surface.EvaluateGradE_M_W(1), std::runtime_error);
     EXPECT_TRUE(surface.HasGradE_N());
-    EXPECT_EQ(surface.EvaluateGradE_N_W(Index(1)), grad_e[1]);
+    EXPECT_EQ(surface.EvaluateGradE_N_W(1), grad_e[1]);
   }
 
   {
@@ -212,9 +210,9 @@ GTEST_TEST(ContactSurfaceTest, ConstituentGradients) {
         make_e_field(surface_mesh.get()), nullptr,
         make_unique<vector<Vector3d>>(grad_e));
     EXPECT_FALSE(surface.HasGradE_M());
-    EXPECT_THROW(surface.EvaluateGradE_M_W(Index(1)), std::runtime_error);
+    EXPECT_THROW(surface.EvaluateGradE_M_W(1), std::runtime_error);
     EXPECT_TRUE(surface.HasGradE_N());
-    EXPECT_EQ(surface.EvaluateGradE_N_W(Index(1)), grad_e[1]);
+    EXPECT_EQ(surface.EvaluateGradE_N_W(1), grad_e[1]);
   }
 
   {
@@ -225,9 +223,9 @@ GTEST_TEST(ContactSurfaceTest, ConstituentGradients) {
         make_e_field(surface_mesh.get()), nullptr,
         make_unique<vector<Vector3d>>(grad_e));
     EXPECT_TRUE(surface.HasGradE_M());
-    EXPECT_EQ(surface.EvaluateGradE_M_W(Index(1)), grad_e[1]);
+    EXPECT_EQ(surface.EvaluateGradE_M_W(1), grad_e[1]);
     EXPECT_FALSE(surface.HasGradE_N());
-    EXPECT_THROW(surface.EvaluateGradE_N_W(Index(1)), std::runtime_error);
+    EXPECT_THROW(surface.EvaluateGradE_N_W(1), std::runtime_error);
   }
 
   vector<Vector3d> grad_e2;
@@ -242,9 +240,9 @@ GTEST_TEST(ContactSurfaceTest, ConstituentGradients) {
         make_e_field(surface_mesh.get()), make_unique<vector<Vector3d>>(grad_e),
         make_unique<vector<Vector3d>>(grad_e2));
     EXPECT_TRUE(surface.HasGradE_M());
-    EXPECT_EQ(surface.EvaluateGradE_M_W(Index(1)), grad_e[1]);
+    EXPECT_EQ(surface.EvaluateGradE_M_W(1), grad_e[1]);
     EXPECT_TRUE(surface.HasGradE_N());
-    EXPECT_EQ(surface.EvaluateGradE_N_W(Index(1)), grad_e2[1]);
+    EXPECT_EQ(surface.EvaluateGradE_N_W(1), grad_e2[1]);
   }
 
   {
@@ -255,9 +253,9 @@ GTEST_TEST(ContactSurfaceTest, ConstituentGradients) {
         make_e_field(surface_mesh.get()), make_unique<vector<Vector3d>>(grad_e),
         make_unique<vector<Vector3d>>(grad_e2));
     EXPECT_TRUE(surface.HasGradE_M());
-    EXPECT_EQ(surface.EvaluateGradE_M_W(Index(1)), grad_e2[1]);
+    EXPECT_EQ(surface.EvaluateGradE_M_W(1), grad_e2[1]);
     EXPECT_TRUE(surface.HasGradE_N());
-    EXPECT_EQ(surface.EvaluateGradE_N_W(Index(1)), grad_e[1]);
+    EXPECT_EQ(surface.EvaluateGradE_N_W(1), grad_e[1]);
   }
 }
 

--- a/geometry/proximity/test/obb_test.cc
+++ b/geometry/proximity/test/obb_test.cc
@@ -33,8 +33,7 @@ class ObbTester : public ::testing::Test {
 template <typename MeshType>
 class ObbMakerTester {
  public:
-  ObbMakerTester(const MeshType& mesh_M,
-                 const std::set<typename MeshType::VertexIndex>& vertices)
+  ObbMakerTester(const MeshType& mesh_M, const std::set<int>& vertices)
       : obb_maker_(mesh_M, vertices) {}
 
   RotationMatrixd CalcOrientationByPca() const {
@@ -444,10 +443,10 @@ TEST_F(ObbMakerTestTriangle, CalcOrientedBox) {
 // vertices in the mesh.
 template <typename MeshType>
 bool Contain(const Obb& obb_M, const MeshType& mesh_M,
-             const std::set<typename MeshType::VertexIndex>& vertices) {
+             const std::set<int>& vertices) {
   const RigidTransformd& X_MB = obb_M.pose();
   const RigidTransformd X_BM = X_MB.inverse();
-  for (const typename MeshType::VertexIndex& v : vertices) {
+  for (int v : vertices) {
     Vector3d p_MV = mesh_M.vertex(v);
     Vector3d p_BV = X_BM * p_MV;
     if ((p_BV.array() > obb_M.half_width().array()).any()) {

--- a/geometry/proximity/volume_mesh.h
+++ b/geometry/proximity/volume_mesh.h
@@ -12,19 +12,10 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
-#include "drake/common/type_safe_index.h"
 #include "drake/geometry/proximity/mesh_traits.h"
 
 namespace drake {
 namespace geometry {
-/** Index used to identify a vertex in a volume mesh. Use `int` instead; this
- will disappear imminently. */
-using VolumeVertexIndex = int;
-
-/** Index used to identify a tetrahedral element in a volume mesh. Use `int`
- instead; this will disappear imminently. */
-using VolumeElementIndex = int;
-
 /** %VolumeElement represents a tetrahedral element in a VolumeMesh. It is a
  topological entity in the sense that it only knows the indices of its vertices
  but not their coordinates.
@@ -122,14 +113,6 @@ class VolumeMesh {
    */
   static constexpr int kVertexPerElement = 4;
 
-  /** Index for identifying a vertex.
-   */
-  using VertexIndex = int;
-
-  /** Index for identifying a tetrahedral element.
-   */
-  using ElementIndex = int;
-
   // TODO(SeanCurtis-TRI) This is very dissatisfying. The alias contained in a
   //  templated class doesn't depend on the class template parameter, but
   //  depends on some non-template-dependent property (kVertexPerElement).
@@ -164,7 +147,7 @@ class VolumeMesh {
     }
   }
 
-  const VolumeElement& element(ElementIndex e) const {
+  const VolumeElement& element(int e) const {
     DRAKE_DEMAND(0 <= e && num_elements());
     return elements_[e];
   }
@@ -238,7 +221,7 @@ class VolumeMesh {
    */
   template <typename C>
   Barycentric<promoted_numerical_t<T, C>> CalcBarycentric(
-      const Vector3<C>& p_MQ, ElementIndex e) const {
+      const Vector3<C>& p_MQ, int e) const {
     // We have two conditions to satisfy.
     // 1. b₀ + b₁ + b₂ + b₃ = 1
     // 2. b₀*v0 + b₁*v1 + b₂*v2 + b₃*v3 = p_M.

--- a/geometry/proximity/volume_to_surface_mesh.cc
+++ b/geometry/proximity/volume_to_surface_mesh.cc
@@ -14,8 +14,6 @@ namespace drake {
 namespace geometry {
 namespace internal {
 
-using geometry::internal::SortedTriplet;
-
 std::vector<std::array<int, 3>> IdentifyBoundaryFaces(
     const std::vector<VolumeElement>& tetrahedra) {
   // We want to identify a triangle ABC from all six permutations of A,B,C


### PR DESCRIPTION
There are four index types associated with the two mesh types. This final commit removes the place-holder aliases for those index types, completing the removal. The aliases served the role of deferring any action that had to be coordinated based on the removal of multiple index types.

This also does the work that had to be deferred until all index types could be removed completely:

  - Constructs that had to work across mesh types, had to worry about specific index types associated with mesh types. They no longer have to worry about those details and can simply use ints. This includes:
      `Bvh`, `Aabb`, `Obb`, `MeshDeformer`, `MeshFieldLinear`, and writing meshes to VTK.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15942)
<!-- Reviewable:end -->
