### PR TITLE
MeshcatPointCloudVisualizer: Add missing newline in docs

### DIFF
--- a/geometry/meshcat_point_cloud_visualizer.h
+++ b/geometry/meshcat_point_cloud_visualizer.h
@@ -16,7 +16,8 @@ namespace geometry {
 perception::PointCloud from its input port to Meshcat.
 
 @system
-name: MeshcatPointCloudVisualizer input_ports:
+name: MeshcatPointCloudVisualizer
+input_ports:
 - cloud
 - X_ParentCloud (optional)
 @endsystem


### PR DESCRIPTION
The changes in #15938 caused the doc builds to fail:

- [linux-bionic-unprovisioned-gcc-bazel-continuous-documentation](https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-bionic-unprovisioned-gcc-bazel-continuous-documentation/1172/)
- [linux-focal-unprovisioned-gcc-bazel-continuous-documentation](https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-focal-unprovisioned-gcc-bazel-continuous-documentation/1173/)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15980)
<!-- Reviewable:end -->
