### PR TITLE
[acrobot] Remove optional scenario_name

### DIFF
--- a/examples/acrobot/acrobot_io.py
+++ b/examples/acrobot/acrobot_io.py
@@ -3,25 +3,15 @@ import numpy as np
 from pydrake.common.yaml import yaml_load, yaml_dump
 
 
-def load_scenario(*, filename=None, data=None, scenario_name=None):
-    """Given a scenario `filename` xor `data`, and optionally `scenario_name`,
-    loads and returns one acrobot scenario from the file.  The `scenario_name`
-    may only be omitted when the file contains a single scenario.
+def load_scenario(*, filename=None, data=None):
+    """Given a scenario `filename` xor `data`  loads and
+    returns the acrobot scenario from the file.
     """
-    scenarios = yaml_load(filename=filename, data=data)
-    if scenario_name:
-        result = scenarios[scenario_name]
-    else:
-        if len(scenarios) != 1:
-            raise RuntimeError(
-                "A scenario_name is required because the scenario file "
-                "contains more than one scenario.")
-        (_, result), = scenarios.items()
-    return result
+    return yaml_load(filename=filename, data=data)
 
 
-def save_scenario(*, scenario, scenario_name):
-    """Given a scenario and its name, returns a yaml-formatted str for it.
+def save_scenario(*, scenario):
+    """Given a scenario, returns a yaml-formatted str for it.
     """
     # For a known list of scenario-specific items, convert numpy arrays into
     # lists for serialization purposes.
@@ -34,7 +24,7 @@ def save_scenario(*, scenario, scenario_name):
                 ]
         else:
             scrubbed[key] = [float(x) for x in scenario[key]]
-    return yaml_dump({scenario_name: scrubbed})
+    return yaml_dump(scrubbed)
 
 
 def load_output(*, filename=None, data=None):

--- a/examples/acrobot/optimizer_demo.py
+++ b/examples/acrobot/optimizer_demo.py
@@ -36,9 +36,7 @@ def evaluate_metric_once(scenario, metric, seeds):
                                      dir=env_tmpdir) as temp_dir:
         scenario_filename = os.path.join(temp_dir, "scenario.yaml")
         with open(scenario_filename, "w") as scenario_file:
-            scenario_file.write(
-                save_scenario(scenario=scenario,
-                              scenario_name="evaluation_scenario"))
+            scenario_file.write(save_scenario(scenario=scenario))
         tapes = []
         for seed in seeds:
             output_filename = os.path.join(temp_dir, f"output_{seed}.yaml")
@@ -123,8 +121,7 @@ def main():
             num_evaluations=args.num_evaluations)
         output_scenario = input_scenario
         output_scenario["controller_params"] = result
-        output.write(save_scenario(scenario=output_scenario,
-                                   scenario_name="optimized_scenario"))
+        output.write(save_scenario(scenario=output_scenario))
 
 
 if __name__ == "__main__":

--- a/examples/acrobot/spong_sim.py
+++ b/examples/acrobot/spong_sim.py
@@ -51,16 +51,12 @@ def simulate(*, initial_state, controller_params, t_final, tape_period):
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--scenario", metavar="*.yaml",
+        "--scenario", metavar="*.yaml", required=True,
         help="Scenario file to load (required).")
     parser.add_argument(
-        "--output", metavar="*.yaml",
+        "--output", metavar="*.yaml", required=True,
         help="Output file to save (required).")
     args = parser.parse_args()
-    if not args.scenario:
-        parser.error("A --scenario file is required.")
-    if not args.output:
-        parser.error("An --output file is required.")
     scenario = load_scenario(filename=args.scenario)
     x_tape = simulate(**scenario)
     text = save_output(x_tape=x_tape)

--- a/examples/acrobot/test/acrobot_io_test.py
+++ b/examples/acrobot/test/acrobot_io_test.py
@@ -14,28 +14,25 @@ class TestIo(unittest.TestCase):
         self.example = FindResourceOrThrow(
             "drake/examples/acrobot/test/example_scenario.yaml")
         # When saving, everything comes out as floats (not `int`, etc.).
