### PR TITLE
[meshcat] Adds MeshcatContactVisualizer

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -561,6 +561,7 @@ drake_py_unittest(
         ":lcm_py",
         ":perception_py",
         "//bindings/pydrake/common/test_utilities",
+        "//bindings/pydrake/multibody:plant_py",
         "//bindings/pydrake/systems:analysis_py",
         "//bindings/pydrake/systems:lcm_py",
     ],

--- a/bindings/pydrake/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry_py_visualizers.cc
@@ -74,6 +74,34 @@ void DoScalarDependentDefinitions(py::module m, T) {
             cls_doc.DispatchLoadMessage.doc);
   }
 
+  // MeshcatPointCloudVisualizer
+  {
+    using Class = MeshcatPointCloudVisualizer<T>;
+    constexpr auto& cls_doc = doc.MeshcatPointCloudVisualizer;
+    auto cls = DefineTemplateClassWithDefault<Class, LeafSystem<T>>(m,
+        "MeshcatPointCloudVisualizerCpp", param,
+        (std::string(cls_doc.doc) + R"""(
+Note that we are temporarily re-mapping MeshcatPointCloudVisualizer =>
+MeshcatPointCloudVisualizerCpp to avoid collisions with the python
+MeshcatPointCloudVisualizer.  See #13038.)""")
+            .c_str());
+    cls  // BR
+        .def(py::init<std::shared_ptr<Meshcat>, std::string, double>(),
+            py::arg("meshcat"), py::arg("path"),
+            py::arg("publish_period") = 1 / 32.0,
+            // `meshcat` is a shared_ptr, so does not need a keep_alive.
+            cls_doc.ctor.doc)
+        .def("set_point_size", &Class::set_point_size,
+            cls_doc.set_point_size.doc)
+        .def("set_default_rgba", &Class::set_default_rgba,
+            cls_doc.set_default_rgba.doc)
+        .def("Delete", &Class::Delete, cls_doc.Delete.doc)
+        .def("cloud_input_port", &Class::cloud_input_port,
+            py_rvp::reference_internal, cls_doc.cloud_input_port.doc)
+        .def("pose_input_port", &Class::pose_input_port,
+            py_rvp::reference_internal, cls_doc.pose_input_port.doc);
+  }
+
   // MeshcatVisualizer
   {
     using Class = MeshcatVisualizer<T>;
@@ -126,34 +154,6 @@ MeshcatVisualizer.  See #13038.)""")
             cls_doc.AddToBuilder
                 .doc_4args_builder_query_object_port_meshcat_params);
   }
-
-  // MeshcatPointCloudVisualizer
-  {
-    using Class = MeshcatPointCloudVisualizer<T>;
-    constexpr auto& cls_doc = doc.MeshcatPointCloudVisualizer;
-    auto cls = DefineTemplateClassWithDefault<Class, LeafSystem<T>>(m,
-        "MeshcatPointCloudVisualizerCpp", param,
-        (std::string(cls_doc.doc) + R"""(
-Note that we are temporarily re-mapping MeshcatPointCloudVisualizer =>
-MeshcatPointCloudVisualizerCpp to avoid collisions with the python
-MeshcatPointCloudVisualizer.  See #13038.)""")
-            .c_str());
-    cls  // BR
-        .def(py::init<std::shared_ptr<Meshcat>, std::string, double>(),
-            py::arg("meshcat"), py::arg("path"),
-            py::arg("publish_period") = 1 / 32.0,
-            // `meshcat` is a shared_ptr, so does not need a keep_alive.
-            cls_doc.ctor.doc)
-        .def("set_point_size", &Class::set_point_size,
-            cls_doc.set_point_size.doc)
-        .def("set_default_rgba", &Class::set_default_rgba,
-            cls_doc.set_default_rgba.doc)
-        .def("Delete", &Class::Delete, cls_doc.Delete.doc)
-        .def("cloud_input_port", &Class::cloud_input_port,
-            py_rvp::reference_internal, cls_doc.cloud_input_port.doc)
-        .def("pose_input_port", &Class::pose_input_port,
-            py_rvp::reference_internal, cls_doc.pose_input_port.doc);
-  }
 }
 
 void DoScalarIndependentDefinitions(py::module m) {
@@ -186,6 +186,78 @@ void DoScalarIndependentDefinitions(py::module m) {
               .format(self.publish_period, self.role, self.default_color,
                   self.show_hydroelastic);
         });
+  }
+
+  // Meshcat
+  {
+    using Class = Meshcat;
+    constexpr auto& cls_doc = doc.Meshcat;
+    py::class_<Class, std::shared_ptr<Class>> cls(m, "Meshcat", cls_doc.doc);
+    cls  // BR
+        .def(py::init<const std::optional<int>&>(),
+            py::arg("port") = std::nullopt, cls_doc.ctor.doc)
+        .def("web_url", &Class::web_url, cls_doc.web_url.doc)
+        .def("port", &Class::port, cls_doc.port.doc)
+        .def("ws_url", &Class::ws_url, cls_doc.ws_url.doc)
+        .def("SetObject",
+            py::overload_cast<std::string_view, const Shape&, const Rgba&>(
+                &Class::SetObject),
+            py::arg("path"), py::arg("shape"),
+            py::arg("rgba") = Rgba(.9, .9, .9, 1.), cls_doc.SetObject.doc_shape)
+        .def("SetObject",
+            py::overload_cast<std::string_view, const perception::PointCloud&,
+                double, const Rgba&>(&Class::SetObject),
+            py::arg("path"), py::arg("cloud"), py::arg("point_size") = 0.001,
+            py::arg("rgba") = Rgba(.9, .9, .9, 1.), cls_doc.SetObject.doc_cloud)
+        // TODO(russt): Bind SetCamera.
+        .def("Set2dRenderMode", &Class::Set2dRenderMode,
+            py::arg("X_WC") = RigidTransformd{Eigen::Vector3d{0, -1, 0}},
+            py::arg("xmin") = -1.0, py::arg("xmax") = 1.0,
+            py::arg("ymin") = -1.0, py::arg("ymax") = 1.0,
+            cls_doc.Set2dRenderMode.doc)
+        .def("ResetRenderMode", &Class::ResetRenderMode,
+            cls_doc.ResetRenderMode.doc)
+        .def("SetTransform",
+            py::overload_cast<std::string_view, const math::RigidTransformd&>(
+                &Class::SetTransform),
+            py::arg("path"), py::arg("X_ParentPath"),
+            cls_doc.SetTransform.doc_RigidTransform)
+        .def("SetTransform",
+            py::overload_cast<std::string_view,
+                const Eigen::Ref<const Eigen::Matrix4d>&>(&Class::SetTransform),
+            py::arg("path"), py::arg("matrix"), cls_doc.SetTransform.doc_matrix)
+        .def("Delete", &Class::Delete, py::arg("path") = "", cls_doc.Delete.doc)
+        .def("SetProperty",
+            py::overload_cast<std::string_view, std::string, bool>(
+                &Class::SetProperty),
+            py::arg("path"), py::arg("property"), py::arg("value"),
+            cls_doc.SetProperty.doc_bool)
+        .def("SetProperty",
+            py::overload_cast<std::string_view, std::string, double>(
+                &Class::SetProperty),
+            py::arg("path"), py::arg("property"), py::arg("value"),
+            cls_doc.SetProperty.doc_double)
+        .def("SetAnimation", &Class::SetAnimation, py::arg("animation"),
+            +cls_doc.SetAnimation.doc)
+        .def("AddButton", &Class::AddButton, py::arg("name"),
+            cls_doc.AddButton.doc)
+        .def("GetButtonClicks", &Class::GetButtonClicks, py::arg("name"),
+            cls_doc.GetButtonClicks.doc)
+        .def("DeleteButton", &Class::DeleteButton, py::arg("name"),
+            cls_doc.DeleteButton.doc)
+        .def("AddSlider", &Class::AddSlider, py::arg("name"), py::arg("min"),
+            py::arg("max"), py::arg("step"), py::arg("value"),
+            cls_doc.AddSlider.doc)
+        .def("SetSliderValue", &Class::SetSliderValue, py::arg("name"),
+            py::arg("value"), cls_doc.SetSliderValue.doc)
+        .def("GetSliderValue", &Class::GetSliderValue, py::arg("name"),
+            cls_doc.GetSliderValue.doc)
+        .def("DeleteSlider", &Class::DeleteSlider, py::arg("name"),
+            cls_doc.DeleteSlider.doc)
+        .def("DeleteAddedControls", &Class::DeleteAddedControls,
+            cls_doc.DeleteAddedControls.doc);
+    // Note: we intentionally do not bind the advanced methods (HasProperty and
+    // GetPacked*) which were intended primarily for testing in C++.
   }
 
   // MeshcatAnimation
