### PR TITLE
Toppra: Use one solver for every optimization and fix zero velocity bug

### DIFF
--- a/multibody/optimization/BUILD.bazel
+++ b/multibody/optimization/BUILD.bazel
@@ -178,8 +178,12 @@ drake_cc_library(
     deps = [
         "//common/trajectories",
         "//multibody/plant",
+        "//solvers:choose_best_solver",
+        "//solvers:clp_solver",
         "//solvers:mathematical_program",
-        "//solvers:solve",
+        "//solvers:mathematical_program_result",
+        "//solvers:mosek_solver",
+        "//solvers:solver_interface",
     ],
 )
 


### PR DESCRIPTION
Constructs the solver to be used for all the optimizations performed and explicitly prefer Clp over Mosek as the solver for Toppra.  Also fixes a bug where input trajectories that had segments with zero velocity caused Toppra to crash.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15964)
<!-- Reviewable:end -->