-        self.expected_save = """example:
-  controller_params: [5.0, 50.0, 5.0, 1000.0]
-  initial_state: [1.2, 0.0, 0.0, 0.0]
-  t_final: 30.0
-  tape_period: 0.05
+        self.expected_save = """\
+controller_params: [5.0, 50.0, 5.0, 1000.0]
+initial_state: [1.2, 0.0, 0.0, 0.0]
+t_final: 30.0
+tape_period: 0.05
 """
 
     def test_load_scenario(self):
-        a = load_scenario(filename=self.example)
-        b = load_scenario(filename=self.example, scenario_name="example")
+        scenario = load_scenario(filename=self.example)
         expected = ", ".join([
             "{'controller_params': [5, 50, 5, '1e3']",
             "'initial_state': [1.2, 0, 0, 0]",
             "'t_final': 30.0",
             "'tape_period': 0.05}"])
-        self.assertEqual(str(a), expected)
-        self.assertEqual(str(b), expected)
-        self.assertEqual(a, b)
+        self.assertEqual(str(scenario), expected)
 
     def test_save_scenario(self):
         scenario = load_scenario(filename=self.example)
-        actual = save_scenario(scenario_name="example", scenario=scenario)
+        actual = save_scenario(scenario=scenario)
         self.assertEqual(actual, self.expected_save)
 
     def test_save_scenario_numpy(self):
@@ -45,7 +42,7 @@ class TestIo(unittest.TestCase):
             "t_final": 30.0,
             "tape_period": 0.05,
         }
-        actual = save_scenario(scenario_name="example", scenario=scenario)
+        actual = save_scenario(scenario=scenario)
         self.assertEqual(actual, self.expected_save)
 
     def test_save_scenario_stochastic(self):
@@ -58,14 +55,14 @@ class TestIo(unittest.TestCase):
             "t_final": 30.0,
             "tape_period": 0.05,
         }
-        actual = save_scenario(scenario_name="example", scenario=scenario)
-        self.assertEqual(actual, """example:
-  controller_params:
-    max: [5.0, 50.0, 5.0, 1000.0]
-    min: [1.0, 10.0, 1.0, 100.0]
-  initial_state: [1.2, 0.0, 0.0, 0.0]
-  t_final: 30.0
-  tape_period: 0.05
+        actual = save_scenario(scenario=scenario)
+        self.assertEqual(actual, """\
+controller_params:
+  max: [5.0, 50.0, 5.0, 1000.0]
+  min: [1.0, 10.0, 1.0, 100.0]
+initial_state: [1.2, 0.0, 0.0, 0.0]
+t_final: 30.0
+tape_period: 0.05
 """)
 
     def test_save_output_and_load_output(self):

--- a/examples/acrobot/test/example_scenario.yaml
+++ b/examples/acrobot/test/example_scenario.yaml
@@ -1,7 +1,6 @@
 # An example scenario for acrobot.
 
-example:
-  controller_params: [5, 50, 5, 1e3]
-  initial_state: [1.2, 0, 0, 0]
-  t_final: 30.0
-  tape_period: 0.05
+controller_params: [5, 50, 5, 1e3]
+initial_state: [1.2, 0, 0, 0]
+t_final: 30.0
+tape_period: 0.05

--- a/examples/acrobot/test/example_stochastic_scenario.yaml
+++ b/examples/acrobot/test/example_stochastic_scenario.yaml
@@ -1,11 +1,10 @@
 # An example scenario for acrobot, with randomness.
 
-example:
-  controller_params: !UniformVector
-    min: [4, 40, 4, 0.9e3]
-    max: [6, 60, 6, 1.1e3]
-  initial_state: !UniformVector
-    min: [1.1, -0.1, -0.1, -0.1]
-    max: [1.3, 0.1, 0.1, 0.1]
-  t_final: 30.0
-  tape_period: 0.05
+controller_params: !UniformVector
+  min: [4, 40, 4, 0.9e3]
+  max: [6, 60, 6, 1.1e3]
+initial_state: !UniformVector
+  min: [1.1, -0.1, -0.1, -0.1]
+  max: [1.3, 0.1, 0.1, 0.1]
+t_final: 30.0
+tape_period: 0.05


### PR DESCRIPTION
Preparation for #15902 towards #15868.  With the new sugar functions, there is no longer any affordance for parsing a YAML file halfway, guessing a scenario_name to use, and then finishing the de-serialization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/15998)
<!-- Reviewable:end -->
