### PR TITLE
geometry: Migrate hydroelastic modulus in property functions

### DIFF
--- a/bindings/pydrake/geometry_py_common.cc
+++ b/bindings/pydrake/geometry_py_common.cc
@@ -476,14 +476,13 @@ void DoScalarIndependentDefinitions(py::module m) {
 
   m.def("AddContactMaterial",
       py::overload_cast<const std::optional<double>&,
-          const std::optional<double>&, const std::optional<double>&,
+          const std::optional<double>&,
           const std::optional<multibody::CoulombFriction<double>>&,
           ProximityProperties*>(&AddContactMaterial),
-      py::arg("hydroelastic_modulus") = std::nullopt,
       py::arg("dissipation") = std::nullopt,
       py::arg("point_stiffness") = std::nullopt,
       py::arg("friction") = std::nullopt, py::arg("properties"),
-      doc.AddContactMaterial.doc_5args);
+      doc.AddContactMaterial.doc);
 }
 
 // Test-only code.

--- a/bindings/pydrake/geometry_py_hydro.cc
+++ b/bindings/pydrake/geometry_py_hydro.cc
@@ -112,19 +112,14 @@ void DoScalarIndependentDefinitions(py::module m) {
       py::overload_cast<ProximityProperties*>(&AddRigidHydroelasticProperties),
       py::arg("properties"), doc.AddRigidHydroelasticProperties.doc_1args);
 
-  m.def("AddSoftHydroelasticProperties",
-      py::overload_cast<double, ProximityProperties*>(
-          &AddSoftHydroelasticProperties),
-      py::arg("resolution_hint"), py::arg("properties"),
-      doc.AddSoftHydroelasticProperties.doc_2args);
-
-  m.def("AddSoftHydroelasticProperties",
-      py::overload_cast<ProximityProperties*>(&AddSoftHydroelasticProperties),
-      py::arg("properties"), doc.AddSoftHydroelasticProperties.doc_1args);
+  m.def("AddSoftHydroelasticProperties", &AddSoftHydroelasticProperties,
+      py::arg("resolution_hint"), py::arg("hydroelastic_modulus"),
+      py::arg("properties"), doc.AddSoftHydroelasticProperties.doc);
 
   m.def("AddSoftHydroelasticPropertiesForHalfSpace",
       &AddSoftHydroelasticPropertiesForHalfSpace, py::arg("slab_thickness"),
-      py::arg("properties"), doc.AddSoftHydroelasticPropertiesForHalfSpace.doc);
+      py::arg("hydroelastic_modulus"), py::arg("properties"),
+      doc.AddSoftHydroelasticPropertiesForHalfSpace.doc);
 }
 
 }  // namespace

--- a/bindings/pydrake/test/geometry_common_test.py
+++ b/bindings/pydrake/test/geometry_common_test.py
@@ -231,15 +231,10 @@ class TestGeometryCore(unittest.TestCase):
         """
         props = mut.ProximityProperties()
         reference_friction = CoulombFriction(0.25, 0.125)
-        mut.AddContactMaterial(hydroelastic_modulus=1.5,
-                               dissipation=2.7,
+        mut.AddContactMaterial(dissipation=2.7,
                                point_stiffness=3.9,
                                friction=reference_friction,
                                properties=props)
-        self.assertTrue(
-            props.HasProperty("material", "hydroelastic_modulus"))
-        self.assertEqual(
-            props.GetProperty("material", "hydroelastic_modulus"), 1.5)
         self.assertTrue(
             props.HasProperty("material", "hunt_crossley_dissipation"))
         self.assertEqual(
@@ -257,6 +252,7 @@ class TestGeometryCore(unittest.TestCase):
 
         props = mut.ProximityProperties()
         res_hint = 0.175
+        E = 1e8
         mut.AddRigidHydroelasticProperties(
             resolution_hint=res_hint, properties=props)
         self.assertTrue(props.HasProperty("hydroelastic", "compliance_type"))
@@ -274,28 +270,31 @@ class TestGeometryCore(unittest.TestCase):
         props = mut.ProximityProperties()
         res_hint = 0.275
         mut.AddSoftHydroelasticProperties(
-            resolution_hint=res_hint, properties=props)
+            resolution_hint=res_hint, hydroelastic_modulus=E, properties=props)
         self.assertTrue(props.HasProperty("hydroelastic", "compliance_type"))
         self.assertTrue(mut_testing.PropertiesIndicateSoftHydro(props))
         self.assertTrue(props.HasProperty("hydroelastic", "resolution_hint"))
         self.assertEqual(props.GetProperty("hydroelastic", "resolution_hint"),
                          res_hint)
-
-        props = mut.ProximityProperties()
-        mut.AddSoftHydroelasticProperties(properties=props)
-        self.assertTrue(props.HasProperty("hydroelastic", "compliance_type"))
-        self.assertTrue(mut_testing.PropertiesIndicateSoftHydro(props))
-        self.assertFalse(props.HasProperty("hydroelastic", "resolution_hint"))
+        self.assertTrue(props.HasProperty("hydroelastic",
+                                          "hydroelastic_modulus"))
+        self.assertEqual(props.GetProperty("hydroelastic",
+                                           "hydroelastic_modulus"), E)
 
         props = mut.ProximityProperties()
         slab_thickness = 0.275
         mut.AddSoftHydroelasticPropertiesForHalfSpace(
-            slab_thickness=slab_thickness, properties=props)
+            slab_thickness=slab_thickness, hydroelastic_modulus=E,
+            properties=props)
         self.assertTrue(props.HasProperty("hydroelastic", "compliance_type"))
         self.assertTrue(mut_testing.PropertiesIndicateSoftHydro(props))
         self.assertTrue(props.HasProperty("hydroelastic", "slab_thickness"))
         self.assertEqual(props.GetProperty("hydroelastic", "slab_thickness"),
                          slab_thickness)
+        self.assertTrue(props.HasProperty("hydroelastic",
+                                          "hydroelastic_modulus"))
+        self.assertEqual(props.GetProperty("hydroelastic",
+                                           "hydroelastic_modulus"), E)
 
     def test_rgba_api(self):
         r, g, b, a = 0.75, 0.5, 0.25, 1.

--- a/bindings/pydrake/test/geometry_hydro_test.py
+++ b/bindings/pydrake/test/geometry_hydro_test.py
@@ -15,6 +15,7 @@ class TestGeometryHydro(unittest.TestCase):
         """
         props = mut.ProximityProperties()
         res_hint = 0.175