@@ -244,71 +316,6 @@ void DoScalarIndependentDefinitions(py::module m) {
             loop_doc.kLoopRepeat.doc)
         .value("kLoopPingPong", MeshcatAnimation::LoopMode::kLoopPingPong,
             loop_doc.kLoopPingPong.doc);
-  }
-
-  // Meshcat
-  {
-    using Class = Meshcat;
-    constexpr auto& cls_doc = doc.Meshcat;
-    py::class_<Class, std::shared_ptr<Class>> cls(m, "Meshcat", cls_doc.doc);
-    cls  // BR
-        .def(py::init<const std::optional<int>&>(),
-            py::arg("port") = std::nullopt, cls_doc.ctor.doc)
-        .def("web_url", &Class::web_url, cls_doc.web_url.doc)
-        .def("port", &Class::port, cls_doc.port.doc)
-        .def("ws_url", &Class::ws_url, cls_doc.ws_url.doc)
-        .def("SetObject",
-            py::overload_cast<std::string_view, const Shape&, const Rgba&>(
-                &Class::SetObject),
-            py::arg("path"), py::arg("shape"),
-            py::arg("rgba") = Rgba(.9, .9, .9, 1.), cls_doc.SetObject.doc_shape)
-        .def("SetObject",
-            py::overload_cast<std::string_view, const perception::PointCloud&,
-                double, const Rgba&>(&Class::SetObject),
-            py::arg("path"), py::arg("cloud"), py::arg("point_size") = 0.001,
-            py::arg("rgba") = Rgba(.9, .9, .9, 1.), cls_doc.SetObject.doc_cloud)
-        // TODO(russt): Bind SetCamera.
-        .def("Set2dRenderMode", &Class::Set2dRenderMode,
-            py::arg("X_WC") = RigidTransformd{Eigen::Vector3d{0, -1, 0}},
-            py::arg("xmin") = -1.0, py::arg("xmax") = 1.0,
-            py::arg("ymin") = -1.0, py::arg("ymax") = 1.0,
-            cls_doc.Set2dRenderMode.doc)
-        .def("ResetRenderMode", &Class::ResetRenderMode,
-            cls_doc.ResetRenderMode.doc)
-        .def("SetTransform", &Class::SetTransform, py::arg("path"),
-            py::arg("X_ParentPath"), cls_doc.SetTransform.doc)
-        .def("Delete", &Class::Delete, py::arg("path") = "", cls_doc.Delete.doc)
-        .def("SetProperty",
-            py::overload_cast<std::string_view, std::string, bool>(
-                &Class::SetProperty),
-            py::arg("path"), py::arg("property"), py::arg("value"),
-            cls_doc.SetProperty.doc_bool)
-        .def("SetProperty",
-            py::overload_cast<std::string_view, std::string, double>(
-                &Class::SetProperty),
-            py::arg("path"), py::arg("property"), py::arg("value"),
-            cls_doc.SetProperty.doc_double)
-        .def("SetAnimation", &Class::SetAnimation, py::arg("animation"),
-            +cls_doc.SetAnimation.doc)
-        .def("AddButton", &Class::AddButton, py::arg("name"),
-            cls_doc.AddButton.doc)
-        .def("GetButtonClicks", &Class::GetButtonClicks, py::arg("name"),
-            cls_doc.GetButtonClicks.doc)
-        .def("DeleteButton", &Class::DeleteButton, py::arg("name"),
-            cls_doc.DeleteButton.doc)
-        .def("AddSlider", &Class::AddSlider, py::arg("name"), py::arg("min"),
-            py::arg("max"), py::arg("step"), py::arg("value"),
-            cls_doc.AddSlider.doc)
-        .def("SetSliderValue", &Class::SetSliderValue, py::arg("name"),
-            py::arg("value"), cls_doc.SetSliderValue.doc)
-        .def("GetSliderValue", &Class::GetSliderValue, py::arg("name"),
-            cls_doc.GetSliderValue.doc)
-        .def("DeleteSlider", &Class::DeleteSlider, py::arg("name"),
-            cls_doc.DeleteSlider.doc)
-        .def("DeleteAddedControls", &Class::DeleteAddedControls,
-            cls_doc.DeleteAddedControls.doc);
-    // Note: we intentionally do not bind the advanced methods (HasProperty and
-    // GetPacked*) which were intended primarily for testing in C++.
   }
 
   // MeshcatVisualizerParams

--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -17,6 +17,7 @@
 #include "drake/math/rigid_transform.h"
 #include "drake/multibody/plant/contact_results.h"
 #include "drake/multibody/plant/contact_results_to_lcm.h"
+#include "drake/multibody/plant/contact_results_to_meshcat.h"
 #include "drake/multibody/plant/externally_applied_spatial_force.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/multibody/plant/point_pair_contact_info.h"
@@ -1148,6 +1149,52 @@ void DoScalarDependentDefinitions(py::module m, T) {
             &Class::get_spatial_forces_output_port, py_rvp::reference_internal,
             doc.Propeller.get_spatial_forces_output_port.doc);
   }
