### PR TITLE
[doc] Completely revamp installation instructions

### DIFF
--- a/doc/_pages/apt.md
+++ b/doc/_pages/apt.md
@@ -1,0 +1,64 @@
+---
+title: Installation via APT (Ubuntu)
+---
+
+# APT Packages
+
+Drake publishes pre-compiled binaries as APT packages (``*.deb``) for the
+Ubuntu 18.04 (Bionic) and Ubuntu 20.04 (Focal) operating systems. Refer to
+[Supported Configurations](/installation.html#supported-configurations)
+for additional compatibility details.
+
+To learn about other installation methods, refer to
+[Installation and Quickstart](/installation.html).
+
+Drake binary releases incorporate a pre-compiled version of
+[SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the
+[Mathematical Program toolbox](https://drake.mit.edu/doxygen_cxx/group__solvers.html).
+Thanks to Philip E. Gill and Elizabeth Wong for their kind support.
+
+## Stable Releases
+
+To add the Drake APT repository to your machine and install the `drake-dev` package,
+please do the following in order:
+
+If you are using a [minimal](https://wiki.ubuntu.com/Minimal) cloud or
+container image, you may need to install the following packages:
+
+```bash
+sudo apt-get update
+sudo apt-get install --no-install-recommends \
+  ca-certificates gnupg lsb-release wget
+```
+
+Download a copy of the Drake GPG signing key and add it to an APT trusted keychain:
+
+```bash
+wget -qO- https://drake-apt.csail.mit.edu/drake.asc | gpg --dearmor - \
+  | sudo tee /etc/apt/trusted.gpg.d/drake.gpg >/dev/null
+```
+
+Add the Drake repository to your APT sources list:
+
+```bash
+echo "deb [arch=amd64] https://drake-apt.csail.mit.edu/$(lsb_release -cs) $(lsb_release -cs) main" \
+  | sudo tee /etc/apt/sources.list.d/drake.list >/dev/null
+```
+
+Update your local APT package index and install the `drake-dev` package:
+
+```bash
+sudo apt-get update
+sudo apt-get install --no-install-recommends drake-dev
+```
+
+Most content installs to `/opt/drake`, so setting the following environment
+variables may be useful:
+
+  ```bash
+  export LD_LIBRARY_PATH="/opt/drake/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+  export PATH="/opt/drake/bin${PATH:+:${PATH}}"
+  export PYTHONPATH="/opt/drake/lib/python$(python3 -c 'import sys; print("{0}.{1}".format(*sys.version_info))')/site-packages${PYTHONPATH:+:${PYTHONPATH}}"
+  ```
+
+Refer to [Quickstart](/installation.html#quickstart) for next steps.

--- a/doc/_pages/developers.md
+++ b/doc/_pages/developers.md
@@ -57,34 +57,9 @@ of artifacts distributed with this website.
 * [Detailed Notes on Drake's Unit Tests](/unit_testing_instructions.html)
 * [Downstream Testing (Drake as a Dependency)](/downstream_testing.html)
 
-
 # Supported Configurations
 
-The following table shows the configurations and platforms that Drake
-officially supports. Supported configurations are tested in continuous
-integration. All other configurations are provided on a best-effort basis.
-
-Drake requires a compiler running in C++17 mode.
-
-| Operating System                 | Bazel | CMake | C/C++ Compiler                 | Java                          | Python |
-|----------------------------------|-------|-------|--------------------------------|-------------------------------|--------|
-| Ubuntu 18.04 LTS (Bionic Beaver) | 4.2   | 3.10  | GCC 7.5 (default) or Clang 9   | OpenJDK 11                    | 3.6    |
-| Ubuntu 20.04 LTS (Focal Fossa)   | 4.2   | 3.16  | GCC 9.3 (default) or Clang 9   | OpenJDK 11                    | 3.8    |
-| macOS Catalina (10.15)           | 4.2   | 3.19  | Apple LLVM 12.0.0 (Xcode 12.4) | AdoptOpenJDK 15 (HotSpot JVM) | 3.9    |
-| macOS Big Sur (11)               | 4.2   | 3.19  | Apple LLVM 12.0.0 (Xcode 12.4) | AdoptOpenJDK 15 (HotSpot JVM) | 3.9    |
-
-CPython is the only Python implementation supported. On Ubuntu, amd64
-(i.e., x86_64) is the only supported architecture. On macOS, x86_64 is the only
-supported architecture and running Drake under Rosetta 2 emulation on arm64 is
-not supported. Plans for any future arm64 support on macOS and/or Ubuntu are
-discussed in [issue #13514](https://github.com/RobotLocomotion/drake/issues/13514).
-
-Drake Ubuntu builds assume support for Intel's AVX2 and FMA instructions,
-introduced with the Haswell architecture in 2013 with substantial performance
-improvements in the Broadwell architecture in 2014. Drake is compiled with
-`-march=broadwell` to exploit these instructions (that also works for Haswell
-machines). Drake can be used on older machines if necessary by building from
-source with that flag removed.
+Refer to [Source Installation](/from_source.html#supported-configurations).
 
 ## Configuration Management Non-Determinism
 
@@ -104,15 +79,6 @@ Homebrew; however, we generally try to stay on top of Bazel versions.
 If you have tried and are unable to configure your system by
 [following the instructions](/from_source.html) please do not hesitate
 to [ask for help](/getting_help.html).
-
-## Binary Packages
-
-The binary releases of Drake are built with GCC 7.5 on Ubuntu 18.04 (Bionic),
-GCC 9.3 on Ubuntu 20.04 (Focal), and Apple LLVM 12.0.0 on macOS Catalina
-(10.15).
-
-The links for these packages are listed in
-[Binary installation](/from_binary.html).
 
 # Issue Tracking
 

--- a/doc/_pages/docker.md
+++ b/doc/_pages/docker.md
@@ -1,21 +1,60 @@
 ---
-title: Using the Drake Docker Images From Docker Hub
+title: Installation via Docker
 ---
 
-Drake's continuous integration has nightly jobs that publish the binary
-archives that are described in the [Nightly releases](/from_binary.html#nightly-releases) section. The Ubuntu
-18.04 (Bionic) binary archive is also used to publish a Docker image on
-[Docker Hub](https://hub.docker.com/r/robotlocomotion/drake). You can see the
-available Docker images here:
+# Docker Hub
 
-[https://hub.docker.com/r/robotlocomotion/drake/tags](https://hub.docker.com/r/robotlocomotion/drake/tags)
+Drake publishes pre-compiled binaries as Docker images on
+[Docker Hub](https://hub.docker.com/r/robotlocomotion/drake). Refer to
+[Supported Configurations](/installation.html#supported-configurations)
+for additional compatibility details.
 
-The [latest](https://hub.docker.com/r/robotlocomotion/drake/tags?name=latest)
-image can be pulled from Docker Hub as follows:
+To learn about other installation methods, refer to
+[Installation and Quickstart](/installation.html).
+
+Drake binary releases incorporate a pre-compiled version of
+[SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the
+[Mathematical Program toolbox](https://drake.mit.edu/doxygen_cxx/group__solvers.html).
+Thanks to Philip E. Gill and Elizabeth Wong for their kind support.
+
+## Stable Releases
+
+The latest stable image can be pulled from
+[Docker Hub](https://hub.docker.com/r/robotlocomotion/drake)
+as follows:
+
+```
+docker pull robotlocomotion/drake:X.Y.Z
+```
+
+Refer to [Release Notes](/release_notes/release_notes.html) for a list of
+published X.Y.Z version numbers.
+
+The docker tags for Drake's stable releases are spelled like:
+
+* ``bionic-X.Y.Z`` for the Ubuntu 18.04 image of Drake vX.Y.Z.
+* ``focal-X.Y.Z`` for the Ubuntu 20.04 image of Drake vX.Y.Z.
+* ``X.Y.Z`` is a synonym for one of the above, currently bionic-X.Y.Z.
+
+Refer to [Quickstart](/installation.html#quickstart) for next steps.
+
+## Nightly Releases
+
+The latest nightly image can be pulled from
+[Docker Hub](https://hub.docker.com/r/robotlocomotion/drake)
+as follows:
 
 ```
 docker pull robotlocomotion/drake:latest
 ```
 
-Docker images based on the Ubuntu 20.04 (Focal) binary archive are not
-available.
+The docker tags for Drake's nightly releases are spelled like:
+
+* ``bionic-YYYYMMDD`` for the Ubuntu 18.04 image of Drake as of date YYYY-MM-DD.
+* ``bionic`` is a synonym for the most recent ``bionic-YYYYMMDD``.
+* ``focal-YYYYMMDD`` for the Ubuntu 20.04 image of Drake as of date YYYY-MM-DD.
+* ``focal`` is a synonym for the most recent ``focal-YYYYMMDD``.
+* ``YYYYMMDD`` is a synonym for one of the above, currently ``bionic-YYYYMMDD``.
+* ``latest`` is a synonym for the most recent ``YYYYMMDD``.
+
+Refer to [Quickstart](/installation.html#quickstart) for next steps.

--- a/doc/_pages/from_binary.md
+++ b/doc/_pages/from_binary.md
@@ -1,111 +1,91 @@
 ---
-title: Binary installation (macOS, Ubuntu)
+title: Installation via Direct Download
 ---
 
-# Nightly Releases
+# Binary Packages
 
-Binary packages of Drake for Ubuntu 18.04 (Bionic), Ubuntu 20.04 (Focal) and
-Mac are generated nightly and are tagged ``latest`` or by ``yyyymmdd``. Latest
-releases are available to download at:
+Drake publishes pre-compiled binaries as binary downloads (``*.tar.gz``)
+for all supported operating systems.  Refer to
+[Supported Configurations](/installation.html#supported-configurations)
+for compatibility details.
 
-* [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-bionic.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-bionic.tar.gz)
-* [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-focal.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-focal.tar.gz)
-* [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-mac.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-mac.tar.gz)
-
-Releases for specific days are available as follows:
-`https://drake-packages.csail.mit.edu/drake/nightly/drake-yyyymmdd-bionic|focal|mac.tar.gz`
-
-For example: [https://drake-packages.csail.mit.edu/drake/nightly/drake-20191026-bionic.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-20191026-bionic.tar.gz)
-
-
-Note that Drake no longer supports Ubuntu 16.04 (Xenial), but older packages are available here:
-
-* [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-xenial.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-xenial.tar.gz)
-* [https://drake-packages.csail.mit.edu/drake/nightly/drake-20191026-xenial.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-20191026-xenial.tar.gz)
-
-Individual packages are archived two years from their date of creation.
-
-Note that for release v0.30.0 and later, Ubuntu binaries require support for
-Intel's AVX2 and FMA instruction sets which were introduced with the Haswell
-architecture in 2013 with substantial performance improvements in the Broadwell
-architecture in 2014. Drake is compiled with `-march=broadwell` to exploit these
-instructions (that also works for Haswell machines). Drake can be used on older
-machines if necessary by building from source with that flag removed.
-
-For the compilers used to produce these releases, see
-[Binary Packages](/developers.html#binary-packages).
+To learn about other installation methods, refer to
+[Installation and Quickstart](/installation.html).
 
 Drake binary releases incorporate a pre-compiled version of
 [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the
 [Mathematical Program toolbox](https://drake.mit.edu/doxygen_cxx/group__solvers.html).
 Thanks to Philip E. Gill and Elizabeth Wong for their kind support.
 
+## Stable Releases
 
-## Example Usage
+Binary packages of Drake for Ubuntu 18.04 (Bionic), Ubuntu 20.04 (Focal) and
+Mac are available to download as attachments from Drake's GitHub
+[releases](https://github.com/RobotLocomotion/drake/releases) page.
 
-An example of how to use the nightly binaries is shown in this
-[example CMake project](https://github.com/RobotLocomotion/drake-external-examples/tree/main/drake_cmake_installed).
+The most recent release is
+[v0.35.0](https://github.com/RobotLocomotion/drake/releases/tag/v0.35.0):
 
-## Binary Installation for Python
+* [https://github.com/RobotLocomotion/drake/releases/download/v0.35.0/drake-20211021-bionic.tar.gz](https://github.com/RobotLocomotion/drake/releases/download/v0.35.0/drake-20211021-bionic.tar.gz)
+* [https://github.com/RobotLocomotion/drake/releases/download/v0.35.0/drake-20211021-focal.tar.gz](https://github.com/RobotLocomotion/drake/releases/download/v0.35.0/drake-20211021-focal.tar.gz)
+* [https://github.com/RobotLocomotion/drake/releases/download/v0.35.0/drake-20211021-mac.tar.gz](https://github.com/RobotLocomotion/drake/releases/download/v0.35.0/drake-20211021-mac.tar.gz)
 
-To use Python bindings, see [Binary Installation for Python](/python_bindings.html#installation).
+### Use as a C++ library
 
-## Docker Images
+For an example of using a Drake ``*.tar.gz`` image from a CMake project, refer
+to the
+[drake_cmake_installed](https://github.com/RobotLocomotion/drake-external-examples/tree/main/drake_cmake_installed)
+example.
 
-You may also use binary releases in Docker images. See
-[Using the Drake Docker Images From Docker Hub](/docker.html)
-for more information.
+### Use as a Python library
 
-## Experimental Packages
+In most cases, we suggest using our [pip releases](/pip.html), because that
+will be more convenient than manually downloading.  However, if you need both
+C++ and Python API support, then pip will not work.  This section shows
+how to incorporate a manual download into a
+[virtual environment](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment)
+directory.  In the example below, we will name that directory ``env``, but you
+can choose any name.
 
-Drake maintainers may build "experimental" packages on demand using Jenkins by
-following [these instructions](/jenkins.html#building-binary-packages-on-demand).
+Download the binary release ``*.tar.gz`` file, using one of the links above.
+In the example below, we'll use ``drake.tar.gz`` to refer to it, but your
+download will have a more version-specific filename.
 
-## Historical Note
+Create and activate the envionment:
 
-Older releases were built around substantial MATLAB support, and are
-described on [release notes page](/release_notes/older_releases.html).
+```bash
+mkdir -p env
+tar -xvzf drake.tar.gz -C env --strip-components=1
+python3 -m virtualenv -p python3 env --system-site-packages
+source env/bin/activate
+```
 
-# APT Packages for Monthly Tagged Releases
+Install dependencies within the environment:
 
-APT packages are currently available for the Ubuntu 18.04 (Bionic) and
-Ubuntu 20.04 (Focal) operating systems on x86 64-bit architectures.
+```bash
+env/share/drake/setup/install_prereqs
+````
 
-## To Install the Packages
+(On Ubuntu, the script might ask to be run under ``sudo``.)
 
-To add the Drake APT repository to your machine and install the `drake-dev` package,
-please do the following in order:
+Refer to [Quickstart](/installation.html#quickstart) for next steps.
 
-1. If you are using a [minimal](https://wiki.ubuntu.com/Minimal) cloud or
-   container image, you may need to install the following packages:
-   ```bash
-   sudo apt-get update
-   sudo apt-get install --no-install-recommends \
-     ca-certificates gnupg lsb-release wget
-   ```
+## Nightly Releases
 
-2. Download a copy of the Drake GPG signing key and add it to an APT trusted keychain:
-   ```bash
-   wget -qO- https://drake-apt.csail.mit.edu/drake.asc | gpg --dearmor - \
-     | sudo tee /etc/apt/trusted.gpg.d/drake.gpg >/dev/null
-   ```
+Binary packages of Drake for Ubuntu 18.04 (Bionic), Ubuntu 20.04 (Focal) and
+Mac are generated nightly and are available to download at:
 
-3. Add the Drake repository to your APT sources list:
-   ```bash
-   echo "deb [arch=amd64] https://drake-apt.csail.mit.edu/$(lsb_release -cs) $(lsb_release -cs) main" \
-     | sudo tee /etc/apt/sources.list.d/drake.list >/dev/null
-   ```
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-bionic.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-bionic.tar.gz)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-focal.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-focal.tar.gz)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-mac.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-mac.tar.gz)
 
-4. Update your local APT package index and install the `drake-dev` package:
-   ```bash
-   sudo apt-get update
-   sudo apt-get install --no-install-recommends drake-dev
-   ```
+Older packages for specific dates are available by replacing ``latest`` with an
+8-digit date, e.g., ``20200102`` for January 2nd, 2020.
 
-Most content installs to `/opt/drake`, so setting the following environment
-variables may be useful:
-  ```bash
-  export LD_LIBRARY_PATH="/opt/drake/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
-  export PATH="/opt/drake/bin${PATH:+:${PATH}}"
-  export PYTHONPATH="/opt/drake/lib/python$(python3 -c 'import sys; print("{0}.{1}".format(*sys.version_info))')/site-packages${PYTHONPATH:+:${PYTHONPATH}}"
-  ```
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-YYYYMMDD-bionic.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-YYYYMMDD-bionic.tar.gz)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-YYYYMMDD-focal.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-YYYYMMDD-focal.tar.gz)
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-YYYYMMDD-mac.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-YYYYMMDD-mac.tar.gz)
+
+Individual packages are archived two years from their date of creation.
+
+The installation instructions are identical to stable releases as shown above.

--- a/doc/_pages/from_source.md
+++ b/doc/_pages/from_source.md
@@ -1,6 +1,38 @@
 ---
-title: Source installation (macOS, Ubuntu)
+title: Source Installation
 ---
+
+# Supported Configurations
+
+The following table shows the configurations and platforms that Drake
+officially supports. Supported configurations are tested in continuous
+integration. Any other configurations are provided on a best-effort basis.
+
+| Operating System ⁽⁴⁾             | Architecture | Python  | Bazel | CMake | C/C++ Compiler ⁽⁵⁾                 | Java                          |
+|----------------------------------|--------------|---------|-------|-------|------------------------------------|-------------------------------|
+| Ubuntu 18.04 LTS (Bionic Beaver) | x86_64 ⁽¹⁾   | 3.6 ⁽³⁾ | 4.2   | 3.10  | GCC 7.5 (default) or Clang 9   | OpenJDK 11                    |
+| Ubuntu 20.04 LTS (Focal Fossa)   | x86_64 ⁽¹⁾   | 3.8 ⁽³⁾ | 4.2   | 3.16  | GCC 9.3 (default) or Clang 9   | OpenJDK 11                    |
+| macOS Catalina (10.15)           | x86_64 ⁽²⁾   | 3.9 ⁽³⁾ | 4.2   | 3.19  | Apple LLVM 12.0.0 (Xcode 12.4) | AdoptOpenJDK 15 (HotSpot JVM) |
+| macOS Big Sur (11)               | x86_64 ⁽²⁾   | 3.9 ⁽³⁾ | 4.2   | 3.19  | Apple LLVM 12.0.0 (Xcode 12.4) | AdoptOpenJDK 15 (HotSpot JVM) |
+
+⁽¹⁾ Drake Ubuntu builds assume support for Intel's AVX2 and FMA instructions,
+introduced with the Haswell architecture in 2013 with substantial performance
+improvements in the Broadwell architecture in 2014. Drake is compiled with
+`-march=broadwell` to exploit these instructions (that also works for Haswell
+machines). Drake can be used on older machines if necessary by building from
+source with that flag removed.
+
+⁽²⁾ Running Drake under Rosetta 2 emulation on arm64 is not supported. Plans
+for any future arm64 support on macOS and/or Ubuntu are discussed in
+[issue #13514](https://github.com/RobotLocomotion/drake/issues/13514).
+
+⁽³⁾ CPython is the only Python implementation supported.
+
+⁽⁴⁾ Drake features that perform image rendering (e.g., camera simulation)
+require a working display server.  Most personal computers will have this
+already built in, but some cloud or docker environments may not.
+
+⁽⁵⁾ Drake requires a compiler running in C++17 or C++20 mode.
 
 # Getting Drake
 
@@ -43,7 +75,7 @@ setup steps:
 * [macOS](/mac.html)
 * [Ubuntu](/ubuntu.html)
 
-See [supported configurations](/developers.html#supported-configurations)
+See [above](#supported-configurations)
 for the configurations and platforms that Drake officially supports.
 All else being equal, we would recommend developers use Ubuntu Bionic.
 
@@ -54,7 +86,51 @@ full details at:
 
 * [Bazel build system](/bazel.html)
 
-# Historical Note
+## Building the Python Bindings
 
-Older releases were built around substantial MATLAB support, and are
-described on [this release notes page](/release_notes/older_releases.html).
+To use the Python bindings from Drake externally, we recommend using CMake.
+As an example:
+
+```bash
+git clone https://github.com/RobotLocomotion/drake.git
+mkdir drake-build
+cd drake-build
+cmake ../drake
+make -j
+```
+
+Please note the additional CMake options which affect the Python bindings:
+
+* ``-DWITH_GUROBI={ON, [OFF]}`` - Build with Gurobi enabled.
+* ``-DWITH_MOSEK={ON, [OFF]}`` - Build with MOSEK enabled.
+* ``-DWITH_SNOPT={ON, [OFF]}`` - Build with SNOPT enabled.
+
+``{...}`` means a list of options, and the option surrounded by ``[...]`` is
+the default option. An example of building ``pydrake`` with both Gurobi and
+MOSEK, without building tests:
+
+```bash
+cmake -DWITH_GUROBI=ON -DWITH_MOSEK=ON ../drake
+```
+
+You will also need to have your ``PYTHONPATH`` configured correctly.
+
+*Ubuntu 18.04 (Bionic):*
+
+```bash
+cd drake-build
+export PYTHONPATH=${PWD}/install/lib/python3.6/site-packages:${PYTHONPATH}
+```
+
+*Ubuntu 20.04 (Focal):*
+
+```bash
+cd drake-build
+export PYTHONPATH=${PWD}/install/lib/python3.8/site-packages:${PYTHONPATH}
+```
+*macOS:*
+
+```bash
+cd drake-build
+export PYTHONPATH=${PWD}/install/lib/python3.9/site-packages:${PYTHONPATH}
+```

--- a/doc/_pages/installation.md
+++ b/doc/_pages/installation.md
@@ -4,19 +4,97 @@ title: Installation and Quickstart
 
 # Previewing
 
-Before installing, you can preview the Python functionality of Drake by using
-Binder: <br/>
-<a target="_doc" href="https://mybinder.org/v2/gh/RobotLocomotion/drake/nightly-release-binder?urlpath=/tree/tutorials">
-  <img src="https://mybinder.org/badge_logo.svg"/>
-</a> <br/>
-As you are exploring, you should also review
-[What's Available from Python](/python_bindings.html#whats-available-from-python).
+Before installing, you can preview Drake online using our interactive Python
+notebooks. See the [Tutorials](/index.html#tutorials) page for details.
 
-# Choose an installation method
+# Installation
 
-You can choose to download a pre-compiled version of Drake, or to build it from source. The pre-compiled versions are much easier to use, but the source version is easier to update and will make it easier for you to contribute your fixes/improvements.
+## Supported Configurations
 
-* [Binary installation (macOS, Ubuntu)](/from_binary.html)  
-* [Source installation (macOS, Ubuntu)](/from_source.html)  
-* [Using the Drake Docker Images From Docker Hub](/docker.html)  
-* [Release Notes](/release_notes/release_notes.html)
+The following table shows the configurations and platforms that Drake
+officially supports:
+
+| Operating System ⁽⁴⁾             | Architecture | Python  |
+|----------------------------------|--------------|---------|
+| Ubuntu 18.04 LTS (Bionic Beaver) | x86_64 ⁽¹⁾   | 3.6 ⁽³⁾ |
+| Ubuntu 20.04 LTS (Focal Fossa)   | x86_64 ⁽¹⁾   | 3.8 ⁽³⁾ |
+| macOS Catalina (10.15)           | x86_64 ⁽²⁾   | 3.9 ⁽³⁾ |
+| macOS Big Sur (11)               | x86_64 ⁽²⁾   | 3.9 ⁽³⁾ |
+
+⁽¹⁾ Drake Ubuntu builds assume support for Intel's AVX2 and FMA instructions,
+introduced with the Haswell architecture in 2013 with substantial performance
+improvements in the Broadwell architecture in 2014. Drake is compiled with
+`-march=broadwell` to exploit these instructions (that also works for Haswell
+machines). Drake can be used on older machines if necessary by building from
+source with that flag removed.
+
+⁽²⁾ Running Drake under Rosetta 2 emulation on arm64 is not supported. Plans
+for any future arm64 support on macOS and/or Ubuntu are discussed in
+[issue #13514](https://github.com/RobotLocomotion/drake/issues/13514).
+
+⁽³⁾ CPython is the only Python implementation supported.
+
+⁽⁴⁾ Drake features that perform image rendering (e.g., camera simulation)
+require a working display server.  Most personal computers will have this
+already built in, but some cloud or docker environments may not.
+
+Additionally, if you compiling your own C++ code against Drake's C++ code
+and are using Drake's pre-compiled binaries, then you must use the same
+compiler as our releases:
+
+| Operating System                 | C/C++ Compiler                 |
+|----------------------------------|--------------------------------|
+| Ubuntu 18.04 LTS (Bionic Beaver) | GCC 7.5                        |
+| Ubuntu 20.04 LTS (Focal Fossa)   | GCC 9.3                        |
+| macOS Catalina (10.15)           | Apple LLVM 12.0.0 (Xcode 12.4) |
+| macOS Big Sur (11)               | Apple LLVM 12.0.0 (Xcode 12.4) |
+
+## Available Versions
+
+Drake publishes stable releases approximately once a month, and also
+offers nightly builds on an ongoing basis.
+
+For new users, we recommend using the stable releases.  New releases
+will be announced on Drake's GitHub
+[releases](https://github.com/RobotLocomotion/drake/releases) page and
+documented in Drake's [Release Notes](/release_notes/release_notes.html).
+
+Experienced users who want access to the latest features may use the
+nightly builds.
+
+## Choose an Installation Method
+
+The following table shows the installation methods available for Drake's
+pre-compiled binaries, per the supported platforms and release versions.
+
+The pip packages only support using Drake via Python.
+All other packages support both C++ and/or Python.
+
+|                       | Ubuntu | macOS |
+|-----------------------|--------|-------|
+| Using pip             | [Stable](/pip.html#stable-releases) ⁽¹⁾ | |
+| Using apt (deb)       | [Stable](/apt.html#stable-releases) | |
+| Using tar.gz download | [Stable](/from_binary.html#stable-releases) or [Nightly](/from_binary.html#nightly-releases) | [Stable](/from_binary.html#stable-releases) or [Nightly](/from_binary.html#nightly-releases) |
+| Using Docker Hub      | [Stable](/docker.html#stable-releases) or [Nightly](/docker.html#nightly-releases) | [Stable](/docker.html#stable-releases) or [Nightly](/docker.html#nightly-releases) |
+
+⁽¹⁾ For the moment, we only support ``pip install drake`` for Ubuntu 18.04 LTS
+(Bionic Beaver), not Ubuntu 20.04 LTS (Focal Fossa).  Subscribe to
+[#15959](https://github.com/RobotLocomotion/drake/issues/15959) for updates.
+
+Alternatively, you can skip the pre-compiled binaries and
+[build Drake from source](/from_source.html).
+
+We're considering adding macOS support for Homebrew, i.e., ``brew install
+drake``.  Please upvote or comment on
+[#12782](https://github.com/RobotLocomotion/drake/issues/12782)
+if you are interested.
+
+# Quickstart
+
+For Python, refer to
+[Using the Python Bindings](/python_bindings.html#using-the-python-bindings).
+
+For C++, refer to either the
+[example CMake project for apt (deb)](https://github.com/RobotLocomotion/drake-external-examples/tree/main/drake_cmake_installed_apt)
+or the
+[example CMake project for tar.gz download](https://github.com/RobotLocomotion/drake-external-examples/tree/main/drake_cmake_installed).

--- a/doc/_pages/jenkins.md
+++ b/doc/_pages/jenkins.md
@@ -84,7 +84,7 @@ Installation prerequisites are packages that are not pulled in Bazel, but
 instead installed on the OS itself using a package manager like ``apt``,
 Homebrew, or ``pip`` (only on Mac). They are installed via the scripts under
 ``setup/``, and are split between ``binary_distribution`` (dependencies that
-are necessary for [binary installation](/from_binary.html)) and
+are necessary for [binary installation](/installation.html)) and
 ``source_distribution`` (dependencies, in addition to those in
 ``binary_distribution``, necessary for
 [source installation](/from_source.html)). Since

--- a/doc/_pages/mac.md
+++ b/doc/_pages/mac.md
@@ -12,5 +12,5 @@ Prerequisite setup is otherwise automated. Simply run:
 ./setup/mac/install_prereqs.sh
 ```
 
-After running the script, return to [Source installation (macOS, Ubuntu)](/from_source.html) to complete and test your
+After running the script, return to [Source installation](/from_source.html) to complete and test your
 installation.

--- a/doc/_pages/pip.md
+++ b/doc/_pages/pip.md
@@ -1,0 +1,70 @@
+---
+title: Installation via Pip
+---
+
+# Pip Packages
+
+Drake publishes pre-compiled binaries as
+[PyPI wheel packages](https://pypi.org/project/drake/).  Refer to
+[Supported Configurations](/installation.html#supported-configurations)
+for additional compatibility details.
+
+To learn about other installation methods, refer to
+[Installation and Quickstart](/installation.html).
+
+<!--
+TODO(#15961) The wheels do not yet incorporate SNOPT.
+Once they do, we should uncomment this paragraph:
+
+Drake binary releases incorporate a pre-compiled version of
+[SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the
+[Mathematical Program toolbox](https://drake.mit.edu/doxygen_cxx/group__solvers.html).
+Thanks to Philip E. Gill and Elizabeth Wong for their kind support.
+-->
+
+## Stable Releases
+
+<div class="warning" markdown="1">
+Drake's support for pip has only just recently been introduced (as of October
+2021), so still has some known issues (see
+[issue #15954](https://github.com/RobotLocomotion/drake/issues/15954)).
+Please [let us know](/getting_help.html) if you
+experience any additional problems. To fall back to other installation methods
+in the meantime, refer to [Installation and Quickstart](/installation.html)
+for more choices.
+</div>
+
+<div class="warning" markdown="1">
+Drake's pip wheels are only published for CPython 3.6 and CPython 3.7 running
+on Linux.  In the future, we intend to publish additional builds.
+</div>
+
+We recommend installing drake into a
+[virtual environment](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment)
+directory.  In the example below, we will name that directory ``env``, but you
+can choose any name.
+
+Create a virtual environment and install Drake:
+
+```bash
+python3 -m venv env
+env/bin/pip install --upgrade pip
+env/bin/pip install drake
+```
+
+Drake requires certain basic runtime libraries from the host linux distribution.
+
+For Ubuntu 18.04, install these additional libraries:
+
+```bash
+sudo apt-get install --no-install-recommends \
+  libpython3.6 python3-tk libx11-6 libsm6 libxt6 libglib2.0-0
+```
+
+Activate the virtual environment:
+
+```bash
+source env/bin/activate
+````
+
+Refer to [Quickstart](/installation.html#quickstart) for next steps.

--- a/doc/_pages/python_bindings.md
+++ b/doc/_pages/python_bindings.md
@@ -6,7 +6,7 @@ layout: page_with_toc
 {% include toc.md %}
 <article class="markdown-body" markdown="1">
 
-# Installation
+# Background
 
 A substantial subset of the Drake C++ functionality is available from Python.
 The Drake Python bindings are generated using [pybind11](https://github.com/pybind/pybind11),
@@ -16,135 +16,16 @@ source files inside the ``bindings/pydrake`` folder. These bindings are
 installed as a single package called ``pydrake``.
 
 <div class="warning" markdown="1">
-Drake is incompatible with the Python environment supplied by Anaconda. Please
+Drake does not support the Python environment supplied by Anaconda.
+To use our supported workflow, please
 uninstall Anaconda or remove the Anaconda bin directory from the `PATH` before
 building or using the Drake Python bindings.
 </div>
 
-Before attempting installation, please review the
-[supported configurations](/developers.html#supported-configurations) to know what
-versions of Python are supported for your platform.
+# Installation
 
-## Binary Installation for Python
-
-First, download and extract an [available binary package](/from_binary.html).
-
-As an example, here is how to download and extract one of the latest releases
-to ``/opt`` (where ``<platform>`` could be ``bionic``, ``focal``, or ``mac``):
-
-```bash
-curl -o drake.tar.gz https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-<platform>.tar.gz
-rm -rf /opt/drake
-tar -xvzf drake.tar.gz -C /opt
-```
-
-Ensure that you have the system dependencies:
-
-```bash
-/opt/drake/share/drake/setup/install_prereqs
-```
-
-Next, ensure that your ``PYTHONPATH`` is properly configured.
-
-*Ubuntu 18.04 (Bionic):*
-
-```bash
-export PYTHONPATH=/opt/drake/lib/python3.6/site-packages:${PYTHONPATH}
-```
-
-*Ubuntu 20.04 (Focal):*
-
-```bash
- export PYTHONPATH=/opt/drake/lib/python3.8/site-packages:${PYTHONPATH}
-```
-
-*macOS:*
-
-```bash
- export PYTHONPATH=/opt/drake/lib/python3.9/site-packages:${PYTHONPATH}
-```
-
-See [below](#using-the-python-bindings) for usage instructions.
-
-## Inside ``virtualenv``
-
-At present, Drake is not installable via ``pip``. However, you can still
-incorporate its install tree into a ``virtualenv``
-[FHS](https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard)-like
-environment.
-
-An example, where you should replace ``<venv_path>`` and ``<platform>``:
-
-```bash
-# Setup drake, and run prerequisites.
-curl -o drake.tar.gz https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-<platform>.tar.gz
-mkdir -p <venv_path>
-tar -xvzf drake.tar.gz -C <venv_path> --strip-components=1
-# - You may need `sudo` here.
-<venv_path>/share/drake/setup/install_prereqs
-
-# Setup a virtualenv over the drake install.
-python3 -m virtualenv -p python3 <venv_path> --system-site-packages
-```
-
-<div class="note" markdown="1">
-You can extract Drake into an existing `virtualenv` tree if you have already run `install_prereqs`; however, you should ensure that you have run `install_prereqs`. Before you do this, you should capture / freeze your current requirements to reproduce your environment if there are conflicts.
-</div>
-
-To check if this worked, follow the instructions as
-[shown below](#using-the-python-bindings), but either:
-
-* Use ``<venv_path>/bin/python`` instead of ``python3``, or
-* Source ``<venv_path>/bin/activate`` in your current shell session.
-
-## Building the Python Bindings
-
-To use the Python bindings from Drake externally, we recommend using CMake.
-As an example:
-
-```bash
-git clone https://github.com/RobotLocomotion/drake.git
-mkdir drake-build
-cd drake-build
-cmake ../drake
-make -j
-```
-
-Please note the additional CMake options which affect the Python bindings:
-
-* ``-DWITH_GUROBI={ON, [OFF]}`` - Build with Gurobi enabled.
-* ``-DWITH_MOSEK={ON, [OFF]}`` - Build with MOSEK enabled.
-* ``-DWITH_SNOPT={ON, [OFF]}`` - Build with SNOPT enabled.
-
-``{...}`` means a list of options, and the option surrounded by ``[...]`` is
-the default option. An example of building ``pydrake`` with both Gurobi and
-MOSEK, without building tests:
-
-```bash
-cmake -DWITH_GUROBI=ON -DWITH_MOSEK=ON ../drake
-```
-
-You will also need to have your ``PYTHONPATH`` configured correctly.
-
-*Ubuntu 18.04 (Bionic):*
-
-```bash
-cd drake-build
-export PYTHONPATH=${PWD}/install/lib/python3.6/site-packages:${PYTHONPATH}
-```
-
-*Ubuntu 20.04 (Focal):*
-
-```bash
-cd drake-build
-export PYTHONPATH=${PWD}/install/lib/python3.8/site-packages:${PYTHONPATH}
-```
-*macOS:*
-
-```bash
-cd drake-build
-export PYTHONPATH=${PWD}/install/lib/python3.9/site-packages:${PYTHONPATH}
-```
+Refer to [Installation](/installation.html) for how to install Drake's
+stable releases using pip.
 
 # Using the Python Bindings
 
@@ -158,7 +39,7 @@ python3 -c 'import pydrake.all; print(pydrake.__file__)'
 ```
 
 <div class="note" markdown="1">
-If you are using Gurobi, you must either have it installed in the suggested location under `/opt/...`> mentioned in Gurobi 9.0.2, or you must ensure that you define the `${GUROBI_HOME}` environment variable, or specify `${GUROBI_INCLUDE_DIR}` via CMake.
+If you are using Gurobi, you must either have it installed in the suggested location under `/opt/...` mentioned in Gurobi 9.0.2, or you must ensure that you define the `${GUROBI_HOME}` environment variable, or specify `${GUROBI_INCLUDE_DIR}` via CMake.
 </div>
 
 
@@ -167,7 +48,8 @@ If you are using Gurobi, you must either have it installed in the suggested loca
 You should first browse the [Python API](https://drake.mit.edu/pydrake/index.html) to see what
 modules are available. The most up-to-date high-level demonstrations of what
 can be done using ``pydrake`` are in Drake's [Tutorials](/index.html#tutorials) and
-the [Underactuated Robotics Textbook](http://underactuated.mit.edu/).
+the [Underactuated Robotics Textbook](http://underactuated.mit.edu/) and
+the [Robotic Manipulation Textbook](https://manipulation.mit.edu/).
 
 You can also see lower-level usages of the API in the ``pydrake`` unit tests
 themselves, which you can find inside of the

--- a/doc/_pages/release_playbook.md
+++ b/doc/_pages/release_playbook.md
@@ -129,6 +129,8 @@ the main body of the document:
     ``newest_commit`` whose changes are enumerated in the notes.  Some dates
     are YYYYMMDD format, some are YYYY-MM-DD format; be sure to manually fix
     them all.
+   1. Update the github links within doc/_pages/from_binary.md to reflect the
+      upcoming v0.N.0 and YYYYMMDD.
 11. Merge the release notes PR
    1. After merge, go to <https://drake-jenkins.csail.mit.edu/view/Documentation/job/linux-bionic-unprovisioned-gcc-bazel-nightly-documentation/> and push "Build now".
       * If you don't have "Build now" click "Log in" first in upper right.

--- a/doc/_release-notes/2015.md
+++ b/doc/_release-notes/2015.md
@@ -1,6 +1,6 @@
 ---
-title: Using older (2015) releases
-released: in 2015
+title: Using older (MATLAB 2015) releases
+released: in 2015 or earlier
 ---
 
 We cannot offer support for older releases, but we still host the binaries for

--- a/doc/_release-notes/2016.md
+++ b/doc/_release-notes/2016.md
@@ -1,0 +1,11 @@
+---
+title: Using older (Ubuntu 16.04) releases
+released: for Ubuntu 16.04
+---
+
+We cannot offer support for older releases, but we still host the binaries
+for reference.
+
+The last published package for Ubuntu 16.04 (Xenial) is available here:
+
+* [https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-xenial.tar.gz](https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-xenial.tar.gz)

--- a/doc/_release-notes/template.txt
+++ b/doc/_release-notes/template.txt
@@ -107,7 +107,7 @@ Newly bound
 
 
 This release provides [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/{version}) named
-``drake-YYYYMMDD-{{bionic|focal|mac}}.tar.gz``. See [Nightly Releases](/from_binary.html#nightly-releases) for instructions on how to use them.
+``drake-YYYYMMDD-{{bionic|focal|mac}}.tar.gz``. See [Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the
 [Mathematical Program toolbox](https://drake.mit.edu/doxygen_cxx/group__solvers.html). Thanks to

--- a/doc/_release-notes/v0.10.0.md
+++ b/doc/_release-notes/v0.10.0.md
@@ -12,13 +12,13 @@ Some of the more recent or substantial changes include:
 * Added [MultibodyPlant dynamics](https://drake.mit.edu/doxygen_cxx/group__multibody.html) (RigidBodyPlant is no longer actively maintained).
 * Added camera and depth simulation (RgbdSensor) and geometric queries (SceneGraph).
 * Reworked examples.
-* Supports Ubuntu 16, Ubuntu 18, and macOS (see [Supported Configurations](/developers.html#supported-configurations) documentation for details).
+* Supports Ubuntu 16, Ubuntu 18, and macOS (see [Installation](/installation.html) documentation for details).
 * Removed support for MATLAB; removed support for Windows.
 
 This release provides
 [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/v0.10.0)
 named ``drake-20190905-{bionic|xenial|mac}.tar.gz``. See
-[Nightly Releases](/from_binary.html#nightly-releases) for instructions on how to use them.
+[Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of
 [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the

--- a/doc/_release-notes/v0.11.0.md
+++ b/doc/_release-notes/v0.11.0.md
@@ -89,7 +89,7 @@ Removal of deprecated APIs
 
 This release provides [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/v0.11.0)
 named ``drake-20191002-{bionic|xenial|mac}.tar.gz``. See
-[Nightly Releases](/from_binary.html#nightly-releases) for instructions on how to use them.
+[Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/)  as part of the [Mathematical Program toolbox](https://drake.mit.edu/doxygen_cxx/group__solvers.html). Thanks to Philip E. Gill and Elizabeth Wong for their kind support.
 

--- a/doc/_release-notes/v0.12.0.md
+++ b/doc/_release-notes/v0.12.0.md
@@ -263,7 +263,7 @@ New hydroelastic contact model in progress ([#12102][_#12102], [#12114][_#12114]
 This release provides
 [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/v0.12.0)
 named ``drake-20191108-{bionic|mac}.tar.gz``. See
-[Nightly Releases](/from_binary.html#nightly-releases) for instructions on how to use them.
+[Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the [Mathematical Program toolbox](https://drake.mit.edu/doxygen_cxx/group__solvers.html). Thanks to Philip E. Gill and Elizabeth Wong for their kind support.
 

--- a/doc/_release-notes/v0.13.0.md
+++ b/doc/_release-notes/v0.13.0.md
@@ -196,7 +196,7 @@ Newly bound
 This release provides
 [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/v0.13.0)
 named ``drake-20191217-{bionic|mac}.tar.gz``. See
-[Nightly Releases](/from_binary.html#nightly-releases) for instructions on how to use them.
+[Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of
 [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the

--- a/doc/_release-notes/v0.14.0.md
+++ b/doc/_release-notes/v0.14.0.md
@@ -228,7 +228,7 @@ Newly bound
 This release provides
 [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/v0.14.0)
 named ``drake-20200116-{bionic|mac}.tar.gz``. See
-[Nightly Releases](/from_binary.html#nightly-releases) for instructions on how to use them.
+[Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of
 [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the

--- a/doc/_release-notes/v0.15.0.md
+++ b/doc/_release-notes/v0.15.0.md
@@ -178,7 +178,7 @@ Fixes
 This release provides
 [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/v0.15.0)
 named ``drake-20200212-{bionic|mac}.tar.gz``. See
-[Nightly Releases](/from_binary.html#nightly-releases) for instructions on how to use them.
+[Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of
 [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the

--- a/doc/_release-notes/v0.16.0.md
+++ b/doc/_release-notes/v0.16.0.md
@@ -145,7 +145,7 @@ Fixes
 This release provides
 [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/v0.16.0)
 named ``drake-20200311-{bionic|mac}.tar.gz``. See
-[Nightly Releases](/from_binary.html#nightly-releases) for instructions on how to use them.
+[Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of
 [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the

--- a/doc/_release-notes/v0.16.1.md
+++ b/doc/_release-notes/v0.16.1.md
@@ -13,7 +13,7 @@ released: 2020-03-12
 This release provides
 [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/v0.16.1)
 named ``drake-20200312-{bionic|mac}.tar.gz``. See 
-[Nightly Releases](/from_binary.html#nightly-releases) for instructions on how to use them.
+[Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of
 [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the

--- a/doc/_release-notes/v0.17.0.md
+++ b/doc/_release-notes/v0.17.0.md
@@ -267,7 +267,7 @@ Fixes
 This release provides
 [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/v0.17.0)
 named ``drake-20200421-{bionic|mac}.tar.gz``. See
-[Nightly Releases](/from_binary.html#nightly-releases) for instructions on how to use them.
+[Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of
 [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the

--- a/doc/_release-notes/v0.18.0.md
+++ b/doc/_release-notes/v0.18.0.md
@@ -189,7 +189,7 @@ Fixes
 This release provides
 [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/v0.18.0)
 name ``drake-20200514-{bionic|mac}.tar.gz``. See
-[Nightly Releases](/from_binary.html#nightly-releases) for instructions on how to use them.
+[Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of
 [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the

--- a/doc/_release-notes/v0.19.0.md
+++ b/doc/_release-notes/v0.19.0.md
@@ -370,7 +370,7 @@ timeline, and let us know if this will cause a problem.
 This release provides
 [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/v0.19.0)
 named ``drake-20200615-{bionic|focal|mac}.tar.gz``. See
-[Nightly Releases](/from_binary.html#nightly-releases) for instructions on how to use them.
+[Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of
 [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/)

--- a/doc/_release-notes/v0.20.0.md
+++ b/doc/_release-notes/v0.20.0.md
@@ -177,7 +177,7 @@ Newly bound
 This release provides
 [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/v0.20.0)
 named ``drake-20200717-{bionic|focal|mac}.tar.gz``. See
-[Nightly Releases](/from_binary.html#nightly-releases) for instructions on how to use them.
+[Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of
 [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the

--- a/doc/_release-notes/v0.21.0.md
+++ b/doc/_release-notes/v0.21.0.md
@@ -81,7 +81,7 @@ No changes.
 This release provides
 [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/v0.21.0)
 named ``drake-20200723-{bionic|focal|mac}.tar.gz``. See
-[Nightly Releases](/from_binary.html#nightly-releases) for instructions on how to use them.
+[Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of
 [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the

--- a/doc/_release-notes/v0.22.0.md
+++ b/doc/_release-notes/v0.22.0.md
@@ -136,7 +136,7 @@ Newly bound
 This release provides
 [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/v0.22.0)
 named ``drake-20200817-{bionic|focal|mac}.tar.gz``. See
-[Nightly Releases](/from_binary.html#nightly-releases) for instructions on how to use them.
+[Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of
 [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the

--- a/doc/_release-notes/v0.23.0.md
+++ b/doc/_release-notes/v0.23.0.md
@@ -206,7 +206,7 @@ Newly bound
 This release provides
 [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/v0.23.0)
 named ``drake-20200913-{bionic|focal|mac}.tar.gz``. See
-[Nightly Releases](/from_binary.html#nightly-releases) for instructions on how to use them.
+[Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of
 [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the

--- a/doc/_release-notes/v0.24.0.md
+++ b/doc/_release-notes/v0.24.0.md
@@ -320,7 +320,7 @@ Newly bound
 # Notes
 
 This release provides [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/v0.24.0) named
-``drake-20201026-{bionic|focal|mac}.tar.gz``. See [Nightly Releases](/from_binary.html#nightly-releases) for instructions on how to use them.
+``drake-20201026-{bionic|focal|mac}.tar.gz``. See [Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the
 [Mathematical Program toolbox](https://drake.mit.edu/doxygen_cxx/group__solvers.html). Thanks to

--- a/doc/_release-notes/v0.25.0.md
+++ b/doc/_release-notes/v0.25.0.md
@@ -324,7 +324,7 @@ Models
 This release provides
 [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/v0.25.0)
 named ``drake-20201215-{bionic|focal|mac}.tar.gz``. See
-[Nightly Releases](/from_binary.html#nightly-releases) for instructions on how to use them.
+[Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of
 [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the

--- a/doc/_release-notes/v0.26.0.md
+++ b/doc/_release-notes/v0.26.0.md
@@ -138,7 +138,7 @@ Changes specific to Ubuntu:
 # Notes
 
 This release provides [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/v0.24.0) named
-``drake-20210121-{bionic|focal|mac}.tar.gz``. See [Nightly Releases](/from_binary.html#nightly-releases) for instructions on how to use them.
+``drake-20210121-{bionic|focal|mac}.tar.gz``. See [Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the
 [Mathematical Program toolbox](https://drake.mit.edu/doxygen_cxx/group__solvers.html). Thanks to

--- a/doc/_release-notes/v0.27.0.md
+++ b/doc/_release-notes/v0.27.0.md
@@ -153,7 +153,7 @@ C++
 # Notes
 
 This release provides [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/v0.27.0) named
-``drake-20210216-{bionic|focal|mac}.tar.gz``. See [Nightly Releases](/from_binary.html#nightly-releases) for instructions on how to use them.
+``drake-20210216-{bionic|focal|mac}.tar.gz``. See [Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the
 [Mathematical Program toolbox](https://drake.mit.edu/doxygen_cxx/group__solvers.html). Thanks to

--- a/doc/_release-notes/v0.28.0.md
+++ b/doc/_release-notes/v0.28.0.md
@@ -130,7 +130,7 @@ Newly bound
 
 
 This release provides [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/v0.28.0) named
-``drake-20210315-{bionic|focal|mac}.tar.gz``. See [Nightly Releases](/from_binary.html#nightly-releases) for instructions on how to use them.
+``drake-20210315-{bionic|focal|mac}.tar.gz``. See [Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the
 [Mathematical Program toolbox](https://drake.mit.edu/doxygen_cxx/group__solvers.html). Thanks to

--- a/doc/_release-notes/v0.29.0.md
+++ b/doc/_release-notes/v0.29.0.md
@@ -204,7 +204,7 @@ Newly bound
 # Notes
 
 This release provides [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/v0.29.0) named
-``drake-20210418-{bionic|focal|mac}.tar.gz``. See [Nightly Releases](/from_binary.html#nightly-releases) for instructions on how to use them.
+``drake-20210418-{bionic|focal|mac}.tar.gz``. See [Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the
 [Mathematical Program toolbox](https://drake.mit.edu/doxygen_cxx/group__solvers.html). Thanks to

--- a/doc/_release-notes/v0.30.0.md
+++ b/doc/_release-notes/v0.30.0.md
@@ -157,7 +157,7 @@ Newly bound
 # Notes
 
 This release provides [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/v0.30.0) named
-``drake-20210517-{bionic|focal|mac}.tar.gz``. See [Nightly Releases](/from_binary.html#nightly-releases) for instructions on how to use them.
+``drake-20210517-{bionic|focal|mac}.tar.gz``. See [Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the
 [Mathematical Program toolbox](https://drake.mit.edu/doxygen_cxx/group__solvers.html). Thanks to

--- a/doc/_release-notes/v0.31.0.md
+++ b/doc/_release-notes/v0.31.0.md
@@ -192,7 +192,7 @@ Newly bound
 
 
 This release provides [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/v0.31.0) named
-``drake-20210623-{bionic|focal|mac}.tar.gz``. See [Nightly Releases](/from_binary.html#nightly-releases) for instructions on how to use them.
+``drake-20210623-{bionic|focal|mac}.tar.gz``. See [Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the
 [Mathematical Program toolbox](https://drake.mit.edu/doxygen_cxx/group__solvers.html). Thanks to

--- a/doc/_release-notes/v0.32.0.md
+++ b/doc/_release-notes/v0.32.0.md
@@ -187,7 +187,7 @@ Newly bound
 
 
 This release provides [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/v0.32.0) named
-``drake-20210714-{bionic|focal|mac}.tar.gz``. See [Nightly Releases](/from_binary.html#nightly-releases) for instructions on how to use them.
+``drake-20210714-{bionic|focal|mac}.tar.gz``. See [Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the
 [Mathematical Program toolbox](https://drake.mit.edu/doxygen_cxx/group__solvers.html). Thanks to

--- a/doc/_release-notes/v0.33.0.md
+++ b/doc/_release-notes/v0.33.0.md
@@ -208,7 +208,7 @@ Newly bound
 # Notes
 
 This release provides [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/v0.33.0) named
-``drake-20210811-{bionic|focal|mac}.tar.gz``. See [Nightly Releases](/from_binary.html#nightly-releases) for instructions on how to use them.
+``drake-20210811-{bionic|focal|mac}.tar.gz``. See [Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the
 [Mathematical Program toolbox](https://drake.mit.edu/doxygen_cxx/group__solvers.html). Thanks to

--- a/doc/_release-notes/v0.34.0.md
+++ b/doc/_release-notes/v0.34.0.md
@@ -185,7 +185,7 @@ Newly bound
 # Notes
 
 This release provides [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/v0.34.0) named
-``drake-20210915-{bionic|focal|mac}.tar.gz``. See [Nightly Releases](/from_binary.html#nightly-releases) for instructions on how to use them.
+``drake-20210915-{bionic|focal|mac}.tar.gz``. See [Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the
 [Mathematical Program toolbox](https://drake.mit.edu/doxygen_cxx/group__solvers.html). Thanks to

--- a/doc/_release-notes/v0.35.0.md
+++ b/doc/_release-notes/v0.35.0.md
@@ -16,6 +16,8 @@ has been added to Drake C++ and Python ([#15731][_#15731], [#15799][_#15799])
     models without introducing new scopes (the contents of the included model
     are moved without any modification to the parent model). (*Note*: This
     currently does not support URDFs parsed via SDFormat composition.)
+* This release is the first to include PyPI wheels.
+    * Refer to [Installation via Pip](/pip.html) for instructions and known limitations.
 
 # Breaking changes since v0.34.0
 
@@ -191,7 +193,7 @@ Newly bound
 # Notes
 
 This release provides [pre-compiled binaries](https://github.com/RobotLocomotion/drake/releases/tag/v0.35.0) named
-``drake-20211021-{bionic|focal|mac}.tar.gz``. See [Nightly Releases](/from_binary.html#nightly-releases) for instructions on how to use them.
+``drake-20211021-{bionic|focal|mac}.tar.gz``. See [Stable Releases](/from_binary.html#stable-releases) for instructions on how to use them.
 
 Drake binary releases incorporate a pre-compiled version of [SNOPT](https://ccom.ucsd.edu/~optimizers/solvers/snopt/) as part of the
 [Mathematical Program toolbox](https://drake.mit.edu/doxygen_cxx/group__solvers.html). Thanks to

--- a/examples/kuka_iiwa_arm/README.md
+++ b/examples/kuka_iiwa_arm/README.md
@@ -14,9 +14,6 @@ Ensure that you have installed the drake visualizer with
 bazel build //tools:drake_visualizer
 ```
 
-Ensure that you have set your
-[PYTHONPATH](https://drake.mit.edu/python_bindings.html?highlight=python).
-
 All instructions assume that you are launching from the `drake`
 workspace directory.
 ```

--- a/examples/multibody/inclined_plane_with_body/README.md
+++ b/examples/multibody/inclined_plane_with_body/README.md
@@ -20,9 +20,6 @@ finite box (if a finite box, the block can fall off the inclined plane).
 
 ### Building and running this example
 
-First complete the one-time setup instructions, if you have not already done so:
-https://drake.mit.edu/from_source.html#mandatory-platform-specific-instructions
-
 Open a terminal in the `drake` workspace, and type commands as shown below.
 
 Build the example like so:

--- a/solvers/mathematical_program_doxygen.h
+++ b/solvers/mathematical_program_doxygen.h
@@ -140,7 +140,7 @@
  * † This is a commercial solver which requires a license
  * (note that some have free licenses for academics).
  *
- * ‡ <a href="https://drake.mit.edu/from_binary.html">Drake's pre-compiled
+ * ‡ <a href="https://drake.mit.edu/installation.html">Drake's pre-compiled
  * binary releases</a> incorporate a private build of SNOPT that does not
  * require a license when invoked via Drake's SnoptSolver wrapper class.
  *
@@ -247,7 +247,7 @@
  * † This is a commercial solver which requires a license
  * (note that some have free licenses for academics).
  *
- * ‡ <a href="https://drake.mit.edu/from_binary.html">Drake's pre-compiled
+ * ‡ <a href="https://drake.mit.edu/installation.html">Drake's pre-compiled
  * binary releases</a> incorporate a private build of SNOPT that does not
  * require a license when invoked via Drake's SnoptSolver wrapper class.
  *

--- a/solvers/snopt_solver.h
+++ b/solvers/snopt_solver.h
@@ -43,7 +43,7 @@ struct SnoptSolverDetails {
  * SolverInterface::available() will return false. You must opt-in to build
  * SNOPT per the documentation at https://drake.mit.edu/bazel.html#snopt.
  *
- * <a href="https://drake.mit.edu/from_binary.html">Drake's
+ * <a href="https://drake.mit.edu/installation.html">Drake's
  * pre-compiled binary releases</a> do incorporate SNOPT, so therefore
  * SolverInterface::available() will return true.
  * Thanks to Philip E. Gill and Elizabeth Wong for their kind support.

--- a/tools/install/colab/setup_drake_colab.py
+++ b/tools/install/colab/setup_drake_colab.py
@@ -44,7 +44,7 @@ def setup_drake(*, version, build):
           https://drake.mit.edu/jenkins#building-binary-packages-on-demand for
           information on obtaining a binary from an experimental branch.
 
-    See https://drake.mit.edu/from_binary.html for more information.
+    See https://drake.mit.edu/installation.html for more information.
 
     Note: If you already have pydrake installed to the target location, this
         will confirm that the build/version are the same as the installed


### PR DESCRIPTION
My goal is to improve the binary installation instructions.  There are still many problems with the "build from source" instructions, but I'm deferring those for the moment.

My goal is to get correct information in place and into something like a reasonable structure.  I believe we could still do more to make the information more clearly explained and better organized, but here I'm only aiming for "not harmfully wrong or incomplete".

As a reminder, for local preview:
```sh
git fetch upstream pull/15953/head && git checkout FETCH_HEAD
bazel run //doc:pages -- --serve
```

Closes #13202.
Closes #13210.
Closes #13500.
Closes #14493.
Closes #14920.
Closes #15747.

Relates to #13539.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15953)
<!-- Reviewable:end -->
