### PR TITLE
Bump CRU and VGT to latest, including mesh rasterizer

### DIFF
--- a/tools/workspace/common_robotics_utilities/repository.bzl
+++ b/tools/workspace/common_robotics_utilities/repository.bzl
@@ -14,8 +14,8 @@ def common_robotics_utilities_repository(
         repository = "ToyotaResearchInstitute/common_robotics_utilities",
         # When updating, ensure that any new unit tests are reflected in
         # package.BUILD.bazel and BUILD.bazel in drake.
-        commit = "bbd315e222b97fb6dbf69e1f2efbe994e749874c",
-        sha256 = "4dba27e69f9557a1c4ce38358ee52bd877a73e02de3f1705aafd095e63a9de07",  # noqa
+        commit = "2d5593f89e4245946b06fdbd5402519f65c15ded",
+        sha256 = "8c7a1f79809975cdfeb2e6bf78687f643e446b35983d34447d6cea965486ea4a",  # noqa
         build_file = "@drake//tools/workspace/common_robotics_utilities:package.BUILD.bazel",  # noqa
         mirrors = mirrors,
     )

--- a/tools/workspace/voxelized_geometry_tools/BUILD.bazel
+++ b/tools/workspace/voxelized_geometry_tools/BUILD.bazel
@@ -8,4 +8,9 @@ sh_test(
     srcs = ["@voxelized_geometry_tools//:pointcloud_voxelization_test"],
 )
 
+sh_test(
+    name = "mesh_rasterization_test",
+    srcs = ["@voxelized_geometry_tools//:mesh_rasterization_test"],
+)
+
 add_lint_tests()

--- a/tools/workspace/voxelized_geometry_tools/package.BUILD.bazel
+++ b/tools/workspace/voxelized_geometry_tools/package.BUILD.bazel
@@ -20,11 +20,13 @@ cc_library(
     srcs = [
         "src/voxelized_geometry_tools/collision_map.cpp",
         "src/voxelized_geometry_tools/dynamic_spatial_hashed_collision_map.cpp",  # noqa
+        "src/voxelized_geometry_tools/mesh_rasterizer.cpp",
         "src/voxelized_geometry_tools/tagged_object_collision_map.cpp",
     ],
     hdrs = [
         "include/voxelized_geometry_tools/collision_map.hpp",
         "include/voxelized_geometry_tools/dynamic_spatial_hashed_collision_map.hpp",  # noqa
+        "include/voxelized_geometry_tools/mesh_rasterizer.hpp",
         "include/voxelized_geometry_tools/signed_distance_field.hpp",
         "include/voxelized_geometry_tools/signed_distance_field_generation.hpp",  # noqa
         "include/voxelized_geometry_tools/tagged_object_collision_map.hpp",
@@ -110,6 +112,16 @@ cc_test(
         ":cuda_voxelization_helpers",
         ":opencl_voxelization_helpers",
         ":pointcloud_voxelization",
+        "@common_robotics_utilities",
+        "@gtest//:without_main",
+    ],
+)
+
+cc_test(
+    name = "mesh_rasterization_test",
+    srcs = ["test/mesh_rasterization_test.cpp"],
+    deps = [
+        ":voxelized_geometry_tools",
         "@common_robotics_utilities",
         "@gtest//:without_main",
     ],

--- a/tools/workspace/voxelized_geometry_tools/repository.bzl
+++ b/tools/workspace/voxelized_geometry_tools/repository.bzl
@@ -14,8 +14,8 @@ def voxelized_geometry_tools_repository(
         repository = "ToyotaResearchInstitute/voxelized_geometry_tools",
         # When updating, ensure that any new unit tests are reflected in
         # package.BUILD.bazel and BUILD.bazel in drake.
-        commit = "f4fdbfa75bffa225afda13f5adce6e3edf9538ee",
-        sha256 = "a52a869a5050ccf5822a0095e24208d58e29262a334ad0db36193c2457621b92",  # noqa
+        commit = "677127a546984c3c0fb0e42fb694217328f66923",
+        sha256 = "227f0c35dfccfca32ef816a3d66fb56c6e80e851b974863337de087838db6b3f",  # noqa
         build_file = "@drake//tools/workspace/voxelized_geometry_tools:package.BUILD.bazel",  # noqa
         mirrors = mirrors,
     )


### PR DESCRIPTION
Updates `common_robotics_utilities` and `voxelized_geometry_tools` to latest commit (with corresponding tags on said repos), which brings a few minor fixes and mesh->voxel rasterization.

+@hongkai-dai for feature review, thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15951)
<!-- Reviewable:end -->