+
+  // ContactResultsToMeshcat
+  if constexpr (!std::is_same_v<T, symbolic::Expression>) {
+    using Class = ContactResultsToMeshcat<T>;
+    constexpr auto& cls_doc = doc.ContactResultsToMeshcat;
+    auto cls = DefineTemplateClassWithDefault<Class, systems::LeafSystem<T>>(
+        m, "ContactResultsToMeshcat", param, cls_doc.doc);
+    cls  // BR
+        .def(py::init<std::shared_ptr<geometry::Meshcat>,
+                 ContactResultsToMeshcatParams>(),
+            py::arg("meshcat"),
+            py::arg("params") = ContactResultsToMeshcatParams{},
+            // `meshcat` is a shared_ptr, so does not need a keep_alive.
+            cls_doc.ctor.doc)
+        .def("Delete", &Class::Delete, cls_doc.Delete.doc)
+        .def("contact_results_input_port", &Class::contact_results_input_port,
+            py_rvp::reference_internal, cls_doc.contact_results_input_port.doc)
+        .def_static("AddToBuilder",
+            py::overload_cast<systems::DiagramBuilder<T>*,
+                const MultibodyPlant<T>&, std::shared_ptr<geometry::Meshcat>,
+                ContactResultsToMeshcatParams>(
+                &ContactResultsToMeshcat<T>::AddToBuilder),
+            py::arg("builder"), py::arg("plant"), py::arg("meshcat"),
+            py::arg("params") = ContactResultsToMeshcatParams{},
+            // Keep alive, ownership: `return` keeps `builder` alive.
+            py::keep_alive<0, 1>(),
+            // `meshcat` is a shared_ptr, so does not need a keep_alive.
+            py_rvp::reference,
+            cls_doc.AddToBuilder.doc_4args_builder_plant_meshcat_params)
+        .def_static("AddToBuilder",
+            py::overload_cast<systems::DiagramBuilder<T>*,
+                const systems::OutputPort<T>&,
+                std::shared_ptr<geometry::Meshcat>,
+                ContactResultsToMeshcatParams>(
+                &ContactResultsToMeshcat<T>::AddToBuilder),
+            py::arg("builder"), py::arg("contact_results_port"),
+            py::arg("meshcat"),
+            py::arg("params") = ContactResultsToMeshcatParams{},
+            // Keep alive, ownership: `return` keeps `builder` alive.
+            py::keep_alive<0, 1>(),
+            // `meshcat` is a shared_ptr, so does not need a keep_alive.
+            py_rvp::reference,
+            cls_doc.AddToBuilder
+                .doc_4args_builder_contact_results_port_meshcat_params);
+  }
+
   // NOLINTNEXTLINE(readability/fn_size)
 }
 }  // namespace
@@ -1165,8 +1212,6 @@ PYBIND11_MODULE(plant, m) {
   py::module::import("pydrake.multibody.tree");
   py::module::import("pydrake.systems.framework");
 
-  type_visit([m](auto dummy) { DoScalarDependentDefinitions(m, dummy); },
-      CommonScalarPack{});
   constexpr auto& doc = pydrake_doc.drake.multibody;
 
   using T = double;
@@ -1185,6 +1230,47 @@ PYBIND11_MODULE(plant, m) {
         .def("get_lcm_message_output_port", &Class::get_lcm_message_output_port,
             py_rvp::reference_internal,
             cls_doc.get_lcm_message_output_port.doc);
+  }
+
+  // ContactResultsToMeshcatParams
+  {
+    using Class = ContactResultsToMeshcatParams;
+    constexpr auto& cls_doc = doc.ContactResultsToMeshcatParams;
+    py::class_<Class>(
+        m, "ContactResultsToMeshcatParams", py::dynamic_attr(), cls_doc.doc)
+        .def(ParamInit<Class>())
+        .def_readwrite("publish_period",
+            &ContactResultsToMeshcatParams::publish_period,
+            cls_doc.publish_period.doc)
+        .def_readwrite(
+            "color", &ContactResultsToMeshcatParams::color, cls_doc.color.doc)
+        .def_readwrite("prefix", &ContactResultsToMeshcatParams::prefix,
+            cls_doc.prefix.doc)
+        .def_readwrite("delete_on_initialization_event",
+            &ContactResultsToMeshcatParams::delete_on_initialization_event,
+            cls_doc.delete_on_initialization_event.doc)
+        .def_readwrite("force_threshold",
+            &ContactResultsToMeshcatParams::force_threshold,
+            cls_doc.force_threshold.doc)
+        .def_readwrite("newtons_per_meter",
+            &ContactResultsToMeshcatParams::newtons_per_meter,
+            cls_doc.newtons_per_meter.doc)
+        .def_readwrite("radius", &ContactResultsToMeshcatParams::radius,
+            cls_doc.radius.doc)
+        .def("__repr__", [](const Class& self) {
+          return py::str(
+              "ContactResultsToMeshcatParams("
+              "publish_period={}, "
+              "color={}, "
+              "prefix={}, "
+              "delete_on_initialization_event={}, "
+              "force_threshold={}, "
+              "newtons_per_meter={}, "
+              "radius={})")
+              .format(self.publish_period, self.color, self.prefix,
+                  self.delete_on_initialization_event, self.force_threshold,
+                  self.newtons_per_meter, self.radius);
+        });
   }
 
 #pragma GCC diagnostic push
@@ -1267,6 +1353,9 @@ PYBIND11_MODULE(plant, m) {
         .value("kPointContactOnly", Class::kPointContactOnly,
             cls_doc.kPointContactOnly.doc);
   }
+
+  type_visit([m](auto dummy) { DoScalarDependentDefinitions(m, dummy); },
+      CommonScalarPack{});
 }  // NOLINT(readability/fn_size)
 
 }  // namespace pydrake

--- a/bindings/pydrake/test/geometry_visualizers_test.py
+++ b/bindings/pydrake/test/geometry_visualizers_test.py
@@ -98,6 +98,7 @@ class TestGeometryVisualizers(unittest.TestCase):
                           shape=mut.Box(1, 1, 1),
                           rgba=mut.Rgba(.5, .5, .5))
         meshcat.SetTransform(path="/test/box", X_ParentPath=RigidTransform())
