### PR TITLE
[sensors] Add OptitrackReceiver, deprecate OptitrackPoseExtractor

### DIFF
--- a/manipulation/perception/BUILD.bazel
+++ b/manipulation/perception/BUILD.bazel
@@ -24,6 +24,7 @@ drake_cc_library(
     name = "optitrack_pose_extractor",
     srcs = ["optitrack_pose_extractor.cc"],
     hdrs = ["optitrack_pose_extractor.h"],
+    copts = ["-Wno-deprecated-declarations"],
     visibility = ["//visibility:public"],
     deps = [
         "//math:geometric_transform",
@@ -46,6 +47,7 @@ drake_cc_library(
 
 drake_cc_googletest(
     name = "optitrack_pose_extractor_test",
+    copts = ["-Wno-deprecated-declarations"],
     deps = [
         ":optitrack_pose_extractor",
         "//common/test_utilities:eigen_matrix_compare",

--- a/manipulation/perception/optitrack_pose_extractor.h
+++ b/manipulation/perception/optitrack_pose_extractor.h
@@ -9,6 +9,7 @@
 #include "optitrack/optitrack_data_descriptions_t.hpp"
 #include "optitrack/optitrack_frame_t.hpp"
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
 #include "drake/systems/framework/leaf_system.h"
 
@@ -20,6 +21,7 @@ namespace perception {
  * Gets the pose of an Optitrack rigid body.
  * @returns X_OB, the pose of the body `B` in the optitrack frame `O`.
  */
+DRAKE_DEPRECATED("2022-02-01", "Possibly use OptitrackReceiver instead.")
 Isometry3<double> ExtractOptitrackPose(
     const optitrack::optitrack_rigid_body_t& message);
 
@@ -27,6 +29,7 @@ Isometry3<double> ExtractOptitrackPose(
  * Extracts poses of all objects from an Optitrack message.
  * @returns Mapping from object ID to pose.
  */
+DRAKE_DEPRECATED("2022-02-01", "This function is being removed.")
 std::map<int, Isometry3<double>> ExtractOptitrackPoses(
     const optitrack::optitrack_frame_t& frame);
 
@@ -36,6 +39,7 @@ std::map<int, Isometry3<double>> ExtractOptitrackPoses(
  * @param object_id ID to be searched for in the frame message.
  * @returns Rigid body object, or `nullopt` if not found.
  */
+DRAKE_DEPRECATED("2022-02-01", "This function is being removed.")
 std::optional<optitrack::optitrack_rigid_body_t> FindOptitrackBody(
       const optitrack::optitrack_frame_t& message, int object_id);
 
@@ -44,6 +48,7 @@ std::optional<optitrack::optitrack_rigid_body_t> FindOptitrackBody(
  * @param message Description message.
  * @returns Object ID if found, or `nullopt` if not found.
  */
+DRAKE_DEPRECATED("2022-02-01", "This function is being removed.")
 std::optional<int> FindOptitrackObjectId(
     const optitrack::optitrack_data_descriptions_t& message,
     const std::string& object_name);
@@ -55,7 +60,8 @@ std::optional<int> FindOptitrackObjectId(
  *
  * @ingroup manipulation_systems
  */
-class OptitrackPoseExtractor : public systems::LeafSystem<double> {
+class DRAKE_DEPRECATED("2022-02-01", "Use OptitrackReceiver instead.")
+OptitrackPoseExtractor : public systems::LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(OptitrackPoseExtractor)
   /**

--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -35,6 +35,7 @@ drake_cc_package_library(
         ":image_writer",
         ":lcm_image_array_to_images",
         ":lcm_image_traits",
+        ":optitrack_receiver",
         ":optitrack_sender",
         ":rgbd_sensor",
         ":rotary_encoders",
@@ -212,6 +213,17 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "optitrack_receiver",
+    srcs = ["optitrack_receiver.cc"],
+    hdrs = ["optitrack_receiver.h"],
+    deps = [
+        "//math:geometric_transform",
+        "//systems/framework:leaf_system",
+        "@optitrack_driver//lcmtypes:optitrack_lcmtypes",
+    ],
+)
+
+drake_cc_library(
     name = "optitrack_sender",
     srcs = ["optitrack_sender.cc"],
     hdrs = ["optitrack_sender.h"],
@@ -340,11 +352,19 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "optitrack_receiver_test",
+    deps = [
+        ":optitrack_receiver",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
+        "@optitrack_driver//lcmtypes:optitrack_lcmtypes",
+    ],
+)
+
+drake_cc_googletest(
     name = "optitrack_sender_test",
-    srcs = ["test/optitrack_sender_test.cc"],
     deps = [
         ":optitrack_sender",
-        "//systems/framework",
         "@optitrack_driver//lcmtypes:optitrack_lcmtypes",
     ],
 )

--- a/systems/sensors/optitrack_receiver.cc
+++ b/systems/sensors/optitrack_receiver.cc
@@ -1,0 +1,62 @@
+#include "drake/systems/sensors/optitrack_receiver.h"
+
+#include "optitrack/optitrack_frame_t.hpp"
+#include <fmt/format.h>
+
+namespace drake {
+namespace systems {
+namespace sensors {
+namespace {
+
+using math::RigidTransformd;
+
+/* Returns the pose of rigid body frame `B` in Optitrack frame `O`. */
+RigidTransformd Decode_X_OB(const optitrack::optitrack_rigid_body_t& body) {
+  // The optitrack quaternion ordering is X-Y-Z-W and this needs fitting into
+  // Eigen's W-X-Y-Z ordering.
+  auto& q_xyzw = body.quat;
+  const Eigen::Quaterniond q_wxyz(q_xyzw[3], q_xyzw[0], q_xyzw[1], q_xyzw[2]);
+  const Eigen::Vector3d position(body.xyz[0], body.xyz[1], body.xyz[2]);
+  const math::RigidTransformd X_OB(q_wxyz, position);
+  return X_OB;
+}
+
+}  // namespace
+
+OptitrackReceiver::OptitrackReceiver(
+    const std::map<int, std::string>& frame_map,
+    const RigidTransformd& X_WO)
+    : X_WO_(X_WO) {
+  this->DeclareAbstractInputPort(
+      "optitrack_frame_t",
+      Value<optitrack::optitrack_frame_t>());
+  for (const auto& [body_id, body_name] : frame_map) {
+    this->DeclareAbstractOutputPort(
+        body_name,
+        []() { return AbstractValue::Make<RigidTransformd>(); },
+        [this, body_id = body_id](const Context<double>& context,
+                                  AbstractValue* output_abstract) {
+          auto& output = output_abstract->get_mutable_value<RigidTransformd>();
+          this->CalcOutput(context, body_id, &output);
+        });
+  }
+}
+
+void OptitrackReceiver::CalcOutput(
+    const Context<double>& context, int body_id,
+    RigidTransformd* output) const {
+  const auto& input_port = this->get_input_port();
+  const auto& message = input_port.Eval<optitrack::optitrack_frame_t>(context);
+  for (const auto& body : message.rigid_bodies) {
+    if (body.id == body_id) {
+      *output = X_WO_ * Decode_X_OB(body);
+      return;
+    }
+  }
+  throw std::runtime_error(fmt::format(
+      "OptitrackReceiver: input message does not contain body id={}", body_id));
+}
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/systems/sensors/optitrack_receiver.h
+++ b/systems/sensors/optitrack_receiver.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "drake/math/rigid_transform.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+/** Converts LCM optitrack_frame_t message data on an input port to
+RigidTransform data on per-body output ports.
+
+@system
+name: OptitrackReceiver
+input_ports:
+- optitrack_frame_t
+output_ports:
+- <em style="color:gray">...</em>
+- <em style="color:gray">...</em>
+@endsystem
+*/
+class OptitrackReceiver : public systems::LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(OptitrackReceiver)
+
+  /** Constructs an OptitrackReceiver.
+  @param frame_map Mapping from optitrack body id to output port name.
+    All ids must always be present in the input message.
+  @param X_WO Pose of the optitrack frame O in the world frame W.
+    Defaults to the Identity transform.
+  */
+  explicit OptitrackReceiver(
+      const std::map<int, std::string>& frame_map,
+      const math::RigidTransformd& X_WO = {});
+
+ private:
+  void CalcOutput(const Context<double>&, int, math::RigidTransformd*) const;
+
+  const math::RigidTransformd X_WO_;
+};
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/systems/sensors/test/optitrack_receiver_test.cc
+++ b/systems/sensors/test/optitrack_receiver_test.cc
@@ -1,0 +1,80 @@
+#include "drake/systems/sensors/optitrack_receiver.h"
+
+#include "optitrack/optitrack_frame_t.hpp"
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+namespace {
+
+using math::RigidTransformd;
+
+// Checks that body poses are passed through correctly.
+GTEST_TEST(OptitrackPoseTest, InputOutputTest) {
+  // Set up the device under test, with two tracked bodies.
+  const std::map<int, std::string> frame_map{{1, "one"}, {2, "two"}};
+  const RigidTransformd X_WO(
+      Eigen::AngleAxisd(-0.75 * M_PI, Eigen::Vector3d::UnitX()),
+      Vector3<double>(1, 2, 3));
+  const OptitrackReceiver dut(frame_map, X_WO);
+  EXPECT_EQ(dut.num_input_ports(), 1);
+  EXPECT_EQ(dut.num_output_ports(), 2);
+
+  // Use an arbitrarily chosen pose for body 1.
+  const math::RigidTransform<double> X_OB1(
+      Eigen::AngleAxisd(0.75 * M_PI, Eigen::Vector3d::UnitX()) *
+      Eigen::AngleAxisd(-0.75 * M_PI, Eigen::Vector3d::UnitY()),
+      Vector3<double>(0.01, -5.0, 10.10));
+  const Eigen::Quaterniond R_OB1_quat = X_OB1.rotation().ToQuaternion();
+
+  // Encode body 1 into LCM.
+  optitrack::optitrack_rigid_body_t body_1{};
+  body_1.id = 1;
+  body_1.xyz[0] = X_OB1.translation()[0];
+  body_1.xyz[1] = X_OB1.translation()[1];
+  body_1.xyz[2] = X_OB1.translation()[2];
+  body_1.quat[0] = R_OB1_quat.x();
+  body_1.quat[1] = R_OB1_quat.y();
+  body_1.quat[2] = R_OB1_quat.z();
+  body_1.quat[3] = R_OB1_quat.w();
+
+  // Encode body 2 (posed at the origin) into LCM.
+  optitrack::optitrack_rigid_body_t body_2{};
+  body_2.id = 2;
+  body_2.quat[3] = 1.0 /* w */;
+
+  // Copy the message into the context.
+  optitrack::optitrack_frame_t frame{};
+  frame.rigid_bodies.push_back(body_2);
+  frame.rigid_bodies.push_back(body_1);
+  auto context = dut.CreateDefaultContext();
+  dut.get_input_port().FixValue(context.get(), frame);
+
+  // Check each output. This tolerance is relatively loose because the LCM
+  // message types use single-precision floating point types for quaternions.
+  constexpr double kTolerance = 1e-6;
+  const auto& out_1 = dut.GetOutputPort("one").Eval<RigidTransformd>(*context);
+  const auto& out_2 = dut.GetOutputPort("two").Eval<RigidTransformd>(*context);
+  EXPECT_TRUE(CompareMatrices(
+      out_1.GetAsMatrix34(), (X_WO * X_OB1).GetAsMatrix34(),
+      kTolerance, MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(
+      out_2.GetAsMatrix34(), X_WO.GetAsMatrix34(),
+      kTolerance, MatrixCompareType::absolute));
+
+  // If a body is missing from the message, that is an error.
+  frame.rigid_bodies.clear();
+  dut.get_input_port().FixValue(context.get(), frame);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dut.GetOutputPort("one").Eval<RigidTransformd>(*context),
+      ".*does not contain body.*");
+}
+
+}  // namespace
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
Towards #9865.

The new OptitrackReceiver is based on the now-deprecated OptitrackPoseExtractor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/16011)
<!-- Reviewable:end -->
