### PR TITLE
[controllers] Deprecate CartesianSetpoint and VectorSetpoint

### DIFF
--- a/systems/controllers/BUILD.bazel
+++ b/systems/controllers/BUILD.bazel
@@ -275,6 +275,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "setpoint_test",
     srcs = ["test/setpoint_test.cc"],
+    copts = ["-Wno-deprecated-declarations"],
     # TODO(ggould-tri) This test hit kcov#339; untag when we have kcov>=40.
     tags = ["no_kcov"],
     deps = [

--- a/systems/controllers/setpoint.cc
+++ b/systems/controllers/setpoint.cc
@@ -4,8 +4,11 @@ namespace drake {
 namespace systems {
 namespace controllers {
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 template class CartesianSetpoint<double>;
 template class VectorSetpoint<double>;
+#pragma GCC diagnostic pop
 
 }  // namespace controllers
 }  // namespace systems

--- a/systems/controllers/setpoint.h
+++ b/systems/controllers/setpoint.h
@@ -30,7 +30,8 @@ namespace controllers {
  * accelerations.
  */
 template <typename Scalar>
-class CartesianSetpoint {
+class DRAKE_DEPRECATED("2022-02-01", "This (unused) class is being removed.")
+CartesianSetpoint {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CartesianSetpoint)
 
@@ -146,9 +147,12 @@ class CartesianSetpoint {
   Vector6<Scalar> Kd_;
 };
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 template <typename Scalar>
 std::ostream& operator<<(std::ostream& out,
                          const CartesianSetpoint<Scalar>& setpoint) {
+#pragma GCC diagnostic pop
   const math::RigidTransform<Scalar> X(setpoint.desired_pose());
   const math::RollPitchYaw<Scalar> rpy(X.rotation());
   out << "pose: (" << X.translation().transpose()
@@ -163,7 +167,8 @@ std::ostream& operator<<(std::ostream& out,
 }
 
 template <typename Scalar>
-class VectorSetpoint {
+class DRAKE_DEPRECATED("2022-02-01", "This (unused) class is being removed.")
+VectorSetpoint {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(VectorSetpoint)
 
@@ -275,9 +280,12 @@ class VectorSetpoint {
   VectorX<Scalar> Kd_;
 };
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 template <typename Scalar>
 std::ostream& operator<<(std::ostream& out,
                          const VectorSetpoint<Scalar>& setpoint) {
+#pragma GCC diagnostic pop
   out << "pos: " << setpoint.desired_position().transpose() << "\n";
   out << "vel: " << setpoint.desired_velocity().transpose() << "\n";
   out << "acc: " << setpoint.desired_acceleration().transpose() << "\n";


### PR DESCRIPTION
Towards #9865.

This code is unused within Drake and Anzu, and is stale with respect to modern practices:
- RigidTransform vs Isometry3;
- SpatialAcceleration vs Vector6, etc.;
- Templates, scalar types, and inline code.

Because it's unused, we elect to remove it rather than update it.  Any projects that were using this class are welcome to copy its source files into their own codebase.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16006)
<!-- Reviewable:end -->