+        meshcat.SetTransform(path="/test/box", matrix=np.eye(4))
         cloud = PointCloud(4)
         cloud.mutable_xyzs()[:] = np.zeros((3, 4))
         meshcat.SetObject(path="/test/cloud", cloud=cloud,

--- a/examples/manipulation_station/models/sphere.sdf
+++ b/examples/manipulation_station/models/sphere.sdf
@@ -32,9 +32,6 @@
             <radius>0.04</radius>
           </sphere>
         </geometry>
-        <material>
-          <diffuse>0 1 0 1.0</diffuse>
-        </material>
       </collision>
     </link>
   </model>

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -424,6 +424,7 @@ drake_cc_binary(
     testonly = True,
     srcs = ["test/meshcat_manual_test.cc"],
     data = [
+        "//examples/kuka_iiwa_arm:models",
         "//geometry/render:test_models",
         "//manipulation/models/iiwa_description:models",
         "//manipulation/models/ycb:models",
@@ -434,6 +435,7 @@ drake_cc_binary(
         ":meshcat_visualizer",
         "//multibody/parsing",
         "//multibody/plant",
+        "//multibody/plant:contact_results_to_meshcat",
         "//systems/analysis:simulator",
     ],
 )

--- a/geometry/meshcat.cc
+++ b/geometry/meshcat.cc
@@ -630,13 +630,13 @@ class Meshcat::WebSocketPublisher {
   }
 
   void SetTransform(std::string_view path,
-                    const RigidTransformd& X_ParentPath) {
+                    const Eigen::Ref<const Eigen::Matrix4d>& matrix) {
     DRAKE_DEMAND(IsThread(main_thread_id_));
     DRAKE_DEMAND(loop_ != nullptr);
 
     internal::SetTransformData data;
     data.path = FullPath(path);
-    Eigen::Map<Eigen::Matrix4d>(data.matrix) = X_ParentPath.GetAsMatrix4();
+    Eigen::Map<Eigen::Matrix4d>(data.matrix) = matrix;
 
     loop_->defer([this, data = std::move(data)]() {
       DRAKE_DEMAND(IsThread(websocket_thread_id_));
@@ -1267,7 +1267,12 @@ void Meshcat::SetCamera(OrthographicCamera camera, std::string path) {
 
 void Meshcat::SetTransform(std::string_view path,
                            const RigidTransformd& X_ParentPath) {
-  publisher_->SetTransform(path, X_ParentPath);
+  publisher_->SetTransform(path, X_ParentPath.GetAsMatrix4());
+}
+
+void Meshcat::SetTransform(std::string_view path,
+                           const Eigen::Ref<const Eigen::Matrix4d>& matrix) {
+  publisher_->SetTransform(path, matrix);
 }
 
 void Meshcat::Delete(std::string_view path) { publisher_->Delete(path); }

--- a/geometry/meshcat.h
+++ b/geometry/meshcat.h
@@ -191,17 +191,37 @@ class Meshcat {
    default settings. */
   void ResetRenderMode();
 
-  /** Set the RigidTransform for a given path in the scene tree. An object's
-  pose is the concatenation of all of the transforms along its path, so setting
-  the transform of "/foo" will move the objects at "/foo/box1" and
-  "/foo/robots/HAL9000".
+  /** Set the RigidTransform for a given path in the scene tree relative to its
+  parent path. An object's pose is the concatenation of all of the transforms
+  along its path, so setting the transform of "/foo" will move the objects at
+  "/foo/box1" and "/foo/robots/HAL9000".
   @param path a "/"-delimited string indicating the path in the scene tree.
               See @ref meshcat_path "Meshcat paths" for the semantics.
   @param X_ParentPath the relative transform from the path to its immediate
   parent.
+
+  @pydrake_mkdoc_identifier{RigidTransform}
   */
   void SetTransform(std::string_view path,
                     const math::RigidTransformd& X_ParentPath);
+
+  /** Set the homogeneous transform for a given path in the scene tree relative
+  to its parent path. An object's pose is the concatenation of all of the
+  transforms along its path, so setting the transform of "/foo" will move the
+  objects at "/foo/box1" and "/foo/robots/HAL9000".
+  @param path a "/"-delimited string indicating the path in the scene tree. See
+              @ref meshcat_path "Meshcat paths" for the semantics.
+  @param matrix the relative transform from the path to its immediate
+                parent.
+
+  Note: Prefer to use the overload which takes a RigidTransformd unless you need
+  the fully parameterized homogeneous transform (which additionally allows
+  scale and sheer).
+
+  @pydrake_mkdoc_identifier{matrix}
+  */
+  void SetTransform(std::string_view path,
+                    const Eigen::Ref<const Eigen::Matrix4d>& matrix);
 
   /** Deletes the object at the given `path` as well as all of its children.
   See @ref meshcat_path for the detailed semantics of deletion. */

--- a/geometry/meshcat_visualizer.h
+++ b/geometry/meshcat_visualizer.h
@@ -133,8 +133,8 @@ class MeshcatVisualizer final : public systems::LeafSystem<T> {
   static MeshcatVisualizer<T>& AddToBuilder(
       systems::DiagramBuilder<T>* builder,
       const systems::OutputPort<T>& query_object_port,
-      std::shared_ptr<Meshcat> meshcat, MeshcatVisualizerParams params = {});
-  //@}
+      std::shared_ptr<Meshcat> meshcat,
+      MeshcatVisualizerParams params = {});
 
  private:
   /* MeshcatVisualizer of different scalar types can all access each other's

--- a/geometry/meshcat_visualizer_params.h
+++ b/geometry/meshcat_visualizer_params.h
@@ -29,7 +29,7 @@ struct MeshcatVisualizerParams {
    details. */
   std::string prefix{"visualizer"};
 
-  /** Determines whether to send a Meschat::Delete("/prefix") message on an
+  /** Determines whether to send a Meschat::Delete(prefix) message on an
    initialization event to remove any visualizations e.g. from a previous
    simulation. See @ref declare_initialization_events "Declare initialization
    events" for more information. */

--- a/geometry/test/meshcat_manual_test.cc
+++ b/geometry/test/meshcat_manual_test.cc
@@ -7,6 +7,7 @@
 #include "drake/math/rigid_transform.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/plant/contact_results_to_meshcat.h"
 #include "drake/multibody/plant/multibody_plant.h"
 #include "drake/systems/analysis/simulator.h"
 
@@ -35,18 +36,22 @@ int do_main() {
   meshcat->SetObject("box", Box(.25, .25, .5), Rgba(0, 0, 1, 1));
   meshcat->SetTransform("box", RigidTransformd(Vector3d{0, 0, 0}));
 
+  // Note that height (in z) is the first argument.
+  meshcat->SetObject("cone", MeshcatCone(.5, .25, .5), Rgba(1, 0, 0, 1));
+  meshcat->SetTransform("cone", RigidTransformd(Vector3d{1, 0, 0}));
+
   // The green color of this cube comes from the texture map.
   meshcat->SetObject(
       "obj", Mesh(FindResourceOrThrow(
                       "drake/geometry/render/test/meshes/box.obj"),
                   .25));
-  meshcat->SetTransform("obj", RigidTransformd(Vector3d{1, 0, 0}));
+  meshcat->SetTransform("obj", RigidTransformd(Vector3d{2, 0, 0}));
 
   meshcat->SetObject(
       "mustard",
       Mesh(FindResourceOrThrow("drake/manipulation/models/ycb/meshes/"
                                "006_mustard_bottle_textured.obj"), 3.0));
-  meshcat->SetTransform("mustard", RigidTransformd(Vector3d{2, 0, 0}));
+  meshcat->SetTransform("mustard", RigidTransformd(Vector3d{3, 0, 0}));
 
   const int kPoints = 100000;
   perception::PointCloud cloud(
@@ -55,7 +60,7 @@ int do_main() {
   cloud.mutable_xyzs() = Eigen::DiagonalMatrix<float, 3>{.25, .25, .5} * m;
   cloud.mutable_rgbs() = (255.0 * (m.array() + 1.0) / 2.0).cast<uint8_t>();
   meshcat->SetObject("point_cloud", cloud, 0.01);
-  meshcat->SetTransform("point_cloud", RigidTransformd(Vector3d{3, 0, 0}));
+  meshcat->SetTransform("point_cloud", RigidTransformd(Vector3d{4, 0, 0}));
   std::cout << R"""(
 Open up your browser to the URL above.
 
@@ -65,6 +70,7 @@ Open up your browser to the URL above.
   - a green cylinder (with the long axis in z)
   - a pink semi-transparent ellipsoid (long axis in z)
   - a blue box (long axis in z)
+  - a red cone (expanding in +z, twice as wide in y than in x)
   - a bright green cube (the green comes from a texture map)
   - a yellow mustard bottle w/ label
   - a dense rainbow point cloud in a box (long axis in z)
@@ -161,21 +167,34 @@ Open up your browser to the URL above.
   std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
 
   meshcat->SetProperty("/Lights/AmbientLight/<object>", "intensity", 0.6);
+
   systems::DiagramBuilder<double> builder;
   auto [plant, scene_graph] =
       multibody::AddMultibodyPlantSceneGraph(&builder, 0.001);
-  multibody::Parser(&plant).AddModelFromFile(
+  multibody::Parser parser(&plant);
+  parser.AddModelFromFile(
       FindResourceOrThrow("drake/manipulation/models/iiwa_description/urdf/"
-                          "iiwa14_no_collision.urdf"));
+                          "iiwa14_spheres_collision.urdf"));
   plant.WeldFrames(plant.world_frame(),
-                   plant.GetBodyByName("base").body_frame());
+                   plant.GetFrameByName("base"));
+  parser.AddModelFromFile(
+      FindResourceOrThrow("drake/examples/kuka_iiwa_arm/models/table/"
+                          "extra_heavy_duty_table_surface_only_collision.sdf"));
+  const double table_height = 0.7645;
+  plant.WeldFrames(plant.world_frame(), plant.GetFrameByName("link"),
+                   RigidTransformd(Vector3d{0, 0, -table_height-.01}));
   plant.Finalize();
 
   builder.ExportInput(plant.get_actuation_input_port(), "actuation_input");
   MeshcatVisualizerParams params;
   params.delete_on_initialization_event = false;
-  auto& visualizer =
-      MeshcatVisualizerd::AddToBuilder(&builder, scene_graph, meshcat, params);
+  auto& visualizer = MeshcatVisualizerd::AddToBuilder(
+      &builder, scene_graph, meshcat, std::move(params));
+
+  multibody::ContactResultsToMeshcatParams cparams;
+  cparams.newtons_per_meter = 60.0;
+  auto& contact = multibody::ContactResultsToMeshcatd::AddToBuilder(
+      &builder, plant, meshcat, std::move(cparams));
 
   auto diagram = builder.Build();
   auto context = diagram->CreateDefaultContext();
@@ -189,18 +208,23 @@ Open up your browser to the URL above.
   std::cout << "[Press RETURN to continue]." << std::endl;
   std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
 
-  std::cout
-      << "Now we'll run the simulation (you should see the robot fall down)."
-      << std::endl;
+  std::cout << "Now we'll run the simulation...\n"
+            << "- You should see the robot fall down and hit the table\n"
+            << "- You should see the contact force vectors (when it hits)\n"
+            << "- You will also see large forces near the wrist until we "
+               "resolve #15965\n"
+            << std::endl;
 
   systems::Simulator<double> simulator(*diagram, std::move(context));
   simulator.set_target_realtime_rate(1.0);
   visualizer.StartRecording();
   simulator.AdvanceTo(4.0);
   visualizer.PublishRecording();
+  contact.Delete();
 
   std::cout << "The recorded simulation results should now be available as an "
-               "animation.  Use the animation GUI to confirm."
+               "animation.  Use the animation GUI to confirm.  The contact "
+               "forces are not recorded (yet)."
             << std::endl;
 
   std::cout << "[Press RETURN to continue]." << std::endl;

--- a/geometry/test/meshcat_test.cc
+++ b/geometry/test/meshcat_test.cc
@@ -157,6 +157,29 @@ GTEST_TEST(MeshcatTest, SetTransform) {
   EXPECT_TRUE(CompareMatrices(matrix, X_ParentPath.GetAsMatrix4()));
 }
 
+GTEST_TEST(MeshcatTest, SetTransformWithMatrix) {
+  Meshcat meshcat;
+  EXPECT_FALSE(meshcat.HasPath("frame"));
+  EXPECT_TRUE(meshcat.GetPackedTransform("frame").empty());
+  Eigen::Matrix4d matrix;
+  // clang-format off
+  matrix <<  1,  2,  3,  4,
+             5,  6,  7,  8,
+            -1, -2, -3, -4,
+            -5, -6, -7, -8;
+  // clang-format on
+  meshcat.SetTransform("frame", matrix);
+
+  std::string transform = meshcat.GetPackedTransform("frame");
+  msgpack::object_handle oh =
+      msgpack::unpack(transform.data(), transform.size());
+  auto data = oh.get().as<internal::SetTransformData>();
+  EXPECT_EQ(data.type, "set_transform");
+  EXPECT_EQ(data.path, "/drake/frame");
+  Eigen::Map<Eigen::Matrix4d> actual(data.matrix);
+  EXPECT_TRUE(CompareMatrices(matrix, actual));
+}
+
 GTEST_TEST(MeshcatTest, Delete) {
   Meshcat meshcat;
   // Ok to delete an empty tree.

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -21,6 +21,8 @@ drake_cc_package_library(
         ":contact_jacobians",
         ":contact_permutation",
         ":contact_results",
+        ":contact_results_to_meshcat",
+        ":contact_results_to_meshcat_params",
         ":coulomb_friction",
         ":discrete_contact_pair",
         ":externally_applied_spatial_force",
@@ -187,7 +189,7 @@ drake_cc_library(
         "contact_results_to_lcm.h",
     ],
     tags = [
-        # Don't add this library into the ":multibody_plant" package library.
+        # Don't add this library into the ":plant" package library.
         # Use of MBP doesn't imply use of contact visualization so this
         # dependency should be invoked explicitly.
         "exclude_from_package",
@@ -200,6 +202,32 @@ drake_cc_library(
         "//lcmtypes:point_pair_contact_info_for_viz",
         "//systems/framework:diagram_builder",
         "//systems/lcm:lcm_pubsub_system",
+    ],
+)
+
+drake_cc_library(
+    name = "contact_results_to_meshcat_params",
+    hdrs = ["contact_results_to_meshcat_params.h"],
+    deps = [
+        "//geometry:rgba",
+    ],
+)
+
+drake_cc_library(
+    name = "contact_results_to_meshcat",
+    srcs = ["contact_results_to_meshcat.cc"],
+    hdrs = [
+        "contact_results_to_meshcat.h",
+    ],
+    deps = [
+        ":contact_results_to_meshcat_params",
+        ":multibody_plant_core",
+        "//common:essential",
+        "//geometry:meshcat",
+        "//math:geometric_transform",
+        "//systems/framework:context",
+        "//systems/framework:diagram_builder",
+        "//systems/framework:leaf_system",
     ],
 )
 
@@ -599,6 +627,19 @@ drake_cc_googletest(
     deps = [
         ":contact_results_to_lcm",
         "//common/test_utilities:eigen_geometry_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "contact_results_to_meshcat_test",
+    data = [
+        "//examples/manipulation_station:models",
+    ],
+    deps = [
+        ":contact_results_to_meshcat",
+        ":plant",
+        "//common/test_utilities:expect_throws_message",
+        "//multibody/parsing",
     ],
 )
 

--- a/multibody/plant/contact_results_to_meshcat.cc
+++ b/multibody/plant/contact_results_to_meshcat.cc
@@ -1,0 +1,182 @@
+#include "drake/multibody/plant/contact_results_to_meshcat.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include <fmt/format.h>
+
+#include "drake/common/extract_double.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/multibody/plant/contact_results.h"
+
+namespace drake {
+namespace multibody {
+
+using geometry::GeometryId;
+using geometry::Meshcat;
+
+template <typename T>
+ContactResultsToMeshcat<T>::ContactResultsToMeshcat(
+    std::shared_ptr<Meshcat> meshcat, ContactResultsToMeshcatParams params)
+    : systems::LeafSystem<T>(systems::SystemTypeTag<ContactResultsToMeshcat>{}),
+      meshcat_(std::move(meshcat)),
+      params_(std::move(params)) {
+  DRAKE_DEMAND(meshcat_ != nullptr);
+  DRAKE_DEMAND(params_.publish_period >= 0.0);
+  DRAKE_DEMAND(params_.force_threshold > 0.0);  // Strictly positive.
+
+  this->DeclarePeriodicPublishEvent(params_.publish_period, 0.0,
+                                    &ContactResultsToMeshcat::UpdateMeshcat);
+  this->DeclareForcedPublishEvent(&ContactResultsToMeshcat::UpdateMeshcat);
+
+  if (params_.delete_on_initialization_event) {
+    this->DeclareInitializationPublishEvent(
+        &ContactResultsToMeshcat::OnInitialization);
+  }
+
+  contact_results_input_port_ =
+      this->DeclareAbstractInputPort("contact_results",
+                                     Value<ContactResults<T>>())
+          .get_index();
+}
+
+template <typename T>
+template <typename U>
+ContactResultsToMeshcat<T>::ContactResultsToMeshcat(
+    const ContactResultsToMeshcat<U>& other)
+    : ContactResultsToMeshcat(other.meshcat_, other.params_) {}
+
+template <typename T>
+void ContactResultsToMeshcat<T>::Delete() const {
+  meshcat_->Delete(params_.prefix);
+  contacts_.clear();
+}
+
+template <typename T>
+const ContactResultsToMeshcat<T>& ContactResultsToMeshcat<T>::AddToBuilder(
+    systems::DiagramBuilder<T>* builder, const MultibodyPlant<T>& plant,
+    std::shared_ptr<Meshcat> meshcat, ContactResultsToMeshcatParams params) {
+  return AddToBuilder(builder, plant.get_contact_results_output_port(),
+                      std::move(meshcat), std::move(params));
+}
+
+template <typename T>
+const ContactResultsToMeshcat<T>& ContactResultsToMeshcat<T>::AddToBuilder(
+    systems::DiagramBuilder<T>* builder,
+    const systems::OutputPort<T>& contact_results_port,
+    std::shared_ptr<Meshcat> meshcat, ContactResultsToMeshcatParams params) {
+  auto& visualizer = *builder->template AddSystem<ContactResultsToMeshcat<T>>(
+      std::move(meshcat), std::move(params));
+  builder->Connect(contact_results_port,
+                   visualizer.contact_results_input_port());
+  return visualizer;
+}
+
+template <typename T>
+systems::EventStatus ContactResultsToMeshcat<T>::UpdateMeshcat(
+    const systems::Context<T>& context) const {
+  const auto& contact_results =
+      contact_results_input_port().template Eval<ContactResults<T>>(context);
+
+  std::map<SortedPair<GeometryId>, bool> contacts_to_process = contacts_;
+
+  for (int i = 0; i < contact_results.num_point_pair_contacts(); ++i) {
+    const PointPairContactInfo<T>& info =
+        contact_results.point_pair_contact_info(i);
+    const geometry::PenetrationAsPointPair<T>& pair = info.point_pair();
+
+    const SortedPair<GeometryId> ids(pair.id_A, pair.id_B);
+    const double force_norm = ExtractDoubleOrThrow(info.contact_force()).norm();
+    // TODO(russt): Use geometry instance names once they are cleaned up
+    // or the body name convention in ContactResultsToLcmSystem.
+    const std::string path =
+        fmt::format("{}/{}+{}", params_.prefix, pair.id_A, pair.id_B);
+    const bool visible = (force_norm >= params_.force_threshold);
+
+    const double arrowhead_height = params_.radius * 2.0;
+    const double arrowhead_width = params_.radius * 2.0;
+
+    auto iter = contacts_.find(ids);
+    if (iter == contacts_.end()) {
+      // This contact hasn't been visualized yet.
+      if (!visible) {
+        // Continue without visualizing.
+        continue;
+      }
+
+      // Add the geometry to meshcat.
+      // Note: the height of the cylinder is 2 and gets scaled to twice the
+      // contact force length because I am drawing both (equal and opposite)
+      // forces.
+      meshcat_->SetObject(path + "/cylinder",
+                          geometry::Cylinder(params_.radius, 2.0),
+                          params_.color);
+      const geometry::MeshcatCone arrowhead(arrowhead_height, arrowhead_width,
+                                            arrowhead_width);
+      meshcat_->SetObject(path + "/head", arrowhead, params_.color);
+      meshcat_->SetObject(path + "/tail", arrowhead, params_.color);
+
+      contacts_[ids] = true;
+    } else {
+      // This contact has been visualized before.  We avoid setting or deleting
+      // the existing objects, as it leads to visual artifacts (flickering) in
+      // the browser, and is incompatible with animations.
+      if (visible != iter->second) {
+        meshcat_->SetProperty(path, "visible", visible);
+        iter->second = visible;
+      }
+      contacts_[ids] = visible;
+      contacts_to_process.erase(ids);
+    }
+
+    if (visible) {
+      // Set the transforms.
+      const double height = force_norm / params_.newtons_per_meter;
+      // Stretch the cylinder in z.
+      meshcat_->SetTransform(
+          path + "/cylinder",
+          Eigen::Matrix4d(Eigen::Vector4d{1, 1, height, 1}.asDiagonal()));
+      // Translate the arrowheads.
+      meshcat_->SetTransform(path + "/head",
+                             math::RigidTransformd(Eigen::Vector3d{
+                                 0, 0, -height - arrowhead_height}));
+      meshcat_->SetTransform(
+          path + "/tail",
+          math::RigidTransformd(
+              math::RotationMatrixd::MakeXRotation(M_PI),
+              Eigen::Vector3d{0, 0, height + arrowhead_height}));
+
+      meshcat_->SetTransform(
+          path, math::RigidTransformd(
+                    math::RotationMatrixd::MakeFromOneVector(
+                        ExtractDoubleOrThrow(info.contact_force()), 2),
+                    ExtractDoubleOrThrow(info.contact_point())));
+    }
+  }
+
+  // Set visible=false for any contacts not in the current list.
+  for (const auto& [ids, visible] : contacts_to_process) {
+    if (visible) {
+      const std::string path =
+          fmt::format("{}/{}+{}", params_.prefix, ids.first(), ids.second());
+      meshcat_->SetProperty(path, "visible", false);
+    }
+    contacts_[ids] = false;
+  }
+
+  return systems::EventStatus::Succeeded();
+}
+
+template <typename T>
+systems::EventStatus ContactResultsToMeshcat<T>::OnInitialization(
+    const systems::Context<T>&) const {
+  Delete();
+  return systems::EventStatus::Succeeded();
+}
+
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::ContactResultsToMeshcat)

--- a/multibody/plant/contact_results_to_meshcat.h
+++ b/multibody/plant/contact_results_to_meshcat.h
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "drake/geometry/meshcat.h"
+#include "drake/multibody/plant/contact_results_to_meshcat_params.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace multibody {
+
+/** ContactResultsToMeshcat is a system that publishes a ContactResults to
+geometry::Meshcat; it draws double-sided arrows at the location of the contact
+force with length scaled by the magnitude of the contact force.  The most common
+use of this system is to connect its input port to the contact results output
+port of a MultibodyPlant.
+
+ @system
+ name: ContactResultsToMeshcat
+ input_ports:
+ - contact_results
+ @endsystem
+
+Note: This system current only visualizes "point pair" contacts.
+
+@tparam_nonsymbolic_scalar
+@ingroup visualization */
+template <typename T>
+class ContactResultsToMeshcat final : public systems::LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ContactResultsToMeshcat)
+
+  /** Creates an instance of %ContactResultsToMeshcat */
+  explicit ContactResultsToMeshcat(std::shared_ptr<geometry::Meshcat> meshcat,
+                                   ContactResultsToMeshcatParams params = {});
+
+  /** Scalar-converting copy constructor. See @ref system_scalar_conversion.
+  It should only be used to convert _from_ double _to_ other scalar types. */
+  template <typename U>
+  explicit ContactResultsToMeshcat(const ContactResultsToMeshcat<U>& other);
+
+  /** Calls geometry::Meshcat::Delete(std::string_view path), with the path set
+  to `prefix`. Since this visualizer will only ever add geometry under this
+  prefix, this will remove all geometry/transforms added by the visualizer, or
+  by a previous instance of this visualizer using the same prefix.  Use the
+  `delete_on_initialization_event` in the parameters to determine whether this
+  should be called on initialization. */
+  void Delete() const;
+
+  /** Returns the multibody::ContactResults-valued input port. It should be
+  connected to MultibodyPlant's multibody::ContactResults-valued output port.
+  Failure to do so will cause a runtime error when attempting to broadcast
+  messages. */
+  const systems::InputPort<T>& contact_results_input_port() const {
+    return this->get_input_port(contact_results_input_port_);
+  }
+
+  /** Adds a ContactResultsToMeshcat and connects it to the given
+  MultibodyPlant's ContactResults-valued output port. */
+  static const ContactResultsToMeshcat<T>& AddToBuilder(
+      systems::DiagramBuilder<T>* builder, const MultibodyPlant<T>& plant,
+      std::shared_ptr<geometry::Meshcat> meshcat,
+      ContactResultsToMeshcatParams params = {});
+
+  /** Adds a ContactResultsToMeshcat and connects it to the given
+  multibody::ContactResults-valued output port. */
+  static const ContactResultsToMeshcat<T>& AddToBuilder(
+      systems::DiagramBuilder<T>* builder,
+      const systems::OutputPort<T>& contact_results_port,
+      std::shared_ptr<geometry::Meshcat> meshcat,
+      ContactResultsToMeshcatParams params = {});
+
+ private:
+  /* ContactResultsToMeshcat of different scalar types can all access each
+  other's data. */
+  template <typename>
+  friend class ContactResultsToMeshcat;
+
+  /* The periodic event handler. It tests to see if the last scene description
+  is valid (if not, sends the objects) and then sends the transforms. */
+  systems::EventStatus UpdateMeshcat(const systems::Context<T>& context) const;
+
+  /* Handles the initialization event. */
+  systems::EventStatus OnInitialization(const systems::Context<T>&) const;
+
+  /* The index of this System's QueryObject-valued input port. */
+  int contact_results_input_port_{};
+
+  /* Meshcat is mutable because we must send messages (a non-const operation)
+  from a const System (e.g. during simulation).  We use shared_ptr instead of
+  unique_ptr to facilitate sharing ownership through scalar conversion;
+  creating a new Meshcat object during the conversion is not a viable option.
+   */
+  mutable std::shared_ptr<geometry::Meshcat> meshcat_{};
+
+  /* Map of the published contact pairs to their boolean visible status. */
+  mutable std::map<SortedPair<geometry::GeometryId>, bool> contacts_{};
+
+  /* The parameters for the visualizer.  */
+  ContactResultsToMeshcatParams params_;
+};
+
+/** A convenient alias for the ContactResultsToMeshcat class when using
+the `double` scalar type. */
+using ContactResultsToMeshcatd = ContactResultsToMeshcat<double>;
+
+}  // namespace multibody
+
+}  // namespace drake
+
+DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::ContactResultsToMeshcat)

--- a/multibody/plant/contact_results_to_meshcat_params.h
+++ b/multibody/plant/contact_results_to_meshcat_params.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <string>
+
+#include "drake/geometry/rgba.h"
+
+namespace drake {
+namespace multibody {
+
+/** The set of parameters for configuring ContactResultsToMeshcat. */
+struct ContactResultsToMeshcatParams {
+  /** The duration (in simulation seconds) between attempts to update poses in
+   the visualizer. (To help avoid small simulation timesteps, we use a default
+   period that has an exact representation in binary floating point; see
+   drake#15021 for details.) */
+  double publish_period{1 / 32.0};
+
+  /** The color used to draw the contact force arrows. */
+  geometry::Rgba color{0, 1, 0, 1};
+
+  /** A prefix to add to the path for all objects and transforms curated by the
+   ContactResultsToMeshcat. It can be an absolute path or relative path.
+   If relative, this `prefix` will be appended to the geometry::Meshcat `prefix`
+   based on the standard path semantics in Meshcat. See @ref meshcat_path
+   "Meshcat paths" for details. */
+  std::string prefix{"contact_forces"};
+
+  /** Determines whether to send a Meschat::Delete(prefix) message on an
+   initialization event to remove any visualizations e.g. from a previous
+   simulation. See @ref declare_initialization_events "Declare initialization
+   events" for more information. */
+  bool delete_on_initialization_event{true};
+
+  /** The threshold below which forces will no longer be drawn.  The
+   ContactResultsToMeshcat constructor enforces that this must be strictly
+   positive; zero forces do not have a meaningful direction and cannot be
+   visualized. */
+  double force_threshold{0.01};
+
+  /** Sets the length scale of the force vectors. */
+  double newtons_per_meter{10};
+
+  /** The radius of cylinder geometry used in the force vector . */
+  double radius{0.01};
+};
+
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/plant/test/contact_results_to_meshcat_test.cc
+++ b/multibody/plant/test/contact_results_to_meshcat_test.cc
@@ -1,0 +1,163 @@
+#include "drake/multibody/plant/contact_results_to_meshcat.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/multibody/parsing/parser.h"
+#include "drake/multibody/plant/multibody_plant.h"
+#include "drake/multibody/tree/prismatic_joint.h"
+#include "drake/systems/framework/diagram_builder.h"
+
+namespace drake {
+namespace multibody {
+namespace {
+
+using geometry::Meshcat;
+
+// Set up a simple plant + visualizer.  The plant has two spheres on prismatic
+// joints.
+class ContactResultsToMeshcatTest : public ::testing::Test {
+ protected:
+  ContactResultsToMeshcatTest() : meshcat_(std::make_shared<Meshcat>()) {}
+
+  void SetUpDiagram(const ContactResultsToMeshcatParams& cparams =
+                        ContactResultsToMeshcatParams()) {
+    systems::DiagramBuilder<double> builder;
+    auto [plant, scene_graph] =
+        multibody::AddMultibodyPlantSceneGraph(&builder, 0.001);
+    multibody::Parser parser(&plant);
+    const std::string sdf = FindResourceOrThrow(
+        "drake/examples/manipulation_station/models/sphere.sdf");
+    auto sphere1_model = parser.AddModelFromFile(sdf, "sphere1");
+    plant.AddJoint<multibody::PrismaticJoint>(
+        "sphere1_x", plant.world_body(), std::nullopt,
+        plant.GetBodyByName("base_link", sphere1_model), std::nullopt,
+        Eigen::Vector3d::UnitX());
+    auto sphere2_model = parser.AddModelFromFile(sdf, "sphere2");
+    plant.AddJoint<multibody::PrismaticJoint>(
+        "sphere2_x", plant.world_body(), std::nullopt,
+        plant.GetBodyByName("base_link", sphere2_model), std::nullopt,
+        Eigen::Vector3d::UnitX());
+    plant.Finalize();
+    // The SceneGraph is needed for contact, but not referenced directly.
+    unused(scene_graph);
+
+    visualizer_ = &ContactResultsToMeshcatd::AddToBuilder(&builder, plant,
+                                                          meshcat_, cparams);
+
+    diagram_ = builder.Build();
+    context_ = diagram_->CreateDefaultContext();
+    // Start them in contact, but not completely overlapping.
+    plant.SetPositions(&plant.GetMyMutableContextFromRoot(context_.get()),
+                       Eigen::Vector2d{-0.03, 0.03});
+  }
+
+  std::shared_ptr<Meshcat> meshcat_;
+  const ContactResultsToMeshcat<double>* visualizer_{};
+  std::unique_ptr<systems::Diagram<double>> diagram_{};
+  std::unique_ptr<systems::Context<double>> context_{};
+};
+
+TEST_F(ContactResultsToMeshcatTest, Publish) {
+  SetUpDiagram();
+
+  EXPECT_FALSE(meshcat_->HasPath("contact_forces"));
+  diagram_->Publish(*context_);
+  EXPECT_TRUE(meshcat_->HasPath("contact_forces"));
+}
+
+TEST_F(ContactResultsToMeshcatTest, Parameters) {
+  ContactResultsToMeshcatParams params;
+  params.prefix = "test_prefix";
+  params.publish_period = 1 / 12.0;
+  // We don't have a good way to test the other parameters without
+  // visualization; they are partially covered by meshcat_manual_test.
+  SetUpDiagram(params);
+
+  diagram_->Publish(*context_);
+  EXPECT_FALSE(meshcat_->HasPath("contact_forces"));
+  EXPECT_TRUE(meshcat_->HasPath("test_prefix"));
+
+  auto periodic_events = visualizer_->GetPeriodicEvents();
+  for (const auto& data_and_vector : periodic_events) {
+    EXPECT_EQ(data_and_vector.second.size(), 1);  // only one periodic event
+    EXPECT_EQ(data_and_vector.first.period_sec(), params.publish_period);
+    EXPECT_EQ(data_and_vector.first.offset_sec(), 0.0);
+  }
+}
+
+TEST_F(ContactResultsToMeshcatTest, Delete) {
+  SetUpDiagram();
+
+  diagram_->Publish(*context_);
+  EXPECT_TRUE(meshcat_->HasPath("contact_forces"));
+
+  visualizer_->Delete();
+  EXPECT_FALSE(meshcat_->HasPath("contact_forces"));
+
+  diagram_->Publish(*context_);
+  EXPECT_TRUE(meshcat_->HasPath("contact_forces"));
+}
+
+GTEST_TEST(ContactResultsToMeshcat, PortTest) {
+  auto meshcat = std::make_shared<Meshcat>();
+  // Also tests the default constructor.
+  ContactResultsToMeshcat<double> visualizer(meshcat);
+  auto context = visualizer.CreateDefaultContext();
+
+  // Confirm that I can assign a ContactResults to this port.
+  multibody::ContactResults<double> results;
+  visualizer.contact_results_input_port().FixValue(context.get(), results);
+}
+
+// Test the other variant of AddToBuilder (taking the port instead of the
+// plant).
+GTEST_TEST(ContactResultsToMeshcat, AddToBuilderVariant) {
+  auto meshcat = std::make_shared<Meshcat>();
+  systems::DiagramBuilder<double> builder;
+  auto [plant, scene_graph] =
+      multibody::AddMultibodyPlantSceneGraph(&builder, 0.001);
+  multibody::Parser parser(&plant);
+  const std::string sdf = FindResourceOrThrow(
+      "drake/examples/manipulation_station/models/sphere.sdf");
+  auto sphere1_model = parser.AddModelFromFile(sdf, "sphere1");
+  plant.AddJoint<multibody::PrismaticJoint>(
+      "sphere1_x", plant.world_body(), std::nullopt,
+      plant.GetBodyByName("base_link", sphere1_model), std::nullopt,
+      Eigen::Vector3d::UnitX());
+  auto sphere2_model = parser.AddModelFromFile(sdf, "sphere2");
+  plant.AddJoint<multibody::PrismaticJoint>(
+      "sphere2_x", plant.world_body(), std::nullopt,
+      plant.GetBodyByName("base_link", sphere2_model), std::nullopt,
+      Eigen::Vector3d::UnitX());
+  plant.Finalize();
+  // The SceneGraph is needed for contact, but not referenced directly.
+  unused(scene_graph);
+
+  ContactResultsToMeshcatd::AddToBuilder(
+      &builder, plant.get_contact_results_output_port(), meshcat);
+
+  auto diagram = builder.Build();
+  auto context = diagram->CreateDefaultContext();
+  // Start them in contact, but not completely overlapping.
+  plant.SetPositions(&plant.GetMyMutableContextFromRoot(context.get()),
+                     Eigen::Vector2d{-0.03, 0.03});
+  diagram->Publish(*context);
+  EXPECT_TRUE(meshcat->HasPath("contact_forces"));
+}
+
+TEST_F(ContactResultsToMeshcatTest, ScalarConversion) {
+  SetUpDiagram();
+
+  auto ad_diagram = diagram_->ToAutoDiffXd();
+  auto ad_context = ad_diagram->CreateDefaultContext();
+
+  // Call publish to provide code coverage for the AutoDiffXd version of
+  // UpdateMeshcat.  We simply confirm that the code doesn't blow up.
+  ad_diagram->Publish(*ad_context);
+}
+
+}  // namespace
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
This is a cleaned-up C++ version of the MeshcatContactVisualizer in meshcat_visualizer.py .  It uses meshcat more effectively now, by simply setting the forces visible=False; this will also be compatible with animations that will include the forces (which never worked before).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15968)
<!-- Reviewable:end -->