+        E = 1e8
         mut.AddRigidHydroelasticProperties(
             resolution_hint=res_hint, properties=props)
         self.assertTrue(props.HasProperty("hydroelastic", "compliance_type"))
@@ -32,28 +33,31 @@ class TestGeometryHydro(unittest.TestCase):
         props = mut.ProximityProperties()
         res_hint = 0.275
         mut.AddSoftHydroelasticProperties(
-            resolution_hint=res_hint, properties=props)
+            resolution_hint=res_hint, hydroelastic_modulus=E, properties=props)
         self.assertTrue(props.HasProperty("hydroelastic", "compliance_type"))
         self.assertTrue(mut_testing.PropertiesIndicateSoftHydro(props))
         self.assertTrue(props.HasProperty("hydroelastic", "resolution_hint"))
         self.assertEqual(props.GetProperty("hydroelastic", "resolution_hint"),
                          res_hint)
-
-        props = mut.ProximityProperties()
-        mut.AddSoftHydroelasticProperties(properties=props)
-        self.assertTrue(props.HasProperty("hydroelastic", "compliance_type"))
-        self.assertTrue(mut_testing.PropertiesIndicateSoftHydro(props))
-        self.assertFalse(props.HasProperty("hydroelastic", "resolution_hint"))
+        self.assertTrue(props.HasProperty("hydroelastic",
+                                          "hydroelastic_modulus"))
+        self.assertEqual(props.GetProperty("hydroelastic",
+                                           "hydroelastic_modulus"), E)
 
         props = mut.ProximityProperties()
         slab_thickness = 0.275
         mut.AddSoftHydroelasticPropertiesForHalfSpace(
-            slab_thickness=slab_thickness, properties=props)
+            slab_thickness=slab_thickness, hydroelastic_modulus=E,
+            properties=props)
         self.assertTrue(props.HasProperty("hydroelastic", "compliance_type"))
         self.assertTrue(mut_testing.PropertiesIndicateSoftHydro(props))
         self.assertTrue(props.HasProperty("hydroelastic", "slab_thickness"))
         self.assertEqual(props.GetProperty("hydroelastic", "slab_thickness"),
                          slab_thickness)
+        self.assertTrue(props.HasProperty("hydroelastic",
+                                          "hydroelastic_modulus"))
+        self.assertEqual(props.GetProperty("hydroelastic",
+                                           "hydroelastic_modulus"), E)
 
     def test_surface_mesh(self):
         # Create a mesh out of two triangles forming a quad.

--- a/bindings/pydrake/test/geometry_scene_graph_test.py
+++ b/bindings/pydrake/test/geometry_scene_graph_test.py
@@ -52,8 +52,8 @@ class TestGeometrySceneGraph(unittest.TestCase):
                                           shape=mut.Sphere(1.),
                                           name="sphere3"))
         props = mut.ProximityProperties()
-        mut.AddContactMaterial(hydroelastic_modulus=1e8, properties=props)
-        mut.AddSoftHydroelasticProperties(resolution_hint=1, properties=props)
+        mut.AddSoftHydroelasticProperties(
+            resolution_hint=1, hydroelastic_modulus=1e8, properties=props)
         scene_graph.AssignRole(source_id=global_source, geometry_id=sphere_3,
                                properties=props)
 

