### PR TITLE
[pydrake] Deprecate Isometry3 in the multibody API

### DIFF
--- a/bindings/pydrake/multibody/plant_py.cc
+++ b/bindings/pydrake/multibody/plant_py.cc
@@ -37,8 +37,8 @@ using systems::State;
 
 namespace {
 constexpr char doc_iso3_deprecation[] = R"""(
-This API using Isometry3 is / will be deprecated soon with the resolution of
-#9865. We only offer it for backwards compatibility. DO NOT USE!.
+Use of Isometry3 with the MultibodyPlant API is deprecated and will be removed
+from Drake on or after 2022-02-01.  Pass a pydrake.math.RigidTransform instead.
 )""";
 
 template <typename T>

--- a/bindings/pydrake/multibody/test/plant_test.py
+++ b/bindings/pydrake/multibody/test/plant_test.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from pydrake.autodiffutils import AutoDiffXd
 from pydrake.symbolic import Expression, Variable
+from pydrake.common.eigen_geometry import Isometry3
 from pydrake.lcm import DrakeLcm
 from pydrake.math import RigidTransform
 from pydrake.multibody.tree import (
@@ -225,6 +226,15 @@ class TestPlant(unittest.TestCase):
         context = diagram.CreateDefaultContext()
         with self.assertRaises(RuntimeError):
             plant.EvalBodyPoseInWorld(context, body)
+
+    def test_deprecated_register_visual_geometry(self):
+        builder = DiagramBuilder_[float]()
+        plant, scene_graph = AddMultibodyPlantSceneGraph(builder, 0.0)
+        body = plant.AddRigidBody(name="B", M_BBo_B=SpatialInertia_[float]())
+        with catch_drake_warnings(expected_count=1):
+            plant.RegisterVisualGeometry(
+                body=body, X_BG=Isometry3(), shape=Box(1.0, 1.0, 1.0),
+                name="G", diffuse_color=[1., 0., 0., 0.])
 
     @numpy_compare.check_all_types
     def test_multibody_plant_api_via_parsing(self, T):
@@ -932,6 +942,17 @@ class TestPlant(unittest.TestCase):
         base.SetCenterOfMassInBodyFrame(context=context, com=[0.0, 0.0, 0.0])
         M = SpatialInertia_[T](1, [0, 0, 0], UnitInertia_[T](1, 1, 1))
         base.SetSpatialInertiaInBodyFrame(context=context, M_Bo_B=M)
+
+    def test_deprecated_set_free_body_pose(self):
+        plant = MultibodyPlant_[float](0.0)
+        Parser(plant).AddModelFromFile(FindResourceOrThrow(
+            "drake/bindings/pydrake/multibody/test/double_pendulum.sdf"))
+        plant.Finalize()
+        with catch_drake_warnings(expected_count=1):
+            plant.SetFreeBodyPose(
+                context=plant.CreateDefaultContext(),
+                body=plant.GetBodyByName("base"),
+                X_WB=Isometry3())
 
     @numpy_compare.check_all_types
     def test_multibody_state_access(self, T):
@@ -1735,6 +1756,33 @@ class TestPlant(unittest.TestCase):
                 loop_body(make_joint, 0.001)
 
     @numpy_compare.check_all_types
+    def test_deprecated_weld_joint(self, T):
+        plant = MultibodyPlant_[T](0.0)
+        child = plant.AddRigidBody("Child", SpatialInertia_[float]())
+        with catch_drake_warnings(expected_count=1):
+            joint = WeldJoint_[T](
+                name="weld",
+                parent_frame_P=plant.world_frame(),
+                child_frame_C=child.body_frame(),
+                X_PC=Isometry3())
+        self.assertIsInstance(joint, Joint_[T])
+
+    def test_deprecated_weld_frames(self):
+        plant = MultibodyPlant_[float](0.0)
+        parser = Parser(plant)
+        iiwa_sdf_path = FindResourceOrThrow(
+            "drake/manipulation/models/"
+            "iiwa_description/sdf/iiwa14_no_collision.sdf")
+        iiwa_model = parser.AddModelFromFile(
+            file_name=iiwa_sdf_path, model_name="robot")
+        with catch_drake_warnings(expected_count=1):
+            weld = plant.WeldFrames(
+                A=plant.world_frame(),
+                B=plant.GetFrameByName("iiwa_link_0", iiwa_model),
+                X_AB=Isometry3())
+        self.assertIsInstance(weld, Joint_[float])
+
+    @numpy_compare.check_all_types
     def test_multibody_add_frame(self, T):
         MultibodyPlant = MultibodyPlant_[T]
         FixedOffsetFrame = FixedOffsetFrame_[T]
@@ -1759,6 +1807,15 @@ class TestPlant(unittest.TestCase):
         numpy_compare.assert_float_equal(
             frame.CalcPoseInBodyFrame(context).GetAsMatrix34(),
             numpy_compare.to_float(X_PF.GetAsMatrix34()))
+
+    @numpy_compare.check_all_types
+    def test_deprecated_fixed_offset_frame(self, T):
+        plant = MultibodyPlant_[T](0.0)
+        with catch_drake_warnings(expected_count=1):
+            frame = plant.AddFrame(frame=FixedOffsetFrame_[T](
+                name="frame", P=plant.world_frame(),
+                X_PF=Isometry3(), model_instance=None))
+        self.assertIsInstance(frame, Frame_[T])
 
     @numpy_compare.check_all_types
     def test_frame_context_methods(self, T):

--- a/bindings/pydrake/multibody/tree_py.cc
+++ b/bindings/pydrake/multibody/tree_py.cc
@@ -50,8 +50,8 @@ using multibody::SpatialAcceleration;
 using multibody::SpatialVelocity;
 
 constexpr char doc_iso3_deprecation[] = R"""(
-This API using Isometry3 is / will be deprecated soon with the resolution of
-#9865. We only offer it for backwards compatibility. DO NOT USE!.
+Use of Isometry3 with the MultibodyPlant API is deprecated and will be removed
+from Drake on or after 2022-02-01.  Pass a pydrake.math.RigidTransform instead.
 )""";
 
 namespace {

--- a/bindings/pydrake/systems/meshcat_visualizer.py
+++ b/bindings/pydrake/systems/meshcat_visualizer.py
@@ -12,7 +12,6 @@ import webbrowser
 import numpy as np
 
 from pydrake.common.deprecation import _warn_deprecated
-from pydrake.common.eigen_geometry import Quaternion, Isometry3
 from pydrake.common.value import AbstractValue
 from pydrake.geometry import (
     Box, ConvertVolumeToSurfaceMesh, Convex, Cylinder, Mesh, Sphere,

--- a/bindings/pydrake/systems/test/meshcat_visualizer_test.py
+++ b/bindings/pydrake/systems/test/meshcat_visualizer_test.py
@@ -42,7 +42,6 @@ from pydrake.systems.meshcat_visualizer import (
     MeshcatContactVisualizer,
     MeshcatPointCloudVisualizer
 )
-from pydrake.common.eigen_geometry import Isometry3
 from pydrake.math import RigidTransform, RotationMatrix
 from pydrake.multibody.plant import CoulombFriction, MultibodyPlant
 from pydrake.multibody.tree import SpatialInertia, UnitInertia
@@ -358,7 +357,7 @@ class TestMeshcat(unittest.TestCase):
         sim_time = _DEFAULT_PUBLISH_PERIOD * 3.
 
         def se3_from_xyz(xyz):
-            return Isometry3(np.eye(3), xyz)
+            return RigidTransform(p=xyz)
 
         def show_cloud(pc, pc2=None, use_native=False, **kwargs):
             # kwargs go to ctor.


### PR DESCRIPTION
Towards #9865.

(These were already deprecated, but lacked cutoff dates, a useful message, and any test coverage at all.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16008)
<!-- Reviewable:end -->
