### PR TITLE
[geometry:optimization] Add python bindings for GraphOfConvexSets

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -124,6 +124,7 @@ drake_pybind_library(
         "//bindings/pydrake:documentation_pybind",
         "//bindings/pydrake/common:default_scalars_pybind",
         "//bindings/pydrake/common:deprecation_pybind",
+        "//bindings/pydrake/common:identifier_pybind",
         "//bindings/pydrake/common:type_pack",
         "//bindings/pydrake/common:type_safe_index_pybind",
         "//bindings/pydrake/common:value_pybind",

--- a/bindings/pydrake/common/BUILD.bazel
+++ b/bindings/pydrake/common/BUILD.bazel
@@ -291,6 +291,17 @@ drake_cc_library(
     ],
 )
 
+drake_cc_library(
+    name = "identifier_pybind",
+    hdrs = ["identifier_pybind.h"],
+    declare_installed_headers = 0,
+    visibility = ["//visibility:public"],
+    deps = [
+        "//:drake_shared_library",
+        "//bindings/pydrake:documentation_pybind",
+    ],
+)
+
 generate_pybind11_version_py_file(
     name = "pybind11_version.py",
 )

--- a/bindings/pydrake/common/identifier_pybind.h
+++ b/bindings/pydrake/common/identifier_pybind.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <string>
+
+#include "pybind11/operators.h"
+#include "pybind11/pybind11.h"
+
+#include "drake/bindings/pydrake/documentation_pybind.h"
+#include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/common/identifier.h"
+
+namespace drake {
+namespace pydrake {
+
+/// Binds an Identifier instantiation.
+template <typename Class, typename ModuleOrClass>
+void BindIdentifier(
+    ModuleOrClass m, const std::string& name, const char* id_doc) {
+  constexpr auto& cls_doc = pydrake_doc.drake.Identifier;
+
+  py::class_<Class>(m, name.c_str(), id_doc)
+      .def("get_value", &Class::get_value, cls_doc.get_value.doc)
+      .def("is_valid", &Class::is_valid, cls_doc.is_valid.doc)
+      .def(py::self == py::self)
+      .def(py::self != py::self)
+      .def(py::self < py::self)
+      // TODO(eric.cousineau): Use `py::hash()` instead of `py::detail::hash()`
+      // pending merge of: https://github.com/pybind/pybind11/pull/2217
+      .def(py::detail::hash(py::self))
+      .def_static("get_new_id", &Class::get_new_id, cls_doc.get_new_id.doc)
+      .def("__repr__", [name](const Class& self) {
+        return py::str("<{} value={}>").format(name, self.get_value());
+      });
+}
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/geometry_py_common.cc
+++ b/bindings/pydrake/geometry_py_common.cc
@@ -7,6 +7,7 @@
 #include "pybind11/operators.h"
 
 #include "drake/bindings/pydrake/common/default_scalars_pybind.h"
+#include "drake/bindings/pydrake/common/identifier_pybind.h"
 #include "drake/bindings/pydrake/common/value_pybind.h"
 #include "drake/bindings/pydrake/documentation_pybind.h"
 #include "drake/geometry/collision_filter_declaration.h"
@@ -23,25 +24,6 @@
 namespace drake {
 namespace pydrake {
 namespace {
-
-template <typename Class>
-void BindIdentifier(py::module m, const std::string& name, const char* id_doc) {
-  constexpr auto& cls_doc = pydrake_doc.drake.Identifier;
-
-  py::class_<Class>(m, name.c_str(), id_doc)
-      .def("get_value", &Class::get_value, cls_doc.get_value.doc)
-      .def("is_valid", &Class::is_valid, cls_doc.is_valid.doc)
-      .def(py::self == py::self)
-      .def(py::self != py::self)
-      .def(py::self < py::self)
-      // TODO(eric.cousineau): Use `py::hash()` instead of `py::detail::hash()`
-      // pending merge of: https://github.com/pybind/pybind11/pull/2217
-      .def(py::detail::hash(py::self))
-      .def_static("get_new_id", &Class::get_new_id, cls_doc.get_new_id.doc)
-      .def("__repr__", [name](const Class& self) {
-        return py::str("<{} value={}>").format(name, self.get_value());
-      });
-}
 
 void DoScalarIndependentDefinitions(py::module m) {
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.

--- a/bindings/pydrake/test/geometry_optimization_test.py
+++ b/bindings/pydrake/test/geometry_optimization_test.py
@@ -1,11 +1,18 @@
-import pydrake.geometry as mut
+import pydrake.geometry.optimization as mut
 
 import unittest
 
 import numpy as np
 
+from pydrake.geometry import (
+    Box, Capsule, Cylinder, Ellipsoid, FramePoseVector, GeometryFrame,
+    GeometryInstance, SceneGraph, Sphere,
+)
 from pydrake.math import RigidTransform
-from pydrake.solvers.mathematicalprogram import MathematicalProgram
+from pydrake.solvers.mathematicalprogram import (
+    MathematicalProgram, MathematicalProgramResult, Binding, Cost, Constraint
+)
+from pydrake.symbolic import Variable
 
 
 class TestGeometryOptimization(unittest.TestCase):
@@ -19,7 +26,7 @@ class TestGeometryOptimization(unittest.TestCase):
 
     def test_point_convex_set(self):
         p = np.array([11.1, 12.2, 13.3])
-        point = mut.optimization.Point(p)
+        point = mut.Point(p)
         self.assertEqual(point.ambient_dimension(), 3)
         np.testing.assert_array_equal(point.x(), p)
         point.set_x(x=2*p)
@@ -30,7 +37,7 @@ class TestGeometryOptimization(unittest.TestCase):
         # builds from shape.
 
     def test_h_polyhedron(self):
-        hpoly = mut.optimization.HPolyhedron(A=self.A, b=self.b)
+        hpoly = mut.HPolyhedron(A=self.A, b=self.b)
         self.assertEqual(hpoly.ambient_dimension(), 3)
         np.testing.assert_array_equal(hpoly.A(), self.A)
         np.testing.assert_array_equal(hpoly.b(), self.b)
@@ -40,167 +47,214 @@ class TestGeometryOptimization(unittest.TestCase):
                 RuntimeError, ".*not implemented yet for HPolyhedron.*"):
             hpoly.ToShapeWithPose()
 
-        h_box = mut.optimization.HPolyhedron.MakeBox(
+        h_box = mut.HPolyhedron.MakeBox(
             lb=[-1, -1, -1], ub=[1, 1, 1])
-        h_unit_box = mut.optimization.HPolyhedron.MakeUnitBox(dim=3)
+        h_unit_box = mut.HPolyhedron.MakeUnitBox(dim=3)
         np.testing.assert_array_equal(h_box.A(), h_unit_box.A())
         np.testing.assert_array_equal(h_box.b(), h_unit_box.b())
         self.assertIsInstance(
             h_box.MaximumVolumeInscribedEllipsoid(),
-            mut.optimization.Hyperellipsoid)
+            mut.Hyperellipsoid)
         np.testing.assert_array_almost_equal(
             h_box.ChebyshevCenter(), [0, 0, 0])
 
     def test_hyper_ellipsoid(self):
-        ellipsoid = mut.optimization.Hyperellipsoid(A=self.A, center=self.b)
+        ellipsoid = mut.Hyperellipsoid(A=self.A, center=self.b)
         self.assertEqual(ellipsoid.ambient_dimension(), 3)
         np.testing.assert_array_equal(ellipsoid.A(), self.A)
         np.testing.assert_array_equal(ellipsoid.center(), self.b)
         self.assertTrue(ellipsoid.PointInSet(x=self.b, tol=0.0))
         ellipsoid.AddPointInSetConstraints(self.prog, self.x)
         shape, pose = ellipsoid.ToShapeWithPose()
-        self.assertIsInstance(shape, mut.Ellipsoid)
+        self.assertIsInstance(shape, Ellipsoid)
         self.assertIsInstance(pose, RigidTransform)
         p = np.array([11.1, 12.2, 13.3])
-        point = mut.optimization.Point(p)
+        point = mut.Point(p)
         scale, witness = ellipsoid.MinimumUniformScalingToTouch(point)
         self.assertTrue(scale > 0.0)
         np.testing.assert_array_almost_equal(witness, p)
-        e_ball = mut.optimization.Hyperellipsoid.MakeAxisAligned(
+        e_ball = mut.Hyperellipsoid.MakeAxisAligned(
             radius=[1, 1, 1], center=self.b)
         np.testing.assert_array_equal(e_ball.A(), self.A)
         np.testing.assert_array_equal(e_ball.center(), self.b)
-        e_ball2 = mut.optimization.Hyperellipsoid.MakeHypersphere(
+        e_ball2 = mut.Hyperellipsoid.MakeHypersphere(
             radius=1, center=self.b)
         np.testing.assert_array_equal(e_ball2.A(), self.A)
         np.testing.assert_array_equal(e_ball2.center(), self.b)
-        e_ball3 = mut.optimization.Hyperellipsoid.MakeUnitBall(dim=3)
+        e_ball3 = mut.Hyperellipsoid.MakeUnitBall(dim=3)
         np.testing.assert_array_equal(e_ball3.A(), self.A)
         np.testing.assert_array_equal(e_ball3.center(), [0, 0, 0])
 
     def test_minkowski_sum(self):
-        point = mut.optimization.Point(np.array([11.1, 12.2, 13.3]))
-        hpoly = mut.optimization.HPolyhedron(A=self.A, b=self.b)
-        sum = mut.optimization.MinkowskiSum(setA=point, setB=hpoly)
+        point = mut.Point(np.array([11.1, 12.2, 13.3]))
+        hpoly = mut.HPolyhedron(A=self.A, b=self.b)
+        sum = mut.MinkowskiSum(setA=point, setB=hpoly)
         self.assertEqual(sum.ambient_dimension(), 3)
         self.assertEqual(sum.num_terms(), 2)
-        sum2 = mut.optimization.MinkowskiSum(sets=[point, hpoly])
+        sum2 = mut.MinkowskiSum(sets=[point, hpoly])
         self.assertEqual(sum2.ambient_dimension(), 3)
         self.assertEqual(sum2.num_terms(), 2)
-        self.assertIsInstance(sum2.term(0), mut.optimization.Point)
+        self.assertIsInstance(sum2.term(0), mut.Point)
 
     def test_v_polytope(self):
         vertices = np.array([[0.0, 1.0, 2.0], [3.0, 7.0, 5.0]])
-        vpoly = mut.optimization.VPolytope(vertices=vertices)
+        vpoly = mut.VPolytope(vertices=vertices)
         self.assertEqual(vpoly.ambient_dimension(), 2)
         np.testing.assert_array_equal(vpoly.vertices(), vertices)
         self.assertTrue(vpoly.PointInSet(x=[1.0, 5.0], tol=1e-8))
         vpoly.AddPointInSetConstraints(self.prog, self.x[0:2])
-        v_box = mut.optimization.VPolytope.MakeBox(
+        v_box = mut.VPolytope.MakeBox(
             lb=[-1, -1, -1], ub=[1, 1, 1])
         self.assertTrue(v_box.PointInSet([0, 0, 0]))
-        v_unit_box = mut.optimization.VPolytope.MakeUnitBox(dim=3)
+        v_unit_box = mut.VPolytope.MakeUnitBox(dim=3)
         self.assertTrue(v_unit_box.PointInSet([0, 0, 0]))
 
     def test_cartesian_product(self):
-        point = mut.optimization.Point(np.array([11.1, 12.2, 13.3]))
-        h_box = mut.optimization.HPolyhedron.MakeBox(
+        point = mut.Point(np.array([11.1, 12.2, 13.3]))
+        h_box = mut.HPolyhedron.MakeBox(
             lb=[-1, -1, -1], ub=[1, 1, 1])
-        sum = mut.optimization.CartesianProduct(setA=point, setB=h_box)
+        sum = mut.CartesianProduct(setA=point, setB=h_box)
         self.assertEqual(sum.ambient_dimension(), 6)
         self.assertEqual(sum.num_factors(), 2)
-        sum2 = mut.optimization.CartesianProduct(sets=[point, h_box])
+        sum2 = mut.CartesianProduct(sets=[point, h_box])
         self.assertEqual(sum2.ambient_dimension(), 6)
         self.assertEqual(sum2.num_factors(), 2)
-        self.assertIsInstance(sum2.factor(0), mut.optimization.Point)
-        sum2 = mut.optimization.CartesianProduct(
+        self.assertIsInstance(sum2.factor(0), mut.Point)
+        sum2 = mut.CartesianProduct(
             sets=[point, h_box], A=np.eye(6, 3), b=[0, 1, 2, 3, 4, 5])
         self.assertEqual(sum2.ambient_dimension(), 3)
         self.assertEqual(sum2.num_factors(), 2)
-        self.assertIsInstance(sum2.factor(1), mut.optimization.HPolyhedron)
+        self.assertIsInstance(sum2.factor(1), mut.HPolyhedron)
 
     def test_make_from_scene_graph_and_iris(self):
         """
         Tests the make from scene graph and iris functionality together as
         the Iris code makes obstacles from geometries registered in SceneGraph.
         """
-        scene_graph = mut.SceneGraph()
+        scene_graph = SceneGraph()
         source_id = scene_graph.RegisterSource("source")
         frame_id = scene_graph.RegisterFrame(
-            source_id=source_id, frame=mut.GeometryFrame("frame"))
+            source_id=source_id, frame=GeometryFrame("frame"))
         box_geometry_id = scene_graph.RegisterGeometry(
             source_id=source_id, frame_id=frame_id,
-            geometry=mut.GeometryInstance(X_PG=RigidTransform(),
-                                          shape=mut.Box(1., 1., 1.),
-                                          name="box"))
+            geometry=GeometryInstance(X_PG=RigidTransform(),
+                                      shape=Box(1., 1., 1.),
+                                      name="box"))
         cylinder_geometry_id = scene_graph.RegisterGeometry(
             source_id=source_id, frame_id=frame_id,
-            geometry=mut.GeometryInstance(X_PG=RigidTransform(),
-                                          shape=mut.Cylinder(1., 1.),
-                                          name="cylinder"))
+            geometry=GeometryInstance(X_PG=RigidTransform(),
+                                      shape=Cylinder(1., 1.),
+                                      name="cylinder"))
         sphere_geometry_id = scene_graph.RegisterGeometry(
             source_id=source_id, frame_id=frame_id,
-            geometry=mut.GeometryInstance(X_PG=RigidTransform(),
-                                          shape=mut.Sphere(1.), name="sphere"))
+            geometry=GeometryInstance(X_PG=RigidTransform(),
+                                      shape=Sphere(1.), name="sphere"))
         capsule_geometry_id = scene_graph.RegisterGeometry(
             source_id=source_id,
             frame_id=frame_id,
-            geometry=mut.GeometryInstance(X_PG=RigidTransform(),
-                                          shape=mut.Capsule(1., 1.0),
-                                          name="capsule"))
+            geometry=GeometryInstance(X_PG=RigidTransform(),
+                                      shape=Capsule(1., 1.0),
+                                      name="capsule"))
         context = scene_graph.CreateDefaultContext()
-        pose_vector = mut.FramePoseVector()
+        pose_vector = FramePoseVector()
         pose_vector.set_value(frame_id, RigidTransform())
         scene_graph.get_source_pose_port(source_id).FixValue(
             context, pose_vector)
         query_object = scene_graph.get_query_output_port().Eval(context)
-        H = mut.optimization.HPolyhedron(
+        H = mut.HPolyhedron(
             query_object=query_object, geometry_id=box_geometry_id,
             reference_frame=scene_graph.world_frame_id())
         self.assertEqual(H.ambient_dimension(), 3)
-        C = mut.optimization.CartesianProduct(
+        C = mut.CartesianProduct(
             query_object=query_object, geometry_id=cylinder_geometry_id,
             reference_frame=scene_graph.world_frame_id())
         self.assertEqual(C.ambient_dimension(), 3)
-        E = mut.optimization.Hyperellipsoid(
+        E = mut.Hyperellipsoid(
             query_object=query_object, geometry_id=sphere_geometry_id,
             reference_frame=scene_graph.world_frame_id())
         self.assertEqual(E.ambient_dimension(), 3)
-        S = mut.optimization.MinkowskiSum(
+        S = mut.MinkowskiSum(
             query_object=query_object, geometry_id=capsule_geometry_id,
             reference_frame=scene_graph.world_frame_id())
         self.assertEqual(S.ambient_dimension(), 3)
-        P = mut.optimization.Point(
+        P = mut.Point(
             query_object=query_object, geometry_id=sphere_geometry_id,
             reference_frame=scene_graph.world_frame_id(),
             maximum_allowable_radius=1.5)
         self.assertEqual(P.ambient_dimension(), 3)
-        V = mut.optimization.VPolytope(
+        V = mut.VPolytope(
             query_object=query_object, geometry_id=box_geometry_id,
             reference_frame=scene_graph.world_frame_id())
         self.assertEqual(V.ambient_dimension(), 3)
 
-        obstacles = mut.optimization.MakeIrisObstacles(
+        obstacles = mut.MakeIrisObstacles(
             query_object=query_object,
             reference_frame=scene_graph.world_frame_id())
-        options = mut.optimization.IrisOptions()
+        options = mut.IrisOptions()
         options.require_sample_point_is_contained = True
         options.iteration_limit = 1
         options.termination_threshold = 0.1
         self.assertNotIn("object at 0x", repr(options))
-        region = mut.optimization.Iris(
+        region = mut.Iris(
             obstacles=obstacles, sample=[2, 3.4, 5],
-            domain=mut.optimization.HPolyhedron.MakeBox(
+            domain=mut.HPolyhedron.MakeBox(
                 lb=[-5, -5, -5], ub=[5, 5, 5]), options=options)
-        self.assertIsInstance(region, mut.optimization.HPolyhedron)
+        self.assertIsInstance(region, mut.HPolyhedron)
 
         obstacles = [
-            mut.optimization.HPolyhedron.MakeUnitBox(3),
-            mut.optimization.Hyperellipsoid.MakeUnitBall(3),
-            mut.optimization.Point([0, 0, 0]),
-            mut.optimization.VPolytope.MakeUnitBox(3)]
-        region = mut.optimization.Iris(
+            mut.HPolyhedron.MakeUnitBox(3),
+            mut.Hyperellipsoid.MakeUnitBall(3),
+            mut.Point([0, 0, 0]),
+            mut.VPolytope.MakeUnitBox(3)]
+        region = mut.Iris(
             obstacles=obstacles, sample=[2, 3.4, 5],
-            domain=mut.optimization.HPolyhedron.MakeBox(
+            domain=mut.HPolyhedron.MakeBox(
                 lb=[-5, -5, -5], ub=[5, 5, 5]), options=options)
-        self.assertIsInstance(region, mut.optimization.HPolyhedron)
+        self.assertIsInstance(region, mut.HPolyhedron)
+
+    def test_graph_of_convex_sets(self):
+        spp = mut.GraphOfConvexSets()
+        source = spp.AddVertex(set=mut.Point([0.0]), name="source")
+        target = spp.AddVertex(set=mut.Point([0.0]), name="target")
+        edge0 = spp.AddEdge(u=source, v=target, name="edge0")
+        edge1 = spp.AddEdge(u_id=source.id(), v_id=target.id(), name="edge1")
+        self.assertEqual(len(spp.VertexIds()), 2)
+        self.assertEqual(len(spp.Edges()), 2)
+        result = spp.SolveShortestPath(
+            source_id=source.id(), target_id=target.id(),
+            convex_relaxation=True)
+        self.assertIsInstance(result, MathematicalProgramResult)
+        self.assertIsInstance(spp.SolveShortestPath(
+            source=source, target=target, convex_relaxation=True),
+            MathematicalProgramResult)
+
+        # Vertex
+        self.assertIsInstance(source.id(), mut.GraphOfConvexSets.VertexId)
+        self.assertEqual(source.ambient_dimension(), 1)
+        self.assertEqual(source.name(), "source")
+        self.assertIsInstance(source.x()[0], Variable)
+        self.assertIsInstance(source.set(), mut.Point)
+        np.testing.assert_array_almost_equal(
+            source.GetSolution(result), [0.], 1e-6)
+
+        # Edge
+        self.assertAlmostEqual(edge0.GetSolutionCost(result=result), 0.0, 1e-6)
+        self.assertIsInstance(edge0.id(), mut.GraphOfConvexSets.EdgeId)
+        self.assertEqual(edge0.name(), "edge0")
+        self.assertEqual(edge0.u(), source)
+        self.assertEqual(edge0.v(), target)
+        self.assertIsInstance(edge0.phi(), Variable)
+        self.assertIsInstance(edge0.xu()[0], Variable)
+        self.assertIsInstance(edge0.xv()[0], Variable)
+        var, binding = edge0.AddCost(e=1.0+edge0.xu()[0])
+        self.assertIsInstance(var, Variable)
+        self.assertIsInstance(binding, Binding[Cost])
+        var, binding = edge0.AddCost(binding=binding)
+        self.assertIsInstance(var, Variable)
+        self.assertIsInstance(binding, Binding[Cost])
+        binding = edge0.AddConstraint(f=(edge0.xu()[0] == edge0.xv()[0]))
+        self.assertIsInstance(binding, Binding[Constraint])
+        binding = edge0.AddConstraint(binding=binding)
+        self.assertIsInstance(binding, Binding[Constraint])
+        edge0.AddPhiConstraint(phi_value=False)
+        edge0.ClearPhiConstraints()

--- a/geometry/optimization/graph_of_convex_sets.h
+++ b/geometry/optimization/graph_of_convex_sets.h
@@ -125,7 +125,7 @@ class GraphOfConvexSets {
     const Vertex& u() const { return *u_; }
 
     /** Returns a const reference to the "right" Vertex that this edge connects
-     * to. */
+    to. */
     const Vertex& v() const { return *v_; }
 
     /** Returns the binary variable associated with this edge. It can be used
@@ -153,6 +153,7 @@ class GraphOfConvexSets {
     @endverbatim
     @returns the pair <ℓ, Binding<Cost>>.
     @throws std::exception if e.GetVariables() is not a subset of xu() ∪ xv().
+    @pydrake_mkdoc_identifier{expression}
     */
     std::pair<symbolic::Variable, solvers::Binding<solvers::Cost>> AddCost(
         const symbolic::Expression& e);
@@ -166,7 +167,9 @@ class GraphOfConvexSets {
     @endverbatim
     @returns the pair <ℓ, Binding<Cost>>.
     @throws std::exception if binding.variables() is not a subset of xu() ∪
-    xv(). */
+    xv().
+    @pydrake_mkdoc_identifier{binding}
+    */
     std::pair<symbolic::Variable, solvers::Binding<solvers::Cost>> AddCost(
         const solvers::Binding<solvers::Cost>& binding);
 
@@ -174,6 +177,7 @@ class GraphOfConvexSets {
     containing *only* elements of xu() and xv() as variables.
     @throws std::exception if f.GetFreeVariables() is not a subset of xu() ∪
     xv().
+    @pydrake_mkdoc_identifier{formula}
     */
     solvers::Binding<solvers::Constraint> AddConstraint(
         const symbolic::Formula& f);
@@ -181,7 +185,9 @@ class GraphOfConvexSets {
     /** Adds a constraint to this edge.  @p binding must contain *only*
     elements of xu() and xv() as variables.
     @throws std::exception if binding.variables() is not a subset of xu() ∪
-    xv(). */
+    xv().
+    @pydrake_mkdoc_identifier{binding}
+    */
     solvers::Binding<solvers::Constraint> AddConstraint(
         const solvers::Binding<solvers::Constraint>& binding);
 
@@ -235,13 +241,17 @@ class GraphOfConvexSets {
 
   /** Adds an edge to the graph from VertexId @p u_id to VertexId @p v_id.  The
   ids must refer to valid vertices in this graph. If @p name is empty then a
-  default name will be provided. */
+  default name will be provided.
+  @pydrake_mkdoc_identifier{by_id}
+  */
   Edge* AddEdge(const VertexId& u_id, const VertexId& v_id,
                 std::string name = "");
 
   /** Adds an edge to the graph from Vertex @p u to Vertex @p v.  The
   vertex references must refer to valid vertices in this graph. If @p name is
-  empty then a default name will be provided. */
+  empty then a default name will be provided.
+  @pydrake_mkdoc_identifier{by_reference}
+  */
   Edge* AddEdge(const Vertex& u, const Vertex& v, std::string name = "");
 
   /** Returns the VertexIds of the vertices stored in the graph.  Note that the
@@ -275,13 +285,16 @@ class GraphOfConvexSets {
   @throws std::exception if any of the costs or constraints in the graph are
   incompatible with the shortest path formulation or otherwise unsupported.
   All costs must be non-negative (for all values of the continuous variables).
+  @pydrake_mkdoc_identifier{by_id}
   */
   solvers::MathematicalProgramResult SolveShortestPath(
       const VertexId& source_id, const VertexId& target_id,
       bool convex_relaxation = false) const;
 
   /** Convenience overload that takes const reference arguments for source and
-  target. */
+  target.
+  @pydrake_mkdoc_identifier{by_reference}
+  */
   solvers::MathematicalProgramResult SolveShortestPath(
       const Vertex& source, const Vertex& target,
       bool convex_relaxation = false) const;


### PR DESCRIPTION
Also lifts the BindIdentifier logic out of geometry_py_common.cc (next
to the equivalent BindTypeSafeIndex) so that it can be used in
geometry_py_optimization.cc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15974)
<!-- Reviewable:end -->
