### PR TITLE
py unittest: Do not use XMLTestRunner when using --trace

### DIFF
--- a/common/test_utilities/drake_py_unittest_main.py
+++ b/common/test_utilities/drake_py_unittest_main.py
@@ -128,7 +128,8 @@ def main():
         # warnings settings, exploting a loophole where it checks "if warnings
         # is None" to check if the user passed a kwarg, but "if warning" to
         # actually apply the user's kwarg.
-        if "XML_OUTPUT_FILE" in os.environ:
+        # N.B. Do not use the runner when `--trace={user,sys}` is enabled.
+        if "XML_OUTPUT_FILE" in os.environ and args.trace == "none":
             with open(os.environ["XML_OUTPUT_FILE"], "wb") as output:
                 unittest.main(
                     module=test_name, argv=unittest_argv, warnings=False,


### PR DESCRIPTION
Resolves #15981

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15982)
<!-- Reviewable:end -->
