### PR TITLE
[pydrake] Add repr for some Options structs

### DIFF
--- a/bindings/pydrake/geometry_py_optimization.cc
+++ b/bindings/pydrake/geometry_py_optimization.cc
@@ -195,7 +195,22 @@ void DefineGeometryOptimization(py::module m) {
           doc.IrisOptions.iteration_limit.doc)
       .def_readwrite("termination_threshold",
           &IrisOptions::termination_threshold,
-          doc.IrisOptions.termination_threshold.doc);
+          doc.IrisOptions.termination_threshold.doc)
+      .def_readwrite("configuration_space_margin",
+          &IrisOptions::configuration_space_margin,
+          doc.IrisOptions.configuration_space_margin.doc)
+      .def("__repr__", [](const IrisOptions& self) {
+        return py::str(
+            "IrisOptions("
+            "require_sample_point_is_contained={}, "
+            "iteration_limit={}, "
+            "termination_threshold={}, "
+            "configuration_space_margin={}"
+            ")")
+            .format(self.require_sample_point_is_contained,
+                self.iteration_limit, self.termination_threshold,
+                self.configuration_space_margin);
+      });
 
   m.def("Iris", &Iris, py::arg("obstacles"), py::arg("sample"),
       py::arg("domain"), py::arg("options") = IrisOptions(), doc.Iris.doc);

--- a/bindings/pydrake/geometry_py_visualizers.cc
+++ b/bindings/pydrake/geometry_py_visualizers.cc
@@ -288,7 +288,18 @@ void DoScalarIndependentDefinitions(py::module m) {
             "prefix", &MeshcatVisualizerParams::prefix, cls_doc.prefix.doc)
         .def_readwrite("delete_on_initialization_event",
             &MeshcatVisualizerParams::delete_on_initialization_event,
-            cls_doc.delete_on_initialization_event.doc);
+            cls_doc.delete_on_initialization_event.doc)
+        .def("__repr__", [](const Class& self) {
+          return py::str(
+              "MeshcatVisualizerParams("
+              "publish_period={}, "
+              "role={}, "
+              "default_color={}, "
+              "prefix={}, "
+              "delete_on_initialization_event={}")
+              .format(self.publish_period, self.role, self.default_color,
+                  self.prefix, self.delete_on_initialization_event);
+        });
   }
 }
 

--- a/bindings/pydrake/test/geometry_optimization_test.py
+++ b/bindings/pydrake/test/geometry_optimization_test.py
@@ -187,6 +187,7 @@ class TestGeometryOptimization(unittest.TestCase):
         options.require_sample_point_is_contained = True
         options.iteration_limit = 1
         options.termination_threshold = 0.1
+        self.assertNotIn("object at 0x", repr(options))
         region = mut.optimization.Iris(
             obstacles=obstacles, sample=[2, 3.4, 5],
             domain=mut.optimization.HPolyhedron.MakeBox(

--- a/bindings/pydrake/test/geometry_visualizers_test.py
+++ b/bindings/pydrake/test/geometry_visualizers_test.py
@@ -155,6 +155,7 @@ class TestGeometryVisualizers(unittest.TestCase):
         params.default_color = mut.Rgba(0.5, 0.5, 0.5)
         params.prefix = "py_visualizer"
         params.delete_on_initialization_event = False
+        self.assertNotIn("object at 0x", repr(params))
         vis = mut.MeshcatVisualizerCpp_[T](meshcat=meshcat, params=params)
         vis.Delete()
         self.assertIsInstance(vis.query_object_input_port(), InputPort_[T])


### PR DESCRIPTION
Fixes `object at 0x....` churn in docs:
- https://drake.mit.edu/pydrake/pydrake.geometry.html#pydrake.geometry.MeshcatVisualizerCpp_[float]
- https://drake.mit.edu/pydrake/pydrake.geometry.optimization.html#pydrake.geometry.optimization.Iris

Also adds missing `configuration_space_margin` option binding for Iris.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15972)
<!-- Reviewable:end -->
