### PR TITLE
fix missing SONAME fields for libdrake.so and libdrake_marker.so

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -316,12 +316,8 @@ drake_cc_binary(
         "drake_marker.h",
     ],
     linkopts = select({
-        "//tools/cc_toolchain:linux": [
-            "-pthread",
-            "-Wl,-soname,libdrake_marker.so",
-        ],
-        # This is a bazel-default rule, and does not need @drake//
-        "@//conditions:default": [],
+        "//tools/cc_toolchain:linux": ["-Wl,-soname,libdrake_marker.so"],
+        "//conditions:default": [],
     }),
     linkshared = 1,
     linkstatic = 1,

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -315,6 +315,14 @@ drake_cc_binary(
         "drake_marker.cc",
         "drake_marker.h",
     ],
+    linkopts = select({
+        "//tools/cc_toolchain:linux": [
+            "-pthread",
+            "-Wl,-soname,libdrake_marker.so",
+        ],
+        # This is a bazel-default rule, and does not need @drake//
+        "@//conditions:default": [],
+    }),
     linkshared = 1,
     linkstatic = 1,
     visibility = ["//visibility:private"],

--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -43,6 +43,14 @@ cc_whole_archive_library(
 # contain any references to constituent shared libraries inside the build tree.
 cc_binary(
     name = "libdrake.so",
+    linkopts = select({
+        "//tools/cc_toolchain:linux": [
+            "-pthread",
+            "-Wl,-soname,libdrake.so",
+        ],
+        # This is a bazel-default rule, and does not need @drake//
+        "@//conditions:default": [],
+    }),
     linkshared = 1,
     linkstatic = 1,
     deps = [

--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -44,12 +44,8 @@ cc_whole_archive_library(
 cc_binary(
     name = "libdrake.so",
     linkopts = select({
-        "//tools/cc_toolchain:linux": [
-            "-pthread",
-            "-Wl,-soname,libdrake.so",
-        ],
-        # This is a bazel-default rule, and does not need @drake//
-        "@//conditions:default": [],
+        "//tools/cc_toolchain:linux": ["-Wl,-soname,libdrake.so"],
+        "//conditions:default": [],
     }),
     linkshared = 1,
     linkstatic = 1,


### PR DESCRIPTION
Partially addresses #15946
Relates: #15963

The original patch suggested by @jwnimmer-tri

https://github.com/RobotLocomotion/drake/blob/610ec7f88ab8f09507d2cd382c48cb15393d9467/tools/workspace/spdlog/package.BUILD.bazel#L66-L70

Relies on

https://github.com/RobotLocomotion/drake/blob/610ec7f88ab8f09507d2cd382c48cb15393d9467/tools/workspace/spdlog/package.BUILD.bazel#L14-L18

(`config_setting(name = "linux", ...)`) being declared.  Currently this patch utilizes a selection based off of `//tools/cc_toolchain:linux`, I'm not sure if a new `config` entry should be declared or if the current selection here is valid.  I have a small SONAME verification script, prior to this change:

```
Drake specific libraries missing SONAME:
  - /tmp/drake-master/lib/libdrake_ibex.so
  - /tmp/drake-master/lib/libdrake_marker.so
  - /tmp/drake-master/lib/libdrake.so
```

Afterward:

```
Drake specific libraries missing SONAME:
  - /tmp/drake-soname-fixed/lib/libdrake_ibex.so
```

Where `libdrake_ibex.so` is currently on hold until #15963 is complete.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16002)
<!-- Reviewable:end -->