--- a/examples/multibody/rolling_sphere/make_rolling_sphere_plant.cc
+++ b/examples/multibody/rolling_sphere/make_rolling_sphere_plant.cc
@@ -42,11 +42,12 @@ std::unique_ptr<drake::multibody::MultibodyPlant<double>> MakeBouncingBallPlant(
     const RigidTransformd X_WG;  // identity.
     ProximityProperties ground_props;
     if (soft_ground) {
-      AddSoftHydroelasticPropertiesForHalfSpace(1.0, &ground_props);
+      AddSoftHydroelasticPropertiesForHalfSpace(
+          1.0, hydroelastic_modulus, &ground_props);
     } else {
       AddRigidHydroelasticProperties(&ground_props);
     }
-    AddContactMaterial(hydroelastic_modulus, dissipation, surface_friction,
+    AddContactMaterial(dissipation, {} /* point stiffness */, surface_friction,
                        &ground_props);
     plant->RegisterCollisionGeometry(plant->world_body(), X_WG,
                                      geometry::HalfSpace{}, "collision",
@@ -60,12 +61,12 @@ std::unique_ptr<drake::multibody::MultibodyPlant<double>> MakeBouncingBallPlant(
     const RigidTransformd X_BS = RigidTransformd::Identity();
     // Set material properties for hydroelastics.
     ProximityProperties ball_props;
-    AddContactMaterial(hydroelastic_modulus, dissipation, surface_friction,
+    AddContactMaterial(dissipation, {} /* point stiffness */, surface_friction,
                        &ball_props);
     if (rigid_sphere) {
       AddRigidHydroelasticProperties(radius, &ball_props);
     } else {
-      AddSoftHydroelasticProperties(radius, &ball_props);
+      AddSoftHydroelasticProperties(radius, hydroelastic_modulus, &ball_props);
     }
     plant->RegisterCollisionGeometry(ball, X_BS, Sphere(radius), "collision",
                                      std::move(ball_props));

--- a/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
+++ b/examples/multibody/rolling_sphere/rolling_sphere_run_dynamics.cc
@@ -121,9 +121,10 @@ int do_main() {
     geometry::Box wall{0.2, 4, 0.4};
     const RigidTransformd X_WB(Vector3d{-0.5, 0, 0});
     geometry::ProximityProperties prox_prop;
-    geometry::AddContactMaterial(1e8, {}, CoulombFriction<double>(),
+    geometry::AddContactMaterial({} /* dissipation */, {} /* point stiffness */,
+                                 CoulombFriction<double>(),
                                  &prox_prop);
-    geometry::AddSoftHydroelasticProperties(0.1, &prox_prop);
+    geometry::AddSoftHydroelasticProperties(0.1, 1e8, &prox_prop);
     plant.RegisterCollisionGeometry(plant.world_body(), X_WB, wall,
                                     "wall_collision", std::move(prox_prop));
 

--- a/examples/scene_graph/simple_contact_surface_vis.cc
+++ b/examples/scene_graph/simple_contact_surface_vis.cc
@@ -41,7 +41,6 @@ namespace contact_surface {
 
 using Eigen::Vector3d;
 using Eigen::Vector4d;
-using geometry::AddContactMaterial;
 using geometry::AddRigidHydroelasticProperties;
 using geometry::AddSoftHydroelasticProperties;
 using geometry::Box;
@@ -119,8 +118,7 @@ class MovingBall final : public LeafSystem<double> {
                                       make_unique<Sphere>(1.0), "ball"));
 
     ProximityProperties prox_props;
-    AddContactMaterial(1e8, {}, {}, &prox_props);
-    AddSoftHydroelasticProperties(FLAGS_length, &prox_props);
+    AddSoftHydroelasticProperties(FLAGS_length, 1e8, &prox_props);
     scene_graph->AssignRole(source_id_, geometry_id_, prox_props);
 
     IllustrationProperties illus_props;

--- a/geometry/profiling/contact_surface_rigid_bowl_soft_ball.cc
+++ b/geometry/profiling/contact_surface_rigid_bowl_soft_ball.cc
@@ -58,7 +58,6 @@ using geometry::FramePoseVector;
 using geometry::GeometryFrame;
 using geometry::GeometryId;
 using geometry::GeometryInstance;
-using geometry::AddContactMaterial;
 using geometry::AddRigidHydroelasticProperties;
 using geometry::AddSoftHydroelasticProperties;
 using geometry::IllustrationProperties;
@@ -182,9 +181,8 @@ class MovingSoftGeometry final : public LeafSystem<double> {
       }
     }
     ProximityProperties prox_props;
-    AddContactMaterial(1e8, {}, {}, &prox_props);
     // Resolution Hint affects the soft ball but not the soft box.
-    AddSoftHydroelasticProperties(FLAGS_resolution_hint, &prox_props);
+    AddSoftHydroelasticProperties(FLAGS_resolution_hint, 1e8, &prox_props);
     scene_graph->AssignRole(source_id_, geometry_id_, prox_props);
 
     IllustrationProperties illus_props;

--- a/geometry/proximity/hydroelastic_internal.cc
+++ b/geometry/proximity/hydroelastic_internal.cc
@@ -275,7 +275,7 @@ std::optional<SoftGeometry> MakeSoftRepresentation(
       MakeSphereVolumeMesh<double>(sphere, edge_length, strategy));
 
   const double hydroelastic_modulus =
-      validator.Extract(props, kMaterialGroup, kElastic);
+      validator.Extract(props, kHydroGroup, kElastic);
 
   auto pressure = make_unique<VolumeMeshFieldLinear<double, double>>(
       MakeSpherePressureField(sphere, mesh.get(), hydroelastic_modulus));
@@ -291,7 +291,7 @@ std::optional<SoftGeometry> MakeSoftRepresentation(
       make_unique<VolumeMesh<double>>(MakeBoxVolumeMeshWithMa<double>(box));
 
   const double hydroelastic_modulus =
-      validator.Extract(props, kMaterialGroup, kElastic);
+      validator.Extract(props, kHydroGroup, kElastic);
 
   auto pressure = make_unique<VolumeMeshFieldLinear<double, double>>(
       MakeBoxPressureField(box, mesh.get(), hydroelastic_modulus));
@@ -308,7 +308,7 @@ std::optional<SoftGeometry> MakeSoftRepresentation(
       MakeCylinderVolumeMeshWithMa<double>(cylinder, edge_length));
 
   const double hydroelastic_modulus =
-      validator.Extract(props, kMaterialGroup, kElastic);
+      validator.Extract(props, kHydroGroup, kElastic);
 
   auto pressure = make_unique<VolumeMeshFieldLinear<double, double>>(
       MakeCylinderPressureField(cylinder, mesh.get(), hydroelastic_modulus));
@@ -325,7 +325,7 @@ std::optional<SoftGeometry> MakeSoftRepresentation(
       MakeCapsuleVolumeMesh<double>(capsule, edge_length));
 
   const double hydroelastic_modulus =
-      validator.Extract(props, kMaterialGroup, kElastic);
+      validator.Extract(props, kHydroGroup, kElastic);
 
   auto pressure = make_unique<VolumeMeshFieldLinear<double, double>>(
       MakeCapsulePressureField(capsule, mesh.get(), hydroelastic_modulus));
@@ -346,7 +346,7 @@ std::optional<SoftGeometry> MakeSoftRepresentation(
       MakeEllipsoidVolumeMesh<double>(ellipsoid, edge_length, strategy));
 
   const double hydroelastic_modulus =
-      validator.Extract(props, kMaterialGroup, kElastic);
+      validator.Extract(props, kHydroGroup, kElastic);
 
   auto pressure = make_unique<VolumeMeshFieldLinear<double, double>>(
       MakeEllipsoidPressureField(ellipsoid, mesh.get(), hydroelastic_modulus));
@@ -362,7 +362,7 @@ std::optional<SoftGeometry> MakeSoftRepresentation(
       validator.Extract(props, kHydroGroup, kSlabThickness);
 
   const double hydroelastic_modulus =
-      validator.Extract(props, kMaterialGroup, kElastic);
+      validator.Extract(props, kHydroGroup, kElastic);
 
   return SoftGeometry(SoftHalfSpace{hydroelastic_modulus / thickness});
 }

--- a/geometry/proximity/hydroelastic_internal.h
+++ b/geometry/proximity/hydroelastic_internal.h
@@ -435,36 +435,37 @@ std::optional<SoftGeometry> MakeSoftRepresentation(const Shape& shape,
 
 /* Creates a soft sphere (assuming the proximity properties have sufficient
  information). Requires the ('hydroelastic', 'resolution_hint') and
- ('material', 'hydroelastic_modulus') properties.  */
+ ('hydroelastic', 'hydroelastic_modulus') properties.  */
 std::optional<SoftGeometry> MakeSoftRepresentation(
     const Sphere& sphere, const ProximityProperties& props);
 
 /* Creates a soft box (assuming the proximity properties have sufficient
- information). Requires the ('material', 'hydroelastic_modulus') properties.  */
+ information). Requires the ('hydroelastic', 'hydroelastic_modulus')
+ properties.  */
 std::optional<SoftGeometry> MakeSoftRepresentation(
     const Box& box, const ProximityProperties& props);
 
 /* Creates a soft cylinder (assuming the proximity properties have sufficient
  information). Requires the ('hydroelastic', 'resolution_hint') and
- ('material', 'hydroelastic_modulus') properties.  */
+ ('hydroelastic', 'hydroelastic_modulus') properties.  */
 std::optional<SoftGeometry> MakeSoftRepresentation(
     const Cylinder& cylinder, const ProximityProperties& props);
 
 /* Creates a soft capsule (assuming the proximity properties have sufficient
  information). Requires the ('hydroelastic', 'resolution_hint') and
- ('material', 'hydroelastic_modulus') properties.  */
+ ('hydroelastic', 'hydroelastic_modulus') properties.  */
 std::optional<SoftGeometry> MakeSoftRepresentation(
     const Capsule& capsule, const ProximityProperties& props);
 
 /* Creates a soft ellipsoid (assuming the proximity properties have sufficient
  information). Requires the ('hydroelastic', 'resolution_hint') and
- ('material', 'hydroelastic_modulus') properties.  */
+ ('hydroelastic', 'hydroelastic_modulus') properties.  */
 std::optional<SoftGeometry> MakeSoftRepresentation(
     const Ellipsoid& ellipsoid, const ProximityProperties& props);
 
 /* Creates a compliant half space (assuming the proximity properties have
  sufficient information). Requires the ('hydroelastic', 'slab_thickness') and
- ('material', 'hydroelastic_modulus') properties.  */
+ ('hydroelastic', 'hydroelastic_modulus') properties.  */
 std::optional<SoftGeometry> MakeSoftRepresentation(
     const HalfSpace& half_space, const ProximityProperties& props);
 

--- a/geometry/proximity/test/hydroelastic_callback_test.cc
+++ b/geometry/proximity/test/hydroelastic_callback_test.cc
@@ -46,9 +46,8 @@ ProximityProperties rigid_properties() {
 // for supported geometries.
 ProximityProperties soft_properties() {
   ProximityProperties props;
-  AddContactMaterial(1e8, {}, {}, &props);
   const double resolution_hint = 0.25;
-  AddSoftHydroelasticProperties(resolution_hint, &props);
+  AddSoftHydroelasticProperties(resolution_hint, 1e8, &props);
   // Redundantly add slab thickness so it can be used with compliant mesh or
   // compliant half space.
   props.AddProperty(kHydroGroup, kSlabThickness, 0.25);

--- a/geometry/proximity_properties.h
+++ b/geometry/proximity_properties.h
@@ -31,8 +31,6 @@ namespace internal {
 //@{
 
 extern const char* const kMaterialGroup;   ///< The contact material group name.
-extern const char* const kElastic;         ///< Hydroelastic modulus property
-                                           ///< name.
 extern const char* const kFriction;        ///< Friction coefficients property
                                            ///< name.
 extern const char* const kHcDissipation;   ///< Hunt-Crossley dissipation
@@ -63,6 +61,8 @@ extern const char* const kPointStiffness;  ///< Point stiffness property
 //@{
 
 extern const char* const kHydroGroup;       ///< Hydroelastic group name.
+extern const char* const kElastic;          ///< Hydroelastic modulus property
+                                            ///< name.
 extern const char* const kRezHint;          ///< Resolution hint property name.
 extern const char* const kComplianceType;   ///< Compliance type property name.
 extern const char* const kSlabThickness;    ///< Slab thickness property name
@@ -90,50 +90,24 @@ std::ostream& operator<<(std::ostream& out, const HydroelasticType& type);
 }  // namespace internal
 
 /**
- * @anchor contact_material_utility_functions
- * @name         Contact Material Utility Functions
- * AddContactMaterial() adds contact material properties to the given set of
- * proximity `properties`. Only the parameters that carry values will be added
- * to the given set of `properties`; no default values will be provided.
+ * AddContactMaterial() adds general contact material properties to the given
+ * set of proximity `properties`. These are the properties required by the
+ * default point contact model. However, other contact models can opt to use
+ * these properties as well. Only the parameters that carry values will be
+ * added to the given set of `properties`; no default values will be provided.
  * Downstream consumers of the contact materials can optionally provide
  * defaults for missing properties.
  *
- * For legacy and backwards compatibility purposes, two overloads for
- * AddContactMaterial() are provided. One supports all contact material
- * properties **except** `point_stiffness`, and the other includes it.
- * Users are encouraged to use the overload that contains the argument for
- * `point_stiffness`.
- *
- * These functions will throw an error if:
- * - `hydroelastic_modulus` is not positive
- * - `dissipation` is negative
- * - `point_stiffness` is not positive
- * - Any of the contact material properties have already been defined in
- *   `properties`.
- */
-///@{
-/**
- * @throws std::exception if any parameter doesn't satisfy the requirements
- *                        listed in @ref contact_material_utility_functions
- *                        "Contact Material Utility Functions".
+ * @throws std::exception if `dissipation` is negative, `point_stiffness` is
+ * not positive, of any of the contact material properties have already been
+ * defined in ``properties`.
+ * @pre `properties` is not nullptr.
  */
 void AddContactMaterial(
-    const std::optional<double>& hydroelastic_modulus,
     const std::optional<double>& dissipation,
     const std::optional<double>& point_stiffness,
     const std::optional<multibody::CoulombFriction<double>>& friction,
     ProximityProperties* properties);
-
-/**
- * @warning Please use the overload of AddContactMaterial() that includes the
- * argument for `point_stiffness` rather than this one.
- */
-void AddContactMaterial(
-    const std::optional<double>& hydroelastic_modulus,
-    const std::optional<double>& dissipation,
-    const std::optional<multibody::CoulombFriction<double>>& friction,
-    ProximityProperties* properties);
-///@}
 
 /** Adds properties to the given set of proximity properties sufficient to cause
  the associated geometry to generate a rigid hydroelastic representation.
@@ -171,31 +145,31 @@ void AddRigidHydroelasticProperties(ProximityProperties* properties);
                               roughly corresponds to a typical edge length in
                               the resulting mesh. This will be ignored for
                               geometry types that don't require tessellation.
+ @param hydroelastic_modulus  A multiplier that maps penetration to pressure.
  @param[in,out] properties    The properties will be added to this property set.
  @throws std::exception       If `properties` already has properties with the
                               names that this function would need to add.
- @pre 0 < `resolution_hint` < ∞, `properties` is not nullptr, and `properties`
-      contains a valid elastic modulus value. */
+ @pre 0 < `resolution_hint` < ∞, 0 < `hydroelastic_modulus`, and `properties`
+      is not nullptr. */
 void AddSoftHydroelasticProperties(double resolution_hint,
+                                   double hydroelastic_modulus,
                                    ProximityProperties* properties);
-
-/** Overload, intended for shapes that don't get tessellated in their
- hydroelastic representation (e.g., HalfSpace).
- See @ref MODULE_NOT_WRITTEN_YET.  */
-void AddSoftHydroelasticProperties(ProximityProperties* properties);
 
 /** Soft half spaces are handled as a special case; they do not get tessellated.
  Instead, they are treated as infinite slabs with a finite thickness. This
  variant is required for hydroelastic half spaces.
 
- @param slab_thickness      The distance from the half space boundary to its
-                            rigid core (this helps define the extent field of
-                            the half space).
- @param[out] properties     The properties will be added to this property set.
+ @param slab_thickness       The distance from the half space boundary to its
+                             rigid core (this helps define the extent field of
+                             the half space).
+ @param hydroelastic_modulus A multiplier that maps penetration to pressure.
+ @param[out] properties      The properties will be added to this property set.
  @throws std::exception If `properties` already has properties with the names
                         that this function would need to add.
- @pre 0 < `slab_thickness` < ∞ . */
+ @pre 0 < `slab_thickness` < ∞, 0 < `hydroelastic_modulus`, and `properties`
+      is not nullptr. */
 void AddSoftHydroelasticPropertiesForHalfSpace(double slab_thickness,
+                                               double hydroelastic_modulus,
                                                ProximityProperties* properties);
 
 //@}

--- a/geometry/test/drake_visualizer_test.cc
+++ b/geometry/test/drake_visualizer_test.cc
@@ -778,7 +778,7 @@ TYPED_TEST(DrakeVisualizerTest, VisualizeHydroGeometry) {
 
   /* Populate with soft hydroelastic properties and add soft geometries. */
   props.AddProperty(internal::kHydroGroup, internal::kSlabThickness, 5.0);
-  props.AddProperty(internal::kMaterialGroup, internal::kElastic, 5.0);
+  props.AddProperty(internal::kHydroGroup, internal::kElastic, 5.0);
   props.UpdateProperty(internal::kHydroGroup, internal::kComplianceType,
                        HydroelasticType::kSoft);
   const RigidTransformd X_PSphere{RotationMatrixd::MakeZRotation(0.3),

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -3715,8 +3715,8 @@ GTEST_TEST(GeometryStateHydroTest, GetHydroMesh) {
   ProximityProperties rigid_hydro;
   AddRigidHydroelasticProperties(1.0, &rigid_hydro);
   ProximityProperties soft_hydro;
-  AddContactMaterial(1e8, 0.0, {}, &soft_hydro);
-  AddSoftHydroelasticProperties(1.0, &soft_hydro);
+  AddContactMaterial(0.0, {}, {}, &soft_hydro);
+  AddSoftHydroelasticProperties(1.0, 1e8, &soft_hydro);
 
   // We'll simply affix a number of geometries as anchored with the identity
   // pose. The other details don't really matter.

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -121,8 +121,7 @@ GTEST_TEST(ProximityEngineTests, ProcessHydroelasticProperties) {
   const double edge_length = 0.5;
   const double E = 1e8;  // Elastic modulus.
   ProximityProperties soft_properties;
-  AddContactMaterial(E, {}, {}, &soft_properties);
-  AddSoftHydroelasticProperties(edge_length, &soft_properties);
+  AddSoftHydroelasticProperties(edge_length, E, &soft_properties);
   ProximityProperties rigid_properties;
   AddRigidHydroelasticProperties(edge_length, &rigid_properties);
 
@@ -216,9 +215,7 @@ std::pair<GeometryId, RigidTransformd> AddShape(ProximityEngine<double>* engine,
   const double edge_length = 0.5;
   ProximityProperties properties;
   if (is_soft) {
-    // If soft, we need an elastic modulus.
-    AddContactMaterial(1e8, {}, {}, &properties);
-    AddSoftHydroelasticProperties(edge_length, &properties);
+    AddSoftHydroelasticProperties(edge_length, 1e8, &properties);
   } else {
     AddRigidHydroelasticProperties(edge_length, &properties);
   }
@@ -499,7 +496,7 @@ GTEST_TEST(ProximityEngineTests, ReplaceProperties) {
     // Pick a characteristic length sufficiently large that we create the
     // coarsest, cheapest mesh possible.
     EXPECT_EQ(PET::hydroelastic_type(sphere.id(), engine), kUndefined);
-    props.AddProperty(kMaterialGroup, kElastic,
+    props.AddProperty(kHydroGroup, kElastic,
                       std::numeric_limits<double>::infinity());
     AddRigidHydroelasticProperties(3 * radius, &props);
     DRAKE_EXPECT_NO_THROW(
@@ -533,7 +530,7 @@ GTEST_TEST(ProximityEngineTests, ReplaceProperties) {
         std::logic_error, "Cannot create soft Sphere; missing the .+ property");
 
     ProximityProperties bad_props_no_length(hydro_trigger);
-    bad_props_no_length.AddProperty(kMaterialGroup, kElastic, 5e8);
+    bad_props_no_length.AddProperty(kHydroGroup, kElastic, 5e8);
     DRAKE_EXPECT_THROWS_MESSAGE(
         engine.UpdateRepresentationForNewProperties(sphere,
                                                     bad_props_no_length),
@@ -1897,8 +1894,7 @@ class ProximityEngineHydro : public testing::Test {
     poses_ = MakeCollidingRing(r, 4);
 
     ProximityProperties soft_properties;
-    AddContactMaterial(1e8, {}, {}, {}, &soft_properties);
-    AddSoftHydroelasticProperties(r, &soft_properties);
+    AddSoftHydroelasticProperties(r, 1e8, &soft_properties);
     ProximityProperties rigid_properties;
     AddRigidHydroelasticProperties(r, &rigid_properties);
 
@@ -1968,8 +1964,7 @@ class ProximityEngineHydroWithFallback : public testing::Test {
     poses_ = MakeCollidingRing(r, N_);
 
     ProximityProperties soft_properties;
-    AddContactMaterial(1e8, {}, {}, {}, &soft_properties);
-    AddSoftHydroelasticProperties(r / 2, &soft_properties);
+    AddSoftHydroelasticProperties(r / 2, 1e8, &soft_properties);
     ProximityProperties rigid_properties;
     AddRigidHydroelasticProperties(r, &rigid_properties);
 

--- a/multibody/fixed_fem/dev/run_cantilever_beam.cc
+++ b/multibody/fixed_fem/dev/run_cantilever_beam.cc
@@ -70,7 +70,7 @@ int DoMain() {
   /* A dummy proximity property that's used since there is no contact in this
    demo. */
   geometry::ProximityProperties dummy_proximity_props;
-  geometry::AddContactMaterial({}, {}, {},
+  geometry::AddContactMaterial({}, {},
                                multibody::CoulombFriction<double>(0, 0),
                                &dummy_proximity_props);
 

--- a/multibody/fixed_fem/dev/run_simple_gripper.cc
+++ b/multibody/fixed_fem/dev/run_simple_gripper.cc
@@ -114,7 +114,7 @@ int DoMain() {
   /* Set up proximity properties for the deformable box. */
   const CoulombFriction<double> surface_friction(1.0, 1.0);
   geometry::ProximityProperties proximity_props;
-  geometry::AddContactMaterial({}, {}, {}, surface_friction, &proximity_props);
+  geometry::AddContactMaterial({}, {}, surface_friction, &proximity_props);
 
   /* Register the deformable box in the DeformableModel. */
   auto deformable_model = std::make_unique<DeformableModel<double>>(&plant);

--- a/multibody/fixed_fem/dev/test/deformable_box_test.cc
+++ b/multibody/fixed_fem/dev/test/deformable_box_test.cc
@@ -77,7 +77,7 @@ class DeformableRigidContactSolverTest : public ::testing::Test {
             box, kSideLength / kNumBlocks, X_WB);
     geometry::ProximityProperties proximity_props;
     /* Use default stiffness and dissipation. */
-    geometry::AddContactMaterial({}, {}, {}, kFriction, &proximity_props);
+    geometry::AddContactMaterial({}, {}, kFriction, &proximity_props);
     /* Use the Corotated constitutive model. */
     auto deformable_model = std::make_unique<DeformableModel<double>>(plant_);
     const auto* deformable_model_ptr = deformable_model.get();

--- a/multibody/fixed_fem/dev/test/deformable_model_test.cc
+++ b/multibody/fixed_fem/dev/test/deformable_model_test.cc
@@ -66,7 +66,7 @@ class DeformableModelTest : public ::testing::Test {
   /* Creates a dummy proximity property. */
   static geometry::ProximityProperties MakeProximityProps() {
     geometry::ProximityProperties dummy_proximity_props;
-    geometry::AddContactMaterial({}, {}, {},
+    geometry::AddContactMaterial({}, {},
                                  multibody::CoulombFriction<double>(0, 0),
                                  &dummy_proximity_props);
     return dummy_proximity_props;

--- a/multibody/fixed_fem/dev/test/deformable_rigid_contact_solver_test.cc
+++ b/multibody/fixed_fem/dev/test/deformable_rigid_contact_solver_test.cc
@@ -55,7 +55,7 @@ ProximityProperties MakeProximityProperties(double stiffness,
                                             double dissipation,
                                             const CoulombFriction<double>& mu) {
   ProximityProperties proximity_properties;
-  geometry::AddContactMaterial({}, dissipation, stiffness, mu,
+  geometry::AddContactMaterial(dissipation, stiffness, mu,
                                &proximity_properties);
   return proximity_properties;
 }

--- a/multibody/fixed_fem/dev/test/deformable_rigid_manager_test.cc
+++ b/multibody/fixed_fem/dev/test/deformable_rigid_manager_test.cc
@@ -92,7 +92,7 @@ ProximityProperties MakeProximityProperties(double stiffness,
                                             double dissipation,
                                             const CoulombFriction<double>& mu) {
   ProximityProperties proximity_properties;
-  geometry::AddContactMaterial({}, dissipation, stiffness, mu,
+  geometry::AddContactMaterial(dissipation, stiffness, mu,
                                &proximity_properties);
   return proximity_properties;
 }

--- a/multibody/hydroelastics/hydroelastic_engine.cc
+++ b/multibody/hydroelastics/hydroelastic_engine.cc
@@ -32,9 +32,10 @@ MaterialProperties GetMaterials(GeometryId id,
   if (const ProximityProperties* properties =
           inspector.GetProximityProperties(id)) {
     material.hydroelastic_modulus = properties->GetPropertyOrDefault(
-        "material", "hydroelastic_modulus", kInf);
+        geometry::internal::kHydroGroup, geometry::internal::kElastic, kInf);
     material.dissipation = properties->GetPropertyOrDefault(
-        "material", "hunt_crossley_dissipation", 0.0);
+        geometry::internal::kMaterialGroup, geometry::internal::kHcDissipation,
+        0.0);
     DRAKE_DEMAND(material.hydroelastic_modulus > 0);
     DRAKE_DEMAND(material.dissipation >= 0);
   } else {

--- a/multibody/hydroelastics/test/hydroelastic_engine_test.cc
+++ b/multibody/hydroelastics/test/hydroelastic_engine_test.cc
@@ -52,8 +52,10 @@ class HydroelasticEngineTest : public ::testing::Test {
                              double hydroelastic_modulus, double dissipation) {
     GeometryId id = AddGeometry(name);
     ProximityProperties props;
-    props.AddProperty("material", "hydroelastic_modulus", hydroelastic_modulus);
-    props.AddProperty("material", "hunt_crossley_dissipation", dissipation);
+    props.AddProperty(geometry::internal::kHydroGroup,
+                      geometry::internal::kElastic, hydroelastic_modulus);
+    props.AddProperty(geometry::internal::kMaterialGroup,
+                      geometry::internal::kHcDissipation, dissipation);
     scene_graph_.AssignRole(source_id_, id, props);
     return id;
   }

--- a/multibody/parsing/detail_scene_graph.h
+++ b/multibody/parsing/detail_scene_graph.h
@@ -147,7 +147,7 @@ math::RigidTransformd MakeGeometryPoseFromSdfCollision(
  | Tag                              | Group        | Property                  | Notes                                                                                                                            |
  | :------------------------------: | :----------: | :-----------------------: | :------------------------------------------------------------------------------------------------------------------------------: |
  | drake:mesh_resolution_hint       | hydroelastic | resolution_hint           | Required for shapes that require tessellation to support hydroelastic contact.                                                   |
- | drake:hydroelastic_modulus       | material     | hydroelastic_modulus      | Finite positive value. Required for soft hydroelastic representations.                                                           |
+ | drake:hydroelastic_modulus       | hydroelastic | hydroelastic_modulus      | Finite positive value. Required for soft hydroelastic representations.                                                           |
  | drake:hunt_crossley_dissipation  | material     | hunt_crossley_dissipation |                                                                                                                                  |
  | drake:mu_dynamic                 | material     | coulomb_friction          | See note below on friction.                                                                                                      |
  | drake:mu_static                  | material     | coulomb_friction          | See note below on friction.                                                                                                      |

--- a/multibody/parsing/detail_urdf_geometry.h
+++ b/multibody/parsing/detail_urdf_geometry.h
@@ -160,7 +160,7 @@ geometry::GeometryInstance ParseVisual(
  | Tag                              | Group        | Property                  | Notes                                                                                                                            |
  | :------------------------------: | :----------: | :-----------------------: | :------------------------------------------------------------------------------------------------------------------------------: |
  | drake:mesh_resolution_hint       | hydroelastic | resolution_hint           | Required for shapes that require tessellation to support hydroelastic contact.                                                   |
- | drake:hydroelastic_modulus       | material     | hydroelastic_modulus      | Finite positive value. Required for soft hydroelastic representations.                                                           |
+ | drake:hydroelastic_modulus       | hydroelastic | hydroelastic_modulus      | Finite positive value. Required for soft hydroelastic representations.                                                           |
  | drake:hunt_crossley_dissipation  | material     | hunt_crossley_dissipation |                                                                                                                                  |
  | drake:mu_dynamic                 | material     | coulomb_friction          | See note below on friction.                                                                                                      |
  | drake:mu_static                  | material     | coulomb_friction          | See note below on friction.                                                                                                      |

--- a/multibody/parsing/test/detail_common_test.cc
+++ b/multibody/parsing/test/detail_common_test.cc
@@ -154,10 +154,10 @@ GTEST_TEST(ParseProximityPropertiesTest, HydroelasticModulus) {
   const double kValue = 1.75;
   ProximityProperties properties = ParseProximityProperties(
       param_read_double("drake:hydroelastic_modulus", kValue), !rigid, !soft);
-  EXPECT_TRUE(ExpectScalar(kMaterialGroup, kElastic, kValue, properties));
+  EXPECT_TRUE(ExpectScalar(kHydroGroup, kElastic, kValue, properties));
   // Hydroelastic modulus is the only property.
-  EXPECT_EQ(properties.GetPropertiesInGroup(kMaterialGroup).size(), 1u);
-  EXPECT_EQ(properties.num_groups(), 2);  // Material and default groups.
+  EXPECT_EQ(properties.GetPropertiesInGroup(kHydroGroup).size(), 1u);
+  EXPECT_EQ(properties.num_groups(), 2);  // Hydro and default groups.
 }
 
 // TODO(DamrongGuoy): Remove this test when we remove the support of the tag
@@ -170,9 +170,9 @@ GTEST_TEST(ParseProximityPropertiesTest, DeprecateElasticModulus) {
   const double kValue = 1.75;
   ProximityProperties properties = ParseProximityProperties(
       param_read_double("drake:elastic_modulus", kValue), !rigid, !soft);
-  EXPECT_TRUE(ExpectScalar(kMaterialGroup, kElastic, kValue, properties));
-  EXPECT_EQ(properties.GetPropertiesInGroup(kMaterialGroup).size(), 1u);
-  EXPECT_EQ(properties.num_groups(), 2);  // Material and default groups.
+  EXPECT_TRUE(ExpectScalar(kHydroGroup, kElastic, kValue, properties));
+  EXPECT_EQ(properties.GetPropertiesInGroup(kHydroGroup).size(), 1u);
+  EXPECT_EQ(properties.num_groups(), 2);  // Hydro and default groups.
 }
 
 // Confirms successful parsing of dissipation.

--- a/multibody/parsing/test/detail_scene_graph_test.cc
+++ b/multibody/parsing/test/detail_scene_graph_test.cc
@@ -1066,6 +1066,8 @@ GTEST_TEST(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
   auto assert_single_property = [](const ProximityProperties& properties,
                                    const char* group, const char* property,
                                    double value) {
+    SCOPED_TRACE(fmt::format("testing group {} property {} value {}",
+                             group, property, value));
     ASSERT_TRUE(properties.HasProperty(group, property));
     EXPECT_EQ(properties.GetProperty<double>(group, property), value);
   };
@@ -1087,7 +1089,7 @@ GTEST_TEST(SceneGraphParserDetail, MakeProximityPropertiesForCollision) {
         MakeProximityPropertiesForCollision(*sdf_collision);
     assert_single_property(properties, geometry::internal::kHydroGroup,
                            geometry::internal::kRezHint, 2.5);
-    assert_single_property(properties, geometry::internal::kMaterialGroup,
+    assert_single_property(properties, geometry::internal::kHydroGroup,
                            geometry::internal::kElastic, 3.5);
     assert_single_property(properties, geometry::internal::kMaterialGroup,
                            geometry::internal::kHcDissipation, 4.5);

--- a/multibody/parsing/test/detail_urdf_geometry_test.cc
+++ b/multibody/parsing/test/detail_urdf_geometry_test.cc
@@ -571,7 +571,7 @@ TEST_F(UrdfGeometryTests, CollisionProperties) {
     const ProximityProperties& properties = *instance.proximity_properties();
     verify_single_property(properties, geometry::internal::kHydroGroup,
                            geometry::internal::kRezHint, 2.5);
-    verify_single_property(properties, geometry::internal::kMaterialGroup,
+    verify_single_property(properties, geometry::internal::kHydroGroup,
                            geometry::internal::kElastic, 3.5);
     verify_single_property(properties, geometry::internal::kMaterialGroup,
                            geometry::internal::kHcDissipation, 3.5);

--- a/multibody/plant/test/multibody_plant_hydroelastic_test.cc
+++ b/multibody/plant/test/multibody_plant_hydroelastic_test.cc
@@ -124,9 +124,10 @@ class HydroelasticModelTests : public ::testing::Test {
 
     geometry::ProximityProperties props;
     // This should produce a level-2 refinement (two steps beyond octahedron).
-    geometry::AddSoftHydroelasticProperties(radius / 2, &props);
+    geometry::AddSoftHydroelasticProperties(
+        radius / 2, hydroelastic_modulus, &props);
     geometry::AddContactMaterial(
-        hydroelastic_modulus, dissipation,
+        dissipation, {},
         CoulombFriction<double>(friction_coefficient, friction_coefficient),
         &props);
     plant->RegisterCollisionGeometry(body, X_BG, shape, "BodyCollisionGeometry",
@@ -292,12 +293,12 @@ TEST_F(HydroelasticModelTests, DiscreteTamsiSolver) {
   const Vector3<double> fz_BBo_W = F_BBo_W.translational();
 
   // The contact force should match the weight of the sphere.
-  const Vector3<double> fz_BBo_W_expeted =
+  const Vector3<double> fz_BBo_W_expected =
       -plant_->gravity_field().gravity_vector() * kMass;
 
   // We use a tolerance value based on previous runs of this test.
   const double tolerance = 2.0e-8;
-  EXPECT_TRUE(CompareMatrices(fz_BBo_W, fz_BBo_W_expeted, tolerance));
+  EXPECT_TRUE(CompareMatrices(fz_BBo_W, fz_BBo_W_expected, tolerance));
 }
 
 // This tests consistency across the ContactModel modes: point pair,
@@ -350,7 +351,7 @@ class ContactModelTest : public ::testing::Test {
 
     geometry::ProximityProperties props;
     geometry::AddContactMaterial(
-        kElasticModulus, kDissipation,
+        kDissipation, {},
         CoulombFriction<double>(kFrictionCoefficient, kFrictionCoefficient),
         &props);
     AddGround(props, plant_);
@@ -391,7 +392,8 @@ class ContactModelTest : public ::testing::Test {
     const double kSize = 10;
     const RigidTransformd X_WG{Vector3d{0, 0, -kSize / 2}};
     geometry::Box ground = geometry::Box::MakeCube(kSize);
-    geometry::AddSoftHydroelasticProperties(kSize, &contact_material);
+    geometry::AddSoftHydroelasticProperties(
+        kSize, kElasticModulus, &contact_material);
     plant->RegisterCollisionGeometry(plant->world_body(), X_WG, ground,
                                      "GroundCollisionGeometry",
                                      std::move(contact_material));


### PR DESCRIPTION
Relevant to: #15796

This is a breaking change, mitigated by the experimental status of
hydroelastic contact support.

This patch migrates hydroelastic_modulus (HEM) from being a generic
material property to being a property specific to hydroelastic
contact. To accomplish this, AddContactMaterial loses its HEM argument,
and AddSoftwHydroelasticProperties gains one. In addition, the
underlying property entry moves from the "material" group to the
"hydroelastic" group.

Refactoring note: to make the transition of weakly typed arguments
safer, obsolete or unused overloads were first removed to help
disambiguate parsing of call sites, and subsequently the argument and
property name transitions were done. This patch squashes all those steps
together.

In addition, a few typos and minor errors were corrected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16009)
<!-- Reviewable:end -->
