### PR TITLE
[geometry] Clean up volume_to_surface_mesh_test.

### DIFF
--- a/geometry/proximity/test/volume_to_surface_mesh_test.cc
+++ b/geometry/proximity/test/volume_to_surface_mesh_test.cc
@@ -15,27 +15,6 @@ namespace geometry {
 namespace internal {
 namespace {
 
-// Calculates unit normal vector to a triangular face of a surface mesh. The
-// direction of the vector depends on the winding of the face.
-template <typename T>
-Vector3<T> CalcFaceNormal(const TriangleSurfaceMesh<T>& surface,
-                          int face_index) {
-  // TODO(DamrongGuoy): Consider moving this function into TriangleSurfaceMesh
-  //  by adding a member variable `normal_M_` similar to `area_`. Consequently
-  //  we will update `normal_M_` when TransformVertices() and
-  //  ReverseFaceWinding() of TriangleSurfaceMesh are called.
-  const SurfaceTriangle& face = surface.element(face_index);
-  const Vector3<T>& r_MA = surface.vertex(face.vertex(0));
-  const Vector3<T>& r_MB = surface.vertex(face.vertex(1));
-  const Vector3<T>& r_MC = surface.vertex(face.vertex(2));
-  const auto r_AB_M = r_MB - r_MA;
-  const auto r_AC_M = r_MC - r_MA;
-  const auto rhat_AB_M = r_AB_M.normalized();
-  const auto rhat_AC_M = r_AC_M.normalized();
-  const auto cross_M = rhat_AB_M.cross(rhat_AC_M);
-  return cross_M.normalized();
-}
-
 GTEST_TEST(VolumeToSurfaceMeshTest, IdentifyBoundaryFaces) {
   // Two tetrahedra with their five vertices like this:
   //
@@ -134,11 +113,10 @@ void TestVolumeToSurfaceMesh() {
 
   // Check that the face normal vectors are in the outward direction.
   for (int f = 0; f < surface.num_triangles(); ++f) {
-    const Vector3<T> normal_M = internal::CalcFaceNormal(surface, f);
     // Position vector of the first vertex V of the face.
     const Vector3<T> r_MV =
         surface.vertex(surface.element(f).vertex(0));
-    EXPECT_GT(normal_M.dot(r_MV), T(0.0));
+    EXPECT_GT(surface.face_normal(f).dot(r_MV), T(0.0));
   }
 }
 


### PR DESCRIPTION
[geometry] Clean up volume_to_surface_mesh_test.
  - Call face_normal() of the surface mesh instead of re-calculating it again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15989)
<!-- Reviewable:end -->
